### PR TITLE
fix(tests): SharderInfoTheoreticTests — deterministic XxHash3 (Otto-281)

### DIFF
--- a/tests/Tests.FSharp/Formal/Sharder.InfoTheoretic.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Sharder.InfoTheoretic.Tests.fs
@@ -2,9 +2,27 @@ module Zeta.Tests.Formal.SharderInfoTheoreticTests
 #nowarn "0893"
 
 open System
+open System.IO.Hashing
 open FsUnit.Xunit
 open global.Xunit
 open Zeta.Core
+
+
+/// Deterministic 64-bit hash for an integer key. Replaces the
+/// process-randomized `HashCode.Combine` (which by .NET design
+/// re-seeds per-process to deter hash flooding) with `XxHash3` on
+/// the key's 4-byte little-endian representation. Same convention
+/// `src/Core/Sketch.fs` `AddBytes` already uses.
+///
+/// Otto-281 fix (DST discipline, Aaron 2026-04-25): the prior
+/// `HashCode.Combine`-based `Pick` made
+/// `SharderInfoTheoreticTests` flake across CI runs because the
+/// Jump-consistent-hash output depends on the input hash, and
+/// `HashCode.Combine` produces different hashes in different
+/// processes for the same int. Process-randomization is good for
+/// dictionary security; bad for determinism tests.
+let private detHash (k: int) : uint64 =
+    XxHash3.HashToUInt64 (ReadOnlySpan (BitConverter.GetBytes k))
 
 
 // ═══════════════════════════════════════════════════════════════════
@@ -51,7 +69,7 @@ let ``Consistent-hash bucket skew is material on Zipfian keys`` () =
     let shards = 16
     let loads = Array.zeroCreate<int> shards
     for k in keys do
-        let h = uint64 (HashCode.Combine k)
+        let h = detHash k
         let s = JumpConsistentHash.Pick(h, shards)
         loads.[s] <- loads.[s] + 1
     let ratio = maxAvgRatio loads
@@ -62,11 +80,11 @@ let ``Consistent-hash bucket skew is material on Zipfian keys`` () =
     printfn "Jump ratio on Zipf(s=1.2): %.3f" ratio
 
 
-// DST-exempt: uses `HashCode.Combine` which is process-randomized
-// per-run. Flake analysis + fix pipeline tracked in docs/BACKLOG.md
-// "SharderInfoTheoreticTests 'Uniform traffic' flake" row. DST
-// marker convention + lint rule: docs/BACKLOG.md "DST-marker
-// convention + lint rule" row (Aaron 2026-04-24 directive).
+// DST-clean per Otto-281 fix (Aaron 2026-04-25): all three
+// `HashCode.Combine`-based hashes in this file are now `detHash`
+// (XxHash3 on the key's bytes), which is deterministic across
+// processes. Earlier "DST-exempt" marker dropped — the test is
+// no longer exempt; it's required to be deterministic and is.
 [<Fact>]
 let ``InfoTheoreticSharder does not make skew worse`` () =
     // 100k Zipf keys, 16 shards. Observe then query with the MI-sharder.
@@ -88,7 +106,7 @@ let ``InfoTheoreticSharder does not make skew worse`` () =
 
     let jumpLoads = Array.zeroCreate<int> shards
     for k in keys do
-        let h = uint64 (HashCode.Combine k)
+        let h = detHash k
         let s = JumpConsistentHash.Pick(h, shards)
         jumpLoads.[s] <- jumpLoads.[s] + 1
     let jumpRatio = maxAvgRatio jumpLoads
@@ -116,7 +134,7 @@ let ``Uniform traffic: consistent-hash is already near-optimal`` () =
     let shards = 16
     let loads = Array.zeroCreate<int> shards
     for k in keys do
-        let h = uint64 (HashCode.Combine k)
+        let h = detHash k
         let s = JumpConsistentHash.Pick(h, shards)
         loads.[s] <- loads.[s] + 1
     let ratio = maxAvgRatio loads


### PR DESCRIPTION
## Summary

Per Aaron 2026-04-25 invocation of the DST no-flakes rule (Otto-272 / Otto-248): \`Zeta.Tests.Formal.SharderInfoTheoreticTests.Uniform traffic: consistent-hash is already near-optimal\` flaked 3 times this session on unrelated PRs (#454, #458, #473). Diagnosed the root cause and shipped the fix.

## Root cause

Three call sites in \`tests/Tests.FSharp/Formal/Sharder.InfoTheoretic.Tests.fs\` (lines 54, 91, 119) used \`HashCode.Combine k\` for hashing. **\`HashCode.Combine\` is process-randomized by .NET design** to deter hash-flooding attacks on dictionaries. The Jump-consistent-hash output depends on the input hash, so different CI processes assign the same keys to different shards — sometimes the load distribution lands within \`< 1.2 max/avg ratio\`, sometimes not.

## Fix

Introduce \`detHash\` helper using \`XxHash3.HashToUInt64\` on the key's 4-byte little-endian representation. Same convention \`src/Core/Sketch.fs\` \`AddBytes\` already uses. Replace all three \`HashCode.Combine\` call sites with \`detHash\`.

\`\`\`fsharp
let private detHash (k: int) : uint64 =
    XxHash3.HashToUInt64 (ReadOnlySpan (BitConverter.GetBytes k))
\`\`\`

Drop the obsolete \"DST-exempt\" comment on the \`InfoTheoreticSharder does not make skew worse\` test — the test is now DST-clean, not exempt.

## Verification

Built clean (\`0 Warning(s)\` / \`0 Error(s)\`). Ran the affected tests 3 times in separate processes — all pass with identical output (\`Passed: 3\`).

## Why fix-now (DST discipline)

Per Otto-272 DST (Deterministic Simulation Testing) and Otto-248 \"never ignore flakes\":

> *\"flakes are not 'transient, retry' but active determinism violations; a flake means the DST isn't perfect and there's a real bug\"*

This is the \"real flake\" class — an actual determinism violation in test code, not a registry 502 or transient infra issue. Aaron 2026-04-25: *\"if not we need to stop and fix it now or it will compound, that's why the DST no flakes rule exist.\"*

## Out of scope

Other \`HashCode.Combine\` sites still in the codebase are intentionally left alone in this PR — they have different determinism contracts:

- \`src/Core/Sketch.fs\`, \`src/Core/Shard.fs\`, \`src/Core/NovelMathExt.fs\` — production code where some non-determinism may be acceptable (per-process partitioning, per-instance shard salt, etc.)
- \`tests/Tests.FSharp/Sketches/CountMin.Tests.fs:31\` — uses a fixed-string key (\`HashCode.Combine(\"x\")\`) which may not flake the same way; leave for a separate audit.

A separate audit can sweep them if/when they become a problem. This PR addresses the bleeding test today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)