### PR TITLE
fix(backlog/generate-index.ts): close .ts/.sh parity bug (squash-miss from #1399)

### DIFF
--- a/tools/backlog/generate-index.ts
+++ b/tools/backlog/generate-index.ts
@@ -144,7 +144,15 @@ function generateContent(backlogDir: string): string {
   out.push("_Each entry below is a link to a per-row file under");
   out.push("`docs/backlog/`. Entries with `- [ ]` are open; `- [x]`");
   out.push("are closed (status: closed in frontmatter)._");
-  out.push("");
+  // No explicit blank line here: the per-tier loop below pushes its
+  // own leading "" before each section label, which (after
+  // `out.join("\n")`) produces exactly one blank line between the
+  // frontmatter prose and the first section header. Adding another
+  // "" here would produce two blank lines and drift from
+  // `tools/backlog/generate-index.sh`'s canonical output (the .sh
+  // emits the HEADER heredoc → trailing newline only, then the tier
+  // loop's `echo ""` is the single separator).
+  // backlog-index-integrity.yml runs the .sh; this matches it.
 
   for (const tier of TIERS) {
     const tierDir = join(backlogDir, tier);


### PR DESCRIPTION
## Summary

Re-apply of the .ts/.sh parity fix that didn't make it into #1399's squash-merge (auto-merge fired before the parity-fix commit propagated).

**Bug:** The .ts generator emitted TWO blank lines between the header prose and `## P0`; the .sh canonical generator emits ONE.

**Fix:** Removed the redundant `out.push("")` after the prose. The per-tier loop's leading `out.push("")` is the canonical separator, matching .sh.

## Verification

- `./tools/backlog/generate-index.sh --check` → ok
- `bun tools/backlog/generate-index.ts --check` → ok
- `diff` between the two stdout outputs is empty (full byte-level parity)

## Discipline lesson

Parity-debt is invisible until both implementations run on the same input. The .ts ported in #885 had this latent drift; surfaced via CI's .sh-check on #1399.

## Test plan

- [x] Both generators produce identical output (byte-level diff confirmed)
- [x] Existing committed BACKLOG.md matches both generators

🤖 Generated with [Claude Code](https://claude.com/claude-code)