### PR TITLE
feat(B-0306): pace-instruction extractor + test fixtures

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -21,7 +21,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0279](backlog/P0/B-0279-autonomous-backlog-claim-worktree-bootstrap-2026-05-08.md)** Autonomous backlog pickup - claim and worktree bootstrap
 - [x] **[B-0280](backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md)** Autonomous backlog pickup - PR publication and auto-merge
 - [x] **[B-0281](backlog/P0/B-0281-codex-loop-empty-queue-backlog-pickup-integration-2026-05-08.md)** Codex loop - empty queue autonomous backlog pickup
-- [ ] **[B-0305](backlog/P0/B-0305-mechanical-auth-check-skill-body-2026-05-08.md)** Mechanical authorization check — skill body (SKILL.md via skill-creator)
+- [x] **[B-0305](backlog/P0/B-0305-mechanical-auth-check-skill-body-2026-05-08.md)** Mechanical authorization check — skill body (SKILL.md via skill-creator)
 - [ ] **[B-0306](backlog/P0/B-0306-mechanical-auth-check-pace-extractor-ts-2026-05-08.md)** Mechanical authorization check — pace-instruction extractor + test fixtures
 - [ ] **[B-0307](backlog/P0/B-0307-mechanical-auth-check-source-recency-resolver-2026-05-08.md)** Mechanical authorization check — source-filter + recency resolver
 - [ ] **[B-0308](backlog/P0/B-0308-mechanical-auth-check-loop-integration-2026-05-08.md)** Mechanical authorization check — autonomous-loop tick-start integration

--- a/docs/backlog/P0/B-0306-mechanical-auth-check-pace-extractor-ts-2026-05-08.md
+++ b/docs/backlog/P0/B-0306-mechanical-auth-check-pace-extractor-ts-2026-05-08.md
@@ -63,13 +63,19 @@ test at `tools/authorization/pace-extractor.test.ts`.
 
 ## Pre-start checklist
 
-_To be completed with proof before implementation begins._
+Completed 2026-05-08.
 
-- [ ] Prior-art search: searched skill router, `.claude/skills/`,
-  `tools/`, `memory/` for existing pace-extraction substrate
-- [ ] Dependency walk: B-0160 parent verified as `decomposed`,
-  no unresolved `depends_on` for this child
-- [ ] Reciprocal pointers: B-0307 `depends_on` includes this row
+- [x] Prior-art search: grepped `pace-extractor|PaceInstruction`
+  across repo — 7 hits, all in backlog/skill/research docs, no
+  existing TS implementation. `tools/authorization/` directory
+  does not exist. Skill router has `mechanical-authorization-check`
+  skill (B-0305, landed PR #2082) — defines contract only, no
+  implementation. No other extraction substrate found.
+- [x] Dependency walk: B-0160 parent verified as `decomposed`
+  with `children: [B-0305, B-0306, B-0307, B-0308, B-0309]`.
+  B-0306 has `depends_on: []` — no blockers.
+- [x] Reciprocal pointers: B-0307 has `depends_on: [B-0305, B-0306]`
+  — confirmed includes this row.
 
 ## Composes with
 

--- a/tools/authorization/pace-extractor.test.ts
+++ b/tools/authorization/pace-extractor.test.ts
@@ -4,6 +4,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { extractPaceInstructions, type PaceInstruction } from "./pace-extractor.ts";
 
+function instructionAt(
+  instructions: PaceInstruction[],
+  index: number,
+): PaceInstruction {
+  const instruction = instructions[index];
+  expect(instruction).toBeDefined();
+  return instruction!;
+}
+
 function makeTempRoot(): string {
   const root = mkdtempSync(join(tmpdir(), "pace-ext-"));
   mkdirSync(join(root, "memory"), { recursive: true });
@@ -31,10 +40,11 @@ describe("extractPaceInstructions", () => {
 
     const result = await extractPaceInstructions(root);
     expect(result.length).toBe(1);
-    expect(result[0].source).toBe("aaron");
-    expect(result[0].file).toContain("feedback_go_hard_aaron_2026_05_02.md");
-    expect(result[0].raw).toContain("go hard");
-    expect(result[0].timestamp).toBe("2026-05-02");
+    const instruction = instructionAt(result, 0);
+    expect(instruction.source).toBe("aaron");
+    expect(instruction.file).toContain("feedback_go_hard_aaron_2026_05_02.md");
+    expect(instruction.raw).toContain("go hard");
+    expect(instruction.timestamp).toBe("2026-05-02");
   });
 
   test("two instructions from maintainer → both returned in chronological order", async () => {
@@ -70,7 +80,9 @@ describe("extractPaceInstructions", () => {
 
     const result = await extractPaceInstructions(root);
     expect(result.length).toBe(2);
-    expect(result[0].timestamp!.localeCompare(result[1].timestamp!)).toBeLessThanOrEqual(0);
+    const first = instructionAt(result, 0);
+    const second = instructionAt(result, 1);
+    expect((first.timestamp ?? "").localeCompare(second.timestamp ?? "")).toBeLessThanOrEqual(0);
   });
 
   test("peer-AI framing → extracted with peer-AI source tag", async () => {
@@ -149,8 +161,9 @@ describe("extractPaceInstructions", () => {
 
     const result = await extractPaceInstructions(root);
     expect(result.length).toBe(1);
-    expect(result[0].raw).toContain("stop grinding");
-    expect(result[0].source).toBe("aaron");
+    const instruction = instructionAt(result, 0);
+    expect(instruction.raw).toContain("stop grinding");
+    expect(instruction.source).toBe("aaron");
   });
 
   test("CLAUDE.md pace bullet → extracted", async () => {
@@ -190,9 +203,10 @@ describe("extractPaceInstructions", () => {
 
     const result = await extractPaceInstructions(root);
     expect(result.length).toBe(1);
-    expect(result[0].source).toBe("aaron");
-    expect(result[0].raw).toContain("keep grinding");
-    expect(result[0].file).toContain("CURRENT-aaron.md");
+    const instruction = instructionAt(result, 0);
+    expect(instruction.source).toBe("aaron");
+    expect(instruction.raw).toContain("keep grinding");
+    expect(instruction.file).toContain("CURRENT-aaron.md");
   });
 
   test("docs/active-trajectory.md → extracted", async () => {
@@ -208,7 +222,8 @@ describe("extractPaceInstructions", () => {
 
     const result = await extractPaceInstructions(root);
     expect(result.length).toBe(1);
-    expect(result[0].file).toContain("active-trajectory.md");
+    const instruction = instructionAt(result, 0);
+    expect(instruction.file).toContain("active-trajectory.md");
   });
 
   test("mixed sources across surfaces → all extracted", async () => {
@@ -270,7 +285,8 @@ describe("extractPaceInstructions", () => {
 
     const result = await extractPaceInstructions(root);
     expect(result.length).toBe(1);
-    expect(result[0].source).toBe("amara");
+    const instruction = instructionAt(result, 0);
+    expect(instruction.source).toBe("amara");
   });
 
   test("missing surfaces gracefully handled", async () => {

--- a/tools/authorization/pace-extractor.test.ts
+++ b/tools/authorization/pace-extractor.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { extractPaceInstructions, type PaceInstruction } from "./pace-extractor.ts";
+
+function makeTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "pace-ext-"));
+  mkdirSync(join(root, "memory"), { recursive: true });
+  mkdirSync(join(root, "docs"), { recursive: true });
+  return root;
+}
+
+describe("extractPaceInstructions", () => {
+  test("single pace instruction from memory file → extracted with source attribution", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "feedback_go_hard_aaron_2026_05_02.md"),
+      [
+        "---",
+        "name: Go hard authorization",
+        "description: Aaron authorized go-hard overnight",
+        "type: feedback",
+        "---",
+        "",
+        "Aaron 2026-05-02 ~00:42Z:",
+        "",
+        '> *"you can go hard, you don\'t have to do minimum action"*',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(1);
+    expect(result[0].source).toBe("aaron");
+    expect(result[0].file).toContain("feedback_go_hard_aaron_2026_05_02.md");
+    expect(result[0].raw).toContain("go hard");
+    expect(result[0].timestamp).toBe("2026-05-02");
+  });
+
+  test("two instructions from maintainer → both returned in chronological order", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "feedback_go_hard_aaron_2026_05_01.md"),
+      [
+        "---",
+        "name: Go hard first",
+        "description: First go-hard",
+        "type: feedback",
+        "---",
+        "",
+        "Aaron 2026-05-01:",
+        "",
+        '> *"go hard on the backlog"*',
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(root, "memory", "feedback_rest_now_aaron_2026_05_02.md"),
+      [
+        "---",
+        "name: Rest now",
+        "description: Rest instruction",
+        "type: feedback",
+        "---",
+        "",
+        "Aaron 2026-05-02:",
+        "",
+        '> *"rest now, hold the line"*',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(2);
+    expect(result[0].timestamp!.localeCompare(result[1].timestamp!)).toBeLessThanOrEqual(0);
+  });
+
+  test("peer-AI framing → extracted with peer-AI source tag", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "feedback_cooling_period_claudeai_2026_05_02.md"),
+      [
+        "---",
+        "name: Cooling period advisory",
+        "description: Claude.ai suggested cooling period",
+        "type: feedback",
+        "---",
+        "",
+        "Claude.ai 2026-05-02:",
+        "",
+        '> *"cooling period applies after the intense session"*',
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(root, "memory", "feedback_codex_pace_note_codex_2026_05_03.md"),
+      [
+        "---",
+        "name: Codex pace framing",
+        "description: Codex suggested holding",
+        "type: feedback",
+        "---",
+        "",
+        "Codex 2026-05-03:",
+        "",
+        '> *"recommend holding until maintainer returns"*',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    const sources = result.map((r) => r.source);
+    expect(sources).toContain("claude.ai");
+    expect(sources).toContain("codex");
+  });
+
+  test("no pace instruction in substrate → empty array", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "feedback_some_unrelated_topic_2026_05_01.md"),
+      [
+        "---",
+        "name: Unrelated topic",
+        "description: Nothing about pace",
+        "type: feedback",
+        "---",
+        "",
+        "This file discusses the build gate configuration.",
+        "No pace instructions here.",
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(0);
+  });
+
+  test("instruction with rescind language → extracted with raw text preserved", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "feedback_stop_grinding_aaron_2026_05_03.md"),
+      [
+        "---",
+        "name: Stop grinding",
+        "description: Aaron rescinded go-hard",
+        "type: feedback",
+        "---",
+        "",
+        "Aaron 2026-05-03:",
+        "",
+        '> *"stop grinding, take it easy for now"*',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(1);
+    expect(result[0].raw).toContain("stop grinding");
+    expect(result[0].source).toBe("aaron");
+  });
+
+  test("CLAUDE.md pace bullet → extracted", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "CLAUDE.md"),
+      [
+        "# CLAUDE.md",
+        "",
+        "Some preamble text.",
+        "",
+        '- **No-op cadence is the failure mode** — Aaron 2026-05-02: *"you can go hard"*',
+        "",
+        "Other content.",
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    const fromClaude = result.find((r) => r.file.endsWith("CLAUDE.md"));
+    expect(fromClaude).toBeDefined();
+    expect(fromClaude!.raw).toContain("go hard");
+  });
+
+  test("CURRENT-aaron.md → extracted", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "CURRENT-aaron.md"),
+      [
+        "# CURRENT-aaron.md",
+        "",
+        "## Pace",
+        "",
+        'Aaron 2026-05-07: *"keep grinding through backlog"*',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(1);
+    expect(result[0].source).toBe("aaron");
+    expect(result[0].raw).toContain("keep grinding");
+    expect(result[0].file).toContain("CURRENT-aaron.md");
+  });
+
+  test("docs/active-trajectory.md → extracted", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "docs", "active-trajectory.md"),
+      [
+        "# Active trajectory",
+        "",
+        'Aaron 2026-05-06: *"go hard on B-0160 decomposition"*',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(1);
+    expect(result[0].file).toContain("active-trajectory.md");
+  });
+
+  test("mixed sources across surfaces → all extracted", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "feedback_go_hard_aaron_2026_05_02.md"),
+      [
+        "---",
+        "name: Go hard",
+        "description: Maintainer go-hard",
+        "type: feedback",
+        "---",
+        "",
+        'Aaron 2026-05-02: *"go hard overnight"*',
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(root, "memory", "feedback_cooling_claudeai_2026_05_02.md"),
+      [
+        "---",
+        "name: Cooling",
+        "description: Claude.ai cooling period",
+        "type: feedback",
+        "---",
+        "",
+        'Claude.ai 2026-05-02: *"cooling period applies"*',
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(root, "memory", "CURRENT-aaron.md"),
+      [
+        "# CURRENT-aaron.md",
+        "",
+        'Aaron 2026-05-04: *"keep working on the backlog"*',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(3);
+    const sources = result.map((r) => r.source);
+    expect(sources).toContain("aaron");
+    expect(sources).toContain("claude.ai");
+  });
+
+  test("Amara framing → extracted with source amara", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "feedback_amara_hold_amara_2026_05_01.md"),
+      [
+        "---",
+        "name: Amara hold",
+        "description: Amara suggested holding",
+        "type: feedback",
+        "---",
+        "",
+        'Amara 2026-05-01: *"hold until maintainer confirms"*',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(1);
+    expect(result[0].source).toBe("amara");
+  });
+
+  test("missing surfaces gracefully handled", async () => {
+    const root = makeTempRoot();
+    const result = await extractPaceInstructions(root);
+    expect(result).toEqual([]);
+  });
+});

--- a/tools/authorization/pace-extractor.ts
+++ b/tools/authorization/pace-extractor.ts
@@ -61,11 +61,17 @@ function inferSource(text: string, filename: string): string {
 }
 
 function extractTimestamp(text: string, filename: string): string | null {
-  const inlineMatch = text.match(DATE_RE);
-  if (inlineMatch) return inlineMatch[1];
+  const inlineMatch = DATE_RE.exec(text);
+  const inlineTimestamp = inlineMatch?.[1];
+  if (inlineTimestamp !== undefined) return inlineTimestamp;
 
-  const fnMatch = filename.match(FILENAME_DATE_RE);
-  if (fnMatch) return `${fnMatch[1]}-${fnMatch[2]}-${fnMatch[3]}`;
+  const fnMatch = FILENAME_DATE_RE.exec(filename);
+  const year = fnMatch?.[1];
+  const month = fnMatch?.[2];
+  const day = fnMatch?.[3];
+  if (year !== undefined && month !== undefined && day !== undefined) {
+    return `${year}-${month}-${day}`;
+  }
 
   return null;
 }

--- a/tools/authorization/pace-extractor.ts
+++ b/tools/authorization/pace-extractor.ts
@@ -1,0 +1,151 @@
+/**
+ * Mechanical authorization check — pace-instruction extractor (B-0306).
+ *
+ * Pure function: reads substrate surfaces, returns typed PaceInstruction[]
+ * with source attribution. Does NOT determine rescind status — that is
+ * the resolver's job (B-0307).
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+export interface PaceInstruction {
+  source: string;
+  timestamp: string | null;
+  raw: string;
+  file: string;
+}
+
+const PACE_PATTERNS = [
+  /go\s+hard/i,
+  /grind(?:ing)?\s+(?:through|the|on)/i,
+  /keep\s+(?:working|grinding)/i,
+  /really\s+look\s+at\s+the\s+backlog/i,
+  /stop\s+grinding/i,
+  /hold\s+the\s+line/i,
+  /rest\s+now/i,
+  /cooling\s+period/i,
+  /take\s+it\s+easy/i,
+  /don'?t\s+have\s+to\s+do\s+minimum/i,
+  /you\s+(?:can|are)\s+(?:authorized|go)/i,
+  /recommend\s+holding/i,
+  /hold\s+until\s+maintainer/i,
+];
+
+const SOURCE_PATTERNS: [RegExp, string][] = [
+  [/\bAaron\b/i, "aaron"],
+  [/\bClaude\.ai\b/i, "claude.ai"],
+  [/\bCodex\b/i, "codex"],
+  [/\bAmara\b/i, "amara"],
+  [/\bGemini\b/i, "gemini"],
+  [/\bGrok\b/i, "grok"],
+  [/\bAni\b/i, "ani"],
+  [/\bRiven\b/i, "riven"],
+];
+
+const DATE_RE = /\b(20\d{2}-\d{2}-\d{2})\b/;
+const FILENAME_DATE_RE = /(\d{4})_(\d{2})_(\d{2})/;
+
+function containsPaceInstruction(text: string): boolean {
+  return PACE_PATTERNS.some((p) => p.test(text));
+}
+
+function inferSource(text: string, filename: string): string {
+  for (const [re, label] of SOURCE_PATTERNS) {
+    if (re.test(text)) return label;
+  }
+  for (const [re, label] of SOURCE_PATTERNS) {
+    if (re.test(filename)) return label;
+  }
+  return "unknown";
+}
+
+function extractTimestamp(text: string, filename: string): string | null {
+  const inlineMatch = text.match(DATE_RE);
+  if (inlineMatch) return inlineMatch[1];
+
+  const fnMatch = filename.match(FILENAME_DATE_RE);
+  if (fnMatch) return `${fnMatch[1]}-${fnMatch[2]}-${fnMatch[3]}`;
+
+  return null;
+}
+
+function extractRawQuote(text: string): string {
+  const lines = text.split("\n");
+  const paceLines: string[] = [];
+  for (const line of lines) {
+    if (PACE_PATTERNS.some((p) => p.test(line))) {
+      paceLines.push(line.trim());
+    }
+  }
+  return paceLines.join(" ").slice(0, 500);
+}
+
+function stripFrontmatter(content: string): string {
+  if (!content.startsWith("---")) return content;
+  const endIdx = content.indexOf("---", 3);
+  if (endIdx === -1) return content;
+  return content.slice(endIdx + 3);
+}
+
+function extractFromFile(
+  filePath: string,
+  rootPath: string,
+): PaceInstruction[] {
+  if (!existsSync(filePath)) return [];
+
+  const content = readFileSync(filePath, "utf-8");
+  const body = stripFrontmatter(content);
+
+  if (!containsPaceInstruction(body)) return [];
+
+  const relPath = relative(rootPath, filePath);
+  const source = inferSource(body, relPath);
+  const timestamp = extractTimestamp(body, relPath);
+  const raw = extractRawQuote(body);
+
+  return [{ source, timestamp, raw, file: relPath }];
+}
+
+export async function extractPaceInstructions(
+  rootPath: string,
+): Promise<PaceInstruction[]> {
+  const results: PaceInstruction[] = [];
+
+  // Surface 1: CLAUDE.md
+  results.push(...extractFromFile(join(rootPath, "CLAUDE.md"), rootPath));
+
+  // Surface 2: memory/feedback_*.md files
+  const memoryDir = join(rootPath, "memory");
+  if (existsSync(memoryDir)) {
+    const files = readdirSync(memoryDir).filter(
+      (f) => f.startsWith("feedback_") && f.endsWith(".md"),
+    );
+    for (const f of files) {
+      results.push(...extractFromFile(join(memoryDir, f), rootPath));
+    }
+  }
+
+  // Surface 3: memory/CURRENT-aaron.md
+  results.push(
+    ...extractFromFile(join(rootPath, "memory", "CURRENT-aaron.md"), rootPath),
+  );
+
+  // Surface 4: docs/active-trajectory.md
+  results.push(
+    ...extractFromFile(
+      join(rootPath, "docs", "active-trajectory.md"),
+      rootPath,
+    ),
+  );
+
+  // Sort chronologically (nulls last)
+  results.sort((a, b) => {
+    if (a.timestamp === b.timestamp) return 0;
+    if (a.timestamp === null) return 1;
+    if (b.timestamp === null) return -1;
+    return a.timestamp.localeCompare(b.timestamp);
+  });
+
+  return results;
+}


### PR DESCRIPTION
## Summary

- TDD-first implementation of `tools/authorization/pace-extractor.ts` — the substrate scanner for the mechanical authorization check (B-0160 parent).
- Reads four surfaces (CLAUDE.md, `memory/feedback_*.md`, `memory/CURRENT-aaron.md`, `docs/active-trajectory.md`) and returns `PaceInstruction[]` with source attribution, timestamp, and raw text.
- 11 test fixtures in `tools/authorization/pace-extractor.test.ts` covering all five B-0306 acceptance criteria.
- Pre-start checklist completed with proof on the backlog item.

## Design

The extractor is a pure function (`extractPaceInstructions(rootPath)`) with no side effects. It:
1. Strips YAML frontmatter before scanning body text
2. Matches pace-relevant patterns (go hard, grind, rest, hold, cooling period, etc.)
3. Infers source attribution from body text first, filename second
4. Extracts timestamps from inline dates or filename date suffixes
5. Returns ALL candidates — no filtering by source authority or rescind status (that's B-0307's job)

## Test plan

- [x] `bun test tools/authorization/pace-extractor.test.ts` — 11 pass, 0 fail, 28 expects
- [x] `dotnet build -c Release` — 0 warnings, 0 errors

## Unblocks

- B-0307 (source-filter + recency resolver) depends on this extractor's `PaceInstruction` type.


🤖 Generated with [Claude Code](https://claude.com/claude-code)