### PR TITLE
fix(B-0362): mark concept-search-index closed — shipped in PRs #2322 + #2323

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -187,7 +187,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0357](backlog/P1/B-0357-replace-tautology-z3-agenda-proofs-with-real-verification.md)** Replace tautology Z3 agenda/trajectory proofs with non-trivial verification
 - [x] **[B-0358](backlog/P1/B-0358-bool-as-degenerate-distribution-confidence-typed-apis.md)** Bool as degenerate distribution — replace binary API returns with confidence scores
 - [ ] **[B-0361](backlog/P1/B-0361-anchor-to-human-lineage-step-in-formal-and-concept-workflows.md)** Anchor-to-human-lineage step in formal verification and concept workflows
-- [ ] **[B-0362](backlog/P1/B-0362-concept-search-index-for-instant-term-lookup.md)** Concept search index — pre-built term→file mapping for instant lookups
+- [x] **[B-0362](backlog/P1/B-0362-concept-search-index-for-instant-term-lookup.md)** Concept search index — pre-built term→file mapping for instant lookups
 - [ ] **[B-0364](backlog/P1/B-0364-policy-relocation-semantic-preservation-fscheck-property.md)** Policy relocation semantic preservation — FsCheck property for mobile DBSP query boundaries
 - [x] **[B-0365](backlog/P1/B-0365-nirvanic-fusion-ship-research-bundle-spaceship-math-rice-class4-shadow-taxonomy.md)** Nirvanic Fusion Ship research bundle — spaceship math + Rice's theorem + Class 4 shadow taxonomy
 - [x] **[B-0365.1](backlog/P1/B-0365.1-spaceship-math-one-pager-subscribe-vision-monad-cache-identity.md)** Spaceship math one-pager: subscribe primitive + vision monad + cache identity

--- a/docs/backlog/P1/B-0362-concept-search-index-for-instant-term-lookup.md
+++ b/docs/backlog/P1/B-0362-concept-search-index-for-instant-term-lookup.md
@@ -1,11 +1,13 @@
 ---
 id: B-0362
 priority: P1
-status: open
+status: closed
 title: "Concept search index — pre-built term→file mapping for instant lookups"
 effort: S
 created: 2026-05-09
-last_updated: 2026-05-09
+last_updated: 2026-05-10
+resolved: 2026-05-09
+resolved_by: "PR #2322 feat(B-0362): smallest safe slice — concept search index (curated regex term→file); PR #2323 feat(B-0362): concept search index — build-index.ts, lookup.ts, AND semantics, tests"
 depends_on: [B-0310]
 classification: buildable-now
 decomposition: atomic
@@ -48,10 +50,18 @@ Index rebuilt on commit (or on-demand via `bun tools/search/build-index.ts`).
 
 ## Acceptance criteria
 
-- [ ] `bun tools/search/build-index.ts` builds index in <5s
-- [ ] `bun tools/search/lookup.ts <term>` returns results in <100ms
-- [ ] Index covers memory/, docs/, .claude/skills/, .claude/rules/
-- [ ] Supports multi-word queries (AND semantics)
+- [x] `bun tools/search/build-index.ts` builds index in <5s — measured 2.55s (2026-05-10)
+- [x] `bun tools/search/lookup.ts <term>` returns results in <100ms — measured 0.6ms (2026-05-10)
+- [x] Index covers memory/, docs/, .claude/skills/, .claude/rules/, .claude/agents/
+- [x] Supports multi-word queries (AND semantics) — implemented via `words.every()` filter
+
+## Resolution
+
+Shipped in two PRs merged 2026-05-09:
+- PR #2322 `feat(B-0362): smallest safe slice — concept search index (curated regex term→file)` — introduced curated-not-corpus design (Vera 2026-05-09 guardrails), 8 concept-query classes
+- PR #2323 `feat(B-0362): concept search index — build-index.ts, lookup.ts, AND semantics, tests` — full implementation: `tools/search/build-index.ts`, `tools/search/lookup.ts`, `tools/search/concept-index.ts`, 13 passing tests
+
+Verified 2026-05-10: all acceptance criteria met. Status updated to closed.
 
 ## Origin
 

--- a/docs/backlog/P1/B-0362-concept-search-index-for-instant-term-lookup.md
+++ b/docs/backlog/P1/B-0362-concept-search-index-for-instant-term-lookup.md
@@ -14,6 +14,7 @@ decomposition: atomic
 owners: [architect]
 type: friction-reducer
 tags: [search, index, concept-registry, performance]
+
 ---
 
 # B-0362 — Concept search index
@@ -58,6 +59,7 @@ Index rebuilt on commit (or on-demand via `bun tools/search/build-index.ts`).
 ## Resolution
 
 Shipped in two PRs merged 2026-05-09:
+
 - PR #2322 `feat(B-0362): smallest safe slice — concept search index (curated regex term→file)` — introduced curated-not-corpus design (Vera 2026-05-09 guardrails), 8 concept-query classes
 - PR #2323 `feat(B-0362): concept search index — build-index.ts, lookup.ts, AND semantics, tests` — full implementation: `tools/search/build-index.ts`, `tools/search/lookup.ts`, `tools/search/concept-index.ts`, 13 passing tests
 


### PR DESCRIPTION
## Summary

- Marks B-0362 (Concept search index) as `status: closed` in the backlog row and BACKLOG.md
- All acceptance criteria verified 2026-05-10: build <5s (2.55s), lookup <100ms (0.6ms), AND semantics, 13 tests passing
- Status was left open despite the implementation shipping in PRs #2322 and #2323 on 2026-05-09

## Test plan

- [x] `bun test tools/search/concept-index.test.ts` — 13 pass, 0 fail
- [x] `bun tools/search/build-index.ts` — 2.55s, 766 entries
- [x] `bun tools/search/lookup.ts "glass-halo"` — 0.6ms, 1 match (206 files)
- [x] `dotnet build -c Release` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)