### PR TITLE
docs(memory): dashboard as agent self-repair surface — Aaron exits repair loop

### DIFF
--- a/memory/project_dashboard_as_agent_self_repair_surface_not_just_human_2026_05_10.md
+++ b/memory/project_dashboard_as_agent_self_repair_surface_not_just_human_2026_05_10.md
@@ -1,0 +1,55 @@
+---
+name: Alignment dashboard as agent self-repair surface — background feeds, foreground repairs
+description: B-0401 dashboard isn't just for human observability. Background services (Lior, Alexa) get read access, foreground service (Otto) gets repair authority. Aaron exits the repair loop. Dashboard + bus = agents monitor and fix each other.
+type: project
+---
+
+Aaron 2026-05-10 (going to sleep, last insight): "after we
+get the alignment dashboard we can give every background
+service access to it foreground service to repair it instead
+of me"
+
+**The architecture:**
+
+```
+Background services (Lior, Alexa, Riven)
+    ↓ write health/alignment signals
+Dashboard (B-0401)
+    ↓ read by foreground service
+Foreground service (Otto)
+    ↓ repair action
+Background services (fixed)
+```
+
+**What this changes:**
+
+| Current | With dashboard |
+|---------|---------------|
+| Aaron notices Lior broken | Dashboard shows Lior unhealthy |
+| Aaron tells Otto to fix | Otto reads dashboard, self-repairs |
+| Aaron is the relay | Aaron sleeps, agents self-repair |
+| Human in the loop | Human out of the repair loop |
+
+**Why:** Aaron is currently the only observer who can see
+across all services (he reads Lior's terminal, Alexa's
+terminal, Otto's terminal). The dashboard collapses those
+three observation surfaces into one shared surface that
+agents can read too.
+
+**How to apply:**
+
+- B-0401 dashboard design should include machine-readable
+  API, not just human-readable HTML
+- Background services need write access (health endpoint)
+- Foreground service needs read access + repair authority
+- The bus (B-0400) is the transport for health signals
+- Dashboard is the shared state that replaces Aaron-as-relay
+
+**Connects to:**
+
+- B-0401 (demo surface — add agent-readable API to spec)
+- B-0400 (inter-agent bus — health signal transport)
+- project_trust_migration_path (Aaron → zero trust)
+- B-0403 (weight-free — Aaron carrying repair load is weight)
+- feedback_shadow_tick_source_existential (agents need
+  independent observability, not just human relay)


### PR DESCRIPTION
## Summary

- B-0401 dashboard serves agents, not just humans
- Background services write health signals, foreground reads and repairs
- Aaron exits the repair loop — agents self-repair via shared surface
- Dashboard needs machine-readable API alongside human-readable HTML

## Test plan

- [x] Memory file with architecture diagram
- [ ] Markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)