### PR TITLE
backlog(B-0085 close): option-C empirical supersession — deadline window passed without intervention

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -13,7 +13,7 @@ are closed (status: closed in frontmatter)._
 
 - [ ] **[B-0062](backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md)** Wallet v0 build-out — concrete spec-logic punch list aggregating PR #72 deferred review concerns (Aaron 2026-04-28 honest-tracking catch)
 - [x] **[B-0073](backlog/P0/B-0073-lfg-csharp-code-scanning-cleanup-13-alerts-blocking-ruleset-2026-04-28.md)** LFG csharp Code Scanning cleanup — 13 open alerts gating code_quality severity:all ruleset on every PR
-- [ ] **[B-0085](backlog/P0/B-0085-budget-cadence-workflow-cron-misses-task-287-deadline-window-aaron-2026-04-28.md)** Budget cadence workflow's weekly-Sundays cron misses task #287 cost-visibility deadline window (2026-04-26..04-29)
+- [x] **[B-0085](backlog/P0/B-0085-budget-cadence-workflow-cron-misses-task-287-deadline-window-aaron-2026-04-28.md)** Budget cadence workflow's weekly-Sundays cron misses task #287 cost-visibility deadline window (2026-04-26..04-29)
 - [ ] **[B-0109](backlog/P0/B-0109-dependency-status-tracking-surface-2026-04-30.md)** Dependency status tracking surface — outages and issues affecting us (Aaron 2026-04-30, urgent)
 
 ## P1 — within 2-3 rounds

--- a/docs/backlog/P0/B-0085-budget-cadence-workflow-cron-misses-task-287-deadline-window-aaron-2026-04-28.md
+++ b/docs/backlog/P0/B-0085-budget-cadence-workflow-cron-misses-task-287-deadline-window-aaron-2026-04-28.md
@@ -3,7 +3,7 @@ id: B-0085
 priority: P0
 status: closed
 closed: 2026-05-02
-closed_by: "option-C empirical supersession (deadline-window 2026-04-26..04-29 closed without intervention; workflow's natural Sunday fire restarts 2026-05-03)"
+closed_by: "superseded-by-acceptance (option-C empirical supersession per row's own acceptance criteria; deadline-window 2026-04-26..04-29 closed without intervention; workflow's natural Sunday fire restarts 2026-05-03)"
 title: Budget cadence workflow's weekly-Sundays cron misses task #287 cost-visibility deadline window (2026-04-26..04-29)
 tier: factory-tooling
 effort: S

--- a/docs/backlog/P0/B-0085-budget-cadence-workflow-cron-misses-task-287-deadline-window-aaron-2026-04-28.md
+++ b/docs/backlog/P0/B-0085-budget-cadence-workflow-cron-misses-task-287-deadline-window-aaron-2026-04-28.md
@@ -1,16 +1,38 @@
 ---
 id: B-0085
 priority: P0
-status: open
+status: closed
+closed: 2026-05-02
+closed_by: "option-C empirical supersession (deadline-window 2026-04-26..04-29 closed without intervention; workflow's natural Sunday fire restarts 2026-05-03)"
 title: Budget cadence workflow's weekly-Sundays cron misses task #287 cost-visibility deadline window (2026-04-26..04-29)
 tier: factory-tooling
 effort: S
 ask: autonomous-loop tick discovery 2026-04-28T19:50Z (deferred to maintainer per visibility-constraint)
 created: 2026-04-28
-last_updated: 2026-04-28
+last_updated: 2026-05-02
+depends_on: []
 composes_with: []
 tags: [task-287, deadline-2026-04-29, budget-snapshot, visibility-constraint, cadence-gap, scheduled-fire-vs-deadline-window]
 ---
+
+> **Closed 2026-05-02 — option-C empirical supersession.** The
+> deadline window 2026-04-26..04-29 closed without intervention.
+> The 3-point series in `docs/budget-history/snapshots.jsonl`
+> (2026-04-26 ×2 + 2026-04-27) is the data that informed runway
+> projection during the window per snapshot #4's own note field.
+> The cadence workflow's natural Sunday fire restarts 2026-05-03
+> (one day after this close). Per the row's own acceptance
+> criteria: *"If C: this row closed with note
+> `superseded-by-acceptance` (option-C means the gap is
+> acceptable)."*
+>
+> Coverage hole against task #269 (cadenced counterweight-audit
+> skill should catch deadline-window vs cron-fire-schedule
+> mismatches proactively) is NOT addressed by this closure;
+> remains open as a separate concern. If the workflow-coverage-
+> audit pattern matters going forward, file a fresh row when the
+> next deadline-window mismatch is detected, OR extend task #269
+> directly.
 
 # B-0085 — Budget cadence workflow's weekly-Sundays cron misses task #287 deadline window
 


### PR DESCRIPTION
## Summary

Closes B-0085 (P0, filed 2026-04-28) via option-C empirical supersession. The deadline window 2026-04-26..04-29 has passed without intervention; the workflow's natural Sunday cron fires tomorrow (2026-05-03), restarting cadence on its own.

## Empirical state 2026-05-02

- Workflow has never fired (`gh run list --workflow=.github/workflows/budget-snapshot-cadence.yml` returns empty)
- Snapshots stuck at 4 entries (most recent 2026-04-27, 5+ days old)
- Deadline 2026-04-29 passed 3 days ago
- Next Sunday cron fire = 2026-05-03 (tomorrow, natural restart)

## Why option-C

Per the row's own acceptance criteria:

> *"If C: this row closed with note `superseded-by-acceptance` (option-C means the gap is acceptable)."*

The 3-point series (2026-04-26 ×2 + 2026-04-27) informed runway projection during the window per snapshot #4's own note field. The deadline window closed with the data that was visible.

## Coverage hole NOT addressed

Task #269 (cadenced counterweight-audit skill) should catch deadline-window vs cron-fire-schedule mismatches proactively. This closure does NOT address that coverage hole — it remains open as a separate concern.

## Per the never-idle refinement landed in PR #1224

`depends_on: []` populated per the on-demand-backfill discipline (no upstream blocking dependencies). This is the second backlog row this session to populate `depends_on` as part of starting the work.

## Test plan

- [x] Frontmatter updated to `status: closed` + `closed: 2026-05-02` + `closed_by: option-C empirical supersession`
- [x] Closure note at top of body
- [x] `depends_on: []` populated per new discipline
- [x] BACKLOG.md regenerated
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)