### PR TITLE
feat(C3 partial): MerkleTree property tests (determinism + collision-freedom)

### DIFF
--- a/tests/Tests.FSharp/Storage/Merkle.Tests.fs
+++ b/tests/Tests.FSharp/Storage/Merkle.Tests.fs
@@ -1,6 +1,9 @@
 module Zeta.Tests.Storage.MerkleTests
 #nowarn "0893"
 
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.Xunit
 open FsUnit.Xunit
 open global.Xunit
 open Zeta.Core
@@ -34,3 +37,36 @@ let ``MerkleTree LeafDiff detects single-leaf change`` () =
     let diff = (MerkleTree leaves2).LeafDiff(MerkleTree leaves1)
     diff.Length |> should equal 1
     diff.[0] |> should equal 3
+
+
+// ─── Property: same-leaves determinism + pair collision-freedom ────
+// Generalisations of the existing [<Fact>] checks. FsCheck shrinks
+// failing inputs to minimal counter-examples — useful if the leaf
+// hashing pipeline ever loses determinism (e.g. a regression that
+// hashes byte arrays via reference equality) or if tree-building
+// introduces accidental collisions on small byte-array inputs.
+
+[<Property>]
+let ``MerkleTree root is deterministic for any leaf set`` (leaves: byte array array) =
+    // Both trees built from the SAME input must produce equal roots.
+    // Treats null arrays as empty (FsCheck can generate null).
+    let safe = if isNull leaves then [||] else leaves |> Array.map (fun b -> if isNull b then [||] else b)
+    let t1 = MerkleTree safe
+    let t2 = MerkleTree safe
+    t1.Root = t2.Root
+
+[<Property>]
+let ``MerkleTree root differs under any single-leaf edit (collision-free in practice)``
+        (NonEmptyArray (leaves: byte array array)) (replacement: byte array) =
+    // Replace the first leaf, expect a different root. The 128-bit
+    // XxHash makes practical collisions astronomically unlikely for
+    // the small inputs FsCheck generates; if the hashing pipeline
+    // regresses to <128 bits or to a non-collision-resistant hash,
+    // this property starts failing.
+    let arr = leaves |> Array.map (fun b -> if isNull b then [||] else b)
+    let r = if isNull replacement then [||] else replacement
+    if arr.[0] = r then true   // skip cases where replacement is identical
+    else
+        let modified = Array.copy arr
+        modified.[0] <- r
+        (MerkleTree arr).Root <> (MerkleTree modified).Root


### PR DESCRIPTION
## Summary

Two FsCheck properties added to `tests/Tests.FSharp/Storage/Merkle.Tests.fs` that generalise the per-leaf-edit `[<Fact>]` check into shrinking-friendly property tests:

- `MerkleTree root is deterministic for any leaf set`
- `MerkleTree root differs under any single-leaf edit (collision-free in practice)`

Both properties guard against future regressions:
- determinism catches accidental reference-equality hashing
- collision-freedom catches a regression to a smaller or structural hash (relies on XxHash128's 128-bit hash space making FsCheck-generator-collisions astronomically unlikely)

## C3 progress

Math-proofs assessment matrix C3 row: closes 2 more after the CRDT batch (G + PN + OR + LWW each had 3). Running total: ~11 of 15 target after this PR.

## Test plan

- [x] All 6 Merkle tests pass (4 original + 2 new properties): `dotnet test --filter "FullyQualifiedName~MerkleTree"` → 6 passed in 137ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)