### PR TITLE
fix(setup): retry verifier-jar download on transient 5xx (Otto-285)

### DIFF
--- a/tools/setup/common/verifiers.sh
+++ b/tools/setup/common/verifiers.sh
@@ -41,8 +41,21 @@ grep -vE '^(#|$)' "$MANIFEST" | while IFS= read -r line; do
     # Download to a .part suffix then atomic-rename. Protects against
     # partial downloads (network flap, Ctrl-C, OOM) becoming
     # permanently trusted by the TOFU check above.
+    #
+    # Retries: GitHub's release-asset CDN occasionally returns
+    # transient 502 / 5xx responses (most recent observed: 2026-04-25
+    # ~13:52 UTC, hit PR #481 CodeQL csharp + PR #482 markdownlint
+    # CI runs). Per Otto-285 (don't use determinism to avoid
+    # edge-case handling — handle the network-non-determinism
+    # algorithmically), curl handles the retry: `--retry 5` attempts,
+    # exponential backoff (2/4/8/16/32 s default), `--retry-all-errors`
+    # so 4xx/5xx server errors retry too (curl's default only retries
+    # connect / dns / 408 / 429 / 5xx-with-Retry-After). Keeps
+    # `-fsSL` semantics — fail at the end if all 5 attempts hit
+    # the same transient.
     echo "↓ downloading $target from $url"
-    curl -fsSL -o "$dest.part" "$url"
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+      -o "$dest.part" "$url"
     mv "$dest.part" "$dest"
     echo "✓ $target"
   fi


### PR DESCRIPTION
## Summary

`tools/setup/common/verifiers.sh` calls `curl -fsSL` to download `tla2tools.jar` and `alloy.jar` without retries. GitHub's release-asset CDN occasionally returns 502 / 5xx errors during install, killing CI on every job that uses the install script (which is most of them).

Most recent observed: 2026-04-25 ~13:52 UTC, hit:
- PR #481 (CodeQL csharp) — \`tla2tools.jar\` 502
- PR #482 (markdownlint) — \`elan\` 502 (via mise:elan plugin; outside our control but same pattern)

Both PRs had **zero code changes** related to the failures — pure environmental flake.

## The fix

Per Otto-285 (don't use DST/determinism to avoid edge-case handling — when we can't control real-world chaos, react to it algorithmically), the curl call now retries:

- \`--retry 5\` attempts
- \`--retry-delay 2\` (initial; exponential-backs to 2/4/8/16/32 s)
- \`--retry-all-errors\` (so 4xx/5xx retry too — curl's default only retries connect/dns/408/429)

\`-fsSL\` semantics preserved: if all 5 attempts hit the same transient, the final exit still fails. We don't silently swallow persistent CDN outages.

## Aaron's framing

> "the right fix is making install robust to network blips ... that is the right answer we cant control that part of the real world environment we have to react to it, good call"

## Test plan

- [x] \`bash -n tools/setup/common/verifiers.sh\` syntax OK
- [x] CI runs (this PR exercises the install script via every job that runs setup)
- [ ] Future CI flake counts on transient 5xx should drop measurably

## Doesn't fix

The mise:elan curl on PR #482 is in mise's plugin code, not ours. Filing a separate BACKLOG row to investigate whether mise has a similar retry config or whether we need to mirror these assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)