### PR TITLE
fix(tsc): non-null assertions for noUncheckedIndexedAccess on agents[]

### DIFF
--- a/tools/ops/setup-dual-background-agents.ts
+++ b/tools/ops/setup-dual-background-agents.ts
@@ -127,8 +127,8 @@ if (existsSync(oldPlist)) {
 
 console.log(`\n=== Done ===`);
 console.log(`Two background agents registered:`);
-console.log(`  Opus:   ${agents[0].label} → ${agents[0].worktree}`);
-console.log(`  Sonnet: ${agents[1].label} → ${agents[1].worktree}`);
+console.log(`  Opus:   ${agents[0]!.label} → ${agents[0]!.worktree}`);
+console.log(`  Sonnet: ${agents[1]!.label} → ${agents[1]!.worktree}`);
 console.log(`\nBoth write ratings to their respective state dirs.`);
 console.log(`Report: bun tools/ops/model-rating-report.ts --reviews`);
 if (dryRun) console.log(`\n(DRY RUN — no changes made)`);


### PR DESCRIPTION
## Summary

- `noUncheckedIndexedAccess` makes `agents[0]` and `agents[1]` type as `AgentConfig | undefined` even though the array is a statically-known two-element literal
- Add `!` non-null assertions to suppress the false-positive — this is the correct fix when the index is provably in-range at the call site
- The tsc lint check was non-required so PR #2189 merged clean, but the error remained on main

## Test plan

- [x] `bun x tsc --noEmit` exits 0
- [x] `dotnet build -c Release` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)