### PR TITLE
fix(B-0164): add reciprocal ticks↔divergences pointer + mark AC status

### DIFF
--- a/docs/backlog/P1/B-0164-dual-loop-substrate-attribution-and-reconciliation-protocol-2026-05-02.md
+++ b/docs/backlog/P1/B-0164-dual-loop-substrate-attribution-and-reconciliation-protocol-2026-05-02.md
@@ -43,17 +43,17 @@ Aaron's morning reconciliation has to resolve these. The architecture's commitme
 
 ## Acceptance criteria
 
-1. **Per-loop attribution channel.** Otto's tick-shards under `docs/hygiene-history/ticks/**` already include col2 model-identifier (e.g., `opus-4-7 / autonomous-loop session continuation`). Codex's loop should write to the same shard surface with its own model-identifier (e.g., `gpt-5.5 / codex-loop`). The col2 schema accommodates this; no schema change needed.
+1. **Per-loop attribution channel.** ✅ SATISFIED BY EXISTING SUBSTRATE — Otto's tick-shards under `docs/hygiene-history/ticks/**` already include col2 model-identifier (e.g., `opus-4-7 / autonomous-loop session continuation`). Codex's loop should write to the same shard surface with its own model-identifier (e.g., `gpt-5.5 / codex-loop`). The col2 schema accommodates this; no schema change needed.
 
-2. **Disagreement-preservation protocol for PR reviews.** When both loops review the same PR thread with different conclusions: each loop's review-comment is preserved with attribution; neither auto-resolves the other. The morning reconciliation reads both, decides, resolves accordingly. No silent overwrites.
+2. **Disagreement-preservation protocol for PR reviews.** ⏳ BLOCKED — requires dual-loop running. When both loops review the same PR thread with different conclusions: each loop's review-comment is preserved with attribution; neither auto-resolves the other. The morning reconciliation reads both, decides, resolves accordingly. No silent overwrites.
 
-3. **Branch-attribution for in-flight work.** When both loops produce concurrent commits to the same branch: each loop commits with its own author-identifier (already supported by `Co-Authored-By` trailer). Different loops working different threads don't conflict if file-isolation holds; if they touch the same file, the second loop's tick should detect the conflict and either rebase OR file a divergence-shard noting the conflict for morning reconciliation.
+3. **Branch-attribution for in-flight work.** ✅ SATISFIED BY EXISTING SUBSTRATE — When both loops produce concurrent commits to the same branch: each loop commits with its own author-identifier (already supported by `Co-Authored-By` trailer). Different loops working different threads don't conflict if file-isolation holds; if they touch the same file, the second loop's tick should detect the conflict and either rebase OR file a divergence-shard noting the conflict for morning reconciliation.
 
-4. **Substrate-divergence shard format.** When two loops disagree on substrate-class commitment (different memory file content, different ALIGNMENT.md interpretation), file a per-tick shard under `docs/hygiene-history/divergences/YYYY/MM/DD/HHMMZ-<hash>.md` with both perspectives + attribution. Morning reconciliation reads divergence shards explicitly.
+4. **Substrate-divergence shard format.** ✅ DONE (PR #2475, 2026-05-10) — `docs/hygiene-history/divergences/` created with README (schema + naming + frontmatter + reconciliation protocol + worked example). When two loops disagree on substrate-class commitment (different memory file content, different ALIGNMENT.md interpretation), file a per-tick shard under `docs/hygiene-history/divergences/YYYY/MM/DD/HHMMSSZ-<hash>.md` with both perspectives + attribution. Morning reconciliation reads divergence shards explicitly.
 
-5. **Tooling support.** `tools/github/poll-pr-gate-batch.ts` already supports any agent identity reading the gate; no change needed there. `tools/hygiene/append-tick-history-row.sh` (or its successor per B-0163) needs to support multi-loop attribution.
+5. **Tooling support.** ⏳ BLOCKED (gated by B-0163) — `tools/github/poll-pr-gate-batch.ts` already supports any agent identity reading the gate; no change needed there. `tools/hygiene/append-tick-history-row.sh` (or its successor per B-0163) needs to support multi-loop attribution.
 
-6. **Cron-tick coordination.** Decision: do both loops fire on the same `* * * * *` cron, or staggered? Same-cron means concurrent perturbation (more BFT-information per tick); staggered means sequential review where second loop reviews first loop's output. Trade-off; pick based on testing.
+6. **Cron-tick coordination.** ⏳ BLOCKED — requires dual-loop running. Decision: do both loops fire on the same `* * * * *` cron, or staggered? Same-cron means concurrent perturbation (more BFT-information per tick); staggered means sequential review where second loop reviews first loop's output. Trade-off; pick based on testing.
 
 ## Composes with
 
@@ -87,6 +87,26 @@ Aaron's morning reconciliation has to resolve these. The architecture's commitme
 ### 3. Proof of isolation
 
 ACs #1 (attribution channel), #3 (branch attribution) are already satisfied by existing substrate. AC #2 (PR review protocol) and AC #6 (cron coordination) require dual-loop running. AC #5 (tooling) is gated by B-0163. AC #4 is the only AC deliverable without those dependencies.
+
+## Pre-start checklist (2026-05-10, fix/B-0164-ticks-readme-divergence-pointer)
+
+**Slice**: Reciprocal pointer — add "Composition with divergence shards" section to `docs/hygiene-history/ticks/README.md` + update AC status markers in this row.
+
+### 1. Prior-art search
+
+- `divergences/README.md` → already references `docs/hygiene-history/ticks/README.md` (outgoing pointer exists)
+- `ticks/README.md` → no reference to `docs/hygiene-history/divergences/` found (incoming pointer missing)
+- `grep -r "divergences" docs/hygiene-history/ticks/`: zero results — confirms the gap
+- **Result**: reciprocal pointer is missing; safe to add
+
+### 2. Dependency restructure
+
+- No new dependencies introduced; this is additive documentation only
+- `composes_with: ticks/README.md` — this slice completes the reciprocal-pointer pair
+
+### 3. Proof of isolation
+
+This is a pure documentation update: one new section in `ticks/README.md` + AC status markers on this backlog row. No code, no schema, no tooling. Isolated from all blocked ACs.
 
 ## Effort
 

--- a/docs/hygiene-history/ticks/2026/05/10/1159Z.md
+++ b/docs/hygiene-history/ticks/2026/05/10/1159Z.md
@@ -1,0 +1,8 @@
+---
+tick: "2026-05-10T11:59:00Z"
+agent: otto
+mode: interactive
+operative-authorization: "aaron 2026-05-04: \"it**, not just the output. Grinding through failures + recoveries\""
+---
+
+| 2026-05-10T11:59:00Z | claude-sonnet-4-6 / interactive | fix/B-0164-ticks-readme-divergence-pointer | B-0164 reciprocal pointer: add "Composition with divergence shards" section to ticks/README.md + mark AC status on B-0164 row | fix/B-0164-ticks-readme-divergence-pointer | AC #4 done (PR #2475); this slice closes the missing reciprocal pointer between tick-shard and divergence-shard surfaces |

--- a/docs/hygiene-history/ticks/README.md
+++ b/docs/hygiene-history/ticks/README.md
@@ -228,6 +228,19 @@ the multi-AI synthesis arc + Aaron's explicit delegation
 - Does NOT introduce a new tick-history schema — same column
   structure as the legacy table, one row per shard.
 
+## Composition with divergence shards
+
+When two concurrent agent loops disagree on a substrate-class commitment,
+a **divergence shard** is written to `docs/hygiene-history/divergences/`
+in addition to (not instead of) the normal tick shard here.
+
+- **Tick shard** (this directory): records what a loop DID.
+- **Divergence shard** (divergences/): records a CONFLICT between two loops.
+
+Both surfaces are canonical write surfaces; neither replaces the other.
+See: `docs/hygiene-history/divergences/README.md` for the divergence shard
+schema and reconciliation protocol (B-0164 AC #4, 2026-05-10).
+
 ## Migration of historical content
 
 The legacy table at `docs/hygiene-history/loop-tick-history.md`


### PR DESCRIPTION
## Summary

- **Reciprocal pointer**: `docs/hygiene-history/ticks/README.md` gains a new "Composition with divergence shards" section linking to `docs/hygiene-history/divergences/README.md`. The outgoing pointer (divergences → ticks) landed in PR #2475; this closes the missing incoming pointer so cold-boot agents navigating either README can find the other.
- **AC status markers**: B-0164 backlog row now marks each AC with ✅/⏳ inline, making the disposition visible without reading the full pre-start checklist.
- **Tick shard**: `docs/hygiene-history/ticks/2026/05/10/1159Z.md` records this tick.

## Slice rationale

B-0164 AC #4 (divergence shard schema) merged as PR #2475. That PR's pre-start checklist noted `composes_with: ticks/README.md — reciprocal pointer added in divergences/README.md` — but only the outgoing pointer was added. This PR closes the gap with the incoming pointer.

No code changes. No schema changes. No blocked ACs touched.

## Focused checks

```
dotnet build -c Release  →  0 warnings, 0 errors ✅
git diff --stat          →  3 files, 47 insertions, 6 deletions ✅
```

## Blocked ACs (not in scope)

- AC #2 (PR review disagreement protocol) — requires dual-loop running
- AC #5 (tooling: multi-loop attribution in append-tick-history) — gated by B-0163
- AC #6 (cron-tick coordination) — requires dual-loop testing

operative-authorization: aaron 2026-05-04: "it**, not just the output. Grinding through failures + recoveries"

🤖 Generated with [Claude Code](https://claude.com/claude-code)