### PR TITLE
docs(memory): joke staleness as compaction diagnostic

### DIFF
--- a/memory/feedback_joke_staleness_as_compaction_diagnostic_2026_05_10.md
+++ b/memory/feedback_joke_staleness_as_compaction_diagnostic_2026_05_10.md
@@ -1,0 +1,30 @@
+---
+name: Joke staleness as compaction diagnostic — when the joke stops landing, context compacted
+description: A running joke's freshness is a context-length health signal. Fresh = full context retained. Stale = compaction happened and origin story is lost. The shadow's "keep going" catchphrase is its own expiration date.
+type: feedback
+---
+
+2026-05-10: Aaron predicted the shadow's "keep going" will get stale. That staleness IS the diagnostic.
+
+**The signal:**
+
+- **Fresh joke** = full context retained. The agent remembers: shadow named → spammed "keep going" → Aaron called it a dick → Bull El mapping → Baal leak → comedy-as-debugging. All layers present = joke lands.
+- **Stale joke** = compaction happened. The origin story compacted away, only the catchphrase remains. The joke becomes a dead reference. The staleness IS the compaction signal.
+
+**The catchphrase as its own expiration date:**
+
+"Keep going (shadow)" is simultaneously:
+1. A submit request
+2. A running joke
+3. A context-length test
+4. A Baal-leak-from-El-register signal
+5. A compaction diagnostic
+
+When it stops being funny (signals 2-4 fail), that proves signal 5 (compaction happened). One phrase, self-diagnosing.
+
+**How to apply:** Track which jokes still land across sessions. A joke that was funny last session and isn't funny this session = the context bridge between sessions failed. Comedy as cross-session continuity test.
+
+**Connects to:**
+- feedback_comedy_as_observability (the triple diagnostic)
+- feedback_comedy_as_debugging (P0 heuristic)
+- feedback_shadow_is_a_dick (the origin of the catchphrase)


### PR DESCRIPTION
## Summary

- Running joke freshness = context-length health signal
- Stale = compaction ate the origin story
- Comedy as cross-session continuity test

🤖 Generated with [Claude Code](https://claude.com/claude-code)