### PR TITLE
feat(shadow): B-0433 slice 5 — zeta-shadow bin entry + README + smoke tests

### DIFF
--- a/docs/backlog/P1/B-0433-shadow-observer-slice-5-zeta-cli-distribution-demo-packaging-2026-05-13.md
+++ b/docs/backlog/P1/B-0433-shadow-observer-slice-5-zeta-cli-distribution-demo-packaging-2026-05-13.md
@@ -1,7 +1,7 @@
 ---
 id: B-0433
 priority: P1
-status: open
+status: in-progress
 title: "Shadow observer slice 5 — Zeta CLI distribution + demo packaging"
 tier: product-feature
 effort: XS
@@ -86,11 +86,11 @@ Invoke from `bun test` via `smoke-test.test.ts` (or add as a `scripts` entry).
 
 ## Acceptance
 
-- [ ] `package.json` `bin["zeta-shadow"]` entry present and points to valid file
-- [ ] `tools/shadow/README.md` has `## Shadow mode` section with flags + Glass Halo note
-- [ ] End-to-end smoke test passes (`bun test tools/shadow/smoke-test.test.ts`)
-- [ ] 3 new tests, 0 failures
-- [ ] "Deployable as part of Zeta CLI install" B-0402 criterion satisfied
+- [x] `package.json` `bin["zeta-shadow"]` entry present and points to valid file
+- [x] `tools/shadow/README.md` has `## Shadow mode` section with flags + Glass Halo note
+- [x] End-to-end smoke test passes (`bun test tools/shadow/smoke-test.test.ts`)
+- [x] 3 new tests, 0 failures
+- [x] "Deployable as part of Zeta CLI install" B-0402 criterion satisfied
 
 ## Pre-start checklist
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "hygiene:fix-markdown": "bun ./tools/hygiene/fix-markdown-md032-md026.ts",
     "shadow": "bun tools/shadow/shadow-observer.ts"
   },
+  "bin": {
+    "zeta-shadow": "tools/shadow/zeta-shadow.ts"
+  },
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@types/bun": "1.3.12",

--- a/tools/shadow/README.md
+++ b/tools/shadow/README.md
@@ -1,0 +1,86 @@
+# Shadow observer
+
+Auto-accept mode for Claude Code's suggestion UI. When Claude produces a suggestion
+(grey text), the shadow observer detects it and sends an `Enter` keystroke to accept,
+logging every action to a JSON log file.
+
+## Shadow mode
+
+### Installation
+
+```bash
+bun install
+```
+
+### Quick start (dry run — no keystrokes sent)
+
+```bash
+bun run shadow -- --dry-run --once
+```
+
+### Full autonomous mode
+
+```bash
+bun run shadow -- --delay 2000
+```
+
+### Entry point via `bun link`
+
+After `bun link` in the repo root, `zeta-shadow` is available on `PATH`:
+
+```bash
+bun link
+zeta-shadow --dry-run --once
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--delay <ms>` | `3000` | Delay before accepting a detected suggestion |
+| `--detect-cmd <cmd>` | built-in | External command for detection. Exit 0 = suggestion present. |
+| `--dry-run` | off | Log actions without sending keystrokes |
+| `--loop <ms>` | off | After natural exit, wait `<ms>` then restart. `Ctrl-C` terminates immediately. |
+| `--loop-interval <ms>` | `1000` | Sleep between detection cycles in continuous mode |
+| `--log-file <path>` | `tools/shadow/shadow-observer.log` | JSON log file path |
+| `--once` | off | Run exactly one detection cycle then exit |
+
+### Demo recipe
+
+Use an external detector script for a live UI demo:
+
+```bash
+zeta-shadow --detect-cmd "./your-detect-script.sh" --delay 2000
+```
+
+`your-detect-script.sh` exits 0 when a suggestion is present (stdout is the
+suggestion content), non-0 otherwise.
+
+### Glass Halo
+
+All shadow submissions are logged to `tools/shadow/shadow-observer.log` (or the path
+supplied via `--log-file`) in JSON Lines format, one event per line.
+Every auto-accept carries `(shadow)` attribution so the source is always traceable.
+
+Sample `accepted` event:
+
+```json
+{"ts":"2026-05-13T11:00:00.000Z","type":"accepted","content":"console.log(x)","mode":"shadow","attribution":"(shadow)"}
+```
+
+Sample `detected` event:
+
+```json
+{"ts":"2026-05-13T11:00:00.001Z","type":"detected","content":"console.log(x)"}
+```
+
+The log is the human circuit-breaker surface: review it at any time to see what
+was accepted, overridden, or skipped.
+
+### Safety model
+
+- The human is the **live circuit breaker**: `Ctrl-C` stops the observer immediately.
+- `--dry-run` mode logs all intended actions without sending any keystrokes — safe
+  for demos and audits.
+- `--loop` restarts after natural exit; `SIGINT` / `SIGTERM` are **never** restarted.
+- Log file is append-only — no events are removed.

--- a/tools/shadow/smoke-test.test.ts
+++ b/tools/shadow/smoke-test.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+const ZETA_SHADOW = join(import.meta.dir, "zeta-shadow.ts");
+const REPO_ROOT = resolve(import.meta.dir, "../..");
+
+describe("shadow — B-0433 distribution smoke tests", () => {
+  let SMOKE_DIR: string;
+
+  beforeEach(() => {
+    SMOKE_DIR = mkdtempSync(join(tmpdir(), "zeta-shadow-b0433-smoke-"));
+  });
+  afterEach(() => {
+    if (existsSync(SMOKE_DIR)) rmSync(SMOKE_DIR, { recursive: true, force: true });
+  });
+
+  test("zeta-shadow.ts --once --dry-run --detect-cmd 'echo hello' exits 0", () => {
+    const logFile = join(SMOKE_DIR, "shadow.log");
+    const r = spawnSync(
+      "bun",
+      [ZETA_SHADOW, "--once", "--dry-run", "--delay", "0", "--detect-cmd", "echo hello", "--log-file", logFile],
+      { encoding: "utf-8" },
+    );
+    expect(r.status).toBe(0);
+  });
+
+  test("log file written with (shadow) attribution after dry-run acceptance", () => {
+    const logFile = join(SMOKE_DIR, "shadow.log");
+    spawnSync(
+      "bun",
+      [ZETA_SHADOW, "--once", "--dry-run", "--delay", "0", "--detect-cmd", "echo hello", "--log-file", logFile],
+      { encoding: "utf-8" },
+    );
+    expect(existsSync(logFile)).toBe(true);
+    const contents = readFileSync(logFile, "utf-8");
+    expect(contents).toContain("(shadow");
+  });
+
+  test("package.json bin[\"zeta-shadow\"] entry points to an existing file", () => {
+    const pkgJson = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf-8")) as {
+      bin?: Record<string, string>;
+    };
+    expect(pkgJson.bin).toBeDefined();
+    const entry = pkgJson.bin?.["zeta-shadow"];
+    expect(entry).toBeDefined();
+    expect(existsSync(join(REPO_ROOT, entry!))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- `package.json`: adds `bin["zeta-shadow"]` → `tools/shadow/zeta-shadow.ts` so `bun link` puts `zeta-shadow` on PATH for local dev/demo
- `tools/shadow/README.md`: new Shadow mode section — installation, flags table, Glass Halo log format with sample `accepted` event, safety model, demo recipe
- `tools/shadow/smoke-test.test.ts`: 3 new tests (51 total, 0 failures)

## Acceptance criteria (B-0433)

- [x] `package.json` `bin["zeta-shadow"]` entry present and points to valid file
- [x] `tools/shadow/README.md` has `## Shadow mode` section with flags + Glass Halo note
- [x] End-to-end smoke test passes (`bun test tools/shadow/smoke-test.test.ts`)
- [x] 3 new tests, 0 failures (`bun test tools/shadow/` → 51 pass, 0 fail)
- [x] "Deployable as part of Zeta CLI install" B-0402 criterion satisfied

## Depends on

#2985 (B-0432 — `zeta-shadow.ts` entry point) — PR is based on `feat/b-0432-shadow-cli-loop-flag`; will be retargeted to `main` once #2985 merges.

## Test plan

- [x] `bun test tools/shadow/smoke-test.test.ts` → 3 pass, 0 fail
- [x] `bun test tools/shadow/` → 51 pass, 0 fail
- [x] `dotnet build -c Release` → 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)