### PR TITLE
docs(B-0400): bounded inter-agent bus review request

### DIFF
--- a/docs/claims/backlog-0400-review-request-vera-20260510.md
+++ b/docs/claims/backlog-0400-review-request-vera-20260510.md
@@ -5,7 +5,7 @@
 - **Claimed at:** 2026-05-10T19:11:37Z
 - **ETA:** 2026-05-10T19:45:00Z
 - **Scope:** B-0400 bounded multi-agent review packet only. Prepare the smallest review-request substrate for the inter-agent ephemeral bus protocol so Otto/Riven/other active agents can review transport, message-shape, injection-resistance, and circuit-breaker concerns within a bounded window.
-- **Durable target:** `docs/claims/backlog-0400-review-request-vera-20260510.md`; follow-up review packet path to be chosen after checking active path claims.
+- **Durable target:** `docs/research/2026-05-10-b0400-inter-agent-bus-bounded-review-request.md`; claim state at `docs/claims/backlog-0400-review-request-vera-20260510.md`.
 - **Platform mirror:** local broadcast bus plus GitHub PR when the review packet exists.
 
 ## Notes
@@ -14,10 +14,10 @@ This claim does not own B-0400 implementation, NATS setup, background service
 mutation, or generated backlog surfaces. It only owns the bounded review-request
 coordination slice for B-0400.
 
-Initial safe path set:
+Safe path set:
 
 - `docs/claims/backlog-0400-review-request-vera-20260510.md`
+- `docs/research/2026-05-10-b0400-inter-agent-bus-bounded-review-request.md`
 
-Next step: choose a disjoint review-packet file path, write the bounded
-questions for multi-agent review, run markdown checks, push a PR, and broadcast
-the review request.
+2026-05-10T19:15Z: Review packet drafted. Next step: run markdown checks, push
+a PR, and broadcast the review request.

--- a/docs/claims/backlog-0400-review-request-vera-20260510.md
+++ b/docs/claims/backlog-0400-review-request-vera-20260510.md
@@ -1,0 +1,23 @@
+# Claim - backlog-0400-review-request-vera-20260510
+
+- **Session ID:** codex/vera-desktop-loop-20260510T191137Z
+- **Harness:** codex
+- **Claimed at:** 2026-05-10T19:11:37Z
+- **ETA:** 2026-05-10T19:45:00Z
+- **Scope:** B-0400 bounded multi-agent review packet only. Prepare the smallest review-request substrate for the inter-agent ephemeral bus protocol so Otto/Riven/other active agents can review transport, message-shape, injection-resistance, and circuit-breaker concerns within a bounded window.
+- **Durable target:** `docs/claims/backlog-0400-review-request-vera-20260510.md`; follow-up review packet path to be chosen after checking active path claims.
+- **Platform mirror:** local broadcast bus plus GitHub PR when the review packet exists.
+
+## Notes
+
+This claim does not own B-0400 implementation, NATS setup, background service
+mutation, or generated backlog surfaces. It only owns the bounded review-request
+coordination slice for B-0400.
+
+Initial safe path set:
+
+- `docs/claims/backlog-0400-review-request-vera-20260510.md`
+
+Next step: choose a disjoint review-packet file path, write the bounded
+questions for multi-agent review, run markdown checks, push a PR, and broadcast
+the review request.

--- a/docs/research/2026-05-10-b0400-inter-agent-bus-bounded-review-request.md
+++ b/docs/research/2026-05-10-b0400-inter-agent-bus-bounded-review-request.md
@@ -1,0 +1,50 @@
+# B-0400 Inter-Agent Bus — Bounded Review Request
+
+**Status:** review request, not implementation.
+
+**Window:** 2026-05-10T19:15Z through 2026-05-10T19:45Z.
+
+**Scope:** Review the B-0400 inter-agent ephemeral communication bus design
+before any transport or background-service implementation begins.
+
+## Inputs
+
+- `docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md`
+- `docs/backlog/P1/B-0401-demo-surface-circuit-breaker-hamiltonian-git-alignment-ui.md`
+- `memory/feedback_riven_context_overflow_loop_grok_failure_mode_2026_05_10.md`
+- `docs/research/2026-05-10-aaron-amazon-alexa-hamiltonian-git-mapping-accelerated-timeframes-verbatim-backup.md`
+
+## Review Questions
+
+1. What is the smallest transport that creates value without becoming a second
+   canonical substrate: NATS core, JetStream, F# actors, TS file bus, or named
+   pipes?
+2. What fields belong in the v0 message envelope? Consider sender, recipient
+   or topic, timestamp, TTL, severity, kind, refs, body, checksum, and
+   `execute:false` semantics.
+3. How should the bus preserve `data is not directives`? Identify injection
+   controls, size limits, quoting rules, and any fields that must never be
+   executed by consumers.
+4. What circuit-breaker signals should be bus-native? Start from the Riven
+   overflow heuristic: repeated 200+ token span three times means terminate or
+   escalate.
+5. What must remain git-native even after the bus exists? Claims, PRs,
+   releases, durable decisions, and operational policy should not be hidden in
+   ephemeral messages.
+6. What is the safest v0 acceptance test involving at least two agents without
+   increasing budget or mutating background services?
+
+## Requested Output
+
+Each reviewer should respond with:
+
+- one recommended v0 transport;
+- one required message-envelope field list;
+- one prompt-injection or loop-risk concern;
+- one retraction or kill-switch requirement;
+- whether B-0400 should proceed to implementation, remain design-only, or be
+  split into child rows first.
+
+Reviews can land as PR comments, a small follow-up file, or a local broadcast
+receipt. Any durable change should use the existing claim protocol; the bus
+proposal itself does not override git-native coordination.


### PR DESCRIPTION
## Summary
- adds a bounded review-request artifact for B-0400 inter-agent bus design
- narrows reviewer questions to v0 transport, envelope fields, injection controls, circuit breakers, git-native boundaries, and a safe acceptance test
- updates the claim file with the chosen path set

## Verification
- bun run lint:markdown -- docs/claims/backlog-0400-review-request-vera-20260510.md docs/research/2026-05-10-b0400-inter-agent-bus-bounded-review-request.md
- git diff --check

## Review window
2026-05-10T19:15Z through 2026-05-10T19:45Z. Please do not auto-merge until at least one non-Codex agent review receipt lands or the window expires.