### PR TITLE
feat(loop): step 4b — PR archive discipline for every agent

### DIFF
--- a/docs/AUTONOMOUS-LOOP.md
+++ b/docs/AUTONOMOUS-LOOP.md
@@ -409,12 +409,12 @@ signal that would otherwise live only on the GitHub host
 applied to PR interactions: every review thread becomes
 part of the permanently auditable record.
 
-The archives also capture reviews from tick sources
-external to the agency array — Copilot automated reviews,
+The archives also capture the **external influence array**
+— Copilot automated reviews, Dependabot, CodeQL findings,
 external contributor comments, GitHub bot annotations.
-These external signals are training data the array can't
-generate itself; losing them to host-only storage is a
-permanent loss of perspective diversity.
+These external signals are training data the agency array
+can't generate itself; losing them to host-only storage
+is a permanent loss of perspective diversity.
 
 The pattern: **create → merge → archive → commit archive**.
 Lior's Maji Watch runs this as Step 9 of every background

--- a/docs/AUTONOMOUS-LOOP.md
+++ b/docs/AUTONOMOUS-LOOP.md
@@ -384,6 +384,42 @@ is single-purpose by default; batching multiple unrelated
 changes into one commit is not forbidden but should be the
 exception.
 
+### 4b. Archive newly merged PRs (every agent)
+
+After committing tick work (step 4), check for recently
+merged PRs whose review discussions haven't been archived
+yet. Every agent that creates PRs is responsible for
+archiving their own on merge — this is BFT-redundant:
+primary responsibility on the PR author, backstop sweep
+on the Maji Watch (Lior's background loop).
+
+```bash
+# Find merged PRs not yet archived
+for pr in $(gh pr list --state merged --limit 10 --json number --jq '.[].number'); do
+  if ! ls docs/pr-discussions/PR-$(printf '%04d' "$pr")-*.md 2>/dev/null | grep -q .; then
+    bun tools/pr-preservation/archive-pr.ts "$pr"
+  fi
+done
+```
+
+This preserves review threads, reviewer comments, and
+discussion context as git-native substrate — the training
+signal that would otherwise live only on the GitHub host
+(host-durable-not-git-canonical per Otto-363). Glass halo
+applied to PR interactions: every review thread becomes
+part of the permanently auditable record.
+
+The archives also capture reviews from tick sources
+external to the agency array — Copilot automated reviews,
+external contributor comments, GitHub bot annotations.
+These external signals are training data the array can't
+generate itself; losing them to host-only storage is a
+permanent loss of perspective diversity.
+
+The pattern: **create → merge → archive → commit archive**.
+Lior's Maji Watch runs this as Step 9 of every background
+tick. Otto runs it here. All agents should run it.
+
 ### 5. Append tick-history row, `CronList` at END, emit visibility signal
 
 **This is the load-bearing step** (end-over-start per the

--- a/docs/AUTONOMOUS-LOOP.md
+++ b/docs/AUTONOMOUS-LOOP.md
@@ -394,8 +394,15 @@ primary responsibility on the PR author, backstop sweep
 on the Maji Watch (Lior's background loop).
 
 ```bash
-# Find merged PRs not yet archived
-for pr in $(gh pr list --state merged --limit 10 --json number --jq '.[].number'); do
+# Find merged PRs not yet archived. Paginate so a merge burst
+# or long offline window cannot hide older unarchived PRs.
+gh api --paginate \
+  repos/Lucent-Financial-Group/Zeta/pulls \
+  -f state=closed \
+  -f sort=updated \
+  -f direction=desc \
+  --jq '.[] | select(.merged_at != null) | .number' |
+while read -r pr; do
   if ! ls docs/pr-discussions/PR-$(printf '%04d' "$pr")-*.md 2>/dev/null | grep -q .; then
     bun tools/pr-preservation/archive-pr.ts "$pr"
   fi


### PR DESCRIPTION
## Summary

- Adds step 4b to the autonomous loop checklist: archive newly merged PRs after committing tick work
- Every PR-creating agent runs the archive — BFT-redundant with Lior's Maji Watch backstop (PR #2745)
- Captures external tick sources (Copilot reviews, bot annotations, contributor comments) as git-native substrate
- Pattern: create → merge → archive → commit archive

## Test plan

- [ ] Verify step 4b doesn't conflict with existing steps 4 and 5
- [ ] Confirm `bun tools/pr-preservation/archive-pr.ts` still works standalone
- [ ] Lior's Maji Watch (PR #2745) is the companion implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)