### PR TITLE
ci(memory-index-duplicate-lint): switch from .sh to .ts via bun (lowest-risk first per #1376)

### DIFF
--- a/.github/workflows/memory-index-duplicate-lint.yml
+++ b/.github/workflows/memory-index-duplicate-lint.yml
@@ -19,19 +19,19 @@ name: memory-index-duplicate-lint
 #   - runs-on: ubuntu-24.04 pinned
 #
 # See:
-#   - tools/hygiene/audit-memory-index-duplicates.sh (the tool)
+#   - tools/hygiene/audit-memory-index-duplicates.ts (the tool)
 
 on:
   pull_request:
     paths:
       - "memory/MEMORY.md"
-      - "tools/hygiene/audit-memory-index-duplicates.sh"
+      - "tools/hygiene/audit-memory-index-duplicates.ts"
       - ".github/workflows/memory-index-duplicate-lint.yml"
   push:
     branches: [main]
     paths:
       - "memory/MEMORY.md"
-      - "tools/hygiene/audit-memory-index-duplicates.sh"
+      - "tools/hygiene/audit-memory-index-duplicates.ts"
       - ".github/workflows/memory-index-duplicate-lint.yml"
   workflow_dispatch: {}
 
@@ -49,8 +49,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        # Provides bun via mise's pin in .mise.toml. Same pattern as
+        # gate.yml. shellenv.sh wires BASH_ENV so subsequent run:
+        # steps auto-source the managed shellenv with bun on PATH.
+        run: ./tools/setup/install.sh
+
       - name: run duplicate-link lint
         shell: bash
         run: |
           set -euo pipefail
-          tools/hygiene/audit-memory-index-duplicates.sh --enforce
+          bun tools/hygiene/audit-memory-index-duplicates.ts --enforce


### PR DESCRIPTION
Per Aaron 2026-05-03 'fully converted' + B-0156 TS standardization. Lowest-risk-first per #1376 risk-stratification. Adds setup step for install.sh (mise+bun per GOVERNANCE §24); replaces .sh with bun .ts call. Verified locally: both produce identical output + exit code. .sh NOT removed in this PR — kept during transition; removal after all 3 workflows are .ts-based + verified.