### PR TITLE
skill(commit-message-shape): add HEREDOC mechanics (B-0069)

### DIFF
--- a/.claude/skills/commit-message-shape/SKILL.md
+++ b/.claude/skills/commit-message-shape/SKILL.md
@@ -96,6 +96,42 @@ coauthor; future contributors see the origin. The
 `noreply@anthropic.com` is a real Anthropic address;
 don't invent a different email.
 
+## HEREDOC mechanics
+
+Multi-line commit messages and PR bodies use the HEREDOC
+pattern to preserve formatting through the shell:
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(B-0042): add the thing
+
+Why: Aaron asked for it. The constraint is X.
+
+- Change 1
+- Change 2
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Key details:
+- **Single-quoted `'EOF'`** — prevents shell expansion
+  inside the message (dollar signs, backticks stay literal).
+- **No leading whitespace** on the `EOF` terminator line.
+- **The closing `)"` on the same line as `EOF`** — no
+  trailing newline after the message.
+
+PR bodies use the same pattern:
+
+```bash
+gh pr create --title "the title" --body "$(cat <<'EOF'
+## Summary
+...
+EOF
+)"
+```
+
 ## One commit or several
 
 **One logical change per commit.** Rules of thumb:

--- a/.claude/skills/commit-message-shape/SKILL.md
+++ b/.claude/skills/commit-message-shape/SKILL.md
@@ -116,6 +116,7 @@ EOF
 ```
 
 Key details:
+
 - **Single-quoted `'EOF'`** — prevents shell expansion
   inside the message (dollar signs, backticks stay literal).
 - **No leading whitespace** on the `EOF` terminator line.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -24,8 +24,8 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0305](backlog/P0/B-0305-mechanical-auth-check-skill-body-2026-05-08.md)** Mechanical authorization check — skill body (SKILL.md via skill-creator)
 - [x] **[B-0306](backlog/P0/B-0306-mechanical-auth-check-pace-extractor-ts-2026-05-08.md)** Mechanical authorization check — pace-instruction extractor + test fixtures
 - [x] **[B-0307](backlog/P0/B-0307-mechanical-auth-check-source-recency-resolver-2026-05-08.md)** Mechanical authorization check — source-filter + recency resolver
-- [ ] **[B-0308](backlog/P0/B-0308-mechanical-auth-check-loop-integration-2026-05-08.md)** Mechanical authorization check — autonomous-loop tick-start integration
-- [ ] **[B-0309](backlog/P0/B-0309-mechanical-auth-check-claude-md-pointer-2026-05-08.md)** Mechanical authorization check — CLAUDE.md discoverable-skill pointer
+- [x] **[B-0308](backlog/P0/B-0308-mechanical-auth-check-loop-integration-2026-05-08.md)** Mechanical authorization check — autonomous-loop tick-start integration
+- [x] **[B-0309](backlog/P0/B-0309-mechanical-auth-check-claude-md-pointer-2026-05-08.md)** Mechanical authorization check — CLAUDE.md discoverable-skill pointer
 
 ## P1 — within 2-3 rounds
 

--- a/docs/backlog/P2/B-0069-heredoc-patterns-encode-into-commit-message-shape-skill-aaron-2026-04-28.md
+++ b/docs/backlog/P2/B-0069-heredoc-patterns-encode-into-commit-message-shape-skill-aaron-2026-04-28.md
@@ -1,7 +1,7 @@
 ---
 id: B-0069
 priority: P2
-status: open
+status: done
 title: Encode HEREDOC patterns into commit-message-shape skill (Aaron 2026-04-28)
 effort: S
 ask: maintainer Aaron 2026-04-28 /btw aside


### PR DESCRIPTION
## Summary

Encode HEREDOC patterns into commit-message-shape skill. Three key details: single-quoted EOF, no leading whitespace on terminator, closing )" on same line. Mark B-0069 done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)