### PR TITLE
fix(backlog): close B-0278 + land B-0265 CI Gate ruleset

### DIFF
--- a/docs/backlog/P1/B-0265-ruleset-split-ci-gate-ruleset-2026-05-08.md
+++ b/docs/backlog/P1/B-0265-ruleset-split-ci-gate-ruleset-2026-05-08.md
@@ -1,7 +1,9 @@
 ---
 id: B-0265
 priority: P1
-status: open
+status: closed
+closed: 2026-05-08
+closed_by: "Ruleset 'CI Gate' (id 16134995) created; 7 status checks migrated from legacy branch protection; snapshot updated"
 title: "GitHub ruleset split — CI gate ruleset (required status checks)"
 created: 2026-05-08
 last_updated: 2026-05-08
@@ -19,7 +21,28 @@ protection). Move from legacy branch protection to ruleset.
 
 ## Acceptance criteria
 
-- New ruleset "CI Gate" created via `gh api`
-- 7 required status checks migrated from branch protection
-- Legacy branch protection status checks removed
-- Drift detector snapshot updated
+- [x] New ruleset "CI Gate" created via `gh api`
+- [x] 7 required status checks migrated from branch protection
+- [x] Legacy branch protection status checks removed
+- [x] Drift detector snapshot updated
+
+## Implementation (2026-05-08)
+
+Created ruleset "CI Gate" (id: 16134995, enforcement: active)
+targeting `~DEFAULT_BRANCH` with 7 required status checks:
+
+| Context | Integration ID |
+|---|---|
+| build-and-test (macos-26) | 15368 |
+| build-and-test (ubuntu-24.04) | 15368 |
+| build-and-test (ubuntu-24.04-arm) | 15368 |
+| lint (actionlint) | 15368 |
+| lint (markdownlint) | 15368 |
+| lint (semgrep) | 15368 |
+| lint (shellcheck) | 15368 |
+
+Removed `required_status_checks` from legacy branch protection
+via `DELETE /repos/{owner}/{repo}/branches/main/protection/required_status_checks`.
+
+Updated `tools/hygiene/github-settings.expected.json` to reflect
+the new ruleset and null status checks in legacy protection.

--- a/docs/backlog/P1/B-0278-durable-computation-survey-8-systems-2026-05-08.md
+++ b/docs/backlog/P1/B-0278-durable-computation-survey-8-systems-2026-05-08.md
@@ -3,7 +3,7 @@ id: B-0278
 priority: P1
 status: closed
 closed: 2026-05-08
-closed_by: "Survey landed at docs/research/2026-05-08-durable-computation-survey-8-systems.md"
+closed_by: "PR #2023 merged — survey doc at docs/research/"
 title: "Durable computation survey — compare 8 systems against Zeta's gap"
 created: 2026-05-08
 parent: B-0251

--- a/docs/backlog/P1/B-0278-durable-computation-survey-8-systems-2026-05-08.md
+++ b/docs/backlog/P1/B-0278-durable-computation-survey-8-systems-2026-05-08.md
@@ -3,7 +3,8 @@ id: B-0278
 priority: P1
 status: closed
 closed: 2026-05-08
-closed_by: "PR #2023 merged — survey doc at docs/research/"
+closed_by: "PR #2023 merged — survey doc at docs/research/2026-05-08-durable-computation-survey-8-systems.md"
+last_updated: 2026-05-08
 title: "Durable computation survey — compare 8 systems against Zeta's gap"
 created: 2026-05-08
 parent: B-0251

--- a/tools/hygiene/github-settings.expected.json
+++ b/tools/hygiene/github-settings.expected.json
@@ -68,6 +68,59 @@
         }
       },
       "enforcement": "active",
+      "id": 16134995,
+      "name": "CI Gate",
+      "rules": [
+        {
+          "parameters": {
+            "strict_required_status_checks_policy": false,
+            "do_not_enforce_on_create": false,
+            "required_status_checks": [
+              {
+                "context": "build-and-test (macos-26)",
+                "integration_id": 15368
+              },
+              {
+                "context": "build-and-test (ubuntu-24.04)",
+                "integration_id": 15368
+              },
+              {
+                "context": "build-and-test (ubuntu-24.04-arm)",
+                "integration_id": 15368
+              },
+              {
+                "context": "lint (actionlint)",
+                "integration_id": 15368
+              },
+              {
+                "context": "lint (markdownlint)",
+                "integration_id": 15368
+              },
+              {
+                "context": "lint (semgrep)",
+                "integration_id": 15368
+              },
+              {
+                "context": "lint (shellcheck)",
+                "integration_id": 15368
+              }
+            ]
+          },
+          "type": "required_status_checks"
+        }
+      ],
+      "target": "branch"
+    },
+    {
+      "conditions": {
+        "ref_name": {
+          "exclude": [],
+          "include": [
+            "~DEFAULT_BRANCH"
+          ]
+        }
+      },
+      "enforcement": "active",
       "id": 15256879,
       "name": "Default",
       "rules": [
@@ -123,18 +176,7 @@
       "required_approving_review_count": 0
     },
     "required_signatures": false,
-    "required_status_checks": {
-      "contexts": [
-        "build-and-test (macos-26)",
-        "build-and-test (ubuntu-24.04)",
-        "build-and-test (ubuntu-24.04-arm)",
-        "lint (actionlint)",
-        "lint (markdownlint)",
-        "lint (semgrep)",
-        "lint (shellcheck)"
-      ],
-      "strict": false
-    }
+    "required_status_checks": null
   },
   "actions_permissions": {
     "allowed_actions": "all",

--- a/tools/hygiene/github-settings.expected.json
+++ b/tools/hygiene/github-settings.expected.json
@@ -68,6 +68,55 @@
         }
       },
       "enforcement": "active",
+      "id": 15256879,
+      "name": "Default",
+      "rules": [
+        {
+          "parameters": null,
+          "type": "deletion"
+        },
+        {
+          "parameters": null,
+          "type": "non_fast_forward"
+        },
+        {
+          "parameters": {
+            "review_draft_pull_requests": true,
+            "review_on_push": true
+          },
+          "type": "copilot_code_review"
+        },
+        {
+          "parameters": {
+            "allowed_merge_methods": [
+              "squash"
+            ],
+            "dismiss_stale_reviews_on_push": false,
+            "require_code_owner_review": false,
+            "require_last_push_approval": false,
+            "required_approving_review_count": 0,
+            "required_review_thread_resolution": true,
+            "required_reviewers": []
+          },
+          "type": "pull_request"
+        },
+        {
+          "parameters": null,
+          "type": "required_linear_history"
+        }
+      ],
+      "target": "branch"
+    },
+    {
+      "conditions": {
+        "ref_name": {
+          "exclude": [],
+          "include": [
+            "~DEFAULT_BRANCH"
+          ]
+        }
+      },
+      "enforcement": "active",
       "id": 16134995,
       "name": "CI Gate",
       "rules": [
@@ -107,55 +156,6 @@
             ]
           },
           "type": "required_status_checks"
-        }
-      ],
-      "target": "branch"
-    },
-    {
-      "conditions": {
-        "ref_name": {
-          "exclude": [],
-          "include": [
-            "~DEFAULT_BRANCH"
-          ]
-        }
-      },
-      "enforcement": "active",
-      "id": 15256879,
-      "name": "Default",
-      "rules": [
-        {
-          "parameters": null,
-          "type": "deletion"
-        },
-        {
-          "parameters": null,
-          "type": "non_fast_forward"
-        },
-        {
-          "parameters": {
-            "review_draft_pull_requests": true,
-            "review_on_push": true
-          },
-          "type": "copilot_code_review"
-        },
-        {
-          "parameters": {
-            "allowed_merge_methods": [
-              "squash"
-            ],
-            "dismiss_stale_reviews_on_push": false,
-            "require_code_owner_review": false,
-            "require_last_push_approval": false,
-            "required_approving_review_count": 0,
-            "required_review_thread_resolution": true,
-            "required_reviewers": []
-          },
-          "type": "pull_request"
-        },
-        {
-          "parameters": null,
-          "type": "required_linear_history"
         }
       ],
       "target": "branch"


### PR DESCRIPTION
## Summary

- **B-0278** (durable computation survey): Updated `closed_by` to reference PR #2023 which merged the survey.
- **B-0265** (CI Gate ruleset): Created a new "CI Gate" ruleset (id: 16134995) containing all 7 required status checks previously in legacy branch protection. Removed `required_status_checks` from legacy branch protection. Updated the drift detector snapshot.

### What changed on GitHub

| Before | After |
|--------|-------|
| 1 ruleset (Default) | 2 rulesets (Default + CI Gate) |
| 7 status checks in legacy branch protection | Status checks in "CI Gate" ruleset; legacy branch protection has `required_status_checks: null` |

### Status checks migrated

- `build-and-test (macos-26)`
- `build-and-test (ubuntu-24.04)`
- `build-and-test (ubuntu-24.04-arm)`
- `lint (actionlint)`
- `lint (markdownlint)`
- `lint (semgrep)`
- `lint (shellcheck)`

## Test plan

- [ ] Verify the CI Gate ruleset is active: `gh api repos/Lucent-Financial-Group/Zeta/rulesets --jq '.[] | {id, name, enforcement}'`
- [ ] Verify legacy branch protection no longer has status checks: `gh api repos/Lucent-Financial-Group/Zeta/branches/main/protection --jq '.required_status_checks'`
- [ ] Confirm this PR itself requires the 7 status checks to pass (proving the ruleset is enforcing)
- [ ] Verify drift detector snapshot matches live state

🤖 Generated with [Claude Code](https://claude.com/claude-code)