### PR TITLE
fix(lint): TS2345 noUncheckedIndexedAccess in missed-substrate-detector.ts parseArgs

### DIFF
--- a/tools/bg/missed-substrate-detector.ts
+++ b/tools/bg/missed-substrate-detector.ts
@@ -79,7 +79,7 @@ export function parseArgs(argv: string[]): DetectorConfig {
   const config: DetectorConfig = { ...DEFAULT_CONFIG };
 
   for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
+    const arg = argv[i]!;
     if (arg === "--once") {
       config.once = true;
     } else if (arg === "--poll-min") {


### PR DESCRIPTION
## Summary

- `tools/bg/missed-substrate-detector.ts` line 82: `argv[i]` → `argv[i]!`

**Root cause:** `noUncheckedIndexedAccess: true` in `tsconfig.json` makes `argv[i]` return `string | undefined`. The loop condition `i < argv.length` guarantees the element exists at runtime, but TypeScript can't narrow through it. `Set<string>.has()` requires `string`, not `string | undefined`, so `KNOWN_FLAGS.has(arg)` at line 87 fails with TS2345.

**Why missed in #3008:** B-0442.1 included a `fix(tsc)` commit for `results[0]!` in the test file but the source file's `argv[i]` indexing was a separate violation that only surfaces when `lint (tsc tools)` CI runs against the merge commit (which combines the PR branch with main's state).

**Sibling to #3010** (which fixed the same class of errors in the two test files for B-0440.1 and B-0441.1).

## Test plan

- [x] `bun --bun tsc --noEmit -p tsconfig.json` passes locally (zero errors)
- [x] Change is minimal: 1-character addition, no logic change
- [ ] CI lint (tsc tools) should go green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)