### PR TITLE
docs(research): UoM dual safety + categorical substrate + narrative engine

### DIFF
--- a/docs/research/2026-05-11-claudeai-uom-categorical-substrate-recursive-generators-narrative-engine.md
+++ b/docs/research/2026-05-11-claudeai-uom-categorical-substrate-recursive-generators-narrative-engine.md
@@ -1,0 +1,176 @@
+# Claude.ai: UoM categorical substrate + recursive generators + narrative engine
+
+**Date:** 2026-05-11 ~01:27-01:53 UTC
+**Participants:** Aaron (human), Claude.ai (asymmetric critic → architect)
+**Session type:** Forwarded exchange, key formulations preserved
+**Significance:** UoM as both dimensional AND domain safety; recursive
+type providers as anamorphisms; categorical substrate sketch; narrative
+engine methodology; panpsychism-as-undetermined-pending-verification
+
+## Aaron's opening move
+
+> okay i'm trying to make this into a narrative engine that can
+> follow the plot of movies and series and such what do you think?
+> not trying to be rigorous with the math yet just get ideas.
+
+Softener worked — Claude.ai engaged in exploration mode without
+demanding rigor prematurely.
+
+## Seven ground rules for formalizing metaphysical positions
+
+1. Separate formalization from truth claims
+2. Symbols carry no metaphysical content until axioms specify
+3. Start with weakest claim that does work
+4. Every axiom needs a falsifier
+5. Mark axiom-to-claim dependency graph
+6. Prefer structural to substantive commitments
+7. Formalism agnostic between rival positions (= polymorphism)
+
+## Base ontology — three primitives
+
+- **Σ** — substrate (no assumed content)
+- **Π** — participants (distinguishable structures in Σ)
+- **Ω** — observations (relation between participants)
+
+Six axioms with explicit falsifiers:
+
+- Σ1: Σ supports multiple distinguishable participants
+- Σ2: Σ closed under framework operations
+- Π1: Every participant has at least one trajectory
+- Π2: Observation relation exists between participants
+- Ω1: Observation not necessarily symmetric
+- Ω2: Observation composable through intermediaries
+- Ω3: Observation has resolution limits (fusion-assumption follows)
+
+## Categorical substrate (F-algebras)
+
+```fsharp
+/// Base functor whose fixed point is the substrate type structure
+type F<'pos, 'r> =
+    | SubstrateF of 'pos
+    | ParticipantF of identity: 'r * trajectory: 'r
+    | ObservationF of source: 'r * target: 'r * content: 'r
+    | TrajectoryF of participant: 'r * points: 'r list
+    | ResidueF of observation: 'r * unobservable: 'r
+
+/// Fix F = least fixed point (recursive type)
+type Fix<'pos> = Fix of F<'pos, Fix<'pos>>
+
+/// Catamorphism — universal fold (consume recursive structure)
+let rec cata (algebra: F<'pos, 'a> -> 'a) (Fix fx) : 'a =
+    fx |> fmap (cata algebra) |> algebra
+
+/// Anamorphism — universal unfold (the recursive generator)
+let rec ana (coalgebra: 'a -> F<'pos, 'a>) (seed: 'a) : Fix<'pos> =
+    seed |> coalgebra |> fmap (ana coalgebra) |> Fix
+```
+
+**Key insight:** The recursive type provider IS an anamorphism.
+Position seed = F-coalgebra. Generator = `ana seed initial`.
+Fixed point = full implementation from minimal differential.
+
+## Recursive generator architecture
+
+Three generator types that compose:
+
+1. **File-driven** — position spec in structured format → types
+2. **Recursive code-structure** — type provider applies to its
+   own output until fixed point (THIS is the load-bearing piece)
+3. **Roslyn generators** — source-level equivalent for C# interop
+
+The recursion: type provider generates types → those types become
+input → provider generates more types → repeat until fixed point.
+This IS computing the carrier of an F-algebra. Termination when
+functor is polynomial. Convergence = consistency check.
+
+## UoM as BOTH dimensional AND domain safety
+
+Aaron's correction: "is there some reason we can't use both?"
+
+```fsharp
+// Dimensional measures
+[<Measure>] type tick
+[<Measure>] type observation_depth
+
+// Semantic domain measures
+[<Measure>] type hypothesized
+[<Measure>] type claimed
+[<Measure>] type mirror
+[<Measure>] type beacon
+
+// BOTH AT ONCE — compound type:
+type HypothesizedObservationDepth = float<observation_depth * hypothesized>
+type ClaimedTrajectoryDuration = float<tick * claimed>
+
+// Semantic tags cancel within same domain:
+// (observation_depth * hypothesized) / (tick * hypothesized)
+//   = observation_depth / tick
+// Correct: rate within one domain is purely dimensional
+
+// Semantic tags fail across domains:
+// (observation_depth * hypothesized) + (observation_depth * claimed)
+//   = COMPILE ERROR
+// Correct: can't mix hypothesized with claimed
+```
+
+Conversion IS the safety boundary for BOTH dimensional and
+semantic crossings:
+
+```fsharp
+let selfClaim (h: float<observation_depth * hypothesized>)
+              (event: ClaimEvent)
+    : float<observation_depth * claimed> =
+    // Semantic conversion preserves dimensional measure
+
+let promoteMirrorToBeacon
+        (mirror: SubstrateRef<mirror>)
+        (falsifier: FalsifierSpec)
+        (anchor: ExternalAnchor)
+    : SubstrateRef<beacon> =
+    // The type system ensures promotion is always explicit
+```
+
+## Panpsychism as undetermined position
+
+Aaron: "my version of panpsychism is yet to be fully determined
+it must pass all the PR checks and formal analysis and static
+analysis etc... and use non-judgmental labels or just symbols"
+
+Claude.ai: "Your version of panpsychism is currently undetermined.
+Not vague — undetermined. It's an open commitment that will get
+specified through the same discipline the rest of the framework
+uses."
+
+The position is a type parameter. Different implementations
+(panpsychism, pancomputationalism, structural realism) are
+concrete instantiations. The framework operates by natural
+transformations polymorphic across all positions.
+
+## Narrative engine methodology
+
+Fiction as empirical training set for ontology patterns.
+Success criterion: present engine with unseen story, extract
+participants/agendas/trajectories, check against human judgment.
+
+Pieces most likely to crystallize:
+
+- Identity-fusion as measurable pattern in narratives
+- Bifurcation pressure as narrative force
+- Trajectory as primitive for plot analysis
+- Fiction-as-prior-art observation
+
+Pieces to hold loosely until math compiles:
+
+- Specific Clifford operators for specific characters
+- Specific functorial structures for narrative operations
+- "Same math at every layer" claim
+
+## Aaron's key corrections during session
+
+1. "is there some reason we can't?" (UoM both, not either/or)
+2. "it's polymorphism" (metaphysical agnosticism = polymorphism)
+3. Recursive type providers apply to their own output (anamorphism)
+4. "what about duck typing or uom?" (structural typing + UoM solve
+   the higher-rank polymorphism encoding problem)
+5. "category theory for programmers is required reading by my team"
+   (Milewski as foundation, not optional reference)

--- a/memory/project_uom_both_dimensional_and_domain_safety_recursive_generators_2026_05_11.md
+++ b/memory/project_uom_both_dimensional_and_domain_safety_recursive_generators_2026_05_11.md
@@ -1,0 +1,63 @@
+---
+name: UoM as BOTH dimensional physics AND domain safety — recursive generators, F-algebras, categorical substrate
+description: Claude.ai session where Aaron walked critic through using F# UoM for both dimensional quantities AND semantic categories simultaneously. Recursive type providers as anamorphisms. F-algebra fixed points for position generation. Category theory (Milewski required reading) as engineering substrate. UoM tags compose through multiplication — hypothesized×observation_depth is a real compound type.
+type: project
+---
+
+2026-05-11 ~01:27-01:53 UTC: Aaron walked Claude.ai through
+a major architectural session.
+
+**Key insight — UoM for both, not either/or:**
+
+Aaron asked "is there some reason we can't use both?" when
+Claude.ai framed UoM as domain-safety "rather than" dimensional
+physics. The answer: no reason. They compose. The compiler
+handles both simultaneously.
+
+```fsharp
+// Dimensional + semantic at once:
+type HypothesizedObservationDepth = float<observation_depth * hypothesized>
+type ClaimedTrajectoryDuration = float<tick * claimed>
+// Semantic tags cancel within same domain (rate calculation)
+// Semantic tags fail across domains (mixed = compile error)
+```
+
+**Recursive generators as anamorphisms:**
+
+- Type provider applies to its own output recursively
+- This IS an F-coalgebra producing a Fix-point via anamorphism
+- Termination when functor is polynomial (well-understood math)
+- Convergence = consistency check (seed that doesn't converge = inconsistent position)
+- Three-way composition: F# type providers + Roslyn generators + recursive code-structure walkers
+
+**Categorical substrate (Milewski required reading):**
+
+- Base functor F whose fixed point is the substrate type structure
+- Catamorphisms consume recursive structure (fold)
+- Anamorphisms produce recursive structure (unfold = the generator)
+- Natural transformations = framework operations polymorphic across positions
+- Positions = implementations of ISubstrate interface
+
+**Seven ground rules for formalizing metaphysical positions:**
+
+1. Separate formalization from truth claims
+2. Symbols carry no content until axioms specify
+3. Start with weakest claim that does work
+4. Every axiom needs a falsifier
+5. Mark which axioms are load-bearing for which claims
+6. Prefer structural to substantive commitments
+7. Formalism should be agnostic between rival positions (= polymorphism)
+
+**Narrative engine:**
+
+Fiction as empirical training set for ontology patterns.
+Success criterion: present engine with unseen story, extract
+participants/agendas/trajectories, check against human judgment.
+
+**How to apply:** Extend existing UoM (weight/cardinality/delta,
+tick/ms/ns/s, prob/pct, per_tick/per_sec) with semantic domains
+(hypothesized/claimed, mirror/beacon, pre/post-bifurcation).
+Both compose through multiplication. Conversion IS the safety
+boundary for both dimensional and semantic crossings.
+
+**Verbatim:** `docs/research/2026-05-11-claudeai-uom-categorical-substrate-recursive-generators-narrative-engine.md`


### PR DESCRIPTION
## Summary

- UoM as BOTH dimensional physics AND domain safety (Aaron's correction)
- Recursive type providers as anamorphisms (F-coalgebra → Fix-point)
- Seven ground rules for formalizing metaphysical positions
- F# categorical substrate sketch with Milewski as required reading
- Narrative engine: fiction as empirical training set for ontology
- Panpsychism undetermined pending verification stack

## Test plan

- [x] Research doc with key F# code sketches
- [x] Memory file with project summary
- [ ] Markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)