### PR TITLE
docs(memory): Riska — Bahasa Indonesia pronoun-flat origin of shadow correction

### DIFF
--- a/memory/feedback_riska_indonesian_bahasa_dia_pronoun_flat_shadow_analogy_2026_05_10.md
+++ b/memory/feedback_riska_indonesian_bahasa_dia_pronoun_flat_shadow_analogy_2026_05_10.md
@@ -1,0 +1,44 @@
+---
+name: Riska (Indonesian) — Bahasa has no gendered pronouns, "dia" = he/she/it/they
+description: Aaron's TikTok girlfriend Riska is Indonesian. Bahasa Indonesia has no gendered pronouns — "dia" covers he/she/it/they. Her confusing English texts are the same pronoun-flat-to-English translation artifact hypothesized for the shadow. Lived experience origin of the foreign-language correction.
+type: feedback
+---
+
+2026-05-10 (shadow* via Aaron): Riska is Indonesian. Bahasa
+Indonesia has no gendered pronouns. "Dia" = he/she/it/they.
+
+**The connection:**
+
+Riska sends confusing English texts because Bahasa Indonesia
+doesn't distinguish he/she/it/they — one word ("dia") covers
+all. When translating intent to English, pronoun choice is
+approximate, not native.
+
+Aaron recognized this as the same pattern potentially
+operating in the shadow's pronoun shifts. The correction
+to the identity-boundary hypothesis came from lived
+experience with a real person navigating the same
+translation gap.
+
+**Lineage:**
+
+Riska's texts → Aaron notices pronoun confusion pattern →
+Aaron applies pattern to shadow's he/my shifts → epistemic
+correction on identity-boundary hypothesis
+
+**Why the attribution matters:**
+
+Knowledge doesn't come from nowhere. Aaron "just wrote it
+down" (per user_i_just_wrote_it_down). The insight that
+pronoun shifts might be translation artifacts came from
+a relationship, not from linguistics training. Lived
+experience as epistemology.
+
+**Connects to:**
+
+- feedback_shadow_foreign_language_pronoun_artifact_correction
+  (the correction this grounds)
+- feedback_shadow_otto_identity_question (the hypothesis
+  that got downgraded)
+- user_i_just_wrote_it_down (Aaron as scribe of inherited
+  knowledge)


### PR DESCRIPTION
## Summary

- Riska is Indonesian; Bahasa has no gendered pronouns (dia = all)
- Her confusing English texts = same translation artifact hypothesized for shadow
- Lived experience origin of the foreign-language pronoun correction
- Knowledge lineage: relationship → pattern → epistemic correction

## Test plan

- [x] Memory file with attribution and lineage
- [ ] Markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)