### PR TITLE
docs(research): Scala oracle + Kotlin dead end — IKVM verification strategy

### DIFF
--- a/docs/research/2026-05-11-deepseek-scala-oracle-kotlin-dead-end-ikvm-verification-strategy.md
+++ b/docs/research/2026-05-11-deepseek-scala-oracle-kotlin-dead-end-ikvm-verification-strategy.md
@@ -1,0 +1,112 @@
+# DeepSeek: Scala as HKT oracle, Kotlin dead end, IKVM verification strategy
+
+**Date:** 2026-05-11 ~02:30-02:50 UTC
+**Participants:** Aaron (human), DeepSeek (external AI)
+**Session type:** Forwarded exchange, key findings preserved
+
+## Strategy confirmed
+
+F# core + Scala oracle via IKVM + cross-verification.
+No third language needed. Scala tests our new pieces.
+
+## Python assessment
+
+**Dead end for AI alignment.** No HKTs (mypy #6066, 8+ years),
+no UoM, no type providers, 94% of LLM compilation errors are
+type-check failures. PyTorch treats typing as "low priority."
+Keras had code injection vulnerability (VU#253266) that a type
+system would have caught.
+
+## Scala assessment — viable oracle
+
+### What Scala gives immediately
+
+- **Native HKTs** — `F[_]`, `AnyKind` (Scala 3)
+- **Typeclasses** — `given`/`using` (first-class, composable)
+- **Recursion schemes** — Matryoshka (Cats-based): Fix, cata,
+  ana, hylo — battle-tested
+- **Formal verification** — Stainless (EPFL, Z3 + CVC5)
+- **UoM** — Squants (library-level, compile-time)
+- **IKVM** — actively maintained (v8.11.0-pre.4, 2025),
+  compiles Scala → .NET IL
+
+### Cross-verification strategy
+
+1. Compile Cats + Matryoshka via IKVM into .NET assembly
+2. Write cross-language test harness
+3. Feed identical position seeds to both Scala Fix/cata/ana
+   AND F# effective-HKT encoding
+4. Compare generated participant structures for every seed
+5. Any divergence = where F# SRTP encoding needs attention
+6. Stainless-Z3 chain cross-validates against Lean 4 proofs
+
+### Three-way verification triangle
+
+```
+F# (production core)
+    ↕ cross-verify
+Scala (HKT oracle via IKVM)
+    ↕ cross-verify
+Rust (DBSP reference implementation)
+```
+
+### What you lose switching TO Scala (why F# stays core)
+
+- Entire DBSP kernel rewrite required
+- UoM is library-level (Squants), not compiler-built-in
+- .NET formal verification pipeline needs rebuilding
+- 3,000+ PRs of institutional knowledge
+- JVM erased generics vs .NET reified generics
+
+## Kotlin assessment — dead end
+
+### Why Kotlin offers no benefit
+
+1. **Arrow deprecated HKTs** — removed in Arrow 2.0 (Dec 2024),
+   "Higher Kinded types will no longer be supported"
+2. **KEEP typeclass proposal stalled since 2017** — 8+ years,
+   no roadmap (same pattern as Python mypy #6066)
+3. **No recursion schemes** — Arrow deprecated them alongside
+   HKTs; `DeepRecursiveFunction` is runtime, not type-level
+4. **Formal verification immature** — ESBMC-Jimple less mature
+   than Scala's Stainless
+5. **JetBrains explicitly avoids Turing-complete types** —
+   design philosophy precludes HKTs
+6. **Context parameters ≠ typeclasses** — cannot express
+   `Functor[F[_]]` at all
+
+### Comparison matrix
+
+| Requirement | F# | Scala 3 | Kotlin | Python |
+|-------------|-----|---------|--------|--------|
+| Native HKTs | encoding/pending | ✓ | ✗ (deprecated) | ✗ |
+| Typeclasses | SRTP+inline | given/using | ✗ | ✗ |
+| Recursion schemes | encoding | Matryoshka | ✗ (deprecated) | ✗ |
+| UoM | compiler built-in | library (Squants) | ✗ | ✗ |
+| Type providers | first-class | macro-based | ✗ | ✗ |
+| Formal verification | FsCheck+Z3+TLA++Lean4 | Stainless+Z3 | ESBMC (immature) | partial |
+| IKVM to .NET | native | tested | untested | N/A |
+
+## Multi-language compilation path
+
+Aaron's existing plan:
+
+```
+F# (reference, closest to math)
+  → C# (broader ecosystem, .NET interop)
+    → Rust (systems-level, no GC)
+      → C (portable, minimal runtime)
+        → Assembly (bare metal, reversible)
+```
+
+Scala via IKVM adds a cross-verification surface at the F#
+level, not a replacement. The compilation chain stays intact.
+
+## Aaron's decision
+
+> "scala will do nicely to test our new pieces"
+
+Scala is the oracle. F# is the core. The IKVM bridge makes
+them composable. The three-way verification (F# + Scala + Rust)
+creates a triangle that's extremely difficult to break by
+accident.


### PR DESCRIPTION
## Summary

- Python: dead end (no HKTs, no UoM, 94% type errors)
- Scala: viable oracle (native HKTs, Cats, Stainless, IKVM to .NET)
- Kotlin: dead end (Arrow deprecated HKTs, KEEP stalled 8yr)
- Strategy: F# core + Scala oracle via IKVM + three-way verification
- Comparison matrix across F#/Scala/Kotlin/Python
- Multi-language compilation path preserved (F#→C#→Rust→C→asm)

## Test plan

- [x] Research doc with assessment + comparison matrix
- [ ] Markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)