### PR TITLE
feat(C3 partial): OR-Set semilattice property tests (3 more)

### DIFF
--- a/tests/Tests.FSharp/Properties/Math.Invariants.Tests.fs
+++ b/tests/Tests.FSharp/Properties/Math.Invariants.Tests.fs
@@ -108,13 +108,28 @@ let ``PN-counter merge is associative`` (a: int) (b: int) (c: int) =
 // but the *observable* set (elements with ANY weight > 0) is the
 // CRDT contract. These properties pin the laws on the observable
 // set, which is the layer external code consumes.
+//
+// Tag derivation: deterministic Guid from list-index so FsCheck
+// shrinking is replayable. Naive `OrSet.Empty.Add x` would call
+// Guid.NewGuid() on every step, which (a) makes shrinking
+// non-replayable and (b) takes O(N^2) work via repeated linear
+// merges. Building Entries directly via ZSet.ofSeq is deterministic
+// and O(N log N).
 
 let private orSetValueEqual<'T when 'T : comparison>
     (a: OrSet<'T>) (b: OrSet<'T>) =
     Set.ofSeq a.Value = Set.ofSeq b.Value
 
 let private buildOrSet (xs: int list) : OrSet<int> =
-    xs |> List.fold (fun (s: OrSet<int>) x -> s.Add x) OrSet<int>.Empty
+    let entries =
+        xs
+        |> List.mapi (fun i x ->
+            // Encode list-index into a 16-byte Guid for determinism;
+            // index is unique per call so no collisions across xs.
+            let bytes = Array.zeroCreate<byte> 16
+            (System.BitConverter.GetBytes i).CopyTo(bytes, 0)
+            (x, System.Guid bytes), 1L)
+    { Entries = ZSet.ofSeq entries }
 
 [<Property>]
 let ``OR-set merge value is commutative`` (xs: int list) (ys: int list) =

--- a/tests/Tests.FSharp/Properties/Math.Invariants.Tests.fs
+++ b/tests/Tests.FSharp/Properties/Math.Invariants.Tests.fs
@@ -102,6 +102,41 @@ let ``PN-counter merge is associative`` (a: int) (b: int) (c: int) =
     lhs.Value = rhs.Value
 
 
+// ─── OR-Set — semilattice laws on observable element set ──────────
+// OrSet.Merge is ZSet.add on the (elem, tag) entries. Internal
+// weights can vary across merge orderings (Merge a a doubles weights),
+// but the *observable* set (elements with ANY weight > 0) is the
+// CRDT contract. These properties pin the laws on the observable
+// set, which is the layer external code consumes.
+
+let private orSetValueEqual<'T when 'T : comparison>
+    (a: OrSet<'T>) (b: OrSet<'T>) =
+    Set.ofSeq a.Value = Set.ofSeq b.Value
+
+let private buildOrSet (xs: int list) : OrSet<int> =
+    xs |> List.fold (fun (s: OrSet<int>) x -> s.Add x) OrSet<int>.Empty
+
+[<Property>]
+let ``OR-set merge value is commutative`` (xs: int list) (ys: int list) =
+    let a = buildOrSet xs
+    let b = buildOrSet ys
+    orSetValueEqual (OrSet<int>.Merge a b) (OrSet<int>.Merge b a)
+
+[<Property>]
+let ``OR-set merge value is idempotent`` (xs: int list) =
+    let a = buildOrSet xs
+    orSetValueEqual (OrSet<int>.Merge a a) a
+
+[<Property>]
+let ``OR-set merge value is associative`` (xs: int list) (ys: int list) (zs: int list) =
+    let a = buildOrSet xs
+    let b = buildOrSet ys
+    let c = buildOrSet zs
+    let lhs = OrSet<int>.Merge (OrSet<int>.Merge a b) c
+    let rhs = OrSet<int>.Merge a (OrSet<int>.Merge b c)
+    orSetValueEqual lhs rhs
+
+
 // ─── HyperMinHash — Jaccard monotonicity ───────────────────────────
 // Reference: Yu & Weber arXiv:1710.08436.
 


### PR DESCRIPTION
## Summary

Three FsCheck properties for `OrSet`, mirroring the G-Counter / PN-Counter pattern:
- OR-set merge value is commutative
- OR-set merge value is idempotent
- OR-set merge value is associative

Compares on the **observable element-set** (`Set.ofSeq orset.Value`), not on internal entry weights — OrSet.Merge is `ZSet.add`, so weights can vary by merge order but the externally-visible CRDT set must be invariant under semilattice laws.

Math-proofs assessment matrix C3 row: closes 3 more after PN-Counter's 3 (PR #1420). Running total: 6 of ~15 target.

## Test plan

- [x] All 3 properties pass: `dotnet test --filter "FullyQualifiedName~OR-set"` → 3 passed in 160ms.
- [x] `dotnet build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)