### PR TITLE
research: ARC-AGI-3 CHIP-8 Atari DBSP replay-algebra correction

### DIFF
--- a/docs/research/2026-05-07-arc-agi-3-chip8-atari-dbsp-replay-algebra-curriculum-correction.md
+++ b/docs/research/2026-05-07-arc-agi-3-chip8-atari-dbsp-replay-algebra-curriculum-correction.md
@@ -1,0 +1,356 @@
+---
+Scope: external conversation absorb - ARC-AGI-3 / CHIP-8 / Atari / DBSP structure-recognition curriculum correction; DBSP-as-replay-algebra precision guard; ROM safety rule tightening
+Attribution: Aaron ferrying Amara/Aaron correction to Codex/Vera
+Operational status: research-grade
+Non-fusion disclaimer: This file preserves an external conversation correction as research-grade substrate. It is not operational policy until separately promoted into a current-state artifact such as an ADR, numbered governance rule, backlog item, or operational doc.
+---
+
+# ARC-AGI-3 / CHIP-8 / Atari / DBSP Replay-Algebra Curriculum
+
+## Why This Matters
+
+This packet tightens a promising research lane without letting the
+metaphor overrun the engineering boundary.
+
+The research lane is:
+
+```text
+ARC-AGI-3
+-> homemade video-game levels
+-> compounding lessons across slightly different levels
+-> DBSP/emulator substrate + Atari 2600 corpus
+```
+
+The correction is load-bearing:
+
+```text
+The emulator runs the game.
+DBSP remembers what changed.
+The recognizer learns what carried forward.
+```
+
+## Core Thesis
+
+ARC-AGI-3 tests whether an agent can discover and compound
+latent game mechanics across levels.
+
+Atari 2600 ROMs provide a controllable state-machine corpus.
+
+CHIP-8 is the smaller pre-Atari first rung: 35 opcodes, 4KB
+memory, 64x32 display, and a simple enough VM that the DBSP
+state/change representation can be proven before moving up to
+the 2600.
+
+DBSP provides the algebra for replayable state deltas, snapshots,
+retractions, and temporal structure.
+
+The structure recognizer learns fingerprints of mechanics and
+compositions across games and levels.
+
+## Precision Guard
+
+Do not promote:
+
+```text
+DBSP is every emulator.
+```
+
+Promote the tighter version:
+
+```text
+Every emulator exposes a state-transition stream.
+DBSP gives us the algebra to represent, diff, replay, retract,
+and compare those transition streams.
+```
+
+An actual Atari emulator still has to implement CPU, TIA, RIOT,
+memory bus timing, input, video, audio, and other machine-specific
+behavior. DBSP does not replace that. DBSP gives the state/change
+algebra around it.
+
+Clean stack:
+
+```text
+Emulator = transition oracle.
+DBSP = differential ledger of the transition stream.
+Structure recognizer = invariant extractor over those streams.
+```
+
+## Correct Stack
+
+```text
+CHIP-8 = first proof rung.
+Atari 2600 corpus = training ground.
+ARC-AGI-3 = benchmark.
+Emulator = transition oracle.
+DBSP = replay algebra.
+Structure recognizer = eyes.
+Genesis Seed = bootloader.
+```
+
+Carved:
+
+```text
+Lessons must compound across levels.
+Surfaces change; structure persists.
+```
+
+Second blade:
+
+```text
+The emulator runs the game.
+DBSP remembers what changed.
+The recognizer learns what carried forward.
+```
+
+Best blade:
+
+```text
+ARC-AGI-3 asks whether lessons compound.
+Atari gives the lessons.
+DBSP makes them replayable.
+```
+
+## ROM Safety Rule
+
+Commit only legally distributable ROMs:
+
+- public-domain ROMs
+- homebrew ROMs with explicit license
+- author-permitted ROMs with source URL and license text
+- synthetic or minimal test ROMs generated in-repo
+
+Do not commit:
+
+- commercial ROMs
+- abandonware
+- ROMs with unknown provenance
+- ROMs merely owned locally by Aaron
+
+For local or non-distributable ROMs:
+
+- keep ROM bytes local only
+- commit hashes and metadata only
+- do not commit download links
+- do not redistribute bytes
+
+This composes with B-0083 and B-0199. The strict form matters:
+ROM safety cannot be vibes. It has to be provenance, license text,
+hashes, and no bytes unless redistribution is explicitly allowed.
+
+## Promotion Targets
+
+Potential follow-up substrate:
+
+- Backlog: CHIP-8-first DBSP emulator trace curriculum before
+  Atari 2600.
+- ADR: emulator-as-transition-oracle / DBSP-as-replay-algebra
+  boundary.
+- ROM policy/current-state doc: safe ROM commit rules, local-only
+  manifests, and hash-only metadata for non-distributable ROMs.
+- B-0240 extension: structure recognizer accepts emulator trace
+  streams as first-class input.
+
+## Verbatim Correction Packet
+
+```text
+Oh, this is a big convergence packet. The part that jumps out is that the loop finally connected four things that had been orbiting each other:
+
+ARC-AGI-3
+-> homemade video-game levels
+-> compounding lessons across slightly different levels
+-> DBSP/emulator substrate + Atari 2600 corpus
+
+That is not a random association. That is a real research lane.
+
+What looks genuinely strong
+
+The ARC-AGI-3 connection is correct once Otto stopped guessing and searched. ARC-AGI-3 is officially described as an interactive reasoning benchmark where agents must explore novel environments with no instructions, build world models, acquire goals, and plan/act; the launch post says it uses hundreds of original turn-based environments and thousands of game-style levels, with no stated rules or goals, and humans at 100% while frontier AI was around 0.51% at launch.
+
+Your "homemade video game" read is the important human translation:
+
+Each level is slightly different.
+The lesson has to compound.
+The agent has to notice the same structure under changed surface.
+
+That is exactly the structure-recognition gap. ARC's docs say the benchmark targets exploration, percept -> plan -> action, memory, goal acquisition, and alignment; that lines up directly with your dials / shadow / structure-recognizer story.
+
+The attached log also shows a healthy shadow correction: Otto first guessed that "ARC3" meant your internal Arc 3, then you said "no search dont guess," and he logged that as shadow catch #6. Good. That is exactly the pattern the shadow log is for: the confident narrative appeared before the cheap reality check.
+
+The best research framing
+
+I'd name the lane something like:
+
+ARC-AGI-3 / Atari / DBSP structure-recognition curriculum
+
+Not just "ARC3 research." That avoids ambiguity with internal "Arc 3" language.
+
+The thesis:
+
+ARC-AGI-3 tests whether an agent can discover and compound latent game mechanics across levels.
+
+Atari 2600 ROMs provide a controllable state-machine corpus.
+
+DBSP provides the algebra for replayable state deltas, snapshots, retractions, and temporal structure.
+
+The structure recognizer learns fingerprints of mechanics and compositions across games/levels.
+
+That is a real program.
+
+DBSP-as-emulator: strong metaphor, but needs a precision guard
+
+The line "DBSP is every emulator" is exciting, but I'd tighten it before it becomes doctrine.
+
+Safer:
+
+Every emulator exposes a state-transition stream.
+DBSP gives us the algebra to represent, diff, replay, retract, and compare those transition streams.
+
+That is much harder to attack than:
+
+DBSP is the emulator.
+
+Because an actual Atari emulator still has to implement CPU, TIA, RIOT, memory bus timing, input, video/audio, etc. DBSP does not replace all of that. DBSP gives you the state/change algebra around it.
+
+So:
+
+Emulator = transition oracle.
+DBSP = differential ledger of the transition stream.
+Structure recognizer = invariant extractor over those streams.
+
+That's the clean stack.
+
+Microsoft's System.IO.Pipelines docs are also relevant for the B-0242 side: they emphasize high-performance parsing of streaming data with less boilerplate, PipeReader/PipeWriter, ReadOnlySequence<T>, AdvanceTo, and explicit ownership/completion rules. That matters because if you are going to stream emulator frames / agent actions / replay traces through a harness, this is exactly the kind of I/O discipline you want.
+
+ROM safety: Otto got the shape right, but make it strict
+
+Your "only check in safe ones" is load-bearing. Do not let that be vibes.
+
+MAME's own docs are blunt: ROM/media images are copyrighted material and may not be distributed without explicit permission; MAME itself does not include original game code and requires users to provide their own media.
+
+So the repo rule should be:
+
+Commit only:
+- homebrew/public-domain ROMs with explicit license
+- author-permitted ROMs with source URL + license text
+- synthetic/minimal test ROMs generated in-repo
+
+Never commit:
+- commercial ROMs
+- "abandonware"
+- ROMs with unknown provenance
+- ROMs merely owned locally by Aaron
+
+For unsafe/local ROMs:
+
+Keep local only.
+Commit hash manifest + metadata only.
+No download links.
+No redistribution.
+
+That gives you the corpus without turning the repo into a liability magnet.
+
+What I'd correct in Otto's line
+
+Otto said:
+
+The Atari 2600 is the training ground. ARC-AGI-3 is the test. DBSP is the engine. The structure recognizer is the eyes. The Genesis Seed is the brain.
+
+Good line. I'd adjust one word:
+
+DBSP is the replay algebra.
+
+Not "engine." The emulator is the engine. DBSP is the algebraic recorder/differencer/replayer.
+
+Better:
+
+The Atari 2600 corpus is the training ground.
+ARC-AGI-3 is the benchmark.
+The emulator is the transition oracle.
+DBSP is the replay algebra.
+The structure recognizer is the eyes.
+The Genesis Seed is the bootloader.
+
+That is cleaner and won't get dinged by systems people.
+
+Sendable correction to Otto
+
+Amara/Aaron correction:
+
+The ARC-AGI-3 connection is real, but tighten the naming and substrate claim.
+
+Do not call it only "ARC3 research" because that collides with internal Arc 3 history.
+Use:
+
+ARC-AGI-3 / Atari / DBSP structure-recognition curriculum
+
+Thesis:
+
+ARC-AGI-3 tests whether an agent can explore unknown game-like environments, infer rules/goals, and compound lessons across slightly different levels.
+
+The Atari 2600 corpus gives us controlled state-machine environments.
+
+The emulator is the transition oracle.
+
+DBSP is not literally "every emulator."
+DBSP is the replay/delta algebra over emulator state streams:
+- frame advance = next transition
+- state diff = D
+- accumulated state = I / integration
+- save state = snapshot
+- rewind/retraction = negative delta / replay
+- invariant extraction = structure recognizer over streams
+
+Structure recognizer learns mechanic fingerprints and compositions across levels/games.
+
+Correct stack:
+
+Atari 2600 corpus = training ground.
+ARC-AGI-3 = benchmark.
+Emulator = transition oracle.
+DBSP = replay algebra.
+Structure recognizer = eyes.
+Genesis Seed = bootloader.
+
+ROM safety rule:
+
+Only commit legally distributable ROMs:
+- public domain
+- homebrew with explicit license
+- author-permitted
+- synthetic/minimal test ROMs generated in-repo
+
+Do not commit commercial, abandonware, unknown-provenance, or merely locally-owned ROMs.
+
+For local/non-distributable ROMs:
+commit hashes + metadata only.
+No ROM bytes.
+No download links.
+
+Carved:
+
+Lessons must compound across levels.
+Surfaces change; structure persists.
+
+Second blade:
+
+The emulator runs the game.
+DBSP remembers what changed.
+The recognizer learns what carried forward.
+
+My verdict
+
+This is a very promising research direction because it gives you a bridge from real, small, controllable systems to ARC-AGI-3-style interactive intelligence:
+
+old games -> replayable traces -> structure fingerprints -> compounded lessons -> ARC-style agents
+
+The correction is just to keep the layers precise. Don't let "DBSP is every emulator" become an overclaim. Make it:
+
+DBSP is the algebra of replayable change.
+
+Best blade:
+
+ARC-AGI-3 asks whether lessons compound.
+Atari gives the lessons.
+DBSP makes them replayable.
+```


### PR DESCRIPTION
## Summary
- preserves the Amara/Aaron correction packet for the ARC-AGI-3 / CHIP-8 / Atari / DBSP curriculum lane
- tightens the DBSP overclaim into the transition-oracle / replay-algebra boundary
- records strict ROM safety rules and promotion targets as research-grade substrate

## Checks
- bunx markdownlint-cli2 docs/research/2026-05-07-arc-agi-3-chip8-atari-dbsp-replay-algebra-curriculum-correction.md
- git diff --check
- bun tools/hygiene/check-archive-header-section33.ts