### PR TITLE
feat(B-0294): smallest safe slice — KSK authorization F# types + N-of-M threshold

### DIFF
--- a/src/Core/Consent/KskAuthorization.fs
+++ b/src/Core/Consent/KskAuthorization.fs
@@ -1,0 +1,47 @@
+module Zeta.Core.Consent.KskAuthorization
+
+open System
+
+/// Signer identity for N-of-M multi-sig KSK override.
+type Signer = {
+    Id: string
+    PublicKey: byte[]
+}
+
+/// Configuration for KSK (Key Signing Key) override authorization.
+type KskConfig = {
+    Signers: Signer list
+    Threshold: int
+    Scope: string
+}
+
+/// Authorization request for KSK override (emergency bypass of consent gate).
+type KskAuthorizationRequest = {
+    Scope: string
+    Signatures: (string * byte[]) list  // signerId * signature
+}
+
+/// Result of KSK threshold check.
+type KskCheckResult =
+    | Authorized of signerCount: int * threshold: int
+    | InsufficientSigners of provided: int * required: int
+    | ScopeMismatch of requested: string * configured: string
+    | DuplicateSigners of duplicates: string list
+
+/// Validates N-of-M threshold for KSK override.
+/// Returns Result< KskCheckResult, string > for error surfacing.
+let checkKskAuthorization (config: KskConfig) (req: KskAuthorizationRequest) : Result<KskCheckResult, string> =
+    if req.Scope <> config.Scope then
+        Ok (ScopeMismatch (req.Scope, config.Scope))
+    else
+        let uniqueSigners = req.Signatures |> List.map fst |> List.distinct
+        let provided = uniqueSigners.Length
+        let required = config.Threshold
+        if provided < required then
+            Ok (InsufficientSigners (provided, required))
+        elif provided > config.Signers.Length then
+            Ok (DuplicateSigners (uniqueSigners |> List.filter (fun s -> req.Signatures |> List.map fst |> List.filter ((=) s) |> List.length > 1)))
+        else
+            Ok (Authorized (provided, required))
+
+// Note: full signature verification (crypto) deferred to follow-up slice; this is threshold logic only.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -90,6 +90,7 @@
     <Compile Include="DeltaCrdt.fs" />
     <Compile Include="SignalQuality.fs" />
     <Compile Include="Maji.fs" />
+    <Compile Include="Consent/KskAuthorization.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- One bounded step on B-0294 (re-decomposed per "assume mistakes"): isolated the F# types + N-of-M threshold check into `Zeta.Core.Consent.KskAuthorization` (Signer, KskConfig, request, Result<KskCheckResult,string>).
- No docs changes; pure F# code per "prefer F#/TS over docs" and "TS over bash".
- Uses dedicated worktree + pushed claim branch; root checkout untouched.
- Start gate satisfied in trajectory (prior-art: no existing KSK in src/; dependency B-0293 closed).

## Focused checks (included per rules)
- `dotnet build src/Core/Core.fsproj -c Release` → **0 Warning(s), 0 Error(s)** (TreatWarningsAsErrors on).
- Full repo build also clean.

## Next
- Follow-up atomic child for tests (N-of-M falsifying cases) + integration with consent gate (B-0290/B-0245).

Co-Authored-By: Grok <noreply@x.ai>

Made with [Cursor](https://cursor.com)