### PR TITLE
hygiene(backlog-index): backfill frontmatter on B-0124/B-0125/B-0126 + regenerate aggregate

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -31,6 +31,8 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0083](backlog/P1/B-0083-atari-2600-rom-canonical-naming-tosec-goodtools-tooling-aaron-2026-04-28.md)** Atari 2600 ROM canonical-naming + safe-vs-unsafe folder split + TOSEC/Good-Tools-style hash-lookup tooling
 - [ ] **[B-0087](backlog/P1/B-0087-github-settings-drift-workflow-broken-invalid-permission-administration-otto-2026-04-28.md)** github-settings-drift.yml has been broken since PR #45 — declares invalid GHA permission `administration: read`
 - [ ] **[B-0110](backlog/P1/B-0110-acehack-mirror-protocol-drift-2026-04-30.md)** AceHack mirror-refresh protocol drift — Path 2 chosen, doctrine update landing in same PR (2026-04-30)
+- [ ] **[B-0125](backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md)** Skip Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
+- [ ] **[B-0126](backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md)** Port the 4-layer meta-learning pattern from a sibling repo to Zeta
 
 ## P2 — research-grade
 
@@ -92,6 +94,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0118](backlog/P2/B-0118-amara-peer-call-headless-cli-bootstrap-end-courier-debt-2026-04-30.md)** tools/peer-call/amara.sh — autonomous bootstrap + communication for Amara (ChatGPT) to end Aaron-courier silent debt (Aaron 2026-04-30)
 - [ ] **[B-0120](backlog/P2/B-0120-peer-call-architecture-refactor-script-per-cli-persona-flag-2026-04-30.md)** Peer-call architecture refactor — script-per-CLI with persona-flag instead of script-per-named-agent (Aaron 2026-04-30)
 - [ ] **[B-0121](backlog/P2/B-0121-otto-kenji-peer-call-cross-harness-claude-cli-aaron-2026-04-30.md)** Otto + Kenji as externally-callable peers via claude-cli — cross-harness symmetry (Aaron 2026-04-30)
+- [ ] **[B-0124](backlog/P2/B-0124-claudeai-csap-conversation-distill-uber-arch-2026-05-01.md)** Distill the Claude.ai CSAP-pushback conversation into uber-architecture (deferred multi-week)
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md
+++ b/docs/backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md
@@ -3,6 +3,8 @@ id: B-0125
 priority: P1
 status: open
 title: Skip Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
+created: 2026-05-01
+last_updated: 2026-05-01
 ---
 
 # B-0125 — Skip Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`

--- a/docs/backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md
+++ b/docs/backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md
@@ -1,3 +1,10 @@
+---
+id: B-0125
+priority: P1
+status: open
+title: Skip Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
+---
+
 # B-0125 — Skip Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
 
 **Priority:** P1 (high value, soon)

--- a/docs/backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md
+++ b/docs/backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md
@@ -1,3 +1,10 @@
+---
+id: B-0126
+priority: P1
+status: open
+title: Port the 4-layer meta-learning pattern from a sibling repo to Zeta
+---
+
 # B-0126 — Port the 4-layer meta-learning pattern from STCRM to Zeta
 
 **Priority:** P1 (high leverage; PR-review pain is recurring; pattern already proven in ServiceTitan exploit context)

--- a/docs/backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md
+++ b/docs/backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md
@@ -3,6 +3,8 @@ id: B-0126
 priority: P1
 status: open
 title: Port the 4-layer meta-learning pattern from a sibling repo to Zeta
+created: 2026-05-01
+last_updated: 2026-05-01
 ---
 
 # B-0126 — Port the 4-layer meta-learning pattern from STCRM to Zeta

--- a/docs/backlog/P2/B-0124-claudeai-csap-conversation-distill-uber-arch-2026-05-01.md
+++ b/docs/backlog/P2/B-0124-claudeai-csap-conversation-distill-uber-arch-2026-05-01.md
@@ -1,3 +1,10 @@
+---
+id: B-0124
+priority: P2
+status: open
+title: Distill the Claude.ai CSAP-pushback conversation into uber-architecture (deferred multi-week)
+---
+
 # B-0124 — Distill the Claude.ai CSAP-pushback conversation into uber-architecture (across 4 projects, eventually)
 
 **Priority:** P2 (deferred, multi-week)

--- a/docs/backlog/P2/B-0124-claudeai-csap-conversation-distill-uber-arch-2026-05-01.md
+++ b/docs/backlog/P2/B-0124-claudeai-csap-conversation-distill-uber-arch-2026-05-01.md
@@ -3,6 +3,8 @@ id: B-0124
 priority: P2
 status: open
 title: Distill the Claude.ai CSAP-pushback conversation into uber-architecture (deferred multi-week)
+created: 2026-05-01
+last_updated: 2026-05-01
 ---
 
 # B-0124 — Distill the Claude.ai CSAP-pushback conversation into uber-architecture (across 4 projects, eventually)


### PR DESCRIPTION
## Summary

Pre-existing BACKLOG.md drift on main: B-0124 (#1000), B-0125 (#1004/#1005), B-0126 (#1011) all merged with markdown `# Heading` format but without the YAML frontmatter that `tools/backlog/generate-index.sh` reads. The generator's check fails on every new backlog PR.

This PR adds the missing frontmatter (additive, body unchanged) and regenerates `docs/BACKLOG.md` to match the canonical output. Unblocks #1012 (B-0127) and #1015 (B-0128) — they'll need their own frontmatter additions on top.

For B-0126: the `title:` field uses generic phrasing (*"a sibling repo"* — not the original leaky internal name) per `memory/feedback_no_copy_only_learning_from_sibling_repos_aaron_2026_04_30.md`. The file *body* keeps its un-scrubbed exemplar status per Aaron 2026-05-01 *"you can leave your mistake"* + *"we should leave this one even then"*. Filename also unchanged — path-leak stays as evidence.

## Files changed

- `docs/backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md` — +7 lines (frontmatter)
- `docs/backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md` — +7 lines (frontmatter, generic title)
- `docs/backlog/P2/B-0124-claudeai-csap-conversation-distill-uber-arch-2026-05-01.md` — +7 lines (frontmatter)
- `docs/BACKLOG.md` — +3 lines (regenerated rows for B-0124/0125/0126)

## Composes with

- `.github/workflows/backlog-index-integrity.yml` — the CI check this unblocks.
- `tools/backlog/generate-index.sh` — the generator this satisfies.
- `docs/research/backlog-split-design-otto-181.md` — the per-row schema retroactively applied.

## Test plan

- [ ] CI `check docs/BACKLOG.md generated-index drift` passes.
- [ ] No new content leaks introduced (verified: aggregate `title:` fields generic for the sibling-repo-class row).
- [ ] Standard markdown lint.

🤖 Posted by Claude Code on Aaron's behalf