### PR TITLE
hygiene(conflict-markers): allowlist rerere-cache-dividend memory file

### DIFF
--- a/tools/hygiene/check-no-conflict-markers.sh
+++ b/tools/hygiene/check-no-conflict-markers.sh
@@ -57,6 +57,11 @@ ALLOWLIST=(
   # examples. Allowed because the file body is meta-discussion not
   # accidental marker leakage.
   "memory/feedback_otto_341_lint_suppression_is_self_deception_noise_signal_or_underlying_fix_greenfield_large_refactors_welcome_training_data_human_shortcut_bias_2026_04_26.md"
+  # Rerere cache dividend memory file — landed PR #694 (2026-04-30).
+  # Body has a worked-example trace of the MEMORY.md sibling-DIRTY
+  # conflict shape inside a fenced code block (lines 117-121).
+  # Fenced examples of merge markers are documentation, not leakage.
+  "memory/feedback_rerere_conflict_resolution_cache_dividend_amara_2026_04_28.md"
 )
 
 is_allowed() {

--- a/tools/hygiene/check-no-conflict-markers.sh
+++ b/tools/hygiene/check-no-conflict-markers.sh
@@ -58,9 +58,12 @@ ALLOWLIST=(
   # accidental marker leakage.
   "memory/feedback_otto_341_lint_suppression_is_self_deception_noise_signal_or_underlying_fix_greenfield_large_refactors_welcome_training_data_human_shortcut_bias_2026_04_26.md"
   # Rerere cache dividend memory file — landed PR #694 (2026-04-30).
-  # Body has a worked-example trace of the MEMORY.md sibling-DIRTY
-  # conflict shape inside a fenced code block (lines 117-121).
-  # Fenced examples of merge markers are documentation, not leakage.
+  # The "Worked-example trace" section quotes the MEMORY.md sibling-
+  # DIRTY conflict shape inside a fenced code block as the rule's
+  # documented example. Fenced examples of merge markers are
+  # documentation, not leakage. (Line numbers intentionally omitted
+  # so the rationale survives section-level edits — file-level
+  # allowlist scope is the durable contract.)
   "memory/feedback_rerere_conflict_resolution_cache_dividend_amara_2026_04_28.md"
 )
 


### PR DESCRIPTION
## Summary

Adds the rerere memory file (landed via PR #694) to the conflict-markers lint ALLOWLIST.

The file's worked-example trace at lines 117-121 contains literal merge marker tokens (`<<<<<<<`, `=======`, `>>>>>>>`) inside a fenced code block — used as documentation of the MEMORY.md sibling-DIRTY conflict shape that rerere recorded. The lint correctly flagged them as line-start markers; the allowlist mechanism is exactly the documented escape valve for legitimate-discussion files.

Composes with the existing allowlist entry for `feedback_otto_341_*.md` — same pattern, same reasoning.

## Test plan

- [x] `bash tools/hygiene/check-no-conflict-markers.sh` passes locally
- [x] Allowlist comment explains why the file is exempt
- [x] No other allowlist additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)