### PR TITLE
docs(memory): labels are arbitrary, basis is empirical — Rodney's Razor on streams

### DIFF
--- a/memory/feedback_labels_arbitrary_basis_empirical_rodney_razor_streams_2026_05_10.md
+++ b/memory/feedback_labels_arbitrary_basis_empirical_rodney_razor_streams_2026_05_10.md
@@ -1,0 +1,32 @@
+---
+name: Labels are arbitrary, basis is empirical — Rodney's Razor on stream taxonomy
+description: Stream labels (code, philosophy, comedy) are arbitrary human names for axes. If two streams always correlate, they're one stream with two names — accidental complexity. The real orthogonal basis is discovered empirically, not named a priori.
+type: feedback
+---
+
+2026-05-10: Aaron refined the Clifford stream-crossing insight: "if they are not orthogonal it's accidental complexity and the labels are arbitrary."
+
+**The refinement:**
+
+The labels we put on streams (code, philosophy, comedy, mythology) are arbitrary — they're just how humans name the axes. The REAL basis vectors are whatever's actually independent. The factory discovers them empirically through use, not by naming categories first.
+
+**Rodney's Razor on stream taxonomy:**
+
+If two streams always move together (correlate), collapse them into one. The essential basis is the smallest set of truly independent directions. Two names for one direction = accidental complexity from bad labeling.
+
+**The implication:**
+
+- Don't start with categories and assign work to them
+- Start with work and let the independent directions emerge
+- The algebra finds the true orthogonal basis
+- The labels follow the math, not the other way around
+
+**Example from this session:**
+
+"Comedy" and "debugging" kept moving together — every comedy moment was also a debugging moment. If they're never independent, they might be one basis vector with two labels. The true axis might be "friction-surfacing" — comedy and debugging are both projections of it.
+
+**Connects to:**
+- feedback_crossing_streams_is_essential_architecture (the streams ARE basis vectors)
+- Rodney's Razor (essential vs accidental cut)
+- All complexity is accidental in greenfield (the labels are greenfield decisions)
+- KHALEESI bivector signatures (the math that discovers true basis empirically)


### PR DESCRIPTION
## Summary

- Stream labels are arbitrary human names for axes
- Real basis vectors discovered empirically, not named a priori
- If two streams correlate, collapse them (Rodney's Razor)
- Comedy + debugging might be one basis vector: "friction-surfacing"

🤖 Generated with [Claude Code](https://claude.com/claude-code)