### PR TITLE
drain(#409 post-merge): node provisioning bug + version alignment + role-refs + typos

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -351,8 +351,8 @@ jobs:
         # version on dev laptops + CI runners. Prior step hardcoded
         # the version in this workflow (0.18.1) which drifted
         # behind the pin discipline the rest of the lints use and
-        # violated Aaron's "update declarativly everywhere"
-        # directive (2026-04-24).
+        # violated the human maintainer's "update declaratively
+        # everywhere" directive (2026-04-24).
         run: ./tools/setup/install.sh
 
       - name: Run markdownlint

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -33,17 +33,19 @@
     // the ignore to the whole directory keeps the rule simple
     // (one path, not 10 file-specific entries).
     "docs/amara-full-conversation/**",
-    // PR-preservation archive (tools/pr-preservation/archive-pr.sh
+    // PR-preservation archive (`tools/pr-preservation/archive-pr.sh`
     // output) is verbatim preservation of PR bodies + review-thread
     // content. By design, the archive carries the input markdown
     // structure unchanged (blank-line-around-lists, duplicate
     // "Pull request overview" headings from GitHub's auto-preamble,
     // consecutive blank lines from the source, etc.). Reformatting
     // to satisfy MD032/MD024/MD012 would violate the verbatim-
-    // preservation contract (Otto-250 + Otto-279 pr-preservation IS
-    // a history surface). The scripts that generate these files
-    // already ship their own hygiene pass; the archive output is
-    // not author-controlled prose.
+    // preservation contract — the policy lives in
+    // `docs/AGENT-BEST-PRACTICES.md` "PR-preservation archive
+    // discipline" + "history-surface name attribution exemption"
+    // sections. The scripts that generate these files already ship
+    // their own hygiene pass; the archive output is not author-
+    // controlled prose.
     "docs/pr-discussions/**",
     "docs/pr-preservation/**"
   ],

--- a/.mise.toml
+++ b/.mise.toml
@@ -46,12 +46,21 @@ actionlint = "1.7.12"
 # slim + ubuntu-24.04-arm runners don't ship shellcheck pre-
 # installed, so declarative pin here ensures dev/CI parity.
 shellcheck = "0.11.0"
-# markdownlint-cli2: markdown linter. Declarative pin per Aaron's
-# "update declarativly everywhere" directive (2026-04-24); moves
-# the version off a hardcoded `.github/workflows/gate.yml` line
-# and into the single source of truth the rest of the toolchain
-# already uses. 0.22.1 (npm latest as of 2026-04-24); prior pin
-# was 0.18.1 inlined in gate.yml.
+# Node + npm: required for the npm-backed mise tools below.
+# Mise's `npm:` backend installs via `npm install -g`, so the
+# Node runtime must be installed first. Pinned here so dev
+# laptops + CI runners + devcontainers all get the same Node
+# version through the install script — no separate
+# actions/setup-node step in gate.yml. 22 LTS as of 2026-04.
+node = "22"
+# markdownlint-cli2: markdown linter. Declarative pin per the
+# human maintainer's "update declaratively everywhere" directive
+# (2026-04-24). Moves the version off a hardcoded
+# `.github/workflows/gate.yml` line and into the single source
+# of truth the rest of the toolchain already uses. Kept in sync
+# with `package.json` devDependency (used by the `lint:markdown`
+# script in package.json) so dev laptops can also `bun run
+# lint:markdown`. Both pins point at the same version.
 "npm:markdownlint-cli2" = "0.22.1"
 
 [settings]

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "eslint": "10.2.1",
     "eslint-plugin-sonarjs": "4.0.3",
     "globals": "17.5.0",
-    "markdownlint-cli2": "0.22.0",
+    "markdownlint-cli2": "0.22.1",
     "prettier": "3.8.3",
     "prettier-plugin-toml": "2.0.6",
     "typescript": "6.0.3",


### PR DESCRIPTION
## Summary

9 post-merge findings on #409. Most important: a real bug — Node wasn't provisioned for the npm-backed mise tool after we removed actions/setup-node. Plus housekeeping fixes.

- **P1 Codex — Node not provisioned.** Added \`node = "22"\` to \`.mise.toml\` so install.sh provisions Node alongside the other tools. The npm: backend needs npm to be on PATH.
- **Double-pin alignment.** package.json had 0.22.0; .mise.toml moved to 0.22.1. Aligned to 0.22.1 with a comment explaining why both pins exist (CI global vs local devDep).
- **Typos ×2.** "declarativly" → "declaratively".
- **BP-24 name attribution ×3.** "Aaron's directive" → "the human maintainer's directive" in .mise.toml + gate.yml. Otto-250/279 inline refs in .markdownlint-cli2.jsonc replaced with rule pointers to AGENT-BEST-PRACTICES.md.
- **Broken xref reply:** archive-pr.sh DOES exist (landed in #357); reply notes the reviewer's 'no matches' was likely against a stale index. Path wrapped in backticks.

## Test plan

- [x] Files modified: .mise.toml, package.json, .github/workflows/gate.yml, .markdownlint-cli2.jsonc.
- [x] Both pins now align at 0.22.1.
- [x] node = "22" provisions Node before npm-backed mise tools.
- [ ] CI markdownlint job passes with the install.sh path (no setup-node needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)