### PR TITLE
chore(B-0074.1): fix stale .sh refs in kiro-cli memory + mark resolved sub-items

### DIFF
--- a/docs/backlog/P2/B-0074-pr-72-punch-list-stale-item-sweep-spec-consistency-2026-04-28.md
+++ b/docs/backlog/P2/B-0074-pr-72-punch-list-stale-item-sweep-spec-consistency-2026-04-28.md
@@ -6,7 +6,7 @@ title: PR #72 punch-list / spec-consistency drift sweep — 8 codex threads on s
 effort: M
 ask: chatgpt-codex-connector + copilot reviews on PR #72
 created: 2026-04-28
-last_updated: 2026-05-02
+last_updated: 2026-05-10
 depends_on: []
 tags: [pr-72, punch-list, spec-consistency, b-0062, deferral-tracking]
 type: friction-reducer
@@ -37,10 +37,17 @@ session. Codex flagged 4 stale entries:
    item flagged the §9.1 vs §3.3/§3.4 self-revocation
    contradiction; subsequent EAT/wallet edits resolved it.
    Remove from punch list with audit trail in commit message.
+   **RESOLVED:** B-0062 closed 2026-05-08 (Vera final
+   companion-spec cleanup); all 21 punch-list items carry
+   resolution notes. No further action needed.
 2. **L152 — reorg-metric blocker (cid: SIvLus5-BHvP)**: stale
    reorg-metric blocker, no longer applicable.
+   **RESOLVED:** B-0062 closed 2026-05-08; reorg-metric item
+   aligned in EAT §9 / wallet spec §9.3.
 3. **L161 — §15 unresolved-questions item (cid: SIvLus5-BHvU)**:
    the §15 entry that was open is now closed; drop from punch.
+   **RESOLVED:** B-0062 closed 2026-05-08; §15 send-readiness
+   statement reconciled (prior pass).
 4. **L62 — pre-broadcast freeze item (cid: SIvLus5-Bk-Z)**:
    the in-repo-monitor topology aspect of this entry was
    resolved by the §13.4 in-repo-monitor removal (earlier
@@ -50,6 +57,11 @@ session. Codex flagged 4 stale entries:
    invariant the punch-list item flagged) remains OPEN.**
    The B-0062 entry should be split: close the topology
    sub-item, keep the state-machine sub-item open.
+   **RESOLVED:** B-0062 closed 2026-05-08; both the topology
+   sub-item and the state-machine semantics sub-item received
+   explicit resolution notes (`frozen` terminal state §7.3,
+   thesis-review vs classification-review distinction in
+   item 2 of the preflight-retraction state-machine section).
 
 ### EAT/wallet cross-doc alignment
 
@@ -72,6 +84,10 @@ session. Codex flagged 4 stale entries:
    PR's branch). Once #28's content propagates to AceHack
    main + PR #72 rebases, the reference becomes valid. Either
    wait for the rebase or relabel the reference now.
+   **RESOLVED (B-0074.1 2026-05-10):** All peer-call scripts
+   migrated to `.ts` (Rule 0). `kiro.ts` already ships.
+   Memory file updated to reference `.ts` paths and note that
+   no further kiro stub is needed.
 2. **`docs/backlog/P1/B-0067-cadenced-git-hotspot-detection-aaron-2026-04-28.md`
    L50 (cid: SIvLus5-B6tS)**: log-line analysis should
    exclude blank lines from hotspot scoring. Small
@@ -79,6 +95,9 @@ session. Codex flagged 4 stale entries:
    (Earlier draft incorrectly cited the location as
    `docs/research/...` — the actual file is the B-0067
    backlog row at the path above.)
+   **RESOLVED:** `audit-git-hotspots.ts` line 215 already
+   filters empty strings via `s.length > 0` in the TS port.
+   B-0067 closed 2026-05-07 with Phase 3 triage complete.
 
 ## Why deferred (not fixed in PR #72)
 
@@ -89,12 +108,35 @@ focused sweep PR that touches just these 4 files.
 
 ## Acceptance
 
-- 4 stale entries removed from B-0062 with explicit audit
-  trail
-- EAT §504 + wallet-v0 §377 cross-doc consistency verified
-- kiro-cli memory rephrased OR PR #72 rebased (whichever
-  resolves the live xref first)
-- git-hotspot log-line filter algorithm refined
+- [x] 4 stale entries removed from B-0062 with explicit audit
+  trail — **DONE:** B-0062 closed 2026-05-08 with all 21
+  items resolved; resolution notes added in-row above.
+- [ ] EAT §504 + wallet-v0 §377 cross-doc consistency verified
+  — **OPEN:** EAT §21.e prose and wallet spec §8.1 bond-ledger
+  schema still need a targeted audit pass.
+- [x] kiro-cli memory rephrased OR PR #72 rebased (whichever
+  resolves the live xref first) — **DONE (B-0074.1):** memory
+  file updated to `.ts` paths; kiro.ts already ships.
+- [x] git-hotspot log-line filter algorithm refined — **DONE:**
+  `audit-git-hotspots.ts:215` filters `s.length > 0`; B-0067
+  closed 2026-05-07.
+
+## Progress
+
+### B-0074.1 (2026-05-10, PR #TODO)
+
+Smallest safe slice: kiro-cli memory file stale `.sh`-path fix.
+
+- Items 1-4 (B-0062 punch-list stale-item removal): marked
+  resolved per B-0062 closure 2026-05-08.
+- Item 7 (kiro memory L18): updated `.sh` → `.ts`; noted
+  `kiro.ts` already ships.
+- Item 8 (B-0067 blank-line filter): confirmed already resolved
+  in the TS port at `audit-git-hotspots.ts:215`.
+
+**Remaining open:** Items 5 (EAT §504 wallet-acceptance prose)
+and 6 (wallet spec §377 bond-ledger vs INTENTIONAL-DEBT.md).
+Both require a targeted doc-audit pass — separate slice.
 
 ## Composes with
 

--- a/memory/feedback_kiro_cli_added_to_agent_roster_aaron_2026_04_28.md
+++ b/memory/feedback_kiro_cli_added_to_agent_roster_aaron_2026_04_28.md
@@ -1,6 +1,6 @@
 ---
 name: kiro-cli added to the agent / CLI roster (Aaron 2026-04-28)
-description: Aaron 2026-04-28 expanded the CLI / harness roster with kiro-cli — a new entry alongside Claude Code, Codex, Cursor, Gemini, Grok. Verify-currency-via-WebSearch per Otto-247 before asserting kiro-cli capabilities; treat the inventory as growing list, not a closed set. Composes with the multi-harness peer-call pattern (`tools/peer-call/{gemini,codex,grok}.sh`) — kiro-cli should get a sibling caller script when the integration matures.
+description: Aaron 2026-04-28 expanded the CLI / harness roster with kiro-cli — a new entry alongside Claude Code, Codex, Cursor, Gemini, Grok. Verify-currency-via-WebSearch per Otto-247 before asserting kiro-cli capabilities; treat the inventory as growing list, not a closed set. Composes with the multi-harness peer-call pattern (`tools/peer-call/{gemini,codex,grok,kiro}.ts`) — kiro.ts already ships as of B-0074.1.
 type: reference
 ---
 
@@ -12,11 +12,10 @@ agent / CLI / harness roster as of 2026-04-28.
 **Why this matters:**
 
 - **Multi-harness pattern.** The factory already has
-  named-agent peer-callers for Gemini, Codex, and Grok
-  (`tools/peer-call/{gemini,codex,grok}.sh` per task
-  #303). kiro-cli is a candidate for the same pattern
-  once integration matures — sibling
-  `tools/peer-call/kiro.sh` if the workflow stabilises.
+  named-agent peer-callers for Gemini, Codex, Grok, and
+  Kiro (`tools/peer-call/{gemini,codex,grok,kiro}.ts` —
+  all Rule-0 TS scripts). `kiro.ts` shipped as part of
+  the peer-call TS migration; no further stub needed.
 - **Cross-CLI verify is load-bearing.** Per Otto-347
   ("would be good to ask another CLI"), having more
   harnesses available means more options for cross-CLI
@@ -51,13 +50,10 @@ training-data cutoff makes default knowledge stale.
 
 ## Composes with
 
-- `tools/peer-call/grok.sh` (existing sibling caller on
-  AceHack main as of 2026-04-28). `tools/peer-call/codex.sh`
-  + `tools/peer-call/gemini.sh` were added via PR #28
-  (merged on AceHack main 2026-04-28T09:04Z) but are not
-  yet rebased into PR #72's branch — verify post-rebase
-  before relying on them. kiro.sh would be a parallel-shape
-  addition.
+- `tools/peer-call/grok.ts`, `codex.ts`, `gemini.ts`,
+  `kiro.ts` — all present; Rule-0 TS migration complete
+  (B-0074.1). `amara.ts`, `ani.ts`, `riven.ts`, `claude.ts`
+  are additional callers in the same directory.
 - Otto-247 version-currency rule (WebSearch before
   asserting CLI versions / capabilities).
 - Otto-347 cross-CLI verify (more harnesses = more


### PR DESCRIPTION
## Summary

Smallest safe slice of B-0074 (PR #72 punch-list / spec-consistency drift sweep).

- **Fix kiro-cli memory stale `.sh` paths** — `memory/feedback_kiro_cli_added_to_agent_roster_*.md` referenced `tools/peer-call/{gemini,codex,grok}.sh` paths that no longer exist (Rule 0 TS migration complete; actual files are `.ts`). Updated to `.ts` paths and removed the future-tense "create kiro.sh stub" suggestion — `kiro.ts` already ships.
- **Mark 6 of 8 B-0074 sub-items resolved** — added inline RESOLVED notes and updated acceptance-criteria checkboxes in the B-0074 row:
  - Items 1–4 (B-0062 punch-list stale removal): B-0062 closed 2026-05-08 with all 21 items resolved.
  - Item 7 (kiro memory L18): fixed in this PR.
  - Item 8 (B-0067 blank-line filter): confirmed already handled in `audit-git-hotspots.ts:215` (`s.length > 0` filter was present in the TS port).
- **Remaining open** (separate slice): Items 5 (EAT §504 wallet-acceptance prose audit) and 6 (wallet spec §377 bond-ledger vs INTENTIONAL-DEBT.md verification).

## Checks

- `dotnet build -c Release`: **0 Warning(s) 0 Error(s)**
- No code changes — doc + memory file only.
- Stale `.sh` paths verified non-existent: `tools/peer-call/` contains only `.ts` wrappers.
- `kiro.ts` existence confirmed: `tools/peer-call/kiro.ts` present.

## Test plan

- [ ] Build passes (0 warnings, 0 errors)
- [ ] `memory/feedback_kiro_cli_added_to_agent_roster_*.md` no longer references `.sh` paths
- [ ] `docs/backlog/P2/B-0074-*.md` progress section accurately describes remaining open items (5 and 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)