### PR TITLE
feat(B-0277): shape-indexed StructureCatalog with query-by-shape and similarity

### DIFF
--- a/docs/backlog/P1/B-0277-structure-recognizer-catalog-index-2026-05-08.md
+++ b/docs/backlog/P1/B-0277-structure-recognizer-catalog-index-2026-05-08.md
@@ -4,7 +4,7 @@ priority: P1
 status: closed
 title: "Structure recognizer — shape-indexed catalog without labels"
 created: 2026-05-08
-last_updated: 2026-05-08
+last_updated: 2026-05-09
 parent: B-0240
 depends_on: [B-0276]
 classification: closed

--- a/docs/backlog/P1/B-0277-structure-recognizer-catalog-index-2026-05-08.md
+++ b/docs/backlog/P1/B-0277-structure-recognizer-catalog-index-2026-05-08.md
@@ -1,14 +1,15 @@
 ---
 id: B-0277
 priority: P1
-status: open
+status: closed
 title: "Structure recognizer — shape-indexed catalog without labels"
 created: 2026-05-08
 last_updated: 2026-05-08
 parent: B-0240
 depends_on: [B-0276]
-classification: blocked-on-B-0276
+classification: closed
 decomposition: atomic
+closed_by: "StructureCatalog.fs — shape-indexed catalog with add, queryByShape, queryBySimilarity, count; 9 tests"
 owners: [architect, performance-engineer]
 type: feature
 ---

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -45,6 +45,7 @@
     <Compile Include="Veridicality.fs" />
     <Compile Include="Graph.fs" />
     <Compile Include="StructureFingerprint.fs" />
+    <Compile Include="StructureCatalog.fs" />
     <Compile Include="PhaseExtraction.fs" />
     <Compile Include="Window.fs" />
     <Compile Include="Units.fs" />

--- a/src/Core/StructureCatalog.fs
+++ b/src/Core/StructureCatalog.fs
@@ -1,0 +1,69 @@
+namespace Zeta.Core
+
+
+/// Shape-indexed catalog for querying structures by fingerprint.
+///
+/// A `StructureCatalog` maps `StructureFingerprint.Shape` values
+/// to collections of entries, enabling query-by-shape and
+/// query-by-similarity without relying on labels.
+///
+/// This is the second child (B-0277) of the structure recognizer
+/// (B-0240). It consumes the fingerprint library from B-0276.
+[<RequireQualifiedAccess>]
+module StructureCatalog =
+
+    /// A catalog entry: a named structure plus its fingerprint.
+    type Entry<'N when 'N: comparison> =
+        { Id: string
+          Graph: Graph<'N>
+          Fingerprint: StructureFingerprint.Fingerprint }
+
+    /// A shape-indexed catalog. Entries are grouped by their
+    /// classified shape for O(1) shape-exact lookups.
+    type Catalog<'N when 'N: comparison> =
+        { ByShape: Map<StructureFingerprint.Shape, Entry<'N> list> }
+
+    /// An empty catalog.
+    let empty<'N when 'N: comparison> : Catalog<'N> =
+        { ByShape = Map.empty }
+
+    /// Add a graph to the catalog under the given id.
+    let add (id: string) (graph: Graph<'N>) (catalog: Catalog<'N>) : Catalog<'N> =
+        let fp = StructureFingerprint.fingerprint graph
+        let entry = { Id = id; Graph = graph; Fingerprint = fp }
+        let existing =
+            catalog.ByShape
+            |> Map.tryFind fp.Shape
+            |> Option.defaultValue []
+        { ByShape = catalog.ByShape |> Map.add fp.Shape (entry :: existing) }
+
+    /// Query all entries with an exact shape match.
+    let queryByShape
+        (shape: StructureFingerprint.Shape)
+        (catalog: Catalog<'N>)
+        : Entry<'N> list =
+        catalog.ByShape
+        |> Map.tryFind shape
+        |> Option.defaultValue []
+
+    /// Query entries whose fingerprint similarity to the probe
+    /// meets or exceeds the given threshold.
+    let queryBySimilarity
+        (probe: StructureFingerprint.Fingerprint)
+        (threshold: float)
+        (catalog: Catalog<'N>)
+        : (Entry<'N> * float) list =
+        catalog.ByShape
+        |> Map.toList
+        |> List.collect (fun (_shape, entries) ->
+            entries
+            |> List.choose (fun entry ->
+                let sim = StructureFingerprint.similarity probe entry.Fingerprint
+                if sim >= threshold then Some(entry, sim) else None))
+        |> List.sortByDescending snd
+
+    /// Total number of entries in the catalog.
+    let count (catalog: Catalog<'N>) : int =
+        catalog.ByShape
+        |> Map.toList
+        |> List.sumBy (fun (_shape, entries) -> List.length entries)

--- a/tests/Tests.FSharp/Algebra/StructureCatalog.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/StructureCatalog.Tests.fs
@@ -1,0 +1,162 @@
+module Zeta.Tests.Algebra.StructureCatalogTests
+#nowarn "0893"
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+
+// ─── Helper graphs (reuse real Zeta patterns) ───
+
+let private pipelineGraph =
+    Graph.fromEdgeSeq [ (0, 1, 1L); (1, 2, 1L); (2, 3, 1L); (3, 4, 1L) ]
+
+let private ringGraph =
+    Graph.fromEdgeSeq [ (0, 1, 1L); (1, 2, 1L); (2, 3, 1L); (3, 0, 1L) ]
+
+let private starGraph =
+    Graph.fromEdgeSeq [ (0, 1, 1L); (0, 2, 1L); (0, 3, 1L); (0, 4, 1L); (0, 5, 1L) ]
+
+let private treeGraph =
+    Graph.fromEdgeSeq
+        [ (0, 1, 1L); (0, 2, 1L); (1, 3, 1L); (1, 4, 1L); (2, 5, 1L) ]
+
+let private layeredDagGraph =
+    Graph.fromEdgeSeq
+        [ (0, 1, 1L); (0, 2, 1L)
+          (1, 3, 1L); (2, 3, 1L)
+          (1, 4, 1L); (2, 4, 1L)
+          (3, 5, 1L); (4, 5, 1L) ]
+
+
+// ─── Empty catalog ───────────────────────────────
+
+[<Fact>]
+let ``empty catalog has zero entries`` () =
+    StructureCatalog.count StructureCatalog.empty<int>
+    |> should equal 0
+
+[<Fact>]
+let ``queryByShape on empty catalog returns empty list`` () =
+    StructureCatalog.queryByShape
+        StructureFingerprint.Pipeline
+        StructureCatalog.empty<int>
+    |> should be Empty
+
+
+// ─── Add and query by shape ──────────────────────
+
+[<Fact>]
+let ``add then queryByShape returns the added entry`` () =
+    let catalog =
+        StructureCatalog.empty<int>
+        |> StructureCatalog.add "etl-pipeline" pipelineGraph
+
+    let results =
+        StructureCatalog.queryByShape StructureFingerprint.Pipeline catalog
+
+    results |> should haveLength 1
+    results.[0].Id |> should equal "etl-pipeline"
+
+[<Fact>]
+let ``multiple entries with same shape are all returned`` () =
+    let catalog =
+        StructureCatalog.empty<int>
+        |> StructureCatalog.add "pipeline-a" pipelineGraph
+        |> StructureCatalog.add "pipeline-b"
+            (Graph.fromEdgeSeq [ (10, 11, 1L); (11, 12, 1L); (12, 13, 1L) ])
+
+    let results =
+        StructureCatalog.queryByShape StructureFingerprint.Pipeline catalog
+
+    results |> should haveLength 2
+
+[<Fact>]
+let ``queryByShape returns only matching shape`` () =
+    let catalog =
+        StructureCatalog.empty<int>
+        |> StructureCatalog.add "my-pipeline" pipelineGraph
+        |> StructureCatalog.add "my-ring" ringGraph
+
+    let pipelines =
+        StructureCatalog.queryByShape StructureFingerprint.Pipeline catalog
+    let rings =
+        StructureCatalog.queryByShape StructureFingerprint.Ring catalog
+
+    pipelines |> should haveLength 1
+    pipelines.[0].Id |> should equal "my-pipeline"
+    rings |> should haveLength 1
+    rings.[0].Id |> should equal "my-ring"
+
+
+// ─── Count ───────────────────────────────────────
+
+[<Fact>]
+let ``count reflects total entries across all shapes`` () =
+    let catalog =
+        StructureCatalog.empty<int>
+        |> StructureCatalog.add "p" pipelineGraph
+        |> StructureCatalog.add "r" ringGraph
+        |> StructureCatalog.add "s" starGraph
+        |> StructureCatalog.add "t" treeGraph
+
+    StructureCatalog.count catalog |> should equal 4
+
+
+// ─── Query by similarity ─────────────────────────
+
+[<Fact>]
+let ``queryBySimilarity with threshold 1.0 returns exact matches only`` () =
+    let catalog =
+        StructureCatalog.empty<int>
+        |> StructureCatalog.add "pipe" pipelineGraph
+        |> StructureCatalog.add "ring" ringGraph
+        |> StructureCatalog.add "dag" layeredDagGraph
+
+    let probe = StructureFingerprint.fingerprint pipelineGraph
+    let results = StructureCatalog.queryBySimilarity probe 1.0 catalog
+
+    results |> should haveLength 1
+    (fst results.[0]).Id |> should equal "pipe"
+    snd results.[0] |> should equal 1.0
+
+[<Fact>]
+let ``queryBySimilarity with lower threshold returns related shapes`` () =
+    let catalog =
+        StructureCatalog.empty<int>
+        |> StructureCatalog.add "pipe" pipelineGraph
+        |> StructureCatalog.add "dag" layeredDagGraph
+        |> StructureCatalog.add "ring" ringGraph
+
+    let probe = StructureFingerprint.fingerprint pipelineGraph
+    let results = StructureCatalog.queryBySimilarity probe 0.5 catalog
+
+    results |> List.length |> should be (greaterThanOrEqualTo 2)
+    let ids = results |> List.map (fun (e, _) -> e.Id)
+    ids |> should contain "pipe"
+    ids |> should contain "dag"
+
+
+// ─── Real Zeta pattern: catalog of architecture shapes ──
+
+[<Fact>]
+let ``catalog with Zeta architecture shapes supports shape query`` () =
+    let catalog =
+        StructureCatalog.empty<int>
+        |> StructureCatalog.add "zeta-operator-pipeline" pipelineGraph
+        |> StructureCatalog.add "zeta-spine-tree" treeGraph
+        |> StructureCatalog.add "zeta-circuit-dag" layeredDagGraph
+        |> StructureCatalog.add "zeta-event-ring" ringGraph
+        |> StructureCatalog.add "zeta-hub-star" starGraph
+
+    StructureCatalog.count catalog |> should equal 5
+
+    let trees =
+        StructureCatalog.queryByShape StructureFingerprint.TreeHierarchy catalog
+    trees |> should haveLength 1
+    trees.[0].Id |> should equal "zeta-spine-tree"
+
+    let dags =
+        StructureCatalog.queryByShape StructureFingerprint.LayeredDag catalog
+    dags |> should haveLength 1
+    dags.[0].Id |> should equal "zeta-circuit-dag"

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="Algebra/Veridicality.Tests.fs" />
     <Compile Include="Algebra/Graph.Tests.fs" />
     <Compile Include="Algebra/StructureFingerprint.Tests.fs" />
+    <Compile Include="Algebra/StructureCatalog.Tests.fs" />
     <Compile Include="Algebra/PhaseExtraction.Tests.fs" />
     <Compile Include="Algebra/SignalQuality.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />


### PR DESCRIPTION
## Summary

- Adds `StructureCatalog.fs` — a shape-indexed catalog that groups `Graph` entries by their `StructureFingerprint.Shape`, enabling O(1) exact-shape lookups and threshold-based similarity queries.
- API: `empty`, `add`, `queryByShape`, `queryBySimilarity`, `count`.
- 9 xUnit tests covering empty catalog, add/query, shape isolation, count, exact and fuzzy similarity, and a multi-shape Zeta architecture scenario.
- Closes B-0277 (child of B-0240, depends on B-0276 which is already closed).

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test --filter StructureCatalog` — 9/9 passed (58ms)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)