### PR TITLE
research(B-0189): add missing Twist citation in lit-survey doc

### DIFF
--- a/docs/research/2026-05-04-b-0189-q-sharp-bayesian-bp-ep-runtime-literature-survey.md
+++ b/docs/research/2026-05-04-b-0189-q-sharp-bayesian-bp-ep-runtime-literature-survey.md
@@ -77,7 +77,7 @@ EP appears far less in the QEC literature. The dominant message-passing family t
 - **Quipper** (Green et al., 2013) — functional, scalable, generates trillion-gate circuits. Higher-order, type-safe. ([arXiv:1304.3390](https://arxiv.org/abs/1304.3390), WebSearch 2026-05-04.)
 - **Silq** (Bichsel et al., PLDI 2020) — high-level quantum language with safe uncomputation. ~46% less code than Q#. ([SRI ETH paper](https://files.sri.inf.ethz.ch/website/papers/pldi20-silq.pdf), WebSearch 2026-05-04.)
 - **Qunity** (Voichick et al.) — unified language for quantum and classical, algebraic data types, quantum control construct. ([NSF par](https://par.nsf.gov/servlets/purl/10394898), WebSearch 2026-05-04.)
-- **Twist** — quantum-classical interaction via entanglement / purity restrictions.
+- **Twist** (Yuan, McNally, Carbin, POPL 2022) — first quantum language with a type system for sound reasoning about purity / entanglement; enables identifying pure expressions via type annotations and automatic detection of subtle entanglement bugs. ([arXiv:2205.02287](https://arxiv.org/abs/2205.02287), [DOI 10.1145/3498691](https://dl.acm.org/doi/abs/10.1145/3498691), WebSearch 2026-05-04.)
 - **Qutes** (2025) — high-level quantum language for simplified quantum computing. ([arXiv:2503.13084](https://arxiv.org/html/2503.13084v1), WebSearch 2026-05-04.)
 - **Q#** — Microsoft's quantum language, in QDK; supports rich classical computation alongside quantum operations. ([Microsoft Q# overview](https://learn.microsoft.com/en-us/azure/quantum/qsharp-overview), WebSearch 2026-05-04.)
 


### PR DESCRIPTION
## Summary

- Addresses follow-up flagged on merged PR #1506: the Twist entry was the only bullet in the quantum probabilistic-programming-languages list missing a URL + WebSearch date.
- Adds canonical citation: Yuan/McNally/Carbin POPL 2022 (arXiv:2205.02287, DOI 10.1145/3498691, WebSearch 2026-05-04).

## Why this matters for B-0189

Twist's purity-and-entanglement type system is genuinely relevant — Q# already encodes adjointability (\`Adj\`) + controllability (\`Ctl\`) at the type level; Twist's purity discipline is a sibling type-system contribution that quantum BP/EP runtime work could compose with for static guarantees about classical-side estimator correctness.

## Test plan

- [x] Single-bullet edit; format matches sibling Quipper / Silq / Qunity / Qutes / Q# entries
- [x] WebSearch 2026-05-04 verification per Otto-364 search-first authority
- [x] Document's own traceability contract satisfied (all bullets now have URL + date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)