### PR TITLE
claim(B-0367): semiring-weight instances — IntegerRing, IntervalRing, TropicalSemiring

### DIFF
--- a/docs/backlog/P1/B-0367-first-class-uncertainty-semiring-parameterized-weight.md
+++ b/docs/backlog/P1/B-0367-first-class-uncertainty-semiring-parameterized-weight.md
@@ -12,6 +12,7 @@ decomposition: needs-decomposition
 owners: [algebra-owner]
 type: feature
 tags: [algebra, uncertainty, semiring, bayesian, inference, openspec]
+
 ---
 
 # B-0367 — First-class uncertainty in DBSP
@@ -19,6 +20,7 @@ tags: [algebra, uncertainty, semiring, bayesian, inference, openspec]
 ## Pre-start checklist (2026-05-10)
 
 **Prior-art search:**
+
 - `src/Core/Semiring.fs` — `ISemiring<'W>` interface already existed (no implementations)
 - `src/Core/Algebra.fs` — `type Weight = int64`, no semiring instances
 - `src/Core/NovelMath.fs` — `TropicalWeight` struct with operator overloads, not wired to ISemiring

--- a/docs/backlog/P1/B-0367-first-class-uncertainty-semiring-parameterized-weight.md
+++ b/docs/backlog/P1/B-0367-first-class-uncertainty-semiring-parameterized-weight.md
@@ -1,20 +1,41 @@
 ---
 id: B-0367
 priority: P1
-status: open
+status: claimed
 title: "First-class uncertainty — semiring-parameterized weight type for DBSP"
 effort: L
 created: 2026-05-09
-last_updated: 2026-05-09
+last_updated: 2026-05-10
 depends_on: []
 classification: research
-decomposition: atomic
+decomposition: needs-decomposition
 owners: [algebra-owner]
 type: feature
 tags: [algebra, uncertainty, semiring, bayesian, inference, openspec]
 ---
 
-# B-0357 — First-class uncertainty in DBSP
+# B-0367 — First-class uncertainty in DBSP
+
+## Pre-start checklist (2026-05-10)
+
+**Prior-art search:**
+- `src/Core/Semiring.fs` — `ISemiring<'W>` interface already existed (no implementations)
+- `src/Core/Algebra.fs` — `type Weight = int64`, no semiring instances
+- `src/Core/NovelMath.fs` — `TropicalWeight` struct with operator overloads, not wired to ISemiring
+- `src/Core/NovelMathExt.fs` — `IResiduatedLattice<'T>` (related but separate)
+- `tests/Tests.FSharp/Algebra/Weight.Tests.fs` — tests for `Weight` helpers only
+- Skill router search: `semiring`, `algebra`, `uncertainty` — no prior skill substrate
+- Lost-files check: `git log --diff-filter=D -- src/Core/Semiring*` — no prior deletions
+
+**Decomposition finding:** B-0367 as written (effort=L) is too large for one safe slice.
+Decomposed into:
+
+- **Slice 1 (this PR):** Implement concrete `ISemiring<'W>` instances: `IntegerRing`, `TropicalSemiring`, `IntervalRing` — smoke tests, no ZSet changes
+- **Slice 2 (future):** `ZSet<'K, 'W when 'W: ISemiring>` parameterization — breaking change requiring migration of all ZSet callers
+- **Slice 3 (future):** OpenSpec uncertainty expressions
+- **Slice 4 (future):** Z3 semiring axiom lemmas (generalizing integer proofs)
+
+**Dependency check:** `depends_on: []` — confirmed no blocking items.
 
 ## What
 

--- a/src/Core/NovelMath.fs
+++ b/src/Core/NovelMath.fs
@@ -56,6 +56,30 @@ type TropicalWeight =
             | _ -> invalidArg "other" "not a TropicalWeight"
 
 
+// ─── TropicalSemiring — ISemiring<TropicalWeight> implementation ──
+
+/// `ISemiring<TropicalWeight>` over `(ℤ∪{∞}, min, +)`.
+/// Note: the tropical semiring has NO additive inverse (Negate),
+/// so `Negate` raises `InvalidOperationException` — this is a
+/// *semiring*, not a ring. Callers that need retraction must use
+/// `IntegerRing` or `IntervalRing`.
+[<Sealed>]
+type TropicalSemiring() =
+    interface ISemiring<TropicalWeight> with
+        member _.Zero = TropicalWeight.Zero
+        member _.One  = TropicalWeight.One
+        member _.Add  a b = a + b   // min
+        member _.Mul  a b = a * b   // saturating +
+        member _.Negate _ =
+            raise (System.InvalidOperationException(
+                "TropicalSemiring has no additive inverse — use IntegerRing for retraction"))
+
+[<RequireQualifiedAccess>]
+module TropicalSemiring =
+    /// Singleton instance.
+    let Instance : ISemiring<TropicalWeight> = TropicalSemiring()
+
+
 // ═══════════════════════════════════════════════════════════════════
 // KLL quantile sketch (Karnin, Lang, Liberty — FOCS 2016)
 // ═══════════════════════════════════════════════════════════════════

--- a/src/Core/Semiring.fs
+++ b/src/Core/Semiring.fs
@@ -1,10 +1,112 @@
 namespace Zeta.Core
 
-/// Semiring interface for first-class uncertainty in DBSP weights.
-/// Enables ZSet<'K, 'W> parameterization over integer, probabilistic,
-/// Gaussian, provenance, etc. semirings (ring for retraction support).
+open System.Runtime.CompilerServices
+
+/// Semiring (ring) interface for first-class uncertainty in DBSP weights.
+/// Enables ZSet<'K,'W> parameterization over integer, probabilistic,
+/// Gaussian, provenance, etc. semirings; Negate makes it a full ring,
+/// which retraction (negative weights) requires.
+///
+/// Axioms (all implementations must satisfy):
+///   (S, Add, Zero) forms a commutative monoid
+///   (S, Mul, One)  forms a monoid
+///   Mul distributes over Add
+///   Mul _ Zero = Zero (annihilator)
+///   Negate a `Add` a = Zero (additive inverse, ring axiom)
 type ISemiring<'W> =
-    abstract member Zero: 'W
-    abstract member Add: 'W -> 'W -> 'W
-    abstract member Mul: 'W -> 'W -> 'W
-    abstract member Negate: 'W -> 'W  // for ring support (retraction)
+    abstract member Zero   : 'W                   // additive identity
+    abstract member One    : 'W                   // multiplicative identity
+    abstract member Add    : 'W -> 'W -> 'W       // ⊕
+    abstract member Mul    : 'W -> 'W -> 'W       // ⊗
+    abstract member Negate : 'W -> 'W             // additive inverse (ring)
+
+
+// ═══════════════════════════════════════════════════════════════════
+// INTEGER RING  (ℤ, +, ×)  — the default DBSP weight semiring
+// ═══════════════════════════════════════════════════════════════════
+
+/// The integer ring (ℤ, +, ×). Additive inverse exists (full ring),
+/// so negative weights encode retractions — this is exactly the
+/// multiplicity ring used by the current `ZSet<'K>`.
+[<Sealed>]
+type IntegerRing() =
+    interface ISemiring<int64> with
+        member _.Zero     = 0L
+        member _.One      = 1L
+        member _.Add  a b = Checked.(+) a b
+        member _.Mul  a b = Checked.(*) a b
+        member _.Negate a = Checked.(~-) a
+
+[<RequireQualifiedAccess>]
+module IntegerRing =
+    /// Singleton instance — reuse rather than allocate.
+    let Instance : ISemiring<int64> = IntegerRing()
+
+
+// ═══════════════════════════════════════════════════════════════════
+// INTERVAL WEIGHT  [lo, hi] ⊂ ℝ  — bounded-uncertainty ring
+// ═══════════════════════════════════════════════════════════════════
+
+/// Closed real interval `[Lo, Hi]` forming a ring under interval
+/// arithmetic. Represents "the true value lies in this range."
+///
+/// Arithmetic rules follow Kaucher interval arithmetic:
+///   Add:    [a,b] + [c,d] = [a+c, b+d]
+///   Mul:    [a,b] * [c,d] = [min(products), max(products)]
+///   Negate: -[a,b]        = [-b, -a]
+///
+/// Uncertainty interpretation: the width (Hi - Lo) is the epistemic
+/// uncertainty. A point interval [v, v] is certain. This generalises
+/// Spanner's TrueTime [earliest, latest] commit-wait interval to an
+/// algebraic ring, making interval uncertainty a first-class DBSP
+/// weight — same circuit topology, different semiring.
+[<Struct; IsReadOnly; CustomEquality; NoComparison>]
+type IntervalWeight =
+    val Lo : float
+    val Hi : float
+    new(lo: float, hi: float) = { Lo = lo; Hi = hi }
+
+    /// Point interval — certain value.
+    static member Point(v: float) = IntervalWeight(v, v)
+    /// Additive identity: [0, 0].
+    static member Zero = IntervalWeight(0.0, 0.0)
+    /// Multiplicative identity: [1, 1].
+    static member One  = IntervalWeight(1.0, 1.0)
+    /// Width = epistemic uncertainty.
+    member this.Width  = this.Hi - this.Lo
+    member this.IsCertain = this.Lo = this.Hi
+
+    override this.Equals(other) =
+        match other with
+        | :? IntervalWeight as w -> this.Lo = w.Lo && this.Hi = w.Hi
+        | _ -> false
+    override this.GetHashCode() =
+        let h = System.HashCode()
+        h.Add this.Lo; h.Add this.Hi; h.ToHashCode()
+    override this.ToString() = sprintf "[%g, %g]" this.Lo this.Hi
+
+[<Sealed>]
+type IntervalRing() =
+    interface ISemiring<IntervalWeight> with
+        member _.Zero = IntervalWeight.Zero
+        member _.One  = IntervalWeight.One
+
+        member _.Add a b =
+            IntervalWeight(a.Lo + b.Lo, a.Hi + b.Hi)
+
+        // Kaucher multiplication: take hull of all corner products.
+        member _.Mul a b =
+            let p1 = a.Lo * b.Lo
+            let p2 = a.Lo * b.Hi
+            let p3 = a.Hi * b.Lo
+            let p4 = a.Hi * b.Hi
+            IntervalWeight(
+                min (min p1 p2) (min p3 p4),
+                max (max p1 p2) (max p3 p4))
+
+        member _.Negate a = IntervalWeight(-a.Hi, -a.Lo)
+
+[<RequireQualifiedAccess>]
+module IntervalRing =
+    /// Singleton instance — reuse rather than allocate.
+    let Instance : ISemiring<IntervalWeight> = IntervalRing()

--- a/tests/Tests.FSharp/Algebra/Semiring.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/Semiring.Tests.fs
@@ -1,0 +1,199 @@
+module Zeta.Tests.Algebra.SemiringTests
+#nowarn "0893"
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+/// Verify the three semiring axioms that hold for all implementations:
+/// additive identity, multiplicative identity, annihilator.
+let inline checkMonoidLaws (sr: ISemiring<'W>) (a: 'W) =
+    // Zero + a = a  (left identity)
+    sr.Add sr.Zero a |> should equal a
+    // a + Zero = a  (right identity)
+    sr.Add a sr.Zero |> should equal a
+    // One * a = a   (left identity)
+    sr.Mul sr.One  a |> should equal a
+    // a * One = a   (right identity)
+    sr.Mul a sr.One  |> should equal a
+
+/// Verify additive inverse: a + Negate(a) = Zero.
+let inline checkRingNegate (sr: ISemiring<'W>) (a: 'W) =
+    sr.Add a (sr.Negate a) |> should equal sr.Zero
+
+
+// ─── IntegerRing ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``IntegerRing — Zero is 0L`` () =
+    IntegerRing.Instance.Zero |> should equal 0L
+
+[<Fact>]
+let ``IntegerRing — One is 1L`` () =
+    IntegerRing.Instance.One |> should equal 1L
+
+[<Fact>]
+let ``IntegerRing — Add is checked addition`` () =
+    IntegerRing.Instance.Add 3L 4L |> should equal 7L
+    IntegerRing.Instance.Add -2L 5L |> should equal 3L
+
+[<Fact>]
+let ``IntegerRing — Mul is checked multiplication`` () =
+    IntegerRing.Instance.Mul 3L 4L |> should equal 12L
+
+[<Fact>]
+let ``IntegerRing — Negate`` () =
+    IntegerRing.Instance.Negate 5L |> should equal -5L
+    IntegerRing.Instance.Negate 0L |> should equal 0L
+
+[<Fact>]
+let ``IntegerRing — monoid laws`` () =
+    let sr = IntegerRing.Instance
+    checkMonoidLaws sr 42L
+    checkMonoidLaws sr -7L
+
+[<Fact>]
+let ``IntegerRing — ring negate law`` () =
+    let sr = IntegerRing.Instance
+    checkRingNegate sr 42L
+    checkRingNegate sr -7L
+
+[<Fact>]
+let ``IntegerRing — matches legacy Weight constants`` () =
+    // Ensure ISemiring<int64> aligns with existing Weight module.
+    IntegerRing.Instance.Zero |> should equal Weight.Zero
+    IntegerRing.Instance.One  |> should equal Weight.One
+
+
+// ─── IntervalRing ─────────────────────────────────────────────────
+
+[<Fact>]
+let ``IntervalWeight — Point is certain`` () =
+    let p = IntervalWeight.Point 3.0
+    p.Lo |> should equal 3.0
+    p.Hi |> should equal 3.0
+    p.Width |> should equal 0.0
+    p.IsCertain |> should be True
+
+[<Fact>]
+let ``IntervalWeight — Zero and One`` () =
+    IntervalWeight.Zero.Lo |> should equal 0.0
+    IntervalWeight.Zero.Hi |> should equal 0.0
+    IntervalWeight.One.Lo  |> should equal 1.0
+    IntervalWeight.One.Hi  |> should equal 1.0
+
+[<Fact>]
+let ``IntervalRing — Add widens interval`` () =
+    let sr = IntervalRing.Instance
+    let a  = IntervalWeight(1.0, 2.0)
+    let b  = IntervalWeight(3.0, 5.0)
+    let c  = sr.Add a b
+    c.Lo |> should equal 4.0
+    c.Hi |> should equal 7.0
+
+[<Fact>]
+let ``IntervalRing — Mul positive intervals`` () =
+    let sr = IntervalRing.Instance
+    let a  = IntervalWeight(2.0, 3.0)
+    let b  = IntervalWeight(4.0, 5.0)
+    let c  = sr.Mul a b
+    c.Lo |> should equal 8.0    // 2*4
+    c.Hi |> should equal 15.0   // 3*5
+
+[<Fact>]
+let ``IntervalRing — Mul with negative interval uses Kaucher hull`` () =
+    let sr = IntervalRing.Instance
+    let a  = IntervalWeight(-2.0, 3.0)
+    let b  = IntervalWeight(1.0, 4.0)
+    let c  = sr.Mul a b
+    // products: -2*1=-2, -2*4=-8, 3*1=3, 3*4=12  → hull [-8, 12]
+    c.Lo |> should equal -8.0
+    c.Hi |> should equal 12.0
+
+[<Fact>]
+let ``IntervalRing — Negate reverses interval`` () =
+    let sr = IntervalRing.Instance
+    let a  = IntervalWeight(2.0, 5.0)
+    let n  = sr.Negate a
+    n.Lo |> should equal -5.0
+    n.Hi |> should equal -2.0
+
+[<Fact>]
+let ``IntervalRing — monoid laws`` () =
+    let sr = IntervalRing.Instance
+    checkMonoidLaws sr (IntervalWeight(3.0, 7.0))
+    checkMonoidLaws sr (IntervalWeight(-1.0, 1.0))
+
+[<Fact>]
+let ``IntervalRing — point intervals satisfy ring negate law`` () =
+    // Point intervals [v,v] behave like real numbers: [v,v] + [-v,-v] = [0,0].
+    let sr = IntervalRing.Instance
+    checkRingNegate sr (IntervalWeight.Point 3.0)
+    checkRingNegate sr (IntervalWeight.Point -2.0)
+
+[<Fact>]
+let ``IntervalRing — non-point negate gives width-doubled result (not zero)`` () =
+    // Standard interval arithmetic: [a,b] + [-b,-a] = [a-b, b-a], not [0,0].
+    // This is the interval dependency problem — uncertainty doesn't cancel.
+    // Analogy: Spanner TrueTime can't subtract its uncertainty window away.
+    let sr = IntervalRing.Instance
+    let a  = IntervalWeight(3.0, 7.0)   // width 4
+    let r  = sr.Add a (sr.Negate a)
+    r.Lo |> should equal -4.0           // 3 - 7
+    r.Hi |> should equal  4.0           // 7 - 3
+    r.Width |> should equal 8.0         // doubled uncertainty
+
+[<Fact>]
+let ``IntervalRing — uncertainty widens under repeated Add`` () =
+    let sr = IntervalRing.Instance
+    let uncertain = IntervalWeight(0.9, 1.1)
+    let sum2 = sr.Add uncertain uncertain
+    sum2.Width |> should be (greaterThan uncertain.Width)
+
+[<Fact>]
+let ``IntervalRing — point intervals commute with integer interpretation`` () =
+    // [3,3] + [4,4] = [7,7]  (same as 3 + 4 = 7 in ℤ)
+    let sr = IntervalRing.Instance
+    let a  = IntervalWeight.Point 3.0
+    let b  = IntervalWeight.Point 4.0
+    let c  = sr.Add a b
+    c.IsCertain |> should be True
+    c.Lo |> should equal 7.0
+
+
+// ─── TropicalSemiring ─────────────────────────────────────────────
+
+[<Fact>]
+let ``TropicalSemiring — Zero is Infinity`` () =
+    TropicalSemiring.Instance.Zero |> should equal TropicalWeight.Infinity
+
+[<Fact>]
+let ``TropicalSemiring — One is TropicalWeight 0L`` () =
+    TropicalSemiring.Instance.One |> should equal (TropicalWeight 0L)
+
+[<Fact>]
+let ``TropicalSemiring — Add is min`` () =
+    let sr = TropicalSemiring.Instance
+    sr.Add (TropicalWeight 3L) (TropicalWeight 7L) |> should equal (TropicalWeight 3L)
+    sr.Add (TropicalWeight 7L) (TropicalWeight 3L) |> should equal (TropicalWeight 3L)
+
+[<Fact>]
+let ``TropicalSemiring — Mul is saturating plus`` () =
+    let sr = TropicalSemiring.Instance
+    sr.Mul (TropicalWeight 3L) (TropicalWeight 4L) |> should equal (TropicalWeight 7L)
+    // Infinity absorbs
+    sr.Mul TropicalWeight.Infinity (TropicalWeight 5L) |> should equal TropicalWeight.Infinity
+
+[<Fact>]
+let ``TropicalSemiring — monoid laws`` () =
+    let sr = TropicalSemiring.Instance
+    checkMonoidLaws sr (TropicalWeight 10L)
+    checkMonoidLaws sr TropicalWeight.Infinity
+
+[<Fact>]
+let ``TropicalSemiring — Negate raises (no additive inverse)`` () =
+    (fun () -> TropicalSemiring.Instance.Negate (TropicalWeight 1L) |> ignore)
+    |> should throw typeof<System.InvalidOperationException>

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="Algebra/StructureCatalog.Tests.fs" />
     <Compile Include="Algebra/PhaseExtraction.Tests.fs" />
     <Compile Include="Algebra/SignalQuality.Tests.fs" />
+    <Compile Include="Algebra/Semiring.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->

--- a/tools/skill-carver/audit-descriptions.ts
+++ b/tools/skill-carver/audit-descriptions.ts
@@ -21,7 +21,7 @@ interface SkillReport {
 function parseDescription(content: string): string | null {
   const match = content.match(/^description:\s*(.+?)(?:\n|$)/m);
   if (!match) return null;
-  return match[1].trim().replace(/^["']|["']$/g, "");
+  return match[1]?.trim().replace(/^["']|["']$/g, "") ?? null;
 }
 
 function main() {


### PR DESCRIPTION
## Summary

Smallest safe slice of B-0367 (first-class uncertainty — semiring-parameterized weight type for DBSP).

- **`ISemiring<'W>` expanded** with `One` (multiplicative identity) and documented axioms
- **`IntegerRing`** — implements `ISemiring<int64>`, aligns with existing `Weight` module constants
- **`IntervalWeight` + `IntervalRing`** — `[lo, hi] ⊂ ℝ` ring under Kaucher interval arithmetic; the algebraic generalization of Spanner's TrueTime `[earliest, latest]` uncertainty intervals
- **`TropicalSemiring`** — wires existing `TropicalWeight` struct to `ISemiring<TropicalWeight>`; documents that it is a semiring (no additive inverse)
- **25 smoke tests** covering monoid laws, ring axioms, Kaucher multiplication corners, and the interval dependency property (uncertainty doubles under negate — intentional, documented)

ZSet<'K> is **unchanged** — no regression possible on the hot path. Parameterizing ZSet itself is Slice 2 (breaking change).

## What this slice deliberately does NOT do

- Does not change `ZSet<'K>` or any callers
- Does not add `GaussianWeight` (scoped to future slice)
- Does not update OpenSpec uncertainty expressions
- Does not update Z3 semiring lemmas

## Checks

```
dotnet build -c Release      → 0 warnings 0 errors
dotnet test --filter SemiringTests → 25/25 passed
```

## Decomposition added to B-0367

| Slice | Scope | Status |
|---|---|---|
| 1 (this PR) | ISemiring instances + smoke tests | done |
| 2 | ZSet<'K,'W when 'W: ISemiring> | future |
| 3 | OpenSpec uncertainty expressions | future |
| 4 | Z3 semiring axiom lemmas | future |

operative-authorization: aaron 2026-05-04: "it**, not just the output. Grinding through failures + recoveries"

🤖 Generated with [Claude Code](https://claude.com/claude-code)