### PR TITLE
fix(#1341 post-merge): B-0176 title casing — capitalized to match sibling-row convention

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -136,7 +136,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0172](backlog/P2/B-0172-skill-domain-plugin-packaging-aaron-2026-05-03.md)** Skill-domain plugin packaging — package mature skill domains as Claude Code plugins (Aaron 2026-05-03 rule 3a from skill-design memo)
 - [ ] **[B-0174](backlog/P2/B-0174-cross-model-tool-review-convergence-rate-replay-otto-2026-05-03.md)** Cross-model tool-review convergence-rate replay protocol — measure how many review rounds different models need to settle on a tool-authoring PR (Otto 2026-05-03 sibling-instance of multi-harness convergence skill domain)
 - [ ] **[B-0175](backlog/P2/B-0175-substrate-retrieval-index-active-in-flight-matcher-aaron-2026-05-03.md)** Substrate-retrieval-index — active in-flight matcher for memos + carved sentences (Aaron 2026-05-03 'specialed indeex we build over time'; addresses 4-layer retrieval gap empirically self-demonstrated)
-- [ ] **[B-0176](backlog/P2/B-0176-substrate-claim-checker-v07-context-aware-suppression-otto-2026-05-03.md)** substrate-claim-checker v0.7 — context-aware suppression for hypothetical / contrastive / partial-path / branch-name references (Otto 2026-05-03 empirical observation)
+- [ ] **[B-0176](backlog/P2/B-0176-substrate-claim-checker-v07-context-aware-suppression-otto-2026-05-03.md)** Substrate-claim-checker v0.7 — context-aware suppression for hypothetical / contrastive / partial-path / branch-name references (Otto 2026-05-03 empirical observation)
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-0176-substrate-claim-checker-v07-context-aware-suppression-otto-2026-05-03.md
+++ b/docs/backlog/P2/B-0176-substrate-claim-checker-v07-context-aware-suppression-otto-2026-05-03.md
@@ -2,7 +2,7 @@
 id: B-0176
 priority: P2
 status: open
-title: substrate-claim-checker v0.7 — context-aware suppression for hypothetical / contrastive / partial-path / branch-name references (Otto 2026-05-03 empirical observation)
+title: Substrate-claim-checker v0.7 — context-aware suppression for hypothetical / contrastive / partial-path / branch-name references (Otto 2026-05-03 empirical observation)
 tier: tooling
 effort: M
 ask: Otto self-derived 2026-05-03 from v0.6 retroactive eval (PR #1329) finding 7 drift items mostly from a recurring false-positive class; subsequent 0603Z drift exploration confirmed the class


### PR DESCRIPTION
## Summary

2 P1 review findings on merged #1341:

- Line 16 (B-0176 frontmatter \`title:\`): lowercase \`substrate-claim-checker\` vs sibling-row convention (B-0170 uses capitalized \`Substrate-claim-checker\`)
- Line 139 (BACKLOG.md regenerated entry): same casing issue propagated from the title

## Fix

- Title: \`substrate-claim-checker v0.7\` → \`Substrate-claim-checker v0.7\`
- BACKLOG.md regenerated; the new entry now uses the capitalized form matching B-0170

## Pattern reinforcement

Continues the post-merge-thread-loop diamond-formation pattern: each follow-up amend lands as a small precision-improvement; cumulative across many PRs the substrate hardens into diamond-quality precision. This is the 4th post-merge bounded-fix landed this session.

## Test plan

- [x] B-0176 title now matches sibling-row casing convention
- [x] BACKLOG.md regenerated with updated casing
- [x] markdownlint passes locally