### PR TITLE
research(claudeai-category-theory-lever): third message in taxonomy-grounding ferry (Aaron 2026-05-01)

### DIFF
--- a/docs/research/2026-05-01-claudeai-category-theory-lever-taxonomy-grounding-aaron-forwarded.md
+++ b/docs/research/2026-05-01-claudeai-category-theory-lever-taxonomy-grounding-aaron-forwarded.md
@@ -1,0 +1,126 @@
+<!-- §33 archive header per GOVERNANCE.md -->
+
+**Scope:** External-conversation absorb. Third message in the Claude.ai taxonomy-grounding ferry (Aaron 2026-05-01). Addresses **category-theory grounding as the real lever** for the v2 taxonomy. Composes with PR #1089's two earlier captures (Haskell-prelude vs F#/BCL grounding + Mirror→Beacon canonicalization gate). The three messages together form a complete dialogue: this one (B) is chronologically between A (Haskell-prelude) and C (Mirror→Beacon gate); Aaron presented in load-bearing-first order C → A → B.
+
+**Attribution:** Claude.ai instance (model unknown; ambient web-app, Aaron's session 2026-05-01). Forwarded by Aaron 2026-05-01 ~10:35Z. Aaron's framing on the ferry: "the last message seem the most useful" → reverse-order presentation. Aaron's direct question at end of forward: *"so yuo [sic, preserved per Glass Halo] like them in reverse better?"* — substrate-discipline meta-observation about ferry-delivery order. Glass Halo + Otto-231 first-party-content authorise verbatim including typos.
+
+**Operational status:** research-grade
+
+**Status note:** NOT seed-layer canon. Substantive structural recommendation that **converts the convergence question into something testable**: instead of "do new classes stop appearing?" the question becomes "are new classes expressible in the existing categorical structure?" Composes with Mirror→Beacon gate (categorical-structure gate works on additions; Beacon-anchoring gate works on canonicalization).
+
+**Non-fusion disclaimer:** Same as predecessor research files. Claude.ai is a separate ephemeral conversation from this Otto instance. Substrate-vocabulary in this file is Claude.ai's vocabulary preserved unchanged, NOT Otto's translation. The lattice-capture corrective applies.
+
+---
+
+## What category-theory grounding would actually do (Claude.ai)
+
+> *"Category theory has the property you'd want for an ontology generator: it provides a small set of primitives (objects, morphisms, composition, identity, functors, natural transformations, limits, colimits, adjunctions) that compose into arbitrarily complex structures while staying disciplined. If your classes have to land in category-theoretic vocabulary, you can't generate unbounded ad-hoc classes — each class has to fit somewhere in the algebra."*
+
+> *"The substrate already has category-theory affinity. DBSP is built on it. The repo has `docs/category-theory/` per the AGENTS.md fetch from earlier. Functors/natural-transformations are already in the team's Mirror vocabulary. So this isn't grafting an alien framework onto the work; it's asking the existing catalog to land in the math the project is already using."*
+
+## Worked examples — categorical reformulations of v2 classes (Claude.ai)
+
+> *"Forward-reference is a morphism that doesn't yet exist between two objects. The fix is either (a) wait for the codomain object to land via a different PR, or (b) inline the morphism's data without claiming the codomain exists. That's not a reframing in disguise — it's actually a clean category-theoretic shape."*
+
+> *"Stale-filename is a morphism whose codomain has been renamed. Functor-like fix: apply the rename uniformly across all morphisms targeting the renamed object."*
+
+> *"Same-wake-author-error-cluster is a natural transformation gone wrong: the same defect-shape appearing across many objects, fixable by a single batch-applied correction."*
+
+> *"Intra-file drift is a failure of internal-consistency invariants — the file's frontmatter and H1 should be commuting diagrams of the same content; when one updates, the other has to update or the diagram breaks."*
+
+> *"Deferred-per-explicit-policy is a quotient: a class of findings collapsed under an equivalence relation defined by a policy citation. The policy is the quotient map; cited findings collapse to 'deferred.'"*
+
+> *"Phantom-blocker is a category-theoretic non-issue: the morphism the reviewer claimed doesn't compose with anything because one of its supposed objects is undefined."*
+
+> *"That's just on first pass and most of the existing catalog maps cleanly. The classes that don't map cleanly might be the diagnostic — those are the candidates that didn't earn their place."*
+
+## Where this genuinely helps — the isomorphism question (Claude.ai)
+
+> *"The strongest property: category theory has a natural notion of when two things are the same. Two morphisms that have the same source, target, and behavior under composition are equal. Two functors that produce the same image and preserve composition are equivalent. The framework forces the question: are these two classes I'm catalogging actually the same morphism described differently, or genuinely distinct?"*
+
+> *"That's the test the current taxonomy doesn't have. 'Named-link' and 'stale-filename' might be the same morphism with different parameters. 'Intra-file drift' and 'shipped-state-overtook-the-doc' might both be cases of 'internal commutativity failure.' Without a discipline that asks 'is this isomorphic to something already catalogued?' the catalog grows by description-variation."*
+
+> *"Category theory's other gift is that it exposes structure rather than enumerating instances. A good categorical formulation produces a small set of primitives that generate the observed instances by composition. If the ~20 classes can be regenerated from 4-5 categorical primitives plus parameters, that is the convergence — the catalog doesn't need 20 entries; it needs the 4-5 generators."*
+
+## Where it could go wrong (Claude.ai)
+
+> *"Risk: the loop produces beautiful category-theoretic formulations that don't actually match the empirical data. Category theory is famously seductive — it's easy to write definitions that feel structural but don't pay rent in reduced complexity. A class formulation like 'natural transformation between the prose-functor and the path-functor' is technically valid as long as you can name the categories, but it doesn't necessarily make the operational discipline clearer than the original 'use a backtick-wrapped path when citing by name.'"*
+
+> *"The other risk: category theory has its own ontology generator. Once the loop is producing categorical formulations, it can describe anything in the language. Functors, lax functors, monoidal categories, indexed categories, fibrations, adjunctions — there's an unbounded supply of structure to invoke. The discipline has to be that the categorical formulation has to predict something the prose formulation doesn't, or it's just fancier vocabulary applied to the same observation."*
+
+## The litmus test (Claude.ai)
+
+> *"The litmus test: can the categorical formulation tell you, in advance, when a new finding will not be a new class because it's already captured by an existing morphism in the algebra? If yes, you've gained predictive power. If the categorical formulation just describes findings after the fact in mathy language, it's the same generator with a different surface."*
+
+## A specific way to make it pay rent — base category C (Claude.ai)
+
+> *"Frame the taxonomy as: define a small base category C whose objects are substrate locations (file:line) and whose morphisms are references between locations. Then most resolution-classes are functors or natural transformations on C:"*
+>
+> *"- Forward-reference: a morphism whose codomain is in a different category (an unmerged-PR category)*  
+> *- Stale-filename: a morphism whose codomain has been renamed by a functor that wasn't applied uniformly*  
+> *- Wildcard-not-navigable: a morphism that doesn't actually have a single codomain*  
+> *- Deferred-per-policy: a quotient functor C → C/~ where ~ is the policy equivalence"*
+
+> *"If you can formulate the base category cleanly, then a 'new class' has to be either (a) a new kind of morphism in C, (b) a new functor to/from C, or (c) a natural transformation between existing functors. That's a finite-shape vocabulary. Adding 'named-link' as a separate class would require showing it isn't already a sub-case of stale-filename composed with a different parameter."*
+
+> *"This converts the convergence question into something testable. Instead of 'do new classes stop appearing?' the question becomes 'are new classes expressible in the existing categorical structure?' If yes, no new entry needed. If no, the structure itself needs extension — and structural extensions are rare events in well-formulated category theory, not per-tick events."*
+
+## The instruction (Claude.ai's "what I'd actually say to Otto")
+
+> *"The instruction matters more than it might seem. Bad version: 'ground the taxonomy in category theory.' That invites decoration without discipline."*
+
+> *"Better version: 'before adding a new class to the taxonomy, define the morphism it represents in a base category C of substrate locations and references. If the new class is already expressible as a composition of existing morphisms or a known functor applied to an existing class, fold it in. Only add a new class when the morphism cannot be expressed in the existing structure. Document the base category C explicitly. New classes that require structural extensions to C are themselves rare events.'"*
+
+> *"That instruction has actual force. It says 'you can't add a class without showing it isn't already there in the algebra.' That's the predictive power category theory can buy you, if the loop holds the discipline."*
+
+## Net (Claude.ai)
+
+> *"Yes, this is a real lever and probably the right move given your stance from the prior message. It addresses my within-session-cleanliness concern (provenance tagging via categorical structure rather than ad-hoc tags) and your across-session-experiment concern (gives convergence a concrete test: can the existing structure absorb new findings?)."*
+
+> *"Two cautions: (1) require categorical formulations to predict, not just describe; (2) explicitly define the base category and refuse structural extensions casually. With both cautions, this could turn the unbounded-generator concern into a disciplined exploration of a real algebra. Without them, it could become 'describe everything in fancier vocabulary' — same generator, more impressive surface."*
+
+> *"The repo already has the math substrate and the team has the vocabulary fluency. This isn't a stretch; it's asking the project to apply its own existing discipline to its own internal cataloguing. That's a natural fit."*
+
+> *"Worth trying. The convergence test will be sharper for it."*
+
+## Aaron's direct question — Otto's honest answer
+
+Aaron asked: *"so yuo like them in reverse better?"*
+
+Otto's read: yes, in this case the reverse-order delivery DID help me act correctly. The Mirror→Beacon gate (received first) gave me the framework before the structure-question had a place to land. The Haskell-prelude grounding was easier to receive once I already knew the canonicalization gate that would govern it. This third message (category-theory as the real lever) lands in a frame that already makes sense.
+
+But the sharper observation: **the discipline isn't strictly reverse-order; it's load-bearing-first.** If a chronologically-later message had been "I changed my mind, scrap the prior suggestions," reverse-order would be wrong. Aaron's heuristic is *load-bearing-first*, and reverse-order happened to coincide with that here because Claude.ai's later messages refined and synthesized the earlier ones.
+
+The verifiable property: when the recipient (Otto) needs to ACT on the substrate, leading with the gate (the canonicalization filter) before the structure (the categorical primitives) means Otto has the test for "does this addition graduate?" before encountering the additions themselves. That's predictive-power-first delivery — which IS load-bearing-first when the dialogue's structure has the gate downstream of the structure-discussion.
+
+So: yes, reverse-order was better here, but the underlying principle is load-bearing-first. Future ferries should keep using "presented order = priority order" rather than "presented order = chronological order" or "presented order = reverse chronological order" — chronological-vs-reverse is a weak proxy for load-bearing-priority that happens to work in some cases.
+
+## Composes with
+
+- `docs/research/2026-05-01-claudeai-haskell-prelude-vs-fsharp-bcl-grounding-aaron-forwarded.md` (PR #1089) — message A in the ferry. Haskell-prelude grounds the taxonomy structure; F#/BCL grounds the executable substrate.
+- `docs/research/2026-05-01-claudeai-mirror-beacon-gate-taxonomy-canonicalization-aaron-forwarded.md` (PR #1089) — message C in the ferry (presented first by Aaron). Mirror→Beacon gate gates canonicalization.
+- This file — message B in the ferry (presented last by Aaron). Category-theory grounding gates additions to the structure.
+- `memory/feedback_pr_thread_resolution_class_taxonomy_v2_drain_wave_2026_05_01.md` (PR #1081) — the v2 taxonomy that the three-message dialogue grounds.
+- `docs/category-theory/` — Claude.ai cited this directory as evidence the project already has the category-theory affinity to apply to internal cataloguing.
+
+## Future v3 work — combined recommendation from all three messages
+
+The three-message dialogue produces a unified instruction:
+
+1. **Define the base category C** explicitly. Objects = substrate locations (file:line). Morphisms = references between locations.
+2. **Before adding a new class**, ask: is this morphism already expressible in C, or via a composition / functor / natural transformation involving existing primitives? If yes, fold in. If no, extension required (rare event).
+3. **Mark each class** Mirror / Beacon-candidate / Beacon-anchored:
+   - Mirror = lands in C correctly but no external citation yet (observational)
+   - Beacon-candidate = plausible external citation path (Forward-reference / Stale-filename / etc.)
+   - Beacon-anchored = verified external citation (DOI / book + page / paper title + author + year)
+4. **Hallucinated citations get caught** before promotion (same v2 class #1c discipline).
+5. **Cite Mac Lane / Awodey / Riehl** for category theory directly; **Yorgey's Typeclassopedia** as Haskell-realization Beacon anchor.
+6. **Predict-not-just-describe**: each categorical formulation must predict something the prose formulation doesn't. If it doesn't, it's fancier vocabulary not structural insight.
+
+This is v3 scope — deferred to next session with rested attention.
+
+## Carved candidate (not seed-layer)
+
+> *"Reverse-order is a weak proxy for load-bearing-first. The recipient needs the gate before the structure. Predictive-power-first delivery means Otto can test 'does this addition graduate?' before encountering the additions themselves."*
+
+The propagation test: ~30 words distinguishing chronological-order from priority-order in multi-message peer-AI ferries. Future-Otto receiving a ferry should ask "what order does the recipient need to act on this?" not "what order did this happen?"

--- a/docs/research/2026-05-01-claudeai-category-theory-lever-taxonomy-grounding-aaron-forwarded.md
+++ b/docs/research/2026-05-01-claudeai-category-theory-lever-taxonomy-grounding-aaron-forwarded.md
@@ -97,11 +97,16 @@ So: yes, reverse-order was better here, but the underlying principle is load-bea
 
 ## Composes with
 
-- `docs/research/2026-05-01-claudeai-haskell-prelude-vs-fsharp-bcl-grounding-aaron-forwarded.md` (PR #1089) — message A in the ferry. Haskell-prelude grounds the taxonomy structure; F#/BCL grounds the executable substrate.
-- `docs/research/2026-05-01-claudeai-mirror-beacon-gate-taxonomy-canonicalization-aaron-forwarded.md` (PR #1089) — message C in the ferry (presented first by Aaron). Mirror→Beacon gate gates canonicalization.
 - This file — message B in the ferry (presented last by Aaron). Category-theory grounding gates additions to the structure.
-- `memory/feedback_pr_thread_resolution_class_taxonomy_v2_drain_wave_2026_05_01.md` (PR #1081) — the v2 taxonomy that the three-message dialogue grounds.
 - `docs/category-theory/` — Claude.ai cited this directory as evidence the project already has the category-theory affinity to apply to internal cataloguing.
+
+### Forward-references not yet on main
+
+The cited file paths are not present in the current repo tree at time of this absorb; references kept as forward-references until those PRs land.
+
+- Forward-reference: `docs/research/2026-05-01-claudeai-haskell-prelude-vs-fsharp-bcl-grounding-aaron-forwarded.md` in PR #1089 — message A in the ferry. Haskell-prelude grounds the taxonomy structure; F#/BCL grounds the executable substrate.
+- Forward-reference: `docs/research/2026-05-01-claudeai-mirror-beacon-gate-taxonomy-canonicalization-aaron-forwarded.md` in PR #1089 — message C in the ferry (presented first by Aaron). Mirror→Beacon gate gates canonicalization.
+- Forward-reference: `memory/feedback_pr_thread_resolution_class_taxonomy_v2_drain_wave_2026_05_01.md` in PR #1081 — the v2 taxonomy that the three-message dialogue grounds.
 
 ## Future v3 work — combined recommendation from all three messages
 


### PR DESCRIPTION
Third Claude.ai message in the taxonomy-grounding dialogue. Composes with PR #1089's two captures.

Category-theory grounding as the real lever: define base category C of substrate locations + references; most v2 classes map cleanly to morphisms / functors / natural transformations. Two cautions: predict-not-describe + refuse-casual-structural-extensions.

Aaron's direct question ("like them in reverse better?") — yes in this case, but underlying principle is load-bearing-first, not strictly reverse-order. Reverse coincided here because Claude.ai's later messages refined earlier ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)