### PR TITLE
fix(backlog): decompose B-0236 pages validation

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -128,6 +128,8 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0294](backlog/P1/B-0294-coherence-ai-ksk-override-implementation-2026-05-08.md)** Coherence AI — KSK override implementation
 - [ ] **[B-0295](backlog/P1/B-0295-pages-repo-metadata-discovery-surface-2026-05-08.md)** Pages discoverability - repository metadata and discovery surface
 - [ ] **[B-0296](backlog/P1/B-0296-pages-sitemap-submission-discovery-metrics-2026-05-08.md)** Pages discoverability - sitemap submission and discovery metrics
+- [ ] **[B-0297](backlog/P1/B-0297-pages-playwright-public-surface-validation-2026-05-08.md)** Pages discoverability - Playwright public surface validation
+- [ ] **[B-0298](backlog/P1/B-0298-pages-frontend-dora-metrics-2026-05-08.md)** Pages discoverability - frontend DORA metric definitions
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0236-pages-playwright-validation-dora-metrics-2026-05-06.md
+++ b/docs/backlog/P1/B-0236-pages-playwright-validation-dora-metrics-2026-05-06.md
@@ -4,11 +4,13 @@ priority: P1
 status: open
 title: "GitHub Pages discoverability - Playwright validation and DORA metrics"
 created: 2026-05-06
-last_updated: 2026-05-06
+last_updated: 2026-05-08
 parent: B-0154
 depends_on: [B-0147, B-0232, B-0234]
 classification: blocked-on-pages-and-metrics-lane
-decomposition: blob
+decomposition: decomposed
+children: [B-0297, B-0298]
+owners: [qa, observability]
 ---
 
 # B-0236 - Pages validation and DORA metrics

--- a/docs/backlog/P1/B-0297-pages-playwright-public-surface-validation-2026-05-08.md
+++ b/docs/backlog/P1/B-0297-pages-playwright-public-surface-validation-2026-05-08.md
@@ -1,0 +1,28 @@
+---
+id: B-0297
+priority: P1
+status: open
+title: "Pages discoverability - Playwright public surface validation"
+created: 2026-05-08
+last_updated: 2026-05-08
+parent: B-0236
+depends_on: [B-0232, B-0234, B-0284, B-0285]
+classification: blocked-on-pages-content-and-seo-files
+decomposition: atomic
+owners: [qa, docs]
+---
+
+# B-0297 - Pages Playwright validation
+
+Add browser-level validation for the published GitHub Pages
+surface so discovery regressions fail in automation instead of
+being found by a crawler or visitor.
+
+## Acceptance criteria
+
+- Playwright covers the public Pages URL with an HTTP 200 check.
+- Navigation links used by the public landing flow are exercised.
+- Metadata, `sitemap.xml`, and `robots.txt` are validated once
+  those files are published.
+- Mobile viewport coverage catches layout or overflow regressions
+  on the primary Pages surface.

--- a/docs/backlog/P1/B-0298-pages-frontend-dora-metrics-2026-05-08.md
+++ b/docs/backlog/P1/B-0298-pages-frontend-dora-metrics-2026-05-08.md
@@ -1,0 +1,28 @@
+---
+id: B-0298
+priority: P1
+status: open
+title: "Pages discoverability - frontend DORA metric definitions"
+created: 2026-05-08
+last_updated: 2026-05-08
+parent: B-0236
+depends_on: [B-0147, B-0297]
+classification: blocked-on-pages-validation
+decomposition: atomic
+owners: [observability, qa]
+---
+
+# B-0298 - Pages frontend DORA metrics
+
+Define the DORA measurement layer for the GitHub Pages
+deployment path without creating a second observability
+substrate.
+
+## Acceptance criteria
+
+- Deployment frequency is defined for the Pages publishing lane.
+- Lead time is measured from merged change to live Pages
+  availability.
+- MTTR and change failure rate definitions include Pages-specific
+  rollback or repair events.
+- The metrics path composes with the existing timeseries lane.


### PR DESCRIPTION
## Summary
- mark B-0236 as decomposed and add child links
- add B-0297 for Playwright public Pages validation
- add B-0298 for Pages frontend DORA metric definitions
- refresh docs/BACKLOG.md from the generator

## Checks
- bun tools/backlog/generate-index.ts --check
- git diff --check
- npx markdownlint-cli2 docs/backlog/P1/B-0236-pages-playwright-validation-dora-metrics-2026-05-06.md docs/backlog/P1/B-0297-pages-playwright-public-surface-validation-2026-05-08.md docs/backlog/P1/B-0298-pages-frontend-dora-metrics-2026-05-08.md docs/BACKLOG.md