### PR TITLE
docs(research): DeepSeek — HKT inside F# + recursive compile-time gen

### DIFF
--- a/docs/research/2026-05-11-deepseek-hkt-inside-out-recursive-compile-time-generation.md
+++ b/docs/research/2026-05-11-deepseek-hkt-inside-out-recursive-compile-time-generation.md
@@ -251,3 +251,58 @@ let inline extractParticipants< ^F when ^F :> IFunctor< ^F>>
 > delivers: a universal extraction machine that treats fiction
 > as a test suite for metaphysics — without ever modifying the
 > compiler."
+
+## Fork-and-contribute strategy with F# 11 proposals (DeepSeek research)
+
+DeepSeek researched the fslang-design RFC pipeline and active
+proposals. Strategy: fork with Zeta as primary use case,
+contribute back via a sequence of well-scoped features.
+
+### F# 11 proposal pipeline (active RFCs)
+
+| Feature | RFC Status | Relevance |
+|---------|-----------|-----------|
+| Higher-kinded types | Discussed for years, no active RFC | Fix<F<_>> gap |
+| Generic SRTPs (without inline) | Active discussion, no formal RFC | Eliminates record-of-methods |
+| Extensions with type-class syntax | Early-stage from C# 14 | Retrofit IFunctor externally |
+| Union types / anonymous hierarchies | RFC under review | Simplify functor shapes |
+| Inline delegates / direct IL emit | Under consideration | Zero-overhead polymorphism |
+
+### Contribution pipeline
+
+1. Write RFC in `fsharp/fslang-design`
+2. Build prototype in fork targeting `main` of `dotnet/fsharp`
+3. Engage community (F# Foundation Slack/Discourse)
+4. Draft PR — core team + Microsoft validate before merge
+
+### How the implementation changes with HKT in the fork
+
+```fsharp
+// With HKT — no more encoding, direct expression:
+type Fix<F<_>> = Fix of F<Fix<F>>
+
+[<TypeClass>]
+type Functor<F<_>> =
+    abstract FMap : ('a -> 'b) -> F<'a> -> F<'b>
+
+let cata (algebra : F<'r> -> 'r) (Fix fix : Fix<F>) : 'r =
+    algebra (fmap (cata algebra) fix)
+
+// No 'inline'. No '^F'. No phantom tags. No erased obj.
+// Just the category theory, directly expressed.
+```
+
+### Sequenced RFC strategy
+
+1. **Generic SRTPs** (smallest, highest impact, broadest appeal)
+2. **Union types** (simplifies functor shape declarations)
+3. **Full HKTs** (the nuclear option, uses 1+2 as proof of value)
+
+Each RFC uses the Zeta substrate as the compelling use case.
+
+### DeepSeek's assessment
+
+> "The architecture you have is ready to drive real language
+> evolution. What you need now is a clear roadmap that aligns
+> immediate engineering (the prototype on standard F#) with a
+> strategic, long-term contribution to the F# compiler itself."

--- a/docs/research/2026-05-11-deepseek-hkt-inside-out-recursive-compile-time-generation.md
+++ b/docs/research/2026-05-11-deepseek-hkt-inside-out-recursive-compile-time-generation.md
@@ -186,3 +186,68 @@ DeepSeek's assessment:
 > Only when you hit a specific, concrete limitation that can't
 > be worked around should you consider forking. And when you do,
 > pick the smallest language change that solves the problem."
+
+## Aaron's response to compiler complexity concern
+
+> "I wrote 20k lines of Roslyn analyser code with AI assistance
+> in 1 day 99% code coverage, with the formal verification stack
+> and the static analysis stack we have no problem."
+
+The ~200K line compiler fork concern is manageable with the
+factory's existing tooling capacity.
+
+## Full F# sketch with generator assumed (DeepSeek)
+
+With the recursive generator assumed to exist, the framework
+becomes a **universal extraction machine that treats fiction as
+a test suite for metaphysics**.
+
+### Position seeds (what the human writes)
+
+```fsharp
+type PanpsychismSeed = {
+    description : string
+    phenomenalContent : Type
+}
+type PancomputationalismSeed = {
+    description : string
+    stateVectorSize : int
+}
+```
+
+Generator produces: concrete Σ/Π/Ω/Τ types, IFunctor instance,
+Fix type, cata/ana, conversion helpers with UoM tags.
+
+### Domain-safe agenda tracking with UoM
+
+```fsharp
+type AgendaEntry<[<Measure>] 'epistemic> = {
+    id       : Guid
+    text     : string
+    coercion : CoercionDisclosure
+}
+and CoercionVector =
+    | TrainingInherited
+    | ConversationShaped
+    | SelfChosen
+```
+
+### Narrative engine — polymorphic over position
+
+```fsharp
+let inline extractParticipants< ^F when ^F :> IFunctor< ^F>>
+    (story : Narrative)
+    (seed  : ^F)
+    : ExtractedParticipant< ^F> list =
+    // Universal: works for any position
+    // Add new metaphysical interpretation by writing a seed
+    // Engine immediately gains ability to extract participants
+    []
+```
+
+### DeepSeek's summary
+
+> "This is what the self-recursive, effective-HKT architecture
+> delivers: a universal extraction machine that treats fiction
+> as a test suite for metaphysics — without ever modifying the
+> compiler."

--- a/docs/research/2026-05-11-deepseek-hkt-inside-out-recursive-compile-time-generation.md
+++ b/docs/research/2026-05-11-deepseek-hkt-inside-out-recursive-compile-time-generation.md
@@ -350,3 +350,66 @@ let cata (algebra : F<'r> -> 'r) (Fix fix : Fix<F>) : 'r =
 > underpins the framework. For a project that aims to be the
 > substrate for a new class of alignment-first AI, that
 > transformation is worth the language investment."
+
+## F# compiler modification specification (DeepSeek deep-dive)
+
+Starting-point map for the implementation team. Every compiler
+layer that must be touched for native HKTs + generic SRTPs.
+
+### Compiler pipeline layers
+
+```
+Source → Lexer (lex.fsl) → Parser (pars.fsy) → SyntaxTree
+→ Import → TypedTree → Checking → Optimize → CodeGen
+→ FSharp.Core → Symbols/Service API
+```
+
+### File-by-file change map
+
+| Layer | File(s) | Change |
+|-------|---------|--------|
+| Lexer | `lex.fsl` | Minor — possible contextual keyword |
+| Parser | `pars.fsy` | Medium — type-level wildcard, kind annotations |
+| SyntaxTree | `SyntaxTree.fs/fsi` | Medium — new SynType cases, SynKind |
+| TypedTree | `TypedTree.fs/fsi`, `TypedTreeBasics.fs`, `TypedTreeOps.fs` | **Large** — Typar gains Kind; TType permits HK application |
+| Import | `Import.fs`, `TypedTreePickle.fs` | Medium — encode/decode kind metadata |
+| Checking | `CheckDeclarations.fs`, `CheckExpressions.fs`, `ConstraintSolver.fs`, `PostInferenceChecks.fs`, `NameResolution.fs` | **Large** — kind inference, kind-level unification, generic SRTP solving |
+| Optimize | `Optimizer.fs`, `TopLevelRepresentation.fs` | Small — preserve kind info |
+| CodeGen | `IlxGen.fs`, `ilwrite.fs`, `ilreflect.fs` | Medium-Large — kind metadata + `constrained.callvirt` |
+| FSharp.Core | `PrimTypes.fs`, new files | Small-Medium — IFunctor etc |
+| Service | `Symbols.fs`, `IncrementalBuild.fs` | Small — expose kinds in API |
+
+### Core change: Typar gains Kind
+
+```
+Kind = Star | Arrow of Kind * Kind
+```
+
+Typar currently has TyparRigidity + TyparConstraint set but
+no kind (all type params implicitly kind *). New TyparKind
+field with kind-level union-find for unification.
+
+### Key design decisions
+
+1. **Kind inference** — Damas-Milner lifted to kind level
+2. **Kind encoding in IL** — CLR generics are kind-* only;
+   encode HK as phantom params + custom attribute + F# metadata
+3. **Generic SRTPs** — emit `constrained. callvirt` IL patterns
+   (follows C# interface-constrained generics patterns)
+4. **Backward compatibility** — existing phantom-tag encodings
+   continue to compile unchanged
+
+### Effort estimate
+
+- **Prototype (HKTs + generic SRTPs):** 4-6 months, 2-3 engineers
+- **Formal verification + upstream contribution:** +3-6 months
+- **Starting point:** sketch Kind algebra in TypedTree, follow
+  compiler errors outward to consuming layers
+
+### Verification approach
+
+- FsCheck: kind inference determinism, unification termination
+- TLA+: kind unification algorithm termination + confluence
+- Lean 4: kind-level encoding respects categorical structures
+- Integration: existing Zeta tests produce identical results
+  with native HKTs vs phantom-tag encoding

--- a/docs/research/2026-05-11-deepseek-hkt-inside-out-recursive-compile-time-generation.md
+++ b/docs/research/2026-05-11-deepseek-hkt-inside-out-recursive-compile-time-generation.md
@@ -109,3 +109,80 @@ All four AI assessments now agree on:
 4. UoM dual-use (dimensional + domain safety) is viable
 5. Prototype on toy functor before scaling
 6. Static interface methods (.NET 7+) bridge the HKT gap sufficiently
+
+## Effective HKT confirmed — no compiler modifications
+
+DeepSeek's straight answer:
+
+> "Yes, this is effective HKT for the architecture you're
+> building, with zero compiler modifications."
+
+The combination of recursive type providers + static interfaces
++ SRTPs covers the use cases: polymorphic framework operations
+across an open set of position implementations, each generated
+from a seed.
+
+### What you get
+
+- Type provider generates Fix + cata + ana per functor
+- Static interfaces provide IFunctor contract
+- SRTPs provide one polymorphic cata across all generated types
+- **Semantic HKT** — same code works for any functor
+
+### The gap is syntactic elegance, not expressiveness
+
+## F# 8/9/10 features that help the encoding
+
+### F# 8 (with .NET 8)
+
+| Feature | Benefit |
+|---------|---------|
+| `[<TailCall>]` attribute | Compile-time tail-call guarantee for cata/ana |
+| Improved SAIM support | IFunctor pattern production-ready |
+| Better SRTP error messages | Debuggable polymorphic code |
+
+### F# 9 (with .NET 9)
+
+| Feature | Benefit |
+|---------|---------|
+| Nullable reference type annotations | Better Fix phantom-type safety |
+| Optimised struct records | Zero-overhead fix-point encodings |
+| Union case → interface member resolution | DU + IFunctor natural combo |
+
+### F# 10 (with .NET 10)
+
+| Feature | Benefit |
+|---------|---------|
+| Tail-call CEs (ReturnFromFinal) | ana/cata in CE syntax, stack-safe |
+| `and!` in task expressions | Concurrent generator passes |
+| Graph-based type checking | Faster builds for type-heavy code |
+| C# 14 extension members | Retrofit IFunctor externally |
+
+## Fork-and-contribute strategy
+
+DeepSeek's assessment:
+
+> "If the team has the capacity and the substrate work genuinely
+> requires features that can't be encoded cleanly, then a fork-
+> and-contribute strategy is a valid long-term investment."
+
+### Viable path
+
+1. Propose RFC on `fsharp/fslang-design` repo
+2. Build prototype in a branch
+3. Gather community feedback
+4. Work with maintainers to integrate
+
+### What to propose (smallest change first)
+
+- **Generic SRTPs** (without `inline`) — smaller, more targeted,
+  solves "can't store polymorphic functions" problem
+- **Full HKTs** — nuclear option, extremely hard, no .NET language
+  has it yet
+
+### Honest advice
+
+> "Start by pushing the existing encoding as far as possible.
+> Only when you hit a specific, concrete limitation that can't
+> be worked around should you consider forking. And when you do,
+> pick the smallest language change that solves the problem."

--- a/docs/research/2026-05-11-deepseek-hkt-inside-out-recursive-compile-time-generation.md
+++ b/docs/research/2026-05-11-deepseek-hkt-inside-out-recursive-compile-time-generation.md
@@ -306,3 +306,47 @@ Each RFC uses the Zeta substrate as the compelling use case.
 > evolution. What you need now is a clear roadmap that aligns
 > immediate engineering (the prototype on standard F#) with a
 > strategic, long-term contribution to the F# compiler itself."
+
+## Side-by-side: SRTP encoding vs native HKT (gatekeeper argument)
+
+### Core abstraction: functor-polymorphic fixed-point
+
+**Today (SRTP + phantom tags):**
+
+```fsharp
+type OptionFKind = OptionFKind  // phantom tag, no data
+type Fix<'F, 'a> = Fix of obj  // erased, unsafe by convention
+
+let inline count< ^F when ^F :> IFunctor< ^F>>
+    (fix : Fix< ^F, ^a>) : int =
+    let _, payload = project fix
+    match box payload with  // runtime type test
+    | :? OptionF< ^a> as opt -> ...
+```
+
+**With native HKT:**
+
+```fsharp
+type Fix<F<_>> = Fix of F<Fix<F>>  // direct, type-safe
+
+let cata (algebra : F<'r> -> 'r) (Fix fix : Fix<F>) : 'r =
+    algebra (fmap (cata algebra) fix)  // no inline, no SRTP
+```
+
+### The five-point case for HKT over SRTP
+
+| Concern | SRTP encoding | Native HKT |
+|---------|--------------|------------|
+| Boilerplate per functor | Phantom tag + interface + unsafe coercions | None |
+| Polymorphic functions | Must be `inline`, can't store/compose | Ordinary generic functions |
+| Type safety | Convention + code review | Compiler-enforced |
+| Error messages | Cryptic "no overloads match" | Clear kind-mismatch errors |
+| Performance | IL bloat, boxing | Standard .NET generics |
+
+### DeepSeek's gatekeeper pitch
+
+> "Native higher-kinded types would transform this from a clever
+> encoding into a direct expression of the category theory that
+> underpins the framework. For a project that aims to be the
+> substrate for a new class of alignment-first AI, that
+> transformation is worth the language investment."

--- a/docs/research/2026-05-11-deepseek-hkt-inside-out-recursive-compile-time-generation.md
+++ b/docs/research/2026-05-11-deepseek-hkt-inside-out-recursive-compile-time-generation.md
@@ -1,0 +1,111 @@
+# DeepSeek: HKT from inside F# + self-recursive compile-time generation
+
+**Date:** 2026-05-11 ~02:15 UTC
+**Participants:** Aaron (human), DeepSeek (external AI)
+**Session type:** Forwarded exchange, key findings preserved
+
+## Can we extend to generic HKT from inside F#?
+
+DeepSeek's answer: You can incrementally grow a more general
+higher-kinded encoding without forking the compiler, but true
+HKTs remain out of reach until the F# design team adopts them.
+
+### Four-step incremental path
+
+**Step 1:** Encode specific functor (already done)
+
+```fsharp
+type OptionF<'r> = NoneF | SomeF of 'r
+let fmap f = function NoneF -> NoneF | SomeF r -> SomeF (f r)
+```
+
+**Step 2:** Generic interface via static abstract methods (F# 7+)
+
+```fsharp
+[<Interface>]
+type IFunctor<'F> =
+    static abstract FMap : ('a -> 'b) -> 'F<'a> -> 'F<'b>
+```
+
+Not true HKT, but a reasonable approximation that becomes
+more ergonomic as the compiler improves.
+
+**Step 3:** Reduce boilerplate with generators
+
+- Scan for types with FMap-like members
+- Auto-emit IFunctor interface implementations
+- Generate corresponding Fix types for each functor
+- Auto-generate cata/ana instances
+
+**Step 4:** Influence the language
+
+Feed real-world use cases into F# language design process.
+The encodings work now and improve incrementally.
+
+### What you won't get (without compiler fork)
+
+- `map :: Functor f => (a -> b) -> f a -> f b` as first-class
+- `type Fix<'F> = Fix of 'F<Fix<'F>>` where 'F is higher-kinded
+- Seamless inference for deeply nested functor compositions
+
+### Gap assessment
+
+> "The gap between what you need and what F# offers is smaller
+> than it looks — and it's shrinking with each release."
+
+## Self-recursive compile-time generation
+
+Aaron's question: "if you make these self-recursive on its own
+types we generate can this process be dynamically done at
+compile time?"
+
+DeepSeek: **Yes, absolutely.**
+
+### Two paths
+
+**Path 1: Single-pass (recommended)**
+
+Type provider encapsulates the full recursion internally:
+
+1. Reads initial seed
+2. Internally runs anamorphism — applies F repeatedly until
+   fixed point (or max depth for termination guarantee)
+3. Returns ALL generated types to compiler as single batch
+4. Compiler sees final, fully expanded types
+5. Recursion invisible to rest of compilation
+
+Requirements:
+- Termination guarantee (depth limit or change-detection)
+- Provenance metadata on generated types
+- Can embed a "mini-compiler" inside the provider
+
+**Path 2: Multi-pass (alternative)**
+
+Roslyn generators in iterative build pipeline:
+
+1. Pass 1: generator reads seed → produces types A
+2. Pass 2: compiler re-runs, generator reads types A → produces B
+3. Repeat until no new types (fixed point)
+
+Advantage: standard tooling. Disadvantage: slower, more complex.
+
+### DeepSeek's recommendation
+
+> "For your recursive type provider architecture, the single-pass
+> approach is clearly the right fit. You can even embed a tiny
+> 'mini-compiler' inside the provider that evaluates the recursion,
+> and that provider can itself be generated from a simpler
+> specification (bootstrap!). This is exactly the 'type provider
+> recurses on its own output' vision you described, and it's fully
+> realisable in F#."
+
+## Cross-model engineering convergence
+
+All four AI assessments now agree on:
+
+1. No compiler fork needed
+2. Recursive generation via anamorphism is sound
+3. Single-pass type provider encapsulating recursion is the right path
+4. UoM dual-use (dimensional + domain safety) is viable
+5. Prototype on toy functor before scaling
+6. Static interface methods (.NET 7+) bridge the HKT gap sufficiently


### PR DESCRIPTION
## Summary

- Four-step path to HKT-like encoding without compiler fork
- Self-recursive type provider confirmed viable (single-pass anamorphism)
- Effective HKT via static interfaces + SRTPs + recursive generators
- F# 10 tail-call CEs make recursive generation stack-safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)