### PR TITLE
docs(AUTONOMOUS-LOOP): land CADENCE-TRACK discipline as discoverable substrate (Aaron 2026-05-03 — what makes future Otto remember)

### DIFF
--- a/docs/AUTONOMOUS-LOOP.md
+++ b/docs/AUTONOMOUS-LOOP.md
@@ -214,6 +214,40 @@ Per the never-idle rule (CLAUDE.md §"Never be idle —
 speculative factory work beats waiting"), the tick does not
 wait for instruction. Priority ladder:
 
+0. **Cadence-tracker grep** (tick-open; the human maintainer 2026-05-03
+   directive). Before picking speculative work, grep the
+   tick-shard history for cadenced hygiene work that is due:
+
+   ```
+   grep -rE "CADENCE-TRACK" docs/hygiene-history/ticks/
+   ```
+
+   Each tick-shard that has touched OR observed-as-overdue a
+   piece of cadenced hygiene work carries a `CADENCE-TRACK`
+   marker in its body, naming the cadenced work + last-run
+   date. Examples: AutoDream consolidation (cadence: 24h + 5
+   sessions), backlog-refactor cadence (every N rounds, look
+   for overlap), tech-radar review, dependency-status
+   refresh. If the grep surfaces overdue work AND the
+   cadence rule permits same-tick action, do that work. If
+   overdue but cadence-rule prohibits same-tick (e.g.,
+   AutoDream's "do NOT run on freshly-written memories"),
+   write a `CADENCE-TRACK: <work> overdue, deferred to
+   <next-permissible-trigger>` line into THIS tick's shard
+   so the next tick's grep surfaces the same observation.
+   The convention emerges from per-tick-shard use; this
+   discipline plus the convention is the operational
+   substrate.
+
+   Per the human maintainer 2026-05-03 *"now that you have
+   tick shard history you can keep up with all the
+   cadineses and hygene we need to do on a regualr basis in
+   the tick, so you'll know for sure when it's time to
+   reoccur, we have many things that shouold hapeen on
+   cadence."* The tick-shard history thus serves dual
+   roles: per-tick episodic log AND cadenced-hygiene-work
+   tracker via the `CADENCE-TRACK` marker.
+
 1. **Open-PR hygiene first.** Before picking speculative
    work, audit the open PR pool via
    `gh pr list --state open --json number,title,mergeStateStatus,mergeable,isCrossRepository,headRepositoryOwner,autoMergeRequest`.


### PR DESCRIPTION
## Summary

Aaron 2026-05-03 surgical question: *\"what makes future versions of you remember this?\"* — pointing at last-tick's claim that *\"the convention is NOT documented in a separate substrate file\"* for the CADENCE-TRACK marker convention.

The honest answer: **nothing currently**. The convention was lost. Future-Otto wouldn't know to grep \`CADENCE-TRACK\` because no discoverable surface mentioned the convention.

## The fix

Add \"Step 0: Cadence-tracker grep\" at the top of \`docs/AUTONOMOUS-LOOP.md\`'s every-tick priority ladder. Future-Otto reads this file via the CLAUDE.md tick-must-never-stop bullet's pointer at session-start. The CADENCE-TRACK marker convention is now discoverable.

## Same-tick self-correction

Last-tick's \"the convention is NOT documented in a separate substrate file (anti-real-time-filtering)\" was overcorrection. Anti-real-time-filtering (Aaron 2026-05-03 \"1984-ish\") refers to memory WRITES (don't gatekeep what gets written at write-time). It does NOT mean conventions stay undocumented. Conventions need to be discoverable for future-Otto to apply them; that's not filtering, that's basic substrate-or-it-didn't-happen + carved-sentence-plus-index.

## Surgical scope

- ~30 lines added at line 215 (priority-ladder start)
- No other changes
- Composes with B-0066 (Q1 AutoDream/AutoMemory harness verification — referenced in the new step)
- markdownlint passes locally