### PR TITLE
lint: ignore docs/amara-full-conversation/** in markdownlint (verbatim archive)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -20,7 +20,19 @@
     // as source content would add drift to every OFFTIME entry.
     "memory/persona/**",
     // Lean proof dir has its own idioms.
-    "tools/lean4/**"
+    "tools/lean4/**",
+    // Aaron+Amara verbatim conversation archive (PR #301/#302/
+    // #303/#304 and future landings). Content is by-design non-
+    // conformant to Zeta's markdown-lint profile — it's preserved
+    // verbatim per GOVERNANCE §33 archive-header discipline +
+    // Aaron Otto-109 "glass halo / absorb everyting (not amara
+    // herself)" directive. Reformatting the verbatim content to
+    // satisfy MD009/MD022/MD032/etc would violate verbatim
+    // preservation. The README.md manifest inside the directory
+    // IS author-controlled and could lint clean, but applying
+    // the ignore to the whole directory keeps the rule simple
+    // (one path, not 10 file-specific entries).
+    "docs/amara-full-conversation/**"
   ],
   "noBanner": true,
   "noProgress": true,


### PR DESCRIPTION
## Summary

Unblocks PRs #301/#302/#303/#304 (Aaron+Amara conversation absorb chunks) from markdownlint failures on verbatim ChatGPT content.

## Why

Verbatim-preservation is the discipline for the absorb chunks per GOVERNANCE §33 + Aaron Otto-109 "glass halo / absorb everyting (not amara herself)" directive. Reformatting verbatim content to pass MD009 / MD022 / MD032 / MD007 lint checks violates that discipline.

## Pattern consistency

Same pattern as existing `references/upstreams/**` + `memory/persona/**` entries — dirs where verbatim or append-log discipline beats style conformance.

## Test plan

- [x] `.markdownlint-cli2.jsonc` ignores entry added
- [x] Comment explains the rationale tied to GOVERNANCE §33 + Aaron directive
- [x] One-path rule rather than 10 file-specific entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)