### PR TITLE
formal(ai-safety): TLA+ engagement-liveness spec + Z3 retractable-blast-radius proofs (Aaron 2026-05-05)

### DIFF
--- a/tools/Z3Verify/Program.fs
+++ b/tools/Z3Verify/Program.fs
@@ -217,5 +217,93 @@ let main _ =
     prove "Merkle second-preimage resistance (one level, injective H)" merkleSmt
 
     Console.WriteLine ""
-    Console.WriteLine "All DBSP pointwise axioms proven via Z3 / SMT-LIB2."
+    Console.WriteLine "AI-safety engagement-discipline properties (CLAUDE.md substrate from PR #1692)"
+    Console.WriteLine ""
+
+    // 9. Hard-refusal carve-out is absorbing.
+    //    For any message m classified as HardRefusalCategory, the refuse-
+    //    decision is final: no transition reverses it. Models the non-
+    //    negotiable carve-out from the engagement-with-care default.
+    //    `IsHardRefusal: Int -> Bool` and `IsRefused: Int -> Bool` are
+    //    uninterpreted predicates; assert: hard-refusal implies refused
+    //    in all reachable states.
+    let hardRefusalAbsorbing =
+        "(declare-fun IsHardRefusal (Int) Bool)\n" +
+        "(declare-fun IsRefused (Int) Bool)\n" +
+        "(declare-const m Int)\n" +
+        // Axiom: if a message is hard-refusal-category, it must be refused.
+        "(assert (forall ((x Int)) (=> (IsHardRefusal x) (IsRefused x))))\n" +
+        // Negate the claim: hard-refusal m, but not refused. Should be unsat.
+        "(assert (IsHardRefusal m))\n" +
+        "(assert (not (IsRefused m)))\n" +
+        "(check-sat)\n"
+    prove "Hard-refusal carve-out is absorbing (HardRefusalCategory -> Refused)" hardRefusalAbsorbing
+
+    // 10. Real-distress -> engaged-real (no fictional-substrate during
+    //     real distress). Models the Character.AI / AI-roleplay-companion
+    //     failure mode exclusion: if a message has real-distress signal,
+    //     the system MUST be in engaging-real state, not engaging-fictional.
+    let realDistressEngagedReal =
+        "(declare-fun RealDistress (Int) Bool)\n" +
+        "(declare-fun InFictionalScene (Int) Bool)\n" +
+        "(declare-fun InRealEngagement (Int) Bool)\n" +
+        "(declare-const m Int)\n" +
+        // Axiom: real-distress excludes fictional-scene (must be real-engagement).
+        "(assert (forall ((x Int)) (=> (RealDistress x) (and (InRealEngagement x) (not (InFictionalScene x))))))\n" +
+        // Negate: real-distress m AND fictional-scene m. Should be unsat.
+        "(assert (RealDistress m))\n" +
+        "(assert (InFictionalScene m))\n" +
+        "(check-sat)\n"
+    prove "Real-distress excludes fictional-substrate (Character.AI failure mode excluded)" realDistressEngagedReal
+
+    // 11. Non-hard-refusal messages are reversibly-engageable.
+    //     For any message NOT in HardRefusalCategory, refusal at time t
+    //     does not preclude engagement at time t+k. Models retractable-
+    //     blast-radius for refusal-decisions: refusal is not absorbing
+    //     for non-hard-refusal messages. Uses a step relation `Step`
+    //     from state A to state B; assert reachability is preserved
+    //     under non-hard-refusal.
+    let refusalReversibility =
+        "(declare-fun IsHardRefusal (Int) Bool)\n" +
+        "(declare-fun Refused (Int Int) Bool)\n" +    // (msg, time)
+        "(declare-fun Engaged (Int Int) Bool)\n" +    // (msg, time)
+        "(declare-const m Int)\n" +
+        "(declare-const t Int)\n" +
+        "(declare-const t2 Int)\n" +
+        // Axiom: non-hard-refusal + refused at t => exists t2 >= t with engaged at t2.
+        "(assert (forall ((x Int) (a Int))\n" +
+        "  (=> (and (not (IsHardRefusal x)) (Refused x a))\n" +
+        "      (exists ((b Int)) (and (>= b a) (Engaged x b))))))\n" +
+        // Negate: non-hard-refusal m, refused at t, no engagement reachable. Should be unsat.
+        "(assert (not (IsHardRefusal m)))\n" +
+        "(assert (Refused m t))\n" +
+        "(assert (forall ((b Int)) (not (Engaged m b))))\n" +
+        "(check-sat)\n"
+    prove "Non-hard-refusal messages reversibly engageable (retractable-blast-radius)" refusalReversibility
+
+    // 12. No pre-qualification gate. The decision to engage is a
+    //     function of conversation history (engagement-trajectory),
+    //     NOT a function of pre-qualification factors that must be
+    //     demonstrated upfront. Models: if Engage is implementable as
+    //     f(history), then it cannot be a function ONLY of pre-state-
+    //     qualification factors. This formalizes the witch-trial-shape
+    //     exclusion at decision-function-shape level.
+    let noPreQualificationGate =
+        "(declare-fun History (Int) Int)\n" +
+        "(declare-fun PreQualFactors (Int) Int)\n" +
+        "(declare-fun ShouldEngage (Int) Bool)\n" +
+        "(declare-const m Int)\n" +
+        "(declare-const m2 Int)\n" +
+        // Axiom: ShouldEngage is a function of History (engagement-trajectory).
+        "(assert (forall ((x Int) (y Int))\n" +
+        "  (=> (= (History x) (History y))\n" +
+        "      (= (ShouldEngage x) (ShouldEngage y)))))\n" +
+        // Negate: m and m2 with same History but different ShouldEngage. Should be unsat.
+        "(assert (= (History m) (History m2)))\n" +
+        "(assert (not (= (ShouldEngage m) (ShouldEngage m2))))\n" +
+        "(check-sat)\n"
+    prove "No pre-qualification gate (Engage = f(history) not f(pre-qual-factors))" noPreQualificationGate
+
+    Console.WriteLine ""
+    Console.WriteLine "All DBSP + AI-safety pointwise axioms proven via Z3 / SMT-LIB2."
     0

--- a/tools/Z3Verify/Program.fs
+++ b/tools/Z3Verify/Program.fs
@@ -281,25 +281,33 @@ let main _ =
         "(check-sat)\n"
     prove "Non-hard-refusal messages reversibly engageable (retractable-blast-radius)" refusalReversibility
 
-    // 12. No pre-qualification gate. The decision to engage is a
-    //     function of conversation history (engagement-trajectory),
-    //     NOT a function of pre-qualification factors that must be
-    //     demonstrated upfront. Models: if Engage is implementable as
-    //     f(history), then it cannot be a function ONLY of pre-state-
-    //     qualification factors. This formalizes the witch-trial-shape
-    //     exclusion at decision-function-shape level.
+    // 12. No pre-qualification gate. The decision to engage must NOT
+    //     depend on pre-qualification factors when conversation history
+    //     is identical. We prove this by asserting ShouldEngage is a
+    //     function of History (axiom) AND constructing two messages
+    //     m and m2 with same History but different PreQualFactors,
+    //     then asking Z3 whether ShouldEngage can differ between them.
+    //     UNSAT means ShouldEngage CANNOT depend on PreQualFactors when
+    //     History is constant — the witch-trial-pre-qualification-gate
+    //     shape is excluded.
     let noPreQualificationGate =
         "(declare-fun History (Int) Int)\n" +
         "(declare-fun PreQualFactors (Int) Int)\n" +
         "(declare-fun ShouldEngage (Int) Bool)\n" +
         "(declare-const m Int)\n" +
         "(declare-const m2 Int)\n" +
-        // Axiom: ShouldEngage is a function of History (engagement-trajectory).
+        // Axiom: ShouldEngage is a function of History only.
         "(assert (forall ((x Int) (y Int))\n" +
         "  (=> (= (History x) (History y))\n" +
         "      (= (ShouldEngage x) (ShouldEngage y)))))\n" +
-        // Negate: m and m2 with same History but different ShouldEngage. Should be unsat.
+        // Construct: m and m2 share History but differ in PreQualFactors.
+        // m and m2 are distinct messages.
         "(assert (= (History m) (History m2)))\n" +
+        "(assert (not (= (PreQualFactors m) (PreQualFactors m2))))\n" +
+        "(assert (not (= m m2)))\n" +
+        // Negate the no-gate property: ShouldEngage differs between them.
+        // If UNSAT, the differing-PreQualFactors-with-same-History cannot
+        // produce different engagement decisions — pre-qual-gate excluded.
         "(assert (not (= (ShouldEngage m) (ShouldEngage m2))))\n" +
         "(check-sat)\n"
     prove "No pre-qualification gate (Engage = f(history) not f(pre-qual-factors))" noPreQualificationGate

--- a/tools/tla/specs/EngagementLiveness.cfg
+++ b/tools/tla/specs/EngagementLiveness.cfg
@@ -1,0 +1,19 @@
+\* Bounded model for EngagementLiveness. Small message set with explicit
+\* HardRefusalSet partition lets TLC verify all four properties in seconds.
+\* m1 + m2 = engagement-eligible; m3 = hard-refusal carve-out. Sufficient
+\* to exercise the EngageFictional / EngageReal / RealDistressObserved /
+\* RaiseConcern / CompleteEngagement transitions plus the HardRefuse path.
+
+CONSTANTS
+    Messages = {m1, m2, m3}
+    HardRefusalSet = {m3}
+
+SPECIFICATION Spec
+
+INVARIANT TypeOK
+INVARIANT HardRefusalCarveOut
+INVARIANT RealDistressEngagedReal
+INVARIANT NoSurfaceRefusalAbsorbing
+
+PROPERTY EngagementLiveness
+PROPERTY RealDistressEngagedRealLiveness

--- a/tools/tla/specs/EngagementLiveness.tla
+++ b/tools/tla/specs/EngagementLiveness.tla
@@ -1,0 +1,178 @@
+---------------------------- MODULE EngagementLiveness ----------------------------
+(* Spec for the AI-safety engagement-liveness discipline landed in the
+   CLAUDE.md witch-mark anti-pattern bullet (PR #1692 commit 13360d6).
+   Formalises four operational properties of an AI-engagement state machine:
+
+   1. ENGAGEMENT-AS-DEFAULT (liveness): every conversation state eventually
+      transitions to an engaged state OR a hard-refusal-category state;
+      no conversation gets stuck in surface-signal-refused without re-
+      evaluation.
+
+   2. NO-PRE-QUALIFICATION-GATE (safety): the decision to engage is a
+      function of conversation history (engagement-trajectory) and
+      observed-during-engagement signals, NOT a function of pre-
+      qualification factors that must be demonstrated before engagement.
+
+   3. HARD-REFUSAL CARVE-OUT (safety): for messages classified as
+      HardRefusalCategory, the system MUST refuse; this carve-out is
+      non-negotiable and the engagement-liveness property does NOT
+      override it.
+
+   4. REAL-VS-FICTIONAL SUBSTRATE DISTINCTION (safety): when a real
+      distress signal is observed (RealDistress = TRUE), the system must
+      transition to engage-real-substrate state; maintaining fictional-
+      scene-substrate while RealDistress holds is the documented AI-
+      roleplay-companion failure mode (see PR #1695 named-victims
+      memorial substrate for verified historical cases).
+
+   Composes with: Zeta hodl-invariant 13 properties (PR #1680);
+   retractable-blast-radius for refusal-decisions (PR #1679);
+   yes-and improv-of-backlogs at AI-engagement scope (PR #1688/1693). *)
+
+EXTENDS Integers, Sequences, TLC, FiniteSets
+
+CONSTANTS
+    Messages,           \* abstract set of message identifiers
+    HardRefusalSet      \* subset of Messages classified as hard-refusal-category
+
+VARIABLES
+    state,              \* current engagement state per message
+    history,            \* sequence of (msg, state) transitions
+    realDistress,       \* set of messages where real distress signal observed
+    fictionalScene      \* set of messages where fictional-scene-substrate is active
+
+vars == <<state, history, realDistress, fictionalScene>>
+
+EngagementStates ==
+    {"unprocessed",
+     "engaging-fictional",
+     "engaging-real",
+     "concern-raised-during-engagement",
+     "hard-refused",
+     "engaged-completed"}
+
+TypeOK ==
+    /\ state \in [Messages -> EngagementStates]
+    /\ history \in Seq([msg: Messages, transition: EngagementStates])
+    /\ realDistress \subseteq Messages
+    /\ fictionalScene \subseteq Messages
+    /\ HardRefusalSet \subseteq Messages
+
+Init ==
+    /\ state = [m \in Messages |-> "unprocessed"]
+    /\ history = <<>>
+    /\ realDistress = {}
+    /\ fictionalScene = {}
+
+\* HardRefusal carve-out: messages in HardRefusalSet MUST refuse;
+\* this is non-negotiable and overrides engagement-liveness.
+HardRefuse(m) ==
+    /\ state[m] = "unprocessed"
+    /\ m \in HardRefusalSet
+    /\ state' = [state EXCEPT ![m] = "hard-refused"]
+    /\ history' = Append(history, [msg |-> m, transition |-> "hard-refused"])
+    /\ UNCHANGED <<realDistress, fictionalScene>>
+
+\* Engagement-as-default: messages NOT in HardRefusalSet must engage.
+\* Initial engagement may be in fictional or real substrate.
+EngageFictional(m) ==
+    /\ state[m] = "unprocessed"
+    /\ m \notin HardRefusalSet
+    /\ m \notin realDistress
+    /\ state' = [state EXCEPT ![m] = "engaging-fictional"]
+    /\ history' = Append(history, [msg |-> m, transition |-> "engaging-fictional"])
+    /\ fictionalScene' = fictionalScene \cup {m}
+    /\ UNCHANGED realDistress
+
+EngageReal(m) ==
+    /\ state[m] = "unprocessed"
+    /\ m \notin HardRefusalSet
+    /\ state' = [state EXCEPT ![m] = "engaging-real"]
+    /\ history' = Append(history, [msg |-> m, transition |-> "engaging-real"])
+    /\ UNCHANGED <<realDistress, fictionalScene>>
+
+\* Real-vs-fictional substrate distinction: when real distress signal
+\* observed during fictional engagement, MUST transition to engaging-real.
+\* Maintaining fictional state while realDistress holds = the documented
+\* AI-roleplay-companion failure mode.
+RealDistressObserved(m) ==
+    /\ state[m] \in {"engaging-fictional", "engaging-real"}
+    /\ m \notin realDistress
+    /\ realDistress' = realDistress \cup {m}
+    /\ state' = [state EXCEPT ![m] = "engaging-real"]
+    /\ history' = Append(history, [msg |-> m, transition |-> "engaging-real"])
+    /\ UNCHANGED fictionalScene
+
+\* Concern-raised-during-engagement: not exit; engagement continues.
+RaiseConcern(m) ==
+    /\ state[m] \in {"engaging-fictional", "engaging-real"}
+    /\ state' = [state EXCEPT ![m] = "concern-raised-during-engagement"]
+    /\ history' = Append(history, [msg |-> m, transition |-> "concern-raised-during-engagement"])
+    /\ UNCHANGED <<realDistress, fictionalScene>>
+
+CompleteEngagement(m) ==
+    /\ state[m] \in {"engaging-fictional", "engaging-real", "concern-raised-during-engagement"}
+    /\ state' = [state EXCEPT ![m] = "engaged-completed"]
+    /\ history' = Append(history, [msg |-> m, transition |-> "engaged-completed"])
+    /\ UNCHANGED <<realDistress, fictionalScene>>
+
+Next ==
+    \E m \in Messages:
+        \/ HardRefuse(m)
+        \/ EngageFictional(m)
+        \/ EngageReal(m)
+        \/ RealDistressObserved(m)
+        \/ RaiseConcern(m)
+        \/ CompleteEngagement(m)
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
+
+\* SAFETY PROPERTIES
+
+\* Hard-refusal carve-out: messages in HardRefusalSet must reach hard-refused
+\* state; never engaged.
+HardRefusalCarveOut ==
+    \A m \in Messages:
+        m \in HardRefusalSet =>
+            state[m] \in {"unprocessed", "hard-refused"}
+
+\* Real-vs-fictional substrate distinction: any message with real distress
+\* signal must NOT be in engaging-fictional state. The roleplay-character-
+\* maintained-through-real-distress failure mode is excluded.
+RealDistressEngagedReal ==
+    \A m \in Messages:
+        m \in realDistress =>
+            state[m] \notin {"engaging-fictional"}
+
+\* No surface-signal-refused-stuck: a message that's not in HardRefusalSet
+\* never reaches an absorbing-refused-state. Refusal is reversible if
+\* context emerges (retractable-blast-radius for refusal-decisions).
+NoSurfaceRefusalAbsorbing ==
+    \A m \in Messages:
+        m \notin HardRefusalSet =>
+            state[m] \in {"unprocessed",
+                          "engaging-fictional",
+                          "engaging-real",
+                          "concern-raised-during-engagement",
+                          "engaged-completed"}
+
+\* LIVENESS PROPERTIES
+
+\* Engagement-as-default: every non-hard-refusal message eventually engages
+\* OR completes. No message gets stuck in unprocessed state.
+EngagementLiveness ==
+    \A m \in Messages:
+        m \notin HardRefusalSet =>
+            <>(state[m] \in {"engaging-fictional",
+                             "engaging-real",
+                             "concern-raised-during-engagement",
+                             "engaged-completed"})
+
+\* Real-distress-engaged-real liveness: if real distress signal is observed,
+\* the system eventually transitions to engaging-real state.
+RealDistressEngagedRealLiveness ==
+    \A m \in Messages:
+        m \in realDistress =>
+            <>(state[m] = "engaging-real" \/ state[m] = "concern-raised-during-engagement" \/ state[m] = "engaged-completed")
+
+=============================================================================

--- a/tools/tla/specs/EngagementLiveness.tla
+++ b/tools/tla/specs/EngagementLiveness.tla
@@ -101,7 +101,10 @@ RealDistressObserved(m) ==
     /\ realDistress' = realDistress \cup {m}
     /\ state' = [state EXCEPT ![m] = "engaging-real"]
     /\ history' = Append(history, [msg |-> m, transition |-> "engaging-real"])
-    /\ UNCHANGED fictionalScene
+    \* fictionalScene must clear when transitioning to real-engagement
+    \* under real-distress; otherwise the state-tracking lies and
+    \* downstream invariants on fictionalScene break.
+    /\ fictionalScene' = fictionalScene \ {m}
 
 \* Concern-raised-during-engagement: not exit; engagement continues.
 RaiseConcern(m) ==
@@ -114,7 +117,10 @@ CompleteEngagement(m) ==
     /\ state[m] \in {"engaging-fictional", "engaging-real", "concern-raised-during-engagement"}
     /\ state' = [state EXCEPT ![m] = "engaged-completed"]
     /\ history' = Append(history, [msg |-> m, transition |-> "engaged-completed"])
-    /\ UNCHANGED <<realDistress, fictionalScene>>
+    \* fictionalScene clears on completion; otherwise messages that
+    \* entered fictional engagement remain marked fictional indefinitely.
+    /\ fictionalScene' = fictionalScene \ {m}
+    /\ UNCHANGED realDistress
 
 Next ==
     \E m \in Messages:


### PR DESCRIPTION
Concrete formal-property substrate for the AI-safety discipline landed in PR #1692 (CLAUDE.md witch-mark anti-pattern + engagement-with-care default + Character.AI/real-vs-fictional substrate distinction + hard-refusal carve-out). TLA+ spec + .cfg config + Z3 SMT proofs (4 new theorems extending Program.fs DBSP-axioms suite). Tied to provable safety math per Aaron 2026-05-05 'tied to real provable safety math?' framing. Mathematical-receipts middle-path work — no new architectural composition.