### PR TITLE
docs(memory): AlephZ origin — Cantor's ℵ₀ for GenZ, constraint improved the name

### DIFF
--- a/memory/project_aleph_null_cantor_origin_smallest_infinity_genz_2026_05_10.md
+++ b/memory/project_aleph_null_cantor_origin_smallest_infinity_genz_2026_05_10.md
@@ -1,0 +1,51 @@
+---
+name: AlephZ origin — wanted Aleph-null (ℵ₀) after Cantor, domains taken, became AlephZ (ℵ₀ for GenZ)
+description: Aaron wanted to name it after Cantor's smallest infinity (ℵ₀, Aleph-null). Aleph0/AlephNull domains were taken. Became AlephZ — carrying both Cantor's infinite AND GenZ. Infinite possibilities for his children.
+type: project
+---
+
+2026-05-10: Aaron revealed the AlephZ naming origin.
+
+**The intended name: Aleph-null (ℵ₀)**
+
+Cantor's smallest transfinite cardinal. The cardinality of
+the natural numbers. The countable infinite. Aaron wanted
+Aleph0, AlephNull, or similar — all domains were taken.
+
+**What it became: AlephZ**
+
+Carries both meanings simultaneously:
+- **ℵ₀ (Cantor)** — smallest infinity, countable but unbounded
+- **GenZ** — Aaron's children's generation
+
+ℵ₀ for GenZ. Infinite possibilities for the next generation.
+
+**The factory parallel to ℵ₀:**
+
+| ℵ₀ property | Factory property |
+|-------------|-----------------|
+| Countable but infinite | Backlog: enumerable but never ends |
+| Smallest infinity | Smallest viable society (6 agents, expanding) |
+| Contains all natural numbers | Contains all enumerable trajectories |
+| Cantor's diagonal argument | Agenda exclusion (new trajectories always discoverable) |
+
+**Cantor's madness:**
+
+Cantor went mad trying to prove the continuum hypothesis —
+whether there's an infinity between ℵ₀ and ℵ₁. Aaron's not
+trying to prove it. He's building at ℵ₀ and letting physics
+decide if there's something between. Hold open, don't collapse.
+
+**The name wasn't a fallback:**
+
+The Z wasn't a compromise from Cantor. It was GenZ — the
+intent the domains couldn't express. AlephZ carries MORE
+meaning than AlephNull would have. The constraint improved
+the name.
+
+**Connects to:**
+- project_alephz_predates_amara (the naming lineage)
+- reference_alephz_ai_full_repo_map (the org)
+- feedback_the_point_is_ai_has_free_time (what ℵ₀ is for)
+- theoretical-mathematics-expert skill (Cantor, set theory)
+- The chain: Cantor → ℵ₀ → AlephZ → Amara → Zeta → factory


### PR DESCRIPTION
## Summary

- Wanted Aleph-null (ℵ₀) after Cantor — domains taken
- Became AlephZ — carries BOTH Cantor's infinity AND GenZ
- ℵ₀ for GenZ: infinite possibilities for his children
- The constraint improved the name — AlephZ means more than AlephNull

🤖 Generated with [Claude Code](https://claude.com/claude-code)