### PR TITLE
Round 33 followup — bash is Unix-only; cross-platform automation = TypeScript/Bun

### DIFF
--- a/docs/security/SECURITY-BACKLOG.md
+++ b/docs/security/SECURITY-BACKLOG.md
@@ -174,6 +174,29 @@ cost) but is still worth shipping eventually.
 - **Rough cost estimate:** S (just add to cadence)
 - **Priority:** P1
 
+### Post-install repo automation: Bun + TypeScript + package.json
+
+- **Why deferred:** `tools/setup/install.sh` (bash) owns bootstrap
+  because it can't assume Bun/Node/anything pre-install. After
+  install, Zeta's eventual polyglot repo-automation surface
+  (format-repo, coverage-collect, benchmark-compare, lint
+  orchestration) benefits from a single cross-platform runtime.
+  Aaron: "I used bun and typescript and package.json for repo
+  automation after the point of install … better than maintaining
+  bash and pwsh scripts everywhere." Pattern visible in
+  `../SQLSharp/tools/automation/` and `../scratch`.
+- **Trigger to revisit:** first post-install automation task that
+  would need cross-platform scripting (benchmark comparison,
+  coverage aggregation, format-repo across .fs/.cs/.md/etc., or
+  the first case where bash+pwsh would have to be maintained in
+  parallel).
+- **Rough cost estimate:** M (introduce `bun`/`package.json`
+  at repo root, first TypeScript automation entry point, wire
+  Bun install into `tools/setup/`)
+- **Priority:** P2 (on-demand; not blocking)
+- **Note:** post-install only; install.sh stays bash so the
+  bootstrap can't depend on its own output.
+
 ### `static-analysis-gap-finder` skill (missing-lint-tool detection)
 
 - **Why deferred:** Round 33 Track D surfaced that Zeta had no

--- a/openspec/specs/repo-automation/profiles/bash.md
+++ b/openspec/specs/repo-automation/profiles/bash.md
@@ -43,14 +43,23 @@ rather than re-installing or re-downloading.
 - **AND** CI MUST be able to assert this contract via a
   second-run check if a regression is suspected
 
-### Requirement: macOS bash 3.2 compatibility
+### Requirement: macOS bash 3.2 + Linux bash 5.x compatibility
 
-Zeta scripts MUST run under macOS's default bash 3.2 as well as
-Linux bash 5.x. Associative arrays (`declare -A`), advanced
-parameter expansion, and other bash-4+ features are forbidden in
-scripts that need to work on both.
+Zeta bash scripts are Unix-only. They MUST run under macOS's
+default bash 3.2 and Linux bash 5.x. Windows contributors run
+a separate PowerShell install path (`tools/setup/windows.ps1`
+— backlogged); bash is NOT expected to run on Git Bash for
+Windows. Two reasons, together: (1) Git Bash is not guaranteed
+installed on a Windows developer machine, so assuming it would
+make bootstrap fail on fresh boxes; and (2) post-install
+automation moves to TypeScript (via Bun) for cross-platform
+work — cleaner than trying to make bash portable to msys2.
 
-#### Scenario: Adding cross-platform logic
+Associative arrays (`declare -A`) and other bash-4+ features
+are forbidden because macOS ships bash 3.2 as `/bin/bash` for
+licensing reasons.
+
+#### Scenario: Adding cross-platform bash logic
 
 - **WHEN** a bash script needs to map multiple keys to values
 - **THEN** the script MUST use parallel arrays (`NAMES=(...)`
@@ -60,6 +69,19 @@ scripts that need to work on both.
   instead)
 - **AND** MUST avoid `readarray` / `mapfile` (use a
   `while IFS= read -r line; do ... done < <(...)` loop instead)
+
+#### Scenario: Cross-platform repo automation (non-install)
+
+- **WHEN** an automation task needs to run on Unix + Windows
+  developer machines (formatting, benchmark orchestration,
+  coverage aggregation, lint driver, etc.)
+- **THEN** the task MUST be written in TypeScript + Bun + a
+  repo-root `package.json` entry rather than in bash
+- **AND** bash MUST NOT be chosen for any task that would
+  otherwise need a parallel PowerShell twin — maintaining
+  bash+pwsh for the same job is explicitly out-of-scope per
+  Aaron round 33 + SECURITY-BACKLOG "Post-install repo
+  automation: Bun + TypeScript + package.json"
 
 ### Requirement: Manifest-driven installs
 


### PR DESCRIPTION
Correction to the bash profile per Aaron: install.sh + tools/setup/*.sh are macOS + Linux only. Windows gets a separate PowerShell install path. Git Bash compat is NOT a requirement on Zeta bash — two reasons:

1. Git Bash is not guaranteed installed on Windows — assuming it would make bootstrap fail on fresh boxes.
2. Post-install automation moves to TypeScript + Bun + package.json for cross-platform work, matching ../SQLSharp + ../scratch patterns. Aaron: "better than maintaining bash and pwsh scripts everywhere."

Changes:
- `openspec/specs/repo-automation/profiles/bash.md` — requirement rewritten
- `docs/security/SECURITY-BACKLOG.md` — "Post-install repo automation: Bun + TypeScript + package.json" entry added (P2, triggered on first post-install task that needs cross-platform scripting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)