### PR TITLE
ci(theme-a): ubuntu-22.04 → ubuntu-24.04 (gate.yml + resume-diff.yml) — 0/0/0 reconciliation

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -317,9 +317,11 @@ jobs:
         # Installs shellcheck via mise (pinned in .mise.toml). Single
         # source of truth — the same version on dev laptops + CI
         # runners. Prior step relied on shellcheck shipping pre-
-        # installed on ubuntu-24.04, which broke parity (dev machines
-        # may have a different version) and wouldn't survive newer
-        # runner images like ubuntu-slim that don't ship shellcheck.
+        # installed on ubuntu-22.04 (the older runner image), which
+        # broke parity (dev machines may have a different version)
+        # and wouldn't survive newer runner images like ubuntu-slim
+        # that don't ship shellcheck. Same parity concern applies on
+        # ubuntu-24.04 — install via mise regardless.
         run: ./tools/setup/install.sh
 
       - name: Run shellcheck

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -13,7 +13,7 @@
 #     — too slow for per-PR gating; runs on every push to main +
 #     nightly schedule (in practice every merge, since direct
 #     pushes are blocked by branch protection).
-#     Lint jobs pinned to ubuntu-22.04 (short-lived, OS-independent
+#     Lint jobs pinned to ubuntu-24.04 (short-lived, OS-independent
 #     work). Windows legs deferred to peer-harness milestone.
 #   - Third-party actions SHA-pinned by full 40-char commit SHA;
 #     trailing `# vX.Y.Z` comments for humans.
@@ -266,7 +266,7 @@ jobs:
     # elevation design (docs/research/threat-model-elevation.md).
     name: lint (semgrep)
     timeout-minutes: 10
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # Toolchain via three-way-parity install.sh (GOVERNANCE §24): same
     # semgrep version that dev laptops + devcontainers get, pinned in
@@ -307,7 +307,7 @@ jobs:
     # See openspec/specs/static-analysis/profiles/shell.md.
     name: lint (shellcheck)
     timeout-minutes: 5
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -317,7 +317,7 @@ jobs:
         # Installs shellcheck via mise (pinned in .mise.toml). Single
         # source of truth — the same version on dev laptops + CI
         # runners. Prior step relied on shellcheck shipping pre-
-        # installed on ubuntu-22.04, which broke parity (dev machines
+        # installed on ubuntu-24.04, which broke parity (dev machines
         # may have a different version) and wouldn't survive newer
         # runner images like ubuntu-slim that don't ship shellcheck.
         run: ./tools/setup/install.sh
@@ -352,7 +352,7 @@ jobs:
     # github-actions.md.
     name: lint (actionlint)
     timeout-minutes: 5
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -395,7 +395,7 @@ jobs:
     # layer.
     name: lint (tick-history order)
     timeout-minutes: 2
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -419,7 +419,7 @@ jobs:
     # merge-conflict resolution.
     name: lint (no conflict markers)
     timeout-minutes: 2
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -447,7 +447,7 @@ jobs:
     # backfilled all pre-existing violations to 0.
     name: lint (archive header §33)
     timeout-minutes: 2
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -468,7 +468,7 @@ jobs:
     # No untrusted input used in run: — only a fixed repo path.
     name: lint (no empty dirs)
     timeout-minutes: 3
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -484,7 +484,7 @@ jobs:
     # See openspec/specs/static-analysis/profiles/markdown.md.
     name: lint (markdownlint)
     timeout-minutes: 5
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/resume-diff.yml
+++ b/.github/workflows/resume-diff.yml
@@ -34,7 +34,7 @@
 #     the comment.
 #   - concurrency: workflow-scoped; cancel-in-progress for PR
 #     events.
-#   - Runner digest-pinned (ubuntu-22.04).
+#   - Runner digest-pinned (ubuntu-24.04).
 #   - Graceful no-change handling: if the diff has no claim-
 #     bearing lines, posts a clarifying message and passes.
 #     Does not fail the PR.
@@ -58,7 +58,7 @@ concurrency:
 jobs:
   resume-diff:
     name: claim-level diff
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/resume-diff.yml
+++ b/.github/workflows/resume-diff.yml
@@ -34,7 +34,8 @@
 #     the comment.
 #   - concurrency: workflow-scoped; cancel-in-progress for PR
 #     events.
-#   - Runner digest-pinned (ubuntu-24.04).
+#   - Runner pinned to ubuntu-24.04 (not -latest, so OS image
+#     changes are explicit and tracked).
 #   - Graceful no-change handling: if the diff has no claim-
 #     bearing lines, posts a clarifying message and passes.
 #     Does not fail the PR.


### PR DESCRIPTION
Theme A of the AceHack/LFG 0/0/0 reconciliation per `docs/0-0-0-readiness/CLASSIFICATION.md`.

Pure surgical substitution: ubuntu-22.04 → ubuntu-24.04 in 8 locations across 2 workflow files. No structural changes; no whole-file copy.

**Why surgical**: the AceHack version of resume-diff.yml also reverted an LFG-side Codex P1 fix (REST integer comment_id vs GraphQL node ID). Whole-file copy would re-introduce that regression. Per the hard-defect-response rule in PR #695, surgical-extract is correct.

Aaron 2026-04-28: 'we better not be using that old version of ubuntu' + Otto-247 version-currency.

Closes Theme A. Themes B + C follow.