### PR TITLE
fix(backlog): use status: closed for B-0357/B-0365/B-0365.5/B-0373 — clear BACKLOG drift

### DIFF
--- a/docs/backlog/P1/B-0357-replace-tautology-z3-agenda-proofs-with-real-verification.md
+++ b/docs/backlog/P1/B-0357-replace-tautology-z3-agenda-proofs-with-real-verification.md
@@ -1,7 +1,9 @@
 ---
 id: B-0357
 priority: P1
-status: done
+status: closed
+closed: 2026-05-09
+closed_by: "Lemma 17 strengthened with stateA1≠stateA2 — all Z3 proofs now non-tautological (PR #2367)"
 title: "Replace tautology Z3 agenda/trajectory proofs with non-trivial verification"
 effort: M
 created: 2026-05-09

--- a/docs/backlog/P1/B-0365-nirvanic-fusion-ship-research-bundle-spaceship-math-rice-class4-shadow-taxonomy.md
+++ b/docs/backlog/P1/B-0365-nirvanic-fusion-ship-research-bundle-spaceship-math-rice-class4-shadow-taxonomy.md
@@ -1,7 +1,7 @@
 ---
 id: B-0365
 priority: P1
-status: done
+status: closed
 closed: 2026-05-09
 closed_by: "all 6 child rows done (B-0365.1–B-0365.6)"
 title: "Nirvanic Fusion Ship research bundle — spaceship math + Rice's theorem + Class 4 shadow taxonomy"

--- a/docs/backlog/P1/B-0365.5-infernet-bp-ep-factor-graph-multi-agent-review-architecture.md
+++ b/docs/backlog/P1/B-0365.5-infernet-bp-ep-factor-graph-multi-agent-review-architecture.md
@@ -1,7 +1,9 @@
 ---
 id: B-0365.5
 priority: P1
-status: open
+status: closed
+closed: 2026-05-09
+closed_by: "research doc shipped at docs/research/2026-05-09-infernet-bp-ep-factor-graph-multi-agent-review.md"
 title: "Infer.NET BP/EP factor graph architecture: multi-agent review as belief propagation"
 effort: M
 created: 2026-05-09

--- a/docs/backlog/P1/B-0373-alignment-proof-primitive-ladder-one-type-one-property.md
+++ b/docs/backlog/P1/B-0373-alignment-proof-primitive-ladder-one-type-one-property.md
@@ -1,7 +1,7 @@
 ---
 id: B-0373
 priority: P1
-status: done
+status: closed
 closed: 2026-05-09
 closed_by: "adversarial review pass completed — Lemma 17 strengthened with stateA1≠stateA2 constraint"
 title: "Alignment proof primitive ladder — one type, one falsifiable property"


### PR DESCRIPTION
## Summary

- Fixes `check docs/BACKLOG.md generated-index drift` CI failure that survived the #2367 merge
- `generate-index.ts:130` only emits `[x]` for `status: closed`; all four rows were `status: done` (or `open`), causing drift
- Changed B-0357, B-0365, B-0373 from `status: done → closed`; B-0365.5 from `status: open → closed` with `closed`/`closed_by` fields
- `bun tools/backlog/generate-index.ts --check` passes clean; build 0 warnings 0 errors

## Test plan

- [x] `bun tools/backlog/generate-index.ts --check` → `ok: ...BACKLOG.md matches generator output`
- [x] `dotnet build -c Release` → 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)