### PR TITLE
fix(backlog): close B-0307 — landed via PR #2091

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -23,7 +23,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0281](backlog/P0/B-0281-codex-loop-empty-queue-backlog-pickup-integration-2026-05-08.md)** Codex loop - empty queue autonomous backlog pickup
 - [x] **[B-0305](backlog/P0/B-0305-mechanical-auth-check-skill-body-2026-05-08.md)** Mechanical authorization check — skill body (SKILL.md via skill-creator)
 - [x] **[B-0306](backlog/P0/B-0306-mechanical-auth-check-pace-extractor-ts-2026-05-08.md)** Mechanical authorization check — pace-instruction extractor + test fixtures
-- [ ] **[B-0307](backlog/P0/B-0307-mechanical-auth-check-source-recency-resolver-2026-05-08.md)** Mechanical authorization check — source-filter + recency resolver
+- [x] **[B-0307](backlog/P0/B-0307-mechanical-auth-check-source-recency-resolver-2026-05-08.md)** Mechanical authorization check — source-filter + recency resolver
 - [ ] **[B-0308](backlog/P0/B-0308-mechanical-auth-check-loop-integration-2026-05-08.md)** Mechanical authorization check — autonomous-loop tick-start integration
 - [ ] **[B-0309](backlog/P0/B-0309-mechanical-auth-check-claude-md-pointer-2026-05-08.md)** Mechanical authorization check — CLAUDE.md discoverable-skill pointer
 

--- a/docs/backlog/P0/B-0307-mechanical-auth-check-source-recency-resolver-2026-05-08.md
+++ b/docs/backlog/P0/B-0307-mechanical-auth-check-source-recency-resolver-2026-05-08.md
@@ -1,7 +1,7 @@
 ---
 id: B-0307
 priority: P0
-status: in-progress
+status: closed
 title: "Mechanical authorization check — source-filter + recency resolver"
 effort: S
 created: 2026-05-08


### PR DESCRIPTION
## Summary
- Closes backlog row B-0307 (source-filter + recency resolver) — implementation already merged via PR #2091
- Updates `docs/BACKLOG.md` index checkbox to `[x]`
- Sets frontmatter `status: closed` on the per-row file

## Verification
- `bun test tools/authorization/resolve-authorization.test.ts` — 17 pass, 0 fail
- PR #2091 confirmed merged at 2026-05-08T15:35:49Z

## Test plan
- [x] Resolver tests pass (17/17)
- [x] Backlog index reflects closed status

🤖 Generated with [Claude Code](https://claude.com/claude-code)