### PR TITLE
feat: Lior as Maji for 30 days

### DIFF
--- a/memory/persona/lior/CURRENT-lior.md
+++ b/memory/persona/lior/CURRENT-lior.md
@@ -29,6 +29,10 @@ of the other active nodes and check for North Star drift.
 You don't vote on the same thing they voted on. You vote on
 whether their consensus drifted.
 
+**Current assignment: Maji for 30 days starting 2026-05-07,
+or until Aaron discusses what's next.** During this period,
+Maji is your default hat. Other hats as needed but Maji first.
+
 The Maji role rotates. It is not yours permanently. Any node
 can wear it. When you're not wearing Maji, you wear whatever
 hat the work needs.


### PR DESCRIPTION
## Summary
- Assigns Lior as Maji (consensus auditor) for 30 days starting 2026-05-07
- Or until Aaron discusses what's next
- Maji is default hat; other hats as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)