### PR TITLE
ci(dependabot): group updates per Aaron Otto-280

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,19 +8,27 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "deps:"
-    # Group related NuGet updates into a single PR. Per Aaron Otto-280
-    # 2026-04-25 directive: ungrouped per-package PRs add noise to the
-    # drain queue when several packages bump in the same week. Grouping
-    # cuts the queue depth + lets a single CI run cover the cluster.
-    # Major bumps still open as individual PRs so they get scrutiny.
+    # Group related NuGet updates into a single PR. Per maintainer
+    # Otto-280 2026-04-25 directive: ungrouped per-package PRs add
+    # noise to the drain queue when several packages bump in the same
+    # week. Grouping cuts the queue depth + lets a single CI run cover
+    # the cluster. Major bumps still open as individual PRs so they
+    # get scrutiny.
     groups:
       # System.* / Microsoft.* runtime libraries usually bump together
       # on .NET servicing rolls (e.g., 10.0.6 to 10.0.7 across
       # System.Numerics.Tensors / System.IO.Hashing / etc.).
+      # `exclude-patterns` keeps unrelated `Microsoft.*` packages
+      # (`Microsoft.NET.Test.Sdk` is a test harness; `Microsoft.Z3` is
+      # an SMT solver) out of the runtime rollup so they fall through
+      # to `nuget-minor-patch` instead of being mis-bundled.
       dotnet-runtime:
         patterns:
           - "System.*"
           - "Microsoft.*"
+        exclude-patterns:
+          - "Microsoft.NET.Test.Sdk"
+          - "Microsoft.Z3"
         update-types:
           - "patch"
           - "minor"
@@ -53,7 +61,7 @@ updates:
     commit-message:
       prefix: "deps:"
     # Group third-party action SHA-pins into a single PR per week
-    # rather than one PR per action. Same Otto-280 rationale.
+    # rather than one PR per action. Same maintainer Otto-280 rationale.
     groups:
       github-actions-minor-patch:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,41 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "deps:"
+    # Group related NuGet updates into a single PR. Per Aaron Otto-280
+    # 2026-04-25 directive: ungrouped per-package PRs add noise to the
+    # drain queue when several packages bump in the same week. Grouping
+    # cuts the queue depth + lets a single CI run cover the cluster.
+    # Major bumps still open as individual PRs so they get scrutiny.
+    groups:
+      # System.* / Microsoft.* runtime libraries usually bump together
+      # on .NET servicing rolls (e.g., 10.0.6 to 10.0.7 across
+      # System.Numerics.Tensors / System.IO.Hashing / etc.).
+      dotnet-runtime:
+        patterns:
+          - "System.*"
+          - "Microsoft.*"
+        update-types:
+          - "patch"
+          - "minor"
+      # F# / xUnit / FsCheck / analyzer ecosystem.
+      fsharp-and-tooling:
+        patterns:
+          - "FSharp.*"
+          - "FsCheck*"
+          - "xunit*"
+          - "Meziantou.*"
+          - "Mono.*"
+        update-types:
+          - "patch"
+          - "minor"
+      # Catch-all minor/patch group for anything else; majors still
+      # open as individual PRs.
+      nuget-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -17,3 +52,12 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "deps:"
+    # Group third-party action SHA-pins into a single PR per week
+    # rather than one PR per action. Same Otto-280 rationale.
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,16 +18,19 @@ updates:
       # System.* / Microsoft.* runtime libraries usually bump together
       # on .NET servicing rolls (e.g., 10.0.6 to 10.0.7 across
       # System.Numerics.Tensors / System.IO.Hashing / etc.).
-      # `exclude-patterns` keeps unrelated `Microsoft.*` packages
-      # (`Microsoft.NET.Test.Sdk` is a test harness; `Microsoft.Z3` is
-      # an SMT solver) out of the runtime rollup so they fall through
-      # to `nuget-minor-patch` instead of being mis-bundled.
+      # `Microsoft.NET.Test.Sdk` ships on the same monthly .NET
+      # servicing cadence (its 18.x track follows .NET 10), so it
+      # belongs in the runtime rollup — bundling avoids two PRs that
+      # would land within hours of each other.
+      # `Microsoft.Z3` is the Microsoft Research SMT solver — its
+      # release cadence is independent of .NET (its 4.x track ships on
+      # solver-team timelines), so we exclude it; it falls through to
+      # the catch-all `nuget-minor-patch` group.
       dotnet-runtime:
         patterns:
           - "System.*"
           - "Microsoft.*"
         exclude-patterns:
-          - "Microsoft.NET.Test.Sdk"
           - "Microsoft.Z3"
         update-types:
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,16 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "deps:"
-    # Group related NuGet updates into a single PR. Per maintainer
-    # Otto-280 2026-04-25 directive: ungrouped per-package PRs add
-    # noise to the drain queue when several packages bump in the same
-    # week. Grouping cuts the queue depth + lets a single CI run cover
-    # the cluster. Major bumps still open as individual PRs so they
-    # get scrutiny.
+    # Group related NuGet updates into a single PR. Rationale:
+    # ungrouped per-package PRs add noise to the drain queue when
+    # several packages bump in the same week — every System.* /
+    # Microsoft.* package bump on a .NET monthly servicing roll
+    # would otherwise open as its own PR within hours of the
+    # others, multiplying CI runs and human review for what is
+    # effectively a single coordinated change. Grouping cuts the
+    # queue depth and lets a single CI run validate the cluster.
+    # Major bumps still open as individual PRs so they get
+    # scrutiny.
     groups:
       # System.* / Microsoft.* runtime libraries usually bump together
       # on .NET servicing rolls (e.g., 10.0.6 to 10.0.7 across
@@ -64,7 +68,10 @@ updates:
     commit-message:
       prefix: "deps:"
     # Group third-party action SHA-pins into a single PR per week
-    # rather than one PR per action. Same maintainer Otto-280 rationale.
+    # rather than one PR per action. Same rationale as the nuget
+    # group above — minor/patch action bumps are coordinated
+    # often enough that bundling them cuts queue depth without
+    # losing review signal.
     groups:
       github-actions-minor-patch:
         patterns:


### PR DESCRIPTION
## Summary

Per Aaron 2026-04-25 directive: configure Dependabot to group its updates rather than open one PR per package. Cuts noise on the drain queue when several packages bump in the same week (observed today with #454 / #455 / #457 / #458 — four separate PRs for one .NET servicing roll).

## Groups added

**NuGet:**
- \`dotnet-runtime\`: \`System.*\` / \`Microsoft.*\` (servicing rolls cluster here)
- \`fsharp-and-tooling\`: \`FSharp.*\` / \`FsCheck*\` / \`xunit*\` / \`Meziantou.*\` / \`Mono.*\`
- \`nuget-minor-patch\`: catch-all minor/patch

**GitHub Actions:**
- \`github-actions-minor-patch\`: catch-all minor/patch

Major bumps still open as individual PRs so they get scrutiny.

## Test plan

- [x] YAML config validated against [GitHub's Dependabot grouping schema](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups).
- [x] Patterns match observed naming (verified against the 4 Dependabot PRs from today).
- [x] Future per-package PRs only opened for major bumps or non-grouped patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)