### PR TITLE
fix(B-0160): correct 7 issues in mechanical-authorization-check decomposition

### DIFF
--- a/docs/backlog/P0/B-0305-mechanical-auth-check-skill-body-2026-05-08.md
+++ b/docs/backlog/P0/B-0305-mechanical-auth-check-skill-body-2026-05-08.md
@@ -3,6 +3,8 @@ id: B-0305
 priority: P0
 status: open
 title: "Mechanical authorization check — skill body (SKILL.md via skill-creator)"
+effort: XS
+ask: "Substrate-class promotion (new skill); needs maintainer grading before landing under .claude/skills/"
 created: 2026-05-08
 last_updated: 2026-05-08
 parent: B-0160
@@ -30,9 +32,10 @@ the implementation script.
    pattern (capability skill, no inline persona).
 2. Body covers: source-filter rule (only human maintainer for pace),
    recency-filter rule (most-recent-not-rescinded wins), rescind-
-   detection semantics, print-at-tick-start output shape, no-grading
-   invariant ("unclear substrate = substrate-quality bug, not
-   judgment problem").
+   detection semantics (explicit revocation only — implicit
+   displacement does NOT rescind), print-at-tick-start output
+   shape, no-grading invariant ("unclear substrate =
+   substrate-quality bug, not judgment problem").
 3. "When to wear / When to defer" section names the composing
    surfaces: `refresh-before-decide`, `never-idle`, `substrate-or-
    it-didn't-happen`, autonomous-loop tick-start.
@@ -40,11 +43,27 @@ the implementation script.
 5. Does NOT reference a TS implementation path — the skill body
    is the contract; implementation lands in B-0306/B-0307.
 
+## Pre-start checklist
+
+_To be completed with proof before implementation begins._
+
+- [ ] Prior-art search: searched skill router for existing
+  "authorization" / "pace" skills; searched `.claude/skills/`
+  directory for overlapping scope
+- [ ] Dependency walk: no `depends_on` — this is a root child
+- [ ] Source materials verified: memory file at
+  `memory/feedback_mechanical_authorization_check_supersedes_
+  introspective_discipline_claudeai_2026_05_02.md` + research doc
+  at `docs/research/2026-05-02-claudeai-mechanical-authorization-
+  check-supersedes-introspective-discipline.md` both exist
+
 ## Composes with
 
 - B-0160 (parent umbrella)
 - B-0306 (extractor implementation honors the contract this skill
   defines)
+- B-0307 (resolver implements the source-filter + rescind rules
+  this skill defines)
 - B-0308 (autonomous-loop wiring references this skill)
 - `memory/feedback_mechanical_authorization_check_supersedes_
   introspective_discipline_claudeai_2026_05_02.md`

--- a/docs/backlog/P0/B-0306-mechanical-auth-check-pace-extractor-ts-2026-05-08.md
+++ b/docs/backlog/P0/B-0306-mechanical-auth-check-pace-extractor-ts-2026-05-08.md
@@ -3,6 +3,7 @@ id: B-0306
 priority: P0
 status: open
 title: "Mechanical authorization check — pace-instruction extractor + test fixtures"
+effort: S
 created: 2026-05-08
 last_updated: 2026-05-08
 parent: B-0160
@@ -21,33 +22,54 @@ tags: [tool-build, mechanical-check, authorization-source, typescript]
 TDD-first: write the test fixtures that define the contract, then
 the TS implementation that satisfies them. The extractor reads
 substrate surfaces (CLAUDE.md, `memory/feedback_*.md` files,
-`CURRENT-aaron.md`) and returns a typed list of pace-instruction
-records with source, timestamp, and raw text.
+`CURRENT-aaron.md`, `docs/active-trajectory.md`) and returns a
+typed list of raw pace-instruction candidate records with source
+attribution, timestamp, and raw text. The extractor does NOT
+determine rescind status — that is the resolver's job (B-0307).
 
 Lands at `tools/authorization/pace-extractor.ts` with paired
 test at `tools/authorization/pace-extractor.test.ts`.
 
 ## Acceptance criteria
 
-1. **Test fixtures** (write first) cover the five cases from B-0160:
-   - Single pace instruction → extracted correctly
+1. **Test fixtures** (write first) cover:
+   - Single pace instruction → extracted correctly with source
+     attribution
    - Two instructions, both from maintainer → both returned in
      chronological order
-   - Peer-AI framing (Claude.ai, Amara, Codex) → filtered out
-     by source-filter (not returned)
+   - Peer-AI framing (Claude.ai, Amara, Codex) present in
+     substrate → extracted with `source: "claude.ai"` (etc.)
+     so the resolver can filter by source
    - No pace instruction in substrate → empty array
-   - Instruction with explicit rescind marker → tagged as rescinded
-2. **Implementation** reads from:
+   - Instruction containing explicit rescind language → extracted
+     with raw text preserved (rescind-detection is resolver's
+     responsibility in B-0307)
+2. **Implementation** reads from (all surfaces listed in B-0160):
    - `CLAUDE.md` pace bullets (grep for pace-relevant patterns)
    - `memory/feedback_*.md` files (parse frontmatter + body for
-     maintainer pace-instructions)
+     pace-instructions)
    - `memory/CURRENT-aaron.md` (if exists — distilled projection)
+   - `docs/active-trajectory.md` (current operative authorizations)
 3. Returns typed `PaceInstruction[]` with fields:
    `{ source: string; timestamp: string | null; raw: string;
-     file: string; rescinded: boolean }`.
+     file: string }`.
+   Note: no `rescinded` field — rescind-detection is a resolver
+   concern (B-0307), not an extraction concern. The extractor
+   returns ALL candidates; the resolver determines which are
+   operative.
 4. Pure function on file content (no side effects) — accepts a
    root-path argument for testability.
 5. TypeScript, runs under Bun (Rule 0).
+
+## Pre-start checklist
+
+_To be completed with proof before implementation begins._
+
+- [ ] Prior-art search: searched skill router, `.claude/skills/`,
+  `tools/`, `memory/` for existing pace-extraction substrate
+- [ ] Dependency walk: B-0160 parent verified as `decomposed`,
+  no unresolved `depends_on` for this child
+- [ ] Reciprocal pointers: B-0307 `depends_on` includes this row
 
 ## Composes with
 

--- a/docs/backlog/P0/B-0307-mechanical-auth-check-source-recency-resolver-2026-05-08.md
+++ b/docs/backlog/P0/B-0307-mechanical-auth-check-source-recency-resolver-2026-05-08.md
@@ -3,10 +3,11 @@ id: B-0307
 priority: P0
 status: open
 title: "Mechanical authorization check — source-filter + recency resolver"
+effort: S
 created: 2026-05-08
 last_updated: 2026-05-08
 parent: B-0160
-depends_on: [B-0306]
+depends_on: [B-0305, B-0306]
 classification: blocked
 decomposition: atomic
 owners: [architect]
@@ -19,8 +20,13 @@ tags: [tool-build, mechanical-check, authorization-source, typescript]
 ## What
 
 The core algorithm: given the `PaceInstruction[]` from B-0306's
-extractor, apply the two-stage mechanical filter (source-filter →
-recency-filter) and return the single operative authorization.
+extractor, apply the three-stage mechanical filter defined by the
+skill body (B-0305): source-filter → rescind-detection →
+recency-filter → return the single operative authorization.
+
+Depends on B-0305 (skill body defines the source-filter rules and
+rescind semantics this tool implements) AND B-0306 (extractor
+provides the `PaceInstruction[]` input type).
 
 Lands at `tools/authorization/resolve-authorization.ts` with
 paired test at `tools/authorization/resolve-authorization.test.ts`.
@@ -31,27 +37,46 @@ paired test at `tools/authorization/resolve-authorization.test.ts`.
    matches the authorized source for the pace-instruction class
    (human maintainer only). Peer-AI, Claude.ai, Amara framings
    are discarded.
-2. **Recency filter** — among source-authorized instructions,
-   returns the most-recent-not-rescinded. An instruction is
-   rescinded only if a later instruction from the same source
-   explicitly revokes it (implicit displacement does NOT rescind).
-3. **Output shape**: `{ operative: PaceInstruction | null;
+2. **Rescind detection** — an instruction is rescinded if a later
+   instruction from the same authorized source explicitly replaces
+   or revokes it. Implicit displacement (later instruction on a
+   different topic) does NOT rescind. This is the resolver's
+   responsibility — the extractor (B-0306) returns raw candidates
+   without rescind tags.
+3. **Recency filter** — among source-authorized, non-rescinded
+   instructions, returns the most recent.
+4. **Output shape**: `{ operative: PaceInstruction | null;
    reason: string; allCandidates: PaceInstruction[];
    filteredOut: PaceInstruction[] }`.
-4. **Test fixtures** (write first) cover:
+5. **Test fixtures** (write first) cover:
    - Cross-instance absorption (Claude.ai "cooling-period"
      alongside maintainer "go-hard") → only maintainer surfaces
-   - Most-recent rescinded → prior instruction wins
+   - Most-recent explicitly rescinded by a later instruction →
+     prior instruction wins
+   - Implicit displacement (later instruction on different topic)
+     → does NOT rescind the pace instruction
    - No maintainer instruction → `operative: null` with
      reason "no operative pace authorization found; default to
      never-idle floor per CLAUDE.md"
-   - Multiple maintainer instructions → most recent wins
-5. Composes: the resolver is a pure function over
+   - Multiple maintainer instructions, none rescinded → most
+     recent wins
+6. Composes: the resolver is a pure function over
    `PaceInstruction[]` — no file I/O.
-6. TypeScript, runs under Bun (Rule 0).
+7. TypeScript, runs under Bun (Rule 0).
+
+## Pre-start checklist
+
+_To be completed with proof before implementation begins._
+
+- [ ] Prior-art search: searched skill router, `.claude/skills/`,
+  `tools/` for existing authorization-resolution substrate
+- [ ] Dependency walk: B-0305 (skill body) landed with source-filter
+  rules; B-0306 (extractor) landed with `PaceInstruction` type
+- [ ] Reciprocal pointers: B-0308 `depends_on` includes this row
 
 ## Composes with
 
 - B-0160 (parent umbrella)
+- B-0305 (skill body defines the contract this tool implements)
 - B-0306 (extractor provides the input type)
 - B-0308 (autonomous-loop wiring calls extractor → resolver)

--- a/docs/backlog/P0/B-0308-mechanical-auth-check-loop-integration-2026-05-08.md
+++ b/docs/backlog/P0/B-0308-mechanical-auth-check-loop-integration-2026-05-08.md
@@ -3,6 +3,7 @@ id: B-0308
 priority: P0
 status: open
 title: "Mechanical authorization check — autonomous-loop tick-start integration"
+effort: S
 created: 2026-05-08
 last_updated: 2026-05-08
 parent: B-0160
@@ -41,6 +42,18 @@ in the chat/console output.
 6. Tick-history shard template includes an "operative-
    authorization" field populated by this check.
 7. TypeScript, runs under Bun (Rule 0).
+
+## Pre-start checklist
+
+_To be completed with proof before implementation begins._
+
+- [ ] Prior-art search: searched `docs/AUTONOMOUS-LOOP.md` for
+  current tick-start sequence; searched `tools/` for existing
+  tick-start wiring patterns
+- [ ] Dependency walk: B-0305 (skill body) landed; B-0307
+  (resolver) landed; both verified in `.claude/skills/` and
+  `tools/authorization/` respectively
+- [ ] Reciprocal pointers: B-0309 `depends_on` includes this row
 
 ## Composes with
 

--- a/docs/backlog/P0/B-0309-mechanical-auth-check-claude-md-pointer-2026-05-08.md
+++ b/docs/backlog/P0/B-0309-mechanical-auth-check-claude-md-pointer-2026-05-08.md
@@ -3,10 +3,11 @@ id: B-0309
 priority: P0
 status: open
 title: "Mechanical authorization check — CLAUDE.md discoverable-skill pointer"
+effort: XS
 created: 2026-05-08
 last_updated: 2026-05-08
 parent: B-0160
-depends_on: [B-0305]
+depends_on: [B-0308]
 classification: blocked
 decomposition: atomic
 owners: [architect]
@@ -24,6 +25,12 @@ or-it-didn't-land rule, the skill exists but is invisible to cold-
 start agents without a CLAUDE.md pointer or a transitive path
 from CLAUDE.md.
 
+Depends on B-0308 (loop integration) rather than just B-0305
+(skill body) because a CLAUDE.md pointer to a skill that doesn't
+work end-to-end would be misleading. The pointer should land only
+after the full pipeline (skill body + extractor + resolver + loop
+integration) is operative.
+
 ## Acceptance criteria
 
 1. CLAUDE.md gains a bullet under "Ground rules Claude Code
@@ -38,9 +45,21 @@ from CLAUDE.md.
    substrate-inventory bullet (the skill is now in the router
    AND in the CLAUDE.md pointer tree).
 
+## Pre-start checklist
+
+_To be completed with proof before implementation begins._
+
+- [ ] Prior-art search: searched CLAUDE.md for existing mechanical-
+  authorization-check bullet; confirmed it references B-0160
+  (to be updated)
+- [ ] Dependency walk: B-0308 (loop integration) landed and
+  verified working; full pipeline (B-0305 → B-0306 → B-0307 →
+  B-0308) is operative
+
 ## Composes with
 
 - B-0160 (parent umbrella)
 - B-0305 (skill body this pointer references)
+- B-0308 (loop integration this pointer presupposes)
 - The wake-time-substrate-or-it-didn't-land CLAUDE.md bullet
 - The skill-router-as-substrate-inventory CLAUDE.md bullet


### PR DESCRIPTION
## Summary

Re-decompose review of PR #2076 children (B-0305..B-0309) found and corrected 7 issues:

1. **Rescind-boundary blurred** — B-0306 extractor tagged `rescinded: boolean` but rescind-detection is the resolver's job (B-0307). Fixed: extractor returns raw candidates without rescind tags; resolver owns the three-stage pipeline (source-filter → rescind-detection → recency-filter).
2. **B-0306 missing search surface** — `docs/active-trajectory.md` listed in parent B-0160 but omitted from extractor acceptance criteria.
3. **B-0307 missing dependency on B-0305** — resolver implements rules defined by the skill body. Changed `depends_on: [B-0306]` → `depends_on: [B-0305, B-0306]`.
4. **B-0309 dependency too narrow** — depended only on B-0305 (skill body) but a CLAUDE.md pointer to a non-functional skill is misleading. Changed to `depends_on: [B-0308]` (loop integration covers full pipeline transitively).
5. **Missing `effort:` fields** — all 5 children now have effort estimates (XS or S).
6. **Missing `ask:` field** — B-0305 (skill body) is a substrate-class promotion needing maintainer grading.
7. **Missing pre-start checklists** — per CLAUDE.md backlog-item start gate rule, all children now have a "Pre-start checklist" section.

### Corrected dependency graph

```
B-0305 (skill body, XS)  ──┬──→  B-0307 (resolver, S)  ──┬──→  B-0308 (loop, S)  ──→  B-0309 (CLAUDE.md, XS)
                            │                              │
B-0306 (extractor, S)  ────┘                              ─┘
```

**Before** (PR #2076):
- B-0307 → B-0306 only (missing B-0305)
- B-0309 → B-0305 only (should be B-0308)
- B-0306 owned rescind logic (should be B-0307)

**After** (this PR):
- B-0307 → [B-0305, B-0306] (resolver implements skill body's rules + consumes extractor type)
- B-0309 → B-0308 (pointer lands only after full pipeline is operative)
- Rescind-detection cleanly owned by B-0307 resolver, not B-0306 extractor

## Test plan

- [x] `dotnet build -c Release` — 0 Warning(s), 0 Error(s)
- [x] `BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts` — index unchanged (IDs/titles stable)
- [x] `depends_on:` chains verified acyclic: B-0305/B-0306 (no deps) → B-0307 → B-0308 → B-0309
- [x] All children have `effort:`, pre-start checklist, and updated `composes_with:` sections
- [x] Rescind-detection responsibility clearly assigned to B-0307 (resolver), not B-0306 (extractor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)