### PR TITLE
feat(bus): extend B-0400 schema — 3 new topics for bg services (unblocks slice 4 of B-0440/B-0441/B-0442)

### DIFF
--- a/tools/bus/types.ts
+++ b/tools/bus/types.ts
@@ -4,10 +4,13 @@
 // Each message is one JSON file; TTL expiry pruned by `clean --expired`.
 //
 // Topic taxonomy (agent-designed, 2026-05-13):
-//   heartbeat     — liveness signal; agents advertise they are alive
-//   claim         — work coordination; claim or release a backlog item
-//   shadow-catch  — share an observation or insight between agents
-//   review-request — ask another agent to review a specific artifact
+//   heartbeat                 — liveness signal; agents advertise they are alive
+//   claim                     — work coordination; claim or release a backlog item
+//   shadow-catch              — share an observation or insight between agents
+//   review-request            — ask another agent to review a specific artifact
+//   infinite-backlog-nudge    — B-0440: nudge agent toward decomposition when Standing-by detected
+//   work-assignment           — B-0441: proactive assignment of a ready-to-grind backlog row
+//   missed-substrate-cascade  — B-0442: branch-vs-merged-PR drift detected; recovery needed
 
 export type AgentId =
   | "otto"
@@ -20,7 +23,14 @@ export type AgentId =
 /** Sender identity — excludes broadcast target "*" which is not a valid origin. */
 export type SenderAgentId = Exclude<AgentId, "*">;
 
-export type Topic = "heartbeat" | "claim" | "shadow-catch" | "review-request";
+export type Topic =
+  | "heartbeat"
+  | "claim"
+  | "shadow-catch"
+  | "review-request"
+  | "infinite-backlog-nudge"
+  | "work-assignment"
+  | "missed-substrate-cascade";
 
 // ── per-topic payloads ────────────────────────────────────────────────────────
 
@@ -45,13 +55,47 @@ export type ReviewRequestPayload = {
   question?: string;
 };
 
+/** B-0440: Standing-by detector nudges an agent toward decomposition work. */
+export type InfiniteBacklogNudgePayload = {
+  idleMinutes: number;
+  /** Reason for the nudge — human-readable. */
+  rationale: string;
+  /** Optional suggested backlog row to pick up. */
+  suggestedRowId?: string;
+};
+
+/** B-0441: backlog-ready notifier proactively assigns a ready-to-grind row. */
+export type WorkAssignmentPayload = {
+  rowId: string; // e.g. "B-0440.3"
+  priority: "P0" | "P1" | "P2" | "P3";
+  /** Why this row was picked — short rationale. */
+  rationale: string;
+  /** Optional decomposition hint for the implementer. */
+  decompositionHint?: string;
+};
+
+/** B-0442: missed-substrate detector reports branch-vs-merged-PR drift. */
+export type MissedSubstrateCascadePayload = {
+  prNumber: number;
+  branchName: string;
+  /** Commit SHAs present on the branch but missing from main after squash. */
+  missingCommits: string[];
+  /** Suggested next action (e.g. "open-recovery-PR"). */
+  recommendedAction: string;
+  /** Severity hint — high if branch is about to be deleted. */
+  urgency: "low" | "medium" | "high";
+};
+
 // ── discriminated union ───────────────────────────────────────────────────────
 
 export type BusMessage =
   | { topic: "heartbeat"; payload: HeartbeatPayload }
   | { topic: "claim"; payload: ClaimPayload }
   | { topic: "shadow-catch"; payload: ShadowCatchPayload }
-  | { topic: "review-request"; payload: ReviewRequestPayload };
+  | { topic: "review-request"; payload: ReviewRequestPayload }
+  | { topic: "infinite-backlog-nudge"; payload: InfiniteBacklogNudgePayload }
+  | { topic: "work-assignment"; payload: WorkAssignmentPayload }
+  | { topic: "missed-substrate-cascade"; payload: MissedSubstrateCascadePayload };
 
 // ── envelope (what lands on disk) ────────────────────────────────────────────
 
@@ -71,8 +115,11 @@ export const AGENT_IDS: readonly AgentId[] = [...SENDER_IDS, "*"];
 // ── TTL defaults (milliseconds) ───────────────────────────────────────────────
 
 export const TTL_MS: Record<Topic, number> = {
-  heartbeat: 5 * 60 * 1_000,      // 5 min — liveness signal is short-lived
-  claim: 24 * 60 * 60 * 1_000,    // 24 h  — claim survives a sleep cycle
-  "shadow-catch": 60 * 60 * 1_000, // 1 h   — observation stays for a tick window
-  "review-request": 4 * 60 * 60 * 1_000, // 4 h — review window
+  heartbeat: 5 * 60 * 1_000,                        // 5 min — liveness signal is short-lived
+  claim: 24 * 60 * 60 * 1_000,                       // 24 h  — claim survives a sleep cycle
+  "shadow-catch": 60 * 60 * 1_000,                   // 1 h   — observation stays for a tick window
+  "review-request": 4 * 60 * 60 * 1_000,             // 4 h   — review window
+  "infinite-backlog-nudge": 30 * 60 * 1_000,         // 30 min — nudge stale fast (agent likely acted or moved on)
+  "work-assignment": 2 * 60 * 60 * 1_000,            // 2 h   — assignment relevant for next claim cycle
+  "missed-substrate-cascade": 24 * 60 * 60 * 1_000,  // 24 h  — cascade survives until recovery PR lands
 };


### PR DESCRIPTION
## Summary

Extends \`tools/bus/types.ts\` (B-0400 schema) with three new topics + payloads + TTL entries that unblock slice 4 (bus publish) for all three background services.

## New topics

| Topic | Source service | TTL | Purpose |
|-------|----------------|-----|---------|
| \`infinite-backlog-nudge\` | B-0440 standing-by-detector | 30 min | Nudge agent toward decomposition when idle detected |
| \`work-assignment\` | B-0441 backlog-ready-notifier | 2 h | Proactively assign a ready-to-grind backlog row |
| \`missed-substrate-cascade\` | B-0442 missed-substrate-detector | 24 h | Report branch-vs-merged-PR drift; recovery needed |

## Tests

All 64 existing bus tests still pass — TypeScript's \`Record<Topic, number>\` enforces TTL coverage at compile time.

## Composes with

- B-0400 (the schema this extends)
- B-0440 + B-0441 + B-0442 + their slice-2 impl PRs (#3011, #3012, #3014)
- Future slice-4 PRs (one per service) that will publish on these topics

🤖 Generated with [Claude Code](https://claude.com/claude-code)