### PR TITLE
chore(B-0347): carve final 5 skill descriptions (batch 21 — completes B-0347)

### DIFF
--- a/.claude/skills/linq-expert/SKILL.md
+++ b/.claude/skills/linq-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linq-expert
-description: "LINQ — IQueryable/IEnumerable, expression-tree providers, SelectMany monad, Nuqleon query serialisation, Standard Query Operators, Zeta operator algebra."
+description: LINQ — IQueryable/IEnumerable, expression trees, SelectMany monad, Nuqleon serialisation, Zeta algebra.
 ---
 
 # LINQ Expert — Language-Integrated Query Hat

--- a/.claude/skills/streaming-window-expert/SKILL.md
+++ b/.claude/skills/streaming-window-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: streaming-window-expert
-description: Windowed streaming aggregation — tumbling/hopping/session windows, watermark policy, late-event handling, allowed-lateness, retraction-native window deltas.
+description: Windowed streaming — tumbling/hopping/session windows, watermarks, late events, retraction-native deltas.
 ---
 
 # Streaming Window Expert — Windowed Aggregation Narrow

--- a/.claude/skills/time-and-clocks-expert/SKILL.md
+++ b/.claude/skills/time-and-clocks-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: time-and-clocks-expert
-description: Time and clocks — wall-clock vs monotonic, NTP/PTP drift, epoch arithmetic, UTC/TAI leap seconds, logical clocks (Lamport/vector), DST-safe time reasoning.
+description: Time and clocks — wall vs monotonic, NTP/PTP drift, UTC/TAI, logical clocks (Lamport/vector), DST-safe.
 ---
 
 # Time + Clocks Expert — Ordering, Sync, Causality

--- a/.claude/skills/tla-expert/SKILL.md
+++ b/.claude/skills/tla-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tla-expert
-description: TLA+ specification idioms for Zeta's 18 specs under tools/tla/specs/ — operators, fairness, refinement mappings, TLC model checking, TLAPS proof discipline.
+description: TLA+ — operators, fairness, refinement mappings, TLC model checking, TLAPS proof discipline.
 ---
 
 # TLA+ Expert — Procedure + Lore

--- a/.claude/skills/volcano-iterator-expert/SKILL.md
+++ b/.claude/skills/volcano-iterator-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: volcano-iterator-expert
-description: Volcano/iterator execution model — open/next/close protocol, pull-based pipeline, blocking operators, bushy/left-deep trees, classic DBMS execution layer.
+description: Volcano/iterator model — open/next/close, pull-based pipeline, blocking operators, bushy/left-deep trees.
 ---
 
 # Volcano Iterator Expert — Classical Pull-Based Model


### PR DESCRIPTION
## Summary
- Carve final 5 oversized skill descriptions to routing sentences per B-0347
- Skills: tla-expert, streaming-window-expert, time-and-clocks-expert, linq-expert, volcano-iterator-expert
- **B-0347 is now complete** — 0 skills remain above 150 chars (all 246 carved)

## Test plan
- [ ] CI passes (frontmatter-only changes, no code impact)
- [ ] `for f in .claude/skills/*/SKILL.md; do desc=$(sed -n '/^description:/p' "$f"); [ ${#desc} -gt 150 ] && echo "OVER: $f"; done` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>