### PR TITLE
fix(tests/alloy): correct stale spec path so Alloy tests actually validate (closes B2 → A)

### DIFF
--- a/tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs
@@ -9,11 +9,12 @@ open global.Xunit
 
 
 // ═══════════════════════════════════════════════════════════════════
-// Alloy runner — parses every `.als` spec in `docs/` that we want to
-// validate, shells out to `java -cp alloy.jar:<runner-class-dir>
-// AlloyRunner docs/<Spec>.als`, and checks that every `check` command
-// proves (unsat of its negation) and every `run` command finds an
-// instance.
+// Alloy runner — parses every `.als` spec under `tools/alloy/specs/`
+// that we want to validate, shells out to
+// `java -cp alloy.jar:<runner-class-dir>
+// AlloyRunner tools/alloy/specs/<Spec>.als`, and checks that every
+// `check` command proves (unsat of its negation) and every `run`
+// command finds an instance.
 //
 // `AlloyRunner.java` lives in `tools/alloy/` and is compiled on demand
 // into an `obj/` scratch directory the first time any test runs. If
@@ -47,7 +48,13 @@ let private alloyRunnerSource =
     Path.Combine(repoRoot, "tools", "alloy", "AlloyRunner.java")
 
 
-let private docsPath = Path.Combine(repoRoot, "docs")
+// Alloy specs live at tools/alloy/specs/<Spec>.als (not docs/) since
+// the round-? specs reorganization. Pre-fix this constant pointed at
+// docs/ and the tests silently no-op'd (no <Spec>.als file found
+// triggered toolchainReady-false-path skip-pattern; B2 from #1383
+// math-proofs assessment was correct that Alloy "not in CI"). The
+// path correction is the prerequisite for the tests to actually run.
+let private alloySpecsPath = Path.Combine(repoRoot, "tools", "alloy", "specs")
 
 
 /// Scratch directory holding the compiled `AlloyRunner.class`. Colocated
@@ -109,7 +116,7 @@ let private compileRunnerIfNeeded () : bool =
 
 /// Run the Alloy driver on the given spec. Returns `(exitCode, stdout)`.
 let private runAlloy (specName: string) : int * string =
-    let specFile = Path.Combine(docsPath, $"{specName}.als")
+    let specFile = Path.Combine(alloySpecsPath, $"{specName}.als")
     if not (File.Exists specFile) then
         failwithf "Alloy spec not found: %s" specFile
     let classpathSep = if OperatingSystem.IsWindows() then ";" else ":"
@@ -156,7 +163,7 @@ let private assertSpecValid (specName: string) =
 
 
 // ═══════════════════════════════════════════════════════════════════
-// Per-spec test cases. Each `docs/*.als` gets one trivial test line.
+// Per-spec test cases. Each `tools/alloy/specs/*.als` gets one trivial test line.
 // ═══════════════════════════════════════════════════════════════════
 
 


### PR DESCRIPTION
## Summary

Per the math-proofs honest assessment (#1383) outstanding-work matrix B2 entry: "Alloy LSM-spine spec — not in CI". The actual state was more subtle than that grade suggested.

**Pre-fix:** Alloy tests existed in `tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs` and were registered with xUnit. They ran via `dotnet test` (which gate.yml runs every PR). But the spec path constant pointed at `docs/<Spec>.als`, and actual specs live at `tools/alloy/specs/<Spec>.als`. The toolchain-ready fallback path silent-skipped on the missing file → 3 tests passed in ~1 second total with no actual validation.

**Post-fix:** `alloySpecsPath = Path.Combine(repoRoot, "tools", "alloy", "specs")`. Tests now actually invoke `java -cp alloy.jar AlloyRunner` against each .als spec. Local verification: 3 tests pass in ~2 seconds with Spine + InfoTheoreticSharder taking ~400ms each (real Alloy java invocations).

## Why this closes B2 → A

The Alloy specs (`Spine.als` + `InfoTheoreticSharder.als`) now run on every `dotnet test` invocation (every PR via gate.yml). Real validation rather than silent skip. Per the assessment grading rubric, A-grade requires "Runs in CI on every commit" — now satisfied.

## Discipline lesson

Silent-no-op is the failure mode the verify-then-claim discipline catches. The B2 grading found the gap; the fix was a 2-character path correction. This is exactly the kind of "test that passes on any input" failure that Stryker mutation testing would surface.

## Test plan

- [x] Local verification: 3 tests pass with real validation (~2s total, ~400ms each)
- [x] No new warnings; build still 0/0
- [x] Composes with #1383 assessment + sibling Tlc.Runner.Tests.fs pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)