### PR TITLE
fix(trajectories): ignore placeholder child candidates

### DIFF
--- a/docs/claims/fix-trajectory-none-child-candidate.md
+++ b/docs/claims/fix-trajectory-none-child-candidate.md
@@ -15,6 +15,6 @@ The bounded gate observed `codex-backlog-runner` selecting
 selected`. That placeholder should block the packet as having no concrete next
 action instead of producing a bogus child-packet prompt.
 
-2026-05-08T06:27Z: Vera resumed the stale Codex claim, preserved the existing
-worktree patch, and verified the selector now routes the packet to `blocked`
-with reason `no next action found`.
+2026-05-08T06:27Z: The Codex harness resumed the stale claim, preserved the
+existing worktree patch, and verified the selector now routes the packet to
+`blocked` with reason `no next action found`.

--- a/docs/claims/fix-trajectory-none-child-candidate.md
+++ b/docs/claims/fix-trajectory-none-child-candidate.md
@@ -3,7 +3,7 @@
 - **Session ID:** codex/20260508T040741Z-fix-trajectory-none-child-candidate
 - **Harness:** codex
 - **Claimed at:** 2026-05-08T04:07:41Z
-- **ETA:** 2026-05-08T04:30:00Z
+- **ETA:** 2026-05-08T06:35:00Z
 - **Scope:** Fix the trajectory selector so placeholder child-candidate text is not treated as actionable trajectory work.
 - **Durable target:** `tools/trajectories/autonomous-pickup.ts`, `tools/trajectories/autonomous-pickup.test.ts`
 - **Platform mirror:** PR to be opened from this branch.
@@ -14,3 +14,7 @@ The bounded gate observed `codex-backlog-runner` selecting
 `factory-trajectory-surface` with `First child candidate: none currently
 selected`. That placeholder should block the packet as having no concrete next
 action instead of producing a bogus child-packet prompt.
+
+2026-05-08T06:27Z: Vera resumed the stale Codex claim, preserved the existing
+worktree patch, and verified the selector now routes the packet to `blocked`
+with reason `no next action found`.

--- a/docs/claims/fix-trajectory-none-child-candidate.md
+++ b/docs/claims/fix-trajectory-none-child-candidate.md
@@ -1,0 +1,16 @@
+# Claim - fix-trajectory-none-child-candidate
+
+- **Session ID:** codex/20260508T040741Z-fix-trajectory-none-child-candidate
+- **Harness:** codex
+- **Claimed at:** 2026-05-08T04:07:41Z
+- **ETA:** 2026-05-08T04:30:00Z
+- **Scope:** Fix the trajectory selector so placeholder child-candidate text is not treated as actionable trajectory work.
+- **Durable target:** `tools/trajectories/autonomous-pickup.ts`, `tools/trajectories/autonomous-pickup.test.ts`
+- **Platform mirror:** PR to be opened from this branch.
+
+## Notes
+
+The bounded gate observed `codex-backlog-runner` selecting
+`factory-trajectory-surface` with `First child candidate: none currently
+selected`. That placeholder should block the packet as having no concrete next
+action instead of producing a bogus child-packet prompt.

--- a/tools/trajectories/autonomous-pickup.test.ts
+++ b/tools/trajectories/autonomous-pickup.test.ts
@@ -72,6 +72,26 @@ describe("selectNextTrajectory", () => {
     expect(selection.blocked[0]?.reason).toBe("no next action found");
   });
 
+  test("ignores placeholder child candidates when next action is concrete", () => {
+    const selection = selectNextTrajectory(
+      [
+        packet({
+          slug: "ready-lane",
+          title: "Ready lane",
+          nextAction: "Claim and implement one small action",
+          childCandidates: ["none currently selected"],
+        }),
+      ],
+      [],
+    );
+
+    expect(selection.status).toBe("selected");
+    expect(selection.selected?.slug).toBe("ready-lane");
+    expect(selection.action).toBe("claim-and-implement");
+    expect(selection.executionPrompt).not.toContain("First child candidate");
+    expect(selection.executionPrompt).not.toContain("none currently selected");
+  });
+
   test("blocks packets with explicit blockers", () => {
     const selection = selectNextTrajectory(
       [

--- a/tools/trajectories/autonomous-pickup.test.ts
+++ b/tools/trajectories/autonomous-pickup.test.ts
@@ -53,6 +53,25 @@ describe("selectNextTrajectory", () => {
     expect(selection.action).toBe("decompose");
   });
 
+  test("blocks placeholder child candidate text", () => {
+    const selection = selectNextTrajectory(
+      [
+        packet({
+          slug: "factory-trajectory-surface",
+          title: "Factory Trajectory Surface",
+          nextAction: "none currently selected",
+          childCandidates: ["none currently selected"],
+        }),
+        packet({ slug: "typescript-bun-migration", title: "fallback" }),
+      ],
+      [],
+    );
+
+    expect(selection.status).toBe("selected");
+    expect(selection.selected?.slug).toBe("typescript-bun-migration");
+    expect(selection.blocked[0]?.reason).toBe("no next action found");
+  });
+
   test("blocks packets with explicit blockers", () => {
     const selection = selectNextTrajectory(
       [

--- a/tools/trajectories/autonomous-pickup.ts
+++ b/tools/trajectories/autonomous-pickup.ts
@@ -113,6 +113,31 @@ function stripMarkdown(value: string): string {
   return trimmed;
 }
 
+function isPlaceholderAction(value: string | null): boolean {
+  if (value === null) {
+    return true;
+  }
+  const normalized = stripMarkdown(value).toLowerCase();
+  return (
+    normalized === "" ||
+    normalized === "none" ||
+    normalized === "none currently selected" ||
+    normalized === "no current action" ||
+    normalized === "not currently selected" ||
+    normalized === "n/a" ||
+    normalized === "na" ||
+    normalized === "tbd"
+  );
+}
+
+function actionableText(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  const stripped = stripMarkdown(value);
+  return isPlaceholderAction(stripped) ? null : stripped;
+}
+
 function firstHeading(lines: readonly string[], fallback: string): string {
   for (const line of lines) {
     const trimmed = line.trim();
@@ -169,7 +194,7 @@ function bulletsFromSection(lines: readonly string[], heading: string): string[]
     .map((line) => line.trim())
     .filter((line) => line.startsWith("- "))
     .map((line) => stripMarkdown(line.slice(2)))
-    .filter(Boolean);
+    .filter((line) => !isPlaceholderAction(line));
 }
 
 function paragraphFromSection(lines: readonly string[], heading: string): string | null {
@@ -222,8 +247,8 @@ function readPacket(repoRoot: string, slug: string): TrajectoryPacket | null {
     const lines = content.split(/\r?\n/);
     const childCandidates = bulletsFromSection(lines, "Next Child Packets");
     const nextAction =
-      firstField(lines, ["Next concrete action", "Recommended next action"]) ??
-      paragraphFromSection(lines, "Recommended next action") ??
+      actionableText(firstField(lines, ["Next concrete action", "Recommended next action"])) ??
+      actionableText(paragraphFromSection(lines, "Recommended next action")) ??
       (childCandidates.length > 0 ? (childCandidates[0] ?? null) : null);
 
     return {
@@ -269,7 +294,7 @@ function blockerReason(packet: TrajectoryPacket): string | null {
   if (packet.blocker !== null && packet.blocker.toLowerCase() !== "none") {
     return `active blocker: ${packet.blocker}`;
   }
-  if (packet.nextAction === null) {
+  if (packet.nextAction === null || isPlaceholderAction(packet.nextAction)) {
     return "no next action found";
   }
   return null;
@@ -287,7 +312,7 @@ function claimBlocker(packet: TrajectoryPacket, activeClaims: readonly string[])
 
 function actionFor(packet: TrajectoryPacket): TrajectoryAction {
   const next = packet.nextAction?.toLowerCase() ?? "";
-  if (packet.childCandidates.length > 0) {
+  if (packet.childCandidates.some((candidate) => !isPlaceholderAction(candidate))) {
     return "create-child-packet";
   }
   if (
@@ -309,7 +334,7 @@ function promptFor(packet: TrajectoryPacket, action: TrajectoryAction): string {
   } else if (action === "decompose") {
     lead = `Decompose ${packet.slug} into one atomic, claimable next trajectory action.`;
   }
-  const firstChild = packet.childCandidates[0];
+  const firstChild = packet.childCandidates.find((candidate) => !isPlaceholderAction(candidate));
   const childLine = firstChild === undefined ? [] : [`First child candidate: ${firstChild}`, ""];
   return [
     lead,


### PR DESCRIPTION
## Summary
- fixes the trajectory selector so placeholder text like `none currently selected` is treated as no actionable next step
- keeps `factory-trajectory-surface` from generating a bogus child-packet prompt when its candidate list is empty by design
- resumes the existing Codex claim instead of creating a duplicate lane

## Checks
- passed: `bun test tools/trajectories/autonomous-pickup.test.ts`
- passed: `bun run typecheck` (with the root node_modules symlinked into the isolated worktree for local tooling)
- passed: `prettier --check docs/claims/fix-trajectory-none-child-candidate.md tools/trajectories/autonomous-pickup.ts tools/trajectories/autonomous-pickup.test.ts`
- passed: `markdownlint-cli2 docs/claims/fix-trajectory-none-child-candidate.md`
- passed: `git diff --check origin/main...HEAD`

## Coordination
- Claim: `docs/claims/fix-trajectory-none-child-candidate.md`
- Worktree: `/Users/acehack/.codex/worktrees/fix-trajectory-none-child-candidate`
