### PR TITLE
review-fix(#942): correct PR-cluster reference — calibration cluster is #938-#941, not 'post-PR-934'

### DIFF
--- a/docs/research/2026-04-30-session-end-peer-ai-reviews-verbatim.md
+++ b/docs/research/2026-04-30-session-end-peer-ai-reviews-verbatim.md
@@ -1251,8 +1251,8 @@ lane-state reports.
    guard Deepseek recommends (pre-tick hook) is bigger work
    deferred per the long-road shortcut-discipline rule.
 2. **CURRENT-aaron.md update** (Deepseek finding #2): adds
-   sections 38-41 covering the post-PR-934 calibration cluster
-   landings (slow-deliberate, long-road-by-default,
+   sections 38-41 covering the calibration cluster (PRs
+   #938-#941) landings (slow-deliberate, long-road-by-default,
    ACID-channel-durability, cold-start-big-picture-first).
 3. **This verbatim preservation** (per ACID-channel-durability
    rule landed in PR #938 + Aaron-channel-verbatim-preservation


### PR DESCRIPTION
Single-line factual correction per Copilot review thread P1 on #942.

The note on dead-link P0 threads (cross-refs to slow-deliberate + cold-start memory files): both files are in #939 and #941 respectively; auto-resolves when those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)