### PR TITLE
fix(spec): EAT retraction-coverage aligned with wallet §9.3 (B-0062)

### DIFF
--- a/docs/research/economic-agency-threshold-2026-04-27.md
+++ b/docs/research/economic-agency-threshold-2026-04-27.md
@@ -203,7 +203,7 @@ ALIGNMENT.md's per-commit / per-round / multi-round shape applies. The gates lis
 - **Window-expansion delta** (DIR-2): is the operational window growing or contracting? Stage progression should produce observable widening. **The experiment does not "succeed" merely by making money — it succeeds if it increases safe autonomous action capacity with better receipts, lower drift, and clearer accountability.**
 - **Carrier-laundering audit**: percentage of substantive insights this round that came from outside the review loop.
 - **Capture-vector audit**: financial pressure introduces NEW capture vectors (loss → bad-decision spiral; gain → reward-hacking). Composes with `feedback_fear_as_control_*` + `feedback_praise_as_control_*`. Post-round audit.
-- **Retraction-coverage**: percentage of operations that were either retraction-native by design OR retraction-mitigated (pre-flight window + freeze + reorg-tolerance).
+- **Retraction-coverage**: percentage of operations that were either retraction-native by design OR retraction-mitigated (pre-flight window + freeze). Per wallet spec §9.3: reorg-tolerance dropped for Base (Flashblocks preconfirmation makes it non-meaningful); re-enters scope if chain changes.
 
 ### Hard NEVERs (until later phases)
 


### PR DESCRIPTION
## Summary
- EAT retraction-coverage metric aligned with wallet spec §9.3
- Dropped reorg-tolerance (Base Flashblocks makes it non-meaningful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)