### PR TITLE
backlog(B-0356): capture model + token cost on every PR

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -188,7 +188,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0353](backlog/P1/B-0353-write-bootstrap-process-claude-md.md)** Write bootstrap-process CLAUDE.md (<50 lines)
 - [ ] **[B-0354](backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md)** Fresh-instance validation test for bootstrap CLAUDE.md
 - [ ] **[B-0355](backlog/P1/B-0355-cross-harness-bootstrap-template.md)** Cross-harness bootstrap template (AGENTS.md, CODEX.md, CURSOR.md)
-- [ ] **[B-0356](backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md)** Capture model + token cost on every PR description
+- [ ] **[B-0356](backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md)** Capture model + token cost in commit message footer (git-native)
 
 ## P2 — research-grade
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -164,7 +164,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0327](backlog/P1/B-0327-peer-call-claude-ts-self-call-cold-boot.md)** Author claude.ts self-call wrapper — subprocess mode for cold-boot self-testing
 - [ ] **[B-0328](backlog/P1/B-0328-peer-call-readme-kiro-claude-entries.md)** Update peer-call/README.md with kiro.ts + claude.ts entries
 - [ ] **[B-0329](backlog/P1/B-0329-claude-md-as-process-not-doctrine.md)** Replace CLAUDE.md doctrine with bootstrap process — rules emerge from walking, not memorizing
-- [ ] **[B-0330](backlog/P1/B-0330-memory-format-standardization-step2-b0190.md)** Memory-format standardization — define frontmatter shape, filename conventions, section headers
+- [x] **[B-0330](backlog/P1/B-0330-memory-format-standardization-step2-b0190.md)** Memory-format standardization — define frontmatter shape, filename conventions, section headers
 - [ ] **[B-0331](backlog/P1/B-0331-memory-ontology-classification-audit-step3-b0190.md)** Memory ontology/classification audit — reclassify mistyped feedback/project/user/reference files
 - [ ] **[B-0332](backlog/P1/B-0332-memory-load-bearing-vs-decorative-classifier-step7-b0190.md)** Memory load-bearing-vs-decorative classifier — identify which memory files are cited from bootstrap surfaces
 - [ ] **[B-0333](backlog/P1/B-0333-memory-retire-supersession-discipline-step5-b0190.md)** Memory-retire/supersession discipline — define what happens when a memory file is superseded
@@ -188,6 +188,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0353](backlog/P1/B-0353-write-bootstrap-process-claude-md.md)** Write bootstrap-process CLAUDE.md (<50 lines)
 - [ ] **[B-0354](backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md)** Fresh-instance validation test for bootstrap CLAUDE.md
 - [ ] **[B-0355](backlog/P1/B-0355-cross-harness-bootstrap-template.md)** Cross-harness bootstrap template (AGENTS.md, CODEX.md, CURSOR.md)
+- [ ] **[B-0356](backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md)** Capture model + token cost on every PR description
 
 ## P2 — research-grade
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -188,7 +188,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0353](backlog/P1/B-0353-write-bootstrap-process-claude-md.md)** Write bootstrap-process CLAUDE.md (<50 lines)
 - [ ] **[B-0354](backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md)** Fresh-instance validation test for bootstrap CLAUDE.md
 - [ ] **[B-0355](backlog/P1/B-0355-cross-harness-bootstrap-template.md)** Cross-harness bootstrap template (AGENTS.md, CODEX.md, CURSOR.md)
-- [ ] **[B-0356](backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md)** Capture model + token cost in commit message footer (git-native)
+- [ ] **[B-0356](backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md)** Capture model + token usage in commit trailer (git-native, cost derived at query time)
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md
+++ b/docs/backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md
@@ -2,7 +2,7 @@
 id: B-0356
 priority: P1
 status: open
-title: "Capture model + token cost on every PR description"
+title: "Capture model + token cost in commit message footer (git-native)"
 effort: S
 created: 2026-05-09
 last_updated: 2026-05-09
@@ -14,33 +14,28 @@ type: friction-reducer
 tags: [cost-governance, model-routing, A/B-testing, enterprise-billing]
 ---
 
-# B-0356 — Capture model + token cost on every PR description
+# B-0356 — Capture model + token cost in commit message footer
 
 ## What
 
-Every PR created by the background loop (or foreground subagents)
-should include a cost metadata footer in the PR description:
+Every commit created by the background loop (or foreground
+subagents) should include a cost trailer in the commit message:
 
 ```
-### Cost metadata
-- Model: opus
-- Input tokens: 200,420
-- Output tokens: 45,100
-- Estimated cost: $4.13
-- Duration: 156s
+Cost: model=opus input=200420 output=45100 est=$4.13 dur=156s
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 ```
+
+Git-native. Survives host migration. Queryable via `git log`.
+PR descriptions are host-durable-not-git-canonical — cost data
+belongs in the commit, not the PR.
 
 ## Why
 
 On enterprise API billing, this data is the evidence for
 Kevin's reports. Without it, cost analysis requires
-reconstructing token usage from API logs — which we don't
-have access to from the repo side. PR descriptions are
-git-canonical (host-durable) and queryable via `gh api`.
-
-The model-rating-report.ts already tracks model/duration/
-produced_pr — adding cost to the PR description closes the
-loop so the report can pull cost directly from GitHub.
+reconstructing token usage from API logs. Commit messages
+are git-canonical and queryable via `git log --grep="Cost:"`.
 
 ## Implementation
 
@@ -51,18 +46,18 @@ loop so the report can pull cost directly from GitHub.
    (already done — logged to `ticks.err`), extract
    token counts, compute estimated cost using the
    pricing table in `docs/ops/COST-REDUCTION-LESSONS.md`.
-3. When the tick creates a PR (via `gh pr create`), append
-   the cost metadata footer to the PR body.
-4. In `model-rating-report.ts --reviews`, pull cost from
-   PR description via `gh api` and include in the
-   per-model comparison table.
+3. Include `Cost:` trailer in the commit message the tick
+   creates, right above the `Co-Authored-By` footer.
+4. In `model-rating-report.ts`, add `--git-costs` flag
+   that parses `git log --grep="Cost:"` and aggregates
+   per-model cost data from committed history.
 
 ## Acceptance criteria
 
-- [ ] Every background-loop PR has cost metadata in description
-- [ ] `model-rating-report.ts --reviews` includes cost column
-- [ ] Foreground subagent PRs also include cost (when dispatched
-  via the parallel A/B pattern)
+- [ ] Every background-loop commit has `Cost:` trailer
+- [ ] `git log --grep="Cost:" --oneline` shows cost per commit
+- [ ] `model-rating-report.ts --git-costs` aggregates from log
+- [ ] Foreground subagent commits also include cost trailer
 
 ## Composes with
 

--- a/docs/backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md
+++ b/docs/backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md
@@ -2,7 +2,7 @@
 id: B-0356
 priority: P1
 status: open
-title: "Capture model + token cost in commit message footer (git-native)"
+title: "Capture model + token usage in commit trailer (git-native, cost derived at query time)"
 effort: S
 created: 2026-05-09
 last_updated: 2026-05-09
@@ -14,28 +14,34 @@ type: friction-reducer
 tags: [cost-governance, model-routing, A/B-testing, enterprise-billing]
 ---
 
-# B-0356 — Capture model + token cost in commit message footer
+# B-0356 — Capture model + token usage in commit trailer
 
 ## What
 
 Every commit created by the background loop (or foreground
-subagents) should include a cost trailer in the commit message:
+subagents) should include a `Tokens:` trailer in the commit
+message — raw token counts only, no cost estimate:
 
 ```
-Cost: model=opus input=200420 output=45100 est=$4.13 dur=156s
+Tokens: model=opus input=200420 output=45100 dur=156s
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 ```
 
-Git-native. Survives host migration. Queryable via `git log`.
-PR descriptions are host-durable-not-git-canonical — cost data
-belongs in the commit, not the PR.
+**Tokens are the atoms. Cost is derived at query time** from
+the current rate card. Never store cost — it changes when
+pricing changes. Store the immutable fact (tokens used),
+derive the view (dollar cost) when you need it.
+
+Git-native. Survives host migration. Queryable via
+`git log --grep="Tokens:"`.
 
 ## Why
 
 On enterprise API billing, this data is the evidence for
-Kevin's reports. Without it, cost analysis requires
-reconstructing token usage from API logs. Commit messages
-are git-canonical and queryable via `git log --grep="Cost:"`.
+Kevin's reports. Token counts are the raw material; the
+report script multiplies by the current pricing table to
+produce cost. No re-pricing hygiene needed — the facts
+never rot, only the rate card changes.
 
 ## Implementation
 
@@ -44,20 +50,19 @@ are git-canonical and queryable via `git log --grep="Cost:"`.
    `"input_tokens": N, "output_tokens": N` from stderr.
 2. In `claude-loop-tick.ts`, capture stderr output
    (already done — logged to `ticks.err`), extract
-   token counts, compute estimated cost using the
-   pricing table in `docs/ops/COST-REDUCTION-LESSONS.md`.
-3. Include `Cost:` trailer in the commit message the tick
-   creates, right above the `Co-Authored-By` footer.
+   token counts.
+3. Include `Tokens:` trailer in the commit message the
+   tick creates, right above the `Co-Authored-By` footer.
 4. In `model-rating-report.ts`, add `--git-costs` flag
-   that parses `git log --grep="Cost:"` and aggregates
-   per-model cost data from committed history.
+   that parses `git log --grep="Tokens:"`, multiplies by
+   the current pricing table, and aggregates per-model.
 
 ## Acceptance criteria
 
-- [ ] Every background-loop commit has `Cost:` trailer
-- [ ] `git log --grep="Cost:" --oneline` shows cost per commit
-- [ ] `model-rating-report.ts --git-costs` aggregates from log
-- [ ] Foreground subagent commits also include cost trailer
+- [ ] Every background-loop commit has `Tokens:` trailer
+- [ ] `git log --grep="Tokens:" --oneline` shows usage per commit
+- [ ] `model-rating-report.ts --git-costs` derives cost from log
+- [ ] Foreground subagent commits also include token trailer
 
 ## Composes with
 

--- a/docs/backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md
+++ b/docs/backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md
@@ -1,0 +1,72 @@
+---
+id: B-0356
+priority: P1
+status: open
+title: "Capture model + token cost on every PR description"
+effort: S
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on: []
+classification: buildable-now
+decomposition: atomic
+owners: [architect]
+type: friction-reducer
+tags: [cost-governance, model-routing, A/B-testing, enterprise-billing]
+---
+
+# B-0356 — Capture model + token cost on every PR description
+
+## What
+
+Every PR created by the background loop (or foreground subagents)
+should include a cost metadata footer in the PR description:
+
+```
+### Cost metadata
+- Model: opus
+- Input tokens: 200,420
+- Output tokens: 45,100
+- Estimated cost: $4.13
+- Duration: 156s
+```
+
+## Why
+
+On enterprise API billing, this data is the evidence for
+Kevin's reports. Without it, cost analysis requires
+reconstructing token usage from API logs — which we don't
+have access to from the repo side. PR descriptions are
+git-canonical (host-durable) and queryable via `gh api`.
+
+The model-rating-report.ts already tracks model/duration/
+produced_pr — adding cost to the PR description closes the
+loop so the report can pull cost directly from GitHub.
+
+## Implementation
+
+1. The `claude` CLI prints token usage to stderr on
+   completion. Parse the last line matching
+   `"input_tokens": N, "output_tokens": N` from stderr.
+2. In `claude-loop-tick.ts`, capture stderr output
+   (already done — logged to `ticks.err`), extract
+   token counts, compute estimated cost using the
+   pricing table in `docs/ops/COST-REDUCTION-LESSONS.md`.
+3. When the tick creates a PR (via `gh pr create`), append
+   the cost metadata footer to the PR body.
+4. In `model-rating-report.ts --reviews`, pull cost from
+   PR description via `gh api` and include in the
+   per-model comparison table.
+
+## Acceptance criteria
+
+- [ ] Every background-loop PR has cost metadata in description
+- [ ] `model-rating-report.ts --reviews` includes cost column
+- [ ] Foreground subagent PRs also include cost (when dispatched
+  via the parallel A/B pattern)
+
+## Composes with
+
+- `docs/ops/COST-REDUCTION-LESSONS.md` (pricing reference)
+- `docs/ops/agents/otto-cost-profile.md` (per-agent cost model)
+- `tools/ops/model-rating-report.ts` (report consumer)
+- B-0347 (skill description carving — reduces context cost)


### PR DESCRIPTION
## Summary

Files B-0356 — every PR created by background loops or subagents should include model, token count, and estimated cost in the description. This is the data layer that makes the model-rating-report cost comparison work from GitHub metadata instead of session memory.

## Test plan

- [x] Backlog item filed with implementation steps
- [x] BACKLOG.md index regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)