### PR TITLE
feat(B-0126.1): add AI attribution footer for agent-posted PR comments

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -44,6 +44,10 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0110](backlog/P1/B-0110-acehack-mirror-protocol-drift-2026-04-30.md)** AceHack mirror-refresh protocol drift — Path 2 chosen, doctrine update landing in same PR (2026-04-30)
 - [x] **[B-0125](backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md)** Skip F#/Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
 - [ ] **[B-0126](backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md)** Port the 4-layer meta-learning pattern from a sibling repo to Zeta
+- [ ] **[B-0126.1](backlog/P1/B-0126.1-ai-attribution-footer-ts-tools.md)** Layer 4: AI attribution footer for TS comment-posting tools
+- [ ] **[B-0126.2](backlog/P1/B-0126.2-ai-attribution-footer-gh-actions.md)** Layer 4: AI attribution footer for GitHub Actions workflows
+- [ ] **[B-0126.3](backlog/P1/B-0126.3-document-layers-1-3-meta-learning.md)** Layers 1-3: document meta-learning pattern adapted for Zeta
+- [ ] **[B-0126.4](backlog/P1/B-0126.4-pilot-validation-meta-learning.md)** Pilot validation: meta-learning pattern on 2-3 PR cycles
 - [ ] **[B-0139](backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md)** Pre-substrate Kenji-era Otto-lineage work inventory — past recovery branches, worktrees, built artifacts not yet referenced in substrate
 - [ ] **[B-0140](backlog/P1/B-0140-bash-to-ts-migration-completion-debt-prevention-aaron-2026-05-01.md)** Bash → TS migration completion — debt-prevention prerequisite to B-0132 (CRDT-composition)
 - [x] **[B-0144](backlog/P1/B-0144-doc-code-two-lane-parallel-split-aaron-2026-05-01.md)** Doc/code two-lane parallel split — rung-2 unlock for factory parallelism

--- a/docs/backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md
+++ b/docs/backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md
@@ -4,9 +4,10 @@ priority: P1
 status: open
 title: Port the 4-layer meta-learning pattern from a sibling repo to Zeta
 created: 2026-05-01
-last_updated: 2026-05-02
+last_updated: 2026-05-08
 depends_on: []
-decomposition: atomic
+decomposition: parent
+children: [B-0126.1, B-0126.2, B-0126.3, B-0126.4]
 classification: buildable-now
 type: friction-reducer
 ---

--- a/docs/backlog/P1/B-0126.1-ai-attribution-footer-ts-tools.md
+++ b/docs/backlog/P1/B-0126.1-ai-attribution-footer-ts-tools.md
@@ -1,0 +1,46 @@
+---
+id: B-0126.1
+priority: P1
+status: in-progress
+title: "Layer 4: AI attribution footer for TS comment-posting tools"
+created: 2026-05-08
+last_updated: 2026-05-08
+depends_on: []
+parent: B-0126
+classification: buildable-now
+type: friction-reducer
+---
+
+# B-0126.1 — Layer 4: AI attribution footer for TS comment-posting tools
+
+**Slice of:** [B-0126](B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md)
+
+## What
+
+Create a shared `tools/github/ai-attribution.ts` utility that appends a
+machine-readable attribution footer to any AI-posted GitHub comment body.
+Integrate into `tools/git/batch-resolve-pr-threads.ts` (the only TS tool
+that currently posts PR thread replies).
+
+Footer format: `🤖 *Posted by <agent-name> on behalf of @<username>*`
+
+## Why
+
+When an AI agent posts PR comments via `gh api` using a human's PAT, the
+comment appears under the human's GitHub identity. Readers cannot
+distinguish human-written from agent-written responses. The footer makes
+authorship transparent — glass halo applied to PR interactions.
+
+## Acceptance criteria
+
+1. `tools/github/ai-attribution.ts` exports `appendAttribution(body, opts)`.
+2. `tools/github/ai-attribution.test.ts` covers agent-only and on-behalf-of cases.
+3. `batch-resolve-pr-threads.ts` uses `appendAttribution` for every reply it posts.
+4. `bun test tools/github/ai-attribution.test.ts` passes.
+5. `dotnet build -c Release` still passes (no .NET changes, but gate must hold).
+
+## Out of scope
+
+- GitHub Actions workflow attribution (YAML/bash — separate child B-0126.2).
+- Layers 1-3 documentation (B-0126.3).
+- Pilot validation (B-0126.4).

--- a/docs/backlog/P1/B-0126.2-ai-attribution-footer-gh-actions.md
+++ b/docs/backlog/P1/B-0126.2-ai-attribution-footer-gh-actions.md
@@ -1,0 +1,29 @@
+---
+id: B-0126.2
+priority: P1
+status: open
+title: "Layer 4: AI attribution footer for GitHub Actions workflows"
+created: 2026-05-08
+last_updated: 2026-05-08
+depends_on: [B-0126.1]
+parent: B-0126
+classification: buildable-now
+type: friction-reducer
+---
+
+# B-0126.2 — Layer 4: AI attribution footer for GitHub Actions workflows
+
+**Slice of:** [B-0126](B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md)
+
+## What
+
+Add the attribution footer to comment-posting steps in GitHub Actions
+workflows: `resume-diff.yml` (`gh pr comment`) and `razor-cadence.yml`
+(`gh issue comment`). These run under `GITHUB_TOKEN` (bot identity) or PAT
+(human identity) depending on configuration.
+
+## Depends on
+
+B-0126.1 establishes the footer format convention. Workflow integration
+follows the same format but uses inline bash (not TS import) since these
+are YAML workflow files.

--- a/docs/backlog/P1/B-0126.3-document-layers-1-3-meta-learning.md
+++ b/docs/backlog/P1/B-0126.3-document-layers-1-3-meta-learning.md
@@ -1,0 +1,36 @@
+---
+id: B-0126.3
+priority: P1
+status: open
+title: "Layers 1-3: document meta-learning pattern adapted for Zeta"
+created: 2026-05-08
+last_updated: 2026-05-08
+depends_on: []
+parent: B-0126
+classification: buildable-now
+type: friction-reducer
+---
+
+# B-0126.3 — Layers 1-3: document meta-learning pattern adapted for Zeta
+
+**Slice of:** [B-0126](B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md)
+
+## What
+
+Document the 3 meta-learning layers adapted for Zeta's surfaces:
+
+- **Layer 1** — Fix the bot's findings. Reply with reasoning, resolve.
+- **Layer 2** — Every bot comment is a joint learning opportunity. Land the
+  doc update in the SAME PR as the comment. Two paths: real-bug encodes in
+  code-author substrate; off-base encodes in reviewer-instructions.
+- **Layer 3** — Encode the class of error, not the instance. Test: imagine
+  the next 3 PRs that could hit a similar bug; would the encoding catch
+  all 3?
+
+Landing surface: `docs/AGENT-BEST-PRACTICES.md` (new BP-NN rules) or a
+dedicated `docs/META-LEARNING.md` with AGENTS.md pointer.
+
+## Depends on
+
+Independent of B-0126.1/B-0126.2 (Layer 4 attribution). Can be done in
+parallel.

--- a/docs/backlog/P1/B-0126.4-pilot-validation-meta-learning.md
+++ b/docs/backlog/P1/B-0126.4-pilot-validation-meta-learning.md
@@ -19,6 +19,7 @@ type: friction-reducer
 
 Run the 4-layer meta-learning pattern on the next 2-3 PR-thread cycles
 to verify:
+
 - Layer 4 attribution footer appears on all agent-posted comments
 - Layer 2 same-PR encoding is exercised at least once
 - Layer 3 class-level encoding catches a cousin-bug in a subsequent PR

--- a/docs/backlog/P1/B-0126.4-pilot-validation-meta-learning.md
+++ b/docs/backlog/P1/B-0126.4-pilot-validation-meta-learning.md
@@ -1,0 +1,36 @@
+---
+id: B-0126.4
+priority: P1
+status: open
+title: "Pilot validation: meta-learning pattern on 2-3 PR cycles"
+created: 2026-05-08
+last_updated: 2026-05-08
+depends_on: [B-0126.1, B-0126.3]
+parent: B-0126
+classification: blocked
+type: friction-reducer
+---
+
+# B-0126.4 — Pilot validation: meta-learning pattern on 2-3 PR cycles
+
+**Slice of:** [B-0126](B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md)
+
+## What
+
+Run the 4-layer meta-learning pattern on the next 2-3 PR-thread cycles
+to verify:
+- Layer 4 attribution footer appears on all agent-posted comments
+- Layer 2 same-PR encoding is exercised at least once
+- Layer 3 class-level encoding catches a cousin-bug in a subsequent PR
+
+## Depends on
+
+Requires B-0126.1 (attribution footer landed) and B-0126.3 (Layers 1-3
+documented) before piloting is meaningful.
+
+## Acceptance criteria
+
+- At least 2 PR cycles exercised with the full pattern.
+- At least 1 class-level encoding (Layer 3) validated by catching a
+  cousin-bug.
+- Retrospective note added to B-0126 parent row.

--- a/tools/git/batch-resolve-pr-threads.ts
+++ b/tools/git/batch-resolve-pr-threads.ts
@@ -32,6 +32,7 @@
 //   2 — argument errors
 
 import { spawnSync } from "node:child_process";
+import { appendAttribution } from "../github/ai-attribution";
 
 const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
 
@@ -468,12 +469,16 @@ function emitSummary(args: {
   }
 }
 
+function attributed(body: string): string {
+  return appendAttribution(body, { agent: "batch-resolve-pr-threads" });
+}
+
 function applyResolutions(classified: ClassifiedThreads): number {
   const total = classified.dangling.length + classified.nameAttribution.length;
   process.stdout.write(`\nAPPLY MODE — resolving ${String(total)} threads...\n`);
   for (const tid of classified.dangling) {
     process.stdout.write(`  resolving dangling-ref: ${tid}\n`);
-    const err = resolveThread(tid, REPLY_DANGLING_REF);
+    const err = resolveThread(tid, attributed(REPLY_DANGLING_REF));
     if (err !== null) {
       process.stderr.write(
         `error: could not ${err.stage} thread ${err.threadId}: ${err.message}\n`,
@@ -483,7 +488,7 @@ function applyResolutions(classified: ClassifiedThreads): number {
   }
   for (const tid of classified.nameAttribution) {
     process.stdout.write(`  resolving name-attribution: ${tid}\n`);
-    const err = resolveThread(tid, REPLY_NAME_ATTRIBUTION);
+    const err = resolveThread(tid, attributed(REPLY_NAME_ATTRIBUTION));
     if (err !== null) {
       process.stderr.write(
         `error: could not ${err.stage} thread ${err.threadId}: ${err.message}\n`,

--- a/tools/github/ai-attribution.test.ts
+++ b/tools/github/ai-attribution.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { aiAttributionFooter, appendAttribution } from "./ai-attribution";
+
+describe("aiAttributionFooter", () => {
+  test("includes agent name", () => {
+    const footer = aiAttributionFooter({ agent: "Claude Code" });
+    expect(footer).toContain("Claude Code");
+    expect(footer).toContain("🤖");
+  });
+
+  test("includes onBehalfOf when provided", () => {
+    const footer = aiAttributionFooter({
+      agent: "Claude Code",
+      onBehalfOf: "acehack",
+    });
+    expect(footer).toContain("@acehack");
+    expect(footer).toContain("on behalf of");
+  });
+
+  test("omits onBehalfOf when not provided", () => {
+    const footer = aiAttributionFooter({ agent: "batch-resolve" });
+    expect(footer).not.toContain("on behalf of");
+    expect(footer).not.toContain("@");
+  });
+});
+
+describe("appendAttribution", () => {
+  test("appends footer to body with separator", () => {
+    const result = appendAttribution("Some review comment.", {
+      agent: "Claude Code",
+      onBehalfOf: "acehack",
+    });
+    expect(result).toStartWith("Some review comment.");
+    expect(result).toContain("---");
+    expect(result).toContain("🤖");
+    expect(result).toContain("Claude Code");
+    expect(result).toContain("@acehack");
+  });
+
+  test("preserves original body exactly", () => {
+    const body = "Line 1\nLine 2\n\nParagraph 2";
+    const result = appendAttribution(body, { agent: "test-tool" });
+    expect(result.startsWith(body)).toBe(true);
+  });
+});

--- a/tools/github/ai-attribution.ts
+++ b/tools/github/ai-attribution.ts
@@ -1,0 +1,30 @@
+/**
+ * AI-attribution footer for agent-posted GitHub comments.
+ *
+ * B-0126 Layer 4: when an AI agent posts a PR/issue comment via
+ * `gh api` under a human's PAT identity, append a footer so readers
+ * know the comment was agent-authored.
+ */
+
+const SEPARATOR = "\n\n---\n";
+
+export interface AttributionOptions {
+  /** Agent or tool name, e.g. "Claude Code", "batch-resolve-pr-threads" */
+  readonly agent: string;
+  /** GitHub username the PAT belongs to. Omit if running under a bot token. */
+  readonly onBehalfOf?: string;
+}
+
+export function aiAttributionFooter(opts: AttributionOptions): string {
+  const who = opts.onBehalfOf
+    ? ` on behalf of @${opts.onBehalfOf}`
+    : "";
+  return `${SEPARATOR}🤖 *Posted by ${opts.agent}${who}*`;
+}
+
+export function appendAttribution(
+  body: string,
+  opts: AttributionOptions,
+): string {
+  return `${body}${aiAttributionFooter(opts)}`;
+}


### PR DESCRIPTION
## Summary

- Adds `tools/github/ai-attribution.ts` — shared utility that appends a `🤖 *Posted by <agent>*` footer to any AI-posted GitHub comment body (B-0126 Layer 4)
- Integrates into `tools/git/batch-resolve-pr-threads.ts` so all auto-resolved thread replies carry the attribution footer
- Decomposes B-0126 (marked `atomic`) into 4 dependency-ordered children: B-0126.1 (this PR), B-0126.2 (GH Actions workflows), B-0126.3 (Layers 1-3 docs), B-0126.4 (pilot validation)

## Focused checks

```
$ bun test tools/github/ai-attribution.test.ts
5 pass, 0 fail, 12 expect() calls

$ bun build tools/git/batch-resolve-pr-threads.ts --outdir /tmp/check
Bundled 2 modules (import resolves cleanly)

$ dotnet build -c Release
Build succeeded. 0 Warning(s) 0 Error(s)
```

## Test plan

- [x] `bun test tools/github/ai-attribution.test.ts` — 5 tests pass (agent-only footer, on-behalf-of footer, body preservation)
- [x] `bun build` — batch-resolve-pr-threads.ts bundles with the new import
- [x] `dotnet build -c Release` — 0 warnings, 0 errors (no .NET changes, gate holds)
- [ ] Next invocation of `bun tools/git/batch-resolve-pr-threads.ts <PR> --apply` will produce attributed replies (manual verification on next PR cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)