### PR TITLE
free-memory: persona-table expansion — named-agents vs end-user + PR Copilot first-class (Aaron 2026-05-03)

### DIFF
--- a/memory/feedback_dst_justifies_ts_quality_over_bash_and_harness_hooks_suffice_no_git_hooks_aaron_2026_05_03.md
+++ b/memory/feedback_dst_justifies_ts_quality_over_bash_and_harness_hooks_suffice_no_git_hooks_aaron_2026_05_03.md
@@ -55,14 +55,28 @@ Aaron 2026-05-03: *"vibe coders will never be without a harness of some kind"* +
 
 Aaron 2026-05-03: *"can we count on our install/setup has run for contributors and/or maintainers, yes, so we can count on bun here too then, not for skills we send out via skill bundles for pepole who only resued they have cluade hooks, we maintiners and contributors can have both and both on ts."*.
 
-**Tracked end-user personas (per Aaron 2026-05-03 — *"we should start keeping us with our end user persona contrbutor maintainer skill bundle user, there will be more over time"*)**:
+**Persona vocabulary distinction (Aaron 2026-05-03 — *"now we have ai agents that are named and personas that are end user ai and human personas"*)**:
 
-| Persona | Bun availability | Hook options |
-|---|---|---|
-| **Contributor** (runs `tools/setup/install.sh`) | Yes (installed bun) | Could have both git hooks AND harness hooks, both in TS |
-| **Maintainer** (also runs install) | Yes | Same as contributor |
-| **Skill-bundle user** (uses plugins via harness) | Only via harness's runtime | Harness hooks only |
-| *(more personas over time)* | TBD | TBD |
+There are two distinct persona axes:
+
+1. **Named AI agents** (internal to Zeta's identity): Otto, Soraya, Daya, Aarav, Nadia, etc. These are the project's internal-cognition personas — they have notebooks, history surfaces, and contribute as named contributors per Otto-279
+2. **End-user personas** (external consumers of Zeta substrate): both human (contributor / maintainer / skill-bundle user) AND AI (PR Copilot, external Codex / Cursor / Aider reviewers, etc.)
+
+This memo's table covers **end-user personas** (axis 2). Internal named-agent personas are tracked separately (per the Otto-279 history-surface attribution carve-out + persona notebooks under `memory/persona/`).
+
+**Tracked end-user personas (per Aaron 2026-05-03 — *"we should start keeping us with our end user persona contrbutor maintainer skill bundle user, there will be more over time"* + *"the pr copilot ... yes that's a first class personal any any exteranl ai like that that could benefit from our runtime"*)**:
+
+| Persona | Type | Bun availability | What they execute |
+|---|---|---|---|
+| **Contributor** (runs `tools/setup/install.sh`) | Human | Yes (installed bun) | Could run git hooks + harness hooks, both in TS |
+| **Maintainer** (also runs install) | Human | Yes | Same as contributor |
+| **Skill-bundle user** (uses plugins via harness) | Human | Only via harness's runtime | Harness hooks only |
+| **PR Copilot reviewer** (default static) | AI | N/A — doesn't execute | Static analysis only; reads + flags issues |
+| **PR Copilot reviewer** (with `copilot-setup-steps.yml`) | AI | Yes (via our setup) | Both bash + TS executable; can verify findings by running tools |
+| **Other external-AI PR reviewers** (Codex, Cursor, Aider, Gemini-CLI, etc.) | AI | Conditional per their integration | Static or executable depending on setup |
+| *(more personas over time)* | TBD | TBD | TBD |
+
+**Architectural commitment**: external AI reviewers that could benefit from our runtime are first-class personas, not afterthoughts. When designing infrastructure (CI workflows, install scripts, distribution mechanisms), include rows for external-AI personas in the planning table.
 
 **Even for contributors/maintainers**, harness hooks cover the use cases git hooks would. Aaron's analysis (confirming Otto's):
 


### PR DESCRIPTION
## Summary

Follow-up to #1313 expanding the persona-table with two Aaron 2026-05-03 refinements:

1. **Named AI agents vs end-user personas** distinction (axes-of-persona-tracking) — internal-cognition (Otto, Soraya, Daya) is one axis; external consumers (humans + AIs) is another
2. **PR Copilot + external-AI reviewers as first-class personas** — *"the pr copilot ... yes that's a first class personal any any exteranl ai like that that could benefit from our runtime"*

## Updated table

Now includes:
- **Type** column (Human / AI)
- **PR Copilot reviewer** (split into default-static + with-`copilot-setup-steps.yml` rows)
- **Other external-AI PR reviewers** row
- Architectural-commitment statement: external AI reviewers are first-class

## Implementation note

GitHub's official mechanism for giving PR Copilot a setup pipeline is `copilot-setup-steps.yml` (job name `copilot-setup-steps` is required). Example pattern visible at `references/upstreams/efcore/.github/workflows/copilot-setup-steps.yml`. Adopting this for Zeta would let PR Copilot execute our TS tools during review — but that's a separate architectural decision (separate PR if/when we proceed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)