### PR TITLE
drain(#133 follow-up): bash quoting (SC2086) + status-banner truth-update

### DIFF
--- a/docs/research/secret-handoff-protocol-options-2026-04-22.md
+++ b/docs/research/secret-handoff-protocol-options-2026-04-22.md
@@ -145,7 +145,9 @@ On Linux with `libsecret`:
 # Once (store):
 secret-tool store --label="Zeta xAI" service zeta-xai
 
-# Each session (quote the substitution per shellcheck SC2086):
+# Each session (quote the command substitution — handles
+# whitespace / glob chars / newlines in the retrieved value;
+# closely related to shellcheck SC2046 for unquoted $(...)):
 export XAI_API_KEY="$(secret-tool lookup service zeta-xai)"
 ```
 
@@ -172,7 +174,9 @@ op item create --category=api-credential --title='Zeta xAI' \
     "credential[password]=$key"
 unset key
 
-# Each session (quote the substitution per shellcheck SC2086):
+# Each session (quote the command substitution — handles
+# whitespace / glob chars / newlines in the retrieved value;
+# closely related to shellcheck SC2046 for unquoted $(...)):
 export XAI_API_KEY="$(op read "op://Private/Zeta xAI/credential")"
 ```
 

--- a/docs/research/secret-handoff-protocol-options-2026-04-22.md
+++ b/docs/research/secret-handoff-protocol-options-2026-04-22.md
@@ -1,10 +1,13 @@
 # Secret-handoff protocol — options analysis for human-operator → agent
 
-**Status:** first-pass, 2026-04-22, auto-loop-33. Not a BACKLOG
-row yet — maintainer explicitly scoped this as in-chat
-analysis pending shape preference. Published here so the
-reasoning is auditable outside the chat transcript and
-survives transcript rotation.
+**Status:** first-pass, 2026-04-22, auto-loop-33. Originally
+scoped as in-chat analysis pending shape preference; a
+BACKLOG row has since landed in `docs/BACKLOG.md` (Secret-
+handoff protocol — env-var default + password-…) pointing at
+this doc. The doc itself remains design-input research, not
+final-form spec; the BACKLOG row tracks the implementation
+work. Published here so the reasoning is auditable outside
+the chat transcript and survives transcript rotation.
 
 **Triggering event:** auto-loop-31 tick had maintainer paste
 an xAI API key inline after the Grok CLI OAuth flow blocked
@@ -117,8 +120,10 @@ read -rs -p "xAI key: " key
 printf '%s' "$key" | security add-generic-password -s zeta-xai -a "$USER" -w
 unset key
 
-# Each session (launcher):
-export XAI_API_KEY=$(security find-generic-password -s zeta-xai -a "$USER" -w)
+# Each session (launcher) — quote the substitution so any
+# whitespace / glob chars / newlines in the retrieved value
+# don't get word-split or expanded:
+export XAI_API_KEY="$(security find-generic-password -s zeta-xai -a "$USER" -w)"
 claude
 
 # Rotate:
@@ -140,8 +145,8 @@ On Linux with `libsecret`:
 # Once (store):
 secret-tool store --label="Zeta xAI" service zeta-xai
 
-# Each session:
-export XAI_API_KEY=$(secret-tool lookup service zeta-xai)
+# Each session (quote the substitution per shellcheck SC2086):
+export XAI_API_KEY="$(secret-tool lookup service zeta-xai)"
 ```
 
 **Properties:** encrypted at rest by the OS, gated by login
@@ -167,8 +172,8 @@ op item create --category=api-credential --title='Zeta xAI' \
     "credential[password]=$key"
 unset key
 
-# Each session:
-export XAI_API_KEY=$(op read "op://Private/Zeta xAI/credential")
+# Each session (quote the substitution per shellcheck SC2086):
+export XAI_API_KEY="$(op read "op://Private/Zeta xAI/credential")"
 ```
 
 Note: avoid `credential=<paste-key-here>` literal forms in


### PR DESCRIPTION
## Summary

Codex post-merge review on PR #133 surfaced 5 P1+P2 findings on \`docs/research/secret-handoff-protocol-options-2026-04-22.md\`. Addressed in one follow-up PR.

| Finding | Severity | Fix |
|---|---|---|
| Unquoted command substitution in macOS Keychain launcher | P2 | \`export VAR=\"\$(...)\"\` |
| Unquoted command substitution in Linux libsecret launcher | P2 | \`export VAR=\"\$(...)\"\` |
| Unquoted command substitution in 1Password launcher | P2 | \`export VAR=\"\$(...)\"\` |
| Status banner says \"Not a BACKLOG row yet\" but row exists | P1 | Updated banner |
| Transcript path Tier 5 thread | P1 | Reply only — path is correct (\`~/.claude/projects/<slug>/<session>.jsonl\` is the Claude Code transcript format) |

## Discipline

Per Otto-279, this is a research/history surface so research-doc names stay (Otto / Aaron in the file are intentional).

Per Otto-229, post-merge corrections to merged content go in a NEW follow-up PR (this one), not in-place edits.

## Test plan

- [ ] CI markdownlint passes
- [ ] CI shellcheck passes (the new \`\"\$(...)\"\` quoting is exactly what shellcheck SC2086 wants)
- [ ] Auto-merge armed; merges on green