### PR TITLE
core: Graph.internalDensity + exclusivity + conductance — 15th graduation (Amara #3 correction)

### DIFF
--- a/docs/pr-preservation/329-drain-log.md
+++ b/docs/pr-preservation/329-drain-log.md
@@ -1,0 +1,352 @@
+# PR #329 drain log — Graph cohesion primitives review-thread drain
+
+PR: <https://github.com/Lucent-Financial-Group/Zeta/pull/329>
+Branch: `feat/graph-cohesion-exclusivity-conductance`
+Drain session: 2026-04-24 (loop-agent, review-drain subagent)
+Thread count at drain start: 7 unresolved (1 P0 → escalated to
+3 P0 after re-read, 4 P1, 1 P2; all from
+`copilot-pull-request-reviewer`)
+Rebase context: branch was already rebased onto `origin/main`
+in the prior recovery pass (`docs/pr-preservation/329-recovery-log.md`);
+this drain pass started clean — `git rebase origin/main` reported
+"Successfully rebased and updated" with no conflicts to resolve.
+
+Per the PR-preservation discipline (Otto-250: PR review comments
++ responses + resolutions are high-quality training signals):
+full per-thread record with verbatim reviewer text, outcome,
+verbatim reply, and resolution commit SHA.
+
+Resolution commit: `0dbaddd39b6ea3c685937ec840361780a035032c`
+("core: drain Graph cohesion-primitives review threads (#329)").
+
+---
+
+## Thread 1 — `src/Core/Graph.fs:612` — name attribution in docstring
+
+- Reviewer: `copilot-pull-request-reviewer`
+- Thread ID: `PRRT_kwDOSF9kNM59VSla`
+- Severity: P1
+
+### Original comment (verbatim)
+
+> P1: Repo convention: avoid contributor/agent name attribution
+> in code comments; prefer role references or stable doc links.
+> This new comment adds named attribution ("Amara …") inside a
+> public API docstring; please rephrase to remove names (e.g.,
+> reference the correction/doc directly without naming
+> individuals/agents).
+
+### Outcome
+
+FIX — dropped the `Provenance: Amara 17th-ferry Part 2
+correction #3 …` block from the `internalDensity` docstring
+entirely. The code-comments-explain-code-not-history discipline
+forbids in-code factory-process lineage (provenance, ferry
+names, persona names, "Nth correction" tags); rationale belongs
+in the commit message and PR description, both of which carry
+the lineage. The docstring was simultaneously rewritten to
+explain the math the function actually implements (see Threads
+4 + 5).
+
+### Reply (verbatim)
+
+> Fixed in `0dbaddd`. Dropped the in-code `Provenance: Amara
+> …` block per the code-comments-explain-code-not-history
+> discipline; the docstring now explains the math the function
+> implements. The provenance lineage lives in the commit
+> message and PR description (which both reference the
+> upstream correction).
+
+### Resolution commit
+
+`0dbaddd39b6ea3c685937ec840361780a035032c`
+
+---
+
+## Thread 2 — `tests/Tests.FSharp/Algebra/Graph.Tests.fs:527` — wrong volume in test comment
+
+- Reviewer: `copilot-pull-request-reviewer`
+- Thread ID: `PRRT_kwDOSF9kNM59VSl_`
+- Severity: P2
+
+### Original comment (verbatim)
+
+> P2: The test comment says volume is "(~60)", but
+> `Graph.conductance` as implemented counts incident weight
+> per endpoint on directed edges, so the volume for the K3
+> side is ~122 in this setup (120 internal + 2 boundary).
+> Updating the comment to match the implemented definition
+> would prevent confusion when debugging failures.
+
+### Outcome
+
+FIX — comment rewritten to cite the ~122 figure under the
+implemented directed-edge incident-weight semantics, with the
+arithmetic spelled out inline (6 directed weight-10 edges =
+120 internal contribution + 2 from the boundary edges
+`(3, 4)` and `(4, 3)` weight-1 each). A future debugger of
+this test no longer has to re-derive the correct number from
+first principles.
+
+### Reply (verbatim)
+
+> Fixed in `0dbaddd`. Comment now cites ~122 under the
+> implemented directed-edge incident-weight definition, with
+> the 120 internal + 2 boundary breakdown spelled out so the
+> next debugger doesn't re-derive it.
+
+### Resolution commit
+
+`0dbaddd39b6ea3c685937ec840361780a035032c`
+
+---
+
+## Thread 3 — `src/Core/Graph.fs:683` — conductance docstring vs implementation drift
+
+- Reviewer: `copilot-pull-request-reviewer`
+- Thread ID: `PRRT_kwDOSF9kNM59VSmQ`
+- Severity: P1
+
+### Original comment (verbatim)
+
+> P1: `conductance` docstring says the boundary cut is "summed
+> in one direction; symmetrized", but the implementation sums
+> every directed edge crossing the boundary (`sIn <> tIn`), so
+> if both directions are present the cut doubles, and there's
+> no symmetrization step. Please align the doc (and/or
+> implementation) with the intended directed vs symmetrized-
+> undirected semantics.
+
+### Outcome
+
+FIX (docstring) — chose to align the documentation with the
+existing implementation rather than change the implementation,
+because `Graph` is a directed-by-default substrate and
+introducing a symmetrization step would have broader semantic
+consequences across `internalDensity` + `exclusivity` +
+`conductance`. The docstring now explicitly says the cut sums
+every directed edge crossing the boundary, with the "if both
+directions are present each is counted once" clarifier.
+
+### Reply (verbatim)
+
+> Fixed in `0dbaddd` by aligning the docstring with the
+> implementation: `cut(S, V\\S)` now described as "sum over
+> every directed edge `(s, t)` whose endpoints lie on opposite
+> sides of the partition (no symmetrization step; if both
+> `(s, t)` and `(t, s)` cross the boundary, each is counted
+> once)". `Graph` is directed-by-default, so the directed-as-
+> stored semantics is the correct one to document; a future
+> symmetrized variant would compose by materializing
+> `(w_ij + w_ji) / 2` before the call.
+
+### Resolution commit
+
+`0dbaddd39b6ea3c685937ec840361780a035032c`
+
+---
+
+## Thread 4 — `src/Core/Graph.fs:622` — internalDensity self-loop counted in numerator only
+
+- Reviewer: `copilot-pull-request-reviewer`
+- Thread ID: `PRRT_kwDOSF9kNM59VSmk`
+- Severity: P0
+
+### Original comment (verbatim)
+
+> P0: `internalDensity` currently counts self-loops in the
+> numerator (when `s = t`) but the denominator uses
+> `|S| * (|S|-1)` which excludes `i=j` ordered pairs. Either
+> exclude self-loops from `acc` or adjust the
+> denominator/doc so the formula matches the implementation;
+> otherwise self-loop weights inflate density unexpectedly.
+
+### Outcome
+
+FIX (code) — added `s <> t` guard to the numerator
+accumulator so self-loops are excluded from `acc`, matching
+the `|S| * (|S| - 1)` denominator (which already excludes
+the `i = j` ordered pairs). Docstring updated in the same
+commit to call out the self-loop exclusion explicitly:
+`sum_{(i, j) in E, i in S, j in S, i <> j} w_ij`.
+
+### Reply (verbatim)
+
+> Fixed in `0dbaddd`. Added `s <> t` guard to the numerator
+> accumulator so self-loops are excluded — they were
+> inflating `acc` while the `|S| * (|S| - 1)` denominator
+> already excluded the diagonal. Docstring formula now
+> explicitly shows the `i <> j` constraint
+> (`sum_{(i, j) in E, i in S, j in S, i <> j} w_ij`) so the
+> next reader doesn't need to cross-check.
+
+### Resolution commit
+
+`0dbaddd39b6ea3c685937ec840361780a035032c`
+
+---
+
+## Thread 5 — `src/Core/Graph.fs:604` — internalDensity "symmetrized" claim is wrong
+
+- Reviewer: `copilot-pull-request-reviewer`
+- Thread ID: `PRRT_kwDOSF9kNM59VSm-`
+- Severity: P1
+
+### Original comment (verbatim)
+
+> P1: The `internalDensity` docstring says the internal weight
+> is "symmetrized", but the implementation sums weights
+> exactly as stored in `g.Edges` (no `(w_ij + w_ji)/2` step).
+> Please either implement the stated symmetrization or adjust
+> the wording/formula to describe the directed-as-stored
+> behavior to avoid misleading API consumers.
+
+### Outcome
+
+FIX (docstring) — same rationale as Thread 3 (align doc with
+existing impl rather than change `Graph`'s directed default).
+Removed the "(symmetrized)" claim and added an explicit
+sentence: "Edge weights are summed as stored in the directed
+edge set; no `(w_ij + w_ji) / 2` symmetrization step is
+applied — callers that want a symmetrized variant should
+materialize it before calling."
+
+### Reply (verbatim)
+
+> Fixed in `0dbaddd`. Removed the misleading "(symmetrized)"
+> claim and added an explicit sentence: edges are summed as
+> stored in the directed edge set; callers that want a
+> symmetrized variant should materialize
+> `(w_ij + w_ji) / 2` before calling. `Graph` is directed-by-
+> default; a symmetrize-on-call helper is a natural follow-up
+> if multiple primitives end up needing it.
+
+### Resolution commit
+
+`0dbaddd39b6ea3c685937ec840361780a035032c`
+
+---
+
+## Thread 6 — `src/Core/Graph.fs:659` — exclusivity bounded-ratio claim breaks under signed weights
+
+- Reviewer: `copilot-pull-request-reviewer`
+- Thread ID: `PRRT_kwDOSF9kNM59VSnY`
+- Severity: P0
+
+### Original comment (verbatim)
+
+> P0: `exclusivity` assumes a non-negative "outgoing weight"
+> denominator and claims the result is in `[0,1]`, but `Graph`
+> edge weights are signed (retractions/anti-edges). With
+> negative weights this can return values outside `[0,1]` or
+> flip sign. Consider clamping negative weights to 0 (similar
+> to `labelPropagation`), using absolute weights, or
+> documenting/enforcing that inputs must be materialized to
+> non-negative weights before calling.
+
+### Outcome
+
+FIX (docstring) — chose the documentation route rather than
+clamping or absolute-value wrapping in code, because
+`exclusivity` is a community-detection primitive and the
+"correct" handling of signed weights is application-specific
+(retractions might mean "this edge was undone" → drop;
+anti-edges might mean "negative association" → use absolute
+value; an analyst doing cartel detection might want
+`max 0L` per-edge). Forcing one of these in the primitive
+would surprise the others. The docstring now explicitly
+states the input contract: result is in `[0, 1]` only when
+outgoing weights are non-negative; callers materialize a
+non-negative view before calling. Behaviour on signed
+weights is documented (ratio can fall outside `[0, 1]` or
+flip sign), not silently corrupted.
+
+### Reply (verbatim)
+
+> Fixed in `0dbaddd` by tightening the input contract in the
+> docstring rather than clamping in code. The
+> `[0, 1]`-bounded guarantee now explicitly requires
+> non-negative outgoing weights; callers that hold signed
+> weights (retractions / anti-edges) materialize a
+> non-negative view (`max 0L` per-edge, `abs`, or filter)
+> before calling. The reason this is a doc fix not a code
+> fix: the right handling of signed weights is application-
+> specific (drop retractions vs use absolute value vs clamp),
+> so building one of those into the primitive would surprise
+> the other use sites. If a consistent project-wide policy
+> emerges (e.g. "all community-detection primitives clamp at
+> the boundary"), that becomes a follow-up that touches
+> `internalDensity` + `conductance` + `exclusivity` together.
+
+### Resolution commit
+
+`0dbaddd39b6ea3c685937ec840361780a035032c`
+
+---
+
+## Thread 7 — `src/Core/Graph.fs:688` — conductance full-set check uses Count not equality
+
+- Reviewer: `copilot-pull-request-reviewer`
+- Thread ID: `PRRT_kwDOSF9kNM59VSnu`
+- Severity: P0
+
+### Original comment (verbatim)
+
+> P0: `conductance` treats "S is the full node set" as
+> `subset.Count = allNodes.Count`. This is incorrect when
+> `subset` includes nodes not present in the graph (or misses
+> some but matches the count), causing a false `None`. Use
+> set equality (`subset = allNodes`) or explicitly check
+> `subset.IsSupersetOf allNodes && subset.IsSubsetOf
+> allNodes`.
+
+### Outcome
+
+FIX (code) — replaced `subset.Count = allNodes.Count` with
+`subset = allNodes`. F#'s structural equality on `Set<'N>`
+gives full-set equality (membership-based, not just
+cardinality-based) at the same `O(|S|)` cost, so the fix is
+strictly tighter without a complexity penalty. Now
+`subset = {1, 2, 3}` against a graph whose `nodes` is
+`{1, 2, 4}` correctly returns a real conductance value
+(rather than a misleading `None` when the cardinalities
+happened to match).
+
+### Reply (verbatim)
+
+> Fixed in `0dbaddd`. Replaced `subset.Count =
+> allNodes.Count` with `subset = allNodes`. F#'s structural
+> equality on `Set<'N>` is membership-based (not just
+> cardinality-based) and runs at the same complexity, so the
+> guard is strictly tighter — a subset that matches the
+> graph's node count without matching its membership now
+> returns a real conductance value rather than a false
+> `None`.
+
+### Resolution commit
+
+`0dbaddd39b6ea3c685937ec840361780a035032c`
+
+---
+
+## Build verification
+
+`dotnet build src/Core/Core.fsproj -c Release` — `0 Warning(s),
+0 Error(s)` on the fixed Core project. Full-solution test run
+deferred to CI (the local `dotnet test` invocation hits the
+.NET 10 Server-GC SIGSEGV on Apple Silicon known-issue tracked
+as Otto-248; CI runs on Ubuntu and is the authoritative
+all-tests-pass gate).
+
+## Discipline check
+
+- Append-only audit trail: this drain log is a NEW file under
+  `docs/pr-preservation/`; the existing
+  `329-recovery-log.md` was not edited.
+- Three-outcome model: every thread closed FIX (no
+  NARROW+BACKLOG, no BACKLOG+RESOLVE; every reply
+  paired with `resolveReviewThread`).
+- Code-comments-explain-code: in-code provenance / ferry /
+  persona attribution removed from `internalDensity`
+  docstring (Thread 1 fix); rationale moved to commit message.
+- F# / C# preservation: no `#`-suffix renames touched.

--- a/docs/pr-preservation/329-drain-log.md
+++ b/docs/pr-preservation/329-drain-log.md
@@ -11,10 +11,10 @@ in the prior recovery pass (`docs/pr-preservation/329-recovery-log.md`);
 this drain pass started clean — `git rebase origin/main` reported
 "Successfully rebased and updated" with no conflicts to resolve.
 
-Per the PR-preservation discipline (Otto-250: PR review comments
-+ responses + resolutions are high-quality training signals):
-full per-thread record with verbatim reviewer text, outcome,
-verbatim reply, and resolution commit SHA.
+Per the PR-preservation discipline (Otto-250: PR review
+comments, responses, and resolutions are high-quality training
+signals): full per-thread record with verbatim reviewer text,
+outcome, verbatim reply, and resolution commit SHA.
 
 Resolution commit: `0dbaddd39b6ea3c685937ec840361780a035032c`
 ("core: drain Graph cohesion-primitives review threads (#329)").

--- a/docs/pr-preservation/329-recovery-log.md
+++ b/docs/pr-preservation/329-recovery-log.md
@@ -1,0 +1,54 @@
+# PR #329 — Rebase Recovery Log
+
+**PR:** https://github.com/Lucent-Financial-Group/Zeta/pull/329
+**Title:** core: Graph.internalDensity + exclusivity + conductance — 15th graduation (Amara #3 correction)
+**Branch:** `feat/graph-cohesion-exclusivity-conductance`
+**Context:** PR was closed-as-superseded, then reopened. Main had advanced with new Graph
+primitives (`coordinationRiskScore`, `coordinationRiskScoreRobust`) that landed in the
+interim. Rebased `feat/graph-cohesion-exclusivity-conductance` onto `origin/main` at
+`a54bdf114c70b9a3bbb02acaa5fb388d3a22837b`.
+
+## Conflicts resolved
+
+### 1. `src/Core/Graph.fs` (lines 452 – 709 in the conflicting state)
+
+- **Shape:** both sides added new `let` bindings at the same insertion point in the
+  `Graph` module (directly after `labelPropagation`). HEAD added two composite-risk
+  functions (`coordinationRiskScore`, `coordinationRiskScoreRobust`). The PR branch
+  added three cohesion primitives (`internalDensity`, `exclusivity`, `conductance`).
+- **Classification:** substantive code. **NOT** an append-only / audit-trail surface —
+  `-X ours` would have discarded one entire side's primitives. Resolved by careful
+  union: keep both sides, one after the other, with a blank line between blocks.
+- **Resolution choice:** union-keep-both, HEAD first, then PR-branch additions.
+- **Rationale:** the two sets of functions are disjoint — no shared identifiers, no
+  shared signatures, no shared data dependencies. Each side cites distinct Amara
+  ferries (17th Part 2 correction #4 for risk scores; 17th Part 2 correction #3 for
+  cohesion primitives). Landing both is the correct semantic outcome; the conflict
+  was purely positional (same line range in the source file), not semantic.
+- **Verification:** confirmed `largestEigenvalue`, `labelPropagation`, `modularityScore`
+  (lines 290 – 309, 322 in pre-rebase) and `RobustStats.robustZScore` all remain
+  reachable from their callers. No symbol renames needed.
+
+### 2. `tests/Tests.FSharp/Algebra/Graph.Tests.fs` (lines 340 – 535 in the conflicting state)
+
+- **Shape:** identical structural pattern — HEAD added test fixtures for
+  `coordinationRiskScore` + `coordinationRiskScoreRobust` + `robustZScore` (7 tests).
+  The PR branch added test fixtures for `internalDensity` + `exclusivity` +
+  `conductance` (6 tests).
+- **Classification:** substantive test code (not append-only).
+- **Resolution choice:** union-keep-both, HEAD first, then PR-branch additions, with
+  blank-line separator between the two `// ───` section banners.
+- **Rationale:** same reasoning as Graph.fs — disjoint fixtures exercising disjoint
+  primitives. Each test block is self-contained; no shared test helpers introduced
+  by one side get clobbered by the other.
+
+## Build & test
+
+- `dotnet build -c Release` — result recorded in the commit trailer.
+- `dotnet test Zeta.sln -c Release` — result recorded in the commit trailer.
+
+## Unresolved threads
+
+7 unresolved review threads from the previous open period remain on the PR. These
+were **intentionally** not drained in this pass — the scope of the recovery was
+rebase-only. They are deferred to a later re-drain pass.

--- a/src/Core/Graph.fs
+++ b/src/Core/Graph.fs
@@ -590,26 +590,29 @@ module Graph =
 
     /// **Internal density of a node subset S.**
     ///
-    /// Ratio of total internal edge weight (symmetrized) to the
-    /// maximum possible number of ordered pairs within S. High
-    /// internal-density indicates a tight sub-cluster.
+    /// Ratio of total internal edge weight, summed exactly as
+    /// stored in the directed edge set, to the maximum possible
+    /// number of ordered pairs within S. High internal-density
+    /// indicates a tight sub-cluster.
     ///
     /// Formula:
     /// ```
-    ///   InternalDensity(S) = sum_{i,j in S} w_ij / (|S| * (|S| - 1))
+    ///   InternalDensity(S) = sum_{(i,j) in E, i in S, j in S, i <> j} w_ij
+    ///                        / (|S| * (|S| - 1))
     /// ```
-    /// with `|S| * (|S| - 1)` ordered-pair count (directed graph
-    /// convention; includes both (i, j) and (j, i)). For an
-    /// undirected graph where each edge appears in both
-    /// directions, this matches the mean per-pair edge weight.
+    /// where `|S| * (|S| - 1)` is the count of ordered pairs
+    /// `(i, j)` with `i in S`, `j in S`, `i <> j` (directed graph
+    /// convention; self-loops `i = i` are excluded from both the
+    /// numerator and the denominator so the formula matches the
+    /// implementation). For an undirected graph where each edge
+    /// appears in both directions, this matches the mean per-pair
+    /// edge weight. Edge weights are summed as stored in the
+    /// directed edge set; no `(w_ij + w_ji) / 2` symmetrization
+    /// step is applied — callers that want a symmetrized variant
+    /// should materialize it before calling.
     ///
     /// Returns `None` when `|S| < 2` (density undefined on a
     /// singleton or empty set).
-    ///
-    /// Provenance: Amara 17th-ferry Part 2 correction #3 —
-    /// replaces muddy "subgraph entropy collapse" with
-    /// explicit cohesion measures used in the cartel-detection
-    /// literature (Wachs & Kertész 2019).
     let internalDensity (subset: Set<'N>) (g: Graph<'N>) : double option =
         let size = subset.Count
         if size < 2 then None
@@ -619,7 +622,7 @@ module Graph =
             for k in 0 .. span.Length - 1 do
                 let entry = span.[k]
                 let (s, t) = entry.Key
-                if subset.Contains s && subset.Contains t then
+                if s <> t && subset.Contains s && subset.Contains t then
                     acc <- acc + double entry.Weight
             let pairs = double size * double (size - 1)
             Some (acc / pairs)
@@ -638,9 +641,17 @@ module Graph =
     ///                   sum_{i in S, j in V} w_ij
     /// ```
     ///
-    /// Returns `Some x` in `[0.0, 1.0]` when defined; `None`
-    /// when S is empty or S has no outgoing edges (denominator
-    /// would be zero).
+    /// **Input contract.** The result is in `[0.0, 1.0]` only
+    /// when all outgoing edge weights from S are non-negative.
+    /// `Graph` weights are signed (retractions / anti-edges are
+    /// legal), so callers that need the bounded-ratio guarantee
+    /// must materialize a non-negative-weight view first
+    /// (filter or `max 0L` per-edge); on signed weights the
+    /// ratio can fall outside `[0, 1]` or change sign as the
+    /// signs of numerator and denominator diverge.
+    ///
+    /// Returns `Some x` when defined; `None` when S is empty or
+    /// the outgoing-weight denominator is zero.
     let exclusivity (subset: Set<'N>) (g: Graph<'N>) : double option =
         if subset.Count = 0 then None
         else
@@ -671,21 +682,25 @@ module Graph =
     ///   Conductance(S) = cut(S, V \ S) / min(vol(S), vol(V \ S))
     /// ```
     /// where:
-    /// * `cut(S, V\S)` = sum of edge weights crossing the
-    ///   boundary (summed in one direction; symmetrized)
-    /// * `vol(S)` = sum of edge weights incident on S (internal
-    ///   counted twice — once per endpoint — per standard
-    ///   conductance definition)
+    /// * `cut(S, V\S)` = sum over every directed edge `(s, t)`
+    ///   in `g.Edges` whose endpoints lie on opposite sides of
+    ///   the partition (no symmetrization step; if both
+    ///   `(s, t)` and `(t, s)` cross the boundary, each is
+    ///   counted once)
+    /// * `vol(S)` = sum of directed edge weights incident on
+    ///   nodes in S; an internal edge `(s, t)` with both
+    ///   `s, t in S` is counted twice — once per endpoint —
+    ///   per the standard conductance definition
     ///
     /// Returns `Some c` in `[0.0, 1.0]` (approximately) when
     /// both sides of the bisection have non-zero volume;
-    /// `None` for degenerate cases (S is empty, S is the full
-    /// node set, or both volumes are zero).
+    /// `None` for degenerate cases (S is empty, S equals the
+    /// full node set, or both volumes are zero).
     let conductance (subset: Set<'N>) (g: Graph<'N>) : double option =
         if subset.Count = 0 then None
         else
             let allNodes = nodes g
-            if subset.Count = allNodes.Count then None
+            if subset = allNodes then None
             else
                 let mutable cut = 0.0
                 let mutable volS = 0.0

--- a/src/Core/Graph.fs
+++ b/src/Core/Graph.fs
@@ -587,3 +587,121 @@ module Graph =
                 | Some zLambda, Some zQ ->
                     Some (alpha * zLambda + beta * zQ)
                 | _ -> None
+
+    /// **Internal density of a node subset S.**
+    ///
+    /// Ratio of total internal edge weight (symmetrized) to the
+    /// maximum possible number of ordered pairs within S. High
+    /// internal-density indicates a tight sub-cluster.
+    ///
+    /// Formula:
+    /// ```
+    ///   InternalDensity(S) = sum_{i,j in S} w_ij / (|S| * (|S| - 1))
+    /// ```
+    /// with `|S| * (|S| - 1)` ordered-pair count (directed graph
+    /// convention; includes both (i, j) and (j, i)). For an
+    /// undirected graph where each edge appears in both
+    /// directions, this matches the mean per-pair edge weight.
+    ///
+    /// Returns `None` when `|S| < 2` (density undefined on a
+    /// singleton or empty set).
+    ///
+    /// Provenance: Amara 17th-ferry Part 2 correction #3 —
+    /// replaces muddy "subgraph entropy collapse" with
+    /// explicit cohesion measures used in the cartel-detection
+    /// literature (Wachs & Kertész 2019).
+    let internalDensity (subset: Set<'N>) (g: Graph<'N>) : double option =
+        let size = subset.Count
+        if size < 2 then None
+        else
+            let mutable acc = 0.0
+            let span = g.Edges.AsSpan()
+            for k in 0 .. span.Length - 1 do
+                let entry = span.[k]
+                let (s, t) = entry.Key
+                if subset.Contains s && subset.Contains t then
+                    acc <- acc + double entry.Weight
+            let pairs = double size * double (size - 1)
+            Some (acc / pairs)
+
+    /// **Exclusivity of a node subset S.**
+    ///
+    /// Ratio of internal edge weight (within S) to the total
+    /// outgoing weight from S (internal + boundary). A cartel
+    /// that interacts heavily within itself and avoids outsiders
+    /// has exclusivity near 1; a well-integrated community has
+    /// exclusivity near its relative weight share.
+    ///
+    /// Formula:
+    /// ```
+    ///   Exclusivity(S) = sum_{i, j in S} w_ij /
+    ///                   sum_{i in S, j in V} w_ij
+    /// ```
+    ///
+    /// Returns `Some x` in `[0.0, 1.0]` when defined; `None`
+    /// when S is empty or S has no outgoing edges (denominator
+    /// would be zero).
+    let exclusivity (subset: Set<'N>) (g: Graph<'N>) : double option =
+        if subset.Count = 0 then None
+        else
+            let mutable internalWeight = 0.0
+            let mutable totalWeight = 0.0
+            let span = g.Edges.AsSpan()
+            for k in 0 .. span.Length - 1 do
+                let entry = span.[k]
+                let (s, t) = entry.Key
+                let w = double entry.Weight
+                if subset.Contains s then
+                    totalWeight <- totalWeight + w
+                    if subset.Contains t then
+                        internalWeight <- internalWeight + w
+            if totalWeight = 0.0 then None
+            else Some (internalWeight / totalWeight)
+
+    /// **Conductance of a node subset S.**
+    ///
+    /// Classical cut-to-volume ratio measuring how well S
+    /// isolates from the rest of the graph. Low conductance
+    /// means tight isolation (cartel-like); high conductance
+    /// means the cut is large relative to the smaller side's
+    /// volume.
+    ///
+    /// Formula:
+    /// ```
+    ///   Conductance(S) = cut(S, V \ S) / min(vol(S), vol(V \ S))
+    /// ```
+    /// where:
+    /// * `cut(S, V\S)` = sum of edge weights crossing the
+    ///   boundary (summed in one direction; symmetrized)
+    /// * `vol(S)` = sum of edge weights incident on S (internal
+    ///   counted twice — once per endpoint — per standard
+    ///   conductance definition)
+    ///
+    /// Returns `Some c` in `[0.0, 1.0]` (approximately) when
+    /// both sides of the bisection have non-zero volume;
+    /// `None` for degenerate cases (S is empty, S is the full
+    /// node set, or both volumes are zero).
+    let conductance (subset: Set<'N>) (g: Graph<'N>) : double option =
+        if subset.Count = 0 then None
+        else
+            let allNodes = nodes g
+            if subset.Count = allNodes.Count then None
+            else
+                let mutable cut = 0.0
+                let mutable volS = 0.0
+                let mutable volRest = 0.0
+                let span = g.Edges.AsSpan()
+                for k in 0 .. span.Length - 1 do
+                    let entry = span.[k]
+                    let (s, t) = entry.Key
+                    let w = double entry.Weight
+                    let sIn = subset.Contains s
+                    let tIn = subset.Contains t
+                    if sIn then volS <- volS + w
+                    if tIn then volS <- volS + w
+                    if not sIn then volRest <- volRest + w
+                    if not tIn then volRest <- volRest + w
+                    if sIn <> tIn then cut <- cut + w
+                let denom = min volS volRest
+                if denom <= 0.0 then None
+                else Some (cut / denom)

--- a/tests/Tests.FSharp/Algebra/Graph.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/Graph.Tests.fs
@@ -523,8 +523,12 @@ let ``conductance is low for well-isolated subset`` () =
     let c =
         Graph.conductance (Set.ofList [1; 2; 3]) g
         |> Option.defaultValue nan
-    // Small cut (2 units) relative to volume (~60); conductance
-    // should be well below 0.1.
+    // Small cut (2 units) relative to subset volume (~122)
+    // under the implemented directed-edge incident-weight
+    // definition (each internal directed edge contributes to
+    // volS twice — once per endpoint — so K3 with 6 directed
+    // weight-10 edges = 120 internal + 2 boundary = 122);
+    // conductance should be well below 0.1.
     c |> should (be lessThan) 0.1
 
 [<Fact>]

--- a/tests/Tests.FSharp/Algebra/Graph.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/Graph.Tests.fs
@@ -449,3 +449,86 @@ let ``coordinationRiskScoreRobust returns None when baselines empty`` () =
     let g = Graph.fromEdgeSeq [ (1, 2, 1L); (2, 1, 1L) ]
     Graph.coordinationRiskScoreRobust 0.5 0.5 1e-9 200 30 [||] [||] g
     |> should equal (None: double option)
+
+
+// ─── internalDensity / exclusivity / conductance ─────────
+
+[<Fact>]
+let ``internalDensity returns None for subset of size < 2`` () =
+    let g = Graph.fromEdgeSeq [ (1, 2, 1L); (2, 1, 1L) ]
+    Graph.internalDensity (Set.singleton 1) g |> should equal (None: double option)
+    Graph.internalDensity Set.empty g |> should equal (None: double option)
+
+[<Fact>]
+let ``internalDensity of K3 clique is high`` () =
+    // K3 with weight 10: three pairs, each appearing both
+    // directions, so 6 ZSet entries of weight 10. Sum = 60.
+    // |S|*(|S|-1) = 6. Density = 10.0.
+    let edges = [
+        (1, 2, 10L); (2, 1, 10L)
+        (2, 3, 10L); (3, 2, 10L)
+        (3, 1, 10L); (1, 3, 10L)
+    ]
+    let g = Graph.fromEdgeSeq edges
+    let density =
+        Graph.internalDensity (Set.ofList [1; 2; 3]) g
+        |> Option.defaultValue 0.0
+    abs (density - 10.0) |> should (be lessThan) 1e-9
+
+[<Fact>]
+let ``exclusivity is 1 for an isolated subset`` () =
+    // A K3 clique with no external edges: all weight is
+    // internal. Exclusivity = 1.
+    let edges = [
+        (1, 2, 5L); (2, 1, 5L)
+        (2, 3, 5L); (3, 2, 5L)
+        (3, 1, 5L); (1, 3, 5L)
+    ]
+    let g = Graph.fromEdgeSeq edges
+    let e =
+        Graph.exclusivity (Set.ofList [1; 2; 3]) g
+        |> Option.defaultValue 0.0
+    abs (e - 1.0) |> should (be lessThan) 1e-9
+
+[<Fact>]
+let ``exclusivity is lower when subset has external edges`` () =
+    // K3 clique on {1,2,3} + one external edge (3, 4). Total
+    // outgoing from S = 6 internal edges (weight 5 each = 30)
+    // + 1 external (weight 1) = 31. Internal = 30. Exclusivity
+    // = 30/31 ≈ 0.968.
+    let edges = [
+        (1, 2, 5L); (2, 1, 5L)
+        (2, 3, 5L); (3, 2, 5L)
+        (3, 1, 5L); (1, 3, 5L)
+        (3, 4, 1L)
+    ]
+    let g = Graph.fromEdgeSeq edges
+    let e =
+        Graph.exclusivity (Set.ofList [1; 2; 3]) g
+        |> Option.defaultValue 0.0
+    e |> should (be lessThan) 1.0
+    e |> should (be greaterThan) 0.9
+
+[<Fact>]
+let ``conductance is low for well-isolated subset`` () =
+    // Two K3 cliques connected by one thin edge. Each K3 has
+    // tight internal volume; the cut is small. Conductance
+    // should be low.
+    let edges = [
+        (1, 2, 10L); (2, 1, 10L); (2, 3, 10L); (3, 2, 10L); (3, 1, 10L); (1, 3, 10L)
+        (4, 5, 10L); (5, 4, 10L); (5, 6, 10L); (6, 5, 10L); (6, 4, 10L); (4, 6, 10L)
+        (3, 4, 1L); (4, 3, 1L)
+    ]
+    let g = Graph.fromEdgeSeq edges
+    let c =
+        Graph.conductance (Set.ofList [1; 2; 3]) g
+        |> Option.defaultValue nan
+    // Small cut (2 units) relative to volume (~60); conductance
+    // should be well below 0.1.
+    c |> should (be lessThan) 0.1
+
+[<Fact>]
+let ``conductance is None for empty or full-graph subset`` () =
+    let g = Graph.fromEdgeSeq [ (1, 2, 1L); (2, 1, 1L) ]
+    Graph.conductance Set.empty g |> should equal (None: double option)
+    Graph.conductance (Set.ofList [1; 2]) g |> should equal (None: double option)


### PR DESCRIPTION
Applies Amara 17th-ferry Part 2 correction #3: replace muddy 'subgraph entropy collapse' with explicit cohesion/exclusivity/conductance metrics (Wachs & Kertész 2019 cartel-detection literature).

Three new primitives + 6 new tests (37 total in GraphTests passing).