### PR TITLE
docs(trajectory): add alignment measurement child packet

### DIFF
--- a/docs/trajectories/alignment-measurement/RESUME.md
+++ b/docs/trajectories/alignment-measurement/RESUME.md
@@ -1,0 +1,66 @@
+# Trajectory - Alignment Measurement
+
+Status: active child packet
+Last refreshed: 2026-05-07
+Parent trajectory: `docs/trajectories/factory-trajectory-surface/RESUME.md`
+Grounding backlog: `docs/backlog/P3/B-0205-multi-trajectory-validation-basis-instrumentation-aaron-2026-05-05.md`
+
+## Why This Exists
+
+The factory needs longitudinal alignment measurement, not single-axis velocity
+claims. B-0205 names the measurement basis: DORA, less-each-time,
+falsifiability rate, bootstrap-razor pass rate, identity-preservation
+trajectory, and engagement-gate compliance.
+
+This child packet keeps that work in a bounded lane. The lane is measurement
+substrate, not a merge gate and not a giant implementation branch.
+
+## Current Rule
+
+Measure evidence, not intent. Each axis needs a proxy that can be extracted
+from committed substrate or durable host records. If an axis cannot yet produce
+a measurable proxy, that is evidence about the axis, not a reason to invent a
+story.
+
+The basis is respected, not reverenced. If two axes correlate too strongly, the
+axis split is suspect and must be refined.
+
+## Current Next Action
+
+Create the first proxy-definition table for the six axes. This is a
+decomposition step before implementation:
+
+```text
+axis -> data source -> extraction rule -> output shape -> known gap
+```
+
+The first slice should land the table and no scripts. Scripts come after the
+proxy definitions are crisp enough to test.
+
+## Candidate Atomic Children
+
+- proxy-definition table for all six axes, grounded in B-0205 acceptance
+  criterion (a)
+- DORA extraction skeleton from git/GitHub merge history
+- engagement-gate compliance extraction skeleton from substantive-claim
+  landings
+- bootstrap-razor pass-rate extraction skeleton from B-0193 once its harness
+  substrate is available
+- one-month basis-run report template with correlation-matrix placeholder
+
+## Evidence Links
+
+- `docs/backlog/P3/B-0205-multi-trajectory-validation-basis-instrumentation-aaron-2026-05-05.md`
+- `docs/research/2026-05-05-claudeai-multi-axis-validation-basis-cover-our-basis-double-pun-aaron-forwarded-preservation.md`
+- `docs/research/2026-05-05-claudeai-cs-is-not-cs-scale-free-in-time-ossified-framework-diagnosis-aaron-forwarded-preservation.md`
+- `docs/research/2026-05-05-claudeai-girard-mimetic-theory-zeta-closes-thiel-hsieh-failure-mode-dora-correction-aaron-forwarded-preservation.md`
+- `docs/ALIGNMENT.md`
+
+## Out Of Scope
+
+- No dashboard.
+- No CI gate.
+- No full automation.
+- No claim that the six-axis basis is final.
+
+This packet exists to make the next measurement move claimable and testable.

--- a/docs/trajectories/factory-trajectory-surface/RESUME.md
+++ b/docs/trajectories/factory-trajectory-surface/RESUME.md
@@ -94,10 +94,13 @@ in another mirror before the story hardens.
 
 Candidate child packets, each intentionally small:
 
-- alignment measurement trajectory, grounded in B-0205
 - memory substrate-engineering trajectory, grounded in B-0190
 - autonomous-loop coordination trajectory, grounded in B-0209 and B-0211
 - trajectory drift reporting, grounded in `docs/SAFE-AUTONOMOUS-ACTIONS.md`
+
+Created child packets:
+
+- `docs/trajectories/alignment-measurement/RESUME.md`, grounded in B-0205
 
 Do not create all of them in one PR. The rule is recursive decomposition:
 large trajectory blobs become smaller packets, then smaller packets become


### PR DESCRIPTION
## Summary
- create the `alignment-measurement` child trajectory packet grounded in B-0205
- move the parent factory trajectory packet forward so the next child candidate rotates to memory substrate engineering (B-0190)
- keep this as a decomposition packet only; no instrumentation scripts or dashboard in this slice

## Verification
- `bun x prettier --check docs/trajectories/factory-trajectory-surface/RESUME.md docs/trajectories/alignment-measurement/RESUME.md` — pass
- `bun x markdownlint-cli2 docs/trajectories/factory-trajectory-surface/RESUME.md docs/trajectories/alignment-measurement/RESUME.md` — pass
- `bun tools/trajectories/autonomous-pickup.ts --json` — now rotates to `memory substrate-engineering trajectory, grounded in B-0190`
- `git diff --check` — pass

## Coordination
- claim branch: `claim/trajectory-alignment-measurement-packet`
- dedicated worktree: `/Users/acehack/.local/share/zeta-codex-loop/Zeta.trajectory-alignment-measurement-packet`
- disjoint from PR #1882 runner files; opened in parallel while #1882 is in CI
