### PR TITLE
core: burstAlignment — 4th Amara graduation (trivial-cartel-detect, 11th ferry)

### DIFF
--- a/src/Core/TemporalCoordinationDetection.fs
+++ b/src/Core/TemporalCoordinationDetection.fs
@@ -148,3 +148,71 @@ module TemporalCoordinationDetection =
             let meanCos = sumCos / n
             let meanSin = sumSin / n
             Some (sqrt (meanCos * meanCos + meanSin * meanSin))
+
+    /// **Significant lags from a correlation profile.** Returns the
+    /// subset of lags from a `crossCorrelationProfile` where the
+    /// absolute correlation meets or exceeds `threshold`. `None`
+    /// entries (undefined-variance lags) are never counted as
+    /// significant — a missing measurement is not a coordination
+    /// signal.
+    ///
+    /// Threshold semantics: caller-supplied. Typical values for
+    /// trivial-cartel-detect use cases: `0.7`-`0.8` for "strong
+    /// coordination", `0.9` for "unusually strong". For null-
+    /// hypothesis testing against a baseline, compute the
+    /// baseline's profile for independent streams and derive the
+    /// threshold from its percentile rather than hard-coding.
+    ///
+    /// This is the input to downstream cluster / burst detectors;
+    /// alone it answers "which lags look coordinated?" and leaves
+    /// "are they bursty / clustered / sustained?" to the next
+    /// primitive.
+    let significantLags (profile: (int * double option) array) (threshold: double) : int array =
+        profile
+        |> Array.choose (fun (lag, corrOpt) ->
+            match corrOpt with
+            | Some c when System.Double.IsFinite c && abs c >= threshold -> Some lag
+            | _ -> None)
+
+    /// **Burst alignment — contiguous significant-lag ranges.**
+    /// Groups significant lags (from `significantLags`) into
+    /// contiguous runs. Each run is reported as `(startLag,
+    /// endLag)` inclusive. Two consecutive lags count as
+    /// contiguous if they differ by exactly `1`.
+    ///
+    /// Output encodes "bursts" of coordinated timing — a run of
+    /// lags `[-2 .. 3]` suggests actors that coordinate across a
+    /// 5-step window, not a single-point coincidence. A single
+    /// isolated significant lag reports as `(n, n)`.
+    ///
+    /// Returns an empty array when the profile has no significant
+    /// lags. Non-finite correlations are filtered by the underlying
+    /// `significantLags` pass.
+    ///
+    /// The 11th-ferry signal-model definition (Amara, §1):
+    /// > *"Firefly detection = identify clusters where ∃ S ⊂ N
+    /// > such that ∀ i,j ∈ S, corr(E_i, E_j) ≫ baseline"*
+    ///
+    /// This function operationalises the pair-wise case (two
+    /// streams) — `S` is represented as the set of lags at which
+    /// two streams clear the threshold, clustered into contiguous
+    /// runs. The node-set generalisation (clustering across many
+    /// stream pairs into coordinated subsets of N) is a separate
+    /// graduation candidate that composes over this primitive.
+    let burstAlignment (profile: (int * double option) array) (threshold: double) : (int * int) array =
+        let significant = significantLags profile threshold
+        if significant.Length = 0 then [||]
+        else
+            let runs = ResizeArray<int * int>()
+            let mutable runStart = significant.[0]
+            let mutable runEnd = significant.[0]
+            for i in 1 .. significant.Length - 1 do
+                let lag = significant.[i]
+                if lag = runEnd + 1 then
+                    runEnd <- lag
+                else
+                    runs.Add(runStart, runEnd)
+                    runStart <- lag
+                    runEnd <- lag
+            runs.Add(runStart, runEnd)
+            runs.ToArray()

--- a/tests/Tests.FSharp/Algebra/TemporalCoordinationDetection.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/TemporalCoordinationDetection.Tests.fs
@@ -181,3 +181,84 @@ let ``phaseLockingValue handles single-element series`` () =
     TemporalCoordinationDetection.phaseLockingValue a b
     |> Option.map (fun v -> Math.Round(v, 9))
     |> should equal (Some 1.0)
+// ─── significantLags ─────────
+
+[<Fact>]
+let ``significantLags picks only above-threshold entries`` () =
+    let profile =
+        [| (-2, Some 0.2)
+           (-1, Some 0.5)
+           ( 0, Some 0.9)
+           ( 1, Some 0.8)
+           ( 2, Some 0.1) |]
+    TemporalCoordinationDetection.significantLags profile 0.7
+    |> should equal [| 0; 1 |]
+
+[<Fact>]
+let ``significantLags picks strong negative correlation by absolute value`` () =
+    // Perfect anti-correlation at lag 0 is coordination, just
+    // inverse. |corr| = 1 >= threshold.
+    let profile =
+        [| (-1, Some 0.1)
+           ( 0, Some -0.95)
+           ( 1, Some 0.1) |]
+    TemporalCoordinationDetection.significantLags profile 0.8
+    |> should equal [| 0 |]
+
+[<Fact>]
+let ``significantLags skips None entries`` () =
+    // None correlations are undefined; never count as significant.
+    let profile =
+        [| (-1, None)
+           ( 0, Some 0.99)
+           ( 1, None) |]
+    TemporalCoordinationDetection.significantLags profile 0.5
+    |> should equal [| 0 |]
+
+[<Fact>]
+let ``significantLags returns empty when threshold above all values`` () =
+    let profile =
+        [| (-1, Some 0.3); (0, Some 0.4); (1, Some 0.2) |]
+    TemporalCoordinationDetection.significantLags profile 0.95
+    |> should equal ([||]: int array)
+
+
+// ─── burstAlignment ─────────
+
+[<Fact>]
+let ``burstAlignment groups contiguous lags into single run`` () =
+    let profile =
+        [| (-2, Some 0.2); (-1, Some 0.9); (0, Some 0.95); (1, Some 0.85); (2, Some 0.1) |]
+    TemporalCoordinationDetection.burstAlignment profile 0.7
+    |> should equal [| (-1, 1) |]
+
+[<Fact>]
+let ``burstAlignment separates non-contiguous significant lags into distinct runs`` () =
+    let profile =
+        [| (-3, Some 0.9); (-2, Some 0.2); (-1, Some 0.1); (0, Some 0.85); (1, Some 0.9); (2, Some 0.3) |]
+    TemporalCoordinationDetection.burstAlignment profile 0.7
+    |> should equal [| (-3, -3); (0, 1) |]
+
+[<Fact>]
+let ``burstAlignment returns empty when no significant lags`` () =
+    let profile =
+        [| (-1, Some 0.2); (0, Some 0.3); (1, Some 0.2) |]
+    TemporalCoordinationDetection.burstAlignment profile 0.9
+    |> should equal ([||]: (int * int) array)
+
+[<Fact>]
+let ``burstAlignment handles a single significant lag as isolated run`` () =
+    let profile = [| (5, Some 0.99) |]
+    TemporalCoordinationDetection.burstAlignment profile 0.8
+    |> should equal [| (5, 5) |]
+
+[<Fact>]
+let ``burstAlignment ignores None entries when forming runs`` () =
+    // (-1, None) breaks contiguity between -2 and 0 even if they're
+    // both significant — significantLags discards None entries, so
+    // the run-detector sees only lags [-2; 0] which are not
+    // consecutive, producing two separate runs.
+    let profile =
+        [| (-2, Some 0.9); (-1, None); (0, Some 0.9) |]
+    TemporalCoordinationDetection.burstAlignment profile 0.7
+    |> should equal [| (-2, -2); (0, 0) |]


### PR DESCRIPTION
## Summary

Fourth Amara graduation — ships the burst-detection primitive from Aaron's differentiable firefly network design (11th ferry PR #296). This is the direct answer to Aaron Otto-111: *"Are you able to import the ideas and concepts and math from the conversation at some point?"* — yes, continuously, this is the cadence.

## What lands

- `significantLags : (int * double option) array -> double -> int array` — filters profile to lags where `|corr| >= threshold`; skips `None` and non-finite
- `burstAlignment : (int * double option) array -> double -> (int * int) array` — groups significant lags into contiguous runs

## 11th-ferry definition operationalized

Amara §1: *"Firefly detection = identify clusters where ∃ S ⊂ N such that ∀ i,j ∈ S, corr(E_i, E_j) ≫ baseline"*.

This function implements the pair-wise case. Node-set generalization (clusters across many stream pairs) is a future graduation that composes over this one.

## SPOF note (per Otto-106)

Caller-supplied threshold is a sensitivity SPOF. Mitigation: threshold should come from null-hypothesis baseline percentile, not hard-coded. Documented in XML-doc.

## Test plan

- [x] 9 new tests pass (19 total in module)
- [x] Build 0 Warning / 0 Error
- [x] Handles negative-correlation significance (anti-phase coordination)
- [x] Handles None entries without breaking (filtered, contiguity broken)
- [x] Single-lag + multi-run cases tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)