### PR TITLE
doctrine(autonomous-loop): rediscoverable-from-main invariant — meta-property the every-tick checklist serves (2026-04-30)

### DIFF
--- a/docs/AUTONOMOUS-LOOP.md
+++ b/docs/AUTONOMOUS-LOOP.md
@@ -125,7 +125,7 @@ invariant holds. If no, the change has broken it.
 Four properties make the invariant true today:
 
 - **Tick-history is on `main`.** Each tick lands a row in
-  `docs/hygiene-history/ticks/YYYY/MM/DD/HHMMz.md` before
+  `docs/hygiene-history/ticks/YYYY/MM/DD/HHMMZ.md` before
   the tick stops, so the next session sees the prior tick's
   context by reading the repo.
 - **PR queue is on the host.** Open PRs are visible via
@@ -140,22 +140,31 @@ Four properties make the invariant true today:
   2026-04-30), if it isn't on `main`, the next tick
   won't see it.
 - **Cron is the cadence engine, not session memory.** The
-  every-minute heartbeat fires regardless of which session
-  is active; `CronList` is checked end-of-tick so the
-  [last-check → next-fire] window is minimised; the next
+  every-minute heartbeat fires whenever a session is active
+  to receive it; `CronList` is checked end-of-tick so the
+  [last-check → next-fire] window is minimized; the next
   tick fires without depending on the prior tick's
-  process state.
+  process state. Sessions that resume via `--resume` /
+  `--continue` inherit the registered cron when it's still
+  within its 7-day expiry; brand-new sessions re-arm via
+  the every-tick checklist (per the "Session-restart
+  recovery" section below).
 
 Future revisions of this file may add, drop, or restructure
 the checklist below — provided the rediscoverable-from-`main`
 invariant is preserved or strengthened. Treat the four
 properties above as the test surface.
 
-> The human maintainer, 2026-04-30: *"[the rediscoverable-on-
-> main part] should be an invariant for all future changes
-> to this file"* — the meta-property is what makes the
-> discipline portable across sessions, agents, and forks of
-> the factory.
+> The human maintainer, 2026-04-30 (paraphrased — the original
+> framing was "Six-step tick close has a satisfying property
+> that should be an invariant for all future changes to this
+> file" followed by a sharpening "not six step the
+> rediscoverable on main part"; the bracketed gloss reflects
+> the sharpening): *"[the rediscoverable-on-main part]
+> should be an invariant for all future changes to this
+> file."* The meta-property is what makes the discipline
+> portable across sessions, agents, and forks of the
+> factory.
 
 ## The every-tick checklist
 

--- a/docs/AUTONOMOUS-LOOP.md
+++ b/docs/AUTONOMOUS-LOOP.md
@@ -103,6 +103,60 @@ fires one final time, then deletes itself."* For runs
 longer than 7 days, the `long-term-rescheduler` skill rotates
 crons near expiry via `CronDelete` + `CronCreate`.
 
+## Invariant — rediscoverable from `main` alone
+
+This discipline serves a load-bearing invariant:
+
+> **A fresh agent reading `main` alone — no chat history,
+> no in-session memory, no out-of-band context — can pick
+> up the next tick and continue the work cleanly.**
+
+The every-tick checklist below is *a* mechanism that
+preserves this invariant; it is not itself the invariant.
+The number of checklist steps is incidental — discoverability
+from `main` alone is what's load-bearing.
+
+Concretely, every change to this file MUST preserve (or
+strengthen) the invariant. The check is: *can a freshly
+spawned agent, reading only committed-on-`main` artifacts,
+find the prior tick's state and act on it?* If yes, the
+invariant holds. If no, the change has broken it.
+
+Four properties make the invariant true today:
+
+- **Tick-history is on `main`.** Each tick lands a row in
+  `docs/hygiene-history/ticks/YYYY/MM/DD/HHMMz.md` before
+  the tick stops, so the next session sees the prior tick's
+  context by reading the repo.
+- **PR queue is on the host.** Open PRs are visible via
+  `gh pr list` without session state; the next tick can
+  poll the gate (real-dependency-wait discipline) without
+  remembering which PRs are in flight.
+- **Substrate precedes narration.** Decisions, corrections,
+  and framings land as memory files / backlog rows / docs
+  in committed substrate BEFORE chat narration. Per
+  substrate-or-it-didn't-happen (Otto-363) +
+  non-durable-means-does-not-exist (the human maintainer,
+  2026-04-30), if it isn't on `main`, the next tick
+  won't see it.
+- **Cron is the cadence engine, not session memory.** The
+  every-minute heartbeat fires regardless of which session
+  is active; `CronList` is checked end-of-tick so the
+  [last-check → next-fire] window is minimised; the next
+  tick fires without depending on the prior tick's
+  process state.
+
+Future revisions of this file may add, drop, or restructure
+the checklist below — provided the rediscoverable-from-`main`
+invariant is preserved or strengthened. Treat the four
+properties above as the test surface.
+
+> The human maintainer, 2026-04-30: *"[the rediscoverable-on-
+> main part] should be an invariant for all future changes
+> to this file"* — the meta-property is what makes the
+> discipline portable across sessions, agents, and forks of
+> the factory.
+
 ## The every-tick checklist
 
 This is the load-bearing bit. **Every tick**, in order:


### PR DESCRIPTION
## Summary

Adds an "Invariant — rediscoverable from \`main\` alone" section to `docs/AUTONOMOUS-LOOP.md`, framing the every-tick checklist as a *mechanism serving an invariant* rather than the invariant itself.

## Verbatim direction from the maintainer

> "Six-step tick close (docs/AUTONOMOUS-LOOP.md) has a satisfying property that should be an invariant for all future changes to this file"
>
> follow-up sharpening: "not six step the rediscoverable on main part"

## What's in scope

- New "Invariant" section *before* "The every-tick checklist"
- Names the load-bearing property: a fresh agent reading `main` alone can pick up the next tick
- Names four supporting properties (tick-history on main, PR queue on host, substrate precedes narration, cron-as-cadence-engine)
- Explicit test for future revisions: does the change preserve or strengthen the invariant?
- Verbatim quote from the maintainer at the end of the section

## What's NOT in scope

- The every-tick checklist itself is unchanged. The point is exactly that the count of steps is incidental — only the discoverability is load-bearing. Future revisions can restructure provided the invariant holds.
- No memory file added; the invariant lives in the doc itself, where the maintainer asked it to live.

## Composes with

- `Otto-363` substrate-or-it-didn't-happen
- `non-durable-means-does-not-exist` (the maintainer, 2026-04-30)
- Together: "if it isn't on `main`, the next tick won't see it" — the structural reason the invariant matters.

## Test plan

- [x] markdownlint passes on the changed file
- [x] Section placement verified (before "## The every-tick checklist")
- [x] Role-ref discipline honored (the maintainer's quote uses "the human maintainer" framing in surrounding prose; the verbatim quote retains the directive content)
- [x] No checklist content changed — surgical addition only

🤖 Generated with [Claude Code](https://claude.com/claude-code)