### PR TITLE
feat(B-0072.1): smallest safe slice — pure-TS MEMORY.md index entry length auditor (Rule 0)

### DIFF
--- a/tools/hygiene/audit-memory-index-entry-lengths.ts
+++ b/tools/hygiene/audit-memory-index-entry-lengths.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+// audit-memory-index-entry-lengths.ts — flag MEMORY.md index entries exceeding one-line limit
+// per memory/README.md ("one line per memory file") and CLAUDE.md (~200 chars).
+//
+// Smallest safe slice of B-0072 (P2). Pure-TS implementation (Rule 0).
+// Future slices can add auto-fix or integrate into B-0066 auto-gen.
+//
+// Usage:
+//   bun tools/hygiene/audit-memory-index-entry-lengths.ts
+//   bun ... --enforce   # exit 2 on any long entry
+//
+// Exit: 0 clean, 2 violations under --enforce, 64 arg error.
+
+import { readFileSync } from "node:fs";
+
+type AuditExitCode = 0 | 2 | 64;
+
+interface Args {
+  readonly target: string;
+  readonly enforce: boolean;
+  readonly maxLen: number;
+}
+
+interface LongEntry {
+  readonly line: number;
+  readonly length: number;
+  readonly text: string;
+}
+
+const HELP = "Usage: audit-memory-index-entry-lengths.ts [--file PATH] [--enforce] [--max N]\n";
+
+function parseArgs(argv: readonly string[]): { kind: "args"; args: Args } | { kind: "help" } | { kind: "error"; message: string } {
+  let target = "memory/MEMORY.md";
+  let enforce = false;
+  let maxLen = 200;
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg === "--file") {
+      const v = argv[i + 1];
+      if (!v) return { kind: "error", message: "--file needs path" };
+      target = v;
+      i += 2;
+    } else if (arg === "--enforce") {
+      enforce = true;
+      i++;
+    } else if (arg === "--max") {
+      const v = argv[i + 1];
+      maxLen = v ? parseInt(v, 10) : 200;
+      i += 2;
+    } else if (arg === "-h" || arg === "--help") {
+      return { kind: "help" };
+    } else {
+      return { kind: "error", message: `unknown: ${arg}` };
+    }
+  }
+  return { kind: "args", args: { target, enforce, maxLen } };
+}
+
+function audit(file: string, max: number): LongEntry[] {
+  const content = readFileSync(file, "utf8");
+  const lines = content.split("\n");
+  const findings: LongEntry[] = [];
+  lines.forEach((line, idx) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("- [") || trimmed.startsWith("- `")) {
+      const len = line.length; // raw for terminal width realism
+      if (len > max) {
+        findings.push({ line: idx + 1, length: len, text: trimmed.slice(0, 80) + "..." });
+      }
+    }
+  });
+  return findings;
+}
+
+function main() {
+  const res = parseArgs(process.argv.slice(2));
+  if (res.kind === "help") {
+    console.log(HELP);
+    process.exit(0);
+  }
+  if (res.kind === "error") {
+    console.error(res.message);
+    process.exit(64);
+  }
+  const { target, enforce, maxLen } = res.args;
+  try {
+    const bad = audit(target, maxLen);
+    if (bad.length === 0) {
+      console.log(`OK: all index entries ≤ ${maxLen} chars in ${target}`);
+      process.exit(0);
+    }
+    console.error(`Found ${bad.length} long entries (> ${maxLen} chars):`);
+    bad.forEach(f => console.error(`  L${f.line} (${f.length}c): ${f.text}`));
+    process.exit(enforce ? 2 : 0);
+  } catch (e) {
+    console.error("IO error:", e);
+    process.exit(64);
+  }
+}
+
+main();

--- a/tools/hygiene/audit-memory-index-entry-lengths.ts
+++ b/tools/hygiene/audit-memory-index-entry-lengths.ts
@@ -13,8 +13,6 @@
 
 import { readFileSync } from "node:fs";
 
-type AuditExitCode = 0 | 2 | 64;
-
 interface Args {
   readonly target: string;
   readonly enforce: boolean;


### PR DESCRIPTION
## Summary
Implements audit leg of B-0072 (P2) as the smallest bounded code slice (TS auditor). B-0072 was too broad (M effort, 191+ long entries found); re-decomposed per "always re-decompose" rule. This step delivers the diagnostic tool only; normalization / auto-fix in follow-ups. Composes with B-0066 auto-gen future.

## Focused checks (included per task)
- `bun tools/hygiene/audit-memory-index-entry-lengths.ts --max 120` → reported 191 long entries (correct, index has grown)
- Type check: `bun --bun tsc --noEmit ...` clean (0 errors)
- Root build gate: `dotnet build -c Release` → 0 Warning(s) 0 Error(s)
- No root checkout touched; dedicated worktree + pushed claim branch used
- TS only (Rule 0); no .sh, no broad doc edits

## One bounded step
Exactly one: the auditor file. PR body + commit follow project shape.

Co-Authored-By: Grok <noreply@x.ai>

Made with [Cursor](https://cursor.com)