### PR TITLE
chore(B-0079): regenerate BACKLOG.md — B-0079 closed status → [x]

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -297,7 +297,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0076](backlog/P2/B-0076-disowned-runtime-sweep-python-typescript-2026-04-28.md)** Disowned-runtime sweep — Python + TypeScript surface (same pattern PR #662 fixed for Java)
 - [ ] **[B-0077](backlog/P2/B-0077-curl-fetch-canonical-content-cleanup-codex-pr-663.md)** tools/setup/common/curl-fetch.sh canonical-content cleanup — Codex P0/P1 on PR #663
 - [x] **[B-0078](backlog/P2/B-0078-markdownlint-research-carve-out-narrowing-codex-pr-663.md)** Narrow markdownlint carve-out from `docs/research/2026-*-*.md` to verbatim-only pattern — Codex P1 on PR #663
-- [ ] **[B-0079](backlog/P2/B-0079-audit-agencysignature-script-hardening-codex-pr-663.md)** tools/hygiene/audit-agencysignature-main-tip.sh hardening — 4 Codex findings on PR #663
+- [x] **[B-0079](backlog/P2/B-0079-audit-agencysignature-script-hardening-codex-pr-663.md)** tools/hygiene/audit-agencysignature-main-tip.ts hardening — 5 Codex findings on PR #663 (sh→ts ported)
 - [ ] **[B-0081](backlog/P2/B-0081-path-gate-kotlin-scala-codex-pr-662.md)** codeql.yml path-gate should match `*.kt` + `*.scala` not just `*.java` — Codex P2 on PR #662
 - [ ] **[B-0082](backlog/P2/B-0082-glossary-persona-name-attribution-role-ref-conversion-pr-671.md)** docs/GLOSSARY.md provenance entries use persona-name attribution; convert to role-refs
 - [ ] **[B-0086](backlog/P2/B-0086-port-tools-hygiene-python-to-typescript-bun-aaron-2026-04-28.md)** Port tools/hygiene Python scripts to TypeScript/Bun (factory-default; AI/ML carve-out applies)


### PR DESCRIPTION
## Summary

- PR #2444 (`fix(B-0079)`) updated the B-0079 row file (`status: closed`, title updated to reflect `.ts` port and all 5 findings resolved) but did not regenerate `docs/BACKLOG.md`
- The generated-index drift check failed (non-required) on that PR; auto-merge went through anyway
- This single-file follow-up regenerates the index so B-0079 shows `[x]` on main

## Changes

- `docs/BACKLOG.md` — B-0079 row updated: `[ ]` → `[x]`, old `.sh` title → new `.ts` title with 5 findings

## Build gate

```
bun tools/backlog/generate-index.ts --check → ok: matches generator output
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)