### PR TITLE
feat(B-0361): literature-first anchor check in formal-verification-expert skill

### DIFF
--- a/.claude/skills/formal-verification-expert/SKILL.md
+++ b/.claude/skills/formal-verification-expert/SKILL.md
@@ -51,6 +51,49 @@ Before any recommendation, in this order:
 Without these six, a recommendation is a guess; with them, it is
 a routing decision.
 
+## Literature-first anchor check — step 0 of every routing walk
+
+**Before classifying a property or picking a tool**, ask:
+
+> *Is this property already formally defined in the established
+> literature? If so, anchor to the canonical definition rather
+> than reinventing it.*
+
+The Z3 shadow-catch failure mode (round-20..22 retrospective) is the
+canonical example: tautologies slip through because the prover verifies
+*our encoding* rather than an independently-grounded definition. When
+the encoding IS the established definition, the tautology risk collapses.
+
+**Anchor check procedure:**
+
+1. Query `tools/alignment/concept_registry.ts` KNOWN_ANCHORS map for the
+   concept-id. If it is listed with `state: "anchored"`, use the cited
+   paper's definition verbatim as the formal grounding. Do not re-derive.
+2. If not in the registry, search the literature for established
+   definitions before writing a spec. Priority sources:
+   - Pearl (2009) *Causality* for causal/interventional properties.
+   - CSP / CCS for trace-equivalence / bisimulation properties.
+   - Dec-POMDPs (Oliehoek & Amato 2016) for multi-agent partial
+     observability properties.
+   - Shapiro et al. (2011) CRDTs for retraction / convergence properties.
+   - Lamport (1977) for safety / liveness properties in distributed systems.
+3. If an established definition exists:
+   - Cite it in the spec header as `# Anchor: <citation>`.
+   - The spec should prove **conformance to the cited definition**, not
+     a free-standing encoding.
+   - Register the concept in the KNOWN_ANCHORS map if it is missing
+     (one-line addition to `tools/alignment/concept_registry.ts`).
+4. If no established definition exists, proceed to the routing table —
+   but note in the output that the property is **factory-native** and
+   document the justification.
+
+**Why this comes first.** If we skip the anchor check and route directly
+to tools, we risk: (a) proving a tautology; (b) reinventing a known
+definition with a subtly different encoding that may not cover the same
+failure modes; (c) missing a published counter-example or
+established impossibility result. The anchor check costs minutes;
+discovering a tautology in production costs rounds.
+
 ## Tool-routing decision table
 
 Rows are **property classes** (stable). Cells are **tools**
@@ -117,6 +160,13 @@ P0 evidence is insufficient.
 The `docs/BUGS.md` entry: "InfoTheoreticSharder has no formal
 spec." `formal-verification-expert`'s walk:
 
+0. **Anchor check.** KNOWN_ANCHORS has no entry for `InfoTheoreticSharder`.
+   Literature search: "observe side-effect-free" maps loosely to
+   *referential transparency* (Backus 1978 / Hughes 1989) but not to a
+   precise formal definition for load-balancing. "Commit exactly once"
+   maps to Bernstein & Goodman (1981) two-phase commit atomicity but is
+   not a pointwise algebraic identity. Verdict: **factory-native** — no
+   established anchor. Proceed to classification.
 1. **Classify.** Three properties mixed together: (a) `Observe`
    is side-effect-free on `shardLoads` — a state-machine safety
    invariant; (b) `Pick` commits exactly once per call — a
@@ -156,6 +206,11 @@ to see.
 
 ```markdown
 # Formal-verification routing review — <target>
+
+## Anchor
+- Literature anchor: <citation OR "factory-native — <justification>">
+- Anchor state: anchored / partially-anchored / factory-native
+- Spec grounding: <"conforms to <citation>" OR "free-standing — reviewed for tautology">
 
 ## Classification
 - Property class: <verbatim row name from the routing table above>
@@ -204,6 +259,7 @@ the `architect` reads it before sizing the round.
 
 ## Reference patterns
 
+- `tools/alignment/concept_registry.ts` — KNOWN_ANCHORS map (literature-first step 0)
 - `docs/research/proof-tool-coverage.md` — the portfolio
 - `docs/TECH-RADAR.md` — tool ring assignments
 - `docs/BUGS.md` — known gaps she routes against

--- a/docs/backlog/P1/B-0361-anchor-to-human-lineage-step-in-formal-and-concept-workflows.md
+++ b/docs/backlog/P1/B-0361-anchor-to-human-lineage-step-in-formal-and-concept-workflows.md
@@ -1,7 +1,7 @@
 ---
 id: B-0361
 priority: P1
-status: in-progress
+status: done
 title: "Anchor-to-human-lineage step in formal verification and concept workflows"
 effort: S
 created: 2026-05-09
@@ -52,8 +52,10 @@ of things that are trivially true by definition.
 
 ## Acceptance criteria
 
-- [ ] Formal-verification-expert skill updated with
-      "check literature first" step
+- [x] Formal-verification-expert skill updated with
+      "check literature first" step (literature-first anchor check
+      section + step 0 in example walk + Anchor output block +
+      KNOWN_ANCHORS reference in reference patterns)
 - [x] Concept-registry schema gains `anchor:` field
       (tools/alignment/concept_registry.ts — schema v1.1,
       Concept.anchor + Concept.anchorState + Registry.anchoredCount)


### PR DESCRIPTION
## Summary

- Closes the final open acceptance criterion of B-0361: formal-verification-expert skill gains an explicit \"literature-first anchor check\" as **step 0** of every routing walk.
- New `## Literature-first anchor check` section with a 4-step procedure: query `KNOWN_ANCHORS`, search literature (Pearl/CSP/Dec-POMDPs/CRDTs/Lamport priority list), cite in spec header, register if missing.
- Step 0 \"Anchor check\" added to the InfoTheoreticSharder example walk (verdict: factory-native — no established anchor → proceed).
- Output format gains `## Anchor` block (literature anchor, anchor state, spec grounding).
- Reference patterns section gains `tools/alignment/concept_registry.ts` KNOWN_ANCHORS pointer.
- B-0361 backlog row marked `status: done`; all acceptance criteria now satisfied.

## Rationale

The Z3 shadow-catch failure mode (round-20..22 retrospective) showed tautologies slip through when specs encode our own definitions rather than anchoring to independently-grounded literature definitions. The anchor check costs minutes; discovering a tautology in production costs rounds.

Composes with: B-0310 (concept registry + KNOWN_ANCHORS), B-0311 (external-anchor scanner), B-0357 (Z3 proof replacement).

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors (no code changes)
- [x] SKILL.md grepped for `Literature-first`, `KNOWN_ANCHORS`, `Anchor check` — all present
- [x] B-0361 backlog row: all 3 acceptance criteria checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)