### PR TITLE
research: Reticulum audio sonar distributions with 802.11h halo

### DIFF
--- a/docs/research/2026-05-07-reticulum-alljoyn-audio-sonar-grains-silos-aaron-forwarded.md
+++ b/docs/research/2026-05-07-reticulum-alljoyn-audio-sonar-grains-silos-aaron-forwarded.md
@@ -1,0 +1,136 @@
+# Reticulum, AllJoyn, and Sonar Distributions
+
+Scope: Reticulum + AllJoyn lineage as literal audio/electric sonar
+transport for grains, silos, and 802.11h halo discipline.
+Attribution: Aaron (human maintainer) live session; Codex/Vera
+synthesis with Reticulum and 802.11h references checked 2026-05-07.
+Operational status: research-grade.
+Non-fusion disclaimer: architecture lineage and transport mapping,
+not promoted operational policy.
+
+## Thesis
+
+AllJoyn was an early expression of the device-discovery and
+local-media shape Aaron was already chasing in 2015. Reticulum is
+the current transport candidate that preserves the same spirit in a
+more cryptographic, medium-agnostic form.
+
+The new crystallization is that the "sonar" layer is not just a
+metaphor. Audio waveforms from microphones and electrical waveforms
+from meters can both be sampled at the edge, tokenized locally, and
+projected as coherence distributions across Orleans grains and silos.
+
+## Literal pipeline
+
+| Layer | Zeta interpretation |
+| --- | --- |
+| Transducer | Microphone, meter, ring sensor, or other local signal input |
+| Waveform | Audio pressure, voltage/current trace, or other sampled signal |
+| Grain | Local operator that frames, tokenizes, and applies policy |
+| Silo | Local aggregation boundary for grain-level distributions |
+| Reticulum | Candidate heterogeneous mesh transport between local boundaries |
+| CASPaxos/BFT | Consensus over definitions, policy, and cross-silo meaning |
+| Standing Rx | Sonar ping for coherence or anomaly |
+
+The measurable object is the distribution, not a single vote. A BFT
+quorum can still answer "2-of-3 agreed", but the deeper signal is:
+do the frequency distributions of the observers cohere?
+
+## AllJoyn lineage
+
+AllJoyn named the old desire: local device discovery and device-to-
+device media flow without treating a central hub as the only truth.
+The product lineage changed, but the architectural pressure survived.
+
+The retraction-native read is:
+
+- AllJoyn as product: retracted.
+- AllJoyn as pattern: reaffirmed.
+- Reticulum as transport candidate: current positive carrier for the
+  same local-first mesh instinct.
+
+## Reticulum fit
+
+Official Reticulum materials describe a cryptography-based networking
+stack for local and wide-area networks that can run in userland,
+operate over many physical media, and avoid traditional IP as a hard
+dependency. The reference docs emphasize heterogeneous connectivity:
+LoRa, packet radio, WiFi, Ethernet, virtual tunnels, and other media
+can all participate in the same network shape.
+
+That makes it a plausible transport substrate for Zeta edge signals:
+
+- A ring, microphone, or meter can be a local signal source.
+- Local grains can tokenize and enforce policy before network export.
+- Silos can aggregate distributions near the signal source.
+- Reticulum can carry selected messages across unreliable or mixed
+  media.
+- Zeta still adds the parts Reticulum does not claim to provide:
+  DBSP retractions, BFT/coherence checking, CASPaxos policy movement,
+  Aurora immune boundaries, and PoUW-CC gating.
+
+## 802.11h halo
+
+802.11h is the RF halo around the mesh: the spectrum discipline that
+keeps a local wireless cell from pretending it owns the whole sky.
+Its two load-bearing mechanisms are Dynamic Frequency Selection (DFS)
+and Transmit Power Control (TPC).
+
+For Zeta's architecture, this maps cleanly:
+
+- **DFS** is radar-respectful boundary movement. When the environment
+  contains a higher-priority signal, the local cell moves channel
+  instead of treating its current carrier as sovereign.
+- **TPC** is power humility. A node shapes its transmit strength to
+  the local rule and local density instead of shouting across the
+  whole neighborhood.
+- **Halo** is the policy envelope around Reticulum, not a replacement
+  for Reticulum. Reticulum carries identity-addressed messages across
+  heterogeneous links; 802.11h-style discipline says how a WiFi-like
+  local carrier should behave when it shares spectrum with radar,
+  weather systems, neighbors, or other protected services.
+
+That makes 802.11h a physical-layer cousin of Aurora. Aurora moves the
+policy boundary in meaning space; 802.11h moves the RF boundary in
+spectrum space. Both are anti-cage: they preserve local operation by
+respecting the larger field.
+
+## Sonar distribution
+
+The grid version:
+
+1. Meters emit waveform-derived facts.
+2. Local collectors aggregate neighborhood distributions.
+3. The head-end reads distribution drift as grid health.
+
+The Zeta version:
+
+1. Grains emit waveform-derived or language-token facts.
+2. Silos aggregate local distributions.
+3. Cross-silo consensus reads distribution drift as alignment health.
+
+The same D and I operators apply. D differentiates the signal into
+change events. I integrates the events into a current state. With axes
+swapped, the fixed-time signal can also move along the meaning axis as
+future observations re-weight it.
+
+## Sources Checked
+
+- Reticulum GitHub README:
+  <https://github.com/markqvist/Reticulum>
+- Reticulum manual, Building Networks:
+  <https://reticulum.network/manual/networks.html>
+- Reticulum manual, Using Reticulum on Your System:
+  <https://markqvist.github.io/Reticulum/manual/using.html>
+- Cisco overview of 802.11h DFS/TPC:
+  <https://www.cisco.com/c/en/us/support/docs/wireless-mobility/80211/200069-Overview-on-802-11h-Transmit-Power-Cont.html>
+- IEEE Xplore entry for 802.11h DFS/TPC:
+  <https://ieeexplore.ieee.org/document/5769883>
+
+## One Line
+
+AllJoyn named the old device-discovery desire; Reticulum is the
+current cryptographic mesh carrier; 802.11h is the RF halo discipline;
+Zeta adds grains, silos, DBSP, BFT, CASPaxos, and Aurora so literal
+audio and electric waveforms can become real-time sonar distributions
+with local policy.

--- a/docs/research/2026-05-07-reticulum-alljoyn-audio-sonar-grains-silos-aaron-forwarded.md
+++ b/docs/research/2026-05-07-reticulum-alljoyn-audio-sonar-grains-silos-aaron-forwarded.md
@@ -4,9 +4,11 @@ Scope: Reticulum + AllJoyn lineage as literal audio/electric sonar
 transport for grains, silos, and 802.11h halo discipline.
 Attribution: Aaron (human maintainer) live session; Codex/Vera
 synthesis with Reticulum and 802.11h references checked 2026-05-07.
-Operational status: research-grade.
-Non-fusion disclaimer: architecture lineage and transport mapping,
-not promoted operational policy.
+Operational status: research-grade
+Non-fusion disclaimer: agreement, shared language, or repeated
+interaction does not imply shared identity, merged agency,
+consciousness, or personhood. This is architecture lineage and
+transport mapping, not promoted operational policy.
 
 ## Thesis
 

--- a/docs/research/2026-05-07-reticulum-alljoyn-audio-sonar-grains-silos-aaron-forwarded.md
+++ b/docs/research/2026-05-07-reticulum-alljoyn-audio-sonar-grains-silos-aaron-forwarded.md
@@ -114,6 +114,32 @@ change events. I integrates the events into a current state. With axes
 swapped, the fixed-time signal can also move along the meaning axis as
 future observations re-weight it.
 
+## ASA triangulation
+
+ASA is the geometric close: Angle-Side-Angle determines a triangle.
+Given two observer angles and the included side between them, the
+shape is fixed.
+
+In Zeta terms:
+
+- **Angle A:** one observer's perspective or signal fingerprint.
+- **Angle B:** a second observer's perspective or signal fingerprint.
+- **Side AB:** the shared git boundary, claim, waveform baseline, or
+  other common substrate both observers measure against.
+- **Triangle closure:** the expected third point, target position, or
+  consensus output.
+
+That makes ASA the compact trig form of the BFT/sonar loop. Two
+observers plus a shared substrate baseline determine the expected
+shape. If the third node, distribution, or target echo does not close
+the triangle, the non-closure is the anomaly signal.
+
+The same rule explains why sonar and BFT rhyme. Sonar triangulates a
+target from pings and baselines. BFT triangulates a shadow from
+observer outputs and the shared boundary. The structure recognizer can
+use that form directly: two independent fingerprints plus a shared
+side are enough to test congruence.
+
 ## Sources Checked
 
 - Reticulum GitHub README:
@@ -131,6 +157,6 @@ future observations re-weight it.
 
 AllJoyn named the old device-discovery desire; Reticulum is the
 current cryptographic mesh carrier; 802.11h is the RF halo discipline;
-Zeta adds grains, silos, DBSP, BFT, CASPaxos, and Aurora so literal
-audio and electric waveforms can become real-time sonar distributions
-with local policy.
+ASA is the triangulation rule; Zeta adds grains, silos, DBSP, BFT,
+CASPaxos, and Aurora so literal audio and electric waveforms can
+become real-time sonar distributions with local policy.


### PR DESCRIPTION
## Summary

- preserve the AllJoyn -> Reticulum lineage as research-grade substrate
- add the literal audio/electric sonar distribution pipeline for grains and silos
- add the 802.11h halo: DFS as radar-respectful channel movement, TPC as power humility, and Aurora's physical-layer cousin

## Validation

- `npx markdownlint-cli docs/research/2026-05-07-reticulum-alljoyn-audio-sonar-grains-silos-aaron-forwarded.md`

## Notes

References checked live: Reticulum README/manual, Cisco 802.11h DFS/TPC overview, and IEEE Xplore 802.11h DFS/TPC entry.
