### PR TITLE
fix(tsc strict): no-op-cadence-pattern.ts — fallback for regex match groups

### DIFF
--- a/tools/hygiene/check-no-op-cadence-pattern.ts
+++ b/tools/hygiene/check-no-op-cadence-pattern.ts
@@ -96,8 +96,8 @@ export function collectShards(dir: string, dateFlat: string): Shard[] {
     const m2 = name.match(/^(\d{6})Z-([0-9a-f]+)\.md$/);
     if (m2) {
       shards.push({
-        primary: `${dateFlat}${m2[1]}`,
-        disamb: m2[2],
+        primary: `${dateFlat}${m2[1] ?? ""}`,
+        disamb: m2[2] ?? "",
         path: join(dir, name),
       });
     }

--- a/tools/hygiene/check-no-op-cadence-pattern.ts
+++ b/tools/hygiene/check-no-op-cadence-pattern.ts
@@ -94,10 +94,13 @@ export function collectShards(dir: string, dateFlat: string): Shard[] {
       continue;
     }
     const m2 = name.match(/^(\d{6})Z-([0-9a-f]+)\.md$/);
+    // Both capture groups are required by the regex — when m2 is
+    // truthy, m2[1] and m2[2] are guaranteed strings. Non-null
+    // assertions (vs `?? ""`) preserve the invariant explicitly.
     if (m2) {
       shards.push({
-        primary: `${dateFlat}${m2[1] ?? ""}`,
-        disamb: m2[2] ?? "",
+        primary: `${dateFlat}${m2[1]!}`,
+        disamb: m2[2]!,
         path: join(dir, name),
       });
     }


### PR DESCRIPTION
Post-#1366-merge tsc strict-mode error on line 100: `m2[2]` typed as `string | undefined`. Same on `m2[1]` template interpolation. Added `?? ""` fallbacks. Behavior unchanged (regex guarantees both groups exist when m2 is truthy).