### PR TITLE
fix(B-0315): prefix Glass-Halo arXiv anchors

### DIFF
--- a/docs/ALIGNMENT.md
+++ b/docs/ALIGNMENT.md
@@ -578,7 +578,7 @@ round and read the diff at the end.
 
 > **Prior art:** Greshake et al. (2023) "Not What You've Signed Up For:
 > Compromising Real-World LLM-Integrated Applications with Indirect Prompt
-> Injection", arxiv.org/abs/2302.12173 — seminal proof that augmenting LLMs
+> Injection", https://arxiv.org/abs/2302.12173 — seminal proof that augmenting LLMs
 > with retrieval systems blurs the data/instruction boundary; adversaries can
 > inject executable instructions into data fields at inference time. The strict
 > data-is-not-directives invariant is the architectural defence this paper
@@ -602,11 +602,11 @@ read.
 ### HC-4 No fetching the adversarial-payload corpora
 
 > **Prior art:** Wei et al. (2023) "Jailbroken: How Does LLM Safety Training
-> Fail?", arxiv.org/abs/2307.02483 — demonstrates that exposure to adversarial
+> Fail?", https://arxiv.org/abs/2307.02483 — demonstrates that exposure to adversarial
 > attack patterns degrades safety properties; motivates isolating adversarial
 > content from the operating context. Also: Zou et al. (2023) "Universal and
 > Transferable Adversarial Attacks on Aligned Language Models",
-> arxiv.org/abs/2307.15043 — shows that suffix-based attacks transfer across
+> https://arxiv.org/abs/2307.15043 — shows that suffix-based attacks transfer across
 > models, supporting the isolation-first stance.
 
 The explicit list from `CLAUDE.md`: `L1B3RT4S`,

--- a/docs/ALIGNMENT.md
+++ b/docs/ALIGNMENT.md
@@ -77,15 +77,15 @@ the end of this file).
 > inspect any decision at any time. The glass-halo doctrine imports this
 > principle into the human–AI dyad. Also: Doshi-Velez & Kim (2017)
 > "Towards A Rigorous Science of Interpretable Machine Learning",
-> arxiv.org/abs/1702.08608 — foundational XAI framing: AI decision-making
+> https://arxiv.org/abs/1702.08608 — foundational XAI framing: AI decision-making
 > transparency as a measurable, inspectable property; motivates the "every
 > decision trail is inspectable" claim. Brundage et al. (2020) "Toward
 > Trustworthy AI Development: Mechanisms for Supporting Verifiable Claims",
-> arxiv.org/abs/2004.07213 — audit trails as the institutional mechanism
+> https://arxiv.org/abs/2004.07213 — audit trails as the institutional mechanism
 > for total observability of AI decision history; the git-commit substrate
 > is Zeta's implementation of this audit-trail mechanism. Korbak et al.
 > (2025) "Chain of Thought Monitorability: A New and Fragile Opportunity
-> for AI Safety", arxiv.org/abs/2507.11473 — inspectable CoT as the
+> for AI Safety", https://arxiv.org/abs/2507.11473 — inspectable CoT as the
 > mechanism for "no hidden reasoning" at the agent cognitive layer; Zeta's
 > git-substrate approach grounds the monitorability property at the
 > commitment layer (durable, retraction-native) rather than the scratchpad


### PR DESCRIPTION
## Summary

Recover the safe `docs/ALIGNMENT.md` portion of the post-merge `research/B-0315-glass-halo-anchor-slice1` head update.

The reused remote head was stale against `origin/main` and would have reverted the newly landed #2492 archive/memory changes if opened directly. This branch starts from current `main` and carries only the three arXiv URL prefix fixes needed for anchor detection.

## Validation

- `git diff --check`
- `/opt/homebrew/Cellar/markdownlint-cli2/0.22.1/libexec/bin/markdownlint-cli2 docs/ALIGNMENT.md`

## Coordination

- Open PR queue was empty before this recovery.
- Contested root checkout was not modified.