### PR TITLE
fix(tsc): resolve two lint (tsc tools) errors from mythology catalog PRs

### DIFF
--- a/tools/mythology-resonance/candidate-schema.ts
+++ b/tools/mythology-resonance/candidate-schema.ts
@@ -49,9 +49,9 @@ export const heimdallrSeed: MythologyCandidate = {
   role: 'bridge-figure',
   threeFilter: {
     f1Pass: true,
-    f2Strength: 'strong-but-looser',
+    f2Strength: 'moderate',
     f3Pass: true,
-    notes: 'F3 within Norse but thinner canonicity (Christianization-filtered Eddas); second anchor pending',
+    notes: 'F2 moderate (strong role-fit but looser than full-pass — Eddic canonicity thinner due to Christianization-filtering); F3 within Norse; second anchor pending',
   },
   textualAnchors: ['Poetic Edda', 'Prose Edda'],
   state: 'candidate',

--- a/tools/resonance/mythology-catalog-schema.ts
+++ b/tools/resonance/mythology-catalog-schema.ts
@@ -448,7 +448,6 @@ const SEED_CATALOG: MythologyResonanceCatalog = {
       },
       status: "candidate",
       counterexampleAttempts: [],
-      sourceMemory: undefined,
       notes:
         "The overlap with the occult track (B-0057) via Hermes Trismegistus (Greek Hermes + " +
         "Egyptian Thoth fusion figure, load-bearing in Renaissance Hermeticism) is noted. " +


### PR DESCRIPTION
## Summary

- **TS2322** in `tools/mythology-resonance/candidate-schema.ts:52`: `f2Strength: 'strong-but-looser'` is not assignable to the union `'weak' | 'moderate' | 'strong'`. Changed to `'moderate'`; qualifier moved into the `notes` field.
- **TS2375** in `tools/resonance/mythology-catalog-schema.ts`: explicit `sourceMemory: undefined` violates `exactOptionalPropertyTypes: true`. Removed the line — omitting an optional property is correct; explicitly setting to `undefined` is not.

Both errors were introduced in `#2423` / `#2424` (mythology catalog PRs) and first surfaced by the `lint (tsc tools)` CI job running against PR `#2426`'s merge context. `#2426` auto-merged before the fix could land on its branch.

## Test plan

- [x] `bun --bun tsc --noEmit -p tsconfig.json` — 0 errors after fix (verified locally)
- [x] No logic change: `'moderate'` is semantically accurate (explicitly described as "strong-but-looser" = below strong); qualifier preserved in notes
- [x] `sourceMemory` omission matches all other catalog entries that lack a source memory file

🤖 Generated with [Claude Code](https://claude.com/claude-code)