### PR TITLE
docs(B-0341): define minimal bootstrap seed manifest

### DIFF
--- a/docs/backlog/P1/B-0341-minimal-bootstrap-seed-manifest-b0193.md
+++ b/docs/backlog/P1/B-0341-minimal-bootstrap-seed-manifest-b0193.md
@@ -1,7 +1,7 @@
 ---
 id: B-0341
 priority: P1
-status: open
+status: done
 title: Minimal bootstrap seed manifest — exact file set for the recreation test repo
 tier: foundation
 effort: S

--- a/docs/bootstrap-razor/SEED-MANIFEST.md
+++ b/docs/bootstrap-razor/SEED-MANIFEST.md
@@ -1,0 +1,118 @@
+# Seed Manifest — Bootstrap Razor Test Repo
+
+The minimal file set that seeds the test repo for the 23-hour
+recreation experiment (B-0193). A fresh-context agent starts
+with ONLY these files and attempts to recreate the codebase.
+
+## Design decisions
+
+### 1. Bootstrap docs: EXCLUDED
+
+The test repo does NOT include CLAUDE.md, AGENTS.md, or
+GOVERNANCE.md. Rationale: including them gives the fresh agent
+the answer key — factory conventions, reviewer roles, build
+gates. Excluding them tests whether specs alone are sufficient
+to derive those conventions. This is the stronger test.
+
+If the fresh agent cannot derive build conventions from specs,
+that's a finding (the specs are incomplete, not that the
+bootstrap docs should be included).
+
+### 2. Formal proofs: INCLUDED
+
+TLA+ specs are included because they encode safety invariants
+that can't be derived from code alone (they specify properties
+the code SHOULD have, not properties it DOES have). Excluding
+them would force the fresh agent to rediscover safety
+properties from first principles — interesting but not the
+hypothesis under test.
+
+### 3. Directory structure: MIRRORED
+
+The test repo mirrors Zeta's directory layout. Rationale: the
+directory structure IS part of the spec (paths are referenced
+in overlay files, profile templates, etc.).
+
+## Included paths
+
+```yaml
+include:
+  # OpenSpec behavioural specs (6 capabilities)
+  - openspec/specs/**/spec.md
+  - openspec/specs/**/overlays/**
+  - openspec/README.md
+
+  # TLA+ formal specs (19 specs)
+  - tools/tla/specs/*.tla
+
+  # Alloy specs (2 specs)
+  - tools/alloy/specs/*.als
+
+  # Z3 verification (the algebraic lemmas, not the tautologies)
+  - tools/Z3Verify/Program.fs
+  - tools/Z3Verify/Z3Verify.fsproj
+
+  # Build infrastructure (the contract, not the implementation)
+  - Directory.Build.props
+  - Directory.Packages.props
+  - Zeta.sln
+  - .editorconfig
+
+  # Project structure (empty dirs with READMEs)
+  - src/Core/README.md          # if exists
+  - tests/Tests.FSharp/README.md # if exists
+```
+
+## Excluded paths (with rationale)
+
+```yaml
+exclude:
+  # Bootstrap docs — the answer key (Decision #1)
+  - CLAUDE.md
+  - AGENTS.md
+  - GOVERNANCE.md
+  - docs/ALIGNMENT.md
+
+  # Source code — the thing being recreated
+  - src/**/*.fs
+  - src/**/*.cs
+  - tests/**/*.fs
+
+  # Memory — per B-0339 categories 1/3/4 (KEEP/EXEMPT)
+  - memory/**
+
+  # Factory tooling — derivative of specs
+  - tools/hygiene/**
+  - tools/backlog/**
+  - tools/github/**
+  - tools/ops/**
+  - tools/peer-call/**
+
+  # CI workflows — derivative of repo-automation spec
+  - .github/workflows/**
+
+  # Skills/agents/commands — derivative of GOVERNANCE
+  - .claude/**
+
+  # Docs — derivative or exempt
+  - docs/**  # except bootstrap-razor/ itself
+```
+
+## Metrics
+
+Per B-0340 (spec audit):
+
+| What's seeded | Count |
+| ------------- | ----- |
+| OpenSpec behavioural specs | 6 |
+| TLA+ formal specs | 19 |
+| Alloy specs | 2 |
+| Z3 lemmas | 16 |
+| Build config files | 4 |
+| **Total seed files** | **~47** |
+
+The recreation experiment measures: from these 47 files, how
+much of the 81-module `src/Core/` can a fresh agent recreate
+in 23 hours? The spec audit (B-0340) showed 37% coverage —
+the experiment tests whether that 37% is sufficient to
+bootstrap the other 63%.


### PR DESCRIPTION
## Summary

- Create `docs/bootstrap-razor/SEED-MANIFEST.md` — lists every included/excluded path with rationale
- 47 seed files (specs + proofs + build config)
- Bootstrap docs deliberately excluded for the stronger test
- Mark B-0341 done

## Test plan

- [x] Manifest is machine-readable (YAML code blocks)
- [x] Every include/exclude has rationale
- [x] Bootstrap-docs decision documented with reasoning
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)