### PR TITLE
fix(B-0324): guard billing-reader minutes capture

### DIFF
--- a/tools/playwright/github-ui/billing-reader.ts
+++ b/tools/playwright/github-ui/billing-reader.ts
@@ -78,7 +78,17 @@ export async function readOrgBillingUsage(
       };
     }
 
-    const minutesUsed = parseInt(actionsMatch[1].replace(/,/g, ""), 10) || 0;
+    const minutesUsedText = actionsMatch[1];
+    if (!minutesUsedText) {
+      return {
+        org,
+        actions: { minutesUsed: 0, minutesLimit: null },
+        error: "parse-error",
+        rawExcerpt: html.substring(0, 300),
+      };
+    }
+
+    const minutesUsed = parseInt(minutesUsedText.replace(/,/g, ""), 10) || 0;
     let minutesLimit: number | null = null;
     if (actionsMatch[2] && actionsMatch[2].toLowerCase() !== "unlimited") {
       minutesLimit = parseInt(actionsMatch[2].replace(/,/g, ""), 10) || null;


### PR DESCRIPTION
## Summary
- guard the required Actions minutes capture before normalizing it
- preserve the existing parse-error result shape when the regex match lacks that capture

## Why
Main push gate is failing `lint (tsc tools)` at `tools/playwright/github-ui/billing-reader.ts(81,34)` after #2313/#2314. This fixes that TypeScript regression from current `main`.

## Verification
- `bun --bun tsc --noEmit -p tsconfig.json`
- `bun test tools/playwright/github-ui/billing-reader.test.ts`