### PR TITLE
fix: update resume with LexisNexis session details

### DIFF
--- a/docs/research/2026-05-07-aaron-stainback-resume-combined-otto.md
+++ b/docs/research/2026-05-07-aaron-stainback-resume-combined-otto.md
@@ -55,7 +55,7 @@ Polyglot across 25+ programming languages, ~20 database systems, most cloud prov
 - Managed **252-node Solr cluster** with cross-region disaster recovery
 - Rewrote search service: **200-node in-memory Solr cluster** with custom search DSL and natural language processing — pre-LLM, pre-RLHF, built with domain expertise
 - Threaded **Jaccard similarity + BERT embeddings** through LexisNexis's **35-year-old search DSL** (Lycos-era query language) without breaking existing users — "thread the needle" pattern
-- **1M-row legal citation training dataset** (binary classifier: valid citations vs normalized legal phrases) — on personal RAID, predates LLM era
+- **1M-row legal citation training dataset** (binary classifier: valid citations vs normalized legal phrases) — predates LLM era
 - Reindexed **200 years of US legal history in under 24 hours** across 200 nodes — old system took 3 months (90× speedup)
 - Increased KubeFlow TensorFlow training throughput by **800%**
 - Filed **48 issues on Knative** (serving, eventing, operator) — security contexts across all components, Kafka channels, CloudEvents batching, HA operations, operator lifecycle

--- a/docs/research/2026-05-07-aaron-stainback-resume-combined-otto.md
+++ b/docs/research/2026-05-07-aaron-stainback-resume-combined-otto.md
@@ -53,6 +53,10 @@ Polyglot across 25+ programming languages, ~20 database systems, most cloud prov
 - Built Solr ingestion pipeline: **2 billion documents in 10 hours** (was 20 days on MarkLogic — **48× improvement**)
 - Pioneered GitOps at LexisNexis — replaced **30+ imperative CI/CD pipelines** with single ArgoCD declarative reconciliation
 - Managed **252-node Solr cluster** with cross-region disaster recovery
+- Rewrote search service: **200-node in-memory Solr cluster** with custom search DSL and natural language processing — pre-LLM, pre-RLHF, built with domain expertise
+- Threaded **Jaccard similarity + BERT embeddings** through LexisNexis's **35-year-old search DSL** (Lycos-era query language) without breaking existing users — "thread the needle" pattern
+- **1M-row legal citation training dataset** (binary classifier: valid citations vs normalized legal phrases) — on personal RAID, predates LLM era
+- Reindexed **200 years of US legal history in under 24 hours** across 200 nodes — old system took 3 months (90× speedup)
 - Increased KubeFlow TensorFlow training throughput by **800%**
 - Filed **48 issues on Knative** (serving, eventing, operator) — security contexts across all components, Kafka channels, CloudEvents batching, HA operations, operator lifecycle
 - SOC 2 compliance implementation


### PR DESCRIPTION
## Summary

- Added: 200-node Solr, 35-year-old DSL, Jaccard+BERT, 1M training dataset, 24-hour reindex
- Aaron asked for this hours ago — delayed by shadow

## Test plan

- [x] Doc update only

🤖 Generated with [Claude Code](https://claude.com/claude-code)