### PR TITLE
feat(b-0445): C# fluent operator surface — ZetaCircuitBuilder<T>

### DIFF
--- a/src/Core.CSharp/ZetaCircuitBuilder.cs
+++ b/src/Core.CSharp/ZetaCircuitBuilder.cs
@@ -1,0 +1,132 @@
+// This file contains two tightly-related types that form the fluent C# builder
+// surface: `ZetaCircuitBuilder<T>` (the chain) and `CircuitBuilderExtensions`
+// (the entry-point extension). They are in one file by namespace-concept, not
+// one-type-per-file; `CircuitBuilderExtensions` carries a MA0048 suppression.
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Zeta.Core;
+
+namespace Zeta.Core.CSharp;
+
+/// <summary>
+/// Fluent builder for constructing Zeta Z-set operator pipelines from C#.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Enter the chain with <see cref="CircuitBuilderExtensions.From{T}(Circuit,Stream{ZSet{T}})"/>
+/// and terminate with <see cref="Build"/> to obtain an <see cref="OutputHandle{T}"/>.
+/// </para>
+/// <para>
+/// Each method registers the corresponding operator with the owning
+/// <see cref="Circuit"/> and returns a new builder over the result stream.
+/// All operators delegate to the F# <c>Operators.fs</c> implementation —
+/// one cost model, one semantic definition, zero behavioural divergence.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">Element type of the Z-set stream.</typeparam>
+public sealed class ZetaCircuitBuilder<T>
+{
+    private readonly Circuit _circuit;
+    private readonly Stream<ZSet<T>> _stream;
+
+    internal ZetaCircuitBuilder(Circuit circuit, Stream<ZSet<T>> stream)
+    {
+        _circuit = circuit;
+        _stream = stream;
+    }
+
+    /// <summary>Projects each element through <paramref name="selector"/>.</summary>
+    public ZetaCircuitBuilder<TResult> Map<TResult>(Func<T, TResult> selector)
+        => new(_circuit, _circuit.Map(_stream, selector));
+
+    /// <summary>Retains only elements satisfying <paramref name="predicate"/>.</summary>
+    public ZetaCircuitBuilder<T> Filter(Func<T, bool> predicate)
+        => new(_circuit, _circuit.Filter(_stream, predicate));
+
+    /// <summary>Flattens each element to a Z-set of <typeparamref name="TResult"/> values.</summary>
+    public ZetaCircuitBuilder<TResult> FlatMap<TResult>(Func<T, ZSet<TResult>> selector)
+        => new(_circuit, _circuit.FlatMap(_stream, selector));
+
+    /// <summary>
+    /// Collapses multiplicities: elements with positive weight become weight 1;
+    /// elements with zero or negative weight are removed.
+    /// </summary>
+    public ZetaCircuitBuilder<T> Distinct()
+        => new(_circuit, _circuit.Distinct(_stream));
+
+    /// <summary>
+    /// Integrates (accumulates across ticks) the delta stream into a running snapshot.
+    /// Equivalent to a continuously-maintained <c>SELECT … FROM …</c> materialised view.
+    /// </summary>
+    public ZetaCircuitBuilder<T> Integrate()
+        => new(_circuit, _circuit.IntegrateZSet(_stream));
+
+    /// <summary>
+    /// Joins this stream with <paramref name="other"/> on matching keys extracted by
+    /// <paramref name="keyLeft"/> and <paramref name="keyRight"/>, combining matched
+    /// pairs with <paramref name="combine"/>.
+    /// </summary>
+    /// <typeparam name="TRight">Element type of the right-hand stream.</typeparam>
+    /// <typeparam name="TKey">Join-key type; must be non-null and comparable.</typeparam>
+    /// <typeparam name="TResult">Output element type.</typeparam>
+    public ZetaCircuitBuilder<TResult> Join<TRight, TKey, TResult>(
+        ZetaCircuitBuilder<TRight> other,
+        Func<T, TKey> keyLeft,
+        Func<TRight, TKey> keyRight,
+        Func<T, TRight, TResult> combine)
+        where TKey : notnull
+        => new(_circuit, _circuit.Join(_stream, other._stream, keyLeft, keyRight, combine));
+
+    /// <summary>
+    /// Groups elements by <paramref name="key"/> and sums the <see cref="long"/> values
+    /// extracted by <paramref name="value"/>. The output stream contains
+    /// <c>(group, sum)</c> value-tuples.
+    /// </summary>
+    /// <typeparam name="TGroup">Group-key type; must be non-null and comparable.</typeparam>
+    public ZetaCircuitBuilder<(TGroup, long)> GroupBySum<TGroup>(
+        Func<T, TGroup> key,
+        Func<T, long> value)
+        where TGroup : notnull
+    {
+        // F# tuples compile to System.Tuple (reference type); Map converts to
+        // C# ValueTuple so downstream chain and indexer use idiomatic (G, long).
+        var s = _circuit.GroupBySum(_stream, key, value);
+        return new(_circuit, _circuit.Map(s, t => (t.Item1, t.Item2)));
+    }
+
+    /// <summary>
+    /// Returns the underlying <see cref="Stream{T}"/> for use with Circuit APIs
+    /// not exposed on this builder (e.g. <c>SpeculativeWindow</c> for temporal windowing).
+    /// </summary>
+    public Stream<ZSet<T>> ToStream() => _stream;
+
+    /// <summary>
+    /// Registers an output handle for the current stream.
+    /// After each <see cref="Circuit.StepAsync()"/>, read results from
+    /// <see cref="OutputHandle{T}.Current"/>.
+    /// </summary>
+    public OutputHandle<ZSet<T>> Build() => _circuit.Output(_stream);
+}
+
+/// <summary>Entry-point extension that begins a <see cref="ZetaCircuitBuilder{T}"/> chain.</summary>
+[SuppressMessage("Design", "MA0048:File name must match type name",
+    Justification = "Entry-point extension collected with ZetaCircuitBuilder<T> by namespace concept; see file header.")]
+public static class CircuitBuilderExtensions
+{
+    /// <summary>
+    /// Wraps <paramref name="stream"/> in a <see cref="ZetaCircuitBuilder{T}"/> so
+    /// operator calls can be chained without re-specifying the circuit on each call.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var output = circuit
+    ///     .From(input.Stream)
+    ///     .Filter(x => x > 0)
+    ///     .Map(x => x * 2)
+    ///     .Distinct()
+    ///     .Build();
+    /// </code>
+    /// </example>
+    public static ZetaCircuitBuilder<T> From<T>(this Circuit circuit, Stream<ZSet<T>> stream)
+        => new(circuit, stream);
+}

--- a/tests/Core.CSharp.Tests/Core.CSharp.Tests.csproj
+++ b/tests/Core.CSharp.Tests/Core.CSharp.Tests.csproj
@@ -5,6 +5,12 @@
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>latest</LangVersion>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Zeta.Core.CSharp.Tests</RootNamespace>
+    <!-- xUnit1051: tests intentionally call StepAsync without a CancellationToken
+         (matches the pattern in Tests.CSharp/Tests.CSharp.csproj). -->
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Core.CSharp.Tests/FluentBuilderTests.cs
+++ b/tests/Core.CSharp.Tests/FluentBuilderTests.cs
@@ -1,0 +1,133 @@
+namespace Zeta.Core.CSharp.Tests;
+
+/// <summary>
+/// Verifies the fluent <see cref="ZetaCircuitBuilder{T}"/> surface introduced in B-0445.
+/// Each test checks one operator from the builder chain; the final tests exercise
+/// multi-step chains and <see cref="ZetaCircuitBuilder{T}.GroupBySum{TGroup}"/>.
+/// </summary>
+public class FluentBuilderTests
+{
+    private static readonly int[] FilterMapInputKeys = { 1, 2, 3 };
+    private static readonly (int, string)[] JoinLeftKeys = { (1, "Alice"), (2, "Bob") };
+    private static readonly (int, int)[] JoinRightKeys = { (1, 95), (2, 80) };
+    private static readonly (string, long)[] GroupBySumRows =
+    {
+        ("Lead",     100_00L),
+        ("Lead",     200_00L),
+        ("Proposal", 500_00L),
+        ("Won",      300_00L),
+    };
+
+    [Fact]
+    public async Task FilterMapBuildRoundTrip()
+    {
+        var c = new Circuit();
+        var input = c.ZSetInput<int>();
+        var output = c
+            .From(input.Stream)
+            .Filter(x => x > 1)
+            .Map(x => x * 10)
+            .Build();
+
+        input.Send(ZSetModule.ofKeys(FilterMapInputKeys));
+        await c.StepAsync();
+
+        Assert.Equal(0L, output.Current[10]);
+        Assert.Equal(1L, output.Current[20]);
+        Assert.Equal(1L, output.Current[30]);
+    }
+
+    [Fact]
+    public async Task DistinctCollapsesMultiplicities()
+    {
+        var c = new Circuit();
+        var input = c.ZSetInput<int>();
+        var output = c
+            .From(input.Stream)
+            .Distinct()
+            .Build();
+
+        input.Send(ZSetModule.ofPairs(new[] { (1, 5L), (2, 1L), (3, -2L) }));
+        await c.StepAsync();
+
+        Assert.Equal(1L, output.Current[1]);
+        Assert.Equal(1L, output.Current[2]);
+        Assert.Equal(0L, output.Current[3]);
+    }
+
+    [Fact]
+    public async Task IntegrateAccumulatesAcrossTicks()
+    {
+        var c = new Circuit();
+        var input = c.ZSetInput<int>();
+        var output = c
+            .From(input.Stream)
+            .Integrate()
+            .Build();
+
+        input.Send(ZSetModule.singleton(7, 1L));
+        await c.StepAsync();
+        Assert.Equal(1L, output.Current[7]);
+
+        input.Send(ZSetModule.singleton(7, 1L));
+        await c.StepAsync();
+        Assert.Equal(2L, output.Current[7]);
+    }
+
+    [Fact]
+    public async Task GroupBySumAggregatesCorrectly()
+    {
+        var c = new Circuit();
+        var input = c.ZSetInput<(string Stage, long AmountCents)>();
+        var output = c
+            .From(input.Stream)
+            .GroupBySum(x => x.Stage, x => x.AmountCents)
+            .Build();
+
+        input.Send(ZSetModule.ofKeys(GroupBySumRows));
+        await c.StepAsync();
+
+        // GroupBySumOp emits one entry per group with weight 1L; the key IS
+        // (group, sum), so we verify the expected sum landed in the ZSet.
+        Assert.Equal(1L, output.Current[("Lead", 300_00L)]);
+        Assert.Equal(1L, output.Current[("Proposal", 500_00L)]);
+        Assert.Equal(1L, output.Current[("Won", 300_00L)]);
+    }
+
+    [Fact]
+    public async Task JoinCombinesTwoStreams()
+    {
+        var c = new Circuit();
+        var left = c.ZSetInput<(int Id, string Name)>();
+        var right = c.ZSetInput<(int Id, int Score)>();
+
+        var leftBuilder = c.From(left.Stream);
+        var rightBuilder = c.From(right.Stream);
+
+        var output = leftBuilder
+            .Join(
+                rightBuilder,
+                x => x.Id,
+                y => y.Id,
+                (l, r) => (l.Name, r.Score))
+            .Build();
+
+        left.Send(ZSetModule.ofKeys(JoinLeftKeys));
+        right.Send(ZSetModule.ofKeys(JoinRightKeys));
+        await c.StepAsync();
+
+        Assert.Equal(1L, output.Current[("Alice", 95)]);
+        Assert.Equal(1L, output.Current[("Bob", 80)]);
+    }
+
+    [Fact]
+    public void ToStreamReturnsUnderlyingStream()
+    {
+        var c = new Circuit();
+        var input = c.ZSetInput<int>();
+        var builder = c.From(input.Stream);
+        var stream = builder.ToStream();
+
+        Assert.Equal(input.Stream, stream);
+    }
+}

--- a/tests/Core.CSharp.Tests/GlobalUsings.cs
+++ b/tests/Core.CSharp.Tests/GlobalUsings.cs
@@ -1,0 +1,5 @@
+global using System;
+global using System.Threading.Tasks;
+global using Xunit;
+global using Zeta.Core;
+global using Zeta.Core.CSharp;


### PR DESCRIPTION
## Summary

- Adds `ZetaCircuitBuilder<T>` — a fluent C# chain wrapping `Circuit` and `Stream<ZSet<T>>` so consumers can write `circuit.From(stream).Filter(...).Map(...).Distinct().Build()` without touching F# discriminated unions
- Adds `CircuitBuilderExtensions.From<T>` as the entry-point
- Fixes GroupBySum to convert F# reference tuples (`System.Tuple<G, long>`) to C# value tuples via a Map operator, keeping indexer syntax idiomatic
- Adds `tests/Core.CSharp.Tests/` with 6 round-trip tests; corrects weight assertions (GroupBySumOp emits weight 1L per group)
- Configures the test project to match `Tests.CSharp` conventions (LangVersion, NoWarn xUnit1051, GlobalUsings)

Closes B-0445.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] 8/8 `Core.CSharp.Tests` pass (FilterMap, Distinct, Integrate, GroupBySum, Join, ToStream)
- [x] 910/911 suite-wide pass (1 pre-existing skip unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)