### PR TITLE
docs(research): preserve Itron mentor lineage roster

### DIFF
--- a/docs/research/2026-05-07-itron-mentor-lineage-roster-aaron.md
+++ b/docs/research/2026-05-07-itron-mentor-lineage-roster-aaron.md
@@ -1,0 +1,91 @@
+---
+title: Itron mentor lineage roster
+date: 2026-05-07
+scope: research-grade human-lineage anchor
+source: Aaron maintainer statement in active Zeta session
+operational_status: research-grade provenance, not current-state policy
+---
+
+## Itron Mentor Lineage Roster
+
+Aaron named the following Itron-era mentors as part of the
+human lineage behind his engineering discipline. This note
+preserves the names and the role of the relationship as Aaron
+gave it. It does not independently verify employment history,
+education, name changes, or biographical details.
+
+## Named Mentors And Anchors
+
+- **Chris King** - taught Aaron generics at a deep level,
+  helped with concurrent / generic interface design at Itron,
+  and held Aaron accountable to the design principle that
+  interfaces define the type. Aaron described Chris as an MIT
+  graduate.
+- **James Whitfield** - Aaron's boss at Itron, a physicist,
+  and the person Aaron says taught him physics.
+- **Chris Higgins / Christopher Higgins** - Itron colleague
+  and co-inventor with Aaron on US Patent 10,834,144, the
+  hub-and-agent-through-firewall primitive behind the
+  hole-puncher lineage.
+- **Frank Frisby** - named by Aaron in this session as an
+  Itron mentor. Existing substrate also refers to Frank
+  Frisbee; spelling should remain attribution-bound until
+  Aaron chooses one canonical public spelling.
+- **Diana Duncan (Little now)** - Aaron corrected the name to
+  Diana Duncan, now Little. This supersedes the transient
+  misspelling "Diana Dunac" from the live exchange.
+- **Scott Collins** - Itron mentor, named by Aaron.
+- **Mauna Ree Visser** - Itron mentor, named by Aaron.
+- **Steve Hoiness** - Itron mentor, named by Aaron.
+- **Tim Bognar** - Itron mentor, named by Aaron.
+
+## Why It Matters
+
+This roster is a lineage surface, not a current-state rule.
+The important claim is that Zeta's type-first, interface-first,
+physics-grounded, edge-gate discipline did not appear from an
+abstract slogan. It descends through named people who reviewed,
+taught, challenged, and mentored Aaron inside real Itron
+engineering work.
+
+That lineage gives concrete ancestry to several current Zeta
+threads:
+
+- Type-driven interface design: Chris King's generics and
+  concurrency mentorship.
+- Physics register: James Whitfield's physicist/boss role.
+- Hole puncher / firewall traversal: Chris Higgins as
+  patent co-inventor.
+- Substrate discipline: the Frank Frisby / Frank Frisbee
+  mentorship lineage already preserved elsewhere in memory and
+  research substrate.
+
+## The Physics Is The People
+
+Aaron's correction: with the people, it is the same physics.
+This was never quiet to Aaron; the missing step was preserving
+it clearly on the repo boundary. The mentors are not ornamental
+provenance around the technical work. They are the boundary
+conditions that shaped which moves were possible.
+
+- A mentor who holds a design accountable acts like a type
+  boundary: many moves are excluded before runtime.
+- A physicist boss gives the system a physical register: force,
+  friction, energy, phase transition, and conservation become
+  native design language rather than borrowed metaphor.
+- A patent co-inventor records a primitive on the public
+  boundary: the idea becomes inspectable, named, and citable.
+- A "duplicate yourself" mentor turns apprenticeship into a
+  replication operator: knowledge is not merely transferred,
+  it is made runnable in another person.
+
+In this reading, mentorship is a field interaction. The people
+provide constraints, coupling, pressure, and reflection. Those
+constraints reduce the space of bad moves and increase the
+force toward coherent design. That is the same structural
+shape later reappearing as types, BFT, edge gates, checkpoint
+interfaces, and shadow/friction detection.
+
+Future resume drafts, architecture archaeology, and lineage
+notes may cite this roster. Promotion into operational docs
+should require a separate current-state edit or ADR.


### PR DESCRIPTION
## Summary
- preserve Aaron's named Itron mentor roster as research-grade provenance
- include corrected Diana Duncan (Little now) spelling and note the transient misspelling boundary
- connect the people to the physics: mentorship as field interaction / boundary conditions, not ornamental attribution

## Checks
- npx markdownlint-cli docs/research/2026-05-07-itron-mentor-lineage-roster-aaron.md
- git diff --check
- ASCII scan