### PR TITLE
fix(stryker-ci): use real actions/upload-artifact SHA (v7.0.1) — fix #1417 hallucinated SHA

### DIFF
--- a/.github/workflows/stryker-mutation.yml
+++ b/.github/workflows/stryker-mutation.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload Stryker reports
         if: always()
-        uses: actions/upload-artifact@9eaf0eba75d52b5e72c7a193fc2887e6caf95df0 # v5.1.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: stryker-reports-${{ github.run_id }}
           path: StrykerOutput/


### PR DESCRIPTION
## Summary

#1417's `.github/workflows/stryker-mutation.yml` referenced a hallucinated SHA for `actions/upload-artifact` (`9eaf0eba75d52b5e72c7a193fc2887e6caf95df0` claimed v5.1.0) which doesn't resolve. Every workflow run fails at the "Set up job" step with `Unable to resolve action`.

## Fix

Replaced with the SHA already pinned elsewhere in the repo (`scorecard.yml` uses `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` for v7.0.1). Per Otto-364 search-first-authority + the in-repo-pattern audit, this SHA is verified to resolve and is the version Zeta has standardized on.

## Empirical surface

#1420's CI run (`databaseId 25283000236`) failed with `Unable to resolve action actions/upload-artifact@9eaf0eba...` on the very first invocation of the new workflow.

## Author-time discipline (next time)

When adding an action SHA, grep the repo first for an existing pin to that action — it's authoritative and tested. Don't make up SHAs from imagined version numbers.

## Test plan

- [ ] Stryker workflow run on this PR's CI exercises the fixed SHA end-to-end (the Stryker run itself may take 15-30 min, but if Set-up-job succeeds, the SHA is correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)