### PR TITLE
fix(#1343 post-merge): B-0176 H1 casing parity with frontmatter title

### DIFF
--- a/docs/backlog/P2/B-0176-substrate-claim-checker-v07-context-aware-suppression-otto-2026-05-03.md
+++ b/docs/backlog/P2/B-0176-substrate-claim-checker-v07-context-aware-suppression-otto-2026-05-03.md
@@ -13,7 +13,7 @@ composes_with: [B-0175]
 tags: [substrate-claim-checker, false-positive, context-aware, hypothetical, contrastive, drift, severity-tier, tooling]
 ---
 
-# substrate-claim-checker v0.7 — context-aware suppression
+# Substrate-claim-checker v0.7 — context-aware suppression
 
 ## Origin
 


### PR DESCRIPTION
## Summary

P2 review finding on merged #1343: the frontmatter \`title:\` was capitalized to \`Substrate-claim-checker\` (matching B-0170 sibling-row convention), but the H1 in the body still used lowercase \`# substrate-claim-checker...\`. Mismatch between page title and frontmatter.

## Fix

H1: \`# substrate-claim-checker v0.7\` → \`# Substrate-claim-checker v0.7\`

Now consistent: frontmatter \`title:\`, BACKLOG.md entry, and H1 all use the capitalized form.

## Pattern

This is the second-order convention-drift case: fixing one casing site (frontmatter) revealed another (H1). Future-Otto pre-commit check expanded: when fixing convention-drift in artifact A, scan for ALL sites within the artifact that share the same convention class.

## Test plan

- [x] H1 now matches frontmatter title casing
- [x] markdownlint passes locally