### PR TITLE
backlog: PR #1261 post-merge fixes (B-0172 plugin paths + B-0173 hook paths)

### DIFF
--- a/docs/backlog/P1/B-0173-hook-authoring-for-skill-creation-contracts-aaron-2026-05-03.md
+++ b/docs/backlog/P1/B-0173-hook-authoring-for-skill-creation-contracts-aaron-2026-05-03.md
@@ -48,8 +48,8 @@ Fires post-PR-creation on the GitHub host. Validates **the PR description** for 
 
 ## Hook authoring deliverables
 
-1. `tools/git-hooks/pre-commit` (bash invoking `bun tools/substrate-claim-checker/...` with staged files)
-2. `tools/git-hooks/commit-msg` (bash invoking the same tool with commit message)
+1. `tools/git/hooks/pre-commit` (bash invoking `bun tools/substrate-claim-checker/...` with staged files)
+2. `tools/git/hooks/commit-msg` (bash invoking the same tool with commit message)
 3. `.github/workflows/substrate-claim-checker.yml` (CI check for PR descriptions)
 4. Documentation: how to install hooks (`tools/setup/install.sh` integration)
 5. Opt-out mechanism for legitimate edge cases (e.g., a hedged-claim memo where strict drift checking would false-positive — `# substrate-claim-checker: skip` comment in the file)

--- a/docs/backlog/P2/B-0172-skill-domain-plugin-packaging-aaron-2026-05-03.md
+++ b/docs/backlog/P2/B-0172-skill-domain-plugin-packaging-aaron-2026-05-03.md
@@ -19,7 +19,7 @@ Aaron 2026-05-03 named plugin-packaging as Rule 3a of the skill-design memo (`fe
 
 > *"look at packaking skill domains a plugins or other packagin so we can take advantage of hooks in harnesses"*
 
-Claude Code supports plugins under `.claude/plugins/`. When a skill domain matures (per the future-skill-domain memos' promotion-trigger criteria — 3+ worked examples per skill candidate + 1+ judgment-disagreement per expert candidate), packaging the whole domain as a plugin lets it ship as one unit including its hooks.
+Claude Code installs plugins under `~/.claude/plugins/cache/<plugin-name>/` (per `docs/research/codex-builtins-skills-vs-plugins-factory-integration-2026-04-24.md`). When a skill domain matures (per the future-skill-domain memos' promotion-trigger criteria — 3+ worked examples per skill candidate + 1+ judgment-disagreement per expert candidate), packaging the whole domain as a plugin lets it ship as one unit including its hooks.
 
 ## Why P2 (promotion-trigger pending)
 
@@ -34,15 +34,16 @@ When promotion-trigger DOES fire on a skill domain, this row becomes the impleme
 
 ## Scope (when promotion-trigger fires)
 
-Per Claude Code plugin convention (`.claude/plugins/<name>/`):
+Per Claude Code plugin convention (installed at `~/.claude/plugins/cache/<plugin-name>/`; the source bundle has the manifest at `.claude-plugin/plugin.json`):
 
-1. Each plugin contains:
-   - One or more `SKILL.md` files (the procedure-skills of the domain)
-   - One or more `agent.md` files (the named-persona-experts)
+1. Each plugin bundle contains:
+   - `.claude-plugin/plugin.json` — manifest with name + description + author (minimal fields per the upstream Claude Code spec)
+   - `skills/<skill>/SKILL.md` files (the procedure-skills of the domain) under conventional subdirectories
+   - `agents/<agent>.md` files (the named-persona-experts) under conventional subdirectories
    - One or more hook configurations (per B-0173)
    - Tools under `tools/` (TS files per Aaron skill-design rule 2)
    - References to OpenSpec capabilities the plugin contracts against (per B-0171)
-2. Plugin manifest (`plugin.json` per Anthropic spec) with description + dependencies + capabilities
+2. Codex equivalent uses `.codex-plugin/plugin.json` with richer fields (semver + interface block + URLs + category) per the cross-harness research at `docs/research/codex-builtins-skills-vs-plugins-factory-integration-2026-04-24.md`
 3. Cross-harness portability documentation: how Codex / Cursor / Gemini-CLI consume the equivalent substrate (per Aaron 2026-05-02 *"skills are for everyone and even other agent harnesses"*)
 
 ## Cross-harness consideration


### PR DESCRIPTION
## Summary

3 substantive Copilot post-merge findings on PR #1261 (already merged):

1. **B-0172 plugin location wrong**: `.claude/plugins/<name>/` → `~/.claude/plugins/cache/<plugin-name>/`
2. **B-0172 manifest wrong**: top-level `plugin.json` → `.claude-plugin/plugin.json` (Claude Code) / `.codex-plugin/plugin.json` (Codex)
3. **B-0173 hook path wrong**: `tools/git-hooks/` → `tools/git/hooks/`

All verified empirically against repo state + existing research docs (`docs/research/codex-builtins-skills-vs-plugins-factory-integration-2026-04-24.md`; `ls tools/git/`).

The 4th Copilot finding (B-0173 depends_on B-0170 not on main yet) resolves automatically when PR #1260 lands — B-0170 ships in that PR. False-positive on timing.

## Pattern

These are verify-then-claim drift instances of the **existence-drift sub-class**: claimed locations/conventions without verifying canonical surfaces. Each would have been caught by the v1+ existence-check sub-class of substrate-claim-checker (B-0170).

## Test plan

- [x] B-0172 plugin location updated to `~/.claude/plugins/cache/<plugin-name>/`
- [x] B-0172 manifest path updated to `.claude-plugin/plugin.json` with Codex equivalent noted
- [x] B-0173 hook path updated to `tools/git/hooks/` (2 occurrences)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)