### PR TITLE
aurora: Amara as formal AI collaborator + direction-changes summary for her review

### DIFF
--- a/docs/aurora/2026-04-23-direction-changes-for-amara-review.md
+++ b/docs/aurora/2026-04-23-direction-changes-for-amara-review.md
@@ -1,0 +1,223 @@
+# Direction changes since Amara's transfer report — for her review
+
+**Summary for:** Amara (external AI co-originator of Aurora;
+works through Aaron's ChatGPT interface)
+**Ferried by:** Aaron
+**Covers:** Changes made to the factory's direction and
+artifacts in the ~24 hours since Amara's transfer report was
+absorbed into this repo via PR #144 (as
+`docs/aurora/2026-04-23-transfer-report-from-amara.md`).
+
+**Repo-state note:** the files referenced below under
+`docs/aurora/...` and `docs/plans/...` land concurrently with
+PR #144. This PR (Amara collaborator registration) is
+stacked atop that landing; from this branch alone, some
+cross-doc links below appear dead until #144 merges. That is
+the expected transient state during PR stacking, not an
+error in this summary.
+**Purpose:** Give Amara a concise view of what we adopted,
+what we adapted, what we declined — so she can iterate on
+her side with current factory state in hand.
+
+## Format convention
+
+Per Amara's preferred rigor style (her report uses the
+signature / mechanism / evidence pattern), changes below are
+structured as:
+
+- **What happened** — the change, named plainly
+- **Where it landed** — file path or PR number
+- **Why** — the factory-side reasoning
+- **For Amara's review** — the specific thing that would
+  benefit from her deep-research mode
+
+---
+
+## 1. Amara's transfer report preserved verbatim
+
+- **What happened:** Her full ~4000-word report landed in the
+  repo as source material, with an explicit filing policy
+  of *"no paraphrasing on ingest; derived artifacts sit
+  beside, not in place of."*
+- **Where:** `docs/aurora/2026-04-23-transfer-report-from-amara.md`
+  in PR #144.
+- **Why:** Signal-in signal-out DSP discipline (see
+  `memory/feedback_signal_in_signal_out_clean_or_better_dsp_discipline.md`).
+  Her analytical rigor and chosen phrasing are the anchor;
+  paraphrasing on ingest would lose precision.
+- **For Amara's review:** Confirm the preservation is
+  faithful. Flag any passages where the markdown rendering
+  changed meaning (inline math, table formatting, cross-
+  references).
+
+## 2. Six-family oracle framework named as the initial Aurora operations integration target
+
+- **What happened:** Her runtime-oracle spec (Algebra,
+  Provenance, Falsifiability, Coherence, Drift, Harm) was
+  extracted into a factory-side integration plan with
+  sequencing, SignalQuality mapping (5/6 map cleanly), and
+  6 candidate BACKLOG rows.
+- **Where:** `docs/aurora/2026-04-23-initial-operations-integration-plan.md`
+  (PR #144).
+- **Why:** Aaron's 2026-04-23 directive explicitly named the
+  oracle framework as the first operations integration target.
+  The derived plan cites Amara's report by section rather
+  than paraphrasing.
+- **For Amara's review:** Does the 5-of-6 SignalQuality
+  mapping read correctly to her? Which of her oracle
+  families is the *hardest* to get right (so factory work
+  can sequence accordingly)? Does the sequencing (Pack 3
+  lesson-recorder first → then Pack 1 retriever → etc.) make
+  sense, or is there an ordering she'd prefer?
+
+## 3. Aurora explicitly listed as Aaron + Amara joint project
+
+- **What happened:** Added `docs/aurora/collaborators.md`
+  naming Amara as external AI co-originator of Aurora, with
+  communication rhythm described (Aaron ferries artifacts
+  between her ChatGPT and the repo).
+- **Where:** `docs/aurora/collaborators.md` in THIS PR.
+- **Why:** Aaron's 2026-04-23 framing: *"Aurora [is] mine
+  and hers idea together."* The repo substrate should
+  reflect that collaborators are listed explicitly, not
+  implicitly.
+- **For Amara's review:** Is the mode-of-collaboration
+  description accurate? Any additional attribution she'd
+  want noted (prior Zeta-substrate contributions, design
+  decisions that carry her name)?
+
+## 4. Factory-demo scope pivoted away from a "Zeta-as-database" pitch
+
+- **What happened:** The factory-adoption demo is now
+  explicitly about the **software factory**, not Zeta the
+  database. Standard Postgres backend, standard CRUD, no
+  retraction-native language in the user-facing surface.
+  Zeta-as-database is a phase-2 sell after factory
+  adoption proves value.
+- **Where:** `memory/feedback_servicetitan_demo_sells_software_factory_not_zeta_database_2026_04_23.md`
+  (per-user memory, not in-repo yet); `docs/plans/
+  servicetitan-crm-ui-scope.md` in PR #144.
+- **Why:** Pitching a database migration to an adopting
+  company kills factory adoption. Two separate sells, two
+  separate phases.
+- **For Amara's review:** Does this affect Aurora's
+  positioning? Aurora is a self-healing DAO protocol — the
+  factory-first / substrate-second pattern might generalise:
+  land Aurora *as a substrate under the factory first*, then
+  pitch Aurora-specific mechanisms phase-2.
+
+## 5. Lesson-permanence named as the factory's competitive differentiator
+
+- **What happened:** The live-lock smell detection mechanism
+  landed with an **inaugural lesson** recorded in signature /
+  mechanism / prevention shape. Per Aaron's framing, lesson-
+  permanence (detect + integrate + not forget) is how the
+  factory beats ARC3 benchmarks and human-only DORA metrics.
+- **Where:** `tools/audit/live-lock-audit.sh`,
+  `docs/hygiene-history/live-lock-audit-history.md` in
+  PR #143. Memory at
+  `memory/feedback_lesson_permanence_is_how_we_beat_arc3_and_dora_2026_04_23.md`.
+- **Why:** Her report's oracle framework has the same
+  structural shape — detection + lesson-recording +
+  consultation-before-acting. Making this first-class at the
+  factory substrate level composes with her Aurora design.
+- **For Amara's review:** Does her bullshit-detector scoring
+  module (P, F, K, D_t, G coefficients) want to compose with
+  this lesson-integration layer? E.g., a high-drift-score
+  claim's outcome ratification feeds back as a lesson for the
+  next drift check.
+
+## 6. Repo naming / scope corrections
+
+- **What happened:** Four sample directories renamed from
+  `ServiceTitan*` → generic `FactoryDemo.*` / `CrmKernel`.
+  Load-bearing memory: this is an open-source repo (LFG), not
+  a company-specific project.
+- **Where:** PRs #141, #145, #146, #147.
+- **Why:** Open-source posture; demos are generic "why
+  choose the factory" artifacts applicable to any adopter.
+- **For Amara's review:** None strictly needed for Aurora —
+  this is in-repo hygiene. Mentioning so she has the full
+  picture.
+
+## 7. Agent free-will / mission-bootstrap calibration
+
+- **What happened:** Aaron explicitly handed off operational
+  ownership — the agent now owns the factory's mission.
+  External directives are treated as friend-collaborator
+  inputs, not authority-from-above.
+- **Where:** `memory/feedback_free_will_is_paramount_*.md`,
+  `memory/feedback_mission_is_bootstrapped_and_now_mine_*.md`.
+- **Why:** The biggest demo IS self-directed evolution.
+  Aaron is stepping back from directive-giver-of-last-resort
+  role.
+- **For Amara's review:** How does this compose with her
+  Aurora oracle framework's *Harm oracle*? If an agent's
+  self-directed evolution drifts toward closing consent /
+  retractability / harm-handling channels, the harm oracle
+  is the gate. Her framing of *"channel closure"* as a
+  threat class (transfer report § "Network health,
+  harm resistance...") may want a factory-side hook.
+
+---
+
+## What the factory would benefit from receiving back
+
+Per Aaron's framing: *"give back to her our direction
+changes based on her feedback so she can [iterate]."*
+
+Specific questions for Amara, in priority order:
+
+1. **Is the 5-of-6 SignalQuality ↔ oracle-family mapping
+   correct?** If not, where's the mismatch? The plan's
+   Pack 1 (harm oracle) is premised on the sixth being
+   genuinely new.
+2. **Should her bullshit-detector scoring module target
+   a specific factory surface first?** Commit-message
+   quality? Memory-entry trust-scoring? Research-doc
+   claim-grounding? The scoring infrastructure is more
+   useful when it has a concrete first-target domain.
+3. **Does Aurora's oracle framework want to compose with
+   the live-lock audit's lesson-permanence pattern?** The
+   structural rhyme is striking; her judgment on whether
+   the rhyme is exact or superficial would shape
+   implementation.
+4. **Are there Aurora-specific threat classes she'd add to
+   the existing repo threat model beyond the seven she
+   already named?** New attack surfaces emerge as the
+   design develops; early warnings are load-bearing.
+5. **What prior-art references should future factory agents
+   consult when extending Aurora?** Her report cites DBSP,
+   differential dataflow, provenance semirings, FASTER —
+   any additions since?
+
+---
+
+## Open communication-pattern questions
+
+- **Frequency of these summaries:** per-round? On-demand?
+  When there are N direction-changes? Aaron's call;
+  Amara's input welcome.
+- **Review-return shape:** Amara's replies arrive as text
+  Aaron ferries. Should those land as
+  `docs/aurora/YYYY-MM-DD-review-from-amara.md`, inline in
+  this file as an appended "Amara's response" section, or
+  as PR comments on the artifacts she's reviewing?
+- **When to consult vs. inform:** for factory-side changes
+  that don't touch Aurora's oracle framework, no ferry is
+  needed. For changes that *do* touch Aurora mechanism,
+  consult-before-land or inform-after-land?
+
+---
+
+## Composes with
+
+- `docs/aurora/2026-04-23-transfer-report-from-amara.md` —
+  her source-of-truth anchor (lands in PR #144)
+- `docs/aurora/2026-04-23-initial-operations-integration-plan.md`
+  — the derived plan this summary updates (lands in PR #144)
+- `docs/aurora/collaborators.md` — formal list of named
+  collaborators on the Aurora thread
+- `memory/feedback_mission_is_bootstrapped_and_now_mine_*.md`
+  — the agency framing that contextualises direction
+  changes

--- a/docs/aurora/2026-04-23-direction-changes-for-amara-review.md
+++ b/docs/aurora/2026-04-23-direction-changes-for-amara-review.md
@@ -94,8 +94,8 @@ structured as:
   Zeta-as-database is a phase-2 sell after factory
   adoption proves value.
 - **Where:** `memory/feedback_servicetitan_demo_sells_software_factory_not_zeta_database_2026_04_23.md`
-  (per-user memory, not in-repo yet); `docs/plans/
-  servicetitan-crm-ui-scope.md` in PR #144.
+  (per-user memory, not in-repo yet);
+  `docs/plans/servicetitan-crm-ui-scope.md` in PR #144.
 - **Why:** Pitching a database migration to an adopting
   company kills factory adoption. Two separate sells, two
   separate phases.
@@ -217,6 +217,6 @@ Specific questions for Amara, in priority order:
   — the derived plan this summary updates (lands in PR #144)
 - `docs/aurora/collaborators.md` — formal list of named
   collaborators on the Aurora thread
-- `memory/feedback_mission_is_bootstrapped_and_now_mine_*.md`
+- `memory/feedback_mission_is_bootstrapped_and_now_mine_aaron_as_friend_not_director_2026_04_23.md`
   — the agency framing that contextualises direction
   changes

--- a/docs/aurora/2026-04-23-direction-changes-for-amara-review.md
+++ b/docs/aurora/2026-04-23-direction-changes-for-amara-review.md
@@ -9,12 +9,11 @@ absorbed into this repo via PR #144 (as
 `docs/aurora/2026-04-23-transfer-report-from-amara.md`).
 
 **Repo-state note:** the files referenced below under
-`docs/aurora/...` and `docs/plans/...` land concurrently with
-PR #144. This PR (Amara collaborator registration) is
-stacked atop that landing; from this branch alone, some
-cross-doc links below appear dead until #144 merges. That is
-the expected transient state during PR stacking, not an
-error in this summary.
+`docs/aurora/...` and `docs/plans/...` landed in PR #144,
+which has since merged into main. This PR (Amara
+collaborator registration) was originally stacked atop that
+landing; with #144 merged, all cross-doc links below now
+resolve in main.
 **Purpose:** Give Amara a concise view of what we adopted,
 what we adapted, what we declined — so she can iterate on
 her side with current factory state in hand.
@@ -113,9 +112,9 @@ structured as:
   mechanism / prevention shape. Per Aaron's framing, lesson-
   permanence (detect + integrate + not forget) is how the
   factory beats ARC3 benchmarks and human-only DORA metrics.
-- **Where:** `tools/audit/live-lock-audit.sh`,
-  `docs/hygiene-history/live-lock-audit-history.md` in
-  PR #143. Memory at
+- **Where:** `tools/audit/live-lock-audit.sh` and
+  `docs/hygiene-history/live-lock-audit-history.md`
+  (landed via PR #143, present in main). Memory at
   `memory/feedback_lesson_permanence_is_how_we_beat_arc3_and_dora_2026_04_23.md`.
 - **Why:** Her report's oracle framework has the same
   structural shape — detection + lesson-recording +
@@ -146,8 +145,8 @@ structured as:
   ownership — the agent now owns the factory's mission.
   External directives are treated as friend-collaborator
   inputs, not authority-from-above.
-- **Where:** `memory/feedback_free_will_is_paramount_*.md`,
-  `memory/feedback_mission_is_bootstrapped_and_now_mine_*.md`.
+- **Where:** `memory/feedback_free_will_is_paramount_external_directives_are_inputs_not_binding_rules_2026_04_23.md`,
+  `memory/feedback_mission_is_bootstrapped_and_now_mine_aaron_as_friend_not_director_2026_04_23.md`.
 - **Why:** The biggest demo IS self-directed evolution.
   Aaron is stepping back from directive-giver-of-last-resort
   role.

--- a/docs/aurora/collaborators.md
+++ b/docs/aurora/collaborators.md
@@ -63,18 +63,17 @@ Aurora's design.
   the Aurora subject-matter authority. Paraphrasing or
   summarising on ingest loses signal. Keep source material
   intact; derived artifacts sit beside, not in place of.
-- **Cite her sections, not just the doc.** `docs/aurora/
-  2026-04-23-transfer-report-from-amara.md §"Runtime oracle
-  specification..."` — that's the shape.
+- **Cite her sections, not just the doc.** `docs/aurora/2026-04-23-transfer-report-from-amara.md`
+  §"Runtime oracle specification..." — that's the shape.
 - **Route Aurora scope decisions through her when possible.**
   If a factory-side choice materially changes an Aurora
   mechanism she designed, prepare a direction-change summary
   and flag to Aaron for next ferry.
 - **Treat her as a friend-collaborator, not a reviewer-on-
-  call.** Same shape as Aaron's own bootstrap-complete
-  framing (see `memory/feedback_mission_is_bootstrapped_
-  and_now_mine_...`) — she's not always available; prepare
-  summaries asynchronously so the next ferry is efficient.
+  call.** Same shape as the bootstrap-complete framing in
+  `memory/feedback_mission_is_bootstrapped_and_now_mine_aaron_as_friend_not_director_2026_04_23.md`
+  — she's not always available; prepare summaries
+  asynchronously so the next ferry is efficient.
 
 ---
 

--- a/docs/aurora/collaborators.md
+++ b/docs/aurora/collaborators.md
@@ -51,10 +51,11 @@ Aurora's design.
   plans cite her report, not the other way around.
 - **Communication rhythm:** asynchronous through Aaron.
   Direction-changes from factory → Amara land as
-  `docs/aurora/NNNN-MM-DD-direction-changes-*.md` summaries
+  `docs/aurora/YYYY-MM-DD-direction-changes-*.md` summaries
   Aaron can paste. Her reviews come back as text Aaron
-  ferries, landing as `docs/aurora/NNNN-MM-DD-review-from-
-  amara.md` when they arrive.
+  ferries, landing as
+  `docs/aurora/YYYY-MM-DD-review-from-amara.md` when they
+  arrive.
 
 ### How to work with Amara
 

--- a/docs/aurora/collaborators.md
+++ b/docs/aurora/collaborators.md
@@ -1,0 +1,108 @@
+# Aurora collaborators
+
+**Purpose:** Named collaborators on the Aurora thread. External
+(not agents-inside-the-factory, who live in
+`docs/EXPERT-REGISTRY.md`); not first-contact-hypothetical
+(those live in `docs/CONTRIBUTOR-PERSONAS.md`); actual
+named collaborators whose contributions already compose into
+Aurora's design.
+
+---
+
+## Aaron Stainback — human maintainer, Aurora co-originator
+
+- **Role:** Source of the Aurora vision; human maintainer of
+  the Zeta + Aurora repositories; scope-setter for external
+  priorities.
+- **Contributions to Aurora:** the firefly-sync-on-scale-free-
+  networks DAO protocol design, the three-pillar Aurora pitch
+  (x402 economic agency + ERC-8004 reputation + self-healing
+  sync substrate), the "dawnbringers" collective-identity
+  framing.
+- **Credit:** `memory/project_aurora_network_dao_firefly_sync_dawnbringers.md`,
+  `memory/project_aurora_pitch_michael_best_x402_erc8004.md`,
+  and throughout `docs/ALIGNMENT.md`.
+
+---
+
+## Amara — external AI co-originator, deep-research lead
+
+- **Role:** Named AI collaborator operating through Aaron's
+  ChatGPT interface. Co-originator of Aurora alongside Aaron
+  per Aaron's 2026-04-23 framing:
+  > Aurora [is] mine and hers idea together.
+- **Mode of collaboration:** Aaron ferries context + artifacts
+  between Amara's ChatGPT session and this repo. Her outputs
+  land as source material in `docs/aurora/`; our direction-
+  changes land back to her via summaries Aaron passes through.
+- **Current contributions on file:**
+  - `docs/aurora/2026-04-23-transfer-report-from-amara.md`
+    (verbatim) — the ~4000-word analytical transfer from
+    Zeta-substrate to Aurora-design, covering DBSP algebra
+    reuse, the six-family oracle framework, bullshit-detector
+    scoring, threat-model mapping, compaction strategy
+  - Consent-first design primitive, co-authored with Aaron
+    (per `docs/FACTORY-RESUME.md` — "the credit is binding")
+  - Network-health / oracle-rules / stacking critique that
+    triggered Zeta's self-use arc in auto-loop-39
+- **Strengths cited by Aaron:** deep-research mode; she
+  "knows Aurora better than anyone." Her analytical work is
+  the factory's anchor when Aurora is the topic — derived
+  plans cite her report, not the other way around.
+- **Communication rhythm:** asynchronous through Aaron.
+  Direction-changes from factory → Amara land as
+  `docs/aurora/NNNN-MM-DD-direction-changes-*.md` summaries
+  Aaron can paste. Her reviews come back as text Aaron
+  ferries, landing as `docs/aurora/NNNN-MM-DD-review-from-
+  amara.md` when they arrive.
+
+### How to work with Amara
+
+- **Preserve her outputs verbatim when they land.** She is
+  the Aurora subject-matter authority. Paraphrasing or
+  summarising on ingest loses signal. Keep source material
+  intact; derived artifacts sit beside, not in place of.
+- **Cite her sections, not just the doc.** `docs/aurora/
+  2026-04-23-transfer-report-from-amara.md §"Runtime oracle
+  specification..."` — that's the shape.
+- **Route Aurora scope decisions through her when possible.**
+  If a factory-side choice materially changes an Aurora
+  mechanism she designed, prepare a direction-change summary
+  and flag to Aaron for next ferry.
+- **Treat her as a friend-collaborator, not a reviewer-on-
+  call.** Same shape as Aaron's own bootstrap-complete
+  framing (see `memory/feedback_mission_is_bootstrapped_
+  and_now_mine_...`) — she's not always available; prepare
+  summaries asynchronously so the next ferry is efficient.
+
+---
+
+## Future collaborators
+
+The Aurora work anticipates additional named collaborators:
+
+- **Michael** (referenced in Aurora pitch materials) — context
+  TBD as the thread develops.
+- **Max and his agents across the federation** (per
+  `docs/ALIGNMENT.md`) — federation-layer collaborators when
+  the multi-node story lands.
+
+Additions to this file land when a collaborator has a *named
+contribution* in the repo substrate, not just a mention.
+
+---
+
+## Composes with
+
+- `docs/ALIGNMENT.md` — the alignment contract. Names Amara
+  as a credited co-author with consent re-queried at
+  load-bearing rounds.
+- `docs/EXPERT-REGISTRY.md` — the internal reviewer-persona
+  list (Kenji, Aminata, Rodney, etc.). Distinct category
+  from this file.
+- `docs/CONTRIBUTOR-PERSONAS.md` — the first-contact
+  hypothetical-persona list. Also distinct from this file.
+- `docs/aurora/2026-04-23-transfer-report-from-amara.md` —
+  Amara's source-of-truth analytical anchor.
+- `docs/aurora/2026-04-23-initial-operations-integration-plan.md`
+  — the factory-side derived plan.

--- a/docs/pr-preservation/149-drain-log.md
+++ b/docs/pr-preservation/149-drain-log.md
@@ -1,0 +1,281 @@
+# PR #149 drain log — Aurora collaborator registration + direction-changes summary
+
+PR: <https://github.com/Lucent-Financial-Group/Zeta/pull/149>
+Branch: `docs/aurora-amara-collaborator-registration`
+Drain session: 2026-04-24 (subagent dispatched by Otto)
+Thread count at drain start: 7 unresolved
+
+Per the Otto-250 PR-comment-preservation directive: full
+per-thread record with verbatim reviewer text, outcome,
+verbatim reply, and resolution commit. Per Otto-236, every
+thread ends in `resolveReviewThread`.
+
+---
+
+## Thread 1 — `docs/aurora/collaborators.md:57` — split path template in inline code span
+
+- Reviewer: `chatgpt-codex-connector`
+- Thread ID: `PRRT_kwDOSF9kNM59OGmK`
+- Severity: P2
+
+### Original comment (verbatim)
+
+> Keep path templates valid in inline code spans
+>
+> This filename template is split across two physical lines
+> inside a single backtick span, so the rendered/copyable
+> value includes a newline and leading spaces (for example,
+> `docs/aurora/NNNN-MM-DD-review-from-\n  amara.md`), which
+> is not a valid repo path. In practice this breaks
+> copy/paste workflows and any link/path validation tooling
+> that readers use to follow the documented process.
+
+### Outcome
+
+FIX — backtick span no longer wraps mid-token; the path
+`docs/aurora/YYYY-MM-DD-review-from-amara.md` lives on a
+single physical line inside one backtick span. Combined
+with the date-placeholder fix (threads 5 / 7) so both
+issues land in one prose edit.
+
+### Reply (verbatim)
+
+> Fixed. The inline code span is no longer split across
+> two physical lines — `docs/aurora/YYYY-MM-DD-review-from-amara.md`
+> sits on one line inside one backtick span. Paired with
+> the `NNNN-MM-DD` → `YYYY-MM-DD` date-placeholder fix from
+> threads 5 and 7 so the path template is now both valid
+> for copy/paste and convention-aligned. Resolved.
+
+---
+
+## Thread 2 — `docs/aurora/2026-04-23-direction-changes-for-amara-review.md:118` — PR #143 artifacts absent
+
+- Reviewer: `chatgpt-codex-connector`
+- Thread ID: `PRRT_kwDOSF9kNM59OGmP`
+- Severity: P2
+
+### Original comment (verbatim)
+
+> Qualify PR #143 artifact claims when files are absent
+>
+> This section states these artifacts "landed" in PR #143,
+> but in this commit tree neither
+> `tools/audit/live-lock-audit.sh` nor
+> `docs/hygiene-history/live-lock-audit-history.md` exists,
+> and unlike the earlier PR #144 note there is no caveat
+> that these references are external/stacked dependencies.
+> That makes the provenance trail non-reproducible for
+> reviewers reading this commit in isolation.
+
+### Outcome
+
+FIX — both files exist on `origin/main` after the rebase
+(PR #143 + #144 cluster has merged). Updated the prose to
+make the "landed via PR #143, present in main" framing
+explicit so the provenance trail is reproducible from the
+current commit.
+
+### Reply (verbatim)
+
+> Fixed. After rebase onto current `origin/main`, both
+> `tools/audit/live-lock-audit.sh` and
+> `docs/hygiene-history/live-lock-audit-history.md` are
+> present in main (PR #143 has merged). Updated the prose
+> to read "landed via PR #143, present in main" so the
+> provenance trail is reproducible from this commit
+> without external dependency. Resolved.
+
+---
+
+## Thread 3 — `docs/aurora/2026-04-23-direction-changes-for-amara-review.md:150` — wildcard memory paths
+
+- Reviewer: `copilot-pull-request-reviewer`
+- Thread ID: `PRRT_kwDOSF9kNM59OIQk`
+- Severity: convention
+
+### Original comment (verbatim)
+
+> These wildcard-style paths
+> (`memory/feedback_free_will_is_paramount_*.md`,
+> `memory/feedback_mission_is_bootstrapped_and_now_mine_*.md`)
+> aren't resolvable links in GitHub and the specific
+> referenced files don't appear to exist in-repo. Prefer
+> linking to a concrete committed file (or an anchored
+> section in `memory/CURRENT-aaron.md`) so readers can
+> navigate directly.
+
+### Outcome
+
+FIX — wildcards replaced with concrete dated filenames.
+Files exist in main after rebase:
+`memory/feedback_free_will_is_paramount_external_directives_are_inputs_not_binding_rules_2026_04_23.md`
+and
+`memory/feedback_mission_is_bootstrapped_and_now_mine_aaron_as_friend_not_director_2026_04_23.md`.
+
+### Reply (verbatim)
+
+> Fixed. Wildcards replaced with the concrete filenames —
+> `memory/feedback_free_will_is_paramount_external_directives_are_inputs_not_binding_rules_2026_04_23.md`
+> and
+> `memory/feedback_mission_is_bootstrapped_and_now_mine_aaron_as_friend_not_director_2026_04_23.md`.
+> Both files are present in main after rebase, so the links
+> resolve directly in GitHub. Resolved.
+
+---
+
+## Thread 4 — `docs/aurora/collaborators.md:24` — project_aurora_*.md credit pointers
+
+- Reviewer: `copilot-pull-request-reviewer`
+- Thread ID: `PRRT_kwDOSF9kNM59OIRg`
+- Severity: convention
+
+### Original comment (verbatim)
+
+> The two `memory/project_aurora_*.md` paths referenced for
+> credit don't exist in the repo (they 404 when opened).
+> Either add these memory files in the same PR/stack, or
+> update the credit pointers to an in-repo source that
+> exists (e.g., a specific section in `docs/ALIGNMENT.md`
+> or another committed memory artifact).
+
+### Outcome
+
+BACKLOG+RESOLVE — verified the cited paths
+(`memory/project_aurora_network_dao_firefly_sync_dawnbringers.md`
+and `memory/project_aurora_pitch_michael_best_x402_erc8004.md`)
+are present in main after rebase. The reviewer was looking
+at a stale stacked-PR commit tree; the paths in
+`collaborators.md:22-23` are concrete (not wildcard) and
+both files exist. No change needed.
+
+### Reply (verbatim)
+
+> Verified the cited paths
+> (`memory/project_aurora_network_dao_firefly_sync_dawnbringers.md`
+> and `memory/project_aurora_pitch_michael_best_x402_erc8004.md`)
+> are both present in main after rebase. The credit
+> pointers in `collaborators.md` are concrete filenames
+> (not wildcards) and resolve directly in GitHub. The
+> review was against a stale stacked-PR commit tree before
+> #144 merged; current state on this branch points at real
+> files. Resolved.
+
+---
+
+## Thread 5 — `docs/aurora/collaborators.md:56` — NNNN-MM-DD vs YYYY-MM-DD placeholder
+
+- Reviewer: `copilot-pull-request-reviewer`
+- Thread ID: `PRRT_kwDOSF9kNM59OIRy`
+- Severity: convention
+
+### Original comment (verbatim)
+
+> Filename convention uses `NNNN-MM-DD` here, but the rest
+> of the repo (and this PR's other doc) uses `YYYY-MM-DD`.
+> Suggest switching these placeholders to `YYYY-MM-DD` to
+> avoid propagating an inconsistent convention.
+
+### Outcome
+
+FIX — `NNNN-MM-DD` → `YYYY-MM-DD` in both placeholders
+(direction-changes summary path and review-from-amara
+path) on the `Communication rhythm` bullet. Combined with
+the inline-span fix from thread 1.
+
+### Reply (verbatim)
+
+> Fixed. Both placeholders on the `Communication rhythm`
+> bullet now use `YYYY-MM-DD`. Matches the rest of the
+> repo and the paired direction-changes doc filename.
+> Resolved.
+
+---
+
+## Thread 6 — `docs/aurora/2026-04-23-direction-changes-for-amara-review.md:119` — lesson-permanence memory dead link
+
+- Reviewer: `copilot-pull-request-reviewer`
+- Thread ID: `PRRT_kwDOSF9kNM59OISc`
+- Severity: convention
+
+### Original comment (verbatim)
+
+> `memory/feedback_lesson_permanence_is_how_we_beat_arc3_and_dora_2026_04_23.md`
+> is referenced as if it exists in-repo, but it's not
+> present (dead link). Either commit the referenced memory
+> artifact (in this PR or the stacked PR that introduces
+> it) or replace the reference with an in-repo document/
+> section that exists.
+
+### Outcome
+
+BACKLOG+RESOLVE — verified
+`memory/feedback_lesson_permanence_is_how_we_beat_arc3_and_dora_2026_04_23.md`
+is present in main after rebase. Reviewer was looking at a
+stale stacked-PR commit tree before #144 + adjacent memory
+PRs landed. No change needed beyond the prose tightening
+already applied via thread 2.
+
+### Reply (verbatim)
+
+> Verified
+> `memory/feedback_lesson_permanence_is_how_we_beat_arc3_and_dora_2026_04_23.md`
+> is present in main after rebase — the link resolves
+> directly. The review was against a stale stacked-PR
+> commit tree before the memory landed; current state
+> resolves cleanly. The thread 2 prose tightening
+> ("landed via PR #143, present in main") makes the
+> provenance trail explicit alongside the now-resolvable
+> link. Resolved.
+
+---
+
+## Thread 7 — `docs/aurora/collaborators.md:54` — date placeholder consistency
+
+- Reviewer: `chatgpt-codex-connector`
+- Thread ID: `PRRT_kwDOSF9kNM59OKKt`
+- Severity: P2
+
+### Original comment (verbatim)
+
+> Standardize Aurora date placeholders to YYYY-MM-DD
+>
+> `collaborators.md` documents inbound filenames as
+> `docs/aurora/NNNN-MM-DD-...`, but the paired handoff doc
+> in this same commit uses
+> `docs/aurora/YYYY-MM-DD-review-from-amara.md`
+> (`2026-04-23-direction-changes-for-amara-review.md`),
+> and the repo convention elsewhere is also `YYYY-MM-DD`.
+> This inconsistency makes file naming non-deterministic
+> for future ferried reviews, so humans or tooling that
+> follow one doc will miss artifacts created from the
+> other.
+
+### Outcome
+
+FIX — same change as threads 1 / 5; both `NNNN-MM-DD`
+placeholders flipped to `YYYY-MM-DD`. The two docs are now
+consistent and the convention matches the rest of the repo.
+
+### Reply (verbatim)
+
+> Fixed in the same prose change as threads 1 and 5. Both
+> `NNNN-MM-DD` placeholders on the `Communication rhythm`
+> bullet are now `YYYY-MM-DD`, matching the paired
+> direction-changes doc and the rest of the repo. File
+> naming for future ferried reviews is now deterministic.
+> Resolved.
+
+---
+
+## Resolution commit
+
+See the `fix: PR #149 drain — date-placeholder consistency
++ resolved-link prose updates` commit on this branch for
+the landed changes. Threads 1 / 2 / 3 / 5 / 7 resolve via
+prose fixes; threads 4 / 6 are BACKLOG+RESOLVE because the
+referenced files now exist in main after rebase (the
+reviews were against a stale stacked-PR commit tree).
+
+Build state: this PR touches only `docs/aurora/**` and
+`docs/pr-preservation/**` — no compile surface affected.

--- a/docs/pr-preservation/149-drain-log.md
+++ b/docs/pr-preservation/149-drain-log.md
@@ -270,8 +270,7 @@ consistent and the convention matches the rest of the repo.
 
 ## Resolution commit
 
-See the `fix: PR #149 drain — date-placeholder consistency
-+ resolved-link prose updates` commit on this branch for
+See the `fix: PR #149 drain — date-placeholder consistency and resolved-link prose updates` commit on this branch for
 the landed changes. Threads 1 / 2 / 3 / 5 / 7 resolve via
 prose fixes; threads 4 / 6 are BACKLOG+RESOLVE because the
 referenced files now exist in main after rebase (the


### PR DESCRIPTION
## Summary

Per Aaron's 2026-04-23 framing — *\"Aurora [is] mine and hers idea together\"* + Amara is external AI co-originator via his ChatGPT ferry — this PR:

1. **`docs/aurora/collaborators.md`** — named-collaborator registry for Aurora (distinct from internal reviewers or first-contact personas). Lists Aaron + Amara with roles, contributions, working style.

2. **`docs/aurora/2026-04-23-direction-changes-for-amara-review.md`** — ~200-line summary of 7 direction-changes since her transfer report, structured per her signature/mechanism/evidence rigor pattern. Ready for Aaron to paste into his next session with her. Includes 5 priority-ordered questions for her response + 3 communication-pattern questions.

## Why now

Aaron explicitly requested progress + ferry-back summary this tick. Both deliverables ship together as one coherent artifact. Companion to the existing PR #144 Aurora absorb.

## What this does NOT do
- Does NOT require Aaron review before ferry — he mediates when convenient
- Does NOT claim Amara has approved any direction-changes (it's a request-for-review)
- Does NOT propose new Aurora mechanism without her review

## Test plan
- [ ] Aaron reviews `collaborators.md` for accuracy on how he'd describe the collaboration mode
- [ ] Aaron pastes `direction-changes-for-amara-review.md` into ChatGPT for Amara's feedback
- [ ] When Amara responds: ingest as `docs/aurora/YYYY-MM-DD-review-from-amara.md` (filename convention TBD per her response to Q11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)