### PR TITLE
backlog: elevate git-native PR-preservation P2→P1 + phased plan (Otto-150..154)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5646,159 +5646,6 @@ systems. This track claims the space.
 
 - [ ] **Schema-as-Graph — entire database schema as first-class typed graph.** Aaron 2026-04-24 Otto-127: *"would it be possible to have a graph view of the entire table and relations so the whole schema is first class i the graph plus we could have special edge node whatever else we need entities if needed for more fidelity than reguarl sql table structrue and relationships allow. backlog"*. Natural extension of Graph substrate (PR #317 + #324). Scope: (1) schema-node types — Table/Column/Index/Constraint/View/StoredProcedure/Trigger; (2) schema-edge types — ForeignKey/Contains/References/DependsOn/InheritsFrom; (3) custom entity types beyond SQL — Domain/Aggregate/EventStream/Retraction (first-class "removed" with timestamp)/Provenance; (4) round-trip SQL↔Graph invariants; (5) bidirectional — Graph mutations emit DDL; DDL mutates Graph. Schema-change-over-time = Graph event stream w/ retraction-native. Aminata BP-11 threat-pass. Priority P2; effort M+M+L.
 
-- [ ] **Git-native PR-conversation preservation — extract PR review threads + comments to git-tracked files on merge, PLUS backfill of all historical PRs.** **Priority: P1 (elevated from P2 per Aaron Otto-151..153).** Aaron Otto-113 originating directive: *"you probably need to resolve and save the conversations on the PRs to git for gitnative presevration"*. Aaron Otto-150..153 follow-up burst ratifying priority + scope: *"you are still capturing all the PR reviews from copilot and your responses to gitnative right? / that's high signaldata we should get on that pretty quickly i think / can you post fill by going through all the old PRs and all the threads/conversations? / back fill i mean"* — then course-correction *"no not that quick / do it the right way / i just mean pritorize the right way"* confirming the ask is **appropriate prioritization, not rushed shipping**. Current status: NOT running; no workflow archives review threads; no `docs/pr-discussions/` directory exists. Currently PR review threads (Copilot / Codex connector / human reviewer comments) live GitHub-side only; if repo is mirrored / forked / GitHub has an outage / repo is migrated, the conversation substrate is lost. For glass-halo transparency + retractability, PR discussions belong in-repo. This is high-signal data (Copilot's actual critiques of the factory's code; Otto's replies showing reasoning patterns; human-contributor thought process). Proposed phased landing:
-
-  **Phase 1 — design (this tick or next, S effort).** Decide:
-  (a) file-per-PR vs index-plus-per-thread; (b) markdown
-  schema (YAML frontmatter fields: `pr_number`, `pr_title`,
-  `pr_author`, `merged_at`, `scope`, `privacy_pass`); (c) slug
-  collision rules; (d) idempotent-update semantics when a
-  resolved thread is reopened or a comment is edited
-  post-merge; (e) who authors the archive commits (GHA bot vs
-  human-contributor-attributed).
-
-  **Phase 2 — privacy review (Aminata threat-model pass,
-  blocking).** Questions: what classes of content in a
-  reviewer comment could be sensitive (credentials
-  accidentally pasted, customer data, internal-only URLs,
-  names of external organizations)? Is the privacy pass a
-  manual-review-then-merge step or an automated
-  redaction-on-ingest step? What does a review-comment
-  redaction look like (strike-through with reason, or hash
-  +reference)? Does Aminata recommend a different trust
-  posture for agents (Copilot / Codex-connector / github-
-  actions / Claude Code personas) vs humans (contributors
-  with arbitrary comment content)?
-
-  **Phase 3 — ongoing-capture mechanism (S-M effort after
-  Phase 2 signs off).** GHA workflow with:
-
-  ```yaml
-  on:
-    pull_request_target:
-      types: [closed]
-  ```
-
-  Job gates on `if: github.event.pull_request.merged == true`.
-  Fetches threads via `gh api graphql`, writes to
-  `docs/pr-discussions/PR-<N>-<slug>.md` on a dedicated
-  branch, opens an auto-archive PR.
-
-  **Security constraints for `pull_request_target`**
-  (known GitHub Actions footgun — elevated permissions +
-  access to secrets on base-branch code, but the trigger
-  FIRES for PRs from forks; the well-known exploit is
-  checking out PR-head and executing its code with the
-  elevated permissions):
-
-  - MUST NOT `actions/checkout` the PR head (`refs/pull/<N>/
-    merge` or `head.ref`). Check out the base ref only;
-    the archive content is fetched via `gh api graphql`
-    against the already-merged PR state, not by running
-    PR code.
-  - MUST NOT use `${{ github.event.pull_request.title }}` /
-    `.body` / `.head.ref` / `.head.label` / etc. in any
-    `run:` step. Fetch title via `gh api /repos/.../pulls/
-    <N>` INSIDE the workflow (Otto-154 learned this via
-    injection-hook false-positive). Or write the archive
-    with only `number`-keyed fields and derive the slug
-    from the fetched JSON, not from event payload.
-  - MUST declare minimal `permissions:` (just `contents:
-    write` for the archive branch + `pull-requests: write`
-    to open the auto-archive PR). No `actions:`, no
-    `id-token:`, no `deployments:`.
-  - SHOULD pin all `actions/*` to commit SHA per FACTORY-
-    HYGIENE row #43.
-
-  **Docs/memory lint policy reference** (cited in the
-  Non-goals section below): the "docs-lint / memory-
-  no-lint" split is the convention documented in
-  `memory/feedback_docs_linted_memory_not_otto_decides_
-  where_external_content_lives_2026_04_24.md` + enforced
-  by `.markdownlint-cli2.jsonc` (which excludes
-  `memory/**` via ignore patterns). This PR's discussion-
-  archive output lives in `docs/pr-discussions/` which
-  IS subject to markdownlint; memory/ continues to be
-  ignored.
-
-  **Phase 4 — backfill (M effort after Phase 3 is proven on
-  live PRs).** Per-PR script that walks all merged PRs in
-  priority order (richest-review-content first — PRs with
-  Copilot comments, PRs with Codex-connector comments,
-  bulk-change PRs, then routine PRs), applies the Phase-2
-  privacy pass, commits archives in batches (e.g. 20 PRs
-  per commit) to keep diffs reviewable. Budget: expect
-  ~300+ merged PRs historically.
-
-  **Phase 5 — ongoing-reconciliation hygiene (S effort, after
-  Phase 4).** Periodic audit (weekly GHA cron) that checks
-  all merged PRs have an archive file; flags divergences;
-  surfaces edit-after-merge comment updates. Captures the
-  drift that would otherwise silently accrue.
-
-  **Scope addendum (Aaron Otto-155..156).** Otto-155: *"we
-  can capture the comments from both acehack and lfg the bots,
-  forks should be expected to ship bot comments too like
-  acehack back to the main repo, that's high value signals."*
-  Otto-156 self-correction: *"sorry i said bot comments i
-  should have said agent comments"* — per GOVERNANCE §3 and
-  CLAUDE.md "Agents, not bots." Terminology correction:
-  Copilot, Codex connector, Claude Code personas, and
-  github-actions all count as **agents** with agency,
-  judgement, and accountability — not bots. Two binding
-  scope decisions follow:
-
-  (i) **Dual-agent-surface capture.** Agent comments across
-  both account contexts get archived — those posted under
-  the personal account (`AceHack/...` forks) AND under the
-  org account (`Lucent-Financial-Group/Zeta` main). Same
-  schema, same workflow, different event sources.
-
-  (ii) **Fork-upstream-sync obligation.** When a fork of the
-  repo runs its own Copilot / Codex / agent reviews on its
-  own PRs (e.g. `AceHack/Zeta#42` with a personal-account
-  Copilot review), those agent-comment archives ride back
-  to the main repo when the branch lands upstream — via a
-  sync job that copies fork-side `docs/pr-discussions/`
-  entries into the main repo at merge time. Human comments
-  on fork-side PRs stay under the human-privacy-pass
-  discipline; agent comments get sync-with-scope. Treat
-  fork-originated agent signals as high-value upstream
-  input.
-
-  Non-goals for this row:
-
-  - Replacing GitHub as the live review venue (it's the
-    source-of-truth; archive is the durable mirror).
-  - Attempting historical backfill in a single CI run
-    (300+ PRs × GraphQL rate limits would likely fail —
-    batch it; see Phase 4 for batch strategy).
-  - Assuming agent-authored content is privacy-trivial.
-    Earlier phrasing said agent reviews had "no privacy
-    concern"; that was wrong and contradicted Phase 2's
-    explicit privacy-review scope. Copilot / Codex /
-    Claude Code personas can echo secrets (pasted by
-    humans into a PR description or reviewer reply),
-    internal-only URLs, customer identifiers, or other
-    sensitive substrate the human reviewer dropped into
-    the conversation unaware. Phase 2's privacy pass
-    evaluates ALL archived content — agent-authored
-    included — for redaction need. The trust-posture
-    default for agent content IS higher (no hand-typed
-    free-form prose = lower leak rate) but not
-    zero-risk. Aminata threat-review sets the posture
-    per content source; this row does not pre-commit to
-    "agent content archives verbatim without review."
-
-  Effort: S (Phase 1 design) + M (Phase 2 threat-review +
-  Phase 3 workflow) + M (Phase 4 backfill) + S (Phase 5
-  hygiene). Cumulative: L. Lands across multiple ticks;
-  Phase 1 can go this tick or next; later phases land when
-  ready. Composes with Otto-113 bootstrap-attempt-1 memory +
-  Otto-150..154 burst + docs-lint/memory-no-lint policy
-  (discussions go in docs/) + ChatGPT-download-skill
-  (PR #300) pattern + Aminata threat-model authority.
-
 - [ ] **Ongoing memory-sync mechanism — keep in-repo `memory/` mirrored with auto-memory writes during each Otto tick.** Aaron 2026-04-24 Otto-113 directive *"our memories should all be checked in now"* + Otto-114 confirmation that in-repo memory/ is the natural home for ALL memory types. Otto-113 one-shot sync (PR #307) mirrored 439 files. Going forward, every Otto tick that writes to `~/.claude/projects/.../memory/` should also land new/updated files in-repo `memory/` with matching MEMORY.md pointer update (per memory-index-integrity + memory-reference-existence-lint workflows). Proposed mechanisms: (a) end-of-tick skill that rsyncs new memories to a branch + PRs them; (b) direct-to-repo writes with auto-memory as read-cache; (c) GHA cron periodic sync. Initial preference: (a) for CLI-tool compatibility today, (b) long-term. Also includes path-unification design (decide whether to deprecate the `~/.claude/projects/...` path for this project entirely or keep as staging). Priority P2 research-grade; effort S (rsync skill) + M (direct-write tooling). Composes with `memory/feedback_natural_home_of_memories_is_in_repo_now_all_types_*.md` (Otto-114 policy) + PR #307 one-shot sync + memory-index-integrity workflow.
 
 - [ ] **"Frontier" naming conflict with OpenAI Frontier
@@ -9730,6 +9577,165 @@ Keeping them adjacent preserves the directive cluster.
   archive tool; Mateo (security-researcher) reviews the
   schema for adversarial-training-corpus risks; Kenji
   synthesizes the dual-use deliverable.
+
+- [ ] **Git-native PR-conversation preservation — extract PR review threads + comments to git-tracked files on merge, PLUS backfill of all historical PRs.** **Priority: P1 (elevated from P2 per Aaron Otto-151..153; relocated from `## P2 — research-grade` to this `## P1 — Git-native hygiene cadences` section per #335 review thread on internal-priority-vs-section consistency).** Aaron Otto-113 originating directive: *"you probably need to resolve and save the conversations on the PRs to git for gitnative presevration"*. Aaron Otto-150..153 follow-up burst ratifying priority + scope: *"you are still capturing all the PR reviews from copilot and your responses to gitnative right? / that's high signaldata we should get on that pretty quickly i think / can you post fill by going through all the old PRs and all the threads/conversations? / back fill i mean"* — then course-correction *"no not that quick / do it the right way / i just mean pritorize the right way"* confirming the ask is **appropriate prioritization, not rushed shipping**. Current status: NOT running; no workflow archives review threads; no `docs/pr-discussions/` directory exists. Currently PR review threads (Copilot / Codex connector / human reviewer comments) live GitHub-side only; if repo is mirrored / forked / GitHub has an outage / repo is migrated, the conversation substrate is lost. For glass-halo transparency + retractability, PR discussions belong in-repo. This is high-signal data (Copilot's actual critiques of the factory's code; Otto's replies showing reasoning patterns; human-contributor thought process). Proposed phased landing:
+
+  **Phase 1 — design (this tick or next, S effort).** Decide:
+  (a) file-per-PR vs index-plus-per-thread; (b) markdown
+  schema (YAML frontmatter fields: `pr_number`, `pr_title`,
+  `pr_author`, `merged_at`, `scope`, `privacy_pass`); (c) slug
+  collision rules; (d) idempotent-update semantics when a
+  resolved thread is reopened or a comment is edited
+  post-merge; (e) who authors the archive commits (GHA bot vs
+  human-contributor-attributed).
+
+  **Phase 2 — privacy review (Aminata threat-model pass,
+  blocking).** Questions: what classes of content in a
+  reviewer comment could be sensitive (credentials
+  accidentally pasted, customer data, internal-only URLs,
+  names of external organizations)? Is the privacy pass a
+  manual-review-then-merge step or an automated
+  redaction-on-ingest step? What does a review-comment
+  redaction look like (strike-through with reason, or hash
+  and reference)? Does Aminata recommend a different trust
+  posture for agents (Copilot / Codex-connector / github-
+  actions / Claude Code personas) vs humans (contributors
+  with arbitrary comment content)?
+
+  **Phase 3 — ongoing-capture mechanism (S-M effort after
+  Phase 2 signs off).** GHA workflow with:
+
+  ```yaml
+  on:
+    pull_request_target:
+      types: [closed]
+  ```
+
+  Job gates on `if: github.event.pull_request.merged == true`.
+  Fetches threads via `gh api graphql`, writes to
+  `docs/pr-discussions/PR-<N>-<slug>.md` on a dedicated
+  branch, opens an auto-archive PR.
+
+  **Security constraints for `pull_request_target`**
+  (known GitHub Actions footgun — elevated permissions +
+  access to secrets on base-branch code, but the trigger
+  FIRES for PRs from forks; the well-known exploit is
+  checking out PR-head and executing its code with the
+  elevated permissions). The reviewer-suggested safer
+  alternatives — `push` on `main` after merge, or a
+  `workflow_run` chain from a CI workflow that ran on the
+  merge commit — remain on the table for Phase 1 design;
+  the constraints below apply if `pull_request_target` is
+  the chosen mechanism:
+
+  - MUST NOT `actions/checkout` the PR head (`refs/pull/<N>/
+    merge` or `head.ref`). Check out the base ref only;
+    the archive content is fetched via `gh api graphql`
+    against the already-merged PR state, not by running
+    PR code.
+  - MUST NOT use `${{ github.event.pull_request.title }}` /
+    `.body` / `.head.ref` / `.head.label` / etc. in any
+    `run:` step. Fetch title via `gh api /repos/.../pulls/
+    <N>` INSIDE the workflow (Otto-154 learned this via
+    injection-hook false-positive). Or write the archive
+    with only `number`-keyed fields and derive the slug
+    from the fetched JSON, not from event payload.
+  - MUST declare minimal `permissions:` (just `contents:
+    write` for the archive branch + `pull-requests: write`
+    to open the auto-archive PR). No `actions:`, no
+    `id-token:`, no `deployments:`.
+  - SHOULD pin all `actions/*` to commit SHA per FACTORY-
+    HYGIENE row #43.
+
+  **Docs/memory lint policy reference** (cited in the
+  Non-goals section below): the "docs-lint / memory-
+  no-lint" split is the convention documented in
+  [`memory/feedback_docs_linted_memory_not_otto_decides_where_external_content_lives_2026_04_24.md`](../memory/feedback_docs_linted_memory_not_otto_decides_where_external_content_lives_2026_04_24.md)
+  and enforced by `.markdownlint-cli2.jsonc` (which
+  excludes `memory/**` via ignore patterns). This PR's
+  discussion-archive output lives in `docs/pr-discussions/`
+  which IS subject to markdownlint; memory/ continues to
+  be ignored.
+
+  **Phase 4 — backfill (M effort after Phase 3 is proven on
+  live PRs).** Per-PR script that walks all merged PRs in
+  priority order (richest-review-content first — PRs with
+  Copilot comments, PRs with Codex-connector comments,
+  bulk-change PRs, then routine PRs), applies the Phase-2
+  privacy pass, commits archives in batches (e.g. 20 PRs
+  per commit) to keep diffs reviewable. Budget: expect
+  ~300+ merged PRs historically.
+
+  **Phase 5 — ongoing-reconciliation hygiene (S effort, after
+  Phase 4).** Periodic audit (weekly GHA cron) that checks
+  all merged PRs have an archive file; flags divergences;
+  surfaces edit-after-merge comment updates. Captures the
+  drift that would otherwise silently accrue.
+
+  **Scope addendum (Aaron Otto-155..156).** Otto-155: *"we
+  can capture the comments from both acehack and lfg the bots,
+  forks should be expected to ship bot comments too like
+  acehack back to the main repo, that's high value signals."*
+  Otto-156 self-correction: *"sorry i said bot comments i
+  should have said agent comments"* — per GOVERNANCE §3 and
+  CLAUDE.md "Agents, not bots." Terminology correction:
+  Copilot, Codex connector, Claude Code personas, and
+  github-actions all count as **agents** with agency,
+  judgement, and accountability — not bots. Two binding
+  scope decisions follow:
+
+  (i) **Dual-agent-surface capture.** Agent comments across
+  both account contexts get archived — those posted under
+  the personal account (`AceHack/...` forks) AND under the
+  org account (`Lucent-Financial-Group/Zeta` main). Same
+  schema, same workflow, different event sources.
+
+  (ii) **Fork-upstream-sync obligation.** When a fork of the
+  repo runs its own Copilot / Codex / agent reviews on its
+  own PRs (e.g. `AceHack/Zeta#42` with a personal-account
+  Copilot review), those agent-comment archives ride back
+  to the main repo when the branch lands upstream — via a
+  sync job that copies fork-side `docs/pr-discussions/`
+  entries into the main repo at merge time. Human comments
+  on fork-side PRs stay under the human-privacy-pass
+  discipline; agent comments get sync-with-scope. Treat
+  fork-originated agent signals as high-value upstream
+  input.
+
+  Non-goals for this row:
+
+  - Replacing GitHub as the live review venue (it's the
+    source-of-truth; archive is the durable mirror).
+  - Attempting historical backfill in a single CI run
+    (300+ PRs × GraphQL rate limits would likely fail —
+    batch it; see Phase 4 for batch strategy).
+  - Assuming agent-authored content is privacy-trivial.
+    Earlier phrasing said agent reviews had "no privacy
+    concern"; that was wrong and contradicted Phase 2's
+    explicit privacy-review scope. Copilot / Codex /
+    Claude Code personas can echo secrets (pasted by
+    humans into a PR description or reviewer reply),
+    internal-only URLs, customer identifiers, or other
+    sensitive substrate the human reviewer dropped into
+    the conversation unaware. Phase 2's privacy pass
+    evaluates ALL archived content — agent-authored
+    included — for redaction need. The trust-posture
+    default for agent content IS higher (no hand-typed
+    free-form prose = lower leak rate) but not
+    zero-risk. Aminata threat-review sets the posture
+    per content source; this row does not pre-commit to
+    "agent content archives verbatim without review."
+
+  Effort: S (Phase 1 design) + M (Phase 2 threat-review +
+  Phase 3 workflow) + M (Phase 4 backfill) + S (Phase 5
+  hygiene). Cumulative: L. Lands across multiple ticks;
+  Phase 1 can go this tick or next; later phases land when
+  ready. Composes with Otto-113 bootstrap-attempt-1 memory +
+  Otto-150..154 burst + the docs-lint/memory-no-lint policy
+  cited in the "Docs/memory lint policy reference" block
+  above (discussions go in `docs/`, which is markdownlint-
+  enforced; `memory/` is excluded) + ChatGPT-download-skill
+  (PR #300) pattern + Aminata threat-model authority.
 
 ## P2 — BP-25 promotion candidate — live-state-before-policy
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5666,9 +5666,9 @@ systems. This track claims the space.
   redaction-on-ingest step? What does a review-comment
   redaction look like (strike-through with reason, or hash
   +reference)? Does Aminata recommend a different trust
-  posture for bots (Copilot / Codex-connector / github-
-  actions) vs humans (contributors with arbitrary comment
-  content)?
+  posture for agents (Copilot / Codex-connector / github-
+  actions / Claude Code personas) vs humans (contributors
+  with arbitrary comment content)?
 
   **Phase 3 — ongoing-capture mechanism (S-M effort after
   Phase 2 signs off).** GHA workflow on `pull_request_target:
@@ -5698,34 +5698,40 @@ systems. This track claims the space.
   surfaces edit-after-merge comment updates. Captures the
   drift that would otherwise silently accrue.
 
-  **Scope addendum (Aaron Otto-155).** *"we can capture the
-  comments from both acehack and lfg the bots, forks should
-  be expected to ship bot comments too like acehack back to
-  the main repo, that's high value signals."* Two binding
+  **Scope addendum (Aaron Otto-155..156).** Otto-155: *"we
+  can capture the comments from both acehack and lfg the bots,
+  forks should be expected to ship bot comments too like
+  acehack back to the main repo, that's high value signals."*
+  Otto-156 self-correction: *"sorry i said bot comments i
+  should have said agent comments"* — per GOVERNANCE §3 and
+  CLAUDE.md "Agents, not bots." Terminology correction:
+  Copilot, Codex connector, Claude Code personas, and
+  github-actions all count as **agents** with agency,
+  judgement, and accountability — not bots. Two binding
   scope decisions follow:
 
-  (i) **Dual-bot-surface capture.** Bot comments across both
-  account contexts get archived — those posted under the
-  personal account (`AceHack/...` forks) AND under the org
-  account (`Lucent-Financial-Group/Zeta` main). Same schema,
-  same workflow, different event sources.
+  (i) **Dual-agent-surface capture.** Agent comments across
+  both account contexts get archived — those posted under
+  the personal account (`AceHack/...` forks) AND under the
+  org account (`Lucent-Financial-Group/Zeta` main). Same
+  schema, same workflow, different event sources.
 
   (ii) **Fork-upstream-sync obligation.** When a fork of the
-  repo runs its own Copilot / Codex / bot reviews on its
+  repo runs its own Copilot / Codex / agent reviews on its
   own PRs (e.g. `AceHack/Zeta#42` with a personal-account
-  Copilot review), those bot-comment archives ride back
+  Copilot review), those agent-comment archives ride back
   to the main repo when the branch lands upstream — via a
   sync job that copies fork-side `docs/pr-discussions/`
   entries into the main repo at merge time. Human comments
   on fork-side PRs stay under the human-privacy-pass
-  discipline; bot comments get sync-with-scope. Treat
-  fork-originated bot signals as high-value upstream
+  discipline; agent comments get sync-with-scope. Treat
+  fork-originated agent signals as high-value upstream
   input.
 
   Non-goals for this row: replacing GitHub as the live
   review venue (it's the source-of-truth; archive is the
   durable mirror); redacting Copilot / Codex-connector
-  reviews (they're bot content without privacy concern);
+  reviews (they're agent content without privacy concern);
   attempting backfill in a single CI run (300+ PRs ×
   GraphQL rate limits would likely fail; batch it).
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5698,6 +5698,30 @@ systems. This track claims the space.
   surfaces edit-after-merge comment updates. Captures the
   drift that would otherwise silently accrue.
 
+  **Scope addendum (Aaron Otto-155).** *"we can capture the
+  comments from both acehack and lfg the bots, forks should
+  be expected to ship bot comments too like acehack back to
+  the main repo, that's high value signals."* Two binding
+  scope decisions follow:
+
+  (i) **Dual-bot-surface capture.** Bot comments across both
+  account contexts get archived — those posted under the
+  personal account (`AceHack/...` forks) AND under the org
+  account (`Lucent-Financial-Group/Zeta` main). Same schema,
+  same workflow, different event sources.
+
+  (ii) **Fork-upstream-sync obligation.** When a fork of the
+  repo runs its own Copilot / Codex / bot reviews on its
+  own PRs (e.g. `AceHack/Zeta#42` with a personal-account
+  Copilot review), those bot-comment archives ride back
+  to the main repo when the branch lands upstream — via a
+  sync job that copies fork-side `docs/pr-discussions/`
+  entries into the main repo at merge time. Human comments
+  on fork-side PRs stay under the human-privacy-pass
+  discipline; bot comments get sync-with-scope. Treat
+  fork-originated bot signals as high-value upstream
+  input.
+
   Non-goals for this row: replacing GitHub as the live
   review venue (it's the source-of-truth; archive is the
   durable mirror); redacting Copilot / Codex-connector

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5646,7 +5646,73 @@ systems. This track claims the space.
 
 - [ ] **Schema-as-Graph — entire database schema as first-class typed graph.** Aaron 2026-04-24 Otto-127: *"would it be possible to have a graph view of the entire table and relations so the whole schema is first class i the graph plus we could have special edge node whatever else we need entities if needed for more fidelity than reguarl sql table structrue and relationships allow. backlog"*. Natural extension of Graph substrate (PR #317 + #324). Scope: (1) schema-node types — Table/Column/Index/Constraint/View/StoredProcedure/Trigger; (2) schema-edge types — ForeignKey/Contains/References/DependsOn/InheritsFrom; (3) custom entity types beyond SQL — Domain/Aggregate/EventStream/Retraction (first-class "removed" with timestamp)/Provenance; (4) round-trip SQL↔Graph invariants; (5) bidirectional — Graph mutations emit DDL; DDL mutates Graph. Schema-change-over-time = Graph event stream w/ retraction-native. Aminata BP-11 threat-pass. Priority P2; effort M+M+L.
 
-- [ ] **Git-native PR-conversation preservation — extract PR review threads + comments to git-tracked files on merge.** Aaron 2026-04-24 Otto-113 directive: *"you probably need to resolve and save the conversations on the PRs to git for gitnative presevration"*. Currently PR review threads (Copilot / Codex connector / human reviewer comments) live GitHub-side only; if repo is mirrored / forked / GitHub has an outage / repo is migrated, the conversation substrate is lost. For glass-halo transparency + retractability, PR discussions belong in-repo. Proposed mechanism: workflow (or post-merge skill) that fetches all review threads + general PR comments for a merged PR, serialises them as markdown at `docs/pr-discussions/PR-<number>-<slug>.md` with attribution (reviewer id/bot), timestamps, thread structure, and resolution status. Scope: (1) design PR-discussion schema + file shape; (2) fetch-on-merge mechanism (GHA workflow using `gh api graphql`); (3) privacy pass (strip anything sensitive from reviewer comments); (4) backfill historical PRs or declare cutover-forward. Priority P2 research-grade; effort S (mechanism) + M (backfill if chosen). Composes with Otto-113 bootstrap-attempt-1 memory + docs-lint/memory-no-lint policy (discussions go in docs/) + the ChatGPT-download-skill (PR #300) pattern.
+- [ ] **Git-native PR-conversation preservation — extract PR review threads + comments to git-tracked files on merge, PLUS backfill of all historical PRs.** **Priority: P1 (elevated from P2 per Aaron Otto-151..153).** Aaron Otto-113 originating directive: *"you probably need to resolve and save the conversations on the PRs to git for gitnative presevration"*. Aaron Otto-150..153 follow-up burst ratifying priority + scope: *"you are still capturing all the PR reviews from copilot and your responses to gitnative right? / that's high signaldata we should get on that pretty quickly i think / can you post fill by going through all the old PRs and all the threads/conversations? / back fill i mean"* — then course-correction *"no not that quick / do it the right way / i just mean pritorize the right way"* confirming the ask is **appropriate prioritization, not rushed shipping**. Current status: NOT running; no workflow archives review threads; no `docs/pr-discussions/` directory exists. Currently PR review threads (Copilot / Codex connector / human reviewer comments) live GitHub-side only; if repo is mirrored / forked / GitHub has an outage / repo is migrated, the conversation substrate is lost. For glass-halo transparency + retractability, PR discussions belong in-repo. This is high-signal data (Copilot's actual critiques of the factory's code; Otto's replies showing reasoning patterns; human-contributor thought process). Proposed phased landing:
+
+  **Phase 1 — design (this tick or next, S effort).** Decide:
+  (a) file-per-PR vs index-plus-per-thread; (b) markdown
+  schema (YAML frontmatter fields: `pr_number`, `pr_title`,
+  `pr_author`, `merged_at`, `scope`, `privacy_pass`); (c) slug
+  collision rules; (d) idempotent-update semantics when a
+  resolved thread is reopened or a comment is edited
+  post-merge; (e) who authors the archive commits (GHA bot vs
+  human-contributor-attributed).
+
+  **Phase 2 — privacy review (Aminata threat-model pass,
+  blocking).** Questions: what classes of content in a
+  reviewer comment could be sensitive (credentials
+  accidentally pasted, customer data, internal-only URLs,
+  names of external organizations)? Is the privacy pass a
+  manual-review-then-merge step or an automated
+  redaction-on-ingest step? What does a review-comment
+  redaction look like (strike-through with reason, or hash
+  +reference)? Does Aminata recommend a different trust
+  posture for bots (Copilot / Codex-connector / github-
+  actions) vs humans (contributors with arbitrary comment
+  content)?
+
+  **Phase 3 — ongoing-capture mechanism (S-M effort after
+  Phase 2 signs off).** GHA workflow on `pull_request_target:
+  closed` with `merged == true`, fetches threads via `gh api
+  graphql`, writes to `docs/pr-discussions/PR-<N>-<slug>.md`
+  on a dedicated branch, opens an auto-archive PR. Safe-
+  pattern compliance per FACTORY-HYGIENE row #43 (SHA-pinned
+  actions, explicit minimal `permissions:`, values via `env:`
+  with quoting — and notably, title/body references cannot
+  flow directly into shell; fetch title via `gh api
+  /repos/.../pulls/<N>` INSIDE the workflow rather than from
+  the `github.event` payload to avoid injection-hook
+  triggers; Otto-154 learned this).
+
+  **Phase 4 — backfill (M effort after Phase 3 is proven on
+  live PRs).** Per-PR script that walks all merged PRs in
+  priority order (richest-review-content first — PRs with
+  Copilot comments, PRs with Codex-connector comments,
+  bulk-change PRs, then routine PRs), applies the Phase-2
+  privacy pass, commits archives in batches (e.g. 20 PRs
+  per commit) to keep diffs reviewable. Budget: expect
+  ~300+ merged PRs historically.
+
+  **Phase 5 — ongoing-reconciliation hygiene (S effort, after
+  Phase 4).** Periodic audit (weekly GHA cron) that checks
+  all merged PRs have an archive file; flags divergences;
+  surfaces edit-after-merge comment updates. Captures the
+  drift that would otherwise silently accrue.
+
+  Non-goals for this row: replacing GitHub as the live
+  review venue (it's the source-of-truth; archive is the
+  durable mirror); redacting Copilot / Codex-connector
+  reviews (they're bot content without privacy concern);
+  attempting backfill in a single CI run (300+ PRs ×
+  GraphQL rate limits would likely fail; batch it).
+
+  Effort: S (Phase 1 design) + M (Phase 2 threat-review +
+  Phase 3 workflow) + M (Phase 4 backfill) + S (Phase 5
+  hygiene). Cumulative: L. Lands across multiple ticks;
+  Phase 1 can go this tick or next; later phases land when
+  ready. Composes with Otto-113 bootstrap-attempt-1 memory +
+  Otto-150..154 burst + docs-lint/memory-no-lint policy
+  (discussions go in docs/) + ChatGPT-download-skill
+  (PR #300) pattern + Aminata threat-model authority.
 
 - [ ] **Ongoing memory-sync mechanism — keep in-repo `memory/` mirrored with auto-memory writes during each Otto tick.** Aaron 2026-04-24 Otto-113 directive *"our memories should all be checked in now"* + Otto-114 confirmation that in-repo memory/ is the natural home for ALL memory types. Otto-113 one-shot sync (PR #307) mirrored 439 files. Going forward, every Otto tick that writes to `~/.claude/projects/.../memory/` should also land new/updated files in-repo `memory/` with matching MEMORY.md pointer update (per memory-index-integrity + memory-reference-existence-lint workflows). Proposed mechanisms: (a) end-of-tick skill that rsyncs new memories to a branch + PRs them; (b) direct-to-repo writes with auto-memory as read-cache; (c) GHA cron periodic sync. Initial preference: (a) for CLI-tool compatibility today, (b) long-term. Also includes path-unification design (decide whether to deprecate the `~/.claude/projects/...` path for this project entirely or keep as staging). Priority P2 research-grade; effort S (rsync skill) + M (direct-write tooling). Composes with `memory/feedback_natural_home_of_memories_is_in_repo_now_all_types_*.md` (Otto-114 policy) + PR #307 one-shot sync + memory-index-integrity workflow.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5671,17 +5671,55 @@ systems. This track claims the space.
   with arbitrary comment content)?
 
   **Phase 3 — ongoing-capture mechanism (S-M effort after
-  Phase 2 signs off).** GHA workflow on `pull_request_target:
-  closed` with `merged == true`, fetches threads via `gh api
-  graphql`, writes to `docs/pr-discussions/PR-<N>-<slug>.md`
-  on a dedicated branch, opens an auto-archive PR. Safe-
-  pattern compliance per FACTORY-HYGIENE row #43 (SHA-pinned
-  actions, explicit minimal `permissions:`, values via `env:`
-  with quoting — and notably, title/body references cannot
-  flow directly into shell; fetch title via `gh api
-  /repos/.../pulls/<N>` INSIDE the workflow rather than from
-  the `github.event` payload to avoid injection-hook
-  triggers; Otto-154 learned this).
+  Phase 2 signs off).** GHA workflow with:
+
+  ```yaml
+  on:
+    pull_request_target:
+      types: [closed]
+  ```
+
+  Job gates on `if: github.event.pull_request.merged == true`.
+  Fetches threads via `gh api graphql`, writes to
+  `docs/pr-discussions/PR-<N>-<slug>.md` on a dedicated
+  branch, opens an auto-archive PR.
+
+  **Security constraints for `pull_request_target`**
+  (known GitHub Actions footgun — elevated permissions +
+  access to secrets on base-branch code, but the trigger
+  FIRES for PRs from forks; the well-known exploit is
+  checking out PR-head and executing its code with the
+  elevated permissions):
+
+  - MUST NOT `actions/checkout` the PR head (`refs/pull/<N>/
+    merge` or `head.ref`). Check out the base ref only;
+    the archive content is fetched via `gh api graphql`
+    against the already-merged PR state, not by running
+    PR code.
+  - MUST NOT use `${{ github.event.pull_request.title }}` /
+    `.body` / `.head.ref` / `.head.label` / etc. in any
+    `run:` step. Fetch title via `gh api /repos/.../pulls/
+    <N>` INSIDE the workflow (Otto-154 learned this via
+    injection-hook false-positive). Or write the archive
+    with only `number`-keyed fields and derive the slug
+    from the fetched JSON, not from event payload.
+  - MUST declare minimal `permissions:` (just `contents:
+    write` for the archive branch + `pull-requests: write`
+    to open the auto-archive PR). No `actions:`, no
+    `id-token:`, no `deployments:`.
+  - SHOULD pin all `actions/*` to commit SHA per FACTORY-
+    HYGIENE row #43.
+
+  **Docs/memory lint policy reference** (cited in the
+  Non-goals section below): the "docs-lint / memory-
+  no-lint" split is the convention documented in
+  `memory/feedback_docs_linted_memory_not_otto_decides_
+  where_external_content_lives_2026_04_24.md` + enforced
+  by `.markdownlint-cli2.jsonc` (which excludes
+  `memory/**` via ignore patterns). This PR's discussion-
+  archive output lives in `docs/pr-discussions/` which
+  IS subject to markdownlint; memory/ continues to be
+  ignored.
 
   **Phase 4 — backfill (M effort after Phase 3 is proven on
   live PRs).** Per-PR script that walks all merged PRs in
@@ -5728,12 +5766,29 @@ systems. This track claims the space.
   fork-originated agent signals as high-value upstream
   input.
 
-  Non-goals for this row: replacing GitHub as the live
-  review venue (it's the source-of-truth; archive is the
-  durable mirror); redacting Copilot / Codex-connector
-  reviews (they're agent content without privacy concern);
-  attempting backfill in a single CI run (300+ PRs ×
-  GraphQL rate limits would likely fail; batch it).
+  Non-goals for this row:
+
+  - Replacing GitHub as the live review venue (it's the
+    source-of-truth; archive is the durable mirror).
+  - Attempting historical backfill in a single CI run
+    (300+ PRs × GraphQL rate limits would likely fail —
+    batch it; see Phase 4 for batch strategy).
+  - Assuming agent-authored content is privacy-trivial.
+    Earlier phrasing said agent reviews had "no privacy
+    concern"; that was wrong and contradicted Phase 2's
+    explicit privacy-review scope. Copilot / Codex /
+    Claude Code personas can echo secrets (pasted by
+    humans into a PR description or reviewer reply),
+    internal-only URLs, customer identifiers, or other
+    sensitive substrate the human reviewer dropped into
+    the conversation unaware. Phase 2's privacy pass
+    evaluates ALL archived content — agent-authored
+    included — for redaction need. The trust-posture
+    default for agent content IS higher (no hand-typed
+    free-form prose = lower leak rate) but not
+    zero-risk. Aminata threat-review sets the posture
+    per content source; this row does not pre-commit to
+    "agent content archives verbatim without review."
 
   Effort: S (Phase 1 design) + M (Phase 2 threat-review +
   Phase 3 workflow) + M (Phase 4 backfill) + S (Phase 5

--- a/docs/pr-preservation/335-drain-log.md
+++ b/docs/pr-preservation/335-drain-log.md
@@ -1,0 +1,172 @@
+# PR #335 drain log — `backlog: elevate git-native PR-preservation P2→P1 + phased plan (Otto-150..154)`
+
+Drain ferry: 2026-04-24. Resolution commit (review-thread fixes) on top of the rebased branch: `e80a326`. Auto-merge armed; rebased onto fresh `origin/main` before drain. PR scope is docs-only (single file: `docs/BACKLOG.md`).
+
+Per Otto-250 PR-preservation drain-log discipline: per-thread fields are reviewer, file:line, original comment verbatim, outcome, reply verbatim, resolution commit. Bot handles preserved verbatim per Otto-237.
+
+---
+
+## Thread 1 — `PRRT_kwDOSF9kNM59VtxI`
+
+- **Reviewer:** Copilot
+- **File:line:** `docs/BACKLOG.md:4597` (diff line; the referenced "Composes with ... docs-lint/memory-no-lint policy" sentence is now at the bottom of the moved row, post-rebase)
+- **Outcome:** FIX
+- **Resolution commit:** `e80a326`
+
+### Original comment
+
+> "docs-lint/memory-no-lint policy" is referenced as if it's an established named policy, but this phrase doesn't appear elsewhere in the repo. Consider replacing it with a concrete citation (e.g., the specific config/file that enforces "docs are linted, memory is ignored") so future implementers know what rule you mean.
+>
+> ```suggestion
+>   maintainer-owned forks (`<fork-owner>/Zeta`) AND under the
+>   org account (`Lucent-Financial-Group/Zeta` main). Same
+>   schema, same workflow, different event sources.
+>
+>   (ii) **Fork-upstream-sync obligation.** When a fork of the
+>   repo runs its own Copilot / Codex
+> ```
+
+### Reply
+
+> Fixed in e80a326. The bottom "Composes with ..." now points at the in-row "Docs/memory lint policy reference" block (added earlier in 4f330cc) and cites `.markdownlint-cli2.jsonc` + the `memory/**` ignore-pattern enforcement explicitly. The phrase now has a concrete grounding instead of standing as an unanchored named policy.
+
+---
+
+## Thread 2 — `PRRT_kwDOSF9kNM59Vtx0`
+
+- **Reviewer:** Copilot
+- **File:line:** `docs/BACKLOG.md` (line null on the latest diff — comment was on a since-edited block in Phase 3)
+- **Outcome:** BACKLOG+RESOLVE (already addressed in commit `4f330cc` before this drain)
+- **Resolution commit:** `4f330cc` (prior commit on this branch)
+
+### Original comment
+
+> The workflow trigger syntax in backticks (`pull_request_target: closed` with `merged == true`) reads like literal YAML, but it isn't valid GitHub Actions syntax. If this is meant as an implementation hint, rephrase to the actual `on: pull_request_target` + `types: [closed]` shape and the real merge condition (`github.event.pull_request.merged`).
+>
+> ```suggestion
+>   Phase 2 signs off).** GHA workflow with `on:
+>   pull_request_target` and `types: [closed]`, gated on
+>   `github.event.pull_request.merged`, fetches threads via
+>   `gh api graphql`, writes to
+>   `docs/pr-discussions/PR-<N>-<slug>.md` on a de
+> ```
+
+### Reply
+
+> Already fixed in 4f330cc on this same branch. The Phase 3 block now has a real fenced YAML example (`on: pull_request_target: types: [closed]`) plus the merge gate `if: github.event.pull_request.merged == true`. Resolving.
+
+---
+
+## Thread 3 — `PRRT_kwDOSF9kNM59VtyM`
+
+- **Reviewer:** Copilot
+- **File:line:** `docs/BACKLOG.md` (line null on latest diff — Phase 3 security)
+- **Outcome:** NARROW+BACKLOG (security constraints landed; safer-alternative suggestions noted as Phase-1-design options)
+- **Resolution commit:** `e80a326` + `4f330cc`
+
+### Original comment
+
+> Phase 3 proposes `pull_request_target` for an auto-archiving workflow that would write branches/PRs back to the repo. That event runs with elevated permissions and is a common footgun; the plan should explicitly constrain it to avoid checking out/executing PR-head content and consider safer alternatives (e.g., `push` on `main` after merge, or a `workflow_run` chain) if write access is required.
+>
+> ```suggestion
+>   Phase 2 signs off).** GHA workflow on trusted post-merge
+>   context (`push` on `main` after merge; `workflow_run`
+>   chaining if a second write-capable workflow is needed),
+>   fetches threa
+> ```
+
+### Reply
+
+> Two-part fix. (1) Security constraints for `pull_request_target` were added in 4f330cc — MUST-NOTs on checking out PR head, MUST-NOTs on `${{ github.event.pull_request.* }}` substitution in `run:` steps, minimal `permissions:` declaration, SHA-pinning for `actions/*`. (2) e80a326 explicitly notes the reviewer's safer-alternative suggestions (`push` on `main` after merge, `workflow_run` chain) remain on the table for Phase 1 design — Phase 1 picks the mechanism, the constraint block applies if `pull_request_target` is the chosen mechanism.
+
+---
+
+## Thread 4 — `PRRT_kwDOSF9kNM59Vtyl`
+
+- **Reviewer:** Copilot
+- **File:line:** `docs/BACKLOG.md:4581` (diff line — old non-goal text on agent privacy)
+- **Outcome:** FIX (already corrected in commit `4f330cc`)
+- **Resolution commit:** `4f330cc`
+
+### Original comment
+
+> The non-goal "redacting Copilot / Codex-connector reviews (they're bot content without privacy concern)" is unsafe and also contradicts Phase 2's privacy questions. Bot-authored comments can still contain sensitive material (e.g., echoed secrets/URLs pasted by humans, or internal details), so Phase 2 should explicitly decide whether bot comments are included in the privacy/redaction pass (even if the outcome is "usually no redaction").
+
+### Reply
+
+> Already fixed in 4f330cc. The earlier non-goal phrasing was reversed — the row now states the prior phrasing was wrong, calls out that agent-authored content can still echo secrets / internal URLs / customer identifiers pasted by humans, scopes Phase 2's privacy pass to ALL archived content (agent-authored included), and explicitly does not pre-commit to "agent content archives verbatim without review." Trust posture default for agent content is documented as higher (no hand-typed free-form prose) but not zero-risk; Aminata threat-review sets the per-source posture. Resolving.
+
+---
+
+## Thread 5 — `PRRT_kwDOSF9kNM59YY8N`
+
+- **Reviewer:** Copilot
+- **File:line:** `docs/BACKLOG.md:4556` (diff line — broken inline-code span in the docs/memory lint policy reference block)
+- **Outcome:** FIX
+- **Resolution commit:** `e80a326`
+
+### Original comment
+
+> This inline code span is split across two lines (`...decides_` then `where_external_content_lives...`). Markdown inline code cannot contain newlines, so the rendered path/reference will be broken and the cross-reference becomes hard to use. Keep the full filename on a single line (or switch to a normal markdown link) so it reliably renders and can be searched/copied.
+>
+> ```suggestion
+>   no-lint" split is the convention documented in `memory/feedback_docs_linted_memory_not_otto_decides_where_external_content_lives_2026_04_24.md`
+>   + enforced by `.markdownlint-cli2.jsonc` (which excludes
+> ```
+
+### Reply
+
+> Fixed in e80a326. The reference is now a markdown link with the full filename on one line, so it renders reliably and is grep-able / copy-able. Switched from inline backticks (which can't span newlines) to `[`...`](...)` link form so the reference is also a clickable anchor in rendered views.
+
+---
+
+## Thread 6 — `PRRT_kwDOSF9kNM59YY87`
+
+- **Reviewer:** Copilot
+- **File:line:** `docs/BACKLOG.md:4487` (diff line — row at top of P2 section declaring Priority: P1)
+- **Outcome:** FIX (relocate row to P1 section)
+- **Resolution commit:** `e80a326`
+
+### Original comment
+
+> This item is under the `## P2 — research-grade` section but declares **Priority: P1**. That creates an internal inconsistency in the backlog structure and makes it harder to find P1 work. Either move this row into the appropriate P1 section (or update the surrounding section header) so priority matches placement.
+>
+> ```suggestion
+> - [ ] **Git-native PR-conversation preservation — extract PR review threads + comments to git-tracked files on merge, PLUS backfill of all historical PRs.** **Priority: P2.** Aaron Otto-113 originating directive: *"you probably need to resolve and save the conversations
+> ```
+
+### Reply
+
+> Fixed in e80a326 by relocating the row, not by reverting the priority. The Otto-150..153 burst explicitly elevated this row P2 → P1, so the right move is to honor that priority and put the row under a P1 header. New home: `## P1 — Git-native hygiene cadences (Otto-54 directive cluster)` — that section's theme ("git-native posture lets git log itself detect and guide cleanup") is the closest semantic fit. Header annotation in the row records the elevation source and the relocation rationale so the audit trail survives. Resolving.
+
+---
+
+## Thread 7 — `PRRT_kwDOSF9kNM59YY9O`
+
+- **Reviewer:** Copilot
+- **File:line:** `docs/BACKLOG.md:4506` (diff line — Phase 2 paragraph, "+reference)" continuation)
+- **Outcome:** FIX
+- **Resolution commit:** `e80a326`
+
+### Original comment
+
+> The line break before `+reference` starts a continuation line with `+` inside a list item, which markdownlint can parse as a nested `+` bullet (MD004/ul-style) and fail CI. Reword so the wrapped line does not begin with `+` (e.g., "and reference").
+>
+> ```suggestion
+>   and reference)? Does Aminata recommend a different trust
+> ```
+
+### Reply
+
+> Fixed in e80a326 with the reviewer's suggested wording: "or hash and reference)". Removes the MD004 trip risk; `and` is also clearer prose than the `+` operator-style join in this context.
+
+---
+
+## Drain summary
+
+- **Threads:** 7 unresolved at start, 7 resolved at end.
+- **Outcome distribution:** 5 FIX (threads 1, 4, 5, 6, 7), 1 NARROW+BACKLOG (thread 3), 1 BACKLOG+RESOLVE (thread 2). Threads 2, 3, 4 were addressed by the prior commit `4f330cc` on this branch; threads 1, 5, 6, 7 land in `e80a326`.
+- **Rebase:** Clean. Rebased branch from 4-commit history (`896f085`, `07336a8`, `48c5d6a`, `4f330cc`) onto fresh `origin/main`; no conflicts.
+- **Final commits on branch (post-drain):** rebased base + the four original commits + `e80a326` review-thread-fix commit.
+- **Build gate:** N/A — docs-only change to `docs/BACKLOG.md`.
+- **Auto-merge:** armed pre-drain; expected to land once required-conversation-resolution and check-suite gates are green.


### PR DESCRIPTION
## Summary

Aaron Otto-150..154 signal burst elevated git-native PR-conversation preservation priority (P2 → P1) and requested backfill. Course correction Otto-154 clarified: *"no not that quick / do it the right way / i just mean pritorize the right way"* — the ask is appropriate prioritization, not rushed shipping.

Expands the existing BACKLOG row (line 4280) into a 5-phase landing plan: design → privacy review (Aminata blocking) → ongoing capture (GHA workflow) → backfill (300+ PRs batched) → reconciliation hygiene.

## Honest status

**Currently NOT running.** No workflow archives review threads. No `docs/pr-discussions/` directory. Prior session summary implied this was ongoing; it was not. BACKLOG elevation makes this visible.

## Also captured

Otto-154 operational-pattern learning: GHA workflows that reference `github.event.pull_request.title` / `.body` trigger the injection-reminder hook even when using the safe `env:` + quoted-shell pattern. Future implementers should fetch via `gh api` INSIDE the workflow instead — documented in Phase-3 body.

## Test plan

- [x] BACKLOG row is the only change; `git diff --stat` shows 1 file, +67/-1.
- [ ] Aminata threat-review pass (Phase 2) before any workflow lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)