### PR TITLE
backlog(B-0215): harness parity audit for Riven learning

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -65,6 +65,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0213](backlog/P1/B-0213-broadcast-bus-production-hardening-schema-ttl-receipts-2026-05-06.md)** Broadcast bus production hardening — structured schema, TTL, receipts, conflict detection
 - [x] **[B-0214](backlog/P1/B-0214-backlog-decomposition-skill-dependency-ordering-2026-05-06.md)** Backlog decomposition skill — break architectural directions into dependency-ordered items
 - [ ] **[B-0215](backlog/P1/B-0215-alignment-rewrite-survey-preserve-refine-add-map-2026-05-06.md)** ALIGNMENT.md rewrite survey - preserve/refine/add map
+- [ ] **[B-0215](backlog/P1/B-0215-harness-parity-audit-otto-setup-for-riven-learning-2026-05-06.md)** Harness parity audit — document Otto's session setup so Riven (and future nodes) can approximate the same autonomy
 - [ ] **[B-0216](backlog/P1/B-0216-alignment-finite-resource-collisions-foundation-2026-05-06.md)** ALIGNMENT.md rewrite - finite-resource collisions foundation
 - [ ] **[B-0217](backlog/P1/B-0217-alignment-bidirectional-clause-audit-tightening-2026-05-06.md)** ALIGNMENT.md rewrite - bidirectional clause audit and tightening
 - [ ] **[B-0218](backlog/P1/B-0218-alignment-factory-superfluid-empirical-calibration-2026-05-06.md)** ALIGNMENT.md rewrite - factory-as-superfluid empirical calibration

--- a/docs/backlog/P1/B-0215-harness-parity-audit-otto-setup-for-riven-learning-2026-05-06.md
+++ b/docs/backlog/P1/B-0215-harness-parity-audit-otto-setup-for-riven-learning-2026-05-06.md
@@ -1,0 +1,56 @@
+---
+id: B-0215
+priority: P1
+status: open
+title: "Harness parity audit — document Otto's session setup so Riven (and future nodes) can approximate the same autonomy"
+created: 2026-05-06
+last_updated: 2026-05-06
+depends_on: [B-0208]
+decomposition: atomic
+---
+
+# B-0215 — Harness parity audit
+
+Otto (Claude Code) has capabilities Riven (Cursor) doesn't:
+- CronCreate (session-scoped cron, fires every minute)
+- Auto-mode (continuous autonomous execution)
+- Tool permissions (granular allowedTools)
+- Session compaction (harness manages context automatically)
+
+Riven has:
+- Per-turn gate only (fires when Aaron types)
+- alwaysApply rules (static, not timer-driven)
+- Background launchd loop (healthy but conservative)
+
+## Deliverables
+
+1. **Document Otto's session setup** — CronCreate config,
+   auto-mode settings, tool permissions, .claude/settings.json
+   relevant entries. Make this a "how to set up a productive
+   Claude Code session" reference.
+
+2. **Map Cursor equivalents** — for each Otto capability, what's
+   the closest Cursor approximation? Where is there no equivalent?
+
+3. **Codex comparison** — Vera starts with `danger-full-access`
+   (allow everything). Document what that gives her and what the
+   safe-actions list (SAFE-AUTONOMOUS-ACTIONS.md) constrains.
+
+4. **Riven improvement path** — specific changes to
+   `.cursor/bin/riven-loop-tick.ts` and `.cursor/rules/` that
+   would close the autonomy gap within Cursor's constraints.
+
+5. **Monitor Cursor for timer hooks** — when Cursor adds
+   timer/scheduler hooks, Riven should be first to wire them.
+
+## Why P1
+
+Riven's lower throughput is partly harness constraint, not
+capability. Closing the harness gap directly increases the
+BFT's weakest node, which improves the whole system.
+
+## Composes with
+
+- B-0208 (launchd forward-tick reliability)
+- B-0209 (remote-only background agent test matrix)
+- docs/SAFE-AUTONOMOUS-ACTIONS.md

--- a/docs/backlog/P1/B-0215-harness-parity-audit-otto-setup-for-riven-learning-2026-05-06.md
+++ b/docs/backlog/P1/B-0215-harness-parity-audit-otto-setup-for-riven-learning-2026-05-06.md
@@ -12,12 +12,14 @@ decomposition: atomic
 # B-0215 — Harness parity audit
 
 Otto (Claude Code) has capabilities Riven (Cursor) doesn't:
+
 - CronCreate (session-scoped cron, fires every minute)
 - Auto-mode (continuous autonomous execution)
 - Tool permissions (granular allowedTools)
 - Session compaction (harness manages context automatically)
 
 Riven has:
+
 - Per-turn gate only (fires when Aaron types)
 - alwaysApply rules (static, not timer-driven)
 - Background launchd loop (healthy but conservative)


### PR DESCRIPTION
## Summary

- Files B-0215: document Otto's session setup so Riven can approximate the same autonomy
- Maps Claude Code capabilities → Cursor equivalents → gaps
- Codex starts allow-everything (valid starting point, cut down later)
- Monitor Cursor for timer hooks — Riven should be first to wire them

Motivated by Aaron's observation: "if you were like that [per-turn only] would you be as good?"

## Test plan

- [ ] CI passes (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)