### PR TITLE
feat(C1 partial): ChaosEnvDeterminism cfg + atomize splitMix+AdvanceTime critical section

### DIFF
--- a/docs/research/2026-05-03-math-proofs-honest-assessment.md
+++ b/docs/research/2026-05-03-math-proofs-honest-assessment.md
@@ -292,7 +292,7 @@ to publishable form:
 | Semgrep CI | B4 → A | 0.5 day | P1 | **Already done (verify-then-claim correction; see B4 section)** |
 | 4 deferred TLA+ specs into CI | B1 → A | 2 days | P1 | **Done (4 of 4): DbspSpec ✓ #1397; CircuitRegistration ✓ #1401 (B-0180 Safety operator); SpineAsyncProtocol ✓ #1411 (B-0179 CHECK_DEADLOCK FALSE for bounded-protocol terminal state); SpineMergeInvariants ✓ this PR (B-0181 Cascade downstream-room precondition + state constraint + WF on Cascade)** |
 | Alloy CI hook | B2 → A | 0.5 day | P1 | **Done (PR #1396, 2026-05-03 — `tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs` spec-path fixed; Spine + InfoTheoreticSharder specs now actually validate, not silent-no-op)** |
-| `.cfg` for 4 C1 specs | C1 → B | 2 days | P2 | open |
+| `.cfg` for 4 C1 specs | C1 → B | 2 days | P2 | **Partial (1 of 4): ChaosEnvDeterminism ✓ this PR (cfg + atomized DelayCritical so Atomic invariant holds across the splitMix+AdvanceTime critical section; 2043 distinct states / depth 26). Remaining 3: ConsistentHashRebalance + DictionaryStripedCAS + AsyncStreamEnumerator (each needs more than just a cfg — structural spec issues)** |
 | TLA+ spec for `Recursive.fs` LFP | C2 → B | 2-3 days | P2 | open |
 | TLA+ spec for WDC protocol | C2 → B | 3-5 days | P1 | open |
 | 15 FsCheck properties (C3) | C3 → B | 3 days | P2 | open |

--- a/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Tlc.Runner.Tests.fs
@@ -290,6 +290,24 @@ let ``TLC validates CircuitRegistration`` () =
 
 
 [<Fact>]
+let ``TLC validates ChaosEnvDeterminism`` () =
+    // ChaosEnvironment seeded-determinism contract — verifies the
+    // composite safety invariant `Safety == TypeOK /\ Atomic` over a
+    // bounded 2-thread / Seed=0 / HistoryBound=16 run. The Atomic
+    // invariant says: for every "rng" entry in history, the
+    // immediately following entry is a "clock" entry from the same
+    // thread. Modeling the splitMix + AdvanceTime critical section
+    // as a SINGLE atomic step (DelayCritical) mirrors
+    // ChaosEnvironment.fs holding the lock across both ops; without
+    // atomicity, the model would expose an intermediate
+    // "rng-recorded-but-no-clock-yet" state where Atomic fails. The
+    // cfg declares CHECK_DEADLOCK FALSE because every thread reaching
+    // "done" then "idle" is intentional cycle completion. Bounded by
+    // HistoryBound = 16 entries to keep TLC's BFS tractable.
+    assertSpecValid "ChaosEnvDeterminism"
+
+
+[<Fact>]
 let ``TLC validates SpineMergeInvariants`` () =
     // BalancedSpine's level-cap merge protocol — verifies two safety
     // invariants over a bounded MaxLevel=2 / MaxBatchSize=1 run with

--- a/tools/tla/specs/ChaosEnvDeterminism.cfg
+++ b/tools/tla/specs/ChaosEnvDeterminism.cfg
@@ -1,0 +1,13 @@
+\* Bounded model for ChaosEnvDeterminism. 2 threads is the smallest
+\* configuration that exhibits the splitMix-vs-AdvanceTime interleaving
+\* race the spec models; Seed = 0 is fixed (the spec parameterises seed
+\* but the safety claim doesn't depend on its value). State constraint
+\* caps history length so TLC's BFS terminates — every thread completes
+\* a fixed number of acquire/release cycles, after which the system
+\* repeats the same (rng, clock) pattern without adding novel state.
+CONSTANTS Threads = {"t1", "t2"} Seed = 0
+SPECIFICATION Spec
+INVARIANT TypeOK
+INVARIANT Atomic
+CONSTRAINT HistoryBound
+CHECK_DEADLOCK FALSE

--- a/tools/tla/specs/ChaosEnvDeterminism.tla
+++ b/tools/tla/specs/ChaosEnvDeterminism.tla
@@ -19,7 +19,7 @@ TypeOK ==
   /\ rngState \in Int
   /\ clockState \in Int
   /\ lockHolder \in Threads \cup {"none"}
-  /\ action \in [Threads -> {"idle", "delay-rng", "delay-clock", "done"}]
+  /\ action \in [Threads -> {"idle", "delay-rng", "done"}]
   /\ history \in Seq([thread: Threads, op: {"rng", "clock"}, value: Int])
 
 Init ==
@@ -36,22 +36,26 @@ AcquireLock(t) ==
   /\ action' = [action EXCEPT ![t] = "delay-rng"]
   /\ UNCHANGED <<rngState, clockState, history>>
 
-\* The critical path: splitMix + AdvanceTime while the lock is held.
-DelayRng(t) ==
+\* Critical section: splitMix + AdvanceTime executed as a SINGLE step.
+\* The implementation in ChaosEnvironment.fs holds the lock across both
+\* operations and the spec must model that same atomicity — splitting
+\* into separate DelayRng/DelayClock steps would expose a per-state
+\* counterexample to Atomic at the intermediate "rng-recorded-but-no-
+\* clock-yet" instant. Real concurrent code never observes that state
+\* because the lock is held; the spec models the same observation.
+DelayCritical(t) ==
   /\ lockHolder = t
   /\ action[t] = "delay-rng"
-  /\ rngState' = rngState + 1   \* model splitMix as monotone advance
-  /\ action' = [action EXCEPT ![t] = "delay-clock"]
-  /\ history' = Append(history, [thread |-> t, op |-> "rng", value |-> rngState + 1])
-  /\ UNCHANGED <<clockState, lockHolder>>
-
-DelayClock(t) ==
-  /\ lockHolder = t
-  /\ action[t] = "delay-clock"
+  /\ rngState' = rngState + 1
   /\ clockState' = clockState + 1
   /\ action' = [action EXCEPT ![t] = "done"]
-  /\ history' = Append(history, [thread |-> t, op |-> "clock", value |-> clockState + 1])
-  /\ UNCHANGED <<rngState, lockHolder>>
+  /\ history' = Append(
+                  Append(history,
+                         [thread |-> t, op |-> "rng",
+                          value |-> rngState + 1]),
+                  [thread |-> t, op |-> "clock",
+                   value |-> clockState + 1])
+  /\ UNCHANGED lockHolder
 
 ReleaseLock(t) ==
   /\ lockHolder = t
@@ -61,7 +65,7 @@ ReleaseLock(t) ==
   /\ UNCHANGED <<rngState, clockState, history>>
 
 Next ==
-  \/ \E t \in Threads: AcquireLock(t) \/ DelayRng(t) \/ DelayClock(t) \/ ReleaseLock(t)
+  \/ \E t \in Threads: AcquireLock(t) \/ DelayCritical(t) \/ ReleaseLock(t)
 
 Spec == Init /\ [][Next]_vars
 
@@ -74,4 +78,11 @@ Atomic == \A i \in 1..Len(history):
 
 Safety == [](TypeOK /\ Atomic)
 THEOREM Spec => Safety
+
+\* State constraint to bound TLC's exploration. Each thread
+\* repeatedly acquires + releases the lock, appending two entries
+\* per cycle (rng + clock). With 2 threads and 4 cycles each, history
+\* tops out at 16 entries — large enough to exhibit every interleaving
+\* class while keeping state finite.
+HistoryBound == Len(history) <= 16
 ====


### PR DESCRIPTION
## Summary

- **C1 → B partial (1 of 4 specs).** ChaosEnvDeterminism.tla had no .cfg so TLC couldn't run it; adding the cfg surfaced a latent spec atomicity issue.
- **Atomized DelayCritical(t)** — collapsed DelayRng + DelayClock into one step. Mirrors ChaosEnvironment.fs holding the lock across both splitMix + AdvanceTime; real concurrent code never observes the "rng-recorded-but-no-clock-yet" intermediate state because the lock is held.
- **TLC clean**: 2043 distinct states / depth 26 / both `TypeOK` and `Atomic` invariants hold. Bounded by 2 threads / Seed=0 / HistoryBound=16.
- **F# CI registration** added: `[<Fact>] TLC validates ChaosEnvDeterminism`.

## Why partial (not all 4 C1 specs)

The other 3 C1 specs (ConsistentHashRebalance, DictionaryStripedCAS, AsyncStreamEnumerator) need more than just a cfg — they have structural spec issues (dangling `CONSTANT` declarations, incomplete actions with TODO comments, etc.) that need more careful redesign. Filed for future work.

## Pattern

Same author-time class as B-0181 + B-0184 (per `memory/feedback_under_specified_action_preconditions_recurring_class_in_formal_specs_aaron_2026_05_03.md`): the original spec modeled separate-step DelayRng + DelayClock without a precondition that prevented the intermediate state from being observable. The fix is to model the action's actual atomicity (single step with both effects).

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors).
- [x] `dotnet test --filter "FullyQualifiedName~ChaosEnvDeterminism"` passes (1 test, 481ms).
- [x] Direct TLC: `cd tools/tla/specs && java -cp ../tla2tools.jar tlc2.TLC ChaosEnvDeterminism` reports "No error has been found" with 2043 distinct states.
- [ ] CI gate green on Linux x64 standard runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)