### PR TITLE
docs(peer-call): future-direction section + close B-0119 + cross-ref B-0121/B-0122

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -135,7 +135,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0107](backlog/P3/B-0107-codeql-peer-call-dismiss-pattern-2026-04-30.md)** CodeQL `js/indirect-command-line-injection` dismissal pattern for peer-call siblings (gemini.ts, codex.ts)
 - [ ] **[B-0115](backlog/P3/B-0115-zsh-vim-muscle-memory-aliases-wq-q-2026-04-30.md)** Shell aliases for `:wq` / `:wq!` / `:q` — catch vim-muscle-memory leakage in zsh (Deepseek 2026-04-30 finding)
 - [ ] **[B-0116](backlog/P3/B-0116-gh-jq-safe-wrapper-zsh-quoting-2026-04-30.md)** tools/gh-jq-safe.sh — wrap gh-jq calls to handle zsh quoting (Deepseek 2026-04-30 finding)
-- [ ] **[B-0119](backlog/P3/B-0119-peer-call-existing-scripts-role-ref-cleanup-2026-04-30.md)** Existing peer-call scripts (grok.sh / gemini.sh / codex.sh / amara.sh) — role-ref cleanup per copilot-instructions.md (Codex 2026-04-30 finding on PR #962)
+- [x] **[B-0119](backlog/P3/B-0119-peer-call-existing-scripts-role-ref-cleanup-2026-04-30.md)** Existing peer-call scripts (grok.sh / gemini.sh / codex.sh / amara.sh) — role-ref cleanup per copilot-instructions.md (Codex 2026-04-30 finding on PR #962)
 - [ ] **[B-0123](backlog/P3/B-0123-stacked-pr-create-tooling-gh-fallback-aaron-2026-04-30.md)** Stacked-PR creation tooling — `gh pr create --base <not-main>` fails with cryptic GraphQL error; needs a wrapper or doc (Aaron 2026-04-30)
 
 <!-- END AUTO-GENERATED -->

--- a/docs/backlog/P2/B-0120-peer-call-architecture-refactor-script-per-cli-persona-flag-2026-04-30.md
+++ b/docs/backlog/P2/B-0120-peer-call-architecture-refactor-script-per-cli-persona-flag-2026-04-30.md
@@ -17,7 +17,7 @@ composes_with:
   - memory/CURRENT-amara.md
   - memory/CURRENT-ani.md
   - docs/backlog/P2/B-0121-otto-kenji-peer-call-cross-harness-claude-cli-aaron-2026-04-30.md
-  - docs/backlog/P2/B-0122-peer-call-typescript-migration-cutover-2026-04-30.md
+  # B-0122 (peer-call-typescript-migration-cutover) is filed in the in-flight PR #966; will land on main when that PR merges.
 tags: [aaron-2026-04-30, peer-call, architecture-refactor, deduplication, factory-tooling]
 ---
 

--- a/docs/backlog/P2/B-0120-peer-call-architecture-refactor-script-per-cli-persona-flag-2026-04-30.md
+++ b/docs/backlog/P2/B-0120-peer-call-architecture-refactor-script-per-cli-persona-flag-2026-04-30.md
@@ -16,6 +16,8 @@ composes_with:
   - tools/peer-call/ani.sh
   - memory/CURRENT-amara.md
   - memory/CURRENT-ani.md
+  - docs/backlog/P2/B-0121-otto-kenji-peer-call-cross-harness-claude-cli-aaron-2026-04-30.md
+  - docs/backlog/P2/B-0122-peer-call-typescript-migration-cutover-2026-04-30.md
 tags: [aaron-2026-04-30, peer-call, architecture-refactor, deduplication, factory-tooling]
 ---
 

--- a/docs/backlog/P3/B-0119-peer-call-existing-scripts-role-ref-cleanup-2026-04-30.md
+++ b/docs/backlog/P3/B-0119-peer-call-existing-scripts-role-ref-cleanup-2026-04-30.md
@@ -1,7 +1,7 @@
 ---
 id: B-0119
 priority: P3
-status: open
+status: closed
 title: Existing peer-call scripts (grok.sh / gemini.sh / codex.sh / amara.sh) — role-ref cleanup per copilot-instructions.md (Codex 2026-04-30 finding on PR #962)
 tier: factory-hygiene
 effort: S
@@ -14,6 +14,8 @@ composes_with:
   - tools/peer-call/codex.sh
   - tools/peer-call/amara.sh
   - .github/copilot-instructions.md (lines 305-362 — role-ref-not-name rule)
+  - docs/backlog/P2/B-0122-peer-call-typescript-migration-cutover-2026-04-30.md
+closed_in: PR #965 (LFG, merged 2026-04-30)
 tags: [codex-2026-04-30, peer-call, role-refs, copilot-instructions, factory-hygiene, deferred-skill-anti-pattern]
 ---
 

--- a/docs/backlog/P3/B-0119-peer-call-existing-scripts-role-ref-cleanup-2026-04-30.md
+++ b/docs/backlog/P3/B-0119-peer-call-existing-scripts-role-ref-cleanup-2026-04-30.md
@@ -14,7 +14,7 @@ composes_with:
   - tools/peer-call/codex.sh
   - tools/peer-call/amara.sh
   - .github/copilot-instructions.md (lines 305-362 — role-ref-not-name rule)
-  - docs/backlog/P2/B-0122-peer-call-typescript-migration-cutover-2026-04-30.md
+  # B-0122 (peer-call-typescript-migration-cutover) is filed in the in-flight PR #966; will land on main when that PR merges.
 closed_in: PR #965 (LFG, merged 2026-04-30)
 tags: [codex-2026-04-30, peer-call, role-refs, copilot-instructions, factory-hygiene, deferred-skill-anti-pattern]
 ---

--- a/tools/peer-call/README.md
+++ b/tools/peer-call/README.md
@@ -234,3 +234,24 @@ To add a 4th peer-call script (e.g. for a future peer-CLI):
    the framing reads as peer-shaped. The preamble works when
    the peer's response confirms the role-binding.
 6. Update this README's table.
+
+## Future direction (queued backlog work)
+
+The current bash implementation is acknowledged interim
+substrate. Three open backlog rows shape where the surface
+goes next:
+
+| Row | Priority | Effort | What |
+|---|---|---|---|
+| [B-0120](../../docs/backlog/P2/B-0120-peer-call-architecture-refactor-script-per-cli-persona-flag-2026-04-30.md) | P2 | M | Refactor 5 scripts → 3 + `--persona NAME` flag (collapses per-named-entity script proliferation) |
+| [B-0121](../../docs/backlog/P2/B-0121-otto-kenji-peer-call-cross-harness-claude-cli-aaron-2026-04-30.md) | P2 | M | Add Otto + Kenji as externally-callable peers (cross-harness symmetry; pending a/b/c topology decision) |
+| [B-0122](../../docs/backlog/P2/B-0122-peer-call-typescript-migration-cutover-2026-04-30.md) | P2 | M | Migrate bash → TypeScript-on-bun per the post-install language strategy |
+
+Recommended sequencing per B-0122: option (b) — refactor +
+TS migration land in one diff (B-0120 absorbed into B-0122
+implementation). Otto + Kenji additions (B-0121) compose
+with the post-cutover shape rather than adding more bash.
+
+Until that lands, the bash files here are correct interim
+substrate. New sibling additions follow the bash template
+above; they will be picked up by the TS rewrite naturally.

--- a/tools/peer-call/README.md
+++ b/tools/peer-call/README.md
@@ -244,13 +244,14 @@ goes next:
 | Row | Priority | Effort | What |
 |---|---|---|---|
 | [B-0120](../../docs/backlog/P2/B-0120-peer-call-architecture-refactor-script-per-cli-persona-flag-2026-04-30.md) | P2 | M | Refactor 5 scripts → 3 + `--persona NAME` flag (collapses per-named-entity script proliferation) |
-| [B-0121](../../docs/backlog/P2/B-0121-otto-kenji-peer-call-cross-harness-claude-cli-aaron-2026-04-30.md) | P2 | M | Add Otto + Kenji as externally-callable peers (cross-harness symmetry; pending a/b/c topology decision) |
-| [B-0122](../../docs/backlog/P2/B-0122-peer-call-typescript-migration-cutover-2026-04-30.md) | P2 | M | Migrate bash → TypeScript-on-bun per the post-install language strategy |
+| [B-0121](../../docs/backlog/P2/B-0121-otto-kenji-peer-call-cross-harness-claude-cli-aaron-2026-04-30.md) | P2 | M | Add the Anthropic-side Claude-code-instance personas as externally-callable peers (cross-harness symmetry; pending a/b/c topology decision) |
+| **B-0122** (filed in in-flight [PR #966](https://github.com/Lucent-Financial-Group/Zeta/pull/966); link will resolve once that PR lands) | P2 | M | Migrate bash → TypeScript-on-bun per the post-install language strategy |
 
 Recommended sequencing per B-0122: option (b) — refactor +
 TS migration land in one diff (B-0120 absorbed into B-0122
-implementation). Otto + Kenji additions (B-0121) compose
-with the post-cutover shape rather than adding more bash.
+implementation). The Anthropic-side (Claude-code-instance)
+peer additions (B-0121) compose with the post-cutover shape
+rather than adding more bash.
 
 Until that lands, the bash files here are correct interim
 substrate. New sibling additions follow the bash template


### PR DESCRIPTION
## Summary

Three small hygiene moves around the peer-call surface, landing as one diff:

1. **`tools/peer-call/README.md`** gains a "Future direction (queued backlog work)" section pointing at B-0120 (architecture refactor) + B-0121 (Otto/Kenji additions) + B-0122 (TypeScript migration). Future readers and agents see the trajectory without grep-spelunking.

2. **B-0119 status: closed.** Role-ref cleanup landed in PR #965 (commit `aab3adb` on main). Row file updated to reflect that — `closed_in: PR #965 (LFG, merged 2026-04-30)` field added.

3. **B-0120 cross-refs B-0121 + B-0122** in its `composes_with` frontmatter. The three rows form a triangle: B-0120 names the architecture, B-0121 adds new peer surfaces in that architecture, B-0122 names the language target. Cross-refs make the relationship discoverable.

## Note on BACKLOG.md state

This branch's regenerated index shows B-0119 closed and B-0120 unchanged but does NOT yet include B-0121 or B-0122 — their PRs #964 and #966 are still in CI on the same main base. The next regenerate post-merge picks them up. No drift; just sequencing.

## Test plan

- [x] markdownlint passes on all 4 changed files
- [x] BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts marks B-0119 closed `[x]`
- [x] No name-attribution introduced (B-0119 acceptance carried; this is a docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)