### PR TITLE
fix(B-0306): preserve pace instruction boundaries

### DIFF
--- a/tools/authorization/pace-extractor.test.ts
+++ b/tools/authorization/pace-extractor.test.ts
@@ -122,6 +122,48 @@ describe("extractPaceInstructions", () => {
     expect(sources).toContain("codex");
   });
 
+  test("peer-authored file mentioning Aaron uses filename source", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "feedback_cooling_claudeai_2026_05_04.md"),
+      [
+        "---",
+        "name: Peer summary of maintainer pace",
+        "description: Claude.ai discusses Aaron pace language",
+        "type: feedback",
+        "---",
+        "",
+        "Claude.ai 2026-05-04:",
+        "",
+        'Aaron used the phrase "go hard", but recommend holding until maintainer returns.',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(1);
+    const instruction = instructionAt(result, 0);
+    expect(instruction.source).toBe("claude.ai");
+    expect(instruction.raw).toContain("recommend holding");
+  });
+
+  test("multiple pace lines in one file emit separate candidates", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "CURRENT-aaron.md"),
+      [
+        "# CURRENT-aaron.md",
+        "",
+        'Aaron 2026-05-01: *"go hard on B-0160"*',
+        'Aaron 2026-05-02: *"rest now, hold the line"*',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(2);
+    expect(instructionAt(result, 0).raw).toContain("go hard");
+    expect(instructionAt(result, 1).raw).toContain("rest now");
+  });
+
   test("no pace instruction in substrate → empty array", async () => {
     const root = makeTempRoot();
     writeFileSync(

--- a/tools/authorization/pace-extractor.test.ts
+++ b/tools/authorization/pace-extractor.test.ts
@@ -188,6 +188,28 @@ describe("extractPaceInstructions", () => {
     expect(instruction.timestamp).toBe("2026-05-02");
   });
 
+  test("multi-line pace quote inherits attribution header", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "CLAUDE.md"),
+      [
+        "# CLAUDE.md",
+        "",
+        "Aaron 2026-05-02:",
+        "",
+        '> *"go hard on B-0160"*',
+        '> *"you can go hard, you don\'t have to do minimum action"*',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(2);
+    for (const instruction of result) {
+      expect(instruction.source).toBe("aaron");
+      expect(instruction.timestamp).toBe("2026-05-02");
+    }
+  });
+
   test("multiple pace lines in one file emit separate candidates with correct timestamps", async () => {
     const root = makeTempRoot();
     writeFileSync(

--- a/tools/authorization/pace-extractor.test.ts
+++ b/tools/authorization/pace-extractor.test.ts
@@ -122,7 +122,7 @@ describe("extractPaceInstructions", () => {
     expect(sources).toContain("codex");
   });
 
-  test("peer-authored file mentioning Aaron uses filename source", async () => {
+  test("peer-authored file mentioning Aaron uses issuer line for source", async () => {
     const root = makeTempRoot();
     writeFileSync(
       join(root, "memory", "feedback_cooling_claudeai_2026_05_04.md"),
@@ -145,6 +145,47 @@ describe("extractPaceInstructions", () => {
     expect(instruction.source).toBe("claude.ai");
     expect(instruction.raw).toContain("recommend holding");
     expect(instruction.timestamp).toBe("2026-05-04");
+  });
+
+  test("peer-authored file without issuer line falls back to filename source", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "feedback_cooling_claudeai_2026_05_04.md"),
+      [
+        "---",
+        "name: Peer summary of maintainer pace",
+        "description: Claude.ai discusses Aaron pace language",
+        "type: feedback",
+        "---",
+        "",
+        'Aaron used the phrase "go hard", but recommend holding until maintainer returns.',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(1);
+    const instruction = instructionAt(result, 0);
+    expect(instruction.source).toBe("claude.ai");
+  });
+
+  test("role-ref 'the human maintainer' recognized as aaron source", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "CLAUDE.md"),
+      [
+        "# CLAUDE.md",
+        "",
+        "the human maintainer 2026-05-02:",
+        "",
+        '> *"go hard, you don\'t have to do minimum action"*',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(1);
+    const instruction = instructionAt(result, 0);
+    expect(instruction.source).toBe("aaron");
+    expect(instruction.timestamp).toBe("2026-05-02");
   });
 
   test("multiple pace lines in one file emit separate candidates with correct timestamps", async () => {

--- a/tools/authorization/pace-extractor.test.ts
+++ b/tools/authorization/pace-extractor.test.ts
@@ -144,6 +144,7 @@ describe("extractPaceInstructions", () => {
     const instruction = instructionAt(result, 0);
     expect(instruction.source).toBe("claude.ai");
     expect(instruction.raw).toContain("recommend holding");
+    expect(instruction.timestamp).toBe("2026-05-04");
   });
 
   test("multiple pace lines in one file emit separate candidates", async () => {
@@ -161,7 +162,9 @@ describe("extractPaceInstructions", () => {
     const result = await extractPaceInstructions(root);
     expect(result.length).toBe(2);
     expect(instructionAt(result, 0).raw).toContain("go hard");
+    expect(instructionAt(result, 0).timestamp).toBe("2026-05-01");
     expect(instructionAt(result, 1).raw).toContain("rest now");
+    expect(instructionAt(result, 1).timestamp).toBe("2026-05-02");
   });
 
   test("no pace instruction in substrate → empty array", async () => {
@@ -227,7 +230,9 @@ describe("extractPaceInstructions", () => {
     expect(result.length).toBeGreaterThanOrEqual(1);
     const fromClaude = result.find((r) => r.file.endsWith("CLAUDE.md"));
     expect(fromClaude).toBeDefined();
+    expect(fromClaude!.source).toBe("aaron");
     expect(fromClaude!.raw).toContain("go hard");
+    expect(fromClaude!.timestamp).toBe("2026-05-02");
   });
 
   test("CURRENT-aaron.md → extracted", async () => {

--- a/tools/authorization/pace-extractor.test.ts
+++ b/tools/authorization/pace-extractor.test.ts
@@ -147,7 +147,7 @@ describe("extractPaceInstructions", () => {
     expect(instruction.timestamp).toBe("2026-05-04");
   });
 
-  test("multiple pace lines in one file emit separate candidates", async () => {
+  test("multiple pace lines in one file emit separate candidates with correct timestamps", async () => {
     const root = makeTempRoot();
     writeFileSync(
       join(root, "memory", "CURRENT-aaron.md"),

--- a/tools/authorization/pace-extractor.test.ts
+++ b/tools/authorization/pace-extractor.test.ts
@@ -331,6 +331,26 @@ describe("extractPaceInstructions", () => {
     expect(instruction.source).toBe("amara");
   });
 
+  test("CLAUDE.md entry quoting Aaron → attributed to aaron, not claude.ai", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "CLAUDE.md"),
+      [
+        "# CLAUDE.md",
+        "",
+        "Aaron 2026-05-02:",
+        "",
+        '> *"go hard, you don\'t have to do minimum action"*',
+      ].join("\n"),
+    );
+
+    const result = await extractPaceInstructions(root);
+    expect(result.length).toBe(1);
+    const instruction = instructionAt(result, 0);
+    expect(instruction.source).toBe("aaron");
+    expect(instruction.file).toBe("CLAUDE.md");
+  });
+
   test("missing surfaces gracefully handled", async () => {
     const root = makeTempRoot();
     const result = await extractPaceInstructions(root);

--- a/tools/authorization/pace-extractor.ts
+++ b/tools/authorization/pace-extractor.ts
@@ -34,7 +34,7 @@ const PACE_PATTERNS = [
 
 const SOURCE_PATTERNS: [RegExp, string][] = [
   [/\bAaron\b/i, "aaron"],
-  [/\bClaude\.ai\b/i, "claude.ai"],
+  [/\bClaude(?:\.ai|ai)?\b/i, "claude.ai"],
   [/\bCodex\b/i, "codex"],
   [/\bAmara\b/i, "amara"],
   [/\bGemini\b/i, "gemini"],
@@ -43,21 +43,53 @@ const SOURCE_PATTERNS: [RegExp, string][] = [
   [/\bRiven\b/i, "riven"],
 ];
 
+const FILENAME_SOURCE_PATTERNS: [RegExp, string][] = [
+  [/(?:^|[/_.-])aaron(?:[/_.-]|$)/i, "aaron"],
+  [/(?:^|[/_.-])claude(?:[_.-]?ai)?(?:[/_.-]|$)/i, "claude.ai"],
+  [/(?:^|[/_.-])codex(?:[/_.-]|$)/i, "codex"],
+  [/(?:^|[/_.-])amara(?:[/_.-]|$)/i, "amara"],
+  [/(?:^|[/_.-])gemini(?:[/_.-]|$)/i, "gemini"],
+  [/(?:^|[/_.-])grok(?:[/_.-]|$)/i, "grok"],
+  [/(?:^|[/_.-])ani(?:[/_.-]|$)/i, "ani"],
+  [/(?:^|[/_.-])riven(?:[/_.-]|$)/i, "riven"],
+];
+
 const DATE_RE = /\b(20\d{2}-\d{2}-\d{2})\b/;
 const FILENAME_DATE_RE = /(\d{4})_(\d{2})_(\d{2})/;
+const NON_EMPTY_RE = /\S/;
 
-function containsPaceInstruction(text: string): boolean {
-  return PACE_PATTERNS.some((p) => p.test(text));
+function containsPaceInstruction(line: string): boolean {
+  return PACE_PATTERNS.some((p) => p.test(line));
 }
 
-function inferSource(text: string, filename: string): string {
+function inferSourceFromText(text: string): string {
   for (const [re, label] of SOURCE_PATTERNS) {
     if (re.test(text)) return label;
   }
-  for (const [re, label] of SOURCE_PATTERNS) {
+  return "unknown";
+}
+
+function inferSourceFromFilename(filename: string): string {
+  for (const [re, label] of FILENAME_SOURCE_PATTERNS) {
     if (re.test(filename)) return label;
   }
   return "unknown";
+}
+
+function inferSource(
+  raw: string,
+  previousLine: string | null,
+  filename: string,
+): string {
+  const filenameSource = inferSourceFromFilename(filename);
+  if (filenameSource !== "unknown") return filenameSource;
+
+  if (previousLine !== null) {
+    const issuerSource = inferSourceFromText(previousLine);
+    if (issuerSource !== "unknown") return issuerSource;
+  }
+
+  return inferSourceFromText(raw);
 }
 
 function extractTimestamp(text: string, filename: string): string | null {
@@ -76,22 +108,21 @@ function extractTimestamp(text: string, filename: string): string | null {
   return null;
 }
 
-function extractRawQuote(text: string): string {
-  const lines = text.split("\n");
-  const paceLines: string[] = [];
-  for (const line of lines) {
-    if (PACE_PATTERNS.some((p) => p.test(line))) {
-      paceLines.push(line.trim());
-    }
-  }
-  return paceLines.join(" ").slice(0, 500);
-}
-
 function stripFrontmatter(content: string): string {
   if (!content.startsWith("---")) return content;
   const endIdx = content.indexOf("---", 3);
   if (endIdx === -1) return content;
   return content.slice(endIdx + 3);
+}
+
+function previousNonEmptyLine(lines: string[], beforeIndex: number): string | null {
+  for (let i = beforeIndex - 1; i >= 0; i -= 1) {
+    const candidate = lines[i]?.trim();
+    if (candidate !== undefined && NON_EMPTY_RE.test(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
 }
 
 function extractFromFile(
@@ -102,15 +133,23 @@ function extractFromFile(
 
   const content = readFileSync(filePath, "utf-8");
   const body = stripFrontmatter(content);
-
-  if (!containsPaceInstruction(body)) return [];
-
   const relPath = relative(rootPath, filePath);
-  const source = inferSource(body, relPath);
-  const timestamp = extractTimestamp(body, relPath);
-  const raw = extractRawQuote(body);
+  const lines = body.split("\n");
+  const instructions: PaceInstruction[] = [];
 
-  return [{ source, timestamp, raw, file: relPath }];
+  for (const [index, line] of lines.entries()) {
+    if (!containsPaceInstruction(line)) continue;
+
+    const raw = line.trim().slice(0, 500);
+    const previous = previousNonEmptyLine(lines, index);
+    const context = previous === null ? raw : `${previous}\n${raw}`;
+    const source = inferSource(raw, previous, relPath);
+    const timestamp = extractTimestamp(context, relPath);
+
+    instructions.push({ source, timestamp, raw, file: relPath });
+  }
+
+  return instructions;
 }
 
 export async function extractPaceInstructions(

--- a/tools/authorization/pace-extractor.ts
+++ b/tools/authorization/pace-extractor.ts
@@ -81,15 +81,15 @@ function inferSource(
   previousLine: string | null,
   filename: string,
 ): string {
-  const filenameSource = inferSourceFromFilename(filename);
-  if (filenameSource !== "unknown") return filenameSource;
-
   if (previousLine !== null) {
     const issuerSource = inferSourceFromText(previousLine);
     if (issuerSource !== "unknown") return issuerSource;
   }
 
-  return inferSourceFromText(raw);
+  const rawSource = inferSourceFromText(raw);
+  if (rawSource !== "unknown") return rawSource;
+
+  return inferSourceFromFilename(filename);
 }
 
 function extractTimestamp(text: string, filename: string): string | null {

--- a/tools/authorization/pace-extractor.ts
+++ b/tools/authorization/pace-extractor.ts
@@ -43,9 +43,20 @@ const SOURCE_PATTERNS: [RegExp, string][] = [
   [/\bRiven\b/i, "riven"],
 ];
 
+const ISSUER_PATTERNS: [RegExp, string][] = [
+  [/^(?:[-*>\s"']*)Aaron\b/i, "aaron"],
+  [/^(?:[-*>\s"']*)Claude(?:\.ai|ai)?\b/i, "claude.ai"],
+  [/^(?:[-*>\s"']*)Codex\b/i, "codex"],
+  [/^(?:[-*>\s"']*)Amara\b/i, "amara"],
+  [/^(?:[-*>\s"']*)Gemini\b/i, "gemini"],
+  [/^(?:[-*>\s"']*)Grok\b/i, "grok"],
+  [/^(?:[-*>\s"']*)Ani\b/i, "ani"],
+  [/^(?:[-*>\s"']*)Riven\b/i, "riven"],
+];
+
 const FILENAME_SOURCE_PATTERNS: [RegExp, string][] = [
   [/(?:^|[/_.-])aaron(?:[/_.-]|$)/i, "aaron"],
-  [/(?:^|[/_.-])claude(?:[_.-]?ai)?(?:[/_.-]|$)/i, "claude.ai"],
+  [/(?:^|[/_.-])claude[_.-]?ai(?:[/_.-]|$)/i, "claude.ai"],
   [/(?:^|[/_.-])codex(?:[/_.-]|$)/i, "codex"],
   [/(?:^|[/_.-])amara(?:[/_.-]|$)/i, "amara"],
   [/(?:^|[/_.-])gemini(?:[/_.-]|$)/i, "gemini"],
@@ -69,6 +80,13 @@ function inferSourceFromText(text: string): string {
   return "unknown";
 }
 
+function inferIssuerSource(text: string): string {
+  for (const [re, label] of ISSUER_PATTERNS) {
+    if (re.test(text)) return label;
+  }
+  return "unknown";
+}
+
 function inferSourceFromFilename(filename: string): string {
   for (const [re, label] of FILENAME_SOURCE_PATTERNS) {
     if (re.test(filename)) return label;
@@ -82,9 +100,12 @@ function inferSource(
   filename: string,
 ): string {
   if (previousLine !== null) {
-    const issuerSource = inferSourceFromText(previousLine);
+    const issuerSource = inferIssuerSource(previousLine);
     if (issuerSource !== "unknown") return issuerSource;
   }
+
+  const rawIssuerSource = inferIssuerSource(raw);
+  if (rawIssuerSource !== "unknown") return rawIssuerSource;
 
   const rawSource = inferSourceFromText(raw);
   if (rawSource !== "unknown") return rawSource;
@@ -92,11 +113,14 @@ function inferSource(
   return inferSourceFromFilename(filename);
 }
 
-function extractTimestamp(text: string, filename: string): string | null {
+function extractInlineTimestamp(text: string): string | null {
   const inlineMatch = DATE_RE.exec(text);
   const inlineTimestamp = inlineMatch?.[1];
   if (inlineTimestamp !== undefined) return inlineTimestamp;
+  return null;
+}
 
+function extractFilenameTimestamp(filename: string): string | null {
   const fnMatch = FILENAME_DATE_RE.exec(filename);
   const year = fnMatch?.[1];
   const month = fnMatch?.[2];
@@ -106,6 +130,18 @@ function extractTimestamp(text: string, filename: string): string | null {
   }
 
   return null;
+}
+
+function extractTimestamp(
+  raw: string,
+  previousLine: string | null,
+  filename: string,
+): string | null {
+  return (
+    extractInlineTimestamp(raw) ??
+    (previousLine === null ? null : extractInlineTimestamp(previousLine)) ??
+    extractFilenameTimestamp(filename)
+  );
 }
 
 function stripFrontmatter(content: string): string {
@@ -142,9 +178,8 @@ function extractFromFile(
 
     const raw = line.trim().slice(0, 500);
     const previous = previousNonEmptyLine(lines, index);
-    const context = previous === null ? raw : `${previous}\n${raw}`;
     const source = inferSource(raw, previous, relPath);
-    const timestamp = extractTimestamp(context, relPath);
+    const timestamp = extractTimestamp(raw, previous, relPath);
 
     instructions.push({ source, timestamp, raw, file: relPath });
   }

--- a/tools/authorization/pace-extractor.ts
+++ b/tools/authorization/pace-extractor.ts
@@ -33,6 +33,7 @@ const PACE_PATTERNS = [
 ];
 
 const SOURCE_PATTERNS: [RegExp, string][] = [
+  [/\bthe\s+human\s+maintainer\b/i, "aaron"],
   [/\bAaron\b/i, "aaron"],
   [/\bClaude(?:\.ai|ai)?\b/i, "claude.ai"],
   [/\bCodex\b/i, "codex"],
@@ -44,6 +45,7 @@ const SOURCE_PATTERNS: [RegExp, string][] = [
 ];
 
 const ISSUER_PATTERNS: [RegExp, string][] = [
+  [/^(?:[-*>\s"']*)(?:the\s+human\s+maintainer)\b/i, "aaron"],
   [/^(?:[-*>\s"']*)Aaron\b/i, "aaron"],
   [/^(?:[-*>\s"']*)Claude(?:\.ai|ai)?\b/i, "claude.ai"],
   [/^(?:[-*>\s"']*)Codex\b/i, "codex"],
@@ -104,13 +106,10 @@ function inferSource(
     if (issuerSource !== "unknown") return issuerSource;
   }
 
-  const rawIssuerSource = inferIssuerSource(raw);
-  if (rawIssuerSource !== "unknown") return rawIssuerSource;
+  const filenameSource = inferSourceFromFilename(filename);
+  if (filenameSource !== "unknown") return filenameSource;
 
-  const rawSource = inferSourceFromText(raw);
-  if (rawSource !== "unknown") return rawSource;
-
-  return inferSourceFromFilename(filename);
+  return inferSourceFromText(raw);
 }
 
 function extractInlineTimestamp(text: string): string | null {

--- a/tools/authorization/pace-extractor.ts
+++ b/tools/authorization/pace-extractor.ts
@@ -70,6 +70,7 @@ const FILENAME_SOURCE_PATTERNS: [RegExp, string][] = [
 const DATE_RE = /\b(20\d{2}-\d{2}-\d{2})\b/;
 const FILENAME_DATE_RE = /(\d{4})_(\d{2})_(\d{2})/;
 const NON_EMPTY_RE = /\S/;
+const MAX_ATTRIBUTION_LOOKBACK = 12;
 
 function containsPaceInstruction(line: string): boolean {
   return PACE_PATTERNS.some((p) => p.test(line));
@@ -150,10 +151,24 @@ function stripFrontmatter(content: string): string {
   return content.slice(endIdx + 3);
 }
 
-function previousNonEmptyLine(lines: string[], beforeIndex: number): string | null {
-  for (let i = beforeIndex - 1; i >= 0; i -= 1) {
+function previousAttributionLine(
+  lines: string[],
+  beforeIndex: number,
+): string | null {
+  let seen = 0;
+  for (
+    let i = beforeIndex - 1;
+    i >= 0 && seen < MAX_ATTRIBUTION_LOOKBACK;
+    i -= 1
+  ) {
     const candidate = lines[i]?.trim();
-    if (candidate !== undefined && NON_EMPTY_RE.test(candidate)) {
+    if (candidate === undefined || !NON_EMPTY_RE.test(candidate)) continue;
+
+    seen += 1;
+    if (
+      inferIssuerSource(candidate) !== "unknown" ||
+      extractInlineTimestamp(candidate) !== null
+    ) {
       return candidate;
     }
   }
@@ -176,7 +191,7 @@ function extractFromFile(
     if (!containsPaceInstruction(line)) continue;
 
     const raw = line.trim().slice(0, 500);
-    const previous = previousNonEmptyLine(lines, index);
+    const previous = previousAttributionLine(lines, index);
     const source = inferSource(raw, previous, relPath);
     const timestamp = extractTimestamp(raw, previous, relPath);
 


### PR DESCRIPTION
## What
- Follow up on #2084 after the PR merged with two P1 review concerns still present in main.
- Prefer filename and issuer-line metadata for pace-instruction source attribution before scanning raw instruction text.
- Emit one `PaceInstruction` candidate per matching pace line instead of collapsing a whole file into one candidate.
- Add regressions for peer-authored files that mention Aaron and for multiple pace lines in one file.

## Verification
- `bun test tools/authorization/pace-extractor.test.ts`
- `bun tools/backlog/generate-index.ts --check`
- `bun --bun tsc --noEmit -p tsconfig.json`
- `git diff --check`

## Notes
- Root checkout was not edited; this was built from the isolated follow-up worktree.