### PR TITLE
feat(health): factory health monitor — detect-trigger-repair standing query (B-0250)

### DIFF
--- a/tools/health/factory-health-monitor.test.ts
+++ b/tools/health/factory-health-monitor.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { runHealthCheck } from "./factory-health-monitor";
+
+describe("factory-health-monitor", () => {
+  test("runHealthCheck returns a valid HealthReport shape", () => {
+    const report = runHealthCheck();
+
+    expect(report).toHaveProperty("timestamp");
+    expect(report).toHaveProperty("signals");
+    expect(report).toHaveProperty("summary");
+    expect(Array.isArray(report.signals)).toBe(true);
+    expect(typeof report.summary.ok).toBe("number");
+    expect(typeof report.summary.warning).toBe("number");
+    expect(typeof report.summary.critical).toBe("number");
+  });
+
+  test("summary counts match signal levels", () => {
+    const report = runHealthCheck();
+
+    const okCount = report.signals.filter((s) => s.level === "ok").length;
+    const warnCount = report.signals.filter(
+      (s) => s.level === "warning",
+    ).length;
+    const critCount = report.signals.filter(
+      (s) => s.level === "critical",
+    ).length;
+
+    expect(report.summary.ok).toBe(okCount);
+    expect(report.summary.warning).toBe(warnCount);
+    expect(report.summary.critical).toBe(critCount);
+  });
+
+  test("all signals have required fields", () => {
+    const report = runHealthCheck();
+
+    for (const signal of report.signals) {
+      expect(typeof signal.surface).toBe("string");
+      expect(["ok", "warning", "critical"]).toContain(signal.level);
+      expect(typeof signal.message).toBe("string");
+      expect(signal.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("timestamp is valid ISO 8601", () => {
+    const report = runHealthCheck();
+    const parsed = new Date(report.timestamp);
+    expect(parsed.getTime()).not.toBeNaN();
+  });
+
+  test("at least one signal covers each expected surface", () => {
+    const report = runHealthCheck();
+    const surfaces = new Set(report.signals.map((s) => s.surface));
+
+    expect(surfaces.has("pr-queue") || surfaces.has("backlog")).toBe(true);
+    expect(surfaces.has("cadence")).toBe(true);
+  });
+});

--- a/tools/health/factory-health-monitor.test.ts
+++ b/tools/health/factory-health-monitor.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { runHealthCheck } from "./factory-health-monitor";
+import {
+  buildHealthReport,
+  runHealthCheck,
+  type HealthSignal,
+} from "./factory-health-monitor";
 
 const HEALTH_CHECK_TIMEOUT_MS = 20_000;
 let cachedReport: ReturnType<typeof runHealthCheck> | undefined;
@@ -10,6 +14,33 @@ function getReport(): ReturnType<typeof runHealthCheck> {
 }
 
 describe("factory-health-monitor", () => {
+  test("buildHealthReport summarizes deterministic signals", () => {
+    const signals: HealthSignal[] = [
+      { surface: "pr-queue", level: "ok", message: "ready" },
+      {
+        surface: "claims",
+        level: "warning",
+        message: "claim drift",
+        action: "audit claims",
+      },
+      {
+        surface: "cadence",
+        level: "critical",
+        message: "idle",
+        action: "wake runner",
+      },
+    ];
+
+    const report = buildHealthReport(
+      signals,
+      "2026-05-07T15:10:00.000Z",
+    );
+
+    expect(report.summary).toEqual({ ok: 1, warning: 1, critical: 1 });
+    expect(report.recommendedAction).toBe("wake runner");
+    expect(report.timestamp).toBe("2026-05-07T15:10:00.000Z");
+  });
+
   test("runHealthCheck returns a valid HealthReport shape", () => {
     const report = getReport();
 

--- a/tools/health/factory-health-monitor.test.ts
+++ b/tools/health/factory-health-monitor.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { runHealthCheck } from "./factory-health-monitor";
 
+const HEALTH_CHECK_TIMEOUT_MS = 20_000;
+let cachedReport: ReturnType<typeof runHealthCheck> | undefined;
+
+function getReport(): ReturnType<typeof runHealthCheck> {
+  cachedReport ??= runHealthCheck();
+  return cachedReport;
+}
+
 describe("factory-health-monitor", () => {
   test("runHealthCheck returns a valid HealthReport shape", () => {
-    const report = runHealthCheck();
+    const report = getReport();
 
     expect(report).toHaveProperty("timestamp");
     expect(report).toHaveProperty("signals");
@@ -12,10 +20,10 @@ describe("factory-health-monitor", () => {
     expect(typeof report.summary.ok).toBe("number");
     expect(typeof report.summary.warning).toBe("number");
     expect(typeof report.summary.critical).toBe("number");
-  });
+  }, HEALTH_CHECK_TIMEOUT_MS);
 
   test("summary counts match signal levels", () => {
-    const report = runHealthCheck();
+    const report = getReport();
 
     const okCount = report.signals.filter((s) => s.level === "ok").length;
     const warnCount = report.signals.filter(
@@ -28,10 +36,10 @@ describe("factory-health-monitor", () => {
     expect(report.summary.ok).toBe(okCount);
     expect(report.summary.warning).toBe(warnCount);
     expect(report.summary.critical).toBe(critCount);
-  });
+  }, HEALTH_CHECK_TIMEOUT_MS);
 
   test("all signals have required fields", () => {
-    const report = runHealthCheck();
+    const report = getReport();
 
     for (const signal of report.signals) {
       expect(typeof signal.surface).toBe("string");
@@ -39,19 +47,19 @@ describe("factory-health-monitor", () => {
       expect(typeof signal.message).toBe("string");
       expect(signal.message.length).toBeGreaterThan(0);
     }
-  });
+  }, HEALTH_CHECK_TIMEOUT_MS);
 
   test("timestamp is valid ISO 8601", () => {
-    const report = runHealthCheck();
+    const report = getReport();
     const parsed = new Date(report.timestamp);
     expect(parsed.getTime()).not.toBeNaN();
-  });
+  }, HEALTH_CHECK_TIMEOUT_MS);
 
   test("at least one signal covers each expected surface", () => {
-    const report = runHealthCheck();
+    const report = getReport();
     const surfaces = new Set(report.signals.map((s) => s.surface));
 
     expect(surfaces.has("pr-queue") || surfaces.has("backlog")).toBe(true);
     expect(surfaces.has("cadence")).toBe(true);
-  });
+  }, HEALTH_CHECK_TIMEOUT_MS);
 });

--- a/tools/health/factory-health-monitor.ts
+++ b/tools/health/factory-health-monitor.ts
@@ -2,7 +2,7 @@
 // factory-health-monitor.ts -- Standing query for factory health signals.
 //
 // Detects conditions that need action across multiple surfaces:
-// PR queue, backlog state, CI status, claim freshness, trajectory
+// PR queue, backlog state, claim freshness, trajectory
 // progress. Produces a structured JSON report suitable for the
 // autonomous loop's tick-decision.
 //
@@ -10,16 +10,17 @@
 
 import { spawnSync } from "node:child_process";
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-interface HealthSignal {
+export interface HealthSignal {
   surface: string;
   level: "ok" | "warning" | "critical";
   message: string;
   action?: string;
 }
 
-interface HealthReport {
+export interface HealthReport {
   timestamp: string;
   signals: HealthSignal[];
   summary: {
@@ -30,9 +31,12 @@ interface HealthReport {
   recommendedAction: string | null;
 }
 
-const ROOT = resolve(import.meta.dir, "../..");
+type ToolCommand = "bun" | "gh" | "git";
 
-function run(cmd: string, args: string[]): { ok: boolean; stdout: string } {
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const REPO = process.env.REPO ?? "Lucent-Financial-Group/Zeta";
+
+function run(cmd: ToolCommand, args: string[]): { ok: boolean; stdout: string } {
   const r = spawnSync(cmd, args, {
     cwd: ROOT,
     encoding: "utf-8",
@@ -47,7 +51,7 @@ function checkPRQueue(): HealthSignal[] {
     "pr",
     "list",
     "--repo",
-    "Lucent-Financial-Group/Zeta",
+    REPO,
     "--state",
     "open",
     "--json",
@@ -271,10 +275,14 @@ function checkWorkingTreeCleanliness(): HealthSignal[] {
   }
 
   if (modified.length === 0 && untracked.length <= 5) {
+    const untrackedNote =
+      untracked.length === 0
+        ? "Working tree clean"
+        : `No modified files; ${untracked.length} untracked local file(s) present`;
     signals.push({
       surface: "working-tree",
       level: "ok",
-      message: "Working tree clean",
+      message: untrackedNote,
     });
   }
 
@@ -309,25 +317,20 @@ function checkTrajectoryProgress(): HealthSignal[] {
       }
     }
 
-    if (stalledCount > 0) {
-      signals.push({
-        surface: "trajectories",
-        level: "warning",
-        message: `${stalledCount} trajectory(ies) not updated in 7+ days`,
-        action: "refresh stalled trajectories or mark as paused",
-      });
-    }
-
     signals.push({
       surface: "trajectories",
-      level: "ok",
+      level: stalledCount > 0 ? "warning" : "ok",
       message: `${activeCount} active, ${stalledCount} stalled trajectory(ies)`,
+      ...(stalledCount > 0
+        ? { action: "refresh stalled trajectories or mark as paused" }
+        : {}),
     });
   } catch {
     signals.push({
       surface: "trajectories",
-      level: "ok",
-      message: "No trajectory directory found",
+      level: "warning",
+      message: "Could not inspect trajectory directory",
+      action: "verify docs/trajectories exists and is readable",
     });
   }
 
@@ -378,7 +381,7 @@ function checkLostFiles(): HealthSignal[] {
     "pr",
     "list",
     "--repo",
-    "Lucent-Financial-Group/Zeta",
+    REPO,
     "--state",
     "closed",
     "--limit",
@@ -459,7 +462,7 @@ function checkLostFiles(): HealthSignal[] {
     "pr",
     "list",
     "--repo",
-    "Lucent-Financial-Group/Zeta",
+    REPO,
     "--state",
     "open",
     "--json",
@@ -522,7 +525,15 @@ function checkRecentCommitCadence(): HealthSignal[] {
     "--format=%H",
   ]);
 
-  if (!r.ok) return signals;
+  if (!r.ok) {
+    signals.push({
+      surface: "cadence",
+      level: "warning",
+      message: "Could not query recent commit cadence",
+      action: "inspect local git state before trusting cadence health",
+    });
+    return signals;
+  }
 
   const commits = r.stdout.split("\n").filter(Boolean);
   if (commits.length === 0) {
@@ -543,17 +554,10 @@ function checkRecentCommitCadence(): HealthSignal[] {
   return signals;
 }
 
-export function runHealthCheck(): HealthReport {
-  const allSignals: HealthSignal[] = [
-    ...checkPRQueue(),
-    ...checkBacklogHealth(),
-    ...checkClaimFreshness(),
-    ...checkWorkingTreeCleanliness(),
-    ...checkTrajectoryProgress(),
-    ...checkLostFiles(),
-    ...checkRecentCommitCadence(),
-  ];
-
+export function buildHealthReport(
+  allSignals: HealthSignal[],
+  timestamp = new Date().toISOString(),
+): HealthReport {
   const summary = {
     ok: allSignals.filter((s) => s.level === "ok").length,
     warning: allSignals.filter((s) => s.level === "warning").length,
@@ -573,18 +577,60 @@ export function runHealthCheck(): HealthReport {
   }
 
   return {
-    timestamp: new Date().toISOString(),
+    timestamp,
     signals: allSignals,
     summary,
     recommendedAction,
   };
 }
 
-if (import.meta.main) {
-  const report = runHealthCheck();
-  const json = process.argv.includes("--json");
+export function runHealthCheck(): HealthReport {
+  return buildHealthReport([
+    ...checkPRQueue(),
+    ...checkBacklogHealth(),
+    ...checkClaimFreshness(),
+    ...checkWorkingTreeCleanliness(),
+    ...checkTrajectoryProgress(),
+    ...checkLostFiles(),
+    ...checkRecentCommitCadence(),
+  ]);
+}
 
-  if (json) {
+function printHelp(): void {
+  console.log(`Usage: bun tools/health/factory-health-monitor.ts [--json]
+
+Options:
+  --json   Emit the health report as JSON.
+  --help   Show this help text.`);
+}
+
+function parseArgs(args: string[]): { json: boolean; help: boolean } {
+  const parsed = { json: false, help: false };
+  for (const arg of args) {
+    if (arg === "--json") {
+      parsed.json = true;
+    } else if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      printHelp();
+      process.exit(2);
+    }
+  }
+  return parsed;
+}
+
+if (import.meta.main) {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const report = runHealthCheck();
+
+  if (args.json) {
     console.log(JSON.stringify(report, null, 2));
   } else {
     console.log(`Factory Health Report — ${report.timestamp}`);

--- a/tools/health/factory-health-monitor.ts
+++ b/tools/health/factory-health-monitor.ts
@@ -164,6 +164,12 @@ function checkBacklogHealth(): HealthSignal[] {
       level: "ok",
       message: `${p0Count} open P0, ${p1Count} open P1, ${totalOpen} total open`,
     });
+  } else if (totalOpen > 0) {
+    signals.push({
+      surface: "backlog",
+      level: "ok",
+      message: `0 open P0, ${p1Count} open P1, ${totalOpen} total open`,
+    });
   }
 
   if (totalOpen === 0) {
@@ -187,7 +193,17 @@ function checkClaimFreshness(): HealthSignal[] {
     "origin/claim/*",
   ]);
 
-  if (!r.ok || !r.stdout) {
+  if (!r.ok) {
+    signals.push({
+      surface: "claims",
+      level: "warning",
+      message: "Could not query claim branches",
+      action: "inspect local git remote state and credentials before trusting claim freshness",
+    });
+    return signals;
+  }
+
+  if (!r.stdout) {
     signals.push({
       surface: "claims",
       level: "ok",

--- a/tools/health/factory-health-monitor.ts
+++ b/tools/health/factory-health-monitor.ts
@@ -334,6 +334,185 @@ function checkTrajectoryProgress(): HealthSignal[] {
   return signals;
 }
 
+function checkLostFiles(): HealthSignal[] {
+  const signals: HealthSignal[] = [];
+
+  const deletedRecent = run("git", [
+    "log",
+    "--all",
+    "--diff-filter=D",
+    "--since=7 days ago",
+    "--name-only",
+    "--pretty=format:",
+  ]);
+
+  if (deletedRecent.ok) {
+    const deleted = deletedRecent.stdout
+      .split("\n")
+      .filter((l) => l.trim().length > 0);
+    if (deleted.length > 0) {
+      signals.push({
+        surface: "lost-files",
+        level: "warning",
+        message: `${deleted.length} file(s) deleted in last 7 days`,
+        action:
+          "audit recent deletions — check if content was captured elsewhere before removal",
+      });
+    }
+  }
+
+  const stash = run("git", ["stash", "list"]);
+  if (stash.ok && stash.stdout.length > 0) {
+    const stashCount = stash.stdout.split("\n").filter(Boolean).length;
+    if (stashCount > 0) {
+      signals.push({
+        surface: "lost-files",
+        level: "warning",
+        message: `${stashCount} stash entry(ies) — possible lost work-in-progress`,
+        action: "review stash entries — pop or drop",
+      });
+    }
+  }
+
+  const closedNotMerged = run("gh", [
+    "pr",
+    "list",
+    "--repo",
+    "Lucent-Financial-Group/Zeta",
+    "--state",
+    "closed",
+    "--limit",
+    "20",
+    "--json",
+    "number,mergedAt,closedAt,title",
+  ]);
+
+  if (closedNotMerged.ok) {
+    try {
+      const prs = JSON.parse(closedNotMerged.stdout) as Array<{
+        number: number;
+        mergedAt: string | null;
+        closedAt: string;
+        title: string;
+      }>;
+      const unmerged = prs.filter((pr) => {
+        if (pr.mergedAt) return false;
+        const age = Date.now() - new Date(pr.closedAt).getTime();
+        return age < 30 * 24 * 60 * 60 * 1000;
+      });
+
+      if (unmerged.length > 0) {
+        signals.push({
+          surface: "lost-files",
+          level: "warning",
+          message: `${unmerged.length} closed-not-merged PR(s) in last 30 days: ${unmerged.map((p) => `#${p.number}`).join(", ")}`,
+          action:
+            "check if closed-not-merged PRs contain unrecovered content",
+        });
+      }
+    } catch {
+      // parse failure
+    }
+  }
+
+  const orphanBranches = run("git", [
+    "for-each-ref",
+    "--no-merged",
+    "origin/main",
+    "--format=%(refname:short)",
+    "refs/remotes/origin/",
+  ]);
+
+  if (orphanBranches.ok && orphanBranches.stdout) {
+    const branches = orphanBranches.stdout.split("\n").filter(Boolean);
+    const nonClaim = branches.filter(
+      (b) => !b.includes("claim/") && !b.includes("origin/main"),
+    );
+    if (nonClaim.length > 10) {
+      signals.push({
+        surface: "lost-files",
+        level: "warning",
+        message: `${nonClaim.length} orphan branch(es) not merged to main`,
+        action:
+          "audit orphan branches for unrecovered content — per LOST-FILES-LOCATIONS.md class 2",
+      });
+    }
+  }
+
+  const worktrees = run("git", ["worktree", "list", "--porcelain"]);
+  if (worktrees.ok) {
+    const wtPaths = worktrees.stdout
+      .split("\n")
+      .filter((l) => l.startsWith("worktree "));
+    if (wtPaths.length > 1) {
+      signals.push({
+        surface: "lost-files",
+        level: "warning",
+        message: `${wtPaths.length - 1} extra worktree(s) — possible subagent remnants`,
+        action:
+          "check worktrees for uncommitted changes — per LOST-FILES-LOCATIONS.md class 7",
+      });
+    }
+  }
+
+  const drafts = run("gh", [
+    "pr",
+    "list",
+    "--repo",
+    "Lucent-Financial-Group/Zeta",
+    "--state",
+    "open",
+    "--json",
+    "number,isDraft,title",
+  ]);
+
+  if (drafts.ok) {
+    try {
+      const prs = JSON.parse(drafts.stdout) as Array<{
+        number: number;
+        isDraft: boolean;
+        title: string;
+      }>;
+      const draftPRs = prs.filter((pr) => pr.isDraft);
+      if (draftPRs.length > 0) {
+        signals.push({
+          surface: "lost-files",
+          level: "warning",
+          message: `${draftPRs.length} draft PR(s): ${draftPRs.map((p) => `#${p.number}`).join(", ")}`,
+          action:
+            "review draft PRs — publish or close — per LOST-FILES-LOCATIONS.md class 8",
+        });
+      }
+    } catch {
+      // parse failure
+    }
+  }
+
+  const memoryRefs = run("bun", [
+    join(ROOT, "tools/hygiene/audit-memory-references.ts"),
+  ]);
+  if (memoryRefs.ok && memoryRefs.stdout.includes("BROKEN")) {
+    const brokenCount = (memoryRefs.stdout.match(/BROKEN/g) || []).length;
+    signals.push({
+      surface: "lost-files",
+      level: "warning",
+      message: `${brokenCount} broken memory reference(s) — possible deleted memory files`,
+      action:
+        "fix broken memory references — per LOST-FILES-LOCATIONS.md class 15",
+    });
+  }
+
+  if (signals.length === 0) {
+    signals.push({
+      surface: "lost-files",
+      level: "ok",
+      message: "No lost-file signals detected",
+    });
+  }
+
+  return signals;
+}
+
 function checkRecentCommitCadence(): HealthSignal[] {
   const signals: HealthSignal[] = [];
   const r = run("git", [
@@ -371,6 +550,7 @@ export function runHealthCheck(): HealthReport {
     ...checkClaimFreshness(),
     ...checkWorkingTreeCleanliness(),
     ...checkTrajectoryProgress(),
+    ...checkLostFiles(),
     ...checkRecentCommitCadence(),
   ];
 

--- a/tools/health/factory-health-monitor.ts
+++ b/tools/health/factory-health-monitor.ts
@@ -368,10 +368,12 @@ export function runHealthCheck(): HealthReport {
   const warnings = allSignals.filter((s) => s.level === "warning");
 
   let recommendedAction: string | null = null;
-  if (critical.length > 0) {
-    recommendedAction = critical[0].action ?? critical[0].message;
-  } else if (warnings.length > 0) {
-    recommendedAction = warnings[0].action ?? warnings[0].message;
+  const firstCritical = critical[0];
+  const firstWarning = warnings[0];
+  if (firstCritical) {
+    recommendedAction = firstCritical.action ?? firstCritical.message;
+  } else if (firstWarning) {
+    recommendedAction = firstWarning.action ?? firstWarning.message;
   }
 
   return {

--- a/tools/health/factory-health-monitor.ts
+++ b/tools/health/factory-health-monitor.ts
@@ -1,0 +1,416 @@
+#!/usr/bin/env bun
+// factory-health-monitor.ts -- Standing query for factory health signals.
+//
+// Detects conditions that need action across multiple surfaces:
+// PR queue, backlog state, CI status, claim freshness, trajectory
+// progress. Produces a structured JSON report suitable for the
+// autonomous loop's tick-decision.
+//
+// This is the "detect" half of detect-trigger-repair (B-0250).
+
+import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+interface HealthSignal {
+  surface: string;
+  level: "ok" | "warning" | "critical";
+  message: string;
+  action?: string;
+}
+
+interface HealthReport {
+  timestamp: string;
+  signals: HealthSignal[];
+  summary: {
+    ok: number;
+    warning: number;
+    critical: number;
+  };
+  recommendedAction: string | null;
+}
+
+const ROOT = resolve(import.meta.dir, "../..");
+
+function run(cmd: string, args: string[]): { ok: boolean; stdout: string } {
+  const r = spawnSync(cmd, args, {
+    cwd: ROOT,
+    encoding: "utf-8",
+    timeout: 30_000,
+  });
+  return { ok: r.status === 0, stdout: (r.stdout ?? "").trim() };
+}
+
+function checkPRQueue(): HealthSignal[] {
+  const signals: HealthSignal[] = [];
+  const r = run("gh", [
+    "pr",
+    "list",
+    "--repo",
+    "Lucent-Financial-Group/Zeta",
+    "--state",
+    "open",
+    "--json",
+    "number,title,createdAt,autoMergeRequest",
+    "--limit",
+    "50",
+  ]);
+
+  if (!r.ok) {
+    signals.push({
+      surface: "pr-queue",
+      level: "warning",
+      message: "Could not query PR queue (gh CLI issue)",
+    });
+    return signals;
+  }
+
+  try {
+    const prs = JSON.parse(r.stdout) as Array<{
+      number: number;
+      title: string;
+      createdAt: string;
+      autoMergeRequest: { enabledAt: string } | null;
+    }>;
+
+    if (prs.length === 0) {
+      signals.push({
+        surface: "pr-queue",
+        level: "ok",
+        message: "PR queue empty — runway available for new work",
+        action: "run autonomous-pickup to select next backlog item",
+      });
+    } else {
+      const stale = prs.filter((pr) => {
+        const age =
+          Date.now() - new Date(pr.createdAt).getTime();
+        return age > 24 * 60 * 60 * 1000;
+      });
+
+      if (stale.length > 0) {
+        signals.push({
+          surface: "pr-queue",
+          level: "warning",
+          message: `${stale.length} PR(s) older than 24h: ${stale.map((p) => `#${p.number}`).join(", ")}`,
+          action: "investigate stale PRs — check CI status and unresolved threads",
+        });
+      }
+
+      const noAutoMerge = prs.filter((pr) => !pr.autoMergeRequest);
+      if (noAutoMerge.length > 0) {
+        signals.push({
+          surface: "pr-queue",
+          level: "warning",
+          message: `${noAutoMerge.length} PR(s) without auto-merge: ${noAutoMerge.map((p) => `#${p.number}`).join(", ")}`,
+          action: "arm auto-merge on qualifying PRs",
+        });
+      }
+
+      if (stale.length === 0 && noAutoMerge.length === 0) {
+        signals.push({
+          surface: "pr-queue",
+          level: "ok",
+          message: `${prs.length} PR(s) open, all auto-merge armed and fresh`,
+        });
+      }
+    }
+  } catch {
+    signals.push({
+      surface: "pr-queue",
+      level: "warning",
+      message: "Could not parse PR queue response",
+    });
+  }
+
+  return signals;
+}
+
+function checkBacklogHealth(): HealthSignal[] {
+  const signals: HealthSignal[] = [];
+  const backlogDir = join(ROOT, "docs/backlog");
+
+  let p0Count = 0;
+  let p1Count = 0;
+  let totalOpen = 0;
+
+  for (const priority of ["P0", "P1", "P2", "P3"]) {
+    const dir = join(backlogDir, priority);
+    try {
+      const files = readdirSync(dir).filter((f) => f.endsWith(".md"));
+      for (const file of files) {
+        const content = readFileSync(join(dir, file), "utf-8");
+        const statusMatch = content.match(/^status:\s*(\S+)/m);
+        if (statusMatch && statusMatch[1] === "open") {
+          totalOpen++;
+          if (priority === "P0") p0Count++;
+          if (priority === "P1") p1Count++;
+        }
+      }
+    } catch {
+      // directory may not exist
+    }
+  }
+
+  if (p0Count > 5) {
+    signals.push({
+      surface: "backlog",
+      level: "critical",
+      message: `${p0Count} open P0 items — too many critical items`,
+      action: "triage P0 items: close resolved, decompose blobs, deprioritize if not truly P0",
+    });
+  } else if (p0Count > 0) {
+    signals.push({
+      surface: "backlog",
+      level: "ok",
+      message: `${p0Count} open P0, ${p1Count} open P1, ${totalOpen} total open`,
+    });
+  }
+
+  if (totalOpen === 0) {
+    signals.push({
+      surface: "backlog",
+      level: "critical",
+      message: "No open backlog items — factory has no work queue",
+      action: "file new backlog items from trajectories or gap analysis",
+    });
+  }
+
+  return signals;
+}
+
+function checkClaimFreshness(): HealthSignal[] {
+  const signals: HealthSignal[] = [];
+  const r = run("git", [
+    "branch",
+    "-r",
+    "--list",
+    "origin/claim/*",
+  ]);
+
+  if (!r.ok || !r.stdout) {
+    signals.push({
+      surface: "claims",
+      level: "ok",
+      message: "No active claim branches",
+    });
+    return signals;
+  }
+
+  const branches = r.stdout
+    .split("\n")
+    .map((b) => b.trim())
+    .filter(Boolean);
+
+  if (branches.length > 5) {
+    signals.push({
+      surface: "claims",
+      level: "warning",
+      message: `${branches.length} claim branches — possible stale claims`,
+      action: "audit claim branches for completed or abandoned work",
+    });
+  } else {
+    signals.push({
+      surface: "claims",
+      level: "ok",
+      message: `${branches.length} active claim branch(es)`,
+    });
+  }
+
+  return signals;
+}
+
+function checkWorkingTreeCleanliness(): HealthSignal[] {
+  const signals: HealthSignal[] = [];
+  const r = run("git", ["status", "--porcelain"]);
+
+  if (!r.ok) {
+    signals.push({
+      surface: "working-tree",
+      level: "warning",
+      message: "Could not check working tree status",
+    });
+    return signals;
+  }
+
+  const lines = r.stdout.split("\n").filter(Boolean);
+  const untracked = lines.filter((l) => l.startsWith("??"));
+  const modified = lines.filter((l) => !l.startsWith("??"));
+
+  if (modified.length > 0) {
+    signals.push({
+      surface: "working-tree",
+      level: "warning",
+      message: `${modified.length} modified file(s) not committed`,
+      action: "review uncommitted changes — commit or stash",
+    });
+  }
+
+  if (untracked.length > 5) {
+    signals.push({
+      surface: "working-tree",
+      level: "warning",
+      message: `${untracked.length} untracked file(s) — possible artifacts`,
+      action: "clean up or .gitignore untracked files",
+    });
+  }
+
+  if (modified.length === 0 && untracked.length <= 5) {
+    signals.push({
+      surface: "working-tree",
+      level: "ok",
+      message: "Working tree clean",
+    });
+  }
+
+  return signals;
+}
+
+function checkTrajectoryProgress(): HealthSignal[] {
+  const signals: HealthSignal[] = [];
+  const trajDir = join(ROOT, "docs/trajectories");
+
+  try {
+    const entries = readdirSync(trajDir, { withFileTypes: true });
+    const trajectories = entries.filter((e) => e.isDirectory());
+
+    let activeCount = 0;
+    let stalledCount = 0;
+
+    for (const traj of trajectories) {
+      const resumePath = join(trajDir, traj.name, "RESUME.md");
+      try {
+        const stat = statSync(resumePath);
+        const age = Date.now() - stat.mtimeMs;
+        const daysSinceUpdate = age / (24 * 60 * 60 * 1000);
+
+        if (daysSinceUpdate > 7) {
+          stalledCount++;
+        } else {
+          activeCount++;
+        }
+      } catch {
+        // no RESUME.md
+      }
+    }
+
+    if (stalledCount > 0) {
+      signals.push({
+        surface: "trajectories",
+        level: "warning",
+        message: `${stalledCount} trajectory(ies) not updated in 7+ days`,
+        action: "refresh stalled trajectories or mark as paused",
+      });
+    }
+
+    signals.push({
+      surface: "trajectories",
+      level: "ok",
+      message: `${activeCount} active, ${stalledCount} stalled trajectory(ies)`,
+    });
+  } catch {
+    signals.push({
+      surface: "trajectories",
+      level: "ok",
+      message: "No trajectory directory found",
+    });
+  }
+
+  return signals;
+}
+
+function checkRecentCommitCadence(): HealthSignal[] {
+  const signals: HealthSignal[] = [];
+  const r = run("git", [
+    "log",
+    "--oneline",
+    "--since=24 hours ago",
+    "--format=%H",
+  ]);
+
+  if (!r.ok) return signals;
+
+  const commits = r.stdout.split("\n").filter(Boolean);
+  if (commits.length === 0) {
+    signals.push({
+      surface: "cadence",
+      level: "critical",
+      message: "No commits in the last 24 hours — factory may be idle",
+      action: "check autonomous loop status and backlog runner",
+    });
+  } else {
+    signals.push({
+      surface: "cadence",
+      level: "ok",
+      message: `${commits.length} commit(s) in last 24h`,
+    });
+  }
+
+  return signals;
+}
+
+export function runHealthCheck(): HealthReport {
+  const allSignals: HealthSignal[] = [
+    ...checkPRQueue(),
+    ...checkBacklogHealth(),
+    ...checkClaimFreshness(),
+    ...checkWorkingTreeCleanliness(),
+    ...checkTrajectoryProgress(),
+    ...checkRecentCommitCadence(),
+  ];
+
+  const summary = {
+    ok: allSignals.filter((s) => s.level === "ok").length,
+    warning: allSignals.filter((s) => s.level === "warning").length,
+    critical: allSignals.filter((s) => s.level === "critical").length,
+  };
+
+  const critical = allSignals.filter((s) => s.level === "critical");
+  const warnings = allSignals.filter((s) => s.level === "warning");
+
+  let recommendedAction: string | null = null;
+  if (critical.length > 0) {
+    recommendedAction = critical[0].action ?? critical[0].message;
+  } else if (warnings.length > 0) {
+    recommendedAction = warnings[0].action ?? warnings[0].message;
+  }
+
+  return {
+    timestamp: new Date().toISOString(),
+    signals: allSignals,
+    summary,
+    recommendedAction,
+  };
+}
+
+if (import.meta.main) {
+  const report = runHealthCheck();
+  const json = process.argv.includes("--json");
+
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(`Factory Health Report — ${report.timestamp}`);
+    console.log("=".repeat(50));
+
+    for (const signal of report.signals) {
+      const icon =
+        signal.level === "ok"
+          ? "[OK]"
+          : signal.level === "warning"
+            ? "[!!]"
+            : "[XX]";
+      console.log(`${icon} ${signal.surface}: ${signal.message}`);
+      if (signal.action) {
+        console.log(`     -> ${signal.action}`);
+      }
+    }
+
+    console.log("=".repeat(50));
+    console.log(
+      `Summary: ${report.summary.ok} ok, ${report.summary.warning} warning, ${report.summary.critical} critical`,
+    );
+    if (report.recommendedAction) {
+      console.log(`Recommended: ${report.recommendedAction}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `tools/health/factory-health-monitor.ts` — standing query that monitors 6 factory surfaces (PR queue, backlog state, claim freshness, working tree, trajectory progress, commit cadence)
- Each surface emits ok/warning/critical signal with recommended action
- Produces structured JSON (`--json`) or human-readable report
- This is the "detect" half of the detect-trigger-repair pipeline (B-0250) Aaron flagged as critical survival infrastructure

## Output example
```
[OK] pr-queue: 1 PR(s) open, all auto-merge armed and fresh
[OK] backlog: 4 open P0, 60 open P1, 224 total open
[!!] claims: 40 claim branches — possible stale claims
[OK] working-tree: Working tree clean
[OK] trajectories: 4 active, 0 stalled trajectory(ies)
[OK] cadence: 189 commit(s) in last 24h
```

## Test plan
- [x] `bun tools/health/factory-health-monitor.ts` produces readable report
- [x] `bun tools/health/factory-health-monitor.ts --json` produces valid JSON
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)