### PR TITLE
fix: also skip actions/variables 403 with insufficient-token-scope sentinel

### DIFF
--- a/tools/hygiene/snapshot-github-settings.ts
+++ b/tools/hygiene/snapshot-github-settings.ts
@@ -217,12 +217,13 @@ export async function snapshot(repo: string): Promise<string> {
   const actionsPermsRaw = await ghApiOptional(`/repos/${repo}/actions/permissions`, "{enabled, allowed_actions}");
   const actionsPerms = actionsPermsRaw === null ? { _skipped: "insufficient-token-scope" } : parseJsonSafe(actionsPermsRaw);
 
-  // Actions variables
-  const actionsVarsRaw = await ghApi(
+  // Actions variables — requires admin token; falls back to a sentinel when the
+  // GITHUB_TOKEN in CI lacks that scope (HTTP 403).
+  const actionsVarsRaw = await ghApiOptional(
     `/repos/${repo}/actions/variables`,
     "[.variables[]? | {name, value}] | sort_by(.name)"
   );
-  const actionsVars = parseJsonSafe(actionsVarsRaw, []);
+  const actionsVars = actionsVarsRaw === null ? { _skipped: "insufficient-token-scope" } : parseJsonSafe(actionsVarsRaw, []);
 
   // Workflows
   const workflowsRaw = await ghApi(


### PR DESCRIPTION
## Summary

- PR #2448 fixed the `check drift` 403 for `actions/permissions` but CI immediately revealed `actions/variables` hits the same problem
- Applies the identical sentinel pattern: `ghApiOptional` + `{_skipped:"insufficient-token-scope"}` fallback
- `check-github-settings-drift.ts` already strips any top-level field with that sentinel before diffing — no changes needed there

## Root cause

`/repos/.../actions/variables` requires admin token scope, same as `actions/permissions`. The CI `GITHUB_TOKEN` lacks it, producing:
```
error: snapshot failed: gh api /repos/.../actions/variables failed (exit 1): gh: Resource not accessible by integration (HTTP 403)
```

## Verification

```
bun tools/hygiene/check-github-settings-drift.ts --repo Lucent-Financial-Group/Zeta
→ github-settings-drift: no drift (repo=Lucent-Financial-Group/Zeta)
```

## Test plan

- [x] `bun tsc --noEmit` passes clean
- [x] Single-line diff: `ghApi` → `ghApiOptional` + sentinel for `actions/variables`
- [x] No change needed to drift checker — sentinel-stripping loop already handles any skipped key

🤖 Generated with [Claude Code](https://claude.com/claude-code)