### PR TITLE
docs(B-0060): decompose into 7 dependency-ordered child rows

### DIFF
--- a/docs/backlog/P1/B-0060-human-lineage-external-anchor-backfill-all-substrate-beacon-safe.md
+++ b/docs/backlog/P1/B-0060-human-lineage-external-anchor-backfill-all-substrate-beacon-safe.md
@@ -1,15 +1,16 @@
 ---
 id: B-0060
 priority: P1
-status: open
+status: umbrella
 title: Human-lineage / external-anchor backfill across all factory substrate — Beacon-safe + human-anchored prior-art citations for every load-bearing concept
 tier: substrate-quality
 effort: L
 ask: maintainer Aaron 2026-04-28 ("we should backlog human lineage to all our substraight stuff too if it exists, all our AI stuff even though we are just editing md files is coding and thee might be articles and research papers or question/answer fourms stack overflow etc... we should research waht we've already done and make sure it's beacon safe and human anchored/linage.")
 created: 2026-04-28
-last_updated: 2026-05-02
+last_updated: 2026-05-08
 depends_on: []
 composes_with: [B-0003]
+children: [B-0310, B-0311, B-0312, B-0313, B-0314, B-0315, B-0316]
 tags: [substrate-quality, beacon-safety, otto-351, otto-352, external-anchors, human-lineage, prior-art, agent-design-research, research-discipline]
 type: friction-reducer
 ---
@@ -103,6 +104,47 @@ For each load-bearing substrate concept:
       vocabulary doesn't collide with Beacon-blocked
       terminology (per Otto-351 + the prompt-protector
       review).
+
+## Decomposition (2026-05-08)
+
+This umbrella row is decomposed into 7 atomic child rows,
+dependency-ordered across 3 layers:
+
+**Layer 0 — Tooling (no external deps, buildable now):**
+
+| Child | Title | Effort | Depends on |
+| --- | --- | --- | --- |
+| B-0310 | Concept-registry extraction tool | S | — |
+
+**Layer 1 — Scanner (depends on registry):**
+
+| Child | Title | Effort | Depends on |
+| --- | --- | --- | --- |
+| B-0311 | External-anchor coverage scanner | S | B-0310 |
+
+**Layer 2 — Research backfill (parallelizable, depends on scanner):**
+
+| Child | Title | Effort | Depends on |
+| --- | --- | --- | --- |
+| B-0312 | HC/SD/DIR alignment-clause anchor backfill | M | B-0311 |
+| B-0313 | Wake-time Otto-NN principle anchor backfill | M | B-0311 |
+| B-0314 | BP-NN rule anchor backfill | M | B-0311 |
+| B-0315 | Glass-Halo doctrine anchor backfill | S | B-0311 |
+
+**Layer 3 — Long-tail cadence (depends on scanner):**
+
+| Child | Title | Effort | Depends on |
+| --- | --- | --- | --- |
+| B-0316 | Long-tail anchor cadenced sweep setup | S | B-0311 |
+
+Dependency graph:
+```
+B-0310 → B-0311 → B-0312 (HC/SD/DIR)
+                 → B-0313 (Otto-NN)
+                 → B-0314 (BP-NN)
+                 → B-0315 (Glass-Halo)
+                 → B-0316 (cadence setup)
+```
 
 ## Composes with
 

--- a/docs/backlog/P1/B-0310-concept-registry-extraction-tool.md
+++ b/docs/backlog/P1/B-0310-concept-registry-extraction-tool.md
@@ -1,0 +1,69 @@
+---
+id: B-0310
+priority: P1
+status: open
+title: "Concept-registry extraction tool — canonical inventory of load-bearing concepts"
+tier: substrate-quality
+effort: S
+parent: B-0060
+created: 2026-05-08
+last_updated: 2026-05-08
+depends_on: []
+composes_with: [B-0060, B-0311]
+tags: [substrate-quality, tooling, concept-registry, human-lineage]
+type: friction-reducer
+---
+
+# Concept-registry extraction tool
+
+Build `tools/alignment/concept_registry.ts` — extracts the
+canonical list of load-bearing concept IDs from their source
+surfaces into a single JSON registry. The registry is the
+machine-readable input to all downstream coverage-gap and
+anchoring work under B-0060.
+
+## Concept classes to extract
+
+| Class | Source surface | Example IDs |
+| --- | --- | --- |
+| Alignment clauses | `docs/ALIGNMENT.md` | HC-1..HC-7, SD-1..SD-9, DIR-1..DIR-5 |
+| Best-practice rules | `docs/AGENT-BEST-PRACTICES.md` | BP-1..BP-25 |
+| Otto-NN principles | `CLAUDE.md`, `memory/feedback_*.md` | Otto-247, Otto-275, Otto-357 |
+| Glass-Halo doctrines | `AGENTS.md`, `docs/ALIGNMENT.md` | radical-honesty, total-observability |
+
+## Existing infrastructure
+
+- `audit_clause_coverage.ts` already extracts HC/SD/DIR IDs
+  via regex. Reuse the `extractClauses` pattern.
+- `citations.ts` scans 5 directory trees. Reuse the
+  `scanFiles` / `listMarkdownRecursive` pattern.
+
+## Output schema
+
+```json
+{
+  "schema": "concept-registry-v1",
+  "generated": "2026-05-08T00:00:00Z",
+  "concepts": [
+    {
+      "id": "HC-1",
+      "class": "alignment-clause",
+      "source": "docs/ALIGNMENT.md",
+      "label": "..."
+    }
+  ]
+}
+```
+
+## Done-criteria
+
+- [ ] `bun tools/alignment/concept_registry.ts` runs and
+      emits JSON to stdout.
+- [ ] All 4 concept classes extracted with correct counts.
+- [ ] Tests in `concept_registry.test.ts` cover extraction
+      for each class.
+- [ ] Build gate passes (`dotnet build -c Release` — 0W 0E).
+
+## Reviewers
+
+- `spec-zealot` — registry schema correctness.

--- a/docs/backlog/P1/B-0311-external-anchor-coverage-scanner.md
+++ b/docs/backlog/P1/B-0311-external-anchor-coverage-scanner.md
@@ -1,0 +1,86 @@
+---
+id: B-0311
+priority: P1
+status: open
+title: "External-anchor coverage scanner — per-concept anchor presence/absence audit"
+tier: substrate-quality
+effort: S
+parent: B-0060
+created: 2026-05-08
+last_updated: 2026-05-08
+depends_on: [B-0310]
+composes_with: [B-0060, B-0310, B-0312, B-0313, B-0314, B-0315, B-0316]
+tags: [substrate-quality, tooling, external-anchors, human-lineage, beacon-safety]
+type: friction-reducer
+---
+
+# External-anchor coverage scanner
+
+Build `tools/alignment/audit_external_anchors.ts` — given
+the concept registry from B-0310, scans the substrate surface
+where each concept lives and extracts existing external anchor
+URLs (papers, RFCs, blog posts, Stack Overflow / Stack Exchange
+threads, conference talks). Produces a coverage report mapping
+each concept to its external anchors or an "anchor-pending"
+marker.
+
+## How it works
+
+1. Load the concept registry (from B-0310 tool output or
+   inline extraction).
+2. For each concept, locate its definition section in the
+   source surface.
+3. Extract external URLs (http/https) from that section.
+4. Classify each URL: paper / RFC / blog / SO-SE / talk /
+   other.
+5. Emit per-concept coverage: `anchored` (with URL list) or
+   `anchor-pending`.
+
+## Existing infrastructure
+
+- `citations.ts` already detects external URLs via
+  `EXTERNAL_RE` and counts them. Extend with per-concept
+  granularity.
+- `audit_clause_coverage.ts` already locates clause
+  references per surface. Extend to locate the clause
+  definition sections.
+
+## Output schema
+
+```json
+{
+  "schema": "external-anchor-coverage-v1",
+  "totalConcepts": 72,
+  "anchored": 15,
+  "pending": 57,
+  "concepts": [
+    {
+      "id": "HC-1",
+      "class": "alignment-clause",
+      "status": "anchored",
+      "anchors": [
+        { "url": "https://...", "kind": "paper", "title": "..." }
+      ]
+    },
+    {
+      "id": "BP-3",
+      "class": "best-practice",
+      "status": "anchor-pending",
+      "anchors": []
+    }
+  ]
+}
+```
+
+## Done-criteria
+
+- [ ] `bun tools/alignment/audit_external_anchors.ts` emits
+      JSON coverage report.
+- [ ] `--md` flag emits markdown coverage table.
+- [ ] Tests cover anchored and anchor-pending classification.
+- [ ] Build gate passes.
+
+## Reviewers
+
+- `spec-zealot` — schema correctness.
+- `alignment-auditor` — HC/SD/DIR coverage signal.

--- a/docs/backlog/P1/B-0312-alignment-clause-anchor-backfill.md
+++ b/docs/backlog/P1/B-0312-alignment-clause-anchor-backfill.md
@@ -1,0 +1,65 @@
+---
+id: B-0312
+priority: P1
+status: open
+title: "HC/SD/DIR alignment-clause external-anchor backfill"
+tier: substrate-quality
+effort: M
+parent: B-0060
+created: 2026-05-08
+last_updated: 2026-05-08
+depends_on: [B-0311]
+composes_with: [B-0060, B-0003]
+tags: [substrate-quality, external-anchors, alignment, beacon-safety, research]
+type: friction-reducer
+---
+
+# HC/SD/DIR alignment-clause external-anchor backfill
+
+Research and land external prior-art anchors for all 21
+alignment clauses in `docs/ALIGNMENT.md`. Each clause gets
+either (a) a cited human-authored external source or (b) an
+explicit "original to Zeta" note.
+
+## Scope — 21 clauses
+
+- HC-1 through HC-7 (Honesty Commitments)
+- SD-1 through SD-9 (Safety Defaults)
+- DIR-1 through DIR-5 (Directional Commitments)
+
+## Research approach per clause
+
+1. Identify the clause's core property (e.g., HC-1 is about
+   truthfulness in AI outputs).
+2. WebSearch for the property in AI safety / alignment
+   literature, ACM / IEEE / AAAI proceedings, ArXiv, blog
+   posts from recognized researchers.
+3. If a human-authored prior-art source exists, cite it
+   inline in ALIGNMENT.md using a footnote or "Prior art:"
+   annotation.
+4. If no prior art found after diligent search, add an
+   explicit "Original to Zeta — no external prior art found
+   as of YYYY-MM-DD" note.
+5. Beacon-safety check: verify cited source vocabulary does
+   not collide with Beacon-blocked terminology (per
+   Otto-351).
+
+## Composes with B-0003
+
+B-0003 is the ALIGNMENT.md rewrite. If B-0003 lands first,
+anchor backfill applies to the rewritten surface. If B-0312
+lands first, anchors carry forward into the rewrite.
+
+## Done-criteria
+
+- [ ] All 21 clauses have either an external anchor citation
+      or an explicit "original to Zeta" note.
+- [ ] Each citation includes: URL, author/org, title, date.
+- [ ] Beacon-safety pass completed on all cited sources.
+- [ ] Coverage scanner (B-0311) shows 21/21 anchored or
+      explicitly noted.
+
+## Reviewers
+
+- `alignment-auditor` — clause integrity.
+- `threat-model-critic` — Beacon-safety vocabulary check.

--- a/docs/backlog/P1/B-0313-wake-time-otto-nn-anchor-backfill.md
+++ b/docs/backlog/P1/B-0313-wake-time-otto-nn-anchor-backfill.md
@@ -1,0 +1,58 @@
+---
+id: B-0313
+priority: P1
+status: open
+title: "Wake-time Otto-NN principle external-anchor backfill"
+tier: substrate-quality
+effort: M
+parent: B-0060
+created: 2026-05-08
+last_updated: 2026-05-08
+depends_on: [B-0311]
+composes_with: [B-0060]
+tags: [substrate-quality, external-anchors, otto-nn, beacon-safety, research]
+type: friction-reducer
+---
+
+# Wake-time Otto-NN principle external-anchor backfill
+
+Research and land external prior-art anchors for the 7
+wake-time Otto-NN principles that compose into CLAUDE.md
+bootstrap disciplines. These are the most-cited internal
+principles; anchoring them to human-authored prior art
+strengthens external credibility and teachability.
+
+## Target principles
+
+| ID | Name | Core property |
+| --- | --- | --- |
+| Otto-247 | Search-first authority | Training data is stale; verify upstream |
+| Otto-275 | Manufactured patience | Sustainable cadence over burst-then-idle |
+| Otto-279 | Named-agent distinctness | Agents carry identity, not interchangeability |
+| Otto-341 | Substrate-IS-identity | The medium shapes the message/decision |
+| Otto-351 | Beacon-safety | Vocabulary discipline for external-facing prose |
+| Otto-352 | External-anchor-lineage | Cite human prior art for credibility |
+| Otto-357 | No-directives | Autonomy-first framing, not order-following |
+
+## Research approach per principle
+
+1. Extract the principle's operational definition from
+   CLAUDE.md / the source memory file.
+2. WebSearch for the property in agent-design literature,
+   multi-agent systems research, organizational autonomy
+   theory, software engineering methodology.
+3. Cite or note "original to Zeta" per the B-0060 protocol.
+4. Land anchors as inline citations in the relevant CLAUDE.md
+   bullet or as a dedicated `docs/research/` entry.
+
+## Done-criteria
+
+- [ ] All 7 principles have external anchor or "original"
+      note.
+- [ ] Citations include URL, author/org, title, date.
+- [ ] Beacon-safety pass on all cited sources.
+- [ ] Coverage scanner (B-0311) confirms 7/7 resolved.
+
+## Reviewers
+
+- `alignment-auditor` — principle-level coverage.

--- a/docs/backlog/P1/B-0314-bp-nn-rule-anchor-backfill.md
+++ b/docs/backlog/P1/B-0314-bp-nn-rule-anchor-backfill.md
@@ -1,0 +1,57 @@
+---
+id: B-0314
+priority: P1
+status: open
+title: "BP-NN rule external-anchor backfill"
+tier: substrate-quality
+effort: M
+parent: B-0060
+created: 2026-05-08
+last_updated: 2026-05-08
+depends_on: [B-0311]
+composes_with: [B-0060]
+tags: [substrate-quality, external-anchors, best-practices, beacon-safety, research]
+type: friction-reducer
+---
+
+# BP-NN rule external-anchor backfill
+
+Research and land external prior-art anchors for the 25
+BP-NN rules in `docs/AGENT-BEST-PRACTICES.md`. Priority:
+rules enforced by CI/pre-commit hooks first (they fire most
+frequently and need the strongest justification trail).
+
+## Scope
+
+BP-1 through BP-25 as enumerated in
+`docs/AGENT-BEST-PRACTICES.md`.
+
+## Priority ordering within scope
+
+1. Rules enforced by hooks or CI (e.g., BP-10 invisible-
+   Unicode lint, BP-11 data-is-not-directives).
+2. Rules cited in pre-commit or pre-push checks.
+3. Rules referenced by 3+ skills or agents.
+4. Remaining rules.
+
+## Research approach per rule
+
+1. Extract the rule's core claim from AGENT-BEST-PRACTICES.md.
+2. WebSearch for the underlying practice in software
+   engineering, AI agent design, security, prompt engineering
+   literature.
+3. Cite or note "original to Zeta" per the B-0060 protocol.
+4. Land anchors as inline citations within the rule's section
+   in AGENT-BEST-PRACTICES.md.
+
+## Done-criteria
+
+- [ ] All 25 rules have external anchor or "original" note.
+- [ ] Citations include URL, author/org, title, date.
+- [ ] Beacon-safety pass on all cited sources.
+- [ ] Coverage scanner (B-0311) confirms 25/25 resolved.
+
+## Reviewers
+
+- `spec-zealot` — rule integrity post-edit.
+- `threat-model-critic` — security-rule anchor adequacy.

--- a/docs/backlog/P1/B-0315-glass-halo-doctrine-anchor-backfill.md
+++ b/docs/backlog/P1/B-0315-glass-halo-doctrine-anchor-backfill.md
@@ -1,0 +1,54 @@
+---
+id: B-0315
+priority: P1
+status: open
+title: "Glass-Halo doctrine external-anchor backfill"
+tier: substrate-quality
+effort: S
+parent: B-0060
+created: 2026-05-08
+last_updated: 2026-05-08
+depends_on: [B-0311]
+composes_with: [B-0060]
+tags: [substrate-quality, external-anchors, glass-halo, beacon-safety, research]
+type: friction-reducer
+---
+
+# Glass-Halo doctrine external-anchor backfill
+
+Research and land external prior-art anchors for Glass-Halo
+doctrines visible on public-facing surfaces (README.md,
+AGENTS.md, CLAUDE.md, docs/ALIGNMENT.md).
+
+## Target doctrines
+
+| Doctrine | Public surface | Core property |
+| --- | --- | --- |
+| Radical honesty | AGENTS.md, ALIGNMENT.md | AI never hides reasoning from observers |
+| Total observability | AGENTS.md, ALIGNMENT.md | Every decision trail is inspectable |
+| No hidden reasoning | AGENTS.md | Visible chain of thought, not opaque |
+| Glass-halo transparency | CLAUDE.md, README.md | External-facing truthfulness contract |
+| Retraction-native | AGENTS.md | Every action has a bounded undo path |
+
+## Research approach per doctrine
+
+1. Extract the doctrine's operational definition from
+   AGENTS.md / ALIGNMENT.md.
+2. WebSearch for the underlying concept in AI transparency
+   research, explainable AI (XAI), organizational
+   transparency theory, software auditability literature.
+3. Cite or note "original to Zeta" per the B-0060 protocol.
+4. Land anchors inline in the doctrine's defining surface.
+
+## Done-criteria
+
+- [ ] All Glass-Halo doctrines have external anchor or
+      "original" note.
+- [ ] Citations include URL, author/org, title, date.
+- [ ] Beacon-safety pass on all cited sources.
+- [ ] Coverage scanner (B-0311) confirms resolution.
+
+## Reviewers
+
+- `public-api-designer` — public-surface language quality.
+- `alignment-auditor` — doctrine-level integrity.

--- a/docs/backlog/P2/B-0316-long-tail-anchor-sweep-cadence.md
+++ b/docs/backlog/P2/B-0316-long-tail-anchor-sweep-cadence.md
@@ -1,0 +1,61 @@
+---
+id: B-0316
+priority: P2
+status: open
+title: "Long-tail external-anchor cadenced sweep — memory files + research docs"
+tier: substrate-quality
+effort: S
+parent: B-0060
+created: 2026-05-08
+last_updated: 2026-05-08
+depends_on: [B-0311]
+composes_with: [B-0060, B-0090]
+tags: [substrate-quality, external-anchors, cadence, memory, research-docs]
+type: friction-reducer
+---
+
+# Long-tail external-anchor cadenced sweep
+
+Define and integrate a cadenced sweep procedure for
+external-anchor coverage across the ~930 memory files and
+~358 docs/research/ files. This is Phase 3 of B-0060 —
+ongoing, not a one-shot.
+
+## Approach
+
+1. Add an `--sweep N` flag to the external-anchor coverage
+   scanner (B-0311) that samples every Nth file.
+2. Wire the sweep into an existing cadence tool or the
+   razor-cadence workflow as an optional check.
+3. Each sweep iteration:
+   - Pick the next batch of memory/research files.
+   - For each file with a load-bearing concept and no
+     external anchor, flag as `anchor-pending`.
+   - Log sweep progress so subsequent iterations continue
+     where the last left off.
+
+## Scope boundary
+
+This row covers the SETUP of the cadence (the tool flag +
+the wiring), not the execution of all ~1288 files. Execution
+is ongoing cadenced work after setup lands.
+
+## Composes with B-0090
+
+B-0090 (cadenced lost-substrate recovery audit) already
+defines a cadence pattern for sweeping memory files. This
+row adds the external-anchor dimension to that sweep.
+
+## Done-criteria
+
+- [ ] `--sweep N` flag added to audit_external_anchors.ts.
+- [ ] Sweep progress tracking (file or JSON state) so
+      iterations resume.
+- [ ] Integration point documented (razor-cadence or
+      standalone invocation).
+- [ ] Tests cover sweep-resume behavior.
+- [ ] Build gate passes.
+
+## Reviewers
+
+- `devops-engineer` — cadence integration.


### PR DESCRIPTION
## Summary

- Decomposes B-0060 (human-lineage / external-anchor backfill, L effort) into **7 atomic child backlog rows** across 3 dependency layers
- Updates parent B-0060 to `status: umbrella` with `children:` pointer and dependency graph
- No code changes — backlog-only decomposition

## Dependency graph

```
B-0310 (concept-registry tool)
  → B-0311 (external-anchor coverage scanner)
    → B-0312 (HC/SD/DIR alignment-clause anchors)    [parallel]
    → B-0313 (wake-time Otto-NN principle anchors)    [parallel]
    → B-0314 (BP-NN rule anchors)                     [parallel]
    → B-0315 (Glass-Halo doctrine anchors)            [parallel]
    → B-0316 (long-tail sweep cadence setup, P2)      [parallel]
```

## Child rows

| ID | Layer | Title | Effort | Priority |
| --- | --- | --- | --- | --- |
| B-0310 | 0 | Concept-registry extraction tool | S | P1 |
| B-0311 | 1 | External-anchor coverage scanner | S | P1 |
| B-0312 | 2 | HC/SD/DIR alignment-clause anchor backfill | M | P1 |
| B-0313 | 2 | Wake-time Otto-NN principle anchor backfill | M | P1 |
| B-0314 | 2 | BP-NN rule anchor backfill | M | P1 |
| B-0315 | 2 | Glass-Halo doctrine anchor backfill | S | P1 |
| B-0316 | 3 | Long-tail anchor cadenced sweep setup | S | P2 |

## Existing infrastructure leveraged

- `tools/alignment/citations.ts` — external URL counting (extends with per-concept granularity)
- `tools/alignment/audit_clause_coverage.ts` — HC/SD/DIR extraction pattern (reuse for registry)

## Checks

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] No code files modified — backlog-only PR
- [x] Parent B-0060 updated to umbrella with children array
- [x] All child rows have `parent: B-0060` and correct `depends_on` edges

## Test plan

- [ ] Verify each child row has valid YAML frontmatter
- [ ] Verify dependency chain is acyclic (B-0310 → B-0311 → B-031{2,3,4,5,6})
- [ ] Verify no duplicate backlog IDs (B-0310..B-0316 are new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)