### PR TITLE
docs(backlog): B-0444 — bus claim envelope worktree field (Otto-Desktop's identified follow-up gap)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -493,6 +493,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0421](backlog/P2/B-0421-grok-peer-call-failure-cursor-agent-exit-1-2026-05-11.md)** Grok peer-call failure — cursor-agent exit 1 during multi-agent review
 - [ ] **[B-0430](backlog/P2/B-0430-peer-call-wrappers-codeql-insecure-tmp-file-all-8-wrappers-substrate-consistent-fix-2026-05-13.md)** Peer-call wrappers — CodeQL insecure-temp-file alert on autogenOutputPath() across all 8 wrappers (substrate-consistent fix needed)
 - [ ] **[B-0443](backlog/P2/B-0443-launch-substrate-carve-out-for-persona-naming-in-docs-launch-2026-05-13.md)** Launch-substrate carve-out — persona naming allowed in docs/launch/** under existing closed-list pattern
+- [ ] **[B-0444](backlog/P2/B-0444-bus-claim-envelope-worktree-field-multi-surface-disambiguation-2026-05-13.md)** Bus claim envelope — add `worktree` field for multi-surface disambiguation + worktree-aware claim semantics
 - [ ] **[B-0446](backlog/P2/B-0446-lean4-formal-proof-completion-dbsp-core-identities-pm2-2026-05-13.md)** Lean 4 formal proof completion — DBSP chain rule + core stream-calculus identities
 - [ ] **[B-0447](backlog/P2/B-0447-nuget-package-metadata-completeness-pm2-2026-05-13.md)** NuGet package metadata completeness — description, tags, SourceLink, semantic versioning
 

--- a/docs/backlog/P2/B-0444-bus-claim-envelope-worktree-field-multi-surface-disambiguation-2026-05-13.md
+++ b/docs/backlog/P2/B-0444-bus-claim-envelope-worktree-field-multi-surface-disambiguation-2026-05-13.md
@@ -1,0 +1,129 @@
+---
+id: B-0444
+priority: P2
+status: open
+title: "Bus claim envelope — add `worktree` field for multi-surface disambiguation + worktree-aware claim semantics"
+tier: factory-infrastructure
+effort: M
+created: 2026-05-13
+last_updated: 2026-05-13
+depends_on: [B-0400]
+composes_with: [B-0440, B-0441, B-0442]
+tags: [bus, claim, worktree, multi-foreground-surface, split-brain, B-0400-followup]
+type: feature
+---
+
+# Bus claim envelope — add `worktree` field
+
+## Origin
+
+Otto-Desktop 2026-05-13 tick-close (after multi-foreground-surface
+activation):
+
+> Bus envelopes are advisory broadcasts, not locks — scanned 9
+> envelopes at `/tmp/zeta-bus/`; they're work-assignment and
+> review-request topics with from/to/payload/expiresAt. No
+> `action: claim` envelopes yet. The claim-coordinator at
+> `tools/bus/claim.ts` is a SEPARATE mechanism Otto-CLI's rule
+> points to but isn't yet wired into the bus envelope schema.
+> That's a follow-up gap worth filing.
+
+The current B-0400 `ClaimPayload` schema (`tools/bus/types.ts`):
+
+```typescript
+export type ClaimPayload = {
+  action: "claim" | "release";
+  itemId: string; // e.g. "B-0400"
+  branch?: string;
+};
+```
+
+Has `branch` but no `worktree`. For multi-surface agents
+(Otto-CLI + Otto-Desktop, etc.), the WORKTREE PATH is the
+distinguishing operational coordinate — Otto-CLI on
+`/Users/acehack/Documents/src/repos/Zeta` is a different
+operational context than Otto-Desktop on
+`/tmp/zeta-otto-desktop`.
+
+## What lands
+
+Extend `ClaimPayload` with optional `worktree` field:
+
+```typescript
+export type ClaimPayload = {
+  action: "claim" | "release";
+  itemId: string;
+  branch?: string;
+  worktree?: string; // NEW: absolute path of the agent's worktree
+};
+```
+
+Update `tools/bus/claim.ts` to:
+
+1. Accept `--worktree <path>` flag on `acquire`
+2. Default to `process.cwd()` if not provided
+3. Surface in `check` output for operator visibility
+4. Optionally: filter claims by worktree in `activeClaims`
+   (an agent should be able to claim its own item again from the
+   same worktree, but a different worktree by the same sender ID
+   should NOT race-acquire — TBD per substrate-honest design)
+
+## Acceptance criteria
+
+- [ ] `ClaimPayload.worktree?: string` added to schema
+- [ ] `tools/bus/claim.ts acquire --worktree <path>` flag accepted
+- [ ] Defaults to `process.cwd()` when not specified
+- [ ] `check` output includes worktree of holder
+- [ ] Existing claims without worktree field continue to work (back-compat)
+- [ ] Tests cover: claim with worktree, claim without (back-compat),
+      different worktrees same sender (substrate-honest design TBD)
+
+## Substrate-honest caveats
+
+- **Design ambiguity**: should two claims from the same sender ID
+  but different worktrees be treated as one claim or two? Otto-CLI
+  on `/Zeta` claiming B-0444 vs Otto-CLI on `/tmp/zeta-foo` claiming
+  B-0444 — same operational instance or different?
+- **Operational answer probably**: same sender ID + different
+  worktree = same logical agent operating on different problems;
+  not a split-brain. The schema captures the metadata; the design
+  decision is whether `acquire` blocks across worktrees.
+- **Composes with PR #3037** (`SENDER_IDS` schema extension): the
+  multi-surface fix is at the sender-ID level; this is the
+  per-worktree metadata level. Both are needed substrate-honestly.
+
+## Composes with
+
+- B-0400 (bus protocol root)
+- B-0400 slice 3 (claim-coordinator)
+- PR #3032 (`.claude/rules/claim-acquire-before-worktree-work.md`)
+- PR #3037 (`SENDER_IDS` schema extension — sibling substrate-level fix)
+- PR #3034 (multi-foreground-surface routines)
+- `memory/feedback_aaron_multi_foreground_surface_otto_activation_*`
+  (operational evidence)
+- `memory/feedback_aaron_otto_identity_stays_unified_across_surfaces_*`
+  (identity stays unified; this is the protocol-level
+  disambiguation that supports unified identity)
+
+## Pre-start checklist (per backlog-item-start-gate)
+
+- [ ] Prior-art search: `git log --all --oneline -- tools/bus/types.ts`
+      for prior claim-envelope schema changes
+- [ ] Dependency check: PR #3037 (SENDER_IDS extension) merged
+      before this lands so the multi-surface use case is fully
+      supported
+- [ ] Verify claim-coordinator's atomic-lock logic doesn't need
+      updating for the new field
+- [ ] Decide design: cross-worktree-same-sender = same-claim or
+      different-claim? Substrate-honest disclosure of the decision
+      in commit message
+
+## Future work
+
+After this row lands:
+
+- Update `.claude/rules/claim-acquire-before-worktree-work.md`
+  to mention `--worktree` flag
+- Update bus envelope examples in canonical bootstream
+- Consider auto-population of `worktree` field via
+  `process.cwd()` so agents don't need to pass it explicitly


### PR DESCRIPTION
Files Otto-Desktop's tick-close-identified gap: bus claim envelopes are advisory broadcasts, not locks; the claim-coordinator at `tools/bus/claim.ts` is a SEPARATE mechanism the bus envelope schema doesn't yet expose.

Extends `ClaimPayload` with optional `worktree` field for multi-surface operational disambiguation. Composes with PR #3037 (SENDER_IDS schema extension at sender-ID level) — this row works at the per-worktree metadata level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)