### PR TITLE
fix(B-0249): git reset --hard after fetch in tick script

### DIFF
--- a/.claude/bin/claude-loop-tick.ts
+++ b/.claude/bin/claude-loop-tick.ts
@@ -99,6 +99,9 @@ function heartbeat(): void {
     // Fetch
     const fetch = run("git", ["fetch", "origin"], fetchTimeoutMs);
     const fetchOk = fetch.status === 0 ? "ok" : `exit-${fetch.status}`;
+    if (fetch.status === 0) {
+        run("git", ["reset", "--hard", "origin/main"], 10_000);
+    }
 
     // Claims
     const claims = run("git", ["branch", "-r", "--list", "origin/claim/*"], 10_000);


### PR DESCRIPTION
Fixes the stale-worktree loop where pickup keeps selecting completed items.