### PR TITLE
Fix markdownlint errors in bug_report.md (unblocks PR #32)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +25,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
## Summary

- Fix `MD032` (blanks-around-lists) and `MD007` (ul-indent) in `.github/ISSUE_TEMPLATE/bug_report.md`.
- Content unchanged — whitespace only.

## Why now

PR #32's `lint (markdownlint)` check fails on this file. CI's `pull_request` event lints the merge ref (head ∪ base), so main's broken template blocks PR #32 even though the file doesn't exist on PR #32's head.

## Test plan

- [x] `npx markdownlint-cli2 .github/ISSUE_TEMPLATE/bug_report.md` → clean locally.
- [ ] CI `lint (markdownlint)` green on this PR.
- [ ] After merge, re-run PR #32's CI and confirm `lint (markdownlint)` clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)