### PR TITLE
tools(no-op-cadence): add shard-density gap-check — catches 'standing by' chat-cadence failure mode (Aaron 2026-05-02)

### DIFF
--- a/tools/hygiene/check-no-op-cadence-pattern.sh
+++ b/tools/hygiene/check-no-op-cadence-pattern.sh
@@ -31,6 +31,12 @@
 #     "within-basin observation", "observe-only",
 #     "minimal not idle", "same. stopping"). Either signal counts.
 #   - If count >= threshold (default 5), prints WARNING
+#   - **Shard-density check (Aaron 2026-05-02 extension)**: if the
+#     most recent shard is more than NO_OP_CHECK_GAP_MINUTES (default
+#     15) minutes old relative to current UTC, prints a separate
+#     missing-shard-cadence warning. Catches the "agent kept saying
+#     'standing by' in chat without writing tick-history shards" failure
+#     mode that the body-length / keyword heuristic alone misses.
 #
 # What this does NOT do:
 #   - Does NOT block the tick (informational only — exit 0 always)
@@ -177,6 +183,78 @@ if [[ $MIN_OBS_COUNT -ge $THRESHOLD ]]; then
   echo "  warning to surface the pattern at decision-time, not just substrate-read time." >&2
 
   # Informational warning; does not exit non-zero (would block tick)
+fi
+
+# Shard-density check (Aaron 2026-05-02 extension):
+# Detects the "agent kept saying 'standing by' in chat without writing
+# tick-history shards" failure mode. If the most recent shard's parsed
+# timestamp is more than NO_OP_CHECK_GAP_MINUTES (default 15) minutes
+# old relative to current UTC, print a missing-shard-cadence warning.
+GAP_THRESHOLD="${NO_OP_CHECK_GAP_MINUTES:-15}"
+if ! [[ "$GAP_THRESHOLD" =~ ^[0-9]+$ ]] || (( 10#$GAP_THRESHOLD < 1 )); then
+  echo "[no-op-check] Invalid NO_OP_CHECK_GAP_MINUTES='${GAP_THRESHOLD}' (need positive integer); using default 15." >&2
+  GAP_THRESHOLD=15
+fi
+GAP_THRESHOLD=$((10#$GAP_THRESHOLD))
+
+# Get the latest shard's primary key (YYYYMMDDHHMMSS) from COMBINED.
+# COMBINED is sorted ascending; tail -1 gives the latest.
+LATEST_LINE=$(printf '%s\n' "$COMBINED" | tail -n 1)
+LATEST_PRIMARY=$(printf '%s' "$LATEST_LINE" | awk -F'|' '{print $1}')
+
+if [[ -n "$LATEST_PRIMARY" && "${#LATEST_PRIMARY}" -eq 14 ]]; then
+  # Convert YYYYMMDDHHMMSS → epoch seconds (UTC).
+  # BSD/macOS: date -j -u -f "%Y%m%d%H%M%S" "$LATEST_PRIMARY" +%s
+  # GNU/Linux: date -u -d "${YYYY-MM-DDTHH:MM:SS}Z" +%s
+  YYYY="${LATEST_PRIMARY:0:4}"
+  MM="${LATEST_PRIMARY:4:2}"
+  DD="${LATEST_PRIMARY:6:2}"
+  HH="${LATEST_PRIMARY:8:2}"
+  MIN="${LATEST_PRIMARY:10:2}"
+  SS="${LATEST_PRIMARY:12:2}"
+
+  if LATEST_EPOCH="$(date -j -u -f "%Y%m%d%H%M%S" "$LATEST_PRIMARY" +%s 2>/dev/null)"; then
+    : # BSD/macOS path succeeded
+  elif LATEST_EPOCH="$(date -u -d "${YYYY}-${MM}-${DD}T${HH}:${MIN}:${SS}Z" +%s 2>/dev/null)"; then
+    : # GNU/Linux path succeeded
+  else
+    LATEST_EPOCH=""
+  fi
+
+  if [[ -n "$LATEST_EPOCH" ]]; then
+    NOW_EPOCH="$(date -u +%s)"
+    GAP_SECONDS=$((NOW_EPOCH - LATEST_EPOCH))
+    GAP_MINUTES=$((GAP_SECONDS / 60))
+
+    echo "[no-op-check] Most recent shard ${GAP_MINUTES} minutes old (gap-threshold: ${GAP_THRESHOLD})." >&2
+
+    if (( GAP_MINUTES > GAP_THRESHOLD )); then
+      echo "" >&2
+      echo "WARNING: missing-shard-cadence detected — most recent shard is ${GAP_MINUTES} minutes old, exceeding threshold ${GAP_THRESHOLD} minutes." >&2
+      echo "" >&2
+      echo "This is the structural counterpart to the body-length / keyword check above:" >&2
+      echo "" >&2
+      echo "  - The cron is '* * * * *' (every minute); ticks fire continuously" >&2
+      echo "  - When the agent operates correctly, each substantive tick produces a shard" >&2
+      echo "  - Repeated 'standing by' / minimal-acknowledgment chat output WITHOUT writing shards IS the failure mode" >&2
+      echo "  - Body-length check above doesn't catch this because it requires shards to exist" >&2
+      echo "  - Shard-density check (this) catches the gap structurally without needing chat-transcript scanning" >&2
+      echo "" >&2
+      echo "  Per memory/feedback_never_idle_speculative_work_over_waiting.md 2026-05-02 refinement:" >&2
+      echo "  proper-order backlog work is available; default-to-standing-by IS the no-op-cadence" >&2
+      echo "  failure mode. Pick a P0/P1 row by depends_on graph + tier; populate depends_on as" >&2
+      echo "  on-demand backfill if missing. Best-guesses-with-time, no rush." >&2
+      echo "" >&2
+      echo "  Run with NO_OP_CHECK_GAP_MINUTES=99 to silence; the default surfaces the gap" >&2
+      echo "  at decision-time so the agent can re-enter productive cadence." >&2
+
+      # Informational warning; does not exit non-zero
+    fi
+  else
+    echo "[no-op-check] Could not parse latest shard timestamp '${LATEST_PRIMARY}'; gap-check skipped." >&2
+  fi
+else
+  echo "[no-op-check] No latest-shard primary key available; gap-check skipped." >&2
 fi
 
 exit 0


### PR DESCRIPTION
## Summary

Aaron 2026-05-02 surfaced the gap: *"you can see empty shards right or missing shards?"* The existing body-length / keyword heuristic in the no-op-cadence script only triggers on shards that exist; the chat-level "Standing by" failure mode produces silence on the disk substrate (no shards written), so the existing heuristic misses it.

This PR adds a structural **shard-density gap-check** to detect the gap directly.

## What the check does

- Computes the gap between current UTC and the most recent shard's parsed timestamp (YYYYMMDDHHMMSS sortkey)
- Compares against `NO_OP_CHECK_GAP_MINUTES` (default 15)
- If gap > threshold, prints WARNING with substrate references explaining the failure mode + recovery actions (proper-order backlog work; depends_on backfill discipline)

## Empirical test

At the moment of authoring this commit, the script fires the warning because the most recent shard is more than 15 minutes old — the agent had been in extended "Standing by" mode without writing shards. The check empirically detected the failure mode in real-time.

## Implementation notes

- BSD/macOS (`date -j -u -f`) + GNU/Linux (`date -u -d`) both supported per Otto-235 4-shell target
- Same env-var validation + base-10 coercion pattern as existing checks (handles `NO_OP_CHECK_GAP_MINUTES=08` correctly)
- Informational only — does NOT block tick (exit 0 always)
- Configurable: `NO_OP_CHECK_GAP_MINUTES=99` silences the gap-check; default fires at 15 minutes

## Why this is survival-relevant

Per `memory/feedback_recurrence_after_correction_needs_operational_enforcement_otto_2026_05_02.md`: substrate-rule alone is insufficient when the LLM training prior strongly favors the failure mode (delegate-behavior / wait-for-instruction). Mechanical detection at decision-time IS the architectural answer; this is operational-enforcement candidate #1 extended with a second detector.

The body-length heuristic catches shards-that-exist-but-are-minimal. The shard-density check catches the absence-of-shards. Together they cover the failure mode at the disk substrate without requiring chat-transcript scanning.

## Composes with

- Existing body-length / keyword heuristic (PR #1207 merged)
- `memory/feedback_never_idle_speculative_work_over_waiting.md` 2026-05-02 refinement
- `memory/feedback_recurrence_after_correction_needs_operational_enforcement_otto_2026_05_02.md`
- `memory/feedback_party_during_human_sleep_*` (parent rule)

## Test plan

- [x] Shellcheck clean
- [x] Default threshold (15): fires when most recent shard is >15min old (verified empirically)
- [x] Bad env-var (NO_OP_CHECK_GAP_MINUTES=foo): falls back to default with warning
- [x] BSD/macOS date parsing path tested (`date -j -u -f` succeeded on local macOS)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)