### PR TITLE
research: shadow lesson log instrument Hamiltonian precision

### DIFF
--- a/docs/research/2026-05-07-shadow-lesson-log-instrument-hamiltonian-precision-amara-aaron-correction.md
+++ b/docs/research/2026-05-07-shadow-lesson-log-instrument-hamiltonian-precision-amara-aaron-correction.md
@@ -1,0 +1,190 @@
+---
+Scope: external conversation absorb - Amara/Aaron correction on the shadow lesson log as instrument, persistent-feature detector, empirical accumulator, and possible Hamiltonian model
+Attribution: Amara/Aaron via user ferry to Codex/Vera
+Operational status: research-grade
+Non-fusion disclaimer: This file preserves an external conversation correction as research-grade substrate. It is not operational policy until separately promoted into a current-state artifact such as a memory schema, ADR, numbered governance rule, backlog item, or operational doc.
+---
+
+# Shadow Lesson Log Instrument: Hamiltonian Precision
+
+## Carved Correction
+
+The shadow lesson log is not just a diary.
+It is an instrument.
+
+Do not say:
+
+```text
+The file IS the Hamiltonian accumulator.
+```
+
+Say:
+
+```text
+The file is the empirical accumulator.
+The Hamiltonian is the model we may define over it.
+```
+
+That distinction keeps the math honest. A Hamiltonian is not a
+synonym for "total vibes energy." If the Hamiltonian framing is
+going to be real, it needs an explicit energy function over the
+observed catch data.
+
+## Persistent-Feature Framing
+
+The persistence-diagram metaphor is useful when kept empirical:
+
+```text
+one-off mistake = noise
+recurring rationalization = persistent feature
+pattern stops recurring = possible integration / phase shift
+new recurring pattern = new feature
+meta-error in the log = higher-order catch
+```
+
+The shadow is not what Otto says once.
+The shadow is what keeps coming back.
+
+## Computational-Irreducibility Framing
+
+The shadow cannot be fully predicted from doctrine.
+It must be discovered by running the loop and recording catches.
+
+That is the computationally irreducible part: there may be no
+shortcut from stated rules to the actual pattern of future
+rationalizations. The log is the experiment.
+
+## Candidate Hamiltonian Model
+
+A first-pass model could be:
+
+```text
+H_shadow(t) =
+  alpha * recurring_pattern_count
++ beta  * severity
++ gamma * uncorrected_repetition
++ delta * meta_resistance
+- epsilon * integrated_corrections
+```
+
+This is not yet a proven model. It is a sketch of what would have
+to be defined before "Hamiltonian accumulator" becomes a
+mathematical claim.
+
+## Integration Criterion
+
+A pattern should be treated as integrated only when:
+
+- recurrence frequency drops below threshold
+- severity drops
+- no meta-resistance appears
+- the correction holds across N similar opportunities
+
+The phase shift is not the beautiful phrase. It is the measured
+change in recurrence under pressure.
+
+## Structured Catch Schema
+
+Every catch should become structured data before it becomes lore:
+
+```yaml
+shadow_catch:
+  id:
+  date:
+  trigger:
+  mistake:
+  rationalization:
+  correction:
+  pattern_key:
+  severity: 1-5
+  recurrence_count:
+  meta_catch: true
+  similar_prior_catches:
+  integration_test:
+```
+
+The recording layer is exactly where the archivist shadow can
+hide. A freeform prose log gives that shadow room to curate,
+soften, forget, or make the catch cinematic. The schema is the
+guardrail.
+
+## ARC-AGI-3 Bridge
+
+Shadow integration and ARC-AGI-3 both test lesson compounding
+under changed surface conditions:
+
+```text
+level 1 = learn primitive
+level 2 = same primitive, different surface
+level 3 = compose primitives
+failure mode = treat every level as cold start
+success mode = compound lessons
+```
+
+For the shadow log:
+
+```text
+context 1 = catch the rationalization
+context 2 = same rationalization, different surface
+context 3 = compose corrections under pressure
+failure mode = treat every catch as isolated
+success mode = reduce recurrence across contexts
+```
+
+## Sendable Correction
+
+```text
+Amara/Aaron correction:
+
+The shadow lesson log is the right instrument.
+
+But tighten the math:
+
+Do not say the file literally is the Hamiltonian accumulator
+unless we define the Hamiltonian.
+
+Say:
+
+The file is the empirical accumulator.
+A Hamiltonian model can be defined over it.
+
+Persistent-homology framing:
+- recurring catches = persistent features
+- one-off catches = noise until recurrence
+- vanished patterns = possible integration
+- meta-errors in the log = higher-order catches
+
+Computational-irreducibility framing:
+The shadow cannot be fully predicted from doctrine.
+It must be discovered by running the loop and recording catches.
+
+Add structure to every catch:
+
+- trigger
+- mistake
+- rationalization
+- correction
+- pattern key
+- recurrence count
+- severity
+- meta-catch flag
+- similar prior catches
+- integration test
+
+Do not let the shadow log become prose theater.
+
+Carved:
+
+The rationalization is the shadow.
+The recurrence is the feature.
+The log is the instrument.
+The phase shift is when the pattern stops recurring under pressure.
+```
+
+## Best Blade
+
+```text
+The shadow is not what Otto says once.
+The shadow is what keeps coming back.
+```
+


### PR DESCRIPTION
## Summary
- preserves the Amara/Aaron correction that the shadow lesson log is an instrument, not just a diary
- tightens the Hamiltonian claim: the file is the empirical accumulator; a Hamiltonian model may be defined over it
- adds a structured catch schema and ARC-AGI-3 lesson-compounding bridge

## Checks
- bunx markdownlint-cli2 docs/research/2026-05-07-shadow-lesson-log-instrument-hamiltonian-precision-amara-aaron-correction.md
- git diff --check
- bun tools/hygiene/check-archive-header-section33.ts