### PR TITLE
fix: gate hooks 403 sentinel on HTTP 403 only, not all errors

### DIFF
--- a/tools/hygiene/snapshot-github-settings.ts
+++ b/tools/hygiene/snapshot-github-settings.ts
@@ -270,8 +270,9 @@ export async function snapshot(repo: string): Promise<string> {
   const codeql = codeqlRaw === null ? { _skipped: "insufficient-token-scope" } : parseJsonSafe(codeqlRaw);
 
   // Counts — hooks requires admin token; falls back to a sentinel when the
-  // GITHUB_TOKEN in CI lacks that scope (HTTP 403).
-  const webhooksCountRaw = await ghApiOptional(`/repos/${repo}/hooks`, "length");
+  // GITHUB_TOKEN in CI lacks that scope (HTTP 403). Other errors remain fatal
+  // so transient API failures are not silently hidden from the drift check.
+  const webhooksCountRaw = await ghApiSkip403(`/repos/${repo}/hooks`, "length");
   const deployKeysCountRaw = await ghApi(`/repos/${repo}/keys`, "length");
   const actionsSecretsCountRaw = await ghApi(`/repos/${repo}/actions/secrets`, ".secrets | length");
   const dependabotSecretsCountRaw = await ghApiOptional(`/repos/${repo}/dependabot/secrets`, ".secrets | length");


### PR DESCRIPTION
## Summary

- PR #2456 merged with `ghApiOptional` for `/repos/:repo/hooks` rather than `ghApiSkip403`
- `ghApiOptional` returns `null` for **any** non-zero exit (5xx, rate-limit, network errors), not just HTTP 403 scope errors — this silently hides real API failures from the drift check
- `ghApiSkip403` was added in #2454 specifically to address this same class of bug for the codeql endpoint; this PR applies the same pattern to the webhooks count
- Both Codex and Copilot reviewers flagged this on #2456 before it merged via auto-merge

## Fix

One-line: `ghApiOptional` → `ghApiSkip403` at the `/repos/:repo/hooks` call site, with comment clarifying that non-403 failures remain fatal.

## Test plan

- [x] `bun tools/hygiene/check-github-settings-drift.ts` — passes with no drift
- [x] `dotnet build -c Release` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)