### PR TITLE
chore(backlog): close B-0431 — slice-3 shipped in #2983, all criteria verified

### DIFF
--- a/docs/backlog/P0/B-0431-shadow-observer-slice-3-macos-grey-text-detection-osascript-2026-05-13.md
+++ b/docs/backlog/P0/B-0431-shadow-observer-slice-3-macos-grey-text-detection-osascript-2026-05-13.md
@@ -1,7 +1,7 @@
 ---
 id: B-0431
 priority: P0
-status: open
+status: done
 title: "Shadow observer slice 3 — macOS grey-text detection via osascript"
 tier: product-feature
 effort: S
@@ -86,13 +86,17 @@ detector. This slice adds the built-in macOS implementation that fires when no
 
 ## Acceptance
 
-- [ ] `detectGreyTextMacOS()` exported from `tools/shadow/shadow-observer.ts`
-- [ ] Non-macOS guard logs warning and returns `null` without crashing
-- [ ] `detect-grey-text.applescript` present in `tools/shadow/`
-- [ ] Built-in `detectGreyText()` calls `detectGreyTextMacOS()` (stub replaced)
-- [ ] 12 new tests, 0 failures (`bun test tools/shadow/shadow-observer.test.ts`)
-- [ ] "Human keystroke overrides at any moment" B-0402 acceptance criterion satisfied
+- [x] `detectGreyTextMacOS()` exported from `tools/shadow/shadow-observer.ts`
+- [x] Non-macOS guard logs warning and returns `null` without crashing
+- [x] `detect-grey-text.applescript` present in `tools/shadow/`
+- [x] Built-in `detectGreyText()` calls `detectGreyTextMacOS()` (stub replaced)
+- [x] 12 new tests, 0 failures (`bun test tools/shadow/shadow-observer.test.ts`) — 39 total pass
+- [x] "Human keystroke overrides at any moment" B-0402 acceptance criterion satisfied
   (the re-detect path returns `"overridden"` when suggestion disappears during delay)
+
+## Shipped
+
+PR #2983 — merged 2026-05-13. All acceptance criteria verified post-merge.
 
 ## Pre-start checklist
 

--- a/docs/backlog/P0/B-0431-shadow-observer-slice-3-macos-grey-text-detection-osascript-2026-05-13.md
+++ b/docs/backlog/P0/B-0431-shadow-observer-slice-3-macos-grey-text-detection-osascript-2026-05-13.md
@@ -1,7 +1,7 @@
 ---
 id: B-0431
 priority: P0
-status: done
+status: closed
 title: "Shadow observer slice 3 — macOS grey-text detection via osascript"
 tier: product-feature
 effort: S

--- a/docs/hygiene-history/ticks/2026/05/13/1103Z.md
+++ b/docs/hygiene-history/ticks/2026/05/13/1103Z.md
@@ -1,6 +1,6 @@
 ---
 tick: 2026-05-13T11:03Z
-agent: Otto
+agent: otto
 worktree: moonlit-coalescing-spindle
 branch: chore/b-0431-close-backlog-item
 operative-authorization: aaron 2026-05-13: "Cooling period: TBD. The memory file IS the durable record"

--- a/docs/hygiene-history/ticks/2026/05/13/1103Z.md
+++ b/docs/hygiene-history/ticks/2026/05/13/1103Z.md
@@ -1,0 +1,32 @@
+---
+tick: 2026-05-13T11:03Z
+agent: Otto
+worktree: moonlit-coalescing-spindle
+branch: chore/b-0431-close-backlog-item
+operative-authorization: aaron 2026-05-13: "Cooling period: TBD. The memory file IS the durable record"
+---
+
+# Tick 2026-05-13T11:03Z — B-0431 close-out
+
+## Work done
+
+B-0431 (Shadow observer slice 3 — macOS grey-text detection via osascript) was already
+fully shipped in PR #2983 (merged 2026-05-13T10:56Z). This tick:
+
+1. Confirmed all 39 tests pass, 0 failures:
+   `bun test tools/shadow/shadow-observer.test.ts` → 39 pass / 0 fail
+2. Verified all 6 acceptance criteria met in the implementation
+3. Updated `docs/backlog/P0/B-0431-*.md`: status open → done, criteria checked, Shipped section added
+
+## Verify trace
+
+- `bun test tools/shadow/shadow-observer.test.ts` → 39 pass / 0 fail ✓
+- `detectGreyTextMacOS` exported from `shadow-observer.ts` ✓
+- `detect-grey-text.applescript` present in `tools/shadow/` ✓
+- `detectGreyText()` delegates to `detectGreyTextMacOS()` (stub replaced) ✓
+- Non-darwin guard: returns null + logs warning ✓
+- Re-detect override path: returns "overridden" when suggestion disappears ✓
+
+## PR opened
+
+Close-out PR: `chore/b-0431-close-backlog-item` → marks backlog item done


### PR DESCRIPTION
## Summary

- B-0431 (Shadow observer slice 3 — macOS grey-text detection via osascript) was fully implemented and merged in PR #2983 (2026-05-13T10:56Z)
- This PR closes the backlog item: sets `status: open` → `done`, checks all 6 acceptance criteria, and adds the Shipped section
- Adds tick shard at `docs/hygiene-history/ticks/2026/05/13/1103Z.md`

## Test plan

- [x] `bun test tools/shadow/shadow-observer.test.ts` → **39 pass / 0 fail** (verified in this session)
- [x] `detectGreyTextMacOS()` exported from `tools/shadow/shadow-observer.ts`
- [x] `detect-grey-text.applescript` present in `tools/shadow/`
- [x] `detectGreyText()` delegates to `detectGreyTextMacOS()` (stub replaced)
- [x] Non-darwin guard returns `null` + logs warning (covered by unit test)
- [x] Re-detect override path returns `"overridden"` when suggestion disappears (covered by slice-3 cycle tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)