### PR TITLE
feat: BFT consensus state machine — typed lifecycle + 6 tests

### DIFF
--- a/src/Core/Consensus.fs
+++ b/src/Core/Consensus.fs
@@ -48,3 +48,69 @@ module Consensus =
         match result with
         | Committed(v, _, _) -> Some v
         | Rejected _ -> None
+
+    type Phase =
+        | Proposed
+        | Voting
+        | Decided
+
+    type Message<'T> =
+        | Propose of proposer: NodeId * value: 'T
+        | CastVote of voter: NodeId * value: 'T
+        | Finalize
+
+    type RoundState<'T> =
+        { Phase: Phase
+          Proposal: 'T option
+          Proposer: NodeId option
+          Votes: Vote<'T> list
+          Result: ConsensusResult<'T> option
+          Nodes: NodeId list }
+
+    let emptyRound (nodes: NodeId list) : RoundState<'T> =
+        { Phase = Proposed
+          Proposal = None
+          Proposer = None
+          Votes = []
+          Result = None
+          Nodes = nodes }
+
+    type TransitionResult<'T> =
+        | Ok of RoundState<'T>
+        | InvalidTransition of reason: string
+
+    let transition<'T when 'T: equality>
+        (state: RoundState<'T>)
+        (msg: Message<'T>)
+        : TransitionResult<'T> =
+        match state.Phase, msg with
+        | Proposed, Propose(proposer, value) ->
+            if not (List.contains proposer state.Nodes) then
+                InvalidTransition $"unknown proposer: %A{proposer}"
+            else
+                Ok { state with
+                        Phase = Voting
+                        Proposal = Some value
+                        Proposer = Some proposer }
+        | Voting, CastVote(voter, value) ->
+            if not (List.contains voter state.Nodes) then
+                InvalidTransition $"unknown voter: %A{voter}"
+            elif state.Votes |> List.exists (fun v -> v.Node = voter) then
+                InvalidTransition $"duplicate vote from %A{voter}"
+            else
+                let vote =
+                    { Node = voter
+                      Value = value
+                      Timestamp = DateTimeOffset.UtcNow }
+                Ok { state with Votes = vote :: state.Votes }
+        | Voting, Finalize ->
+            let result = decide state.Votes
+            Ok { state with Phase = Decided; Result = Some result }
+        | Decided, _ ->
+            InvalidTransition "round already decided"
+        | Proposed, CastVote _ ->
+            InvalidTransition "cannot vote before proposal"
+        | Proposed, Finalize ->
+            InvalidTransition "cannot finalize before proposal"
+        | Voting, Propose _ ->
+            InvalidTransition "cannot propose during voting"

--- a/tests/Tests.FSharp/Consensus.Tests.fs
+++ b/tests/Tests.FSharp/Consensus.Tests.fs
@@ -77,3 +77,65 @@ let ``unanimous votes always commit`` (NonEmptyArray (values: int array)) =
     let v = values[0]
     let votes = values |> Array.mapi (fun i _ -> vote (NodeId $"n{i}") v) |> Array.toList
     isCommitted (decide votes)
+
+let nodes = [ otto; vera; riven; lior ]
+
+let unwrap (r: TransitionResult<'T>) : RoundState<'T> =
+    match r with
+    | TransitionResult.Ok s -> s
+    | InvalidTransition reason -> failwith $"unexpected InvalidTransition: {reason}"
+
+[<Fact>]
+let ``state machine — full round commits`` () =
+    let s0 = emptyRound nodes
+    let s1 = unwrap (transition s0 (Propose(otto, "merge")))
+    Assert.Equal(Voting, s1.Phase)
+    let s2 = unwrap (transition s1 (CastVote(otto, "merge")))
+    let s3 = unwrap (transition s2 (CastVote(vera, "merge")))
+    let s4 = unwrap (transition s3 (CastVote(riven, "merge")))
+    let s5 = unwrap (transition s4 Finalize)
+    Assert.Equal(Decided, s5.Phase)
+    Assert.True(s5.Result |> Option.map isCommitted |> Option.defaultValue false)
+
+[<Fact>]
+let ``state machine — cannot vote before proposal`` () =
+    let s0 = emptyRound nodes
+    match transition s0 (CastVote(otto, "merge")) with
+    | InvalidTransition r -> Assert.Contains("before proposal", r)
+    | TransitionResult.Ok _ -> Assert.Fail "expected invalid transition"
+
+[<Fact>]
+let ``state machine — cannot propose during voting`` () =
+    let s0 = emptyRound nodes
+    let s1 = unwrap (transition s0 (Propose(otto, "merge")))
+    match transition s1 (Propose(vera, "reject")) with
+    | InvalidTransition r -> Assert.Contains("during voting", r)
+    | TransitionResult.Ok _ -> Assert.Fail "expected invalid transition"
+
+[<Fact>]
+let ``state machine — duplicate vote rejected`` () =
+    let s0 = emptyRound nodes
+    let s1 = unwrap (transition s0 (Propose(otto, "merge")))
+    let s2 = unwrap (transition s1 (CastVote(otto, "merge")))
+    match transition s2 (CastVote(otto, "merge")) with
+    | InvalidTransition r -> Assert.Contains("duplicate", r)
+    | TransitionResult.Ok _ -> Assert.Fail "expected invalid transition"
+
+[<Fact>]
+let ``state machine — unknown node rejected`` () =
+    let s0 = emptyRound nodes
+    match transition s0 (Propose(NodeId "mallory", "merge")) with
+    | InvalidTransition r -> Assert.Contains("unknown", r)
+    | TransitionResult.Ok _ -> Assert.Fail "expected invalid transition"
+
+[<Fact>]
+let ``state machine — decided round rejects further messages`` () =
+    let s0 = emptyRound nodes
+    let s1 = unwrap (transition s0 (Propose(otto, "merge")))
+    let s2 = unwrap (transition s1 (CastVote(otto, "merge")))
+    let s3 = unwrap (transition s2 (CastVote(vera, "merge")))
+    let s4 = unwrap (transition s3 (CastVote(riven, "merge")))
+    let s5 = unwrap (transition s4 Finalize)
+    match transition s5 (CastVote(lior, "merge")) with
+    | InvalidTransition r -> Assert.Contains("already decided", r)
+    | Ok _ -> Assert.Fail "expected invalid transition"


### PR DESCRIPTION
## Summary

Extends Consensus.fs with:
- `Phase` (Proposed → Voting → Decided)
- `Message<'T>` (Propose | CastVote | Finalize)
- `RoundState<'T>` (full round state)
- `transition` function with exhaustive guards

6 new tests: full round, vote-before-proposal, propose-during-voting,
duplicate vote, unknown node, decided-round rejection. 24 total pass.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings
- [x] `dotnet test --filter Consensus` — 24/24 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)