### PR TITLE
chore(B-0325): close backlog item — KIRO + CLAUDE trigger lists already shipped

### DIFF
--- a/docs/backlog/P1/B-0325-peer-call-firewall-kiro-claude-trigger-lists.md
+++ b/docs/backlog/P1/B-0325-peer-call-firewall-kiro-claude-trigger-lists.md
@@ -1,7 +1,7 @@
 ---
 id: B-0325
 priority: P1
-status: done
+status: closed
 title: "Add KIRO + CLAUDE firewall trigger lists to _firewall.ts"
 tier: peer-call-substrate
 effort: XS

--- a/docs/backlog/P1/B-0325-peer-call-firewall-kiro-claude-trigger-lists.md
+++ b/docs/backlog/P1/B-0325-peer-call-firewall-kiro-claude-trigger-lists.md
@@ -1,7 +1,7 @@
 ---
 id: B-0325
 priority: P1
-status: open
+status: done
 title: "Add KIRO + CLAUDE firewall trigger lists to _firewall.ts"
 tier: peer-call-substrate
 effort: XS
@@ -45,7 +45,7 @@ cross-file dependency on an unmerged sibling.
 
 ## Done-criteria
 
-- [ ] `KIRO_SUBSTANTIVE_TRIGGERS` exported from `_firewall.ts`
-- [ ] `CLAUDE_SUBSTANTIVE_TRIGGERS` exported from `_firewall.ts`
-- [ ] Both extend `DEFAULT_SUBSTANTIVE_TRIGGERS` (spread pattern)
-- [ ] `bun run typecheck` passes
+- [x] `KIRO_SUBSTANTIVE_TRIGGERS` exported from `_firewall.ts`
+- [x] `CLAUDE_SUBSTANTIVE_TRIGGERS` exported from `_firewall.ts`
+- [x] Both extend `DEFAULT_SUBSTANTIVE_TRIGGERS` (spread pattern)
+- [x] `bun run typecheck` passes (scoped to `tools/peer-call/`; repo-wide failures are pre-existing in `snapshot.ts`, unrelated to this item)


### PR DESCRIPTION
## Summary

- B-0325 implementation landed in PR #2178 (`f2ce2f3a`) — `KIRO_SUBSTANTIVE_TRIGGERS` and `CLAUDE_SUBSTANTIVE_TRIGGERS` were added to `tools/peer-call/_firewall.ts` following the spread pattern.
- Backlog item status was stuck at `open` with unchecked done-criteria.
- This PR closes out the tracking state only (no code changes).

## Checks run

- `bun run typecheck` scoped to `tools/peer-call/` — zero errors in `_firewall.ts`
- Repo-wide typecheck fails in `tools/playwright/github-ui/snapshot.ts` (pre-existing issue from B-0318, unrelated to this item)
- All four done-criteria verified against merged code

## Done-criteria verification

| Criterion | Status |
|-----------|--------|
| `KIRO_SUBSTANTIVE_TRIGGERS` exported from `_firewall.ts` | ✓ (line 110–119) |
| `CLAUDE_SUBSTANTIVE_TRIGGERS` exported from `_firewall.ts` | ✓ (line 121–135) |
| Both extend `DEFAULT_SUBSTANTIVE_TRIGGERS` (spread pattern) | ✓ |
| `bun run typecheck` passes for peer-call module | ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)