### PR TITLE
fix(B-0164): dotted-ID regex in claim tool + remove redundant parent from depends_on

### DIFF
--- a/docs/backlog/P1/B-0164.1-pr-review-disagreement-preservation-protocol.md
+++ b/docs/backlog/P1/B-0164.1-pr-review-disagreement-preservation-protocol.md
@@ -8,7 +8,6 @@ created: 2026-05-10
 last_updated: 2026-05-10
 depends_on:
   - B-0160
-  - B-0164
 parent: B-0164
 classification: blocked
 decomposition: atomic

--- a/docs/backlog/P1/B-0164.2-multi-loop-tick-tooling-attribution.md
+++ b/docs/backlog/P1/B-0164.2-multi-loop-tick-tooling-attribution.md
@@ -8,7 +8,6 @@ created: 2026-05-10
 last_updated: 2026-05-10
 depends_on:
   - B-0163
-  - B-0164
 parent: B-0164
 classification: blocked
 decomposition: atomic

--- a/docs/backlog/P1/B-0164.3-cron-tick-coordination-dual-loop.md
+++ b/docs/backlog/P1/B-0164.3-cron-tick-coordination-dual-loop.md
@@ -8,7 +8,6 @@ created: 2026-05-10
 last_updated: 2026-05-10
 depends_on:
   - B-0160
-  - B-0164
   - B-0164.1
 parent: B-0164
 classification: blocked

--- a/tools/backlog/claim-worktree-bootstrap.ts
+++ b/tools/backlog/claim-worktree-bootstrap.ts
@@ -198,7 +198,7 @@ function validateRepoPath(path: string): void {
 
 function validateRequest(request: BootstrapRequest): void {
   validateSlug(request.slug);
-  if (!/^B-[0-9]+$/.test(request.backlogId)) {
+  if (!/^B-[0-9]+(\.[0-9]+)*$/.test(request.backlogId)) {
     throw new Error(`invalid backlog id: ${request.backlogId}`);
   }
   if (request.scope.trim().length === 0) {


### PR DESCRIPTION
## Summary

- `tools/backlog/claim-worktree-bootstrap.ts`: extend `^B-[0-9]+$` → `^B-[0-9]+(\.[0-9]+)*$` so child rows like `B-0164.1`, `B-0164.2`, `B-0164.3` are claimable by autonomous agents (Copilot P1 finding on PR #2479)
- `B-0164.1/2/3`: remove `B-0164` from `depends_on` since `parent: B-0164` already captures that relationship; `depends_on` should list true prerequisites only (Copilot/Codex P2 finding on PR #2479)

## Test plan

- [ ] `bun tools/backlog/generate-index.ts --check` passes (BACKLOG.md unchanged since depends_on doesn't affect the generated index)
- [ ] `bun tools/backlog/claim-worktree-bootstrap.ts --backlog-id B-0164.1 ...` no longer rejects with "invalid backlog id"
- [ ] `B-0164.x` frontmatter: `depends_on` no longer contains the parent row ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)