### PR TITLE
fix: gracefully skip actions/permissions 403 in GitHub settings drift check

### DIFF
--- a/tools/hygiene/check-github-settings-drift.ts
+++ b/tools/hygiene/check-github-settings-drift.ts
@@ -108,8 +108,9 @@ export async function main(argv: readonly string[]): Promise<number> {
   const { repo, expected } = parsed.args;
 
   // Verify expected snapshot exists
+  let expectedContent: string;
   try {
-    readFileSync(expected, "utf8");
+    expectedContent = readFileSync(expected, "utf8");
   } catch {
     process.stderr.write(`error: expected snapshot not found: ${expected}\n`);
     return 2;
@@ -119,28 +120,67 @@ export async function main(argv: readonly string[]): Promise<number> {
   let liveContent: string;
   try {
     liveContent = await snapshot(repo);
-    // Ensure trailing newline for clean diff
-    if (!liveContent.endsWith("\n")) {
-      liveContent += "\n";
-    }
   } catch (err: unknown) {
     process.stderr.write(`error: snapshot failed: ${err instanceof Error ? err.message : String(err)}\n`);
     return 2;
   }
 
-  // Write live snapshot to temp file for diff
-  const tmpPath = resolve(SCRIPT_DIR, `.github-settings-live-${Date.now()}.json`);
+  // Strip scope-limited fields: when the live snapshot emits {_skipped: "insufficient-token-scope"}
+  // for a field (e.g. actions/permissions requires admin token, not available in CI), drop that
+  // field from both sides so a missing-scope field doesn't register as false drift.
+  let liveObj: Record<string, unknown>;
+  let expectedObj: Record<string, unknown>;
   try {
-    writeFileSync(tmpPath, liveContent, "utf8");
+    liveObj = JSON.parse(liveContent) as Record<string, unknown>;
+    expectedObj = JSON.parse(expectedContent) as Record<string, unknown>;
+  } catch {
+    process.stderr.write("error: failed to parse JSON snapshots\n");
+    return 2;
+  }
+
+  const skippedKeys: string[] = [];
+  for (const [key, value] of Object.entries(liveObj)) {
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      "_skipped" in (value as Record<string, unknown>) &&
+      (value as Record<string, unknown>)._skipped === "insufficient-token-scope"
+    ) {
+      skippedKeys.push(key);
+    }
+  }
+
+  if (skippedKeys.length > 0) {
+    process.stderr.write(
+      `github-settings-drift: skipping ${skippedKeys.length} field(s) not readable with current token: ${skippedKeys.join(", ")}\n`,
+    );
+    for (const key of skippedKeys) {
+      delete liveObj[key];
+      delete expectedObj[key];
+    }
+    liveContent = JSON.stringify(liveObj, null, 2);
+    expectedContent = JSON.stringify(expectedObj, null, 2);
+  }
+
+  if (!liveContent.endsWith("\n")) liveContent += "\n";
+  if (!expectedContent.endsWith("\n")) expectedContent += "\n";
+
+  // Write both to temp files for diff (content may have been stripped above)
+  const ts = Date.now();
+  const tmpLive = resolve(SCRIPT_DIR, `.github-settings-live-${ts}.json`);
+  const tmpExp = resolve(SCRIPT_DIR, `.github-settings-expected-${ts}.json`);
+  try {
+    writeFileSync(tmpLive, liveContent, "utf8");
+    writeFileSync(tmpExp, expectedContent, "utf8");
 
     // Run diff — exit 0 = identical, 1 = differences, 2 = error
-    const diffResult = await runCmd(["diff", "-u", expected, tmpPath]);
+    // Use --label so output shows real paths, not temp paths.
+    const diffResult = await runCmd(["diff", "-u", "--label", expected, "--label", "(live from gh api)", tmpExp, tmpLive]);
 
     if (diffResult.exitCode === 0) {
       process.stderr.write(`github-settings-drift: no drift (repo=${repo})\n`);
       return 0;
     } else if (diffResult.exitCode >= 2) {
-      // diff exit code 2+ means an error (missing file, unreadable, etc.)
       process.stderr.write(`error: diff command failed (exit ${diffResult.exitCode}): ${diffResult.stderr.trim()}\n`);
       return 2;
     } else {
@@ -160,10 +200,15 @@ export async function main(argv: readonly string[]): Promise<number> {
       return 1;
     }
   } finally {
-    // Clean up temp file
     try {
       const { unlinkSync } = await import("node:fs");
-      unlinkSync(tmpPath);
+      unlinkSync(tmpLive);
+    } catch {
+      // Best-effort cleanup
+    }
+    try {
+      const { unlinkSync } = await import("node:fs");
+      unlinkSync(tmpExp);
     } catch {
       // Best-effort cleanup
     }

--- a/tools/hygiene/snapshot-github-settings.ts
+++ b/tools/hygiene/snapshot-github-settings.ts
@@ -212,9 +212,10 @@ export async function snapshot(repo: string): Promise<string> {
   );
   const protection = parseJsonSafe(protectionRaw);
 
-  // Actions permissions
-  const actionsPermsRaw = await ghApi(`/repos/${repo}/actions/permissions`, "{enabled, allowed_actions}");
-  const actionsPerms = parseJsonSafe(actionsPermsRaw);
+  // Actions permissions — requires admin token; falls back to a sentinel when the
+  // GITHUB_TOKEN in CI lacks that scope (HTTP 403).
+  const actionsPermsRaw = await ghApiOptional(`/repos/${repo}/actions/permissions`, "{enabled, allowed_actions}");
+  const actionsPerms = actionsPermsRaw === null ? { _skipped: "insufficient-token-scope" } : parseJsonSafe(actionsPermsRaw);
 
   // Actions variables
   const actionsVarsRaw = await ghApi(


### PR DESCRIPTION
## Summary

- Fixes `check drift` CI failure caused by `GITHUB_TOKEN` lacking admin scope for `/repos/.../actions/permissions` (HTTP 403)
- `snapshot-github-settings.ts`: switches `actions/permissions` from `ghApi` (throws on failure) to `ghApiOptional`; emits `{_skipped: \"insufficient-token-scope\"}` sentinel when 403
- `check-github-settings-drift.ts`: before diffing, strips sentinel fields from both sides and warns on stderr — prevents false drift for admin-only endpoints

Real drift on fields the token CAN read is still detected normally. When running locally with an admin token, the sentinel never fires and all fields are compared.

## Root cause

The `check drift` workflow check was failing on every PR with:
```
error: snapshot failed: gh api /repos/.../actions/permissions failed (exit 1): gh: Resource not accessible by integration (HTTP 403)
```
The default `GITHUB_TOKEN` in Actions doesn't have `admin` scope to read repository Actions permissions settings. The check was non-required but produced noise on every PR.

## Verification

```
bun tools/hygiene/check-github-settings-drift.ts --repo Lucent-Financial-Group/Zeta
→ github-settings-drift: no drift (repo=Lucent-Financial-Group/Zeta)
```

No sentinel triggered locally (admin token has full access). In CI, the sentinel will fire for `actions_permissions`, emit a skip warning, and the diff will proceed on all other fields.

## Test plan

- [x] Drift check passes locally (no false positives)
- [x] sentinel path verified by inspecting code: null → `{_skipped: "insufficient-token-scope"}` → stripped from both sides before diff
- [x] Build gate: `dotnet build -c Release` → 0 Warning(s) 0 Error(s)
- [x] Rebased on main (after #2447 merged with refreshed `github-settings.expected.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)