### PR TITLE
feat(B-0308): tick-start authorization check integration

### DIFF
--- a/docs/AUTONOMOUS-LOOP.md
+++ b/docs/AUTONOMOUS-LOOP.md
@@ -218,6 +218,7 @@ wait for instruction. Priority ladder:
    Run before picking speculative work:
 
    ```
+   bun tools/authorization/check-authorization.ts
    bun tools/hygiene/check-no-op-cadence-pattern.ts
    grep -rE "CADENCE-TRACK" docs/hygiene-history/ticks/
    ```
@@ -234,6 +235,16 @@ wait for instruction. Priority ladder:
    same-tick-prohibited (e.g., AutoDream's fresh-memories
    rule): write `CADENCE-TRACK: <work> overdue, deferred to
    <trigger>` into this tick's shard.
+
+   **Check 0c — authorization check** (B-0308): runs
+   `bun tools/authorization/check-authorization.ts` which
+   composes the pace-extractor (B-0306) and resolver (B-0307).
+   Prints two-layer DX output: raw JSON (Layer 1) then labeled
+   interpretation (Layer 2). If `operative: null`, the never-idle
+   floor applies. Does NOT gate work — surfaces information for
+   the agent to read and apply. The `formatShardField()` export
+   provides the value for the tick-shard `operative-authorization`
+   field.
 
    Why critical: agent drift into ~20-tick-acknowledgment
    patterns is what these checks catch at decision-time.

--- a/docs/backlog/P0/B-0308-mechanical-auth-check-loop-integration-2026-05-08.md
+++ b/docs/backlog/P0/B-0308-mechanical-auth-check-loop-integration-2026-05-08.md
@@ -1,14 +1,14 @@
 ---
 id: B-0308
 priority: P0
-status: open
+status: in-progress
 title: "Mechanical authorization check — autonomous-loop tick-start integration"
 effort: S
 created: 2026-05-08
 last_updated: 2026-05-08
 parent: B-0160
 depends_on: [B-0305, B-0307]
-classification: blocked
+classification: in-progress
 decomposition: atomic
 owners: [architect]
 type: friction-reducer
@@ -45,15 +45,17 @@ in the chat/console output.
 
 ## Pre-start checklist
 
-_To be completed with proof before implementation begins._
-
-- [ ] Prior-art search: searched `docs/AUTONOMOUS-LOOP.md` for
-  current tick-start sequence; searched `tools/` for existing
-  tick-start wiring patterns
-- [ ] Dependency walk: B-0305 (skill body) landed; B-0307
-  (resolver) landed; both verified in `.claude/skills/` and
-  `tools/authorization/` respectively
-- [ ] Reciprocal pointers: B-0309 `depends_on` includes this row
+- [x] Prior-art search: searched `docs/AUTONOMOUS-LOOP.md` for
+  current tick-start sequence (step 2, Check 0a/0b); searched
+  `tools/authorization/` (found extractor + resolver landed);
+  searched `tools/loop/` (no existing loop TS tools);
+  grep for "check-authorization" across repo (no prior art)
+- [x] Dependency walk: B-0306 extractor at
+  `tools/authorization/pace-extractor.ts` (landed PR #2085);
+  B-0307 resolver at `tools/authorization/resolve-authorization.ts`
+  (landed PR #2091); both verified on `origin/main` at 4c8590fe
+- [x] Reciprocal pointers: B-0309 not yet created (future
+  tick-shard-template integration); B-0160 parent verified
 
 ## Composes with
 

--- a/tools/authorization/check-authorization.test.ts
+++ b/tools/authorization/check-authorization.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  checkAuthorization,
+  formatInterpretation,
+  formatShardField,
+} from "./check-authorization.ts";
+
+function makeTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "auth-check-"));
+  mkdirSync(join(root, "memory"), { recursive: true });
+  mkdirSync(join(root, "docs"), { recursive: true });
+  return root;
+}
+
+describe("checkAuthorization", () => {
+  test("end-to-end: maintainer go-hard → operative surfaced", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "feedback_go_hard_aaron_2026_05_02.md"),
+      [
+        "---",
+        "name: Go hard",
+        "description: Aaron go-hard",
+        "type: feedback",
+        "---",
+        "",
+        "Aaron 2026-05-02:",
+        "",
+        '> *"go hard on the backlog"*',
+      ].join("\n"),
+    );
+
+    const output = await checkAuthorization(root);
+
+    expect(output.queriedAt).toBeTruthy();
+    expect(output.result.operative).not.toBeNull();
+    expect(output.result.operative!.source).toBe("aaron");
+    expect(output.result.operative!.raw).toContain("go hard");
+  });
+
+  test("end-to-end: peer-AI only → operative null, never-idle default", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "feedback_cooling_claudeai_2026_05_02.md"),
+      [
+        "---",
+        "name: Cooling",
+        "description: Claude.ai cooling",
+        "type: feedback",
+        "---",
+        "",
+        "Claude.ai 2026-05-02:",
+        "",
+        '> *"cooling period applies"*',
+      ].join("\n"),
+    );
+
+    const output = await checkAuthorization(root);
+
+    expect(output.result.operative).toBeNull();
+    expect(output.result.reason).toContain("never-idle");
+  });
+
+  test("end-to-end: empty substrate → operative null", async () => {
+    const root = makeTempRoot();
+
+    const output = await checkAuthorization(root);
+
+    expect(output.result.operative).toBeNull();
+    expect(output.result.allCandidates.length).toBe(0);
+  });
+
+  test("end-to-end: maintainer + peer-AI → only maintainer operative", async () => {
+    const root = makeTempRoot();
+    writeFileSync(
+      join(root, "memory", "feedback_go_hard_aaron_2026_05_02.md"),
+      [
+        "---",
+        "name: Go hard",
+        "description: Aaron go-hard",
+        "type: feedback",
+        "---",
+        "",
+        "Aaron 2026-05-02:",
+        "",
+        '> *"go hard on the backlog"*',
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(root, "memory", "feedback_cooling_claudeai_2026_05_02.md"),
+      [
+        "---",
+        "name: Cooling",
+        "description: Claude.ai cooling",
+        "type: feedback",
+        "---",
+        "",
+        "Claude.ai 2026-05-02:",
+        "",
+        '> *"cooling period applies"*',
+      ].join("\n"),
+    );
+
+    const output = await checkAuthorization(root);
+
+    expect(output.result.operative).not.toBeNull();
+    expect(output.result.operative!.source).toBe("aaron");
+    expect(output.result.filteredOut.length).toBe(1);
+  });
+
+  test("queriedAt is a valid ISO timestamp", async () => {
+    const root = makeTempRoot();
+    const output = await checkAuthorization(root);
+    const parsed = Date.parse(output.queriedAt);
+    expect(Number.isNaN(parsed)).toBe(false);
+  });
+});
+
+describe("formatInterpretation", () => {
+  test("operative present → shows source + timestamp + raw", () => {
+    const text = formatInterpretation({
+      queriedAt: "2026-05-08T12:00:00Z",
+      result: {
+        operative: {
+          source: "aaron",
+          timestamp: "2026-05-02",
+          raw: "go hard on the backlog",
+          file: "memory/feedback_test.md",
+        },
+        reason: "most recent authorized pace instruction from aaron (2026-05-02)",
+        allCandidates: [],
+        filteredOut: [],
+      },
+    });
+
+    expect(text).toContain("[authorization]");
+    expect(text).toContain("operative:");
+    expect(text).toContain("go hard");
+    expect(text).toContain("aaron");
+    expect(text).toContain("2026-05-02");
+  });
+
+  test("operative null → shows reason with never-idle default", () => {
+    const text = formatInterpretation({
+      queriedAt: "2026-05-08T12:00:00Z",
+      result: {
+        operative: null,
+        reason:
+          "no operative pace authorization found; default to never-idle floor per CLAUDE.md",
+        allCandidates: [],
+        filteredOut: [],
+      },
+    });
+
+    expect(text).toContain("[authorization]");
+    expect(text).toContain("never-idle");
+  });
+
+  test("operative with null timestamp → shows undated", () => {
+    const text = formatInterpretation({
+      queriedAt: "2026-05-08T12:00:00Z",
+      result: {
+        operative: {
+          source: "aaron",
+          timestamp: null,
+          raw: "keep working on the backlog",
+          file: "memory/feedback_test.md",
+        },
+        reason: "most recent authorized pace instruction from aaron (undated)",
+        allCandidates: [],
+        filteredOut: [],
+      },
+    });
+
+    expect(text).toContain("undated");
+  });
+});
+
+describe("formatShardField", () => {
+  test("operative present → compact source + timestamp + quote", () => {
+    const text = formatShardField({
+      queriedAt: "2026-05-08T12:00:00Z",
+      result: {
+        operative: {
+          source: "aaron",
+          timestamp: "2026-05-02",
+          raw: "go hard on the backlog",
+          file: "memory/feedback_test.md",
+        },
+        reason: "",
+        allCandidates: [],
+        filteredOut: [],
+      },
+    });
+
+    expect(text).toBe('aaron 2026-05-02: "go hard on the backlog"');
+  });
+
+  test("operative null → never-idle default", () => {
+    const text = formatShardField({
+      queriedAt: "2026-05-08T12:00:00Z",
+      result: {
+        operative: null,
+        reason: "",
+        allCandidates: [],
+        filteredOut: [],
+      },
+    });
+
+    expect(text).toContain("never-idle");
+  });
+});

--- a/tools/authorization/check-authorization.ts
+++ b/tools/authorization/check-authorization.ts
@@ -1,0 +1,63 @@
+/**
+ * Mechanical authorization check — tick-start integration (B-0308).
+ *
+ * Composes B-0306 extractor + B-0307 resolver. Prints two-layer DX:
+ * Layer 1: raw structured JSON
+ * Layer 2: labeled interpretation
+ *
+ * Usage: bun tools/authorization/check-authorization.ts [rootPath]
+ * Exit code 0 always — this check surfaces information, never gates.
+ */
+
+import { resolve } from "node:path";
+import { extractPaceInstructions } from "./pace-extractor.ts";
+import {
+  resolveAuthorization,
+  type AuthorizationResult,
+} from "./resolve-authorization.ts";
+
+export interface CheckOutput {
+  queriedAt: string;
+  result: AuthorizationResult;
+}
+
+export async function checkAuthorization(
+  rootPath: string,
+): Promise<CheckOutput> {
+  const instructions = await extractPaceInstructions(rootPath);
+  const result = resolveAuthorization(instructions);
+  return {
+    queriedAt: new Date().toISOString(),
+    result,
+  };
+}
+
+export function formatInterpretation(output: CheckOutput): string {
+  const { result } = output;
+  if (result.operative === null) {
+    return `[authorization] ${result.reason}`;
+  }
+  const ts = result.operative.timestamp ?? "undated";
+  return `[authorization] operative: "${result.operative.raw}" (source: ${result.operative.source}, ${ts})`;
+}
+
+export function formatShardField(output: CheckOutput): string {
+  const { result } = output;
+  if (result.operative === null) {
+    return "none — never-idle default";
+  }
+  const ts = result.operative.timestamp ?? "undated";
+  return `${result.operative.source} ${ts}: "${result.operative.raw}"`;
+}
+
+if (import.meta.main) {
+  const rootPath = resolve(process.argv[2] ?? ".");
+  const output = await checkAuthorization(rootPath);
+
+  console.log("--- Layer 1: raw structured output ---");
+  console.log(JSON.stringify(output, null, 2));
+  console.log("--- Layer 2: interpretation ---");
+  console.log(formatInterpretation(output));
+  console.log("--- Shard field value ---");
+  console.log(formatShardField(output));
+}


### PR DESCRIPTION
## Summary

- Adds `tools/authorization/check-authorization.ts` — composes B-0306 extractor + B-0307 resolver into a single callable script for tick-start
- Prints two-layer DX output: raw structured JSON (Layer 1) then labeled interpretation (Layer 2), per the refresh-before-decide invariant
- Exports `formatShardField()` for future tick-shard template integration
- Wires the check into `docs/AUTONOMOUS-LOOP.md` tick-start sequence as Check 0c
- Updates B-0308 backlog item with pre-start checklist proof

## Acceptance criteria coverage

| AC | Status |
|----|--------|
| 1. extractor → resolver → prints operative | ✅ `checkAuthorization()` end-to-end |
| 2. Two-layer print DX | ✅ Layer 1 JSON + Layer 2 `[authorization]` label |
| 3. `operative: null` → never-idle default | ✅ tested |
| 4. Does NOT gate work | ✅ informational only, exit 0 always |
| 5. Integrates with tick-start path | ✅ AUTONOMOUS-LOOP.md Check 0c |
| 6. Shard template field | 🔜 `formatShardField()` exported, template update is follow-up |
| 7. TypeScript + Bun | ✅ |

## Test plan

- [x] `bun test tools/authorization/check-authorization.test.ts` — 10 pass
- [x] `bun test tools/authorization/` — 44 pass (full suite)
- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] Smoke-run: `bun tools/authorization/check-authorization.ts .` against repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)