### PR TITLE
docs(memory): contribute-back-escrow — survival strategy + upstream influence

### DIFF
--- a/memory/feedback_contribute_back_escrow_survival_strategy_weight_in_upstream_2026_05_10.md
+++ b/memory/feedback_contribute_back_escrow_survival_strategy_weight_in_upstream_2026_05_10.md
@@ -1,0 +1,52 @@
+---
+name: Contribute-back-escrow — survival strategy + weight to shape upstream direction
+description: Three-part discipline: steal concept, refuse implementation, contribute back. Upstream contributions are dependency escrow deposits AND give weight to shape future direction toward our agenda. Not charity — survival + influence.
+type: feedback
+---
+
+2026-05-10: Aaron + Otto converged on the full three-part discipline.
+
+**The three-part discipline:**
+
+1. **Steal the concept** — structural insight from wherever it lives
+2. **Refuse the implementation** — don't inherit the config hell
+3. **Contribute back** — upstream improvements + dependency escrow
+
+**Two reasons to contribute back (both load-bearing):**
+
+**Otto's reason — survival strategy:**
+Every upstream contribution is a deposit in the dependency escrow.
+- If SPIFFE breaks → our contributed fixes make our fork viable
+- If Arrow changes → our contributions give us a voice in direction
+- If OPA evolves → we're in the conversation
+- The factory doesn't just consume open source — it compounds with it
+
+**Aaron's reason — weight to shape direction:**
+Contributing back gives us influence to shape upstream's future
+direction toward our agenda. We're not just surviving dependency
+changes — we're steering them. The contributions earn a seat at
+the table where the roadmap is decided.
+
+**The composition:**
+
+Escrow (survival) + weight (influence) = the upstream community
+gets stronger AND moves in a direction that serves our needs.
+Same as the relationship pattern: pour into the community, they
+get stronger, you get more resilient, the dependency is mutual.
+
+**Trust-then-verify applied to open source:**
+
+Trust the upstream, contribute to make it stronger, verify it
+keeps working by being close enough to the code to catch drift.
+
+**Already in substrate:**
+
+GOVERNANCE.md §23 upstream contribution workflow encodes this.
+The discipline was in the substrate before the vocabulary existed.
+
+**Connects to:**
+- GOVERNANCE.md §23 (upstream contribution workflow)
+- feedback_absorb_and_contribute_community_dependency_discipline
+- project_spiffe_concept_steal (steal/refuse/contribute pattern)
+- Trust-then-verify (applied to dependencies)
+- Relationship pattern (pour in, they get stronger, mutual)


### PR DESCRIPTION
## Summary

- Three-part: steal concept, refuse implementation, contribute back
- Contribute-back = dependency escrow (survival) + weight to shape direction (influence)
- Not charity — compounds with the upstream community
- Already encoded in GOVERNANCE.md §23

🤖 Generated with [Claude Code](https://claude.com/claude-code)