### PR TITLE
chore(B-0347): carve 5 more skill descriptions (batch 19)

### DIFF
--- a/.claude/skills/package-auditor/SKILL.md
+++ b/.claude/skills/package-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: package-auditor
-description: Use this skill to audit Zeta.Core's NuGet package pins against latest NuGet versions and classify bumps (major/minor/patch) by whether our code actually touches the changed API surface. Runs `tools/audit-packages.sh`, queries release notes for majors, and produces a concrete bump plan — not a "defer all majors" fear-list.
+description: NuGet package audit — pin-vs-latest classification, bump plan by blast radius, release-note surface check.
 ---
 
 # Zeta.Core Package Auditor

--- a/.claude/skills/product-manager/SKILL.md
+++ b/.claude/skills/product-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-manager
-description: Product Manager PM-2 skill. Use when Zeta needs proactive product discovery, feature-gap prediction before user friction, roadmap option shaping, acceptance-criteria sharpening, or conversion of vague maintainer/user signals into testable product bets. Distinct from project-management or delivery tracking; this skill asks what should exist next and why.
+description: Product discovery — feature-gap prediction, roadmap option shaping, acceptance criteria, vague signals to testable bets.
 ---
 
 # Product Manager PM-2

--- a/.claude/skills/product-manager/SKILL.md
+++ b/.claude/skills/product-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-manager
-description: Product discovery — feature-gap prediction, roadmap option shaping, acceptance criteria, vague signals to testable bets.
+description: Product discovery — feature-gap prediction, roadmap option shaping, vague signals to testable bets.
 ---
 
 # Product Manager PM-2

--- a/.claude/skills/public-api-designer/SKILL.md
+++ b/.claude/skills/public-api-designer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: public-api-designer
-description: Reviews every proposed public API change on Zeta before it lands — new public types/members, internal→public flips, signature changes on existing public surface, public member removals. Conservative by default: every public member is a contract Zeta maintains to consumers we have not yet met. Advisory; the Architect integrates.
+description: Public API review — new public types/members, signature changes, internal→public flips; conservative contract guard.
 ---
 
 # Public API Designer

--- a/.claude/skills/race-hunter/SKILL.md
+++ b/.claude/skills/race-hunter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: race-hunter
-description: Use this skill when reviewing Zeta.Core F# code for concurrency bugs — missed `Interlocked.CompareExchange`, torn reads on shared mutable state, lock-across-await, unguarded `ResizeArray` iteration during concurrent `Register`. Produces a ranked P0/P1/P2 finding list with file:line references and concrete repros.
+description: F# concurrency race hunter — Interlocked gaps, torn reads, lock-across-await, unguarded ResizeArray iteration.
 ---
 
 # Zeta.Core Race Hunter

--- a/.claude/skills/storage-specialist/SKILL.md
+++ b/.claude/skills/storage-specialist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: storage-specialist
-description: Use this skill as the designated specialist reviewer for Zeta.Core's storage layer — DiskBackingStore, Spine family, checkpoint format, durability modes, WDC. Carries deep advisory authority on storage technical direction; final decisions require Architect buy-in or human contributor sign-off (see docs/CONFLICT-RESOLUTION.md).
+description: Storage layer review — DiskBackingStore, Spine family, checkpoint format, durability modes, WDC advisory.
 ---
 
 # Storage Specialist — Advisory Code Owner


### PR DESCRIPTION
## Summary
- Carve 5 oversized skill descriptions to routing sentences per B-0347
- Skills: product-manager, public-api-designer, storage-specialist, package-auditor, race-hunter
- Body content preserved; only frontmatter `description:` field reduced

## Test plan
- [ ] CI passes (frontmatter-only changes, no code impact)
- [ ] Skill router still triggers on relevant queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>