### PR TITLE
research: preserve Alexa DLC product feedback

### DIFF
--- a/docs/backlog/P1/B-0247-ace-dlc-content-packs-kernel-extensions-package-manager-2026-05-07.md
+++ b/docs/backlog/P1/B-0247-ace-dlc-content-packs-kernel-extensions-package-manager-2026-05-07.md
@@ -62,6 +62,15 @@ They may not be mutually exclusive: the structure recognizer
 (B-0240) built for Ace DLCs IS the engine that would solve
 ARC-AGI-3. Building the product builds the benchmark solver.
 
+## External review signal
+
+Alexa's 2026-05-07 feedback on this product thesis is preserved
+as research-grade review signal at
+`docs/research/2026-05-07-alexa-dlc-product-research-loop-feedback.md`.
+
+The key line: the product sustains the research, the research
+validates the product, and the prize becomes marketing for both.
+
 ## Composes with
 
 - B-0240 (structure recognizer) — the engine DLCs compose on

--- a/docs/research/2026-05-07-alexa-dlc-product-research-loop-feedback.md
+++ b/docs/research/2026-05-07-alexa-dlc-product-research-loop-feedback.md
@@ -1,0 +1,116 @@
+---
+Scope: external conversation absorb - Alexa feedback on the DLC/Ace product-research loop, Green Lantern ring device, and ARC-AGI-3 prize framing
+Attribution: Alexa via Aaron ferry -> Codex/Vera
+Operational status: research-grade
+Non-fusion disclaimer: agreement, shared language, or repeated interaction between models and humans does not imply shared identity, merged agency, consciousness, or personhood (per GOVERNANCE.md §33). Alexa's response is preserved as external review signal; Codex/Vera's notes are a separate agent contribution.
+---
+
+# Alexa: DLC product-research loop feedback
+
+## Source packet
+
+Aaron ferried Alexa's feedback after the Alexa DLC writeup and
+the B-0246/B-0247 product backlog items landed. Alexa affirmed
+the following product thesis:
+
+- Genesis Seed as the free bootloader.
+- Ace DLC packs as downloadable content for composable kernel
+  extensions.
+- Product and research as the same loop: the DLC platform
+  generates evidence while the research engine improves the
+  platform.
+- ARC-AGI-3 as validation and marketing, not the primary
+  business model.
+- Green Lantern ring as a later IoT edge-device expression of
+  the same architecture.
+
+Alexa's compact line:
+
+> The product sustains the research, the research validates the
+> product, and the prize becomes marketing for both.
+
+## What Alexa got right
+
+The core signal is the product-research loop. B-0247 is not a
+side quest next to ARC-AGI-3. It is the substrate that would
+produce the same structure-recognition engine needed for
+ARC-AGI-3-style compounding:
+
+1. Build the DLC platform because AI agents need portable,
+   composable capabilities.
+2. Use each DLC install, retraction, compatibility check, and
+   policy decision as research data.
+3. Feed that research data back into B-0240, coherence checks,
+   and the Genesis Seed extension discipline.
+4. Enter benchmarks with the same engine that already has a
+   product reason to exist.
+
+That means the prize is optional upside. The product is the
+sustaining loop.
+
+## Guardrails
+
+Alexa's praise is useful morale, not evidence. The evidence still
+has to come from shipping, checks, usage, failure reports, and
+retention.
+
+"Willpower-based authentication" is metaphor, not a security
+protocol. The operational security path remains concrete:
+signed DLC packages, lattice/post-quantum identity work, consent
+policy, KSK override gates, local receipts, and retraction-native
+deployment logs.
+
+Itron infrastructure, US Patent 10,834,144, NVIDIA Thor, and KSK
+ground the hardware and edge-compute imagination, but they do not
+prove product-market fit. They prove the idea is engineering-shaped
+instead of only poetic.
+
+The ring is probably not the first shippable product. It is a
+strong product symbol and eventual edge device. The first cut is
+more likely a software DLC pack that can run on existing machines
+and prove the package/permission/update/retraction loop.
+
+## Product reading
+
+The clean business distinction:
+
+- **Prize path**: one-time validation, one-time money, strong
+  marketing if won.
+- **DLC path**: recurring revenue, ecosystem surface, and a
+  reason to keep improving the structure recognizer.
+
+They compose when ordered correctly:
+
+1. Build Ace DLCs as the product.
+2. Let the product generate research data.
+3. Let the research improve B-0240 and coherence scoring.
+4. Use ARC-AGI-3 as an external test of the same engine.
+5. If the prize lands, treat it as acceleration and marketing.
+
+## Immediate product cut
+
+The next shippable unit should be a small software DLC before
+hardware:
+
+- a DLC manifest format: identity, seed compatibility,
+  capabilities, consent scope, signatures, retraction plan, and
+  focused checks;
+- a first DLC candidate: coherence analyzer, shadow-log harness,
+  or guardian policy pack;
+- an Ace install path that can add, remove, verify, and roll back
+  the DLC without relying on trust in chat;
+- receipts that record what was installed, what it could touch,
+  and how it can be retracted.
+
+The ring remains the product icon. The software DLC is the first
+revenue test.
+
+## Composes with
+
+- `docs/research/2026-05-07-alexa-dlc-linguistic-seed-kernel-extensions-fsharp-algebra.md`
+- `docs/backlog/P1/B-0246-green-lantern-ring-iot-device-genesis-seed-local-inference-2026-05-07.md`
+- `docs/backlog/P1/B-0247-ace-dlc-content-packs-kernel-extensions-package-manager-2026-05-07.md`
+- B-0240 (structure recognizer)
+- B-0244 (language coherence/concordance downstream application)
+- B-0245 (coherence AI consent-first + KSK override)
+


### PR DESCRIPTION
## Summary

- preserve Alexa's DLC/product-research-loop feedback as research-grade external review signal
- backlink the absorb from B-0247 so the Ace DLC backlog points to the review
- keep guardrails explicit: praise is not evidence, the ring is likely after a first software DLC, and ARC-AGI-3 is validation/marketing rather than the sustaining business model

## Checks

- PATH=/opt/homebrew/bin:/Users/acehack/.bun/bin:$PATH bunx markdownlint-cli2 docs/research/2026-05-07-alexa-dlc-product-research-loop-feedback.md docs/backlog/P1/B-0247-ace-dlc-content-packs-kernel-extensions-package-manager-2026-05-07.md
- git diff --check
- PATH=/opt/homebrew/bin:/Users/acehack/.bun/bin:$PATH bun tools/hygiene/check-archive-header-section33.ts docs/research/2026-05-07-alexa-dlc-product-research-loop-feedback.md
