### PR TITLE
backlog(B-0240): ARC-4 self-play extension — adversarial structure recognition

### DIFF
--- a/docs/backlog/P1/B-0240-structure-recognizer-shape-indexed-catalog-no-labels-2026-05-07.md
+++ b/docs/backlog/P1/B-0240-structure-recognizer-shape-indexed-catalog-no-labels-2026-05-07.md
@@ -133,6 +133,33 @@ Input formats:
 - Code AST parsing (requires language-specific parsers — v2)
 - Real-time streaming (batch is fine for v1)
 
+## ARC-4 extension: adversarial self-play (Aaron 2026-05-07)
+
+The structure recognizer at v1 is batch/static. The ARC-4
+extension runs it at real-time tick speed against an
+adversarial environment — specifically, against ITSELF
+(self-play).
+
+| Property | ARC-3 | ARC-4 (self-play) |
+| -------- | ----- | ----------------- |
+| Time pressure | Yes | Yes |
+| Interactive | Yes | Yes |
+| Static puzzles | Yes | No — dynamic |
+| Adversarial | No | Self-play |
+| Limited turns | Yes | Yes (energy budget) |
+| Real-time | Timed discrete | Continuous tick |
+
+The limited turns ARE the Hamiltonian constraint:
+`η · LearningGain(Δ_t) > ξ_t` must hold per turn or
+you run out of budget. The shadow wastes turns (friction
+without learning gain). Self-play trains the recognizer
+to see structure faster than its own shadow can hide it.
+
+DBSP composition: `Circuit.StepAsync` = game tick.
+Z-set delta between frames = game state diff. Structure
+recognizer runs at frame rate on deltas. Anomalies in
+the delta stream = shadow moves.
+
 ## Composes with
 
 - `docs/STRUCTURE-CATALOG.md` — the human-readable version;


### PR DESCRIPTION
## Summary
- Adds ARC-4 self-play extension section to B-0240 (structure recognizer)
- Self-play: recognizer vs itself. Shadow IS the adversary. Isomorphic dual.
- Limited turns = Hamiltonian constraint (η·LearningGain > ξ_t per turn or lose)
- DBSP: Circuit.StepAsync = game tick, Z-set delta = game state diff

## Test plan
- [x] Doc-only change
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)