### PR TITLE
docs(loop): require minimum background PR runway

### DIFF
--- a/docs/AUTONOMOUS-LOOP.md
+++ b/docs/AUTONOMOUS-LOOP.md
@@ -280,6 +280,26 @@ wait for instruction. Priority ladder:
    refresh-debt accumulation even when nothing needs
    doing.
 
+   **Minimum open-PR runway.** GitHub PRs are the
+   authoritative coordination queue for cross-agent work. A
+   healthy active factory targets roughly two open PRs per
+   active implementation loop, with a hard minimum of one
+   open owned background PR per loop. If the open PR pool is
+   below that target, or this loop has no owned PR in flight,
+   the tick does not stop after observation. It opens or
+   advances the next bounded PR from the priority ladder
+   before idling.
+
+   The valid blockers are concrete: no non-overlapping path
+   set, an active claim on the same path set, a dirty shared
+   checkout with no dedicated worktree available, a required
+   CI/review action that must be handled first, or an explicit
+   budget/safety stop. A stale local status file or "nothing
+   to do" narration is not a blocker. Do not create duplicate
+   backlog rows to satisfy runway; use existing backlog rows,
+   decomposition state, claims, and PR review threads as the
+   work source.
+
 2. **Drop-zone audit second.** Run `ls -la drop/`. The
    maintainer deposits files for absorption there
    (`drop/README.md`). If only the tracked sentinels

--- a/docs/AUTONOMOUS-LOOP.md
+++ b/docs/AUTONOMOUS-LOOP.md
@@ -291,14 +291,15 @@ wait for instruction. Priority ladder:
    before idling.
 
    The valid blockers are concrete: no non-overlapping path
-   set, an active claim on the same path set, a dirty shared
-   checkout with no dedicated worktree available, a required
-   CI/review action that must be handled first, or an explicit
-   budget/safety stop. A stale local status file or "nothing
-   to do" narration is not a blocker. Do not create duplicate
-   backlog rows to satisfy runway; use existing backlog rows,
-   decomposition state, claims, and PR review threads as the
-   work source.
+   set, an active claim on the same path set, failure to create
+   a dedicated worktree, a required CI/review action that must
+   be handled first, or an explicit budget/safety stop. A dirty
+   shared/root checkout is not an execution option to offer the
+   maintainer; it is the reason to create an isolated worktree.
+   A stale local status file or "nothing to do" narration is not
+   a blocker. Do not create duplicate backlog rows to satisfy
+   runway; use existing backlog rows, decomposition state,
+   claims, and PR review threads as the work source.
 
 2. **Drop-zone audit second.** Run `ls -la drop/`. The
    maintainer deposits files for absorption there

--- a/docs/FOREGROUND-BACKGROUND-SPLIT.md
+++ b/docs/FOREGROUND-BACKGROUND-SPLIT.md
@@ -19,6 +19,9 @@ scopes of attention.
 - Forward actions (arm auto-merge, resolve phantom threads, sync clones)
 - Rotation detection (stale peers, activation requests)
 - Git state (fetch, dirty check, main HEAD)
+- Minimum PR runway (keep at least one, target two, open
+  background PRs per active implementation loop unless a
+  concrete safety blocker is present)
 
 **Does NOT own:**
 

--- a/docs/FOREGROUND-BACKGROUND-SPLIT.md
+++ b/docs/FOREGROUND-BACKGROUND-SPLIT.md
@@ -22,6 +22,9 @@ scopes of attention.
 - Minimum PR runway (keep at least one, target two, open
   background PRs per active implementation loop unless a
   concrete safety blocker is present)
+- Worktree isolation (a dirty shared/root checkout is never
+  a normal write surface and never a permission prompt; create
+  a dedicated worktree or stop on a concrete failure)
 
 **Does NOT own:**
 


### PR DESCRIPTION
## Summary
- require active implementation loops to keep a minimum open background PR runway
- make an empty owned PR lane a work-pickup trigger, not an idle condition
- record the runway as background-owned project state in the foreground/background split

## Coordination
- Claim branch: claim/task-min-background-pr-runway
- Disjoint from origin/claim/backlog-0249-tier1-runner; this PR only touches docs/process paths

## Checks
- git diff --check