### PR TITLE
fix(drain-log): #607 — explicit thread count + #625 ref consistency (followup to #628)

### DIFF
--- a/docs/pr-preservation/607-drain-log.md
+++ b/docs/pr-preservation/607-drain-log.md
@@ -4,7 +4,7 @@ PR: <https://github.com/Lucent-Financial-Group/Zeta/pull/607>
 Branch: `tick-history/2026-04-26T13-39Z`
 Outcome class: **CLOSED-NOT-MERGED** (superseded; 2nd-agent verified)
 Drain session: 2026-04-26 (Otto, autonomous-loop continuation)
-Total threads drained: minimal (close-and-reopen happened quickly)
+Total threads drained: 0 (close-and-reopen happened quickly; no review activity beyond CI lint pass)
 Rebase context: closed before review activity beyond CI lint pass.
 
 Per Otto-250 + task #268 backfill. This drain-log composes with
@@ -84,6 +84,6 @@ Two tick-history rows added:
 - Otto-250 PR-reviews-as-training-signals
 - Otto-347 (rule that caught the chain-supersession loss via 2nd-agent)
 - 618-drain-log.md (the consolidated-backfill that absorbed this PR)
-- 625 (the recovery PR that landed 13:38Z + 13:52Z back on main)
+- #625 (the recovery PR that landed 13:38Z + 13:52Z back on main)
 - Otto-348 verify-substrate-exists (the discipline this PR's
   13:38Z row documents)


### PR DESCRIPTION
## Summary

Mechanical follow-up. #628 (607-drain-log) merged at unfixed SHA before my fix commit landed. This PR ships the two Copilot P2 consistency fixes:
1. 'Total threads drained: minimal' → '0' (machine/scan-friendly per sibling drain-logs)
2. '625' → '#625' (consistency with sibling references)

Composes with Otto-348 verify-state-exists discipline — should have checked PR-merged-state before attempting on-branch fixes.