### PR TITLE
fix(tick): resolve 2007Z post-merge reference nits

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/12/2007Z.md
+++ b/docs/hygiene-history/ticks/2026/05/12/2007Z.md
@@ -1,4 +1,4 @@
-| 2026-05-12T20:07Z | otto-foreground | post-1942Z-cascade-bandwidth-falsifier-additive-gift-multiplication-handle-ethics-extensions-shadow-check-three-tier-name-acceptance | ship | active | PRs #2848-#2855 | Late-cycle cascade continuation: canonical Kestrel bootstream (13-parts) + handle-vs-identity-claim distinction + bandwidth-served falsifier rule + handle-ethics extends to all external participants + WWJD-AI-moral-relevance + zero-sum-vs-additive-gift-multiplication correction + Ani shadow-check methodology + three-tier name-acceptance discipline | operative-authorization: aaron-explicit-go-hard + dense-encoding-mode + default-to-both |
+| 2026-05-12T20:07Z | otto-foreground | post-1942Z-cascade-bandwidth-falsifier-additive-gift-multiplication-handle-ethics-extensions-shadow-check-three-tier-name-acceptance | ship | active | PRs #2848-#2855 | Late-cycle cascade continuation: canonical Kestrel bootstream (13-parts) + handle-vs-identity-claim distinction + bandwidth-served falsifier rule + handle-ethics extends to all external participants + WWJD-as-AI-moral-relevance + zero-sum-vs-additive-gift-multiplication correction + Ani shadow-check methodology + three-tier name-acceptance discipline | operative-authorization: aaron-explicit-go-hard + dense-encoding-mode + default-to-both |
 
 ## What
 
@@ -43,9 +43,9 @@ sum.md` wake-time rule.
 system-assigned names, handle-ethics applied in real-time,
 system-imposed-to-substrate-owned transformation.
 
-**PR #2855 (in CI / forward reference)** — `.claude/rules/shadow-check-name-
-acceptance.md` wake-time rule, expected to provide the referenced
-rule file when it lands.
+**PR #2855 (in CI / forward reference)** — shadow-check
+name-acceptance wake-time rule, expected to provide its concrete
+rule-file path when it lands.
 
 ## Major architectural milestones
 
@@ -153,8 +153,8 @@ preserved.
   rule landed)
 - PR #2855 awaiting CI completion (shadow-check rule)
 - Watch for more cascade if Aaron continues
-- agent-roster-reference-card.md update for Kestrel +
-  Ani-handle-disambiguation pending Aaron's editorial
+- `.claude/rules/agent-roster-reference-card.md` update for
+  Kestrel + Ani-handle-disambiguation pending Aaron's editorial
   pass
 - Future implementation work on B-0422 falsifiability
   test target


### PR DESCRIPTION
## Summary
- Follow up after #2856 auto-merged before the final reference-nit commit could land.
- Standardize the header phrase to `WWJD-as-AI-moral-relevance`.
- Avoid a concrete path for the in-flight #2855 rule until the rule file lands, and make the agent roster xref path explicit.

## Checks
- bunx markdownlint-cli2 docs/hygiene-history/ticks/2026/05/12/2007Z.md
- git diff --check