### PR TITLE
fix(B-0081): add .kt + .scala to CodeQL path-gate

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -245,10 +245,10 @@ jobs:
               # SC2222 (later pattern shadowed by earlier one).
               src/*|tests/*|tools/*) code_changed=true ;;
               *.cs|*.fs|*.fsproj|*.csproj|*.sln) code_changed=true ;;
-              # Java surface: tools/alloy/AlloyRunner.java is the
-              # only first-party Java today; java is a mise-pinned
-              # runtime per .mise.toml.
-              *.java) code_changed=true ;;
+              # JVM surface: tools/alloy/AlloyRunner.java is the
+              # only first-party Java today. CodeQL java-kotlin
+              # extractor handles .java + .kt + .scala.
+              *.java|*.kt|*.scala) code_changed=true ;;
               *.py|pyproject.toml|requirements*.txt) code_changed=true ;;
               *.js|*.jsx|*.ts|*.tsx|*.mjs|*.cjs) code_changed=true ;;
               package.json|package-lock.json|tsconfig*.json) code_changed=true ;;

--- a/docs/backlog/P2/B-0081-path-gate-kotlin-scala-codex-pr-662.md
+++ b/docs/backlog/P2/B-0081-path-gate-kotlin-scala-codex-pr-662.md
@@ -1,7 +1,7 @@
 ---
 id: B-0081
 priority: P2
-status: open
+status: done
 title: codeql.yml path-gate should match `*.kt` + `*.scala` not just `*.java` — Codex P2 on PR #662
 effort: S
 ask: extend the path-gate `case` statement to include Kotlin and Scala source extensions so the analyze matrix triggers correctly when JVM code changes


### PR DESCRIPTION
## Summary

Add `.kt` and `.scala` extensions to the CodeQL path-gate case statement so security scanning triggers on Kotlin/Scala changes, not just Java.

🤖 Generated with [Claude Code](https://claude.com/claude-code)