### PR TITLE
fix(B-0365): use status: closed so generate-index emits [x]

### DIFF
--- a/docs/backlog/P1/B-0365.1-spaceship-math-one-pager-subscribe-vision-monad-cache-identity.md
+++ b/docs/backlog/P1/B-0365.1-spaceship-math-one-pager-subscribe-vision-monad-cache-identity.md
@@ -1,7 +1,7 @@
 ---
 id: B-0365.1
 priority: P1
-status: done
+status: closed
 title: "Spaceship math one-pager: subscribe primitive + vision monad + cache identity"
 effort: S
 created: 2026-05-09

--- a/docs/backlog/P1/B-0365.2-shadow-log-backfill-catches-16-30-consensus-smoothness.md
+++ b/docs/backlog/P1/B-0365.2-shadow-log-backfill-catches-16-30-consensus-smoothness.md
@@ -1,7 +1,7 @@
 ---
 id: B-0365.2
 priority: P1
-status: done
+status: closed
 title: "Shadow log backfill: catches 16-30 + consensus-smoothness meta-class"
 effort: M
 created: 2026-05-09

--- a/docs/backlog/P1/B-0365.3-class4-empirical-analysis-wolfram-shadow-taxonomy.md
+++ b/docs/backlog/P1/B-0365.3-class4-empirical-analysis-wolfram-shadow-taxonomy.md
@@ -1,7 +1,7 @@
 ---
 id: B-0365.3
 priority: P1
-status: done
+status: closed
 title: "Class 4 empirical analysis: Wolfram shadow taxonomy doc (30 catches, 8 classes)"
 effort: M
 created: 2026-05-09

--- a/docs/backlog/P1/B-0365.4-reactor-dynamics-houman-learning-failure-landscape.md
+++ b/docs/backlog/P1/B-0365.4-reactor-dynamics-houman-learning-failure-landscape.md
@@ -1,7 +1,7 @@
 ---
 id: B-0365.4
 priority: P1
-status: done
+status: closed
 title: "Reactor dynamics model: Houman's learning-failure-landscape refinement"
 effort: M
 created: 2026-05-09

--- a/docs/backlog/P1/B-0365.6-nirvanic-fusion-ship-publishable-claim-synthesis.md
+++ b/docs/backlog/P1/B-0365.6-nirvanic-fusion-ship-publishable-claim-synthesis.md
@@ -1,7 +1,7 @@
 ---
 id: B-0365.6
 priority: P1
-status: done
+status: closed
 title: "Nirvanic Fusion Ship publishable claim synthesis: paper outline + abstract"
 effort: M
 created: 2026-05-09


### PR DESCRIPTION
## Summary

- Fixes BACKLOG.md generate-index drift introduced by PR #2362
- `checkboxFor()` in `generate-index.ts` only maps `"closed"` and `"superseded-by-*"` to `[x]`; `"done"` falls through to `"[ ]"`
- PR #2362 set per-row files to `status: done`, leaving BACKLOG.md (manually updated to `[x]`) drifted from generator output
- Non-required CI check `check docs/BACKLOG.md generated-index drift` was failing on every PR as a result

## Changes

Five per-row files changed `status: done` → `status: closed`:
- B-0365.1, B-0365.2, B-0365.3, B-0365.4, B-0365.6

## Build gate

- `dotnet build -c Release` → **0 Warning(s), 0 Error(s)**
- `bun tools/backlog/generate-index.ts --check` → **ok**

🤖 Generated with [Claude Code](https://claude.com/claude-code)