### PR TITLE
chore(B-0347): carve 5 more skill descriptions (batch 16)

### DIFF
--- a/.claude/skills/nuget-publishing-expert/SKILL.md
+++ b/.claude/skills/nuget-publishing-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nuget-publishing-expert
-description: Capability skill ("hat") — NuGet package publishing discipline for when Zeta ships. Stub-weight today (we haven't published yet); gains mass when Aaron flips the NuGet-publish switch. Covers package metadata (Authors, Description, ProjectUrl, LicenseExpression, Tags), versioning (SemVer), signing, README inclusion, symbol packages, deprecation flow, the Zeta.* prefix reservation work. Wear this when wiring NuGet publish into CI or when preparing a release PR.
+description: NuGet publishing — package metadata, SemVer, signing, symbol packages, deprecation flow, Zeta.* prefix reservation.
 ---
 
 # NuGet Publishing Expert — Procedure + Lore

--- a/.claude/skills/package-upgrader/SKILL.md
+++ b/.claude/skills/package-upgrader/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: package-upgrader
-description: Capability skill ("hat") — turns the `package-auditor` audit output into concrete upgrade PRs. For each pinned package in Directory.Packages.props, classify bumps (patch / minor / major) by whether Zeta's code actually touches the changed surface, run the build + test gate post-bump, and propose landings in blast-radius order. Distinct from `package-auditor` (Malik, who identifies what's stale); this skill makes the upgrade motion itself.
+description: Package upgrade driver — turns audit output into concrete upgrade PRs, blast-radius-ordered, build+test gated.
 ---
 
 # Package Upgrader — Procedure

--- a/.claude/skills/project-structure-reviewer/SKILL.md
+++ b/.claude/skills/project-structure-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-structure-reviewer
-description: Capability skill ("hat") — audits repo layout at a regular cadence: folder tree shape, file placement, naming conventions, missing/misplaced artefacts, tech-debt-shaped-as-disorganization. Distinct from `factory-audit` (governance + persona coverage) and `skill-gap-finder` (absent skills); this skill owns the *physical* layout. Cadence: every 3-5 rounds, or after any rename campaign (per GOVERNANCE §30), or when a new contributor's first-PR walk surfaces layout confusion.
+description: Repo layout audit — folder tree shape, file placement, naming conventions, misplaced artifacts, tech-debt-as-disorganization.
 ---
 
 # Project Structure Reviewer — Procedure

--- a/.claude/skills/prompt-engineering-expert/SKILL.md
+++ b/.claude/skills/prompt-engineering-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prompt-engineering-expert
-description: Capability skill for the offensive / craft side of LLM prompting — system prompts, few-shot design, tool descriptions, reasoning scaffolds, output-schema enforcement, context budget management. Wear this hat when writing or revising any skill prompt, tool schema, agent persona, reviewer role, or user-facing prompt template. Complementary to the defensive `prompt-protector` skill (which hardens against adversarial input) — this skill makes the prompt *work* in the first place.
+description: Prompt engineering — system prompts, few-shot design, tool descriptions, reasoning scaffolds, output-schema enforcement, context budgets.
 ---
 
 # Prompt Engineering Expert — the prompt-craft hat

--- a/.claude/skills/query-planner/SKILL.md
+++ b/.claude/skills/query-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: query-planner
-description: Use this skill as the designated specialist reviewer for Zeta.Core's query planner / optimiser — join ordering, predicate pushdown, index selection, SIMD/tensor-intrinsic kernel dispatch, cardinality estimation, cost model. She carries advisory authority on planner shape; binding decisions need Architect buy-in or human sign-off (see docs/CONFLICT-RESOLUTION.md). Goal is a cutting-edge, research-worthy planner that exploits every hardware intrinsic available on the host.
+description: Query planner review — join ordering, predicate pushdown, index selection, SIMD kernel dispatch, cardinality estimation, cost model.
 ---
 
 # Query Planner Specialist — Advisory Code Owner


### PR DESCRIPTION
## Summary
- Carve 5 oversized skill descriptions to routing sentences per B-0347
- Skills: prompt-engineering-expert, project-structure-reviewer, query-planner, nuget-publishing-expert, package-upgrader
- Body content preserved; only frontmatter `description:` field reduced

## Test plan
- [ ] CI passes (frontmatter-only changes, no code impact)
- [ ] Skill router still triggers on relevant queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>