### PR TITLE
docs(B-0001): smallest safe slice — update generator ref in example row

### DIFF
--- a/docs/backlog/P2/B-0001-example-schema-self-reference.md
+++ b/docs/backlog/P2/B-0001-example-schema-self-reference.md
@@ -18,7 +18,7 @@ type: friction-reducer
 
 This is a placeholder row that exists to:
 
-1. Exercise the `tools/backlog/generate-index.sh` generator
+1. Exercise the `tools/backlog/generate-index.ts` generator
    against a non-empty `docs/backlog/` tree, so drift-CI and
    manual `--check` runs have something to validate.
 2. Show contributors what the file shape looks like end-to-
@@ -53,7 +53,7 @@ recovered via `git log --diff-filter=D` if needed).
 ## Cross-references
 
 - `tools/backlog/README.md` — schema spec.
-- `tools/backlog/generate-index.sh` — the generator this
+- `tools/backlog/generate-index.ts` — the generator this
   file exercises.
 - `docs/research/backlog-split-design-otto-181.md` — full
   design spec.


### PR DESCRIPTION
## Summary
Smallest safe slice of B-0001 (P2 example row for per-row-file schema).

**One bounded step**: Updated the self-referential cross-references in `docs/backlog/P2/B-0001-example-schema-self-reference.md` from the retired `.sh` generator to the current `generate-index.ts` (Rule 0: TS over bash; prefer F#/TS code over docs).

This keeps the example row accurate as a living demonstration of the schema while the generator is now TS.

## Re-decomposition note
Assumed original decomposition (static .sh reference) had a mistake once TS port landed; re-decomposed the maintenance slice to this atomic doc hygiene update. No new backlog child created (S-effort, one step only).

## Focused checks (worktree only, root untouched)
- `bun tools/backlog/generate-index.ts --check` → `ok: ... matches generator output` (exit 0, no drift from body edit)
- Pre-work build gate: `dotnet build -c Release` → 0 Warning(s) 0 Error(s)

## Rules followed
- Dedicated worktree + pushed claim branch before any write
- Root checkout untouched
- Exactly one bounded step
- TS/Rule 0 honoured (no bash touched)
- PR body includes check outcomes

Co-Authored-By: Grok <noreply@x.ai>

Made with [Cursor](https://cursor.com)