### PR TITLE
feat(b-0469): civsim repo scaffolding — product-repo create-repo.ts extension

### DIFF
--- a/.github/workflows/scaffold-stage1-create-repos.yml
+++ b/.github/workflows/scaffold-stage1-create-repos.yml
@@ -1,8 +1,9 @@
 name: scaffold-stage1-create-repos
 
-# B-0424.2 — Stage 1 of the three-repo split: create LFG/Forge and LFG/ace
-# with the full best-practice checklist from
-# docs/DECISIONS/2026-04-22-three-repo-split-zeta-forge-ace.md.
+# B-0424.2 / B-0469 — Stage 1 of the three-repo split: create LFG/Forge, LFG/ace,
+# and product repos (LFG/civsim) with the full best-practice checklist from
+# docs/DECISIONS/2026-04-22-three-repo-split-zeta-forge-ace.md and
+# docs/DECISIONS/2026-05-14-product-repo-split-decisions.md.
 #
 # WHY workflow_dispatch only (no schedule):
 # This is an irreversible one-shot operation. Creating GitHub repos is
@@ -16,8 +17,9 @@ name: scaffold-stage1-create-repos
 #    repo, read:org, workflow scopes on a user with LFG org owner/admin rights.
 #    (GITHUB_TOKEN cannot create org repos — its scope is the current repo only.)
 # 3. Verify dry-run output locally first:
-#    bun tools/scaffold/create-repo.ts --repo forge --dry-run
-#    bun tools/scaffold/create-repo.ts --repo ace  --dry-run
+#    bun tools/scaffold/create-repo.ts --repo forge  --dry-run
+#    bun tools/scaffold/create-repo.ts --repo ace    --dry-run
+#    bun tools/scaffold/create-repo.ts --repo civsim --dry-run
 #
 # SECURITY (safe-pattern compliance):
 # All workflow_dispatch inputs are routed via env: into run blocks and
@@ -32,12 +34,13 @@ on:
   workflow_dispatch:
     inputs:
       repo:
-        description: "Which repo to create (forge, ace, or both)"
+        description: "Which repo to create (forge, ace, civsim, or both)"
         required: true
         type: choice
         options:
           - forge
           - ace
+          - civsim
           - both
       confirm:
         description: "Type CONFIRM (all caps) — creates real GitHub repos (irreversible)"
@@ -123,6 +126,10 @@ jobs:
             echo "--- ace ---"
             bun tools/scaffold/create-repo.ts --repo ace --dry-run
           fi
+          if [ "$REPO_INPUT" = "civsim" ]; then
+            echo "--- civsim ---"
+            bun tools/scaffold/create-repo.ts --repo civsim --dry-run
+          fi
           echo "=== END DRY-RUN ==="
 
       - name: Create Forge repo
@@ -141,6 +148,14 @@ jobs:
           set -euo pipefail
           bun tools/scaffold/create-repo.ts --repo ace --apply
 
+      - name: Create civsim repo
+        if: ${{ github.event.inputs.repo == 'civsim' }}
+        env:
+          GH_TOKEN: ${{ secrets.SCAFFOLD_STAGE1_PAT }}
+        run: |
+          set -euo pipefail
+          bun tools/scaffold/create-repo.ts --repo civsim --apply
+
       - name: Post-creation summary
         if: success()
         env:
@@ -153,17 +168,22 @@ jobs:
           echo "Manual steps remaining (create-repo.ts step 07):"
           echo "  1. Upload SVG social-preview PNG via GitHub UI"
           echo "  2. Enable merge queue: Settings → Merge queue (no REST API)"
-          echo "  3. Add Semgrep GHA inline-untrusted-in-run rule"
+          echo "  3. Add Semgrep GHA inline-untrusted-in-run rule (factory repos only)"
           echo "  4. Verify \$0 budget caps at LFG org billing settings"
           echo "  5. Confirm CodeQL default-setup: Security → Code scanning"
           echo ""
           if [ "$REPO_INPUT" = "forge" ] || [ "$REPO_INPUT" = "both" ]; then
-            echo "  Forge: https://github.com/Lucent-Financial-Group/Forge"
+            echo "  Forge:  https://github.com/Lucent-Financial-Group/Forge"
           fi
           if [ "$REPO_INPUT" = "ace" ] || [ "$REPO_INPUT" = "both" ]; then
-            echo "  ace:   https://github.com/Lucent-Financial-Group/ace"
+            echo "  ace:    https://github.com/Lucent-Financial-Group/ace"
+          fi
+          if [ "$REPO_INPUT" = "civsim" ]; then
+            echo "  civsim: https://github.com/Lucent-Financial-Group/civsim"
           fi
           echo ""
-          echo "After verifying the repos, update the ADR and close B-0424:"
+          echo "After verifying the repos, update the relevant ADR and backlog rows:"
           echo "  docs/DECISIONS/2026-04-22-three-repo-split-zeta-forge-ace.md"
+          echo "  docs/DECISIONS/2026-05-14-product-repo-split-decisions.md"
           echo "  docs/backlog/P1/B-0424-three-repo-split-stage1-create-forge-ace-with-scaffolding-aaron-2026-05-13.md"
+          echo "  docs/backlog/P1/B-0469-civsim-repo-scaffolding-2026-05-14.md"

--- a/.github/workflows/scaffold-stage1-create-repos.yml
+++ b/.github/workflows/scaffold-stage1-create-repos.yml
@@ -126,7 +126,7 @@ jobs:
             echo "--- ace ---"
             bun tools/scaffold/create-repo.ts --repo ace --dry-run
           fi
-          if [ "$REPO_INPUT" = "civsim" ]; then
+          if [ "$REPO_INPUT" = "civsim" ] || [ "$REPO_INPUT" = "both" ]; then
             echo "--- civsim ---"
             bun tools/scaffold/create-repo.ts --repo civsim --dry-run
           fi
@@ -149,7 +149,7 @@ jobs:
           bun tools/scaffold/create-repo.ts --repo ace --apply
 
       - name: Create civsim repo
-        if: ${{ github.event.inputs.repo == 'civsim' }}
+        if: ${{ github.event.inputs.repo == 'civsim' || github.event.inputs.repo == 'both' }}
         env:
           GH_TOKEN: ${{ secrets.SCAFFOLD_STAGE1_PAT }}
         run: |
@@ -178,7 +178,7 @@ jobs:
           if [ "$REPO_INPUT" = "ace" ] || [ "$REPO_INPUT" = "both" ]; then
             echo "  ace:    https://github.com/Lucent-Financial-Group/ace"
           fi
-          if [ "$REPO_INPUT" = "civsim" ]; then
+          if [ "$REPO_INPUT" = "civsim" ] || [ "$REPO_INPUT" = "both" ]; then
             echo "  civsim: https://github.com/Lucent-Financial-Group/civsim"
           fi
           echo ""

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -262,6 +262,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0466](backlog/P1/B-0466-product-repo-naming-expert-review-2026-05-14.md)** Naming-expert review for product repo names — KSK / wellness / civsim / AD2.0 / DIO / Aurora / Dawn
 - [x] **[B-0467](backlog/P1/B-0467-product-repo-cross-ref-glue-mechanism-design-2026-05-14.md)** Product-repo cross-ref glue mechanism design — how product repos reference Zeta/Forge/ace
 - [x] **[B-0468](backlog/P1/B-0468-product-repo-split-adr-2026-05-14.md)** ADR — product-repo split decisions; closes B-0425
+- [ ] **[B-0469](backlog/P1/B-0469-civsim-repo-scaffolding-2026-05-14.md)** Scaffold Lucent-Financial-Group/civsim public repo (Stage 1)
 
 ## P2 — research-grade
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -262,7 +262,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0466](backlog/P1/B-0466-product-repo-naming-expert-review-2026-05-14.md)** Naming-expert review for product repo names — KSK / wellness / civsim / AD2.0 / DIO / Aurora / Dawn
 - [x] **[B-0467](backlog/P1/B-0467-product-repo-cross-ref-glue-mechanism-design-2026-05-14.md)** Product-repo cross-ref glue mechanism design — how product repos reference Zeta/Forge/ace
 - [x] **[B-0468](backlog/P1/B-0468-product-repo-split-adr-2026-05-14.md)** ADR — product-repo split decisions; closes B-0425
-- [ ] **[B-0469](backlog/P1/B-0469-civsim-repo-scaffolding-2026-05-14.md)** Scaffold Lucent-Financial-Group/civsim public repo (Stage 1)
+- [x] **[B-0469](backlog/P1/B-0469-civsim-repo-scaffolding-2026-05-14.md)** Scaffold Lucent-Financial-Group/civsim public repo (Stage 1)
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0469-civsim-repo-scaffolding-2026-05-14.md
+++ b/docs/backlog/P1/B-0469-civsim-repo-scaffolding-2026-05-14.md
@@ -1,0 +1,104 @@
+---
+id: B-0469
+priority: P1
+status: open
+title: "Scaffold Lucent-Financial-Group/civsim public repo (Stage 1)"
+type: infrastructure
+origin: B-0468 ADR Stage 1 (Otto 2026-05-14)
+created: 2026-05-14
+last_updated: 2026-05-14
+depends_on:
+  - B-0464
+  - B-0465
+  - B-0466
+  - B-0467
+  - B-0468
+composes_with:
+  - B-0424
+  - docs/DECISIONS/2026-05-14-product-repo-split-decisions.md
+  - docs/DECISIONS/2026-05-14-product-repo-glue-mechanism.md
+  - tools/scaffold/create-repo.ts
+---
+
+# B-0469 — Scaffold Lucent-Financial-Group/civsim (Stage 1)
+
+## What this row does
+
+Execute Stage 1 of the product-repo split ADR (B-0468): scaffold the
+`Lucent-Financial-Group/civsim` public repo with the full best-practice
+checklist inherited from B-0424's by-default principle.
+
+Civsim is the only product declared **repo-ready now** in B-0465/B-0466/B-0468.
+
+## Pre-start checklist
+
+### Prior-art search
+
+- `create-repo.ts` at `tools/scaffold/create-repo.ts` covers `forge` and `ace`
+  (factory repos) — needs product-repo variant for civsim
+- `tools/scaffold/forge/` and `tools/scaffold/ace/` are the scaffold templates
+- B-0424 `REPO_CONFIGS` pattern is the extension point
+- No existing civsim scaffold directory
+- Honor-system license at `docs/legal/HONOR-SYSTEM-LICENSE-DRAFT.md` is the LICENSE template
+- ADR Stage 1 checklist is the authoritative source of truth
+
+### Dependency check
+
+- **B-0464** (closed, PR #3122) — license language ✓
+- **B-0465** (closed, PR #3124) — civsim is repo-ready-now verdict ✓
+- **B-0466** (closed, PR #3125) — approved slug: `civsim` ✓
+- **B-0467** (closed, PR #3125) — glue mechanism: `.zeta-version` pin file ✓
+- **B-0468** (closed, PR #3125) — ADR scaffold checklist ✓
+
+All dependencies satisfied. Row is unblocked.
+
+## Definition of done
+
+Extend `create-repo.ts` to support product repos (distinct from factory repos):
+
+- `civsim` added to `REPO_CONFIGS`
+- Scaffold directory `tools/scaffold/civsim/` created with:
+  - `README.md` — product carved sentence + honor-system license note
+  - `LICENSE` — honor-system text from `docs/legal/HONOR-SYSTEM-LICENSE-DRAFT.md`
+  - `.zeta-version` — pin file with current Zeta main SHA (immutable reference)
+  - `.claude/CLAUDE.md` — product-scoped bootstrap
+  - `CONTRIBUTING.md` — product-scoped contributor guidance
+- `bun tools/scaffold/create-repo.ts --repo civsim --dry-run` passes with expected operations
+- PR merged
+
+Note: the actual `--apply` invocation (which creates the real GitHub repo) is a
+human-confirmed step — it falls under "actions visible to others / affect shared state"
+(new GitHub repo). This row covers the tooling; the `--apply` step is documented
+in the PR description as a manual follow-up.
+
+## ADR scaffolding checklist (from B-0468)
+
+- [ ] Repo created: `Lucent-Financial-Group/civsim`
+- [ ] Visibility: **public** (glass-halo)
+- [ ] LICENSE: honor-system text (mutual-privacy FAQ clause)
+- [ ] `.zeta-version` pin file (immutable SHA/tag reference)
+- [ ] Branch protection on `main`: `required_conversation_resolution` + squash-only + no-force-push
+- [ ] CodeQL: enabled
+- [ ] `.claude/CLAUDE.md`: product-scoped bootstrap
+- [ ] Initial README: product carved sentence + honor-system license note
+- [ ] `repository_dispatch` subscription: wired for Zeta release-tag events
+- [ ] Claim released on bus after merge
+
+## Key differences from factory repos (forge/ace)
+
+| Property | Factory repos (forge/ace) | civsim (product repo) |
+|----------|--------------------------|----------------------|
+| License | Apache 2.0 | Honor-system |
+| Forking | Welcome | "Please don't" honor-ask; EXCEPT civsim: forks welcome, mutual-privacy clause |
+| AceHack mirror | Yes (step 05) | No (product repo; skip fork-to-AceHack) |
+| `.zeta-version` | N/A | Required (glue mechanism Stage 1) |
+| CLAUDE.md scope | Factory bootstrap | Product-scoped |
+
+## Dependency graph position
+
+```
+B-0464 → B-0468 → B-0469 (this row)
+B-0465 → B-0468 → B-0469
+B-0466 → B-0468 → B-0469
+B-0467 → B-0468 → B-0469
+```

--- a/docs/backlog/P1/B-0469-civsim-repo-scaffolding-2026-05-14.md
+++ b/docs/backlog/P1/B-0469-civsim-repo-scaffolding-2026-05-14.md
@@ -1,12 +1,14 @@
 ---
 id: B-0469
 priority: P1
-status: open
+status: closed
 title: "Scaffold Lucent-Financial-Group/civsim public repo (Stage 1)"
 type: infrastructure
 origin: B-0468 ADR Stage 1 (Otto 2026-05-14)
 created: 2026-05-14
 last_updated: 2026-05-14
+resolved: 2026-05-14
+closed_by: PR #3126
 depends_on:
   - B-0464
   - B-0465

--- a/docs/hygiene-history/ticks/2026/05/14/1029Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/1029Z.md
@@ -1,0 +1,74 @@
+# Tick shard — 2026-05-14T1029Z
+
+**Branch:** `feat/b-0469-civsim-repo-scaffolding-2026-05-14`
+**PR:** [#3126](https://github.com/Lucent-Financial-Group/Zeta/pull/3126) — open, auto-merge armed
+**Gate:** BLOCKED (CI in-progress: 14 checks, 0 failed, 0 unresolved threads) → wait-ci
+
+---
+
+## Work done this tick
+
+**B-0469 — civsim repo scaffolding tooling (Stage 1, product-repo split)**
+
+Session started with 0 open PRs (task specified 1, but it had already merged as PR #3125
+by the time the session started). Per never-be-idle discipline, picked up the next
+logical work item from the product-repo split trajectory.
+
+### What was built
+
+1. **`docs/backlog/P1/B-0469-civsim-repo-scaffolding-2026-05-14.md`** — new backlog row
+   documenting civsim scaffolding as the immediate Stage 1 action from the ADR
+
+2. **`tools/scaffold/create-repo.ts`** — extended for product repos:
+   - Added `isProduct?: boolean` field to `RepoConfig` interface
+   - Added `civsim` entry to `REPO_CONFIGS` (honor-system, no AceHack mirror)
+   - Gated step 05 (AceHack fork) on `!config.isProduct` — product repos are not
+     factory-backup candidates
+   - Added product-specific next steps to `step07_summary` (repo_dispatch wiring,
+     .zeta-version update, bus claim release)
+
+3. **`tools/scaffold/civsim/`** — 5 day-one scaffold files:
+   - `README.md` — carved sentence + fork-friendly framing (civsim is forkable)
+   - `LICENSE` — honor-system text from B-0464 (mutual-privacy clause)
+   - `.zeta-version` — Zeta main SHA pin (`eaea0682...`)
+   - `.claude/CLAUDE.md` — product-scoped bootstrap (no factory duplication)
+   - `CONTRIBUTING.md` — fork-friendly contributor guidance
+
+4. **`docs/BACKLOG.md`** regenerated to include B-0469
+
+### Verification
+
+- `bun tools/scaffold/create-repo.ts --repo civsim --dry-run` — 11 ops planned,
+  step 05 correctly skipped ✓
+- `dotnet build -c Release` — 0 warnings, 0 errors ✓
+- Existing repos (`forge`, `ace`) unaffected by changes ✓
+
+### Important note on `--apply`
+
+The actual `gh repo create` invocation requires `--apply` and creates a real
+GitHub repo (shared state, hard to reverse). This PR prepares the tooling;
+the `--apply` step is documented as a human-confirmed follow-up:
+
+```bash
+bun tools/scaffold/create-repo.ts --repo civsim --dry-run   # review
+bun tools/scaffold/create-repo.ts --repo civsim --apply     # create
+```
+
+---
+
+## 7-step verify trace
+
+1. **Speculative work** — B-0469 (Stage 1 civsim scaffolding from ADR) ✓
+2. **Verify** — dry-run 11 ops, build 0w/0e ✓
+3. **Commit** — `3d764134` on `feat/b-0469-civsim-repo-scaffolding-2026-05-14` ✓
+4. **Shard** — this file ✓
+5. **CronList** — cron re-armed at session start (job 0ddcbd3c, every minute) ✓
+6. **Visibility** — PR #3126 open, auto-merge armed ✓
+
+---
+
+## Next work
+
+- Wait for PR #3126 CI to pass (14 checks in-progress); auto-merge will close B-0469
+- After merge: `bun tools/scaffold/create-repo.ts --repo civsim --apply` (human-confirmed)
+- After `--apply`: wire `repository_dispatch` subscription (Forge CI → civsim)

--- a/tools/scaffold/civsim/.claude/CLAUDE.md
+++ b/tools/scaffold/civsim/.claude/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md — Claude Code session bootstrap for civsim
+
+Civsim is a product repo. Factory tooling, skills, and governance live in
+[Lucent-Financial-Group/Zeta](https://github.com/Lucent-Financial-Group/Zeta).
+
+## 1. Orient
+
+This repo contains civsim-specific game substrate: design docs, faction models,
+scenario specs, and product CI. Factory infrastructure is not duplicated here.
+
+Check `.zeta-version` for the Zeta commit SHA this product is pinned against.
+
+For factory-level docs, read Zeta's `AGENTS.md`, `docs/ALIGNMENT.md`,
+`docs/GLOSSARY.md`, and `GOVERNANCE.md`.
+
+## 2. What lives here vs Zeta
+
+| Content | Lives in |
+|---------|----------|
+| Game design docs | `docs/` (this repo) |
+| Faction substrate | `docs/factions/` (this repo) |
+| Scenario specs | `docs/scenarios/` (this repo) |
+| Factory skills | Zeta `.claude/skills/` |
+| Core runtime (F#) | Zeta `src/` |
+| Factory tooling | Zeta `tools/` |
+
+## 3. Zeta version pin
+
+The `.zeta-version` file contains an immutable Zeta commit SHA. To bump:
+
+```bash
+echo "<new-sha>" > .zeta-version
+git add .zeta-version && git commit -m "chore: bump Zeta pin to <short-sha>"
+```
+
+Do NOT use a branch pointer — `.zeta-version` must be immutable (SHA or release tag).
+
+## 4. Build gate
+
+```bash
+# No build target yet (pre-v1). When CI is wired, run:
+# bun test
+```
+
+## 5. Ship
+
+Set branch: `export ZETA_EXPECTED_BRANCH=<branch> && git checkout -b "$ZETA_EXPECTED_BRANCH"`
+Open PR against `main`. Arm auto-merge: `gh pr merge <N> --auto --squash`.
+
+## Conventions
+
+- **Agents, not bots** — every AI carries agency (Zeta GOVERNANCE.md §3).
+- **Glass-halo** — this repo is public by design; honor-system license governs.
+- **Civsim forks welcome** — mutual-privacy clause; forks play the game with us.
+- **Factory access via peer-call** — `bun tools/peer-call/claude.ts` from the Zeta repo.

--- a/tools/scaffold/civsim/.zeta-version
+++ b/tools/scaffold/civsim/.zeta-version
@@ -1,0 +1,1 @@
+eaea0682bd50344404c975e9d8eac4bb95e2c2bc

--- a/tools/scaffold/civsim/CONTRIBUTING.md
+++ b/tools/scaffold/civsim/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to civsim
+
+Thank you for your interest in civsim!
+
+## Quick start
+
+1. Read [`README.md`](README.md) for project context.
+2. Read [`LICENSE`](LICENSE) — this is a public repo with an honor-system license.
+3. Open an issue or draft PR describing what you want to change.
+
+## What to work on
+
+- Game design feedback and scenario ideas — open a GitHub Discussion or issue.
+- Bug reports — open an issue with reproduction steps.
+- Code contributions — pre-v1, coordinate via issue before opening a large PR.
+
+## Forking
+
+Civsim is **fork-friendly**. If you fork to build your own simulation, the
+only ask is the mutual-privacy clause: keep what you want private, as we do —
+no structural strategic advantage to either side.
+
+See [`LICENSE`](LICENSE) for the full text.
+
+## Code of conduct
+
+Be honest, be kind, play the game with us. Mutual privacy, mutual sovereignty.
+
+## Questions?
+
+Open an issue or find us at [Lucent Financial Group](https://github.com/Lucent-Financial-Group).

--- a/tools/scaffold/civsim/LICENSE
+++ b/tools/scaffold/civsim/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2026 Aaron Stainback / Lucent Financial Group
+
+This repository is public by design. Transparency, alignment-auditability,
+and independent inspection are features, not bugs.
+
+You are free to read, study, cite, and build upon the ideas and concepts
+in this repository. (For rights to copy or distribute source code, see
+file-level licenses — this honor-system text does not grant code rights.)
+
+We ask — as a matter of honesty, not legal obligation — that you please
+not fork this repository to ship competing products. We know this is not
+enforceable. We are asking because we believe in honor-system norms as a
+coordination mechanism, and because we are substrate-honest about what we
+can and cannot control.
+
+If you do fork: we hope you play the civsim with us. We hope your fork
+keeps what it wants private, just as we keep what we want private — no
+structural strategic advantage to either side. Mutual privacy and mutual
+sovereignty are the design intent.
+
+Underlying code, when present, may carry separate open-source licensing
+(e.g., Apache 2.0). Check individual files for file-level license
+declarations. This honor-system text does not override or replace any
+file-level license; it operates alongside it as a statement of intent.
+
+This honor-system ask does not create legal obligations. It is a social
+and cultural contract only.

--- a/tools/scaffold/civsim/README.md
+++ b/tools/scaffold/civsim/README.md
@@ -1,0 +1,42 @@
+# civsim
+
+**Civsim** is a turn-based civilisation simulation with AI-directed factions,
+mutual-privacy design, and Destiny-style PvP raids — built on the
+[Zeta](https://github.com/Lucent-Financial-Group/Zeta) platform.
+
+## Status
+
+**Pre-v1. No production users.**
+
+Civsim is a product of [Lucent Financial Group](https://github.com/Lucent-Financial-Group).
+Factory tooling, core skills, and the Zeta runtime live in the Zeta monorepo.
+This repo holds civsim-specific game substrate, design docs, and product CI.
+
+## What this repo contains
+
+- `docs/` — game design documents, faction substrate, scenario specs
+- `.claude/` — product-scoped Claude Code bootstrap (references Zeta for factory tools)
+- `LICENSE` — honor-system public license (forking welcome; mutual-privacy clause)
+- `.zeta-version` — pinned Zeta release SHA this product is built against
+
+## Forking
+
+Civsim is explicitly **fork-friendly**. If you fork, the only ask is the
+mutual-privacy clause in the license: keep what you want private, as we keep
+what we want private — no structural strategic advantage to either side.
+
+See [`LICENSE`](LICENSE) for the full honor-system text.
+
+## Factory connection
+
+Civsim is built on Zeta. The `.zeta-version` file pins the Zeta commit SHA
+this product is built against. Factory tools are accessed via the Zeta repo;
+this repo does not duplicate factory infrastructure.
+
+## Contributing
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## License
+
+Honor-system public license — see [`LICENSE`](LICENSE).

--- a/tools/scaffold/create-repo.test.ts
+++ b/tools/scaffold/create-repo.test.ts
@@ -36,7 +36,7 @@ interface RunResult {
   summary: string;
 }
 
-function runDryRun(repo: "forge" | "ace"): RunResult {
+function runDryRun(repo: "forge" | "ace" | "civsim"): RunResult {
   const result = spawnSync("bun", [SCRIPT, "--repo", repo, "--dry-run"], {
     encoding: "utf8",
     maxBuffer: 4 * 1024 * 1024,
@@ -242,6 +242,75 @@ describe("ace dry-run", () => {
     // Dependabot config must be present from day one (B-0424.7).
     // API enablement (steps 03b/03c) toggles the feature; this file names ecosystems.
     expect(files.some((f) => f.includes("dependabot.yml"))).toBe(true);
+  });
+});
+
+// --- civsim (product repo) ---
+
+describe("civsim dry-run", () => {
+  let result: RunResult;
+  beforeAll(() => {
+    result = runDryRun("civsim");
+  });
+
+  test("produces dryRun:true with LFG/civsim repo name", () => {
+    expect(result.dryRun).toBe(true);
+    expect(result.repo).toBe("Lucent-Financial-Group/civsim");
+  });
+
+  test("contains all 12 expected step IDs", () => {
+    const steps = result.operations.map((o) => o.step);
+    for (const expected of EXPECTED_STEPS) {
+      expect(steps).toContain(expected);
+    }
+    expect(result.operations).toHaveLength(EXPECTED_STEPS.length);
+  });
+
+  test("step 05 is skipped — product repos are not mirrored to AceHack", () => {
+    const op = result.operations.find((o) => o.step === "05-fork-to-acehack");
+    expect(op).toBeDefined();
+    expect(op!.status).toBe("skipped");
+  });
+
+  test("all non-skipped operations are planned in dry-run mode", () => {
+    for (const op of result.operations) {
+      if (op.step !== "05-fork-to-acehack") {
+        expect(op.status).toBe("planned");
+      }
+    }
+  });
+
+  test("step 06 lists civsim scaffold files — minimal product set without .semgrep.yml", () => {
+    const op = result.operations.find((o) => o.step === "06-push-scaffold-files");
+    expect(op).toBeDefined();
+    const files = (op!.data as { files: string[] }).files;
+    expect(files.some((f) => f.includes("README.md"))).toBe(true);
+    expect(files.some((f) => f.includes("LICENSE"))).toBe(true);
+    expect(files.some((f) => f.includes("CONTRIBUTING.md"))).toBe(true);
+    expect(files.some((f) => f.includes(".zeta-version"))).toBe(true);
+    // civsim scaffold intentionally omits .semgrep.yml (product repo, not factory)
+    expect(files.some((f) => f.includes(".semgrep.yml"))).toBe(false);
+  });
+
+  test("step 07 omits semgrep wiring instruction — .semgrep.yml not in civsim scaffold", () => {
+    const op = result.operations.find((o) => o.step === "07-next-steps");
+    expect(op).toBeDefined();
+    const manual = (op!.data as { manualSteps: string[] }).manualSteps;
+    expect(manual.some((s) => s.includes(".semgrep.yml"))).toBe(false);
+  });
+
+  test("step 07 includes repository_dispatch glue wiring step", () => {
+    const op = result.operations.find((o) => o.step === "07-next-steps");
+    expect(op).toBeDefined();
+    const manual = (op!.data as { manualSteps: string[] }).manualSteps;
+    expect(manual.some((s) => s.toLowerCase().includes("repository_dispatch"))).toBe(true);
+  });
+
+  test("step 07 includes B-0469 claim release with correct item ID", () => {
+    const op = result.operations.find((o) => o.step === "07-next-steps");
+    expect(op).toBeDefined();
+    const manual = (op!.data as { manualSteps: string[] }).manualSteps;
+    expect(manual.some((s) => s.includes("B-0469"))).toBe(true);
   });
 });
 

--- a/tools/scaffold/create-repo.ts
+++ b/tools/scaffold/create-repo.ts
@@ -37,6 +37,8 @@ interface RepoConfig {
   homepage?: string;
   /** Product repos skip the AceHack mirror step and use the honor-system license. */
   isProduct?: boolean;
+  /** Backlog item ID referenced in the post-creation claim-release reminder (e.g. "B-0469"). */
+  backlogItem?: string;
 }
 
 interface Operation {
@@ -80,6 +82,7 @@ const REPO_CONFIGS: Record<string, RepoConfig> = {
     description:
       "Civilisation simulation — turn-based strategy with AI-directed factions and mutual-privacy design",
     isProduct: true,
+    backlogItem: "B-0469",
   },
 };
 
@@ -545,19 +548,28 @@ function collectFiles(dir: string): string[] {
 }
 
 function step07_summary(): void {
+  // Gate the Semgrep wiring instruction on whether .semgrep.yml is actually
+  // present in the scaffold. Product repos (e.g. civsim) intentionally omit it;
+  // emitting the instruction for them would produce a runbook that fails on copy.
+  const scaffoldPath = join(SCAFFOLD_DIR, config.name);
+  const hasSemgrep = existsSync(join(scaffoldPath, ".semgrep.yml"));
+
   const baseSteps = [
     "Upload SVG social-preview PNG via GitHub UI (GitHub requires rasterized PNG format)",
     "Enable merge queue via GitHub UI: Settings → Merge queue (org feature, no API)",
-    "Wire gate workflow: add `semgrep --config .semgrep.yml --error --metrics=off` step (.semgrep.yml is in scaffold files; CI job still needs wiring in Stage 2)",
+    ...(hasSemgrep
+      ? ["Wire gate workflow: add `semgrep --config .semgrep.yml --error --metrics=off` step (.semgrep.yml is in scaffold files; CI job still needs wiring in Stage 2)"]
+      : []),
     "Add bun-test, bun-lint, codeql, scorecard as required status checks AFTER CI workflows are wired (branch protection was created with empty contexts to avoid deadlock)",
     "Verify budget caps $0 at org level: github.com/organizations/Lucent-Financial-Group/settings/billing",
     "Confirm CodeQL default-setup is active: Security → Code scanning → Default setup",
   ];
+  const claimItem = config.backlogItem ?? "<B-NNNN>";
   const productSteps = config.isProduct
     ? [
         "Wire repository_dispatch subscription: configure Forge CI to emit release-tag events to this repo (glue mechanism Stage 1, per ADR 2026-05-14-product-repo-glue-mechanism.md)",
         "Update .zeta-version pin file to the actual current Zeta main SHA after repo creation",
-        "Release bus claim: bun tools/bus/claim.ts release --from otto --item B-0469",
+        `Release bus claim: bun tools/bus/claim.ts release --from <agent> --item ${claimItem}`,
       ]
     : [];
   plan(

--- a/tools/scaffold/create-repo.ts
+++ b/tools/scaffold/create-repo.ts
@@ -1,17 +1,18 @@
 #!/usr/bin/env bun
 // create-repo.ts — scaffolds a new GitHub repo with B-0424 best-practice settings.
 //
-// Implements Stage 1 of the three-repo split (ADR 2026-04-22). Applies
-// the full best-practice checklist: merge settings, branch protection,
-// security scanning, CodeQL default-setup, Dependabot, spending-cap
-// verification (manual step), and day-one governance files from
-// tools/scaffold/<repoName>/.
+// Implements Stage 1 of the three-repo split (ADR 2026-04-22) and the
+// product-repo split (ADR 2026-05-14). Applies the full best-practice checklist:
+// merge settings, branch protection, security scanning, CodeQL default-setup,
+// Dependabot, spending-cap verification (manual step), and day-one governance
+// files from tools/scaffold/<repoName>/.
 //
 // Usage:
-//   bun tools/scaffold/create-repo.ts --repo forge --dry-run   # preview (default)
-//   bun tools/scaffold/create-repo.ts --repo ace  --dry-run
-//   bun tools/scaffold/create-repo.ts --repo forge --apply     # create for real
-//   bun tools/scaffold/create-repo.ts --repo ace  --apply
+//   bun tools/scaffold/create-repo.ts --repo forge  --dry-run   # preview (default)
+//   bun tools/scaffold/create-repo.ts --repo ace    --dry-run
+//   bun tools/scaffold/create-repo.ts --repo civsim --dry-run
+//   bun tools/scaffold/create-repo.ts --repo forge  --apply     # create for real
+//   bun tools/scaffold/create-repo.ts --repo civsim --apply
 //
 // Requires:
 //   gh CLI authenticated with: repo, read:org, workflow scopes
@@ -34,6 +35,8 @@ interface RepoConfig {
   name: string;
   description: string;
   homepage?: string;
+  /** Product repos skip the AceHack mirror step and use the honor-system license. */
+  isProduct?: boolean;
 }
 
 interface Operation {
@@ -55,6 +58,7 @@ interface RunResult {
 // --- Config ---
 
 const REPO_CONFIGS: Record<string, RepoConfig> = {
+  // Factory-infrastructure repos — Apache 2.0, forking welcome, AceHack mirror
   forge: {
     org: "Lucent-Financial-Group",
     name: "Forge",
@@ -67,6 +71,15 @@ const REPO_CONFIGS: Record<string, RepoConfig> = {
     name: "ace",
     description:
       "Package manager for the Lucent Financial Group software stack",
+  },
+  // Product repos — honor-system license, no AceHack mirror
+  // See ADR: docs/DECISIONS/2026-05-14-product-repo-split-decisions.md
+  civsim: {
+    org: "Lucent-Financial-Group",
+    name: "civsim",
+    description:
+      "Civilisation simulation — turn-based strategy with AI-directed factions and mutual-privacy design",
+    isProduct: true,
   },
 };
 
@@ -377,6 +390,17 @@ function step04_codeqlDefaultSetup(): void {
 }
 
 function step05_forkToAcehack(): void {
+  // Product repos are NOT mirrored to AceHack — AceHack is the factory backup
+  // mirror only. Per ADR 2026-05-14-product-repo-split-decisions.md.
+  if (config.isProduct) {
+    plan(
+      "05-fork-to-acehack",
+      `Skipped — product repos are not mirrored to ${FORK_ORG} (factory repos only)`,
+      "",
+      {}
+    ).status = "skipped";
+    return;
+  }
   const op = plan(
     "05-fork-to-acehack",
     `Fork ${config.org}/${config.name} → ${FORK_ORG}/${config.name}`,
@@ -521,20 +545,26 @@ function collectFiles(dir: string): string[] {
 }
 
 function step07_summary(): void {
+  const baseSteps = [
+    "Upload SVG social-preview PNG via GitHub UI (GitHub requires rasterized PNG format)",
+    "Enable merge queue via GitHub UI: Settings → Merge queue (org feature, no API)",
+    "Wire gate workflow: add `semgrep --config .semgrep.yml --error --metrics=off` step (.semgrep.yml is in scaffold files; CI job still needs wiring in Stage 2)",
+    "Add bun-test, bun-lint, codeql, scorecard as required status checks AFTER CI workflows are wired (branch protection was created with empty contexts to avoid deadlock)",
+    "Verify budget caps $0 at org level: github.com/organizations/Lucent-Financial-Group/settings/billing",
+    "Confirm CodeQL default-setup is active: Security → Code scanning → Default setup",
+  ];
+  const productSteps = config.isProduct
+    ? [
+        "Wire repository_dispatch subscription: configure Forge CI to emit release-tag events to this repo (glue mechanism Stage 1, per ADR 2026-05-14-product-repo-glue-mechanism.md)",
+        "Update .zeta-version pin file to the actual current Zeta main SHA after repo creation",
+        "Release bus claim: bun tools/bus/claim.ts release --from otto --item B-0469",
+      ]
+    : [];
   plan(
     "07-next-steps",
     "Manual steps required after this tool completes",
     "",
-    {
-      manualSteps: [
-        "Upload SVG social-preview PNG via GitHub UI (GitHub requires rasterized PNG format)",
-        "Enable merge queue via GitHub UI: Settings → Merge queue (org feature, no API)",
-        "Wire gate workflow: add `semgrep --config .semgrep.yml --error --metrics=off` step (.semgrep.yml is in scaffold files; CI job still needs wiring in Stage 2)",
-        "Add bun-test, bun-lint, codeql, scorecard as required status checks AFTER CI workflows are wired (branch protection was created with empty contexts to avoid deadlock)",
-        "Verify budget caps $0 at org level: github.com/organizations/Lucent-Financial-Group/settings/billing",
-        "Confirm CodeQL default-setup is active: Security → Code scanning → Default setup",
-      ],
-    }
+    { manualSteps: [...baseSteps, ...productSteps] }
   ).status = "planned";
 }
 

--- a/tools/scaffold/create-repo.ts
+++ b/tools/scaffold/create-repo.ts
@@ -551,7 +551,9 @@ function step07_summary(): void {
   // Gate the Semgrep wiring instruction on whether .semgrep.yml is actually
   // present in the scaffold. Product repos (e.g. civsim) intentionally omit it;
   // emitting the instruction for them would produce a runbook that fails on copy.
-  const scaffoldPath = join(SCAFFOLD_DIR, config.name);
+  // Use repoArg (the CLI key, e.g. "forge") not config.name (e.g. "Forge") so the
+  // directory lookup matches the on-disk scaffold path structure.
+  const scaffoldPath = join(SCAFFOLD_DIR, repoArg as string);
   const hasSemgrep = existsSync(join(scaffoldPath, ".semgrep.yml"));
 
   const baseSteps = [


### PR DESCRIPTION
## Summary

- Extends `tools/scaffold/create-repo.ts` to support product repos via `isProduct` flag — gates AceHack mirror step (step 05) so product repos are NOT mirrored to AceHack (factory repos only)
- Adds `civsim` to `REPO_CONFIGS` as first product repo (honor-system license, fork-friendly, mutual-privacy clause)
- Creates `tools/scaffold/civsim/` with 5 day-one scaffold files: README, LICENSE (honor-system), `.zeta-version` (Zeta pin), `.claude/CLAUDE.md` (product-scoped), CONTRIBUTING
- Adds `docs/backlog/P1/B-0469-civsim-repo-scaffolding-2026-05-14.md` backlog row

**Closes B-0469.** Implements Stage 1 of `docs/DECISIONS/2026-05-14-product-repo-split-decisions.md`.

## Dry-run verified

```
bun tools/scaffold/create-repo.ts --repo civsim --dry-run
```

11 operations planned. Step 05 (AceHack fork) correctly shows `"status": "skipped"` with reason. Build gate: 0 warnings, 0 errors.

## ⚠️ Manual follow-up required

The actual repo creation requires `--apply` — this creates a real GitHub repo (shared state, hard to reverse):

```bash
# Review dry-run first:
bun tools/scaffold/create-repo.ts --repo civsim --dry-run

# When ready, create the repo:
bun tools/scaffold/create-repo.ts --repo civsim --apply
```

After `--apply`:
1. Wire `repository_dispatch` subscription (Forge CI → civsim)
2. Upload social-preview PNG via GitHub UI
3. Enable merge queue via GitHub UI
4. Confirm CodeQL default-setup is active

## Test plan

- [x] `bun tools/scaffold/create-repo.ts --repo civsim --dry-run` — 11 ops planned, step 05 skipped ✓
- [x] `bun tools/scaffold/create-repo.ts --repo forge --dry-run` — existing factory repo unaffected ✓
- [x] `bun tools/scaffold/create-repo.ts --repo ace --dry-run` — existing factory repo unaffected ✓
- [x] `dotnet build -c Release` — 0 warnings, 0 errors ✓

🤖 Generated with [Claude Code](https://claude.ai/claude-code)