### PR TITLE
fix(ci): test archive PR policy-denial classifier

### DIFF
--- a/.github/workflows/pr-archive-on-merge.yml
+++ b/.github/workflows/pr-archive-on-merge.yml
@@ -88,7 +88,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Need full history for git rev-parse HEAD (commit_sha field in
           # manifest entries), and so the bot branch is based on current main.
@@ -99,7 +99,7 @@ jobs:
           persist-credentials: true
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
@@ -214,7 +214,7 @@ jobs:
           fi
 
           cat "$create_log" >&2
-          if grep -Fq "GitHub Actions is not permitted to create or approve pull requests (createPullRequest)" "$create_log"; then
+          if bun tools/github/is-pr-create-policy-denial.ts "$create_log"; then
             {
               echo "### Archive PR creation skipped by repository policy"
               echo

--- a/tools/github/is-pr-create-policy-denial.test.ts
+++ b/tools/github/is-pr-create-policy-denial.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { isActionsCreatePullRequestPolicyDenial } from "./is-pr-create-policy-denial";
+
+describe("isActionsCreatePullRequestPolicyDenial", () => {
+  test("accepts the exact Actions createPullRequest policy denial", () => {
+    expect(
+      isActionsCreatePullRequestPolicyDenial(
+        "GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)",
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects unrelated createPullRequest GraphQL failures", () => {
+    expect(isActionsCreatePullRequestPolicyDenial("GraphQL: Base ref must be a branch (createPullRequest)")).toBe(
+      false,
+    );
+  });
+
+  test("rejects permission failures that are not the Actions PR-create policy", () => {
+    expect(
+      isActionsCreatePullRequestPolicyDenial("GraphQL: Resource not accessible by integration (createPullRequest)"),
+    ).toBe(false);
+  });
+
+  test("requires the createPullRequest suffix as part of the exact denial", () => {
+    expect(
+      isActionsCreatePullRequestPolicyDenial("GitHub Actions is not permitted to create or approve pull requests"),
+    ).toBe(false);
+  });
+});

--- a/tools/github/is-pr-create-policy-denial.ts
+++ b/tools/github/is-pr-create-policy-denial.ts
@@ -1,0 +1,22 @@
+export const ACTIONS_CREATE_PR_POLICY_DENIAL =
+  "GitHub Actions is not permitted to create or approve pull requests (createPullRequest)";
+
+export function isActionsCreatePullRequestPolicyDenial(output: string): boolean {
+  return output.includes(ACTIONS_CREATE_PR_POLICY_DENIAL);
+}
+
+async function main(argv: string[]): Promise<number> {
+  if (argv.length > 1) {
+    console.error("usage: bun tools/github/is-pr-create-policy-denial.ts [log-file]");
+    return 2;
+  }
+
+  const logPath = argv[0];
+  const output = logPath === undefined ? await new Response(Bun.stdin.stream()).text() : await Bun.file(logPath).text();
+
+  return isActionsCreatePullRequestPolicyDenial(output) ? 0 : 1;
+}
+
+if (import.meta.main) {
+  process.exit(await main(process.argv.slice(2)));
+}

--- a/tools/github/is-pr-create-policy-denial.ts
+++ b/tools/github/is-pr-create-policy-denial.ts
@@ -5,7 +5,7 @@ export function isActionsCreatePullRequestPolicyDenial(output: string): boolean 
   return output.includes(ACTIONS_CREATE_PR_POLICY_DENIAL);
 }
 
-async function main(argv: string[]): Promise<number> {
+export async function main(argv: readonly string[]): Promise<number> {
   if (argv.length > 1) {
     console.error("usage: bun tools/github/is-pr-create-policy-denial.ts [log-file]");
     return 2;


### PR DESCRIPTION
## Summary\n\n- add a tiny tested classifier for the exact GitHub Actions createPullRequest policy denial\n- make pr-archive-on-merge call the classifier instead of embedding the predicate inline\n- preserve hard-fail behavior for unrelated gh pr create GraphQL failures\n\n## Checks\n\n- bun test tools/github/is-pr-create-policy-denial.test.ts\n- bunx actionlint .github/workflows/pr-archive-on-merge.yml\n- git diff --check\n- bunx prettier --check tools/github/is-pr-create-policy-denial.ts tools/github/is-pr-create-policy-denial.test.ts .github/workflows/pr-archive-on-merge.yml\n- bun run typecheck