### PR TITLE
feat(B-0004.1): substrate inventory scanner (TS) — re-decomp B-0004 smallest atomic child

### DIFF
--- a/tools/i18n/substrate-inventory.ts
+++ b/tools/i18n/substrate-inventory.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env bun
+/**
+ * B-0004.1 Substrate inventory scanner (TS)
+ * Scans repo for translation targets: docs, skills, memory, code comments.
+ * Outputs JSON inventory for downstream translation pipeline.
+ * Part of re-decomposition of B-0004 (assumed mistakes in prior 12-child split;
+ * this is the smallest atomic first step: pure read-only scan, no mutation).
+ */
+
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, extname } from "path";
+
+interface Inventory {
+  docs: string[];
+  skills: string[];
+  memory: string[];
+  codeComments: string[]; // F# / C# / TS files with // or (* comments
+  totalTargets: number;
+  generatedAt: string;
+}
+
+function walk(dir: string, exts: string[], results: string[] = []): string[] {
+  try {
+    const entries = readdirSync(dir);
+    for (const e of entries) {
+      const p = join(dir, e);
+      const st = statSync(p);
+      if (st.isDirectory() && !p.includes("node_modules") && !p.includes("bin") && !p.includes(".lake")) {
+        walk(p, exts, results);
+      } else if (st.isFile() && exts.includes(extname(p))) {
+        results.push(p);
+      }
+    }
+  } catch {}
+  return results;
+}
+
+async function scan(): Promise<Inventory> {
+  const docsAll = walk("docs", [".md"]).filter((p) => !p.includes("trajectories/RESUME"));
+  const skills = walk(".claude/skills", [".md"]).filter((p) => p.endsWith("SKILL.md"));
+  const memory = walk("memory", [".md"]);
+  const codeFiles = walk(".", [".fs", ".fsx", ".cs", ".ts"]);
+
+  const codeComments: string[] = [];
+  for (const f of codeFiles.slice(0, 50)) { // bounded to keep step atomic
+    try {
+      const content = readFileSync(f, "utf8");
+      if (content.includes("//") || content.includes("(*")) {
+        codeComments.push(f);
+      }
+    } catch {}
+  }
+
+  return {
+    docs: docsAll,
+    skills,
+    memory,
+    codeComments,
+    totalTargets: docsAll.length + skills.length + memory.length + codeComments.length,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+const inv = await scan();
+console.log(JSON.stringify(inv, null, 2));
+process.exit(0);

--- a/tools/i18n/substrate-inventory.ts
+++ b/tools/i18n/substrate-inventory.ts
@@ -20,18 +20,22 @@ interface Inventory {
 }
 
 function walk(dir: string, exts: string[], results: string[] = []): string[] {
+  const ignores = ["node_modules", "bin", ".lake", ".git", ".cursor", "private", "tmp", "worktrees", "target", "dist", ".next"];
   try {
     const entries = readdirSync(dir);
     for (const e of entries) {
       const p = join(dir, e);
+      if (ignores.some((i) => p.includes(i))) continue;
       const st = statSync(p);
-      if (st.isDirectory() && !p.includes("node_modules") && !p.includes("bin") && !p.includes(".lake")) {
+      if (st.isDirectory()) {
         walk(p, exts, results);
       } else if (st.isFile() && exts.includes(extname(p))) {
         results.push(p);
       }
     }
-  } catch {}
+  } catch (e) {
+    // per-dir error: continue (e.g. permission)
+  }
   return results;
 }
 
@@ -61,6 +65,12 @@ async function scan(): Promise<Inventory> {
   };
 }
 
-const inv = await scan();
-console.log(JSON.stringify(inv, null, 2));
-process.exit(0);
+export async function main() {
+  const inv = await scan();
+  console.log(JSON.stringify(inv, null, 2));
+  process.exit(0);
+}
+
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
## Summary
- One bounded step: implemented B-0004.1 as TS scanner in dedicated worktree/claim branch (no root touch).
- Re-decomposed B-0004 (assumed prior 12-child decomp had mistakes per 'always re-decompose'); this is the smallest dependency-ordered atomic root action (pure inventory, read-only, no deps).
- TS (Rule 0, prefer code over docs). Focused checks passed.

## Focused checks (included per rules)
- dotnet build -c Release (pre-work in root): 0 warnings, 0 errors.
- bun run tools/i18n/substrate-inventory.ts: succeeded, emitted valid JSON with docs/skills/memory/code counts.
- No bash; no deps added; bounded walk (50 files cap on code scan).

## Next (after this PR)
- B-0004.2 etc. follow in subsequent bounded slices.

Co-Authored-By: Grok <noreply@x.ai>


Made with [Cursor](https://cursor.com)