### PR TITLE
feat(toffoli): B-0366.2.1 — ToffoliCircuit type + wire-map formal model

### DIFF
--- a/docs/backlog/P1/B-0366.2.1-toffoli-circuit-type-wire-map-formal-model.md
+++ b/docs/backlog/P1/B-0366.2.1-toffoli-circuit-type-wire-map-formal-model.md
@@ -1,11 +1,13 @@
 ---
 id: B-0366.2.1
 priority: P1
-status: open
+status: claimed
 title: "ToffoliCircuit type + wire-map formal model (smallest slice of B-0366.2)"
 effort: S
 created: 2026-05-11
-last_updated: 2026-05-11
+last_updated: 2026-05-13
+claimed_by: otto
+claim_branch: feat/b-0366-2-1-toffoli-circuit-wire-map
 depends_on: [B-0366.1]
 parent: B-0366.2
 classification: buildable-now
@@ -17,28 +19,42 @@ tags: [toffoli, circuit-model, fsharp, zset]
 
 # B-0366.2.1 — ToffoliCircuit type and wire map
 
+## Pre-start checklist (2026-05-13, Otto)
+
+- **Prior-art search**: B-0366.1 already shipped `Bit`, `ToffoliWires`, `ZSetGateOp`
+  in `src/Core/ToffoliGate.fs`. That file contained a stub `ToffoliCircuit`
+  (`Gates: ToffoliWires list; Description: string`) that does not match the
+  spec. No `WireId`, `WireMap`, or `ToffoliGateStep` exist anywhere in repo.
+  No conflict with existing substrate.
+- **Dependency check**: B-0366.1 is shipped (ToffoliGate.fs present, tests green).
+  Dependency satisfied.
+- **Scope**: Pure type additions to `src/Core/ToffoliGate.fs` at namespace level.
+  No new files (no .fsproj change needed). Remove stub; add proper types.
+
 ## What (bounded slice)
 
 Define the minimal F# data model for a Toffoli gate network:
 
-- `type ToffoliCircuit = { Gates: ToffoliGate list; Wires: WireMap; Ancilla: int }`
-- `type WireMap = Map<WireId, BitState>`
-- Symbolic join context: input wires for A/B weights, output wires for product.
+- `type WireId = int` — wire index type
+- `type WireMap = Map<WireId, Bit>` — wire state map (reuses `Bit` from B-0366.1)
+- `[<Struct>] type ToffoliGateStep` — single gate application by wire indices
+- `type ToffoliCircuit = { Gates: ToffoliGateStep list; Wires: WireMap; Ancilla: int }`
+- `ToffoliGate.emptyCircuit : ToffoliCircuit` — factory for the empty circuit
 
 No implementation of join yet. Pure type + invariant docs.
 
 ## Deliverable
 
-F# module `Zeta.Core.ToffoliCircuit` (or extend ToffoliGate.fs) with the type and a factory `emptyCircuit : ToffoliCircuit`.
+Extended `src/Core/ToffoliGate.fs` — proper circuit types at namespace level,
+replacing the earlier stub. `ToffoliGate.emptyCircuit` is the factory function.
 
 ## Focused checks (mandatory)
 
-- `dotnet build -c Release` → 0 warnings 0 errors
-- FsCheck smoke test for wire-map roundtrip (if time)
+- `dotnet build -c Release` → **0 warnings 0 errors** ✓
+- `dotnet test tests/Tests.FSharp -c Release --filter "ToffoliGate"` → **7/7 passed** ✓
 
 ## Evidence
 
-- Depends on B-0366.1 gate types
-- Prepares B-0366.2.2 join encoding
-
-This slice is the smallest safe type anchor before any gate-network logic.
+- Depends on B-0366.1 gate types ✓ (landed)
+- Prepares B-0366.2.2 join encoding (Gates list + WireMap now exist)
+- Prepares B-0366.2.3 reversibility laws (types ready for FsCheck generators)

--- a/src/Core/ToffoliGate.fs
+++ b/src/Core/ToffoliGate.fs
@@ -30,6 +30,53 @@ type ZSetGateOp =
     | Retract  // -1: recover one unit of information
 
 
+// ── Wire-map formal model (B-0366.2.1) ──────────────────────────────────────
+//
+// A Toffoli circuit is a gate network over named wires. Each wire has an
+// integer index (WireId) and carries a Bit value. A circuit step is a
+// single Toffoli gate application that references three wire indices;
+// the circuit itself is a sequence of steps plus the current wire state.
+//
+// Invariants:
+//   - Every WireId in ToffoliGateStep.ControlA / ControlB / Target must
+//     exist as a key in ToffoliCircuit.Wires.
+//   - ToffoliCircuit.Ancilla >= 0.
+//   - Ancilla wires occupy indices 0 .. Ancilla-1 by convention.
+//   - No bit erasure: ancilla wires carry the inverse function, so the
+//     circuit is reversible over its full wire set.
+
+/// Integer index identifying a wire in a ToffoliCircuit.
+type WireId = int
+
+/// State of all wires in a circuit at a given point in execution.
+/// Maps each wire index to its current Bit value.
+type WireMap = Map<WireId, Bit>
+
+/// A single Toffoli gate application, identified by wire indices.
+///
+/// Semantics: Wires[Target] ← Wires[Target] ⊕ (Wires[ControlA] ∧ Wires[ControlB]).
+/// ControlA and ControlB wires are read-only in this step.
+[<Struct>]
+type ToffoliGateStep = {
+    ControlA : WireId
+    ControlB : WireId
+    Target   : WireId
+}
+
+/// A Toffoli gate network (B-0366.2.1 formal model).
+///
+/// Gates:   ordered sequence of gate applications (wire-index based).
+/// Wires:   current bit state of every named wire.
+/// Ancilla: number of ancilla (helper) wires. By convention, their
+///          indices occupy 0 .. Ancilla-1. Ancilla carry the inverse
+///          function — no bits are erased when the circuit runs.
+type ToffoliCircuit = {
+    Gates   : ToffoliGateStep list
+    Wires   : WireMap
+    Ancilla : int
+}
+
+
 [<RequireQualifiedAccess>]
 module ToffoliGate =
 
@@ -62,20 +109,9 @@ module ToffoliGate =
     let assertThenRetract (w: ToffoliWires) : ToffoliWires =
         w |> encode Assert |> encode Retract
 
-    /// Circuit representation for reversible Z-set operations (B-0366.2 smallest slice).
-    /// A ToffoliCircuit is a sequence of gates plus metadata; ancilla wires are implicit
-    /// in the gate list (no bit erasure).
-    [<Struct>]
-    type ToffoliCircuit = {
-        Gates: ToffoliWires list
-        Description: string
-    }
-
-    /// Model a Z-set join as a Toffoli-gate network (formal gate-network model slice).
+    /// Empty circuit: no gate steps, no wires initialised, zero ancilla.
     ///
-    /// This is the bounded first step: returns an empty circuit stub. Full join
-    /// expansion (N×M weight multiplications encoded as Peres/Toffoli chains)
-    /// is deferred to a child decomposition. The stub satisfies the signature
-    /// and keeps the build green.
-    let modelJoinCircuit (_a: obj) (_b: obj) : ToffoliCircuit =
-        { Gates = []; Description = "B-0366.2: empty Toffoli circuit for Z-set join (re-decomposed slice)" }
+    /// Use as the base for circuit construction. Satisfies all ToffoliCircuit
+    /// invariants trivially — empty gate list implies no WireId constraints.
+    let emptyCircuit : ToffoliCircuit =
+        { Gates = []; Wires = Map.empty; Ancilla = 0 }


### PR DESCRIPTION
## Summary

- Replaces the B-0366.2 stub `ToffoliCircuit` (`Gates: ToffoliWires list; Description: string`) with the proper formal model defined in B-0366.2.1.
- Adds four new types at `Zeta.Core` namespace scope (no new files, no `.fsproj` change): `WireId`, `WireMap`, `ToffoliGateStep`, `ToffoliCircuit`.
- Adds `ToffoliGate.emptyCircuit : ToffoliCircuit` as the zero-gate factory.
- All B-0366.1 FsCheck property tests still pass (self-inverse, assert-retract identity, bit-conservation, truth-table spot checks).

## Type model

```fsharp
type WireId  = int
type WireMap = Map<WireId, Bit>   // Bit from B-0366.1

[<Struct>]
type ToffoliGateStep = {
    ControlA : WireId
    ControlB : WireId
    Target   : WireId
}

type ToffoliCircuit = {
    Gates   : ToffoliGateStep list
    Wires   : WireMap
    Ancilla : int
}
```

`ToffoliGateStep` captures circuit *topology* (gate applications by wire index), distinct from `ToffoliWires` which captures *evaluated bit state*. This separation is load-bearing for B-0366.2.2 (join encoding) and B-0366.2.3 (reversibility FsCheck laws).

## Focused checks

| Check | Result |
|---|---|
| `dotnet build -c Release` | ✅ 0 warnings, 0 errors |
| `dotnet test tests/Tests.FSharp -c Release --filter "ToffoliGate"` | ✅ 7/7 passed |

## Backlog closure

Sets B-0366.2.1 `status: claimed` with pre-start checklist completed. Unblocks B-0366.2.2 and B-0366.2.3.

operative-authorization: aaron 2026-05-13: "Cooling period: TBD. The memory file IS the durable record"

🤖 Generated with [Claude Code](https://claude.com/claude-code)