### PR TITLE
fix(backlog): decompose B-0237 wiki integration

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -130,6 +130,8 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0296](backlog/P1/B-0296-pages-sitemap-submission-discovery-metrics-2026-05-08.md)** Pages discoverability - sitemap submission and discovery metrics
 - [ ] **[B-0297](backlog/P1/B-0297-pages-playwright-public-surface-validation-2026-05-08.md)** Pages discoverability - Playwright public surface validation
 - [ ] **[B-0298](backlog/P1/B-0298-pages-frontend-dora-metrics-2026-05-08.md)** Pages discoverability - frontend DORA metric definitions
+- [ ] **[B-0299](backlog/P1/B-0299-github-wiki-seed-pages-and-boundaries-2026-05-08.md)** GitHub Wiki integration - seed pages and Pages/Wiki boundaries
+- [ ] **[B-0300](backlog/P1/B-0300-github-wiki-sync-mode-and-indexing-validation-2026-05-08.md)** GitHub Wiki integration - sync mode and indexing validation
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0237-github-wiki-first-class-integration-2026-05-06.md
+++ b/docs/backlog/P1/B-0237-github-wiki-first-class-integration-2026-05-06.md
@@ -4,11 +4,13 @@ priority: P1
 status: open
 title: "GitHub Wiki first-class integration after Pages launch"
 created: 2026-05-06
-last_updated: 2026-05-06
+last_updated: 2026-05-08
 parent: B-0154
 depends_on: [B-0232, B-0233, B-0234]
 classification: blocked-on-pages-primary-surface
-decomposition: blob
+decomposition: decomposed
+children: [B-0299, B-0300]
+owners: [docs, architect]
 ---
 
 # B-0237 - GitHub Wiki first-class integration

--- a/docs/backlog/P1/B-0299-github-wiki-seed-pages-and-boundaries-2026-05-08.md
+++ b/docs/backlog/P1/B-0299-github-wiki-seed-pages-and-boundaries-2026-05-08.md
@@ -1,0 +1,28 @@
+---
+id: B-0299
+priority: P1
+status: open
+title: "GitHub Wiki integration - seed pages and Pages/Wiki boundaries"
+created: 2026-05-08
+last_updated: 2026-05-08
+parent: B-0237
+depends_on: [B-0232, B-0233, B-0234]
+classification: blocked-on-pages-primary-surface
+decomposition: atomic
+owners: [docs, architect]
+---
+
+# B-0299 - Wiki seed pages and boundaries
+
+Name the initial GitHub Wiki pages and define what belongs on
+the Wiki versus the primary GitHub Pages surface.
+
+## Acceptance criteria
+
+- Initial Wiki pages are named and mapped to canonical repo
+  source material.
+- Pages-vs-Wiki content boundaries are explicit.
+- The Wiki role is framed as a second surface after Pages, not
+  a replacement for the primary public site.
+- Human-facing rendering goals are documented for internal
+  markdown substrate selected for Wiki exposure.

--- a/docs/backlog/P1/B-0300-github-wiki-sync-mode-and-indexing-validation-2026-05-08.md
+++ b/docs/backlog/P1/B-0300-github-wiki-sync-mode-and-indexing-validation-2026-05-08.md
@@ -1,0 +1,28 @@
+---
+id: B-0300
+priority: P1
+status: open
+title: "GitHub Wiki integration - sync mode and indexing validation"
+created: 2026-05-08
+last_updated: 2026-05-08
+parent: B-0237
+depends_on: [B-0299]
+classification: blocked-on-wiki-seed-plan
+decomposition: atomic
+owners: [docs, qa]
+---
+
+# B-0300 - Wiki sync and indexing validation
+
+Choose the GitHub Wiki integration mode and define the checks
+that prove Wiki discovery is real before assigning SEO credit to
+the Wiki lane.
+
+## Acceptance criteria
+
+- Integration mode is selected: repo-source-to-wiki or
+  wiki-canonical-with-repo snapshot.
+- Sync ownership and update cadence are documented.
+- Wiki indexing preconditions are listed before launch.
+- Validation distinguishes Pages search success from Wiki search
+  success.


### PR DESCRIPTION
## Summary
- mark B-0237 as decomposed and add child links
- add B-0299 for Wiki seed pages and Pages/Wiki boundaries
- add B-0300 for Wiki sync mode and indexing validation
- refresh docs/BACKLOG.md from the generator

## Checks
- bun tools/backlog/generate-index.ts --check
- git diff --check
- npx markdownlint-cli2 docs/backlog/P1/B-0237-github-wiki-first-class-integration-2026-05-06.md docs/backlog/P1/B-0299-github-wiki-seed-pages-and-boundaries-2026-05-08.md docs/backlog/P1/B-0300-github-wiki-sync-mode-and-indexing-validation-2026-05-08.md docs/BACKLOG.md