### PR TITLE
feat(bg): B-0441.3 — agent queue-state detection (commits + PRs)

### DIFF
--- a/tools/bg/backlog-ready-notifier.test.ts
+++ b/tools/bg/backlog-ready-notifier.test.ts
@@ -23,6 +23,8 @@ function fakeAdapters(
   nowIso: string,
   rows: BacklogRow[],
   capturedCalls: FakeAssignmentCall[] = [],
+  gitLogStr: string = "",
+  ghPrListStr: string = "",
 ): Adapters {
   return {
     now: () => new Date(nowIso),
@@ -39,6 +41,11 @@ function fakeAdapters(
         payload: { rowId, priority, rationale },
       };
     },
+    agentPatterns: {
+      "TestAgent": ["testagent"],
+    },
+    execGitLog: () => gitLogStr,
+    execGhPrList: () => ghPrListStr,
   };
 }
 
@@ -152,6 +159,31 @@ depends_on:
 title: only a title
 ---`;
       expect(parseRow(content, "x.md")).toBeNull();
+    });
+  });
+
+  describe("isAgentQueueEmpty", () => {
+    const { isAgentQueueEmpty } = require("./backlog-ready-notifier");
+
+    test("returns true when agent is unknown", () => {
+      const adapters = fakeAdapters("2026-05-13T18:00:00Z", [], [], "some git log", "some prs");
+      expect(isAgentQueueEmpty("UnknownAgent", adapters)).toBe(true);
+    });
+
+    test("returns true when known agent has no commits and no PRs", () => {
+      const adapters = fakeAdapters("2026-05-13T18:00:00Z", [], [], "other stuff", "[]");
+      expect(isAgentQueueEmpty("TestAgent", adapters)).toBe(true);
+    });
+
+    test("returns false when known agent has recent commits", () => {
+      const adapters = fakeAdapters("2026-05-13T18:00:00Z", [], [], "commit by testagent", "[]");
+      expect(isAgentQueueEmpty("TestAgent", adapters)).toBe(false);
+    });
+
+    test("returns false when known agent has open PRs", () => {
+      const prData = JSON.stringify([{ title: "test", body: "fixed by TestAgent", author: { login: "other" } }]);
+      const adapters = fakeAdapters("2026-05-13T18:00:00Z", [], [], "", prData);
+      expect(isAgentQueueEmpty("TestAgent", adapters)).toBe(false);
     });
   });
 

--- a/tools/bg/backlog-ready-notifier.test.ts
+++ b/tools/bg/backlog-ready-notifier.test.ts
@@ -185,6 +185,23 @@ title: only a title
       const adapters = fakeAdapters("2026-05-13T18:00:00Z", [], [], "", prData);
       expect(isAgentQueueEmpty("TestAgent", adapters)).toBe(false);
     });
+
+    test("returns false (conservative-busy) when execGitLog returns null — git unavailable must not trigger assignment", () => {
+      const adapters: Adapters = {
+        ...fakeAdapters("2026-05-13T18:00:00Z", [], [], "irrelevant", "[]"),
+        execGitLog: () => null,
+      };
+      expect(isAgentQueueEmpty("TestAgent", adapters)).toBe(false);
+    });
+
+    test("returns false (conservative-busy) when execGhPrList returns null — gh unavailable must not trigger assignment", () => {
+      // git log is clean (no agent pattern), but gh fails → still conservative
+      const adapters: Adapters = {
+        ...fakeAdapters("2026-05-13T18:00:00Z", [], [], "no match here", "irrelevant"),
+        execGhPrList: () => null,
+      };
+      expect(isAgentQueueEmpty("TestAgent", adapters)).toBe(false);
+    });
   });
 
   describe("pollOnce with injected adapters", () => {

--- a/tools/bg/backlog-ready-notifier.test.ts
+++ b/tools/bg/backlog-ready-notifier.test.ts
@@ -42,7 +42,7 @@ function fakeAdapters(
       };
     },
     agentPatterns: {
-      "TestAgent": ["testagent"],
+      "testagent": ["testagent"],
     },
     execGitLog: () => gitLogStr,
     execGhPrList: () => ghPrListStr,

--- a/tools/bg/backlog-ready-notifier.ts
+++ b/tools/bg/backlog-ready-notifier.ts
@@ -82,13 +82,13 @@ export type Adapters = {
 };
 
 // Keys are lowercase to match the canonical bus agent IDs (SENDER_IDS in tools/bus/types.ts).
+// Only otto/alexa/riven/vera/lior are valid SENDER_IDS; aaron is a human, not a bus sender.
 export const AGENT_MAP: Record<string, string[]> = {
   otto: ["Co-Authored-By: Claude"],
   alexa: ["kiro", "alexa", "qwen"],
   lior: ["lior", "gemini"],
   vera: ["codex", "vera"],
   riven: ["riven", "grok"],
-  aaron: ["Aaron Stainback", "AceHack"],
 };
 
 function parseDependsOn(frontmatter: string): string[] {
@@ -163,7 +163,7 @@ const REAL_ADAPTERS: Adapters = {
     // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array; no shell, no injection risk.
     const result = spawnSync(
       "git",
-      ["log", "--all", `--since=${cutoff}`, "--format=%an %b"],
+      ["log", "--all", `--since=${cutoff}`, "--format=%an %B"],
       { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
     );
     if (result.status !== 0 || result.error) return null;
@@ -174,7 +174,7 @@ const REAL_ADAPTERS: Adapters = {
     // eslint-disable-next-line sonarjs/no-os-command-from-path -- gh invoked as explicit args array; no shell, no injection risk.
     const result = spawnSync(
       "gh",
-      ["pr", "list", "--state", "open", "--json", "title,body,author"],
+      ["pr", "list", "--state", "open", "--limit", "1000", "--json", "title,body,author"],
       { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
     );
     if (result.status !== 0 || result.error) return null;

--- a/tools/bg/backlog-ready-notifier.ts
+++ b/tools/bg/backlog-ready-notifier.ts
@@ -75,17 +75,20 @@ export type Adapters = {
     rationale: string,
   ) => MessageEnvelope;
   agentPatterns: Record<string, string[]>;
-  execGitLog: (sinceMinutes: number) => string;
-  execGhPrList: () => string;
+  /** Returns git log output, or null if the git invocation fails (treat as indeterminate). */
+  execGitLog: (sinceMinutes: number) => string | null;
+  /** Returns `gh pr list` JSON output, or null if the gh invocation fails (treat as indeterminate). */
+  execGhPrList: () => string | null;
 };
 
+// Keys are lowercase to match the canonical bus agent IDs (SENDER_IDS in tools/bus/types.ts).
 export const AGENT_MAP: Record<string, string[]> = {
-  Otto: ["Co-Authored-By: Claude"],
-  Alexa: ["kiro", "alexa", "qwen"],
-  Lior: ["lior", "gemini"],
-  Vera: ["codex", "vera"],
-  Riven: ["riven", "grok"],
-  Aaron: ["Aaron Stainback", "AceHack"],
+  otto: ["Co-Authored-By: Claude"],
+  alexa: ["kiro", "alexa", "qwen"],
+  lior: ["lior", "gemini"],
+  vera: ["codex", "vera"],
+  riven: ["riven", "grok"],
+  aaron: ["Aaron Stainback", "AceHack"],
 };
 
 function parseDependsOn(frontmatter: string): string[] {
@@ -155,42 +158,51 @@ const REAL_ADAPTERS: Adapters = {
     }),
   agentPatterns: AGENT_MAP,
   execGitLog: (sinceMinutes: number) => {
-    try {
-      const cutoff = Math.floor(Date.now() / 1000) - (sinceMinutes * 60);
-      const { spawnSync } = require("node:child_process");
-      const result = spawnSync("git", ["log", `--since=${cutoff}`, "--format=%an %b"], { encoding: "utf8" });
-      return result.stdout || "";
-    } catch {
-      return "";
-    }
+    const cutoff = Math.floor(Date.now() / 1000) - (sinceMinutes * 60);
+    const { spawnSync } = require("node:child_process");
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array; no shell, no injection risk.
+    const result = spawnSync(
+      "git",
+      ["log", "--all", `--since=${cutoff}`, "--format=%an %b"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    if (result.status !== 0 || result.error) return null;
+    return result.stdout ?? "";
   },
   execGhPrList: () => {
-    try {
-      const { spawnSync } = require("node:child_process");
-      const result = spawnSync("gh", ["pr", "list", "--state", "open", "--json", "title,body,author"], { encoding: "utf8" });
-      return result.stdout || "";
-    } catch {
-      return "";
-    }
+    const { spawnSync } = require("node:child_process");
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- gh invoked as explicit args array; no shell, no injection risk.
+    const result = spawnSync(
+      "gh",
+      ["pr", "list", "--state", "open", "--json", "title,body,author"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    if (result.status !== 0 || result.error) return null;
+    return result.stdout ?? "";
   },
 };
 
 /**
  * Returns true if the agent has no commits in the last 30 minutes AND
- * no currently open PRs.
+ * no currently open PRs. Returns false (conservative) when any adapter
+ * call fails — a sensor failure must not be mistaken for agent inactivity.
  */
 export function isAgentQueueEmpty(
   agentName: string,
   adapters: Adapters = REAL_ADAPTERS,
 ): boolean {
-  const patterns = adapters.agentPatterns[agentName] ?? [];
+  const patterns = adapters.agentPatterns[agentName.toLowerCase()] ?? [];
   if (patterns.length === 0) return true; // unknown agent = queue empty
 
-  const logStr = adapters.execGitLog(30).toLowerCase();
+  const logOutput = adapters.execGitLog(30);
+  if (logOutput === null) return false; // git unavailable — treat as busy
+  const logStr = logOutput.toLowerCase();
   const hasCommits = patterns.some(p => logStr.includes(p.toLowerCase()));
   if (hasCommits) return false;
 
-  const prStr = adapters.execGhPrList().toLowerCase();
+  const prOutput = adapters.execGhPrList();
+  if (prOutput === null) return false; // gh unavailable — treat as busy
+  const prStr = prOutput.toLowerCase();
   const hasPRs = patterns.some(p => prStr.includes(p.toLowerCase()));
   if (hasPRs) return false;
 

--- a/tools/bg/backlog-ready-notifier.ts
+++ b/tools/bg/backlog-ready-notifier.ts
@@ -63,7 +63,7 @@ export type PollResult = {
   note: string;
 };
 
-/** Adapter abstraction so tests can inject deterministic time + filesystem + bus. */
+/** Adapter abstraction so tests can inject deterministic time + filesystem + bus + shell. */
 export type Adapters = {
   now: () => Date;
   scanBacklog: (backlogDir: string) => BacklogRow[];
@@ -74,6 +74,18 @@ export type Adapters = {
     priority: "P0" | "P1" | "P2" | "P3",
     rationale: string,
   ) => MessageEnvelope;
+  agentPatterns: Record<string, string[]>;
+  execGitLog: (sinceMinutes: number) => string;
+  execGhPrList: () => string;
+};
+
+export const AGENT_MAP: Record<string, string[]> = {
+  Otto: ["Co-Authored-By: Claude"],
+  Alexa: ["kiro", "alexa", "qwen"],
+  Lior: ["lior", "gemini"],
+  Vera: ["codex", "vera"],
+  Riven: ["riven", "grok"],
+  Aaron: ["Aaron Stainback", "AceHack"],
 };
 
 function parseDependsOn(frontmatter: string): string[] {
@@ -141,8 +153,56 @@ const REAL_ADAPTERS: Adapters = {
       topic: "work-assignment",
       payload: { rowId, priority, rationale },
     }),
+  agentPatterns: AGENT_MAP,
+  execGitLog: (sinceMinutes: number) => {
+    try {
+      const cutoff = Math.floor(Date.now() / 1000) - (sinceMinutes * 60);
+      const { spawnSync } = require("node:child_process");
+      const result = spawnSync("git", ["log", `--since=${cutoff}`, "--format=%an %b"], { encoding: "utf8" });
+      return result.stdout || "";
+    } catch {
+      return "";
+    }
+  },
+  execGhPrList: () => {
+    try {
+      const { spawnSync } = require("node:child_process");
+      const result = spawnSync("gh", ["pr", "list", "--state", "open", "--json", "title,body,author"], { encoding: "utf8" });
+      return result.stdout || "";
+    } catch {
+      return "";
+    }
+  },
 };
 
+/**
+ * Returns true if the agent has no commits in the last 30 minutes AND
+ * no currently open PRs.
+ */
+export function isAgentQueueEmpty(
+  agentName: string,
+  adapters: Adapters = REAL_ADAPTERS,
+): boolean {
+  const patterns = adapters.agentPatterns[agentName] ?? [];
+  if (patterns.length === 0) return true; // unknown agent = queue empty
+
+  const logStr = adapters.execGitLog(30).toLowerCase();
+  const hasCommits = patterns.some(p => logStr.includes(p.toLowerCase()));
+  if (hasCommits) return false;
+
+  const prStr = adapters.execGhPrList().toLowerCase();
+  const hasPRs = patterns.some(p => prStr.includes(p.toLowerCase()));
+  if (hasPRs) return false;
+
+  return true;
+}
+
+/**
+ * A dependency is "satisfied" iff the dep's row status is `closed` OR begins
+ * with `superseded-by-` (matching the canonical generator's checkbox logic
+ * in tools/backlog/generate-index.ts). A dangling reference (dep ID not
+ * present in the scan) is treated as UNSATISFIED.
+ */
 function isDepSatisfied(depStatus: string | undefined): boolean {
   if (depStatus === undefined) return false;
   return depStatus === "closed" || depStatus.startsWith("superseded-by-");


### PR DESCRIPTION
Implements slice 3 of B-0441 (backlog-ready-notifier). Adds `isAgentQueueEmpty` function which checks git log and open PRs for a given agent to determine if they are currently idle. 26 tests passing.