### PR TITLE
fix(B-0335): address Copilot P0/P1/P2 review findings (post-merge followup)

### DIFF
--- a/docs/backlog/P1/B-0335-memory-schema-validation-tooling-step11-b0190.md
+++ b/docs/backlog/P1/B-0335-memory-schema-validation-tooling-step11-b0190.md
@@ -7,7 +7,7 @@ tier: foundation
 effort: M
 ask: B-0190 Step 11 decomposition
 created: 2026-05-08
-last_updated: 2026-05-08
+last_updated: 2026-05-09
 parent: B-0190
 depends_on: [B-0330]
 composes_with: [B-0190, B-0330, B-0334]

--- a/tools/hygiene/validate-memory-schema.ts
+++ b/tools/hygiene/validate-memory-schema.ts
@@ -7,8 +7,12 @@ import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 
 function getDefaultMemoryDir(): string {
-    const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
-    return join(repoRoot, "memory");
+    try {
+        const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+        return join(repoRoot, "memory");
+    } catch {
+        throw new Error("Not a git repository or git is unavailable. Pass --memory-dir to specify the memory directory explicitly.");
+    }
 }
 
 const VALID_TYPES = ["feedback", "user", "project", "reference"] as const;
@@ -21,10 +25,10 @@ const PREFIX_TO_TYPE: Record<string, MemoryType> = {
     reference_: "reference",
 };
 
-// Per B-0330: feedback files require Why + How-to-apply; project files require Why.
+// Per B-0330: feedback and project files require Why + How-to-apply.
 const REQUIRED_BODY_MARKERS: Partial<Record<MemoryType, string[]>> = {
     feedback: ["Why:", "How to apply:"],
-    project: ["Why:"],
+    project: ["Why:", "How to apply:"],
 };
 
 const SPECIAL_FILES = new Set([
@@ -132,13 +136,17 @@ function applyFixes(file: string, content: string, violations: Violation[]): str
             if (!prefix) continue;
             const expectedType = PREFIX_TO_TYPE[prefix];
             if (!expectedType) continue;
-            if (fixed.includes("\ntype:")) {
-                fixed = fixed.replace(/\ntype:[^\n]*/, `\ntype: ${expectedType}`);
+            // Restrict replacement to the frontmatter block (before the closing \n---).
+            // Replacing in the full file can accidentally rewrite a `type:` occurrence in
+            // the body (e.g., in code examples) while leaving the frontmatter unchanged.
+            const fmEnd = fixed.indexOf("\n---", 3);
+            if (fmEnd === -1) continue;
+            const fm = fixed.slice(0, fmEnd);
+            const rest = fixed.slice(fmEnd);
+            if (fm.includes("\ntype:")) {
+                fixed = fm.replace(/\ntype:[^\n]*/, `\ntype: ${expectedType}`) + rest;
             } else {
-                const endIdx = fixed.indexOf("\n---", 3);
-                if (endIdx !== -1) {
-                    fixed = fixed.slice(0, endIdx) + `\ntype: ${expectedType}` + fixed.slice(endIdx);
-                }
+                fixed = fm + `\ntype: ${expectedType}` + rest;
             }
         }
     }
@@ -284,7 +292,14 @@ function main(argv: string[] = process.argv): number {
         }
     }
 
-    const result = validate(memoryDir);
+    let result: ValidateResult;
+    try {
+        result = validate(memoryDir);
+    } catch (e) {
+        console.error(`Error reading memory directory "${memoryDir}": ${e}`);
+        console.error("Pass --memory-dir to specify a valid directory.");
+        return 1;
+    }
 
     if (fix) {
         const fixableFiles = new Set(
@@ -303,6 +318,12 @@ function main(argv: string[] = process.argv): number {
                 writeFileSync(filePath, fixed, "utf8");
                 if (!jsonOutput) console.log(`Fixed: ${file}`);
             }
+        }
+        // Re-validate so output and --enforce reflect the post-fix state.
+        try {
+            result = validate(memoryDir);
+        } catch {
+            // If re-validate fails unexpectedly, fall through with the pre-fix result.
         }
     }
 

--- a/tools/hygiene/validate-memory-schema.ts
+++ b/tools/hygiene/validate-memory-schema.ts
@@ -2,15 +2,14 @@
 // validate-memory-schema.ts — B-0335
 // Enforces the memory-file format standard (B-0330) mechanically.
 
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { execFileSync } from "node:child_process";
 
-const home = process.env.HOME ?? homedir();
-const DEFAULT_MEMORY_DIR = join(
-    home,
-    ".claude/projects/-Users-acehack-Documents-src-repos-Zeta/memory",
-);
+function getDefaultMemoryDir(): string {
+    const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+    return join(repoRoot, "memory");
+}
 
 const VALID_TYPES = ["feedback", "user", "project", "reference"] as const;
 type MemoryType = (typeof VALID_TYPES)[number];
@@ -20,6 +19,12 @@ const PREFIX_TO_TYPE: Record<string, MemoryType> = {
     user_: "user",
     project_: "project",
     reference_: "reference",
+};
+
+// Per B-0330: feedback files require Why + How-to-apply; project files require Why.
+const REQUIRED_BODY_MARKERS: Partial<Record<MemoryType, string[]>> = {
+    feedback: ["Why:", "How to apply:"],
+    project: ["Why:"],
 };
 
 const SPECIAL_FILES = new Set([
@@ -76,32 +81,89 @@ function isSpecialFile(filename: string): boolean {
 }
 
 function parseMemoryIndex(memoryDir: string): Set<string> {
-    const indexPath = join(memoryDir, "MEMORY.md");
-    if (!existsSync(indexPath)) return new Set();
-    const content = readFileSync(indexPath, "utf8");
+    let content: string;
+    try {
+        content = readFileSync(join(memoryDir, "MEMORY.md"), "utf8");
+    } catch {
+        return new Set();
+    }
     const linked = new Set<string>();
     const linkPattern = /\]\(([^)]+\.md)\)/g;
     let match: RegExpExecArray | null;
     while ((match = linkPattern.exec(content)) !== null) {
-        linked.add(match[1]!);
+        const target = match[1]!;
+        // Only count flat filenames (no path separators) as memory-file index entries.
+        // MEMORY.md also links to subdirectories (e.g. architectural-intent-guesses/README.md)
+        // and external paths (../docs/research/...) — those are not memory files.
+        if (!target.includes("/")) {
+            linked.add(target);
+        }
     }
     return linked;
 }
 
+function checkSectionMarkers(body: string, fileType: MemoryType): string[] {
+    const required = REQUIRED_BODY_MARKERS[fileType] ?? [];
+    return required.filter((marker) => !body.toLowerCase().includes(marker.toLowerCase()));
+}
+
+function checkLinkIntegrity(body: string, allFiles: Set<string>): string[] {
+    const broken: string[] = [];
+    const linkPattern = /\]\(([^)]+\.md)\)/g;
+    let match: RegExpExecArray | null;
+    while ((match = linkPattern.exec(body)) !== null) {
+        const target = match[1]!;
+        // Only validate flat memory-file links (no path separators).
+        if (!target.includes("/") && !allFiles.has(target)) {
+            broken.push(target);
+        }
+    }
+    return broken;
+}
+
+function applyFixes(file: string, content: string, violations: Violation[]): string {
+    const fixable = violations.filter((v) => v.file === file && v.fixable);
+    if (fixable.length === 0) return content;
+
+    let fixed = content;
+    for (const v of fixable) {
+        if (v.check === "prefix-type-mismatch" || v.check === "frontmatter-type") {
+            const prefix = extractPrefix(file);
+            if (!prefix) continue;
+            const expectedType = PREFIX_TO_TYPE[prefix];
+            if (!expectedType) continue;
+            if (fixed.includes("\ntype:")) {
+                fixed = fixed.replace(/\ntype:[^\n]*/, `\ntype: ${expectedType}`);
+            } else {
+                const endIdx = fixed.indexOf("\n---", 3);
+                if (endIdx !== -1) {
+                    fixed = fixed.slice(0, endIdx) + `\ntype: ${expectedType}` + fixed.slice(endIdx);
+                }
+            }
+        }
+    }
+    return fixed;
+}
+
 function validate(memoryDir: string): ValidateResult {
     const allEntries = readdirSync(memoryDir).filter((f) => f.endsWith(".md"));
+    const allFilesSet = new Set(allEntries);
     const regularFiles = allEntries.filter((f) => !isSpecialFile(f));
     const violations: Violation[] = [];
 
     for (const file of regularFiles) {
-        const content = readFileSync(join(memoryDir, file), "utf8");
+        let content: string;
+        try {
+            content = readFileSync(join(memoryDir, file), "utf8");
+        } catch (e) {
+            violations.push({ file, check: "read-error", severity: "error", message: `Could not read file: ${e}`, fixable: false });
+            continue;
+        }
         const prefix = extractPrefix(file);
 
         if (!prefix) {
             violations.push({
-                file,
-                check: "filename-prefix",
-                severity: "error",
+                file, check: "filename-prefix", severity: "error",
                 message: `Filename does not start with a valid type prefix (${VALID_TYPES.join("/")}_)`,
                 fixable: false,
             });
@@ -109,61 +171,43 @@ function validate(memoryDir: string): ValidateResult {
 
         if (file.includes(" ")) {
             violations.push({
-                file,
-                check: "filename-spaces",
-                severity: "error",
-                message: "Filename contains spaces (use underscores)",
-                fixable: false,
+                file, check: "filename-spaces", severity: "error",
+                message: "Filename contains spaces (use underscores)", fixable: false,
             });
         }
 
         const fm = parseFrontmatter(content);
         if (!fm) {
             violations.push({
-                file,
-                check: "frontmatter-missing",
-                severity: "error",
-                message: "No YAML frontmatter block found",
-                fixable: false,
+                file, check: "frontmatter-missing", severity: "error",
+                message: "No YAML frontmatter block found", fixable: false,
             });
             continue;
         }
 
         if (!fm.fields["name"]) {
             violations.push({
-                file,
-                check: "frontmatter-name",
-                severity: "error",
-                message: "Missing required field: name",
-                fixable: false,
+                file, check: "frontmatter-name", severity: "error",
+                message: "Missing required field: name", fixable: false,
             });
         }
 
         if (!fm.fields["description"]) {
             violations.push({
-                file,
-                check: "frontmatter-description",
-                severity: "error",
-                message: "Missing required field: description",
-                fixable: false,
+                file, check: "frontmatter-description", severity: "error",
+                message: "Missing required field: description", fixable: false,
             });
         }
 
         if (!fm.fields["type"]) {
             violations.push({
-                file,
-                check: "frontmatter-type",
-                severity: "error",
-                message: "Missing required field: type",
-                fixable: true,
+                file, check: "frontmatter-type", severity: "error",
+                message: "Missing required field: type", fixable: true,
             });
         } else if (!VALID_TYPES.includes(fm.fields["type"] as MemoryType)) {
             violations.push({
-                file,
-                check: "frontmatter-type-invalid",
-                severity: "error",
-                message: `Invalid type: "${fm.fields["type"]}" (must be ${VALID_TYPES.join("|")})`,
-                fixable: false,
+                file, check: "frontmatter-type-invalid", severity: "error",
+                message: `Invalid type: "${fm.fields["type"]}" (must be ${VALID_TYPES.join("|")})`, fixable: false,
             });
         }
 
@@ -171,13 +215,32 @@ function validate(memoryDir: string): ValidateResult {
             const expectedType = PREFIX_TO_TYPE[prefix];
             if (expectedType && fm.fields["type"] !== expectedType) {
                 violations.push({
-                    file,
-                    check: "prefix-type-mismatch",
-                    severity: "error",
+                    file, check: "prefix-type-mismatch", severity: "error",
                     message: `Filename prefix "${prefix}" implies type "${expectedType}" but frontmatter says "${fm.fields["type"]}"`,
                     fixable: true,
                 });
             }
+        }
+
+        const fileType = (fm.fields["type"] as MemoryType | undefined) ??
+            (prefix ? PREFIX_TO_TYPE[prefix] : undefined);
+        const body = content.slice(fm.bodyStart);
+
+        if (fileType) {
+            for (const marker of checkSectionMarkers(body, fileType)) {
+                violations.push({
+                    file, check: "section-marker-missing", severity: "warning",
+                    message: `Missing required body marker: "${marker}" (per B-0330 ${fileType} format)`,
+                    fixable: false,
+                });
+            }
+        }
+
+        for (const link of checkLinkIntegrity(body, allFilesSet)) {
+            violations.push({
+                file, check: "link-integrity", severity: "warning",
+                message: `Link target not found in memory dir: ${link}`, fixable: false,
+            });
         }
     }
 
@@ -200,10 +263,11 @@ function validate(memoryDir: string): ValidateResult {
     };
 }
 
-function main(argv: string[] = process.argv): void {
-    let memoryDir = DEFAULT_MEMORY_DIR;
+function main(argv: string[] = process.argv): number {
+    let memoryDir: string | undefined;
     const jsonOutput = argv.includes("--json");
     const enforce = argv.includes("--enforce");
+    const fix = argv.includes("--fix");
 
     for (let i = 2; i < argv.length; i++) {
         if (argv[i] === "--memory-dir" && argv[i + 1]) {
@@ -211,17 +275,42 @@ function main(argv: string[] = process.argv): void {
         }
     }
 
-    if (!existsSync(memoryDir)) {
-        console.error(`Memory directory not found: ${memoryDir}`);
-        process.exit(1);
+    if (!memoryDir) {
+        try {
+            memoryDir = getDefaultMemoryDir();
+        } catch (e) {
+            console.error(String(e));
+            return 1;
+        }
     }
 
     const result = validate(memoryDir);
+
+    if (fix) {
+        const fixableFiles = new Set(
+            result.violations.filter((v) => v.fixable).map((v) => v.file),
+        );
+        for (const file of fixableFiles) {
+            const filePath = join(memoryDir, file);
+            let content: string;
+            try {
+                content = readFileSync(filePath, "utf8");
+            } catch {
+                continue;
+            }
+            const fixed = applyFixes(file, content, result.violations);
+            if (fixed !== content) {
+                writeFileSync(filePath, fixed, "utf8");
+                if (!jsonOutput) console.log(`Fixed: ${file}`);
+            }
+        }
+    }
 
     if (jsonOutput) {
         console.log(JSON.stringify(result, null, 2));
     } else {
         console.log("\n=== Memory Schema Validation ===\n");
+        console.log(`Memory dir: ${memoryDir}`);
         console.log(`Total files: ${result.totalFiles}`);
         console.log(`Checked (regular memory files): ${result.checkedFiles}`);
         console.log(`Errors: ${result.errorCount}`);
@@ -253,12 +342,13 @@ function main(argv: string[] = process.argv): void {
     }
 
     if (enforce && result.errorCount > 0) {
-        process.exit(2);
+        return 2;
     }
+    return 0;
 }
 
 if (import.meta.main) {
-    main();
+    process.exit(main());
 }
 
 export { validate, parseFrontmatter, extractPrefix };


### PR DESCRIPTION
## Summary

- **P0**: Fix `DEFAULT_MEMORY_DIR` to use `git rev-parse --show-toplevel` — the hardcoded `~/.claude/projects/-Users-acehack-Documents-src-repos-Zeta/memory` path failed for all contributors and CI runners
- **P0**: Fix `parseMemoryIndex` to filter out links containing `/` — MEMORY.md links to subdirectories (`architectural-intent-guesses/README.md`) and external paths (`../docs/research/...`) were misidentified as orphan entries
- **P1**: Replace `existsSync` + `readFileSync` TOCTOU pattern with `try/catch` around a single `readFileSync`, matching `audit-memory-index-duplicates.ts` convention
- **P2**: `main()` now returns `number`; `process.exit()` moved to `import.meta.main` guard
- Add missing AC: section-marker check (feedback/project type required markers), link-integrity check, `--fix` flag
- Bump `B-0335` `last_updated` to 2026-05-09

## Context

PR #2202 merged before the fix commit landed. This follow-up closes all 5 Copilot review threads from that PR.

## Test plan

- [ ] `bun tools/hygiene/validate-memory-schema.ts` runs without error against repo `memory/`
- [ ] `bun tools/hygiene/validate-memory-schema.ts --json` produces valid JSON output
- [ ] `bun tools/hygiene/validate-memory-schema.ts --memory-dir <path>` respects the override
- [ ] `bun --bun tsc --noEmit -p tsconfig.json` passes (no new TS errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)