### PR TITLE
docs(B-0336): recalibrate B-0006 MEMORY.md compression targets

### DIFF
--- a/docs/backlog/P1/B-0006-memory-md-compression-pass-prune-distill-entries-to-one-line-cap-200-lines.md
+++ b/docs/backlog/P1/B-0006-memory-md-compression-pass-prune-distill-entries-to-one-line-cap-200-lines.md
@@ -88,7 +88,7 @@ After the pass, the file should be:
 - Entries ordered with most-recent at top (per existing
   convention)
 
-## Acceptance signals
+## Acceptance signals (recalibrated per B-0336, 2026-05-09)
 
 The compression pass is "good enough to ship" when:
 
@@ -101,6 +101,34 @@ The compression pass is "good enough to ship" when:
 - Fast-path discipline (read CURRENT-* + scan MEMORY.md +
   drill into specific body file) works under typical
   context budget
+
+### Recalibrated targets (B-0336)
+
+Current state (2026-05-09): 588 entries in 592 lines.
+B-0332 classifier: 5 load-bearing files (cited from
+CLAUDE.md/AGENTS.md/GOVERNANCE.md/ALIGNMENT.md), 622
+decorative (not cited from bootstrap surfaces).
+
+**Differentiated targets:**
+
+| Category | Target | Rationale |
+| -------- | ------ | --------- |
+| Load-bearing (5 files) | KEEP in index, up to 200 chars | These are the files a fresh agent WILL read via bootstrap citation chain |
+| CURRENT-* files (4-6) | KEEP in index, up to 150 chars | Fast-path discipline requires these visible |
+| Recent entries (last 30 days) | KEEP in index, ~120 chars | Active context; recent memory is high-value |
+| Decorative older entries | REMOVE from index | Files stay on disk; the index is not the archive |
+
+**Feasibility math:** 200 lines - 5 header lines = 195 entries.
+With ~5 load-bearing + ~5 CURRENT + ~100 recent-30-day entries
+= ~110 entries. Leaves ~85 slots for curated older entries.
+This is achievable by removing the ~490 oldest decorative
+entries from the index (not from disk).
+
+**The index is a navigation surface, not an archive.** Files
+removed from the index are still discoverable via grep,
+the classifier tool (B-0332), and the cross-reference
+audit (B-0334). The index serves cold-start agents; the
+tools serve hot-path agents.
 
 ## Risks + mitigations
 

--- a/docs/backlog/P1/B-0336-b0006-acceptance-recalibration-b0190.md
+++ b/docs/backlog/P1/B-0336-b0006-acceptance-recalibration-b0190.md
@@ -1,7 +1,7 @@
 ---
 id: B-0336
 priority: P1
-status: open
+status: done
 title: B-0006 acceptance recalibration — adjust compression targets given load-bearing classification
 tier: maintenance
 effort: S


### PR DESCRIPTION
## Summary

- Recalibrate B-0006 acceptance criteria using B-0332 load-bearing data
- Add differentiated targets: load-bearing KEEP, decorative REMOVE from index
- Feasibility math: 195 slots, ~110 needed, achievable
- Mark B-0336 done

🤖 Generated with [Claude Code](https://claude.com/claude-code)