### PR TITLE
memory(fork-audit): R/C/T diff-filter coverage + plumbing-vs-porcelain note + slot-semantics on MEMORY.md HTML comment (Amara round-10)

### DIFF
--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,6 +1,6 @@
 [AutoDream last run: 2026-04-23]
 
-**📌 Fast path: read `CURRENT-aaron.md` and `CURRENT-amara.md` first.** <!-- paired-edit: hard-reset safety addendum on AceHack/LFG fork-topology memory + content-equivalence audit rule (2026-04-29 round-9 peer-harness save) -->
+**📌 Fast path: read `CURRENT-aaron.md` and `CURRENT-amara.md` first.** <!-- latest-paired-edit: fork-audit R/C/T diff-filter coverage + plumbing-vs-porcelain note (2026-04-29 round-10 Amara). NOTE: this comment is a single-slot "latest paired edit" marker (not a paired-edit log). Per the round-10 Amara framing the slot semantics are now explicit. -->
 
 - [**Bare `main` is ambiguous — automation uses explicit refs (Amara, 2026-04-29)**](feedback_bare_main_ambiguity_automation_discipline_explicit_refs_required_amara_2026_04_29.md) — Generic multi-remote-repo automation rule: scripts use `refs/remotes/<remote>/<branch>` (or `refs/heads/<branch>`); bare branch names only for interactive humans. Hard-stop on fatal base-ref errors. Caught when bare `git checkout main` was hitting `fatal: matched multiple (2) remote tracking branches` and the loop continued past the failure with wrong downstream state.
 

--- a/memory/feedback_lfg_master_acehack_zero_divergence_fork_double_hop_aaron_2026_04_27.md
+++ b/memory/feedback_lfg_master_acehack_zero_divergence_fork_double_hop_aaron_2026_04_27.md
@@ -135,21 +135,47 @@ caught missing content in the reset-readiness claim.
 ### Required content-equivalence audit (BEFORE any hard-reset)
 
 ```bash
-# Both checks required for safety:
+# All categories required for safety. Use --find-renames so
+# moved/copied content isn't misclassified as
+# "AceHack-only" or "deleted":
 
-# (1) Files present only on AceHack (not on LFG)
-git diff --name-status --diff-filter=A origin/main..acehack/main
+# (1) Comprehensive status across all relevant categories
+#     A=added (AceHack-only path)
+#     C=copied (content reused under new path)
+#     M=modified (shared path with possibly-unique content)
+#     R=renamed (moved content; compare by content, not path)
+#     T=type change (symlink vs file etc.; inspect manually)
+#     (D=deleted is intentionally omitted — deletion alone
+#     is not content loss going LFG→AceHack direction; if
+#     the deletion is intentional drop, classify so.)
+git diff --name-status --find-renames --diff-filter=ACMRT \
+  origin/main..acehack/main
 
-# (2) Shared files MODIFIED on AceHack (may contain unique content)
+# (2) Numstat for shared MODIFIED files (sizing the audit)
 git diff --numstat --diff-filter=M origin/main..acehack/main
 
-# Then for each modified shared path, content-compare:
+# (3) For each shared / renamed / copied path, content-compare:
 git diff origin/main..acehack/main -- <path>
 
-# And test reachability of each candidate SHA:
+# (4) Test reachability of each candidate SHA:
 git merge-base --is-ancestor <sha> origin/main  # 0=ancestor, 1=not
 git merge-base --is-ancestor <sha> acehack/main
 ```
+
+**Plumbing-vs-porcelain (when this becomes scripted tooling):**
+human auditors are fine with `git diff` (porcelain). When
+this audit graduates to a CI tool or shell script, prefer
+`git diff-tree -r --name-status --find-renames --diff-filter=ACMRT
+origin/main acehack/main` (plumbing) — output is more stable
+and immune to user `core.*` config interference. Alternatively
+add `git -c core.quotepath=false diff --no-ext-diff …`
+for predictable byte sequences.
+
+**Inverse of "same path is not same substrate":** different
+path can still be same substrate. R/C status entries (renamed
+/ copied) require content comparison, not path equality. Don't
+over-flag a moved file as content-loss when its content lives
+under a new path on LFG main.
 
 ### Required classification per unforwarded substantive PR
 

--- a/memory/feedback_lfg_master_acehack_zero_divergence_fork_double_hop_aaron_2026_04_27.md
+++ b/memory/feedback_lfg_master_acehack_zero_divergence_fork_double_hop_aaron_2026_04_27.md
@@ -135,20 +135,29 @@ caught missing content in the reset-readiness claim.
 ### Required content-equivalence audit (BEFORE any hard-reset)
 
 ```bash
-# All categories required for safety. Use --find-renames so
-# moved/copied content isn't misclassified as
-# "AceHack-only" or "deleted":
+# All categories required for safety. Use BOTH --find-renames
+# AND --find-copies so moved/copied content isn't misclassified
+# as "AceHack-only" or "deleted". Note: --diff-filter=C only
+# emits Copied entries when copy detection is enabled; filter
+# alone is not sufficient.
 
-# (1) Comprehensive status across all relevant categories
+# (1) Comprehensive status across content-loss categories
 #     A=added (AceHack-only path)
-#     C=copied (content reused under new path)
+#     C=copied (content reused under new path; requires --find-copies)
 #     M=modified (shared path with possibly-unique content)
-#     R=renamed (moved content; compare by content, not path)
+#     R=renamed (moved content; requires --find-renames; compare by content, not path)
 #     T=type change (symlink vs file etc.; inspect manually)
-#     (D=deleted is intentionally omitted — deletion alone
-#     is not content loss going LFG→AceHack direction; if
-#     the deletion is intentional drop, classify so.)
-git diff --name-status --find-renames --diff-filter=ACMRT \
+git diff --name-status --find-renames --find-copies \
+  --diff-filter=ACMRT \
+  origin/main..acehack/main
+
+# (1b) D=deleted SEPARATE pass — not AceHack-content-loss in
+#      this reset direction (LFG already lacks the file), but
+#      can be SEMANTIC REGRESSION if AceHack intentionally
+#      removed bad/stale/unsafe content. Review separately
+#      when the deleted path is workflow / security config /
+#      tooling / governance substrate.
+git diff --name-status --diff-filter=D \
   origin/main..acehack/main
 
 # (2) Numstat for shared MODIFIED files (sizing the audit)
@@ -165,11 +174,31 @@ git merge-base --is-ancestor <sha> acehack/main
 **Plumbing-vs-porcelain (when this becomes scripted tooling):**
 human auditors are fine with `git diff` (porcelain). When
 this audit graduates to a CI tool or shell script, prefer
-`git diff-tree -r --name-status --find-renames --diff-filter=ACMRT
-origin/main acehack/main` (plumbing) — output is more stable
-and immune to user `core.*` config interference. Alternatively
-add `git -c core.quotepath=false diff --no-ext-diff …`
-for predictable byte sequences.
+`git diff-tree -r --name-status -M -C --diff-filter=ACMRT
+origin/main acehack/main` (plumbing; `-M`/`-C` are the
+plumbing flags for rename/copy detection). Output is more
+stable and immune to user `core.*` config interference.
+Alternatively add `git -c core.quotepath=false diff
+--no-ext-diff …` for predictable byte sequences.
+
+**Copy-detection cost (CI bound):** `-C` (find-copies)
+includes an O(n²) fallback that compares each added file to
+each deleted file. Bound with `-l200` (or similar) for CI:
+
+```bash
+# Two-pass tooling pattern (cheap then thorough)
+# Fast pass — A/M/R/T with rename detection only
+git diff-tree -r --name-status -M --diff-filter=ACMRT \
+  origin/main acehack/main
+
+# Slow pass — copy detection bounded, only if first pass
+# leaves suspicious add/delete clusters
+git diff-tree -r --name-status -M -C -l200 \
+  --diff-filter=ACMRT \
+  origin/main acehack/main
+```
+
+For human audit (one-shot), the unbounded full form is fine.
 
 **Inverse of "same path is not same substrate":** different
 path can still be same substrate. R/C status entries (renamed


### PR DESCRIPTION
## Summary

Three Amara round-10 corrections to the now-merged hard-reset safety addendum (PR #826):

1. **Audit was missing rename/copy/type-change coverage.** The slogan *"same path is not same substrate"* has an inverse: *"different path can still be same substrate."* Renames/copies need content comparison, not path equality. Replaced `--diff-filter=A` + `--diff-filter=M` with comprehensive `--diff-filter=ACMRT --find-renames` + per-status interpretation guide.

2. **Plumbing-vs-porcelain note added.** Human audit is fine with `git diff`; scripted tooling should prefer `git diff-tree -r --name-status --find-renames` (plumbing) for output stability + config-immunity, OR add `-c core.quotepath=false --no-ext-diff` to porcelain for predictability.

3. **`MEMORY.md` HTML comment slot-semantics made explicit.** The comment was acting as a single-slot ledger and silently overwriting prior markers. Renamed `paired-edit:` → `latest-paired-edit:` with explicit slot-semantics note.

## Best round-10 keepers

```text
Added files are a clue.
Modified shared files are the trap.
Content equivalence is the gate.
```

```text
Same path is not same substrate.
Different path can still be same substrate.
```

## Skipped per B-0105 consolidation gate (deferred to consolidation pass)

- "Paired-edit failure must stop before commit" — process discipline; will absorb into existing paired-edit lint documentation.
- "Safety blockers should land as soon as green" — discipline-level rule; honored in this PR's intent (small follow-up, not new conceptual island).

## Test plan

- [x] Verbatim Amara quotes preserved in commit body
- [x] Existing memory file edited (no new conceptual island per B-0105)
- [x] MEMORY.md paired-edit comment updated with explicit slot-semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)