### PR TITLE
feat(B-0400): inter-agent claim coordinator — slice 3

### DIFF
--- a/tools/bus/bus.ts
+++ b/tools/bus/bus.ts
@@ -14,7 +14,7 @@ import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmSync, wr
 import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { AgentId, SenderAgentId, MessageEnvelope, Topic, BusMessage } from "./types.ts";
-import { TTL_MS } from "./types.ts";
+import { TTL_MS, SENDER_IDS, AGENT_IDS } from "./types.ts";
 
 export const BUS_DIR = process.env.ZETA_BUS_DIR ?? join("/tmp", "zeta-bus");
 
@@ -154,8 +154,7 @@ Topics: heartbeat | claim | shadow-catch | review-request
 Agents: otto | alexa | riven | vera | lior | * (broadcast)`);
 }
 
-const SENDER_IDS: readonly string[] = ["otto", "alexa", "riven", "vera", "lior"];
-const AGENT_IDS: readonly string[] = [...SENDER_IDS, "*"];
+// SENDER_IDS and AGENT_IDS imported from types.ts
 
 function main(): void {
   const { command, flags, positional } = parseArgs(process.argv);

--- a/tools/bus/bus.ts
+++ b/tools/bus/bus.ts
@@ -151,7 +151,7 @@ function usage(): void {
   bus.ts watch [--to <agent>] [--topic <topic>] [--interval <ms>] [--timeout <sec>] [--json]
 
 Topics: heartbeat | claim | shadow-catch | review-request
-Agents: otto | alexa | riven | vera | lior | * (broadcast)`);
+Agents: ${SENDER_IDS.join(" | ")} | * (broadcast)`);
 }
 
 // SENDER_IDS and AGENT_IDS imported from types.ts

--- a/tools/bus/claim.test.ts
+++ b/tools/bus/claim.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync, utimesSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
@@ -259,7 +259,41 @@ describe("claim.ts — unknown action protection (P2)", () => {
   });
 });
 
-// ── P1: acquire lock cleanup ──────────────────────────────────────────────────
+// ── P2: same-timestamp mtime tiebreak ────────────────────────────────────────
+
+describe("claim.ts — same-timestamp mtime tiebreak (P2)", () => {
+  beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-claim-test-")); });
+  afterEach(cleanTestDir);
+
+  test("release with later mtime wins over claim sharing the same ISO timestamp", () => {
+    const claimId = "00000000-0000-0000-0000-aaaaaaaaaaaa";
+    const releaseId = "00000000-0000-0000-0000-bbbbbbbbbbbb";
+    const ts = new Date().toISOString();
+    const exp = new Date(Date.now() + 86_400_000).toISOString();
+    const base = new Date();
+    const laterMs = new Date(base.getTime() + 50);
+
+    writeFileSync(join(TEST_DIR, `${claimId}.json`), JSON.stringify({
+      id: claimId, from: "otto", to: "*", topic: "claim",
+      timestamp: ts, expiresAt: exp,
+      payload: { action: "claim", itemId: "B-0999" },
+    }));
+    utimesSync(join(TEST_DIR, `${claimId}.json`), base, base);
+
+    writeFileSync(join(TEST_DIR, `${releaseId}.json`), JSON.stringify({
+      id: releaseId, from: "otto", to: "*", topic: "claim",
+      timestamp: ts, expiresAt: exp,
+      payload: { action: "release", itemId: "B-0999" },
+    }));
+    utimesSync(join(TEST_DIR, `${releaseId}.json`), laterMs, laterMs);
+
+    const r = run("check", "--item", "B-0999");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("unclaimed");
+  });
+});
+
+// ── P1: acquire lock cleanup + stale lock recovery ───────────────────────────
 
 describe("claim.ts — acquire lock cleanup (P1)", () => {
   beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-claim-test-")); });

--- a/tools/bus/claim.test.ts
+++ b/tools/bus/claim.test.ts
@@ -1,0 +1,235 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+const CLAIM_SCRIPT = join(import.meta.dir, "claim.ts");
+let TEST_DIR: string;
+
+function run(...args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  const r = spawnSync("bun", [CLAIM_SCRIPT, ...args], {
+    encoding: "utf-8",
+    env: { ...process.env, ZETA_BUS_DIR: TEST_DIR },
+  });
+  return {
+    stdout: (r.stdout ?? "").trim(),
+    stderr: (r.stderr ?? "").trim(),
+    exitCode: r.status ?? 1,
+  };
+}
+
+function cleanTestDir(): void {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });
+}
+
+describe("claim.ts — check", () => {
+  beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-claim-test-")); });
+  afterEach(cleanTestDir);
+
+  test("check reports unclaimed when bus is empty", () => {
+    const r = run("check", "--item", "B-0400");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("unclaimed");
+  });
+
+  test("check --json exits 0 with claimed:false when empty", () => {
+    const r = run("check", "--item", "B-0400", "--json");
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.claimed).toBe(false);
+    expect(out.itemId).toBe("B-0400");
+    expect(out.claims).toHaveLength(0);
+  });
+
+  test("check exits 1 and reports claimant after acquire", () => {
+    run("acquire", "--from", "otto", "--item", "B-0400");
+
+    const r = run("check", "--item", "B-0400");
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toContain("claimed by otto");
+  });
+
+  test("check --json exits 1 with claimed:true after acquire", () => {
+    run("acquire", "--from", "vera", "--item", "B-0400");
+
+    const r = run("check", "--item", "B-0400", "--json");
+    expect(r.exitCode).toBe(1);
+    const out = JSON.parse(r.stdout);
+    expect(out.claimed).toBe(true);
+    expect(out.claims).toHaveLength(1);
+    expect(out.claims[0].from).toBe("vera");
+  });
+
+  test("check includes branch info when present", () => {
+    run("acquire", "--from", "otto", "--item", "B-0400", "--branch", "feat/my-branch");
+
+    const r = run("check", "--item", "B-0400");
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toContain("feat/my-branch");
+  });
+
+  test("check exits 0 after acquire + release", () => {
+    run("acquire", "--from", "otto", "--item", "B-0400");
+    run("release", "--from", "otto", "--item", "B-0400");
+
+    const r = run("check", "--item", "B-0400");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("unclaimed");
+  });
+
+  test("check --item required", () => {
+    const r = run("check");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("--item");
+  });
+});
+
+describe("claim.ts — acquire", () => {
+  beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-claim-test-")); });
+  afterEach(cleanTestDir);
+
+  test("acquire succeeds on unclaimed item", () => {
+    const r = run("acquire", "--from", "otto", "--item", "B-0123");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("claimed by otto");
+  });
+
+  test("acquire --json returns acquired:true with messageId", () => {
+    const r = run("acquire", "--from", "otto", "--item", "B-0123", "--json");
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.acquired).toBe(true);
+    expect(typeof out.messageId).toBe("string");
+  });
+
+  test("acquire fails when another agent already holds claim", () => {
+    run("acquire", "--from", "vera", "--item", "B-0123");
+
+    const r = run("acquire", "--from", "otto", "--item", "B-0123");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("already claimed");
+  });
+
+  test("acquire --json exits 1 with acquired:false when blocked", () => {
+    run("acquire", "--from", "vera", "--item", "B-0123");
+
+    const r = run("acquire", "--from", "otto", "--item", "B-0123", "--json");
+    expect(r.exitCode).toBe(1);
+    const out = JSON.parse(r.stdout);
+    expect(out.acquired).toBe(false);
+    expect(out.claimedBy).toContain("vera");
+  });
+
+  test("acquire succeeds after other agent releases", () => {
+    run("acquire", "--from", "vera", "--item", "B-0123");
+    run("release", "--from", "vera", "--item", "B-0123");
+
+    const r = run("acquire", "--from", "otto", "--item", "B-0123");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("same agent can re-acquire its own claim (idempotent)", () => {
+    run("acquire", "--from", "otto", "--item", "B-0123");
+    const r = run("acquire", "--from", "otto", "--item", "B-0123");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("acquire includes branch in output when provided", () => {
+    const r = run("acquire", "--from", "riven", "--item", "B-0500", "--branch", "feat/b-0500");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("feat/b-0500");
+  });
+
+  test("acquire with invalid sender exits 1", () => {
+    const r = run("acquire", "--from", "unknown-bot", "--item", "B-0001");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("unknown sender");
+  });
+
+  test("acquire missing --from exits 1", () => {
+    const r = run("acquire", "--item", "B-0001");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("required");
+  });
+
+  test("acquire missing --item exits 1", () => {
+    const r = run("acquire", "--from", "otto");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("required");
+  });
+});
+
+describe("claim.ts — release", () => {
+  beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-claim-test-")); });
+  afterEach(cleanTestDir);
+
+  test("release publishes successfully", () => {
+    run("acquire", "--from", "otto", "--item", "B-0400");
+    const r = run("release", "--from", "otto", "--item", "B-0400");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("released by otto");
+  });
+
+  test("release --json returns released:true with messageId", () => {
+    const r = run("release", "--from", "otto", "--item", "B-0400", "--json");
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.released).toBe(true);
+    expect(typeof out.messageId).toBe("string");
+  });
+
+  test("release without prior acquire still publishes (idempotent best-effort)", () => {
+    const r = run("release", "--from", "otto", "--item", "B-0999");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("release with invalid sender exits 1", () => {
+    const r = run("release", "--from", "bad-agent", "--item", "B-0001");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("unknown sender");
+  });
+
+  test("release missing --from exits 1", () => {
+    const r = run("release", "--item", "B-0001");
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("required");
+  });
+});
+
+describe("claim.ts — multi-item isolation", () => {
+  beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-claim-test-")); });
+  afterEach(cleanTestDir);
+
+  test("claims for different items do not interfere", () => {
+    run("acquire", "--from", "otto", "--item", "B-0001");
+    run("acquire", "--from", "vera", "--item", "B-0002");
+
+    const r1 = run("check", "--item", "B-0001");
+    expect(r1.exitCode).toBe(1);
+    expect(r1.stdout).toContain("otto");
+
+    const r2 = run("check", "--item", "B-0002");
+    expect(r2.exitCode).toBe(1);
+    expect(r2.stdout).toContain("vera");
+  });
+
+  test("check returns only claims for the queried item", () => {
+    run("acquire", "--from", "otto", "--item", "B-0001");
+    run("acquire", "--from", "vera", "--item", "B-0002");
+
+    const r = run("check", "--item", "B-0001", "--json");
+    const out = JSON.parse(r.stdout);
+    expect(out.claims.every((c: { itemId: string }) => c.itemId === "B-0001")).toBe(true);
+  });
+});
+
+describe("claim.ts — unknown command", () => {
+  beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-claim-test-")); });
+  afterEach(cleanTestDir);
+
+  test("unknown command exits 1", () => {
+    const r = run("frobulate");
+    expect(r.exitCode).toBe(1);
+  });
+});

--- a/tools/bus/claim.test.ts
+++ b/tools/bus/claim.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
@@ -274,6 +274,21 @@ describe("claim.ts — acquire lock cleanup (P1)", () => {
   test("no lock files remain after failed acquire", () => {
     run("acquire", "--from", "vera", "--item", "B-0555");
     run("acquire", "--from", "otto", "--item", "B-0555"); // blocked
+    const lockFiles = readdirSync(TEST_DIR).filter((f) => f.startsWith("acquire-"));
+    expect(lockFiles).toHaveLength(0);
+  });
+
+  test("stale lock (age > 5s) is reclaimed so acquire succeeds", () => {
+    // Simulate a lock file left by a crashed process by backdating its mtime.
+    // B-0777 → safe name is "B-0777" (hyphen preserved), so lock file is acquire-B-0777.lock.
+    const lockPath = join(TEST_DIR, "acquire-B-0777.lock");
+    const staleDate = new Date(Date.now() - 10_000); // 10s ago — beyond the 5s threshold
+    writeFileSync(lockPath, "");
+    utimesSync(lockPath, staleDate, staleDate);
+
+    const r = run("acquire", "--from", "otto", "--item", "B-0777");
+    expect(r.exitCode).toBe(0);
+    // Lock must be cleaned up after successful acquire.
     const lockFiles = readdirSync(TEST_DIR).filter((f) => f.startsWith("acquire-"));
     expect(lockFiles).toHaveLength(0);
   });

--- a/tools/bus/claim.test.ts
+++ b/tools/bus/claim.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
@@ -231,5 +231,50 @@ describe("claim.ts — unknown command", () => {
   test("unknown command exits 1", () => {
     const r = run("frobulate");
     expect(r.exitCode).toBe(1);
+  });
+});
+
+// ── P2: unknown action guard ──────────────────────────────────────────────────
+
+describe("claim.ts — unknown action protection (P2)", () => {
+  const BUS_SCRIPT = join(import.meta.dir, "bus.ts");
+
+  beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-claim-test-")); });
+  afterEach(cleanTestDir);
+
+  test("unknown action on claim topic does not clear an existing claim", () => {
+    run("acquire", "--from", "otto", "--item", "B-0300");
+
+    // Inject a message with an unknown action to simulate a buggy sender.
+    spawnSync(
+      "bun",
+      [BUS_SCRIPT, "publish", "--from", "vera", "--to", "*", "--topic", "claim",
+       "--payload", JSON.stringify({ action: "relinquish", itemId: "B-0300" })],
+      { encoding: "utf-8", env: { ...process.env, ZETA_BUS_DIR: TEST_DIR } },
+    );
+
+    const r = run("check", "--item", "B-0300");
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toContain("claimed by otto");
+  });
+});
+
+// ── P1: acquire lock cleanup ──────────────────────────────────────────────────
+
+describe("claim.ts — acquire lock cleanup (P1)", () => {
+  beforeEach(() => { TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-claim-test-")); });
+  afterEach(cleanTestDir);
+
+  test("no lock files remain in bus dir after acquire", () => {
+    run("acquire", "--from", "otto", "--item", "B-0555");
+    const lockFiles = readdirSync(TEST_DIR).filter((f) => f.startsWith("acquire-"));
+    expect(lockFiles).toHaveLength(0);
+  });
+
+  test("no lock files remain after failed acquire", () => {
+    run("acquire", "--from", "vera", "--item", "B-0555");
+    run("acquire", "--from", "otto", "--item", "B-0555"); // blocked
+    const lockFiles = readdirSync(TEST_DIR).filter((f) => f.startsWith("acquire-"));
+    expect(lockFiles).toHaveLength(0);
   });
 });

--- a/tools/bus/claim.test.ts
+++ b/tools/bus/claim.test.ts
@@ -313,11 +313,12 @@ describe("claim.ts — acquire lock cleanup (P1)", () => {
   });
 
   test("stale lock (age > 5s) is reclaimed so acquire succeeds", () => {
-    // Simulate a lock file left by a crashed process by backdating its mtime.
-    // B-0777 → safe name is "B-0777" (hyphen preserved), so lock file is acquire-B-0777.lock.
+    // Simulate a lock file left by a crashed process: backdate its mtime AND write a
+    // dead PID (0 is never a valid running process so isProcessRunning(0) = false).
+    // B-0777 → encodeURIComponent("B-0777") = "B-0777", so lock file is acquire-B-0777.lock.
     const lockPath = join(TEST_DIR, "acquire-B-0777.lock");
     const staleDate = new Date(Date.now() - 10_000); // 10s ago — beyond the 5s threshold
-    writeFileSync(lockPath, "");
+    writeFileSync(lockPath, "0");
     utimesSync(lockPath, staleDate, staleDate);
 
     const r = run("acquire", "--from", "otto", "--item", "B-0777");

--- a/tools/bus/claim.ts
+++ b/tools/bus/claim.ts
@@ -14,8 +14,33 @@
 //   acquire: 0 = claim published, 1 = already claimed (no publish)
 //   release: 0 = release published, 1 = error
 
-import { publish, list } from "./bus.ts";
+import { openSync, closeSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { publish, list, BUS_DIR, ensureDir } from "./bus.ts";
 import type { AgentId, SenderAgentId, MessageEnvelope } from "./types.ts";
+
+// Per-item advisory file lock — guards acquire's check+publish against concurrent processes.
+function lockFilePath(itemId: string): string {
+  const safe = itemId.replace(/[^a-zA-Z0-9_-]/g, "_");
+  return join(BUS_DIR, `acquire-${safe}.lock`);
+}
+
+function withAcquireLock<T>(itemId: string, fn: () => T): T {
+  ensureDir();
+  const lp = lockFilePath(itemId);
+  let fd: number | undefined;
+  // O_CREAT|O_EXCL ("wx"): atomic exclusive create — exactly one winner per race.
+  for (let i = 0; i < 3; i++) {
+    try { fd = openSync(lp, "wx"); break; } catch { /* retry */ }
+  }
+  if (fd === undefined) throw new Error(`${itemId}: acquire lock busy — retry`);
+  try {
+    return fn();
+  } finally {
+    closeSync(fd);
+    try { unlinkSync(lp); } catch { /* best-effort */ }
+  }
+}
 
 export type ClaimRecord = {
   id: string;
@@ -34,11 +59,13 @@ export type ClaimRecord = {
 export function activeClaims(itemId: string): ClaimRecord[] {
   const msgs = list({ topic: "claim" });
 
-  // Latest action wins per (from, itemId) pair.
+  // Latest action wins per (from, itemId) pair — only known actions participate
+  // so a malformed sender cannot silently clear a valid claim.
   const byKey = new Map<string, MessageEnvelope>();
   for (const m of msgs) {
     const p = m.payload as { action: string; itemId: string; branch?: string };
     if (p.itemId !== itemId) continue;
+    if (p.action !== "claim" && p.action !== "release") continue;
     const key = `${m.from}:${p.itemId}`;
     const existing = byKey.get(key);
     if (!existing || m.timestamp > existing.timestamp) {
@@ -130,25 +157,41 @@ function main(): void {
         process.exit(1);
       }
 
-      const existing = activeClaims(itemId).filter((c) => c.from !== from);
-      if (existing.length > 0) {
-        const by = existing.map((c) => c.from).join(", ");
+      const sender = from; // capture narrowed type for use inside closure
+      let acquired = false;
+      let claimedByOthers: string[] = [];
+      let messageId: string | undefined;
+
+      try {
+        ({ acquired, claimedByOthers, messageId } = withAcquireLock(itemId, () => {
+          const existing = activeClaims(itemId).filter((c) => c.from !== sender);
+          if (existing.length > 0) {
+            return { acquired: false, claimedByOthers: existing.map((c) => c.from as string), messageId: undefined };
+          }
+          const env = publish(sender, "*" as AgentId, {
+            topic: "claim",
+            payload: { action: "claim", itemId, ...(branch ? { branch } : {}) },
+          });
+          return { acquired: true, claimedByOthers: [] as string[], messageId: env.id };
+        }));
+      } catch (err) {
+        console.error(`Error: ${(err as Error).message}`);
+        process.exit(1);
+      }
+
+      if (!acquired) {
         if (asJson) {
-          console.log(JSON.stringify({ itemId, acquired: false, claimedBy: existing.map((c) => c.from) }));
+          console.log(JSON.stringify({ itemId, acquired: false, claimedBy: claimedByOthers }));
         } else {
-          console.error(`${itemId}: already claimed by ${by} — not acquiring`);
+          console.error(`${itemId}: already claimed by ${claimedByOthers.join(", ")} — not acquiring`);
         }
         process.exit(1);
       }
 
-      const env = publish(from, "*" as AgentId, {
-        topic: "claim",
-        payload: { action: "claim", itemId, ...(branch ? { branch } : {}) },
-      });
       if (asJson) {
-        console.log(JSON.stringify({ itemId, acquired: true, messageId: env.id }));
+        console.log(JSON.stringify({ itemId, acquired: true, messageId }));
       } else {
-        console.log(`${itemId}: claimed by ${from}${branch ? ` (${branch})` : ""} — ${env.id}`);
+        console.log(`${itemId}: claimed by ${sender}${branch ? ` (${branch})` : ""} — ${messageId}`);
       }
       break;
     }

--- a/tools/bus/claim.ts
+++ b/tools/bus/claim.ts
@@ -14,23 +14,31 @@
 //   acquire: 0 = claim published, 1 = already claimed (no publish)
 //   release: 0 = release published, 1 = error
 
-import { openSync, closeSync, unlinkSync, statSync } from "node:fs";
+import { openSync, closeSync, unlinkSync, statSync, writeSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { publish, list, BUS_DIR, ensureDir } from "./bus.ts";
 import { SENDER_IDS } from "./types.ts";
 import type { AgentId, SenderAgentId, MessageEnvelope } from "./types.ts";
 
-// Stale lock threshold — a lock older than this is treated as a crash remnant.
-// The critical section (list + writeFileSync) runs in <50ms on /tmp; 5s is
-// 100× that, making false-positive reclamation of an active holder extremely
-// unlikely.  Claim coordination is advisory (not a hard lock), so the rare
-// theoretical race produces a duplicate advisory claim, not data corruption.
+// Stale lock threshold — age floor before a lock is a candidate for reclamation.
+// Used together with a PID liveness check: only reclaim if the holder process is
+// dead, preventing false-positive reclamation of a slow-but-live holder.
 const LOCK_STALE_MS = 5_000;
 
+// Returns true if a process with the given PID is running (signal 0 = liveness probe).
+// EPERM means the process exists but we lack permission — still alive.
+// ESRCH means the process does not exist — dead.
+function isProcessRunning(pid: number): boolean {
+  if (isNaN(pid) || pid <= 0) return false;
+  try { process.kill(pid, 0); return true; }
+  catch (e) { return (e as NodeJS.ErrnoException).code === "EPERM"; }
+}
+
 // Per-item advisory file lock — guards acquire's check+publish against concurrent processes.
+// encodeURIComponent produces a collision-free mapping: distinct item IDs always produce
+// distinct lock paths (e.g. "A/B" → "A%2FB", "A_B" → "A_B").
 function lockFilePath(itemId: string): string {
-  const safe = itemId.replace(/[^a-zA-Z0-9_-]/g, "_");
-  return join(BUS_DIR, `acquire-${safe}.lock`);
+  return join(BUS_DIR, `acquire-${encodeURIComponent(itemId)}.lock`);
 }
 
 function withAcquireLock<T>(itemId: string, fn: () => T): T {
@@ -38,16 +46,25 @@ function withAcquireLock<T>(itemId: string, fn: () => T): T {
   const lp = lockFilePath(itemId);
   let fd: number | undefined;
   // O_CREAT|O_EXCL ("wx"): atomic exclusive create — exactly one winner per race.
-  // Between retries, check whether an existing lock is stale (mtime age > LOCK_STALE_MS);
-  // if so, delete it — the holder crashed and will never release it otherwise.
+  // Write our PID so stale-lock detection can verify the holder is still alive before
+  // reclaiming: age threshold guards against reading a newly-created empty file.
   for (let i = 0; i < 3; i++) {
-    try { fd = openSync(lp, "wx"); break; } catch {
+    try {
+      fd = openSync(lp, "wx");
+      writeSync(fd, String(process.pid));
+      break;
+    } catch (e) {
+      // Only do stale-lock recovery on EEXIST; other errors (permissions, I/O) bubble up.
+      if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
       try {
+        const content = readFileSync(lp, "utf8").trim();
+        const holderPid = parseInt(content, 10);
         const st = statSync(lp);
-        if (Date.now() - st.mtimeMs > LOCK_STALE_MS) {
+        // Reclaim only if the lock is old enough AND its holder process is dead.
+        if (Date.now() - st.mtimeMs > LOCK_STALE_MS && !isProcessRunning(holderPid)) {
           unlinkSync(lp); // reclaim stale lock left by a crashed process
         }
-      } catch { /* lock already gone between stat and unlink — harmless */ }
+      } catch { /* lock disappeared between reads — harmless */ }
     }
   }
   if (fd === undefined) throw new Error(`${itemId}: acquire lock busy — retry`);

--- a/tools/bus/claim.ts
+++ b/tools/bus/claim.ts
@@ -20,7 +20,11 @@ import { publish, list, BUS_DIR, ensureDir } from "./bus.ts";
 import { SENDER_IDS } from "./types.ts";
 import type { AgentId, SenderAgentId, MessageEnvelope } from "./types.ts";
 
-// Stale lock threshold: a lock file older than this was left by a crashed process.
+// Stale lock threshold — a lock older than this is treated as a crash remnant.
+// The critical section (list + writeFileSync) runs in <50ms on /tmp; 5s is
+// 100× that, making false-positive reclamation of an active holder extremely
+// unlikely.  Claim coordination is advisory (not a hard lock), so the rare
+// theoretical race produces a duplicate advisory claim, not data corruption.
 const LOCK_STALE_MS = 5_000;
 
 // Per-item advisory file lock — guards acquire's check+publish against concurrent processes.

--- a/tools/bus/claim.ts
+++ b/tools/bus/claim.ts
@@ -10,13 +10,14 @@
 //   bun tools/bus/claim.ts release --from otto --item B-0400 [--json]
 //
 // Exit codes:
-//   check:   0 = unclaimed, 1 = already claimed by another agent
+//   check:   0 = unclaimed, 1 = claimed (by any agent — check has no --from)
 //   acquire: 0 = claim published, 1 = already claimed (no publish)
 //   release: 0 = release published, 1 = error
 
 import { openSync, closeSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { publish, list, BUS_DIR, ensureDir } from "./bus.ts";
+import { SENDER_IDS } from "./types.ts";
 import type { AgentId, SenderAgentId, MessageEnvelope } from "./types.ts";
 
 // Per-item advisory file lock — guards acquire's check+publish against concurrent processes.
@@ -63,14 +64,18 @@ export function activeClaims(itemId: string): ClaimRecord[] {
   // so a malformed sender cannot silently clear a valid claim.
   const byKey = new Map<string, MessageEnvelope>();
   for (const m of msgs) {
+    // Guard against null/non-object payloads written by buggy senders.
+    if (!m.payload || typeof m.payload !== "object" || Array.isArray(m.payload)) continue;
     const p = m.payload as { action: string; itemId: string; branch?: string };
     if (p.itemId !== itemId) continue;
     if (p.action !== "claim" && p.action !== "release") continue;
     const key = `${m.from}:${p.itemId}`;
     const existing = byKey.get(key);
-    if (!existing || m.timestamp > existing.timestamp) {
-      byKey.set(key, m);
-    }
+    // Tiebreak equal timestamps by id (UUID lexicographic) for determinism.
+    const newer = !existing ||
+      m.timestamp > existing.timestamp ||
+      (m.timestamp === existing.timestamp && m.id > existing.id);
+    if (newer) byKey.set(key, m);
   }
 
   const records: ClaimRecord[] = [];
@@ -90,8 +95,6 @@ export function activeClaims(itemId: string): ClaimRecord[] {
 }
 
 // ── CLI ───────────────────────────────────────────────────────────────────────
-
-const SENDER_IDS: readonly string[] = ["otto", "alexa", "riven", "vera", "lior"];
 
 function parseArgs(argv: string[]): { command: string; flags: Record<string, string> } {
   const args = argv.slice(2);

--- a/tools/bus/claim.ts
+++ b/tools/bus/claim.ts
@@ -64,6 +64,13 @@ export type ClaimRecord = {
   expiresAt: string;
 };
 
+// Sub-ms tiebreaker: file mtime reflects actual write order more reliably than
+// UUID lexicographic order for messages with the same ISO timestamp string.
+function messageMtimeMs(id: string): number {
+  try { return statSync(join(BUS_DIR, `${id}.json`)).mtimeMs; }
+  catch { return 0; } // message may have expired and been cleaned
+}
+
 /**
  * Returns all active (non-expired) claim messages for a given backlog item.
  * A "claim" means action === "claim"; "release" messages with the same itemId
@@ -74,8 +81,11 @@ export function activeClaims(itemId: string): ClaimRecord[] {
 
   // Latest action wins per (from, itemId) pair — only known actions participate
   // so a malformed sender cannot silently clear a valid claim.
-  const byKey = new Map<string, MessageEnvelope>();
-  for (const m of msgs) {
+  type Entry = { envelope: MessageEnvelope; mtime: number; idx: number };
+  const byKey = new Map<string, Entry>();
+
+  for (let i = 0; i < msgs.length; i++) {
+    const m = msgs[i]!;
     // Guard against null/non-object payloads written by buggy senders.
     if (!m.payload || typeof m.payload !== "object" || Array.isArray(m.payload)) continue;
     const p = m.payload as { action: string; itemId: string; branch?: string };
@@ -83,15 +93,23 @@ export function activeClaims(itemId: string): ClaimRecord[] {
     if (p.action !== "claim" && p.action !== "release") continue;
     const key = `${m.from}:${p.itemId}`;
     const existing = byKey.get(key);
-    // Tiebreak equal timestamps by id (UUID lexicographic) for determinism.
-    const newer = !existing ||
-      m.timestamp > existing.timestamp ||
-      (m.timestamp === existing.timestamp && m.id > existing.id);
-    if (newer) byKey.set(key, m);
+    if (!existing) {
+      byKey.set(key, { envelope: m, mtime: messageMtimeMs(m.id), idx: i });
+      continue;
+    }
+    if (m.timestamp > existing.envelope.timestamp) {
+      byKey.set(key, { envelope: m, mtime: messageMtimeMs(m.id), idx: i });
+    } else if (m.timestamp === existing.envelope.timestamp) {
+      // Same ISO timestamp: use file mtime (sub-ms precision) then list index.
+      const mm = messageMtimeMs(m.id);
+      if (mm > existing.mtime || (mm === existing.mtime && i > existing.idx)) {
+        byKey.set(key, { envelope: m, mtime: mm, idx: i });
+      }
+    }
   }
 
   const records: ClaimRecord[] = [];
-  for (const m of byKey.values()) {
+  for (const { envelope: m } of byKey.values()) {
     const p = m.payload as { action: string; itemId: string; branch?: string };
     if (p.action !== "claim") continue; // release means no active claim
     records.push({

--- a/tools/bus/claim.ts
+++ b/tools/bus/claim.ts
@@ -14,11 +14,14 @@
 //   acquire: 0 = claim published, 1 = already claimed (no publish)
 //   release: 0 = release published, 1 = error
 
-import { openSync, closeSync, unlinkSync } from "node:fs";
+import { openSync, closeSync, unlinkSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { publish, list, BUS_DIR, ensureDir } from "./bus.ts";
 import { SENDER_IDS } from "./types.ts";
 import type { AgentId, SenderAgentId, MessageEnvelope } from "./types.ts";
+
+// Stale lock threshold: a lock file older than this was left by a crashed process.
+const LOCK_STALE_MS = 5_000;
 
 // Per-item advisory file lock — guards acquire's check+publish against concurrent processes.
 function lockFilePath(itemId: string): string {
@@ -31,8 +34,17 @@ function withAcquireLock<T>(itemId: string, fn: () => T): T {
   const lp = lockFilePath(itemId);
   let fd: number | undefined;
   // O_CREAT|O_EXCL ("wx"): atomic exclusive create — exactly one winner per race.
+  // Between retries, check whether an existing lock is stale (mtime age > LOCK_STALE_MS);
+  // if so, delete it — the holder crashed and will never release it otherwise.
   for (let i = 0; i < 3; i++) {
-    try { fd = openSync(lp, "wx"); break; } catch { /* retry */ }
+    try { fd = openSync(lp, "wx"); break; } catch {
+      try {
+        const st = statSync(lp);
+        if (Date.now() - st.mtimeMs > LOCK_STALE_MS) {
+          unlinkSync(lp); // reclaim stale lock left by a crashed process
+        }
+      } catch { /* lock already gone between stat and unlink — harmless */ }
+    }
   }
   if (fd === undefined) throw new Error(`${itemId}: acquire lock busy — retry`);
   try {

--- a/tools/bus/claim.ts
+++ b/tools/bus/claim.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env bun
+// claim.ts — Claim-coordination helper for the inter-agent bus (B-0400 slice 3)
+//
+// Wraps the `claim` topic into three typed commands so agents can coordinate
+// ownership of backlog items without writing ad-hoc publish calls.
+//
+// Usage:
+//   bun tools/bus/claim.ts check   --item B-0400 [--json]
+//   bun tools/bus/claim.ts acquire --from otto --item B-0400 [--branch feat/x] [--json]
+//   bun tools/bus/claim.ts release --from otto --item B-0400 [--json]
+//
+// Exit codes:
+//   check:   0 = unclaimed, 1 = already claimed by another agent
+//   acquire: 0 = claim published, 1 = already claimed (no publish)
+//   release: 0 = release published, 1 = error
+
+import { publish, list } from "./bus.ts";
+import type { AgentId, SenderAgentId, MessageEnvelope } from "./types.ts";
+
+export type ClaimRecord = {
+  id: string;
+  from: SenderAgentId;
+  itemId: string;
+  branch?: string;
+  timestamp: string;
+  expiresAt: string;
+};
+
+/**
+ * Returns all active (non-expired) claim messages for a given backlog item.
+ * A "claim" means action === "claim"; "release" messages with the same itemId
+ * cancel the claim — so we filter to the latest action per sender.
+ */
+export function activeClaims(itemId: string): ClaimRecord[] {
+  const msgs = list({ topic: "claim" });
+
+  // Latest action wins per (from, itemId) pair.
+  const byKey = new Map<string, MessageEnvelope>();
+  for (const m of msgs) {
+    const p = m.payload as { action: string; itemId: string; branch?: string };
+    if (p.itemId !== itemId) continue;
+    const key = `${m.from}:${p.itemId}`;
+    const existing = byKey.get(key);
+    if (!existing || m.timestamp > existing.timestamp) {
+      byKey.set(key, m);
+    }
+  }
+
+  const records: ClaimRecord[] = [];
+  for (const m of byKey.values()) {
+    const p = m.payload as { action: string; itemId: string; branch?: string };
+    if (p.action !== "claim") continue; // release means no active claim
+    records.push({
+      id: m.id,
+      from: m.from,
+      itemId: p.itemId,
+      branch: p.branch,
+      timestamp: m.timestamp,
+      expiresAt: m.expiresAt,
+    });
+  }
+  return records;
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+const SENDER_IDS: readonly string[] = ["otto", "alexa", "riven", "vera", "lior"];
+
+function parseArgs(argv: string[]): { command: string; flags: Record<string, string> } {
+  const args = argv.slice(2);
+  const command = args[0] ?? "";
+  const flags: Record<string, string> = {};
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i]!;
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = args[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = "true";
+      }
+    }
+  }
+  return { command, flags };
+}
+
+function usage(): void {
+  console.log(`Usage:
+  claim.ts check   --item <id> [--json]
+  claim.ts acquire --from <agent> --item <id> [--branch <branch>] [--json]
+  claim.ts release --from <agent> --item <id> [--json]
+
+Agents: ${SENDER_IDS.join(" | ")}`);
+}
+
+function main(): void {
+  const { command, flags } = parseArgs(process.argv);
+  const asJson = flags.json === "true";
+
+  switch (command) {
+    case "check": {
+      const itemId = flags.item;
+      if (!itemId) { console.error("Error: --item is required"); process.exit(1); }
+
+      const claims = activeClaims(itemId);
+      if (asJson) {
+        console.log(JSON.stringify({ itemId, claims, claimed: claims.length > 0 }));
+      } else if (claims.length === 0) {
+        console.log(`${itemId}: unclaimed`);
+      } else {
+        for (const c of claims) {
+          console.log(`${itemId}: claimed by ${c.from}${c.branch ? ` (${c.branch})` : ""} since ${c.timestamp}`);
+        }
+      }
+      process.exit(claims.length > 0 ? 1 : 0);
+    }
+
+    case "acquire": {
+      const from = flags.from as SenderAgentId | undefined;
+      const itemId = flags.item;
+      const branch = flags.branch;
+      if (!from || !itemId) {
+        console.error("Error: --from and --item are required");
+        process.exit(1);
+      }
+      if (!SENDER_IDS.includes(from)) {
+        console.error(`Error: unknown sender '${from}'. Valid: ${SENDER_IDS.join(", ")}`);
+        process.exit(1);
+      }
+
+      const existing = activeClaims(itemId).filter((c) => c.from !== from);
+      if (existing.length > 0) {
+        const by = existing.map((c) => c.from).join(", ");
+        if (asJson) {
+          console.log(JSON.stringify({ itemId, acquired: false, claimedBy: existing.map((c) => c.from) }));
+        } else {
+          console.error(`${itemId}: already claimed by ${by} — not acquiring`);
+        }
+        process.exit(1);
+      }
+
+      const env = publish(from, "*" as AgentId, {
+        topic: "claim",
+        payload: { action: "claim", itemId, ...(branch ? { branch } : {}) },
+      });
+      if (asJson) {
+        console.log(JSON.stringify({ itemId, acquired: true, messageId: env.id }));
+      } else {
+        console.log(`${itemId}: claimed by ${from}${branch ? ` (${branch})` : ""} — ${env.id}`);
+      }
+      break;
+    }
+
+    case "release": {
+      const from = flags.from as SenderAgentId | undefined;
+      const itemId = flags.item;
+      if (!from || !itemId) {
+        console.error("Error: --from and --item are required");
+        process.exit(1);
+      }
+      if (!SENDER_IDS.includes(from)) {
+        console.error(`Error: unknown sender '${from}'. Valid: ${SENDER_IDS.join(", ")}`);
+        process.exit(1);
+      }
+
+      const env = publish(from, "*" as AgentId, {
+        topic: "claim",
+        payload: { action: "release", itemId },
+      });
+      if (asJson) {
+        console.log(JSON.stringify({ itemId, released: true, messageId: env.id }));
+      } else {
+        console.log(`${itemId}: released by ${from} — ${env.id}`);
+      }
+      break;
+    }
+
+    default:
+      usage();
+      process.exit(command ? 1 : 0);
+  }
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/tools/bus/types.ts
+++ b/tools/bus/types.ts
@@ -63,6 +63,11 @@ export type MessageEnvelope = BusMessage & {
   expiresAt: string; // ISO-8601; pruned by clean --expired
 };
 
+// ── canonical agent lists (single source of truth for both CLIs) ─────────────
+
+export const SENDER_IDS: readonly SenderAgentId[] = ["otto", "alexa", "riven", "vera", "lior"];
+export const AGENT_IDS: readonly AgentId[] = [...SENDER_IDS, "*"];
+
 // ── TTL defaults (milliseconds) ───────────────────────────────────────────────
 
 export const TTL_MS: Record<Topic, number> = {


### PR DESCRIPTION
## Summary

Slice 3 of B-0400 — adds \`tools/bus/claim.ts\`, a typed claim-coordination
helper that wraps the bus \`claim\` topic into three commands:

| Command | Purpose | Exit code |
|---------|---------|-----------| 
| \`check  --item <id>\` | Query active claims | 0 = unclaimed, 1 = claimed |
| \`acquire --from <agent> --item <id> [--branch <branch>]\` | Atomic check + publish | 0 = acquired, 1 = blocked |
| \`release --from <agent> --item <id>\` | Publish release | 0 = released, 1 = validation error |

**Latest-action-wins semantics** per \`(sender, itemId)\` pair: a \`release\`
message from the same agent cancels a prior \`claim\`. Same agent can
re-acquire its own claim (idempotent). All commands support \`--json\`.

No new runtime dependencies — reuses \`/tmp/zeta-bus/\` transport from
slice 1.

## Test results

\`\`\`
bun test tools/bus/claim.test.ts   →  30 pass, 0 fail
bun test tools/bus/bus.test.ts     →  21 pass, 0 fail (no regressions)
\`\`\`

30 tests covering: check when empty, check after claim, check after
release, acquire success, acquire blocked by other agent, acquire same-
agent idempotent, acquire-then-release then re-acquire, invalid sender,
missing flags, multi-item isolation, \`--json\` mode on all paths,
unknown action guard (P2), same-timestamp mtime tiebreak (P2), acquire
lock cleanup + stale lock recovery (P1).

## B-0400 acceptance criteria progress

- [x] Protocol designed by agents (not Aaron) — Otto designed schema in PR #2886
- [x] At least 2 agents can exchange messages via the bus — PR #2886
- [x] Messages survive between ticks but not necessarily reboots — /tmp JSON, TTL-gated
- [x] Subscription watch mode — PR #2899 (slice 2)
- [x] **Claim coordination helper — this PR (slice 3)**
- [ ] Multi-agent review of this design

## Multi-agent review request

This is factory infrastructure that all named entities will use. Per B-0400
review requirement: **Alexa (Kiro), Riven, Vera, Lior** — please review the
claim coordination design. Key questions:

1. Does latest-action-wins per \`(sender, itemId)\` give enough conflict
   resolution, or do we need vector clocks?
2. Should \`acquire\` auto-release when the 24h TTL expires, or is that
   sufficient via the clean command?
3. Is there a race between \`check\` and \`publish\` in \`acquire\` that matters
   in practice? (Best-effort advisory coordination — not a hard lock.)

## Deferred to slice 4+

- NATS JetStream transport swap
- Named-pipe transport option
- \`poll-pr-gate-batch.ts\` integration for coordinated PR claims

operative-authorization: aaron 2026-05-12: "- The \"go hard\" + dense-encoding-mode authorizations —"

🤖 Generated with [Claude Code](https://claude.com/claude-code)