### PR TITLE
feat(B-0396): split ISemiring/IRing — fix TropicalSemiring and IntervalRing contract violations

### DIFF
--- a/src/Core/NovelMath.fs
+++ b/src/Core/NovelMath.fs
@@ -59,10 +59,9 @@ type TropicalWeight =
 // ─── TropicalSemiring — ISemiring<TropicalWeight> implementation ──
 
 /// `ISemiring<TropicalWeight>` over `(ℤ∪{∞}, min, +)`.
-/// Note: the tropical semiring has NO additive inverse (Negate),
-/// so `Negate` raises `InvalidOperationException` — this is a
-/// *semiring*, not a ring. Callers that need retraction must use
-/// `IntegerRing` or `IntervalRing`.
+/// The tropical semiring has no additive inverse — it satisfies ISemiring
+/// but NOT IRing. Callers that need retraction (negative weights) must use
+/// IntegerRing or IntervalRing instead.
 [<Sealed>]
 type TropicalSemiring() =
     interface ISemiring<TropicalWeight> with
@@ -70,9 +69,6 @@ type TropicalSemiring() =
         member _.One  = TropicalWeight.One
         member _.Add  a b = a + b   // min
         member _.Mul  a b = a * b   // saturating +
-        member _.Negate _ =
-            raise (System.InvalidOperationException(
-                "TropicalSemiring has no additive inverse — use IntegerRing for retraction"))
 
 [<RequireQualifiedAccess>]
 module TropicalSemiring =

--- a/src/Core/Semiring.fs
+++ b/src/Core/Semiring.fs
@@ -2,23 +2,30 @@ namespace Zeta.Core
 
 open System.Runtime.CompilerServices
 
-/// Semiring (ring) interface for first-class uncertainty in DBSP weights.
+/// Commutative semiring for first-class uncertainty in DBSP weights.
 /// Enables ZSet<'K,'W> parameterization over integer, probabilistic,
-/// Gaussian, provenance, etc. semirings; Negate makes it a full ring,
-/// which retraction (negative weights) requires.
+/// tropical, provenance, etc. semirings without requiring an additive inverse.
 ///
 /// Axioms (all implementations must satisfy):
 ///   (S, Add, Zero) forms a commutative monoid
 ///   (S, Mul, One)  forms a monoid
 ///   Mul distributes over Add
 ///   Mul _ Zero = Zero (annihilator)
-///   Negate a `Add` a = Zero (additive inverse, ring axiom)
 type ISemiring<'W> =
     abstract member Zero   : 'W                   // additive identity
     abstract member One    : 'W                   // multiplicative identity
     abstract member Add    : 'W -> 'W -> 'W       // ⊕
     abstract member Mul    : 'W -> 'W -> 'W       // ⊗
-    abstract member Negate : 'W -> 'W             // additive inverse (ring)
+
+/// Full ring — a semiring with an additive inverse.
+/// Required for DBSP retraction (negative weight encoding).
+/// ZSet callers that require retraction must constrain to IRing, not ISemiring.
+///
+/// Additional axiom:
+///   Negate a `Add` a = Zero  (additive inverse / ring axiom)
+type IRing<'W> =
+    inherit ISemiring<'W>
+    abstract member Negate : 'W -> 'W             // additive inverse ⊖
 
 
 // ═══════════════════════════════════════════════════════════════════
@@ -35,12 +42,13 @@ type IntegerRing() =
         member _.One      = 1L
         member _.Add  a b = Checked.(+) a b
         member _.Mul  a b = Checked.(*) a b
+    interface IRing<int64> with
         member _.Negate a = Checked.(~-) a
 
 [<RequireQualifiedAccess>]
 module IntegerRing =
     /// Singleton instance — reuse rather than allocate.
-    let Instance : ISemiring<int64> = IntegerRing()
+    let Instance : IRing<int64> = IntegerRing()
 
 
 // ═══════════════════════════════════════════════════════════════════
@@ -104,9 +112,16 @@ type IntervalRing() =
                 min (min p1 p2) (min p3 p4),
                 max (max p1 p2) (max p3 p4))
 
+    interface IRing<IntervalWeight> with
+        /// Kaucher negation: -[a,b] = [-b,-a].
+        /// Ring axiom (Negate a + a = Zero) holds ONLY for point intervals [v,v].
+        /// Non-point intervals exhibit the interval dependency problem — uncertainty
+        /// does not cancel algebraically (analogous to Spanner TrueTime commit-wait).
+        /// The intended DBSP use case for IntervalRing is point-interval precision
+        /// encoding, where the ring axiom holds.
         member _.Negate a = IntervalWeight(-a.Hi, -a.Lo)
 
 [<RequireQualifiedAccess>]
 module IntervalRing =
     /// Singleton instance — reuse rather than allocate.
-    let Instance : ISemiring<IntervalWeight> = IntervalRing()
+    let Instance : IRing<IntervalWeight> = IntervalRing()

--- a/tests/Tests.FSharp/Algebra/Semiring.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/Semiring.Tests.fs
@@ -21,7 +21,7 @@ let inline checkMonoidLaws (sr: ISemiring<'W>) (a: 'W) =
     sr.Mul a sr.One  |> should equal a
 
 /// Verify additive inverse: a + Negate(a) = Zero.
-let inline checkRingNegate (sr: ISemiring<'W>) (a: 'W) =
+let inline checkRingNegate (sr: IRing<'W>) (a: 'W) =
     sr.Add a (sr.Negate a) |> should equal sr.Zero
 
 
@@ -52,20 +52,20 @@ let ``IntegerRing — Negate`` () =
 [<Fact>]
 let ``IntegerRing — monoid laws`` () =
     let sr = IntegerRing.Instance
-    checkMonoidLaws sr 42L
-    checkMonoidLaws sr -7L
+    checkMonoidLaws (sr :> ISemiring<int64>) 42L
+    checkMonoidLaws (sr :> ISemiring<int64>) -7L
 
 [<Fact>]
 let ``IntegerRing — ring negate law`` () =
-    let sr = IntegerRing.Instance
+    let sr : IRing<int64> = IntegerRing.Instance
     checkRingNegate sr 42L
     checkRingNegate sr -7L
 
 [<Fact>]
 let ``IntegerRing — matches legacy Weight constants`` () =
-    // Ensure ISemiring<int64> aligns with existing Weight module.
-    IntegerRing.Instance.Zero |> should equal Weight.Zero
-    IntegerRing.Instance.One  |> should equal Weight.One
+    // Ensure IRing<int64> aligns with existing Weight module.
+    (IntegerRing.Instance :> ISemiring<int64>).Zero |> should equal Weight.Zero
+    (IntegerRing.Instance :> ISemiring<int64>).One  |> should equal Weight.One
 
 
 // ─── IntervalRing ─────────────────────────────────────────────────
@@ -124,13 +124,13 @@ let ``IntervalRing — Negate reverses interval`` () =
 [<Fact>]
 let ``IntervalRing — monoid laws`` () =
     let sr = IntervalRing.Instance
-    checkMonoidLaws sr (IntervalWeight(3.0, 7.0))
-    checkMonoidLaws sr (IntervalWeight(-1.0, 1.0))
+    checkMonoidLaws (sr :> ISemiring<IntervalWeight>) (IntervalWeight(3.0, 7.0))
+    checkMonoidLaws (sr :> ISemiring<IntervalWeight>) (IntervalWeight(-1.0, 1.0))
 
 [<Fact>]
 let ``IntervalRing — point intervals satisfy ring negate law`` () =
     // Point intervals [v,v] behave like real numbers: [v,v] + [-v,-v] = [0,0].
-    let sr = IntervalRing.Instance
+    let sr : IRing<IntervalWeight> = IntervalRing.Instance
     checkRingNegate sr (IntervalWeight.Point 3.0)
     checkRingNegate sr (IntervalWeight.Point -2.0)
 
@@ -194,6 +194,8 @@ let ``TropicalSemiring — monoid laws`` () =
     checkMonoidLaws sr TropicalWeight.Infinity
 
 [<Fact>]
-let ``TropicalSemiring — Negate raises (no additive inverse)`` () =
-    (fun () -> TropicalSemiring.Instance.Negate (TropicalWeight 1L) |> ignore)
-    |> should throw typeof<System.InvalidOperationException>
+let ``TropicalSemiring — does not implement IRing (no additive inverse)`` () =
+    // The tropical semiring is a semiring, not a ring — it has no Negate.
+    // Verify at the type level that TropicalSemiring.Instance is not an IRing.
+    let isTropicalRing = TropicalSemiring.Instance :? IRing<TropicalWeight>
+    isTropicalRing |> should be False


### PR DESCRIPTION
## Summary

- Splits `ISemiring<'W>` (no Negate) from `IRing<'W> : ISemiring<'W>` (Negate + ring axiom), fixing two P1/P2 contract violations flagged in the Codex review on PR #2388
- `TropicalSemiring` now implements `ISemiring<TropicalWeight>` only — the throwing `Negate` stub (an LSP violation) is removed entirely
- `IntervalRing` now implements `IRing<IntervalWeight>` with a doc comment explaining the point-interval scope of the ring axiom
- `IntegerRing` unchanged in behaviour; its `Instance` type promoted from `ISemiring<int64>` to `IRing<int64>`
- ZSet retraction callers can now be statically constrained to `IRing` rather than `ISemiring`

## Changed files

| File | Change |
|------|--------|
| `src/Core/Semiring.fs` | `ISemiring<'W>` loses `Negate`; `IRing<'W> : ISemiring<'W>` added; `IntegerRing`/`IntervalRing` split their interface implementations; `Instance` types updated |
| `src/Core/NovelMath.fs` | `TropicalSemiring` — `Negate` throwing stub removed; only `ISemiring<TropicalWeight>` implemented |
| `tests/Tests.FSharp/Algebra/Semiring.Tests.fs` | `checkRingNegate` takes `IRing<'W>`; monoid law tests add explicit upcasts; TropicalSemiring "Negate raises" test replaced with type-check asserting `TropicalSemiring ∉ IRing` |

## Checks

```
dotnet build -c Release  →  0 Warning(s)  0 Error(s)
dotnet test Zeta.sln -c Release  →  918 passed, 1 skip (pre-existing), 0 failed
```

## Acceptance criteria coverage

1. ✅ `ISemiring<'W>` interface does NOT include `Negate`
2. ✅ `IRing<'W> : ISemiring<'W>` adds `Negate` with documented axiom
3. ✅ `IntegerRing` implements `IRing<int64>`
4. ✅ `IntervalRing` implements `IRing<IntervalWeight>` with doc comment on point-interval scope
5. ✅ `TropicalSemiring` implements `ISemiring<TropicalWeight>` only — no Negate, no throwing
6. ✅ Retraction callers can constrain to `IRing<'W>` (type-level distinction now exists)
7. ✅ All existing semiring tests pass; new test verifies TropicalSemiring ∉ IRing
8. ✅ Build: 0 warnings 0 errors

Closes B-0396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)