### PR TITLE
feat: add gradient falsifiability (round, not sharp)

### DIFF
--- a/src/Core/SignalQuality.fs
+++ b/src/Core/SignalQuality.fs
@@ -335,6 +335,23 @@ module SignalQuality =
             if total = 0 then 1.0
             else float falsifiable / float total
 
+    /// Gradient falsifiability — each claim gets a score in [0.0, 1.0]
+    /// instead of a binary yes/no. The aggregate is the weighted average
+    /// over currently-asserted claims. This is the "round" variant;
+    /// `falsifiabilityWith` is the "sharp" (boolean) variant.
+    let falsifiabilityWithScore (scorer: string -> float) (claims: ZSet<string>) : float =
+        let span = claims.AsSpan()
+        if span.IsEmpty then 1.0
+        else
+            let mutable scoreSum = 0.0
+            let mutable total = 0
+            for i = 0 to span.Length - 1 do
+                if span.[i].Weight > 0L then
+                    total <- total + 1
+                    scoreSum <- scoreSum + (scorer span.[i].Key |> max 0.0 |> min 1.0)
+            if total = 0 then 1.0
+            else scoreSum / float total
+
     /// Falsifiability-dimension measure. Suspicion score =
     /// `1 - falsifiable` (higher falsifiability = lower suspicion).
     let falsifiabilityMeasure (predicate: string -> bool) : IQualityMeasure<ZSet<string>> =
@@ -347,6 +364,18 @@ module SignalQuality =
                   Severity = severityOfScore suspicion
                   Score = suspicion
                   Evidence = sprintf "falsifiable=%.3f claims=%d" falsifiable claims.Count } }
+
+    /// Gradient falsifiability measure — scorer returns [0.0, 1.0] per claim.
+    let falsifiabilityMeasureGradient (scorer: string -> float) : IQualityMeasure<ZSet<string>> =
+        { new IQualityMeasure<ZSet<string>> with
+            member _.Dimension = Falsifiability
+            member _.Measure(claims: ZSet<string>) =
+                let falsifiable = falsifiabilityWithScore scorer claims
+                let disagreement = 1.0 - falsifiable
+                { Dimension = Falsifiability
+                  Severity = severityOfScore disagreement
+                  Score = disagreement
+                  Evidence = sprintf "falsifiable=%.3f(gradient) claims=%d" falsifiable claims.Count } }
 
 
     // ───────────────────────────────────────────────────────────────

--- a/tests/Tests.FSharp/Algebra/SignalQuality.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/SignalQuality.Tests.fs
@@ -113,6 +113,34 @@ let ``falsifiabilityWith returns 1.0 on an empty claim store`` () =
     |> should (equalWithin 1e-9) 1.0
 
 
+[<Fact>]
+let ``falsifiabilityWithScore returns gradient average`` () =
+    let claims =
+        SignalQuality.claimsOf [ ("testable-claim", 1L); ("vague-claim", 1L); ("unfalsifiable", 1L) ]
+    let scorer (s: string) =
+        match s with
+        | "testable-claim" -> 1.0
+        | "vague-claim" -> 0.5
+        | _ -> 0.0
+    SignalQuality.falsifiabilityWithScore scorer claims
+    |> should (equalWithin 1e-9) 0.5
+
+
+[<Fact>]
+let ``falsifiabilityWithScore clamps to 0-1`` () =
+    let claims = SignalQuality.claimsOf [ ("over", 1L) ]
+    SignalQuality.falsifiabilityWithScore (fun _ -> 2.5) claims
+    |> should (equalWithin 1e-9) 1.0
+
+
+[<Fact>]
+let ``falsifiabilityWithScore ignores retracted claims`` () =
+    let claims =
+        SignalQuality.claimsOf [ ("alive", 1L); ("dead", 1L); ("dead", -1L) ]
+    SignalQuality.falsifiabilityWithScore (fun _ -> 0.8) claims
+    |> should (equalWithin 1e-9) 0.8
+
+
 // ═══════════════════════════════════════════════════════════════════
 // Consistency — only over-retraction flags inconsistency; clean
 // cancellation to zero is fine.


### PR DESCRIPTION
## Summary

- Add `falsifiabilityWithScore` — gradient variant that takes `string -> float` scorer instead of `string -> bool` predicate
- Add `falsifiabilityMeasureGradient` — IQualityMeasure wrapper using "disagreement" (unloaded language) instead of "suspicion"
- Each claim gets a falsifiability score in [0.0, 1.0]; aggregate is clamped weighted average
- 3 new tests: gradient average, clamping, retraction-ignoring

Aaron's framing: falsifiability was "sharp" (boolean), needs to be "round" (gradient). The per-claim predicate was the sharp part — now claims can be partially falsifiable.

"Disagreement" replaces "suspicion" in the new variant — distance from falsifiability ideal, no value judgment.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test --filter SignalQuality` — 22/22 pass
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)