### PR TITLE
docs(B-0256): cite Microsoft Detours as verified hook tool

### DIFF
--- a/docs/backlog/P1/B-0256-model-recursion-exploit-class-metasploit-ida-pro-mapping-2026-05-07.md
+++ b/docs/backlog/P1/B-0256-model-recursion-exploit-class-metasploit-ida-pro-mapping-2026-05-07.md
@@ -30,8 +30,19 @@ traditional security tooling for this class:
   vulnerabilities, including buffer overflow payloads
 - **IDA Pro** — reverse engineering disassembler for
   analyzing binary vulnerability surfaces
+- **Microsoft Detours** — Microsoft Research / `microsoft/Detours`
+  binary-function interception library. Official references describe it
+  as intercepting binary functions on ARM, ARM64, X86, X64, and IA64,
+  preserving the original target through a trampoline:
+  <https://github.com/microsoft/Detours/wiki> and
+  <https://www.microsoft.com/en-us/research/project/detours/>.
 
 These tools have model-level analogues that need mapping.
+
+Detours resolves the 2026-05-07 native-hooking identification path: it is the
+named, verifiable Microsoft tool for binary-level interception/trampoline
+behavior. It is not itself the AI-layer filter surface; it is the compiled-code
+hook analogue to cite without guessing.
 
 ## What
 


### PR DESCRIPTION
## Summary

- Adds Microsoft Detours to B-0256 as the verified Microsoft binary interception/trampoline tool for the native-code hook analogue.
- Cites the official `microsoft/Detours` wiki and Microsoft Research Detours page.
- Keeps the distinction explicit: Detours is the compiled-code hook analogue, not the AI-layer filter surface.

## Verification

- `git diff --check`
- `./node_modules/.bin/markdownlint-cli2 docs/backlog/P1/B-0256-model-recursion-exploit-class-metasploit-ida-pro-mapping-2026-05-07.md`