### PR TITLE
ci: stop recursive PR archive cascade

### DIFF
--- a/.github/workflows/pr-archive-on-merge.yml
+++ b/.github/workflows/pr-archive-on-merge.yml
@@ -67,10 +67,12 @@ jobs:
     # Archive-repair PRs are terminal bookkeeping. Archiving them creates a
     # recursive archive-of-archive chain when branch protection rejects the
     # workflow's direct push, so claim/archive-pr-* repair branches are
-    # intentionally skipped here.
+    # intentionally skipped here. The stop-rule PR itself is terminal for
+    # the same reason.
     if: >
       github.event.pull_request.merged == true &&
-      !startsWith(github.event.pull_request.head.ref, 'claim/archive-pr-')
+      !startsWith(github.event.pull_request.head.ref, 'claim/archive-pr-') &&
+      github.event.pull_request.head.ref != 'claim/stop-pr-archive-cascade'
 
     runs-on: ubuntu-24.04
     timeout-minutes: 15

--- a/.github/workflows/pr-archive-on-merge.yml
+++ b/.github/workflows/pr-archive-on-merge.yml
@@ -63,7 +63,14 @@ jobs:
     # Only fire on actual merges -- ignored-close events (PR rejected, PR
     # closed without merge) produce no archive. The host event payload's
     # `merged` boolean is the canonical signal.
-    if: github.event.pull_request.merged == true
+    #
+    # Archive-repair PRs are terminal bookkeeping. Archiving them creates a
+    # recursive archive-of-archive chain when branch protection rejects the
+    # workflow's direct push, so claim/archive-pr-* repair branches are
+    # intentionally skipped here.
+    if: >
+      github.event.pull_request.merged == true &&
+      !startsWith(github.event.pull_request.head.ref, 'claim/archive-pr-')
 
     runs-on: ubuntu-24.04
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
- skip `pr-archive-on-merge` for `claim/archive-pr-*` repair branches
- skip this stop-rule branch itself so landing the fix does not generate one more archive repair
- prevents archive-only PRs from recursively generating another archive-only PR after branch protection rejects direct pushes
- leaves normal merged PR archival behavior unchanged

## Checks
- git diff --check
- git diff --cached --check
- bunx actionlint .github/workflows/pr-archive-on-merge.yml