### PR TITLE
backlog: P2 doc-lint suite from drain-log corpus patterns

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4457,6 +4457,49 @@ Landed in task #261 bundle.
 
 ## P2 — hygiene refinements (Otto-254/255/256/260/263)
 
+- [ ] **Doc-lint suite — recurring drain-finding classes
+  promoted to pre-commit automation.** The
+  `docs/pr-preservation/*-drain-log.md` corpus has surfaced
+  three findings classes at high enough observation density
+  that pre-commit-lint automation is high-leverage. See
+  `docs/pr-preservation/_patterns.md` for the full pattern
+  index + per-class observation citations.
+
+  **Class A — inline-code-span line-wrap** (4 observed PRs:
+  #191, #195, #219, #423). Backtick spans that cross a
+  newline render as two adjacent code spans rather than one
+  path/command. Lint: regex check for backtick spans crossing
+  newlines in `*.md` files. Fix template: reflow to single
+  line OR convert to a markdown link with the full path on
+  one line.
+
+  **Class B — count-vs-list cardinality** (5 observed PRs:
+  #191, #219, #430, #85, #426). Doc claims "N drift classes /
+  phases / audits / items / PRs" but the enumerated list has
+  a different cardinality. Lint: regex on `\b\d+\s+(items|
+  phases|audits|drift classes|PRs|tests|fixes)\b` patterns +
+  count surrounding list cardinality + warn on mismatch.
+
+  **Class C — pipe-in-Markdown-table-row** (3+ observed PRs).
+  Inline code spans containing `|` inside a Markdown table
+  row get parsed as column separators, breaking the table
+  structure + markdownlint MD056. Lint: regex check on
+  markdown table rows for unescaped `|` inside code spans;
+  suggest backslash-escape or alternative wording.
+
+  **Effort: M.** Each class is ~20-50 lines of regex + test
+  cases. Could land as three separate scripts under
+  `tools/lint/` or one combined `tools/lint/doc-lint.sh`.
+  Wire into pre-commit hook + `.github/workflows/gate.yml`
+  per the existing lint-script convention. Verifies against
+  the per-class observation citations in
+  `docs/pr-preservation/_patterns.md`. Composes with the
+  related-document-cluster manifest (Class D candidate from
+  multi-CLI capability-map family), shellcheck-rule-ID
+  precision (Class E candidate), stable-identifier-vs-line-
+  number xref (Class F candidate) — all observed but at lower
+  density; promote when density justifies.
+
 - [ ] **`StakeCovariance` file split** — move the
   `StakeCovariance` module out of `src/Core/Graph.fs`
   and into its own `src/Core/StakeCovariance.fs`.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4476,16 +4476,17 @@ Landed in task #261 bundle.
   **Class B — count-vs-list cardinality** (5 observed PRs:
   #191, #219, #430, #85, #426). Doc claims "N drift classes /
   phases / audits / items / PRs" but the enumerated list has
-  a different cardinality. Lint: regex on `\b\d+\s+(items|
-  phases|audits|drift classes|PRs|tests|fixes)\b` patterns +
-  count surrounding list cardinality + warn on mismatch.
+  a different cardinality. Lint: regex on `\b\d+\s+(items|phases|audits|drift classes|PRs|tests|fixes)\b`
+  patterns + count surrounding list cardinality + warn on
+  mismatch.
 
   **Class C — pipe-in-Markdown-table-row** (3+ observed PRs).
   Inline code spans containing `|` inside a Markdown table
   row get parsed as column separators, breaking the table
-  structure + markdownlint MD056. Lint: regex check on
-  markdown table rows for unescaped `|` inside code spans;
-  suggest backslash-escape or alternative wording.
+  structure + markdownlint `MD056/table-column-count`.
+  Lint: regex check on markdown table rows for unescaped `|`
+  inside code spans; suggest backslash-escape or
+  alternative wording.
 
   **Effort: M.** Each class is ~20-50 lines of regex + test
   cases. Could land as three separate scripts under
@@ -4496,9 +4497,10 @@ Landed in task #261 bundle.
   `docs/pr-preservation/_patterns.md`. Composes with the
   related-document-cluster manifest (Class D candidate from
   multi-CLI capability-map family), shellcheck-rule-ID
-  precision (Class E candidate), stable-identifier-vs-line-
-  number xref (Class F candidate) — all observed but at lower
-  density; promote when density justifies.
+  precision (Class E candidate),
+  stable-identifier-vs-line-number xref (Class F candidate)
+  — all observed but at lower density; promote when density
+  justifies.
 
 - [ ] **`StakeCovariance` file split** — move the
   `StakeCovariance` module out of `src/Core/Graph.fs`


### PR DESCRIPTION
## Summary

Compounding-substrate work on Otto-268+ drain-log corpus: three findings classes from `docs/pr-preservation/_patterns.md` (PR #448) have reached observation density warranting pre-commit-lint automation. P2 BACKLOG row promotes them.

## Classes promoted

- **Class A — Inline-code-span line-wrap** (4 observed PRs: #191, #195, #219, #423). Backtick spans that cross a newline render as two adjacent code spans rather than one path/command. Lint: regex check for backtick spans crossing newlines in `*.md`. Fix template: reflow to single line OR convert to markdown link with full path on one line.
- **Class B — Count-vs-list cardinality** (5 observed PRs: #191, #219, #430, #85, #426). Doc claims "N items / phases / audits / drift classes / PRs" but enumerated list has different cardinality. Lint: regex on `\b\d+\s+(items|phases|audits|drift classes|PRs|tests|fixes)\b` patterns + count surrounding list + warn on mismatch.
- **Class C — Pipe-in-Markdown-table-row** (3+ observed PRs). Inline code spans containing `|` inside Markdown table row get parsed as column separators, breaking table structure + markdownlint MD056. Lint: regex check on table rows for unescaped `|` inside code spans; suggest backslash-escape or alternative wording.

## Compounding rationale

Each class is ~20-50 lines of regex + tests. Could land as three separate scripts or one combined `tools/lint/doc-lint.sh`. Wire into pre-commit + `.github/workflows/gate.yml` per existing lint-script convention.

Compounding with Otto-114 forward-mirror substrate-fix shape: structural change converts per-PR fix-toil into never-recurring. The 3 classes have already paid for themselves in verify-and-resolve replies; pre-commit-lint catches future instances at author-time and prevents the round-trip.

## Composes with

- `docs/pr-preservation/_patterns.md` — full pattern index + per-class observation citations.
- Lower-density candidate classes (D-F) — multi-CLI capability-map cluster, shellcheck-rule-ID precision, stable-identifier-vs-line-number xref — promote when density justifies.

## Test plan

- [x] BACKLOG row cites all observation PRs per class.
- [x] Effort estimate (M) reflects realistic scope (~20-50 lines/class + test cases + CI wiring).
- [x] Composability with existing lint scripts noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)