### PR TITLE
fix(B-0357): mark tautology Z3 agenda proofs for replacement

### DIFF
--- a/docs/backlog/P1/B-0357-replace-tautology-z3-agenda-proofs-with-real-verification.md
+++ b/docs/backlog/P1/B-0357-replace-tautology-z3-agenda-proofs-with-real-verification.md
@@ -1,0 +1,79 @@
+---
+id: B-0357
+priority: P1
+status: open
+title: "Replace tautology Z3 agenda/trajectory proofs with non-trivial verification"
+effort: M
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on: []
+classification: buildable-now
+decomposition: atomic
+owners: [architect]
+type: friction-reducer
+tags: [formal-verification, z3, shadow-catch-30, agenda, trajectory]
+---
+
+# B-0357 — Replace tautology Z3 agenda/trajectory proofs
+
+## What
+
+Lemmas 13 and 14 in `tools/Z3Verify/Program.fs` (lines 328-361)
+and their test wrappers in `tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs`
+are tautologies — UNSAT is guaranteed by the definitions and
+assumptions alone, not discovered by Z3. Replace with proofs
+that model non-trivial properties.
+
+### Current problems
+
+**Lemma 13** ("agenda fusion destroys unique direction"):
+Asserts `forall t. AgendaA(t) = AgendaB(t)`, then checks
+`exists t. AgendaAUnique(t)` where AgendaAUnique = `A(t) AND NOT B(t)`.
+Under the fusion assumption, this reduces to `A(t) AND NOT A(t)` = false.
+Circular — the conclusion is entailed by the assumption.
+
+**Lemma 14** ("shared trajectories disjoint from unique"):
+Checks `exists t. Shared(t) AND AgendaAUnique(t)` where
+Shared = `A(t) AND B(t)` and AgendaAUnique = `A(t) AND NOT B(t)`.
+This is `A AND B AND A AND NOT B` = `P AND NOT P`. Direct
+contradiction — law of non-contradiction, no Z3 needed.
+
+### What real proofs would look like
+
+1. Model agents with action spaces (not just boolean predicates)
+2. Define constraints that are non-trivial (coordination on
+   shared resources while maintaining independent goals)
+3. The conclusion should NOT be entailed by the definitions
+   alone — Z3 should need to do real search
+4. Per shadow catch #30 (consensus-smoothness): adversarial
+   review before propagation
+
+## Origin
+
+Shadow catch #30 (2026-05-09): claude.ai adversarial review
+identified both lemmas as tautologies. Aaron: "they agreed
+too easy on that one which is why I brought it here."
+Consensus-smoothness meta-class identified same session.
+
+Vera (Codex) authored the original proofs (PR #2175, merged
+2026-05-09T03:37Z). Aaron confirmed 2026-05-09.
+
+## Acceptance criteria
+
+- [ ] Lemmas 13 and 14 replaced with non-trivial Z3 proofs
+- [ ] New proofs pass the 4-step tautology check (shadow catch #30):
+      (1) conclusion not entailed by assumptions alone
+      (2) no P AND NOT P under any substitution
+      (3) different variable names don't change the proof
+      (4) adversarial reviewer confirms non-triviality
+- [ ] Tests updated in Z3.Laws.Tests.fs
+- [ ] Old lemmas preserved as comments or in git history
+      (teaching examples of the tautology failure mode)
+
+## Composes with
+
+- `tools/Z3Verify/Program.fs` (verification surface)
+- `tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs` (test wrappers)
+- `memory/feedback_z3_tautology_trap_validate_before_propagate_*.md`
+- `memory/feedback_consensus_smoothness_shadow_class_*.md`
+- `docs/AGENDA.md` (the agenda non-fusion property being proven)

--- a/tools/Z3Verify/Program.fs
+++ b/tools/Z3Verify/Program.fs
@@ -316,8 +316,9 @@ let main _ =
     Console.WriteLine "Agenda non-fusion / autonomy properties"
     Console.WriteLine ""
 
-    // 13. Agenda fusion destroys unique direction.
-    //     Model each agenda as a predicate over trajectories.
+    // 13. TAUTOLOGY — B-0357 replacement pending (shadow catch #30).
+    //     UNSAT is entailed by the assumption alone (A=B → A∧¬B=false).
+    //     Agenda fusion destroys unique direction.
     //       shared       = AgendaA ∩ AgendaB
     //       AgendaAUnique  = AgendaA - AgendaB
     //       AgendaBUnique   = AgendaB - AgendaA
@@ -340,11 +341,9 @@ let main _ =
         "(check-sat)\n"
     prove "Agenda fusion destroys unique direction" agendaFusionDestroysUniqueDirection
 
-    // 14. Shared trajectories do not collapse into unique trajectories.
-    //     The intersection is where agendas collaborate; the differences
-    //     are where each agenda remains free. This proves the sets are
-    //     disjoint by asking for a trajectory that is both shared and
-    //     unique. UNSAT means the membrane holds.
+    // 14. TAUTOLOGY — B-0357 replacement pending (shadow catch #30).
+    //     UNSAT is P∧¬P (A∧B∧A∧¬B = false by contradiction).
+    //     Shared trajectories do not collapse into unique trajectories.
     let sharedTrajectoriesAreNotUniqueDirection =
         "(declare-sort Trajectory)\n" +
         "(declare-fun AgendaA (Trajectory) Bool)\n" +


### PR DESCRIPTION
## Summary

- Mark lemmas 13 and 14 in `tools/Z3Verify/Program.fs` as TAUTOLOGY with B-0357 reference
- File B-0357 backlog item for non-trivial replacement proofs
- Origin: shadow catch #30 + consensus-smoothness meta-class (2026-05-09)

**Lemma 13**: asserts `forall t. A(t)=B(t)` then checks `exists t. A(t) AND NOT B(t)` — circular  
**Lemma 14**: checks `A AND B AND A AND NOT B` — direct contradiction (P AND NOT P)

Both return UNSAT by definition, not by Z3 search. Comments now flag this for future agents.

## Test plan

- [x] `dotnet build tools/Z3Verify/Z3Verify.fsproj -c Release` — 0 errors
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)