### PR TITLE
feat(B-0058): add filter-gate honesty log tool

### DIFF
--- a/tools/alignment/README.md
+++ b/tools/alignment/README.md
@@ -20,6 +20,7 @@ folder as the experimental loop.
 | `audit_clause_coverage.ts` | HC/SD/DIR clause citations in skills, agents, backlog P0/P1 | Per-surface coverage audit |
 | `audit_clause_drift.ts` | Clause additions/removals/changes + impact survey | Cross-ref drift detection |
 | `audit_retractibility.ts` | Git-tracked + inbound-ref entanglement per surface | Retractibility gate (B-0058 #1) |
+| `filter_gate_log.ts`  | Pass/fail/defer decisions for candidate adoptions | Honesty log (B-0058 #3) |
 | `sd6_names.txt`       | SD-6 watchlist (per-host)                    | Data (not code)             |
 
 The three scripts form the gitops observability trio:

--- a/tools/alignment/audit_retractibility.test.ts
+++ b/tools/alignment/audit_retractibility.test.ts
@@ -97,7 +97,8 @@ describe("countInboundRefs", () => {
   });
 
   test("returns zero for a nonexistent path pattern", () => {
-    const result = countInboundRefs("this/path/definitely/does/not/exist/anywhere.md", process.cwd());
+    const needle = ["x9z8y7w6", "no", "such", "file"].join("/") + ".md";
+    const result = countInboundRefs(needle, process.cwd());
     expect(result.count).toBe(0);
     expect(result.from).toEqual([]);
   });

--- a/tools/alignment/filter_gate_log.test.ts
+++ b/tools/alignment/filter_gate_log.test.ts
@@ -1,0 +1,315 @@
+// filter_gate_log.test.ts — tests for filter-gate decision log.
+//
+// B-0058 responsibility #3: candidate-failure honesty log.
+// Tests CLI arg parsing, entry recording, log reading, and summary.
+//
+// Run: bun test tools/alignment/filter_gate_log.test.ts
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  computeSummary,
+  type Decision,
+  type FilterGateEntry,
+  main,
+  parseArgs,
+  readLog,
+  recordEntry,
+} from "./filter_gate_log.ts";
+
+describe("parseArgs", () => {
+  test("returns help for -h", () => {
+    expect(parseArgs(["-h"])).toEqual({ kind: "help" });
+  });
+
+  test("returns help for --help", () => {
+    expect(parseArgs(["--help"])).toEqual({ kind: "help" });
+  });
+
+  test("errors when no mode specified", () => {
+    const result = parseArgs([]);
+    expect(result.kind).toBe("error");
+  });
+
+  test("parses --list mode", () => {
+    const result = parseArgs(["--list"]);
+    expect(result.kind).toBe("args");
+    if (result.kind === "args") {
+      expect(result.args.mode).toBe("list");
+    }
+  });
+
+  test("parses --list --json", () => {
+    const result = parseArgs(["--list", "--json"]);
+    expect(result.kind).toBe("args");
+    if (result.kind === "args" && result.args.mode === "list") {
+      expect(result.args.json).toBe(true);
+      expect(result.args.md).toBe(false);
+    }
+  });
+
+  test("parses --list --md", () => {
+    const result = parseArgs(["--list", "--md"]);
+    expect(result.kind).toBe("args");
+    if (result.kind === "args" && result.args.mode === "list") {
+      expect(result.args.md).toBe(true);
+      expect(result.args.json).toBe(false);
+    }
+  });
+
+  test("parses --summary mode", () => {
+    const result = parseArgs(["--summary"]);
+    expect(result.kind).toBe("args");
+    if (result.kind === "args") {
+      expect(result.args.mode).toBe("summary");
+    }
+  });
+
+  test("parses full --record with all fields", () => {
+    const result = parseArgs([
+      "--record",
+      "--candidate", "skill:foo",
+      "--source", "B-0056",
+      "--decision", "fail",
+      "--rationale", "Breaks retractibility",
+      "--clauses", "HC-1,SD-3",
+    ]);
+    expect(result.kind).toBe("args");
+    if (result.kind === "args" && result.args.mode === "record") {
+      expect(result.args.candidate).toBe("skill:foo");
+      expect(result.args.source).toBe("B-0056");
+      expect(result.args.decision).toBe("fail");
+      expect(result.args.rationale).toBe("Breaks retractibility");
+      expect(result.args.clauses).toEqual(["HC-1", "SD-3"]);
+    }
+  });
+
+  test("parses --record without --clauses (defaults to empty)", () => {
+    const result = parseArgs([
+      "--record",
+      "--candidate", "glossary:bar",
+      "--source", "B-0059",
+      "--decision", "pass",
+      "--rationale", "Additive and retractible",
+    ]);
+    expect(result.kind).toBe("args");
+    if (result.kind === "args" && result.args.mode === "record") {
+      expect(result.args.clauses).toEqual([]);
+    }
+  });
+
+  test("errors when --record missing --candidate", () => {
+    const result = parseArgs([
+      "--record",
+      "--source", "B-0056",
+      "--decision", "fail",
+      "--rationale", "missing candidate",
+    ]);
+    expect(result.kind).toBe("error");
+  });
+
+  test("errors when --record missing --source", () => {
+    const result = parseArgs([
+      "--record",
+      "--candidate", "skill:foo",
+      "--decision", "fail",
+      "--rationale", "missing source",
+    ]);
+    expect(result.kind).toBe("error");
+  });
+
+  test("errors when --record missing --decision", () => {
+    const result = parseArgs([
+      "--record",
+      "--candidate", "skill:foo",
+      "--source", "B-0056",
+      "--rationale", "missing decision",
+    ]);
+    expect(result.kind).toBe("error");
+  });
+
+  test("errors when --record missing --rationale", () => {
+    const result = parseArgs([
+      "--record",
+      "--candidate", "skill:foo",
+      "--source", "B-0056",
+      "--decision", "pass",
+    ]);
+    expect(result.kind).toBe("error");
+  });
+
+  test("errors on invalid decision value", () => {
+    const result = parseArgs([
+      "--record",
+      "--candidate", "skill:foo",
+      "--source", "B-0056",
+      "--decision", "maybe",
+      "--rationale", "invalid decision",
+    ]);
+    expect(result.kind).toBe("error");
+  });
+
+  test("errors on unknown arg", () => {
+    const result = parseArgs(["--bad-flag"]);
+    expect(result.kind).toBe("error");
+  });
+
+  test("accepts all three valid decisions", () => {
+    for (const d of ["pass", "fail", "defer"] as const) {
+      const result = parseArgs([
+        "--record",
+        "--candidate", "skill:test",
+        "--source", "B-0056",
+        "--decision", d,
+        "--rationale", `testing ${d}`,
+      ]);
+      expect(result.kind).toBe("args");
+      if (result.kind === "args" && result.args.mode === "record") {
+        expect(result.args.decision).toBe(d);
+      }
+    }
+  });
+});
+
+describe("readLog", () => {
+  test("returns empty array for nonexistent file", () => {
+    expect(readLog("/tmp/definitely-does-not-exist-filter-gate.jsonl")).toEqual([]);
+  });
+
+  test("returns empty array for empty file", () => {
+    const path = "/tmp/filter-gate-test-empty.jsonl";
+    writeFileSync(path, "");
+    expect(readLog(path)).toEqual([]);
+    rmSync(path, { force: true });
+  });
+
+  test("parses valid JSONL entries", () => {
+    const path = "/tmp/filter-gate-test-parse.jsonl";
+    const entry: FilterGateEntry = {
+      schema: "filter-gate-v1",
+      timestamp: "2026-05-08T00:00:00.000Z",
+      candidate: "skill:test",
+      source: "B-0056",
+      decision: "pass",
+      rationale: "test entry",
+      clauses: ["HC-1"],
+      author: "test",
+    };
+    writeFileSync(path, `${JSON.stringify(entry)}\n`);
+    const entries = readLog(path);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.candidate).toBe("skill:test");
+    expect(entries[0]!.decision).toBe("pass");
+    rmSync(path, { force: true });
+  });
+
+  test("skips malformed lines", () => {
+    const path = "/tmp/filter-gate-test-malformed.jsonl";
+    const good: FilterGateEntry = {
+      schema: "filter-gate-v1",
+      timestamp: "2026-05-08T00:00:00.000Z",
+      candidate: "skill:good",
+      source: "B-0056",
+      decision: "pass",
+      rationale: "good",
+      clauses: [],
+      author: "test",
+    };
+    writeFileSync(path, `${JSON.stringify(good)}\nnot-json\n${JSON.stringify(good)}\n`);
+    const entries = readLog(path);
+    expect(entries).toHaveLength(2);
+    rmSync(path, { force: true });
+  });
+});
+
+describe("computeSummary", () => {
+  test("returns zeroes for empty log", () => {
+    const summary = computeSummary([]);
+    expect(summary.total).toBe(0);
+    expect(summary.pass).toBe(0);
+    expect(summary.fail).toBe(0);
+    expect(summary.defer).toBe(0);
+    expect(summary.sources.size).toBe(0);
+  });
+
+  test("counts decisions correctly", () => {
+    const entries: FilterGateEntry[] = [
+      { schema: "filter-gate-v1", timestamp: "", candidate: "a", source: "B-0056", decision: "pass", rationale: "", clauses: [], author: "" },
+      { schema: "filter-gate-v1", timestamp: "", candidate: "b", source: "B-0056", decision: "fail", rationale: "", clauses: [], author: "" },
+      { schema: "filter-gate-v1", timestamp: "", candidate: "c", source: "B-0057", decision: "defer", rationale: "", clauses: [], author: "" },
+      { schema: "filter-gate-v1", timestamp: "", candidate: "d", source: "B-0057", decision: "pass", rationale: "", clauses: [], author: "" },
+    ];
+    const summary = computeSummary(entries);
+    expect(summary.total).toBe(4);
+    expect(summary.pass).toBe(2);
+    expect(summary.fail).toBe(1);
+    expect(summary.defer).toBe(1);
+  });
+
+  test("groups by source", () => {
+    const entries: FilterGateEntry[] = [
+      { schema: "filter-gate-v1", timestamp: "", candidate: "a", source: "B-0056", decision: "pass", rationale: "", clauses: [], author: "" },
+      { schema: "filter-gate-v1", timestamp: "", candidate: "b", source: "B-0056", decision: "fail", rationale: "", clauses: [], author: "" },
+      { schema: "filter-gate-v1", timestamp: "", candidate: "c", source: "B-0059", decision: "pass", rationale: "", clauses: [], author: "" },
+    ];
+    const summary = computeSummary(entries);
+    expect(summary.sources.get("B-0056")).toBe(2);
+    expect(summary.sources.get("B-0059")).toBe(1);
+  });
+});
+
+describe("main() CLI", () => {
+  test("returns 0 with --help", () => {
+    expect(main(["--help"])).toBe(0);
+  });
+
+  test("returns 1 with no args", () => {
+    expect(main([])).toBe(1);
+  });
+
+  test("returns 1 for unknown arg", () => {
+    expect(main(["--bad-flag"])).toBe(1);
+  });
+
+  test("returns 0 with --list (empty log)", () => {
+    expect(main(["--list"])).toBe(0);
+  });
+
+  test("returns 0 with --list --json", () => {
+    expect(main(["--list", "--json"])).toBe(0);
+  });
+
+  test("returns 0 with --list --md", () => {
+    expect(main(["--list", "--md"])).toBe(0);
+  });
+
+  test("returns 0 with --summary (empty log)", () => {
+    expect(main(["--summary"])).toBe(0);
+  });
+
+  test("returns 1 for --record with missing fields", () => {
+    expect(main(["--record", "--candidate", "skill:foo"])).toBe(1);
+  });
+
+  test("returns 1 for --record with invalid decision", () => {
+    expect(main([
+      "--record",
+      "--candidate", "skill:foo",
+      "--source", "B-0056",
+      "--decision", "invalid",
+      "--rationale", "test",
+    ])).toBe(1);
+  });
+
+  test("returns 0 for valid --record", () => {
+    const code = main([
+      "--record",
+      "--candidate", "skill:test-entry",
+      "--source", "B-0056",
+      "--decision", "pass",
+      "--rationale", "Integration test entry",
+    ]);
+    expect(code).toBe(0);
+  });
+});

--- a/tools/alignment/filter_gate_log.ts
+++ b/tools/alignment/filter_gate_log.ts
@@ -1,0 +1,374 @@
+#!/usr/bin/env bun
+// filter_gate_log.ts — candidate-failure honesty log.
+//
+// B-0058 responsibility #3: candidates that fail the ethics+safety
+// filter-gate are recorded as failure-data, NOT silently dropped.
+// Rubber-stamping is the exact failure-mode the three-filter
+// discipline exists to prevent — this tool extends that discipline
+// into the ethics axis.
+//
+// Records pass/fail/defer decisions for candidate adoptions from
+// downstream research tracks (B-0056 mythology, B-0057 occult,
+// B-0059 etymology+epistemology, and any future resonance-family row).
+//
+// Usage:
+//   bun tools/alignment/filter_gate_log.ts --record \
+//     --candidate "skill:foo" --source B-0056 --decision fail \
+//     --rationale "Breaks retractibility — force-publishes to channel"
+//
+//   bun tools/alignment/filter_gate_log.ts --record \
+//     --candidate "glossary:bar" --source B-0059 --decision pass \
+//     --rationale "Additive, git-tracked, one-commit removable" \
+//     --clauses HC-1,SD-3
+//
+//   bun tools/alignment/filter_gate_log.ts --list
+//   bun tools/alignment/filter_gate_log.ts --list --json
+//   bun tools/alignment/filter_gate_log.ts --list --md
+//   bun tools/alignment/filter_gate_log.ts --summary
+//
+// Exit codes:
+//   0  Success
+//   1  Validation error (missing required fields, bad decision value)
+//   2  Script error / bad args
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+type ExitCode = 0 | 1 | 2;
+
+export type Decision = "pass" | "fail" | "defer";
+
+const VALID_DECISIONS: readonly Decision[] = ["pass", "fail", "defer"] as const;
+
+export interface FilterGateEntry {
+  readonly schema: "filter-gate-v1";
+  readonly timestamp: string;
+  readonly candidate: string;
+  readonly source: string;
+  readonly decision: Decision;
+  readonly rationale: string;
+  readonly clauses: readonly string[];
+  readonly author: string;
+}
+
+interface RecordArgs {
+  readonly mode: "record";
+  readonly candidate: string;
+  readonly source: string;
+  readonly decision: Decision;
+  readonly rationale: string;
+  readonly clauses: readonly string[];
+}
+
+interface ListArgs {
+  readonly mode: "list";
+  readonly json: boolean;
+  readonly md: boolean;
+}
+
+interface SummaryArgs {
+  readonly mode: "summary";
+}
+
+type Args = RecordArgs | ListArgs | SummaryArgs;
+
+type ParseResult =
+  | { readonly kind: "args"; readonly args: Args }
+  | { readonly kind: "help" }
+  | { readonly kind: "error"; readonly message: string };
+
+function repoRoot(): string {
+  const result = spawnSync(
+    "git",
+    ["rev-parse", "--show-toplevel"],
+    { encoding: "utf8" },
+  );
+  if (result.error) throw new Error(`git rev-parse failed: ${result.error.message}`);
+  if (result.status !== 0) throw new Error(`git rev-parse exited with status ${String(result.status)}`);
+  return result.stdout.trim();
+}
+
+function gitUser(): string {
+  const result = spawnSync(
+    "git",
+    ["config", "user.name"],
+    { encoding: "utf8" },
+  );
+  if (result.error || result.status !== 0) return "unknown";
+  return result.stdout.trim();
+}
+
+const LOG_PATH = "tools/alignment/out/filter-gate-log.jsonl";
+
+export function logFilePath(): string {
+  return join(repoRoot(), LOG_PATH);
+}
+
+export function parseArgs(argv: readonly string[]): ParseResult {
+  let mode: "record" | "list" | "summary" | null = null;
+  let candidate = "";
+  let source = "";
+  let decision = "";
+  let rationale = "";
+  let clauses = "";
+  let json = false;
+  let md = false;
+
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i] ?? "";
+    if (arg === "-h" || arg === "--help") return { kind: "help" };
+
+    if (arg === "--record") { mode = "record"; i += 1; continue; }
+    if (arg === "--list") { mode = "list"; i += 1; continue; }
+    if (arg === "--summary") { mode = "summary"; i += 1; continue; }
+    if (arg === "--json") { json = true; i += 1; continue; }
+    if (arg === "--md") { md = true; i += 1; continue; }
+
+    if (arg === "--candidate") {
+      const next = argv[i + 1];
+      if (next === undefined) return { kind: "error", message: "filter_gate_log: --candidate requires a value" };
+      candidate = next;
+      i += 2;
+      continue;
+    }
+    if (arg === "--source") {
+      const next = argv[i + 1];
+      if (next === undefined) return { kind: "error", message: "filter_gate_log: --source requires a value" };
+      source = next;
+      i += 2;
+      continue;
+    }
+    if (arg === "--decision") {
+      const next = argv[i + 1];
+      if (next === undefined) return { kind: "error", message: "filter_gate_log: --decision requires a value" };
+      decision = next;
+      i += 2;
+      continue;
+    }
+    if (arg === "--rationale") {
+      const next = argv[i + 1];
+      if (next === undefined) return { kind: "error", message: "filter_gate_log: --rationale requires a value" };
+      rationale = next;
+      i += 2;
+      continue;
+    }
+    if (arg === "--clauses") {
+      const next = argv[i + 1];
+      if (next === undefined) return { kind: "error", message: "filter_gate_log: --clauses requires a value" };
+      clauses = next;
+      i += 2;
+      continue;
+    }
+
+    return { kind: "error", message: `filter_gate_log: unknown arg: ${arg}` };
+  }
+
+  if (mode === null) return { kind: "error", message: "filter_gate_log: must specify --record, --list, or --summary" };
+
+  if (mode === "list") {
+    return { kind: "args", args: { mode: "list", json, md } };
+  }
+
+  if (mode === "summary") {
+    return { kind: "args", args: { mode: "summary" } };
+  }
+
+  if (candidate === "") return { kind: "error", message: "filter_gate_log: --candidate is required for --record" };
+  if (source === "") return { kind: "error", message: "filter_gate_log: --source is required for --record" };
+  if (decision === "") return { kind: "error", message: "filter_gate_log: --decision is required for --record" };
+  if (!VALID_DECISIONS.includes(decision as Decision)) {
+    return { kind: "error", message: `filter_gate_log: --decision must be one of: ${VALID_DECISIONS.join(", ")}` };
+  }
+  if (rationale === "") return { kind: "error", message: "filter_gate_log: --rationale is required for --record" };
+
+  const parsedClauses = clauses === ""
+    ? []
+    : clauses.split(",").map((c) => c.trim()).filter((c) => c.length > 0);
+
+  return {
+    kind: "args",
+    args: {
+      mode: "record",
+      candidate,
+      source,
+      decision: decision as Decision,
+      rationale,
+      clauses: parsedClauses,
+    },
+  };
+}
+
+export function readLog(path: string): readonly FilterGateEntry[] {
+  if (!existsSync(path)) return [];
+  const content = readFileSync(path, "utf8").trim();
+  if (content === "") return [];
+  const entries: FilterGateEntry[] = [];
+  for (const line of content.split("\n")) {
+    if (line.trim() === "") continue;
+    try {
+      entries.push(JSON.parse(line) as FilterGateEntry);
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return entries;
+}
+
+export function recordEntry(args: RecordArgs): FilterGateEntry {
+  const entry: FilterGateEntry = {
+    schema: "filter-gate-v1",
+    timestamp: new Date().toISOString(),
+    candidate: args.candidate,
+    source: args.source,
+    decision: args.decision,
+    rationale: args.rationale,
+    clauses: args.clauses,
+    author: gitUser(),
+  };
+
+  const path = logFilePath();
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+  appendFileSync(path, `${JSON.stringify(entry)}\n`);
+
+  return entry;
+}
+
+function emitListJson(entries: readonly FilterGateEntry[]): string {
+  return `${JSON.stringify(entries, null, 2)}\n`;
+}
+
+function emitListMd(entries: readonly FilterGateEntry[]): string {
+  const lines: string[] = [];
+  lines.push("# Filter-gate decision log");
+  lines.push("");
+  lines.push(`Total entries: **${String(entries.length)}**.`);
+  lines.push("");
+
+  if (entries.length === 0) {
+    lines.push("No entries recorded yet.");
+    return lines.join("\n");
+  }
+
+  lines.push("| Timestamp | Candidate | Source | Decision | Clauses | Rationale |");
+  lines.push("| --- | --- | --- | --- | --- | --- |");
+  for (const e of entries) {
+    const clauseStr = e.clauses.length > 0 ? e.clauses.join(", ") : "(none)";
+    lines.push(`| ${e.timestamp} | ${e.candidate} | ${e.source} | **${e.decision}** | ${clauseStr} | ${e.rationale} |`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function emitListHuman(entries: readonly FilterGateEntry[]): string {
+  const lines: string[] = [];
+  lines.push(`filter-gate-log entries=${String(entries.length)}`);
+  lines.push("");
+
+  if (entries.length === 0) {
+    lines.push("No entries recorded yet.");
+    return lines.join("\n");
+  }
+
+  for (const e of entries) {
+    const clauseStr = e.clauses.length > 0 ? ` clauses=${e.clauses.join(",")}` : "";
+    lines.push(`  [${e.decision}] ${e.candidate} (source=${e.source}${clauseStr})`);
+    lines.push(`         ${e.rationale}`);
+    lines.push(`         ${e.timestamp} by ${e.author}`);
+  }
+  return lines.join("\n");
+}
+
+export interface Summary {
+  readonly total: number;
+  readonly pass: number;
+  readonly fail: number;
+  readonly defer: number;
+  readonly sources: ReadonlyMap<string, number>;
+}
+
+export function computeSummary(entries: readonly FilterGateEntry[]): Summary {
+  const sources = new Map<string, number>();
+  let pass = 0;
+  let fail = 0;
+  let defer = 0;
+
+  for (const e of entries) {
+    if (e.decision === "pass") pass += 1;
+    else if (e.decision === "fail") fail += 1;
+    else defer += 1;
+
+    sources.set(e.source, (sources.get(e.source) ?? 0) + 1);
+  }
+
+  return { total: entries.length, pass, fail, defer, sources };
+}
+
+function emitSummary(summary: Summary): string {
+  const lines: string[] = [];
+  lines.push(`filter-gate-summary total=${String(summary.total)} pass=${String(summary.pass)} fail=${String(summary.fail)} defer=${String(summary.defer)}`);
+
+  if (summary.sources.size > 0) {
+    lines.push("");
+    lines.push("By source:");
+    for (const [src, count] of [...summary.sources.entries()].sort((a, b) => b[1] - a[1])) {
+      lines.push(`  ${src}: ${String(count)}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+const HELP = `Usage:
+  filter_gate_log.ts --record --candidate NAME --source TRACK --decision pass|fail|defer --rationale TEXT [--clauses HC-1,SD-3,...]
+  filter_gate_log.ts --list [--json | --md]
+  filter_gate_log.ts --summary
+`;
+
+export function main(argv: readonly string[]): ExitCode {
+  const parsed = parseArgs(argv);
+  if (parsed.kind === "help") {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (parsed.kind === "error") {
+    process.stderr.write(`${parsed.message}\n`);
+    return 1;
+  }
+  const { args } = parsed;
+
+  process.chdir(repoRoot());
+
+  if (args.mode === "record") {
+    const entry = recordEntry(args);
+    process.stdout.write(`recorded: [${entry.decision}] ${entry.candidate} (${entry.source})\n`);
+    return 0;
+  }
+
+  if (args.mode === "list") {
+    const entries = readLog(logFilePath());
+    if (args.json) {
+      process.stdout.write(emitListJson(entries));
+    } else if (args.md) {
+      process.stdout.write(emitListMd(entries));
+    } else {
+      process.stdout.write(`${emitListHuman(entries)}\n`);
+    }
+    return 0;
+  }
+
+  if (args.mode === "summary") {
+    const entries = readLog(logFilePath());
+    const summary = computeSummary(entries);
+    process.stdout.write(`${emitSummary(summary)}\n`);
+    return 0;
+  }
+
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Summary
- Implements **B-0058 responsibility #3** (candidate-failure honesty log): `tools/alignment/filter_gate_log.ts` records pass/fail/defer decisions for candidate adoptions from downstream research tracks (B-0056/B-0057/B-0059) as append-only JSONL at `tools/alignment/out/filter-gate-log.jsonl`.
- Prevents the rubber-stamping failure mode — candidates that fail the ethics+safety gate are recorded as failure-data, NOT silently dropped.
- Fixes a pre-existing test regression in `audit_retractibility.test.ts` where `git grep` found the test file's own literal path string (1 fail → 0 fail).

## What the tool does
- `--record` mode: appends a structured JSON entry with candidate, source track, decision (pass/fail/defer), rationale, clause citations, author, and timestamp
- `--list` mode: reads and displays the log (plain/json/md)
- `--summary` mode: aggregates by decision type and source track

## Focused checks
- `bun test tools/alignment/` → **93 pass, 0 fail** (was 59 pass / 1 fail before this PR)
- `dotnet build -c Release` → **0 Warning(s), 0 Error(s)**

## B-0058 progress after this PR
| Responsibility | Tool | Status |
| --- | --- | --- |
| #1 Retractibility-and-log check | `audit_retractibility.ts` | Done (PR #2108) |
| #2 New-surface clause coverage | `audit_clause_coverage.ts` | Done (PR #2102) |
| #3 Candidate-failure honesty log | `filter_gate_log.ts` | **This PR** |
| #4 Alignment-clause drift detector | `audit_clause_drift.ts` | Done (PR #2103) |
| #5 Blast-radius-before-rewrite audit | — | Not yet built |

🤖 Generated with [Claude Code](https://claude.com/claude-code)