### PR TITLE
feat(B-0264): wire refresh-worldview.ts as canonical pre-decide in tick checklist

### DIFF
--- a/docs/AUTONOMOUS-LOOP.md
+++ b/docs/AUTONOMOUS-LOOP.md
@@ -253,9 +253,24 @@ wait for instruction. Priority ladder:
    `docs/hygiene-history/ticks/2026/05/03/0918Z.md`, plus
    PR #1366 (TS port of the check script).
 
-1. **Open-PR hygiene first.** Before picking speculative
-   work, audit the open PR pool via
-   `gh pr list --state open --json number,title,mergeStateStatus,mergeable,isCrossRepository,headRepositoryOwner,autoMergeRequest`.
+1. **Refresh worldview, then open-PR hygiene.** Before
+   picking speculative work, run the canonical pre-decide
+   refresh:
+
+   ```
+   bun tools/github/refresh-worldview.ts
+   ```
+
+   This replaces ad-hoc `gh pr list` / `git status` /
+   `git log` chains with a single structured JSON snapshot
+   (open PRs, recent merges, open issues, git state,
+   backlog delta, claim branches, branch state, pending
+   CI, and a one-line `summary` for cross-cutting drift
+   detection). If the refresh fails, stop and report the
+   exact failure as the blocker instead of guessing from
+   stale state.
+
+   Then audit the open PR pool from the `openPRs` array.
    For each open PR:
    - **Verify fork-status live** (`isCrossRepository` +
      `headRepositoryOwner.login`) rather than carrying

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -110,7 +110,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0256](backlog/P1/B-0256-model-recursion-exploit-class-metasploit-ida-pro-mapping-2026-05-07.md)** Model recursion exploit class — Metasploit/IDA Pro mapping for AI models
 - [x] **[B-0262](backlog/P1/B-0262-refresh-worldview-scaffold-open-prs-recent-merges-2026-05-08.md)** refresh-worldview scaffold - open-PR list + recent-merges query
 - [x] **[B-0263](backlog/P1/B-0263-refresh-worldview-backlog-delta-claims-branch-state-2026-05-08.md)** refresh-worldview — backlog delta + claim inventory + branch state
-- [ ] **[B-0264](backlog/P1/B-0264-refresh-worldview-tick-integration-canonical-pre-decide-2026-05-08.md)** refresh-worldview — integrate into tick scripts as canonical pre-decide
+- [x] **[B-0264](backlog/P1/B-0264-refresh-worldview-tick-integration-canonical-pre-decide-2026-05-08.md)** refresh-worldview — integrate into tick scripts as canonical pre-decide
 - [x] **[B-0265](backlog/P1/B-0265-ruleset-split-ci-gate-ruleset-2026-05-08.md)** GitHub ruleset split — CI gate ruleset (required status checks)
 - [ ] **[B-0266](backlog/P1/B-0266-ruleset-split-review-policy-ruleset-2026-05-08.md)** GitHub ruleset split — review policy ruleset (conversation resolution + reviews)
 - [ ] **[B-0267](backlog/P1/B-0267-ruleset-split-safety-ruleset-2026-05-08.md)** GitHub ruleset split — safety ruleset (deletion + force-push + linear history)

--- a/docs/backlog/P1/B-0264-refresh-worldview-tick-integration-canonical-pre-decide-2026-05-08.md
+++ b/docs/backlog/P1/B-0264-refresh-worldview-tick-integration-canonical-pre-decide-2026-05-08.md
@@ -15,12 +15,12 @@ type: friction-reducer
 
 # B-0264 — refresh-worldview tick integration
 
-Third child of B-0159. Wire refresh.ts into all agent
-tick scripts as the canonical pre-decide refresh call.
+Third child of B-0159. Wire refresh-worldview.ts into all
+agent tick scripts as the canonical pre-decide refresh call.
 
 ## Acceptance criteria
 
-- Otto's tick calls refresh.ts before picking work
-- Vera's tick calls refresh.ts before picking work
-- Lior's tick calls refresh.ts before reporting status
+- Otto's tick calls refresh-worldview.ts before picking work
+- Vera's tick calls refresh-worldview.ts before picking work
+- Lior's tick calls refresh-worldview.ts before reporting status
 - Summary field in JSON enables cross-cutting drift detection

--- a/docs/backlog/P1/B-0264-refresh-worldview-tick-integration-canonical-pre-decide-2026-05-08.md
+++ b/docs/backlog/P1/B-0264-refresh-worldview-tick-integration-canonical-pre-decide-2026-05-08.md
@@ -1,13 +1,14 @@
 ---
 id: B-0264
 priority: P1
-status: open
+status: closed
 title: "refresh-worldview — integrate into tick scripts as canonical pre-decide"
 created: 2026-05-08
-last_updated: 2026-05-08
+last_updated: 2026-05-09
+closed_by: "PR via claim/B-0264-refresh-worldview-tick-integration"
 parent: B-0159
 depends_on: [B-0262, B-0263]
-classification: blocked-on-B-0262
+classification: buildable-now
 decomposition: atomic
 type: friction-reducer
 ---

--- a/tools/github/refresh-worldview.ts
+++ b/tools/github/refresh-worldview.ts
@@ -22,6 +22,7 @@
 //     "owner": "Lucent-Financial-Group",
 //     "repo": "Zeta",
 //     "queriedAt": "2026-05-08T12:00:00.000Z",
+//     "summary": "1 open PR, 3 recent merges, ...",
 //     "openPRs": [ { number, title, headRefName, ... }, ... ],
 //     "recentMerges": [ { number, title, mergedAt }, ... ],
 //     "openIssues": [ { number, title, labels, createdAt }, ... ],
@@ -52,6 +53,8 @@ interface OpenPR {
   updatedAt: string;
   autoMergeRequest: { enabledAt?: string } | null;
   reviewDecision: string;
+  isCrossRepository: boolean;
+  headRepositoryOwner: { login: string };
 }
 
 interface MergedPR {
@@ -188,7 +191,7 @@ function fetchOpenPRs(owner: string, repo: string, limit: number): OpenPR[] {
       "--state",
       "open",
       "--json",
-      "number,title,headRefName,createdAt,updatedAt,autoMergeRequest,reviewDecision",
+      "number,title,headRefName,createdAt,updatedAt,autoMergeRequest,reviewDecision,isCrossRepository,headRepositoryOwner",
       "--limit",
       String(limit),
     ],
@@ -460,6 +463,10 @@ function parseArgs(argv: string[]): ParsedArgs {
 
 // --- Summary builder ---
 
+function plural(n: number, singular: string, pluralForm?: string): string {
+  return `${n} ${n === 1 ? singular : (pluralForm ?? singular + "s")}`;
+}
+
 function buildSummary(
   openPRs: OpenPR[],
   recentMerges: MergedPR[],
@@ -471,14 +478,15 @@ function buildSummary(
   pendingCI: PendingCIRun[],
 ): string {
   const parts: string[] = [];
-  parts.push(`${openPRs.length} open PRs`);
-  parts.push(`${recentMerges.length} recent merges`);
-  parts.push(`${openIssues.length} open issues`);
-  parts.push(`${claims.length} claims`);
-  parts.push(`${backlogDelta.totalFiles} backlog items`);
-  if (pendingCI.length > 0) parts.push(`${pendingCI.length} CI runs pending`);
+  parts.push(plural(openPRs.length, "open PR"));
+  parts.push(plural(recentMerges.length, "recent merge"));
+  parts.push(plural(openIssues.length, "open issue"));
+  parts.push(plural(claims.length, "claim"));
+  parts.push(plural(backlogDelta.totalFiles, "backlog item"));
+  if (pendingCI.length > 0)
+    parts.push(plural(pendingCI.length, "CI run") + " pending");
   if (gitState.uncommittedFiles.length > 0)
-    parts.push(`${gitState.uncommittedFiles.length} dirty files`);
+    parts.push(plural(gitState.uncommittedFiles.length, "dirty file"));
   if (branchState.behind > 0) parts.push(`${branchState.behind} behind`);
   if (branchState.ahead > 0) parts.push(`${branchState.ahead} ahead`);
   return parts.join(", ");

--- a/tools/github/refresh-worldview.ts
+++ b/tools/github/refresh-worldview.ts
@@ -105,6 +105,7 @@ export interface WorldviewSnapshot {
   owner: string;
   repo: string;
   queriedAt: string;
+  summary: string;
   openPRs: OpenPR[];
   recentMerges: MergedPR[];
   openIssues: OpenIssue[];
@@ -457,6 +458,32 @@ function parseArgs(argv: string[]): ParsedArgs {
   return out;
 }
 
+// --- Summary builder ---
+
+function buildSummary(
+  openPRs: OpenPR[],
+  recentMerges: MergedPR[],
+  openIssues: OpenIssue[],
+  gitState: GitState,
+  backlogDelta: BacklogDelta,
+  claims: ClaimBranch[],
+  branchState: BranchState,
+  pendingCI: PendingCIRun[],
+): string {
+  const parts: string[] = [];
+  parts.push(`${openPRs.length} open PRs`);
+  parts.push(`${recentMerges.length} recent merges`);
+  parts.push(`${openIssues.length} open issues`);
+  parts.push(`${claims.length} claims`);
+  parts.push(`${backlogDelta.totalFiles} backlog items`);
+  if (pendingCI.length > 0) parts.push(`${pendingCI.length} CI runs pending`);
+  if (gitState.uncommittedFiles.length > 0)
+    parts.push(`${gitState.uncommittedFiles.length} dirty files`);
+  if (branchState.behind > 0) parts.push(`${branchState.behind} behind`);
+  if (branchState.ahead > 0) parts.push(`${branchState.ahead} ahead`);
+  return parts.join(", ");
+}
+
 // --- Main ---
 
 export function main(argv: string[]): number {
@@ -478,10 +505,22 @@ export function main(argv: string[]): number {
   const branchState = fetchBranchState();
   const pendingCI = fetchPendingCI(args.owner, args.repo);
 
+  const summary = buildSummary(
+    openPRs,
+    recentMerges,
+    openIssues,
+    gitState,
+    backlogDelta,
+    claims,
+    branchState,
+    pendingCI,
+  );
+
   const snapshot: WorldviewSnapshot = {
     owner: args.owner,
     repo: args.repo,
     queriedAt: new Date().toISOString(),
+    summary,
     openPRs,
     recentMerges,
     openIssues,


### PR DESCRIPTION
## Summary

- Add `summary` field to `refresh-worldview.ts` output — one-line human-readable snapshot (e.g. `"0 open PRs, 5 recent merges, 20 open issues, 42 claims, 343 backlog items"`) enabling cross-cutting drift detection across agents
- Update `docs/AUTONOMOUS-LOOP.md` step 2 to call `bun tools/github/refresh-worldview.ts` as the canonical pre-decide refresh, replacing ad-hoc `gh pr list --state open --json ...` chains
- Close B-0264 (third child of B-0159; dependencies B-0262 and B-0263 already closed)

## Test plan

- [x] `bun tools/github/refresh-worldview.ts` runs and outputs `summary` field in JSON
- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [ ] Verify next autonomous tick follows the updated checklist and calls refresh-worldview.ts before picking work

🤖 Generated with [Claude Code](https://claude.com/claude-code)