### PR TITLE
fix: resolve 6 backlog ID collisions (B-0368..B-0373)

### DIFF
--- a/docs/backlog/P1/B-0368-claude-code-permissions-feature-tight-integration-aaron-2026-05-02.md
+++ b/docs/backlog/P1/B-0368-claude-code-permissions-feature-tight-integration-aaron-2026-05-02.md
@@ -1,5 +1,5 @@
 ---
-id: B-0160
+id: B-0368
 priority: P1
 status: in-progress
 title: Claude Code `/permissions` feature — research current API + integrate tightly so the harness allows maximum agent freedom (Aaron 2026-05-02)

--- a/docs/backlog/P1/B-0369-durable-computation-survey-8-systems-2026-05-08.md
+++ b/docs/backlog/P1/B-0369-durable-computation-survey-8-systems-2026-05-08.md
@@ -1,5 +1,5 @@
 ---
-id: B-0278
+id: B-0369
 priority: P1
 status: closed
 closed: 2026-05-08

--- a/docs/backlog/P1/B-0370-durable-computation-checkpoint-interface-extension-2026-05-08.md
+++ b/docs/backlog/P1/B-0370-durable-computation-checkpoint-interface-extension-2026-05-08.md
@@ -1,5 +1,5 @@
 ---
-id: B-0279
+id: B-0370
 priority: P1
 status: done
 title: "Durable computation — extend Checkpoint.fs with StableStorage mode"

--- a/docs/backlog/P1/B-0371-pages-seo-metadata-jsonld-social-preview-2026-05-08.md
+++ b/docs/backlog/P1/B-0371-pages-seo-metadata-jsonld-social-preview-2026-05-08.md
@@ -1,5 +1,5 @@
 ---
-id: B-0284
+id: B-0371
 priority: P1
 status: open
 title: "Pages discoverability - SEO metadata, JSON-LD, and social previews"

--- a/docs/backlog/P1/B-0372-pages-sitemap-robots-ai-crawler-policy-2026-05-08.md
+++ b/docs/backlog/P1/B-0372-pages-sitemap-robots-ai-crawler-policy-2026-05-08.md
@@ -1,5 +1,5 @@
 ---
-id: B-0285
+id: B-0372
 priority: P1
 status: open
 title: "Pages discoverability - sitemap, robots, and AI crawler policy"

--- a/docs/backlog/P1/B-0373-alignment-proof-primitive-ladder-one-type-one-property.md
+++ b/docs/backlog/P1/B-0373-alignment-proof-primitive-ladder-one-type-one-property.md
@@ -1,5 +1,5 @@
 ---
-id: B-0362
+id: B-0373
 priority: P1
 status: open
 title: "Alignment proof primitive ladder — one type, one falsifiable property"


### PR DESCRIPTION
## Summary
- 6 pairs of backlog items shared the same ID — each newer file gets a fresh ID
- B-0160 → B-0368, B-0278 → B-0369, B-0279 → B-0370, B-0284 → B-0371, B-0285 → B-0372, B-0362 → B-0373
- B-0357 collision already handled by PR #2268

## Test plan
- [ ] CI passes (file renames + id field changes only)
- [ ] `find docs/backlog -name 'B-*.md' -exec sed -n 's/^id: //p' {} \; | sort | uniq -d` returns only B-0357 (handled by #2268)

🤖 Generated with [Claude Code](https://claude.com/claude-code)