### PR TITLE
chore(B-0365.2): mark B-0365.1/2/3/4/6 done in BACKLOG.md + parent table

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -190,12 +190,12 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0362](backlog/P1/B-0362-concept-search-index-for-instant-term-lookup.md)** Concept search index — pre-built term→file mapping for instant lookups
 - [ ] **[B-0364](backlog/P1/B-0364-policy-relocation-semantic-preservation-fscheck-property.md)** Policy relocation semantic preservation — FsCheck property for mobile DBSP query boundaries
 - [ ] **[B-0365](backlog/P1/B-0365-nirvanic-fusion-ship-research-bundle-spaceship-math-rice-class4-shadow-taxonomy.md)** Nirvanic Fusion Ship research bundle — spaceship math + Rice's theorem + Class 4 shadow taxonomy
-- [ ] **[B-0365.1](backlog/P1/B-0365.1-spaceship-math-one-pager-subscribe-vision-monad-cache-identity.md)** Spaceship math one-pager: subscribe primitive + vision monad + cache identity
-- [ ] **[B-0365.2](backlog/P1/B-0365.2-shadow-log-backfill-catches-16-30-consensus-smoothness.md)** Shadow log backfill: catches 16-30 + consensus-smoothness meta-class
-- [ ] **[B-0365.3](backlog/P1/B-0365.3-class4-empirical-analysis-wolfram-shadow-taxonomy.md)** Class 4 empirical analysis: Wolfram shadow taxonomy doc (30 catches, 8 classes)
-- [ ] **[B-0365.4](backlog/P1/B-0365.4-reactor-dynamics-houman-learning-failure-landscape.md)** Reactor dynamics model: Houman's learning-failure-landscape refinement
+- [x] **[B-0365.1](backlog/P1/B-0365.1-spaceship-math-one-pager-subscribe-vision-monad-cache-identity.md)** Spaceship math one-pager: subscribe primitive + vision monad + cache identity
+- [x] **[B-0365.2](backlog/P1/B-0365.2-shadow-log-backfill-catches-16-30-consensus-smoothness.md)** Shadow log backfill: catches 16-30 + consensus-smoothness meta-class
+- [x] **[B-0365.3](backlog/P1/B-0365.3-class4-empirical-analysis-wolfram-shadow-taxonomy.md)** Class 4 empirical analysis: Wolfram shadow taxonomy doc (30 catches, 8 classes)
+- [x] **[B-0365.4](backlog/P1/B-0365.4-reactor-dynamics-houman-learning-failure-landscape.md)** Reactor dynamics model: Houman's learning-failure-landscape refinement
 - [ ] **[B-0365.5](backlog/P1/B-0365.5-infernet-bp-ep-factor-graph-multi-agent-review-architecture.md)** Infer.NET BP/EP factor graph architecture: multi-agent review as belief propagation
-- [ ] **[B-0365.6](backlog/P1/B-0365.6-nirvanic-fusion-ship-publishable-claim-synthesis.md)** Nirvanic Fusion Ship publishable claim synthesis: paper outline + abstract
+- [x] **[B-0365.6](backlog/P1/B-0365.6-nirvanic-fusion-ship-publishable-claim-synthesis.md)** Nirvanic Fusion Ship publishable claim synthesis: paper outline + abstract
 - [ ] **[B-0366](backlog/P1/B-0366-fpga-toffoli-zset-reversible-heat-measurement.md)** FPGA Toffoli-gate Z-set test — measure reversible vs irreversible heat dissipation
 - [ ] **[B-0366.1](backlog/P1/B-0366.1-toffoli-gate-fsharp-type-model-zset-encoding.md)** F# Toffoli gate type model — Z-set assert/retract encoding with reversibility properties
 - [ ] **[B-0366.2](backlog/P1/B-0366.2-toffoli-circuit-zset-join-formal-model.md)** Toffoli circuit for Z-set join — formal gate-network model

--- a/docs/backlog/P1/B-0365-nirvanic-fusion-ship-research-bundle-spaceship-math-rice-class4-shadow-taxonomy.md
+++ b/docs/backlog/P1/B-0365-nirvanic-fusion-ship-research-bundle-spaceship-math-rice-class4-shadow-taxonomy.md
@@ -39,12 +39,12 @@ B-0365.2 (shadow log backfill)        ──┐                   │
 
 | Child | Title | Effort | Deps | Status |
 |-------|-------|--------|------|--------|
-| B-0365.1 | Spaceship math one-pager | S | none | open |
-| B-0365.2 | Shadow log backfill (catches 16-30) | M | none | open |
-| B-0365.3 | Class 4 empirical analysis doc | M | B-0365.2 | blocked |
-| B-0365.4 | Reactor dynamics model doc | M | none | open |
+| B-0365.1 | Spaceship math one-pager | S | none | done |
+| B-0365.2 | Shadow log backfill (catches 16-30) | M | none | done |
+| B-0365.3 | Class 4 empirical analysis doc | M | B-0365.2 | done |
+| B-0365.4 | Reactor dynamics model doc | M | none | done |
 | B-0365.5 | Infer.NET BP/EP architecture doc | M | none | open |
-| B-0365.6 | Publishable claim synthesis | M | all above | blocked |
+| B-0365.6 | Publishable claim synthesis | M | all above | done |
 
 ## What
 


### PR DESCRIPTION
## Summary

- Marks B-0365.1, B-0365.2, B-0365.3, B-0365.4, B-0365.6 as `[x]` in `docs/BACKLOG.md` (5 of 6 children now done)
- Updates the parent B-0365 status table to reflect true status (5 done, 1 open)
- B-0365.5 (Infer.NET BP/EP architecture doc) remains `[ ]` — still open

## What was stale

All 6 B-0365 children were showing `- [ ]` in BACKLOG.md despite completions in PRs:
- B-0365.2: done via PR #2339
- B-0365.1/3/4/6: done via PR #2351

The parent `B-0365` status table also showed all children as `open` or `blocked`.

## Build gate

`dotnet build -c Release` → **0 Warning(s), 0 Error(s)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)