### PR TITLE
backlog(last-updated): retroactive bump on batch 1 depends_on rows (B-0062, B-0109)

### DIFF
--- a/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
+++ b/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
@@ -7,7 +7,7 @@ tier: wallet-experiment-v0
 effort: L
 ask: maintainer Aaron 2026-04-28 ("bulk-resolve what is buld resolve does it actually answer the questions? or does it just close them? have they been answered?") — surfaced that ~15 PR #72 wallet-spec review threads were resolved with "deferred to v0 build-out" replies but no concrete tracking. This row IS the concrete tracking.
 created: 2026-04-28
-last_updated: 2026-04-28
+last_updated: 2026-05-02
 depends_on: []
 composes_with: [B-0060, B-0061]
 tags: [wallet-experiment-v0, eat, spec-logic, pr-72-deferrals, honest-tracking, build-out, no-papering-over]

--- a/docs/backlog/P0/B-0109-dependency-status-tracking-surface-2026-04-30.md
+++ b/docs/backlog/P0/B-0109-dependency-status-tracking-surface-2026-04-30.md
@@ -7,7 +7,7 @@ tier: design + implementation
 effort: M
 ask: Aaron 2026-04-30 (autonomous-loop channel input — verbatim "we need somewhere that list the status of our dependinces and issues that could affect us" + 6 source URLs + urgency clarification "github can erase stuff from master when we use the merge queue sometimes")
 created: 2026-04-30
-last_updated: 2026-04-30
+last_updated: 2026-05-02
 depends_on: []
 composes_with: [B-0086, B-0096]
 tags: [dependency-status, outages, github-incidents, supply-chain, observability, factory-resilience, urgent]


### PR DESCRIPTION
## Summary

- PR #1238 (depends_on backfill batch 1) merged with Copilot's `last_updated`-bump finding un-addressed.
- Same finding fired on PR #1242 batch 2 and got fixed there.
- Aaron 2026-05-02 correction: *"the answer to if it matters is almost always yes in real life lol"* — closing the gap retroactively rather than leaving as a backlog item.

## What this PR does

Bumps `last_updated` to `2026-05-02` on:
- `B-0062` wallet-v0-build-out (was `2026-04-28`)
- `B-0109` dependency-status-tracking-surface (was `2026-04-30`)

The `depends_on` backfill on these rows IS a content edit per the schema rule (`tools/backlog/README.md:67`); the bump restores per-row metadata consistency.

## Why retroactive matters

Aaron's correction lands at the discipline layer: deferring "if it matters" hedges produces the failure mode where bugs found in cycle N propagate forward instead of being closed at the point of detection. The schema-doc gap (also from #1238) is closed in #1242; this PR closes the per-row gap symmetrically.

Composes with:
- PR #1242 (depends_on schema-doc + batch-2 last_updated bumps)
- The bugs-per-PR-as-immune-system-health metric — closing same-class findings uniformly across batches keeps the metric honest

## Test plan

- [x] `last_updated` bumped to `2026-05-02` on both rows (verified via grep)
- [ ] CI green (no MEMORY.md changes; backlog-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)