### PR TITLE
ts(B-0086): port 3 audit/lint scripts (.sh→.ts) — slice 8 of TS/Bun migration

### DIFF
--- a/docs/trajectories/typescript-bun-migration/RESUME.md
+++ b/docs/trajectories/typescript-bun-migration/RESUME.md
@@ -1,9 +1,9 @@
 # Trajectory — TypeScript / Bun migration
 
-**Status**: Active (Lane B slice 6 merged — [#876](https://github.com/Lucent-Financial-Group/Zeta/pull/876), commit `02baabc`)
-**Milestone**: 22 hygiene/lint scripts ported (2 from #849 + 3 from #866 + 3 from #868 + 3 from #870 + 2 from #872 + 3 from #874 + 3 from #876 + 3 from PR #878). **Cluster H-3-of-5 complete in PR #878 (no-empty-dirs, safety-clause-audit, doc-comment-history-audit); 2 remain in slice-8 (no-directives-otto-prose at 261 lines + runner-version-freshness at 356 lines).** This row updates atomically with the PR #878 merge — the count + PR-list are merge-stable; subsequent slices append a row, not edit this one.
+**Status**: Active (Lane B slice 7 merged — [#878](https://github.com/Lucent-Financial-Group/Zeta/pull/878), commit `4dac957`)
+**Milestone**: 25 hygiene/lint/audit scripts ported (2 from #849 + 3 from #866 + 3 from #868 + 3 from #870 + 2 from #872 + 3 from #874 + 3 from #876 + 3 from #878 + 3 in-flight in slice-8). **Cluster H complete (5/5): #878 landed 3 lint-pattern ports (no-empty-dirs, safety-clause-audit, doc-comment-history-audit); slice-8 finishes Cluster H with no-directives-otto-prose + runner-version-freshness, plus the live-lock-audit port from `tools/audit/`.** 19 Bucket B files remain.
 **Current blocker**: None.
-**Next concrete action**: Pick a coherent next slice from Bucket B (22 files remaining). Per Gate B: read-only scope first, then re-verify the layered baseline currency before first mutating action.
+**Next concrete action**: Pick a coherent next slice from Bucket B (19 files remaining). Per Gate B: read-only scope first, then re-verify the layered baseline currency before first mutating action.
 **Last updated**: 2026-04-30
 
 ## Why this trajectory exists
@@ -59,13 +59,12 @@ tools/profile.sh
 
 Rationale: TS/Bun is itself one of the things `install.sh` installs. These scripts cannot depend on Bun.
 
-### Bucket B — Should become TypeScript (22 files remaining)
+### Bucket B — Should become TypeScript (19 files remaining)
 
-Post-install scripts that operate on the repo (lints, audits, hygiene checks, peer-call wrappers, budget reports, git ops). Same shape as the scripts ported in #849, #866, #868, #870, #872, #874, #876. Seventeen originally-listed audit scripts are now ported to TS and removed from this list; the bash originals remain in-tree as the equivalence reference and will retire once the TS ports have soaked.
+Post-install scripts that operate on the repo (lints, audits, hygiene checks, peer-call wrappers, budget reports, git ops). Same shape as the scripts ported in #849, #866, #868, #870, #872, #874, #876, #878. Twenty-three originally-listed audit/lint scripts are now ported to TS and removed from this list (3 in slice-8 in flight); the bash originals remain in-tree as the equivalence reference and will retire once the TS ports have soaked.
 
 ```text
 tools/audit-packages.sh
-tools/audit/live-lock-audit.sh
 tools/backlog/generate-index.sh
 tools/budget/daily-cost-report.sh
 tools/budget/project-runway.sh
@@ -77,10 +76,6 @@ tools/hygiene/audit-agencysignature-main-tip.sh
 tools/hygiene/capture-tick-snapshot.sh
 tools/hygiene/counterweight-audit.sh
 tools/hygiene/validate-agencysignature-pr-body.sh
-tools/lint/doc-comment-history-audit.sh
-tools/lint/no-directives-otto-prose.sh
-tools/lint/no-empty-dirs.sh
-tools/lint/runner-version-freshness.sh
 tools/peer-call/codex.sh
 tools/peer-call/gemini.sh
 tools/peer-call/grok.sh
@@ -105,9 +100,9 @@ tools/lint/safety-clause-audit.sh
 
 Rationale: borderline — depends on whether the lint can be expressed as cleanly in TS as it currently is in shell. Worth a small comparison before committing the port.
 
-### Bucket D — Ported, bash retained (17 files)
+### Bucket D — Ported, bash retained (23 files)
 
-The TS ports landed in #866 + #868 + #870 + #872 + #874 + #876; the bash originals stay in-tree as equivalence references and will retire once the TS ports have soaked.
+The TS ports landed in #866 + #868 + #870 + #872 + #874 + #876 + #878 (3 more in slice-8 PR in flight); the bash originals stay in-tree as equivalence references and will retire once the TS ports have soaked.
 
 ```text
 tools/hygiene/audit-md032-plus-linestart.sh        # ported in #866
@@ -127,9 +122,12 @@ tools/hygiene/audit-missing-prevention-layers.sh   # ported in #874
 tools/hygiene/check-no-conflict-markers.sh         # ported in #876
 tools/hygiene/check-archive-header-section33.sh    # ported in #876
 tools/hygiene/check-tick-history-order.sh          # ported in #876
-tools/lint/no-empty-dirs.sh                        # ported on slice-7 branch (in flight)
-tools/lint/safety-clause-audit.sh                  # ported on slice-7 branch (in flight)
-tools/lint/doc-comment-history-audit.sh            # ported on slice-7 branch (in flight)
+tools/lint/no-empty-dirs.sh                        # ported in #878
+tools/lint/safety-clause-audit.sh                  # ported in #878
+tools/lint/doc-comment-history-audit.sh            # ported in #878
+tools/lint/runner-version-freshness.sh             # ported in slice-8 PR (in flight)
+tools/lint/no-directives-otto-prose.sh             # ported in slice-8 PR (in flight)
+tools/audit/live-lock-audit.sh                     # ported in slice-8 PR (in flight)
 ```
 
 ## Recommended next slice

--- a/docs/trajectories/typescript-bun-migration/slice-audits.md
+++ b/docs/trajectories/typescript-bun-migration/slice-audits.md
@@ -411,7 +411,45 @@ Per-port pattern checklist:
 
 Slice 6 passes audit. No new patterns recorded — all reused from prior slices.
 
-## Slice 7 — 3 lint-pattern ports (PR pending — `lane-b/ts-bun-slice-7-lint-scripts-2026-04-30`)
+## Slice 8 — 3 ports (Cluster H finish + audit-cluster start) (PR pending — `lane-b/ts-bun-slice-8-runner-version-freshness-2026-04-30`)
+
+**Slice files**:
+
+- `tools/lint/runner-version-freshness.{sh→ts}`
+- `tools/lint/no-directives-otto-prose.{sh→ts}`
+- `tools/audit/live-lock-audit.{sh→ts}`
+
+**Comparison points**: identical to slice 6/7 (TypeScript 6.0, Bun 1.3, typescript-eslint v8, `../SQLSharp` at `7d3d9f6`, `../scratch` at mtime `2026-04-15`). Within Gate B 30-day window — no re-verification needed.
+
+### Tsconfig audit
+
+- Reuses repo `tsconfig.json` (no per-slice deviation).
+- All 3 files compile under `bun x tsc --noEmit` clean.
+
+### Eslint audit
+
+- All 3 files clean under `eslint` (typescript-eslint strictTypeChecked + stylisticTypeChecked + sonarjs).
+- Pattern: `eslint-disable-next-line sonarjs/no-os-command-from-path` reused on `git` invocations only (intentional — same as prior slices).
+
+### Code-pattern audit (per-port)
+
+- **`runner-version-freshness.ts`** (356 lines bash → 394 lines TS): three label arrays (ALLOWED_LABELS / ROLLING_ALIASES / STALE_LABELS) preserved verbatim. Bash escape_for_regex sed expression replaced with single `String.replace(REGEX_META_RE, ...)` matching the same metachar set. Bash `_verify_age_ok` cross-platform date arithmetic (BSD `date -j -f` + GNU `date -d` branches) replaced with single `Date.parse` + `Math.floor` on ms delta. Bash trailing-comment regex (sonarjs/slow-regex flag) replaced with manual char walk in `stripTrailingComment`. Three scan helpers (scanStaleOrRolling / scanUnknownScalar / scanUnknownMatrix) match the bash three-pass structure 1:1.
+- **`no-directives-otto-prose.ts`** (261 lines bash → 316 lines TS): bash 4-alternative regex split into 4 RegExp[] entries via matchesDirective (each individually under sonarjs/regex-complexity). Bash temp-file pipeline replaced with in-memory AddedLine[] arrays. Bash `git diff -U0 | awk` → TS `extractAddedLinesFromDiff` with `isAddedContentLine` helper. Worktree-mode 4-source merge preserved verbatim with Set-based dedup. Untracked-file detection (`git ls-files --error-unmatch`) preserved as `isUntracked()` helper.
+- **`live-lock-audit.ts`** (116 lines bash → 245 lines TS): bash `git fetch || true` → fire-and-forget spawnSync. Bash origin/main verify guard preserved. Per-commit `git log -m --first-parent --name-only` (Codex P1 PR #147 merge-classification fix) preserved verbatim. Three regex `grep -cE` → three RegExp test-and-count helpers. Bash `printf "%2d   %3d%%"` → manual pad2/pad3 helpers for byte-equivalence. LIVELOCK_MIN_EXT_PCT env var preserved. WINDOW positional arg validation preserved.
+
+### Equivalence audit
+
+Diff'd against bash output on this repo state (2026-04-30 main):
+
+- **`runner-version-freshness`**: byte-equivalent against bash on the live workflow tree + 3 synthetic fixtures (stale ubuntu-22.04 / rolling ubuntu-latest / matrix mixed stale+allowed).
+- **`no-directives-otto-prose`**: byte-equivalent across both `pr` (default) and `worktree` SCOPE modes.
+- **`live-lock-audit`**: byte-equivalent across window=5 + window=25; sole intentional diff is the script self-reference (.sh vs .ts) in the usage-error message — same pattern as prior ports.
+
+### Outcome
+
+Slice 8 passes audit. **Cluster H complete (5/5)**: all five lint-pattern scripts now have TS ports. New cluster opened: `audit-cluster` starts with `live-lock-audit` (slice 8). Bucket B reduced from 22 → 19 remaining files. No new patterns recorded — all reused from prior slices.
+
+## Slice 7 — 3 lint-pattern ports (PR #878, merged 2026-04-30, commit `4dac957`)
 
 **Slice files**:
 

--- a/tools/audit/live-lock-audit.ts
+++ b/tools/audit/live-lock-audit.ts
@@ -1,0 +1,245 @@
+#!/usr/bin/env bun
+// live-lock-audit.ts — classify the last N commits on origin/main into
+// external (src/tests/samples/bench), internal-factory (tick-history /
+// BACKLOG / round-history / .claude), or speculative (research / memory /
+// DECISIONS), and flag the live-lock smell when the external ratio is
+// overwhelmed.
+//
+// TypeScript+Bun port of live-lock-audit.sh, slice 8 of the TS+Bun
+// migration. See docs/best-practices/repo-scripting.md.
+//
+// Factory-health signal: external-code motion (product-surface changes)
+// should not be zero over a rolling window. When it is, the factory is
+// spinning on process work without shipping — live-lock.
+//
+// Usage:
+//   bun tools/audit/live-lock-audit.ts [N]
+//   N defaults to 25.
+//
+// Exit codes:
+//   0  healthy — external ratio at or above threshold
+//   1  smell firing — external ratio below threshold
+//   2  usage / environment error (bad WINDOW, no origin/main, etc.)
+//
+// Env:
+//   LIVELOCK_MIN_EXT_PCT — minimum healthy external-commit % (default 20)
+
+import { spawnSync } from "node:child_process";
+
+type ExitCode = 0 | 1 | 2;
+
+const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+
+const DEFAULT_WINDOW = 25;
+const DEFAULT_THRESHOLD = 20;
+
+const POSITIVE_INT_RE = /^[1-9]\d*$/;
+const EXT_RE = /^(?:src|tests|samples|bench)\//;
+const RESEARCH_RE = /^(?:docs\/research|memory|docs\/DECISIONS)\//;
+const META_RE = /^(?:docs\/ROUND-HISTORY|docs\/hygiene-history|\.claude|docs\/BACKLOG)/;
+
+interface Counts {
+  readonly ext: number;
+  readonly intl: number;
+  readonly spec: number;
+  readonly other: number;
+  readonly lines: readonly string[];
+}
+
+function gitOutput(args: readonly string[]): {
+  status: number;
+  stdout: string;
+} {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", args, {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  return { status: result.status ?? 1, stdout: result.stdout };
+}
+
+function parseWindow(arg: string | undefined): number | null {
+  if (arg === undefined) return DEFAULT_WINDOW;
+  if (!POSITIVE_INT_RE.test(arg)) return null;
+  return Number.parseInt(arg, 10);
+}
+
+function getThreshold(): number {
+  const env = process.env.LIVELOCK_MIN_EXT_PCT;
+  if (env === undefined) return DEFAULT_THRESHOLD;
+  if (!POSITIVE_INT_RE.test(env)) return DEFAULT_THRESHOLD;
+  return Number.parseInt(env, 10);
+}
+
+function fetchOriginMain(): void {
+  // Fire-and-forget; bash version uses `|| true`. Keep going regardless.
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  spawnSync("git", ["fetch", "origin", "main", "--quiet"], {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+}
+
+function originMainResolves(): boolean {
+  return (
+    gitOutput(["rev-parse", "--verify", "--quiet", "origin/main"]).status === 0
+  );
+}
+
+function listCommitShas(window: number): readonly string[] {
+  const out = gitOutput([
+    "log",
+    "origin/main",
+    `-${String(window)}`,
+    "--format=%H",
+  ]);
+  return out.stdout.split("\n").filter((s) => s.length > 0);
+}
+
+function commitFiles(sha: string): readonly string[] {
+  // -m --first-parent: classify merge commits by what they actually
+  // *introduced* to origin/main (parent 1 diff), not the union of both
+  // parents. Mirrors bash original (Codex P1 on PR #147).
+  const out = gitOutput([
+    "log",
+    "-1",
+    "-m",
+    "--first-parent",
+    "--name-only",
+    "--format=",
+    sha,
+  ]);
+  return out.stdout.split("\n").filter((s) => s.length > 0);
+}
+
+function commitSubject(sha: string): string {
+  const out = gitOutput(["log", "-1", "--format=%s", sha]);
+  return out.stdout.split("\n")[0]?.slice(0, 72) ?? "";
+}
+
+function classifyCommit(files: readonly string[]): "EXT " | "INTL" | "SPEC" | "OTHR" {
+  const src = files.filter((f) => EXT_RE.test(f)).length;
+  const research = files.filter((f) => RESEARCH_RE.test(f)).length;
+  const meta = files.filter((f) => META_RE.test(f)).length;
+  if (src > 0) return "EXT ";
+  if (meta > 0 && research <= meta) return "INTL";
+  if (research > 0) return "SPEC";
+  return "OTHR";
+}
+
+function tallyCommits(shas: readonly string[]): Counts {
+  let ext = 0;
+  let intl = 0;
+  let spec = 0;
+  let other = 0;
+  const lines: string[] = [];
+  for (const sha of shas) {
+    const files = commitFiles(sha);
+    const subj = commitSubject(sha);
+    const cat = classifyCommit(files);
+    if (cat === "EXT ") ext++;
+    else if (cat === "INTL") intl++;
+    else if (cat === "SPEC") spec++;
+    else other++;
+    lines.push(`${cat}  ${subj}`);
+  }
+  return { ext, intl, spec, other, lines };
+}
+
+function emitReport(counts: Counts, window: number, threshold: number): ExitCode {
+  const total = counts.ext + counts.intl + counts.spec + counts.other;
+  if (total === 0) {
+    process.stderr.write(
+      `error: no commits found in window of ${String(window)} on origin/main.\n`,
+    );
+    return 2;
+  }
+  const extPct = Math.floor((100 * counts.ext) / total);
+  const intlPct = Math.floor((100 * counts.intl) / total);
+  const specPct = Math.floor((100 * counts.spec) / total);
+  const otherPct = Math.floor((100 * counts.other) / total);
+
+  process.stdout.write(
+    `Live-lock audit — last ${String(window)} commits on origin/main\n`,
+  );
+  process.stdout.write(
+    "======================================================\n",
+  );
+  for (const line of counts.lines) process.stdout.write(`${line}\n`);
+  process.stdout.write("\n");
+  process.stdout.write("Category totals:\n");
+  process.stdout.write(
+    `  EXT  (src/tests/samples/bench) : ${pad2(counts.ext)}   ${pad3(extPct)}%\n`,
+  );
+  process.stdout.write(
+    `  INTL (tick-history/BACKLOG/...) : ${pad2(counts.intl)}   ${pad3(intlPct)}%\n`,
+  );
+  process.stdout.write(
+    `  SPEC (research/memory/ADR)      : ${pad2(counts.spec)}   ${pad3(specPct)}%\n`,
+  );
+  process.stdout.write(
+    `  OTHR (uncategorised)            : ${pad2(counts.other)}   ${pad3(otherPct)}%\n`,
+  );
+  process.stdout.write("\n");
+  process.stdout.write(`Healthy threshold: EXT >= ${String(threshold)}%\n`);
+  process.stdout.write("\n");
+
+  if (extPct < threshold) {
+    process.stdout.write(
+      `SMELL FIRING: external-commit ratio ${String(extPct)}% < threshold ${String(threshold)}%.\n`,
+    );
+    process.stdout.write(
+      "Factory may be live-locked — spinning on process work without product motion.\n",
+    );
+    process.stdout.write(
+      "Response: pause speculative, ship one external-priority increment, re-measure.\n",
+    );
+    return 1;
+  }
+  process.stdout.write(
+    `Healthy: external-commit ratio ${String(extPct)}% >= threshold ${String(threshold)}%.\n`,
+  );
+  return 0;
+}
+
+function pad2(n: number): string {
+  const s = String(n);
+  return s.padStart(2, " ");
+}
+
+function pad3(n: number): string {
+  const s = String(n);
+  return s.padStart(3, " ");
+}
+
+export function main(argv: readonly string[]): ExitCode {
+  const window = parseWindow(argv[0]);
+  if (window === null) {
+    process.stderr.write("usage: live-lock-audit.ts [N]\n");
+    process.stderr.write(
+      `error: WINDOW must be a positive integer, got '${argv[0] ?? ""}'.\n`,
+    );
+    return 2;
+  }
+
+  fetchOriginMain();
+
+  if (!originMainResolves()) {
+    process.stderr.write(
+      "error: cannot resolve origin/main (shallow clone, missing remote, or failed fetch).\n",
+    );
+    process.stderr.write(
+      "refusing to report audit result — unresolved ref cannot be treated as healthy.\n",
+    );
+    return 2;
+  }
+
+  const threshold = getThreshold();
+  const shas = listCommitShas(window);
+  const counts = tallyCommits(shas);
+  return emitReport(counts, window, threshold);
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/tools/lint/no-directives-otto-prose.ts
+++ b/tools/lint/no-directives-otto-prose.ts
@@ -1,0 +1,316 @@
+#!/usr/bin/env bun
+// no-directives-otto-prose.ts — advisory lint that flags Otto-authored
+// prose using "directive" framing for maintainer input in CHANGED FILES.
+//
+// TypeScript+Bun port of no-directives-otto-prose.sh, slice 8 of the
+// TS+Bun migration. See docs/best-practices/repo-scripting.md.
+//
+// Diff-based scope (does NOT retrofit historical content):
+//   pr (default)         — diff between BASE_REF and HEAD
+//   worktree             — unstaged + staged + committed + untracked
+//
+// Otto-authored prose surfaces (path filter applied to changed files):
+//   memory/*.md (top-level only, NOT memory/persona/)
+//   docs/hygiene-history/ticks/**/*.md
+//   docs/research/*.md
+//   docs/active-trajectory.md
+//   .github/copilot-instructions.md
+//
+// Pattern (per Amara's narrowed regex):
+//   "Aaron's directive" / "maintainer directive" / "QoL directive" /
+//   "human directive" / "directive from Aaron" / etc.
+//
+// Whitelist (NOT flagged):
+//   - lines starting with `> ` (markdown blockquote)
+//   - the rule-documentation files themselves
+//
+// Usage:
+//   bun tools/lint/no-directives-otto-prose.ts             # PR-diff advisory
+//   bun tools/lint/no-directives-otto-prose.ts --strict    # PR-diff strict
+//   SCOPE=worktree bun tools/lint/no-directives-otto-prose.ts
+//
+// Env:
+//   BASE_REF — base ref to diff against (default: origin/main)
+//   SCOPE    — "pr" (default) or "worktree"
+//
+// Exit codes:
+//   0  no hits OR advisory mode
+//   1  --strict + hits found
+
+import { readFileSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+type ExitCode = 0 | 1;
+type Mode = "advisory" | "strict";
+type Scope = "pr" | "worktree";
+
+const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+
+const PROSE_PATH_RE =
+  /^(?:memory\/[^/]+\.md|docs\/hygiene-history\/ticks\/.*\.md|docs\/research\/[^/]+\.md|docs\/active-trajectory\.md|\.github\/copilot-instructions\.md)$/;
+
+const RULE_DOC_RE =
+  /(feedback_input_is_not_directive_|feedback_otto_357_no_directives_|feedback_free_will_is_paramount_external_directives_|no-directives-otto-prose)/;
+
+// Pattern split into 4 sub-regexes (each under sonarjs/regex-complexity).
+// Each pattern uses explicit non-alpha boundaries `(^|\W)` and
+// `(\W|$)` to mirror the bash POSIX-portable boundary form.
+const DIRECTIVE_PATTERNS: readonly RegExp[] = [
+  /(^|\W)(?:maintainer|QoL|human)[^|]*directive(?:\W|$)/,
+  /(^|\W)directive[^|]*(?:maintainer|QoL|human)(?:\W|$)/,
+  /(^|\W)[A-Z][a-z]+'?s[\t ]+directive(?:\W|$)/,
+  /(^|\W)directive[\t ]+from[\t ]+[A-Z][a-z]+(?:\W|$)/,
+];
+
+const BLOCKQUOTE_RE = /^[\t ]*>/;
+
+interface AddedLine {
+  readonly file: string;
+  readonly content: string;
+}
+
+function gitOutput(args: readonly string[]): string {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", args, {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  // git diff exits non-zero in some legitimate states (e.g., "couldn't
+  // resolve ref"); we still want the stdout when present, but propagate
+  // errors that produced no output.
+  if (result.status !== 0 && result.stdout.length === 0) return "";
+  return result.stdout;
+}
+
+function repoRoot(): string {
+  const out = gitOutput(["rev-parse", "--show-toplevel"]);
+  return out.trim() || process.cwd();
+}
+
+interface ParsedArgs {
+  readonly mode: Mode;
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+  for (const arg of argv) {
+    if (arg === "--strict") return { mode: "strict" };
+  }
+  return { mode: "advisory" };
+}
+
+function getScope(): Scope {
+  const env = process.env.SCOPE;
+  return env === "worktree" ? "worktree" : "pr";
+}
+
+function getBaseRef(): string {
+  return process.env.BASE_REF ?? "origin/main";
+}
+
+function splitLines(s: string): readonly string[] {
+  if (s === "") return [];
+  return s.split("\n").filter((l) => l.length > 0);
+}
+
+function changedFilesPr(baseRef: string): readonly string[] {
+  return splitLines(
+    gitOutput(["diff", "--name-only", "--diff-filter=AMR", `${baseRef}...HEAD`]),
+  );
+}
+
+function changedFilesWorktree(baseRef: string): readonly string[] {
+  const sets = [
+    splitLines(gitOutput(["diff", "--name-only", "--diff-filter=AMR"])),
+    splitLines(
+      gitOutput(["diff", "--cached", "--name-only", "--diff-filter=AMR"]),
+    ),
+    splitLines(
+      gitOutput([
+        "diff",
+        "--name-only",
+        "--diff-filter=AMR",
+        `${baseRef}...HEAD`,
+      ]),
+    ),
+    splitLines(gitOutput(["ls-files", "--others", "--exclude-standard"])),
+  ];
+  const merged = new Set<string>();
+  for (const s of sets) for (const v of s) merged.add(v);
+  return [...merged].sort((a, b) => a.localeCompare(b));
+}
+
+function getChangedFiles(scope: Scope, baseRef: string): readonly string[] {
+  return scope === "worktree"
+    ? changedFilesWorktree(baseRef)
+    : changedFilesPr(baseRef);
+}
+
+function isProseFile(path: string): boolean {
+  return PROSE_PATH_RE.test(path);
+}
+
+function isRuleDoc(path: string): boolean {
+  return RULE_DOC_RE.test(path);
+}
+
+function isUntracked(file: string): boolean {
+  const args = ["ls-files", "--error-unmatch", "--", file];
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", args, {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  return result.status !== 0;
+}
+
+function readFileAsAddedLines(file: string): readonly AddedLine[] {
+  let content: string;
+  try {
+    content = readFileSync(file, "utf8");
+  } catch {
+    return [];
+  }
+  return content
+    .split("\n")
+    .filter((l) => l.length > 0)
+    .map((content) => ({ file, content }));
+}
+
+function diffOutput(
+  scope: Scope,
+  baseRef: string,
+  file: string,
+): readonly string[] {
+  if (scope === "worktree") {
+    return [
+      gitOutput(["diff", "-U0", "--", file]),
+      gitOutput(["diff", "--cached", "-U0", "--", file]),
+      gitOutput(["diff", "-U0", `${baseRef}...HEAD`, "--", file]),
+    ];
+  }
+  return [gitOutput(["diff", "-U0", `${baseRef}...HEAD`, "--", file])];
+}
+
+function isAddedContentLine(line: string): boolean {
+  if (line.startsWith("\\ No newline")) return false;
+  if (line.startsWith("@@")) return false;
+  if (line.startsWith("---")) return false;
+  if (line.startsWith("+++")) return false;
+  if (line.startsWith("-")) return false;
+  return line.startsWith("+");
+}
+
+function extractAddedLinesFromDiff(
+  file: string,
+  diffText: string,
+): readonly AddedLine[] {
+  const out: AddedLine[] = [];
+  for (const line of diffText.split("\n")) {
+    if (!isAddedContentLine(line)) continue;
+    out.push({ file, content: line.slice(1) });
+  }
+  return out;
+}
+
+function extractAddedLines(
+  scope: Scope,
+  baseRef: string,
+  file: string,
+): readonly AddedLine[] {
+  if (!existsSync(file)) return [];
+  if (scope === "worktree" && isUntracked(file)) {
+    return readFileAsAddedLines(file);
+  }
+  const out: AddedLine[] = [];
+  for (const diff of diffOutput(scope, baseRef, file)) {
+    out.push(...extractAddedLinesFromDiff(file, diff));
+  }
+  return out;
+}
+
+function matchesDirective(content: string): boolean {
+  if (BLOCKQUOTE_RE.test(content)) return false;
+  return DIRECTIVE_PATTERNS.some((re) => re.test(content));
+}
+
+function emitFooter(): void {
+  process.stderr.write("\n");
+  process.stderr.write(
+    "Prose framing maintainer input as 'directive' (Aaron's directive /\n",
+  );
+  process.stderr.write(
+    "maintainer directive / QoL directive / human directive) collapses\n",
+  );
+  process.stderr.write(
+    "self-provenance into bot-execution. Use 'input' / 'framing' /\n",
+  );
+  process.stderr.write("'correction' / 'pass' instead.\n");
+  process.stderr.write(
+    "See memory/feedback_otto_357_no_directives_aaron_makes_autonomy_first_class_accountability_mine_2026_04_27.md\n",
+  );
+}
+
+export function main(argv: readonly string[]): ExitCode {
+  const root = repoRoot();
+  process.chdir(root);
+
+  const { mode } = parseArgs(argv);
+  const scope = getScope();
+  const baseRef = getBaseRef();
+
+  const changed = getChangedFiles(scope, baseRef);
+  if (changed.length === 0) {
+    process.stdout.write(
+      `no-directives-otto-prose: no changed files vs ${baseRef}; skipping\n`,
+    );
+    return 0;
+  }
+
+  const proseFiles = changed.filter(isProseFile);
+  if (proseFiles.length === 0) {
+    process.stdout.write(
+      "no-directives-otto-prose: no Otto-prose surfaces changed; skipping\n",
+    );
+    return 0;
+  }
+
+  const filtered = proseFiles.filter((f) => !isRuleDoc(f));
+  if (filtered.length === 0) {
+    process.stdout.write(
+      "no-directives-otto-prose: only rule-docs touched; skipping\n",
+    );
+    return 0;
+  }
+
+  const hits: AddedLine[] = [];
+  for (const file of filtered) {
+    const lines = extractAddedLines(scope, baseRef, file);
+    for (const ln of lines) {
+      if (matchesDirective(ln.content)) hits.push(ln);
+    }
+  }
+
+  if (hits.length > 0) {
+    process.stderr.write(
+      `no-directives-otto-prose: found ${String(hits.length)} candidate hit(s) in added Otto-prose lines:\n`,
+    );
+    for (const h of hits) {
+      process.stderr.write(`${h.file}: ${h.content}\n`);
+    }
+    emitFooter();
+    if (mode === "strict") return 1;
+    process.stderr.write(
+      "(advisory mode; not failing build — pass --strict to fail)\n",
+    );
+    return 0;
+  }
+
+  process.stdout.write(
+    "no-directives-otto-prose: clean (0 candidate hits in added Otto-prose lines)\n",
+  );
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/tools/lint/runner-version-freshness.ts
+++ b/tools/lint/runner-version-freshness.ts
@@ -1,0 +1,394 @@
+#!/usr/bin/env bun
+// runner-version-freshness.ts — fail CI when a GitHub Actions
+// workflow pins a runner to a label not on the current allow-list.
+//
+// TypeScript+Bun port of runner-version-freshness.sh, slice 8 of
+// the TS+Bun migration. See docs/best-practices/repo-scripting.md.
+//
+// Allow-list sourced from the authoritative GitHub docs page:
+//   https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
+// "Standard GitHub-hosted runners for public repositories" table.
+//
+// LAST_VERIFIED below has an explicit timestamp. If older than 30
+// days, the script prints a warning to stderr but exits 0
+// (warning-only — does NOT fail CI). When GitHub announces a new
+// stable runner, update ALLOWED_LABELS + bump LAST_VERIFIED.
+//
+// Usage:
+//   bun tools/lint/runner-version-freshness.ts             # all workflows
+//   bun tools/lint/runner-version-freshness.ts <file>...   # specific
+//
+// Exit codes:
+//   0  current (or freshness warning only — non-fatal)
+//   1  environment / usage error
+//   2  stale / rolling / not-on-allow-list label found
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+type ExitCode = 0 | 1 | 2;
+
+const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+
+const LAST_VERIFIED = "2026-04-24";
+const VERIFY_URL =
+  "https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories";
+
+const ALLOWED_LABELS: readonly string[] = [
+  "ubuntu-slim",
+  "ubuntu-24.04",
+  "ubuntu-24.04-arm",
+  "windows-2025",
+  "windows-2025-vs2026",
+  "windows-11-arm",
+  "macos-26",
+  "macos-26-intel",
+];
+
+const ROLLING_ALIASES: readonly string[] = [
+  "ubuntu-latest",
+  "windows-latest",
+  "macos-latest",
+];
+
+const STALE_LABELS: readonly string[] = [
+  "ubuntu-22.04",
+  "ubuntu-22.04-arm",
+  "ubuntu-20.04",
+  "macos-14",
+  "macos-15",
+  "macos-15-intel",
+  "macos-13",
+  "macos-13-xlarge",
+  "windows-2022",
+  "windows-2019",
+];
+
+const REGEX_META_RE = /[\\.*^$+?()[\]{}|/]/g;
+
+function repoRoot(): string {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  if (result.status !== 0) {
+    process.stderr.write("ERROR: not inside a git working tree\n");
+    return "";
+  }
+  return result.stdout.trim();
+}
+
+function escapeForRegex(s: string): string {
+  return s.replace(REGEX_META_RE, "\\$&");
+}
+
+function alternation(labels: readonly string[]): string {
+  return labels.map(escapeForRegex).join("|");
+}
+
+function ageDays(lastVerified: string): number | null {
+  const parsed = Date.parse(`${lastVerified}T00:00:00Z`);
+  if (Number.isNaN(parsed)) return null;
+  return Math.floor((Date.now() - parsed) / 86_400_000);
+}
+
+function emitFreshnessWarning(): boolean {
+  const days = ageDays(LAST_VERIFIED);
+  if (days === null) {
+    process.stderr.write(
+      `WARN: could not parse LAST_VERIFIED=${LAST_VERIFIED} on this platform\n`,
+    );
+    return false;
+  }
+  if (days <= 30) return false;
+  process.stderr.write(
+    `WARN: runner-version allow-list last verified ${String(days)} days ago (${LAST_VERIFIED}).\n`,
+  );
+  process.stderr.write(`      Re-verify against: ${VERIFY_URL}\n`);
+  process.stderr.write("      Then bump LAST_VERIFIED in this script.\n");
+  return true;
+}
+
+function listWorkflowFiles(root: string): readonly string[] {
+  const wfDir = join(root, ".github", "workflows");
+  let entries: readonly import("node:fs").Dirent[];
+  try {
+    entries = readdirSync(wfDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    if (!e.isFile()) continue;
+    if (!e.name.endsWith(".yml") && !e.name.endsWith(".yaml")) continue;
+    out.push(join(wfDir, e.name));
+  }
+  return out.sort((a, b) => a.localeCompare(b));
+}
+
+const COMMENT_LINE_RE = /^[\t ]*#/;
+
+function stripTrailingComment(line: string): string {
+  // Find first '#' preceded by whitespace; strip from the
+  // whitespace onward. Manual scan avoids sonarjs/slow-regex.
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] !== "#") continue;
+    if (i === 0) continue;
+    const prev = line[i - 1];
+    if (prev !== " " && prev !== "\t") continue;
+    let start = i - 1;
+    while (start > 0) {
+      const c = line[start - 1];
+      if (c !== " " && c !== "\t") break;
+      start--;
+    }
+    return line.slice(0, start);
+  }
+  return line;
+}
+
+function stripComments(content: string): string {
+  const lines = content.split("\n");
+  const out: string[] = [];
+  for (const line of lines) {
+    if (COMMENT_LINE_RE.test(line)) continue;
+    out.push(stripTrailingComment(line));
+  }
+  return out.join("\n");
+}
+
+interface ScanResult {
+  readonly stale: readonly string[];
+  readonly rolling: readonly string[];
+  readonly unknown: readonly string[];
+}
+
+const NONWORD_START = "([^A-Za-z0-9_]|^)";
+const NONWORD_END = "([^A-Za-z0-9_]|$)";
+const MATRIX_PREFIX = "^[\\t ]*-[\\t ]+(['\"]?)";
+const MATRIX_PREFIX_LN = "(^|^[0-9]+:)[\\t ]*-[\\t ]+(['\"]?)";
+
+function findMatchingLines(
+  uncommented: string,
+  prefilter: RegExp,
+  boundary: RegExp,
+): readonly string[] {
+  const lines = uncommented.split("\n");
+  const hits: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (!prefilter.test(line)) continue;
+    if (!boundary.test(line)) continue;
+    hits.push(`${String(i + 1)}:${line}`);
+  }
+  return hits;
+}
+
+function scanStaleOrRolling(
+  uncommented: string,
+  pattern: string,
+): readonly string[] {
+  const prefilter = new RegExp(
+    `runs-on:|(^|[^A-Za-z0-9_])os:|${MATRIX_PREFIX}(${pattern})`,
+  );
+  const boundary = new RegExp(`${NONWORD_START}(${pattern})${NONWORD_END}`);
+  return findMatchingLines(uncommented, prefilter, boundary);
+}
+
+function scanUnknownScalar(
+  uncommented: string,
+  rollingOrAllowed: string,
+): readonly string[] {
+  const lines = uncommented.split("\n");
+  const out: string[] = [];
+  const matchRe = /runs-on:[\t ]*[A-Za-z0-9_-][A-Za-z0-9._-]*/;
+  const exprRe = /runs-on:[\t ]*\$\{\{/;
+  const allowedRe = new RegExp(
+    `runs-on:[\\t ]*(${rollingOrAllowed})($|[\\t ]|#)`,
+  );
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (!matchRe.test(line)) continue;
+    if (exprRe.test(line)) continue;
+    if (allowedRe.test(line)) continue;
+    out.push(`${String(i + 1)}:${line}`);
+  }
+  return out;
+}
+
+function scanUnknownMatrix(
+  uncommented: string,
+  rollingOrAllowed: string,
+  stalePattern: string,
+): readonly string[] {
+  const lines = uncommented.split("\n");
+  const out: string[] = [];
+  const labelRe = new RegExp(
+    `${MATRIX_PREFIX}[A-Za-z][A-Za-z0-9._-]*[0-9][A-Za-z0-9._-]*`,
+  );
+  const allowedRe = new RegExp(
+    `${MATRIX_PREFIX_LN}(${rollingOrAllowed})(['"]?)([\\t ]|$|#)`,
+  );
+  const staleRe = new RegExp(`${MATRIX_PREFIX_LN}(${stalePattern})`);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (!labelRe.test(line)) continue;
+    const numbered = `${String(i + 1)}:${line}`;
+    if (allowedRe.test(numbered)) continue;
+    if (staleRe.test(numbered)) continue;
+    out.push(numbered);
+  }
+  return out;
+}
+
+function scanFile(content: string): ScanResult {
+  const uncommented = stripComments(content);
+  const stalePattern = alternation(STALE_LABELS);
+  const rollingPattern = alternation(ROLLING_ALIASES);
+  const allowedPattern = alternation(ALLOWED_LABELS);
+  const rollingOrAllowed = `${allowedPattern}|${rollingPattern}`;
+
+  const stale = scanStaleOrRolling(uncommented, stalePattern);
+  const rolling = scanStaleOrRolling(uncommented, rollingPattern);
+  const scalarUnknown = scanUnknownScalar(uncommented, rollingOrAllowed);
+  const matrixUnknown = scanUnknownMatrix(
+    uncommented,
+    rollingOrAllowed,
+    stalePattern,
+  );
+  const unknown = [...scalarUnknown, ...matrixUnknown];
+
+  return { stale, rolling, unknown };
+}
+
+function emitFileFindings(file: string, r: ScanResult): boolean {
+  let any = false;
+  if (r.stale.length > 0) {
+    process.stdout.write(`STALE RUNNER LABEL(S) in ${file}:\n`);
+    for (const h of r.stale) process.stdout.write(`  ${h}\n`);
+    any = true;
+  }
+  if (r.rolling.length > 0) {
+    process.stdout.write(
+      `ROLLING-ALIAS RUNNER LABEL(S) in ${file} (use a pinned version per repo convention):\n`,
+    );
+    for (const h of r.rolling) process.stdout.write(`  ${h}\n`);
+    any = true;
+  }
+  if (r.unknown.length > 0) {
+    process.stdout.write(
+      `NOT-ON-ALLOW-LIST RUNNER LABEL(S) in ${file} (label is neither stale nor allowed; allow-list may need refresh):\n`,
+    );
+    for (const h of r.unknown) process.stdout.write(`  ${h}\n`);
+    any = true;
+  }
+  return any;
+}
+
+function emitFailureFooter(): void {
+  process.stdout.write("\n");
+  process.stdout.write(
+    "One or more workflow files pin stale / rolling /\n",
+  );
+  process.stdout.write(
+    "not-on-allow-list runner labels. Update to current\n",
+  );
+  process.stdout.write(
+    "standard-runner labels. Canonical list:\n",
+  );
+  for (const l of ALLOWED_LABELS) process.stdout.write(`  - ${l}\n`);
+  process.stdout.write("\n");
+  process.stdout.write(`Source: ${VERIFY_URL}\n`);
+}
+
+function emitEnvErrorFooter(): void {
+  process.stderr.write("\n");
+  process.stderr.write(
+    "Environment / usage error encountered (see ERROR\n",
+  );
+  process.stderr.write(
+    "lines above). This is distinct from stale-label\n",
+  );
+  process.stderr.write(
+    "findings; exit 1 reserves an out-of-band code so\n",
+  );
+  process.stderr.write(
+    "callers can distinguish 'something broke' from\n",
+  );
+  process.stderr.write("'stale labels found'.\n");
+}
+
+function resolveArgs(argv: readonly string[], cwd: string): readonly string[] {
+  return argv.map((a) => (isAbsolute(a) ? a : resolve(cwd, a)));
+}
+
+function isReadable(file: string): boolean {
+  try {
+    statSync(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function main(argv: readonly string[]): ExitCode {
+  const cwd = process.cwd();
+  const root = repoRoot();
+  if (root === "") return 1;
+
+  const absArgs = resolveArgs(argv, cwd);
+  process.chdir(root);
+
+  const files = absArgs.length === 0 ? listWorkflowFiles(root) : absArgs;
+  if (files.length === 0) {
+    process.stdout.write("no workflow files found; nothing to lint\n");
+    return 0;
+  }
+
+  let fail = false;
+  let envError = false;
+
+  for (const file of files) {
+    if (!isReadable(file)) {
+      process.stderr.write(
+        `ERROR: cannot read ${file} (does not exist or unreadable)\n`,
+      );
+      envError = true;
+      continue;
+    }
+    let content: string;
+    try {
+      content = readFileSync(file, "utf8");
+    } catch {
+      process.stderr.write(
+        `ERROR: cannot read ${file} (does not exist or unreadable)\n`,
+      );
+      envError = true;
+      continue;
+    }
+    const result = scanFile(content);
+    if (emitFileFindings(file, result)) fail = true;
+  }
+
+  const warn = emitFreshnessWarning();
+
+  if (envError) {
+    emitEnvErrorFooter();
+    return 1;
+  }
+  if (fail) {
+    emitFailureFooter();
+    return 2;
+  }
+  if (warn) return 0;
+  process.stdout.write(
+    `ok: all workflow runner labels are current (verified ${LAST_VERIFIED})\n`,
+  );
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Summary

- Slice 8 of the TS+Bun migration. Ports 3 scripts (2 lint + 1 audit) byte-equivalent against bash.
- **Cluster H complete (5/5)** — `runner-version-freshness` + `no-directives-otto-prose` round out the lint-pattern cluster from PR #878. **New audit-cluster opened** with `live-lock-audit`.

## Files

- `tools/lint/runner-version-freshness.{sh→ts}` — GH Actions runner-label allow-list lint with 30-day freshness warning
- `tools/lint/no-directives-otto-prose.{sh→ts}` — advisory diff-based "directive" prose lint (pr + worktree SCOPE modes)
- `tools/audit/live-lock-audit.{sh→ts}` — last-N origin/main commit classifier (EXT/INTL/SPEC/OTHR) with live-lock smell threshold

Plus:

- `docs/trajectories/typescript-bun-migration/slice-audits.md` — slice-8 audit appended (Gate A merge-gate substrate)
- `docs/trajectories/typescript-bun-migration/RESUME.md` — slice-7-merged closure + slice-8-in-flight + Bucket B/D updates

## Equivalence

Per-script diff against bash original:

| script | mode(s) tested | result |
|---|---|---|
| runner-version-freshness | live workflow tree + stale fixture + rolling fixture + matrix fixture | byte-equivalent |
| no-directives-otto-prose | pr (default), worktree | byte-equivalent across both SCOPE modes |
| live-lock-audit | window=5, window=25 | byte-equivalent (intentional .ts vs .sh in usage error) |

## Lint + types

All three files pass:

- `bun x tsc --noEmit` clean
- `bun x eslint` clean (typescript-eslint strictTypeChecked + stylisticTypeChecked + sonarjs)

## Test plan

- [ ] CI: lint + typecheck on the slice files
- [ ] CI: `bun tools/lint/runner-version-freshness.ts` returns 0 against current `.github/workflows/`
- [ ] CI: `bun tools/lint/no-directives-otto-prose.ts` runs cleanly against the PR diff
- [ ] CI: `bun tools/audit/live-lock-audit.ts 25` produces a healthy report against current origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)