### PR TITLE
fix(actions): open PR for archive workflow output

### DIFF
--- a/.github/workflows/pr-archive-on-merge.yml
+++ b/.github/workflows/pr-archive-on-merge.yml
@@ -155,6 +155,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -171,10 +172,11 @@ jobs:
 
           git commit -m "$msg"
 
-          branch="automation/pr-archive-${PR_NUMBER}-run-${RUN_ID}"
+          branch="automation/pr-archive-${PR_NUMBER}-run-${RUN_ID}-attempt-${RUN_ATTEMPT}"
           git push origin "HEAD:${branch}"
 
           body_file="$(mktemp)"
+          trap 'rm -f "$body_file"' EXIT
           {
             echo "## Summary"
             echo
@@ -188,6 +190,7 @@ jobs:
             echo
             echo "PR title: ${PR_TITLE}"
             echo "Workflow run: ${RUN_ID}"
+            echo "Workflow attempt: ${RUN_ATTEMPT}"
           } >"${body_file}"
 
           gh pr create \

--- a/.github/workflows/pr-archive-on-merge.yml
+++ b/.github/workflows/pr-archive-on-merge.yml
@@ -28,19 +28,12 @@ name: pr-archive-on-merge
 # PR number is also validated as a positive integer before being passed
 # to the archival tool.
 #
-# Direct-push posture: this workflow pushes the archive + manifest update
-# directly to main using GITHUB_TOKEN with `contents: write`. If the
-# branch-protection ruleset on Lucent-Financial-Group/Zeta is configured
-# to require PR review on main, this push will be rejected by the host
-# and the workflow run will fail with a non-fast-forward / rule-rejection
-# error. In that case, the operational escalation is one of:
-#   (a) add `github-actions[bot]` to the ruleset's bypass actors,
-#   (b) switch this workflow to PR-based (open a small PR with the
-#       archive + manifest, auto-merge), or
-#   (c) use a deploy-key with explicit per-path allowance.
-# (a) is the minimum-cost option and matches the existing
-# budget-snapshot-cadence.yml pattern of bot-pushed branches. Choice
-# deferred until empirical merge attempts surface the failure mode.
+# PR-based posture: branch protection rejects direct GITHUB_TOKEN pushes
+# to main, so this workflow commits archive output to a unique bot branch
+# and opens a small PR instead. GITHUB_TOKEN-created PRs may not trigger
+# downstream required checks; like budget-snapshot-cadence.yml, this
+# workflow therefore opens the PR and leaves merge/auto-merge handling to
+# the next maintainer or agent pass through the queue.
 
 on:
   pull_request:
@@ -64,38 +57,40 @@ jobs:
     # closed without merge) produce no archive. The host event payload's
     # `merged` boolean is the canonical signal.
     #
-    # Repo-local archive-repair PRs are terminal bookkeeping. Archiving them
-    # creates a recursive archive-of-archive chain when branch protection
-    # rejects the workflow's direct push, so local claim/archive-pr-* repair
-    # branches are intentionally skipped here. Fork PRs with matching branch
-    # names must still be archived.
+    # Repo-local archive PRs are terminal bookkeeping. Archiving them creates
+    # a recursive archive-of-archive chain, so local claim/archive-pr-* repair
+    # branches and automation/pr-archive-* bot branches are intentionally
+    # skipped here. Fork PRs with matching branch names must still be archived.
     if: >
       github.event.pull_request.merged == true &&
       !(
         github.event.pull_request.head.repo.full_name == github.repository &&
-        startsWith(github.event.pull_request.head.ref, 'claim/archive-pr-')
+        (
+          startsWith(github.event.pull_request.head.ref, 'claim/archive-pr-') ||
+          startsWith(github.event.pull_request.head.ref, 'automation/pr-archive-')
+        )
       )
 
     runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     permissions:
-      # contents:write to push the archive + manifest update directly to
-      # main. pull-requests:read so the archival tool's gh CLI calls
-      # against /pulls/N/comments and graphql reviewThreads succeed under
-      # GITHUB_TOKEN. No other scopes needed.
+      # contents:write to push the archive + manifest update to a bot branch.
+      # pull-requests:write opens the archive PR and also covers the archival
+      # tool's read calls against /pulls/N/comments and graphql reviewThreads
+      # under GITHUB_TOKEN. No other scopes needed.
       contents: write
-      pull-requests: read
+      pull-requests: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           # Need full history for git rev-parse HEAD (commit_sha field in
-          # manifest entries), and so the subsequent push is fast-forward.
+          # manifest entries), and so the bot branch is based on current main.
           fetch-depth: 0
           ref: main
-          # Persist credentials so the post-archival `git push` uses
+          # Persist credentials so the post-archival bot-branch push uses
           # GITHUB_TOKEN. (default true; explicit for clarity)
           persist-credentials: true
 
@@ -153,13 +148,14 @@ jobs:
           fi
           echo "changed=true" >>"$GITHUB_OUTPUT"
 
-      - name: Commit and push
+      - name: Commit and open archive PR
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           # Configure committer identity for the workflow commit.
@@ -175,8 +171,28 @@ jobs:
 
           git commit -m "$msg"
 
-          # Push to main. If branch-protection rejects this push, the
-          # workflow fails here -- the failure is the signal to switch to
-          # one of the escalation options documented at the top of this
-          # file. We do NOT --force; non-fast-forward must surface honestly.
-          git push origin HEAD:main
+          branch="automation/pr-archive-${PR_NUMBER}-run-${RUN_ID}"
+          git push origin "HEAD:${branch}"
+
+          body_file="$(mktemp)"
+          {
+            echo "## Summary"
+            echo
+            echo "- Archive review substrate for merged PR #${PR_NUMBER}"
+            echo "- Update docs/github/prs/manifest.jsonl"
+            echo
+            echo "## Notes"
+            echo
+            echo "Generated by .github/workflows/pr-archive-on-merge.yml"
+            echo "from tools/archive/archive-pr-reviews.ts."
+            echo
+            echo "PR title: ${PR_TITLE}"
+            echo "Workflow run: ${RUN_ID}"
+          } >"${body_file}"
+
+          gh pr create \
+            --repo "$REPO" \
+            --base main \
+            --head "$branch" \
+            --title "archive(pr-reviews): PR #${PR_NUMBER} on merge" \
+            --body-file "${body_file}"


### PR DESCRIPTION
## Summary

- Switch pr-archive-on-merge from protected-branch direct push to unique bot-branch PR creation.
- Add pull-requests:write for PR creation and keep contents:write scoped to the bot branch push.
- Skip local automation/pr-archive-* branches so archive PR merges do not recursively archive themselves.

## Verification

- ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/pr-archive-on-merge.yml\"); puts \"yaml ok\"'
- git diff --check -- .github/workflows/pr-archive-on-merge.yml
- actionlint .github/workflows/pr-archive-on-merge.yml

## Notes

This intentionally mirrors budget-snapshot-cadence.yml: GITHUB_TOKEN-created PRs may not trigger downstream required checks, so the workflow opens the PR and leaves merge/auto-merge handling to the next maintainer or agent pass.