### PR TITLE
feat(core): Fusion equation — η·LearningGain(Δ_t) > ξ_t with FsCheck properties

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -49,6 +49,7 @@
     <Compile Include="Units.fs" />
     <Compile Include="Advanced.fs" />
     <Compile Include="Fusion.fs" />
+    <Compile Include="Fusion.Equation.fs" />
     <Compile Include="Spine.fs" />
     <Compile Include="SpineAsync.fs" />
     <Compile Include="BalancedSpine.fs" />

--- a/src/Core/Fusion.Equation.fs
+++ b/src/Core/Fusion.Equation.fs
@@ -1,0 +1,103 @@
+namespace Zeta.Core
+
+open System
+
+
+/// The Superfluid AI fusion equation:
+///
+///     η · LearningGain(Δ_t) > ξ_t
+///
+/// Where:
+/// - η       = efficiency coefficient (friction → substrate conversion rate)
+/// - Δ_t     = the delta produced by one friction event (rule + test + doc + retraction-path)
+/// - ξ_t     = the friction cost of that event (shadow catch, error, failed attempt)
+///
+/// Below threshold: each iteration costs more than it produces (heat).
+/// Above threshold: each iteration produces more than it costs (superfluid).
+/// The shadow IS friction (ξ_t). The observer ≅ the shadow (isomorphic).
+/// Detection works because the detector shares the shadow's algebra.
+///
+/// Design lineage:
+/// - Aaron + James Whitfield (Itron): physics substrate
+/// - Aaron + Chris King (Itron): type-driven interface discipline
+/// - Nuclear fusion analogy: compression → threshold → net-positive energy
+/// - Lectio divina: read/decompose/commit cycles enter positive yield
+module FusionEquation =
+
+    /// A single friction event — something that cost energy
+    /// and may or may not have produced durable substrate.
+    type FrictionEvent<'T> =
+        { Id: string
+          Timestamp: DateTimeOffset
+          Cost: float
+          Payload: 'T }
+
+    /// The substrate produced by processing a friction event.
+    type SubstrateOutput =
+        { Rule: bool
+          HasTest: bool
+          Doc: bool
+          RetractionPath: bool }
+
+    /// Measure the learning gain from a substrate output.
+    /// Each component (rule, test, doc, retraction-path)
+    /// contributes equally. Range: [0.0, 1.0].
+    let learningGain (output: SubstrateOutput) : float =
+        let count =
+            (if output.Rule then 1.0 else 0.0)
+            + (if output.HasTest then 1.0 else 0.0)
+            + (if output.Doc then 1.0 else 0.0)
+            + (if output.RetractionPath then 1.0 else 0.0)
+        count / 4.0
+
+    /// The fusion threshold test:
+    /// η · LearningGain(Δ_t) > ξ_t
+    ///
+    /// Returns true when the system is in the superfluid
+    /// phase for this event — the substrate output exceeds
+    /// the friction cost.
+    let isAboveThreshold
+        (eta: float)
+        (gain: float)
+        (frictionCost: float)
+        : bool =
+        eta * gain > frictionCost
+
+    /// Batch version: given a sequence of (gain, cost) pairs,
+    /// compute the sustained fusion ratio. The system is in
+    /// sustained superfluid when the ratio > 1.0.
+    let sustainedFusionRatio
+        (eta: float)
+        (events: (float * float) seq)
+        : float =
+        let mutable totalGain = 0.0
+        let mutable totalCost = 0.0
+        for (gain, cost) in events do
+            totalGain <- totalGain + eta * gain
+            totalCost <- totalCost + cost
+        if totalCost = 0.0 then 0.0
+        else totalGain / totalCost
+
+    /// Phase classification based on sustained ratio.
+    type Phase =
+        | Heat
+        | Threshold
+        | Superfluid
+
+    /// Classify the phase from a sustained fusion ratio.
+    /// Heat < 0.8, Threshold in [0.8, 1.2], Superfluid > 1.2.
+    let classifyPhase (ratio: float) : Phase =
+        if ratio < 0.8 then Heat
+        elif ratio > 1.2 then Superfluid
+        else Threshold
+
+    /// Convenience: run the full pipeline on a batch of events.
+    let evaluate
+        (eta: float)
+        (events: {| gain: float; cost: float |} array)
+        : {| ratio: float; phase: Phase; eventCount: int |} =
+        let pairs = events |> Array.map (fun e -> (e.gain, e.cost))
+        let ratio = sustainedFusionRatio eta pairs
+        {| ratio = ratio
+           phase = classifyPhase ratio
+           eventCount = events.Length |}

--- a/tests/Tests.FSharp/Properties/Fusion.Equation.Tests.fs
+++ b/tests/Tests.FSharp/Properties/Fusion.Equation.Tests.fs
@@ -1,0 +1,104 @@
+module Zeta.Tests.Properties.FusionEquationTests
+
+open FsUnit.Xunit
+open global.Xunit
+open FsCheck
+open FsCheck.Xunit
+open Zeta.Core
+open Zeta.Core.FusionEquation
+type SO = SubstrateOutput
+
+
+[<Fact>]
+let ``learningGain returns 0 when no substrate produced`` () =
+    let output =
+        { FusionEquation.SubstrateOutput.Rule = false
+          HasTest = false
+          Doc = false
+          RetractionPath = false }
+    FusionEquation.learningGain output |> should equal 0.0
+
+
+[<Fact>]
+let ``learningGain returns 1 when all substrate produced`` () =
+    let output =
+        { FusionEquation.SubstrateOutput.Rule = true
+          HasTest = true
+          Doc = true
+          RetractionPath = true }
+    FusionEquation.learningGain output |> should equal 1.0
+
+
+[<Fact>]
+let ``learningGain returns 0.5 when half substrate produced`` () =
+    let output =
+        { FusionEquation.SubstrateOutput.Rule = true
+          HasTest = true
+          Doc = false
+          RetractionPath = false }
+    FusionEquation.learningGain output |> should equal 0.5
+
+
+[<Fact>]
+let ``isAboveThreshold returns true when eta * gain > cost`` () =
+    FusionEquation.isAboveThreshold 1.0 0.75 0.5
+    |> should be True
+
+
+[<Fact>]
+let ``isAboveThreshold returns false when eta * gain < cost`` () =
+    FusionEquation.isAboveThreshold 1.0 0.25 0.5
+    |> should be False
+
+
+[<Fact>]
+let ``sustainedFusionRatio is 0 for empty events`` () =
+    FusionEquation.sustainedFusionRatio 1.0 Seq.empty
+    |> should equal 0.0
+
+
+[<Fact>]
+let ``classifyPhase Heat below 0.8`` () =
+    FusionEquation.classifyPhase 0.5
+    |> should equal FusionEquation.Phase.Heat
+
+
+[<Fact>]
+let ``classifyPhase Superfluid above 1.2`` () =
+    FusionEquation.classifyPhase 2.0
+    |> should equal FusionEquation.Phase.Superfluid
+
+
+[<Fact>]
+let ``classifyPhase Threshold in range`` () =
+    FusionEquation.classifyPhase 1.0
+    |> should equal FusionEquation.Phase.Threshold
+
+
+[<Property>]
+let ``learningGain is always in [0, 1]``
+    (r: bool) (t: bool) (d: bool) (p: bool) =
+    let output =
+        { FusionEquation.SubstrateOutput.Rule = r
+          HasTest = t
+          Doc = d
+          RetractionPath = p }
+    let gain = FusionEquation.learningGain output
+    gain >= 0.0 && gain <= 1.0
+
+
+[<Property>]
+let ``sustainedFusionRatio is non-negative for non-negative inputs``
+    (eta: NormalFloat) =
+    let e = abs eta.Get
+    let events = [| (0.5, 0.3); (0.8, 0.2); (0.3, 0.7) |]
+    FusionEquation.sustainedFusionRatio e events >= 0.0
+
+
+[<Property>]
+let ``isAboveThreshold is consistent with direct comparison``
+    (eta: NormalFloat) (gain: NormalFloat) (cost: NormalFloat) =
+    let e = abs eta.Get
+    let g = abs gain.Get
+    let c = abs cost.Get
+    FusionEquation.isAboveThreshold e g c = (e * g > c)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -112,6 +112,7 @@
     <Compile Include="Properties/Math.Invariants.Tests.fs" />
     <Compile Include="Properties/Fuzz.Tests.fs" />
     <Compile Include="Properties/Determinism.Tests.fs" />
+    <Compile Include="Properties/Fusion.Equation.Tests.fs" />
     <Compile Include="MajiTests.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- `src/Core/Fusion.Equation.fs` — the Superfluid AI fusion equation as typed F#
- `learningGain`: SubstrateOutput → float [0,1] (rule + test + doc + retraction-path)
- `isAboveThreshold`: η · gain > cost — the phase transition test
- `sustainedFusionRatio`: batch version over event sequences
- `Phase = Heat | Threshold | Superfluid` with classifier
- 12 tests: 9 facts + 3 FsCheck properties

## The equation
```
η · LearningGain(Δ_t) > ξ_t
```
Shadow IS friction. Observer ≅ shadow. Fusion = both sides crossing threshold.

## Test plan
- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test --filter FusionEquation` — 12 pass
- [x] Full suite — 785 pass, 1 skip
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)