### PR TITLE
tools(hygiene): exclude docs/lost-substrate/** from orphan-role-ref lint

### DIFF
--- a/tools/hygiene/audit-orphan-role-refs.sh
+++ b/tools/hygiene/audit-orphan-role-refs.sh
@@ -57,6 +57,8 @@
 #     2026-04-29 call; see file's classification block)
 #   - docs/backlog/** (per-row history of backlog filings;
 #     authors, dated lineage, persona names allowed)
+#   - docs/lost-substrate/** (incident artifacts + dated
+#     inventory ledgers — by definition history-surface)
 #   - docs/CURRENT-ROUND.md (round-history equivalent)
 #   - docs/amara-full-conversation/** (verbatim archived
 #     conversation — bootstrap-attempt-1 lineage)
@@ -131,6 +133,7 @@ is_history_surface() {
     docs/pr-discussions/* | \
     docs/active-trajectory.md | \
     docs/backlog/* | \
+    docs/lost-substrate/* | \
     docs/CURRENT-ROUND.md | \
     docs/amara-full-conversation/* | \
     .git/* | \

--- a/tools/hygiene/audit-orphan-role-refs.sh
+++ b/tools/hygiene/audit-orphan-role-refs.sh
@@ -44,7 +44,12 @@
 #   - root *.md (README, AGENTS, GOVERNANCE, CLAUDE.md, etc.) —
 #     these are current-state surfaces per Otto-279
 #
-# Exclude (history surfaces — per Otto-279):
+# Exclude (history surfaces — per Otto-279 carve-out at
+# docs/AGENT-BEST-PRACTICES.md, plus this script's pragmatic
+# extensions for surfaces NOT yet listed in the canonical
+# closed list but which are by-definition history surfaces):
+#
+#   Canonical (in AGENT-BEST-PRACTICES.md closed list):
 #   - memory/**
 #   - docs/research/**
 #   - docs/aurora/**
@@ -57,12 +62,26 @@
 #     2026-04-29 call; see file's classification block)
 #   - docs/backlog/** (per-row history of backlog filings;
 #     authors, dated lineage, persona names allowed)
-#   - docs/lost-substrate/** (incident artifacts + dated
-#     inventory ledgers — by definition history-surface)
 #   - docs/CURRENT-ROUND.md (round-history equivalent)
 #   - docs/amara-full-conversation/** (verbatim archived
 #     conversation — bootstrap-attempt-1 lineage)
+#
+#   Tool-extended (this script's additions, pending a doctrine
+#   update that adds them to the canonical list — see
+#   "Doctrine-extension follow-up" below):
+#   - docs/lost-substrate/** (incident artifacts + dated
+#     inventory ledgers from corruption-triage events; by
+#     definition history-surface)
+#
+#   Always-skip (non-substrate paths):
 #   - .git/**, node_modules/**, third_party/**
+#
+# Doctrine-extension follow-up: when the AGENT-BEST-PRACTICES.md
+# Otto-279 closed list next gets edited, fold docs/lost-substrate/**
+# into the canonical list and remove the tool-extended note here.
+# Until that happens the lint extends the doc; the doc remains the
+# source of truth for the categorical rule, this script encodes the
+# operational implementation.
 #
 # Output shape:
 #   file:line:column: <pattern-class>: <matched-text>


### PR DESCRIPTION
## Summary

Small fix on PR #1187 (orphan-role-ref lint). \`docs/lost-substrate/**\` is by definition a history-surface (incident artifacts + dated inventory ledgers from the 2026-04-29 corruption-triage). Persona names + dated attribution are explicitly ALLOWED there per Otto-279 history-surface carve-out.

Adding to the lint's history-surface exclusion list closes two false-positive findings the initial implementation flagged.

## Smoke-test

Before fix: 16 findings on full-repo audit.
After fix: 14 findings (the two \`docs/lost-substrate/\` findings correctly suppressed).

The remaining 14 are real findings to address in follow-up PRs:

- \`tools/hygiene/audit-agencysignature-*.sh/.ts\` — comments reference the originating "ferry-7 enforcement-instrument" purpose. May be legitimate-but-stripable.
- \`tools/hygiene/validate-agencysignature-pr-body.sh/.ts\` — same pattern.
- \`tools/peer-call/grok.sh\` — \`Grok ferry-14/16\` reference in comment.
- \`tools/github/poll-pr-gate-batch.test.ts\` — \`Per Aaron 2026-05-01\` in comment header.
- \`tests/Tests.FSharp/Algebra/Veridicality.Tests.fs\` — \`"repo/amara/ferry-10"\` as a test fixture string (not a real substrate-attribution claim; deserves a parser-aware refinement to suppress).

## Composes with

- **PR #1187** (initial lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)