### PR TITLE
feat(B-0048.1): Alloy 3-coloring Stage 1 — ThreeColoring.als probe with K4 chromatic-number check

### DIFF
--- a/docs/backlog/P2/B-0048-3-4-color-theorem-research-track.md
+++ b/docs/backlog/P2/B-0048-3-4-color-theorem-research-track.md
@@ -1,7 +1,7 @@
 ---
 id: B-0048
 priority: P2
-status: in-progress
+status: open
 title: 3-color / 4-color theorem research track — graph coloring, computer-assisted proof, Gonthier Coq formalization, formal-verification routing
 tier: formal-verification-research
 effort: L
@@ -51,7 +51,7 @@ Graph coloring is the paradigmatic CSP. Imani's planner (operator-cost model) al
 - skill-router: `alloy-expert` skill covers Alloy modeling; no graph-coloring spec existed
 - orthogonal-axes: `tools/alloy/specs/` contains `Spine.als` and `InfoTheoreticSharder.als` — pattern clear
 - Otto-364: Alloy 6 / SAT4J already in use; no version drift risk
-- lost-files: `LOST-FILES-LOCATIONS.md` consulted; no orphan graph-coloring artifacts found
+- lost-files: `tools/hygiene/LOST-FILES-LOCATIONS.md` consulted; no orphan graph-coloring artifacts found
 
 **Dependency-restructure:**
 

--- a/docs/backlog/P2/B-0048-3-4-color-theorem-research-track.md
+++ b/docs/backlog/P2/B-0048-3-4-color-theorem-research-track.md
@@ -1,13 +1,13 @@
 ---
 id: B-0048
 priority: P2
-status: open
+status: in-progress
 title: 3-color / 4-color theorem research track — graph coloring, computer-assisted proof, Gonthier Coq formalization, formal-verification routing
 tier: formal-verification-research
 effort: L
 ask: Aaron 2026-04-21 — *"3 4 color theorm backlog"*
 created: 2026-04-26
-last_updated: 2026-05-02
+last_updated: 2026-05-10
 depends_on: []
 composes_with: [B-0050, B-0051, docs/research/chain-rule-proof-log.md, tools/lean4/Lean4/DbspChainRule.lean, .claude/agents/formal-verification-expert.md, feedback_teaching_is_how_we_change_the_current_order_chronology_everything_star.md]
 tags: [graph-coloring, four-color-theorem, three-color, gonthier-coq, appel-haken, formal-verification, lean4, alloy, z3, csp, proof-by-reflection, planar-graphs]
@@ -42,9 +42,24 @@ Appel-Haken 1976 was the first major result where the community had to decide wh
 
 Graph coloring is the paradigmatic CSP. Imani's planner (operator-cost model) already reasons about join-ordering as a CSP; the coloring algorithms (DSATUR, Welsh-Powell, backtracking with constraint-propagation) are structurally cousin to the pipeline-scheduling problems Zeta already solves. Retraction-native twist: can a k-coloring be maintained under additive/subtractive graph deltas without full re-coloring? (Sometimes yes, with bounded recoloring budget — directly relevant to Zeta's incremental-recomputation discipline.)
 
+## Pre-start checklist (2026-05-10)
+
+**Prior-art search:**
+- wake-time-substrate: no prior ThreeColoring substrate found
+- skill-router: `alloy-expert` skill covers Alloy modeling; no graph-coloring spec existed
+- orthogonal-axes: `tools/alloy/specs/` contains `Spine.als` and `InfoTheoreticSharder.als` — pattern clear
+- Otto-364: Alloy 6 / SAT4J already in use; no version drift risk
+- lost-files: `LOST-FILES-LOCATIONS.md` consulted; no orphan graph-coloring artifacts found
+
+**Dependency-restructure:**
+- `depends_on: []` — no blockers
+- `composes_with`: B-0050 (Lean reflection; Stage 3 depends on it), B-0051 (isomorphism catalog); pointers already present
+
+**Stage 1 landed:** `tools/alloy/specs/ThreeColoring.als` (3 commands: `run Find3Coloring`, `check NoMonochromaticEdge`, `check K4HasNo3Coloring`). Registered in `run-alloy.ts` CATALOGUE and `Alloy.Runner.Tests.fs`. PR feat/B-0048.1-alloy-3-coloring-stage1.
+
 ## Scope (staged)
 
-- **Stage 1 — Alloy-scale finite 3-coloring probe:** small `docs/3Coloring.als` modelling a tiny graph + `check NoMonochromaticEdge for 5`. Effort: S.
+- **Stage 1 — Alloy-scale finite 3-coloring probe:** `tools/alloy/specs/ThreeColoring.als` — 5-vertex scope, 3 commands (Find3Coloring run, NoMonochromaticEdge check, K4HasNo3Coloring check). Effort: S. **DONE 2026-05-10.**
 - **Stage 2 — Z3 chromatic-number upper-bound search:** `tools/z3/chromatic.smt2` encoding. Test on benchmark graphs (Petersen graph, Mycielski constructions). Effort: S.
 - **Stage 3 — Lean 4 + Mathlib chromatic-number reading group:** port a small exercise from `Mathlib.Combinatorics.SimpleGraph.Coloring` into `tools/lean4/Lean4/GraphColoring.lean`. Effort: M.
 - **Stage 4 — four-color case study (Gonthier-following):** read Gonthier's paper; trace how the reducibility predicate and discharging method factor through Coq reflection; produce `docs/research/gonthier-four-color-walkthrough-YYYY-MM-DD.md`. **Primary teaching target** — downstream of Stage 1+ of the Lean-reflection row (B-0050). Effort: L.

--- a/docs/backlog/P2/B-0048-3-4-color-theorem-research-track.md
+++ b/docs/backlog/P2/B-0048-3-4-color-theorem-research-track.md
@@ -12,6 +12,7 @@ depends_on: []
 composes_with: [B-0050, B-0051, docs/research/chain-rule-proof-log.md, tools/lean4/Lean4/DbspChainRule.lean, .claude/agents/formal-verification-expert.md, feedback_teaching_is_how_we_change_the_current_order_chronology_everything_star.md]
 tags: [graph-coloring, four-color-theorem, three-color, gonthier-coq, appel-haken, formal-verification, lean4, alloy, z3, csp, proof-by-reflection, planar-graphs]
 type: feature
+
 ---
 
 # B-0048 — 3-color / 4-color theorem research track
@@ -45,6 +46,7 @@ Graph coloring is the paradigmatic CSP. Imani's planner (operator-cost model) al
 ## Pre-start checklist (2026-05-10)
 
 **Prior-art search:**
+
 - wake-time-substrate: no prior ThreeColoring substrate found
 - skill-router: `alloy-expert` skill covers Alloy modeling; no graph-coloring spec existed
 - orthogonal-axes: `tools/alloy/specs/` contains `Spine.als` and `InfoTheoreticSharder.als` — pattern clear
@@ -52,6 +54,7 @@ Graph coloring is the paradigmatic CSP. Imani's planner (operator-cost model) al
 - lost-files: `LOST-FILES-LOCATIONS.md` consulted; no orphan graph-coloring artifacts found
 
 **Dependency-restructure:**
+
 - `depends_on: []` — no blockers
 - `composes_with`: B-0050 (Lean reflection; Stage 3 depends on it), B-0051 (isomorphism catalog); pointers already present
 

--- a/tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs
@@ -207,6 +207,11 @@ let ``Alloy spec InfoTheoreticSharder rules out double commits`` () =
 
 
 [<Fact>]
+let ``Alloy spec ThreeColoring 3-coloring probe and K4 no-3-coloring check`` () =
+    assertSpecValid "ThreeColoring"
+
+
+[<Fact>]
 let ``Alloy jar is installed where tools/setup/install.sh drops it`` () =
     // Informational gate: fails when someone forgets to re-run
     // `tools/setup/install.sh`. Keeps the "why is the runner

--- a/tools/alloy/specs/ThreeColoring.als
+++ b/tools/alloy/specs/ThreeColoring.als
@@ -13,8 +13,8 @@
 // searches; Lean + Mathlib handles theorem-level closure (Stage 3+).
 //
 // Commands and expected outcomes (per AlloyRunner protocol):
-//   run  Find3Coloring         — SAT   (K3 triangle fits in scope 5)
-//   check NoMonochromaticEdge  — OK    (encoding soundness, tautological)
+//   run  Find3Coloring         — SAT   (genuinely 3-chromatic witness; all 3 colors used)
+//   check NoMonochromaticEdge  — OK    (non-tautological encoding consistency guard)
 //   check K4HasNo3Coloring     — OK    (K4 chromatic number = 4, no 3-coloring)
 
 module ThreeColoring
@@ -45,23 +45,29 @@ pred ProperColoring {
 }
 
 // ── Run 1: find a proper 3-coloring of a non-trivial graph ───────────────────
-// The triangle (K3) is 3-colorable and fits comfortably in scope 5.
+// Constrain all three colors to appear so the witness must be genuinely
+// 3-chromatic (a single-edge + isolated-vertices would only need 2 colors).
+// Color in Vertex.color asserts every Color atom is the color of some Vertex.
 // AlloyRunner expects SAT here: the run finds an instance => OK.
 
 run Find3Coloring {
   ProperColoring
   some adj
+  Color in Vertex.color  -- all 3 colors used; ensures a genuinely 3-chromatic structure
 } for 5 but 5 Vertex
 
-// ── Check 1: encoding soundness ───────────────────────────────────────────────
-// ProperColoring is definitionally equivalent to "no monochromatic edge."
-// Asserting this tautology and checking it within scope 5 verifies that the
-// predicate encoding has no bugs that would silently allow monochromatic edges.
-// AlloyRunner expects UNSAT (no counterexample) => OK.
+// ── Check 1: encoding consistency guard ──────────────────────────────────────
+// HasMonochromaticEdge independently encodes the negation of ProperColoring.
+// Asserting their equivalence (ProperColoring <=> not HasMonochromaticEdge)
+// is a non-tautological regression guard: if either definition drifts, Alloy
+// finds a counterexample. AlloyRunner expects UNSAT (no counterexample) => OK.
+
+pred HasMonochromaticEdge {
+  some u, v: Vertex | u in v.adj and u.color = v.color
+}
 
 assert NoMonochromaticEdge {
-  ProperColoring =>
-    (all u, v: Vertex | u in v.adj => u.color != v.color)
+  ProperColoring <=> not HasMonochromaticEdge
 }
 check NoMonochromaticEdge for 5
 

--- a/tools/alloy/specs/ThreeColoring.als
+++ b/tools/alloy/specs/ThreeColoring.als
@@ -1,0 +1,83 @@
+// Alloy finite model of graph 3-coloring — Stage 1 of B-0048.
+// (3-color / 4-color theorem research track)
+//
+// Vertex-coloring encoding: each Vertex carries its assigned Color as a
+// field; edges form a symmetric, irreflexive adjacency relation enforced
+// by facts. Alloy's SAT4J backend exhaustively explores all graphs up to
+// the declared scope bound, making the checks finite-model proofs.
+//
+// Tool-choice rationale (Soraya routing, B-0048 §"Formal-verification
+// portfolio routing"): Alloy excels at first-order relational structure.
+// For 3-coloring — NP-complete on general graphs — Alloy handles small
+// bounded instances exactly; Z3 SMT (Stage 2) handles larger k-bounded
+// searches; Lean + Mathlib handles theorem-level closure (Stage 3+).
+//
+// Commands and expected outcomes (per AlloyRunner protocol):
+//   run  Find3Coloring         — SAT   (K3 triangle fits in scope 5)
+//   check NoMonochromaticEdge  — OK    (encoding soundness, tautological)
+//   check K4HasNo3Coloring     — OK    (K4 chromatic number = 4, no 3-coloring)
+
+module ThreeColoring
+
+// ── Three colors ─────────────────────────────────────────────────────────────
+
+abstract sig Color {}
+one sig Red, Green, Blue extends Color {}
+
+// ── Graph ─────────────────────────────────────────────────────────────────────
+
+sig Vertex {
+  adj  : set Vertex,  -- adjacency neighbours
+  color: one Color    -- coloring assignment (exactly one per vertex)
+}
+
+// Edges are undirected (symmetric) and have no self-loops (irreflexive).
+// ~adj is the relational transpose (converse) of adj.
+// iden is the identity relation {v->v | v : Vertex}.
+fact Undirected { adj = ~adj }
+fact NoSelfLoop { no iden & adj }
+
+// ── Coloring predicate ────────────────────────────────────────────────────────
+
+// A coloring is proper when no two adjacent vertices share a color.
+pred ProperColoring {
+  all u, v: Vertex | u in v.adj => u.color != v.color
+}
+
+// ── Run 1: find a proper 3-coloring of a non-trivial graph ───────────────────
+// The triangle (K3) is 3-colorable and fits comfortably in scope 5.
+// AlloyRunner expects SAT here: the run finds an instance => OK.
+
+run Find3Coloring {
+  ProperColoring
+  some adj
+} for 5 but 5 Vertex
+
+// ── Check 1: encoding soundness ───────────────────────────────────────────────
+// ProperColoring is definitionally equivalent to "no monochromatic edge."
+// Asserting this tautology and checking it within scope 5 verifies that the
+// predicate encoding has no bugs that would silently allow monochromatic edges.
+// AlloyRunner expects UNSAT (no counterexample) => OK.
+
+assert NoMonochromaticEdge {
+  ProperColoring =>
+    (all u, v: Vertex | u in v.adj => u.color != v.color)
+}
+check NoMonochromaticEdge for 5
+
+// ── Check 2: K4 requires 4 colors (chromatic number = 4) ─────────────────────
+// K4 is the complete graph on 4 vertices — every pair of vertices is adjacent.
+// Its chromatic number is 4, so no proper 3-coloring can exist.
+// Alloy exhaustively explores all 4-vertex graphs with all 3-color assignments
+// and confirms no valid 3-coloring of K4 exists within scope 4.
+// AlloyRunner expects UNSAT (no counterexample) => OK.
+
+pred IsK4 {
+  #Vertex = 4
+  all disj u, v: Vertex | u in v.adj
+}
+
+assert K4HasNo3Coloring {
+  IsK4 => not ProperColoring
+}
+check K4HasNo3Coloring for 4

--- a/tools/formal-verification/run-alloy.ts
+++ b/tools/formal-verification/run-alloy.ts
@@ -31,6 +31,7 @@ const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
 const CATALOGUE: readonly string[] = [
   "Spine",
   "InfoTheoreticSharder",
+  "ThreeColoring",
 ];
 
 function repoRoot(): string {


### PR DESCRIPTION
## Summary

- Adds `tools/alloy/specs/ThreeColoring.als` — Stage 1 of B-0048 (3-color / 4-color theorem research track)
- Three Alloy commands driven by the existing SAT4J-backed `AlloyRunner.java`:
  - `run Find3Coloring` — finds a proper 3-coloring instance in scope 5 (K3 triangle fits)
  - `check NoMonochromaticEdge` — encoding soundness verification (tautological, scope 5)
  - `check K4HasNo3Coloring` — bounded proof that the complete 4-vertex graph (K4) has no proper 3-coloring (scope 4); first formal-verification evidence that K4 needs chromatic number > 3
- Wired into `run-alloy.ts` `CATALOGUE` and `Alloy.Runner.Tests.fs` `[<Fact>]`
- Backlog item updated: Stage 1 marked done, pre-start checklist appended, status → in-progress

## Formal-verification context (Soraya routing, B-0048 §1)

3-coloring is NP-complete on general graphs — Alloy's exhaustive finite-model search is the right tool for small bounded instances. The K4 check is particularly interesting: Alloy's SAT4J solver exhaustively confirms no assignment of {Red, Green, Blue} can properly color K4 within scope 4, which is a model-bounded proof that K4's chromatic number exceeds 3. Stages 2–5 (Z3 SMT, Lean + Mathlib, Gonthier walkthrough, retraction-native incremental coloring) remain open.

## Build gate

```
dotnet build -c Release
→ 0 Warning(s) / 0 Error(s)
```

## Alloy toolchain check

```
bun tools/formal-verification/run-alloy.ts --check-toolchain
→ ERROR: Alloy toolchain not ready (no JDK on dev macOS)
```

macOS devboxes without JDK: `toolchainReady()` in `Alloy.Runner.Tests.fs` skips gracefully. CI (Linux x64 with JDK ≥ 17) will execute the three commands.

The spec syntax follows the same conventions as `Spine.als` and `InfoTheoreticSharder.als` (already passing in CI).

## Checklist

- [x] `tools/alloy/specs/ThreeColoring.als` created
- [x] `tools/formal-verification/run-alloy.ts` CATALOGUE updated
- [x] `tests/Tests.FSharp/Formal/Alloy.Runner.Tests.fs` `[<Fact>]` added
- [x] `docs/backlog/P2/B-0048-3-4-color-theorem-research-track.md` pre-start checklist + Stage 1 done marker
- [x] `dotnet build -c Release` → 0 warnings 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)