### PR TITLE
decompose(b-0429): end-user persona mapping — 9 atomic child rows B-0485..B-0493

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -278,6 +278,15 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0482](backlog/P1/B-0482-dbpedia-sparql-fsharp-ce-computation-expression-2026-05-14.md)** DBpedia B-0428.3 — SPARQL F# computation expression (query authoring CE)
 - [ ] **[B-0483](backlog/P1/B-0483-dbpedia-hkt-mdm-entity-bindings-dv2-hub-satellite-2026-05-14.md)** DBpedia B-0428.4 — HKT-MDM entity bindings + DV2.0 hub-satellite types
 - [ ] **[B-0484](backlog/P1/B-0484-dbpedia-end-to-end-demo-project-2026-05-14.md)** DBpedia B-0428.5 — end-to-end demo project + integration test
+- [ ] **[B-0485](backlog/P1/B-0485-persona-mapping-framework-template-substrate-inventory-2026-05-14.md)** B-0429.1 — Persona-mapping framework: define per-persona template + audit existing persona substrate
+- [ ] **[B-0486](backlog/P1/B-0486-civsim-persona-map-2026-05-14.md)** B-0429.2 — Civsim persona map
+- [ ] **[B-0487](backlog/P1/B-0487-aurora-persona-map-2026-05-14.md)** B-0429.3 — Aurora persona map
+- [ ] **[B-0488](backlog/P1/B-0488-ksk-persona-map-2026-05-14.md)** B-0429.4 — KSK (Kinetic Safeguard Kernel) persona map
+- [ ] **[B-0489](backlog/P1/B-0489-wellness-app-persona-map-2026-05-14.md)** B-0429.5 — Wellness app persona map
+- [ ] **[B-0490](backlog/P1/B-0490-american-dream-dio-persona-map-2026-05-14.md)** B-0429.6 — American Dream 2.0 + DIO persona map
+- [ ] **[B-0491](backlog/P1/B-0491-dawn-universal-biz-templates-persona-map-2026-05-14.md)** B-0429.7 — Dawn + Universal business templates persona map
+- [ ] **[B-0492](backlog/P1/B-0492-cross-product-persona-reuse-refused-registry-2026-05-14.md)** B-0429.8 — Cross-product persona reuse map + refused-personas registry
+- [ ] **[B-0493](backlog/P1/B-0493-skill-catalog-persona-crossref-2026-05-14.md)** B-0429.9 — Skill catalog × persona cross-reference
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0429-end-user-persona-mapping-product-team-multiple-products-multiple-personas-each-aaron-2026-05-13.md
+++ b/docs/backlog/P1/B-0429-end-user-persona-mapping-product-team-multiple-products-multiple-personas-each-aaron-2026-05-13.md
@@ -8,7 +8,7 @@ ask: Aaron 2026-05-13 — *"end users need to map personas backlog for prducot t
 created: 2026-05-13
 last_updated: 2026-05-14
 decomposed_by: Otto, 2026-05-14
-child_rows:
+children:
   - B-0485
   - B-0486
   - B-0487

--- a/docs/backlog/P1/B-0429-end-user-persona-mapping-product-team-multiple-products-multiple-personas-each-aaron-2026-05-13.md
+++ b/docs/backlog/P1/B-0429-end-user-persona-mapping-product-team-multiple-products-multiple-personas-each-aaron-2026-05-13.md
@@ -1,12 +1,23 @@
 ---
 id: B-0429
 priority: P1
-status: open
+status: decomposed
 title: "End-user persona mapping — product team — multiple products × multiple personas each"
 type: planning
 ask: Aaron 2026-05-13 — *"end users need to map personas backlog for prducot team we have mtiple differnt end users and need to clarity all our expected humans personas we also have several products that have several personas each"*
 created: 2026-05-13
-last_updated: 2026-05-13
+last_updated: 2026-05-14
+decomposed_by: Otto, 2026-05-14
+child_rows:
+  - B-0485
+  - B-0486
+  - B-0487
+  - B-0488
+  - B-0489
+  - B-0490
+  - B-0491
+  - B-0492
+  - B-0493
 composes_with: [B-0424, B-0425, B-0426, B-0427, B-0428, B-0043]
 ---
 
@@ -207,3 +218,55 @@ When designing skills or features for end users:
 4. **Apply HARD LIMITS** at persona scope
 5. **Compose with substrate-honest framing** (don't pretend
    product serves personas it doesn't)
+
+## Decomposition record (Otto, 2026-05-14)
+
+B-0429 decomposed into 9 dependency-ordered atomic child rows.
+
+### Dependency graph
+
+```
+B-0485 (gate: template + inventory)
+  ├── B-0486 (Civsim persona map)         ─┐
+  ├── B-0487 (Aurora persona map)          │
+  ├── B-0488 (KSK persona map)             ├─ parallel; all depend on B-0485
+  ├── B-0489 (Wellness persona map)        │
+  ├── B-0490 (AD 2.0 + DIO persona map)   │
+  └── B-0491 (Dawn + Univ biz personas)  ─┘
+                  │
+                  ▼
+          B-0492 (cross-product reuse + refused-personas registry)
+                  │
+                  ▼
+          B-0493 (skill catalog × persona cross-reference)
+```
+
+### Child rows
+
+| ID | Title | Type | Depends on | Status |
+|----|-------|------|------------|--------|
+| B-0485 | Persona-mapping framework + substrate inventory | research (gate) | — | open |
+| B-0486 | Civsim persona map | planning | B-0485 | open |
+| B-0487 | Aurora persona map | planning | B-0485 | open |
+| B-0488 | KSK persona map | planning | B-0485 | open |
+| B-0489 | Wellness app persona map | planning | B-0485 | open |
+| B-0490 | American Dream 2.0 + DIO persona map | planning | B-0485 | open |
+| B-0491 | Dawn + Universal biz templates persona map | planning | B-0485 | open |
+| B-0492 | Cross-product persona reuse + refused-personas registry | planning | B-0486..B-0491 | open |
+| B-0493 | Skill catalog × persona cross-reference | planning | B-0492 | open |
+
+### Prior-art search completed
+
+- Existing `memory/user_*.md` files: Aaron, Elizabeth — persona substrate found
+- Aurora pitch (PR #2924): implicit personas identified (BTC ecosystem, edge operators, ombud, liaison)
+- Imagination Circle (PR #2893): family-AI persona substrate found
+- Center-First Playbook (PR #2894): Mom + family personas found
+- Parenting history (PR #2900): Aaron's kids personas found
+- PR #2902: Aaron's grey-hat security expert persona found
+- WONT-DO.md: no persona-mapping refusals found
+
+### Dependency restructure
+
+- B-0424, B-0425, B-0426, B-0427, B-0428, B-0043: `composes_with:` verified in frontmatter
+- PR #2933 (ships-with-skills): verified as key motivation for B-0493
+- PR #2893 PEC v0.1 + Charter v0.2: mandatory for Dawn (B-0491) consent-first personas

--- a/docs/backlog/P1/B-0485-persona-mapping-framework-template-substrate-inventory-2026-05-14.md
+++ b/docs/backlog/P1/B-0485-persona-mapping-framework-template-substrate-inventory-2026-05-14.md
@@ -75,6 +75,7 @@ role: "<1-sentence role description>"
 ```
 
 Body sections:
+
 - **Capabilities they bring** (technical fluency, domain expertise)
 - **Context of use** (when / where / why they engage)
 - **Value proposition** (what changes for them)

--- a/docs/backlog/P1/B-0485-persona-mapping-framework-template-substrate-inventory-2026-05-14.md
+++ b/docs/backlog/P1/B-0485-persona-mapping-framework-template-substrate-inventory-2026-05-14.md
@@ -1,0 +1,113 @@
+---
+id: B-0485
+priority: P1
+status: open
+title: "B-0429.1 — Persona-mapping framework: define per-persona template + audit existing persona substrate"
+type: research
+origin: B-0429 decomposition (Otto, 2026-05-14)
+created: 2026-05-14
+last_updated: 2026-05-14
+parent: B-0429
+depends_on: []
+composes_with:
+  - B-0429
+  - B-0486
+  - B-0487
+  - B-0488
+  - B-0489
+  - B-0490
+  - B-0491
+  - B-0492
+  - B-0493
+  - memory/user_aaron_kenji_naming_practice_this_factory_claude_instance_2026_04_22.md
+  - memory/user_sister_elizabeth.md
+---
+
+# B-0485 — Persona-mapping framework: template definition + substrate inventory
+
+**Gate row for B-0486..B-0491.** No per-product persona-map work begins until
+this row closes.
+
+## Purpose
+
+Define the canonical per-persona capture template and inventory all existing
+persona substrate across the repo. This gives every subsequent product row
+(B-0486..B-0491) a consistent schema and avoids duplicating or contradicting
+existing work.
+
+## Pre-start checklist
+
+Per `.claude/rules/backlog-item-start-gate.md`:
+
+- [ ] Survey `memory/user_*.md` files for existing persona substrate
+- [ ] Read Aurora pitch (PR #2924) for implicit persona enumeration
+- [ ] Read Imagination Circle substrate (PR #2893) for family-AI personas
+- [ ] Read Center-First Playbook (PR #2894) for Mom + family member personas
+- [ ] Read parenting-history substrate (PR #2900) for Aaron's kids personas
+- [ ] Walk `composes_with:` chain (B-0429 → B-0424 → B-0425)
+- [ ] Otto-364: check WONT-DO.md for any refused persona-mapping work
+
+## Existing persona substrate to inventory
+
+| Source | Path | Persona(s) implied |
+|--------|------|--------------------|
+| Aaron user memory | `memory/user_aaron_kenji_naming_practice_*` | Aaron — edge-runner maintainer |
+| Elizabeth memory | `memory/user_sister_elizabeth.md` | Elizabeth — terminal-purpose persona |
+| Imagination Circle | PR #2893 substrate | Family AI: parents + children |
+| Center-First Playbook | PR #2894 | Mom + family members |
+| Parenting history | PR #2900 | Aaron's kids personas |
+| Aurora pitch | PR #2924 | BTC ecosystem operators, edge operators, ombud, liaison |
+| Agent roster | `.claude/rules/agent-roster-reference-card.md` | AI agents (complementary axis; NOT end-user) |
+| Grey-hat security | PR #2902 | Security expert persona (Aaron) |
+
+## Per-persona capture template (to be defined)
+
+The output of this row is a canonical YAML-frontmatter template plus a short
+markdown body scaffold that every product-persona doc (B-0486..B-0491) will
+use. Minimum fields:
+
+```yaml
+persona_id: <product>-<slug>
+product: <product name>
+persona_type: primary | secondary | adjacent | refused
+name: "<descriptive handle>"
+role: "<1-sentence role description>"
+```
+
+Body sections:
+- **Capabilities they bring** (technical fluency, domain expertise)
+- **Context of use** (when / where / why they engage)
+- **Value proposition** (what changes for them)
+- **Substrate-honest limits** (where the product doesn't serve them)
+- **HARD LIMITS check** (refused-persona signal per `.claude/rules/methodology-hard-limits.md`)
+- **Composes with personas** (cross-persona references)
+
+## Output
+
+A research document at:
+
+```
+docs/research/2026-05-14-persona-mapping-framework-b0485.md
+```
+
+Containing:
+
+1. Canonical per-persona template (YAML + markdown scaffold)
+2. Inventory of all existing persona substrate found
+3. Conflicts or gaps identified
+4. Substrate-ready signal: "B-0486..B-0491 can begin"
+
+## Definition of done
+
+- [ ] Per-persona capture template defined and documented
+- [ ] All existing persona substrate inventoried (table complete)
+- [ ] Conflicts / stale references flagged
+- [ ] Output doc committed at canonical path
+- [ ] B-0486..B-0491 unblocked (no remaining template ambiguity)
+- [ ] B-0485 status set to `closed` with PR link
+
+## Why P1 / gate
+
+All six per-product rows (B-0486..B-0491) depend on a consistent template.
+Without it, per-product docs will diverge in schema, making B-0492
+(cross-product synthesis) expensive to merge.

--- a/docs/backlog/P1/B-0486-civsim-persona-map-2026-05-14.md
+++ b/docs/backlog/P1/B-0486-civsim-persona-map-2026-05-14.md
@@ -55,6 +55,7 @@ docs/personas/civsim-personas.md
 ```
 
 With:
+
 - Primary / secondary / adjacent / refused persona entries (template schema)
 - HARD LIMITS check for refused personas
 - Substrate references for each persona (which PR/memory supports it)

--- a/docs/backlog/P1/B-0486-civsim-persona-map-2026-05-14.md
+++ b/docs/backlog/P1/B-0486-civsim-persona-map-2026-05-14.md
@@ -1,0 +1,75 @@
+---
+id: B-0486
+priority: P1
+status: open
+title: "B-0429.2 — Civsim persona map"
+type: planning
+origin: B-0429 decomposition (Otto, 2026-05-14)
+created: 2026-05-14
+last_updated: 2026-05-14
+parent: B-0429
+depends_on:
+  - B-0485
+composes_with:
+  - B-0429
+  - B-0485
+  - B-0492
+  - B-0493
+  - docs/backlog/P1/B-0470-civsim-zeta-version-pin-bump-2026-05-14.md
+---
+
+# B-0486 — Civsim persona map
+
+## Purpose
+
+Produce the canonical persona map for **Civsim** — the factory's highest-substrate-maturity
+product (PR #2903, #2906, B-0469 live). Civsim is first because existing substrate is
+richest, yielding the most grounded initial persona inventory.
+
+## Pre-start checklist
+
+Per `.claude/rules/backlog-item-start-gate.md`:
+
+- [ ] Template from B-0485 is closed and available
+- [ ] Read PR #2903 (Civsim repo scaffold) for product description
+- [ ] Read PR #2906 (Civsim governance) for persona signals
+- [ ] Read B-0469 (civsim --apply live) for usage context
+- [ ] Walk `composes_with:` chain
+
+## Persona hypotheses (to be validated)
+
+| Persona type | Candidate | Source hint |
+|---|---|---|
+| Primary | Edge-runner developer building civic simulations | PR #2906 governance charter |
+| Primary | Policy researcher / scenario modeler | civsim product charter |
+| Secondary | Civic technologist integrating Civsim outputs | PR #2909 language escalation |
+| Adjacent | Academic studying AI-assisted civic modeling | peer-review substrate |
+| Refused | State-level covert influence operator | methodology-hard-limits |
+
+## Output
+
+Per-product persona map using template from B-0485:
+
+```
+docs/personas/civsim-personas.md
+```
+
+With:
+- Primary / secondary / adjacent / refused persona entries (template schema)
+- HARD LIMITS check for refused personas
+- Substrate references for each persona (which PR/memory supports it)
+
+## Definition of done
+
+- [ ] Template from B-0485 applied
+- [ ] At least 2 primary personas documented with full template fields
+- [ ] At least 1 refused persona documented with HARD LIMITS rationale
+- [ ] Output doc committed at canonical path
+- [ ] B-0492 `composes_with:` pointer backfilled
+- [ ] B-0486 status set to `closed` with PR link
+
+## Why P1
+
+Civsim is the live product (B-0469 shipped). Persona clarity unblocks
+skill authoring for Civsim (per PR #2933 ships-with-skills). Also provides
+the first worked example of the template from B-0485.

--- a/docs/backlog/P1/B-0487-aurora-persona-map-2026-05-14.md
+++ b/docs/backlog/P1/B-0487-aurora-persona-map-2026-05-14.md
@@ -58,6 +58,7 @@ docs/personas/aurora-personas.md
 ```
 
 With:
+
 - All implicit pitch-deck personas formalised using template schema
 - Refused-persona entries with HARD LIMITS citation
 - Aurora Slide 9 preserved verbatim in refused-persona entries

--- a/docs/backlog/P1/B-0487-aurora-persona-map-2026-05-14.md
+++ b/docs/backlog/P1/B-0487-aurora-persona-map-2026-05-14.md
@@ -1,0 +1,80 @@
+---
+id: B-0487
+priority: P1
+status: open
+title: "B-0429.3 — Aurora persona map"
+type: planning
+origin: B-0429 decomposition (Otto, 2026-05-14)
+created: 2026-05-14
+last_updated: 2026-05-14
+parent: B-0429
+depends_on:
+  - B-0485
+composes_with:
+  - B-0429
+  - B-0485
+  - B-0492
+  - B-0493
+---
+
+# B-0487 — Aurora persona map
+
+## Purpose
+
+Produce the canonical persona map for **Aurora** — the data-sovereignty /
+edge-intelligence product. The Aurora pitch deck (PR #2924) already enumerates
+implicit personas (BTC ecosystem participants, edge operators, ombud, liaison);
+this row formalises them using the B-0485 template.
+
+## Pre-start checklist
+
+Per `.claude/rules/backlog-item-start-gate.md`:
+
+- [ ] Template from B-0485 is closed and available
+- [ ] Read PR #2924 (Aurora pitch deck) — slides enumerate implied personas
+- [ ] Cross-check against PR #2825 (Aurora data sovereignty substrate)
+- [ ] Walk `composes_with:` chain
+- [ ] HARD LIMITS check: Aurora Slide 9 explicitly lists refused personas
+      (covert influence operators, coercive data-capture actors)
+
+## Persona hypotheses (from Aurora pitch PR #2924)
+
+| Persona type | Candidate | Source hint |
+|---|---|---|
+| Primary | BTC ecosystem operator (node runner, custody manager) | Aurora pitch Slide |
+| Primary | Edge computing operator (data-sovereignty node) | PR #2825 |
+| Secondary | Ombud / liaison (trust-bridge between communities) | Aurora pitch |
+| Secondary | Privacy-first enterprise IT decision-maker | PR #2825 |
+| Adjacent | Regulator or compliance officer observing | Aurora pitch |
+| Refused | Covert influence operator | Aurora Slide 9 + methodology-hard-limits |
+| Refused | Coercive data-capture actor | Aurora Slide 9 + methodology-hard-limits |
+
+## Output
+
+Per-product persona map using template from B-0485:
+
+```
+docs/personas/aurora-personas.md
+```
+
+With:
+- All implicit pitch-deck personas formalised using template schema
+- Refused-persona entries with HARD LIMITS citation
+- Aurora Slide 9 preserved verbatim in refused-persona entries
+
+## Definition of done
+
+- [ ] Template from B-0485 applied
+- [ ] All pitch-deck personas formalised (minimum 5 entries)
+- [ ] Refused-persona entries include Aurora Slide 9 verbatim rationale
+- [ ] Output doc committed at canonical path
+- [ ] PR #2924 referenced as provenance in each entry
+- [ ] B-0492 `composes_with:` pointer backfilled
+- [ ] B-0487 status set to `closed` with PR link
+
+## Why P1
+
+Aurora partnership pitches need persona clarity (cited in B-0429 why-now).
+The pitch deck already has implicit personas; formalising them is low
+research cost with high-value payoff (pitch + skill-authoring + refused-
+personas registry all unblocked).

--- a/docs/backlog/P1/B-0488-ksk-persona-map-2026-05-14.md
+++ b/docs/backlog/P1/B-0488-ksk-persona-map-2026-05-14.md
@@ -58,6 +58,7 @@ docs/personas/ksk-personas.md
 ```
 
 With:
+
 - Primary / secondary / adjacent / refused entries (template schema)
 - Refused-persona entries citing methodology-hard-limits HARD LIMITS clause
 - Security-domain capability fields populated

--- a/docs/backlog/P1/B-0488-ksk-persona-map-2026-05-14.md
+++ b/docs/backlog/P1/B-0488-ksk-persona-map-2026-05-14.md
@@ -1,0 +1,78 @@
+---
+id: B-0488
+priority: P1
+status: open
+title: "B-0429.4 — KSK (Kinetic Safeguard Kernel) persona map"
+type: planning
+origin: B-0429 decomposition (Otto, 2026-05-14)
+created: 2026-05-14
+last_updated: 2026-05-14
+parent: B-0429
+depends_on:
+  - B-0485
+composes_with:
+  - B-0429
+  - B-0485
+  - B-0492
+  - B-0493
+---
+
+# B-0488 — KSK persona map
+
+## Purpose
+
+Produce the canonical persona map for **KSK (Kinetic Safeguard Kernel)** —
+the security-focused substrate product (PR #2892). KSK's personas are
+primarily security professionals; the refused-personas list is critical
+given the product's attack-surface-adjacent nature.
+
+## Pre-start checklist
+
+Per `.claude/rules/backlog-item-start-gate.md`:
+
+- [ ] Template from B-0485 is closed and available
+- [ ] Read PR #2892 (KSK substrate) for product description and intended scope
+- [ ] Read PR #2902 (Aaron's grey-hat security expert substrate) — Aaron's
+      security persona is the seed for KSK primary persona
+- [ ] Walk `composes_with:` chain
+- [ ] HARD LIMITS check: KSK's security capabilities create meaningful
+      refused-persona requirements (weapons-grade, nation-state APT use)
+
+## Persona hypotheses
+
+| Persona type | Candidate | Source hint |
+|---|---|---|
+| Primary | Grey-hat / ethical security researcher | PR #2902 + methodology-hard-limits |
+| Primary | Security engineer building safeguard layers | PR #2892 product charter |
+| Secondary | Enterprise security architect evaluating KSK | PR #2892 |
+| Adjacent | Compliance auditor validating safeguard claims | governance substrate |
+| Refused | Nation-state APT operator | methodology-hard-limits — HARD LIMIT |
+| Refused | Weapons-grade exploit developer | methodology-hard-limits — HARD LIMIT |
+
+## Output
+
+Per-product persona map using template from B-0485:
+
+```
+docs/personas/ksk-personas.md
+```
+
+With:
+- Primary / secondary / adjacent / refused entries (template schema)
+- Refused-persona entries citing methodology-hard-limits HARD LIMITS clause
+- Security-domain capability fields populated
+
+## Definition of done
+
+- [ ] Template from B-0485 applied
+- [ ] Grey-hat / ethical researcher primary persona fully documented
+- [ ] At least 2 refused personas with explicit HARD LIMITS rationale
+- [ ] Output doc committed at canonical path
+- [ ] B-0492 `composes_with:` pointer backfilled
+- [ ] B-0488 status set to `closed` with PR link
+
+## Why P1
+
+KSK's dual-use security nature requires explicit refused-persona documentation
+before any skill authoring — the HARD LIMITS discipline (`methodology-hard-limits.md`)
+mandates this for security products. Unblocks secure skill authoring for KSK.

--- a/docs/backlog/P1/B-0489-wellness-app-persona-map-2026-05-14.md
+++ b/docs/backlog/P1/B-0489-wellness-app-persona-map-2026-05-14.md
@@ -1,0 +1,79 @@
+---
+id: B-0489
+priority: P1
+status: open
+title: "B-0429.5 — Wellness app persona map"
+type: planning
+origin: B-0429 decomposition (Otto, 2026-05-14)
+created: 2026-05-14
+last_updated: 2026-05-14
+parent: B-0429
+depends_on:
+  - B-0485
+composes_with:
+  - B-0429
+  - B-0485
+  - B-0492
+  - B-0493
+---
+
+# B-0489 — Wellness app persona map
+
+## Purpose
+
+Produce the canonical persona map for the **Wellness app** — described as
+"killer-app-for-AI" in the factory's product portfolio. Thin substrate
+currently; this row surfaces what personas the product is designed for.
+
+## Pre-start checklist
+
+Per `.claude/rules/backlog-item-start-gate.md`:
+
+- [ ] Template from B-0485 is closed and available
+- [ ] Search `docs/` and `memory/` for any wellness-app substrate
+- [ ] Read PR #2893 (Imagination Circle — family-AI) for family-health persona signals
+- [ ] Read PR #2894 (Center-First Playbook) — "Mom" persona as primary health/wellness user
+- [ ] Read PR #2900 (parenting history) — kids as adjacent wellness personas
+- [ ] Walk `composes_with:` chain
+- [ ] HARD LIMITS check: wellness contexts may involve health data, consent requirements
+      (per PR #2893 consent-first scaffolding)
+
+## Persona hypotheses
+
+| Persona type | Candidate | Source hint |
+|---|---|---|
+| Primary | Mom / primary family caregiver | PR #2894 Center-First Playbook |
+| Primary | Health-conscious individual (Aaron archetype) | Wellness-as-killer-app framing |
+| Secondary | Family member (child, partner) as secondary user | PR #2893 Imagination Circle |
+| Secondary | Healthcare practitioner adjacent (not primary) | wellness domain |
+| Adjacent | Aaron as product builder / tester | maintainer persona |
+| Refused | Data broker / health-data harvester | methodology-hard-limits |
+
+## Output
+
+Per-product persona map using template from B-0485:
+
+```
+docs/personas/wellness-personas.md
+```
+
+With:
+- Family-AI personas from PR #2893 and PR #2894 formalised into template schema
+- Consent-first annotations for any persona involving health data
+- Refused-persona entries for data-harvesting actors
+
+## Definition of done
+
+- [ ] Template from B-0485 applied
+- [ ] Mom / primary caregiver primary persona fully documented
+- [ ] Consent-first annotations present on all health-data-adjacent personas
+- [ ] Refused-persona (health data broker) entry with HARD LIMITS rationale
+- [ ] Output doc committed at canonical path
+- [ ] B-0492 `composes_with:` pointer backfilled
+- [ ] B-0489 status set to `closed` with PR link
+
+## Why P1
+
+Wellness is the "killer-app-for-AI" — the product most likely to be the
+first user-facing touchpoint. Getting the persona map right early means
+skill authoring targets the right people from the start.

--- a/docs/backlog/P1/B-0489-wellness-app-persona-map-2026-05-14.md
+++ b/docs/backlog/P1/B-0489-wellness-app-persona-map-2026-05-14.md
@@ -58,6 +58,7 @@ docs/personas/wellness-personas.md
 ```
 
 With:
+
 - Family-AI personas from PR #2893 and PR #2894 formalised into template schema
 - Consent-first annotations for any persona involving health data
 - Refused-persona entries for data-harvesting actors

--- a/docs/backlog/P1/B-0490-american-dream-dio-persona-map-2026-05-14.md
+++ b/docs/backlog/P1/B-0490-american-dream-dio-persona-map-2026-05-14.md
@@ -1,0 +1,87 @@
+---
+id: B-0490
+priority: P1
+status: open
+title: "B-0429.6 — American Dream 2.0 + DIO persona map"
+type: planning
+origin: B-0429 decomposition (Otto, 2026-05-14)
+created: 2026-05-14
+last_updated: 2026-05-14
+parent: B-0429
+depends_on:
+  - B-0485
+composes_with:
+  - B-0429
+  - B-0485
+  - B-0492
+  - B-0493
+---
+
+# B-0490 — American Dream 2.0 + DIO persona map
+
+## Purpose
+
+Produce the canonical persona map for two thin-substrate infrastructure/systemic
+products:
+
+- **American Dream 2.0** — systemic / socioeconomic substrate product
+- **DIO (Distributed Intelligence Organism)** — distributed AI-organism substrate
+
+Both have thin current substrate, making this primarily a forward-looking persona
+definition pass. Grouped because both serve systemic/infrastructure audiences
+rather than individual end-users.
+
+## Pre-start checklist
+
+Per `.claude/rules/backlog-item-start-gate.md`:
+
+- [ ] Template from B-0485 is closed and available
+- [ ] Search `docs/` and `memory/` for any American Dream 2.0 substrate
+- [ ] Search `docs/` and `memory/` for any DIO substrate
+- [ ] Check VISION.md for any product-charter language for these products
+- [ ] Walk `composes_with:` chain
+- [ ] HARD LIMITS check for systemic products (covert influence, mass surveillance)
+
+## American Dream 2.0 — persona hypotheses
+
+| Persona type | Candidate | Source hint |
+|---|---|---|
+| Primary | Civic entrepreneur / community builder | "American Dream" framing |
+| Primary | Policy analyst studying systemic opportunity | systemic product charter |
+| Secondary | Community organiser / grassroots operator | distributed-substrate framing |
+| Adjacent | Academic researcher on economic mobility | systemic scope |
+| Refused | Predatory lender / rent-extraction actor | methodology-hard-limits |
+
+## DIO — persona hypotheses
+
+| Persona type | Candidate | Source hint |
+|---|---|---|
+| Primary | AI systems researcher / distributed-AI builder | DIO product charter |
+| Primary | Edge-runner agent operator (Aaron archetype) | factory-agent roster |
+| Secondary | Enterprise deploying distributed intelligence | DIO substrate |
+| Adjacent | AI safety researcher observing DIO behavior | alignment focus |
+| Refused | Adversarial AI controller (weaponising DIO) | methodology-hard-limits |
+
+## Output
+
+Per-product persona maps using template from B-0485 — one section per product
+in a combined file:
+
+```
+docs/personas/american-dream-2-dio-personas.md
+```
+
+## Definition of done
+
+- [ ] Template from B-0485 applied to both products
+- [ ] At least 2 primary personas per product documented
+- [ ] At least 1 refused persona per product with HARD LIMITS rationale
+- [ ] Output doc committed at canonical path
+- [ ] B-0492 `composes_with:` pointer backfilled
+- [ ] B-0490 status set to `closed` with PR link
+
+## Why grouped
+
+Both AD 2.0 and DIO have thin substrate — grouping them keeps the per-product
+work bounded. If either grows substantially in substrate maturity, split into
+separate rows at that point.

--- a/docs/backlog/P1/B-0491-dawn-universal-biz-templates-persona-map-2026-05-14.md
+++ b/docs/backlog/P1/B-0491-dawn-universal-biz-templates-persona-map-2026-05-14.md
@@ -1,0 +1,95 @@
+---
+id: B-0491
+priority: P1
+status: open
+title: "B-0429.7 — Dawn + Universal business templates persona map"
+type: planning
+origin: B-0429 decomposition (Otto, 2026-05-14)
+created: 2026-05-14
+last_updated: 2026-05-14
+parent: B-0429
+depends_on:
+  - B-0485
+composes_with:
+  - B-0429
+  - B-0485
+  - B-0492
+  - B-0493
+  - docs/backlog/P3/B-0043-universal-company-government-information-substrate.md
+---
+
+# B-0491 — Dawn + Universal business templates persona map
+
+## Purpose
+
+Produce the canonical persona map for two frontier/thin-substrate products:
+
+- **Dawn** — child-AI charter product; personas are the most consent-sensitive
+  in the factory (children, parents, guardians)
+- **Universal business templates (B-0043)** — universal-company/government
+  substrate; the widest possible persona surface
+
+Both are frontier products. Grouped because both have thin substrate and require
+careful persona scoping before implementation.
+
+## Pre-start checklist
+
+Per `.claude/rules/backlog-item-start-gate.md`:
+
+- [ ] Template from B-0485 is closed and available
+- [ ] Search for Dawn charter substrate in `docs/` and `memory/`
+- [ ] Read B-0043 (`docs/backlog/P3/B-0043-*.md`) for universal-business scope
+- [ ] Read PR #2920 (TERMINAL-PURPOSE Elizabeth) for Dawn's edge-runner persona
+      context and terminal-purpose grounding
+- [ ] Read PR #2893 (Imagination Circle) for consent-first scaffolding relevant
+      to Dawn's child-AI context
+- [ ] HARD LIMITS check: Dawn involves children — strictest consent requirements
+      apply; PEC v0.1 + Charter v0.2 per PR #2893
+
+## Dawn — persona hypotheses
+
+| Persona type | Candidate | Source hint |
+|---|---|---|
+| Primary | Parent / guardian authorising child's AI interaction | PR #2893 consent-first |
+| Primary | Child learner (age-appropriate, consent-gated) | Dawn charter |
+| Secondary | Educator using Dawn in structured context | educational substrate |
+| Adjacent | Child-safety researcher observing Dawn behavior | alignment + safety |
+| Refused | Unaccompanied minor without guardian consent | PR #2893 PEC v0.1 |
+| Refused | Adult posing as child or misrepresenting age | methodology-hard-limits |
+
+## Universal business templates (B-0043) — persona hypotheses
+
+| Persona type | Candidate | Source hint |
+|---|---|---|
+| Primary | Startup founder / SMB operator | "every company" framing |
+| Primary | Enterprise information architect | B-0043 universal scope |
+| Secondary | Government agency information manager | B-0043 "government" clause |
+| Adjacent | Consultant deploying templates for clients | universal reach |
+| Refused | Tax-evasion / fraudulent entity structuring | methodology-hard-limits |
+
+## Output
+
+Per-product persona maps using template from B-0485:
+
+```
+docs/personas/dawn-universal-biz-personas.md
+```
+
+One section per product. Dawn section must include consent-first annotations
+per PR #2893 PEC v0.1 + Charter v0.2.
+
+## Definition of done
+
+- [ ] Template from B-0485 applied to both products
+- [ ] Dawn: parent/guardian primary persona with consent-first annotations
+- [ ] Dawn: at least 2 refused personas with PEC v0.1 / HARD LIMITS rationale
+- [ ] Universal biz templates: at least 2 primary personas documented
+- [ ] Output doc committed at canonical path
+- [ ] B-0492 `composes_with:` pointer backfilled
+- [ ] B-0491 status set to `closed` with PR link
+
+## Why consent-first matters for Dawn
+
+Dawn's product charter involves children. Per PR #2893 (Imagination Circle),
+the consent-first scaffolding is mandatory — not advisory — before any
+feature authoring for child-adjacent personas.

--- a/docs/backlog/P1/B-0492-cross-product-persona-reuse-refused-registry-2026-05-14.md
+++ b/docs/backlog/P1/B-0492-cross-product-persona-reuse-refused-registry-2026-05-14.md
@@ -1,0 +1,106 @@
+---
+id: B-0492
+priority: P1
+status: open
+title: "B-0429.8 — Cross-product persona reuse map + refused-personas registry"
+type: planning
+origin: B-0429 decomposition (Otto, 2026-05-14)
+created: 2026-05-14
+last_updated: 2026-05-14
+parent: B-0429
+depends_on:
+  - B-0486
+  - B-0487
+  - B-0488
+  - B-0489
+  - B-0490
+  - B-0491
+composes_with:
+  - B-0429
+  - B-0485
+  - B-0486
+  - B-0487
+  - B-0488
+  - B-0489
+  - B-0490
+  - B-0491
+  - B-0493
+---
+
+# B-0492 — Cross-product persona reuse map + refused-personas registry
+
+## Purpose
+
+After all six per-product persona maps (B-0486..B-0491) are closed, synthesise:
+
+1. **Cross-product persona reuse map** — which personas appear across multiple
+   products? Which skills serve multiple personas? Where is there shared substrate?
+2. **Factory-wide refused-personas registry** — consolidated list of all refused
+   personas across all products, with HARD LIMITS citations.
+
+This is the B-0429 definition-of-done requirement: *"Cross-product persona reuse
+mapped"* and *"Refused-personas list per product"* (consolidated view).
+
+## Pre-start checklist
+
+Per `.claude/rules/backlog-item-start-gate.md`:
+
+- [ ] All of B-0486..B-0491 must be closed before this begins
+- [ ] Template from B-0485 available for reference
+- [ ] Walk all six per-product docs for shared persona patterns
+- [ ] Walk all six per-product docs for refused-persona entries
+- [ ] HARD LIMITS check: verify every refused-persona entry has explicit HARD
+      LIMITS clause citation (not just "general concern")
+
+## Cross-product persona reuse analysis
+
+Candidate shared personas (to be verified against B-0486..B-0491 outputs):
+
+| Persona | Products | Reuse signal |
+|---------|----------|--------------|
+| Aaron-archetype edge-runner | Civsim, DIO, KSK | Factory maintainer is first user of all products |
+| Parent / primary caregiver | Wellness, Dawn | Same person in different contexts |
+| Privacy-first operator | Aurora, KSK | Data-sovereignty + safeguard concerns overlap |
+| Policy / civic researcher | Civsim, AD 2.0 | Systemic-outcomes audience |
+| Enterprise IT architect | KSK, Universal biz | Security + templates both enterprise-facing |
+
+## Refused-personas registry format
+
+Each entry in the consolidated registry:
+
+```markdown
+### <persona handle>
+
+- **Products**: <list>
+- **HARD LIMITS clause**: <exact clause from methodology-hard-limits.md>
+- **Why refused**: <one sentence>
+- **Detection signal**: <how would you recognize this actor? — for future gating>
+```
+
+## Output
+
+Two documents:
+
+```
+docs/personas/cross-product-persona-reuse.md
+docs/personas/refused-personas-registry.md
+```
+
+The refused-personas registry is a **first-class factory surface** — referenced
+by skill authoring gates and future access-control design.
+
+## Definition of done
+
+- [ ] All six per-product docs (B-0486..B-0491) closed
+- [ ] Cross-product reuse map: every persona appearing in ≥2 products documented
+- [ ] Refused-personas registry: all refused personas from all products consolidated
+- [ ] Every refused-persona entry has exact HARD LIMITS clause citation
+- [ ] Both output docs committed at canonical paths
+- [ ] B-0493 `composes_with:` pointer backfilled
+- [ ] B-0492 status set to `closed` with PR link
+
+## Why P1
+
+The refused-personas registry is a safety surface — it prevents skill authors
+from accidentally targeting refused personas. Can't be written before per-product
+maps are done; should be written immediately after.

--- a/docs/backlog/P1/B-0493-skill-catalog-persona-crossref-2026-05-14.md
+++ b/docs/backlog/P1/B-0493-skill-catalog-persona-crossref-2026-05-14.md
@@ -1,0 +1,100 @@
+---
+id: B-0493
+priority: P1
+status: open
+title: "B-0429.9 — Skill catalog × persona cross-reference"
+type: planning
+origin: B-0429 decomposition (Otto, 2026-05-14)
+created: 2026-05-14
+last_updated: 2026-05-14
+parent: B-0429
+depends_on:
+  - B-0492
+composes_with:
+  - B-0429
+  - B-0485
+  - B-0492
+---
+
+# B-0493 — Skill catalog × persona cross-reference
+
+## Purpose
+
+Per PR #2933 (Zeta ships with skills — immediate value), skills are authored for
+**specific personas' use cases**. Without a skill × persona cross-reference,
+skill authoring is untargeted and may serve the wrong audiences.
+
+This row produces the cross-reference linking each existing `.claude/skills/`
+entry to the persona(s) it serves, and identifies skill gaps (personas with no
+matching skill yet).
+
+## Pre-start checklist
+
+Per `.claude/rules/backlog-item-start-gate.md`:
+
+- [ ] B-0492 must be closed (cross-product persona reuse + refused registry must
+      exist before we can cross-reference against the full persona space)
+- [ ] Read PR #2933 (ships-with-skills discipline) for context
+- [ ] Enumerate all skills via `.claude/skills/` skill-router listing
+- [ ] Walk `composes_with:` chain
+
+## Cross-reference analysis
+
+For each skill in the skill catalog:
+
+1. **Primary persona served** — which persona in the factory's persona space does
+   this skill primarily serve?
+2. **Product context** — which product(s) is this skill relevant to?
+3. **Gap signal** — does this skill target a refused persona? (flag)
+
+And the inverse: for each persona in the cross-product reuse map (B-0492):
+
+1. **Skills available** — which existing skills already serve this persona?
+2. **Skills needed** — what obvious skill gaps exist for this persona?
+
+## Output format
+
+A cross-reference table document:
+
+```
+docs/personas/skill-persona-crossref.md
+```
+
+With two tables:
+
+**Table A — Skill → Persona**:
+
+| Skill | Primary persona(s) | Product context | Gap or refused signal |
+|-------|---------------------|-----------------|----------------------|
+| ... | ... | ... | ... |
+
+**Table B — Persona → Skill**:
+
+| Persona | Available skills | Needed skills (gaps) |
+|---------|-----------------|----------------------|
+| ... | ... | ... |
+
+Gap rows in Table B become candidates for new B-NNNN skill-authoring backlog items.
+
+## Definition of done
+
+- [ ] B-0492 closed (prerequisite met)
+- [ ] All skills in `.claude/skills/` enumerated in Table A
+- [ ] All primary personas from B-0486..B-0491 represented in Table B
+- [ ] At least one "needed skills" gap identified per product
+- [ ] Gap rows noted as candidate backlog items (but NOT decomposed in this row —
+      that's a future pass)
+- [ ] Output doc committed at canonical path
+- [ ] B-0493 status set to `closed` with PR link
+
+## Why P1
+
+This is the B-0429 definition-of-done requirement: *"Skill catalog
+cross-referenced to persona-served (per PR #2933 ships-with-skills layer)."*
+Cannot be done before B-0492 (need full persona space). Closes out B-0429.
+
+## What this row does NOT do
+
+- Does NOT author new skills — only identifies gaps as future candidates
+- Does NOT require all gaps to be filed as backlog rows immediately
+- Does NOT retroactively change existing skill SKILL.md files


### PR DESCRIPTION
## Summary

- Decomposes B-0429 (end-user persona mapping for all 8 factory products) into 9 dependency-ordered atomic child rows (B-0485..B-0493)
- B-0429 frontmatter updated: `status: decomposed`, `child_rows:` list added, decomposition record appended
- No code changes; pure backlog/planning substrate

## Dependency graph

```
B-0485 (gate: template + inventory)
  ├── B-0486 (Civsim)  ─┐
  ├── B-0487 (Aurora)   │
  ├── B-0488 (KSK)      ├─ parallel; all depend on B-0485
  ├── B-0489 (Wellness) │
  ├── B-0490 (AD2+DIO) │
  └── B-0491 (Dawn+Biz)─┘
              │
              ▼
       B-0492 (cross-product reuse + refused-personas registry)
              │
              ▼
       B-0493 (skill catalog × persona cross-reference)
```

## Child rows created

| ID | Title | Type | Gate / Depends |
|----|-------|------|----------------|
| B-0485 | Persona-mapping framework + substrate inventory | research | Gate — no deps |
| B-0486 | Civsim persona map | planning | B-0485 |
| B-0487 | Aurora persona map | planning | B-0485 |
| B-0488 | KSK persona map | planning | B-0485 |
| B-0489 | Wellness app persona map | planning | B-0485 |
| B-0490 | American Dream 2.0 + DIO persona map | planning | B-0485 |
| B-0491 | Dawn + Universal biz templates persona map | planning | B-0485 |
| B-0492 | Cross-product reuse + refused-personas registry | planning | B-0486..B-0491 |
| B-0493 | Skill catalog × persona cross-reference | planning | B-0492 |

## Design notes

- B-0485 is the gate row — template must be defined before per-product work starts to ensure schema consistency for B-0492 synthesis
- B-0490 groups American Dream 2.0 + DIO (both thin-substrate infrastructure products); B-0491 groups Dawn + Universal biz templates (both frontier/thin)
- Dawn (B-0491) requires consent-first annotations per PR #2893 PEC v0.1 — flagged in the row
- KSK (B-0488) requires explicit refused-persona entries with HARD LIMITS citations given dual-use security nature
- B-0493 closes out B-0429's DoD requirement: "Skill catalog cross-referenced to persona-served (per PR #2933 ships-with-skills layer)"

## Checks

- `dotnet build -c Release`: not applicable (no code changes; backlog-only PR)
- All 9 child rows follow the pattern established by B-0471..B-0484 decompositions
- Claim acquired: `bun tools/bus/claim.ts acquire --from otto-cli --item B-0429` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)