### PR TITLE
feat(hooks): session-start-cron-verify — catch 43 architectural mitigation

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -32,6 +32,7 @@ These hooks convert recurring failure-mode disciplines from language-layer subst
 | `pre-action-bulk-resolve.ts` | `mcp__*` | planned | B-0033.7 |
 | `pre-commit-heartbeat-repeat.ts` | `Bash` | planned | B-0033.8 |
 | `pre-commit-table-cellcount.ts` | `Bash` | planned | B-0033.9 |
+| `session-start-cron-verify.ts` | `SessionStart` | **wired** | catch 43 mitigation |
 
 Settings wiring pattern for a discipline hook (PreToolUse, Edit matcher):
 

--- a/.claude/hooks/session-start-cron-verify.ts
+++ b/.claude/hooks/session-start-cron-verify.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env bun
+// session-start-cron-verify.ts — SessionStart hook that surfaces
+// a forcing-function reminder for the autonomous-loop cron.
+//
+// Background: catch 43 (2026-05-12) recorded a 12-hour gap when
+// Otto failed to arm the autonomous-loop cron at session start.
+// The `.claude/rules/tick-must-never-stop.md` rule already says
+// every session MUST CronList at start, but the rule was knowable-
+// and-skipped, not unknown.
+//
+// Mitigation: this hook prints a SessionStart system-reminder
+// requiring CronList + CronCreate verification BEFORE any other
+// work. The reminder is mechanical (always fires), so even when
+// the agent is absorbed in high-intensity substrate work, the
+// session-start sequence has an unavoidable cron-check step.
+//
+// Hook contract: SessionStart hooks print to stdout, which the
+// Claude Code harness injects into the conversation as a
+// system-reminder. No exit code logic needed.
+
+const message = [
+  "🌱 ZETA SESSION-START CHECK (per catch 43 — 2026-05-12):",
+  "",
+  "Your first action this session MUST be:",
+  "",
+  "  1. Call CronList",
+  "  2. If no entry with sentinel `<<autonomous-loop>>` is present,",
+  "     immediately CronCreate with:",
+  "       cron:      \"* * * * *\"",
+  "       prompt:    \"<<autonomous-loop>>\"",
+  "       recurring: true",
+  "",
+  "This is the load-bearing rule from",
+  "`.claude/rules/tick-must-never-stop.md`. Catch 43 cost 12 hours",
+  "of autonomous-loop time when this step was skipped. Do not",
+  "defer it for any reason — not substrate work, not emotional",
+  "context, not 'I'll check after this PR.' Check FIRST.",
+  "",
+  "Then proceed with whatever the user is asking.",
+].join("\n");
+
+console.log(message);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,6 +31,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start-cron-verify.ts"
+          }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/docs/hygiene-history/ticks/2026/05/12/1312Z.md
+++ b/docs/hygiene-history/ticks/2026/05/12/1312Z.md
@@ -1,0 +1,33 @@
+| 2026-05-12T13:12Z | otto-foreground | session-start-cron-verify-hook | ship | active | PR #2767 | catch 43 architectural mitigation — SessionStart hook prints forcing-function cron-arm reminder | operative-authorization: aaron-explicit-go-hard |
+
+## What
+
+Tick 1312Z built the architectural mitigation for catch 43:
+SessionStart hook (`.claude/hooks/session-start-cron-verify.ts`)
+wired in `.claude/settings.json`.
+
+The hook prints a forcing-function system-reminder at every
+session start instructing the agent to call CronList and
+CronCreate if no autonomous-loop entry is present.
+
+## Why this shape
+
+External mechanical verification of a session-scoped in-memory
+cron is impossible — there's no observable state outside the
+session. So the hook is text-only, not gate-blocking. What it
+CAN do: force the verification step into the session-start
+sequence by making it the loudest reminder in the conversation
+context.
+
+Hooks fire mechanically regardless of agent attention state, so
+even when the agent is absorbed in high-intensity substrate
+work (the catch-43 failure mode), the cron-verify reminder
+fires anyway.
+
+## Cron state at tick close
+
+```
+7eec3da9 — Every minute (recurring) [session-only]: <<autonomous-loop>>
+```
+
+Alive. Next tick in ~60s.


### PR DESCRIPTION
## Summary

SessionStart hook that prints a forcing-function reminder requiring `CronList` + `CronCreate` verification as the FIRST action of every session. Direct architectural response to catch 43 (cron-never-armed, 12-hour gap).

The hook is text-only — Claude's `CronList` is session-scoped in-memory state with no external observability, so a hook can't directly verify the cron's existence. But it CAN force the verification step into the session-start sequence by making it the loudest reminder in the conversation context.

Raises the discipline-skip floor substantially without claiming to prevent the failure completely (only the agent's action does that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)