### PR TITLE
feat(B-0164): land divergence-shard schema — AC #4 of dual-loop attribution protocol

### DIFF
--- a/docs/backlog/P1/B-0164-dual-loop-substrate-attribution-and-reconciliation-protocol-2026-05-02.md
+++ b/docs/backlog/P1/B-0164-dual-loop-substrate-attribution-and-reconciliation-protocol-2026-05-02.md
@@ -64,6 +64,30 @@ Aaron's morning reconciliation has to resolve these. The architecture's commitme
 - Named-agent distinctness commitment (Otto-279) — Codex would be a distinct named agent
 - BFT-many-masters at cognitive layer — this is the loop-layer counterpart
 
+## Pre-start checklist (2026-05-10, fix/B-0164-divergence-shard-schema)
+
+**Slice**: AC #4 only — substrate-divergence shard schema (`docs/hygiene-history/divergences/` README)
+
+### 1. Prior-art search
+
+- `wake-time-substrate`: tick shard README at `docs/hygiene-history/ticks/README.md` — no divergence directory or schema found
+- `skill-router`: no skill named "divergence-shard" or "dual-loop"
+- `orthogonal-axes` / `tools/hygiene/LOST-FILES-LOCATIONS.md`: no existing divergence surface
+- `Otto-364` (search-first): `docs/backlog/P1/B-0164-*.md` is the only source naming the `divergences/` path
+- `PR #1701` prior-art grep: `grep -r "divergences/" docs/` returns only the B-0164 row itself
+- `decision-archaeology` via `git log --all --oneline -- docs/hygiene-history/divergences/`: no history
+- **Result**: no prior art found; directory does not exist; safe to create
+
+### 2. Dependency restructure
+
+- `depends_on: B-0160` — B-0160 is P0 (`docs/backlog/P0/B-0160-*.md`); the divergence-shard schema (AC #4) does not depend on B-0160's harness integration; AC #4 is schema-only, safe to land independently
+- `composes_with: B-0162, B-0163` — B-0162 (pre-commit hook, P1) and B-0163 (append-tick-history-row.sh retirement, P3) are independent; no pointer update needed for this slice
+- `composes_with: ticks/README.md` — reciprocal pointer added in divergences/README.md
+
+### 3. Proof of isolation
+
+ACs #1 (attribution channel), #3 (branch attribution) are already satisfied by existing substrate. AC #2 (PR review protocol) and AC #6 (cron coordination) require dual-loop running. AC #5 (tooling) is gated by B-0163. AC #4 is the only AC deliverable without those dependencies.
+
 ## Effort
 
 L — substantial work. ~1-2 weeks for full implementation including Codex onboarding, tooling adjustment, divergence-shard format, cron coordination.

--- a/docs/hygiene-history/divergences/2026/05/10/114800Z-example.md
+++ b/docs/hygiene-history/divergences/2026/05/10/114800Z-example.md
@@ -1,0 +1,44 @@
+---
+tick: "2026-05-10T11:48:00Z"
+type: divergence
+loop-a:
+  agent: otto
+  model: "claude-opus-4-7"
+  harness: claude-code
+loop-b:
+  agent: codex-loop
+  model: "gpt-5.5"
+  harness: codex
+topic: "EXAMPLE — docs/hygiene-history/divergences/README.md schema demonstration"
+operative-authorization: "aaron 2026-05-04: \"it**, not just the output. Grinding through failures + recoveries\""
+---
+
+<!-- THIS IS AN EXAMPLE SHARD ONLY — illustrates the schema, not a real divergence -->
+
+## Loop A perspective
+
+otto (claude-opus-4-7, claude-code): The divergence shard README should open
+with the operational trigger conditions before explaining the background
+motivation, so an agent waking cold can immediately determine whether the
+current situation requires filing a shard.
+
+## Loop B perspective
+
+codex-loop (gpt-5.5, codex): The divergence shard README should open with the
+background motivation (why the surface exists) before the operational details,
+matching the established pattern in `docs/hygiene-history/ticks/README.md`,
+which opens with "Why shards exist."
+
+## Disagreement summary
+
+Both loops agree the divergence shard README must exist and cover operational
+trigger conditions + schema. They disagree on section ordering: Loop A prefers
+trigger-first (operational immediacy), Loop B prefers motivation-first
+(consistent pattern with ticks/README.md). Either ordering is valid; the
+disagreement is stylistic.
+
+## Reconciliation
+
+accept-loop-b — motivation-first ordering is consistent with the established
+ticks/README.md pattern; consistency aids cold-boot orientation. (Aaron,
+2026-05-10)

--- a/docs/hygiene-history/divergences/README.md
+++ b/docs/hygiene-history/divergences/README.md
@@ -1,0 +1,137 @@
+# Substrate-divergence shard files
+
+This directory holds **per-divergence shard files** recording disagreements
+between concurrent agent loops working on shared substrate.
+
+Origin: B-0164 AC #4 (2026-05-10).
+
+## Why divergence shards exist
+
+When two independent agent loops (e.g., Otto on Claude Code + a second loop on
+Codex) produce uncorrelated outputs, those outputs can either converge or
+diverge. The information value of dual-loop operation comes from BOTH cases:
+
+- **Convergence**: strengthens evidence (both loops independently reached the
+  same conclusion)
+- **Divergence**: reveals which loop's training distribution captured what
+
+Without an explicit protocol, divergent outputs either silently overwrite each
+other (information loss) or create merge conflicts (operational loss). The
+divergence shard format preserves both perspectives with attribution so the
+human maintainer can read and reconcile them explicitly each morning.
+
+## What triggers a divergence shard
+
+File a shard whenever two loops disagree on a **substrate-class commitment**:
+
+- Different memory-file content for the same discipline
+- Different ALIGNMENT.md interpretations
+- Conflicting PR-review thread conclusions (each loop reviews the same thread
+  with opposite recommendations)
+- Conflicting branch work on the same file (second loop detects the conflict
+  and cannot rebase cleanly)
+- Conflicting next-action proposals competing for the same narrow slot
+
+Do NOT file shards for disagreements that are already resolved by the loops
+themselves (e.g., one loop defers to the other's Co-Authored-By attribution).
+
+## File naming
+
+```
+docs/hygiene-history/divergences/YYYY/MM/DD/HHMMSSZ-<short-content-hash>.md
+```
+
+- Year / month / day are zero-padded numeric folders.
+- Filename is `HHMMSSZ-<short-content-hash>` (UTC, with `Z` suffix).
+  - `HHMMSSZ` uses seconds precision to reduce same-minute collisions.
+  - `<short-content-hash>` is 8 hex chars from `sha256(loop-a-body + loop-b-body)`.
+- Extension `.md` so each shard is independently grep-able and rendered.
+
+**Unique-filename rule (fail-closed-OR-idempotent):** if the target path already
+exists when a new shard is being written, the write MUST either (a) succeed
+silently if the new content is byte-identical (idempotent re-write), OR (b)
+fail closed and choose a unique-suffix path. Silent overwrites of different
+content are forbidden — they erase divergence evidence.
+
+## Required frontmatter
+
+```yaml
+---
+tick: "2026-05-10T11:48:00Z"     # ISO 8601 UTC, seconds precision
+type: divergence
+loop-a:
+  agent: otto                     # named agent identifier (e.g., otto, vera)
+  model: "claude-opus-4-7"        # model ID string
+  harness: claude-code
+loop-b:
+  agent: codex-loop               # named agent identifier
+  model: "gpt-5.5"               # model ID string
+  harness: codex
+topic: "memory/feedback_xyz.md"   # the substrate path or topic in conflict
+operative-authorization: "aaron 2026-05-04: \"it**, not just the output. Grinding through failures + recoveries\""
+---
+```
+
+## Required body sections
+
+```markdown
+## Loop A perspective
+
+<agent> (<model>, <harness>): <full framing of the position>
+
+## Loop B perspective
+
+<agent> (<model>, <harness>): <full framing of the position>
+
+## Disagreement summary
+
+One-paragraph neutral summary of the disagreement for morning reconciliation.
+
+## Reconciliation
+
+<!-- Leave blank until morning reconciliation. The human maintainer fills this in. -->
+<!-- Options: accept-loop-a | accept-loop-b | accept-both (explicit divergence) | escalate -->
+```
+
+## Reconciliation outcomes
+
+Morning reconciliation reads all shards with empty `Reconciliation` sections.
+For each:
+
+- **accept-loop-a**: Loop A's framing wins; Loop B's is discarded.
+- **accept-loop-b**: Loop B's framing wins; Loop A's is discarded.
+- **accept-both (explicit divergence)**: Both framings are preserved as
+  explicitly-annotated divergent views on a topic that admits multiple
+  valid positions.
+- **escalate**: Neither framing is clearly correct; the human maintainer
+  documents the uncertainty and defers until more evidence arrives.
+
+After reconciliation, the shard is updated in place (not deleted) so the
+divergence history is preserved permanently.
+
+## Composition with tick shards
+
+Divergence shards are written in addition to (not instead of) the normal tick
+shards at `docs/hygiene-history/ticks/**`. A tick shard records what a loop
+DID; a divergence shard records a CONFLICT between two loops. Both surfaces
+are canonical write surfaces; neither replaces the other.
+
+See: `docs/hygiene-history/ticks/README.md` for the tick shard schema.
+
+## What this directory does NOT do
+
+- Does NOT replace normal tick shards for liveness evidence.
+- Does NOT impose any ordering constraint between concurrent loops.
+- Does NOT auto-resolve conflicts — resolution is always by the human
+  maintainer (or a designated reconciliation agent, once one exists).
+- Does NOT change the AUTONOMOUS-LOOP.md liveness invariant.
+
+## Example shard
+
+See `docs/hygiene-history/divergences/2026/05/10/114800Z-example.md` for a
+worked example demonstrating the schema.
+
+## Migration
+
+There is no legacy divergence surface. This directory is created fresh (B-0164
+AC #4, 2026-05-10). All shards from 2026-05-10 onward are written here.


### PR DESCRIPTION
## Summary

- Creates `docs/hygiene-history/divergences/` — the foundational storage surface for B-0164's dual-loop disagreement-preservation protocol (AC #4)
- `README.md` defines the full divergence-shard schema: YAML frontmatter fields, `HHMMSSZ-<short-content-hash>.md` naming convention, required body sections (Loop A/B perspectives + disagreement summary + reconciliation), fail-closed-OR-idempotent uniqueness rule, and reconciliation outcomes (accept-loop-a / accept-loop-b / accept-both / escalate)
- `2026/05/10/114800Z-example.md` — worked example demonstrating the schema end-to-end
- Updates B-0164 backlog item with pre-start checklist (prior-art search + dependency isolation proof)

## Scope

**Smallest safe slice**: AC #4 only. Prior-art search confirmed no existing divergence surface; dependency analysis confirmed AC #4 is the only AC deliverable without B-0160 harness integration or a second loop running.

- AC #1 (per-loop attribution channel): already satisfied by tick-shard col2 model-identifier
- AC #3 (branch attribution): already satisfied by `Co-Authored-By` trailer
- AC #4 (substrate-divergence shard format): **this PR** ✓
- AC #2, #5, #6: require second loop running / B-0163 tooling / experimentation

## Checks

```
dotnet build -c Release
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

operative-authorization: aaron 2026-05-04: "it**, not just the output. Grinding through failures + recoveries"

🤖 Generated with [Claude Code](https://claude.com/claude-code)