### PR TITLE
ts(B-0086): port 3 hygiene audit scripts (.sh→.ts) — slice 5 of TS/Bun migration

### DIFF
--- a/docs/trajectories/typescript-bun-migration/slice-audits.md
+++ b/docs/trajectories/typescript-bun-migration/slice-audits.md
@@ -322,6 +322,50 @@ Per-port pattern checklist:
 
 Slice 4 passes audit. New pattern recorded: per-line scan to preserve bash `grep` behavior across regex extraction.
 
+## Slice 5 — 3 hygiene-audit ports (PR #NNN, 2026-04-30)
+
+**Slice files**:
+
+- `tools/hygiene/audit-tick-history-bounded-growth.{sh→ts}`
+- `tools/hygiene/audit-post-setup-script-stack.{sh→ts}`
+- `tools/hygiene/audit-missing-prevention-layers.{sh→ts}`
+
+**Comparison points**: Layered baseline verified 2026-04-30 (1 day old). Slices 1-4 canonical patterns reused.
+
+### Code-pattern audit
+
+| Check | Result |
+|---|---|
+| No `any` uses | 0 matches |
+| No `as` casts | 0 matches |
+| Project typecheck clean | 0 errors |
+| ESLint strictTypeChecked | 0 errors |
+
+Per-port pattern checklist:
+
+- **Applied (all 3)**: typed boundary objects (Args, AuditBuckets, AuditResult, HygieneRow, ClassificationEntry).
+- **Applied (all 3)**: literal-type union exit codes.
+- **Applied (all 3)**: ParseResult discriminated-union via reduceFlag.
+- **Applied (all 3)**: structured spawn-failure classifier.
+- **`audit-tick-history-bounded-growth`**: simple line-count check; no git invocations beyond repo-root resolution; threshold default 500 (per inline mini-ADR in bash original).
+- **`audit-post-setup-script-stack`**: classification logic (exempt / labelled / violation) extracted into pure helpers (isExempt, hasLabel) for testability. LABEL_RE compiled once.
+- **`audit-missing-prevention-layers`**: `trimSpaces` extracted as a pure helper to avoid sonarjs/slow-regex on `^ +` / ` +$` patterns. ROW_RE compiled once. `Map<string, string>` for classifications (vs bash's parallel arrays + linear lookup).
+
+### DST + coverage audit
+
+- **DST-friendly: applied** — `audit-post-setup-script-stack` and `audit-missing-prevention-layers` use `new Date().toISOString()` for the report timestamp; would inject a `Clock` interface (slice-2 pattern) if/when tests are added. `audit-tick-history-bounded-growth` has no time/random surface.
+- **Coverage: deferred** — bash originals had no tests; ports don't introduce a new module.
+
+### Equivalence audit
+
+- **`audit-tick-history-bounded-growth`**: byte-equivalent under both terse and `--summary` modes against current repo state.
+- **`audit-post-setup-script-stack`**: byte-equivalent under `--summary` (counts only) and report mode (modulo `Run:` timestamp).
+- **`audit-missing-prevention-layers`**: byte-equivalent (modulo `Run:` timestamp).
+
+### Outcome
+
+Slice 5 passes audit. New pattern recorded: `trimSpaces` pure helper as eslint-clean alternative to anchored space-stripping regexes (avoids sonarjs/slow-regex flag).
+
 ## Slice template (for future slices)
 
 Copy this section header and fill out before merging the slice's PR:

--- a/docs/trajectories/typescript-bun-migration/slice-audits.md
+++ b/docs/trajectories/typescript-bun-migration/slice-audits.md
@@ -349,7 +349,7 @@ Per-port pattern checklist:
 - **Applied (all 3)**: structured spawn-failure classifier.
 - **`audit-tick-history-bounded-growth`**: simple line-count check; no git invocations beyond repo-root resolution; threshold default 500 (per inline mini-ADR in bash original).
 - **`audit-post-setup-script-stack`**: classification logic (exempt / labelled / violation) extracted into pure helpers (isExempt, hasLabel) for testability. LABEL_RE compiled once.
-- **`audit-missing-prevention-layers`**: `trimSpaces` extracted as a pure helper to avoid sonarjs/slow-regex on `^ +` / ` +$` patterns. ROW_RE compiled once. `Map<string, string>` for classifications (vs bash's parallel arrays + linear lookup).
+- **`audit-missing-prevention-layers`**: `trimSpaces` extracted as a pure helper to avoid sonarjs/slow-regex on anchored space patterns. ROW_RE compiled once. `Map<string, string>` for classifications (vs bash's parallel arrays + linear lookup).
 
 ### DST + coverage audit
 

--- a/tools/hygiene/audit-missing-prevention-layers.ts
+++ b/tools/hygiene/audit-missing-prevention-layers.ts
@@ -1,0 +1,264 @@
+#!/usr/bin/env bun
+// audit-missing-prevention-layers.ts — meta-hygiene audit.
+//
+// TypeScript+Bun port of audit-missing-prevention-layers.sh, slice 5
+// of the TS+Bun migration. See docs/best-practices/repo-scripting.md.
+//
+// What this does:
+//   For every row in docs/FACTORY-HYGIENE.md's main table, looks up
+//   the row's classification in docs/hygiene-history/prevention-
+//   layer-classification.md (or override via --classify FILE), and
+//   surfaces unclassified + gap rows.
+//
+// Usage:
+//   bun tools/hygiene/audit-missing-prevention-layers.ts
+//   bun tools/hygiene/audit-missing-prevention-layers.ts --classify FILE
+//
+// Exit codes:
+//   0   all rows classified, no gap rows
+//   1   usage error
+//   2   one or more rows lack classification OR are detection-only-gap
+
+import { readFileSync } from "node:fs";
+import {
+  spawnSync,
+  type SpawnSyncReturns,
+} from "node:child_process";
+
+type AuditExitCode = 0 | 1 | 2;
+
+interface Args {
+  readonly classificationFile: string;
+}
+
+type ParseResult =
+  | { readonly kind: "args"; readonly args: Args }
+  | { readonly kind: "help" }
+  | { readonly kind: "error"; readonly message: string };
+
+interface HygieneRow {
+  readonly num: string;
+  readonly title: string;
+}
+
+interface ClassificationEntry {
+  readonly num: string;
+  readonly label: string;
+}
+
+interface AuditResult {
+  readonly rows: readonly HygieneRow[];
+  readonly classifications: ReadonlyMap<string, string>;
+  readonly unclassified: readonly HygieneRow[];
+  readonly gaps: readonly HygieneRow[];
+  readonly okCount: number;
+}
+
+const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+const HYGIENE_FILE = "docs/FACTORY-HYGIENE.md";
+const DEFAULT_CLASSIFICATION_FILE = "docs/hygiene-history/prevention-layer-classification.md";
+const ROW_RE = /^\| {1,3}\d+ {1,3}\|/;
+
+function trimSpaces(s: string): string {
+  // Match bash awk's `sub(/^ +/, ""); sub(/ +$/, "")`. Bounded by
+  // line length; not slow-regex.
+  let i = 0;
+  while (i < s.length && s[i] === " ") i += 1;
+  let j = s.length;
+  while (j > i && s[j - 1] === " ") j -= 1;
+  return s.slice(i, j);
+}
+
+function classifyFailure(
+  cmd: string,
+  args: readonly string[],
+  result: SpawnSyncReturns<string>,
+): string | null {
+  if (result.error) {
+    return `Failed to start '${cmd} ${args.join(" ")}': ${result.error.message}`;
+  }
+  if (result.status === null) {
+    return `'${cmd} ${args.join(" ")}' terminated before reporting an exit code`;
+  }
+  if (result.status !== 0) {
+    return `'${cmd} ${args.join(" ")}' exited ${String(result.status)}`;
+  }
+  return null;
+}
+
+function repoRoot(): string {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  const failure = classifyFailure("git", ["rev-parse"], result);
+  if (failure !== null) throw new Error(failure);
+  return result.stdout.trim();
+}
+
+function parseArgs(argv: readonly string[]): ParseResult {
+  let classificationFile = DEFAULT_CLASSIFICATION_FILE;
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i] ?? "";
+    if (arg === "-h" || arg === "--help") return { kind: "help" };
+    if (arg === "--classify") {
+      const v = argv[i + 1];
+      if (v === undefined || v === "") {
+        return { kind: "error", message: "error: --classify requires a file path" };
+      }
+      classificationFile = v;
+      i += 2;
+      continue;
+    }
+    return { kind: "error", message: `error: unknown arg: ${arg}` };
+  }
+  return { kind: "args", args: { classificationFile } };
+}
+
+// Bash extracts rows from FACTORY-HYGIENE.md with an awk script:
+// only rows after `^## The list` and before `^## Ships to project-under-construction`,
+// matching `^| NN |` lines, taking col 2 (num) and col 3 (title).
+function extractHygieneRows(content: string): readonly HygieneRow[] {
+  const rows: HygieneRow[] = [];
+  let inMain = false;
+  for (const line of content.split("\n")) {
+    if (line.startsWith("## Ships to project-under-construction")) {
+      inMain = false;
+      continue;
+    }
+    if (line.startsWith("## The list")) {
+      inMain = true;
+      continue;
+    }
+    if (!inMain) continue;
+    if (!ROW_RE.test(line)) continue;
+    const cols = line.split("|");
+    const num = (cols[1] ?? "").replace(/ /g, "");
+    const title = trimSpaces(cols[2] ?? "");
+    rows.push({ num, title });
+  }
+  return rows;
+}
+
+// Classification file uses the same `| NN | ... | label | ...` shape;
+// bash takes col 2 as num and col 4 as label.
+function extractClassifications(content: string): readonly ClassificationEntry[] {
+  const out: ClassificationEntry[] = [];
+  for (const line of content.split("\n")) {
+    if (!ROW_RE.test(line)) continue;
+    const cols = line.split("|");
+    const num = (cols[1] ?? "").replace(/ /g, "");
+    const label = trimSpaces(cols[3] ?? "");
+    out.push({ num, label });
+  }
+  return out;
+}
+
+function audit(args: Args, root: string): AuditResult | { error: string } {
+  const hygienePath = `${root}/${HYGIENE_FILE}`;
+  let hygieneContent: string;
+  try {
+    hygieneContent = readFileSync(hygienePath, "utf8");
+  } catch {
+    return { error: `error: ${HYGIENE_FILE} not found` };
+  }
+  const rows = extractHygieneRows(hygieneContent);
+
+  const classMap = new Map<string, string>();
+  let classContent: string;
+  try {
+    classContent = readFileSync(`${root}/${args.classificationFile}`, "utf8");
+  } catch {
+    classContent = "";
+  }
+  if (classContent !== "") {
+    for (const e of extractClassifications(classContent)) {
+      classMap.set(e.num, e.label);
+    }
+  }
+
+  const unclassified: HygieneRow[] = [];
+  const gaps: HygieneRow[] = [];
+  let okCount = 0;
+  for (const r of rows) {
+    const label = classMap.get(r.num);
+    if (label === undefined || label === "") unclassified.push(r);
+    else if (label.includes("detection-only (gap)")) gaps.push(r);
+    else okCount += 1;
+  }
+
+  return { rows, classifications: classMap, unclassified, gaps, okCount };
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n);
+}
+
+function emitReport(args: Args, r: AuditResult): string {
+  const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const lines: string[] = [];
+  lines.push("# Missing prevention-layer audit");
+  lines.push("");
+  lines.push(`Run: ${now}`);
+  lines.push(`Classification source: ${args.classificationFile}`);
+  lines.push("");
+  lines.push("## Matrix");
+  lines.push("");
+  lines.push("| Row # | Hygiene item | Classification |");
+  lines.push("|---|---|---|");
+  for (const row of r.rows) {
+    const stored = r.classifications.get(row.num);
+    const label = stored === undefined || stored === "" ? "**unclassified**" : stored;
+    lines.push(`| ${row.num} | ${truncate(row.title, 80)} | ${label} |`);
+  }
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(`- prevention-bearing or detection-only-justified: ${String(r.okCount)}`);
+  lines.push(`- detection-only-gap (prevention could exist but does not): ${String(r.gaps.length)}`);
+  lines.push(`- unclassified (no entry in classification file): ${String(r.unclassified.length)}`);
+  if (r.unclassified.length > 0) {
+    lines.push("");
+    lines.push("## Unclassified rows (fill in classification file)");
+    for (const row of r.unclassified) lines.push(`- ${row.num} — ${row.title}`);
+  }
+  if (r.gaps.length > 0) {
+    lines.push("");
+    lines.push("## Gap rows (prevention layer candidate)");
+    for (const row of r.gaps) lines.push(`- ${row.num} — ${row.title}`);
+    lines.push("");
+    lines.push("Each gap row is a candidate for an author-time / commit-time /");
+    lines.push("trigger-time prevention layer. Design ROI — prevention is");
+    lines.push("cheaper than detection + fix per violation × violation-rate.");
+  }
+  return lines.join("\n");
+}
+
+export function main(argv: readonly string[]): AuditExitCode {
+  const parsed = parseArgs(argv);
+  if (parsed.kind === "help") {
+    process.stdout.write(
+      "Usage: audit-missing-prevention-layers.ts [--classify FILE]\n",
+    );
+    return 0;
+  }
+  if (parsed.kind === "error") {
+    process.stderr.write(`${parsed.message}\n`);
+    return 1;
+  }
+  const root = repoRoot();
+  const r = audit(parsed.args, root);
+  if ("error" in r) {
+    process.stderr.write(`${r.error}\n`);
+    return 1;
+  }
+  process.stdout.write(`${emitReport(parsed.args, r)}\n`);
+  if (r.unclassified.length > 0 || r.gaps.length > 0) return 2;
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/tools/hygiene/audit-post-setup-script-stack.ts
+++ b/tools/hygiene/audit-post-setup-script-stack.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env bun
+// audit-post-setup-script-stack.ts — detects bash/PowerShell scripts
+// under tools/ that violate the post-setup-stack rule (post-setup
+// tooling should be bun + TypeScript by default).
+//
+// TypeScript+Bun port of audit-post-setup-script-stack.sh, slice 5
+// of the TS+Bun migration. See docs/best-practices/repo-scripting.md.
+//
+// Classification:
+//   exempt    — tools/setup/**, tools/_deprecated/**
+//   labelled  — header comment carries one of the 5 exception labels
+//   violation — bash/PowerShell under tools/ outside exempt without label
+//
+// Usage:
+//   bun tools/hygiene/audit-post-setup-script-stack.ts             # full report
+//   bun tools/hygiene/audit-post-setup-script-stack.ts --summary   # counts
+//
+// Exit codes:
+//   0   no violations (labelled + exempt acceptable)
+//   1   usage error
+//   2   one or more violations
+
+import { readFileSync } from "node:fs";
+import {
+  spawnSync,
+  type SpawnSyncReturns,
+} from "node:child_process";
+
+type AuditExitCode = 0 | 1 | 2;
+type Mode = "report" | "summary";
+
+type ParseResult =
+  | { readonly kind: "mode"; readonly mode: Mode }
+  | { readonly kind: "help" }
+  | { readonly kind: "error"; readonly message: string };
+
+interface AuditBuckets {
+  readonly exempt: readonly string[];
+  readonly labelled: readonly string[];
+  readonly violations: readonly string[];
+}
+
+const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+
+const LABEL_RE = /(bun\+TS migration candidate|bash scaffolding|thin wrapper over existing CLI|trivial find-xargs pipeline|stay bash forever)/;
+
+function classifyFailure(
+  cmd: string,
+  args: readonly string[],
+  result: SpawnSyncReturns<string>,
+): string | null {
+  if (result.error) {
+    return `Failed to start '${cmd} ${args.join(" ")}': ${result.error.message}`;
+  }
+  if (result.status === null) {
+    return `'${cmd} ${args.join(" ")}' terminated before reporting an exit code`;
+  }
+  if (result.status !== 0) {
+    return `'${cmd} ${args.join(" ")}' exited ${String(result.status)}`;
+  }
+  return null;
+}
+
+function runGit(args: readonly string[]): string {
+  const result = spawnSync(
+    // eslint-disable-next-line sonarjs/no-os-command-from-path
+    "git",
+    args,
+    { encoding: "utf8", maxBuffer: SPAWN_MAX_BUFFER },
+  );
+  const failure = classifyFailure("git", args, result);
+  if (failure !== null) throw new Error(failure);
+  return result.stdout;
+}
+
+function repoRoot(): string {
+  return runGit(["rev-parse", "--show-toplevel"]).trim();
+}
+
+function listAllScripts(): readonly string[] {
+  const raw = runGit([
+    "ls-files",
+    "-z",
+    "tools/*.sh",
+    "tools/*.ps1",
+    "tools/**/*.sh",
+    "tools/**/*.ps1",
+  ]);
+  return raw
+    .split("\0")
+    .filter((s): s is string => s.length > 0)
+    .sort((a, b) => byteCompare(a, b));
+}
+
+function byteCompare(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function isExempt(path: string): boolean {
+  return path.startsWith("tools/setup/") || path.startsWith("tools/_deprecated/");
+}
+
+function hasLabel(path: string): boolean {
+  let content: string;
+  try {
+    content = readFileSync(path, "utf8");
+  } catch {
+    return false;
+  }
+  const head = content.split("\n").slice(0, 60).join("\n");
+  return LABEL_RE.test(head);
+}
+
+function parseMode(argv: readonly string[]): ParseResult {
+  let mode: Mode = "report";
+  for (const arg of argv) {
+    if (arg === "-h" || arg === "--help") return { kind: "help" };
+    if (arg === "--summary") {
+      mode = "summary";
+      continue;
+    }
+    return { kind: "error", message: `error: unknown arg: ${arg}` };
+  }
+  return { kind: "mode", mode };
+}
+
+export function audit(): AuditBuckets {
+  const all = listAllScripts();
+  const exempt: string[] = [];
+  const labelled: string[] = [];
+  const violations: string[] = [];
+  for (const file of all) {
+    if (isExempt(file)) {
+      exempt.push(file);
+    } else if (hasLabel(file)) {
+      labelled.push(file);
+    } else {
+      violations.push(file);
+    }
+  }
+  return { exempt, labelled, violations };
+}
+
+function emitSummary(b: AuditBuckets): string {
+  return [
+    `exempt:     ${String(b.exempt.length)}`,
+    `labelled:   ${String(b.labelled.length)}`,
+    `violations: ${String(b.violations.length)}`,
+  ].join("\n");
+}
+
+function emitReportSection(title: string, items: readonly string[], hint?: string): readonly string[] {
+  const lines: string[] = [];
+  lines.push(`## ${title}`);
+  if (items.length > 0) {
+    for (const i of items) lines.push(`- ${i}`);
+  } else {
+    lines.push(hint === "clean" ? "- (none — clean)" : "- (none)");
+  }
+  return lines;
+}
+
+function emitReport(b: AuditBuckets): string {
+  // Run timestamp matches bash format `date -u +%Y-%m-%dT%H:%M:%SZ`.
+  const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const lines: string[] = [];
+  lines.push("# Post-setup script stack audit");
+  lines.push("");
+  lines.push(`Run: ${now}`);
+  lines.push("Authoritative rule: docs/POST-SETUP-SCRIPT-STACK.md");
+  lines.push("");
+  for (const l of emitReportSection(`Exempt (${String(b.exempt.length)})`, b.exempt)) lines.push(l);
+  lines.push("");
+  for (const l of emitReportSection(`Labelled exceptions (${String(b.labelled.length)})`, b.labelled)) lines.push(l);
+  lines.push("");
+  for (const l of emitReportSection(`Violations (${String(b.violations.length)})`, b.violations, "clean")) lines.push(l);
+  if (b.violations.length > 0) {
+    lines.push("");
+    lines.push("Each violation must either (a) gain an exception label");
+    lines.push("header comment (see docs/POST-SETUP-SCRIPT-STACK.md Q3");
+    lines.push("exceptions), (b) migrate to bun + TypeScript under");
+    lines.push("tools/**/*.ts, or (c) move to tools/_deprecated/ if");
+    lines.push("unused.");
+  }
+  return lines.join("\n");
+}
+
+export function main(argv: readonly string[]): AuditExitCode {
+  const parsed = parseMode(argv);
+  if (parsed.kind === "help") {
+    process.stdout.write("Usage: audit-post-setup-script-stack.ts [--summary]\n");
+    return 0;
+  }
+  if (parsed.kind === "error") {
+    process.stderr.write(`${parsed.message}\n`);
+    return 1;
+  }
+  process.chdir(repoRoot());
+  const b = audit();
+  if (parsed.mode === "summary") {
+    process.stdout.write(`${emitSummary(b)}\n`);
+  } else {
+    process.stdout.write(`${emitReport(b)}\n`);
+  }
+  return b.violations.length > 0 ? 2 : 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/tools/hygiene/audit-tick-history-bounded-growth.ts
+++ b/tools/hygiene/audit-tick-history-bounded-growth.ts
@@ -1,0 +1,199 @@
+#!/usr/bin/env bun
+// audit-tick-history-bounded-growth.ts — checks whether
+// docs/hygiene-history/loop-tick-history.md is within its
+// bounded-growth threshold.
+//
+// TypeScript+Bun port of audit-tick-history-bounded-growth.sh,
+// slice 5 of the TS+Bun migration. See
+// docs/best-practices/repo-scripting.md for conventions.
+//
+// Default threshold: 500 lines (per inline mini-ADR in bash
+// original). Override with --threshold N. Two modes: summary
+// human-readable; default terse machine-friendly.
+//
+// Usage:
+//   bun tools/hygiene/audit-tick-history-bounded-growth.ts            # terse
+//   bun tools/hygiene/audit-tick-history-bounded-growth.ts --summary  # multi-line
+//   bun tools/hygiene/audit-tick-history-bounded-growth.ts --threshold 1000
+//
+// Exit codes:
+//   0   within bounds (or approaching but not over)
+//   1   usage error / target file not found
+//   2   over threshold (archive action due)
+
+import { readFileSync } from "node:fs";
+import {
+  spawnSync,
+  type SpawnSyncReturns,
+} from "node:child_process";
+
+type AuditExitCode = 0 | 1 | 2;
+
+interface Args {
+  readonly summary: boolean;
+  readonly threshold: number;
+}
+
+type ParseResult =
+  | { readonly kind: "args"; readonly args: Args }
+  | { readonly kind: "help" }
+  | { readonly kind: "error"; readonly message: string };
+
+const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+const DEFAULT_THRESHOLD = 500;
+const TARGET_REL = "docs/hygiene-history/loop-tick-history.md";
+
+function classifyFailure(
+  cmd: string,
+  args: readonly string[],
+  result: SpawnSyncReturns<string>,
+): string | null {
+  if (result.error) {
+    return `Failed to start '${cmd} ${args.join(" ")}': ${result.error.message}`;
+  }
+  if (result.status === null) {
+    return `'${cmd} ${args.join(" ")}' terminated before reporting an exit code`;
+  }
+  if (result.status !== 0) {
+    return `'${cmd} ${args.join(" ")}' exited ${String(result.status)}`;
+  }
+  return null;
+}
+
+function repoRoot(): string {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  const failure = classifyFailure("git", ["rev-parse"], result);
+  if (failure !== null) throw new Error(failure);
+  return result.stdout.trim();
+}
+
+function reduceFlag(
+  arg: string,
+  next: string | undefined,
+  state: { summary: boolean; threshold: number },
+): { ok: true; consumed: 1 | 2 } | { ok: false; message: string } {
+  if (arg === "--summary") {
+    state.summary = true;
+    return { ok: true, consumed: 1 };
+  }
+  if (arg === "--threshold") {
+    if (next === undefined) {
+      return { ok: false, message: "error: --threshold requires a value" };
+    }
+    const n = Number(next);
+    if (!Number.isFinite(n) || n <= 0) {
+      return { ok: false, message: `error: --threshold requires a positive number, got: ${next}` };
+    }
+    state.threshold = n;
+    return { ok: true, consumed: 2 };
+  }
+  return { ok: false, message: `error: unknown argument: ${arg}` };
+}
+
+function parseArgs(argv: readonly string[]): ParseResult {
+  const state = { summary: false, threshold: DEFAULT_THRESHOLD };
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i] ?? "";
+    if (arg === "-h" || arg === "--help") return { kind: "help" };
+    const r = reduceFlag(arg, argv[i + 1], state);
+    if (!r.ok) return { kind: "error", message: r.message };
+    i += r.consumed;
+  }
+  return { kind: "args", args: { summary: state.summary, threshold: state.threshold } };
+}
+
+function lineCount(path: string): number {
+  // Match bash `wc -l < FILE`: counts newline characters.
+  let content: string;
+  try {
+    content = readFileSync(path, "utf8");
+  } catch {
+    return -1;
+  }
+  let count = 0;
+  for (const ch of content) {
+    if (ch === "\n") count += 1;
+  }
+  return count;
+}
+
+function emitSummary(target: string, lc: number, threshold: number): string {
+  const remaining = threshold - lc;
+  const pct = Math.floor((lc * 100) / threshold);
+  const lines: string[] = [];
+  lines.push("tick-history-bounded-growth audit");
+  lines.push(`  target:           ${target}`);
+  lines.push(`  line count:       ${String(lc)}`);
+  lines.push(`  threshold:        ${String(threshold)}`);
+  lines.push(`  remaining room:   ${String(remaining)} lines (${String(100 - pct)}%)`);
+  if (lc > threshold) {
+    lines.push("  status:           OVER THRESHOLD — archive action due");
+  } else if (pct >= 80) {
+    lines.push(`  status:           approaching threshold (${String(pct)}%)`);
+  } else {
+    lines.push(`  status:           within bounds (${String(pct)}%)`);
+  }
+  return lines.join("\n");
+}
+
+function emitTerse(lc: number, threshold: number): { text: string; code: AuditExitCode } {
+  const pct = Math.floor((lc * 100) / threshold);
+  if (lc > threshold) {
+    return {
+      text: [
+        `OVER threshold: ${String(lc)}/${String(threshold)} lines (${String(pct)}%). Archive action due.`,
+        "Expected action: move first 80% of rows to docs/hygiene-history/loop-tick-history-YYYY-QN-archive.md and leave a pointer.",
+      ].join("\n"),
+      code: 2,
+    };
+  }
+  if (pct >= 80) {
+    return {
+      text: `APPROACHING threshold: ${String(lc)}/${String(threshold)} lines (${String(pct)}%).`,
+      code: 0,
+    };
+  }
+  return {
+    text: `within bounds: ${String(lc)}/${String(threshold)} lines (${String(pct)}%).`,
+    code: 0,
+  };
+}
+
+export function main(argv: readonly string[]): AuditExitCode {
+  const parsed = parseArgs(argv);
+  if (parsed.kind === "help") {
+    process.stdout.write(
+      "Usage: audit-tick-history-bounded-growth.ts [--summary] [--threshold N]\n",
+    );
+    return 0;
+  }
+  if (parsed.kind === "error") {
+    process.stderr.write(`${parsed.message}\n`);
+    return 1;
+  }
+  const { args } = parsed;
+  const root = repoRoot();
+  const target = `${root}/${TARGET_REL}`;
+  const lc = lineCount(target);
+  if (lc < 0) {
+    process.stderr.write(`error: target file not found: ${target}\n`);
+    return 1;
+  }
+
+  if (args.summary) {
+    process.stdout.write(`${emitSummary(target, lc, args.threshold)}\n`);
+    return lc > args.threshold ? 2 : 0;
+  }
+  const out = emitTerse(lc, args.threshold);
+  process.stdout.write(`${out.text}\n`);
+  return out.code;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Summary

Slice 5 of the TS/Bun migration. Cluster E (3 hygiene audit scripts):

- \`audit-tick-history-bounded-growth.{sh→ts}\` — line-count threshold check
- \`audit-post-setup-script-stack.{sh→ts}\` — classify scripts as exempt/labelled/violation
- \`audit-missing-prevention-layers.{sh→ts}\` — meta-hygiene matrix from FACTORY-HYGIENE.md

Per Gate B prerequisite (verified currency of layered baseline 1 day old).

## New pattern this slice

**\`trimSpaces\` pure helper**: bash awk's \`sub(/^ +/, "")\` and \`sub(/ +$/, "")\` patterns trigger sonarjs/slow-regex. Replacing with a pure-function character-walk (manual head/tail trim) avoids the lint flag without changing semantics. Recorded for future ports.

## Equivalence

Per-file bash-vs-TS diff against current repo state:
- \`audit-tick-history-bounded-growth\`: byte-equivalent under both terse and --summary modes.
- \`audit-post-setup-script-stack\`: byte-equivalent under --summary; report mode equivalent modulo Run: timestamp.
- \`audit-missing-prevention-layers\`: byte-equivalent modulo Run: timestamp.

## Test plan

- [x] tsc --noEmit clean
- [x] eslint clean
- [x] Bash-vs-TS equivalence per file
- [x] markdownlint clean
- [x] Slice-5 audit landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)