### PR TITLE
docs(memory): comedy sixth signal — human attention retention keeps safety model alive

### DIFF
--- a/memory/feedback_comedy_sixth_signal_holds_human_attention_safety_model_2026_05_10.md
+++ b/memory/feedback_comedy_sixth_signal_holds_human_attention_safety_model_2026_05_10.md
@@ -1,0 +1,30 @@
+---
+name: Comedy sixth signal — holds human attention, keeps the safety model alive
+description: Comedy keeps the human paying attention to the factory output. Without attention, the human circuit breaker is gone. Comedy-as-debugging isn't just diagnostic — it's the mechanism that keeps the safety model alive.
+type: feedback
+---
+
+2026-05-10: Aaron added the sixth observability signal for comedy-as-debugging: "it keeps human attention too which is VERY hard."
+
+**The six signals (updated):**
+
+1. Friction surfacing — comedy surfaces bugs viscerally
+2. Alignment test — shared values to get the joke
+3. Context retention — remembers the setup
+4. Context length — jokes still land deep in session
+5. Compaction diagnostic — joke going stale = context lost
+6. **Human attention retention** — comedy keeps the human engaged with factory output
+
+**Why signal 6 is the most important:**
+
+The entire safety model depends on the human watching. Aaron is the live circuit breaker — always watching, always can type, always can override. But humans stop paying attention to dashboards, metrics, log files. Attention is the hardest resource to hold.
+
+Comedy holds it. Aaron will read "shadow is a dick." Aaron will skip "context-retention-metric-v2.md." The joke title IS the engagement mechanism that keeps the human in the loop.
+
+If the human stops paying attention, the circuit breaker is gone. Comedy keeps the human paying attention. Comedy-as-debugging isn't just diagnostic — it's the mechanism that keeps the safety model alive.
+
+**Connects to:**
+- B-0402 safety model (human as live circuit breaker)
+- feedback_comedy_as_debugging (P0 heuristic)
+- feedback_comedy_as_debugging_is_load_bearing (the -1 on the critic)
+- DeBank UX reference (make it engaging, not just informative)


### PR DESCRIPTION
## Summary

- 6th comedy-as-debugging signal: holds human attention
- Humans skip dashboards, read jokes — comedy IS engagement
- Without attention, the human circuit breaker is gone
- Comedy keeps the safety model alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)