### PR TITLE
fix(tsc): guard undefined capture group in validate-memory-parity

### DIFF
--- a/tools/memory/validate-memory-parity.ts
+++ b/tools/memory/validate-memory-parity.ts
@@ -42,7 +42,9 @@ function extractLinkedFilenames(content: string): string[] {
   const pattern = /\(([a-zA-Z0-9_\-\.\/]+\.md)\)/g;
   const results: string[] = [];
   for (const m of content.matchAll(pattern)) {
-    let raw = m[1];
+    const captured = m[1];
+    if (captured === undefined) continue;
+    let raw = captured;
     // Strip leading "memory/" prefix — validator joins with MEMORY_DIR anyway
     if (raw.startsWith("memory/")) {
       raw = raw.slice("memory/".length);


### PR DESCRIPTION
## Summary

- TypeScript 6.0 types `RegExpMatchArray` capture groups as `string | undefined` — even non-optional groups like ours — causing five `TS18048`/`TS2345` errors in `tools/memory/validate-memory-parity.ts`
- Adds a two-line guard (`const captured = m[1]; if (captured === undefined) continue;`) that narrows the type to `string`, fixes all five errors, and eliminates the `lint (tsc tools)` failure on every future CI run
- No functional change: the regex's single capture group will never actually be `undefined`, so the guard is only type-level

## Test plan

- [x] `bun --bun tsc --noEmit -p tsconfig.json` exits 0 locally
- [ ] `lint (tsc tools)` CI check passes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)