### PR TITLE
fix(wallet): align B-0062 intentional-debt bond ledger

### DIFF
--- a/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
+++ b/docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md
@@ -290,15 +290,17 @@ it (closed-thread links survive in the PR's review history).
     format** (cid 3151337321 P1). Spec proposes recording
     bond entries in a YAML schema; INTENTIONAL-DEBT.md is
     currently a prose/bulleted ledger. Either land the
-
-    **Proposed (Otto 2026-05-07):** Defer YAML schema
-    to v0+1. For v0: define bond entries in the existing
-    prose format. The YAML migration is a separate ADR
-    when tooling justifies the format change. v0 bond
-    scale doesn't need machine-readable schema yet.
     YAML schema migration (separate ADR + tooling), or
     define bond entries in the existing prose format
     until the schema lands.
+
+    **Resolved (Vera 2026-05-08):** Defer YAML schema to
+    v0+1. For v0, wallet spec §8.1 now maps blast-radius
+    bond entries onto the existing `docs/INTENTIONAL-DEBT.md`
+    six-field prose contract. A YAML migration becomes a
+    separate ADR + tooling task only when multiple bonds,
+    assets, or automated accounting make machine-readable
+    schema worth its maintenance cost.
 
 ## Done-criteria
 
@@ -328,7 +330,7 @@ comments.
 
 ## Progress (2026-05-07 session)
 
-18 of 21 items resolved via doc reconciliation:
+19 of 21 items resolved via doc reconciliation:
 
 + PR #1907: 3 stale "open question" refs → resolved
 + PR #1908: EAT Task B monitor → sibling-repo
@@ -348,10 +350,11 @@ comments.
   wallet spec §7.2.1
 + Vera 2026-05-08: preflight `retracted` and `frozen` local proposal
   lifecycle states landed in wallet spec §7.3
++ Vera 2026-05-08: INTENTIONAL-DEBT bond accounting aligned to existing
+  six-field prose ledger format in wallet spec §8.1
 
-3 items remain — all P1/P2 design decisions needing
-deeper wallet-domain engagement (INTENTIONAL-DEBT schema and final
-companion-spec cleanup).
+2 items remain — final companion-spec cleanup requiring
+deeper wallet-domain engagement.
 
 2026-05-07 red-team correction: PR #1942 briefly marked
 this row closed by trusting a "21/21 addressed" pickup

--- a/docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md
+++ b/docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md
@@ -442,27 +442,35 @@ All paths are glass-halo (public, version-controlled, auditable by either party 
 
 ## §8 — Bond accounting
 
-### §8.1 Bond entry schema in `docs/INTENTIONAL-DEBT.md`
+### §8.1 Bond entry format in `docs/INTENTIONAL-DEBT.md`
 
-Schema:
+Wallet v0 does not require a YAML migration of
+`docs/INTENTIONAL-DEBT.md`. For v0, every posted bond lands as a normal
+intentional-debt row using the ledger's existing six-field prose contract.
+The row title should use:
 
-```yaml
-entry_id: wallet-v0-<seq>
-type: blast-radius-bond
-posted_by: aaron
-posted_at: <ISO8601>
-asset: USDC
-value: <decimal>
-purpose: |
-  Wallet experiment v0 — deliberate-tuition bond for mapping
-  blast radius of agent-proposed DEX swaps on Base. v0 scaffold
-  per docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md.
-expected_loss: full
-recovery_curve: |
-  Bond exhaustion → freeze; postmortem required;
-  scaling-threshold review before bond renewal.
-related_receipts: <list of proposal_ids that draw against this bond>
+```markdown
+### <YYYY-MM-DD> — Wallet v0 blast-radius bond <seq>
 ```
+
+The six fields carry the wallet-specific accounting facts:
+
+- **Shortcut:** name the deliberate blast-radius-bond constraint and include
+  `posted_by`, `posted_at`, `asset`, `value`, expected loss (`full` for v0),
+  and the wallet spec path.
+- **Why now:** state why a finite bond is the right v0 risk budget instead of
+  pretending the agent has unbounded operating authority.
+- **Right long-term solution:** describe the un-shortcut version, including a
+  machine-readable bond ledger or contract-indexed accounting if v0+1 scale
+  justifies it.
+- **Trigger:** include bond exhaustion, bond renewal, scaling-threshold review,
+  and the receipt IDs that draw against this bond.
+- **Estimated effort:** `S` for a single v0 row; `M` or `L` if the trigger is
+  schema migration plus tooling.
+- **Filed by:** the agent/persona opening the bond row and the PR or round.
+
+If multiple bonds, assets, or automated accounting become necessary, the YAML
+schema migration is a v0+1 ADR + tooling task, not a v0 acceptance blocker.
 
 ### §8.2 Bond exhaustion
 


### PR DESCRIPTION
## Summary
- replace the wallet v0 §8.1 YAML bond schema with the existing `docs/INTENTIONAL-DEBT.md` six-field prose ledger format
- defer YAML/schema migration to v0+1 ADR + tooling when wallet scale justifies it
- update B-0062 progress from 18/21 to 19/21 resolved items

## Checks
- `BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts && bun tools/backlog/generate-index.ts --check`
- `bunx markdownlint-cli2 docs/research/wallet-experiment-v0-operational-spec-2026-04-27.md docs/backlog/P0/B-0062-wallet-v0-build-out-spec-logic-punch-list-from-pr-72-deferrals.md`
- `git diff --check`

Advances B-0062.
