### PR TITLE
fix(backlog): change B-0126.3 status from done to closed

### DIFF
--- a/docs/backlog/P1/B-0126.3-document-layers-1-3-meta-learning.md
+++ b/docs/backlog/P1/B-0126.3-document-layers-1-3-meta-learning.md
@@ -1,7 +1,7 @@
 ---
 id: B-0126.3
 priority: P1
-status: done
+status: closed
 title: "Layers 1-3: document meta-learning pattern adapted for Zeta"
 created: 2026-05-08
 last_updated: 2026-05-08


### PR DESCRIPTION
## Summary
- Fixes BACKLOG.md generated-index drift on main after PR #2122 merged
- Changes B-0126.3 per-row file from `status: done` to `status: closed` so the generator maps it to `[x]`, matching the committed index
- The generator only maps `closed` (and `superseded-by-*`) to `[x]`; `done` maps to `[ ]`

## Test plan
- [ ] `bun tools/backlog/generate-index.ts --check` passes (no drift)
- [ ] CI backlog-index-integrity check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)