### PR TITLE
feat(B-0050.1): Lean reflection Stage 1 — read-only competence skill + scouting note

### DIFF
--- a/.claude/skills/lean-reflection-expert/SKILL.md
+++ b/.claude/skills/lean-reflection-expert/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: lean-reflection-expert
+description: "Lean 4 reflection and metaprogramming — read and diagnose code using MetaM, TermElabM, TacticM, macro, elab_rules, Syntax/Expr pipeline, @[simp]/@[reducible]/@[irreducible] attributes. Stage 1: read-only competence. Complements lean4-expert (build/proofs). Routes from formal-verification-expert when the question is about Lean metaprogramming rather than proof strategy."
+stage: 1
+backlog: B-0050
+---
+
+# Lean 4 Reflection Expert — Stage 1 (Read-Only Competence)
+
+Capability skill. Stage 1 only: read and diagnose existing Lean 4
+metaprogramming code. Does NOT yet author new tactics, macros, or
+elaborators (Stages 2-5).
+
+Complements `lean4-expert` (which covers `lake build`, tactic basics,
+Mathlib imports, sorry discipline). This skill covers the layer beneath
+the user-facing tactics — the metaprogramming infrastructure that BUILDS
+them.
+
+## When to wear
+
+- Reading Lean 4 code that uses `MetaM`, `TermElabM`, `TacticM`
+- Diagnosing elaboration errors ("type mismatch", "failed to synthesize")
+- Explaining what a `macro`, `macro_rules`, `elab`, or `elab_rules`
+  definition does
+- Explaining what `@[simp]`, `@[reducible]`, `@[irreducible]`,
+  `@[deprecated]` attributes do to a definition
+- Navigating Mathlib tactic source code to understand how a tactic works
+- Answering "what does this `Syntax`/`Expr` code do?"
+
+## The three-stage pipeline
+
+```
+Source text
+    │
+[1] Parser → Syntax (no semantics, just structure)
+    │
+    ▼ macro expansion (Syntax → Syntax, recursive)
+[2] Macros
+    │
+    ▼
+[3] Elaborator → Expr (typed AST, de Bruijn-indexed)
+    │
+Type-checker → kernel-verified proof term
+```
+
+**Macros** = pure syntax rewriting (no type information).
+**Elaborators** = produce typed `Expr` (have type information, can
+call back into elaboration). The two are cleanly separated.
+
+## The monad stack
+
+```
+CoreM           — global environment (all constants/definitions)
+  └── MetaM     — metavariable context (unsolved goals, local contexts)
+        └── TermElabM  — term elaboration state (typeclass deferral, etc.)
+              └── TacticM    — current proof goal list
+```
+
+Each monad can run those below it. Read the return type's monad to know
+what the computation has access to.
+
+### `MetaM` — key operations to recognize
+
+```lean
+mkFreshExprMVar (type? : Option Expr) : MetaM Expr
+  -- creates a "hole" (unknown term) of the given type
+
+assign (mvarId : MVarId) (val : Expr) : MetaM Unit
+  -- fills a hole with a proof term
+
+instantiateMVars (e : Expr) : MetaM Expr
+  -- substitute all assigned holes into an expression
+
+inferType (e : Expr) : MetaM Expr
+  -- what type does this expression have?
+
+isDefEq (a b : Expr) : MetaM Bool
+  -- are these two types definitionally equal (unifiable)?
+```
+
+### `TermElabM` — term elaborator signature
+
+```lean
+def myElab (stx : Syntax) (expectedType? : Option Expr) : TermElabM Expr
+```
+
+When you see this signature, the function converts a parse tree
+(`Syntax`) into a typed expression (`Expr`), with optional type hint.
+
+### `TacticM` — tactic implementation pattern
+
+```lean
+def myTactic : TacticM Unit := do
+  let goal ← getMainGoal           -- current goal MVarId
+  let goalType ← inferType (mkMVar goal)  -- what we need to prove
+  closeMainGoal proofTerm           -- close goal with proof term
+```
+
+## Syntax and quotations
+
+**Quotation syntax (backticks):**
+
+```lean
+`(term| $a + $b)        -- match/construct addition syntax
+`(tactic| ring)         -- syntax node for the `ring` tactic
+`($x:ident)             -- anti-quotation: insert/extract identifier
+`(term| if $c then $t else $e)  -- conditional
+$[...],*                -- splice: zero-or-more comma-separated items
+```
+
+Backtick expressions create or pattern-match `Syntax` objects.
+Anti-quotations (`$x`) are the "holes" — they bind variables
+into/from the syntax tree.
+
+## Macro vs. elab
+
+| Feature | Input → Output | Monad | When to use |
+|---------|----------------|-------|-------------|
+| `macro` / `macro_rules` | Syntax → Syntax | `MacroM` | Pure structural rewriting; no types needed |
+| `elab` / `elab_rules` | Syntax → Expr | `TermElabM` | Need type information or proof search |
+| `@[macro xxx]` | Syntax → Syntax | `MacroM` | Low-level macro registration |
+| `@[command_elab xxx]` | Syntax → `CommandElabM Unit` | `CommandElabM` | Commands (not terms) |
+
+## Attributes — reading guide
+
+| Attribute | What it does |
+|-----------|-------------|
+| `@[simp]` | Register as rewrite rule for the `simp` tactic (LHS → RHS direction) |
+| `@[reducible]` / `abbrev` | Always unfold in proof search (transparent type alias) |
+| `@[semireducible]` (default) | Unfold when needed (default for `def`) |
+| `@[irreducible]` | Never unfold (abstract type; prevents leaking internals) |
+| `@[deprecated name (since := "date")]` | Warning when used; tooling shows replacement |
+| `@[ext]` | Register as extensionality lemma for `ext` tactic |
+| `@[instance]` | Register as typeclass instance for synthesis |
+| `@[inline]` / `@[specialize]` | Compiler hints; not semantically meaningful in proofs |
+
+## What Zeta's code already uses
+
+From `tools/lean4/Lean4/DbspChainRule.lean`:
+
+| Feature | Usage | Reading |
+|---------|-------|---------|
+| `@[simp] theorem zInv_zero` | Auto-applied by `simp [zInv]` | Closes `zInv s 0 = 0` goals automatically |
+| `@[deprecated Dop_LTI_commute]` | Warning on old `chain_rule` name | Points users to `Dop_LTI_commute` |
+| `abbrev ZSet (K) := K →₀ ℤ` | Transparent alias | `ZSet K` and `K →₀ ℤ` are definitionally equal everywhere |
+| `abbrev Stream (G) := ℕ → G` | Transparent alias | Same — `ℕ → G` is always acceptable where `Stream G` is expected |
+| `structure IsLinear (f) : Prop where` | Proof predicate | A record type grouping multiple proof fields (`map_zero`, `map_add`) |
+| `simp [I, zInv]` | Unfold + rewrite | Unfolds `I` and `zInv` definitions, applies all `@[simp]` lemmas |
+| `simp only [lemma1]` | Restricted simp | Only use `lemma1`; no global simp set (more stable across Mathlib bumps) |
+| `funext n` | Function extensionality | Close `f = g` by proving `∀ n, f n = g n` |
+| `obtain ⟨phi, hphi⟩ := hf.pointwise` | Existential destructure | Unpack `∃ phi, ...` hypothesis |
+| `calc expr = ... := ... _ = ... := ...` | Equational chain | Chain of equalities with per-step justifications |
+
+**None of the current Zeta Lean code uses `MetaM`, `TermElabM`, `macro`,
+or `elab_rules` directly.** Those are the Stage 2+ targets.
+
+## Elaboration error reading guide
+
+| Error text | Meaning |
+|-----------|---------|
+| `unknown identifier 'x'` | `x` is not in scope; check binder structure or missing `intro` |
+| `type mismatch, expected T, got U` | Elaborator inferred type U; expected T; check `abbrev` / unfolding |
+| `function expected at f, term has type T` | `f` is not a function — wrong arity or universe level |
+| `failed to synthesize TypeClass instance` | Missing `@[instance]` or ambiguous resolution |
+| `maximum recursion depth reached` | Macro loop or infinite typeclass chain |
+| `metavariable ?m has not been assigned` | A `?` hole was created but never closed |
+| `application type mismatch` | Argument type mismatch — check implicit arguments |
+
+## Mathlib tactic reading pattern
+
+When reading a tactic like `by ring` or `by abel`:
+
+1. `by` switches to `TacticM` mode
+2. `ring` / `abel` are tactic names — elaborated by registered `TacticM`
+   functions from `Mathlib.Tactic.Ring` / `Mathlib.Tactic.Abel`
+3. Each tactic internally calls into `MetaM` to build a proof term
+4. `simp` is special: it runs a simplification engine using all `@[simp]`
+   lemmas registered in the current import context
+
+## Stage 2 prerequisite checklist (not yet implemented)
+
+To move to Stage 2 (tactic authoring), the following are prerequisites:
+- [ ] Understand `MVarId` and what a "goal" looks like as an `Expr`
+- [ ] Understand `closeMainGoal` / `liftMetaTactic` patterns
+- [ ] Write a trivial `TacticM Unit` that closes a goal with `rfl`
+- [ ] Wire it as `macro "my_tactic" : tactic => ...` or `elab_rules : tactic`
+
+## Does NOT do
+
+- Stage 2: Writing new tactics (use when Stage 2 is shipped)
+- Stage 3: Macro/elab authoring (notation, custom syntax)
+- Stage 4: Decision-procedure authoring
+- Stage 5: `aesop`/`polyrith`/`linarith` extension
+- Build/proof mechanics — that's `lean4-expert`
+- Formal-verification routing (Lean vs Z3 vs TLA+) — that's
+  `formal-verification-expert`
+- Algebra correctness sign-off — that's `algebra-owner`
+- Paper-level proof rigor — that's `paper-peer-reviewer`
+
+## Reference
+
+- Scouting note: `docs/research/lean-reflection-stage-1-notes-2026-05-10.md`
+- Real proof surface: `tools/lean4/Lean4/DbspChainRule.lean`
+- Complementary skill: `.claude/skills/lean4-expert/SKILL.md`
+- Routing authority: `.claude/skills/formal-verification-expert/SKILL.md`
+- Primary reading: `https://leanprover-community.github.io/lean4-metaprogramming-book/`

--- a/.claude/skills/lean-reflection-expert/SKILL.md
+++ b/.claude/skills/lean-reflection-expert/SKILL.md
@@ -180,6 +180,7 @@ When reading a tactic like `by ring` or `by abel`:
 ## Stage 2 prerequisite checklist (not yet implemented)
 
 To move to Stage 2 (tactic authoring), the following are prerequisites:
+
 - [ ] Understand `MVarId` and what a "goal" looks like as an `Expr`
 - [ ] Understand `closeMainGoal` / `liftMetaTactic` patterns
 - [ ] Write a trivial `TacticM Unit` that closes a goal with `rfl`

--- a/docs/backlog/P2/B-0050-lean-reflection-capability-skill-staged-trajectory.md
+++ b/docs/backlog/P2/B-0050-lean-reflection-capability-skill-staged-trajectory.md
@@ -12,6 +12,7 @@ depends_on: []
 composes_with: [tools/lean4/Lean4/DbspChainRule.lean, docs/research/chain-rule-proof-log.md, docs/research/stainback-conjecture-fix-at-source.md, B-0048, B-0051, feedback_teaching_is_how_we_change_the_current_order_chronology_everything_star.md, .claude/agents/formal-verification-expert.md]
 tags: [lean4, reflection, metaprogramming, mathlib, proof-automation, tactic-authoring, custom-elaborators, formal-verification, stainback-conjecture, ceramist-port]
 type: friction-reducer
+
 ---
 
 # B-0050 — Lean reflection capability skill + scouting note
@@ -62,6 +63,7 @@ If Aaron meant "reflection" in the general programming sense (C#/F#/Java runtime
 ## Pre-start checklist (Stage 1 — 2026-05-10)
 
 **Prior-art search axes:**
+
 - `wake-time-substrate`: no existing `lean-reflection-expert` skill or memory file found
 - `skill-router`: `lean4-expert` skill covers `lake build`, tactic basics, Mathlib — does NOT cover `MetaM`/`TermElabM`/`macro`/`elab_rules`; `formal-verification-expert` routes Lean vs Z3 vs TLA+ but is not a metaprogramming lore skill
 - `orthogonal-axes`: `lean4-expert` and `lean-reflection-expert` are clearly orthogonal (build+proof-basics vs metaprogramming+reflection)
@@ -72,14 +74,17 @@ If Aaron meant "reflection" in the general programming sense (C#/F#/Java runtime
 - `honor-those-that-came-before`: no `memory/persona/<lean-reflection>` folder; no retired SKILL.md; safe to mint new
 
 **Dependency restructure:**
+
 - `depends_on: []` — no blockers
 - `composes_with` pointers verified: `DbspChainRule.lean` exists at `tools/lean4/Lean4/DbspChainRule.lean` ✓; `chain-rule-proof-log.md` and `stainback-conjecture-fix-at-source.md` are in `docs/research/` ✓
 
 **Stage 1 implementation (this PR):**
+
 - `docs/research/lean-reflection-stage-1-notes-2026-05-10.md` — scouting note
 - `.claude/skills/lean-reflection-expert/SKILL.md` — Stage 1 read-only reflection competence skill
 
 **Does NOT implement:**
+
 - Stages 2-5 (tactic authoring, macro/elab authoring, decision procedures, proof-automation integration)
 - Any new Lean proof files
 

--- a/docs/backlog/P2/B-0050-lean-reflection-capability-skill-staged-trajectory.md
+++ b/docs/backlog/P2/B-0050-lean-reflection-capability-skill-staged-trajectory.md
@@ -7,7 +7,7 @@ tier: formal-verification-tooling-skill
 effort: L
 ask: Aaron 2026-04-21 — *"laern reflection backlog"*. Primary reading in context: Lean 4 reflection (MetaM/TermElabM/macros/tactic authoring/custom elaborators).
 created: 2026-04-26
-last_updated: 2026-05-02
+last_updated: 2026-05-10
 depends_on: []
 composes_with: [tools/lean4/Lean4/DbspChainRule.lean, docs/research/chain-rule-proof-log.md, docs/research/stainback-conjecture-fix-at-source.md, B-0048, B-0051, feedback_teaching_is_how_we_change_the_current_order_chronology_everything_star.md, .claude/agents/formal-verification-expert.md]
 tags: [lean4, reflection, metaprogramming, mathlib, proof-automation, tactic-authoring, custom-elaborators, formal-verification, stainback-conjecture, ceramist-port]
@@ -58,6 +58,32 @@ If Aaron meant "reflection" in the general programming sense (C#/F#/Java runtime
 - Building a bespoke tactic framework before Stage 1 is solid (premature abstraction trap).
 - Rewriting the chain-rule proof in tactics (the hand-written proof is teaching-surface; tactics come later as amortization).
 - Using reflection to break static guarantees elsewhere in the factory (reflection is a Lean-proof tool; factory source code stays statically verifiable).
+
+## Pre-start checklist (Stage 1 — 2026-05-10)
+
+**Prior-art search axes:**
+- `wake-time-substrate`: no existing `lean-reflection-expert` skill or memory file found
+- `skill-router`: `lean4-expert` skill covers `lake build`, tactic basics, Mathlib — does NOT cover `MetaM`/`TermElabM`/`macro`/`elab_rules`; `formal-verification-expert` routes Lean vs Z3 vs TLA+ but is not a metaprogramming lore skill
+- `orthogonal-axes`: `lean4-expert` and `lean-reflection-expert` are clearly orthogonal (build+proof-basics vs metaprogramming+reflection)
+- `Otto-364 search-first`: searched `leanprover-community.github.io/lean4-metaprogramming-book/` — authoritative, current; key resources verified: Lean 4 metaprogramming book (2024), Lean 4 official docs (v4.x)
+- `PR #1701 prior-art grep`: no prior lean-reflection PRs found
+- `decision-archaeology`: no retired lean-reflection skills in `git log --diff-filter=D -- .claude/skills/lean-reflection*`
+- `lost-files canonical`: `tools/hygiene/LOST-FILES-LOCATIONS.md` not checked for lean-reflection orphans (no prior work expected)
+- `honor-those-that-came-before`: no `memory/persona/<lean-reflection>` folder; no retired SKILL.md; safe to mint new
+
+**Dependency restructure:**
+- `depends_on: []` — no blockers
+- `composes_with` pointers verified: `DbspChainRule.lean` exists at `tools/lean4/Lean4/DbspChainRule.lean` ✓; `chain-rule-proof-log.md` and `stainback-conjecture-fix-at-source.md` are in `docs/research/` ✓
+
+**Stage 1 implementation (this PR):**
+- `docs/research/lean-reflection-stage-1-notes-2026-05-10.md` — scouting note
+- `.claude/skills/lean-reflection-expert/SKILL.md` — Stage 1 read-only reflection competence skill
+
+**Does NOT implement:**
+- Stages 2-5 (tactic authoring, macro/elab authoring, decision procedures, proof-automation integration)
+- Any new Lean proof files
+
+---
 
 ## Cross-reference
 

--- a/docs/research/lean-reflection-stage-1-notes-2026-05-10.md
+++ b/docs/research/lean-reflection-stage-1-notes-2026-05-10.md
@@ -1,0 +1,397 @@
+# Lean 4 Reflection / Metaprogramming — Stage 1 Scouting Notes
+
+**Date:** 2026-05-10  
+**Stage:** 1 — Read-only reflection competence  
+**Backlog row:** B-0050 (P2)  
+**Teaching discipline:** additive-layering, Mr-Khan-pedagogy posture — free to read, prior understanding preserved
+
+---
+
+## Purpose
+
+Stage 1 goal: be able to **read** Lean 4 code that uses `MetaM`, `TermElabM`,
+`macro`, `elab_rules`, and attributes (`@[simp]`, `@[reducible]`, `@[deprecated]`)
+and explain what each piece does. Navigate Mathlib tactic code with comprehension.
+Diagnose elaboration errors by tracing the `Syntax → Expr` pipeline.
+
+This note covers what we need to know at Stage 1. It is the teachable artifact
+per the teaching-discipline commitment in B-0050 — the next learner (human or
+agent) picks up from here.
+
+---
+
+## The Three-Stage Lean 4 Compilation Pipeline
+
+```
+Source text
+    │
+    ▼
+[1] Parser → Syntax (parse tree, no semantics, just structure)
+    │
+    ▼ (macro expansion — Syntax → Syntax, recursive until fixed point)
+[2] Macros
+    │
+    ▼
+[3] Elaborator → Expr (typed AST, semantics, de Bruijn-indexed)
+    │
+    ▼
+Type-checker → kernel-checked proof term
+```
+
+**Key insight:** Macros are pure syntax manipulation (no type information).
+Elaborators introduce types and resolve references. The two are cleanly separated.
+When you read metaprogramming code, the first question is: which stage does
+this code live in?
+
+---
+
+## Core Data Types
+
+### `Syntax`
+
+A parse tree node. No semantic meaning — just structure. Produced by parsing,
+consumed by macros and elaborators.
+
+```lean
+-- The `Syntax` type has four variants:
+-- Syntax.missing  — parse error placeholder
+-- Syntax.node k children  — internal node (k = SyntaxNodeKind = Name)
+-- Syntax.atom info val  — terminal (a string like "+" or "if")
+-- Syntax.ident info rawVal val pre  — identifier
+```
+
+When you see `stx : Syntax` in code, you're reading code that works with
+raw parse trees — usually a macro or the entry point of an elaborator.
+
+**Quotation syntax (backticks):** The primary way to work with `Syntax`.
+
+```lean
+`(term| $a + $b)     -- match or construct an addition expression
+`(tactic| ring)      -- a syntax node for the `ring` tactic
+`($x:ident)          -- anti-quotation: insert variable x as an identifier
+```
+
+Anti-quotations (`$x`) splice variables into or extract variables from syntax
+trees. The category annotation (`:term`, `:ident`, `:tactic`) tells the parser
+what syntactic category to use.
+
+### `Expr`
+
+The internal AST. Fully typed, de Bruijn-indexed (variables are numbers, not
+names — avoids capture). Produced by elaboration, consumed by the kernel.
+
+```lean
+-- Key Expr constructors:
+Expr.bvar (deBruijn : Nat)       -- bound variable (number = distance to binder)
+Expr.fvar (id : FVarId)          -- free variable in local context
+Expr.mvar (id : MVarId)          -- metavariable (unsolved goal / placeholder)
+Expr.const (name : Name) (levels) -- reference to a global definition
+Expr.app (f arg : Expr)          -- function application
+Expr.lam (binderName : Name) (binderType body : Expr) (bi : BinderInfo)
+Expr.forallE (binderName : Name) (binderType body : Expr) (bi : BinderInfo)
+Expr.letE (declName : Name) (type val body : Expr) (nonDep : Bool)
+Expr.lit (val : Literal)         -- numeric / string literals
+Expr.sort (u : Level)            -- `Type u`, `Prop` = `Sort 0`
+```
+
+When you see `e : Expr` in code, you're in elaboration or proof-term manipulation
+territory.
+
+---
+
+## The Monad Stack
+
+Each layer adds more state/context. The stack is:
+
+```
+CoreM           — global environment (all known definitions/constants)
+  └── MetaM     — metavariable context (unsolved goals, local contexts)
+        └── TermElabM  — term elaboration state (pending synthesis, etc.)
+              └── TacticM    — list of current proof goals
+```
+
+Every monad can run those below it: `MetaM` can call `CoreM`; `TermElabM`
+can call `MetaM`; `TacticM` can call `TermElabM`. Reading code, look at the
+return type's monad to know what context the computation has access to.
+
+### `CoreM`
+
+Access to the global `Environment` — the set of all declared constants,
+inductive types, and their definitions.
+
+```lean
+getEnv : CoreM Environment
+getConst (name : Name) : CoreM (Option ConstantInfo)
+```
+
+### `MetaM`
+
+The key metaprogramming monad. Adds metavariable context (a mapping from
+`MVarId` to assigned/unassigned `Expr`s) and local contexts (`LocalContext`
+— the variables in scope at a given proof state).
+
+```lean
+-- Create a fresh metavariable (a "hole" to fill later)
+mkFreshExprMVar (type? : Option Expr) : MetaM Expr
+
+-- Assign a metavariable
+assign (mvarId : MVarId) (val : Expr) : MetaM Unit
+
+-- Substitute all assigned metavariables into an expression
+instantiateMVars (e : Expr) : MetaM Expr
+
+-- Run computation in a local context (the hypotheses available in a proof)
+withLocalContext (lctx : LocalContext) (m : MetaM α) : MetaM α
+
+-- Infer the type of an expression
+inferType (e : Expr) : MetaM Expr
+
+-- Check definitional equality (unification)
+isDefEq (a b : Expr) : MetaM Bool
+```
+
+When you see `MetaM`, the code is doing proof-search-level manipulation —
+creating unknown terms, checking if two types are the same, filling in
+implicit arguments.
+
+### `TermElabM`
+
+Used inside term elaborators (the functions that turn `Syntax` into `Expr`).
+Adds a layer for handling "synthetic metavariables" — goals that elaboration
+defers for later solving (typeclasses, coercions, tactic blocks).
+
+The signature of a **term elaborator**:
+
+```lean
+-- stx: the Syntax node to elaborate
+-- expectedType?: what type the result should have (can be `none`)
+-- returns: the Expr this syntax elaborates to
+def myElab (stx : Syntax) (expectedType? : Option Expr) : TermElabM Expr := ...
+```
+
+### `TacticM`
+
+Used inside tactic implementations. Has access to the list of current goals
+(`MVarId`s) and can manipulate them.
+
+```lean
+-- Get all current goals
+getGoals : TacticM (List MVarId)
+
+-- Close a goal with a proof term
+closeMainGoal (e : Expr) : TacticM Unit
+
+-- Run a tactic on the main goal
+evalTactic (tactic : Syntax) : TacticM Unit
+```
+
+---
+
+## Macros, `macro_rules`, `elab_rules`
+
+### `macro` / `macro_rules` — Syntax → Syntax
+
+The simplest metaprogramming tool. A macro takes a `Syntax` tree and returns
+a new `Syntax` tree. No type information. Pure structural rewriting.
+
+```lean
+-- Single-rule macro (the `macro` keyword)
+macro "myNotation" x:term "⊕" y:term : term => `($x + $y + 0)
+
+-- Multi-rule macro (the `macro_rules` keyword)
+macro_rules
+  | `(myNotation $x $y) => `($x + $y)
+  | `(myNotation $x) => `($x)
+```
+
+Macros are **hygienic by default**: names introduced in macro expansions are
+scoped to avoid capture. To intentionally expose a name (make it available in
+the caller's scope), use `mkIdent`.
+
+### `elab` / `elab_rules` — Syntax → TermElabM Expr
+
+Used when the expansion needs type information or proof search. The elaborator
+receives the expected type and can create metavariables.
+
+```lean
+-- Single elaborator
+elab "myTerm" : term => do
+  let type ← inferType (mkConst `Nat)
+  return mkConst `Nat.zero
+
+-- Multi-rule elaborator
+elab_rules : term
+  | `(myTerm $x) => elabTerm x none
+```
+
+**Reading rule:** if you see `elab` or `elab_rules`, you're in `TermElabM`
+territory and the code needs type information. If you see `macro` or
+`macro_rules`, it's pure syntax rewriting.
+
+### `@[macro xxx]` and `@[command_elab xxx]`
+
+Lower-level registration: registers a function as the macro/elaborator for
+a syntax kind named `xxx`. The `macro` / `elab` keywords are syntactic sugar
+over these.
+
+---
+
+## Attributes
+
+Attributes are metadata attached to definitions via `@[attrName]`. They tell
+Lean's subsystems how to handle the definition.
+
+### `@[simp]`
+
+Registers a theorem/lemma as a rewrite rule for the `simp` tactic.
+
+```lean
+@[simp] theorem zInv_zero (s : Stream G) : zInv s 0 = 0 := rfl
+```
+
+When `simp` runs, it tries to rewrite the goal using all `@[simp]`-tagged
+lemmas whose LHS matches. Direction: LHS → RHS (LHS is the "complex" form,
+RHS is the "simplified" form).
+
+**Reading `DbspChainRule.lean`:** `zInv_zero` and `zInv_succ` are `@[simp]`
+so that calls to `simp [I, D, zInv]` in the proof automatically close goals
+involving `zInv s 0 = 0`.
+
+### `@[reducible]`
+
+Marks a definition as unfoldable by proof automation. The default is
+`semireducible` (unfolded only when needed); `reducible` means "always unfold."
+`@[irreducible]` means "never unfold" (useful for abstract types).
+
+```lean
+-- In DbspChainRule.lean:
+abbrev ZSet (K : Type _) : Type _ := K →₀ ℤ
+abbrev Stream (G : Type _) : Type _ := ℕ → G
+```
+
+`abbrev` is syntactic sugar for `@[reducible] def` — the type alias is always
+unfolded, so `Stream G` and `ℕ → G` are definitionally equal.
+
+### `@[deprecated]`
+
+Marks a definition as deprecated, producing a warning when used. Takes the
+replacement name.
+
+```lean
+-- In DbspChainRule.lean:
+@[deprecated Dop_LTI_commute (since := "2026-04-19")]
+theorem chain_rule ... := Dop_LTI_commute ...
+```
+
+This is Lean's built-in deprecation system — not a metaprogramming hook, just
+metadata for tooling.
+
+### `@[ext]`
+
+Tags a theorem as an extensionality lemma. The `ext` tactic uses these to
+decompose equality goals.
+
+### `@[simp]` sets management
+
+When reading tactic proofs, `simp [lemma1, lemma2]` adds those lemmas to the
+simp set for that call only. `simp only [lemma1]` restricts to ONLY those
+lemmas (no global `@[simp]` set). The difference matters for proof robustness
+across Mathlib bumps: `simp only` is more stable.
+
+---
+
+## Reading Mathlib Tactic Code
+
+Mathlib uses reflection heavily. The pattern to recognize:
+
+```
+import Mathlib.Tactic.Ring    -- imports the `ring` tactic
+import Mathlib.Tactic.Abel    -- imports the `abel` tactic
+import Mathlib.Tactic.Linarith -- imports the `linarith` tactic
+```
+
+Each of these tactics is implemented as a `TacticM Unit` that manipulates
+the goal list. When you read `by ring` in a proof, you're seeing `TacticM`
+run the `ring` elaborator, which internally calls into `MetaM` to build a
+proof term.
+
+**The pattern in `DbspChainRule.lean` to read:**
+
+```lean
+theorem T3 ... := by
+  induction n with
+  | zero => simp [I, zInv]          -- TacticM: apply induction, simp closes base
+  | succ n ih =>                    -- TacticM: introduce induction hypothesis
+    rw [hL, hR, zInv_succ, ih]      -- TacticM: rewrite using lemmas
+    abel                            -- TacticM: close abelian group identity
+```
+
+Each tactic line is elaborated as a `TacticM Unit` that transforms the goal list.
+`by` switches from term mode to tactic mode.
+
+---
+
+## What Zeta's Lean Code Already Uses (Stage 1 Reading Inventory)
+
+From `tools/lean4/Lean4/DbspChainRule.lean`:
+
+| Feature | Occurrence | What it does |
+|---------|-----------|--------------|
+| `@[simp]` | `zInv_zero`, `zInv_succ` | Auto-close `simp` goals matching these patterns |
+| `@[deprecated]` | `chain_rule` | Warning when old name used; points to `Dop_LTI_commute` |
+| `abbrev` (`@[reducible] def`) | `ZSet`, `Stream` | Transparent type aliases |
+| `structure` | `IsLinear`, `IsCausal`, `IsTimeInvariant`, `IsPointwiseLinear` | Record types used as proof predicates |
+| `theorem`/`lemma` in `by` mode | All proofs | Tactic-mode proof blocks (TacticM) |
+| `simp`, `abel`, `ring`, `rfl` | Throughout | Core tactics from Mathlib |
+| `funext` | `D_I_eq`, `I_D_eq`, etc. | Functional extensionality — closes `f = g` by proving `∀ x, f x = g x` |
+| `cases n with \| zero => ... \| succ n => ...` | Throughout | Pattern-match on `Nat` for inductive proofs |
+| `rw [lemma1, lemma2]` | Throughout | Rewrite goal using equalities |
+| `obtain ⟨phi, hphi⟩ := hf.pointwise` | `IsPointwiseLinear` proofs | Destructure an existential |
+| `calc` | `linear_commute_I` | Chain of equalities with justifications |
+
+**None of the current code uses `MetaM`, `TermElabM`, `macro`, or `elab_rules`
+directly** — all tactic usage goes through Mathlib's pre-built tactics.
+Stage 2 (tactic authoring) is where we'd write code that USES these monads.
+
+---
+
+## Elaboration Error Diagnosis (Stage 1 Level)
+
+Common error patterns and what they mean:
+
+| Error | What it means |
+|-------|--------------|
+| `unknown identifier 'x'` | `x` is not in scope; check binder structure |
+| `type mismatch` | Elaboration inferred type A, expected type B; check `abbrev`/`def` unfolding |
+| `function expected at f` | `f` is not a function — universe or application-order issue |
+| `failed to synthesize TypeClass instance` | Typeclass resolution failed; a `@[instance]` is missing or ambiguous |
+| `maximum recursion depth reached` | Macro loop or infinite type-class search |
+| `metavariable ... has not been assigned` | A `?` placeholder in a term was never resolved |
+
+---
+
+## Authoritative Resources
+
+- **Lean 4 Metaprogramming Book:**
+  `https://leanprover-community.github.io/lean4-metaprogramming-book/`
+  Chapters: Overview, Expressions, MetaM, Syntax, Macros, Elaboration
+- **Lean 4 Official Reference:**
+  `https://lean-lang.org/doc/reference/latest/`
+- **Mathlib4 Metaprogramming wiki:**
+  `https://github.com/leanprover-community/mathlib4/wiki/Metaprogramming-for-dummies`
+
+---
+
+## Stage 2 Preview (next step)
+
+Stage 2 is tactic authoring — writing a simple tactic (e.g., `by decide_retractible`)
+using `TacticM`. The prerequisite from Stage 1: understanding what `MVarId` goals
+look like, how `MetaM` manipulates them, and how `closeMainGoal` closes a goal
+with a proof term. All of that is now in this note.
+
+**Composes with:**
+- `tools/lean4/Lean4/DbspChainRule.lean` — the proof that benefits from Stage 2+
+- B-0051 — isomorphism catalog, IF4 filter
+- B-0048 — 3-colorability (Stage 4 decision procedure target)
+- `.claude/skills/lean4-expert/SKILL.md` — the complementary build/proof skill
+- `.claude/skills/lean-reflection-expert/SKILL.md` — the Stage 1 capability skill (this PR)

--- a/docs/research/lean-reflection-stage-1-notes-2026-05-10.md
+++ b/docs/research/lean-reflection-stage-1-notes-2026-05-10.md
@@ -53,7 +53,9 @@ A parse tree node. No semantic meaning — just structure. Produced by parsing,
 consumed by macros and elaborators.
 
 ```lean
+
 -- The `Syntax` type has four variants:
+
 -- Syntax.missing  — parse error placeholder
 -- Syntax.node k children  — internal node (k = SyntaxNodeKind = Name)
 -- Syntax.atom info val  — terminal (a string like "+" or "if")
@@ -81,6 +83,7 @@ The internal AST. Fully typed, de Bruijn-indexed (variables are numbers, not
 names — avoids capture). Produced by elaboration, consumed by the kernel.
 
 ```lean
+
 -- Key Expr constructors:
 Expr.bvar (deBruijn : Nat)       -- bound variable (number = distance to binder)
 Expr.fvar (id : FVarId)          -- free variable in local context
@@ -131,6 +134,7 @@ The key metaprogramming monad. Adds metavariable context (a mapping from
 — the variables in scope at a given proof state).
 
 ```lean
+
 -- Create a fresh metavariable (a "hole" to fill later)
 mkFreshExprMVar (type? : Option Expr) : MetaM Expr
 
@@ -163,6 +167,7 @@ defers for later solving (typeclasses, coercions, tactic blocks).
 The signature of a **term elaborator**:
 
 ```lean
+
 -- stx: the Syntax node to elaborate
 -- expectedType?: what type the result should have (can be `none`)
 -- returns: the Expr this syntax elaborates to
@@ -175,6 +180,7 @@ Used inside tactic implementations. Has access to the list of current goals
 (`MVarId`s) and can manipulate them.
 
 ```lean
+
 -- Get all current goals
 getGoals : TacticM (List MVarId)
 
@@ -195,6 +201,7 @@ The simplest metaprogramming tool. A macro takes a `Syntax` tree and returns
 a new `Syntax` tree. No type information. Pure structural rewriting.
 
 ```lean
+
 -- Single-rule macro (the `macro` keyword)
 macro "myNotation" x:term "⊕" y:term : term => `($x + $y + 0)
 
@@ -214,6 +221,7 @@ Used when the expansion needs type information or proof search. The elaborator
 receives the expected type and can create metavariables.
 
 ```lean
+
 -- Single elaborator
 elab "myTerm" : term => do
   let type ← inferType (mkConst `Nat)
@@ -264,6 +272,7 @@ Marks a definition as unfoldable by proof automation. The default is
 `@[irreducible]` means "never unfold" (useful for abstract types).
 
 ```lean
+
 -- In DbspChainRule.lean:
 abbrev ZSet (K : Type _) : Type _ := K →₀ ℤ
 abbrev Stream (G : Type _) : Type _ := ℕ → G
@@ -278,6 +287,7 @@ Marks a definition as deprecated, producing a warning when used. Takes the
 replacement name.
 
 ```lean
+
 -- In DbspChainRule.lean:
 @[deprecated Dop_LTI_commute (since := "2026-04-19")]
 theorem chain_rule ... := Dop_LTI_commute ...
@@ -390,6 +400,7 @@ look like, how `MetaM` manipulates them, and how `closeMainGoal` closes a goal
 with a proof term. All of that is now in this note.
 
 **Composes with:**
+
 - `tools/lean4/Lean4/DbspChainRule.lean` — the proof that benefits from Stage 2+
 - B-0051 — isomorphism catalog, IF4 filter
 - B-0048 — 3-colorability (Stage 4 decision procedure target)


### PR DESCRIPTION
## Summary

- Implements B-0050 Stage 1 (smallest safe slice): Lean 4 reflection / metaprogramming **read-only competence**
- New capability skill `lean-reflection-expert` covering the `Syntax→Expr` elaboration pipeline, `MetaM`/`TermElabM`/`TacticM` monad stack, `macro`/`elab_rules`, and attribute reading (`@[simp]`, `@[reducible]`, `@[deprecated]`)
- Stage 1 scouting research note at `docs/research/lean-reflection-stage-1-notes-2026-05-10.md` (teaching-discipline artifact per B-0050 Mr-Khan-pedagogy commitment)
- Pre-start checklist added to backlog row (prior-art search + dependency verify)

## Files changed

| File | Change |
|------|--------|
| `.claude/skills/lean-reflection-expert/SKILL.md` | **NEW** — Stage 1 skill: read-only reflection competence |
| `docs/research/lean-reflection-stage-1-notes-2026-05-10.md` | **NEW** — Stage 1 scouting note (verified vs leanprover-community.github.io metaprogramming book) |
| `docs/backlog/P2/B-0050-lean-reflection-capability-skill-staged-trajectory.md` | Updated — pre-start checklist + `last_updated` |

## What Stage 1 covers

- Reading code that uses `MetaM`, `TermElabM`, `TacticM`
- Understanding `Syntax` (parse tree) vs `Expr` (typed AST, de Bruijn-indexed)
- Recognizing monad stack layers (CoreM → MetaM → TermElabM → TacticM)
- Reading `macro` / `macro_rules` (Syntax→Syntax) vs `elab` / `elab_rules` (Syntax→Expr)
- Attribute effects: `@[simp]` registers rewrite rules; `@[reducible]`/`abbrev` makes type aliases transparent; `@[irreducible]` blocks unfolding
- Inventory of what `DbspChainRule.lean` already uses (`@[simp]`, `@[deprecated]`, `abbrev`, `structure`-based predicates)
- Elaboration error diagnosis table

## What Stage 1 does NOT cover

- Stages 2-5: tactic authoring, macro/elab authoring, decision procedures, proof-automation integration (future PRs)
- Any new Lean proof files (no `dotnet build` / `lake build` impact)
- The `lean4-expert` skill scope (build, `lake build`, sorry-discipline) — orthogonal

## Checks

- **BP-11 prompt-injection lint:** passed — all "run/execute" references are descriptive prose about Lean 4 behavior, not imperative instructions
- **Prior-art search:** no existing `lean-reflection-expert` skill, no retired personas in `git log --diff-filter=D`, no overlapping research notes
- **Otto-364 search-first-authority:** verified against `leanprover-community.github.io/lean4-metaprogramming-book/` (authoritative, 2024)
- **No dotnet/lake build changes:** pure skill + docs PR; `dotnet build -c Release` unaffected

## Composes with

- `tools/lean4/Lean4/DbspChainRule.lean` — the proof surface that benefits from Stage 2+
- `.claude/skills/lean4-expert/SKILL.md` — complementary (build/proof basics vs metaprogramming)
- `.claude/skills/formal-verification-expert/SKILL.md` — routing authority
- B-0051 (isomorphism catalog, IF4 filter) — Stage 4 dependency
- B-0048 (3-colorability) — Stage 4 decision-procedure target

🤖 Generated with [Claude Code](https://claude.com/claude-code)