### PR TITLE
fix(backlog-index): add B-0054.3–B-0054.10 child rows to generated BACKLOG.md

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -273,7 +273,15 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0050](backlog/P2/B-0050-lean-reflection-capability-skill-staged-trajectory.md)** Lean reflection — learn it properly, land a capability skill + scouting note (staged 5-stage trajectory)
 - [ ] **[B-0051](backlog/P2/B-0051-isomorphism-homomorphism-catalog-consolidation.md)** Isomorphism / homomorphism catalog — consolidate the category-theory surface, identify gaps, lift to coherent track
 - [ ] **[B-0054](backlog/P2/B-0054-pop-culture-media-research-track.md)** Pop-culture / media research track — operational-resonance sweep across film, TV, YouTube documentary, music, video games, conspiracy-corpus
+- [ ] **[B-0054.10](backlog/P2/B-0054.10-bollywood-hindi-cinema-hindu-karmic-cycle.md)** Bollywood + Hindi cinema sweep + Hindu karmic-cycle substrate
 - [x] **[B-0054.2](backlog/P2/B-0054.2-video-game-priority-seeds-extension.md)** Video-game priority tier — Brütal Legend + Final Fantasy VI/VII
+- [ ] **[B-0054.3](backlog/P2/B-0054.3-video-game-mario-genshin.md)** Video-game priority tier — Super Mario + Genshin Impact
+- [ ] **[B-0054.4](backlog/P2/B-0054.4-double-fine-broken-age-brutal-legend-narrative.md)** Tim Schafer / Double Fine sub-thread — Broken Age + Brütal Legend narrative mapping
+- [ ] **[B-0054.5](backlog/P2/B-0054.5-british-serial-tv-monty-python-red-dwarf-black-mirror.md)** British long-serial TV — Monty Python + Red Dwarf + Black Mirror
+- [ ] **[B-0054.6](backlog/P2/B-0054.6-hollywood-film-arrival-interstellar-primer-tenet.md)** Hollywood film sweep — Arrival, Interstellar, Primer, Tenet
+- [ ] **[B-0054.7](backlog/P2/B-0054.7-conspiracy-corpus-chronovisor-why-files.md)** Conspiracy-corpus — Chronovisor / Cronovisor (Ernetti 1972) + The Why Files
+- [ ] **[B-0054.8](backlog/P2/B-0054.8-music-corpus-progressive-rock-tool-nin.md)** Music corpus — progressive rock + Tool / Meshuggah / NIN first pass
+- [ ] **[B-0054.9](backlog/P2/B-0054.9-catalog-tier-games-portal-braid-outer-wilds-disco-elysium.md)** Catalog-tier game sweep — Portal, Braid, Outer Wilds, Disco Elysium
 - [ ] **[B-0055](backlog/P2/B-0055-frontier-edge-claims-CTF-flags.md)** Frontier edge-claims research track — plant flags on unclaimed intellectual territory (CTF-style, falsifiable, retractibly-defensible)
 - [ ] **[B-0056](backlog/P2/B-0056-mythology-research-track.md)** Mythology research track — operational-resonance candidates from world-mythology bridge / messenger / boundary figures
 - [x] **[B-0056.1](backlog/P2/B-0056.1-mythology-resonance-catalog-v0.md)** Mythology resonance catalog v0 — typed schema + 3 seed entries (Heimdallr, Hermes/Mercury, Loki anti-instance)


### PR DESCRIPTION
## Summary

- PR #2432 squash-merged before the BACKLOG.md index could be updated
- The 8 new per-row files (B-0054.3–B-0054.10) exist on main but were missing from the generated index
- Regenerated via `BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts`; `--check` confirms parity

## Focused checks

- `bun tools/backlog/generate-index.ts --check` → `ok: ... matches generator output` ✓
- Only `docs/BACKLOG.md` changed (+8 lines)

## operative-authorization

aaron 2026-05-04: "it**, not just the output. Grinding through failures + recoveries"

🤖 Generated with [Claude Code](https://claude.com/claude-code)