### PR TITLE
fix: gate codeql-403 sentinel on HTTP 403 only, not all errors

### DIFF
--- a/tools/hygiene/snapshot-github-settings.ts
+++ b/tools/hygiene/snapshot-github-settings.ts
@@ -70,6 +70,23 @@ async function ghApiOptional(path: string, jqFilter?: string): Promise<string | 
   return r.stdout.trim();
 }
 
+// Like ghApiOptional but only silences HTTP 403 token-scope errors; all other
+// failures are fatal so they don't get silently swallowed by the sentinel path.
+async function ghApiSkip403(path: string, jqFilter?: string): Promise<string | null> {
+  const args = ["gh", "api", path];
+  if (jqFilter !== undefined) {
+    args.push("--jq", jqFilter);
+  }
+  const r = await runCmd(args);
+  if (r.exitCode !== 0) {
+    if (r.stderr.includes("HTTP 403")) {
+      return null;
+    }
+    throw new Error(`gh api ${path} failed (exit ${r.exitCode}): ${r.stderr.trim()}`);
+  }
+  return r.stdout.trim();
+}
+
 function parseJsonSafe(raw: string | null, fallback: unknown = null): unknown {
   if (raw === null || raw.length === 0) return fallback;
   try {
@@ -244,8 +261,9 @@ export async function snapshot(repo: string): Promise<string> {
   const pages = parseJsonSafe(pagesRaw);
 
   // CodeQL default setup — requires admin token; falls back to a sentinel when the
-  // GITHUB_TOKEN in CI lacks that scope (HTTP 403).
-  const codeqlRaw = await ghApiOptional(
+  // GITHUB_TOKEN in CI lacks that scope (HTTP 403). Other errors remain fatal so
+  // transient API failures are not silently hidden from the drift check.
+  const codeqlRaw = await ghApiSkip403(
     `/repos/${repo}/code-scanning/default-setup`,
     "{state, languages: (.languages | sort), query_suite}"
   );


### PR DESCRIPTION
## Summary

Follow-up to #2450. Codex reviewer (P2) caught that `ghApiOptional` silences **any** non-zero exit, not just HTTP 403 token-scope errors. The `code-scanning/default-setup` sentinel path would silently hide transient API failures, jq query errors, or endpoint regressions — they'd get swallowed by the sentinel-stripping loop in `check-github-settings-drift.ts`.

- Adds `ghApiSkip403`: identical to `ghApiOptional` except it only returns `null` when `stderr` contains `"HTTP 403"`; all other errors re-throw and remain fatal
- Swaps `code-scanning/default-setup` to use `ghApiSkip403` so only the intended insufficient-token-scope 403 gets the sentinel

## Test plan

- [x] `bun tsc --noEmit` passes clean
- [x] 403 path: stderr contains `HTTP 403` → returns null → sentinel `{_skipped: "insufficient-token-scope"}` applied
- [x] Non-403 path: any other error → throws → snapshot fails loudly (not silently hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)