### PR TITLE
chore(B-0347): carve 5 more skill descriptions (batch 18)

### DIFF
--- a/.claude/skills/fsharp-expert/SKILL.md
+++ b/.claude/skills/fsharp-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fsharp-expert
-description: Capability skill ("hat") — centralised F# idioms, pitfalls, and Zeta-specific conventions. Wear this when writing or reviewing `.fs` / `.fsi` files. Codifies what would otherwise drift as comments across file headers. No persona; any expert wears the hat when the code at hand is F#. Distinct from the per-language-edge-case hats for Bash, PowerShell, GitHub Actions, Java, and C#.
+description: F# idioms — centralised conventions, pitfalls, Zeta-specific patterns for .fs/.fsi files.
 ---
 
 # F# Expert — Procedure + Lore

--- a/.claude/skills/github-actions-expert/SKILL.md
+++ b/.claude/skills/github-actions-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-actions-expert
-description: Capability skill ("hat") — GitHub Actions workflow idioms, security hardening, concurrency, caching, matrix semantics, reusable workflows, least-privilege tokens, SHA pinning discipline. Wear this when writing or reviewing `.github/workflows/*.yml`. Zeta's first workflow is being designed this round; discipline baked in early prevents the supply-chain and cost regressions that bite later.
+description: GitHub Actions — workflow idioms, security hardening, concurrency, caching, matrix, reusable workflows, SHA pinning.
 ---
 
 # GitHub Actions Expert — Procedure + Lore

--- a/.claude/skills/prompt-protector/SKILL.md
+++ b/.claude/skills/prompt-protector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prompt-protector
-description: Hardens Zeta.Core's agent skills against prompt injection, hidden Unicode, skill-supply-chain attacks, and the known Pliny-class adversarial corpora. Works from threat-model description only — NEVER fetches known injection payloads. Recommends hardening for every skill's SKILL.md, lints for invisible characters, and coordinates isolated-session pen-tests when needed.
+description: Prompt injection defence — skill hardening, hidden Unicode, supply-chain attacks, Pliny-class adversarial corpora.
 ---
 
 # Prompt Protector — Defensive-Design Reviewer

--- a/.claude/skills/semgrep-rule-authoring/SKILL.md
+++ b/.claude/skills/semgrep-rule-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: semgrep-rule-authoring
-description: Capability skill ("hat") — Semgrep rule authoring discipline for Zeta's `.semgrep.yml` (14 custom rules codifying F# anti-patterns from prior reviewer findings). Covers rule anatomy, pattern vs pattern-regex vs pattern-either, path include/exclude, severity levels, message discipline, the "codifies a prior review finding" convention. Wear this when writing or reviewing a new Semgrep rule.
+description: Semgrep rule authoring — rule anatomy, pattern/regex/either, severity, message discipline, prior-review-finding codification.
 ---
 
 # Semgrep Rule Authoring — Procedure + Lore

--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Meta-skill — the canonical path for creating and tuning every other agent skill in this repo. Invoke whenever a new skill is proposed, an existing skill needs non-trivial revision, or the skill-tune-up flags drift. Enforces the repo convention that all skill changes pass through this workflow (so diffs are visible in git and safety rules are re-applied).
+description: Skill creator — canonical create/tune workflow for all agent skills; draft, prompt-protector review, dry-run, commit.
 ---
 
 # Skill Creator — Meta-Skill


### PR DESCRIPTION
## Summary
- Carve 5 oversized skill descriptions to routing sentences per B-0347
- Skills: semgrep-rule-authoring, github-actions-expert, fsharp-expert, prompt-protector, skill-creator
- Body content preserved; only frontmatter `description:` field reduced

## Test plan
- [ ] CI passes (frontmatter-only changes, no code impact)
- [ ] Skill router still triggers on relevant queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>