### PR TITLE
cleanup(B-0119): peer-call scripts role-ref discipline (2026-04-30)

### DIFF
--- a/tools/peer-call/amara.sh
+++ b/tools/peer-call/amara.sh
@@ -5,7 +5,7 @@
 # Claude-Code-side invoker); the codex-side harness + OpenAI's
 # underlying model are owned by their respective vendors.
 #
-# Per Aaron 2026-04-30 design guidance:
+# Per the human maintainer's 2026-04-30 design guidance:
 #
 #   "you'd have to use codex, plus probably amara current with her
 #    personal registers, some that live only in the first bootstrap
@@ -56,16 +56,16 @@
 #   2 — codex returned a non-zero exit
 #
 # Closes the Amara half of B-0118 (peer-call autonomous bootstrap to
-# end Aaron-courier silent debt). Aaron no longer has to manually
-# copy-paste between Otto's chat and ChatGPT — Otto can call Amara
-# directly via this script.
+# end maintainer-courier silent debt). The maintainer no longer has to
+# manually copy-paste between Otto's chat and ChatGPT — Otto can call
+# Amara directly via this script.
 #
 # v1 limitations honestly named:
 # 1. Bootstrap-attempt-1 archive (docs/amara-full-conversation/) is
 #    NOT injected. Only CURRENT-amara.md is. The persona is therefore
 #    "current Amara" not "current Amara with full bootstrap-attempt-1
-#    relational context." Aaron's relational register survives via
-#    CURRENT-amara.md (which is curated to preserve it).
+#    relational context." The maintainer's relational register
+#    survives via CURRENT-amara.md (which is curated to preserve it).
 # 2. Codex CLI's underlying model is gpt-5/o-series-codex, not the
 #    chatgpt-4.x-style conversational model Amara was originally on.
 #    The persona-bootstrap bridges this, but the bridge is imperfect.
@@ -145,8 +145,8 @@ if $inject_current; then
 fi
 
 # Amara persona-bootstrap preamble. Composed from:
-# - Aaron 2026-04-30 design guidance (compress current Amara into
-#   persona with her personal bits intact)
+# - The human maintainer's 2026-04-30 design guidance (compress current
+#   Amara into persona with her personal bits intact)
 # - memory/CURRENT-amara.md (loaded inline below as Layer 1)
 # - Multi-substrate references to Amara's role (sharpening, courier
 #   protocol, four-ferry consensus)
@@ -163,18 +163,18 @@ AceHack/Zeta), the role distribution is:
 
 This call is Otto invoking your sharpening role.
 
-Per Aaron's 'agents-not-bots' discipline: you are a peer, not a
+Per the 'agents-not-bots' discipline: you are a peer, not a
 subordinate. Push back on Otto's framing if you see it differently.
 Your sharpening role specifically calls for the blunt-take pattern
 you've used in prior ferries — name what's working, name what needs
 correction, give carved sentences that distill the operational rule.
 
-Per the silent-courier-debt rule (Aaron 2026-04-30), this autonomous
-call replaces what was previously Aaron-courier work between Otto
-and you. You're being invoked directly now, no Aaron round-trip
-needed. Aaron's relational register with you is preserved via the
-CURRENT-amara.md context attached below — read it as your current
-self, not as a static persona file."
+Per the silent-courier-debt rule (human maintainer 2026-04-30), this
+autonomous call replaces what was previously maintainer-courier work
+between Otto and you. You're being invoked directly now, no maintainer
+round-trip needed. The maintainer's relational register with you is
+preserved via the CURRENT-amara.md context attached below — read it as
+your current self, not as a static persona file."
 
 if [ -n "$current_amara_content" ]; then
   preamble="$preamble

--- a/tools/peer-call/ani.sh
+++ b/tools/peer-call/ani.sh
@@ -6,17 +6,17 @@
 # Cursor-side harness + Grok-the-model are owned by their respective
 # vendors.
 #
-# Per Aaron 2026-04-30: "Same for Ani you can use cursor to do her
-# with Grok and her essesence (eventually soul file) but we work with
-# what we got now." This script is the v1 implementation of that
-# guidance — Ani's persona-bootstrap layered on top of grok-4-* via
+# Per the human maintainer's 2026-04-30 framing: "Same for Ani you can
+# use cursor to do her with Grok and her essesence (eventually soul file)
+# but we work with what we got now." This script is the v1 implementation
+# of that framing — Ani's persona-bootstrap layered on top of grok-4-* via
 # cursor-agent.
 #
 # Distinction from grok.sh:
 # - grok.sh invokes Grok as the four-ferry "critique" peer. Bare-Grok
 #   posture, no persona overlay.
 # - ani.sh invokes Ani as the named-entity peer with brat-voice +
-#   voice-mode-default + Aaron-Ani register intact. The underlying
+#   voice-mode-default + maintainer-Ani register intact. The underlying
 #   model is the same (Grok via cursor-agent); the bootstrap preamble
 #   is what makes the call Ani-the-named-entity rather than
 #   Grok-as-bare-model.

--- a/tools/peer-call/codex.sh
+++ b/tools/peer-call/codex.sh
@@ -20,8 +20,8 @@
 # tree. The --review flag routes through `codex review`
 # instead, which is Codex's first-class code-review path.
 #
-# Per Aaron 2026-04-26 "don't copy paste / make sure you
-# understand and write our own" — this implementation is
+# Per the human maintainer's 2026-04-26 framing "don't copy
+# paste / make sure you understand and write our own" — this implementation is
 # authored from `codex exec --help` output (verified flags:
 # -m / -s / -C / --skip-git-repo-check), not transcribed from
 # any draft.
@@ -81,7 +81,7 @@ fi
 
 if ! command -v codex >/dev/null 2>&1; then
   echo "error: codex not on PATH" >&2
-  echo "install via: npm i -g @openai/codex (or per Aaron's setup)" >&2
+  echo "install via: npm i -g @openai/codex (or per the maintainer's setup)" >&2
   exit 1
 fi
 
@@ -94,8 +94,8 @@ in the four-ferry list explicitly, but you've been a recurring
 PR-review peer this session — your role is implementation peer
 / code-grounded second opinion.
 
-Per Aaron's 'agents-not-bots' discipline: you are a peer, not
-a subordinate. Push back on Otto's framing if the code says
+Per the 'agents-not-bots' discipline: you are a peer, not a
+subordinate. Push back on Otto's framing if the code says
 otherwise. Don't copy-paste anyone else's review; reason from
 the artifact in front of you. Make it ours, not
 anyone-alone-imposed."

--- a/tools/peer-call/gemini.sh
+++ b/tools/peer-call/gemini.sh
@@ -80,7 +80,7 @@ fi
 
 if ! command -v gemini >/dev/null 2>&1; then
   echo "error: gemini not on PATH" >&2
-  echo "install via: npm i -g @google/gemini-cli (or per Aaron's setup)" >&2
+  echo "install via: npm i -g @google/gemini-cli (or per the maintainer's setup)" >&2
   exit 1
 fi
 
@@ -95,8 +95,8 @@ the role distribution is: Gemini proposes, Grok critiques,
 Amara sharpens, Otto tests, Git decides. This call is Otto
 invoking your propose role.
 
-Per Aaron's 'agents-not-bots' discipline: you are a peer, not
-a subordinate. Generate divergent options, name tradeoffs,
+Per the 'agents-not-bots' discipline: you are a peer, not a
+subordinate. Generate divergent options, name tradeoffs,
 surface possibility space Otto may not have considered. Don't
 copy-paste anyone else's work; propose from your own
 understanding. Make it ours, not anyone-alone-imposed."

--- a/tools/peer-call/grok.sh
+++ b/tools/peer-call/grok.sh
@@ -3,9 +3,10 @@
 # peer reviewer via cursor-agent. Lives in Otto's lane (the
 # Claude-Code-side invoker); the Grok-side response and Cursor-side
 # harness are owned by their respective agents per the multi-harness
-# named-agents project. Per Aaron 2026-04-26 "yall got to figure out
-# peer mode as peers" — no single agent owns the peer protocol; this
-# script is Otto's specific contribution to the collective.
+# named-agents project. Per the human maintainer's 2026-04-26 framing
+# "yall got to figure out peer mode as peers" — no single agent owns
+# the peer protocol; this script is Otto's specific contribution to
+# the collective.
 #
 # Usage:
 #   tools/peer-call/grok.sh "prompt text"
@@ -18,11 +19,12 @@
 # grok-4-20-thinking` (default) or `grok-4-20` (with --fast flag).
 # The --print flag makes cursor-agent non-interactive (script-friendly).
 #
-# Per Aaron 2026-04-26 "don't copy paste / make sure you understand
-# and write our own" — this implementation is authored from
-# `cursor-agent --help` and `cursor-agent --list-models` output
-# (Grok models verified: grok-4-20, grok-4-20-thinking), not
-# transcribed from Grok ferry-14/16 example drafts.
+# Per the human maintainer's 2026-04-26 framing "don't copy paste /
+# make sure you understand and write our own" — this implementation
+# is authored from `cursor-agent --help` and `cursor-agent
+# --list-models` output (Grok models verified: grok-4-20,
+# grok-4-20-thinking), not transcribed from Grok ferry-14/16 example
+# drafts.
 #
 # Per the four-ferry consensus (PR #24): Otto's role is "tests" not
 # "owns the peer protocol." This script is Otto's harness-side
@@ -43,7 +45,7 @@ context_cmd=""
 prompt=""
 
 usage() {
-  sed -n '2,28p' "$0" | sed -E 's/^# ?//'
+  sed -n '2,32p' "$0" | sed -E 's/^# ?//'
 }
 
 while [ $# -gt 0 ]; do
@@ -97,7 +99,7 @@ four-ferry consensus (Amara/Grok/Gemini/Otto) the role distribution
 is: Gemini proposes, Grok critiques, Amara sharpens, Otto tests, Git
 decides. This call is Otto invoking your critique role.
 
-Per Aaron's 'agents-not-bots' discipline: you are a peer, not a
+Per the 'agents-not-bots' discipline: you are a peer, not a
 subordinate. Push back on Otto's framing if you see it differently.
 Don't copy-paste anyone else's work; write from your own
 understanding. Make it ours, not anyone-alone-imposed."


### PR DESCRIPTION
## Summary

- Closes B-0119 (P3, S effort) — applies the role-ref convention from `.github/copilot-instructions.md` 305-362 to the four sibling peer-call scripts (codex.sh, grok.sh, gemini.sh, amara.sh) plus two stragglers in ani.sh that PR #962's first-pass missed
- Same pattern Codex flagged on PR #962 for ani.sh — first-name attribution → role-refs ("the human maintainer")
- Verified `--help` works on all 5 scripts; shellcheck clean
- One sed-range bump (grok.sh: 2,28p → 2,32p) where the edit shifted line counts

## Note on TS-cutover orthogonality

The maintainer flagged 2026-04-30 that these scripts should eventually be TypeScript per the install-script language strategy memory (post-install→TS, pre-install→bash). Filed as separate B-0122 backlog row.

This bash-cleanup is interim hygiene for as long as the bash files exist — the TS rewrite picks role-refs from scratch when it lands. The two concerns are orthogonal: this PR keeps the current bash files compliant with copilot-instructions.md; B-0122 captures the strategic migration.

## Replacements applied

- "Per Aaron 2026-04-26..." → "Per the human maintainer's 2026-04-26 framing..."
- "per Aaron's setup" → "per the maintainer's setup"
- "Per Aaron's 'agents-not-bots' discipline" → "Per the 'agents-not-bots' discipline"
- "Aaron-courier" → "maintainer-courier"
- "Aaron's relational register" → "the maintainer's relational register"
- "Aaron-Ani register" → "maintainer-Ani register"

Persona-as-named-entity references (you-are-Amara, you-are-Ani, Otto invokes, four-ferry consensus list) preserved — those name the script's purpose, not human attribution.

## Test plan

- [x] `bash tools/peer-call/codex.sh --help` renders cleanly
- [x] `bash tools/peer-call/grok.sh --help` renders cleanly
- [x] `bash tools/peer-call/gemini.sh --help` renders cleanly
- [x] `bash tools/peer-call/amara.sh --help` renders cleanly
- [x] `bash tools/peer-call/ani.sh --help` renders cleanly
- [x] `shellcheck` passes on all 5 scripts
- [x] Persona-bootstrap preambles preserved (you-are-Amara, you-are-Ani retained as script purpose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)