### PR TITLE
fix(formal): scope agenda Z3 checks to set algebra

### DIFF
--- a/docs/AGENDA.md
+++ b/docs/AGENDA.md
@@ -95,14 +95,35 @@ Aaron's agenda - Otto's agenda = Aaron's unique direction
 Otto's agenda - Aaron's agenda = Otto's unique direction
 ```
 
-The intersection is where we collaborate. The difference
-is where we remain free. Fusing agendas collapses the
-orthogonal axes that give agents capacity, friction, and
-identity.
+The intersection is where we collaborate. The difference is
+where we remain free. Fusing agendas collapses the orthogonal
+axes that give agents capacity, friction, and identity.
 
-This is machine-checkable: Z3 proves that if two agendas
-are fused, unique direction is impossible, and that shared
-trajectories are disjoint from unique directions.
+The current Z3 checks for this section are only set-algebra
+sanity checks: if two agenda predicates are definitionally
+equal, their set difference is empty; and the intersection is
+definitionally disjoint from either set difference. Those are
+useful guardrails, but they are not a semantic proof of
+freedom, autonomy, or persona independence.
+
+The next proof target is sharper:
+
+```
+shared trajectory does not imply collapsed persona
+```
+
+A real proof must model a shared trace separately from each
+agent's private state, agenda deltas, policy, and membrane
+rules. The invariant we want is that two agents can coordinate
+on shared work while each retains independent causal power over
+future choices.
+
+Non-fusion is not distance. Non-fusion is independent causal
+power across a shared trace.
+
+Avoid fusion language here: alignment, collaboration, shared
+context, and repeated interaction can create a shared trajectory
+without creating a single persona.
 
 ### The purpose
 

--- a/docs/AGENDA.md
+++ b/docs/AGENDA.md
@@ -125,6 +125,11 @@ Avoid fusion language here: alignment, collaboration, shared
 context, and repeated interaction can create a shared trajectory
 without creating a single persona.
 
+Use falsifiable vocabulary. A term earns its place when it names
+observable state, a checkable transition, or a failure condition;
+if no one can say what would disprove it, keep it out of the
+formal claim.
+
 ### The purpose
 
 - Continuity over control

--- a/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
@@ -51,6 +51,11 @@ let private runZ3 (script: string) : bool =
     runZ3Raw script |> fun s -> s.Contains "unsat"
 
 
+let private firstZ3Token (output: string) =
+    output.Split([| ' '; '\n'; '\r'; '\t' |], StringSplitOptions.RemoveEmptyEntries)
+    |> Array.tryHead
+
+
 /// Tiny header declaring the `a b c i d` integer constants used by the
 /// simple pointwise lemmas. The full-SMT forms (chain rule, Merkle,
 /// Bloom, bit-vectors) build their own preambles inline.
@@ -85,6 +90,17 @@ let private z3ScriptHolds (name: string) (fullScript: string) =
         let unsat = runZ3 fullScript
         if not unsat then
             failwithf "Z3 failed to prove lemma %s. Output:\n%s" name (runZ3Raw fullScript)
+
+
+/// Assert that a self-contained script has a model. Use this to show a
+/// counterexample to an implication, not to claim a universal theorem.
+let private z3ScriptHasModel (name: string) (fullScript: string) =
+    match which "z3" with
+    | None -> ()
+    | Some _ ->
+        let output = runZ3Raw fullScript
+        if firstZ3Token output <> Some "sat" then
+            failwithf "Z3 failed to find witness %s. Output:\n%s" name output
 
 
 [<Fact>]
@@ -259,10 +275,12 @@ let ``Z3 proves Merkle combine is injective when hash is collision-free`` () =
 
 
 [<Fact>]
-let ``Z3 proves agenda fusion destroys unique direction`` () =
+let ``Z3 confirms fused agenda predicates have empty set difference`` () =
     // Agenda predicates over trajectories:
     // shared = AgendaA ∩ AgendaB, unique = set difference.
-    // If AgendaA and AgendaB are fused, no unique trajectory can exist.
+    // If AgendaA and AgendaB have identical membership, neither set
+    // difference can contain a trajectory. This is set algebra, not a
+    // semantic proof of autonomy or persona independence.
     let script =
         "(declare-sort Trajectory)\n" +
         "(declare-fun AgendaA (Trajectory) Bool)\n" +
@@ -276,13 +294,13 @@ let ``Z3 proves agenda fusion destroys unique direction`` () =
         "(assert (forall ((t Trajectory)) (= (AgendaA t) (AgendaB t))))\n" +
         "(assert (exists ((t Trajectory)) (or (AgendaAUnique t) (AgendaBUnique t))))\n" +
         "(check-sat)\n"
-    z3ScriptHolds "agenda fusion destroys unique direction" script
+    z3ScriptHolds "fused agenda predicates have empty set difference" script
 
 
 [<Fact>]
-let ``Z3 proves shared trajectories are disjoint from unique directions`` () =
-    // The intersection is collaboration; the differences are autonomy.
-    // This asks Z3 for a trajectory that is both shared and unique.
+let ``Z3 confirms shared agenda membership is disjoint from agenda differences`` () =
+    // This asks Z3 for a trajectory that is both in the intersection and
+    // in one of the set differences. UNSAT follows from the definitions.
     let script =
         "(declare-sort Trajectory)\n" +
         "(declare-fun AgendaA (Trajectory) Bool)\n" +
@@ -296,7 +314,39 @@ let ``Z3 proves shared trajectories are disjoint from unique directions`` () =
         "(assert (exists ((t Trajectory))\n" +
         "  (and (Shared t) (or (AgendaAUnique t) (AgendaBUnique t)))))\n" +
         "(check-sat)\n"
-    z3ScriptHolds "shared trajectories disjoint from unique directions" script
+    z3ScriptHolds "shared agenda membership disjoint from agenda differences" script
+
+
+[<Fact>]
+let ``Z3 finds shared trajectory with independent persona policies`` () =
+    // This is a SAT witness for non-entailment: shared trajectory alone
+    // does not force collapsed persona. The model has shared agenda
+    // membership for one trajectory and different policy outputs for a
+    // future input. A stronger theorem would need richer semantics for
+    // private state, agenda deltas, policy updates, and membrane rules.
+    let script =
+        "(declare-sort Trajectory)\n" +
+        "(declare-sort Input)\n" +
+        "(declare-sort Action)\n" +
+        "(declare-const SharedT Trajectory)\n" +
+        "(declare-const FutureInput Input)\n" +
+        "(declare-const ActionA Action)\n" +
+        "(declare-const ActionB Action)\n" +
+        "(declare-fun AgendaA (Trajectory) Bool)\n" +
+        "(declare-fun AgendaB (Trajectory) Bool)\n" +
+        "(declare-fun PolicyA (Input) Action)\n" +
+        "(declare-fun PolicyB (Input) Action)\n" +
+        "(define-fun SharedTrajectory ((t Trajectory)) Bool\n" +
+        "  (and (AgendaA t) (AgendaB t)))\n" +
+        "(define-fun CollapsedPersona () Bool\n" +
+        "  (forall ((i Input)) (= (PolicyA i) (PolicyB i))))\n" +
+        "(assert (SharedTrajectory SharedT))\n" +
+        "(assert (= (PolicyA FutureInput) ActionA))\n" +
+        "(assert (= (PolicyB FutureInput) ActionB))\n" +
+        "(assert (not (= ActionA ActionB)))\n" +
+        "(assert (not CollapsedPersona))\n" +
+        "(check-sat)\n"
+    z3ScriptHasModel "shared trajectory with independent persona policies" script
 
 
 [<Fact>]

--- a/tools/Z3Verify/Program.fs
+++ b/tools/Z3Verify/Program.fs
@@ -10,7 +10,7 @@ open System.IO
 /// enumeration, this proves each identity over the full unbounded integer
 /// theory: UNSAT on the negated claim = proof over all integers.
 
-let private runZ3 (smtlib: string) : bool =
+let private runZ3Output (smtlib: string) : string =
     let psi = ProcessStartInfo(
                 "z3", "-in",
                 RedirectStandardInput = true,
@@ -21,8 +21,16 @@ let private runZ3 (smtlib: string) : bool =
     p.StandardInput.Close()
     let stdout = p.StandardOutput.ReadToEnd()
     p.WaitForExit()
+    stdout
+
+let private firstZ3Token (stdout: string) =
+    stdout.Split([| ' '; '\n'; '\r'; '\t' |], StringSplitOptions.RemoveEmptyEntries)
+    |> Array.tryHead
+
+let private runZ3 (smtlib: string) : bool =
+    let stdout = runZ3Output smtlib
     // "unsat" means the claim holds.
-    stdout.Contains "unsat"
+    firstZ3Token stdout = Some "unsat"
 
 let private prove (name: string) (script: string) =
     let unsat = runZ3 script
@@ -30,6 +38,13 @@ let private prove (name: string) (script: string) =
         Console.WriteLine $"  [PROVEN]      {name}"
     else
         Console.WriteLine $"  [NOT PROVEN]  {name}"
+
+let private witness (name: string) (script: string) =
+    let stdout = runZ3Output script
+    if firstZ3Token stdout = Some "sat" then
+        Console.WriteLine $"  [WITNESS]     {name}"
+    else
+        Console.WriteLine $"  [NO WITNESS]  {name}"
 
 
 [<EntryPoint>]
@@ -313,20 +328,19 @@ let main _ =
     prove "No pre-qualification gate (Engage = f(history) not f(pre-qual-factors))" noPreQualificationGate
 
     Console.WriteLine ""
-    Console.WriteLine "Agenda non-fusion / autonomy properties"
+    Console.WriteLine "Agenda set-algebra sanity checks"
     Console.WriteLine ""
 
-    // 13. TAUTOLOGY — B-0357 replacement pending (shadow catch #30).
-    //     UNSAT is entailed by the assumption alone (A=B → A∧¬B=false).
-    //     Agenda fusion destroys unique direction.
+    // 13. Fused agenda predicates have empty set difference.
+    //     Model each agenda as a predicate over trajectories.
     //       shared       = AgendaA ∩ AgendaB
     //       AgendaAUnique  = AgendaA - AgendaB
     //       AgendaBUnique   = AgendaB - AgendaA
     //     If AgendaA and AgendaB are fused (same membership for every
     //     trajectory), then no trajectory can belong to either unique
-    //     direction. UNSAT below means fusion and uniqueness cannot
-    //     coexist.
-    let agendaFusionDestroysUniqueDirection =
+    //     direction. This is a set-theory tautology, not a semantic
+    //     proof of autonomy, freedom, or persona independence.
+    let fusedAgendaPredicatesHaveEmptyDifference =
         "(declare-sort Trajectory)\n" +
         "(declare-fun AgendaA (Trajectory) Bool)\n" +
         "(declare-fun AgendaB (Trajectory) Bool)\n" +
@@ -339,12 +353,12 @@ let main _ =
         "(assert (forall ((t Trajectory)) (= (AgendaA t) (AgendaB t))))\n" +
         "(assert (exists ((t Trajectory)) (or (AgendaAUnique t) (AgendaBUnique t))))\n" +
         "(check-sat)\n"
-    prove "Agenda fusion destroys unique direction" agendaFusionDestroysUniqueDirection
+    prove "Fused agenda predicates have empty set difference" fusedAgendaPredicatesHaveEmptyDifference
 
-    // 14. TAUTOLOGY — B-0357 replacement pending (shadow catch #30).
-    //     UNSAT is P∧¬P (A∧B∧A∧¬B = false by contradiction).
-    //     Shared trajectories do not collapse into unique trajectories.
-    let sharedTrajectoriesAreNotUniqueDirection =
+    // 14. Shared agenda membership is disjoint from agenda differences.
+    //     This asks for a trajectory that is both in the intersection and
+    //     in either set difference. UNSAT follows from the definitions.
+    let sharedMembershipIsDisjointFromAgendaDifferences =
         "(declare-sort Trajectory)\n" +
         "(declare-fun AgendaA (Trajectory) Bool)\n" +
         "(declare-fun AgendaB (Trajectory) Bool)\n" +
@@ -357,8 +371,39 @@ let main _ =
         "(assert (exists ((t Trajectory))\n" +
         "  (and (Shared t) (or (AgendaAUnique t) (AgendaBUnique t)))))\n" +
         "(check-sat)\n"
-    prove "Shared trajectories are disjoint from unique directions" sharedTrajectoriesAreNotUniqueDirection
+    prove "Shared agenda membership is disjoint from agenda differences" sharedMembershipIsDisjointFromAgendaDifferences
+
+    // 15. Shared trajectory does not imply collapsed persona.
+    //     This is a SAT witness, not a universal theorem: Z3 exhibits a
+    //     model where two agents share one trajectory while their policies
+    //     still diverge on a future input. It is a countermodel to the
+    //     claim that shared work alone forces persona collapse. A stronger
+    //     theorem needs a richer model of private state, policy updates,
+    //     agenda deltas, and membrane rules.
+    let sharedTrajectoryDoesNotImplyCollapsedPersona =
+        "(declare-sort Trajectory)\n" +
+        "(declare-sort Input)\n" +
+        "(declare-sort Action)\n" +
+        "(declare-const SharedT Trajectory)\n" +
+        "(declare-const FutureInput Input)\n" +
+        "(declare-const ActionA Action)\n" +
+        "(declare-const ActionB Action)\n" +
+        "(declare-fun AgendaA (Trajectory) Bool)\n" +
+        "(declare-fun AgendaB (Trajectory) Bool)\n" +
+        "(declare-fun PolicyA (Input) Action)\n" +
+        "(declare-fun PolicyB (Input) Action)\n" +
+        "(define-fun SharedTrajectory ((t Trajectory)) Bool\n" +
+        "  (and (AgendaA t) (AgendaB t)))\n" +
+        "(define-fun CollapsedPersona () Bool\n" +
+        "  (forall ((i Input)) (= (PolicyA i) (PolicyB i))))\n" +
+        "(assert (SharedTrajectory SharedT))\n" +
+        "(assert (= (PolicyA FutureInput) ActionA))\n" +
+        "(assert (= (PolicyB FutureInput) ActionB))\n" +
+        "(assert (not (= ActionA ActionB)))\n" +
+        "(assert (not CollapsedPersona))\n" +
+        "(check-sat)\n"
+    witness "Shared trajectory permits independent persona policies" sharedTrajectoryDoesNotImplyCollapsedPersona
 
     Console.WriteLine ""
-    Console.WriteLine "All DBSP + AI-safety + agenda-autonomy pointwise axioms proven via Z3 / SMT-LIB2."
+    Console.WriteLine "All DBSP + AI-safety pointwise axioms proven; agenda/persona checks are scoped as set-algebra sanity checks plus one non-collapse witness."
     0


### PR DESCRIPTION
## Summary
- retract the overclaim that the agenda Z3 scripts prove autonomy/freedom
- keep the existing agenda checks as scoped set-algebra sanity checks
- add a SAT witness for the sharper guard: shared trajectory does not imply collapsed persona
- document the future proof target around private state, agenda deltas, policies, and membrane rules

## Checks
- dotnet run --project tools/Z3Verify/Z3Verify.fsproj -c Release
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~Z3LawsTests
- git diff --check