### PR TITLE
feat(hygiene): tools/hygiene/sort-tick-history-canonical.py — substrate-built-in instead of dynamic Python

### DIFF
--- a/tools/hygiene/sort-tick-history-canonical.py
+++ b/tools/hygiene/sort-tick-history-canonical.py
@@ -114,6 +114,12 @@ def sort_canonical(text: str) -> tuple[str, dict]:
     header = lines[: sep_idx + 1]
     data = lines[sep_idx + 1 :]
 
+    # File-line offset for converting post-separator indices into
+    # 1-based file line numbers in error diagnostics. Reviewer P2:
+    # 0-based post-separator indices were confusing; the user wants
+    # to grep / open-at-line, not arithmetic in their head.
+    sep_file_line = sep_idx + 1  # 1-based line number of separator
+
     data_rows: list[tuple[str, int, str]] = []
     unmatched_table_rows: list[tuple[int, str]] = []
     for original_index, line in enumerate(data):
@@ -132,15 +138,40 @@ def sort_canonical(text: str) -> tuple[str, dict]:
     rows_in = len(data_rows)
     original_order = [line for _, _, line in data_rows]
 
+    # Trailing non-row content after the table — anything that isn't
+    # blank and isn't a table row must be preserved (Codex P2 finding:
+    # naive header+rows reconstruction would lose trailing prose).
+    # Find the index of the last table-shaped line (matched OR
+    # unmatched); everything after that index is trailing content.
+    trailing_lines: list[str] = []
+    table_indices = sorted(
+        [idx for _, idx, _ in data_rows]
+        + [idx for idx, _ in unmatched_table_rows]
+    )
+    if table_indices:
+        last_table_idx = table_indices[-1]
+        # Trailing = lines AFTER the last table-row. Strip leading
+        # blank-line separator(s) so the reconstructed file gets a
+        # single canonical blank between table-end and prose-start.
+        trailing_candidate = data[last_table_idx + 1 :]
+        first_non_blank = next(
+            (i for i, line in enumerate(trailing_candidate) if line.strip()),
+            len(trailing_candidate),
+        )
+        if first_non_blank < len(trailing_candidate):
+            trailing_lines = trailing_candidate[first_non_blank:]
+
     # P0 guard: if the data region has table-shaped lines but zero
     # match the timestamp regex, the schema has drifted and the
     # naive write-back would wipe the table. Refuse.
     if rows_in == 0 and unmatched_table_rows:
+        first_orig = unmatched_table_rows[0][0]
         raise ValueError(
             f"schema drift: {len(unmatched_table_rows)} table-shaped row(s) "
             f"found but ZERO matched the ISO-8601 timestamp regex. "
             f"Refusing to write — would wipe tick-history. "
-            f"First unmatched row at data-line {unmatched_table_rows[0][0]}: "
+            f"First unmatched row at file-line "
+            f"{sep_file_line + 1 + first_orig}: "
             f"{unmatched_table_rows[0][1][:120]}"
         )
 
@@ -153,7 +184,8 @@ def sort_canonical(text: str) -> tuple[str, dict]:
             f"refusing to drop {len(unmatched_table_rows)} unmatched "
             f"table row(s); per Otto-229 (append-only discipline) the "
             f"sort tool must not silently lose rows. "
-            f"First unmatched at data-line {first[0]}: {first[1][:120]}"
+            f"First unmatched at file-line "
+            f"{sep_file_line + 1 + first[0]}: {first[1][:120]}"
         )
 
     # Stable sort by (timestamp, original_index) so ties preserve
@@ -168,7 +200,17 @@ def sort_canonical(text: str) -> tuple[str, dict]:
         seen.add(line)
         unique_rows.append(line)
 
-    new_text = "\n".join(header) + "\n" + "\n".join(unique_rows) + "\n"
+    # Reconstruct: header + sorted-rows + (blank-line separator +
+    # trailing prose if any). Without trailing-content preservation
+    # the naive header + rows reconstruction would silently drop any
+    # post-table prose paragraph (Codex P2 finding). The blank-line
+    # separator between table-end and trailing-content is required by
+    # CommonMark to terminate the table and start a new block.
+    parts = ["\n".join(header), "\n".join(unique_rows)]
+    if trailing_lines:
+        parts.append("")  # explicit blank-line separator
+        parts.append("\n".join(trailing_lines))
+    new_text = "\n".join(parts) + "\n"
     rows_out = len(unique_rows)
     reordered = unique_rows != original_order[: len(unique_rows)] or rows_out != rows_in
 
@@ -177,6 +219,7 @@ def sort_canonical(text: str) -> tuple[str, dict]:
         "rows_out": rows_out,
         "duplicates_removed": rows_in - rows_out,
         "reordered": reordered,
+        "trailing_lines_preserved": len(trailing_lines),
     }
 
 
@@ -192,7 +235,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--file",
         default="docs/hygiene-history/loop-tick-history.md",
-        help="Path to tick-history file (relative to repo root)",
+        help="Path to tick-history file (relative paths resolve to repo "
+             "root via 'git rev-parse --show-toplevel'; if not in a git "
+             "checkout, falls back to current working directory)",
     )
     args = parser.parse_args(argv)
 

--- a/tools/hygiene/sort-tick-history-canonical.py
+++ b/tools/hygiene/sort-tick-history-canonical.py
@@ -45,8 +45,27 @@ Exit codes:
 
 import argparse
 import re
+import subprocess
 import sys
 from pathlib import Path
+
+
+def repo_root() -> Path | None:
+    """Resolve the repo root via `git rev-parse --show-toplevel`.
+
+    Mirrors sibling hygiene scripts so that running this tool from a
+    subdirectory still resolves the default `--file` correctly. Returns
+    None if not in a git repo (caller falls back to CWD)."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return Path(out.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
 
 
 def find_separator_line(lines: list[str]) -> int | None:
@@ -96,15 +115,46 @@ def sort_canonical(text: str) -> tuple[str, dict]:
     data = lines[sep_idx + 1 :]
 
     data_rows: list[tuple[str, int, str]] = []
+    unmatched_table_rows: list[tuple[int, str]] = []
     for original_index, line in enumerate(data):
         if not line.strip():
             continue
         ts = get_timestamp(line)
         if ts:
             data_rows.append((ts, original_index, line))
+        elif line.lstrip().startswith("|"):
+            # Looks like a table row but no timestamp matched —
+            # schema drift or malformed row. Refuse to silently drop;
+            # caller decides whether to fail or skip after seeing
+            # the count.
+            unmatched_table_rows.append((original_index, line))
 
     rows_in = len(data_rows)
     original_order = [line for _, _, line in data_rows]
+
+    # P0 guard: if the data region has table-shaped lines but zero
+    # match the timestamp regex, the schema has drifted and the
+    # naive write-back would wipe the table. Refuse.
+    if rows_in == 0 and unmatched_table_rows:
+        raise ValueError(
+            f"schema drift: {len(unmatched_table_rows)} table-shaped row(s) "
+            f"found but ZERO matched the ISO-8601 timestamp regex. "
+            f"Refusing to write — would wipe tick-history. "
+            f"First unmatched row at data-line {unmatched_table_rows[0][0]}: "
+            f"{unmatched_table_rows[0][1][:120]}"
+        )
+
+    # P1 guard: any unmatched table row is a discipline violation;
+    # silently dropping rows is exactly the failure mode this script
+    # is supposed to prevent. Surface and refuse.
+    if unmatched_table_rows:
+        first = unmatched_table_rows[0]
+        raise ValueError(
+            f"refusing to drop {len(unmatched_table_rows)} unmatched "
+            f"table row(s); per Otto-229 (append-only discipline) the "
+            f"sort tool must not silently lose rows. "
+            f"First unmatched at data-line {first[0]}: {first[1][:120]}"
+        )
 
     # Stable sort by (timestamp, original_index) so ties preserve
     # input order. ISO-8601 strings sort lex == chronological.
@@ -146,7 +196,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    # Resolve --file relative to repo root when it is a relative path,
+    # so the tool works the same whether invoked from repo root or any
+    # subdirectory. Sibling hygiene scripts share this convention.
     p = Path(args.file)
+    if not p.is_absolute():
+        root = repo_root()
+        if root is not None:
+            p = root / args.file
     if not p.exists():
         print(f"ERROR: file not found: {p}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

Aaron 2026-04-26 caught me using inline `python3 << PYEOF` heredocs for the canonical-order sort each time the one-case Otto-229 override needed applying:

> *\"maybe this should be substraite built in instead of dynamic python\"*
> *\"in python shape should be a queue that we are missing substrate primitives\"*

Two related substantive claims, both load-bearing.

## (1) The specific fix

`tools/hygiene/sort-tick-history-canonical.py` — proper Python tool replacing the recurring inline heredocs:

- argparse, type-hinted, --dry-run mode, exit codes
- Idempotent: running on already-sorted file is no-op
- Composes with existing `tools/hygiene/check-tick-history-order.sh` (the detection; this is the fix)
- Same architectural shape as `check-no-conflict-markers.sh` + `check-tick-history-order.sh`

Applied once on this branch's tick-history.md: 5 duplicates removed, 120 → 115 unique rows, check passes cleanly.

## (2) The meta-principle

**Recurring dynamic Python is a signal that a substrate primitive is missing.**

When the same operation gets written dynamically more than once, the shape of \"do this again\" is itself a queue of absent tools waiting to be built. The substrate isn't just code — it's the queue of recognizable patterns we keep doing, made explicit as primitives.

Composes with:
- **Otto-341** (mechanism over vigilance — extends to tool-extraction-from-dynamic-pattern)
- **Otto-345** (Linus → git → tools-as-substrate; the same lineage applies one layer down: substrate-tooling)
- **Otto-339** (anywhere-means-anywhere — recurring patterns ARE signal at the meta-layer)

This is itself a discipline-claim worth tracking: future ticks, when I find myself writing the same Python heredoc twice, that's the signal to extract it to `tools/hygiene/`.

## Self-tests

- `python3 tools/hygiene/sort-tick-history-canonical.py --dry-run`: works
- `python3 tools/hygiene/sort-tick-history-canonical.py --help`: documents
- Apply on current state: 5 dupes removed, file canonical
- `check-tick-history-order.sh` post-apply: 0 violations, exit 0

## What this DOES NOT do

- Does NOT auto-run on every commit — committers invoke it explicitly
- Does NOT replace the detection check (`check-tick-history-order.sh`) — they're paired (detect + fix)
- Does NOT itself rewrite history — the `sort_canonical()` function preserves all unique row content; only reorders + dedupes

## Composes with

- `tools/hygiene/check-tick-history-order.sh` (paired detection check)
- `tools/hygiene/check-no-conflict-markers.sh` (sibling architectural pattern)
- Otto-229 (append-only tick-history; one-case override authorized for canonical-order preservation since git history retains prior state)
- Otto-341 (mechanism over vigilance)
- Otto-345 (tools-as-substrate inheritance from Linus → git lineage)

## Test plan

- [ ] Tool lands in `tools/hygiene/`
- [ ] Tick-history canonical-order check passes on this branch (verified)
- [ ] No regression in existing CI lints

🤖 Generated with [Claude Code](https://claude.com/claude-code)