### PR TITLE
close(B-0396): mark ISemiring/IRing split done — all 8 acceptance criteria met

### DIFF
--- a/docs/backlog/P1/B-0396-isemiring-iring-interface-split-interval-tropical-negate-axiom.md
+++ b/docs/backlog/P1/B-0396-isemiring-iring-interface-split-interval-tropical-negate-axiom.md
@@ -1,10 +1,12 @@
 ---
 id: B-0396
 priority: P1
-status: open
+status: done
 title: "Split ISemiring into ISemiring (no Negate) and IRing : ISemiring (with Negate axiom) — fix IntervalRing/TropicalSemiring contract violations"
 created: 2026-05-10
 last_updated: 2026-05-10
+closed: 2026-05-10
+closed_by: PR #2391
 depends_on: []
 composes_with: [B-0367]
 classification: buildable-now
@@ -75,3 +77,20 @@ Change `IntervalRing.Negate` to `[-a,-b]` (satisfies ring axiom for all interval
 - `tests/Tests.FSharp/Algebra/Semiring.Tests.fs` lines 131-147 (interval dependency problem tests)
 - `src/Core/Semiring.fs` line 15 (axiom documentation on ISemiring)
 - PR #2383 (`claim(B-0367): semiring-weight instances`)
+
+## Completion record
+
+Shipped in commit `1121b239` via PR #2391 (2026-05-10).
+
+All acceptance criteria verified:
+
+| # | Criterion | Status |
+|---|-----------|--------|
+| 1 | `ISemiring<'W>` has no `Negate` | ✓ `src/Core/Semiring.fs:14-18` |
+| 2 | `IRing<'W> : ISemiring<'W>` adds `Negate` with axiom doc | ✓ `src/Core/Semiring.fs:20-28` |
+| 3 | `IntegerRing` implements `IRing<int64>` | ✓ `src/Core/Semiring.fs:45-46` |
+| 4 | `IntervalRing` implements `IRing<IntervalWeight>` with point-interval scope note | ✓ `src/Core/Semiring.fs:115-122` |
+| 5 | `TropicalSemiring` implements `ISemiring<TropicalWeight>` only — no `Negate`, no throwing | ✓ `src/Core/NovelMath.fs:66-76` |
+| 6 | Retraction callers constrained to `IRing<'W>` | ✓ `IntegerRing.Instance : IRing<int64>`, `IntervalRing.Instance : IRing<IntervalWeight>` |
+| 7 | All semiring tests pass; `TropicalSemiring` non-`IRing` test present | ✓ 25/25 tests pass |
+| 8 | `dotnet build -c Release` → 0 warnings 0 errors | ✓ confirmed 2026-05-10 |


### PR DESCRIPTION
## Summary

- B-0396 (ISemiring/IRing interface split) was fully implemented in PR #2391 (commit `1121b239`).
- This PR closes the backlog item: sets `status: done`, adds `closed_by: PR #2391`, and records a completion table mapping each acceptance criterion to its source location.

## Acceptance criteria verified

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `ISemiring<'W>` has no `Negate` | ✓ `src/Core/Semiring.fs:14-18` |
| 2 | `IRing<'W> : ISemiring<'W>` adds `Negate` with axiom doc | ✓ `src/Core/Semiring.fs:20-28` |
| 3 | `IntegerRing` implements `IRing<int64>` | ✓ `src/Core/Semiring.fs:45-46` |
| 4 | `IntervalRing` implements `IRing<IntervalWeight>` with point-interval scope note | ✓ `src/Core/Semiring.fs:115-122` |
| 5 | `TropicalSemiring` implements `ISemiring<TropicalWeight>` only — no `Negate`, no throwing | ✓ `src/Core/NovelMath.fs:66-76` |
| 6 | Retraction callers constrained to `IRing<'W>` | ✓ `IntegerRing.Instance : IRing<int64>`, `IntervalRing.Instance : IRing<IntervalWeight>` |
| 7 | All semiring tests pass; `TropicalSemiring` non-`IRing` test present | ✓ 25/25 tests |
| 8 | `dotnet build -c Release` → 0 warnings 0 errors | ✓ confirmed |

## Test run

```
dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~Semiring"
Passed! - Failed: 0, Passed: 25, Skipped: 0, Total: 25, Duration: 50 ms
```

## Build

```
dotnet build -c Release
Build succeeded.  0 Warning(s)  0 Error(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)