### PR TITLE
feat(B-0170): add check-path-forms.ts — path-form drift sub-class (v0.7)

### DIFF
--- a/docs/backlog/P1/B-0170-substrate-claim-checker-ts-tool-aaron-2026-05-03.md
+++ b/docs/backlog/P1/B-0170-substrate-claim-checker-ts-tool-aaron-2026-05-03.md
@@ -46,11 +46,11 @@ Per the verify-then-claim catalogue:
 | Sub-class | v0? | Description |
 |---|---|---|
 | Count drift | ✓ shipped | "N rows / instances / items" vs actual count |
-| Existence drift | v1 | "file/dir/tool exists" claim vs `ls` / `test -e` |
+| Existence drift | ✓ shipped | "file/dir/tool exists" claim vs `ls` / `test -e` |
 | Semantic-equivalence drift | v1 | command substitution equivalence claims |
 | Empirical-output drift | v1 | "command returns X" vs actual output |
 | Convention drift | v1 | recommended pattern matches canonical convention |
-| Path-form drift | v1 | fully-qualified vs bare paths consistent across document |
+| Path-form drift | ✓ shipped | fully-qualified vs bare paths consistent across document |
 | Self-recursive drift | v1 | the memo about X contains its own X |
 | Cross-surface count drift (frontmatter ↔ body ↔ section heading ↔ carved sentence ↔ MEMORY.md) | v1 (v0 catches narrative-vs-table within a single document; cross-surface narrative-to-narrative comparison is v1 work) | five surfaces should match consistent N |
 

--- a/tools/substrate-claim-checker/README.md
+++ b/tools/substrate-claim-checker/README.md
@@ -3,7 +3,7 @@
 Substrate-claim-checker per the verify-then-claim discipline memo
 (`memory/feedback_verify_then_claim_discipline_dominant_failure_mode_substrate_authoring_otto_2026_05_03.md`).
 
-Catches two of the seven sub-classes B-0170 names:
+Catches 3 of the 7 sub-classes B-0170 names:
 
 - **Count drift** (v0.4.4) — between narrative claims (e.g. "18+ drift
   instances", "13-row table", "5 procedure skills") and the actual
@@ -11,9 +11,12 @@ Catches two of the seven sub-classes B-0170 names:
   `check-counts.ts`.
 - **Existence drift** (v0.5) — claims that a file or directory exists
   when it doesn't on disk. Implemented in `check-existence.ts`.
+- **Path-form drift** (v0.7) — same physical file referenced with
+  inconsistent path forms within a single document. Implemented in
+  `check-path-forms.ts`.
 
-The remaining 5 sub-classes (semantic-equivalence, empirical-output,
-convention, path-form, self-recursive) are deferred to v0.6+.
+The remaining 4 sub-classes (semantic-equivalence, empirical-output,
+convention, self-recursive) are deferred to v0.8+.
 
 ## Usage
 
@@ -55,11 +58,11 @@ input error).
 
 ## What this does NOT do (v0)
 
-- **Existence drift** (file/dir/tool claimed to exist; doesn't) — v1
+- **Existence drift** (file/dir/tool claimed to exist; doesn't) — shipped v0.5
+- **Path-form drift** (fully-qualified vs bare paths inconsistent) — shipped v0.7
 - **Semantic-equivalence drift** (command substitution claims) — v1
 - **Empirical-output drift** (run-the-command-and-compare) — v1
 - **Convention drift** (recommended pattern doesn't match canonical) — v1
-- **Path-form drift** (fully-qualified vs bare paths inconsistent) — v1
 - **Self-recursive drift** (the memo about drift contains its own drift) — v1
 
 ## Composes with
@@ -166,3 +169,43 @@ If both are present, drift wins for exit code (1).
 ### Implementation
 
 Uses `git check-ignore --quiet <path>` via `spawnSync` (no shell — avoids command injection) to ask git directly. Exit code 0 from git = path IS gitignored; exit code 1 = NOT gitignored. The 5-second timeout guards against pathological cases.
+
+## v0.7 — `check-path-forms.ts` (path-form drift)
+
+The third sub-class checker, covering **path-form drift** — when the same physical file is referenced with inconsistent path forms within a single document.
+
+### What it catches
+
+A document references the same file using different string forms:
+
+- `tools/substrate-claim-checker/check-counts.ts` on line 3
+- `check-counts.ts` on line 7
+
+Both resolve to the same on-disk file, but a reader may not realize they're the same, and a grep for the full path misses the bare form.
+
+### How it works
+
+1. Extracts all path claims via `findPathClaims()` (reused from `check-existence.ts`)
+2. Resolves each claim to an absolute path using the same 3-root resolution (file dir → parent dir → repo root)
+3. Groups claims by resolved absolute path
+4. For groups with >1 distinct string form, emits a path-form drift finding
+
+Non-resolving paths are skipped (that's `check-existence.ts`'s domain).
+
+### Usage
+
+```bash
+bun tools/substrate-claim-checker/check-path-forms.ts <file>
+bun tools/substrate-claim-checker/check-path-forms.ts <file1> <file2> ...
+```
+
+Exit codes: `0` clean, `1` drift detected or input error.
+
+### Known limitations (v0.7)
+
+- **Same-directory prose vs usage-example forms**: a README documenting
+  its own directory naturally uses bare filenames in prose (`check-counts.ts`)
+  and fully-qualified paths in usage examples
+  (`tools/substrate-claim-checker/check-counts.ts`). Both are intentional.
+  v1 candidate: exempt paths inside fenced code blocks from grouping, since
+  usage examples conventionally show repo-root-relative invocations.

--- a/tools/substrate-claim-checker/check-path-forms.test.ts
+++ b/tools/substrate-claim-checker/check-path-forms.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { checkFile } from "./check-path-forms.ts";
+
+function setupRepo(): {
+  root: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), "check-path-forms-"));
+  spawnSync("git", ["init", "--quiet"], { cwd: root, stdio: "ignore" });
+  spawnSync("git", ["config", "user.email", "test@example.com"], { cwd: root, stdio: "ignore" });
+  spawnSync("git", ["config", "user.name", "test"], { cwd: root, stdio: "ignore" });
+
+  mkdirSync(join(root, "tools", "checker"), { recursive: true });
+  writeFileSync(join(root, "tools", "checker", "main.ts"), "// main");
+  writeFileSync(join(root, "tools", "checker", "utils.ts"), "// utils");
+  writeFileSync(join(root, "README.md"), "# Repo");
+
+  spawnSync("git", ["add", "."], { cwd: root, stdio: "ignore" });
+  spawnSync("git", ["commit", "-m", "init", "--quiet"], { cwd: root, stdio: "ignore" });
+
+  return {
+    root,
+    cleanup: () => {
+      try { rmSync(root, { recursive: true, force: true }); } catch {}
+    },
+  };
+}
+
+describe("checkFile", () => {
+  test("detects path-form drift when same file has two forms", () => {
+    const fx = setupRepo();
+    try {
+      const md = join(fx.root, "tools", "checker", "doc.md");
+      writeFileSync(
+        md,
+        [
+          "# Doc",
+          "",
+          "See `tools/checker/main.ts` for the implementation.",
+          "",
+          "The `main.ts` file also exports a CLI.",
+          "",
+        ].join("\n"),
+      );
+      const result = checkFile(md);
+      expect(result.ok).toBe(true);
+      expect(result.findings.length).toBe(1);
+      expect(result.findings[0]!.forms.length).toBe(2);
+      const forms = result.findings[0]!.forms.map((f) => f.path).sort();
+      expect(forms).toEqual(["main.ts", "tools/checker/main.ts"]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("no drift when all references use the same form", () => {
+    const fx = setupRepo();
+    try {
+      const md = join(fx.root, "tools", "checker", "doc.md");
+      writeFileSync(
+        md,
+        [
+          "# Doc",
+          "",
+          "See `tools/checker/main.ts` for the implementation.",
+          "",
+          "Also see `tools/checker/main.ts` for the CLI.",
+          "",
+        ].join("\n"),
+      );
+      const result = checkFile(md);
+      expect(result.ok).toBe(true);
+      expect(result.findings).toEqual([]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("no drift when different files are referenced", () => {
+    const fx = setupRepo();
+    try {
+      const md = join(fx.root, "tools", "checker", "doc.md");
+      writeFileSync(
+        md,
+        [
+          "# Doc",
+          "",
+          "See `tools/checker/main.ts` for the implementation.",
+          "",
+          "And `tools/checker/utils.ts` for helpers.",
+          "",
+        ].join("\n"),
+      );
+      const result = checkFile(md);
+      expect(result.ok).toBe(true);
+      expect(result.findings).toEqual([]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("no findings for paths that don't resolve on disk", () => {
+    const fx = setupRepo();
+    try {
+      const md = join(fx.root, "doc.md");
+      writeFileSync(
+        md,
+        [
+          "# Doc",
+          "",
+          "See `nonexistent/path.ts` for nothing.",
+          "",
+          "Also `path.ts` doesn't exist.",
+          "",
+        ].join("\n"),
+      );
+      const result = checkFile(md);
+      expect(result.ok).toBe(true);
+      expect(result.findings).toEqual([]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("returns ok=false for missing input file", () => {
+    const result = checkFile("/no/such/path/check-path-forms-test.md");
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([]);
+  });
+
+  test("returns ok=false for directory input", () => {
+    const fx = setupRepo();
+    try {
+      const result = checkFile(fx.root);
+      expect(result.ok).toBe(false);
+      expect(result.findings).toEqual([]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("detects drift across markdown link and backtick forms", () => {
+    const fx = setupRepo();
+    try {
+      const md = join(fx.root, "tools", "checker", "doc.md");
+      writeFileSync(
+        md,
+        [
+          "# Doc",
+          "",
+          "See [the main file](tools/checker/main.ts) for details.",
+          "",
+          "The `main.ts` implementation is straightforward.",
+          "",
+        ].join("\n"),
+      );
+      const result = checkFile(md);
+      expect(result.ok).toBe(true);
+      expect(result.findings.length).toBe(1);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("handles multiple drift groups independently", () => {
+    const fx = setupRepo();
+    try {
+      const md = join(fx.root, "tools", "checker", "doc.md");
+      writeFileSync(
+        md,
+        [
+          "# Doc",
+          "",
+          "See `tools/checker/main.ts` and `tools/checker/utils.ts`.",
+          "",
+          "Short: `main.ts` and `utils.ts`.",
+          "",
+        ].join("\n"),
+      );
+      const result = checkFile(md);
+      expect(result.ok).toBe(true);
+      expect(result.findings.length).toBe(2);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("clean file with no path claims produces no findings", () => {
+    const fx = setupRepo();
+    try {
+      const md = join(fx.root, "doc.md");
+      writeFileSync(md, "# Just a heading\n\nNo paths here.\n");
+      const result = checkFile(md);
+      expect(result.ok).toBe(true);
+      expect(result.findings).toEqual([]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+});

--- a/tools/substrate-claim-checker/check-path-forms.ts
+++ b/tools/substrate-claim-checker/check-path-forms.ts
@@ -1,0 +1,200 @@
+#!/usr/bin/env bun
+/**
+ * substrate-claim-checker / check-path-forms.ts (v0.7.0)
+ *
+ * Path-form drift sub-class checker — catches inconsistent path forms
+ * within a single document. When the same physical file is referenced
+ * as both `tools/substrate-claim-checker/check-counts.ts` and
+ * `check-counts.ts`, a reader may not realize they point to the same
+ * file, and a grep for the full path misses the bare form.
+ *
+ * Per the verify-then-claim memo's 7-class taxonomy (B-0170):
+ *   "fully-qualified vs bare paths consistent across document"
+ *
+ * Reuses findPathClaims() from check-existence.ts for path extraction.
+ */
+
+import { readFileSync, statSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve, relative } from "node:path";
+import { findPathClaims, type PathClaim } from "./check-existence.ts";
+
+interface Finding {
+  file: string;
+  line: number;
+  resolvedPath: string;
+  forms: { path: string; line: number }[];
+  reason: string;
+}
+
+function statExists(p: string): boolean {
+  try {
+    statSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findRepoRoot(startPath: string): string {
+  let cur = isAbsolute(startPath) ? startPath : resolve(startPath);
+  try {
+    if (statSync(cur).isFile()) cur = dirname(cur);
+  } catch {
+    cur = dirname(cur);
+  }
+  while (cur !== "/" && cur !== "") {
+    const gitPath = join(cur, ".git");
+    if (statExists(gitPath)) return cur;
+    const parent = dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return process.cwd();
+}
+
+/**
+ * Resolve a path claim to an absolute path using the same 3-root
+ * resolution strategy as check-existence.ts:
+ *   1. File's own directory
+ *   2. Parent directory
+ *   3. Repository root
+ *
+ * Returns null if the path doesn't resolve to any existing file.
+ */
+function resolveClaim(
+  claimPath: string,
+  fileDir: string,
+  fileParentDir: string,
+  repoRoot: string,
+): string | null {
+  const candidateRoots = [fileDir, fileParentDir, repoRoot];
+  for (const root of candidateRoots) {
+    const absPath = isAbsolute(claimPath) ? claimPath : join(root, claimPath);
+    if (statExists(absPath)) return absPath;
+  }
+  return null;
+}
+
+interface CheckResult {
+  findings: Finding[];
+  ok: boolean;
+}
+
+/**
+ * Check a single file for path-form drift.
+ *
+ * Strategy:
+ *   1. Extract all path claims via findPathClaims()
+ *   2. Resolve each claim to an absolute on-disk path
+ *   3. Group claims by resolved absolute path
+ *   4. For groups with >1 distinct string form, emit a finding
+ */
+export function checkFile(filePath: string): CheckResult {
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf8");
+  } catch (e: unknown) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code === "ENOENT") {
+      console.error(`error: file not found: ${filePath}`);
+    } else if (err.code === "EISDIR") {
+      console.error(`error: not a regular file (directory): ${filePath}`);
+    } else {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`error: read failed for ${filePath}: ${msg}`);
+    }
+    return { findings: [], ok: false };
+  }
+
+  const lines = content.split("\n");
+  const repoRoot = findRepoRoot(filePath);
+  const claims = findPathClaims(lines);
+
+  const fileDir = isAbsolute(filePath)
+    ? dirname(filePath)
+    : resolve(dirname(filePath));
+  const fileParentDir = dirname(fileDir);
+
+  // Group claims by resolved absolute path
+  const groups = new Map<string, { path: string; line: number }[]>();
+  for (const claim of claims) {
+    const resolved = resolveClaim(claim.path, fileDir, fileParentDir, repoRoot);
+    if (resolved === null) continue; // non-existent paths are check-existence's domain
+    const entries = groups.get(resolved) ?? [];
+    entries.push({ path: claim.path, line: claim.line });
+    groups.set(resolved, entries);
+  }
+
+  const findings: Finding[] = [];
+  for (const [absPath, entries] of groups) {
+    // Deduplicate string forms (same path string used on multiple lines is fine)
+    const distinctForms = new Set(entries.map((e) => e.path));
+    if (distinctForms.size <= 1) continue;
+
+    // Collect one representative occurrence per distinct form
+    const formExamples: { path: string; line: number }[] = [];
+    const seen = new Set<string>();
+    for (const entry of entries) {
+      if (!seen.has(entry.path)) {
+        seen.add(entry.path);
+        formExamples.push(entry);
+      }
+    }
+
+    const relPath = relative(repoRoot, absPath);
+    const formList = formExamples
+      .map((f) => `"${f.path}" (line ${f.line})`)
+      .join(", ");
+
+    findings.push({
+      file: filePath,
+      line: formExamples[0]!.line,
+      resolvedPath: relPath,
+      forms: formExamples,
+      reason: `same file referenced as ${formList} — use a consistent form`,
+    });
+  }
+
+  return { findings, ok: true };
+}
+
+export { type Finding, type PathClaim };
+
+export function main(): number {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error(
+      "usage: bun tools/substrate-claim-checker/check-path-forms.ts <file> [<file> ...]",
+    );
+    return 1;
+  }
+  let totalFindings = 0;
+  let inputErrors = 0;
+  for (const arg of args) {
+    const { findings, ok } = checkFile(arg);
+    if (!ok) {
+      inputErrors++;
+      continue;
+    }
+    for (const f of findings) {
+      console.log(
+        `${f.file}:${f.line}: path-form drift — ${f.reason}`,
+      );
+      totalFindings++;
+    }
+  }
+  if (inputErrors > 0) {
+    console.error(`\n${inputErrors} input error(s).`);
+    return 1;
+  }
+  if (totalFindings > 0) {
+    console.log(`\n${totalFindings} path-form drift finding(s).`);
+    return 1;
+  }
+  console.log("no path-form drift detected.");
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}


### PR DESCRIPTION
## Summary

- Adds `check-path-forms.ts`, the third sub-class checker for B-0170's substrate-claim-checker tool
- Detects when the same physical file is referenced with inconsistent path forms within a single markdown document (e.g. `tools/checker/main.ts` in one place and `main.ts` in another)
- Reuses `findPathClaims()` from `check-existence.ts`; resolves via same 3-root strategy; groups by resolved absolute path
- Updates B-0170 backlog row: 3 of 7 sub-classes now shipped (count drift, existence drift, path-form drift)

## Test plan

- [x] 9 new unit tests in `check-path-forms.test.ts` (drift detection, no-drift, cross-form, multiple groups, error handling)
- [x] All 62 existing + 9 new = 71 tests pass across 3 test files (`bun test tools/substrate-claim-checker/`)
- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] Smoke-tested on real repo files: catches real path-form inconsistency in `tools/substrate-claim-checker/README.md` (documented as known limitation — same-directory prose vs usage-example forms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)