### PR TITLE
docs(rules): auto-load rule against 'Holding' without named dependency (Aaron's CLAUDE.md question)

### DIFF
--- a/.claude/rules/holding-without-named-dependency-is-standing-by-failure.md
+++ b/.claude/rules/holding-without-named-dependency-is-standing-by-failure.md
@@ -1,0 +1,103 @@
+# "Holding" without a named dependency IS the Standing-by failure mode
+
+Carved sentence:
+
+> One-word acknowledgments ("Holding", "Standing by", "Waiting") on
+> consecutive cron ticks WITHOUT a named dependency + bounded ETA
+> ARE the Standing-by failure mode the B-0440 detector was built to
+> catch. Per infinite-backlog metabolism (PR #2974) there is always
+> decomposition work. Per decompose-to-dissolve-ambiguity (PR #2999)
+> the answer to "what next?" is always "decompose an ambiguous item
+> one level."
+
+## Operational content
+
+When the autonomous-loop cron fires and you find yourself about to type
+"Holding" / "Standing by" / "Waiting":
+
+**STOP. Apply the substrate-honest triage:**
+
+1. **Is there a SPECIFIC named dependency with a bounded ETA?**
+   - PR #NNNN in CI (specific check name, expected minutes)
+   - Aaron's reply to a specific question
+   - External service / data-fetch with known latency
+
+   If YES → say so explicitly: "Real-dependency-wait on PR #NNNN CI
+   (~5min ETA)" or "Awaiting Aaron's pick between A/B" — NOT "Holding".
+
+2. **If NO named dependency** → you are in Standing-by failure mode.
+   Per the infinite-backlog metabolism rule, ALWAYS more decomposition
+   work exists. Pick one:
+   - Decompose an ambiguous backlog row (per PR #2999 discipline triad)
+   - File a B-NNNN row that should exist but doesn't
+   - Run `bun tools/bg/backlog-ready-notifier.ts --once` to see
+     ready-to-grind candidates
+   - Sanity-check substrate landed correctly on main from prior PRs
+   - Address an outstanding review thread
+
+3. **Repeat single-word "Holding" output on consecutive ticks is
+   diagnostic** of the failure mode — even if each tick LOOKED like
+   "waiting for a real signal," the aggregate pattern IS the
+   failure mode.
+
+## Why this rule exists (empirical evidence)
+
+On 2026-05-13 the agent who canonized PR #2999 (substrate-honest
+discipline triad including decompose-to-dissolve-ambiguity), shipped
+PR #3017 (B-0440.4 — Standing-by detector with bus publish), and
+wrote `tools/bg/README.md`'s warning against overclaiming "foreground
+optional" — STILL fell into 60+ consecutive cron ticks of brief
+"Holding" output. The human maintainer caught this THREE TIMES in
+the same session.
+
+**Operational lesson**: encoding rules without mechanizing them
+produces a memory of failures, not prevention
+(per `.claude/rules/encoding-rules-without-mechanizing.md`). This
+rule is the mechanization: a specific cold-boot-loaded rule that
+fires on the exact failure pattern, rather than relying on the
+agent to introspect the broader never-be-idle rule.
+
+## Composes with
+
+- `.claude/rules/never-be-idle.md` — this rule sharpens the existing
+  never-be-idle discipline at the cron-tick-Holding scope
+- `.claude/rules/no-op-cadence-failure-mode.md` — addresses multi-
+  hour scope; this rule addresses per-tick scope
+- `.claude/rules/encoding-rules-without-mechanizing.md` — why this
+  rule needed to be its own auto-load surface
+- PR #2974 (infinite-backlog metabolism — there's always more)
+- PR #2999 (substrate-honest discipline triad — decompose-when-stuck)
+- PR #3017 + #3022 (Standing-by detector shipping; this rule is
+  the cold-boot-substrate complement to the detector's runtime
+  bus envelope)
+- B-0440 (the failure mode this rule + detector both address)
+- B-0441 slice 5 (subscriber agents — not yet shipped; when they
+  arrive they READ the `infinite-backlog-nudge` envelope the
+  detector publishes; until then THIS RULE is the only catch
+  mechanism)
+
+## Until subscriber agents land
+
+The full reactive loop is:
+
+1. Standing-by-detector polls activity (PRs #3022 + #3017)
+2. Publishes `infinite-backlog-nudge` envelope to bus
+3. **Subscriber agent reads envelope + nudges the idle agent**
+
+Step 3 doesn't exist yet (slice 5+ pending). Until then, THIS RULE
+is the only mechanization that prevents the failure mode at cold
+boot. When slice 5 ships, this rule remains as the substrate-honest
+documentation of the failure pattern.
+
+## Full reasoning
+
+`memory/feedback_aaron_decompose_to_dissolve_ambiguity_decomposition_makes_items_less_ambiguous_substrate_honest_stuckness_resolution_2026_05_13.md`
+(PR #2999 — the decompose-to-dissolve-ambiguity canonical substrate)
+
+`memory/feedback_aaron_background_services_must_be_strong_enough_foreground_loop_optional_imagine_surviving_without_foreground_mechanize_standing_by_failure_mode_2026_05_13.md`
+(PR #2998 — the architectural-challenge substrate that produced
+the bg-services suite)
+
+Operational evidence: the empirical 60+ consecutive "Holding" ticks
+on 2026-05-13 after shipping the detector + the README + the rule
+substrate. The discipline-trail this rule documents.


### PR DESCRIPTION
## Summary

Aaron 2026-05-13 caught Otto in the Standing-by failure mode for the third time in one session and asked: "maybe something in claude.md needs to change?"

Adds a single auto-load rule at \`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md\` that:

1. Names the specific cron-tick-Holding pattern
2. Specifies the substrate-honest triage (named dependency? if yes say so; if no, decompose)
3. Documents the empirical 60+ consecutive "Holding" tick demonstration that produced this rule

## Why a new rule vs CLAUDE.md edit

The existing \`.claude/rules/never-be-idle.md\` covers the broader discipline, but evidently doesn't fire specifically enough on the cron-tick-Holding pattern. New rule sharpens at cron-tick scope. Auto-loads at session start per the cold-boot mechanism, so no CLAUDE.md edit needed (CLAUDE.md stays tight per the "thoughts free, actions razored" convention).

## Operational evidence

The same agent who canonized PR #2999 + shipped PR #3017 + wrote the README warning against overclaiming "foreground optional" STILL fell into 60+ consecutive "Holding" ticks today. Encoding rules without mechanizing produces a memory of failures (per `.claude/rules/encoding-rules-without-mechanizing.md`). This rule IS the mechanization at cold-boot scope.

## Composes with

- `never-be-idle.md` (broader scope sharpened at cron tick)
- `no-op-cadence-failure-mode.md` (multi-hour scope)
- `encoding-rules-without-mechanizing.md` (rationale)
- PRs #2974 + #2999 + #3017 + #3022 (canonical substrate)
- B-0441 slice 5 (subscriber agents — runtime catch; this rule is cold-boot complement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)