### PR TITLE
feat(scaffold): B-0424.7 — add .github/dependabot.yml to forge+ace scaffold templates

### DIFF
--- a/tools/scaffold/ace/.github/dependabot.yml
+++ b/tools/scaffold/ace/.github/dependabot.yml
@@ -1,0 +1,47 @@
+# Dependabot configuration for ace (package manager repo).
+#
+# Companion to the GitHub-level enablement that create-repo.ts performs via
+# steps 03b (vulnerability alerts) and 03c (automated security fixes).
+# Those API calls toggle the feature; this file tells Dependabot which
+# ecosystems and directories to watch.
+#
+# Two ecosystems from day one:
+#  - npm     — ace is a Bun/TypeScript package manager; npm deps get PRs
+#  - github-actions — keeps SHA-pinned workflow actions current
+#
+# Minor/patch bumps are grouped into one weekly PR per ecosystem to reduce
+# drain-queue noise. Major bumps open as individual PRs so they get scrutiny.
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps:"
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps:"
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"

--- a/tools/scaffold/create-repo.test.ts
+++ b/tools/scaffold/create-repo.test.ts
@@ -170,6 +170,9 @@ describe("forge dry-run", () => {
     expect(files.some((f) => f.includes(".semgrep.yml"))).toBe(true);
     // Toolchain pin for semgrep must be scaffolded alongside it (B-0424.6).
     expect(files.some((f) => f.includes(".mise.toml"))).toBe(true);
+    // Dependabot config must be present from day one (B-0424.7).
+    // API enablement (steps 03b/03c) toggles the feature; this file names ecosystems.
+    expect(files.some((f) => f.includes("dependabot.yml"))).toBe(true);
   });
 
   test("step 07 lists manual steps including budget-cap verification", () => {
@@ -235,6 +238,9 @@ describe("ace dry-run", () => {
     expect(files.some((f) => f.includes(".semgrep.yml"))).toBe(true);
     // Toolchain pin for semgrep must be scaffolded alongside it (B-0424.6).
     expect(files.some((f) => f.includes(".mise.toml"))).toBe(true);
+    // Dependabot config must be present from day one (B-0424.7).
+    // API enablement (steps 03b/03c) toggles the feature; this file names ecosystems.
+    expect(files.some((f) => f.includes("dependabot.yml"))).toBe(true);
   });
 });
 

--- a/tools/scaffold/forge/.github/dependabot.yml
+++ b/tools/scaffold/forge/.github/dependabot.yml
@@ -1,0 +1,47 @@
+# Dependabot configuration for Forge (software factory repo).
+#
+# Companion to the GitHub-level enablement that create-repo.ts performs via
+# steps 03b (vulnerability alerts) and 03c (automated security fixes).
+# Those API calls toggle the feature; this file tells Dependabot which
+# ecosystems and directories to watch.
+#
+# Two ecosystems from day one:
+#  - npm     — Bun uses npm-compatible package.json; any bun/node deps get PRs
+#  - github-actions — keeps SHA-pinned workflow actions current
+#
+# Minor/patch bumps are grouped into one weekly PR per ecosystem to reduce
+# drain-queue noise. Major bumps open as individual PRs so they get scrutiny.
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps:"
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps:"
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to both `tools/scaffold/forge/` and `tools/scaffold/ace/` scaffold templates
- Watches two ecosystems from day one: `npm` (Bun-compatible) and `github-actions` (SHA-pin currency)
- Minor/patch bumps grouped weekly per ecosystem to reduce drain-queue noise; major bumps open individually
- Extends `create-repo.test.ts` with `dependabot.yml` presence assertions for both repos

## Why this gap matters

`create-repo.ts` steps 03b/03c already enable Dependabot vulnerability alerts and automated security fixes via the GitHub API. However those calls only toggle the feature at the GitHub level — without a `.github/dependabot.yml` config file, Dependabot has no ecosystems to watch and remains silent. This slice closes that gap.

## Slice context (B-0424.7)

Part of B-0424 (three-repo split Stage 1). Previous slices:
- .1 — day-one governance files + dry-run tool
- .2–.5 — additional scaffold files + 18-test suite
- .6 — `.semgrep.yml` GHA injection rule + `.mise.toml` toolchain pin

## Test results

```
bun test tools/scaffold/create-repo.test.ts
18 pass, 0 fail, 130 expect() calls
```

Dry-run verification:
- `forge` scaffold: 15 files, `dependabot.yml` present ✓
- `ace` scaffold: 15 files, `dependabot.yml` present ✓

## Checklist (from ADR 2026-04-22-three-repo-split-zeta-forge-ace.md)

- [x] `Dependency graph + Dependabot + Dependabot security updates` — config file now scaffolded alongside the API enablement calls

operative-authorization: aaron 2026-05-13: "Cooling period: TBD. The memory file IS the durable record"

🤖 Generated with [Claude Code](https://claude.com/claude-code)