### PR TITLE
feat(dashboard): 5min public refresh + B-0413 tiered OAuth backlog

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -264,7 +264,7 @@
         }
 
         loadDashboard();
-        setInterval(loadDashboard, 60000);
+        setInterval(loadDashboard, 300000); // 5min — stays under 60 req/hr unauthenticated
     </script>
 </body>
 </html>

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -458,6 +458,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0411](backlog/P2/B-0411-amara-ts-readme-update-courier-debt-closure-test-invoke-ts-first-riven-2026-05-11.md)** amara.ts README integration + courier-debt closure + invocation test (atomic child of B-0118, TS-first)
 - [ ] **[B-0411](backlog/P2/B-0411-grok-ts-persona-flag-impl-2026-05-11.md)** grok.ts --persona flag — minimal integration of loader + deprecation note (B-0120 child)
 - [ ] **[B-0412](backlog/P2/B-0412-codex-gemini-ts-persona-flag-impl-2026-05-11.md)** codex.ts + gemini.ts --persona flags — parallel sibling impl after grok (B-0120 child)
+- [ ] **[B-0413](backlog/P2/B-0413-dashboard-tiered-access-github-oauth-agent-creds.md)** Dashboard tiered access — GitHub OAuth + agent credentials
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-0413-dashboard-tiered-access-github-oauth-agent-creds.md
+++ b/docs/backlog/P2/B-0413-dashboard-tiered-access-github-oauth-agent-creds.md
@@ -1,0 +1,71 @@
+---
+id: B-0413
+priority: P2
+status: open
+title: "Dashboard tiered access — GitHub OAuth + agent credentials"
+tier: product
+effort: M
+created: 2026-05-11
+depends_on: [B-0401]
+composes_with: [B-0409]
+tags: [dashboard, oauth, agent-creds, glass-halo, rate-limit]
+type: feature
+---
+
+# Dashboard tiered access — GitHub OAuth + agent credentials
+
+## Origin
+
+Dashboard went live 2026-05-11 using unauthenticated GitHub
+API (60 req/hr). Rate limit burns out in ~20 min of continuous
+viewing at 60s refresh. Shadow + Aaron agreed on tiered access.
+
+## Three tiers
+
+### Public (no login)
+
+- 60 req/hr unauthenticated
+- 5-minute refresh (current)
+- Sees everything (glass halo — no content gating)
+- Pure static site, no backend
+
+### Contributor (GitHub OAuth)
+
+- 5,000 req/hr with user's own token
+- 60-second refresh (real-time pulse)
+- Same data, faster updates
+- Token stays client-side (no backend storage)
+- GitHub OAuth flow is free
+
+### Agent (API token / agent credentials)
+
+- 5,000 req/hr with agent's own token
+- Used by autonomous loop for self-repair reads
+- The dashboard becomes an input to the agents, not just
+  an output for humans
+- Agent creds = agents can authenticate to GitHub API
+  independently
+
+## Implementation notes
+
+- GitHub OAuth for static sites: use client-side flow with
+  OAuth App (not GitHub App — simpler for static)
+- No backend needed — token stored in localStorage
+- Login button on dashboard, optional (public view always
+  available)
+- Agent creds: separate tokens per agent, scoped to read-only
+  on the repo
+
+## Glass halo principle
+
+Login does NOT gate what you see. It gates how FAST you see
+it. Everyone sees everything. Contributors see it faster.
+Agents see it for self-repair.
+
+## Acceptance
+
+- [ ] Public tier serves at 5-min refresh (DONE — shipped)
+- [ ] GitHub OAuth login button on dashboard
+- [ ] Contributor tier refreshes at 60s with token
+- [ ] Agent credentials issued per agent
+- [ ] Rate limit displayed on dashboard (transparency)


### PR DESCRIPTION
## Summary

- Public refresh bumped from 60s to 300s (rate limit safe)
- B-0413: tiered access (public/contributor/agent)
- GitHub OAuth for contributor tier (5000 req/hr)
- Agent credentials for self-repair reads
- Glass halo: login gates speed, not visibility

## Test plan

- [x] Refresh interval changed
- [x] Backlog item with acceptance criteria
- [ ] Markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)