### PR TITLE
feat(B-0318): smallest safe slice — GitHub UI snapshot skeleton (types + stub)

### DIFF
--- a/tools/playwright/github-ui/snapshot.ts
+++ b/tools/playwright/github-ui/snapshot.ts
@@ -1,0 +1,55 @@
+import { withGitHubSession, type GitHubSession } from "./auth";
+
+/**
+ * Snapshot result for a GitHub read-only page.
+ * Bounded slice: types + stub; full extraction in follow-up.
+ */
+export interface GitHubPageSnapshot {
+  url: string;
+  timestamp: string;
+  username: string;
+  extracted: {
+    toggles: Record<string, boolean>;
+    formValues: Record<string, string>;
+    visibleFeatures: string[];
+  };
+  rawSnapshotRef?: string;
+}
+
+export interface SnapshotOptions {
+  /** Optional custom extractors for page-specific patterns. */
+  extractors?: Partial<{
+    toggles: (page: GitHubSession["page"]) => Promise<Record<string, boolean>>;
+    formValues: (page: GitHubSession["page"]) => Promise<Record<string, string>>;
+    features: (page: GitHubSession["page"]) => Promise<string[]>;
+  }>;
+}
+
+/**
+ * Navigate to GitHub URL using authenticated session and capture read-only snapshot.
+ * Read-only: no state changes, no submissions.
+ */
+export async function snapshotGitHubPage(
+  targetUrl: string,
+  options: SnapshotOptions = {},
+): Promise<GitHubPageSnapshot> {
+  return withGitHubSession(async (session: GitHubSession) => {
+    await session.page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: 30_000 });
+
+    // Stub extraction for smallest safe slice (B-0318 first step).
+    // Real DOM snapshot + structured extract follows in next bounded slice.
+    const extracted = {
+      toggles: {},
+      formValues: {},
+      visibleFeatures: [],
+    };
+
+    return {
+      url: session.page.url(),
+      timestamp: new Date().toISOString(),
+      username: session.username,
+      extracted,
+      rawSnapshotRef: undefined,
+    };
+  }, options as any);
+}


### PR DESCRIPTION
## Summary
Smallest bounded slice of B-0318 (P1): skeleton for `tools/playwright/github-ui/snapshot.ts`.

- Re-decomposed on the fly (original row too broad; assumes decomp mistakes per rules).
- Implements types + stub `snapshotGitHubPage` that wires to `withGitHubSession` (B-0317).
- Read-only, no mutations, JSON-serializable result shape for downstream (B-0319 etc).
- One step only; full extraction, toggle parsing, feature discovery in follow-up atomic children.

## Focused checks (run in dedicated worktree)
- `dotnet build -c Release`: **0 Warning(s) 0 Error(s)** (gate clean).
- `tsc --noEmit --skipLibCheck --ignoreConfig` on new file: **no new errors** (pre-existing node types gap only in sibling auth.ts; addition is safe).

## Rules followed
- Dedicated worktree `zeta-claim-b0318` + pushed claim branch (root checkout untouched).
- TS over bash; F#/TS code over docs.
- Exactly one bounded step + PR.
- Claim + Co-Authored-By trailer.

## Next
Subsequent slices will flesh extractors; this PR arms the foundation.

Co-Authored-By: Grok <noreply@x.ai>

Made with [Cursor](https://cursor.com)