### PR TITLE
docs(memory): B-0423.2 — update memory/ docs for heap-state-acceptable model

### DIFF
--- a/memory/README.md
+++ b/memory/README.md
@@ -85,8 +85,11 @@ memories freely — that is the whole point of this folder.
   correction, a decision, a project fact). In the right type
   bucket: feedback / project / user / reference.
 - New memory files **must have valid frontmatter** (`name:`,
-  `description:`, `type:`, `created:` fields). The reindexer
-  requires these to build the MEMORY.md stack view.
+  `description:`, `type:` required; `created:` strongly recommended).
+  The reindexer only skips files with **no frontmatter block at all** —
+  missing individual fields use safe fallbacks (see
+  `memory/project_memory_format_standard.md` §6.4 for the full
+  fallback/enforcement table).
 - A synchronous MEMORY.md paired-edit is **no longer required**
   (heap-state model, B-0423). `MEMORY.md` is kept current by
   `tools/memory/reindex-memory-md.ts` running on cadence via the

--- a/memory/README.md
+++ b/memory/README.md
@@ -84,8 +84,15 @@ memories freely — that is the whole point of this folder.
 - Write new files when something durable is learned (a
   correction, a decision, a project fact). In the right type
   bucket: feedback / project / user / reference.
-- Update MEMORY.md to include new entries at the top
-  (newest-first). Keep the index terse.
+- New memory files **must have valid frontmatter** (`name:`,
+  `description:`, `type:`, `created:` fields). The reindexer
+  requires these to build the MEMORY.md stack view.
+- A synchronous MEMORY.md paired-edit is **no longer required**
+  (heap-state model, B-0423). `MEMORY.md` is kept current by
+  `tools/memory/reindex-memory-md.ts` running on cadence via the
+  autonomous-loop tick. Agents MAY run it manually to promote heap
+  files to the stack view immediately:
+  `bun tools/memory/reindex-memory-md.ts`
 - Revise existing entries when they drift, when a new
   maintainer message refines the rule, or when a memory
   folds into a newer one. Leave a correction note when the
@@ -93,6 +100,31 @@ memories freely — that is the whole point of this folder.
 - Delete entries when they are no longer useful or have been
   subsumed by a newer memory. The agents are trusted to curate
   their own corpus.
+
+## Stack-vs-heap model (B-0423)
+
+`MEMORY.md` is the **STACK** — an indexed, ordered, traversable
+canonical view of the heap. Files in `memory/` that have not yet
+been promoted to the MEMORY.md index are in **HEAP** state —
+floating cache, accessible by direct path, not yet visible through
+the index traversal.
+
+Both states are valid:
+
+- **Stack** (indexed): visible via MEMORY.md traversal; preferred
+  for retrieval when the index is current.
+- **Heap** (unindexed): accessible by direct path or timestamp/
+  filename; the normal state for recently-committed memory files
+  before the next reindex cadence fires.
+
+Heap→stack promotion happens on cadence (not per-PR) via
+`tools/memory/reindex-memory-md.ts` (B-0423), callable from the
+autonomous-loop tick. Readers should assume the newest few entries
+may be in heap state and check direct paths if the index seems
+stale.
+
+The architectural fix and its child implementation rows are tracked
+at `docs/backlog/P1/B-0423-memory-md-serialization-point-2026-05-12.md`.
 
 The reason the *human* rule is stricter: humans deleting
 memories behind the agents' backs amounts to silently

--- a/memory/project_memory_format_standard.md
+++ b/memory/project_memory_format_standard.md
@@ -279,7 +279,7 @@ skipped:
 |---|---|---|
 | `name:` | Falls back to filename (without `.md`) | Error — enforced |
 | `description:` | Falls back to `"(no description)"` | Error — enforced |
-| `type:` | Inferred from filename prefix if possible | Error — enforced |
+| `type:` | Not used by reindexer; B-0335 `--fix` auto-infers from filename prefix | Error — enforced |
 | `created:` | Falls back to date extracted from filename, or `"0000-00-00"` | Not enforced by B-0335 |
 
 Best practice: include all four fields so the index entry is

--- a/memory/project_memory_format_standard.md
+++ b/memory/project_memory_format_standard.md
@@ -269,20 +269,25 @@ Three existing files validated against this standard:
 ### 6.4 Heap-state validation (B-0423)
 
 Under the heap-state-acceptable model, a memory file does not
-require a MEMORY.md paired-edit, but MUST satisfy the reindexer
-contract:
+require a MEMORY.md paired-edit. The reindexer
+(`tools/memory/reindex-memory-md.ts`) only skips files with **no
+frontmatter block at all**. Files with frontmatter but missing
+individual fields fall back to safe defaults rather than being
+skipped:
 
-| Field | Required | Notes |
+| Field | Behavior when missing | B-0335 enforcement |
 |---|---|---|
-| `name:` | **yes** | Used as display title in the index entry. |
-| `description:` | **yes** | Retrieval key — be specific. |
-| `type:` | **yes** | Must be `feedback`, `user`, `project`, or `reference`. |
-| `created:` | **yes** | ISO date `YYYY-MM-DD`. Used for newest-first sort. |
+| `name:` | Falls back to filename (without `.md`) | Error — enforced |
+| `description:` | Falls back to `"(no description)"` | Error — enforced |
+| `type:` | Inferred from filename prefix if possible | Error — enforced |
+| `created:` | Falls back to date extracted from filename, or `"0000-00-00"` | Not enforced by B-0335 |
 
-Files missing any required field will be silently skipped by
-`tools/memory/reindex-memory-md.ts` (they never promote from
-heap to stack). B-0335 validation tooling enforces these fields
-mechanically.
+Best practice: include all four fields so the index entry is
+useful. Files with missing `name`, `description`, or `type`
+will be flagged as errors by B-0335 validation
+(`tools/hygiene/validate-memory-schema.ts --enforce`). The
+`created` field is not yet mechanically enforced but strongly
+recommended for correct newest-first sort order.
 
 ## 7 Scope and boundaries
 

--- a/memory/project_memory_format_standard.md
+++ b/memory/project_memory_format_standard.md
@@ -215,6 +215,14 @@ Each entry in `MEMORY.md` follows the pattern:
 - The hook should be distinct enough to decide relevance
   without reading the file.
 
+**Heap-state-acceptable (B-0423):** a new memory file does **not**
+require a same-PR MEMORY.md paired-edit. Files without an index
+entry are in **heap** state — valid and accessible by direct path.
+`tools/memory/reindex-memory-md.ts` promotes heap files to the
+stack view on cadence (called from the autonomous-loop tick).
+Agents may run it manually:
+`bun tools/memory/reindex-memory-md.ts`
+
 ## 6 Validation smoke check
 
 Three existing files validated against this standard:
@@ -257,6 +265,24 @@ Three existing files validated against this standard:
   and descriptive. **PASS.**
 - Composes-with: References `reference_autodream_feature.md`
   in description. File exists. **PASS.**
+
+### 6.4 Heap-state validation (B-0423)
+
+Under the heap-state-acceptable model, a memory file does not
+require a MEMORY.md paired-edit, but MUST satisfy the reindexer
+contract:
+
+| Field | Required | Notes |
+|---|---|---|
+| `name:` | **yes** | Used as display title in the index entry. |
+| `description:` | **yes** | Retrieval key — be specific. |
+| `type:` | **yes** | Must be `feedback`, `user`, `project`, or `reference`. |
+| `created:` | **yes** | ISO date `YYYY-MM-DD`. Used for newest-first sort. |
+
+Files missing any required field will be silently skipped by
+`tools/memory/reindex-memory-md.ts` (they never promote from
+heap to stack). B-0335 validation tooling enforces these fields
+mechanically.
 
 ## 7 Scope and boundaries
 


### PR DESCRIPTION
## Summary

- Updates `memory/README.md` to replace the old synchronous paired-edit instruction with the heap-state model (B-0423)
- Updates `memory/project_memory_format_standard.md` §5 + adds §6.4 (heap-state validation)

Until these docs are updated, cold-booting agents follow the old discipline, defeating the B-0423 architectural fix.

## Acceptance criteria verification

- [x] `memory/README.md` — "Agents writing memories" section updated: frontmatter required, paired-edit not required, reindexer runs on cadence
- [x] `memory/README.md` — "Stack-vs-heap model" subsection added, links to B-0423
- [x] `memory/project_memory_format_standard.md` §5 — heap-state-acceptable note added
- [x] `memory/project_memory_format_standard.md` §6.4 — new subsection documenting the 4 required frontmatter fields for reindexer contract
- [x] `bunx markdownlint-cli2 memory/README.md memory/project_memory_format_standard.md` → clean
- [x] `dotnet build -c Release` → 0 Warning(s), 0 Error(s)

## Test plan

```
bunx markdownlint-cli2 memory/README.md memory/project_memory_format_standard.md
dotnet build -c Release
```

Closes B-0423.2. Composes with B-0423.1 (test coverage) and gates B-0423.4 (CI relaxation — docs should describe the contract before CI stops enforcing the old one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)