### PR TITLE
hygiene: gitignore .claude/worktrees/ — parallel-research scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,13 @@ coverage-summary.json
 .claude/scheduled_tasks.lock
 .claude/scheduled_tasks.json
 .claude/*.lock
+
+# Git-worktree scratch created when agents run parallel-worktree research
+# (per `docs/research/parallel-worktree-safety-2026-04-22.md`). The parent
+# `.claude/worktrees/` dir can be left behind as an empty directory after
+# the worktree is cleaned up; ignoring it keeps the no-empty-dirs lint
+# (tools/lint/no-empty-dirs.sh) from flagging legitimate harness scratch.
+.claude/worktrees/
 .DS_Store
 Thumbs.db
 StrykerOutput/


### PR DESCRIPTION
## Summary

Adds `.claude/worktrees/` to `.gitignore` so the no-empty-dirs CI gate stops flagging the parent dir left behind after a Claude Code parallel-worktree research session.

## Found by

The Round-36-committed-P0 *"Empty-folder allowlist review"* — one of two P0s queued in `docs/CURRENT-ROUND.md` §Round-36 committed P0. Ran `bash tools/lint/no-empty-dirs.sh --list` locally; `.claude/worktrees` appeared as an unexpected flagged entry.

## Why gitignore and not allowlist

The allowlist (`tools/lint/no-empty-dirs.allowlist`) is for **load-bearing** empty dirs — paths that `install.sh` creates and that tools later populate (`tools/alloy/classes`, `tools/tla/specs/states`). `.claude/worktrees/` is harness-private runtime scratch; it shouldn't be a repo concern at all. `.gitignore` is the right layer per the lint script's *"Excluded from scan: any path matched by `.gitignore`"* rule.

## Cross-reference

Origin context: `docs/research/parallel-worktree-safety-2026-04-22.md` §9 — the incident log for the parallel-worktree-safety research pass that produced this leftover state.

## Side-finding (not in scope for this PR)

While running the lint locally on macOS bash 3.2.57, the script crashes with `FILTERED[@]: unbound variable` at line 111 when the `FILTERED` array is empty (happens after removing `.claude/worktrees/` and when the allowlist targets don't exist yet). CI (Ubuntu bash 5.x) doesn't trigger this — empty-array deref under `set -u` is bash-3.2-specific. Belongs to FACTORY-HYGIENE #48 (cross-platform parity hygiene); noting here for findability but leaving for a separate fix.

## Test plan

- [x] `git check-ignore .claude/worktrees` returns path on this branch
- [x] `.claude/worktrees/` absent from `git ls-files`
- [x] CI no-empty-dirs gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)