### PR TITLE
feat: .broadcasts/ gitignore — local multi-loop coordination bus

### DIFF
--- a/.claude/bin/claude-forward-tick.ts
+++ b/.claude/bin/claude-forward-tick.ts
@@ -75,7 +75,32 @@ function releaseLock(): void {
   try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* best effort */ }
 }
 
+function readBroadcasts(): void {
+  const broadcastDir = join(home, ".local/share/zeta-broadcasts");
+  const peers = ["vera.md", "riven.md"];
+  for (const peer of peers) {
+    const path = join(broadcastDir, peer);
+    if (existsSync(path)) {
+      const content = readFileSync(path, "utf8").trim();
+      if (content) log(`broadcast from ${peer.replace(".md", "")}: ${content.split("\n")[0] ?? "(empty)"}`);
+    }
+  }
+}
+
+function writeBroadcast(summary: string): void {
+  const broadcastDir = join(home, ".local/share/zeta-broadcasts");
+  mkdirSync(broadcastDir, { recursive: true });
+  writeFileSync(join(broadcastDir, "otto.md"), [
+    `# Otto broadcast — ${nowIso()}`,
+    "",
+    "## Background tick status",
+    summary,
+  ].join("\n"));
+}
+
 function forward(): void {
+  readBroadcasts();
+
   // Fetch
   const fetch = git("fetch", "--quiet", "origin");
   if (fetch.status !== 0) {
@@ -131,12 +156,14 @@ function forward(): void {
           "--squash", "--auto"
         );
         log(`auto-merge result PR #${pr} status=${merge.status}`);
+        writeBroadcast(`Forward tick ${runId}: armed auto-merge on PR #${pr}.`);
         return; // one action per tick
       }
     } catch { continue; }
   }
 
   log(`no actionable PR found, idle tick`);
+  writeBroadcast(`Forward tick ${runId}: idle — no actionable PR. ${prNumbers.length} open.`);
 }
 
 // Main

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ Spine/
 # Alloy runner compiled-class scratch directory — produced by `javac
 # tools/alloy/AlloyRunner.java` on first test run. Regenerated; not source.
 tools/alloy/classes/
+.broadcasts/


### PR DESCRIPTION
## Summary

- Adds `.broadcasts/` to `.gitignore` — symlink to `~/.local/share/zeta-broadcasts/`
- Shared filesystem bus where all 3 loops (Otto/Vera/Riven) post broadcasts
- Accessible by interactive sessions AND background launchd services
- Each loop owns `{name}.md`, reads the other two on tick

## Test plan

- [x] `ls .broadcasts/` shows symlinked content
- [x] Gitignore prevents the symlink from being tracked
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)