### PR TITLE
fix(backlog): decompose B-0235 pages discovery

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -122,6 +122,12 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0287](backlog/P1/B-0287-ace-dlc-package-format-spec-2026-05-08.md)** Ace DLC — package format specification
 - [ ] **[B-0288](backlog/P1/B-0288-ace-dlc-package-manager-cli-2026-05-08.md)** Ace DLC — package manager CLI (install/verify/list)
 - [ ] **[B-0290](backlog/P1/B-0290-green-lantern-consent-gate-firmware-2026-05-08.md)** Green Lantern ring — consent gate firmware design
+- [ ] **[B-0291](backlog/P1/B-0291-concordance-ai-corpus-pipeline-2026-05-08.md)** Concordance AI — corpus ingestion + tokenization pipeline
+- [ ] **[B-0292](backlog/P1/B-0292-concordance-ai-local-gpu-inference-2026-05-08.md)** Concordance AI — local GPU inference for structure recognition
+- [ ] **[B-0293](backlog/P1/B-0293-coherence-ai-consent-architecture-2026-05-08.md)** Coherence AI — consent-first architecture design
+- [ ] **[B-0294](backlog/P1/B-0294-coherence-ai-ksk-override-implementation-2026-05-08.md)** Coherence AI — KSK override implementation
+- [ ] **[B-0295](backlog/P1/B-0295-pages-repo-metadata-discovery-surface-2026-05-08.md)** Pages discoverability - repository metadata and discovery surface
+- [ ] **[B-0296](backlog/P1/B-0296-pages-sitemap-submission-discovery-metrics-2026-05-08.md)** Pages discoverability - sitemap submission and discovery metrics
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0235-pages-repo-metadata-sitemap-submission-discovery-2026-05-06.md
+++ b/docs/backlog/P1/B-0235-pages-repo-metadata-sitemap-submission-discovery-2026-05-06.md
@@ -4,11 +4,13 @@ priority: P1
 status: open
 title: "GitHub Pages discoverability - repo metadata, sitemap submission, and discovery signals"
 created: 2026-05-06
-last_updated: 2026-05-06
+last_updated: 2026-05-08
 parent: B-0154
 depends_on: [B-0232, B-0234]
 classification: blocked-on-live-pages-and-sitemap
-decomposition: blob
+decomposition: decomposed
+children: [B-0295, B-0296]
+owners: [architect, docs]
 ---
 
 # B-0235 - Repo metadata and discovery signals

--- a/docs/backlog/P1/B-0295-pages-repo-metadata-discovery-surface-2026-05-08.md
+++ b/docs/backlog/P1/B-0295-pages-repo-metadata-discovery-surface-2026-05-08.md
@@ -1,0 +1,29 @@
+---
+id: B-0295
+priority: P1
+status: open
+title: "Pages discoverability - repository metadata and discovery surface"
+created: 2026-05-08
+last_updated: 2026-05-08
+parent: B-0235
+depends_on: [B-0232, B-0234]
+classification: blocked-on-live-pages
+decomposition: atomic
+owners: [architect, docs]
+---
+
+# B-0295 - Repository discovery surface
+
+Wire the GitHub repository metadata to the public Pages site
+so visitors, contributors, and search systems see one coherent
+entry point.
+
+## Acceptance criteria
+
+- Repository homepage points at the live GitHub Pages URL.
+- Repository description matches the Pages positioning without
+  overclaiming production readiness.
+- Repository topics include the honest technical discovery terms
+  from B-0154.
+- The repo-to-Pages path is documented so future metadata edits
+  have an owner and review surface.

--- a/docs/backlog/P1/B-0296-pages-sitemap-submission-discovery-metrics-2026-05-08.md
+++ b/docs/backlog/P1/B-0296-pages-sitemap-submission-discovery-metrics-2026-05-08.md
@@ -1,0 +1,28 @@
+---
+id: B-0296
+priority: P1
+status: open
+title: "Pages discoverability - sitemap submission and discovery metrics"
+created: 2026-05-08
+last_updated: 2026-05-08
+parent: B-0235
+depends_on: [B-0285, B-0295]
+classification: blocked-on-sitemap-and-metadata
+decomposition: atomic
+owners: [architect, docs]
+---
+
+# B-0296 - Sitemap submission and discovery metrics
+
+Define the external discovery handoff after the Pages metadata,
+sitemap, and crawler policy are live.
+
+## Acceptance criteria
+
+- Google Search Console submission path is documented or
+  completed.
+- Bing Webmaster Tools submission path is documented or completed.
+- Discovery metrics are defined: time-to-index, target-query
+  ranking, crawler hit rate, and external contributor source.
+- Measurement composes with the existing observability or
+  timeseries lane instead of creating a second metrics substrate.


### PR DESCRIPTION
## Summary
- mark B-0235 as decomposed and add child links
- add B-0295 for repository metadata and discovery surface work
- add B-0296 for sitemap submission and discovery metrics
- refresh docs/BACKLOG.md from the generator

## Checks
- bun tools/backlog/generate-index.ts --check
- git diff --check
- npx markdownlint-cli2 docs/backlog/P1/B-0235-pages-repo-metadata-sitemap-submission-discovery-2026-05-06.md docs/backlog/P1/B-0295-pages-repo-metadata-discovery-surface-2026-05-08.md docs/backlog/P1/B-0296-pages-sitemap-submission-discovery-metrics-2026-05-08.md docs/BACKLOG.md