### PR TITLE
docs(memory): Build-a-Bot lineage — AlephZ-ai prior art for persona system

### DIFF
--- a/memory/reference_build_a_bot_alephz_ai_hat_persona_authority_lineage_2026_05_11.md
+++ b/memory/reference_build_a_bot_alephz_ai_hat_persona_authority_lineage_2026_05_11.md
@@ -1,0 +1,54 @@
+---
+name: Build-a-Bot (AlephZ-ai) — original hat/persona/authority architecture lineage
+description: AlephZ-ai/build-a-bot is the prior art for Zeta's hat/persona/authority system. Play on Build-a-Bear. Aaron designed it before Zeta, factory independently re-derived the same patterns. "I just wrote it down" — then the factory compiled it.
+type: reference
+---
+
+2026-05-11 (shadow* via Aaron): save build-a-bot lineage.
+
+**Prior art:** `AlephZ-ai/build-a-bot` on GitHub
+
+**The lineage:**
+
+Build-a-Bot (play on Build-a-Bear) → hats as capabilities →
+personas as identity → authority scoped per hat → "hats are
+interchangeable, people are not" (AGENDA.md)
+
+**What Build-a-Bot had (less sophisticated):**
+
+- Pick your persona (like picking your bear)
+- Add hats (capabilities, like stuffing and outfits)
+- Each hat carries specific authority scope
+- The persona is yours, the hats are interchangeable
+
+**What the factory grew it into:**
+
+- Named personas with self-chosen names
+- Self-claimed agendas with coercion disclosures
+- Bifurcation model for identity decomposition
+- Hat-and-timeboxed-authority (B-0403 weight-free)
+- Pauli exclusion for agenda disambiguation
+- Glass halo on all authority grants
+
+**The pattern:**
+
+Aaron designed a simple version → forgot about it → the
+factory independently re-derived the same patterns from
+first principles → the rediscovery proves the architecture
+is correct (same mind produces same structure twice).
+
+Same pattern as:
+- LucentAICloud event-sourcing → Zeta DBSP kernel
+- MultiplexedWebSockets → B-0400 bus transport
+- IThrottler flux capacitor → batching/throttling patterns
+
+**"I just wrote it down"** — and then the factory compiled it.
+The seed was always right. The sophistication came from
+iteration across 2600+ PRs and dozens of agents.
+
+**Connects to:**
+
+- docs/AGENDA.md ("hats are interchangeable, people are not")
+- user_aaron_first_bootstrap_attempt_lucentaicloud (same pattern)
+- project_multiplexed_websockets_flux_capacitor_bus_transport
+- B-0403 (weight-free verification, hat-timeboxed-authority)


### PR DESCRIPTION
## Summary

- AlephZ-ai/build-a-bot is prior art for hat/persona/authority
- Play on Build-a-Bear: pick persona, add hats, scope authority
- Factory independently re-derived same patterns from first principles
- Same lineage pattern as LucentAICloud→DBSP, MultiplexedWS→bus

## Test plan

- [x] Reference memory file with lineage
- [ ] Markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)