### PR TITLE
memory(ui-canonical-reference): Blazor SSG tooling extension (Aaron 2026-05-01 ponder-for-future)

### DIFF
--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -591,7 +591,7 @@ These per-maintainer distillations show what's currently in force. Raw memories 
 - [Script names honest — `install` ≠ `ensure`](feedback_script_and_artifact_name_honesty_ensure_not_install.md).
 - [Symmetry audit = FACTORY-HYGIENE #22](feedback_symmetry_check_as_factory_hygiene.md) — sweep asymmetries.
 - [bun+TS post-setup — medium-confidence watchlist](project_bun_ts_post_setup_low_confidence_watchlist.md).
-- [UI=bun+TS canonical; backend=cutting-edge asymmetry](project_ui_canonical_reference_bun_ts_backend_cutting_edge_asymmetry.md).
+- [UI=bun+TS canonical; backend=cutting-edge asymmetry](project_ui_canonical_reference_bun_ts_backend_cutting_edge_asymmetry.md). <!-- 2026-05-01 paired-edit: extended with Blazor SSG concrete tooling (BlazorStatic / AspNetStatic / .NET 10 persistent-state-attribute) per Aaron's "ponder for the future" research -->
 - [Scripts-layer invariant substrate candidate](project_scripts_layer_invariant_substrate_candidate.md) — Bats/ShellCheck/Pester first.
 - [Tier rename `guess`→`hypothesis`](project_guess_to_hypothesis_tier_rename.md) — research-grade vocab.
 - [Aaron loves defining BP — branch-prediction faculty](user_aaron_enjoys_defining_best_practices.md) — invite into BP discussions.

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -591,7 +591,7 @@ These per-maintainer distillations show what's currently in force. Raw memories 
 - [Script names honest — `install` ≠ `ensure`](feedback_script_and_artifact_name_honesty_ensure_not_install.md).
 - [Symmetry audit = FACTORY-HYGIENE #22](feedback_symmetry_check_as_factory_hygiene.md) — sweep asymmetries.
 - [bun+TS post-setup — medium-confidence watchlist](project_bun_ts_post_setup_low_confidence_watchlist.md).
-- [UI=bun+TS canonical; backend=cutting-edge asymmetry](project_ui_canonical_reference_bun_ts_backend_cutting_edge_asymmetry.md). <!-- 2026-05-01 paired-edit: extended with Blazor SSG concrete tooling (BlazorStatic / AspNetStatic / .NET 10 persistent-state-attribute) per Aaron's "ponder for the future" research -->
+- [UI=bun+TS canonical; backend=cutting-edge asymmetry](project_ui_canonical_reference_bun_ts_backend_cutting_edge_asymmetry.md). <!-- 2026-05-01 paired-edit: Blazor SSG tooling appended -->
 - [Scripts-layer invariant substrate candidate](project_scripts_layer_invariant_substrate_candidate.md) — Bats/ShellCheck/Pester first.
 - [Tier rename `guess`→`hypothesis`](project_guess_to_hypothesis_tier_rename.md) — research-grade vocab.
 - [Aaron loves defining BP — branch-prediction faculty](user_aaron_enjoys_defining_best_practices.md) — invite into BP discussions.

--- a/memory/project_ui_canonical_reference_bun_ts_backend_cutting_edge_asymmetry.md
+++ b/memory/project_ui_canonical_reference_bun_ts_backend_cutting_edge_asymmetry.md
@@ -63,12 +63,13 @@ work without re-learning paradigms.
   or [AspNetStatic](https://github.com/ZarehD/AspNetStatic)
   — both crawl the Blazor app at build time and emit
   `.html` files. Render mode taxonomy (best→worst SEO):
-  Static SSR (5-star) > Interactive Server (3-star) >
-  Interactive Auto (4-star, mixed) > Interactive WASM
+  Static SSR (5-star) > Interactive Auto (4-star, mixed)
+  > Interactive Server (3-star) > Interactive WASM
   (1-star, requires prerendering). .NET 10's persistent-
   state attribute fixes the prerender→hydrate flicker
   (Core Web Vitals win). Astro stays the right choice
-  for content-heavy SEO (B-0154); Blazor + BlazorStatic
+  for content-heavy SEO (per the Pages-site backlog row,
+  in-flight integration); Blazor + BlazorStatic
   becomes the right choice when a future surface needs
   C#-deep dashboards with a few SEO landing pages.
 

--- a/memory/project_ui_canonical_reference_bun_ts_backend_cutting_edge_asymmetry.md
+++ b/memory/project_ui_canonical_reference_bun_ts_backend_cutting_edge_asymmetry.md
@@ -56,22 +56,21 @@ work without re-learning paradigms.
   UI is the known-good stable-ground that new tech
   is compared against.
 
-  **Blazor SSG concrete tooling** (Aaron 2026-05-01
-  research add): for any future Blazor surface that
-  needs static-site output (e.g., GitHub-Pages-hosted
-  docs/dashboards), use [BlazorStatic](https://github.com/BlazorStatic/BlazorStatic)
-  or [AspNetStatic](https://github.com/ZarehD/AspNetStatic)
-  — both crawl the Blazor app at build time and emit
-  `.html` files. Render mode taxonomy (best→worst SEO):
-  Static SSR (5-star) > Interactive Auto (4-star, mixed)
-  > Interactive Server (3-star) > Interactive WASM
-  (1-star, requires prerendering). .NET 10's persistent-
-  state attribute fixes the prerender→hydrate flicker
-  (Core Web Vitals win). Astro stays the right choice
-  for content-heavy SEO (per the Pages-site backlog row,
-  in-flight integration); Blazor + BlazorStatic
-  becomes the right choice when a future surface needs
-  C#-deep dashboards with a few SEO landing pages.
+**Blazor SSG concrete tooling** (Aaron 2026-05-01 research
+add): for any future Blazor surface that needs static-site
+output (e.g., GitHub-Pages-hosted docs/dashboards), use
+[BlazorStatic](https://github.com/BlazorStatic/BlazorStatic)
+or [AspNetStatic](https://github.com/ZarehD/AspNetStatic) —
+both crawl the Blazor app at build time and emit `.html`
+files. Render mode SEO ranking (best to worst): Static SSR
+(5-star), Interactive Auto (4-star, mixed), Interactive
+Server (3-star), Interactive WASM (1-star, requires
+prerendering). .NET 10's persistent-state attribute fixes
+the prerender→hydrate flicker (Core Web Vitals win). Astro
+stays the right choice for content-heavy SEO (per the
+Pages-site backlog row, in-flight integration); Blazor +
+BlazorStatic becomes the right choice when a future surface
+needs C#-deep dashboards with a few SEO landing pages.
 
 **The evolve-over-time pattern:**
 

--- a/memory/project_ui_canonical_reference_bun_ts_backend_cutting_edge_asymmetry.md
+++ b/memory/project_ui_canonical_reference_bun_ts_backend_cutting_edge_asymmetry.md
@@ -56,6 +56,22 @@ work without re-learning paradigms.
   UI is the known-good stable-ground that new tech
   is compared against.
 
+  **Blazor SSG concrete tooling** (Aaron 2026-05-01
+  research add): for any future Blazor surface that
+  needs static-site output (e.g., GitHub-Pages-hosted
+  docs/dashboards), use [BlazorStatic](https://github.com/BlazorStatic/BlazorStatic)
+  or [AspNetStatic](https://github.com/ZarehD/AspNetStatic)
+  — both crawl the Blazor app at build time and emit
+  `.html` files. Render mode taxonomy (best→worst SEO):
+  Static SSR (5-star) > Interactive Server (3-star) >
+  Interactive Auto (4-star, mixed) > Interactive WASM
+  (1-star, requires prerendering). .NET 10's persistent-
+  state attribute fixes the prerender→hydrate flicker
+  (Core Web Vitals win). Astro stays the right choice
+  for content-heavy SEO (B-0154); Blazor + BlazorStatic
+  becomes the right choice when a future surface needs
+  C#-deep dashboards with a few SEO landing pages.
+
 **The evolve-over-time pattern:**
 
 1. **Start:** Canonical reference UI in bun+TS.


### PR DESCRIPTION
Extends existing UI-canonical-reference memo with concrete Blazor SSG tooling research Aaron shared (BlazorStatic / AspNetStatic / .NET 10 persistent-state). Goldfish-ontology discipline applied: extend existing memo rather than create new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)