### PR TITLE
fix(tsc): non-null assert ZETA_SHADOW_DIR in outlet.test.ts — TS2769

### DIFF
--- a/tools/shadow-outlet/outlet.test.ts
+++ b/tools/shadow-outlet/outlet.test.ts
@@ -145,13 +145,13 @@ describe("ephemeral library", () => {
 
   test("getEphemeralShadowOutletDir returns ZETA_SHADOW_DIR when set", () => {
     const dir = getEphemeralShadowOutletDir();
-    expect(dir).toBe(process.env.ZETA_SHADOW_DIR);
+    expect(dir).toBe(process.env.ZETA_SHADOW_DIR!);
   });
 
   test("ensureEphemeralShadowOutlet creates directory and returns path", () => {
     const dir = ensureEphemeralShadowOutlet();
     expect(existsSync(dir)).toBe(true);
-    expect(dir).toBe(process.env.ZETA_SHADOW_DIR);
+    expect(dir).toBe(process.env.ZETA_SHADOW_DIR!);
   });
 
   test("ensureEphemeralShadowOutlet is idempotent — safe to call twice", () => {


### PR DESCRIPTION
## Summary

- Fixes pre-existing `lint (tsc tools)` CI failure on every PR branch
- `process.env.ZETA_SHADOW_DIR` is typed `string | undefined` but bun:test's `toBe()` overload requires `string` when the tested value is `string`
- `beforeEach` at line 133 guarantees the env var is set, so `!` (non-null assertion) is the correct and safe fix

## Root cause

`tools/shadow-outlet/outlet.test.ts:148,154` — TS2769 "No overload matches this call" — both `toBe()` overloads expect `string`, not `string | undefined`.

## Test plan

- [x] `bun tsc --noEmit` passes clean (0 errors)
- [x] Change is 2 lines, non-null assertion on an env var guaranteed set in `beforeEach`
- [x] No logic change — existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)