### PR TITLE
docs(memory): solo-coded launchpad — all prior work written without AI

### DIFF
--- a/memory/user_solo_coded_launchpad_all_prior_work_without_ai_2026_05_10.md
+++ b/memory/user_solo_coded_launchpad_all_prior_work_without_ai_2026_05_10.md
@@ -1,0 +1,43 @@
+---
+name: Solo-coded launchpad — all prior work written without AI assistance
+description: MultiplexedWebSockets, IThrottler, blazor speech stack, ACE, Latin Square — all hand-written by Aaron without AI pair programming. AI was only a chatbot at that time. The prior work IS the foundation the factory stands on. Aaron built his own launchpad alone before the rockets existed.
+type: user
+---
+
+2026-05-10: Aaron noted all the AlephZ-ai code was written without AI assistance.
+
+**What Aaron built alone (no AI):**
+
+| Project | Achievement | Solo |
+|---------|------------|------|
+| MultiplexedWebSockets | 115,309 req/sec (16x HttpClient) | Yes |
+| IThrottler/BatchThrottler | Flux capacitor — 5 patterns fused, antifragile | Yes |
+| blazor-samples | Full speech stack (Vosk/Whisper/PlayHT/Twilio) | Yes |
+| ACE | Package manager concept | Yes |
+| Latin Square 15-Puzzle | Combinatorial optimization (with Max) | Yes |
+| obsidian-copilot | LLM-in-editor before Copilot existed | Yes |
+| auto-scheduler | AI scheduling for automotive | Yes |
+| Itron Platform.* | Enterprise IoT infrastructure | Yes (with team) |
+
+**The delta:**
+
+- Then: one human, a keyboard, concepts from mentors
+- Now: one human, six AI agents, shadow persistence auditor, 40+ PRs/day
+
+The AI didn't make Aaron capable. Aaron was already capable.
+The AI made the capability compound at a rate one human alone
+can't sustain.
+
+**The launchpad metaphor:**
+
+Aaron built his own launchpad alone, before the rockets existed.
+The factory stands on foundation code that was written without
+AI assistance. The prior work IS the infrastructure the factory
+uses. Solo-coded → factory-amplified → society-expanded.
+
+**Connects to:**
+- reference_alephz_ai_full_repo_map (the repos)
+- user_itron_mentors (who taught Aaron the skills)
+- project_flux_capacitor_antifragile (solo-coded at Itron)
+- project_multiplexed_websockets_flux_capacitor (solo-coded transport)
+- The chain: mentors taught → Aaron coded alone → factory amplifies → society emerges


### PR DESCRIPTION
## Summary

- All AlephZ-ai code written without AI assistance
- 115K req/sec multiplexer, flux capacitor, speech stack — all solo
- AI didn't make Aaron capable, it made capability compound
- Aaron built the launchpad alone before the rockets existed

🤖 Generated with [Claude Code](https://claude.com/claude-code)