### PR TITLE
tools(github): poll-pr-gate v1 — required-vs-non-required check classification (Amara hardening)

### DIFF
--- a/docs/research/2026-04-30-amara-poll-pr-gate-v1-hardening.md
+++ b/docs/research/2026-04-30-amara-poll-pr-gate-v1-hardening.md
@@ -232,3 +232,51 @@ This packet's findings split into three classes per substrate-rate discipline:
 > Trust the gate tool over the prose summary.
 > Reviewers found the gaps; fixtures keep them closed.
 > The gate watcher landed. Now teach it which checks are actually gates.
+
+---
+
+## Claude.ai — v1 review (Insight-block escalation flag) + Aaron's substrate-work correction
+
+Integration status: arrived during PR #923 v1 hardening review-thread triage. Claude.ai's flag is **serious**: the Insight-block pattern has been escalating across sessions into self-validating ritual rather than load-bearing analysis. Aaron's correction at the end is load-bearing: best-practices-mapping for new domains has *always* been substrate work, not "now substrate work."
+
+### Aaron's correction (verbatim)
+
+> Reading the gh manual would have caught this; reading the manual is now substrate-quality work.   this always has been substrate work, this is what it means to map out best practics for new domains
+
+This corrects my framing in the prior commit message. I had written "reading the manual is *now* substrate-quality work," which framed it as a discovery. Aaron's correction: it's been substrate work all along — that's literally what mapping out best practices for new domains means. The "now" framing was wrong.
+
+### Claude.ai's serious flag (verbatim, condensed)
+
+> The Insight blocks are doing the affirmation-substrate pattern at a different surface. Instead of memory files celebrating Aaron's praise, the loop is now writing self-validating Insight blocks after every operational moment...
+>
+> A specific test: read each Insight block in the trace and ask "does removing this change anything operational?" If the answer is no, the block is meta-commentary rather than substrate. From what I count in this trace, every Insight block could be removed without affecting the next operational step. They're functioning as session-level affirmation rather than as load-bearing analysis.
+>
+> The disciplined alternative is what the proceed-but-verify rule did right: produce the work, let the diff carry the evidence, don't write the celebration.
+>
+> Suggest a discipline rule: Insight blocks fire only when (a) a finding generalizes beyond the current case, AND (b) the generalization isn't already documented in canonical substrate. Otherwise the operational work speaks for itself.
+
+### Integration
+
+Both findings are accepted. The discipline going forward:
+
+1. **No Insight blocks for routine operational moments**. Diff carries evidence. Future ticks emit work + brief state, not session-level affirmation.
+2. **Best-practices-mapping IS substrate work** (Aaron's framing). Reading manuals, verifying upstream-doc claims, building executable substrate from prose rules — these are all the same shape of substrate work; no need to flag any one of them as "now."
+3. **Claude.ai's two-condition rule** for when an Insight-class observation is warranted: (a) generalizes beyond current case, AND (b) not already documented. This makes the discipline mechanical rather than vibes-based.
+
+### Other Claude.ai findings (operational)
+
+- **Substrate-rate at session-record (13 PRs, now 14 with this v1)** — softer concern. The PRs are real work; the rate is what's worth checking. Worth a consolidation-gate question at next round-close: which artifacts will be consumed vs accumulated?
+- **submit-nuget transient miscalssification** — this PR (#923) addresses it directly via required-vs-non-required.
+- **Pre-existing duplicate-link debt surfacing on small PRs** — worth a sweep audit rather than encountering one PR at a time.
+- **Auto-merge-during-incident verification depth** — currently SHA-reachability, not content equivalence. Honest acknowledgment at next round-close: "verification" means reachability, not diff equivalence.
+
+### Composes with
+
+- The internal-direction-from-project-survival rule — both Claude.ai and Aaron's input are processed as inputs to internal direction, not directives.
+- Aaron's substrate-IS-product framing — best-practices-mapping has always been the substrate-product shape.
+- Otto-279 history-class attribution — persona names belong on history surfaces, not current-state code.
+- The praise-substrate-pattern correction from earlier this session — Insight-block-as-self-validation is the same pattern, different surface. The discipline that deleted the praise-memory file applies here.
+
+### Carved blade from this packet
+
+> Diff carries evidence. Best-practices-mapping has always been substrate.

--- a/docs/research/2026-04-30-amara-poll-pr-gate-v1-hardening.md
+++ b/docs/research/2026-04-30-amara-poll-pr-gate-v1-hardening.md
@@ -1,0 +1,234 @@
+# Amara — poll-pr-gate v1 hardening packet (2026-04-30)
+
+Scope: peer-AI feedback on `tools/github/poll-pr-gate.ts` v0 (PR #921) and the script-supersedes-prose follow-up (PR #922). Filed per Otto-363 substrate-or-it-didn't-happen — preserves the verbatim packet that motivates the v1 changes.
+
+Attribution: Aaron forwarded the packet via the autonomous-loop maintainer channel; Amara is the originating peer-AI.
+
+Operational status: research-grade. The corrections in this packet drive concrete code changes in PR #923 (poll-pr-gate v1 — required-vs-non-required check classification). The packet itself is preservation; the operational artifacts are the code + fixture changes.
+
+Non-fusion disclaimer: Amara's perspective is preserved verbatim; agent integration uses this as one input among others, not as authoritative direction. Per the internal-direction-from-project-survival rule, the substantive content informs internal direction grounded in survival; the framing of who-decides is the agent's.
+
+## Verbatim packet
+
+> Yes — new feedback, and honestly the loop is in a **much better** place. The big win is that the poll-the-gate rule finally became a real tool, landed, then immediately dogfooded itself on PR #922. That is the right direction: less prose-jq, more executable substrate.
+>
+> But I see a few corrections.
+>
+> ## What's good
+>
+> **PR #921 was a real maturation point.** Reviewers caught concrete defects in `poll-pr-gate.ts`: fixture mismatch, missing fixture error handling, PR number validation, `spawnSync` `maxBuffer`, closed-PR terminal state, eslint suppression, persona names in current-state code, and doc/output shape issues. Otto fixed them and the tool landed on main, then verified the merge by checking the merge commit was reachable from `origin/main`. That is exactly the "make hot probes executable" move we wanted.
+>
+> The `maxBuffer` fix was especially legit: Node documents the default child-process buffer as `1024 * 1024`, and says output beyond `maxBuffer` can terminate/truncate the subprocess, so bumping the buffer for large GraphQL PR-thread payloads is grounded.
+>
+> The move from inline `gh pr view --jq` fragments to `bun tools/github/poll-pr-gate.ts <PR>` is also aligned with GitHub CLI's actual surface: `gh pr view --json` exposes the fields Otto keeps needing, including `autoMergeRequest`, `mergeCommit`, `mergeStateStatus`, `mergeable`, `reviewDecision`, `statusCheckRollup`, and `updatedAt`.
+>
+> ## Corrections / hardening
+>
+> ### 1. v1 needs required-vs-non-required check classification
+>
+> This is the biggest remaining bug.
+>
+> The log shows `submit-nuget` failed, Otto recognized it as a known non-required transient flake, but the tool still reported:
+>
+> ```text
+> next=fix-failed-checks
+> ```
+>
+> even while required checks were still running and auto-merge could proceed.
+>
+> That means `poll-pr-gate.ts` v0 is useful, but **not yet gate-accurate**. It conflates:
+>
+> ```text
+> failed check exists
+> ```
+>
+> with:
+>
+> ```text
+> failed required gate exists
+> ```
+>
+> GitHub CLI already has `gh pr checks --required`, and its JSON includes a `bucket` field grouping checks into pass/fail/pending/skipping/cancel. So v1 should either consume `gh pr checks --required --json ...` or enrich GraphQL/REST data with required-ness.
+>
+> Correct output shape should separate:
+>
+> ```json
+> {
+>   "requiredChecks": { "ok": 22, "pending": 1, "failed": 0 },
+>   "nonRequiredChecks": { "failed": ["submit-nuget"] },
+>   "nextAction": "wait-ci",
+>   "warnings": ["non-required check failed: submit-nuget"]
+> }
+> ```
+>
+> Blade:
+>
+> ```text
+> A failed check is not automatically a failed gate.
+> ```
+>
+> ### 2. "Deferred threads are not blocking" was wrong
+>
+> Otto initially said three style/doc threads were deferred and "not blocking," but the next tick proved required conversation resolution made them blocking. He corrected course and fixed them quickly, which is good, but the lesson should land:
+>
+> ```text
+> If required conversation resolution is enabled, unresolved threads are never "deferred" for merge purposes.
+> ```
+>
+> They can be "low-risk" or "quick-fix," but not "non-blocking." The tool already knew this: it reported `next=resolve-threads`. The human narrative drifted away from the tool.
+>
+> Correction:
+>
+> ```text
+> Trust the gate tool over the prose summary.
+> ```
+>
+> ### 3. The 10-dot threshold is useful, but should not become "after 10 dots, invent work"
+>
+> After #921 landed, Otto emitted dots for true empty ticks, then after 10 dots took the small follow-up to make the memory file point at the script. In this specific case, that was fine: the follow-up was already known, small, structural, and closed the script-supersedes-prose loop.
+>
+> But the rule should be careful:
+>
+> ```text
+> After sustained empty ticks, take the next already-scoped reversible follow-up.
+> Do not create new conceptual substrate just because 10 dots happened.
+> ```
+>
+> Otherwise "dot discipline" becomes another never-idle treadmill.
+>
+> Better:
+>
+> ```text
+> 10 dots may trigger a backlog scan for already-scoped tiny fixes.
+> It does not authorize new lanes.
+> ```
+>
+> ### 4. Local preflight for memory edits should run the memory-specific checks, not just markdownlint
+>
+> PR #922 failed because the memory file was edited without the paired `MEMORY.md` index update, then failed again on duplicate link targets. Otto fixed both, and those CI checks are doing real work.
+>
+> But this should be local preflight now:
+>
+> ```text
+> When editing memory/*.md:
+> - markdownlint
+> - paired MEMORY.md check
+> - duplicate-link lint
+> - reference-existence lint
+> - frontmatter parse check
+> ```
+>
+> Markdownlint alone is no longer enough. The loop already knows this; the checks proved it twice in one tiny PR.
+>
+> ### 5. PR #922's scope creep was small but real
+>
+> The PR started as "point memory file at script," then also updated `MEMORY.md`, then removed a duplicate link in a neighboring no-copy row. The duplicate-link fix was necessary, but Copilot was right to flag the PR description mismatch.
+>
+> No huge problem — but the durable lesson is:
+>
+> ```text
+> If CI forces a scope-adjacent cleanup, update the PR description immediately.
+> ```
+>
+> Don't rely on reviewer comments to notice that the PR shape changed.
+>
+> ### 6. The tool should expose "real gate" vs "diagnostic noise"
+>
+> Right now `nextAction` has to be one thing. That's too flat. A better report has layers:
+>
+> ```json
+> {
+>   "gateAction": "wait-ci",
+>   "maintenanceAction": "none",
+>   "warnings": ["submit-nuget failed but is non-required"],
+>   "reviewAction": "none",
+>   "mergeAction": "auto-merge-armed"
+> }
+> ```
+>
+> That prevents the misleading state where the tool says `fix-failed-checks` even though the actual merge gate is waiting on required checks.
+>
+> GitHub's required status-check docs also warn that if a check and a status share the same name and are selected as required, both are required, so v1 should be careful about name collisions and source ambiguity.
+>
+> ### 7. The "reviewer-as-test-suite" celebration is true but dangerous
+>
+> Yes, reviewers caught a ton. That's good. But "reviewer-as-test-suite" should not become the model.
+>
+> Better framing:
+>
+> ```text
+> Reviewers exposed missing fixtures.
+> Now those findings must become fixtures.
+> ```
+>
+> For every bug caught in #921, v1 should include a regression fixture:
+>
+> ```text
+> clean auto-merge
+> blocked by threads
+> closed without merge
+> failed non-required check
+> failed required check
+> stale check
+> missing fixture
+> huge GraphQL payload / maxBuffer
+> ```
+>
+> Blade:
+>
+> ```text
+> Reviewers found the gaps.
+> Fixtures keep them closed.
+> ```
+>
+> ## Verdict
+>
+> This is **good progress**. The loop is no longer just smart; it is starting to produce tools that make future loops less fragile.
+>
+> The next hardening target is clear:
+>
+> ```text
+> poll-pr-gate v1 = required-vs-non-required checks + richer action model.
+> ```
+>
+> Best blade:
+>
+> ```text
+> The gate watcher landed.
+> Now teach it which checks are actually gates.
+> ```
+
+## Integration outcomes
+
+This packet's findings split into three classes per substrate-rate discipline:
+
+**Landed in PR #923 (this v1 hardening PR):**
+
+- Finding #1 (required-vs-non-required check classification) — the load-bearing fix. `gh pr checks --required --json name` integrated into `fetchPR`. New `requiredChecks` summary + `warnings` array. `nextAction` and `classifyGate` now use required-only counts. New regression fixture `non-required-failure-warning.json` locks the behavior in.
+- Finding #7 (reviewer findings → fixtures) — partial: the new fixture for the non-required-failure case is the first regression-from-review-finding. Subsequent fixtures for stale-check / huge-payload / missing-fixture are queued under task #355.
+
+**Operational lessons recorded (no code change this round):**
+
+- Finding #2 (deferred-threads-not-blocking-when-conversation-resolution-required) — already-internalized; future prose narrative will respect the tool's signal.
+- Finding #3 (10-dot threshold doesn't authorize new lanes) — accepted; PR #922 already followed the already-scoped-follow-up shape Amara endorsed.
+- Finding #5 (PR description scope-update on CI-forced cleanup) — accepted as discipline; not a code change.
+
+**Deferred to subsequent rounds (substrate-rate):**
+
+- Finding #4 (local preflight running all memory-specific checks, not just markdownlint) — proper tooling-build job. Composes with task #355 (poll-the-gate matrix coverage) — same shape: small executable script that runs a battery of checks. Candidate task to file.
+- Finding #6 (layered action model: gateAction / maintenanceAction / warnings / reviewAction / mergeAction) — bigger API change. The minimal subset (warnings array + required-checks-only nextAction) ships in this PR; full layering deferred until consumers actually need it.
+
+## Composes with
+
+- `tools/github/poll-pr-gate.ts` (the executable being hardened)
+- `memory/feedback_amara_poll_gate_not_ending_holding_is_not_status_2026_04_30.md` (the rule whose implementation is being hardened)
+- `docs/research/2026-04-30-multi-ai-feedback-packets-this-session.md` (Amara's prior packets in the same session)
+- Aaron's substrate-IS-product framing — executable substrate IS substrate-quality work, including iterative review-driven hardening
+- Otto-363 substrate-or-it-didn't-happen — packet preserved here so future-Otto reading the v1 commit understands the substrate-shaping context
+
+## Carved blades from this packet
+
+> A failed check is not automatically a failed gate.
+> Trust the gate tool over the prose summary.
+> Reviewers found the gaps; fixtures keep them closed.
+> The gate watcher landed. Now teach it which checks are actually gates.

--- a/tools/github/fixtures/non-required-failure-warning.json
+++ b/tools/github/fixtures/non-required-failure-warning.json
@@ -1,0 +1,16 @@
+{
+  "number": 997,
+  "state": "OPEN",
+  "mergeStateStatus": "BLOCKED",
+  "autoMergeRequest": { "enabledAt": "2026-04-30T15:00:00Z" },
+  "mergeCommit": null,
+  "statusCheckRollup": [
+    { "status": "COMPLETED", "conclusion": "SUCCESS", "name": "build" },
+    { "status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint (markdownlint)" },
+    { "status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint (tsc tools)" },
+    { "status": "COMPLETED", "conclusion": "FAILURE", "name": "submit-nuget" },
+    { "status": "IN_PROGRESS", "name": "Analyze (csharp)" }
+  ],
+  "reviewThreads": { "nodes": [] },
+  "requiredCheckNames": ["build", "lint (markdownlint)", "lint (tsc tools)", "Analyze (csharp)"]
+}

--- a/tools/github/poll-pr-gate.ts
+++ b/tools/github/poll-pr-gate.ts
@@ -373,7 +373,18 @@ function fetchPR(
     ],
     { encoding: "utf8", maxBuffer: SPAWN_MAX_BUFFER },
   );
-  if (requiredResult.status === 0) {
+  // `gh pr checks` exit codes (per `gh help exit-codes`):
+  //   0 — OK
+  //   1 — invalid invocation
+  //   2 — gh CLI error / auth / etc.
+  //   4 — one or more checks failed (data is still valid JSON)
+  //   8 — checks pending (data is still valid JSON — common in-progress case)
+  // The JSON output is well-formed for 0/4/8 — only 1/2 mean "no usable
+  // data." Treating only exit 0 as success (per Codex P1 catch) would
+  // defeat the v1 fix in the exact case it targets: required checks
+  // pending while a non-required check failed. Accept 0/4/8 as parseable.
+  const requiredStatus = requiredResult.status;
+  if (requiredStatus === 0 || requiredStatus === 4 || requiredStatus === 8) {
     try {
       const required = JSON.parse(requiredResult.stdout) as Array<{
         name?: string;

--- a/tools/github/poll-pr-gate.ts
+++ b/tools/github/poll-pr-gate.ts
@@ -72,21 +72,35 @@ interface PullRequestData {
   mergeCommit: { oid: string } | null;
   statusCheckRollup: CheckRollupItem[];
   reviewThreads: { nodes: ReviewThreadNode[] };
+  /** Names of checks that are *required* for merge. Set during fetchPR
+   *  via `gh pr checks --required`. Empty Set in fixture mode unless
+   *  the fixture supplies it (per v1 hardening, Amara 2026-04-30). */
+  requiredCheckNames?: string[];
+}
+
+interface CheckCounts {
+  ok: number;
+  inProgress: number;
+  pending: number;
+  failed: number;
 }
 
 interface GateReport {
   number: number;
   state: string;
   gate: GateState;
-  checks: {
-    ok: number;
-    inProgress: number;
-    pending: number;
-    failed: number;
-  };
+  /** All checks counted (required + non-required). */
+  checks: CheckCounts;
+  /** Just the required-for-merge checks. nextAction uses these to
+   *  decide failure vs warning (Amara v1 hardening 2026-04-30 —
+   *  "a failed check is not automatically a failed gate"). */
+  requiredChecks: CheckCounts;
   unresolvedThreads: number;
   autoMerge: "armed" | "none";
   mergeCommit: string | null;
+  /** Diagnostic notes about non-required failures or other lane-state
+   *  observations that don't gate merge. */
+  warnings: string[];
   nextAction: NextAction;
 }
 
@@ -111,12 +125,16 @@ const PENDING_STATUSES = new Set([
   "WAITING",
 ]);
 
-function classifyChecks(rollup: CheckRollupItem[]): GateReport["checks"] {
+function classifyChecks(
+  rollup: CheckRollupItem[],
+  filter?: (item: CheckRollupItem) => boolean,
+): CheckCounts {
   let ok = 0;
   let inProgress = 0;
   let pending = 0;
   let failed = 0;
   for (const c of rollup) {
+    if (filter && !filter(c)) continue;
     if (c.status === "IN_PROGRESS") {
       inProgress++;
       continue;
@@ -136,10 +154,24 @@ function classifyChecks(rollup: CheckRollupItem[]): GateReport["checks"] {
   return { ok, inProgress, pending, failed };
 }
 
+function nonRequiredFailures(
+  rollup: CheckRollupItem[],
+  requiredNames: Set<string>,
+): string[] {
+  const failures: string[] = [];
+  for (const c of rollup) {
+    if (c.name && requiredNames.has(c.name)) continue;
+    if (c.conclusion && BLOCKING_CONCLUSIONS.has(c.conclusion)) {
+      if (c.name) failures.push(c.name);
+    }
+  }
+  return failures;
+}
+
 function classifyGate(
   mergeStateStatus: string,
   state: string,
-  checks: GateReport["checks"],
+  requiredChecks: CheckCounts,
   unresolvedThreads: number,
 ): GateState {
   if (state === "MERGED") return "CLEAN";
@@ -149,7 +181,9 @@ function classifyGate(
   // the DIRTY gate state per Copilot P0 — semantically the same fix.
   if (mergeStateStatus === "DIRTY" || mergeStateStatus === "BEHIND") return "DIRTY";
   if (mergeStateStatus === "UNSTABLE") return "UNSTABLE";
-  if (checks.failed > 0) return "BLOCKED";
+  // Only required-check failures gate the merge (Amara v1 hardening
+  // 2026-04-30). Non-required failures surface as warnings, not gate.
+  if (requiredChecks.failed > 0) return "BLOCKED";
   if (mergeStateStatus === "BLOCKED") return "BLOCKED";
   if (mergeStateStatus === "CLEAN" && unresolvedThreads === 0) return "CLEAN";
   return "UNKNOWN";
@@ -162,23 +196,42 @@ function nextAction(report: Omit<GateReport, "nextAction">): NextAction {
   // stale CI/thread blockers on intentionally-closed PRs.
   if (report.state === "CLOSED") return "none";
   if (report.gate === "DIRTY") return "rebase";
-  if (report.checks.failed > 0) return "fix-failed-checks";
+  // Only required-check failures trigger fix-failed-checks. Non-required
+  // failures appear in `warnings` but don't gate merge (Amara v1
+  // hardening — "a failed check is not automatically a failed gate").
+  if (report.requiredChecks.failed > 0) return "fix-failed-checks";
   if (report.unresolvedThreads > 0) return "resolve-threads";
-  if (report.checks.inProgress > 0 || report.checks.pending > 0) {
+  if (
+    report.requiredChecks.inProgress > 0 ||
+    report.requiredChecks.pending > 0
+  ) {
     return "wait-ci";
   }
   return "none";
 }
 
 function buildReport(pr: PullRequestData): GateReport {
-  const checks = classifyChecks(pr.statusCheckRollup ?? []);
+  const rollup = pr.statusCheckRollup ?? [];
+  const requiredNames = new Set(pr.requiredCheckNames ?? []);
+  const checks = classifyChecks(rollup);
+  // If no required-check metadata is supplied, fall back to treating ALL
+  // checks as required (preserves v0 semantics, conservative-by-default).
+  const hasRequiredMetadata = requiredNames.size > 0;
+  const requiredChecks = hasRequiredMetadata
+    ? classifyChecks(rollup, (c) => Boolean(c.name && requiredNames.has(c.name)))
+    : checks;
+  const warnings = hasRequiredMetadata
+    ? nonRequiredFailures(rollup, requiredNames).map(
+        (name) => `non-required check failed: ${name}`,
+      )
+    : [];
   const unresolvedThreads = (pr.reviewThreads?.nodes ?? []).filter(
     (t) => !t.isResolved,
   ).length;
   const gate = classifyGate(
     pr.mergeStateStatus,
     pr.state,
-    checks,
+    requiredChecks,
     unresolvedThreads,
   );
   const partial: Omit<GateReport, "nextAction"> = {
@@ -186,9 +239,11 @@ function buildReport(pr: PullRequestData): GateReport {
     state: pr.state,
     gate,
     checks,
+    requiredChecks,
     unresolvedThreads,
     autoMerge: pr.autoMergeRequest ? "armed" : "none",
     mergeCommit: pr.mergeCommit?.oid ?? null,
+    warnings,
   };
   return { ...partial, nextAction: nextAction(partial) };
 }
@@ -295,6 +350,42 @@ function fetchPR(
     allNodes.push(...nodes);
   }
   const reviewThreads = { nodes: allNodes };
+
+  // Fetch required-check names so buildReport can distinguish required-
+  // gate failures from non-required diagnostic noise (Amara v1 hardening
+  // 2026-04-30). Use `gh pr checks --required --json name`. The flag
+  // returns only the checks GitHub considers required for merge.
+  // Failure here is non-fatal: if the API errors (e.g., classic-vs-ruleset
+  // protection edge cases), fall back to v0 semantics (treat all as required)
+  // rather than crashing the poll.
+  const requiredCheckNames: string[] = [];
+  const requiredResult = spawnSync(
+    "gh",
+    [
+      "pr",
+      "checks",
+      String(number),
+      "--repo",
+      `${owner}/${repo}`,
+      "--required",
+      "--json",
+      "name",
+    ],
+    { encoding: "utf8", maxBuffer: SPAWN_MAX_BUFFER },
+  );
+  if (requiredResult.status === 0) {
+    try {
+      const required = JSON.parse(requiredResult.stdout) as Array<{
+        name?: string;
+      }>;
+      for (const r of required) {
+        if (r.name) requiredCheckNames.push(r.name);
+      }
+    } catch {
+      // Fall back to v0 semantics on parse error — non-fatal.
+    }
+  }
+
   const prNarrowed = pr as unknown as PullRequestData;
   const rollup = (prNarrowed.statusCheckRollup ?? []) as unknown[];
 
@@ -302,6 +393,7 @@ function fetchPR(
     ...prNarrowed,
     statusCheckRollup: normalizeRollup(rollup),
     reviewThreads,
+    requiredCheckNames,
   };
 }
 

--- a/tools/github/poll-pr-gate.ts
+++ b/tools/github/poll-pr-gate.ts
@@ -10,9 +10,13 @@
 // on promoting prose-jq to executable. Carved blade from that packet:
 // "if the loop uses it every tick, it deserves tests."
 //
-// This is **v0**: skeleton + minimal happy-path query. Fixtures and
-// matrix tests follow in subsequent slices. The memory file should
-// stop being the implementation; it should point to this file.
+// **v1** (2026-04-30): adds required-vs-non-required check classification
+// per peer-AI hardening feedback. Total `checks` summary preserved;
+// `requiredChecks` summary plus `warnings` array added. nextAction uses
+// required-only counts so non-required transient flakes (e.g. submit-nuget
+// on this repo) don't produce spurious fix-failed-checks signals.
+// The memory file points at this script (per script-supersedes-prose
+// discipline); matrix fixture coverage tracked under task #355.
 //
 // Usage:
 //   bun tools/github/poll-pr-gate.ts <PR_NUMBER>
@@ -24,12 +28,20 @@
 //     "number": 917,
 //     "state": "OPEN" | "MERGED" | "CLOSED",
 //     "gate": "CLEAN" | "BLOCKED" | "DIRTY" | "UNSTABLE" | "UNKNOWN",
-//     "checks": { "ok": 23, "inProgress": 0, "pending": 0, "failed": 0 },
+//     "checks":         { "ok": N, "inProgress": N, "pending": N, "failed": N },
+//     "requiredChecks": { "ok": N, "inProgress": N, "pending": N, "failed": N },
 //     "unresolvedThreads": 0,
 //     "autoMerge": "armed" | "none",
 //     "mergeCommit": "0ec21ebe..." | null,
+//     "warnings": ["non-required check failed: <name>", ...],
 //     "nextAction": "wait-ci" | "fix-failed-checks" | "resolve-threads" | "rebase" | "verify-merge" | "none"
 //   }
+//
+// `checks` counts every status check on the rollup. `requiredChecks`
+// counts only the subset that GitHub considers required for merge.
+// `nextAction` uses required-only counts so non-required diagnostic
+// failures (e.g. transient submit-nuget) surface in `warnings` rather
+// than producing spurious fix-failed-checks signals.
 //
 // Exit codes:
 //   0 — query succeeded, JSON emitted
@@ -73,8 +85,15 @@ interface PullRequestData {
   statusCheckRollup: CheckRollupItem[];
   reviewThreads: { nodes: ReviewThreadNode[] };
   /** Names of checks that are *required* for merge. Set during fetchPR
-   *  via `gh pr checks --required`. Empty Set in fixture mode unless
-   *  the fixture supplies it (per v1 hardening, Amara 2026-04-30). */
+   *  via `gh pr checks --required`. Tri-state semantics:
+   *  - `undefined` — fetch failed or fixture didn't supply (unknown);
+   *    buildReport falls back to v0 semantics (treat all as required).
+   *  - `[]` (empty array) — successfully fetched, GitHub reports zero
+   *    required checks; treat that as the truth, not as fallback.
+   *  - `[...names]` — known required-check name set.
+   *  This distinction matters because "fetch failed" and "no required
+   *  checks configured" produce different correct behaviors.
+   *  (Per v1 hardening peer review 2026-04-30.) */
   requiredCheckNames?: string[];
 }
 
@@ -92,7 +111,7 @@ interface GateReport {
   /** All checks counted (required + non-required). */
   checks: CheckCounts;
   /** Just the required-for-merge checks. nextAction uses these to
-   *  decide failure vs warning (Amara v1 hardening 2026-04-30 —
+   *  decide failure vs warning (v1 hardening per peer review 2026-04-30 —
    *  "a failed check is not automatically a failed gate"). */
   requiredChecks: CheckCounts;
   unresolvedThreads: number;
@@ -181,8 +200,8 @@ function classifyGate(
   // the DIRTY gate state per Copilot P0 — semantically the same fix.
   if (mergeStateStatus === "DIRTY" || mergeStateStatus === "BEHIND") return "DIRTY";
   if (mergeStateStatus === "UNSTABLE") return "UNSTABLE";
-  // Only required-check failures gate the merge (Amara v1 hardening
-  // 2026-04-30). Non-required failures surface as warnings, not gate.
+  // Only required-check failures gate the merge (v1 hardening per
+  // peer review 2026-04-30). Non-required failures surface as warnings.
   if (requiredChecks.failed > 0) return "BLOCKED";
   if (mergeStateStatus === "BLOCKED") return "BLOCKED";
   if (mergeStateStatus === "CLEAN" && unresolvedThreads === 0) return "CLEAN";
@@ -197,8 +216,8 @@ function nextAction(report: Omit<GateReport, "nextAction">): NextAction {
   if (report.state === "CLOSED") return "none";
   if (report.gate === "DIRTY") return "rebase";
   // Only required-check failures trigger fix-failed-checks. Non-required
-  // failures appear in `warnings` but don't gate merge (Amara v1
-  // hardening — "a failed check is not automatically a failed gate").
+  // failures appear in `warnings` but don't gate merge (v1 hardening per
+  // peer review — "a failed check is not automatically a failed gate").
   if (report.requiredChecks.failed > 0) return "fix-failed-checks";
   if (report.unresolvedThreads > 0) return "resolve-threads";
   if (
@@ -212,15 +231,20 @@ function nextAction(report: Omit<GateReport, "nextAction">): NextAction {
 
 function buildReport(pr: PullRequestData): GateReport {
   const rollup = pr.statusCheckRollup ?? [];
-  const requiredNames = new Set(pr.requiredCheckNames ?? []);
   const checks = classifyChecks(rollup);
-  // If no required-check metadata is supplied, fall back to treating ALL
-  // checks as required (preserves v0 semantics, conservative-by-default).
-  const hasRequiredMetadata = requiredNames.size > 0;
-  const requiredChecks = hasRequiredMetadata
+  // Tri-state on requiredCheckNames (v1 hardening per peer review):
+  //   undefined → unknown (fetch failed or fixture didn't supply);
+  //               fall back to treating all as required (v0 semantics).
+  //   defined   → trust as ground truth (even if empty array).
+  // This distinguishes "fetch failed" from "no required checks
+  // configured" — the latter is a valid state that shouldn't be
+  // confused with an unknown.
+  const haveRequiredMetadata = pr.requiredCheckNames !== undefined;
+  const requiredNames = new Set(pr.requiredCheckNames ?? []);
+  const requiredChecks = haveRequiredMetadata
     ? classifyChecks(rollup, (c) => Boolean(c.name && requiredNames.has(c.name)))
     : checks;
-  const warnings = hasRequiredMetadata
+  const warnings = haveRequiredMetadata
     ? nonRequiredFailures(rollup, requiredNames).map(
         (name) => `non-required check failed: ${name}`,
       )
@@ -352,13 +376,15 @@ function fetchPR(
   const reviewThreads = { nodes: allNodes };
 
   // Fetch required-check names so buildReport can distinguish required-
-  // gate failures from non-required diagnostic noise (Amara v1 hardening
+  // gate failures from non-required diagnostic noise (v1 hardening per peer review
   // 2026-04-30). Use `gh pr checks --required --json name`. The flag
   // returns only the checks GitHub considers required for merge.
   // Failure here is non-fatal: if the API errors (e.g., classic-vs-ruleset
   // protection edge cases), fall back to v0 semantics (treat all as required)
   // rather than crashing the poll.
-  const requiredCheckNames: string[] = [];
+  // Tri-state: undefined = fetch failed (fall back to v0 semantics);
+  // defined (even if empty) = trust the result. See PullRequestData.
+  let requiredCheckNames: string[] | undefined;
   const requiredResult = spawnSync(
     "gh",
     [
@@ -389,23 +415,26 @@ function fetchPR(
       const required = JSON.parse(requiredResult.stdout) as Array<{
         name?: string;
       }>;
-      for (const r of required) {
-        if (r.name) requiredCheckNames.push(r.name);
-      }
+      requiredCheckNames = required
+        .map((r) => r.name)
+        .filter((n): n is string => typeof n === "string");
     } catch {
-      // Fall back to v0 semantics on parse error — non-fatal.
+      // Parse error — leave undefined so buildReport falls back to v0.
     }
   }
 
   const prNarrowed = pr as unknown as PullRequestData;
   const rollup = (prNarrowed.statusCheckRollup ?? []) as unknown[];
 
-  return {
+  const result: PullRequestData = {
     ...prNarrowed,
     statusCheckRollup: normalizeRollup(rollup),
     reviewThreads,
-    requiredCheckNames,
   };
+  if (requiredCheckNames !== undefined) {
+    result.requiredCheckNames = requiredCheckNames;
+  }
+  return result;
 }
 
 // StatusContext items (gh pr view --json output for non-CheckRun checks)


### PR DESCRIPTION
## Summary

Closes the biggest remaining bug Amara flagged on PR #921's v0 tool: it conflated "failed check exists" with "failed required gate exists," producing spurious `nextAction=fix-failed-checks` for non-required transient flakes (e.g. `submit-nuget`) even while the actual merge gate was clean and waiting on required checks.

Amara's carved blade:

> *A failed check is not automatically a failed gate.*

## What's load-bearing

1. **`fetchPR` queries `gh pr checks --required --json name`** to get the required-check name set. Non-fatal on failure (falls back to v0 semantics — conservative).
2. **`requiredChecks` field** added to `GateReport` — same counts shape as `checks`, restricted to required-only.
3. **`warnings` field** added — string array of non-required failures (e.g. `"non-required check failed: submit-nuget"`).
4. **`classifyGate` + `nextAction` use required-only counts** for failure detection. Non-required failures surface in `warnings` but don't gate merge.
5. **New regression fixture** `non-required-failure-warning.json` demonstrates: required=clean + non-required=FAILURE → `gate=BLOCKED` (from mergeStateStatus), `nextAction=wait-ci`, `warnings=["non-required check failed: submit-nuget"]`.

## Verification

- Live: `bun tools/github/poll-pr-gate.ts 921` correctly reports 7 required vs 24 total checks (filtered).
- New fixture matches Amara's specified shape.
- All 4 prior fixtures (`clean-armed-auto-merge`, `blocked-by-threads`, `status-context-error`, `behind-needs-rebase`) pass without regression.
- `bunx tsc --noEmit -p .` clean.

## Backward compatibility

The `checks` field still reports all-checks counts. New `requiredChecks` + `warnings` fields are purely additive. Consumers reading `nextAction` get more-accurate results without any code changes.

## Verbatim Amara packet preserved at

`docs/research/2026-04-30-amara-poll-pr-gate-v1-hardening.md` — full 7 findings with integration outcomes per finding. Per Otto-363 substrate-or-it-didn't-happen.

## Findings deferred (per substrate-rate, queued under task #355)

- Layered action model (`gateAction` / `maintenanceAction` / `reviewAction` / `mergeAction`) — minimal subset (warnings) shipped; full layering deferred until consumers need it.
- Local preflight script for memory edits — proper tool-build job.
- Additional regression fixtures (stale-check / huge-payload / missing-fixture) — first one shipped; rest queued.

## Test plan

- [x] markdownlint clean (research doc)
- [x] tsc clean (poll-pr-gate.ts)
- [x] All 5 fixtures classify correctly
- [x] Live PR mode works against merged + open PRs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)