### PR TITLE
fix(B-0077): close as resolved-by-B-0063 — curl-fetch Codex findings already fixed

### DIFF
--- a/docs/backlog/P2/B-0077-curl-fetch-canonical-content-cleanup-codex-pr-663.md
+++ b/docs/backlog/P2/B-0077-curl-fetch-canonical-content-cleanup-codex-pr-663.md
@@ -1,12 +1,12 @@
 ---
 id: B-0077
 priority: P2
-status: open
+status: done
 title: tools/setup/common/curl-fetch.sh canonical-content cleanup — Codex P0/P1 on PR #663
 effort: S
 ask: address Codex P0 (docstring with `curl ... | sh` examples) + P1 (commentary about install paths is inaccurate) on AceHack first, then forward-sync to LFG
 created: 2026-04-28
-last_updated: 2026-05-02
+last_updated: 2026-05-10
 depends_on: []
 tags: [pr-663, codex, deferred, acehack-canonical, curl-fetch, install-hardening]
 type: friction-reducer
@@ -27,11 +27,33 @@ PR #663 is a pure-additive forward-sync of AceHack-canonical content to LFG. Mod
 
 ## Acceptance
 
-- [ ] P0 docstring updated on AceHack to remove pipe-to-shell examples
-- [ ] P1 commentary updated on AceHack to match actual call-site state
-- [ ] Forward-sync the cleaned-up file to LFG (next sync round)
+- [x] P0 docstring updated to remove pipe-to-shell examples — resolved by
+  B-0063 (PR #2114, 2026-05-08): `curl_fetch_stream` removed entirely;
+  USAGE section replaced with download-to-temp + verify + exec pattern.
+- [x] P1 commentary updated to match actual call-site state — resolved by
+  B-0063 (PR #2114, 2026-05-08): "two-gate command-substitution" and
+  "streamed callers" language removed; COMMAND-SUBSTITUTION + SET-E
+  section now accurately describes download-to-temp + exec for all three
+  call sites (macos.sh, linux.sh, elan.sh).
+- [x] LFG carries the cleaned-up file — PR #2114 landed directly on LFG
+  (AceHack-first workflow was abandoned 2026-05-02; double-hop not required).
+
+## Resolution
+
+Both Codex findings were resolved as a side-effect of B-0063 (PR #2114,
+merged 2026-05-08). Verified 2026-05-10:
+
+- `curl_fetch_stream` and all pipe-to-shell USAGE examples are gone from
+  `tools/setup/common/curl-fetch.sh`.
+- All three upstream-installer call sites (macos.sh line 56, linux.sh line 98,
+  elan.sh line 44) use `curl_fetch --output` (download-to-temp). No `| sh` or
+  `bash -c "$(curl …)"` patterns remain in these files.
+- The inaccurate "two-gate command-substitution" commentary at the original
+  line 141 is gone; the file now contains one helper (`curl_fetch`) and
+  accurate per-section prose.
 
 ## Composes with
 
 - PR #663 (the forward-sync that surfaced these via Codex review)
-- B-0063 (streamed-installer download-to-temp checksum pattern from Codex P0 on PR #75)
+- B-0063 (streamed-installer download-to-temp checksum pattern — the PR that
+  resolved both findings; PR #2114)


### PR DESCRIPTION
## Summary

B-0077 tracked two Codex P0/P1 findings from PR #663 on `tools/setup/common/curl-fetch.sh`:

- **P0 (original line 86)**: `curl_fetch_stream … | sh` examples in the USAGE docstring — violates repo's no-pipe-to-shell policy even as commentary.
- **P1 (original line 141)**: commentary claimed `macos.sh` used two-gate command-substitution while `linux.sh`/`elan.sh` were "streamed callers" — empirically wrong at the time, as `elan.sh`/`linux.sh` already downloaded to temp.

Both findings were **already resolved** as a side-effect of B-0063 (PR #2114, merged 2026-05-08), which removed `curl_fetch_stream` entirely and converted the last remaining pipe-to-shell call site (Homebrew in `macos.sh`) to download-to-temp.

## Evidence (verified 2026-05-10)

| Finding | Status | How resolved |
|---------|--------|--------------|
| P0: pipe-to-shell USAGE examples | ✅ Resolved | `curl_fetch_stream` removed; USAGE section now shows download-to-temp + verify + exec pattern |
| P1: inaccurate call-site commentary | ✅ Resolved | "two-gate command-substitution" language gone; all three scripts now accurately shown as using `curl_fetch --output` |
| Forward-sync to LFG | ✅ Resolved | PR #2114 landed directly on LFG (AceHack-first workflow abandoned 2026-05-02) |

**Verified call-site audit:**
- `tools/setup/macos.sh:56` — `curl_fetch --output "${HOMEBREW_INSTALLER_TMP}"` ✓
- `tools/setup/linux.sh:98` — `curl_fetch --output "${MISE_TMP}/${MISE_TARBALL}"` ✓
- `tools/setup/common/elan.sh:44` — `curl_fetch --output "${ELAN_INIT_TMP}"` ✓

## Change

Single file updated: `docs/backlog/P2/B-0077-…md`
- `status: open` → `status: done`
- `last_updated: 2026-05-02` → `2026-05-10`
- Acceptance checkboxes checked with evidence
- Resolution section added pointing to B-0063/PR #2114

## Checks

- `bun tools/backlog/generate-index.ts --check` → `ok: matches generator output`
- `dotnet build -c Release` → `Build succeeded. 0 Warning(s) 0 Error(s)`

operative-authorization: aaron 2026-05-04: "it**, not just the output. Grinding through failures + recoveries"