### PR TITLE
fix(backlog): complete B-0278 autonomous priority selector

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -17,7 +17,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0109](backlog/P0/B-0109-dependency-status-tracking-surface-2026-04-30.md)** Dependency status tracking surface — outages and issues affecting us (Aaron 2026-04-30, urgent)
 - [ ] **[B-0160](backlog/P0/B-0160-mechanical-authorization-check-skill-build-claudeai-2026-05-02.md)** Mechanical authorization check skill build — pace-instruction resolver per Claude.ai 2026-05-02 architectural correction
 - [ ] **[B-0249](backlog/P0/B-0249-autonomous-backlog-pickup-self-sustaining-new-work-2026-05-07.md)** Autonomous backlog pickup — loops must start new work, not just maintain
-- [ ] **[B-0278](backlog/P0/B-0278-autonomous-backlog-selector-priority-safe-pickup-2026-05-08.md)** Autonomous backlog pickup - priority selector
+- [x] **[B-0278](backlog/P0/B-0278-autonomous-backlog-selector-priority-safe-pickup-2026-05-08.md)** Autonomous backlog pickup - priority selector
 - [ ] **[B-0279](backlog/P0/B-0279-autonomous-backlog-claim-worktree-bootstrap-2026-05-08.md)** Autonomous backlog pickup - claim and worktree bootstrap
 - [ ] **[B-0280](backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md)** Autonomous backlog pickup - PR publication and auto-merge
 - [ ] **[B-0281](backlog/P0/B-0281-codex-loop-empty-queue-backlog-pickup-integration-2026-05-08.md)** Codex loop - empty queue autonomous backlog pickup
@@ -115,7 +115,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0275](backlog/P1/B-0275-pages-astro-http-200-and-deploy-validation-2026-05-08.md)** Pages discoverability - Astro deploy validation and HTTP 200 check
 - [ ] **[B-0276](backlog/P1/B-0276-structure-recognizer-fingerprint-library-2026-05-08.md)** Structure recognizer — fingerprint library for codebase shapes
 - [ ] **[B-0277](backlog/P1/B-0277-structure-recognizer-catalog-index-2026-05-08.md)** Structure recognizer — shape-indexed catalog without labels
-- [ ] **[B-0278](backlog/P1/B-0278-durable-computation-survey-8-systems-2026-05-08.md)** Durable computation survey — compare 8 systems against Zeta's gap
+- [x] **[B-0278](backlog/P1/B-0278-durable-computation-survey-8-systems-2026-05-08.md)** Durable computation survey — compare 8 systems against Zeta's gap
 - [ ] **[B-0279](backlog/P1/B-0279-durable-computation-checkpoint-interface-extension-2026-05-08.md)** Durable computation — extend Checkpoint.fs with StableStorage mode
 - [ ] **[B-0284](backlog/P1/B-0284-pages-seo-metadata-jsonld-social-preview-2026-05-08.md)** Pages discoverability - SEO metadata, JSON-LD, and social previews
 - [ ] **[B-0285](backlog/P1/B-0285-pages-sitemap-robots-ai-crawler-policy-2026-05-08.md)** Pages discoverability - sitemap, robots, and AI crawler policy

--- a/docs/backlog/P0/B-0278-autonomous-backlog-selector-priority-safe-pickup-2026-05-08.md
+++ b/docs/backlog/P0/B-0278-autonomous-backlog-selector-priority-safe-pickup-2026-05-08.md
@@ -1,7 +1,9 @@
 ---
 id: B-0278
 priority: P0
-status: open
+status: closed
+closed: 2026-05-08
+closed_by: "tools/backlog/autonomous-pickup.ts priority/age selector, open-child/open-PR claim filtering, decompose-first action, and focused tests"
 title: "Autonomous backlog pickup - priority selector"
 created: 2026-05-08
 last_updated: 2026-05-08

--- a/tools/backlog/autonomous-pickup.test.ts
+++ b/tools/backlog/autonomous-pickup.test.ts
@@ -7,6 +7,9 @@ function item(partial: Partial<BacklogItem> & Pick<BacklogItem, "id" | "priority
     status: "open",
     relativePath: `docs/backlog/${partial.priority}/${partial.id}.md`,
     dependsOn: [],
+    parent: null,
+    created: null,
+    lastUpdated: null,
     decomposition: null,
     bodyLineCount: 20,
     ...partial,
@@ -44,7 +47,7 @@ describe("selectNextBacklogItem", () => {
 
     expect(selection.status).toBe("selected");
     expect(selection.selected?.id).toBe("B-0249");
-    expect(selection.action).toBe("decompose");
+    expect(selection.action).toBe("decompose-first");
     expect(selection.executionPrompt).toContain("Decompose B-0249");
   });
 
@@ -63,7 +66,7 @@ describe("selectNextBacklogItem", () => {
 
     expect(selection.status).toBe("selected");
     expect(selection.selected?.id).toBe("B-0062");
-    expect(selection.action).toBe("decompose");
+    expect(selection.action).toBe("decompose-first");
   });
 
   test("blocks rows with open dependencies", () => {
@@ -98,5 +101,57 @@ describe("selectNextBacklogItem", () => {
     expect(selection.status).toBe("selected");
     expect(selection.selected?.id).toBe("B-0109");
     expect(selection.blocked[0]?.reason).toContain("claim/backlog-0062-wallet");
+  });
+
+  test("orders equal-priority candidates by creation age before item number", () => {
+    const selection = selectNextBacklogItem(
+      [
+        item({
+          id: "B-0001",
+          priority: "P1",
+          title: "newer lower id",
+          created: "2026-05-08",
+        }),
+        item({
+          id: "B-9999",
+          priority: "P1",
+          title: "older higher id",
+          created: "2026-04-30",
+        }),
+      ],
+      [],
+    );
+
+    expect(selection.status).toBe("selected");
+    expect(selection.selected?.id).toBe("B-9999");
+  });
+
+  test("skips decomposed parents while open children remain", () => {
+    const selection = selectNextBacklogItem(
+      [
+        item({
+          id: "B-0249",
+          priority: "P0",
+          title: "parent",
+          decomposition: "decomposed",
+        }),
+        item({
+          id: "B-0278",
+          priority: "P0",
+          title: "child",
+          parent: "B-0249",
+        }),
+        item({
+          id: "B-0300",
+          priority: "P1",
+          title: "fallback",
+        }),
+      ],
+      [],
+    );
+
+    expect(selection.status).toBe("selected");
+    expect(selection.selected?.id).toBe("B-0278");
+    expect(selection.blocked[0]?.reason).toContain("open child B-0278");
   });
 });

--- a/tools/backlog/autonomous-pickup.ts
+++ b/tools/backlog/autonomous-pickup.ts
@@ -6,12 +6,12 @@
 // when the PR queue is empty, what is the next backlog item a loop may safely
 // decompose or claim?
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
 type Priority = "P0" | "P1" | "P2" | "P3";
-type Action = "decompose" | "claim-and-implement";
+type Action = "decompose-first" | "claim-and-implement";
 
 export interface BacklogItem {
   id: string;
@@ -20,6 +20,9 @@ export interface BacklogItem {
   title: string;
   relativePath: string;
   dependsOn: string[];
+  parent: string | null;
+  created: string | null;
+  lastUpdated: string | null;
   decomposition: string | null;
   bodyLineCount: number;
 }
@@ -56,6 +59,7 @@ const PRIORITY_RANK: Record<Priority, number> = {
   P3: 3,
 };
 const GIT_BIN = "/usr/bin/git";
+const GH_BINS = ["/opt/homebrew/bin/gh", "/usr/bin/gh"] as const;
 
 function usage(): string {
   return [
@@ -301,19 +305,44 @@ export function readBacklogItems(repoRoot: string): BacklogItem[] {
         title,
         relativePath: relative(repoRoot, absolutePath).split("\\").join("/"),
         dependsOn: asStringList(frontmatter.depends_on),
+        parent: asString(frontmatter.parent) || null,
+        created: asString(frontmatter.created) || null,
+        lastUpdated: asString(frontmatter.last_updated) || null,
         decomposition: asString(frontmatter.decomposition) || null,
         bodyLineCount: content.split(/\r?\n/).length,
       });
     }
   }
 
-  return items.sort((a, b) => {
-    const priorityDelta = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
-    if (priorityDelta !== 0) {
-      return priorityDelta;
-    }
-    return itemNumber(a.id) - itemNumber(b.id);
-  });
+  return items.sort(compareBacklogItems);
+}
+
+function ageKey(item: BacklogItem): string {
+  return item.created ?? item.lastUpdated ?? "9999-12-31";
+}
+
+function compareAge(a: BacklogItem, b: BacklogItem): number {
+  const createdDelta = ageKey(a).localeCompare(ageKey(b));
+  if (createdDelta !== 0) {
+    return createdDelta;
+  }
+  const updatedDelta = (a.lastUpdated ?? "9999-12-31").localeCompare(b.lastUpdated ?? "9999-12-31");
+  if (updatedDelta !== 0) {
+    return updatedDelta;
+  }
+  return 0;
+}
+
+function compareBacklogItems(a: BacklogItem, b: BacklogItem): number {
+  const priorityDelta = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
+  if (priorityDelta !== 0) {
+    return priorityDelta;
+  }
+  const ageDelta = compareAge(a, b);
+  if (ageDelta !== 0) {
+    return ageDelta;
+  }
+  return itemNumber(a.id) - itemNumber(b.id);
 }
 
 function isOpen(status: string): boolean {
@@ -327,7 +356,7 @@ function isClosed(status: string | undefined): boolean {
   return status === "closed" || status.startsWith("superseded-by-");
 }
 
-function dependencyBlocker(item: BacklogItem, byId: Map<string, BacklogItem>): string | null {
+function dependencyBlocker(item: BacklogItem, byId: ReadonlyMap<string, BacklogItem>): string | null {
   for (const dependency of item.dependsOn) {
     const depItem = byId.get(dependency);
     if (!depItem) {
@@ -354,18 +383,59 @@ function claimBlocker(item: BacklogItem, activeClaims: readonly string[]): strin
   return claim ? `active claim ${claim}` : null;
 }
 
+function decomposedParentBlocker(
+  item: BacklogItem,
+  openChildrenByParent: ReadonlyMap<string, readonly BacklogItem[]>,
+): string | null {
+  if (item.decomposition !== "decomposed") {
+    return null;
+  }
+  const openChildren = openChildrenByParent.get(item.id) ?? [];
+  if (openChildren.length === 0) {
+    return null;
+  }
+  const childIds = openChildren.map((child) => child.id).sort((a, b) => a.localeCompare(b));
+  return `decomposed parent has open child ${childIds.join(", ")}`;
+}
+
+function openChildrenByParent(items: readonly BacklogItem[]): Map<string, BacklogItem[]> {
+  const grouped = new Map<string, BacklogItem[]>();
+  for (const item of items) {
+    if (item.parent === null || !isOpen(item.status)) {
+      continue;
+    }
+    const children = grouped.get(item.parent) ?? [];
+    children.push(item);
+    grouped.set(item.parent, children);
+  }
+  return grouped;
+}
+
+function itemBlocker(
+  item: BacklogItem,
+  byId: ReadonlyMap<string, BacklogItem>,
+  childrenByParent: ReadonlyMap<string, readonly BacklogItem[]>,
+  activeClaims: readonly string[],
+): string | null {
+  return (
+    decomposedParentBlocker(item, childrenByParent) ??
+    dependencyBlocker(item, byId) ??
+    claimBlocker(item, activeClaims)
+  );
+}
+
 function actionFor(item: BacklogItem): Action {
   if (item.decomposition === "atomic" || item.decomposition === "decomposed") {
     return "claim-and-implement";
   }
   return item.decomposition === "blob" || item.bodyLineCount >= BLOB_LINE_THRESHOLD
-    ? "decompose"
+    ? "decompose-first"
     : "claim-and-implement";
 }
 
 function promptFor(item: BacklogItem, action: Action): string {
   const lead =
-    action === "decompose"
+    action === "decompose-first"
       ? `Decompose ${item.id} into the smallest dependency-ordered atomic child backlog rows.`
       : `Claim and implement the smallest safe slice of ${item.id}.`;
   return [
@@ -391,13 +461,8 @@ export function selectNextBacklogItem(
   const byId = new Map(items.map((item) => [item.id, item]));
   const blocked: BlockedItem[] = [];
   const maxRank = PRIORITY_RANK[maxPriority];
-  const sortedItems = [...items].sort((a, b) => {
-    const priorityDelta = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
-    if (priorityDelta !== 0) {
-      return priorityDelta;
-    }
-    return itemNumber(a.id) - itemNumber(b.id);
-  });
+  const childrenByParent = openChildrenByParent(items);
+  const sortedItems = [...items].sort(compareBacklogItems);
 
   for (const item of sortedItems) {
     if (PRIORITY_RANK[item.priority] > maxRank) {
@@ -407,15 +472,9 @@ export function selectNextBacklogItem(
       continue;
     }
 
-    const dependencyReason = dependencyBlocker(item, byId);
-    if (dependencyReason !== null) {
-      blocked.push({ item, reason: dependencyReason });
-      continue;
-    }
-
-    const claimReason = claimBlocker(item, activeClaims);
-    if (claimReason !== null) {
-      blocked.push({ item, reason: claimReason });
+    const blockedReason = itemBlocker(item, byId, childrenByParent, activeClaims);
+    if (blockedReason !== null) {
+      blocked.push({ item, reason: blockedReason });
       continue;
     }
 
@@ -425,7 +484,7 @@ export function selectNextBacklogItem(
       selected: item,
       action,
       reason:
-        action === "decompose"
+        action === "decompose-first"
           ? "highest-priority open item needs decomposition before implementation"
           : "highest-priority open unclaimed item with satisfied dependencies",
       blocked,
@@ -472,6 +531,51 @@ function readActiveClaims(repoRoot: string): string[] {
   return [...new Set([...remoteClaims, ...localClaims])].sort((a, b) => a.localeCompare(b));
 }
 
+function ghBin(): string | null {
+  return GH_BINS.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+function readOpenPrClaims(repoRoot: string): string[] {
+  const gh = ghBin();
+  if (gh === null) {
+    return [];
+  }
+
+  const result = spawnSync(
+    gh,
+    ["pr", "list", "--state", "open", "--limit", "1000", "--json", "number,headRefName,title"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    },
+  );
+  if (result.status !== 0) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout) as {
+      number?: number;
+      headRefName?: string;
+      title?: string;
+    }[];
+    return parsed.flatMap((pr) => {
+      const claims: string[] = [];
+      if (pr.headRefName !== undefined && pr.headRefName.trim().length > 0) {
+        claims.push(pr.headRefName.trim());
+      }
+      if (pr.title !== undefined && pr.title.trim().length > 0) {
+        const numberLabel = typeof pr.number === "number" ? pr.number.toString() : "unknown";
+        claims.push(`pr-${numberLabel}:${pr.title.trim()}`);
+      }
+      return claims;
+    });
+  } catch {
+    return [];
+  }
+}
+
 function printText(selection: PickupSelection): void {
   if (selection.status === "empty") {
     process.stdout.write(`no-pick: ${selection.reason}\n`);
@@ -498,7 +602,10 @@ export function main(argv: string[]): number {
 
   const items = readBacklogItems(args.repoRoot);
   const gitClaims = args.noGitClaims ? [] : readActiveClaims(args.repoRoot);
-  const activeClaims = [...new Set([...gitClaims, ...args.activeClaim])].sort((a, b) => a.localeCompare(b));
+  const openPrClaims = args.noGitClaims ? [] : readOpenPrClaims(args.repoRoot);
+  const activeClaims = [...new Set([...gitClaims, ...openPrClaims, ...args.activeClaim])].sort((a, b) =>
+    a.localeCompare(b),
+  );
   const selection = selectNextBacklogItem(items, activeClaims, args.maxPriority);
 
   if (args.json) {


### PR DESCRIPTION
## Summary
- complete B-0278 selector semantics: priority then creation/update age, decompose-first action, decomposed-parent/open-child skip, and open PR branch/title claims
- close B-0278 and regenerate docs/BACKLOG.md
- add focused tests for equal-priority age ordering and decomposed-parent child blocking

## Checks
- bun run typecheck
- bunx eslint tools/backlog/autonomous-pickup.ts tools/backlog/autonomous-pickup.test.ts
- bun test tools/backlog/autonomous-pickup.test.ts
- BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts && bun tools/backlog/generate-index.ts --check
- bun tools/backlog/autonomous-pickup.ts --json | jq '{status, action, selected: .selected.id, reason}'\n- git diff --check\n\nCloses B-0278.