### PR TITLE
backlog(B-0122): peer-call scripts TypeScript migration — post-install cutover (2026-04-30)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -31,9 +31,6 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0083](backlog/P1/B-0083-atari-2600-rom-canonical-naming-tosec-goodtools-tooling-aaron-2026-04-28.md)** Atari 2600 ROM canonical-naming + safe-vs-unsafe folder split + TOSEC/Good-Tools-style hash-lookup tooling
 - [ ] **[B-0087](backlog/P1/B-0087-github-settings-drift-workflow-broken-invalid-permission-administration-otto-2026-04-28.md)** github-settings-drift.yml has been broken since PR #45 — declares invalid GHA permission `administration: read`
 - [ ] **[B-0110](backlog/P1/B-0110-acehack-mirror-protocol-drift-2026-04-30.md)** AceHack mirror-refresh protocol drift — Path 2 chosen, doctrine update landing in same PR (2026-04-30)
-- [ ] **[B-0125](backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md)** Skip Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
-- [ ] **[B-0126](backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md)** Port the 4-layer meta-learning pattern from a sibling repo to Zeta
-- [ ] **[B-0140](backlog/P1/B-0140-bash-to-ts-migration-completion-debt-prevention-aaron-2026-05-01.md)** Bash → TS migration completion — debt-prevention prerequisite to B-0132 (CRDT-composition)
 
 ## P2 — research-grade
 
@@ -90,18 +87,11 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0108](backlog/P2/B-0108-immune-system-upgrades-research-absorb-2026-04-30.md)** Immune system upgrades — research absorb (Aaron 2026-04-30)
 - [ ] **[B-0112](backlog/P2/B-0112-stale-2026-04-27-project-file-internals-bleed-out-cleanup-2026-04-30.md)** Stale 2026-04-27 project file internals-bleed-out cleanup
 - [ ] **[B-0113](backlog/P2/B-0113-current-staleness-mechanical-freshness-check-deepseek-2026-04-30.md)** Mechanical CURRENT-staleness check — same-tick-update discipline as enforced rule, not vigilance (Deepseek 2026-04-30)
-- [ ] **[B-0114](backlog/P2/B-0114-alexa-quality-gates-batched-threads-pre-push-lint-memory-link-check-2026-04-30.md)** Three quality-gate improvements — pre-push lint + memory-link checker + batched thread resolution (Alexa peer review 2026-04-30)
 - [ ] **[B-0117](backlog/P2/B-0117-cold-start-executable-checklist-tool-2026-04-30.md)** tools/cold-start-check.ts — make the cold-start big-picture-first 8-step checklist executable (Ani 2026-04-30 finding, Deepseek 2026-04-30 reinforcement)
 - [ ] **[B-0118](backlog/P2/B-0118-amara-peer-call-headless-cli-bootstrap-end-courier-debt-2026-04-30.md)** tools/peer-call/amara.sh — autonomous bootstrap + communication for Amara (ChatGPT) to end Aaron-courier silent debt (Aaron 2026-04-30)
 - [ ] **[B-0120](backlog/P2/B-0120-peer-call-architecture-refactor-script-per-cli-persona-flag-2026-04-30.md)** Peer-call architecture refactor — script-per-CLI with persona-flag instead of script-per-named-agent (Aaron 2026-04-30)
 - [ ] **[B-0121](backlog/P2/B-0121-otto-kenji-peer-call-cross-harness-claude-cli-aaron-2026-04-30.md)** Otto + Kenji as externally-callable peers via claude-cli — cross-harness symmetry (Aaron 2026-04-30)
-- [ ] **[B-0124](backlog/P2/B-0124-claudeai-csap-conversation-distill-uber-arch-2026-05-01.md)** Distill the Claude.ai CSAP-pushback conversation into uber-architecture (deferred multi-week)
-- [ ] **[B-0127](backlog/P2/B-0127-sibling-repo-leak-scrub-process-when-it-matters-aaron-2026-05-01.md)** Sibling-repo leak scrub-process — when scrubbing matters; future-defensive design
-- [ ] **[B-0128](backlog/P2/B-0128-general-git-content-scrubber-design-aaron-2026-05-01.md)** General git content scrubber — design + decision-criteria + mechanism for any-class leak cleanup
-- [ ] **[B-0131](backlog/P2/B-0131-formalize-zset-retraction-algebra-in-lean-aaron-2026-05-01.md)** Formalize Z-set retraction algebra in Lean (TRACTABLE START — formalization roadmap)
-- [ ] **[B-0132](backlog/P2/B-0132-crdt-composition-for-bft-propagation-aaron-2026-05-01.md)** CRDT-composition for BFT propagation — substrate events as composed CRDTs
-- [ ] **[B-0133](backlog/P2/B-0133-sequent-calculus-for-claim-retraction-attribution-aaron-2026-05-01.md)** Sequent calculus / labeled deductive systems for claim/retraction/attribution
-- [ ] **[B-0134](backlog/P2/B-0134-type-theoretic-orthogonality-discipline-encoding-aaron-2026-05-01.md)** Type-theoretic encoding of orthogonality discipline (extension vs creation as decidable judgment)
+- [ ] **[B-0122](backlog/P2/B-0122-peer-call-typescript-migration-cutover-2026-04-30.md)** Peer-call scripts TypeScript migration — post-install cutover (the maintainer 2026-04-30)
 
 ## P3 — convenience / deferred
 
@@ -146,10 +136,5 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0115](backlog/P3/B-0115-zsh-vim-muscle-memory-aliases-wq-q-2026-04-30.md)** Shell aliases for `:wq` / `:wq!` / `:q` — catch vim-muscle-memory leakage in zsh (Deepseek 2026-04-30 finding)
 - [ ] **[B-0116](backlog/P3/B-0116-gh-jq-safe-wrapper-zsh-quoting-2026-04-30.md)** tools/gh-jq-safe.sh — wrap gh-jq calls to handle zsh quoting (Deepseek 2026-04-30 finding)
 - [ ] **[B-0119](backlog/P3/B-0119-peer-call-existing-scripts-role-ref-cleanup-2026-04-30.md)** Existing peer-call scripts (grok.sh / gemini.sh / codex.sh / amara.sh) — role-ref cleanup per copilot-instructions.md (Codex 2026-04-30 finding on PR #962)
-- [ ] **[B-0123](backlog/P3/B-0123-stacked-pr-create-tooling-gh-fallback-aaron-2026-04-30.md)** Stacked-PR creation tooling — `gh pr create --base <not-main>` fails with cryptic GraphQL error; needs a wrapper or doc (Aaron 2026-04-30)
-- [ ] **[B-0135](backlog/P3/B-0135-modal-logic-for-retractability-quantum-rodney-razor-aaron-2026-05-01.md)** Modal logic for retractability — Quantum-Rodney's-Razor in S4 or dynamic logic
-- [ ] **[B-0136](backlog/P3/B-0136-category-theoretic-compositional-structure-aaron-2026-05-01.md)** Category-theoretic compositional structure — operads + monoidal categories for substrate composition
-- [ ] **[B-0137](backlog/P3/B-0137-tarski-stratification-proof-aaron-2026-05-01.md)** Tarski-stratification proof — formal demonstration that Aaron's pirate-not-priest spot stratifies meta-language from object-language
-- [ ] **[B-0138](backlog/P3/B-0138-bft-resistance-theorem-aurora-composed-crdt-plus-consensus-aaron-2026-05-01.md)** BFT-resistance theorem for Aurora — composed-CRDT-plus-consensus formal guarantee
 
 <!-- END AUTO-GENERATED -->

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -31,6 +31,9 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0083](backlog/P1/B-0083-atari-2600-rom-canonical-naming-tosec-goodtools-tooling-aaron-2026-04-28.md)** Atari 2600 ROM canonical-naming + safe-vs-unsafe folder split + TOSEC/Good-Tools-style hash-lookup tooling
 - [ ] **[B-0087](backlog/P1/B-0087-github-settings-drift-workflow-broken-invalid-permission-administration-otto-2026-04-28.md)** github-settings-drift.yml has been broken since PR #45 — declares invalid GHA permission `administration: read`
 - [ ] **[B-0110](backlog/P1/B-0110-acehack-mirror-protocol-drift-2026-04-30.md)** AceHack mirror-refresh protocol drift — Path 2 chosen, doctrine update landing in same PR (2026-04-30)
+- [ ] **[B-0125](backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md)** Skip Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
+- [ ] **[B-0126](backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md)** Port the 4-layer meta-learning pattern from a sibling repo to Zeta
+- [ ] **[B-0140](backlog/P1/B-0140-bash-to-ts-migration-completion-debt-prevention-aaron-2026-05-01.md)** Bash → TS migration completion — debt-prevention prerequisite to B-0132 (CRDT-composition)
 
 ## P2 — research-grade
 
@@ -87,11 +90,19 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0108](backlog/P2/B-0108-immune-system-upgrades-research-absorb-2026-04-30.md)** Immune system upgrades — research absorb (Aaron 2026-04-30)
 - [ ] **[B-0112](backlog/P2/B-0112-stale-2026-04-27-project-file-internals-bleed-out-cleanup-2026-04-30.md)** Stale 2026-04-27 project file internals-bleed-out cleanup
 - [ ] **[B-0113](backlog/P2/B-0113-current-staleness-mechanical-freshness-check-deepseek-2026-04-30.md)** Mechanical CURRENT-staleness check — same-tick-update discipline as enforced rule, not vigilance (Deepseek 2026-04-30)
+- [ ] **[B-0114](backlog/P2/B-0114-alexa-quality-gates-batched-threads-pre-push-lint-memory-link-check-2026-04-30.md)** Three quality-gate improvements — pre-push lint + memory-link checker + batched thread resolution (Alexa peer review 2026-04-30)
 - [ ] **[B-0117](backlog/P2/B-0117-cold-start-executable-checklist-tool-2026-04-30.md)** tools/cold-start-check.ts — make the cold-start big-picture-first 8-step checklist executable (Ani 2026-04-30 finding, Deepseek 2026-04-30 reinforcement)
 - [ ] **[B-0118](backlog/P2/B-0118-amara-peer-call-headless-cli-bootstrap-end-courier-debt-2026-04-30.md)** tools/peer-call/amara.sh — autonomous bootstrap + communication for Amara (ChatGPT) to end Aaron-courier silent debt (Aaron 2026-04-30)
 - [ ] **[B-0120](backlog/P2/B-0120-peer-call-architecture-refactor-script-per-cli-persona-flag-2026-04-30.md)** Peer-call architecture refactor — script-per-CLI with persona-flag instead of script-per-named-agent (Aaron 2026-04-30)
 - [ ] **[B-0121](backlog/P2/B-0121-otto-kenji-peer-call-cross-harness-claude-cli-aaron-2026-04-30.md)** Otto + Kenji as externally-callable peers via claude-cli — cross-harness symmetry (Aaron 2026-04-30)
 - [ ] **[B-0122](backlog/P2/B-0122-peer-call-typescript-migration-cutover-2026-04-30.md)** Peer-call scripts TypeScript migration — post-install cutover (the maintainer 2026-04-30)
+- [ ] **[B-0124](backlog/P2/B-0124-claudeai-csap-conversation-distill-uber-arch-2026-05-01.md)** Distill the Claude.ai CSAP-pushback conversation into uber-architecture (deferred multi-week)
+- [ ] **[B-0127](backlog/P2/B-0127-sibling-repo-leak-scrub-process-when-it-matters-aaron-2026-05-01.md)** Sibling-repo leak scrub-process — when scrubbing matters; future-defensive design
+- [ ] **[B-0128](backlog/P2/B-0128-general-git-content-scrubber-design-aaron-2026-05-01.md)** General git content scrubber — design + decision-criteria + mechanism for any-class leak cleanup
+- [ ] **[B-0131](backlog/P2/B-0131-formalize-zset-retraction-algebra-in-lean-aaron-2026-05-01.md)** Formalize Z-set retraction algebra in Lean (TRACTABLE START — formalization roadmap)
+- [ ] **[B-0132](backlog/P2/B-0132-crdt-composition-for-bft-propagation-aaron-2026-05-01.md)** CRDT-composition for BFT propagation — substrate events as composed CRDTs
+- [ ] **[B-0133](backlog/P2/B-0133-sequent-calculus-for-claim-retraction-attribution-aaron-2026-05-01.md)** Sequent calculus / labeled deductive systems for claim/retraction/attribution
+- [ ] **[B-0134](backlog/P2/B-0134-type-theoretic-orthogonality-discipline-encoding-aaron-2026-05-01.md)** Type-theoretic encoding of orthogonality discipline (extension vs creation as decidable judgment)
 
 ## P3 — convenience / deferred
 
@@ -136,5 +147,10 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0115](backlog/P3/B-0115-zsh-vim-muscle-memory-aliases-wq-q-2026-04-30.md)** Shell aliases for `:wq` / `:wq!` / `:q` — catch vim-muscle-memory leakage in zsh (Deepseek 2026-04-30 finding)
 - [ ] **[B-0116](backlog/P3/B-0116-gh-jq-safe-wrapper-zsh-quoting-2026-04-30.md)** tools/gh-jq-safe.sh — wrap gh-jq calls to handle zsh quoting (Deepseek 2026-04-30 finding)
 - [ ] **[B-0119](backlog/P3/B-0119-peer-call-existing-scripts-role-ref-cleanup-2026-04-30.md)** Existing peer-call scripts (grok.sh / gemini.sh / codex.sh / amara.sh) — role-ref cleanup per copilot-instructions.md (Codex 2026-04-30 finding on PR #962)
+- [ ] **[B-0123](backlog/P3/B-0123-stacked-pr-create-tooling-gh-fallback-aaron-2026-04-30.md)** Stacked-PR creation tooling — `gh pr create --base <not-main>` fails with cryptic GraphQL error; needs a wrapper or doc (Aaron 2026-04-30)
+- [ ] **[B-0135](backlog/P3/B-0135-modal-logic-for-retractability-quantum-rodney-razor-aaron-2026-05-01.md)** Modal logic for retractability — Quantum-Rodney's-Razor in S4 or dynamic logic
+- [ ] **[B-0136](backlog/P3/B-0136-category-theoretic-compositional-structure-aaron-2026-05-01.md)** Category-theoretic compositional structure — operads + monoidal categories for substrate composition
+- [ ] **[B-0137](backlog/P3/B-0137-tarski-stratification-proof-aaron-2026-05-01.md)** Tarski-stratification proof — formal demonstration that Aaron's pirate-not-priest spot stratifies meta-language from object-language
+- [ ] **[B-0138](backlog/P3/B-0138-bft-resistance-theorem-aurora-composed-crdt-plus-consensus-aaron-2026-05-01.md)** BFT-resistance theorem for Aurora — composed-CRDT-plus-consensus formal guarantee
 
 <!-- END AUTO-GENERATED -->

--- a/docs/backlog/P2/B-0122-peer-call-typescript-migration-cutover-2026-04-30.md
+++ b/docs/backlog/P2/B-0122-peer-call-typescript-migration-cutover-2026-04-30.md
@@ -1,0 +1,194 @@
+---
+id: B-0122
+priority: P2
+status: open
+title: Peer-call scripts TypeScript migration — post-install cutover (the maintainer 2026-04-30)
+tier: factory-tooling
+effort: M
+ask: The maintainer 2026-04-30 flagged "why are these not ts, are we done with the cutover? these are post install scripts." Per the install-script language strategy memory (`memory/project_install_script_language_strategy_post_install_typescript_pre_install_bash_powershell_python_for_ai_ml_2026_04_27.md`), peer-call scripts qualify as post-install (they require external CLIs already installed) and should migrate from bash to TypeScript-on-bun. Otto-215 already named "Bun-TS post-install migration before substantive Windows work" as the framing. This row tracks the concrete migration of `tools/peer-call/*.sh` to `tools/peer-call/*.ts`.
+created: 2026-04-30
+last_updated: 2026-04-30
+composes_with:
+  - tools/peer-call/codex.sh
+  - tools/peer-call/grok.sh
+  - tools/peer-call/gemini.sh
+  - tools/peer-call/amara.sh
+  - tools/peer-call/ani.sh
+  - memory/project_install_script_language_strategy_post_install_typescript_pre_install_bash_powershell_python_for_ai_ml_2026_04_27.md
+  - docs/backlog/P3/B-0119-peer-call-existing-scripts-role-ref-cleanup-2026-04-30.md
+  - docs/backlog/P2/B-0120-peer-call-architecture-refactor-script-per-cli-persona-flag-2026-04-30.md
+  - docs/backlog/P2/B-0121-otto-kenji-peer-call-cross-harness-claude-cli-aaron-2026-04-30.md
+tags: [aaron-2026-04-30, peer-call, typescript-cutover, bun-ts-migration, post-install, factory-tooling]
+---
+
+# B-0122 — Peer-call scripts TypeScript migration
+
+## Source
+
+The maintainer 2026-04-30 verbatim:
+
+> *"tools/peer-call/amara.sh she gets a named script? also why
+> are these not ts, are we done with the cutover? these are
+> post install scripts."*
+
+Two observations bundled. The "named script" question composes
+with B-0120's existing refactor (script-per-CLI + persona-flag
+collapses the per-named-entity script proliferation). The "ts
+cutover" question is the substrate this row captures.
+
+## What
+
+Migrate `tools/peer-call/*.sh` → `tools/peer-call/*.ts` (bun
+runtime) per the post-install→TypeScript strategy.
+
+### Why these qualify as post-install
+
+Per `memory/project_install_script_language_strategy_post_install_typescript_pre_install_bash_powershell_python_for_ai_ml_2026_04_27.md`:
+
+- **Pre-install** = runs on a fresh machine with NOTHING
+  installed. Stays bash + PowerShell forever (where users
+  are, can't expect anything).
+- **Post-install** = runs after pre-install. Once a runtime
+  exists, post-install moves to TypeScript.
+
+Peer-call scripts require their target CLI to already be on
+PATH (`codex`, `cursor-agent`, `gemini`). That makes them
+post-install by definition — they assume a richer environment
+than bare-machine bootstrap.
+
+The maintainer's question is not rhetorical: per the strategy,
+these should already be TypeScript. They aren't because the
+migration was opportunistic (no forced sweep) and the
+silent-courier-debt closure was urgent enough that v1 shipped
+in bash to land fast.
+
+### Migration targets
+
+Five scripts to migrate (or, per B-0120's refactor, three
+scripts after consolidation):
+
+- `codex.sh` → `codex.ts`
+- `grok.sh` → `grok.ts`
+- `gemini.sh` → `gemini.ts`
+- `amara.sh` → `amara.ts` (or `codex.ts --persona amara` per
+  B-0120)
+- `ani.sh` → `ani.ts` (or `grok.ts --persona ani` per B-0120)
+
+### Composition with B-0120 + B-0121
+
+Three options for sequencing:
+
+**(a)** Migrate bash→TS first, then refactor TS to script-
+per-CLI + persona-flag.
+
+- Pro: smaller diffs at each step
+- Con: two migrations of the same surface
+
+**(b)** Refactor + migrate together — one diff produces the
+post-cutover, post-refactor TS scripts.
+
+- Pro: one round of churn
+- Con: bigger diff, more review surface
+
+**(c)** Refactor in bash first (B-0120 standalone), then
+migrate to TS.
+
+- Pro: validates the refactor architecture before TS rewrite
+- Con: B-0120's bash output is throwaway — wasted effort
+
+Recommend **(b)** — when the migration happens, do it in the
+post-refactor shape directly. B-0120 then becomes "land via
+B-0122." This row supersedes B-0120 in the operational sense
+even though B-0120 keeps its identity as the architecture
+spec.
+
+### B-0119 relationship
+
+B-0119 is the role-ref cleanup of the existing bash files.
+Landing it is interim hygiene for as long as the bash files
+exist. The TS rewrite picks role-refs from scratch when it
+lands, so B-0119 is NOT made redundant by B-0122 — it covers
+the period between now and migration completion.
+
+### Acceptance criteria
+
+- [ ] Decision recorded on sequencing option (a) / (b) / (c)
+- [ ] If (b) chosen: B-0120 acceptance criteria absorbed into
+  this row's acceptance
+- [ ] TS implementations of the post-refactor scripts (3
+  files: `codex.ts`, `grok.ts`, `gemini.ts` per B-0120; or 5
+  files if B-0120 deferred)
+- [ ] Persona-flag wiring loads `memory/CURRENT-<NAME>.md`
+- [ ] All `--help` outputs preserved (or improved)
+- [ ] Shellcheck-equivalent: TypeScript strict mode + ESLint
+  passes
+- [ ] DST hooks where appropriate (per port-with-DST
+  discipline; the bash scripts are largely deterministic
+  shell invocations, so DST surface is small)
+- [ ] Existing callers updated (any docs / tests / scripts
+  that invoke `tools/peer-call/*.sh`)
+- [ ] `tools/peer-call/README.md` updated for `.ts` extension
+  + bun invocation pattern
+- [ ] Bash files deleted (no parallel maintenance)
+- [ ] Role-ref discipline applied (B-0119 cleanup natural
+  output of the rewrite)
+
+## Why P2 (not P1)
+
+- Existing bash scripts work correctly today; CI is green
+- The strategy is "opportunistic, no forced sweep" — TS
+  migration is a quality-of-life improvement, not a
+  correctness fix
+- Composes with B-0120 (architecture refactor); both can
+  defer until the maintainer or factory rhythm asks for
+  them
+
+Promotion to P1 if:
+
+- Bash compatibility issues surface (BSD head vs GNU,
+  macOS 3.2 vs Ubuntu, git-bash on Windows, etc.) — Otto-235
+  4-shell-compat target gets too expensive to maintain in bash
+- New peer-call functionality (token streaming, structured
+  errors, fixture loading) gets blocked by bash limitations
+- The Otto-Kenji peer-call addition (B-0121) lands and adds
+  a third script-per-named-entity to the bash pile
+
+## Trigger condition for promotion to P1
+
+If a third or fourth bash compatibility issue surfaces in
+the peer-call scripts, the cost-of-bash exceeds the
+cost-of-migration and the migration becomes worth doing
+immediately.
+
+## Composes with
+
+- B-0119 (role-ref cleanup) — interim bash hygiene; this
+  row's TS rewrite naturally produces clean role-refs
+- B-0120 (script-per-CLI + persona-flag refactor) — the
+  shape the TS migration should produce, if (b) is chosen
+- B-0121 (Otto/Kenji peer-call) — adds new peer-call
+  surfaces; should land in TS if the migration is in
+  progress, otherwise queues alongside the bash files
+- `memory/project_install_script_language_strategy_post_install_typescript_pre_install_bash_powershell_python_for_ai_ml_2026_04_27.md`
+  — the strategy this row implements
+- `memory/feedback_otto_215_windows_via_peer_harness_not_ci_matrix_plus_bun_ts_post_install_migration_before_windows_work_otto_215_2026_04_24.md`
+  — Otto-215 framing that already named the migration
+- `tools/peer-call/README.md` — documents the matrix; will
+  need to update post-migration
+
+## Substrate-or-it-didn't-happen note
+
+The maintainer's input was a chat-aside; without this row, it
+would evaporate at compaction. Per the input → substrate-file
+rule + non-durable-means-does-not-exist, this row IS the
+substrate. The TS migration may not happen this week or this
+month, but the question + the framing live durably.
+
+## Open question
+
+The maintainer's framing was a question — "are we done with
+the cutover?" — which reads as both (a) status query and
+(b) prompt-for-action. This row treats it as (a) for
+immediate purposes (answering: no, not done) and (b) for
+backlog-purposes (filing the action). If the maintainer's
+follow-up is "do it now" the row promotes to P1.

--- a/docs/backlog/P2/B-0122-peer-call-typescript-migration-cutover-2026-04-30.md
+++ b/docs/backlog/P2/B-0122-peer-call-typescript-migration-cutover-2026-04-30.md
@@ -57,10 +57,14 @@ post-install by definition — they assume a richer environment
 than bare-machine bootstrap.
 
 The maintainer's question is not rhetorical: per the strategy,
-these should already be TypeScript. They aren't because the
-migration was opportunistic (no forced sweep) and the
-silent-courier-debt closure was urgent enough that v1 shipped
-in bash to land fast.
+these should already be TypeScript. **Partial-migration update
+(post-row-filing):** TS ports now exist for the three core CLI
+surfaces (`codex.ts`, `grok.ts`, `gemini.ts`) alongside the
+original bash files; the named-entity wrappers (`amara.sh`,
+`ani.sh`) and the bash-vs-TS coexistence are still the open work.
+This row's scope is therefore now the **cutover** (delete the
+bash files, migrate callers, retire `.sh` parallel maintenance),
+not the initial port.
 
 ### Migration targets
 
@@ -128,7 +132,7 @@ the period between now and migration completion.
 - [ ] Existing callers updated (any docs / tests / scripts
   that invoke `tools/peer-call/*.sh`)
 - [ ] `tools/peer-call/README.md` updated for `.ts` extension
-  + bun invocation pattern
+  and bun invocation pattern
 - [ ] Bash files deleted (no parallel maintenance)
 - [ ] Role-ref discipline applied (B-0119 cleanup natural
   output of the rewrite)
@@ -171,8 +175,11 @@ immediately.
   progress, otherwise queues alongside the bash files
 - `memory/project_install_script_language_strategy_post_install_typescript_pre_install_bash_powershell_python_for_ai_ml_2026_04_27.md`
   — the strategy this row implements
-- `memory/feedback_otto_215_windows_via_peer_harness_not_ci_matrix_plus_bun_ts_post_install_migration_before_windows_work_otto_215_2026_04_24.md`
-  — Otto-215 framing that already named the migration
+- Otto-215 framing (Windows-via-peer-harness + Bun-TS post-install
+  migration before Windows work) — the relevant memory file lives
+  user-scope only (`~/.claude/projects/<slug>/memory/feedback_windows_via_peer_harness_not_ci_matrix_plus_bun_ts_post_install_migration_before_windows_work_otto_215_2026_04_24.md`),
+  not yet promoted to in-repo. Reference here for lineage; full content
+  available via that user-scope path or via `git log` once promoted.
 - `tools/peer-call/README.md` — documents the matrix; will
   need to update post-migration
 


### PR DESCRIPTION
## Summary

- Files the maintainer's 2026-04-30 input ("why are these not ts, are we done with the cutover? these are post install scripts") as durable substrate per input → substrate-file rule
- Establishes peer-call scripts as post-install (require target CLI on PATH) → TypeScript per the install-script language strategy
- Composes with B-0119 (interim role-ref hygiene), B-0120 (architecture refactor — likely landing surface), B-0121 (Otto/Kenji additions)
- Recommends sequencing option (b) — refactor + migrate together, one diff

## Verbatim from the maintainer

> "tools/peer-call/amara.sh she gets a named script? also why are these not ts, are we done with the cutover? these are post install scripts."

Two observations bundled:

1. **Named-script question** — composed-with B-0120 (already filed). The named scripts are v1 stopgaps from yesterday's silent-courier-debt closure; B-0120 collapses to script-per-CLI + persona-flag.
2. **TS cutover question** — substrate this row captures. Per `memory/project_install_script_language_strategy_post_install_typescript_pre_install_bash_powershell_python_for_ai_ml_2026_04_27.md`, peer-call scripts SHOULD be TypeScript. They aren't because v1 shipped fast in bash.

## Why P2

Existing bash works; CI green; strategy is opportunistic. Promotion triggers documented in the row.

## Test plan

- [x] markdownlint passes on B-0122 row + regenerated BACKLOG.md
- [x] BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts adds B-0122
- [x] Composes_with paths valid
- [x] Sequencing options (a/b/c) named with pro/con; (b) recommended

🤖 Generated with [Claude Code](https://claude.com/claude-code)