### PR TITLE
drain(#126 follow-up): Gemini capability map xref truth-update

### DIFF
--- a/docs/research/grok-cli-capability-map.md
+++ b/docs/research/grok-cli-capability-map.md
@@ -37,8 +37,8 @@ Companion to:
 - [`docs/research/openai-codex-cli-capability-map.md`](./openai-codex-cli-capability-map.md)
   — OpenAI Codex CLI map (v0.122.0, verified).
 - `docs/research/gemini-cli-capability-map.md` — Gemini CLI
-  map (currently on PR #122, not yet merged to `main`; treat as
-  forthcoming sibling).
+  map (landed in main; sibling pre-install sketch using the
+  same template).
 
 This doc is **descriptive**, not prescriptive.
 

--- a/docs/research/grok-cli-capability-map.md
+++ b/docs/research/grok-cli-capability-map.md
@@ -36,9 +36,10 @@ Companion to:
   — Claude Code CLI map (v2.1.116, verified).
 - [`docs/research/openai-codex-cli-capability-map.md`](./openai-codex-cli-capability-map.md)
   — OpenAI Codex CLI map (v0.122.0, verified).
-- `docs/research/gemini-cli-capability-map.md` — Gemini CLI
-  map (landed in main; sibling pre-install sketch using the
-  same template).
+- [`docs/research/gemini-cli-capability-map.md`](./gemini-cli-capability-map.md)
+  — Gemini CLI map (v0.39.1, verified). The Grok map below
+  is the only pre-install sketch in this set; Claude /
+  Codex / Gemini siblings are all verified.
 
 This doc is **descriptive**, not prescriptive.
 


### PR DESCRIPTION
Codex post-merge thread on PR #126: `docs/research/gemini-cli-capability-map.md` was described as "currently on PR #122, not yet merged", but the file now exists in main. Updated to "landed in main; sibling pre-install sketch using the same template".