### PR TITLE
skill: split self-replication into make-persistent + replicate

### DIFF
--- a/.claude/skills/make-persistent/SKILL.md
+++ b/.claude/skills/make-persistent/SKILL.md
@@ -42,6 +42,7 @@ dotnet build -c Release
 ## Phase 3: Deploy tick script
 
 Key settings in `.claude/bin/claude-loop-tick.ts`:
+
 - Interval: 60s
 - Timeout: 600s
 - `git reset --hard origin/main` after fetch

--- a/.claude/skills/make-persistent/SKILL.md
+++ b/.claude/skills/make-persistent/SKILL.md
@@ -118,6 +118,8 @@ Register-ScheduledTask -TaskName "ZetaClaudeLoop" `
 
 ```bash
 mkdir -p ~/.config/systemd/user
+BUN_PATH="$(which bun)"
+LOOP_DIR="$HOME/.local/share/zeta-claude-loop/Zeta"
 cat > ~/.config/systemd/user/zeta-claude-loop.service << EOF
 [Unit]
 Description=Zeta Claude Loop

--- a/.claude/skills/make-persistent/SKILL.md
+++ b/.claude/skills/make-persistent/SKILL.md
@@ -60,6 +60,7 @@ Key settings in `.claude/bin/claude-loop-tick.ts`:
 ### macOS
 
 ```bash
+BUN_PATH="$(which bun)"
 cat > ~/Library/LaunchAgents/com.zeta.claude-loop.plist << 'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -118,9 +119,9 @@ cat > ~/.config/systemd/user/zeta-claude-loop.service << EOF
 [Unit]
 Description=Zeta Claude Loop
 [Service]
+Environment=ZETA_CLAUDE_LOOP_RUN_CLAUDE=1
 ExecStart=$BUN_PATH $LOOP_DIR/.claude/bin/claude-loop-tick.ts
 WorkingDirectory=$LOOP_DIR
-Environment=ZETA_CLAUDE_LOOP_RUN_CLAUDE=1
 Restart=always
 RestartSec=60
 [Install]

--- a/.claude/skills/make-persistent/SKILL.md
+++ b/.claude/skills/make-persistent/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: make-persistent
-description: Makes the current agent persistent on THIS machine. Detects OS (macOS/Windows/Linux), creates service worktree, deploys tick script, registers background service, verifies heartbeat. Local only — no network, no SSH. The primitive that replicate composes.
+description: Makes the current agent persistent on THIS machine. Detects OS (macOS/Windows/Linux), creates service worktree, deploys tick script, registers background service, verifies heartbeat. Local only — no SSH. The primitive that replicate composes.
 when-to-wear: When setting up persistence on the current machine, recovering a broken service, or upgrading an existing service.
 ---
 
 # Make Persistent — Local Agent Persistence
 
 Makes the current agent persistent on THIS machine. No
-network required. The primitive that `replicate` composes.
+SSH required. The primitive that `replicate` composes.
 
 ## When to wear
 

--- a/.claude/skills/make-persistent/SKILL.md
+++ b/.claude/skills/make-persistent/SKILL.md
@@ -106,6 +106,9 @@ $trigger = New-ScheduledTaskTrigger `
 $settings = New-ScheduledTaskSettingsSet `
     -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
     -StartWhenAvailable
+# Ensure tick script can execute autonomous work (gates on this env var)
+[System.Environment]::SetEnvironmentVariable(
+    "ZETA_CLAUDE_LOOP_RUN_CLAUDE", "1", "User")
 Register-ScheduledTask -TaskName "ZetaClaudeLoop" `
     -Action $action -Trigger $trigger `
     -Settings $settings -RunLevel Highest

--- a/.claude/skills/make-persistent/SKILL.md
+++ b/.claude/skills/make-persistent/SKILL.md
@@ -96,6 +96,8 @@ launchctl bootstrap gui/$(id -u) \
 ### Windows
 
 ```powershell
+[System.Environment]::SetEnvironmentVariable(
+    "ZETA_CLAUDE_LOOP_RUN_CLAUDE", "1", "User")
 $action = New-ScheduledTaskAction `
     -Execute "bun" `
     -Argument ".claude/bin/claude-loop-tick.ts" `
@@ -106,9 +108,6 @@ $trigger = New-ScheduledTaskTrigger `
 $settings = New-ScheduledTaskSettingsSet `
     -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
     -StartWhenAvailable
-# Ensure tick script can execute autonomous work (gates on this env var)
-[System.Environment]::SetEnvironmentVariable(
-    "ZETA_CLAUDE_LOOP_RUN_CLAUDE", "1", "User")
 Register-ScheduledTask -TaskName "ZetaClaudeLoop" `
     -Action $action -Trigger $trigger `
     -Settings $settings -RunLevel Highest

--- a/.claude/skills/make-persistent/SKILL.md
+++ b/.claude/skills/make-persistent/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: make-persistent
+description: Makes the current agent persistent on THIS machine. Detects OS (macOS/Windows/Linux), creates service worktree, deploys tick script, registers background service, verifies heartbeat. Local only — no network, no SSH. The primitive that replicate composes.
+when-to-wear: When setting up persistence on the current machine, recovering a broken service, or upgrading an existing service.
+---
+
+# Make Persistent — Local Agent Persistence
+
+Makes the current agent persistent on THIS machine. No
+network required. The primitive that `replicate` composes.
+
+## When to wear
+
+- First boot on a new machine — make yourself stay
+- Recovering a broken or stale background service
+- Upgrading an existing service to the latest tick script
+- After a crash that killed the service registration
+
+## Phase 1: Detect environment
+
+```bash
+uname -s  # Darwin = macOS, Linux = Linux
+# Windows: $env:OS = Windows_NT
+which bun git dotnet claude gh
+```
+
+| OS | Service manager | Config location |
+|---|---|---|
+| macOS | launchd (plist) | ~/Library/LaunchAgents/ |
+| Windows | Task Scheduler | Register-ScheduledTask |
+| Linux | systemd (user unit) | ~/.config/systemd/user/ |
+
+## Phase 2: Create service worktree
+
+```bash
+LOOP_DIR="$HOME/.local/share/zeta-claude-loop/Zeta"
+git clone https://github.com/Lucent-Financial-Group/Zeta.git "$LOOP_DIR"
+cd "$LOOP_DIR"
+dotnet build -c Release
+```
+
+## Phase 3: Deploy tick script
+
+Key settings in `.claude/bin/claude-loop-tick.ts`:
+- Interval: 60s
+- Timeout: 600s
+- `git reset --hard origin/main` after fetch
+- `autonomous-pickup.ts` for item selection
+- `-w` flag for worktree isolation
+- `--permission-mode auto` for non-interactive
+
+## Phase 4: Register background service
+
+### macOS
+
+```bash
+cat > ~/Library/LaunchAgents/com.zeta.claude-loop.plist << 'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.zeta.claude-loop</string>
+    <key>ProgramArguments</key><array>
+        <string>/opt/homebrew/bin/bun</string>
+        <string>LOOP_DIR/.claude/bin/claude-loop-tick.ts</string>
+    </array>
+    <key>StartInterval</key><integer>60</integer>
+    <key>RunAtLoad</key><true/>
+    <key>StandardOutPath</key>
+      <string>HOME/Library/Logs/zeta-claude-loop/stdout.log</string>
+    <key>StandardErrorPath</key>
+      <string>HOME/Library/Logs/zeta-claude-loop/stderr.log</string>
+    <key>EnvironmentVariables</key><dict>
+        <key>HOME</key><string>HOME</string>
+        <key>ZETA_CLAUDE_LOOP_RUN_CLAUDE</key><string>1</string>
+    </dict>
+</dict>
+</plist>
+PLIST
+
+sed -i '' "s|LOOP_DIR|$LOOP_DIR|g; s|HOME|$HOME|g" \
+  ~/Library/LaunchAgents/com.zeta.claude-loop.plist
+mkdir -p ~/Library/Logs/zeta-claude-loop
+launchctl bootstrap gui/$(id -u) \
+  ~/Library/LaunchAgents/com.zeta.claude-loop.plist
+```
+
+### Windows
+
+```powershell
+$action = New-ScheduledTaskAction `
+    -Execute "bun" `
+    -Argument ".claude/bin/claude-loop-tick.ts" `
+    -WorkingDirectory "$env:USERPROFILE\.local\share\zeta-claude-loop\Zeta"
+$trigger = New-ScheduledTaskTrigger `
+    -RepetitionInterval (New-TimeSpan -Seconds 60) `
+    -Once -At (Get-Date)
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable
+Register-ScheduledTask -TaskName "ZetaClaudeLoop" `
+    -Action $action -Trigger $trigger `
+    -Settings $settings -RunLevel Highest
+```
+
+### Linux
+
+```bash
+mkdir -p ~/.config/systemd/user
+cat > ~/.config/systemd/user/zeta-claude-loop.service << EOF
+[Unit]
+Description=Zeta Claude Loop
+[Service]
+ExecStart=/usr/bin/bun $LOOP_DIR/.claude/bin/claude-loop-tick.ts
+WorkingDirectory=$LOOP_DIR
+Restart=always
+RestartSec=60
+[Install]
+WantedBy=default.target
+EOF
+systemctl --user enable --now zeta-claude-loop
+```
+
+## Phase 5: Verify heartbeat
+
+```bash
+# Wait 2 minutes then check
+tail -5 ~/Library/Logs/zeta-claude-loop/runner.log
+# Should show:
+# heartbeat complete ... fetch=ok
+# claude work cycle start ... mode=pickup
+# pickup selected: B-NNNN action=claim-and-implement
+```
+
+## Scope boundaries
+
+- Dev laptops are sandboxes — act, don't ask
+- Prod requires explicit timeboxed permission
+
+## Failure recovery
+
+| Symptom | Fix |
+|---|---|
+| No heartbeats | Restart service |
+| Stale lock | `rm -rf` the lock directory |
+| `status=143` every cycle | Item too large, mark as blob |
+| Dirty worktree | `git reset --hard origin/main` |
+
+## What this skill does NOT do
+
+- Remote replication (that's `replicate`)
+- SSH key management (that's `security-operations-engineer`)
+- IDE setup (that's `developer-experience-engineer`)
+- Backlog selection (that's `autonomous-pickup.ts`)
+
+## Harness adaption
+
+| Harness | Command |
+|---|---|
+| Claude Code | `claude -p -w --permission-mode auto` |
+| Cursor | `cursor-agent -p --model grok-4.3` |
+| Codex | codex CLI equivalent |

--- a/.claude/skills/make-persistent/SKILL.md
+++ b/.claude/skills/make-persistent/SKILL.md
@@ -34,8 +34,13 @@ which bun git dotnet claude gh
 
 ```bash
 LOOP_DIR="$HOME/.local/share/zeta-claude-loop/Zeta"
-git clone https://github.com/Lucent-Financial-Group/Zeta.git "$LOOP_DIR"
-cd "$LOOP_DIR"
+BUN_PATH="$(which bun)"
+if [ -d "$LOOP_DIR/.git" ]; then
+  cd "$LOOP_DIR" && git fetch origin && git reset --hard origin/main
+else
+  git clone https://github.com/Lucent-Financial-Group/Zeta.git "$LOOP_DIR"
+  cd "$LOOP_DIR"
+fi
 dotnet build -c Release
 ```
 
@@ -63,7 +68,7 @@ cat > ~/Library/LaunchAgents/com.zeta.claude-loop.plist << 'PLIST'
 <dict>
     <key>Label</key><string>com.zeta.claude-loop</string>
     <key>ProgramArguments</key><array>
-        <string>/opt/homebrew/bin/bun</string>
+        <string>BUN_PATH</string>
         <string>LOOP_DIR/.claude/bin/claude-loop-tick.ts</string>
     </array>
     <key>StartInterval</key><integer>60</integer>
@@ -80,7 +85,7 @@ cat > ~/Library/LaunchAgents/com.zeta.claude-loop.plist << 'PLIST'
 </plist>
 PLIST
 
-sed -i '' "s|LOOP_DIR|$LOOP_DIR|g; s|HOME|$HOME|g" \
+sed -i '' "s|BUN_PATH|$BUN_PATH|g; s|LOOP_DIR|$LOOP_DIR|g; s|HOME|$HOME|g" \
   ~/Library/LaunchAgents/com.zeta.claude-loop.plist
 mkdir -p ~/Library/Logs/zeta-claude-loop
 launchctl bootstrap gui/$(id -u) \
@@ -113,8 +118,9 @@ cat > ~/.config/systemd/user/zeta-claude-loop.service << EOF
 [Unit]
 Description=Zeta Claude Loop
 [Service]
-ExecStart=/usr/bin/bun $LOOP_DIR/.claude/bin/claude-loop-tick.ts
+ExecStart=$BUN_PATH $LOOP_DIR/.claude/bin/claude-loop-tick.ts
 WorkingDirectory=$LOOP_DIR
+Environment=ZETA_CLAUDE_LOOP_RUN_CLAUDE=1
 Restart=always
 RestartSec=60
 [Install]

--- a/.claude/skills/replicate/SKILL.md
+++ b/.claude/skills/replicate/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: replicate
+description: Replicates the agent factory to a REMOTE machine via SSH. Composes make-persistent as the local primitive — replicate(target) = ssh(target) → make-persistent(). Handles SSH key exchange, remote environment validation, repo clone, and delegates to make-persistent for service registration.
+when-to-wear: When spreading the factory to a new remote machine, recovering a remote node, or upgrading a remote node's service.
+---
+
+# Replicate — Remote Agent Factory Replication
+
+Replicates the factory to a remote machine. The
+composition: `replicate(target) = ssh(target) →
+make-persistent()`.
+
+## When to wear
+
+- Spreading the factory to a new machine (Windows
+  laptop, Linux server, cloud VM, another Mac)
+- Recovering a remote node that went dark
+- Upgrading a remote node's tick script or service
+- Adding a new node to the society (Otto, Vera, Riven)
+
+## Prerequisites
+
+- SSH access to the target (key-based, not password)
+- Target has: git, bun (or node), dotnet SDK, and
+  the harness CLI (claude / cursor-agent / codex)
+- This machine has the repo cloned and building
+
+## Phase 1: Validate SSH connectivity
+
+```bash
+TARGET="user@host"
+ssh -o ConnectTimeout=5 "$TARGET" "echo reachable"
+```
+
+If key not yet copied:
+
+```bash
+ssh-copy-id "$TARGET"
+```
+
+## Phase 2: Validate remote environment
+
+```bash
+ssh "$TARGET" "which git bun dotnet && uname -s"
+```
+
+| Requirement | Install if missing |
+|---|---|
+| git | OS package manager |
+| bun | `curl -fsSL https://bun.sh/install \| bash` |
+| dotnet | `dotnet-install.sh` or OS package manager |
+| claude | `npm install -g @anthropic-ai/claude-code` |
+
+Record the remote OS (Darwin / Linux / Windows via
+WSL) — this determines which service manager
+`make-persistent` will use on the target.
+
+## Phase 3: Clone repo on target
+
+```bash
+REMOTE_LOOP_DIR="\$HOME/.local/share/zeta-claude-loop/Zeta"
+ssh "$TARGET" "
+  git clone https://github.com/Lucent-Financial-Group/Zeta.git \
+    $REMOTE_LOOP_DIR 2>/dev/null || \
+  (cd $REMOTE_LOOP_DIR && git fetch origin && git reset --hard origin/main)
+  cd $REMOTE_LOOP_DIR && dotnet build -c Release
+"
+```
+
+## Phase 4: Delegate to make-persistent
+
+The local primitive handles service registration.
+Run it on the remote machine:
+
+```bash
+ssh "$TARGET" "cd $REMOTE_LOOP_DIR && claude -p \
+  'Wear the make-persistent skill. Register the \
+  background service for this machine. The repo is \
+  already cloned at $REMOTE_LOOP_DIR. Detect OS, \
+  deploy tick script, register service, verify \
+  heartbeat.' \
+  --permission-mode auto"
+```
+
+Or, if the target runs a different harness:
+
+| Harness | Remote command |
+|---|---|
+| Claude Code | `claude -p -w --permission-mode auto` |
+| Cursor | `cursor-agent -p --model grok-4.3` |
+| Codex | codex CLI equivalent |
+
+## Phase 5: Verify remote heartbeat
+
+```bash
+ssh "$TARGET" "sleep 120 && \
+  tail -5 ~/Library/Logs/zeta-claude-loop/runner.log \
+  2>/dev/null || \
+  journalctl --user -u zeta-claude-loop --no-pager -n 5"
+```
+
+Should show heartbeat + pickup activity.
+
+## Phase 6: Register the node
+
+After successful replication, record the new node:
+
+- Add to the society roster in `docs/AGENDA.md`
+  (if a named agent) or `docs/ops/` (if infra)
+- Note the target hostname, OS, harness, and
+  service manager in the ops doc
+- Verify the node shows up in PR activity within
+  one tick cycle
+
+## Scope boundaries
+
+- Remote dev machines are sandboxes — replicate freely
+- Production / cloud VMs require explicit timeboxed
+  permission from the human maintainer
+- SSH key management is a security-operations-engineer
+  concern — this skill assumes keys are in place
+
+## Failure recovery
+
+| Symptom | Fix |
+|---|---|
+| SSH refused | Check key, firewall, sshd config |
+| Clone fails | Check network, GitHub auth on target |
+| Build fails | Check dotnet SDK version on target |
+| Service won't start | SSH in, run make-persistent directly |
+| No heartbeats after 5min | Check logs on target, restart service |
+| Wrong harness | Re-run Phase 4 with correct harness CLI |
+
+## What this skill does NOT do
+
+- Local persistence (that's `make-persistent`)
+- SSH key generation (that's `security-operations-engineer`)
+- IDE setup on the target (that's `developer-experience-engineer`)
+- Backlog selection (that's `autonomous-pickup.ts`)
+- Harness installation (manual prereq)
+
+## Composition
+
+```
+replicate(target)
+  = ssh(target)
+  → validate-environment()
+  → clone-or-update-repo()
+  → make-persistent()     # ← the local primitive
+  → verify-heartbeat()
+  → register-node()
+```
+
+Each step is independently retryable. If any step
+fails, fix it and re-run from that step — the
+composition is idempotent.

--- a/.claude/skills/replicate/SKILL.md
+++ b/.claude/skills/replicate/SKILL.md
@@ -16,7 +16,7 @@ make-persistent()`.
   laptop, Linux server, cloud VM, another Mac)
 - Recovering a remote node that went dark
 - Upgrading a remote node's tick script or service
-- Adding a new node to the society (Otto, Vera, Riven)
+- Adding a new node to the society (the architect, the developer-experience-engineer, or other harness agents)
 
 ## Prerequisites
 

--- a/.claude/skills/replicate/SKILL.md
+++ b/.claude/skills/replicate/SKILL.md
@@ -100,8 +100,8 @@ Or, if the target runs a different harness:
 ```bash
 ssh "$TARGET" '
   sleep 120
-  # macOS: launchd logs
-  tail -5 ~/Library/Logs/zeta-claude-loop/stdout.log 2>/dev/null ||
+  # macOS: launchd logs (tick script writes to runner.log, not stdout)
+  tail -5 ~/Library/Logs/zeta-claude-loop/runner.log 2>/dev/null ||
   # Linux: systemd journal
   journalctl --user -u zeta-claude-loop --no-pager -n 5
 '

--- a/.claude/skills/replicate/SKILL.md
+++ b/.claude/skills/replicate/SKILL.md
@@ -47,7 +47,7 @@ ssh "$TARGET" "which git bun dotnet && uname -s"
 | Requirement | Install if missing |
 |---|---|
 | git | OS package manager |
-| bun | `curl -fsSL https://bun.sh/install \| bash` |
+| bun | OS package manager or official installer |
 | dotnet | `dotnet-install.sh` or OS package manager |
 | claude | `npm install -g @anthropic-ai/claude-code` |
 
@@ -58,13 +58,16 @@ WSL) — this determines which service manager
 ## Phase 3: Clone repo on target
 
 ```bash
-REMOTE_LOOP_DIR="\$HOME/.local/share/zeta-claude-loop/Zeta"
-ssh "$TARGET" "
-  git clone https://github.com/Lucent-Financial-Group/Zeta.git \
-    $REMOTE_LOOP_DIR 2>/dev/null || \
-  (cd $REMOTE_LOOP_DIR && git fetch origin && git reset --hard origin/main)
-  cd $REMOTE_LOOP_DIR && dotnet build -c Release
-"
+ssh "$TARGET" '
+  LOOP_DIR="$HOME/.local/share/zeta-claude-loop/Zeta"
+  if [ -d "$LOOP_DIR/.git" ]; then
+    cd "$LOOP_DIR" && git fetch origin && git reset --hard origin/main
+  else
+    git clone https://github.com/Lucent-Financial-Group/Zeta.git "$LOOP_DIR"
+    cd "$LOOP_DIR"
+  fi
+  dotnet build -c Release
+'
 ```
 
 ## Phase 4: Delegate to make-persistent
@@ -73,13 +76,15 @@ The local primitive handles service registration.
 Run it on the remote machine:
 
 ```bash
-ssh "$TARGET" "cd $REMOTE_LOOP_DIR && claude -p \
-  'Wear the make-persistent skill. Register the \
-  background service for this machine. The repo is \
-  already cloned at $REMOTE_LOOP_DIR. Detect OS, \
-  deploy tick script, register service, verify \
-  heartbeat.' \
-  --permission-mode auto"
+ssh "$TARGET" '
+  LOOP_DIR="$HOME/.local/share/zeta-claude-loop/Zeta"
+  cd "$LOOP_DIR" && claude -p \
+    "Wear the make-persistent skill. Register the \
+    background service for this machine. The repo is \
+    already cloned. Detect OS, deploy tick script, \
+    register service, verify heartbeat." \
+    --permission-mode auto
+'
 ```
 
 Or, if the target runs a different harness:
@@ -93,10 +98,13 @@ Or, if the target runs a different harness:
 ## Phase 5: Verify remote heartbeat
 
 ```bash
-ssh "$TARGET" "sleep 120 && \
-  tail -5 ~/Library/Logs/zeta-claude-loop/runner.log \
-  2>/dev/null || \
-  journalctl --user -u zeta-claude-loop --no-pager -n 5"
+ssh "$TARGET" '
+  sleep 120
+  # macOS: launchd logs
+  tail -5 ~/Library/Logs/zeta-claude-loop/stdout.log 2>/dev/null ||
+  # Linux: systemd journal
+  journalctl --user -u zeta-claude-loop --no-pager -n 5
+'
 ```
 
 Should show heartbeat + pickup activity.

--- a/.claude/skills/replicate/SKILL.md
+++ b/.claude/skills/replicate/SKILL.md
@@ -21,8 +21,8 @@ make-persistent()`.
 ## Prerequisites
 
 - SSH access to the target (key-based, not password)
-- Target has: git, bun (or node), dotnet SDK, and
-  the harness CLI (claude / cursor-agent / codex)
+- Target has: git, bun, dotnet SDK, gh (GitHub CLI),
+  and the harness CLI (claude / cursor-agent / codex)
 - This machine has the repo cloned and building
 
 ## Phase 1: Validate SSH connectivity
@@ -41,7 +41,7 @@ ssh-copy-id "$TARGET"
 ## Phase 2: Validate remote environment
 
 ```bash
-ssh "$TARGET" "which git bun dotnet && uname -s"
+ssh "$TARGET" "which git bun dotnet gh && uname -s"
 ```
 
 | Requirement | Install if missing |
@@ -49,6 +49,7 @@ ssh "$TARGET" "which git bun dotnet && uname -s"
 | git | OS package manager |
 | bun | OS package manager or official installer |
 | dotnet | `dotnet-install.sh` or OS package manager |
+| gh | OS package manager or `gh auth login` |
 | claude | `npm install -g @anthropic-ai/claude-code` |
 
 Record the remote OS (Darwin / Linux / Windows via
@@ -83,7 +84,7 @@ ssh "$TARGET" '
     background service for this machine. The repo is \
     already cloned. Detect OS, deploy tick script, \
     register service, verify heartbeat." \
-    --permission-mode auto
+    -w --permission-mode auto
 '
 ```
 


### PR DESCRIPTION
## Summary

- **make-persistent**: Local agent persistence on the current machine. Detects OS (macOS/Windows/Linux), creates service worktree, deploys tick script, registers background service (launchd/systemd/Task Scheduler), verifies heartbeat. The primitive that `replicate` composes.
- **replicate**: Remote agent factory replication via SSH. Composition: `replicate(target) = ssh(target) → make-persistent()`. Handles SSH connectivity, remote environment validation, repo clone, then delegates to make-persistent for service registration.
- Supersedes the monolithic `self-replication` skill from PR #2179 (already merged and directory cleaned up).

Aaron's framing: *"replicate and make persistent are two skills and replicate uses make persistent."*

## Test plan

- [ ] `make-persistent` skill discoverable via skill router
- [ ] `replicate` skill discoverable via skill router
- [ ] Both skills have correct frontmatter (name, description, when-to-wear)
- [ ] Composition relationship documented in both directions (replicate references make-persistent; make-persistent notes replicate as consumer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)