### PR TITLE
test(scaffold): B-0424.5 — dry-run test suite for create-repo.ts (18 tests)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/13/2007Z.md
+++ b/docs/hygiene-history/ticks/2026/05/13/2007Z.md
@@ -28,6 +28,7 @@ before anyone runs `--apply`.
 ## Artifact
 
 `tools/scaffold/create-repo.test.ts` — 18 subprocess-based tests:
+
 - All 12 planned operations present for both `forge` and `ace`
 - All operations have `status:"planned"` in dry-run mode
 - Branch protection data: no force-push, linear history, empty

--- a/docs/hygiene-history/ticks/2026/05/13/2007Z.md
+++ b/docs/hygiene-history/ticks/2026/05/13/2007Z.md
@@ -1,0 +1,53 @@
+---
+tick: 2026-05-13T20:07Z
+agent: Otto (Claude Sonnet 4.6, worktree tidy-leaping-pancake)
+task: B-0424.5 — dry-run test suite for create-repo.ts
+pr: "https://github.com/Lucent-Financial-Group/Zeta/pull/3025"
+build: "dotnet build -c Release → 0 warnings 0 errors"
+tests: "bun test tools/scaffold/create-repo.test.ts → 18 pass 0 fail"
+operative-authorization: aaron 2026-05-13: "Cooling period: TBD. The memory file IS the durable record"
+---
+
+# Tick 2026-05-13T20:07Z
+
+## Work done
+
+Claimed and implemented B-0424.5 — the smallest safe slice of B-0424 given
+that B-0424.1–.4 are already merged.
+
+**Context**: B-0424 is the three-repo split Stage 1 (ADR 2026-04-22). Prior
+slices landed the governance templates (`tools/scaffold/forge/` + `ace/`), the
+`create-repo.ts` dry-run tool, a `workflow_dispatch` gate, UPSTREAM-RHYTHM.md
+templates, and Scorecard workflows. The remaining scope is the irreversible
+`--apply` step (actual GitHub repo creation), which is deferred to a future PR
+with Aaron's review.
+
+The smallest safe next step was a test suite that verifies the dry-run output
+before anyone runs `--apply`.
+
+## Artifact
+
+`tools/scaffold/create-repo.test.ts` — 18 subprocess-based tests:
+- All 12 planned operations present for both `forge` and `ace`
+- All operations have `status:"planned"` in dry-run mode
+- Branch protection data: no force-push, linear history, empty
+  `required_status_checks` (avoids deadlock before CI workflows are wired)
+- CodeQL step asserts `default-setup` (guards against advanced-only regression)
+- Governance file inventory asserts README/AGENTS/GOVERNANCE/SECURITY/LICENSE
+- Error-handling: non-zero exit for missing/unknown `--repo`
+
+## 7-step verify trace
+
+1. Cron list checked → re-armed (no live entry at session start)
+2. Worldview refreshed → 0 open PRs, main at b4f62e78
+3. B-0424 backlog read → slices .1–.4 already merged; .5 = test suite
+4. `bun test tools/scaffold/create-repo.test.ts` → 18 pass 0 fail
+5. `dotnet build -c Release` → 0 warnings 0 errors
+6. PR #3025 opened, auto-merge armed
+7. Tick shard written
+
+## Next for B-0424
+
+The remaining DoD step is the actual `--apply` execution to create
+`LFG/Forge` and `LFG/ace`. That step is irreversible and requires Aaron's
+explicit review of the dry-run output and sign-off. Not autonomous-mode safe.

--- a/tools/scaffold/create-repo.test.ts
+++ b/tools/scaffold/create-repo.test.ts
@@ -1,0 +1,245 @@
+// create-repo.test.ts — DST coverage for the B-0424 Stage 1 scaffold tool.
+//
+// All tests run create-repo.ts as a subprocess with --dry-run (no external
+// side effects, no network, no GitHub calls). Each test asserts the planned
+// operation set is correct and complete before anyone runs --apply.
+//
+// Runs via:
+//   bun test tools/scaffold/create-repo.test.ts
+//
+// Zero network — all data comes from the on-disk scaffold templates.
+
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+const SCRIPT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "create-repo.ts"
+);
+
+interface Operation {
+  step: string;
+  description: string;
+  command?: string;
+  data?: Record<string, unknown>;
+  status: "planned" | "executed" | "skipped" | "failed";
+  error?: string;
+}
+
+interface RunResult {
+  repo: string;
+  dryRun: boolean;
+  operations: Operation[];
+  summary: string;
+}
+
+function runDryRun(repo: "forge" | "ace"): RunResult {
+  const result = spawnSync("bun", [SCRIPT, "--repo", repo, "--dry-run"], {
+    encoding: "utf8",
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `create-repo.ts exited ${result.status}: ${result.stderr}`
+    );
+  }
+  return JSON.parse(result.stdout) as RunResult;
+}
+
+// Canonical step IDs emitted by the tool (order matches execution order in
+// main: 01, 01b, 06, 02, 02b, 03a, 03b, 03c, 03d, 04, 05, 07).
+const EXPECTED_STEPS = [
+  "01-create-repo",
+  "01b-merge-settings",
+  "06-push-scaffold-files",
+  "02-branch-protection",
+  "02b-required-signed-commits",
+  "03a-secret-scanning",
+  "03b-dependabot-alerts",
+  "03c-dependabot-security-updates",
+  "03d-private-vuln-reporting",
+  "04-codeql-default-setup",
+  "05-fork-to-acehack",
+  "07-next-steps",
+] as const;
+
+function assertCommonInvariants(result: RunResult, orgName: string): void {
+  expect(result.dryRun).toBe(true);
+  expect(result.repo).toBe(`Lucent-Financial-Group/${orgName}`);
+  expect(result.summary).toContain("DRY RUN");
+  expect(result.summary).toContain("planned");
+
+  // Every operation is "planned" in dry-run mode.
+  for (const op of result.operations) {
+    expect(op.status).toBe("planned");
+  }
+
+  // Exact step inventory (order-independent).
+  const steps = result.operations.map((o) => o.step);
+  for (const expected of EXPECTED_STEPS) {
+    expect(steps).toContain(expected);
+  }
+  expect(result.operations).toHaveLength(EXPECTED_STEPS.length);
+}
+
+// --- forge ---
+
+describe("forge dry-run", () => {
+  const result = runDryRun("forge");
+
+  test("produces dryRun:true with LFG/Forge repo name", () => {
+    expect(result.dryRun).toBe(true);
+    expect(result.repo).toBe("Lucent-Financial-Group/Forge");
+  });
+
+  test("all operations are planned (no executions in dry-run)", () => {
+    for (const op of result.operations) {
+      expect(op.status).toBe("planned");
+    }
+  });
+
+  test("contains all 12 expected step IDs", () => {
+    assertCommonInvariants(result, "Forge");
+  });
+
+  test("step 01 targets LFG/Forge as public squash-merge repo", () => {
+    const op = result.operations.find((o) => o.step === "01-create-repo");
+    expect(op).toBeDefined();
+    expect(op!.data).toMatchObject({
+      visibility: "public",
+      allow_squash_merge: true,
+      allow_merge_commit: false,
+      allow_rebase_merge: false,
+      delete_branch_on_merge: true,
+      allow_auto_merge: true,
+    });
+  });
+
+  test("step 02 branch protection disables force-push and requires linear history", () => {
+    const op = result.operations.find((o) => o.step === "02-branch-protection");
+    expect(op).toBeDefined();
+    expect(op!.data).toMatchObject({
+      allow_force_pushes: false,
+      required_linear_history: true,
+      required_conversation_resolution: true,
+    });
+  });
+
+  test("step 02 branch protection has empty required_status_checks (avoids deadlock)", () => {
+    const op = result.operations.find((o) => o.step === "02-branch-protection");
+    expect(op).toBeDefined();
+    const checks = (op!.data as { required_status_checks: { contexts: string[] } }).required_status_checks;
+    // Empty at creation time — CI workflows don't exist yet; adding them before
+    // the workflows land deadlocks the repo. Populated after CI is wired.
+    expect(checks.contexts).toEqual([]);
+  });
+
+  test("step 04 enables CodeQL default-setup (not advanced-only)", () => {
+    const op = result.operations.find((o) => o.step === "04-codeql-default-setup");
+    expect(op).toBeDefined();
+    expect(op!.data).toMatchObject({ state: "configured", query_suite: "default" });
+    // Confirm description calls out the ruleset-rule requirement.
+    expect(op!.description).toContain("code_scanning");
+    expect(op!.description).toContain("default-setup");
+  });
+
+  test("step 05 forks to AceHack org", () => {
+    const op = result.operations.find((o) => o.step === "05-fork-to-acehack");
+    expect(op).toBeDefined();
+    expect(op!.data).toMatchObject({ organization: "AceHack" });
+    expect(op!.description).toContain("AceHack/Forge");
+  });
+
+  test("step 06 lists scaffold files to push", () => {
+    const op = result.operations.find((o) => o.step === "06-push-scaffold-files");
+    expect(op).toBeDefined();
+    const files = (op!.data as { files: string[] }).files;
+    expect(files.length).toBeGreaterThan(0);
+    // Core governance files must be present.
+    expect(files.some((f) => f.includes("README.md"))).toBe(true);
+    expect(files.some((f) => f.includes("AGENTS.md"))).toBe(true);
+    expect(files.some((f) => f.includes("GOVERNANCE.md"))).toBe(true);
+    expect(files.some((f) => f.includes("SECURITY.md"))).toBe(true);
+    expect(files.some((f) => f.includes("LICENSE"))).toBe(true);
+  });
+
+  test("step 07 lists manual steps including budget-cap verification", () => {
+    const op = result.operations.find((o) => o.step === "07-next-steps");
+    expect(op).toBeDefined();
+    const manual = (op!.data as { manualSteps: string[] }).manualSteps;
+    expect(manual.length).toBeGreaterThan(0);
+    expect(manual.some((s) => s.toLowerCase().includes("budget"))).toBe(true);
+    expect(manual.some((s) => s.toLowerCase().includes("codeql"))).toBe(true);
+  });
+});
+
+// --- ace ---
+
+describe("ace dry-run", () => {
+  const result = runDryRun("ace");
+
+  test("produces dryRun:true with LFG/ace repo name", () => {
+    expect(result.dryRun).toBe(true);
+    expect(result.repo).toBe("Lucent-Financial-Group/ace");
+  });
+
+  test("all operations are planned (no executions in dry-run)", () => {
+    for (const op of result.operations) {
+      expect(op.status).toBe("planned");
+    }
+  });
+
+  test("contains all 12 expected step IDs", () => {
+    assertCommonInvariants(result, "ace");
+  });
+
+  test("step 01 targets LFG/ace as public squash-merge repo (no homepage)", () => {
+    const op = result.operations.find((o) => o.step === "01-create-repo");
+    expect(op).toBeDefined();
+    expect(op!.data).toMatchObject({
+      name: "ace",
+      visibility: "public",
+      allow_squash_merge: true,
+    });
+    // ace has no homepage in the config (unlike Forge which links back to Zeta).
+    expect((op!.data as Record<string, unknown>)["homepage"]).toBeUndefined();
+  });
+
+  test("step 05 forks to AceHack org", () => {
+    const op = result.operations.find((o) => o.step === "05-fork-to-acehack");
+    expect(op).toBeDefined();
+    expect(op!.data).toMatchObject({ organization: "AceHack" });
+    expect(op!.description).toContain("AceHack/ace");
+  });
+
+  test("step 06 lists scaffold files to push", () => {
+    const op = result.operations.find((o) => o.step === "06-push-scaffold-files");
+    expect(op).toBeDefined();
+    const files = (op!.data as { files: string[] }).files;
+    expect(files.length).toBeGreaterThan(0);
+    expect(files.some((f) => f.includes("README.md"))).toBe(true);
+    expect(files.some((f) => f.includes("SECURITY.md"))).toBe(true);
+  });
+});
+
+// --- error handling ---
+
+describe("invalid --repo argument", () => {
+  test("exits non-zero with usage message for unknown repo", () => {
+    const result = spawnSync("bun", [SCRIPT, "--repo", "nonexistent", "--dry-run"], {
+      encoding: "utf8",
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Usage:");
+  });
+
+  test("exits non-zero when --repo is omitted", () => {
+    const result = spawnSync("bun", [SCRIPT, "--dry-run"], {
+      encoding: "utf8",
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Usage:");
+  });
+});

--- a/tools/scaffold/create-repo.test.ts
+++ b/tools/scaffold/create-repo.test.ts
@@ -12,7 +12,7 @@
 import { spawnSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 
 const SCRIPT = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -65,9 +65,9 @@ const EXPECTED_STEPS = [
   "07-next-steps",
 ] as const;
 
-function assertCommonInvariants(result: RunResult, orgName: string): void {
+function assertCommonInvariants(result: RunResult, repoName: string): void {
   expect(result.dryRun).toBe(true);
-  expect(result.repo).toBe(`Lucent-Financial-Group/${orgName}`);
+  expect(result.repo).toBe(`Lucent-Financial-Group/${repoName}`);
   expect(result.summary).toContain("DRY RUN");
   expect(result.summary).toContain("planned");
 
@@ -87,7 +87,10 @@ function assertCommonInvariants(result: RunResult, orgName: string): void {
 // --- forge ---
 
 describe("forge dry-run", () => {
-  const result = runDryRun("forge");
+  let result: RunResult;
+  beforeAll(() => {
+    result = runDryRun("forge");
+  });
 
   test("produces dryRun:true with LFG/Forge repo name", () => {
     expect(result.dryRun).toBe(true);
@@ -178,7 +181,10 @@ describe("forge dry-run", () => {
 // --- ace ---
 
 describe("ace dry-run", () => {
-  const result = runDryRun("ace");
+  let result: RunResult;
+  beforeAll(() => {
+    result = runDryRun("ace");
+  });
 
   test("produces dryRun:true with LFG/ace repo name", () => {
     expect(result.dryRun).toBe(true);
@@ -232,7 +238,7 @@ describe("invalid --repo argument", () => {
       encoding: "utf8",
     });
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("Usage:");
+    expect(result.stderr + result.stdout).toContain("Usage:");
   });
 
   test("exits non-zero when --repo is omitted", () => {
@@ -240,6 +246,6 @@ describe("invalid --repo argument", () => {
       encoding: "utf8",
     });
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("Usage:");
+    expect(result.stderr + result.stdout).toContain("Usage:");
   });
 });


### PR DESCRIPTION
## Summary

- Adds `tools/scaffold/create-repo.test.ts` — 18 subprocess-based tests for the B-0424 Stage 1 scaffold tool
- Tests verify the `--dry-run` output for both `forge` and `ace` before anyone runs `--apply` (the irreversible GitHub repo creation step)
- Closes the test gap between B-0424.4 (Scorecard workflow) and the eventual Stage 1 execution PR

## What the tests cover

| Scenario | Assertions |
|---|---|
| Both repos produce 12 planned operations | Step ID inventory, all status:"planned" |
| Step 01 repo settings | public, squash-merge, auto-merge, delete-branch; ace has no homepage |
| Step 02 branch protection | no force-push, linear history, empty required_status_checks (deadlock guard) |
| Step 04 CodeQL | default-setup (not advanced-only) — guards against code_scanning ruleset regression |
| Step 05 fork | targets AceHack org |
| Step 06 scaffold files | core governance files present (README, AGENTS, GOVERNANCE, SECURITY, LICENSE) |
| Step 07 manual steps | budget-cap + CodeQL verification items present |
| Error handling | unknown/missing --repo exits non-zero with usage message |

## Why subprocess-based tests

`create-repo.ts` calls `process.exit()` and runs logic at module load — both break import-time unit testing. Spawning as a subprocess mirrors the actual invocation path, requires zero refactoring, and is zero-network (no GitHub calls, no side effects).

## Checks

- `bun test tools/scaffold/create-repo.test.ts` → **18 pass, 0 fail**
- `dotnet build -c Release` → **0 warnings, 0 errors**

## Context

- B-0424 backlog: `docs/backlog/P1/B-0424-three-repo-split-stage1-create-forge-ace-with-scaffolding-aaron-2026-05-13.md`
- ADR: `docs/DECISIONS/2026-04-22-three-repo-split-zeta-forge-ace.md`
- Prior slices: B-0424.1 (#2994), .2 (#2996), .3 (#3003), .4 (#3019)

operative-authorization: aaron 2026-05-13: "Cooling period: TBD. The memory file IS the durable record"

🤖 Generated with [Claude Code](https://claude.com/claude-code)