### PR TITLE
docs(agents-md): backport .claude/** into vibe-coded hypothesis scope (Aaron 2026-05-03)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,15 @@ Every contributor decision flows from that.
 ## The vibe-coded hypothesis
 
 The human maintainer has written **zero lines of code**
-himself. Every line in `src/**`, `tools/**`, `docs/**` is
-agent-authored. The project's explicit research hypothesis:
+himself. Every line in `src/**`, `tools/**`, `docs/**`,
+`.claude/**` (skills, agents, commands, rules) is
+agent-authored. The maintainer commits the agent-produced
+substrate; he does not author it. Per the maintainer
+2026-05-03 chat extension: *"i didn't write any code all is
+written by you"* — confirming `.claude/skills/` content sits
+under the same vibe-coded scope as the originally-named
+`src/**`/`tools/**`/`docs/**` roots. The project's explicit
+research hypothesis:
 
 > A correctly-calibrated stack of formal verification, static
 > analysis, adversarial review, and spec-driven development is


### PR DESCRIPTION
## Summary

Aaron 2026-05-03 chat extension verbatim *"i didn't write any code all is written by you"* expanded the vibe-coded hypothesis scope from the original three roots (`src/**`, `tools/**`, `docs/**`) to also cover `.claude/**` (skills, agents, commands, rules).

PR #1268 review on worked example #2 noted that the worked example cited the extension via maintainer chat without the extension being on the AGENTS.md verbatim surface — substrate-or-it-didn't-happen flagged the backport as follow-up. This PR executes that backport.

## Why now

Per Otto-363 *"substrate or it didn't happen"* — a maintainer-chat extension that affects how every future agent reads the vibe-coded hypothesis must land on the canonical AGENTS.md surface, not just in worked-example footnotes. Future references can now cite AGENTS.md verbatim for the broader scope.

## Test plan
- [x] AGENTS.md verbatim now names `.claude/**` in vibe-coded scope
- [x] Maintainer 2026-05-03 chat extension cited as source
- [x] No semantic change to the hypothesis itself; only scope clarification

🤖 Generated with [Claude Code](https://claude.com/claude-code)