### PR TITLE
fix(snapshot): null-guard matchAll capture groups — TS strict null

### DIFF
--- a/tools/playwright/github-ui/snapshot.ts
+++ b/tools/playwright/github-ui/snapshot.ts
@@ -29,6 +29,7 @@ export function extractToggles(html: string): Record<string, boolean> {
   const result: Record<string, boolean> = {};
   const tagPattern = /<input\b([^>]*?)(?:\s*\/?>)/gi;
   for (const [, attrs] of html.matchAll(tagPattern)) {
+    if (attrs == null) continue;
     if (!/\btype\s*=\s*["']checkbox["']/i.test(attrs)) continue;
     const name = parseAttr(attrs, "name") ?? parseAttr(attrs, "id");
     if (!name) continue;
@@ -51,6 +52,7 @@ export function extractFormValues(html: string): Record<string, string> {
   const textTypes = new Set(["text", "email", "url", "number", "search", "tel"]);
   const tagPattern = /<input\b([^>]*?)(?:\s*\/?>)/gi;
   for (const [, attrs] of html.matchAll(tagPattern)) {
+    if (attrs == null) continue;
     const typeRaw = parseAttr(attrs, "type");
     // Inputs with no explicit type default to "text" in HTML
     const type = typeRaw?.toLowerCase() ?? "text";
@@ -71,6 +73,7 @@ export function extractVisibleFeatures(html: string): string[] {
   const features: string[] = [];
   const headingPattern = /<h[23]\b[^>]*>([\s\S]*?)<\/h[23]>/gi;
   for (const [, inner] of html.matchAll(headingPattern)) {
+    if (inner == null) continue;
     const text = inner.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
     if (text) features.push(text);
   }


### PR DESCRIPTION
## Summary

- `snapshot.ts` had 10 TypeScript strict-null errors introduced in B-0318 / PR #2300
- `RegExpMatchArray` capture groups type as `string | undefined` in strict mode, but `parseAttr()` and `RegExp.prototype.test()` both require `string`
- Added `if (x == null) continue;` guard immediately after each `for...of matchAll` destructuring in the three extractor functions (`extractToggles`, `extractFormValues`, `extractVisibleFeatures`)
- No behavioral change — the regex patterns always bind the capture group when they match, so the guard is a no-op at runtime; it only narrows the TS type

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `dotnet build -c Release` is unaffected (TS-only change)
- [ ] CI `lint (tsc tools)` should go green

Fixes the pre-existing failure blocking `lint (tsc tools)` on every PR since #2300 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)