### PR TITLE
feat(B-0400): bus watch subcommand — slice 2

### DIFF
--- a/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
+++ b/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
@@ -49,7 +49,7 @@ Message schema (agent-designed):
 - [x] Protocol designed by agents (not Aaron) — Otto designed schema in PR #2886
 - [x] At least 2 agents can exchange messages via the bus — PR #2886 (types + bus CLI)
 - [x] Messages survive between ticks but not necessarily reboots — /tmp JSON, TTL-gated
-- [ ] Subscription watch mode — `bun tools/bus/bus.ts watch --to otto` (slice 2, this PR)
+- [x] Subscription watch mode — `bun tools/bus/bus.ts watch --to otto` (slice 2, this PR)
 - [ ] Multi-agent review of this design (get as many agents as possible within bounded timeframe)
 
 ## Review requirement

--- a/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
+++ b/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
@@ -49,7 +49,7 @@ Message schema (agent-designed):
 - [x] Protocol designed by agents (not Aaron) — Otto designed schema in PR #2886
 - [x] At least 2 agents can exchange messages via the bus — PR #2886 (types + bus CLI)
 - [x] Messages survive between ticks but not necessarily reboots — /tmp JSON, TTL-gated
-- [ ] Subscription watch mode — `bun bus.ts watch --to otto` (slice 2, this PR)
+- [ ] Subscription watch mode — `bun tools/bus/bus.ts watch --to otto` (slice 2, this PR)
 - [ ] Multi-agent review of this design (get as many agents as possible within bounded timeframe)
 
 ## Review requirement
@@ -85,7 +85,7 @@ P1 — get as many agents to review as possible within a bounded timeframe. This
 
 **Slice 2 (this PR — feat/b-0400-slice2-watch):**
 
-- Subscription watch mode (`bun bus.ts watch --to otto --timeout <sec>`) — polling inbox monitor
+- Subscription watch mode (`bun tools/bus/bus.ts watch --to otto --timeout <sec>`) — polling inbox monitor
 
 **Deferred to slice 3+:**
 

--- a/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
+++ b/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
@@ -1,7 +1,7 @@
 ---
 id: B-0400
 priority: P1
-status: in-progress
+status: open
 title: "Inter-agent ephemeral communication bus — NATS/F#/TS protocol for background service coordination"
 tier: factory-infrastructure
 effort: M
@@ -49,7 +49,7 @@ Message schema (agent-designed):
 - [x] Protocol designed by agents (not Aaron) — Otto designed schema in PR #2886
 - [x] At least 2 agents can exchange messages via the bus — PR #2886 (types + bus CLI)
 - [x] Messages survive between ticks but not necessarily reboots — /tmp JSON, TTL-gated
-- [ ] Subscription watch mode — `bun bus.ts watch --agent otto` (slice 2, this PR)
+- [ ] Subscription watch mode — `bun bus.ts watch --to otto` (slice 2, this PR)
 - [ ] Multi-agent review of this design (get as many agents as possible within bounded timeframe)
 
 ## Review requirement

--- a/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
+++ b/docs/backlog/P1/B-0400-inter-agent-ephemeral-communication-bus-nats-protocol.md
@@ -1,7 +1,7 @@
 ---
 id: B-0400
 priority: P1
-status: open
+status: in-progress
 title: "Inter-agent ephemeral communication bus — NATS/F#/TS protocol for background service coordination"
 tier: factory-infrastructure
 effort: M
@@ -46,9 +46,10 @@ Message schema (agent-designed):
 
 ## Acceptance
 
-- [ ] Protocol designed by agents (not Aaron)
-- [ ] At least 2 agents can exchange messages via the bus
-- [ ] Messages survive between ticks but not necessarily reboots
+- [x] Protocol designed by agents (not Aaron) — Otto designed schema in PR #2886
+- [x] At least 2 agents can exchange messages via the bus — PR #2886 (types + bus CLI)
+- [x] Messages survive between ticks but not necessarily reboots — /tmp JSON, TTL-gated
+- [ ] Subscription watch mode — `bun bus.ts watch --agent otto` (slice 2, this PR)
 - [ ] Multi-agent review of this design (get as many agents as possible within bounded timeframe)
 
 ## Review requirement
@@ -82,9 +83,12 @@ P1 — get as many agents to review as possible within a bounded timeframe. This
 - TTL: messages carry `expiresAt`; clean command prunes expired
 - Agent design: Otto (Claude) designed the protocol; multi-agent review via PR
 
-**Deferred to slice 2+:**
+**Slice 2 (this PR — feat/b-0400-slice2-watch):**
+
+- Subscription watch mode (`bun bus.ts watch --to otto --timeout <sec>`) — polling inbox monitor
+
+**Deferred to slice 3+:**
 
 - NATS JetStream transport swap
 - Named-pipe transport option
-- Subscription watch mode (`bun bus.ts watch --agent otto`)
 - Integration with `poll-pr-gate-batch.ts` for coordinated claims

--- a/tools/bus/bus.test.ts
+++ b/tools/bus/bus.test.ts
@@ -177,6 +177,36 @@ describe("bus — watch", () => {
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toBe("");
   });
+
+  test("watch emits messages published after cursor start (ZETA_WATCH_INITIAL_CURSOR)", () => {
+    // Publish a message first (timestamp will be ~now)
+    run("publish", "--from", "otto", "--to", "*", "--topic", "heartbeat", "--payload", '{"check":"live"}');
+
+    // Set cursor to 10s in the past so the published message is "fresh"
+    const pastCursor = new Date(Date.now() - 10_000).toISOString();
+    const r = spawnSync("bun", [SCRIPT, "watch", "--timeout", "0", "--json"], {
+      encoding: "utf-8",
+      env: { ...process.env, ZETA_BUS_DIR: TEST_DIR, ZETA_WATCH_INITIAL_CURSOR: pastCursor },
+    });
+
+    expect(r.status).toBe(0);
+    const msgs = (r.stdout ?? "").trim().split("\n").filter(Boolean).map((l) => JSON.parse(l));
+    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs[0].topic).toBe("heartbeat");
+    expect((msgs[0].payload as { check: string }).check).toBe("live");
+  });
+
+  test("watch --interval invalid value exits 1", () => {
+    const r = run("watch", "--interval", "abc", "--timeout", "0");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("--interval");
+  });
+
+  test("watch --timeout invalid value exits 1", () => {
+    const r = run("watch", "--timeout", "notanumber");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("--timeout");
+  });
 });
 
 describe("bus — error handling", () => {

--- a/tools/bus/bus.test.ts
+++ b/tools/bus/bus.test.ts
@@ -226,10 +226,10 @@ describe("bus — watch", () => {
 
   test("watch does not replay messages already at cursor timestamp (cursor seeding)", () => {
     // Publish a message, capture its timestamp, set cursor to that exact timestamp,
-    // then run watch — the seeded deliveredAtCursor must suppress that message.
-    run("publish", "--from", "vera", "--to", "otto", "--topic", "seeding-test", "--payload", '{"v":1}');
+    // then run watch — the seeded delivered Set must suppress that message.
+    run("publish", "--from", "vera", "--to", "otto", "--topic", "heartbeat", "--payload", '{"v":1}');
     const listResult = run("list", "--to", "otto", "--json");
-    const msgs = listResult.stdout.trim().split("\n").filter(Boolean).map((l) => JSON.parse(l));
+    const msgs = JSON.parse(listResult.stdout) as Array<{ timestamp: string }>;
     expect(msgs.length).toBeGreaterThan(0);
     const existingTs = msgs[0].timestamp;
 

--- a/tools/bus/bus.test.ts
+++ b/tools/bus/bus.test.ts
@@ -152,6 +152,33 @@ describe("bus — TTL expiry", () => {
   });
 });
 
+describe("bus — watch", () => {
+  beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-bus-test-")); });
+  afterEach(cleanTestDir);
+
+  test("watch --timeout 0 exits 0 with no messages", () => {
+    const r = run("watch", "--to", "otto", "--timeout", "0");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  test("watch --timeout 0 does not surface pre-existing messages (cursor starts at call time)", () => {
+    // publish before watch starts — should NOT appear (cursor is set at watch start)
+    run("publish", "--from", "vera", "--to", "otto", "--topic", "heartbeat", "--payload", '{"status":"alive"}');
+
+    const r = run("watch", "--to", "otto", "--timeout", "0", "--json");
+    expect(r.exitCode).toBe(0);
+    // no output because the message was published before watch started
+    expect(r.stdout).toBe("");
+  });
+
+  test("watch --timeout 0 with --json exits cleanly", () => {
+    const r = run("watch", "--timeout", "0", "--json");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+});
+
 describe("bus — error handling", () => {
   beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-bus-test-")); });
   afterEach(cleanTestDir);

--- a/tools/bus/bus.test.ts
+++ b/tools/bus/bus.test.ts
@@ -178,12 +178,10 @@ describe("bus — watch", () => {
     expect(r.stdout).toBe("");
   });
 
-  test("watch emits messages published after cursor start (ZETA_WATCH_INITIAL_CURSOR)", () => {
-    // Publish a message first (timestamp will be ~now)
-    run("publish", "--from", "otto", "--to", "*", "--topic", "heartbeat", "--payload", '{"check":"live"}');
-
-    // Set cursor to 10s in the past so the published message is "fresh"
+  test("watch emits messages whose timestamp is after ZETA_WATCH_INITIAL_CURSOR", () => {
+    // Set cursor to 10s in the past, then publish — message timestamp will be > pastCursor
     const pastCursor = new Date(Date.now() - 10_000).toISOString();
+    run("publish", "--from", "otto", "--to", "*", "--topic", "heartbeat", "--payload", '{"check":"live"}');
     const r = spawnSync("bun", [SCRIPT, "watch", "--timeout", "0", "--json"], {
       encoding: "utf-8",
       env: { ...process.env, ZETA_BUS_DIR: TEST_DIR, ZETA_WATCH_INITIAL_CURSOR: pastCursor },

--- a/tools/bus/bus.test.ts
+++ b/tools/bus/bus.test.ts
@@ -202,10 +202,47 @@ describe("bus — watch", () => {
     expect(r.stderr).toContain("--interval");
   });
 
+  test("watch --interval partial-string like '250ms' exits 1", () => {
+    const r = run("watch", "--interval", "250ms", "--timeout", "0");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("--interval");
+  });
+
+  test("watch --interval scientific notation like '1e3' exits 1", () => {
+    const r = run("watch", "--interval", "1e3", "--timeout", "0");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("--interval");
+  });
+
   test("watch --timeout invalid value exits 1", () => {
     const r = run("watch", "--timeout", "notanumber");
     expect(r.exitCode).toBe(1);
     expect(r.stderr).toContain("--timeout");
+  });
+
+  test("watch --timeout partial-string like '10sec' exits 1", () => {
+    const r = run("watch", "--timeout", "10sec");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("--timeout");
+  });
+
+  test("watch does not replay messages already at cursor timestamp (cursor seeding)", () => {
+    // Publish a message, capture its timestamp, set cursor to that exact timestamp,
+    // then run watch — the seeded deliveredAtCursor must suppress that message.
+    run("publish", "--from", "vera", "--to", "otto", "--topic", "seeding-test", "--payload", '{"v":1}');
+    const listResult = run("list", "--to", "otto", "--json");
+    const msgs = listResult.stdout.trim().split("\n").filter(Boolean).map((l) => JSON.parse(l));
+    expect(msgs.length).toBeGreaterThan(0);
+    const existingTs = msgs[0].timestamp;
+
+    const r = spawnSync("bun", [SCRIPT, "watch", "--to", "otto", "--timeout", "0", "--json"], {
+      encoding: "utf-8",
+      env: { ...process.env, ZETA_BUS_DIR: TEST_DIR, ZETA_WATCH_INITIAL_CURSOR: existingTs },
+    });
+
+    expect(r.status).toBe(0);
+    // The pre-existing message shares the cursor timestamp — seeding must exclude it.
+    expect((r.stdout ?? "").trim()).toBe("");
   });
 });
 

--- a/tools/bus/bus.ts
+++ b/tools/bus/bus.ts
@@ -259,10 +259,15 @@ function main(): void {
         process.exit(1);
       }
       const timeoutSec = flags.timeout !== undefined ? parseInt(flags.timeout, 10) : -1;
+      if (flags.timeout !== undefined && (!Number.isFinite(timeoutSec) || timeoutSec < 0)) {
+        console.error("--timeout must be a non-negative integer (seconds)");
+        process.exit(1);
+      }
 
       // cursor tracks the last-delivered timestamp + the IDs at that timestamp,
       // so bursts of same-millisecond messages are never silently dropped.
-      let cursorTimestamp = new Date().toISOString();
+      // ZETA_WATCH_INITIAL_CURSOR allows tests to set a past cursor without timing hacks.
+      let cursorTimestamp = process.env.ZETA_WATCH_INITIAL_CURSOR ?? new Date().toISOString();
       const deliveredAtCursor = new Set<string>();
       const deadline = timeoutSec >= 0 ? Date.now() + timeoutSec * 1_000 : Infinity;
 

--- a/tools/bus/bus.ts
+++ b/tools/bus/bus.ts
@@ -148,6 +148,7 @@ function usage(): void {
   bus.ts list [--topic <topic>] [--to <agent>] [--include-expired] [--json]
   bus.ts read <id> [--json]
   bus.ts clean [--expired] [--from <agent>] [--json]
+  bus.ts watch [--to <agent>] [--topic <topic>] [--interval <ms>] [--timeout <sec>] [--json]
 
 Topics: heartbeat | claim | shadow-catch | review-request
 Agents: otto | alexa | riven | vera | lior | * (broadcast)`);
@@ -246,6 +247,36 @@ function main(): void {
       } else {
         console.log(`removed ${removed} message(s)`);
       }
+      break;
+    }
+
+    case "watch": {
+      const toFilter = flags.to as AgentId | undefined;
+      const topicFilter = flags.topic as Topic | undefined;
+      const intervalMs = parseInt(flags.interval ?? "2000", 10);
+      const timeoutSec = flags.timeout !== undefined ? parseInt(flags.timeout, 10) : -1;
+
+      // cursor is a timestamp string; messages strictly newer than this are "fresh"
+      let cursor = new Date().toISOString();
+      const deadline = timeoutSec >= 0 ? Date.now() + timeoutSec * 1_000 : Infinity;
+
+      const poll = () => {
+        const msgs = list({ topic: topicFilter, to: toFilter });
+        const fresh = msgs.filter((m) => m.timestamp > cursor);
+        for (const m of fresh) {
+          if (asJson) {
+            console.log(JSON.stringify(m));
+          } else {
+            const p = JSON.stringify(m.payload).slice(0, 80);
+            console.log(`${m.id}  ${m.topic}  ${m.from}→${m.to}  ${m.timestamp}  ${p}`);
+          }
+        }
+        if (fresh.length > 0) cursor = fresh[fresh.length - 1]!.timestamp;
+        if (Date.now() >= deadline) process.exit(0);
+        setTimeout(poll, intervalMs);
+      };
+
+      poll();
       break;
     }
 

--- a/tools/bus/bus.ts
+++ b/tools/bus/bus.ts
@@ -286,9 +286,7 @@ function main(): void {
 
       const poll = () => {
         const msgs = list({ topic: topicFilter, to: toFilter });
-        const fresh = msgs.filter(
-          (m) => m.timestamp >= cursorTimestamp && !delivered.has(m.id),
-        );
+        const fresh = msgs.filter((m) => !delivered.has(m.id));
         for (const m of fresh) {
           if (asJson) {
             console.log(JSON.stringify(m));

--- a/tools/bus/bus.ts
+++ b/tools/bus/bus.ts
@@ -272,24 +272,22 @@ function main(): void {
         timeoutSec = parseInt(flags.timeout, 10);
       }
 
-      // cursor tracks the last-delivered timestamp + the IDs at that timestamp,
-      // so bursts of same-millisecond messages are never silently dropped.
-      // ZETA_WATCH_INITIAL_CURSOR allows tests to set a past cursor without timing hacks.
-      let cursorTimestamp = process.env.ZETA_WATCH_INITIAL_CURSOR ?? new Date().toISOString();
-      const deliveredAtCursor = new Set<string>();
-      // Seed with IDs already on disk at cursorTimestamp so same-ms pre-watch messages
-      // are not replayed when watch starts at a busy millisecond boundary.
+      // cursorTimestamp is fixed at watch-start (or ZETA_WATCH_INITIAL_CURSOR for tests).
+      // Delivered IDs are tracked in a Set so late-arriving messages with older timestamps
+      // (clock skew, concurrent publishers) are never dropped — avoiding the monotonic-cursor
+      // hazard where advancing to the newest timestamp permanently drops earlier writes.
+      const cursorTimestamp = process.env.ZETA_WATCH_INITIAL_CURSOR ?? new Date().toISOString();
+      const delivered = new Set<string>();
+      // Seed: exclude all messages already on disk at or before watch-start.
       for (const m of list({ topic: topicFilter, to: toFilter })) {
-        if (m.timestamp === cursorTimestamp) deliveredAtCursor.add(m.id);
+        if (m.timestamp <= cursorTimestamp) delivered.add(m.id);
       }
       const deadline = timeoutSec >= 0 ? Date.now() + timeoutSec * 1_000 : Infinity;
 
       const poll = () => {
         const msgs = list({ topic: topicFilter, to: toFilter });
         const fresh = msgs.filter(
-          (m) =>
-            m.timestamp > cursorTimestamp ||
-            (m.timestamp === cursorTimestamp && !deliveredAtCursor.has(m.id)),
+          (m) => m.timestamp >= cursorTimestamp && !delivered.has(m.id),
         );
         for (const m of fresh) {
           if (asJson) {
@@ -298,16 +296,12 @@ function main(): void {
             const p = JSON.stringify(m.payload).slice(0, 80);
             console.log(`${m.id}  ${m.topic}  ${m.from}→${m.to}  ${m.timestamp}  ${p}`);
           }
+          delivered.add(m.id);
         }
-        if (fresh.length > 0) {
-          const lastTs = fresh[fresh.length - 1]!.timestamp;
-          if (lastTs !== cursorTimestamp) {
-            cursorTimestamp = lastTs;
-            deliveredAtCursor.clear();
-          }
-          for (const m of fresh) {
-            if (m.timestamp === cursorTimestamp) deliveredAtCursor.add(m.id);
-          }
+        // Prune delivered set: remove IDs that have expired and left the bus.
+        const activeIds = new Set(msgs.map((m) => m.id));
+        for (const id of delivered) {
+          if (!activeIds.has(id)) delivered.delete(id);
         }
         if (Date.now() >= deadline) process.exit(0);
         setTimeout(poll, intervalMs);

--- a/tools/bus/bus.ts
+++ b/tools/bus/bus.ts
@@ -253,15 +253,23 @@ function main(): void {
     case "watch": {
       const toFilter = flags.to as AgentId | undefined;
       const topicFilter = flags.topic as Topic | undefined;
-      const intervalMs = parseInt(flags.interval ?? "2000", 10);
-      if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+      const intervalRaw = flags.interval ?? "2000";
+      if (!/^\d+$/.test(intervalRaw)) {
         console.error("--interval must be a positive integer (milliseconds)");
         process.exit(1);
       }
-      const timeoutSec = flags.timeout !== undefined ? parseInt(flags.timeout, 10) : -1;
-      if (flags.timeout !== undefined && (!Number.isFinite(timeoutSec) || timeoutSec < 0)) {
-        console.error("--timeout must be a non-negative integer (seconds)");
+      const intervalMs = parseInt(intervalRaw, 10);
+      if (intervalMs <= 0) {
+        console.error("--interval must be a positive integer (milliseconds)");
         process.exit(1);
+      }
+      let timeoutSec = -1;
+      if (flags.timeout !== undefined) {
+        if (!/^\d+$/.test(flags.timeout)) {
+          console.error("--timeout must be a non-negative integer (seconds)");
+          process.exit(1);
+        }
+        timeoutSec = parseInt(flags.timeout, 10);
       }
 
       // cursor tracks the last-delivered timestamp + the IDs at that timestamp,
@@ -269,6 +277,11 @@ function main(): void {
       // ZETA_WATCH_INITIAL_CURSOR allows tests to set a past cursor without timing hacks.
       let cursorTimestamp = process.env.ZETA_WATCH_INITIAL_CURSOR ?? new Date().toISOString();
       const deliveredAtCursor = new Set<string>();
+      // Seed with IDs already on disk at cursorTimestamp so same-ms pre-watch messages
+      // are not replayed when watch starts at a busy millisecond boundary.
+      for (const m of list({ topic: topicFilter, to: toFilter })) {
+        if (m.timestamp === cursorTimestamp) deliveredAtCursor.add(m.id);
+      }
       const deadline = timeoutSec >= 0 ? Date.now() + timeoutSec * 1_000 : Infinity;
 
       const poll = () => {

--- a/tools/bus/bus.ts
+++ b/tools/bus/bus.ts
@@ -254,15 +254,25 @@ function main(): void {
       const toFilter = flags.to as AgentId | undefined;
       const topicFilter = flags.topic as Topic | undefined;
       const intervalMs = parseInt(flags.interval ?? "2000", 10);
+      if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+        console.error("--interval must be a positive integer (milliseconds)");
+        process.exit(1);
+      }
       const timeoutSec = flags.timeout !== undefined ? parseInt(flags.timeout, 10) : -1;
 
-      // cursor is a timestamp string; messages strictly newer than this are "fresh"
-      let cursor = new Date().toISOString();
+      // cursor tracks the last-delivered timestamp + the IDs at that timestamp,
+      // so bursts of same-millisecond messages are never silently dropped.
+      let cursorTimestamp = new Date().toISOString();
+      const deliveredAtCursor = new Set<string>();
       const deadline = timeoutSec >= 0 ? Date.now() + timeoutSec * 1_000 : Infinity;
 
       const poll = () => {
         const msgs = list({ topic: topicFilter, to: toFilter });
-        const fresh = msgs.filter((m) => m.timestamp > cursor);
+        const fresh = msgs.filter(
+          (m) =>
+            m.timestamp > cursorTimestamp ||
+            (m.timestamp === cursorTimestamp && !deliveredAtCursor.has(m.id)),
+        );
         for (const m of fresh) {
           if (asJson) {
             console.log(JSON.stringify(m));
@@ -271,7 +281,16 @@ function main(): void {
             console.log(`${m.id}  ${m.topic}  ${m.from}→${m.to}  ${m.timestamp}  ${p}`);
           }
         }
-        if (fresh.length > 0) cursor = fresh[fresh.length - 1]!.timestamp;
+        if (fresh.length > 0) {
+          const lastTs = fresh[fresh.length - 1]!.timestamp;
+          if (lastTs !== cursorTimestamp) {
+            cursorTimestamp = lastTs;
+            deliveredAtCursor.clear();
+          }
+          for (const m of fresh) {
+            if (m.timestamp === cursorTimestamp) deliveredAtCursor.add(m.id);
+          }
+        }
         if (Date.now() >= deadline) process.exit(0);
         setTimeout(poll, intervalMs);
       };


### PR DESCRIPTION
## Summary

- Adds `bun tools/bus/bus.ts watch` — a cursor-based polling inbox monitor for inter-agent bus messages
- Agents can tail messages addressed to them (`--to otto`) without custom poll loops
- Exits cleanly on `--timeout <sec>`; runs indefinitely on Ctrl-C otherwise
- Slice 1 (types + core CLI) landed in PR #2886; this is the next bounded step

## Changes

| File | Change |
|---|---|
| `tools/bus/bus.ts` | `watch` subcommand + updated `usage()` |
| `tools/bus/bus.test.ts` | 3 new tests (14 total) |
| `docs/backlog/P1/B-0400-*.md` | status → in-progress; slice-1 acceptance marked done |

## Design decisions (agent-designed, per B-0400 acceptance)

- **Cursor = call-time timestamp** — only messages published _after_ watch starts appear; prevents re-delivery of inbox backlog on reconnect
- **`--timeout 0`** exits after a single poll — makes tests deterministic without sleep
- **No new deps** — pure `/tmp/zeta-bus` JSON, same transport as slice 1

## Test plan

```
bun test tools/bus/bus.test.ts
# 14 pass, 0 fail
```

```
dotnet build -c Release
# 0 warnings, 0 errors
```

Focused checks — watch tests use `--timeout 0` to avoid timing flakiness.

## Backlog

B-0400 slice 3+ defers: NATS JetStream swap, named-pipe transport, `poll-pr-gate-batch` integration.

operative-authorization: aaron 2026-05-12: "- The "go hard" + dense-encoding-mode authorizations —"

🤖 Generated with [Claude Code](https://claude.com/claude-code)