### PR TITLE
fix(ci/gate): narrow verifier-jars cache path — was clobbering source-controlled specs (P0; unblocks #1401)

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -358,13 +358,25 @@ jobs:
       - name: Cache verifier jars (TLC + Alloy)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
+          # Path narrowed 2026-05-03 to specific jar files only. The
+          # prior pattern (`tools/tla` + `tools/alloy` as whole
+          # directories) caused cache hits to OVERWRITE source-
+          # controlled spec files (`tools/tla/specs/*.tla` /
+          # `*.cfg`, `tools/alloy/specs/*.als`,
+          # `tools/alloy/AlloyRunner.java`). Failure mode: PR edits
+          # to specs were silently reverted to whatever version was
+          # cached, while the test report claimed CI ran "the new"
+          # spec. Surfaced empirically by #1401 (CircuitRegistration
+          # Safety invariant fix passing locally but failing on CI
+          # with the pre-fix error). Cache key suffix `-v2` busts
+          # the stale cache containing the pre-narrow content.
           path: |
-            tools/tla
-            tools/alloy
+            tools/tla/tla2tools.jar
+            tools/alloy/alloy.jar
           # Manifest is the single source of truth — cache busts when
           # either URL or (future) SHA changes. Jars are JVM bytecode
           # so arch-neutral; key kept os-only on purpose.
-          key: verifiers-${{ runner.os }}-${{ hashFiles('tools/setup/manifests/verifiers') }}
+          key: verifiers-${{ runner.os }}-${{ hashFiles('tools/setup/manifests/verifiers') }}-v2
 
       - name: Cache NuGet packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## Summary

P0 silent-bug found via verify-then-claim sweep on #1401's CI failure. The verifier-jars cache in gate.yml uses `tools/tla` + `tools/alloy` as whole-directory paths. On cache hit, actions/cache OVERWRITES the freshly-checked-out PR-modified spec files with cached versions.

## Failure mode (silent + invisible)

PR edits to spec files were reverted by cache restoration. CI ran the OLD spec text but reported it as the new test result. The PR's fix was never actually checked.

## How surfaced

PR #1401 (CircuitRegistration `Safety` invariant fix):

| Environment | Result |
|---|---|
| Local | "Model checking completed. No error has been found." 3538 states / depth 14 |
| CI | "Error: The invariant Safety specified in the configuration file is not defined in the specification." |

Diff: local ran the fixed spec; CI ran the cache-restored old spec.

## Fix

1. Narrow cache path to specific jar files only (`tools/tla/tla2tools.jar`, `tools/alloy/alloy.jar`)
2. Bump cache key suffix to `-v2` to bust the existing stale cache

## Why P0

Latent silent failure: every PR that modified `tools/tla/specs/**` or `tools/alloy/**` silently failed to actually test its changes. The test report would show the OLD spec passing. Discovery-by-luck class — only surfaced when a PR introduced a new invariant referenced by the cfg.

## Test plan

- [x] gate.yml diff is minimal (path narrowed; key bumped to `-v2`)
- [ ] CI cache miss on first run after this lands (expected; -v2 suffix)
- [ ] After this lands + cache rewarms, #1401 should pass (its fix actually applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)