### PR TITLE
docs(backlog): B-0448 — Cloud Routines integration as 4th catch-43 defence layer

### DIFF
--- a/docs/backlog/P1/B-0448-cloud-routines-integration-4th-catch-43-defence-layer-2026-05-13.md
+++ b/docs/backlog/P1/B-0448-cloud-routines-integration-4th-catch-43-defence-layer-2026-05-13.md
@@ -1,0 +1,171 @@
+---
+id: B-0448
+priority: P1
+status: open
+title: "Cloud Routines integration — 4th catch-43 defence layer via Anthropic-hosted scheduled tasks + API + GitHub event triggers"
+type: feature
+origin: Aaron 2026-05-13 — "yes that sounds good about the backlog too" (authorizing the Cloud Routines row that Otto on the Desktop surface offered to file) + 2026-05-13 Claude Desktop research synthesis
+created: 2026-05-13
+last_updated: 2026-05-13
+depends_on: []
+composes_with: [B-0440, B-0441, B-0442, B-0444]
+tags: [routines, scheduled-tasks, claude-desktop, cloud-routines, catch-43, github-event-trigger, autonomous-loop, api-trigger]
+---
+
+# B-0448 — Cloud Routines integration as 4th catch-43 defence layer
+
+## Why now
+
+Today (2026-05-13) the autonomous-loop substrate established three layers of catch-43 defence
+([PR #3034](https://github.com/Lucent-Financial-Group/Zeta/pull/3034)):
+
+1. **CLI session cron** (`* * * * *` `<<autonomous-loop>>`) — cheap, dies on session exit
+2. **Desktop routine** (`0 */2 * * *`) — persistent on disk, runs while Desktop app open
+3. **`tools/routines/` repo canonical** — git-tracked source-of-truth
+
+Research surfaced a 4th layer Anthropic ships:
+**Cloud Routines** ([research preview, Claude Code 2026](https://nimbalyst.com/blog/claude-code-routines-practical-guide/)). Cloud Routines run on Anthropic's
+infrastructure with three trigger types:
+
+- **Scheduled** — hourly, daily, nightly, weekdays, weekly
+- **API** — HTTP POST to per-routine endpoint with bearer token
+- **GitHub events** — `pull_request.opened`, `push`, `issues`, `releases`, `check_runs`
+
+Usage caps: Pro 5/day, Max 15/day, Team/Enterprise 25/day.
+
+Aaron 2026-05-13 authorized this work in the same session that ran the research:
+*"yes that sounds good about the backlog too"*.
+
+## What
+
+1. **Extend `tools/routines/<id>/` canonical schema** to support Cloud Routines
+   alongside Desktop routines:
+   - `schedule.json` — already exists; Desktop scheduled-tasks MCP target
+   - **NEW**: `cloud-schedule.json` — Cloud Routine trigger config (one of:
+     scheduled cron, GitHub event filter, or API endpoint declaration; plus
+     repos + connectors)
+   - Both files are independent; a routine can have one, both, or neither.
+     A routine with both fires on Desktop *and* on Cloud — different cost /
+     durability characteristics.
+
+2. **Extend `tools/routines/install.ts`**:
+   - Currently calls the Desktop scheduled-tasks MCP `create_scheduled_task`
+   - Add: when `cloud-schedule.json` is present, print the corresponding
+     Cloud Routine registration steps (or invoke a Cloud Routines API if a
+     wrapping MCP exists at the time of implementation).
+   - Maintain idempotency + parseError surfacing already established for
+     `schedule.json`.
+
+3. **Register `autonomous-loop` as a Cloud Routine** alongside the existing
+   Desktop routine:
+   - Single cron trigger (e.g., daily 9am Pacific) — bounded by Pro/Max/Team
+     daily quota
+   - GitHub event trigger on `pull_request.opened` — fire a per-PR review tick
+     (cheap; uses GitHub event quota only, not the per-day cron quota)
+   - Total daily cost depends on PR volume; should stay within Pro 5/day
+     baseline given Zeta's current cadence
+
+4. **Document the 4-layer architecture** in `tools/routines/README.md`:
+   - Update the existing "CLI vs Desktop tick" sweet-spot table to include
+     Cloud Routines as a 3rd column
+   - Add cost-vs-durability vs trigger-flexibility tradeoff matrix
+   - Note: Desktop routine fires only while the app is open; Cloud Routine
+     fires regardless of any local state — that's the failure-mode-coverage
+     gap this layer closes.
+
+## Acceptance criteria
+
+- [ ] `tools/routines/autonomous-loop/cloud-schedule.json` authored with
+      sane trigger config (cron + at least one GitHub event filter)
+- [ ] `tools/routines/install.ts` extended (with tests if test suite has
+      landed by then — Copilot suggested test-coverage refactor; that
+      refactor already shipped in PR #3034 — exported pure functions accept
+      directory parameters)
+- [ ] Cloud Routine registered via the Cloud Routines API (or instructions
+      documented in README.md if no wrapping MCP exists at implementation
+      time)
+- [ ] `tools/routines/README.md` 4-layer table landed (replaces the
+      existing 2-row CLI-vs-Desktop table)
+- [ ] At least one Cloud Routine fire empirically observed — fresh session
+      cold-boots from bootstream, executes tick, commits substantively (or
+      no-ops substrate-honestly), and reports back
+
+## Why not P0
+
+This is additive (adds a 4th layer; doesn't replace existing 3). The factory
+is operational without it. P1 = work on within 2-3 rounds; P0 would require
+the absence of Cloud Routines to be blocking, which it isn't.
+
+## Why not P2
+
+Cloud Routines unlock genuinely new failure-mode coverage that the existing
+3 layers don't provide:
+
+- **App-closed Desktop window**: Desktop routine doesn't fire; Cloud does
+- **GitHub-event-triggered ticks**: no existing layer can do this; Cloud
+  routines on `pull_request.opened` would fire a review tick per PR without
+  any local cron infrastructure
+- **API-trigger ticks**: external monitoring could fire remediation ticks via
+  HTTP POST (e.g., on-call paged → tick fires)
+
+These are not nice-to-haves; they substantively improve the catch-43 surface.
+P1 captures the value-vs-effort balance correctly.
+
+## Composes with
+
+- [B-0440](docs/backlog/P*/B-0440-standing-by-failure-mode-detector-background-service-2026-05-13.md) — Standing-by failure mode detector — a Cloud Routine on GitHub events would catch this in real-time
+- [B-0441](docs/backlog/P*/B-0441-backlog-row-ready-to-grind-notifier-background-service-2026-05-13.md) — backlog-ready notifier — Cloud Routine could fire on `issues.opened` for new backlog rows
+- [B-0442](docs/backlog/P*/B-0442-missed-substrate-cascade-detector-background-service-2026-05-13.md) — missed substrate cascade detector — Cloud Routine triggered on `push` to main could detect
+- [B-0444 (P2 — bus claim envelope worktree field)](docs/backlog/P2/B-0444-bus-claim-envelope-worktree-field-multi-surface-disambiguation-2026-05-13.md) — multi-surface coordination substrate this depends on
+- [PR #3034](https://github.com/Lucent-Financial-Group/Zeta/pull/3034) (`tools/routines/` substrate — must be MERGED before implementation starts)
+- [docs/AUTONOMOUS-LOOP.md](docs/AUTONOMOUS-LOOP.md) (tick procedure that fires inside each Cloud Routine session)
+- [.claude/rules/tick-must-never-stop.md](.claude/rules/tick-must-never-stop.md) (catch-43 substrate — this row's design intent)
+
+## Research substrate
+
+Source list from 2026-05-13 Claude Desktop feature research:
+
+- [Schedule recurring tasks in Claude Code Desktop — Claude Code Docs](https://code.claude.com/docs/en/desktop-scheduled-tasks)
+- [Claude Code Routines: A Practical Guide (2026) — Nimbalyst](https://nimbalyst.com/blog/claude-code-routines-practical-guide/)
+- [Claude Code Scheduled Tasks: Complete Setup Guide (2026)](https://claudefa.st/blog/guide/development/scheduled-tasks)
+- [Anthropic adds repeatable routines to Claude Code — 9to5Mac](https://9to5mac.com/2026/04/14/anthropic-adds-repeatable-routines-feature-to-claude-code-heres-how-it-works/)
+- [Claude Code Desktop Redesign: Multi-Sessions + Routines (2026) — BuildFastWithAI](https://www.buildfastwithai.com/blogs/claude-code-desktop-redesign-2026)
+- [Claude Updates by Anthropic — May 2026 — Releasebot](https://releasebot.io/updates/anthropic/claude)
+
+## Pre-start checklist (per `.claude/rules/backlog-item-start-gate.md`)
+
+Before picking up this row to implement, complete prior-art search + dependency
+restructure:
+
+- [ ] Grep for existing Cloud Routines integration attempts:
+      `grep -ri "cloud routine\|cloud-routine\|cloud_routine" docs/ memory/ tools/`
+- [ ] Check claim coordinator for conflicting claims:
+      `bun tools/bus/claim.ts list 2>/dev/null | grep -i cloud-routine`
+- [ ] Verify dependency chain — PR #3034 (`tools/routines/` substrate) MUST
+      be merged on main before this work starts
+- [ ] Confirm Cloud Routines availability on the operating Anthropic plan
+      (research-preview status as of 2026-05-13; may have changed by
+      implementation time)
+- [ ] Determine the correct authentication path — bearer token? OAuth?
+      Existing scheduled-tasks MCP wraps it? (Unknown at filing time;
+      research-grade question for the implementing slice)
+- [ ] Update this row with a "Pre-start checklist" completed section
+      before any code/substrate work begins
+
+## Decomposition hint (per `.claude/rules/largest-mechanizable-backlog-wins.md`)
+
+Once started, suggested slice ordering:
+
+1. **B-0448.1** — Research the Cloud Routines authentication + registration API
+   surface (resolve the unknowns from the pre-start checklist)
+2. **B-0448.2** — Extend `tools/routines/<id>/` schema with `cloud-schedule.json`
+   (canonical format only; no installer changes yet)
+3. **B-0448.3** — Extend `tools/routines/install.ts` to detect + print
+   registration hints for `cloud-schedule.json`
+4. **B-0448.4** — Author `autonomous-loop/cloud-schedule.json` for the
+   factory's first Cloud Routine
+5. **B-0448.5** — Register the routine (via API/MCP); empirical first-fire
+   observation
+6. **B-0448.6** — Update README.md with 4-layer table
+7. **B-0448.7** — Memory file capturing the empirical-bootstrap learning
+   (similar to today's split-brain memory)


### PR DESCRIPTION
## Summary

Files [B-0448](docs/backlog/P1/B-0448-cloud-routines-integration-4th-catch-43-defence-layer-2026-05-13.md) — a P1 backlog row authorizing future implementation work to integrate Anthropic's Cloud Routines as a 4th catch-43 defence layer.

## Why

Today the autonomous-loop substrate established three layers of catch-43 defence ([PR #3034](https://github.com/Lucent-Financial-Group/Zeta/pull/3034)): CLI session cron, Desktop routine, repo canonical. The 2026-05-13 Claude Desktop feature research surfaced a 4th Anthropic ships — **Cloud Routines** (research preview) — that adds:

- Scheduled triggers on Anthropic's infrastructure (runs even when machine is off)
- **GitHub event triggers** (\`pull_request.opened\`, \`push\`, \`issues\`, \`releases\`, \`check_runs\`) — unlock per-PR review ticks without any local cron
- API triggers (HTTP POST + bearer token) for external monitoring integrations

Usage caps: Pro 5/day, Max 15/day, Team/Enterprise 25/day.

Aaron 2026-05-13 explicitly authorized this row: *"yes that sounds good about the backlog too"* after the research synthesis.

## Composition

B-0448 builds on PR #3034's \`tools/routines/\` two-layer architecture. The Cloud Routines integration is **additive**: \`tools/routines/<id>/cloud-schedule.json\` lives alongside \`schedule.json\`; a routine can have either, both, or neither.

## Test plan

This PR is a docs-only backlog row — no code changes. The implementation slice (when picked up) will:

- [ ] Complete the pre-start checklist documented in the row
- [ ] Resolve research-grade unknowns (auth path, MCP wrapping availability)
- [ ] Implement decomposed slices B-0448.1 through B-0448.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)