### PR TITLE
sync(acehack→lfg): gate.yml — macos-26 back to per-PR cadence (unblocks queue)

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -92,21 +92,22 @@ jobs:
       - id: set
         shell: bash
         run: |
-          # Pre-merge (pull_request + merge_group): Linux production
-          # legs only (~3 min wall clock).
-          # Push-to-main / workflow_dispatch: full surface incl.
-          # macos-26 (developer-experience) + Windows legs
-          # (peer-harness milestone seeding per maintainer 2026-04-27 —
-          # "start the windows one as a per push to main too/merge to
-          # main, you can start slowly building that out before I get
-          # my windows laptop running the peer-mode agent, windows
-          # will be mostly ready and they can just clean it up").
-          # Windows legs are gated by `continue-on-error: true` at the
-          # build-and-test job level so initial failures (e.g. missing
-          # tools/setup/install.ps1) don't block per-merge runs while
-          # the peer-agent polishes the path.
+          # Pre-merge (pull_request + merge_group): Linux + macos-26
+          # (~5 min wall clock with macos in parallel). macos-26 is
+          # required by branch protection's required-status-checks,
+          # so it runs on every PR — moved back to per-PR cadence
+          # 2026-04-28 after maintainer correction ("we pull out mac
+          # and codeql to merge to main time instead of per pr, and
+          # then moved it back to per pr"). The earlier per-merge-only
+          # split structurally blocked the PR queue.
+          # Push-to-main / workflow_dispatch: full surface adds Windows
+          # legs (peer-harness milestone seeding per maintainer
+          # 2026-04-27). Windows legs are gated by `continue-on-error:
+          # true` at the build-and-test job level so initial failures
+          # (e.g. missing tools/setup/install.ps1) don't block per-merge
+          # runs while the peer-agent polishes the path.
           if [ "${GH_EVENT}" = "pull_request" ] || [ "${GH_EVENT}" = "merge_group" ]; then
-            echo 'os=["ubuntu-24.04","ubuntu-24.04-arm"]' >> "$GITHUB_OUTPUT"
+            echo 'os=["ubuntu-24.04","ubuntu-24.04-arm","macos-26"]' >> "$GITHUB_OUTPUT"
           else
             echo 'os=["ubuntu-24.04","ubuntu-24.04-arm","macos-26","windows-2025","windows-11-arm"]' >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary

Forward-ports gate.yml from AceHack to LFG. AceHack already moved macos-26 + Analyze (csharp) back to per-PR cadence; LFG is stale on the prior cadence-split (matrix-setup dynamic switch that excludes macos-26 from pull_request events).

**Effect:** unblocks the structurally-blocked LFG queue. Branch protection requires `build-and-test (macos-26)` as a status check; LFG gate.yml's PR-event matrix didn't include it. After this PR lands, PR-events run macos-26 directly.

## Aaron's correction

> *"we pull out mac and codeql to merge to main time instead of per pr, and then moved it back to per pr, I think you just have some staleness and not update to date with the move back to per per"*
> — Aaron 2026-04-28T16:30Z

## Composes with

- PR #657 (the originally-queued forward-sync of this same change; itself BLOCKED by this gate — becomes redundant once this lands)
- task #306 (cadence-fast revisit — Analyze csharp sibling of macos-26 gate question)
- BLOCKED LFG queue: #655/#656/#657/#658/#659/#660/#661/#662/#663/#665 — all awaiting this unblock

🤖 Generated with [Claude Code](https://claude.com/claude-code)