### PR TITLE
backlog(B-0186): budget-snapshot-cadence jq --argjson failure 2026-05-03 — diagnosis + proposed defensive fix (maintainer-gated)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -53,6 +53,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0173](backlog/P1/B-0173-hook-authoring-for-skill-creation-contracts-aaron-2026-05-03.md)** Hook authoring for skill-creation contracts — pre/post-condition enforcement at skill-creation + commit + PR-creation time (Aaron 2026-05-03 rule 3b from skill-design memo)
 - [x] **[B-0181](backlog/P1/B-0181-fix-spinemergeinvariants-tla-counterexample-blocks-b1-ci-registration-2026-05-03.md)** Fix SpineMergeInvariants.tla counterexample (closed — Cascade downstream-room precondition + state constraint; B1 → A CI registration landed)
 - [x] **[B-0184](backlog/P1/B-0184-fix-spine-als-alloy-6-2-0-type-error-line-35-spec-bug-2026-05-03.md)** Fix Spine.als spec bug — Alloy 6.2.0 type-check failure at line 35 col 25 (sum-vs-all comprehension confusion) + check-vs-run-vs-fact semantic confusion
+- [ ] **[B-0186](backlog/P1/B-0186-budget-snapshot-cadence-jq-argjson-failure-2026-05-03.md)** budget-snapshot-cadence workflow jq --argjson failure on first natural-Sunday fire post-B-0085-close (2026-05-03)
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0186-budget-snapshot-cadence-jq-argjson-failure-2026-05-03.md
+++ b/docs/backlog/P1/B-0186-budget-snapshot-cadence-jq-argjson-failure-2026-05-03.md
@@ -1,0 +1,142 @@
+---
+id: B-0186
+priority: P1
+status: open
+title: budget-snapshot-cadence workflow jq --argjson failure on first natural-Sunday fire post-B-0085-close (2026-05-03)
+tier: factory-tooling
+effort: S
+ask: maintainer-gated diagnosis + defensive-fix landing (autonomous-loop investigated 2026-05-03T17:46Z but couldn't reproduce in CI environment)
+created: 2026-05-03
+last_updated: 2026-05-03
+depends_on: []
+composes_with: [B-0085]
+tags: [budget-snapshot, jq, argjson, ci-failure, cron-fire-2026-05-03, github-token-scopes]
+---
+
+# B-0186 — budget-snapshot-cadence workflow `jq --argjson` failure on first natural-Sunday fire after B-0085 close
+
+## The failure
+
+Run `25285483579` (`.github/workflows/budget-snapshot-cadence.yml`,
+2026-05-03T17:11:12Z, the first natural Sunday fire after B-0085's
+2026-05-02 close) failed with:
+
+```
+jq: invalid JSON text passed to --argjson
+Use jq --help for help with command-line options,
+or see the jq manpage, or online docs at https://jqlang.github.io/jq
+error: snapshot compaction produced empty/null output — refusing to append
+##[error]Process completed with exit code 1.
+```
+
+Total runtime ~6 seconds. No `warning:` lines preceded the failure
+in the log (the script's `api_warnings` defensive pattern didn't
+fire), suggesting the failure was at the first `--argjson` site,
+not after a fallback-to-empty pattern.
+
+## Hypothesis
+
+The script `tools/budget/snapshot-burn.sh` line 68 fetches:
+
+```bash
+copilot_raw="$(gh api "/orgs/${org}/copilot/billing" 2>/dev/null || echo "{}")"
+```
+
+The workflow's GITHUB_TOKEN has `contents:write + pull-requests:write
++ actions:read` per `.github/workflows/budget-snapshot-cadence.yml`,
+but **does NOT have `read:org`** which the
+`/orgs/{org}/copilot/billing` endpoint requires.
+
+The current fallback (`|| echo "{}"`) only triggers if `gh api` exits
+non-zero. **Suspicion**: in the CI environment, `gh api` may either
+(a) write partial output to stdout before the 403 is detected,
+producing `partial-output{}` after the fallback appends; or
+(b) exit zero with non-JSON body in some `gh` version edge case.
+
+Either way, `copilot_raw` ends up as non-JSON text, and the later
+`--argjson copilot "$copilot_raw"` (line 139) chokes.
+
+Could also be at line 102 (per-run timing aggregation) or
+line 117-121 (entry composition) — without trace-mode log output, the
+specific `--argjson` site isn't identified.
+
+## Could-not-reproduce
+
+Local run of `bash tools/budget/snapshot-burn.sh --dry-run` with
+the maintainer's `gh auth` (which has `read:org`) succeeds —
+local environment has more scopes than CI. Without simulating
+the CI's restricted token, the specific failing call can't be
+isolated.
+
+## Proposed defensive fix
+
+Apply a JSON-validation guard before each `--argjson` site:
+
+```bash
+# After line 68:
+copilot_raw="$(gh api "/orgs/${org}/copilot/billing" 2>/dev/null || echo "{}")"
+echo "$copilot_raw" | jq empty 2>/dev/null || copilot_raw='{}'
+```
+
+Same pattern applied to:
+
+- `runs_json` (line 79) — already has `||` fallback but should
+  also validate
+- `copilot_raw` (line 68) — primary suspect
+- `pr_raw` (line 111) — same pattern as `runs_json`
+- The `agg`, `per_run`, `pr_stats`, `entry` intermediate values
+  — same defensive validation before each `--argjson` use
+
+Lower-cost alternative: a single helper function
+
+```bash
+ensure_json() {
+  # Usage: ensure_json "$var" '{}' (returns valid JSON or fallback)
+  if echo "$1" | jq empty 2>/dev/null; then echo "$1"; else echo "$2"; fi
+}
+copilot_raw="$(ensure_json "$copilot_raw" '{}')"
+```
+
+## Why not autonomous fix this tick
+
+1. **Cannot reproduce locally** — local `gh auth` has more scopes
+   than CI's GITHUB_TOKEN; the failing path isn't directly hit
+   from my workstation.
+2. **Cannot verify the fix actually closes the bug** without a
+   CI test cycle the autonomous loop can't safely pre-create.
+3. **Per superpowers:verification-before-completion**, claiming
+   a fix without being able to verify it pass/fail is anti-pattern.
+4. **The workflow is weekly cadence** — the cost of waiting is
+   bounded (one snapshot row missed in `docs/budget-history/snapshots.jsonl`
+   per failed Sunday).
+
+## Acceptance criteria
+
+- [ ] Land defensive `jq empty` validation before each `--argjson`
+  site in `tools/budget/snapshot-burn.sh`
+- [ ] Test on next Sunday cron fire (2026-05-10) OR via
+  workflow_dispatch with deliberately-invalid token simulation
+- [ ] Snapshot row appears in `docs/budget-history/snapshots.jsonl`
+  with `scope_coverage.has_read_org: false` (which matches what
+  the CI token actually has)
+
+## Composes with
+
+- **B-0085** (closed 2026-05-02): the parent row that documented
+  the workflow's cron timing. This row is the next-failure-mode
+  in the same workflow surface, after B-0085's natural Sunday fire
+  restart actually happened.
+- `tools/budget/snapshot-burn.sh` lines 68, 79, 102, 111, 117-121,
+  134-154 — the `--argjson` sites
+- `.github/workflows/budget-snapshot-cadence.yml` permissions
+  block (`contents:write + pull-requests:write + actions:read`,
+  notably missing `read:org`)
+
+## Origin
+
+Discovered during autonomous-loop tick 2026-05-03T17:45Z while
+auditing main CI for failures during a drained-bounded-PR-queue
+no-op window. The failure had been silent for 35+ minutes without
+any other surface flagging it (which is the cadence-workflow-null-
+result-hygiene-scan class — see `feedback_scheduled_workflow_null_result_hygiene_scan_aaron_2026_04_28.md`
+if it exists, otherwise the broader cadence-detector pattern).

--- a/docs/backlog/P1/B-0186-budget-snapshot-cadence-jq-argjson-failure-2026-05-03.md
+++ b/docs/backlog/P1/B-0186-budget-snapshot-cadence-jq-argjson-failure-2026-05-03.md
@@ -42,9 +42,12 @@ The script `tools/budget/snapshot-burn.sh` line 68 fetches:
 copilot_raw="$(gh api "/orgs/${org}/copilot/billing" 2>/dev/null || echo "{}")"
 ```
 
-The workflow's GITHUB_TOKEN has `contents:write + pull-requests:write
-+ actions:read` per `.github/workflows/budget-snapshot-cadence.yml`,
-but **does NOT have `read:org`** which the
+The workflow's `snapshot` job grants
+`contents:write` + `pull-requests:write` + `actions:read` to its
+`GITHUB_TOKEN` per `.github/workflows/budget-snapshot-cadence.yml`
+(top-level workflow `permissions:` is `contents: read`, narrower —
+the snapshot job widens within job scope only). The job
+**does NOT grant `read:org`** scope, which the
 `/orgs/{org}/copilot/billing` endpoint requires.
 
 The current fallback (`|| echo "{}"`) only triggers if `gh api` exits
@@ -137,6 +140,7 @@ copilot_raw="$(ensure_json "$copilot_raw" '{}')"
 Discovered during autonomous-loop tick 2026-05-03T17:45Z while
 auditing main CI for failures during a drained-bounded-PR-queue
 no-op window. The failure had been silent for 35+ minutes without
-any other surface flagging it (which is the cadence-workflow-null-
-result-hygiene-scan class — see `feedback_scheduled_workflow_null_result_hygiene_scan_aaron_2026_04_28.md`
-if it exists, otherwise the broader cadence-detector pattern).
+any other surface flagging it — exemplifying the broader
+cadence-detector pattern where scheduled workflows' silent failures
+need their own audit cadence (the `gh run list --branch main` audit
+this iteration found it).


### PR DESCRIPTION
## Summary

- File backlog row B-0186 documenting today's failure of the first natural-Sunday fire of `budget-snapshot-cadence` after B-0085's 2026-05-02 close
- Run 25285483579 failed with `jq: invalid JSON text passed to --argjson` at 2026-05-03T17:11Z
- Diagnosis: workflow GITHUB_TOKEN lacks `read:org` for `/orgs/.../copilot/billing` endpoint; existing `|| echo "{}"` fallback at `snapshot-burn.sh:68` may not catch all failure modes
- Proposed defensive fix: `jq empty` validation before each `--argjson` site
- Couldn't reproduce in CI vs local (my user has `read:org`); deferred to maintainer per verification-before-completion discipline

## Test plan

- [x] Backlog row at `docs/backlog/P1/B-0186-*.md`
- [x] Composes-with B-0085 (closed parent)
- [x] Frontmatter follows backlog row schema (id, priority, status, title, tier, effort, ask, created, last_updated, depends_on, composes_with, tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)