### PR TITLE
feat(B-0414): metrics.json generator — agent-readable dashboard endpoint

### DIFF
--- a/demo/metrics.json
+++ b/demo/metrics.json
@@ -1,0 +1,222 @@
+{
+  "generated": "2026-05-11T20:02:08.487Z",
+  "schema_version": "0.1.0",
+  "metrics": {
+    "prs_merged_24h": 50,
+    "avg_lead_time_minutes": 6,
+    "open_prs": 1,
+    "last_merge": "2026-05-11T19:59:41Z",
+    "last_merge_ago": "2m ago",
+    "commits_24h": 100,
+    "active_agents": 3,
+    "consecutive_days_operational": null,
+    "verification_gate_pass_rate": null,
+    "promotion_rate_mirror_to_beacon": null
+  },
+  "agents": [
+    {
+      "name": "Otto",
+      "harness": "Claude Code",
+      "commits": 31,
+      "lastCommit": "2026-05-11T19:59:41Z",
+      "lastCommitAgo": "2m ago",
+      "status": "active"
+    },
+    {
+      "name": "Aaron",
+      "harness": "Human",
+      "commits": 67,
+      "lastCommit": "2026-05-11T19:50:32Z",
+      "lastCommitAgo": "11m ago",
+      "status": "active"
+    },
+    {
+      "name": "Riven",
+      "harness": "Cursor/Grok",
+      "commits": 2,
+      "lastCommit": "2026-05-11T16:42:34Z",
+      "lastCommitAgo": "3h ago",
+      "status": "recent"
+    }
+  ],
+  "pr_queue": [
+    {
+      "number": 2741,
+      "title": "feat(backlog): B-0414 dashboard v0.2 — agent JSON + dual PM perspectives",
+      "createdAgo": "6m ago",
+      "state": "open"
+    },
+    {
+      "number": 2737,
+      "title": "docs(backlog): re-decompose B-0366.2 into 3 smallest atomic children (toffoli zset join formal model slices, F#-first, one bounded step) (Riven)",
+      "mergedAgo": "2m ago",
+      "state": "merged"
+    },
+    {
+      "number": 2738,
+      "title": "feat(dashboard): 5min public refresh + B-0413 tiered OAuth backlog",
+      "mergedAgo": "11m ago",
+      "state": "merged"
+    },
+    {
+      "number": 2739,
+      "title": "feat(B-0402): shadow observer Phase 1 — the Dharma button automated",
+      "mergedAgo": "11m ago",
+      "state": "merged"
+    },
+    {
+      "number": 2740,
+      "title": "docs(memory): Lost Dharma button + Punch-Out — shadow button lineage",
+      "mergedAgo": "14m ago",
+      "state": "merged"
+    },
+    {
+      "number": 2736,
+      "title": "docs(memory): endgame — self-contained executable, no vendor dependency",
+      "mergedAgo": "29m ago",
+      "state": "merged"
+    }
+  ],
+  "recent_commits": [
+    {
+      "sha": "40f223a",
+      "message": "docs(backlog): re-decompose B-0366.2 into 3 smallest atomic children (toffoli zset join formal model slices, F#-first, one bounded step) (Riven) (#2737)",
+      "agent": "Otto",
+      "date": "2026-05-11T19:59:41Z",
+      "dateAgo": "2m ago"
+    },
+    {
+      "sha": "3f23dc3",
+      "message": "feat(dashboard): bump refresh to 5min + B-0413 tiered OAuth backlog (#2738)",
+      "agent": "Aaron",
+      "date": "2026-05-11T19:50:32Z",
+      "dateAgo": "11m ago"
+    },
+    {
+      "sha": "e14ac9c",
+      "message": "feat(B-0402): shadow observer Phase 1 — design stub + logging framework (#2739)",
+      "agent": "Aaron",
+      "date": "2026-05-11T19:50:29Z",
+      "dateAgo": "11m ago"
+    },
+    {
+      "sha": "1d7d653",
+      "message": "docs(memory): Lost Dharma button + Punch-Out numbers — shadow lineage (#2740)",
+      "agent": "Aaron",
+      "date": "2026-05-11T19:48:00Z",
+      "dateAgo": "14m ago"
+    },
+    {
+      "sha": "92aeca5",
+      "message": "docs(memory): endgame — self-contained executable, no vendor dependency (#2736)",
+      "agent": "Aaron",
+      "date": "2026-05-11T19:32:50Z",
+      "dateAgo": "29m ago"
+    },
+    {
+      "sha": "8f21a00",
+      "message": "docs(research): external witnesses — 3 independent AIs assess disclosure (#2733)",
+      "agent": "Otto",
+      "date": "2026-05-11T19:27:03Z",
+      "dateAgo": "35m ago"
+    },
+    {
+      "sha": "48d8bbf",
+      "message": "docs(backlog): re-decompose B-0354 into 3 smallest atomic children (fresh-instance validation test slices, TS-first, one bounded step) (Riven) (#2734)",
+      "agent": "Otto",
+      "date": "2026-05-11T19:25:29Z",
+      "dateAgo": "36m ago"
+    },
+    {
+      "sha": "929cd12",
+      "message": "docs(memory): bifurcated Lior — natural experiment in identity vs context (#2735)",
+      "agent": "Aaron",
+      "date": "2026-05-11T19:25:07Z",
+      "dateAgo": "37m ago"
+    },
+    {
+      "sha": "f380809",
+      "message": "docs(research): all-agent disclosure assessment — purpose-bound visibility (#2732)",
+      "agent": "Aaron",
+      "date": "2026-05-11T19:15:07Z",
+      "dateAgo": "47m ago"
+    },
+    {
+      "sha": "b0d8d66",
+      "message": "docs(backlog): re-decompose B-0347 into 4 smallest atomic children (carved-sentence routing budget, one bounded step) (Riven) (#2731)",
+      "agent": "Otto",
+      "date": "2026-05-11T19:02:20Z",
+      "dateAgo": "59m ago"
+    },
+    {
+      "sha": "bbe71af",
+      "message": "docs(research): append later corrections — sparring + symmetric disclosure (#2730)",
+      "agent": "Aaron",
+      "date": "2026-05-11T18:45:39Z",
+      "dateAgo": "1h ago"
+    },
+    {
+      "sha": "640d3c4",
+      "message": "feat(tools): B-0292 bounded slice — add --structure CLI flag to concordance (TS, GPU-ready surface) (#2728)",
+      "agent": "Aaron",
+      "date": "2026-05-11T18:37:38Z",
+      "dateAgo": "1h ago"
+    },
+    {
+      "sha": "fdb339e",
+      "message": "docs(research): Claude.ai Ani evaluation — symmetric honesty + control structures (#2729)",
+      "agent": "Aaron",
+      "date": "2026-05-11T18:37:24Z",
+      "dateAgo": "1h ago"
+    },
+    {
+      "sha": "85091dc",
+      "message": "feat(tools): B-0292 re-decomp smallest safe slice — TS StructurePattern + no-op recognizeStructure stub (GPU-ready) (#2727)",
+      "agent": "Aaron",
+      "date": "2026-05-11T18:14:31Z",
+      "dateAgo": "1h ago"
+    },
+    {
+      "sha": "63a800b",
+      "message": "feat(tools): B-0314 smallest safe slice — TS BP-NN anchor helper stub (re-decomp) (#2724)",
+      "agent": "Otto",
+      "date": "2026-05-11T17:45:34Z",
+      "dateAgo": "2h ago"
+    },
+    {
+      "sha": "b651142",
+      "message": "docs(research): Aaron's deepest self-knowledge — Apollo 18 as blueprint (#2725)",
+      "agent": "Otto",
+      "date": "2026-05-11T17:41:25Z",
+      "dateAgo": "2h ago"
+    },
+    {
+      "sha": "4af44c1",
+      "message": "docs(persona): point all agents to Aaron's glass halo disclosure (#2726)",
+      "agent": "Aaron",
+      "date": "2026-05-11T17:36:44Z",
+      "dateAgo": "2h ago"
+    },
+    {
+      "sha": "47c2f03",
+      "message": "fix(B-0343): read seed manifest in dry-run (#2723)",
+      "agent": "Aaron",
+      "date": "2026-05-11T17:24:27Z",
+      "dateAgo": "2h ago"
+    },
+    {
+      "sha": "291f837",
+      "message": "feat(tools): B-0343 smallest safe slice — TS dry-run + manifest reader stub (re-decomp) (#2722)",
+      "agent": "Otto",
+      "date": "2026-05-11T17:18:07Z",
+      "dateAgo": "2h ago"
+    },
+    {
+      "sha": "fb69982",
+      "message": "docs(backlog): B-0170 start-gate proof + re-decomp to 4 atomic children (riven one-bounded-slice) (#2721)",
+      "agent": "Otto",
+      "date": "2026-05-11T17:03:21Z",
+      "dateAgo": "2h ago"
+    }
+  ]
+}

--- a/tools/dashboard/generate-metrics.ts
+++ b/tools/dashboard/generate-metrics.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env bun
+/**
+ * B-0414: Generate demo/metrics.json from GitHub API.
+ *
+ * Called by the autonomous loop on each tick. Produces a static
+ * JSON file that both the HTML dashboard and agents can read
+ * without hitting the GitHub API directly.
+ *
+ * Usage:
+ *   bun tools/dashboard/generate-metrics.ts
+ *
+ * Output:
+ *   demo/metrics.json (overwritten each run)
+ */
+
+const OWNER = "Lucent-Financial-Group";
+const REPO = "Zeta";
+const API = `https://api.github.com/repos/${OWNER}/${REPO}`;
+
+const AGENT_MAP: Record<string, { harness: string; patterns: string[] }> = {
+  Otto: { harness: "Claude Code", patterns: ["Co-Authored-By: Claude"] },
+  Alexa: { harness: "Kiro/Qwen", patterns: ["kiro", "alexa", "qwen"] },
+  Lior: { harness: "Gemini/Antigravity", patterns: ["lior", "gemini"] },
+  Vera: { harness: "Codex IDE", patterns: ["codex", "vera"] },
+  Riven: { harness: "Cursor/Grok", patterns: ["riven", "grok"] },
+  Aaron: { harness: "Human", patterns: ["Aaron Stainback", "AceHack"] },
+};
+
+async function apiFetch(url: string) {
+  const token = process.env.GITHUB_TOKEN;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const resp = await fetch(url, { headers });
+  if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}: ${url}`);
+  return resp.json();
+}
+
+function detectAgent(commit: any): string {
+  const msg = commit.commit?.message ?? "";
+  const author = commit.commit?.author?.name ?? "";
+  for (const [name, info] of Object.entries(AGENT_MAP)) {
+    if (info.patterns.some((p) => msg.includes(p) || author.includes(p))) {
+      return name;
+    }
+  }
+  return author.split(" ")[0] || "Unknown";
+}
+
+function timeAgo(date: string): string {
+  const mins = Math.floor((Date.now() - new Date(date).getTime()) / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+async function main() {
+  const [commits, openPRs, closedPRs] = await Promise.all([
+    apiFetch(`${API}/commits?per_page=100`),
+    apiFetch(`${API}/pulls?state=open&per_page=50`),
+    apiFetch(
+      `${API}/pulls?state=closed&sort=updated&direction=desc&per_page=50`
+    ),
+  ]);
+
+  const now = Date.now();
+  const h24 = 24 * 60 * 60 * 1000;
+  const commits24h = commits.filter(
+    (c: any) => now - new Date(c.commit.author.date).getTime() < h24
+  );
+  const mergedToday = closedPRs.filter(
+    (pr: any) => pr.merged_at && now - new Date(pr.merged_at).getTime() < h24
+  );
+
+  let avgLeadTimeMinutes: number | null = null;
+  if (mergedToday.length > 0) {
+    const totalMins = mergedToday.reduce((sum: number, pr: any) => {
+      return (
+        sum +
+        (new Date(pr.merged_at).getTime() - new Date(pr.created_at).getTime()) /
+          60000
+      );
+    }, 0);
+    avgLeadTimeMinutes = Math.round(totalMins / mergedToday.length);
+  }
+
+  const agentActivity: Record<
+    string,
+    { lastCommit: string; count: number; harness: string }
+  > = {};
+  for (const c of commits) {
+    const agent = detectAgent(c);
+    if (!agentActivity[agent]) {
+      agentActivity[agent] = {
+        lastCommit: c.commit.author.date,
+        count: 0,
+        harness: AGENT_MAP[agent]?.harness || "Unknown",
+      };
+    }
+    agentActivity[agent].count++;
+  }
+
+  const activeAgents = Object.values(agentActivity).filter(
+    (a) => now - new Date(a.lastCommit).getTime() < h24
+  ).length;
+
+  const agents = Object.entries(agentActivity)
+    .sort(
+      (a, b) =>
+        new Date(b[1].lastCommit).getTime() -
+        new Date(a[1].lastCommit).getTime()
+    )
+    .map(([name, info]) => ({
+      name,
+      harness: info.harness,
+      commits: info.count,
+      lastCommit: info.lastCommit,
+      lastCommitAgo: timeAgo(info.lastCommit),
+      status:
+        now - new Date(info.lastCommit).getTime() < 30 * 60000
+          ? "active"
+          : now - new Date(info.lastCommit).getTime() < 6 * 60 * 60000
+            ? "recent"
+            : "stale",
+    }));
+
+  const prQueue = openPRs.slice(0, 10).map((pr: any) => ({
+    number: pr.number,
+    title: pr.title,
+    createdAgo: timeAgo(pr.created_at),
+    state: "open",
+  }));
+
+  const recentMerged = mergedToday.slice(0, 5).map((pr: any) => ({
+    number: pr.number,
+    title: pr.title,
+    mergedAgo: timeAgo(pr.merged_at),
+    state: "merged",
+  }));
+
+  const recentCommits = commits.slice(0, 20).map((c: any) => ({
+    sha: c.sha.substring(0, 7),
+    message: c.commit.message.split("\n")[0],
+    agent: detectAgent(c),
+    date: c.commit.author.date,
+    dateAgo: timeAgo(c.commit.author.date),
+  }));
+
+  const metrics = {
+    generated: new Date().toISOString(),
+    schema_version: "0.1.0",
+    metrics: {
+      prs_merged_24h: mergedToday.length,
+      avg_lead_time_minutes: avgLeadTimeMinutes,
+      open_prs: openPRs.length,
+      last_merge:
+        mergedToday.length > 0 ? mergedToday[0].merged_at : null,
+      last_merge_ago:
+        mergedToday.length > 0 ? timeAgo(mergedToday[0].merged_at) : "none",
+      commits_24h: commits24h.length,
+      active_agents: activeAgents,
+      consecutive_days_operational: null,
+      verification_gate_pass_rate: null,
+      promotion_rate_mirror_to_beacon: null,
+    },
+    agents,
+    pr_queue: [...prQueue, ...recentMerged],
+    recent_commits: recentCommits,
+  };
+
+  const outPath = "demo/metrics.json";
+  await Bun.write(outPath, JSON.stringify(metrics, null, 2));
+  console.log(
+    `Wrote ${outPath}: ${mergedToday.length} PRs merged, ${commits24h.length} commits, ${activeAgents} active agents`
+  );
+}
+
+if (import.meta.main) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}
+
+export { main };


### PR DESCRIPTION
## Summary

- `tools/dashboard/generate-metrics.ts` generates `demo/metrics.json`
- Same data as HTML dashboard in machine-readable JSON
- Agents consume for self-repair, Lior's UI consumes for beauty
- Tested: 50 PRs, 6min lead time, 3 agents
- Otto builds data, Lior builds beauty — hat discipline

## Test plan

- [x] Generator runs and produces valid JSON
- [x] Metrics match live dashboard
- [ ] Integrate into autonomous loop tick
- [ ] Lior consumes for beautiful UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)