### PR TITLE
ci: restrict archive skip to local repair branches

### DIFF
--- a/.github/workflows/pr-archive-on-merge.yml
+++ b/.github/workflows/pr-archive-on-merge.yml
@@ -64,15 +64,17 @@ jobs:
     # closed without merge) produce no archive. The host event payload's
     # `merged` boolean is the canonical signal.
     #
-    # Archive-repair PRs are terminal bookkeeping. Archiving them creates a
-    # recursive archive-of-archive chain when branch protection rejects the
-    # workflow's direct push, so claim/archive-pr-* repair branches are
-    # intentionally skipped here. The stop-rule PR itself is terminal for
-    # the same reason.
+    # Repo-local archive-repair PRs are terminal bookkeeping. Archiving them
+    # creates a recursive archive-of-archive chain when branch protection
+    # rejects the workflow's direct push, so local claim/archive-pr-* repair
+    # branches are intentionally skipped here. Fork PRs with matching branch
+    # names must still be archived.
     if: >
       github.event.pull_request.merged == true &&
-      !startsWith(github.event.pull_request.head.ref, 'claim/archive-pr-') &&
-      github.event.pull_request.head.ref != 'claim/stop-pr-archive-cascade'
+      !(
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.event.pull_request.head.ref, 'claim/archive-pr-')
+      )
 
     runs-on: ubuntu-24.04
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
- require `github.event.pull_request.head.repo.full_name == github.repository` before skipping archive repair branches
- preserve archival for fork PRs even when their branch names resemble `claim/archive-pr-*`
- remove the one-off stop-rule branch skip now that the cascade guard has landed

## Checks
- git diff --check
- git diff --cached --check
- bunx actionlint .github/workflows/pr-archive-on-merge.yml