### PR TITLE
feat(B-0170): cross-surface count drift checker v0.8 — frontmatter description vs body table

### DIFF
--- a/docs/backlog/P1/B-0170-substrate-claim-checker-ts-tool-aaron-2026-05-03.md
+++ b/docs/backlog/P1/B-0170-substrate-claim-checker-ts-tool-aaron-2026-05-03.md
@@ -7,7 +7,7 @@ tier: tooling
 effort: M
 ask: Otto 2026-05-03 self-grading, surfaced via drift instances (the verify-then-claim memo's body table is canonical) across 9+ PRs in single session despite naming the verify-then-claim discipline; manual discipline provably insufficient against trained-prior pull
 created: 2026-05-03
-last_updated: 2026-05-03
+last_updated: 2026-05-09
 depends_on: []
 decomposition: atomic
 classification: buildable-now
@@ -47,12 +47,12 @@ Per the verify-then-claim catalogue:
 |---|---|---|
 | Count drift | ✓ shipped | "N rows / instances / items" vs actual count |
 | Existence drift | ✓ shipped | "file/dir/tool exists" claim vs `ls` / `test -e` |
-| Semantic-equivalence drift | v1 | command substitution equivalence claims |
-| Empirical-output drift | v1 | "command returns X" vs actual output |
-| Convention drift | v1 | recommended pattern matches canonical convention |
+| Semantic-equivalence drift | v0.9 | command substitution equivalence claims |
+| Empirical-output drift | v0.9 | "command returns X" vs actual output |
+| Convention drift | v0.9 | recommended pattern matches canonical convention |
 | Path-form drift | ✓ shipped | fully-qualified vs bare paths consistent across document |
-| Self-recursive drift | v1 | the memo about X contains its own X |
-| Cross-surface count drift (frontmatter ↔ body ↔ section heading ↔ carved sentence ↔ MEMORY.md) | v1 (v0 catches narrative-vs-table within a single document; cross-surface narrative-to-narrative comparison is v1 work) | five surfaces should match consistent N |
+| Self-recursive drift | v0.9 | the memo about X contains its own X |
+| Cross-surface count drift (frontmatter ↔ body ↔ section heading ↔ carved sentence ↔ MEMORY.md) | ✓ shipped (v0.8 — frontmatter description vs body table; full cross-surface v0.9) | five surfaces should match consistent N |
 
 ## Hooks integration (planned, not v0)
 

--- a/tools/substrate-claim-checker/README.md
+++ b/tools/substrate-claim-checker/README.md
@@ -3,7 +3,7 @@
 Substrate-claim-checker per the verify-then-claim discipline memo
 (`memory/feedback_verify_then_claim_discipline_dominant_failure_mode_substrate_authoring_otto_2026_05_03.md`).
 
-Catches 3 of the 7 sub-classes B-0170 names:
+Catches 4 of the 7 sub-classes B-0170 names:
 
 - **Count drift** (v0.4.4) — between narrative claims (e.g. "18+ drift
   instances", "13-row table", "5 procedure skills") and the actual
@@ -14,9 +14,14 @@ Catches 3 of the 7 sub-classes B-0170 names:
 - **Path-form drift** (v0.7) — same physical file referenced with
   inconsistent path forms within a single document. Implemented in
   `check-path-forms.ts`.
+- **Cross-surface count drift** (v0.8) — count claims in YAML
+  frontmatter `description:` fields that don't match any body table.
+  Catches eval-set instances #19 and #20 (frontmatter claims a count
+  that diverges from the actual table row count). Implemented in
+  `check-cross-surface.ts`.
 
-The remaining 4 sub-classes (semantic-equivalence, empirical-output,
-convention, self-recursive) are deferred to v0.8+.
+The remaining 3 sub-classes (semantic-equivalence, empirical-output,
+convention) are deferred to v0.9+.
 
 ## Usage
 
@@ -209,3 +214,56 @@ Exit codes: `0` clean, `1` drift detected or input error.
   (`tools/substrate-claim-checker/check-counts.ts`). Both are intentional.
   v1 candidate: exempt paths inside fenced code blocks from grouping, since
   usage examples conventionally show repo-root-relative invocations.
+
+## v0.8 — `check-cross-surface.ts` (cross-surface count drift)
+
+The fourth sub-class checker, covering **cross-surface count drift** —
+when the YAML frontmatter `description:` field claims a count that
+doesn't match any table in the document body.
+
+### Empirical eval-set (from the verify-then-claim memo)
+
+- **Instance #19**: frontmatter description said "9 drift instances"
+  but the body table had 15+ rows.
+- **Instance #20**: frontmatter description updated to "18+" but the
+  body table still had only 15 rows — the count-drift fix itself
+  introduced opposite-direction drift.
+
+### How it works
+
+1. Parses YAML frontmatter (leading `---` block)
+2. Extracts count claims from the `description:` field using the
+   same noun vocabulary as `check-counts.ts`
+3. Finds all markdown tables in the document body
+4. For each count claim, checks if ANY body table satisfies it
+   (exact match for `N noun`; at-least match for `N+ noun`)
+5. Reports drift if no table satisfies the claim
+
+### "Any-table" semantics
+
+Frontmatter precedes the entire body, so the "nearest table within
+50 lines" heuristic used by `check-counts.ts` is inapplicable. Instead,
+any table in the body can satisfy the claim. A multi-table file
+(drift-instances table + sub-classes table) passes if either table
+matches.
+
+### Usage
+
+```bash
+bun tools/substrate-claim-checker/check-cross-surface.ts <file>
+bun tools/substrate-claim-checker/check-cross-surface.ts <file1> <file2> ...
+```
+
+Exit codes: `0` clean, `1` drift detected or input error.
+
+### Known limitations (v0.8)
+
+- **Only `description:` field scanned**: other frontmatter fields
+  (e.g., `title:`, custom fields) are not checked. v0.9 candidate.
+- **Body-only tables**: section headings that embed counts
+  (e.g., `## 7 sub-classes`) are not compared. v0.9 candidate.
+- **No table semantics**: the checker doesn't know which table
+  corresponds to which claim — it uses any-table permissive
+  matching. A document with a 15-row drift table and a 3-row
+  sub-classes table would pass a "15 sub-classes" claim
+  (false negative). v0.9 noun-matching would address this.

--- a/tools/substrate-claim-checker/check-cross-surface.test.ts
+++ b/tools/substrate-claim-checker/check-cross-surface.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseFrontmatter,
+  extractClaims,
+  checkFile,
+} from "./check-cross-surface.ts";
+
+// ── parseFrontmatter ──────────────────────────────────────────────────────────
+
+describe("parseFrontmatter", () => {
+  test("returns null for files without frontmatter", () => {
+    expect(parseFrontmatter("# Just a header\n\nSome text.")).toBeNull();
+  });
+
+  test("returns null when closing --- is missing", () => {
+    expect(parseFrontmatter("---\nname: foo\n")).toBeNull();
+  });
+
+  test("parses well-formed frontmatter", () => {
+    const content = "---\nname: test\ndescription: 20 drift instances catalogued\ntype: feedback\n---\n\n# Body";
+    const fm = parseFrontmatter(content);
+    expect(fm).not.toBeNull();
+    expect(fm!.fields["name"]).toBe("test");
+    expect(fm!.fields["description"]).toBe("20 drift instances catalogued");
+    expect(fm!.fields["type"]).toBe("feedback");
+  });
+
+  test("strips surrounding quotes from field values", () => {
+    const content = "---\ndescription: \"quoted value\"\n---\n# Body";
+    const fm = parseFrontmatter(content);
+    expect(fm!.fields["description"]).toBe("quoted value");
+  });
+
+  test("bodyStart points past the closing ---", () => {
+    const content = "---\nname: test\n---\nbody line";
+    const fm = parseFrontmatter(content);
+    // bodyStart lands on the "\n" that follows the closing "---"; splitting
+    // on "\n" produces an empty first element then the actual body lines
+    expect(content.slice(fm!.bodyStart).trimStart()).toBe("body line");
+  });
+});
+
+// ── extractClaims ─────────────────────────────────────────────────────────────
+
+describe("extractClaims", () => {
+  test("finds 'N drift instances' claim", () => {
+    const claims = extractClaims("caught 20 drift instances this session");
+    expect(claims).toHaveLength(1);
+    expect(claims[0]!.n).toBe(20);
+    expect(claims[0]!.isMinimum).toBe(false);
+    expect(claims[0]!.noun).toBe("drift instances");
+  });
+
+  test("finds 'N+ drift instances' minimum claim", () => {
+    const claims = extractClaims("caught 18+ drift instances across 9+ PRs");
+    expect(claims.some((c) => c.n === 18 && c.isMinimum && c.noun === "drift instances")).toBe(true);
+  });
+
+  test("finds hyphenated form '20-row table'", () => {
+    const claims = extractClaims("the 20-row table is the eval set");
+    expect(claims).toHaveLength(1);
+    expect(claims[0]!.n).toBe(20);
+    expect(claims[0]!.noun).toBe("row");
+  });
+
+  test("finds 'N rows' claim", () => {
+    const claims = extractClaims("catalogues 15 rows of evidence");
+    expect(claims[0]!.n).toBe(15);
+    expect(claims[0]!.noun).toBe("rows");
+  });
+
+  test("returns empty for strings with no count claims", () => {
+    expect(extractClaims("no numbers here")).toHaveLength(0);
+  });
+
+  test("ignores count claims for unknown nouns", () => {
+    expect(extractClaims("runs 5 tests, covers 3 files")).toHaveLength(0);
+  });
+});
+
+// ── checkFile — helper ────────────────────────────────────────────────────────
+
+function withTmpFile(content: string, cb: (path: string) => void): void {
+  const dir = mkdtempSync(join(tmpdir(), "check-cross-surface-"));
+  const path = join(dir, "test.md");
+  try {
+    writeFileSync(path, content);
+    cb(path);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── checkFile — clean cases ───────────────────────────────────────────────────
+
+describe("checkFile — clean", () => {
+  test("no drift when frontmatter count matches body table row count", () => {
+    withTmpFile(
+      [
+        "---",
+        "name: test",
+        "description: caught 3 drift instances this session",
+        "type: feedback",
+        "---",
+        "",
+        "| A | B |",
+        "| --- | --- |",
+        "| r1 | v1 |",
+        "| r2 | v2 |",
+        "| r3 | v3 |",
+      ].join("\n"),
+      (path) => {
+        const { findings, ok } = checkFile(path);
+        expect(ok).toBe(true);
+        expect(findings).toHaveLength(0);
+      },
+    );
+  });
+
+  test("no drift when frontmatter minimum claim is satisfied", () => {
+    // "9+ drift instances" and body has 15 rows — satisfies >=9
+    withTmpFile(
+      [
+        "---",
+        "name: test",
+        "description: 9+ drift instances catalogued",
+        "type: feedback",
+        "---",
+        "",
+        "| A | B |",
+        "| --- | --- |",
+        "| 1 | a |",
+        "| 2 | b |",
+        "| 3 | c |",
+        "| 4 | d |",
+        "| 5 | e |",
+        "| 6 | f |",
+        "| 7 | g |",
+        "| 8 | h |",
+        "| 9 | i |",
+        "| 10 | j |",
+        "| 11 | k |",
+        "| 12 | l |",
+        "| 13 | m |",
+        "| 14 | n |",
+        "| 15 | o |",
+      ].join("\n"),
+      (path) => {
+        const { findings } = checkFile(path);
+        expect(findings).toHaveLength(0);
+      },
+    );
+  });
+
+  test("no drift when description has no count claims", () => {
+    withTmpFile(
+      [
+        "---",
+        "name: test",
+        "description: a self-grading memo about failures",
+        "type: feedback",
+        "---",
+        "",
+        "# Body",
+        "",
+        "| A | B |",
+        "| --- | --- |",
+        "| 1 | x |",
+      ].join("\n"),
+      (path) => {
+        const { findings } = checkFile(path);
+        expect(findings).toHaveLength(0);
+      },
+    );
+  });
+
+  test("no drift for file with no frontmatter", () => {
+    withTmpFile("# Just a header\n\nSome text.", (path) => {
+      const { findings } = checkFile(path);
+      expect(findings).toHaveLength(0);
+    });
+  });
+
+  test("no drift when body has multiple tables and one matches", () => {
+    // frontmatter says "3 drift instances"; body has a 2-row sub-classes
+    // table AND a 3-row drift-instances table — any-table semantics → no drift
+    withTmpFile(
+      [
+        "---",
+        "name: test",
+        "description: caught 3 drift instances",
+        "type: feedback",
+        "---",
+        "",
+        "## Sub-classes",
+        "",
+        "| Sub-class | Done |",
+        "| --- | --- |",
+        "| count | yes |",
+        "| existence | yes |",
+        "",
+        "## Instances",
+        "",
+        "| # | Description |",
+        "| --- | --- |",
+        "| 1 | foo |",
+        "| 2 | bar |",
+        "| 3 | baz |",
+      ].join("\n"),
+      (path) => {
+        const { findings } = checkFile(path);
+        expect(findings).toHaveLength(0);
+      },
+    );
+  });
+
+  test("no drift for frontmatter with no body tables", () => {
+    // Cannot check claims without tables — treat as clean (not a drift finding)
+    withTmpFile(
+      [
+        "---",
+        "name: test",
+        "description: caught 5 drift instances",
+        "type: feedback",
+        "---",
+        "",
+        "No tables here, just prose.",
+      ].join("\n"),
+      (path) => {
+        const { findings } = checkFile(path);
+        expect(findings).toHaveLength(0);
+      },
+    );
+  });
+});
+
+// ── checkFile — drift cases ───────────────────────────────────────────────────
+
+describe("checkFile — drift", () => {
+  test("instance #19 regression: description says '9 drift instances', body has 15 rows", () => {
+    const rows = Array.from(
+      { length: 15 },
+      (_, i) => `| ${i + 1} | instance ${i + 1} |`,
+    );
+    withTmpFile(
+      [
+        "---",
+        "name: verify-then-claim",
+        "description: caught 9 drift instances across 9+ PRs",
+        "type: feedback",
+        "---",
+        "",
+        "| # | Description |",
+        "| --- | --- |",
+        ...rows,
+      ].join("\n"),
+      (path) => {
+        const { findings, ok } = checkFile(path);
+        expect(ok).toBe(true);
+        expect(findings).toHaveLength(1);
+        expect(findings[0]!.claimedCount).toBe(9);
+        expect(findings[0]!.claimIsMinimum).toBe(false);
+        expect(findings[0]!.actualCounts).toContain(15);
+        expect(findings[0]!.field).toBe("description");
+      },
+    );
+  });
+
+  test("instance #20 regression: description says '18+', body has only 15 rows (undercount)", () => {
+    const rows = Array.from(
+      { length: 15 },
+      (_, i) => `| ${i + 1} | instance ${i + 1} |`,
+    );
+    withTmpFile(
+      [
+        "---",
+        "name: verify-then-claim",
+        "description: 18+ drift instances catalogued",
+        "type: feedback",
+        "---",
+        "",
+        "| # | Description |",
+        "| --- | --- |",
+        ...rows,
+      ].join("\n"),
+      (path) => {
+        const { findings, ok } = checkFile(path);
+        expect(ok).toBe(true);
+        expect(findings).toHaveLength(1);
+        expect(findings[0]!.claimedCount).toBe(18);
+        expect(findings[0]!.claimIsMinimum).toBe(true);
+        expect(findings[0]!.actualCounts).toContain(15);
+      },
+    );
+  });
+
+  test("exact-count claim drift fires when no table matches", () => {
+    withTmpFile(
+      [
+        "---",
+        "description: covers 7 sub-classes",
+        "type: feedback",
+        "---",
+        "",
+        "| Sub-class | Done |",
+        "| --- | --- |",
+        "| count | yes |",
+        "| existence | yes |",
+        "| path-form | yes |",
+        // only 3 rows, description claims 7
+      ].join("\n"),
+      (path) => {
+        const { findings } = checkFile(path);
+        expect(findings).toHaveLength(1);
+        expect(findings[0]!.claimedCount).toBe(7);
+        expect(findings[0]!.actualCounts).toContain(3);
+      },
+    );
+  });
+
+  test("multiple count claims in description — each checked independently", () => {
+    // description claims "20 drift instances" and "7 sub-classes"
+    // body: one table with 20 rows (drift), no table with 7 rows
+    const rows = Array.from({ length: 20 }, (_, i) => `| ${i + 1} | d${i + 1} |`);
+    withTmpFile(
+      [
+        "---",
+        "description: 20 drift instances across 7 sub-classes",
+        "type: feedback",
+        "---",
+        "",
+        "| # | Desc |",
+        "| --- | --- |",
+        ...rows,
+      ].join("\n"),
+      (path) => {
+        const { findings } = checkFile(path);
+        // "20 drift instances" is satisfied; "7 sub-classes" is not
+        expect(findings).toHaveLength(1);
+        expect(findings[0]!.claimedCount).toBe(7);
+      },
+    );
+  });
+});
+
+// ── checkFile — error handling ────────────────────────────────────────────────
+
+describe("checkFile — errors", () => {
+  test("returns ok: false for missing file", () => {
+    const { ok } = checkFile("/tmp/definitely-does-not-exist-abcxyz.md");
+    expect(ok).toBe(false);
+  });
+});

--- a/tools/substrate-claim-checker/check-cross-surface.ts
+++ b/tools/substrate-claim-checker/check-cross-surface.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env bun
+/**
+ * substrate-claim-checker / check-cross-surface.ts (v0.8)
+ *
+ * Cross-surface count drift sub-class checker — catches count claims in
+ * YAML frontmatter `description:` fields that are inconsistent with the
+ * actual table row counts in the document body.
+ *
+ * Empirical eval-set (instances from the verify-then-claim memo):
+ *   #19: frontmatter description + MEMORY.md index said "9 drift instances"
+ *        but body table had 15+ rows.
+ *   #20: frontmatter description updated to "18+" but body table still
+ *        had only 15 rows — the count-drift fix introduced opposite-
+ *        direction drift.
+ *
+ * How it works:
+ *   1. Parses YAML frontmatter (leading `---` block)
+ *   2. Extracts count claims from the `description:` field using the
+ *      same noun vocabulary as check-counts.ts
+ *   3. Finds all markdown tables in the document body
+ *   4. For each count claim, checks if ANY body table satisfies it:
+ *      - exact match for "N noun" claims
+ *      - at-least match for "N+ noun" claims
+ *   5. Reports drift if no table satisfies the claim
+ *
+ * "Any-table" semantics (vs check-counts.ts "nearest-table"):
+ *   Frontmatter precedes the entire body, so "nearest table below" is
+ *   meaningless. A multi-table file (drift-instances table + sub-classes
+ *   table) passes if any one table matches the claimed count.
+ *
+ * Usage:
+ *   bun tools/substrate-claim-checker/check-cross-surface.ts <file>
+ *   bun tools/substrate-claim-checker/check-cross-surface.ts <file1> <file2> ...
+ *
+ * Exit code:
+ *   0  no drift detected
+ *   1  drift detected, input error, or no inputs given
+ */
+
+import { readFileSync } from "node:fs";
+import { findTables } from "./check-counts.ts";
+
+export interface Finding {
+  file: string;
+  field: string;
+  claim: string;
+  claimedCount: number;
+  claimIsMinimum: boolean;
+  actualCounts: number[];
+}
+
+interface FrontmatterClaim {
+  raw: string;
+  n: number;
+  isMinimum: boolean;
+  noun: string;
+}
+
+/** YAML frontmatter parse result. */
+interface Frontmatter {
+  fields: Record<string, string>;
+  /** Byte offset in the original string where the body begins. */
+  bodyStart: number;
+  /** 1-indexed line number where the body begins (for error messages). */
+  bodyLineStart: number;
+}
+
+const TRACKED_NOUNS = [
+  "drift instances",
+  "drift instance",
+  "rows",
+  "row",
+  "items",
+  "item",
+  "procedure skills",
+  "named-persona experts",
+  "tools",
+  "sub-classes",
+  "check-types",
+] as const;
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Extract count claims from a flat string (no fenced code blocks). */
+export function extractClaims(text: string): FrontmatterClaim[] {
+  const claims: FrontmatterClaim[] = [];
+  const nounAlt = TRACKED_NOUNS.map(escapeRegex).join("|");
+  const pattern = new RegExp(`\\b(\\d+)(\\+?)[\\s-]+(${nounAlt})\\b`, "gi");
+  for (const m of text.matchAll(pattern)) {
+    const numStr = m[1];
+    const plus = m[2];
+    const noun = m[3];
+    if (numStr === undefined || noun === undefined) continue;
+    claims.push({
+      raw: m[0] ?? "",
+      n: parseInt(numStr, 10),
+      isMinimum: plus === "+",
+      noun: noun.toLowerCase(),
+    });
+  }
+  return claims;
+}
+
+/** Parse YAML frontmatter from a markdown file. Returns null if absent. */
+export function parseFrontmatter(content: string): Frontmatter | null {
+  if (!content.startsWith("---")) return null;
+  const endIdx = content.indexOf("\n---", 3);
+  if (endIdx === -1) return null;
+
+  const yaml = content.slice(4, endIdx);
+  const fields: Record<string, string> = {};
+  for (const line of yaml.split("\n")) {
+    const match = line.match(/^(\w[\w-]*):\s*(.*)/);
+    if (match) {
+      fields[match[1]!] = (match[2] ?? "").replace(/^["']|["']$/g, "").trim();
+    }
+  }
+
+  const bodyStart = endIdx + 4; // skip past "\n---"
+  const bodyLineStart = content.slice(0, bodyStart).split("\n").length + 1;
+  return { fields, bodyStart, bodyLineStart };
+}
+
+export function checkFile(filePath: string): { findings: Finding[]; ok: boolean } {
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      console.error(`error: file not found: ${filePath}`);
+    } else if (code === "EISDIR") {
+      console.error(`error: not a regular file (directory): ${filePath}`);
+    } else {
+      console.error(`error: read failed for ${filePath}: ${(err as Error).message}`);
+    }
+    return { findings: [], ok: false };
+  }
+
+  const fm = parseFrontmatter(content);
+  if (!fm) return { findings: [], ok: true };
+
+  const description = fm.fields["description"];
+  if (!description) return { findings: [], ok: true };
+
+  const claims = extractClaims(description);
+  if (claims.length === 0) return { findings: [], ok: true };
+
+  const bodyLines = content.slice(fm.bodyStart).split("\n");
+  const tables = findTables(bodyLines);
+
+  if (tables.length === 0) return { findings: [], ok: true };
+
+  const actualCounts = tables.map((t) => t.rowCount);
+  const findings: Finding[] = [];
+
+  for (const claim of claims) {
+    const satisfied = claim.isMinimum
+      ? actualCounts.some((c) => c >= claim.n)
+      : actualCounts.some((c) => c === claim.n);
+
+    if (!satisfied) {
+      findings.push({
+        file: filePath,
+        field: "description",
+        claim: claim.raw,
+        claimedCount: claim.n,
+        claimIsMinimum: claim.isMinimum,
+        actualCounts,
+      });
+    }
+  }
+
+  return { findings, ok: true };
+}
+
+export function main(): number {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error(
+      "usage: bun tools/substrate-claim-checker/check-cross-surface.ts <file> [<file> ...]",
+    );
+    return 1;
+  }
+
+  let totalFindings = 0;
+  let inputErrors = 0;
+
+  for (const arg of args) {
+    const { findings, ok } = checkFile(arg);
+    if (!ok) {
+      inputErrors++;
+      continue;
+    }
+    for (const f of findings) {
+      const op = f.claimIsMinimum ? ">=" : "==";
+      const actual = f.actualCounts.join(", ");
+      console.log(
+        `${f.file}: cross-surface count drift — frontmatter.${f.field} claims "${f.claim}" (expected ${op} ${f.claimedCount}); body tables have [${actual}] rows`,
+      );
+      totalFindings++;
+    }
+  }
+
+  if (inputErrors > 0) {
+    console.error(`\n${inputErrors} input error(s).`);
+    return 1;
+  }
+  if (totalFindings > 0) {
+    console.log(`\n${totalFindings} cross-surface count-drift finding(s).`);
+    return 1;
+  }
+  console.log("no cross-surface count drift detected.");
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}


### PR DESCRIPTION
## Summary

- Adds `tools/substrate-claim-checker/check-cross-surface.ts` — the 4th sub-class checker for B-0170, covering **cross-surface count drift**
- Mechanizes eval-set instances **#19** and **#20** from the verify-then-claim memo: frontmatter `description:` field count claims that diverge from body table row counts
- Ships with 22 unit tests (all pass); 84 total substrate-claim-checker tests pass

## What was shipped

**`check-cross-surface.ts` (v0.8):**
- Parses YAML frontmatter from markdown files
- Extracts count claims from the `description:` field (same noun vocabulary as `check-counts.ts`)
- Compares against all tables in the document body using **any-table semantics**: a claim passes if any body table satisfies it
- Reports drift if no table satisfies the claim (exact or minimum count)

**Key design: any-table vs nearest-table**
`check-counts.ts` uses "nearest table within 50 lines below the claim" because claims and tables are in the same body flow. Frontmatter precedes the entire body, so "nearest" is meaningless — any-table semantics avoid false positives in multi-table docs.

## Eval-set regressions covered

| Instance | Frontmatter claim | Body reality | Now caught |
|---|---|---|---|
| #19 | "9 drift instances" | 15-row table | ✓ |
| #20 | "18+ drift instances" | 15-row table (minimum undercount) | ✓ |

## Known limitations (documented in README v0.8 section)

- Only `description:` field scanned (other frontmatter fields deferred)
- Bullet-list counts not compared (lists not tables)
- Any-table semantics can produce false negatives if noun-to-table matching is needed

## Checks

```
bun test tools/substrate-claim-checker/ → 84 pass, 0 fail
dotnet build -c Release → 0 warnings, 0 errors
```

## B-0170 progress

| Sub-class | Status |
|---|---|
| Count drift | ✓ shipped (v0.4.4) |
| Existence drift | ✓ shipped (v0.5) |
| Path-form drift | ✓ shipped (v0.7) |
| **Cross-surface count drift** | **✓ shipped (v0.8) — this PR** |
| Semantic-equivalence drift | v0.9 |
| Empirical-output drift | v0.9 |
| Convention drift | v0.9 |

operative-authorization: aaron 2026-05-04: "it**, not just the output. Grinding through failures + recoveries"