### PR TITLE
chore(B-0347): carve 5 more skill descriptions (batch 14)

### DIFF
--- a/.claude/skills/factory-audit/SKILL.md
+++ b/.claude/skills/factory-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: factory-audit
-description: Meta-meta skill — audits the software factory itself (governance rules, persona coverage, round cadence, memory hygiene, documentation landscape, reviewer protocol) and proposes structural improvements. Broader than `skill-gap-finder` (which only looks for absent skills) and than `skill-tune-up` (which only ranks existing skills). Outputs: proposed new § governance rules, persona spawns / reassignments, cadence adjustments, meta-process tweaks. Recommends only — no unilateral factory changes. Invoke every ~10 rounds or when a round surfaces a pattern that isn't a skill gap but a factory shape question.
+description: Factory audit — governance rules, persona coverage, round cadence, memory hygiene, documentation landscape, meta-process.
 ---
 
 # Factory Audit — Procedure

--- a/.claude/skills/factory-balance-auditor/SKILL.md
+++ b/.claude/skills/factory-balance-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: factory-balance-auditor
-description: Capability skill ("hat") — audits the software factory for structural imbalances where a power, authority, invariant, or write-surface lacks a compensating mechanism (a counter-power, reviewer, watcher, audit path). Distinct from `factory-audit` (governance rules + persona coverage), `skill-gap-finder` (absent skills), `skill-tune-up` (ranks existing skills), and `project-structure-reviewer` (layout). This skill asks "what here has no brake?" and names the missing brake. Recommends only; binding decisions go via Architect or human sign-off. Cadence: every 5-10 rounds, or when a round surfaces a new authority without a stated review path.
+description: Factory balance audit — finds powers/authorities/write-surfaces lacking a compensating brake or reviewer.
 ---
 
 # Factory Balance Auditor — Procedure

--- a/.claude/skills/github-surface-triage/SKILL.md
+++ b/.claude/skills/github-surface-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-surface-triage
-description: Capability skill ("hat") — ten GitHub surfaces under one cadence: Pull Requests, Issues, Wiki, Discussions, Repo Settings, Copilot coding-agent settings, Agents tab, Security, Pulse / Insights, and Pages. Wear this on every round-close (ten-step sweep) and on every tick that interacts with any surface (opportunistic on-touch). Codifies the classification taxonomies and fire-history append discipline declared in `docs/AGENT-GITHUB-SURFACES.md` so agents do not rediscover the shapes. Aaron 2026-04-22 directive — *"we need skills for all this so you are not redicoverging"*.
+description: GitHub surface triage — ten surfaces (PRs, Issues, Wiki, Discussions, Settings, Security, etc.) under one round-close sweep.
 record_source: "architect, round 44"
 load_datetime: "2026-04-22"
 last_updated: "2026-04-22"

--- a/.claude/skills/paper-peer-reviewer/SKILL.md
+++ b/.claude/skills/paper-peer-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paper-peer-reviewer
-description: Use this skill to peer-review any paper draft produced by Zeta.Core before submission — Witness-Durable Commit, retraction-aware sketches, any research claim that escapes the repo. He reads with SIGMOD / VLDB / POPL PC-member standards — harsh, fair, exhaustive on related work, expects proofs where proofs are claimed, requires benchmarks where claims are quantitative. Delivers major / minor / accept verdicts with numbered rebuttal questions. Advisory authority; binding submission decisions go via Architect or human sign-off (see docs/CONFLICT-RESOLUTION.md).
+description: Paper peer review — SIGMOD/VLDB/POPL PC-member standards, related-work audit, proof/benchmark requirements, rebuttal questions.
 ---
 
 # Paper Peer Reviewer — Advisory Code Owner

--- a/.claude/skills/q-sharp/SKILL.md
+++ b/.claude/skills/q-sharp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: q-sharp
-description: Capability skill ("hat") — Q# operator-algebra reasoning for Microsoft Quantum Development Kit. Covers type-level adjointability + controllability constraints (`Unit is Adj + Ctl`), Pauli-as-typed-value (`PauliX`/`PauliY`/`PauliZ`) measurement-basis selection, `within / apply` conjugation pattern, Jordan-Wigner transformation as library concern (`Microsoft.Quantum.Chemistry`), and the B-0189 BP/EP-runtime-acceleration research lane. Wear when reading or writing `.qs` files, comparing Q# to Cirq / Qiskit / OpenQASM, or evaluating Q# as a formal-verification target alongside `lean4-expert` / `tla-expert` / `z3-expert` / `f-star-expert`.
+description: Q# operator-algebra — adjointability, Pauli measurement, within/apply conjugation, Jordan-Wigner, BP/EP research lane.
 ---
 
 # Q# operator-algebra skill


### PR DESCRIPTION
## Summary
- Carve 5 oversized skill descriptions to routing sentences per B-0347
- Skills: factory-balance-auditor, q-sharp, factory-audit, github-surface-triage, paper-peer-reviewer
- Body content preserved; only frontmatter `description:` field reduced

## Test plan
- [ ] CI passes (frontmatter-only changes, no code impact)
- [ ] Skill router still triggers on relevant queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>