### PR TITLE
docs(B-0164): finish post-merge decomposition review nits

### DIFF
--- a/docs/backlog/P1/B-0164-dual-loop-substrate-attribution-and-reconciliation-protocol-2026-05-02.md
+++ b/docs/backlog/P1/B-0164-dual-loop-substrate-attribution-and-reconciliation-protocol-2026-05-02.md
@@ -11,7 +11,7 @@ children:
   - B-0164.1
   - B-0164.2
   - B-0164.3
-decomposition: parent
+decomposition: decomposed
 type: friction-reducer
 ---
 

--- a/docs/backlog/P1/B-0164.3-cron-tick-coordination-dual-loop.md
+++ b/docs/backlog/P1/B-0164.3-cron-tick-coordination-dual-loop.md
@@ -54,7 +54,7 @@ The trade-off maps to what failure mode is higher-priority:
 ## What
 
 1. **Decision**: pick one topology (same-cron or staggered) based on current
-   dual-loop risk profile. Document the reasoning in a research shard.
+   dual-loop risk profile. Document the reasoning in an ADR.
 2. **Implementation**: wire the chosen topology into `CronCreate` calls at
    each loop's harness startup. If staggered: offset by 30s (`*/1 * * * *`
    at second 0 vs. second 30 or equivalent — note CronCreate uses `* * * * *`
@@ -65,8 +65,8 @@ The trade-off maps to what failure mode is higher-priority:
 
 ## Acceptance criteria
 
-1. Topology decision documented in a research shard
-   (`docs/research/YYYY-MM-DD-dual-loop-cron-coordination-topology-decision.md`).
+1. Topology decision documented in an ADR
+   (`docs/DECISIONS/YYYY-MM-DD-dual-loop-cron-coordination-topology.md`).
 2. Both loops fire at the chosen offset, verified by a 5-minute observation
    window of tick shard timestamps.
 3. No silent overwrites: if both loops write to the same target in the same


### PR DESCRIPTION
## Summary
- mark B-0164 with the supported decomposed parent state
- move the cron-topology decision artifact target from ignored research-shard pattern to ADR space

## Checks
- bun tools/backlog/generate-index.ts --check
- bun run lint:markdown docs/backlog/P1/B-0164-dual-loop-substrate-attribution-and-reconciliation-protocol-2026-05-02.md docs/backlog/P1/B-0164.3-cron-tick-coordination-dual-loop.md
- git diff --check