### PR TITLE
feat(tools): add refresh worldview scaffold

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -99,7 +99,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0251](backlog/P1/B-0251-durable-computation-stack-temporal-reaqtor-orleans-bonsai-research-2026-05-07.md)** Durable computation stack research — Temporal + Reaqtor + Orleans + Bonsai composition for DurabilityMode.StableStorage
 - [ ] **[B-0255](backlog/P1/B-0255-probabilistic-dials-existing-posterior-quorum-substrate-2026-05-07.md)** Probabilistic dials over existing posterior quorum substrate
 - [ ] **[B-0256](backlog/P1/B-0256-model-recursion-exploit-class-metasploit-ida-pro-mapping-2026-05-07.md)** Model recursion exploit class — Metasploit/IDA Pro mapping for AI models
-- [ ] **[B-0262](backlog/P1/B-0262-refresh-worldview-scaffold-open-prs-recent-merges-2026-05-08.md)** refresh-worldview scaffold — open-PR list + recent-merges query
+- [x] **[B-0262](backlog/P1/B-0262-refresh-worldview-scaffold-open-prs-recent-merges-2026-05-08.md)** refresh-worldview scaffold - open-PR list + recent-merges query
 - [ ] **[B-0263](backlog/P1/B-0263-refresh-worldview-backlog-delta-claims-branch-state-2026-05-08.md)** refresh-worldview — backlog delta + claim inventory + branch state
 - [ ] **[B-0264](backlog/P1/B-0264-refresh-worldview-tick-integration-canonical-pre-decide-2026-05-08.md)** refresh-worldview — integrate into tick scripts as canonical pre-decide
 - [ ] **[B-0265](backlog/P1/B-0265-ruleset-split-ci-gate-ruleset-2026-05-08.md)** GitHub ruleset split — CI gate ruleset (required status checks)
@@ -119,7 +119,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0279](backlog/P1/B-0279-durable-computation-checkpoint-interface-extension-2026-05-08.md)** Durable computation — extend Checkpoint.fs with StableStorage mode
 - [ ] **[B-0284](backlog/P1/B-0284-pages-seo-metadata-jsonld-social-preview-2026-05-08.md)** Pages discoverability - SEO metadata, JSON-LD, and social previews
 - [ ] **[B-0285](backlog/P1/B-0285-pages-sitemap-robots-ai-crawler-policy-2026-05-08.md)** Pages discoverability - sitemap, robots, and AI crawler policy
-- [ ] **[B-0287](backlog/P1/B-0287-ace-dlc-package-format-spec-2026-05-08.md)** Ace DLC — package format specification
+- [x] **[B-0287](backlog/P1/B-0287-ace-dlc-package-format-spec-2026-05-08.md)** Ace DLC — package format specification
 - [ ] **[B-0288](backlog/P1/B-0288-ace-dlc-package-manager-cli-2026-05-08.md)** Ace DLC — package manager CLI (install/verify/list)
 - [ ] **[B-0290](backlog/P1/B-0290-green-lantern-consent-gate-firmware-2026-05-08.md)** Green Lantern ring — consent gate firmware design
 - [ ] **[B-0291](backlog/P1/B-0291-concordance-ai-corpus-pipeline-2026-05-08.md)** Concordance AI — corpus ingestion + tokenization pipeline

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -251,7 +251,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0254](backlog/P2/B-0254-infernet-probabilistic-triangulation-posterior-quorum-2026-05-07.md)** Posterior quorum triangulation over existing Bayesian DBSP substrate
 - [ ] **[B-0283](backlog/P2/B-0283-interloop-messaging-protocol-design-2026-05-08.md)** Interloop messaging — protocol design (message types + delivery)
 - [ ] **[B-0284](backlog/P2/B-0284-interloop-messaging-implementation-2026-05-08.md)** Interloop messaging — implementation on chosen transport
-- [ ] **[B-0285](backlog/P2/B-0285-arc4-selfplay-arena-design-2026-05-08.md)** ARC-4 — adversarial self-play arena design
+- [x] **[B-0285](backlog/P2/B-0285-arc4-selfplay-arena-design-2026-05-08.md)** ARC-4 — adversarial self-play arena design
 - [ ] **[B-0286](backlog/P2/B-0286-arc4-selfplay-implementation-2026-05-08.md)** ARC-4 — self-play implementation + training loop
 
 ## P3 — convenience / deferred

--- a/docs/backlog/P1/B-0262-refresh-worldview-scaffold-open-prs-recent-merges-2026-05-08.md
+++ b/docs/backlog/P1/B-0262-refresh-worldview-scaffold-open-prs-recent-merges-2026-05-08.md
@@ -1,17 +1,18 @@
 ---
 id: B-0262
 priority: P1
-status: open
-title: "refresh-worldview scaffold — open-PR list + recent-merges query"
+status: closed
+title: "refresh-worldview scaffold - open-PR list + recent-merges query"
 created: 2026-05-08
 last_updated: 2026-05-08
+closed_by: "tools/refresh-github-worldview/refresh.ts"
 parent: B-0159
 depends_on: []
 classification: buildable-now
 decomposition: atomic
 ---
 
-# B-0262 — refresh-worldview scaffold
+# B-0262 - refresh-worldview scaffold
 
 First child of B-0159. Create `tools/refresh-github-worldview/refresh.ts`
 with two queries:

--- a/tools/refresh-github-worldview/refresh.ts
+++ b/tools/refresh-github-worldview/refresh.ts
@@ -1,0 +1,138 @@
+#!/usr/bin/env bun
+import { spawnSync } from "node:child_process";
+
+interface CommandResult {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+interface RecentMerge {
+  oid: string;
+  parents: string[];
+  author: string;
+  authoredAt: string;
+  subject: string;
+}
+
+interface WorldviewSnapshot {
+  generatedAt: string;
+  repository: string;
+  recentMergeRange: string;
+  prs: unknown[];
+  recentMerges: RecentMerge[];
+}
+
+function run(command: string, args: string[]): CommandResult {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  return {
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim(),
+    status: result.status ?? 1,
+  };
+}
+
+function fail(message: string, result: CommandResult): never {
+  const detail = result.stderr || result.stdout || "no output";
+  console.error(`${message}: ${detail}`);
+  process.exit(1);
+}
+
+function readOpenPullRequests(repository: string): unknown[] {
+  const fields = [
+    "number",
+    "title",
+    "headRefName",
+    "baseRefName",
+    "state",
+    "isDraft",
+    "mergeStateStatus",
+    "reviewDecision",
+    "url",
+    "updatedAt",
+    "author",
+  ].join(",");
+
+  const result = run("gh", [
+    "pr",
+    "list",
+    "--repo",
+    repository,
+    "--state",
+    "open",
+    "--limit",
+    "100",
+    "--json",
+    fields,
+  ]);
+
+  if (result.status !== 0) {
+    fail("failed to query open pull requests", result);
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(result.stdout || "[]");
+    if (!Array.isArray(parsed)) {
+      throw new Error("expected array");
+    }
+    return parsed;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`failed to parse gh JSON: ${message}`);
+    process.exit(1);
+  }
+}
+
+function readRecentMerges(range: string): RecentMerge[] {
+  const result = run("git", [
+    "log",
+    range,
+    "--format=%H%x1f%P%x1f%an%x1f%aI%x1f%s",
+  ]);
+
+  if (result.status !== 0) {
+    fail("failed to query recent merges", result);
+  }
+
+  if (result.stdout.length === 0) {
+    return [];
+  }
+
+  return result.stdout.split("\n").map((line) => {
+    const [oid, parents, author, authoredAt, subject] = line.split("\x1f");
+    if (!oid || !parents || !author || !authoredAt || subject === undefined) {
+      throw new Error(`unexpected git log row: ${line}`);
+    }
+    return {
+      oid,
+      parents: parents.length === 0 ? [] : parents.split(" "),
+      author,
+      authoredAt,
+      subject,
+    };
+  });
+}
+
+function main(): void {
+  const repository =
+    process.env.ZETA_GITHUB_REPOSITORY ??
+    process.env.GITHUB_REPOSITORY ??
+    "Lucent-Financial-Group/Zeta";
+  const recentMergeRange = process.env.ZETA_WORLDVIEW_RECENT_RANGE ?? "origin/main..HEAD";
+
+  const snapshot: WorldviewSnapshot = {
+    generatedAt: new Date().toISOString(),
+    repository,
+    recentMergeRange,
+    prs: readOpenPullRequests(repository),
+    recentMerges: readRecentMerges(recentMergeRange),
+  };
+
+  console.log(JSON.stringify(snapshot, null, 2));
+}
+
+main();

--- a/tools/refresh-github-worldview/refresh.ts
+++ b/tools/refresh-github-worldview/refresh.ts
@@ -62,32 +62,61 @@ function fail(message: string, result: CommandResult): never {
   process.exit(1);
 }
 
+function parseRepository(repository: string): { owner: string; name: string } {
+  const [owner, name, extra] = repository.split("/");
+  if (!owner || !name || extra !== undefined) {
+    console.error(`invalid GitHub repository '${repository}', expected owner/name`);
+    process.exit(1);
+  }
+  return { owner, name };
+}
+
 function readOpenPullRequests(repository: string): unknown[] {
-  const fields = [
-    "number",
-    "title",
-    "headRefName",
-    "baseRefName",
-    "state",
-    "isDraft",
-    "mergeStateStatus",
-    "reviewDecision",
-    "url",
-    "updatedAt",
-    "author",
-  ].join(",");
+  const { owner, name } = parseRepository(repository);
+  const query = `
+    query($owner: String!, $name: String!, $endCursor: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequests(
+          first: 100
+          after: $endCursor
+          states: OPEN
+          orderBy: { field: UPDATED_AT, direction: DESC }
+        ) {
+          nodes {
+            number
+            title
+            headRefName
+            baseRefName
+            state
+            isDraft
+            mergeStateStatus
+            reviewDecision
+            url
+            updatedAt
+            author {
+              login
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  `;
 
   const result = run("gh", [
-    "pr",
-    "list",
-    "--repo",
-    repository,
-    "--state",
-    "open",
-    "--limit",
-    "100",
-    "--json",
-    fields,
+    "api",
+    "graphql",
+    "--paginate",
+    "--slurp",
+    "-F",
+    `owner=${owner}`,
+    "-F",
+    `name=${name}`,
+    "-f",
+    `query=${query}`,
   ]);
 
   if (result.status !== 0) {
@@ -95,11 +124,28 @@ function readOpenPullRequests(repository: string): unknown[] {
   }
 
   try {
-    const parsed: unknown = JSON.parse(result.stdout || "[]");
-    if (!Array.isArray(parsed)) {
-      throw new Error("expected array");
+    const pages: unknown = JSON.parse(result.stdout || "[]");
+    if (!Array.isArray(pages)) {
+      throw new Error("expected paginated array");
     }
-    return parsed;
+    return pages.flatMap((page) => {
+      if (typeof page !== "object" || page === null || !("data" in page)) {
+        throw new Error("expected GraphQL page object");
+      }
+      const pageRecord = page as Record<string, unknown>;
+      const data = pageRecord.data as {
+        repository?: {
+          pullRequests?: {
+            nodes?: unknown[];
+          };
+        };
+      };
+      const nodes = data.repository?.pullRequests?.nodes;
+      if (!Array.isArray(nodes)) {
+        throw new Error("expected pullRequests.nodes array");
+      }
+      return nodes;
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`failed to parse gh JSON: ${message}`);

--- a/tools/refresh-github-worldview/refresh.ts
+++ b/tools/refresh-github-worldview/refresh.ts
@@ -1,10 +1,14 @@
 #!/usr/bin/env bun
 import { spawnSync } from "node:child_process";
 
+const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+
 interface CommandResult {
   stdout: string;
   stderr: string;
   status: number;
+  error: string | undefined;
+  signal: NodeJS.Signals | null;
 }
 
 interface RecentMerge {
@@ -24,20 +28,36 @@ interface WorldviewSnapshot {
 }
 
 function run(command: string, args: string[]): CommandResult {
+  // Shelling out is intentional here: gh owns GitHub auth and git owns
+  // repository history. Args are fixed arrays, never shell-interpolated.
   const result = spawnSync(command, args, {
     encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
     stdio: ["ignore", "pipe", "pipe"],
   });
 
+  const stdout = typeof result.stdout === "string" ? result.stdout : "";
+  const stderr = typeof result.stderr === "string" ? result.stderr : "";
+  let error: string | undefined;
+  if (result.error instanceof Error) {
+    error = result.error.message;
+  }
+
   return {
-    stdout: result.stdout.trim(),
-    stderr: result.stderr.trim(),
+    stdout: stdout.trim(),
+    stderr: stderr.trim(),
     status: result.status ?? 1,
+    error,
+    signal: result.signal,
   };
 }
 
 function fail(message: string, result: CommandResult): never {
-  const detail = result.stderr || result.stdout || "no output";
+  const signal = result.signal ? `terminated by signal ${result.signal}` : "";
+  const detail =
+    [result.stderr, result.stdout, result.error, signal].find(
+      (candidate) => candidate !== undefined && candidate.length > 0,
+    ) ?? "no output";
   console.error(`${message}: ${detail}`);
   process.exit(1);
 }
@@ -91,6 +111,9 @@ function readRecentMerges(range: string): RecentMerge[] {
   const result = run("git", [
     "log",
     range,
+    "--merges",
+    "--first-parent",
+    "--max-count=25",
     "--format=%H%x1f%P%x1f%an%x1f%aI%x1f%s",
   ]);
 
@@ -117,12 +140,12 @@ function readRecentMerges(range: string): RecentMerge[] {
   });
 }
 
-function main(): void {
+export function main(): 0 {
   const repository =
     process.env.ZETA_GITHUB_REPOSITORY ??
     process.env.GITHUB_REPOSITORY ??
     "Lucent-Financial-Group/Zeta";
-  const recentMergeRange = process.env.ZETA_WORLDVIEW_RECENT_RANGE ?? "origin/main..HEAD";
+  const recentMergeRange = process.env.ZETA_WORLDVIEW_RECENT_RANGE ?? "origin/main";
 
   const snapshot: WorldviewSnapshot = {
     generatedAt: new Date().toISOString(),
@@ -133,6 +156,9 @@ function main(): void {
   };
 
   console.log(JSON.stringify(snapshot, null, 2));
+  return 0;
 }
 
-main();
+if (import.meta.main) {
+  process.exit(main());
+}


### PR DESCRIPTION
## Summary
- add tools/refresh-github-worldview/refresh.ts
- query open PRs via gh and recent branch commits via git log origin/main..HEAD
- emit one JSON object with prs[] and recentMerges[]
- close B-0262 and refresh docs/BACKLOG.md

## Checks
- bun tools/refresh-github-worldview/refresh.ts | jq -e '(.prs | type == "array") and (.recentMerges | type == "array")'
- bun tools/backlog/generate-index.ts --check
- git diff --check
- bun run typecheck
- bunx eslint tools/refresh-github-worldview/refresh.ts
- npx markdownlint-cli2 docs/backlog/P1/B-0262-refresh-worldview-scaffold-open-prs-recent-merges-2026-05-08.md docs/BACKLOG.md