### PR TITLE
feat(B-0279): add FileCheckpointStore with fsync

### DIFF
--- a/src/Core/Checkpoint.fs
+++ b/src/Core/Checkpoint.fs
@@ -65,6 +65,117 @@ type ICheckpointStore =
         ct: CancellationToken ->
             ValueTask<struct (int64 * (int * ICheckpointReader) array) voption>
 
+/// File-based checkpoint store with fsync for crash-safe
+/// operator state persistence. StableStorage mode for
+/// the checkpoint control plane.
+///
+/// Design lineage:
+/// - Reaqtor checkpoint persistence (periodic state snapshots)
+/// - Atomic-rename pattern (write-to-temp, fsync, rename)
+/// - WitnessDurableBackingStore path-canonicalization pattern
+[<Sealed>]
+type FileCheckpointStore(rootDir: string) =
+    // Canonicalise path once — same TOCTOU-avoidance pattern
+    // as WitnessDurableBackingStore.
+    let canonicalRoot = Path.GetFullPath rootDir
+
+    do
+        Directory.CreateDirectory canonicalRoot |> ignore
+
+    let checkpointPath (circuitId: string) =
+        Path.Combine(canonicalRoot, circuitId + ".checkpoint")
+
+    interface ICheckpointStore with
+        member _.SaveCheckpointAsync
+            (circuitId, tick, states, _ct) =
+            // Serialize to a MemoryStream first, then write
+            // atomically via temp-file + fsync + rename.
+            use ms = new MemoryStream()
+            use bw = new BinaryWriter(ms)
+            bw.Write tick
+            bw.Write(states.Length)
+            for (opId, checkpointable) in states do
+                bw.Write opId
+                bw.Write checkpointable.StateVersion
+                // Capture operator state into a sub-buffer so
+                // we can length-prefix the data blob.
+                use opMs = new MemoryStream()
+                use opBw = new BinaryWriter(opMs)
+                let writer =
+                    { new ICheckpointWriter with
+                        member _.WriteInt32 v = opBw.Write v
+                        member _.WriteInt64 v = opBw.Write v
+                        member _.WriteFloat v = opBw.Write v
+                        member _.WriteBool v = opBw.Write v
+                        member _.WriteBytes v =
+                            opBw.Write(v.Length)
+                            opBw.Write v
+                        member _.WriteString v = opBw.Write v }
+                checkpointable.SaveState writer
+                opBw.Flush()
+                let data = opMs.ToArray()
+                bw.Write(data.Length)
+                bw.Write data
+            bw.Flush()
+
+            let payload = ms.ToArray()
+            let target = checkpointPath circuitId
+            let tmpPath =
+                target + ".tmp." + Guid.NewGuid().ToString("N")
+
+            // Write to temp file, fsync, then atomic rename.
+            use fs =
+                new FileStream(
+                    tmpPath,
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.None)
+            fs.Write(payload, 0, payload.Length)
+            // Flush(true) = FlushFileBuffers / fsync
+            fs.Flush true
+            fs.Close()
+
+            File.Move(tmpPath, target, true)
+            ValueTask.CompletedTask
+
+        member _.LoadCheckpointAsync(circuitId, _ct) =
+            let path = checkpointPath circuitId
+            if not (File.Exists path) then
+                ValueTask.FromResult ValueNone
+            else
+                let bytes = File.ReadAllBytes path
+                use ms = new MemoryStream(bytes)
+                use br = new BinaryReader(ms)
+                let tick = br.ReadInt64()
+                let count = br.ReadInt32()
+                let readers =
+                    Array.init count (fun _ ->
+                        let opId = br.ReadInt32()
+                        let _version = br.ReadInt32()
+                        let dataLen = br.ReadInt32()
+                        let data = br.ReadBytes dataLen
+                        let opMs = new MemoryStream(data)
+                        let opBr = new BinaryReader(opMs)
+                        let reader =
+                            { new ICheckpointReader with
+                                member _.ReadInt32() =
+                                    opBr.ReadInt32()
+                                member _.ReadInt64() =
+                                    opBr.ReadInt64()
+                                member _.ReadFloat() =
+                                    opBr.ReadDouble()
+                                member _.ReadBool() =
+                                    opBr.ReadBoolean()
+                                member _.ReadBytes() =
+                                    let len = opBr.ReadInt32()
+                                    opBr.ReadBytes len
+                                member _.ReadString() =
+                                    opBr.ReadString() }
+                        (opId, reader))
+                ValueTask.FromResult(
+                    ValueSome(struct (tick, readers)))
+
+
 /// In-memory checkpoint store for testing and DST.
 [<Sealed>]
 type InMemoryCheckpointStore() =

--- a/src/Core/Checkpoint.fs
+++ b/src/Core/Checkpoint.fs
@@ -82,8 +82,27 @@ type FileCheckpointStore(rootDir: string) =
     do
         Directory.CreateDirectory canonicalRoot |> ignore
 
+    /// Is Windows / macOS case-insensitive filesystem?
+    /// Same pattern as DiskBackingStore.
+    let isCaseInsensitivePathFs =
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+
+    let pathComparison =
+        if isCaseInsensitivePathFs then StringComparison.OrdinalIgnoreCase
+        else StringComparison.Ordinal
+
     let checkpointPath (circuitId: string) =
-        Path.Combine(canonicalRoot, circuitId + ".checkpoint")
+        let candidate =
+            Path.GetFullPath(
+                Path.Combine(canonicalRoot, circuitId + ".checkpoint"))
+        let rootWithSep =
+            canonicalRoot.TrimEnd(Path.DirectorySeparatorChar)
+            + string Path.DirectorySeparatorChar
+        if not (candidate.StartsWith(rootWithSep, pathComparison)) then
+            raise (ArgumentException(
+                $"Circuit ID would escape checkpoint root: {circuitId}",
+                nameof circuitId))
+        candidate
 
     interface ICheckpointStore with
         member _.SaveCheckpointAsync
@@ -136,6 +155,28 @@ type FileCheckpointStore(rootDir: string) =
             fs.Close()
 
             File.Move(tmpPath, target, true)
+
+            // Best-effort directory fsync — ensures the rename
+            // metadata is durable on POSIX. On Linux/macOS we
+            // can open the directory as a FileStream and flush;
+            // on Windows this is not supported and we accept
+            // the limitation (.NET has no portable dir-fsync
+            // API). The checkpoint is still recoverable via the
+            // temp file pattern; worst case under power loss is
+            // reverting to the prior checkpoint.
+            try
+                let dirPath = Path.GetDirectoryName target
+                use dirFs =
+                    new FileStream(
+                        dirPath,
+                        FileMode.Open,
+                        FileAccess.Read,
+                        FileShare.ReadWrite)
+                dirFs.Flush true
+            with
+            | :? UnauthorizedAccessException -> ()
+            | :? IOException -> ()
+
             ValueTask.CompletedTask
 
         member _.LoadCheckpointAsync(circuitId, _ct) =
@@ -143,37 +184,48 @@ type FileCheckpointStore(rootDir: string) =
             if not (File.Exists path) then
                 ValueTask.FromResult ValueNone
             else
-                let bytes = File.ReadAllBytes path
-                use ms = new MemoryStream(bytes)
-                use br = new BinaryReader(ms)
-                let tick = br.ReadInt64()
-                let count = br.ReadInt32()
-                let readers =
-                    Array.init count (fun _ ->
-                        let opId = br.ReadInt32()
-                        let _version = br.ReadInt32()
-                        let dataLen = br.ReadInt32()
-                        let data = br.ReadBytes dataLen
-                        let opMs = new MemoryStream(data)
-                        let opBr = new BinaryReader(opMs)
-                        let reader =
-                            { new ICheckpointReader with
-                                member _.ReadInt32() =
-                                    opBr.ReadInt32()
-                                member _.ReadInt64() =
-                                    opBr.ReadInt64()
-                                member _.ReadFloat() =
-                                    opBr.ReadDouble()
-                                member _.ReadBool() =
-                                    opBr.ReadBoolean()
-                                member _.ReadBytes() =
-                                    let len = opBr.ReadInt32()
-                                    opBr.ReadBytes len
-                                member _.ReadString() =
-                                    opBr.ReadString() }
-                        (opId, reader))
-                ValueTask.FromResult(
-                    ValueSome(struct (tick, readers)))
+                // Treat corrupt / truncated checkpoint as
+                // missing — safer than crashing recovery.
+                // The circuit will fall back to replay from
+                // the event stream (Temporal model).
+                try
+                    let bytes = File.ReadAllBytes path
+                    use ms = new MemoryStream(bytes)
+                    use br = new BinaryReader(ms)
+                    let tick = br.ReadInt64()
+                    let count = br.ReadInt32()
+                    if count < 0 then
+                        ValueTask.FromResult ValueNone
+                    else
+                        let readers =
+                            Array.init count (fun _ ->
+                                let opId = br.ReadInt32()
+                                let _version = br.ReadInt32()
+                                let dataLen = br.ReadInt32()
+                                let data = br.ReadBytes dataLen
+                                let opMs = new MemoryStream(data)
+                                let opBr = new BinaryReader(opMs)
+                                let reader =
+                                    { new ICheckpointReader with
+                                        member _.ReadInt32() =
+                                            opBr.ReadInt32()
+                                        member _.ReadInt64() =
+                                            opBr.ReadInt64()
+                                        member _.ReadFloat() =
+                                            opBr.ReadDouble()
+                                        member _.ReadBool() =
+                                            opBr.ReadBoolean()
+                                        member _.ReadBytes() =
+                                            let len = opBr.ReadInt32()
+                                            opBr.ReadBytes len
+                                        member _.ReadString() =
+                                            opBr.ReadString() }
+                                (opId, reader))
+                        ValueTask.FromResult(
+                            ValueSome(struct (tick, readers)))
+                with
+                | :? EndOfStreamException -> ValueTask.FromResult ValueNone
+                | :? IOException -> ValueTask.FromResult ValueNone
 
 
 /// In-memory checkpoint store for testing and DST.

--- a/tests/Tests.FSharp/Storage/CheckpointStore.Tests.fs
+++ b/tests/Tests.FSharp/Storage/CheckpointStore.Tests.fs
@@ -1,5 +1,7 @@
 module Zeta.Tests.Storage.CheckpointStoreTests
 
+open System
+open System.IO
 open FsUnit.Xunit
 open global.Xunit
 open Zeta.Core
@@ -120,3 +122,252 @@ let ``InMemoryCheckpointStore overwrites on second save`` () =
     let (_, r) = readers.[0]
     op.LoadState r
     v |> should equal 20
+
+
+// ═══════════════════════════════════════════════════════════════════
+// ═ FileCheckpointStore tests
+// ═══════════════════════════════════════════════════════════════════
+
+let private makeTempDir () =
+    let dir =
+        Path.Combine(
+            Path.GetTempPath(),
+            "zeta-checkpoint-test-" + Guid.NewGuid().ToString("N"))
+    Directory.CreateDirectory dir |> ignore
+    dir
+
+let private cleanupDir (dir: string) =
+    if Directory.Exists dir then
+        Directory.Delete(dir, true)
+
+
+[<Fact>]
+let ``FileCheckpointStore roundtrips operator state`` () =
+    let dir = makeTempDir ()
+    try
+        let store = FileCheckpointStore(dir) :> ICheckpointStore
+
+        let mutable savedValue = 42
+        let checkpointable =
+            { new ICheckpointable with
+                member _.SaveState writer =
+                    writer.WriteInt32 savedValue
+                member _.LoadState reader =
+                    savedValue <- reader.ReadInt32()
+                member _.StateVersion = 1 }
+
+        let states = [| (0, checkpointable) |]
+        store.SaveCheckpointAsync(
+            "test-circuit", 1L, states,
+            Threading.CancellationToken.None)
+        |> fun vt ->
+            vt.AsTask()
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
+
+        savedValue <- 0
+
+        let loaded =
+            store.LoadCheckpointAsync(
+                "test-circuit",
+                Threading.CancellationToken.None)
+            |> fun vt ->
+                vt.AsTask()
+                |> Async.AwaitTask
+                |> Async.RunSynchronously
+
+        loaded.IsSome |> should be True
+        let struct (tick, readers) = loaded.Value
+        tick |> should equal 1L
+        readers.Length |> should equal 1
+
+        let (opId, reader) = readers.[0]
+        opId |> should equal 0
+        checkpointable.LoadState reader
+        savedValue |> should equal 42
+    finally
+        cleanupDir dir
+
+
+[<Fact>]
+let ``FileCheckpointStore returns ValueNone when empty`` () =
+    let dir = makeTempDir ()
+    try
+        let store = FileCheckpointStore(dir) :> ICheckpointStore
+
+        let loaded =
+            store.LoadCheckpointAsync(
+                "nonexistent",
+                Threading.CancellationToken.None)
+            |> fun vt ->
+                vt.AsTask()
+                |> Async.AwaitTask
+                |> Async.RunSynchronously
+
+        loaded.IsNone |> should be True
+    finally
+        cleanupDir dir
+
+
+[<Fact>]
+let ``FileCheckpointStore handles multiple operators`` () =
+    let dir = makeTempDir ()
+    try
+        let store = FileCheckpointStore(dir) :> ICheckpointStore
+
+        let mutable val1 = 100L
+        let mutable val2 = "hello"
+
+        let op1 =
+            { new ICheckpointable with
+                member _.SaveState writer =
+                    writer.WriteInt64 val1
+                member _.LoadState reader =
+                    val1 <- reader.ReadInt64()
+                member _.StateVersion = 1 }
+
+        let op2 =
+            { new ICheckpointable with
+                member _.SaveState writer =
+                    writer.WriteString val2
+                member _.LoadState reader =
+                    val2 <- reader.ReadString()
+                member _.StateVersion = 1 }
+
+        let states = [| (0, op1); (1, op2) |]
+        store.SaveCheckpointAsync(
+            "multi", 5L, states,
+            Threading.CancellationToken.None)
+        |> fun vt ->
+            vt.AsTask()
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
+
+        val1 <- 0L
+        val2 <- ""
+
+        let loaded =
+            store.LoadCheckpointAsync(
+                "multi",
+                Threading.CancellationToken.None)
+            |> fun vt ->
+                vt.AsTask()
+                |> Async.AwaitTask
+                |> Async.RunSynchronously
+
+        let struct (tick, readers) = loaded.Value
+        tick |> should equal 5L
+        readers.Length |> should equal 2
+
+        let (_, r1) = readers.[0]
+        let (_, r2) = readers.[1]
+        op1.LoadState r1
+        op2.LoadState r2
+
+        val1 |> should equal 100L
+        val2 |> should equal "hello"
+    finally
+        cleanupDir dir
+
+
+[<Fact>]
+let ``FileCheckpointStore overwrites on second save`` () =
+    let dir = makeTempDir ()
+    try
+        let store = FileCheckpointStore(dir) :> ICheckpointStore
+
+        let mutable v = 10
+        let op =
+            { new ICheckpointable with
+                member _.SaveState writer =
+                    writer.WriteInt32 v
+                member _.LoadState reader =
+                    v <- reader.ReadInt32()
+                member _.StateVersion = 1 }
+
+        store.SaveCheckpointAsync(
+            "c", 1L, [| (0, op) |],
+            Threading.CancellationToken.None)
+        |> fun vt ->
+            vt.AsTask()
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
+
+        v <- 20
+        store.SaveCheckpointAsync(
+            "c", 2L, [| (0, op) |],
+            Threading.CancellationToken.None)
+        |> fun vt ->
+            vt.AsTask()
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
+
+        v <- 0
+
+        let loaded =
+            store.LoadCheckpointAsync(
+                "c",
+                Threading.CancellationToken.None)
+            |> fun vt ->
+                vt.AsTask()
+                |> Async.AwaitTask
+                |> Async.RunSynchronously
+
+        let struct (tick, readers) = loaded.Value
+        tick |> should equal 2L
+        let (_, r) = readers.[0]
+        op.LoadState r
+        v |> should equal 20
+    finally
+        cleanupDir dir
+
+
+[<Fact>]
+let ``FileCheckpointStore survives across instances`` () =
+    let dir = makeTempDir ()
+    try
+        let mutable savedValue = 69420
+        let checkpointable =
+            { new ICheckpointable with
+                member _.SaveState writer =
+                    writer.WriteInt32 savedValue
+                member _.LoadState reader =
+                    savedValue <- reader.ReadInt32()
+                member _.StateVersion = 1 }
+
+        // Save with one instance.
+        let store1 =
+            FileCheckpointStore(dir) :> ICheckpointStore
+        store1.SaveCheckpointAsync(
+            "persist", 7L, [| (0, checkpointable) |],
+            Threading.CancellationToken.None)
+        |> fun vt ->
+            vt.AsTask()
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
+
+        savedValue <- 0
+
+        // Load with a completely new instance.
+        let store2 =
+            FileCheckpointStore(dir) :> ICheckpointStore
+        let loaded =
+            store2.LoadCheckpointAsync(
+                "persist",
+                Threading.CancellationToken.None)
+            |> fun vt ->
+                vt.AsTask()
+                |> Async.AwaitTask
+                |> Async.RunSynchronously
+
+        loaded.IsSome |> should be True
+        let struct (tick, readers) = loaded.Value
+        tick |> should equal 7L
+        readers.Length |> should equal 1
+
+        let (opId, reader) = readers.[0]
+        opId |> should equal 0
+        checkpointable.LoadState reader
+        savedValue |> should equal 69420
+    finally
+        cleanupDir dir


### PR DESCRIPTION
## Summary

- Adds `FileCheckpointStore` to `src/Core/Checkpoint.fs` — a file-based `ICheckpointStore` implementation with crash-safe persistence via atomic-rename + fsync (`FileStream.Flush(true)`)
- Binary format: `[tick: int64][count: int32][per-op: opId: int32, version: int32, dataLen: int32, data: byte[]]`
- Follows existing codebase patterns: `[<Sealed>]` attribute, `Path.GetFullPath` canonicalization (same as `WitnessDurableBackingStore`), `Directory.CreateDirectory` on construction
- 5 new tests in `tests/Tests.FSharp/Storage/CheckpointStore.Tests.fs` covering roundtrip, empty-load, multi-operator, overwrite, and cross-instance survival

## Test plan

- [x] `dotnet build -c Release` passes with 0 warnings, 0 errors
- [x] `dotnet test Zeta.sln -c Release --filter "CheckpointStore"` — all 9 tests pass (4 existing InMemory + 5 new File)
- [ ] Review that atomic-rename pattern (write temp, fsync, `File.Move` with overwrite) provides crash-safety guarantees

🤖 Generated with [Claude Code](https://claude.com/claude-code)