### PR TITLE
feat(B-0280): add PR publication executor with push/create-pr/auto-merge sequence

### DIFF
--- a/docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md
+++ b/docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md
@@ -1,7 +1,9 @@
 ---
 id: B-0280
 priority: P0
-status: open
+status: closed
+closed: 2026-05-08
+closed_by: "tools/backlog/pr-publication-executor.ts — executor with push/create-pr/auto-merge sequence and 10 focused tests"
 title: "Autonomous backlog pickup - PR publication and auto-merge"
 created: 2026-05-08
 last_updated: 2026-05-08
@@ -40,3 +42,10 @@ without the maintainer acting as courier or permission surface.
   file argument with a validated `bodyFilePath` input and adds an explicit
   `--write-body` helper that writes the generated review packet exactly once
   before `gh pr create` runs.
+- 2026-05-08: Final slice adds `tools/backlog/pr-publication-executor.ts` —
+  the executor that takes a PublicationPlan, writes the PR body file, pushes
+  the branch, opens the PR via `gh pr create`, parses the PR URL, and arms
+  auto-merge via `gh pr merge --auto --squash` when the gate allows. Command
+  runner is dependency-injected for testability. 10 focused tests cover the
+  full happy path, push/create-pr/auto-merge failures, auto-merge gating,
+  and URL extraction.

--- a/tools/backlog/pr-publication-executor.test.ts
+++ b/tools/backlog/pr-publication-executor.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "bun:test";
+import {
+  executePlan,
+  extractPrUrl,
+  substituteUrl,
+  type CommandResult,
+  type CommandRunner,
+  type PublicationPlan,
+} from "./pr-publication-executor";
+import { buildPublicationPlan, type PublicationInput } from "./pr-publication-plan";
+
+function input(overrides: Partial<PublicationInput> = {}): PublicationInput {
+  return {
+    backlogId: "B-0280",
+    backlogTitle: "PR publication executor",
+    backlogPath: "docs/backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md",
+    branch: "claim/B-0280-pr-publication-executor",
+    baseBranch: "main",
+    bodyFilePath: "tmp/pr-bodies/B-0280.md",
+    summary: ["adds the executor that runs push/create-pr/auto-merge"],
+    checks: [{ command: "bun test", status: "passed" }],
+    requiredChecks: { ok: 1, inProgress: 0, pending: 0, failed: 0 },
+    unresolvedReviewThreads: 0,
+    ...overrides,
+  };
+}
+
+function plan(overrides: Partial<PublicationInput> = {}): PublicationPlan {
+  return buildPublicationPlan(input(overrides));
+}
+
+type CommandLog = Array<{ argv: string[] }>;
+
+function mockRunner(responses: Record<string, CommandResult>): { runner: CommandRunner; log: CommandLog } {
+  const log: CommandLog = [];
+  const runner: CommandRunner = {
+    run(argv: string[]): CommandResult {
+      log.push({ argv: [...argv] });
+      const key = argv[0] ?? "";
+      if (key === "git" && argv[1] === "push") return responses["push"] ?? { exitCode: 0, stdout: "", stderr: "" };
+      if (key === "gh" && argv[1] === "pr" && argv[2] === "create")
+        return responses["create-pr"] ?? { exitCode: 0, stdout: "", stderr: "" };
+      if (key === "gh" && argv[1] === "pr" && argv[2] === "merge")
+        return responses["arm-auto-merge"] ?? { exitCode: 0, stdout: "", stderr: "" };
+      return { exitCode: 1, stdout: "", stderr: "unrecognized command" };
+    },
+  };
+  return { runner, log };
+}
+
+const PR_URL = "https://github.com/Lucent-Financial-Group/Zeta/pull/2070";
+
+describe("extractPrUrl", () => {
+  test("extracts PR URL from gh output", () => {
+    expect(extractPrUrl(PR_URL)).toBe(PR_URL);
+    expect(extractPrUrl(`\n${PR_URL}\n`)).toBe(PR_URL);
+    expect(extractPrUrl("Creating pull request...\n" + PR_URL)).toBe(PR_URL);
+  });
+
+  test("returns null when no PR URL is found", () => {
+    expect(extractPrUrl("")).toBeNull();
+    expect(extractPrUrl("error: something failed")).toBeNull();
+    expect(extractPrUrl("https://github.com/owner/repo/issues/1")).toBeNull();
+  });
+});
+
+describe("substituteUrl", () => {
+  test("replaces <pr-url> placeholder", () => {
+    const argv = ["gh", "pr", "merge", "<pr-url>", "--auto", "--squash"];
+    expect(substituteUrl(argv, PR_URL)).toEqual(["gh", "pr", "merge", PR_URL, "--auto", "--squash"]);
+  });
+
+  test("leaves other args unchanged", () => {
+    const argv = ["gh", "pr", "view"];
+    expect(substituteUrl(argv, PR_URL)).toEqual(["gh", "pr", "view"]);
+  });
+});
+
+describe("executePlan", () => {
+  test("full happy path: push → create-pr → arm-auto-merge", () => {
+    const p = plan();
+    const { runner, log } = mockRunner({
+      push: { exitCode: 0, stdout: "", stderr: "" },
+      "create-pr": { exitCode: 0, stdout: PR_URL + "\n", stderr: "" },
+      "arm-auto-merge": { exitCode: 0, stdout: "auto-merge enabled\n", stderr: "" },
+    });
+
+    const result = executePlan(p, runner);
+
+    expect(result.pushed).toBe(true);
+    expect(result.prCreated).toBe(true);
+    expect(result.prUrl).toBe(PR_URL);
+    expect(result.autoMergeArmed).toBe(true);
+    expect(result.steps).toHaveLength(3);
+    expect(log).toHaveLength(3);
+    expect(log[0]?.argv[0]).toBe("git");
+    expect(log[1]?.argv[0]).toBe("gh");
+    expect(log[2]?.argv).toContain(PR_URL);
+  });
+
+  test("stops on push failure", () => {
+    const p = plan();
+    const { runner, log } = mockRunner({
+      push: { exitCode: 128, stdout: "", stderr: "fatal: remote rejected" },
+    });
+
+    const result = executePlan(p, runner);
+
+    expect(result.pushed).toBe(false);
+    expect(result.prCreated).toBe(false);
+    expect(result.prUrl).toBeNull();
+    expect(result.autoMergeArmed).toBe(false);
+    expect(result.steps).toHaveLength(1);
+    expect(log).toHaveLength(1);
+  });
+
+  test("stops on create-pr failure", () => {
+    const p = plan();
+    const { runner, log } = mockRunner({
+      push: { exitCode: 0, stdout: "", stderr: "" },
+      "create-pr": { exitCode: 1, stdout: "", stderr: "already exists" },
+    });
+
+    const result = executePlan(p, runner);
+
+    expect(result.pushed).toBe(true);
+    expect(result.prCreated).toBe(false);
+    expect(result.autoMergeArmed).toBe(false);
+    expect(result.steps).toHaveLength(2);
+    expect(log).toHaveLength(2);
+  });
+
+  test("skips auto-merge when plan disallows it", () => {
+    const p = plan({ unresolvedReviewThreads: 1 });
+    const { runner, log } = mockRunner({
+      push: { exitCode: 0, stdout: "", stderr: "" },
+      "create-pr": { exitCode: 0, stdout: PR_URL + "\n", stderr: "" },
+    });
+
+    const result = executePlan(p, runner);
+
+    expect(result.pushed).toBe(true);
+    expect(result.prCreated).toBe(true);
+    expect(result.prUrl).toBe(PR_URL);
+    expect(result.autoMergeArmed).toBe(false);
+    expect(result.steps).toHaveLength(2);
+    expect(log).toHaveLength(2);
+  });
+
+  test("handles auto-merge failure gracefully", () => {
+    const p = plan();
+    const { runner } = mockRunner({
+      push: { exitCode: 0, stdout: "", stderr: "" },
+      "create-pr": { exitCode: 0, stdout: PR_URL + "\n", stderr: "" },
+      "arm-auto-merge": { exitCode: 1, stdout: "", stderr: "merge not allowed" },
+    });
+
+    const result = executePlan(p, runner);
+
+    expect(result.pushed).toBe(true);
+    expect(result.prCreated).toBe(true);
+    expect(result.prUrl).toBe(PR_URL);
+    expect(result.autoMergeArmed).toBe(false);
+    expect(result.steps).toHaveLength(3);
+  });
+
+  test("skips auto-merge when PR URL cannot be parsed", () => {
+    const p = plan();
+    const { runner, log } = mockRunner({
+      push: { exitCode: 0, stdout: "", stderr: "" },
+      "create-pr": { exitCode: 0, stdout: "created but no url\n", stderr: "" },
+    });
+
+    const result = executePlan(p, runner);
+
+    expect(result.pushed).toBe(true);
+    expect(result.prCreated).toBe(true);
+    expect(result.prUrl).toBeNull();
+    expect(result.autoMergeArmed).toBe(false);
+    expect(result.steps).toHaveLength(2);
+    expect(log).toHaveLength(2);
+  });
+});

--- a/tools/backlog/pr-publication-executor.ts
+++ b/tools/backlog/pr-publication-executor.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env bun
+// pr-publication-executor.ts -- executes a PublicationPlan built by
+// pr-publication-plan.ts: writes the PR body file, pushes the branch,
+// opens the PR via gh, and arms auto-merge when the gate allows it.
+//
+// B-0280 final slice: the executor path that closes the row.
+
+import { readFileSync } from "node:fs";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import {
+  buildPublicationPlan,
+  writePrBodyFile,
+  type PublicationInput,
+  type PublicationPlan,
+} from "./pr-publication-plan";
+
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface CommandRunner {
+  run(argv: string[]): CommandResult;
+}
+
+export interface ExecutionResult {
+  pushed: boolean;
+  prCreated: boolean;
+  prUrl: string | null;
+  autoMergeArmed: boolean;
+  steps: StepResult[];
+}
+
+export interface StepResult {
+  name: string;
+  argv: string[];
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+const REAL_RUNNER: CommandRunner = {
+  run(argv: string[]): CommandResult {
+    const [cmd, ...args] = argv;
+    if (!cmd) {
+      return { exitCode: 1, stdout: "", stderr: "empty command" };
+    }
+    const result: SpawnSyncReturns<Buffer> = spawnSync(cmd, args, {
+      timeout: 60_000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    return {
+      exitCode: result.status ?? 1,
+      stdout: result.stdout?.toString("utf8") ?? "",
+      stderr: result.stderr?.toString("utf8") ?? "",
+    };
+  },
+};
+
+function extractPrUrl(ghOutput: string): string | null {
+  const lines = ghOutput.trim().split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (/^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/.test(trimmed)) {
+      return trimmed;
+    }
+  }
+  return null;
+}
+
+function substituteUrl(argv: string[], prUrl: string): string[] {
+  return argv.map((arg) => (arg === "<pr-url>" ? prUrl : arg));
+}
+
+export function executePlan(plan: PublicationPlan, runner: CommandRunner = REAL_RUNNER): ExecutionResult {
+  const steps: StepResult[] = [];
+  const result: ExecutionResult = {
+    pushed: false,
+    prCreated: false,
+    prUrl: null,
+    autoMergeArmed: false,
+    steps,
+  };
+
+  // Step 1: push
+  const pushResult = runner.run(plan.commands.push);
+  steps.push({
+    name: "push",
+    argv: plan.commands.push,
+    exitCode: pushResult.exitCode,
+    stdout: pushResult.stdout,
+    stderr: pushResult.stderr,
+  });
+  if (pushResult.exitCode !== 0) {
+    return result;
+  }
+  result.pushed = true;
+
+  // Step 2: create PR
+  const prResult = runner.run(plan.commands.createPr);
+  steps.push({
+    name: "create-pr",
+    argv: plan.commands.createPr,
+    exitCode: prResult.exitCode,
+    stdout: prResult.stdout,
+    stderr: prResult.stderr,
+  });
+  if (prResult.exitCode !== 0) {
+    return result;
+  }
+  result.prCreated = true;
+  result.prUrl = extractPrUrl(prResult.stdout);
+
+  // Step 3: arm auto-merge (only if plan allows it and we got a PR URL)
+  if (plan.commands.armAutoMerge !== null && result.prUrl !== null) {
+    const mergeArgv = substituteUrl(plan.commands.armAutoMerge, result.prUrl);
+    const mergeResult = runner.run(mergeArgv);
+    steps.push({
+      name: "arm-auto-merge",
+      argv: mergeArgv,
+      exitCode: mergeResult.exitCode,
+      stdout: mergeResult.stdout,
+      stderr: mergeResult.stderr,
+    });
+    if (mergeResult.exitCode === 0) {
+      result.autoMergeArmed = true;
+    }
+  }
+
+  return result;
+}
+
+interface CliArgs {
+  inputPath: string | null;
+  json: boolean;
+  dryRun: boolean;
+}
+
+function usage(): string {
+  return [
+    "Usage:",
+    "  bun tools/backlog/pr-publication-executor.ts --input publication.json [--json] [--dry-run]",
+    "",
+    "Reads a PublicationInput JSON, builds the plan, writes the PR body,",
+    "then executes push → create-PR → arm-auto-merge in sequence.",
+    "",
+    "  --dry-run  Print the plan without executing any commands.",
+  ].join("\n");
+}
+
+function parseCliArgs(argv: readonly string[]): CliArgs {
+  const args: CliArgs = { inputPath: null, json: false, dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--input") {
+      const value = argv[++i];
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error("--input requires a value");
+      }
+      args.inputPath = value;
+    } else if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--dry-run") {
+      args.dryRun = true;
+    } else if (arg === "--help" || arg === "-h") {
+      process.stdout.write(`${usage()}\n`);
+      process.exit(0);
+    } else {
+      throw new Error(`unknown arg: ${arg}`);
+    }
+  }
+  if (args.inputPath === null) {
+    throw new Error("--input is required");
+  }
+  return args;
+}
+
+export function main(argv: readonly string[]): number {
+  try {
+    const args = parseCliArgs(argv);
+    const input: PublicationInput = JSON.parse(readFileSync(args.inputPath ?? "", "utf8"));
+    const plan = buildPublicationPlan(input);
+
+    if (args.dryRun) {
+      process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+      return 0;
+    }
+
+    writePrBodyFile(plan);
+    const result = executePlan(plan);
+
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    } else {
+      process.stdout.write(`pushed: ${result.pushed}\n`);
+      process.stdout.write(`pr-created: ${result.prCreated}\n`);
+      if (result.prUrl) {
+        process.stdout.write(`pr-url: ${result.prUrl}\n`);
+      }
+      process.stdout.write(`auto-merge-armed: ${result.autoMergeArmed}\n`);
+      for (const step of result.steps) {
+        if (step.exitCode !== 0) {
+          process.stderr.write(`step ${step.name} failed (exit ${step.exitCode}): ${step.stderr.trim()}\n`);
+        }
+      }
+    }
+
+    return result.pushed && result.prCreated ? 0 : 1;
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n\n${usage()}\n`);
+    return 1;
+  }
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}
+
+export { extractPrUrl, substituteUrl };


### PR DESCRIPTION
## Summary
- Adds `tools/backlog/pr-publication-executor.ts` — the executor that takes a `PublicationPlan`, writes the PR body file, pushes the branch, opens the PR via `gh pr create`, extracts the PR URL, and arms auto-merge via `gh pr merge --auto --squash` when the gate allows.
- Command runner is dependency-injected (`CommandRunner` interface) so the executor is fully testable without hitting real git/gh CLIs.
- 10 focused tests covering happy path, push failure, create-pr failure, auto-merge gating, auto-merge failure, URL extraction, and URL substitution.
- Closes B-0280 (P0).

## Test plan
- [x] `bun test tools/backlog/pr-publication-executor.test.ts` — 10 pass, 45 expect() calls
- [x] `bun test tools/backlog/pr-publication-plan.test.ts` — 15 pass (no regression)
- [x] `dotnet build -c Release` — 0 Warning(s), 0 Error(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)