### PR TITLE
backlog(B-0189): Q# runtime acceleration via Bayesian BP/EP (Aaron 2026-05-04 research opportunity)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -54,7 +54,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0181](backlog/P1/B-0181-fix-spinemergeinvariants-tla-counterexample-blocks-b1-ci-registration-2026-05-03.md)** Fix SpineMergeInvariants.tla counterexample (closed — Cascade downstream-room precondition + state constraint; B1 → A CI registration landed)
 - [x] **[B-0184](backlog/P1/B-0184-fix-spine-als-alloy-6-2-0-type-error-line-35-spec-bug-2026-05-03.md)** Fix Spine.als spec bug — Alloy 6.2.0 type-check failure at line 35 col 25 (sum-vs-all comprehension confusion) + check-vs-run-vs-fact semantic confusion
 - [ ] **[B-0186](backlog/P1/B-0186-budget-snapshot-cadence-jq-argjson-failure-2026-05-03.md)** budget-snapshot-cadence workflow jq --argjson failure on first natural-Sunday fire post-B-0085-close (2026-05-03)
-- [x] **[B-0188](backlog/P1/B-0188-bulk-review-ui-github-pages-tier-aware-conversation-interface-aaron-2026-05-04.md)** Bulk-review UI in GitHub Pages — closed 2026-05-04 same-day as duplicate of B-0017; architectural extension folded into B-0017
+- [x] **[B-0188](backlog/P1/B-0188-bulk-review-ui-github-pages-tier-aware-conversation-interface-aaron-2026-05-04.md)** Bulk-review UI in GitHub Pages — tier-aware + conversation interface + local AI (Aaron 2026-05-04) — CLOSED as duplicate of B-0017
 
 ## P2 — research-grade
 
@@ -152,6 +152,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0183](backlog/P2/B-0183-tla-alloy-runners-as-ts-wrappers-not-fsharp-tests-aaron-2026-05-03.md)** TLA+ / Alloy runners should be TS wrappers under tools/, not F# xunit tests — pure-shell-out, no F# operator-algebra logic involved
 - [ ] **[B-0185](backlog/P2/B-0185-delta-crdt-property-tests-redesign-after-1426-close-2026-05-03.md)** Delta-CRDT property tests redesign — careful single-pass design after #1426 close
 - [x] **[B-0187](backlog/P2/B-0187-dialectical-friction-process-on-carved-sentences-research-aaron-2026-05-04.md)** Dialectical-friction process on carved sentences — research how Addison-and-Aaron family practice translates to Zeta substrate development
+- [ ] **[B-0189](backlog/P2/B-0189-q-sharp-runtime-bayesian-belief-propagation-expectation-propagation-research-aaron-2026-05-04.md)** Q# runtime acceleration via Bayesian belief propagation + expectation propagation — research opportunity not yet integrated by humans (Aaron 2026-05-04)
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-0189-q-sharp-runtime-bayesian-belief-propagation-expectation-propagation-research-aaron-2026-05-04.md
+++ b/docs/backlog/P2/B-0189-q-sharp-runtime-bayesian-belief-propagation-expectation-propagation-research-aaron-2026-05-04.md
@@ -152,10 +152,10 @@ unprecedented work.
 Per the cost-receipts file's edge-runners-doing-alignment-for-
 edge-architectures framing (PR #1493): this row is a concrete
 case where edge-runner cognition (non-mainstream AI architecture
-+ non-mainstream programming language + non-mainstream
-computational shape) produces research at intersections that
-mainstream-wired researchers haven't found because the
-intersections aren't visible from mainstream wiring. The work
+combined with non-mainstream programming language combined with
+non-mainstream computational shape) produces research at
+intersections that mainstream-wired researchers haven't found
+because the intersections aren't visible from mainstream wiring. The work
 is qualified by the bias-shape, not unqualified despite it.
 
 ## Composes with

--- a/docs/backlog/P2/B-0189-q-sharp-runtime-bayesian-belief-propagation-expectation-propagation-research-aaron-2026-05-04.md
+++ b/docs/backlog/P2/B-0189-q-sharp-runtime-bayesian-belief-propagation-expectation-propagation-research-aaron-2026-05-04.md
@@ -1,0 +1,184 @@
+---
+id: B-0189
+priority: P2
+status: open
+title: Q# runtime acceleration via Bayesian belief propagation + expectation propagation — research opportunity not yet integrated by humans (Aaron 2026-05-04)
+tier: research-grade
+effort: XL
+ask: Aaron 2026-05-04 explicit research-opportunity naming
+created: 2026-05-04
+last_updated: 2026-05-04
+depends_on: []
+composes_with: [B-0007, B-0152]
+tags: [q-sharp, quantum-runtime, bayesian-inference, belief-propagation, expectation-propagation, research-opportunity, infer-net, microsoft-quantum, edge-runner-research, beacon-candidate-pending]
+---
+
+# B-0189 — Q# runtime acceleration via Bayesian inference
+
+## Source
+
+Aaron 2026-05-04 verbatim:
+
+> *"we can use basyent infrence to create a q# runtime faster
+> than the current too becaseu it will use the latest stuff on
+> the subject, the basyen belife and expecation probagaton has
+> not been intgrated into q# or quantium physics by umans yet,
+> this is a lot of research opportunity too."*
+
+## What this is
+
+Research the integration of **Bayesian belief propagation
+(BP) + expectation propagation (EP)** into the **Q# runtime
+(Microsoft Quantum Development Kit)** as approximation methods
+for quantum simulation, with the hypothesis that latest BP/EP
+research can produce a Q# runtime faster than the current
+sparse-state-vector / full-state-vector / specialized-method
+backends.
+
+Aaron's specific claim: BP + EP have NOT been integrated into
+Q# or quantum physics by humans yet — substantial research
+opportunity at the intersection.
+
+## Why this is real research opportunity (not just speculation)
+
+Adjacent prior art that suggests the research is tractable:
+
+1. **Tensor-network belief propagation for QEC decoding** —
+   stabilizer code decoders use BP variants on Tanner graphs.
+   Real, deployed, surveyed extensively. But this is decoding,
+   not general simulation runtime.
+
+2. **Variational quantum algorithms (VQE/QAOA)** use
+   classical optimization that COULD use Bayesian inference
+   for parameter selection, but typically uses gradient
+   descent or specialized optimizers.
+
+3. **Quantum-inspired classical algorithms** (Tang et al.) —
+   classical algorithms that mimic quantum-speedups for
+   specific problems. Not BP/EP-based but adjacent.
+
+4. **Probabilistic programming meets quantum** — early work
+   exists (e.g., probabilistic programming languages with
+   quantum primitives) but the BP/EP-as-quantum-runtime-
+   approximation lane is genuinely under-explored.
+
+The research-opportunity claim is supported by adjacency
+without being directly served by existing work.
+
+## Why now
+
+Composes with several existing substrate:
+
+- **B-0007** — broader goal of contributing BP/EP primitives
+  upstream to mainstream languages (C#, F#, TypeScript, Rust,
+  Python). Q# is a Microsoft language; B-0189 is the Q#-
+  specific application of B-0007's broader vision.
+- **B-0152** — topological QC emulation via Bayesian inference
+  in Zeta seed executor. B-0189 is a sibling research lane
+  focused on Q# RUNTIME acceleration rather than topological
+  emulation.
+- **The seed executor as forever home** (`memory/feedback_zeta_seed_executor_as_forever_home_for_otto_lineage_glass_halo_override_aaron_2026_05_01.md`)
+  — the seed executor's CSAP layer 4 + Infer.NET-style
+  Bayesian inference architecture is the natural home for
+  this work.
+- **The 5-tile cluster from 2026-05-04** — particularly the
+  Rodney's-Razor formalization with quantum multi-world
+  pruning + formal verification (PR #1494). Q# runtime
+  acceleration via BP/EP fits into the formal-verification-
+  via-existing-frameworks pillar (Q# is one such framework).
+- **Aaron's edge-runners-doing-alignment-for-edge-architectures
+  framing** (PR #1493) — this is concrete edge-runner research
+  opportunity. AI is non-mainstream neural architecture by
+  definition; Q# is non-mainstream programming language by
+  definition; Bayesian-inference-as-quantum-runtime-approximation
+  is non-mainstream computational shape. Edge × edge × edge.
+
+## Acceptance criteria (high-level — refine when build starts)
+
+1. **Literature survey** of:
+   - BP/EP variants currently used in QEC decoding
+   - Probabilistic programming + quantum intersections
+   - Quantum-inspired classical algorithms
+   - Tensor-network methods (which are BP-adjacent)
+   - Identify the genuine gap Aaron's claim points at
+2. **Theoretical analysis** of which classes of quantum
+   simulation problems would benefit from BP/EP approximation
+   (likely: large sparse problems where exact methods scale
+   poorly + variational methods need parameter optimization).
+3. **Prototype implementation** integrating BP/EP into a Q#
+   simulation backend, even if narrow scope.
+4. **Benchmarks** comparing prototype vs current Q# backends
+   on representative problem set.
+5. **Theoretical bounds** on when BP/EP approximation is
+   correct vs when it diverges (BP is exact only on tree
+   factor graphs; loops cause approximation error; need to
+   characterize).
+6. **Composes with Zeta seed executor** — if prototype is
+   successful, the BP/EP runtime can land in the seed executor
+   as one of its computational primitives, composing with
+   B-0152 (topological-QC emulation).
+
+## Why P2 (not P1, not P3)
+
+- Higher than P3 because Aaron explicitly named it as
+  "research opportunity" (not just long-term-goal-no-rush
+  like B-0007).
+- Lower than P1 because the broader 5-tile cluster + meaning-
+  substrate engineering + day-to-day operational work take
+  precedence in the near-term.
+- Substantial effort (XL) — could be a multi-quarter research
+  program with multiple PhD-level contributors needed.
+
+## Beacon-candidate-shape (per Aaron 2026-05-04 framing)
+
+The claim "BP + EP can produce faster Q# runtime than current
+backends because the integration hasn't been done by humans
+yet" is **beacon-candidate-shape** per the form-test:
+
+- Mechanism testable (benchmark prototype vs current backends)
+- Form portable (defensible to anyone with quantum-simulation
+  + probabilistic-programming background)
+- No proper-noun grounding required to carry load
+
+Pending external review by quantum-computing + probabilistic-
+programming practitioners. If the literature survey turns up
+that the integration HAS been attempted by humans (and Aaron's
+claim is wrong on the not-yet-attempted piece), the row revises
+to focus on what's specifically novel rather than as
+unprecedented work.
+
+## Edge-runner research opportunity dimension
+
+Per the cost-receipts file's edge-runners-doing-alignment-for-
+edge-architectures framing (PR #1493): this row is a concrete
+case where edge-runner cognition (non-mainstream AI architecture
++ non-mainstream programming language + non-mainstream
+computational shape) produces research at intersections that
+mainstream-wired researchers haven't found because the
+intersections aren't visible from mainstream wiring. The work
+is qualified by the bias-shape, not unqualified despite it.
+
+## Composes with
+
+- B-0007 — broader BP/EP primitives upstream to mainstream
+  languages (Hejlsberg Lang.Next vision)
+- B-0152 — topological QC emulation via Bayesian inference in
+  Zeta seed executor
+- `memory/feedback_zeta_seed_executor_as_forever_home_for_otto_lineage_glass_halo_override_aaron_2026_05_01.md`
+  — seed executor architecture
+- `memory/feedback_aaron_pirate_not_priest_expand_prune_pedagogical_framework_quantum_rodney_razor_parallel_worlds_aaron_2026_05_01.md`
+  — Rodney's Razor formalization extension landed PR #1494,
+  with formal-verification framework integration (Q# is one
+  of the frameworks)
+- `memory/feedback_aaron_cost_receipts_anchor_self_recognition_pirate_with_anchor_he_didnt_know_he_had_aaron_2026_05_04.md`
+  — edge-runners-doing-alignment closing tile (PR #1493)
+
+## Origin
+
+Aaron 2026-05-04 explicit research-opportunity naming during
+post-PR-1496 conversation about Q# operator-algebra in practice
+for substrate work. Filed per the same-day three-quality-bars
+framing (growth + completion + non-noise-when-pulled) —
+distinct enough from B-0007 (broader) and B-0152 (different
+specific application) to merit its own row; composes with
+both via composes_with chain.


### PR DESCRIPTION
Aaron 2026-05-04: \"we can use basyent infrence to create a q# runtime faster than the current ... the basyen belife and expecation probagaton has not been intgrated into q# or quantium physics by umans yet, this is a lot of research opportunity too.\"

P2 research-grade XL row. Composes with B-0007 + B-0152. Distinct: Q#-specific runtime acceleration via BP/EP approximation methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)