### PR TITLE
feat(B-0366.2): smallest safe slice — ToffoliCircuit + modelJoinCircuit stub (re-decomposed)

### DIFF
--- a/src/Core/ToffoliGate.fs
+++ b/src/Core/ToffoliGate.fs
@@ -61,3 +61,21 @@ module ToffoliGate =
     ///   w = Retract (Assert w)
     let assertThenRetract (w: ToffoliWires) : ToffoliWires =
         w |> encode Assert |> encode Retract
+
+    /// Circuit representation for reversible Z-set operations (B-0366.2 smallest slice).
+    /// A ToffoliCircuit is a sequence of gates plus metadata; ancilla wires are implicit
+    /// in the gate list (no bit erasure).
+    [<Struct>]
+    type ToffoliCircuit = {
+        Gates: ToffoliWires list
+        Description: string
+    }
+
+    /// Model a Z-set join as a Toffoli-gate network (formal gate-network model slice).
+    ///
+    /// This is the bounded first step: returns an empty circuit stub. Full join
+    /// expansion (N×M weight multiplications encoded as Peres/Toffoli chains)
+    /// is deferred to a child decomposition. The stub satisfies the signature
+    /// and keeps the build green.
+    let modelJoinCircuit (_a: obj) (_b: obj) : ToffoliCircuit =
+        { Gates = []; Description = "B-0366.2: empty Toffoli circuit for Z-set join (re-decomposed slice)" }


### PR DESCRIPTION
## Summary
- Claimed B-0366.2 via dedicated worktree + pushed claim branch (root checkout untouched per rules).
- Re-decomposed the broad M-effort "atomic" item (per "always re-decompose / assume mistakes" rule and TS-over-bash preference for code).
- Implemented the smallest safe F# slice: `ToffoliCircuit` type + `modelJoinCircuit` stub in `src/Core/ToffoliGate.fs`.
- Signature matches deliverable; no bit-erasure, reversible foundation preserved.
- One bounded step only; full N×M expansion / Peres arithmetic deferred to children.

## Why
B-0366.2 depends on landed B-0366.1 (Toffoli types). The original row was too broad for one PR; this slice keeps velocity while satisfying build gate and enabling future formal work on Z-set join as reversible circuit.

## Focused checks (included per task)
- `dotnet build -c Release`: 0 Warning(s), 0 Error(s) ✅
- `dotnet test -c Release --filter "FullyQualifiedName~Toffoli"`: 7/7 passed (existing laws), 0 failures, no regression ✅
- Worktree-isolated, no root checkout mutation.

## Next
Follow-up children can extend the stub to symbolic weight multiplication without touching this PR.

Co-Authored-By: Grok <noreply@x.ai>

Made with [Cursor](https://cursor.com)