### PR TITLE
fix(backlog): avoid multiline inline code predicate

### DIFF
--- a/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
+++ b/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
@@ -228,11 +228,11 @@ it (closed-thread links survive in the PR's review history).
     that decides when it's required (spend > $X? new
     counterparty? new venue?).
 
-    **Proposed (Otto 2026-05-07):** `required =
-    (amount > 10% of remaining bond) OR
-    (new counterparty not in prior receipts) OR
-    (new venue not in prior receipts)`. Conservative
-    for v0. Revisable as the bond grows.
+    **Proposed (Otto 2026-05-07):** require second-agent
+    review when any of these are true: amount exceeds 10%
+    of remaining bond; counterparty is absent from prior
+    receipts; venue is absent from prior receipts.
+    Conservative for v0. Revisable as the bond grows.
 3. **Align retraction metric with updated Base reorg
     policy** (cid 3150816620 P2). Retraction metric still
     requires "reorg-window monitored after" the §12.2


### PR DESCRIPTION
## Summary

- Replace the multiline inline-code material-spend predicate with prose
- Preserve the same three OR conditions from #1937
- Avoid CommonMark rendering drift in the B-0062 backlog item

## Checks

- `bunx markdownlint-cli2 docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md`
- `tools/backlog/generate-index.sh --check`
- `rg -n '<<<<<<<|=======|>>>>>>>' docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md || true`
- `git diff --check`
