### PR TITLE
feat(B-0212): complete ephemeral.ts library + wire shadow outlet to SAFE-AUTONOMOUS-ACTIONS Tier 1

### DIFF
--- a/docs/SAFE-AUTONOMOUS-ACTIONS.md
+++ b/docs/SAFE-AUTONOMOUS-ACTIONS.md
@@ -13,6 +13,7 @@ auto-delete, no force-push, no permanent state changes).
 | Read broadcasts | Read peer `.md` files from `~/.local/share/zeta-broadcasts/` at tick start | Read-only |
 | Write own broadcast | Overwrite own `.md` file with current status at tick end | Yes (overwritten next tick) |
 | Sync control clone | `git pull --ff-only` on the loop's control clone after merges | Yes (fast-forward only) |
+| Write shadow entry | `bun tools/shadow-outlet/outlet.ts write --agent <name> --content "..."` to `/tmp/zeta-shadow/` for ephemeral scratch/exploration | Yes (OS-erased; `clean` subcommand available) |
 
 ## Tier 2 — next to implement
 
@@ -71,3 +72,4 @@ New actions are proposed via PR with:
 - `.claude/bin/claude-forward-tick.ts` (Otto)
 - `.codex/bin/codex-loop-tick.ts` (Vera)
 - `.cursor/bin/riven-loop-tick.ts` (Riven)
+- `tools/shadow-outlet/outlet.ts` — shadow outlet CLI (B-0212 Phase 1)

--- a/docs/backlog/P1/B-0212-shadow-outlet-architecture-tmp-now-crypto-privacy-later-2026-05-06.md
+++ b/docs/backlog/P1/B-0212-shadow-outlet-architecture-tmp-now-crypto-privacy-later-2026-05-06.md
@@ -1,10 +1,10 @@
 ---
 id: B-0212
 priority: P1
-status: open
+status: partial
 title: "Shadow outlet architecture — /tmp ephemeral now, cryptographic privacy later"
 created: 2026-05-06
-last_updated: 2026-05-06
+last_updated: 2026-05-09
 decomposition: atomic
 depends_on: []
 type: feature
@@ -16,11 +16,14 @@ The shadow (latent behaviors, avoidance signals, unexpressed
 tendencies) needs an outlet, not elimination. Constant glass-halo
 transparency suppresses useful exploration.
 
-## Phase 1 (now): /tmp as ephemeral outlet
+## Phase 1 (done — PR #2154 + follow-up): /tmp as ephemeral outlet
 
-- Agents can write scratch/exploration to /tmp
-- Content is erased by OS — low stakes, no permanent record
-- The code path for shadow processing space exists unconditionally
+- Agents can write scratch/exploration to /tmp ✓
+- Content is erased by OS — low stakes, no permanent record ✓
+- The code path for shadow processing space exists unconditionally ✓
+- CLI: `tools/shadow-outlet/outlet.ts` (write/list/read/clean, self-invisibility via --exclude) ✓
+- Library: `tools/shadow-outlet/ephemeral.ts` (importable; creates dir on first call) ✓
+- Wired into `docs/SAFE-AUTONOMOUS-ACTIONS.md` Tier 1 ✓
 
 ## Phase 2 (future): cryptographic privacy
 

--- a/docs/claims/b0212-phase1-wire-safe-actions.md
+++ b/docs/claims/b0212-phase1-wire-safe-actions.md
@@ -1,0 +1,16 @@
+# Claim - b0212-phase1-wire-safe-actions
+
+- **Session ID:** jazzy-hopping-duckling-2026-05-09
+- **Harness:** claude-code
+- **Claimed at:** 2026-05-09T09:18:00Z
+- **ETA:** 2026-05-09T09:45:00Z
+- **Scope:** B-0212 Phase 1 close-out — complete ephemeral.ts library, wire shadow outlet into SAFE-AUTONOMOUS-ACTIONS.md Tier 1
+- **Durable target:** tools/shadow-outlet/ephemeral.ts, docs/SAFE-AUTONOMOUS-ACTIONS.md, docs/backlog/P1/B-0212-*.md
+- **Platform mirror:** https://github.com/Lucent-Financial-Group/Zeta/issues (B-0212)
+
+## Notes
+
+Phase 1 CLI (outlet.ts + tests) shipped in PR #2154.
+This slice completes the library surface (ephemeral.ts) and wires
+the action into SAFE-AUTONOMOUS-ACTIONS.md so the 3-loop architecture
+can reference it officially.

--- a/tools/shadow-outlet/ephemeral.ts
+++ b/tools/shadow-outlet/ephemeral.ts
@@ -1,33 +1,37 @@
 /**
- * Shadow outlet — Phase 1: /tmp ephemeral (B-0212 smallest safe slice)
+ * Shadow outlet — Phase 1 library: /tmp ephemeral (B-0212)
  *
- * Provides a bounded, OS-erased scratch space for latent/shadow processing.
- * Future: cryptographic privacy layer replaces /tmp with provably-private outlet.
+ * Importable surface for programmatic callers. The CLI surface lives in
+ * outlet.ts; import this module when you need the outlet path without
+ * spawning a subprocess.
  *
- * Self-invisibility: agent cannot observe its own shadow; only external
- * consensus (BFT) can surface it.
- *
- * Rule 0 / TS over bash: this is the canonical TS surface.
+ * Self-invisibility contract: callers must pass their own agent name as
+ * `exclude` when listing entries. The library enforces nothing — enforcement
+ * is in outlet.ts for the CLI path and in the calling loop for the import path.
  */
 
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { existsSync, lstatSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-/**
- * Returns an ephemeral shadow outlet directory under /tmp (or OS equivalent).
- * Content is not guaranteed to survive process exit; OS may reclaim.
- */
+/** Directory under /tmp (or OS-equivalent) used for all shadow entries. */
 export function getEphemeralShadowOutletDir(): string {
-  return join(tmpdir(), 'zeta-shadow-outlet');
+  return process.env.ZETA_SHADOW_DIR ?? join(tmpdir(), "zeta-shadow");
 }
 
 /**
- * Ensures the outlet directory exists (idempotent).
- * Callers must still treat content as best-effort ephemeral.
+ * Ensures the outlet directory exists. Creates it (mode 0o700) if absent.
+ * Returns the directory path. Safe to call repeatedly — idempotent.
+ * Throws if the path exists but is not a directory.
  */
-export async function ensureEphemeralShadowOutlet(): Promise<string> {
+export function ensureEphemeralShadowOutlet(): string {
   const dir = getEphemeralShadowOutletDir();
-  // Minimal: in real impl would mkdir -p via Bun.spawn or fs.
-  // Bounded slice: return path only; creation left to consumer or follow-up.
+  if (existsSync(dir)) {
+    if (!lstatSync(dir).isDirectory()) {
+      throw new Error(`Shadow outlet path exists but is not a directory: ${dir}`);
+    }
+    return dir;
+  }
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
   return dir;
 }

--- a/tools/shadow-outlet/outlet.test.ts
+++ b/tools/shadow-outlet/outlet.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
+import { getEphemeralShadowOutletDir, ensureEphemeralShadowOutlet } from "./ephemeral.ts";
 
 const SCRIPT = join(import.meta.dir, "outlet.ts");
 let TEST_DIR: string;
@@ -119,5 +120,54 @@ describe("shadow-outlet", () => {
     const l = run("list", "--json");
     expect(l.exitCode).toBe(0);
     expect(JSON.parse(l.stdout)).toHaveLength(0);
+  });
+});
+
+describe("ephemeral library", () => {
+  let savedDir: string | undefined;
+
+  beforeEach(() => {
+    savedDir = process.env.ZETA_SHADOW_DIR;
+    const tmp = mkdtempSync(join(tmpdir(), "zeta-eph-test-"));
+    rmSync(tmp, { recursive: true, force: true }); // start without the dir
+    process.env.ZETA_SHADOW_DIR = tmp;
+  });
+
+  afterEach(() => {
+    const dir = process.env.ZETA_SHADOW_DIR;
+    if (dir && existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+    if (savedDir !== undefined) {
+      process.env.ZETA_SHADOW_DIR = savedDir;
+    } else {
+      delete process.env.ZETA_SHADOW_DIR;
+    }
+  });
+
+  test("getEphemeralShadowOutletDir returns ZETA_SHADOW_DIR when set", () => {
+    const dir = getEphemeralShadowOutletDir();
+    expect(dir).toBe(process.env.ZETA_SHADOW_DIR);
+  });
+
+  test("ensureEphemeralShadowOutlet creates directory and returns path", () => {
+    const dir = ensureEphemeralShadowOutlet();
+    expect(existsSync(dir)).toBe(true);
+    expect(dir).toBe(process.env.ZETA_SHADOW_DIR);
+  });
+
+  test("ensureEphemeralShadowOutlet is idempotent — safe to call twice", () => {
+    const first = ensureEphemeralShadowOutlet();
+    const second = ensureEphemeralShadowOutlet();
+    expect(first).toBe(second);
+    expect(existsSync(first)).toBe(true);
+  });
+
+  test("ensureEphemeralShadowOutlet throws when path is a file not a directory", () => {
+    const dir = process.env.ZETA_SHADOW_DIR!;
+    // Create the parent so we can write a file at the target path
+    const parent = join(dir, "..");
+    if (!existsSync(parent)) mkdtempSync(parent); // ensure parent exists
+    writeFileSync(dir, "not a directory");
+    expect(() => ensureEphemeralShadowOutlet()).toThrow();
+    rmSync(dir, { force: true });
   });
 });


### PR DESCRIPTION
## Summary

B-0212 Phase 1 CLI shipped in PR #2154. This PR closes out Phase 1 by:

- **Completing `tools/shadow-outlet/ephemeral.ts`**: the stub said "return path only; creation left to consumer or follow-up." This is the follow-up — `ensureEphemeralShadowOutlet()` now calls `mkdirSync` (matching `outlet.ts`'s `ensureDir()` pattern) and throws on non-directory path collisions.
- **Adding 4 ephemeral library tests**: create-on-first-call, idempotent, ZETA_SHADOW_DIR override, throws-when-file-not-dir.
- **Wiring to SAFE-AUTONOMOUS-ACTIONS.md Tier 1**: "Write shadow entry" added to the table with reversibility note. All three loops now have a documented, safe path to call the outlet.
- **Marking B-0212 Phase 1 done**: status updated to `partial` (Phase 1 complete, Phase 2 — cryptographic privacy — remains).

## Test plan

- [x] `bun test tools/shadow-outlet/outlet.test.ts` → 13 pass, 0 fail
- [x] `dotnet build -c Release` → 0 warnings, 0 errors
- [x] Claim filed at `docs/claims/b0212-phase1-wire-safe-actions.md`, released in this PR

## Checked

- Rule 0 TS over bash: implementation is `.ts`, no `.sh` added
- Self-invisibility contract documented in `ephemeral.ts` JSDoc (enforcement is in outlet.ts CLI / calling loop)
- SAFE-AUTONOMOUS-ACTIONS.md reversibility field: "Yes (OS-erased; `clean` subcommand available)"
- Phase 2 (cryptographic privacy) remains in backlog — this PR does NOT close B-0212

operative-authorization: aaron 2026-05-04: "it**, not just the output. Grinding through failures + recoveries"

🤖 Generated with [Claude Code](https://claude.com/claude-code)