### PR TITLE
tool(B-0171): add openspec/inventory.ts — Phase 1 spec-to-code gap report

### DIFF
--- a/openspec/README.md
+++ b/openspec/README.md
@@ -81,7 +81,7 @@ tree holding retired proposals.
 
 ## Capabilities (populated progressively)
 
-Three capabilities are spec'd today:
+Six capabilities are spec'd today:
 
 - **`operator-algebra`** — Z-sets, D / I / z⁻¹ / H operators, chain
   rule, bilinearity of Join, retraction-native invariants.
@@ -91,20 +91,28 @@ Three capabilities are spec'd today:
 - **`durability-modes`** — `DurabilityMode` DU, factory,
   feature-flag gating on `WitnessDurable`, evaluator resolution
   order, offline-safety, lifecycle stages.
+- **`circuit-recursion`** — nested circuits with private inner clock,
+  scope-boundary lifecycle, fixpoint semantics, DBSP §5-6 recursive
+  query pattern substrate.
+- **`lsm-spine-family`** — LSM spine for Z-set delta integration,
+  `Spine`, `SpineAsync`, `DiskSpine`, `BalancedSpine`, merge
+  policies, checkpoint format.
+- **`repo-automation`** — install scripts, GitHub Actions workflows,
+  doctor script, CI/CD pipeline conventions.
 
-Each capability ships with a `spec.md` plus at least an
-`fsharp.md` profile under `profiles/`.
+Each capability ships with a `spec.md` plus at least one profile
+under `profiles/`.
 
 Planned capabilities (not yet spec'd — the Architect prioritises
 these per round):
 
-- `storage-spines` — `Spine`, `SpineAsync`, `DiskSpine`,
-  `BalancedSpine`, checkpoint format
 - `sketches` — HLL, Count-Min, KLL, Bloom (blocked + counting),
   future CQF
 - `feature-flags` — already in-tree as a standalone module
   (`src/Core/FeatureFlags.fs`); behavioural spec pending
-- `circuit-scheduling` — topo-sort, strict ops, async fast path
+
+Run `bun tools/openspec/inventory.ts` for a full gap report mapping
+specs to `src/Core/` modules.
 
 Future profiles (`csharp.md` for the shim, `rust.md`,
 `python.md`) land only when there's an implementation to describe.

--- a/tools/openspec/inventory.test.ts
+++ b/tools/openspec/inventory.test.ts
@@ -127,18 +127,40 @@ describe("buildGapReport", () => {
   });
 
   test("coverage denominator excludes only present excluded modules", () => {
+    const specs: SpecEntry[] = [
+      {
+        capability: "operator-algebra",
+        specPath: "openspec/specs/operator-algebra/spec.md",
+        profiles: ["fsharp"],
+        purposeSnippet: "the core algebra",
+      },
+    ];
+    const modules: ModuleEntry[] = [
+      { name: "ZSet.fs", path: "src/Core/ZSet.fs", namespace: "Zeta.Core" },
+      { name: "Sketch.fs", path: "src/Core/Sketch.fs", namespace: "Zeta.Core" },
+    ];
+
+    const report = buildGapReport(specs, modules);
+    // Neither AssemblyInfo.fs nor FSharpApi.fs is in the module list,
+    // so denominator should be 2 (not 2 - 2 = 0).
+    // ZSet.fs is covered via operator-algebra mapping (spec present), so 1/2 = 50%.
+    expect(report.coveragePercent).toBe(50);
+    expect(report.uncoveredModules).toHaveLength(1);
+    expect(report.uncoveredModules).toContain("Sketch.fs");
+  });
+
+  test("modules are not covered when their capability spec is missing", () => {
     const modules: ModuleEntry[] = [
       { name: "ZSet.fs", path: "src/Core/ZSet.fs", namespace: "Zeta.Core" },
       { name: "Sketch.fs", path: "src/Core/Sketch.fs", namespace: "Zeta.Core" },
     ];
 
     const report = buildGapReport([], modules);
-    // Neither AssemblyInfo.fs nor FSharpApi.fs is in the module list,
-    // so denominator should be 2 (not 2 - 2 = 0).
-    // ZSet.fs is covered via operator-algebra mapping, so 1/2 = 50%.
-    expect(report.coveragePercent).toBe(50);
-    expect(report.uncoveredModules).toHaveLength(1);
-    expect(report.uncoveredModules).toContain("Sketch.fs");
+    // No specs present — even though ZSet.fs is in the operator-algebra mapping,
+    // coverage should be 0% because the spec itself doesn't exist.
+    expect(report.coveragePercent).toBe(0);
+    expect(report.coveredModules).toHaveLength(0);
+    expect(report.uncoveredModules).toHaveLength(2);
   });
 
   test("reports missing mapped modules", () => {

--- a/tools/openspec/inventory.test.ts
+++ b/tools/openspec/inventory.test.ts
@@ -34,6 +34,7 @@ describe("scanSpecs", () => {
     const specs = scanSpecs(root);
     expect(specs).toHaveLength(1);
     expect(specs[0]!.capability).toBe("my-cap");
+    expect(specs[0]!.specPath).toBe(join(root, "my-cap", "spec.md"));
     expect(specs[0]!.profiles).toEqual(["fsharp"]);
     expect(specs[0]!.purposeSnippet).toContain("foo capability");
 
@@ -46,6 +47,19 @@ describe("scanSpecs", () => {
 
     const specs = scanSpecs(root);
     expect(specs).toHaveLength(0);
+
+    rmSync(root, { recursive: true });
+  });
+
+  test("returns entries in sorted order", () => {
+    const root = makeTempDir();
+    for (const name of ["zebra", "alpha", "middle"]) {
+      mkdirSync(join(root, name), { recursive: true });
+      writeFileSync(join(root, name, "spec.md"), "## Purpose\n\nTest.\n");
+    }
+
+    const specs = scanSpecs(root);
+    expect(specs.map((s) => s.capability)).toEqual(["alpha", "middle", "zebra"]);
 
     rmSync(root, { recursive: true });
   });
@@ -67,7 +81,20 @@ describe("scanModules", () => {
     const modules = scanModules(root);
     expect(modules).toHaveLength(1);
     expect(modules[0]!.name).toBe("Foo.fs");
+    expect(modules[0]!.path).toBe(join(root, "Foo.fs"));
     expect(modules[0]!.namespace).toBe("Zeta.Core");
+
+    rmSync(root, { recursive: true });
+  });
+
+  test("returns entries in sorted order", () => {
+    const root = makeTempDir();
+    for (const name of ["Zebra.fs", "Alpha.fs", "Middle.fs"]) {
+      writeFileSync(join(root, name), "namespace Zeta.Core\n");
+    }
+
+    const modules = scanModules(root);
+    expect(modules.map((m) => m.name)).toEqual(["Alpha.fs", "Middle.fs", "Zebra.fs"]);
 
     rmSync(root, { recursive: true });
   });
@@ -97,6 +124,33 @@ describe("buildGapReport", () => {
     expect(report.uncoveredModules).not.toContain("AssemblyInfo.fs");
     expect(report.uncoveredModules).not.toContain("ZSet.fs");
     expect(report.coveragePercent).toBeGreaterThan(0);
+  });
+
+  test("coverage denominator excludes only present excluded modules", () => {
+    const modules: ModuleEntry[] = [
+      { name: "ZSet.fs", path: "src/Core/ZSet.fs", namespace: "Zeta.Core" },
+      { name: "Sketch.fs", path: "src/Core/Sketch.fs", namespace: "Zeta.Core" },
+    ];
+
+    const report = buildGapReport([], modules);
+    // Neither AssemblyInfo.fs nor FSharpApi.fs is in the module list,
+    // so denominator should be 2 (not 2 - 2 = 0).
+    // ZSet.fs is covered via operator-algebra mapping, so 1/2 = 50%.
+    expect(report.coveragePercent).toBe(50);
+    expect(report.uncoveredModules).toHaveLength(1);
+    expect(report.uncoveredModules).toContain("Sketch.fs");
+  });
+
+  test("reports missing mapped modules", () => {
+    const modules: ModuleEntry[] = [
+      { name: "ZSet.fs", path: "src/Core/ZSet.fs", namespace: "Zeta.Core" },
+    ];
+
+    const report = buildGapReport([], modules);
+    const algebraMapping = report.mappings.find((m) => m.capability === "operator-algebra");
+    expect(algebraMapping).toBeDefined();
+    expect(algebraMapping!.missingModules).toContain("Algebra.fs");
+    expect(algebraMapping!.missingModules).not.toContain("ZSet.fs");
   });
 
   test("flags specs not in mapping table", () => {
@@ -138,7 +192,7 @@ describe("mapping table integrity", () => {
 
 describe("integration: real repo scan", () => {
   test("finds at least 6 specs in the real openspec/specs/ dir", () => {
-    const repoRoot = join(__dirname, "..", "..");
+    const repoRoot = join(import.meta.dir, "..", "..");
     const specs = scanSpecs(join(repoRoot, "openspec", "specs"));
     expect(specs.length).toBeGreaterThanOrEqual(6);
 
@@ -152,7 +206,7 @@ describe("integration: real repo scan", () => {
   });
 
   test("finds at least 50 modules in the real src/Core/ dir", () => {
-    const repoRoot = join(__dirname, "..", "..");
+    const repoRoot = join(import.meta.dir, "..", "..");
     const modules = scanModules(join(repoRoot, "src", "Core"));
     expect(modules.length).toBeGreaterThanOrEqual(50);
   });

--- a/tools/openspec/inventory.test.ts
+++ b/tools/openspec/inventory.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  scanSpecs,
+  scanModules,
+  buildGapReport,
+  CAPABILITY_MODULE_MAP,
+  EXCLUDED_MODULES,
+} from "./inventory.ts";
+import type { SpecEntry, ModuleEntry } from "./inventory.ts";
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "openspec-inventory-test-"));
+}
+
+describe("scanSpecs", () => {
+  test("returns empty for nonexistent dir", () => {
+    expect(scanSpecs("/nonexistent/path")).toEqual([]);
+  });
+
+  test("finds specs with purpose and profiles", () => {
+    const root = makeTempDir();
+    const specDir = join(root, "my-cap");
+    const profilesDir = join(specDir, "profiles");
+    mkdirSync(profilesDir, { recursive: true });
+    writeFileSync(
+      join(specDir, "spec.md"),
+      "## Purpose\n\nThis defines the foo capability.\n\n## Requirements\n",
+    );
+    writeFileSync(join(profilesDir, "fsharp.md"), "# F# overlay\n");
+
+    const specs = scanSpecs(root);
+    expect(specs).toHaveLength(1);
+    expect(specs[0]!.capability).toBe("my-cap");
+    expect(specs[0]!.profiles).toEqual(["fsharp"]);
+    expect(specs[0]!.purposeSnippet).toContain("foo capability");
+
+    rmSync(root, { recursive: true });
+  });
+
+  test("skips dirs without spec.md", () => {
+    const root = makeTempDir();
+    mkdirSync(join(root, "empty-cap"), { recursive: true });
+
+    const specs = scanSpecs(root);
+    expect(specs).toHaveLength(0);
+
+    rmSync(root, { recursive: true });
+  });
+});
+
+describe("scanModules", () => {
+  test("returns empty for nonexistent dir", () => {
+    expect(scanModules("/nonexistent/path")).toEqual([]);
+  });
+
+  test("finds .fs files and extracts namespace", () => {
+    const root = makeTempDir();
+    writeFileSync(
+      join(root, "Foo.fs"),
+      "namespace Zeta.Core\n\ntype Foo = { X: int }\n",
+    );
+    writeFileSync(join(root, "NotFs.txt"), "ignored");
+
+    const modules = scanModules(root);
+    expect(modules).toHaveLength(1);
+    expect(modules[0]!.name).toBe("Foo.fs");
+    expect(modules[0]!.namespace).toBe("Zeta.Core");
+
+    rmSync(root, { recursive: true });
+  });
+});
+
+describe("buildGapReport", () => {
+  test("correctly classifies covered vs uncovered", () => {
+    const specs: SpecEntry[] = [
+      {
+        capability: "operator-algebra",
+        specPath: "openspec/specs/operator-algebra/spec.md",
+        profiles: ["fsharp"],
+        purposeSnippet: "the core algebra",
+      },
+    ];
+
+    const modules: ModuleEntry[] = [
+      { name: "ZSet.fs", path: "src/Core/ZSet.fs", namespace: "Zeta.Core" },
+      { name: "Sketch.fs", path: "src/Core/Sketch.fs", namespace: "Zeta.Core" },
+      { name: "AssemblyInfo.fs", path: "src/Core/AssemblyInfo.fs", namespace: "Zeta.Core" },
+    ];
+
+    const report = buildGapReport(specs, modules);
+
+    expect(report.coveredModules).toContain("ZSet.fs");
+    expect(report.uncoveredModules).toContain("Sketch.fs");
+    expect(report.uncoveredModules).not.toContain("AssemblyInfo.fs");
+    expect(report.uncoveredModules).not.toContain("ZSet.fs");
+    expect(report.coveragePercent).toBeGreaterThan(0);
+  });
+
+  test("flags specs not in mapping table", () => {
+    const specs: SpecEntry[] = [
+      {
+        capability: "brand-new-spec",
+        specPath: "openspec/specs/brand-new-spec/spec.md",
+        profiles: [],
+        purposeSnippet: "new",
+      },
+    ];
+
+    const report = buildGapReport(specs, []);
+    expect(report.unmappedSpecs).toContain("brand-new-spec");
+  });
+
+  test("coverage is 0% with no modules", () => {
+    const report = buildGapReport([], []);
+    expect(report.coveragePercent).toBe(0);
+  });
+});
+
+describe("mapping table integrity", () => {
+  test("all mapped capabilities have entries in CAPABILITY_MODULE_MAP", () => {
+    for (const [cap, modules] of Object.entries(CAPABILITY_MODULE_MAP)) {
+      expect(typeof cap).toBe("string");
+      expect(Array.isArray(modules)).toBe(true);
+    }
+  });
+
+  test("EXCLUDED_MODULES is a Set of strings", () => {
+    expect(EXCLUDED_MODULES).toBeInstanceOf(Set);
+    for (const m of EXCLUDED_MODULES) {
+      expect(typeof m).toBe("string");
+      expect(m.endsWith(".fs")).toBe(true);
+    }
+  });
+});
+
+describe("integration: real repo scan", () => {
+  test("finds at least 6 specs in the real openspec/specs/ dir", () => {
+    const repoRoot = join(__dirname, "..", "..");
+    const specs = scanSpecs(join(repoRoot, "openspec", "specs"));
+    expect(specs.length).toBeGreaterThanOrEqual(6);
+
+    const names = specs.map((s) => s.capability);
+    expect(names).toContain("operator-algebra");
+    expect(names).toContain("retraction-safe-recursion");
+    expect(names).toContain("durability-modes");
+    expect(names).toContain("circuit-recursion");
+    expect(names).toContain("lsm-spine-family");
+    expect(names).toContain("repo-automation");
+  });
+
+  test("finds at least 50 modules in the real src/Core/ dir", () => {
+    const repoRoot = join(__dirname, "..", "..");
+    const modules = scanModules(join(repoRoot, "src", "Core"));
+    expect(modules.length).toBeGreaterThanOrEqual(50);
+  });
+});

--- a/tools/openspec/inventory.ts
+++ b/tools/openspec/inventory.ts
@@ -10,7 +10,7 @@
  */
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
 
 // ── Types ────────────────────────────────────────────────────────────
 

--- a/tools/openspec/inventory.ts
+++ b/tools/openspec/inventory.ts
@@ -1,0 +1,277 @@
+#!/usr/bin/env bun
+/**
+ * openspec/inventory.ts (v0.1.0)
+ *
+ * Phase 1 mechanization for B-0171: scans openspec/specs/ and src/Core/
+ * to produce a structured gap report — which code modules have specs,
+ * which don't, and which specs have no matching code module.
+ *
+ * Output: JSON to stdout. Human-readable summary to stderr.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+interface SpecEntry {
+  capability: string;
+  specPath: string;
+  profiles: string[];
+  purposeSnippet: string;
+}
+
+interface ModuleEntry {
+  name: string;
+  path: string;
+  namespace: string;
+}
+
+interface Mapping {
+  capability: string;
+  modules: string[];
+}
+
+interface GapReport {
+  timestamp: string;
+  specs: SpecEntry[];
+  modules: ModuleEntry[];
+  mappings: Mapping[];
+  coveredModules: string[];
+  uncoveredModules: string[];
+  unmappedSpecs: string[];
+  coveragePercent: number;
+}
+
+// ── Known capability → module mappings ──────────────────────────────
+//
+// This is the authoritative map of which specs cover which F# modules.
+// Maintained manually — when a new spec or module lands, add the link.
+// The inventory tool flags anything not in this map as a gap.
+
+const CAPABILITY_MODULE_MAP: Record<string, string[]> = {
+  "operator-algebra": [
+    "ZSet.fs",
+    "Algebra.fs",
+    "Operators.fs",
+    "IndexedZSet.fs",
+    "Incremental.fs",
+    "Units.fs",
+    "Primitive.fs",
+    "Handles.fs",
+  ],
+  "retraction-safe-recursion": [
+    "Recursive.fs",
+    "RecursiveSigned.fs",
+  ],
+  "durability-modes": [
+    "Durability.fs",
+  ],
+  "circuit-recursion": [
+    "Circuit.fs",
+    "NestedCircuit.fs",
+  ],
+  "lsm-spine-family": [
+    "Spine.fs",
+    "SpineAsync.fs",
+    "DiskSpine.fs",
+    "BalancedSpine.fs",
+    "SpineSelector.fs",
+  ],
+  "repo-automation": [],
+};
+
+// Modules excluded from gap analysis — infrastructure, assembly metadata,
+// or modules whose spec coverage is tracked under a different capability.
+const EXCLUDED_MODULES = new Set([
+  "AssemblyInfo.fs",
+  "FSharpApi.fs",
+]);
+
+// ── Scanning ─────────────────────────────────────────────────────────
+
+function findRepoRoot(): string {
+  let cur = resolve(__dirname);
+  while (cur !== "/" && cur !== "") {
+    try {
+      statSync(join(cur, ".git"));
+      return cur;
+    } catch {
+      const parent = join(cur, "..");
+      if (resolve(parent) === cur) break;
+      cur = resolve(parent);
+    }
+  }
+  return process.cwd();
+}
+
+function scanSpecs(specsDir: string): SpecEntry[] {
+  const entries: SpecEntry[] = [];
+  let dirs: string[];
+  try {
+    dirs = readdirSync(specsDir);
+  } catch {
+    return entries;
+  }
+
+  for (const name of dirs) {
+    const specPath = join(specsDir, name, "spec.md");
+    try {
+      statSync(specPath);
+    } catch {
+      continue;
+    }
+
+    const content = readFileSync(specPath, "utf8");
+    const purposeMatch = content.match(
+      /##\s*Purpose\s*\n+([\s\S]*?)(?=\n##\s|\n$)/,
+    );
+    const purposeSnippet = purposeMatch
+      ? purposeMatch[1]!.trim().split("\n")[0]!.slice(0, 200)
+      : "(no purpose section found)";
+
+    let profiles: string[] = [];
+    const profilesDir = join(specsDir, name, "profiles");
+    try {
+      profiles = readdirSync(profilesDir)
+        .filter((f) => f.endsWith(".md"))
+        .map((f) => f.replace(/\.md$/, ""));
+    } catch {
+      // no profiles dir
+    }
+
+    entries.push({
+      capability: name,
+      specPath: `openspec/specs/${name}/spec.md`,
+      profiles,
+      purposeSnippet,
+    });
+  }
+
+  return entries;
+}
+
+function scanModules(coreDir: string): ModuleEntry[] {
+  const entries: ModuleEntry[] = [];
+  let files: string[];
+  try {
+    files = readdirSync(coreDir).filter((f) => f.endsWith(".fs"));
+  } catch {
+    return entries;
+  }
+
+  for (const file of files) {
+    const filePath = join(coreDir, file);
+    const content = readFileSync(filePath, "utf8");
+    const nsMatch = content.match(/^namespace\s+(\S+)/m);
+    entries.push({
+      name: file,
+      path: `src/Core/${file}`,
+      namespace: nsMatch ? nsMatch[1]! : "unknown",
+    });
+  }
+
+  return entries;
+}
+
+// ── Gap analysis ─────────────────────────────────────────────────────
+
+function buildGapReport(specs: SpecEntry[], modules: ModuleEntry[]): GapReport {
+  const allModuleNames = new Set(modules.map((m) => m.name));
+  const coveredSet = new Set<string>();
+  const mappings: Mapping[] = [];
+
+  for (const [capability, moduleNames] of Object.entries(CAPABILITY_MODULE_MAP)) {
+    const actualModules = moduleNames.filter((m) => allModuleNames.has(m));
+    mappings.push({ capability, modules: actualModules });
+    for (const m of actualModules) {
+      coveredSet.add(m);
+    }
+  }
+
+  const coveredModules = [...coveredSet].sort();
+  const uncoveredModules = modules
+    .map((m) => m.name)
+    .filter((m) => !coveredSet.has(m) && !EXCLUDED_MODULES.has(m))
+    .sort();
+
+  const specCapabilities = new Set(specs.map((s) => s.capability));
+  const mappedCapabilities = new Set(Object.keys(CAPABILITY_MODULE_MAP));
+  const unmappedSpecs = [...specCapabilities]
+    .filter((c) => !mappedCapabilities.has(c))
+    .sort();
+
+  const totalAnalyzable = modules.length - EXCLUDED_MODULES.size;
+  const coveragePercent =
+    totalAnalyzable > 0
+      ? Math.round((coveredModules.length / totalAnalyzable) * 1000) / 10
+      : 0;
+
+  return {
+    timestamp: new Date().toISOString(),
+    specs,
+    modules,
+    mappings,
+    coveredModules,
+    uncoveredModules,
+    unmappedSpecs,
+    coveragePercent,
+  };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────
+
+export {
+  scanSpecs,
+  scanModules,
+  buildGapReport,
+  CAPABILITY_MODULE_MAP,
+  EXCLUDED_MODULES,
+};
+export type { SpecEntry, ModuleEntry, GapReport, Mapping };
+
+export function main(): number {
+  const repoRoot = findRepoRoot();
+  const specsDir = join(repoRoot, "openspec", "specs");
+  const coreDir = join(repoRoot, "src", "Core");
+
+  const specs = scanSpecs(specsDir);
+  const modules = scanModules(coreDir);
+  const report = buildGapReport(specs, modules);
+
+  // Structured JSON to stdout
+  console.log(JSON.stringify(report, null, 2));
+
+  // Human-readable summary to stderr
+  const err = console.error.bind(console);
+  err("");
+  err(`── OpenSpec inventory ──────────────────────────`);
+  err(`  Specs:             ${report.specs.length}`);
+  err(`  Core modules:      ${report.modules.length}`);
+  err(`  Covered modules:   ${report.coveredModules.length}`);
+  err(`  Uncovered modules: ${report.uncoveredModules.length}`);
+  err(`  Coverage:          ${report.coveragePercent}%`);
+  err("");
+
+  if (report.unmappedSpecs.length > 0) {
+    err(`  Specs without module mapping:`);
+    for (const s of report.unmappedSpecs) {
+      err(`    - ${s}`);
+    }
+    err("");
+  }
+
+  if (report.uncoveredModules.length > 0) {
+    err(`  Uncovered modules (candidates for new specs):`);
+    for (const m of report.uncoveredModules) {
+      err(`    - ${m}`);
+    }
+    err("");
+  }
+
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/tools/openspec/inventory.ts
+++ b/tools/openspec/inventory.ts
@@ -180,6 +180,7 @@ function scanModules(coreDir: string): ModuleEntry[] {
 
 function buildGapReport(specs: SpecEntry[], modules: ModuleEntry[]): GapReport {
   const allModuleNames = new Set(modules.map((m) => m.name));
+  const specCapabilities = new Set(specs.map((s) => s.capability));
   const coveredSet = new Set<string>();
   const mappings: Mapping[] = [];
 
@@ -187,8 +188,10 @@ function buildGapReport(specs: SpecEntry[], modules: ModuleEntry[]): GapReport {
     const actualModules = moduleNames.filter((m) => allModuleNames.has(m));
     const missingModules = moduleNames.filter((m) => !allModuleNames.has(m));
     mappings.push({ capability, modules: actualModules, missingModules });
-    for (const m of actualModules) {
-      coveredSet.add(m);
+    if (specCapabilities.has(capability)) {
+      for (const m of actualModules) {
+        coveredSet.add(m);
+      }
     }
   }
 
@@ -198,7 +201,6 @@ function buildGapReport(specs: SpecEntry[], modules: ModuleEntry[]): GapReport {
     .filter((m) => !coveredSet.has(m) && !EXCLUDED_MODULES.has(m))
     .sort();
 
-  const specCapabilities = new Set(specs.map((s) => s.capability));
   const mappedCapabilities = new Set(Object.keys(CAPABILITY_MODULE_MAP));
   const unmappedSpecs = [...specCapabilities]
     .filter((c) => !mappedCapabilities.has(c))

--- a/tools/openspec/inventory.ts
+++ b/tools/openspec/inventory.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * openspec/inventory.ts (v0.1.0)
+ * tools/openspec/inventory.ts (v0.2.0)
  *
  * Phase 1 mechanization for B-0171: scans openspec/specs/ and src/Core/
  * to produce a structured gap report — which code modules have specs,
@@ -9,8 +9,8 @@
  * Output: JSON to stdout. Human-readable summary to stderr.
  */
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -30,6 +30,7 @@ interface ModuleEntry {
 interface Mapping {
   capability: string;
   modules: string[];
+  missingModules: string[];
 }
 
 interface GapReport {
@@ -91,15 +92,15 @@ const EXCLUDED_MODULES = new Set([
 // ── Scanning ─────────────────────────────────────────────────────────
 
 function findRepoRoot(): string {
-  let cur = resolve(__dirname);
+  let cur = resolve(import.meta.dir);
   while (cur !== "/" && cur !== "") {
     try {
-      statSync(join(cur, ".git"));
+      readFileSync(join(cur, ".git", "HEAD"));
       return cur;
     } catch {
-      const parent = join(cur, "..");
-      if (resolve(parent) === cur) break;
-      cur = resolve(parent);
+      const parent = resolve(cur, "..");
+      if (parent === cur) break;
+      cur = parent;
     }
   }
   return process.cwd();
@@ -109,20 +110,20 @@ function scanSpecs(specsDir: string): SpecEntry[] {
   const entries: SpecEntry[] = [];
   let dirs: string[];
   try {
-    dirs = readdirSync(specsDir);
+    dirs = readdirSync(specsDir).sort();
   } catch {
     return entries;
   }
 
   for (const name of dirs) {
     const specPath = join(specsDir, name, "spec.md");
+    let content: string;
     try {
-      statSync(specPath);
+      content = readFileSync(specPath, "utf8");
     } catch {
       continue;
     }
 
-    const content = readFileSync(specPath, "utf8");
     const purposeMatch = content.match(
       /##\s*Purpose\s*\n+([\s\S]*?)(?=\n##\s|\n$)/,
     );
@@ -135,14 +136,15 @@ function scanSpecs(specsDir: string): SpecEntry[] {
     try {
       profiles = readdirSync(profilesDir)
         .filter((f) => f.endsWith(".md"))
-        .map((f) => f.replace(/\.md$/, ""));
+        .map((f) => f.replace(/\.md$/, ""))
+        .sort();
     } catch {
       // no profiles dir
     }
 
     entries.push({
       capability: name,
-      specPath: `openspec/specs/${name}/spec.md`,
+      specPath,
       profiles,
       purposeSnippet,
     });
@@ -155,7 +157,7 @@ function scanModules(coreDir: string): ModuleEntry[] {
   const entries: ModuleEntry[] = [];
   let files: string[];
   try {
-    files = readdirSync(coreDir).filter((f) => f.endsWith(".fs"));
+    files = readdirSync(coreDir).filter((f) => f.endsWith(".fs")).sort();
   } catch {
     return entries;
   }
@@ -166,7 +168,7 @@ function scanModules(coreDir: string): ModuleEntry[] {
     const nsMatch = content.match(/^namespace\s+(\S+)/m);
     entries.push({
       name: file,
-      path: `src/Core/${file}`,
+      path: filePath,
       namespace: nsMatch ? nsMatch[1]! : "unknown",
     });
   }
@@ -183,7 +185,8 @@ function buildGapReport(specs: SpecEntry[], modules: ModuleEntry[]): GapReport {
 
   for (const [capability, moduleNames] of Object.entries(CAPABILITY_MODULE_MAP)) {
     const actualModules = moduleNames.filter((m) => allModuleNames.has(m));
-    mappings.push({ capability, modules: actualModules });
+    const missingModules = moduleNames.filter((m) => !allModuleNames.has(m));
+    mappings.push({ capability, modules: actualModules, missingModules });
     for (const m of actualModules) {
       coveredSet.add(m);
     }
@@ -201,7 +204,8 @@ function buildGapReport(specs: SpecEntry[], modules: ModuleEntry[]): GapReport {
     .filter((c) => !mappedCapabilities.has(c))
     .sort();
 
-  const totalAnalyzable = modules.length - EXCLUDED_MODULES.size;
+  const excludedPresent = modules.filter((m) => EXCLUDED_MODULES.has(m.name)).length;
+  const totalAnalyzable = modules.length - excludedPresent;
   const coveragePercent =
     totalAnalyzable > 0
       ? Math.round((coveredModules.length / totalAnalyzable) * 1000) / 10
@@ -239,6 +243,14 @@ export function main(): number {
   const modules = scanModules(coreDir);
   const report = buildGapReport(specs, modules);
 
+  // Convert absolute paths to repo-relative for display
+  for (const s of report.specs) {
+    s.specPath = relative(repoRoot, s.specPath);
+  }
+  for (const m of report.modules) {
+    m.path = relative(repoRoot, m.path);
+  }
+
   // Structured JSON to stdout
   console.log(JSON.stringify(report, null, 2));
 
@@ -252,6 +264,15 @@ export function main(): number {
   err(`  Uncovered modules: ${report.uncoveredModules.length}`);
   err(`  Coverage:          ${report.coveragePercent}%`);
   err("");
+
+  const allMissing = report.mappings.flatMap((m) => m.missingModules);
+  if (allMissing.length > 0) {
+    err(`  Mapped modules not found in src/Core/ (possible drift):`);
+    for (const m of allMissing) {
+      err(`    - ${m}`);
+    }
+    err("");
+  }
 
   if (report.unmappedSpecs.length > 0) {
     err(`  Specs without module mapping:`);


### PR DESCRIPTION
## Summary

- **New tool**: `tools/openspec/inventory.ts` — scans `openspec/specs/` and `src/Core/` to produce a structured JSON gap report mapping behavioural specs to code modules. Mechanizes Phase 1 (inventory + sequencing) of B-0171.
- **README fix**: `openspec/README.md` capabilities section was stale — listed 3 specs when 6 exist; listed `storage-spines` and `circuit-scheduling` as "planned" when `lsm-spine-family` and `circuit-recursion` already cover them.
- **12 tests** covering scanners, gap analysis, mapping table integrity, and real-repo integration.

### Current inventory output

```
Specs:             6
Core modules:      80
Covered modules:   18
Uncovered modules: 60
Coverage:          23.1%
```

The 60 uncovered modules are the Phase 2 candidate list for new specs. Run `bun tools/openspec/inventory.ts` for the full gap report.

## Test plan

- [x] `bun test tools/openspec/inventory.test.ts` — 12/12 pass
- [x] `bun tools/openspec/inventory.ts` — produces structured JSON + human summary
- [x] `dotnet build -c Release` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)