### PR TITLE
fix(B-0162): close — role-ref check mechanization landed

### DIFF
--- a/docs/backlog/P1/B-0162-pre-commit-hook-direct-name-attribution-on-current-state-surfaces-aaron-2026-05-02.md
+++ b/docs/backlog/P1/B-0162-pre-commit-hook-direct-name-attribution-on-current-state-surfaces-aaron-2026-05-02.md
@@ -1,7 +1,9 @@
 ---
 id: B-0162
 priority: P1
-status: open
+status: closed
+closed: 2026-05-07
+closed_by: "Mechanization landed — tool + CI workflow operational in soft-launch mode"
 title: Pre-commit hook to catch direct name attribution on current-state surfaces (Otto-279 role-ref convention) — mechanize the recurring failure mode (5 catches this branch — past mechanization breakeven)
 created: 2026-05-02
 last_updated: 2026-05-02


### PR DESCRIPTION
## Summary

- B-0162 closed: tool + CI workflow both operational
- Soft-launch mode (exit 0 despite violations; `--strict` to enforce)
- `tools/hygiene/check-role-ref-on-current-state-surfaces.ts` scans current-state surfaces
- `.github/workflows/role-ref-current-state-surfaces-lint.yml` runs on PRs

## Test plan

- [x] Tool runs: `bun tools/hygiene/check-role-ref-on-current-state-surfaces.ts`
- [x] CI workflow exists and fires on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)