### PR TITLE
fix(lint): TS2345 noUncheckedIndexedAccess in standing-by-detector parseArgs

### DIFF
--- a/tools/bg/standing-by-detector.ts
+++ b/tools/bg/standing-by-detector.ts
@@ -125,7 +125,7 @@ export function parseArgs(argv: string[]): DetectorConfig {
   const config: DetectorConfig = { ...DEFAULT_CONFIG };
 
   for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
+    const arg = argv[i]!; // i < argv.length guarantees defined; noUncheckedIndexedAccess needs explicit assertion
     if (arg === "--once") {
       config.once = true;
     } else if (arg === "--poll-min") {


### PR DESCRIPTION
## Summary

- `argv[i]` inside the `parseArgs` loop is typed `string | undefined` under `noUncheckedIndexedAccess`
- `KNOWN_FLAGS.has(arg)` fails because `Set<string>.has()` doesn't accept `undefined`
- The loop guard `i < argv.length` guarantees `argv[i]` is always defined — add `!` to narrow

## Root cause

PR #3011 (B-0440.2) was squash-merged while the `lint (tsc tools)` non-required check was still failing. That check fired on the entire codebase and caught `standing-by-detector.ts`. Since the check is non-required it didn't block merge, but the bug landed on main.

PR #3013 applied the same fix pattern to `missed-substrate-detector.ts`. This PR applies it to `standing-by-detector.ts`.

## Test plan

- [ ] `bun --bun tsc --noEmit -p tsconfig.json` — passes clean (verified locally)
- [ ] CI `lint (tsc tools)` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)