### PR TITLE
fix(scorecard): scope budget-cadence permissions job-level (TokenPermissionsID)

### DIFF
--- a/.github/workflows/budget-snapshot-cadence.yml
+++ b/.github/workflows/budget-snapshot-cadence.yml
@@ -75,18 +75,10 @@ on:
         default: ""
 
 permissions:
-  # Need contents:write to push the snapshot branch; pull-requests:write
-  # to open the snapshot PR; actions:read so snapshot-burn.sh can call
-  # the Actions REST endpoints (/repos/.../actions/runs and
-  # /actions/runs/{id}/timing) to populate burn metrics. Without
-  # actions:read, those API calls 403 silently and snapshot-burn.sh
-  # falls back to empty/zeroed timing data while still writing a
-  # snapshot — producing misleading evidence rather than a hard
-  # failure. With explicit workflow permissions, omitted scopes are
-  # `none`, so actions:read MUST be listed explicitly here.
-  contents: write
-  pull-requests: write
-  actions: read
+  # Top-level: read-only by default (per Scorecard TokenPermissions
+  # best-practice — minimize blast radius if any step is compromised).
+  # The snapshot job below scopes write permissions narrowly.
+  contents: read
 
 concurrency:
   # Only one cadence run at a time. Retriggers queue (rather than
@@ -100,6 +92,20 @@ jobs:
   snapshot:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+
+    permissions:
+      # Need contents:write to push the snapshot branch; pull-requests:write
+      # to open the snapshot PR; actions:read so snapshot-burn.sh can call
+      # the Actions REST endpoints (/repos/.../actions/runs and
+      # /actions/runs/{id}/timing) to populate burn metrics. Without
+      # actions:read, those API calls 403 silently and snapshot-burn.sh
+      # falls back to empty/zeroed timing data while still writing a
+      # snapshot — producing misleading evidence rather than a hard
+      # failure. With explicit job permissions, omitted scopes are
+      # `none`, so actions:read MUST be listed explicitly here.
+      contents: write
+      pull-requests: write
+      actions: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Scorecard TokenPermissionsID alert (#26, high severity) flagged
top-level `contents: write` on `.github/workflows/budget-snapshot-cadence.yml`.
This is a Scorecard best-practice violation — top-level should be
read-only, with write scoped narrowly to jobs that need it.

## What changes

- Top-level `permissions:` block becomes `contents: read` only
- Job-level `jobs.snapshot.permissions:` gets the original set
  (contents:write + pull-requests:write + actions:read)

**Functional behavior: identical.** Job-level permissions override
top-level (per [GitHub Actions docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token)).
The snapshot job still gets all 3 scopes it needs.

**Security posture: tightened.** Blast-radius bounded to the snapshot
job rather than the whole workflow.

## Why now

PR #661 (B-0073 CodeQL unblock) is gated by `code_quality:severity=all`
ruleset which requires zero open code-scanning alerts. This alert is
one of two blocking. After this PR + CodeQL/Scorecard re-scan, the
TokenPermissionsID alert should close, unblocking #661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)