### PR TITLE
docs(trajectory): add trajectory drift reporting packet

### DIFF
--- a/docs/trajectories/factory-trajectory-surface/RESUME.md
+++ b/docs/trajectories/factory-trajectory-surface/RESUME.md
@@ -94,7 +94,7 @@ in another mirror before the story hardens.
 
 Candidate child packets, each intentionally small:
 
-- trajectory drift reporting, grounded in `docs/SAFE-AUTONOMOUS-ACTIONS.md`
+- none currently selected
 
 Do not create all of them in one PR. The rule is recursive decomposition:
 large trajectory blobs become smaller packets, then smaller packets become
@@ -107,3 +107,5 @@ atomic next actions.
   B-0190
 - `docs/trajectories/autonomous-loop-coordination/RESUME.md`, grounded in
   B-0209 and B-0211
+- `docs/trajectories/trajectory-drift-reporting/RESUME.md`, grounded in
+  `docs/SAFE-AUTONOMOUS-ACTIONS.md`

--- a/docs/trajectories/trajectory-drift-reporting/RESUME.md
+++ b/docs/trajectories/trajectory-drift-reporting/RESUME.md
@@ -1,0 +1,65 @@
+# Trajectory - Trajectory Drift Reporting
+
+Status: active child packet
+Last refreshed: 2026-05-07
+Parent trajectory: `docs/trajectories/factory-trajectory-surface/RESUME.md`
+Grounding surface: `docs/SAFE-AUTONOMOUS-ACTIONS.md`
+
+## Why This Exists
+
+`docs/SAFE-AUTONOMOUS-ACTIONS.md` names trajectory drift as a future
+autonomous action, but explicitly limits it to report-only behavior. This child
+packet makes that lane claimable without giving loops permission to rewrite
+trajectory state automatically.
+
+Trajectory packets are supposed to remember lane state. Drift reporting is the
+small, auditable check that notices when committed work, recent claims, or
+merged backlog movement no longer matches the current `docs/trajectories/`
+surface.
+
+## Current Rule
+
+Surface drift; do not correct it automatically.
+
+A trajectory drift report compares committed substrate against the current
+trajectory packet set and produces reviewable evidence. It may recommend a next
+action, but the recommendation remains report-only until a separate claim or PR
+updates the trajectory surface.
+
+## Current Next Action
+
+Define the first report table shape before writing scripts:
+
+```text
+trajectory -> expected current signal -> observed evidence -> drift class -> recommended next action
+```
+
+The first report should use recent git history plus `docs/trajectories/` state
+as input and should land as documentation only. Automation can follow once the
+classification language is stable enough to test.
+
+## Candidate Atomic Children
+
+- drift-report template for all active trajectory packets
+- stale child-packet classifier with explicit evidence links
+- parent/child linkage audit for `docs/trajectories/`
+- recent-commit sampler that proposes, but does not apply, trajectory updates
+- loop-safe read-only command for producing a trajectory drift report
+
+## Evidence Links
+
+- `docs/SAFE-AUTONOMOUS-ACTIONS.md`
+- `docs/trajectories/factory-trajectory-surface/RESUME.md`
+- `docs/AUTONOMOUS-LOOP.md`
+- `docs/AGENT-CLAIM-PROTOCOL.md`
+
+## Out Of Scope
+
+- No automatic trajectory rewrites.
+- No runner behavior changes.
+- No CI gate.
+- No broad backlog migration.
+- No claim that drift exists until a report cites concrete evidence.
+
+This packet exists to make trajectory drift observable before making it
+actionable.


### PR DESCRIPTION
## Summary

- Adds `docs/trajectories/trajectory-drift-reporting/RESUME.md` as the report-only child packet grounded in `docs/SAFE-AUTONOMOUS-ACTIONS.md`.
- Updates the factory trajectory surface so the trajectory drift packet is listed as created instead of pending.

## Verification

- `git diff --check`
- `./node_modules/.bin/markdownlint-cli2 docs/trajectories/factory-trajectory-surface/RESUME.md docs/trajectories/trajectory-drift-reporting/RESUME.md`