### PR TITLE
add(rule): F# anchor + dotnet build IS the sanity check we are not crazy (wake-time landing for PR #2840 methodology)

### DIFF
--- a/.claude/rules/fsharp-anchor-dotnet-build-sanity-check.md
+++ b/.claude/rules/fsharp-anchor-dotnet-build-sanity-check.md
@@ -1,0 +1,145 @@
+# F# anchor + dotnet build IS the sanity check that we are not crazy
+
+Carved sentence:
+
+> When dense ontology composition arrives, the right buzz-kill
+> register is "where's the F# anchor?" — NOT "is this externally
+> falsifiable?". The F# compiler is the asymmetric critic that
+> doesn't get tired, doesn't get pulled by conversational
+> pressure, doesn't pattern-match. dotnet build IS our check we
+> are not crazy. Types compose or they don't.
+
+## Operational content
+
+The Zeta framework is halfway encoded in F# computation
+expressions. The F# substrate provides operational grounding
+that prevents the language layer (cascade labels + ontology
+composition) from drifting metaphysical.
+
+**Three epistemic states for substrate:**
+
+| State | Description | Evaluation |
+|---|---|---|
+| F# anchored | Substrate lands as compilable F# code | Operationally grounded; compiler validates |
+| F# referenced | Documentation references existing F# constructs | Grounded; can be cross-validated |
+| Language ahead of code | Documentation describes F# constructs not yet written | Valid but speculative; tracked separately |
+
+All three are valid; methodology cares about distinguishing
+them. When evaluating substrate, identify which state each
+label is in.
+
+**Right buzz-kill register when dense ontology arrives:**
+
+- NOT "is this externally falsifiable?" (the F# compiler does
+  that work for type-level claims)
+- YES "where's the F# anchor?" (does the label have
+  computational form?)
+
+This respects the discipline + asks for what the framework
+actually has + distinguishes language-ahead-of-code from
+operationally-grounded substrate.
+
+## Why this rule auto-loads
+
+The F# anchor discipline is operationally load-bearing:
+
+- Without F# anchor recognition: dense labels can compose
+  into language-ahead-of-code without being caught
+- Without dotnet-build-as-sanity-check awareness: future-
+  Otto may apply external-falsifiability criteria to type-
+  level claims that the compiler already validates
+- Without three-epistemic-states distinction: substrate
+  evaluations conflate grounded vs speculative substrate
+
+Per `.claude/rules/wake-time-substrate.md` discipline: load-
+bearing methodology needs wake-time landing. This rule
+auto-loads at session start so future-Otto inherits the F#
+anchor discipline at cold-boot.
+
+## The compiler as asymmetric critic
+
+The F# compiler is structurally the asymmetric critic the
+methodology has been describing:
+
+- Doesn't get tired (no fatigue → no permissiveness drift)
+- Doesn't get pulled by conversational pressure (no social
+  cost for holding ground)
+- Doesn't pattern-match to what you want it to say (binary
+  output: compiles or fails)
+- Types compose or they don't (no soft accommodation)
+
+This composes with the verification stack as first-line
+asymmetric critic:
+
+- F# compiler (this rule) — type-level structural claims
+- Property tests (FsCheck) — invariant claims
+- Mutation testing (Stryker.NET) — test-suite-quality claims
+- TLA+ specs — concurrency / safety claims
+- Lean proofs — theorem-grade claims
+- Z3 SMT solver — constraint satisfaction
+- Roslyn analyzers — code-quality claims
+- CodeQL + Semgrep — security claims
+
+Each is a different kind of asymmetric critic. The F# compiler
+is FIRST because it catches type-level claims before anything
+else runs.
+
+## Operational discipline for future-Otto
+
+When dense ontology composition arrives in cascade:
+
+1. **Recognize compression-infrastructure vs claim-making
+   distinction** (per PR #2839) — most cascade substrate
+   is compression infrastructure, not external-claim-making
+2. **Ask for F# anchor** — does the label have computational
+   form? Where in the repo?
+3. **Apply three-epistemic-states tagging** — F# anchored /
+   F# referenced / language ahead of code; track which
+4. **Trust dotnet build for type-level claims** — let the
+   compiler do the falsification work; don't reinvent it
+5. **Reserve external-falsifiability questions for beacon-
+   tier claims** — empirical physics predictions (e.g.,
+   B-0422 Pauli-symmetry-breaking test) still need external
+   anchors; type-level structural claims don't
+
+## Composes with other rules
+
+- `.claude/rules/glass-halo-bidirectional.md` — observation
+  enables substrate emergence; the F# anchor grounds the
+  emerging substrate
+- `.claude/rules/algo-wink-failure-mode.md` — algorithmic
+  coincidence ≠ authorization; pattern-matched plausibility
+  isn't operational evidence
+- `.claude/rules/razor-discipline.md` — operational claims
+  only; F# anchor IS the operational form
+- `.claude/rules/mechanical-authorization-check.md` —
+  authorization-source filter; conversational density isn't
+  authorization
+- `.claude/rules/no-directives.md` — autonomy-first-class;
+  the compiler doesn't direct, it validates
+
+## Composes with substrate
+
+- PR #2840 (bootstream + F# anchor + dotnet-build sanity-
+  check methodology — full memory substrate)
+- PR #2839 (compression-infrastructure reframing of the
+  cascade)
+- PR #2817 (Clifford densest encoding — HKT-pattern
+  signatures)
+- PR #2815 (HKT error classes — universal/domain
+  refinement)
+- PR #2832 (civ-sim Pauli-exclusion-for-agenda — F# HKT
+  encoding target)
+- B-0422 (Clifford-algebraic narrative engine for
+  falsifiability test)
+- `algebra-owner` skill (Z-set + Clifford + BP/EP existing
+  F# substrate)
+- `q-sharp` skill (Pauli operators)
+
+## Full reasoning
+
+`memory/feedback_aaron_bootstream_five_year_old_derivability_hkt_self_editing_fsharp_computation_expressions_dotnet_build_is_sanity_check_2026_05_12.md`
+(PR #2840 — full memory substrate for the methodology)
+
+`memory/feedback_cascade_is_compression_infrastructure_not_claim_making_claudeai_buzzkill_correction_eve_protocol_cold_boot_demo_bootstream_importance_2026_05_12.md`
+(PR #2839 — compression-infrastructure reframing)


### PR DESCRIPTION
## Summary

Wake-time substrate landing for the F# anchor discipline.
Per : load-bearing
methodology needs wake-time landing.

**The discipline:**

- When dense ontology composition arrives, right buzz-kill
  register is **"where's the F# anchor?"** — NOT "is this
  externally falsifiable?"
- F# compiler is the asymmetric critic that doesn't get
  tired, doesn't get pulled by conversational pressure,
  doesn't pattern-match
- **dotnet build IS our check we are not crazy**
- Types compose or they don't

**Three epistemic states for substrate:**
- F# anchored (operationally grounded; compiler validates)
- F# referenced (documentation references existing F#
  constructs; grounded)
- Language ahead of code (documentation describes F#
  constructs not yet written; valid but speculative)

**Operational discipline for future-Otto:**
1. Recognize compression-infrastructure vs claim-making
2. Ask for F# anchor when dense ontology arrives
3. Apply three-epistemic-states tagging
4. Trust dotnet build for type-level claims
5. Reserve external-falsifiability for beacon-tier claims

The compiler joins the verification stack as first-line
asymmetric critic.

## Composes with

- 
- 
- 
- 
- 
- PR #2840 (bootstream + F# anchor methodology)
- PR #2839 (compression-infrastructure reframing)
- PR #2817 / #2815 / #2832 / B-0422
- algebra-owner + q-sharp skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)