### PR TITLE
docs(roms): sweep 26 leaf READMEs to match tightened gitignore rule

### DIFF
--- a/roms/atari/2600/README.md
+++ b/roms/atari/2600/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/atari/800/README.md
+++ b/roms/atari/800/README.md
@@ -42,8 +42,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/atari/jaguar/README.md
+++ b/roms/atari/jaguar/README.md
@@ -42,8 +42,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/atari/st/README.md
+++ b/roms/atari/st/README.md
@@ -42,8 +42,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/commodore/amiga/README.md
+++ b/roms/commodore/amiga/README.md
@@ -42,8 +42,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/computers/msx/README.md
+++ b/roms/computers/msx/README.md
@@ -42,8 +42,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/computers/zxspectrum/README.md
+++ b/roms/computers/zxspectrum/README.md
@@ -42,8 +42,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/handheld-other/pokemini/README.md
+++ b/roms/handheld-other/pokemini/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/handheld-other/wonderswan/README.md
+++ b/roms/handheld-other/wonderswan/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/handheld-other/wonderswancolor/README.md
+++ b/roms/handheld-other/wonderswancolor/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/microsoft/msdos/README.md
+++ b/roms/microsoft/msdos/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/nec/pcengine/README.md
+++ b/roms/nec/pcengine/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/nintendo/gb/README.md
+++ b/roms/nintendo/gb/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/nintendo/gba/README.md
+++ b/roms/nintendo/gba/README.md
@@ -42,8 +42,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/nintendo/gbc/README.md
+++ b/roms/nintendo/gbc/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/nintendo/n64/README.md
+++ b/roms/nintendo/n64/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/nintendo/nes/README.md
+++ b/roms/nintendo/nes/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/nintendo/snes/README.md
+++ b/roms/nintendo/snes/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/nintendo/virtualboy/README.md
+++ b/roms/nintendo/virtualboy/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/sega/gamegear/README.md
+++ b/roms/sega/gamegear/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/sega/mastersystem/README.md
+++ b/roms/sega/mastersystem/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/sega/megadrive/README.md
+++ b/roms/sega/megadrive/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/sega/sega32x/README.md
+++ b/roms/sega/sega32x/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/sega/sg1000/README.md
+++ b/roms/sega/sg1000/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/snk/ngp/README.md
+++ b/roms/snk/ngp/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs

--- a/roms/snk/ngpc/README.md
+++ b/roms/snk/ngpc/README.md
@@ -35,8 +35,7 @@ Forbidden (do not drop here):
 ## Gitignore behaviour
 
 Every file in this folder except this `README.md` is
-gitignored via the root `roms/.gitignore` rule (`*` +
-`!*/` + `!**/README.md`). Drop ROMs confidently — git will
+gitignored via the root `roms/.gitignore` rule (`*` + `!*/` + `!/README.md` + `!/*/README.md` + `!/*/*/README.md`). Drop ROMs confidently — git will
 not accidentally track them.
 
 ## Cross-refs


### PR DESCRIPTION
## Summary

Post-merge on #402, Copilot flagged ~29 duplicate threads all saying the same thing: each leaf README's \"Gitignore behaviour\" section documents the stale \`!**/README.md\` glob, but the actual \`roms/.gitignore\` was tightened to depth-limited \`!/README.md\` + \`!/*/README.md\` + \`!/*/*/README.md\` during the same PR drain. Doc/code drift on merged content.

Mechanical sweep: all 26 leaf READMEs updated to the correct rule text.

## Why it happened

The gitignore rule was updated late in #402's drain response to Codex's ROM-set-bundled-README leak concern (depth-limiting the allowlist so deeper README files from unpacked ROM sets stay ignored). The sweep to update all the leaf READMEs that inlined the old rule text was missed at that time. These Copilot threads arrived post-merge, so the drain discovered them here.

## Scope

- 26 leaf README files under \`roms/*/{platform}/README.md\` and \`roms/{single-platform}/README.md\`
- Branch READMEs (\`roms/nintendo/README.md\`, \`roms/sega/README.md\`, etc.) describe behaviour in prose rather than inlining the glob; left as-is
- Top-level \`roms/README.md\` uses prose framing; left as-is

## Test plan

- [x] 26 files, same one-line change each
- [x] No semantic change to gitignore behaviour; only doc alignment
- [x] \`grep -rln '!\\*\\*/' roms/\` returns empty after the sweep
- [ ] CI markdownlint passes
- [ ] Resolve the ~29 threads on #402 pointing at this PR SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)