### PR TITLE
fix(B-0310): align output-schema example with actual Concept interface

### DIFF
--- a/docs/backlog/P1/B-0310-concept-registry-extraction-tool.md
+++ b/docs/backlog/P1/B-0310-concept-registry-extraction-tool.md
@@ -7,7 +7,7 @@ tier: substrate-quality
 effort: S
 parent: B-0060
 created: 2026-05-08
-last_updated: 2026-05-08
+last_updated: 2026-05-09
 depends_on: []
 composes_with: [B-0060, B-0311]
 tags: [substrate-quality, tooling, concept-registry, human-lineage]
@@ -47,11 +47,15 @@ anchoring work under B-0060.
   "concepts": [
     {
       "id": "HC-1",
-      "class": "alignment-clause",
+      "conceptClass": "alignment-clause",
       "source": "docs/ALIGNMENT.md",
-      "label": "..."
+      "label": "...",
+      "anchor": "optional-human-lineage-anchor"
     }
-  ]
+  ],
+  "summary": {
+    "alignment-clause": 7
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

Fixes schema drift in B-0310 doc flagged by Copilot reviewer on PR #2316.

### Changes
 `conceptClass` (the field has always been `conceptClass` in the implementation; the schema snippet was stale from before the rename)
- Added optional `anchor?` field (landed in PR #2316 / B-0361 slice)
- Added `summary` object to the example (present in `Registry` output but missing from snippet)

### Relation to PR #2316
The Copilot reviewer on #2316 flagged that adding `anchor?` extended the JSON shape without updating B-0310's schema doc. This PR addresses that drift, allowing the thread on #2316 to be resolved.

No code  docs/backlog only.changes 

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>