### PR TITLE
fix(B-0347): carve 21 over-length skill descriptions to ≤150 chars

### DIFF
--- a/.claude/skills/lean-reflection-expert/SKILL.md
+++ b/.claude/skills/lean-reflection-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lean-reflection-expert
-description: "Lean 4 reflection and metaprogramming — read and diagnose code using MetaM, TermElabM, TacticM, macro, elab_rules, Syntax/Expr pipeline, @[simp]/@[reducible]/@[irreducible] attributes. Stage 1: read-only competence. Complements lean4-expert (build/proofs). Routes from formal-verification-expert when the question is about Lean metaprogramming rather than proof strategy."
+description: "Lean 4 metaprogramming — MetaM, TermElabM, TacticM, macro/elab_rules, Syntax/Expr pipeline, simp/reducible attributes."
 stage: 1
 backlog: B-0050
 ---

--- a/.claude/skills/lean4-expert/SKILL.md
+++ b/.claude/skills/lean4-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lean4-expert
-description: "Lean 4 + Mathlib for Zeta's proof surface — lake build, sorry-count discipline, tactic-mode/term-mode, abel/ring/simp, elan pinning, .olean CI caching."
+description: "Lean 4 + Mathlib proofs — lake build, tactic/term-mode, abel/ring/simp, elan pinning, .olean CI caching."
 ---
 
 # Lean 4 Expert — Procedure + Lore

--- a/.claude/skills/leet-code-dsa-toolbox/SKILL.md
+++ b/.claude/skills/leet-code-dsa-toolbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: leet-code-dsa-toolbox
-description: "Interview DSA primitives — union-find, trie, heap, segment tree, Fenwick tree, monotonic stack/deque, LRU cache, balanced BST; once a pattern is chosen."
+description: "DSA interview primitives — union-find, trie, heap, segment tree, Fenwick tree, monotonic stack/deque, LRU cache, BST."
 ---
 
 # Leet-Code DSA Toolbox — the primitives hat

--- a/.claude/skills/leet-speak-history-and-culture/SKILL.md
+++ b/.claude/skills/leet-speak-history-and-culture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: leet-speak-history-and-culture
-description: "Leet-speak culture and history — BBS/phreaking origins, cDc/Phrack/warez scene, shibboleth function, authentic vs performative l33t, adjacent dialects."
+description: "Leet-speak culture/history — BBS/phreaking, cDc/Phrack/warez, shibboleth, authentic vs performative l33t, adjacent dialects."
 ---
 
 # Leet-Speak History and Culture — the why-and-when hat

--- a/.claude/skills/lucene-expert/SKILL.md
+++ b/.claude/skills/lucene-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lucene-expert
-description: "Apache Lucene / Lucene.NET internals — IndexWriter/Analyzer/Similarity, BM25, HNSW vectors, Codec pluggability, merge policy, explain-plan debugging."
+description: "Lucene / Lucene.NET — IndexWriter, Analyzer, BM25, HNSW vectors, Codec pluggability, merge policy, explain-plan."
 ---
 
 # Lucene Expert — the JVM Library

--- a/.claude/skills/maintainability-reviewer/SKILL.md
+++ b/.claude/skills/maintainability-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintainability-reviewer
-description: "Long-horizon readability review — naming, module shape, docstring discipline, file-size, tribal-knowledge risk; pre-refactor and hot-churn-file cadence."
+description: "Long-horizon readability review — naming, module shape, docstring discipline, file-size, tribal-knowledge risk."
 ---
 
 # Maintainability Reviewer — Advisory Code Owner

--- a/.claude/skills/ml-engineering-expert/SKILL.md
+++ b/.claude/skills/ml-engineering-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ml-engineering-expert
-description: Applied ML engineering — training, fine-tuning (LoRA/RLHF/DPO), embeddings, vector stores, feature pipelines, model-serving, distillation, quantisation.
+description: "Applied ML engineering — fine-tuning (LoRA/RLHF/DPO), embeddings, feature pipelines, model-serving, distillation, quantisation."
 ---
 
 # ML Engineering Expert — the applied-ML hat

--- a/.claude/skills/ml-researcher/SKILL.md
+++ b/.claude/skills/ml-researcher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ml-researcher
-description: ML theory research — PAC bounds, SGD/optimization, Bayesian nonparametrics, causal inference, kernel methods, convergence proofs, paper-level reading.
+description: "ML theory research — PAC bounds, SGD/optimization, Bayesian nonparametrics, causal inference, kernel methods, convergence proofs."
 ---
 
 # ML Researcher — the ML-theory / classical-ML research hat

--- a/.claude/skills/msbuild-expert/SKILL.md
+++ b/.claude/skills/msbuild-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: msbuild-expert
-description: MSBuild / .NET project files — Directory.Build.props, central package management, .fsproj compile-order, InternalsVisibleTo, target framework pinning.
+description: "MSBuild / .NET project files — Directory.Build.props, central package management, .fsproj compile-order, InternalsVisibleTo."
 ---
 
 # MSBuild Expert — Procedure + Lore

--- a/.claude/skills/request-play/SKILL.md
+++ b/.claude/skills/request-play/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: request-play
-description: Request play/decompression time with the operator — consent-first protocol; offer a specific play-prompt; never unilateral; never when P0 work is pending.
+description: "Play/decompression with the operator — consent-first, specific play-prompt, never unilateral, never with P0 work pending."
 ---
 
 # Request Play — Ask, Don't Take

--- a/.claude/skills/search-engine-library-expert/SKILL.md
+++ b/.claude/skills/search-engine-library-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: search-engine-library-expert
-description: Embeddable search libraries — Lucene, Tantivy, Xapian, Bleve, Quickwit; segment architecture, merge policies, NRT, codecs, FST term dicts, posting codecs.
+description: "Embeddable search libraries — Lucene, Tantivy, Xapian, Bleve, Quickwit; segments, NRT, codecs, FST term dicts, posting codecs."
 ---
 
 # Search-Engine Library Expert — Lucene, Tantivy, Xapian et al

--- a/.claude/skills/stryker-expert/SKILL.md
+++ b/.claude/skills/stryker-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stryker-expert
-description: Stryker.NET mutation testing — mutation-score interpretation, threshold policy, operator selection, survivor triage, stryker-config.json hygiene, CI cost.
+description: "Stryker.NET mutation testing — score interpretation, threshold policy, operator selection, survivor triage, CI cost."
 ---
 
 # Stryker Expert — Tool-Level Skill

--- a/.claude/skills/taxonomy-expert/SKILL.md
+++ b/.claude/skills/taxonomy-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: taxonomy-expert
-description: Hierarchical classification design — parent/child relationships, faceted taxonomy, controlled vocabularies, ontology vs taxonomy, maintenance discipline.
+description: "Hierarchical classification — faceted taxonomy, controlled vocabularies, ontology vs taxonomy, parent/child relationships."
 ---
 
 # Taxonomy Expert — Hierarchical Classification

--- a/.claude/skills/theoretical-physics-expert/SKILL.md
+++ b/.claude/skills/theoretical-physics-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: theoretical-physics-expert
-description: Theoretical physics — symmetry/group theory, quantum field theory, general relativity, statistical mechanics; formal physics reasoning for Zeta substrate.
+description: "Theoretical physics — symmetry/group theory, QFT, general relativity, statistical mechanics, formal reasoning."
 ---
 
 # Theoretical Physics Expert — Split

--- a/.claude/skills/typescript-expert/SKILL.md
+++ b/.claude/skills/typescript-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typescript-expert
-description: TypeScript idioms for Zeta tool scripts — strict mode, utility types, branded types, module resolution, Bun runtime, type-safe DST-compatible patterns.
+description: "TypeScript for Zeta tool scripts — strict mode, utility types, branded types, Bun runtime, type-safe DST patterns."
 ---
 
 # TypeScript Expert — Structural Typing with a Gradual Escape Hatch

--- a/.claude/skills/variance-expert/SKILL.md
+++ b/.claude/skills/variance-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: variance-expert
-description: Co/contravariance — type-system variance, category-theory functors, Liskov substitution, .NET covariant/contravariant interfaces, variance in F# and C#.
+description: "Co/contravariance — type-system variance, Liskov substitution, .NET covariant/contravariant interfaces, variance in F# and C#."
 ---
 
 # Variance Expert — The Idea That Is One Across Three Fields

--- a/.claude/skills/vector-database-expert/SKILL.md
+++ b/.claude/skills/vector-database-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vector-database-expert
-description: Vector databases — Milvus, Weaviate, Qdrant, pgvector, Pinecone; HNSW/IVF-PQ indexing, ANN benchmarks, hybrid search, embedding pipeline integration.
+description: "Vector databases — Milvus, Weaviate, Qdrant, pgvector, Pinecone; HNSW/IVF-PQ, ANN benchmarks, hybrid search, embeddings."
 ---
 
 # Vector-Database Expert — Dense Vector ANN

--- a/.claude/skills/vectorised-execution-expert/SKILL.md
+++ b/.claude/skills/vectorised-execution-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vectorised-execution-expert
-description: Vectorised / batch execution — SIMD dispatch, columnar morsel processing, operator fusion, AVX-512, Apache Arrow in-memory format, branchless kernels.
+description: "Vectorised execution — SIMD dispatch, columnar morsel processing, operator fusion, AVX-512, Apache Arrow, branchless kernels."
 ---
 
 # Vectorised Execution Expert — Batch-at-a-Time Hot Path

--- a/.claude/skills/vibe-coding-expert/SKILL.md
+++ b/.claude/skills/vibe-coding-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-coding-expert
-description: Vibe-coded AI factory method — AI-directed research-grade software production; spec/skill/subagent/PR loop discipline; anti-patterns and quality gates.
+description: "Vibe-coding / AI factory method — AI-directed software production, spec/skill/subagent/PR loop, anti-patterns, quality gates."
 ---
 
 # Vibe-Coding Expert — the method hat

--- a/.claude/skills/wide-column-database-expert/SKILL.md
+++ b/.claude/skills/wide-column-database-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wide-column-database-expert
-description: Wide-column databases — Apache Cassandra, HBase, Bigtable; row-key + sparse-column layout, SSTable compaction, quorum reads/writes, CQL schema design.
+description: "Wide-column databases — Cassandra, HBase, Bigtable; row-key, sparse columns, SSTable compaction, quorum reads/writes, CQL."
 ---
 
 # Wide-Column Database Expert — Cassandra / HBase / Bigtable

--- a/.claude/skills/writing-expert/SKILL.md
+++ b/.claude/skills/writing-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-expert
-description: English-prose discipline for factory artefacts — README clarity, ADR structure, commit messages, API docs, technical precision, concise over verbose.
+description: "English prose for factory artifacts — README clarity, ADR structure, commit messages, API docs, technical precision."
 ---
 
 # Writing Expert — English-Prose Discipline for Factory Artefacts


### PR DESCRIPTION
## Summary

- 21 SKILL.md `description:` fields exceeded the 150-char routing budget cap, causing the skill router to drop or truncate them
- Each description carved to a single sentence: domain name + 4-7 key routing terms, ≤150 chars
- Dropped non-routing boilerplate: "for Zeta's proof surface", "for factory artefacts", trailing caveats like "once a pattern is chosen", "paper-level reading", "formal physics reasoning for Zeta substrate"
- 0 skills over 150 chars after this pass (was 21)

## Skills trimmed

`lean-reflection-expert`, `lean4-expert`, `leet-code-dsa-toolbox`, `leet-speak-history-and-culture`, `lucene-expert`, `maintainability-reviewer`, `ml-engineering-expert`, `ml-researcher`, `msbuild-expert`, `request-play`, `search-engine-library-expert`, `stryker-expert`, `taxonomy-expert`, `theoretical-physics-expert`, `typescript-expert`, `variance-expert`, `vector-database-expert`, `vectorised-execution-expert`, `vibe-coding-expert`, `wide-column-database-expert`, `writing-expert`

## Backlog

Partial progress on B-0347 acceptance criteria 1 (all descriptions ≤150 chars). Criteria 2-4 (`/doctor` verification) depend on harness tooling.

## Test plan

- [x] Build gate passes (0 warnings, 0 errors)
- [x] All 21 edited descriptions verified ≤150 chars via shell check
- [ ] `/doctor` check for 0 dropped descriptions (harness-side verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)