### PR TITLE
feat(substrate-claim-checker): v0.6.0 — gitignore awareness for existence-drift

### DIFF
--- a/tools/substrate-claim-checker/README.md
+++ b/tools/substrate-claim-checker/README.md
@@ -22,7 +22,7 @@ bun tools/substrate-claim-checker/check-counts.ts <file>
 bun tools/substrate-claim-checker/check-counts.ts memory/feedback_*.md
 ```
 
-Exit code 0 = no drift detected. Exit code 1 = drift detected (or
+Exit code 0 = no drift detected (warnings alone are non-blocking per the v0.6 severity model — see "v0.6 — gitignore awareness for existence-drift" below). Exit code 1 = drift detected (or
 input error).
 
 ## What it does (v0)
@@ -147,3 +147,22 @@ bun tools/substrate-claim-checker/check-existence.ts <file1> <file2> ...
 ```
 
 Exit codes match check-counts.ts: `0` clean, `1` drift detected or input error.
+
+## v0.6 — gitignore awareness for existence-drift
+
+Extends `check-existence.ts` to flag a new sub-class: paths that exist on disk but are gitignored. Per substrate convention, references should point to git-tracked paths or stable URLs, NOT to local-mirror sync state (e.g., `references/upstreams/*` which is gitignored per the upstream-mirror sync convention).
+
+### Empirical seed
+
+PR #1322 review found `references/upstreams/efcore/.github/workflows/copilot-setup-steps.yml` referenced in a tick shard. The path exists on disk (synced from upstream efcore) but is gitignored. Pre-v0.6, `check-existence.ts` reported "no drift" because the path resolved on disk; v0.6 emits a warning.
+
+### Severity model (new in v0.6)
+
+- **drift** (severity `"drift"`): path doesn't exist anywhere — exit code 1
+- **warning** (severity `"warning"`): path exists on disk but is gitignored — exit code 0 (substrate-quality concern but not blocking)
+
+If both are present, drift wins for exit code (1).
+
+### Implementation
+
+Uses `git check-ignore --quiet <path>` via `spawnSync` (no shell — avoids command injection) to ask git directly. Exit code 0 from git = path IS gitignored; exit code 1 = NOT gitignored. The 5-second timeout guards against pathological cases.

--- a/tools/substrate-claim-checker/check-existence.test.ts
+++ b/tools/substrate-claim-checker/check-existence.test.ts
@@ -251,3 +251,137 @@ describe("findPathClaims - angle-bracket link targets", () => {
     expect(claims.map((c) => c.path).sort()).toEqual(["docs/angled.md", "docs/normal.md"]);
   });
 });
+
+describe("checkFile - v0.6 gitignore awareness", () => {
+  // Build a self-contained git repo with .gitignore + tracked + ignored
+  // files so the tests work on fresh clones / CI without the
+  // developer-local references/upstreams/ mirror.
+  function setupGitignoreFixture(): { repoRoot: string; mdFile: string; cleanup: () => void } {
+    const repoRoot = mkdtempSync(join(tmpdir(), "check-existence-gitignore-"));
+    const { spawnSync } = require("node:child_process");
+    spawnSync("git", ["init", "--quiet"], { cwd: repoRoot, stdio: "ignore" });
+    spawnSync("git", ["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
+    spawnSync("git", ["config", "user.name", "test"], { cwd: repoRoot, stdio: "ignore" });
+    writeFileSync(join(repoRoot, ".gitignore"), "ignored-dir/\n");
+    require("node:fs").mkdirSync(join(repoRoot, "ignored-dir"), { recursive: true });
+    writeFileSync(join(repoRoot, "ignored-dir", "ghosts.md"), "# Ignored");
+    writeFileSync(join(repoRoot, "tracked.md"), "# Tracked");
+    spawnSync("git", ["add", ".gitignore", "tracked.md"], { cwd: repoRoot, stdio: "ignore" });
+    spawnSync("git", ["commit", "-m", "init", "--quiet"], { cwd: repoRoot, stdio: "ignore" });
+    const mdFile = join(repoRoot, "test.md");
+    return {
+      repoRoot,
+      mdFile,
+      cleanup: () => {
+        try { require("node:fs").rmSync(repoRoot, { recursive: true, force: true }); } catch {}
+      },
+    };
+  }
+
+  test("flags exists-on-disk-but-gitignored as warning", () => {
+    const fx = setupGitignoreFixture();
+    try {
+      writeFileSync(
+        fx.mdFile,
+        "# Test\n\nSee `ignored-dir/ghosts.md` for the canonical pattern.\n",
+      );
+      const result = checkFile(fx.mdFile);
+      expect(result.ok).toBe(true);
+      const gitignoredFindings = result.findings.filter(
+        (f) => f.severity === "warning" && f.reason.includes("gitignored"),
+      );
+      expect(gitignoredFindings.length).toBeGreaterThan(0);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("git-tracked path produces no findings", () => {
+    const fx = setupGitignoreFixture();
+    try {
+      writeFileSync(
+        fx.mdFile,
+        "# Test\n\nSee `tracked.md` for the implementation.\n",
+      );
+      const result = checkFile(fx.mdFile);
+      expect(result.ok).toBe(true);
+      expect(result.findings).toEqual([]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("severity is 'drift' for non-existent paths and 'warning' for gitignored", () => {
+    const fx = setupGitignoreFixture();
+    try {
+      writeFileSync(
+        fx.mdFile,
+        `# Test\n\nMissing: \`does/not/exist-${Date.now()}.md\`\n\nGitignored: \`ignored-dir/ghosts.md\`\n`,
+      );
+      const result = checkFile(fx.mdFile);
+      expect(result.ok).toBe(true);
+      const driftFindings = result.findings.filter((f) => f.severity === "drift");
+      const warningFindings = result.findings.filter((f) => f.severity === "warning");
+      expect(driftFindings.length).toBeGreaterThan(0);
+      expect(warningFindings.length).toBeGreaterThan(0);
+    } finally {
+      fx.cleanup();
+    }
+  });
+});
+
+describe("main CLI - v0.6 exit codes", () => {
+  // Re-uses the gitignore fixture pattern from above. Tests the
+  // CLI behavior + exit-code contract for warning-only / drift-only /
+  // mixed runs.
+  function setupGitignoreFixture(): { repoRoot: string; mdFile: string; cleanup: () => void } {
+    const repoRoot = mkdtempSync(join(tmpdir(), "check-existence-cli-"));
+    const { spawnSync: spawnSyncCp } = require("node:child_process");
+    spawnSyncCp("git", ["init", "--quiet"], { cwd: repoRoot, stdio: "ignore" });
+    spawnSyncCp("git", ["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
+    spawnSyncCp("git", ["config", "user.name", "test"], { cwd: repoRoot, stdio: "ignore" });
+    writeFileSync(join(repoRoot, ".gitignore"), "ignored-dir/\n");
+    require("node:fs").mkdirSync(join(repoRoot, "ignored-dir"), { recursive: true });
+    writeFileSync(join(repoRoot, "ignored-dir", "ghosts.md"), "# Ignored");
+    writeFileSync(join(repoRoot, "tracked.md"), "# Tracked");
+    spawnSyncCp("git", ["add", ".gitignore", "tracked.md"], { cwd: repoRoot, stdio: "ignore" });
+    spawnSyncCp("git", ["commit", "-m", "init", "--quiet"], { cwd: repoRoot, stdio: "ignore" });
+    const mdFile = join(repoRoot, "test.md");
+    return {
+      repoRoot,
+      mdFile,
+      cleanup: () => {
+        try { require("node:fs").rmSync(repoRoot, { recursive: true, force: true }); } catch {}
+      },
+    };
+  }
+
+  test("warning-only run produces warning finding (exit code 0 contract)", () => {
+    const fx = setupGitignoreFixture();
+    try {
+      writeFileSync(fx.mdFile, "# Test\n\nWarning: `ignored-dir/ghosts.md`\n");
+      const result = checkFile(fx.mdFile);
+      expect(result.ok).toBe(true);
+      // All findings are warnings; main() should return 0 for this case.
+      // We test the underlying severity model (the contract that main()
+      // depends on); main()'s exit-code branch reads f.severity.
+      const allWarnings = result.findings.length > 0 && result.findings.every((f) => f.severity === "warning");
+      expect(allWarnings).toBe(true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("drift-only run produces drift finding (exit code 1 contract)", () => {
+    const fx = setupGitignoreFixture();
+    try {
+      writeFileSync(fx.mdFile, `# Test\n\nMissing: \`does/not/exist-${Date.now()}.md\`\n`);
+      const result = checkFile(fx.mdFile);
+      expect(result.ok).toBe(true);
+      const allDrift = result.findings.length > 0 && result.findings.every((f) => f.severity === "drift");
+      expect(allDrift).toBe(true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+});

--- a/tools/substrate-claim-checker/check-existence.ts
+++ b/tools/substrate-claim-checker/check-existence.ts
@@ -1,13 +1,23 @@
 #!/usr/bin/env bun
 /**
- * substrate-claim-checker / check-existence.ts (v0.5.0)
+ * substrate-claim-checker / check-existence.ts (v0.6.0)
  *
  * Existence-drift sub-class checker — catches claims that a file or
  * directory exists when it doesn't. Per the verify-then-claim memo,
  * one of 7 sub-classes B-0170 v1+ should mechanize.
+ *
+ * v0.6 changes:
+ * - Gitignore awareness: paths that exist on disk but are gitignored
+ *   are flagged as "exists-on-disk-not-in-git" findings (substrate
+ *   convention: references should point to git-tracked paths or stable
+ *   URLs, not to local-mirror sync state). Caught via `git check-ignore`.
+ *   Empirical seed: PR #1322 review found `references/upstreams/efcore/...`
+ *   reference in a tick shard; references/upstreams/* is gitignored per
+ *   the upstream-mirror sync convention.
  */
 
 import { readFileSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 interface Finding {
@@ -15,6 +25,8 @@ interface Finding {
   line: number;
   pathClaim: string;
   reason: string;
+  /** v0.6: severity hint for downstream filtering. */
+  severity?: "drift" | "warning";
 }
 
 interface PathClaim {
@@ -47,6 +59,35 @@ function statExists(p: string): {
       isDirectory: false,
       errorCode: err.code ?? "EUNKNOWN",
     };
+  }
+}
+
+/**
+ * Check whether a path is gitignored, by invoking `git check-ignore`.
+ * Returns true if the path matches a gitignore rule (would not be tracked
+ * by git).
+ *
+ * Uses spawnSync (no shell) per the project's avoid-command-injection
+ * discipline. The path argument is passed as a separate argv entry.
+ *
+ * Edge cases:
+ * - If git is not on PATH (highly unusual), returns false (safe default —
+ *   don't flag everything as gitignored)
+ * - If path is outside the git working tree, returns false
+ * - If git returns 0, the path IS gitignored; if 1, it's NOT; other exit
+ *   codes treated as "unknown — assume not gitignored"
+ */
+function isGitIgnored(absPath: string, repoRoot: string): boolean {
+  try {
+    const result = spawnSync("git", ["check-ignore", "--quiet", absPath], {
+      cwd: repoRoot,
+      stdio: "ignore",
+      timeout: 5000,
+    });
+    // Exit 0 = path IS gitignored; Exit 1 = NOT gitignored; other = unknown
+    return result.status === 0;
+  } catch {
+    return false;
   }
 }
 
@@ -258,6 +299,7 @@ function checkFile(filePath: string): CheckResult {
     if (isFutureStateContext(lineText, before, after)) continue;
 
     let isResolvedClaim = false;
+    let resolvedAbsPath: string | null = null;
     let unreadableButExtant = false; // EACCES/EPERM/etc. — can't tell
     const triedRelative: string[] = [];
     for (const root of candidateRoots) {
@@ -268,6 +310,7 @@ function checkFile(filePath: string): CheckResult {
       const stat = statExists(absPath);
       if (stat.exists) {
         isResolvedClaim = true;
+        resolvedAbsPath = absPath;
         break;
       }
       if (stat.errorCode && stat.errorCode !== "ENOENT") {
@@ -281,7 +324,22 @@ function checkFile(filePath: string): CheckResult {
         line: claim.line,
         pathClaim: claim.path,
         reason: `path does not exist (tried relative-to-repo: ${triedRelative.join(", ")})`,
+        severity: "drift",
       });
+    } else if (isResolvedClaim && resolvedAbsPath !== null) {
+      // v0.6: path exists on disk — but is it git-tracked? Substrate
+      // references should point to git-tracked paths or stable URLs,
+      // NOT to local-mirror sync state (e.g., `references/upstreams/*`
+      // which is gitignored per the upstream-mirror sync convention).
+      if (isGitIgnored(resolvedAbsPath, repoRoot)) {
+        findings.push({
+          file: filePath,
+          line: claim.line,
+          pathClaim: claim.path,
+          reason: `path exists on disk but is gitignored (resolves to ${toRelative(resolvedAbsPath)}) — substrate references should point to git-tracked paths or stable URLs, not local-mirror sync state`,
+          severity: "warning",
+        });
+      }
     }
   }
   return { findings, ok: true };
@@ -296,7 +354,8 @@ export function main(): number {
     console.error("usage: bun tools/substrate-claim-checker/check-existence.ts <file> [<file> ...]");
     return 1;
   }
-  let totalFindings = 0;
+  let totalDrift = 0;
+  let totalWarnings = 0;
   let inputErrors = 0;
   for (const arg of args) {
     const { findings, ok } = checkFile(arg);
@@ -305,17 +364,27 @@ export function main(): number {
       continue;
     }
     for (const f of findings) {
-      console.log(`${f.file}:${f.line}: existence drift — claim "${f.pathClaim}" — ${f.reason}`);
-      totalFindings++;
+      const label = f.severity === "warning" ? "existence warning" : "existence drift";
+      console.log(`${f.file}:${f.line}: ${label} — claim "${f.pathClaim}" — ${f.reason}`);
+      if (f.severity === "warning") {
+        totalWarnings++;
+      } else {
+        totalDrift++;
+      }
     }
   }
   if (inputErrors > 0) {
     console.error(`\n${inputErrors} input error(s).`);
     return 1;
   }
-  if (totalFindings > 0) {
-    console.log(`\n${totalFindings} existence-drift finding(s).`);
-    return 1;
+  if (totalDrift > 0 || totalWarnings > 0) {
+    const parts: string[] = [];
+    if (totalDrift > 0) parts.push(`${totalDrift} drift finding(s)`);
+    if (totalWarnings > 0) parts.push(`${totalWarnings} warning(s)`);
+    console.log(`\n${parts.join(", ")}.`);
+    // Drift findings are real failures (exit 1); warnings alone exit 0
+    // (substrate-quality concern but not blocking) per v0.6 design.
+    return totalDrift > 0 ? 1 : 0;
   }
   console.log("no existence drift detected.");
   return 0;


### PR DESCRIPTION
## Summary

Extends check-existence.ts (v0.5) with gitignore awareness — paths that exist on disk but are gitignored emit a warning. Empirical seed: PR #1322 review caught a gitignored upstream-mirror path referenced as canonical pattern.

## Severity model (new)

| Severity | Condition | Exit |
|---|---|---|
| `drift` | Path doesn't exist anywhere | 1 |
| `warning` | Path exists on disk but is gitignored | 0 |

Drift wins exit code if both present.

## Implementation

`spawnSync('git', ['check-ignore', '--quiet', absPath])` — no shell, no command injection. 5-second timeout. Exit 0 = gitignored, 1 = not, other = unknown (treated as not-gitignored).

## Tests

3 new tests; 51 total across the dir, all pass.

## Sanity-check on main

- `references/upstreams/efcore/.github/workflows/copilot-setup-steps.yml` → **warning** (exists on disk, gitignored)
- `does/not/exist.md` → **drift** (doesn't exist)
- `tools/substrate-claim-checker/check-existence.ts` → **no findings** (git-tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)