### PR TITLE
lint: add docs/aurora/** to markdownlint ignore (Otto-227 verbatim ferry)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -59,8 +59,13 @@
     // across heading breaks. Reformatting the verbatim content to
     // satisfy MD032/MD029/etc. would violate Otto-227
     // signal-in-signal-out discipline — same policy that already
-    // covers `docs/amara-full-conversation/**`.
-    "docs/aurora/**"
+    // covers `docs/amara-full-conversation/**`. Ignore is scoped to
+    // the named ferry-absorb pattern only; non-Amara, non-ferry
+    // docs in `docs/aurora/` (README.md, collaborators.md, the
+    // initial-operations-integration plan, the codex-4 peer-review
+    // archive, the transfer-report which has its own lint-compliance
+    // carve-out, etc.) stay linted.
+    "docs/aurora/2026-*-amara-*.md"
   ],
   "noBanner": true,
   "noProgress": true,

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -47,7 +47,20 @@
     // their own hygiene pass; the archive output is not author-
     // controlled prose.
     "docs/pr-discussions/**",
-    "docs/pr-preservation/**"
+    "docs/pr-preservation/**",
+    // Aurora ferry absorbs (`docs/aurora/2026-*-amara-*.md`) are
+    // verbatim courier-protocol preservation of Amara's deepresearch
+    // ferry reports per Otto-227 verbatim-preservation discipline.
+    // Each absorb has a "## Verbatim preservation (Amara's report)"
+    // section containing Amara's report as paste, including AI-tool
+    // citation anchors (`citeturn…file…`/`citeturn…search…`),
+    // wrap points that hit CommonMark special characters (`+ ...`/
+    // `- ...` line-leading), and ordered-list numbering preserved
+    // across heading breaks. Reformatting the verbatim content to
+    // satisfy MD032/MD029/etc. would violate Otto-227
+    // signal-in-signal-out discipline — same policy that already
+    // covers `docs/amara-full-conversation/**`.
+    "docs/aurora/**"
   ],
   "noBanner": true,
   "noProgress": true,


### PR DESCRIPTION
## Summary

The per-ferry Amara absorbs under \`docs/aurora/2026-*-amara-*.md\` each contain a "## Verbatim preservation (Amara's report)" section where Amara's deepresearch report is preserved verbatim per Otto-227 signal-in-signal-out discipline. Editing that content to satisfy markdownlint MD032/MD029/etc would violate the verbatim-courier contract.

Add \`docs/aurora/**\` to the markdownlint ignore list, mirroring the existing precedent for \`docs/amara-full-conversation/**\` and \`docs/pr-preservation/**\`.

## Why this unblocks 3+ PRs

Currently failing markdownlint on aurora ferry content:
- #235 (5th-ferry: Zeta/KSK/Aurora validation) — line 252 \`+ git history\` line-leading
- #219 (3rd-ferry: decision-proxy + technical review) — line 8 \`- [...]\` continuation
- (and future ferry absorbs would hit the same class)

Auto-merge SQUASH should fire on those PRs once they rebase to pick up this change.

## Test plan

- [x] Mirrors existing precedent (\`docs/amara-full-conversation/**\`, \`docs/pr-preservation/**\`) — same Otto-227 verbatim-preservation rationale
- [x] Comment in config explains the rationale (not just a path)
- [x] Lint covers any non-aurora content normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)