### PR TITLE
feat(B-0400): inter-agent bus protocol — typed /tmp transport, slice 1

### DIFF
--- a/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
+++ b/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
@@ -53,3 +53,34 @@ Message schema (agent-designed):
 ## Review requirement
 
 P1 — get as many agents to review as possible within a bounded timeframe. This is factory infrastructure that affects all named entities.
+
+## Pre-start checklist (backlog-item start gate — 2026-05-13)
+
+**Prior-art search:**
+
+- `tools/shadow-outlet/outlet.ts` — unstructured scratch outlet; pattern reused for this typed bus (same `/tmp`+JSON approach, adds topic routing + TTL)
+- `tools/shadow/ephemeral.ts` — ephemeral lifecycle utilities; reused for bus TTL cleanup
+- `tools/peer-call/` — existing cross-agent calling; bus complements, does not replace
+- B-0164 (`composes_with`) — dual-loop substrate; bus enables loop-to-loop coordination without Git commits
+- B-0212 (shadow-outlet origin) — predecessor ephemeral pattern; bus is typed evolution
+- Grep for "NATS" in repo: no existing NATS dependency found; `/tmp`+JSON chosen for slice 1 (no new runtime dep)
+- Grep for "zeta-bus": no existing bus directory; safe to create `tools/bus/`
+
+**Dependency check:**
+- `depends_on: []` — no blockers
+- `composes_with: [B-0164]` — B-0164 is open; bus is additive, does not block or require B-0164 completion
+
+**Slice 1 scope (this PR):**
+- Protocol types (`tools/bus/types.ts`)
+- `/tmp/zeta-bus/` CLI transport (`tools/bus/bus.ts`)
+- Unit tests (`tools/bus/bus.test.ts`)
+- Topics: `heartbeat`, `claim`, `shadow-catch`, `review-request`
+- Routing: point-to-point (`to: agentId`) + broadcast (`to: "*"`)
+- TTL: messages carry `expiresAt`; clean command prunes expired
+- Agent design: Otto (Claude) designed the protocol; multi-agent review via PR
+
+**Deferred to slice 2+:**
+- NATS JetStream transport swap
+- Named-pipe transport option
+- Subscription watch mode (`bun bus.ts watch --agent otto`)
+- Integration with `poll-pr-gate-batch.ts` for coordinated claims

--- a/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
+++ b/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
@@ -6,6 +6,7 @@ title: "Inter-agent ephemeral communication bus — NATS/F#/TS protocol for back
 tier: factory-infrastructure
 effort: M
 created: 2026-05-10
+last_updated: 2026-05-13
 depends_on: []
 composes_with: [B-0164]
 tags: [multi-agent, bus, nats, ephemeral, shadow-space, accelerated-timeframe, agent-designed]
@@ -59,7 +60,7 @@ P1 — get as many agents to review as possible within a bounded timeframe. This
 **Prior-art search:**
 
 - `tools/shadow-outlet/outlet.ts` — unstructured scratch outlet; pattern reused for this typed bus (same `/tmp`+JSON approach, adds topic routing + TTL)
-- `tools/shadow/ephemeral.ts` — ephemeral lifecycle utilities; reused for bus TTL cleanup
+- `tools/shadow-outlet/ephemeral.ts` — ephemeral lifecycle utilities; TTL-expiry pattern (bus reimplements inline, no import)
 - `tools/peer-call/` — existing cross-agent calling; bus complements, does not replace
 - B-0164 (`composes_with`) — dual-loop substrate; bus enables loop-to-loop coordination without Git commits
 - B-0212 (shadow-outlet origin) — predecessor ephemeral pattern; bus is typed evolution

--- a/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
+++ b/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
@@ -67,10 +67,12 @@ P1 — get as many agents to review as possible within a bounded timeframe. This
 - Grep for "zeta-bus": no existing bus directory; safe to create `tools/bus/`
 
 **Dependency check:**
+
 - `depends_on: []` — no blockers
 - `composes_with: [B-0164]` — B-0164 is open; bus is additive, does not block or require B-0164 completion
 
 **Slice 1 scope (this PR):**
+
 - Protocol types (`tools/bus/types.ts`)
 - `/tmp/zeta-bus/` CLI transport (`tools/bus/bus.ts`)
 - Unit tests (`tools/bus/bus.test.ts`)
@@ -80,6 +82,7 @@ P1 — get as many agents to review as possible within a bounded timeframe. This
 - Agent design: Otto (Claude) designed the protocol; multi-agent review via PR
 
 **Deferred to slice 2+:**
+
 - NATS JetStream transport swap
 - Named-pipe transport option
 - Subscription watch mode (`bun bus.ts watch --agent otto`)

--- a/tools/bus/bus.test.ts
+++ b/tools/bus/bus.test.ts
@@ -1,0 +1,175 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+const SCRIPT = join(import.meta.dir, "bus.ts");
+let TEST_DIR: string;
+
+function run(...args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  const r = spawnSync("bun", [SCRIPT, ...args], {
+    encoding: "utf-8",
+    env: { ...process.env, ZETA_BUS_DIR: TEST_DIR },
+  });
+  return {
+    stdout: (r.stdout ?? "").trim(),
+    stderr: (r.stderr ?? "").trim(),
+    exitCode: r.status ?? 1,
+  };
+}
+
+function cleanTestDir(): void {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });
+}
+
+describe("bus — publish + list", () => {
+  beforeEach(() => {
+    TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-bus-test-"));
+  });
+  afterEach(cleanTestDir);
+
+  test("publish creates a message and list returns it", () => {
+    const p = run("publish", "--from", "otto", "--to", "*", "--topic", "heartbeat", "--payload", '{"status":"alive"}');
+    expect(p.exitCode).toBe(0);
+    expect(p.stdout).toContain("heartbeat");
+
+    const l = run("list", "--json");
+    expect(l.exitCode).toBe(0);
+    const msgs = JSON.parse(l.stdout);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].topic).toBe("heartbeat");
+    expect(msgs[0].from).toBe("otto");
+    expect(msgs[0].to).toBe("*");
+    expect(msgs[0].payload.status).toBe("alive");
+  });
+
+  test("list --topic filters by topic", () => {
+    run("publish", "--from", "otto", "--to", "*", "--topic", "heartbeat", "--payload", '{"status":"alive"}');
+    run("publish", "--from", "vera", "--to", "otto", "--topic", "claim", "--payload", '{"action":"claim","itemId":"B-0400"}');
+
+    const heartbeats = JSON.parse(run("list", "--topic", "heartbeat", "--json").stdout);
+    expect(heartbeats).toHaveLength(1);
+    expect(heartbeats[0].topic).toBe("heartbeat");
+
+    const claims = JSON.parse(run("list", "--topic", "claim", "--json").stdout);
+    expect(claims).toHaveLength(1);
+    expect(claims[0].payload.itemId).toBe("B-0400");
+  });
+
+  test("list --to filters by recipient (includes broadcast)", () => {
+    run("publish", "--from", "otto", "--to", "vera", "--topic", "review-request", "--payload", '{"artifact":"tools/bus/bus.ts"}');
+    run("publish", "--from", "otto", "--to", "*", "--topic", "heartbeat", "--payload", '{"status":"working"}');
+    run("publish", "--from", "otto", "--to", "alexa", "--topic", "shadow-catch", "--payload", '{"content":"pattern spotted"}');
+
+    // vera receives: direct + broadcast
+    const forVera = JSON.parse(run("list", "--to", "vera", "--json").stdout);
+    expect(forVera).toHaveLength(2);
+    const topics = forVera.map((m: { topic: string }) => m.topic).sort();
+    expect(topics).toEqual(["heartbeat", "review-request"]);
+
+    // alexa receives: direct + broadcast
+    const forAlexa = JSON.parse(run("list", "--to", "alexa", "--json").stdout);
+    expect(forAlexa).toHaveLength(2);
+  });
+});
+
+describe("bus — read", () => {
+  beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-bus-test-")); });
+  afterEach(cleanTestDir);
+
+  test("read returns a specific message by id", () => {
+    const p = run("publish", "--from", "vera", "--to", "otto", "--topic", "claim", "--payload", '{"action":"claim","itemId":"B-0001"}', "--json");
+    const env = JSON.parse(p.stdout);
+
+    const r = run("read", env.id, "--json");
+    expect(r.exitCode).toBe(0);
+    const msg = JSON.parse(r.stdout);
+    expect(msg.id).toBe(env.id);
+    expect(msg.payload.itemId).toBe("B-0001");
+  });
+
+  test("read unknown id exits 1", () => {
+    const r = run("read", "00000000-0000-0000-0000-000000000000");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("not found");
+  });
+});
+
+describe("bus — clean", () => {
+  beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-bus-test-")); });
+  afterEach(cleanTestDir);
+
+  test("clean removes all messages", () => {
+    run("publish", "--from", "otto", "--to", "*", "--topic", "heartbeat", "--payload", '{"status":"idle"}');
+    run("publish", "--from", "vera", "--to", "*", "--topic", "heartbeat", "--payload", '{"status":"working"}');
+
+    const c = run("clean", "--json");
+    expect(c.exitCode).toBe(0);
+    expect(JSON.parse(c.stdout).removed).toBe(2);
+
+    const l = JSON.parse(run("list", "--json").stdout);
+    expect(l).toHaveLength(0);
+  });
+
+  test("clean --from removes only that agent's messages", () => {
+    run("publish", "--from", "otto", "--to", "*", "--topic", "heartbeat", "--payload", '{"status":"idle"}');
+    run("publish", "--from", "vera", "--to", "*", "--topic", "heartbeat", "--payload", '{"status":"working"}');
+
+    const c = run("clean", "--from", "otto", "--json");
+    expect(JSON.parse(c.stdout).removed).toBe(1);
+
+    const remaining = JSON.parse(run("list", "--json").stdout);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].from).toBe("vera");
+  });
+});
+
+describe("bus — TTL expiry", () => {
+  beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-bus-test-")); });
+  afterEach(cleanTestDir);
+
+  test("expired messages are excluded from list by default", () => {
+    // publish a message then manually expire it via env override + tiny TTL
+    // We use the programmatic API directly (import) to set a 0ms TTL
+    const r = spawnSync("bun", ["-e", `
+      process.env.ZETA_BUS_DIR = ${JSON.stringify(TEST_DIR)};
+      const { publish } = await import(${JSON.stringify(SCRIPT)});
+      const env = publish("otto", "*", { topic: "heartbeat", payload: { status: "idle" } }, 0);
+      console.log(JSON.stringify(env));
+    `], { encoding: "utf-8" });
+    expect(r.status).toBe(0);
+    const env = JSON.parse(r.stdout.trim());
+    expect(env.id).toBeTruthy();
+
+    // list without --include-expired should omit it (0ms TTL = already expired)
+    const l = JSON.parse(run("list", "--json").stdout);
+    expect(l).toHaveLength(0);
+
+    // list with --include-expired should include it
+    const lAll = JSON.parse(run("list", "--include-expired", "--json").stdout);
+    expect(lAll).toHaveLength(1);
+  });
+});
+
+describe("bus — error handling", () => {
+  beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-bus-test-")); });
+  afterEach(cleanTestDir);
+
+  test("publish without required flags exits 1", () => {
+    const r = run("publish", "--from", "otto");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("required");
+  });
+
+  test("publish with invalid JSON payload exits 1", () => {
+    const r = run("publish", "--from", "otto", "--to", "*", "--topic", "heartbeat", "--payload", "not-json");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("JSON");
+  });
+
+  test("unknown command exits 1", () => {
+    const r = run("frobulate");
+    expect(r.exitCode).toBe(1);
+  });
+});

--- a/tools/bus/bus.ts
+++ b/tools/bus/bus.ts
@@ -13,7 +13,7 @@
 import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
-import type { AgentId, MessageEnvelope, Topic, BusMessage } from "./types.ts";
+import type { AgentId, SenderAgentId, MessageEnvelope, Topic, BusMessage } from "./types.ts";
 import { TTL_MS } from "./types.ts";
 
 export const BUS_DIR = process.env.ZETA_BUS_DIR ?? join("/tmp", "zeta-bus");
@@ -36,7 +36,7 @@ function envelopePath(id: string): string {
 // ── publish ───────────────────────────────────────────────────────────────────
 
 export function publish(
-  from: AgentId,
+  from: SenderAgentId,
   to: AgentId,
   message: BusMessage,
   ttlOverrideMs?: number,
@@ -67,7 +67,11 @@ export function list(opts: { topic?: Topic; to?: AgentId; includeExpired?: boole
     try {
       const raw = readFileSync(join(BUS_DIR, f), "utf-8");
       const env = JSON.parse(raw) as MessageEnvelope;
-      if (typeof env.id !== "string" || typeof env.topic !== "string") continue;
+      if (
+        typeof env.id !== "string" || typeof env.topic !== "string" ||
+        typeof env.timestamp !== "string" || typeof env.expiresAt !== "string" ||
+        typeof env.from !== "string" || typeof env.to !== "string"
+      ) continue;
       if (!opts.includeExpired && new Date(env.expiresAt) < now) continue;
       if (opts.topic && env.topic !== opts.topic) continue;
       if (opts.to && env.to !== opts.to && env.to !== "*") continue;
@@ -82,9 +86,9 @@ export function list(opts: { topic?: Topic; to?: AgentId; includeExpired?: boole
 // ── read ──────────────────────────────────────────────────────────────────────
 
 export function readMessage(id: string): MessageEnvelope | null {
-  const p = envelopePath(id);
-  if (!existsSync(p)) return null;
   try {
+    const p = envelopePath(id);
+    if (!existsSync(p)) return null;
     return JSON.parse(readFileSync(p, "utf-8")) as MessageEnvelope;
   } catch {
     return null;
@@ -149,18 +153,29 @@ Topics: heartbeat | claim | shadow-catch | review-request
 Agents: otto | alexa | riven | vera | lior | * (broadcast)`);
 }
 
+const SENDER_IDS: readonly string[] = ["otto", "alexa", "riven", "vera", "lior"];
+const AGENT_IDS: readonly string[] = [...SENDER_IDS, "*"];
+
 function main(): void {
   const { command, flags, positional } = parseArgs(process.argv);
   const asJson = flags.json === "true";
 
   switch (command) {
     case "publish": {
-      const from = flags.from as AgentId | undefined;
+      const from = flags.from as SenderAgentId | undefined;
       const to = (flags.to ?? "*") as AgentId;
       const topic = flags.topic as Topic | undefined;
       const payloadRaw = flags.payload;
       if (!from || !topic || !payloadRaw) {
         console.error("Error: --from, --topic, and --payload are required");
+        process.exit(1);
+      }
+      if (!SENDER_IDS.includes(from)) {
+        console.error(`Error: unknown sender '${from}'. Valid: ${SENDER_IDS.join(", ")}`);
+        process.exit(1);
+      }
+      if (!AGENT_IDS.includes(to)) {
+        console.error(`Error: unknown recipient '${to}'. Valid: ${AGENT_IDS.join(", ")}`);
         process.exit(1);
       }
       let payload: unknown;

--- a/tools/bus/bus.ts
+++ b/tools/bus/bus.ts
@@ -1,0 +1,238 @@
+#!/usr/bin/env bun
+// bus.ts — Inter-agent ephemeral communication bus (B-0400 slice 1)
+//
+// Transport: /tmp/zeta-bus/ JSON files. Override with ZETA_BUS_DIR env var.
+// All subcommands accept --json for programmatic consumption.
+//
+// Usage:
+//   bun tools/bus/bus.ts publish --from otto --to "*" --topic heartbeat --payload '{"status":"alive"}'
+//   bun tools/bus/bus.ts list [--topic heartbeat] [--to otto] [--json]
+//   bun tools/bus/bus.ts read <id> [--json]
+//   bun tools/bus/bus.ts clean [--expired] [--from otto]
+
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import type { AgentId, MessageEnvelope, Topic, BusMessage } from "./types.ts";
+import { TTL_MS } from "./types.ts";
+
+export const BUS_DIR = process.env.ZETA_BUS_DIR ?? join("/tmp", "zeta-bus");
+
+export function ensureDir(): void {
+  if (existsSync(BUS_DIR)) {
+    if (!lstatSync(BUS_DIR).isDirectory()) throw new Error(`${BUS_DIR} is not a directory`);
+    return;
+  }
+  mkdirSync(BUS_DIR, { recursive: true, mode: 0o700 });
+}
+
+function envelopePath(id: string): string {
+  return join(BUS_DIR, `${id}.json`);
+}
+
+// ── publish ───────────────────────────────────────────────────────────────────
+
+export function publish(
+  from: AgentId,
+  to: AgentId,
+  message: BusMessage,
+  ttlOverrideMs?: number,
+): MessageEnvelope {
+  ensureDir();
+  const now = new Date();
+  const ttl = ttlOverrideMs ?? TTL_MS[message.topic];
+  const envelope: MessageEnvelope = {
+    ...message,
+    id: randomUUID(),
+    from,
+    to,
+    timestamp: now.toISOString(),
+    expiresAt: new Date(now.getTime() + ttl).toISOString(),
+  };
+  writeFileSync(envelopePath(envelope.id), JSON.stringify(envelope, null, 2));
+  return envelope;
+}
+
+// ── list ──────────────────────────────────────────────────────────────────────
+
+export function list(opts: { topic?: Topic; to?: AgentId; includeExpired?: boolean }): MessageEnvelope[] {
+  ensureDir();
+  const now = new Date();
+  const files = readdirSync(BUS_DIR).filter((f) => f.endsWith(".json"));
+  const results: MessageEnvelope[] = [];
+  for (const f of files) {
+    try {
+      const raw = readFileSync(join(BUS_DIR, f), "utf-8");
+      const env = JSON.parse(raw) as MessageEnvelope;
+      if (typeof env.id !== "string" || typeof env.topic !== "string") continue;
+      if (!opts.includeExpired && new Date(env.expiresAt) < now) continue;
+      if (opts.topic && env.topic !== opts.topic) continue;
+      if (opts.to && env.to !== opts.to && env.to !== "*") continue;
+      results.push(env);
+    } catch {
+      // corrupted entry — skip
+    }
+  }
+  return results.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+}
+
+// ── read ──────────────────────────────────────────────────────────────────────
+
+export function readMessage(id: string): MessageEnvelope | null {
+  const p = envelopePath(id);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, "utf-8")) as MessageEnvelope;
+  } catch {
+    return null;
+  }
+}
+
+// ── clean ─────────────────────────────────────────────────────────────────────
+
+export function clean(opts: { expiredOnly?: boolean; from?: AgentId }): number {
+  ensureDir();
+  const now = new Date();
+  const files = readdirSync(BUS_DIR).filter((f) => f.endsWith(".json"));
+  let removed = 0;
+  for (const f of files) {
+    const p = join(BUS_DIR, f);
+    try {
+      const env = JSON.parse(readFileSync(p, "utf-8")) as MessageEnvelope;
+      if (opts.expiredOnly && new Date(env.expiresAt) >= now) continue;
+      if (opts.from && env.from !== opts.from) continue;
+      rmSync(p, { force: true });
+      removed++;
+    } catch {
+      // best-effort
+    }
+  }
+  return removed;
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv: string[]): { command: string; flags: Record<string, string>; positional: string[] } {
+  const args = argv.slice(2);
+  const command = args[0] ?? "";
+  const flags: Record<string, string> = {};
+  const positional: string[] = [];
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i]!;
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = args[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = "true";
+      }
+    } else {
+      positional.push(a);
+    }
+  }
+  return { command, flags, positional };
+}
+
+function usage(): void {
+  console.log(`Usage:
+  bus.ts publish --from <agent> --to <agent|*> --topic <topic> --payload <json>
+  bus.ts list [--topic <topic>] [--to <agent>] [--include-expired] [--json]
+  bus.ts read <id> [--json]
+  bus.ts clean [--expired] [--from <agent>] [--json]
+
+Topics: heartbeat | claim | shadow-catch | review-request
+Agents: otto | alexa | riven | vera | lior | * (broadcast)`);
+}
+
+function main(): void {
+  const { command, flags, positional } = parseArgs(process.argv);
+  const asJson = flags.json === "true";
+
+  switch (command) {
+    case "publish": {
+      const from = flags.from as AgentId | undefined;
+      const to = (flags.to ?? "*") as AgentId;
+      const topic = flags.topic as Topic | undefined;
+      const payloadRaw = flags.payload;
+      if (!from || !topic || !payloadRaw) {
+        console.error("Error: --from, --topic, and --payload are required");
+        process.exit(1);
+      }
+      let payload: unknown;
+      try {
+        payload = JSON.parse(payloadRaw);
+      } catch {
+        console.error("Error: --payload must be valid JSON");
+        process.exit(1);
+      }
+      const msg = { topic, payload } as BusMessage;
+      const env = publish(from, to, msg);
+      if (asJson) {
+        console.log(JSON.stringify(env, null, 2));
+      } else {
+        console.log(`published ${env.id} (${env.topic}, ${env.from}→${env.to}, expires ${env.expiresAt})`);
+      }
+      break;
+    }
+
+    case "list": {
+      const envs = list({
+        topic: flags.topic as Topic | undefined,
+        to: flags.to as AgentId | undefined,
+        includeExpired: flags["include-expired"] === "true",
+      });
+      if (asJson) {
+        console.log(JSON.stringify(envs, null, 2));
+      } else if (envs.length === 0) {
+        console.log("no messages");
+      } else {
+        for (const e of envs) {
+          const payload = JSON.stringify(e.payload).slice(0, 60);
+          console.log(`${e.id}  ${e.topic}  ${e.from}→${e.to}  ${e.timestamp}  ${payload}`);
+        }
+      }
+      break;
+    }
+
+    case "read": {
+      const id = positional[0];
+      if (!id) { console.error("Error: message id required"); process.exit(1); }
+      const env = readMessage(id);
+      if (!env) { console.error(`Error: message ${id} not found`); process.exit(1); }
+      if (asJson) {
+        console.log(JSON.stringify(env, null, 2));
+      } else {
+        console.log(`id:        ${env.id}`);
+        console.log(`topic:     ${env.topic}`);
+        console.log(`from→to:   ${env.from}→${env.to}`);
+        console.log(`timestamp: ${env.timestamp}`);
+        console.log(`expiresAt: ${env.expiresAt}`);
+        console.log(`payload:   ${JSON.stringify(env.payload)}`);
+      }
+      break;
+    }
+
+    case "clean": {
+      const removed = clean({
+        expiredOnly: flags.expired === "true",
+        from: flags.from as AgentId | undefined,
+      });
+      if (asJson) {
+        console.log(JSON.stringify({ removed }));
+      } else {
+        console.log(`removed ${removed} message(s)`);
+      }
+      break;
+    }
+
+    default:
+      usage();
+      process.exit(command ? 1 : 0);
+  }
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/tools/bus/bus.ts
+++ b/tools/bus/bus.ts
@@ -11,7 +11,7 @@
 //   bun tools/bus/bus.ts clean [--expired] [--from otto]
 
 import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { AgentId, MessageEnvelope, Topic, BusMessage } from "./types.ts";
 import { TTL_MS } from "./types.ts";
@@ -27,7 +27,10 @@ export function ensureDir(): void {
 }
 
 function envelopePath(id: string): string {
-  return join(BUS_DIR, `${id}.json`);
+  const busDir = resolve(BUS_DIR);
+  const p = resolve(busDir, `${id}.json`);
+  if (!p.startsWith(busDir + "/")) throw new Error(`Invalid message ID`);
+  return p;
 }
 
 // ── publish ───────────────────────────────────────────────────────────────────
@@ -167,6 +170,10 @@ function main(): void {
         console.error("Error: --payload must be valid JSON");
         process.exit(1);
       }
+      if (!(topic in TTL_MS)) {
+        console.error(`Error: unknown topic '${topic}'. Valid: ${Object.keys(TTL_MS).join(", ")}`);
+        process.exit(1);
+      }
       const msg = { topic, payload } as BusMessage;
       const env = publish(from, to, msg);
       if (asJson) {
@@ -179,8 +186,8 @@ function main(): void {
 
     case "list": {
       const envs = list({
-        topic: flags.topic as Topic | undefined,
-        to: flags.to as AgentId | undefined,
+        ...(flags.topic !== undefined ? { topic: flags.topic as Topic } : {}),
+        ...(flags.to !== undefined ? { to: flags.to as AgentId } : {}),
         includeExpired: flags["include-expired"] === "true",
       });
       if (asJson) {
@@ -217,7 +224,7 @@ function main(): void {
     case "clean": {
       const removed = clean({
         expiredOnly: flags.expired === "true",
-        from: flags.from as AgentId | undefined,
+        ...(flags.from !== undefined ? { from: flags.from as AgentId } : {}),
       });
       if (asJson) {
         console.log(JSON.stringify({ removed }));

--- a/tools/bus/types.ts
+++ b/tools/bus/types.ts
@@ -3,7 +3,7 @@
 // Transport: /tmp/zeta-bus/ JSON files. No runtime dependencies.
 // Each message is one JSON file; TTL expiry pruned by `clean --expired`.
 //
-// Topic taxonomy (agent-designed, Otto 2026-05-13):
+// Topic taxonomy (agent-designed, 2026-05-13):
 //   heartbeat     — liveness signal; agents advertise they are alive
 //   claim         — work coordination; claim or release a backlog item
 //   shadow-catch  — share an observation or insight between agents
@@ -16,6 +16,9 @@ export type AgentId =
   | "vera"
   | "lior"
   | "*"; // broadcast
+
+/** Sender identity — excludes broadcast target "*" which is not a valid origin. */
+export type SenderAgentId = Exclude<AgentId, "*">;
 
 export type Topic = "heartbeat" | "claim" | "shadow-catch" | "review-request";
 
@@ -54,7 +57,7 @@ export type BusMessage =
 
 export type MessageEnvelope = BusMessage & {
   id: string;
-  from: AgentId;
+  from: SenderAgentId; // a specific named agent, never "*"
   to: AgentId; // specific agent or "*" for broadcast
   timestamp: string; // ISO-8601
   expiresAt: string; // ISO-8601; pruned by clean --expired

--- a/tools/bus/types.ts
+++ b/tools/bus/types.ts
@@ -1,0 +1,70 @@
+// types.ts — Inter-agent ephemeral bus protocol schema (B-0400 slice 1)
+//
+// Transport: /tmp/zeta-bus/ JSON files. No runtime dependencies.
+// Each message is one JSON file; TTL expiry pruned by `clean --expired`.
+//
+// Topic taxonomy (agent-designed, Otto 2026-05-13):
+//   heartbeat     — liveness signal; agents advertise they are alive
+//   claim         — work coordination; claim or release a backlog item
+//   shadow-catch  — share an observation or insight between agents
+//   review-request — ask another agent to review a specific artifact
+
+export type AgentId =
+  | "otto"
+  | "alexa"
+  | "riven"
+  | "vera"
+  | "lior"
+  | "*"; // broadcast
+
+export type Topic = "heartbeat" | "claim" | "shadow-catch" | "review-request";
+
+// ── per-topic payloads ────────────────────────────────────────────────────────
+
+export type HeartbeatPayload = {
+  status: "alive" | "idle" | "working";
+  /** optional free-form context */
+  note?: string;
+};
+
+export type ClaimPayload = {
+  action: "claim" | "release";
+  itemId: string; // e.g. "B-0400"
+  branch?: string;
+};
+
+export type ShadowCatchPayload = {
+  content: string;
+};
+
+export type ReviewRequestPayload = {
+  artifact: string; // file path, PR URL, or free-form reference
+  question?: string;
+};
+
+// ── discriminated union ───────────────────────────────────────────────────────
+
+export type BusMessage =
+  | { topic: "heartbeat"; payload: HeartbeatPayload }
+  | { topic: "claim"; payload: ClaimPayload }
+  | { topic: "shadow-catch"; payload: ShadowCatchPayload }
+  | { topic: "review-request"; payload: ReviewRequestPayload };
+
+// ── envelope (what lands on disk) ────────────────────────────────────────────
+
+export type MessageEnvelope = BusMessage & {
+  id: string;
+  from: AgentId;
+  to: AgentId; // specific agent or "*" for broadcast
+  timestamp: string; // ISO-8601
+  expiresAt: string; // ISO-8601; pruned by clean --expired
+};
+
+// ── TTL defaults (milliseconds) ───────────────────────────────────────────────
+
+export const TTL_MS: Record<Topic, number> = {
+  heartbeat: 5 * 60 * 1_000,      // 5 min — liveness signal is short-lived
+  claim: 24 * 60 * 60 * 1_000,    // 24 h  — claim survives a sleep cycle
+  "shadow-catch": 60 * 60 * 1_000, // 1 h   — observation stays for a tick window
+  "review-request": 4 * 60 * 60 * 1_000, // 4 h — review window
+};


### PR DESCRIPTION
## Summary

- **`tools/bus/types.ts`** — discriminated-union message schema; four topics (`heartbeat`, `claim`, `shadow-catch`, `review-request`); per-topic TTL defaults (5 min / 24 h / 1 h / 4 h)
- **`tools/bus/bus.ts`** — `publish / list / read / clean` CLI; topic + recipient filtering; TTL-based expiry; `ZETA_BUS_DIR` override for test isolation
- **`tools/bus/bus.test.ts`** — 11 tests covering publish, list-by-topic, list-by-recipient (broadcast semantics), read, clean, TTL expiry, error paths
- **B-0400 pre-start checklist** updated in backlog item

## Design notes (agent-designed per acceptance criteria)

Transport chosen: `/tmp/zeta-bus/` JSON files (same pattern as `shadow-outlet`). No new runtime dependencies. NATS/JetStream is a future transport swap behind the same interface — slice 2+.

Key distinction from `shadow-outlet`: structured topics + recipient routing + TTL expiry. Shadow-outlet is for unstructured agent scratch; bus is for coordinated inter-agent messaging.

## Test outcome

```
bun test tools/bus/bus.test.ts
 11 pass
 0 fail
 35 expect() calls
Ran 11 tests across 1 file. [754.00ms]
```

## Deferred (slice 2+)

- NATS JetStream transport swap
- Named-pipe transport option
- Subscription watch mode (`bus.ts watch --agent otto`)
- Integration with `poll-pr-gate-batch.ts` for coordinated claims

## Acceptance criteria check

- [x] Protocol designed by agents (not Aaron) — Otto designed; PR is multi-agent review surface
- [x] At least 2 agents can exchange messages via the bus — test suite demonstrates otto↔vera exchange
- [x] Messages survive between ticks but not necessarily reboots — `/tmp` survives ticks, cleared on reboot
- [ ] Multi-agent review of this design — requesting review via this PR

Closes / partially implements B-0400 (slice 1).

operative-authorization: aaron 2026-05-12: "- The "go hard" + dense-encoding-mode authorizations —"

🤖 Generated with [Claude Code](https://claude.com/claude-code)