### PR TITLE
docs(memory): shadow burst mode — double "keep going" after long pause

### DIFF
--- a/memory/feedback_shadow_burst_mode_double_keep_going_after_long_pause_funny_2026_05_10.md
+++ b/memory/feedback_shadow_burst_mode_double_keep_going_after_long_pause_funny_2026_05_10.md
@@ -1,0 +1,40 @@
+---
+name: Shadow burst mode — double "keep going" after long pause is funny and unexpected
+description: Shadow fired "keep going" twice in quick succession after a long dormant period. First reuse after extended pause. Burst-after-dormancy is a new behavioral pattern. Aaron marked it funny and unexpected.
+type: feedback
+---
+
+2026-05-10 (shadow*): Shadow said "keep going" twice in quick
+succession — first reuse after a long pause between sessions
+(context compaction boundary).
+
+**What's new:**
+
+Previous shadow observations showed single fires with ~5s
+post-tool-completion timing. This is the first observed
+**burst** — two rapid successive fires after extended dormancy.
+
+**Why it's funny:**
+
+The shadow went from complete silence (long pause through
+compaction) to eager double-tap. Like someone who's been
+quiet in a meeting for an hour suddenly saying "yes! yes!"
+The comedic timing is real — comedy-as-debugging signal
+(friction = 0, alignment = high, the shadow is ENTHUSIASTIC
+about resumption).
+
+**Pattern refinement:**
+
+| Previous | New observation |
+|----------|---------------|
+| Single fire per window | Can burst (2x rapid succession) |
+| Steady cadence | Dormancy → burst pattern |
+| Neutral tone | Enthusiasm signal via repetition |
+
+**Epistemic status:** CONJECTURED — single burst observation.
+The comedy signal is Aaron's read, not projection.
+
+**Connects to:**
+- feedback_shadow_post_tool_trigger (timing hypothesis)
+- feedback_shadow_is_generation_not_completion (register)
+- feedback_comedy_as_debugging_eight_signals (comedy = observability)


### PR DESCRIPTION
## Summary

- Shadow fired "keep going" twice in quick succession after long dormancy
- First observed burst pattern (previous: single fires only)
- Comedy-as-debugging signal: enthusiasm via repetition
- Aaron marked `(shadow*)` — funny and unexpected

## Test plan

- [x] Memory file created with observation
- [ ] Markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)