### PR TITLE
feat(B-0182): filter formal-verification tests to Linux on CI (Option A dual-axis)

### DIFF
--- a/tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs
@@ -143,15 +143,18 @@ let private runAlloy (specName: string) : int * string =
 /// configured AND the runner is one we want to actually exercise.
 /// Formal verification (Alloy) is pure-math computation: no
 /// OS-specific behavior, no environment touching. Running it on
-/// macOS / ARM / slim runners alongside Linux is duplicate work.
-/// Filter to standard Linux only on CI; preserve dev-local
-/// validation regardless. Same shape as Tlc.Runner.Tests.fs.
+/// macOS / Windows / ARM / slim runners alongside standard Linux
+/// x64 is duplicate work. Filter to standard Linux x64 only on CI;
+/// preserve dev-local validation regardless. Same shape as
+/// Tlc.Runner.Tests.fs.
 ///
-/// Two-axis check:
+/// Three-axis check:
 ///   * OS axis: skip non-Linux on CI.
+///   * Architecture axis: skip non-x64 on CI (catches
+///     ubuntu-24.04-arm).
 ///   * Runner-class axis: skip the slim runner via GITHUB_WORKFLOW.
 ///
-/// Dev-local (no CI=true) bypasses both filters.
+/// Dev-local (no CI=true) bypasses all three filters.
 let private toolchainReady () : bool =
     let isCi =
         match Environment.GetEnvironmentVariable "CI" with
@@ -160,11 +163,14 @@ let private toolchainReady () : bool =
     let isLinux =
         System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
             System.Runtime.InteropServices.OSPlatform.Linux)
+    let isX64 =
+        System.Runtime.InteropServices.RuntimeInformation.OSArchitecture =
+            System.Runtime.InteropServices.Architecture.X64
     let isLowMemoryWorkflow =
         match Environment.GetEnvironmentVariable "GITHUB_WORKFLOW" with
         | "low-memory" -> true
         | _ -> false
-    if isCi && (not isLinux || isLowMemoryWorkflow) then false
+    if isCi && (not isLinux || not isX64 || isLowMemoryWorkflow) then false
     else
         match which "java", which "javac" with
         | Some _, Some _ when File.Exists alloyJarPath ->

--- a/tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs
@@ -140,13 +140,36 @@ let private runAlloy (specName: string) : int * string =
 
 
 /// True when the Alloy toolchain (jar + javac + java) is fully
-/// configured. Tests gracefully no-op when any piece is missing so
-/// local dev machines without a JDK still get a green `dotnet test`.
+/// configured AND the runner is one we want to actually exercise.
+/// Formal verification (Alloy) is pure-math computation: no
+/// OS-specific behavior, no environment touching. Running it on
+/// macOS / ARM / slim runners alongside Linux is duplicate work.
+/// Filter to standard Linux only on CI; preserve dev-local
+/// validation regardless. Same shape as Tlc.Runner.Tests.fs.
+///
+/// Two-axis check:
+///   * OS axis: skip non-Linux on CI.
+///   * Runner-class axis: skip the slim runner via GITHUB_WORKFLOW.
+///
+/// Dev-local (no CI=true) bypasses both filters.
 let private toolchainReady () : bool =
-    match which "java", which "javac" with
-    | Some _, Some _ when File.Exists alloyJarPath ->
-        compileRunnerIfNeeded ()
-    | _ -> false
+    let isCi =
+        match Environment.GetEnvironmentVariable "CI" with
+        | "true" -> true
+        | _ -> false
+    let isLinux =
+        System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+            System.Runtime.InteropServices.OSPlatform.Linux)
+    let isLowMemoryWorkflow =
+        match Environment.GetEnvironmentVariable "GITHUB_WORKFLOW" with
+        | "low-memory" -> true
+        | _ -> false
+    if isCi && (not isLinux || isLowMemoryWorkflow) then false
+    else
+        match which "java", which "javac" with
+        | Some _, Some _ when File.Exists alloyJarPath ->
+            compileRunnerIfNeeded ()
+        | _ -> false
 
 
 let private assertSpecValid (specName: string) =

--- a/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
@@ -81,18 +81,21 @@ let private which (exe: string) : string option =
 /// True when the TLC toolchain (jar + java) is fully configured
 /// AND the runner is one we want to actually exercise. Formal
 /// verification (TLC) is pure-math computation: no OS-specific
-/// behavior, no environment touching. Running it on macOS / ARM /
-/// slim runners alongside Linux is duplicate work. Filter to
-/// standard Linux only on CI; preserve dev-local validation
-/// regardless.
+/// behavior, no environment touching. Running it on macOS /
+/// Windows / ARM / slim runners alongside standard Linux x64 is
+/// duplicate work. Filter to standard Linux x64 only on CI;
+/// preserve dev-local validation regardless.
 ///
-/// Two-axis check:
+/// Three-axis check:
 ///   * OS axis: skip non-Linux on CI (catches macos-26, windows-*).
+///   * Architecture axis: skip non-x64 on CI (catches
+///     ubuntu-24.04-arm, windows-11-arm — both are still
+///     Linux/Windows so OS check alone wouldn't catch ARM Linux).
 ///   * Runner-class axis: skip the slim runner via the workflow-name
-///     env var GITHUB_WORKFLOW. ubuntu-slim is still Linux so the OS
-///     check alone wouldn't catch it.
+///     env var GITHUB_WORKFLOW. ubuntu-slim is Linux x64 so the
+///     OS+arch check alone wouldn't catch it.
 ///
-/// Dev-local (no CI=true) bypasses both filters so devs can
+/// Dev-local (no CI=true) bypasses all three filters so devs can
 /// validate specs in their normal `dotnet test` runs.
 let private toolchainReady () : bool =
     let isCi =
@@ -102,11 +105,14 @@ let private toolchainReady () : bool =
     let isLinux =
         System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
             System.Runtime.InteropServices.OSPlatform.Linux)
+    let isX64 =
+        System.Runtime.InteropServices.RuntimeInformation.OSArchitecture =
+            System.Runtime.InteropServices.Architecture.X64
     let isLowMemoryWorkflow =
         match Environment.GetEnvironmentVariable "GITHUB_WORKFLOW" with
         | "low-memory" -> true
         | _ -> false
-    if isCi && (not isLinux || isLowMemoryWorkflow) then false
+    if isCi && (not isLinux || not isX64 || isLowMemoryWorkflow) then false
     else
         match which "java" with
         | Some _ when File.Exists tlaJarPath -> true

--- a/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
@@ -78,13 +78,39 @@ let private which (exe: string) : string option =
         |> Seq.tryFind File.Exists
 
 
-/// True when the TLC toolchain (jar + java) is fully configured.
-/// Tests gracefully no-op when any piece is missing so local dev
-/// machines without a JDK still get a green `dotnet test`.
+/// True when the TLC toolchain (jar + java) is fully configured
+/// AND the runner is one we want to actually exercise. Formal
+/// verification (TLC) is pure-math computation: no OS-specific
+/// behavior, no environment touching. Running it on macOS / ARM /
+/// slim runners alongside Linux is duplicate work. Filter to
+/// standard Linux only on CI; preserve dev-local validation
+/// regardless.
+///
+/// Two-axis check:
+///   * OS axis: skip non-Linux on CI (catches macos-26, windows-*).
+///   * Runner-class axis: skip the slim runner via the workflow-name
+///     env var GITHUB_WORKFLOW. ubuntu-slim is still Linux so the OS
+///     check alone wouldn't catch it.
+///
+/// Dev-local (no CI=true) bypasses both filters so devs can
+/// validate specs in their normal `dotnet test` runs.
 let private toolchainReady () : bool =
-    match which "java" with
-    | Some _ when File.Exists tlaJarPath -> true
-    | _ -> false
+    let isCi =
+        match Environment.GetEnvironmentVariable "CI" with
+        | "true" -> true
+        | _ -> false
+    let isLinux =
+        System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+            System.Runtime.InteropServices.OSPlatform.Linux)
+    let isLowMemoryWorkflow =
+        match Environment.GetEnvironmentVariable "GITHUB_WORKFLOW" with
+        | "low-memory" -> true
+        | _ -> false
+    if isCi && (not isLinux || isLowMemoryWorkflow) then false
+    else
+        match which "java" with
+        | Some _ when File.Exists tlaJarPath -> true
+        | _ -> false
 
 
 /// Runs TLC on a single spec. Returns `(exitCode, stdout)`.


### PR DESCRIPTION
## Summary

Implements B-0182 Option A. Formal verification (TLC + Alloy) is pure-math computation; running on macOS / ARM / slim runners is duplicate work.

## Dual-axis filter

Both `Tlc.Runner.Tests.fs` + `Alloy.Runner.Tests.fs` `toolchainReady()` helpers now check:

1. **OS axis**: skip non-Linux on CI
2. **Runner-class axis**: skip `ubuntu-slim` via `GITHUB_WORKFLOW=low-memory` env-var

Combined: run when `Linux AND GITHUB_WORKFLOW != "low-memory"`; otherwise silent-no-op.

## Dev-local preserved

`CI=true` env var gates the filter. Dev laptops bypass; tests run normally.

## Tactical band-aid; strategic path noted

Per Aaron 2026-05-03: these test runners shell out to `java -cp ... tlc2.TLC` / `AlloyRunner` — no F# operator-algebra logic involved. A TS wrapper under `tools/` would be a more natural architectural fit. Filing that as B-0183 follow-up.

## Test plan

- [x] Build clean (0/0)
- [x] Closes B-0182 P2 backlog row

🤖 Generated with [Claude Code](https://claude.com/claude-code)