### PR TITLE
fix(wallet): move B-0062 glass-halo gate to monitor

### DIFF
--- a/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
+++ b/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
@@ -217,6 +217,13 @@ it (closed-thread links survive in the PR's review history).
     making it a contract-level gate is a separation-of-
     concerns mistake. Move to off-chain monitor.
 
+    **Resolved (Vera 2026-05-08):** The wallet v0 spec now
+    clarifies §6.1 and §7.1: the smart-account only enforces
+    the monitor-signed classification flag. It does not verify
+    git / glass-halo writes. Missing receipts, failed writes,
+    or tx-broadcast-without-substrate are off-chain monitor
+    anomalies that trigger freeze and receipt-loop catch-up.
+
 ### Acceptance-criteria + auth + metric alignment
 
 1. **Require auth for retraction-queue cancellation** (cid
@@ -311,7 +318,7 @@ comments.
 
 ## Progress (2026-05-07 session)
 
-10 of 21 items resolved via doc reconciliation:
+11 of 21 items resolved via doc reconciliation:
 
 + PR #1907: 3 stale "open question" refs → resolved
 + PR #1908: EAT Task B monitor → sibling-repo
@@ -323,12 +330,13 @@ comments.
 + §15 send-readiness already reconciled (prior pass)
 + Vera 2026-05-08: drawdown oracle landed in wallet spec §5.5
 + Vera 2026-05-08: Tx N+1 classification signal landed in wallet spec §7.1
++ Vera 2026-05-08: glass-halo logging gate moved to monitor freeze path
 
-11 items remain — all P1/P2 design decisions needing
+10 items remain — all P1/P2 design decisions needing
 deeper wallet-domain engagement (preflight terminal
 state, agent self-revocation auth, monitor-stall freeze,
-glass-halo logging gate, auth for cancellation,
-material-spend criteria, INTENTIONAL-DEBT schema).
+auth for cancellation, material-spend criteria,
+INTENTIONAL-DEBT schema).
 
 2026-05-07 red-team correction: PR #1942 briefly marked
 this row closed by trusting a "21/21 addressed" pickup

--- a/docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md
+++ b/docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md
@@ -258,6 +258,8 @@ All caps enforced in smart-account contract code, not in any prompt or off-chain
    - Velocity violation.
    - Allowlist violation.
    - Receipt-loop failure (Tx N+1 attempted before Tx N classified).
+     This is a classification-flag gate, not a git / glass-halo
+     write gate.
    - **Post-broadcast classification stall**: a broadcast tx
      remains unclassified beyond a configurable timeout (default
      60s after broadcast). Anchored at the post-broadcast pipeline
@@ -308,6 +310,15 @@ guard before allowing Tx N+1. Minimum signed payload: `chainId`,
 smart-account address, tx identifier, classification value, mandate
 / budget id, monotonic nonce or round, classified-at timestamp, and
 expiry.
+
+The smart-account does not verify that a git substrate write
+succeeded. Git / glass-halo logging remains off-chain
+infrastructure: if the monitor sees a missing receipt, failed write,
+or tx broadcast without durable substrate, it triggers the independent
+monitor freeze path in §6.1 and requires receipt-loop catch-up before
+unfreeze. This keeps smart-contract enforcement scoped to on-chain
+facts and monitor signatures, while preserving the glass-halo
+invariant through the monitor.
 
 ### §7.2 Receipt schema
 


### PR DESCRIPTION
## Summary
- clarify wallet spec §6.1 and §7.1: smart-account enforces the monitor-signed classification flag, not git/glass-halo writes
- route missing receipts, failed writes, or broadcast-without-substrate to the off-chain monitor freeze path
- update B-0062 progress from 10/21 to 11/21 resolved items

## Checks
- BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts && bun tools/backlog/generate-index.ts --check
- bunx markdownlint-cli2 docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
- git diff --check

Advances B-0062.