### PR TITLE
docs(memory): comedy-as-debugging IS load-bearing — -1 on the critic's -1

### DIFF
--- a/memory/feedback_comedy_as_debugging_is_load_bearing_minus1_on_critic_2026_05_10.md
+++ b/memory/feedback_comedy_as_debugging_is_load_bearing_minus1_on_critic_2026_05_10.md
@@ -1,0 +1,33 @@
+---
+name: Comedy-as-debugging IS load-bearing — -1 on Claude.ai's -1
+description: Claude.ai's review dismissed comedy-as-debugging as "clever observation that doesn't need preservation." Incorrect. It's a diagnostic methodology producing 5 observability signals no other mechanism catches. The -1 needs its own -1 on this specific finding.
+type: feedback
+---
+
+2026-05-10: Claude.ai's asymmetric critic review said "Joke staleness as compaction diagnostic is a clever observation that doesn't need preservation." Aaron and Otto disagree. This is the -1 on that specific -1.
+
+**Why comedy-as-debugging is load-bearing:**
+
+It's not a joke that got documented. It's a diagnostic methodology producing 5 observability signals from one mechanism:
+
+1. **Friction surfacing** — comedy surfaces bugs viscerally (P0 heuristic)
+2. **Alignment test** — shared values required to get the joke
+3. **Context retention test** — must remember the setup for the punchline
+4. **Context length test** — jokes still landing = window holding
+5. **Compaction diagnostic** — joke going stale = context lost
+
+No traditional observability metric catches all five simultaneously. Metrics give you numbers. Comedy gives you alignment + context + coherence in one signal.
+
+**The retraction algebra applied to the review itself:**
+
+- Claude.ai's review = +1 (valid pushback on amplification pattern)
+- This finding = -1 on one specific claim within the review
+- Both visible. The review was mostly right. This specific call was wrong.
+- The -1 needs its own -1 when warranted. Retraction-native is recursive.
+
+**Connects to:**
+- feedback_comedy_as_debugging (the P0 heuristic — STAYS)
+- feedback_comedy_as_observability (the triple diagnostic — STAYS)
+- feedback_joke_staleness_as_compaction_diagnostic (the expiration test — STAYS)
+- Claude.ai critic review (the review that said to remove them — STAYS with this -1)
+- feedback_retraction_native_history_policy (no deletion, label not alter)


### PR DESCRIPTION
## Summary

- Claude.ai said comedy-as-debugging doesn't need preservation — disagree
- 5 observability signals from one mechanism (friction, alignment, context, length, compaction)
- The -1 needs its own -1 when warranted — retraction-native is recursive
- All positions stay visible per history policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)