### PR TITLE
feat(check-archive-header-section33): validate Operational-status enum value (Codex P2 follow-up)

### DIFF
--- a/tools/hygiene/check-archive-header-section33.sh
+++ b/tools/hygiene/check-archive-header-section33.sh
@@ -126,10 +126,34 @@ while IFS= read -r -d '' file; do
     fi
   done
 
-  if [[ ${#missing[@]} -gt 0 ]]; then
+  # Operational-status VALUE validation per GOVERNANCE.md §33 lines
+  # 777-780: enum is strict — `research-grade` or `operational`,
+  # nothing else. Free-form values (e.g. `research-grade specification
+  # with implementation-ready type signatures...`) violate the spec
+  # and would fail downstream tooling that parses this field.
+  #
+  # Codex P2 finding (PR #572 review): catch the value-discipline at
+  # lint-time, not only label-presence.
+  bad_value=""
+  if echo "$header_region" | grep -q '^Operational status:'; then
+    op_line=$(echo "$header_region" | grep -m1 '^Operational status:')
+    # Strict-enum regex: anchored to start, ends after the enum token.
+    # Trailing whitespace tolerated (markdownlint may strip it
+    # anyway).
+    if ! echo "$op_line" | grep -qE '^Operational status: (research-grade|operational)\s*$'; then
+      bad_value="$op_line"
+    fi
+  fi
+
+  if [[ ${#missing[@]} -gt 0 || -n "$bad_value" ]]; then
     violations=$((violations + 1))
     violation_files+=("$file")
-    echo "VIOLATION: ${file#"$REPO_ROOT/"} missing §33 labels: ${missing[*]}" >&2
+    if [[ ${#missing[@]} -gt 0 ]]; then
+      echo "VIOLATION: ${file#"$REPO_ROOT/"} missing §33 labels: ${missing[*]}" >&2
+    fi
+    if [[ -n "$bad_value" ]]; then
+      echo "VIOLATION: ${file#"$REPO_ROOT/"} Operational-status value not enum-strict (must be 'research-grade' or 'operational' alone): ${bad_value}" >&2
+    fi
   fi
 done < <(find "$RESEARCH_DIR" -type f -name '*.md' -print0)
 

--- a/tools/hygiene/check-archive-header-section33.sh
+++ b/tools/hygiene/check-archive-header-section33.sh
@@ -121,12 +121,16 @@ while IFS= read -r -d '' file; do
   header_region=$(head -20 "$file")
   missing=()
   for label in "${required_labels[@]}"; do
-    if ! echo "$header_region" | grep -qF "$label"; then
+    # Anchor label search to start-of-line. The labels are positional
+    # — they should be at start-of-line, not buried mid-line. A fixed-
+    # string search would accept `- Operational status:` (mid-list-item)
+    # which is structurally wrong (Copilot P1 finding: PR #575 review).
+    if ! echo "$header_region" | grep -qE "^$label"; then
       missing+=("$label")
     fi
   done
 
-  # Operational-status VALUE validation per GOVERNANCE.md §33 lines
+  # Operational status VALUE validation per GOVERNANCE.md §33 lines
   # 777-780: enum is strict — `research-grade` or `operational`,
   # nothing else. Free-form values (e.g. `research-grade specification
   # with implementation-ready type signatures...`) violate the spec
@@ -135,12 +139,13 @@ while IFS= read -r -d '' file; do
   # Codex P2 finding (PR #572 review): catch the value-discipline at
   # lint-time, not only label-presence.
   bad_value=""
-  if echo "$header_region" | grep -q '^Operational status:'; then
-    op_line=$(echo "$header_region" | grep -m1 '^Operational status:')
-    # Strict-enum regex: anchored to start, ends after the enum token.
-    # Trailing whitespace tolerated (markdownlint may strip it
-    # anyway).
-    if ! echo "$op_line" | grep -qE '^Operational status: (research-grade|operational)\s*$'; then
+  if echo "$header_region" | grep -qE '^Operational status:'; then
+    op_line=$(echo "$header_region" | grep -m1 -E '^Operational status:')
+    # Strict-enum regex anchored to start AND end. Use POSIX ERE
+    # character class [[:space:]]* — `\s` is NOT POSIX ERE; with
+    # `grep -E` `\s` matches a literal `s`, not whitespace (Copilot
+    # P0 finding: PR #575 review).
+    if ! echo "$op_line" | grep -qE '^Operational status: (research-grade|operational)[[:space:]]*$'; then
       bad_value="$op_line"
     fi
   fi
@@ -152,7 +157,7 @@ while IFS= read -r -d '' file; do
       echo "VIOLATION: ${file#"$REPO_ROOT/"} missing §33 labels: ${missing[*]}" >&2
     fi
     if [[ -n "$bad_value" ]]; then
-      echo "VIOLATION: ${file#"$REPO_ROOT/"} Operational-status value not enum-strict (must be 'research-grade' or 'operational' alone): ${bad_value}" >&2
+      echo "VIOLATION: ${file#"$REPO_ROOT/"} 'Operational status:' value not enum-strict (must be 'research-grade' or 'operational' alone): ${bad_value}" >&2
     fi
   fi
 done < <(find "$RESEARCH_DIR" -type f -name '*.md' -print0)


### PR DESCRIPTION
## Summary

Tightens the §33 lint to validate Operational-status **value** (not just label presence), per GOVERNANCE.md §33 lines 777-780 strict enum spec: `research-grade` or `operational`, nothing else.

Codex caught this discipline manually across the PR #572 review chain — every iteration of the lint-tool's user-side fixes had a different free-form Operational-status value (free-form → period+elaboration → strict-enum-only). Per Otto-346, recurring review-finding → substrate primitive; this PR enforces the value-discipline at lint-time.

## What this adds

- Per-file Operational-status value check on the line matching `^Operational status:`
- Strict regex: `^Operational status: (research-grade|operational)\s*$`
- Trailing whitespace tolerated (markdownlint may strip)
- Free-form, period+elaboration, bold-styling, etc. all flagged

## Two independent failure modes

Per-file: violation increments **once** even if both label-missing AND value-bad. Both diagnostic lines emit when both fail.

```text
VIOLATION: foo.md missing §33 labels: Non-fusion disclaimer:
VIOLATION: foo.md Operational-status value not enum-strict (must be 'research-grade' or 'operational' alone): Operational status: research-grade. Specification.
```

## Acceptance criterion (now codified)

```text
^Operational status: (research-grade|operational)\s*$
```

## Smoke-test

- 12 unique files flagged (was 12 with label-only check)
- 6 of the 12 docs that had bold-stripped labels via #573 ALSO have free-form Operational-status values; this PR catches both gaps
- Regex correctly accepts `research-grade` and `operational` and rejects `research-grade.`

## Composition

- **PR #572** review chain: established the strict-enum discipline via iterative Codex review
- **Otto-346**: recurring inline pattern → substrate primitive
- **Otto-341**: mechanism over vigilance
- **B-0036**: already noted this as a Test Plan follow-up in the existing backlog row

## Test plan

- [x] Smoke-test on main shows 12 unique files violating (12 missing-label + 6 enum-value-bad)
- [x] Regex accepts `operational`, accepts `research-grade`, rejects `research-grade.`
- [x] Shellcheck clean
- [x] Exit code 1 on any violation
- [ ] Future: extend to validate `Scope:` / `Attribution:` / `Non-fusion disclaimer:` field structure (smaller-leverage; deferred)