### PR TITLE
fix(backlog): decompose B-0249 autonomous pickup

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -17,6 +17,10 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0109](backlog/P0/B-0109-dependency-status-tracking-surface-2026-04-30.md)** Dependency status tracking surface — outages and issues affecting us (Aaron 2026-04-30, urgent)
 - [ ] **[B-0160](backlog/P0/B-0160-mechanical-authorization-check-skill-build-claudeai-2026-05-02.md)** Mechanical authorization check skill build — pace-instruction resolver per Claude.ai 2026-05-02 architectural correction
 - [ ] **[B-0249](backlog/P0/B-0249-autonomous-backlog-pickup-self-sustaining-new-work-2026-05-07.md)** Autonomous backlog pickup — loops must start new work, not just maintain
+- [ ] **[B-0278](backlog/P0/B-0278-autonomous-backlog-selector-priority-safe-pickup-2026-05-08.md)** Autonomous backlog pickup - priority selector
+- [ ] **[B-0279](backlog/P0/B-0279-autonomous-backlog-claim-worktree-bootstrap-2026-05-08.md)** Autonomous backlog pickup - claim and worktree bootstrap
+- [ ] **[B-0280](backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md)** Autonomous backlog pickup - PR publication and auto-merge
+- [ ] **[B-0281](backlog/P0/B-0281-codex-loop-empty-queue-backlog-pickup-integration-2026-05-08.md)** Codex loop - empty queue autonomous backlog pickup
 
 ## P1 — within 2-3 rounds
 

--- a/docs/backlog/P0/B-0249-autonomous-backlog-pickup-self-sustaining-new-work-2026-05-07.md
+++ b/docs/backlog/P0/B-0249-autonomous-backlog-pickup-self-sustaining-new-work-2026-05-07.md
@@ -4,9 +4,10 @@ priority: P0
 status: open
 title: "Autonomous backlog pickup — loops must start new work, not just maintain"
 created: 2026-05-07
-last_updated: 2026-05-07
+last_updated: 2026-05-08
 depends_on: []
-decomposition: blob
+decomposition: decomposed
+children: [B-0278, B-0279, B-0280, B-0281]
 owners: [architect]
 ---
 
@@ -50,6 +51,14 @@ sleeps.
 - [ ] PR is created and auto-merge armed
 - [ ] If the item is too large (blob), decompose first, then
   pick the first atomic child
+
+## Decomposition
+
+- `B-0278` selects the next safe backlog item from committed
+  substrate.
+- `B-0279` creates the git-native claim and isolated worktree.
+- `B-0280` publishes the first autonomous PR and arms auto-merge.
+- `B-0281` wires the empty-queue pickup path into the Codex loop.
 
 ## Composes with
 

--- a/docs/backlog/P0/B-0278-autonomous-backlog-selector-priority-safe-pickup-2026-05-08.md
+++ b/docs/backlog/P0/B-0278-autonomous-backlog-selector-priority-safe-pickup-2026-05-08.md
@@ -1,0 +1,27 @@
+---
+id: B-0278
+priority: P0
+status: open
+title: "Autonomous backlog pickup - priority selector"
+created: 2026-05-08
+last_updated: 2026-05-08
+parent: B-0249
+depends_on: []
+classification: buildable-now
+decomposition: atomic
+owners: [architect, backlog-shepherd]
+---
+
+# B-0278 - Autonomous backlog selector
+
+Build the read-only selector that runs when the PR queue is empty
+and returns the next safe backlog item to work.
+
+## Acceptance criteria
+
+- Reads committed backlog rows from `docs/backlog/**`.
+- Orders candidates by priority, then creation/update age.
+- Skips closed rows, already-decomposed parents with open children,
+  rows with active claim branches, and rows with open PR branches.
+- Returns `decompose-first` when the best candidate is still a blob.
+- Emits a concise machine-readable decision record for loop logs.

--- a/docs/backlog/P0/B-0279-autonomous-backlog-claim-worktree-bootstrap-2026-05-08.md
+++ b/docs/backlog/P0/B-0279-autonomous-backlog-claim-worktree-bootstrap-2026-05-08.md
@@ -1,0 +1,26 @@
+---
+id: B-0279
+priority: P0
+status: open
+title: "Autonomous backlog pickup - claim and worktree bootstrap"
+created: 2026-05-08
+last_updated: 2026-05-08
+parent: B-0249
+depends_on: [B-0278]
+classification: blocked-on-B-0278
+decomposition: atomic
+owners: [architect, codex]
+---
+
+# B-0279 - Claim and worktree bootstrap
+
+Create the isolated write surface for a selected backlog row before
+any file edits happen.
+
+## Acceptance criteria
+
+- Creates or updates the git-native claim for the selected row.
+- Uses a dedicated worktree rooted at current `origin/main`.
+- Refuses to write in the contested root checkout.
+- Records the selected path set before edits begin.
+- Fails closed if another active claim overlaps the path set.

--- a/docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md
+++ b/docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md
@@ -1,0 +1,27 @@
+---
+id: B-0280
+priority: P0
+status: open
+title: "Autonomous backlog pickup - PR publication and auto-merge"
+created: 2026-05-08
+last_updated: 2026-05-08
+parent: B-0249
+depends_on: [B-0279]
+classification: blocked-on-B-0279
+decomposition: atomic
+owners: [architect, codex]
+---
+
+# B-0280 - PR publication and auto-merge
+
+Turn one autonomous backlog pickup into a reviewable GitHub PR
+without the maintainer acting as courier or permission surface.
+
+## Acceptance criteria
+
+- Runs the focused checks required by the selected row.
+- Commits with the Codex `Co-Authored-By` trailer.
+- Pushes the claim branch.
+- Opens a PR with summary, checks, and selected backlog row.
+- Arms auto-merge only when the PR has no unresolved review threads
+  and required checks are clean or pending.

--- a/docs/backlog/P0/B-0281-codex-loop-empty-queue-backlog-pickup-integration-2026-05-08.md
+++ b/docs/backlog/P0/B-0281-codex-loop-empty-queue-backlog-pickup-integration-2026-05-08.md
@@ -1,0 +1,27 @@
+---
+id: B-0281
+priority: P0
+status: open
+title: "Codex loop - empty queue autonomous backlog pickup"
+created: 2026-05-08
+last_updated: 2026-05-08
+parent: B-0249
+depends_on: [B-0280]
+classification: blocked-on-B-0280
+decomposition: atomic
+owners: [architect, codex]
+---
+
+# B-0281 - Empty-queue backlog pickup integration
+
+Wire the selector, claim bootstrap, and PR publication path into the
+Codex background loop so an empty PR queue starts new work.
+
+## Acceptance criteria
+
+- Runs only after PR maintenance finds no actionable open PR.
+- Picks at most one backlog row per tick.
+- Uses the same cooldown and heartbeat discipline as existing loop
+  work.
+- Writes a durable decision trace to loop logs.
+- Leaves the root checkout untouched.


### PR DESCRIPTION
## Summary

Decomposes P0 backlog row B-0249 into four atomic children so autonomous loops can start new work when the PR queue is empty:

- B-0278 backlog selector
- B-0279 claim/worktree bootstrap
- B-0280 PR publication and auto-merge
- B-0281 Codex loop empty-queue integration

Also regenerates `docs/BACKLOG.md`.

## Checks

- `bun tools/backlog/generate-index.ts --check`
- `git diff --check HEAD`
- `markdownlint-cli2` on changed backlog rows