### PR TITLE
fix(B-0180): define Safety invariant in CircuitRegistration.tla + register in CI

### DIFF
--- a/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
@@ -268,7 +268,7 @@ let ``TLC validates DbspSpec`` () =
 let ``TLC validates CircuitRegistration`` () =
     // Circuit's Register/Build interleaving — verifies the
     // composite safety invariant `Safety == TypeOK /\
-    // NoRegisterAfterBuild` (per the spec's THEOREM at line ~96:
+    // NoRegisterAfterBuild` (matching the spec's stated THEOREM
     // `Spec => [](TypeOK /\ NoRegisterAfterBuild)`). The `Safety`
     // operator was missing from the .tla until B-0180 fixed the
     // config bug surfaced by the 2026-05-03 verify-then-claim sweep.

--- a/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
@@ -256,7 +256,26 @@ let ``TLC validates DbspSpec`` () =
     // other 3 (SpineAsyncProtocol, CircuitRegistration,
     // SpineMergeInvariants) have known issues per a 2026-05-03
     // verify-then-claim sweep — SpineAsyncProtocol +
-    // SpineMergeInvariants produce trace files (counterexamples);
-    // CircuitRegistration has a config bug (invariant Safety
-    // not defined in spec). Tracked as B-0179 + B-0180 + B-0181.
+    // SpineMergeInvariants produce trace files (counterexamples,
+    // tracked as B-0179 + B-0181). CircuitRegistration's config bug
+    // was fixed in B-0180 (the missing `Safety` invariant operator
+    // was defined in CircuitRegistration.tla; cfg now resolves);
+    // see the test below.
     assertSpecValid "DbspSpec"
+
+
+[<Fact>]
+let ``TLC validates CircuitRegistration`` () =
+    // Circuit's Register/Build interleaving — verifies the
+    // composite safety invariant `Safety == TypeOK /\
+    // NoRegisterAfterBuild` (per the spec's THEOREM at line ~96:
+    // `Spec => [](TypeOK /\ NoRegisterAfterBuild)`). The `Safety`
+    // operator was missing from the .tla until B-0180 fixed the
+    // config bug surfaced by the 2026-05-03 verify-then-claim sweep.
+    // Coverage: 3538 distinct states explored at depth 14 in <1s wall.
+    //
+    // Closes 1 of 3 broken sibling specs from #1397's verify-then-claim.
+    // Remaining: B-0179 (SpineAsyncProtocol) and B-0181
+    // (SpineMergeInvariants) — both produce TTrace dumps and need
+    // counterexample investigation, not just config fixes.
+    assertSpecValid "CircuitRegistration"

--- a/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
@@ -232,35 +232,19 @@ let ``TLC validates DbspSpec`` () =
     // InvDistinctIdempotent / InvHCorrectness) over the cfg's
     // configured state space.
     //
-    // **Coverage scope (verbatim from DbspSpec.cfg):**
-    //   * Keys K = {"k1", "k2"} (2-key universe)
-    //   * Weights W = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9} — POSITIVE
+    // Coverage scope (from DbspSpec.cfg):
+    //   - Keys K = {"k1", "k2"} (2-key universe)
+    //   - Weights W = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9} — POSITIVE
     //     ONLY. Retraction (negative-weight) cases are NOT
     //     exercised by this model-check; they are covered separately
     //     by the FsCheck property-tests over Z-set algebra in
-    //     `tests/Tests.FSharp/Algebra/ZSetTests.fs` and by the
-    //     Lean proof of Prop 3.2 (`tools/lean4/Lean4/
-    //     DbspChainRule.lean`) which is general over abelian-group
-    //     weights.
-    //   * Explores ~1M distinct initial states in ~11s wall on dev
-    //     hardware; full state-space coverage of the positive-
-    //     weight subset.
+    //     tests/Tests.FSharp/Algebra/ZSetTests.fs and by the Lean
+    //     proof of Prop 3.2 (tools/lean4/Lean4/DbspChainRule.lean)
+    //     which is general over abelian-group weights.
     //
-    // Adding negative-weight coverage to this cfg would either
-    // require enlarging W (linear blow-up in state space) or
-    // refining the spec model — captured as a future-work refinement
-    // for whoever lands the chain_rule_poly (3-group) follow-on.
-    //
-    // Closes the first of the 4 deferred specs in B1 (#1383
-    // math-proofs honest assessment outstanding-work matrix). The
-    // other 3 (SpineAsyncProtocol, CircuitRegistration,
-    // SpineMergeInvariants) have known issues per a 2026-05-03
-    // verify-then-claim sweep — SpineAsyncProtocol +
-    // SpineMergeInvariants produce trace files (counterexamples,
-    // tracked as B-0179 + B-0181). CircuitRegistration's config bug
-    // was fixed in B-0180 (the missing `Safety` invariant operator
-    // was defined in CircuitRegistration.tla; cfg now resolves);
-    // see the test below.
+    // Adding negative-weight coverage would require enlarging W
+    // (linear blow-up in state space) or refining the spec model —
+    // future work tied to the chain_rule_poly (3-group) follow-on.
     assertSpecValid "DbspSpec"
 
 
@@ -269,13 +253,5 @@ let ``TLC validates CircuitRegistration`` () =
     // Circuit's Register/Build interleaving — verifies the
     // composite safety invariant `Safety == TypeOK /\
     // NoRegisterAfterBuild` (matching the spec's stated THEOREM
-    // `Spec => [](TypeOK /\ NoRegisterAfterBuild)`). The `Safety`
-    // operator was missing from the .tla until B-0180 fixed the
-    // config bug surfaced by the 2026-05-03 verify-then-claim sweep.
-    // Coverage: 3538 distinct states explored at depth 14 in <1s wall.
-    //
-    // Closes 1 of 3 broken sibling specs from #1397's verify-then-claim.
-    // Remaining: B-0179 (SpineAsyncProtocol) and B-0181
-    // (SpineMergeInvariants) — both produce TTrace dumps and need
-    // counterexample investigation, not just config fixes.
+    // `Spec => [](TypeOK /\ NoRegisterAfterBuild)`).
     assertSpecValid "CircuitRegistration"

--- a/tools/tla/specs/CircuitRegistration.tla
+++ b/tools/tla/specs/CircuitRegistration.tla
@@ -82,6 +82,16 @@ Spec == Init /\ [][Next]_vars /\ WF_vars(Build)
 NoRegisterAfterBuild ==
   built => \A t \in Threads: pending[t] # "registering"
 
+\* Composite safety invariant — the conjunction the THEOREM at the
+\* end of this spec asserts (Spec => [](TypeOK /\
+\* NoRegisterAfterBuild)). Defined as a named operator so
+\* CircuitRegistration.cfg's `INVARIANT Safety` directive resolves;
+\* without this definition TLC fails with "The invariant Safety
+\* specified in the configuration file is not defined in the
+\* specification" (B-0180 — surfaced by the 2026-05-03
+\* verify-then-claim sweep on #1397).
+Safety == TypeOK /\ NoRegisterAfterBuild
+
 \* Safety: no FeedbackOp can be connected twice. Second Connect call
 \* would require feedbackConnected[op] = FALSE but our CAS guard rejects.
 \* We encode the post-condition: if feedbackConnected[op] flips, it flips

--- a/tools/tla/specs/CircuitRegistration.tla
+++ b/tools/tla/specs/CircuitRegistration.tla
@@ -83,13 +83,9 @@ NoRegisterAfterBuild ==
   built => \A t \in Threads: pending[t] # "registering"
 
 \* Composite safety invariant — the conjunction the THEOREM at the
-\* end of this spec asserts (Spec => [](TypeOK /\
-\* NoRegisterAfterBuild)). Defined as a named operator so
-\* CircuitRegistration.cfg's `INVARIANT Safety` directive resolves;
-\* without this definition TLC fails with "The invariant Safety
-\* specified in the configuration file is not defined in the
-\* specification" (B-0180 — surfaced by the 2026-05-03
-\* verify-then-claim sweep on #1397).
+\* end of this spec asserts. Defined as a named operator so
+\* CircuitRegistration.cfg's `INVARIANT Safety` directive resolves
+\* against a state predicate.
 Safety == TypeOK /\ NoRegisterAfterBuild
 
 \* Safety: no FeedbackOp can be connected twice. Second Connect call


### PR DESCRIPTION
## Summary

Closes B-0180. CircuitRegistration.cfg referenced `INVARIANT Safety` but the spec didn't define a `Safety` operator, causing TLC to error out:

> Error: The invariant Safety specified in the configuration file is not defined in the specification.

The intended composite invariant is documented at the spec's THEOREM:
```
THEOREM Spec => [](TypeOK /\ NoRegisterAfterBuild)
```

Defined `Safety` as exactly that conjunction. Fixes the config bug without changing TLC's check semantics.

## Local verification

| Check | Result |
|---|---|
| `java -cp tla2tools.jar tlc2.TLC ...` | Model checking completed. No error has been found. |
| State coverage | 3538 distinct states, depth 14, <1s wall |
| `dotnet test --filter CircuitRegistration` | 1 passed, 1.7s |
| Build | 0 warnings / 0 errors |

## Math-proofs assessment matrix progress

This closes the 2nd of 4 deferred B1 specs (after DbspSpec in #1397):

- ✓ DbspSpec — #1397 (1M states / 11s)
- ✓ **CircuitRegistration — this PR (3538 states / <1s)**
- ✗ SpineAsyncProtocol — B-0179 (counterexample investigation needed)
- ✗ SpineMergeInvariants — B-0181 (counterexample investigation needed)

## Composes with

- #1383 math-proofs honest assessment
- #1397 DbspSpec → CI (sibling B1 closure)
- #1398 backlog rows for the 3 broken specs (this closes B-0180)
- The verify-then-claim sweep that surfaced the bug class

🤖 Generated with [Claude Code](https://claude.com/claude-code)