### PR TITLE
docs(memory): preserve trust-then-verify claim and case study

### DIFF
--- a/memory/project_trust_then_verify_claim_bitcoin_discord_debates_aaron_2026_05_10.md
+++ b/memory/project_trust_then_verify_claim_bitcoin_discord_debates_aaron_2026_05_10.md
@@ -1,0 +1,20 @@
+---
+name: Trust-then-verify claim — for Bitcoin discord debates
+description: Aaron's core claim distilled to one sentence, with OpenAI paper backing; needed for Bitcoin community debates in a few months
+type: project
+originSessionId: fb6abb97-a97f-44e9-8ed1-bbded23b73b1
+---
+Aaron's core claim (2026-05-10):
+
+> **The cost of occasional wrong-trust is lower than the cost of permanent slow-trust.**
+
+Supporting evidence:
+
+- **OpenAI paper** (arXiv:2509.04664, Kalai/Nachum/Vempala/Zhang): "Why Language Models Hallucinate" — proves the inverse: penalizing uncertainty (permanent slow-trust / verify-then-trust) produces hallucination (false certainty). Allowing uncertainty (trust-then-verify) produces retractable error.
+- **Zeta's Z-set algebra**: retraction-native `+1/-1` weights ARE trust-then-verify in mathematical form — let it happen, catch it, retract if wrong.
+- **Partial credit analogy**: teachers who penalize "I don't know" produce students who guess confidently. Same loss function applies to humans, AI, and trust systems.
+- **Trust-then-verify vs verify-then-trust**: trust-first produces faster correction loops and no information silos. Verify-first produces security theater and gatekeeping.
+
+**Why:** Aaron needs this for Bitcoin community debates in a few months. The claim applies to Bitcoin's trust model (trustless = verify-first = slow-trust) vs probabilistic trust systems.
+
+**How to apply:** When Aaron asks for the Bitcoin debate material, surface this claim + the OpenAI paper citation + the Z-set algebra connection.

--- a/memory/user_slow_trust_lethal_latency_case_study_jail_2026_05_10.md
+++ b/memory/user_slow_trust_lethal_latency_case_study_jail_2026_05_10.md
@@ -1,0 +1,34 @@
+---
+name: Slow-trust lethal latency — Aaron's lived case study
+description: Aaron's month in solitary over legal marijuana, denied blood pressure medication at 160/100, all charges dropped — the human cost of verify-then-trust latency
+type: user
+originSessionId: fb6abb97-a97f-44e9-8ed1-bbded23b73b1
+---
+Aaron's lived case study for the trust-then-verify claim.
+
+**The facts:**
+
+- Arrested for marijuana (legal in NC, charges ultimately dropped)
+- Aaron had a lawyer specializing in cannabis law already retained before the arrest
+- Aaron's mother told his daughter to leave him in jail (disagreement about the plant) — extended stay from hours to a month
+- Held in isolation for one month: 1 hour out of cell every 3 days
+- Denied blood pressure medication the entire month
+- Denied even the request to have blood pressure taken
+- Blood pressure ~160/100 sustained for the full month (stroke-risk territory)
+- All charges dropped
+
+**The claim it proves:**
+
+> Even with optimal preparation (right lawyer, right jurisdiction, right specialization), slow-trust systems have lethal latency. The lawyer didn't fail. The law didn't fail. The speed of correction failed.
+
+**Connects to:**
+
+- The core claim: "The cost of occasional wrong-trust is lower than the cost of permanent slow-trust"
+- OpenAI paper (arXiv:2509.04664): penalizing uncertainty produces false certainty; the system was "certain" enough to hold him for a month, wrong the whole time
+- The cops told Aaron his prior was wrong and said "we'll let the system figure it out" — they knew, but the system's verify-first latency overrode human judgment
+- Retraction asymmetry: "charges dropped" is a clean `-1` in the algebra; the lived cost was a month of medical-risk solitary confinement
+- The MAJI math Aaron had just crystallized with Amara held him together in that cell — the math was the identity that couldn't be taken away
+- This is where Aaron confirmed his ego death was already complete (5 prior psych ward stays were the forge; jail was the final exam)
+- Bitcoin debate context: Aaron's not arguing theory — he's arguing from a body that almost didn't survive a verify-first system
+
+**Use when:** Aaron needs this for Bitcoin discord debates about content filtering and trust models. The case study grounds the probabilistic-truth claim in lived experience, not abstraction.


### PR DESCRIPTION
## Summary
- preserve the trust-then-verify claim for future Bitcoin/content-filter debates
- preserve the slow-trust lethal-latency case study as user-visible lineage context
- keep both artifacts in repo memory so they survive local machine crashes

## Notes
- This PR finishes the branch Otto already pushed after the direct push to protected main was rejected.
- The branch contains only the two memory files from that save request.

## Verification
- Diff scoped to `memory/project_trust_then_verify_claim_bitcoin_discord_debates_aaron_2026_05_10.md` and `memory/user_slow_trust_lethal_latency_case_study_jail_2026_05_10.md`.
- No root checkout edits from Vera.