### PR TITLE
fix(backlog): add decomposition + classification to P1 items

### DIFF
--- a/docs/backlog/P1/B-0063-streamed-installer-download-to-temp-checksum-pattern-codex-p0-pr-75.md
+++ b/docs/backlog/P1/B-0063-streamed-installer-download-to-temp-checksum-pattern-codex-p0-pr-75.md
@@ -9,6 +9,8 @@ ask: codex P0 review on PR #75 (5 threads on tools/setup/common/curl-fetch.sh, m
 created: 2026-04-28
 last_updated: 2026-05-02
 depends_on: []
+decomposition: atomic
+classification: buildable-now
 composes_with: [B-0060]
 tags: [install-path, supply-chain, upstream-installers, codex-p0, pr-75, streaming-vs-buffered, checksum]
 ---

--- a/docs/backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md
+++ b/docs/backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md
@@ -6,6 +6,8 @@ title: Port the 4-layer meta-learning pattern from a sibling repo to Zeta
 created: 2026-05-01
 last_updated: 2026-05-02
 depends_on: []
+decomposition: atomic
+classification: buildable-now
 ---
 
 # B-0126 — Port the 4-layer meta-learning pattern from STCRM to Zeta

--- a/docs/backlog/P1/B-0140-bash-to-ts-migration-completion-debt-prevention-aaron-2026-05-01.md
+++ b/docs/backlog/P1/B-0140-bash-to-ts-migration-completion-debt-prevention-aaron-2026-05-01.md
@@ -6,6 +6,8 @@ title: Bash → TS migration completion — debt-prevention prerequisite to B-01
 created: 2026-05-01
 last_updated: 2026-05-08
 depends_on: []
+decomposition: atomic
+classification: buildable-now
 composes_with: [B-0190, B-0196]
 ---
 

--- a/docs/backlog/P1/B-0160-claude-code-permissions-feature-tight-integration-aaron-2026-05-02.md
+++ b/docs/backlog/P1/B-0160-claude-code-permissions-feature-tight-integration-aaron-2026-05-02.md
@@ -6,6 +6,8 @@ title: Claude Code `/permissions` feature — research current API + integrate t
 created: 2026-05-02
 last_updated: 2026-05-02
 depends_on: []
+decomposition: atomic
+classification: buildable-now
 ---
 
 # B-0160 — Claude Code `/permissions` feature tight integration (Aaron 2026-05-02)

--- a/docs/backlog/P1/B-0161-substrate-reshelf-asymmetry-applied-to-pr-1202-overshoot-aaron-claudeai-2026-05-02.md
+++ b/docs/backlog/P1/B-0161-substrate-reshelf-asymmetry-applied-to-pr-1202-overshoot-aaron-claudeai-2026-05-02.md
@@ -7,6 +7,7 @@ created: 2026-05-02
 last_updated: 2026-05-02
 depends_on:
   - B-0160
+decomposition: atomic
 ---
 
 # B-0161 — Substrate reshelf for PR #1202 asymmetry-application (Aaron + Claude.ai 2026-05-02)

--- a/docs/backlog/P1/B-0168-incorporate-brat-voice-enterprise-translation-framework-claudeai-research-2026-05-02.md
+++ b/docs/backlog/P1/B-0168-incorporate-brat-voice-enterprise-translation-framework-claudeai-research-2026-05-02.md
@@ -9,6 +9,8 @@ ask: Aaron 2026-05-02 ("we can incorporate it on the backlog it's good research 
 created: 2026-05-02
 last_updated: 2026-05-02
 depends_on: []
+decomposition: atomic
+classification: buildable-now
 composes_with: [B-0164, B-0167]
 tags: [register-architecture, brat-voice, enterprise-translation, claudeai-research, lucent, gen-z-recruitment, alignment-discipline, beacon-safe, plain-language]
 ---

--- a/docs/backlog/P1/B-0169-decision-archaeology-skill-aaron-2026-05-02.md
+++ b/docs/backlog/P1/B-0169-decision-archaeology-skill-aaron-2026-05-02.md
@@ -9,6 +9,8 @@ ask: Aaron 2026-05-02 (autonomous-loop channel — *"that is amazing i never ask
 created: 2026-05-02
 last_updated: 2026-05-02
 depends_on: []
+decomposition: atomic
+classification: buildable-now
 composes_with: [B-0058]
 tags: [skill, onboarding, contributor-experience, dx, ux, ax, git-blame, lineage, intent-reconstruction]
 ---

--- a/docs/backlog/P1/B-0170-substrate-claim-checker-ts-tool-aaron-2026-05-03.md
+++ b/docs/backlog/P1/B-0170-substrate-claim-checker-ts-tool-aaron-2026-05-03.md
@@ -9,6 +9,8 @@ ask: Otto 2026-05-03 self-grading, surfaced via drift instances (the verify-then
 created: 2026-05-03
 last_updated: 2026-05-03
 depends_on: []
+decomposition: atomic
+classification: buildable-now
 composes_with: [B-0169]
 tags: [tooling, ts, substrate-claim-checker, verify-then-claim, drift-detection, mechanization, hub-shaped, foundation]
 ---

--- a/docs/backlog/P1/B-0173-hook-authoring-for-skill-creation-contracts-aaron-2026-05-03.md
+++ b/docs/backlog/P1/B-0173-hook-authoring-for-skill-creation-contracts-aaron-2026-05-03.md
@@ -9,6 +9,7 @@ ask: Aaron 2026-05-03 verbatim *"this feature is great for reminding yourself to
 created: 2026-05-03
 last_updated: 2026-05-03
 depends_on: [B-0170, B-0171]
+decomposition: atomic
 composes_with: [B-0169, B-0172]
 tags: [hooks, contract-based-development, design-by-contract, openspec, pre-condition, post-condition, ci, p1-foundation]
 ---

--- a/docs/backlog/P1/B-0191-orchestrator-branch-verify-mechanization-design-aaron-2026-05-04.md
+++ b/docs/backlog/P1/B-0191-orchestrator-branch-verify-mechanization-design-aaron-2026-05-04.md
@@ -9,6 +9,8 @@ ask: Aaron 2026-05-04 verbatim *"for humans this is why oh my zsh reminds us of 
 created: 2026-05-04
 last_updated: 2026-05-05
 depends_on: []
+decomposition: atomic
+classification: buildable-now
 composes_with: [B-0006, B-0140, B-0156, B-0162]
 tags: [orchestrator, concurrency-hazard, mechanization, pre-commit-hook, worktree, foundation]
 ---

--- a/docs/backlog/P1/B-0217-alignment-bidirectional-clause-audit-tightening-2026-05-06.md
+++ b/docs/backlog/P1/B-0217-alignment-bidirectional-clause-audit-tightening-2026-05-06.md
@@ -7,7 +7,8 @@ created: 2026-05-06
 last_updated: 2026-05-06
 parent: B-0003
 depends_on: [B-0215]
-classification: buildable-after-survey
+decomposition: atomic
+classification: buildable-now
 ---
 
 # B-0217 - Bidirectional clause audit and tightening

--- a/docs/backlog/P1/B-0221-alignment-authority-delegation-idle-pr-collaboration-substrate-2026-05-06.md
+++ b/docs/backlog/P1/B-0221-alignment-authority-delegation-idle-pr-collaboration-substrate-2026-05-06.md
@@ -7,6 +7,7 @@ created: 2026-05-06
 last_updated: 2026-05-06
 parent: B-0003
 depends_on: [B-0217, B-0219]
+decomposition: atomic
 classification: blocked-on-bidirectional-and-rigor-clauses
 ---
 


### PR DESCRIPTION
## Summary

- Adds `decomposition: atomic` to 12 P1 backlog items that are single-PR-able
- Adds `classification: buildable-now` to 9 items whose `depends_on` are empty or all closed
- Updates B-0217 classification from `buildable-after-survey` to `buildable-now` (B-0215 dependency is closed)
- Leaves 9 blob-scope items unclassified for future decomposition passes
- Skips 6 items already classified as `decomposed`

## Test plan

- [x] `dotnet build -c Release` passes with 0 warnings, 0 errors
- [x] Changes are frontmatter-only (no body content modified)
- [x] Each `depends_on` chain verified against actual item statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)