### PR TITLE
ci(B-0106): add lint-tsc-tools gate job — tsc --noEmit on tsconfig.json

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -625,3 +625,72 @@ jobs:
 
       - name: Run markdownlint
         run: mise exec -- markdownlint-cli2 "**/*.md"
+
+  lint-tsc-tools:
+    # Strict typecheck on every TypeScript file via `tsc --noEmit -p
+    # tsconfig.json`. Round 35 static-analysis expansion per B-0106:
+    # ESLint with typed-linting catches *most* TS issues but not all
+    # assignability narrowings. Slice 9 (PR #882) shipped a real
+    # TS2322 (`Type 'string' is not assignable to type "head" | ...`)
+    # to main because gate.yml previously had `dotnet build` for F#/C#
+    # but no tsc step for `tools/**/*.ts`. PR #887 fixed the bug; this
+    # job is the missing gate that prevents the class. Same shape as
+    # round-30 semgrep elevation: codified rules (tsconfig strict mode)
+    # without a gate aren't a control.
+    name: lint (tsc tools)
+    timeout-minutes: 5
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Cache install.sh outputs (mise runtimes + dotnet tools + verifier jars)
+        # Comprehensive cache — see lint-shell job above for the
+        # rationale. Bun is what mise installs and what the tsc step
+        # consumes; cache hit avoids the bun-1.3.13 GitHub releases
+        # CDN entirely (same flake class as PR #23 2026-04-28).
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.local/bin/mise
+            ~/.local/share/mise
+            ~/.cache/mise
+            ~/.dotnet/tools
+            ~/.elan
+            ~/.config/zeta
+          key: install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.mise.toml', 'tools/setup/**', 'global.json') }}
+
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        # Provides bun via mise's `bun = "1.3"` pin in .mise.toml.
+        # See lint-shell job above for retry rationale (Aaron 2026-04-28
+        # PR #23 mise+bun-1.3.13 502).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            if ./tools/setup/install.sh; then exit 0; fi
+            [ "$attempt" = "5" ] && { echo "install.sh failed after 5 attempts"; exit 1; }
+            case "$attempt" in
+              1) backoff=10 ;;
+              2) backoff=30 ;;
+              3) backoff=60 ;;
+              4) backoff=120 ;;
+            esac
+            echo "install.sh attempt $attempt failed; retrying in ${backoff}s..." >&2
+            sleep "$backoff"
+          done
+
+      - name: Install npm devDependencies (typescript@6.0.3 + eslint stack)
+        # tsc lives in node_modules/.bin via the typescript devDep
+        # pinned in package.json + bun.lock. --frozen-lockfile fails
+        # if the lockfile is out of date with package.json — same
+        # discipline as bun's own CI patterns.
+        run: bun install --frozen-lockfile
+
+      - name: Run tsc --noEmit on tsconfig.json
+        # Strict typecheck: catches type errors (TS2322 narrowing,
+        # noUncheckedIndexedAccess gaps, exactOptionalPropertyTypes
+        # mismatches, etc.) that eslint typed-linting may miss. Per
+        # the .tsconfig.json strictness profile (verbatimModuleSyntax,
+        # noUncheckedIndexedAccess, exactOptionalPropertyTypes).
+        run: bun --bun tsc --noEmit -p tsconfig.json

--- a/docs/backlog/P2/B-0106-tsc-noemit-gate-job-for-ts-tools-2026-04-30.md
+++ b/docs/backlog/P2/B-0106-tsc-noemit-gate-job-for-ts-tools-2026-04-30.md
@@ -1,7 +1,7 @@
 ---
 id: B-0106
 priority: P2
-status: open
+status: in-progress
 title: Add `tsc --noEmit` gate job for tools/**.ts so type errors fail CI
 tier: factory-hygiene
 effort: S


### PR DESCRIPTION
## Summary

Implements [B-0106](docs/backlog/P2/B-0106-tsc-noemit-gate-job-for-ts-tools-2026-04-30.md) — adds a `lint (tsc tools)` job to `gate.yml` that runs `bun --bun tsc --noEmit -p tsconfig.json`.

## Why

ESLint with typed-linting catches *most* TypeScript issues but not all assignability narrowings. Slice 9 ([#882](https://github.com/Lucent-Financial-Group/Zeta/pull/882)) shipped a real `TS2322` error to main because `gate.yml` runs `dotnet build` for F#/C# but had no tsc step for `tools/**/*.ts`. The bug was found post-merge during slice-12 verification ([#887](https://github.com/Lucent-Financial-Group/Zeta/pull/887) fixed the local instance; this PR closes the structural gap).

Same shape as the round-30 semgrep elevation: codified rules (tsconfig strict mode) without a gate aren't a control.

## Implementation

Modeled after `lint-shell` + `lint-markdown`:

1. Cache install.sh outputs (mise + bun + dotnet tools).
2. install.sh with 5-attempt retry/backoff (bun-1.3.13 transient 502 mitigation).
3. `bun install --frozen-lockfile` → materializes `node_modules/typescript@6.0.3`.
4. `bun --bun tsc --noEmit -p tsconfig.json` — strict typecheck.

Pinned to `ubuntu-24.04`, 5-min timeout. ~70 lines of YAML.

## Test plan

- [x] Local `actionlint .github/workflows/gate.yml` clean.
- [x] Local `bun --bun tsc --noEmit -p tsconfig.json` exits 0 (verified post-#887 merge).
- [ ] CI gate (the new job runs against itself; ironic but correct).
- [ ] Verify the new check appears in branch protection's required-checks list (post-merge follow-up if needed).

## Composes with

- **B-0086** — TS+Bun migration trajectory; the more we port, the more important this gate becomes.
- **PR #887** — fixed the local instance of the bug class this gate prevents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)