### PR TITLE
fix(tsc): exactOptionalPropertyTypes — bus.ts/claim.ts/bus.test.ts

### DIFF
--- a/tools/bus/bus.test.ts
+++ b/tools/bus/bus.test.ts
@@ -231,7 +231,7 @@ describe("bus — watch", () => {
     const listResult = run("list", "--to", "otto", "--json");
     const msgs = JSON.parse(listResult.stdout) as Array<{ timestamp: string }>;
     expect(msgs.length).toBeGreaterThan(0);
-    const existingTs = msgs[0].timestamp;
+    const existingTs = msgs[0]!.timestamp;
 
     const r = spawnSync("bun", [SCRIPT, "watch", "--to", "otto", "--timeout", "0", "--json"], {
       encoding: "utf-8",

--- a/tools/bus/bus.ts
+++ b/tools/bus/bus.ts
@@ -283,14 +283,18 @@ function main(): void {
       // hazard where advancing to the newest timestamp permanently drops earlier writes.
       const cursorTimestamp = process.env.ZETA_WATCH_INITIAL_CURSOR ?? new Date().toISOString();
       const delivered = new Set<string>();
+      const listOpts = {
+        ...(topicFilter !== undefined && { topic: topicFilter }),
+        ...(toFilter !== undefined && { to: toFilter }),
+      };
       // Seed: exclude all messages already on disk at or before watch-start.
-      for (const m of list({ topic: topicFilter, to: toFilter })) {
+      for (const m of list(listOpts)) {
         if (m.timestamp <= cursorTimestamp) delivered.add(m.id);
       }
       const deadline = timeoutSec >= 0 ? Date.now() + timeoutSec * 1_000 : Infinity;
 
       const poll = () => {
-        const msgs = list({ topic: topicFilter, to: toFilter });
+        const msgs = list(listOpts);
         const fresh = msgs.filter((m) => !delivered.has(m.id));
         for (const m of fresh) {
           if (asJson) {

--- a/tools/bus/claim.ts
+++ b/tools/bus/claim.ts
@@ -137,7 +137,7 @@ export function activeClaims(itemId: string): ClaimRecord[] {
       id: m.id,
       from: m.from,
       itemId: p.itemId,
-      branch: p.branch,
+      ...(p.branch !== undefined && { branch: p.branch }),
       timestamp: m.timestamp,
       expiresAt: m.expiresAt,
     });


### PR DESCRIPTION
## Summary

- `bus.ts`: Replace two identical `list({ topic: topicFilter, to: toFilter })` calls (where both args are `T | undefined`) with a shared `listOpts` object built via conditional spread — omits the property entirely when undefined, satisfying `exactOptionalPropertyTypes: true`
- `claim.ts`: Conditional spread for optional `branch` field in `ClaimRecord` push — property is omitted when `p.branch` is undefined
- `bus.test.ts`: Non-null assertion on `msgs[0]` guarded by the preceding `expect(msgs.length).toBeGreaterThan(0)`

These were pre-existing non-required `lint (tsc tools)` failures firing on every PR since the `exactOptionalPropertyTypes: true` tsconfig flag rejects `T | undefined` being passed to an optional `T?` parameter.

## Test plan
- [x] `bun --bun tsc --noEmit -p tsconfig.json` → 0 errors (verified locally)
- [x] `dotnet build -c Release` → 0 warnings, 0 errors (no .NET changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>