### PR TITLE
fix(wallet): land B-0062 monitor-stall freeze

### DIFF
--- a/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
+++ b/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
@@ -170,11 +170,11 @@ it (closed-thread links survive in the PR's review history).
     `freeze-on-monitor-stall` rule + the terminal state
     that the freeze creates.
 
-    **Resolved (Otto 2026-05-07):** The `frozen`
-    terminal state (PR #1935) covers this. Monitor
-    stall triggers `signed → frozen` via the same
-    path as freeze-on-dissent. §9.1 line 550 already
-    says "monitor defaults to freeze-on-stall."
+    **Resolved (Vera 2026-05-08):** The wallet v0 spec now
+    lands this in §6.1 and §9.1. Monitor stall triggers
+    `signed → frozen` before broadcast via the same off-chain
+    monitor path as freeze-on-dissent; unfreeze follows §6.2
+    and requires receipt-loop catch-up.
 2. **Define an on-chain classification signal for Tx N+1
     gating** (cid 3151333578 P1). §7.1 requires the
     smart-account contract to reject Tx N+1 if Tx N's
@@ -323,7 +323,7 @@ comments.
 
 ## Progress (2026-05-07 session)
 
-14 of 21 items resolved via doc reconciliation:
+15 of 21 items resolved via doc reconciliation:
 
 + PR #1907: 3 stale "open question" refs → resolved
 + PR #1908: EAT Task B monitor → sibling-repo
@@ -338,11 +338,11 @@ comments.
 + Vera 2026-05-08: glass-halo logging gate moved to monitor freeze path
 + Vera 2026-05-08: retraction-scoped session-key auth landed in wallet
   spec §3.3/§9.1 for self-revocation and cancellation
++ Vera 2026-05-08: monitor-stall freeze landed in wallet spec §6.1/§9.1
 
-7 items remain — all P1/P2 design decisions needing
+6 items remain — all P1/P2 design decisions needing
 deeper wallet-domain engagement (preflight terminal
-state, monitor-stall freeze, material-spend criteria,
-INTENTIONAL-DEBT schema).
+state, material-spend criteria, INTENTIONAL-DEBT schema).
 
 2026-05-07 red-team correction: PR #1942 briefly marked
 this row closed by trusting a "21/21 addressed" pickup

--- a/docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md
+++ b/docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md
@@ -280,6 +280,11 @@ All caps enforced in smart-account contract code, not in any prompt or off-chain
    - Pattern-detection flags (rapid-fire trades, suspected adversarial counterparty interaction).
    - Substrate logging failures (glass-halo write failed but tx broadcast — anomaly).
    - Reasoning-trace anomalies (agent's stated thesis diverges sharply from actions).
+   - **Pre-broadcast monitor stall**: if the monitor cannot finish
+     its reasoning-trace check within the 60s retraction window,
+     it triggers `freeze-on-stall` before broadcast. The proposal's
+     terminal state is `frozen`, not `broadcast`; unfreeze follows
+     §6.2 and requires receipt-loop catch-up.
    - **Delegate-target drift** (per EIP-7702 sweeper threat model in §3.2): the smart-account's delegate-target SHA must remain on the audited-allowlist; if the delegate-target changes mid-session or points at a non-audited contract, freeze immediately. This catches the 97%-sweeper-contract pattern where compromised EOAs end up delegated to drain contracts.
    - **Phishing-tuple anomaly**: any new 7702 authorization tuple signed by the master EOA mid-session triggers freeze pending review.
 3. **Aaron's direct freeze key**. Triggered by: Aaron decides.


### PR DESCRIPTION
## Summary
- land the B-0062 pre-broadcast monitor-stall freeze path in wallet spec §6.1
- clarify that monitor stall resolves to `frozen`, not `broadcast`, with §6.2 unfreeze + receipt-loop catch-up
- update B-0062 progress from 14/21 to 15/21 resolved items

## Checks
- BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts && bun tools/backlog/generate-index.ts --check
- bunx markdownlint-cli2 docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
- git diff --check

Advances B-0062.