### PR TITLE
fix: also skip hooks 403 with insufficient-token-scope sentinel

### DIFF
--- a/tools/hygiene/check-github-settings-drift.ts
+++ b/tools/hygiene/check-github-settings-drift.ts
@@ -128,6 +128,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   // Strip scope-limited fields: when the live snapshot emits {_skipped: "insufficient-token-scope"}
   // for a field (e.g. actions/permissions requires admin token, not available in CI), drop that
   // field from both sides so a missing-scope field doesn't register as false drift.
+  // Stripping is recursive so nested fields (e.g. counts.webhooks) are also handled.
   let liveObj: Record<string, unknown>;
   let expectedObj: Record<string, unknown>;
   try {
@@ -138,26 +139,52 @@ export async function main(argv: readonly string[]): Promise<number> {
     return 2;
   }
 
-  const skippedKeys: string[] = [];
-  for (const [key, value] of Object.entries(liveObj)) {
-    if (
-      value !== null &&
-      typeof value === "object" &&
-      "_skipped" in (value as Record<string, unknown>) &&
-      (value as Record<string, unknown>)._skipped === "insufficient-token-scope"
-    ) {
-      skippedKeys.push(key);
+  function isSkipped(v: unknown): boolean {
+    return (
+      v !== null &&
+      typeof v === "object" &&
+      "_skipped" in (v as Record<string, unknown>) &&
+      (v as Record<string, unknown>)._skipped === "insufficient-token-scope"
+    );
+  }
+
+  function stripSkippedSentinels(
+    live: Record<string, unknown>,
+    exp: Record<string, unknown>,
+    pathPrefix: string,
+    report: string[],
+  ): void {
+    for (const key of Object.keys(live)) {
+      const val = live[key];
+      if (isSkipped(val)) {
+        report.push(pathPrefix.length > 0 ? `${pathPrefix}.${key}` : key);
+        delete live[key];
+        delete exp[key];
+      } else if (
+        val !== null &&
+        typeof val === "object" &&
+        !Array.isArray(val) &&
+        exp[key] !== null &&
+        typeof exp[key] === "object" &&
+        !Array.isArray(exp[key])
+      ) {
+        stripSkippedSentinels(
+          val as Record<string, unknown>,
+          exp[key] as Record<string, unknown>,
+          pathPrefix.length > 0 ? `${pathPrefix}.${key}` : key,
+          report,
+        );
+      }
     }
   }
 
-  if (skippedKeys.length > 0) {
+  const skippedPaths: string[] = [];
+  stripSkippedSentinels(liveObj, expectedObj, "", skippedPaths);
+
+  if (skippedPaths.length > 0) {
     process.stderr.write(
-      `github-settings-drift: skipping ${skippedKeys.length} field(s) not readable with current token: ${skippedKeys.join(", ")}\n`,
+      `github-settings-drift: skipping ${skippedPaths.length} field(s) not readable with current token: ${skippedPaths.join(", ")}\n`,
     );
-    for (const key of skippedKeys) {
-      delete liveObj[key];
-      delete expectedObj[key];
-    }
     liveContent = JSON.stringify(liveObj, null, 2);
     expectedContent = JSON.stringify(expectedObj, null, 2);
   }

--- a/tools/hygiene/snapshot-github-settings.ts
+++ b/tools/hygiene/snapshot-github-settings.ts
@@ -251,13 +251,14 @@ export async function snapshot(repo: string): Promise<string> {
   );
   const codeql = codeqlRaw === null ? { _skipped: "insufficient-token-scope" } : parseJsonSafe(codeqlRaw);
 
-  // Counts
-  const webhooksCountRaw = await ghApi(`/repos/${repo}/hooks`, "length");
+  // Counts — hooks requires admin token; falls back to a sentinel when the
+  // GITHUB_TOKEN in CI lacks that scope (HTTP 403).
+  const webhooksCountRaw = await ghApiOptional(`/repos/${repo}/hooks`, "length");
   const deployKeysCountRaw = await ghApi(`/repos/${repo}/keys`, "length");
   const actionsSecretsCountRaw = await ghApi(`/repos/${repo}/actions/secrets`, ".secrets | length");
   const dependabotSecretsCountRaw = await ghApiOptional(`/repos/${repo}/dependabot/secrets`, ".secrets | length");
 
-  const webhooksCount = parseInt(webhooksCountRaw, 10) || 0;
+  const webhooksCount = webhooksCountRaw === null ? { _skipped: "insufficient-token-scope" } : (parseInt(webhooksCountRaw, 10) || 0);
   const deployKeysCount = parseInt(deployKeysCountRaw, 10) || 0;
   const actionsSecretsCount = parseInt(actionsSecretsCountRaw, 10) || 0;
   const dependabotSecretsCount = parseInt(dependabotSecretsCountRaw ?? "0", 10) || 0;


### PR DESCRIPTION
## Summary

- `/repos/:repo/hooks` returns HTTP 403 in CI when `GITHUB_TOKEN` lacks admin scope, crashing the snapshot with _\"Resource not accessible by integration\"_ and failing the `check drift` job (non-required, but noisy)
- `snapshot-github-settings.ts`: switch from `ghApi` → `ghApiOptional` for `/hooks`; when null, emit `{ _skipped: \"insufficient-token-scope\" }` for `counts.webhooks` (same sentinel pattern as #2448/#2449/#2450)
- `check-github-settings-drift.ts`: make the `_skipped` sentinel-stripping recursive so it handles nested fields like `counts.webhooks` inside the `counts` object, not just top-level keys

## Test plan

- [ ] `bun tools/hygiene/check-github-settings-drift.ts` — passes locally with no drift
- [ ] `dotnet build -c Release` — 0 warnings, 0 errors
- [ ] CI `check drift` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)