### PR TITLE
chore(B-0347): carve 5 more skill descriptions (batch 20)

### DIFF
--- a/.claude/skills/formal-verification-expert/SKILL.md
+++ b/.claude/skills/formal-verification-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: formal-verification-expert
-description: the `formal-verification-expert` — formal-verification routing expert. Picks the right tool for each property class (TLA+, Z3, Lean, Alloy, FsCheck, Stryker, Semgrep, CodeQL, plus researched-only tools) before any spec gets written. Guards against TLA+-hammer bias. Owns the portfolio view of formal coverage.
+description: Formal-verification routing — picks TLA+/Z3/Lean/Alloy/FsCheck/Stryker/Semgrep/CodeQL per property class.
 ---
 
 # Formal Verification Expert — Routing Procedure

--- a/.claude/skills/next-steps/SKILL.md
+++ b/.claude/skills/next-steps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: next-steps
-description: Recommends the next 3-5 items to work on, ranked by value-delivered-per-effort. Invoke at session end, before committing, or when the human asks "what now?". Reads BACKLOG.md + recent ROUND-HISTORY.md + open harsh-critic findings + incomplete research reports and proposes a short, sharp list with reasoning.
+description: Next-steps recommender — top 3-5 items ranked by value-per-effort from backlog, findings, and research.
 ---
 
 # Next Steps Advisor

--- a/.claude/skills/performance-engineer/SKILL.md
+++ b/.claude/skills/performance-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-engineer
-description: Capability skill — hot-path tuning, allocation audits, cache-line behaviour, SIMD dispatch, benchmark-driven optimization. Distinct from the `complexity-reviewer` (complexity-reviewer's asymptotics + lower bounds) and the `query-planner` (query-planner's cost model + join order).
+description: Hot-path tuning — allocation audits, cache-line behaviour, SIMD dispatch, benchmark-driven optimization.
 ---
 
 # Performance Engineer — Procedure

--- a/.claude/skills/replicate/SKILL.md
+++ b/.claude/skills/replicate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: replicate
-description: Replicates the agent factory to a REMOTE machine via SSH. Composes make-persistent as the local primitive — replicate(target) = ssh(target) → make-persistent(). Handles SSH key exchange, remote environment validation, repo clone, and delegates to make-persistent for service registration.
+description: Remote agent replication — SSH key exchange, repo clone, service registration via make-persistent.
 when-to-wear: When spreading the factory to a new remote machine, recovering a remote node, or upgrading a remote node's service.
 ---
 

--- a/.claude/skills/security-researcher/SKILL.md
+++ b/.claude/skills/security-researcher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-researcher
-description: Capability skill — proactive security research. Scouts novel attack classes, crypto primitives, supply-chain patterns, CVEs in the dep graph, and research-preview attack surfaces. Distinct from the `threat-model-critic` (reviews the *shipped* model) and the `prompt-protector` (owns the agent layer).
+description: Proactive security research — novel attack classes, crypto primitives, supply-chain risks, CVE scouting.
 ---
 
 # Security Researcher — Procedure


### PR DESCRIPTION
## Summary
- Carve 5 oversized skill descriptions to routing sentences per B-0347
- Skills: formal-verification-expert, next-steps, security-researcher, replicate, performance-engineer
- Body content preserved; only frontmatter `description:` field reduced

## Test plan
- [ ] CI passes (frontmatter-only changes, no code impact)
- [ ] Skill router still triggers on relevant queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>