### PR TITLE
fix(ts): tsc TS2322 in audit-agencysignature-main-tip — narrow ArgStep.key

### DIFF
--- a/tools/hygiene/audit-agencysignature-main-tip.ts
+++ b/tools/hygiene/audit-agencysignature-main-tip.ts
@@ -76,8 +76,10 @@ interface ArgParseResult {
   readonly errorMessage: string;
 }
 
+type StringArgKey = "commitSha" | "maxN" | "sinceDate" | "branch" | "v1ShipDate";
+
 type ArgStep =
-  | { readonly kind: "ok"; readonly key: keyof MutableArgs; readonly value: string; readonly setMode: Mode | null; readonly skip: 1 }
+  | { readonly kind: "ok"; readonly key: StringArgKey; readonly value: string; readonly setMode: Mode | null; readonly skip: 1 }
   | { readonly kind: "error"; readonly message: string }
   | { readonly kind: "help" };
 
@@ -91,7 +93,7 @@ interface MutableArgs {
 }
 
 function classifyArg(arg: string, next: string | undefined): ArgStep {
-  const requiresNext: Record<string, { key: keyof MutableArgs; setMode: Mode | null; missing: string }> = {
+  const requiresNext: Record<string, { key: StringArgKey; setMode: Mode | null; missing: string }> = {
     "--commit": { key: "commitSha", setMode: "commit", missing: "error: --commit requires SHA" },
     "--max": { key: "maxN", setMode: "max", missing: "error: --max requires N" },
     "--since": { key: "sinceDate", setMode: "since", missing: "error: --since requires DATE (YYYY-MM-DD)" },

--- a/tools/hygiene/audit-agencysignature-main-tip.ts
+++ b/tools/hygiene/audit-agencysignature-main-tip.ts
@@ -76,13 +76,6 @@ interface ArgParseResult {
   readonly errorMessage: string;
 }
 
-type StringArgKey = "commitSha" | "maxN" | "sinceDate" | "branch" | "v1ShipDate";
-
-type ArgStep =
-  | { readonly kind: "ok"; readonly key: StringArgKey; readonly value: string; readonly setMode: Mode | null; readonly skip: 1 }
-  | { readonly kind: "error"; readonly message: string }
-  | { readonly kind: "help" };
-
 interface MutableArgs {
   mode: Mode;
   commitSha: string;
@@ -91,6 +84,16 @@ interface MutableArgs {
   branch: string;
   v1ShipDate: string;
 }
+
+// Derived from MutableArgs so adding/removing string fields cannot drift
+// from the ArgStep narrowing. `mode` is set via the parallel `setMode`
+// channel, never via key/value.
+type StringArgKey = Exclude<keyof MutableArgs, "mode">;
+
+type ArgStep =
+  | { readonly kind: "ok"; readonly key: StringArgKey; readonly value: string; readonly setMode: Mode | null; readonly skip: 1 }
+  | { readonly kind: "error"; readonly message: string }
+  | { readonly kind: "help" };
 
 function classifyArg(arg: string, next: string | undefined): ArgStep {
   const requiresNext: Record<string, { key: StringArgKey; setMode: Mode | null; missing: string }> = {


### PR DESCRIPTION
## Summary

Fix a strict-typecheck error in `tools/hygiene/audit-agencysignature-main-tip.ts` that was introduced when slice 9 ([#882](https://github.com/Lucent-Financial-Group/Zeta/pull/882)) ported the bash original.

## The error

```text
tools/hygiene/audit-agencysignature-main-tip.ts(124,5): error TS2322:
  Type 'string' is not assignable to type '"head" | "commit" | "max" | "since"'.
```

## Why it's a bug

`MutableArgs.mode` is `Mode = "head" | "commit" | "max" | "since"`; all other fields are `string`. The `ArgStep` "ok" variant declared `key: keyof MutableArgs` which includes `"mode"`, but `step.value` is always derived from argv (so always a `string`). The line `args[step.key] = step.value` (124) therefore failed assignability narrowing.

In practice the assignment is never executed for the `"mode"` case — the mode is set via the parallel `setMode` field, never through `key`/`value`. The fix is purely a type narrowing: introduce `StringArgKey = "commitSha" | "maxN" | "sinceDate" | "branch" | "v1ShipDate"` and use that for the `key` field. **No runtime change.**

## Why CI didn't catch it

`gate.yml` runs `dotnet build` for F#/C# but no `tsc --noEmit` step for TS scripts. ESLint (typed-linting) catches many type issues but not this specific assignability narrowing. Adding a `tsc --noEmit` step to gate.yml is queued as a separate follow-up.

## Test plan

- [x] `bun --bun tsc --noEmit -p tsconfig.json` is clean (was 1 error, now 0).
- [x] `npx eslint tools/hygiene/audit-agencysignature-main-tip.ts` is clean.
- [x] Smoke-test `--help` exits 0 with the expected usage block.
- [x] Smoke-test `--commit HEAD` produces an identical `AgencySignature v1 main-tip audit` block (verified locally — same fields, same values).
- [ ] CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)