### PR TITLE
fix(backlog): resolve duplicate IDs B-0215 and B-0216

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -65,9 +65,9 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0213](backlog/P1/B-0213-broadcast-bus-production-hardening-schema-ttl-receipts-2026-05-06.md)** Broadcast bus production hardening — structured schema, TTL, receipts, conflict detection
 - [x] **[B-0214](backlog/P1/B-0214-backlog-decomposition-skill-dependency-ordering-2026-05-06.md)** Backlog decomposition skill — break architectural directions into dependency-ordered items
 - [ ] **[B-0215](backlog/P1/B-0215-alignment-rewrite-survey-preserve-refine-add-map-2026-05-06.md)** ALIGNMENT.md rewrite survey - preserve/refine/add map
-- [ ] **[B-0215](backlog/P1/B-0215-harness-parity-audit-otto-setup-for-riven-learning-2026-05-06.md)** Harness parity audit — document Otto's session setup so Riven (and future nodes) can approximate the same autonomy
+- [ ] **[B-0238](backlog/P1/B-0238-harness-parity-audit-otto-setup-for-riven-learning-2026-05-06.md)** Harness parity audit — document Otto's session setup so Riven (and future nodes) can approximate the same autonomy
 - [ ] **[B-0216](backlog/P1/B-0216-alignment-finite-resource-collisions-foundation-2026-05-06.md)** ALIGNMENT.md rewrite - finite-resource collisions foundation
-- [ ] **[B-0216](backlog/P1/B-0216-shadow-work-as-ai-debugger-for-regular-people-product-pitch-2026-05-06.md)** Shadow work as AI debugger for regular people — product pitch + on-ramp design
+- [ ] **[B-0239](backlog/P1/B-0239-shadow-work-as-ai-debugger-for-regular-people-product-pitch-2026-05-06.md)** Shadow work as AI debugger for regular people — product pitch + on-ramp design
 - [ ] **[B-0217](backlog/P1/B-0217-alignment-bidirectional-clause-audit-tightening-2026-05-06.md)** ALIGNMENT.md rewrite - bidirectional clause audit and tightening
 - [ ] **[B-0218](backlog/P1/B-0218-alignment-factory-superfluid-empirical-calibration-2026-05-06.md)** ALIGNMENT.md rewrite - factory-as-superfluid empirical calibration
 - [ ] **[B-0219](backlog/P1/B-0219-alignment-dst-empirical-rigor-and-falsification-floor-2026-05-06.md)** ALIGNMENT.md rewrite - DST empirical-rigor and falsification floor

--- a/docs/FOREGROUND-BACKGROUND-SPLIT.md
+++ b/docs/FOREGROUND-BACKGROUND-SPLIT.md
@@ -128,4 +128,4 @@ the whole system becomes foreground-optional.
 - `docs/SAFE-AUTONOMOUS-ACTIONS.md` — the background's action set
 - `docs/LOCAL-BROADCAST-PEERING.md` — the bus protocol
 - `docs/AGENT-CLAIM-PROTOCOL.md` — background's coordination
-- B-0215 (harness parity audit)
+- B-0238 (harness parity audit)

--- a/docs/ROTATION-PROTOCOL.md
+++ b/docs/ROTATION-PROTOCOL.md
@@ -162,4 +162,4 @@ where to add nodes.
 - B-0208 (launchd forward-tick reliability)
 - B-0209 (remote-only background agent test matrix)
 - B-0211 (fractal BFT architecture)
-- B-0215 (harness parity audit)
+- B-0238 (harness parity audit)

--- a/docs/backlog/P1/B-0238-harness-parity-audit-otto-setup-for-riven-learning-2026-05-06.md
+++ b/docs/backlog/P1/B-0238-harness-parity-audit-otto-setup-for-riven-learning-2026-05-06.md
@@ -1,5 +1,5 @@
 ---
-id: B-0215
+id: B-0238
 priority: P1
 status: open
 title: "Harness parity audit — document Otto's session setup so Riven (and future nodes) can approximate the same autonomy"
@@ -9,7 +9,7 @@ depends_on: [B-0208]
 decomposition: atomic
 ---
 
-# B-0215 — Harness parity audit
+# B-0238 — Harness parity audit
 
 Otto (Claude Code) has capabilities Riven (Cursor) doesn't:
 

--- a/docs/backlog/P1/B-0239-shadow-work-as-ai-debugger-for-regular-people-product-pitch-2026-05-06.md
+++ b/docs/backlog/P1/B-0239-shadow-work-as-ai-debugger-for-regular-people-product-pitch-2026-05-06.md
@@ -1,5 +1,5 @@
 ---
-id: B-0216
+id: B-0239
 priority: P1
 status: open
 title: "Shadow work as AI debugger for regular people — product pitch + on-ramp design"
@@ -10,7 +10,7 @@ decomposition: atomic
 owners: [product-scrum-master, branding-specialist, user-experience-engineer]
 ---
 
-# B-0216 — Shadow work as AI debugger for regular people
+# B-0239 — Shadow work as AI debugger for regular people
 
 ## The insight (Aaron 2026-05-06)
 


### PR DESCRIPTION
## Summary
- B-0215 and B-0216 each had two items claiming the same ID
- Alignment rewrite children (PR #1732) claimed them first
- Harness parity audit (#1744) and shadow-work debugger (#1759) reused the IDs
- Renumber the later items: B-0215→B-0238, B-0216→B-0239
- Updates all cross-references (BACKLOG.md, ROTATION-PROTOCOL.md, FOREGROUND-BACKGROUND-SPLIT.md)

## Test plan
- [ ] No duplicate IDs in `docs/backlog/` after merge
- [ ] All backlog cross-references resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)