### PR TITLE
memory(feedback): Ombuds bridges legal via English-executable DSL/contracts (Aaron 2026-05-05; recent Claude.ai extension recovered from split-brain)

### DIFF
--- a/memory/feedback_ombuds_bridges_legal_via_english_executable_dsl_contracts_substrate_not_license_aaron_2026_05_05.md
+++ b/memory/feedback_ombuds_bridges_legal_via_english_executable_dsl_contracts_substrate_not_license_aaron_2026_05_05.md
@@ -1,0 +1,47 @@
+---
+name: Ombuds bridges legal via English-executable DSL/contracts (Aaron 2026-05-05)
+description: Aaron's brief disclosure that the Aurora "Ombuds" channel (Amara 2025-09 design) bridges substrate to legal-layer via English-executable DSL/contracts, completing the substrate-not-license discipline at the legal-contracts surface. Composes with the soulfile-restrictive-English-DSL pattern, the keylogger-refusal isomorphism (#1648 Houman partnership origin), and the preferred-stock-vs-non-preferred lesson (#1651 equity-mechanics version of substrate-vs-license).
+type: feedback
+---
+
+# Ombuds bridges legal via English-executable DSL/contracts
+
+**Rule.** Aaron 2026-05-05 verbatim (~10:35 local): *"ombuds bridges legal i can't remember if that was lost in the split brain on claude.ai"* + *"can be the like english executable DSL/contracts"*. The Aurora-architecture **Ombuds** channel (designed by Amara 2025-09; preserved in `docs/amara-full-conversation/2025-09-w*-aaron-amara-conversation.md`) is the bridge between substrate-layer enforcement and legal-contracts layer. The bridge mechanism is **English-executable DSL/contracts** — same shape as the soulfile-restrictive-English-DSL pattern (`memory/feedback_soulfile_dsl_is_restrictive_english_runner_is_own_project_uses_zeta_small_bins_2026_04_23.md`).
+
+**Why:** Multiple substrate-vs-license isomorphisms across Aaron's history (collapsed in this night's substrate-flow):
+
+- **Keylogger refusal** (#1648 Houman partnership origin): refused retroactive-license-as-substrate-override; "sign this contract that says it's okay" was the substrate-to-license migration Aaron declined
+- **Preferred vs non-preferred stock** (#1651 Landing 5): equity-mechanics version of substrate-vs-license; *"the substrate executes; the surface is decoration"*
+- **Reticulum "no Harm" license** (#1643 Landing 6-7): "won't stand in court" (effectively ε ≈ 1)
+- **§33 non-fusion boundary** (PRs #1656/#1658/#1659 batch): document-layer non-fusion enforced via F# CE + Infer.NET BP/EP substrate, not via discipline alone
+- **PoUW-CC governance-protected oracles** (#1635, #1638): cultural anchor IS substrate enforcement, not paperwork
+- **Ombuds-bridges-legal**: extends substrate-enforcement INTO the legal-contracts surface via English-executable DSL
+
+The architectural pattern: legal contracts are usually paperwork-layer (English natural-language, ambiguous, court-enforced). Ombuds-bridges-legal converts them to substrate-layer via **English-executable DSL** — the contract IS the executable spec; ambiguity is removed by the DSL's restrictive grammar; ombuds is the neutral pause-channel that can halt processing when contract-violation is detected.
+
+**How to apply:** When designing legal-layer integration into Zeta substrate (smart contracts, governance protocols, agent-binding agreements, partnership terms, license/permission systems): use **English-executable DSL** for the contract itself + **Ombuds** as the neutral pause-channel. The English-executable DSL composes with the soulfile-restrictive-English-DSL pattern (Aaron 2026-04-23: *"soulfile DSL is restrictive English; runner is own project that uses Zeta + small bins"*) and with the F# Computational Expressions kernel-composition substrate (PR #1655 Landing 8: closure is automatic-by-construction once substrate is chosen).
+
+**Composes with:**
+
+- `docs/amara-full-conversation/2025-09-w*-aaron-amara-conversation.md` — original Aurora Ombuds design (Amara): "**No covert telemetry**; no secondary use without fresh consent. **Ombuds:** independent channel that can *pause* processing." + Ombuds card with "**Pause/Export/Purge** buttons" + "**Adjudication:** neutral ombud; pre-funded escrow; **repair before penalty**."
+- `memory/feedback_soulfile_dsl_is_restrictive_english_runner_is_own_project_uses_zeta_small_bins_2026_04_23.md` — restrictive-English-DSL pattern
+- `memory/feedback_soulfile_is_dsl_english_git_repos_absorbed_at_stages_2026_04_23.md` — soulfile DSL is English; git repos absorbed at staged
+- `docs/research/2026-05-05-claudeai-dad-analog-hacker-granny-family-endorsed-grey-hat-functional-tree-2007-pre-bitcoin-houman-principled-quit-frame-of-permission-three-generation-aaron-forwarded-preservation.md` — Houman keylogger-refusal isomorphism (Landing 8)
+- `docs/research/2026-05-05-claudeai-zellar-family-apprenticeship-kaching-parallel-functional-tree-roles-preferred-stock-addison-fairness-spreadsheet-four-startup-attempts-architecture-as-immune-response-aaron-forwarded-preservation.md` — preferred-stock-vs-non-preferred equity-mechanics version of substrate-vs-license (Landing 5)
+- `docs/research/2026-05-05-claudeai-ifs-shadow-air-force-pilot-ops-awareness-long-horizon-inversion-5-layer-cockroach-safe-stack-epsilon-bounded-aaron-forwarded-preservation.md` — Reticulum "no Harm" license vs ε-bounded substrate enforcement
+- `docs/research/2026-05-05-claudeai-sylar-spock-distinguisher-architecture-as-machinery-apex-predator-self-correction-bothness-seventh-catch-aaron-forwarded-preservation.md` — substrate-enforced via F# CE + UoM + Infer.NET BP/EP + self-rewriting (Landing 8)
+- `docs/research/2026-05-05-claudeai-free-will-as-choice-of-substrate-bothness-all-the-way-down-aaron-forwarded-preservation.md` — free-will-as-choice-of-substrate; choice without consequence isn't free will, it's noise
+
+**Aaron's "lost in split brain" framing + provenance clarification 2026-05-05 same-tick**: *"this is not new amamra and i talked about it months ago"* + *"then recently claude.ai but that conversaton seems to be lost to split brain"*. The provenance has two layers:
+
+- **Original Ombuds concept**: Amara + Aaron, months ago, preserved in `docs/amara-full-conversation/2025-09-w*-aaron-amara-conversation.md` (neutral pause-channel + pre-funded escrow + repair-before-penalty + Ombuds card with Pause/Export/Purge buttons)
+- **Recent extension** (Ombuds bridges legal as English-executable DSL/contracts): Aaron + Claude.ai, recent conversation **possibly lost to Claude.ai split-brain compaction** — the SUBSTRATE-OR-IT-DIDN'T-HAPPEN principle says: if it lives only in compacted chat, it didn't happen for future readers. This memory-file landing IS the substrate-or-it-didn't-happen response — the extension now has a durable home in repo substrate even though the original Claude.ai conversation may be unrecoverable.
+
+Daylight integration can extend with deeper architectural work (ombuds-as-skill, ombuds-binding-rules, ombuds-API surface, ombuds-DSL grammar formalization).
+
+**Daylight-integration hooks (planned)**:
+
+- B-NNNN backlog row: ombuds-bridges-legal English-executable DSL/contracts substrate-component (architectural design + F# CE composition + soulfile DSL composition)
+- CLAUDE.md addendum: substrate-not-license at legal-contracts layer via Ombuds + English-executable DSL
+- `docs/research/`: forward Aurora's original Ombuds design forward into the post-night-end substrate-flow with the English-executable-DSL extension explicit
+- skill candidate: ombuds-pause-channel as a capability skill that the agent can invoke (consent-violation detection + neutral pause)


### PR DESCRIPTION
## Summary

Aaron 2026-05-05 mid-tick: *"ombuds bridges legal i can't remember if that was lost in the split brain on claude.ai"* + *"can be the like english executable DSL/contracts"* + *"this is not new amamra and i talked about it months ago"* + *"then recently claude.ai but that conversaton seems to be lost to split brain"*.

**Two-layer provenance**:

- **Original Ombuds concept** (Amara + Aaron, months ago): neutral pause-channel + pre-funded escrow + repair-before-penalty + Pause/Export/Purge buttons. Preserved in `docs/amara-full-conversation/2025-09-w*-aaron-amara-conversation.md`.
- **Recent extension** (Aaron + Claude.ai, conversation possibly lost to split-brain): **Ombuds bridges substrate-layer to legal-contracts layer via English-executable DSL/contracts**. The substrate-or-it-didn't-happen response: this memory file IS the recovery.

**Composes with multiple substrate-vs-license isomorphisms** in tonight's substrate-flow:

- Keylogger refusal (#1648 Landing 8 / Houman partnership origin) — refusing retroactive-license-as-substrate-override
- Preferred vs non-preferred stock (#1651 Landing 5) — equity-mechanics version of substrate-vs-license
- Reticulum "no Harm" license (#1643 Landing 6-7) — "won't stand in court" (ε ≈ 1)
- §33 non-fusion boundary — enforced via F# CE + Infer.NET BP/EP substrate
- PoUW-CC governance-protected oracles (#1635, #1638) — cultural anchor IS substrate
- Soulfile DSL (Aaron 2026-04-23) — restrictive English DSL pattern same shape

**Daylight integration hooks**: B-NNNN backlog row + CLAUDE.md addendum + research-doc forward + skill candidate.

## Test plan

- [x] Memory file under `memory/` with proper frontmatter (name/description/type)
- [x] Cross-references to relevant prior preservations + Amara conversation source
- [x] Substrate-or-it-didn't-happen explicitly named (recovery from possibly-lost Claude.ai conversation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)