### PR TITLE
fix(riven): --model not -m for cursor-agent

### DIFF
--- a/.cursor/bin/riven-loop-tick.ts
+++ b/.cursor/bin/riven-loop-tick.ts
@@ -245,7 +245,7 @@ function heartbeat(): void {
 
                 const gate = run("cursor-agent", [
                     "-p",
-                    "-m", "grok-4.3",
+                    "--model", "grok-4.3",
                     prompt,
                 ], agentTimeoutMs);
 


### PR DESCRIPTION
CLI flag was wrong. Fixed.