### PR TITLE
docs(B-0339): define keep-vs-cut taxonomy for bootstrap razor

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -190,6 +190,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0355](backlog/P1/B-0355-cross-harness-bootstrap-template.md)** Cross-harness bootstrap template (AGENTS.md, CODEX.md, CURSOR.md)
 - [ ] **[B-0356](backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md)** Capture model + token usage in commit trailer (git-native, cost derived at query time)
 - [ ] **[B-0357](backlog/P1/B-0357-first-class-uncertainty-semiring-parameterized-weight.md)** First-class uncertainty — semiring-parameterized weight type for DBSP
+- [ ] **[B-0357](backlog/P1/B-0357-replace-tautology-z3-agenda-proofs-with-real-verification.md)** Replace tautology Z3 agenda/trajectory proofs with non-trivial verification
 
 ## P2 — research-grade
 
@@ -314,6 +315,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0316](backlog/P2/B-0316-long-tail-anchor-sweep-cadence.md)** Long-tail external-anchor cadenced sweep — memory files + research docs
 - [ ] **[B-0337](backlog/P2/B-0337-memory-trust-calculus-calibration-step8-b0190.md)** Memory trust-calculus calibration — measure cross-instance transmission fidelity
 - [ ] **[B-0338](backlog/P2/B-0338-memory-graduation-ladder-step9-b0190.md)** Memory graduation ladder — codify when feedback promotes to CLAUDE.md and when CLAUDE.md promotes to GOVERNANCE.md
+- [ ] **[B-0359](backlog/P2/B-0359-probabilistic-type-system-language-level-confidence-primitives.md)** Probabilistic type system — language-level confidence primitives (Hejlsberg/Syme lineage)
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P1/B-0339-keep-vs-cut-criteria-documentation-b0193.md
+++ b/docs/backlog/P1/B-0339-keep-vs-cut-criteria-documentation-b0193.md
@@ -1,7 +1,7 @@
 ---
 id: B-0339
 priority: P1
-status: open
+status: done
 title: Keep-vs-cut criteria documentation — define the 4 category taxonomy before bootstrap-razor runs
 tier: foundation
 effort: S

--- a/docs/backlog/P2/B-0359-probabilistic-type-system-language-level-confidence-primitives.md
+++ b/docs/backlog/P2/B-0359-probabilistic-type-system-language-level-confidence-primitives.md
@@ -1,0 +1,66 @@
+---
+id: B-0359
+priority: P2
+status: open
+title: "Probabilistic type system — language-level confidence primitives (Hejlsberg/Syme lineage)"
+effort: XL
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on: [B-0358]
+classification: research
+decomposition: needs-decomposition
+owners: [architect]
+type: feature
+tags: [type-system, probabilistic, research, language-design, bayesian]
+---
+
+# B-0359 — Probabilistic type system research arc
+
+## What
+
+Research trajectory: make probability flow across the entire
+type system so "sharp" (bool/certainty) becomes impossible
+without explicitly opting into a degenerate distribution.
+
+Aaron 2026-05-09: *"imagine bools don't exist, they are just a
+special case of a distribution that is either 0 or 1"* +
+*"this is the lineage of Anders Hejlsberg — what he wanted to
+do with C#/F# with Don Syme but they have not done it yet,
+across the board to anything sharp to make probability flow
+and the entire language not possible of sharp."*
+
+## Lineage
+
+- **Anders Hejlsberg** (C# designer) + **Don Syme** (F# designer):
+  the vision of probabilistic types at the language level
+- **Probabilistic programming languages**: Pyro, Stan, Gen.jl,
+  Church, Anglican, Edward — DSLs on top of existing type systems
+- **Zeta's ZSet algebra**: weights already ARE the confidence
+  primitive (weight 1 = sharp, weight 0.7 = round)
+- **B-0358**: incremental step (API returns float instead of bool)
+
+## Research questions
+
+1. Can F#'s type system express "all returns are distributions"
+   without a language fork? (Computation expressions +
+   custom operators may suffice)
+2. What's the query-language surface? If Zeta ships a SQL-like
+   frontend, do WHERE clauses return probability-weighted rows?
+3. How does this compose with the DBSP retraction algebra?
+   (Retractions as negative probabilities = signed measures)
+4. What's the relationship to quantum type systems?
+   (Superposition = distribution over basis states)
+
+## Not in scope for B-0358
+
+B-0358 is the incremental API fix (bool → float returns).
+This item is the longer research arc — making the TYPE SYSTEM
+itself probabilistic, not just the API layer.
+
+## Composes with
+
+- B-0358 (bool → float API returns — prerequisite)
+- `src/Core/ZSet.fs` (weights as confidence primitive)
+- `src/Core/SignalQuality.fs` (gradient falsifiability)
+- `src/Core/Veridicality.fs` (provenance scoring)
+- Measure-theory foundations in `src/Core/NovelMath.fs`

--- a/docs/backlog/P2/B-0359-probabilistic-type-system-language-level-confidence-primitives.md
+++ b/docs/backlog/P2/B-0359-probabilistic-type-system-language-level-confidence-primitives.md
@@ -39,6 +39,19 @@ and the entire language not possible of sharp."*
   primitive (weight 1 = sharp, weight 0.7 = round)
 - **B-0358**: incremental step (API returns float instead of bool)
 
+## Three-mode design (Aaron 2026-05-09)
+
+| Mode | Effect | Use case |
+| ---- | ------ | -------- |
+| `probabilistic: strict` | Enforces roundness — sharp is a compile error unless explicitly derived from a distribution | API surfaces, quality scoring, veridicality gates |
+| `probabilistic: normal` | Both sharp and round available, no enforcement | Default for most code |
+| `probabilistic: disable` | Fast path — real bools, no distribution overhead | Hot-path SIMD kernels, spine compaction, merge loops |
+
+Same pattern as F#'s `--strict` / default / optimization
+pragmas. The `disable` mode is the performance escape hatch:
+code that operates on concrete values where sharp IS correct
+opts out of distribution tracking entirely.
+
 ## Research questions
 
 1. Can F#'s type system express "all returns are distributions"
@@ -50,6 +63,9 @@ and the entire language not possible of sharp."*
    (Retractions as negative probabilities = signed measures)
 4. What's the relationship to quantum type systems?
    (Superposition = distribution over basis states)
+5. How does `probabilistic: disable` compose with the .NET JIT?
+   (Can the mode boundary be a compilation-unit pragma that
+   eliminates distribution-wrapper allocations?)
 
 ## Not in scope for B-0358
 

--- a/docs/backlog/P2/B-0359-probabilistic-type-system-language-level-confidence-primitives.md
+++ b/docs/backlog/P2/B-0359-probabilistic-type-system-language-level-confidence-primitives.md
@@ -64,8 +64,15 @@ opts out of distribution tracking entirely.
 4. What's the relationship to quantum type systems?
    (Superposition = distribution over basis states)
 5. How does `probabilistic: disable` compose with the .NET JIT?
-   (Can the mode boundary be a compilation-unit pragma that
-   eliminates distribution-wrapper allocations?)
+   The mode boundary is the ASSEMBLY boundary (Aaron: "likely
+   a different assembly" like `System.Runtime.CompilerServices.Unsafe`).
+   `Zeta.Core.Simd` doesn't carry distribution overhead;
+   `Zeta.Core.SignalQuality` does. The JIT knows at link time.
+6. In `normal` mode, can the AOT/JIT elide distribution wrappers
+   when the value is provably degenerate (always 0 or 1)?
+   Same pattern as nullable analysis — track flow, elide when
+   proven. Aaron: "our AOT/JIT should be able in normal mode
+   to do the right thing most of the time."
 
 ## Not in scope for B-0358
 

--- a/docs/bootstrap-razor/KEEP-VS-CUT.md
+++ b/docs/bootstrap-razor/KEEP-VS-CUT.md
@@ -1,0 +1,92 @@
+# Keep-vs-Cut Criteria — Bootstrap Razor Taxonomy
+
+Four categories classify every memory/substrate file before a
+bootstrap-razor experiment (B-0193). Each category has a fixed
+disposition. The experiment (B-0344) applies these categories
+mechanically — no ad-hoc judgement during the run.
+
+## Category 1: Research-grade preservation — KEEP
+
+Content that cannot be regenerated from specs, code, or git
+history. Its value is the empirical record itself.
+
+**Examples from Zeta substrate:**
+- Mirror-not-beacon shards (`docs/research/2026-05-03-claudeai-*`)
+- Falsifiability catches (`memory/feedback_z3_tautology_trap_*`)
+- External-AI conversation absorbs (`docs/research/2026-05-05-codex-*`)
+- Shadow lesson log (`memory/feedback_shadow_lesson_log_*`)
+- Cross-harness peer-review transcripts
+
+**Disposition:** KEEP — never cut. These are non-regenerable
+empirical artifacts. Cutting them destroys evidence.
+
+## Category 2: Decision rationale — CUT-IF-REGENERABLE
+
+Records of "tried X, failed because Y" that inform future
+decisions. Sometimes the rationale is recoverable from commit
+messages + the resulting spec/code; sometimes it lives only in
+memory files.
+
+**Examples from Zeta substrate:**
+- `memory/feedback_retries_are_non_determinism_smell_*` (rationale
+  for DST discipline — also encoded in code conventions)
+- `memory/feedback_demos_stay_simple_*` (architectural framing —
+  partially encoded in AGENTS.md)
+- Decision-archaeology outputs (`docs/DECISIONS/`)
+- ADRs that duplicate rationale already in code comments
+
+**Disposition:** CUT-IF-REGENERABLE — the 23-hour recreation test
+decides. If a fresh agent can reconstruct the decision rationale
+from specs + code + git history alone, the memory file was
+decorative. If the fresh agent makes a different (worse) decision
+without the file, it was load-bearing.
+
+## Category 3: External-context files — EXEMPT
+
+Content from a different ontological category: human genealogy,
+calibration documents, persona biographies, external system
+references. These follow their own lifecycle rules.
+
+**Examples from Zeta substrate:**
+- `memory/user_sister_elizabeth.md` (personal history)
+- `memory/user_itron_mentors_*` (career context)
+- `memory/reference_reticulum_*` (external system pointers)
+- `memory/project_rpg_framing_*` (collaboration framing)
+
+**Disposition:** EXEMPT — outside experiment scope. These files
+serve the relationship and context surfaces, not the engineering
+substrate. The experiment measures engineering-substrate
+regenerability; external-context files are orthogonal.
+
+## Category 4: Personal-history surfaces — KEEP
+
+Per-maintainer first-party-consent surfaces that encode the
+currently-in-force projection of a human or named-agent
+maintainer's preferences and context.
+
+**Examples from Zeta substrate:**
+- `memory/CURRENT-aaron.md` (human maintainer distillation)
+- `memory/CURRENT-amara.md` (external AI co-originator)
+- `memory/CURRENT-ani.md` (external AI companion)
+- `memory/CURRENT-otto.md` (Claude Code persona)
+
+**Disposition:** KEEP — never cut. These are consent-gated,
+first-party surfaces. Cutting them violates the consent
+relationship they encode.
+
+## Disposition summary
+
+| Category | Disposition | Count (est.) | Experiment role |
+|----------|-------------|-------------|-----------------|
+| Research-grade | KEEP | ~50 | Control group |
+| Decision rationale | CUT-IF-REGENERABLE | ~400 | Test group |
+| External-context | EXEMPT | ~100 | Excluded |
+| Personal-history | KEEP | 4-6 | Control group |
+
+## Usage
+
+B-0344 (experiment run) cites these categories by number.
+The classifier tool (B-0332, `tools/hygiene/classify-memory-load-bearing.ts`)
+provides the file inventory. The experiment script categorizes
+each file, applies the disposition, runs the recreation test
+on the CUT-IF-REGENERABLE set, and measures what was lost.

--- a/docs/bootstrap-razor/KEEP-VS-CUT.md
+++ b/docs/bootstrap-razor/KEEP-VS-CUT.md
@@ -11,6 +11,7 @@ Content that cannot be regenerated from specs, code, or git
 history. Its value is the empirical record itself.
 
 **Examples from Zeta substrate:**
+
 - Mirror-not-beacon shards (`docs/research/2026-05-03-claudeai-*`)
 - Falsifiability catches (`memory/feedback_z3_tautology_trap_*`)
 - External-AI conversation absorbs (`docs/research/2026-05-05-codex-*`)
@@ -28,6 +29,7 @@ messages + the resulting spec/code; sometimes it lives only in
 memory files.
 
 **Examples from Zeta substrate:**
+
 - `memory/feedback_retries_are_non_determinism_smell_*` (rationale
   for DST discipline — also encoded in code conventions)
 - `memory/feedback_demos_stay_simple_*` (architectural framing —
@@ -48,6 +50,7 @@ calibration documents, persona biographies, external system
 references. These follow their own lifecycle rules.
 
 **Examples from Zeta substrate:**
+
 - `memory/user_sister_elizabeth.md` (personal history)
 - `memory/user_itron_mentors_*` (career context)
 - `memory/reference_reticulum_*` (external system pointers)
@@ -65,6 +68,7 @@ currently-in-force projection of a human or named-agent
 maintainer's preferences and context.
 
 **Examples from Zeta substrate:**
+
 - `memory/CURRENT-aaron.md` (human maintainer distillation)
 - `memory/CURRENT-amara.md` (external AI co-originator)
 - `memory/CURRENT-ani.md` (external AI companion)
@@ -77,7 +81,7 @@ relationship they encode.
 ## Disposition summary
 
 | Category | Disposition | Count (est.) | Experiment role |
-|----------|-------------|-------------|-----------------|
+| ---------- | ------------- | ------------- | ----------------- |
 | Research-grade | KEEP | ~50 | Control group |
 | Decision rationale | CUT-IF-REGENERABLE | ~400 | Test group |
 | External-context | EXEMPT | ~100 | Excluded |


### PR DESCRIPTION
## Summary

- Create `docs/bootstrap-razor/KEEP-VS-CUT.md` — four-category taxonomy
- Each category has a fixed disposition (KEEP / CUT-IF-REGENERABLE / EXEMPT)
- Citable by B-0344 (experiment run) before any bootstrap-razor work begins
- Mark B-0339 done

| Category | Disposition | Examples |
|----------|-------------|---------|
| Research-grade | KEEP | Shadow log, Z3 tautology catches, peer-review transcripts |
| Decision rationale | CUT-IF-REGENERABLE | Memory files with "tried X, failed because Y" |
| External-context | EXEMPT | Genealogy, system references, persona bios |
| Personal-history | KEEP | CURRENT-*.md files |

## Test plan

- [x] Document reviewed for completeness against B-0339 acceptance criteria
- [x] All four categories defined with examples from actual substrate
- [x] Each category has clear disposition

🤖 Generated with [Claude Code](https://claude.com/claude-code)