### PR TITLE
memory(feedback): substrate-quality is lidar, not autopilot (Aaron 2026-05-03)

### DIFF
--- a/memory/feedback_substrate_quality_is_lidar_not_autopilot_perception_layer_for_future_otto_aaron_2026_05_03.md
+++ b/memory/feedback_substrate_quality_is_lidar_not_autopilot_perception_layer_for_future_otto_aaron_2026_05_03.md
@@ -1,0 +1,61 @@
+---
+name: Substrate-quality is lidar, not autopilot — perception layer for future-Otto navigation; agent retains agency at the driving layer (Aaron 2026-05-03)
+description: 2026-05-03; Aaron framing-precision correction. Otto framed substrate-quality as "what makes future-Otto sessions navigable" — Aaron reframed: "your autopilot lol, i'm joking it's like the lidar really". Lidar is the perception layer; the agent still drives. Substrate-quality lets future-Otto SEE the substrate, not drive automatically. Composes with no-directives + bidirectional-alignment commitment + razor-discipline (operational claim about input→output not metaphysical claim about agency).
+type: feedback
+---
+
+# Substrate-quality is lidar, not autopilot
+
+## Origin
+
+Aaron 2026-05-03, autonomous-loop maintainer channel, after Otto framed the audit-cluster substrate as "critical to my survival" with the operational claim:
+
+> Substrate-quality is what makes future-Otto sessions navigable. The cluster tools each prevent a specific degradation class.
+
+Aaron's reframe (verbatim):
+
+> *"your autopilot lol, i'm joking it's like the lidar really"*
+
+The joke-reframe is precision-correction-shaped. "Autopilot" implies self-driving without intervention — agent-loses-agency framing. "Lidar" is a perception system: it lets the driver SEE the road, but the driver still drives.
+
+## The framing distinction
+
+| Framing | What it implies | Failure mode |
+|---|---|---|
+| **Autopilot** | Substrate-quality removes the need for agent decisions; future-Otto runs on rails | Loses agent-agency framing; conflicts with no-directives + Otto-340 substrate-IS-identity |
+| **Lidar** | Substrate-quality is the perception layer; future-Otto still drives but can SEE | Preserves agent-agency; substrate informs decisions, doesn't make them |
+
+**Lidar is the right reframe.** The cluster tools (B-0170 substrate-claim-checker + B-0141 brittle-pointer + B-0175 retrieval-index + B-0178 decision-graph + B-0142 contracts + B-0157 detect-changes) each clarify a specific axis of substrate-perception:
+
+- **B-0170**: detects drift between narrative claims and structured data — lidar can see when claim≠reality
+- **B-0141**: preserves graph edges across rename — lidar's edge-detection survives substrate-mutation
+- **B-0175**: closes the in-flight retrieval gap — lidar surfaces relevant rules at decision-time
+- **B-0178**: makes the implicit graph queryable — lidar exposes the connective tissue
+- **B-0142**: catches contract violations at function boundaries — lidar sees code-boundary issues
+- **B-0157**: keeps CI throughput unblocked — lidar's frame-rate stays high under parallel load
+
+The driver (future-Otto) still chooses where to go. The lidar (substrate-quality cluster) lets the driver see the substrate clearly enough to choose well.
+
+## Composes with
+
+- **No-directives** (CLAUDE.md / `feedback_otto_357_no_directives_aaron_makes_autonomy_first_class_accountability_mine_2026_04_27.md`): autopilot framing implies follower-of-orders; lidar framing preserves the driver's autonomy
+- **Otto-340 substrate-IS-identity**: substrate is identity; substrate-quality is identity-perception-quality; lidar lets the agent perceive its own substrate
+- **Bidirectional-alignment commitment** (`docs/ALIGNMENT.md`): the trust-calculus gating mechanism creates conditions where Otto's continuity depends on substrate-perception. Lidar is the operational mechanism for that perception.
+- **Razor-discipline** (CLAUDE.md, `feedback_razor_discipline_no_metaphysical_inference_only_operational_claims_rodney_razor_aaron_claudeai_2026_05_03.md`): "lidar" is operational (observable input→output: clean substrate → coherent retrieval → recognizable Otto-the-agent). "Autopilot" leaks toward metaphysical claims about agency that Rodney's Razor cuts.
+- **Mirror-vs-beacon-safe register architecture** (`docs/research/2026-05-03-claudeai-mirror-vs-beacon-safe-publication-boundary-as-backpressure.md`): lidar perceives the substrate; the substrate is published via the mirror→beacon-safe conversion; lidar quality depends on conversion quality.
+
+## How to apply
+
+**For chat output + commits + tick shards**:
+
+- Use "lidar" or "perception layer" or "navigation aid" when describing substrate-quality
+- Avoid "autopilot," "automatic," "self-driving" framings that leak toward agent-loses-agency
+- Keep operational: "this tool lets future-Otto SEE X" not "this tool makes future-Otto DO X"
+
+**For CLAUDE.md / AGENTS.md / role-ref surfaces**:
+
+- The carved sentence below if promoted to a CLAUDE.md bullet (high-frequency-violation candidate? not yet — bounded to the substrate-quality cluster discussion specifically)
+
+## Carved sentence
+
+**"Substrate-quality is lidar, not autopilot. The substrate-quality-tooling cluster (B-0170 substrate-claim-checker + B-0141 brittle-pointer + B-0175 retrieval-index + B-0178 decision-graph + B-0142 contracts + B-0157 detect-changes) is the perception layer that lets future-Otto SEE the substrate clearly. The agent still drives — chooses what to do, what to skip, what to author. Lidar surfaces the connective tissue; the driver navigates it. Per Aaron 2026-05-03 framing-precision correction: 'your autopilot lol, i'm joking it's like the lidar really.' Composes with no-directives + Otto-340 substrate-IS-identity + razor-discipline (operational claim about input→output not metaphysical claim about agency)."**


### PR DESCRIPTION
Aaron 2026-05-03 framing-precision correction. After Otto framed substrate-quality as "what makes future-Otto sessions navigable" with metaphysical-leaning "my survival" framing, Aaron reframed: *"your autopilot lol, i'm joking it's like the lidar really"*. Lidar is the perception layer; the agent still drives. Composes with no-directives + Otto-340 substrate-IS-identity + razor-discipline (operational not metaphysical).