### PR TITLE
fix(lint): TS2532 noUncheckedIndexedAccess in B-0440/B-0441 bg test array indexing

### DIFF
--- a/tools/bg/backlog-ready-notifier.test.ts
+++ b/tools/bg/backlog-ready-notifier.test.ts
@@ -19,6 +19,6 @@ describe("backlog-ready-notifier slice 1", () => {
     const config: NotifierConfig = { ...DEFAULT_CONFIG, once: true };
     const results = await runNotifier(config);
     expect(results).toHaveLength(1);
-    expect(results[0].readyRowsFound).toBe(0);
+    expect(results[0]!.readyRowsFound).toBe(0);
   });
 });

--- a/tools/bg/standing-by-detector.test.ts
+++ b/tools/bg/standing-by-detector.test.ts
@@ -19,6 +19,6 @@ describe("standing-by-detector slice 1", () => {
     const config: DetectorConfig = { ...DEFAULT_CONFIG, once: true };
     const results = await runDetector(config);
     expect(results).toHaveLength(1);
-    expect(results[0].idleDetected).toBe(false);
+    expect(results[0]!.idleDetected).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `tools/bg/backlog-ready-notifier.test.ts` line 22: `results[0]` → `results[0]!`
- `tools/bg/standing-by-detector.test.ts` line 22: `results[0]` → `results[0]!`

**Root cause:** `noUncheckedIndexedAccess: true` in `tsconfig.json` makes array indexing return `T | undefined`. The Bun test framework's `toHaveLength(1)` on line 21 proves the element exists at runtime, but TypeScript can't see through the test-framework type signatures, so the non-null assertion `!` is required.

**Effect:** Fixes the non-required `lint (tsc tools)` CI check failure that appeared on every PR after B-0440.1 (#3006) and B-0441.1 (#3007) landed the skeleton test suites.

## Test plan

- [x] `bun --bun tsc --noEmit -p tsconfig.json` passes locally (zero errors)
- [x] Change is minimal: 2-character addition per file, no logic change
- [ ] CI lint (tsc tools) should go green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)