### PR TITLE
feat(B-0285): ARC-4 arena types + 9 tests

### DIFF
--- a/src/Core/Arena.fs
+++ b/src/Core/Arena.fs
@@ -1,0 +1,108 @@
+namespace Zeta.Core
+
+open System
+
+module Arena =
+
+    type CellValue =
+        | Empty
+        | Filled of color: int
+
+    type Grid = CellValue array2d
+
+    type Puzzle =
+        { Input: Grid
+          ExpectedOutput: Grid
+          Id: string }
+
+    type Move =
+        | Fill of row: int * col: int * color: int
+        | Clear of row: int * col: int
+        | CopyRow of src: int * dst: int
+        | CopyCol of src: int * dst: int
+        | FloodFill of row: int * col: int * color: int
+
+    type Score =
+        { CorrectCells: int
+          TotalCells: int
+          MovesUsed: int
+          MoveLimit: int }
+
+    let accuracy (score: Score) : float =
+        if score.TotalCells = 0 then 0.0
+        else float score.CorrectCells / float score.TotalCells
+
+    let withinBudget (score: Score) : bool =
+        score.MovesUsed <= score.MoveLimit
+
+    let createGrid (rows: int) (cols: int) : Grid =
+        Array2D.create rows cols Empty
+
+    let applyMove (grid: Grid) (move: Move) : Grid =
+        let g = Array2D.copy grid
+        let rows = Array2D.length1 g
+        let cols = Array2D.length2 g
+        match move with
+        | Fill(r, c, color) when r >= 0 && r < rows && c >= 0 && c < cols ->
+            g[r, c] <- Filled color
+            g
+        | Clear(r, c) when r >= 0 && r < rows && c >= 0 && c < cols ->
+            g[r, c] <- Empty
+            g
+        | CopyRow(src, dst) when src >= 0 && src < rows && dst >= 0 && dst < rows ->
+            for c in 0 .. cols - 1 do
+                g[dst, c] <- g[src, c]
+            g
+        | CopyCol(src, dst) when src >= 0 && src < cols && dst >= 0 && dst < cols ->
+            for r in 0 .. rows - 1 do
+                g[r, dst] <- g[r, src]
+            g
+        | FloodFill(r, c, color) when r >= 0 && r < rows && c >= 0 && c < cols ->
+            let target = g[r, c]
+            let newColor = Filled color
+            if target = newColor then g
+            else
+                let visited = Array2D.create rows cols false
+                let rec fill row col =
+                    if row >= 0 && row < rows && col >= 0 && col < cols
+                       && not visited[row, col] && g[row, col] = target then
+                        visited[row, col] <- true
+                        g[row, col] <- newColor
+                        fill (row - 1) col
+                        fill (row + 1) col
+                        fill row (col - 1)
+                        fill row (col + 1)
+                fill r c
+                g
+        | _ -> g
+
+    let scoreAttempt
+        (expected: Grid)
+        (actual: Grid)
+        (movesUsed: int)
+        (moveLimit: int)
+        : Score =
+        let rows = Array2D.length1 expected
+        let cols = Array2D.length2 expected
+        let mutable correct = 0
+        let mutable total = 0
+        for r in 0 .. rows - 1 do
+            for c in 0 .. cols - 1 do
+                total <- total + 1
+                if expected[r, c] = actual[r, c] then
+                    correct <- correct + 1
+        { CorrectCells = correct
+          TotalCells = total
+          MovesUsed = movesUsed
+          MoveLimit = moveLimit }
+
+    let solve
+        (puzzle: Puzzle)
+        (moves: Move list)
+        (moveLimit: int)
+        : Score =
+        let limited = moves |> List.truncate moveLimit
+        let result =
+            limited
+            |> List.fold applyMove puzzle.Input
+        scoreAttempt puzzle.ExpectedOutput result limited.Length moveLimit

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -67,6 +67,7 @@
     <Compile Include="Durability.fs" />
     <Compile Include="Checkpoint.fs" />
     <Compile Include="Consensus.fs" />
+    <Compile Include="Arena.fs" />
     <Compile Include="NestedCircuit.fs" />
     <Compile Include="Runtime.fs" />
     <Compile Include="WorkStealingRuntime.fs" />

--- a/tests/Tests.FSharp/Arena.Tests.fs
+++ b/tests/Tests.FSharp/Arena.Tests.fs
@@ -1,0 +1,76 @@
+module Zeta.Tests.ArenaTests
+
+open Xunit
+open Zeta.Core.Arena
+
+[<Fact>]
+let ``createGrid makes empty grid`` () =
+    let g = createGrid 3 3
+    Assert.Equal(Empty, g[0, 0])
+    Assert.Equal(Empty, g[2, 2])
+
+[<Fact>]
+let ``Fill sets cell`` () =
+    let g = createGrid 3 3
+    let g2 = applyMove g (Fill(1, 1, 5))
+    Assert.Equal(Filled 5, g2[1, 1])
+    Assert.Equal(Empty, g2[0, 0])
+
+[<Fact>]
+let ``Clear resets cell`` () =
+    let g = createGrid 3 3 |> fun g -> applyMove g (Fill(1, 1, 5))
+    let g2 = applyMove g (Clear(1, 1))
+    Assert.Equal(Empty, g2[1, 1])
+
+[<Fact>]
+let ``CopyRow duplicates row`` () =
+    let g = createGrid 3 3
+    let g2 = applyMove g (Fill(0, 0, 1))
+    let g3 = applyMove g2 (Fill(0, 1, 2))
+    let g4 = applyMove g3 (CopyRow(0, 2))
+    Assert.Equal(Filled 1, g4[2, 0])
+    Assert.Equal(Filled 2, g4[2, 1])
+
+[<Fact>]
+let ``scoreAttempt — perfect match`` () =
+    let g = createGrid 2 2
+    let score = scoreAttempt g g 0 10
+    Assert.Equal(4, score.CorrectCells)
+    Assert.Equal(4, score.TotalCells)
+    Assert.Equal(1.0, accuracy score)
+
+[<Fact>]
+let ``scoreAttempt — partial match`` () =
+    let expected = createGrid 2 2 |> fun g -> applyMove g (Fill(0, 0, 1))
+    let actual = createGrid 2 2
+    let score = scoreAttempt expected actual 1 10
+    Assert.Equal(3, score.CorrectCells)
+
+[<Fact>]
+let ``solve — correct moves produce perfect score`` () =
+    let input = createGrid 2 2
+    let expected = applyMove input (Fill(0, 0, 7))
+    let puzzle = { Input = input; ExpectedOutput = expected; Id = "test-1" }
+    let score = solve puzzle [ Fill(0, 0, 7) ] 5
+    Assert.Equal(1.0, accuracy score)
+    Assert.True(withinBudget score)
+
+[<Fact>]
+let ``solve — move limit truncates`` () =
+    let input = createGrid 2 2
+    let expected =
+        input
+        |> fun g -> applyMove g (Fill(0, 0, 1))
+        |> fun g -> applyMove g (Fill(1, 1, 2))
+    let puzzle = { Input = input; ExpectedOutput = expected; Id = "test-2" }
+    let score = solve puzzle [ Fill(0, 0, 1); Fill(1, 1, 2) ] 1
+    Assert.Equal(1, score.MovesUsed)
+    Assert.Equal(3, score.CorrectCells)
+
+[<Fact>]
+let ``FloodFill fills connected region`` () =
+    let g = createGrid 3 3
+    let g2 = applyMove g (FloodFill(0, 0, 3))
+    for r in 0 .. 2 do
+        for c in 0 .. 2 do
+            Assert.Equal(Filled 3, g2[r, c])

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -115,6 +115,7 @@
     <Compile Include="Properties/Fusion.Equation.Tests.fs" />
     <Compile Include="MajiTests.fs" />
     <Compile Include="Consensus.Tests.fs" />
+    <Compile Include="Arena.Tests.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Arena.fs: Grid, Puzzle, Move, Score. applyMove with 5 move
types including FloodFill. solve with move-limit truncation.
9 tests, all pass. 0 warnings.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings
- [x] `dotnet test --filter Arena` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)