### PR TITLE
fix(B-0272): parse single-quoted DAT attributes

### DIFF
--- a/tools/roms/canonicalize.test.ts
+++ b/tools/roms/canonicalize.test.ts
@@ -51,6 +51,14 @@ describe("parseDatfile", () => {
     expect(entry?.name).toBe('Fish & Chips "Demo".bin');
   });
 
+  test("handles single-quoted XML attributes", () => {
+    const xml = `<rom name='SingleQuote.bin' size='1024' sha1='aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d' />`;
+    const lookup = parseDatfile(xml);
+    expect(lookup.size).toBe(1);
+    const entry = lookup.get("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d");
+    expect(entry?.name).toBe("SingleQuote.bin");
+  });
+
   test("returns empty map for empty input", () => {
     const lookup = parseDatfile("");
     expect(lookup.size).toBe(0);

--- a/tools/roms/canonicalize.ts
+++ b/tools/roms/canonicalize.ts
@@ -102,7 +102,7 @@ function isSafeCanonicalName(name: string): boolean {
 export function parseDatfile(xml: string): ReadonlyMap<string, DatEntry> {
   const lookup = new Map<string, DatEntry>();
   const romTagRe = /<rom\s+([^>]*?)\/?\s*>/g;
-  const attrRe = /(\w+)\s*=\s*"([^"]*)"/g;
+  const attrRe = /(\w+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
 
   let tagMatch: RegExpExecArray | null;
   while ((tagMatch = romTagRe.exec(xml)) !== null) {
@@ -111,7 +111,7 @@ export function parseDatfile(xml: string): ReadonlyMap<string, DatEntry> {
     let attrMatch: RegExpExecArray | null;
     while ((attrMatch = attrRe.exec(attrStr)) !== null) {
       const key = attrMatch[1];
-      const val = attrMatch[2];
+      const val = attrMatch[2] ?? attrMatch[3];
       if (key !== undefined && val !== undefined) {
         attrs[key] = decodeXmlAttributeValue(val);
       }


### PR DESCRIPTION
## Summary
- accepts single-quoted Logiqx DAT XML attribute values in the ROM canonicalizer
- adds a focused parser regression for single-quoted ROM attributes

## Checks
- bun test tools/roms/canonicalize.test.ts
- git diff --check origin/main..HEAD -- tools/roms/canonicalize.ts tools/roms/canonicalize.test.ts

Co-Authored-By: Codex <noreply@openai.com>