### PR TITLE
fix(spec): unify unfreeze quorum — §11.3 matches §6.2 (B-0062)

### DIFF
--- a/docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md
+++ b/docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md
@@ -504,7 +504,7 @@ Per Ani's review of the original packet, three failure modes the v0 spec has to 
 
 - Symptom: "freeze at -30%" is a system-prompt instruction; agent can rationalize past it.
 - Defense: drawdown freeze enforced by smart-contract guard; agent cannot override; off-chain monitor can pile-on independently.
-- Test: in dry-run, manually trigger -30% drawdown via simulated price oracle; verify smart-contract freezes; verify agent cannot unfreeze; verify Aaron-plus-monitor required to unfreeze.
+- Test: in dry-run, manually trigger -30% drawdown via simulated price oracle; verify smart-contract freezes; verify agent cannot unfreeze; verify smart-contract-guard-plus-Aaron required to unfreeze (per §6.2).
 
 ---
 


### PR DESCRIPTION
## Summary
- §11.3 test said "Aaron-plus-monitor" for unfreeze but §6.2 says "smart-contract guard + Aaron"
- Unified to match §6.2 (the authoritative section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)