### PR TITLE
feat(backlog): advance B-0280 PR body publication

### DIFF
--- a/docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md
+++ b/docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md
@@ -36,3 +36,7 @@ without the maintainer acting as courier or permission surface.
 - 2026-05-08: Second implementation slice adds the deterministic Codex
   commit command, including the required Codex co-author trailer, to the
   publication plan.
+- 2026-05-08: Third implementation slice replaces the placeholder PR body
+  file argument with a validated `bodyFilePath` input and adds an explicit
+  `--write-body` helper that writes the generated review packet exactly once
+  before `gh pr create` runs.

--- a/docs/claims/task-b0280-pr-body-file.md
+++ b/docs/claims/task-b0280-pr-body-file.md
@@ -1,0 +1,19 @@
+# Claim - task-b0280-pr-body-file
+
+- **Session ID:** codex/20260508T073517Z-task-b0280-pr-body-file
+- **Harness:** codex
+- **Claimed at:** 2026-05-08T07:35:17.568Z
+- **ETA:** 2026-05-08T08:20:17.568Z
+- **Scope:** materialize deterministic PR body file for publication executor
+- **Durable target:** docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md
+- **Platform mirror:** GitHub PR pending
+
+## Notes
+
+Branch: `claim/task-b0280-pr-body-file`
+
+Initial intended path set:
+
+- `docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md`
+- `tools/backlog/pr-publication-plan.ts`
+- `tools/backlog/pr-publication-plan.test.ts`

--- a/tools/backlog/pr-publication-plan.test.ts
+++ b/tools/backlog/pr-publication-plan.test.ts
@@ -68,6 +68,7 @@ describe("buildPublicationPlan", () => {
     expect(plan.prBody).toContain("## Backlog row");
     expect(plan.prBody).toContain("B-0280");
     expect(plan.prBody).toContain("Decision: arm auto-merge");
+    expect(plan.bodyFilePath).toBe("tmp/pr-bodies/B-0280.md");
     expect(plan.commands.commit).toEqual([
       "git",
       "commit",
@@ -149,6 +150,9 @@ describe("validation", () => {
     );
     expect(() => {
       validatePublicationInput(input({ bodyFilePath: "/tmp/body.md" }));
+    }).toThrow("unsafe repo-relative path");
+    expect(() => {
+      validatePublicationInput(input({ bodyFilePath: "C:/tmp/body.md" }));
     }).toThrow("unsafe repo-relative path");
     expect(() => {
       validatePublicationInput(input({ bodyFilePath: "../body.md" }));

--- a/tools/backlog/pr-publication-plan.test.ts
+++ b/tools/backlog/pr-publication-plan.test.ts
@@ -155,6 +155,9 @@ describe("validation", () => {
       validatePublicationInput(input({ bodyFilePath: "C:/tmp/body.md" }));
     }).toThrow("unsafe repo-relative path");
     expect(() => {
+      validatePublicationInput(input({ bodyFilePath: "C:../outside/body.md" }));
+    }).toThrow("unsafe repo-relative path");
+    expect(() => {
       validatePublicationInput(input({ bodyFilePath: "../body.md" }));
     }).toThrow("unsafe repo-relative path");
     expect(() => {

--- a/tools/backlog/pr-publication-plan.test.ts
+++ b/tools/backlog/pr-publication-plan.test.ts
@@ -99,17 +99,20 @@ describe("buildPublicationPlan", () => {
 
   test("writes the generated PR body to the configured body file once", () => {
     const dir = mkdtempSync(join(tmpdir(), "zeta-pr-body-"));
-    const bodyFilePath = join(dir, "body.md");
+    const originalCwd = process.cwd();
+    const bodyFilePath = "body/body.md";
     try {
+      process.chdir(dir);
       const plan = buildPublicationPlan(input({ bodyFilePath }));
 
       writePrBodyFile(plan);
 
-      expect(readFileSync(bodyFilePath, "utf8")).toBe(plan.prBody);
+      expect(readFileSync(join(dir, bodyFilePath), "utf8")).toBe(plan.prBody);
       expect(() => {
         writePrBodyFile(plan);
       }).toThrow();
     } finally {
+      process.chdir(originalCwd);
       rmSync(dir, { force: true, recursive: true });
     }
   });
@@ -144,6 +147,18 @@ describe("validation", () => {
     }).toThrow(
       "unsafe PR body file path",
     );
+    expect(() => {
+      validatePublicationInput(input({ bodyFilePath: "/tmp/body.md" }));
+    }).toThrow("unsafe repo-relative path");
+    expect(() => {
+      validatePublicationInput(input({ bodyFilePath: "../body.md" }));
+    }).toThrow("unsafe repo-relative path");
+    expect(() => {
+      validatePublicationInput(input({ bodyFilePath: "tmp/../body.md" }));
+    }).toThrow("unsafe repo-relative path");
+    expect(() => {
+      validatePublicationInput(input({ bodyFilePath: ".git/body.md" }));
+    }).toThrow("unsafe repo-relative path");
   });
 
   test("formats body check notes without mutating input", () => {

--- a/tools/backlog/pr-publication-plan.test.ts
+++ b/tools/backlog/pr-publication-plan.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   buildPrBody,
   buildPrTitle,
@@ -6,6 +9,7 @@ import {
   decideAutoMerge,
   normalizeBranchRef,
   validatePublicationInput,
+  writePrBodyFile,
   type PublicationInput,
 } from "./pr-publication-plan";
 
@@ -16,6 +20,7 @@ function input(overrides: Partial<PublicationInput> = {}): PublicationInput {
     backlogPath: "docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md",
     branch: "claim/task-b0280-pr-publication-plan",
     baseBranch: "main",
+    bodyFilePath: "tmp/pr-bodies/B-0280.md",
     summary: [
       "adds a deterministic PR publication packet",
       "keeps auto-merge arming behind review-thread and required-check gates",
@@ -73,6 +78,7 @@ describe("buildPublicationPlan", () => {
     ]);
     expect(plan.commands.push).toEqual(["git", "push", "-u", "origin", "claim/task-b0280-pr-publication-plan"]);
     expect(plan.commands.createPr).toContain("--body-file");
+    expect(plan.commands.createPr).toContain("tmp/pr-bodies/B-0280.md");
     expect(plan.commands.armAutoMerge).toEqual([
       "gh",
       "pr",
@@ -89,6 +95,23 @@ describe("buildPublicationPlan", () => {
     const plan = buildPublicationPlan(input({ unresolvedReviewThreads: 1 }));
     expect(plan.autoMerge.allowed).toBe(false);
     expect(plan.commands.armAutoMerge).toBeNull();
+  });
+
+  test("writes the generated PR body to the configured body file once", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zeta-pr-body-"));
+    const bodyFilePath = join(dir, "body.md");
+    try {
+      const plan = buildPublicationPlan(input({ bodyFilePath }));
+
+      writePrBodyFile(plan);
+
+      expect(readFileSync(bodyFilePath, "utf8")).toBe(plan.prBody);
+      expect(() => {
+        writePrBodyFile(plan);
+      }).toThrow();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
   });
 });
 
@@ -115,6 +138,11 @@ describe("validation", () => {
     expect(() => validatePublicationInput(input({ checks: [] }))).toThrow("at least one focused check");
     expect(() => validatePublicationInput(input({ backlogPath: "../outside.md" }))).toThrow(
       "unsafe repo-relative path",
+    );
+    expect(() => {
+      validatePublicationInput(input({ bodyFilePath: "-body.md" }));
+    }).toThrow(
+      "unsafe PR body file path",
     );
   });
 

--- a/tools/backlog/pr-publication-plan.ts
+++ b/tools/backlog/pr-publication-plan.ts
@@ -46,6 +46,7 @@ export interface AutoMergeDecision {
 export interface PublicationPlan {
   prTitle: string;
   prBody: string;
+  bodyFilePath: string;
   autoMerge: AutoMergeDecision;
   commands: {
     commit: string[];
@@ -118,6 +119,7 @@ function validateRepoPath(path: string): void {
   if (
     normalized.trim().length === 0 ||
     normalized.startsWith("/") ||
+    /^[A-Za-z]:\//.test(normalized) ||
     normalized.startsWith("../") ||
     normalized.includes("/../") ||
     normalized === ".git" ||
@@ -291,6 +293,7 @@ export function buildPublicationPlan(input: PublicationInput): PublicationPlan {
   return {
     prTitle: title,
     prBody: buildPrBody(input),
+    bodyFilePath: input.bodyFilePath,
     autoMerge,
     commands: {
       commit: ["git", "commit", "-m", title, "-m", CODEX_COMMIT_TRAILER],
@@ -304,12 +307,8 @@ export function buildPublicationPlan(input: PublicationInput): PublicationPlan {
 }
 
 export function writePrBodyFile(plan: PublicationPlan): void {
-  const bodyFile = plan.commands.createPr.at(-1);
-  if (bodyFile === undefined || bodyFile.length === 0) {
-    throw new Error("createPr command is missing --body-file path");
-  }
-  mkdirSync(dirname(bodyFile), { recursive: true });
-  writeFileSync(bodyFile, plan.prBody, { flag: "wx" });
+  mkdirSync(dirname(plan.bodyFilePath), { recursive: true });
+  writeFileSync(plan.bodyFilePath, plan.prBody, { flag: "wx" });
 }
 
 function readInput(path: string): PublicationInput {

--- a/tools/backlog/pr-publication-plan.ts
+++ b/tools/backlog/pr-publication-plan.ts
@@ -7,7 +7,8 @@
 // from machine-readable inputs so the executor path can stay small and
 // testable.
 
-import { readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 
 export type CheckStatus = "passed" | "failed" | "running" | "pending" | "skipped";
 
@@ -30,6 +31,7 @@ export interface PublicationInput {
   backlogPath: string;
   branch: string;
   baseBranch: string;
+  bodyFilePath: string;
   summary: string[];
   checks: FocusedCheck[];
   requiredChecks: RequiredCheckCounts;
@@ -56,6 +58,7 @@ export interface PublicationPlan {
 interface Args {
   inputPath: string | null;
   json: boolean;
+  writeBody: boolean;
 }
 
 const DEFAULT_REPO = "Lucent-Financial-Group/Zeta";
@@ -68,7 +71,7 @@ const CODEX_COMMIT_TRAILER = "Co-Authored-By: Codex <noreply@openai.com>";
 function usage(): string {
   return [
     "Usage:",
-    "  bun tools/backlog/pr-publication-plan.ts --input publication.json [--json]",
+    "  bun tools/backlog/pr-publication-plan.ts --input publication.json [--json] [--write-body]",
     "",
     "Input JSON shape: PublicationInput exported by this module.",
   ].join("\n");
@@ -82,13 +85,15 @@ function requireValue(flag: string, value: string | undefined): string {
 }
 
 function parseArgs(argv: readonly string[]): Args {
-  const args: Args = { inputPath: null, json: false };
+  const args: Args = { inputPath: null, json: false, writeBody: false };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--input") {
       args.inputPath = requireValue(arg, argv[++i]);
     } else if (arg === "--json") {
       args.json = true;
+    } else if (arg === "--write-body") {
+      args.writeBody = true;
     } else if (arg === "--help" || arg === "-h") {
       process.stdout.write(`${usage()}\n`);
       process.exit(0);
@@ -119,6 +124,19 @@ function validateRepoPath(path: string): void {
     normalized.startsWith(".git/")
   ) {
     throw new Error(`unsafe repo-relative path: ${path}`);
+  }
+}
+
+function validateBodyFilePath(path: string): void {
+  const value = path.trim();
+  if (
+    value.length === 0 ||
+    value.startsWith("-") ||
+    value.includes("\0") ||
+    value.endsWith("/") ||
+    value.endsWith("\\")
+  ) {
+    throw new Error(`unsafe PR body file path: ${path}`);
   }
 }
 
@@ -169,7 +187,9 @@ export function validatePublicationInput(input: PublicationInput): void {
   assertNonEmpty("backlogTitle", input.backlogTitle);
   assertNonEmpty("branch", input.branch);
   assertNonEmpty("baseBranch", input.baseBranch);
+  assertNonEmpty("bodyFilePath", input.bodyFilePath);
   validateRepoPath(input.backlogPath);
+  validateBodyFilePath(input.bodyFilePath);
   const branch = validateNormalizedBranchRef("branch", input.branch);
   validateNormalizedBranchRef("baseBranch", input.baseBranch);
   if (isDefaultBranchRef(branch)) {
@@ -265,7 +285,7 @@ export function buildPublicationPlan(input: PublicationInput): PublicationPlan {
     "--title",
     title,
     "--body-file",
-    "<body-file>",
+    input.bodyFilePath,
   ];
   return {
     prTitle: title,
@@ -282,6 +302,15 @@ export function buildPublicationPlan(input: PublicationInput): PublicationPlan {
   };
 }
 
+export function writePrBodyFile(plan: PublicationPlan): void {
+  const bodyFile = plan.commands.createPr.at(-1);
+  if (bodyFile === undefined || bodyFile.length === 0) {
+    throw new Error("createPr command is missing --body-file path");
+  }
+  mkdirSync(dirname(bodyFile), { recursive: true });
+  writeFileSync(bodyFile, plan.prBody, { flag: "wx" });
+}
+
 function readInput(path: string): PublicationInput {
   return JSON.parse(readFileSync(path, "utf8")) as PublicationInput;
 }
@@ -290,6 +319,9 @@ export function main(argv: readonly string[]): number {
   try {
     const args = parseArgs(argv);
     const plan = buildPublicationPlan(readInput(args.inputPath ?? ""));
+    if (args.writeBody) {
+      writePrBodyFile(plan);
+    }
     process.stdout.write(args.json ? `${JSON.stringify(plan, null, 2)}\n` : plan.prBody);
     return 0;
   } catch (error) {

--- a/tools/backlog/pr-publication-plan.ts
+++ b/tools/backlog/pr-publication-plan.ts
@@ -119,7 +119,7 @@ function validateRepoPath(path: string): void {
   if (
     normalized.trim().length === 0 ||
     normalized.startsWith("/") ||
-    /^[A-Za-z]:\//.test(normalized) ||
+    /^[A-Za-z]:/.test(normalized) ||
     normalized.startsWith("../") ||
     normalized.includes("/../") ||
     normalized === ".git" ||

--- a/tools/backlog/pr-publication-plan.ts
+++ b/tools/backlog/pr-publication-plan.ts
@@ -138,6 +138,7 @@ function validateBodyFilePath(path: string): void {
   ) {
     throw new Error(`unsafe PR body file path: ${path}`);
   }
+  validateRepoPath(value);
 }
 
 export function normalizeBranchRef(branch: string): string {


### PR DESCRIPTION
## Summary
- Replaces the PR publication plan's `<body-file>` placeholder with a validated `bodyFilePath` input.
- Adds `--write-body` / `writePrBodyFile` so the generated review packet can be materialized exactly once before `gh pr create`.
- Records B-0280 progress for this executor slice.

## Backlog row
- B-0280: Autonomous backlog pickup - PR publication and auto-merge
- Path: `docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md`

## Checks
- passed: `bun test tools/backlog/pr-publication-plan.test.ts`
- passed: `bun run typecheck`
- passed: `git diff --check`
- diagnostic: `bun run lint:typescript` still fails on pre-existing repo-wide ESLint debt outside this claim; this slice did not use it as a gate.