### PR TITLE
hygiene(#470 follow-up): fix MD032 naming + citation drift on patterns class

### DIFF
--- a/docs/pr-preservation/_patterns.md
+++ b/docs/pr-preservation/_patterns.md
@@ -136,13 +136,17 @@ heading to scope explicitly.
 
 **Future doc-lint candidate**: claim-vs-list cardinality check.
 
-### Line-leading list-marker confusion (CommonMark MD032)
+### Line-leading list-marker confusion (markdownlint MD032)
 
-Observed on: #377 (`+ manifest files` continuation), #280
-(`+ provenance-aware scoring` continuation), #195 (`+ Kenji
-(Architect)` owner-list continuation), #235 + #219 (Amara
-verbatim ferry content with `+ git history` / `- [link]`
-continuation lines). 5 instances in one tick (2026-04-25).
+Observed on: #377 (`+ manifest files` continuation), #195
+(`+ Kenji (Architect)` owner-list continuation), #235 + #219
+(Amara verbatim ferry content with `+ git history` / `- [link]`
+continuation lines). PR #280's research-doc fix (commit
+`cce1df2`) is a same-class instance — `+ provenance-aware
+scoring` continuation reflowed at write-time before any
+drain-log was filed for #280, so the citation here is to the
+fix-commit rather than to a per-PR drain log. 5 instances in
+one tick (2026-04-25).
 
 Pattern: line wrap in multi-line prose / inline-bold spans /
 multi-author lists hits a CommonMark special character (`+`,
@@ -163,11 +167,17 @@ Decision tree:
   `docs/amara-full-conversation/**`). Config-PR fix unblocks
   every downstream PR touching the same surface in one shot.
 
-**Pre-commit-lint candidate**: regex check for line-leading
-`+ ` / `- ` / `* ` inside non-list contexts (paragraph
-continuation lines without preceding blank). Compose with
-the existing Class A inline-code-span line-wrap check; same
-shape (line-wrap hits a CommonMark special).
+**Pre-commit-lint candidate**: the repo already has
+`tools/hygiene/audit-md032-plus-linestart.sh` covering the
+`+`-at-line-start case. The new work here is either (a)
+extending that audit to `- ` / `* ` in the same
+non-list paragraph-continuation context, or (b) promoting
+the audit from detect-only hygiene to pre-commit
+enforcement. Same general failure mode as the
+"Inline-code-span line-wrap rendering bug" class above
+(line-wrap hits a CommonMark special character and the
+parser reads it as a structural marker instead of prose
+continuation).
 
 ### External-source verifiability gaps
 


### PR DESCRIPTION
## Summary

Three Copilot post-merge findings on the freshly-landed Class H entry in \`docs/pr-preservation/_patterns.md\`:

- **L139**: heading said 'CommonMark MD032' — but MD032 is a markdownlint rule ID ('blanks-around-lists'), not a CommonMark identifier. Renamed to 'markdownlint MD032' (the trigger uses CommonMark-style list markers, but the lint rule itself is markdownlint's).
- **L145**: '#280' citation pointed at a drain-log that doesn't exist. PR #280's same-class fix landed at write-time (commit \`cce1df2\`) before any per-PR drain log was filed for #280. Cite the fix-commit rather than a phantom drain-log so the observation is verifiable from the stated corpus.
- **L170**: 'Pre-commit-lint candidate' wording was vague. The repo already has \`tools/hygiene/audit-md032-plus-linestart.sh\` covering the \`+\`-at-line-start case. Update to point at the existing audit + state the new work clearly: extend to \`- \` / \`* \` or promote to pre-commit enforcement. Drop the 'Class A' label (this doc doesn't use Class A/B/C labels; that's BACKLOG #465's roster); replace with the actual prior heading 'Inline-code-span line-wrap rendering bug'.

## Test plan

- [x] Three findings are pattern instances of classes the same doc names: citation drift (Class B-ish), terminology accuracy (markdownlint vs CommonMark surface-class confusion), and pre-existing-tool-not-cited (similar to Otto-114 forward-mirror compounding).
- [x] Same shape as PR #467 self-correction (\`_patterns.md\` shape divergence corrected its own template snippet) — substrate doc continues to refine itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)