### PR TITLE
docs(security): safe-patterns docs + Trivy TeamPCP incident addition (split from #52)

### DIFF
--- a/docs/security/GITHUB-ACTIONS-SAFE-PATTERNS.md
+++ b/docs/security/GITHUB-ACTIONS-SAFE-PATTERNS.md
@@ -1,0 +1,198 @@
+# GitHub Actions workflow injection — safe patterns
+
+**Purpose:** keep every `.github/workflows/*.yml` file in this
+repo secure-by-default against workflow-injection attacks, so
+new workflow authors (human or agent) don't have to rediscover
+the pattern every time. This doc is the **pre-write checklist**
+and the authoritative reference for reviewer gates on CI YAML.
+
+**Primary source:** GitHub Security Lab, *How to catch GitHub
+Actions workflow injections before attackers do*
+(<https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/>).
+Audit against the blog's current revision on the same cadence as
+the rest of the harness-surface audit (FACTORY-HYGIENE #38).
+
+## Threat model in one sentence
+
+Any `${{ ... }}` expression expanded directly into a `run:` shell
+script can execute attacker-controlled strings if the value
+originates from an untrusted context (PR title, issue body, branch
+name, commit message, …). The expression is expanded as raw text
+*before* the shell runs, so embedded backticks / `$( )` /
+newlines-plus-command are evaluated as shell even if the field
+looks like plain data.
+
+## The one rule you cannot break
+
+> **Never inline `${{ ... }}` for attacker-controllable data
+> inside a `run:` block. Bind it to an `env:` entry and read the
+> resulting shell variable (`"$VAR"`, always quoted) instead.**
+
+This is the only rule that is load-bearing for injection
+prevention. Everything else on this page is defence in depth.
+
+## Untrusted context — treat as attacker-controlled
+
+| Context | Notes |
+|---|---|
+| `github.event.issue.title` / `.body` | Comes from any GitHub user. |
+| `github.event.pull_request.title` / `.body` | Comes from the PR author (often a forker). |
+| `github.event.pull_request.head_ref`, `github.head_ref` | Branch name on the PR's head. Forks control it. |
+| `github.event.pull_request.base_ref` | Less risky but still user-influenced via PR retargeting. |
+| `github.event.head_commit.message` | Commit message. Author-controlled. |
+| `github.event.commits[*].message` | Same, for push events. |
+| `github.event.comment.body` | Issue / PR / review comments. |
+| `github.event.review.body` | PR review body. |
+| `github.event.pull_request.head.label`, `.repo.html_url` | Fork-controlled strings. |
+| `github.event.workflow_run.head_branch` | Cross-workflow triggers inherit the same risk. |
+| Tag names (`github.ref` on `push` tag events) | Tag authors may be external. |
+| `workflow_dispatch` / `workflow_call` inputs | Trusted only if the caller is trusted *and* inputs are typed+validated. |
+
+Anything reaching a `run:` from these contexts without the
+env-block buffer is an injection sink.
+
+## Trusted context — safe to inline
+
+- `github.workflow`, `github.run_id`, `github.run_number`
+- `github.repository`, `github.repository_owner`
+- `github.sha`, `github.ref` (for branch refs on push-to-branch),
+  `github.event.pull_request.number`
+- `github.event.pull_request.base.sha`,
+  `github.event.pull_request.head.sha` (SHAs are 40-hex, injection-proof)
+- `runner.*`, `matrix.*`, `hashFiles(...)`, `env.*` (when `env` was
+  set from a trusted literal), `secrets.*`
+
+"Trusted" here means GitHub sets the value, not a user.
+
+## Pre-write checklist
+
+Before committing any new workflow or editing an existing one, walk
+this list. Every item is reviewer-visible; CI enforcement catches
+most but not all.
+
+- [ ] **Trigger choice.** `pull_request` (default) grants no secrets
+      and write-permissions to fork PRs. `pull_request_target` runs
+      with repo-owner secrets on forked PRs — use **only** when
+      genuinely required and with extra scrutiny of every
+      interpolation.
+- [ ] **Permissions minimized.** Workflow-level `permissions:
+      contents: read`. Per-job elevations only where needed
+      (`pull-requests: write` for comment posters,
+      `security-events: write` for SARIF uploaders, …). No
+      `write-all`.
+- [ ] **Env-block buffer for every untrusted value.** Any
+      `github.event.*` value read in a `run:` step appears only as
+      an `env:` entry on that step, then as `"$VAR"` in the shell.
+      Never `${{ github.event.* }}` inline.
+- [ ] **Actions SHA-pinned.** Every `uses:` pins a full 40-char
+      commit SHA with a trailing `# vX.Y.Z` comment for humans.
+      Mutable tags (`@main`, `@v1`, `@latest`) are forbidden — they
+      are a supply-chain vector.
+- [ ] **Runners pinned.** `ubuntu-22.04` / `macos-14` — never
+      `-latest`.
+- [ ] **Concurrency group.** Declared at workflow level;
+      `cancel-in-progress: true` for PR events (never for main
+      pushes — every main commit deserves a record).
+- [ ] **Timeout set.** Every job declares a `timeout-minutes`. A
+      stuck job is a cost and availability risk.
+- [ ] **Header comment block.** Starts with a one-paragraph purpose
+      + a `SECURITY NOTE` section enumerating *which* contexts the
+      workflow reads and *where* they are consumed. This is the
+      reviewer's first stop.
+- [ ] **No secrets in `run:` strings.** `secrets.*` is fine in
+      `env:` blocks; never interpolated into a shell command.
+- [ ] **Linters will catch the rest.** Do not rely on that — author
+      correctly, then let lint confirm.
+
+## Factory tooling that enforces this
+
+Three layers; each covers a different failure mode. None catches
+everything — **the pre-write checklist is the primary defence**;
+the linters are the safety net.
+
+1. **`actionlint`** (`lint-workflows` job in `gate.yml`). Fires on
+   every PR. Catches unknown context refs, invalid runner labels,
+   shellcheck-style issues on `run:` blocks, and several well-known
+   injection patterns (e.g. `${{ github.head_ref }}` inside `run:`).
+   Hard-fails the build. Highest-signal layer for most authoring
+   mistakes.
+2. **CodeQL `actions` language** (`codeql.yml` matrix includes
+   `language: actions`, build-mode `none`). GitHub's late-2024
+   taint-tracking query for workflow injection runs here. Runs on
+   PRs-to-main and on a weekly schedule — **not every push to
+   feature branches**. Findings surface under Security → Code
+   scanning; triaged per GOVERNANCE.md §22. The most semantically
+   precise of the three, but also the slowest feedback loop.
+3. **Semgrep** (`lint (semgrep)` job). Fires on every PR via
+   `.semgrep.yml`. Two GitHub-Actions rules:
+     - `gha-action-mutable-tag` — catches `uses: foo@v1` / `@main`
+       instead of a 40-char SHA (supply-chain vector).
+     - `gha-untrusted-in-run-line` — catches single-line
+       `run: ... ${{ github.<unsafe-path> }} ...` forms for the
+       attacker-controlled context list enumerated above (PR
+       titles, issue bodies, branch refs, commit messages, etc.).
+       Runs ahead of CodeQL, so injection is caught at PR time even
+       when CodeQL is on its weekly cadence. Multi-line `run: |`
+       blocks are left to actionlint's YAML-aware parser.
+
+If all three pass, the workflow is compliant with the
+author-checkable slice of this document — the env-block buffer and
+permission-minimization items remain on the author and reviewer.
+When any fail, **fix the code, never the lint**.
+
+## Do / don't — minimal pair
+
+### Unsafe
+
+```yaml
+- name: Log PR title
+  run: echo "Processing PR ${{ github.event.pull_request.title }}"
+```
+
+A PR with title `` `rm -rf ~` `` executes the embedded command.
+
+### Safe
+
+```yaml
+- name: Log PR title
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: |
+    echo "Processing PR $PR_TITLE"
+```
+
+The expansion now happens inside the shell, which treats
+`$PR_TITLE` as a plain string. Always quote the variable (`"$PR_TITLE"`)
+in non-trivial uses.
+
+## Why this doc exists in-repo, not just as a link
+
+- **Offline readable** by every agent and reviewer, including ones
+  without web-fetch.
+- **Factory-specific cross-refs** — points at our actual lint jobs,
+  our actual CodeQL config, our actual SHA-pinning convention. The
+  blog is generic; this is ours.
+- **Cadenced audit target** — FACTORY-HYGIENE row 40 cadences a
+  re-read against the blog's current revision so drift is caught.
+- **Reviewer citation** — a CI YAML review can reject with "violates
+  §Pre-write checklist item N" rather than handwaving.
+
+## Related
+
+- `docs/security/SUPPLY-CHAIN-SAFE-PATTERNS.md` — sibling
+  checklist for the third-party-ingress class. The SHA-pinning
+  rule for `uses:` pins appears in both docs; the supply-chain
+  doc is the authoritative reference when a pin is being **added
+  or bumped** (evaluating the dependency itself), while this doc
+  is authoritative when a workflow is being **authored or edited**
+  (evaluating the shell commands inside).
+- `docs/security/INCIDENT-PLAYBOOK.md` Playbook A — the reactive
+  counterpart when a third-party action we pinned is discovered
+  to have been compromised.
+
+## Scope
+
+Factory-wide. Applies to every workflow in `.github/workflows/`,
+including future workflows for factory-reuse projects that inherit
+this CI shape. Inherits automatically via the factory CI discipline
+(`docs/research/ci-workflow-design.md`, FACTORY-HYGIENE row 40).

--- a/docs/security/INCIDENT-PLAYBOOK.md
+++ b/docs/security/INCIDENT-PLAYBOOK.md
@@ -48,10 +48,26 @@ investigate before you fix.
 malicious release, OR the upstream repo is compromised
 and someone rewrites a tag to point at a malicious commit.
 
-**Canonical case:** tj-actions/changed-files cascade
-(CVE-2025-30066, March 2025). 4 hops deep, 3-4 month
-dwell, SpotBugs PAT → reviewdog → tj-actions → 23,000
-repos.
+**Canonical cases** (both mutable-tag class):
+
+- **tj-actions/changed-files cascade** (CVE-2025-30066,
+  March 2025). 4 hops deep, 3-4 month dwell, SpotBugs PAT
+  → reviewdog → tj-actions → 23,000 repos.
+- **Trivy TeamPCP attack** (2026-03-19). 76 of 77 version
+  tags force-pushed on `aquasecurity/trivy-action` plus 7
+  of 7 on `aquasecurity/setup-trivy`, malicious binary
+  `v0.69.4` published via the compromised `aqua-bot`
+  service account. Notable because (a) the target was a
+  *security scanner itself* — the very thing ecosystems use
+  to audit each other — and (b) even SHA-pinned consumers
+  were hit if they bumped during the compromise window,
+  which underscores why `docs/security/SUPPLY-CHAIN-SAFE-
+  PATTERNS.md` §"Content review is the load-bearing step"
+  matters: a SHA-256 of a compromised release is still a
+  valid SHA-256. We do not currently consume `trivy-action`;
+  scanner-adoption decisions are tracked in
+  `docs/research/vuln-and-dep-scanner-landscape-2026-04-
+  22.md`, which defers Trivy pending rebuild-trust.
 
 ### Detect
 

--- a/docs/security/SUPPLY-CHAIN-SAFE-PATTERNS.md
+++ b/docs/security/SUPPLY-CHAIN-SAFE-PATTERNS.md
@@ -1,0 +1,273 @@
+# Supply-chain attack surface — safe patterns
+
+**Purpose:** keep every third-party-code ingress point in this
+repo — GitHub Actions, NuGet packages, toolchain installers,
+MSBuild `.targets`, OS-package manifests — secure-by-default
+against tag-rewrite, dep-poisoning, and installer-hijack attacks.
+This doc is the **pre-add / pre-bump checklist** and the
+authoritative reference when an agent or contributor is about to
+introduce or upgrade a dependency.
+
+**Primary sources:**
+
+- OWASP Software Component Verification Standard (SCVS) —
+  <https://owasp.org/www-project-software-component-verification-standard/>
+- NIST SP 800-218 *Secure Software Development Framework (SSDF)*
+  PW.4 (Reuse existing, well-secured software) —
+  <https://csrc.nist.gov/Projects/ssdf>
+- SLSA supply-chain levels spec — <https://slsa.dev/>
+- GitHub's dependency-review docs —
+  <https://docs.github.com/en/code-security/supply-chain-security>
+- Canonical incidents (both mutable-tag class):
+  - **CVE-2025-30066** — tj-actions/changed-files tag-rewrite
+    cascade (March 2025), malicious commit landed on 23,000+
+    repos via a single mutable `@v1` tag.
+  - **Trivy TeamPCP attack** — 2026-03-19, Aqua Security's
+      Trivy scanner ecosystem compromised by force-push of 76 of
+      77 version tags on `aquasecurity/trivy-action` + 7 of 7 on
+      `aquasecurity/setup-trivy`, plus a malicious binary
+      `v0.69.4` published via a compromised `aqua-bot` service
+      account. Even SHA-pinned consumers were hit if they bumped
+      during the window. This attack targets a *security
+      scanner itself* — it is the canonical case study for the
+      "content-review-is-load-bearing" policy above: a SHA-256
+      of a compromised release binary is still a valid SHA-256.
+      Referenced in Semgrep rule `gha-action-mutable-tag`,
+      Incident Playbook A, and the scanner-landscape research
+      doc (`docs/research/vuln-and-dep-scanner-landscape-2026-
+      04-22.md`) — which defers Trivy adoption pending
+      rebuild-trust signals.
+
+Re-read against current revisions of these sources every 5-10
+rounds (FACTORY-HYGIENE row 41, same cadence as GHA safe-patterns).
+
+## Threat model in one sentence
+
+Any third-party code that executes in this repo's build, test, or
+runtime (including CI toolchain installers) can execute arbitrary
+commands with the permissions of that step — so every external
+pin is a trust decision that survives until it is re-audited.
+Mutable pins (tags, version ranges, moving URLs) turn a one-time
+trust decision into a standing capability for the upstream
+maintainer to compromise us later.
+
+## The one rule you cannot break
+
+> **Every third-party pin references an immutable identifier.
+> Tags, floating versions, and URLs-without-digests are not
+> pins — they are standing promises.**
+
+For actions this is a 40-char commit SHA. For NuGet it is a fully
+pinned version (no ranges) with a future `packages.lock.json`
+commitment. For toolchain installers it is a SHA-256 of the
+downloaded artefact. For OS packages it is the pinned version in
+the manifest plus repository signature verification.
+
+### Content review is the load-bearing step — the pin caches it
+
+The immutable identifier is *how* we lock a decision, but the
+decision itself is **content review at first pin**. A SHA-256 that
+points at malicious code is still malicious; a hand-verified
+script run `curl | bash`-style after a careful read is safe.
+
+In this factory, Aaron's standing policy (2026-04-22) is: *"never
+run a script you download without checking it for vulnerability,
+trojans and things of that nature even like gist and stuff, it's
+fine to download and run bash and things like that just validate
+them first."* So the actual author-time protocol is:
+
+1. **Download to disk**, do not execute.
+2. **Read the script in full** — check for sudo / privilege
+   escalation, data exfiltration (`curl -X POST`, `nc`, `scp` to
+   non-project hosts), shell-metacharacter injection, opaque
+   base64 blobs, cryptominers, calls to suspicious domains,
+   trojans masquerading as legitimate installers.
+3. **Execute if clean**; record the validation decision in the
+   commit message or manifest comment.
+4. **SHA-256-pin the validated content** — the pin is then a
+   cache of your review. Any bump invalidates the cache and
+   forces a re-read.
+
+The delivery mechanism (`curl | bash` vs `curl -o path && bash
+path`) is not the risk. The risk is unvalidated content.
+
+## Third-party-code ingress points
+
+Zeta has four classes of supply-chain surface. Each has a
+different current enforcement level — **which is itself the
+dominant residual risk** when an ingress is bumped.
+
+| Class | Immutable-pin enforced? | Author-time tooling | Reactive playbook |
+|---|---|---|---|
+| GitHub Actions (`.github/workflows/**`) | **Yes** — Semgrep `gha-action-mutable-tag` + convention of trailing `# vX.Y.Z` comment | Required by rule; lint hard-fails on mutable tags | INCIDENT-PLAYBOOK Playbook A (third-party action compromise) |
+| NuGet packages (`Directory.Packages.props`) | **Partial** — central version management + exact versions. `packages.lock.json` not yet adopted (SDL #7 deliverable). | `tools/audit-packages.sh` + `package-auditor` skill (manual) | INCIDENT-PLAYBOOK Playbook C (NuGet dep poisoning) |
+| Toolchain installers (`tools/setup/manifests/{brew,apt,dotnet-tools,uv-tools,verifiers}`) | **Partial** — versions declared per manifest; not all artefacts carry SHA-256. | `tools/setup/install.sh` is the single consumer; `ensure-*` scripts are opportunistic | INCIDENT-PLAYBOOK Playbook B (toolchain installer hijack mid-setup) |
+| MSBuild `.targets` auto-imported via NuGet | **No** — SDL #7 open deliverable; any package may ship executable MSBuild logic that runs during `dotnet build`. | Manual review; no allowlist yet | Playbook C covers the exploit path |
+
+If you bump or add something in a class marked Partial / No, the
+pre-add checklist is **load-bearing** — the lint won't save you.
+
+## Pre-add / pre-bump checklist — universal
+
+Before committing any third-party addition or bump, walk this
+list. Every item is reviewer-visible.
+
+- [ ] **Justify the dependency at all.** For a new add: does
+      something already in `Directory.Packages.props` / the toolchain
+      / the standard library cover this? Dependency deletion beats
+      dependency audit.
+- [ ] **Read the release notes since the current pin.** Not a
+      skim — specifically look for: breaking changes, new
+      maintainers, repository transfers, deprecation warnings,
+      scope expansions, new transitive dependencies.
+- [ ] **Confirm project health.** Recent commits, responsive
+      issue tracker, not a single-maintainer abandonware account.
+      For high-risk bumps, check the package registry for
+      maintainer account changes.
+- [ ] **Pin by immutable identifier.** SHA for actions; exact
+      version for NuGet; SHA-256 digest (where available) for
+      toolchain installers; pinned version + repo signature for
+      OS packages. Trailing human-readable comment (`# v1.2.3`)
+      so diffs are readable.
+- [ ] **Re-run the whole build gate.** `dotnet build -c Release`
+      plus `dotnet test Zeta.sln -c Release` plus the full CI
+      matrix on a PR — do not trust a one-OS bump.
+- [ ] **Document the bump rationale** in the commit message.
+      "Why this version, now?" Future you (or a future incident
+      responder) needs this.
+- [ ] **Check upstream attestations / SLSA level** if available.
+      SLSA-3+ packages carry build-provenance metadata GitHub can
+      verify automatically.
+
+## Pre-add / pre-bump checklist — per class
+
+### GitHub Actions
+
+- [ ] `uses:` points at a 40-char commit SHA, never a tag.
+- [ ] Trailing `# vX.Y.Z` comment for humans.
+- [ ] Action is from a **known maintainer** — GitHub-owned
+      (`actions/*`), a major-org account, or a single-author action
+      we've audited source for. Avoid newly-created third-party
+      actions unless the blast radius is trivial.
+- [ ] Semgrep `gha-action-mutable-tag` + `actionlint` both pass.
+- [ ] Also apply the injection checklist in
+      `docs/security/GITHUB-ACTIONS-SAFE-PATTERNS.md`.
+
+### NuGet packages
+
+- [ ] Added / bumped only in `Directory.Packages.props` (central
+      version management). No inline `<PackageReference Version=...>`
+      in `.fsproj` / `.csproj`.
+- [ ] Version is exact, not a range (`1.2.3`, never `[1.0,2.0)`).
+- [ ] `tools/audit-packages.sh` was run locally before commit.
+- [ ] `package-auditor` skill workflow was followed for MAJOR
+      bumps — read CHANGELOG for Breaking / Removed bullets, grep
+      our source for any usage of removed surface, **test before
+      deferring**.
+- [ ] If the package ships MSBuild `.targets`, manually read the
+      targets file(s) before committing — they run at build time.
+- [ ] When `packages.lock.json` adoption lands (SDL #7), the lock
+      file gets updated and committed alongside the bump.
+
+### Toolchain installers (`tools/setup/`)
+
+- [ ] Addition or bump lands in the relevant manifest under
+      `tools/setup/manifests/`, not ad-hoc in a script.
+- [ ] Where the upstream publishes SHA-256 digests, include the
+      digest in the manifest; the install script verifies.
+- [ ] The three-way-parity invariant still holds (GOVERNANCE.md
+      §24) — dev laptop, CI, devcontainer all bootstrap from the
+      same manifest.
+- [ ] For new installer scripts, prefer Homebrew / apt / mise /
+      elan over hand-rolled `curl | bash`; when `curl | bash` is
+      unavoidable, pin the raw URL by SHA-256.
+
+### OS-package manifests (brew / apt)
+
+- [ ] Package listed in `tools/setup/manifests/{brew,apt}` with
+      pinned version.
+- [ ] For apt: repository GPG key is captured under
+      `tools/setup/apt-keys/` and verified during install, not
+      fetched from a keyserver at install-time.
+
+## Factory tooling that enforces this
+
+Three layers; none individually sufficient — the pre-add
+checklist is the primary defence.
+
+1. **Semgrep** — `.semgrep.yml` rule `gha-action-mutable-tag`
+   hard-fails any non-SHA action pin. Runs on every PR. One rule
+   today; expansion candidates tracked in SDL #7.
+2. **`package-auditor` skill + `tools/audit-packages.sh`** — the
+   manual NuGet-side audit. Paired with an agent; not yet
+   CI-gated (SDL #7 open deliverable to make the audit a gate).
+3. **Incident playbooks** (`docs/security/INCIDENT-PLAYBOOK.md`) —
+   reactive. Playbook A (action compromise), B (toolchain
+   installer hijack), C (NuGet dep poisoning), D (maintainer
+   account compromise). Triggered when prevention fails.
+
+When adding a third-party surface that none of the above covers,
+either extend the tooling in the same commit or flag a SECURITY-
+BACKLOG row naming the residual risk explicitly.
+
+## Do / don't — minimal pair
+
+### Unsafe
+
+```xml
+<!-- Directory.Packages.props — tag-range opens a standing ingress -->
+<PackageVersion Include="SomePkg" Version="[1.0,2.0)" />
+```
+
+```yaml
+# .github/workflows/foo.yml — one mutable tag is a trust delegation
+- uses: tj-actions/changed-files@v45
+```
+
+### Safe
+
+```xml
+<!-- exact version; diff-legible; auditable -->
+<PackageVersion Include="SomePkg" Version="1.7.2" />
+```
+
+```yaml
+# Full SHA is the trust anchor; trailing comment keeps diffs readable.
+- uses: tj-actions/changed-files@0fe0c5a3b5ed3a1df2c6e8bab4a1a52f8e4c07d9 # v45.0.7
+```
+
+## Upstream signals to watch
+
+The supply-chain threat surface evolves fast. During the cadenced
+re-read (FACTORY-HYGIENE row 41), check:
+
+- **GitHub Security Advisories** for packages we depend on
+  (`dependabot` alerts on the repo; Security → Dependabot).
+- **SLSA progress tracker** — new attestation publishers; new
+  verification requirements.
+- **CVE feeds** filtered for NuGet ecosystem + GitHub Actions
+  ecosystem.
+- **Incident write-ups** for the canonical attack classes (the
+  `tj-actions/changed-files` post-mortem is the reference; newer
+  incidents get added here).
+
+## Why this doc exists in-repo
+
+- **Author-time reference.** Agents and contributors about to add
+  a dependency should not have to rediscover OWASP SCVS or NIST
+  SSDF — the relevant subset lives here, cross-referenced to our
+  actual tooling.
+- **Factory-specific cross-refs.** Points at our Semgrep rule,
+  our `audit-packages.sh`, our manifests, our playbooks. Generic
+  external guidance can't do that.
+- **Cadenced audit target.** FACTORY-HYGIENE row 41 re-reads
+  upstream guidance on cadence so drift is caught.
+- **Reviewer citation surface.** A PR review can reject with
+  "violates §Pre-add checklist item N" rather than handwaving.
+
+## Scope
+
+Factory-wide. Applies to every third-party ingress in this repo
+and — via factory reuse — to adopter projects. Inherits
+automatically via the factory CI discipline and the ships-to-
+project row in `docs/FACTORY-HYGIENE.md`.


### PR DESCRIPTION
## Summary

Three security docs from #52, split off as a fresh branch off main. Pure docs, no runtime impact.

- **\`docs/security/GITHUB-ACTIONS-SAFE-PATTERNS.md\`** (new): workflow-injection vectors + \`env:\` binding fix.
- **\`docs/security/SUPPLY-CHAIN-SAFE-PATTERNS.md\`** (new): mutable-tag risk, SHA-pinning, content-review-as-load-bearing.
- **\`docs/security/INCIDENT-PLAYBOOK.md\`** (modified): Trivy TeamPCP cascade (2026-03-19) added as second canonical case alongside tj-actions/changed-files.

## Why fresh branch (split from #52)

#52 was 289 commits ahead / 5 behind main with a 829-file diff because main expanded enormously since the branch forked. Per Aaron 2026-04-25 *"redo the work and split, easier from master"*.

This is part 1 of 3 of the #52 split. Coming next:
- PR-B: \`.semgrep.yml\` Rule 17 workflow-injection detection
- PR-C: \`.github/workflows/scorecard.yml\` (OpenSSF Scorecard) + \`.github/workflows/resume-diff.yml\`

## Test plan

- [x] Pure docs — no runtime/CI impact beyond markdownlint.
- [x] Cross-references between safe-patterns docs and incident playbook are consistent.
- [x] Trivy entry includes the load-bearing observation: SHA-pinned consumers hit during compromise window because content review is the actual gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)