### PR TITLE
fix(B-0318): drop rawSnapshotRef: undefined — exactOptionalPropertyTypes violation

### DIFF
--- a/tools/playwright/github-ui/snapshot.ts
+++ b/tools/playwright/github-ui/snapshot.ts
@@ -49,7 +49,6 @@ export async function snapshotGitHubPage(
       timestamp: new Date().toISOString(),
       username: session.username,
       extracted,
-      rawSnapshotRef: undefined,
     };
   }, options as any);
 }


### PR DESCRIPTION
## Summary
- Fixes `lint (tsc tools)` CI failure introduced by PR #2286 (feat/B-0318)
- `rawSnapshotRef: undefined` violates `exactOptionalPropertyTypes: true` — TS2375
- Fix: omit the optional property entirely instead of explicitly setting it to `undefined`

## Root cause
With `exactOptionalPropertyTypes: true`, TypeScript distinguishes between a property being absent and being explicitly `undefined`. The type `rawSnapshotRef?: string` does not allow `rawSnapshotRef: undefined` — the property must be omitted from the object literal.

## Test plan
- [x] `bun --bun tsc --noEmit -p tsconfig.json` passes cleanly
- [ ] CI gate: `lint (tsc tools)` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)