### PR TITLE
sync(acehack→lfg): infra clean-additive batch (5 files including audit script dependency)

### DIFF
--- a/.github/workflows/budget-snapshot-cadence.yml
+++ b/.github/workflows/budget-snapshot-cadence.yml
@@ -71,9 +71,17 @@ on:
 
 permissions:
   # Need contents:write to push the snapshot branch; pull-requests:write
-  # to open the auto-merge PR. No other permissions needed.
+  # to open the snapshot PR; actions:read so snapshot-burn.sh can call
+  # the Actions REST endpoints (/repos/.../actions/runs and
+  # /actions/runs/{id}/timing) to populate burn metrics. Without
+  # actions:read, those API calls 403 silently and snapshot-burn.sh
+  # falls back to empty/zeroed timing data while still writing a
+  # snapshot — producing misleading evidence rather than a hard
+  # failure. With explicit workflow permissions, omitted scopes are
+  # `none`, so actions:read MUST be listed explicitly here.
   contents: write
   pull-requests: write
+  actions: read
 
 concurrency:
   # Only one cadence run at a time. Retriggers queue (rather than

--- a/.github/workflows/budget-snapshot-cadence.yml
+++ b/.github/workflows/budget-snapshot-cadence.yml
@@ -2,11 +2,13 @@ name: budget-snapshot-cadence
 
 # Weekly cadence for evidence-based LFG burn tracking. Runs
 # tools/budget/snapshot-burn.sh, captures the resulting JSONL row,
-# opens a PR (per the AceHack-first UPSTREAM-RHYTHM rhythm) with the
-# snapshot included, and arms auto-merge so the row lands without
-# human intervention. Closes task #297 (cadence half of the
-# evidence-based-budgeting work; tooling was task #285, baseline
-# snapshot was task #287).
+# and opens a PR (per the AceHack-first UPSTREAM-RHYTHM rhythm)
+# with the snapshot included. The PR is left for the next
+# human-or-agent pass through the queue to merge — auto-merge is
+# NOT armed here, see "Auto-merge limitation" section below for
+# why. Closes task #297 (cadence half of the evidence-based-
+# budgeting work; tooling was task #285, baseline snapshot was
+# task #287).
 #
 # Why weekly: docs/budget-history/README.md says "On a cadenced
 # schedule (weekly) — catches drift when no PRs are merging." Weekly
@@ -36,23 +38,24 @@ name: budget-snapshot-cadence
 # `gh auth refresh -s admin:org` the snapshots get richer
 # automatically (Actions billing / Packages / shared-storage).
 #
-# AgencySignature v1 attribution (per the post-ferry-7 convention):
-# this workflow's commits identify themselves as the
-# budget-cadence-workflow agent running on GitHub Actions. The
-# Human-Review-Evidence trailer is "signed-policy" because the
-# cadence is authorized by docs/budget-history/README.md +
-# the maintainer's 2026-04-22 standing direction for evidence-based
-# budgeting.
+# AgencySignature v1 attribution (per the canonical 10-trailer
+# convention documented in tools/hygiene/validate-
+# agencysignature-pr-body.sh): this workflow's commits identify
+# themselves as the budget-cadence-workflow agent running on
+# GitHub Actions. The Human-Review-Evidence trailer is "signed-
+# policy" because the cadence is authorized by docs/budget-
+# history/README.md + the maintainer's 2026-04-22 standing
+# direction for evidence-based budgeting.
 #
-# Auto-merge limitation (Codex review #25 P1): events triggered by
-# secrets.GITHUB_TOKEN do not fire downstream workflow runs (GitHub's
-# anti-infinite-loop guard). That means a PR opened by this workflow
-# would never accumulate the required-status-check runs that
-# auto-merge needs to fire on, and `gh pr merge --auto` would sit
-# in a dead-end. Until a PAT secret is configured, this workflow
-# opens the snapshot PR and leaves it for the next human-or-agent
-# pass through the queue to merge — explicit-no-auto-merge over
-# silent-stall is the operational call.
+# Auto-merge limitation: events triggered by
+# secrets.GITHUB_TOKEN do not fire downstream workflow runs
+# (GitHub's anti-infinite-loop guard). That means a PR opened by
+# this workflow would never accumulate the required-status-check
+# runs that auto-merge needs to fire on, and `gh pr merge --auto`
+# would sit in a dead-end. Until a PAT secret is configured, this
+# workflow opens the snapshot PR and leaves it for the next
+# human-or-agent pass through the queue to merge — explicit-no-
+# auto-merge over silent-stall is the operational call.
 
 on:
   schedule:
@@ -150,10 +153,10 @@ jobs:
 
           # Commit message uses the AgencySignature v1 canonical shape.
           # Trailer block is at the end with strict blank-line discipline
-          # (one blank line before, zero within). Per the four-ferry
-          # consensus: this workflow is a named-agent acting under
-          # signed-policy authorization (the maintainer's 2026-04-22 evidence-
-          # based budgeting direction + docs/budget-history/README.md).
+          # (one blank line before, zero within). This workflow is a
+          # named-agent acting under signed-policy authorization (the
+          # maintainer's 2026-04-22 evidence-based budgeting direction +
+          # docs/budget-history/README.md).
           {
             echo "ops(budget): cadence snapshot $ts — task #297"
             echo
@@ -203,8 +206,8 @@ jobs:
           git push -u origin "$branch"
 
           # Open PR with trailer block in body (Squash-Merge Invariant
-          # per Amara ferry-7 + Grok ferry-16 — no non-trailer text
-          # after the trailer block).
+          # per the canonical 10-trailer convention — no non-trailer
+          # text after the trailer block).
           {
             echo "## Summary"
             echo

--- a/.github/workflows/budget-snapshot-cadence.yml
+++ b/.github/workflows/budget-snapshot-cadence.yml
@@ -42,10 +42,15 @@ name: budget-snapshot-cadence
 # convention documented in tools/hygiene/validate-
 # agencysignature-pr-body.sh): this workflow's commits identify
 # themselves as the budget-cadence-workflow agent running on
-# GitHub Actions. The Human-Review-Evidence trailer is "signed-
-# policy" because the cadence is authorized by docs/budget-
-# history/README.md + the maintainer's 2026-04-22 standing
-# direction for evidence-based budgeting.
+# GitHub Actions. The Human-Review-Evidence trailer is "none"
+# because the validator's consistency rule (Amara ferry-5 evidence-
+# pointer rule) requires Evidence="none" whenever Human-Review is
+# not "explicit". The signed-policy authorization for the cadence
+# itself (docs/budget-history/README.md + the maintainer's
+# 2026-04-22 standing direction for evidence-based budgeting) is
+# documented in the commit body prose, not the per-run trailer
+# fields — per-run trailers describe the per-run state, not the
+# deployment-time authorization.
 #
 # Auto-merge limitation: events triggered by
 # secrets.GITHUB_TOKEN do not fire downstream workflow runs
@@ -116,7 +121,11 @@ jobs:
       - name: Run budget snapshot
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NOTE_INPUT: ${{ inputs.note }}
+          # `inputs.note` is only defined for workflow_dispatch / reusable
+          # workflows; on schedule runs that context is undefined and the
+          # expression would fail evaluation. `github.event.inputs.note` is
+          # safe across both trigger types (returns empty string on schedule).
+          NOTE_INPUT: ${{ github.event.inputs.note || '' }}
           RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -172,7 +181,8 @@ jobs:
             echo "- Weekly cadence per docs/budget-history/README.md"
             echo "  ('catches drift when no PRs are merging')."
             echo "- Closes task #297 by automating what task #287"
-            echo "  required a maintainer or Otto to do manually."
+            echo "  previously required a human maintainer or agent to"
+            echo "  trigger manually."
             echo
             echo "What:"
             echo "- One JSONL row appended to"
@@ -205,7 +215,7 @@ jobs:
             echo "Credential-Identity: github-actions[bot]"
             echo "Credential-Mode: dedicated-agent"
             echo "Human-Review: not-implied-by-credential"
-            echo "Human-Review-Evidence: signed-policy"
+            echo "Human-Review-Evidence: none"
             echo "Action-Mode: autonomous-fail-open"
             echo "Task: Otto-297"
             echo "Co-authored-by: Otto <noreply@anthropic.com>"
@@ -233,7 +243,9 @@ jobs:
             echo "Per docs/budget-history/README.md: weekly cadence"
             echo "catches drift when no PRs are merging. Authorized by"
             echo "the human maintainer's 2026-04-22 evidence-based"
-            echo "budgeting direction (Human-Review-Evidence: signed-policy)."
+            echo "budgeting direction; per-run trailer fields use"
+            echo "Human-Review-Evidence=none per the validator consistency"
+            echo "rule, since per-run review is not explicit."
             echo
             echo "Agency-Signature-Version: 1"
             echo "Agent: budget-cadence-workflow"
@@ -242,7 +254,7 @@ jobs:
             echo "Credential-Identity: github-actions[bot]"
             echo "Credential-Mode: dedicated-agent"
             echo "Human-Review: not-implied-by-credential"
-            echo "Human-Review-Evidence: signed-policy"
+            echo "Human-Review-Evidence: none"
             echo "Action-Mode: autonomous-fail-open"
             echo "Task: Otto-297"
             echo "Co-authored-by: Otto <noreply@anthropic.com>"

--- a/.github/workflows/budget-snapshot-cadence.yml
+++ b/.github/workflows/budget-snapshot-cadence.yml
@@ -240,12 +240,20 @@ jobs:
             echo "Co-authored-by: Otto <noreply@anthropic.com>"
           } > /tmp/pr-body.md
 
+          # NOTE: --label "agent-otto" was previously added here for
+          # host-native attribution but the labels API is part of the
+          # Issues API. Adding it would require widening permissions to
+          # `issues: write`, which this workflow doesn't currently grant
+          # (and shouldn't widen casually for a single host-native nice-
+          # to-have when the AgencySignature commit-trailer-block already
+          # covers the attribution at the git-native layer). Labeling is
+          # deferred to a maintainer / human pass through the queue, or
+          # to a future workflow with an explicit `issues: write` scope.
           gh pr create \
             --base main \
             --head "$branch" \
             --title "ops(budget): cadence snapshot $ts (task #297)" \
-            --body-file /tmp/pr-body.md \
-            --label "agent-otto"
+            --body-file /tmp/pr-body.md
 
           # Intentional: no `gh pr merge --auto` here. See header
           # comment §"Auto-merge limitation" — GITHUB_TOKEN-created

--- a/.github/workflows/memory-index-duplicate-lint.yml
+++ b/.github/workflows/memory-index-duplicate-lint.yml
@@ -1,11 +1,10 @@
 name: memory-index-duplicate-lint
 
-# Detects duplicate link targets in `memory/MEMORY.md` —
-# Amara 2026-04-23 decision-proxy + technical review action
-# item #2 (PR #219 absorb). An index with duplicate entries
-# is a discoverability defect: fresh sessions can't tell
-# which entry is authoritative; the newest-first ordering
-# invariant breaks when the same file appears twice.
+# Detects duplicate link targets in `memory/MEMORY.md`. An index
+# with duplicate entries is a discoverability defect: fresh
+# sessions can't tell which entry is authoritative; the
+# newest-first ordering invariant breaks when the same file
+# appears twice.
 #
 # Companion to `.github/workflows/memory-index-integrity.yml`
 # (the same-commit-pairing check for memory/ changes +
@@ -21,8 +20,6 @@ name: memory-index-duplicate-lint
 #
 # See:
 #   - tools/hygiene/audit-memory-index-duplicates.sh (the tool)
-#   - docs/aurora/2026-04-23-amara-decision-proxy-technical-
-#     review.md (ferry with the proposal)
 
 on:
   pull_request:

--- a/.github/workflows/memory-index-duplicate-lint.yml
+++ b/.github/workflows/memory-index-duplicate-lint.yml
@@ -56,4 +56,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          tools/hygiene/audit-memory-index-duplicates.sh --enforce
+          # Run in warn-only mode (no --enforce). LFG main has 8+
+          # pre-existing duplicates in memory/MEMORY.md that need
+          # cleanup via a separate dedup PR before this lint can
+          # safely promote to --enforce. Keep the lint visible so
+          # reviewers see the duplicate count, but don't block PR
+          # merges on the data-cleanup-not-yet-done state.
+          # TODO: promote to --enforce after LFG memory/MEMORY.md
+          # dedup PR lands.
+          tools/hygiene/audit-memory-index-duplicates.sh || {
+            rc=$?
+            echo "::warning::duplicate-link lint reported issues (warn-only mode); see output above"
+            exit 0
+          }

--- a/.github/workflows/memory-index-duplicate-lint.yml
+++ b/.github/workflows/memory-index-duplicate-lint.yml
@@ -56,16 +56,4 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Run in warn-only mode (no --enforce). LFG main has 8+
-          # pre-existing duplicates in memory/MEMORY.md that need
-          # cleanup via a separate dedup PR before this lint can
-          # safely promote to --enforce. Keep the lint visible so
-          # reviewers see the duplicate count, but don't block PR
-          # merges on the data-cleanup-not-yet-done state.
-          # TODO: promote to --enforce after LFG memory/MEMORY.md
-          # dedup PR lands.
-          tools/hygiene/audit-memory-index-duplicates.sh || {
-            rc=$?
-            echo "::warning::duplicate-link lint reported issues (warn-only mode); see output above"
-            exit 0
-          }
+          tools/hygiene/audit-memory-index-duplicates.sh --enforce

--- a/tools/hygiene/audit-memory-index-duplicates.sh
+++ b/tools/hygiene/audit-memory-index-duplicates.sh
@@ -2,13 +2,11 @@
 # tools/hygiene/audit-memory-index-duplicates.sh
 #
 # Detects duplicate link targets (same `.md` file referenced
-# more than once) in a MEMORY.md-shaped index. Amara's 2026-
-# 04-23 decision-proxy + technical review (PR #219) flagged
-# the pattern: an index with duplicate entries is a
-# discoverability defect — fresh sessions can't tell which
-# entry is authoritative; external reviewers miss the newest-
-# first ordering because duplicates break the implicit
-# "one row per memory" invariant.
+# more than once) in a MEMORY.md-shaped index. An index with
+# duplicate entries is a discoverability defect — fresh
+# sessions can't tell which entry is authoritative; external
+# reviewers miss the newest-first ordering because duplicates
+# break the implicit "one row per memory" invariant.
 #
 # Companion to:
 #   - `.github/workflows/memory-index-integrity.yml` — checks
@@ -16,7 +14,8 @@
 #     This tool checks that MEMORY.md doesn't list the same
 #     file twice.
 #   - FACTORY-HYGIENE row #11 (MEMORY.md cap enforcement) —
-#     this tool is the extension Amara named.
+#     this tool extends that cap discipline to also enforce
+#     no-duplicate-entries.
 #
 # Detection strategy:
 #   Line-grep the target file for `](filename.md)` link

--- a/tools/setup/common/curl-fetch.sh
+++ b/tools/setup/common/curl-fetch.sh
@@ -149,10 +149,38 @@
 if [[ -z "${_CURL_FETCH_LOADED:-}" ]]; then
 _CURL_FETCH_LOADED=1
 
+# Feature-detect --retry-all-errors support. The flag was added in
+# curl 7.71.0 (2020-06-24); older OS-provided curl builds (notably
+# pre-2020 LTS distros, some embedded environments, some older macOS
+# system curl) reject it as an unknown option and fail the entire
+# call. This helper is sourced from install.sh BEFORE any toolchain
+# manager has put a newer curl on PATH, so the OS-provided curl IS
+# what runs first. Memoised so the `curl --help` probe runs once per
+# shell, not once per call.
+_curl_fetch_supports_retry_all_errors() {
+  if [[ -z "${_CURL_FETCH_SUPPORTS_RETRY_ALL_ERRORS:-}" ]]; then
+    if curl --help all 2>/dev/null | grep -Fq -- '--retry-all-errors'; then
+      _CURL_FETCH_SUPPORTS_RETRY_ALL_ERRORS=1
+    else
+      _CURL_FETCH_SUPPORTS_RETRY_ALL_ERRORS=0
+    fi
+  fi
+  [[ "${_CURL_FETCH_SUPPORTS_RETRY_ALL_ERRORS}" == "1" ]]
+}
+
 # File-output variant — safe with --retry-all-errors because
-# curl restarts the output file from scratch on each retry.
+# curl restarts the output file from scratch on each retry. Falls
+# back to plain --retry / --retry-delay on older curl builds that
+# don't support --retry-all-errors (curl < 7.71.0). The fallback
+# loses the "retry on HTTP 5xx without Retry-After" coverage but
+# keeps the connect/DNS/408/429/5xx-with-Retry-After retry behaviour
+# that bare --retry already provides.
 curl_fetch() {
-  curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "$@"
+  local -a retry_args=(--retry 5 --retry-delay 2)
+  if _curl_fetch_supports_retry_all_errors; then
+    retry_args+=(--retry-all-errors)
+  fi
+  curl -fsSL "${retry_args[@]}" "$@"
 }
 
 # Streamed variant — NO --retry, NO --retry-all-errors.

--- a/tools/setup/common/curl-fetch.sh
+++ b/tools/setup/common/curl-fetch.sh
@@ -175,10 +175,9 @@ curl_fetch() {
 #
 # The proper structural fix — download to a temp file with
 # `curl_fetch` (file-output), checksum-verify if available,
-# then `bash <tempfile` — is tracked as a backlog item under
-# `docs/backlog/P1/B-0063-streamed-installer-download-to-temp-
-# pattern-codex-p0-pr-75.md`. Until that lands, this variant
-# is fail-fast-no-retry by design.
+# then `bash <tempfile` — is tracked as backlog item B-0063
+# (streamed-installer download-to-temp pattern). Until that
+# lands, this variant is fail-fast-no-retry by design.
 curl_fetch_stream() {
   curl -fsSL "$@"
 }

--- a/tools/setup/common/curl-fetch.sh
+++ b/tools/setup/common/curl-fetch.sh
@@ -55,8 +55,8 @@
 #
 #   curl_fetch_stream — for streamed-to-shell installers
 #                       (`curl ... | sh`, `bash -c "$(curl
-#                       ...)"`). NO --retry. Codex P0 review
-#                       on PR #75 confirmed: even bare
+#                       ...)"`). NO --retry. Reviewers
+#                       confirmed: even bare
 #                       `--retry` (without `--retry-all-
 #                       errors`) can retry after bytes have
 #                       already been written to stdout, and
@@ -86,9 +86,11 @@
 #
 # RETRY POLICY (rationale)
 # ========================
-#   --retry 5            — five attempts total. Empirically
-#                          covers the upstream 5xx blips
-#                          this install path has hit.
+#   --retry 5            — up to 5 retries (6 total attempts
+#                          including the initial try, per
+#                          curl(1)). Empirically covers the
+#                          upstream 5xx blips this install
+#                          path has hit.
 #   --retry-delay 2      — 2-second base delay between retries.
 #   --retry-all-errors   — (file-output only) retry on ALL
 #                          transient errors including HTTP
@@ -136,8 +138,9 @@
 # would silently skip BOTH definitions if the caller
 # environment already had an unrelated `curl_fetch`
 # function, leaving `curl_fetch_stream` undefined and
-# breaking the streamed callers (`linux.sh` / `macos.sh`
-# / `elan.sh`) at runtime with `curl_fetch_stream:
+# breaking the streamed callers (`tools/setup/linux.sh` /
+# `tools/setup/macos.sh` / `tools/setup/common/elan.sh`)
+# at runtime with `curl_fetch_stream:
 # command not found`. Sentinel-based guarding ties the
 # load decision to "did this file load?" instead of "does
 # that name exist?" — collisions in the caller environment
@@ -154,7 +157,7 @@ curl_fetch() {
 
 # Streamed variant — NO --retry, NO --retry-all-errors.
 #
-# Codex P0 review on PR #75 surfaced that even bare `curl
+# Reviewers surfaced that even bare `curl
 # --retry` (without --retry-all-errors) can still retry after
 # bytes have been written to stdout: the connect error happens
 # mid-transfer, curl resets the input but the bytes already

--- a/tools/setup/macos.sh
+++ b/tools/setup/macos.sh
@@ -23,6 +23,10 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 SETUP_DIR="$REPO_ROOT/tools/setup"
 
+# shellcheck source=common/curl-fetch.sh
+# shellcheck disable=SC1091  # CI runs without -x; source path verified in tools/setup/common/curl-fetch.sh
+source "$SETUP_DIR/common/curl-fetch.sh"
+
 # ── 1. Xcode Command Line Tools ─────────────────────────────────────
 if ! xcode-select -p >/dev/null 2>&1; then
   echo "↓ installing Xcode Command Line Tools (non-interactive)..."
@@ -37,7 +41,24 @@ echo "✓ Xcode CLT at $(xcode-select -p 2>/dev/null || echo 'pending user confi
 # ── 2. Homebrew ─────────────────────────────────────────────────────
 if ! command -v brew >/dev/null 2>&1; then
   echo "↓ installing Homebrew..."
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  # Capture to a named variable + check exit code explicitly.
+  # bash's `set -e` is not reliably triggered by a failing
+  # command substitution without `inherit_errexit`; codex P0
+  # review on PR #75 flagged this. Pattern: capture, check
+  # length, exec only on non-empty + curl-success. The proper
+  # fix (download-to-temp + checksum-verify) is tracked as
+  # B-0063; this is a small-improvement-not-structurally-safe
+  # form acknowledged in tools/setup/common/curl-fetch.sh
+  # COMMAND-SUBSTITUTION + SET-E section.
+  if ! HOMEBREW_INSTALLER="$(curl_fetch_stream https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
+    echo "error: failed to fetch Homebrew installer; check network and re-run install.sh" >&2
+    exit 1
+  fi
+  if [ -z "$HOMEBREW_INSTALLER" ]; then
+    echo "error: Homebrew installer was empty; refusing to exec" >&2
+    exit 1
+  fi
+  /bin/bash -c "$HOMEBREW_INSTALLER"
   # Ensure brew is on PATH for the remainder of this script run.
   if [ -x /opt/homebrew/bin/brew ]; then
     eval "$(/opt/homebrew/bin/brew shellenv)"

--- a/tools/setup/macos.sh
+++ b/tools/setup/macos.sh
@@ -23,16 +23,21 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 SETUP_DIR="$REPO_ROOT/tools/setup"
 
-# shellcheck source=common/curl-fetch.sh
-# shellcheck disable=SC1091  # CI runs without -x; source path verified in tools/setup/common/curl-fetch.sh
+# shellcheck source=tools/setup/common/curl-fetch.sh
+# shellcheck disable=SC1091  # SC1091 fires because the source path is
+# constructed via $SETUP_DIR (a runtime variable) rather than a
+# literal; shellcheck cannot statically resolve it. The source=
+# directive above tells shellcheck where the file actually lives so
+# it follows the include for static analysis. The SC1091 disable is
+# the matching runtime-side suppression.
 source "$SETUP_DIR/common/curl-fetch.sh"
 
 # ── 1. Xcode Command Line Tools ─────────────────────────────────────
 if ! xcode-select -p >/dev/null 2>&1; then
   echo "↓ installing Xcode Command Line Tools (non-interactive)..."
   # Apple still shows one confirmation prompt on this path; we accept
-  # that rather than fail fast per Aaron's "just install everything"
-  # round-29 call.
+  # that rather than fail fast per the maintainer's standing
+  # "just install everything" framing for first-run setup.
   xcode-select --install || true
   echo "  If a GUI prompt appeared, complete the install and re-run this script."
 fi
@@ -43,13 +48,13 @@ if ! command -v brew >/dev/null 2>&1; then
   echo "↓ installing Homebrew..."
   # Capture to a named variable + check exit code explicitly.
   # bash's `set -e` is not reliably triggered by a failing
-  # command substitution without `inherit_errexit`; codex P0
-  # review on PR #75 flagged this. Pattern: capture, check
-  # length, exec only on non-empty + curl-success. The proper
-  # fix (download-to-temp + checksum-verify) is tracked as
-  # B-0063; this is a small-improvement-not-structurally-safe
-  # form acknowledged in tools/setup/common/curl-fetch.sh
-  # COMMAND-SUBSTITUTION + SET-E section.
+  # command substitution without `inherit_errexit`. Pattern:
+  # capture, check length, exec only on non-empty + curl-
+  # success. The proper fix (download-to-temp + checksum-
+  # verify) is tracked as B-0063; this is a small-improvement-
+  # not-structurally-safe form acknowledged in
+  # tools/setup/common/curl-fetch.sh COMMAND-SUBSTITUTION +
+  # SET-E section.
   if ! HOMEBREW_INSTALLER="$(curl_fetch_stream https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
     echo "error: failed to fetch Homebrew installer; check network and re-run install.sh" >&2
     exit 1


### PR DESCRIPTION
## Summary

First measurable forward-sync step toward the 0/0/0 invariant. This batch is the **safe subset** of today's infra divergence: 5 files where AceHack/main has changes since the last sync but LFG/main has zero LFG-only changes since (no 3-way merge needed).

## What

| File | Status | What |
|------|--------|------|
| `.github/workflows/budget-snapshot-cadence.yml` | NEW | Weekly budget cadence (task #297) |
| `.github/workflows/memory-index-duplicate-lint.yml` | NEW | Lint for memory/MEMORY.md duplicate-link detection |
| `tools/hygiene/audit-memory-index-duplicates.sh` | NEW | Audit script dependency for the duplicate-link lint workflow above |
| `tools/setup/common/curl-fetch.sh` | NEW | Sourceable curl-with-retry helper (file-output + streamed two-function split per the curl-from-shell-pipe partial-replay caveat) |
| `tools/setup/macos.sh` | MODIFIED | Use curl_fetch_stream for Homebrew install with two-gate empty-string + exit-status defensive check |

Total: **+540 / -17 lines** (after dedup of 14 duplicate MEMORY.md entries that the new lint caught on initial CI run), no overwrites of LFG-only content.

## Why now

Per the human maintainer's 2026-04-28 framing *"the numbers are just growing can you make them go down"* — corrective action for the manufactured-patience-on-forward-sync pattern (Otto-275-FOREVER: knowing-rule != applying-rule). The ADR for option-c cherry-pick-with-rewrites landed today via PR #31; this PR applies it on the smallest safe scope.

## What's deferred

The other 9 infra files (`gate.yml`, `codeql.yml`, `mise.toml`, `.markdownlint-cli2.jsonc`, `linux.sh`, `elan.sh`, `verifiers.sh`, `resume-diff.yml`, `scorecard.yml`) all have bidirectional changes (both LFG-only and AceHack-only commits). They need per-file 3-way merge — follow-up batches per the documented option-c plan in `docs/DECISIONS/2026-04-26-sync-drain-plan-acehack-lfg-roundtrip-option-c.md`.

## Verification

Each of the 5 files individually verified as zero-LFG-only-changes:

```bash
git log --oneline acehack/main..origin/main -- .github/workflows/budget-snapshot-cadence.yml
git log --oneline acehack/main..origin/main -- .github/workflows/memory-index-duplicate-lint.yml
git log --oneline acehack/main..origin/main -- tools/hygiene/audit-memory-index-duplicates.sh
git log --oneline acehack/main..origin/main -- tools/setup/common/curl-fetch.sh
git log --oneline acehack/main..origin/main -- tools/setup/macos.sh
```

(All return empty.)

## Note on file count discrepancy fix

Initial PR description said "4 files" but the audit script
`tools/hygiene/audit-memory-index-duplicates.sh` was the dependency that
the duplicate-link workflow invokes. The script was committed in a
follow-up commit (`e71fe3d`) when the workflow's lint pointed at it as
a missing dependency. PR description updated to 5 files to reflect
actual scope per the codex review thread on this PR.