### PR TITLE
chore(backlog): decompose B-0423 into 5 dependency-ordered child rows

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -226,6 +226,11 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0418](backlog/P1/B-0418-amplification-ratio-metric-dashboard-2026-05-11.md)** Amplification ratio metric — human input : agent actions on dashboard
 - [ ] **[B-0419](backlog/P1/B-0419-honest-agenda-amplification-metric-aaron-2026-05-11.md)** Honest agenda amplification metric — actions weighted by agenda alignment
 - [ ] **[B-0423](backlog/P1/B-0423-memory-md-serialization-point-2026-05-12.md)** MEMORY.md serialization-point anti-pattern
+- [ ] **[B-0423.1](backlog/P1/B-0423.1-reindex-memory-md-test-coverage-collectentries-renderindex.md)** Extend reindex-memory-md.ts test coverage — collectEntries + renderIndex
+- [ ] **[B-0423.2](backlog/P1/B-0423.2-memory-docs-update-heap-state-acceptable.md)** Update memory/ documentation to describe heap-state-acceptable model
+- [ ] **[B-0423.3](backlog/P1/B-0423.3-wire-reindex-into-autonomous-loop-tick.md)** Wire reindex-memory-md.ts into autonomous-loop tick cadence
+- [ ] **[B-0423.4](backlog/P1/B-0423.4-relax-memory-index-integrity-ci-check.md)** Relax memory-index-integrity.yml CI check — heap-state-acceptable
+- [ ] **[B-0423.5](backlog/P1/B-0423.5-close-b0088-chain-superseded-by-heap-architecture.md)** Close B-0088 chain as superseded by B-0423 heap architecture
 - [ ] **[B-0424](backlog/P1/B-0424-three-repo-split-stage1-create-forge-ace-with-scaffolding-aaron-2026-05-13.md)** Three-repo split Stage 1 — create empty Forge + ace with day-one scaffolding
 - [ ] **[B-0425](backlog/P1/B-0425-product-repo-split-planning-ksk-wellness-american-dream-civsim-honor-system-no-fork-license-aaron-2026-05-13.md)** Product-repo split planning — KSK / wellness / civsim / AD2.0 / DIO / Aurora / Dawn — honor-system no-fork license
 - [ ] **[B-0426](backlog/P1/B-0426-repo-split-orthogonal-mirror-beacon-axis-aaron-2026-05-13.md)** Repo-split orthogonal Mirror/Beacon axis — speculative-fast-forks vs governance-citation-gated

--- a/docs/backlog/P1/B-0423-memory-md-serialization-point-2026-05-12.md
+++ b/docs/backlog/P1/B-0423-memory-md-serialization-point-2026-05-12.md
@@ -5,6 +5,7 @@ class: substrate-architecture
 status: decomposed
 title: MEMORY.md serialization-point anti-pattern
 created: 2026-05-12
+last_updated: 2026-05-13
 authors: [otto, aaron]
 decomposed: true
 children: [B-0423.1, B-0423.2, B-0423.3, B-0423.4, B-0423.5]

--- a/docs/backlog/P1/B-0423-memory-md-serialization-point-2026-05-12.md
+++ b/docs/backlog/P1/B-0423-memory-md-serialization-point-2026-05-12.md
@@ -2,10 +2,12 @@
 id: B-0423
 priority: P1
 class: substrate-architecture
-status: open
+status: decomposed
 title: MEMORY.md serialization-point anti-pattern
 created: 2026-05-12
 authors: [otto, aaron]
+decomposed: true
+children: [B-0423.1, B-0423.2, B-0423.3, B-0423.4, B-0423.5]
 ---
 
 # B-0423 — MEMORY.md serialization-point anti-pattern (2026-05-12)

--- a/docs/backlog/P1/B-0423.1-reindex-memory-md-test-coverage-collectentries-renderindex.md
+++ b/docs/backlog/P1/B-0423.1-reindex-memory-md-test-coverage-collectentries-renderindex.md
@@ -1,0 +1,84 @@
+---
+id: B-0423.1
+priority: P1
+class: substrate-architecture
+status: open
+title: Extend reindex-memory-md.ts test coverage — collectEntries + renderIndex
+created: 2026-05-13
+parent: B-0423
+depends_on: []
+composes_with: [B-0423]
+effort: XS
+tier: factory-tooling
+authors: [otto]
+---
+
+# B-0423.1 — Extend reindex-memory-md.ts test coverage
+
+## Carved sentence
+
+> `tools/memory/reindex-memory-md.ts` exists and passes CI for
+> `parseFrontmatter` only. Before the architecture relies on it as
+> the authoritative heap→stack promotion mechanism, `collectEntries`
+> and `renderIndex` need their own test coverage.
+
+## Context
+
+`tools/memory/reindex-memory-md.ts` was implemented as part of the
+B-0423 architectural fix. Its test file
+(`tools/memory/reindex-memory-md.test.ts`) currently only covers
+`parseFrontmatter`. The two functions that constitute the reindex
+pipeline — `collectEntries` (scans memory/ directory and parses
+frontmatter) and `renderIndex` (renders the MEMORY.md stack view from
+entries) — have no tests.
+
+B-0423.3 (loop wiring) and B-0423.4 (CI relaxation) both depend on
+the reindexer being trustworthy. This slice validates the tool before
+those slices land.
+
+## Acceptance criteria
+
+- [ ] `collectEntries` is tested with a synthetic fixture directory
+  - Entries with valid frontmatter are collected
+  - Files without frontmatter (`README.md`, `MEMORY.md`, `CURRENT-*`)
+    are excluded
+  - Entries are sorted newest-first by `created:` date falling back
+    to date extracted from filename
+- [ ] `renderIndex` is tested
+  - Renders expected PREAMBLE_MARKER / PREAMBLE_END delimiters
+  - Truncates descriptions at 240 characters
+  - Truncates stack at MAX_STACK_ENTRIES (100) and appends overflow note
+  - `last reindex: YYYY-MM-DD` in preamble reflects current date
+- [ ] All existing tests continue to pass
+- [ ] `bun test tools/memory/reindex-memory-md.test.ts` exits 0
+- [ ] `dotnet build -c Release` exits 0 warnings 0 errors (unchanged)
+
+## Implementation notes
+
+Use a temp directory via `Bun.env.TMPDIR` or a hardcoded fixture
+path under `tools/memory/testdata/`. Prefer fixture files over
+`tmp` so tests are deterministic (DST-compatible).
+
+The `collectEntries` function reads from the `MEMORY_DIR = "memory"`
+constant which is relative to CWD. The test must either:
+1. Use `process.chdir()` within the test (not recommended — affects
+   other tests), or
+2. Expose a `collectEntriesFrom(dir: string)` variant that takes an
+   explicit path — refactor the function to accept an optional dir
+   parameter while keeping the default behaviour.
+
+Option 2 is the clean DST approach: makes the function testable
+without CWD manipulation.
+
+## Why P1 (not P2)
+
+This slice gates B-0423.3 (loop wiring) and B-0423.4 (CI relaxation).
+Without adequate test coverage, rolling out the heap architecture
+carries undefined risk for the reindexer's correctness. Completing
+this first is cheap and removes that risk.
+
+## Composes with
+
+- B-0423 (parent; this is slice 1 of 5)
+- B-0423.3 (loop wiring depends on this slice's confidence signal)
+- B-0423.4 (CI relaxation depends on trustworthy reindexer)

--- a/docs/backlog/P1/B-0423.1-reindex-memory-md-test-coverage-collectentries-renderindex.md
+++ b/docs/backlog/P1/B-0423.1-reindex-memory-md-test-coverage-collectentries-renderindex.md
@@ -5,6 +5,7 @@ class: substrate-architecture
 status: open
 title: Extend reindex-memory-md.ts test coverage — collectEntries + renderIndex
 created: 2026-05-13
+last_updated: 2026-05-13
 parent: B-0423
 depends_on: []
 composes_with: [B-0423]

--- a/docs/backlog/P1/B-0423.1-reindex-memory-md-test-coverage-collectentries-renderindex.md
+++ b/docs/backlog/P1/B-0423.1-reindex-memory-md-test-coverage-collectentries-renderindex.md
@@ -61,6 +61,7 @@ path under `tools/memory/testdata/`. Prefer fixture files over
 
 The `collectEntries` function reads from the `MEMORY_DIR = "memory"`
 constant which is relative to CWD. The test must either:
+
 1. Use `process.chdir()` within the test (not recommended — affects
    other tests), or
 2. Expose a `collectEntriesFrom(dir: string)` variant that takes an

--- a/docs/backlog/P1/B-0423.2-memory-docs-update-heap-state-acceptable.md
+++ b/docs/backlog/P1/B-0423.2-memory-docs-update-heap-state-acceptable.md
@@ -1,0 +1,91 @@
+---
+id: B-0423.2
+priority: P1
+class: substrate-architecture
+status: open
+title: Update memory/ documentation to describe heap-state-acceptable model
+created: 2026-05-13
+parent: B-0423
+depends_on: []
+composes_with: [B-0423, B-0423.1]
+effort: XS
+tier: documentation
+authors: [otto]
+---
+
+# B-0423.2 — Update memory/ docs for heap-state-acceptable model
+
+## Carved sentence
+
+> `memory/README.md` and `memory/project_memory_format_standard.md`
+> still describe the old synchronous paired-edit requirement. Update
+> both to document the heap-state model so future agents author memory
+> files correctly under the new architecture.
+
+## Context
+
+Two documents still require the old paired-edit discipline:
+
+1. **`memory/README.md`** — the "Agents writing memories — full
+   freedom" section says "Update MEMORY.md to include new entries at
+   the top (newest-first)." This implies synchronous paired edit.
+
+2. **`memory/project_memory_format_standard.md` Section 5** —
+   "MEMORY.md index entries" describes the paired-edit format
+   and ordering convention without acknowledging that heap-state
+   (no paired edit) is now acceptable.
+
+Until these documents are updated, future agents cold-booting will
+follow the old discipline, defeating the B-0423 architectural fix.
+
+## Acceptance criteria
+
+### `memory/README.md` changes
+
+- [ ] "Agents writing memories" section: replace paired-edit
+  instruction with heap-state model:
+  - New memory files MUST have valid frontmatter (name, description,
+    type, created fields).
+  - A synchronous MEMORY.md paired-edit is **no longer required**.
+  - MEMORY.md is kept current by `tools/memory/reindex-memory-md.ts`
+    running on cadence (called from the autonomous-loop tick).
+  - Agents MAY run `bun tools/memory/reindex-memory-md.ts` manually
+    to promote heap files to the stack view immediately.
+- [ ] Add "Stack-vs-heap model" subsection linking to B-0423 and the
+  MEMORY.md preamble that already explains the framing.
+
+### `memory/project_memory_format_standard.md` changes
+
+- [ ] Section 5 "MEMORY.md index entries": add note that
+  heap-state-acceptable means a new memory file does NOT require a
+  same-PR MEMORY.md paired edit. The reindexer will pick it up on
+  the next cadence run.
+- [ ] Add a "6.N Heap-state validation" section: agents validate that
+  their new memory file has the required frontmatter fields; the
+  reindexer contract requires `name:`, `description:`, `type:`, and
+  `created:`.
+
+## Implementation notes
+
+Purely documentation changes. No code changes. Does not require
+B-0423.1 (tests) to land first — the docs can be correct before
+the tests are extended.
+
+This slice produces no CI checks to pass beyond `dotnet build`
+and lint. Markdownlint (`MD003`, `MD022`, `MD026`) must be clean
+— run `bunx markdownlint-cli2 memory/README.md memory/project_memory_format_standard.md`
+before commit to verify.
+
+## Why P1
+
+If the documentation stays stale, future agents will continue
+adding synchronous paired edits (increasing merge conflicts),
+defeating the architectural fix. This slice makes the new contract
+visible at cold-boot.
+
+## Composes with
+
+- B-0423 (parent; this is slice 2 of 5)
+- B-0423.1 (tests; independent, can land in parallel)
+- B-0423.4 (CI relaxation; docs should describe the contract
+  before CI stops enforcing the old one)

--- a/docs/backlog/P1/B-0423.2-memory-docs-update-heap-state-acceptable.md
+++ b/docs/backlog/P1/B-0423.2-memory-docs-update-heap-state-acceptable.md
@@ -5,6 +5,7 @@ class: substrate-architecture
 status: open
 title: Update memory/ documentation to describe heap-state-acceptable model
 created: 2026-05-13
+last_updated: 2026-05-13
 parent: B-0423
 depends_on: []
 composes_with: [B-0423, B-0423.1]

--- a/docs/backlog/P1/B-0423.3-wire-reindex-into-autonomous-loop-tick.md
+++ b/docs/backlog/P1/B-0423.3-wire-reindex-into-autonomous-loop-tick.md
@@ -74,24 +74,30 @@ follow this checklist.
 The loop needs to know how many ticks have elapsed since the last
 reindex. Options:
 
-**Option A (recommended):** Read the "Last reindex:" timestamp in
-MEMORY.md preamble. If the date is today and the reindex ran within
-the last 5 minutes (by comparing to the current time), skip. Otherwise
-run.
+**Option A:** Read a timestamp from the MEMORY.md preamble. Requires
+the preamble to store minute-precision time (e.g. `last reindex: YYYY-MM-DD HH:MMZ`)
+rather than date-only. The reindexer must be updated to write and parse
+this format; the "every 5 minutes" skip logic then compares the stored
+UTC timestamp to the current time.
 
-**Option B:** Write a sentinel file `memory/.last-reindex-ts` with an
-epoch timestamp. Compare on each tick.
+**Option B (recommended):** Write a sentinel file `memory/.last-reindex-ts`
+with an epoch timestamp (Unix seconds). Compare on each tick: if
+`(now - stored_epoch) < 300`, skip. This avoids coupling cadence logic
+to preamble format and works correctly across midnight boundaries.
 
-Option A is preferred because it uses the existing stack preamble as
-state — no new file needed, and the preamble already shows the last
-reindex date to readers.
+Option B is preferred because it is simpler to parse, always has
+sub-second precision, and keeps the preamble human-readable (date-only
+format unchanged for readers). The sentinel file is `.gitignore`-ed or
+committed silently as infrastructure.
 
 ### Commit discipline
 
 The reindex commit, if MEMORY.md changed, must:
 
 - Use message: `chore(memory): reindex MEMORY.md stack from heap [B-0423]`
-- Include `Co-Authored-By: Claude <noreply@anthropic.com>` trailer
+- Include the `Co-Authored-By:` trailer matching the active harness
+  (e.g. `Co-Authored-By: Claude <noreply@anthropic.com>` for Otto;
+  use the appropriate identity for Codex/Grok/Gemini/Kiro loops)
 - Target the current branch (main, or any open feature branch the
   loop is working on)
 

--- a/docs/backlog/P1/B-0423.3-wire-reindex-into-autonomous-loop-tick.md
+++ b/docs/backlog/P1/B-0423.3-wire-reindex-into-autonomous-loop-tick.md
@@ -5,6 +5,7 @@ class: substrate-architecture
 status: open
 title: Wire reindex-memory-md.ts into autonomous-loop tick cadence
 created: 2026-05-13
+last_updated: 2026-05-13
 parent: B-0423
 depends_on: [B-0423.1]
 composes_with: [B-0423, B-0423.1, B-0423.2]

--- a/docs/backlog/P1/B-0423.3-wire-reindex-into-autonomous-loop-tick.md
+++ b/docs/backlog/P1/B-0423.3-wire-reindex-into-autonomous-loop-tick.md
@@ -1,0 +1,120 @@
+---
+id: B-0423.3
+priority: P1
+class: substrate-architecture
+status: open
+title: Wire reindex-memory-md.ts into autonomous-loop tick cadence
+created: 2026-05-13
+parent: B-0423
+depends_on: [B-0423.1]
+composes_with: [B-0423, B-0423.1, B-0423.2]
+effort: S
+tier: factory-tooling
+authors: [otto]
+---
+
+# B-0423.3 — Wire reindex-memory-md.ts into autonomous-loop tick
+
+## Carved sentence
+
+> `tools/memory/reindex-memory-md.ts` exists but is not called from
+> the autonomous-loop tick. Without wiring, heap→stack promotion
+> never happens automatically: MEMORY.md will go permanently stale
+> once synchronous paired-edit enforcement is removed.
+
+## Context
+
+B-0423's architectural fix requires three layers:
+
+1. **Heap layer** — memory files commit without MEMORY.md paired edit
+2. **Stack layer** — MEMORY.md is kept current by the reindexer
+3. **High-cadence reindex** — called from the autonomous-loop tick
+
+Layer 3 is the missing link. The reindexer exists and works, but nothing
+calls it on cadence. This slice wires it into the loop.
+
+**Dependency:** Lands after B-0423.1 (test coverage) to ensure the
+reindexer is trustworthy before it runs automatically on every tick.
+
+## Acceptance criteria
+
+### End-of-tick checklist update (`docs/AUTONOMOUS-LOOP.md`)
+
+- [ ] Add step to the end-of-tick checklist:
+  - Every N ticks (recommended: every 5 ticks, i.e. every ~5 min),
+    run `bun tools/memory/reindex-memory-md.ts`.
+  - Commit the result if MEMORY.md changed (commit message:
+    `chore(memory): reindex MEMORY.md stack from heap [B-0423]`).
+  - Use `--check` first to detect staleness before writing.
+- [ ] Document the "every N ticks" cadence rationale:
+  - Every-tick reindex on every minute-cadence cron tick burns
+    unnecessary CPU and creates noisy commits; every 5 ticks
+    keeps MEMORY.md ≤5 min stale, matching Aaron's guidance
+    ("needs to run more often than Anthropic allows on their base").
+
+### Operational wiring in the loop instructions
+
+The autonomous-loop receives `<<autonomous-loop>>` sentinel which
+resolves at fire time to autonomous-loop instructions. The end-of-tick
+checklist in `docs/AUTONOMOUS-LOOP.md` is the canonical place to add
+the reindex step — the sentinel's resolved content calls agents to
+follow this checklist.
+
+- [ ] Update `docs/AUTONOMOUS-LOOP.md` end-of-tick checklist (currently
+  six steps: speculative work, verify, commit, write shard,
+  CronList, visibility signal) to add a seventh step between
+  "commit" and "write shard":
+  > **7. Reindex memory**: If N ticks have elapsed since last
+  > reindex, run `bun tools/memory/reindex-memory-md.ts`.
+  > If MEMORY.md changed, commit with the standard chore message.
+  > Maintains the heap→stack promotion cadence per B-0423.
+
+### State tracking for "every N ticks" cadence
+
+The loop needs to know how many ticks have elapsed since the last
+reindex. Options:
+
+**Option A (recommended):** Read the "Last reindex:" timestamp in
+MEMORY.md preamble. If the date is today and the reindex ran within
+the last 5 minutes (by comparing to the current time), skip. Otherwise
+run.
+
+**Option B:** Write a sentinel file `memory/.last-reindex-ts` with an
+epoch timestamp. Compare on each tick.
+
+Option A is preferred because it uses the existing stack preamble as
+state — no new file needed, and the preamble already shows the last
+reindex date to readers.
+
+### Commit discipline
+
+The reindex commit, if MEMORY.md changed, must:
+
+- Use message: `chore(memory): reindex MEMORY.md stack from heap [B-0423]`
+- Include `Co-Authored-By: Claude <noreply@anthropic.com>` trailer
+- Target the current branch (main, or any open feature branch the
+  loop is working on)
+
+## Implementation notes
+
+This slice requires editing `docs/AUTONOMOUS-LOOP.md` only.
+No code changes to `tools/memory/reindex-memory-md.ts` are needed
+unless Option A (preamble-based staleness detection) requires
+parsing the preamble — in that case, add a `lastReindexDate()`
+helper function to the reindexer module.
+
+Run `dotnet build -c Release` and `bun test` to verify nothing broken.
+
+## Why P1 (not P2)
+
+This slice is the operational linchpin of the B-0423 fix. The heap
+architecture only works if promotion happens. Without this slice,
+removing the CI paired-edit enforcement (B-0423.4) leaves MEMORY.md
+permanently stale. This must land before B-0423.4.
+
+## Composes with
+
+- B-0423 (parent; this is slice 3 of 5)
+- B-0423.1 (depends on test coverage for confidence)
+- B-0423.2 (documentation should be consistent with the loop doc)
+- B-0423.4 (CI relaxation must not land before this slice)

--- a/docs/backlog/P1/B-0423.4-relax-memory-index-integrity-ci-check.md
+++ b/docs/backlog/P1/B-0423.4-relax-memory-index-integrity-ci-check.md
@@ -122,13 +122,17 @@ on main.
 ## Implementation notes
 
 The workflow is a bash script under `run:`. The frontmatter parser
-can be implemented as a simple bash `grep` / `awk` pattern — no bun
-required in CI since this workflow doesn't currently install bun:
+must scope validation to the YAML block only (the first `--- … ---`
+delimited section) — scanning the whole file produces false negatives
+when required keys appear in the markdown body but not in frontmatter.
+Use `awk` to extract the block before grepping:
 
 ```bash
 for f in $trigger_files; do
+  # Extract lines between the first pair of --- delimiters only.
+  frontmatter=$(awk '/^---$/{if (++n==2) exit; next} n==1' "$f")
   for field in name description type created; do
-    if ! grep -qE "^$field:" "$f"; then
+    if ! echo "$frontmatter" | grep -qE "^$field:"; then
       echo "MISSING: $field in $f"
       missing_fields=true
     fi

--- a/docs/backlog/P1/B-0423.4-relax-memory-index-integrity-ci-check.md
+++ b/docs/backlog/P1/B-0423.4-relax-memory-index-integrity-ci-check.md
@@ -1,0 +1,149 @@
+---
+id: B-0423.4
+priority: P1
+class: substrate-architecture
+status: open
+title: Relax memory-index-integrity.yml CI check — heap-state-acceptable
+created: 2026-05-13
+parent: B-0423
+depends_on: [B-0423.1, B-0423.3]
+composes_with: [B-0423, B-0423.2, B-0423.3, B-0088, B-0088.2]
+effort: S
+tier: factory-tooling
+authors: [otto]
+---
+
+# B-0423.4 — Relax memory-index-integrity.yml CI check
+
+## Carved sentence
+
+> `.github/workflows/memory-index-integrity.yml` enforces synchronous
+> MEMORY.md paired edits on every memory file change. This IS the
+> serialization point. Replace the strict paired-edit gate with a
+> frontmatter-completeness gate: new memory files must have valid
+> frontmatter; they do NOT need a same-PR MEMORY.md update.
+
+## Context
+
+`memory-index-integrity.yml` currently exits 1 when a `memory/*.md`
+file is added or modified without a MEMORY.md paired edit in the same
+PR. This enforces the serialization point that B-0423 is removing.
+
+The new contract after B-0423 lands:
+
+- **Required:** New memory files have valid frontmatter (`name:`,
+  `description:`, `type:`, `created:` fields).
+- **Not required:** Synchronous MEMORY.md paired edit.
+- **Instead:** MEMORY.md is kept current by `tools/memory/reindex-memory-md.ts`
+  running on the autonomous-loop tick cadence (B-0423.3).
+
+**Dependency:** This slice must NOT land before B-0423.3 (loop wiring).
+Removing the CI gate without automatic reindexing leaves MEMORY.md
+permanently stale. B-0423.3 is the operational prerequisite.
+
+**Relationship to B-0088:** B-0088 and its children (B-0088.1,
+B-0088.2, B-0088.3) asked whether to promote the paired-edit check
+to required status or weaken it. B-0423 answers this definitively:
+the synchronous paired-edit architecture is wrong; this slice replaces
+it with frontmatter validation. B-0088.2's "Option B (weaken)" is
+effectively implemented here, with a stronger architectural rationale.
+Mark B-0088 and children as superseded by B-0423.4 in the commit.
+
+## Acceptance criteria
+
+### CI workflow changes (`memory-index-integrity.yml`)
+
+Replace the current logic with a two-gate check:
+
+**Gate 1 — Frontmatter completeness (new enforcement):**
+
+For each added or modified `memory/*.md` file (excluding MEMORY.md,
+README.md, CURRENT-*.md, INDEX-*.md, persona/*):
+
+- Parse frontmatter block (`---` to `---`)
+- Assert presence of: `name:`, `description:`, `type:`, `created:`
+- Exit 1 with a clear message if any required field is missing
+
+This ensures the reindexer can process every memory file it finds.
+
+**Gate 2 — Paired-edit check (REMOVED / changed to informational):**
+
+- Remove the `exit 1` when MEMORY.md is NOT updated alongside memory
+  changes.
+- Replace with an informational `echo` that MEMORY.md will be updated
+  on the next autonomous-loop reindex cadence.
+- Do NOT fail on missing MEMORY.md update.
+
+### Workflow name and job name
+
+- Keep workflow name: `memory-index-integrity`
+- Rename job: `check memory file frontmatter completeness`
+  (from `check memory/MEMORY.md paired edit`)
+
+### Update the error message
+
+The existing message cites the NSA-001 incident (discoverability).
+Update to:
+
+```
+Memory file <filename> is missing required frontmatter field(s): <list>.
+Required fields: name, description, type, created.
+The reindexer (tools/memory/reindex-memory-md.ts) requires these
+fields to index the file into MEMORY.md on cadence. Fix the
+frontmatter before merging.
+See B-0423: docs/backlog/P1/B-0423-memory-md-serialization-point-2026-05-12.md
+```
+
+### Mark B-0088 chain as superseded
+
+In the same PR, add to B-0088:
+```
+superseded_by: B-0423.4
+resolved: 2026-05-13
+```
+
+And add a note to B-0088.2:
+```
+resolved_by: B-0423.4 (Option B implemented via heap architecture, stronger fix)
+```
+
+## Why P1 (not P0)
+
+This is the core architectural change. However, the serialization
+point's friction is manageable until B-0423.3 (loop wiring) lands.
+P0 would be appropriate if the serialization point were causing
+factory-blocking failures; currently it produces rebase grind (P1).
+
+Ordering constraint: this row MUST land after B-0423.3 in the merge
+sequence. The PR for this slice should include a `depends_on:
+[B-0423.1, B-0423.3]` check — only merge after those PRs are green
+on main.
+
+## Implementation notes
+
+The workflow is a bash script under `run:`. The frontmatter parser
+can be implemented as a simple bash `grep` / `awk` pattern — no bun
+required in CI since this workflow doesn't currently install bun:
+
+```bash
+for f in $trigger_files; do
+  for field in name description type created; do
+    if ! grep -qE "^$field:" "$f"; then
+      echo "MISSING: $field in $f"
+      missing_fields=true
+    fi
+  done
+done
+if $missing_fields; then exit 1; fi
+```
+
+This keeps the workflow fast and avoids adding the bun install step.
+
+## Composes with
+
+- B-0423 (parent; this is slice 4 of 5)
+- B-0423.1 (test coverage must exist before this lands)
+- B-0423.2 (documentation should describe the new contract)
+- B-0423.3 (loop wiring MUST land before this slice)
+- B-0088 (superseded by this slice)
+- B-0088.2 (Option B is this slice's implementation)

--- a/docs/backlog/P1/B-0423.4-relax-memory-index-integrity-ci-check.md
+++ b/docs/backlog/P1/B-0423.4-relax-memory-index-integrity-ci-check.md
@@ -5,6 +5,7 @@ class: substrate-architecture
 status: open
 title: Relax memory-index-integrity.yml CI check — heap-state-acceptable
 created: 2026-05-13
+last_updated: 2026-05-13
 parent: B-0423
 depends_on: [B-0423.1, B-0423.3]
 composes_with: [B-0423, B-0423.2, B-0423.3, B-0088, B-0088.2]

--- a/docs/backlog/P1/B-0423.5-close-b0088-chain-superseded-by-heap-architecture.md
+++ b/docs/backlog/P1/B-0423.5-close-b0088-chain-superseded-by-heap-architecture.md
@@ -1,0 +1,110 @@
+---
+id: B-0423.5
+priority: P1
+class: substrate-architecture
+status: open
+title: Close B-0088 chain as superseded by B-0423 heap architecture
+created: 2026-05-13
+parent: B-0423
+depends_on: [B-0423.4]
+composes_with: [B-0423, B-0423.4, B-0088, B-0088.1, B-0088.2, B-0088.3]
+effort: XS
+tier: factory-hygiene
+authors: [otto]
+---
+
+# B-0423.5 — Close B-0088 chain superseded by B-0423
+
+## Carved sentence
+
+> B-0088, B-0088.1, B-0088.2, B-0088.3 asked "promote or weaken
+> the paired-edit lint?" B-0423 answers definitively: remove the
+> synchronous paired-edit architecture entirely. Close the B-0088
+> chain as superseded; update each row's frontmatter.
+
+## Context
+
+B-0088 (2026-04-28) opened a decision gate: should the
+`memory-index-integrity.yml` check be promoted to a required status
+check (Option A) or have its message weakened to advisory (Option B)?
+
+B-0088.2 was the maintainer decision gate: locked waiting for the
+maintainer to pick A or B.
+
+B-0423 (2026-05-12) introduced a third option that supersedes both:
+replace the synchronous paired-edit architecture with a heap-state
+model and cadence reindexer. This is architecturally stronger than
+either Option A or Option B:
+
+- Option A would have made the serialization point more rigid
+- Option B would have accepted the serialization point as advisory
+- B-0423 removes the serialization point entirely
+
+After B-0423.4 lands, B-0088's question is moot. This slice closes
+the chain cleanly to prevent orphan open items.
+
+## Acceptance criteria
+
+For each of the following files, add `superseded_by:` frontmatter
+and a `## Resolution` section:
+
+### `docs/backlog/P2/B-0088-paired-edit-lint-advisory-not-enforcement-promote-to-required-check-otto-2026-04-28.md`
+
+- [ ] Add `superseded_by: B-0423.4` to frontmatter
+- [ ] Add `status: closed` to frontmatter
+- [ ] Add `## Resolution` section:
+  > B-0423 (2026-05-12) resolved this question by removing the
+  > synchronous paired-edit architecture entirely. B-0423.4 replaces
+  > the paired-edit gate with a frontmatter-completeness gate and
+  > wires cadence-based reindexing into the autonomous loop. Neither
+  > Option A nor Option B was needed — the architecture was changed
+  > instead. Closed as superseded by B-0423.4.
+
+### `docs/backlog/P2/B-0088.1-verify-paired-edit-job-in-required-status-checks-riven-2026-05-11.md`
+
+- [ ] Add `superseded_by: B-0423.4` to frontmatter
+- [ ] Add `status: closed`
+- [ ] Add `## Resolution`: closed by B-0423.4 superseding the
+  paired-edit check
+
+### `docs/backlog/P2/B-0088.2-decide-promote-vs-weaken-for-memory-paired-lint-riven-2026-05-11.md`
+
+- [ ] Add `superseded_by: B-0423.4` to frontmatter
+- [ ] Add `status: closed`
+- [ ] Add `## Resolution`: B-0423.4 implemented a third option
+  (remove the architecture). The decision gate is moot.
+
+### `docs/backlog/P2/B-0088.3-audit-memory-reference-existence-lint-advisory-status-riven-2026-05-11.md`
+
+- [ ] Read B-0088.3 to determine if it is also fully superseded
+  or only partially affected by B-0423. (The B-0088.3 scope
+  may differ from the paired-edit check specifically.)
+- [ ] Update status appropriately.
+
+### Update B-0423 parent row
+
+- [ ] Add `children: [B-0423.1, B-0423.2, B-0423.3, B-0423.4,
+  B-0423.5]` to B-0423 frontmatter
+- [ ] Update B-0423 `status` from `open` to `decomposed`
+
+## Why P1
+
+Orphan open items in the B-0088 chain will re-surface in backlog
+scans and create confusion about whether the paired-edit check is
+still a decision gate. Closing them cleanly removes that confusion.
+This is low-effort (frontmatter + resolution text) and has high
+hygiene value.
+
+## Implementation notes
+
+Read B-0088.3 before writing its resolution — its scope may differ
+from the others. If B-0088.3 covers a different lint (e.g.
+`memory-reference-existence-lint.yml`) that is NOT affected by
+B-0423.4, close it independently with a narrower note.
+
+## Composes with
+
+- B-0423 (parent; this is slice 5 of 5)
+- B-0423.4 (must land before this slice; the closure is logically
+  downstream of the actual CI change)
+- B-0088, B-0088.1, B-0088.2, B-0088.3 (the rows being closed)

--- a/docs/backlog/P1/B-0423.5-close-b0088-chain-superseded-by-heap-architecture.md
+++ b/docs/backlog/P1/B-0423.5-close-b0088-chain-superseded-by-heap-architecture.md
@@ -5,6 +5,7 @@ class: substrate-architecture
 status: open
 title: Close B-0088 chain as superseded by B-0423 heap architecture
 created: 2026-05-13
+last_updated: 2026-05-13
 parent: B-0423
 depends_on: [B-0423.4]
 composes_with: [B-0423, B-0423.4, B-0088, B-0088.1, B-0088.2, B-0088.3]


### PR DESCRIPTION
## Summary

- Decomposes B-0423 (MEMORY.md serialization-point anti-pattern, P1) into 5 atomic, dependency-ordered child rows
- Prior art found: `tools/memory/reindex-memory-md.ts` is already implemented; MEMORY.md preamble already has stack/heap framing
- Three remaining implementation notes (CI relaxation, documentation, loop wiring) become slices 1–4

## Child rows

| Row | Title | Depends on | Effort |
|-----|-------|-----------|--------|
| B-0423.1 | Extend reindex-memory-md.ts test coverage | — | XS |
| B-0423.2 | Update memory/ docs for heap-state-acceptable model | — | XS |
| B-0423.3 | Wire reindex into autonomous-loop tick cadence | B-0423.1 | S |
| B-0423.4 | Relax memory-index-integrity.yml CI check | B-0423.1, B-0423.3 | S |
| B-0423.5 | Close B-0088 chain as superseded by B-0423 | B-0423.4 | XS |

## Key dependency insight

B-0423.4 (CI relaxation — the core serialization-point fix) must not land before B-0423.3 (loop wiring). Removing the paired-edit gate without automatic reindexing would leave MEMORY.md permanently stale.

## B-0088 supersession

B-0423.4 supersedes B-0088 and its children (B-0088.1, B-0088.2, B-0088.3). Those rows asked "promote or weaken the paired-edit lint?" — B-0423 answers with a stronger architectural fix: remove the synchronous paired-edit architecture entirely.

## Focused checks

```
dotnet build -c Release  →  0 Warning(s), 0 Error(s)  ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)