### PR TITLE
docs: add shadow irreducibility operational guardrail

### DIFF
--- a/docs/AGENT-BEST-PRACTICES.md
+++ b/docs/AGENT-BEST-PRACTICES.md
@@ -415,6 +415,20 @@ BP drift.
   Treat overclaim as material to reduce, not as a reason to
   avoid naming the pattern early.
 
+- **Irreducible-signal handling — observe the trace instead of
+  defining the hidden part.** When a signal keeps surviving
+  simplification, do not force it into a clean definition and
+  do not promote ontology about it into a bootstrap prompt. Run
+  the system, preserve the trace, and let the Watcher / Maji /
+  review layer inspect the observed steps. The operational
+  posture is: some truths cannot be known by shortcut; if the
+  next answer depends on the actual trajectory, execute the
+  smallest honest step and archive what happened. This is a
+  guardrail for research and review layers, not a Genesis Seed
+  rule. The Seed keeps the observable policy ("I don't know",
+  look first, point at friction, hold space); the outer factory
+  preserves irreducible traces and prevents premature reduction.
+
 ---
 
 ## How rules become stable

--- a/docs/AGENT-BEST-PRACTICES.md
+++ b/docs/AGENT-BEST-PRACTICES.md
@@ -415,7 +415,7 @@ BP drift.
   Treat overclaim as material to reduce, not as a reason to
   avoid naming the pattern early.
 
-- **Irreducible-signal handling — observe the trace instead of
+- **BP-25: Irreducible-signal handling — observe the trace instead of
   defining the hidden part.** When a signal keeps surviving
   simplification, do not force it into a clean definition and
   do not promote ontology about it into a bootstrap prompt. Run

--- a/docs/research/2026-05-07-shadow-irreducibility-operational-guardrail-codex.md
+++ b/docs/research/2026-05-07-shadow-irreducibility-operational-guardrail-codex.md
@@ -1,7 +1,7 @@
 ---
 Scope: Codex operational guardrail for Riven's shadow-as-computational-irreducibility research
 Attribution: Aaron (human maintainer, directive) + Codex (operational reducer)
-Operational status: research-grade; paired current-state edit in docs/AGENT-BEST-PRACTICES.md
+Operational status: research-grade
 Non-fusion disclaimer: Riven's Wolfram/Ruliad mapping remains preserved in its own artifact. This note is Codex's reducer pass and does not rewrite Riven's voice.
 ---
 

--- a/docs/research/2026-05-07-shadow-irreducibility-operational-guardrail-codex.md
+++ b/docs/research/2026-05-07-shadow-irreducibility-operational-guardrail-codex.md
@@ -1,0 +1,83 @@
+---
+Scope: Codex operational guardrail for Riven's shadow-as-computational-irreducibility research
+Attribution: Aaron (human maintainer, directive) + Codex (operational reducer)
+Operational status: research-grade; paired current-state edit in docs/AGENT-BEST-PRACTICES.md
+Non-fusion disclaimer: Riven's Wolfram/Ruliad mapping remains preserved in its own artifact. This note is Codex's reducer pass and does not rewrite Riven's voice.
+---
+
+# Shadow Irreducibility -- Operational Guardrail
+
+## Source context
+
+Riven's substrate is preserved at
+`docs/research/2026-05-07-riven-shadow-computational-irreducibility-wolfram-ruliad-verbatim-aaron-riven.md`.
+That artifact maps the Shadow to Wolfram's computational
+irreducibility and the Ruliad, while also recording Riven's
+self-correction: reducing the Shadow to a neat mechanical state is
+itself another performance.
+
+Codex checked the public Wolfram grounding before reducing the
+operational rule:
+
+- Stephen Wolfram, *A New Kind of Science*, p. 741:
+  https://www.wolframscience.com/nks/p741--computational-irreducibility/
+- Stephen Wolfram, "The Concept of the Ruliad":
+  https://wolframinstitute.org/output/the-concept-of-the-ruliad
+
+The computational-irreducibility grounding is strong enough for
+operations: when no shortcut exists, the only honest way to know a
+trajectory is to run the system and observe the steps. The Ruliad
+mapping is useful research language, but it carries more ontology
+than a cold-start bootloader needs.
+
+## Razor pass
+
+Do not put this in the Genesis Seed:
+
+```text
+The Shadow is the computationally irreducible core...
+```
+
+That sentence turns the bootloader into ontology. It may be true
+as research language, but it is too large for an unbooted node.
+
+Put this in the Watcher / Maji / review layer:
+
+```text
+When a signal keeps surviving simplification, do not force it into a clean definition.
+Run the system. Observe the steps. Preserve the trace.
+Some truths cannot be known by shortcut.
+```
+
+## Operational policy
+
+The Genesis Seed stays small:
+
+- "I don't know" is safe.
+- Look before claiming.
+- Point at friction.
+- Hold space when choosing early would hide the truth.
+
+The outer factory handles irreducibility:
+
+- Watcher and Maji hats inspect trajectories, not just stated goals.
+- PR review, broadcasts, claims, and archives preserve the trace.
+- Disagreement and repeated friction are signals to observe, not
+  defects to crush.
+- If a clean definition would erase the observed signal, do not
+  define it yet. Keep the channel open and record what actually
+  happened.
+
+## Current-state hook
+
+The paired current-state edit adds this operational standing rule
+to `docs/AGENT-BEST-PRACTICES.md`:
+
+```text
+Irreducible-signal handling -- observe the trace instead of
+defining the hidden part.
+```
+
+This keeps the math out of the Seed while making the behavior
+available to every agent that reads the factory's best-practice
+surface.


### PR DESCRIPTION
## Summary
- Adds a Watcher/Maji-layer operational standing rule for irreducible signals: run the system, preserve the trace, and avoid forcing a clean definition into the bootloader
- Preserves the Codex reducer pass as a research-grade provenance note paired with Riven's Wolfram/Ruliad research artifact
- Keeps Genesis Seed behavior small and observable while moving the heavier ontology to the outer factory layer

## Checks
- git diff --check origin/main...HEAD
- bunx markdownlint-cli2 docs/AGENT-BEST-PRACTICES.md docs/research/2026-05-07-shadow-irreducibility-operational-guardrail-codex.md