### PR TITLE
fix(backlog): decompose B-0234 pages SEO discovery

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -115,6 +115,10 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0275](backlog/P1/B-0275-pages-astro-http-200-and-deploy-validation-2026-05-08.md)** Pages discoverability - Astro deploy validation and HTTP 200 check
 - [ ] **[B-0276](backlog/P1/B-0276-structure-recognizer-fingerprint-library-2026-05-08.md)** Structure recognizer — fingerprint library for codebase shapes
 - [ ] **[B-0277](backlog/P1/B-0277-structure-recognizer-catalog-index-2026-05-08.md)** Structure recognizer — shape-indexed catalog without labels
+- [ ] **[B-0278](backlog/P1/B-0278-durable-computation-survey-8-systems-2026-05-08.md)** Durable computation survey — compare 8 systems against Zeta's gap
+- [ ] **[B-0279](backlog/P1/B-0279-durable-computation-checkpoint-interface-extension-2026-05-08.md)** Durable computation — extend Checkpoint.fs with StableStorage mode
+- [ ] **[B-0284](backlog/P1/B-0284-pages-seo-metadata-jsonld-social-preview-2026-05-08.md)** Pages discoverability - SEO metadata, JSON-LD, and social previews
+- [ ] **[B-0285](backlog/P1/B-0285-pages-sitemap-robots-ai-crawler-policy-2026-05-08.md)** Pages discoverability - sitemap, robots, and AI crawler policy
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0234-pages-seo-metadata-sitemap-robots-ai-crawlers-2026-05-06.md
+++ b/docs/backlog/P1/B-0234-pages-seo-metadata-sitemap-robots-ai-crawlers-2026-05-06.md
@@ -4,11 +4,12 @@ priority: P1
 status: open
 title: "GitHub Pages discoverability - SEO metadata, sitemap, robots, and AI crawler access"
 created: 2026-05-06
-last_updated: 2026-05-06
+last_updated: 2026-05-08
 parent: B-0154
 depends_on: [B-0232, B-0233]
 classification: blocked-on-pages-content
-decomposition: blob
+decomposition: decomposed
+children: [B-0284, B-0285]
 ---
 
 # B-0234 - SEO metadata and crawler access
@@ -31,3 +32,9 @@ allow-listing.
 - AI-agent crawler policy is explicit and matches the
   discoverability goal.
 - JSON-LD is present where it helps agents parse the content.
+
+## Decomposition
+
+- `B-0284` owns per-page SEO metadata, canonical URLs, social
+  preview cards, and JSON-LD.
+- `B-0285` owns sitemap, robots, and AI-agent crawler policy.

--- a/docs/backlog/P1/B-0284-pages-seo-metadata-jsonld-social-preview-2026-05-08.md
+++ b/docs/backlog/P1/B-0284-pages-seo-metadata-jsonld-social-preview-2026-05-08.md
@@ -1,0 +1,27 @@
+---
+id: B-0284
+priority: P1
+status: open
+title: "Pages discoverability - SEO metadata, JSON-LD, and social previews"
+created: 2026-05-08
+last_updated: 2026-05-08
+parent: B-0234
+depends_on: [B-0233]
+classification: blocked-on-pages-content
+decomposition: atomic
+owners: [architect, docs]
+---
+
+# B-0284 - SEO metadata and structured data
+
+Define the metadata layer for the GitHub Pages site once the
+content inventory exists.
+
+## Acceptance criteria
+
+- Each public page has title, description, and canonical URL.
+- Open Graph and Twitter Card metadata are emitted for link
+  previews.
+- JSON-LD is present where it improves agent parsing.
+- Metadata defaults are centralized instead of duplicated per
+  page.

--- a/docs/backlog/P1/B-0285-pages-sitemap-robots-ai-crawler-policy-2026-05-08.md
+++ b/docs/backlog/P1/B-0285-pages-sitemap-robots-ai-crawler-policy-2026-05-08.md
@@ -1,0 +1,26 @@
+---
+id: B-0285
+priority: P1
+status: open
+title: "Pages discoverability - sitemap, robots, and AI crawler policy"
+created: 2026-05-08
+last_updated: 2026-05-08
+parent: B-0234
+depends_on: [B-0284]
+classification: blocked-on-B-0284
+decomposition: atomic
+owners: [architect, docs]
+---
+
+# B-0285 - Sitemap and crawler policy
+
+Publish the machine-readable discovery files for search engines,
+link-preview systems, and AI-agent crawlers.
+
+## Acceptance criteria
+
+- `sitemap.xml` is generated and reachable.
+- `robots.txt` is generated and reachable.
+- AI-agent crawler policy is explicit and matches the
+  discoverability goal.
+- Validation covers the published sitemap and robots URLs.


### PR DESCRIPTION
## Summary

Decomposes B-0234 into two atomic Pages discoverability rows:

- B-0284 SEO metadata, JSON-LD, and social previews
- B-0285 sitemap, robots, and AI crawler policy

Also regenerates `docs/BACKLOG.md`.

## Checks

- `bun tools/backlog/generate-index.ts --check`
- `git diff --check HEAD`
- `markdownlint-cli2` on changed backlog rows

## Note

Skipped B-0233 because an existing `backlog/b0233-decompose` worktree/branch already owns that lane.