### PR TITLE
feat(scaffold): B-0424.6 — add .semgrep.yml GHA injection rule to forge+ace scaffold templates

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/13/2019Z.md
+++ b/docs/hygiene-history/ticks/2026/05/13/2019Z.md
@@ -1,0 +1,41 @@
+---
+tick: 2026-05-13T20:19Z
+branch: feat/b-0424-6-scaffold-semgrep
+pr: 3026
+operative-authorization: aaron 2026-05-13: "Cooling period: TBD. The memory file IS the durable record"
+---
+
+# Tick — 2026-05-13T20:19Z
+
+## Work done
+
+**B-0424.6** — Add `.semgrep.yml` GHA injection rule to forge + ace scaffold templates.
+
+ADR 2026-04-22 checklist item closed: *"Semgrep rule for GHA inline-untrusted-in-run injection (already landed on Zeta; generalise to Forge + ace)."*
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `tools/scaffold/forge/.semgrep.yml` | Created — `gha-untrusted-in-run-line` rule (Rule 17 from Zeta) |
+| `tools/scaffold/ace/.semgrep.yml` | Created — same rule, ace-scoped header |
+| `tools/scaffold/create-repo.ts` | step07 manual step 3 updated: "add Semgrep rule" → "wire gate workflow" |
+| `tools/scaffold/README.md` | Template tree + manual-steps note updated |
+| `tools/scaffold/create-repo.test.ts` | Added `.semgrep.yml` assertions to step-06 tests for both forge and ace |
+
+### Verify trace
+
+1. `CronList` → no live cron → re-armed `* * * * * <<autonomous-loop>>` ✓
+2. `dotnet build -c Release` → 0 warnings, 0 errors ✓
+3. `semgrep --validate` forge + ace `.semgrep.yml` → 0 errors, 1 rule each ✓
+4. `bun test tools/scaffold/create-repo.test.ts` → 18 pass, 0 fail ✓
+5. PR #3026 opened, auto-merge armed → `gate: BLOCKED, nextAction: wait-ci` ✓
+
+### Context
+
+Previous slices: B-0424.1 (pre-start gate), B-0424.2 (dispatch workflow),
+B-0424.3–B-0424.4 (templates + tool), B-0424.5 (test suite, PR #3025 merged).
+
+This slice completes one more ADR checklist item. The `.semgrep.yml` files will
+be pushed as day-one governance files by `create-repo.ts` step 06. CI wiring
+of the `semgrep` lint job remains Stage-2 work.

--- a/tools/scaffold/README.md
+++ b/tools/scaffold/README.md
@@ -47,6 +47,7 @@ tools/scaffold/
     CODE_OF_CONDUCT.md
     CONTRIBUTING.md
     LICENSE
+    .semgrep.yml         — GHA injection rule (gha-untrusted-in-run-line)
     .github/
       copilot-instructions.md
     docs/
@@ -55,6 +56,7 @@ tools/scaffold/
 
   ace/                   — ace day-one governance files
     (same structure, ace-scoped content)
+    .semgrep.yml         — GHA injection rule (same as Forge)
     docs/
       GITHUB-SETTINGS.md
       UPSTREAM-RHYTHM.md
@@ -71,7 +73,8 @@ The tool prints these at the end, but for reference:
    (GitHub requires a rasterized PNG format — SVG not accepted)
 2. Enable merge queue via GitHub UI
    (Settings → Merge queue — org feature, no REST API)
-3. Add Semgrep GHA inline-untrusted-in-run rule
+3. Wire gate workflow: add `semgrep --config .semgrep.yml --error --metrics=off` step
+   (`.semgrep.yml` is already in the scaffold — only the CI job wiring is manual, done in Stage 2)
 4. Verify $0 budget caps at org level in GitHub billing settings
 5. Confirm CodeQL default-setup is active under Security → Code scanning
 

--- a/tools/scaffold/ace/.mise.toml
+++ b/tools/scaffold/ace/.mise.toml
@@ -1,0 +1,15 @@
+# Runtime tool pins for ace — managed by mise.
+#
+# Install: mise install
+#
+# `pipx:` is mise's registry prefix (not the pipx package manager).
+# When `uv` is present in the toolchain, mise auto-routes `pipx:`
+# installs through `uv tool install` — faster, no separate pipx
+# package needed. See ADR 2026-04-27 §uv-as-canonical.
+
+[tools]
+# uv: Python tool installer. Powers the `pipx:` backend below.
+uv = "0.11.8"
+# semgrep: SAST linter for .semgrep.yml rules. Pinned for
+# dev/CI parity (GOVERNANCE §24 three-way-parity invariant).
+"pipx:semgrep" = "1.161.0"

--- a/tools/scaffold/ace/.semgrep.yml
+++ b/tools/scaffold/ace/.semgrep.yml
@@ -8,6 +8,8 @@
 # CI integration: wire `semgrep --config .semgrep.yml --error
 # --metrics=off` into the gate workflow. Semgrep version is pinned
 # via `pipx:semgrep` in `.mise.toml` — install with `mise install`.
+# (`pipx:` is mise's registry prefix; routes through `uv tool install`
+# when uv is present in the toolchain, per ADR 2026-04-27.)
 
 rules:
 

--- a/tools/scaffold/ace/.semgrep.yml
+++ b/tools/scaffold/ace/.semgrep.yml
@@ -1,0 +1,44 @@
+# Semgrep rules for ace — runs via `semgrep --config .semgrep.yml`
+#
+# Day-one security rules applied at repo creation (B-0424 Stage 1).
+# Pattern: Zeta's proven rule-set generalised to ace on day one
+# per ADR 2026-04-22 §"Repo best practices — applied at creation":
+# "if Zeta does it, Forge and ace do it."
+#
+# CI integration: wire `semgrep --config .semgrep.yml --error
+# --metrics=off` into the gate workflow. Semgrep version is pinned
+# via `pipx:semgrep` in `.mise.toml` — install with `mise install`.
+
+rules:
+
+  # ────────────────────────────────────────────────────────────────
+  # Rule 1 — GitHub Actions workflow-injection: inline untrusted
+  # context on a `run:` line. Primary workflow-injection vector per
+  # https://github.blog/security/vulnerability-research/how-to-
+  # catch-github-actions-workflow-injections-before-attackers-do/.
+  #
+  # Matches single-line `run: ... ${{ github.<unsafe-path> }} ...`
+  # forms for attacker-controlled contexts (PR title, issue body,
+  # branch name, commit message, review body). Multi-line `run: |`
+  # blocks are not covered here — use actionlint + shellcheck over
+  # extracted script bodies for that class.
+  #
+  # Fix: bind the value to an `env:` entry on the step and read it
+  # as `"$VAR"` in the shell.
+  # ────────────────────────────────────────────────────────────────
+  - id: gha-untrusted-in-run-line
+    patterns:
+      - pattern-regex: '(?m)^\s*-?\s*run:.*\$\{\{\s*github\.(head_ref|event\.(issue\.(title|body)|pull_request\.(title|body|head_ref|head\.ref|head\.label)|comment\.body|review\.body|head_commit\.message|commits))'
+    paths:
+      include:
+        - ".github/workflows/*.yml"
+        - ".github/workflows/*.yaml"
+    message: >-
+      Attacker-controlled `github.event.*` / `github.head_ref` value
+      expanded directly into a `run:` shell command — GitHub Actions
+      workflow-injection sink. A PR title / issue body / branch name
+      containing shell metacharacters will execute on the runner.
+      Bind the value to the step's `env:` block and reference it as
+      `"$VAR"` in the shell.
+    languages: [generic]
+    severity: ERROR

--- a/tools/scaffold/create-repo.test.ts
+++ b/tools/scaffold/create-repo.test.ts
@@ -166,6 +166,8 @@ describe("forge dry-run", () => {
     expect(files.some((f) => f.includes("GOVERNANCE.md"))).toBe(true);
     expect(files.some((f) => f.includes("SECURITY.md"))).toBe(true);
     expect(files.some((f) => f.includes("LICENSE"))).toBe(true);
+    // GHA injection protection must be present from day one (B-0424.6).
+    expect(files.some((f) => f.includes(".semgrep.yml"))).toBe(true);
   });
 
   test("step 07 lists manual steps including budget-cap verification", () => {
@@ -227,6 +229,8 @@ describe("ace dry-run", () => {
     expect(files.length).toBeGreaterThan(0);
     expect(files.some((f) => f.includes("README.md"))).toBe(true);
     expect(files.some((f) => f.includes("SECURITY.md"))).toBe(true);
+    // GHA injection protection must be present from day one (B-0424.6).
+    expect(files.some((f) => f.includes(".semgrep.yml"))).toBe(true);
   });
 });
 

--- a/tools/scaffold/create-repo.test.ts
+++ b/tools/scaffold/create-repo.test.ts
@@ -168,6 +168,8 @@ describe("forge dry-run", () => {
     expect(files.some((f) => f.includes("LICENSE"))).toBe(true);
     // GHA injection protection must be present from day one (B-0424.6).
     expect(files.some((f) => f.includes(".semgrep.yml"))).toBe(true);
+    // Toolchain pin for semgrep must be scaffolded alongside it (B-0424.6).
+    expect(files.some((f) => f.includes(".mise.toml"))).toBe(true);
   });
 
   test("step 07 lists manual steps including budget-cap verification", () => {
@@ -231,6 +233,8 @@ describe("ace dry-run", () => {
     expect(files.some((f) => f.includes("SECURITY.md"))).toBe(true);
     // GHA injection protection must be present from day one (B-0424.6).
     expect(files.some((f) => f.includes(".semgrep.yml"))).toBe(true);
+    // Toolchain pin for semgrep must be scaffolded alongside it (B-0424.6).
+    expect(files.some((f) => f.includes(".mise.toml"))).toBe(true);
   });
 });
 

--- a/tools/scaffold/create-repo.ts
+++ b/tools/scaffold/create-repo.ts
@@ -529,7 +529,7 @@ function step07_summary(): void {
       manualSteps: [
         "Upload SVG social-preview PNG via GitHub UI (GitHub requires rasterized PNG format)",
         "Enable merge queue via GitHub UI: Settings → Merge queue (org feature, no API)",
-        "Add Semgrep GHA inline-untrusted-in-run rule workflow",
+        "Wire gate workflow: add `semgrep --config .semgrep.yml --error --metrics=off` step (.semgrep.yml is in scaffold files; CI job still needs wiring in Stage 2)",
         "Add bun-test, bun-lint, codeql, scorecard as required status checks AFTER CI workflows are wired (branch protection was created with empty contexts to avoid deadlock)",
         "Verify budget caps $0 at org level: github.com/organizations/Lucent-Financial-Group/settings/billing",
         "Confirm CodeQL default-setup is active: Security → Code scanning → Default setup",

--- a/tools/scaffold/forge/.mise.toml
+++ b/tools/scaffold/forge/.mise.toml
@@ -1,0 +1,15 @@
+# Runtime tool pins for Forge — managed by mise.
+#
+# Install: mise install
+#
+# `pipx:` is mise's registry prefix (not the pipx package manager).
+# When `uv` is present in the toolchain, mise auto-routes `pipx:`
+# installs through `uv tool install` — faster, no separate pipx
+# package needed. See ADR 2026-04-27 §uv-as-canonical.
+
+[tools]
+# uv: Python tool installer. Powers the `pipx:` backend below.
+uv = "0.11.8"
+# semgrep: SAST linter for .semgrep.yml rules. Pinned for
+# dev/CI parity (GOVERNANCE §24 three-way-parity invariant).
+"pipx:semgrep" = "1.161.0"

--- a/tools/scaffold/forge/.semgrep.yml
+++ b/tools/scaffold/forge/.semgrep.yml
@@ -8,6 +8,8 @@
 # CI integration: wire `semgrep --config .semgrep.yml --error
 # --metrics=off` into the gate workflow. Semgrep version is pinned
 # via `pipx:semgrep` in `.mise.toml` — install with `mise install`.
+# (`pipx:` is mise's registry prefix; routes through `uv tool install`
+# when uv is present in the toolchain, per ADR 2026-04-27.)
 
 rules:
 

--- a/tools/scaffold/forge/.semgrep.yml
+++ b/tools/scaffold/forge/.semgrep.yml
@@ -1,0 +1,44 @@
+# Semgrep rules for Forge — runs via `semgrep --config .semgrep.yml`
+#
+# Day-one security rules applied at repo creation (B-0424 Stage 1).
+# Pattern: Zeta's proven rule-set generalised to Forge on day one
+# per ADR 2026-04-22 §"Repo best practices — applied at creation":
+# "if Zeta does it, Forge and ace do it."
+#
+# CI integration: wire `semgrep --config .semgrep.yml --error
+# --metrics=off` into the gate workflow. Semgrep version is pinned
+# via `pipx:semgrep` in `.mise.toml` — install with `mise install`.
+
+rules:
+
+  # ────────────────────────────────────────────────────────────────
+  # Rule 1 — GitHub Actions workflow-injection: inline untrusted
+  # context on a `run:` line. Primary workflow-injection vector per
+  # https://github.blog/security/vulnerability-research/how-to-
+  # catch-github-actions-workflow-injections-before-attackers-do/.
+  #
+  # Matches single-line `run: ... ${{ github.<unsafe-path> }} ...`
+  # forms for attacker-controlled contexts (PR title, issue body,
+  # branch name, commit message, review body). Multi-line `run: |`
+  # blocks are not covered here — use actionlint + shellcheck over
+  # extracted script bodies for that class.
+  #
+  # Fix: bind the value to an `env:` entry on the step and read it
+  # as `"$VAR"` in the shell.
+  # ────────────────────────────────────────────────────────────────
+  - id: gha-untrusted-in-run-line
+    patterns:
+      - pattern-regex: '(?m)^\s*-?\s*run:.*\$\{\{\s*github\.(head_ref|event\.(issue\.(title|body)|pull_request\.(title|body|head_ref|head\.ref|head\.label)|comment\.body|review\.body|head_commit\.message|commits))'
+    paths:
+      include:
+        - ".github/workflows/*.yml"
+        - ".github/workflows/*.yaml"
+    message: >-
+      Attacker-controlled `github.event.*` / `github.head_ref` value
+      expanded directly into a `run:` shell command — GitHub Actions
+      workflow-injection sink. A PR title / issue body / branch name
+      containing shell metacharacters will execute on the runner.
+      Bind the value to the step's `env:` block and reference it as
+      `"$VAR"` in the shell.
+    languages: [generic]
+    severity: ERROR


### PR DESCRIPTION
## Summary

- **Slice**: B-0424.6 — ADR 2026-04-22 checklist item: *"Semgrep rule for GHA inline-untrusted-in-run injection (already landed on Zeta; generalise to Forge + ace)"*
- Adds `tools/scaffold/forge/.semgrep.yml` and `tools/scaffold/ace/.semgrep.yml`, each containing the `gha-untrusted-in-run-line` rule (Rule 17 from Zeta's `.semgrep.yml`)
- Updates `create-repo.ts` step07 manual steps: step 3 is now "wire gate workflow" since the config file is now scaffolded (only CI job wiring deferred to Stage 2)
- Updates `tools/scaffold/README.md` template tree listing and manual-steps note
- Extends existing step-06 tests to assert `.semgrep.yml` present for both forge and ace

## Test plan

- [x] `bun test tools/scaffold/create-repo.test.ts` — **18 pass, 0 fail**
- [x] `semgrep --config tools/scaffold/forge/.semgrep.yml --validate` — 0 errors, 1 rule
- [x] `semgrep --config tools/scaffold/ace/.semgrep.yml --validate` — 0 errors, 1 rule
- [x] `dotnet build -c Release` — 0 warnings, 0 errors

## Context

B-0424 Stage 1 is the three-repo split scaffold (`LFG/Forge` + `LFG/ace`). Previous slices:
- B-0424.1: pre-start gate + scope decision (scaffold deferred actual creation)
- B-0424.2: `scaffold-stage1-create-repos.yml` CI dispatch workflow
- B-0424.3–B-0424.4: governance templates + `create-repo.ts` tool
- B-0424.5 (PR #3025): dry-run test suite (18 tests)

This slice completes one remaining ADR checklist item for the template set. The `.semgrep.yml` files are pushed as day-one governance files by `create-repo.ts` step 06 (before branch protection). CI wiring of the `semgrep` lint job remains a Stage-2 task.

operative-authorization: aaron 2026-05-13: "Cooling period: TBD. The memory file IS the durable record"

🤖 Generated with [Claude Code](https://claude.com/claude-code)