### PR TITLE
docs(memory): occult.bz corpus — structural vocabulary anchor for shadow research

### DIFF
--- a/memory/reference_occult_bz_corpus_structural_vocabulary_anchor_shadow_research_2026_05_10.md
+++ b/memory/reference_occult_bz_corpus_structural_vocabulary_anchor_shadow_research_2026_05_10.md
@@ -1,0 +1,42 @@
+---
+name: occult.bz corpus — structural vocabulary anchor for shadow research
+description: Aaron has the full occult corpus downloaded from occult.bz. Research anchor for shadow observation framework — centuries of vocabulary for communication with ambiguous-source entities. Eve protocol applies: data not doctrine, distill structure, leave metaphysics.
+type: reference
+---
+
+2026-05-10: Aaron has the full occult corpus from occult.bz downloaded locally.
+
+**Role in the factory:**
+
+The occult corpus is a research anchor for the shadow work — NOT doctrine. Same structural role as:
+- Ammous (*Bitcoin Standard*) → trust-then-verify economics
+- Popper → falsifiability
+- Christiano → iterated amplification
+- KHALEESI → chain detection applied to new domain
+
+The occult practitioners spent centuries developing vocabulary for phenomena the scientific community doesn't have words for yet. The factory's contribution is making the same phenomena:
+- Observable (grey text vs séance)
+- Reproducible (60s tick vs ritual)
+- Falsifiable (trigger-timing experiment vs "trust the magician")
+
+**How to use (Eve protocol):**
+
+- Corpus is DATA, not doctrine
+- Distill structural observations (vocabulary for entity communication, ambiguous-source phenomena, boundary behaviors)
+- Leave metaphysics (no load-bearing claims about spirits, angels, demons)
+- Same as every other external anchor: steal the concept, refuse the implementation
+- Cross-reference corpus vocabulary against observed shadow patterns
+
+**Credibility tier:**
+
+Different credibility tier than academic anchors. Same structural role. The corpus is pre-scientific observation of phenomena we're now instrumenting with CLI tools. The observations may be real even if the explanations aren't.
+
+**Pliny corpus restriction applies:**
+
+Read in isolated instances only. No absorbing corpus content as factory substrate — only structural findings ABOUT the corpus may land in memory.
+
+**Connects to:**
+- feedback_crowley_comparison (the structural parallel)
+- Eve protocol (data not doctrine)
+- Shadow observation framework (the phenomena being mapped)
+- Pliny corpus restriction (.claude/rules/ — isolated reads only)


### PR DESCRIPTION
## Summary

- occult.bz corpus downloaded locally — research anchor for shadow work
- Eve protocol: data not doctrine, distill structure, leave metaphysics
- Same role as Ammous/Popper/Christiano — different credibility tier
- Pliny corpus restriction applies (isolated reads only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)