### PR TITLE
feat(B-0402): shadow observer slice 2 — --detect-cmd external detector, 27 tests pass

### DIFF
--- a/docs/backlog/P0/B-0402-zeta-shadow-mode-first-class-cli-autocomplete.md
+++ b/docs/backlog/P0/B-0402-zeta-shadow-mode-first-class-cli-autocomplete.md
@@ -67,10 +67,11 @@ metrics — a collaborative intelligence surface.
 
 - [ ] `zeta shadow` command starts shadow auto-accept mode
 - [x] Configurable delay (default 3s) — `--delay <ms>` flag, validated (slice 1)
-- [ ] Human keystroke overrides at any moment — slice 2 (requires empirical grey-text detection)
+- [x] External detector plug-in — `--detect-cmd <cmd>` wires any shell command as detector (slice 2)
+- [ ] Human keystroke overrides at any moment — slice 3 (requires empirical grey-text detection)
 - [x] All shadow submissions logged with `(shadow)` attribution — Glass Halo log via `appendFileSync` (slice 1)
-- [ ] Optional `--loop` embeds autonomous loop — slice 3 (requires `zeta` CLI entry point)
-- [ ] Deployable as part of Zeta CLI install — slice 3
+- [ ] Optional `--loop` embeds autonomous loop — slice 4 (requires `zeta` CLI entry point)
+- [ ] Deployable as part of Zeta CLI install — slice 4
 
 ## Pre-start checklist (backlog-item start gate — 2026-05-13)
 
@@ -99,7 +100,21 @@ metrics — a collaborative intelligence surface.
   - Validate numeric flags; exit 1 on invalid
 - Add `tools/shadow/shadow-observer.test.ts`: 16 tests, 0 failures
 
+**Slice 2 scope (this PR — feat/b-0402-shadow-observer-slice-2-detect-cmd):**
+
+- Add `detectCmd?: string` to `ShadowConfig`
+- Implement `detectViaCommand(cmd: string): Promise<string | null>` (exported):
+  - Runs `sh -c <cmd>` via `Bun.spawn`
+  - Exit 0 + stdout → return trimmed stdout
+  - Exit 0 + empty stdout → return `"(detected)"` sentinel (supports `true`/no-output scripts)
+  - Exit non-0 → return `null` (no suggestion)
+- Add `--detect-cmd <cmd>` CLI flag; wires into `run()` as the live `detectFn`
+- Update usage comment in file header
+- 11 new tests (27 total, 0 failures):
+  - 6 `detectViaCommand` unit tests
+  - 5 `--detect-cmd` CLI integration tests
+
 **Deferred:**
 
-- Slice 2: empirical grey text detection (AppleScript/accessibility API testing on macOS)
-- Slice 3: `zeta shadow` top-level CLI entry point + installation wiring
+- Slice 3: empirical grey-text detection via AppleScript/accessibility API (macOS)
+- Slice 4: `zeta shadow` top-level CLI entry point + installation wiring

--- a/tools/shadow/shadow-observer.test.ts
+++ b/tools/shadow/shadow-observer.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
-import { runOneCycle, log } from "./shadow-observer.ts";
+import { runOneCycle, log, detectViaCommand } from "./shadow-observer.ts";
 import type { ShadowConfig, ShadowEvent } from "./shadow-observer.ts";
 
 const SCRIPT = join(import.meta.dir, "shadow-observer.ts");
@@ -204,5 +204,115 @@ describe("shadow-observer — log() unit", () => {
       dryRun: true,
     };
     expect(() => log(event, "/dev/null/nonexistent/path")).not.toThrow();
+  });
+});
+
+describe("shadow-observer — detectViaCommand unit (slice 2)", () => {
+  test("returns trimmed stdout when command exits 0 with text", async () => {
+    const result = await detectViaCommand("echo suggestion");
+    expect(result).toBe("suggestion");
+  });
+
+  test("returns null when command exits non-0 (false)", async () => {
+    const result = await detectViaCommand("false");
+    expect(result).toBeNull();
+  });
+
+  test("returns '(detected)' sentinel when command exits 0 with empty stdout", async () => {
+    const result = await detectViaCommand("true");
+    expect(result).toBe("(detected)");
+  });
+
+  test("returns null when command exits 1 with output (exit code wins)", async () => {
+    const result = await detectViaCommand("sh -c 'echo text; exit 1'");
+    expect(result).toBeNull();
+  });
+
+  test("returns multi-word trimmed stdout for compound echo", async () => {
+    const result = await detectViaCommand("echo hello world");
+    expect(result).toBe("hello world");
+  });
+
+  test("returns null when shell exits 127 (command not found inside sh)", async () => {
+    // sh -c wraps the cmd; unknown command → sh exits 127 (≠ 0) → null
+    const result = await detectViaCommand("this-command-absolutely-does-not-exist-zeta-test");
+    expect(result).toBeNull();
+  });
+});
+
+describe("shadow-observer — --detect-cmd CLI integration (slice 2)", () => {
+  let TEST_DIR: string;
+  beforeEach(() => {
+    TEST_DIR = mkdtempSync(join(tmpdir(), "zeta-shadow-detect-cmd-test-"));
+  });
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  const SCRIPT = join(import.meta.dir, "shadow-observer.ts");
+
+  function run2(...args: string[]): { stdout: string; stderr: string; exitCode: number } {
+    const r = spawnSync("bun", [SCRIPT, ...args, "--log-file", join(TEST_DIR, "shadow.log")], {
+      encoding: "utf-8",
+    });
+    return {
+      stdout: (r.stdout ?? "").trim(),
+      stderr: (r.stderr ?? "").trim(),
+      exitCode: r.status ?? 1,
+    };
+  }
+
+  function readLog2(): ShadowEvent[] {
+    const p = join(TEST_DIR, "shadow.log");
+    if (!existsSync(p)) return [];
+    return readFileSync(p, "utf-8")
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as ShadowEvent);
+  }
+
+  test("--detect-cmd 'echo suggestion' --dry-run --once logs detected + accepted", () => {
+    const r = run2("--detect-cmd", "echo suggestion", "--dry-run", "--once", "--delay", "0");
+    expect(r.exitCode).toBe(0);
+    const events = readLog2();
+    const types = events.map((e) => e.type);
+    expect(types).toContain("detected");
+    expect(types).toContain("accepted");
+  });
+
+  test("--detect-cmd 'echo suggestion' detected event has suggestion as content", () => {
+    run2("--detect-cmd", "echo suggestion", "--dry-run", "--once", "--delay", "0");
+    const events = readLog2();
+    const detected = events.find((e) => e.type === "detected");
+    expect(detected?.content).toBe("suggestion");
+  });
+
+  test("--detect-cmd 'false' --dry-run --once logs no-suggestion", () => {
+    run2("--detect-cmd", "false", "--dry-run", "--once");
+    const events = readLog2();
+    const types = events.map((e) => e.type);
+    expect(types).toContain("no-suggestion");
+    expect(types).not.toContain("accepted");
+  });
+
+  test("--detect-cmd 'true' --dry-run --once detects sentinel string", () => {
+    run2("--detect-cmd", "true", "--dry-run", "--once", "--delay", "0");
+    const events = readLog2();
+    const detected = events.find((e) => e.type === "detected");
+    expect(detected?.content).toBe("(detected)");
+  });
+
+  test("--detect-cmd does not override explicit detectFn in unit tests", async () => {
+    // When detectFn is passed explicitly to runOneCycle, it wins over detectCmd.
+    const baseConfig: ShadowConfig = {
+      delayMs: 0,
+      detectCmd: "echo should-not-appear",
+      dryRun: true,
+      logFile: "/dev/null",
+      loopIntervalMs: 0,
+      once: true,
+    };
+    const result = await runOneCycle(baseConfig, async () => null);
+    expect(result).toBe("no-suggestion");
   });
 });

--- a/tools/shadow/shadow-observer.ts
+++ b/tools/shadow/shadow-observer.ts
@@ -6,8 +6,8 @@
  * and auto-accepts after a configurable delay if no human keystroke
  * interrupts.
  *
- * Slice 1 (this file): polling loop infrastructure + testable dry-run mode.
- * Slice 2 (deferred): empirical grey text detection via AppleScript/accessibility.
+ * Slice 1 (PR #2973): polling loop infrastructure + testable dry-run mode.
+ * Slice 2 (this PR): --detect-cmd flag wires any shell command as the detector.
  * Slice 3 (deferred): `zeta shadow` top-level CLI entry point + installation.
  *
  * The Lost analogy: Desmond pushed the button every 108 minutes.
@@ -20,11 +20,14 @@
  * - --dry-run: logs intended actions without sending keystrokes
  *
  * Usage:
- *   bun tools/shadow/shadow-observer.ts [--delay <ms>] [--dry-run] [--once]
- *     [--loop-interval <ms>] [--log-file <path>]
+ *   bun tools/shadow/shadow-observer.ts [--delay <ms>] [--detect-cmd <cmd>]
+ *     [--dry-run] [--once] [--loop-interval <ms>] [--log-file <path>]
  *
  * Flags:
  *   --delay <ms>          Delay before auto-accepting (default: 3000)
+ *   --detect-cmd <cmd>    Shell command run each cycle to detect grey text.
+ *                         Exit 0 = suggestion present (stdout is content).
+ *                         Exit non-0 = no suggestion. Default: built-in stub.
  *   --dry-run             Log intended actions without sending keystrokes
  *   --once                Run exactly one detection cycle then exit
  *   --loop-interval <ms>  Continuous mode: sleep between cycles (default: 1000)
@@ -36,6 +39,7 @@ import { parseArgs } from "util";
 
 export interface ShadowConfig {
   delayMs: number;
+  detectCmd?: string;
   dryRun: boolean;
   logFile: string;
   loopIntervalMs: number;
@@ -74,6 +78,30 @@ export async function detectGreyText(): Promise<string | null> {
   //
   // Until empirically validated, returns null (no detection).
   return null;
+}
+
+/**
+ * Detect grey text via an external shell command (slice 2).
+ *
+ * The command is run as a subprocess. Contract:
+ *   - Exit 0: suggestion present. Stdout (trimmed) is the content.
+ *     Empty stdout → returns the sentinel "(detected)" so callers
+ *     see a non-null truthy string (e.g. `true` or a no-output AppleScript).
+ *   - Exit non-0: no suggestion → returns null.
+ *
+ * On spawn error (e.g. command not found) the promise rejects; the
+ * caller's try/catch (runOneCycle) handles it as "error".
+ */
+export async function detectViaCommand(cmd: string): Promise<string | null> {
+  const proc = Bun.spawn(["sh", "-c", cmd], {
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) return null;
+  const raw = await new Response(proc.stdout).text();
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : "(detected)";
 }
 
 export async function acceptGreyText(config: ShadowConfig): Promise<boolean> {
@@ -211,7 +239,9 @@ export async function runOneCycle(
 
 export async function run(
   config: ShadowConfig,
-  detectFn: DetectFn = detectGreyText,
+  detectFn: DetectFn = config.detectCmd
+    ? () => detectViaCommand(config.detectCmd!)
+    : detectGreyText,
   acceptFn: AcceptFn = acceptGreyText,
 ): Promise<void> {
   log(
@@ -242,6 +272,7 @@ function parseConfig(argv: string[]): ShadowConfig {
     args: argv,
     options: {
       delay: { type: "string", default: "3000" },
+      "detect-cmd": { type: "string" },
       "dry-run": { type: "boolean", default: false },
       once: { type: "boolean", default: false },
       "loop-interval": { type: "string", default: "1000" },
@@ -262,13 +293,15 @@ function parseConfig(argv: string[]): ShadowConfig {
     process.exit(1);
   }
 
-  return {
+  const base = {
     delayMs,
     dryRun: values["dry-run"] ?? false,
     once: values.once ?? false,
     loopIntervalMs,
     logFile: values["log-file"] ?? "tools/shadow/shadow-observer.log",
   };
+  const detectCmd = values["detect-cmd"];
+  return detectCmd !== undefined ? { ...base, detectCmd } : base;
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
## Summary

- Adds `--detect-cmd <shell cmd>` flag so any shell command can serve as the grey-text detector (bridges CLI→injection gap)
- Implements and exports `detectViaCommand(cmd)`: exit 0 → non-null result (trimmed stdout or `"(detected)"` sentinel); exit non-0 → null
- `ShadowConfig.detectCmd?: string` added with `exactOptionalPropertyTypes`-safe conditional spread
- Backlog acceptance row checked; slice numbering updated (slice 3 = AppleScript/empirical, slice 4 = CLI entry)

## What changed

| File | Change |
|------|--------|
| `tools/shadow/shadow-observer.ts` | +`detectViaCommand`, `--detect-cmd` flag, `ShadowConfig.detectCmd` field |
| `tools/shadow/shadow-observer.test.ts` | +11 tests (6 unit + 5 CLI integration) |
| `docs/backlog/P0/B-0402-*.md` | Acceptance criteria updated; slice 2 scope documented |

## Test plan

```
bun test tools/shadow/shadow-observer.test.ts
# → 27 pass, 0 fail
```

- [x] 27 tests pass (was 16 before this slice)
- [x] `bun run typecheck` — 0 errors (exactOptionalPropertyTypes handled)
- [x] Smoke test: `bun tools/shadow/shadow-observer.ts --detect-cmd "echo hello-shadow" --dry-run --once --delay 0`
  → `detected` event with content `"hello-shadow"` → `accepted` event
- [x] No-detection path: `--detect-cmd "false"` → `no-suggestion` event only

## Depends on

- B-0400 (bus protocol) — closed PR #2973 (slice 1)

## Glass Halo

All shadow submissions log `(shadow)` attribution via `appendFileSync`. The `--detect-cmd` flag is the first real-world wiring into this log — any AppleScript/OCR detector can now plug in via one CLI flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)