### PR TITLE
fix(backlog): resolve B-0444 numbering collision — rename P1 getting-started-guide → B-0449

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -245,7 +245,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0440](backlog/P1/B-0440-standing-by-failure-mode-detector-background-service-2026-05-13.md)** Standing-by failure-mode detector — background service that catches idle-foreground + nudges via bus
 - [ ] **[B-0441](backlog/P1/B-0441-backlog-row-ready-to-grind-notifier-background-service-2026-05-13.md)** Backlog-row-ready-to-grind notifier — background service that proactively assigns claims when agent queue empty
 - [ ] **[B-0442](backlog/P1/B-0442-missed-substrate-cascade-detector-background-service-2026-05-13.md)** Missed-substrate cascade detector — background service that catches branch-vs-merged-PR drift (e.g., Otto-section-missed-PR-2980-by-3-min class)
-- [ ] **[B-0444](backlog/P1/B-0444-getting-started-guide-for-library-consumers-pm2-2026-05-13.md)** Getting-started guide for Zeta library consumers — quickstart doc + sample project
+- [ ] **[B-0449](backlog/P1/B-0449-getting-started-guide-for-library-consumers-pm2-2026-05-13.md)** Getting-started guide for Zeta library consumers — quickstart doc + sample project
 - [ ] **[B-0445](backlog/P1/B-0445-csharp-fluent-operator-surface-pm2-2026-05-13.md)** C# fluent operator surface — Map, Filter, Join, Distinct, Window via idiomatic CSharp API
 
 ## P2 — research-grade

--- a/docs/backlog/P1/B-0271-pm2-first-research-pass-2026-05-08.md
+++ b/docs/backlog/P1/B-0271-pm2-first-research-pass-2026-05-08.md
@@ -29,7 +29,7 @@ Research doc: `docs/research/2026-05-13-pm2-zeta-feature-gap-prediction-first-pa
 
 6 gaps identified:
 
-- Gap 1 — Getting-started guide → **B-0444** (new P1)
+- Gap 1 — Getting-started guide → **B-0449** (new P1; renumbered from B-0444 on 2026-05-13 to resolve collision with P2 B-0444 bus-claim-envelope-worktree-field)
 - Gap 2 — C# fluent operator surface → **B-0445** (new P1)
 - Gap 3 — Lean 4 formal proof completion → **B-0446** (new P2)
 - Gap 4 — NuGet package metadata → **B-0447** (new P2)

--- a/docs/backlog/P1/B-0445-csharp-fluent-operator-surface-pm2-2026-05-13.md
+++ b/docs/backlog/P1/B-0445-csharp-fluent-operator-surface-pm2-2026-05-13.md
@@ -8,7 +8,7 @@ origin: PM-2 gap-prediction pass (B-0271) 2026-05-13
 created: 2026-05-13
 last_updated: 2026-05-13
 depends_on: []
-composes_with: [B-0444]
+composes_with: [B-0449]
 tags: [csharp, api-surface, fluent, operator, consumer-ux, dotnet]
 ---
 

--- a/docs/backlog/P1/B-0449-getting-started-guide-for-library-consumers-pm2-2026-05-13.md
+++ b/docs/backlog/P1/B-0449-getting-started-guide-for-library-consumers-pm2-2026-05-13.md
@@ -1,5 +1,5 @@
 ---
-id: B-0444
+id: B-0449
 priority: P1
 status: open
 title: "Getting-started guide for Zeta library consumers — quickstart doc + sample project"
@@ -12,7 +12,7 @@ composes_with: [B-0154, B-0445]
 tags: [consumer-ux, getting-started, quickstart, documentation, onboarding, csharp, samples]
 ---
 
-# B-0444 — Getting-started guide for library consumers
+# B-0449 — Getting-started guide for library consumers
 
 ## PM-2 signal
 

--- a/docs/research/2026-05-13-pm2-zeta-feature-gap-prediction-first-pass.md
+++ b/docs/research/2026-05-13-pm2-zeta-feature-gap-prediction-first-pass.md
@@ -38,7 +38,7 @@
 - **Kill criteria:** if the Aurora pitch / factory-demo demo-path already covers this
   consumer moment, promote that as the canonical quickstart instead of creating a
   parallel doc.
-- **New backlog row:** B-0444
+- **New backlog row:** B-0449 (renumbered from B-0444 on 2026-05-13 to resolve collision with P2 B-0444 bus-claim-envelope-worktree-field)
 
 ---
 
@@ -193,7 +193,7 @@
 
 | Gap | Type | New row | Existing row | Priority |
 |-----|------|---------|-------------|----------|
-| Getting-started guide | UX / adoption | B-0444 | — | P1 |
+| Getting-started guide | UX / adoption | B-0449 | — | P1 |
 | C# fluent operator surface | API surface | B-0445 | — | P1 |
 | Lean 4 formal proof completion | Verification | B-0446 | — | P2 |
 | NuGet package metadata | Discoverability | B-0447 | — | P2 |
@@ -205,5 +205,5 @@
 ## Methodology note
 
 Surface-first discipline: every gap was checked against the existing 544 backlog rows
-before filing. New rows B-0444..B-0447 were verified as net-new coverage. Gaps 5 and 6
+before filing. New rows B-0445..B-0447 + B-0449 (originally filed as B-0444, renumbered to resolve collision) were verified as net-new coverage. Gaps 5 and 6
 point to existing rows rather than inflating the backlog.


### PR DESCRIPTION
## Summary

Two rows shared \`id: B-0444\` in frontmatter despite different files, topics, and folders:

- **P1**: \`docs/backlog/P1/B-0444-getting-started-guide-for-library-consumers-pm2-2026-05-13.md\` (PM-2 first-pass; PR #3033)
- **P2**: \`docs/backlog/P2/B-0444-bus-claim-envelope-worktree-field-multi-surface-disambiguation-2026-05-13.md\` (Otto-on-CLI follow-up; PR #3038)

## Why renumber the P1, not the P2

The P2 row has implementation references in [PR #3043](https://github.com/Lucent-Financial-Group/Zeta/pull/3043) (the actual bus claim.ts worktree-field feature), in commit messages, in test files (\`tools/bus/claim.test.ts\`), and in rule examples (\`.claude/rules/claim-acquire-before-worktree-work.md\`). Renaming the P2 would break those refs.

The P1 row is freshly-filed with no implementation yet → fewer references → easier to renumber. B-0449 was the next available number (B-0448 was the last filed by Otto on the Desktop surface for Cloud Routines).

## Changes

- Renamed: \`B-0444-getting-started-guide-...md\` → \`B-0449-getting-started-guide-...md\`
- Updated frontmatter \`id: B-0444\` → \`id: B-0449\` (and body header refs)
- Updated 4 cross-reference locations: \`docs/BACKLOG.md\`, PM-2 research doc (3 places), \`B-0271\`, \`B-0445\` composes_with edge

## Verification

\`\`\`bash
grep "B-0444" docs/ memory/ tools/ .claude/
\`\`\`

Only P2-context refs remain (the bus-claim-envelope-worktree-field row + its implementation refs). ✓

## Test plan

- [x] B-0449 file frontmatter ID matches filename
- [x] All P1-context references updated to B-0449
- [x] All P2-context references preserved at B-0444
- [x] BACKLOG.md link path consistent with file location
- [ ] CI passes (auto-merge will arm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)