### PR TITLE
feat(tools): B-0292 bounded slice — --structure CLI for recognizeStructure (Riven)

### DIFF
--- a/tools/concordance/concordance.ts
+++ b/tools/concordance/concordance.ts
@@ -91,6 +91,12 @@ if (import.meta.main) {
 
     if (args.includes("--json")) {
         console.log(JSON.stringify(index, null, 2));
+    } else if (args.includes("--structure")) {
+        const patterns = recognizeStructure(index);
+        console.log(`Structure patterns: ${patterns.length}`);
+        for (const p of patterns) {
+            console.log(`  ${p.type}: ${p.tokens.join(",")} (${p.evidence})`);
+        }
     } else {
         console.log(`Tokens: ${index.tokenCount} total, ${index.uniqueTokens} unique\n`);
         console.log(`Top ${topN}:`);


### PR DESCRIPTION
## Summary
One bounded step on B-0292: added `--structure` flag to `tools/concordance/concordance.ts` exercising the `recognizeStructure` export (TS, no new deps, GPU-ready stub surface).

## Why
Extends the typed surface from the prior re-decomp slice into a testable CLI entrypoint. Keeps the no-op stub (as current design) but wires it for future pattern impl.

## Focused check outcome
```
$ bun tools/concordance/concordance.ts --structure README.md
Structure patterns: 0
```
(Expected; stub returns []. Clean run, no errors.)

## Scope
- Exactly one change: CLI flag addition.
- Retraction-safe (pure additive).
- Prepares next atomic child (e.g. non-empty pattern logic).

## Claim
Per AGENT-CLAIM-PROTOCOL, this is Riven's claim on claim/b0292-... branch. Co-Authored-By trailer on commit.

## Next
After merge, re-decompose B-0292 per "always re-decompose" rule into children for subsequent bounded slices.

Made with [Cursor](https://cursor.com)