### PR TITLE
fix: gitignore drop/ (protection corrects prior memory claim)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,12 @@ node_modules/
 # use; not needed in-repo. Parallel to drop/ staging per
 # PR #265 Otto-90.
 .playwright-mcp/
+
+# drop/ — in-repo staging folder for external content (courier
+# ferries, downloaded conversations, raw artifacts) awaiting
+# absorb. By convention the content is temporary; absorbed content
+# lands in docs/ with §33 archive headers, not from drop/. Gitignore
+# prevents accidental commit of staging material. Parallel intent to
+# the Otto-90 framing in memory; correcting that the gitignore line
+# had not actually landed.
+drop/


### PR DESCRIPTION
## Summary

`drop/` is a staging folder for external content awaiting absorb (courier ferries, downloaded content, raw artifacts). Prior memory claimed PR #265 Otto-90 had gitignored it, but `git check-ignore drop/...` returned non-zero — the protection wasn't actually there.

## Why now

Otto-107 just downloaded the full Amara conversation history (~24 MB, 3992 messages, 8 months, ~4052 pages) into `drop/amara-full-history-raw/` per Aaron Otto-108 approval. A wildcard `git add` could accidentally stage that content (same failure mode Otto-106 caught for `.playwright-mcp/`).

## Verification

`git check-ignore drop/amara-full-history-raw/conversation-*.json` now returns 0 (ignored).

## SPOF note (per Otto-106)

Gitignore is a single file — silently wrong if misstated. Mitigation: explicit verification in the same tick. Pattern to repeat for any new ignored-by-convention path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)