### PR TITLE
backlog: tier the missing-file search-surfaces list by usefulness

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5604,6 +5604,36 @@ systems. This track claims the space.
   prose. Companion feedback memory captures the original
   human-maintainer framing.
 
+- [ ] **Tier the missing-file search-surfaces list by
+  usefulness.** PR #391 landed an organized-by-class list
+  in `docs/FACTORY-DISCIPLINE.md` (six classes: in-tree /
+  git-managed / in-repo factory state / GitHub-side /
+  out-of-repo agent state / local-machine + external).
+  The flat-by-class layout is good for COMPLETENESS but
+  not for ORDER-OF-OPERATIONS — an agent hunting a
+  missing file should hit the highest-yield surfaces
+  first. Maintainer 2026-04-24 directive: *"nice that's
+  super detailed, maybe split it into tiers of usefulness
+  backlog"*. Scope: (1) define tier classes — Tier-1
+  *first place to look* (`git status`, `git log --all`,
+  `git stash list`, `gh pr list`, `git worktree list`),
+  Tier-2 *common second-pass* (reflog, `git fsck
+  --lost-found`, closed-not-merged PRs, in-repo factory
+  state surfaces), Tier-3 *recovery / forensic*
+  (Time Machine, APFS snapshots, Trash, IDE
+  local-history, xattrs, terminal scrollback,
+  diagnostic reports), Tier-4 *external-substrate*
+  (sibling LFG repos, gists, courier-ferry imports
+  pre-absorption); (2) reorganize the section into a
+  tiered checklist while preserving the by-class
+  context as a secondary view; (3) add a "first
+  command to run" hint per tier (e.g. Tier-1 starts
+  with `git status && git log --all -- <path>`).
+  Priority P2 hygiene; effort S (doc reorganization +
+  add tier headers + first-command hints). Composes
+  with Otto-230 fresh-session-quality-gap and the
+  search-surfaces section it refines.
+
 - [ ] **Separation-audit cross-PR rollup — automate `## Audit — ...` count verification.** Codex reviewer Otto (2026-04-24) on PR #190 originally flagged that the pattern-summary table in `docs/frontier-readiness/factory-vs-zeta-separation-audit.md` listed ALIGNMENT / FACTORY-HYGIENE / TECH-RADAR as completed classifications even though those sections then lived only in sibling PRs (#185 + #188). PR #188 has since merged, ALIGNMENT classification was corrected from `factory-generic` to `both (coupled)` to match the in-file audit section, and all 15 audits now have dedicated `## Audit —` sections (verifiable via `grep '^## Audit — '`). The residual discipline question — "completed" audits counted in a file's summary should be mechanically reproducible from that file's own contents — remains for the **future**: as new audits land via separate PRs, the same drift can recur. Remaining option: (c) add a tooling / CI check that diffs pattern-summary claims against `grep '^## Audit — '`. Options (a) wait-for-merge and (b) per-PR summary-row landings have resolved naturally for the first 15 audits. Priority P2 research-grade; effort S (tooling). Composes with glass-halo transparency + audit-as-source-of-truth principle.
 
 - [ ] **KSK naming definition doc — `docs/definitions/KSK.md` leading with canonical expansion `KSK = Kinetic Safeguard Kernel`.** **Authority: Aaron Otto-140 rewrite approved; Max attribution preserved as initial-starting-point contributor (Otto-77).** Amara 2026-04-24 (16th courier ferry, GPT-5.5 Thinking) flagged the naming ambiguity: *"'KSK' has multiple possible meanings: DNSSEC-style Key Signing Key, your emerging Kinetic Safeguard Kernel / trust-anchor idea, maybe broader 'ceremony + root-of-trust + governance key' structure."* Aaron Otto-142..145 (self-correcting Otto-141 typo "SDK") canonicalized: *"kinetic safeguare Kernel, i did the wrong name / it is what amara said / kinetic safeguard kernel"* — matches Amara's 5th and 16th ferry phrasing. Doc scope: (1) lead sentence *"KSK = Kinetic Safeguard Kernel. 'Kernel' here is safety-kernel / security-kernel sense (Anderson 1972, Saltzer-Schroeder reference-monitor, aviation safety-kernel) — a small trusted enforcement core, **NOT OS-kernel-mode** (not ring 0, not Linux/Windows kernel)"*; (2) "Inspired by..." DNSSEC KSK / DNSCrypt / threshold-sig ceremonies / security-kernel lineage; (3) "NOT identical to..." OS kernel, DNSSEC KSK (signs zone keys); (4) cross-refs to 5 ferries elaborating architecture; (5) Max attribution: *"Initial starting point committed by Max under Aaron's direction in LFG/lucent-ksk; substrate is Aaron+Amara's concept, completely rewritable."* (Otto-140 lifted the Max-coordination gate; Otto-77 attribution stands.) Priority P2 research-grade (elevated from P3); effort S (doc) — coordination overhead removed. Composes with Amara 17th-ferry correction #7 (now resolved), Otto-77 Max attribution, Otto-90 Aaron+Max-not-gates, Otto-140..145 Aaron canonical expansion + gate-lift, Otto-108 single-team-until-interfaces-harden.

--- a/docs/FACTORY-DISCIPLINE.md
+++ b/docs/FACTORY-DISCIPLINE.md
@@ -247,6 +247,164 @@ memories.
 
 ---
 
+### missing-file search surfaces
+
+When a file, target, or reference appears "missing"
+(verify-before-deferring per `CLAUDE.md`, Otto-257
+recovery, Otto-230 fresh-session quality-gap), search
+across these classes before declaring loss. Subagents
+in particular cannot see most agent-state surfaces, so
+the list also doubles as a coverage map for what
+authoritative state lives where.
+
+**In-tree (working copy):**
+
+- Untracked scratch dirs surfaced by `git status` —
+  e.g. `drop/`, `.playwright-mcp/`.
+- Subagent worktrees: actual checkouts at
+  `.claude/worktrees/agent-<id>/` PLUS git metadata at
+  `.git/worktrees/<name>/`. Authoritative listing is
+  `git worktree list`. After a manual delete of the
+  working-copy path, run `git worktree prune` to clear
+  the orphaned metadata.
+- `.gitignore`d sidecars: `.btw-queue.md` (session-scope
+  TodoWrite alternative), `.memory-sync-state.json`
+  (Otto-242 sync ledger).
+- Sparse-checked-out siblings (e.g. `../runtime` for
+  dotnet/runtime offline navigation).
+
+**Git-managed but not on `main`:**
+
+- Other branches: `git log --all -- <path>` /
+  `git branch -a --contains <sha>`.
+- Stashes: `git stash list` + `git stash show -p
+  stash@{N}`.
+- Reflog: `git reflog` (orphans pre-force-push or
+  pre-`reset --hard`).
+- Dangling objects: `git fsck --lost-found` (commits
+  and blobs no ref points at).
+- Deleted-in-history: `git log --diff-filter=D --all --
+  <path>` to find the commit that deleted it.
+- Renamed: `git log --follow <path>` /
+  `git log --find-renames=N`.
+- Tags: `git tag -l` + `git show <tag>` — a tag can
+  point at a commit no branch reaches.
+- Notes: `git notes list` — git-notes attached to
+  commits; not visible in `git log` by default.
+- Submodules: `.gitmodules` + `git submodule status` —
+  embedded sub-repos with their own histories.
+- Bundles: `*.bundle` files in-tree — portable git
+  archives that may carry orphan history.
+- Hooks: `.git/hooks/` (local) vs `tools/git/hooks/`
+  (committed) — Zeta keeps committed hooks
+  installable; the local copy may be stale.
+
+**In-repo factory state:**
+
+- `memory/persona/<name>/NOTEBOOK.md` and
+  `OFFTIME.md` — per-persona scratchpads, separate
+  from the canonical `memory/feedback_*.md` store.
+- `docs/hygiene-history/` — append-only audit trail
+  (per Otto-229; never edit prior rows).
+- `docs/hygiene-history/tick-history/` — per-writer
+  tick files when multi-instance lands (Otto-240).
+- `docs/pr-preservation/` — drain-logs and PR
+  conversation extraction (Otto-250).
+- `docs/research/` — courier-ferry research and
+  research-grade reports (Aurora absorbs).
+- `docs/ROUND-HISTORY.md` and `docs/DECISIONS/` —
+  history docs (vs current-state docs); a fact may
+  live in an ADR rather than the live spec.
+
+**GitHub-side (not yet preserved in-repo):**
+
+- Open PRs: `gh pr list` + `gh pr diff <n>` (content
+  may live on a feature branch awaiting merge).
+- Closed-not-merged PRs (Otto-264 row tracks recovery
+  of 14 such branches).
+- Forks (contributor forks pre-PR; Aaron's fork +
+  others).
+- PR review threads / comments — Otto-113 + Otto-250
+  git-native PR-preservation owe extraction; until
+  those land, the discussion substrate lives
+  GitHub-side only.
+- GitHub Discussions and Wiki — covered by the
+  `github-surface-triage` capability skill.
+- Issues with attached files.
+- Actions artifacts: `gh run download <run-id>` for
+  CI-uploaded outputs.
+- Releases (release-attached binaries / assets).
+
+**Out-of-repo agent state:**
+
+- Anthropic per-project AutoMemory at
+  `~/.claude/projects/<slug>/memory/` — invisible to
+  subagents (Otto-230 visibility gap). Per
+  `GOVERNANCE.md` §18 the in-repo `memory/` tree is
+  canonical; the global path is staging.
+- Anthropic global skills: `~/.claude/skills/`.
+- Plugin caches: `~/.claude/plugins/cache/`.
+- Other harness state: Codex `.codex_index/`, Gemini
+  `.gemini/`.
+- Live cron / RemoteTrigger / CronCreate jobs —
+  authoritative listing via `CronList`; a scheduled
+  task may exist as state without a file in-repo.
+- Sibling LFG repos: `lucent-ksk`, other org repos —
+  content referenced from Zeta may live in a sibling
+  repo (Zeta is not the only repo in the org).
+- GitHub gists owned by the user — referenced in
+  research notes; tied to user identity, not repo.
+
+**Local-machine substrates:**
+
+- macOS Time Machine + APFS local snapshots —
+  `tmutil listlocalsnapshots /` lists APFS-level
+  snapshots that may contain a recently-deleted file.
+- Trash: `~/.Trash/` (per-volume `/Volumes/*/.Trashes/`
+  for external drives) — recently deleted files.
+- IDE local-history surfaces: `.vscode/.history/` (VS
+  Code History extension), `.idea/shelf/` and
+  `.idea/workspace.xml` (JetBrains LocalHistory),
+  `.vs/` (Visual Studio).
+- Filesystem-extended attributes: `xattr -l <path>`
+  for macOS metadata, `mdfind` for Spotlight index
+  (find files by content even after rename).
+- Devcontainer / Docker volumes — if the repo is run
+  in a containerised dev env, Docker-managed volumes
+  hold state outside the working tree.
+- Terminal scrollback / shell history (`~/.zsh_history`
+  for zsh) — last-resort recovery of a recently-typed
+  inline content.
+
+**External substrates (pre-absorption):**
+
+- Courier-ferry imports (research from peer harnesses
+  not yet absorbed via PR).
+- External-conversation transcripts pre-archive-header
+  per `GOVERNANCE.md` §33.
+- Local diagnostic reports
+  (`~/Library/Logs/DiagnosticReports/` for the .NET
+  GC SIGSEGV `.ips` files referenced in the
+  Apple-Silicon backlog row).
+
+**Index-integrity check that bites:**
+
+- A file in `memory/*.md` without a pointer row in
+  `memory/MEMORY.md` is invisible to fresh sessions
+  even when it exists on disk. The index IS the
+  discovery mechanism. Always pair the file landing
+  with the index row in the same commit.
+
+**Source:** Aaron 2026-04-24 quiz directive *"wherever
+are all the places you could look for missing files /
+we should probably keep a list check in somewhere"*.
+Composes with Otto-230 (fresh-session-quality-gap),
+Otto-264 (LOST-branch recovery), Otto-242 (sidecar
+pattern), Otto-250 (PR-preservation), and the
+`verify-before-deferring` rule in `CLAUDE.md`.
+
+---
+
 ## What this file is NOT
 
 - Not authoritative. The in-repo `memory/feedback_*.md`


### PR DESCRIPTION
## Summary

- One-line BACKLOG row addition (P2 hygiene) tracking tier-split refinement of the search-surfaces list that just landed in #391.
- Maintainer 2026-04-24 directive on PR #391: *"nice that's super detailed, maybe split it into tiers of usefulness backlog"*.

## Tier outline drafted in the row

- **Tier-1** *first place to look*: `git status`, `git log --all`, `git stash list`, `gh pr list`, `git worktree list`
- **Tier-2** *common second-pass*: reflog, `git fsck --lost-found`, closed-not-merged PRs, in-repo factory state surfaces
- **Tier-3** *recovery / forensic*: Time Machine, APFS snapshots, Trash, IDE local-history, xattrs, terminal scrollback, diagnostic reports
- **Tier-4** *external-substrate*: sibling LFG repos, gists, courier-ferry imports pre-absorption

## Test plan

- [x] Single BACKLOG row addition under P2 — research-grade.
- [x] No code changes; doc-only.
- [x] Cross-references PR #391 + Otto-230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)