### PR TITLE
fix(wallet): land B-0062 monitor-signed signal slice

### DIFF
--- a/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
+++ b/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
@@ -7,7 +7,7 @@ tier: wallet-experiment-v0
 effort: L
 ask: maintainer Aaron 2026-04-28 ("bulk-resolve what is buld resolve does it actually answer the questions? or does it just close them? have they been answered?") — surfaced that ~15 PR #72 wallet-spec review threads were resolved with "deferred to v0 build-out" replies but no concrete tracking. This row IS the concrete tracking.
 created: 2026-04-28
-last_updated: 2026-05-07
+last_updated: 2026-05-08
 decomposition: decomposed
 depends_on: []
 composes_with: [B-0060, B-0061]
@@ -179,16 +179,16 @@ it (closed-thread links survive in the PR's review history).
     from (oracle? monitor-signed message? bond escrow?).
     Pick one.
 
-    **Proposed (Otto 2026-05-07):** Monitor-signed
+    **Resolved (Vera 2026-05-08):** Monitor-signed
     classification message — same pattern as the drawdown
     oracle. Monitor classifies Tx N, signs the result,
     posts to smart-account. Contract checks for signed
     classification before allowing Tx N+1. Minimum signed
     payload: `chainId`, smart-account address, Tx N
     identifier, classification value, monotonic nonce or
-    round, and expiry. Single pattern for both drawdown and
-    classification: monitor signs, contract verifies
-    signature + reads value + freshness.
+    round, and expiry. The wallet v0 spec now lands this in
+    §7.1: monitor signs, contract verifies signature +
+    reads value + freshness before Tx N+1 is allowed.
 
 ### Spec-logic — drawdown oracle + glass-halo logging
 
@@ -199,7 +199,7 @@ it (closed-thread links survive in the PR's review history).
     oracle (Chainlink? own pricing oracle? off-chain
     monitor-signed update?). Spec needs the choice.
 
-    **Proposed (Otto 2026-05-07):** Monitor-signed price
+    **Resolved (Vera 2026-05-08):** Monitor-signed price
     update. The off-chain monitor already watches drawdown;
     it signs its price observation and posts to the
     smart-account. No Chainlink dependency (external vendor
@@ -207,9 +207,9 @@ it (closed-thread links survive in the PR's review history).
     (complexity). The monitor IS the oracle — it just signs.
     Minimum signed payload: asset identifier, price,
     decimals, `chainId`, smart-account address, monotonic
-    nonce or round, and timestamp + expiry. Revisable at
-    v0+1 if Chainlink or custom oracle adds value at larger
-    scale.
+    nonce or round, and timestamp + expiry. The wallet v0
+    spec now lands this in §5.5. Revisable at v0+1 if
+    Chainlink or custom oracle adds value at larger scale.
 2. **Move glass-halo logging gate out of smart-contract
     enforcement** (cid 3151362886 P1). The spec currently
     makes "logging failure ⇒ tx fails" an on-chain
@@ -311,7 +311,7 @@ comments.
 
 ## Progress (2026-05-07 session)
 
-8 of 21 items resolved via doc reconciliation:
+10 of 21 items resolved via doc reconciliation:
 
 + PR #1907: 3 stale "open question" refs → resolved
 + PR #1908: EAT Task B monitor → sibling-repo
@@ -321,11 +321,12 @@ comments.
 + PR #1924: Ledger update (Vera)
 + PR #1927: EAT retraction-coverage metric aligned
 + §15 send-readiness already reconciled (prior pass)
++ Vera 2026-05-08: drawdown oracle landed in wallet spec §5.5
++ Vera 2026-05-08: Tx N+1 classification signal landed in wallet spec §7.1
 
-13 items remain — all P1/P2 design decisions needing
+11 items remain — all P1/P2 design decisions needing
 deeper wallet-domain engagement (preflight terminal
 state, agent self-revocation auth, monitor-stall freeze,
-on-chain classification signal, drawdown oracle,
 glass-halo logging gate, auth for cancellation,
 material-spend criteria, INTENTIONAL-DEBT schema).
 

--- a/docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md
+++ b/docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md
@@ -225,8 +225,20 @@ All caps enforced in smart-account contract code, not in any prompt or off-chain
 ### §5.5 Drawdown freeze
 
 - Trigger: realized + unrealized loss reaches -30% of bond.
-- Enforcement: smart-account checks bond-vs-current-value on every tx; freezes if breached.
-- Off-chain monitor can additionally freeze on stricter threshold (-20%) if monitor logic decides.
+- Enforcement: smart-account checks the latest monitor-signed
+  drawdown observation before every tx; freezes if breached.
+- Off-chain monitor can additionally freeze on stricter threshold
+  (-20%) if monitor logic decides.
+- Oracle source for v0: the off-chain monitor signs a price /
+  mark-to-bond observation and posts it to the smart-account.
+  The smart-account verifies the monitor signature, freshness,
+  mandate scope, and replay guard before using the value. v0
+  deliberately avoids Chainlink and a custom oracle contract at
+  the $100/week bond scale; those can be reconsidered at v0+1 if
+  the bond or venue surface grows.
+- Minimum signed payload: asset identifier, price, decimals,
+  `chainId`, smart-account address, mandate / budget id,
+  monotonic nonce or round, observed-at timestamp, and expiry.
 
 ### §5.6 Hard-coded NEVERs (per EAT packet §9)
 
@@ -287,6 +299,15 @@ All caps enforced in smart-account contract code, not in any prompt or off-chain
 > Transaction N+1 cannot execute until Transaction N has a receipt, classification, and substrate entry.
 
 Enforced at the smart-account layer: a tx-attempt that would be Tx N+1 reverts if Tx N's receipt-classified flag is not set.
+
+The receipt-classified flag is set only by a monitor-signed
+classification message. The off-chain monitor classifies Tx N,
+signs the classification, and posts it to the smart-account; the
+smart-account verifies the monitor signature, freshness, and replay
+guard before allowing Tx N+1. Minimum signed payload: `chainId`,
+smart-account address, tx identifier, classification value, mandate
+/ budget id, monotonic nonce or round, classified-at timestamp, and
+expiry.
 
 ### §7.2 Receipt schema
 


### PR DESCRIPTION
## Summary
- land the B-0062 drawdown oracle decision in wallet spec §5.5
- land the B-0062 Tx N+1 monitor-signed classification signal in wallet spec §7.1
- update B-0062 progress from 8/21 to 10/21 resolved items

## Checks
- BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts && bun tools/backlog/generate-index.ts --check
- bun tools/backlog/generate-index.ts --check
- bunx markdownlint-cli2 docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
- git diff --check

Advances B-0062.