### PR TITLE
docs(claims): preserve task-trajectory-placeholder-filter claim record

### DIFF
--- a/docs/history/claims/task-trajectory-placeholder-filter-2026-05-08.md
+++ b/docs/history/claims/task-trajectory-placeholder-filter-2026-05-08.md
@@ -1,0 +1,18 @@
+# Claim - task-trajectory-placeholder-filter
+
+Archived from an untracked local Codex worktree after the implementation merged
+in #2000. This record is preserved as history, not as an active claim.
+
+- **Session ID:** codex/20260508T023612Z
+- **Harness:** codex
+- **Claimed at:** 2026-05-08T02:36:12Z
+- **ETA:** 2026-05-08T03:00:00Z
+- **Scope:** Filter placeholder trajectory child candidates from autonomous pickup.
+- **Durable target:** tools/trajectories/autonomous-pickup.ts; tools/trajectories/autonomous-pickup.test.ts
+- **Platform mirror:** none
+
+## Notes
+
+Observed during a bounded Codex loop gate: the factory trajectory packet's
+literal `none currently selected` placeholder was treated as a child packet
+candidate, producing an invalid create-child-packet prompt.


### PR DESCRIPTION
## Summary
- archive the untracked Codex claim record found in the stale merged task-trajectory-placeholder-filter worktree
- store it under docs/history/claims so it does not reappear as an active docs/claims claim on main

## Checks
- git diff --check
- npx markdownlint-cli2 docs/history/claims/task-trajectory-placeholder-filter-2026-05-08.md

## Notes
This PR preserves local coordination substrate before the stale merged worktree is cleaned.