### PR TITLE
backfill(B-0036 partial-5): bold-strip + enum-strict on aminata-threat-model-5th-ferry doc

### DIFF
--- a/docs/research/aminata-threat-model-5th-ferry-governance-edits-2026-04-23.md
+++ b/docs/research/aminata-threat-model-5th-ferry-governance-edits-2026-04-23.md
@@ -1,21 +1,19 @@
 # Aminata — Red-Team Review of 5th-Ferry Governance Edits
 
-**Scope:** adversarial review of four proposed governance /
+Scope: adversarial review of four proposed governance /
 doctrine edits from Amara's 5th courier ferry (2026-04-23).
 Research and cross-review artifact only; advisory input to
 Aaron's signoff decision, not a gate.
 
-**Attribution:** findings authored by Aminata (threat-model-
+Attribution: findings authored by Aminata (threat-model-
 critic persona, Claude Code, model `claude-opus-4-7`). Source
 diffs authored by Amara (external AI maintainer) and ferried
 by the human maintainer. Speaker labels preserved; no
 paraphrase of source.
 
-**Operational status:** research-grade. Does not become
-operational policy absent a separate governed change landing
-under GOVERNANCE.md §26 research-doc-lifecycle.
+Operational status: research-grade
 
-**Non-fusion disclaimer:** agreement, shared vocabulary, or
+Non-fusion disclaimer: agreement, shared vocabulary, or
 concordant conclusions between Aminata and Amara on these
 diffs does not imply shared identity, merged agency,
 consciousness, or personhood. Both are models operating in


### PR DESCRIPTION
## Summary

Newly-flagged after PR #575's anchored-label fix landed. This doc had all 4 §33 labels in **bold-styled** form (`**Scope:**` etc.). The pre-#575 fixed-string search accepted bold-styled (via substring match); the post-#575 anchored ERE search correctly rejects them.

## Fix

Same shape as #573 (bold-strip) + #576 (enum-strict):

- Stripped bold from all 4 labels in lines 1-30
- Normalized Operational-status to enum-only (`research-grade`)

## Lint progression

- Lint count was 10 on main after #575 + #576 landed (this doc was caught by #575's anchored-match strengthening)
- After this PR: 9
- Once #577 also lands: 3 (calibration-tension cases blake3 / oracle-scoring / provenance)

## Composition

- **PR #573** (Shape A bold-strip) + **PR #576** (Shape A enum-strict): same fix-shape applied here
- **PR #575** (anchored label): the fix that surfaced this doc as a violation
- **PR #577** (Shape B full-prepend): in flight; will reduce lint to 3 after merge

## Test plan

- [x] All 4 labels now in literal-form (no bold)
- [x] Operational status now enum-strict (`research-grade`)
- [x] Lint no longer flags this doc
- [x] No content loss beyond bold-styling and Op-status elaboration