### PR TITLE
feat(B-0063): replace Homebrew pipe-to-shell with download-to-temp + verify

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -141,6 +141,12 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0302](backlog/P1/B-0302-pages-stable-route-map-pre-indexing-freeze-2026-05-08.md)** Pages content sources - stable route map before indexing
 - [ ] **[B-0303](backlog/P1/B-0303-pages-contributor-on-ramp-information-architecture-2026-05-08.md)** Pages content sources - contributor on-ramp information architecture
 - [ ] **[B-0304](backlog/P1/B-0304-pages-selected-research-publication-queue-redaction-gate-2026-05-08.md)** Pages content sources - selected research queue and redaction gate
+- [ ] **[B-0310](backlog/P1/B-0310-concept-registry-extraction-tool.md)** Concept-registry extraction tool — canonical inventory of load-bearing concepts
+- [ ] **[B-0311](backlog/P1/B-0311-external-anchor-coverage-scanner.md)** External-anchor coverage scanner — per-concept anchor presence/absence audit
+- [ ] **[B-0312](backlog/P1/B-0312-alignment-clause-anchor-backfill.md)** HC/SD/DIR alignment-clause external-anchor backfill
+- [ ] **[B-0313](backlog/P1/B-0313-wake-time-otto-nn-anchor-backfill.md)** Wake-time Otto-NN principle external-anchor backfill
+- [ ] **[B-0314](backlog/P1/B-0314-bp-nn-rule-anchor-backfill.md)** BP-NN rule external-anchor backfill
+- [ ] **[B-0315](backlog/P1/B-0315-glass-halo-doctrine-anchor-backfill.md)** Glass-Halo doctrine external-anchor backfill
 
 ## P2 — research-grade
 
@@ -262,6 +268,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0284](backlog/P2/B-0284-interloop-messaging-implementation-2026-05-08.md)** Interloop messaging — implementation on chosen transport
 - [x] **[B-0285](backlog/P2/B-0285-arc4-selfplay-arena-design-2026-05-08.md)** ARC-4 — adversarial self-play arena design
 - [ ] **[B-0286](backlog/P2/B-0286-arc4-selfplay-implementation-2026-05-08.md)** ARC-4 — self-play implementation + training loop
+- [ ] **[B-0316](backlog/P2/B-0316-long-tail-anchor-sweep-cadence.md)** Long-tail external-anchor cadenced sweep — memory files + research docs
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P1/B-0063-streamed-installer-download-to-temp-checksum-pattern-codex-p0-pr-75.md
+++ b/docs/backlog/P1/B-0063-streamed-installer-download-to-temp-checksum-pattern-codex-p0-pr-75.md
@@ -1,7 +1,7 @@
 ---
 id: B-0063
 priority: P1
-status: open
+status: done
 title: Streamed-installer download-to-temp + checksum-verify pattern — replace pipe-to-shell for upstream installers (Codex P0 on PR #75)
 tier: install-path-supply-chain
 effort: M
@@ -108,18 +108,26 @@ This pattern:
 
 ## Done-criteria
 
-- [ ] All three call sites converted to download-to-temp
+- [x] All three call sites converted to download-to-temp
       + size-check + exec pattern.
-- [ ] For each call site, the upstream's verifiability
+      - `elan.sh`: pinned commit SHA + SHA256 verify (pre-existing).
+      - `linux.sh` mise: pinned tarball + per-arch SHA256 (pre-existing).
+      - `macos.sh` Homebrew: download-to-temp + non-empty size check
+        (converted by this PR).
+- [x] For each call site, the upstream's verifiability
       story is documented in the inline comment (signed
       release / SHA256SUMS / project-as-trust-anchor with
       no upstream verification).
-- [ ] `tools/setup/common/curl-fetch.sh` doc-comments
-      reflect the new pattern; the `curl_fetch_stream`
-      function may then be DEPRECATED-WARNING-on-use or
-      removed entirely.
+      - `elan.sh`: commit-pinned + SHA256.
+      - `linux.sh` mise: version-pinned tarball + per-arch SHA256.
+      - `macos.sh` Homebrew: no upstream SHA256 (HEAD-tracking,
+        no tagged releases); trust anchor is HTTPS + GitHub +
+        Homebrew project. Documented inline.
+- [x] `tools/setup/common/curl-fetch.sh` doc-comments
+      reflect the new pattern; `curl_fetch_stream` removed
+      entirely (no remaining call sites).
 - [ ] CI passes on macOS-26, ubuntu-24.04, ubuntu-24.04-arm
-      with the new pattern.
+      with the new pattern (pending CI run on PR).
 
 ## Why P1 (not P0)
 

--- a/docs/backlog/P1/B-0063-streamed-installer-download-to-temp-checksum-pattern-codex-p0-pr-75.md
+++ b/docs/backlog/P1/B-0063-streamed-installer-download-to-temp-checksum-pattern-codex-p0-pr-75.md
@@ -7,7 +7,7 @@ tier: install-path-supply-chain
 effort: M
 ask: codex P0 review on PR #75 (5 threads on tools/setup/common/curl-fetch.sh, macos.sh, linux.sh, elan.sh) flagging that even bare `curl --retry` can retry after bytes are written to stdout, leaving the shell consumer with partial+full concatenated script content. PR #75 immediate fix: drop --retry from `curl_fetch_stream` entirely. This row tracks the structurally safe replacement.
 created: 2026-04-28
-last_updated: 2026-05-02
+last_updated: 2026-05-08
 depends_on: []
 decomposition: atomic
 classification: buildable-now
@@ -108,8 +108,8 @@ This pattern:
 
 ## Done-criteria
 
-- [x] All three call sites converted to download-to-temp
-      + size-check + exec pattern.
+- [x] All three call sites converted to download-to-temp,
+      size-check, and exec pattern.
       - `elan.sh`: pinned commit SHA + SHA256 verify (pre-existing).
       - `linux.sh` mise: pinned tarball + per-arch SHA256 (pre-existing).
       - `macos.sh` Homebrew: download-to-temp + non-empty size check

--- a/tools/setup/common/curl-fetch.sh
+++ b/tools/setup/common/curl-fetch.sh
@@ -3,23 +3,17 @@
 # tools/setup/common/curl-fetch.sh — sourceable helpers for
 # fetching URLs during install.
 #
-# Two helpers with DIFFERENT retry semantics by output mode:
+# One helper:
 #   - curl_fetch        — file-output downloads. `--retry 5`
 #                         + `--retry-all-errors` (safe because
 #                         curl restarts the file from scratch
 #                         on retry).
-#   - curl_fetch_stream — streamed-to-shell installers
-#                         (`curl ... | sh`, `bash -c
-#                         "$(curl ...)"`). NO retries. Streamed
-#                         retry is unsafe — partial bytes
-#                         already piped to the consumer cannot
-#                         be un-received. Streamed installers
-#                         fail-fast on transient errors;
-#                         caller re-runs install.sh.
-# Do NOT assume all curl usage in this repo is retried —
-# only the `curl_fetch` (file-output) variant retries. See
-# the per-function comments below + B-0063 for the
-# download-to-temp structural fix to the streamed case.
+#
+# All upstream-installer call sites (Homebrew, mise, elan)
+# now use the download-to-temp + verify + exec pattern via
+# curl_fetch. The former curl_fetch_stream function (streamed
+# pipe-to-shell, no retries) was removed by B-0063 — no call
+# sites remain.
 #
 # WHY
 # ===
@@ -39,36 +33,19 @@
 # *"sounds like a common helper would help too rather than
 # copy/paste."*
 #
-# TWO FUNCTIONS — file-output vs streamed
-# =======================================
-# Two helpers are exposed because the safe retry policy
-# differs by output mode. Code review on the original single-
-# function form flagged the partial-output-replay risk for
-# pipe-to-shell call sites:
-#
-#   curl_fetch        — for file-output downloads
-#                       (`-o`/`--output` to disk). Uses
-#                       `--retry-all-errors` because curl
-#                       restarts the file from scratch on
-#                       retry, so partial-output replay
-#                       cannot happen.
-#
-#   curl_fetch_stream — for streamed-to-shell installers
-#                       (`curl ... | sh`, `bash -c "$(curl
-#                       ...)"`). NO --retry. Reviewers
-#                       confirmed: even bare
-#                       `--retry` (without `--retry-all-
-#                       errors`) can retry after bytes have
-#                       already been written to stdout, and
-#                       the consumer cannot un-receive piped
-#                       bytes. Streamed installers fail-fast
-#                       on transient errors; the user re-runs
-#                       install.sh. Proper download-to-temp
-#                       hardening tracked as B-0063.
+# DOWNLOAD-TO-TEMP PATTERN (B-0063)
+# ==================================
+# All upstream-installer call sites now download to a temp
+# file via curl_fetch (with full retries), verify content
+# (SHA256 when upstream publishes one, non-empty size check
+# otherwise), then exec the verified file. This replaces the
+# former curl_fetch_stream pipe-to-shell pattern which could
+# not safely retry (partial bytes already piped to the shell
+# consumer cannot be un-received).
 #
 # USAGE
 # =====
-# Source this file, then call the appropriate helper:
+# Source this file, then call curl_fetch:
 #
 #     # shellcheck source=/dev/null
 #     source "$REPO_ROOT/tools/setup/common/curl-fetch.sh"
@@ -76,13 +53,12 @@
 #     # File output (safe with full retries):
 #     curl_fetch --output "$path" "$url"
 #
-#     # Streamed pipe (must use the stream variant):
-#     curl_fetch_stream https://example.com/install.sh | sh
-#
-#     # Command substitution (capture to var first; see
-#     # IDEMPOTENCE / SET-E note below):
-#     INSTALLER="$(curl_fetch_stream https://example.com/install.sh)"
-#     /bin/bash -c "$INSTALLER"
+#     # Upstream installers — download to temp, verify, exec:
+#     TMP="$(mktemp)"
+#     trap 'rm -f "$TMP"' EXIT
+#     curl_fetch --output "$TMP" "$url"
+#     [ -s "$TMP" ] || { echo "error: empty download" >&2; exit 1; }
+#     bash "$TMP"
 #
 # RETRY POLICY (rationale)
 # ========================
@@ -104,47 +80,26 @@
 #                            -S: show errors when silent
 #                            -L: follow redirects
 #
-# COMMAND-SUBSTITUTION + SET-E (caveat per codex review)
-# ======================================================
-# bash's `errexit` (`set -e`) is NOT reliably triggered by a
-# command substitution that fails without producing output —
-# in some bash versions (especially without `inherit_errexit`
-# enabled) `VAR="$(failing_cmd)"` leaves `VAR=""` and continues.
-# Our macos.sh capture pattern uses an explicit two-gate
-# approach: `if ! HOMEBREW_INSTALLER="$(curl_fetch_stream
-# ...)"; then exit 1; fi` (catches curl failure via the
-# if-not test on the assignment's exit status — verified on
-# bash 3.2.57 / 5.x: `if ! x="$(false)"; then echo CAUGHT;
-# fi` does print CAUGHT) PLUS a secondary `[ -z
-# "$HOMEBREW_INSTALLER" ] && exit 1` empty-string check.
-# Network errors trigger the first gate (curl-22 / curl-6 /
-# HTTP-non-2xx via `-fsSL`); the unreachable case where curl
-# exits 0 but produces empty output is caught by the second
-# gate. Either failure produces a hard `exit 1` with a
-# diagnostic message — never falls through to `bash -c ""`.
-# This is NOT a defense against partial-byte corruption —
-# proper fix is download-to-temp + checksum-verify, tracked
-# as B-0063. The current pattern is a small improvement over
-# the prior `bash -c "$(curl ...)"` direct form (which
-# silently ran whatever partial output survived); it is NOT
-# the structurally safe form.
+# COMMAND-SUBSTITUTION + SET-E (historical note)
+# ===============================================
+# All installer call sites now use download-to-temp + exec
+# (B-0063), which sidesteps the command-substitution + set -e
+# interaction entirely. curl_fetch writes to a file; failure
+# is caught by curl's non-zero exit + set -euo pipefail; the
+# size check ([ -s "$TMP" ]) catches the edge case of an
+# empty download. No command substitution in the critical path.
 #
 # IDEMPOTENCE
 # ===========
-# Re-sourcing this file is a no-op once both helpers are
+# Re-sourcing this file is a no-op once the helper is
 # loaded. The guard uses a file-local sentinel variable
 # (`_CURL_FETCH_LOADED`) instead of probing for an
 # existing `curl_fetch` function: a function-name probe
-# would silently skip BOTH definitions if the caller
+# would silently skip the definition if the caller
 # environment already had an unrelated `curl_fetch`
-# function, leaving `curl_fetch_stream` undefined and
-# breaking the streamed callers (`tools/setup/linux.sh` /
-# `tools/setup/macos.sh` / `tools/setup/common/elan.sh`)
-# at runtime with `curl_fetch_stream:
-# command not found`. Sentinel-based guarding ties the
-# load decision to "did this file load?" instead of "does
-# that name exist?" — collisions in the caller environment
-# can no longer accidentally suppress our definitions.
+# function. Sentinel-based guarding ties the load decision
+# to "did this file load?" instead of "does that name
+# exist?"
 
 if [[ -z "${_CURL_FETCH_LOADED:-}" ]]; then
 _CURL_FETCH_LOADED=1
@@ -181,33 +136,6 @@ curl_fetch() {
     retry_args+=(--retry-all-errors)
   fi
   curl -fsSL "${retry_args[@]}" "$@"
-}
-
-# Streamed variant — NO --retry, NO --retry-all-errors.
-#
-# Reviewers surfaced that even bare `curl
-# --retry` (without --retry-all-errors) can still retry after
-# bytes have been written to stdout: the connect error happens
-# mid-transfer, curl resets the input but the bytes already
-# piped into the consumer (`sh`, `bash -c "$(...)"`) cannot be
-# un-written. The consumer then sees concatenated partial+full
-# script content, which can re-execute commands or run
-# truncated halves. There is no curl-flag combination that
-# gives both retry-on-transient AND safe-restart-on-streamed-
-# stdout — those are mutually exclusive without an
-# intermediate buffer.
-#
-# Therefore this variant ships WITHOUT retries. Streamed
-# installer failures (mise.run / Homebrew / elan) bubble up
-# as install errors; the user re-runs install.sh.
-#
-# The proper structural fix — download to a temp file with
-# `curl_fetch` (file-output), checksum-verify if available,
-# then `bash <tempfile` — is tracked as backlog item B-0063
-# (streamed-installer download-to-temp pattern). Until that
-# lands, this variant is fail-fast-no-retry by design.
-curl_fetch_stream() {
-  curl -fsSL "$@"
 }
 
 fi

--- a/tools/setup/macos.sh
+++ b/tools/setup/macos.sh
@@ -51,7 +51,7 @@ if ! command -v brew >/dev/null 2>&1; then
   # tracks HEAD of github.com/Homebrew/install with no tagged
   # releases). Trust anchor: HTTPS + GitHub + the Homebrew project.
   # We verify non-empty to catch truncated downloads.
-  HOMEBREW_INSTALLER_TMP="$(mktemp)"
+  HOMEBREW_INSTALLER_TMP="$(mktemp)" || { echo "error: mktemp failed" >&2; exit 1; }
   trap 'rm -f "${HOMEBREW_INSTALLER_TMP}"' EXIT
   curl_fetch --output "${HOMEBREW_INSTALLER_TMP}" \
     https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh

--- a/tools/setup/macos.sh
+++ b/tools/setup/macos.sh
@@ -46,24 +46,20 @@ echo "✓ Xcode CLT at $(xcode-select -p 2>/dev/null || echo 'pending user confi
 # ── 2. Homebrew ─────────────────────────────────────────────────────
 if ! command -v brew >/dev/null 2>&1; then
   echo "↓ installing Homebrew..."
-  # Capture to a named variable + check exit code explicitly.
-  # bash's `set -e` is not reliably triggered by a failing
-  # command substitution without `inherit_errexit`. Pattern:
-  # capture, check length, exec only on non-empty + curl-
-  # success. The proper fix (download-to-temp + checksum-
-  # verify) is tracked as B-0063; this is a small-improvement-
-  # not-structurally-safe form acknowledged in
-  # tools/setup/common/curl-fetch.sh COMMAND-SUBSTITUTION +
-  # SET-E section.
-  if ! HOMEBREW_INSTALLER="$(curl_fetch_stream https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
-    echo "error: failed to fetch Homebrew installer; check network and re-run install.sh" >&2
+  # Download to temp file then exec — the B-0063 structural fix.
+  # Homebrew does not publish a SHA256 for install.sh (the script
+  # tracks HEAD of github.com/Homebrew/install with no tagged
+  # releases). Trust anchor: HTTPS + GitHub + the Homebrew project.
+  # We verify non-empty to catch truncated downloads.
+  HOMEBREW_INSTALLER_TMP="$(mktemp)"
+  trap 'rm -f "${HOMEBREW_INSTALLER_TMP}"' EXIT
+  curl_fetch --output "${HOMEBREW_INSTALLER_TMP}" \
+    https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh
+  if [ ! -s "${HOMEBREW_INSTALLER_TMP}" ]; then
+    echo "error: Homebrew installer empty after download; refusing to exec" >&2
     exit 1
   fi
-  if [ -z "$HOMEBREW_INSTALLER" ]; then
-    echo "error: Homebrew installer was empty; refusing to exec" >&2
-    exit 1
-  fi
-  /bin/bash -c "$HOMEBREW_INSTALLER"
+  /bin/bash "${HOMEBREW_INSTALLER_TMP}"
   # Ensure brew is on PATH for the remainder of this script run.
   if [ -x /opt/homebrew/bin/brew ]; then
     eval "$(/opt/homebrew/bin/brew shellenv)"


### PR DESCRIPTION
## Summary

- Converts the last remaining `curl_fetch_stream` call site — Homebrew installer in `tools/setup/macos.sh` — to the download-to-temp + size-check + exec pattern (B-0063 structural fix)
- Removes `curl_fetch_stream` function from `tools/setup/common/curl-fetch.sh` entirely (no remaining call sites after elan + mise were already converted in prior rounds)
- Updates `curl-fetch.sh` docs to reflect the unified `curl_fetch` + download-to-temp pattern
- Marks B-0063 done-criteria as complete

### Per-call-site verification story

| Call site | Verification | Status |
|-----------|-------------|--------|
| `elan.sh` | Commit-pinned SHA + SHA256 | Pre-existing |
| `linux.sh` mise | Version-pinned tarball + per-arch SHA256 | Pre-existing |
| `macos.sh` Homebrew | Non-empty size check (no upstream SHA256 — HEAD-tracking, no tagged releases) | **This PR** |

Homebrew's trust anchor is documented inline: HTTPS + GitHub + the Homebrew project. No upstream-published hash exists to pin.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `shellcheck -x tools/setup/macos.sh tools/setup/common/curl-fetch.sh` — clean
- [x] `bash -n` syntax check — clean
- [x] `grep curl_fetch_stream tools/` — no live call sites remain (only historical comments)
- [ ] CI passes on macOS-26, ubuntu-24.04, ubuntu-24.04-arm (pending CI run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)