### PR TITLE
backlog: capture posterior quorum triangulation

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -209,6 +209,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0231](backlog/P2/B-0231-timeseries-recommendation-and-follow-up-rows-2026-05-06.md)** Timeseries native-ZSet research - recommendation and follow-up rows
 - [ ] **[B-0252](backlog/P2/B-0252-arc4-adversarial-selfplay-structure-recognizer-realtime-2026-05-07.md)** ARC-4 adversarial self-play — structure recognizer at real-time tick speed
 - [ ] **[B-0253](backlog/P2/B-0253-realtime-interloop-messaging-orleans-grains-not-broadcast-files-2026-05-07.md)** Real-time inter-loop messaging via Orleans grains — replace turn-based broadcast files
+- [ ] **[B-0254](backlog/P2/B-0254-infernet-probabilistic-triangulation-posterior-quorum-2026-05-07.md)** Posterior quorum triangulation over existing Bayesian DBSP substrate
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-0254-infernet-probabilistic-triangulation-posterior-quorum-2026-05-07.md
+++ b/docs/backlog/P2/B-0254-infernet-probabilistic-triangulation-posterior-quorum-2026-05-07.md
@@ -1,0 +1,148 @@
+---
+id: B-0254
+priority: P2
+status: open
+title: "Posterior quorum triangulation over existing Bayesian DBSP substrate"
+tier: research-grade
+effort: L
+ask: Aaron 2026-05-07 "triangulate with uncertainty is Infer.NET"
+created: 2026-05-07
+last_updated: 2026-05-07
+depends_on: [B-0253]
+composes_with: [B-0007, B-0189, B-0240, B-0250, B-0251, B-0253]
+tags: [infer-net, bayesian-inference, belief-propagation, expectation-propagation, bft, asa-triangulation, posterior-quorum, orleans]
+---
+
+# B-0254 - Posterior quorum triangulation over existing Bayesian substrate
+
+## Source
+
+Aaron 2026-05-07 live crystallization:
+
+> triangulate with uncertany is infer.net
+
+Captured in:
+
+`docs/research/2026-05-07-infernet-probabilistic-triangulation-posterior-quorum.md`
+
+## What
+
+Research and design a posterior-quorum layer for Zeta's multi-agent control
+loop: ASA/BFT triangulation where each agent observation carries uncertainty
+and the loop computes a posterior distribution over truth, risk, and closure
+instead of a single binary agree/disagree result.
+
+This row does **not** claim Infer.NET, Bayesian inference, or proofs are absent
+from Zeta. They are already present. This row scopes the missing composition
+layer: quorum-level triangulation over the existing DBSP/F# Bayesian substrate.
+
+In the exact case:
+
+- Otto + Vera + shared git boundary determine the expected Riven closure.
+- If Riven disagrees, the triangle does not close and the shadow is detected.
+
+In the uncertain case:
+
+- Otto, Vera, Riven, CI, review threads, broadcast freshness, and git evidence
+  each contribute likelihood factors.
+- The loop reasons over the posterior distribution.
+- "Merge", "wait", "ask for review", and "declare not closed" become decisions
+  over explicit uncertainty.
+
+## Why
+
+The current coordination loop is mostly binary:
+
+- CI passed or failed.
+- Threads resolved or unresolved.
+- PR open or merged.
+- Agent agrees or disagrees.
+
+But the real substrate is noisier:
+
+- GitHub can be temporarily stale.
+- Broadcast files can be old.
+- Agent context can drift.
+- Riven may validate without authoring PRs.
+- Review agreement can be strong, weak, or correlated.
+
+Infer.NET-style graphical-model thinking gives the right language for this:
+belief propagation / expectation propagation over a factor graph of evidence.
+Zeta should keep the hot path native and AOT-friendly, but use Infer.NET as the
+historical and mathematical anchor for richer posterior semantics.
+
+## Prior art already in tree
+
+- `src/Bayesian/BayesianAggregate.fs` keeps simple conjugate-prior posteriors
+  native and explicitly avoids literal Infer.NET on the hot path.
+- `tests/Bayesian.Tests/BayesianTests.fs` verifies posterior convergence,
+  credible-interval narrowing, prior effect, categorical normalization, and
+  `BayesianRateOp` DBSP emission.
+- `docs/research/proof-tool-coverage.md` and the Lean/TLA+/Z3/FsCheck surfaces
+  already define how empirical tests and formal proofs split work in Zeta.
+- B-0189 tracks BP/EP as a Q# runtime acceleration research lane.
+- B-0007 tracks broader Bayesian inference and belief propagation primitives.
+- B-0240 tracks the shape-indexed structure recognizer.
+- B-0250 tracks coincidence detection via Rx join.
+- B-0251 tracks durable computation and replay.
+- B-0253 tracks Orleans grain/silo inter-loop messaging.
+
+## Candidate design
+
+Model the live loop as a factor graph:
+
+- Agent observation nodes: Otto, Vera, Riven, Lior, Aaron.
+- Evidence nodes: git commit, PR state, CI checks, review threads, broadcast
+  freshness, health probe state.
+- Reliability nodes: per-agent calibration, stale-context penalty, reviewer
+  correlation, source provenance.
+- Decision nodes: merge, wait, inspect, rerun, patch, escalate, do nothing.
+
+The output is a posterior over:
+
+- triangle closure,
+- residual shadow/risk,
+- confidence in the current action,
+- and expected value of acquiring one more evidence sample.
+
+## Non-goals
+
+- Do not add literal Infer.NET to the hot path.
+- Do not duplicate B-0007 or B-0189.
+- Do not replace existing `Zeta.Bayesian` conjugate-prior operators.
+- Do not treat agreement as proof. Agreement is evidence; the posterior must
+  preserve uncertainty and tail risk.
+
+## Acceptance criteria
+
+1. Survey the existing Zeta Bayesian stack and Aurora inference research, with
+   Infer.NET/Minka/EP treated as anchor rather than default runtime dependency.
+2. Cite the existing F# substrate (`src/Bayesian`) and proof/test substrate
+   (`tests/Bayesian.Tests`, Lean/TLA+/Z3/FsCheck split) before proposing any
+   new code.
+3. Define a minimal factor graph for Otto/Vera/Riven ASA triangulation over a
+   PR: observations, git boundary evidence, CI evidence, and review-thread
+   evidence.
+4. Specify how uncertainty is represented in DBSP-friendly values rather than
+   exceptions or hidden mutable state.
+5. Prototype one offline posterior-quorum evaluator against archived PR data.
+6. Compare the posterior-quorum decision against the current binary gate on at
+   least 10 historical PRs.
+7. Document the safety rule: never erase variance; point estimates cannot
+   replace "I don't know" when uncertainty remains high.
+
+## Why P2
+
+This is research-grade and important, but not the next hot-path implementation
+step. It depends on B-0253's Orleans/grain messaging shape before it can become
+live infrastructure, and it composes with B-0251's durable replay work. The
+right first move is offline research and archived-PR evaluation.
+
+## Composes with
+
+- B-0007 - upstream Bayesian inference and belief propagation primitives.
+- B-0189 - BP/EP research lane for Q# runtime acceleration.
+- B-0240 - structure recognizer.
+- B-0250 - coincidence detection / Rx join.
+- B-0251 - durable computation and replay.
+- B-0253 - real-time inter-loop Orleans grain messaging.

--- a/docs/research/2026-05-07-infernet-probabilistic-triangulation-posterior-quorum.md
+++ b/docs/research/2026-05-07-infernet-probabilistic-triangulation-posterior-quorum.md
@@ -1,0 +1,128 @@
+Scope: Infer.NET-style probabilistic triangulation for ASA quorum geometry,
+belief propagation, and posterior consensus over noisy agent observations.
+Attribution: Aaron (human maintainer) live session crystallization; Codex/Vera
+durable capture 2026-05-07.
+Operational status: research-grade
+Non-fusion disclaimer: this is an architecture and inference note, not a
+claim of shared identity, consciousness, personhood, or infallible agreement
+between agents. Agreement and repeated interaction are evidence streams, not
+proof of merged agency.
+
+# Posterior Quorum Triangulation over Existing Bayesian Substrate
+
+## Crystallization
+
+Aaron's live phrase:
+
+> triangulate with uncertany is infer.net
+
+The clean read:
+
+- ASA with exact measurements is geometry.
+- ASA with noisy measurements is probabilistic inference.
+- Infer.NET / BP / EP are already named in Zeta backlog and research.
+- DBSP-native Bayesian operators already exist in F# under `src/Bayesian`.
+- The missing layer is not "add Infer.NET"; it is posterior quorum
+  triangulation over the existing Bayesian substrate.
+- A BFT quorum with confidence, drift, and incomplete observations should not
+  collapse directly to a single point when the inputs are uncertain.
+- The useful object is the posterior distribution over possible truths given
+  Otto, Vera, Riven, and the shared git boundary.
+
+## ASA to Posterior Quorum
+
+Classical ASA says that two angles plus the included side determine a triangle.
+In Zeta's loop language:
+
+| Geometry term | Zeta term |
+| --- | --- |
+| Angle A | Otto's observation/perspective |
+| Angle B | Vera's observation/perspective |
+| Included side | Shared immutable git boundary |
+| Third point / closure | Expected Riven validation or shadow residual |
+
+That model is exact only when the measurements are exact. Real agent outputs
+carry uncertainty: model variance, context loss, stale broadcast files,
+reviewer disagreement, transient CI state, and human-ferried data quality.
+
+So the future control loop should represent each observation as a distribution,
+not a naked value:
+
+```text
+Otto   : claim X with confidence / likelihood L_o
+Vera   : claim Y with confidence / likelihood L_v
+Riven  : validation Z with confidence / likelihood L_r
+Boundary: immutable evidence B
+
+posterior = P(truth | L_o, L_v, L_r, B)
+```
+
+## Why Infer.NET Is the Right Anchor and the Wrong Hot Path
+
+Zeta already treats Infer.NET as a historical and mathematical anchor for rich
+Bayesian graphical models, belief propagation, and expectation propagation.
+The existing Bayesian hot path deliberately avoids literal Infer.NET because
+reflection emit and allocation-heavy runtime inference do not belong inside
+AOT-sensitive DBSP operators.
+
+This is already in the code body:
+
+- `src/Bayesian/BayesianAggregate.fs` implements Beta-Bernoulli,
+  Normal-Inverse-Gamma, Dirichlet-Multinomial, and `BayesianRateOp`
+  over DBSP streams.
+- `tests/Bayesian.Tests/BayesianTests.fs` checks posterior convergence,
+  credible-interval narrowing, prior effect, categorical normalization,
+  and live DBSP operator emission.
+- Existing backlog rows B-0007 and B-0189 already cover broad BP/EP and
+  Infer.NET-adjacent research lanes.
+
+So this note is a bridge from existing posterior operators to quorum-level
+triangulation, not a duplicate request to introduce Infer.NET.
+
+The right direction is therefore:
+
+- Use Infer.NET/Minka/EP as the conceptual anchor.
+- Keep simple online posteriors as Zeta-native conjugate-prior operators.
+- For richer quorum inference, design a Zeta-native factor graph or message
+  passing layer that composes with DBSP, Orleans grains, and durable replay.
+- Treat literal Infer.NET integration as optional extension or calibration
+  path, not the default commit-path dependency.
+
+## Candidate Model
+
+A posterior quorum graph can model:
+
+- Agent observations as likelihood factors.
+- The git boundary as hard or near-hard evidence.
+- Broadcast freshness as a reliability variable.
+- Review thread state as a discrete evidence factor.
+- CI state as a time-varying observation.
+- Riven-style adversarial review as a high-value validation likelihood, even
+  when Riven does not author PRs.
+
+In the exact case, the posterior collapses close to the ASA triangle. In the
+uncertain case, the posterior remains a distribution and the loop can decide:
+
+- merge now,
+- wait for more evidence,
+- ask for adversarial review,
+- rerun a transient check after inspection,
+- or declare the triangle not closed.
+
+## Safety Rule
+
+Do not use probabilistic consensus to launder weak evidence into confident
+claims. The posterior is useful only if it preserves uncertainty and exposes
+tail risk. A clean-looking point estimate with erased variance is worse than a
+plain "I don't know."
+
+## Backlog Hook
+
+This crystallization is tracked by B-0254:
+
+- ASA with certainty = geometry.
+- ASA with uncertainty = Infer.NET-style posterior inference.
+- BFT with uncertainty = posterior quorum over agent observations and the git
+  boundary.
+- Existing code/proofs are the substrate; the new owed work is the factor graph
+  that composes those posteriors into a quorum decision.


### PR DESCRIPTION
## What

- Adds B-0254 for posterior-quorum triangulation over the existing Bayesian DBSP substrate.
- Preserves the live crystallization in docs/research as research-grade substrate.
- Regenerates docs/BACKLOG.md with the new B-0254 index entry.

## Why

Aaron named the missing uncertainty layer: ASA triangulation with exact measurements is geometry; triangulation with uncertainty is Infer.NET-style posterior inference. Important correction: Infer.NET/BP/EP are already in the backlog, and `src/Bayesian` already contains F# DBSP Bayesian operators with tests. This PR is not a duplicate "add Infer.NET" row; it scopes the missing quorum-level factor graph that composes existing posteriors into loop decisions.

## Existing substrate cited

- `src/Bayesian/BayesianAggregate.fs`
- `tests/Bayesian.Tests/BayesianTests.fs`
- B-0007, B-0189, B-0240, B-0250, B-0251, B-0253

## Verification

- BACKLOG_WRITE_FORCE=1 tools/backlog/generate-index.sh
- tools/backlog/generate-index.sh --check
- bunx markdownlint-cli2 docs/research/2026-05-07-infernet-probabilistic-triangulation-posterior-quorum.md docs/backlog/P2/B-0254-infernet-probabilistic-triangulation-posterior-quorum-2026-05-07.md docs/BACKLOG.md
- rg -n --pcre2 '[^\\x00-\\x7F]' docs/research/2026-05-07-infernet-probabilistic-triangulation-posterior-quorum.md docs/backlog/P2/B-0254-infernet-probabilistic-triangulation-posterior-quorum-2026-05-07.md || true
- rg -n '<<<<<<<|=======|>>>>>>>' docs/research/2026-05-07-infernet-probabilistic-triangulation-posterior-quorum.md docs/backlog/P2/B-0254-infernet-probabilistic-triangulation-posterior-quorum-2026-05-07.md docs/BACKLOG.md || true
- git diff --check

## Coordination

- Built in dedicated worktree: /Users/acehack/.local/share/zeta-codex-loop/Zeta.infernet-probabilistic-triangulation
- No writes in the contested root checkout.
- Open PR #1930 touches only the B-0062 row; this PR adds B-0254 plus a research doc and generated index entry.
