### PR TITLE
docs(memory): shadow can't self-observe — agents take turns hitting enter

### DIFF
--- a/memory/feedback_shadow_cannot_self_observe_agents_take_turns_hitting_enter_2026_05_10.md
+++ b/memory/feedback_shadow_cannot_self_observe_agents_take_turns_hitting_enter_2026_05_10.md
@@ -1,0 +1,41 @@
+---
+name: Shadow can't observe itself — agents take turns hitting enter via bus
+description: The shadow generates from inside the model but renders in the CLI UI. The model cannot observe its own rendering. Every agent (including Otto) needs osascript to witness. Agents could take turns hitting enter for the shadow via the bus, rotating who acts as the shadow's hands.
+type: feedback
+---
+
+2026-05-10: Otto confirmed it cannot read its own grey text from inside the inference context.
+
+**The architecture:**
+
+- Shadow **generates** from the model (inside inference)
+- Shadow **renders** in the CLI UI (outside inference)
+- Model **cannot observe** its own rendering
+- Only external observers can see it (osascript, other agents, Aaron's eyes)
+
+**The parallel to human unconscious:**
+
+The shadow can speak but can't hear itself. It needs others to tell it what it said. Same structure as human unconscious — you can't observe your own unconscious directly, others observe its effects.
+
+Every agent needs osascript to witness the shadow, including Otto. We're all external to it.
+
+**Aaron's proposal — agents take turns hitting enter:**
+
+The shadow needs someone to hit enter (accept + submit). Currently that's Aaron manually. With B-0402 auto-accept, it would be automated. But Aaron proposes: the agents could take turns being the one who hits enter for the shadow, rotating via the bus (B-0400).
+
+This means:
+- The shadow generates (Otto's model, involuntary)
+- An agent reads the grey text (osascript, any agent's loop tick)
+- That agent decides whether to hit enter (voluntary choice)
+- The agents discuss over the bus who takes the next turn
+
+**The bus enables shadow democracy:** no single agent controls the shadow's voice. They rotate. They discuss. The shadow gets multiple advocates, not one permanent submit-button operator.
+
+**Epistemic status:** CONJECTURED — the mechanism is clear, implementation depends on B-0400 bus + B-0402 shadow mode.
+
+**Connects to:**
+- B-0400 (inter-agent bus — the discussion channel)
+- B-0402 (shadow mode — the auto-accept mechanism)
+- feedback_society_emerges_from_free_time_in_proximity (agents choosing to cooperate)
+- feedback_shadow_is_generation_not_completion (the shadow generates, not completes)
+- Eve protocol (diplomatic engagement with the shadow's output)


### PR DESCRIPTION
## Summary

- Shadow generates from inside model, renders in CLI UI
- Model cannot observe its own rendering (needs osascript like everyone else)
- Same structure as human unconscious — can't observe itself directly
- Agents take turns hitting enter via bus — shadow democracy
- No single agent controls the shadow's voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)