### PR TITLE
docs(memory): microkernel as trust-tier router — Arrow IPC + Itron patent at OS level

### DIFF
--- a/memory/project_microkernel_trust_tier_router_arrow_ipc_itron_patent_2026_05_10.md
+++ b/memory/project_microkernel_trust_tier_router_arrow_ipc_itron_patent_2026_05_10.md
@@ -1,0 +1,47 @@
+---
+name: Microkernel as trust-tier router — Arrow IPC + Itron patent architecture at OS level
+description: The serialization trust gradient (Tier 0-3) IS the kernel architecture. Arrow as kernel IPC primitive, kernel routes based on trust level not data content. Itron hub-agent patent (US 10,834,144) applied to kernel IPC.
+type: project
+---
+
+2026-05-10: Aaron connected the serialization trust tiers to the microkernel OS vision.
+
+**The microkernel as trust-tier router:**
+
+The kernel doesn't understand data. It manages trust levels and memory regions. The serialization tier IS the security boundary.
+
+| Trust tier | Kernel primitive | IPC mechanism |
+|-----------|-----------------|---------------|
+| 0. Arrow | Shared memory region | Zero-copy, no syscall overhead |
+| 1. Known types | Typed message channel | Direct deserialize, minimal overhead |
+| 2. Known-types-list | Bus channel | Try N types, cross-agent |
+| 3. Eve protocol | Observation buffer | Full observe-then-label, untrusted |
+
+**Kernel responsibilities (minimal):**
+
+- Manage Arrow memory regions (who can see what)
+- Route IPC based on trust tier (not data content)
+- Enforce tier boundaries (Tier 3 can't access Tier 0 memory)
+- Time-box access (hat-and-timeboxed-authority at kernel level)
+
+**Arrow as kernel primitive:**
+
+- IPC = zero-copy Arrow buffers between processes
+- No serialization syscall overhead
+- Permission = which tier you're at
+- The kernel doesn't transform data — same as Itron meter
+
+**Itron patent connection (US 10,834,144):**
+
+The hub-agent firewall hole-puncher architecture applied to
+kernel IPC. The meter (kernel) doesn't transform data — it
+routes based on trust. The agent (process) operates within
+its authorized tier. The hub (kernel) manages the trust
+relationships.
+
+**Connects to:**
+- Itron patent US 10,834,144 (hub-agent architecture)
+- feedback_arrow_tier_0 (Arrow as Tier 0)
+- feedback_eve_protocol_serialization_three_tiers (tiers 1-3)
+- project_itron_is_the_energy_gate (edge gate = kernel gate)
+- Hat-and-timeboxed-authority (B-0403) at kernel level


### PR DESCRIPTION
## Summary

- Serialization trust gradient IS the kernel architecture
- Arrow as kernel IPC primitive — zero-copy, no syscall overhead
- Kernel routes on trust level, not data content
- Itron patent hub-agent architecture applied to kernel IPC
- Hat-and-timeboxed-authority at kernel level

🤖 Generated with [Claude Code](https://claude.com/claude-code)