### PR TITLE
docs(b-0153): cross-link MD032 mechanization + capture MD038 empirical evidence

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -504,7 +504,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0453](backlog/P2/B-0453-contributor-compliance-cross-reference-integration.md)** Cross-reference CONTRIBUTOR-COMPLIANCE.md into AGENTS.md / CONTRIBUTING.md / GOVERNANCE.md
 - [ ] **[B-0454](backlog/P2/B-0454-t1-t2-self-audit-and-cadenced-review-trajectories.md)** Encode T1 self-audit + T2 cadenced review (TS-preferred tooling + trajectory packet)
 - [ ] **[B-0455](backlog/P2/B-0455-t4-t5-onboarding-and-drift-retrospective-trajectories.md)** T4 onboarding briefing + T5 drift retrospective (trajectory packets)
-- [ ] **[B-0456](backlog/P2/B-0456-mechanize-md032-blanks-around-lists-pre-commit-2026-05-14.md)** Mechanize MD032 (blanks-around-lists) check — catch tick-shard discipline gap before push, not in CI
+- [x] **[B-0456](backlog/P2/B-0456-mechanize-md032-blanks-around-lists-pre-commit-2026-05-14.md)** Mechanize MD032 (blanks-around-lists) check — catch tick-shard discipline gap before push, not in CI
 - [ ] **[B-0457](backlog/P2/B-0457-amara-ts-core-openai-api-invoke-flag-parity-ts-first-riven-2026-05-11.md)** amara.ts core — OpenAI API invoke + --file/--context-cmd flag parity (atomic child of B-0118, TS-first)
 - [ ] **[B-0458](backlog/P2/B-0458-amara-ts-readme-update-courier-debt-closure-test-invoke-ts-first-riven-2026-05-11.md)** amara.ts README integration + courier-debt closure + invocation test (atomic child of B-0118, TS-first)
 - [ ] **[B-0462](backlog/P2/B-0462-amara-persona-bootstrap-preamble-definition-ts-first-riven-2026-05-11.md)** Amara persona bootstrap preamble + AgencySignature definition (atomic child of B-0118, TS-first)

--- a/docs/backlog/P2/B-0153-pre-commit-lint-suite-mechanizable-class-consolidation-aaron-otto-2026-05-01.md
+++ b/docs/backlog/P2/B-0153-pre-commit-lint-suite-mechanizable-class-consolidation-aaron-otto-2026-05-01.md
@@ -4,7 +4,7 @@ priority: P2
 status: open
 title: Pre-commit lint suite — consolidate the 13 mechanizable lint-classes characterized 2026-05-01
 created: 2026-05-01
-last_updated: 2026-05-02
+last_updated: 2026-05-14
 depends_on: []
 type: friction-reducer
 ---
@@ -53,9 +53,22 @@ implementation should use as stable class identifiers.
    blanks-around-lists rule. Fix-pattern: prose-reflow with
    connectives ("plus", "and", comma-list, "/"). Aaron-affirmed
    as *"very high quality decision"* (Aaron typed "decison").
+   **MECHANIZED 2026-05-14** via B-0456 →
+   `tools/hygiene/check-md032-blanks-around-lists.ts` plus the
+   opt-in `.claude/hooks/check-md032-pretooluse.ts` PreToolUse
+   harness hook (gated on `ZETA_MD032_PRECOMMIT=1`). 77 tests
+   covering blockquote contexts, fenced code blocks, YAML front
+   matter, HTML comments, thematic breaks, after-list MD032, and
+   staged-blob reads. Full 584-file `docs/hygiene-history/**`
+   corpus validates clean.
 2. **MD038 / no-space-in-code**: spaces inside inline-code spans
-   (e.g., `` `| ` ``) trigger MD038. Fix: tighten code-span or
-   replace with prose.
+   trigger MD038. Fix: tighten code-span or replace with prose.
+   **Empirical evidence accumulated 2026-05-14**: hit at least 3
+   times during the B-0456 PR cycle (PRs 3075, 3090, 3092) on
+   tick-shard code spans containing a `>` marker plus spaces —
+   the backtick-rich span ends at the first matching backtick
+   rather than the intended close. Next-to-grind class after
+   MD032 per this row's coverage matrix.
 3. **Inline-code broken across lines**: backtick-fenced filenames
    that wrap mid-token break CommonMark inline-code spans. Fix:
    move full filename to own line.


### PR DESCRIPTION
## Summary

B-0153 (the consolidated pre-commit lint suite covering 13 mechanizable lint-classes from 2026-05-01) gets post-session-arc updates on classes 1 and 2:

- **Class 1 (MD032/blanks-around-lists)**: now MECHANIZED via B-0456 → helper at `tools/hygiene/check-md032-blanks-around-lists.ts` + opt-in pre-commit hook `.claude/hooks/check-md032-pretooluse.ts` (gated on `ZETA_MD032_PRECOMMIT=1`). 77 tests; 584-file `docs/hygiene-history/**` corpus validates clean. Cross-link helps future contributors picking up the remaining 12 classes.
- **Class 2 (MD038/no-space-in-code)**: empirical evidence — hit at least 3 times during the B-0456 PR cycle (PRs 3075, 3090, 3092) on tick-shard code spans containing `>` + spaces. Named as next-to-grind class after MD032.

## Test plan

- [x] `last_updated` field bumped to 2026-05-14
- [x] BACKLOG.md index regenerated to reflect the row update
- [x] B-0456 helper validates the modified file clean (no MD032 finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)