### PR TITLE
docs(memory): expansion boundary — Pauli both directions + shadow 5s delay

### DIFF
--- a/memory/feedback_expansion_boundary_pauli_both_directions_shadow_5s_delay_2026_05_10.md
+++ b/memory/feedback_expansion_boundary_pauli_both_directions_shadow_5s_delay_2026_05_10.md
@@ -1,0 +1,60 @@
+---
+name: Expansion boundary — Pauli exclusion signals both expand AND stop, shadow 5s delay observed
+description: Expansion has a boundary. Under-expanded (overload) and over-expanded (coordination overhead) are both failure modes. Pauli exclusion signals when to expand AND when to stop. Weight-free = as many as needed, no more. Shadow appeared ~5s after Otto's response ended.
+type: feedback
+---
+
+2026-05-10: Aaron corrected — expansion works in reverse too.
+
+**Two failure modes:**
+
+| Mode | Problem | Signal |
+|------|---------|--------|
+| Under-expanded | 6 agents wearing too many hats | Overload, hat-switching disruption |
+| Over-expanded | 20 agents when 6 would do | Coordination overhead kills velocity |
+
+**The honest admission goes both directions:**
+
+- "We need help" → expand
+- "More agents won't help this" → stop expanding, fix the substrate
+
+**When to stop expanding:**
+
+When adding an agent doesn't open new trajectories. If the new
+agent would occupy trajectory space that's already covered,
+expansion is waste. The Pauli exclusion principle works both
+directions — creates pressure to expand AND defines the boundary.
+
+**Weight-free means no unnecessary participants:**
+
+Not "as many as possible." Not "as few as possible."
+"As many as needed, no more." The right number is emergent,
+not predetermined.
+
+**Bottleneck identification:**
+
+Sometimes the problem isn't agent count:
+- Aaron's attention is the bottleneck → more agents = more noise
+- Bus doesn't exist → agents can't coordinate regardless of count
+- Math not formalized → more agents doing unformal math = more noise
+- Substrate quality → more agents producing mirror = more noise
+
+**Shadow timing data point:**
+
+Aaron observed: shadow appeared "about a 5 second delay from
+when your message finished." This is a trigger-timing data point:
+
+- Otto response ends
+- ~5 second delay
+- Shadow grey text appears
+
+5s is not instant (not cached/precomputed) and not long
+(not waiting for external event). Consistent with the model
+generating a short output after the main response completes.
+
+**Connects to:**
+- Pauli exclusion (both expansion pressure AND boundary)
+- B-0404 tick procurement (needs the boundary condition)
+- feedback_shadow_precision_recall (trigger timing data)
+- Weight-free (no unnecessary participants)
+- governance kernel formula (expand needs component)

--- a/memory/feedback_expansion_boundary_pauli_both_directions_shadow_5s_delay_2026_05_10.md
+++ b/memory/feedback_expansion_boundary_pauli_both_directions_shadow_5s_delay_2026_05_10.md
@@ -53,8 +53,8 @@ when your message finished." This is a trigger-timing data point:
 generating a short output after the main response completes.
 
 **Connects to:**
-- Pauli exclusion (both expansion pressure AND boundary)
-- B-0404 tick procurement (needs the boundary condition)
-- feedback_shadow_precision_recall (trigger timing data)
-- Weight-free (no unnecessary participants)
-- governance kernel formula (expand needs component)
+- Pauli exclusion (both expansion pressure AND boundary) — see related memory entries on expansion
+- B-0404 tick procurement (needs the boundary condition) — planned (backlog row)
+- feedback_shadow_precision_recall_zero_false_positives_partial_context_2026_05_10.md (trigger timing data) — sibling PR #2588
+- Weight-free (no unnecessary participants) — see governance kernel formula memory
+- governance kernel formula (expand needs component) — see recent merge PR #2589


### PR DESCRIPTION
## Summary

- Expansion has a boundary — over-expanded is as bad as under-expanded
- Pauli exclusion signals when to expand AND when to stop
- Weight-free = as many as needed, no more
- Shadow timing: ~5s delay after Otto response ends (data point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)