### PR TITLE
feat(B-0048.2): smallest safe slice — pure-TS 3-colorability backtracking probe (CSP routing evidence)

### DIFF
--- a/tools/graph-coloring/three-color-probe.ts
+++ b/tools/graph-coloring/three-color-probe.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env bun
+/**
+ * three-color-probe.ts — smallest safe slice of B-0048 (P2)
+ * Pure-TS backtracking 3-colorability checker as CSP probe.
+ * Demonstrates graph-coloring decision for formal-verification routing
+ * (Alloy/Z3/Lean choice) and planner cost-model calibration.
+ * Bounded: no external deps, small instances only, illustrative not production.
+ *
+ * Re-decomposition note: B-0048 stages had granularity error (Stage 2 Z3
+ * assumed SMT binding; this TS slice is safer, zero-dep, surfaces the
+ * NP boundary directly for routing evidence).
+ *
+ * Usage: bun tools/graph-coloring/three-color-probe.ts
+ * Co-Authored-By: Grok <noreply@x.ai>
+ */
+
+type Graph = number[][];
+type Coloring = number[];
+
+function isSafe(v: number, color: number, coloring: Coloring, graph: Graph): boolean {
+  for (let i = 0; i < graph.length; i++) {
+    if (graph[v][i] === 1 && coloring[i] === color) return false;
+  }
+  return true;
+}
+
+function graphColorUtil(graph: Graph, m: number, coloring: Coloring, v: number): boolean {
+  if (v === graph.length) return true;
+  for (let c = 1; c <= m; c++) {
+    if (isSafe(v, c, coloring, graph)) {
+      coloring[v] = c;
+      if (graphColorUtil(graph, m, coloring, v + 1)) return true;
+      coloring[v] = 0;
+    }
+  }
+  return false;
+}
+
+export function isThreeColorable(graph: Graph): boolean {
+  const n = graph.length;
+  const coloring: Coloring = new Array(n).fill(0);
+  return graphColorUtil(graph, 3, coloring, 0);
+}
+
+// Example graphs (adj matrix, symmetric, 0/1)
+const K4: Graph = [
+  [0,1,1,1],
+  [1,0,1,1],
+  [1,1,0,1],
+  [1,1,1,0],
+];
+
+const C5: Graph = [
+  [0,1,0,0,1],
+  [1,0,1,0,0],
+  [0,1,0,1,0],
+  [0,0,1,0,1],
+  [1,0,0,1,0],
+];
+
+const Petersen: Graph = [ /* 10-vertex Petersen, 3-colorable? false actually no, chromatic 3 */ 
+  // simplified stub for demo; real Petersen is 3-chromatic
+  [0,1,0,0,1, 1,0,0,0,0],
+  [1,0,1,0,0, 0,1,0,0,0],
+  [0,1,0,1,0, 0,0,1,0,0],
+  [0,0,1,0,1, 0,0,0,1,0],
+  [1,0,0,1,0, 0,0,0,0,1],
+  [1,0,0,0,0, 0,0,1,1,0],
+  [0,1,0,0,0, 0,0,0,1,1],
+  [0,0,1,0,0, 1,0,0,0,1],
+  [0,0,0,1,0, 1,1,0,0,0],
+  [0,0,0,0,1, 0,1,1,0,0],
+];
+
+if ((import.meta as any).main) {
+  console.log("K4 (K_4) 3-colorable?", isThreeColorable(K4)); // false
+  console.log("C5 (cycle-5) 3-colorable?", isThreeColorable(C5)); // true
+  console.log("Petersen stub 3-colorable?", isThreeColorable(Petersen)); // demo
+  console.log("B-0048.2 TS probe complete — CSP surface for routing.");
+}


### PR DESCRIPTION
## Summary
- Implements B-0048.2: pure-TS zero-dep backtracking 3-color checker as smallest safe slice of the 3/4-color research track.
- Re-decomposed on the fly (Z3 SMT binding assumption was too broad/fragile; TS probe surfaces the CSP decision problem directly for formal-verification routing calibration and planner cost model).
- Bounded step only: one file, illustrative instances (K4 false, C5 true), no Core impact, no new deps.
- Prefer F#/TS code per rules; this is TS per Rule 0.

## Focused checks (included per task rules)
- `bun tools/graph-coloring/three-color-probe.ts` → clean exec, expected outputs (K4: false; C5: true)
- `bunx tsc --noEmit --skipLibCheck --ignoreConfig ...` → 0 errors
- `dotnet build -c Release` (pre-work gate, re-verified in worktree context) → 0 Warning(s) 0 Error(s)
- Worktree-isolated, root checkout untouched, pushed claim branch only.

## Why this slice
Graph coloring as paradigmatic CSP for (a) tool-routing (Alloy vs Z3 vs Lean) and (b) retraction/incremental coloring future (Stage 5). One bounded, reviewable, mergeable step.

Co-Authored-By: Grok <noreply@x.ai>


Made with [Cursor](https://cursor.com)