### PR TITLE
feat(B-0380): quant × Austrian controlled vocabulary — four-term precision before research begins

### DIFF
--- a/docs/aurora/quant-austrian-vocabulary.md
+++ b/docs/aurora/quant-austrian-vocabulary.md
@@ -1,0 +1,360 @@
+---
+id: B-0380-output
+parent: B-0380
+created: 2026-05-10
+status: canonical
+scope: quant × Austrian synthesis research (B-0023 decomposition)
+---
+
+# Controlled Vocabulary: Quant × Austrian Synthesis
+
+Four load-bearing terms for the B-0023 research program.
+Each definition includes: precise scope, include/exclude examples,
+intra-school disputes, and a falsification-criterion.
+
+---
+
+## 1. "Quant-grade mathematical rigor"
+
+### Precise definition
+
+A formalization meets quant-grade mathematical rigor when ALL of:
+
+1. **Stated axioms**: all foundational assumptions are written down
+   explicitly in mathematical notation before any derivation begins.
+2. **Formal derivation**: every claimed result follows from the
+   stated axioms via rules of inference that are either explicitly
+   named (e.g., Itô's lemma, dominated convergence, optional
+   stopping) or cited in a form that a mathematically-trained
+   reader can verify without additional assumptions.
+3. **Well-typed terms**: every quantity has a declared mathematical
+   type — random variable on a probability space, element of a
+   Banach space, stochastic process adapted to a filtration — not
+   merely a label on a graph or a value in a table.
+4. **Falsifiable embedding**: there exists at least one mapping
+   from formal terms to observable quantities such that the theory
+   makes a prediction that could in principle be falsified by data.
+
+The "quant" qualifier specifies the mathematical culture: stochastic
+calculus, measure-theoretic probability, and functional analysis
+are the standard toolkit. A formalization that satisfies (1)–(3)
+but uses only high-school algebra qualifies as *mathematical* but
+not *quant-grade*.
+
+### Includes (examples that pass)
+
+- Black-Scholes-Merton (1973): axioms explicit (GBM, no-arbitrage),
+  derivation via Itô + replicating portfolio, each term typed
+  (e.g., `S_t : Ω → ℝ₊` adapted to `𝔽ₜ`), falsifiable via
+  option market prices.
+- Merton (1974) credit model: same toolkit applied to firm value.
+- Duffie-Singleton (1999) term structure: axiomatic affine SDE,
+  measure-change derivation, empirically testable yield predictions.
+- Any Austrian claim restated as a formal SDE or measure-theoretic
+  construct satisfying (1)–(4).
+
+### Excludes (examples that fail, with justification)
+
+- Saifedean Ammous stock-to-flow model: empirical fit without
+  formal axioms or type-system; a regression, not a derivation.
+  Fails (1) and (2).
+- Mises praxeology (raw form): rigorous deductive system but
+  terms are not typed in a mathematical sense; "action" is not
+  a random variable. Satisfies a form of (1) and (2) but fails
+  (3) and (4) under the quant-grade standard.
+- Agent-based simulations without measure-theoretic grounding:
+  computationally rigorous but not formally derivable in the
+  sense above.
+
+### Intra-Austrian disputes affecting scope
+
+- **Mises's praxeology vs. mathematical formalization**: Mises
+  and Rothbard explicitly rejected empirical-mathematical methods
+  for economic theory (the "a priori economics" position). This
+  creates a genuine tension: a "quant-grade Austrian formalization"
+  may be considered a category error by orthodox Misesians, while
+  Hayekians (especially post-Hayek complexity theorists) are more
+  open to formal modeling. This dispute affects the scope of
+  row B-0382 (time-preference) and B-0384 (calculation problem)
+  most directly.
+- **Econophysics adjacency**: the Econophysics tradition
+  (Mantegna-Stanley) applies statistical physics to economics;
+  this is quant-grade in the sense above but not specifically
+  Austrian. Proximity is not identity.
+
+### Falsification-criterion
+
+If a claimed formalization cannot be assigned a type for each term
+in a standard graduate mathematical probability textbook (e.g.,
+Durrett 2010), or if its derivation depends on an assumption not
+stated in the axiom list, the "quant-grade" qualifier is withdrawn.
+
+---
+
+## 2. "Austrian primitive"
+
+### Precise definition
+
+An **Austrian primitive** is a claim in the Austrian-school tradition
+that is treated as foundational (not derived from a more basic claim
+within the school) AND that:
+
+(a) appears in at least two of {Mises, Hayek, Böhm-Bawerk, Rothbard,
+    Kirzner} as a starting point rather than a conclusion, AND
+(b) is logically prior in the Austrian derivation order to the
+    claims that depend on it.
+
+### Three-layer taxonomy
+
+The Austrian tradition has three logically distinct layers. The
+"primitive" qualifier applies primarily to **Layer 1**; Layers 2
+and 3 are derived theory and applied theory, respectively.
+
+**Layer 1 — Praxeological core (primitives proper)**
+
+| Primitive | Canonical source | Logical role |
+|-----------|-----------------|--------------|
+| Action axiom (purposeful human behavior) | Mises *Human Action* Ch. 1 | Starting point; not argued from prior premises within praxeology |
+| Time-preference (present goods preferred over future goods, ceteris paribus) | Böhm-Bawerk *Capital and Interest* | Derived from action axiom + scarcity; treated as primitive in downstream applications |
+| Subjective value (value is ordinal, not cardinal; derives from individual ranking) | Menger *Principles* | Primitive; sets aside utility-function approach |
+| Uncertainty and heterogeneous knowledge | Hayek "Use of Knowledge" (1945) | Primitive claim about the epistemic structure of markets |
+
+**Layer 2 — Applied theory (derived from Layer 1)**
+
+ABCT (Austrian Business Cycle Theory), capital-structure
+(Hayekian triangle), interest as intertemporal price, price as
+knowledge aggregator. These are derived, not primitive.
+
+**Layer 3 — Policy layer (applied under Layer 2)**
+
+Sound-money advocacy, anti-central-planning arguments, free-banking
+theory. These are downstream conclusions, not primitives.
+
+### Includes (examples of genuine Austrian primitives)
+
+- Time-preference as a logical precondition for interest
+  (Layer 1; formalization target for B-0382)
+- The action axiom as the starting point of praxeology
+  (Layer 1; not formalized in quant sense — see dispute below)
+- Hayek's dispersed-knowledge claim (Layer 1; formalization
+  target for B-0384 via information-theoretic framing)
+
+### Excludes (examples that are NOT primitives under this definition)
+
+- Sound-money / hard-cap advocacy: Layer 3 conclusion, not a
+  primitive. Treating it as an axiom rather than a derived claim
+  is a common rhetorical move that conflates layers.
+- ABCT as a whole: Layer 2 derived theory; its components
+  (time-preference, roundaboutness, malinvestment) are more
+  primitive than ABCT itself.
+- "Austrians reject fiat money": policy-layer position, not
+  an epistemological or methodological primitive.
+
+### Intra-Austrian disputes affecting scope
+
+- **Mises vs. Hayek on methodology**: Mises's praxeology is purely
+  deductive-from-action-axiom, rejecting empirical input at the
+  theoretical level. Hayek's knowledge-coordination framework is
+  more open to empirical embedding and formal modeling. This means
+  B-0382 (time-preference) is more Misesian and may resist
+  quant-grade formalization, while B-0384 (calculation problem)
+  is more Hayekian and admits information-theoretic restatement.
+- **Rothbard's natural-law addition**: Rothbard adds natural-law
+  premises to praxeology that are not universally accepted within
+  the school. These additions are NOT treated as Austrian primitives
+  under this definition because they fail criterion (a) (not
+  endorsed as starting points by Hayek or Kirzner).
+
+### Falsification-criterion
+
+If a candidate "primitive" is derivable from another Austrian claim
+without additional premises, it is not primitive — it is a derived
+theorem in Layer 2. The test: can a skilled Austrian economist
+provide a derivation of the candidate from more basic Austrian
+claims? If yes, it demotes to Layer 2.
+
+---
+
+## 3. "Formalization"
+
+### Precise definition (three distinct senses)
+
+The term "formalization" covers three distinct operations. Clarity
+about which sense is intended changes the research agenda and the
+effort estimate by at least one order of magnitude.
+
+**Sense A — Mathematical representation**
+
+Translating a verbal Austrian claim into mathematical notation
+without necessarily changing its logical structure or providing
+a derivation from more basic premises.
+
+- Example: "time-preference means present goods are preferred to
+  future goods" → `u(c_t) + δ · u(c_{t+1}) > u(c_{t+1})` for `δ < 1`.
+- Epistemic status: translation, not proof. The claim is now
+  expressible in mathematical language but its truth conditions
+  are the same as the verbal version.
+- Effort: S to M. Almost any Austrian primitive can be given a
+  Sense-A formalization quickly.
+
+**Sense B — Rigorous derivation**
+
+Starting from stated axioms (which may or may not be the Austrian
+primitives themselves), formally derive the Austrian claim using
+quant-grade methods as defined in §1.
+
+- Example: deriving that a competitive equilibrium with time-preference
+  implies positive interest rates, starting from a stated set of
+  axioms about agent preferences and technology.
+- Epistemic status: conditional on the axioms, the claim is proved.
+  If the axioms don't match Austrian foundations, the derivation
+  proves something compatible with Austrian conclusions but not
+  necessarily the Austrian claim itself.
+- Effort: M to L. Requires mathematical skill and careful axiom design.
+
+**Sense C — Empirical embedding**
+
+Giving the formalization observable consequences: defining terms
+that map to measurable quantities and stating predictions that can
+be tested with data.
+
+- Example: specifying that "roundaboutness" corresponds to average
+  production duration in input-output tables, then testing whether
+  credit expansion produces the predicted lengthening pattern.
+- Epistemic status: the claim is now falsifiable.
+- Effort: M to L. Requires both the mathematical formalization
+  (Sense A or B) and an empirical operationalization.
+
+### What "quant-grade formalization" requires for B-0023
+
+Under the B-0380 vocabulary, **quant-grade formalization** requires
+at minimum Sense B (rigorous derivation), ideally Sense C
+(empirical embedding). Sense A alone is categorized as
+*mathematical representation*, not formalization for the purposes
+of the B-0023 research agenda.
+
+### Includes (examples by sense)
+
+- Sense A: expressing time-preference as a discount-factor model.
+  Not sufficient for B-0023 claims, but a necessary first step.
+- Sense B: Prescott-Mehra puzzle literature — quant-grade derivation
+  of equity premium from risk-preference primitives. Not Austrian
+  but Sense-B exemplar at the relevant mathematical standard.
+- Sense C: Garrison (2001) ABCT chapters — partial empirical
+  embedding; below quant-grade standard but directionally correct.
+
+### Excludes
+
+- Sense A alone: Saifedean stock-to-flow fits Sense A (a
+  mathematical representation of scarcity) but lacks Sense B
+  derivation. Not formalization under B-0023 standard.
+- Verbal restatement using Greek letters: not formalization;
+  this is notation without mathematical structure.
+
+### Falsification-criterion
+
+A claimed "formalization" that cannot be written in standard
+mathematical notation with typed terms and explicit derivation
+steps is at most Sense A (representation). Demote accordingly.
+
+---
+
+## 4. "Synthesis gap"
+
+### Precise definition
+
+The **synthesis gap** is the absence of a body of work that achieves
+**quant-grade formalization (Sense B or C as defined in §3)** of
+**Austrian primitives (Layer 1 as defined in §2)**.
+
+It is NOT merely the observation that "no paper combines both
+schools" — that would be a **literature gap** (a gap in the
+publication record). The synthesis gap is a **foundations
+incompatibility** between the two traditions that makes such a
+formalization structurally difficult, not merely historically
+overlooked.
+
+### The foundations incompatibility (structural claim)
+
+The quant tradition is built on equilibrium concepts (risk-neutral
+measure, no-arbitrage, efficient markets), rational expectations,
+and neutral money as background assumptions. Austrian primitives
+make claims that conflict with each of these background assumptions:
+
+| Quant background assumption | Austrian conflict |
+|-----------------------------|-------------------|
+| Markets clear via competitive equilibrium | ABCT: credit expansion prevents true clearing; yields predictable disequilibrium dynamics |
+| Money is neutral (long-run) | Sound-money thesis: monetary expansion distorts relative prices, is never neutral |
+| Rational expectations (homogeneous information) | Hayek dispersed knowledge: heterogeneous information is the *problem*, not an approximation to fix |
+| Preferences are stable and estimable from revealed choice | Subjective value: preferences are ordinal, non-interpersonally-comparable, and resist aggregation |
+
+This means a "quant-grade Austrian formalization" cannot simply
+borrow quant machinery wholesale: the machinery presupposes
+equilibrium structure that Austrian primitives deny. A genuine
+synthesis requires either (a) developing new mathematical tools
+that don't presuppose equilibrium, or (b) proving that some
+Austrian primitives are compatible with limited-equilibrium
+sub-frameworks.
+
+### Literature gap vs. synthesis gap
+
+| Dimension | Literature gap | Synthesis gap (this document) |
+|-----------|---------------|-------------------------------|
+| Cause | Historical accident, academic silo | Foundations incompatibility |
+| Fix | Literature search + assembly | New mathematical framework or compatibility proof |
+| Effort | S to M | L to XL |
+| Research program | Survey existing work | Develop new theory |
+
+The B-0023 research program investigates a **synthesis gap**, not
+merely a literature gap. Treating it as a literature gap
+underestimates the effort by at least an order of magnitude and
+misdirects the agenda toward existing-paper assembly.
+
+### Intra-synthesis debates affecting scope
+
+- **Hayekian complexity economics** (Beinhocker, Santa Fe Institute):
+  applies complex-systems mathematics (power laws, agent-based models)
+  to economic process. This is quant-grade in some senses and
+  Austrian-compatible in some senses, but it rejects equilibrium in
+  a different way than Mises and it is not part of the mainstream
+  Austrian academic tradition. It reduces the synthesis gap at the
+  Hayekian end but not at the Misesian end.
+- **New Monetarist economics**: some authors (Williamson, Wright)
+  use search theory (quant-grade) to model money non-neutrality
+  (Austrian-compatible conclusion). These papers are closest to the
+  synthesis and should be evaluated in B-0381 (literature survey)
+  against the definitions here.
+
+### Falsification-criterion
+
+The synthesis gap is **closed** when: a paper or research artifact
+achieves quant-grade formalization (Sense B or C) of at least one
+Layer-1 Austrian primitive without presupposing equilibrium or
+neutral money as background assumptions, and the result is verified
+by at least one author outside the producing group. Until that
+condition is met, the gap is open.
+
+---
+
+## Summary table
+
+| Term | Short definition | Passes if | Fails if |
+|------|-----------------|-----------|----------|
+| Quant-grade rigor | Stated axioms + formal derivation + typed terms + falsifiable embedding | Itô-calculus derivation from explicit premises | Regression without axioms; verbal restatement |
+| Austrian primitive | Layer-1 claim endorsed as starting point by ≥2 of {Mises, Hayek, Böhm-Bawerk, Rothbard, Kirzner} | Time-preference, action axiom, dispersed knowledge | Sound-money policy, ABCT conclusions |
+| Formalization | Sense B (rigorous derivation) or Sense C (empirical embedding) | Proved theorem from stated axioms | Notation without derivation (Sense A alone) |
+| Synthesis gap | Foundations-incompatibility gap, not merely literature gap | — | Closed only when Sense B/C formalization of Layer-1 primitive achieved without equilibrium presupposition |
+
+---
+
+## Composes with
+
+- B-0381 (literature survey): uses "formalization" Sense A/B/C
+  to classify existing partial attempts
+- B-0382–B-0386 (per-primitive assessments): each uses
+  "Austrian primitive" Layer-1/2/3 taxonomy + "quant-grade rigor"
+  bar to assess formalizability
+- B-0387 (synthesis ADR): uses "synthesis gap" structural claim
+  to determine research-program type (assembly vs. new theory)
+- B-0021 §methodology: same Otto-286 precision discipline applied
+  to the quant × Austrian domain

--- a/docs/backlog/P2/B-0380-quant-austrian-controlled-vocabulary-otto286-2026-05-09.md
+++ b/docs/backlog/P2/B-0380-quant-austrian-controlled-vocabulary-otto286-2026-05-09.md
@@ -1,13 +1,15 @@
 ---
 id: B-0380
 priority: P3
-status: open
+status: closed
 title: Controlled-vocabulary pass — define "quant-grade rigor", "Austrian primitive", "formalization", "synthesis gap" (Otto-286 precision before any research begins)
 tier: research-grade
 effort: S
 ask: decomposition of B-0023
 created: 2026-05-09
-last_updated: 2026-05-09
+last_updated: 2026-05-10
+resolved: 2026-05-10
+resolved_by: "PR closes B-0380: docs/aurora/quant-austrian-vocabulary.md — four-term vocabulary with include/exclude/falsification-criterion per term"
 depends_on: []
 composes_with: [B-0023, B-0381, B-0382, B-0383, B-0384, B-0385, B-0386, B-0387]
 parent: B-0023


### PR DESCRIPTION
## Summary

- Implements B-0380 (Otto-286 precision-before-research): defines the four load-bearing
  terms for the B-0023 quant × Austrian synthesis research program
- Output artifact: `docs/aurora/quant-austrian-vocabulary.md`
- Closes B-0380; unblocks B-0381 (literature survey) and B-0382–B-0387 (per-primitive assessments)

## Four terms defined

| Term | Key distinction |
|------|----------------|
| **Quant-grade rigor** | Stated axioms + formal derivation + typed terms + falsifiable embedding; excludes regression-without-derivation (Saifedean stock-to-flow) |
| **Austrian primitive** | Layer-1 praxeological core only (action axiom, time-preference, subjective value, dispersed knowledge); excludes Layer-3 policy positions |
| **Formalization** | Three-sense taxonomy (A: mathematical representation, B: rigorous derivation, C: empirical embedding); B-0023 requires Sense B or C |
| **Synthesis gap** | Foundations-incompatibility (quant presupposes equilibrium/neutral-money; Austrian primitives deny both) — not merely a literature gap; ≥10x effort difference |

## Why vocabulary matters first (Otto-286 discipline)

Without precise definitions, B-0381's literature survey would misclassify partial
attempts. Saifedean stock-to-flow is Sense-A (mathematical representation) — not a
synthesis. Treating it as formalization inflates the "already done" count and misdirects
the research agenda.

The synthesis-gap distinction (foundations-incompatibility vs. literature gap) determines
whether the program is "assemble existing pieces" or "develop new mathematical framework."

## Checks

- **Prior-art search:** No existing vocabulary doc in `docs/aurora/`. B-0021 §methodology
  names the Otto-286 discipline but does not define these four terms.
- **Build gate:** `dotnet build -c Release` → 0 warnings, 0 errors (pure docs PR)
- **BP-11 prompt-injection lint:** vocabulary definitions are descriptive, not imperative

🤖 Generated with [Claude Code](https://claude.com/claude-code)