### PR TITLE
fix(stryker-config): correct stale project paths (prerequisite for B3 → A CI wire)

### DIFF
--- a/stryker-config.json
+++ b/stryker-config.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/stryker-mutator/stryker-net/master/docs/stryker-config.schema.json",
   "stryker-config": {
-    "project": "Zeta.Core.fsproj",
+    "project": "src/Core/Core.fsproj",
     "test-projects": [
-      "tests/Zeta.Tests.FSharp/Zeta.Tests.FSharp.fsproj"
+      "tests/Tests.FSharp/Tests.FSharp.fsproj"
     ],
     "mutate": [
       "!**/AssemblyInfo.fs",


### PR DESCRIPTION
## Summary

Pre-flight audit on the math-proofs assessment (#1383) B3 outstanding item (Stryker.NET CI wire-up) found the existing `stryker-config.json` had stale paths:

- `project`: `Zeta.Core.fsproj` → **`src/Core/Core.fsproj`** (verified exists)
- `test-projects[0]`: `tests/Zeta.Tests.FSharp/Zeta.Tests.FSharp.fsproj` → **`tests/Tests.FSharp/Tests.FSharp.fsproj`** (verified exists)

Without these fixes, any CI invocation of `dotnet stryker` would have failed immediately on path resolution.

## Tool installation already in place

`dotnet-stryker` is already in `tools/setup/manifests/dotnet-tools` (the declarative-install manifest per GOVERNANCE §24 three-way-parity). Dev laptops + CI runners both have the tool available via `tools/setup/install.sh`.

## Follow-up (separate PR)

CI wire-up itself is a substantial-design follow-up:
- Mutation pass timing on the 471-test suite (probably 30+ min)
- Runner allocation strategy (nightly schedule vs PR-triggered vs manual workflow_dispatch)
- Kill-rate publication target (HTML report to GitHub Pages? release artifact?)
- Threshold tuning (current: high=80, low=60, break=50)

## Test plan

- [x] Verified actual project paths exist
- [x] `dotnet-stryker` available locally (`/Users/.../dotnet/tools/dotnet-stryker`)
- [ ] Full Stryker mutation pass — deferred to CI wire follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)