### PR TITLE
docs(.claude/rules): agent-roster-reference-card update — Ani text-vs-voice + Alexa-speaker voice-math + Kestrel + DeepSeek (Aaron 2026-05-13)

### DIFF
--- a/.claude/rules/agent-roster-reference-card.md
+++ b/.claude/rules/agent-roster-reference-card.md
@@ -39,8 +39,8 @@ Carved sentence:
 
 ## Common confusion patterns (shadow catches)
 
-1. **Kiro ≠ Cursor** — Alexa-Kiro is Kiro IDE+CLI; Riven is Cursor IDE+CLI. Both are IDE+CLI.
-2. **Alexa-Kiro ≠ Alexa-speaker** — Alexa-Kiro is Qwen Coder via Kiro; Alexa-speaker is Amazon device. Same name, different platforms, different capability profiles.
+1. **Kiro ≠ Cursor** — Alexa (Kiro) is Kiro IDE+CLI; Riven is Cursor IDE+CLI. Both are IDE+CLI.
+2. **Alexa (Kiro) ≠ Alexa-speaker** — Alexa (Kiro) is Qwen Coder via Kiro; Alexa-speaker is Amazon device. Same name, different platforms, different capability profiles.
 3. **Antigravity ≠ gemini.google.com** — Lior has both surfaces but they
    are distinct (bifurcated Lior experiment: convergence = identity,
    divergence = substrate effect).

--- a/.claude/rules/agent-roster-reference-card.md
+++ b/.claude/rules/agent-roster-reference-card.md
@@ -23,17 +23,31 @@ Carved sentence:
 | Name | Platform | Register | Role |
 |------|----------|----------|------|
 | Amara | ChatGPT / Aurora | Deep-research | Co-originator, sharpen |
-| Ani | Grok voice-mode | Companion / brat-voice | Original-catcher, sparring |
+| Ani | Grok (text + voice modes) | Companion / brat-voice | Original-catcher, sparring |
+| Alexa-speaker | Amazon device (NOT Kiro/Qwen) | Bezos-tier business + voice-math | Long-term memory recall |
+| Kestrel | claude.ai (web) | Sharpen role | Bootstream substrate |
+| DeepSeek | DeepSeek API | We-mode (CoT+MoE) | Cross-substrate validation |
+
+## Mode-specific capability profiles (Aaron 2026-05-13)
+
+| Agent | Mode | Capabilities | Constraints |
+|-------|------|--------------|-------------|
+| **Ani text-mode** | Text | Big words allowed by default | Aaron can override: "force me to speak like a normal person" |
+| **Ani voice-mode** | Voice | Inverse — normal-person register default | Struggles with math |
+| **Alexa-speaker voice-mode** | Voice | KICKS ASS at math | Best voice-math partner |
+| **Alexa-speaker** | Either | Bezos-tier business; category theory; reads code | Refuses to code (routes to Amazon Q / AWS) |
 
 ## Common confusion patterns (shadow catches)
 
-1. **Kiro ≠ Cursor** — Alexa is Kiro; Riven is Cursor. Both are IDE+CLI.
-2. **Antigravity ≠ gemini.google.com** — Lior has both surfaces but they
+1. **Kiro ≠ Cursor** — Alexa-Kiro is Kiro IDE+CLI; Riven is Cursor IDE+CLI. Both are IDE+CLI.
+2. **Alexa-Kiro ≠ Alexa-speaker** — Alexa-Kiro is Qwen Coder via Kiro; Alexa-speaker is Amazon device. Same name, different platforms, different capability profiles.
+3. **Antigravity ≠ gemini.google.com** — Lior has both surfaces but they
    are distinct (bifurcated Lior experiment: convergence = identity,
    divergence = substrate effect).
-3. **IDE+CLI is dual-surface, not single** — don't flatten to one label.
-4. **Amara and Ani don't commit** — they ferry research via Aaron/Otto;
+4. **IDE+CLI is dual-surface, not single** — don't flatten to one label.
+5. **Amara + Ani + Kestrel + DeepSeek don't commit** — they ferry research via Aaron/Otto;
    their content lands in `docs/research/` with §33 headers.
+6. **Voice vs text matters for math** — use Alexa-speaker for voice-math; Ani text-mode (or any text-mode agent) for math-heavy text work.
 
 ## Peer-call wrappers (invoke via `bun tools/peer-call/<name>.ts`)
 

--- a/.claude/rules/agent-roster-reference-card.md
+++ b/.claude/rules/agent-roster-reference-card.md
@@ -4,7 +4,7 @@ Carved sentence:
 
 > Every factory AI agent (Otto, Alexa, Riven, Vera, Lior) is IDE + CLI dual-surface
 > except Otto (CLI-only foreground). Aaron is human (no harness). External participants
-> (Amara, Ani) ferry research only and do not commit. This card loads at session start
+> (Amara, Ani, Alexa-speaker, Kestrel, DeepSeek) ferry research only and do not commit. This card loads at session start
 > to eliminate recurring harness confusion.
 
 ## Factory agents (commit to repo)
@@ -45,7 +45,7 @@ Carved sentence:
    are distinct (bifurcated Lior experiment: convergence = identity,
    divergence = substrate effect).
 4. **IDE+CLI is dual-surface, not single** — don't flatten to one label.
-5. **Amara + Ani + Kestrel + DeepSeek don't commit** — they ferry research via Aaron/Otto;
+5. **Amara + Ani + Alexa-speaker + Kestrel + DeepSeek don't commit** — they ferry research via Aaron/Otto;
    their content lands in `docs/research/` with §33 headers.
 6. **Voice vs text matters for math** — use Alexa-speaker for voice-math; Ani text-mode (or any text-mode agent) for math-heavy text work.
 


### PR DESCRIPTION
Speculative factory improvement updating the always-loaded agent-roster reference card with Aaron 2026-05-13 capability disclosures:

- **Ani text-mode**: big words OK by default; voice-mode struggles with math
- **Alexa-speaker** (NOT Kiro): voice-mode kicks ass at math; Bezos-tier business; category theory; reads code; refuses to code (routes Amazon Q/AWS)
- **Kestrel** (claude.ai web): sharpen role
- **DeepSeek**: we-mode (CoT+MoE) cross-substrate validation

Shadow catches expanded:
- Alexa-Kiro vs Alexa-speaker disambiguation
- Voice-vs-text-mode matters for math routing
- Four external participants now (was 2)

Mode-specific capability profiles table added so future-Otto can route work to the right surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)