### PR TITLE
test(memory): B-0423.1 — extend reindex-memory-md.ts test coverage

### DIFF
--- a/tools/memory/reindex-memory-md.test.ts
+++ b/tools/memory/reindex-memory-md.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { parseFrontmatter } from "./reindex-memory-md.ts";
+import { join } from "node:path";
+import {
+  collectEntries,
+  MAX_STACK_ENTRIES,
+  parseFrontmatter,
+  PREAMBLE_END,
+  PREAMBLE_MARKER,
+  renderIndex,
+} from "./reindex-memory-md.ts";
+
+const TESTDATA = join(import.meta.dir, "testdata");
 
 describe("parseFrontmatter", () => {
   test("parses simple key: value frontmatter", () => {
@@ -47,5 +57,113 @@ body`;
     const fm = parseFrontmatter(content);
     expect(fm?.name).toBe("quoted name");
     expect(fm?.description).toBe("single-quoted desc");
+  });
+});
+
+describe("collectEntries", () => {
+  test("collects files with valid frontmatter", async () => {
+    const entries = await collectEntries(TESTDATA);
+    const names = entries.map((e) => e.fm.name);
+    expect(names).toContain("alpha-entry");
+    expect(names).toContain("beta-entry");
+  });
+
+  test("excludes MEMORY.md and README.md", async () => {
+    const entries = await collectEntries(TESTDATA);
+    const filenames = entries.map((e) => e.filename);
+    expect(filenames).not.toContain("MEMORY.md");
+    expect(filenames).not.toContain("README.md");
+  });
+
+  test("excludes CURRENT-* files", async () => {
+    const entries = await collectEntries(TESTDATA);
+    const filenames = entries.map((e) => e.filename);
+    expect(filenames.some((f) => f.startsWith("CURRENT-"))).toBe(false);
+  });
+
+  test("excludes files without frontmatter", async () => {
+    const entries = await collectEntries(TESTDATA);
+    const filenames = entries.map((e) => e.filename);
+    expect(filenames).not.toContain("no_frontmatter.md");
+  });
+
+  test("sorts newest-first by created date", async () => {
+    const entries = await collectEntries(TESTDATA);
+    // beta (2026-05-10) is newer than alpha (2026-05-01)
+    const betaIdx = entries.findIndex((e) => e.fm.name === "beta-entry");
+    const alphaIdx = entries.findIndex((e) => e.fm.name === "alpha-entry");
+    expect(betaIdx).toBeGreaterThanOrEqual(0);
+    expect(alphaIdx).toBeGreaterThanOrEqual(0);
+    expect(betaIdx).toBeLessThan(alphaIdx);
+  });
+
+  test("exposes date field from created frontmatter key", async () => {
+    const entries = await collectEntries(TESTDATA);
+    const alpha = entries.find((e) => e.fm.name === "alpha-entry");
+    expect(alpha?.date).toBe("2026-05-01");
+  });
+});
+
+describe("renderIndex", () => {
+  const makeEntry = (name: string, description: string, created: string) => ({
+    filename: `${name}.md`,
+    fm: { name, description, type: "feedback" as const, created },
+    date: created,
+    mtime: 0,
+  });
+
+  test("includes PREAMBLE_MARKER and PREAMBLE_END delimiters", () => {
+    const output = renderIndex([makeEntry("x", "desc", "2026-05-01")]);
+    expect(output).toContain(PREAMBLE_MARKER);
+    expect(output).toContain(PREAMBLE_END);
+    expect(output.indexOf(PREAMBLE_MARKER)).toBeLessThan(output.indexOf(PREAMBLE_END));
+  });
+
+  test("includes last reindex date matching today", () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const output = renderIndex([makeEntry("x", "desc", "2026-05-01")]);
+    expect(output).toContain(`Last reindex: ${today}`);
+  });
+
+  test("truncates description at 240 characters", () => {
+    const longDesc = "a".repeat(300);
+    const output = renderIndex([makeEntry("long", longDesc, "2026-05-01")]);
+    // Entry line format: - [**long**](long.md) — <desc>
+    const match = output.match(/^- \[.*?\]\(long\.md\) — ([^\n]+)/m);
+    expect(match).not.toBeNull();
+    const rendered = match![1]!;
+    expect(rendered.endsWith("…")).toBe(true);
+    expect(rendered.length).toBeLessThanOrEqual(240);
+  });
+
+  test("renders all entries when count <= MAX_STACK_ENTRIES", () => {
+    const entries = Array.from({ length: 5 }, (_, i) =>
+      makeEntry(`entry-${i}`, `desc-${i}`, `2026-05-0${i + 1}`),
+    );
+    const output = renderIndex(entries);
+    for (const e of entries) {
+      expect(output).toContain(e.fm.name);
+    }
+    expect(output).not.toContain("Stack truncated");
+  });
+
+  test("truncates stack at MAX_STACK_ENTRIES and appends overflow note", () => {
+    const entries = Array.from({ length: MAX_STACK_ENTRIES + 5 }, (_, i) =>
+      makeEntry(`entry-${i}`, `desc-${i}`, `2026-05-01`),
+    );
+    const output = renderIndex(entries);
+    expect(output).toContain(`Stack truncated at ${MAX_STACK_ENTRIES} most-recent entries`);
+    expect(output).toContain("5 additional memory files in heap");
+  });
+
+  test("uses filename stem as name when fm.name is absent", () => {
+    const entry = {
+      filename: "no_name_entry.md",
+      fm: { description: "no name" },
+      date: "2026-05-01",
+      mtime: 0,
+    };
+    const output = renderIndex([entry]);
+    expect(output).toContain("no_name_entry");
   });
 });

--- a/tools/memory/reindex-memory-md.ts
+++ b/tools/memory/reindex-memory-md.ts
@@ -89,14 +89,15 @@ function dateFromFilename(filename: string): string {
   return `${match[1]}-${match[2]}-${match[3]}`;
 }
 
-async function collectEntries(): Promise<MemoryEntry[]> {
-  const files = await readdir(MEMORY_DIR);
+async function collectEntries(dir?: string): Promise<MemoryEntry[]> {
+  const targetDir = dir ?? MEMORY_DIR;
+  const files = await readdir(targetDir);
   const entries: MemoryEntry[] = [];
   for (const filename of files) {
     if (!filename.endsWith(".md")) continue;
     if (filename === "MEMORY.md" || filename === "README.md") continue;
     if (filename.startsWith("CURRENT-")) continue;
-    const filePath = join(MEMORY_DIR, filename);
+    const filePath = join(targetDir, filename);
     const content = await readFile(filePath, "utf8");
     const fm = parseFrontmatter(content);
     if (!fm) continue;
@@ -185,4 +186,4 @@ if (import.meta.main) {
   });
 }
 
-export { collectEntries, renderIndex, parseFrontmatter };
+export { collectEntries, renderIndex, parseFrontmatter, PREAMBLE_MARKER, PREAMBLE_END, MAX_STACK_ENTRIES };

--- a/tools/memory/testdata/CURRENT-otto.md
+++ b/tools/memory/testdata/CURRENT-otto.md
@@ -1,0 +1,8 @@
+---
+name: current-otto-fixture
+description: CURRENT- prefixed file — should be excluded by collectEntries
+type: user
+created: 2026-05-13
+---
+
+Current file fixture.

--- a/tools/memory/testdata/MEMORY.md
+++ b/tools/memory/testdata/MEMORY.md
@@ -1,0 +1,1 @@
+# Fixture MEMORY.md — should be excluded by collectEntries

--- a/tools/memory/testdata/README.md
+++ b/tools/memory/testdata/README.md
@@ -1,0 +1,1 @@
+# Fixture README.md — should be excluded by collectEntries

--- a/tools/memory/testdata/feedback_alpha_2026_05_01.md
+++ b/tools/memory/testdata/feedback_alpha_2026_05_01.md
@@ -1,0 +1,8 @@
+---
+name: alpha-entry
+description: Alpha test entry for B-0423.1 coverage — parseFrontmatter and collectEntries path
+type: feedback
+created: 2026-05-01
+---
+
+Alpha content body.

--- a/tools/memory/testdata/no_frontmatter.md
+++ b/tools/memory/testdata/no_frontmatter.md
@@ -1,0 +1,3 @@
+# No frontmatter
+
+This file has no YAML frontmatter and should be excluded by collectEntries.

--- a/tools/memory/testdata/user_beta_2026_05_10.md
+++ b/tools/memory/testdata/user_beta_2026_05_10.md
@@ -1,0 +1,8 @@
+---
+name: beta-entry
+description: Beta test entry for B-0423.1 coverage — newer date should sort first
+type: user
+created: 2026-05-10
+---
+
+Beta content body.


### PR DESCRIPTION
## Summary

- Adds `collectEntries` optional `dir` param so tests can pass a fixture directory (DST-compatible; no `process.chdir()` required)
- Exports `PREAMBLE_MARKER`, `PREAMBLE_END`, `MAX_STACK_ENTRIES` for test assertions
- Creates `tools/memory/testdata/` with 6 deterministic fixture files
- 12 new tests covering all acceptance criteria from B-0423.1

## Acceptance criteria verification

- [x] `collectEntries` tested with synthetic fixture directory
  - Valid frontmatter files collected
  - `MEMORY.md`, `README.md`, `CURRENT-*`, no-frontmatter files excluded
  - Sorted newest-first by `created:` date
- [x] `renderIndex` tested
  - `PREAMBLE_MARKER` / `PREAMBLE_END` delimiters present and ordered
  - Descriptions truncated at 240 characters with `…`
  - Stack truncated at `MAX_STACK_ENTRIES` (100) with overflow note
  - `Last reindex: YYYY-MM-DD` matches current date
- [x] All 16 tests pass (`bun test tools/memory/reindex-memory-md.test.ts`)
- [x] `dotnet build -c Release` → 0 Warning(s), 0 Error(s)

## Test plan

```
bun test tools/memory/reindex-memory-md.test.ts  # 16 pass, 0 fail
dotnet build -c Release                           # 0 warnings, 0 errors
```

Closes B-0423.1. Gates B-0423.3 (loop wiring) and B-0423.4 (CI relaxation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)