### PR TITLE
decompose(B-0329): split CLAUDE.md-as-process into 8 atomic children (B-0348..B-0355)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -180,6 +180,14 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0345](backlog/P1/B-0345-document-recreation-findings-b0193.md)** Document recreation findings — research-grade preservation of experiment results
 - [ ] **[B-0346](backlog/P1/B-0346-backport-spec-gaps-to-openspec-b0193.md)** Back-port spec gaps to OpenSpec — close gaps the recreation experiment reveals
 - [ ] **[B-0347](backlog/P1/B-0347-carved-sentence-skill-descriptions-routing-budget.md)** Carved-sentence skill descriptions — fit 200+ skills into routing budget
+- [ ] **[B-0348](backlog/P1/B-0348-classify-claude-md-bullets-for-extraction.md)** Classify all CLAUDE.md bullets into extraction tiers
+- [ ] **[B-0349](backlog/P1/B-0349-extract-operational-discipline-bullets-to-rules.md)** Extract operational-discipline bullets to .claude/rules/
+- [ ] **[B-0350](backlog/P1/B-0350-extract-autonomy-identity-bullets-to-rules.md)** Extract autonomy/identity bullets to .claude/rules/
+- [ ] **[B-0351](backlog/P1/B-0351-extract-infrastructure-safety-bullets-to-rules.md)** Extract infrastructure/safety bullets to .claude/rules/
+- [ ] **[B-0352](backlog/P1/B-0352-extract-meta-governance-bullets-to-rules.md)** Extract meta/governance bullets to .claude/rules/
+- [ ] **[B-0353](backlog/P1/B-0353-write-bootstrap-process-claude-md.md)** Write bootstrap-process CLAUDE.md (<50 lines)
+- [ ] **[B-0354](backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md)** Fresh-instance validation test for bootstrap CLAUDE.md
+- [ ] **[B-0355](backlog/P1/B-0355-cross-harness-bootstrap-template.md)** Cross-harness bootstrap template (AGENTS.md, CODEX.md, CURSOR.md)
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0329-claude-md-as-process-not-doctrine.md
+++ b/docs/backlog/P1/B-0329-claude-md-as-process-not-doctrine.md
@@ -4,12 +4,21 @@ priority: P1
 status: open
 title: "Replace CLAUDE.md doctrine with bootstrap process — rules emerge from walking, not memorizing"
 created: 2026-05-08
-last_updated: 2026-05-08
+last_updated: 2026-05-09
 depends_on: []
-decomposition: blob
+decomposition: umbrella
 classification: buildable-now
 type: friction-reducer
 owners: [architect]
+children:
+  - B-0348
+  - B-0349
+  - B-0350
+  - B-0351
+  - B-0352
+  - B-0353
+  - B-0354
+  - B-0355
 ---
 
 ## B-0329 — CLAUDE.md as process, not doctrine
@@ -55,6 +64,35 @@ The process-as-bootstrap pattern:
 3. Tested: fresh instance with bootstrap-only produces coherent first PR
 4. Template created for AGENTS.md, CODEX.md, CURSOR.md equivalents
 5. Other harness agents can follow the same pattern
+
+## Decomposition (B-0348..B-0355)
+
+Dependency graph:
+
+```
+B-0348 (classify bullets)
+  ├── B-0349 (extract batch 1: operational discipline)
+  ├── B-0350 (extract batch 2: autonomy/identity)
+  ├── B-0351 (extract batch 3: infrastructure/safety)
+  └── B-0352 (extract batch 4: meta/governance)
+        └── B-0353 (write bootstrap-process CLAUDE.md)
+              └── B-0354 (fresh-instance validation)
+                    └── B-0355 (cross-harness template)
+```
+
+| ID | Title | Depends on | Lines freed |
+|----|-------|-----------|-------------|
+| B-0348 | Classify all CLAUDE.md bullets into extraction tiers | — | 0 (analysis) |
+| B-0349 | Extract operational-discipline bullets to `.claude/rules/` | B-0348 | ~150 |
+| B-0350 | Extract autonomy/identity bullets to `.claude/rules/` | B-0348 | ~190 |
+| B-0351 | Extract infrastructure/safety bullets to `.claude/rules/` | B-0348 | ~240 |
+| B-0352 | Extract meta/governance bullets to `.claude/rules/` | B-0348 | ~300 |
+| B-0353 | Write bootstrap-process CLAUDE.md (<50 lines) | B-0349..B-0352 | final trim |
+| B-0354 | Fresh-instance validation test | B-0353 | 0 (test) |
+| B-0355 | Cross-harness bootstrap template | B-0354 | 0 (template) |
+
+B-0349..B-0352 are parallelizable — they each target disjoint
+bullet groups. B-0353 gates on all four extraction batches.
 
 ## Composes with
 

--- a/docs/backlog/P1/B-0329-claude-md-as-process-not-doctrine.md
+++ b/docs/backlog/P1/B-0329-claude-md-as-process-not-doctrine.md
@@ -6,7 +6,7 @@ title: "Replace CLAUDE.md doctrine with bootstrap process — rules emerge from 
 created: 2026-05-08
 last_updated: 2026-05-09
 depends_on: []
-decomposition: umbrella
+decomposition: decomposed
 classification: buildable-now
 type: friction-reducer
 owners: [architect]

--- a/docs/backlog/P1/B-0348-classify-claude-md-bullets-for-extraction.md
+++ b/docs/backlog/P1/B-0348-classify-claude-md-bullets-for-extraction.md
@@ -1,0 +1,50 @@
+---
+id: B-0348
+priority: P1
+status: open
+title: "Classify all CLAUDE.md bullets into extraction tiers"
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on: []
+decomposition: atomic
+classification: buildable-now
+type: friction-reducer
+owners: [architect]
+parent: B-0329
+---
+
+# B-0348 — Classify all CLAUDE.md bullets into extraction tiers
+
+## What
+
+Audit every bullet in CLAUDE.md's "Ground rules Claude Code
+honours here" section (currently 51 bold-bullet rules across
+~900 lines) and classify each into exactly one extraction tier:
+
+| Tier | Meaning | Destination |
+|------|---------|-------------|
+| `stay` | Essential at wake — part of the bootstrap process | Stays in CLAUDE.md (condensed to 1-2 lines) |
+| `extract` | Behavioral rule — auto-loads from `.claude/rules/` | New `.claude/rules/<name>.md` file; CLAUDE.md bullet becomes pointer |
+| `already` | Already extracted to `.claude/rules/` | CLAUDE.md bullet stays as pointer (no work needed) |
+| `redundant` | Already covered by AGENTS.md / GOVERNANCE.md / docs/ | Remove from CLAUDE.md |
+
+## Why
+
+Every subsequent B-0329 child depends on this classification
+to know which bullets to touch. Without it, extraction batches
+risk moving the wrong content or duplicating what's already
+covered elsewhere.
+
+## Acceptance criteria
+
+1. Classification table added to this row (or a linked doc)
+   listing all 51 bullets with their tier assignment.
+2. Each `extract` bullet assigned to exactly one of the four
+   extraction batches (B-0349..B-0352) by functional group.
+3. Each `redundant` bullet paired with the existing doc that
+   already covers it.
+4. No code/substrate changes — analysis only.
+
+## Effort
+
+S — 1-2 hours of careful reading.

--- a/docs/backlog/P1/B-0349-extract-operational-discipline-bullets-to-rules.md
+++ b/docs/backlog/P1/B-0349-extract-operational-discipline-bullets-to-rules.md
@@ -1,0 +1,54 @@
+---
+id: B-0349
+priority: P1
+status: open
+title: "Extract operational-discipline bullets to .claude/rules/"
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on:
+  - B-0348
+decomposition: atomic
+classification: buildable-now
+type: friction-reducer
+owners: [architect]
+parent: B-0329
+---
+
+# B-0349 — Extract operational-discipline bullets to `.claude/rules/`
+
+## What
+
+Extract the following CLAUDE.md bullets into standalone
+`.claude/rules/<name>.md` files. Each CLAUDE.md bullet shrinks
+to a 1-2 line pointer ("see `.claude/rules/<name>.md`").
+
+Target bullets (operational discipline — how the agent works):
+
+1. **Verify-before-deferring** (~11 lines)
+2. **Future-self is not bound by past-self** (~14 lines)
+3. **Search-first authority** (~33 lines)
+4. **Refresh-before-decide** (~24 lines)
+5. **Refresh world model via poll-pr-gate.ts** (~26 lines)
+6. **BLOCKED-with-green-CI means investigate** (~23 lines)
+7. **Backlog-item start gate** (long single-paragraph)
+
+## Why
+
+These 7 bullets account for ~150+ lines of CLAUDE.md. They are
+behavioral rules (not identity, not infrastructure) that
+`.claude/rules/` auto-loads at session start. Extraction is
+additive — the rules still load, CLAUDE.md shrinks.
+
+## Acceptance criteria
+
+1. 7 new `.claude/rules/<name>.md` files created.
+2. Each file has the carved-sentence + operational-content +
+   full-reasoning-pointer structure (matching existing rules).
+3. CLAUDE.md bullets replaced with 1-2 line pointers.
+4. Build gate passes (`dotnet build -c Release`).
+5. Fresh session test: rules content accessible without
+   explicit Read.
+
+## Effort
+
+M — mechanical extraction, ~2-3 hours.

--- a/docs/backlog/P1/B-0349-extract-operational-discipline-bullets-to-rules.md
+++ b/docs/backlog/P1/B-0349-extract-operational-discipline-bullets-to-rules.md
@@ -28,7 +28,7 @@ Target bullets (operational discipline — how the agent works):
 2. **Future-self is not bound by past-self** (~14 lines)
 3. **Search-first authority** (~33 lines)
 4. **Refresh-before-decide** (~24 lines)
-5. **Refresh world model via poll-pr-gate.ts** (~26 lines)
+5. **Refresh world model via `tools/github/poll-pr-gate.ts`** (~26 lines)
 6. **BLOCKED-with-green-CI means investigate** (~23 lines)
 7. **Backlog-item start gate** (long single-paragraph)
 

--- a/docs/backlog/P1/B-0350-extract-autonomy-identity-bullets-to-rules.md
+++ b/docs/backlog/P1/B-0350-extract-autonomy-identity-bullets-to-rules.md
@@ -1,0 +1,49 @@
+---
+id: B-0350
+priority: P1
+status: open
+title: "Extract autonomy/identity bullets to .claude/rules/"
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on:
+  - B-0348
+decomposition: atomic
+classification: buildable-now
+type: friction-reducer
+owners: [architect]
+parent: B-0329
+---
+
+# B-0350 — Extract autonomy/identity bullets to `.claude/rules/`
+
+## What
+
+Extract the following CLAUDE.md bullets into standalone
+`.claude/rules/<name>.md` files:
+
+Target bullets (autonomy & identity — who the agent is):
+
+1. **No directives** (~20 lines)
+2. **Don't ask permission within authority scope** (~37 lines)
+3. **Otto is an edge-runner** (~36 lines)
+4. **Edge-defining work is NOT speculation** (~33 lines)
+5. **No-op cadence is the failure mode** (~33 lines)
+6. **Shard-cadence triumph** (~28 lines)
+
+## Why
+
+These 6 bullets account for ~190+ lines. They define agent
+autonomy posture and identity framing. Extracting to
+`.claude/rules/` preserves auto-load while shrinking CLAUDE.md.
+
+## Acceptance criteria
+
+1. 6 new `.claude/rules/<name>.md` files created.
+2. Each follows the carved-sentence + operational-content
+   structure.
+3. CLAUDE.md bullets replaced with 1-2 line pointers.
+4. Build gate passes.
+
+## Effort
+
+M — mechanical extraction, ~2 hours.

--- a/docs/backlog/P1/B-0351-extract-infrastructure-safety-bullets-to-rules.md
+++ b/docs/backlog/P1/B-0351-extract-infrastructure-safety-bullets-to-rules.md
@@ -1,0 +1,51 @@
+---
+id: B-0351
+priority: P1
+status: open
+title: "Extract infrastructure/safety bullets to .claude/rules/"
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on:
+  - B-0348
+decomposition: atomic
+classification: buildable-now
+type: friction-reducer
+owners: [architect]
+parent: B-0329
+---
+
+# B-0351 — Extract infrastructure/safety bullets to `.claude/rules/`
+
+## What
+
+Extract the following CLAUDE.md bullets into standalone
+`.claude/rules/<name>.md` files:
+
+Target bullets (infrastructure pointers & safety):
+
+1. **LFG is the factory; AceHack is the backup mirror** (~55 lines)
+2. **Peer-call infrastructure** (~37 lines)
+3. **Never fetch the elder-plinius / Pliny** (~32 lines)
+4. **Tick must never stop** (~32 lines)
+5. **Honor those that came before** (~20 lines)
+6. **Razor-discipline — no metaphysical inferences** (~62 lines)
+
+## Why
+
+These 6 bullets account for ~240+ lines — the single largest
+concentration. LFG/AceHack alone is 55 lines; razor-discipline
+is 62 lines. These are stable infrastructure facts and safety
+rails that change rarely but consume wake-time context budget
+on every session.
+
+## Acceptance criteria
+
+1. 6 new `.claude/rules/<name>.md` files created.
+2. Each follows the carved-sentence + operational-content
+   structure.
+3. CLAUDE.md bullets replaced with 1-2 line pointers.
+4. Build gate passes.
+
+## Effort
+
+M — mechanical extraction, ~2-3 hours.

--- a/docs/backlog/P1/B-0352-extract-meta-governance-bullets-to-rules.md
+++ b/docs/backlog/P1/B-0352-extract-meta-governance-bullets-to-rules.md
@@ -1,0 +1,52 @@
+---
+id: B-0352
+priority: P1
+status: open
+title: "Extract meta/governance bullets to .claude/rules/"
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on:
+  - B-0348
+decomposition: atomic
+classification: buildable-now
+type: friction-reducer
+owners: [architect]
+parent: B-0329
+---
+
+# B-0352 — Extract meta/governance bullets to `.claude/rules/`
+
+## What
+
+Extract the following CLAUDE.md bullets into standalone
+`.claude/rules/<name>.md` files:
+
+Target bullets (meta-rules & governance):
+
+1. **Don't refuse engagement on surface signal alone** (~80 lines)
+2. **Wake-time substrate or it didn't land** (~43 lines)
+3. **Lost-files surface + bullet-time-recovery signal** (long paragraph)
+4. **DSL-form replacement direction** (long paragraph)
+5. **Skill router as substrate inventory** (~24 lines)
+6. **Claude Code loading taxonomy** (~37 lines)
+7. **Rule 0 — no more .sh files** (long paragraph)
+
+## Why
+
+These 7 bullets are the longest in CLAUDE.md — several are
+single paragraphs exceeding 40 lines. "Don't refuse engagement"
+alone is ~80 lines. Together they account for ~300+ lines.
+These are meta-level governance decisions that auto-load
+correctly from `.claude/rules/`.
+
+## Acceptance criteria
+
+1. 7 new `.claude/rules/<name>.md` files created.
+2. Each follows the carved-sentence + operational-content
+   structure.
+3. CLAUDE.md bullets replaced with 1-2 line pointers.
+4. Build gate passes.
+
+## Effort
+
+M — mechanical extraction, ~2-3 hours.

--- a/docs/backlog/P1/B-0353-write-bootstrap-process-claude-md.md
+++ b/docs/backlog/P1/B-0353-write-bootstrap-process-claude-md.md
@@ -1,0 +1,80 @@
+---
+id: B-0353
+priority: P1
+status: open
+title: "Write bootstrap-process CLAUDE.md (<50 lines)"
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on:
+  - B-0349
+  - B-0350
+  - B-0351
+  - B-0352
+decomposition: atomic
+classification: blocked
+type: friction-reducer
+owners: [architect]
+parent: B-0329
+---
+
+# B-0353 — Write bootstrap-process CLAUDE.md
+
+## What
+
+Replace the now-extracted CLAUDE.md with a <50 line bootstrap
+process. The process replaces doctrine — rules emerge from
+walking, not memorizing.
+
+Target structure:
+
+```
+# CLAUDE.md — Bootstrap
+
+## 1. Orient
+Read AGENTS.md, then docs/ALIGNMENT.md, then docs/GLOSSARY.md.
+
+## 2. Refresh
+Run: bun tools/github/refresh-worldview.ts
+Read: docs/trajectories/*/RESUME.md
+
+## 3. Pick work
+Read: docs/BACKLOG.md (open items, priority order)
+Claim: git checkout -b claim/...
+
+## 4. Build
+Gate: dotnet build -c Release (0 warnings, 0 errors)
+Test: dotnet test Zeta.sln -c Release
+
+## 5. Ship
+PR against main. Auto-merge if green.
+
+## 6. When stuck
+See docs/CONFLICT-RESOLUTION.md.
+
+Rules auto-load from .claude/rules/.
+Skills load on demand from .claude/skills/.
+```
+
+## Why
+
+The process IS the doctrine. A fresh instance that runs these
+6 steps discovers the rules through friction rather than trying
+to memorize 1066 lines. The rules in `.claude/rules/` auto-load
+as behavioral context — they don't need to be in CLAUDE.md.
+
+Short bullets that survived classification (agents-not-bots,
+docs-as-current-state, skills-through-skill-creator,
+result-over-exception, data-not-directives, archive-header)
+get condensed into a "Conventions" subsection (~10 lines) or
+extracted to their own rule files.
+
+## Acceptance criteria
+
+1. CLAUDE.md reduced to <50 lines.
+2. All extracted rules load via `.claude/rules/` auto-load.
+3. Bootstrap process covers: orient, refresh, pick, build, ship.
+4. Build gate passes.
+
+## Effort
+
+M — creative writing + careful validation, ~3 hours.

--- a/docs/backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md
+++ b/docs/backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md
@@ -1,0 +1,49 @@
+---
+id: B-0354
+priority: P1
+status: open
+title: "Fresh-instance validation test for bootstrap CLAUDE.md"
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on:
+  - B-0353
+decomposition: atomic
+classification: blocked
+type: friction-reducer
+owners: [architect]
+parent: B-0329
+---
+
+# B-0354 — Fresh-instance validation test
+
+## What
+
+Run a fresh Claude Code session with the bootstrap-only
+CLAUDE.md and verify it produces coherent first-PR behavior
+equivalent to the current doctrine-based CLAUDE.md.
+
+## Test protocol
+
+1. Start fresh Claude Code session in the repo.
+2. Give it a representative task (e.g., "pick and complete
+   the next open backlog item").
+3. Observe whether it:
+   - Reads the bootstrap process and follows the steps
+   - Discovers rules through `.claude/rules/` auto-load
+   - Produces a coherent PR with correct build gate
+   - Handles edge cases (stuck, need escalation, etc.)
+4. Document findings: what worked, what was missed, what
+   rules failed to surface.
+
+## Acceptance criteria
+
+1. Fresh instance completes a representative task
+   successfully.
+2. No critical rules lost in the extraction (all behavioral
+   rules accessible via `.claude/rules/` auto-load).
+3. Findings documented as a test report on this row.
+4. If gaps found: file follow-up items for each gap.
+
+## Effort
+
+S — 1-2 hours of testing + documentation.

--- a/docs/backlog/P1/B-0355-cross-harness-bootstrap-template.md
+++ b/docs/backlog/P1/B-0355-cross-harness-bootstrap-template.md
@@ -44,8 +44,10 @@ not from memorizing harness-specific doctrine.
 
 1. Template document created at `docs/BOOTSTRAP-TEMPLATE.md`
    (or equivalent location).
-2. At least one non-CLAUDE harness file created (CODEX.md or
-   CURSOR.md) following the template.
+2. At least one non-CLAUDE harness file updated or created following
+   the template — use `.codex/AGENTS.md` for the Codex harness (the
+   active Codex bootstrap location per `AGENTS.md`), `CURSOR.md` for
+   Cursor, etc.
 3. Template documents which steps are universal vs
    harness-specific.
 4. Build gate passes.

--- a/docs/backlog/P1/B-0355-cross-harness-bootstrap-template.md
+++ b/docs/backlog/P1/B-0355-cross-harness-bootstrap-template.md
@@ -1,0 +1,55 @@
+---
+id: B-0355
+priority: P1
+status: open
+title: "Cross-harness bootstrap template (AGENTS.md, CODEX.md, CURSOR.md)"
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on:
+  - B-0354
+decomposition: atomic
+classification: blocked
+type: friction-reducer
+owners: [architect]
+parent: B-0329
+---
+
+# B-0355 — Cross-harness bootstrap template
+
+## What
+
+Create a bootstrap-process template that other AI harnesses
+can follow. The pattern from B-0353 (CLAUDE.md as process)
+generalizes to:
+
+- **AGENTS.md** — universal onboarding (already exists,
+  may need process-ification)
+- **CODEX.md** — OpenAI Codex / GPT harness bootstrap
+- **CURSOR.md** — Cursor IDE harness bootstrap
+- **KIRO.md** — Amazon Kiro harness bootstrap (per B-0325)
+
+Each harness file follows the same orient → refresh → pick →
+build → ship process but with harness-specific tooling
+references (e.g., Cursor uses different skill-loading
+mechanisms than Claude Code).
+
+## Why
+
+The process-as-bootstrap pattern transfers across harnesses.
+A Codex instance and a Claude instance running the same process
+produce equivalent behavior — the rules emerge from the walk,
+not from memorizing harness-specific doctrine.
+
+## Acceptance criteria
+
+1. Template document created at `docs/BOOTSTRAP-TEMPLATE.md`
+   (or equivalent location).
+2. At least one non-CLAUDE harness file created (CODEX.md or
+   CURSOR.md) following the template.
+3. Template documents which steps are universal vs
+   harness-specific.
+4. Build gate passes.
+
+## Effort
+
+S — template + one instance, ~2 hours.


### PR DESCRIPTION
## Summary

- Decomposes B-0329 (Replace CLAUDE.md doctrine with bootstrap process) into 8 dependency-ordered atomic child backlog rows (B-0348..B-0355)
- Updates B-0329 parent to `decomposition: umbrella` with children list and dependency graph
- Regenerates BACKLOG.md index to include all 8 children
- Renumbered from B-0347..B-0354 to B-0348..B-0355 to avoid ID collision with merged B-0347 (skill routing budget)

## Dependency graph

```
B-0348 (classify bullets)
  ├── B-0349 (extract batch 1: operational discipline — ~150 lines)
  ├── B-0350 (extract batch 2: autonomy/identity — ~190 lines)
  ├── B-0351 (extract batch 3: infrastructure/safety — ~240 lines)
  └── B-0352 (extract batch 4: meta/governance — ~300 lines)
        └── B-0353 (write bootstrap-process CLAUDE.md <50 lines)
              └── B-0354 (fresh-instance validation test)
                    └── B-0355 (cross-harness bootstrap template)
```

B-0349..B-0352 are parallelizable (disjoint bullet groups). Total ~880 of 1066 CLAUDE.md lines freed by extraction.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts` — all 8 children appear in index
- [x] All child rows have correct `parent: B-0329` and `depends_on:` frontmatter
- [x] No duplicate backlog IDs (B-0348..B-0355 are next available after B-0347)
- [x] Rebased on main after B-0347 (skill routing budget) merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)