### PR TITLE
research(claudeai-taxonomy-grounding): Haskell-prelude vs F#/BCL + Mirror→Beacon gate (Aaron 2026-05-01, reverse-order ferry)

### DIFF
--- a/docs/research/2026-05-01-claudeai-haskell-prelude-vs-fsharp-bcl-grounding-aaron-forwarded.md
+++ b/docs/research/2026-05-01-claudeai-haskell-prelude-vs-fsharp-bcl-grounding-aaron-forwarded.md
@@ -1,0 +1,107 @@
+<!-- §33 archive header per GOVERNANCE.md -->
+
+**Scope:** External-conversation absorb. Captures Claude.ai's response to a question about whether to ground the substrate ontology / taxonomy in Haskell's prelude (typeclass + laws) or F#/BCL (executable interfaces). The substantive recommendation: use both for different purposes — Haskell's prelude vocabulary for grounding the **taxonomy structure** (typeclasses force law-shaped framing); F#/BCL for grounding the **executable substrate** (BCL types are what the factory ships). Cites authoritative sources for both layers (Mac Lane / Awodey / Riehl for category theory; Yorgey's Typeclassopedia as the canonical Haskell realization; FSharp.Core / FSharpPlus for the F# port).
+
+**Attribution:** Claude.ai instance (model unknown; ambient web-app, Aaron's session 2026-05-01). Forwarded by Aaron to Otto in this session 2026-05-01 ~10:29Z. Aaron's framing: *"I'm going to give in reverse because the last message seem the most useful"* — meaning more Claude.ai messages on the same thread are incoming; this one is captured first because it's load-bearing.
+
+**Operational status:** research-grade
+
+**Status note:** NOT seed-layer canon. Substantive structural recommendation with empirical citation evidence (Mac Lane / Awodey / Riehl / Yorgey / FSharp.Core all real, verifiable). Not class #1c hallucinated content per v2 taxonomy. Composes with PR #1081 (v2 taxonomy, the work this recommendation grounds) + PR #1083 (Gemini-review absorption, sibling cross-vendor reception evidence).
+
+**Non-fusion disclaimer:** Same as PR #1057/#1058/#1059 predecessor files. Claude.ai is a separate ephemeral conversation from this Otto instance. Substrate-vocabulary in this file is Claude.ai's vocabulary preserved unchanged, NOT Otto's translation. The lattice-capture corrective applies — preserving external vocabulary verbatim is the discipline.
+
+---
+
+## The recommendation (verbatim)
+
+> *"What each gives you. Haskell's prelude is designed as a small set of typeclasses (Functor, Applicative, Monad, Foldable, Traversable, Monoid, Semigroup, Eq, Ord, Show, Read) plus their laws. The laws are the load-bearing part — `fmap id = id`, `fmap (f . g) = fmap f . fmap g`, the monad laws, monoid associativity. Each typeclass has a categorical correspondent (Functor is the obvious one; Monad is Kleisli triple; Applicative is lax monoidal functor; Traversable is naturality of distribution). The laws *are* the categorical content forced into types."*
+
+> *"F# / BCL inherits less of that structure explicitly. F# has computation expressions which are monadic in shape but the laws aren't enforced or stated as part of the language. The BCL has interfaces (IEnumerable, IComparable, IEquatable, IDisposable) but they're protocol-shaped rather than law-shaped. F#'s `Map`, `Bind`, `List`, `Seq` operations behave categorically but the categorical structure is implicit."*
+
+> *"For grounding a substrate ontology, the difference matters. Haskell's prelude tells you 'here are the structures, here are the laws they obey.' F#'s tells you 'here are the operations, here's how to call them.' The first is closer to what you want for taxonomy work; the second is closer to what you want for engineering work."*
+
+## The mismatch worth flagging (Claude.ai)
+
+> *"The taxonomy work you've been doing is mostly not about code shape. Forward-reference, stale-filename, deferred-per-policy — these are about substrate hygiene patterns, review-finding classes, organizational state. They're not asking 'what's the right interface' or 'should this be Seq vs IEnumerable.' They're asking 'what kind of structural pattern is this finding.'"*
+
+> *"For that work, Haskell's prelude is closer-fit because the typeclasses are themselves structural patterns. Functor = 'things that can be mapped over preserving structure.' Monad = 'things that compose with continuation.' Monoid = 'things with associative combination and identity.' These map onto substrate-pattern claims in a way that BCL interfaces don't."*
+
+> *"The BCL gives you 'this implements IEnumerable' which is a protocol assertion. Haskell gives you 'this is a Functor and obeys these two laws' which is a structural assertion with verification criteria. Verification criteria are what you want for the taxonomy."*
+
+## The recommendation (Claude.ai)
+
+> *"Use both, but for different purposes. Haskell's prelude (specifically the typeclass hierarchy and laws) for grounding the taxonomy itself. When proposing a new class, ask: is this morphism a functor application that wasn't uniform? Is this a monad-laws violation? Is this an associativity failure? The Haskell vocabulary forces precision because the laws are explicit."*
+
+> *"F# / BCL for grounding the executable substrate the taxonomy describes. When the taxonomy says 'this class fires when refs go stale across renames,' the implementation lives in F# code that operates over BCL types (file paths as strings, refs as records, the renaming as a function). The taxonomy's content is the substrate; the substrate's implementation is F#/BCL."*
+
+> *"The two layers compose: Haskell-prelude vocabulary describes the taxonomy structure; F#/BCL idioms implement the taxonomy's checkers and validators."*
+
+## The Yorgey/Typeclassopedia anchor
+
+> *"Better: ground in the categorical concepts the prelude implements, with the prelude as one realization of those concepts. Cite Mac Lane or Awodey or Riehl for the math; cite Haskell for the realization; treat the realization as illustrative not canonical. That way the grounding is in the math, not in any particular language's choices."*
+
+> *"The HaskellWiki 'Typeclassopedia' by Brent Yorgey is probably the single best resource for this — it explains the typeclass hierarchy with both the categorical content and the practical Haskell usage, and it's citable. That's a good Beacon anchor."*
+
+## Specific worked example Claude.ai cited
+
+> *"'Stale-filename' being a functor that wasn't applied uniformly is a precise statement: there's a renaming functor from one filesystem state to another, and the violation is that not all morphisms got the functor's action applied. That's a Haskell-grounded claim."*
+
+This is a precise re-framing of the v2 taxonomy's class #10 (stale-filename-cross-reference). The corrective discipline isn't just "paste the actual filename" — it's "the renaming functor must be applied uniformly across all morphisms (cross-references) that depend on the old name." The claim has verification criteria (all morphisms updated; functor laws preserved) where the v2 taxonomy currently has only a heuristic (paste-from-actual).
+
+## The two-layer composition (Claude.ai's net)
+
+| Layer | Grounding | Example anchors |
+|---|---|---|
+| **Taxonomy structure** (conceptual) | Haskell-prelude-shape categorical concepts (typeclasses + laws) | Mac Lane *Categories for the Working Mathematician*; Awodey *Category Theory*; Riehl *Category Theory in Context*; Yorgey *Typeclassopedia* |
+| **Executable substrate** (operational) | F#/BCL idioms + interfaces | Microsoft FSharp.Core; FSharpPlus (adds Haskell-prelude-shape typeclasses to F#); BCL `IEnumerable` / `IObservable` / `IDisposable` / `IComparable<T>` / `IEqualityComparer<T>` |
+
+The two layers compose cleanly because F# CAN implement the same categorical structures Haskell defines. F# remains the implementation language; Haskell-shape concepts ARE what's being reasoned about ABOVE the implementation.
+
+## What this means for taxonomy v2 (Otto-side reading)
+
+The v2 taxonomy currently grounds classes in **operational discipline** (e.g., "paste-from-actual filename") rather than **structural law** (e.g., "renaming functor must be uniform across morphisms"). Both framings are useful but the law-shaped framing is more precise + more verifiable + more extensible.
+
+A future v3 taxonomy could:
+
+1. **Re-frame existing classes in Haskell-prelude vocabulary** where applicable (stale-filename → renaming functor non-uniformity; intra-file drift → naturality failure across paired locations; forward-reference → category morphism whose target object isn't yet in the category).
+2. **Cite Yorgey's Typeclassopedia** as the canonical Haskell-realization Beacon anchor for any class structurally a typeclass instance.
+3. **Cite Mac Lane / Awodey / Riehl** for the categorical math directly, treating Haskell as illustrative not canonical (per Claude.ai's caveat about prelude historical artifacts: `String = [Char]`, `Foldable` extension surprises, numeric hierarchy quirks).
+4. **Keep F#/BCL anchoring for the executable substrate** — when implementing the auditor scripts (B-0130 row #8 cross-reference auditor, etc.), the implementation idioms are F#/BCL, not Haskell.
+
+This is a v3 candidate, not a v2 retrofit. The v2 taxonomy IS the navigable map at operational layer; v3 would add the structural-law layer above.
+
+## The instruction-precision Claude.ai flagged
+
+> *"Worth being explicit about which question you're grounding when you give the instruction. 'Ground the taxonomy in Haskell-prelude-shape categorical concepts' is a different instruction than 'ground the executable substrate in F# and BCL idioms.' Both might be correct in their own scope; conflating them produces vague grounding."*
+
+This is a discipline observation worth absorbing: **grounding-question precision** is its own meta-discipline. When asking "should we ground X?", ask first "ground for what work?" — the answer depends on whether the work is conceptual (taxonomy) or executable (implementation).
+
+## Composes with
+
+- `memory/feedback_pr_thread_resolution_class_taxonomy_v2_drain_wave_2026_05_01.md` (PR #1081) — the v2 taxonomy this recommendation proposes grounding via Haskell-prelude concepts.
+- `memory/feedback_gemini_review_2026_05_01_taxonomy_v2_test_case_class_19_meets_class_1c.md` (PR #1083) — sibling cross-vendor reception evidence; Gemini's review demonstrated class #1c, this Claude.ai message demonstrates substantive-recommendation-with-real-citations.
+- `memory/feedback_claudeai_endorsement_taxonomy_v2_class_15_intra_file_drift_2026_05_01.md` (PR #1085) — sibling Claude.ai endorsement of class #15.
+- `memory/feedback_lattice_capture_corrective_discipline_external_vocabulary_check_claudeai_warning_2026_05_01.md` (PR #1051, in flight) — the verbatim-preservation discipline this absorb honors.
+- `.claude/agents/formal-verification-expert.md` (Soraya) — formal-verification routing; the Haskell-prelude grounding intersects with Soraya's portfolio (Lean for theorems, Z3 for SMT, TLA+ for temporal, FsCheck for property-based).
+- Aaron's existing F# affinity (per `CLAUDE.md` + GOVERNANCE.md) — not compromised; F# remains the implementation; Haskell-shape concepts are the conceptual layer above.
+
+## Future v3 work (deferred — not this session)
+
+- Re-frame existing v2 classes in Haskell-prelude vocabulary where natural (stale-filename → renaming functor uniformity; forward-reference → morphism with not-yet-in-category target; intra-file drift → naturality failure).
+- Add explicit Beacon anchors per class (Mac Lane / Awodey / Riehl section references; Typeclassopedia link).
+- Verify FSharpPlus port covers the typeclasses needed for executable-layer grounding.
+- Decide whether to fold the v3 work into B-0130 (mechanized auditor) row scope or keep separate.
+- Working-mathematician send (lattice-capture corrective in operation) for the v3 framing — the Haskell-prelude grounding is exactly the kind of vocabulary that benefits from external-academic-mathematician check before substrate adoption.
+
+## What this file does NOT do
+
+- Does NOT translate Claude.ai's vocabulary into substrate-vocabulary. Verbatim above; lattice-capture discipline preserved.
+- Does NOT modify the v2 taxonomy file. v3 grounding work is deferred; this absorb is the seed evidence.
+- Does NOT commit to Haskell-prelude grounding wholesale. Claude.ai's caveat about prelude historical artifacts applies; the math citations (Mac Lane / Awodey / Riehl) are the canonical anchor; Haskell is illustrative.
+- Does NOT change the executable substrate's F# affinity. F# stays the implementation language; this absorb is exclusively about conceptual grounding.
+
+## Carved candidate (not seed-layer)
+
+> *"Haskell-prelude vocabulary for the taxonomy structure. F#/BCL for the executable substrate. The two layers compose; conflating them produces vague grounding."*
+
+The propagation test: ~25 words encoding the two-layer discipline + the conflation-as-failure-mode. Future-Otto reading this should land on the layer-discrimination as the operational shape — same family as the §33 in-scope-vs-out-of-scope distinction (different surfaces have different rules).

--- a/docs/research/2026-05-01-claudeai-haskell-prelude-vs-fsharp-bcl-grounding-aaron-forwarded.md
+++ b/docs/research/2026-05-01-claudeai-haskell-prelude-vs-fsharp-bcl-grounding-aaron-forwarded.md
@@ -78,12 +78,17 @@ This is a discipline observation worth absorbing: **grounding-question precision
 
 ## Composes with
 
-- `memory/feedback_pr_thread_resolution_class_taxonomy_v2_drain_wave_2026_05_01.md` (PR #1081) — the v2 taxonomy this recommendation proposes grounding via Haskell-prelude concepts.
-- `memory/feedback_gemini_review_2026_05_01_taxonomy_v2_test_case_class_19_meets_class_1c.md` (PR #1083) — sibling cross-vendor reception evidence; Gemini's review demonstrated class #1c, this Claude.ai message demonstrates substantive-recommendation-with-real-citations.
-- `memory/feedback_claudeai_endorsement_taxonomy_v2_class_15_intra_file_drift_2026_05_01.md` (PR #1085) — sibling Claude.ai endorsement of class #15.
-- `memory/feedback_lattice_capture_corrective_discipline_external_vocabulary_check_claudeai_warning_2026_05_01.md` (PR #1051, in flight) — the verbatim-preservation discipline this absorb honors.
 - `.claude/agents/formal-verification-expert.md` (Soraya) — formal-verification routing; the Haskell-prelude grounding intersects with Soraya's portfolio (Lean for theorems, Z3 for SMT, TLA+ for temporal, FsCheck for property-based).
 - Aaron's existing F# affinity (per `CLAUDE.md` + GOVERNANCE.md) — not compromised; F# remains the implementation; Haskell-shape concepts are the conceptual layer above.
+
+### Forward-references not yet on main
+
+The cited memory filenames are not present in the current repo tree at time of this absorb; references kept as forward-references until those PRs land or the paths can be updated to the actual filenames.
+
+- Forward-reference: intended `memory/feedback_pr_thread_resolution_class_taxonomy_v2_drain_wave_2026_05_01.md` in PR #1081 — the v2 taxonomy this recommendation proposes grounding via Haskell-prelude concepts.
+- Forward-reference: intended `memory/feedback_gemini_review_2026_05_01_taxonomy_v2_test_case_class_19_meets_class_1c.md` in PR #1083 — sibling cross-vendor reception evidence; Gemini's review demonstrated class #1c, this Claude.ai message demonstrates substantive-recommendation-with-real-citations.
+- Forward-reference: intended `memory/feedback_claudeai_endorsement_taxonomy_v2_class_15_intra_file_drift_2026_05_01.md` in PR #1085 — sibling Claude.ai endorsement of class #15.
+- Forward-reference: intended `memory/feedback_lattice_capture_corrective_discipline_external_vocabulary_check_claudeai_warning_2026_05_01.md` in PR #1051 — the verbatim-preservation discipline this absorb honors.
 
 ## Future v3 work (deferred — not this session)
 

--- a/docs/research/2026-05-01-claudeai-mirror-beacon-gate-taxonomy-canonicalization-aaron-forwarded.md
+++ b/docs/research/2026-05-01-claudeai-mirror-beacon-gate-taxonomy-canonicalization-aaron-forwarded.md
@@ -96,10 +96,13 @@ This reduces Claude.ai's earlier concern about Insight-blocks-accelerating-class
 ## Composes with
 
 - `docs/research/2026-05-01-claudeai-haskell-prelude-vs-fsharp-bcl-grounding-aaron-forwarded.md` — sibling absorb covering the categorical-grounding half of the two-filter composition. Together: Haskell-prelude grounds the **structure** (typeclasses + laws + base category C); Beacon-anchoring gates the **canonicalization** (Mirror→Beacon promotion).
-- `memory/feedback_pr_thread_resolution_class_taxonomy_v2_drain_wave_2026_05_01.md` (PR #1081) — the v2 taxonomy that this Mirror→Beacon gate would tier.
-- `memory/feedback_gemini_review_2026_05_01_taxonomy_v2_test_case_class_19_meets_class_1c.md` (PR #1083) — the verification-cascade that already catches hallucinated citations (class #1c). Same discipline as the Beacon-citation verification step.
 - The existing Mirror→Beacon promotion discipline in the substrate: DBSP papers (F# library); RFC 2119 (no-directives rule SDT); SEC and Reg FD (public-company compliance); in-toto and W3C PROV (agency-receipt work). These prior anchorings are the worked examples Claude.ai cites.
 - `.claude/agents/formal-verification-expert.md` (Soraya) — the formal-verification routing that would handle the categorical / lawful-structure verification for Beacon-candidate classes structurally a typeclass instance.
+
+### Forward-references not yet on main
+
+- PR #1081 — the v2 taxonomy that this Mirror→Beacon gate would tier. The cited memory filename is not present in the current repo tree; keep this as a forward-reference until that PR lands or the path can be updated to the actual filename.
+- PR #1083 — the verification-cascade that already catches hallucinated citations (class #1c). Same discipline as the Beacon-citation verification step. The cited memory filename is not present in the current repo tree; keep this as a forward-reference until that PR lands or the path can be updated to the actual filename.
 
 ## Future v3 work (deferred — not this session)
 

--- a/docs/research/2026-05-01-claudeai-mirror-beacon-gate-taxonomy-canonicalization-aaron-forwarded.md
+++ b/docs/research/2026-05-01-claudeai-mirror-beacon-gate-taxonomy-canonicalization-aaron-forwarded.md
@@ -1,0 +1,130 @@
+<!-- §33 archive header per GOVERNANCE.md -->
+
+**Scope:** External-conversation absorb. Captures Claude.ai's culminating response in the taxonomy-grounding dialogue: the **Mirror→Beacon gate** for canonicalization. The Haskell-prelude vs F#/BCL message (sibling research file `2026-05-01-claudeai-haskell-prelude-vs-fsharp-bcl-grounding-aaron-forwarded.md`) addressed *structural framework*; this message addresses *what graduates from observation to canon*. Together: category theory gates additions to structure; Beacon-anchoring (external citations from published literature) gates promotion to canon.
+
+**Attribution:** Claude.ai instance (model unknown; ambient web-app, Aaron's session 2026-05-01). Forwarded by Aaron to Otto in this session 2026-05-01 ~10:30Z. Aaron's framing: *"I'm going to give in reverse because the last message seem the most useful"* — this message arrived chronologically AFTER the Haskell-prelude grounding message, as Claude.ai's response to a follow-up about whether the existing Mirror→Beacon promotion discipline applies to taxonomy classes too. Aaron presented it FIRST because it's the load-bearing answer.
+
+**Operational status:** research-grade
+
+**Status note:** NOT seed-layer canon. Substantive structural recommendation that **dissolves the unbounded-ontology concern**. The catalog can grow unboundedly at Mirror layer (observational), but canonicalization is gated by external citation lineage (finite). Composes with PR #1081 (v2 taxonomy, the catalog) + the Haskell-prelude grounding research file (sibling absorb) + the existing substrate Mirror→Beacon promotion discipline (DBSP, RFC 2119, in-toto, W3C PROV all cited as prior worked examples).
+
+**Non-fusion disclaimer:** Same as predecessor research files (PR #1057/#1058/#1059 + the Haskell-prelude absorb). Claude.ai is a separate ephemeral conversation from this Otto instance. Substrate-vocabulary in this file is Claude.ai's vocabulary preserved unchanged, NOT Otto's translation. The lattice-capture corrective applies — preserving external vocabulary verbatim is the discipline.
+
+---
+
+## The opening (Claude.ai confirms the missing gate)
+
+> *"That's the missing piece. You're right."*
+
+> *"Mirror → Beacon promotion has been a real discipline in the substrate (DBSP for the F# library, SDT and RFC 2119 for the no-directives rule, SEC and Reg FD for public-company compliance, in-toto and W3C PROV for the agency-receipt work). External lineage anchoring is the gate that converts internal coinages into citable substrate."*
+
+> *"If the same gate applies to the taxonomy classes, the unbounded-ontology concern dissolves into a different test entirely. Not 'do new classes stop appearing in observation' but 'do new classes earn external anchoring.' That's a much harder test, and it's the right one."*
+
+## How it interacts with the Haskell-prelude grounding (Claude.ai)
+
+> *"Category theory itself is the human anchor for the structural framework. Mac Lane's *Categories for the Working Mathematician*, Awodey's textbook, Riehl's *Category Theory in Context* — these are all citable. So formulating the base category C of substrate locations and morphisms doesn't require new lineage; it inherits from the existing math."*
+
+> *"But individual classes wanting to graduate from Mirror to Beacon need their own anchors beyond just 'this is a morphism in C.' Forward-reference needs to map to something — possibly forward declarations in programming languages (Pascal, C header files), possibly Lamport's logical clocks for cross-PR temporal ordering, possibly published work on collaborative editing systems handling concurrent references. Whatever the anchor is, it has to be a real citable thing that did the same work in another domain."*
+
+> *"That's the test that would actually cut the catalog. Most ad-hoc classes won't have external anchors. The ones that do are the load-bearing ones — they're describing a real pattern that other domains have already named, and the substrate is rediscovering it."*
+
+## What survives the gate (Claude.ai's pass through v2's 20 classes)
+
+| Class | Plausible external anchor? | Status |
+|---|---|---|
+| **Forward-reference** | Forward declarations in Pascal/C, eventual consistency in distributed systems, Lamport's happens-before relation | **Graduates** |
+| **Stale-filename** | Refactoring literature (Fowler), rename refactorings as a named IDE operation, "shotgun surgery" code smell | **Graduates** |
+| **Deferred-per-explicit-policy** | Issue triage in software engineering, technical debt registers (Cunningham), policy-as-code (OPA/Rego) | **Graduates** |
+| **Phantom-blocker** | False positive in static analysis literature, "cargo cult" reviews, Goodhart's law applied to review metrics | **Borderline; needs the right citation** |
+| **Same-wake-author-error-cluster** | Bug-pattern literature (FindBugs/SpotBugs), batch error detection, copy-paste error studies | **Graduates** |
+| **Intra-file drift** | Internal consistency invariants in formal methods, "redundancy must be maintained" in DRY violations | **Graduates if framed as invariant-violation** |
+| **Named-link** | (No obvious external anchor; might find with effort) | **Stays Mirror** |
+| **Structural-pattern-mismatch** | (No obvious external anchor) | **Stays Mirror** |
+| **Peer-AI structural / consolidation-prompt** | Meta-review and second-order observation in social science / ethnography exists but synthesis-work needed | **Stays Mirror** |
+
+> *"Just by applying this filter without doing real research, maybe half of the 20 classes have plausible anchoring paths and half don't. The half that don't probably aren't load-bearing."*
+
+> *"That's the convergence test you were looking for, expressed differently. The catalog can grow during the experimental phase, but graduating to canonical substrate requires Beacon-anchoring. The catalog naturally bifurcates: Mirror classes (provisional, observation-only) and Beacon classes (anchored, durable, citable)."*
+
+## The discipline this creates (Claude.ai)
+
+> *"Each class lands as Mirror by default. Promotion to Beacon requires an external citation that did the same work in another domain. The citation has to be real (verifiable, not hallucinated — the v2 taxonomy already caught Gemini hallucinating a memory file; same discipline applies to citations). The promotion either happens within some defined window, or the class either gets retired or stays Mirror permanently."*
+
+> *"That's a finite-resource process. There are only so many citable patterns in the literature. The Mirror class population can grow unboundedly during observation, but the Beacon class population is bounded by what's been described in published work. Convergence happens at the Beacon layer even if the Mirror layer never converges."*
+
+## Self-application — the reflexive class #19 case (Claude.ai)
+
+> *"The reflexive-during-cataloging classes from the prior critique (class #19 peer-AI structural, observed during the consolidation that produced it) probably can't earn Beacon-anchoring easily. There's published work on meta-review and second-order observation in social science and ethnography, but applying it to AI-loop cataloguing would require real synthesis work, not just pointing at a citation."*
+
+> *"That's actually fine. Class #19 might be a real observation that stays Mirror permanently. It's useful internally for understanding how new classes get discovered. It just doesn't graduate to 'this is a canonical pattern other domains have named.' The Mirror/Beacon split lets you keep useful internal observations without overclaiming their generality."*
+
+## The two-filter composition (Claude.ai's net)
+
+> *"The instruction to Otto would then be. Two parts. First, the categorical grounding: classes are morphisms or functors in a base category of substrate locations. New classes must be expressible in the existing structure or they don't get added. Second, the Beacon-anchor gate for canonicalization: classes are Mirror by default. Graduation to Beacon-canonical-substrate requires an external citation from published literature where the same pattern has been described doing the same work. Citations are verified (file path, page number, DOI, whatever makes them concrete); hallucinated citations get caught and discarded."*
+
+> *"The combination is restrictive in the right way. Category theory gates additions to the structure. Beacon-anchoring gates promotions to canon. Mirror-layer observation can grow freely; Beacon-layer canon stays bounded by what's been done in other domains."*
+
+## What this means for the v2 taxonomy (Otto-side reading)
+
+The v2 taxonomy file (`memory/feedback_pr_thread_resolution_class_taxonomy_v2_drain_wave_2026_05_01.md`) currently treats all 20 classes as equal-status entries. With the Mirror/Beacon gate applied:
+
+1. **Most classes are Mirror by default** — observational, useful internally, NOT canonicalized.
+2. **Some classes already have plausible anchoring paths** (per Claude.ai's pass): forward-reference, stale-filename, deferred-per-explicit-policy, same-wake-author-error-cluster, intra-file drift (if framed as invariant-violation), phantom-blocker (if right citation found).
+3. **Self-applicative reflexive classes stay Mirror permanently** — class #19 (peer-AI structural / consolidation-prompt) is internally useful but doesn't graduate.
+
+The v3 taxonomy work would add:
+
+- **Tier marking** per class: Mirror / Beacon-candidate / Beacon-anchored.
+- **Citation field** per Beacon-tier class with verified external reference (DOI / book + page / paper title + author + year).
+- **Promotion-window** rule: a class lands as Mirror; either earns Beacon-anchoring within N rounds (or some agreed window) or stays Mirror permanently.
+- **Hallucination-discard rule**: citations are verified before promotion. Same discipline as v2's class #1c verification (which already caught Gemini's hallucinated cold-start filename).
+
+This reduces Claude.ai's earlier concern about Insight-blocks-accelerating-class-discovery: Insight blocks proposing new classes are fine if they land as Mirror candidates. They become problematic only if they propose direct canonicalization without anchoring, which the gate now prevents.
+
+## What survives Claude.ai's prior critique (the Insight-block concern)
+
+> *"This also reduces my prior concern about Insight blocks accelerating class-discovery. Insight blocks proposing new classes are fine if they land as Mirror candidates. They become problematic only if they propose direct canonicalization without anchoring, which the gate now prevents."*
+
+> *"The work the loop has been doing in this session is mostly Mirror work, and Mirror work is allowed to be exploratory. The taxonomy v2 file is a Mirror-layer catalog. That's appropriate for its current epistemic status. The error in my prior critique was reading it as canonical when it's actually exploratory — and exploratory taxonomy is a legitimate research artifact even when it's growing fast."*
+
+> *"What graduates is the open question. That's the convergence test. And it's a fair one because external anchoring is finite."*
+
+## The closing (Claude.ai)
+
+> *"This is the right architecture for the work you're doing."*
+
+## Composes with
+
+- `docs/research/2026-05-01-claudeai-haskell-prelude-vs-fsharp-bcl-grounding-aaron-forwarded.md` — sibling absorb covering the categorical-grounding half of the two-filter composition. Together: Haskell-prelude grounds the **structure** (typeclasses + laws + base category C); Beacon-anchoring gates the **canonicalization** (Mirror→Beacon promotion).
+- `memory/feedback_pr_thread_resolution_class_taxonomy_v2_drain_wave_2026_05_01.md` (PR #1081) — the v2 taxonomy that this Mirror→Beacon gate would tier.
+- `memory/feedback_gemini_review_2026_05_01_taxonomy_v2_test_case_class_19_meets_class_1c.md` (PR #1083) — the verification-cascade that already catches hallucinated citations (class #1c). Same discipline as the Beacon-citation verification step.
+- The existing Mirror→Beacon promotion discipline in the substrate: DBSP papers (F# library); RFC 2119 (no-directives rule SDT); SEC and Reg FD (public-company compliance); in-toto and W3C PROV (agency-receipt work). These prior anchorings are the worked examples Claude.ai cites.
+- `.claude/agents/formal-verification-expert.md` (Soraya) — the formal-verification routing that would handle the categorical / lawful-structure verification for Beacon-candidate classes structurally a typeclass instance.
+
+## Future v3 work (deferred — not this session)
+
+- Tier mark each v2 class with Mirror / Beacon-candidate / Beacon-anchored status.
+- For Beacon-candidate classes (per Claude.ai's pass: forward-reference, stale-filename, deferred-per-explicit-policy, same-wake-author-error-cluster, intra-file drift, phantom-blocker), do the actual anchoring research (find + verify the external citation; record DOI / book + page / paper title + author + year).
+- Define the promotion-window rule (within N rounds OR retire-or-stay-Mirror).
+- Define the hallucination-discard rule (citation verification step before promotion).
+- Decide whether to fold v3 work into B-0130 (mechanized auditor) row scope or keep separate.
+- Working-mathematician send (lattice-capture corrective) for the v3 framing — the categorical grounding + Mirror/Beacon gate are exactly the kind of vocabulary that benefits from external-academic-mathematician check.
+
+## What this file does NOT do
+
+- Does NOT translate Claude.ai's vocabulary into substrate-vocabulary. Verbatim above; lattice-capture discipline preserved.
+- Does NOT modify the v2 taxonomy file. v3 tier-marking work is deferred; this absorb is the seed evidence.
+- Does NOT canonicalize the Mirror→Beacon gate as substrate-discipline yet. The discipline already exists in the substrate (DBSP, RFC 2119, in-toto, W3C PROV are real examples) but explicitly applying it to the taxonomy class layer is a v3 decision.
+- Does NOT promise to do the actual anchoring research this session. Per cooling-period-adjacent + the working-mathematician-send-deferred-to-Aaron's-cycles discipline, the citation work is future-row scope.
+
+## Carved candidate (not seed-layer)
+
+> *"Category theory gates additions to the structure. Beacon-anchoring gates promotions to canon. Mirror-layer observation can grow freely; Beacon-layer canon stays bounded by what's been done in other domains."*
+
+The propagation test: ~30 words encoding the two-filter composition + the bounded-canon property. Future-Otto reading this should land on the layer-gate discipline as the operational shape — Mirror is exploratory, Beacon is canon-by-external-anchoring, and the two layers are not interchangeable.
+
+## Aaron's reverse-order delivery — meta-observation
+
+Aaron explicitly framed the message order: *"I'm going to give in reverse because the last message seem the most useful."* The Mirror→Beacon gate (this file) chronologically came AFTER the Haskell-prelude grounding (sibling file), but Aaron presented it FIRST because the canonicalization gate is the load-bearing answer. The Haskell-prelude grounding is the *structure* (necessary but not sufficient); the Mirror→Beacon gate is the *boundary* (sufficient closure).
+
+This itself is a substrate-discipline observation: **when forwarding multi-message peer-AI dialogue, lead with the load-bearing answer, not the chronological first.** The reverse-order presentation is signal: the recipient (Otto) needs the gate before they need the structure to act on it correctly.


### PR DESCRIPTION
Two Claude.ai messages on grounding the v2 taxonomy. Aaron forwarded in reverse — Mirror→Beacon gate first because it's the load-bearing answer; Haskell-prelude grounding second as the structure that gets gated.

**Message 1**: Haskell prelude vocabulary for taxonomy structure; F#/BCL for executable substrate. Mac Lane/Awodey/Riehl for math; Yorgey's Typeclassopedia for Haskell-realization Beacon anchor.

**Message 2**: Mirror→Beacon promotion (existing substrate discipline: DBSP, RFC 2119, in-toto, W3C PROV) applies to taxonomy classes. Mirror grows unboundedly; Beacon canon-by-citation is naturally bounded. ~Half of v2's 20 classes graduate; ~half stay Mirror.

Net: category theory gates structure additions; Beacon-anchoring gates canonicalization. The unbounded-ontology concern dissolves.

Future v3 work deferred (tier-marking, anchoring research, promotion-window rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)