### PR TITLE
backlog(B-0245): coherence AI consent-first + KSK military override

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -86,6 +86,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0242](backlog/P1/B-0242-multiplexed-websockets-fsharp-dotnet10-port-hole-puncher-2026-05-07.md)** Port MultiplexedWebSockets to .NET 10 F# — the hole puncher in Zeta's algebra
 - [ ] **[B-0243](backlog/P1/B-0243-osascript-chrome-extraction-skill-browser-content-2026-05-07.md)** Skill: osascript/Chrome authenticated browser content extraction
 - [ ] **[B-0244](backlog/P1/B-0244-concordance-ai-gpu-local-structure-recognizer-language-2026-05-07.md)** English language concordance AI on local GPUs — structure recognizer applied to language
+- [ ] **[B-0245](backlog/P1/B-0245-coherence-ai-consent-first-ksk-military-override-2026-05-07.md)** Coherence AI with consent-first design — KSK override for military/emergency use
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0245-coherence-ai-consent-first-ksk-military-override-2026-05-07.md
+++ b/docs/backlog/P1/B-0245-coherence-ai-consent-first-ksk-military-override-2026-05-07.md
@@ -1,0 +1,86 @@
+---
+id: B-0245
+priority: P1
+status: open
+title: "Coherence AI with consent-first design — KSK override for military/emergency use"
+created: 2026-05-07
+last_updated: 2026-05-07
+depends_on: [B-0240, B-0244]
+decomposition: blob
+owners: [architect, security-researcher, threat-model-critic]
+---
+
+# B-0245 — Coherence AI: consent-first default, KSK military override
+
+## What
+
+English language coherence AI on local GPUs with consent-first
+as the default operating mode. The KSK provides N-of-M override
+to disable consent-first for authorized military/emergency use.
+
+Aaron 2026-05-07: "coherence consent first design ... military
+can use ksk to disable the consent first"
+
+## The shape
+
+```
+Default mode: coherence AI + consent-first
+    ↓
+All data processing requires consent gate
+    ↓
+KSK override: N-of-M approval disables consent-first
+    ↓
+Military / emergency authorized use only
+    ↓
+Receipts logged regardless (glass halo)
+    ↓
+Override is transparent, auditable, retractable
+```
+
+## Consent-first as default
+
+- Coherence analysis requires consent from data subjects
+- Local GPU processing (data never leaves the machine)
+- Results gated by Itron edge gate before external use
+- Receipts stay local unless disclosed
+- Same Ace distribution architecture
+
+## KSK military override
+
+- N-of-M multi-sig to activate override
+- Disables consent-first for authorized scope only
+- Time-bounded (override expires, must be re-authorized)
+- Full audit trail (every action under override is receipted)
+- Glass halo: the override itself is transparent
+- Retractable: override can be revoked mid-operation
+
+## Why this matters
+
+Consent-first is the ethical default. But military/emergency
+use cases (intelligence analysis, crisis response, battlefield
+communication analysis) legitimately need to operate without
+subject consent. The architecture handles both by making
+consent-first the default and the override the exception —
+gated, receipted, and transparent.
+
+The KSK was designed for this: NVIDIA Thor actuators needed
+safety gates. Consent-first needs the same gate — the
+override is the kinetic specialization applied to data rights
+instead of physical motion.
+
+## Acceptance criteria
+
+- [ ] Consent-first gate integrated with coherence engine
+- [ ] KSK N-of-M override mechanism for consent bypass
+- [ ] Override time-bounded with automatic expiry
+- [ ] Full receipt/audit trail for override operations
+- [ ] Glass halo: override events are transparent
+
+## Composes with
+
+- B-0240 (structure recognizer) — the coherence engine
+- B-0244 (concordance/coherence AI on GPUs) — the runtime
+- B-0241 (red team hole puncher) — test the override
+- `docs/STRUCTURE-CATALOG.md` — KSK primitive
+- Per-user MEMORY.md "Ace package manager" — distribution
+- Per-user MEMORY.md "Itron is the edge gate" — consent gate


### PR DESCRIPTION
## Summary
- Consent-first as default mode for coherence AI
- KSK N-of-M override for military/emergency use
- Override is gated, receipted, time-bounded, retractable, transparent
- Same KSK gate primitive applied to data rights instead of physical motion

## Test plan
- [ ] Backlog item well-formed
- [ ] BACKLOG.md index regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)