### PR TITLE
fix(backlog): repair B-0247 metadata after merge

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -119,6 +119,9 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0279](backlog/P1/B-0279-durable-computation-checkpoint-interface-extension-2026-05-08.md)** Durable computation — extend Checkpoint.fs with StableStorage mode
 - [ ] **[B-0284](backlog/P1/B-0284-pages-seo-metadata-jsonld-social-preview-2026-05-08.md)** Pages discoverability - SEO metadata, JSON-LD, and social previews
 - [ ] **[B-0285](backlog/P1/B-0285-pages-sitemap-robots-ai-crawler-policy-2026-05-08.md)** Pages discoverability - sitemap, robots, and AI crawler policy
+- [ ] **[B-0287](backlog/P1/B-0287-ace-dlc-package-format-spec-2026-05-08.md)** Ace DLC — package format specification
+- [ ] **[B-0288](backlog/P1/B-0288-ace-dlc-package-manager-cli-2026-05-08.md)** Ace DLC — package manager CLI (install/verify/list)
+- [ ] **[B-0290](backlog/P1/B-0290-green-lantern-consent-gate-firmware-2026-05-08.md)** Green Lantern ring — consent gate firmware design
 
 ## P2 — research-grade
 
@@ -236,6 +239,10 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0252](backlog/P2/B-0252-arc4-adversarial-selfplay-structure-recognizer-realtime-2026-05-07.md)** ARC-4 adversarial self-play — structure recognizer at real-time tick speed
 - [ ] **[B-0253](backlog/P2/B-0253-realtime-interloop-messaging-orleans-grains-not-broadcast-files-2026-05-07.md)** Real-time inter-loop messaging via Orleans grains — replace turn-based broadcast files
 - [ ] **[B-0254](backlog/P2/B-0254-infernet-probabilistic-triangulation-posterior-quorum-2026-05-07.md)** Posterior quorum triangulation over existing Bayesian DBSP substrate
+- [ ] **[B-0283](backlog/P2/B-0283-interloop-messaging-protocol-design-2026-05-08.md)** Interloop messaging — protocol design (message types + delivery)
+- [ ] **[B-0284](backlog/P2/B-0284-interloop-messaging-implementation-2026-05-08.md)** Interloop messaging — implementation on chosen transport
+- [ ] **[B-0285](backlog/P2/B-0285-arc4-selfplay-arena-design-2026-05-08.md)** ARC-4 — adversarial self-play arena design
+- [ ] **[B-0286](backlog/P2/B-0286-arc4-selfplay-implementation-2026-05-08.md)** ARC-4 — self-play implementation + training loop
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P1/B-0247-ace-dlc-content-packs-kernel-extensions-package-manager-2026-05-07.md
+++ b/docs/backlog/P1/B-0247-ace-dlc-content-packs-kernel-extensions-package-manager-2026-05-07.md
@@ -4,7 +4,7 @@ priority: P1
 status: open
 title: "Ace DLC content packs — distributable kernel extensions via package manager"
 created: 2026-05-07
-last_updated: 2026-05-07
+last_updated: 2026-05-08
 depends_on: [B-0240, B-0244, B-0245]
 decomposition: decomposed
 children: [B-0287, B-0288]

--- a/docs/backlog/P1/B-0287-ace-dlc-package-format-spec-2026-05-08.md
+++ b/docs/backlog/P1/B-0287-ace-dlc-package-format-spec-2026-05-08.md
@@ -4,10 +4,12 @@ priority: P1
 status: open
 title: "Ace DLC — package format specification"
 created: 2026-05-08
+last_updated: 2026-05-08
 parent: B-0247
 depends_on: []
 classification: buildable-now
 decomposition: atomic
+owners: [architect, public-api-designer]
 ---
 
 # B-0287 — DLC package format

--- a/docs/backlog/P1/B-0288-ace-dlc-package-manager-cli-2026-05-08.md
+++ b/docs/backlog/P1/B-0288-ace-dlc-package-manager-cli-2026-05-08.md
@@ -4,10 +4,12 @@ priority: P1
 status: open
 title: "Ace DLC — package manager CLI (install/verify/list)"
 created: 2026-05-08
+last_updated: 2026-05-08
 parent: B-0247
 depends_on: [B-0287]
 classification: blocked-on-B-0287
 decomposition: atomic
+owners: [architect, public-api-designer]
 ---
 
 # B-0288 — DLC package manager CLI


### PR DESCRIPTION
## Summary

Follow-up to #2009. That PR merged before the repair commit could become its head, so this lands the actual missing cleanup:

- regenerate `docs/BACKLOG.md`
- bump `B-0247` `last_updated` to `2026-05-08`
- add `last_updated` and `owners` to `B-0287`/`B-0288`

## Checks

- `bun tools/backlog/generate-index.ts --check`
- `git diff --check HEAD`
- `markdownlint-cli2` on changed B-0247/B-0287/B-0288 rows