### PR TITLE
fix: align B-0248 title with generated backlog index

### DIFF
--- a/docs/backlog/P1/B-0248-multisite-fork-gpu-infra-mirror-host-redundancy-2026-05-07.md
+++ b/docs/backlog/P1/B-0248-multisite-fork-gpu-infra-mirror-host-redundancy-2026-05-07.md
@@ -2,7 +2,7 @@
 id: B-0248
 priority: P1
 status: open
-title: "Multi-site fork + GPU infrastructure redundancy - maintainer mirrors, Max 24/7 host, Rodney local GPU pool"
+title: "Multi-site fork + GPU infrastructure redundancy — maintainer mirrors, Max 24/7 host, Rodney local GPU pool"
 created: 2026-05-07
 last_updated: 2026-05-07
 depends_on: [B-0110, B-0240, B-0246, B-0247]
@@ -10,7 +10,7 @@ decomposition: sliceable
 owners: [architect, infrastructure-operator, security-auditor]
 ---
 
-# B-0248 - Multi-site fork + GPU infrastructure redundancy
+# B-0248 — Multi-site fork + GPU infrastructure redundancy
 
 ## What
 


### PR DESCRIPTION
## Summary
- align B-0248 frontmatter title and H1 with the em-dash form already present in docs/BACKLOG.md
- fixes the generated BACKLOG index drift observed after PR #1868

## Checks
- tools/backlog/generate-index.sh --check
- bunx markdownlint-cli2 docs/BACKLOG.md docs/backlog/P1/B-0248-multisite-fork-gpu-infra-mirror-host-redundancy-2026-05-07.md
- git diff --check
- bun tools/hygiene/audit-backlog-items.ts