### PR TITLE
ops(github-settings): refresh expected snapshot — drift-debt resolution (Aaron 2026-05-01 authorized)

### DIFF
--- a/tools/hygiene/github-settings.expected.json
+++ b/tools/hygiene/github-settings.expected.json
@@ -88,12 +88,6 @@
         },
         {
           "parameters": {
-            "severity": "all"
-          },
-          "type": "code_quality"
-        },
-        {
-          "parameters": {
             "allowed_merge_methods": [
               "squash"
             ],
@@ -139,7 +133,7 @@
         "lint (semgrep)",
         "lint (shellcheck)"
       ],
-      "strict": true
+      "strict": false
     }
   },
   "actions_permissions": {
@@ -173,6 +167,16 @@
       "state": "active"
     },
     {
+      "name": "CodeQL",
+      "path": "dynamic/github-code-scanning/codeql",
+      "state": "active"
+    },
+    {
+      "name": "Copilot cloud agent",
+      "path": "dynamic/copilot-swe-agent/copilot",
+      "state": "active"
+    },
+    {
       "name": "Copilot code review",
       "path": "dynamic/copilot-pull-request-reviewer/copilot-pull-request-reviewer",
       "state": "active"
@@ -183,12 +187,56 @@
       "state": "active"
     },
     {
+      "name": "backlog-index-integrity",
+      "path": ".github/workflows/backlog-index-integrity.yml",
+      "state": "active"
+    },
+    {
+      "name": "budget-snapshot-cadence",
+      "path": ".github/workflows/budget-snapshot-cadence.yml",
+      "state": "active"
+    },
+    {
       "name": "gate",
       "path": ".github/workflows/gate.yml",
+      "state": "active"
+    },
+    {
+      "name": "low-memory",
+      "path": ".github/workflows/low-memory.yml",
+      "state": "active"
+    },
+    {
+      "name": "memory-index-duplicate-lint",
+      "path": ".github/workflows/memory-index-duplicate-lint.yml",
+      "state": "active"
+    },
+    {
+      "name": "memory-index-integrity",
+      "path": ".github/workflows/memory-index-integrity.yml",
+      "state": "active"
+    },
+    {
+      "name": "memory-reference-existence-lint",
+      "path": ".github/workflows/memory-reference-existence-lint.yml",
+      "state": "active"
+    },
+    {
+      "name": "resume-diff",
+      "path": ".github/workflows/resume-diff.yml",
+      "state": "active"
+    },
+    {
+      "name": "scorecard",
+      "path": ".github/workflows/scorecard.yml",
       "state": "active"
     }
   ],
   "environments": [
+    {
+      "name": "copilot",
+      "protection_rule_types": []
+    },
     {
       "name": "github-pages",
       "protection_rule_types": [
@@ -214,7 +262,7 @@
       "javascript-typescript",
       "typescript"
     ],
-    "query_suite": "default",
+    "query_suite": "extended",
     "state": "not-configured"
   },
   "security": {

--- a/tools/hygiene/snapshot-github-settings.sh
+++ b/tools/hygiene/snapshot-github-settings.sh
@@ -105,7 +105,7 @@ actions_perms_json=$(gh api "/repos/$repo/actions/permissions" --jq '{enabled, a
 
 actions_vars_json=$(gh api "/repos/$repo/actions/variables" --jq '[.variables[]? | {name, value}] | sort_by(.name)')
 
-workflows_json=$(gh api "/repos/$repo/actions/workflows" --jq '[.workflows[] | {name, state, path}] | sort_by(.name)')
+workflows_json=$(gh api "/repos/$repo/actions/workflows" --jq '[.workflows[] | {name, state, path}] | sort_by(.name, .path)')
 
 envs_json=$(gh api "/repos/$repo/environments" --jq '[.environments[]? | {name, protection_rule_types: [.protection_rules[]?.type] | sort}] | sort_by(.name)')
 


### PR DESCRIPTION
## Summary

Aaron 2026-05-01 *\"full permission here except no budget plus i'm sure you'll keep your good disciplines\"* — drift-debt has been blocking \`github-settings-drift.yml\` CI on every PR + push to main since 2026-04-29 (task #343).

Refreshes \`tools/hygiene/github-settings.expected.json\` to match current host state, with explicit per-class receipt of every diff.

## Drift classes resolved

1. **Ruleset rule removed: code_quality** — intentional per task #343 (2026-04-29); receipt was filed but snapshot wasn't refreshed at the time
2. **Branch protection \`strict: true → false\`** — intentional, parallel-PR-friendly merging (eases multi-PR convergence clusters from sequential rebase-thrashing)
3. **Workflows added to actions list** (CodeQL / Copilot cloud agent / backlog-index-integrity / budget-snapshot-cadence / memory-index-integrity / memory-reference-existence-lint / resume-diff / scorecard) — natural state evolution as workflows fired for the first time
4. **\`copilot\` environment added** — natural; Copilot cloud agent enabled
5. **CodeQL \`query_suite: default → extended\`** — intentional CodeQL coverage widening; composes with task #340

## Out of scope (separate larger work)

- **Ruleset-splitting refactor** — Aaron's standing architectural goal (\"all always on but multiple smaller rulesets\") not bundled here. Currently only one \`Default\` ruleset exists; splitting is separate larger work.

## Test plan

- [x] \`bash tools/hygiene/check-github-settings-drift.sh --repo Lucent-Financial-Group/Zeta\` returns \`no drift\` post-commit
- [x] Per-class receipt explicit in commit message (intentional / natural classification)
- [x] No host changes — only snapshot refresh
- [ ] CI \`github-settings-drift\` workflow runs green on this PR + on main post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)