### PR TITLE
fix(B-0373): strengthen CausalPower Lemma 17 — add stateA1≠stateA2 + close B-0357/B-0365/B-0365.5/B-0373

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -184,17 +184,17 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0354](backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md)** Fresh-instance validation test for bootstrap CLAUDE.md
 - [ ] **[B-0355](backlog/P1/B-0355-cross-harness-bootstrap-template.md)** Cross-harness bootstrap template (AGENTS.md, CODEX.md, CURSOR.md)
 - [ ] **[B-0356](backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md)** Capture model + token usage in commit trailer (git-native, cost derived at query time)
-- [ ] **[B-0357](backlog/P1/B-0357-replace-tautology-z3-agenda-proofs-with-real-verification.md)** Replace tautology Z3 agenda/trajectory proofs with non-trivial verification
+- [x] **[B-0357](backlog/P1/B-0357-replace-tautology-z3-agenda-proofs-with-real-verification.md)** Replace tautology Z3 agenda/trajectory proofs with non-trivial verification
 - [x] **[B-0358](backlog/P1/B-0358-bool-as-degenerate-distribution-confidence-typed-apis.md)** Bool as degenerate distribution — replace binary API returns with confidence scores
 - [ ] **[B-0361](backlog/P1/B-0361-anchor-to-human-lineage-step-in-formal-and-concept-workflows.md)** Anchor-to-human-lineage step in formal verification and concept workflows
 - [ ] **[B-0362](backlog/P1/B-0362-concept-search-index-for-instant-term-lookup.md)** Concept search index — pre-built term→file mapping for instant lookups
 - [ ] **[B-0364](backlog/P1/B-0364-policy-relocation-semantic-preservation-fscheck-property.md)** Policy relocation semantic preservation — FsCheck property for mobile DBSP query boundaries
-- [ ] **[B-0365](backlog/P1/B-0365-nirvanic-fusion-ship-research-bundle-spaceship-math-rice-class4-shadow-taxonomy.md)** Nirvanic Fusion Ship research bundle — spaceship math + Rice's theorem + Class 4 shadow taxonomy
+- [x] **[B-0365](backlog/P1/B-0365-nirvanic-fusion-ship-research-bundle-spaceship-math-rice-class4-shadow-taxonomy.md)** Nirvanic Fusion Ship research bundle — spaceship math + Rice's theorem + Class 4 shadow taxonomy
 - [x] **[B-0365.1](backlog/P1/B-0365.1-spaceship-math-one-pager-subscribe-vision-monad-cache-identity.md)** Spaceship math one-pager: subscribe primitive + vision monad + cache identity
 - [x] **[B-0365.2](backlog/P1/B-0365.2-shadow-log-backfill-catches-16-30-consensus-smoothness.md)** Shadow log backfill: catches 16-30 + consensus-smoothness meta-class
 - [x] **[B-0365.3](backlog/P1/B-0365.3-class4-empirical-analysis-wolfram-shadow-taxonomy.md)** Class 4 empirical analysis: Wolfram shadow taxonomy doc (30 catches, 8 classes)
 - [x] **[B-0365.4](backlog/P1/B-0365.4-reactor-dynamics-houman-learning-failure-landscape.md)** Reactor dynamics model: Houman's learning-failure-landscape refinement
-- [ ] **[B-0365.5](backlog/P1/B-0365.5-infernet-bp-ep-factor-graph-multi-agent-review-architecture.md)** Infer.NET BP/EP factor graph architecture: multi-agent review as belief propagation
+- [x] **[B-0365.5](backlog/P1/B-0365.5-infernet-bp-ep-factor-graph-multi-agent-review-architecture.md)** Infer.NET BP/EP factor graph architecture: multi-agent review as belief propagation
 - [x] **[B-0365.6](backlog/P1/B-0365.6-nirvanic-fusion-ship-publishable-claim-synthesis.md)** Nirvanic Fusion Ship publishable claim synthesis: paper outline + abstract
 - [ ] **[B-0366](backlog/P1/B-0366-fpga-toffoli-zset-reversible-heat-measurement.md)** FPGA Toffoli-gate Z-set test — measure reversible vs irreversible heat dissipation
 - [ ] **[B-0366.1](backlog/P1/B-0366.1-toffoli-gate-fsharp-type-model-zset-encoding.md)** F# Toffoli gate type model — Z-set assert/retract encoding with reversibility properties
@@ -207,7 +207,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0370](backlog/P1/B-0370-durable-computation-checkpoint-interface-extension-2026-05-08.md)** Durable computation — extend Checkpoint.fs with StableStorage mode
 - [ ] **[B-0371](backlog/P1/B-0371-pages-seo-metadata-jsonld-social-preview-2026-05-08.md)** Pages discoverability - SEO metadata, JSON-LD, and social previews
 - [ ] **[B-0372](backlog/P1/B-0372-pages-sitemap-robots-ai-crawler-policy-2026-05-08.md)** Pages discoverability - sitemap, robots, and AI crawler policy
-- [ ] **[B-0373](backlog/P1/B-0373-alignment-proof-primitive-ladder-one-type-one-property.md)** Alignment proof primitive ladder — one type, one falsifiable property
+- [x] **[B-0373](backlog/P1/B-0373-alignment-proof-primitive-ladder-one-type-one-property.md)** Alignment proof primitive ladder — one type, one falsifiable property
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0365-nirvanic-fusion-ship-research-bundle-spaceship-math-rice-class4-shadow-taxonomy.md
+++ b/docs/backlog/P1/B-0365-nirvanic-fusion-ship-research-bundle-spaceship-math-rice-class4-shadow-taxonomy.md
@@ -1,7 +1,9 @@
 ---
 id: B-0365
 priority: P1
-status: decomposed
+status: done
+closed: 2026-05-09
+closed_by: "all 6 child rows done (B-0365.1–B-0365.6)"
 title: "Nirvanic Fusion Ship research bundle — spaceship math + Rice's theorem + Class 4 shadow taxonomy"
 effort: L
 created: 2026-05-09
@@ -43,7 +45,7 @@ B-0365.2 (shadow log backfill)        ──┐                   │
 | B-0365.2 | Shadow log backfill (catches 16-30) | M | none | done |
 | B-0365.3 | Class 4 empirical analysis doc | M | B-0365.2 | done |
 | B-0365.4 | Reactor dynamics model doc | M | none | done |
-| B-0365.5 | Infer.NET BP/EP architecture doc | M | none | open |
+| B-0365.5 | Infer.NET BP/EP architecture doc | M | none | done |
 | B-0365.6 | Publishable claim synthesis | M | all above | done |
 
 ## What

--- a/docs/backlog/P1/B-0373-alignment-proof-primitive-ladder-one-type-one-property.md
+++ b/docs/backlog/P1/B-0373-alignment-proof-primitive-ladder-one-type-one-property.md
@@ -1,7 +1,9 @@
 ---
 id: B-0373
 priority: P1
-status: claimed
+status: done
+closed: 2026-05-09
+closed_by: "adversarial review pass completed — Lemma 17 strengthened with stateA1≠stateA2 constraint"
 title: "Alignment proof primitive ladder — one type, one falsifiable property"
 effort: M
 created: 2026-05-09
@@ -115,9 +117,17 @@ it into optimistic proof language.
         NOT proved: any specific concrete agent is non-collapsed;
         proving that requires membrane specs + private-state update
         rules — the next slice.
-- [ ] Run an adversarial review pass before promoting the proof
+- [x] Run an adversarial review pass before promoting the proof
       vocabulary to `docs/ALIGNMENT.md`, `docs/AGENDA.md`, or
       other current-state surfaces.
+      → Adversarial finding (2026-05-09): Lemma 17 missing
+        `(assert (not (= stateA1 stateA2)))` — UNSAT could be
+        achieved trivially via identity (stateA1=stateA2) rather
+        than via the collapse constraint. Fixed in Program.fs +
+        Z3.Laws.Tests.fs. UNSAT now exclusively attributable to
+        collapse. Vocabulary not yet promoted to ALIGNMENT.md
+        (no promotion needed until non-collapse for a concrete
+        agent is proven — that requires the next slice).
 
 ## Non-goals
 

--- a/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
@@ -406,6 +406,9 @@ let ``Z3 proves collapsed policy has no causal power: state change cannot change
         "(declare-const stateA2 Int)\n" +
         "(declare-const trace SharedTrace)\n" +
         "(declare-fun PolicyA (Int SharedTrace) Action)\n" +
+        // Intervention: distinct private-state values — ensures UNSAT comes from
+        // the collapse constraint, not the trivial stateA1=stateA2 identity case.
+        "(assert (not (= stateA1 stateA2)))\n" +
         // Collapse: policy output is invariant to private-state changes.
         "(assert (forall ((s1 Int) (s2 Int) (t SharedTrace))\n" +
         "  (= (PolicyA s1 t) (PolicyA s2 t))))\n" +

--- a/tools/Z3Verify/Program.fs
+++ b/tools/Z3Verify/Program.fs
@@ -485,6 +485,10 @@ let main _ =
         "(declare-const stateA2 Int)\n" +
         "(declare-const trace SharedTrace)\n" +
         "(declare-fun PolicyA (Int SharedTrace) Action)\n" +
+        // Intervention: distinct private-state values (mirrors Lemma 16's SAT witness).
+        // Without this, Z3 could achieve UNSAT trivially via stateA1=stateA2 rather
+        // than via the collapse constraint — that would weaken the proof.
+        "(assert (not (= stateA1 stateA2)))\n" +
         // Collapse constraint: policy output is invariant under state change.
         "(assert (forall ((s1 Int) (s2 Int) (t SharedTrace))\n" +
         "  (= (PolicyA s1 t) (PolicyA s2 t))))\n" +


### PR DESCRIPTION
## Summary

- **Adversarial review finding (B-0373)**: Lemma 17 (`causalPowerFailsUnderCollapse`) in `tools/Z3Verify/Program.fs` and `tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs` was missing `(assert (not (= stateA1 stateA2)))`. Without it, Z3 could achieve UNSAT trivially via the identity case (`stateA1=stateA2` → reflexive equality) rather than exclusively via the collapse constraint. This is the exact class of proof-weakening-by-unconstrained-witnesses that shadow catch #30 (consensus-smoothness / adversarial review discipline) is designed to catch.
- **Fix**: Add the distinctness constraint to Lemma 17 in both files, mirroring Lemma 16 (the SAT witness). UNSAT now exclusively attributed to the collapse hypothesis.
- **Backlog hygiene**: Mark B-0357 (already done), B-0365.5 (research doc exists), B-0365 (all 6 children done), and B-0373 (this PR) as `[x]` in `docs/BACKLOG.md`.

All 22 Z3 tests pass. Build: 0 warnings, 0 errors.

## Test plan

- [x] `dotnet test tests/Tests.FSharp/ -c Release --filter "Z3"` → 22 passed
- [x] `dotnet build -c Release` → 0 warnings, 0 errors
- [x] Lemma 17 UNSAT is now attributable exclusively to the collapse constraint (the new constraint prevents the trivial stateA1=stateA2 shortcut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)