### PR TITLE
feat(bg/missed-substrate): B-0442 slice 3 — real branch-vs-squash comparator

### DIFF
--- a/docs/backlog/P1/B-0442-missed-substrate-cascade-detector-background-service-2026-05-13.md
+++ b/docs/backlog/P1/B-0442-missed-substrate-cascade-detector-background-service-2026-05-13.md
@@ -54,19 +54,36 @@ a branch, the service catches it BEFORE branch deletion.
 
 ## Acceptance criteria
 
-- [ ] Background service `tools/bg/missed-substrate-detector.ts` exists
-- [ ] Runs under existing launchd / cron infrastructure
-- [ ] On PR merge events (poll or webhook), checks if branch HEAD ==
-      merge commit content
-- [ ] When branch HEAD has commits the merged PR didn't include,
+- [x] Background service `tools/bg/missed-substrate-detector.ts` exists (slices 1+2+4 — earlier)
+- [ ] Runs under existing launchd / cron infrastructure (slice 6 — pending)
+- [x] On PR merge events (poll or webhook), checks if branch HEAD ==
+      merge commit content (slice 3 — landed 2026-05-13 via `gh pr view --json headRefOid`
+      + `git log <headRefOid>..origin/<branch>`)
+- [x] When branch HEAD has commits the merged PR didn't include,
       publishes cascade-detected message via bus (B-0400):
       `{ topic: "missed-substrate-cascade", to: <agent>,
          payload: { branchName, missingCommits, recommendedAction:
-         "open-recovery-PR" } }`
+         "open-recovery-PR" } }` (slice 4 — earlier)
 - [ ] Optionally auto-opens recovery PR with the missing commits
-      (gated by configuration)
-- [ ] Tests cover the detection heuristics (DST-replayable)
-- [ ] Documented in `docs/AUTONOMOUS-LOOP.md`
+      (gated by configuration) (slice 5 — pending; subscriber-agent layer)
+- [x] Tests cover the detection heuristics (DST-replayable) — 24 tests cover slice 4 wiring + slice 3 detector (drift / no-drift / branch-deleted / branch-rebased / gh-error / git-error) + urgency classification
+- [ ] Documented in `docs/AUTONOMOUS-LOOP.md` (slice 6 — pending)
+
+## Slice 3 implementation summary (2026-05-13)
+
+`realCascadeDetector` is a pure function composed with `CascadeDetectorAdapters`:
+
+- `fetchPRRefs(prNumber)` — calls `gh pr view N --json headRefOid,mergeCommit`
+- `compareBranchToMerged(branchName, headRefOid)` — runs:
+  1. `git fetch --quiet origin <branchName>` (branch-deleted → null)
+  2. `git merge-base --is-ancestor <headRefOid> origin/<branchName>` (rebased → null)
+  3. `git log <headRefOid>..origin/<branchName> --format=%H` (the drift commits)
+
+Urgency classified via `classifyCascadeUrgency(commitCount, mergedAtIso, nowMs)`:
+fresh (<1hr) or 4+ commits → high; 2-3 commits or <24hr → medium; else low.
+
+Cap on reported commits: `MAX_REPORTED_MISSING_COMMITS = 50` prevents false-positive
+floods when the branch is being reused for follow-up work (not a cascade).
 
 ## Design sketch
 

--- a/tools/bg/README.md
+++ b/tools/bg/README.md
@@ -30,7 +30,7 @@ so future readers don't overclaim.
 |---------|------|--------------|------------------|-----------|
 | Standing-by detector | `standing-by-detector.ts` | 1+2+3+4 live | commit-history (HEAD) + PR-activity (repo) via `gh`/`git` | `infinite-backlog-nudge` |
 | Backlog-ready notifier | `backlog-ready-notifier.ts` | 1+2+4 live | backlog-row scan (status + deps satisfied) | `work-assignment` |
-| Missed-substrate detector | `missed-substrate-detector.ts` | 1+2+4 live (slice 3 = STUB) | merged-PR fetch via `gh`; cascade detector is **STUB** — slice 3 plugs in real branch-vs-squash compare | `missed-substrate-cascade` |
+| Missed-substrate detector | `missed-substrate-detector.ts` | 1+2+3+4 live | merged-PR fetch via `gh`; real branch-vs-squash compare via `gh pr view --json headRefOid` + `git log <headRefOid>..origin/<branch>` (slice 3 landed 2026-05-13) | `missed-substrate-cascade` |
 
 Per-service slice ordering (each service decomposes into 6 slices):
 
@@ -86,9 +86,10 @@ bun tools/bg/backlog-ready-notifier.ts --once --to vera
 
 ## What's still pending
 
-- **B-0442 slice 3** — Real branch-vs-squash comparator for missed-substrate-detector (slice 3 is a stub today; "slice N of B-NNNN" is shorthand, not a per-row backlog file)
 - **Slice 5 for all three** — subscriber agents that react to bus envelopes (e.g., auto-claim a `work-assignment`)
 - **Slice 6 for all three** — launchd / cron registration + integration tests
+
+(B-0442 slice 3 landed 2026-05-13: real `headRefOid` vs current-branch-HEAD compare with rebase-guard via `git merge-base --is-ancestor`. The cascade detector now operationally detects the Otto-section-missed-PR-#2980-by-3-min failure class when the branch still exists on origin.)
 
 When all of those land, the architectural claim "foreground loop is
 optional" approaches operational truth. Today the claim is

--- a/tools/bg/missed-substrate-detector.test.ts
+++ b/tools/bg/missed-substrate-detector.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, test } from "bun:test";
 import {
+  classifyCascadeUrgency,
   DEFAULT_CONFIG,
+  MAX_REPORTED_MISSING_COMMITS,
   parseArgs,
   parsePositiveMinutes,
   pollOnce,
+  realCascadeDetector,
   type Adapters,
+  type BranchCompareResult,
+  type CascadeDetectorAdapters,
   type CascadeFinding,
   type FetchResult,
   type MergedPR,
+  type PRRefsResult,
 } from "./missed-substrate-detector";
 import type { AgentId, MessageEnvelope, SenderAgentId } from "../bus/types";
 
@@ -50,6 +56,20 @@ function adapters(opts: {
   };
 }
 
+function cascadeAdapters(opts: {
+  prRefs?: Partial<Record<number, PRRefsResult>>;
+  branchCompares?: Partial<Record<string, BranchCompareResult>>;
+  nowIso?: string;
+}): CascadeDetectorAdapters {
+  return {
+    now: () => new Date(opts.nowIso ?? "2026-05-13T18:00:00Z"),
+    fetchPRRefs: (prNumber: number) =>
+      opts.prRefs?.[prNumber] ?? { status: "error", reason: "no fake configured" },
+    compareBranchToMerged: (branchName: string) =>
+      opts.branchCompares?.[branchName] ?? { status: "error", reason: "no fake configured" },
+  };
+}
+
 describe("missed-substrate-detector slice 4 (bus publish wiring; slice-3 detect is stub)", () => {
   test("default config", () => {
     expect(DEFAULT_CONFIG.pollIntervalMin).toBe(5);
@@ -84,7 +104,6 @@ describe("missed-substrate-detector slice 4 (bus publish wiring; slice-3 detect 
       expect(result.candidatesScanned).toBe(2);
       expect(result.cascadesDetected).toBe(0);
       expect(result.note).toContain("no cascades detected");
-      expect(result.note).toContain("slice 3 plugs in real compare logic");
     });
 
     test("gh-error surfaces explicitly (does NOT silently treat as zero)", () => {
@@ -174,6 +193,120 @@ describe("missed-substrate-detector slice 4 (bus publish wiring; slice-3 detect 
       expect(result.cascadesDetected).toBe(1);
       expect(result.publishedEnvelopeIds).toHaveLength(0);
       expect(result.note).toContain("publish failed");
+    });
+  });
+
+  describe("realCascadeDetector (slice 3 — branch-vs-squash comparator)", () => {
+    const pr2980: MergedPR = {
+      number: 2980,
+      headRefName: "feat/launch-thread",
+      mergedAt: "2026-05-13T17:55:00Z",
+    };
+
+    test("detects cascade — branch has post-squash drift commits", () => {
+      const finding = realCascadeDetector(pr2980, cascadeAdapters({
+        prRefs: { 2980: { status: "ok", headRefOid: "aaaaaaa" } },
+        branchCompares: {
+          "feat/launch-thread": { status: "ok", missingCommits: ["bbb111", "ccc222"] },
+        },
+        nowIso: "2026-05-13T18:00:00Z",
+      }));
+      expect(finding).not.toBeNull();
+      expect(finding!.prNumber).toBe(2980);
+      expect(finding!.branchName).toBe("feat/launch-thread");
+      expect(finding!.missingCommits).toEqual(["bbb111", "ccc222"]);
+      expect(finding!.urgency).toBe("high"); // fresh (<1hr) → high
+    });
+
+    test("no cascade when missingCommits is empty (branch matches squash exactly)", () => {
+      const finding = realCascadeDetector(pr2980, cascadeAdapters({
+        prRefs: { 2980: { status: "ok", headRefOid: "aaaaaaa" } },
+        branchCompares: {
+          "feat/launch-thread": { status: "ok", missingCommits: [] },
+        },
+      }));
+      expect(finding).toBeNull();
+    });
+
+    test("returns null when branch was deleted post-merge (unrecoverable)", () => {
+      const finding = realCascadeDetector(pr2980, cascadeAdapters({
+        prRefs: { 2980: { status: "ok", headRefOid: "aaaaaaa" } },
+        branchCompares: {
+          "feat/launch-thread": { status: "branch-deleted", reason: "deleted" },
+        },
+      }));
+      expect(finding).toBeNull();
+    });
+
+    test("returns null when branch was rebased (too complex to auto-diagnose)", () => {
+      const finding = realCascadeDetector(pr2980, cascadeAdapters({
+        prRefs: { 2980: { status: "ok", headRefOid: "aaaaaaa" } },
+        branchCompares: {
+          "feat/launch-thread": { status: "branch-rebased", reason: "not ancestor" },
+        },
+      }));
+      expect(finding).toBeNull();
+    });
+
+    test("returns null when gh has no merge commit (closed-not-merged)", () => {
+      const finding = realCascadeDetector(pr2980, cascadeAdapters({
+        prRefs: { 2980: { status: "no-merge", reason: "no mergeCommit" } },
+        branchCompares: {
+          "feat/launch-thread": { status: "ok", missingCommits: ["should-not-reach"] },
+        },
+      }));
+      expect(finding).toBeNull();
+    });
+
+    test("returns null when gh errors (cannot diagnose without refs)", () => {
+      const finding = realCascadeDetector(pr2980, cascadeAdapters({
+        prRefs: { 2980: { status: "error", reason: "HTTP 503" } },
+      }));
+      expect(finding).toBeNull();
+    });
+
+    test("returns null when git compare errors", () => {
+      const finding = realCascadeDetector(pr2980, cascadeAdapters({
+        prRefs: { 2980: { status: "ok", headRefOid: "aaaaaaa" } },
+        branchCompares: {
+          "feat/launch-thread": { status: "error", reason: "git fatal" },
+        },
+      }));
+      expect(finding).toBeNull();
+    });
+  });
+
+  describe("classifyCascadeUrgency", () => {
+    const nowMs = new Date("2026-05-13T18:00:00Z").getTime();
+
+    test("high — fresh drift (<1hr) with any commits", () => {
+      expect(classifyCascadeUrgency(1, "2026-05-13T17:58:00Z", nowMs)).toBe("high");
+      expect(classifyCascadeUrgency(1, "2026-05-13T17:05:00Z", nowMs)).toBe("high");
+    });
+
+    test("high — 4+ missing commits regardless of age", () => {
+      expect(classifyCascadeUrgency(4, "2026-05-10T10:00:00Z", nowMs)).toBe("high");
+      expect(classifyCascadeUrgency(10, "2026-05-01T00:00:00Z", nowMs)).toBe("high");
+    });
+
+    test("medium — 2-3 missing commits, age 1hr-24hr", () => {
+      expect(classifyCascadeUrgency(2, "2026-05-13T10:00:00Z", nowMs)).toBe("medium");
+      expect(classifyCascadeUrgency(3, "2026-05-13T05:00:00Z", nowMs)).toBe("medium");
+    });
+
+    test("medium — single commit, age <24hr", () => {
+      expect(classifyCascadeUrgency(1, "2026-05-13T05:00:00Z", nowMs)).toBe("medium");
+    });
+
+    test("low — single commit, age >24hr (might be intentional WIP)", () => {
+      expect(classifyCascadeUrgency(1, "2026-05-11T05:00:00Z", nowMs)).toBe("low");
+    });
+  });
+
+  describe("slice 3 reporting bounds", () => {
+    test("MAX_REPORTED_MISSING_COMMITS is a sane cap", () => {
+      expect(MAX_REPORTED_MISSING_COMMITS).toBeGreaterThan(10);
+      expect(MAX_REPORTED_MISSING_COMMITS).toBeLessThan(500);
     });
   });
 

--- a/tools/bg/missed-substrate-detector.ts
+++ b/tools/bg/missed-substrate-detector.ts
@@ -1,15 +1,23 @@
-// missed-substrate-detector.ts — B-0442 slice 4: bus publish on cascade detection
+// missed-substrate-detector.ts — B-0442 slice 3+4: real branch-vs-squash comparator
 //
 // Background service that detects branch-vs-merged-PR drift: commits landing
-// on a feature branch AFTER its parent PR squash-merged. Slice 4 closes the
-// drift-prevention reactive loop: fetch recent merged PRs, compare branch
-// HEAD against squash content (NOTE: slice 3 implements the actual compare;
-// slice 4 publishes envelopes for each detected cascade).
+// on a feature branch AFTER its parent PR squash-merged. Slice 4 shipped the
+// bus-publish wiring with a stub comparator; slice 3 (this file, 2026-05-13)
+// plugs in the real branch-vs-squash compare logic via `realCascadeDetector`.
 //
-// Slice 4 ships the bus-publish wiring with a stub comparator that ALWAYS
-// reports "no cascade detected" — slice 3 will plug in the real branch-vs-
-// squash compare logic. The bus envelope schema + flags + tests are
-// production-ready; the comparator stays no-op until slice 3.
+// Detection algorithm (slice 3):
+//   1. For each merged PR, fetch `headRefOid` from gh — the branch HEAD SHA
+//      *at merge time* (the SHA that was squashed).
+//   2. Fetch `origin/<branchName>` to get the branch's current state.
+//   3. If branch was deleted post-merge → return null (unrecoverable; the
+//      window for detection closed at branch deletion).
+//   4. Guard against rebases: if `headRefOid` is not an ancestor of the
+//      current branch HEAD, return null (situation too complex to
+//      auto-diagnose; would produce false-positive flood).
+//   5. Run `git log <headRefOid>..origin/<branchName>` — these are the
+//      commits added to the branch AFTER squash. If non-empty, cascade
+//      detected; build CascadeFinding with urgency classified by
+//      commit-count + merge-age.
 //
 // Run: bun tools/bg/missed-substrate-detector.ts [--once] [--poll-min N] [--lookback-min N] [--fetch-limit N] [--no-publish] [--agent NAME] [--to NAME]
 // Compose with: B-0442 + B-0400 (bus) + B-0440 / B-0441 (companion services).
@@ -70,9 +78,10 @@ export type Adapters = {
   now: () => Date;
   fetchRecentMergedPRs: (lookbackMin: number, fetchLimit: number) => FetchResult;
   /**
-   * Detect cascades on a single merged PR. Slice 3 replaces this stub with
-   * real branch-HEAD vs squash-content compare logic. Slice 4 keeps it as
-   * an injectable stub for testing the bus-publish path.
+   * Detect cascades on a single merged PR. Slice 4 keeps this as an
+   * injectable adapter for testing the bus-publish path; slice 3 wires
+   * REAL_ADAPTERS to `realCascadeDetector` composed with real gh + git
+   * sub-adapters (see `REAL_CASCADE_SUB_ADAPTERS`).
    */
   detectCascade: (pr: MergedPR) => CascadeFinding | null;
   publishCascade: (
@@ -81,6 +90,94 @@ export type Adapters = {
     finding: CascadeFinding,
   ) => MessageEnvelope;
 };
+
+/**
+ * Slice 3: result of fetching PR refs from gh. `headRefOid` is the branch
+ * HEAD SHA at merge time — the SHA that was squashed.
+ */
+export type PRRefsResult =
+  | { status: "ok"; headRefOid: string }
+  | { status: "no-merge"; reason: string }
+  | { status: "error"; reason: string };
+
+/**
+ * Slice 3: result of comparing the branch's current state against its
+ * state at merge time. `missingCommits` are commits added to the branch
+ * AFTER the squash — exactly the cascade signal.
+ */
+export type BranchCompareResult =
+  | { status: "ok"; missingCommits: string[] }
+  | { status: "branch-deleted"; reason: string }
+  | { status: "branch-rebased"; reason: string }
+  | { status: "error"; reason: string };
+
+/**
+ * Slice 3 sub-adapters for the real cascade detector. Decoupled so tests
+ * inject deterministic gh + git responses without needing a real repo.
+ */
+export type CascadeDetectorAdapters = {
+  fetchPRRefs: (prNumber: number) => PRRefsResult;
+  compareBranchToMerged: (
+    branchName: string,
+    headRefOid: string,
+  ) => BranchCompareResult;
+  now: () => Date;
+};
+
+/**
+ * Classify cascade urgency by commit count + merge-age. The Otto-section-
+ * missed-PR-#2980 case was 3 minutes old with 1 missing commit ⇒ "high".
+ */
+export function classifyCascadeUrgency(
+  missingCommitCount: number,
+  mergedAtIso: string,
+  nowMs: number,
+): "low" | "medium" | "high" {
+  const mergedAtMs = new Date(mergedAtIso).getTime();
+  const ageHours = (nowMs - mergedAtMs) / (1000 * 60 * 60);
+  if (missingCommitCount >= 4) return "high"; // multiple-commit drift = serious
+  if (ageHours < 1) return "high"; // fresh drift = likely about to be lost
+  if (missingCommitCount >= 2) return "medium";
+  if (ageHours < 24) return "medium"; // recent single-commit drift
+  return "low";
+}
+
+/**
+ * Slice 3: real branch-vs-squash cascade detector. Pure function composed
+ * with sub-adapters for testability. Returns null when no drift detected,
+ * when branch was deleted, when branch was rebased (too complex to
+ * auto-diagnose), or when gh/git errors prevent diagnosis.
+ */
+export function realCascadeDetector(
+  pr: MergedPR,
+  adapters: CascadeDetectorAdapters,
+): CascadeFinding | null {
+  const refs = adapters.fetchPRRefs(pr.number);
+  if (refs.status !== "ok") return null;
+
+  const compare = adapters.compareBranchToMerged(pr.headRefName, refs.headRefOid);
+  if (compare.status !== "ok") return null;
+  if (compare.missingCommits.length === 0) return null;
+
+  return {
+    prNumber: pr.number,
+    branchName: pr.headRefName,
+    missingCommits: compare.missingCommits,
+    urgency: classifyCascadeUrgency(
+      compare.missingCommits.length,
+      pr.mergedAt,
+      adapters.now().getTime(),
+    ),
+  };
+}
+
+/**
+ * Slice 3: maximum number of post-squash commits to surface in a single
+ * envelope. Caps the false-positive flood case where headRefOid is an
+ * ancestor of branchHead but the gap is unexpectedly large (e.g., the
+ * branch is being reused for follow-up work — not a cascade).
+ */
+export const MAX_REPORTED_MISSING_COMMITS = 50;
 
 const REAL_ADAPTERS: Adapters = {
   now: () => new Date(),
@@ -121,8 +218,9 @@ const REAL_ADAPTERS: Adapters = {
       return { status: "gh-error", reason: `JSON parse failed: ${e instanceof Error ? e.message : String(e)}` };
     }
   },
-  // Slice 3 will replace this stub with real branch-vs-squash compare.
-  detectCascade: (_pr: MergedPR) => null,
+  // Slice 3 (2026-05-13): real branch-vs-squash compare via gh + git.
+  detectCascade: (pr: MergedPR) =>
+    realCascadeDetector(pr, REAL_CASCADE_SUB_ADAPTERS),
   publishCascade: (from, to, finding) =>
     publish(from, to, {
       topic: "missed-substrate-cascade",
@@ -137,10 +235,112 @@ const REAL_ADAPTERS: Adapters = {
 };
 
 /**
+ * Slice 3 (2026-05-13): real production sub-adapters for the cascade
+ * detector. `fetchPRRefs` calls `gh pr view --json headRefOid`;
+ * `compareBranchToMerged` fetches the branch from origin and runs
+ * `git log <headRefOid>..origin/<branchName>` to find post-squash drift.
+ */
+export const REAL_CASCADE_SUB_ADAPTERS: CascadeDetectorAdapters = {
+  now: () => new Date(),
+  fetchPRRefs: (prNumber: number): PRRefsResult => {
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- gh invoked as explicit args array; no shell, no injection risk.
+    const result = spawnSync(
+      "gh",
+      ["pr", "view", String(prNumber), "--json", "headRefOid,mergeCommit"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    if (result.status !== 0) {
+      return {
+        status: "error",
+        reason: `gh pr view ${prNumber} exited ${result.status}; stderr: ${(result.stderr ?? "").toString().slice(0, 200)}`,
+      };
+    }
+    if (!result.stdout) {
+      return { status: "error", reason: "gh pr view produced empty stdout" };
+    }
+    try {
+      const parsed = JSON.parse(result.stdout);
+      const headRefOid = parsed?.headRefOid;
+      const mergeCommit = parsed?.mergeCommit;
+      if (typeof headRefOid !== "string" || headRefOid.length === 0) {
+        return { status: "no-merge", reason: "PR has no headRefOid" };
+      }
+      if (!mergeCommit || typeof mergeCommit.oid !== "string") {
+        return { status: "no-merge", reason: "PR has no mergeCommit (closed-not-merged?)" };
+      }
+      return { status: "ok", headRefOid };
+    } catch (e) {
+      return { status: "error", reason: `JSON parse failed: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  },
+  compareBranchToMerged: (branchName: string, headRefOid: string): BranchCompareResult => {
+    // Validate inputs to prevent shell-injection via crafted refs (gh response is
+    // trusted but defensive validation matches our usual posture).
+    if (!/^[A-Za-z0-9._\/\-]+$/.test(branchName)) {
+      return { status: "error", reason: `invalid branchName: ${branchName.slice(0, 40)}` };
+    }
+    if (!/^[0-9a-f]{7,40}$/.test(headRefOid)) {
+      return { status: "error", reason: `invalid headRefOid: ${headRefOid.slice(0, 40)}` };
+    }
+
+    // Fetch the latest branch state. If the branch was deleted post-merge,
+    // git fetch reports "couldn't find remote ref" — surface as branch-deleted.
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array; refs validated above.
+    const fetchResult = spawnSync(
+      "git",
+      ["fetch", "--quiet", "origin", branchName],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    if (fetchResult.status !== 0) {
+      const stderr = (fetchResult.stderr ?? "").toString();
+      if (stderr.includes("couldn't find remote ref") || stderr.includes("not found")) {
+        return { status: "branch-deleted", reason: "branch not on origin (deleted post-merge)" };
+      }
+      return { status: "error", reason: `git fetch failed: ${stderr.slice(0, 200)}` };
+    }
+
+    // Guard against rebases: if headRefOid is NOT an ancestor of the current
+    // branch HEAD, the branch was rewritten and we cannot trust a simple
+    // log-range. Surface branch-rebased; the situation needs manual review.
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array.
+    const ancestorResult = spawnSync(
+      "git",
+      ["merge-base", "--is-ancestor", headRefOid, `origin/${branchName}`],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    if (ancestorResult.status === 1) {
+      return { status: "branch-rebased", reason: `${headRefOid.slice(0, 8)} is not ancestor of origin/${branchName} (rebase or force-push detected)` };
+    }
+    if (ancestorResult.status !== 0) {
+      return { status: "error", reason: `git merge-base failed: ${(ancestorResult.stderr ?? "").toString().slice(0, 200)}` };
+    }
+
+    // Now list commits on origin/<branch> not reachable from headRefOid —
+    // these are the post-squash drift commits (the cascade signal).
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array.
+    const logResult = spawnSync(
+      "git",
+      ["log", `${headRefOid}..origin/${branchName}`, "--format=%H"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    if (logResult.status !== 0) {
+      return { status: "error", reason: `git log failed: ${(logResult.stderr ?? "").toString().slice(0, 200)}` };
+    }
+    const allMissing = (logResult.stdout ?? "")
+      .trim()
+      .split("\n")
+      .filter(line => line.length > 0);
+    const missingCommits = allMissing.slice(0, MAX_REPORTED_MISSING_COMMITS);
+    return { status: "ok", missingCommits };
+  },
+};
+
+/**
  * Single poll iteration. Fetches merged PRs, runs the cascade detector
  * on each, and publishes a missed-substrate-cascade envelope per finding
- * (unless noPublish). Slice 4's detectCascade is a stub (returns null
- * for all PRs); slice 3 plugs in real logic.
+ * (unless noPublish). Slice 3 (2026-05-13) wired the real detector;
+ * REAL_ADAPTERS.detectCascade now calls `realCascadeDetector` with real
+ * gh + git sub-adapters.
  */
 export function pollOnce(
   config: DetectorConfig,
@@ -203,7 +403,7 @@ export function pollOnce(
       ? `${findings.length} cascade(s) detected in ${fetch.prs.length} merged PR(s)${publishSuffix}${truncatedSuffix}`
       : fetch.prs.length === 0
       ? `no merged PRs in last ${config.lookbackMin}min lookback window`
-      : `${fetch.prs.length} merged PR(s) in last ${config.lookbackMin}min; no cascades detected (slice 3 plugs in real compare logic)${truncatedSuffix}`,
+      : `${fetch.prs.length} merged PR(s) in last ${config.lookbackMin}min; no cascades detected${truncatedSuffix}`,
   };
 }
 

--- a/tools/bg/missed-substrate-detector.ts
+++ b/tools/bg/missed-substrate-detector.ts
@@ -274,9 +274,16 @@ export const REAL_CASCADE_SUB_ADAPTERS: CascadeDetectorAdapters = {
     }
   },
   compareBranchToMerged: (branchName: string, headRefOid: string): BranchCompareResult => {
-    // Validate inputs to prevent shell-injection via crafted refs (gh response is
-    // trusted but defensive validation matches our usual posture).
-    if (!/^[A-Za-z0-9._\/\-]+$/.test(branchName)) {
+    // Validate inputs to prevent shell-injection via crafted refs (gh response
+    // is trusted but defensive validation matches our usual posture). Allow-list
+    // covers the git-check-ref-format character set: alphanumerics plus
+    // `._/+@=-`. These are git-legal AND shell-safe (they cannot break out of
+    // the explicit args-array spawnSync call). Characters git itself forbids
+    // (space, `~`, `^`, `:`, `?`, `*`, `[`, `\`) and characters that could
+    // enable injection are excluded. Codex P1 (2026-05-13): widened from the
+    // initial `[A-Za-z0-9._/-]` regex which incorrectly rejected valid refs
+    // containing `@`, `+`, or `=`.
+    if (!/^[A-Za-z0-9._/+@=\-]+$/.test(branchName)) {
       return { status: "error", reason: `invalid branchName: ${branchName.slice(0, 40)}` };
     }
     if (!/^[0-9a-f]{7,40}$/.test(headRefOid)) {
@@ -293,7 +300,13 @@ export const REAL_CASCADE_SUB_ADAPTERS: CascadeDetectorAdapters = {
     );
     if (fetchResult.status !== 0) {
       const stderr = (fetchResult.stderr ?? "").toString();
-      if (stderr.includes("couldn't find remote ref") || stderr.includes("not found")) {
+      // Codex P1 (2026-05-13): only the specific "couldn't find remote ref"
+      // phrase reliably indicates a deleted-branch. The broader "not found"
+      // check matched auth / repository-level failures (e.g.,
+      // "repository ... not found") and miscategorised them as branch
+      // deletion — silently dropping cascade-detection rather than
+      // surfacing the real error.
+      if (stderr.includes("couldn't find remote ref")) {
         return { status: "branch-deleted", reason: "branch not on origin (deleted post-merge)" };
       }
       return { status: "error", reason: `git fetch failed: ${stderr.slice(0, 200)}` };


### PR DESCRIPTION
## Summary

Closes B-0442 slice 3: real branch-vs-squash comparator. Replaces the slice-4 stub `detectCascade: () => null` with a real comparator that detects the Otto-section-missed-PR-#2980-by-3-min failure class — commits landing on a feature branch AFTER its parent PR squash-merged.

## Algorithm

1. `gh pr view N --json headRefOid,mergeCommit` — fetches the branch HEAD SHA at merge time (the SHA that was squashed)
2. `git fetch --quiet origin <branchName>` — surfaces branch-deleted state (post-merge auto-delete window closed → null; unrecoverable)
3. `git merge-base --is-ancestor <headRefOid> origin/<branchName>` — guards against rebases / force-pushes that would produce a false-positive flood
4. `git log <headRefOid>..origin/<branchName>` — the post-squash drift commits

## Why this design

The cleanest signal for post-squash drift is `headRefOid`: gh returns the branch HEAD SHA at merge time, so anything on the branch beyond that SHA is by definition post-squash drift. Trees and merge-commit SHAs are noisier (other PRs land on main in between); `headRefOid` isolates the per-branch comparison.

Rebase-guard via `--is-ancestor` is important: if someone force-pushes the branch after merge (rare but possible), `headRefOid` is no longer reachable and `git log` would return ALL the new branch's commits → false-positive flood. We detect this case and return null with `branch-rebased` status; the situation needs manual review.

## Architecture

Composes with the existing slice-4 adapter-injection pattern. Tests inject the high-level `Adapters.detectCascade` adapter for bus-publish-path testing; slice 3 adds lower-level `CascadeDetectorAdapters` (`fetchPRRefs` + `compareBranchToMerged` + `now`) so the real-detector logic is also unit-testable without a real repo.

New exported surfaces:
- `realCascadeDetector(pr, adapters)` — pure function
- `REAL_CASCADE_SUB_ADAPTERS` — production gh + git wiring
- `classifyCascadeUrgency(count, mergedAtIso, nowMs)` — urgency classifier
- `MAX_REPORTED_MISSING_COMMITS = 50` — cap on reported commits

`REAL_ADAPTERS.detectCascade` now calls `realCascadeDetector(pr, REAL_CASCADE_SUB_ADAPTERS)`.

## Test plan

- [x] 24/24 pass on `tools/bg/missed-substrate-detector.test.ts` — 7 new tests for `realCascadeDetector` covering drift / no-drift / branch-deleted / branch-rebased / no-merge / gh-error / git-error
- [x] 5 new tests for `classifyCascadeUrgency` across all urgency-band boundaries
- [x] 1 sanity test for `MAX_REPORTED_MISSING_COMMITS`
- [x] 73/73 pass across `tools/bg/` suite
- [x] `bun --bun tsc --noEmit` clean

## What's still pending (per `tools/bg/README.md`)

- Slice 5 for all three bg-services — subscriber agents that react to bus envelopes (closes the foreground-optional gap)
- Slice 6 for all three — launchd / cron registration + integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)