### PR TITLE
fix(B-0191): tsc noUncheckedIndexedAccess + BACKLOG.md index drift

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -234,7 +234,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0071](backlog/P2/B-0071-rename-otto-275-forever-out-of-live-lock-class-codex-pr-17-2026-04-28.md)** Rename otto_275_forever memory out of "live-lock 9th pattern" subclass + reclassify per Otto-352 taxonomy split
 - [ ] **[B-0072](backlog/P2/B-0072-memory-md-index-entry-length-normalization-copilot-pr-72-2026-04-28.md)** Normalize MEMORY.md index entry lengths to one-line-per-memory per memory/README.md guidance
 - [ ] **[B-0074](backlog/P2/B-0074-pr-72-punch-list-stale-item-sweep-spec-consistency-2026-04-28.md)** PR #72 punch-list / spec-consistency drift sweep — 8 codex threads on stale items + cross-doc alignment
-- [ ] **[B-0076](backlog/P2/B-0076-disowned-runtime-sweep-python-typescript-2026-04-28.md)** Disowned-runtime sweep — Python + TypeScript surface (same pattern PR #662 fixed for Java)
+- [x] **[B-0076](backlog/P2/B-0076-disowned-runtime-sweep-python-typescript-2026-04-28.md)** Disowned-runtime sweep — Python + TypeScript surface (same pattern PR #662 fixed for Java)
 - [ ] **[B-0077](backlog/P2/B-0077-curl-fetch-canonical-content-cleanup-codex-pr-663.md)** tools/setup/common/curl-fetch.sh canonical-content cleanup — Codex P0/P1 on PR #663
 - [ ] **[B-0078](backlog/P2/B-0078-markdownlint-research-carve-out-narrowing-codex-pr-663.md)** Narrow markdownlint carve-out from `docs/research/2026-*-*.md` to verbatim-only pattern — Codex P1 on PR #663
 - [ ] **[B-0079](backlog/P2/B-0079-audit-agencysignature-script-hardening-codex-pr-663.md)** tools/hygiene/audit-agencysignature-main-tip.sh hardening — 4 Codex findings on PR #663

--- a/tools/orchestrator-checks/check-orchestrator-state.test.ts
+++ b/tools/orchestrator-checks/check-orchestrator-state.test.ts
@@ -14,27 +14,28 @@ describe("parseWorktreeList", () => {
     const raw = `worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n`;
     const entries = parseWorktreeList(raw);
     expect(entries).toHaveLength(1);
-    expect(entries[0].path).toBe("/repo");
-    expect(entries[0].head).toBe("abc123");
-    expect(entries[0].branch).toBe("main");
-    expect(entries[0].bare).toBe(false);
+    const e0 = entries[0]!;
+    expect(e0.path).toBe("/repo");
+    expect(e0.head).toBe("abc123");
+    expect(e0.branch).toBe("main");
+    expect(e0.bare).toBe(false);
   });
 
   test("strips refs/heads/ prefix from branch field", () => {
     const raw = `worktree /repo\nHEAD abc\nbranch refs/heads/feat/my-task\n\n`;
-    const [entry] = parseWorktreeList(raw);
+    const entry = parseWorktreeList(raw)[0]!;
     expect(entry.branch).toBe("feat/my-task");
   });
 
   test("handles detached HEAD (no branch line)", () => {
     const raw = `worktree /repo\nHEAD deadbeef\n\n`;
-    const [entry] = parseWorktreeList(raw);
+    const entry = parseWorktreeList(raw)[0]!;
     expect(entry.branch).toBe("(detached)");
   });
 
   test("handles bare worktree marker", () => {
     const raw = `worktree /bare.git\nHEAD 0000000\nbranch refs/heads/main\nbare\n\n`;
-    const [entry] = parseWorktreeList(raw);
+    const entry = parseWorktreeList(raw)[0]!;
     expect(entry.bare).toBe(true);
   });
 
@@ -47,8 +48,8 @@ describe("parseWorktreeList", () => {
     ].join("\n\n");
     const entries = parseWorktreeList(raw);
     expect(entries).toHaveLength(3);
-    expect(entries[1].branch).toBe("feat/one");
-    expect(entries[2].branch).toBe("feat/two");
+    expect(entries[1]!.branch).toBe("feat/one");
+    expect(entries[2]!.branch).toBe("feat/two");
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #2250 — the squash-merge window closed before these non-required CI fixes landed on the branch.

- Fix `TS2532`/`TS18048` in `check-orchestrator-state.test.ts`: replace `entries[0]`/`[1]`/`[2]` with `[0]!`/`[1]!`/`[2]!` and `const [entry] = ...` destructuring with `const entry = ...[0]!` to satisfy `noUncheckedIndexedAccess`
- Regenerate `docs/BACKLOG.md` so B-0076 (`status: closed` since commit `0a5af0c3`) renders as `[x]` rather than `[ ]`

## Test plan

- [x] `bun --bun tsc --noEmit -p tsconfig.json` → 0 errors
- [x] `bun test tools/orchestrator-checks/` → 12 pass / 0 fail
- [x] `bun tools/backlog/generate-index.ts --check` → ok

operative-authorization: aaron 2026-05-04: "it**, not just the output. Grinding through failures + recoveries"

🤖 Generated with [Claude Code](https://claude.com/claude-code)