### PR TITLE
feat(B-0266): Review Policy ruleset migration script

### DIFF
--- a/docs/backlog/P1/B-0266-ruleset-split-review-policy-ruleset-2026-05-08.md
+++ b/docs/backlog/P1/B-0266-ruleset-split-review-policy-ruleset-2026-05-08.md
@@ -36,6 +36,7 @@ policy (required conversation resolution, code review settings).
 Migration script: `tools/migrations/b0266-review-policy-ruleset.ts`
 
 Two API operations:
+
 1. `POST /repos/{owner}/{repo}/rulesets` — create "Review Policy"
    with `pull_request` (thread resolution, squash-only) +
    `copilot_code_review` (draft + push review)

--- a/docs/backlog/P1/B-0266-ruleset-split-review-policy-ruleset-2026-05-08.md
+++ b/docs/backlog/P1/B-0266-ruleset-split-review-policy-ruleset-2026-05-08.md
@@ -4,7 +4,7 @@ priority: P1
 status: open
 title: "GitHub ruleset split — review policy ruleset (conversation resolution + reviews)"
 created: 2026-05-08
-last_updated: 2026-05-08
+last_updated: 2026-05-09
 parent: B-0155
 depends_on: [B-0265]
 classification: buildable-now
@@ -17,8 +17,42 @@ type: friction-reducer
 Second child of B-0155. Create a dedicated ruleset for review
 policy (required conversation resolution, code review settings).
 
+## Pre-start checklist
+
+- [x] Prior-art search: B-0265 (CI Gate, closed) followed same
+  pattern — API creation + snapshot update. Commit cd9e0483.
+- [x] Dependency check: B-0265 (CI Gate) is closed. No blockers.
+- [x] Parent B-0155 reviewed — three-ruleset target documented in
+  `docs/GITHUB-SETTINGS.md` migration matrix.
+
 ## Acceptance criteria
 
 - New ruleset "Review Policy" created
 - Conversation resolution migrated from branch protection
 - Copilot code review settings preserved
+
+## Implementation
+
+Migration script: `tools/migrations/b0266-review-policy-ruleset.ts`
+
+Two API operations:
+1. `POST /repos/{owner}/{repo}/rulesets` — create "Review Policy"
+   with `pull_request` (thread resolution, squash-only) +
+   `copilot_code_review` (draft + push review)
+2. `PUT /repos/{owner}/{repo}/rulesets/15256879` — update "Default"
+   to keep only `deletion`, `non_fast_forward`,
+   `required_linear_history`
+
+After API calls, re-snapshot via
+`bun tools/hygiene/snapshot-github-settings.ts`.
+
+### Run
+
+```bash
+bun tools/migrations/b0266-review-policy-ruleset.ts
+```
+
+Dry run first:
+```bash
+bun tools/migrations/b0266-review-policy-ruleset.ts --dry-run
+```

--- a/tools/migrations/b0266-review-policy-ruleset.ts
+++ b/tools/migrations/b0266-review-policy-ruleset.ts
@@ -111,7 +111,7 @@ const updatedDefaultPayload = {
   ],
 };
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const dryRun = process.argv.includes("--dry-run");
 
   console.log("B-0266: Review Policy ruleset migration");
@@ -127,17 +127,32 @@ async function main(): Promise<void> {
     );
     console.log(JSON.stringify(updatedDefaultPayload, null, 2));
     console.log();
-    console.log("[DRY RUN] Would re-snapshot expected.json");
+    console.log("[DRY RUN] Would re-snapshot expected.json for same repo");
     return;
   }
 
-  console.log("Step 1: Creating Review Policy ruleset...");
-  const created = (await ghApi(
-    "POST",
+  // Preflight: ensure no duplicate "Review Policy" ruleset (idempotency)
+  console.log("Preflight: checking for existing Review Policy ruleset...");
+  const existingRulesets = (await ghApi(
+    "GET",
     `repos/${OWNER}/${REPO}/rulesets`,
-    reviewPolicyPayload,
-  )) as { id: number; name: string };
-  console.log(`  Created ruleset "${created.name}" (id: ${created.id})`);
+  )) as Array<{ id: number; name: string }>;
+  const existingReviewPolicy = existingRulesets.find(
+    (r) => r.name === "Review Policy",
+  );
+  if (existingReviewPolicy) {
+    console.log(
+      `  "Review Policy" ruleset already exists (id: ${existingReviewPolicy.id}) — skipping create`,
+    );
+  } else {
+    console.log("Step 1: Creating Review Policy ruleset...");
+    const created = (await ghApi(
+      "POST",
+      `repos/${OWNER}/${REPO}/rulesets`,
+      reviewPolicyPayload,
+    )) as { id: number; name: string };
+    console.log(`  Created ruleset "${created.name}" (id: ${created.id})`);
+  }
   console.log();
 
   console.log(
@@ -151,10 +166,12 @@ async function main(): Promise<void> {
   console.log("  Default ruleset updated (3 rules: deletion, non_fast_forward, required_linear_history)");
   console.log();
 
-  console.log("Step 3: Re-snapshotting expected.json...");
+  console.log("Step 3: Re-snapshotting expected.json (targeting same repo)...");
   const snapshotResult = await run([
     "bun",
     "tools/hygiene/snapshot-github-settings.ts",
+    "--repo",
+    `${OWNER}/${REPO}`,
   ]);
   if (snapshotResult.exitCode !== 0) {
     console.error("  Snapshot failed:", snapshotResult.stderr);
@@ -169,7 +186,9 @@ async function main(): Promise<void> {
   console.log("  bun tools/hygiene/check-github-settings-drift.ts");
 }
 
-main().catch((err) => {
-  console.error("Migration failed:", err);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error("Migration failed:", err);
+    process.exit(1);
+  });
+}

--- a/tools/migrations/b0266-review-policy-ruleset.ts
+++ b/tools/migrations/b0266-review-policy-ruleset.ts
@@ -127,22 +127,21 @@ export async function main(): Promise<void> {
   console.log(`Target: ${REPO_SLUG} (hardcoded — this is a one-shot migration)`);
   console.log();
 
-  // Idempotency check: abort if "Review Policy" ruleset already exists
   const existing = (await ghApi(
     "GET",
-    `repos/${OWNER}/${REPO}/rulesets`,
+    `repos/${OWNER}/${REPO}/rulesets?includes_parents=false`,
   )) as Array<{ id: number; name: string }>;
   const alreadyExists = existing.find((r) => r.name === "Review Policy");
-  if (alreadyExists) {
-    console.log(
-      `"Review Policy" ruleset already exists (id: ${alreadyExists.id}). Nothing to do.`,
-    );
-    return;
-  }
 
   if (dryRun) {
-    console.log("[DRY RUN] Would create Review Policy ruleset:");
-    console.log(JSON.stringify(reviewPolicyPayload, null, 2));
+    if (alreadyExists) {
+      console.log(
+        `[DRY RUN] "Review Policy" already exists (id: ${alreadyExists.id}), would skip step 1.`,
+      );
+    } else {
+      console.log("[DRY RUN] Would create Review Policy ruleset:");
+      console.log(JSON.stringify(reviewPolicyPayload, null, 2));
+    }
     console.log();
     console.log(
       `[DRY RUN] Would update Default ruleset (${DEFAULT_RULESET_ID}) to:`,
@@ -153,13 +152,19 @@ export async function main(): Promise<void> {
     return;
   }
 
-  console.log("Step 1: Creating Review Policy ruleset...");
-  const created = (await ghApi(
-    "POST",
-    `repos/${OWNER}/${REPO}/rulesets`,
-    reviewPolicyPayload,
-  )) as { id: number; name: string };
-  console.log(`  Created ruleset "${created.name}" (id: ${created.id})`);
+  if (alreadyExists) {
+    console.log(
+      `Step 1: "Review Policy" already exists (id: ${alreadyExists.id}), skipping create.`,
+    );
+  } else {
+    console.log("Step 1: Creating Review Policy ruleset...");
+    const created = (await ghApi(
+      "POST",
+      `repos/${OWNER}/${REPO}/rulesets`,
+      reviewPolicyPayload,
+    )) as { id: number; name: string };
+    console.log(`  Created ruleset "${created.name}" (id: ${created.id})`);
+  }
   console.log();
 
   console.log(

--- a/tools/migrations/b0266-review-policy-ruleset.ts
+++ b/tools/migrations/b0266-review-policy-ruleset.ts
@@ -104,6 +104,7 @@ const reviewPolicyPayload = {
 
 const updatedDefaultPayload = {
   name: "Default",
+  target: "branch",
   enforcement: "active",
   conditions: {
     ref_name: {
@@ -123,6 +124,7 @@ export async function main(): Promise<void> {
 
   console.log("B-0266: Review Policy ruleset migration");
   console.log("========================================");
+  console.log(`Target: ${REPO_SLUG} (hardcoded — this is a one-shot migration)`);
   console.log();
 
   // Idempotency check: abort if "Review Policy" ruleset already exists
@@ -185,8 +187,7 @@ export async function main(): Promise<void> {
     REPO_SLUG,
   ]);
   if (snapshotResult.exitCode !== 0) {
-    console.error("  Snapshot failed:", snapshotResult.stderr);
-    process.exit(1);
+    throw new Error(`Snapshot failed: ${snapshotResult.stderr}`);
   }
   const expectedPath = resolve(
     repoRoot,

--- a/tools/migrations/b0266-review-policy-ruleset.ts
+++ b/tools/migrations/b0266-review-policy-ruleset.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env bun
+// b0266-review-policy-ruleset.ts — one-shot migration for B-0266.
+//
+// Creates "Review Policy" ruleset with pull_request + copilot_code_review
+// rules, then removes those rules from the "Default" ruleset.
+// After both API calls succeed, re-snapshots expected.json.
+//
+// Usage:
+//   bun tools/migrations/b0266-review-policy-ruleset.ts [--dry-run]
+//
+// Requires: gh CLI authenticated with repo admin scope.
+
+const OWNER = "Lucent-Financial-Group";
+const REPO = "Zeta";
+const DEFAULT_RULESET_ID = 15256879;
+
+interface SpawnResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+async function run(cmd: readonly string[]): Promise<SpawnResult> {
+  const proc = Bun.spawn({
+    cmd: [...cmd],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+async function ghApi(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<unknown> {
+  const args = ["gh", "api", path, "--method", method];
+  if (body !== undefined) {
+    args.push("--input", "-");
+  }
+  const proc = Bun.spawn({
+    cmd: args,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: body !== undefined ? new Blob([JSON.stringify(body)]) : undefined,
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    throw new Error(
+      `gh api ${method} ${path} failed (exit ${exitCode}): ${stderr.trim()}`,
+    );
+  }
+  return JSON.parse(stdout);
+}
+
+const reviewPolicyPayload = {
+  name: "Review Policy",
+  target: "branch",
+  enforcement: "active",
+  conditions: {
+    ref_name: {
+      include: ["~DEFAULT_BRANCH"],
+      exclude: [],
+    },
+  },
+  rules: [
+    {
+      type: "copilot_code_review",
+      parameters: {
+        review_draft_pull_requests: true,
+        review_on_push: true,
+      },
+    },
+    {
+      type: "pull_request",
+      parameters: {
+        allowed_merge_methods: ["squash"],
+        dismiss_stale_reviews_on_push: false,
+        require_code_owner_review: false,
+        require_last_push_approval: false,
+        required_approving_review_count: 0,
+        required_review_thread_resolution: true,
+        required_reviewers: [],
+      },
+    },
+  ],
+};
+
+const updatedDefaultPayload = {
+  name: "Default",
+  enforcement: "active",
+  conditions: {
+    ref_name: {
+      include: ["~DEFAULT_BRANCH"],
+      exclude: [],
+    },
+  },
+  rules: [
+    { type: "deletion" },
+    { type: "non_fast_forward" },
+    { type: "required_linear_history" },
+  ],
+};
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+
+  console.log("B-0266: Review Policy ruleset migration");
+  console.log("========================================");
+  console.log();
+
+  if (dryRun) {
+    console.log("[DRY RUN] Would create Review Policy ruleset:");
+    console.log(JSON.stringify(reviewPolicyPayload, null, 2));
+    console.log();
+    console.log(
+      `[DRY RUN] Would update Default ruleset (${DEFAULT_RULESET_ID}) to:`,
+    );
+    console.log(JSON.stringify(updatedDefaultPayload, null, 2));
+    console.log();
+    console.log("[DRY RUN] Would re-snapshot expected.json");
+    return;
+  }
+
+  console.log("Step 1: Creating Review Policy ruleset...");
+  const created = (await ghApi(
+    "POST",
+    `repos/${OWNER}/${REPO}/rulesets`,
+    reviewPolicyPayload,
+  )) as { id: number; name: string };
+  console.log(`  Created ruleset "${created.name}" (id: ${created.id})`);
+  console.log();
+
+  console.log(
+    `Step 2: Updating Default ruleset (${DEFAULT_RULESET_ID}) — removing pull_request + copilot_code_review...`,
+  );
+  await ghApi(
+    "PUT",
+    `repos/${OWNER}/${REPO}/rulesets/${DEFAULT_RULESET_ID}`,
+    updatedDefaultPayload,
+  );
+  console.log("  Default ruleset updated (3 rules: deletion, non_fast_forward, required_linear_history)");
+  console.log();
+
+  console.log("Step 3: Re-snapshotting expected.json...");
+  const snapshotResult = await run([
+    "bun",
+    "tools/hygiene/snapshot-github-settings.ts",
+  ]);
+  if (snapshotResult.exitCode !== 0) {
+    console.error("  Snapshot failed:", snapshotResult.stderr);
+    process.exit(1);
+  }
+  const expectedPath = "tools/hygiene/github-settings.expected.json";
+  await Bun.write(expectedPath, snapshotResult.stdout);
+  console.log(`  Wrote ${expectedPath}`);
+  console.log();
+
+  console.log("Done. Verify with:");
+  console.log("  bun tools/hygiene/check-github-settings-drift.ts");
+}
+
+main().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/tools/migrations/b0266-review-policy-ruleset.ts
+++ b/tools/migrations/b0266-review-policy-ruleset.ts
@@ -10,9 +10,16 @@
 //
 // Requires: gh CLI authenticated with repo admin scope.
 
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
 const OWNER = "Lucent-Financial-Group";
 const REPO = "Zeta";
 const DEFAULT_RULESET_ID = 15256879;
+const REPO_SLUG = `${OWNER}/${REPO}`;
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "../..");
 
 interface SpawnResult {
   readonly stdout: string;
@@ -118,6 +125,19 @@ export async function main(): Promise<void> {
   console.log("========================================");
   console.log();
 
+  // Idempotency check: abort if "Review Policy" ruleset already exists
+  const existing = (await ghApi(
+    "GET",
+    `repos/${OWNER}/${REPO}/rulesets`,
+  )) as Array<{ id: number; name: string }>;
+  const alreadyExists = existing.find((r) => r.name === "Review Policy");
+  if (alreadyExists) {
+    console.log(
+      `"Review Policy" ruleset already exists (id: ${alreadyExists.id}). Nothing to do.`,
+    );
+    return;
+  }
+
   if (dryRun) {
     console.log("[DRY RUN] Would create Review Policy ruleset:");
     console.log(JSON.stringify(reviewPolicyPayload, null, 2));
@@ -131,28 +151,13 @@ export async function main(): Promise<void> {
     return;
   }
 
-  // Preflight: ensure no duplicate "Review Policy" ruleset (idempotency)
-  console.log("Preflight: checking for existing Review Policy ruleset...");
-  const existingRulesets = (await ghApi(
-    "GET",
+  console.log("Step 1: Creating Review Policy ruleset...");
+  const created = (await ghApi(
+    "POST",
     `repos/${OWNER}/${REPO}/rulesets`,
-  )) as Array<{ id: number; name: string }>;
-  const existingReviewPolicy = existingRulesets.find(
-    (r) => r.name === "Review Policy",
-  );
-  if (existingReviewPolicy) {
-    console.log(
-      `  "Review Policy" ruleset already exists (id: ${existingReviewPolicy.id}) — skipping create`,
-    );
-  } else {
-    console.log("Step 1: Creating Review Policy ruleset...");
-    const created = (await ghApi(
-      "POST",
-      `repos/${OWNER}/${REPO}/rulesets`,
-      reviewPolicyPayload,
-    )) as { id: number; name: string };
-    console.log(`  Created ruleset "${created.name}" (id: ${created.id})`);
-  }
+    reviewPolicyPayload,
+  )) as { id: number; name: string };
+  console.log(`  Created ruleset "${created.name}" (id: ${created.id})`);
   console.log();
 
   console.log(
@@ -163,21 +168,30 @@ export async function main(): Promise<void> {
     `repos/${OWNER}/${REPO}/rulesets/${DEFAULT_RULESET_ID}`,
     updatedDefaultPayload,
   );
-  console.log("  Default ruleset updated (3 rules: deletion, non_fast_forward, required_linear_history)");
+  console.log(
+    "  Default ruleset updated (3 rules: deletion, non_fast_forward, required_linear_history)",
+  );
   console.log();
 
-  console.log("Step 3: Re-snapshotting expected.json (targeting same repo)...");
+  console.log("Step 3: Re-snapshotting expected.json...");
+  const snapshotScript = resolve(
+    repoRoot,
+    "tools/hygiene/snapshot-github-settings.ts",
+  );
   const snapshotResult = await run([
     "bun",
-    "tools/hygiene/snapshot-github-settings.ts",
+    snapshotScript,
     "--repo",
-    `${OWNER}/${REPO}`,
+    REPO_SLUG,
   ]);
   if (snapshotResult.exitCode !== 0) {
     console.error("  Snapshot failed:", snapshotResult.stderr);
     process.exit(1);
   }
-  const expectedPath = "tools/hygiene/github-settings.expected.json";
+  const expectedPath = resolve(
+    repoRoot,
+    "tools/hygiene/github-settings.expected.json",
+  );
   await Bun.write(expectedPath, snapshotResult.stdout);
   console.log(`  Wrote ${expectedPath}`);
   console.log();


### PR DESCRIPTION
## Summary

- Adds one-shot TS migration script at `tools/migrations/b0266-review-policy-ruleset.ts` that:
  1. Creates "Review Policy" ruleset with `pull_request` (thread resolution, squash-only) + `copilot_code_review` (draft + push review)
  2. Updates "Default" ruleset (id 15256879) to keep only `deletion`, `non_fast_forward`, `required_linear_history`
  3. Re-snapshots `tools/hygiene/github-settings.expected.json`
- Updates B-0266 backlog item with pre-start checklist and implementation docs

Second of three rulesets in the B-0155 split (after B-0265 CI Gate).

## To execute

```bash
# Dry run first
bun tools/migrations/b0266-review-policy-ruleset.ts --dry-run

# Then run for real
bun tools/migrations/b0266-review-policy-ruleset.ts

# Verify no drift
bun tools/hygiene/check-github-settings-drift.ts
```

After execution, commit the updated `github-settings.expected.json` and close B-0266.

## Test plan

- [x] `--dry-run` mode outputs correct payloads (verified locally)
- [x] `dotnet build -c Release` passes (0 warnings, 0 errors)
- [ ] Execute migration on merge, verify via drift check

🤖 Generated with [Claude Code](https://claude.com/claude-code)