### PR TITLE
fix(B-0315): recover slice 3 review anchor fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,18 +203,18 @@ These apply to any AI harness.
   has a bounded undo path.
 
   > **Prior art:** Richardson (2016+) "Saga Pattern",
-  > microservices.io/patterns/data/saga.html —
+  > <https://microservices.io/patterns/data/saga.html> —
   > formalises compensating transactions as the
   > mechanism for retractable distributed operations;
   > each action has an explicit inverse, making all
   > side effects undoable without destructive rollback.
   > Also: Microsoft Azure Architecture Center,
   > "Compensating Transaction" pattern,
-  > learn.microsoft.com/en-us/azure/architecture/patterns/compensating-transaction.
+  > <https://learn.microsoft.com/en-us/azure/architecture/patterns/compensating-transaction>.
   > Git-native retraction (code via revert, docs via
   > revert, memory via delete) is original to Zeta.
   > Full doctrine: [`docs/ALIGNMENT.md`
-  > §HC-2](docs/ALIGNMENT.md).
+  > §HC-2](docs/ALIGNMENT.md#hc-2-retraction-native-operations).
 
   No destructive git operations (`rm -rf` beyond the
   agent's working tree, force-push to shared branches,

--- a/README.md
+++ b/README.md
@@ -237,4 +237,5 @@ and agent decisions are equally visible in the same public
 version-controlled substrate — neither party can hide a move from the
 other. The bilateral / symmetric form is original to Zeta; see
 [`docs/ALIGNMENT.md` §"Symmetric transparency: the glass
-halo"](docs/ALIGNMENT.md) for the full definition and mutual commitment.
+halo"](docs/ALIGNMENT.md#symmetric-transparency-the-glass-halo) for the
+full definition and mutual commitment.

--- a/docs/backlog/P1/B-0315-glass-halo-doctrine-anchor-backfill.md
+++ b/docs/backlog/P1/B-0315-glass-halo-doctrine-anchor-backfill.md
@@ -126,7 +126,8 @@ Lands two remaining doctrines:
    adding doctrine content contradicts the B-0353 condensation intent.
 
 All five B-0315 doctrines now have external anchor or "original" note
-on at least one defining surface. Done-criteria met:
+on at least one defining surface. Core done-criteria met; the coverage
+scanner remains deferred to the next audit pass:
 
 - [x] All Glass-Halo doctrines have external anchor or "original" note
 - [x] Citations include URL, author/org, title, date


### PR DESCRIPTION
## Summary
- Recover the #2499 review-anchor fixes onto current `main` after #2499 merged while Vera was patching its original branch.
- Qualify the AGENTS.md prior-art URLs and add direct ALIGNMENT section fragments for the HC-2 and glass-halo references.
- Clarify the closed B-0315 criteria while preserving the deferred coverage-scanner note.

## Verification
- `/opt/homebrew/Cellar/markdownlint-cli2/0.22.1/libexec/bin/markdownlint-cli2 AGENTS.md README.md docs/backlog/P1/B-0315-glass-halo-doctrine-anchor-backfill.md docs/BACKLOG.md`
- `bun tools/backlog/generate-index.ts --check`
- `git diff --check --cached`

## Notes
- This intentionally avoids reopening the stale post-merge #2499 branch because that branch is behind current `main` and would revert unrelated merged artifacts.