### PR TITLE
ts(B-0086): port 3 hygiene scripts (.sh→.ts) — slice 9 of TS/Bun migration

### DIFF
--- a/docs/trajectories/typescript-bun-migration/RESUME.md
+++ b/docs/trajectories/typescript-bun-migration/RESUME.md
@@ -1,9 +1,9 @@
 # Trajectory — TypeScript / Bun migration
 
-**Status**: Active (Lane B slice 7 merged — [#878](https://github.com/Lucent-Financial-Group/Zeta/pull/878), commit `4dac957`)
-**Milestone**: 25 hygiene/lint/audit scripts ported (2 from #849 + 3 from #866 + 3 from #868 + 3 from #870 + 2 from #872 + 3 from #874 + 3 from #876 + 3 from #878 + 3 in-flight in slice-8). **Cluster H complete (5/5): #878 landed 3 lint-pattern ports (no-empty-dirs, safety-clause-audit, doc-comment-history-audit); slice-8 finishes Cluster H with no-directives-otto-prose + runner-version-freshness, plus the live-lock-audit port from `tools/audit/`.** 19 Bucket B files remain.
+**Status**: Active (Lane B slice 8 merged — [#880](https://github.com/Lucent-Financial-Group/Zeta/pull/880), commit `988de70`)
+**Milestone**: 28 hygiene/lint/audit scripts ported (2 from #849 + 3 from #866 + 3 from #868 + 3 from #870 + 2 from #872 + 3 from #874 + 3 from #876 + 3 from #878 + 3 from #880 + 3 in-flight in slice-9). **Cluster H complete (5/5)** in #878 + #880; slice-9 opens **agency-signature-pair cluster** (validate-agencysignature-pr-body + audit-agencysignature-main-tip — paired ferry-7 enforcement-instrument set per Amara) + capture-tick-snapshot (snapshot-pinning per Amara 4th-ferry). 16 Bucket B files remain.
 **Current blocker**: None.
-**Next concrete action**: Pick a coherent next slice from Bucket B (19 files remaining). Per Gate B: read-only scope first, then re-verify the layered baseline currency before first mutating action.
+**Next concrete action**: Pick a coherent next slice from Bucket B (16 files remaining). Per Gate B: read-only scope first, then re-verify the layered baseline currency before first mutating action.
 **Last updated**: 2026-04-30
 
 ## Why this trajectory exists

--- a/docs/trajectories/typescript-bun-migration/slice-audits.md
+++ b/docs/trajectories/typescript-bun-migration/slice-audits.md
@@ -411,6 +411,40 @@ Per-port pattern checklist:
 
 Slice 6 passes audit. No new patterns recorded — all reused from prior slices.
 
+## Slice 9 — 3 ports (agency-signature-pair cluster + snapshot-pinning) (PR pending — `lane-b/ts-bun-slice-9-agencysignature-pair-2026-04-30`)
+
+**Slice files**:
+
+- `tools/hygiene/validate-agencysignature-pr-body.{sh→ts}` (pre-merge validator)
+- `tools/hygiene/audit-agencysignature-main-tip.{sh→ts}` (post-merge auditor)
+- `tools/hygiene/capture-tick-snapshot.{sh→ts}` (factory-state pin)
+
+**Comparison points**: identical to slice 6/7/8 (TypeScript 6.0, Bun 1.3, typescript-eslint v8, `../SQLSharp` at `7d3d9f6`, `../scratch` at mtime `2026-04-15`). Within Gate B 30-day window.
+
+### Tsconfig audit
+
+- Reuses repo `tsconfig.json` (no per-slice deviation). All 3 files compile under `bun x tsc --noEmit` clean.
+
+### Eslint audit
+
+- All 3 files clean under `eslint` (typescript-eslint strictTypeChecked + stylisticTypeChecked + sonarjs).
+
+### Code-pattern audit (per-port)
+
+- **`validate-agencysignature-pr-body.ts`** (247 → 454 lines): bash `cat` for stdin → `readFileSync(0, "utf8")`. `git interpret-trailers --parse` invocation preserved. Markdown code-fence strip via FENCE_RE filter. Terminal-block check (3-strategy lookup) preserved. Bash `[\t ]+$` (sonarjs/slow-regex) replaced with manual trimSpaceTab walk. Bash `check_enum` → ENUMS array + checkEnums helper. Human-Review/Human-Review-Evidence consistency check preserved verbatim.
+- **`audit-agencysignature-main-tip.ts`** (297 → 432 lines): **two bash-bug-fixes-by-port** documented — (1) BSD `date -j -f '%Y-%m-%dT%H:%M:%SZ'` does NOT handle TZ-offset like `-04:00` on macOS; TS uses `Date.parse` which handles both `Z` and `±HH:MM`; (2) bash `exit 2` inside `$(classify_commit ...)` only exits subshell — bash silently produced unclassified output on macOS. TS short-circuits cleanly. Same behaviour-improvement class as no-empty-dirs empty-FILTERED.
+- **`capture-tick-snapshot.ts`** (118 → 186 lines): bash `wc -c` shell-out replaced with `statSync().size`. Bash sed regex greedy-bug (retains `.git` suffix) preserved for drop-in equivalence; future cleanup follow-up to strip after downstream verifies.
+
+### Equivalence audit
+
+- **`validate-agencysignature-pr-body`**: byte-equivalent on PASS + FAIL paths.
+- **`audit-agencysignature-main-tip`**: TS port produces CORRECT classifications where bash silently broke (unclassified output) due to BSD date + exit-in-subshell bugs.
+- **`capture-tick-snapshot`**: byte-equivalent on YAML + JSON modes modulo run-time fields (date_utc + claude_cli_version).
+
+### Outcome
+
+Slice 9 passes audit. **Agency-signature-pair cluster opened**: validate-pr-body (pre-merge) + audit-main-tip (post-merge) form Amara's ferry-7 enforcement-instrument set. Bucket B 19 → 16.
+
 ## Slice 8 — 3 ports (Cluster H finish + audit-cluster start) (PR pending — `lane-b/ts-bun-slice-8-runner-version-freshness-2026-04-30`)
 
 **Slice files**:

--- a/tools/hygiene/audit-agencysignature-main-tip.ts
+++ b/tools/hygiene/audit-agencysignature-main-tip.ts
@@ -1,0 +1,432 @@
+#!/usr/bin/env bun
+// audit-agencysignature-main-tip.ts — post-merge auditor for the
+// AgencySignature Convention v1 trailer block.
+//
+// TypeScript+Bun port of audit-agencysignature-main-tip.sh, slice 9
+// of the TS+Bun migration. See docs/best-practices/repo-scripting.md.
+//
+// Pairs with validate-agencysignature-pr-body.{sh,ts} (pre-merge
+// validator) as the ferry-7 enforcement-instrument set.
+//
+// Usage:
+//   bun tools/hygiene/audit-agencysignature-main-tip.ts                   # audit HEAD
+//   bun tools/hygiene/audit-agencysignature-main-tip.ts --commit <SHA>    # audit specific
+//   bun tools/hygiene/audit-agencysignature-main-tip.ts --max 10          # last N
+//   bun tools/hygiene/audit-agencysignature-main-tip.ts --since YYYY-MM-DD
+//   bun tools/hygiene/audit-agencysignature-main-tip.ts --branch main
+//   bun tools/hygiene/audit-agencysignature-main-tip.ts --v1-ship-date <DATE>
+//
+// Exit codes:
+//   0 — no regressions found (LEGACY / CORRECT / HUMAN-AUTHORED-EXEMPT only)
+//   1 — at least one REGRESSION found
+//   2 — tooling / input error
+
+import { spawnSync } from "node:child_process";
+
+type ExitCode = 0 | 1 | 2;
+type Mode = "head" | "commit" | "max" | "since";
+type Status = "CORRECT" | "LEGACY" | "HUMAN-AUTHORED-EXEMPT" | "REGRESSION";
+
+const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+
+const SPEC_DOC =
+  "docs/research/2026-04-26-gemini-deep-think-agencysignature-commit-attribution-convention-validation-and-refinement.md";
+
+const POSITIVE_INT_RE = /^\d+$/;
+const V1_TRAILER_RE = /^Agency-Signature-Version:\s*1/im;
+const COAUTHOR_RE = /^Co-authored-by:\s*Claude/im;
+
+interface ParsedArgs {
+  readonly mode: Mode;
+  readonly commitSha: string;
+  readonly maxN: string;
+  readonly sinceDate: string;
+  readonly branch: string;
+  readonly v1ShipDate: string;
+}
+
+function gitOutput(args: readonly string[]): {
+  status: number;
+  stdout: string;
+  stderr: string;
+} {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", args, {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function gitAvailable(): boolean {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", ["--version"], {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  return result.status === 0;
+}
+
+interface ArgParseResult {
+  readonly ok: ParsedArgs | null;
+  readonly errorMessage: string;
+}
+
+type ArgStep =
+  | { readonly kind: "ok"; readonly key: keyof MutableArgs; readonly value: string; readonly setMode: Mode | null; readonly skip: 1 }
+  | { readonly kind: "error"; readonly message: string }
+  | { readonly kind: "help" };
+
+interface MutableArgs {
+  mode: Mode;
+  commitSha: string;
+  maxN: string;
+  sinceDate: string;
+  branch: string;
+  v1ShipDate: string;
+}
+
+function classifyArg(arg: string, next: string | undefined): ArgStep {
+  const requiresNext: Record<string, { key: keyof MutableArgs; setMode: Mode | null; missing: string }> = {
+    "--commit": { key: "commitSha", setMode: "commit", missing: "error: --commit requires SHA" },
+    "--max": { key: "maxN", setMode: "max", missing: "error: --max requires N" },
+    "--since": { key: "sinceDate", setMode: "since", missing: "error: --since requires DATE (YYYY-MM-DD)" },
+    "--branch": { key: "branch", setMode: null, missing: "error: --branch requires NAME" },
+    "--v1-ship-date": { key: "v1ShipDate", setMode: null, missing: "error: --v1-ship-date requires DATE" },
+  };
+  const spec = requiresNext[arg];
+  if (spec !== undefined) {
+    if (next === undefined) return { kind: "error", message: spec.missing };
+    return { kind: "ok", key: spec.key, value: next, setMode: spec.setMode, skip: 1 };
+  }
+  if (arg === "-h" || arg === "--help") return { kind: "help" };
+  return { kind: "error", message: `error: unknown arg: ${arg}` };
+}
+
+function parseArgs(argv: readonly string[]): ArgParseResult {
+  const args: MutableArgs = {
+    mode: "head",
+    commitSha: "",
+    maxN: "",
+    sinceDate: "",
+    branch: "",
+    v1ShipDate: "",
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i] ?? "";
+    const step = classifyArg(arg, argv[i + 1]);
+    if (step.kind === "help") return { ok: null, errorMessage: "__HELP__" };
+    if (step.kind === "error") return { ok: null, errorMessage: step.message };
+    args[step.key] = step.value;
+    if (step.setMode !== null) args.mode = step.setMode;
+    i += step.skip;
+  }
+  return { ok: { ...args }, errorMessage: "" };
+}
+
+function commitTrailers(sha: string): string {
+  return gitOutput(["log", "-1", "--pretty=%(trailers)", sha]).stdout;
+}
+
+interface V1Ship {
+  readonly sha: string;
+  readonly date: string;
+}
+
+function detectV1Ship(targetRev: string): V1Ship | null {
+  // Iterate commits oldest-first; return first one whose parsed
+  // trailers contain Agency-Signature-Version: 1.
+  const out = gitOutput([
+    "log",
+    "--reverse",
+    "--max-count=5000",
+    "--pretty=%H %cI",
+    targetRev,
+  ]);
+  const lines = out.stdout.split("\n").filter((s) => s.length > 0);
+  for (const line of lines) {
+    const sp = line.indexOf(" ");
+    if (sp < 0) continue;
+    const sha = line.slice(0, sp);
+    const cdate = line.slice(sp + 1);
+    if (V1_TRAILER_RE.test(commitTrailers(sha))) {
+      return { sha, date: cdate };
+    }
+  }
+  return null;
+}
+
+function parseShipDate(date: string): number | null {
+  // Try Date.parse — handles ISO-8601 with TZ, plain YYYY-MM-DD,
+  // and YYYY-MM-DDTHH:MM:SSZ. Returns Unix timestamp seconds, or null.
+  const ms = Date.parse(date);
+  if (!Number.isNaN(ms)) return Math.floor(ms / 1000);
+  return null;
+}
+
+interface ShipState {
+  readonly date: string;
+  readonly sha: string;
+  readonly tsCache: number | null;
+}
+
+function commitTimestamp(sha: string): number {
+  const out = gitOutput(["log", "-1", "--pretty=%ct", sha]);
+  return Number.parseInt(out.stdout.trim(), 10);
+}
+
+function commitIsoDate(sha: string): string {
+  return gitOutput(["log", "-1", "--pretty=%cI", sha]).stdout.trim();
+}
+
+function commitSubject(sha: string): string {
+  return gitOutput(["log", "-1", "--pretty=%s", sha]).stdout.trim();
+}
+
+function classifyCommit(
+  sha: string,
+  ship: ShipState | null,
+): { status: Status; reason: string } | null {
+  const trailers = commitTrailers(sha);
+  const hasV1 = V1_TRAILER_RE.test(trailers);
+  const hasCoauthor = COAUTHOR_RE.test(trailers);
+
+  if (ship === null) {
+    return { status: "LEGACY", reason: "v1 not yet shipped on this branch" };
+  }
+
+  let shipTs: number;
+  if (ship.tsCache !== null) {
+    shipTs = ship.tsCache;
+  } else {
+    const parsed = parseShipDate(ship.date);
+    if (parsed === null) {
+      process.stderr.write(
+        `error: cannot parse v1-ship-date as timestamp: ${ship.date}\n`,
+      );
+      return null;
+    }
+    shipTs = parsed;
+  }
+
+  const commitTs = commitTimestamp(sha);
+  if (commitTs < shipTs) {
+    return {
+      status: "LEGACY",
+      reason: `pre-v1-ship-date (${commitIsoDate(sha)} < ${ship.date})`,
+    };
+  }
+  if (hasV1) return { status: "CORRECT", reason: "trailer present" };
+  if (hasCoauthor) {
+    return {
+      status: "REGRESSION",
+      reason: "agent commit (Co-authored-by present) missing AgencySignature",
+    };
+  }
+  return {
+    status: "HUMAN-AUTHORED-EXEMPT",
+    reason: "no Co-authored-by signal; assuming human-authored",
+  };
+}
+
+function buildCommitList(args: ParsedArgs, targetRev: string): readonly string[] | null {
+  if (args.mode === "head" || args.mode === "commit") {
+    const ref = args.mode === "head" ? targetRev : args.commitSha;
+    const out = gitOutput(["rev-parse", ref]);
+    if (out.status !== 0) return null;
+    return [out.stdout.trim()];
+  }
+  if (args.mode === "max") {
+    if (!POSITIVE_INT_RE.test(args.maxN)) {
+      process.stderr.write("error: --max value must be a positive integer\n");
+      return null;
+    }
+    const out = gitOutput([
+      "log",
+      `--max-count=${args.maxN}`,
+      "--pretty=%H",
+      targetRev,
+    ]);
+    return out.stdout.split("\n").filter((s) => s.length > 0);
+  }
+  // since
+  const out = gitOutput([
+    "log",
+    `--since=${args.sinceDate}`,
+    "--pretty=%H",
+    targetRev,
+  ]);
+  return out.stdout.split("\n").filter((s) => s.length > 0);
+}
+
+function emitHelp(): ExitCode {
+  process.stdout.write("audit-agencysignature-main-tip.ts — post-merge AgencySignature auditor.\n");
+  process.stdout.write("\nUsage:\n");
+  process.stdout.write("  bun tools/hygiene/audit-agencysignature-main-tip.ts                   # audit HEAD\n");
+  process.stdout.write("  bun tools/hygiene/audit-agencysignature-main-tip.ts --commit <SHA>    # audit specific\n");
+  process.stdout.write("  bun tools/hygiene/audit-agencysignature-main-tip.ts --max 10          # last N\n");
+  process.stdout.write("  bun tools/hygiene/audit-agencysignature-main-tip.ts --since DATE      # since DATE\n");
+  process.stdout.write("  bun tools/hygiene/audit-agencysignature-main-tip.ts --branch NAME     # branch tip\n");
+  process.stdout.write("  bun tools/hygiene/audit-agencysignature-main-tip.ts --v1-ship-date DATE\n");
+  return 0;
+}
+
+interface AuditCounts {
+  correct: number;
+  legacy: number;
+  human: number;
+  regression: number;
+  regressions: string[];
+}
+
+function emitHeader(args: ParsedArgs, targetRev: string, ship: ShipState | null): void {
+  const sha = gitOutput(["rev-parse", targetRev]).stdout.trim();
+  process.stdout.write("AgencySignature v1 main-tip audit\n");
+  process.stdout.write(`  target_rev:    ${targetRev} (${sha})\n`);
+  if (ship !== null) {
+    process.stdout.write(`  v1-ship-date:  ${ship.date}`);
+    if (ship.sha !== "") {
+      process.stdout.write(` (commit ${ship.sha.slice(0, 12)})`);
+    }
+    process.stdout.write("\n");
+  } else {
+    process.stdout.write(
+      "  v1-ship-date:  not yet shipped on this branch (all commits LEGACY)\n",
+    );
+  }
+  process.stdout.write(`  mode:          ${args.mode}\n`);
+  process.stdout.write("\n");
+}
+
+function tallyCommit(status: Status, short: string, counts: AuditCounts): void {
+  if (status === "CORRECT") counts.correct++;
+  else if (status === "LEGACY") counts.legacy++;
+  else if (status === "HUMAN-AUTHORED-EXEMPT") counts.human++;
+  else {
+    counts.regression++;
+    counts.regressions.push(short);
+  }
+}
+
+function emitCommitRow(status: Status, short: string, subject: string, reason: string): void {
+  process.stdout.write(`  [${status.padEnd(22, " ")}] ${short} — ${subject}\n`);
+  process.stdout.write(`    ${reason}\n`);
+}
+
+function auditCommits(
+  commits: readonly string[],
+  ship: ShipState | null,
+): { counts: AuditCounts; toolingError: boolean } {
+  const counts: AuditCounts = {
+    correct: 0,
+    legacy: 0,
+    human: 0,
+    regression: 0,
+    regressions: [],
+  };
+  let cachedShipTs: number | null = ship?.tsCache ?? null;
+  for (const sha of commits) {
+    if (sha === "") continue;
+    const shipState = ship === null ? null : { ...ship, tsCache: cachedShipTs };
+    const result = classifyCommit(sha, shipState);
+    if (result === null) return { counts, toolingError: true };
+    if (ship !== null && cachedShipTs === null) {
+      cachedShipTs = parseShipDate(ship.date);
+    }
+    const short = sha.slice(0, 12);
+    emitCommitRow(result.status, short, commitSubject(sha), result.reason);
+    tallyCommit(result.status, short, counts);
+  }
+  return { counts, toolingError: false };
+}
+
+function emitSummary(counts: AuditCounts): ExitCode {
+  process.stdout.write("\nSummary:\n");
+  process.stdout.write(`  CORRECT:                ${String(counts.correct)}\n`);
+  process.stdout.write(`  LEGACY:                 ${String(counts.legacy)}\n`);
+  process.stdout.write(`  HUMAN-AUTHORED-EXEMPT:  ${String(counts.human)}\n`);
+  process.stdout.write(`  REGRESSION:             ${String(counts.regression)}\n`);
+  if (counts.regression === 0) {
+    process.stdout.write("\nPASS: no regressions detected\n");
+    return 0;
+  }
+  const regressionList = counts.regressions.map((s) => ` ${s}`).join("");
+  process.stdout.write(
+    `\nFAIL: ${String(counts.regression)} regression(s) found:${regressionList}\n`,
+  );
+  process.stdout.write(
+    "  Cause: agent-authored commits (Co-authored-by present) on or after v1\n",
+  );
+  process.stdout.write(
+    "         ship date are missing the Agency-Signature-Version: 1 trailer\n",
+  );
+  process.stdout.write(
+    "         block, indicating squash-merge stripped the trailers OR the PR\n",
+  );
+  process.stdout.write(
+    "         body did not carry the trailer block at the bottom.\n",
+  );
+  process.stdout.write(
+    "  Fix:   re-attach AgencySignature trailers to the next commit; ensure\n",
+  );
+  process.stdout.write(
+    "         future PR bodies include the trailer block at the body bottom\n",
+  );
+  process.stdout.write(
+    "         per the Squash-Merge Invariant rule (ferry-6/7).\n",
+  );
+  process.stdout.write(`  Spec:  ${SPEC_DOC} Section 7.5 + Section 10\n`);
+  return 1;
+}
+
+function determineShip(args: ParsedArgs, targetRev: string): ShipState | null {
+  if (args.v1ShipDate !== "") {
+    return { date: args.v1ShipDate, sha: "", tsCache: null };
+  }
+  const detected = detectV1Ship(targetRev);
+  if (detected === null) return null;
+  return { date: detected.date, sha: detected.sha, tsCache: null };
+}
+
+export function main(argv: readonly string[]): ExitCode {
+  if (!gitAvailable()) {
+    process.stderr.write("error: git not found on PATH\n");
+    return 2;
+  }
+  const parsed = parseArgs(argv);
+  if (parsed.ok === null) {
+    if (parsed.errorMessage === "__HELP__") return emitHelp();
+    process.stderr.write(`${parsed.errorMessage}\n`);
+    return 2;
+  }
+  const args = parsed.ok;
+  const targetRev = args.branch !== "" ? args.branch : "HEAD";
+
+  if (gitOutput(["rev-parse", "--verify", targetRev]).status !== 0) {
+    process.stderr.write(`error: cannot resolve target rev: ${targetRev}\n`);
+    return 2;
+  }
+
+  const ship = determineShip(args, targetRev);
+  const commits = buildCommitList(args, targetRev);
+  if (commits === null) return 2;
+  if (commits.length === 0 && args.mode === "since") {
+    process.stdout.write(
+      `no commits since ${args.sinceDate} on ${targetRev} — nothing to audit\n`,
+    );
+    return 0;
+  }
+
+  emitHeader(args, targetRev, ship);
+  const { counts, toolingError } = auditCommits(commits, ship);
+  if (toolingError) return 2;
+  return emitSummary(counts);
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/tools/hygiene/capture-tick-snapshot.ts
+++ b/tools/hygiene/capture-tick-snapshot.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env bun
+// capture-tick-snapshot.ts — captures a snapshot pin of factory state
+// at tick-open / tick-close time.
+//
+// TypeScript+Bun port of capture-tick-snapshot.sh, slice 9 of the
+// TS+Bun migration. See docs/best-practices/repo-scripting.md.
+//
+// Prints a YAML or JSON fragment for pasting into:
+//   docs/hygiene-history/session-snapshots.md (session-level)
+//   docs/decision-proxy-evidence/DP-NNN.yaml `model` block (decision-level)
+//   a tick-history row's `notes` column (tick-level)
+//
+// Addresses Amara's 4th-ferry snapshot-pinning concern: "Claude is not
+// a single stable operator unless the actual snapshot, system-prompt
+// bundle, and loaded memory surfaces are all pinned and recorded".
+//
+// Usage:
+//   bun tools/hygiene/capture-tick-snapshot.ts         # YAML
+//   bun tools/hygiene/capture-tick-snapshot.ts --json  # JSON
+//
+// Exit codes:
+//   0  always (best-effort capture; missing files yield empty fields)
+
+import { statSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+type ExitCode = 0;
+type Format = "yaml" | "json";
+
+const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+
+// (regex moved to manual extraction in extractRepoName to avoid
+// sonarjs/slow-regex flag on `[^/]+/[^/]+`; the manual version is
+// linear-scan + last-two-segments which preserves bash output exactly)
+
+function gitOutput(args: readonly string[]): string {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", args, {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  if (result.status !== 0) return "";
+  return result.stdout.trim();
+}
+
+function fileExists(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function safeSha(path: string): string {
+  if (!fileExists(path)) return "";
+  return gitOutput(["hash-object", path]);
+}
+
+function safeBytes(path: string): string {
+  if (!fileExists(path)) return "";
+  try {
+    return String(statSync(path).size);
+  } catch {
+    return "";
+  }
+}
+
+function claudeVersion(): string {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("claude", ["--version"], {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  if (result.status !== 0) return "unknown";
+  const first = result.stdout.split("\n")[0] ?? "";
+  return first.trim() || "unknown";
+}
+
+function extractRepoName(url: string): string {
+  // Match bash sed `.*[:/]([^/]+/[^/]+)(\.git)?$` byte-for-byte.
+  // Bash regex is GREEDY on `[^/]+/[^/]+` — when input ends in `.git`,
+  // greedy capture grabs `repo/name.git` and trailing `(\.git)?` matches
+  // empty. Result: bash output keeps `.git` suffix. TS port preserves
+  // this for drop-in equivalence (downstream consumers may rely on it).
+  // Manual extraction: take last two slash-separated segments after the
+  // last `:` or `/` separator that precedes them.
+  const lastSlash = url.lastIndexOf("/");
+  if (lastSlash <= 0) return "unknown";
+  const beforeLast = url.slice(0, lastSlash);
+  const sepIdx = Math.max(
+    beforeLast.lastIndexOf("/"),
+    beforeLast.lastIndexOf(":"),
+  );
+  if (sepIdx < 0) return "unknown";
+  const captured = url.slice(sepIdx + 1);
+  return captured.length > 0 ? captured : "unknown";
+}
+
+function repoFullName(): string {
+  const url = gitOutput(["config", "--get", "remote.origin.url"]);
+  if (url === "") return "unknown";
+  return extractRepoName(url);
+}
+
+function isoUtcNow(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+interface Snapshot {
+  readonly dateUtc: string;
+  readonly headSha: string;
+  readonly branch: string;
+  readonly repo: string;
+  readonly claudeCliVersion: string;
+  readonly claudeMdInRepoSha: string;
+  readonly claudeMdHomeSha: string;
+  readonly agentsMdSha: string;
+  readonly memoryIndexSha: string;
+  readonly memoryIndexBytes: string;
+}
+
+function captureSnapshot(): Snapshot {
+  const homeClaudeMd = join(homedir(), ".claude", "CLAUDE.md");
+  return {
+    dateUtc: isoUtcNow(),
+    headSha: gitOutput(["rev-parse", "HEAD"]) || "unknown",
+    branch: gitOutput(["rev-parse", "--abbrev-ref", "HEAD"]) || "unknown",
+    repo: repoFullName(),
+    claudeCliVersion: claudeVersion(),
+    claudeMdInRepoSha: safeSha("./CLAUDE.md"),
+    claudeMdHomeSha: fileExists(homeClaudeMd) ? safeSha(homeClaudeMd) : "",
+    agentsMdSha: safeSha("./AGENTS.md"),
+    memoryIndexSha: safeSha("memory/MEMORY.md"),
+    memoryIndexBytes: safeBytes("memory/MEMORY.md"),
+  };
+}
+
+function emitJson(s: Snapshot): void {
+  process.stdout.write("{\n");
+  process.stdout.write(`  "date_utc": "${s.dateUtc}",\n`);
+  process.stdout.write(`  "head_sha": "${s.headSha}",\n`);
+  process.stdout.write(`  "branch": "${s.branch}",\n`);
+  process.stdout.write(`  "repo": "${s.repo}",\n`);
+  process.stdout.write(`  "claude_cli_version": "${s.claudeCliVersion}",\n`);
+  process.stdout.write(`  "claude_md_sha_in_repo": "${s.claudeMdInRepoSha}",\n`);
+  process.stdout.write(`  "claude_md_sha_home": "${s.claudeMdHomeSha}",\n`);
+  process.stdout.write(`  "agents_md_sha": "${s.agentsMdSha}",\n`);
+  process.stdout.write(`  "memory_index_sha": "${s.memoryIndexSha}",\n`);
+  process.stdout.write(`  "memory_index_bytes": "${s.memoryIndexBytes}",\n`);
+  process.stdout.write('  "model_snapshot": null,\n');
+  process.stdout.write('  "prompt_bundle_hash": null\n');
+  process.stdout.write("}\n");
+}
+
+function emitYaml(s: Snapshot): void {
+  process.stdout.write(`# tick-snapshot captured ${s.dateUtc}\n`);
+  process.stdout.write("snapshot:\n");
+  process.stdout.write(`  date_utc: ${s.dateUtc}\n`);
+  process.stdout.write(`  head_sha: ${s.headSha}\n`);
+  process.stdout.write(`  branch: ${s.branch}\n`);
+  process.stdout.write(`  repo: ${s.repo}\n`);
+  process.stdout.write(`  claude_cli_version: ${s.claudeCliVersion}\n`);
+  process.stdout.write("  files:\n");
+  process.stdout.write(`    claude_md_in_repo_sha: ${s.claudeMdInRepoSha}\n`);
+  process.stdout.write(`    claude_md_home_sha: ${s.claudeMdHomeSha}\n`);
+  process.stdout.write(`    agents_md_sha: ${s.agentsMdSha}\n`);
+  process.stdout.write(`    memory_index_sha: ${s.memoryIndexSha}\n`);
+  process.stdout.write(`    memory_index_bytes: ${s.memoryIndexBytes}\n`);
+  process.stdout.write("  # Agent fills these from session context:\n");
+  process.stdout.write("  model_snapshot: null        # e.g., claude-opus-4-7\n");
+  process.stdout.write("  prompt_bundle_hash: null    # null until a reconstruct-tool lands\n");
+}
+
+export function main(argv: readonly string[]): ExitCode {
+  const format: Format = argv[0] === "--json" ? "json" : "yaml";
+  const snapshot = captureSnapshot();
+  if (format === "json") emitJson(snapshot);
+  else emitYaml(snapshot);
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/tools/hygiene/validate-agencysignature-pr-body.ts
+++ b/tools/hygiene/validate-agencysignature-pr-body.ts
@@ -1,0 +1,454 @@
+#!/usr/bin/env bun
+// validate-agencysignature-pr-body.ts — pre-merge validator for the
+// AgencySignature Convention v1 trailer block in a PR description body.
+//
+// TypeScript+Bun port of validate-agencysignature-pr-body.sh, slice 9
+// of the TS+Bun migration. See docs/best-practices/repo-scripting.md.
+//
+// Pairs with audit-agencysignature-main-tip.{sh,ts} (post-merge auditor)
+// as the ferry-7 enforcement-instrument set ("stop designing, instrument
+// enforcement").
+//
+// Spec source (the canonical convention):
+//   docs/research/2026-04-26-gemini-deep-think-agencysignature-commit-
+//   attribution-convention-validation-and-refinement.md Section 10
+//
+// Usage:
+//   gh pr view <number> --json body --jq '.body' \
+//     | bun tools/hygiene/validate-agencysignature-pr-body.ts
+//
+// Exit codes:
+//   0 — all required trailers present and enums valid
+//   1 — validation failed (specific failure printed)
+//   2 — tooling / input error
+
+import { spawnSync } from "node:child_process";
+
+type ExitCode = 0 | 1 | 2;
+
+const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+
+const SPEC_DOC =
+  "docs/research/2026-04-26-gemini-deep-think-agencysignature-commit-attribution-convention-validation-and-refinement.md";
+
+const REQUIRED_KEYS: readonly string[] = [
+  "Agency-Signature-Version",
+  "Agent",
+  "Agent-Runtime",
+  "Agent-Model",
+  "Credential-Identity",
+  "Credential-Mode",
+  "Human-Review",
+  "Human-Review-Evidence",
+  "Action-Mode",
+  "Task",
+];
+
+const FENCE_RE = /^[\t ]*```[A-Za-z]*[\t ]*$/;
+const BLANK_RE = /^[\t ]*$/;
+const TASK_RE =
+  /^(?:none|Otto-\d+|task-#?\d+|#?\d+|[A-Za-z][A-Za-z0-9]*-\d+)$/;
+
+const ENUMS: readonly { readonly key: string; readonly allowed: readonly string[] }[] = [
+  { key: "Agency-Signature-Version", allowed: ["1"] },
+  { key: "Credential-Mode", allowed: ["shared", "dedicated-agent", "human-only", "unknown"] },
+  { key: "Human-Review", allowed: ["explicit", "not-implied-by-credential", "none"] },
+  { key: "Human-Review-Evidence", allowed: ["chat", "pr-review", "pr-comment", "signed-policy", "none"] },
+  { key: "Action-Mode", allowed: ["autonomous-fail-open", "human-directed", "supervised"] },
+];
+
+function readStdin(): string {
+  // Bun.stdin / process.stdin sync read via fd 0 + readFileSync.
+  // node:fs readFileSync(0) is the canonical sync stdin read.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const fs = require("node:fs") as typeof import("node:fs");
+  try {
+    return fs.readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function gitAvailable(): boolean {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", ["--version"], {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+  return result.status === 0;
+}
+
+function stripCodeFences(input: string): string {
+  return input
+    .split("\n")
+    .filter((line) => !FENCE_RE.test(line))
+    .join("\n");
+}
+
+function parseTrailers(stripped: string): string {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  const result = spawnSync("git", ["interpret-trailers", "--parse"], {
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+    input: stripped,
+  });
+  // git interpret-trailers exits 0 with empty output when no trailers found;
+  // bash version uses `2>/dev/null || true` — just take the stdout.
+  return result.stdout;
+}
+
+function lastNonBlankLine(text: string): string {
+  const lines = text.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i] ?? "";
+    if (!BLANK_RE.test(line)) return line;
+  }
+  return "";
+}
+
+function findExactLineNumber(input: string, target: string): number {
+  // 1-indexed line number of the LAST exact match in input. Returns 0 if not found.
+  const lines = input.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i] === target) return i + 1;
+  }
+  return 0;
+}
+
+function findKeyPrefixLineNumber(input: string, key: string): number {
+  // 1-indexed line number of the LAST line that starts (case-insensitive)
+  // with `${key}:`. Returns 0 if not found.
+  const prefix = `${key.toLowerCase()}:`;
+  const lines = input.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i] ?? "";
+    if (line.toLowerCase().startsWith(prefix)) return i + 1;
+  }
+  return 0;
+}
+
+function trailerLineKey(line: string): string {
+  const idx = line.indexOf(":");
+  if (idx <= 0) return "";
+  return line.slice(0, idx);
+}
+
+function nonBlankLinesAfter(input: string, lineNum: number): readonly string[] {
+  const lines = input.split("\n");
+  return lines.slice(lineNum).filter((l) => !BLANK_RE.test(l));
+}
+
+function trimSpaceTab(s: string): string {
+  let start = 0;
+  while (start < s.length) {
+    const c = s.charCodeAt(start);
+    if (c !== 0x20 && c !== 0x09) break;
+    start++;
+  }
+  let end = s.length;
+  while (end > start) {
+    const c = s.charCodeAt(end - 1);
+    if (c !== 0x20 && c !== 0x09) break;
+    end--;
+  }
+  return s.slice(start, end);
+}
+
+function getValue(trailers: string, key: string): string {
+  const prefix = `${key.toLowerCase()}:`;
+  for (const line of trailers.split("\n")) {
+    if (!line.toLowerCase().startsWith(prefix)) continue;
+    const idx = line.indexOf(":");
+    if (idx < 0) continue;
+    return trimSpaceTab(line.slice(idx + 1));
+  }
+  return "";
+}
+
+function emitParseFailure(): ExitCode {
+  process.stdout.write("FAIL: no parseable git trailers found in PR body\n");
+  process.stdout.write(
+    "  Class:  Trailer Contiguity Survival Failure\n",
+  );
+  process.stdout.write(
+    "  Cause:  AgencySignature trailer block missing OR blank-line discipline broken\n",
+  );
+  process.stdout.write(
+    "  Fix:    ensure the trailer block at PR body bottom has exactly ONE blank\n",
+  );
+  process.stdout.write(
+    "          line preceding it and ZERO blank lines within it\n",
+  );
+  process.stdout.write(
+    "  Maxim:  A governance convention is not shipped when humans can read it.\n",
+  );
+  process.stdout.write(
+    "          It is shipped when the target substrate can parse it.\n",
+  );
+  process.stdout.write(
+    `  Spec:   ${SPEC_DOC} Section 7.4 (canonical shape) + Section 4 (blank-line guardrail)\n`,
+  );
+  return 1;
+}
+
+function emitLookupFailure(): ExitCode {
+  process.stdout.write(
+    "FAIL: terminal-block check could not locate trailer tail in PR body\n",
+  );
+  process.stdout.write(
+    "  Class:    Validator-Lookup Failure (fail-closed per codex P1 review on PR #24)\n",
+  );
+  process.stdout.write(
+    "  Cause:    parsed trailer line did not match any stripped-input line\n",
+  );
+  process.stdout.write(
+    "            via either exact-match or key-prefix-match strategy.\n",
+  );
+  process.stdout.write(
+    "            Likely cause: parser normalized the trailer (multi-line\n",
+  );
+  process.stdout.write(
+    "            continuation, non-ASCII whitespace, case-fold collision).\n",
+  );
+  process.stdout.write(
+    "  Fix:      simplify PR-body trailer block (single-line trailers,\n",
+  );
+  process.stdout.write(
+    "            literal Key: value, ASCII whitespace) OR extend this\n",
+  );
+  process.stdout.write(
+    "            validator's lookup-fallback chain. Do NOT silently skip.\n",
+  );
+  return 1;
+}
+
+function emitNonTrailerAfterFailure(after: readonly string[]): ExitCode {
+  process.stdout.write(
+    "FAIL: non-trailer content found after the trailer block in PR body\n",
+  );
+  process.stdout.write(
+    "  Class:    Trailer Contiguity Survival Failure (Substrate Truth Principle invariant)\n",
+  );
+  process.stdout.write(
+    "  Cause:    text after the trailer block can push trailers out of the\n",
+  );
+  process.stdout.write(
+    "            terminal-block position when GitHub squash-merge inherits\n",
+  );
+  process.stdout.write(
+    "            the PR description as the squash commit body\n",
+  );
+  process.stdout.write(
+    "  Fix:      move the trailer block to the very END of the PR body;\n",
+  );
+  process.stdout.write(
+    "            no non-trailer non-whitespace content may follow it\n",
+  );
+  process.stdout.write("  Found after trailer block:\n");
+  for (const line of after.slice(0, 5)) process.stdout.write(`    ${line}\n`);
+  process.stdout.write("  Principle: Substrate Truth Principle\n");
+  process.stdout.write(
+    "             A governance convention has not shipped until the parser\n",
+  );
+  process.stdout.write(
+    "             extracts the expected trailers as a contiguous terminal block.\n",
+  );
+  process.stdout.write(`  Spec:      ${SPEC_DOC} Section 7.5 (Squash-Merge Invariant)\n`);
+  return 1;
+}
+
+function emitMissingKeys(missing: readonly string[]): ExitCode {
+  process.stdout.write(
+    `FAIL: missing required AgencySignature v1 trailer keys: ${missing.join(" ")}\n`,
+  );
+  process.stdout.write(
+    "  Class:    Trailer Contiguity Survival Failure — likely cause\n",
+  );
+  process.stdout.write(
+    "            when keys appear textually but blank-line breaks parsing\n",
+  );
+  process.stdout.write(
+    "  Cause:    PR body trailer block is incomplete OR a blank line splits the\n",
+  );
+  process.stdout.write(
+    "            block such that only the final contiguous group parses\n",
+  );
+  process.stdout.write(
+    "  Fix:      add the missing trailers at the PR body bottom OR remove the\n",
+  );
+  process.stdout.write(
+    "            blank line that splits the contiguous block\n",
+  );
+  process.stdout.write(
+    "  Principle: Substrate Truth Principle — text presence is\n",
+  );
+  process.stdout.write(
+    "             insufficient; the parser is the witness\n",
+  );
+  process.stdout.write(`  Spec:     ${SPEC_DOC} Section 7.4 (canonical 10-trailer block)\n`);
+  return 1;
+}
+
+function emitEnumFailure(key: string, found: string, allowed: readonly string[]): ExitCode {
+  process.stdout.write(`FAIL: invalid enum value for ${key}\n`);
+  process.stdout.write(`  Found:    '${found}'\n`);
+  process.stdout.write(`  Expected: one of: ${allowed.join(", ")}\n`);
+  process.stdout.write(`  Spec:     ${SPEC_DOC} Section 7.6 (allowed enum values)\n`);
+  return 1;
+}
+
+function checkTerminalBlock(stripped: string, trailers: string): ExitCode | null {
+  const lastTrailer = lastNonBlankLine(trailers);
+  if (lastTrailer === "") return null;
+
+  let tailLine = findExactLineNumber(stripped, lastTrailer);
+  if (tailLine === 0) {
+    const key = trailerLineKey(lastTrailer);
+    if (key !== "") tailLine = findKeyPrefixLineNumber(stripped, key);
+  }
+  if (tailLine === 0) return emitLookupFailure();
+
+  const after = nonBlankLinesAfter(stripped, tailLine);
+  if (after.length > 0) return emitNonTrailerAfterFailure(after);
+  return null;
+}
+
+function checkRequiredKeys(trailers: string): ExitCode | null {
+  const missing: string[] = [];
+  for (const key of REQUIRED_KEYS) {
+    const prefix = `${key.toLowerCase()}:`;
+    const found = trailers
+      .split("\n")
+      .some((l) => l.toLowerCase().startsWith(prefix));
+    if (!found) missing.push(key);
+  }
+  if (missing.length === 0) return null;
+  return emitMissingKeys(missing);
+}
+
+function checkEnums(trailers: string): ExitCode | null {
+  for (const { key, allowed } of ENUMS) {
+    const value = getValue(trailers, key);
+    if (!allowed.includes(value)) return emitEnumFailure(key, value, allowed);
+  }
+  return null;
+}
+
+function checkTaskPattern(trailers: string): ExitCode | null {
+  const value = getValue(trailers, "Task");
+  if (TASK_RE.test(value)) return null;
+  process.stdout.write("FAIL: invalid Task value\n");
+  process.stdout.write(`  Found:    '${value}'\n`);
+  process.stdout.write(
+    "  Expected: a ticket-id (e.g. Otto-NN, task-#NNN, #NNN, FOO-NN)\n",
+  );
+  process.stdout.write("            or the literal 'none' fallback\n");
+  process.stdout.write(`  Spec:     ${SPEC_DOC} Section 9.2 (Task: none fallback)\n`);
+  return 1;
+}
+
+function checkHumanReviewConsistency(trailers: string): ExitCode | null {
+  const hr = getValue(trailers, "Human-Review");
+  const hre = getValue(trailers, "Human-Review-Evidence");
+  if (hr !== "explicit" && hre !== "none") {
+    process.stdout.write(
+      "FAIL: Human-Review-Evidence must be 'none' when Human-Review is not 'explicit'\n",
+    );
+    process.stdout.write(`  Human-Review:          '${hr}'\n`);
+    process.stdout.write(`  Human-Review-Evidence: '${hre}'\n`);
+    process.stdout.write(`  Spec:                  ${SPEC_DOC} Section 5.3 / 7.6\n`);
+    process.stdout.write(
+      "  Reason: the evidence pointer attaches to actual review claims;\n",
+    );
+    process.stdout.write(
+      "          a non-explicit review state has no evidence to point at\n",
+    );
+    return 1;
+  }
+  if (hr === "explicit" && hre === "none") {
+    process.stdout.write(
+      "FAIL: Human-Review: explicit requires Human-Review-Evidence != 'none'\n",
+    );
+    process.stdout.write(
+      "  Reason: an explicit review claim must cite where the evidence lives\n",
+    );
+    process.stdout.write(
+      "  Fix:    set Human-Review-Evidence to chat | pr-review | pr-comment | signed-policy\n",
+    );
+    process.stdout.write(
+      `  Spec:   ${SPEC_DOC} Section 5.3 (closes the 'explicit according to whom' gap)\n`,
+    );
+    return 1;
+  }
+  return null;
+}
+
+function emitPass(trailers: string): ExitCode {
+  process.stdout.write("PASS: AgencySignature v1 trailer block valid\n");
+  process.stdout.write(
+    `  Agency-Signature-Version: ${getValue(trailers, "Agency-Signature-Version")}\n`,
+  );
+  process.stdout.write(`  Agent:                    ${getValue(trailers, "Agent")}\n`);
+  process.stdout.write(
+    `  Agent-Runtime:            ${getValue(trailers, "Agent-Runtime")}\n`,
+  );
+  process.stdout.write(
+    `  Agent-Model:              ${getValue(trailers, "Agent-Model")}\n`,
+  );
+  process.stdout.write(
+    `  Credential-Identity:      ${getValue(trailers, "Credential-Identity")}\n`,
+  );
+  process.stdout.write(
+    `  Credential-Mode:          ${getValue(trailers, "Credential-Mode")}\n`,
+  );
+  process.stdout.write(
+    `  Human-Review:             ${getValue(trailers, "Human-Review")}\n`,
+  );
+  process.stdout.write(
+    `  Human-Review-Evidence:    ${getValue(trailers, "Human-Review-Evidence")}\n`,
+  );
+  process.stdout.write(
+    `  Action-Mode:              ${getValue(trailers, "Action-Mode")}\n`,
+  );
+  process.stdout.write(`  Task:                     ${getValue(trailers, "Task")}\n`);
+  return 0;
+}
+
+export function main(): ExitCode {
+  if (!gitAvailable()) {
+    process.stderr.write("error: git not found on PATH\n");
+    return 2;
+  }
+  const input = readStdin();
+  if (input === "") {
+    process.stderr.write("error: no input on stdin\n");
+    process.stderr.write(
+      "usage: gh pr view N --json body --jq '.body' | bun tools/hygiene/validate-agencysignature-pr-body.ts\n",
+    );
+    return 2;
+  }
+  const stripped = stripCodeFences(input);
+  const trailers = parseTrailers(stripped);
+  if (trailers === "") return emitParseFailure();
+
+  const terminalCheck = checkTerminalBlock(stripped, trailers);
+  if (terminalCheck !== null) return terminalCheck;
+
+  const requiredCheck = checkRequiredKeys(trailers);
+  if (requiredCheck !== null) return requiredCheck;
+
+  const enumCheck = checkEnums(trailers);
+  if (enumCheck !== null) return enumCheck;
+
+  const taskCheck = checkTaskPattern(trailers);
+  if (taskCheck !== null) return taskCheck;
+
+  const consistencyCheck = checkHumanReviewConsistency(trailers);
+  if (consistencyCheck !== null) return consistencyCheck;
+
+  return emitPass(trailers);
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}


### PR DESCRIPTION
## Summary

- Slice 9 of the TS+Bun migration. Ports 3 hygiene scripts byte-equivalent against bash, with two notable bash-bug-fixes-by-port in audit-agencysignature-main-tip.
- **Agency-signature-pair cluster opened**: validate-agencysignature-pr-body (pre-merge) + audit-agencysignature-main-tip (post-merge) form the ferry-7 enforcement-instrument set per Amara.

## Files

- \`tools/hygiene/validate-agencysignature-pr-body.{sh→ts}\` — pre-merge validator for AgencySignature v1 trailer block in PR bodies (10 required keys + 5 enums + Task pattern + Human-Review consistency)
- \`tools/hygiene/audit-agencysignature-main-tip.{sh→ts}\` — post-merge auditor with 4-state classification (LEGACY / CORRECT / HUMAN-AUTHORED-EXEMPT / REGRESSION) + 5 modes (HEAD / commit / max / since / branch)
- \`tools/hygiene/capture-tick-snapshot.{sh→ts}\` — factory-state YAML/JSON pin per Amara 4th-ferry snapshot-pinning concern

Plus:

- \`docs/trajectories/typescript-bun-migration/slice-audits.md\` — slice-9 audit appended
- \`docs/trajectories/typescript-bun-migration/RESUME.md\` — slice-8-merged closure (#880) + slice-9-in-flight

## Equivalence

Per-script:

| script | result |
|---|---|
| validate-agencysignature-pr-body | byte-equivalent on PASS + FAIL paths |
| audit-agencysignature-main-tip | TS port produces correct classifications where bash silently broke (BSD date TZ-offset + exit-in-subshell bugs on macOS) — documented behaviour-improvement |
| capture-tick-snapshot | byte-equivalent on YAML + JSON modes modulo run-time fields |

## Bash-bug-fixes-by-port (audit-agencysignature-main-tip)

1. **BSD \`date -j -f '%Y-%m-%dT%H:%M:%SZ'\` does NOT handle TZ-offset** like \`-04:00\` on macOS. The TS port uses \`Date.parse\` which handles ISO-8601 with both \`Z\` and \`±HH:MM\` formats.
2. **Bash \`exit 2\` inside \`\$(classify_commit ...)\`** only exits the subshell, not the parent. The bash original silently produced unclassified output on macOS when v1-ship-date had a TZ offset. The TS port short-circuits cleanly.

Same behaviour-improvement-over-bash class as the no-empty-dirs empty-FILTERED case from slice-7.

## Lint + types

All three files pass:

- \`bun x tsc --noEmit\` clean
- \`bun x eslint\` clean (typescript-eslint strictTypeChecked + stylisticTypeChecked + sonarjs)

## Test plan

- [ ] CI: lint + typecheck on the slice files
- [ ] CI: \`bun tools/hygiene/validate-agencysignature-pr-body.ts\` integration smoke test
- [ ] CI: \`bun tools/hygiene/audit-agencysignature-main-tip.ts --max 10\` returns 0 against current main
- [ ] CI: \`bun tools/hygiene/capture-tick-snapshot.ts\` produces parseable YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)