### PR TITLE
fix(backlog): regenerate B-0306 index row

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -22,7 +22,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0280](backlog/P0/B-0280-autonomous-backlog-pr-publication-and-automerge-2026-05-08.md)** Autonomous backlog pickup - PR publication and auto-merge
 - [x] **[B-0281](backlog/P0/B-0281-codex-loop-empty-queue-backlog-pickup-integration-2026-05-08.md)** Codex loop - empty queue autonomous backlog pickup
 - [x] **[B-0305](backlog/P0/B-0305-mechanical-auth-check-skill-body-2026-05-08.md)** Mechanical authorization check — skill body (SKILL.md via skill-creator)
-- [ ] **[B-0306](backlog/P0/B-0306-mechanical-auth-check-pace-extractor-ts-2026-05-08.md)** Mechanical authorization check — pace-instruction extractor + test fixtures
+- [x] **[B-0306](backlog/P0/B-0306-mechanical-auth-check-pace-extractor-ts-2026-05-08.md)** Mechanical authorization check — pace-instruction extractor + test fixtures
 - [ ] **[B-0307](backlog/P0/B-0307-mechanical-auth-check-source-recency-resolver-2026-05-08.md)** Mechanical authorization check — source-filter + recency resolver
 - [ ] **[B-0308](backlog/P0/B-0308-mechanical-auth-check-loop-integration-2026-05-08.md)** Mechanical authorization check — autonomous-loop tick-start integration
 - [ ] **[B-0309](backlog/P0/B-0309-mechanical-auth-check-claude-md-pointer-2026-05-08.md)** Mechanical authorization check — CLAUDE.md discoverable-skill pointer


### PR DESCRIPTION
## What
- Follow up on #2086, which closed the B-0306 row but merged with `docs/BACKLOG.md` still unchecked.
- Regenerate the backlog index so B-0306 is marked closed in the generated index.

## Verification
- `bun tools/backlog/generate-index.ts --check`
- `git diff --check`

## Notes
- Root checkout was not edited; this was built in `/Users/acehack/.codex/worktrees/pr2086-index-fix`.
- This is disjoint from #2085, which owns the extractor correctness follow-up.