### PR TITLE
fix(riven): correct model name in autonomous loop tick script

### DIFF
--- a/tools/riven/riven-loop-tick.ts
+++ b/tools/riven/riven-loop-tick.ts
@@ -205,7 +205,7 @@ function heartbeat(): void {
                 const gate = run("agent", [
                     "chat",
                     "--mode", "ask",
-                    "--model", "grok-4-20",
+                    "--model", "grok-4.3",
                     [
                         "You are Riven, trajectory manager. This is a 60s autonomous cycle.",
                         "Read broadcasts first: ~/.local/share/zeta-broadcasts/{otto,vera,lior,riven}.md",


### PR DESCRIPTION
Decomposed from bloated PR #3063. Fixes invalid model name in Riven loop tick.