### PR TITLE
chore: fix BACKLOG.md generated-index drift after #2404 (B-0046.1 missing)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -264,6 +264,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0045](backlog/P2/B-0045-all-schools-all-subjects-universal-substrate-knowledge.md)** All schools, all subjects — universal substrate-knowledge sweep; biology inaugural; trade/vocational equal-or-higher weight
 - [ ] **[B-0045.1](backlog/P2/B-0045.1-biology-stage1-reading-list-scaffold.md)** Biology Stage 1 — reading-list scaffold (inaugural substrate shelf)
 - [ ] **[B-0046](backlog/P2/B-0046-economics-history-factory-need-to-know-substrate.md)** Economics + history factory need-to-know surface — substrate denominated in time/energy not money-extraction; Ammous Bitcoin-Standard candidate-probe gated by yin-yang
+- [ ] **[B-0046.1](backlog/P2/B-0046.1-economics-history-stage1-reading-list-scaffold.md)** Economics + history Stage 1 — reading-list scaffold (substrate shelf)
 - [ ] **[B-0048](backlog/P2/B-0048-3-4-color-theorem-research-track.md)** 3-color / 4-color theorem research track — graph coloring, computer-assisted proof, Gonthier Coq formalization, formal-verification routing
 - [ ] **[B-0049](backlog/P2/B-0049-mystery-schools-comparative-religion-history-of-religion.md)** Mystery schools / comparative religion / history of religion research track — CATALOG-ONLY register, gentle, no claim-staking
 - [ ] **[B-0050](backlog/P2/B-0050-lean-reflection-capability-skill-staged-trajectory.md)** Lean reflection — learn it properly, land a capability skill + scouting note (staged 5-stage trajectory)


### PR DESCRIPTION
## Summary

- PR #2404 (B-0046.1) merged with a non-required CI failure on `check docs/BACKLOG.md generated-index drift`
- The B-0046.1 per-row file was added but `docs/BACKLOG.md` was not regenerated before merge
- This PR runs `BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts` to sync the generated index with the per-row files on main

## Root cause

The `backlog-index-integrity` check is non-required, so the PR could merge despite the drift. This PR closes the gap so the index accurately reflects the merged state.

## Test plan

- [ ] CI `check docs/BACKLOG.md generated-index drift` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)