### PR TITLE
docs(B-0126): normalize closed backlog status

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -43,7 +43,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0087](backlog/P1/B-0087-github-settings-drift-workflow-broken-invalid-permission-administration-otto-2026-04-28.md)** github-settings-drift.yml broken since PR #45 — option A landed (invalid permission removed); options B/C remain maintainer-gated
 - [x] **[B-0110](backlog/P1/B-0110-acehack-mirror-protocol-drift-2026-04-30.md)** AceHack mirror-refresh protocol drift — Path 2 chosen, doctrine update landing in same PR (2026-04-30)
 - [x] **[B-0125](backlog/P1/B-0125-skip-fsharp-analyze-on-docs-only-prs-2026-05-01.md)** Skip F#/Analyze (csharp) on docs-only PRs without tripping `code_quality severity:all`
-- [ ] **[B-0126](backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md)** Port the 4-layer meta-learning pattern from a sibling repo to Zeta
+- [x] **[B-0126](backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md)** Port the 4-layer meta-learning pattern from a sibling repo to Zeta
 - [x] **[B-0126.1](backlog/P1/B-0126.1-ai-attribution-footer-ts-tools.md)** Layer 4: AI attribution footer for TS comment-posting tools
 - [x] **[B-0126.2](backlog/P1/B-0126.2-ai-attribution-footer-gh-actions.md)** Layer 4: AI attribution footer for GitHub Actions workflows
 - [x] **[B-0126.3](backlog/P1/B-0126.3-document-layers-1-3-meta-learning.md)** Layers 1-3: document meta-learning pattern adapted for Zeta

--- a/docs/backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md
+++ b/docs/backlog/P1/B-0126-port-meta-learning-4-layer-pattern-from-stcrm-aaron-2026-05-01.md
@@ -1,10 +1,10 @@
 ---
 id: B-0126
 priority: P1
-status: done
+status: closed
 title: Port the 4-layer meta-learning pattern from a sibling repo to Zeta
 created: 2026-05-01
-last_updated: 2026-05-08
+last_updated: 2026-05-09
 depends_on: []
 decomposition: decomposed
 children: [B-0126.1, B-0126.2, B-0126.3, B-0126.4]


### PR DESCRIPTION
## Summary\n- normalize B-0126 from unsupported `status: done` to supported `status: closed`\n- bump `last_updated` and regenerate `docs/BACKLOG.md` so the generated index matches the row\n\n## Checks\n- `bun tools/backlog/generate-index.ts --check`