### PR TITLE
chore(B-0347): carve 5 more skill descriptions (batch 10)

### DIFF
--- a/.claude/skills/editorconfig-expert/SKILL.md
+++ b/.claude/skills/editorconfig-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: editorconfig-expert
-description: Capability skill ("hat") — static-analysis narrow under `static-analysis-expert`. Owns `.editorconfig` discipline end-to-end in a .NET repo: canonical keys (`indent_style`, `charset`, `end_of_line`), .NET analyzer severity overrides (`dotnet_diagnostic.XXXX.severity`), C#-specific style keys (`csharp_*`, `dotnet_*`), F#-specific keys (`fsharp_*`), analyzer `build_property.*` plumbing to source generators, pattern precedence (root-first, deepest-wins), glob semantics, and the interaction between `.editorconfig` and MSBuild / Roslyn / `fsautocomplete` / Stryker. Wear this when designing or reviewing a repo's `.editorconfig` strategy, promoting / demoting an analyzer severity, adding a generator option via `build_property`, or reconciling drift between IDE formatting and CI gates. Defers to `static-analysis-expert` for cross-tool severity policy, to `roslyn-analyzers-expert` / `roslyn-generators-expert` / `fsharp-analyzers-expert` for rule-authoring specifics, and to `msbuild-expert` for MSBuild-property wiring.
+description: EditorConfig — indent/charset/EOL keys, .NET analyzer severity overrides, pattern precedence, MSBuild interaction.
 ---
 
 # EditorConfig Expert — `.editorconfig` in a .NET Repo

--- a/.claude/skills/execution-model-expert/SKILL.md
+++ b/.claude/skills/execution-model-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: execution-model-expert
-description: Capability skill ("hat") — execution-model narrow under `sql-engine-expert`. Covers the "engine-type" axis: Volcano iterator vs vectorised iterator vs morsel-driven parallelism vs JIT-codegen (Hyper/Umbra/SingleStore) vs push-vs-pull dataflow vs streaming/incremental (DBSP/Feldera/Materialize/Timely). Evaluates how Zeta's retraction-native semantics interact with each model, what the hot-path execution substrate should be, and when a hybrid model makes sense. Wear this when framing a new executor, comparing Zeta against prior-art engines at the execution-model layer, or resolving a design tension between the logical plan (optimiser's world) and the physical runtime (planner's world). Defers to `query-planner` (Imani) for plan-tree shape and SIMD dispatch, to `query-optimizer-expert` for cost model, to `algebra-owner` for retraction-native invariants, to `hardware-intrinsics-expert` for kernel-level details, and to `performance-engineer` for benchmark-driven decisions.
+description: Execution model — Volcano vs vectorised vs morsel-driven vs JIT-codegen vs push/pull vs streaming/incremental.
 ---
 
 # Execution Model Expert — Engine-Type Narrow

--- a/.claude/skills/push-pull-dataflow-expert/SKILL.md
+++ b/.claude/skills/push-pull-dataflow-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: push-pull-dataflow-expert
-description: Capability skill ("hat") — dataflow-direction specialization under `execution-model-expert`. Covers the **orthogonal** axis to iterator-vs-batch: push vs pull semantics in operator dataflow. Pull (Volcano) means consumers request rows from producers; push means producers emit rows to consumers. The choice interacts with streaming (push-native), blocking operators (push needs flow control), codegen (push fuses more naturally), and back-pressure. Wear this when framing a new operator's interface, debugging a pipeline stall, or reconciling a "streaming" proposal against a "materialise this" proposal. Zeta's call: **push-based by default**, matching the streaming-incremental substrate; pull is the exception for on-demand snapshot materialisation. Defers to `execution-model-expert` for cross-model framing, to `streaming-incremental-expert` for delta-flow specifics, to `query-planner` for plan shape, and to `algebra-owner` for retraction-native semantics.
+description: Push vs pull dataflow — operator direction, streaming vs materialise, back-pressure, Zeta push-default.
 ---
 
 # Push-Pull Dataflow Expert — Dataflow Direction

--- a/.claude/skills/query-optimizer-expert/SKILL.md
+++ b/.claude/skills/query-optimizer-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: query-optimizer-expert
-description: Capability skill ("hat") — cost-based query optimisation hat. Owns the cost model, cardinality estimation, statistics maintenance, logical rewrite rules (predicate pushdown, projection pushdown, subquery unnesting, view merging, outer-join simplification, constant folding, common-subexpression elimination), join-order enumeration (dynamic programming vs greedy vs IKKBZ vs genetic), and the translation-rule library. Hand-off contract with `query-planner` (Imani): **query-optimizer-expert owns logical rewrites + cost model + statistics**; **query-planner owns physical plan tree + SIMD kernel dispatch + runtime adaptive re-planning**. Wear this when the question is "should we rewrite this query shape?" or "is the cost estimate tight?", not "which SIMD lane fires?". Defers to `query-planner` for physical plan shape, to `relational-algebra-expert` for equivalence proofs, to `algebra-owner` for retraction-native preservation, and to `sql-expert` for SQL semantics.
+description: Query optimizer — cost model, cardinality estimation, logical rewrite rules, join-order enumeration, statistics.
 ---
 
 # Query Optimizer Expert — Logical Rewrites + Cost Model

--- a/.claude/skills/sql-parser-expert/SKILL.md
+++ b/.claude/skills/sql-parser-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sql-parser-expert
-description: Capability skill ("hat") — SQL parser narrow under `sql-engine-expert`. Covers lexing (tokenisation, keywords vs identifiers, quoted-identifier rules, string / numeric / date / interval literals, comments, pragmas), parsing (grammar choice — libpg_query C binding vs ANTLR4 vs hand-rolled recursive-descent vs parser-combinator), AST shape and stability, error recovery (panic-mode, phrase-level, synchronising tokens), source-mapping for diagnostics (line / column / token-span preservation through the AST), and parser-fuzzing coverage. Wear this when choosing a grammar tool, designing the AST, triaging a parse error, or evaluating whether a Postgres dialect extension (LATERAL, DISTINCT ON, FILTER, JSONB path, array literals) is a parser-level concern. Defers to `sql-expert` for SQL-the-language semantics, to `postgresql-expert` for dialect-specific grammar, to `sql-engine-expert` for cross-layer decisions, and to `fscheck-expert` for parser-fuzzing property tests.
+description: SQL parser — lexing, grammar choice (libpg_query/ANTLR4/recursive-descent), AST design, error recovery, fuzzing.
 ---
 
 # SQL Parser Expert — Front-End Narrow


### PR DESCRIPTION
## Summary
- Carved 5 more: editorconfig-expert, execution-model-expert, sql-parser-expert, query-optimizer-expert, push-pull-dataflow-expert
- Running total: 45 skills carved, ~84K+ chars freed

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)