### PR TITLE
ci(gate): expose GITHUB_TOKEN so mise aqua backend hits authenticated rate limit (5000/hr)

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -45,6 +45,20 @@ on:
 permissions:
   contents: read
 
+# Workflow-level env: exposes GITHUB_TOKEN to every step so mise's
+# `aqua:` backend (used for uv / shellcheck / actionlint /
+# markdownlint-cli2 / etc) can authenticate its GitHub API calls.
+# Without a token, mise hits the unauthenticated rate limit
+# (60 requests per hour per IP, shared across all GitHub Actions
+# runners) and fails to fetch release tags with a 403. With the
+# token, the limit is 5000/hr per token. See
+# https://mise.jdx.dev/dev-tools/github-tokens.html for mise's
+# supported token sources. The token inherits the workflow's
+# `permissions: contents: read` — no write escalation; mise only
+# reads release-tag metadata.
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Summary

Unblocks the persistent CI failure pattern I've been hitting this session: mise's \`aqua:\` backend (uv / shellcheck / actionlint / markdownlint-cli2) fetches release-tag metadata from the GitHub API, and unauthenticated requests hit the 60/hr shared-runner-IP limit. Adds a workflow-level \`env: GITHUB_TOKEN\` so mise authenticates and gets the 5000/hr per-token limit — plenty of headroom for the ~8 tools install.sh installs.

## Observed failure (#404 actionlint this tick, prior recurrences on #398, #282)

\`\`\`
mise ERROR Failed to install tools: aqua:astral-sh/uv@0.9, aqua:koalaman/shellcheck@0.11.0, aqua:rhysd/actionlint@1.7.12
HTTP 403 Forbidden for api.github.com/repos/...
\`\`\`

## Why workflow-level env

Every install-toolchain step in gate.yml benefits without per-step boilerplate. Workflow \`permissions: contents: read\` stays unchanged — mise only reads release-tag metadata, no write escalation.

## Test plan

- [x] Workflow-level env addition only; no logic changes.
- [ ] CI actionlint / shellcheck / markdownlint jobs pass without 403s on next run.
- [ ] Composes with Otto-247 version-currency — this fix enables reliable version lookups mise uses per that discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)