### PR TITLE
docs(agent-best-practices): add docs/launch/** to persona-naming closed-list (closes B-0443)

### DIFF
--- a/docs/AGENT-BEST-PRACTICES.md
+++ b/docs/AGENT-BEST-PRACTICES.md
@@ -705,6 +705,19 @@ BP drift.
     because the file's job is to preserve who-said-
     what + per-file named evidence for the 0/0/0
     reconciliation record
+  - `docs/launch/**` — launch substrate (public-facing
+    positioning artifacts; persona names + external
+    creator attributions allowed because the substrate's
+    job is to preserve the multi-agent factory's
+    named-team positioning AND IP-respect attribution
+    at a specific date; per the brand register canonized
+    2026-05-13 — Office paper-factory + 8-Bit Theater
+    stick-figure + Tales-from-the-Loop — the launch
+    surface inherently uses named characters; per the
+    IP-respect canonical commitment, external creator
+    attributions like Brian Clevinger / 8-Bit Theater
+    are substrate-honest, not policy violations; closes
+    B-0443)
   - commit messages, PR titles + bodies — git-native
     history (record-of-truth, not factory-doc surfaces)
 


### PR DESCRIPTION
## Summary

Implements the policy amendment proposed in B-0443 (PR #3002 — just merged): adds \`docs/launch/**\` to the persona-naming closed-list in \`docs/AGENT-BEST-PRACTICES.md\`.

## Why

Recurring Copilot finding observed on PR #2997 + PR #3001: launch substrate uses persona names per the canonized brand register (Office paper-factory + 8-Bit Theater + Tales-from-the-Loop), but the closed-list didn't include \`docs/launch/**\`. Each PR resolved with explanatory comments rather than policy fix.

This amendment closes the loop: future launch substrate PRs no longer trigger the policy finding.

## What changed

13-line insertion into the existing closed-list at \`docs/AGENT-BEST-PRACTICES.md\` line 699-707 (after \`docs/active-trajectory.md\`):

\`\`\`
- docs/launch/** — launch substrate (public-facing
  positioning artifacts; persona names + external
  creator attributions allowed because the substrate's
  job is to preserve the multi-agent factory's
  named-team positioning AND IP-respect attribution
  at a specific date; per the brand register canonized
  2026-05-13 — Office paper-factory + 8-Bit Theater
  stick-figure + Tales-from-the-Loop — the launch
  surface inherently uses named characters; per the
  IP-respect canonical commitment, external creator
  attributions like Brian Clevinger / 8-Bit Theater
  are substrate-honest, not policy violations; closes
  B-0443)
\`\`\`

## Composes with

- B-0443 (PR #3002 — backlog row proposing this amendment, just merged)
- PR #2980 (launch thread on main using persona naming throughout)
- PR #2997 + PR #3001 (recurring Copilot finding sites this resolves)
- IP-respect canonical commitment substrate (Brian Clevinger / 8-Bit Theater)

🤖 Generated with [Claude Code](https://claude.com/claude-code)