### PR TITLE
feat(B-0126.2): add AI attribution footer to GitHub Actions workflows

### DIFF
--- a/.github/workflows/razor-cadence.yml
+++ b/.github/workflows/razor-cadence.yml
@@ -141,6 +141,9 @@ jobs:
             --limit 1 \
             --jq '.[0].number // empty')"
 
+          AI_FOOTER=$'\n\n---\n🤖 *Posted by razor-cadence workflow (AI-generated content)*'
+          body="${body}${AI_FOOTER}"
+
           if [ -n "$existing" ]; then
             echo "Updating existing razor-cadence tracking issue #$existing"
             gh issue edit "$existing" \
@@ -149,7 +152,7 @@ jobs:
               --body "$body"
             gh issue comment "$existing" \
               --repo "$REPO" \
-              --body "Cadence fired again on $today (run $RUN_ID). The checklist above is the standing one; close this issue once the pass has been run."
+              --body "Cadence fired again on $today (run $RUN_ID). The checklist above is the standing one; close this issue once the pass has been run.${AI_FOOTER}"
           else
             echo "Opening new razor-cadence tracking issue"
             # Create the razor-cadence label if it doesn't exist

--- a/.github/workflows/resume-diff.yml
+++ b/.github/workflows/resume-diff.yml
@@ -173,12 +173,14 @@ jobs:
           # `<!-- resume-diff-bot-marker -->` which is stable across
           # runs but invisible in the rendered comment.
           MARKER='<!-- resume-diff-bot-marker -->'
+          AI_FOOTER=$'\n\n---\n🤖 *Posted by resume-diff workflow (AI-generated content)*'
 
-          # Prepend marker to the body so future runs can find it.
+          # Prepend marker and append AI attribution footer.
           BODY_FILE="$(mktemp)"
           {
             printf '%s\n' "$MARKER"
             cat "$DIFF_FILE"
+            printf '%s\n' "$AI_FOOTER"
           } > "$BODY_FILE"
 
           # Look for an existing comment containing the marker.

--- a/docs/backlog/P1/B-0126.1-ai-attribution-footer-ts-tools.md
+++ b/docs/backlog/P1/B-0126.1-ai-attribution-footer-ts-tools.md
@@ -1,7 +1,7 @@
 ---
 id: B-0126.1
 priority: P1
-status: in-progress
+status: done
 title: "Layer 4: AI attribution footer for TS comment-posting tools"
 created: 2026-05-08
 last_updated: 2026-05-08

--- a/docs/backlog/P1/B-0126.2-ai-attribution-footer-gh-actions.md
+++ b/docs/backlog/P1/B-0126.2-ai-attribution-footer-gh-actions.md
@@ -1,7 +1,7 @@
 ---
 id: B-0126.2
 priority: P1
-status: open
+status: in-progress
 title: "Layer 4: AI attribution footer for GitHub Actions workflows"
 created: 2026-05-08
 last_updated: 2026-05-08


### PR DESCRIPTION
## Summary

- Appends `🤖 *Posted by <workflow> workflow (AI-generated content)*` footer to every comment posted by `resume-diff.yml` and `razor-cadence.yml`
- Completes Layer 4 (attribution) coverage for the GitHub Actions surface — B-0126.1 (merged in PR #2117) covered the TS tools surface
- Marks B-0126.1 as done, B-0126.2 as in-progress

## Details

**resume-diff.yml**: Footer injected into `BODY_FILE` via `printf`, covering both the new-comment (`gh pr comment`) and edit-in-place (`gh api PATCH`) paths through a single injection point.

**razor-cadence.yml**: Footer appended to the `$body` variable before the if/else branch (covers issue create and issue edit). The update-comment body gets a separate `${AI_FOOTER}` append since it uses a distinct inline string.

No untrusted input involved — `AI_FOOTER` is a static string constant.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `bun test tools/github/ai-attribution.test.ts` — 5/5 pass
- [ ] Verify resume-diff comment includes footer on next PR touching resume files
- [ ] Verify razor-cadence issue body includes footer on next daily fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)