### PR TITLE
fix: remove unused imports in filter-gate log tests

### DIFF
--- a/tools/alignment/filter_gate_log.test.ts
+++ b/tools/alignment/filter_gate_log.test.ts
@@ -5,17 +5,14 @@
 //
 // Run: bun test tools/alignment/filter_gate_log.test.ts
 
-import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { rmSync, writeFileSync } from "node:fs";
 import {
   computeSummary,
-  type Decision,
   type FilterGateEntry,
   main,
   parseArgs,
   readLog,
-  recordEntry,
 } from "./filter_gate_log.ts";
 
 describe("parseArgs", () => {


### PR DESCRIPTION
## Summary
- Removes 6 unused imports in `tools/alignment/filter_gate_log.test.ts` that fail the `lint (tsc tools)` CI check (`noUnusedLocals`/`noUnusedParameters`).
- The squash merge of PR #2110 landed the original commit before the tsc fix commit arrived, so the unused imports persisted on main.

## Test plan
- [x] `bun x tsc --noEmit` — 0 errors
- [x] `bun test tools/alignment/filter_gate_log.test.ts` — 33 pass, 0 fail
- [x] `dotnet build -c Release` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)