### PR TITLE
feat(B-0169): add CLI runner to string-archaeology — closes B-0169

### DIFF
--- a/docs/backlog/P1/B-0169-decision-archaeology-skill-aaron-2026-05-02.md
+++ b/docs/backlog/P1/B-0169-decision-archaeology-skill-aaron-2026-05-02.md
@@ -1,13 +1,13 @@
 ---
 id: B-0169
 priority: P1
-status: open
+status: done
 title: Decision-archaeology skill — universal "why is it like this?" investigation surface for new contributors
 tier: skill-creation
 effort: M
 ask: Aaron 2026-05-02 (autonomous-loop channel — *"that is amazing i never asked you to do anything with git blame, it's an advanced feature many devs don't use, this is exceptional work"* + *"decision-archaeology i'm in love"* + *"is that a skill decision-archaeology?"* + *"that's what every new contributor to any project or a new team member always wants to know why is it like this?"*)
 created: 2026-05-02
-last_updated: 2026-05-02
+last_updated: 2026-05-09
 depends_on: []
 decomposition: atomic
 classification: buildable-now
@@ -129,3 +129,24 @@ Done = a `.claude/skills/decision-archaeology/SKILL.md` exists with the shape sk
 - `docs/AGENT-BEST-PRACTICES.md` — the BP rules each have a decision-archaeology trail behind them; the skill teaches contributors to follow it.
 - `memory/feedback_rule_number_two_assume_its_on_backlog_and_find_it_with_all_dependencies_and_updates_and_clean_up_the_dependson_chain_aaron_2026_05_05.md` — Rule #2 IS the operational spec for decision-archaeology applied to backlog rows: assume the row exists, walk `depends_on:`, walk supersession history, clean the chain. Decision-archaeology is the technique; Rule #2 names the default-posture that drives the technique on the backlog graph.
 - `memory/feedback_rule_number_one_assume_its_already_done_and_you_just_have_to_find_it_remember_forever_and_into_all_future_generations_aaron_2026_05_05.md` — Rule #1 (assume-already-done) is the upstream default-posture; decision-archaeology is the locator-tool that satisfies the assumption.
+
+## Pre-start checklist (2026-05-09)
+
+**Prior-art search** (axes: wake-time-substrate + skill-router + Otto-364 + decision-archaeology + lost-files):
+
+- `.claude/skills/decision-archaeology/SKILL.md` — EXISTS (PR #2139 merged 2026-05-?).
+- `tools/decision-archaeology/string-archaeology.ts` — EXISTS as a library module (PR #2167 merged).
+- `docs/research/2026-05-02-decision-archaeology-worked-example-1-double-hop-abandonment.md` — EXISTS.
+- `docs/research/2026-05-03-decision-archaeology-worked-example-2-mathematics-expert-when-to-defer.md` — EXISTS.
+- `docs/research/2026-05-03-decision-archaeology-worked-example-3-bp-24-attribution-archaeology.md` — EXISTS.
+- `git log --diff-filter=D -- .claude/skills/decision-archaeology/` — no deletions found; skill is active.
+- Skill router: `decision-archaeology` appears in available-skills list; confirming it is router-discoverable.
+
+**Dependency restructure:**
+
+- `depends_on: []` — no upstream deps, correct.
+- `composes_with: [B-0058]` — B-0058 is active; pointer is valid.
+
+**Gap remaining after prior PRs:** `string-archaeology.ts` is a library module — no `#!/usr/bin/env bun` shebang, no `if (import.meta.main)` CLI entrypoint. Contributors cannot invoke it as `bun tools/decision-archaeology/string-archaeology.ts "term"`. The smallest remaining slice is adding the CLI runner block to the existing file.
+
+**Status before this slice:** SKILL.md ✓, worked examples ✓, library helper ✓, CLI runner ✗.

--- a/tools/decision-archaeology/string-archaeology.ts
+++ b/tools/decision-archaeology/string-archaeology.ts
@@ -1,3 +1,21 @@
+#!/usr/bin/env bun
+// string-archaeology.ts — find which commits introduced (or removed) a string.
+//
+// Decision-archaeology tool (B-0169). Wraps `git log -w -S "<string>"` to
+// answer the "when was THIS introduced?" question in existence-mode
+// investigations. The `-w` flag suppresses whitespace-only false positives
+// (anti-pattern #3 in the decision-archaeology SKILL.md).
+//
+// Usage (CLI):
+//   bun tools/decision-archaeology/string-archaeology.ts "search term"
+//   bun tools/decision-archaeology/string-archaeology.ts "search term" path/to/file
+//   bun tools/decision-archaeology/string-archaeology.ts --help
+//
+// Output: JSON with { commits, summary } on stdout.
+// Exit codes:
+//   0 — query ran, JSON emitted (may have 0 commits found)
+//   1 — bad arguments or git error
+
 import { spawnSync } from 'child_process';
 
 export interface ArchaeologyResult {
@@ -9,7 +27,8 @@ export function findStringIntroduction(search: string, filePath?: string): Archa
   if (!search || search.trim() === '') {
     return { commits: [], summary: 'No search string provided.' };
   }
-  const args = ['log', '-S', search, '--oneline'];
+  // -w suppresses whitespace-only commit false positives (SKILL.md anti-pattern #3)
+  const args = ['log', '-w', '-S', search, '--oneline'];
   if (filePath) {
     args.push('--', filePath);
   }
@@ -31,4 +50,44 @@ export function findStringIntroduction(search: string, filePath?: string): Archa
       ? `Found ${commits.length} commit(s) touching "${search}".`
       : `No commits found for "${search}".`,
   };
+}
+
+function printHelp(): void {
+  console.log(`
+string-archaeology.ts — decision-archaeology existence-mode tool
+
+Find commits that introduced or removed a specific string.
+
+Usage:
+  bun tools/decision-archaeology/string-archaeology.ts <search>
+  bun tools/decision-archaeology/string-archaeology.ts <search> <file>
+  bun tools/decision-archaeology/string-archaeology.ts --help
+
+Arguments:
+  <search>   String to search for in git history (required)
+  <file>     Optional path to limit search to a single file
+
+Output: JSON  { commits: string[], summary: string }
+
+Example:
+  bun tools/decision-archaeology/string-archaeology.ts "double-hop"
+  bun tools/decision-archaeology/string-archaeology.ts "HardwareCrc" src/
+`.trim());
+}
+
+export function main(argv: readonly string[]): number {
+  const args = argv.filter(a => a !== '');
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    printHelp();
+    return args.length === 0 ? 1 : 0;
+  }
+  const search = args[0] ?? '';
+  const filePath = args[1];
+  const result = findStringIntroduction(search, filePath);
+  console.log(JSON.stringify(result, null, 2));
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
 }


### PR DESCRIPTION
## Summary

- Adds a CLI entrypoint (`#!/usr/bin/env bun` shebang + `main()` + `import.meta.main` guard) to `tools/decision-archaeology/string-archaeology.ts`, enabling direct invocation as `bun tools/decision-archaeology/string-archaeology.ts "term"`.
- Adds `-w` to the `git log -S` call to suppress whitespace-only false positives (fixes gap vs SKILL.md anti-pattern #3).
- Adds the required pre-start checklist to `docs/backlog/P1/B-0169-*.md` and marks the item `done`.

## Prior slices that this closes out

| PR | Content |
|---|---|
| #2139 | `.claude/skills/decision-archaeology/SKILL.md` |
| #2167 | `string-archaeology.ts` library + 3 worked examples in `docs/research/` |
| This PR | CLI runner — makes the tool directly invocable |

## Test plan

- [x] `bun tools/decision-archaeology/string-archaeology.ts --help` → prints usage, exit 0
- [x] `bun tools/decision-archaeology/string-archaeology.ts` (no args) → prints usage, exit 1
- [x] `bun tools/decision-archaeology/string-archaeology.ts "double-hop"` → JSON with commits list and summary
- [x] `bun tools/decision-archaeology/string-archaeology.ts "decision-archaeology" ".claude/skills/decision-archaeology/SKILL.md"` → scoped search returns 1 commit
- [x] `dotnet build -c Release` → 0 warnings, 0 errors

## Checks

- No new files; one TS file extended, one backlog row updated.
- Rule 0 compliant: TS not bash.
- Import as library still works (exports unchanged; only new symbols added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)