### PR TITLE
fix(backlog): pickup respects decomposition=decomposed|atomic

### DIFF
--- a/tools/backlog/autonomous-pickup.ts
+++ b/tools/backlog/autonomous-pickup.ts
@@ -355,6 +355,9 @@ function claimBlocker(item: BacklogItem, activeClaims: readonly string[]): strin
 }
 
 function actionFor(item: BacklogItem): Action {
+  if (item.decomposition === "atomic" || item.decomposition === "decomposed") {
+    return "claim-and-implement";
+  }
   return item.decomposition === "blob" || item.bodyLineCount >= BLOB_LINE_THRESHOLD
     ? "decompose"
     : "claim-and-implement";


### PR DESCRIPTION
## Summary
- Items marked `decomposition: decomposed` or `decomposition: atomic` now get `claim-and-implement`, not `decompose`, regardless of body line count
- B-0062 (217 lines, already decomposed in-place with 21 spec-logic items) was incorrectly re-triggering decompose on every autonomous pickup

## Test plan
- [x] `bun test tools/backlog/autonomous-pickup.test.ts` — 5 pass
- [x] B-0062 now returns `claim-and-implement` instead of `decompose`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)