### PR TITLE
fix(#1346 post-merge): B-0177 typo — 'scoped scope' → 'bounded scope'

### DIFF
--- a/docs/backlog/P2/B-0177-audit-memos-for-misfiled-backlog-rows-aaron-2026-05-03.md
+++ b/docs/backlog/P2/B-0177-audit-memos-for-misfiled-backlog-rows-aaron-2026-05-03.md
@@ -24,7 +24,7 @@ Aaron 2026-05-03, autonomous-loop maintainer channel. Otto was looking for an ex
 This identifies a substrate-architecture failure mode: **memos got authored in memory/ where backlog rows should have been filed in docs/backlog/**. The two surfaces have different roles:
 
 - **memory/feedback_*.md** — observations, framings, rules, doctrine absorbed from external sources
-- **docs/backlog/P*/B-NNNN-*.md** — actionable work items with stable IDs, tier/effort/ask metadata, scoped scope
+- **docs/backlog/P*/B-NNNN-*.md** — actionable work items with stable IDs, tier/effort/ask metadata, bounded scope
 
 When an item that should have been a backlog row gets authored as a memo, three failure modes:
 


### PR DESCRIPTION
Single-line typo fix: 'scoped scope' was a duplication; replaced with 'bounded scope' which is the intended meaning per the surrounding 'tier/effort/ask metadata' context.