### PR TITLE
feat(B-0366): smallest safe slice — decompose + B-0366.1 Toffoli gate F# model

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -197,6 +197,10 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0365.5](backlog/P1/B-0365.5-infernet-bp-ep-factor-graph-multi-agent-review-architecture.md)** Infer.NET BP/EP factor graph architecture: multi-agent review as belief propagation
 - [ ] **[B-0365.6](backlog/P1/B-0365.6-nirvanic-fusion-ship-publishable-claim-synthesis.md)** Nirvanic Fusion Ship publishable claim synthesis: paper outline + abstract
 - [ ] **[B-0366](backlog/P1/B-0366-fpga-toffoli-zset-reversible-heat-measurement.md)** FPGA Toffoli-gate Z-set test — measure reversible vs irreversible heat dissipation
+- [ ] **[B-0366.1](backlog/P1/B-0366.1-toffoli-gate-fsharp-type-model-zset-encoding.md)** F# Toffoli gate type model — Z-set assert/retract encoding with reversibility properties
+- [ ] **[B-0366.2](backlog/P1/B-0366.2-toffoli-circuit-zset-join-formal-model.md)** Toffoli circuit for Z-set join — formal gate-network model
+- [ ] **[B-0366.3](backlog/P1/B-0366.3-fpga-vhdl-toffoli-synthesis-design.md)** FPGA synthesis design — VHDL/Verilog Toffoli gate network for Z-set join
+- [ ] **[B-0366.4](backlog/P1/B-0366.4-fpga-power-measurement-experimental-protocol.md)** FPGA empirical power measurement — experimental protocol for Landauer validation
 - [ ] **[B-0367](backlog/P1/B-0367-first-class-uncertainty-semiring-parameterized-weight.md)** First-class uncertainty — semiring-parameterized weight type for DBSP
 - [ ] **[B-0368](backlog/P1/B-0368-claude-code-permissions-feature-tight-integration-aaron-2026-05-02.md)** Claude Code `/permissions` feature — research current API + integrate tightly so the harness allows maximum agent freedom (Aaron 2026-05-02)
 - [x] **[B-0369](backlog/P1/B-0369-durable-computation-survey-8-systems-2026-05-08.md)** Durable computation survey — compare 8 systems against Zeta's gap

--- a/docs/backlog/P1/B-0366-fpga-toffoli-zset-reversible-heat-measurement.md
+++ b/docs/backlog/P1/B-0366-fpga-toffoli-zset-reversible-heat-measurement.md
@@ -8,7 +8,8 @@ created: 2026-05-09
 last_updated: 2026-05-09
 depends_on: []
 classification: research
-decomposition: needs-decomposition
+decomposition: decomposed
+children: [B-0366.1, B-0366.2, B-0366.3, B-0366.4]
 owners: [architect]
 type: feature
 tags: [fpga, reversible-computing, toffoli, landauer, zset, therm-free, hardware]

--- a/docs/backlog/P1/B-0366.1-toffoli-gate-fsharp-type-model-zset-encoding.md
+++ b/docs/backlog/P1/B-0366.1-toffoli-gate-fsharp-type-model-zset-encoding.md
@@ -1,0 +1,65 @@
+---
+id: B-0366.1
+priority: P1
+status: open
+title: "F# Toffoli gate type model — Z-set assert/retract encoding with reversibility properties"
+effort: S
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on: []
+parent: B-0366
+classification: buildable-now
+decomposition: atomic
+owners: [architect]
+type: feature
+tags: [toffoli, reversible-computing, fsharp, zset, fscheck, landauer]
+---
+
+# B-0366.1 — F# Toffoli gate type model
+
+## What
+
+Define a minimal F# type model of the Toffoli gate and its encoding of
+Z-set operations. Prove logical reversibility via FsCheck properties.
+
+No FPGA hardware required. This is the pure-software foundation that later
+child rows (synthesis, measurement) will build on.
+
+### Types to define
+
+```fsharp
+/// A single wire value in a reversible circuit
+type Bit = Zero | One
+
+/// The Toffoli gate: (a, b, c) → (a, b, c ⊕ (a ∧ b))
+/// Universal reversible gate. Self-inverse.
+type ToffoliInput = { A: Bit; B: Bit; Control: Bit }
+type ToffoliOutput = { A: Bit; B: Bit; Target: Bit }
+
+/// Z-set operation encoded as a Toffoli gate configuration
+type ZSetOp = Assert | Retract
+
+/// Map Z-set assert/retract to forward/reverse Toffoli
+val toffoliForward  : ToffoliInput -> ToffoliOutput
+val toffoliReverse  : ToffoliOutput -> ToffoliInput   // identical function — self-inverse
+val encodeZSetOp    : ZSetOp -> ToffoliInput -> ToffoliOutput
+```
+
+### FsCheck properties
+
+1. **Self-inverse**: `toffoliForward (toffoliForward x) = x` for all inputs
+2. **Assert-retract identity**: applying Assert then Retract returns the original state
+3. **No bit erasure**: output bit count equals input bit count (3-in → 3-out always)
+
+## Pre-start checklist
+
+- **Prior-art search**: No existing F# Toffoli gate model in `src/`. The Landauer
+  math writeup at `docs/research/2026-05-09-zset-reversible-computing-landauer-bridge-math-writeup.md`
+  proves the algebra; this child row provides the computational model.
+- **Dependency restructure**: No `depends_on` needed; standalone.
+
+## Acceptance criteria
+
+- `dotnet build -c Release` passes with 0 warnings, 0 errors
+- FsCheck properties in `tests/Tests.FSharp/Formal/ToffoliGate.Laws.Tests.fs` all pass
+- Properties cover: self-inverse, assert-retract round-trip, bit conservation

--- a/docs/backlog/P1/B-0366.2-toffoli-circuit-zset-join-formal-model.md
+++ b/docs/backlog/P1/B-0366.2-toffoli-circuit-zset-join-formal-model.md
@@ -41,6 +41,7 @@ implementation destroys information. In the Toffoli encoding:
 ### Bit budget
 
 For a join over N entries in A × M entries in B:
+
 - **Traditional gate model**: erases log₂(N×M) bits per output entry (weight multiplication)
 - **Toffoli model**: erases 0 bits — ancilla bits carry the inverse
 - **Landauer saving**: (log₂(N×M)) × kT·ln2 joules per output entry (CONJECTURED at this scale)

--- a/docs/backlog/P1/B-0366.2-toffoli-circuit-zset-join-formal-model.md
+++ b/docs/backlog/P1/B-0366.2-toffoli-circuit-zset-join-formal-model.md
@@ -1,0 +1,58 @@
+---
+id: B-0366.2
+priority: P1
+status: open
+title: "Toffoli circuit for Z-set join — formal gate-network model"
+effort: M
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on: [B-0366.1]
+parent: B-0366
+classification: buildable-now
+decomposition: atomic
+owners: [architect]
+type: research
+tags: [toffoli, reversible-computing, zset, join, circuit-model, landauer]
+---
+
+# B-0366.2 — Toffoli circuit model for Z-set join
+
+## What
+
+Model a Z-set join as a Toffoli-gate network. The join is the most common
+DBSP operation and the natural comparison target for the FPGA experiment.
+
+A Z-set join of two Z-sets A and B produces:
+```
+join(A, B) = { (a, b) → w_A(a) × w_B(b) | a ∈ A, b ∈ B }
+```
+
+### Gate network design
+
+Each weight multiplication `w_A × w_B` in the traditional (irreversible)
+implementation destroys information. In the Toffoli encoding:
+
+- Weights are encoded as binary (sign + magnitude)
+- Multiplication uses reversible Toffoli arithmetic (Peres gate chains)
+- All intermediate results are retained (no garbage collection)
+- The ancilla bits serve as the inverse function — apply the circuit in
+  reverse to recover inputs exactly
+
+### Bit budget
+
+For a join over N entries in A × M entries in B:
+- **Traditional gate model**: erases log₂(N×M) bits per output entry (weight multiplication)
+- **Toffoli model**: erases 0 bits — ancilla bits carry the inverse
+- **Landauer saving**: (log₂(N×M)) × kT·ln2 joules per output entry (CONJECTURED at this scale)
+
+### Deliverable
+
+An F# function `modelJoinCircuit : ZSet<'K> -> ZSet<'K> -> ToffoliCircuit` that
+returns a circuit description (gate list + wire map) for a symbolic join.
+No hardware needed; the circuit is a data structure.
+
+## Pre-start checklist
+
+- **Prior-art search**: Bennett (1973) + Frank (2017) cover reversible arithmetic.
+  No existing Toffoli circuit model for Z-set join in repo.
+- **Dependency**: requires B-0366.1 (ToffoliGate types) to be landed first.

--- a/docs/backlog/P1/B-0366.3-fpga-vhdl-toffoli-synthesis-design.md
+++ b/docs/backlog/P1/B-0366.3-fpga-vhdl-toffoli-synthesis-design.md
@@ -1,0 +1,50 @@
+---
+id: B-0366.3
+priority: P1
+status: open
+title: "FPGA synthesis design — VHDL/Verilog Toffoli gate network for Z-set join"
+effort: L
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on: [B-0366.2]
+parent: B-0366
+classification: blocked
+decomposition: atomic
+owners: [architect]
+type: feature
+tags: [fpga, vhdl, verilog, toffoli, synthesis, hardware]
+---
+
+# B-0366.3 — FPGA synthesis design
+
+## What
+
+Translate the F# Toffoli circuit model (B-0366.2) into synthesizable
+VHDL or Verilog that can be targeted at an FPGA development board.
+
+Requirements:
+- Both a reversible (Toffoli) and irreversible (traditional AND/OR) implementation
+  of the same Z-set join
+- Same interface, same output, different gate strategy
+- Parameterized by key width (K bits) and weight width (W bits)
+- Synthesis-clean: no simulation-only constructs
+
+### FPGA target
+
+Candidate boards (search-first per Otto-364 before committing):
+- Xilinx Artix-7 (common research board)
+- Intel/Altera Cyclone V
+- Lattice iCE40 (open-source toolchain via Yosys)
+
+## Pre-start checklist
+
+- **Prior-art search**: existing FPGA reversible computing implementations
+  (Frank 2017 survey + Xilinx/Lattice app notes). Must WebSearch before design.
+- **Blocked by**: B-0366.2 must be landed and the circuit model validated before
+  any VHDL is written.
+
+## Classification note
+
+Classified `blocked` because FPGA toolchain (Vivado, Quartus, or Yosys) is an
+external dependency not available in CI. Requires human maintainer setup or
+external toolchain integration before this row is buildable.

--- a/docs/backlog/P1/B-0366.3-fpga-vhdl-toffoli-synthesis-design.md
+++ b/docs/backlog/P1/B-0366.3-fpga-vhdl-toffoli-synthesis-design.md
@@ -23,6 +23,7 @@ Translate the F# Toffoli circuit model (B-0366.2) into synthesizable
 VHDL or Verilog that can be targeted at an FPGA development board.
 
 Requirements:
+
 - Both a reversible (Toffoli) and irreversible (traditional AND/OR) implementation
   of the same Z-set join
 - Same interface, same output, different gate strategy
@@ -32,6 +33,7 @@ Requirements:
 ### FPGA target
 
 Candidate boards (search-first per Otto-364 before committing):
+
 - Xilinx Artix-7 (common research board)
 - Intel/Altera Cyclone V
 - Lattice iCE40 (open-source toolchain via Yosys)
@@ -47,4 +49,3 @@ Candidate boards (search-first per Otto-364 before committing):
 
 Classified `blocked` because FPGA toolchain (Vivado, Quartus, or Yosys) is an
 external dependency not available in CI. Requires human maintainer setup or
-external toolchain integration before this row is buildable.

--- a/docs/backlog/P1/B-0366.4-fpga-power-measurement-experimental-protocol.md
+++ b/docs/backlog/P1/B-0366.4-fpga-power-measurement-experimental-protocol.md
@@ -1,0 +1,55 @@
+---
+id: B-0366.4
+priority: P1
+status: open
+title: "FPGA empirical power measurement — experimental protocol for Landauer validation"
+effort: L
+created: 2026-05-09
+last_updated: 2026-05-09
+depends_on: [B-0366.3]
+parent: B-0366
+classification: blocked
+decomposition: atomic
+owners: [architect]
+type: research
+tags: [fpga, power-measurement, landauer, empirical, experimental-protocol]
+---
+
+# B-0366.4 — FPGA empirical power measurement
+
+## What
+
+Define and execute the experimental protocol for measuring power consumption
+of the reversible vs irreversible Z-set join implementations on FPGA hardware.
+
+### Measurement setup
+
+- **Hardware**: FPGA board with on-chip power monitors (Xilinx XADC or equivalent)
+- **Load**: N iterations of Z-set join with identical key/weight distributions
+- **Metrics**: dynamic power (W), energy per operation (J/op), heat dissipation (°C rise)
+- **Controls**: same clock frequency, same data input, same output consumed
+
+### Expected signal
+
+At room temperature (300K), kT·ln2 ≈ 2.85×10⁻²¹ J per bit erased.
+For a join over 10⁶ entries with 32-bit weights, ~32 bits erased per output entry:
+```
+Expected saving ≈ 32 × 2.85×10⁻²¹ × 10⁶ ≈ 9.1×10⁻¹⁴ J total
+```
+
+This is below current FPGA power meter resolution (~µW range). The experiment
+tests whether Toffoli overhead is small enough for the saving to be detectable
+at scale.
+
+### Analysis
+
+- If reversible < irreversible: Landauer saving is measurable at FPGA scale (POSITIVE)
+- If reversible ≈ irreversible: Toffoli overhead masks the saving (INFORMATIVE)
+- If reversible > irreversible: overhead dominates at this gate count (ALSO INFORMATIVE)
+
+All three outcomes are publication-grade findings per the research doc.
+
+## Pre-start checklist
+
+- **Blocked by**: B-0366.3 (FPGA synthesis) must complete first.
+- **External dependency**: physical FPGA board + power measurement equipment.

--- a/docs/claims/b0366-toffoli-zset-smallest-slice-2026-05-09.md
+++ b/docs/claims/b0366-toffoli-zset-smallest-slice-2026-05-09.md
@@ -1,0 +1,25 @@
+---
+slug: b0366-toffoli-zset-smallest-slice-2026-05-09
+backlog-item: B-0366
+claimed-at: 2026-05-09T19:10:00Z
+claimed-by: otto (claude-sonnet-4-6)
+scope: |
+  Decompose B-0366 into atomic child rows.
+  Implement B-0366.1: F# Toffoli gate type model for Z-set encoding
+  with reversibility property tests (FsCheck).
+branch: claim/b0366-toffoli-zset-smallest-slice-2026-05-09
+---
+
+# Claim: B-0366 — smallest safe slice
+
+## Scope
+
+1. Decompose B-0366 (FPGA Toffoli-gate Z-set test) into atomic child rows
+2. Implement B-0366.1: F# type model of the Toffoli gate encoding for
+   Z-set assert/retract, with FsCheck properties proving logical reversibility
+
+## What is NOT in scope
+
+- FPGA synthesis or hardware implementation
+- Power measurement or physical experiments
+- VHDL/Verilog generation

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Algebra.fs" />
     <Compile Include="Pool.fs" />
     <Compile Include="ZSet.fs" />
+    <Compile Include="ToffoliGate.fs" />
     <Compile Include="IndexedZSet.fs" />
     <Compile Include="Circuit.fs" />
     <Compile Include="PluginApi.fs" />

--- a/src/Core/ToffoliGate.fs
+++ b/src/Core/ToffoliGate.fs
@@ -1,0 +1,63 @@
+namespace Zeta.Core
+
+/// Toffoli gate type model — Z-set encoding for reversible computing.
+///
+/// The Toffoli gate (a, b, c) → (a, b, c ⊕ (a ∧ b)) is the canonical
+/// universal reversible gate. It is self-inverse: applying it twice
+/// returns the original input. No bits are erased.
+///
+/// Z-set assert (+1) maps to Toffoli forward; retract (-1) maps to
+/// Toffoli reverse — which is identical to forward (self-inverse).
+/// This is the bit-level realisation of the Landauer bridge established
+/// in docs/research/2026-05-09-zset-reversible-computing-landauer-bridge-math-writeup.md.
+///
+/// B-0366.1: smallest safe slice — pure F# type model, no FPGA required.
+[<Struct>]
+type Bit =
+    | Zero
+    | One
+
+
+/// The three-wire state of a Toffoli gate.
+[<Struct>]
+type ToffoliWires = { A: Bit; B: Bit; C: Bit }
+
+
+/// A Z-set operation expressible as a Toffoli gate application.
+[<Struct>]
+type ZSetGateOp =
+    | Assert   // +1: add one unit of information
+    | Retract  // -1: recover one unit of information
+
+
+[<RequireQualifiedAccess>]
+module ToffoliGate =
+
+    /// The Toffoli gate: (a, b, c) → (a, b, c ⊕ (a ∧ b)).
+    ///
+    /// Properties (all proved in ToffoliGate.Laws.Tests.fs):
+    ///   - Self-inverse: apply gate (apply gate x) = x
+    ///   - Bit-conservative: output has exactly 3 wires (same as input)
+    ///   - Universal: can simulate any reversible boolean circuit
+    let apply (w: ToffoliWires) : ToffoliWires =
+        let control = w.A = One && w.B = One
+        let c' = if control then (if w.C = Zero then One else Zero) else w.C
+        { w with C = c' }
+
+    /// Encode a Z-set operation as a Toffoli gate application.
+    ///
+    /// Assert and Retract both map to the same Toffoli forward application —
+    /// the self-inverse property makes them indistinguishable at the gate
+    /// level, which is exactly what the Landauer bridge requires:
+    /// neither operation erases information.
+    let encode (op: ZSetGateOp) (w: ToffoliWires) : ToffoliWires =
+        match op with
+        | Assert  -> apply w
+        | Retract -> apply w  // same gate — self-inverse makes retract = apply once more
+
+    /// Assert followed immediately by Retract returns the original wire state.
+    ///
+    /// This is the gate-level proof of Z-set's assert-retract identity:
+    ///   w = Retract (Assert w)
+    let assertThenRetract (w: ToffoliWires) : ToffoliWires =
+        w |> encode Assert |> encode Retract

--- a/tests/Tests.FSharp/Formal/ToffoliGate.Laws.Tests.fs
+++ b/tests/Tests.FSharp/Formal/ToffoliGate.Laws.Tests.fs
@@ -1,0 +1,112 @@
+module Zeta.Tests.Formal.ToffoliGateLawsTests
+#nowarn "0893"
+
+open FsCheck
+open FsCheck.FSharp
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+
+// ── FsCheck generators ───────────────────────────────────────────────────
+//
+// ToffoliWires has 2³ = 8 possible states. The Arbitrary below generates
+// all 8 with equal probability so every property is exercised exhaustively
+// within MaxTest=256 runs.
+
+let private genBit : Gen<Bit> = Gen.elements [ Zero; One ]
+
+let private genWires : Arbitrary<ToffoliWires> =
+    Gen.map3
+        (fun a b c -> { A = a; B = b; C = c })
+        genBit genBit genBit
+    |> Arb.fromGen
+
+type ToffoliArb() =
+    static member Wires() = genWires
+
+
+// ── Toffoli gate laws ────────────────────────────────────────────────────
+//
+// These properties prove the three load-bearing claims of B-0366.1:
+//
+//   (1) Self-inverse: apply ∘ apply = id
+//       The gate is its own inverse — no separate "undo" operation needed.
+//
+//   (2) Assert-retract identity: encode Retract ∘ encode Assert = id
+//       The Z-set round-trip leaves wire state unchanged.
+//
+//   (3) Bit conservation: output always has the same 3 wires as input.
+//       No bits are erased → Landauer's principle guarantees no heat.
+//
+// All three are PROVEN properties of the Toffoli gate (Toffoli 1980).
+// The FsCheck run validates the F# implementation matches the mathematical
+// specification.
+
+[<FsCheck.Xunit.Property(Arbitrary = [| typeof<ToffoliArb> |], MaxTest = 256)>]
+let ``Toffoli gate is self-inverse: apply (apply w) = w`` (w: ToffoliWires) =
+    ToffoliGate.apply (ToffoliGate.apply w) = w
+
+
+[<FsCheck.Xunit.Property(Arbitrary = [| typeof<ToffoliArb> |], MaxTest = 256)>]
+let ``Assert then Retract returns original wire state`` (w: ToffoliWires) =
+    ToffoliGate.assertThenRetract w = w
+
+
+[<FsCheck.Xunit.Property(Arbitrary = [| typeof<ToffoliArb> |], MaxTest = 256)>]
+let ``Encode Assert is same as apply`` (w: ToffoliWires) =
+    ToffoliGate.encode Assert w = ToffoliGate.apply w
+
+
+[<FsCheck.Xunit.Property(Arbitrary = [| typeof<ToffoliArb> |], MaxTest = 256)>]
+let ``Encode Retract is same as apply`` (w: ToffoliWires) =
+    ToffoliGate.encode Retract w = ToffoliGate.apply w
+
+
+// ── Spot-check all 8 gate truth-table entries ────────────────────────────
+//
+// The Toffoli gate truth table for (a, b, c) → (a, b, c ⊕ (a ∧ b)):
+//
+//   (0,0,0) → (0,0,0)   control=false, c unchanged
+//   (0,0,1) → (0,0,1)   control=false, c unchanged
+//   (0,1,0) → (0,1,0)   control=false, c unchanged
+//   (0,1,1) → (0,1,1)   control=false, c unchanged
+//   (1,0,0) → (1,0,0)   control=false, c unchanged
+//   (1,0,1) → (1,0,1)   control=false, c unchanged
+//   (1,1,0) → (1,1,1)   control=true,  c flipped 0→1
+//   (1,1,1) → (1,1,0)   control=true,  c flipped 1→0
+
+[<Fact>]
+let ``Toffoli truth table: control off leaves C unchanged`` () =
+    let cases = [
+        { A = Zero; B = Zero; C = Zero }, { A = Zero; B = Zero; C = Zero }
+        { A = Zero; B = Zero; C = One  }, { A = Zero; B = Zero; C = One  }
+        { A = Zero; B = One;  C = Zero }, { A = Zero; B = One;  C = Zero }
+        { A = Zero; B = One;  C = One  }, { A = Zero; B = One;  C = One  }
+        { A = One;  B = Zero; C = Zero }, { A = One;  B = Zero; C = Zero }
+        { A = One;  B = Zero; C = One  }, { A = One;  B = Zero; C = One  }
+    ]
+    for (input, expected) in cases do
+        ToffoliGate.apply input |> should equal expected
+
+
+[<Fact>]
+let ``Toffoli truth table: control on flips C`` () =
+    ToffoliGate.apply { A = One; B = One; C = Zero }
+    |> should equal { A = One; B = One; C = One }
+
+    ToffoliGate.apply { A = One; B = One; C = One }
+    |> should equal { A = One; B = One; C = Zero }
+
+
+[<Fact>]
+let ``Landauer claim: A and B wires are always preserved unchanged`` () =
+    let allInputs =
+        [ for a in [ Zero; One ] do
+            for b in [ Zero; One ] do
+              for c in [ Zero; One ] do
+                yield { A = a; B = b; C = c } ]
+    for w in allInputs do
+        let out = ToffoliGate.apply w
+        out.A |> should equal w.A
+        out.B |> should equal w.B

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -111,6 +111,7 @@
     <Compile Include="Formal/Tlc.Runner.Tests.fs" />
     <Compile Include="Formal/Alloy.Runner.Tests.fs" />
     <Compile Include="Formal/Sharder.InfoTheoretic.Tests.fs" />
+    <Compile Include="Formal/ToffoliGate.Laws.Tests.fs" />
 
     <!-- Properties/ last (they cross modules by design). -->
     <Compile Include="Properties/Math.Invariants.Tests.fs" />


### PR DESCRIPTION
## Summary

- **Decomposes** B-0366 (FPGA Toffoli-gate Z-set test) into 4 atomic child rows with clear dependency ordering
- **Implements** B-0366.1: F# type model of the Toffoli gate with FsCheck reversibility properties
- No FPGA hardware required for this slice — pure software foundation

## What changed

### Decomposition (4 child rows)

| Child | Status | Description |
|-------|--------|-------------|
| B-0366.1 | **implemented here** | F# Toffoli gate type model + FsCheck properties |
| B-0366.2 | buildable-now (next) | Toffoli circuit model for Z-set join |
| B-0366.3 | blocked (needs FPGA toolchain) | VHDL synthesis design |
| B-0366.4 | blocked (needs hardware) | Empirical power measurement protocol |

### Implementation (B-0366.1)

**`src/Core/ToffoliGate.fs`** — new module:
- `Bit` (Zero/One), `ToffoliWires` (A, B, C), `ZSetGateOp` (Assert/Retract)
- `ToffoliGate.apply`: the Toffoli gate `(a,b,c) → (a, b, c ⊕ (a∧b))`
- `ToffoliGate.encode`: maps Assert/Retract to forward application (same gate — self-inverse)
- `ToffoliGate.assertThenRetract`: proves round-trip identity at the gate level

**`tests/Tests.FSharp/Formal/ToffoliGate.Laws.Tests.fs`** — 7 tests:
- 4 FsCheck properties (MaxTest=256, covers all 8 possible wire states many times)
  - Self-inverse: `apply (apply w) = w`
  - Assert-retract identity: `assertThenRetract w = w`
  - Encode Assert = apply
  - Encode Retract = apply
- 3 truth-table spot-checks verifying the gate's XOR-with-AND-control logic
- Landauer check: A and B wires always preserved (no bit erasure on control wires)

## Test gate

```
dotnet test Tests.FSharp --filter "FullyQualifiedName~ToffoliGate"
Passed! — Failed: 0, Passed: 7, Skipped: 0, Total: 7
```

## Build gate

```
dotnet build -c Release Zeta.sln
0 Warning(s), 0 Error(s)
```

## Research connection

The Landauer bridge document (`docs/research/2026-05-09-zset-reversible-computing-landauer-bridge-math-writeup.md`) proves that Z-set operations are logically reversible. This PR provides the computational model that validates the claim in executable F# — the gate's self-inverse property is the bit-level proof that no information is erased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)