### PR TITLE
fix(post-#1648): redact third-party email PII (P0 Copilot catch) + acknowledge phantom table-format threads

### DIFF
--- a/docs/research/2026-05-05-claudeai-dad-analog-hacker-granny-family-endorsed-grey-hat-functional-tree-2007-pre-bitcoin-houman-principled-quit-frame-of-permission-three-generation-aaron-forwarded-preservation.md
+++ b/docs/research/2026-05-05-claudeai-dad-analog-hacker-granny-family-endorsed-grey-hat-functional-tree-2007-pre-bitcoin-houman-principled-quit-frame-of-permission-three-generation-aaron-forwarded-preservation.md
@@ -132,7 +132,7 @@ Claude.ai's verification attempt + honest verification-limits naming (MEDIUM ver
 
 Aaron pasted verbatim email body (HIGH verbatim confidence — direct paste from chat):
 
-> Subject: Re: Question (August 5, 2008 11:33:12 AM, from Rob Hukill robhukill@gmail.com to Rodney Aaron Stainback aaron_bond@yahoo.com):
+> Subject: Re: Question (August 5, 2008 11:33:12 AM, from Rob Hukill [third-party email REDACTED] to Rodney Aaron Stainback aaron_bond@yahoo.com):
 >
 > *"It is in your best interest for me to serve as CEO of 'FunctionalTree'. As discussed before, the investment is solely based on my involvement. It is my credibility at stake, however, I fully intend on deferring to you and Houman on subjects I neither know or care to know. I want to see this project be as successful as possible for all the obvious reasons. Unfortunately, when outside financing is used checks and balances are required so that decisions are made by committee and all parties interest are protected."*
 >


### PR DESCRIPTION
## Summary

Three reviewer threads on already-merged #1648:

- **Thread 1 (REAL P0 PII catch)**: third-party email address `robhukill@gmail.com` published in verbatim email block. Per `docs/FACTORY-DISCIPLINE.md` "glass-halo first-party vs third-party PII", third-party PII requires explicit maintainer + threat-model-reviewer decision rather than default publish. **Redacted.**
- **Threads 2 + 3 (Phantom-blocker class)**: Copilot reported tables had `||` leading-pipe rendering empty first column. Source hexdump confirmed standard `| col1 | col2 |` syntax with no double-pipes. False positive. Resolving with explanation.

Aaron's own email `aaron_bond@yahoo.com` stays per Otto-231 first-party consented-by-creation rule. Name + date + content + context preserved; only third-party email address redacted.

## Test plan

- [x] Third-party `robhukill@gmail.com` no longer appears in source (`grep -n "robhukill"` returns 0 matches)
- [x] First-party `aaron_bond@yahoo.com` preserved (Otto-231 consent-by-creation)
- [x] Table source verified clean via hexdump (no `||` double-pipe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)