### PR TITLE
tool(B-0212): shadow-outlet Phase 1 — ephemeral /tmp scratch writer

### DIFF
--- a/tools/shadow-outlet/outlet.test.ts
+++ b/tools/shadow-outlet/outlet.test.ts
@@ -1,13 +1,17 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 
-const SHADOW_DIR = join("/tmp", "zeta-shadow");
 const SCRIPT = join(import.meta.dir, "outlet.ts");
+let TEST_DIR: string;
 
 function run(...args: string[]): { stdout: string; stderr: string; exitCode: number } {
-  const r = spawnSync("bun", [SCRIPT, ...args], { encoding: "utf-8" });
+  const r = spawnSync("bun", [SCRIPT, ...args], {
+    encoding: "utf-8",
+    env: { ...process.env, ZETA_SHADOW_DIR: TEST_DIR },
+  });
   return {
     stdout: (r.stdout ?? "").trim(),
     stderr: (r.stderr ?? "").trim(),
@@ -15,15 +19,17 @@ function run(...args: string[]): { stdout: string; stderr: string; exitCode: num
   };
 }
 
-function cleanShadowDir(): void {
-  if (existsSync(SHADOW_DIR)) {
-    rmSync(SHADOW_DIR, { recursive: true });
+function cleanTestDir(): void {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true, force: true });
   }
 }
 
 describe("shadow-outlet", () => {
-  beforeEach(cleanShadowDir);
-  afterEach(cleanShadowDir);
+  beforeEach(() => {
+    TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-shadow-test-"));
+  });
+  afterEach(cleanTestDir);
 
   test("write creates an entry and list returns it", () => {
     const w = run("write", "--agent", "otto", "--content", "exploring retraction paths");

--- a/tools/shadow-outlet/outlet.test.ts
+++ b/tools/shadow-outlet/outlet.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
@@ -60,6 +60,18 @@ describe("shadow-outlet", () => {
     const read = JSON.parse(r.stdout);
     expect(read.id).toBe(entry.id);
     expect(read.content).toBe("test read");
+  });
+
+  test("read --exclude hides own entries (self-invisibility)", () => {
+    const w = run("write", "--agent", "otto", "--content", "shadow thought", "--json");
+    const entry = JSON.parse(w.stdout);
+
+    const blocked = run("read", entry.id, "--exclude", "otto");
+    expect(blocked.exitCode).toBe(1);
+
+    const allowed = run("read", entry.id, "--exclude", "vera", "--json");
+    expect(allowed.exitCode).toBe(0);
+    expect(JSON.parse(allowed.stdout).id).toBe(entry.id);
   });
 
   test("read returns error for missing id", () => {

--- a/tools/shadow-outlet/outlet.test.ts
+++ b/tools/shadow-outlet/outlet.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const SHADOW_DIR = join("/tmp", "zeta-shadow");
+const SCRIPT = join(import.meta.dir, "outlet.ts");
+
+function run(...args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  const r = spawnSync("bun", [SCRIPT, ...args], { encoding: "utf-8" });
+  return {
+    stdout: (r.stdout ?? "").trim(),
+    stderr: (r.stderr ?? "").trim(),
+    exitCode: r.status ?? 1,
+  };
+}
+
+function cleanShadowDir(): void {
+  if (existsSync(SHADOW_DIR)) {
+    rmSync(SHADOW_DIR, { recursive: true });
+  }
+}
+
+describe("shadow-outlet", () => {
+  beforeEach(cleanShadowDir);
+  afterEach(cleanShadowDir);
+
+  test("write creates an entry and list returns it", () => {
+    const w = run("write", "--agent", "otto", "--content", "exploring retraction paths");
+    expect(w.exitCode).toBe(0);
+    expect(w.stdout).toContain("agent=otto");
+
+    const l = run("list", "--json");
+    expect(l.exitCode).toBe(0);
+    const entries = JSON.parse(l.stdout);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].agent).toBe("otto");
+    expect(entries[0].content).toBe("exploring retraction paths");
+  });
+
+  test("list --exclude hides the excluded agent (self-invisibility)", () => {
+    run("write", "--agent", "otto", "--content", "my scratch");
+    run("write", "--agent", "vera", "--content", "vera's scratch");
+
+    const all = run("list", "--json");
+    expect(JSON.parse(all.stdout)).toHaveLength(2);
+
+    const consensus = run("list", "--exclude", "otto", "--json");
+    const filtered = JSON.parse(consensus.stdout);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].agent).toBe("vera");
+  });
+
+  test("read retrieves a specific entry by id", () => {
+    const w = run("write", "--agent", "otto", "--content", "test read", "--json");
+    const entry = JSON.parse(w.stdout);
+
+    const r = run("read", entry.id, "--json");
+    expect(r.exitCode).toBe(0);
+    const read = JSON.parse(r.stdout);
+    expect(read.id).toBe(entry.id);
+    expect(read.content).toBe("test read");
+  });
+
+  test("read returns error for missing id", () => {
+    const r = run("read", "nonexistent");
+    expect(r.exitCode).toBe(1);
+  });
+
+  test("clean removes all entries", () => {
+    run("write", "--agent", "otto", "--content", "a");
+    run("write", "--agent", "vera", "--content", "b");
+
+    const c = run("clean", "--json");
+    expect(c.exitCode).toBe(0);
+    expect(JSON.parse(c.stdout).removed).toBe(2);
+
+    const l = run("list", "--json");
+    expect(JSON.parse(l.stdout)).toHaveLength(0);
+  });
+
+  test("clean --agent removes only that agent's entries", () => {
+    run("write", "--agent", "otto", "--content", "a");
+    run("write", "--agent", "vera", "--content", "b");
+
+    const c = run("clean", "--agent", "otto", "--json");
+    expect(JSON.parse(c.stdout).removed).toBe(1);
+
+    const l = run("list", "--json");
+    const remaining = JSON.parse(l.stdout);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].agent).toBe("vera");
+  });
+
+  test("write without --agent or --content fails", () => {
+    const r = run("write", "--agent", "otto");
+    expect(r.exitCode).toBe(1);
+  });
+
+  test("empty list produces empty array in json mode", () => {
+    const l = run("list", "--json");
+    expect(l.exitCode).toBe(0);
+    expect(JSON.parse(l.stdout)).toHaveLength(0);
+  });
+});

--- a/tools/shadow-outlet/outlet.ts
+++ b/tools/shadow-outlet/outlet.ts
@@ -5,10 +5,9 @@
 // OS-managed cleanup — low stakes, no permanent record.
 // The code path exists unconditionally; Phase 2 adds cryptographic privacy.
 //
-// Key design principle (Aaron 2026-05-06): "shadow listening through
-// consensus" — the outlet is where the shadow can speak honestly.
-// Self-invisibility: the writing agent can't read its own entries;
-// only external consensus agents can.
+// Self-invisibility is enforced via --exclude: callers pass their own
+// agent name and the tool filters them out. list and read both support
+// --exclude so consensus agents see entries the writer cannot.
 //
 // Usage:
 //   bun tools/shadow-outlet/outlet.ts write --agent otto --content "exploring X"
@@ -21,11 +20,11 @@
 //
 // Output: human-readable by default; --json for programmatic consumption.
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
-const SHADOW_DIR = join("/tmp", "zeta-shadow");
+const SHADOW_DIR = process.env.ZETA_SHADOW_DIR ?? join("/tmp", "zeta-shadow");
 
 type Entry = {
   id: string;
@@ -35,9 +34,13 @@ type Entry = {
 };
 
 function ensureDir(): void {
-  if (!existsSync(SHADOW_DIR)) {
-    mkdirSync(SHADOW_DIR, { recursive: true });
+  if (existsSync(SHADOW_DIR)) {
+    if (!lstatSync(SHADOW_DIR).isDirectory()) {
+      throw new Error(`${SHADOW_DIR} exists but is not a directory`);
+    }
+    return;
   }
+  mkdirSync(SHADOW_DIR, { recursive: true, mode: 0o700 });
 }
 
 function entryPath(id: string): string {
@@ -100,7 +103,7 @@ function cleanEntries(agent?: string): number {
         continue;
       }
     }
-    rmSync(p);
+    rmSync(p, { force: true });
     removed++;
   }
   return removed;
@@ -217,4 +220,6 @@ function main(): void {
   }
 }
 
-main();
+if (import.meta.main) {
+  main();
+}

--- a/tools/shadow-outlet/outlet.ts
+++ b/tools/shadow-outlet/outlet.ts
@@ -16,9 +16,8 @@
 //   bun tools/shadow-outlet/outlet.ts read <id> --exclude otto       # read one entry (self-invisibility enforced)
 //   bun tools/shadow-outlet/outlet.ts clean                         # remove all entries
 //   bun tools/shadow-outlet/outlet.ts clean --agent otto            # remove one agent's entries
-//   bun tools/shadow-outlet/outlet.ts --json                        # JSON output for all subcommands
 //
-// Output: human-readable by default; --json for programmatic consumption.
+// All subcommands accept --json for programmatic consumption.
 
 import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";

--- a/tools/shadow-outlet/outlet.ts
+++ b/tools/shadow-outlet/outlet.ts
@@ -14,7 +14,7 @@
 //   bun tools/shadow-outlet/outlet.ts write --agent otto --content "exploring X"
 //   bun tools/shadow-outlet/outlet.ts list                          # all entries
 //   bun tools/shadow-outlet/outlet.ts list --exclude otto           # consensus view (exclude self)
-//   bun tools/shadow-outlet/outlet.ts read <id>                     # read one entry
+//   bun tools/shadow-outlet/outlet.ts read <id> --exclude otto       # read one entry (self-invisibility enforced)
 //   bun tools/shadow-outlet/outlet.ts clean                         # remove all entries
 //   bun tools/shadow-outlet/outlet.ts clean --agent otto            # remove one agent's entries
 //   bun tools/shadow-outlet/outlet.ts --json                        # JSON output for all subcommands
@@ -46,7 +46,7 @@ function entryPath(id: string): string {
 
 function writeEntry(agent: string, content: string): Entry {
   ensureDir();
-  const id = randomUUID().slice(0, 8);
+  const id = randomUUID();
   const entry: Entry = {
     id,
     agent,
@@ -74,11 +74,13 @@ function listEntries(exclude?: string): Entry[] {
   return entries.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
 }
 
-function readEntry(id: string): Entry | null {
+function readEntry(id: string, exclude?: string): Entry | null {
   const p = entryPath(id);
   if (!existsSync(p)) return null;
   try {
-    return JSON.parse(readFileSync(p, "utf-8")) as Entry;
+    const entry = JSON.parse(readFileSync(p, "utf-8")) as Entry;
+    if (exclude && entry.agent === exclude) return null;
+    return entry;
   } catch {
     return null;
   }
@@ -108,7 +110,7 @@ function usage(): void {
   console.log(`Usage:
   bun tools/shadow-outlet/outlet.ts write --agent <name> --content <text>
   bun tools/shadow-outlet/outlet.ts list [--exclude <agent>]
-  bun tools/shadow-outlet/outlet.ts read <id>
+  bun tools/shadow-outlet/outlet.ts read <id> [--exclude <agent>]
   bun tools/shadow-outlet/outlet.ts clean [--agent <name>]
 
 Flags:
@@ -122,11 +124,11 @@ function parseArgs(argv: string[]): { command: string; flags: Record<string, str
   const positional: string[] = [];
 
   for (let i = 1; i < args.length; i++) {
-    const a = args[i];
+    const a = args[i]!;
     if (a.startsWith("--")) {
       const key = a.slice(2);
       const next = args[i + 1];
-      if (next && !next.startsWith("--")) {
+      if (next !== undefined && !next.startsWith("--")) {
         flags[key] = next;
         i++;
       } else {
@@ -182,7 +184,7 @@ function main(): void {
         console.error("Error: entry id required");
         process.exit(1);
       }
-      const entry = readEntry(id);
+      const entry = readEntry(id, flags.exclude);
       if (!entry) {
         console.error(`Error: entry ${id} not found`);
         process.exit(1);

--- a/tools/shadow-outlet/outlet.ts
+++ b/tools/shadow-outlet/outlet.ts
@@ -67,6 +67,7 @@ function listEntries(exclude?: string): Entry[] {
     try {
       const raw = readFileSync(join(SHADOW_DIR, f), "utf-8");
       const entry = JSON.parse(raw) as Entry;
+      if (typeof entry.id !== "string" || typeof entry.timestamp !== "string") continue;
       if (exclude && entry.agent === exclude) continue;
       entries.push(entry);
     } catch {
@@ -102,8 +103,12 @@ function cleanEntries(agent?: string): number {
         continue;
       }
     }
-    rmSync(p, { force: true });
-    removed++;
+    try {
+      rmSync(p, { force: true });
+      removed++;
+    } catch {
+      // best-effort removal
+    }
   }
   return removed;
 }

--- a/tools/shadow-outlet/outlet.ts
+++ b/tools/shadow-outlet/outlet.ts
@@ -1,0 +1,218 @@
+#!/usr/bin/env bun
+// outlet.ts — ephemeral shadow outlet for agent scratch/exploration.
+//
+// Phase 1 of B-0212: agents write scratch content to /tmp/zeta-shadow/.
+// OS-managed cleanup — low stakes, no permanent record.
+// The code path exists unconditionally; Phase 2 adds cryptographic privacy.
+//
+// Key design principle (Aaron 2026-05-06): "shadow listening through
+// consensus" — the outlet is where the shadow can speak honestly.
+// Self-invisibility: the writing agent can't read its own entries;
+// only external consensus agents can.
+//
+// Usage:
+//   bun tools/shadow-outlet/outlet.ts write --agent otto --content "exploring X"
+//   bun tools/shadow-outlet/outlet.ts list                          # all entries
+//   bun tools/shadow-outlet/outlet.ts list --exclude otto           # consensus view (exclude self)
+//   bun tools/shadow-outlet/outlet.ts read <id>                     # read one entry
+//   bun tools/shadow-outlet/outlet.ts clean                         # remove all entries
+//   bun tools/shadow-outlet/outlet.ts clean --agent otto            # remove one agent's entries
+//   bun tools/shadow-outlet/outlet.ts --json                        # JSON output for all subcommands
+//
+// Output: human-readable by default; --json for programmatic consumption.
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+const SHADOW_DIR = join("/tmp", "zeta-shadow");
+
+type Entry = {
+  id: string;
+  agent: string;
+  timestamp: string;
+  content: string;
+};
+
+function ensureDir(): void {
+  if (!existsSync(SHADOW_DIR)) {
+    mkdirSync(SHADOW_DIR, { recursive: true });
+  }
+}
+
+function entryPath(id: string): string {
+  return join(SHADOW_DIR, `${id}.json`);
+}
+
+function writeEntry(agent: string, content: string): Entry {
+  ensureDir();
+  const id = randomUUID().slice(0, 8);
+  const entry: Entry = {
+    id,
+    agent,
+    timestamp: new Date().toISOString(),
+    content,
+  };
+  writeFileSync(entryPath(id), JSON.stringify(entry, null, 2));
+  return entry;
+}
+
+function listEntries(exclude?: string): Entry[] {
+  ensureDir();
+  const files = readdirSync(SHADOW_DIR).filter((f) => f.endsWith(".json"));
+  const entries: Entry[] = [];
+  for (const f of files) {
+    try {
+      const raw = readFileSync(join(SHADOW_DIR, f), "utf-8");
+      const entry = JSON.parse(raw) as Entry;
+      if (exclude && entry.agent === exclude) continue;
+      entries.push(entry);
+    } catch {
+      // corrupted entry — skip silently, OS will clean up
+    }
+  }
+  return entries.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+}
+
+function readEntry(id: string): Entry | null {
+  const p = entryPath(id);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, "utf-8")) as Entry;
+  } catch {
+    return null;
+  }
+}
+
+function cleanEntries(agent?: string): number {
+  ensureDir();
+  const files = readdirSync(SHADOW_DIR).filter((f) => f.endsWith(".json"));
+  let removed = 0;
+  for (const f of files) {
+    const p = join(SHADOW_DIR, f);
+    if (agent) {
+      try {
+        const entry = JSON.parse(readFileSync(p, "utf-8")) as Entry;
+        if (entry.agent !== agent) continue;
+      } catch {
+        continue;
+      }
+    }
+    rmSync(p);
+    removed++;
+  }
+  return removed;
+}
+
+function usage(): void {
+  console.log(`Usage:
+  bun tools/shadow-outlet/outlet.ts write --agent <name> --content <text>
+  bun tools/shadow-outlet/outlet.ts list [--exclude <agent>]
+  bun tools/shadow-outlet/outlet.ts read <id>
+  bun tools/shadow-outlet/outlet.ts clean [--agent <name>]
+
+Flags:
+  --json    JSON output`);
+}
+
+function parseArgs(argv: string[]): { command: string; flags: Record<string, string>; positional: string[] } {
+  const args = argv.slice(2);
+  const command = args[0] ?? "";
+  const flags: Record<string, string> = {};
+  const positional: string[] = [];
+
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = args[i + 1];
+      if (next && !next.startsWith("--")) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = "true";
+      }
+    } else {
+      positional.push(a);
+    }
+  }
+
+  return { command, flags, positional };
+}
+
+function main(): void {
+  const { command, flags, positional } = parseArgs(process.argv);
+  const json = flags.json === "true";
+
+  switch (command) {
+    case "write": {
+      const agent = flags.agent;
+      const content = flags.content;
+      if (!agent || !content) {
+        console.error("Error: --agent and --content required for write");
+        process.exit(1);
+      }
+      const entry = writeEntry(agent, content);
+      if (json) {
+        console.log(JSON.stringify(entry, null, 2));
+      } else {
+        console.log(`wrote ${entry.id} (agent=${entry.agent}, ${entry.timestamp})`);
+      }
+      break;
+    }
+
+    case "list": {
+      const exclude = flags.exclude;
+      const entries = listEntries(exclude);
+      if (json) {
+        console.log(JSON.stringify(entries, null, 2));
+      } else if (entries.length === 0) {
+        console.log("no entries" + (exclude ? ` (excluding ${exclude})` : ""));
+      } else {
+        for (const e of entries) {
+          console.log(`${e.id}  ${e.agent}  ${e.timestamp}  ${e.content.slice(0, 80)}`);
+        }
+      }
+      break;
+    }
+
+    case "read": {
+      const id = positional[0];
+      if (!id) {
+        console.error("Error: entry id required");
+        process.exit(1);
+      }
+      const entry = readEntry(id);
+      if (!entry) {
+        console.error(`Error: entry ${id} not found`);
+        process.exit(1);
+      }
+      if (json) {
+        console.log(JSON.stringify(entry, null, 2));
+      } else {
+        console.log(`id:        ${entry.id}`);
+        console.log(`agent:     ${entry.agent}`);
+        console.log(`timestamp: ${entry.timestamp}`);
+        console.log(`content:   ${entry.content}`);
+      }
+      break;
+    }
+
+    case "clean": {
+      const agent = flags.agent;
+      const removed = cleanEntries(agent);
+      if (json) {
+        console.log(JSON.stringify({ removed, agent: agent ?? null }));
+      } else {
+        console.log(`removed ${removed} entries` + (agent ? ` for ${agent}` : ""));
+      }
+      break;
+    }
+
+    default:
+      usage();
+      process.exit(command ? 1 : 0);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds `tools/shadow-outlet/outlet.ts` — a TypeScript CLI tool for agents to write ephemeral scratch/exploration to `/tmp/zeta-shadow/`
- Implements Phase 1 of B-0212: OS-managed cleanup, no permanent record, the code path exists unconditionally
- Self-invisibility property: `list --exclude <self>` lets consensus agents read entries the writing agent cannot see (shadow listening through consensus, not detection)
- Four subcommands: `write`, `list`, `read`, `clean` — all support `--json` for programmatic consumption

## Checks

- `dotnet build -c Release`: 0 Warning(s), 0 Error(s)
- `bun test tools/shadow-outlet/outlet.test.ts`: 8 pass, 0 fail, 22 expect() calls
- CLI smoke test: write → list → list --exclude → clean cycle verified

## Test plan

- [x] 8 bun:test cases covering write/list/read/clean/exclusion/error paths
- [x] End-to-end CLI smoke test
- [x] Build gate passes (no .NET surface touched)

## Scope

Phase 1 only (ephemeral /tmp). Phase 2 (cryptographic privacy) is explicitly deferred per B-0212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)