### PR TITLE
docs(rules): Rule 0 — mark the 3 legacy hygiene .sh violations as cleared

### DIFF
--- a/.claude/rules/rule-0-no-sh-files.md
+++ b/.claude/rules/rule-0-no-sh-files.md
@@ -18,9 +18,21 @@ wrappers, harness hooks, factory cadences — all `.ts`, run via `bun`.
 testing applies; reproducibility from seed; Bun runtime hosts TS
 factory tools). Bash is forgotten and non-deterministic.
 
-**Legacy violations**: `tools/hygiene/audit-lost-files.sh`,
-`audit-trajectories.sh`, `audit-backlog-items.sh` were authored in
-violation of this rule and owe a TS-port follow-up.
+**Legacy violations cleared 2026-05-13**: the three previously-tracked
+`tools/hygiene/audit-*.sh` violations (`audit-lost-files.sh`,
+`audit-trajectories.sh`, `audit-backlog-items.sh`) have all been ported
+to `.ts`. The current `tools/hygiene/` directory is entirely
+Rule-0-compliant.
+
+**Remaining audit question (out of scope for Rule 0 itself)**: the Lior
+agent's `.gemini/service/install-lior-service.sh` +
+`.gemini/service/lior-loop.sh` live outside `tools/setup/`. They are
+install-graph by intent (Lior's launchd-equivalent service bootstrap)
+but the rule's "only `tools/setup/`" phrasing technically excludes
+them. Resolution is a separate design question — either expand the
+rule's allowed-path list to include agent-specific install-graph
+locations or port / relocate them under `tools/setup/`. Either way,
+NOT a "legacy violation" in the same sense as the cleared three.
 
 **Rule 0** — named as the filter every authoring impulse must pass
 BEFORE any other factory discipline. Composes with

--- a/docs/hygiene-history/ticks/2026/05/13/2249Z.md
+++ b/docs/hygiene-history/ticks/2026/05/13/2249Z.md
@@ -1,0 +1,80 @@
+---
+tick: 2026-05-13T22:49Z
+agent: otto-cli
+session: cron-resumption
+pr: 3048
+---
+
+# Tick 2249Z — Rule 0 staleness cleared; #3046 + previous PRs all merged
+
+## Refresh
+
+- CronList: live (`9ac08520`, `* * * * *`, sentinel `<<autonomous-loop>>`).
+- Since previous tick, PR #3046 (Otto-Desktop's B-0449 design pass) MERGED → `8077181`.
+- Main tip: `8077181 docs(backlog): B-0449 — bg-services slice 5 subscriber-agent design pass (#3046)`.
+- Open PRs: #3047 (slice-rows, wait-ci), #3048 (this tick's Rule 0 update, wait-ci).
+
+## Named-dependency check
+
+Both open PRs auto-merge armed; both `wait-ci`; threads clear. Real-
+dependency-wait — not Holding.
+
+## Speculative work picked
+
+Per never-be-idle: while #3047 CI was running, audited `.claude/rules/`
+for staleness related to this session's substrate-hygiene sweep. Found
+that `rule-0-no-sh-files.md` still listed three `tools/hygiene/audit-*.sh`
+files as "Legacy violations" owing a TS-port follow-up. All three have
+since been ported and the `.sh` files removed:
+
+| Was | Now |
+|---|---|
+| `tools/hygiene/audit-lost-files.sh` | `audit-lost-files.ts` ✓ |
+| `tools/hygiene/audit-trajectories.sh` | `audit-trajectories.ts` ✓ |
+| `tools/hygiene/audit-backlog-items.sh` | `audit-backlog-items.ts` ✓ |
+
+The "Legacy violations" callout was operationally stale documentation
+— exactly the failure-mode class the rest of this session's sweep
+addresses.
+
+## Landed concretely
+
+| Artifact | Where | What |
+|---|---|---|
+| `.claude/rules/rule-0-no-sh-files.md` | PR #3048 `c941098` | "Legacy violations" → "Legacy violations cleared 2026-05-13" + surface the `.gemini/service/*.sh` design question as separate scope |
+
+## Side observation surfaced
+
+`.gemini/service/install-lior-service.sh` + `.gemini/service/lior-loop.sh`
+live outside `tools/setup/` but are install-graph by intent (Lior's
+launchd-equivalent service bootstrap). Rule 0's "only `tools/setup/`"
+phrasing technically excludes them. Surfaced as a NOTE in the updated
+rule body rather than silently leaving the ambiguity. Resolution is a
+separate design question (expand allowed-path list vs port/relocate).
+
+## Verify
+
+- `find . -name "*.sh" -not -path "./tools/setup/*"` shows only:
+  - vendored Lean/Mathlib/Batteries packages (not ours)
+  - `references/upstreams/*` (vendored upstreams, not ours)
+  - `.gemini/service/*.sh` (surfaced as the remaining design question)
+- PR #3047 `wait-ci`, threads clear, auto-merge armed
+- PR #3048 `wait-ci`, threads clear, auto-merge armed
+
+## CronList
+
+- Live (`9ac08520`, `* * * * *`).
+
+## Visibility signal
+
+Session arc complete-ish:
+
+- 5 PRs merged this session (#3041, #3042, #3043, #3044, #3045, #3046 —
+  4 mine + 2 Otto-Desktop)
+- 2 PRs in flight (#3047, #3048 — both mine, both auto-merge armed)
+- Dangling-dep refs on main: 9 → 2 → (0 once #3047 lands)
+- Rule 0 staleness: cleared by #3048
+
+The substrate-hygiene cascade continues to find adjacent stale
+artifacts to clean as each landing surfaces the next thread. Real-
+dependency-wait on remaining CI. Loop continues.


### PR DESCRIPTION
## Summary

The "Legacy violations" callout in [`.claude/rules/rule-0-no-sh-files.md`](.claude/rules/rule-0-no-sh-files.md) listed three `tools/hygiene/audit-*.sh` files as outstanding TS-port debt. All three have since been ported to `.ts` and the corresponding `.sh` files removed from the tree:

| Was (`.sh`) | Now (`.ts`) |
|---|---|
| `tools/hygiene/audit-lost-files.sh` | [`audit-lost-files.ts`](tools/hygiene/audit-lost-files.ts) |
| `tools/hygiene/audit-trajectories.sh` | [`audit-trajectories.ts`](tools/hygiene/audit-trajectories.ts) |
| `tools/hygiene/audit-backlog-items.sh` | [`audit-backlog-items.ts`](tools/hygiene/audit-backlog-items.ts) |

`tools/hygiene/` is now entirely Rule-0-compliant.

## Surfaced as a side observation

While verifying, I noticed `.gemini/service/install-lior-service.sh` + `.gemini/service/lior-loop.sh` live outside `tools/setup/` but are install-graph by intent. The rule's "only `tools/setup/`" phrasing technically excludes them. Resolution is a separate design question (expand allowed-path list vs port/relocate). Captured as a NOTE in the rule body rather than silently leaving the ambiguity.

## Test plan

- [x] `find . -name "*.sh" -not -path "./tools/setup/*"` produces only:
  - vendored Lean/Mathlib/Batteries packages (not ours)
  - `references/upstreams/*` (vendored upstreams, not ours)
  - `.gemini/service/*.sh` (surfaced in PR body as the remaining design question)
- [x] Worktree-isolated build (`/tmp/zeta-rule0-update`) per the multi-Otto split-brain pattern

## Composes with

Continuation of this session's substrate-hygiene sweep — alongside [#3043](https://github.com/Lucent-Financial-Group/Zeta/pull/3043), [#3044](https://github.com/Lucent-Financial-Group/Zeta/pull/3044), [#3045](https://github.com/Lucent-Financial-Group/Zeta/pull/3045), [#3047](https://github.com/Lucent-Financial-Group/Zeta/pull/3047), this PR closes the staleness in the rule that flagged outstanding hygiene work that's already done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)