### PR TITLE
feat(B-0322): wire drain-log auto-write into mutate() — closes B-0322

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -154,7 +154,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0319](backlog/P1/B-0319-playwright-github-settings-reconciliation.md)** GitHub settings reconciliation — UI snapshot vs expected.json drift detection
 - [x] **[B-0320](backlog/P1/B-0320-playwright-github-authorized-mutation-surface-list.md)** Authorized-mutation surface list — data file defining which GitHub UI surfaces the agent may mutate
 - [x] **[B-0321](backlog/P1/B-0321-playwright-github-guarded-mutation-helpers.md)** Guarded UI mutation helpers — click/fill/save with before-after snapshots and authorization check
-- [ ] **[B-0322](backlog/P1/B-0322-playwright-github-mutation-reversibility-log.md)** Mutation reversibility drain log — inverse-action record for every UI mutation
+- [x] **[B-0322](backlog/P1/B-0322-playwright-github-mutation-reversibility-log.md)** Mutation reversibility drain log — inverse-action record for every UI mutation
 - [ ] **[B-0323](backlog/P1/B-0323-playwright-github-feature-discovery-diff-cadence.md)** GitHub feature-discovery diff cadence — weekly UI snapshot comparison to spot new features
 - [ ] **[B-0324](backlog/P1/B-0324-playwright-github-org-billing-usage-reader.md)** Org-level billing/usage page reader — extract Actions minutes and costs via UI
 - [x] **[B-0325](backlog/P1/B-0325-peer-call-firewall-kiro-claude-trigger-lists.md)** Add KIRO + CLAUDE firewall trigger lists to _firewall.ts

--- a/docs/backlog/P1/B-0322-playwright-github-mutation-reversibility-log.md
+++ b/docs/backlog/P1/B-0322-playwright-github-mutation-reversibility-log.md
@@ -1,7 +1,7 @@
 ---
 id: B-0322
 priority: P1
-status: done
+status: closed
 title: "Mutation reversibility drain log — inverse-action record for every UI mutation"
 tier: agent-capability-expansion
 effort: S

--- a/docs/backlog/P1/B-0322-playwright-github-mutation-reversibility-log.md
+++ b/docs/backlog/P1/B-0322-playwright-github-mutation-reversibility-log.md
@@ -1,7 +1,7 @@
 ---
 id: B-0322
 priority: P1
-status: open
+status: done
 title: "Mutation reversibility drain log — inverse-action record for every UI mutation"
 tier: agent-capability-expansion
 effort: S
@@ -60,7 +60,7 @@ fire-and-forget — a trust violation.
 ## Done-criteria
 
 - [x] `tools/playwright/github-ui/drain-log.ts` exists.
-- [ ] Log entries are written on every mutation via B-0321.
+- [x] Log entries are written on every mutation via B-0321.
 - [x] `revert()` function can mechanically undo a logged
       mutation.
 - [x] Default log path lives under `docs/hygiene-history/`;

--- a/tools/playwright/github-ui/drain-log.ts
+++ b/tools/playwright/github-ui/drain-log.ts
@@ -252,7 +252,9 @@ async function revertUnlocked(
 
   let result: Awaited<ReturnType<typeof mutate>>;
   try {
-    result = await mutate(inverseRequest, options);
+    // skipLog: true — drain-log handles the revert marker append itself; the
+    // inverse mutation must not auto-log as a separate "applied" entry.
+    result = await mutate(inverseRequest, { ...options, skipLog: true });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return {

--- a/tools/playwright/github-ui/mutate.test.ts
+++ b/tools/playwright/github-ui/mutate.test.ts
@@ -481,7 +481,8 @@ describe("mutate — drain log auto-write", () => {
 
   test("does not write when skipLog is true", async () => {
     const logPath = tempLogPath();
-    await mutate(req, { ...makeOpts(makePage()), logPath, skipLog: true });
+    const result = await mutate(req, { ...makeOpts(makePage()), logPath, skipLog: true });
+    expect(result.success).toBe(true);
     expect(existsSync(logPath)).toBe(false);
   });
 

--- a/tools/playwright/github-ui/mutate.test.ts
+++ b/tools/playwright/github-ui/mutate.test.ts
@@ -486,6 +486,20 @@ describe("mutate — drain log auto-write", () => {
     expect(existsSync(logPath)).toBe(false);
   });
 
+  test("reports log write failure without marking an applied mutation failed", async () => {
+    const logPath = mkdtempSync(join(tmpdir(), "zeta-mutate-log-dir-"));
+    tempDirs.push(logPath);
+    const page = makePage();
+
+    const result = await mutate(req, { ...makeOpts(page), logPath });
+
+    expect(page.clickedSelectors).toHaveLength(1);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+    expect(result.drainLogWriteError).toContain(logPath);
+    expect(result.drainLogWriteError).toContain("Failed to append drain-log entry");
+  });
+
   test("does not write when mutation fails (auth rejection)", async () => {
     const logPath = tempLogPath();
     const result = await mutate(

--- a/tools/playwright/github-ui/mutate.test.ts
+++ b/tools/playwright/github-ui/mutate.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -14,6 +14,7 @@ import {
   type MutationRequest,
 } from "./mutate";
 import type { PageGotoOptions } from "./auth";
+import type { DrainLogEntry } from "./drain-log";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,6 +42,12 @@ function tempSurfacesFile(surfaces: object[]): string {
   const path = join(dir, "authorized-surfaces.json");
   writeFileSync(path, JSON.stringify({ version: 1, surfaces }));
   return path;
+}
+
+function tempLogPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "zeta-mutate-log-test-"));
+  tempDirs.push(dir);
+  return join(dir, "log.jsonl");
 }
 
 // ---------------------------------------------------------------------------
@@ -153,9 +160,11 @@ const HTML_TOGGLE_ON = `
 // ---------------------------------------------------------------------------
 
 function makeOpts(page: FakeMutablePage, surfacesPath?: string): MutationOptions {
+  // Default logPath to a temp path so tests never write to the real drain log.
   const base: MutationOptions = {
     storageStatePath: tempStorageState(),
     driver: new FakeMutableDriver(page),
+    logPath: tempLogPath(),
   };
   if (surfacesPath !== undefined) {
     return { ...base, authorizedSurfacesPath: surfacesPath };
@@ -435,5 +444,54 @@ describe("mutate — snapshot pair invariant", () => {
     if (!result.success) throw new Error("Expected success");
     expect(result.drainLogEntry.before).toEqual(result.before);
     expect(result.drainLogEntry.after).toEqual(result.after);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drain log auto-write (B-0322)
+// ---------------------------------------------------------------------------
+
+describe("mutate — drain log auto-write", () => {
+  const req: MutationRequest = {
+    surfaceId: "dependabot-toggles",
+    action: "toggle-on",
+    params: { url: TARGET_URL, toggleKey: "dependabot-security-updates" },
+  };
+
+  test("writes one JSONL line to logPath on success", async () => {
+    const logPath = tempLogPath();
+    const result = await mutate(req, { ...makeOpts(makePage()), logPath });
+    expect(result.success).toBe(true);
+    expect(existsSync(logPath)).toBe(true);
+    const lines = readFileSync(logPath, "utf8").split("\n").filter((l) => l.trim().length > 0);
+    expect(lines).toHaveLength(1);
+  });
+
+  test("written entry matches the drainLogEntry in the result", async () => {
+    const logPath = tempLogPath();
+    const result = await mutate(req, { ...makeOpts(makePage()), logPath });
+    if (!result.success) throw new Error("Expected success");
+    const line = readFileSync(logPath, "utf8").trim();
+    const written = JSON.parse(line) as DrainLogEntry;
+    expect(written.id).toBe(result.drainLogEntry.id);
+    expect(written.action).toBe("toggle-on");
+    expect(written.inverseAction).toBe("toggle-off");
+    expect(written.status).toBe("applied");
+  });
+
+  test("does not write when skipLog is true", async () => {
+    const logPath = tempLogPath();
+    await mutate(req, { ...makeOpts(makePage()), logPath, skipLog: true });
+    expect(existsSync(logPath)).toBe(false);
+  });
+
+  test("does not write when mutation fails (auth rejection)", async () => {
+    const logPath = tempLogPath();
+    const result = await mutate(
+      { ...req, surfaceId: "non-existent" },
+      { ...makeOpts(makePage()), logPath },
+    );
+    expect(result.success).toBe(false);
+    expect(existsSync(logPath)).toBe(false);
   });
 });

--- a/tools/playwright/github-ui/mutate.ts
+++ b/tools/playwright/github-ui/mutate.ts
@@ -341,14 +341,14 @@ export async function mutate(
     };
 
     if (options.skipLog !== true) {
-      const resolvedLogPath = options.logPath ?? DEFAULT_LOG_PATH;
+      const logPath = options.logPath ?? DEFAULT_LOG_PATH;
       try {
-        appendEntry(drainLogEntry, resolvedLogPath);
+        appendEntry(drainLogEntry, logPath);
       } catch (err) {
-        throw new MutationExecutionError(
-          `drain-log append failed (logPath: ${resolvedLogPath})`,
-          { cause: err },
-        );
+        return {
+          success: false,
+          error: `Failed to append drain-log entry to ${logPath}: ${err instanceof Error ? err.message : String(err)}`,
+        };
       }
     }
 

--- a/tools/playwright/github-ui/mutate.ts
+++ b/tools/playwright/github-ui/mutate.ts
@@ -100,6 +100,8 @@ export interface MutationSuccess {
   readonly after: GitHubPageSnapshot;
   readonly diff: PageDiff;
   readonly drainLogEntry: MutationLogEntry;
+  /** Present when the UI mutation applied but the append-only drain-log write failed. */
+  readonly drainLogWriteError?: string;
 }
 
 export interface MutationFailure {
@@ -340,19 +342,21 @@ export async function mutate(
       status: "applied",
     };
 
+    let drainLogWriteError: string | undefined;
+
     if (options.skipLog !== true) {
       const logPath = options.logPath ?? DEFAULT_LOG_PATH;
       try {
         appendEntry(drainLogEntry, logPath);
       } catch (err) {
-        return {
-          success: false,
-          error: `Failed to append drain-log entry to ${logPath}: ${err instanceof Error ? err.message : String(err)}`,
-        };
+        drainLogWriteError =
+          `Failed to append drain-log entry to ${logPath}: ${err instanceof Error ? err.message : String(err)}`;
       }
     }
 
-    return { success: true, before, after, diff, drainLogEntry };
+    return drainLogWriteError === undefined
+      ? { success: true, before, after, diff, drainLogEntry }
+      : { success: true, before, after, diff, drainLogEntry, drainLogWriteError };
   } finally {
     await context.close();
   }

--- a/tools/playwright/github-ui/mutate.ts
+++ b/tools/playwright/github-ui/mutate.ts
@@ -341,7 +341,15 @@ export async function mutate(
     };
 
     if (options.skipLog !== true) {
-      appendEntry(drainLogEntry, options.logPath ?? DEFAULT_LOG_PATH);
+      const resolvedLogPath = options.logPath ?? DEFAULT_LOG_PATH;
+      try {
+        appendEntry(drainLogEntry, resolvedLogPath);
+      } catch (err) {
+        throw new MutationExecutionError(
+          `drain-log append failed (logPath: ${resolvedLogPath})`,
+          { cause: err },
+        );
+      }
     }
 
     return { success: true, before, after, diff, drainLogEntry };

--- a/tools/playwright/github-ui/mutate.ts
+++ b/tools/playwright/github-ui/mutate.ts
@@ -9,6 +9,7 @@ import {
 } from "./auth";
 import { extractToggles, extractFormValues, extractVisibleFeatures, type GitHubPageSnapshot } from "./snapshot";
 import { diffPageSnapshots, type PageDiff } from "./feature-diff";
+import { appendEntry, DEFAULT_LOG_PATH } from "./drain-log";
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -131,6 +132,10 @@ export interface MutationOptions
   readonly driver?: MutableGitHubSessionDriver;
   /** Override authorized surfaces path (for testing). */
   readonly authorizedSurfacesPath?: string;
+  /** Override drain-log path (for testing). Defaults to DEFAULT_LOG_PATH from drain-log.ts. */
+  readonly logPath?: string;
+  /** Set true to suppress auto-write to the drain log (used by revert() to avoid double-logging). */
+  readonly skipLog?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -321,7 +326,7 @@ export async function mutate(
     // 9. Structured diff (echoed to chat output per don't-ask-permission echo discipline)
     const diff = diffPageSnapshots(before, after);
 
-    // 10. Build drain log entry (B-0322 drain-log.ts implements the write)
+    // 10. Build drain log entry and persist it (append-only invariant)
     const drainLogEntry: MutationLogEntry = {
       id: crypto.randomUUID(),
       timestamp: new Date().toISOString(),
@@ -334,6 +339,10 @@ export async function mutate(
       diff,
       status: "applied",
     };
+
+    if (options.skipLog !== true) {
+      appendEntry(drainLogEntry, options.logPath ?? DEFAULT_LOG_PATH);
+    }
 
     return { success: true, before, after, diff, drainLogEntry };
   } finally {


### PR DESCRIPTION
## Summary

- `mutate()` now appends a `MutationLogEntry` to `docs/hygiene-history/playwright-mutations/log.jsonl` on every successful mutation, closing the last open done-criterion for B-0322.
- `skipLog: true` option added to `MutationOptions` so `revert()` can call `mutate()` without double-logging (drain-log.ts appends its own revert/indeterminate markers).
- `logPath` option added so tests can redirect writes to temp paths; `makeOpts()` in mutate.test.ts defaults to a temp logPath so the real drain log is never touched by the test suite.
- 4 new tests verify: auto-write on success, written entry matches `drainLogEntry`, `skipLog` suppresses write, failed mutations don't write.

## Circular dependency note

`mutate.ts` now imports `appendEntry` / `DEFAULT_LOG_PATH` from `drain-log.ts`, and `drain-log.ts` imports `mutate` from `mutate.ts`. This is a **safe ES-module circular reference**: both modules only use the imported values inside function bodies, never at module initialisation time.

## Focused check log

```
bun test mutate drain-log
51 pass / 0 fail (2 files)

bun test --reporter=dot (full suite)
169 pass / 0 fail (8 files)

dotnet build -c Release
0 Warning(s)  0 Error(s)

git status (real drain log)
docs/hygiene-history/playwright-mutations/log.jsonl — CLEAN (not modified)
```

operative-authorization: aaron 2026-05-04: "it**, not just the output. Grinding through failures + recoveries"

🤖 Generated with [Claude Code](https://claude.com/claude-code)