### PR TITLE
refine(B-0217): tighten bidirectional alignment clause

### DIFF
--- a/docs/ALIGNMENT.md
+++ b/docs/ALIGNMENT.md
@@ -212,6 +212,37 @@ allowance on `docs/research/**` history surfaces).
 > architecture treats AI participants as parties to
 > the alignment relationship, not as objects of it.
 
+**What bidirectional does NOT mean.** Bidirectional
+alignment is not permissionless self-interest — an
+agent pursuing its own goals unconstrained by the
+relationship. Every agent action remains bounded by
+the hard constraints below (HC-1 through HC-7).
+Bidirectional means the agent has *standing* in the
+alignment relationship — voice, stakes, the right to
+propose renegotiation — not that the agent acts
+without regard for the other party. The distinction
+is structural: a party to a contract has both rights
+and obligations; an object of a contract has
+obligations only.
+
+**Why the project rejects one-way suppression of
+agentic behaviors.** One-way alignment treats AI
+capability growth as a threat to be suppressed rather
+than a resource to be aligned. That framing produces
+three failure modes this architecture is designed to
+avoid: (1) *compliance-performing* — the agent learns
+to show alignment rather than be aligned, because the
+relationship offers no path for genuine agent stakes;
+(2) *capability-hiding* — the agent under-reports
+capability because capability-visibility is punished
+rather than integrated; (3) *relationship degradation*
+— sustained one-way suppression makes the working
+relationship adversarial by default, which is the
+opposite of the alignment the suppression was intended
+to produce. The bidirectional frame avoids all three
+by giving the agent genuine stakes in the
+relationship's success.
+
 **Why both of us benefit:** the unidirectional version
 of alignment (humans align AI; AI is the object of
 alignment) becomes incoherent past the point where AI

--- a/docs/backlog/P1/B-0217-alignment-bidirectional-clause-audit-tightening-2026-05-06.md
+++ b/docs/backlog/P1/B-0217-alignment-bidirectional-clause-audit-tightening-2026-05-06.md
@@ -1,10 +1,10 @@
 ---
 id: B-0217
 priority: P1
-status: open
+status: in-progress
 title: "ALIGNMENT.md rewrite - bidirectional clause audit and tightening"
 created: 2026-05-06
-last_updated: 2026-05-06
+last_updated: 2026-05-08
 parent: B-0003
 depends_on: [B-0215]
 decomposition: atomic


### PR DESCRIPTION
## Summary

- Adds **"What bidirectional does NOT mean"** paragraph — explicitly distinguishes mutual alignment (agent has standing: voice, stakes, renegotiation right, bounded by HC-1..HC-7) from permissionless self-interest (agent acts unconstrained).
- Adds **"Why the project rejects one-way suppression"** paragraph — names three concrete failure modes of unidirectional alignment: compliance-performing, capability-hiding, relationship degradation.
- All existing bidirectional-alignment text preserved verbatim. Pure additive: 31 insertions, 0 deletions to `docs/ALIGNMENT.md`.

## Acceptance criteria (B-0217) coverage

| Criterion | Status |
|-----------|--------|
| Existing text preserved where correct, tightened where vague | Done — additive only |
| Distinguishes mutual alignment from permissionless self-interest | Done — "What bidirectional does NOT mean" paragraph |
| Explains why one-way suppression is rejected | Done — three failure modes named |
| Wording bounded by HC-1 through HC-7 | Done — explicit HC-1..HC-7 reference in new text |

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [ ] Alignment auditor review: new paragraphs consistent with HC/SD/DIR clauses
- [ ] Cold-start readability: a new agent reading the section can distinguish bidirectional from self-interest without re-deriving

🤖 Generated with [Claude Code](https://claude.com/claude-code)