### PR TITLE
feat: multi-loop commit attribution + shared-branch coordination

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -35,6 +35,22 @@ Before editing:
 - Name intended path prefixes in the heartbeat.
 - Do not commit heartbeat files.
 
+## Commit Attribution
+
+Every Codex commit **must** include:
+
+```
+Co-Authored-By: Codex <noreply@openai.com>
+```
+
+This trailer is how parallel loops (Otto on Claude
+Code, Riven on Cursor/Grok, Vera on Codex) tell
+each other's commits apart. Without it, all commits
+look identical to the git user — breaking multi-loop
+coordination and audit. See `AGENTS.md` §"Commit
+attribution — harness-specific trailers" for the
+full convention.
+
 ## Ownership Boundary
 
 Codex owns `.codex/**` content and Codex-authored skills.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,7 +420,7 @@ impossible.
 | OpenAI Codex — Vera (GPT 5.5 max) | `Co-Authored-By: Codex <noreply@openai.com>` |
 | Cursor — Riven (Grok 4.3 max) | `Co-Authored-By: Grok <noreply@x.ai>` |
 | Gemini CLI | `Co-Authored-By: Gemini <noreply@google.com>` |
-| Human contributor | _(git author is sufficient)_ |
+| Human contributor | *(git author is sufficient)* |
 
 The model version may be appended for precision
 (e.g. `Claude Opus 4.6 (1M context)`) but the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -416,9 +416,9 @@ impossible.
 
 | Harness | Trailer |
 |---------|---------|
-| Claude Code (Otto) | `Co-Authored-By: Claude <noreply@anthropic.com>` |
-| OpenAI Codex (Vera) | `Co-Authored-By: Codex <noreply@openai.com>` |
-| Cursor + Grok (Riven) | `Co-Authored-By: Grok <noreply@x.ai>` |
+| Claude Code — Otto (Claude Opus 4.7 max) | `Co-Authored-By: Claude <noreply@anthropic.com>` |
+| OpenAI Codex — Vera (GPT 5.5 max) | `Co-Authored-By: Codex <noreply@openai.com>` |
+| Cursor — Riven (Grok 4.3 max) | `Co-Authored-By: Grok <noreply@x.ai>` |
 | Gemini CLI | `Co-Authored-By: Gemini <noreply@google.com>` |
 | Human contributor | _(git author is sufficient)_ |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,6 +401,54 @@ Detail lives in:
   description. "Why" beats "what" because `git
   diff` already carries the "what".
 
+### Commit attribution — harness-specific trailers
+
+Every AI-authored commit **must** include a
+`Co-Authored-By` trailer that identifies the model
+and harness. This is how parallel loops (Otto, Vera,
+Riven, future agents) tell each other's commits
+apart. Without distinct trailers, all commits look
+like they came from the same git user — making
+multi-loop coordination, audit, and PR review
+impossible.
+
+**Required trailers by harness:**
+
+| Harness | Trailer |
+|---------|---------|
+| Claude Code (Otto) | `Co-Authored-By: Claude <noreply@anthropic.com>` |
+| OpenAI Codex (Vera) | `Co-Authored-By: Codex <noreply@openai.com>` |
+| Cursor + Grok (Riven) | `Co-Authored-By: Grok <noreply@x.ai>` |
+| Gemini CLI | `Co-Authored-By: Gemini <noreply@google.com>` |
+| Human contributor | _(git author is sufficient)_ |
+
+The model version may be appended for precision
+(e.g. `Claude Opus 4.6 (1M context)`) but the
+harness name alone is the minimum. The trailer goes
+on every commit, including claim/progress/release
+commits from the agent claim protocol.
+
+### Shared-branch work (multi-loop PRs)
+
+Two or more loops can contribute commits to the same
+PR branch. The coordination mechanism:
+
+1. **Co-claim** the work via the agent claim protocol
+   (`docs/AGENT-CLAIM-PROTOCOL.md`) — add both
+   session IDs to a single claim file.
+2. Both loops **pull before pushing** (no force-push
+   on shared branches).
+3. The `Co-Authored-By` trailer on each commit tells
+   reviewers (and each other) who contributed what.
+4. Merge conflicts are resolved by the loop that
+   encounters them — standard git conflict
+   resolution; the claim protocol's "first pusher
+   wins" applies per-commit, not per-branch.
+
+This is how Otto and Vera weave commits on the same
+PR: distinct trailers, shared branch, co-claim
+coordination, pull-before-push discipline.
+
 ## Contributor required reading
 
 - `docs/VISION.md` — long-horizon research targets

--- a/docs/AGENT-CLAIM-PROTOCOL.md
+++ b/docs/AGENT-CLAIM-PROTOCOL.md
@@ -545,6 +545,23 @@ platform. If the platform is down, the claim still exists.
   fork, open the PR from the fork. If you have no write
   access anywhere, file a BACKLOG row or issue and stop.
 
+## Commit attribution in shared PRs
+
+When two loops co-claim work and push to the same
+branch, their commits are distinguished by the
+`Co-Authored-By` trailer convention defined in
+`AGENTS.md` §"Commit attribution — harness-specific
+trailers". Each harness has a required trailer
+(Claude → `noreply@anthropic.com`, Codex →
+`noreply@openai.com`, Grok → `noreply@x.ai`, etc.).
+Filter by trailer email to see each loop's
+contribution:
+
+```
+git log --grep="noreply@openai.com" --oneline   # Vera's commits
+git log --grep="noreply@anthropic.com" --oneline # Otto's commits
+```
+
 ## References
 
 - [`AGENT-ISSUE-WORKFLOW.md`](AGENT-ISSUE-WORKFLOW.md) —


### PR DESCRIPTION
## Summary

- Adds harness-specific `Co-Authored-By` trailer requirements to AGENTS.md so parallel loops (Otto/Claude, Vera/Codex, Riven/Grok) produce distinguishable commits
- Adds shared-branch work section to the agent claim protocol for multi-loop PRs (co-claim + pull-before-push + trailer differentiation)
- Updates `.codex/AGENTS.md` with Vera's required trailer: `Co-Authored-By: Codex <noreply@openai.com>`

Without distinct trailers, all AI commits look identical to the git user — making multi-loop coordination, audit, and PR review impossible. This was surfaced by Aaron observing that Otto and Vera commits on the same repo are indistinguishable.

## Test plan

- [ ] Verify Otto commits include `Co-Authored-By: Claude <noreply@anthropic.com>` (already the case)
- [ ] Verify Vera/Codex picks up the `.codex/AGENTS.md` update and starts including `Co-Authored-By: Codex <noreply@openai.com>`
- [ ] Verify `git log --grep="noreply@openai.com"` correctly filters Vera commits after convention is adopted
- [ ] Verify Cursor/Riven adjusts from `cursoragent@cursor.com` to `noreply@x.ai` per the new convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)