### PR TITLE
fix(B-0179): SpineAsyncProtocol — add CHECK_DEADLOCK FALSE (not a real counterexample)

### DIFF
--- a/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
@@ -255,3 +255,16 @@ let ``TLC validates CircuitRegistration`` () =
     // NoRegisterAfterBuild` (matching the spec's stated THEOREM
     // `Spec => [](TypeOK /\ NoRegisterAfterBuild)`).
     assertSpecValid "CircuitRegistration"
+
+
+[<Fact>]
+let ``TLC validates SpineAsyncProtocol`` () =
+    // SpineAsync producer/worker protocol — verifies three
+    // invariants over a bounded NumBatches=4 run: InvMonotonic
+    // (sent counter only increases), InvEventuallyDrains (channel
+    // empties before flush completes), InvFlushTerminates (the
+    // protocol reaches quiescence without livelock). The cfg
+    // declares CHECK_DEADLOCK FALSE because reaching the all-done
+    // state (processed=NumBatches, channel empty, both PCs idle)
+    // is intended termination, not bug-deadlock.
+    assertSpecValid "SpineAsyncProtocol"

--- a/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
@@ -259,12 +259,21 @@ let ``TLC validates CircuitRegistration`` () =
 
 [<Fact>]
 let ``TLC validates SpineAsyncProtocol`` () =
-    // SpineAsync producer/worker protocol — verifies three
-    // invariants over a bounded NumBatches=4 run: InvMonotonic
-    // (sent counter only increases), InvEventuallyDrains (channel
-    // empties before flush completes), InvFlushTerminates (the
-    // protocol reaches quiescence without livelock). The cfg
-    // declares CHECK_DEADLOCK FALSE because reaching the all-done
-    // state (processed=NumBatches, channel empty, both PCs idle)
-    // is intended termination, not bug-deadlock.
+    // SpineAsync producer/worker protocol — verifies three STATE
+    // invariants over a bounded NumBatches=4 run:
+    //   * InvMonotonic: processed <= sent at every reachable state
+    //   * InvEventuallyDrains: when channel is empty, processed
+    //     accounts for everything sent at that instant (not a
+    //     temporal liveness claim — the name is historical from
+    //     the spec author's intent comment; the actual predicate
+    //     is state-conditional)
+    //   * InvFlushTerminates: at any state where a flush target
+    //     <= sent, processed accounts for the in-flight + drained
+    //     work (also state-conditional, not temporal)
+    // The cfg declares CHECK_DEADLOCK FALSE because reaching the
+    // all-done state (processed=NumBatches, channel empty, both
+    // PCs idle) is intended termination for this bounded protocol,
+    // not bug-deadlock. Real liveness (eventual completion) is not
+    // checked by this spec; it would require LTL properties + WF/SF
+    // fairness assumptions.
     assertSpecValid "SpineAsyncProtocol"

--- a/tools/tla/specs/SpineAsyncProtocol.cfg
+++ b/tools/tla/specs/SpineAsyncProtocol.cfg
@@ -3,3 +3,4 @@ CONSTANT NumBatches = 4
 INVARIANT InvMonotonic
 INVARIANT InvEventuallyDrains
 INVARIANT InvFlushTerminates
+CHECK_DEADLOCK FALSE


### PR DESCRIPTION
## Summary

Closes B-0179. The "depth-9 TTrace dump" surfaced by the verify-then-claim sweep on #1397 was NOT a real counterexample — TLC reports "Deadlock reached" at the all-done quiescent state (processed=NumBatches=4, channel empty, both PCs idle). That's intended termination for a bounded protocol, not bug-deadlock.

## Analysis

| Aspect | Result |
|---|---|
| Invariants checked | InvMonotonic, InvEventuallyDrains, InvFlushTerminates |
| Invariant violations | **0** across all 15 explored distinct states |
| Sole "violation" | TLC's default deadlock-detection at the terminal quiescent state |

## Fix

Added `CHECK_DEADLOCK FALSE` to `SpineAsyncProtocol.cfg`. Same pattern as `CircuitRegistration.cfg` + `TwoPCSink.cfg` (bounded protocols that correctly terminate).

## Local verification (post-fix)

```
Model checking completed. No error has been found.
21 states generated, 15 distinct states found, 0 states left on queue.
```

`dotnet test --filter SpineAsyncProtocol` passes in 1.7s.

## B1 progress

3 of 4 deferred specs now in CI:
- ✓ DbspSpec (#1397)
- ✓ CircuitRegistration (#1401)
- ✓ **SpineAsyncProtocol (this PR)**
- ✗ SpineMergeInvariants — B-0181 still open (depth-17; substantial)

## Test plan

- [x] TLC clean locally on SpineAsyncProtocol
- [x] dotnet test passes (1 test, 1.7s)
- [x] Build clean (0/0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)