### PR TITLE
chore(B-0366.1): close backlog item — Toffoli gate already merged in #2333

### DIFF
--- a/docs/backlog/P1/B-0366.1-toffoli-gate-fsharp-type-model-zset-encoding.md
+++ b/docs/backlog/P1/B-0366.1-toffoli-gate-fsharp-type-model-zset-encoding.md
@@ -1,11 +1,13 @@
 ---
 id: B-0366.1
 priority: P1
-status: open
+status: done
 title: "F# Toffoli gate type model — Z-set assert/retract encoding with reversibility properties"
 effort: S
 created: 2026-05-09
 last_updated: 2026-05-09
+resolved: 2026-05-09
+resolved_by: "PR #2333 feat(B-0366): smallest safe slice — decompose + B-0366.1 Toffoli gate F# model"
 depends_on: []
 parent: B-0366
 classification: buildable-now
@@ -63,3 +65,12 @@ val encodeZSetOp    : ZSetOp -> ToffoliInput -> ToffoliOutput
 - `dotnet build -c Release` passes with 0 warnings, 0 errors
 - FsCheck properties in `tests/Tests.FSharp/Formal/ToffoliGate.Laws.Tests.fs` all pass
 - Properties cover: self-inverse, assert-retract round-trip, bit conservation
+
+## Resolution
+
+Merged via PR #2333 (2026-05-09). Implementation:
+
+- `src/Core/ToffoliGate.fs` — `Bit`, `ToffoliWires`, `ZSetGateOp`, `ToffoliGate` module
+- `tests/Tests.FSharp/Formal/ToffoliGate.Laws.Tests.fs` — 7 tests: 4 FsCheck properties + 3 truth-table facts
+
+Test outcome: **7/7 passed** (`dotnet test --filter ToffoliGate`, 346ms).

--- a/docs/hygiene-history/ticks/2026/05/09/2040Z.md
+++ b/docs/hygiene-history/ticks/2026/05/09/2040Z.md
@@ -1,0 +1,30 @@
+---
+tick: 2026-05-09T20:40Z
+branch: fix/b0366.1-toffoli-gate-close-backlog-item
+task: B-0366.1 close-out
+operative-authorization: aaron 2026-05-04: "it**, not just the output. Grinding through failures + recoveries"
+---
+
+# Tick 2026-05-09T20:40Z — B-0366.1 close-out
+
+## Summary
+
+Claimed B-0366.1 (Toffoli gate F# type model). Found the implementation already
+merged in PR #2333. This tick closes the backlog item by updating its status from
+`open` to `done` and adding a Resolution section.
+
+## Verify trace
+
+1. **Worldview refresh**: `bun tools/github/refresh-worldview.ts` — 0 open PRs, clean
+2. **Backlog item read**: `docs/backlog/P1/B-0366.1-*.md` — status was `open`
+3. **Source exists**: `src/Core/ToffoliGate.fs` — committed in PR #2333
+4. **Tests exist**: `tests/Tests.FSharp/Formal/ToffoliGate.Laws.Tests.fs` — 7 tests
+5. **Build gate**: `Tests.FSharp` built successfully (0 warnings, 0 errors); Bayesian.Tests
+   crash (exit 139, SIGSEGV) is pre-existing, unrelated
+6. **Test run**: `dotnet test --filter ToffoliGate` → **7/7 passed** (346ms)
+7. **Backlog update**: status → `done`, resolved_by → PR #2333, Resolution section added
+
+## Files changed
+
+- `docs/backlog/P1/B-0366.1-toffoli-gate-fsharp-type-model-zset-encoding.md` — status → done
+- `docs/hygiene-history/ticks/2026/05/09/2040Z.md` — this shard


### PR DESCRIPTION
## Summary

- B-0366.1 implementation (`src/Core/ToffoliGate.fs` + `tests/Tests.FSharp/Formal/ToffoliGate.Laws.Tests.fs`) was merged in PR #2333
- Backlog item was still marked `status: open` — this PR closes it out
- Updates `docs/backlog/P1/B-0366.1-*.md`: status → `done`, adds `resolved_by` and Resolution section

## Test plan

- [x] `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter ToffoliGate` → **7/7 passed** (346ms)
- [x] `Tests.FSharp` builds with 0 warnings, 0 errors
- [x] Pre-existing `Bayesian.Tests` SIGSEGV (exit 139) is unrelated to this change

## Properties verified

| Law | Result |
|-----|--------|
| Self-inverse: `apply(apply(w)) = w` | ✓ 256 random inputs |
| Assert-then-retract identity | ✓ 256 random inputs |
| Encode Assert = apply | ✓ 256 random inputs |
| Encode Retract = apply | ✓ 256 random inputs |
| Truth-table control-off (6 cases) | ✓ spot-check |
| Truth-table control-on flip | ✓ spot-check |
| Landauer: A,B wires always preserved | ✓ all 8 inputs |

operative-authorization: aaron 2026-05-04: "it**, not just the output. Grinding through failures + recoveries"

🤖 Generated with [Claude Code](https://claude.com/claude-code)