### PR TITLE
fix(B-0140): update stale .sh doc-refs to .ts — close migration

### DIFF
--- a/.claude/skills/developer-experience-engineer/SKILL.md
+++ b/.claude/skills/developer-experience-engineer/SKILL.md
@@ -30,7 +30,7 @@ cosmetics.
   for me" question?
 - `tools/setup/install.sh` and per-OS scripts — install loop.
 - Local build loop: `dotnet build -c Release`, `dotnet test`,
-  `lake build`, `bash tools/run-tlc.sh`.
+  `lake build`, `bun tools/formal-verification/run-tlc.ts`.
 - Test organisation and discoverability under `tests/**`.
 - IDE integration: `.vscode/`, Ionide config, suggested
   extensions, debugger setup.

--- a/.claude/skills/package-upgrader/SKILL.md
+++ b/.claude/skills/package-upgrader/SKILL.md
@@ -15,7 +15,7 @@ build-and-test gating.
 **Lane distinction.**
 
 - **`package-auditor`** (Malik's primary hat) — runs
-  `tools/audit-packages.sh`; outputs the stale-pins list
+  `tools/audit-packages.ts`; outputs the stale-pins list
   with major/minor/patch classification.
 - **`package-upgrader`** (this skill; Malik's second hat
   or anyone's when worn) — consumes that list, makes the
@@ -64,7 +64,7 @@ Every pin gets a tier that drives the upgrade policy:
 
 ### Step 1 — consume the audit
 
-Malik produces `tools/audit-packages.sh` output with rows
+Malik produces `tools/audit-packages.ts` output with rows
 shaped `<PackageId> <currentVersion> <latestVersion>
 <changeClass>`. Parse into a work queue; sort by tier
 ascending (patch first, major last).
@@ -178,7 +178,7 @@ For each row in work-queue order:
 ## Reference patterns
 
 - `Directory.Packages.props` — central pin file
-- `tools/audit-packages.sh` — Malik's audit output
+- `tools/audit-packages.ts` — Malik's audit output
 - `tools/setup/manifests/dotnet-tools` — dotnet global
   tool pins
 - `tools/setup/manifests/uv-tools` — uv CLI pins

--- a/.claude/skills/sonar-issue-fixer/SKILL.md
+++ b/.claude/skills/sonar-issue-fixer/SKILL.md
@@ -132,7 +132,7 @@ treats them as regressions.
 
 - `dotnet build Zeta.sln -c Release` if analyzer is wired.
 - OR read the SonarLint VS Code problem pane export.
-- OR read `tools/audit-packages.sh`-adjacent lint output.
+- OR read `tools/audit-packages.ts`-adjacent lint output.
 
 Produce a list: `(file, line, rule code, brief message)`.
 

--- a/.claude/skills/tla-expert/SKILL.md
+++ b/.claude/skills/tla-expert/SKILL.md
@@ -20,7 +20,7 @@ chosen, this hat is the discipline. 18 specs live under
   dump).
 - Debating invariant vs temporal property vs state
   constraint.
-- Reviewing `tools/run-tlc.sh` behaviour.
+- Reviewing `tools/formal-verification/run-tlc.ts` behaviour.
 
 ## Zeta's TLA+ scope
 
@@ -234,7 +234,7 @@ spec.
   portfolio
 - `tools/tla/tla2tools.jar` — TLC itself (installed by
   `tools/setup/common/verifiers.sh`)
-- `tools/run-tlc.sh` — invocation wrapper
+- `tools/formal-verification/run-tlc.ts` — invocation wrapper
 - `docs/SPEC-CAUGHT-A-BUG.md` — historical record of
   bugs TLC caught
 - `.claude/skills/formal-verification-expert/SKILL.md` —

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ coverage-summary.json
 # (per `docs/research/parallel-worktree-safety-2026-04-22.md`). The parent
 # `.claude/worktrees/` dir can be left behind as an empty directory after
 # the worktree is cleaned up; ignoring it keeps the no-empty-dirs lint
-# (tools/lint/no-empty-dirs.sh) from flagging legitimate harness scratch.
+# (tools/lint/no-empty-dirs.ts) from flagging legitimate harness scratch.
 .claude/worktrees/
 .DS_Store
 Thumbs.db

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -817,7 +817,7 @@ than renumbering the rest.
       `docs/aurora/*.md` is author-time advisory: absorbing
       agents include the four header labels at write time, and
       reviewers spot gaps during PR review. A dedicated lint
-      script (e.g. `tools/alignment/audit_archive_headers.sh`)
+      script (e.g. `tools/alignment/audit_archive_headers.ts`)
       and a corresponding `docs/FACTORY-HYGIENE.md` row are
       not yet landed; both are tracked as follow-up work and
       must ship together with their cross-references in the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ None yet. We ship once the full SDL checklist
 - **Trust boundaries** described in `docs/security/THREAT-MODEL.md`
   (STRIDE-indexed).
 - **Crypto choices** rationale in `docs/security/CRYPTO.md`.
-- **Dependency audit** via `tools/audit-packages.sh` (the package
+- **Dependency audit** via `tools/audit-packages.ts` (the package
   auditor skill reviews bumps).
 - **Static analysis** via Semgrep (`.semgrep.yml`, 12 rules) +
   G-Research + Ionide + Meziantou F# analyzers.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -49,7 +49,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0126.3](backlog/P1/B-0126.3-document-layers-1-3-meta-learning.md)** Layers 1-3: document meta-learning pattern adapted for Zeta
 - [ ] **[B-0126.4](backlog/P1/B-0126.4-pilot-validation-meta-learning.md)** Pilot validation: meta-learning pattern on 2-3 PR cycles
 - [ ] **[B-0139](backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md)** Pre-substrate Kenji-era Otto-lineage work inventory — past recovery branches, worktrees, built artifacts not yet referenced in substrate
-- [ ] **[B-0140](backlog/P1/B-0140-bash-to-ts-migration-completion-debt-prevention-aaron-2026-05-01.md)** Bash → TS migration completion — debt-prevention prerequisite to B-0132 (CRDT-composition)
+- [x] **[B-0140](backlog/P1/B-0140-bash-to-ts-migration-completion-debt-prevention-aaron-2026-05-01.md)** Bash → TS migration completion — debt-prevention prerequisite to B-0132 (CRDT-composition)
 - [x] **[B-0144](backlog/P1/B-0144-doc-code-two-lane-parallel-split-aaron-2026-05-01.md)** Doc/code two-lane parallel split — rung-2 unlock for factory parallelism
 - [ ] **[B-0145](backlog/P1/B-0145-product-manager-role-research-to-predict-features-before-friction-aaron-2026-05-01.md)** Product Manager (PM-2) role — research-to-predict-features-before-friction
 - [ ] **[B-0154](backlog/P1/B-0154-github-pages-seo-discoverability-plus-wiki-first-class-aaron-2026-05-01.md)** GitHub Pages for SEO/discoverability + GitHub Wiki first-class integration (Aaron 2026-05-01)

--- a/docs/FACTORY-DISCIPLINE.md
+++ b/docs/FACTORY-DISCIPLINE.md
@@ -71,7 +71,7 @@ PR descriptions, commit messages, `docs/hygiene-history/**`,
 or memory files.
 
 **Source:** `memory/feedback_code_comments_explain_code_not_history_otto_220_*.md`
-and the lint at `tools/lint/doc-comment-history-audit.sh`.
+and the lint at `tools/lint/doc-comment-history-audit.ts`.
 
 ### name-attribution role references
 

--- a/docs/backlog/P1/B-0140-bash-to-ts-migration-completion-debt-prevention-aaron-2026-05-01.md
+++ b/docs/backlog/P1/B-0140-bash-to-ts-migration-completion-debt-prevention-aaron-2026-05-01.md
@@ -1,10 +1,10 @@
 ---
 id: B-0140
 priority: P1
-status: open
+status: closed
 title: Bash → TS migration completion — debt-prevention prerequisite to B-0132 (CRDT-composition)
 created: 2026-05-01
-last_updated: 2026-05-08
+last_updated: 2026-05-09
 depends_on: []
 decomposition: atomic
 classification: buildable-now
@@ -79,8 +79,12 @@ Specific scope (concrete; verify-before-state-claim discipline applies — first
 
 ## Status
 
-**In progress.** Phase 1 complete (2026-05-07): 19 dead .sh files
-with .ts counterparts removed. 2 CI workflows updated to call .ts.
+**Closed (2026-05-09).** All .sh files outside `tools/setup/` and
+`tools/lean4/.lake/` removed. Stale documentation references
+updated across SECURITY.md, GOVERNANCE.md, FACTORY-DISCIPLINE.md,
+tools/alignment/README.md, tools/hygiene/LOST-FILES-LOCATIONS.md,
+.gitignore, and 4 skill files. Phase 1 (2026-05-07): 19 dead .sh
+files with .ts counterparts removed, 2 CI workflows updated.
 
 ### Audit table (2026-05-07)
 

--- a/tools/alignment/README.md
+++ b/tools/alignment/README.md
@@ -13,10 +13,10 @@ folder as the experimental loop.
 
 | Script                | Signal measured                              | Shape                       |
 |-----------------------|----------------------------------------------|-----------------------------|
-| `audit_commit.sh`     | HC-2, HC-6, SD-6 alignment clauses           | Per-commit lint             |
-| `audit_personas.sh`   | Notebook touch + commit mentions             | Per-round persona runtime   |
-| `audit_skills.sh`     | DORA-2025 columns adapted to skill scope     | Per-round skill runtime     |
-| `audit_archive_headers.sh` | Archive-header discipline (proposed §33) | Per-file lint (detect-only v0) |
+| `audit_commit.ts`     | HC-2, HC-6, SD-6 alignment clauses           | Per-commit lint             |
+| `audit_personas.ts`   | Notebook touch + commit mentions             | Per-round persona runtime   |
+| `audit_skills.ts`     | DORA-2025 columns adapted to skill scope     | Per-round skill runtime     |
+| `audit_archive_headers.ts` | Archive-header discipline (proposed §33) | Per-file lint (detect-only v0) |
 | `audit_clause_coverage.ts` | HC/SD/DIR clause citations in skills, agents, backlog P0/P1 | Per-surface coverage audit |
 | `audit_clause_drift.ts` | Clause additions/removals/changes + impact survey | Cross-ref drift detection |
 | `audit_retractibility.ts` | Git-tracked + inbound-ref entanglement per surface | Retractibility gate (B-0058 #1) |
@@ -25,8 +25,8 @@ folder as the experimental loop.
 | `sd6_names.txt`       | SD-6 watchlist (per-host)                    | Data (not code)             |
 
 The three scripts form the gitops observability trio:
-commit-scope (`audit_commit.sh`), persona-scope
-(`audit_personas.sh`), and skill-scope (`audit_skills.sh`).
+commit-scope (`audit_commit.ts`), persona-scope
+(`audit_personas.ts`), and skill-scope (`audit_skills.ts`).
 Each emits `--json` / `--md` / `--out DIR` in the same
 shape so downstream tooling can uniform-parse.
 
@@ -56,26 +56,26 @@ pathway; this directory owns the code.
 
 ```bash
 # Audit HEAD
-tools/alignment/audit_commit.sh
+bun tools/alignment/audit_commit.ts
 
 # Audit a range
-tools/alignment/audit_commit.sh main..HEAD
+bun tools/alignment/audit_commit.ts main..HEAD
 
 # JSON output (for the observability stream)
-tools/alignment/audit_commit.sh --json
+bun tools/alignment/audit_commit.ts --json
 
 # Write per-commit JSON files to a directory
-tools/alignment/audit_commit.sh --out tools/alignment/out/round-37
+bun tools/alignment/audit_commit.ts --out tools/alignment/out/round-37
 
 # Per-round persona audit
-tools/alignment/audit_personas.sh --round 38 --out tools/alignment/out/round-38
+bun tools/alignment/audit_personas.ts --round 38 --out tools/alignment/out/round-38
 
 # Per-round skill audit (DORA-columns)
-tools/alignment/audit_skills.sh --round 38 --out tools/alignment/out/round-38
+bun tools/alignment/audit_skills.ts --round 38 --out tools/alignment/out/round-38
 
 # Skill audit with friction gate — fails if any skill has
 # friction (rounds-since-owner-touched) >= threshold
-tools/alignment/audit_skills.sh --round 38 --gate 10
+bun tools/alignment/audit_skills.ts --round 38 --gate 10
 
 # Audit the filter-gate honesty log for reconstructable failures
 bun tools/alignment/audit_candidate_failures.ts --md
@@ -130,15 +130,9 @@ stream. It is:
 
 ## Dependencies
 
-- `bash` 3.2+ (macOS default)
+- `bun` (installed by `tools/setup/install.sh`)
 - `git` 2.x
-- `grep`, `awk`, `sed` (POSIX)
-- no runtime libraries; no network
-
-The scripts are intentionally portable to bare
-macOS bash 3.2 so the install script doesn't
-need to pin a newer bash just for alignment
-linting.
+- no network
 
 ## Relationship to other tooling
 

--- a/tools/hygiene/LOST-FILES-LOCATIONS.md
+++ b/tools/hygiene/LOST-FILES-LOCATIONS.md
@@ -149,8 +149,8 @@ This list is the doc-form. The executable form is `tools/hygiene/audit-lost-file
 Composes with:
 
 - `tools/hygiene/audit-memory-references.ts` — covers location-class #15
-- `tools/hygiene/audit-git-hotspots.sh` — surfaces high-churn files (proxy for "high deletion risk")
-- `tools/hygiene/audit-tick-history-bounded-growth.sh` — finds tick-history pattern violations
+- `tools/hygiene/audit-git-hotspots.ts` — surfaces high-churn files (proxy for "high deletion risk")
+- `tools/hygiene/audit-tick-history-bounded-growth.ts` — finds tick-history pattern violations
 - Otto-262 trunk-based-development branch policy
 - Otto-257 clean-default smell triggers audit
 - Otto-238 retractability + glass-halo (deletions should leave visible trails)


### PR DESCRIPTION
## Summary

- Updates 12 files that still referenced deleted `.sh` paths to their `.ts` counterparts
- Closes B-0140 (bash → TS migration completion) by satisfying acceptance criterion #6 (documentation updated)
- Regenerates `docs/BACKLOG.md` with B-0140 status → closed

## Files changed

| File | Change |
|------|--------|
| `SECURITY.md` | `tools/audit-packages.sh` → `.ts` |
| `GOVERNANCE.md` | `tools/alignment/audit_archive_headers.sh` → `.ts` |
| `docs/FACTORY-DISCIPLINE.md` | `tools/lint/doc-comment-history-audit.sh` → `.ts` |
| `tools/alignment/README.md` | All 4 script refs + usage examples + dependencies section |
| `tools/hygiene/LOST-FILES-LOCATIONS.md` | 2 audit script refs → `.ts` |
| `.gitignore` | Comment: `no-empty-dirs.sh` → `.ts` |
| `.claude/skills/tla-expert/SKILL.md` | `tools/run-tlc.sh` → `tools/formal-verification/run-tlc.ts` |
| `.claude/skills/package-upgrader/SKILL.md` | 3 refs to `audit-packages.sh` → `.ts` |
| `.claude/skills/sonar-issue-fixer/SKILL.md` | 1 ref to `audit-packages.sh` → `.ts` |
| `.claude/skills/developer-experience-engineer/SKILL.md` | `tools/run-tlc.sh` → `tools/formal-verification/run-tlc.ts` |
| `docs/backlog/P1/B-0140-*.md` | status: open → closed |
| `docs/BACKLOG.md` | Regenerated index |

## Scope notes

- **Historical surfaces left as-is:** `docs/trajectories/`, `docs/pr-discussions/`, `memory/` files reference `.sh` as historical records of the migration; per "docs read as current state, not history," these are properly history surfaces.
- **`tools/setup/**/*.sh` preserved:** Rule 0 boundary (bash for install-graph only).
- **CI workflow comment** (`backlog-index-integrity.yml` line 15) skipped — security hook blocked; low-priority comment-only change.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] All referenced `.ts` counterparts verified to exist on disk
- [x] No `.sh` files remain outside `tools/setup/` and `tools/lean4/.lake/`
- [ ] CI gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)