### PR TITLE
feat(hooks/md032): pre-commit harness hook closes B-0456 #4

### DIFF
--- a/.claude/hooks/check-md032-pretooluse.ts
+++ b/.claude/hooks/check-md032-pretooluse.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+// check-md032-pretooluse.ts — Claude Code PreToolUse hook wrapper
+// for tools/hygiene/check-md032-blanks-around-lists.ts.
+//
+// Reads stdin JSON per the Claude Code hooks contract
+// (https://code.claude.com/docs/en/hooks-guide). Filters to
+// `git commit` commands only — other Bash invocations exit 0
+// immediately with zero overhead.
+//
+// When ZETA_MD032_PRECOMMIT is unset, the hook is a no-op
+// (exits 0 before reading stdin or spawning any child process).
+// The env-var gate is opt-in per the same pattern as
+// `verify-branch-pretooluse.ts` (ZETA_EXPECTED_BRANCH) so the
+// default commit experience is unchanged.
+//
+// Wired via .claude/settings.json PreToolUse matcher:"Bash".
+// See .claude/hooks/README.md for configuration.
+//
+// Implements B-0456 acceptance criterion #4: wire the MD032
+// helper into the pre-commit harness hook.
+
+import { spawnSync } from "node:child_process";
+
+interface HookInput {
+  readonly tool_name?: string;
+  readonly tool_input?: { readonly command?: string };
+}
+
+interface HookOutput {
+  readonly hookSpecificOutput: {
+    readonly hookEventName: "PreToolUse";
+    readonly permissionDecision: "allow" | "deny";
+    readonly permissionDecisionReason?: string;
+  };
+}
+
+function emitDeny(reason: string): never {
+  const output: HookOutput = {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason,
+    },
+  };
+  console.log(JSON.stringify(output));
+  process.exit(0);
+}
+
+function isGitCommitCommand(command: string): boolean {
+  const trimmed = command.trimStart();
+  return trimmed.startsWith("git commit") || (trimmed.startsWith("git -C") && trimmed.includes("commit"));
+}
+
+function main(): number {
+  if (!process.env.ZETA_MD032_PRECOMMIT) {
+    return 0;
+  }
+
+  let input: HookInput = {};
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- mirror the verify-branch-pretooluse.ts pattern for synchronous stdin read.
+    const stdin = require("fs").readFileSync(0, "utf8");
+    input = JSON.parse(stdin) as HookInput;
+  } catch {
+    return 0;
+  }
+
+  const command = input.tool_input?.command ?? "";
+  if (!isGitCommitCommand(command)) {
+    return 0;
+  }
+
+  const projectDir = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+  // eslint-disable-next-line sonarjs/no-os-command-from-path -- bun invoked as explicit args array; no shell, no user input.
+  const result = spawnSync(
+    "bun",
+    [`${projectDir}/tools/hygiene/check-md032-blanks-around-lists.ts`, "--staged"],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  if (result.status === 0) {
+    // No findings — the helper prints a one-line summary to stdout
+    // that we propagate so the user can see the pre-check ran.
+    if (result.stdout) {
+      process.stderr.write(result.stdout);
+    }
+    return 0;
+  }
+
+  // Helper found MD032 violations OR a git/index failure. Block the
+  // commit and surface the helper's findings so the user can fix.
+  const reason = (result.stderr || result.stdout || "MD032 pre-check failed").trim();
+  emitDeny(`check-md032 pre-commit hook blocked the commit:\n${reason}`);
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,10 @@
           {
             "type": "command",
             "command": "bun \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/verify-branch-pretooluse.ts"
+          },
+          {
+            "type": "command",
+            "command": "bun \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-md032-pretooluse.ts"
           }
         ]
       },

--- a/docs/backlog/P2/B-0456-mechanize-md032-blanks-around-lists-pre-commit-2026-05-14.md
+++ b/docs/backlog/P2/B-0456-mechanize-md032-blanks-around-lists-pre-commit-2026-05-14.md
@@ -1,12 +1,13 @@
 ---
 id: B-0456
 priority: P2
-status: open
+status: closed
 title: Mechanize MD032 (blanks-around-lists) check — catch tick-shard discipline gap before push, not in CI
 tier: factory-hygiene
 effort: S
 created: 2026-05-14
 last_updated: 2026-05-14
+closed: 2026-05-14
 depends_on: []
 composes_with: [B-0451]
 tags: [substrate-hygiene, markdownlint, MD032, mechanization, tick-shards, encoding-rules-without-mechanizing]
@@ -68,18 +69,24 @@ layer). Option 2 is a fallback if hooks add too much friction.
 
 ## Acceptance criteria
 
-- [ ] `tools/hygiene/check-md032-blanks-around-lists.ts` exists +
+- [x] `tools/hygiene/check-md032-blanks-around-lists.ts` exists +
       passes for an MD032-clean fixture and fails for an MD032-dirty
-      fixture
-- [ ] Test file under `tools/hygiene/` covering: clean shard,
+      fixture (PR #3075 merged → 9757609)
+- [x] Test file under `tools/hygiene/` covering: clean shard,
       shard with single MD032 risk, shard with multiple MD032 risks,
-      shard with no lists, list-without-preceding-label (which is
-      MD032-clean and should NOT flag)
-- [ ] CLI emits `file:line` for each finding (matches markdownlint
+      shard with no lists, list-without-preceding-label, plus
+      every round-discovered edge case (77 tests across 20 review
+      rounds; PR #3075 + #3091 follow-up calibrations)
+- [x] CLI emits `file:line` for each finding (matches markdownlint
       output style)
-- [ ] Wire into either pre-push hook or tick-close ritual
-- [ ] Verify against the 4 historical occurrences (2228Z, 2348Z,
-      0017Z, 0024Z) — each should be caught
+- [x] Wire into either pre-push hook or tick-close ritual
+      (`.claude/hooks/check-md032-pretooluse.ts` — opt-in via
+      `ZETA_MD032_PRECOMMIT=1` env var, mirrors `verify-branch-
+      pretooluse.ts` pattern; this PR)
+- [x] Verify against the 4 historical occurrences (2228Z, 2348Z,
+      0017Z, 0024Z) — each is caught by the helper test fixtures
+      (`single bullet violation` / `single numbered-list violation`
+      / `plus-space marker` / `0024Z pattern` cases)
 
 ## Why P2
 


### PR DESCRIPTION
## Summary

Closes B-0456 acceptance criterion #4 (wire helper into pre-push hook OR tick-close ritual) by adding a Claude Code PreToolUse hook that mirrors the `verify-branch-pretooluse.ts` pattern.

## What ships

- [`.claude/hooks/check-md032-pretooluse.ts`](.claude/hooks/check-md032-pretooluse.ts) — opt-in (via `ZETA_MD032_PRECOMMIT=1`) PreToolUse hook that runs the MD032 helper on staged Markdown files before each `git commit` and blocks the commit if violations are found.
- `.claude/settings.json` — wired as a second hook under PreToolUse Bash matcher (after `verify-branch-pretooluse.ts`).
- B-0456 row → `status: closed`; all 5 acceptance criteria checked.

## Default behavior (unchanged)

Without `ZETA_MD032_PRECOMMIT` set, the hook is a no-op: it exits 0 before reading stdin or spawning anything. Commit experience for users who haven't opted in stays exactly as before.

## Opt-in behavior

```bash
export ZETA_MD032_PRECOMMIT=1
git commit -m "..."     # runs `bun tools/hygiene/check-md032-blanks-around-lists.ts --staged` first
# Exit 0 (no MD032 in staged blobs) → commit proceeds
# Exit 1 (MD032 finding)            → commit denied with finding details in the hook reason
```

## Self-test (run before commit)

```
$ echo '{"tool_name":"Bash","tool_input":{"command":"ls"}}' | bun .claude/hooks/check-md032-pretooluse.ts
$ echo $?
0  # no env var: no-op

$ echo '{"tool_name":"Bash","tool_input":{"command":"git commit -m foo"}}' | ZETA_MD032_PRECOMMIT=1 bun .claude/hooks/check-md032-pretooluse.ts
check-md032: no staged .md files
$ echo $?
0
```

## Test plan

- [x] Hook with no env var is a no-op (exit 0, no work)
- [x] Hook with env var + non-commit Bash command is a no-op
- [x] Hook with env var + git commit + no staged .md prints "no staged .md files" and exits 0
- [x] B-0456 helper (already on main, PR #3075/3091/etc.) is reachable from the hook
- [x] All 5 acceptance criteria on B-0456 now checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)