### PR TITLE
ops(theme-c): add build-and-test (macos-26) to expected required_status_checks — 0/0/0 reconciliation

### DIFF
--- a/tools/hygiene/github-settings.expected.json
+++ b/tools/hygiene/github-settings.expected.json
@@ -131,6 +131,7 @@
     "required_signatures": false,
     "required_status_checks": {
       "contexts": [
+        "build-and-test (macos-26)",
         "build-and-test (ubuntu-24.04)",
         "build-and-test (ubuntu-24.04-arm)",
         "lint (actionlint)",


### PR DESCRIPTION
Theme C (final) of the AceHack/LFG 0/0/0 reconciliation per `docs/0-0-0-readiness/CLASSIFICATION.md`.

Single-line additive change to expected.json: macos-26 IS already in actual LFG branch protection (verified via gh api). LFG's expected.json was the drift; this commit makes it match reality.

Pure 1-line addition, no other changes.

Closes Theme C — final NEEDS-FORWARD-SYNC item. After this lands + Themes A (#696) + B (#697), tree-diff should reach zero, completing Step 2 of the path-to-0/0/0 plan.