### PR TITLE
ci(tla/tlc): add DbspSpec to TLC test list (closes B1 partial — 1 of 4 deferred specs)

### DIFF
--- a/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
@@ -222,3 +222,20 @@ let ``TLC validates FeatureFlagsResolution`` () =
     // FeatureFlags.isEnabled matches the documented resolution order
     // on every environment.
     assertSpecValid "FeatureFlagsResolution"
+
+
+[<Fact>]
+let ``TLC validates DbspSpec`` () =
+    // DBSP per-tick semantics — explores 1M distinct initial states in
+    // ~11s wall on dev hardware, proving the operator-algebra
+    // invariants hold across the configured state space. Closes the
+    // first of the 4 deferred specs in B1 (#1383 math-proofs honest
+    // assessment outstanding-work matrix). The other 3
+    // (SpineAsyncProtocol, CircuitRegistration, SpineMergeInvariants)
+    // have known issues per a 2026-05-03 verify-then-claim sweep:
+    // SpineAsyncProtocol + SpineMergeInvariants produce trace files
+    // (counterexamples); CircuitRegistration has a config bug
+    // (invariant `Safety` not defined in spec). They remain
+    // intentionally unregistered until the underlying issues are
+    // fixed in follow-up PRs.
+    assertSpecValid "DbspSpec"

--- a/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
@@ -226,16 +226,37 @@ let ``TLC validates FeatureFlagsResolution`` () =
 
 [<Fact>]
 let ``TLC validates DbspSpec`` () =
-    // DBSP per-tick semantics — explores 1M distinct initial states in
-    // ~11s wall on dev hardware, proving the operator-algebra
-    // invariants hold across the configured state space. Closes the
-    // first of the 4 deferred specs in B1 (#1383 math-proofs honest
-    // assessment outstanding-work matrix). The other 3
-    // (SpineAsyncProtocol, CircuitRegistration, SpineMergeInvariants)
-    // have known issues per a 2026-05-03 verify-then-claim sweep:
-    // SpineAsyncProtocol + SpineMergeInvariants produce trace files
-    // (counterexamples); CircuitRegistration has a config bug
-    // (invariant `Safety` not defined in spec). They remain
-    // intentionally unregistered until the underlying issues are
-    // fixed in follow-up PRs.
+    // DBSP per-tick semantics — verifies the 9 algebra invariants
+    // (InvAssoc / InvCommute / InvIdentity / InvInverse /
+    // InvDoubleNeg / InvNegDistributes / InvSubIsAddNeg /
+    // InvDistinctIdempotent / InvHCorrectness) over the cfg's
+    // configured state space.
+    //
+    // **Coverage scope (verbatim from DbspSpec.cfg):**
+    //   * Keys K = {"k1", "k2"} (2-key universe)
+    //   * Weights W = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9} — POSITIVE
+    //     ONLY. Retraction (negative-weight) cases are NOT
+    //     exercised by this model-check; they are covered separately
+    //     by the FsCheck property-tests over Z-set algebra in
+    //     `tests/Tests.FSharp/Algebra/ZSetTests.fs` and by the
+    //     Lean proof of Prop 3.2 (`tools/lean4/Lean4/
+    //     DbspChainRule.lean`) which is general over abelian-group
+    //     weights.
+    //   * Explores ~1M distinct initial states in ~11s wall on dev
+    //     hardware; full state-space coverage of the positive-
+    //     weight subset.
+    //
+    // Adding negative-weight coverage to this cfg would either
+    // require enlarging W (linear blow-up in state space) or
+    // refining the spec model — captured as a future-work refinement
+    // for whoever lands the chain_rule_poly (3-group) follow-on.
+    //
+    // Closes the first of the 4 deferred specs in B1 (#1383
+    // math-proofs honest assessment outstanding-work matrix). The
+    // other 3 (SpineAsyncProtocol, CircuitRegistration,
+    // SpineMergeInvariants) have known issues per a 2026-05-03
+    // verify-then-claim sweep — SpineAsyncProtocol +
+    // SpineMergeInvariants produce trace files (counterexamples);
+    // CircuitRegistration has a config bug (invariant Safety
+    // not defined in spec). Tracked as B-0179 + B-0180 + B-0181.
     assertSpecValid "DbspSpec"


### PR DESCRIPTION
## Summary

Per the math-proofs honest assessment (#1383) outstanding-work matrix B1 entry. Verify-then-claim sweep found 1 of 4 deferred specs actually passes; the other 3 have real issues blocking CI registration.

## Verify-then-claim findings (local TLC runs, 2026-05-03)

| Spec | Status | Detail |
|---|---|---|
| **DbspSpec** | ✓ PASSES | 1M distinct states explored in ~11s wall; full state-space coverage. **This PR registers it as [Fact].** |
| SpineAsyncProtocol | ✗ FAILS | TLC dumps trace file at depth 9 (counterexample / invariant violation) |
| CircuitRegistration | ✗ FAILS | Config bug — `.cfg` references invariant `Safety` not defined in `.tla` |
| SpineMergeInvariants | ✗ FAILS | TLC dumps trace file at depth 17 (counterexample) |

The 3 failing specs remain intentionally unregistered. They need spec/config fixes in follow-up PRs before CI registration. The test-file comment documents this so future-Otto doesn't blanket-register them and ship 3 immediate red builds.

## Why this is partial closure

This closes 1 of 4 entries in B1, partial progress on B1 → A. Full B1 closure requires fixing the 3 broken specs.

## Test plan

- [x] Local TLC verification on all 4 specs (1 pass, 3 fail with documented reasons)
- [x] `dotnet test --filter DisplayName~DbspSpec` passes in 12.8s
- [x] Build still 0 warnings / 0 errors
- [x] Composes with #1383 + #1393 + proof-tool-coverage.md §2

🤖 Generated with [Claude Code](https://claude.com/claude-code)