### PR TITLE
fix(gitignore): ignore tools/shadow/shadow-observer.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ tools/alloy/classes/
 # Cursor / IDE per-user config and plugin caches (superpowers, etc.)
 .config/
 .kiro/
+
+# Shadow observer runtime log — machine-local, regenerated per boot.
+tools/shadow/shadow-observer.log


### PR DESCRIPTION
Runtime telemetry from the shadow observer; regenerated per boot; not durable substrate. Removing IDE-switch friction.