### PR TITLE
feat(backlog): add B-0280 publication commit command

### DIFF
--- a/docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md
+++ b/docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md
@@ -33,3 +33,6 @@ without the maintainer acting as courier or permission surface.
   builder for selected backlog rows, focused check summaries, and
   auto-merge eligibility. Full row remains open until the executor path
   performs the push/create/auto-merge sequence end to end.
+- 2026-05-08: Second implementation slice adds the deterministic Codex
+  commit command, including the required Codex co-author trailer, to the
+  publication plan.

--- a/docs/claims/task-b0280-publication-commit-command.md
+++ b/docs/claims/task-b0280-publication-commit-command.md
@@ -6,7 +6,7 @@
 - **ETA:** 2026-05-08T07:36:40.940Z
 - **Scope:** add Codex commit command to PR publication plan
 - **Durable target:** docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md
-- **Platform mirror:** GitHub PR pending
+- **Platform mirror:** https://github.com/Lucent-Financial-Group/Zeta/pull/2047
 
 ## Notes
 

--- a/docs/claims/task-b0280-publication-commit-command.md
+++ b/docs/claims/task-b0280-publication-commit-command.md
@@ -1,0 +1,19 @@
+# Claim - task-b0280-publication-commit-command
+
+- **Session ID:** codex/20260508T065140Z-task-b0280-publication-commit-command
+- **Harness:** codex
+- **Claimed at:** 2026-05-08T06:51:40.940Z
+- **ETA:** 2026-05-08T07:36:40.940Z
+- **Scope:** add Codex commit command to PR publication plan
+- **Durable target:** docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md
+- **Platform mirror:** GitHub PR pending
+
+## Notes
+
+Branch: `claim/task-b0280-publication-commit-command`
+
+Initial intended path set:
+
+- `docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md`
+- `tools/backlog/pr-publication-plan.ts`
+- `tools/backlog/pr-publication-plan.test.ts`

--- a/tools/backlog/pr-publication-plan.test.ts
+++ b/tools/backlog/pr-publication-plan.test.ts
@@ -63,6 +63,14 @@ describe("buildPublicationPlan", () => {
     expect(plan.prBody).toContain("## Backlog row");
     expect(plan.prBody).toContain("B-0280");
     expect(plan.prBody).toContain("Decision: arm auto-merge");
+    expect(plan.commands.commit).toEqual([
+      "git",
+      "commit",
+      "-m",
+      "feat(backlog): advance B-0280 Autonomous backlog pickup - PR publication and auto-merge",
+      "-m",
+      "Co-Authored-By: Codex <noreply@openai.com>",
+    ]);
     expect(plan.commands.push).toEqual(["git", "push", "-u", "origin", "claim/task-b0280-pr-publication-plan"]);
     expect(plan.commands.createPr).toContain("--body-file");
     expect(plan.commands.armAutoMerge).toEqual([
@@ -186,6 +194,7 @@ describe("validation", () => {
     expect(plan.commands.push).toEqual(["git", "push", "-u", "origin", "claim/task-b0280-pr-publication-plan"]);
     expect(plan.commands.createPr).toContain("main");
     expect(plan.commands.createPr).toContain("claim/task-b0280-pr-publication-plan");
+    expect(plan.commands.commit).toContain("Co-Authored-By: Codex <noreply@openai.com>");
   });
 
   test("preserves literal origin-prefixed branch names", () => {

--- a/tools/backlog/pr-publication-plan.ts
+++ b/tools/backlog/pr-publication-plan.ts
@@ -46,6 +46,7 @@ export interface PublicationPlan {
   prBody: string;
   autoMerge: AutoMergeDecision;
   commands: {
+    commit: string[];
     push: string[];
     createPr: string[];
     armAutoMerge: string[] | null;
@@ -62,6 +63,7 @@ const DEFAULT_BRANCHES = new Set(["main", "master", "trunk"]);
 const REMOTE_SHORTHAND_NAMES = new Set(["origin", "upstream"]);
 const REMOTE_REF_PREFIX = /^refs\/remotes\/[^/]+\//;
 const FORBIDDEN_REF_CHARS = /[\x00-\x20~^:?*[\\\x7f]/;
+const CODEX_COMMIT_TRAILER = "Co-Authored-By: Codex <noreply@openai.com>";
 
 function usage(): string {
   return [
@@ -270,6 +272,7 @@ export function buildPublicationPlan(input: PublicationInput): PublicationPlan {
     prBody: buildPrBody(input),
     autoMerge,
     commands: {
+      commit: ["git", "commit", "-m", title, "-m", CODEX_COMMIT_TRAILER],
       push: ["git", "push", "-u", "origin", branch],
       createPr,
       armAutoMerge: autoMerge.allowed


### PR DESCRIPTION
## Summary
- adds the deterministic `git commit` argv to the B-0280 PR publication plan
- includes the required `Co-Authored-By: Codex <noreply@openai.com>` trailer in the generated command
- covers the new command shape in focused tests and records the B-0280 progress slice

## Backlog row
- B-0280: Autonomous backlog pickup - PR publication and auto-merge
- Path: `docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md`

## Checks
- passed: `bun test tools/backlog/pr-publication-plan.test.ts`
- passed: `bun run typecheck`
- passed: `bunx prettier --check docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md tools/backlog/pr-publication-plan.ts tools/backlog/pr-publication-plan.test.ts`
- passed: `bunx markdownlint-cli2 docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md docs/claims/task-b0280-publication-commit-command.md`
- passed: `git diff --check`

## Auto-merge gate
- Required checks: pending on PR creation
- Unresolved review threads: 0 at creation
- Decision: arm auto-merge while CI runs