### PR TITLE
feat(scaffold): B-0424.3 — UPSTREAM-RHYTHM.md templates for Forge + ace scaffold dirs

### DIFF
--- a/tools/scaffold/README.md
+++ b/tools/scaffold/README.md
@@ -51,9 +51,13 @@ tools/scaffold/
       copilot-instructions.md
     docs/
       GITHUB-SETTINGS.md
+      UPSTREAM-RHYTHM.md
 
   ace/                   — ace day-one governance files
     (same structure, ace-scoped content)
+    docs/
+      GITHUB-SETTINGS.md
+      UPSTREAM-RHYTHM.md
 
   create-repo.ts         — this tool
   README.md              — this file

--- a/tools/scaffold/ace/docs/UPSTREAM-RHYTHM.md
+++ b/tools/scaffold/ace/docs/UPSTREAM-RHYTHM.md
@@ -4,8 +4,8 @@ This doc is **ace-specific** project configuration for the
 `fork-pr-workflow` skill. The skill itself is factory-generic
 and defers the upstream-cadence choice to project-level
 configuration (see
-`.claude/skills/fork-pr-workflow/SKILL.md` §"Optional
-overlay: batched upstream rhythm"). This doc is that
+`Lucent-Financial-Group/Zeta: .claude/skills/fork-pr-workflow/SKILL.md`
+§"Optional overlay: batched upstream rhythm"). This doc is that
 configuration for ace.
 
 ## Terminology — two surfaces

--- a/tools/scaffold/ace/docs/UPSTREAM-RHYTHM.md
+++ b/tools/scaffold/ace/docs/UPSTREAM-RHYTHM.md
@@ -86,8 +86,8 @@ gh pr create \
   --title "Sync: AceHack/ace:main → LFG/ace:main (batch of N PRs)" \
   --body "Bulk upstream sync per docs/UPSTREAM-RHYTHM.md cadence."
 
-# Use --merge (not --squash) to preserve ancestry for forward-sync.
-gh pr merge <N> --repo Lucent-Financial-Group/ace --auto --merge
+# Squash-merge matches LFG/ace's squash-only merge settings (scaffold default).
+gh pr merge <N> --repo Lucent-Financial-Group/ace --auto --squash
 ```
 
 ### Forward-sync AceHack/main from LFG/main (after a bulk sync)

--- a/tools/scaffold/ace/docs/UPSTREAM-RHYTHM.md
+++ b/tools/scaffold/ace/docs/UPSTREAM-RHYTHM.md
@@ -75,7 +75,7 @@ gh pr merge <N> --repo AceHack/ace --auto --squash
 # Precondition: AceHack/ace:main is ahead of
 # Lucent-Financial-Group/ace:main by ~10 commits.
 # Check:
-gh api /repos/AceHack/ace/compare/main...Lucent-Financial-Group:main \
+gh api /repos/AceHack/ace/compare/Lucent-Financial-Group:main...main \
   --jq '.status,.ahead_by,.behind_by'
 
 # Open ONE bulk sync PR.

--- a/tools/scaffold/ace/docs/UPSTREAM-RHYTHM.md
+++ b/tools/scaffold/ace/docs/UPSTREAM-RHYTHM.md
@@ -86,13 +86,23 @@ gh pr create \
   --title "Sync: AceHack/ace:main → LFG/ace:main (batch of N PRs)" \
   --body "Bulk upstream sync per docs/UPSTREAM-RHYTHM.md cadence."
 
-# Squash-merge matches LFG/ace's squash-only merge settings (scaffold default).
+# NOTE: --squash is required because LFG/ace is squash-only (scaffold default).
+# Unlike Zeta's canonical docs/UPSTREAM-RHYTHM.md (which uses --merge to
+# preserve ancestry), squash-merge rewrites history so LFG/ace:main is no
+# longer a descendant of AceHack/ace:main. The forward-sync still works but
+# produces a non-fast-forward merge commit instead of a true fast-forward.
+# After that merge commit lands, compare/Lucent-Financial-Group:main...main
+# will show ahead_by=1 (the merge commit) — this is expected and does NOT
+# indicate another bulk sync is needed.
 gh pr merge <N> --repo Lucent-Financial-Group/ace --auto --squash
 ```
 
 ### Forward-sync AceHack/main from LFG/main (after a bulk sync)
 
 ```bash
+# GitHub's fork-upstream sync API. Because the bulk-sync above used --squash
+# (not --merge), LFG/ace:main is not a fast-forward ancestor of AceHack:main.
+# merge-upstream handles this by creating a merge commit on AceHack/main.
 gh api -X POST /repos/AceHack/ace/merge-upstream -f branch=main
 ```
 

--- a/tools/scaffold/ace/docs/UPSTREAM-RHYTHM.md
+++ b/tools/scaffold/ace/docs/UPSTREAM-RHYTHM.md
@@ -1,0 +1,128 @@
+# Upstream rhythm — ace's fork-first PR cadence
+
+This doc is **ace-specific** project configuration for the
+`fork-pr-workflow` skill. The skill itself is factory-generic
+and defers the upstream-cadence choice to project-level
+configuration (see
+`.claude/skills/fork-pr-workflow/SKILL.md` §"Optional
+overlay: batched upstream rhythm"). This doc is that
+configuration for ace.
+
+## Terminology — two surfaces
+
+ace has **two surfaces** (the repo axis):
+
+- **upstream** — `Lucent-Financial-Group/ace`. The parent repo.
+  Where releases, stable URLs, issue numbers, the canonical
+  commit history, and the social / governance edge live.
+- **fork** — `AceHack/ace`. The fork the human maintainer and
+  agents develop on day-to-day. Daily agent-loop PRs land here
+  so billed upstream surfaces aren't charged per-PR.
+
+When fork-vs-upstream disagree on anything, upstream wins.
+
+## ace's choice: batched fork-first rhythm
+
+**Default PR target for daily agent work:** the fork
+(`AceHack/ace:main`) — **not** upstream
+(`Lucent-Financial-Group/ace:main`).
+
+Agents develop on fork feature branches, open PRs against the
+fork's `main`, auto-merge there. Once `AceHack/ace:main` is
+~10 commits ahead of `Lucent-Financial-Group/ace:main`, **one**
+bulk sync PR lifts all accumulated work into upstream.
+
+```text
+feature-branches (AceHack)
+   \ \ \ \ \ \ \ \ \ \
+    v v v v v v v v v v
+    AceHack/ace:main ───────────────────────────────┐
+    (agent daily loop,                              │
+     free CI, free Copilot)                         │
+                                                    │ every ~10 PRs
+                                                    │ one bulk-sync PR
+                                                    v
+                                      Lucent-Financial-Group/ace:main
+                                      (LFG Copilot + Actions
+                                       billed ONCE per bulk sync,
+                                       not once per PR)
+```
+
+This pattern mirrors `Lucent-Financial-Group/Zeta`'s rhythm
+(`docs/UPSTREAM-RHYTHM.md` there is the canonical reference
+for the cost-rationale and threshold tuning guidance).
+
+## Concrete commands
+
+### Default PR (the 90% case)
+
+```bash
+# Agent opens a PR from its feature branch to AceHack's main.
+gh pr create \
+  --repo AceHack/ace \
+  --head AceHack:<branch> \
+  --base main \
+  --title "<title>" \
+  --body  "<body>"
+
+# Auto-merge on AceHack.
+gh pr merge <N> --repo AceHack/ace --auto --squash
+```
+
+### Bulk sync (every ~10 PRs)
+
+```bash
+# Precondition: AceHack/ace:main is ahead of
+# Lucent-Financial-Group/ace:main by ~10 commits.
+# Check:
+gh api /repos/AceHack/ace/compare/main...Lucent-Financial-Group:main \
+  --jq '.status,.ahead_by,.behind_by'
+
+# Open ONE bulk sync PR.
+gh pr create \
+  --repo Lucent-Financial-Group/ace \
+  --head AceHack:main \
+  --base main \
+  --title "Sync: AceHack/ace:main → LFG/ace:main (batch of N PRs)" \
+  --body "Bulk upstream sync per docs/UPSTREAM-RHYTHM.md cadence."
+
+# Use --merge (not --squash) to preserve ancestry for forward-sync.
+gh pr merge <N> --repo Lucent-Financial-Group/ace --auto --merge
+```
+
+### Forward-sync AceHack/main from LFG/main (after a bulk sync)
+
+```bash
+gh api -X POST /repos/AceHack/ace/merge-upstream -f branch=main
+```
+
+## When to bypass the batched rhythm
+
+Six named exceptions (same as Zeta's `docs/UPSTREAM-RHYTHM.md`):
+
+1. **Security P0** — any `docs/BUGS.md` P0-security row.
+2. **External-contributor dependency** — a change an external
+   contributor is actively waiting on.
+3. **Human maintainer explicit request** — overrides the rhythm.
+4. **CI-repair to LFG** — when LFG's gate is broken and the fix
+   must land on LFG immediately.
+5. **Bulk-sync PR itself** — the one PR that batches ~10 PRs.
+6. **LFG-only capability experiment** — a deliberate probe of
+   a capability that exists on LFG but not on AceHack.
+
+Outside these cases, default to AceHack.
+
+## Threshold tuning
+
+"~10 PRs" is a suggestion, not a hard rule. Range 5-20 is
+reasonable. Revisit every ~5 bulk syncs; record any change in
+an ADR under `docs/DECISIONS/`.
+
+## Cross-references
+
+- `Lucent-Financial-Group/Zeta: docs/UPSTREAM-RHYTHM.md` —
+  canonical cost-rationale and full guidance; ace follows
+  the same pattern.
+- `docs/DECISIONS/2026-04-22-three-repo-split-zeta-forge-ace.md`
+  (in Zeta) — ADR establishing the three-repo split and ace's
+  role as the package manager / Ouroboros peer.

--- a/tools/scaffold/ace/docs/UPSTREAM-RHYTHM.md
+++ b/tools/scaffold/ace/docs/UPSTREAM-RHYTHM.md
@@ -100,17 +100,31 @@ gh pr merge <N> --repo Lucent-Financial-Group/ace --auto --squash
 ### Forward-sync AceHack/main from LFG/main (after a bulk sync)
 
 ```bash
-# GitHub's fork-upstream sync API. Because the bulk-sync above used --squash
-# (not --merge), LFG/ace:main is not a fast-forward ancestor of AceHack:main.
-# merge-upstream handles this by creating a merge commit on AceHack/main.
-gh api -X POST /repos/AceHack/ace/merge-upstream -f branch=main
+# CAUTION: After a squash bulk-sync the fork's history has diverged from
+# LFG's (individual commits replaced by one squash commit). GitHub's
+# merge-upstream API is fast-forward-only; it returns 409/422 here and
+# cannot create a merge commit to resolve the divergence.
+#
+# Forward-sync is OPTIONAL in the squash-only scaffold: GitHub computes
+# bulk-sync PR diffs via 3-way merge against the common ancestor, so the
+# next batch's bulk-sync PR correctly diffs only the new commits even
+# without a forward-sync.
+#
+# To hard-reset AceHack/ace:main to match LFG/ace:main exactly
+# (requires force-push permission on AceHack/ace):
+#   git fetch https://github.com/Lucent-Financial-Group/ace.git main
+#   git push https://github.com/AceHack/ace.git FETCH_HEAD:refs/heads/main \
+#     --force-with-lease
 ```
 
 ## When to bypass the batched rhythm
 
 Six named exceptions (same as Zeta's `docs/UPSTREAM-RHYTHM.md`):
 
-1. **Security P0** — any `docs/BUGS.md` P0-security row.
+1. **Security P0** — any security P0 finding (track via GitHub Security
+   advisories or a `docs/BUGS.md` file once created, following
+   `Lucent-Financial-Group/Zeta: docs/BUGS.md` as the pattern;
+   this file is not included in the scaffold on day one).
 2. **External-contributor dependency** — a change an external
    contributor is actively waiting on.
 3. **Human maintainer explicit request** — overrides the rhythm.

--- a/tools/scaffold/forge/docs/UPSTREAM-RHYTHM.md
+++ b/tools/scaffold/forge/docs/UPSTREAM-RHYTHM.md
@@ -88,7 +88,7 @@ gh pr merge <N> --repo AceHack/Forge --auto --squash
 # Precondition: AceHack/Forge:main is ahead of
 # Lucent-Financial-Group/Forge:main by ~10 commits.
 # Check:
-gh api /repos/AceHack/Forge/compare/main...Lucent-Financial-Group:main \
+gh api /repos/AceHack/Forge/compare/Lucent-Financial-Group:main...main \
   --jq '.status,.ahead_by,.behind_by'
 
 # Open ONE bulk sync PR.

--- a/tools/scaffold/forge/docs/UPSTREAM-RHYTHM.md
+++ b/tools/scaffold/forge/docs/UPSTREAM-RHYTHM.md
@@ -4,8 +4,8 @@ This doc is **Forge-specific** project configuration for the
 `fork-pr-workflow` skill. The skill itself is factory-generic
 and defers the upstream-cadence choice to project-level
 configuration (see
-`.claude/skills/fork-pr-workflow/SKILL.md` §"Optional
-overlay: batched upstream rhythm"). This doc is that
+`Lucent-Financial-Group/Zeta: .claude/skills/fork-pr-workflow/SKILL.md`
+§"Optional overlay: batched upstream rhythm"). This doc is that
 configuration for Forge.
 
 ## Terminology — three surfaces

--- a/tools/scaffold/forge/docs/UPSTREAM-RHYTHM.md
+++ b/tools/scaffold/forge/docs/UPSTREAM-RHYTHM.md
@@ -99,13 +99,23 @@ gh pr create \
   --title "Sync: AceHack/Forge:main → LFG/Forge:main (batch of N PRs)" \
   --body "Bulk upstream sync per docs/UPSTREAM-RHYTHM.md cadence."
 
-# Squash-merge matches LFG/Forge's squash-only merge settings (scaffold default).
+# NOTE: --squash is required because LFG/Forge is squash-only (scaffold default).
+# Unlike Zeta's canonical docs/UPSTREAM-RHYTHM.md (which uses --merge to
+# preserve ancestry), squash-merge rewrites history so LFG/Forge:main is no
+# longer a descendant of AceHack/Forge:main. The forward-sync still works but
+# produces a non-fast-forward merge commit instead of a true fast-forward.
+# After that merge commit lands, compare/Lucent-Financial-Group:main...main
+# will show ahead_by=1 (the merge commit) — this is expected and does NOT
+# indicate another bulk sync is needed.
 gh pr merge <N> --repo Lucent-Financial-Group/Forge --auto --squash
 ```
 
 ### Forward-sync AceHack/main from LFG/main (after a bulk sync)
 
 ```bash
+# GitHub's fork-upstream sync API. Because the bulk-sync above used --squash
+# (not --merge), LFG/Forge:main is not a fast-forward ancestor of AceHack:main.
+# merge-upstream handles this by creating a merge commit on AceHack/main.
 gh api -X POST /repos/AceHack/Forge/merge-upstream -f branch=main
 ```
 

--- a/tools/scaffold/forge/docs/UPSTREAM-RHYTHM.md
+++ b/tools/scaffold/forge/docs/UPSTREAM-RHYTHM.md
@@ -1,0 +1,140 @@
+# Upstream rhythm — Forge's fork-first PR cadence
+
+This doc is **Forge-specific** project configuration for the
+`fork-pr-workflow` skill. The skill itself is factory-generic
+and defers the upstream-cadence choice to project-level
+configuration (see
+`.claude/skills/fork-pr-workflow/SKILL.md` §"Optional
+overlay: batched upstream rhythm"). This doc is that
+configuration for Forge.
+
+## Terminology — three surfaces
+
+Forge has **three surfaces**:
+
+Two come from git (the repo axis):
+
+- **upstream** — `Lucent-Financial-Group/Forge`. The parent
+  repo. Where releases, stable URLs, issue numbers, the
+  canonical commit history, and the social / governance
+  edge live.
+- **fork** — `AceHack/Forge`. The fork the human maintainer
+  and agents develop on day-to-day. The downstream copy where
+  daily agent-loop PRs land so the billed upstream surfaces
+  (Copilot coding-agent, Actions minutes, paid seats) aren't
+  charged per-PR.
+
+The third is the role axis:
+
+- **factory content** — everything in Forge. Unlike Zeta (which
+  has a SUT/factory split), Forge is *purely* factory content:
+  skills, agents, tools, factory meta-docs, persona notebooks.
+  Every file in Forge is factory-by-role.
+
+When fork-vs-upstream disagree on anything, upstream wins.
+
+## Forge's choice: batched fork-first rhythm
+
+**Default PR target for daily agent work:** the fork
+(`AceHack/Forge:main`) — **not** upstream
+(`Lucent-Financial-Group/Forge:main`).
+
+Agents develop on fork feature branches, open PRs against the
+fork's `main`, auto-merge there. The fork's free-tier CI
+minutes run the gate. Once `AceHack/Forge:main` is ~10 commits
+ahead of `Lucent-Financial-Group/Forge:main`, **one** bulk sync
+PR lifts all accumulated work into upstream.
+
+```text
+feature-branches (AceHack)
+   \ \ \ \ \ \ \ \ \ \
+    v v v v v v v v v v
+    AceHack/Forge:main ─────────────────────────────┐
+    (agent daily loop,                              │
+     free CI, free Copilot)                         │
+                                                    │ every ~10 PRs
+                                                    │ one bulk-sync PR
+                                                    v
+                                    Lucent-Financial-Group/Forge:main
+                                    (LFG Copilot + Actions
+                                     billed ONCE per bulk sync,
+                                     not once per PR)
+```
+
+This pattern mirrors `Lucent-Financial-Group/Zeta`'s rhythm
+(`docs/UPSTREAM-RHYTHM.md` there is the canonical reference
+for the cost-rationale and threshold tuning guidance).
+
+## Concrete commands
+
+### Default PR (the 90% case)
+
+```bash
+# Agent opens a PR from its feature branch to AceHack's main.
+gh pr create \
+  --repo AceHack/Forge \
+  --head AceHack:<branch> \
+  --base main \
+  --title "<title>" \
+  --body  "<body>"
+
+# Auto-merge on AceHack.
+gh pr merge <N> --repo AceHack/Forge --auto --squash
+```
+
+### Bulk sync (every ~10 PRs)
+
+```bash
+# Precondition: AceHack/Forge:main is ahead of
+# Lucent-Financial-Group/Forge:main by ~10 commits.
+# Check:
+gh api /repos/AceHack/Forge/compare/main...Lucent-Financial-Group:main \
+  --jq '.status,.ahead_by,.behind_by'
+
+# Open ONE bulk sync PR.
+gh pr create \
+  --repo Lucent-Financial-Group/Forge \
+  --head AceHack:main \
+  --base main \
+  --title "Sync: AceHack/Forge:main → LFG/Forge:main (batch of N PRs)" \
+  --body "Bulk upstream sync per docs/UPSTREAM-RHYTHM.md cadence."
+
+# Use --merge (not --squash) to preserve ancestry for forward-sync.
+gh pr merge <N> --repo Lucent-Financial-Group/Forge --auto --merge
+```
+
+### Forward-sync AceHack/main from LFG/main (after a bulk sync)
+
+```bash
+gh api -X POST /repos/AceHack/Forge/merge-upstream -f branch=main
+```
+
+## When to bypass the batched rhythm
+
+Six named exceptions (same as Zeta's `docs/UPSTREAM-RHYTHM.md`):
+
+1. **Security P0** — any `docs/BUGS.md` P0-security row.
+2. **External-contributor dependency** — a change an external
+   contributor is actively waiting on.
+3. **Human maintainer explicit request** — overrides the rhythm.
+4. **CI-repair to LFG** — when LFG's gate is broken and the fix
+   must land on LFG immediately.
+5. **Bulk-sync PR itself** — the one PR that batches ~10 PRs.
+6. **LFG-only capability experiment** — a deliberate probe of
+   a capability that exists on LFG but not on AceHack.
+
+Outside these cases, default to AceHack.
+
+## Threshold tuning
+
+"~10 PRs" is a suggestion, not a hard rule. Range 5-20 is
+reasonable. Revisit every ~5 bulk syncs; record any change in
+an ADR under `docs/DECISIONS/`.
+
+## Cross-references
+
+- `Lucent-Financial-Group/Zeta: docs/UPSTREAM-RHYTHM.md` —
+  canonical cost-rationale and full guidance; Forge follows
+  the same pattern.
+- `docs/DECISIONS/2026-04-22-three-repo-split-zeta-forge-ace.md`
+  (in Zeta) — ADR establishing the three-repo split.

--- a/tools/scaffold/forge/docs/UPSTREAM-RHYTHM.md
+++ b/tools/scaffold/forge/docs/UPSTREAM-RHYTHM.md
@@ -99,8 +99,8 @@ gh pr create \
   --title "Sync: AceHack/Forge:main → LFG/Forge:main (batch of N PRs)" \
   --body "Bulk upstream sync per docs/UPSTREAM-RHYTHM.md cadence."
 
-# Use --merge (not --squash) to preserve ancestry for forward-sync.
-gh pr merge <N> --repo Lucent-Financial-Group/Forge --auto --merge
+# Squash-merge matches LFG/Forge's squash-only merge settings (scaffold default).
+gh pr merge <N> --repo Lucent-Financial-Group/Forge --auto --squash
 ```
 
 ### Forward-sync AceHack/main from LFG/main (after a bulk sync)

--- a/tools/scaffold/forge/docs/UPSTREAM-RHYTHM.md
+++ b/tools/scaffold/forge/docs/UPSTREAM-RHYTHM.md
@@ -113,17 +113,31 @@ gh pr merge <N> --repo Lucent-Financial-Group/Forge --auto --squash
 ### Forward-sync AceHack/main from LFG/main (after a bulk sync)
 
 ```bash
-# GitHub's fork-upstream sync API. Because the bulk-sync above used --squash
-# (not --merge), LFG/Forge:main is not a fast-forward ancestor of AceHack:main.
-# merge-upstream handles this by creating a merge commit on AceHack/main.
-gh api -X POST /repos/AceHack/Forge/merge-upstream -f branch=main
+# CAUTION: After a squash bulk-sync the fork's history has diverged from
+# LFG's (individual commits replaced by one squash commit). GitHub's
+# merge-upstream API is fast-forward-only; it returns 409/422 here and
+# cannot create a merge commit to resolve the divergence.
+#
+# Forward-sync is OPTIONAL in the squash-only scaffold: GitHub computes
+# bulk-sync PR diffs via 3-way merge against the common ancestor, so the
+# next batch's bulk-sync PR correctly diffs only the new commits even
+# without a forward-sync.
+#
+# To hard-reset AceHack/Forge:main to match LFG/Forge:main exactly
+# (requires force-push permission on AceHack/Forge):
+#   git fetch https://github.com/Lucent-Financial-Group/Forge.git main
+#   git push https://github.com/AceHack/Forge.git FETCH_HEAD:refs/heads/main \
+#     --force-with-lease
 ```
 
 ## When to bypass the batched rhythm
 
 Six named exceptions (same as Zeta's `docs/UPSTREAM-RHYTHM.md`):
 
-1. **Security P0** — any `docs/BUGS.md` P0-security row.
+1. **Security P0** — any security P0 finding (track via GitHub Security
+   advisories or a `docs/BUGS.md` file once created, following
+   `Lucent-Financial-Group/Zeta: docs/BUGS.md` as the pattern;
+   this file is not included in the scaffold on day one).
 2. **External-contributor dependency** — a change an external
    contributor is actively waiting on.
 3. **Human maintainer explicit request** — overrides the rhythm.


### PR DESCRIPTION
## Summary

- Adds `docs/UPSTREAM-RHYTHM.md` to `tools/scaffold/forge/` — closes the ADR 2026-04-22 checklist item: *"docs/UPSTREAM-RHYTHM.md per repo (Zeta's serves as template)"*
- Adds `docs/UPSTREAM-RHYTHM.md` to `tools/scaffold/ace/` — same checklist item for ace
- Updates `tools/scaffold/README.md` to list the new files in the template tree

Both templates adapt Zeta's batched fork-first rhythm doc (referencing `AceHack/Forge` and `AceHack/ace` respectively) and cross-reference Zeta's canonical doc for the full cost-rationale section. No code changes; `collectFiles()` in `create-repo.ts` recursively enumerates the scaffold dir, so new template files are picked up automatically.

## Context

B-0424.1 (PR #2994) added governance templates + dry-run tool.
B-0424.2 (PR #2996) added the `workflow_dispatch` gate.
B-0424.3 (this PR) closes the `docs/UPSTREAM-RHYTHM.md` gap in the ADR checklist.

ADR: `docs/DECISIONS/2026-04-22-three-repo-split-zeta-forge-ace.md`

## Dry-run verification

```
bun tools/scaffold/create-repo.ts --repo forge --dry-run
```
```json
{
  "step": "06-push-scaffold-files",
  "description": "Push 11 scaffold files to Lucent-Financial-Group/Forge via git",
  "data": {
    "files": [
      "CODE_OF_CONDUCT.md",
      "LICENSE",
      "GOVERNANCE.md",
      "docs/UPSTREAM-RHYTHM.md",   ← new
      "docs/GITHUB-SETTINGS.md",
      "README.md",
      "CONTRIBUTING.md",
      ".github/copilot-instructions.md",
      "AGENTS.md",
      "CLAUDE.md",
      "SECURITY.md"
    ]
  }
}
```
Both repos: **12 operations planned, 0 failures**.

## What's still left for B-0424

After this PR, the remaining items before triggering the `workflow_dispatch` are:
1. `SCAFFOLD_STAGE1_PAT` secret created in LFG org settings (one-time Aaron action)
2. Social preview SVG/PNG (post-creation manual step)
3. OpenSSF Scorecard + Semgrep workflow copies (post-creation manual step)

The actual repo creation (`--apply`) is Aaron-triggered via the workflow in `.github/workflows/scaffold-stage1-create-repos.yml`.

## Test plan

- [x] `bun tools/scaffold/create-repo.ts --repo forge --dry-run` — 12 ops planned, 11 files including `docs/UPSTREAM-RHYTHM.md`
- [x] `bun tools/scaffold/create-repo.ts --repo ace --dry-run` — 12 ops planned, 11 files including `docs/UPSTREAM-RHYTHM.md`
- [x] No code changes; build gate satisfied trivially (markdown-only additions)

operative-authorization: aaron 2026-05-13: "Cooling period: TBD. The memory file IS the durable record"

🤖 Generated with [Claude Code](https://claude.com/claude-code)