### PR TITLE
chore: close stale B-0076 (already in CodeQL matrix)

### DIFF
--- a/docs/backlog/P2/B-0076-disowned-runtime-sweep-python-typescript-2026-04-28.md
+++ b/docs/backlog/P2/B-0076-disowned-runtime-sweep-python-typescript-2026-04-28.md
@@ -1,12 +1,12 @@
 ---
 id: B-0076
 priority: P2
-status: done
+status: closed
 title: Disowned-runtime sweep — Python + TypeScript surface (same pattern PR #662 fixed for Java)
 effort: S
 ask: extend the codeql.yml analyze matrix to cover python + javascript-typescript like PR #662 did for java-kotlin
 created: 2026-04-28
-last_updated: 2026-05-02
+last_updated: 2026-05-09
 depends_on: []
 tags: [codeql, disowned-runtime, python, typescript, dependency-honesty, b-0075-sibling]
 type: friction-reducer

--- a/docs/backlog/P2/B-0076-disowned-runtime-sweep-python-typescript-2026-04-28.md
+++ b/docs/backlog/P2/B-0076-disowned-runtime-sweep-python-typescript-2026-04-28.md
@@ -1,7 +1,7 @@
 ---
 id: B-0076
 priority: P2
-status: open
+status: done
 title: Disowned-runtime sweep — Python + TypeScript surface (same pattern PR #662 fixed for Java)
 effort: S
 ask: extend the codeql.yml analyze matrix to cover python + javascript-typescript like PR #662 did for java-kotlin


### PR DESCRIPTION
Python + JS/TS already in codeql.yml matrix. Mark done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)