### PR TITLE
test(core): CheckpointStore roundtrip tests (B-0251)

### DIFF
--- a/tests/Tests.FSharp/Storage/CheckpointStore.Tests.fs
+++ b/tests/Tests.FSharp/Storage/CheckpointStore.Tests.fs
@@ -1,0 +1,122 @@
+module Zeta.Tests.Storage.CheckpointStoreTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+
+[<Fact>]
+let ``InMemoryCheckpointStore roundtrips operator state`` () =
+    let store = InMemoryCheckpointStore() :> ICheckpointStore
+
+    let mutable savedValue = 42
+    let checkpointable =
+        { new ICheckpointable with
+            member _.SaveState writer = writer.WriteInt32 savedValue
+            member _.LoadState reader = savedValue <- reader.ReadInt32()
+            member _.StateVersion = 1 }
+
+    let states = [| (0, checkpointable) |]
+    store.SaveCheckpointAsync("test-circuit", 1L, states, System.Threading.CancellationToken.None)
+    |> fun vt -> vt.AsTask() |> Async.AwaitTask |> Async.RunSynchronously
+
+    savedValue <- 0
+
+    let loaded =
+        store.LoadCheckpointAsync("test-circuit", System.Threading.CancellationToken.None)
+        |> fun vt -> vt.AsTask() |> Async.AwaitTask |> Async.RunSynchronously
+
+    loaded.IsSome |> should be True
+    let struct (tick, readers) = loaded.Value
+    tick |> should equal 1L
+    readers.Length |> should equal 1
+
+    let (opId, reader) = readers.[0]
+    opId |> should equal 0
+    checkpointable.LoadState reader
+    savedValue |> should equal 42
+
+
+[<Fact>]
+let ``InMemoryCheckpointStore returns ValueNone when empty`` () =
+    let store = InMemoryCheckpointStore() :> ICheckpointStore
+
+    let loaded =
+        store.LoadCheckpointAsync("nonexistent", System.Threading.CancellationToken.None)
+        |> fun vt -> vt.AsTask() |> Async.AwaitTask |> Async.RunSynchronously
+
+    loaded.IsNone |> should be True
+
+
+[<Fact>]
+let ``InMemoryCheckpointStore handles multiple operators`` () =
+    let store = InMemoryCheckpointStore() :> ICheckpointStore
+
+    let mutable val1 = 100L
+    let mutable val2 = "hello"
+
+    let op1 =
+        { new ICheckpointable with
+            member _.SaveState writer = writer.WriteInt64 val1
+            member _.LoadState reader = val1 <- reader.ReadInt64()
+            member _.StateVersion = 1 }
+
+    let op2 =
+        { new ICheckpointable with
+            member _.SaveState writer = writer.WriteString val2
+            member _.LoadState reader = val2 <- reader.ReadString()
+            member _.StateVersion = 1 }
+
+    let states = [| (0, op1); (1, op2) |]
+    store.SaveCheckpointAsync("multi", 5L, states, System.Threading.CancellationToken.None)
+    |> fun vt -> vt.AsTask() |> Async.AwaitTask |> Async.RunSynchronously
+
+    val1 <- 0L
+    val2 <- ""
+
+    let loaded =
+        store.LoadCheckpointAsync("multi", System.Threading.CancellationToken.None)
+        |> fun vt -> vt.AsTask() |> Async.AwaitTask |> Async.RunSynchronously
+
+    let struct (tick, readers) = loaded.Value
+    tick |> should equal 5L
+    readers.Length |> should equal 2
+
+    let (_, r1) = readers.[0]
+    let (_, r2) = readers.[1]
+    op1.LoadState r1
+    op2.LoadState r2
+
+    val1 |> should equal 100L
+    val2 |> should equal "hello"
+
+
+[<Fact>]
+let ``InMemoryCheckpointStore overwrites on second save`` () =
+    let store = InMemoryCheckpointStore() :> ICheckpointStore
+
+    let mutable v = 10
+    let op =
+        { new ICheckpointable with
+            member _.SaveState writer = writer.WriteInt32 v
+            member _.LoadState reader = v <- reader.ReadInt32()
+            member _.StateVersion = 1 }
+
+    store.SaveCheckpointAsync("c", 1L, [| (0, op) |], System.Threading.CancellationToken.None)
+    |> fun vt -> vt.AsTask() |> Async.AwaitTask |> Async.RunSynchronously
+
+    v <- 20
+    store.SaveCheckpointAsync("c", 2L, [| (0, op) |], System.Threading.CancellationToken.None)
+    |> fun vt -> vt.AsTask() |> Async.AwaitTask |> Async.RunSynchronously
+
+    v <- 0
+
+    let loaded =
+        store.LoadCheckpointAsync("c", System.Threading.CancellationToken.None)
+        |> fun vt -> vt.AsTask() |> Async.AwaitTask |> Async.RunSynchronously
+
+    let struct (tick, readers) = loaded.Value
+    tick |> should equal 2L
+    let (_, r) = readers.[0]
+    op.LoadState r
+    v |> should equal 20

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -55,6 +55,7 @@
     <Compile Include="Storage/Spine.Balanced.Tests.fs" />
     <Compile Include="Storage/Spine.Disk.Tests.fs" />
     <Compile Include="Storage/Checkpoint.Tests.fs" />
+    <Compile Include="Storage/CheckpointStore.Tests.fs" />
     <Compile Include="Storage/Merkle.Tests.fs" />
     <Compile Include="Storage/FastCdc.Tests.fs" />
     <Compile Include="Storage/ClosureTable.Tests.fs" />


### PR DESCRIPTION
## Summary
- 4 tests validating ICheckpointable + ICheckpointStore interfaces
- Single-operator roundtrip, empty store, multi-operator (int64+string), overwrite semantics
- All 4 pass locally

## Test plan
- [x] `dotnet test --filter CheckpointStore` — 4 pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)