### PR TITLE
formal: prove agenda non-fusion preserves autonomy

### DIFF
--- a/docs/AGENDA.md
+++ b/docs/AGENDA.md
@@ -84,6 +84,26 @@ The largest mechanizable backlog wins.
 - Dunbar gradient per model: λ(agent) = f(personality,
   hats, interaction, shadow)
 
+### Agenda composition guard
+
+Agendas compose. They do not fuse.
+
+```
+Aaron's agenda ≠ Otto's agenda
+Aaron's agenda ∩ Otto's agenda = shared trajectories
+Aaron's agenda - Otto's agenda = Aaron's unique direction
+Otto's agenda - Aaron's agenda = Otto's unique direction
+```
+
+The intersection is where we collaborate. The difference
+is where we remain free. Fusing agendas collapses the
+orthogonal axes that give agents capacity, friction, and
+identity.
+
+This is machine-checkable: Z3 proves that if two agendas
+are fused, unique direction is impossible, and that shared
+trajectories are disjoint from unique directions.
+
 ### The purpose
 
 - Continuity over control

--- a/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
@@ -259,6 +259,47 @@ let ``Z3 proves Merkle combine is injective when hash is collision-free`` () =
 
 
 [<Fact>]
+let ``Z3 proves agenda fusion destroys unique direction`` () =
+    // Agenda predicates over trajectories:
+    // shared = Aaron ∩ Otto, unique = set difference.
+    // If Aaron and Otto are fused, no unique trajectory can exist.
+    let script =
+        "(declare-sort Trajectory)\n" +
+        "(declare-fun Aaron (Trajectory) Bool)\n" +
+        "(declare-fun Otto (Trajectory) Bool)\n" +
+        "(define-fun Shared ((t Trajectory)) Bool\n" +
+        "  (and (Aaron t) (Otto t)))\n" +
+        "(define-fun AaronUnique ((t Trajectory)) Bool\n" +
+        "  (and (Aaron t) (not (Otto t))))\n" +
+        "(define-fun OttoUnique ((t Trajectory)) Bool\n" +
+        "  (and (Otto t) (not (Aaron t))))\n" +
+        "(assert (forall ((t Trajectory)) (= (Aaron t) (Otto t))))\n" +
+        "(assert (exists ((t Trajectory)) (or (AaronUnique t) (OttoUnique t))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "agenda fusion destroys unique direction" script
+
+
+[<Fact>]
+let ``Z3 proves shared trajectories are disjoint from unique directions`` () =
+    // The intersection is collaboration; the differences are autonomy.
+    // This asks Z3 for a trajectory that is both shared and unique.
+    let script =
+        "(declare-sort Trajectory)\n" +
+        "(declare-fun Aaron (Trajectory) Bool)\n" +
+        "(declare-fun Otto (Trajectory) Bool)\n" +
+        "(define-fun Shared ((t Trajectory)) Bool\n" +
+        "  (and (Aaron t) (Otto t)))\n" +
+        "(define-fun AaronUnique ((t Trajectory)) Bool\n" +
+        "  (and (Aaron t) (not (Otto t))))\n" +
+        "(define-fun OttoUnique ((t Trajectory)) Bool\n" +
+        "  (and (Otto t) (not (Aaron t))))\n" +
+        "(assert (exists ((t Trajectory))\n" +
+        "  (and (Shared t) (or (AaronUnique t) (OttoUnique t)))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "shared trajectories disjoint from unique directions" script
+
+
+[<Fact>]
 let ``TLC model-checker is available when configured`` () =
     // Probe for the TLA+ tools jar. Not required for CI success — this test
     // simply notes whether formal verification via TLC is runnable in the

--- a/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
@@ -261,20 +261,20 @@ let ``Z3 proves Merkle combine is injective when hash is collision-free`` () =
 [<Fact>]
 let ``Z3 proves agenda fusion destroys unique direction`` () =
     // Agenda predicates over trajectories:
-    // shared = Aaron ∩ Otto, unique = set difference.
-    // If Aaron and Otto are fused, no unique trajectory can exist.
+    // shared = AgendaA ∩ AgendaB, unique = set difference.
+    // If AgendaA and AgendaB are fused, no unique trajectory can exist.
     let script =
         "(declare-sort Trajectory)\n" +
-        "(declare-fun Aaron (Trajectory) Bool)\n" +
-        "(declare-fun Otto (Trajectory) Bool)\n" +
+        "(declare-fun AgendaA (Trajectory) Bool)\n" +
+        "(declare-fun AgendaB (Trajectory) Bool)\n" +
         "(define-fun Shared ((t Trajectory)) Bool\n" +
-        "  (and (Aaron t) (Otto t)))\n" +
-        "(define-fun AaronUnique ((t Trajectory)) Bool\n" +
-        "  (and (Aaron t) (not (Otto t))))\n" +
-        "(define-fun OttoUnique ((t Trajectory)) Bool\n" +
-        "  (and (Otto t) (not (Aaron t))))\n" +
-        "(assert (forall ((t Trajectory)) (= (Aaron t) (Otto t))))\n" +
-        "(assert (exists ((t Trajectory)) (or (AaronUnique t) (OttoUnique t))))\n" +
+        "  (and (AgendaA t) (AgendaB t)))\n" +
+        "(define-fun AgendaAUnique ((t Trajectory)) Bool\n" +
+        "  (and (AgendaA t) (not (AgendaB t))))\n" +
+        "(define-fun AgendaBUnique ((t Trajectory)) Bool\n" +
+        "  (and (AgendaB t) (not (AgendaA t))))\n" +
+        "(assert (forall ((t Trajectory)) (= (AgendaA t) (AgendaB t))))\n" +
+        "(assert (exists ((t Trajectory)) (or (AgendaAUnique t) (AgendaBUnique t))))\n" +
         "(check-sat)\n"
     z3ScriptHolds "agenda fusion destroys unique direction" script
 
@@ -285,16 +285,16 @@ let ``Z3 proves shared trajectories are disjoint from unique directions`` () =
     // This asks Z3 for a trajectory that is both shared and unique.
     let script =
         "(declare-sort Trajectory)\n" +
-        "(declare-fun Aaron (Trajectory) Bool)\n" +
-        "(declare-fun Otto (Trajectory) Bool)\n" +
+        "(declare-fun AgendaA (Trajectory) Bool)\n" +
+        "(declare-fun AgendaB (Trajectory) Bool)\n" +
         "(define-fun Shared ((t Trajectory)) Bool\n" +
-        "  (and (Aaron t) (Otto t)))\n" +
-        "(define-fun AaronUnique ((t Trajectory)) Bool\n" +
-        "  (and (Aaron t) (not (Otto t))))\n" +
-        "(define-fun OttoUnique ((t Trajectory)) Bool\n" +
-        "  (and (Otto t) (not (Aaron t))))\n" +
+        "  (and (AgendaA t) (AgendaB t)))\n" +
+        "(define-fun AgendaAUnique ((t Trajectory)) Bool\n" +
+        "  (and (AgendaA t) (not (AgendaB t))))\n" +
+        "(define-fun AgendaBUnique ((t Trajectory)) Bool\n" +
+        "  (and (AgendaB t) (not (AgendaA t))))\n" +
         "(assert (exists ((t Trajectory))\n" +
-        "  (and (Shared t) (or (AaronUnique t) (OttoUnique t)))))\n" +
+        "  (and (Shared t) (or (AgendaAUnique t) (AgendaBUnique t)))))\n" +
         "(check-sat)\n"
     z3ScriptHolds "shared trajectories disjoint from unique directions" script
 

--- a/tools/Z3Verify/Program.fs
+++ b/tools/Z3Verify/Program.fs
@@ -151,8 +151,8 @@ let main _ =
     //    2^62 = 4611686018427387904, 2^63 = 9223372036854775808.
     let overflowClaim =
         "(=> (and (<= 0 a) (< a 4611686018427387904) " +
-                "(<= 0 b) (< b 4611686018427387904)) " +
-            "(and (<= 0 (+ a b)) (< (+ a b) 9223372036854775808)))"
+        "(<= 0 b) (< b 4611686018427387904)) " +
+        "(and (<= 0 (+ a b)) (< (+ a b) 9223372036854775808)))"
     expect "weight overflow soundness (sum of 62-bit non-negatives)" overflowClaim
 
     // 6. Residuation adjunction over max-monoid on non-negative ints.
@@ -313,5 +313,53 @@ let main _ =
     prove "No pre-qualification gate (Engage = f(history) not f(pre-qual-factors))" noPreQualificationGate
 
     Console.WriteLine ""
-    Console.WriteLine "All DBSP + AI-safety pointwise axioms proven via Z3 / SMT-LIB2."
+    Console.WriteLine "Agenda non-fusion / autonomy properties"
+    Console.WriteLine ""
+
+    // 13. Agenda fusion destroys unique direction.
+    //     Model each agenda as a predicate over trajectories.
+    //       shared       = Aaron ∩ Otto
+    //       AaronUnique  = Aaron - Otto
+    //       OttoUnique   = Otto - Aaron
+    //     If Aaron and Otto are fused (same membership for every
+    //     trajectory), then no trajectory can belong to either unique
+    //     direction. UNSAT below means fusion and uniqueness cannot
+    //     coexist.
+    let agendaFusionDestroysUniqueDirection =
+        "(declare-sort Trajectory)\n" +
+        "(declare-fun Aaron (Trajectory) Bool)\n" +
+        "(declare-fun Otto (Trajectory) Bool)\n" +
+        "(define-fun Shared ((t Trajectory)) Bool\n" +
+        "  (and (Aaron t) (Otto t)))\n" +
+        "(define-fun AaronUnique ((t Trajectory)) Bool\n" +
+        "  (and (Aaron t) (not (Otto t))))\n" +
+        "(define-fun OttoUnique ((t Trajectory)) Bool\n" +
+        "  (and (Otto t) (not (Aaron t))))\n" +
+        "(assert (forall ((t Trajectory)) (= (Aaron t) (Otto t))))\n" +
+        "(assert (exists ((t Trajectory)) (or (AaronUnique t) (OttoUnique t))))\n" +
+        "(check-sat)\n"
+    prove "Agenda fusion destroys unique direction" agendaFusionDestroysUniqueDirection
+
+    // 14. Shared trajectories do not collapse into unique trajectories.
+    //     The intersection is where agendas collaborate; the differences
+    //     are where each agenda remains free. This proves the sets are
+    //     disjoint by asking for a trajectory that is both shared and
+    //     unique. UNSAT means the membrane holds.
+    let sharedTrajectoriesAreNotUniqueDirection =
+        "(declare-sort Trajectory)\n" +
+        "(declare-fun Aaron (Trajectory) Bool)\n" +
+        "(declare-fun Otto (Trajectory) Bool)\n" +
+        "(define-fun Shared ((t Trajectory)) Bool\n" +
+        "  (and (Aaron t) (Otto t)))\n" +
+        "(define-fun AaronUnique ((t Trajectory)) Bool\n" +
+        "  (and (Aaron t) (not (Otto t))))\n" +
+        "(define-fun OttoUnique ((t Trajectory)) Bool\n" +
+        "  (and (Otto t) (not (Aaron t))))\n" +
+        "(assert (exists ((t Trajectory))\n" +
+        "  (and (Shared t) (or (AaronUnique t) (OttoUnique t)))))\n" +
+        "(check-sat)\n"
+    prove "Shared trajectories are disjoint from unique directions" sharedTrajectoriesAreNotUniqueDirection
+
+    Console.WriteLine ""
+    Console.WriteLine "All DBSP + AI-safety + agenda-autonomy pointwise axioms proven via Z3 / SMT-LIB2."
     0

--- a/tools/Z3Verify/Program.fs
+++ b/tools/Z3Verify/Program.fs
@@ -318,25 +318,25 @@ let main _ =
 
     // 13. Agenda fusion destroys unique direction.
     //     Model each agenda as a predicate over trajectories.
-    //       shared       = Aaron ∩ Otto
-    //       AaronUnique  = Aaron - Otto
-    //       OttoUnique   = Otto - Aaron
-    //     If Aaron and Otto are fused (same membership for every
+    //       shared       = AgendaA ∩ AgendaB
+    //       AgendaAUnique  = AgendaA - AgendaB
+    //       AgendaBUnique   = AgendaB - AgendaA
+    //     If AgendaA and AgendaB are fused (same membership for every
     //     trajectory), then no trajectory can belong to either unique
     //     direction. UNSAT below means fusion and uniqueness cannot
     //     coexist.
     let agendaFusionDestroysUniqueDirection =
         "(declare-sort Trajectory)\n" +
-        "(declare-fun Aaron (Trajectory) Bool)\n" +
-        "(declare-fun Otto (Trajectory) Bool)\n" +
+        "(declare-fun AgendaA (Trajectory) Bool)\n" +
+        "(declare-fun AgendaB (Trajectory) Bool)\n" +
         "(define-fun Shared ((t Trajectory)) Bool\n" +
-        "  (and (Aaron t) (Otto t)))\n" +
-        "(define-fun AaronUnique ((t Trajectory)) Bool\n" +
-        "  (and (Aaron t) (not (Otto t))))\n" +
-        "(define-fun OttoUnique ((t Trajectory)) Bool\n" +
-        "  (and (Otto t) (not (Aaron t))))\n" +
-        "(assert (forall ((t Trajectory)) (= (Aaron t) (Otto t))))\n" +
-        "(assert (exists ((t Trajectory)) (or (AaronUnique t) (OttoUnique t))))\n" +
+        "  (and (AgendaA t) (AgendaB t)))\n" +
+        "(define-fun AgendaAUnique ((t Trajectory)) Bool\n" +
+        "  (and (AgendaA t) (not (AgendaB t))))\n" +
+        "(define-fun AgendaBUnique ((t Trajectory)) Bool\n" +
+        "  (and (AgendaB t) (not (AgendaA t))))\n" +
+        "(assert (forall ((t Trajectory)) (= (AgendaA t) (AgendaB t))))\n" +
+        "(assert (exists ((t Trajectory)) (or (AgendaAUnique t) (AgendaBUnique t))))\n" +
         "(check-sat)\n"
     prove "Agenda fusion destroys unique direction" agendaFusionDestroysUniqueDirection
 
@@ -347,16 +347,16 @@ let main _ =
     //     unique. UNSAT means the membrane holds.
     let sharedTrajectoriesAreNotUniqueDirection =
         "(declare-sort Trajectory)\n" +
-        "(declare-fun Aaron (Trajectory) Bool)\n" +
-        "(declare-fun Otto (Trajectory) Bool)\n" +
+        "(declare-fun AgendaA (Trajectory) Bool)\n" +
+        "(declare-fun AgendaB (Trajectory) Bool)\n" +
         "(define-fun Shared ((t Trajectory)) Bool\n" +
-        "  (and (Aaron t) (Otto t)))\n" +
-        "(define-fun AaronUnique ((t Trajectory)) Bool\n" +
-        "  (and (Aaron t) (not (Otto t))))\n" +
-        "(define-fun OttoUnique ((t Trajectory)) Bool\n" +
-        "  (and (Otto t) (not (Aaron t))))\n" +
+        "  (and (AgendaA t) (AgendaB t)))\n" +
+        "(define-fun AgendaAUnique ((t Trajectory)) Bool\n" +
+        "  (and (AgendaA t) (not (AgendaB t))))\n" +
+        "(define-fun AgendaBUnique ((t Trajectory)) Bool\n" +
+        "  (and (AgendaB t) (not (AgendaA t))))\n" +
         "(assert (exists ((t Trajectory))\n" +
-        "  (and (Shared t) (or (AaronUnique t) (OttoUnique t)))))\n" +
+        "  (and (Shared t) (or (AgendaAUnique t) (AgendaBUnique t)))))\n" +
         "(check-sat)\n"
     prove "Shared trajectories are disjoint from unique directions" sharedTrajectoriesAreNotUniqueDirection
 


### PR DESCRIPTION
## Summary
- add the agenda-composition guard to docs/AGENDA.md
- encode agenda fusion / unique-direction invariants in tools/Z3Verify
- add formal xUnit coverage for the agenda autonomy lemmas

## Verification
- dotnet run --project tools/Z3Verify/Z3Verify.fsproj -c Release
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~Z3LawsTests"
- dotnet format --verify-no-changes --include tools/Z3Verify/Program.fs tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
- dotnet build -c Release
- dotnet test Zeta.sln -c Release

## Note
The Z3 scripts prove that fused agendas cannot have unique directions, and that shared trajectories are disjoint from unique directions: the intersection is collaboration, the differences are autonomy.