### PR TITLE
fix: also skip code-scanning/default-setup 403 with insufficient-token-scope sentinel

### DIFF
--- a/tools/hygiene/snapshot-github-settings.ts
+++ b/tools/hygiene/snapshot-github-settings.ts
@@ -243,12 +243,13 @@ export async function snapshot(repo: string): Promise<string> {
   const pagesRaw = await ghApiOptional(`/repos/${repo}/pages`, "{source, build_type, https_enforced, public}");
   const pages = parseJsonSafe(pagesRaw);
 
-  // CodeQL default setup
-  const codeqlRaw = await ghApi(
+  // CodeQL default setup — requires admin token; falls back to a sentinel when the
+  // GITHUB_TOKEN in CI lacks that scope (HTTP 403).
+  const codeqlRaw = await ghApiOptional(
     `/repos/${repo}/code-scanning/default-setup`,
     "{state, languages: (.languages | sort), query_suite}"
   );
-  const codeql = parseJsonSafe(codeqlRaw);
+  const codeql = codeqlRaw === null ? { _skipped: "insufficient-token-scope" } : parseJsonSafe(codeqlRaw);
 
   // Counts
   const webhooksCountRaw = await ghApi(`/repos/${repo}/hooks`, "length");


### PR DESCRIPTION
## Summary

- PRs #2448 and #2449 fixed `actions/permissions` and `actions/variables` 403s respectively, but CI immediately revealed `code-scanning/default-setup` hits the same problem
- Applies the identical sentinel pattern: `ghApiOptional` + `{_skipped:"insufficient-token-scope"}` fallback
- `check-github-settings-drift.ts` already strips any top-level field with that sentinel before diffing — no changes needed there

## Root cause

`/repos/.../code-scanning/default-setup` requires admin token scope. The CI `GITHUB_TOKEN` lacks it, producing:
```
error: snapshot failed: gh api /repos/.../code-scanning/default-setup failed (exit 1): gh: Resource not accessible by integration (HTTP 403)
```

## Test plan

- [x] `bun tsc --noEmit` passes clean
- [x] Single pattern change: `ghApi` → `ghApiOptional` + sentinel for `code-scanning/default-setup`
- [x] No change needed to drift checker — sentinel-stripping loop already handles any skipped key

🤖 Generated with [Claude Code](https://claude.com/claude-code)