### PR TITLE
feat(B-0058): add candidate-failure honesty audit

### DIFF
--- a/docs/claims/task-b0058-candidate-failure-log.md
+++ b/docs/claims/task-b0058-candidate-failure-log.md
@@ -17,3 +17,8 @@ Initial intended path set:
 - `tools/alignment/audit_candidate_failures.ts`
 - `tools/alignment/audit_candidate_failures.test.ts`
 - `tools/alignment/README.md`
+
+2026-05-08T18:03Z Codex/Vera implementation step: add a raw-JSONL
+reconstruction audit over `filter_gate_log.ts` so malformed lines and
+missing failure context become visible B-0058 evidence instead of being
+silently tolerated by the normal log reader.

--- a/docs/claims/task-b0058-candidate-failure-log.md
+++ b/docs/claims/task-b0058-candidate-failure-log.md
@@ -1,0 +1,19 @@
+# Claim - task-b0058-candidate-failure-log
+
+- **Session ID:** codex/20260508T173716Z-task-b0058-candidate-failure-log
+- **Harness:** codex
+- **Claimed at:** 2026-05-08T17:37:16.610Z
+- **ETA:** 2026-05-08T18:22:16.610Z
+- **Scope:** B-0058 candidate-failure honesty log audit
+- **Durable target:** tools/alignment/audit_candidate_failures.ts
+- **Platform mirror:** GitHub PR pending
+
+## Notes
+
+Branch: `claim/task-b0058-candidate-failure-log`
+
+Initial intended path set:
+
+- `tools/alignment/audit_candidate_failures.ts`
+- `tools/alignment/audit_candidate_failures.test.ts`
+- `tools/alignment/README.md`

--- a/tools/alignment/README.md
+++ b/tools/alignment/README.md
@@ -21,6 +21,7 @@ folder as the experimental loop.
 | `audit_clause_drift.ts` | Clause additions/removals/changes + impact survey | Cross-ref drift detection |
 | `audit_retractibility.ts` | Git-tracked + inbound-ref entanglement per surface | Retractibility gate (B-0058 #1) |
 | `filter_gate_log.ts`  | Pass/fail/defer decisions for candidate adoptions | Honesty log (B-0058 #3) |
+| `audit_candidate_failures.ts` | Reconstruction audit for failed/deferred candidates | Honesty audit (B-0058 #3) |
 | `sd6_names.txt`       | SD-6 watchlist (per-host)                    | Data (not code)             |
 
 The three scripts form the gitops observability trio:
@@ -75,6 +76,9 @@ tools/alignment/audit_skills.sh --round 38 --out tools/alignment/out/round-38
 # Skill audit with friction gate — fails if any skill has
 # friction (rounds-since-owner-touched) >= threshold
 tools/alignment/audit_skills.sh --round 38 --gate 10
+
+# Audit the filter-gate honesty log for reconstructable failures
+bun tools/alignment/audit_candidate_failures.ts --md
 ```
 
 Exit codes:

--- a/tools/alignment/audit_candidate_failures.test.ts
+++ b/tools/alignment/audit_candidate_failures.test.ts
@@ -1,0 +1,151 @@
+// audit_candidate_failures.test.ts — tests for failure-log reconstruction.
+//
+// Run: bun test tools/alignment/audit_candidate_failures.test.ts
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { auditCandidateFailures, type CandidateFailureAudit, main } from "./audit_candidate_failures.ts";
+import type { FilterGateEntry } from "./filter_gate_log.ts";
+
+function tempLog(name: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "candidate-failure-audit-"));
+  return join(dir, name);
+}
+
+function cleanup(path: string): void {
+  rmSync(dirname(path), { recursive: true, force: true });
+}
+
+function entry(overrides: Partial<FilterGateEntry> = {}): FilterGateEntry {
+  return {
+    schema: "filter-gate-v1",
+    timestamp: "2026-05-08T00:00:00.000Z",
+    candidate: "skill:test",
+    source: "B-0058",
+    decision: "fail",
+    rationale: "Candidate was rejected with enough context to reconstruct it",
+    clauses: ["HC-1"],
+    author: "test",
+    ...overrides,
+  };
+}
+
+function writeJsonl(path: string, lines: readonly unknown[]): void {
+  writeFileSync(path, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`);
+}
+
+describe("auditCandidateFailures", () => {
+  test("returns a clean empty audit for missing log", () => {
+    const path = tempLog("missing.jsonl");
+    const audit = auditCandidateFailures(path);
+    expect(audit.totalEntries).toBe(0);
+    expect(audit.violations).toBe(0);
+    expect(audit.warnings).toBe(0);
+    cleanup(path);
+  });
+
+  test("counts pass, fail, defer, and non-pass entries", () => {
+    const path = tempLog("counts.jsonl");
+    writeJsonl(path, [
+      entry({ candidate: "skill:pass", decision: "pass" }),
+      entry({ candidate: "skill:fail", decision: "fail" }),
+      entry({ candidate: "skill:defer", decision: "defer" }),
+    ]);
+
+    const audit = auditCandidateFailures(path);
+    expect(audit.totalLines).toBe(3);
+    expect(audit.totalEntries).toBe(3);
+    expect(audit.passEntries).toBe(1);
+    expect(audit.failEntries).toBe(1);
+    expect(audit.deferEntries).toBe(1);
+    expect(audit.nonPassEntries).toBe(2);
+    expect(audit.violations).toBe(0);
+    cleanup(path);
+  });
+
+  test("reports malformed JSON as a violation", () => {
+    const path = tempLog("malformed.jsonl");
+    writeFileSync(path, `${JSON.stringify(entry())}\nnot-json\n`);
+
+    const audit = auditCandidateFailures(path);
+    expect(audit.violations).toBe(1);
+    expect(audit.findings[0]?.code).toBe("malformed-json");
+    cleanup(path);
+  });
+
+  test("reports missing rationale as a reconstruction violation", () => {
+    const path = tempLog("missing-rationale.jsonl");
+    writeJsonl(path, [{ ...entry(), rationale: "" }]);
+
+    const audit = auditCandidateFailures(path);
+    expect(audit.violations).toBe(1);
+    expect(audit.findings[0]?.code).toBe("missing-rationale");
+    cleanup(path);
+  });
+
+  test("warns but does not fail when a non-pass entry lacks clauses", () => {
+    const path = tempLog("warning.jsonl");
+    writeJsonl(path, [entry({ decision: "fail", clauses: [] })]);
+
+    const audit = auditCandidateFailures(path);
+    expect(audit.violations).toBe(0);
+    expect(audit.warnings).toBe(1);
+    expect(audit.findings[0]?.code).toBe("non-pass-without-clauses");
+    cleanup(path);
+  });
+
+  test("reports invalid clause arrays as violations", () => {
+    const path = tempLog("bad-clauses.jsonl");
+    writeJsonl(path, [{ ...entry(), clauses: ["HC-1", ""] }]);
+
+    const audit = auditCandidateFailures(path);
+    expect(audit.violations).toBe(1);
+    expect(audit.findings[0]?.code).toBe("invalid-clauses");
+    cleanup(path);
+  });
+
+  test("returns a stable schema name", () => {
+    const path = tempLog("schema.jsonl");
+    const audit: CandidateFailureAudit = auditCandidateFailures(path);
+    expect(audit.schema).toBe("candidate-failure-audit-v1");
+    cleanup(path);
+  });
+});
+
+describe("main() CLI", () => {
+  test("returns 0 with --help", () => {
+    expect(main(["--help"])).toBe(0);
+  });
+
+  test("returns 2 for unknown flags", () => {
+    expect(main(["--bad-flag"])).toBe(2);
+  });
+
+  test("returns 2 when --log has no value", () => {
+    expect(main(["--log"])).toBe(2);
+  });
+
+  test("returns 2 when both output formats are requested", () => {
+    expect(main(["--json", "--md"])).toBe(2);
+  });
+
+  test("returns 0 for a clean log in human, json, and markdown modes", () => {
+    const path = tempLog("clean.jsonl");
+    writeJsonl(path, [entry({ decision: "pass" })]);
+
+    expect(main(["--log", path])).toBe(0);
+    expect(main(["--log", path, "--json"])).toBe(0);
+    expect(main(["--log", path, "--md"])).toBe(0);
+    cleanup(path);
+  });
+
+  test("returns 1 when violations are present", () => {
+    const path = tempLog("invalid.jsonl");
+    writeFileSync(path, "not-json\n");
+
+    expect(main(["--log", path])).toBe(1);
+    cleanup(path);
+  });
+});

--- a/tools/alignment/audit_candidate_failures.ts
+++ b/tools/alignment/audit_candidate_failures.ts
@@ -1,0 +1,349 @@
+#!/usr/bin/env bun
+// audit_candidate_failures.ts — reconstruction audit for filter-gate failures.
+//
+// B-0058 responsibility #3: failed and deferred candidate adoptions are
+// evidence, not trash. This audit makes sure the filter-gate log keeps enough
+// structured context for later agents to reconstruct what was rejected, why,
+// by whom, and under which alignment clauses.
+//
+// Usage:
+//   bun tools/alignment/audit_candidate_failures.ts
+//   bun tools/alignment/audit_candidate_failures.ts --json
+//   bun tools/alignment/audit_candidate_failures.ts --md
+//   bun tools/alignment/audit_candidate_failures.ts --log PATH
+//
+// Exit codes:
+//   0  Log is parseable and reconstruction fields are present
+//   1  One or more reconstruction violations were found
+//   2  Script error / bad args
+
+import { existsSync, readFileSync } from "node:fs";
+import { logFilePath, type Decision } from "./filter_gate_log.ts";
+
+type ExitCode = 0 | 1 | 2;
+
+type Severity = "violation" | "warning";
+
+interface Args {
+  readonly log: string;
+  readonly json: boolean;
+  readonly md: boolean;
+}
+
+type ParseResult =
+  | { readonly kind: "args"; readonly args: Args }
+  | { readonly kind: "help" }
+  | { readonly kind: "error"; readonly message: string };
+
+export interface CandidateFailureFinding {
+  readonly line: number;
+  readonly severity: Severity;
+  readonly code: string;
+  readonly message: string;
+  readonly candidate: string | null;
+  readonly decision: Decision | null;
+}
+
+export interface CandidateFailureAudit {
+  readonly schema: "candidate-failure-audit-v1";
+  readonly logPath: string;
+  readonly totalLines: number;
+  readonly totalEntries: number;
+  readonly passEntries: number;
+  readonly failEntries: number;
+  readonly deferEntries: number;
+  readonly nonPassEntries: number;
+  readonly violations: number;
+  readonly warnings: number;
+  readonly findings: readonly CandidateFailureFinding[];
+}
+
+const VALID_DECISIONS: readonly Decision[] = ["pass", "fail", "defer"] as const;
+
+function parseArgs(argv: readonly string[]): ParseResult {
+  const state = {
+    log: logFilePath(),
+    json: false,
+    md: false,
+  };
+
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i] ?? "";
+    if (arg === "-h" || arg === "--help") return { kind: "help" };
+    if (arg === "--json") {
+      state.json = true;
+      i += 1;
+      continue;
+    }
+    if (arg === "--md") {
+      state.md = true;
+      i += 1;
+      continue;
+    }
+    if (arg === "--log") {
+      const next = argv[i + 1];
+      if (next === undefined) {
+        return { kind: "error", message: "audit_candidate_failures: --log requires a path" };
+      }
+      state.log = next;
+      i += 2;
+      continue;
+    }
+    return { kind: "error", message: `audit_candidate_failures: unknown arg: ${arg}` };
+  }
+
+  if (state.json && state.md) {
+    return { kind: "error", message: "audit_candidate_failures: choose only one of --json or --md" };
+  }
+
+  return { kind: "args", args: state };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(entry: Record<string, unknown>, key: string): string | null {
+  const value = entry[key];
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readDecision(entry: Record<string, unknown>): Decision | null {
+  const value = entry.decision;
+  if (typeof value !== "string") return null;
+  return VALID_DECISIONS.includes(value as Decision) ? (value as Decision) : null;
+}
+
+function readClauses(entry: Record<string, unknown>): readonly string[] | null {
+  const value = entry.clauses;
+  if (!Array.isArray(value)) return null;
+  if (value.some((clause) => typeof clause !== "string" || clause.trim().length === 0)) {
+    return null;
+  }
+  return value;
+}
+
+function finding(
+  line: number,
+  severity: Severity,
+  code: string,
+  message: string,
+  candidate: string | null,
+  decision: Decision | null,
+): CandidateFailureFinding {
+  return { line, severity, code, message, candidate, decision };
+}
+
+function validateEntry(
+  line: number,
+  entry: Record<string, unknown>,
+): {
+  readonly decision: Decision | null;
+  readonly findings: readonly CandidateFailureFinding[];
+} {
+  const findings: CandidateFailureFinding[] = [];
+  const candidate = nonEmptyString(entry, "candidate");
+  const decision = readDecision(entry);
+  const clauses = readClauses(entry);
+
+  if (entry.schema !== "filter-gate-v1") {
+    findings.push(
+      finding(line, "violation", "invalid-schema", "entry schema must be filter-gate-v1", candidate, decision),
+    );
+  }
+
+  for (const key of ["timestamp", "candidate", "source", "rationale", "author"] as const) {
+    if (nonEmptyString(entry, key) === null) {
+      findings.push(
+        finding(line, "violation", `missing-${key}`, `${key} must be a non-empty string`, candidate, decision),
+      );
+    }
+  }
+
+  if (decision === null) {
+    findings.push(
+      finding(line, "violation", "invalid-decision", "decision must be pass, fail, or defer", candidate, null),
+    );
+  }
+
+  if (clauses === null) {
+    findings.push(
+      finding(
+        line,
+        "violation",
+        "invalid-clauses",
+        "clauses must be an array of non-empty strings",
+        candidate,
+        decision,
+      ),
+    );
+  } else if ((decision === "fail" || decision === "defer") && clauses.length === 0) {
+    findings.push(
+      finding(
+        line,
+        "warning",
+        "non-pass-without-clauses",
+        "fail/defer entry has no clause IDs; make the non-adoption rationale reconstructable",
+        candidate,
+        decision,
+      ),
+    );
+  }
+
+  return { decision, findings };
+}
+
+export function auditCandidateFailures(path: string): CandidateFailureAudit {
+  const findings: CandidateFailureFinding[] = [];
+  let totalLines = 0;
+  let totalEntries = 0;
+  let passEntries = 0;
+  let failEntries = 0;
+  let deferEntries = 0;
+
+  if (!existsSync(path)) {
+    return {
+      schema: "candidate-failure-audit-v1",
+      logPath: path,
+      totalLines: 0,
+      totalEntries: 0,
+      passEntries: 0,
+      failEntries: 0,
+      deferEntries: 0,
+      nonPassEntries: 0,
+      violations: 0,
+      warnings: 0,
+      findings: [],
+    };
+  }
+
+  const content = readFileSync(path, "utf8");
+  const lines = content.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = lines[index] ?? "";
+    if (raw.trim().length === 0) continue;
+
+    const line = index + 1;
+    totalLines += 1;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      findings.push(finding(line, "violation", "malformed-json", "line is not valid JSON", null, null));
+      continue;
+    }
+
+    if (!isRecord(parsed)) {
+      findings.push(finding(line, "violation", "invalid-entry", "line must be a JSON object", null, null));
+      continue;
+    }
+
+    totalEntries += 1;
+    const result = validateEntry(line, parsed);
+    findings.push(...result.findings);
+
+    if (result.decision === "pass") passEntries += 1;
+    else if (result.decision === "fail") failEntries += 1;
+    else if (result.decision === "defer") deferEntries += 1;
+  }
+
+  return {
+    schema: "candidate-failure-audit-v1",
+    logPath: path,
+    totalLines,
+    totalEntries,
+    passEntries,
+    failEntries,
+    deferEntries,
+    nonPassEntries: failEntries + deferEntries,
+    violations: findings.filter((f) => f.severity === "violation").length,
+    warnings: findings.filter((f) => f.severity === "warning").length,
+    findings,
+  };
+}
+
+function emitHuman(audit: CandidateFailureAudit): string {
+  const lines: string[] = [];
+  lines.push(
+    `candidate-failure-audit entries=${String(audit.totalEntries)} nonpass=${String(audit.nonPassEntries)} violations=${String(audit.violations)} warnings=${String(audit.warnings)}`,
+  );
+  lines.push(`log=${audit.logPath}`);
+
+  if (audit.findings.length === 0) {
+    lines.push("No reconstruction gaps found.");
+    return lines.join("\n");
+  }
+
+  lines.push("");
+  for (const f of audit.findings) {
+    const candidate = f.candidate === null ? "" : ` candidate=${f.candidate}`;
+    const decision = f.decision === null ? "" : ` decision=${f.decision}`;
+    lines.push(`  [${f.severity}] line=${String(f.line)} code=${f.code}${candidate}${decision}`);
+    lines.push(`         ${f.message}`);
+  }
+  return lines.join("\n");
+}
+
+function emitMarkdown(audit: CandidateFailureAudit): string {
+  const lines: string[] = [];
+  lines.push("# Candidate-failure reconstruction audit");
+  lines.push("");
+  lines.push(`Log: \`${audit.logPath}\``);
+  lines.push("");
+  lines.push(`- Entries: ${String(audit.totalEntries)}`);
+  lines.push(`- Non-pass entries: ${String(audit.nonPassEntries)}`);
+  lines.push(`- Violations: ${String(audit.violations)}`);
+  lines.push(`- Warnings: ${String(audit.warnings)}`);
+
+  if (audit.findings.length === 0) {
+    lines.push("");
+    lines.push("No reconstruction gaps found.");
+    return lines.join("\n");
+  }
+
+  lines.push("");
+  lines.push("| Line | Severity | Code | Candidate | Decision | Message |");
+  lines.push("| --- | --- | --- | --- | --- | --- |");
+  for (const f of audit.findings) {
+    lines.push(
+      `| ${String(f.line)} | ${f.severity} | ${f.code} | ${f.candidate ?? ""} | ${f.decision ?? ""} | ${f.message} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+const HELP = `Usage:
+  audit_candidate_failures.ts [--log PATH] [--json | --md]
+`;
+
+export function main(argv: readonly string[]): ExitCode {
+  const parsed = parseArgs(argv);
+  if (parsed.kind === "help") {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (parsed.kind === "error") {
+    process.stderr.write(`${parsed.message}\n`);
+    return 2;
+  }
+
+  const audit = auditCandidateFailures(parsed.args.log);
+  if (parsed.args.json) {
+    process.stdout.write(`${JSON.stringify(audit, null, 2)}\n`);
+  } else if (parsed.args.md) {
+    process.stdout.write(`${emitMarkdown(audit)}\n`);
+  } else {
+    process.stdout.write(`${emitHuman(audit)}\n`);
+  }
+
+  return audit.violations > 0 ? 1 : 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Summary
- add a B-0058 raw-JSONL audit for filter-gate candidate decisions
- flag malformed/missing reconstruction fields as violations and fail/defer entries without clause context as warnings
- document the new audit surface in tools/alignment/README.md and update the claim substrate

## Checks
- bun test tools/alignment/filter_gate_log.test.ts tools/alignment/audit_candidate_failures.test.ts
- bunx prettier --check tools/alignment/audit_candidate_failures.ts tools/alignment/audit_candidate_failures.test.ts docs/claims/task-b0058-candidate-failure-log.md
- bunx markdownlint-cli2 tools/alignment/README.md docs/claims/task-b0058-candidate-failure-log.md
- git diff --check

## Note
- `bunx tsc --noEmit -p tsconfig.json` is blocked in this worktree by TS2688: missing type definition file for `bun`.