### PR TITLE
backlog(depends_on backfill batch 1): populate empty depends_on:[] on B-0062 + B-0109 (Aaron 2026-05-02 no-rush best-guesses-with-time)

### DIFF
--- a/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
+++ b/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
@@ -8,6 +8,7 @@ effort: L
 ask: maintainer Aaron 2026-04-28 ("bulk-resolve what is buld resolve does it actually answer the questions? or does it just close them? have they been answered?") — surfaced that ~15 PR #72 wallet-spec review threads were resolved with "deferred to v0 build-out" replies but no concrete tracking. This row IS the concrete tracking.
 created: 2026-04-28
 last_updated: 2026-04-28
+depends_on: []
 composes_with: [B-0060, B-0061]
 tags: [wallet-experiment-v0, eat, spec-logic, pr-72-deferrals, honest-tracking, build-out, no-papering-over]
 ---

--- a/docs/backlog/P0/B-0109-dependency-status-tracking-surface-2026-04-30.md
+++ b/docs/backlog/P0/B-0109-dependency-status-tracking-surface-2026-04-30.md
@@ -8,6 +8,7 @@ effort: M
 ask: Aaron 2026-04-30 (autonomous-loop channel input — verbatim "we need somewhere that list the status of our dependinces and issues that could affect us" + 6 source URLs + urgency clarification "github can erase stuff from master when we use the merge queue sometimes")
 created: 2026-04-30
 last_updated: 2026-04-30
+depends_on: []
 composes_with: [B-0086, B-0096]
 tags: [dependency-status, outages, github-incidents, supply-chain, observability, factory-resilience, urgent]
 ---


### PR DESCRIPTION
## Summary

Per never-idle refinement (PR #1224 merged) — on-demand backfill of `depends_on:` field on older rows that don't have it. Aaron's framing: *"best-guesses-with-time, no rush, build out infrastructure incrementally."*

Two open P0 rows backfilled:

- **B-0062** wallet-v0 build-out (composes_with [B-0060, B-0061])
- **B-0109** dependency-status-tracking-surface (composes_with [B-0086, B-0096])

Best-guess: `depends_on: []` for both. composes_with relationships exist (related work clusters) but no upstream blocking dependencies are obvious from the row bodies. If wrong, the discipline allows correction via on-demand-update.

B-0073 (closed) skipped this batch — frontmatter shape lacks composes_with anchor; will pick up in next batch with explicit position handling.

## Composes with

- `memory/feedback_never_idle_speculative_work_over_waiting.md` 2026-05-02 refinement (proper order > smallest-thing-first; depends_on as ordering substrate)

## Test plan

- [x] `depends_on: []` added to B-0062 + B-0109 frontmatter via awk insert before composes_with anchor
- [x] BACKLOG.md regenerated
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)