### PR TITLE
hygiene(backlog-generator): warn on row files missing YAML frontmatter

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -31,7 +31,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0083](backlog/P1/B-0083-atari-2600-rom-canonical-naming-tosec-goodtools-tooling-aaron-2026-04-28.md)** Atari 2600 ROM canonical-naming + safe-vs-unsafe folder split + TOSEC/Good-Tools-style hash-lookup tooling
 - [ ] **[B-0087](backlog/P1/B-0087-github-settings-drift-workflow-broken-invalid-permission-administration-otto-2026-04-28.md)** github-settings-drift.yml has been broken since PR #45 — declares invalid GHA permission `administration: read`
 - [ ] **[B-0110](backlog/P1/B-0110-acehack-mirror-protocol-drift-2026-04-30.md)** AceHack mirror-refresh protocol drift — Path 2 chosen, doctrine update landing in same PR (2026-04-30)
-- [ ] **[B-0125](backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md)** Skip Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
+- [ ] **[B-0125](backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md)** Skip F#/Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
 - [ ] **[B-0126](backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md)** Port the 4-layer meta-learning pattern from a sibling repo to Zeta
 - [ ] **[B-0140](backlog/P1/B-0140-bash-to-ts-migration-completion-debt-prevention-aaron-2026-05-01.md)** Bash → TS migration completion — debt-prevention prerequisite to B-0132 (CRDT-composition)
 

--- a/docs/backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md
+++ b/docs/backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md
@@ -2,7 +2,7 @@
 id: B-0125
 priority: P1
 status: open
-title: Skip Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
+title: Skip F#/Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
 created: 2026-05-01
 last_updated: 2026-05-01
 ---

--- a/docs/backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md
+++ b/docs/backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md
@@ -7,7 +7,7 @@ created: 2026-05-01
 last_updated: 2026-05-01
 ---
 
-# B-0125 — Skip Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
+# B-0125 — Skip F#/Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
 
 **Priority:** P1 (high value, soon)
 

--- a/tools/backlog/generate-index.sh
+++ b/tools/backlog/generate-index.sh
@@ -139,7 +139,7 @@ HEADER
         # Print path relative to REPO_ROOT so CI logs aren't
         # cluttered with runner-specific absolute paths
         # (Codex P2 finding: keep warnings portable).
-        echo "WARN: ${file#"${REPO_ROOT}"/} — missing YAML frontmatter (need id + title)" >&2
+        echo "WARN: ${file#"${REPO_ROOT}"/} — missing required frontmatter field (need both id and title)" >&2
       fi
 
       case "$status" in

--- a/tools/backlog/generate-index.sh
+++ b/tools/backlog/generate-index.sh
@@ -139,7 +139,7 @@ HEADER
         # Print path relative to REPO_ROOT so CI logs aren't
         # cluttered with runner-specific absolute paths
         # (Codex P2 finding: keep warnings portable).
-        echo "WARN: ${file#${REPO_ROOT}/} — missing YAML frontmatter (need id + title)" >&2
+        echo "WARN: ${file#"${REPO_ROOT}"/} — missing YAML frontmatter (need id + title)" >&2
       fi
 
       case "$status" in

--- a/tools/backlog/generate-index.sh
+++ b/tools/backlog/generate-index.sh
@@ -21,7 +21,7 @@
 #   2  drift detected (--check mode only)
 #
 # Stderr warnings (non-fatal):
-#   `WARN: <file> — missing YAML frontmatter (need id + title)`
+#   `WARN: <file> — missing required frontmatter field (need both id and title)`
 #     surfaces row files that are silently rendering as empty
 #     `**[](path)** ` entries because the heading-only format
 #     was used without the YAML frontmatter the generator reads.

--- a/tools/backlog/generate-index.sh
+++ b/tools/backlog/generate-index.sh
@@ -20,6 +20,14 @@
 #   1  environment / dependency error
 #   2  drift detected (--check mode only)
 #
+# Stderr warnings (non-fatal):
+#   `WARN: <file> — missing YAML frontmatter (need id + title)`
+#     surfaces row files that are silently rendering as empty
+#     `**[](path)** ` entries because the heading-only format
+#     was used without the YAML frontmatter the generator reads.
+#     Doesn't change exit code; operators / CI can grep stderr
+#     to surface the cause when --check fails downstream.
+#
 # Dependencies: bash 4+, POSIX awk, sort, diff, find, mktemp.
 # No external `yq` required; inline awk parser handles the
 # flat frontmatter schema. `yq` integration is a Phase 1b
@@ -119,6 +127,17 @@ HEADER
       id=$(extract_field "$file" "id")
       status=$(extract_field "$file" "status")
       title=$(extract_field "$file" "title")
+
+      # Surface missing frontmatter to stderr — the file is
+      # otherwise silently rendered as `**[](path)** ` (empty
+      # link text + empty title) and the integrity check fails
+      # later with no hint at the cause. Warning only — does not
+      # change generator output, so does not regress existing CI
+      # behaviour. Operators / CI can grep stderr for "WARN:" to
+      # surface the cause early.
+      if [ -z "$id" ] || [ -z "$title" ]; then
+        echo "WARN: $file — missing YAML frontmatter (need id + title)" >&2
+      fi
 
       case "$status" in
         closed)                     checkbox="[x]" ;;

--- a/tools/backlog/generate-index.sh
+++ b/tools/backlog/generate-index.sh
@@ -136,7 +136,10 @@ HEADER
       # behaviour. Operators / CI can grep stderr for "WARN:" to
       # surface the cause early.
       if [ -z "$id" ] || [ -z "$title" ]; then
-        echo "WARN: $file — missing YAML frontmatter (need id + title)" >&2
+        # Print path relative to REPO_ROOT so CI logs aren't
+        # cluttered with runner-specific absolute paths
+        # (Codex P2 finding: keep warnings portable).
+        echo "WARN: ${file#${REPO_ROOT}/} — missing YAML frontmatter (need id + title)" >&2
       fi
 
       case "$status" in


### PR DESCRIPTION
Class-level prevention for the bug surfaced by this session's BACKLOG.md drift. Adds a stderr WARN line per row file without id/title frontmatter; output unchanged so CI behaviour unchanged.

Composes with #1016 (the frontmatter backfill).

🤖 Posted by Claude Code on Aaron's behalf