### PR TITLE
fix(check-no-conflict-markers.ts): allowlist parity with .sh (gate.yml prerequisite)

### DIFF
--- a/tools/hygiene/check-no-conflict-markers.ts
+++ b/tools/hygiene/check-no-conflict-markers.ts
@@ -39,6 +39,12 @@ const ALLOWLIST: readonly string[] = [
   SELF_PATH,
   "tools/hygiene/check-no-conflict-markers.ts",
   "memory/feedback_otto_341_lint_suppression_is_self_deception_noise_signal_or_underlying_fix_greenfield_large_refactors_welcome_training_data_human_shortcut_bias_2026_04_26.md",
+  // Rerere cache dividend memory file — landed PR #694 (2026-04-30).
+  // The "Worked-example trace" section quotes the MEMORY.md sibling-
+  // DIRTY conflict shape inside a fenced code block as the rule's
+  // documented example. Fenced examples of merge markers are
+  // documentation, not leakage. Parity with .sh ALLOWLIST.
+  "memory/feedback_rerere_conflict_resolution_cache_dividend_amara_2026_04_28.md",
 ];
 
 const MARKER_RE = /^(<<<<<<<[\t ]|=======$|>>>>>>>[\t ])/;


### PR DESCRIPTION
Real parity bug surfaced during gate.yml conversion preparation: .ts ALLOWLIST was missing `memory/feedback_rerere_conflict_resolution_cache_dividend_amara_2026_04_28.md` which the .sh has. The .sh allowlists this file because it's a substrate memo legitimately quoting conflict-marker syntax in a fenced code block (rerere cache dividend rule). Added to .ts ALLOWLIST. Verified: both now produce 'OK: no git merge-conflict markers found' exit 0. Prerequisite for gate.yml conversion (next per #1376 stratification).