### PR TITLE
feat(B-0347): skill routing budget — raise fraction + document fix

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "skillListingBudgetFraction": 0.02,
   "hooks": {
     "PreToolUse": [
       {
@@ -7,6 +8,10 @@
           {
             "type": "command",
             "command": "bun \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/verify-branch-pretooluse.ts"
+          },
+          {
+            "type": "command",
+            "command": "bun --bun tools/orchestrator-checks/verify-branch.ts"
           }
         ]
       }
@@ -78,13 +83,5 @@
     "huggingface-skills@claude-plugins-official": true,
     "postman@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true
-  },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "command": "bun --bun tools/orchestrator-checks/verify-branch.ts"
-      }
-    ]
   }
 }

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -179,6 +179,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0344](backlog/P1/B-0344-run-23-hour-recreation-experiment-b0193.md)** Run the 23-hour recreation experiment — fresh-context Otto against specs-only repo
 - [ ] **[B-0345](backlog/P1/B-0345-document-recreation-findings-b0193.md)** Document recreation findings — research-grade preservation of experiment results
 - [ ] **[B-0346](backlog/P1/B-0346-backport-spec-gaps-to-openspec-b0193.md)** Back-port spec gaps to OpenSpec — close gaps the recreation experiment reveals
+- [ ] **[B-0347](backlog/P1/B-0347-carved-sentence-skill-descriptions-routing-budget.md)** Carved-sentence skill descriptions — fit 200+ skills into routing budget
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0347-carved-sentence-skill-descriptions-routing-budget.md
+++ b/docs/backlog/P1/B-0347-carved-sentence-skill-descriptions-routing-budget.md
@@ -1,0 +1,81 @@
+---
+id: B-0347
+priority: P1
+status: open
+title: "Carved-sentence skill descriptions — fit 200+ skills into routing budget"
+effort: M
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on: []
+classification: buildable-now
+decomposition: atomic
+owners: [skill-expert]
+type: friction-reducer
+tags: [skill-routing, context-budget, carved-sentence]
+---
+
+# B-0347 — Carved-sentence skill descriptions
+
+## Problem
+
+`/doctor` reports 54 skill descriptions exceed the per-entry
+cap and 209 descriptions are dropped from the skill listing.
+At the default 1% `skillListingBudgetFraction` (raised to 2%
+as immediate relief), multi-paragraph skill descriptions
+consume too much context budget — causing the router to drop
+skills entirely, making them invisible to cold-start agents.
+
+## Fix
+
+Carve every skill's `description:` frontmatter field down to
+a single routing-quality sentence. The description's job is
+to trigger correct routing, not to teach the skill's content
+— that's what the skill body is for.
+
+### Shape
+
+```
+# Before (200+ tokens, gets truncated/dropped):
+description: Capability skill ("hat") — Elasticsearch /
+  OpenSearch narrow. Owns the distributed engine layer
+  above Lucene: cluster topology (master / data / ingest /
+  coordinating-only / ML / transform roles), shard
+  allocation ... [500 words]
+
+# After (one carved sentence, routes correctly):
+description: Elasticsearch / OpenSearch — shards, ILM,
+  Query DSL, aggregations, kNN, cross-cluster, security.
+```
+
+### Rules for the carved sentence
+
+1. One sentence, under 120 characters preferred
+2. Name the domain and 3-7 key routing terms
+3. No "Capability skill (hat)" boilerplate — the router
+   doesn't need it
+4. No "Owns the..." or "Covers the..." preamble
+5. No citations, no "Wear this when...", no "Defers to..."
+   — those belong in the skill body
+6. Test: would a cold-start agent match this description
+   to the right task? If yes, it's carved enough.
+
+## Acceptance criteria
+
+- [ ] All 200+ skills have description under 150 chars
+- [ ] `/doctor` reports 0 descriptions exceeding per-entry cap
+- [ ] `/doctor` reports 0 descriptions dropped
+- [ ] Routing quality verified: spot-check 10 skills by
+  asking the router and confirming correct match
+
+## Immediate mitigation (done)
+
+`skillListingBudgetFraction` raised to 0.02 (2%) in
+`.claude/settings.json`. This doubles the budget but is
+a band-aid — the structural fix is shorter descriptions.
+
+## Composes with
+
+- B-0161 (CLAUDE.md trim) — same context-budget pressure
+- The skill-router-as-substrate-inventory CLAUDE.md bullet
+- `skill-tune-up` and `skill-improver` — they can execute
+  the carving pass

--- a/docs/ops/SKILL-ROUTING-BUDGET.md
+++ b/docs/ops/SKILL-ROUTING-BUDGET.md
@@ -1,0 +1,95 @@
+# Skill Routing Budget — why description length is load-bearing
+
+## The constraint
+
+Every AI harness that routes skills by description has a
+**context budget** for the skill listing. The listing competes
+with the conversation, the system prompt, and the codebase
+context for the same finite window.
+
+In Claude Code, the knob is `skillListingBudgetFraction`
+(default 1% of context). Other harnesses have equivalent
+limits — Cursor's `.cursorrules` competes with file context;
+Codex's system prompt has a hard token cap; any harness that
+lists capabilities at session start pays the same cost.
+
+## The math (Claude Code, 200K effective context)
+
+| Budget fraction | Token budget | Avg tokens/skill | Skills that fit |
+|---|---|---|---|
+| 1% (default) | ~2,000 | 50 (paragraph) | ~40 |
+| 1% | ~2,000 | 15 (carved sentence) | ~133 |
+| 2% (current Zeta setting) | ~4,000 | 50 (paragraph) | ~80 |
+| 2% | ~4,000 | 15 (carved sentence) | ~266 |
+| 3% | ~6,000 | 50 (paragraph) | ~120 |
+
+**Budget fraction is a lever; description length is the
+multiplier.** Raising the fraction costs context everywhere.
+Shortening descriptions costs nothing.
+
+With 200+ skills, paragraph-length descriptions at 1% budget
+means 80% of skills are invisible to the router — dropped
+before the agent even sees them. `/doctor` reports this as
+"descriptions dropped."
+
+## The fix: carved-sentence descriptions
+
+The `description:` frontmatter field in each SKILL.md has
+one job: **trigger correct routing**. It is not a README.
+It is not documentation. It is a search key.
+
+### Rules
+
+1. One sentence, under 120 characters preferred
+2. Name the domain and 3-7 key routing terms
+3. No boilerplate ("Capability skill (hat)", "Owns the...")
+4. No citation chains or "Defers to..." — body content
+5. Test: cold-start agent + ambiguous task → correct match?
+
+### Example
+
+```yaml
+# Before (truncated/dropped by router):
+description: >
+  Capability skill ("hat") — Elasticsearch / OpenSearch
+  narrow. Owns the distributed engine layer above Lucene:
+  cluster topology, shard allocation, ILM, ingest pipeline,
+  dynamic mappings, Query DSL, aggregations, kNN search,
+  hybrid search with RRF, reindex API, snapshot/restore,
+  cross-cluster search/replication, index templates, roles,
+  role-mappings, API keys, security model, data-streams,
+  Watcher, ES|QL, search-application, behavioural-analytics,
+  OpenSearch fork divergence...
+
+# After (fits budget, routes correctly):
+description: >
+  Elasticsearch / OpenSearch — shards, ILM, Query DSL,
+  aggregations, kNN, cross-cluster, security.
+```
+
+## Harness-specific notes
+
+| Harness | Budget mechanism | Diagnostic |
+|---|---|---|
+| Claude Code | `skillListingBudgetFraction` in settings.json | `/doctor` |
+| Cursor | `.cursorrules` size limit (~6K chars) | manual |
+| Codex | system prompt token cap | manual |
+
+The carved-sentence discipline applies to ALL harnesses.
+The budget fraction knob is Claude Code specific. Other
+harnesses need their own equivalent tuning.
+
+## Diagnostic
+
+```bash
+# Claude Code: run /doctor to check skill listing health
+# Look for:
+#   "descriptions exceed the per-entry cap"
+#   "descriptions dropped"
+```
+
+## Tracked at
+
+- B-0347 (carved-sentence skill descriptions)
+- `skillListingBudgetFraction` raised to 0.02 as immediate
+  mitigation (2026-05-09)


### PR DESCRIPTION
## Summary

- **Raise `skillListingBudgetFraction`** from 1% to 2% in settings.json — immediate mitigation for `/doctor` reporting 209 dropped skill descriptions and 54 exceeding per-entry cap
- **File B-0347** — the structural fix: carve every skill's `description:` frontmatter to a single routing-quality sentence (<120 chars). Budget fraction is a lever; description length is the multiplier.
- **Document at `docs/ops/SKILL-ROUTING-BUDGET.md`** — harness-agnostic analysis with budget math table, carved-sentence rules, and per-harness notes (Claude Code / Cursor / Codex)

## Test plan

- [x] `/doctor` no longer reports hooks schema error
- [x] New session shows more skill descriptions loaded (2% vs 1%)
- [ ] After B-0347 execution: `/doctor` reports 0 dropped descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)