### PR TITLE
feat(B-0266): Review Policy ruleset + trim Default

### DIFF
--- a/docs/backlog/P1/B-0266-ruleset-split-review-policy-ruleset-2026-05-08.md
+++ b/docs/backlog/P1/B-0266-ruleset-split-review-policy-ruleset-2026-05-08.md
@@ -1,7 +1,7 @@
 ---
 id: B-0266
 priority: P1
-status: open
+status: done
 title: "GitHub ruleset split — review policy ruleset (conversation resolution + reviews)"
 created: 2026-05-08
 last_updated: 2026-05-09

--- a/tools/hygiene/github-settings.expected.json
+++ b/tools/hygiene/github-settings.expected.json
@@ -80,27 +80,6 @@
           "type": "non_fast_forward"
         },
         {
-          "parameters": {
-            "review_draft_pull_requests": true,
-            "review_on_push": true
-          },
-          "type": "copilot_code_review"
-        },
-        {
-          "parameters": {
-            "allowed_merge_methods": [
-              "squash"
-            ],
-            "dismiss_stale_reviews_on_push": false,
-            "require_code_owner_review": false,
-            "require_last_push_approval": false,
-            "required_approving_review_count": 0,
-            "required_review_thread_resolution": true,
-            "required_reviewers": []
-          },
-          "type": "pull_request"
-        },
-        {
           "parameters": null,
           "type": "required_linear_history"
         }
@@ -156,6 +135,43 @@
             "strict_required_status_checks_policy": false
           },
           "type": "required_status_checks"
+        }
+      ],
+      "target": "branch"
+    },
+    {
+      "conditions": {
+        "ref_name": {
+          "exclude": [],
+          "include": [
+            "~DEFAULT_BRANCH"
+          ]
+        }
+      },
+      "enforcement": "active",
+      "id": 16168181,
+      "name": "Review Policy",
+      "rules": [
+        {
+          "parameters": {
+            "review_draft_pull_requests": true,
+            "review_on_push": true
+          },
+          "type": "copilot_code_review"
+        },
+        {
+          "parameters": {
+            "allowed_merge_methods": [
+              "squash"
+            ],
+            "dismiss_stale_reviews_on_push": false,
+            "require_code_owner_review": false,
+            "require_last_push_approval": false,
+            "required_approving_review_count": 0,
+            "required_review_thread_resolution": true,
+            "required_reviewers": []
+          },
+          "type": "pull_request"
         }
       ],
       "target": "branch"


### PR DESCRIPTION
## Summary

Ran `bun tools/migrations/b0266-review-policy-ruleset.ts` — creates Review Policy ruleset, trims Default. Three-ruleset target achieved. Re-snapshotted expected.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)