### PR TITLE
claim(B-0001): close example schema self-reference row

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -211,7 +211,7 @@ are closed (status: closed in frontmatter)._
 
 ## P2 — research-grade
 
-- [ ] **[B-0001](backlog/P2/B-0001-example-schema-self-reference.md)** Example row — self-reference demonstrating the per-row-file schema
+- [x] **[B-0001](backlog/P2/B-0001-example-schema-self-reference.md)** Example row — self-reference demonstrating the per-row-file schema
 - [ ] **[B-0004](backlog/P2/B-0004-translate-repo-to-other-human-languages.md)** Translate repo (code, skills, documents, memory) into other human languages — inclusivity + meeting humans at their starting point + bidirectional-alignment through learning + education + teaching that's bidirectional
 - [ ] **[B-0004.1](backlog/P2/B-0004.1-substrate-inventory-scanner-ts.md)** B-0004.1 — TS substrate inventory scanner for translatable content surfaces
 - [ ] **[B-0004.2](backlog/P2/B-0004.2-precision-glossary-anchor-set.md)** B-0004.2 — Precision glossary anchor set extraction (precondition for consistent translation)

--- a/docs/backlog/P2/B-0001-example-schema-self-reference.md
+++ b/docs/backlog/P2/B-0001-example-schema-self-reference.md
@@ -76,6 +76,7 @@ Required by `.claude/rules/backlog-item-start-gate.md` before any work.
 - No supersession history; this is the first backlog row.
 
 **Closure rationale:**
+
 All three stated purposes are fulfilled:
 
 1. Generator exercises: `bun tools/backlog/generate-index.ts --check` → `ok` (exit 0).

--- a/docs/backlog/P2/B-0001-example-schema-self-reference.md
+++ b/docs/backlog/P2/B-0001-example-schema-self-reference.md
@@ -1,13 +1,15 @@
 ---
 id: B-0001
 priority: P2
-status: open
+status: closed
+closed: 2026-05-10
+closed_by: "claim(B-0001): all three stated purposes verified fulfilled — generator passes --check, backlog-index-integrity.yml CI gate exists, schema documented by real content"
 title: Example row — self-reference demonstrating the per-row-file schema
 tier: research-grade
 effort: S
 ask: maintainer Otto-181 (BACKLOG split Phase 1a)
 created: 2026-04-24
-last_updated: 2026-05-02
+last_updated: 2026-05-10
 depends_on: []
 composes_with: []
 tags: [backlog-schema, example, phase-1a]
@@ -50,6 +52,37 @@ recovered via `git log --diff-filter=D` if needed).
   is filled by real content, per CLAUDE.md "retire by
   deletion" discipline.
 
+## Pre-start checklist (2026-05-10, claim)
+
+Required by `.claude/rules/backlog-item-start-gate.md` before any work.
+
+**Prior-art search:**
+- Skill router: no overlapping skill covers "backlog example row" scope.
+- `tools/backlog/`: `generate-index.ts`, `README.md` exist — generator
+  is the tool this row exercises.
+- `tools/hygiene/LOST-FILES-LOCATIONS.md`: no lost artifacts for B-0001.
+- `docs/DECISIONS/2026-04-22-backlog-per-row-file-restructure.md`:
+  Phase 1a/1b/1c phases documented; Phase 1c (`backlog-index-integrity.yml`)
+  is landed (confirmed: `.github/workflows/backlog-index-integrity.yml`).
+- `docs/BACKLOG.md --check`: `bun tools/backlog/generate-index.ts --check`
+  returns exit 0 — no drift.
+
+**Dependency-restructure:**
+- `depends_on: []` — no dependencies.
+- `composes_with: []` — standalone example row.
+- No supersession history; this is the first backlog row.
+
+**Closure rationale:**
+All three stated purposes are fulfilled:
+1. Generator exercises: `bun tools/backlog/generate-index.ts --check` → `ok` (exit 0).
+2. Schema documentation: file shape is demonstrated and real rows (B-0002…B-0400+)
+   now fill the per-row corpus, supplanting the need for this example.
+3. Numbering anchor: B-0002+ exist; Phase 2 migration substantially complete.
+
+Phase 1b milestone (CI drift-check gate) is landed as `backlog-index-integrity.yml`.
+Phase 3 condition ("schema-demo role filled by real content") is satisfied by the
+hundreds of real per-row files now in tree. Retiring this item per Phase 3 intent.
+
 ## Cross-references
 
 - `tools/backlog/README.md` — schema spec.
@@ -57,3 +90,5 @@ recovered via `git log --diff-filter=D` if needed).
   file exercises.
 - `docs/research/backlog-split-design-otto-181.md` — full
   design spec.
+- `.github/workflows/backlog-index-integrity.yml` — Phase 1b CI gate
+  (now landed; was cited as future work in this row's original body).

--- a/docs/backlog/P2/B-0001-example-schema-self-reference.md
+++ b/docs/backlog/P2/B-0001-example-schema-self-reference.md
@@ -14,6 +14,7 @@ depends_on: []
 composes_with: []
 tags: [backlog-schema, example, phase-1a]
 type: friction-reducer
+
 ---
 
 # Example row — self-reference demonstrating the per-row-file schema
@@ -57,6 +58,7 @@ recovered via `git log --diff-filter=D` if needed).
 Required by `.claude/rules/backlog-item-start-gate.md` before any work.
 
 **Prior-art search:**
+
 - Skill router: no overlapping skill covers "backlog example row" scope.
 - `tools/backlog/`: `generate-index.ts`, `README.md` exist — generator
   is the tool this row exercises.
@@ -68,12 +70,14 @@ Required by `.claude/rules/backlog-item-start-gate.md` before any work.
   returns exit 0 — no drift.
 
 **Dependency-restructure:**
+
 - `depends_on: []` — no dependencies.
 - `composes_with: []` — standalone example row.
 - No supersession history; this is the first backlog row.
 
 **Closure rationale:**
 All three stated purposes are fulfilled:
+
 1. Generator exercises: `bun tools/backlog/generate-index.ts --check` → `ok` (exit 0).
 2. Schema documentation: file shape is demonstrated and real rows (B-0002…B-0400+)
    now fill the per-row corpus, supplanting the need for this example.


### PR DESCRIPTION
## Summary

- Closes backlog item **B-0001** (P2, Example row — self-reference demonstrating the per-row-file schema)
- Updates `status: open → closed` with `closed: 2026-05-10` and `closed_by` evidence
- Adds pre-start checklist section documenting prior-art search and closure rationale
- Regenerates `docs/BACKLOG.md` — B-0001 now shows as `- [x]`

## Closure rationale

All three stated purposes of B-0001 are verifiably fulfilled:

1. **Exercise the generator** — `bun tools/backlog/generate-index.ts --check` exits 0; no drift
2. **Demonstrate schema shape** — 400+ real per-row files now fill the corpus, making the example row's documentation role redundant  
3. **Anchor B-NNNN numbering** — B-0002 through B-0400+ exist; Phase 2 migration substantially complete

Phase 1b milestone cited in the row body (`backlog-index-integrity.yml` CI gate) is landed.  
Phase 3 condition ("schema-demo role filled by real content") is satisfied.

## Checks

```
bun tools/backlog/generate-index.ts --check
→ ok: docs/BACKLOG.md matches generator output  (exit 0)

dotnet build -c Release
→ Build succeeded. 0 Warning(s)  0 Error(s)
```

## Files changed

| File | Change |
|------|--------|
| `docs/backlog/P2/B-0001-example-schema-self-reference.md` | status → closed; add pre-start checklist |
| `docs/BACKLOG.md` | regenerated; B-0001 now `- [x]` |

Closes #B-0001

🤖 Generated with [Claude Code](https://claude.com/claude-code)