### PR TITLE
docs(autonomous-loop): accurate count of bg-services launchd-wiring status

### DIFF
--- a/docs/AUTONOMOUS-LOOP.md
+++ b/docs/AUTONOMOUS-LOOP.md
@@ -586,11 +586,15 @@ declared) against `CronList` and re-arms missing rows.
 
 - **Background Services Architecture** (B-0440, B-0441, B-0442) — the
   proactive multi-agent loop is augmented by macOS `launchd` background
-  daemons that ensure failure modes and deadlocks are broken without human
-  intervention. See `tools/bg/`. Currently launchd-registered:
-  `missed-substrate-detector.ts` (`.gemini/launchd/com.zeta.missed-substrate-detector.plist`).
-  `standing-by-detector.ts` is not yet wired to launchd (slice 5+ pending).
-  Note: plist files contain machine-specific paths and are maintainer-only artifacts.
+  daemons that ensure failure modes and deadlocks are broken without
+  human intervention. See `tools/bg/`. Currently 4 services exist in
+  `tools/bg/`; only `missed-substrate-detector.ts` is launchd-registered
+  (`.gemini/launchd/com.zeta.missed-substrate-detector.plist`). The other
+  three (`backlog-ready-notifier.ts`, `standing-by-detector.ts`,
+  `audit-duplicate-row-ids.ts`) are invokable on demand via
+  `bun tools/bg/<name>.ts --once` but not yet wired to launchd (B-0441
+  acceptance #2 + B-0442 slice 5+ pending). Note: plist files contain
+  machine-specific paths and are maintainer-only artifacts.
 
 - **`docs/hygiene-history/loop-tick-history.md`** — the
   factory's durable tick fire-log; appended to every tick


### PR DESCRIPTION
## Summary

The "Background Services Architecture" bullet only mentioned `standing-by-detector.ts` as not-yet-wired. The repo actually has 4 services in `tools/bg/`:

- `missed-substrate-detector.ts` (launchd-registered ✓)
- `backlog-ready-notifier.ts` (NOT wired — B-0441 #2 pending)
- `standing-by-detector.ts` (NOT wired — B-0442 slice 5+ pending)
- `audit-duplicate-row-ids.ts` (NOT wired; invoked on-demand from the substrate-hygiene cascade this session)

Updated the bullet to list all 4 + clarify that 3 are invokable on demand via `bun tools/bg/<name>.ts --once` until launchd wiring completes.

## Helper false-positive note (for follow-up)

Running the just-merged `check-md032-blanks-around-lists.ts` helper against this file surfaced 1 finding on line 275 — but markdownlint on main doesn't flag this content (the line is `- bullet` at 3-space indent inside a parent numbered-list-item-body; markdownlint sees it as sub-list of the parent block). The helper doesn't track parent-list-item-body context. Captured as a future helper-refinement class — does NOT block this docs PR.

## Test plan

- [x] Single-line text change to existing bullet; no markdownlint-actually-violating content added or modified
- [x] Substrate-honest accurate count of `tools/bg/` services and their wiring status

🤖 Generated with [Claude Code](https://claude.com/claude-code)