### PR TITLE
feat(scaffold): B-0424.2 — workflow_dispatch gate for Stage 1 repo creation

### DIFF
--- a/.github/workflows/scaffold-stage1-create-repos.yml
+++ b/.github/workflows/scaffold-stage1-create-repos.yml
@@ -64,13 +64,28 @@ jobs:
       contents: read  # checkout only; all gh API calls use SCAFFOLD_STAGE1_PAT
 
     steps:
+      - name: Validate actor allowlist
+        env:
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          # Restrict execution to LFG org maintainers; write access alone is not sufficient.
+          # Update this list via PR when the maintainer roster changes.
+          ALLOWED="AceHack"
+          if ! echo "$ALLOWED" | grep -qw "$ACTOR"; then
+            echo "ERROR: '$ACTOR' is not in the maintainer allowlist."
+            echo "Only authorised LFG org maintainers may trigger this workflow."
+            exit 1
+          fi
+          echo "Actor '$ACTOR' is authorised. Proceeding."
+
       - name: Validate CONFIRM input
         env:
           CONFIRM_INPUT: ${{ github.event.inputs.confirm }}
         run: |
           set -euo pipefail
           if [ "$CONFIRM_INPUT" != "CONFIRM" ]; then
-            echo "ERROR: confirm input must be exactly CONFIRM (got: '$CONFIRM_INPUT')"
+            echo "ERROR: confirm input must be exactly 'CONFIRM' (all caps)."
             echo "Re-trigger the workflow with confirm=CONFIRM to proceed."
             exit 1
           fi
@@ -78,6 +93,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
         run: ./tools/setup/install.sh

--- a/.github/workflows/scaffold-stage1-create-repos.yml
+++ b/.github/workflows/scaffold-stage1-create-repos.yml
@@ -1,0 +1,153 @@
+name: scaffold-stage1-create-repos
+
+# B-0424.2 — Stage 1 of the three-repo split: create LFG/Forge and LFG/ace
+# with the full best-practice checklist from
+# docs/DECISIONS/2026-04-22-three-repo-split-zeta-forge-ace.md.
+#
+# WHY workflow_dispatch only (no schedule):
+# This is an irreversible one-shot operation. Creating GitHub repos is
+# permanent; the workflow must be triggered by explicit maintainer action
+# from the GitHub UI after reviewing the PR that adds this file.
+#
+# PREREQUISITES before triggering:
+# 1. This workflow is merged to main.
+# 2. A GitHub secret named SCAFFOLD_STAGE1_PAT has been created in the
+#    LFG org (or Zeta repo) Settings → Secrets with a PAT that has:
+#    repo, read:org, workflow scopes on a user with LFG org owner/admin rights.
+#    (GITHUB_TOKEN cannot create org repos — its scope is the current repo only.)
+# 3. Verify dry-run output locally first:
+#    bun tools/scaffold/create-repo.ts --repo forge --dry-run
+#    bun tools/scaffold/create-repo.ts --repo ace  --dry-run
+#
+# SECURITY (safe-pattern compliance):
+# All workflow_dispatch inputs are routed via env: into run blocks and
+# quoted as "$VAR"; no ${{ expressions }} appear inside run-block scripts.
+# See .github/workflows/budget-snapshot-cadence.yml for the factory pattern.
+#
+# IDEMPOTENCY:
+# If a repo already exists, gh repo create exits non-zero → step fails loudly.
+# The workflow aborts; no partial state is silently swallowed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: "Which repo to create (forge, ace, or both)"
+        required: true
+        type: choice
+        options:
+          - forge
+          - ace
+          - both
+      confirm:
+        description: "Type CONFIRM (all caps) — creates real GitHub repos (irreversible)"
+        required: true
+        default: ""
+
+permissions:
+  # Top-level read-only (Scorecard TokenPermissions best-practice).
+  # Org repo creation uses SCAFFOLD_STAGE1_PAT, not GITHUB_TOKEN.
+  contents: read
+
+concurrency:
+  # One creation run at a time; no cancel so partial state isn't silently
+  # overridden — operator must inspect first.
+  group: scaffold-stage1-create-repos
+  cancel-in-progress: false
+
+jobs:
+  create-repos:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    permissions:
+      contents: read  # checkout only; all gh API calls use SCAFFOLD_STAGE1_PAT
+
+    steps:
+      - name: Validate CONFIRM input
+        env:
+          CONFIRM_INPUT: ${{ github.event.inputs.confirm }}
+        run: |
+          set -euo pipefail
+          if [ "$CONFIRM_INPUT" != "CONFIRM" ]; then
+            echo "ERROR: confirm input must be exactly CONFIRM (got: '$CONFIRM_INPUT')"
+            echo "Re-trigger the workflow with confirm=CONFIRM to proceed."
+            exit 1
+          fi
+          echo "Confirmation accepted. Proceeding with repo creation."
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        run: ./tools/setup/install.sh
+
+      - name: Verify gh CLI authentication
+        env:
+          GH_TOKEN: ${{ secrets.SCAFFOLD_STAGE1_PAT }}
+        run: |
+          set -euo pipefail
+          command -v bun >/dev/null
+          command -v gh >/dev/null
+          gh auth status
+
+      - name: Dry-run preview (informational)
+        env:
+          GH_TOKEN: ${{ secrets.SCAFFOLD_STAGE1_PAT }}
+          REPO_INPUT: ${{ github.event.inputs.repo }}
+        run: |
+          set -euo pipefail
+          echo "=== DRY-RUN PREVIEW ==="
+          if [ "$REPO_INPUT" = "forge" ] || [ "$REPO_INPUT" = "both" ]; then
+            echo "--- Forge ---"
+            bun tools/scaffold/create-repo.ts --repo forge --dry-run
+          fi
+          if [ "$REPO_INPUT" = "ace" ] || [ "$REPO_INPUT" = "both" ]; then
+            echo "--- ace ---"
+            bun tools/scaffold/create-repo.ts --repo ace --dry-run
+          fi
+          echo "=== END DRY-RUN ==="
+
+      - name: Create Forge repo
+        if: ${{ github.event.inputs.repo == 'forge' || github.event.inputs.repo == 'both' }}
+        env:
+          GH_TOKEN: ${{ secrets.SCAFFOLD_STAGE1_PAT }}
+        run: |
+          set -euo pipefail
+          bun tools/scaffold/create-repo.ts --repo forge --apply
+
+      - name: Create ace repo
+        if: ${{ github.event.inputs.repo == 'ace' || github.event.inputs.repo == 'both' }}
+        env:
+          GH_TOKEN: ${{ secrets.SCAFFOLD_STAGE1_PAT }}
+        run: |
+          set -euo pipefail
+          bun tools/scaffold/create-repo.ts --repo ace --apply
+
+      - name: Post-creation summary
+        if: success()
+        env:
+          REPO_INPUT: ${{ github.event.inputs.repo }}
+        run: |
+          set -euo pipefail
+          echo "=== CREATION COMPLETE ==="
+          echo "Repos created: $REPO_INPUT"
+          echo ""
+          echo "Manual steps remaining (create-repo.ts step 07):"
+          echo "  1. Upload SVG social-preview PNG via GitHub UI"
+          echo "  2. Enable merge queue: Settings → Merge queue (no REST API)"
+          echo "  3. Wire OpenSSF Scorecard: copy .github/workflows/scorecard.yml from Zeta"
+          echo "  4. Add Semgrep GHA inline-untrusted-in-run rule"
+          echo "  5. Verify \$0 budget caps at LFG org billing settings"
+          echo "  6. Confirm CodeQL default-setup: Security → Code scanning"
+          echo ""
+          if [ "$REPO_INPUT" = "forge" ] || [ "$REPO_INPUT" = "both" ]; then
+            echo "  Forge: https://github.com/Lucent-Financial-Group/Forge"
+          fi
+          if [ "$REPO_INPUT" = "ace" ] || [ "$REPO_INPUT" = "both" ]; then
+            echo "  ace:   https://github.com/Lucent-Financial-Group/ace"
+          fi
+          echo ""
+          echo "After verifying the repos, update the ADR and close B-0424:"
+          echo "  docs/DECISIONS/2026-04-22-three-repo-split-zeta-forge-ace.md"
+          echo "  docs/backlog/P1/B-0424-three-repo-split-stage1-create-forge-ace-with-scaffolding-aaron-2026-05-13.md"


### PR DESCRIPTION
## Summary

B-0424.2 — the \"follow-up PR with Aaron's review\" that B-0424.1 explicitly deferred.

Adds `.github/workflows/scaffold-stage1-create-repos.yml`: a `workflow_dispatch`-only
workflow that creates `LFG/Forge` and `LFG/ace` using the
`tools/scaffold/create-repo.ts --apply` path landed in B-0424.1 (PR #2994).

## Why this design

Creating GitHub repos is irreversible. The workflow gates execution behind:

1. **Explicit maintainer trigger** — `workflow_dispatch` only, no schedule.
2. **CONFIRM text input** — must type exactly `CONFIRM` or step 1 fails loudly.
3. **`SCAFFOLD_STAGE1_PAT` secret** — `GITHUB_TOKEN` cannot create org repos
   (its scope is the current repo). A PAT with `repo, read:org, workflow` scopes
   on an LFG org owner/admin is required. Create it at:
   `Settings → Secrets and variables → Actions → New repository secret`.

## Safe-pattern compliance

All `workflow_dispatch` inputs are routed via `env:` into `run:` blocks and
referenced as `"$VAR"` — no `${{ expressions }}` interpolated directly in
shell scripts. See `budget-snapshot-cadence.yml` for the factory pattern.

- SHA-pinned checkout: `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
- `contents: read` at workflow + job level
- Concurrency group prevents double-trigger race

## Dry-run output (verified before PR)

```
Forge: DRY RUN — 12 operations planned for Lucent-Financial-Group/Forge
  01-create-repo, 01b-merge-settings, 06-push-scaffold-files (10 files),
  02-branch-protection, 02b-required-signed-commits,
  03a-secret-scanning, 03b-dependabot-alerts, 03c-dependabot-security-updates,
  03d-private-vuln-reporting, 04-codeql-default-setup,
  05-fork-to-acehack, 07-next-steps

ace: DRY RUN — 12 operations planned for Lucent-Financial-Group/ace
  (same step sequence, ace-scoped governance files)
```

## Build gate

`dotnet build -c Release` → **0 Warning(s) 0 Error(s)**

## How to trigger after merge

1. Create `SCAFFOLD_STAGE1_PAT` secret (PAT: `repo, read:org, workflow` scopes).
2. Go to **Actions → scaffold-stage1-create-repos → Run workflow**.
3. Select repo: `both` (or `forge` / `ace` individually).
4. Type `CONFIRM` in the confirm field.
5. Click **Run workflow**.

Manual steps after the workflow completes (printed in step 7):
- Upload SVG social-preview PNG (GitHub requires rasterized PNG)
- Enable merge queue via GitHub UI (no REST API)
- Wire OpenSSF Scorecard workflow (copy from Zeta's `.github/workflows/scorecard.yml`)
- Add Semgrep GHA inline-untrusted-in-run rule
- Verify \$0 budget caps at LFG org billing
- Confirm CodeQL default-setup is active

## Relation to B-0424

- B-0424.1 (PR #2994, merged): templates + dry-run tool ✅
- **B-0424.2 (this PR)**: `workflow_dispatch` gate for `--apply` execution
- B-0424 DOD: repos exist + scaffolding 100% applied — closes after Aaron triggers workflow

operative-authorization: aaron 2026-05-13: "Cooling period: TBD. The memory file IS the durable record"

Co-Authored-By: Claude <noreply@anthropic.com>