### PR TITLE
feat(bg): B-0441.1 — backlog-ready notifier skeleton (parallel to B-0440.1; proactive layer)

### DIFF
--- a/tools/bg/backlog-ready-notifier.test.ts
+++ b/tools/bg/backlog-ready-notifier.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_CONFIG, pollOnce, runNotifier, type NotifierConfig } from "./backlog-ready-notifier";
+
+describe("backlog-ready-notifier slice 1", () => {
+  test("default config has sensible poll interval", () => {
+    expect(DEFAULT_CONFIG.pollIntervalMin).toBe(10);
+    expect(DEFAULT_CONFIG.once).toBe(false);
+  });
+
+  test("pollOnce returns a result with no-op scan", () => {
+    const result = pollOnce(DEFAULT_CONFIG);
+    expect(result.readyRowsFound).toBe(0);
+    expect(result.assignmentsPublished).toBe(0);
+    expect(result.note).toContain("slice-1 skeleton");
+    expect(result.pollAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("runNotifier with once: true exits after one iteration", async () => {
+    const config: NotifierConfig = { ...DEFAULT_CONFIG, once: true };
+    const results = await runNotifier(config);
+    expect(results).toHaveLength(1);
+    expect(results[0].readyRowsFound).toBe(0);
+  });
+});

--- a/tools/bg/backlog-ready-notifier.ts
+++ b/tools/bg/backlog-ready-notifier.ts
@@ -1,0 +1,83 @@
+// backlog-ready-notifier.ts — B-0441 slice 1: skeleton + no-op poll loop
+//
+// Background service that proactively surfaces ready-to-grind backlog rows
+// (open, dependencies satisfied) to agents whose queue is empty. Composes
+// with B-0440 (Standing-by detector): B-0440 catches the failure mode AFTER
+// it occurs (reactive); this service PREVENTS the failure mode by surfacing
+// work BEFORE the agent goes idle (proactive).
+//
+// This slice ships ONLY the skeleton. Future slices add backlog parsing,
+// queue-state detection, and bus integration.
+//
+// Run: bun tools/bg/backlog-ready-notifier.ts [--once] [--poll-min N]
+// Compose with: B-0441 + B-0400 (bus) + B-0440 (reactive peer).
+
+export type NotifierConfig = {
+  /** How often to poll, in minutes */
+  pollIntervalMin: number;
+  /** When true, run a single poll and exit */
+  once: boolean;
+};
+
+export const DEFAULT_CONFIG: NotifierConfig = {
+  pollIntervalMin: 10,
+  once: false,
+};
+
+export type PollResult = {
+  pollAt: string; // ISO-8601
+  readyRowsFound: number;
+  assignmentsPublished: number;
+  note: string;
+};
+
+/**
+ * Single poll iteration. Slice 1 returns a no-op result. Future slices
+ * implement backlog scan + queue-state detection + assignment publish.
+ */
+export function pollOnce(_config: NotifierConfig): PollResult {
+  return {
+    pollAt: new Date().toISOString(),
+    readyRowsFound: 0,
+    assignmentsPublished: 0,
+    note: "slice-1 skeleton — no scan yet; future slices add backlog-readiness + queue-state + bus publish",
+  };
+}
+
+/**
+ * Run the notifier loop. When `once: true`, runs exactly one iteration.
+ */
+export async function runNotifier(config: NotifierConfig = DEFAULT_CONFIG): Promise<PollResult[]> {
+  const results: PollResult[] = [];
+
+  do {
+    const result = pollOnce(config);
+    results.push(result);
+    console.log(JSON.stringify(result));
+
+    if (config.once) break;
+
+    await new Promise(resolve => setTimeout(resolve, config.pollIntervalMin * 60 * 1000));
+  } while (!config.once);
+
+  return results;
+}
+
+function parseArgs(argv: string[]): NotifierConfig {
+  const config: NotifierConfig = { ...DEFAULT_CONFIG };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--once") config.once = true;
+    else if (arg === "--poll-min" && i + 1 < argv.length) {
+      config.pollIntervalMin = Number(argv[++i]);
+    }
+  }
+
+  return config;
+}
+
+if (import.meta.main) {
+  const config = parseArgs(process.argv.slice(2));
+  await runNotifier(config);
+}

--- a/tools/bg/backlog-ready-notifier.ts
+++ b/tools/bg/backlog-ready-notifier.ts
@@ -45,22 +45,31 @@ export function pollOnce(_config: NotifierConfig): PollResult {
 }
 
 /**
- * Run the notifier loop. When `once: true`, runs exactly one iteration.
+ * Run the notifier loop. When `once: true`, runs exactly one iteration and
+ * returns its result. Otherwise sleeps for pollIntervalMin between
+ * iterations and runs forever; results are NOT accumulated.
  */
 export async function runNotifier(config: NotifierConfig = DEFAULT_CONFIG): Promise<PollResult[]> {
-  const results: PollResult[] = [];
-
-  do {
+  if (config.once) {
     const result = pollOnce(config);
-    results.push(result);
     console.log(JSON.stringify(result));
+    return [result];
+  }
 
-    if (config.once) break;
-
+  while (true) {
+    const result = pollOnce(config);
+    console.log(JSON.stringify(result));
     await new Promise(resolve => setTimeout(resolve, config.pollIntervalMin * 60 * 1000));
-  } while (!config.once);
+  }
+}
 
-  return results;
+function parsePositiveMinutes(raw: string | undefined, name: string): number {
+  if (raw === undefined) throw new Error(`${name} requires a value`);
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`${name} must be a positive finite number; got "${raw}"`);
+  }
+  return n;
 }
 
 function parseArgs(argv: string[]): NotifierConfig {
@@ -69,8 +78,8 @@ function parseArgs(argv: string[]): NotifierConfig {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--once") config.once = true;
-    else if (arg === "--poll-min" && i + 1 < argv.length) {
-      config.pollIntervalMin = Number(argv[++i]);
+    else if (arg === "--poll-min") {
+      config.pollIntervalMin = parsePositiveMinutes(argv[++i], "--poll-min");
     }
   }
 


### PR DESCRIPTION
## Summary

Companion to PR #3006 (B-0440.1 — Standing-by detector). B-0441 is the **proactive** layer that prevents the failure mode by surfacing ready-to-grind backlog rows BEFORE agents go idle.

Together with B-0440 (reactive — catches Standing-by AFTER it occurs), the two services form a two-layer defense against the failure mode the human maintainer caught me on earlier today.

## What lands

- \`tools/bg/backlog-ready-notifier.ts\` (60 lines) — skeleton with no-op poll loop, 10min default interval
- \`tools/bg/backlog-ready-notifier.test.ts\` — 3 tests, all pass

## Test results

\`\`\`
bun test
 3 pass
 0 fail
 8 expect() calls
\`\`\`

## Two-layer defense pattern

| Service | Layer | Trigger | Output |
|---------|-------|---------|--------|
| B-0440 Standing-by detector (PR #3006) | Reactive | Idle threshold + cron fires | Nudge: \"pick work\" |
| B-0441 Backlog-ready notifier (this PR) | Proactive | Queue-empty + rows-ready | Assignment: \"this row is ready\" |

## Composes with

- B-0441 (backlog row; PR #3000 merged)
- B-0440 (companion service; PR #3006)
- B-0400 (bus protocol — future slice 4)
- PR #2998 (architectural challenge)
- PR #2999 (substrate-honest discipline triad)

🤖 Generated with [Claude Code](https://claude.com/claude-code)