### PR TITLE
docs(adr): Otto-283 reflection — partial-migration finding on scope-vs-tags (task #270)

### DIFF
--- a/docs/DECISIONS/2026-04-22-backlog-per-row-file-restructure.md
+++ b/docs/DECISIONS/2026-04-22-backlog-per-row-file-restructure.md
@@ -390,10 +390,21 @@ discipline fails without this restructure.
 
    **Partial-migration revisit (2026-04-26, ~36 of ~350 rows
    migrated):** The current per-row corpus has **240 distinct
-   tag values** across 36 rows — well past the falsification
-   threshold of 12 distinct scope values that Otto-283 task
-   #270 set as a signal to add the `scope:` field. However,
-   the scope-like axis IS implicit in tag prefixes
+   tag values** across 36 rows. **Trigger-formulation
+   correction (Codex P2 catch):** the original task #270
+   trigger "tag noise grows past ~12 distinct scope values"
+   was malformed — a `scope: factory | zeta | shared` enum
+   only permits 3 values, so 12 distinct scope values can
+   never fire under the proposed schema. The intended
+   measurement was **tag-prefix clusters acting AS scope**
+   (the implicit scope-like axis already in use). Restated:
+   if the tag corpus develops more than ~8 distinct
+   scope-like prefix clusters, that's the signal to add a
+   first-class `scope:` field. Currently observed: ~6
+   clusters (`factory-*` / `aurora-*` / `alignment-*` /
+   `substrate-*` / `hygiene-*` / `tooling-*`) — under
+   threshold, but trending up. The scope-like axis IS
+   implicit in tag prefixes
    (`factory-as-superfluid` / `factory-discipline` /
    `factory-maintenance` cluster, `aurora` / `aurora-ksk`
    cluster, `alignment` / `alignment-foundation` /
@@ -414,15 +425,20 @@ discipline fails without this restructure.
    dashboard surface needs scope-as-coarse-filter, and (b)
    whether the ~12-tag threshold meaningfully predicts
    needing a separate field — at 240 tags, the threshold
-   may have been off by an order of magnitude (tag-corpus
-   naturally grows with row count; 240 tags / 36 rows = ~6.7
-   tags-per-row; if Phase 2 brings 350 rows × 6.7 = ~2300
-   tag-mentions but distinct count likely plateaus around
-   400-500 because new rows reuse existing tags). Falsification
-   #1 may need recalibration to "distinct scope-like prefix
-   clusters past 8" (e.g., factory / zeta / aurora /
-   alignment / substrate / hygiene / governance / tooling)
-   rather than raw tag count.
+   may have been off by an order of magnitude. **Math-correctness
+   note (Copilot P1 catch):** my prior draft conflated
+   "distinct tag values" (union; what 240 measures) with
+   "average tags-per-row" (mentions ÷ rows) — different metrics.
+   240 is the distinct-union count; average tags-per-row would
+   require counting all tag mentions (independent measurement),
+   not extrapolating from the union. The 350-row extrapolation
+   "350 × 6.7 = 2300 tag-mentions" was unsound and is removed;
+   the meaningful prediction is just that distinct-union
+   plateaus as Phase 2 lands more rows, not a specific number.
+   Tag-corpus grows with row count, but new rows largely reuse
+   existing tags. Falsification #1 recalibrates to "distinct
+   scope-like prefix clusters past 8" — currently 6 clusters,
+   under threshold.
 
    **Action:** none this round. Phase 2 bulk migration is
    the gating event; reflection completes there. Per

--- a/docs/DECISIONS/2026-04-22-backlog-per-row-file-restructure.md
+++ b/docs/DECISIONS/2026-04-22-backlog-per-row-file-restructure.md
@@ -387,6 +387,48 @@ discipline fails without this restructure.
    If we want it, file a Phase 1b directive to extend the
    parser; otherwise the existing `tags:` array can carry
    `scope-factory` / `scope-zeta` tag values.
+
+   **Partial-migration revisit (2026-04-26, ~36 of ~350 rows
+   migrated):** The current per-row corpus has **240 distinct
+   tag values** across 36 rows — well past the falsification
+   threshold of 12 distinct scope values that Otto-283 task
+   #270 set as a signal to add the `scope:` field. However,
+   the scope-like axis IS implicit in tag prefixes
+   (`factory-as-superfluid` / `factory-discipline` /
+   `factory-maintenance` cluster, `aurora` / `aurora-ksk`
+   cluster, `alignment` / `alignment-foundation` /
+   `alignment-substrate` cluster, `substrate-as-mechanism`
+   / `substrate-as-revenue-surface` / `substrate-poisoning`
+   cluster). The tags-only approach is functioning at
+   partial-migration scale — none of the operational
+   workflows (PR review, BACKLOG-pickup per Aaron's
+   "non-speculative work" rule, hot-file-detector audits)
+   have hit the "factory-vs-zeta scope distinction is
+   load-bearing for a generated dashboard / report"
+   trigger from task #270.
+
+   **Provisional finding:** tags-only approach is **holding**
+   at partial-migration scale. Final reflection deferred
+   until bulk migration completes (Phase 2 ships all ~350
+   rows). At that point: re-check (a) whether any reporting/
+   dashboard surface needs scope-as-coarse-filter, and (b)
+   whether the ~12-tag threshold meaningfully predicts
+   needing a separate field — at 240 tags, the threshold
+   may have been off by an order of magnitude (tag-corpus
+   naturally grows with row count; 240 tags / 36 rows = ~6.7
+   tags-per-row; if Phase 2 brings 350 rows × 6.7 = ~2300
+   tag-mentions but distinct count likely plateaus around
+   400-500 because new rows reuse existing tags). Falsification
+   #1 may need recalibration to "distinct scope-like prefix
+   clusters past 8" (e.g., factory / zeta / aurora /
+   alignment / substrate / hygiene / governance / tooling)
+   rather than raw tag count.
+
+   **Action:** none this round. Phase 2 bulk migration is
+   the gating event; reflection completes there. Per
+   Otto-283 standing directive (`memory/feedback_decide_track_reflect_revisit_then_talk_with_experience_otto_283_2026_04_25.md`):
+   decided, tracked, partially reflected, full revisit when
+   bulk migration ships.
 3. **Concurrent-migration with R45 original intent** — Aaron
    may prefer to land the restructure *and* the reducer-agent
    flip in the same round, trusting the restructure to absorb


### PR DESCRIPTION
## Summary

- Lands the Otto-283 partial-migration reflection on the scope-vs-tags decision in `docs/DECISIONS/2026-04-22-backlog-per-row-file-restructure.md`
- Single-file edit; +42 lines added to the existing "Open questions" section #2

## Findings (~36 of ~350 rows migrated)

- **240 distinct tag values** — well past the falsification-#1 threshold of 12 distinct scope values
- **Scope-like axis IS implicit in tag prefixes** (factory-* / aurora-* / alignment-* / substrate-* clusters)
- **No operational workflow** has hit the "factory-vs-zeta scope distinction is load-bearing for a dashboard/report" trigger
- **Tags-only approach is holding** at this scale

## Provisional finding

Tags-only is functioning. The 12-tag threshold may have been off by an order of magnitude — recommend recalibrating to "distinct scope-like prefix clusters past 8" rather than raw tag count.

Full revisit deferred until Phase 2 bulk migration ships (when all ~350 rows are in per-row files).

## Per Otto-283 standing directive

> "decide, track, reflect, revisit, then talk with experience" — Aaron 2026-04-25

This commit completes the "reflect" step at partial-migration scale; "revisit + talk with experience" gates on bulk migration shipping.

## Test plan

- [x] Existing ADR structure preserved
- [x] New section is additive (Open questions #2 extended, not replaced)
- [x] Composes with standing-directive memory file (cited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)