### PR TITLE
fix(B-0087): confirm cadenced cron verified workflow fix

### DIFF
--- a/docs/backlog/P1/B-0087-github-settings-drift-workflow-broken-invalid-permission-administration-otto-2026-04-28.md
+++ b/docs/backlog/P1/B-0087-github-settings-drift-workflow-broken-invalid-permission-administration-otto-2026-04-28.md
@@ -133,7 +133,7 @@ for security audits.
 - [x] Option A landed (2026-05-03): invalid `administration: read` permission removed; workflow startup-failure resolved.
 - [x] github-settings-drift.yml passes `actionlint` cleanly (no unknown permission scope warnings) — verified via this PR.
 - [x] Workflow no longer fails at workflow-startup ("workflow file issue"). It now reaches the drift-check step. Under GITHUB_TOKEN the snapshot script will likely exit 2 (tooling/input failure) on the first admin-only endpoint returning 403 — that's expected post-option-A behavior, NOT a regression. Exit codes 0 (no-drift) and 1 (drift-detected) are only achievable once option B (PAT) or C (GitHub App) is in place.
-- [ ] Cadenced cron run on next Monday 14:17 UTC confirms fix at LFG-canonical level (reaches the script step instead of failing at startup; exit-2 expected until option B/C).
+- [x] Cadenced cron run confirmed fix (2026-05-04 16:14 UTC, run 25329761635): workflow reaches `check-github-settings-drift.sh`, script exits 2 (403 on admin endpoints — expected under GITHUB_TOKEN). No longer fails at startup.
 - [ ] **(Maintainer-gated, options B/C):** drift detector calls admin-only endpoints (`/automated-security-fixes`, `/private-vulnerability-reporting`, `/autolinks`, etc.) which return 403 under GITHUB_TOKEN; full fidelity requires `DRIFT_DETECTOR_PAT` secret (option B) or GitHub App (option C). Tracked as separate maintainer-action follow-on.
 
 ## What option A did NOT fix


### PR DESCRIPTION
## Summary

- Cadenced cron run (2026-05-04, run 25329761635) confirmed the option A fix works
- Workflow reaches `check-github-settings-drift.sh` and exits 2 (expected — 403 on admin endpoints under GITHUB_TOKEN)
- No longer fails at startup (the original bug)
- Options B/C (PAT/GitHub App) remain maintainer-gated

## Test plan

- [x] Verified run 25329761635 exit code = 2 (not startup failure)
- [x] Checklist item updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)