### PR TITLE
fix(never-idle-memory): MD032 blank-lines-around-lists followup from merged #1509

### DIFF
--- a/memory/feedback_never_idle_speculative_work_over_waiting.md
+++ b/memory/feedback_never_idle_speculative_work_over_waiting.md
@@ -467,6 +467,7 @@ authorization to push from state-2 to state-3 when bounded
 non-conflicting work is available.
 
 **How to read autonomous-loop logs going forward**:
+
 - "1 local agent still running" + per-minute "Unchanged" from
   orchestrator = state-2 (acceptable but check for state-3
   opportunities)
@@ -477,6 +478,7 @@ non-conflicting work is available.
 
 **Operational rule**: when subagents are running, before
 defaulting to heartbeat-only, audit:
+
 - Are there independent backlog items with non-conflicting
   files? (dispatch parallel subagent)
 - Is there bounded direct mechanical work on a different file


### PR DESCRIPTION
## Summary

- Closes the two unresolved-thread followups from merged PR #1509.
- Adds blank lines before the two lists in the team-vs-orchestrator section per MD032/blanks-around-lists.

## Test plan

- [x] Two-line additive diff (no content change)
- [x] Resolves both reviewer threads on PR #1509

🤖 Generated with [Claude Code](https://claude.com/claude-code)