### PR TITLE
feat: include claim path signals in Codex backlog runner

### DIFF
--- a/.codex/bin/codex-backlog-runner.ts
+++ b/.codex/bin/codex-backlog-runner.ts
@@ -7,13 +7,15 @@
 // back to backlog pickup.
 
 import { spawnSync } from "node:child_process";
-import { resolve } from "node:path";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
 
 interface GateResult {
   status: "wait-pr-capacity" | "ready";
   openPrCount: number;
   maxOpenPrs: number;
   availablePrSlots: number;
+  activeClaims: string[];
   pickupSource: "trajectory" | "backlog" | null;
   pickup: unknown | null;
 }
@@ -28,12 +30,25 @@ export interface OpenPrListItem {
   title?: string;
 }
 
+export interface RemoteClaimDiff {
+  branch: string;
+  paths: readonly string[];
+}
+
+export interface HeartbeatSignal {
+  claim?: string;
+  paths?: unknown;
+  updated_at?: string;
+  status?: string;
+}
+
 interface CapacityGate {
   status: "wait-pr-capacity" | "ready";
   availablePrSlots: number;
 }
 
 const DEFAULT_MAX_OPEN_PRS = 3;
+const HEARTBEAT_STALE_MS = 30 * 60 * 1000;
 
 function usage(): string {
   return [
@@ -135,6 +150,149 @@ function openPrActiveClaims(repoRoot: string): string[] {
   return activeClaimsFromOpenPrs(parsed);
 }
 
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))].sort((a, b) => a.localeCompare(b));
+}
+
+export function activeClaimsFromRemoteClaimDiffs(remoteClaims: readonly RemoteClaimDiff[]): string[] {
+  const claims: string[] = [];
+  for (const signal of remoteClaims) {
+    const branch = signal.branch.trim().replace(/^origin\//, "");
+    if (branch.length > 0) {
+      claims.push(branch);
+    }
+    for (const path of signal.paths) {
+      const normalizedPath = path.trim().replaceAll("\\", "/");
+      if (branch.length > 0 && normalizedPath.length > 0) {
+        claims.push(`${branch}:${normalizedPath}`);
+      }
+      if (normalizedPath.length > 0) {
+        claims.push(normalizedPath);
+      }
+    }
+  }
+  return uniqueSorted(claims);
+}
+
+function isTerminalHeartbeat(status: string | undefined): boolean {
+  const normalized = status?.trim().toLowerCase() ?? "";
+  return (
+    normalized === "merged-cleaned" ||
+    normalized === "released" ||
+    normalized === "abandoned" ||
+    normalized === "done"
+  );
+}
+
+function isFreshHeartbeat(updatedAt: string | undefined, now: Date, staleMs: number): boolean {
+  if (updatedAt === undefined || updatedAt.trim().length === 0) {
+    return true;
+  }
+  const updated = Date.parse(updatedAt);
+  if (!Number.isFinite(updated)) {
+    return true;
+  }
+  return Math.abs(now.getTime() - updated) <= staleMs;
+}
+
+export function activeClaimsFromHeartbeatSignals(
+  signals: readonly HeartbeatSignal[],
+  now: Date = new Date(),
+  staleMs: number = HEARTBEAT_STALE_MS,
+): string[] {
+  const claims: string[] = [];
+  for (const signal of signals) {
+    if (isTerminalHeartbeat(signal.status) || !isFreshHeartbeat(signal.updated_at, now, staleMs)) {
+      continue;
+    }
+    const claim = signal.claim?.trim() || "unknown-heartbeat";
+    claims.push(`heartbeat:${claim}`);
+    if (!Array.isArray(signal.paths)) {
+      continue;
+    }
+    for (const rawPath of signal.paths) {
+      if (typeof rawPath !== "string") {
+        continue;
+      }
+      const normalizedPath = rawPath.trim().replaceAll("\\", "/");
+      if (normalizedPath.length === 0) {
+        continue;
+      }
+      claims.push(normalizedPath);
+      claims.push(`heartbeat:${claim}:${normalizedPath}`);
+    }
+  }
+  return uniqueSorted(claims);
+}
+
+function gitLines(repoRoot: string, args: string[]): string[] {
+  const result = run(repoRoot, "git", args);
+  if (result.status !== 0) {
+    return [];
+  }
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function remoteClaimDiffs(repoRoot: string): RemoteClaimDiff[] {
+  return gitLines(repoRoot, ["branch", "-r", "--list", "origin/claim/*"]).map((branch) => ({
+    branch,
+    paths: gitLines(repoRoot, ["diff", "--name-only", `origin/main...${branch}`]),
+  }));
+}
+
+function gitCommonDir(repoRoot: string): string | null {
+  const raw = gitLines(repoRoot, ["rev-parse", "--git-common-dir"])[0];
+  if (raw === undefined) {
+    return null;
+  }
+  return isAbsolute(raw) ? raw : resolve(repoRoot, raw);
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function heartbeatSignals(repoRoot: string): HeartbeatSignal[] {
+  const commonDir = gitCommonDir(repoRoot);
+  if (commonDir === null) {
+    return [];
+  }
+  const dir = join(commonDir, "agent-heartbeats");
+  if (!isDirectory(dir)) {
+    return [];
+  }
+
+  const signals: HeartbeatSignal[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) {
+      continue;
+    }
+    const file = join(dir, entry.name);
+    try {
+      const parsed = JSON.parse(readFileSync(file, "utf8")) as HeartbeatSignal;
+      signals.push(parsed);
+    } catch {
+      continue;
+    }
+  }
+  return signals;
+}
+
+function activeClaims(repoRoot: string): string[] {
+  return uniqueSorted([
+    ...openPrActiveClaims(repoRoot),
+    ...activeClaimsFromRemoteClaimDiffs(remoteClaimDiffs(repoRoot)),
+    ...activeClaimsFromHeartbeatSignals(heartbeatSignals(repoRoot)),
+  ]);
+}
+
 function runPicker(repoRoot: string, script: string, activeClaims: readonly string[]): unknown {
   const claimArgs = activeClaims.flatMap((claim) => ["--active-claim", claim]);
   const result = run(repoRoot, "bun", [script, "--json", ...claimArgs]);
@@ -182,13 +340,14 @@ export function main(argv: string[]): number {
     args = parseArgs(argv);
     const count = openPrCount(args.repoRoot);
     const gate = capacityGate(count, args.maxOpenPrs);
-    const activePrClaims = gate.status === "ready" ? openPrActiveClaims(args.repoRoot) : [];
-    const selected = gate.status === "ready" ? pickup(args.repoRoot, activePrClaims) : { source: null, value: null };
+    const claims = gate.status === "ready" ? activeClaims(args.repoRoot) : [];
+    const selected = gate.status === "ready" ? pickup(args.repoRoot, claims) : { source: null, value: null };
     const result: GateResult = {
       status: gate.status,
       openPrCount: count,
       maxOpenPrs: args.maxOpenPrs,
       availablePrSlots: gate.availablePrSlots,
+      activeClaims: claims,
       pickupSource: selected.source,
       pickup: selected.value,
     };

--- a/docs/claims/task-codex-backlog-runner-claim-filter.md
+++ b/docs/claims/task-codex-backlog-runner-claim-filter.md
@@ -1,0 +1,15 @@
+# Claim - task-codex-backlog-runner-claim-filter
+
+- **Session ID:** codex/20260508T165204Z-task-codex-backlog-runner-claim-filter
+- **Harness:** codex
+- **Claimed at:** 2026-05-08T16:52:04Z
+- **ETA:** 2026-05-08T17:37:06Z
+- **Scope:** Teach the Codex backlog runner to include live remote-claim and heartbeat path signals before selecting trajectory or backlog work.
+- **Durable target:** PR against `.codex/bin/codex-backlog-runner.ts` and `tools/backlog/codex-backlog-runner.test.ts`
+- **Platform mirror:** GitHub PR pending
+
+## Notes
+
+This claim exists because the runner selected the TypeScript/Bun trajectory
+while `claim/trajectory-typescript-bun-live-state` and its heartbeat already
+owned `docs/trajectories/typescript-bun-migration/RESUME.md`.

--- a/tools/backlog/codex-backlog-runner.test.ts
+++ b/tools/backlog/codex-backlog-runner.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { activeClaimsFromOpenPrs, capacityGate } from "../../.codex/bin/codex-backlog-runner";
+import {
+  activeClaimsFromHeartbeatSignals,
+  activeClaimsFromOpenPrs,
+  activeClaimsFromRemoteClaimDiffs,
+  capacityGate,
+} from "../../.codex/bin/codex-backlog-runner";
 
 describe("capacityGate", () => {
   test("allows work while there are open parallel PR slots", () => {
@@ -26,5 +31,69 @@ describe("activeClaimsFromOpenPrs", () => {
 
     expect(claims).toContain("codex/factory-trajectory-surface-alignment-measurement");
     expect(claims).toContain("pr-1881:trajectory: alignment measurement child packet");
+  });
+});
+
+describe("activeClaimsFromRemoteClaimDiffs", () => {
+  test("adds remote claim branches and touched paths as pickup blockers", () => {
+    const claims = activeClaimsFromRemoteClaimDiffs([
+      {
+        branch: "origin/claim/trajectory-typescript-bun-live-state",
+        paths: ["docs/trajectories/typescript-bun-migration/RESUME.md", "docs/backlog/P0/B-0058-example.md"],
+      },
+    ]);
+
+    expect(claims).toContain("claim/trajectory-typescript-bun-live-state");
+    expect(claims).toContain("docs/trajectories/typescript-bun-migration/RESUME.md");
+    expect(claims).toContain("docs/backlog/P0/B-0058-example.md");
+    expect(claims).toContain(
+      "claim/trajectory-typescript-bun-live-state:docs/trajectories/typescript-bun-migration/RESUME.md",
+    );
+  });
+});
+
+describe("activeClaimsFromHeartbeatSignals", () => {
+  const now = new Date("2026-05-08T17:00:00Z");
+
+  test("adds fresh heartbeat paths as pickup blockers", () => {
+    const claims = activeClaimsFromHeartbeatSignals(
+      [
+        {
+          claim: "trajectory-typescript-bun-live-state",
+          paths: ["docs/trajectories/typescript-bun-migration/RESUME.md", "docs/backlog/P0/B-0058-example.md"],
+          updated_at: "2026-05-08T16:55:00Z",
+          status: "active",
+        },
+      ],
+      now,
+    );
+
+    expect(claims).toContain("heartbeat:trajectory-typescript-bun-live-state");
+    expect(claims).toContain("docs/trajectories/typescript-bun-migration/RESUME.md");
+    expect(claims).toContain(
+      "heartbeat:trajectory-typescript-bun-live-state:docs/trajectories/typescript-bun-migration/RESUME.md",
+    );
+  });
+
+  test("ignores stale or completed heartbeat paths", () => {
+    const claims = activeClaimsFromHeartbeatSignals(
+      [
+        {
+          claim: "stale",
+          paths: ["docs/backlog/P0/B-0001-stale.md"],
+          updated_at: "2026-05-08T16:00:00Z",
+          status: "active",
+        },
+        {
+          claim: "done",
+          paths: ["docs/backlog/P0/B-0002-done.md"],
+          updated_at: "2026-05-08T16:59:00Z",
+          status: "merged-cleaned",
+        },
+      ],
+      now,
+    );
+
+    expect(claims).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Teach the Codex backlog runner to pass remote claim branch diff paths into trajectory/backlog pickup filters.
- Add fresh local heartbeat path signals as pickup blockers, while ignoring stale or completed heartbeats.
- Surface the combined active claim set in runner JSON output for auditability.

## Checks

- `bun test tools/backlog/codex-backlog-runner.test.ts`
- `bun x prettier --check .codex/bin/codex-backlog-runner.ts tools/backlog/codex-backlog-runner.test.ts docs/claims/task-codex-backlog-runner-claim-filter.md`
- `git diff --check`
- `bun .codex/bin/codex-backlog-runner.ts --json --max-open-prs 10`