### PR TITLE
Round 33 — license Apache-2.0, VISION v5: PostgreSQL-first, EF-all-features, wire protocol

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <Authors>zeta contributors</Authors>
     <Product>Zeta (DBSP for .NET)</Product>
     <Copyright>Copyright (c) 2026</Copyright>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <OptimizeImplicitlyTriggeredBuild>true</OptimizeImplicitlyTriggeredBuild>

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,204 @@
-MIT License
 
-Copyright (c) 2026 Dbsp.Core contributors
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   Copyright 2026 Zeta contributors

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -116,11 +116,50 @@ within each priority tier.
   Core provider so EF consumers get DBSP incremental query
   plans for free. Aaron: "work tightly with entity framework,
   then branch out to other ORMs." First-class v1.
-- [ ] **F# DSL reimagining SQL for the modern era.** Extends
-  the existing `circuit { ... }` computational-expression
-  seed. Natively retraction-aware, bitemporal-ready,
-  incremental-by-default. Needs a design round; Aaron: "a
-  start with our computational workflow."
+- [ ] **F# DSL reimagining SQL for the modern era (HUGE,
+  multi-round).** Extends the existing `circuit { ... }`
+  computational-expression seed. Natively retraction-aware,
+  bitemporal-ready, incremental-by-default. Aaron round 33
+  flag: "sounds like we need design and research, this
+  task sounds HUGE." Spread across multiple rounds:
+  Round N: research what modern SQL should look like
+    (compose-ability, retraction syntax, time-travel
+    primitives, type-system integration with F#
+    discriminated unions). Survey languages that tried
+    (Rel/Tutorial D, Datalog family, LINQ, Kleppmann's
+    "Rethinking relational" talks, relational algebra
+    type theory).
+  Round N+1: design doc with syntax sketch.
+  Round N+2: paper-peer-reviewer pass.
+  Round N+3+: implementation + fit-check against existing
+    circuit/Op algebra.
+  Output: sequence of `docs/research/f-dsl-*.md` docs
+  then `openspec/specs/f-dsl-surface/` once shape
+  stabilizes.
+
+- [ ] **PostgreSQL wire protocol server.** Aaron round 33:
+  "support an existing protocol so existing tools can
+  connect." pgAdmin, DBeaver, psql, Npgsql (via EF) all
+  speak PostgreSQL's wire protocol. Zeta would implement
+  enough of the frontend/backend message protocol (auth,
+  simple query, extended query, COPY) to appear as a
+  PostgreSQL server. Material precedent: CockroachDB,
+  Materialize, YugabyteDB, Apache AGE — all run non-
+  Postgres engines behind Postgres-shaped endpoints.
+  v1-or-early-post-v1 depending on design round: needs
+  auth shape, SSL/TLS, connection pooling posture,
+  protocol-level error mapping to DBSP Result types.
+  Output: `docs/research/pg-wire-protocol-design.md`.
+
+- [ ] **Own admin UI (far future).** Aaron round 33: "we
+  will need some UI that can connect to it like SSMS or
+  PostgreSQL Admin, so we will have to build our own
+  (which we will eventually do)." Stack choice is open
+  — Fable + Elmish (F# + web), SAFE Stack (F# full-
+  stack), Blazor (C# + WebAssembly), or Avalonia
+  (native F#/C#). Signals the polyglot story. Deferred
+  until `Zeta.Core` v1.0 ships and server mode is
+  stable. Research round first.
 - [ ] **Additional ORM providers (post-EF).** Dapper,
   NHibernate, LLBLGen, etc. After the EF provider lands
   and the pattern is understood.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,6 +1,6 @@
 # Zeta — Long-Term Vision
 
-> **Status:** round 33 v4 after Aaron's third pass of edits.
+> **Status:** round 33 v5 after Aaron's fourth pass of edits.
 > Aaron is the source of truth; this document changes freely.
 > The `product-visionary` role (to be spawned, see
 > `docs/BACKLOG.md`) will steward it once it exists.
@@ -137,25 +137,50 @@ What makes `Zeta.Core 1.0.0` on NuGet:
 - FsCheck LawRunner — `checkBilinear`,
   `checkSinkTerminal`, `checkRetractionCompleteness`
   already landed.
-- **SQL frontend (v1).** Multiple dialect targets (T-SQL,
-  PostgreSQL, MySQL, SQLite, DuckDB) via a shared query
-  IR that compiles to the DBSP operator algebra.
-  `../SQLSharp/openspec/specs/query-frontends/` is the
-  pattern to study; that project has started the
-  LINQ-first frontend + planning convergence we want.
+- **SQL frontend (v1), PostgreSQL dialect first.** Aaron
+  round 33: "whatever is easier to ship first and work
+  with EF, people love postgres compatibility." PostgreSQL
+  wins on both: Npgsql (Apache-2.0) is the widely-used
+  EF Core provider; pgAdmin/DBeaver/psql all speak the
+  wire protocol; Materialize/Feldera/CockroachDB have
+  proven it's viable to look-like-postgres while running
+  a different engine underneath. Other dialects (T-SQL,
+  MySQL, SQLite, DuckDB) follow — all via the shared
+  query IR per `../SQLSharp/openspec/specs/query-
+  frontends/`.
 - **Tight LINQ integration (v1).** `IQueryable<T>` roots
   on mapped tables; LINQ lowers to the same IR the SQL
-  parser targets. This is the primary surface for F# +
-  C# consumers.
-- **Entity Framework provider (v1).** Zeta ships an EF
-  Core provider so EF consumers get DBSP incremental
-  query plans for free; downstream ORMs follow after EF.
+  parser targets. Primary surface for F# + C# consumers.
+- **Entity Framework Core provider (v1), ALL features.**
+  Aaron: "100% all features." Full LINQ provider +
+  save-changes + migrations + tracking + change
+  detection. No "works for SELECT but fails on
+  INSERT-INTO-UPDATE" partial-provider shape —
+  consumers should never hit a "this feature not
+  implemented" wall. Other ORMs (Dapper, NHibernate,
+  LLBLGen) follow the EF Core pattern.
+- **PostgreSQL wire protocol server (v1-or-early-post-v1).**
+  Zeta speaks the PostgreSQL wire protocol so existing
+  tools (pgAdmin, DBeaver, psql, Npgsql-via-EF) connect
+  without modification. Aaron: "we will need some UI
+  that can connect to it like SSMS or PostgreSQL Admin,
+  so we will have to build our own (which we will
+  eventually do) support an existing protocol so
+  existing tools can connect." This is a server mode
+  on top of the embedded library, not a replacement;
+  Zeta keeps the in-process F# surface AND exposes a
+  wire-protocol endpoint. Significant scope — may
+  slip from v1 to early post-v1 depending on design
+  round outcome.
 - **F# DSL reimagining SQL for the modern era (v1).** The
   existing computational-expression sketch (`DSL.fs`,
   `circuit { ... }`) is the seed. Long-term ambition: a
   natively F# relational DSL that treats retractions,
   bitemporality, and incremental plans as first-class —
   not bolted on. Inspired by LINQ but shaped for DBSP.
+  Aaron round 33 on DSL design: "sounds like we need
+  design and research, this task sounds HUGE." Named
+  as a multi-round design effort in `docs/BACKLOG.md`.
 - Formal-method coverage — TLA+ / Alloy specs running
   green in CI.
 - CI parity + security posture — see Product 2 below.
@@ -309,6 +334,21 @@ degrading the factory is a net-negative round.
 - **Not a product chasing users pre-v1.** Research first;
   users follow the research.
 
+## License
+
+**Apache-2.0.** Aaron round 33: "Apache sounds okay …
+just pick one and lets go." Patent grant + contribution
+clauses give slightly better downstream-dispute defence
+than MIT at zero practical cost. Round 33 lands the LICENSE
+flip (MIT → Apache-2.0) and the `<PackageLicenseExpression>`
+update in `Directory.Build.props`.
+
+If commercial emerges, the license can be revisited
+(source-available? dual-licensed with AGPL for the OSS
+core + commercial for hosted?); Apache-2.0 is the start
+state and the easiest to move FROM because all contributors
+have granted patent rights.
+
 ## Commercial posture
 
 Pure research / open-source is the first-class experience.
@@ -434,18 +474,27 @@ Things Aaron resolved this round (round 33 v3 + v4):
   row-oriented Spine family. Fits OLAP / analytics /
   wide-row-sparse-projection workloads.
 
-Remaining gaps the product-visionary walks on first
-audit:
+Things Aaron resolved round 33 v5:
 
-- Which SQL dialect lands first in v1? T-SQL, PostgreSQL,
-  SQLite (all three? incremental?)?
-- What's the license shape — Apache-2 / MIT / LGPL / dual-
-  licensed AGPL+commercial? Licensing is a commercial-
-  trajectory lever worth deciding before the commercial
-  trigger fires.
-- Entity Framework provider surface — full LINQ provider
-  or incremental rollout (query first, then save-changes,
-  then migrations)?
-- F# DSL name — does it need a name distinct from the
-  computational-expression builder syntax, or is
-  `circuit { ... }` the permanent brand?
+- **SQL dialect: PostgreSQL first.** Easier-to-ship +
+  good EF integration + huge existing tool ecosystem.
+- **License: Apache-2.0.** Landed this round.
+- **EF provider: 100% all features.** No partial-provider
+  shape; full LINQ + save-changes + migrations + tracking.
+- **Admin UI**: Zeta will build its own eventually (long-
+  term). In the meantime, speak the PostgreSQL wire
+  protocol so existing admin tools connect.
+- **F# DSL design**: acknowledged as huge multi-round
+  research effort, queued in BACKLOG.
+
+Remaining gaps the product-visionary walks on first
+audit (after round 33):
+
+- Wire protocol server: v1 or slip to early post-v1?
+  Scope impact is significant.
+- Own admin UI: F# + web (Fable? SAFE Stack? Blazor?)
+  or native GUI (Avalonia?). Far-future but the choice
+  signals the polyglot story.
+- Naming within the wire-protocol layer — Zeta as "a
+  PostgreSQL" (we emulate) vs "behind Postgres-shaped
+  endpoint" (we translate on ingress/egress)?


### PR DESCRIPTION
Four resolutions from Aaron round 33:
1. License → Apache-2.0 (LICENSE + Directory.Build.props)
2. SQL dialect: PostgreSQL first (EF + tools ecosystem)
3. EF provider: 100% all features
4. Admin UI: build own eventually; meantime speak PostgreSQL wire protocol

Plus F# DSL flagged as HUGE multi-round design sequence in BACKLOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)