### PR TITLE
Round 33 — check in .vscode/, reframe post-install automation as research

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,12 @@ obj/
 *.user
 *.suo
 .vs/
-.vscode/
+# `.vscode/` is checked in so contributors get the same
+# recommended-extensions + workspace settings (SQLSharp pattern).
+# User-specific overrides go in `.vscode/*.local.json` or
+# `.vscode/settings.user.json` — those are ignored below.
+.vscode/*.local.json
+.vscode/settings.user.json
 .idea/
 .ionide/
 *.swp

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,18 @@
+{
+  "recommendations": [
+    "Ionide.Ionide-fsharp",
+    "ms-dotnettools.csharp",
+    "ms-dotnettools.csdevkit",
+    "editorconfig.editorconfig",
+    "davidanson.vscode-markdownlint",
+    "timonwong.shellcheck",
+    "foxundermoon.shell-format",
+    "redhat.vscode-yaml",
+    "github.vscode-github-actions",
+    "streetsidesoftware.code-spell-checker",
+    "tamasfe.even-better-toml",
+    "semgrep.semgrep",
+    "jnoortheen.xonsh",
+    "alloy.alloy"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,77 @@
+{
+  // Shape mirrors SQLSharp's `.vscode/settings.json` so
+  // contributors get consistent editor behaviour around Zeta's
+  // build outputs + vendored upstreams.
+  "dotnet.defaultSolution": "Zeta.sln",
+
+  "files.exclude": {
+    "**/BenchmarkDotNet.Artifacts/**": true,
+    "**/TestResults/**": true,
+    "**/artifacts/**": true,
+    "**/bin/**": true,
+    "**/obj/**": true,
+    "**/node_modules/**": true,
+    "**/tools/lean4/.lake/**": true,
+    "**/references/upstreams/**": true
+  },
+  "files.watcherExclude": {
+    "**/BenchmarkDotNet.Artifacts/**": true,
+    "**/TestResults/**": true,
+    "**/artifacts/**": true,
+    "**/bin/**": true,
+    "**/obj/**": true,
+    "**/node_modules/**": true,
+    "**/tools/lean4/.lake/**": true,
+    "**/references/upstreams/**": true
+  },
+  "search.exclude": {
+    "**/BenchmarkDotNet.Artifacts/**": true,
+    "**/TestResults/**": true,
+    "**/artifacts/**": true,
+    "**/bin/**": true,
+    "**/obj/**": true,
+    "**/node_modules/**": true,
+    "**/tools/lean4/.lake/**": true,
+    "**/references/upstreams/**": true
+  },
+
+  "FSharp.excludeProjectDirectories": [
+    ".git",
+    "bin",
+    "obj",
+    "node_modules",
+    "tools/lean4/.lake",
+    "references/upstreams"
+  ],
+
+  "shellcheck.customArgs": ["-x"],
+  "shellcheck.useWorkspaceRootAsCwd": true,
+
+  "[fsharp]": {
+    "editor.formatOnSave": true,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 4
+  },
+  "[csharp]": {
+    "editor.formatOnSave": true,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 4
+  },
+  "[json]": {
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2
+  },
+  "[jsonc]": {
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2
+  },
+  "[yaml]": {
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2
+  },
+  "[markdown]": {
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2,
+    "editor.formatOnSave": false
+  }
+}

--- a/docs/security/SECURITY-BACKLOG.md
+++ b/docs/security/SECURITY-BACKLOG.md
@@ -174,28 +174,33 @@ cost) but is still worth shipping eventually.
 - **Rough cost estimate:** S (just add to cadence)
 - **Priority:** P1
 
-### Post-install repo automation: Bun + TypeScript + package.json
+### Post-install repo automation: runtime choice open (research needed)
 
 - **Why deferred:** `tools/setup/install.sh` (bash) owns bootstrap
-  because it can't assume Bun/Node/anything pre-install. After
-  install, Zeta's eventual polyglot repo-automation surface
-  (format-repo, coverage-collect, benchmark-compare, lint
-  orchestration) benefits from a single cross-platform runtime.
-  Aaron: "I used bun and typescript and package.json for repo
-  automation after the point of install … better than maintaining
-  bash and pwsh scripts everywhere." Pattern visible in
-  `../SQLSharp/tools/automation/` and `../scratch`.
+  because it can't assume any runtime pre-install. After install,
+  Zeta's eventual polyglot repo-automation surface (format-repo,
+  coverage-collect, benchmark-compare, lint orchestration)
+  benefits from a single cross-platform runtime. Aaron's prior
+  choice on `../SQLSharp` + `../scratch` was Bun + TypeScript +
+  package.json — it worked, but Aaron is explicitly NOT committed
+  to repeating it: "IDK if I want to stick with this which is
+  why i want the research." Candidates worth comparing include
+  Bun/Node, Deno, Python (already on PATH post-install via mise),
+  .NET console tools (already on PATH), or something else
+  entirely. The constraint is "one runtime handles
+  everything polyglot-post-install, no bash+pwsh parallel twins."
 - **Trigger to revisit:** first post-install automation task that
   would need cross-platform scripting (benchmark comparison,
-  coverage aggregation, format-repo across .fs/.cs/.md/etc., or
-  the first case where bash+pwsh would have to be maintained in
-  parallel).
-- **Rough cost estimate:** M (introduce `bun`/`package.json`
-  at repo root, first TypeScript automation entry point, wire
-  Bun install into `tools/setup/`)
+  coverage aggregation, format-repo across .fs/.cs/.md/etc.).
+  Research round before committing: write a design doc comparing
+  candidate runtimes across cold-start cost, install weight, type
+  safety, ecosystem breadth for lint/format/test orchestration,
+  and maintainability.
+- **Rough cost estimate:** S (research doc) + M (first shipped
+  automation in chosen runtime)
 - **Priority:** P2 (on-demand; not blocking)
-- **Note:** post-install only; install.sh stays bash so the
-  bootstrap can't depend on its own output.
+- **Note:** install.sh stays bash regardless — bootstrap can't
+  depend on its own output.
 
 ### `static-analysis-gap-finder` skill (missing-lint-tool detection)
 


### PR DESCRIPTION
Two follow-ups to round 33 Track D:

## `.vscode/` is now checked in (SQLSharp pattern)

Previously `.gitignore` excluded `.vscode/` wholesale, which silently dropped `.vscode/extensions.json` from the round-33 Track D commit. Aaron: "we need to see how ../SQLSharp ../scratch did their vscode settings gitignore we want most of those checked in."

- `.gitignore`: now ignores only `.vscode/*.local.json` + `.vscode/settings.user.json` for user-specific overrides.
- `.vscode/settings.json` added (workspace search/files/watcher exclusions for bin/obj/TestResults/artifacts/node_modules/tools/lean4/.lake/references/upstreams, FSharp project excludes, shellcheck args, per-language editor settings).
- `.vscode/extensions.json` (was silently ignored) now actually committed.

## Post-install automation backlog reframed

Aaron: "IDK if I want to stick with this which is why i want the research. [Bun+TS] worked but don't know if it was the best."

SECURITY-BACKLOG entry changed from "we'll use Bun + TypeScript" → "research round needed; candidates include Bun/Node, Deno, Python (already on PATH via mise), .NET console tools, etc. Constraint is one-runtime-handles-everything-polyglot post-install." install.sh stays bash regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)