### PR TITLE
ts(B-0086): port 3 check-only hygiene scripts (.sh→.ts) — slice 6 of TS/Bun migration

### DIFF
--- a/docs/trajectories/typescript-bun-migration/slice-audits.md
+++ b/docs/trajectories/typescript-bun-migration/slice-audits.md
@@ -366,6 +366,51 @@ Per-port pattern checklist:
 
 Slice 5 passes audit. New pattern recorded: `trimSpaces` pure helper as eslint-clean alternative to anchored space-stripping regexes (avoids sonarjs/slow-regex flag).
 
+## Slice 6 — 3 check-only hygiene ports (PR #NNN, 2026-04-30)
+
+**Slice files**:
+
+- `tools/hygiene/check-no-conflict-markers.{sh→ts}`
+- `tools/hygiene/check-archive-header-section33.{sh→ts}`
+- `tools/hygiene/check-tick-history-order.{sh→ts}`
+
+**Slice scope adjustment**: Cluster F was 4 files; `append-tick-history-row.sh` is a write-side script (file mutation) and warrants its own careful equivalence-test setup with file-state preservation. Deferred to slice 7+.
+
+**Comparison points**: Layered baseline verified 2026-04-30 (1 day old). Slices 1-5 canonical patterns reused.
+
+### Code-pattern audit
+
+| Check | Result |
+|---|---|
+| No `any` uses | 0 matches |
+| No `as` casts | 0 matches |
+| Project typecheck clean | 0 errors |
+| ESLint strictTypeChecked | 0 errors |
+
+Per-port pattern checklist:
+
+- **Applied (all 3)**: typed boundary objects (Violation, Row).
+- **Applied (all 3)**: literal-type union exit codes.
+- **Applied (all 3)**: self-allowlist where applicable (this script's bash + ts paths).
+- **`check-no-conflict-markers`**: per-line scan with `MARKER_RE` (mirrors bash POSIX `[[:space:]]` via `[\t ]`).
+- **`check-archive-header-section33`**: file-walker with content-hint detection; enum-strict `OP_STATUS_VALID_RE` for the operational-status value.
+- **`check-tick-history-order`**: ISO-8601 lex-sortable string comparison (timestamp format chosen for this property).
+
+### DST + coverage audit
+
+- **DST-friendly: applied** — none of the 3 ports introduce time/random/scheduler dependencies.
+- **Coverage: deferred** — bash originals had no tests; ports don't introduce a new module.
+
+### Equivalence audit
+
+- **`check-no-conflict-markers`**: byte-equivalent against current repo state.
+- **`check-archive-header-section33`**: byte-equivalent against current repo state.
+- **`check-tick-history-order`**: byte-equivalent against current repo state.
+
+### Outcome
+
+Slice 6 passes audit. No new patterns recorded — all reused from prior slices.
+
 ## Slice template (for future slices)
 
 Copy this section header and fill out before merging the slice's PR:

--- a/tools/hygiene/check-archive-header-section33.ts
+++ b/tools/hygiene/check-archive-header-section33.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env bun
+// check-archive-header-section33.ts — validates §33 archive header
+// on courier-ferry / external-conversation imports under docs/research/**.
+//
+// TypeScript+Bun port of check-archive-header-section33.sh, slice 6
+// of the TS+Bun migration. See docs/best-practices/repo-scripting.md.
+//
+// What this checks:
+//   For every docs/research/**.md file matching a courier-ferry
+//   import pattern (filename or first-20-lines content):
+//   - First 20 lines contain all 4 required §33 labels at line-start.
+//   - "Operational status:" value is enum-strict (research-grade |
+//     operational; trailing whitespace tolerated).
+//
+// Usage:
+//   bun tools/hygiene/check-archive-header-section33.ts
+//
+// Exit codes:
+//   0   clean (or no docs/research/)
+//   1   one or more violations
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+type ExitCode = 0 | 1;
+
+interface Violation {
+  readonly file: string;
+  readonly missing: readonly string[];
+  readonly badValue: string;
+}
+
+const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+
+const REQUIRED_LABELS: readonly string[] = [
+  "Scope:",
+  "Attribution:",
+  "Operational status:",
+  "Non-fusion disclaimer:",
+];
+
+const FILENAME_HINT_RE = /(courier-ferry|cross-substrate|external-import|cross-ferry)/;
+const CONTENT_HINT_RE = /(courier.ferry|external conversation|external collaborator|external research agent|courier-ferry capture)/i;
+const OP_STATUS_LINE_RE = /^Operational status:.*$/m;
+const OP_STATUS_VALID_RE = /^Operational status: (research-grade|operational)[\t ]*$/;
+
+function repoRoot(): string {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  if (result.status !== 0) return process.cwd();
+  return result.stdout.trim();
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function listMarkdownRecursive(dir: string): readonly string[] {
+  const out: string[] = [];
+  const stack: string[] = [dir];
+  while (stack.length > 0) {
+    const cur = stack.pop();
+    if (cur === undefined) continue;
+    let entries: readonly import("node:fs").Dirent[];
+    try {
+      entries = readdirSync(cur, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = join(cur, e.name);
+      if (e.isDirectory()) stack.push(full);
+      else if (e.isFile() && e.name.endsWith(".md")) out.push(full);
+    }
+  }
+  return out;
+}
+
+function readHead(path: string, n: number): string {
+  let content: string;
+  try {
+    content = readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+  return content.split("\n").slice(0, n).join("\n");
+}
+
+function isCourierFerryImport(file: string, headerRegion: string): boolean {
+  if (FILENAME_HINT_RE.test(file)) return true;
+  return CONTENT_HINT_RE.test(headerRegion);
+}
+
+function findMissingLabels(headerRegion: string): readonly string[] {
+  const missing: string[] = [];
+  const lines = headerRegion.split("\n");
+  for (const label of REQUIRED_LABELS) {
+    const found = lines.some((line) => line.startsWith(label));
+    if (!found) missing.push(label);
+  }
+  return missing;
+}
+
+function findBadOpStatusValue(headerRegion: string): string {
+  if (!/^Operational status:/m.test(headerRegion)) return "";
+  const match = OP_STATUS_LINE_RE.exec(headerRegion);
+  if (match === null) return "";
+  const opLine = match[0];
+  if (OP_STATUS_VALID_RE.test(opLine)) return "";
+  return opLine;
+}
+
+export function audit(researchDir: string): readonly Violation[] {
+  if (!isDirectory(researchDir)) return [];
+  const files = listMarkdownRecursive(researchDir);
+  const out: Violation[] = [];
+  for (const file of files) {
+    const header = readHead(file, 20);
+    if (!isCourierFerryImport(file, header)) continue;
+    const missing = findMissingLabels(header);
+    const badValue = findBadOpStatusValue(header);
+    if (missing.length > 0 || badValue !== "") {
+      out.push({ file, missing, badValue });
+    }
+  }
+  return out;
+}
+
+function relativize(file: string, root: string): string {
+  const prefix = `${root}/`;
+  return file.startsWith(prefix) ? file.slice(prefix.length) : file;
+}
+
+export function main(): ExitCode {
+  const root = repoRoot();
+  const researchDir = `${root}/docs/research`;
+
+  if (!isDirectory(researchDir)) {
+    process.stdout.write("OK: docs/research/ does not exist; nothing to check\n");
+    return 0;
+  }
+
+  const violations = audit(researchDir);
+
+  for (const v of violations) {
+    const rel = relativize(v.file, root);
+    if (v.missing.length > 0) {
+      process.stderr.write(
+        `VIOLATION: ${rel} missing §33 labels: ${v.missing.join(" ")}\n`,
+      );
+    }
+    if (v.badValue !== "") {
+      process.stderr.write(
+        `VIOLATION: ${rel} 'Operational status:' value not enum-strict (must be 'research-grade' or 'operational' alone): ${v.badValue}\n`,
+      );
+    }
+  }
+
+  if (violations.length > 0) {
+    process.stderr.write("\n");
+    process.stderr.write(
+      `FAIL: ${String(violations.length)} courier-ferry research-doc(s) missing GOVERNANCE.md §33 archive header(s)\n`,
+    );
+    process.stderr.write("\n");
+    process.stderr.write("Required header (literal label form, NOT bold-styled) in first 20 lines:\n");
+    process.stderr.write("  Scope: <one-line scope>\n");
+    process.stderr.write("  Attribution: <named entities + first-name attribution per Otto-279>\n");
+    process.stderr.write("  Operational status: <research-grade vs operational-policy>\n");
+    process.stderr.write("  Non-fusion disclaimer: <attribution boundary preservation>\n");
+    process.stderr.write("\n");
+    process.stderr.write("Pattern reference: see PR #570 / #566 / #563 §33-header fixes for examples.\n");
+    return 1;
+  }
+
+  process.stdout.write("OK: all courier-ferry research docs have §33 archive headers\n");
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/tools/hygiene/check-no-conflict-markers.ts
+++ b/tools/hygiene/check-no-conflict-markers.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env bun
+// check-no-conflict-markers.ts — fails the build if any committed
+// file contains git merge-conflict markers (<<<<<<<, =======, >>>>>>>).
+//
+// TypeScript+Bun port of check-no-conflict-markers.sh, slice 6 of
+// the TS+Bun migration. See docs/best-practices/repo-scripting.md.
+//
+// What this checks:
+//   - All tracked files (via `git ls-files`) for the three conflict
+//     marker patterns at line-start.
+//   - Reports each violation with file:line.
+//   - Exits non-zero if any found.
+//
+// Usage:
+//   bun tools/hygiene/check-no-conflict-markers.ts
+//
+// Exit codes:
+//   0   clean
+//   1   conflict markers found
+
+import { readFileSync } from "node:fs";
+import {
+  spawnSync,
+  type SpawnSyncReturns,
+} from "node:child_process";
+
+type ExitCode = 0 | 1;
+
+interface Violation {
+  readonly file: string;
+  readonly line: number;
+  readonly content: string;
+}
+
+const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+const SELF_PATH = "tools/hygiene/check-no-conflict-markers.sh";
+
+const ALLOWLIST: readonly string[] = [
+  SELF_PATH,
+  "tools/hygiene/check-no-conflict-markers.ts",
+  "memory/feedback_otto_341_lint_suppression_is_self_deception_noise_signal_or_underlying_fix_greenfield_large_refactors_welcome_training_data_human_shortcut_bias_2026_04_26.md",
+];
+
+const MARKER_RE = /^(<<<<<<<[\t ]|=======$|>>>>>>>[\t ])/;
+
+function classifyFailure(
+  cmd: string,
+  args: readonly string[],
+  result: SpawnSyncReturns<string>,
+): string | null {
+  if (result.error) {
+    return `Failed to start '${cmd} ${args.join(" ")}': ${result.error.message}`;
+  }
+  if (result.status === null) {
+    return `'${cmd} ${args.join(" ")}' terminated before reporting an exit code`;
+  }
+  if (result.status !== 0) {
+    return `'${cmd} ${args.join(" ")}' exited ${String(result.status)}`;
+  }
+  return null;
+}
+
+function repoRoot(): string {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  // Bash falls back to pwd if git fails; mirror that.
+  if (result.status !== 0) return process.cwd();
+  return result.stdout.trim();
+}
+
+function listTrackedFiles(): readonly string[] {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", ["ls-files"], {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  const failure = classifyFailure("git", ["ls-files"], result);
+  if (failure !== null) throw new Error(failure);
+  return result.stdout.split("\n").filter((s) => s.length > 0);
+}
+
+function isAllowed(path: string): boolean {
+  return ALLOWLIST.includes(path);
+}
+
+function checkFile(path: string): readonly Violation[] {
+  let content: string;
+  try {
+    content = readFileSync(path, "utf8");
+  } catch {
+    return [];
+  }
+  const out: Violation[] = [];
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (MARKER_RE.test(line)) {
+      out.push({ file: path, line: i + 1, content: line });
+    }
+  }
+  return out;
+}
+
+export function audit(): readonly Violation[] {
+  const all = listTrackedFiles();
+  const out: Violation[] = [];
+  for (const file of all) {
+    if (isAllowed(file)) continue;
+    out.push(...checkFile(file));
+  }
+  return out;
+}
+
+export function main(): ExitCode {
+  process.chdir(repoRoot());
+  const violations = audit();
+  if (violations.length > 0) {
+    let firstHit = "";
+    for (const v of violations) {
+      const hit = `${v.file}:${String(v.line)}:${v.content}`;
+      if (firstHit === "") firstHit = hit;
+      process.stderr.write(`VIOLATION: ${hit}\n`);
+    }
+    process.stderr.write("\n");
+    process.stderr.write(
+      `FAIL: ${String(violations.length)} git merge-conflict marker line(s) found in committed files\n`,
+    );
+    process.stderr.write("\n");
+    process.stderr.write(`First hit: ${firstHit}\n`);
+    process.stderr.write("\n");
+    process.stderr.write("How to fix:\n");
+    process.stderr.write("  - Open each flagged file\n");
+    process.stderr.write(
+      "  - Resolve the conflict (pick one side, both sides, or\n",
+    );
+    process.stderr.write("    re-merge manually); REMOVE all marker lines\n");
+    process.stderr.write(
+      "  - Verify by re-running this script (exit 0 = clean)\n",
+    );
+    process.stderr.write("\n");
+    process.stderr.write(
+      "If a file legitimately discusses these markers (docs about\n",
+    );
+    process.stderr.write(
+      "merge resolution, this script itself, or substrate files\n",
+    );
+    process.stderr.write(
+      "documenting merge-conflict-resolution work), add the path\n",
+    );
+    process.stderr.write("to the ALLOWLIST in this script.\n");
+    return 1;
+  }
+  process.stdout.write("OK: no git merge-conflict markers found in committed files\n");
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/tools/hygiene/check-tick-history-order.ts
+++ b/tools/hygiene/check-tick-history-order.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env bun
+// check-tick-history-order.ts — validates that tick-history rows
+// appear in non-decreasing chronological order (ISO-8601 UTC).
+//
+// TypeScript+Bun port of check-tick-history-order.sh, slice 6 of
+// the TS+Bun migration. See docs/best-practices/repo-scripting.md.
+//
+// What this checks:
+//   - Every row matching `| YYYY-MM-DDTHH:MM:SSZ (...)` is extracted
+//     in file order.
+//   - Timestamps must be non-decreasing (duplicates allowed).
+//   - First violation reported with surrounding context.
+//
+// Usage:
+//   bun tools/hygiene/check-tick-history-order.ts [TICK_FILE]
+//
+// Exit codes:
+//   0  order is fine (or fewer than 2 rows)
+//   1  one or more rows out of order
+//   2  tick-history file not found
+
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+type ExitCode = 0 | 1 | 2;
+
+interface Row {
+  readonly lineNum: number;
+  readonly ts: string;
+  readonly raw: string;
+}
+
+interface Violation {
+  readonly lineNum: number;
+  readonly ts: string;
+  readonly prevLineNum: number;
+  readonly prevTs: string;
+  readonly raw: string;
+  readonly prevRaw: string;
+}
+
+const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+
+const ROW_RE = /^\| (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)/;
+
+function repoRoot(): string {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  if (result.status !== 0) return process.cwd();
+  return result.stdout.trim();
+}
+
+function extractRows(content: string): readonly Row[] {
+  const out: Row[] = [];
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const m = ROW_RE.exec(line);
+    if (m === null) continue;
+    const ts = m[1] ?? "";
+    out.push({ lineNum: i + 1, ts, raw: line });
+  }
+  return out;
+}
+
+function findViolations(rows: readonly Row[]): readonly Violation[] {
+  if (rows.length < 2) return [];
+  const out: Violation[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const prev = rows[i - 1];
+    const cur = rows[i];
+    if (prev === undefined || cur === undefined) continue;
+    if (cur.ts < prev.ts) {
+      out.push({
+        lineNum: cur.lineNum,
+        ts: cur.ts,
+        prevLineNum: prev.lineNum,
+        prevTs: prev.ts,
+        raw: cur.raw,
+        prevRaw: prev.raw,
+      });
+    }
+  }
+  return out;
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n);
+}
+
+export function main(argv: readonly string[]): ExitCode {
+  const root = repoRoot();
+  const tickFile =
+    argv[0] ?? `${root}/docs/hygiene-history/loop-tick-history.md`;
+
+  let content: string;
+  try {
+    content = readFileSync(tickFile, "utf8");
+  } catch {
+    process.stderr.write(`ERROR: tick-history file not found at ${tickFile}\n`);
+    return 2;
+  }
+
+  const rows = extractRows(content);
+
+  if (rows.length < 2) {
+    process.stdout.write(
+      `OK: tick-history has ${String(rows.length)} row(s); nothing to check\n`,
+    );
+    return 0;
+  }
+
+  const violations = findViolations(rows);
+
+  for (const v of violations) {
+    process.stderr.write(
+      `VIOLATION: row at line ${String(v.lineNum)} has timestamp ${v.ts}\n`,
+    );
+    process.stderr.write(
+      `  but previous row at line ${String(v.prevLineNum)} has timestamp ${v.prevTs}\n`,
+    );
+    process.stderr.write("  (timestamps must be non-decreasing in file order)\n");
+    process.stderr.write("\n");
+    process.stderr.write("  context — offending row tail:\n");
+    process.stderr.write(`    ${truncate(v.raw, 200)}\n`);
+    process.stderr.write("\n");
+    process.stderr.write("  context — preceding row tail:\n");
+    process.stderr.write(`    ${truncate(v.prevRaw, 200)}\n`);
+    process.stderr.write("\n");
+  }
+
+  if (violations.length > 0) {
+    process.stderr.write("\n");
+    process.stderr.write(
+      `FAIL: ${String(violations.length)} row(s) out of chronological order in ${tickFile}\n`,
+    );
+    process.stderr.write("\n");
+    process.stderr.write("How to fix:\n");
+    process.stderr.write("  - For NEW rows: revert and re-append using bash heredoc\n");
+    process.stderr.write(
+      "    (cat >> file << EOF) or tools/hygiene/append-tick-history-row.sh\n",
+    );
+    process.stderr.write("  - For HISTORICAL disorder: Otto-229 one-case override is\n");
+    process.stderr.write("    authorized (Aaron 2026-04-26: 'we have git history to\n");
+    process.stderr.write("    keep us honest so no risk of permanat loss'). Re-order\n");
+    process.stderr.write("    rows physically; git preserves the prior state.\n");
+    process.stderr.write("  - Do NOT add an opt-in flag to suppress these violations.\n");
+    process.stderr.write(
+      "    That is the Otto-341 self-deception pattern Aaron caught.\n",
+    );
+    return 1;
+  }
+
+  process.stdout.write(
+    `OK: ${String(rows.length)} tick-history rows in non-decreasing chronological order\n`,
+  );
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Summary

Slice 6 of the TS/Bun migration. Cluster F (3 of 4 check-only hygiene scripts):

- \`check-no-conflict-markers.{sh→ts}\` — git merge-conflict marker detector
- \`check-archive-header-section33.{sh→ts}\` — GOVERNANCE.md §33 archive header validator
- \`check-tick-history-order.{sh→ts}\` — chronological order check on tick-history rows

**Slice scope adjustment**: Cluster F was 4 files; \`append-tick-history-row.sh\` is a write-side script (file mutation) and warrants its own careful equivalence-test setup with file-state preservation. Deferred to slice 7+.

Per Gate B prerequisite (verified currency of layered baseline 1 day old).

## Equivalence

Per-file bash-vs-TS diff against current repo state:
- \`check-no-conflict-markers\`: byte-equivalent (no markers found).
- \`check-archive-header-section33\`: byte-equivalent (all docs have headers).
- \`check-tick-history-order\`: byte-equivalent (rows in non-decreasing order).

## Test plan

- [x] \`bun x tsc --noEmit\` clean
- [x] \`bun x eslint <slice files>\` clean
- [x] Bash-vs-TS equivalence per file
- [x] markdownlint clean
- [x] Slice-6 audit landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)