### PR TITLE
ci(role-ref-lint): wire check-role-ref-on-current-state-surfaces.sh into CI as soft-launch lint (B-0162)

### DIFF
--- a/.github/workflows/role-ref-current-state-surfaces-lint.yml
+++ b/.github/workflows/role-ref-current-state-surfaces-lint.yml
@@ -1,0 +1,87 @@
+name: role-ref-current-state-surfaces-lint
+
+# Detects direct name attribution on current-state surfaces
+# (CLAUDE.md, AGENTS.md, GOVERNANCE.md, ALIGNMENT.md, etc.) per
+# the Otto-279 carve-out documented at
+# docs/AGENT-BEST-PRACTICES.md. Persona/human/external-AI names
+# belong on history surfaces (memory/, docs/research/**,
+# docs/ROUND-HISTORY.md, docs/DECISIONS/**, docs/aurora/**,
+# docs/hygiene-history/**, commit messages); current-state
+# surfaces use role-refs ('the maintainer', 'the architect').
+#
+# Why this CI wiring exists (B-0162; recurring failure mode
+# past mechanization breakeven): the role-ref convention
+# failure mode has recurred across many PRs in 2026-04 / 2026-
+# 05. Each catch costs ~5-10 minutes thread-resolution work.
+# Mechanization estimate ~30-60 min. Past breakeven.
+#
+# Soft-launch mode: the underlying script defaults to exit 0
+# even when violations are reported, so this CI lint surfaces
+# the violations in PR logs without blocking merge. Once
+# existing violations are cleaned up, future work can flip to
+# strict mode (--strict OR ROLE_REF_CHECK_SOFT_LAUNCH=0) by
+# updating the run step here.
+#
+# Safe-pattern compliance (FACTORY-HYGIENE):
+#   - SHA-pinned actions/checkout
+#   - Explicit minimum permissions: contents: read
+#   - No user-authored context (no github.event.* refs in run:)
+#   - Concurrency group + cancel-in-progress: false
+#   - runs-on ubuntu-24.04 pinned
+#
+# See:
+#   - tools/hygiene/check-role-ref-on-current-state-surfaces.sh
+#   - docs/AGENT-BEST-PRACTICES.md Otto-279 carve-out
+#   - docs/backlog/P1/B-0162-pre-commit-hook-direct-name-attribution-on-current-state-surfaces-aaron-2026-05-02.md
+
+on:
+  pull_request:
+    paths:
+      - CLAUDE.md
+      - AGENTS.md
+      - GOVERNANCE.md
+      - docs/ALIGNMENT.md
+      - docs/VISION.md
+      - docs/CONFLICT-RESOLUTION.md
+      - docs/AGENT-BEST-PRACTICES.md
+      - docs/GLOSSARY.md
+      - docs/WONT-DO.md
+      - docs/EXPERT-REGISTRY.md
+      - tools/hygiene/check-role-ref-on-current-state-surfaces.sh
+      - .github/workflows/role-ref-current-state-surfaces-lint.yml
+  push:
+    branches: [main]
+    paths:
+      - CLAUDE.md
+      - AGENTS.md
+      - GOVERNANCE.md
+      - docs/ALIGNMENT.md
+      - docs/VISION.md
+      - docs/CONFLICT-RESOLUTION.md
+      - docs/AGENT-BEST-PRACTICES.md
+      - docs/GLOSSARY.md
+      - docs/WONT-DO.md
+      - docs/EXPERT-REGISTRY.md
+      - tools/hygiene/check-role-ref-on-current-state-surfaces.sh
+      - .github/workflows/role-ref-current-state-surfaces-lint.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: role-ref-current-state-surfaces-lint-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  lint:
+    name: lint current-state surfaces for direct name attribution
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: run role-ref lint (soft-launch mode)
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash tools/hygiene/check-role-ref-on-current-state-surfaces.sh

--- a/.github/workflows/role-ref-current-state-surfaces-lint.yml
+++ b/.github/workflows/role-ref-current-state-surfaces-lint.yml
@@ -41,11 +41,12 @@ on:
       - AGENTS.md
       - GOVERNANCE.md
       - docs/ALIGNMENT.md
-      - docs/VISION.md
       - docs/CONFLICT-RESOLUTION.md
       - docs/AGENT-BEST-PRACTICES.md
       - docs/GLOSSARY.md
       - docs/WONT-DO.md
+      - docs/VISION.md
+      - docs/ROADMAP.md
       - docs/EXPERT-REGISTRY.md
       - tools/hygiene/check-role-ref-on-current-state-surfaces.sh
       - .github/workflows/role-ref-current-state-surfaces-lint.yml
@@ -56,11 +57,12 @@ on:
       - AGENTS.md
       - GOVERNANCE.md
       - docs/ALIGNMENT.md
-      - docs/VISION.md
       - docs/CONFLICT-RESOLUTION.md
       - docs/AGENT-BEST-PRACTICES.md
       - docs/GLOSSARY.md
       - docs/WONT-DO.md
+      - docs/VISION.md
+      - docs/ROADMAP.md
       - docs/EXPERT-REGISTRY.md
       - tools/hygiene/check-role-ref-on-current-state-surfaces.sh
       - .github/workflows/role-ref-current-state-surfaces-lint.yml


### PR DESCRIPTION
## Summary

Wires the existing \`tools/hygiene/check-role-ref-on-current-state-surfaces.sh\` script into CI as a non-blocking lint per B-0162. Soft-launch mode (script defaults to exit 0 even when violations reported); brings violations to PR-log visibility without blocking merge.

Currently 33 known violations (local audit). CI visibility lets future PRs see if they're adding to or reducing the count. Strict mode + violation cleanup remain as future work.

Pattern matches existing hygiene workflows (memory-index-duplicate-lint, memory-reference-existence-lint).

## Test plan

- [x] SHA-pinned actions/checkout
- [x] \`permissions: contents: read\` minimum
- [x] Concurrency group + cancel-in-progress: false
- [x] No \`github.event.*\` refs in run: commands (no injection vector)
- [x] runs-on ubuntu-24.04 pinned
- [x] paths-filter limits trigger to relevant surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)