### PR TITLE
ci(gate): switch 3 lint jobs from .sh to .ts via bun (final risk-strat tier)

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -645,8 +645,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        # Provides bun via mise's pin in .mise.toml. Same pattern as
+        # memory-index-duplicate-lint.yml (#1377) +
+        # memory-reference-existence-lint.yml (#1378). shellenv.sh
+        # wires BASH_ENV so subsequent run: steps auto-source the
+        # managed shellenv with bun on PATH.
+        run: ./tools/setup/install.sh
+
       - name: Run check-tick-history-order
-        run: tools/hygiene/check-tick-history-order.sh
+        run: bun tools/hygiene/check-tick-history-order.ts
 
   lint-no-conflict-markers:
     # Fail if any committed file contains git merge-conflict markers
@@ -669,8 +677,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        # Provides bun via mise's pin in .mise.toml. Same pattern as
+        # memory-index-duplicate-lint.yml (#1377) +
+        # memory-reference-existence-lint.yml (#1378). shellenv.sh
+        # wires BASH_ENV so subsequent run: steps auto-source the
+        # managed shellenv with bun on PATH.
+        run: ./tools/setup/install.sh
+
       - name: Run check-no-conflict-markers
-        run: tools/hygiene/check-no-conflict-markers.sh
+        run: bun tools/hygiene/check-no-conflict-markers.ts
 
   lint-archive-header-section33:
     # Fail if any courier-ferry / external-conversation import under
@@ -697,8 +713,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        # Provides bun via mise's pin in .mise.toml. Same pattern as
+        # memory-index-duplicate-lint.yml (#1377) +
+        # memory-reference-existence-lint.yml (#1378). shellenv.sh
+        # wires BASH_ENV so subsequent run: steps auto-source the
+        # managed shellenv with bun on PATH.
+        run: ./tools/setup/install.sh
+
       - name: Run check-archive-header-section33
-        run: tools/hygiene/check-archive-header-section33.sh
+        run: bun tools/hygiene/check-archive-header-section33.ts
 
   lint-no-empty-dirs:
     # Fail if a committed directory has no files — almost always a


### PR DESCRIPTION
## Summary

- Converts gate.yml's three lint jobs from .sh to .ts via bun, completing the .sh→.ts cleanup risk-stratification per #1376.
- Final tier: gate.yml is the highest-risk workflow (all-PR gate critical path); precedents are #1377 (memory-index-duplicate) + #1378 (memory-reference-existence) + #1379 (allowlist parity prerequisite).
- All three .sh/.ts pairs verified for output + exit-code parity locally (179 tick-history rows; 0 conflict-marker violations; 0 §33 archive-header violations).

## Conversion pattern

Same as #1377 / #1378 — add `./tools/setup/install.sh` step to provide bun via mise pin, then call `bun tools/hygiene/<name>.ts` instead of `tools/hygiene/<name>.sh`.

The three lint jobs run in parallel, so the bun install cost is bounded by the slowest job's path (not 3x).

## After this lands

The 5 deferred .sh files can be removed in a follow-up cleanup PR:
- `tools/hygiene/audit-memory-index-duplicates.sh`
- `tools/hygiene/audit-memory-references.sh`
- `tools/hygiene/check-archive-header-section33.sh`
- `tools/hygiene/check-no-conflict-markers.sh`
- `tools/hygiene/check-tick-history-order.sh`

Closes the maintainer ask from #1371: *"we should clean up .sh and any .sh where we have the .ts I thought we were fully converted."*

## Test plan

- [ ] CI runs all 3 converted lint jobs successfully (lint-tick-history-order, lint-no-conflict-markers, lint-archive-header-section33)
- [ ] Each job's output matches the .sh equivalent (parity already verified locally)
- [ ] No regression in other gate.yml jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)