### PR TITLE
feat(B-0161): add thoughts-free-actions-razored asymmetry bullet to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,3 +45,5 @@ See [`docs/CONFLICT-RESOLUTION.md`](docs/CONFLICT-RESOLUTION.md). On deadlock, t
 - **Result-over-exception** — errors surface as `Result<_, DbspError>`; no exceptions on hot paths.
 - **Memory fast-path** — read `~/.claude/projects/<slug>/memory/CURRENT-*.md` before raw
   `feedback_*.md` logs; CURRENT files win on conflict with older raw memories.
+- **Thoughts free, actions razored** — journal to `memory/` freely; CLAUDE.md additions
+  are razored (cooling-period required, disposition-shaping bar). Full: `memory/feedback_thoughts_free_actions_razored_*`.

--- a/docs/backlog/P1/B-0161-substrate-reshelf-asymmetry-applied-to-pr-1202-overshoot-aaron-claudeai-2026-05-02.md
+++ b/docs/backlog/P1/B-0161-substrate-reshelf-asymmetry-applied-to-pr-1202-overshoot-aaron-claudeai-2026-05-02.md
@@ -91,3 +91,26 @@ M — careful re-architecture work. Single-PR scope but requires deliberate cool
 This row is itself an instance of the rule it's about: the immediate same-session reshelf would have violated the cooling-period; deferring to a backlog row IS the asymmetry applied. Recursive validation.
 
 Aaron's framing for the next-session bootstrap (a few hours from now per his 2026-05-02 message): make sure setup is in place or backlogged. This row covers the in-flight substrate that wants tightening before becoming permanently part of the next session's wake-time payload.
+
+## Pre-start checklist (2026-05-10)
+
+### Prior-art search
+
+| Surface | Query | Result |
+|---------|-------|--------|
+| wake-time-substrate rule | grep "asymmetry" .claude/rules/ | No existing rule for asymmetry; it's described in memory file only |
+| skill-router | available-skills list | No skill covers this convention-addition |
+| orthogonal-axes | B-0351, B-0352, B-0353 | B-0352 closed: extracted 7 bullets to .claude/rules/; B-0353 closed: condensed CLAUDE.md to 47 lines. Demotion work done; asymmetry bullet NOT yet added |
+| Otto-364 | PR #1202, memory file | `memory/feedback_thoughts_free_actions_razored_asymmetry_journal_vs_canonical_substrate_separation_aaron_claudeai_2026_05_02.md` explicitly says "CLAUDE.md should add a single bullet for this asymmetry rule" |
+| lost-files | git log | No lost-files issues found |
+
+**Finding:** The demotion work (action-hierarchy, amortized-speed, edge-runner, cron-unreliability) is already done via B-0351/B-0352. The asymmetry bullet itself was NEVER added to CLAUDE.md. This is the remaining work.
+
+### Dependency check
+
+- **B-0160** (depends_on): closed 2026-05-10 (PR #2459) ✓
+- Cooling-period: PR #1202 was 2026-05-02; now 2026-05-10 = 8 days elapsed ✓
+
+### Smallest safe slice
+
+Add the asymmetry rule as a single bullet in CLAUDE.md Conventions section. This is the one remaining acceptance criterion from the "Razored work" section that B-0351/B-0352/B-0353 didn't cover.


### PR DESCRIPTION
## Summary

- Adds the **thoughts-free, actions-razored** asymmetry as a Convention bullet in `CLAUDE.md` (47 → 49 lines, under 50-line B-0353 boundary)
- Adds pre-start checklist to `B-0161` backlog row with prior-art proof and dependency verification
- Closes the one remaining razored acceptance criterion from B-0161 that was never covered by B-0351/B-0352/B-0353

## Why this is the smallest safe slice

The demotion work from B-0161 (action-hierarchy, amortized-speed, edge-runner, cron-unreliability) was already landed by B-0351 (PR #2435) and B-0352 (PR #2446). The condensed CLAUDE.md was written by B-0353 (PR #2462). What remained was the one explicit addition the B-0161 memory file mandated:

> *"CLAUDE.md should add a single bullet for this asymmetry rule. This rule IS truly disposition-shaping at wake-time — it changes how every other rule gets applied."*

Cooling-period: PR #1202 (origin) was 2026-05-02; this PR is 2026-05-10 — 8 days elapsed.

## Checks

- `dotnet build -c Release` → **0 Warning(s), 0 Error(s)** ✓
- CLAUDE.md line count: **49 lines** (under the 50-line B-0353 boundary) ✓
- Glob `memory/feedback_thoughts_free_actions_razored_*` resolves to the doctrine file ✓

## Remaining B-0161 scope (not this PR)

The free-zone work (journal taxonomy decision + `memory/journal/` subdirectory + MEMORY.md index restructure) remains open and can land in a follow-up at any tick without cooling-period.

operative-authorization: aaron 2026-05-04: "it**, not just the output. Grinding through failures + recoveries"