### PR TITLE
hygiene(_patterns.md): line-leading list-marker confusion as recurring class

### DIFF
--- a/docs/pr-preservation/_patterns.md
+++ b/docs/pr-preservation/_patterns.md
@@ -136,6 +136,39 @@ heading to scope explicitly.
 
 **Future doc-lint candidate**: claim-vs-list cardinality check.
 
+### Line-leading list-marker confusion (CommonMark MD032)
+
+Observed on: #377 (`+ manifest files` continuation), #280
+(`+ provenance-aware scoring` continuation), #195 (`+ Kenji
+(Architect)` owner-list continuation), #235 + #219 (Amara
+verbatim ferry content with `+ git history` / `- [link]`
+continuation lines). 5 instances in one tick (2026-04-25).
+
+Pattern: line wrap in multi-line prose / inline-bold spans /
+multi-author lists hits a CommonMark special character (`+`,
+`-`, `*`, `1.`) at line start. Markdownlint MD032 sees the
+wrap-line as a list-item start and complains about missing
+blank-line separators. The author intent is paragraph
+continuation; the parser sees a new list.
+
+Decision tree:
+
+- **Author-controlled prose** (#377, #280, #195) — reflow
+  inline by extending the prior line, switching to
+  comma-separator (`A + B + C` → `A, B, C`), or replacing
+  `+` with `plus`. Fix the rendering, preserve the meaning.
+- **Verbatim ferry / courier content** (#235, #219) — Otto-227
+  forbids editing the verbatim text. Add the surface to the
+  markdownlint ignore list (precedent: `docs/aurora/**`,
+  `docs/amara-full-conversation/**`). Config-PR fix unblocks
+  every downstream PR touching the same surface in one shot.
+
+**Pre-commit-lint candidate**: regex check for line-leading
+`+ ` / `- ` / `* ` inside non-list contexts (paragraph
+continuation lines without preceding blank). Compose with
+the existing Class A inline-code-span line-wrap check; same
+shape (line-wrap hits a CommonMark special).
+
 ### External-source verifiability gaps
 
 Observed on: #219 (OpenAI help-center / DBSP paper / provenance-


### PR DESCRIPTION
## Summary

Promote the 'CommonMark MD032 — line-leading \`+\` / \`-\` parsed as list marker' pattern to a named recurring-findings class in \`docs/pr-preservation/_patterns.md\` after 5 instances surfaced in a single tick (2026-04-25):

- #377: \`+ manifest files\` continuation line
- #280: \`+ provenance-aware scoring\` continuation
- #195: \`+ Kenji (Architect)\` owner-list continuation
- #235: \`+ git history\` (Amara verbatim ferry)
- #219: \`- [link]\` (Amara verbatim ferry)

## Two-branch fix decision tree

The pattern documents both fix paths:

- **Author-controlled prose** → reflow inline (replace \`+\` separator with comma, extend prior line, etc).
- **Verbatim ferry / courier content** (Otto-227) → add to markdownlint ignore list (precedent: \`docs/aurora/**\` from #469, \`docs/amara-full-conversation/**\`).

Composes with the existing Class A inline-code-span line-wrap pattern (same shape: line-wrap hits a CommonMark special character at line start). Pre-commit-lint candidate noted for the doc-lint suite tracked in #465.

## Test plan

- [x] 5 observation citations preserved with PR numbers
- [x] Decision tree distinguishes Otto-227 verbatim-preservation from author-controlled reflow
- [x] Composes with existing Class A pattern entry
- [x] Pre-commit-lint candidate flagged for #465 doc-lint suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)