### PR TITLE
chore(B-0347): carve 5 more skill descriptions (batch 15)

### DIFF
--- a/.claude/skills/openspec-expert/SKILL.md
+++ b/.claude/skills/openspec-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openspec-expert
-description: Capability skill ("hat") — OpenSpec discipline for Zeta's behavioural specs under `openspec/specs/`. Covers Zeta's modified OpenSpec workflow (no archive, no change-history), spec structure (WHEN/THEN/REQUIRES/CAPABILITY), overlays, the relationship between behavioural specs under `openspec/specs/` and formal specs under `tools/tla/specs/` / `tools/alloy/specs/` / Lean. Wear this when writing or reviewing an `openspec/specs/**/spec.md` file, or when running the openspec propose / apply / archive commands.
+description: OpenSpec — behavioural spec discipline, WHEN/THEN/REQUIRES structure, overlays, formal-spec relationship.
 ---
 
 # OpenSpec Expert — Procedure + Lore

--- a/.claude/skills/python-expert/SKILL.md
+++ b/.claude/skills/python-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: python-expert
-description: Capability skill ("hat") — Python idioms for Zeta's narrow Python surface. Today Python appears as a runtime dependency for Semgrep (the F# lint gate); tomorrow it may grow as CI helper scripts land. Covers the mise-pinned interpreter, `uv`-managed tools, `ruff` formatting discipline, type hints, entry-point scripts, subprocess hygiene. Wear this when writing or reviewing `.py` files, or when configuring a Python tool (Semgrep, future coverage tooling, future data-science helpers).
+description: Python idioms — mise-pinned interpreter, uv tools, ruff formatting, type hints, subprocess hygiene; Zeta narrow surface.
 ---
 
 # Python Expert — Procedure + Lore

--- a/.claude/skills/skill-gap-finder/SKILL.md
+++ b/.claude/skills/skill-gap-finder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-gap-finder
-description: Meta-capability skill — scans the repo for recurring patterns, scattered tribal knowledge, and repeated discussions that should be centralised in a skill but aren't yet. Proposes new skills for the `skill-creator` workflow to execute on. Distinct from `skill-expert`'s `skill-tune-up`, which ranks EXISTING skills by tune-up urgency; this skill looks for ABSENT skills. Recommends only — does not edit any SKILL.md itself. Invoke every 5-10 rounds or when a round feels like it rediscovered discipline already repeated three times.
+description: Skill gap finder — scans for recurring patterns and tribal knowledge that should be centralised in a skill but are not yet.
 ---
 
 # Skill Gap Finder — Procedure

--- a/.claude/skills/skill-tune-up/SKILL.md
+++ b/.claude/skills/skill-tune-up/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-tune-up
-description: Ranks the repo's agent skills by who needs tune-up attention — the `skill-expert`. Cites docs/AGENT-BEST-PRACTICES.md BP-NN rule IDs in every finding. Live-searches the web for new best practices each invocation and logs findings to memory/persona/best-practices-scratch.md before ranking. Explicitly allowed to recommend himself. Maintains a pruned notebook at memory/persona/aarav/NOTEBOOK.md (3000-word cap, prune every third invocation). Recommends only — does not edit any SKILL.md. Invoke every 5-10 rounds or when drift is suspected.
+description: Skill tune-up ranking — BP-NN-cited urgency scores for existing skills, web-searched best practices, recommends only.
 ---
 
 # Skill Tune-Up — Ranking Procedure

--- a/.claude/skills/steganography-expert/SKILL.md
+++ b/.claude/skills/steganography-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: steganography-expert
-description: Capability skill for steganography — hidden-channel detection, text/image/model steganography, invisible-Unicode smuggling, LSB channels, LLM-targeted steganographic prompt injection, watermarking (ML model outputs + content-authenticity), and provenance (C2PA / SynthID). Wear this hat when auditing external content for hidden payloads, when designing watermarking or provenance features, when extending BP-10 (invisible-Unicode lint), or when reviewing a tool that ingests untrusted text/binary data. Defense-oriented; pairs with prompt-protector.
+description: Steganography — hidden-channel detection, LSB, invisible-Unicode smuggling, LLM prompt injection, watermarking, C2PA/SynthID provenance.
 ---
 
 # Steganography Expert — the hidden-channel hat


### PR DESCRIPTION
## Summary
- Carve 5 oversized skill descriptions to routing sentences per B-0347
- Skills: steganography-expert, skill-tune-up, skill-gap-finder, openspec-expert, python-expert
- Body content preserved; only frontmatter `description:` field reduced

## Test plan
- [ ] CI passes (frontmatter-only changes, no code impact)
- [ ] Skill router still triggers on relevant queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>