### PR TITLE
fix(B-0281): repair empty-queue pickup red checks

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -20,7 +20,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0278](backlog/P0/B-0278-autonomous-backlog-selector-priority-safe-pickup-2026-05-08.md)** Autonomous backlog pickup - priority selector
 - [x] **[B-0279](backlog/P0/B-0279-autonomous-backlog-claim-worktree-bootstrap-2026-05-08.md)** Autonomous backlog pickup - claim and worktree bootstrap
 - [x] **[B-0280](backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md)** Autonomous backlog pickup - PR publication and auto-merge
-- [ ] **[B-0281](backlog/P0/B-0281-codex-loop-empty-queue-backlog-pickup-integration-2026-05-08.md)** Codex loop - empty queue autonomous backlog pickup
+- [x] **[B-0281](backlog/P0/B-0281-codex-loop-empty-queue-backlog-pickup-integration-2026-05-08.md)** Codex loop - empty queue autonomous backlog pickup
 - [ ] **[B-0305](backlog/P0/B-0305-mechanical-auth-check-skill-body-2026-05-08.md)** Mechanical authorization check — skill body (SKILL.md via skill-creator)
 - [ ] **[B-0306](backlog/P0/B-0306-mechanical-auth-check-pace-extractor-ts-2026-05-08.md)** Mechanical authorization check — pace-instruction extractor + test fixtures
 - [ ] **[B-0307](backlog/P0/B-0307-mechanical-auth-check-source-recency-resolver-2026-05-08.md)** Mechanical authorization check — source-filter + recency resolver

--- a/tools/backlog/empty-queue-pickup.test.ts
+++ b/tools/backlog/empty-queue-pickup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { orchestrate, type CommandRunner, type OrchestrationResult } from "./empty-queue-pickup";
+import { orchestrate, type CommandRunner } from "./empty-queue-pickup";
 
 function fakeRunner(responses: Map<string, { status: number; stdout: string; stderr: string }>): CommandRunner {
   return {

--- a/tools/backlog/empty-queue-pickup.ts
+++ b/tools/backlog/empty-queue-pickup.ts
@@ -249,7 +249,7 @@ export function orchestrate(args: CliArgs, runner: CommandRunner = spawnRunner()
   result.backlogId = backlogId;
   result.executionPrompt = pickup.executionPrompt ?? null;
 
-  if (pickup.status !== "selected" || pickup.selected === null) {
+  if (pickup.status !== "selected" || pickup.selected == null) {
     result.status = "no-selection";
     return result;
   }


### PR DESCRIPTION
## Summary
- removes the unused TypeScript type import left by #2079
- tightens the pickup selected guard so TypeScript narrows before claim bootstrap
- regenerates docs/BACKLOG.md so B-0281 closed status matches the generated index

## Why
#2079 merged before its non-required failed checks could block auto-merge. This follow-up repairs the two failed surfaces without touching the contested root checkout.

## Verification
- `bun test tools/backlog/empty-queue-pickup.test.ts`
- `bun tools/backlog/generate-index.ts --check`
- `bun --bun tsc --noEmit -p tsconfig.json` using the existing Codex control-clone dependency symlink, removed afterward
- `git diff --check`
