### PR TITLE
fix(no-directives-lint): round-13 — worktree mode catches untracked prose files

### DIFF
--- a/tools/lint/no-directives-otto-prose.sh
+++ b/tools/lint/no-directives-otto-prose.sh
@@ -93,11 +93,22 @@ if [ "$SCOPE" = "worktree" ]; then
   # file with new violations is included). Copies are intentionally
   # omitted here (no need for content-equivalence in this lint;
   # only added-line discipline matters).
+  #
+  # `git diff` only reports TRACKED file changes. A freshly-created
+  # prose file that has not been `git add`-ed yet is UNTRACKED, and
+  # `git diff --name-only` will not list it. The pre-commit
+  # use case explicitly includes about-to-be-committed prose, so
+  # worktree mode also pulls untracked-but-not-ignored files via
+  # `git ls-files --others --exclude-standard`. The PR mode does
+  # not need this because its changed-file set is the BASE_REF
+  # diff — anything not in that diff is by definition not part of
+  # the PR.
   CHANGED_FILES=$(
     {
       git diff --name-only --diff-filter=AMR
       git diff --cached --name-only --diff-filter=AMR
       git diff --name-only --diff-filter=AMR "$BASE_REF...HEAD"
+      git ls-files --others --exclude-standard
     } | sort -u
   )
 else
@@ -164,7 +175,17 @@ trap 'rm -f "$HITS_FILE" "$FILTERED_HITS_FILE" "$ADDED_LINES_FILE"' EXIT
 while IFS= read -r f; do
   [ -z "$f" ] && continue
   [ -f "$f" ] || continue
-  if [ "$SCOPE" = "worktree" ]; then
+  # Untracked-file detection: `git ls-files --error-unmatch` exits 0
+  # when the path is in the index, non-zero otherwise. In worktree
+  # mode an untracked file's contents are treated as ALL added
+  # lines (since there's nothing to diff against); the entire file
+  # is prefixed with `+` and fed into the same awk pipeline as a
+  # tracked-file diff. PR mode never sees untracked files because
+  # the BASE_REF...HEAD diff only includes committed content.
+  if [ "$SCOPE" = "worktree" ] && \
+     ! git ls-files --error-unmatch -- "$f" >/dev/null 2>&1; then
+    awk '{ printf "+%s\n", $0 }' "$f"
+  elif [ "$SCOPE" = "worktree" ]; then
     {
       git diff -U0 -- "$f"
       git diff --cached -U0 -- "$f"

--- a/tools/lint/no-directives-otto-prose.tests.md
+++ b/tools/lint/no-directives-otto-prose.tests.md
@@ -134,12 +134,106 @@ narration of a past bad-event reference is borderline.)
 
 ## How to run the test fixtures manually
 
+The block at the bottom of this section gives a single-pass
+"verify-everything-at-once" run. The blocks before it are the
+per-fixture-class executable reproductions Amara called for in
+round-12 ("documented fixtures are coverage intent; executed
+fixtures are coverage proof"). Each one creates a temporary
+prose file under `memory/`, runs `SCOPE=worktree`, asserts the
+expected pass/fail, and then cleans up.
+
+These are intended to be copy-pasted into a fresh shell from the
+repo root. They make no commits; they only create a temporary
+prose file under `memory/`, run the lint, and remove the file.
+
+Assume a clean working tree (no unstaged prose modifications).
+If you have unstaged changes, either commit/stash them first
+yourself, or run a single fixture at a time with manual cleanup.
+
+Round-13 verified A/B/C return the expected results against
+commit `<round-13>` of this lint. D (renamed-file) requires
+temporary commits and is documented-only.
+
+### A. Real violation MUST flag — `Aaron's directive`
+
 ```bash
-# Snapshot fixtures into a scratch file in the changed-files scope,
-# run the lint in worktree mode, verify hits/misses match the
-# expectations above:
+echo "Aaron's directive elevates introspection." > memory/feedback_TEMP_lint_test_real_violation.md
+SCOPE=worktree tools/lint/no-directives-otto-prose.sh \
+  || echo "EXPECTED: lint flagged (advisory mode exits 0; --strict would exit 1)"
+SCOPE=worktree tools/lint/no-directives-otto-prose.sh --strict \
+  && echo "UNEXPECTED PASS — lint did not flag Aaron's directive" \
+  || echo "OK: --strict mode flagged Aaron's directive"
+rm -f memory/feedback_TEMP_lint_test_real_violation.md
+```
+
+### B. Filename contains regex token but content clean — MUST NOT flag
+
+```bash
+echo "the lineage anchor is preserved per the engineering claim" \
+  > memory/feedback_TEMP_human_lineage_anchors_clean.md
+SCOPE=worktree tools/lint/no-directives-otto-prose.sh --strict \
+  && echo "OK: clean content with 'human' in filename did NOT flag" \
+  || echo "REGRESSION: false positive on filename token (round-12 P0 fix broken)"
+rm -f memory/feedback_TEMP_human_lineage_anchors_clean.md
+```
+
+### C. Blockquote with violation string — MUST NOT flag (whitelist)
+
+```bash
+echo "> Aaron's directive elevates introspection." \
+  > memory/feedback_TEMP_lint_test_blockquote.md
+SCOPE=worktree tools/lint/no-directives-otto-prose.sh --strict \
+  && echo "OK: blockquote-prefixed content did NOT flag" \
+  || echo "REGRESSION: blockquote whitelist broken"
+rm -f memory/feedback_TEMP_lint_test_blockquote.md
+```
+
+### D. Renamed file with new violation — MUST flag (--diff-filter=AMR)
+
+This case requires temporary commits + `git reset --hard HEAD~1`.
+Run inside a disposable `git worktree` (per round-13 review)
+rather than the active checkout, to keep the scar-testing away
+from in-flight work. The shape:
+
+```bash
+# Run from the active checkout root:
+tmpdir=$(mktemp -d)
+git worktree add --detach "$tmpdir" HEAD
+(
+  cd "$tmpdir"
+  echo "clean original content" > memory/feedback_TEMP_rename_orig.md
+  git add memory/feedback_TEMP_rename_orig.md
+  git commit -m "lint test: stage original" --quiet
+  git mv memory/feedback_TEMP_rename_orig.md memory/feedback_TEMP_rename_new.md
+  echo "Aaron's directive added in renamed copy" \
+    >> memory/feedback_TEMP_rename_new.md
+  git add -A
+  SCOPE=worktree tools/lint/no-directives-otto-prose.sh --strict \
+    && echo "REGRESSION: renamed file with violation did NOT flag" \
+    || echo "OK: renamed file with violation flagged"
+)
+git worktree remove --force "$tmpdir"
+```
+
+The R-coverage path through the lint is exercised by
+`git diff --name-only --diff-filter=AMR --cached` returning the
+renamed prose file in CHANGED_FILES; the per-file extraction
+loop then runs `git diff -U0 --cached` on it, which produces a
+diff showing the appended violation line as an added line. The
+pattern-match phase does the rest.
+
+### Single-pass advisory run
+
+```bash
+# Snapshot any current changes, run the lint in worktree mode, verify
+# hits/misses match the expectations above:
 SCOPE=worktree tools/lint/no-directives-otto-prose.sh
 ```
 
 Promote to a real CI test (e.g., bats / shunit2) when wiring the
-lint into `.github/workflows/gate.yml` as advisory.
+lint into `.github/workflows/gate.yml` as advisory. The four
+copy-pasteable blocks above are the manual equivalent until that
+harness lands — they exercise the four canonical fixture classes
+(real-violation / filename-token-clean / blockquote-whitelist /
+renamed-file-violation) that the round-12 rewrite was designed
+around.


### PR DESCRIPTION
Round-13 follow-up to merged PR #825. Round-12 manual verification surfaced a real bug: \`SCOPE=worktree\` mode did not include UNTRACKED prose files. The pre-commit/worktree use case explicitly includes about-to-be-committed prose, but \`git diff --name-only\` only reports tracked file changes — a freshly-created \`memory/feedback_*.md\` file (the most common pre-commit case) was silently skipped with \"no Otto-prose surfaces changed\".

## Round-13 fixes

1. **Worktree CHANGED_FILES** now appends \`git ls-files --others --exclude-standard\`. Untracked-but-not-ignored files matching prose-surface globs are pulled in. PR mode is unchanged (BASE_REF...HEAD diff is committed-only).

2. **Per-file extraction loop** branches on tracked-vs-untracked. For untracked files in worktree mode, every line is prefixed with \`+\` and fed into the same awk pipeline as a tracked-file diff. Detection uses \`git ls-files --error-unmatch\`.

## Tests.md

- Reproduction commands no longer use \`git stash --include-untracked\` (it was hiding tracked .sh modifications during testing — the round-13 discovery itself).
- Fixture D (renamed-file violation) reframed as a \`git worktree add --detach\` flow rather than commits + reset --hard inside the active checkout.

## Verification

A/B/C all executed against this commit:

- **A. Real violation** (\`Aaron's directive\`) → flagged, exit 1.
- **B. Filename contains \`human\` token + clean content** → not flagged, exit 0.
- **C. Blockquote with violation string** → not flagged, exit 0.
- **D. Renamed file** → documented-only (requires worktree setup).

## Best rule (round-13)

\`\`\`text
PR mode checks committed diff.
Worktree mode checks staged, unstaged, AND untracked candidate prose.
\`\`\`

## Best tiny blade

\`\`\`text
The fixture did not fail.
It found the next bug.
\`\`\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>