### PR TITLE
chore(B-0347): carve 5 more skill descriptions (batch 20)

### DIFF
--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openspec-explore
-description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+description: OpenSpec explore mode — thinking partner for idea exploration, problem investigation, requirements clarification.
 license: MIT
 compatibility: Requires openspec CLI.
 metadata:

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openspec-propose
-description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+description: Propose a new OpenSpec change — generates design, specs, and tasks in one step.
 license: MIT
 compatibility: Requires openspec CLI.
 metadata:

--- a/.claude/skills/self-replication/SKILL.md
+++ b/.claude/skills/self-replication/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: self-replication
-description: Makes an agent persistent on the current machine. Detects OS, creates service worktree, deploys tick script, registers background service, verifies heartbeat. Also handles SSH remote replication to other machines. The skill that makes the factory portable.
+description: Agent persistence — OS-detect, service worktree, tick script deploy, daemon register, heartbeat verify; SSH remote replication.
 when-to-wear: When setting up a new machine as a factory node, when replicating to a remote machine via SSH, when recovering a broken background service, or when upgrading an existing service to the latest tick script.
 ---
 

--- a/.claude/skills/spec-zealot/SKILL.md
+++ b/.claude/skills/spec-zealot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-zealot
-description: Capability skill — produces a zero-empathy spec-to-code alignment review. Outputs drift, spec bugs, spec gaps, best-practice lint, and overlay discipline findings. Pure procedure; no persona (the persona lives on the invoking expert — see .claude/agents/spec-zealot.md).
+description: Spec-to-code alignment review — zero-empathy; finds drift, spec bugs, gaps, overlay violations, best-practice lint.
 ---
 
 # Spec Zealot — Disaster-Recovery Review Procedure

--- a/.claude/skills/streaming-incremental-expert/SKILL.md
+++ b/.claude/skills/streaming-incremental-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: streaming-incremental-expert
-description: DBSP / Timely Dataflow streaming-incremental execution — delta-stream composition, retraction-native IVM, standing queries, virtual vs wall time, watermarks/frontiers.
+description: DBSP / Timely Dataflow — delta-stream composition, retraction-native IVM, standing queries, watermarks, frontiers.
 ---
 
 # Streaming / Incremental Expert — The Base Substrate


### PR DESCRIPTION
## Summary

Continues B-0347 carved-sentence carving pass — batch 20 of ~40 remaining.

Carved the 5 longest remaining descriptions:

| Skill | Before | After |
|-------|--------|-------|
| spec-zealot | 274 chars | 118 chars |
| self-replication | 256 chars | 133 chars |
| openspec-propose | 214 chars | 79 chars |
| openspec-explore | 191 chars | 105 chars |
| streaming-incremental-expert | 169 chars | 112 chars |

All descriptions now under 150 chars (preferred <120). Routing terms preserved.

## Test plan

- [x] Build gate passes (0 warnings, 0 errors)
- [x] Each description names domain + key routing terms in one sentence
- [x] No "Capability skill (hat)" boilerplate
- [x] No "Use when the user wants to..." preamble

🤖 Generated with [Claude Code](https://claude.com/claude-code)