### PR TITLE
backlog(B-0125): P1 — skip Analyze (csharp) on docs-only PRs without tripping code_quality severity:all

### DIFF
--- a/docs/backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md
+++ b/docs/backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md
@@ -1,0 +1,66 @@
+# B-0125 — Skip Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
+
+**Priority:** P1 (high value, soon)
+
+**Filed:** 2026-05-01
+
+**Filed by:** Otto under the new backlog-prioritization authority delegated 2026-05-01 (per `memory/feedback_backlog_prioritization_authority_delegated_to_otto_aaron_2026_05_01.md`). Aaron's framing 2026-05-01 in chat: *"speeding up for CI for non code changes? where do you want to priortize that, the typescript is part of the docs but you can skip the f# that's on backlog."*
+
+**Effort:** M (1-3 days — investigation + workflow change + verification)
+
+## What
+
+Make `Analyze (csharp)` (and any other F#-only CI step) skip on PRs that touch only docs/memory/backlog/research surfaces, while keeping all TypeScript checks, build-and-test, and CodeQL on other languages running unchanged. Specifically:
+
+- **Skip on:** `docs/**`, `memory/**`, `docs/backlog/**`, `docs/hygiene-history/**`, `docs/research/**` (and similar non-code surfaces).
+- **Do NOT skip on:** any `src/**` change, any `.github/workflows/**` change, any TypeScript file change anywhere (TypeScript is the factory tooling per CURRENT-aaron §30, treat as code), any `tools/**` change that affects F# build/test.
+- **Must NOT trip:** the `code_quality severity:all` ruleset on LFG/main. The hard part is that `code_quality severity:all` will fail when `Analyze (csharp)` is *skipped* rather than *successful* — Amara's Option B per-language source-presence gate (PR #857 / task #340) addressed an adjacent case but the docs-only path-filter case remains.
+
+## Why P1
+
+- **Throughput cost is real and recurring.** This session block landed 6 non-code PRs (#997 / #999 / #1000 / #1001 / #1002 / #1003) at ~5min CI each = ~30min CI-blocked time for substrate-only work. Project produces ~half its PRs in this non-code class going forward; cost compounds with the high substrate cadence (~550 checkins/week per chunk-11 CSAP-pushback observation).
+- **Bounded scope.** Path-filter + ruleset-coordination is a contained change.
+- **High Aaron-tax reduction.** Aaron flagged this in chat as visible CI-wait pain.
+
+## Why not P0
+
+- **Real risk.** `code_quality severity:all` on LFG/main is host-mutation-protected (per `memory/feedback_*` from PRs #849/#857/#651-cluster, plus task #343 drift-debt receipt for the 2026-04-29 ruleset mutation). Rushing the workflow change can break LFG/main protection.
+- **Not blocking critical-path work.** CI-wait is throughput-drag, not stop-the-line.
+
+## Why not P2
+
+- The throughput cost is paid every non-code PR and compounds. Deferring multi-week leaves substantial Aaron-tax + Otto-tick-time on the table.
+
+## Acceptance criteria
+
+1. **Path-filter implemented.** PRs touching only the listed non-code surfaces skip `Analyze (csharp)` and any F#-only CI steps. Implementation must use a deterministic path-list (not pattern guesswork) to avoid silent drift.
+2. **TypeScript still runs.** Any PR touching `*.ts` / `*.tsx` / `package.json` / `bun.lock` / `tsconfig*.json` runs the full TypeScript pipeline. The "TypeScript is part of docs" carve-out from Aaron's chat framing is honored.
+3. **`code_quality severity:all` does NOT fail** on LFG/main when the skip fires. Either via:
+   - (a) Conditional skip-vs-run rather than always-run pattern (so the ruleset sees "not applicable" not "failed"), OR
+   - (b) Coordinated ruleset config change (with appropriate sign-off — host mutation per task #343 is an Aaron-decision class, NOT Otto's; Otto identifies the option but doesn't execute it without explicit Aaron sign-off because host-mutation has shown failure modes before per Amara/Aaron 2026-04-29).
+4. **Verification across PR shapes:** docs-only PR, TypeScript-only PR, src-only PR, mixed PR, workflow-only PR — all behave correctly.
+5. **No reduction in security coverage** for actual code surfaces. Skip is for non-code only.
+
+## Out of scope
+
+- **Changing what `code_quality severity:all` requires** beyond the minimum needed to support the path-filter (host-mutation needs Aaron sign-off, not Otto-authority).
+- **Skipping CodeQL on other languages** (only F#/csharp is named in Aaron's chat carve-out).
+- **Skipping TypeScript checks ever** — TypeScript IS docs surface per CURRENT-aaron §30.
+- **Cross-cutting CI overhaul** — narrow scope; broader CI work can be its own row.
+
+## Composes with
+
+- **Task #306** (TaskList): "Cadence-fast revisit — find a way to skip Analyze (csharp) on PR without tripping code_quality severity:all" — this row is the substrate version of that task.
+- **Task #340** (completed): PR #857 codeql per-language source-presence gate (Amara Option B). The path-filter case is downstream of source-presence but not solved by it.
+- **Task #342** (completed): Resolve multi-master CodeQL conflict on #849. Reference for the ruleset-interaction patterns that almost-broke things.
+- **Task #343** (completed): Drift-debt receipt for the 2026-04-29 ruleset mutation. The host-mutation discipline that constrains the (b) path above.
+- **Memory:** `feedback_backlog_prioritization_authority_delegated_to_otto_aaron_2026_05_01.md` — this row is the first substantive use of the delegation, filed under Otto's authority with Aaron's framing as input not directive.
+- **CURRENT-aaron.md §30** — TypeScript-is-factory-tooling rule that defines why TypeScript stays in CI even on "docs" PRs.
+
+## Status
+
+**Filed.** Implementation deferred to a future session-open with rested attention (per the §39 slow-deliberate rule + the receipt-energy hazard discipline — first substantive use of the new authority should not also be the implementation rush). Otto picks the implementation tick.
+
+## Verify-before-deferring note
+
+Aaron's chat said *"that's on backlog"* referring to task #306. Verified: task #306 is in the TaskList but NO B-NNNN substrate row existed until this filing. Substrate-or-it-didn't-happen rule applied: the task lived in ephemeral task-tracker only, not in committed substrate. This row closes that gap.


### PR DESCRIPTION
## Summary

P1 backlog row filed under Otto's new prioritization authority. First substantive use of the delegation Aaron granted 2026-05-01.

Aaron's chat framing: *"speeding up for CI for non code changes? where do you want to priortize that, the typescript is part of the docs but you can skip the f# that's on backlog."*

## Otto's call: P1

Reasoning in detail in the row body. Summary: real recurring throughput cost (~5min × every non-code PR), bounded scope (path-filter + ruleset coordination), NOT P0 because `code_quality severity:all` host-mutation has bitten us before, NOT P2 because cost compounds with the ~550-checkins/week substrate cadence.

## Carve-outs preserved

- **TypeScript** stays in CI everywhere (per CURRENT-aaron §30 — TS is factory-tooling, treat as code).
- **Host mutation** of the `code_quality severity:all` ruleset (if needed) requires explicit Aaron sign-off — that's the WONT-DO-class carve-out from Otto-357 still in force.

## Implementation deferred

Per §39 slow-deliberate + receipt-energy hazard — first substantive use of the new authority should not also be an implementation rush. Otto picks the implementation tick on a future session-open with rested attention.

## Test plan

- [x] B-NNNN row written with full acceptance criteria + composes-with chain
- [x] Carve-outs explicit (TypeScript stays; host-mutation needs Aaron sign-off)
- [x] Verify-before-deferring note (task #306 was TaskList-only, no B-NNNN existed)
- [ ] Auto-merge arm

🤖 Generated with [Claude Code](https://claude.com/claude-code)