### PR TITLE
feat(scaffold): B-0424.4 — add Scorecard workflow to Forge + ace scaffold dirs

### DIFF
--- a/.github/workflows/scaffold-stage1-create-repos.yml
+++ b/.github/workflows/scaffold-stage1-create-repos.yml
@@ -153,10 +153,9 @@ jobs:
           echo "Manual steps remaining (create-repo.ts step 07):"
           echo "  1. Upload SVG social-preview PNG via GitHub UI"
           echo "  2. Enable merge queue: Settings → Merge queue (no REST API)"
-          echo "  3. Wire OpenSSF Scorecard: copy .github/workflows/scorecard.yml from Zeta"
-          echo "  4. Add Semgrep GHA inline-untrusted-in-run rule"
-          echo "  5. Verify \$0 budget caps at LFG org billing settings"
-          echo "  6. Confirm CodeQL default-setup: Security → Code scanning"
+          echo "  3. Add Semgrep GHA inline-untrusted-in-run rule"
+          echo "  4. Verify \$0 budget caps at LFG org billing settings"
+          echo "  5. Confirm CodeQL default-setup: Security → Code scanning"
           echo ""
           if [ "$REPO_INPUT" = "forge" ] || [ "$REPO_INPUT" = "both" ]; then
             echo "  Forge: https://github.com/Lucent-Financial-Group/Forge"

--- a/tools/scaffold/README.md
+++ b/tools/scaffold/README.md
@@ -71,11 +71,9 @@ The tool prints these at the end, but for reference:
    (GitHub requires a rasterized PNG format — SVG not accepted)
 2. Enable merge queue via GitHub UI
    (Settings → Merge queue — org feature, no REST API)
-3. Wire OpenSSF Scorecard workflow
-   (copy from Zeta's `.github/workflows/scorecard.yml`)
-4. Add Semgrep GHA inline-untrusted-in-run rule
-5. Verify $0 budget caps at org level in GitHub billing settings
-6. Confirm CodeQL default-setup is active under Security → Code scanning
+3. Add Semgrep GHA inline-untrusted-in-run rule
+4. Verify $0 budget caps at org level in GitHub billing settings
+5. Confirm CodeQL default-setup is active under Security → Code scanning
 
 ## Origin
 

--- a/tools/scaffold/ace/.github/workflows/scorecard.yml
+++ b/tools/scaffold/ace/.github/workflows/scorecard.yml
@@ -1,0 +1,83 @@
+# OpenSSF Scorecard — weekly project-health audit.
+#
+# Scorecard runs ~20 heuristic checks that score the repo on
+# security-relevant posture: branch protection, signed releases,
+# dangerous workflows, pinned dependencies, CII best practices,
+# dependency-update tools, SAST coverage, token permissions,
+# maintained-ness, and so on. Results upload to GitHub
+# Security -> Code scanning as SARIF.
+#
+# Copied from Lucent-Financial-Group/Zeta on scaffold creation
+# (B-0424 Stage 1). Keep SHA pins in sync when updating.
+#
+# SECURITY NOTE on expressions
+# ----------------------------
+# No attacker-controlled fields are interpolated into any `run:`
+# block or action input in this workflow. The only ${{ ... }}
+# expansions are `github.workflow` and `github.ref` (trusted
+# contexts) in the concurrency group. Scorecard action inputs
+# (`results_format`, `results_file`, `publish_results`) are
+# static literals. `publish_results: true` opts in to the
+# OpenSSF public Scorecard dashboard - outbound publish of our
+# score; no inbound attack surface.
+#
+# Action-pin content-review: ossf/scorecard-action v2.4.3 tagged
+# 2025-09-30 by sschrock@google.com (OpenSSF maintainer),
+# SSH-signed, GitHub API reports verified=true reason=valid.
+# Owner org `ossf` is the OpenSSF foundation's GitHub org.
+# Commit SHA `4eaacf0543bb3f2c246792bd56e8cdeffafb205a` locks
+# the reviewed release.
+
+name: scorecard
+
+on:
+  schedule:
+    - cron: '0 7 * * 1'
+  push:
+    branches: [main]
+  branch_protection_rule:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  analysis:
+    name: scorecard analysis
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    permissions:
+      id-token: write
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF as workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 7
+
+      - name: Upload SARIF to GitHub code scanning
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          sarif_file: results.sarif

--- a/tools/scaffold/create-repo.ts
+++ b/tools/scaffold/create-repo.ts
@@ -529,7 +529,6 @@ function step07_summary(): void {
       manualSteps: [
         "Upload SVG social-preview PNG via GitHub UI (GitHub requires rasterized PNG format)",
         "Enable merge queue via GitHub UI: Settings → Merge queue (org feature, no API)",
-        "Wire OpenSSF Scorecard workflow: copy from Zeta's .github/workflows/scorecard.yml",
         "Add Semgrep GHA inline-untrusted-in-run rule workflow",
         "Add bun-test, bun-lint, codeql, scorecard as required status checks AFTER CI workflows are wired (branch protection was created with empty contexts to avoid deadlock)",
         "Verify budget caps $0 at org level: github.com/organizations/Lucent-Financial-Group/settings/billing",

--- a/tools/scaffold/forge/.github/workflows/scorecard.yml
+++ b/tools/scaffold/forge/.github/workflows/scorecard.yml
@@ -1,0 +1,83 @@
+# OpenSSF Scorecard — weekly project-health audit.
+#
+# Scorecard runs ~20 heuristic checks that score the repo on
+# security-relevant posture: branch protection, signed releases,
+# dangerous workflows, pinned dependencies, CII best practices,
+# dependency-update tools, SAST coverage, token permissions,
+# maintained-ness, and so on. Results upload to GitHub
+# Security -> Code scanning as SARIF.
+#
+# Copied from Lucent-Financial-Group/Zeta on scaffold creation
+# (B-0424 Stage 1). Keep SHA pins in sync when updating.
+#
+# SECURITY NOTE on expressions
+# ----------------------------
+# No attacker-controlled fields are interpolated into any `run:`
+# block or action input in this workflow. The only ${{ ... }}
+# expansions are `github.workflow` and `github.ref` (trusted
+# contexts) in the concurrency group. Scorecard action inputs
+# (`results_format`, `results_file`, `publish_results`) are
+# static literals. `publish_results: true` opts in to the
+# OpenSSF public Scorecard dashboard - outbound publish of our
+# score; no inbound attack surface.
+#
+# Action-pin content-review: ossf/scorecard-action v2.4.3 tagged
+# 2025-09-30 by sschrock@google.com (OpenSSF maintainer),
+# SSH-signed, GitHub API reports verified=true reason=valid.
+# Owner org `ossf` is the OpenSSF foundation's GitHub org.
+# Commit SHA `4eaacf0543bb3f2c246792bd56e8cdeffafb205a` locks
+# the reviewed release.
+
+name: scorecard
+
+on:
+  schedule:
+    - cron: '0 7 * * 1'
+  push:
+    branches: [main]
+  branch_protection_rule:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  analysis:
+    name: scorecard analysis
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    permissions:
+      id-token: write
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF as workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 7
+
+      - name: Upload SARIF to GitHub code scanning
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/scorecard.yml` to both `tools/scaffold/forge/` and `tools/scaffold/ace/` template directories so that when `create-repo.ts --apply` runs, the Scorecard workflow is pushed to the new repos on day one instead of being a post-creation manual task.
- Removes "Wire OpenSSF Scorecard workflow" from the manual-steps list in `create-repo.ts` step 07, `tools/scaffold/README.md`, and the post-creation summary in `.github/workflows/scaffold-stage1-create-repos.yml`.
- Manual steps count: **7 → 6** (post-apply remainder).

## What this is

**B-0424.4** — the fourth bounded slice of [B-0424 (P1) Three-repo split Stage 1](../docs/backlog/P1/B-0424-three-repo-split-stage1-create-forge-ace-with-scaffolding-aaron-2026-05-13.md).

Previous slices:
- B-0424.1 (#2994) — governance file templates + dry-run `create-repo.ts` tool
- B-0424.2 (#2996) — `workflow_dispatch` GitHub Actions gate for `--apply`
- B-0424.3 (#3003) — `UPSTREAM-RHYTHM.md` templates

This slice is purely additive: two new scaffold files, three one-line deletions in supporting docs/code.

## Scorecard workflow provenance

`scorecard.yml` is copied verbatim from Zeta's existing reviewed workflow (same SHA-pinned actions, same security commentary). No new action SHAs were introduced; the same content-review that covers Zeta covers Forge and ace.

Workflows have **no `run:` blocks** — only action invocations with static inputs. The only `${{ ... }}` expressions are `github.workflow` and `github.ref` in the concurrency group (trusted contexts; the security hook's injection concern does not apply).

## Checks

```
bun tools/scaffold/create-repo.ts --repo forge --dry-run
→ step 06 files: 12 (was 11), includes .github/workflows/scorecard.yml
→ step 07 manualSteps: 6 (was 7), "Wire OpenSSF Scorecard" removed

bun tools/scaffold/create-repo.ts --repo ace --dry-run
→ same (ace also gets 12 files)

dotnet build -c Release
→ Build succeeded. 0 Warning(s). 0 Error(s).
```

## Test plan

- [x] Dry-run output shows `scorecard.yml` in step-06 file list for both repos
- [x] Dry-run step-07 `manualSteps` no longer includes "Wire OpenSSF Scorecard"
- [x] `dotnet build -c Release` passes 0 warnings 0 errors
- [ ] (After `--apply`) Verify `scorecard.yml` is present in created repos and the workflow appears in Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)