### PR TITLE
ci(semgrep): Rule 17 — GitHub Actions workflow-injection detection (split from #52)

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -340,3 +340,33 @@ rules:
   # "file lacks any of these headings"; a bespoke diff-level lint
   # (which round-30 spec calls the "safety-clause-diff lint") is
   # the stronger signal. Tracked in docs/DEBT.md; target round-31.
+
+  # ────────────────────────────────────────────────────────────────
+  # Rule 17 — GitHub Actions workflow-injection: inline untrusted
+  # context on a `run:` line. The primary workflow-injection vector
+  # per https://github.blog/security/vulnerability-research/how-to-
+  # catch-github-actions-workflow-injections-before-attackers-do/.
+  # Matches single-line `run: ... ${{ github.<unsafe-path> }} ...`
+  # forms for the attacker-controlled contexts enumerated in
+  # docs/security/GITHUB-ACTIONS-SAFE-PATTERNS.md. Multi-line `run:
+  # |` blocks are covered by actionlint's YAML-aware parser.
+  # Fix: bind the value to an `env:` entry on the step and read it
+  # as `"$VAR"` in the shell. See the safe-patterns doc.
+  # ────────────────────────────────────────────────────────────────
+  - id: gha-untrusted-in-run-line
+    patterns:
+      - pattern-regex: '(?m)^\s*-?\s*run:.*\$\{\{\s*github\.(head_ref|event\.(issue\.(title|body)|pull_request\.(title|body|head_ref|head\.ref|head\.label)|comment\.body|review\.body|head_commit\.message|commits))'
+    paths:
+      include:
+        - ".github/workflows/*.yml"
+        - ".github/workflows/*.yaml"
+    message: >-
+      Attacker-controlled `github.event.*` / `github.head_ref` value
+      expanded directly into a `run:` shell command — classic GitHub
+      Actions workflow-injection sink. A PR title / issue body /
+      branch name containing shell metacharacters will execute on
+      the runner. Bind the value to the step's `env:` block and
+      reference it as `"$VAR"` in the shell instead. See
+      `docs/security/GITHUB-ACTIONS-SAFE-PATTERNS.md` §Do / don't.
+    languages: [generic]
+    severity: ERROR


### PR DESCRIPTION
## Summary

Adds Semgrep Rule 17: detects the primary GitHub Actions workflow-injection vector — inline \`\${{ github.event.* }}\` / \`\${{ github.head_ref }}\` expansion on a single-line \`run:\` shell command.

## Pattern matched

\`run: ... \${{ github.<unsafe-path> }} ...\` for attacker-controlled context paths:

- \`github.head_ref\`, \`github.event.pull_request.head_ref\`, \`.head.ref\`, \`.head.label\`
- \`github.event.issue.title\`, \`.issue.body\`
- \`github.event.pull_request.title\`, \`.pull_request.body\`
- \`github.event.comment.body\`
- \`github.event.review.body\`
- \`github.event.head_commit.message\`
- \`github.event.commits\`

## Why this rule

Single-line \`run:\` injections slip past [actionlint](https://github.com/rhysd/actionlint)'s YAML-aware parser (which catches multi-line \`run: |\` block forms). The Semgrep rule fills the gap with regex pattern matching scoped to \`.github/workflows/*.yml\`.

Reference: [How to catch GitHub Actions workflow injections before attackers do](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/) (GitHub Security Lab).

## Why fresh branch (split from #52)

Part 2 of 3 of #52's split per Aaron 2026-04-25. Composes with #475 (security docs) — this rule's \`message:\` cites \`docs/security/GITHUB-ACTIONS-SAFE-PATTERNS.md\` §Do / don't for the fix template.

## Test plan

- [x] Rule scoped to \`.github/workflows/*.yml\` only — no false positives outside workflow files
- [x] Multi-line \`run: |\` blocks covered by actionlint (no overlap)
- [x] Severity ERROR — workflow injection executes attacker code on the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)