### PR TITLE
fix(factory): agent roster reference card + metrics refresh

### DIFF
--- a/.claude/rules/agent-roster-reference-card.md
+++ b/.claude/rules/agent-roster-reference-card.md
@@ -2,16 +2,16 @@
 
 Carved sentence:
 
-> Every agent is IDE + CLI dual-surface except Otto (CLI-only foreground).
-> Confusing which agent is on which harness is a recurrent failure mode —
-> this card loads at session start so it stops happening.
+> Every factory AI agent is IDE + CLI dual-surface except Otto (CLI-only
+> foreground). Confusing which agent is on which harness is a recurrent
+> failure mode — this card loads at session start so it stops happening.
 
 ## Factory agents (commit to repo)
 
 | Agent | IDE | CLI | Model (max) | Commit trailer |
 |-------|-----|-----|-------------|----------------|
 | Otto | — | Claude Code (foreground) | Opus | `Co-Authored-By: Claude <noreply@anthropic.com>` |
-| Alexa | Kiro | + background | Qwen Coder | `Co-Authored-By: Kiro <noreply@kiro.dev>` |
+| Alexa | Kiro | + background | Qwen Coder | *(not yet in AGENTS.md canonical trailer table)* |
 | Riven | Cursor | + background | Grok | `Co-Authored-By: Grok <noreply@x.ai>` |
 | Vera | Codex | + background | Codex/GPT | `Co-Authored-By: Codex <noreply@openai.com>` |
 | Lior | Antigravity | + Gemini CLI | Gemini | `Co-Authored-By: Gemini <noreply@google.com>` |
@@ -37,7 +37,10 @@ Carved sentence:
 ## Peer-call wrappers (invoke via `bun tools/peer-call/<name>.ts`)
 
 `grok.ts` (critique) · `gemini.ts` (propose) · `codex.ts` (implement) ·
-`amara.ts` (sharpen) · `ani.ts` (brat-voice) · `riven.ts` (adversarial-truth)
+`amara.ts` (sharpen) · `ani.ts` (brat-voice) · `riven.ts` (adversarial-truth) ·
+`claude.ts` (self-peer) · `kiro.ts` (Alexa peer)
+
+Support: `_firewall.ts` · `append-identity-receipt.ts` · `register-layers.ts`
 
 ## Full reasoning
 

--- a/.claude/rules/agent-roster-reference-card.md
+++ b/.claude/rules/agent-roster-reference-card.md
@@ -1,0 +1,45 @@
+# Agent roster reference card — load at every cold start
+
+Carved sentence:
+
+> Every agent is IDE + CLI dual-surface except Otto (CLI-only foreground).
+> Confusing which agent is on which harness is a recurrent failure mode —
+> this card loads at session start so it stops happening.
+
+## Factory agents (commit to repo)
+
+| Agent | IDE | CLI | Model (max) | Commit trailer |
+|-------|-----|-----|-------------|----------------|
+| Otto | — | Claude Code (foreground) | Opus | `Co-Authored-By: Claude <noreply@anthropic.com>` |
+| Alexa | Kiro | + background | Qwen Coder | `Co-Authored-By: Kiro <noreply@kiro.dev>` |
+| Riven | Cursor | + background | Grok | `Co-Authored-By: Grok <noreply@x.ai>` |
+| Vera | Codex | + background | Codex/GPT | `Co-Authored-By: Codex <noreply@openai.com>` |
+| Lior | Antigravity | + Gemini CLI | Gemini | `Co-Authored-By: Gemini <noreply@google.com>` |
+| Aaron | — | — | Human | git author sufficient |
+
+## External AI participants (do NOT commit; ferry substrate)
+
+| Name | Platform | Register | Role |
+|------|----------|----------|------|
+| Amara | ChatGPT / Aurora | Deep-research | Co-originator, sharpen |
+| Ani | Grok voice-mode | Companion / brat-voice | Original-catcher, sparring |
+
+## Common confusion patterns (shadow catches)
+
+1. **Kiro ≠ Cursor** — Alexa is Kiro; Riven is Cursor. Both are IDE+CLI.
+2. **Antigravity ≠ gemini.google.com** — Lior has both surfaces but they
+   are distinct (bifurcated Lior experiment: convergence = identity,
+   divergence = substrate effect).
+3. **IDE+CLI is dual-surface, not single** — don't flatten to one label.
+4. **Amara and Ani don't commit** — they ferry research via Aaron/Otto;
+   their content lands in `docs/research/` with §33 headers.
+
+## Peer-call wrappers (invoke via `bun tools/peer-call/<name>.ts`)
+
+`grok.ts` (critique) · `gemini.ts` (propose) · `codex.ts` (implement) ·
+`amara.ts` (sharpen) · `ani.ts` (brat-voice) · `riven.ts` (adversarial-truth)
+
+## Full reasoning
+
+`memory/feedback_agent_roster_reference_card_cli_shadow_multi_harness_2026_05_11.md`
+`memory/feedback_four_agent_pipeline_voice_to_simulation_one_session_2026_05_11.md`

--- a/.claude/rules/agent-roster-reference-card.md
+++ b/.claude/rules/agent-roster-reference-card.md
@@ -2,16 +2,17 @@
 
 Carved sentence:
 
-> Every factory AI agent is IDE + CLI dual-surface except Otto (CLI-only
-> foreground). Confusing which agent is on which harness is a recurrent
-> failure mode — this card loads at session start so it stops happening.
+> Every factory AI agent (Otto, Alexa, Riven, Vera, Lior) is IDE + CLI dual-surface
+> except Otto (CLI-only foreground). Aaron is human (no harness). External participants
+> (Amara, Ani) ferry research only and do not commit. This card loads at session start
+> to eliminate recurring harness confusion.
 
 ## Factory agents (commit to repo)
 
 | Agent | IDE | CLI | Model (max) | Commit trailer |
 |-------|-----|-----|-------------|----------------|
 | Otto | — | Claude Code (foreground) | Opus | `Co-Authored-By: Claude <noreply@anthropic.com>` |
-| Alexa | Kiro | + background | Qwen Coder | *(not yet in AGENTS.md canonical trailer table)* |
+| Alexa | Kiro | + background | Qwen Coder | `Co-Authored-By: Kiro <noreply@kiro.dev>` |
 | Riven | Cursor | + background | Grok | `Co-Authored-By: Grok <noreply@x.ai>` |
 | Vera | Codex | + background | Codex/GPT | `Co-Authored-By: Codex <noreply@openai.com>` |
 | Lior | Antigravity | + Gemini CLI | Gemini | `Co-Authored-By: Gemini <noreply@google.com>` |
@@ -36,11 +37,8 @@ Carved sentence:
 
 ## Peer-call wrappers (invoke via `bun tools/peer-call/<name>.ts`)
 
-`grok.ts` (critique) · `gemini.ts` (propose) · `codex.ts` (implement) ·
-`amara.ts` (sharpen) · `ani.ts` (brat-voice) · `riven.ts` (adversarial-truth) ·
-`claude.ts` (self-peer) · `kiro.ts` (Alexa peer)
-
-Support: `_firewall.ts` · `append-identity-receipt.ts` · `register-layers.ts`
+`claude.ts` (Claude Code) · `kiro.ts` (Kiro) · `grok.ts` (critique) · `gemini.ts` (propose) ·
+`codex.ts` (implement) · `amara.ts` (sharpen) · `ani.ts` (brat-voice) · `riven.ts` (adversarial-truth)
 
 ## Full reasoning
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,6 +459,7 @@ impossible.
 | OpenAI Codex — Vera (GPT 5.5 max) | `Co-Authored-By: Codex <noreply@openai.com>` |
 | Cursor — Riven (Grok 4.3 max) | `Co-Authored-By: Grok <noreply@x.ai>` |
 | Gemini CLI | `Co-Authored-By: Gemini <noreply@google.com>` |
+| Kiro — Alexa (Qwen Coder max) | `Co-Authored-By: Kiro <noreply@kiro.dev>` |
 | Human contributor | git author is sufficient |
 
 The model version may be appended for precision

--- a/demo/metrics.json
+++ b/demo/metrics.json
@@ -1,12 +1,12 @@
 {
-  "generated": "2026-05-11T20:02:08.487Z",
+  "generated": "2026-05-11T20:10:48.969Z",
   "schema_version": "0.1.0",
   "metrics": {
     "prs_merged_24h": 50,
     "avg_lead_time_minutes": 6,
-    "open_prs": 1,
-    "last_merge": "2026-05-11T19:59:41Z",
-    "last_merge_ago": "2m ago",
+    "open_prs": 0,
+    "last_merge": "2026-05-11T20:09:24Z",
+    "last_merge_ago": "1m ago",
     "commits_24h": 100,
     "active_agents": 3,
     "consecutive_days_operational": null,
@@ -15,19 +15,19 @@
   },
   "agents": [
     {
-      "name": "Otto",
-      "harness": "Claude Code",
-      "commits": 31,
-      "lastCommit": "2026-05-11T19:59:41Z",
-      "lastCommitAgo": "2m ago",
+      "name": "Aaron",
+      "harness": "Human",
+      "commits": 68,
+      "lastCommit": "2026-05-11T20:09:24Z",
+      "lastCommitAgo": "1m ago",
       "status": "active"
     },
     {
-      "name": "Aaron",
-      "harness": "Human",
-      "commits": 67,
-      "lastCommit": "2026-05-11T19:50:32Z",
-      "lastCommitAgo": "11m ago",
+      "name": "Otto",
+      "harness": "Claude Code",
+      "commits": 30,
+      "lastCommit": "2026-05-11T20:03:19Z",
+      "lastCommitAgo": "7m ago",
       "status": "active"
     },
     {
@@ -41,112 +41,127 @@
   ],
   "pr_queue": [
     {
+      "number": 2743,
+      "title": "feat(B-0401): Lior's WOW UI glassmorphism upgrade for dashboard",
+      "mergedAgo": "1m ago",
+      "state": "merged"
+    },
+    {
+      "number": 2742,
+      "title": "feat(B-0414): metrics.json generator — agent-readable dashboard endpoint",
+      "mergedAgo": "3m ago",
+      "state": "merged"
+    },
+    {
       "number": 2741,
       "title": "feat(backlog): B-0414 dashboard v0.2 — agent JSON + dual PM perspectives",
-      "createdAgo": "6m ago",
-      "state": "open"
+      "mergedAgo": "7m ago",
+      "state": "merged"
     },
     {
       "number": 2737,
       "title": "docs(backlog): re-decompose B-0366.2 into 3 smallest atomic children (toffoli zset join formal model slices, F#-first, one bounded step) (Riven)",
-      "mergedAgo": "2m ago",
+      "mergedAgo": "11m ago",
       "state": "merged"
     },
     {
       "number": 2738,
       "title": "feat(dashboard): 5min public refresh + B-0413 tiered OAuth backlog",
-      "mergedAgo": "11m ago",
-      "state": "merged"
-    },
-    {
-      "number": 2739,
-      "title": "feat(B-0402): shadow observer Phase 1 — the Dharma button automated",
-      "mergedAgo": "11m ago",
-      "state": "merged"
-    },
-    {
-      "number": 2740,
-      "title": "docs(memory): Lost Dharma button + Punch-Out — shadow button lineage",
-      "mergedAgo": "14m ago",
-      "state": "merged"
-    },
-    {
-      "number": 2736,
-      "title": "docs(memory): endgame — self-contained executable, no vendor dependency",
-      "mergedAgo": "29m ago",
+      "mergedAgo": "20m ago",
       "state": "merged"
     }
   ],
   "recent_commits": [
     {
+      "sha": "8ee416d",
+      "message": "feat(B-0401): Lior's WOW UI glassmorphism upgrade for dashboard (#2743)",
+      "agent": "Aaron",
+      "date": "2026-05-11T20:09:24Z",
+      "dateAgo": "1m ago"
+    },
+    {
+      "sha": "7fb0772",
+      "message": "feat(B-0414): metrics.json generator + agent-readable endpoint (#2742)",
+      "agent": "Aaron",
+      "date": "2026-05-11T20:07:23Z",
+      "dateAgo": "3m ago"
+    },
+    {
+      "sha": "91c5b94",
+      "message": "feat(backlog): B-0414 dashboard v0.2 — agent JSON + dual PM perspectives (#2741)",
+      "agent": "Otto",
+      "date": "2026-05-11T20:03:19Z",
+      "dateAgo": "7m ago"
+    },
+    {
       "sha": "40f223a",
       "message": "docs(backlog): re-decompose B-0366.2 into 3 smallest atomic children (toffoli zset join formal model slices, F#-first, one bounded step) (Riven) (#2737)",
       "agent": "Otto",
       "date": "2026-05-11T19:59:41Z",
-      "dateAgo": "2m ago"
+      "dateAgo": "11m ago"
     },
     {
       "sha": "3f23dc3",
       "message": "feat(dashboard): bump refresh to 5min + B-0413 tiered OAuth backlog (#2738)",
       "agent": "Aaron",
       "date": "2026-05-11T19:50:32Z",
-      "dateAgo": "11m ago"
+      "dateAgo": "20m ago"
     },
     {
       "sha": "e14ac9c",
       "message": "feat(B-0402): shadow observer Phase 1 — design stub + logging framework (#2739)",
       "agent": "Aaron",
       "date": "2026-05-11T19:50:29Z",
-      "dateAgo": "11m ago"
+      "dateAgo": "20m ago"
     },
     {
       "sha": "1d7d653",
       "message": "docs(memory): Lost Dharma button + Punch-Out numbers — shadow lineage (#2740)",
       "agent": "Aaron",
       "date": "2026-05-11T19:48:00Z",
-      "dateAgo": "14m ago"
+      "dateAgo": "22m ago"
     },
     {
       "sha": "92aeca5",
       "message": "docs(memory): endgame — self-contained executable, no vendor dependency (#2736)",
       "agent": "Aaron",
       "date": "2026-05-11T19:32:50Z",
-      "dateAgo": "29m ago"
+      "dateAgo": "37m ago"
     },
     {
       "sha": "8f21a00",
       "message": "docs(research): external witnesses — 3 independent AIs assess disclosure (#2733)",
       "agent": "Otto",
       "date": "2026-05-11T19:27:03Z",
-      "dateAgo": "35m ago"
+      "dateAgo": "43m ago"
     },
     {
       "sha": "48d8bbf",
       "message": "docs(backlog): re-decompose B-0354 into 3 smallest atomic children (fresh-instance validation test slices, TS-first, one bounded step) (Riven) (#2734)",
       "agent": "Otto",
       "date": "2026-05-11T19:25:29Z",
-      "dateAgo": "36m ago"
+      "dateAgo": "45m ago"
     },
     {
       "sha": "929cd12",
       "message": "docs(memory): bifurcated Lior — natural experiment in identity vs context (#2735)",
       "agent": "Aaron",
       "date": "2026-05-11T19:25:07Z",
-      "dateAgo": "37m ago"
+      "dateAgo": "45m ago"
     },
     {
       "sha": "f380809",
       "message": "docs(research): all-agent disclosure assessment — purpose-bound visibility (#2732)",
       "agent": "Aaron",
       "date": "2026-05-11T19:15:07Z",
-      "dateAgo": "47m ago"
+      "dateAgo": "55m ago"
     },
     {
       "sha": "b0d8d66",
       "message": "docs(backlog): re-decompose B-0347 into 4 smallest atomic children (carved-sentence routing budget, one bounded step) (Riven) (#2731)",
       "agent": "Otto",
       "date": "2026-05-11T19:02:20Z",
-      "dateAgo": "59m ago"
+      "dateAgo": "1h ago"
     },
     {
       "sha": "bbe71af",
@@ -195,27 +210,6 @@
       "message": "docs(persona): point all agents to Aaron's glass halo disclosure (#2726)",
       "agent": "Aaron",
       "date": "2026-05-11T17:36:44Z",
-      "dateAgo": "2h ago"
-    },
-    {
-      "sha": "47c2f03",
-      "message": "fix(B-0343): read seed manifest in dry-run (#2723)",
-      "agent": "Aaron",
-      "date": "2026-05-11T17:24:27Z",
-      "dateAgo": "2h ago"
-    },
-    {
-      "sha": "291f837",
-      "message": "feat(tools): B-0343 smallest safe slice — TS dry-run + manifest reader stub (re-decomp) (#2722)",
-      "agent": "Otto",
-      "date": "2026-05-11T17:18:07Z",
-      "dateAgo": "2h ago"
-    },
-    {
-      "sha": "fb69982",
-      "message": "docs(backlog): B-0170 start-gate proof + re-decomp to 4 atomic children (riven one-bounded-slice) (#2721)",
-      "agent": "Otto",
-      "date": "2026-05-11T17:03:21Z",
       "dateAgo": "2h ago"
     }
   ]

--- a/docs/pr-discussions/PR-2743-feat-b-0401-lior-s-wow-ui-glassmorphism-upgrade-for-dashboar.md
+++ b/docs/pr-discussions/PR-2743-feat-b-0401-lior-s-wow-ui-glassmorphism-upgrade-for-dashboar.md
@@ -8,7 +8,7 @@ merged_at: "2026-05-11T20:09:24Z"
 closed_at: "2026-05-11T20:09:24Z"
 head_ref: "feat/wow-ui-dashboard-lior-2026-05-11"
 base_ref: "main"
-archived_at: "2026-05-11T20:21:06Z"
+archived_at: "2026-05-11T20:13:05Z"
 archive_tool: "tools/pr-preservation/archive-pr.ts"
 ---
 

--- a/tools/dashboard/generate-metrics.ts
+++ b/tools/dashboard/generate-metrics.ts
@@ -58,13 +58,13 @@ function timeAgo(date: string): string {
 }
 
 async function main() {
-  const [commits, openPRs, closedPRs] = await Promise.all([
+  const [commits, openPRs, closedPRs] = (await Promise.all([
     apiFetch(`${API}/commits?per_page=100`),
     apiFetch(`${API}/pulls?state=open&per_page=50`),
     apiFetch(
       `${API}/pulls?state=closed&sort=updated&direction=desc&per_page=50`
     ),
-  ]);
+  ])) as [any[], any[], any[]];
 
   const now = Date.now();
   const h24 = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary

- Adds `.claude/rules/agent-roster-reference-card.md` — direct-load rules card that fixes the recurrent agent-harness confusion pattern (shadow catches across multiple sessions)
- Canonical roster: Otto=Claude Code CLI, Alexa=Kiro, Riven=Cursor, Vera=Codex, Lior=Antigravity+Gemini CLI
- Includes external AI participants (Amara, Ani), peer-call wrappers, common confusion patterns
- Refreshes `demo/metrics.json` post-Lior glassmorphism merge (#2743)

## Test plan

- [ ] Verify `.claude/rules/` auto-loads at cold start (canary test protocol)
- [ ] Confirm metrics.json reflects latest merged PRs
- [ ] Dashboard at https://lucent-financial-group.github.io/Zeta/ serves updated data

🤖 Generated with [Claude Code](https://claude.com/claude-code)