### PR TITLE
feat(B-0311): external-anchor coverage scanner — per-concept audit tool

### DIFF
--- a/tools/alignment/audit_external_anchors.test.ts
+++ b/tools/alignment/audit_external_anchors.test.ts
@@ -3,7 +3,7 @@
 // Tests for the external-anchor coverage scanner.
 // Run: bun test tools/alignment/audit_external_anchors.test.ts
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   audit,
   classifyUrl,
@@ -123,6 +123,20 @@ describe("extractUrlsFromWindow", () => {
     const urls = entries.map((e) => e.url);
     expect(urls.filter((u) => u === "https://doi.org/10.1/dup")).toHaveLength(1);
   });
+
+  test("finds anchor near later occurrence when first occurrence has none", () => {
+    // First mention (TOC/intro) has no nearby URL; definition section does.
+    const multiOccurrence = [
+      "intro: see HC-3 for details",
+      "unrelated line 1",
+      "unrelated line 2",
+      "Definition section for HC-3",
+      "see https://arxiv.org/abs/2402.00042 for background",
+    ].join("\n");
+    const entries = extractUrlsFromWindow(multiOccurrence, "HC-3", 2);
+    const urls = entries.map((e) => e.url);
+    expect(urls).toContain("https://arxiv.org/abs/2402.00042");
+  });
 });
 
 describe("audit() integration", () => {
@@ -146,7 +160,7 @@ describe("audit() integration", () => {
     for (const c of result.concepts) {
       expect(typeof c.id).toBe("string");
       expect(c.id.length).toBeGreaterThan(0);
-      expect(typeof c.conceptClass).toBe("string");
+      expect(typeof c.class).toBe("string");
       expect(typeof c.source).toBe("string");
       expect(["anchored", "anchor-pending"]).toContain(c.status);
       expect(Array.isArray(c.anchors)).toBe(true);
@@ -171,6 +185,10 @@ describe("audit() integration", () => {
 });
 
 describe("main() CLI", () => {
+  let savedCwd: string;
+  beforeEach(() => { savedCwd = process.cwd(); });
+  afterEach(() => { process.chdir(savedCwd); });
+
   test("returns 0 with no args", () => {
     expect(main([])).toBe(0);
   });
@@ -193,5 +211,9 @@ describe("main() CLI", () => {
 
   test("returns 2 when --out has no value", () => {
     expect(main(["--out"])).toBe(2);
+  });
+
+  test("returns 2 when --json and --md both specified", () => {
+    expect(main(["--json", "--md"])).toBe(2);
   });
 });

--- a/tools/alignment/audit_external_anchors.test.ts
+++ b/tools/alignment/audit_external_anchors.test.ts
@@ -1,0 +1,197 @@
+// audit_external_anchors.test.ts — B-0311
+//
+// Tests for the external-anchor coverage scanner.
+// Run: bun test tools/alignment/audit_external_anchors.test.ts
+
+import { describe, expect, test } from "bun:test";
+import {
+  audit,
+  classifyUrl,
+  extractUrlsFromWindow,
+  main,
+} from "./audit_external_anchors.ts";
+
+describe("classifyUrl", () => {
+  test("arxiv.org → paper", () => {
+    expect(classifyUrl("https://arxiv.org/abs/1234.5678")).toBe("paper");
+  });
+
+  test("doi.org → paper", () => {
+    expect(classifyUrl("https://doi.org/10.1145/1234567")).toBe("paper");
+  });
+
+  test("dl.acm.org → paper", () => {
+    expect(classifyUrl("https://dl.acm.org/doi/10.1145/123")).toBe("paper");
+  });
+
+  test("tools.ietf.org → rfc", () => {
+    expect(classifyUrl("https://tools.ietf.org/html/rfc7231")).toBe("rfc");
+  });
+
+  test("w3.org → rfc", () => {
+    expect(classifyUrl("https://www.w3.org/TR/json-ld/")).toBe("rfc");
+  });
+
+  test("stackoverflow.com → so-se", () => {
+    expect(classifyUrl("https://stackoverflow.com/questions/12345")).toBe("so-se");
+  });
+
+  test("stackexchange.com → so-se", () => {
+    expect(classifyUrl("https://cs.stackexchange.com/questions/12345")).toBe("so-se");
+  });
+
+  test("youtube.com → talk", () => {
+    expect(classifyUrl("https://www.youtube.com/watch?v=abc")).toBe("talk");
+  });
+
+  test("youtu.be → talk", () => {
+    expect(classifyUrl("https://youtu.be/abc")).toBe("talk");
+  });
+
+  test("github.com → blog", () => {
+    expect(classifyUrl("https://github.com/some/repo")).toBe("blog");
+  });
+
+  test("example.com → blog", () => {
+    expect(classifyUrl("https://example.com/post/foo")).toBe("blog");
+  });
+
+  test("malformed URL → other", () => {
+    expect(classifyUrl("not-a-url")).toBe("other");
+  });
+});
+
+describe("extractUrlsFromWindow", () => {
+  const content = [
+    "Line 0: preamble",
+    "Line 1: HC-1 is defined here",
+    "Line 2: see [Pearl 2009](https://doi.org/10.1017/CBO9780511803161)",
+    "Line 3: also https://arxiv.org/abs/2401.00001",
+    "Line 4: unrelated",
+    "Line 100: far away SD-1 https://example.com/far",
+  ].join("\n");
+
+  test("returns empty array when concept ID not found", () => {
+    expect(extractUrlsFromWindow(content, "HC-99", 5)).toHaveLength(0);
+  });
+
+  test("finds markdown link URL near concept", () => {
+    const entries = extractUrlsFromWindow(content, "HC-1", 5);
+    const urls = entries.map((e) => e.url);
+    expect(urls).toContain("https://doi.org/10.1017/CBO9780511803161");
+  });
+
+  test("classifies doi.org as paper", () => {
+    const entries = extractUrlsFromWindow(content, "HC-1", 5);
+    const doi = entries.find((e) => e.url.includes("doi.org"));
+    expect(doi?.kind).toBe("paper");
+  });
+
+  test("captures markdown link title", () => {
+    const entries = extractUrlsFromWindow(content, "HC-1", 5);
+    const doi = entries.find((e) => e.url.includes("doi.org"));
+    expect(doi?.title).toBe("Pearl 2009");
+  });
+
+  test("finds bare URL near concept", () => {
+    const entries = extractUrlsFromWindow(content, "HC-1", 5);
+    const urls = entries.map((e) => e.url);
+    expect(urls).toContain("https://arxiv.org/abs/2401.00001");
+  });
+
+  test("bare URL has empty title", () => {
+    const entries = extractUrlsFromWindow(content, "HC-1", 5);
+    const arxiv = entries.find((e) => e.url.includes("arxiv.org"));
+    expect(arxiv?.title).toBe("");
+  });
+
+  test("excludes URL too far from concept (small window)", () => {
+    // SD-1 is on line 5 (index 5); HC-1 is on line 1 (index 1).
+    // With windowLines=2, SD-1 at line 5 should NOT capture the HC-1 URLs.
+    const entries = extractUrlsFromWindow(content, "SD-1", 1);
+    const urls = entries.map((e) => e.url);
+    expect(urls).not.toContain("https://doi.org/10.1017/CBO9780511803161");
+    expect(urls).toContain("https://example.com/far");
+  });
+
+  test("deduplicates repeated URLs", () => {
+    const repeated = [
+      "HC-2 intro",
+      "https://doi.org/10.1/dup https://doi.org/10.1/dup",
+    ].join("\n");
+    const entries = extractUrlsFromWindow(repeated, "HC-2", 5);
+    const urls = entries.map((e) => e.url);
+    expect(urls.filter((u) => u === "https://doi.org/10.1/dup")).toHaveLength(1);
+  });
+});
+
+describe("audit() integration", () => {
+  test("returns a valid AuditResult shape", () => {
+    const result = audit();
+    expect(result.schema).toBe("external-anchor-coverage-v1");
+    expect(typeof result.generated).toBe("string");
+    expect(typeof result.totalConcepts).toBe("number");
+    expect(typeof result.anchored).toBe("number");
+    expect(typeof result.pending).toBe("number");
+    expect(Array.isArray(result.concepts)).toBe(true);
+  });
+
+  test("anchored + pending == totalConcepts", () => {
+    const result = audit();
+    expect(result.anchored + result.pending).toBe(result.totalConcepts);
+  });
+
+  test("every concept has required fields", () => {
+    const result = audit();
+    for (const c of result.concepts) {
+      expect(typeof c.id).toBe("string");
+      expect(c.id.length).toBeGreaterThan(0);
+      expect(typeof c.conceptClass).toBe("string");
+      expect(typeof c.source).toBe("string");
+      expect(["anchored", "anchor-pending"]).toContain(c.status);
+      expect(Array.isArray(c.anchors)).toBe(true);
+    }
+  });
+
+  test("anchored status iff anchors array is non-empty", () => {
+    const result = audit();
+    for (const c of result.concepts) {
+      if (c.status === "anchored") {
+        expect(c.anchors.length).toBeGreaterThan(0);
+      } else {
+        expect(c.anchors).toHaveLength(0);
+      }
+    }
+  });
+
+  test("returns at least one concept", () => {
+    const result = audit();
+    expect(result.totalConcepts).toBeGreaterThan(0);
+  });
+});
+
+describe("main() CLI", () => {
+  test("returns 0 with no args", () => {
+    expect(main([])).toBe(0);
+  });
+
+  test("returns 0 with --help", () => {
+    expect(main(["--help"])).toBe(0);
+  });
+
+  test("returns 0 with --json", () => {
+    expect(main(["--json"])).toBe(0);
+  });
+
+  test("returns 0 with --md", () => {
+    expect(main(["--md"])).toBe(0);
+  });
+
+  test("returns 2 for unknown arg", () => {
+    expect(main(["--bad-flag"])).toBe(2);
+  });
+
+  test("returns 2 when --out has no value", () => {
+    expect(main(["--out"])).toBe(2);
+  });
+});

--- a/tools/alignment/audit_external_anchors.test.ts
+++ b/tools/alignment/audit_external_anchors.test.ts
@@ -83,13 +83,13 @@ describe("extractUrlsFromWindow", () => {
 
   test("classifies doi.org as paper", () => {
     const entries = extractUrlsFromWindow(content, "HC-1", 5);
-    const doi = entries.find((e) => e.url.includes("doi.org"));
+    const doi = entries.find((e) => e.url.startsWith("https://doi.org/"));
     expect(doi?.kind).toBe("paper");
   });
 
   test("captures markdown link title", () => {
     const entries = extractUrlsFromWindow(content, "HC-1", 5);
-    const doi = entries.find((e) => e.url.includes("doi.org"));
+    const doi = entries.find((e) => e.url.startsWith("https://doi.org/"));
     expect(doi?.title).toBe("Pearl 2009");
   });
 
@@ -101,7 +101,7 @@ describe("extractUrlsFromWindow", () => {
 
   test("bare URL has empty title", () => {
     const entries = extractUrlsFromWindow(content, "HC-1", 5);
-    const arxiv = entries.find((e) => e.url.includes("arxiv.org"));
+    const arxiv = entries.find((e) => e.url.startsWith("https://arxiv.org/"));
     expect(arxiv?.title).toBe("");
   });
 

--- a/tools/alignment/audit_external_anchors.ts
+++ b/tools/alignment/audit_external_anchors.ts
@@ -1,0 +1,364 @@
+#!/usr/bin/env bun
+// audit_external_anchors.ts — B-0311
+// Per-concept external anchor coverage scanner.
+//
+// Loads the concept registry (B-0310), locates each concept in its
+// source surface, and extracts external URLs from the surrounding
+// context window. Emits a coverage report mapping each concept to
+// its anchors or an "anchor-pending" marker.
+//
+// Usage:
+//   bun tools/alignment/audit_external_anchors.ts
+//   bun tools/alignment/audit_external_anchors.ts --json
+//   bun tools/alignment/audit_external_anchors.ts --md
+//   bun tools/alignment/audit_external_anchors.ts --out DIR
+//
+// Exit codes:
+//   0  Clean run
+//   2  Script error / bad args
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { buildRegistry } from "./concept_registry.ts";
+
+type AuditExitCode = 0 | 2;
+
+// ── URL classification ───────────────────────────────────────────────────────
+
+export type UrlKind = "paper" | "rfc" | "blog" | "so-se" | "talk" | "other";
+
+const PAPER_DOMAINS = [
+  "arxiv.org",
+  "doi.org",
+  "dl.acm.org",
+  "semanticscholar.org",
+  "jstor.org",
+  "scholar.google.com",
+  "springer.com",
+  "nature.com",
+  "ieee.org",
+  "acm.org",
+  "ncbi.nlm.nih.gov",
+  "openreview.net",
+  "proceedings.mlr.press",
+  "papers.nips.cc",
+  "aclanthology.org",
+];
+
+const RFC_DOMAINS = [
+  "tools.ietf.org",
+  "rfc-editor.org",
+  "datatracker.ietf.org",
+  "w3.org",
+];
+
+const SOSE_DOMAINS = [
+  "stackoverflow.com",
+  "stackexchange.com",
+  "serverfault.com",
+  "superuser.com",
+  "askubuntu.com",
+];
+
+const TALK_DOMAINS = [
+  "youtube.com",
+  "youtu.be",
+  "vimeo.com",
+  "slideshare.net",
+  "speakerdeck.com",
+  "loom.com",
+];
+
+function domainOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}
+
+export function classifyUrl(url: string): UrlKind {
+  const host = domainOf(url);
+  if (host === "") return "other";
+  if (PAPER_DOMAINS.some((d) => host === d || host.endsWith(`.${d}`)))
+    return "paper";
+  if (RFC_DOMAINS.some((d) => host === d || host.endsWith(`.${d}`)))
+    return "rfc";
+  if (SOSE_DOMAINS.some((d) => host === d || host.endsWith(`.${d}`)))
+    return "so-se";
+  if (TALK_DOMAINS.some((d) => host === d || host.endsWith(`.${d}`)))
+    return "talk";
+  return "blog";
+}
+
+// ── URL extraction from a text window ────────────────────────────────────────
+
+export interface AnchorEntry {
+  readonly url: string;
+  readonly kind: UrlKind;
+  readonly title: string;
+}
+
+// Matches [title](https://...) — captures title and URL.
+const MARKDOWN_LINK_RE = /\[([^\]]*)\]\((https?:\/\/[^)\s]+)\)/g;
+// Matches bare https?://... not already inside a markdown link.
+const BARE_URL_RE = /(?<!\()https?:\/\/[^\s),\]"'`>]+/g;
+
+export function extractUrlsFromWindow(
+  content: string,
+  conceptId: string,
+  windowLines = 20,
+): AnchorEntry[] {
+  const lines = content.split("\n");
+  // Find the first line that contains the concept ID as a token.
+  const idPattern = new RegExp(`\\b${escapeRegex(conceptId)}\\b`);
+  const anchorIdx = lines.findIndex((l) => idPattern.test(l));
+  if (anchorIdx < 0) return [];
+
+  const start = Math.max(0, anchorIdx - windowLines);
+  const end = Math.min(lines.length, anchorIdx + windowLines + 1);
+  const window = lines.slice(start, end).join("\n");
+
+  const seen = new Set<string>();
+  const entries: AnchorEntry[] = [];
+
+  // Pass 1: markdown links (title available).
+  for (const m of window.matchAll(MARKDOWN_LINK_RE)) {
+    const title = m[1] ?? "";
+    const url = m[2] ?? "";
+    if (!seen.has(url)) {
+      seen.add(url);
+      entries.push({ url, kind: classifyUrl(url), title });
+    }
+  }
+
+  // Pass 2: bare URLs not already captured.
+  for (const m of window.matchAll(BARE_URL_RE)) {
+    const url = m[0];
+    if (!seen.has(url)) {
+      seen.add(url);
+      entries.push({ url, kind: classifyUrl(url), title: "" });
+    }
+  }
+
+  return entries;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// ── Audit ────────────────────────────────────────────────────────────────────
+
+export type ConceptStatus = "anchored" | "anchor-pending";
+
+export interface ConceptCoverage {
+  readonly id: string;
+  readonly conceptClass: string;
+  readonly source: string;
+  readonly status: ConceptStatus;
+  readonly anchors: readonly AnchorEntry[];
+}
+
+export interface AuditResult {
+  readonly schema: string;
+  readonly generated: string;
+  readonly totalConcepts: number;
+  readonly anchored: number;
+  readonly pending: number;
+  readonly concepts: readonly ConceptCoverage[];
+}
+
+const REPO_ROOT = resolve(import.meta.dir, "../..");
+
+function readSource(rel: string): string {
+  const abs = join(REPO_ROOT, rel);
+  return existsSync(abs) ? readFileSync(abs, "utf8") : "";
+}
+
+export function audit(): AuditResult {
+  const registry = buildRegistry();
+  const concepts: ConceptCoverage[] = [];
+
+  for (const concept of registry.concepts) {
+    const content = readSource(concept.source);
+    const anchors = extractUrlsFromWindow(content, concept.id, 20);
+    const status: ConceptStatus = anchors.length > 0 ? "anchored" : "anchor-pending";
+    concepts.push({
+      id: concept.id,
+      conceptClass: concept.conceptClass,
+      source: concept.source,
+      status,
+      anchors,
+    });
+  }
+
+  const anchoredCount = concepts.filter((c) => c.status === "anchored").length;
+
+  return {
+    schema: "external-anchor-coverage-v1",
+    generated: new Date().toISOString(),
+    totalConcepts: concepts.length,
+    anchored: anchoredCount,
+    pending: concepts.length - anchoredCount,
+    concepts,
+  };
+}
+
+// ── Emit helpers ─────────────────────────────────────────────────────────────
+
+function emitJson(r: AuditResult): string {
+  return `${JSON.stringify(r, null, 2)}\n`;
+}
+
+function emitMd(r: AuditResult): string {
+  const lines: string[] = [];
+  lines.push("# External-anchor coverage audit");
+  lines.push("");
+  lines.push(`Schema: \`${r.schema}\`. Generated: ${r.generated}.`);
+  lines.push("");
+  lines.push(
+    `Concepts: **${String(r.totalConcepts)}** — ` +
+      `anchored: **${String(r.anchored)}**, anchor-pending: **${String(r.pending)}**.`,
+  );
+  lines.push("");
+  lines.push("| Concept | Class | Source | Status | Anchor URLs |");
+  lines.push("| --- | --- | --- | --- | --- |");
+  for (const c of r.concepts) {
+    const urlCells =
+      c.anchors.length > 0
+        ? c.anchors
+            .map((a) => (a.title !== "" ? `[${a.title}](${a.url}) \`${a.kind}\`` : `${a.url} \`${a.kind}\``))
+            .join("<br>")
+        : "(none)";
+    lines.push(`| \`${c.id}\` | ${c.conceptClass} | ${c.source} | **${c.status}** | ${urlCells} |`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function emitHumanSummary(r: AuditResult): string {
+  const lines: string[] = [];
+  lines.push(
+    `external-anchor-coverage: ${String(r.totalConcepts)} concepts, ` +
+      `${String(r.anchored)} anchored, ${String(r.pending)} anchor-pending`,
+  );
+  lines.push("");
+
+  const pending = r.concepts.filter((c) => c.status === "anchor-pending");
+  if (pending.length > 0) {
+    lines.push(`anchor-pending (${String(pending.length)}):`);
+    for (const c of pending) {
+      lines.push(`  [${c.conceptClass}] ${c.id}  (${c.source})`);
+    }
+    lines.push("");
+  }
+
+  const anchored = r.concepts.filter((c) => c.status === "anchored");
+  if (anchored.length > 0) {
+    lines.push(`anchored (${String(anchored.length)}):`);
+    for (const c of anchored) {
+      const firstUrl = c.anchors[0]?.url ?? "";
+      lines.push(`  [${c.conceptClass}] ${c.id}  ${firstUrl}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+// ── CLI arg parsing ───────────────────────────────────────────────────────────
+
+interface Args {
+  readonly json: boolean;
+  readonly md: boolean;
+  readonly outDir: string | null;
+}
+
+type ParseResult =
+  | { readonly kind: "args"; readonly args: Args }
+  | { readonly kind: "help" }
+  | { readonly kind: "error"; readonly message: string };
+
+function parseArgs(argv: readonly string[]): ParseResult {
+  const state: { json: boolean; md: boolean; outDir: string | null } = {
+    json: false,
+    md: false,
+    outDir: null,
+  };
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i] ?? "";
+    if (arg === "-h" || arg === "--help") return { kind: "help" };
+    if (arg === "--json") {
+      state.json = true;
+      i++;
+      continue;
+    }
+    if (arg === "--md") {
+      state.md = true;
+      i++;
+      continue;
+    }
+    if (arg === "--out") {
+      const next = argv[i + 1];
+      if (next === undefined)
+        return { kind: "error", message: "audit_external_anchors.ts: --out requires a directory" };
+      state.outDir = next;
+      i += 2;
+      continue;
+    }
+    return { kind: "error", message: `audit_external_anchors.ts: unknown arg: ${arg}` };
+  }
+  return { kind: "args", args: state };
+}
+
+function repoRoot(): string {
+  const result = spawnSync(
+    "git", // eslint-disable-line sonarjs/no-os-command-from-path
+    ["rev-parse", "--show-toplevel"],
+    { encoding: "utf8" },
+  );
+  if (result.error) throw new Error(`git rev-parse failed: ${result.error.message}`);
+  if (result.status !== 0)
+    throw new Error(`git rev-parse exited with status ${String(result.status)}`);
+  return result.stdout.trim();
+}
+
+export function main(argv: readonly string[]): AuditExitCode {
+  const parsed = parseArgs(argv);
+  if (parsed.kind === "help") {
+    process.stdout.write(
+      "Usage: audit_external_anchors.ts [--json | --md] [--out DIR]\n",
+    );
+    return 0;
+  }
+  if (parsed.kind === "error") {
+    process.stderr.write(`${parsed.message}\n`);
+    return 2;
+  }
+
+  process.chdir(repoRoot());
+
+  const { args } = parsed;
+  const result = audit();
+
+  if (args.outDir !== null) {
+    mkdirSync(args.outDir, { recursive: true });
+    writeFileSync(join(args.outDir, "external-anchors.json"), emitJson(result));
+    writeFileSync(join(args.outDir, "external-anchors.md"), emitMd(result));
+    process.stdout.write(
+      `audit_external_anchors: wrote ${args.outDir}/external-anchors.{json,md}\n`,
+    );
+  } else if (args.json) {
+    process.stdout.write(emitJson(result));
+  } else if (args.md) {
+    process.stdout.write(emitMd(result));
+  } else {
+    process.stdout.write(`${emitHumanSummary(result)}\n`);
+  }
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/tools/alignment/audit_external_anchors.ts
+++ b/tools/alignment/audit_external_anchors.ts
@@ -111,34 +111,36 @@ export function extractUrlsFromWindow(
   windowLines = 20,
 ): AnchorEntry[] {
   const lines = content.split("\n");
-  // Find the first line that contains the concept ID as a token.
   const idPattern = new RegExp(`\\b${escapeRegex(conceptId)}\\b`);
-  const anchorIdx = lines.findIndex((l) => idPattern.test(l));
-  if (anchorIdx < 0) return [];
-
-  const start = Math.max(0, anchorIdx - windowLines);
-  const end = Math.min(lines.length, anchorIdx + windowLines + 1);
-  const window = lines.slice(start, end).join("\n");
 
   const seen = new Set<string>();
   const entries: AnchorEntry[] = [];
 
-  // Pass 1: markdown links (title available).
-  for (const m of window.matchAll(MARKDOWN_LINK_RE)) {
-    const title = m[1] ?? "";
-    const url = m[2] ?? "";
-    if (!seen.has(url)) {
-      seen.add(url);
-      entries.push({ url, kind: classifyUrl(url), title });
-    }
-  }
+  // Union URL windows across ALL occurrences of the concept ID.
+  // Scanning only the first occurrence misses anchors near later
+  // (often definition-section) mentions — P0 fix.
+  for (let anchorIdx = 0; anchorIdx < lines.length; anchorIdx++) {
+    if (!idPattern.test(lines[anchorIdx] ?? "")) continue;
 
-  // Pass 2: bare URLs not already captured.
-  for (const m of window.matchAll(BARE_URL_RE)) {
-    const url = m[0];
-    if (!seen.has(url)) {
-      seen.add(url);
-      entries.push({ url, kind: classifyUrl(url), title: "" });
+    const start = Math.max(0, anchorIdx - windowLines);
+    const end = Math.min(lines.length, anchorIdx + windowLines + 1);
+    const window = lines.slice(start, end).join("\n");
+
+    for (const m of window.matchAll(MARKDOWN_LINK_RE)) {
+      const title = m[1] ?? "";
+      const url = m[2] ?? "";
+      if (!seen.has(url)) {
+        seen.add(url);
+        entries.push({ url, kind: classifyUrl(url), title });
+      }
+    }
+
+    for (const m of window.matchAll(BARE_URL_RE)) {
+      const url = m[0];
+      if (!seen.has(url)) {
+        seen.add(url);
+        entries.push({ url, kind: classifyUrl(url), title: "" });
+      }
     }
   }
 
@@ -155,7 +157,7 @@ export type ConceptStatus = "anchored" | "anchor-pending";
 
 export interface ConceptCoverage {
   readonly id: string;
-  readonly conceptClass: string;
+  readonly class: string;
   readonly source: string;
   readonly status: ConceptStatus;
   readonly anchors: readonly AnchorEntry[];
@@ -174,20 +176,28 @@ const REPO_ROOT = resolve(import.meta.dir, "../..");
 
 function readSource(rel: string): string {
   const abs = join(REPO_ROOT, rel);
-  return existsSync(abs) ? readFileSync(abs, "utf8") : "";
+  if (!existsSync(abs)) {
+    process.stderr.write(`audit_external_anchors: source not found: ${rel}\n`);
+    return "";
+  }
+  return readFileSync(abs, "utf8");
 }
 
 export function audit(): AuditResult {
   const registry = buildRegistry();
   const concepts: ConceptCoverage[] = [];
+  const fileCache = new Map<string, string>();
 
   for (const concept of registry.concepts) {
-    const content = readSource(concept.source);
+    if (!fileCache.has(concept.source)) {
+      fileCache.set(concept.source, readSource(concept.source));
+    }
+    const content = fileCache.get(concept.source) ?? "";
     const anchors = extractUrlsFromWindow(content, concept.id, 20);
     const status: ConceptStatus = anchors.length > 0 ? "anchored" : "anchor-pending";
     concepts.push({
       id: concept.id,
-      conceptClass: concept.conceptClass,
+      class: concept.conceptClass,
       source: concept.source,
       status,
       anchors,
@@ -232,7 +242,7 @@ function emitMd(r: AuditResult): string {
             .map((a) => (a.title !== "" ? `[${a.title}](${a.url}) \`${a.kind}\`` : `${a.url} \`${a.kind}\``))
             .join("<br>")
         : "(none)";
-    lines.push(`| \`${c.id}\` | ${c.conceptClass} | ${c.source} | **${c.status}** | ${urlCells} |`);
+    lines.push(`| \`${c.id}\` | ${c.class} | ${c.source} | **${c.status}** | ${urlCells} |`);
   }
   lines.push("");
   return lines.join("\n");
@@ -250,7 +260,7 @@ function emitHumanSummary(r: AuditResult): string {
   if (pending.length > 0) {
     lines.push(`anchor-pending (${String(pending.length)}):`);
     for (const c of pending) {
-      lines.push(`  [${c.conceptClass}] ${c.id}  (${c.source})`);
+      lines.push(`  [${c.class}] ${c.id}  (${c.source})`);
     }
     lines.push("");
   }
@@ -260,7 +270,7 @@ function emitHumanSummary(r: AuditResult): string {
     lines.push(`anchored (${String(anchored.length)}):`);
     for (const c of anchored) {
       const firstUrl = c.anchors[0]?.url ?? "";
-      lines.push(`  [${c.conceptClass}] ${c.id}  ${firstUrl}`);
+      lines.push(`  [${c.class}] ${c.id}  ${firstUrl}`);
     }
   }
   return lines.join("\n");
@@ -309,6 +319,8 @@ function parseArgs(argv: readonly string[]): ParseResult {
     }
     return { kind: "error", message: `audit_external_anchors.ts: unknown arg: ${arg}` };
   }
+  if (state.json && state.md)
+    return { kind: "error", message: "audit_external_anchors.ts: --json and --md are mutually exclusive" };
   return { kind: "args", args: state };
 }
 
@@ -337,7 +349,12 @@ export function main(argv: readonly string[]): AuditExitCode {
     return 2;
   }
 
-  process.chdir(repoRoot());
+  try {
+    process.chdir(repoRoot());
+  } catch (e) {
+    process.stderr.write(`audit_external_anchors.ts: ${String(e)}\n`);
+    return 2;
+  }
 
   const { args } = parsed;
   const result = audit();

--- a/tools/alignment/concept_registry.ts
+++ b/tools/alignment/concept_registry.ts
@@ -114,7 +114,7 @@ function attachAnchor(concept: Concept): Concept {
     if (!known) return concept;
     return {
         ...concept,
-        anchor: known.state !== "factory-native" ? known.citation : undefined,
+        ...(known.state !== "factory-native" ? { anchor: known.citation } : {}),
         anchorState: known.state,
     };
 }


### PR DESCRIPTION
## Summary

- Adds `tools/alignment/audit_external_anchors.ts`: given the concept registry (B-0310), locates each concept in its source surface and extracts external URLs from a ±20-line context window.
- Classifies each URL as `paper` / `rfc` / `blog` / `so-se` / `talk` / `other` by domain matching.
- Emits a JSON or Markdown coverage report mapping each concept to `anchored` (URL list) or `anchor-pending`.
- CLI flags: `--json`, `--md`, `--out DIR`; exit codes 0 / 2.

## Baseline result on current repo

```
external-anchor-coverage: 63 concepts, 2 anchored, 61 anchor-pending
```

Otto-329 and Otto-357 are the 2 currently anchored (they sit next to the `code.claude.com/docs/en/memory` URL in CLAUDE.md). The 61 pending entries are the work queue for follow-on anchor-addition (B-0312+).

## Test plan

- [x] `bun test tools/alignment/audit_external_anchors.test.ts` — 31 tests pass
- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `bun tools/alignment/audit_external_anchors.ts` — human summary output verified
- [x] `bun tools/alignment/audit_external_anchors.ts --json` — valid JSON output verified
- [x] `bun tools/alignment/audit_external_anchors.ts --md` — markdown table verified

## Done-criteria from backlog row

- [x] `bun tools/alignment/audit_external_anchors.ts` emits JSON coverage report (`--json` flag)
- [x] `--md` flag emits markdown coverage table
- [x] Tests cover anchored and anchor-pending classification
- [x] Build gate passes

Reviewers: spec-zealot (schema), alignment-auditor (HC/SD/DIR coverage signal)

🤖 Generated with [Claude Code](https://claude.ai/code)