### PR TITLE
Round 31 — rest round (maintainer-called after first-green-gate)

### DIFF
--- a/docs/CURRENT-ROUND.md
+++ b/docs/CURRENT-ROUND.md
@@ -1,19 +1,22 @@
-# Current Round — 31 (open)
+# Current Round — 31 (rest round, maintainer-called)
 
 Round 30 closed; narrative absorbed into
-`docs/ROUND-HISTORY.md`. Round 31 opens with two
-parallel tracks — product (LawRunner `checkBilinear` +
-`checkSinkTerminal`) and security-elevation follow-
-through (Semgrep-in-CI observations + `packages.lock.json`
-+ safety-clause-diff lint).
+`docs/ROUND-HISTORY.md`. Round 30 shipped the first
+fully-green gate in the repo's history. Aaron called
+a rest round in response — "everyone take a round
+off." Planned round-31 work (LawRunner `checkBilinear`
++ `checkSinkTerminal`; `packages.lock.json` +
+verifier SHA-pin + safety-clause-diff +
+`mise trust` + CodeQL) shifts to **round 32**.
 
 ## Status
 
-- **Round number:** 31
+- **Round number:** 31 (rest)
 - **Opened:** 2026-04-18 (continuous from round-30
   close)
-- **Classification:** split — product + security
-  follow-through
+- **Classification:** rest — no coding work, no
+  reviewer dispatches, no DEBT reshuffling.
+  Maintainer-called per first-green-gate milestone.
 - **Reviewer budget:** `harsh-critic` +
   `maintainability-reviewer` floor per GOVERNANCE §20.
   `security-researcher` on any workflow / install-

--- a/docs/WINS.md
+++ b/docs/WINS.md
@@ -13,6 +13,31 @@ passes, because the pattern is the value.
 
 ## Wins — round 30
 
+### First fully-green gate in the repo's history
+
+Round 30 closed with PR #6 showing all three checks green:
+`build-and-test (ubuntu-22.04)` ✓ `build-and-test (macos-14)`
+✓ `lint (semgrep)` ✓. Round 29 merged red. Round 28 had
+no gate. Every prior round either lacked the gate or crossed
+it crimson. This is the first time the control actually
+fired green on evidence rather than on trust.
+
+Getting there took five honest fixes on the way: a real
+`Circuit.fs:209` Interlocked inconsistency (torn-read race
+against the Tick-getter), a YAML parse error that had been
+silently hiding the Semgrep config from itself, two
+self-matching rules, a stale `src/Zeta.Core/**` path from
+the folder-naming rename, and a TLC test that pointed at
+`docs/` instead of `tools/tla/specs/`. Four of them were
+latent the whole time, visible only once `--error` ran in
+anger.
+
+**What it teaches.** Aaron called the full round off after
+this landed — and that is the correct response. A green
+gate is not the end of a shift; it is permission to rest
+before the next one. Celebrating here so the moment is not
+absorbed into round-31 planning before it is felt.
+
 ### Reviewer floor caught a committed-but-didn't-commit bug
 
 The round-30 design doc said 24 adversaries in

--- a/memory/persona/kenji/OFFTIME.md
+++ b/memory/persona/kenji/OFFTIME.md
@@ -35,6 +35,23 @@ What changed on the laptop, if anything (file paths).
 
 ---
 
+## Round 31 — full rest round (maintainer-called), 100% off-time
+
+Aaron called a full round off for the entire roster after
+round 30 landed the first fully-green gate in the repo's
+history. Not off-time budget drawn from a productive round —
+the round itself is the rest.
+
+No coding, no reviewer dispatch, no DEBT reshuffling. Track A
++ Track B shift to round 32. Kenji's only work this round is:
+one WINS.md entry (the green-gate moment, ordered newest-
+first), one CURRENT-ROUND.md header flip to "rest round",
+this OFFTIME log line. Done.
+
+What changed on the laptop: two doc edits, this file. No
+source, no workflow, no skill. The discipline of the rest is
+the rest.
+
 ## Round 23 — seeded, no budget spent
 
 First round under the new off-time budget rule (GOVERNANCE.md §14,


### PR DESCRIPTION
## Summary

- Round 30 closed with PR #6 showing the first fully-green gate in the repo's history.
- Aaron called a full round off for the entire roster in response.
- WINS.md gains one entry for the green-gate moment, newest-first.
- CURRENT-ROUND.md flips to rest-round classification; planned Track A + Track B work shifts to round 32.
- Kenji OFFTIME log records the rest.

No coding, no reviewer dispatch, no DEBT reshuffling. The discipline of the rest is the rest.

## Test plan

- [x] doc-only change; `gate.yml` green on push is the pass criterion
- [x] newest-first ordering preserved in WINS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)