### PR TITLE
fix(B-0281): resolve tsc type errors + regenerate backlog index

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -20,7 +20,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0278](backlog/P0/B-0278-autonomous-backlog-selector-priority-safe-pickup-2026-05-08.md)** Autonomous backlog pickup - priority selector
 - [x] **[B-0279](backlog/P0/B-0279-autonomous-backlog-claim-worktree-bootstrap-2026-05-08.md)** Autonomous backlog pickup - claim and worktree bootstrap
 - [x] **[B-0280](backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md)** Autonomous backlog pickup - PR publication and auto-merge
-- [ ] **[B-0281](backlog/P0/B-0281-codex-loop-empty-queue-backlog-pickup-integration-2026-05-08.md)** Codex loop - empty queue autonomous backlog pickup
+- [x] **[B-0281](backlog/P0/B-0281-codex-loop-empty-queue-backlog-pickup-integration-2026-05-08.md)** Codex loop - empty queue autonomous backlog pickup
 - [ ] **[B-0305](backlog/P0/B-0305-mechanical-auth-check-skill-body-2026-05-08.md)** Mechanical authorization check — skill body (SKILL.md via skill-creator)
 - [ ] **[B-0306](backlog/P0/B-0306-mechanical-auth-check-pace-extractor-ts-2026-05-08.md)** Mechanical authorization check — pace-instruction extractor + test fixtures
 - [ ] **[B-0307](backlog/P0/B-0307-mechanical-auth-check-source-recency-resolver-2026-05-08.md)** Mechanical authorization check — source-filter + recency resolver

--- a/tools/backlog/empty-queue-pickup.test.ts
+++ b/tools/backlog/empty-queue-pickup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { orchestrate, type CommandRunner, type OrchestrationResult } from "./empty-queue-pickup";
+import { orchestrate, type CommandRunner } from "./empty-queue-pickup";
 
 function fakeRunner(responses: Map<string, { status: number; stdout: string; stderr: string }>): CommandRunner {
   return {

--- a/tools/backlog/empty-queue-pickup.ts
+++ b/tools/backlog/empty-queue-pickup.ts
@@ -249,7 +249,7 @@ export function orchestrate(args: CliArgs, runner: CommandRunner = spawnRunner()
   result.backlogId = backlogId;
   result.executionPrompt = pickup.executionPrompt ?? null;
 
-  if (pickup.status !== "selected" || pickup.selected === null) {
+  if (pickup.status !== "selected" || pickup.selected == null) {
     result.status = "no-selection";
     return result;
   }


### PR DESCRIPTION
## Summary
- Fix TS2345: `pickup.selected` null guard uses `== null` (covers both `null` and `undefined`) instead of `=== null`, allowing TypeScript to narrow the optional field correctly at the `runClaimBootstrap` call site.
- Fix TS6133: remove unused `OrchestrationResult` type import from test file.
- Regenerate `docs/BACKLOG.md` to reflect B-0281 `status: closed`.

These are the two non-required CI failures (`lint (tsc tools)` + `check docs/BACKLOG.md generated-index drift`) from PR #2079, which auto-merged before the fixes landed.

## Test plan
- [x] `tsc --noEmit -p tsconfig.json` passes clean
- [x] `bun tools/backlog/generate-index.ts --check` passes
- [x] `bun test tools/backlog/empty-queue-pickup.test.ts` — 7/7 pass
- [x] `dotnet build -c Release` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)