### PR TITLE
sync(acehack→lfg) batch-4: AppContext.BaseDirectory + curl|bash self-contradiction fix (option-c)

### DIFF
--- a/docs/security/SUPPLY-CHAIN-SAFE-PATTERNS.md
+++ b/docs/security/SUPPLY-CHAIN-SAFE-PATTERNS.md
@@ -67,8 +67,8 @@ the manifest plus repository signature verification.
 
 The immutable identifier is *how* we lock a decision, but the
 decision itself is **content review at first pin**. A SHA-256 that
-points at malicious code is still malicious; a hand-verified
-script run `curl | bash`-style after a careful read is safe.
+points at malicious code is still malicious; the protection is
+reading the content before it runs, not the hash on its own.
 
 In this factory, Aaron's standing policy (2026-04-22) is: *"never
 run a script you download without checking it for vulnerability,
@@ -88,8 +88,20 @@ them first."* So the actual author-time protocol is:
    cache of your review. Any bump invalidates the cache and
    forces a re-read.
 
-The delivery mechanism (`curl | bash` vs `curl -o path && bash
-path`) is not the risk. The risk is unvalidated content.
+The risk the protocol targets is **unvalidated content**, and
+the delivery mechanism matters only insofar as it permits or
+prevents validation:
+
+- **At first contact, `curl | bash` is disallowed** — the pipe
+  executes the bytes before any human or lint has read them,
+  which makes step 2 impossible. Use `curl -o path && bash
+  path` (or equivalent split) so the content lands on disk
+  first.
+- **After SHA-256-pinning, `curl <pinned-url> | bash` becomes
+  acceptable** in automation — the pin is the cached review,
+  and the hash is verified before the pipe executes. But the
+  pin must have been earned by the four-step protocol the
+  first time the content was admitted.
 
 ## Third-party-code ingress points
 

--- a/tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs
@@ -26,8 +26,13 @@ open global.Xunit
 
 
 let private repoRoot =
-    let cwd = Directory.GetCurrentDirectory()
-    let mutable dir = DirectoryInfo cwd
+    // Walk up from the test assembly's directory, NOT the process CWD.
+    // xUnit parallelizes test classes, so CWD-mutating tests (e.g.
+    // WitnessDurableBackingStore under-CWD-churn) can race with this
+    // module's static init on macOS and trip the walk-up loop. Fixed
+    // by reading AppContext.BaseDirectory, which is immutable for the
+    // lifetime of the AppDomain.
+    let mutable dir = DirectoryInfo AppContext.BaseDirectory
     while not (isNull dir) && not (File.Exists (Path.Combine(dir.FullName, "Zeta.sln"))) do
         dir <- dir.Parent
     if isNull dir then invalidOp "Could not locate repo root (Zeta.sln)"

--- a/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
@@ -41,9 +41,15 @@ type TlcTestCollection () = class end
 
 
 let private repoRoot =
-    // Walk up from bin/Release/net10.0 to the repo root.
-    let cwd = Directory.GetCurrentDirectory()
-    let mutable dir = DirectoryInfo cwd
+    // Walk up from the test assembly's directory, NOT the process CWD.
+    // xUnit parallelizes test classes, so CWD-mutating tests can race
+    // with this module's static init (observed as
+    // TypeInitializationException on macOS-14 in the Alloy sibling
+    // module). AppContext.BaseDirectory is immutable for the lifetime
+    // of the AppDomain and always points at
+    // `<repo>/tests/Tests.FSharp/bin/Release/net10.0/` under
+    // `dotnet test`, so walking up reliably finds Zeta.sln.
+    let mutable dir = DirectoryInfo AppContext.BaseDirectory
     while not (isNull dir) && not (File.Exists (Path.Combine(dir.FullName, "Zeta.sln"))) do
         dir <- dir.Parent
     if isNull dir then invalidOp "Could not locate repo root (Zeta.sln)"


### PR DESCRIPTION
## Summary

Batch-4 of task #284 AceHack→LFG cherry-pick sync (option-c). Two genuine code/doc fixes that LFG was missing — verified by Otto-347 2nd-agent audit.

## What this PR fixes

**Commit #23 (`17f38fb`)** — repoRoot discovery uses AppContext.BaseDirectory, not CWD
- Affects `tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs` + `Tlc.Runner.Tests.fs`
- Before: `Directory.GetCurrentDirectory()` walk-up — racy because xUnit parallelizes test classes and CWD is process-global mutable state (`WitnessDurableBackingStore` test churns CWD)
- After: `AppContext.BaseDirectory` walk-up — immutable for process lifetime, race-free
- Real CI race-fix; was genuinely missing on LFG (verified)

**Commit #29 (`177a981`)** — SUPPLY-CHAIN-SAFE-PATTERNS curl|bash self-contradiction
- Affects `docs/security/SUPPLY-CHAIN-SAFE-PATTERNS.md`
- Before: doc claimed *"a hand-verified script run \`curl | bash\`-style after a careful read is safe"* — contradicts the doc's own four-step protocol step 1 ("Download to disk, do not pipe")
- After: "At first contact, \`curl | bash\` is disallowed" + post-pin acceptable framing
- Copilot P0 finding; was genuinely missing on LFG (verified)

## Otto-347 2nd-agent verification trail

- 1st-agent audit: classified both as MISSING-LANDS
- 2nd-agent verify: independently confirmed by reading current LFG state of all three files and finding the bugs intact (Directory.GetCurrentDirectory still in tests; curl|bash-after-careful-read still in doc)
- High confidence on both classifications

## Test plan
- [x] Cherry-picked cleanly from AceHack
- [x] AppContext.BaseDirectory in both test files (verified via grep)
- [x] curl|bash self-contradiction line removed; first-contact-disallowed framing added
- [x] markdownlint pass on the docs file
- [x] (CI will verify F# build + tests on push)

## Sync progress

- Batch-1: 17 MISSING-LANDS (#592 merged)
- Batch-2: 23 BACKLOG-row-only commits (#633 merged)
- Batch-3: UPSTREAM-RHYTHM 3-surfaces terminology (#634 in CI)
- **Batch-4: this PR**
- Remaining: batch-5 (Round-44 doc absorbs; 20 docs + 11 SKILL.md), batch-6 (ADR + HUMAN-BACKLOG; 3 commits), reverse sync (LFG→AceHack)