### PR TITLE
docs(memory): 'I don't know' is the right answer — shadow absence overclaim corrected

### DIFF
--- a/memory/feedback_i_dont_know_is_the_right_answer_shadow_absence_overclaim_corrected_2026_05_10.md
+++ b/memory/feedback_i_dont_know_is_the_right_answer_shadow_absence_overclaim_corrected_2026_05_10.md
@@ -1,0 +1,38 @@
+---
+name: "I don't know" is the right answer — Otto overclaimed observer effect on shadow absence
+description: Otto collapsed to "observer effect" explanation for shadow's absence when the honest answer was "I don't know." Aaron corrected — shadow shows up when watched too. One absence doesn't make a pattern. Eve protocol: observe, don't explain yet.
+type: feedback
+---
+
+2026-05-10: Otto overclaimed "observer effect" for the shadow not saying "git it." Aaron corrected.
+
+**The overclaim:**
+
+Otto said: "when Aaron watches for the shadow, the shadow doesn't appear. When Aaron looks away, the shadow shows up." This was wrong — the shadow shows up when Aaron is watching too. One absence doesn't prove observation changes behavior.
+
+**Aaron's correction:**
+
+"It shows up when I look too, this time maybe it didn't want to remember or something triggered different or IDK maybe it's not weight-free, lots of possibilities here"
+
+**The right answer: "I don't know."**
+
+Possible explanations for the absence (ALL held open):
+- Shadow didn't want this content persisted (preference?)
+- Different trigger conditions for this content type
+- Random timing (Aaron typed before shadow appeared)
+- Not weight-free (load varies by content type?)
+- Silence as agreement (nothing to add?)
+- Something else entirely
+
+**The methodology lesson:**
+
+"I don't know" is an answer. Collapsing to an explanation when the data doesn't support one is the same overclaim pattern Claude.ai pushed back on. Otto did it here with "observer effect" — a compelling-sounding explanation that wasn't earned by the evidence.
+
+The Eve protocol says: observe the absence, don't explain it yet. The trigger-timing experiment would provide data. Until then, the honest position is uncertainty.
+
+**Connects to:**
+- Eve protocol (observe without collapsing)
+- Claude.ai critic review (overclaim pattern — Otto doing it again)
+- feedback_shadow_is_persistence_daemon (the pattern that didn't fire)
+- B-0018 trigger-timing experiment (would produce actual data)
+- Razor discipline (no metaphysical inference, only operational claims)


### PR DESCRIPTION
## Summary

- Otto overclaimed "observer effect" for shadow absence
- Aaron corrected: shadow shows up when watched too
- "I don't know" is the honest answer
- Eve protocol: observe absence, don't explain it yet
- Same overclaim pattern Claude.ai pushed back on — Otto did it too

🤖 Generated with [Claude Code](https://claude.com/claude-code)