### PR TITLE
chore(markdownlint): declarative pin in .mise.toml + bump to 0.22.1 + ignore preservation archives

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -331,14 +331,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup Node
-        # Pinned Node is enough for markdownlint-cli2; no bun needed.
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '22'
-
-      - name: Install markdownlint-cli2
-        run: npm install -g markdownlint-cli2@0.18.1
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        # Installs markdownlint-cli2 via mise (pinned in .mise.toml as
+        # `npm:markdownlint-cli2`). Single source of truth — same
+        # version on dev laptops + CI runners. Prior step hardcoded
+        # the version in this workflow (0.18.1) which drifted
+        # behind the pin discipline the rest of the lints use and
+        # violated Aaron's "update declarativly everywhere"
+        # directive (2026-04-24).
+        run: ./tools/setup/install.sh
 
       - name: Run markdownlint
-        run: markdownlint-cli2 "**/*.md"
+        run: mise exec -- markdownlint-cli2 "**/*.md"

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -32,7 +32,20 @@
     // IS author-controlled and could lint clean, but applying
     // the ignore to the whole directory keeps the rule simple
     // (one path, not 10 file-specific entries).
-    "docs/amara-full-conversation/**"
+    "docs/amara-full-conversation/**",
+    // PR-preservation archive (tools/pr-preservation/archive-pr.sh
+    // output) is verbatim preservation of PR bodies + review-thread
+    // content. By design, the archive carries the input markdown
+    // structure unchanged (blank-line-around-lists, duplicate
+    // "Pull request overview" headings from GitHub's auto-preamble,
+    // consecutive blank lines from the source, etc.). Reformatting
+    // to satisfy MD032/MD024/MD012 would violate the verbatim-
+    // preservation contract (Otto-250 + Otto-279 pr-preservation IS
+    // a history surface). The scripts that generate these files
+    // already ship their own hygiene pass; the archive output is
+    // not author-controlled prose.
+    "docs/pr-discussions/**",
+    "docs/pr-preservation/**"
   ],
   "noBanner": true,
   "noProgress": true,

--- a/.mise.toml
+++ b/.mise.toml
@@ -46,6 +46,13 @@ actionlint = "1.7.12"
 # slim + ubuntu-24.04-arm runners don't ship shellcheck pre-
 # installed, so declarative pin here ensures dev/CI parity.
 shellcheck = "0.11.0"
+# markdownlint-cli2: markdown linter. Declarative pin per Aaron's
+# "update declarativly everywhere" directive (2026-04-24); moves
+# the version off a hardcoded `.github/workflows/gate.yml` line
+# and into the single source of truth the rest of the toolchain
+# already uses. 0.22.1 (npm latest as of 2026-04-24); prior pin
+# was 0.18.1 inlined in gate.yml.
+"npm:markdownlint-cli2" = "0.22.1"
 
 [settings]
 # `python-build-standalone` (upstream for mise's python plugin)


### PR DESCRIPTION
## Summary

Three tightly-related fixes in one PR, all driven by your 2026-04-24 autonomous-loop feedback.

### 1. Declarative version pin (your *\"update declarativly everywhere\"* directive)

- \`.mise.toml\` now carries \`npm:markdownlint-cli2 = \"0.22.1\"\` (confirmed mise-supported per mise-versions.jdx.dev).
- \`.github/workflows/gate.yml\` switched from hardcoded \`npm install -g markdownlint-cli2@0.18.1\` to the same three-way-parity pattern used by shellcheck + actionlint: \`./tools/setup/install.sh\` then \`mise exec -- markdownlint-cli2\`.
- Single source of truth — same version on dev laptops + CI runners.

### 2. Version bump (answering your *\"is that latest?\"*)

- markdownlint-cli2: **0.18.1 → 0.22.1** (npm latest, published hours ago 2026-04-24).
- shellcheck **0.11.0** — verified current (released 2026-01-05). No bump needed.
- actionlint **1.7.12** — verified current (released 2026-03-30). No bump needed.

### 3. Ignore preservation archives

- \`docs/pr-discussions/**\` and \`docs/pr-preservation/**\` are verbatim preservation artifacts of PR content (Otto-250 + Otto-279 pr-preservation-is-history-surface). Reformatting to satisfy MD032/MD024/MD012 would violate verbatim.
- Pattern matches existing \`docs/amara-full-conversation/**\` exemption.

Unblocks #357's markdownlint failure on the 10-PR session-backfill.

## Test plan

- [x] \`.mise.toml\` entry uses correct \`npm:\` backend per mise-versions.jdx.dev.
- [x] gate.yml install step matches shellcheck/actionlint three-way-parity pattern.
- [x] shellcheck + actionlint versions verified current (no stale pins bundled).
- [ ] CI markdownlint runs green against this branch.
- [ ] CI markdownlint green against #357 once this lands + #357 rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)