### PR TITLE
fix(backlog): reopen premature B-0062 closure

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -11,7 +11,7 @@ are closed (status: closed in frontmatter)._
 
 ## P0 — critical / blocking
 
-- [x] **[B-0062](backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md)** Wallet v0 build-out — concrete spec-logic punch list aggregating PR #72 deferred review concerns (Aaron 2026-04-28 honest-tracking catch)
+- [ ] **[B-0062](backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md)** Wallet v0 build-out — concrete spec-logic punch list aggregating PR #72 deferred review concerns (Aaron 2026-04-28 honest-tracking catch)
 - [x] **[B-0073](backlog/P0/B-0073-lfg-csharp-code-scanning-cleanup-13-alerts-blocking-ruleset-2026-04-28.md)** LFG csharp Code Scanning cleanup — 13 open alerts gating code_quality severity:all ruleset on every PR
 - [x] **[B-0085](backlog/P0/B-0085-budget-cadence-workflow-cron-misses-task-287-deadline-window-aaron-2026-04-28.md)** Budget cadence workflow's weekly-Sundays cron misses task #287 cost-visibility deadline window (2026-04-26..04-29)
 - [x] **[B-0109](backlog/P0/B-0109-dependency-status-tracking-surface-2026-04-30.md)** Dependency status tracking surface — outages and issues affecting us (Aaron 2026-04-30, urgent)

--- a/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
+++ b/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
@@ -1,9 +1,7 @@
 ---
 id: B-0062
 priority: P0
-status: closed
-closed: 2026-05-07
-closed_by: "21/21 items addressed — proposals pending Aaron acceptance"
+status: open
 title: Wallet v0 build-out — concrete spec-logic punch list aggregating PR #72 deferred review concerns (Aaron 2026-04-28 honest-tracking catch)
 tier: wallet-experiment-v0
 effort: L
@@ -65,6 +63,14 @@ it (closed-thread links survive in the PR's review history).
    + `retraction_reason`. The state machine becomes:
    `signed → broadcast → settled` (normal) OR
    `signed → retracted` (preflight cancellation).
+
+   **Aaron correction (2026-05-07):** Terminal state is the
+   sharp edge of one proposal instance, not the round shape
+   of the standing Rx query. Retraction is a delta/receipt;
+   it closes that local proposal without popping the standing
+   query wave. The query remains live, and any materialized
+   cache is reconstructable (`cache = I o D`) rather than
+   load-bearing lifecycle state.
 2. **Drop the impossible pre-broadcast classification freeze
    trigger** (cid 3150897609 P1). §6.1 currently freezes
    when the pre-flight retraction monitor disagrees with
@@ -322,6 +328,14 @@ state, agent self-revocation auth, monitor-stall freeze,
 on-chain classification signal, drawdown oracle,
 glass-halo logging gate, auth for cancellation,
 material-spend criteria, INTENTIONAL-DEBT schema).
+
+2026-05-07 red-team correction: PR #1942 briefly marked
+this row closed by trusting a "21/21 addressed" pickup
+summary, but this file still records 8 of 21 resolved and
+13 remaining design decisions. Reopening preserves the
+original done-criteria: the row closes only when every
+punch-list item has a spec edit, ADR, or explicit v0+1
+deferral with follow-up tracking.
 
 ## Composes with
 


### PR DESCRIPTION
## Summary
- Reopen B-0062 after PR #1942 closed it while the row still says 8/21 resolved and 13 design decisions remain.
- Remove false closure metadata and regenerate docs/BACKLOG.md.
- Preserve Aaron's correction: a retraction closes one proposal instance without popping the standing Rx query wave; the materialized cache is reconstructable, not load-bearing lifecycle state.

## Checks
- ./tools/backlog/generate-index.sh --check
- git diff --check
- bun tools/backlog/autonomous-pickup.ts --json | jq '{selected: {id: .selected.id, priority: .selected.priority, status: .selected.status}, action}'