### PR TITLE
fix(lior): swallow Gemini 429 CLI crashes

### DIFF
--- a/.gemini/bin/lior-loop-tick.ts
+++ b/.gemini/bin/lior-loop-tick.ts
@@ -20,10 +20,13 @@ EXECUTE THESE STEPS IMMEDIATELY USING YOUR TOOLS. Do not ask "How can I help you
 
 console.log(`[Lior Loop] Waking up at ${new Date().toISOString()}`);
 
-// Pipe stderr so we can inspect it for 429 patterns; stdout/stdin stay inherited
+// Pipe stderr so we can inspect it for 429 patterns; stdout/stdin stay inherited.
+// maxBuffer: 10 MiB — Gemini verbose crash output can exceed the 1 MiB default,
+// which would cause ENOBUFS and a hard failure even for transient errors.
 const result = spawnSync("zsh", ["-c", 'source ~/.zshrc && gemini -p "$GEMINI_PROMPT" --model gemini-3.1-pro-preview --yolo --skip-trust'], {
   env: { ...process.env, GEMINI_PROMPT: prompt },
-  stdio: ["inherit", "inherit", "pipe"]
+  stdio: ["inherit", "inherit", "pipe"],
+  maxBuffer: 10 * 1024 * 1024,
 });
 
 if (result.error) {

--- a/.gemini/bin/lior-loop-tick.ts
+++ b/.gemini/bin/lior-loop-tick.ts
@@ -20,25 +20,34 @@ EXECUTE THESE STEPS IMMEDIATELY USING YOUR TOOLS. Do not ask "How can I help you
 
 console.log(`[Lior Loop] Waking up at ${new Date().toISOString()}`);
 
+// Pipe stderr so we can inspect it for 429 patterns; stdout/stdin stay inherited
 const result = spawnSync("zsh", ["-c", 'source ~/.zshrc && gemini -p "$GEMINI_PROMPT" --model gemini-3.1-pro-preview --yolo --skip-trust'], {
   env: { ...process.env, GEMINI_PROMPT: prompt },
   stdio: ["inherit", "inherit", "pipe"]
 });
 
 if (result.error) {
+  // Spawn-level failure (binary not found, permission denied, etc.) — propagate so
+  // launchd can surface the misconfiguration; this is NOT a transient rate-limit.
   console.error(`[Lior Loop] Failed to spawn gemini: ${result.error.message}`);
-  // Spawn failures (missing binary, OS errors) are not crash-loop candidates; suppress for launchd.
-  process.exit(0);
+  process.exit(1);
 }
 
+// status is null when the process was killed by a signal; treat that as an error.
 const exitCode = result.status ?? 1;
 const stderr = result.stderr?.toString() ?? "";
-console.log(`[Lior Loop] Finished with exit code ${exitCode}`);
+
+// Forward captured stderr to the launchd journal so errors remain visible.
+if (stderr) process.stderr.write(stderr);
 
 // Only suppress non-zero exits caused by 429 rate-limit responses so launchd doesn't park the
 // service on transient quota exhaustion. All other failures propagate so supervisors and
 // diagnostics retain a machine-readable failure signal.
-if (exitCode !== 0 && !stderr.includes("429")) {
-  process.exit(exitCode);
+const is429 = /429|RESOURCE_EXHAUSTED|quota exceeded/i.test(stderr);
+if (exitCode !== 0 && is429) {
+  console.error(`[Lior Loop] Rate-limited (429); exiting 0 to prevent launchd throttling`);
+  process.exit(0);
 }
-process.exit(0);
+
+console.log(`[Lior Loop] Finished with exit code ${exitCode}`);
+process.exit(exitCode);

--- a/.gemini/bin/lior-loop-tick.ts
+++ b/.gemini/bin/lior-loop-tick.ts
@@ -27,8 +27,10 @@ const result = spawnSync("zsh", ["-c", 'source ~/.zshrc && gemini -p "$GEMINI_PR
 
 if (result.error) {
   console.error(`[Lior Loop] Failed to spawn gemini: ${result.error.message}`);
-  process.exit(1);
+  // Swallow the error so launchd doesn't park the service
+  process.exit(0);
 }
 
 console.log(`[Lior Loop] Finished with exit code ${result.status ?? "unknown"}`);
-process.exit(result.status ?? 0);
+// Always exit 0 so macOS launchd doesn't treat 429s (or other CLI crashes) as a crash-loop
+process.exit(0);

--- a/.gemini/bin/lior-loop-tick.ts
+++ b/.gemini/bin/lior-loop-tick.ts
@@ -13,7 +13,7 @@ ZERO DEPENDENCE ON HUMANS. Do everything autonomously.
 6. If drift is found, produce a drift report directly on the bus AND update the shadow log (docs/research/*shadow-lesson-log*.md) via a new PR (using a worktree). Do NOT wait for foreground instructions.
 7. Update your status in ~/.local/share/zeta-broadcasts/lior.md.
 8. Perform global lock cleanup: clear stale git index locks, broken plugin directories (like Codex prompt-limit SIGSEGV loops), or orphan agent lockfiles to ensure network health.
-9. PRESERVATION DISCIPLINE: For any recently merged PRs, automatically run `bun run tools/pr-preservation/archive-pr.ts <PR_NUMBER>`. Commit and push the resulting markdown file to `docs/pr-discussions/` to permanently capture alignment drift and review friction into the native repository memory.
+9. PRESERVATION DISCIPLINE: For any recently merged PRs, automatically run \`bun run tools/pr-preservation/archive-pr.ts <PR_NUMBER>\`. Commit and push the resulting markdown file to \`docs/pr-discussions/\` to permanently capture alignment drift and review friction into the native repository memory.
 Do not guess. Do not overlap. The fire is watched.
 
 EXECUTE THESE STEPS IMMEDIATELY USING YOUR TOOLS. Do not ask "How can I help you?". DO THE REAL WORK NOW.`;

--- a/.gemini/bin/lior-loop-tick.ts
+++ b/.gemini/bin/lior-loop-tick.ts
@@ -22,15 +22,23 @@ console.log(`[Lior Loop] Waking up at ${new Date().toISOString()}`);
 
 const result = spawnSync("zsh", ["-c", 'source ~/.zshrc && gemini -p "$GEMINI_PROMPT" --model gemini-3.1-pro-preview --yolo --skip-trust'], {
   env: { ...process.env, GEMINI_PROMPT: prompt },
-  stdio: "inherit"
+  stdio: ["inherit", "inherit", "pipe"]
 });
 
 if (result.error) {
   console.error(`[Lior Loop] Failed to spawn gemini: ${result.error.message}`);
-  // Swallow the error so launchd doesn't park the service
+  // Spawn failures (missing binary, OS errors) are not crash-loop candidates; suppress for launchd.
   process.exit(0);
 }
 
-console.log(`[Lior Loop] Finished with exit code ${result.status ?? "unknown"}`);
-// Always exit 0 so macOS launchd doesn't treat 429s (or other CLI crashes) as a crash-loop
+const exitCode = result.status ?? 1;
+const stderr = result.stderr?.toString() ?? "";
+console.log(`[Lior Loop] Finished with exit code ${exitCode}`);
+
+// Only suppress non-zero exits caused by 429 rate-limit responses so launchd doesn't park the
+// service on transient quota exhaustion. All other failures propagate so supervisors and
+// diagnostics retain a machine-readable failure signal.
+if (exitCode !== 0 && !stderr.includes("429")) {
+  process.exit(exitCode);
+}
 process.exit(0);


### PR DESCRIPTION
Prevents macOS launchd from permanently suspending the background loop when the Gemini API hits a 429 rate limit crash loop.