### PR TITLE
Round 33 close hotfix — markdownlint green on main

### DIFF
--- a/docs/CURRENT-ROUND.md
+++ b/docs/CURRENT-ROUND.md
@@ -58,8 +58,7 @@ From `docs/BACKLOG.md` P1 "SQL frontend + query surface"
 11. **Declarative-manifest tiering** (match `../scratch`
     `min`/`runner`/`quality`/`all`).
 
-## Round-33 carry-forward (Tracks A + B from the round-33
-original plan, re-deferred)
+## Round-33 carry-forward (Tracks A + B re-deferred)
 
 **Track A — product (LawRunner):**
 


### PR DESCRIPTION
Fix broken multi-line heading in docs/CURRENT-ROUND.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)