### PR TITLE
backlog(B-0208): launchd forward-tick reliability

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -163,6 +163,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0196](backlog/P2/B-0196-bigint-and-bignumber-integration-aaron-2026-05-05.md)** BigInt + BigRational + BigDecimal + BigFloat integration -- substrate survey + per-class adoption recommendation (Aaron 2026-05-05)
 - [ ] **[B-0197](backlog/P2/B-0197-lean-prop-3-5-misattribution-cleanup-aaron-2026-05-05.md)** Lean DbspChainRule + chain-rule-proof-log -- correct Prop 3.5 misattribution to Theorem 3.3 (Aaron 2026-05-05)
 - [ ] **[B-0206](backlog/P2/B-0206-claude-code-env-mapping-skill-with-carved-sentences-references-ts-files-aaron-2026-05-05.md)** Claude Code environment-mapping skill with carved-sentences-in-behavior referencing existing capability-maps + our TS files
+- [ ] **[B-0208](backlog/P2/B-0208-launchd-forward-tick-reliability-merge-into-heartbeat-2026-05-06.md)** Launchd forward-tick reliability — merge forward logic into working heartbeat tick OR fix StartInterval for new services
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-0208-launchd-forward-tick-reliability-merge-into-heartbeat-2026-05-06.md
+++ b/docs/backlog/P2/B-0208-launchd-forward-tick-reliability-merge-into-heartbeat-2026-05-06.md
@@ -1,0 +1,59 @@
+---
+id: B-0208
+priority: P2
+status: open
+title: "Launchd forward-tick reliability — merge forward logic into working heartbeat tick OR fix StartInterval for new services"
+created: 2026-05-06
+last_updated: 2026-05-06
+depends_on: []
+---
+
+# B-0208 — Launchd forward-tick reliability
+
+## Problem
+
+macOS launchd `StartInterval` does not fire for services loaded
+mid-session on this machine. The pre-existing `claude-loop` (loaded
+at login) works reliably (46+ runs). New services (`claude-forward`,
+`otto-forward`) only get `RunAtLoad` — the interval timer never
+fires. Tested with `StartInterval` (300s, 1800s) and
+`StartCalendarInterval` (every 5 min). Fresh label registration
+did not fix. System-level issue, not config.
+
+## Observed 2026-05-06
+
+- `com.zeta.claude-loop`: runs=46, interval=60s — works
+- `com.zeta.claude-forward`: runs=1 — only RunAtLoad
+- `com.zeta.otto-forward` (fresh label): runs=1 — only RunAtLoad
+- `com.zeta.codex-loop`: runs=many — works (loaded at login)
+
+## Fix options (ranked)
+
+1. **Merge forward-action logic into `claude-loop-tick.ts`** (P1
+   approach). The heartbeat already runs every 60s. Add an internal
+   timer (timestamp-file-gated, check every 5 min) for the
+   forward-progress actions. One service, one interval, proven
+   working. Blocked by classifier in first attempt (2026-05-06) —
+   the edit pattern "script spawns Claude with tool access" was
+   flagged. The current forward-tick uses `gh` CLI directly, not
+   Claude subprocess, so the classifier concern may not apply to
+   this merge.
+
+2. **Reboot** to clear launchd state, then load forward service
+   fresh. Disruptive but likely fixes the StartInterval issue for
+   new services.
+
+3. **Use crontab instead of launchd** for the forward tick.
+   `crontab -e` with `*/5 * * * * /opt/homebrew/bin/bun ...` is
+   simpler and doesn't suffer the StartInterval bug.
+
+4. **Accept limitation** — interactive session cron handles forward
+   actions while running. Background gap exists when no session is
+   active.
+
+## Composes with
+
+- `.claude/bin/claude-loop-tick.ts` (heartbeat — the merge target)
+- `.claude/bin/claude-forward-tick.ts` (forward worker — standalone)
+- B-0156 TS standardization (both scripts are TS)
+- 3-loop BFT coordination (forward tick is Otto's autonomous write layer)


### PR DESCRIPTION
## Summary

- Files B-0208: launchd StartInterval doesn't fire for new services on this machine
- 4 fix options ranked (merge into heartbeat > reboot > crontab > accept)
- Properly backlogged per Aaron's "backlog all these features for proper design"

## Test plan

- [ ] CI passes (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)