### PR TITLE
backlog: exempt memory/CURRENT-*.md from memory-index-integrity paired-edit trigger (P3)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -10707,8 +10707,9 @@ systems. This track claims the space.
   to be paired with a `memory/MEMORY.md` edit in the same
   PR. The intent is real — new session memories must
   have index pointers — but the trigger-exemption list
-  (`memory/README.md`, `memory/persona/**`, `memory/MEMORY.md`
-  itself) misses `memory/CURRENT-*.md`. CURRENT files
+  (`memory/README.md`, `memory/persona/*`, `memory/MEMORY.md`
+  itself — matching the single-star pattern the workflow
+  actually uses) misses `memory/CURRENT-*.md`. CURRENT files
   are per-maintainer distillations of memories that are
   ALREADY indexed under their own `feedback_` / `project_` /
   `reference_` entries; the CURRENT file itself isn't a
@@ -10730,9 +10731,11 @@ systems. This track claims the space.
     `memory/CURRENT-aaron.md` should pass without
     touching MEMORY.md.
   - Leave the core NSA-001 guard intact — any new
-    `memory/feedback_*.md` / `project_*.md` /
-    `user_*.md` / `reference_*.md` still requires a
-    paired MEMORY.md index pointer.
+    `memory/feedback_*.md` / `memory/project_*.md` /
+    `memory/user_*.md` / `memory/reference_*.md` still
+    requires a paired MEMORY.md index pointer. (Directory
+    prefix spelled consistently on each for clarity since
+    all four live at the same depth.)
 
   **Not in scope:**
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -10210,7 +10210,7 @@ systems. This track claims the space.
      Human peer review is additional-trust, not an
      additional required gate — substrate does not
      have to wait on a human to be canonical. Aaron
-     autonomous-loop 2026-04-25 clarification:
+     autonomous-loop 2026-04-24 clarification:
      *"agent peer review is enough to graduate it"*.
      Disclosure tag: `(peer-reviewed; canonical)` or
      no tag (canonical-when-reviewed is the default).
@@ -10714,7 +10714,7 @@ systems. This track claims the space.
   reference_ entries; the CURRENT file itself isn't a
   new indexable memory. Modifying CURRENT shouldn't
   require a MEMORY.md edit, but today it does (hit on
-  PR #412 2026-04-25, worked around by adding a dated
+  PR #412 2026-04-24, worked around by adding a dated
   "refreshed" note to MEMORY.md's fast-path line).
 
   **Scope:**

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -10710,8 +10710,8 @@ systems. This track claims the space.
   (`memory/README.md`, `memory/persona/**`, `memory/MEMORY.md`
   itself) misses `memory/CURRENT-*.md`. CURRENT files
   are per-maintainer distillations of memories that are
-  ALREADY indexed under their own feedback_ / project_ /
-  reference_ entries; the CURRENT file itself isn't a
+  ALREADY indexed under their own `feedback_` / `project_` /
+  `reference_` entries; the CURRENT file itself isn't a
   new indexable memory. Modifying CURRENT shouldn't
   require a MEMORY.md edit, but today it does (hit on
   PR #412 2026-04-24, worked around by adding a dated

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -10700,6 +10700,55 @@ systems. This track claims the space.
   begins — same discipline as `#404`: doctrine lands
   only when the work becomes real.
 
+- [ ] **Exempt `memory/CURRENT-*.md` from memory-index-
+  integrity paired-edit trigger.** The
+  `memory-index-integrity.yml` workflow (NSA-001 guard)
+  requires any modify to a top-level `memory/*.md` file
+  to be paired with a `memory/MEMORY.md` edit in the same
+  PR. The intent is real — new session memories must
+  have index pointers — but the trigger-exemption list
+  (`memory/README.md`, `memory/persona/**`, `memory/MEMORY.md`
+  itself) misses `memory/CURRENT-*.md`. CURRENT files
+  are per-maintainer distillations of memories that are
+  ALREADY indexed under their own feedback_ / project_ /
+  reference_ entries; the CURRENT file itself isn't a
+  new indexable memory. Modifying CURRENT shouldn't
+  require a MEMORY.md edit, but today it does (hit on
+  PR #412 2026-04-25, worked around by adding a dated
+  "refreshed" note to MEMORY.md's fast-path line).
+
+  **Scope:**
+
+  - Add `memory/CURRENT-*.md` (equivalently
+    `memory/CURRENT-aaron.md` / `memory/CURRENT-amara.md`
+    / future CURRENT-<name>.md) to the case-statement
+    exemption list in
+    `.github/workflows/memory-index-integrity.yml:60-95`,
+    alongside the existing `memory/README.md` and
+    `memory/persona/*` cases.
+  - Regression-verify: a PR that modifies only
+    `memory/CURRENT-aaron.md` should pass without
+    touching MEMORY.md.
+  - Leave the core NSA-001 guard intact — any new
+    `memory/feedback_*.md` / `project_*.md` /
+    `user_*.md` / `reference_*.md` still requires a
+    paired MEMORY.md index pointer.
+
+  **Not in scope:**
+
+  - Widening or loosening the NSA-001 guard itself.
+  - Backfilling missed MEMORY.md pointers for prior
+    CURRENT refreshes (none missing today — the
+    cadence has always touched MEMORY.md as part of
+    the refresh).
+
+  **Effort:** S (one case-statement entry in the
+  workflow + one-shot verify).
+
+  **Composes with:** NSA-001 incident
+  (`docs/hygiene-history/nsa-test-history.md`) — same
+  rule, refined exemption.
+
 - [ ] **User-mode filesystem driver interface — Zeta as
   a mountable FS via FUSE / WinFsp / macFUSE; research
   first; composes with eventual microkernel + all-


### PR DESCRIPTION
## Summary

Hit on PR #412 (CURRENT-aaron refresh) — modifying \`memory/CURRENT-aaron.md\` triggered the NSA-001 paired-edit check which then required \`memory/MEMORY.md\` to be touched in the same PR. Worked around by adding a dated "refreshed" note to MEMORY.md's fast-path line, but the exemption list in the workflow should also cover CURRENT projections:

- CURRENT files are DISTILLATIONS of memories already indexed under their own \`feedback_\` / \`project_\` / \`reference_\` entries.
- The CURRENT file itself isn't a new indexable memory.
- Requiring a MEMORY.md pointer for each CURRENT refresh creates false-positive churn.
- Same rationale as the existing \`persona/\` exemption.

S-effort fix: one additional case-statement entry in \`.github/workflows/memory-index-integrity.yml\`. Core NSA-001 guard stays intact for actual new memories.

## Test plan

- [x] Row lands at P3 under "noted, deferred".
- [x] Explicit scope + anti-scope (NSA-001 guard itself stays intact).
- [x] Date references corrected to 2026-04-24 Eastern.
- [ ] CI markdownlint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)