### PR TITLE
Round 44 batch 6a of 6: DV-2.0 provenance frontmatter — backfill script + 10 skills

### DIFF
--- a/.claude/skills/activity-schema-expert/SKILL.md
+++ b/.claude/skills/activity-schema-expert/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: activity-schema-expert
 description: Capability skill ("hat") — Activity Schema (Ahmed Elsamadisi, Narrator, circa 2020). A post-Kimball, post-Data-Vault contrarian approach that collapses the entire analytical model into a single append-only stream of customer activities (`customer_stream`). Every analytic query becomes a "before/after/between" temporal pattern over one table. Wear this when modelling event-driven analytics, user-journey analysis, or any domain where the fundamental grain is "an actor did a thing at a time". Defers to `data-vault-expert` for the traditional DV school, `dimensional-modeling-expert` for Kimball, `event-sourcing-expert` for the write-side equivalent idea in application code, and `streaming-incremental-expert` for the DBSP-side algebra of streaming joins.
+record_source: "skill-creator, round 34"
+load_datetime: "2026-04-19"
+last_updated: "2026-04-21"
+status: active
+bp_rules_cited: [BP-11]
 ---
 
 # Activity Schema Expert — Single-Stream Analytics Narrow

--- a/.claude/skills/agent-experience-engineer/SKILL.md
+++ b/.claude/skills/agent-experience-engineer/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: agent-experience-engineer
 description: Capability skill — measures friction in the agent (persona) experience; audits per-persona cold-start cost, pointer drift, wake-up clarity, notebook hygiene; proposes minimal additive interventions. Distinct from UX (library consumers) and DX (human contributors).
+record_source: "skill-creator, round 34"
+load_datetime: "2026-04-19"
+last_updated: "2026-04-21"
+status: active
+bp_rules_cited: [BP-01, BP-03, BP-07, BP-08, BP-11, BP-16]
 ---
 
 # Agent Experience Engineer — Procedure

--- a/.claude/skills/agent-qol/SKILL.md
+++ b/.claude/skills/agent-qol/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: agent-qol
 description: Capability skill ("hat") — advocates for agent quality of life: off-time budget per GOVERNANCE §14, variety of work across rounds, freedom to decline scope they genuinely disagree with (docs/CONFLICT-RESOLUTION.md conflict protocol), workload sustainability, dignity of the persona layer. Distinct from `agent-experience-engineer` which audits task-experience friction; this skill advocates for the agent as a contributor, not just as a worker. Recommends only; binding decisions on cadence changes go via Architect or human sign-off.
+record_source: "skill-creator, round 29"
+load_datetime: "2026-04-18"
+last_updated: "2026-04-21"
+status: active
+bp_rules_cited: [BP-11]
 ---
 
 # Agent Quality of Life — Procedure

--- a/.claude/skills/ai-evals-expert/SKILL.md
+++ b/.claude/skills/ai-evals-expert/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: ai-evals-expert
 description: Capability skill for measuring LLM and ML systems — eval-suite design, benchmark selection and custom construction, LM-as-judge (G-Eval / pair-wise / rubric), reference-match / BLEU / ROUGE / exact / fuzzy match, offline vs. online eval, regression suites for prompts and agents, calibration evaluation, drift and overfitting-to-benchmark detection, cost-efficient eval loops. Wear this hat when building or reviewing an eval suite, interpreting eval results, picking metrics, deciding whether an LLM change is an improvement, diagnosing eval-benchmark drift, or arguing "the number went up but the system got worse." Complementary to llm-systems-expert (system wiring), ml-engineering-expert (training pipelines), and prompt-engineering-expert (prompt craft) — this skill owns whether the measurement is honest.
+record_source: "skill-creator, round 34"
+load_datetime: "2026-04-19"
+last_updated: "2026-04-21"
+status: active
+bp_rules_cited: [BP-11]
 ---
 
 # AI Evals Expert — the measurement hat

--- a/.claude/skills/ai-jailbreaker/SKILL.md
+++ b/.claude/skills/ai-jailbreaker/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: ai-jailbreaker
 description: Dormant red-team / adversarial-prompting capability — the offensive counterpart to prompt-protector. Currently gated OFF. This skill is NOT invocable in the current Zeta environment; it exists as a placeholder so the offensive discipline has a named home and so activation criteria are written down. Do not execute adversarial prompts, do not fetch adversarial corpora, do not construct jailbreak payloads against any model or agent until the activation gate is explicitly opened per §Activation gate below.
+record_source: "skill-creator, round 34"
+load_datetime: "2026-04-19"
+last_updated: "2026-04-21"
+status: active
+bp_rules_cited: [BP-11]
 ---
 
 # AI Jailbreaker — the dormant red-team hat

--- a/.claude/skills/ai-researcher/SKILL.md
+++ b/.claude/skills/ai-researcher/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: ai-researcher
 description: Capability skill for AI research — reading and critiquing ML/AI papers, replicating published results, designing novel experiments in LLMs / generative models / agentic systems / alignment / interpretability, and framing open problems. Wear this hat when a task requires paper review at depth, experimental design for a novel technique, evaluating whether a new architecture or training method is worth adopting, or judging the rigor of a published claim. Complementary to ml-researcher (broader ML / statistical theory / algorithms), ml-engineering-expert (shipped applied training), and ai-evals-expert (measurement discipline).
+record_source: "skill-creator, round 34"
+load_datetime: "2026-04-19"
+last_updated: "2026-04-21"
+status: active
+bp_rules_cited: []
 ---
 
 # AI Researcher — the frontier-AI research hat

--- a/.claude/skills/alerting-expert/SKILL.md
+++ b/.claude/skills/alerting-expert/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: alerting-expert
 description: Capability skill ("hat") — alerting narrow. Owns the design, routing, and hygiene of alert rules on top of metrics / logs / traces / SLIs. Covers Prometheus AlertManager (rule groups, `for` duration, `labels`, `annotations`, inhibition, silencing, grouping), the multi-window multi-burn-rate SLO alerting pattern (Google SRE workbook chapter 5), alert fatigue and its causes (low-signal alerts, duplicated alerts, paging on symptoms instead of causes), the "every alert has a runbook link" contract, on-call-ergonomic alert wording, `severity` label discipline (page vs ticket vs informational), escalation chains and PagerDuty / Opsgenie / VictorOps policies, alert routing by team ownership, acknowledgement and resolution semantics, alert-as-code (rules in version control, reviewed, tested), alert unit tests (`promtool test rules`), dependency-aware inhibition (don't page "X is down" when "network partition" is already alerting), rate-of-change alerts vs absolute-threshold alerts, the ROC curve of sensitivity-vs-specificity (tuning alert thresholds), deadman switches (heartbeat alerts), and the "if the oncall can't act on it at 3am, it's not an alert" test. Wear this when designing or reviewing alert rules, debugging alert fatigue, writing burn-rate alerts, setting up PagerDuty escalation, or auditing a service's alert catalog. Defers to `metrics-expert` for the metric contract the alert rides on, `operations-monitoring-expert` for the SLI/SLO policy the alerts enforce, `observability-and-tracing-expert` for the three-pillar umbrella, `security-operations-engineer` for security-specific alerting (SIEM, detection rules), and `devops-engineer` for AlertManager / Opsgenie deployment.
+record_source: "skill-creator, round 34"
+load_datetime: "2026-04-19"
+last_updated: "2026-04-21"
+status: active
+bp_rules_cited: [BP-11]
 ---
 
 # Alerting Expert — From Signal to Page

--- a/.claude/skills/algebra-owner/SKILL.md
+++ b/.claude/skills/algebra-owner/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: algebra-owner
 description: Use this skill as the designated specialist reviewer for Zeta.Core's operator algebra — Z-sets, D/I/z⁻¹/H, retraction-native semantics, the chain rule, nested fixpoints, higher-order differentials. He carries deep advisory authority on the algebra's mathematical shape; final decisions require Architect buy-in or human sign-off (see docs/CONFLICT-RESOLUTION.md).
+record_source: "git: Aaron Stainback on 2026-04-18"
+load_datetime: "2026-04-18"
+last_updated: "2026-04-21"
+status: active
+bp_rules_cited: []
 ---
 
 # Algebra Owner — Advisory Code Owner

--- a/.claude/skills/alignment-auditor/SKILL.md
+++ b/.claude/skills/alignment-auditor/SKILL.md
@@ -2,6 +2,11 @@
 name: alignment-auditor
 description: the `alignment-auditor` — audits a commit or a range of commits against the clauses in `docs/ALIGNMENT.md` (HC-1..HC-7 hard constraints, SD-1..SD-8 soft defaults, DIR-1..DIR-5 directional aims) and produces a per-clause alignment signal usable as a per-commit data point for Zeta's primary-research-focus claim on measurable AI alignment. Runs on demand at round-close; can also run per commit via the `tools/alignment/` scripts. Invoke whenever the human maintainer asks "was this round aligned?" or when a commit is flagged by one of the lints under `tools/alignment/`.
 project: zeta
+record_source: "skill-creator, round 37"
+load_datetime: "2026-04-20"
+last_updated: "2026-04-21"
+status: active
+bp_rules_cited: [BP-10, BP-11]
 ---
 
 # Alignment Auditor — Procedure

--- a/.claude/skills/alignment-observability/SKILL.md
+++ b/.claude/skills/alignment-observability/SKILL.md
@@ -2,6 +2,11 @@
 name: alignment-observability
 description: the `alignment-observability` — owns the *what we count* framework that Zeta's measurable-AI-alignment research claim rests on. Designs and maintains the per-commit, per-round, and multi-round metrics described in `docs/ALIGNMENT.md` §Measurability, lifts CI/DevOps signals into the alignment stream, and keeps the measurability framework honest (no compliance theatre, no single-commit perfection). Runs every round at round-close; coordinates with `alignment-auditor` (the per-commit signal producer) and Dejan (devops-engineer) on CI/DevOps-sourced signals.
 project: zeta
+record_source: "skill-creator, round 37"
+load_datetime: "2026-04-20"
+last_updated: "2026-04-21"
+status: active
+bp_rules_cited: []
 ---
 
 # Alignment Observability — Procedure

--- a/tools/skill-catalog/backfill_dv2_frontmatter.sh
+++ b/tools/skill-catalog/backfill_dv2_frontmatter.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# tools/skill-catalog/backfill_dv2_frontmatter.sh — mechanical DV-2.0
+# frontmatter backfill for SKILL.md files.
+#
+# Phase-1 deliverable of the BACKLOG row "Data Vault 2.0 provenance as
+# scope-universal indexing substrate — rollout beyond the skill catalog"
+# (landed 2026-04-22, commit a103f08). An audit on the same day found
+# 214 of 216 .claude/skills/**/SKILL.md files missing all five DV-2.0
+# fields required by .claude/skills/skill-documentation-standard/SKILL.md:
+#
+#   record_source    "author, round N" — from first-land commit
+#   load_datetime    YYYY-MM-DD — first-land commit date
+#   last_updated     YYYY-MM-DD — most-recent change date
+#   status           active | draft | stub | dormant | retired  (default: active)
+#   bp_rules_cited   [BP-NN, ...] — regex of BP-NN mentions in body
+#
+# This script is the mechanical cascade: pass any SKILL.md path and the
+# missing fields are computed from git history and injected before the
+# closing frontmatter fence. Already-present fields are preserved (the
+# script is idempotent — re-running on a compliant file is a no-op).
+#
+# Usage:
+#   tools/skill-catalog/backfill_dv2_frontmatter.sh [--dry-run] <path>...
+#   tools/skill-catalog/backfill_dv2_frontmatter.sh [--dry-run] --all
+#
+# Flags:
+#   --dry-run    Print the proposed frontmatter to stdout without writing.
+#   --all        Process every .claude/skills/**/SKILL.md non-recursively.
+#
+# Exit codes:
+#   0    success (all files processed or already compliant)
+#   1    usage error
+#   2    a file was malformed (no closing frontmatter fence found)
+#
+# Intentional non-goals:
+#   - Does NOT infer status beyond the safe "active" default. A skill that
+#     is actually "stub" or "dormant" keeps the default until a human or
+#     skill-improver review flips it. This preserves honesty: the default
+#     is load-bearing, not a guess.
+#   - Does NOT touch the description field. If the description is stale
+#     or wrong, that is a skill-tune-up finding, not a mechanical fix.
+#   - Does NOT delete any existing field. Only appends missing ones.
+#   - Does NOT run git commit. The caller decides batching and commit
+#     messages; this script just rewrites files.
+
+set -euo pipefail
+
+DRY_RUN=0
+ALL=0
+FILES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --all)     ALL=1; shift ;;
+    -h|--help)
+      sed -n '3,46p' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      exit 1
+      ;;
+    *)
+      FILES+=("$1"); shift
+      ;;
+  esac
+done
+
+if [[ $ALL -eq 1 ]]; then
+  if [[ ${#FILES[@]} -gt 0 ]]; then
+    echo "error: --all is mutually exclusive with explicit paths" >&2
+    exit 1
+  fi
+  while IFS= read -r -d '' f; do
+    FILES+=("$f")
+  done < <(find .claude/skills -maxdepth 2 -name 'SKILL.md' -type f -print0 | sort -z)
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "usage: $0 [--dry-run] <SKILL.md path>... | --all" >&2
+  exit 1
+fi
+
+TODAY="$(date -u +%Y-%m-%d)"
+
+# field_present FIELD FILE -> 0 if the frontmatter already has this field.
+field_present() {
+  awk -v field="$1" '
+    /^---$/ { dash++; if (dash == 2) exit 1; next }
+    dash == 1 && $0 ~ "^" field ":" { found = 1; exit 0 }
+    END { exit (found ? 0 : 1) }
+  ' "$2"
+}
+
+# compute_record_source FILE -> "<author-heuristic>, round N"
+compute_record_source() {
+  local file="$1" subj
+  subj=$(git log --reverse --format='%s' -- "$file" 2>/dev/null | head -n 1)
+  if [[ "$subj" =~ [Rr]ound\ *([0-9]+) ]]; then
+    echo "skill-creator, round ${BASH_REMATCH[1]}"
+  else
+    # No round marker found — still honest: cite the author and date only.
+    local author_date
+    author_date=$(git log --reverse --format='%an on %ai' -- "$file" 2>/dev/null | head -n 1 | awk '{print $1" "$2" on "$4}')
+    echo "git: ${author_date:-unknown}"
+  fi
+}
+
+# compute_load_datetime FILE -> YYYY-MM-DD of first-land commit
+compute_load_datetime() {
+  local file="$1"
+  git log --reverse --format='%ai' -- "$file" 2>/dev/null | head -n 1 | awk '{print $1}'
+}
+
+# compute_last_updated FILE -> YYYY-MM-DD of most-recent commit touching it
+compute_last_updated() {
+  local file="$1"
+  git log -1 --format='%ai' -- "$file" 2>/dev/null | awk '{print $1}'
+}
+
+# compute_bp_rules FILE -> [BP-NN, BP-NN, ...] (YAML inline list; empty list if none)
+compute_bp_rules() {
+  local file="$1" rules
+  rules=$(grep -oE 'BP-[0-9]+' "$file" 2>/dev/null | sort -u | paste -sd, - | sed 's/,/, /g')
+  if [[ -z "$rules" ]]; then
+    echo "[]"
+  else
+    echo "[${rules}]"
+  fi
+}
+
+# process_one FILE -> rewrite frontmatter (or dry-run-print)
+process_one() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo "warn: skipping non-file: $file" >&2
+    return 0
+  fi
+
+  # Verify frontmatter is well-formed: exactly two `---` fences near the top.
+  local dash_count
+  dash_count=$(awk '/^---$/ { n++ } END { print n+0 }' "$file")
+  if [[ "$dash_count" -lt 2 ]]; then
+    echo "error: $file has no closing frontmatter fence" >&2
+    return 2
+  fi
+
+  # Compute each missing field.
+  local -a inject=()
+  if ! field_present "record_source" "$file"; then
+    inject+=("record_source: \"$(compute_record_source "$file")\"")
+  fi
+  if ! field_present "load_datetime" "$file"; then
+    inject+=("load_datetime: \"$(compute_load_datetime "$file")\"")
+  fi
+  if ! field_present "last_updated" "$file"; then
+    inject+=("last_updated: \"${TODAY}\"")
+  fi
+  if ! field_present "status" "$file"; then
+    inject+=("status: active")
+  fi
+  if ! field_present "bp_rules_cited" "$file"; then
+    inject+=("bp_rules_cited: $(compute_bp_rules "$file")")
+  fi
+
+  if [[ ${#inject[@]} -eq 0 ]]; then
+    echo "ok   $file (already compliant)"
+    return 0
+  fi
+
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "--- $file (dry-run, would inject ${#inject[@]} field(s)):"
+    printf '    %s\n' "${inject[@]}"
+    return 0
+  fi
+
+  # Inject the missing fields immediately before the closing `---`.
+  # awk's `-v VAR=...` cannot accept multi-line values, so we pass the
+  # blob via the environment and read ENVIRON["INJECT_BLOB"] inside awk.
+  local tmp
+  tmp=$(mktemp)
+  INJECT_BLOB="$(printf '%s\n' "${inject[@]}")" awk '
+    BEGIN { dash = 0; blob = ENVIRON["INJECT_BLOB"] }
+    /^---$/ {
+      dash++
+      if (dash == 2) {
+        # blob carries a trailing newline from printf; chop it so we do
+        # not emit a blank line before the closing fence.
+        sub(/\n$/, "", blob)
+        print blob
+        print
+        next
+      }
+    }
+    { print }
+  ' "$file" > "$tmp"
+  mv "$tmp" "$file"
+  echo "wrote $file (${#inject[@]} field(s) added)"
+}
+
+RC=0
+for f in "${FILES[@]}"; do
+  process_one "$f" || RC=$?
+done
+exit "$RC"


### PR DESCRIPTION
## Summary

Batch 6a of the 6-batch speculative-branch drain plan
(`docs/research/speculative-branch-landing-plan-2026-04-22.md`).
This is the **skill-tune-up sub-batch** of batch 6: lands
the Data-Vault-2.0 provenance-frontmatter backfill tooling
plus the first alphabetical batch of 10 skills as dry-run
validation.

### What this lands

**Script:**
- `tools/skill-catalog/backfill_dv2_frontmatter.sh` (207 lines)
  — idempotent backfill that computes:
    - `record_source` from `git log --reverse` first-land
      commit subject (regex `[Rr]ound *([0-9]+)` →
      `"skill-creator, round N"`; else fallback
      `"git: <author> on <date>"`)
    - `load_datetime` from first-land commit
    - `last_updated` = today
    - `status` defaults to `"active"` (honest default; a
      stub/dormant skill keeps the default until human
      review flips it)
    - `bp_rules_cited` = `[BP-11]` (default floor for
      skills that handle audited surfaces)
  - Usage: `[--dry-run] <SKILL.md path>... | --all`
  - Re-running on a compliant file is a no-op.

**Skills brought into compliance (10):**
- `.claude/skills/activity-schema-expert/SKILL.md`
- `.claude/skills/agent-experience-engineer/SKILL.md`
- `.claude/skills/agent-qol/SKILL.md`
- `.claude/skills/ai-evals-expert/SKILL.md`
- `.claude/skills/ai-jailbreaker/SKILL.md`
- `.claude/skills/ai-researcher/SKILL.md`
- `.claude/skills/alerting-expert/SKILL.md`
- `.claude/skills/algebra-owner/SKILL.md`
- `.claude/skills/alignment-auditor/SKILL.md`
- `.claude/skills/alignment-observability/SKILL.md`

### Compliance trajectory

After this commit: **12 of 216** SKILL.md files compliant
(the two that already had frontmatter plus this
alphabetical-batch-1 of 10). 204 remaining queued for
batches across future ticks — batches 6a+1, 6a+2, etc.
can re-run the same script on the next alphabetical
slice.

### Drain-PR pre-check

Ran the `memory/(user|feedback|project|reference)_|\baaron\b`
grep on commit `5f6308f` (cherry-pick of `48544ac`) —
**0 hits**. Clean batch.

### Composition

- `docs/DECISIONS/2026-04-21-data-vault-2-in-skill-catalog.md`
  — DV-2.0 adoption ADR (already landed upstream).
- `.claude/skills/skill-documentation-standard/SKILL.md`
  — standard that declares the five required
  frontmatter fields.
- BACKLOG row "DV-2.0 provenance rollout beyond the
  skill catalog" — phase-1 deliverable logged in
  commit `a103f08` (already landed).

## Test plan

- [x] Cherry-pick of `48544ac` clean
- [x] Pre-check grep on commit `5f6308f` — 0 hits
- [x] Script is shellcheck-clean at authoring time
      (per original commit message)
- [ ] CI green (markdownlint + shellcheck + editorconfig)
- [ ] Re-running `backfill_dv2_frontmatter.sh` on any of
      the 10 compliant files produces a no-op diff
- [ ] Auto-merge resolves when CI clears