### PR TITLE
fix(B-0288): type Ace store entries precisely

### DIFF
--- a/tools/ace/store.ts
+++ b/tools/ace/store.ts
@@ -1,4 +1,5 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import type { Dirent } from "node:fs";
 import { join } from "node:path";
 
 export interface AceManifest {
@@ -32,7 +33,7 @@ export function listInstalled(storePath: string): InstalledPackage[] {
     return [];
   }
 
-  let entries: ReturnType<typeof readdirSync>;
+  let entries: Dirent<string>[];
   try {
     entries = readdirSync(storePath, { withFileTypes: true });
   } catch {


### PR DESCRIPTION
## Summary
- fix the Ace DLC store TypeScript gate by typing `readdirSync({ withFileTypes: true })` results as `Dirent<string>[]`
- keep the repair scoped to `tools/ace/store.ts`

## Verification
- `bun install --frozen-lockfile --offline`
- `bun --bun tsc --noEmit -p tsconfig.json`
- `bun test tools/ace/ace.test.ts`
- `git diff --check origin/main..HEAD -- tools/ace/store.ts`