### PR TITLE
fix(B-0272): accept hyphen-prefixed ROM option values

### DIFF
--- a/tools/roms/canonicalize.test.ts
+++ b/tools/roms/canonicalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -204,6 +204,21 @@ describe("main", () => {
       expect(stderr).toContain("missing value for --datfile");
     } finally {
       process.stderr.write = originalStderrWrite;
+    }
+  });
+
+  test("accepts hyphen-prefixed datfile and directory values", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "rom-cli-hyphen-"));
+    const originalCwd = process.cwd();
+    writeFileSync(join(tmp, "-set.dat"), FIXTURE_DATFILE);
+    mkdirSync(join(tmp, "-roms"));
+
+    try {
+      process.chdir(tmp);
+      const code = main(["--datfile", "-set.dat", "--dir", "-roms"]);
+      expect(code).toBe(0);
+    } finally {
+      process.chdir(originalCwd);
     }
   });
 });

--- a/tools/roms/canonicalize.test.ts
+++ b/tools/roms/canonicalize.test.ts
@@ -191,23 +191,19 @@ describe("matchAndReport", () => {
 describe("main", () => {
   test("reports missing datfile value clearly", () => {
     const originalStderrWrite = process.stderr.write;
-    const originalExit = process.exit;
     let stderr = "";
 
     process.stderr.write = ((chunk: string | Uint8Array) => {
       stderr += String(chunk);
       return true;
     }) as typeof process.stderr.write;
-    process.exit = ((code?: number) => {
-      throw new Error(`exit:${code}`);
-    }) as typeof process.exit;
 
     try {
-      expect(() => main(["--datfile"])).toThrow("exit:64");
+      const code = main(["--datfile"]);
+      expect(code).toBe(64);
       expect(stderr).toContain("missing value for --datfile");
     } finally {
       process.stderr.write = originalStderrWrite;
-      process.exit = originalExit;
     }
   });
 });

--- a/tools/roms/canonicalize.test.ts
+++ b/tools/roms/canonicalize.test.ts
@@ -203,7 +203,7 @@ describe("main", () => {
     }) as typeof process.exit;
 
     try {
-      expect(() => main(["--datfile", "--dir", "/tmp"])).toThrow("exit:64");
+      expect(() => main(["--datfile"])).toThrow("exit:64");
       expect(stderr).toContain("missing value for --datfile");
     } finally {
       process.stderr.write = originalStderrWrite;

--- a/tools/roms/canonicalize.ts
+++ b/tools/roms/canonicalize.ts
@@ -253,6 +253,15 @@ interface Args {
   readonly apply: boolean;
 }
 
+class ArgError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: number,
+  ) {
+    super(message);
+  }
+}
+
 function parseArgs(argv: readonly string[]): Args {
   let datfile: string | undefined;
   let dir: string | undefined;
@@ -261,8 +270,7 @@ function parseArgs(argv: readonly string[]): Args {
   function readOptionValue(index: number, flag: string): string {
     const value = argv[index + 1];
     if (value === undefined) {
-      process.stderr.write(`missing value for ${flag}\n`);
-      process.exit(64);
+      throw new ArgError(`missing value for ${flag}`, 64);
     }
     return value;
   }
@@ -284,26 +292,32 @@ function parseArgs(argv: readonly string[]): Args {
           "  --dir          Directory containing ROM files to match.\n" +
           "  --apply        Actually rename files (default: dry-run report).\n",
       );
-      process.exit(0);
+      throw new ArgError("", 0);
     } else {
-      process.stderr.write(`unknown arg: ${arg}\n`);
-      process.exit(64);
+      throw new ArgError(`unknown arg: ${arg}`, 64);
     }
   }
 
   if (!datfile) {
-    process.stderr.write("--datfile is required\n");
-    process.exit(64);
+    throw new ArgError("--datfile is required", 64);
   }
   if (!dir) {
-    process.stderr.write("--dir is required\n");
-    process.exit(64);
+    throw new ArgError("--dir is required", 64);
   }
   return { datfile, dir, apply };
 }
 
 export function main(argv: readonly string[]): number {
-  const args = parseArgs(argv);
+  let args: Args;
+  try {
+    args = parseArgs(argv);
+  } catch (e) {
+    if (e instanceof ArgError) {
+      if (e.message) process.stderr.write(`${e.message}\n`);
+      return e.exitCode;
+    }
+    throw e;
+  }
 
   if (!existsSync(args.datfile)) {
     process.stderr.write(`datfile not found: ${args.datfile}\n`);

--- a/tools/roms/canonicalize.ts
+++ b/tools/roms/canonicalize.ts
@@ -254,11 +254,11 @@ interface Args {
 }
 
 class ArgError extends Error {
-  constructor(
-    message: string,
-    readonly exitCode: number,
-  ) {
+  readonly exitCode: number;
+
+  constructor(message: string, exitCode: number) {
     super(message);
+    this.exitCode = exitCode;
   }
 }
 

--- a/tools/roms/canonicalize.ts
+++ b/tools/roms/canonicalize.ts
@@ -260,7 +260,7 @@ function parseArgs(argv: readonly string[]): Args {
 
   function readOptionValue(index: number, flag: string): string {
     const value = argv[index + 1];
-    if (value === undefined || value.startsWith("-")) {
+    if (value === undefined) {
       process.stderr.write(`missing value for ${flag}\n`);
       process.exit(64);
     }


### PR DESCRIPTION
## Summary
- accept hyphen-prefixed values such as `--datfile -set.dat` and `--dir -roms` by treating only absent option values as missing
- return CLI argument parse errors through `main()` instead of calling `process.exit` inside `parseArgs`
- add a focused regression test for hyphen-prefixed datfile and directory values

## Tests
- `bun test tools/roms/canonicalize.test.ts`
- `git diff --check`

## Coordination
Follow-up to the merged #2166 review thread. This intentionally keeps the older `claim/b0272-rom-canonical-naming-smallest-slice-2026-05-08` single-quote parser branch out of scope so it can be handled separately or retired deliberately.