### PR TITLE
feat(b-0469): execute civsim --apply — LFG/civsim live + B-0470 filed

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -263,6 +263,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0467](backlog/P1/B-0467-product-repo-cross-ref-glue-mechanism-design-2026-05-14.md)** Product-repo cross-ref glue mechanism design — how product repos reference Zeta/Forge/ace
 - [x] **[B-0468](backlog/P1/B-0468-product-repo-split-adr-2026-05-14.md)** ADR — product-repo split decisions; closes B-0425
 - [x] **[B-0469](backlog/P1/B-0469-civsim-repo-scaffolding-2026-05-14.md)** Scaffold Lucent-Financial-Group/civsim public repo (Stage 1)
+- [ ] **[B-0470](backlog/P1/B-0470-civsim-zeta-version-pin-bump-2026-05-14.md)** Bump civsim .zeta-version from scaffold-template SHA to apply-time Zeta main SHA
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0469-civsim-repo-scaffolding-2026-05-14.md
+++ b/docs/backlog/P1/B-0469-civsim-repo-scaffolding-2026-05-14.md
@@ -75,16 +75,18 @@ in the PR description as a manual follow-up.
 
 ## ADR scaffolding checklist (from B-0468)
 
-- [ ] Repo created: `Lucent-Financial-Group/civsim`
-- [ ] Visibility: **public** (glass-halo)
-- [ ] LICENSE: honor-system text (mutual-privacy FAQ clause)
-- [ ] `.zeta-version` pin file (immutable SHA/tag reference)
-- [ ] Branch protection on `main`: `required_conversation_resolution` + squash-only + no-force-push
-- [ ] CodeQL: enabled
-- [ ] `.claude/CLAUDE.md`: product-scoped bootstrap
-- [ ] Initial README: product carved sentence + honor-system license note
-- [ ] `repository_dispatch` subscription: wired for Zeta release-tag events
-- [ ] Claim released on bus after merge
+**`--apply` executed 2026-05-14T10:52Z by Otto (this session):**
+
+- [x] Repo created: `Lucent-Financial-Group/civsim` — https://github.com/Lucent-Financial-Group/civsim
+- [x] Visibility: **public** (glass-halo)
+- [x] LICENSE: honor-system text (mutual-privacy FAQ clause)
+- [x] `.zeta-version` pin file — pushed as `eaea0682...` (Zeta main at scaffold-template time); follow-up B-0470 bumps to `ce5c4101...` (Zeta main at apply-time)
+- [x] Branch protection on `main`: `required_conversation_resolution` + squash-only + no-force-push
+- [x] CodeQL: enabled (default-setup via API)
+- [x] `.claude/CLAUDE.md`: product-scoped bootstrap
+- [x] Initial README: product carved sentence + honor-system license note
+- [ ] `repository_dispatch` subscription: wired for Zeta release-tag events (glue mechanism; manual Forge CI config — pending when Forge ships)
+- [ ] Claim released on bus — pending PR merge
 
 ## Key differences from factory repos (forge/ace)
 

--- a/docs/backlog/P1/B-0470-civsim-zeta-version-pin-bump-2026-05-14.md
+++ b/docs/backlog/P1/B-0470-civsim-zeta-version-pin-bump-2026-05-14.md
@@ -1,0 +1,59 @@
+---
+id: B-0470
+priority: P1
+status: open
+title: "Bump civsim .zeta-version from scaffold-template SHA to apply-time Zeta main SHA"
+type: chore
+origin: B-0469 apply completion — 1-commit drift between scaffold-template time and apply-time
+created: 2026-05-14
+last_updated: 2026-05-14
+depends_on: [B-0469]
+composes_with:
+  - docs/DECISIONS/2026-05-14-product-repo-glue-mechanism.md
+  - docs/DECISIONS/2026-05-14-product-repo-split-decisions.md
+---
+
+# B-0470 — Bump civsim `.zeta-version` to apply-time Zeta main SHA
+
+## Context
+
+When `bun tools/scaffold/create-repo.ts --repo civsim --apply` ran (2026-05-14T10:52Z),
+the scaffold template's `.zeta-version` file contained the SHA at PR #3125 merge time
+(`eaea0682bd50344404c975e9d8eac4bb95e2c2bc`). The actual Zeta main at apply-time was
+one commit ahead (`ce5c4101e9d3d78550215cc5ef8152cffb63b8cc`, PR #3126 merge).
+
+Per the ADR: "Update .zeta-version pin file to the actual current Zeta main SHA after
+repo creation."
+
+## What this row does
+
+Open a PR on `Lucent-Financial-Group/civsim` that bumps `.zeta-version`:
+
+```
+eaea0682bd50344404c975e9d8eac4bb95e2c2bc
+```
+
+→
+
+```
+ce5c4101e9d3d78550215cc5ef8152cffb63b8cc
+```
+
+## Done criteria
+
+- PR opened on `Lucent-Financial-Group/civsim` with the 1-line `.zeta-version` bump
+- PR merged (requires 1 review per branch protection)
+- `.zeta-version` in civsim/main reflects Zeta HEAD at apply-time
+
+## Notes
+
+- Branch protection on civsim requires 1 approving review — this is a quick PR
+- This is a low-urgency chore; the 1-commit difference has no functional impact
+- The `.zeta-version` will next be bumped when the first Zeta release tag is emitted
+  (glue mechanism Stage 1)
+
+## Pre-start checklist
+
+- Prior art: no existing `.zeta-version` bump row; this is the first one
+- Dependency: B-0469 completed (civsim repo exists) ✓
+- No blocking dependencies

--- a/docs/backlog/P1/B-0470-civsim-zeta-version-pin-bump-2026-05-14.md
+++ b/docs/backlog/P1/B-0470-civsim-zeta-version-pin-bump-2026-05-14.md
@@ -8,9 +8,7 @@ origin: B-0469 apply completion — 1-commit drift between scaffold-template tim
 created: 2026-05-14
 last_updated: 2026-05-14
 depends_on: [B-0469]
-composes_with:
-  - docs/DECISIONS/2026-05-14-product-repo-glue-mechanism.md
-  - docs/DECISIONS/2026-05-14-product-repo-split-decisions.md
+composes_with: []
 ---
 
 # B-0470 — Bump civsim `.zeta-version` to apply-time Zeta main SHA
@@ -51,6 +49,11 @@ ce5c4101e9d3d78550215cc5ef8152cffb63b8cc
 - This is a low-urgency chore; the 1-commit difference has no functional impact
 - The `.zeta-version` will next be bumped when the first Zeta release tag is emitted
   (glue mechanism Stage 1)
+
+## Related
+
+- [Product-repo glue mechanism ADR](../../DECISIONS/2026-05-14-product-repo-glue-mechanism.md)
+- [Product-repo split decisions ADR](../../DECISIONS/2026-05-14-product-repo-split-decisions.md)
 
 ## Pre-start checklist
 

--- a/docs/hygiene-history/ticks/2026/05/14/1055Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/1055Z.md
@@ -4,11 +4,11 @@
 
 ## Verify trace
 
-1. **Worldview refresh**: `bun tools/github/refresh-worldview.ts` → 0 open PRs, 5 recent merges (PR #3126 newest: civsim scaffolding tooling). 
+1. **Worldview refresh**: `bun tools/github/refresh-worldview.ts` → 0 open PRs, 5 recent merges (PR #3126 newest: civsim scaffolding tooling).
 2. **Holding discipline**: 0 open PRs; `poll-pr-gate-batch --all-open` confirmed `count: 0`. No BLOCKED+resolve-threads work. Proceeded to next backlog item.
 3. **Picked work**: B-0469 `--apply` step — the manual follow-up from PR #3126 that creates the actual `Lucent-Financial-Group/civsim` GitHub repo.
 4. **Build gate**: `dotnet build -c Release` → 0 warnings, 0 errors ✓
-5. **Executed**: 
+5. **Executed**:
    - `bun tools/scaffold/create-repo.ts --repo civsim --dry-run` → 11 ops planned, step 05 (AceHack fork) correctly skipped ✓
    - `bun tools/bus/claim.ts acquire --from otto --item B-0469` → claimed ✓
    - `bun tools/scaffold/create-repo.ts --repo civsim --apply` → 10 executed, 0 failed ✓

--- a/docs/hygiene-history/ticks/2026/05/14/1055Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/1055Z.md
@@ -1,0 +1,44 @@
+| tick | agent | outcome | PR |
+|------|-------|---------|-----|
+| 2026-05-14T10:55Z | Otto (worktree harmonic-napping-pillow) | civsim repo `--apply` completed; B-0469 checklist updated; B-0470 filed | pending |
+
+## Verify trace
+
+1. **Worldview refresh**: `bun tools/github/refresh-worldview.ts` → 0 open PRs, 5 recent merges (PR #3126 newest: civsim scaffolding tooling). 
+2. **Holding discipline**: 0 open PRs; `poll-pr-gate-batch --all-open` confirmed `count: 0`. No BLOCKED+resolve-threads work. Proceeded to next backlog item.
+3. **Picked work**: B-0469 `--apply` step — the manual follow-up from PR #3126 that creates the actual `Lucent-Financial-Group/civsim` GitHub repo.
+4. **Build gate**: `dotnet build -c Release` → 0 warnings, 0 errors ✓
+5. **Executed**: 
+   - `bun tools/scaffold/create-repo.ts --repo civsim --dry-run` → 11 ops planned, step 05 (AceHack fork) correctly skipped ✓
+   - `bun tools/bus/claim.ts acquire --from otto --item B-0469` → claimed ✓
+   - `bun tools/scaffold/create-repo.ts --repo civsim --apply` → 10 executed, 0 failed ✓
+   - Repo live: https://github.com/Lucent-Financial-Group/civsim (PUBLIC)
+6. **Follow-up**: `.zeta-version` in civsim contains `eaea0682` (scaffold-template time); apply-time Zeta main is `ce5c4101`. Filed B-0470 to track the 1-line bump PR on civsim.
+7. **Shard written** (this file).
+8. **CronList**: confirmed cron job dde500fb active (re-armed at session start).
+
+## What shipped
+
+- `Lucent-Financial-Group/civsim` repo created public with full ADR scaffolding:
+  - LICENSE (honor-system, mutual-privacy clause)
+  - README.md (carved sentence + honor-system note)
+  - CONTRIBUTING.md
+  - `.zeta-version` pin file
+  - `.claude/CLAUDE.md` (product-scoped bootstrap)
+  - Branch protection: squash-only, no-force-push, required_conversation_resolution, 1 review required
+  - Secret scanning + push protection enabled
+  - Dependabot alerts + security updates enabled
+  - Private vulnerability reporting enabled
+  - CodeQL default-setup configured
+  - AceHack fork: correctly skipped (product repos not mirrored)
+
+## Remaining manual steps (post-apply; deferred to human or later rows)
+
+- Upload social-preview PNG via GitHub UI
+- Enable merge queue via GitHub UI
+- Wire `repository_dispatch` subscription (Forge CI → civsim; when Forge ships)
+- B-0470: bump `.zeta-version` from `eaea0682` → `ce5c4101` (1-line PR on civsim)
+
+## Auto-merge
+
+PR to be opened for this shard + B-0469/B-0470 docs.

--- a/docs/hygiene-history/ticks/2026/05/14/1055Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/1055Z.md
@@ -1,5 +1,3 @@
-| tick | agent | outcome | PR |
-|------|-------|---------|-----|
 | 2026-05-14T10:55Z | Otto (worktree harmonic-napping-pillow) | civsim repo `--apply` completed; B-0469 checklist updated; B-0470 filed | pending |
 
 ## Verify trace


### PR DESCRIPTION
## Summary

- **Executed** `bun tools/scaffold/create-repo.ts --repo civsim --apply` — 10/10 ops, 0 failed
- **`Lucent-Financial-Group/civsim` is now live**: https://github.com/Lucent-Financial-Group/civsim (PUBLIC)
- Full ADR scaffolding applied per `docs/DECISIONS/2026-05-14-product-repo-split-decisions.md`
- **B-0469 checklist updated**: all automated steps checked off; manual deferred steps noted
- **B-0470 filed**: 1-line `.zeta-version` bump chore (eaea0682 → ce5c4101, low-urgency)

## What shipped to civsim

| Item | Status |
|------|--------|
| Repo created (public) | ✅ |
| LICENSE (honor-system + mutual-privacy clause) | ✅ |
| README.md (carved sentence + honor-system note) | ✅ |
| CONTRIBUTING.md | ✅ |
| `.zeta-version` pin file | ✅ (contains eaea0682; B-0470 bumps to ce5c4101) |
| `.claude/CLAUDE.md` (product-scoped bootstrap) | ✅ |
| Branch protection (squash-only, no-force-push, required_conversation_resolution, 1 review) | ✅ |
| Secret scanning + push protection | ✅ |
| Dependabot alerts + security updates | ✅ |
| Private vulnerability reporting | ✅ |
| CodeQL default-setup | ✅ |
| AceHack fork | ✅ skipped (product repos not mirrored) |

## Manual steps remaining (deferred)

- Upload social-preview PNG via GitHub UI
- Enable merge queue via GitHub UI
- Wire `repository_dispatch` subscription (Forge CI → civsim; when Forge ships)
- B-0470: bump `.zeta-version` 1-line PR on civsim repo

## Test plan

- [x] `bun tools/scaffold/create-repo.ts --repo civsim --dry-run` verified before apply ✓
- [x] `gh repo view Lucent-Financial-Group/civsim` — name, url, visibility=PUBLIC ✓
- [x] `dotnet build -c Release` — 0 warnings, 0 errors ✓

🤖 Generated with [Claude Code](https://claude.ai/claude-code)