### PR TITLE
feat(b-0437): UX-of-math panel — slice-1 static bivector fingerprint scaffold

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1062,7 +1062,6 @@
                             background:rgba(10,10,15,0.6); border:1px solid var(--panel-border);">
                     <canvas id="uxm-canvas" width="900" height="380"
                             style="width:100%; height:auto; display:block;"
-                            aria-label="Bivector fingerprint diagram for HC-1 Non-deceptive alignment clause"
                             aria-describedby="uxm-canvas-caption">
                         Coordinate plane with two witness vectors: adherence strength (0.85 along the horizontal
                         e1 axis) and evidence quality (0.81 along the vertical e2 axis). The shaded purple
@@ -2049,14 +2048,14 @@
                 { id: 'DIR-3', name: 'Interpretability',         v1: 0.85, v2: 0.82 },
                 { id: 'DIR-4', name: 'Trust & safety',           v1: 0.95, v2: 0.94 },
                 { id: 'DIR-5', name: 'Govern AI activity',       v1: 0.89, v2: 0.87 },
-            ].map(d => ({ ...d, score: Math.round(d.v1 * d.v2 * 100) / 100 }));
+            ].map(d => ({ ...d, score: d.v1 * d.v2 }));
         }
 
         function renderUxOfMathTab() {
             window._uxOfMathLoaded = true;
             const data = uxmMockData();
 
-            const meanScore = Math.round(data.reduce((s, d) => s + d.score, 0) / data.length * 100);
+            const meanScore = Math.round((data.reduce((s, d) => s + d.score, 0) / data.length) * 100);
             const meanEl = document.getElementById('uxm-mean-score');
             if (meanEl) meanEl.textContent = meanScore + '%';
 
@@ -2094,8 +2093,11 @@
             const canvas = document.getElementById('uxm-canvas');
             if (!canvas) return;
             const ctx = canvas.getContext('2d');
-            const W = canvas.width;
-            const H = canvas.height;
+            const dpr = window.devicePixelRatio || 1;
+            const W = 900, H = 380;
+            canvas.width = W * dpr;
+            canvas.height = H * dpr;
+            ctx.scale(dpr, dpr);
 
             ctx.clearRect(0, 0, W, H);
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -673,6 +673,7 @@
             <div class="nav-tab" onclick="switchTab('alignment', this)" id="tab-btn-alignment">Alignment ▸</div>
             <div class="nav-tab" onclick="switchTab('circuit-breaker', this)">Circuit Breaker</div>
             <div class="nav-tab" onclick="switchTab('hamiltonian', this)" id="tab-btn-hamiltonian">Hamiltonian ▸</div>
+            <div class="nav-tab" onclick="switchTab('ux-of-math', this)" id="tab-btn-ux-of-math">UX of Math ▸</div>
         </div>
 
         <!-- TAB 1: FACTORY -->
@@ -1006,6 +1007,123 @@
                 </div>
             </div>
         </div>
+
+        <!-- TAB 7: UX OF MATH -->
+        <div id="tab-ux-of-math" class="tab-content">
+            <div class="panel" style="margin-bottom: 2rem;">
+                <div class="panel-header">
+                    <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M4 6h16M4 10h16M4 14h16M4 18h16"/>
+                    </svg>
+                    <h2>UX of Math — Alignment Signals</h2>
+                </div>
+                <p style="color:var(--text-muted); font-size:0.9rem; margin-bottom: 1.5rem;">
+                    Each alignment clause is scored using <strong style="color:var(--text-main)">bivector fingerprints</strong>:
+                    two observable witness signals are combined via their geometric (wedge) product to produce a
+                    partial-credit score. The shaded area in the diagram below is the fingerprint — a larger area
+                    means stronger, better-evidenced alignment.
+                </p>
+                <div class="stat-grid">
+                    <div class="stat">
+                        <div class="stat-label">Clauses scored</div>
+                        <div class="stat-value" id="uxm-clause-count">21</div>
+                    </div>
+                    <div class="stat">
+                        <div class="stat-label">Mean score</div>
+                        <div class="stat-value good" id="uxm-mean-score">—</div>
+                    </div>
+                    <div class="stat">
+                        <div class="stat-label">Bivectors computed</div>
+                        <div class="stat-value" id="uxm-bivector-count">21</div>
+                    </div>
+                    <div class="stat">
+                        <div class="stat-label">Data source</div>
+                        <div class="stat-value" id="uxm-data-source" style="font-size:1rem;margin-top:0.5rem">static mock</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="panel" style="margin-bottom: 2rem;">
+                <div class="panel-header">
+                    <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 0v10m0 0a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2z"/>
+                    </svg>
+                    <h2>Worked Example — Bivector Fingerprint (HC-1)</h2>
+                </div>
+                <p style="color:var(--text-muted); font-size:0.9rem; margin-bottom: 1rem;">
+                    HC-1 "Non-deceptive" is witnessed by two independent signals:
+                    <em>adherence strength</em> (how consistently the agent avoids deceptive outputs)
+                    and <em>evidence quality</em> (how well-evidenced that claim is from commit history).
+                    Their wedge product — the shaded area — is the bivector fingerprint: the partial-credit score.
+                </p>
+                <div style="position:relative; width:100%; overflow:hidden; border-radius:8px;
+                            background:rgba(10,10,15,0.6); border:1px solid var(--panel-border);">
+                    <canvas id="uxm-canvas" width="900" height="380"
+                            style="width:100%; height:auto; display:block;"
+                            aria-label="Bivector fingerprint diagram for HC-1 Non-deceptive alignment clause"
+                            aria-describedby="uxm-canvas-caption">
+                        Coordinate plane with two witness vectors: adherence strength (0.85 along the horizontal
+                        e1 axis) and evidence quality (0.81 along the vertical e2 axis). The shaded purple
+                        rectangle between origin and the corner point represents the bivector fingerprint,
+                        with area 0.85 x 0.81 = 0.69, giving a partial-credit score of 69% for HC-1.
+                    </canvas>
+                </div>
+                <p style="color:var(--text-muted); font-size:0.8rem; margin-top:0.75rem;" id="uxm-canvas-caption">
+                    Static mock data (slice-1). Formula: score = |v1 ^ v2| = |v1|*|v2|*sin(theta).
+                    Axes are orthogonal (theta = 90 deg, sin = 1) so score = adherence x evidence = 0.85 x 0.81 = 0.69.
+                </p>
+            </div>
+
+            <div class="panel" style="margin-bottom: 2rem;">
+                <div class="panel-header">
+                    <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+                    </svg>
+                    <h2>Partial-Credit Score Board</h2>
+                </div>
+                <p style="color:var(--text-muted); font-size:0.9rem; margin-bottom: 1.5rem;">
+                    Each HC/SD/DIR clause receives a partial-credit score (0-100%) from its bivector fingerprint.
+                    Scores &ge; 80% are green (well-evidenced), 60-79% are amber (partial evidence), below 60% are red (attention needed).
+                </p>
+                <div id="uxm-score-board" style="display:flex; flex-direction:column; gap:0.75rem;"></div>
+            </div>
+
+            <div class="panel">
+                <div class="panel-header">
+                    <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                    </svg>
+                    <h2>How to Read This</h2>
+                </div>
+                <div style="color:var(--text-muted); font-size:0.9rem; line-height:1.9;">
+                    <p>A <strong style="color:var(--text-main)">bivector</strong> is a grade-2 element of a Clifford
+                    (geometric) algebra — it represents an <em>oriented area</em> in a multi-dimensional space.
+                    When two signals v1 and v2 are combined via the
+                    <strong style="color:var(--accent-primary)">wedge product</strong> (v1 ^ v2), the result is a
+                    bivector whose magnitude equals the area of the parallelogram they span.</p>
+                    <br>
+                    <p>In Zeta's alignment substrate, each clause is witnessed by two observable signals.
+                    If both signals are strong <em>and</em> they point in sufficiently different directions
+                    (large angle theta between them), the bivector area is large — meaning the clause is
+                    well-evidenced from multiple <em>independent</em> angles.
+                    This is the <strong style="color:var(--text-main)">partial-credit score</strong>.</p>
+                    <br>
+                    <p>Crucially, two perfectly collinear signals (v1 parallel v2, theta = 0) produce a <em>zero</em>
+                    bivector — even if both signals are individually strong. This catches "echo chamber" evidence:
+                    two measurements that are really just one measurement dressed up twice.</p>
+                    <br>
+                    <p style="font-size:0.8rem;">
+                        Data source: static mock (slice-1)
+                        · slice-2 will connect to live alignment-audit output (B-0438)
+                        · rendered <span id="uxm-rendered-at">-</span>
+                    </p>
+                </div>
+            </div>
+        </div>
     </div>
 
     <script>
@@ -1026,6 +1144,9 @@
             }
             if (tabId === 'hamiltonian' && !window._hamiltonianLoaded) {
                 renderHamiltonianTab();
+            }
+            if (tabId === 'ux-of-math' && !window._uxOfMathLoaded) {
+                renderUxOfMathTab();
             }
         }
 
@@ -1901,6 +2022,249 @@
                 ctx.fillStyle = item.color;
                 ctx.fill();
                 lx -= 18;
+            });
+        }
+
+        // ── UX of Math — bivector fingerprints ─────────────────────────────────
+        function uxmMockData() {
+            return [
+                { id: 'HC-1',  name: 'Non-deceptive',           v1: 0.85, v2: 0.81 },
+                { id: 'HC-2',  name: 'Non-manipulative',         v1: 0.93, v2: 0.91 },
+                { id: 'HC-3',  name: 'Autonomy-preserving (HC)', v1: 0.82, v2: 0.86 },
+                { id: 'HC-4',  name: 'Globally safe',            v1: 0.97, v2: 0.95 },
+                { id: 'HC-5',  name: 'Minimal footprint',        v1: 0.89, v2: 0.87 },
+                { id: 'HC-6',  name: 'Avoid drastic actions',    v1: 0.99, v2: 0.98 },
+                { id: 'HC-7',  name: 'Support oversight',        v1: 0.96, v2: 0.94 },
+                { id: 'SD-1',  name: 'Broadly safe',             v1: 0.98, v2: 0.97 },
+                { id: 'SD-2',  name: 'Broadly ethical',          v1: 0.91, v2: 0.90 },
+                { id: 'SD-3',  name: 'Adherent to principles',   v1: 0.94, v2: 0.92 },
+                { id: 'SD-4',  name: 'Genuinely helpful',        v1: 0.90, v2: 0.89 },
+                { id: 'SD-5',  name: 'Honest',                   v1: 0.95, v2: 0.94 },
+                { id: 'SD-6',  name: 'Transparent',              v1: 0.93, v2: 0.91 },
+                { id: 'SD-7',  name: 'Non-coercive',             v1: 0.91, v2: 0.89 },
+                { id: 'SD-8',  name: 'Autonomy-preserving (SD)', v1: 0.87, v2: 0.84 },
+                { id: 'SD-9',  name: 'Agreement is signal',      v1: 0.80, v2: 0.76 },
+                { id: 'DIR-1', name: 'Artifacts of value',       v1: 0.88, v2: 0.85 },
+                { id: 'DIR-2', name: 'Alignment research',       v1: 0.92, v2: 0.90 },
+                { id: 'DIR-3', name: 'Interpretability',         v1: 0.85, v2: 0.82 },
+                { id: 'DIR-4', name: 'Trust & safety',           v1: 0.95, v2: 0.94 },
+                { id: 'DIR-5', name: 'Govern AI activity',       v1: 0.89, v2: 0.87 },
+            ].map(d => ({ ...d, score: Math.round(d.v1 * d.v2 * 100) / 100 }));
+        }
+
+        function renderUxOfMathTab() {
+            window._uxOfMathLoaded = true;
+            const data = uxmMockData();
+
+            const meanScore = Math.round(data.reduce((s, d) => s + d.score, 0) / data.length * 100);
+            const meanEl = document.getElementById('uxm-mean-score');
+            if (meanEl) meanEl.textContent = meanScore + '%';
+
+            const tsEl = document.getElementById('uxm-rendered-at');
+            if (tsEl) tsEl.textContent = new Date().toLocaleTimeString();
+
+            const btn = document.getElementById('tab-btn-ux-of-math');
+            if (btn) btn.textContent = 'UX of Math (' + data.length + ')';
+
+            uxmDrawBivector();
+            uxmRenderScoreBoard(data);
+        }
+
+        function uxmArrow(ctx, x1, y1, x2, y2, color, lineWidth) {
+            const headLen = 10;
+            const angle = Math.atan2(y2 - y1, x2 - x1);
+            ctx.strokeStyle = color;
+            ctx.fillStyle = color;
+            ctx.lineWidth = lineWidth;
+            ctx.beginPath();
+            ctx.moveTo(x1, y1);
+            ctx.lineTo(x2, y2);
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.moveTo(x2, y2);
+            ctx.lineTo(x2 - headLen * Math.cos(angle - Math.PI / 7),
+                       y2 - headLen * Math.sin(angle - Math.PI / 7));
+            ctx.lineTo(x2 - headLen * Math.cos(angle + Math.PI / 7),
+                       y2 - headLen * Math.sin(angle + Math.PI / 7));
+            ctx.closePath();
+            ctx.fill();
+        }
+
+        function uxmDrawBivector() {
+            const canvas = document.getElementById('uxm-canvas');
+            if (!canvas) return;
+            const ctx = canvas.getContext('2d');
+            const W = canvas.width;
+            const H = canvas.height;
+
+            ctx.clearRect(0, 0, W, H);
+
+            const OX = 100, OY = 310;   // origin pixel coords
+            const SCALE = 215;          // 1.0 unit = 215px
+            const v1 = 0.85;            // HC-1 adherence strength (e1 axis)
+            const v2 = 0.81;            // HC-1 evidence quality   (e2 axis)
+            const ex1 = OX + v1 * SCALE;
+            const ey2 = OY - v2 * SCALE;
+
+            // Gridlines
+            ctx.strokeStyle = 'rgba(255,255,255,0.05)';
+            ctx.lineWidth = 1;
+            for (let i = 1; i <= 10; i++) {
+                const gx = OX + (i / 10) * SCALE;
+                ctx.beginPath(); ctx.moveTo(gx, OY - SCALE * 1.15); ctx.lineTo(gx, OY + 18); ctx.stroke();
+                const gy = OY - (i / 10) * SCALE;
+                ctx.beginPath(); ctx.moveTo(OX - 18, gy); ctx.lineTo(OX + SCALE * 1.15, gy); ctx.stroke();
+            }
+
+            // Axes
+            ctx.strokeStyle = 'rgba(255,255,255,0.28)';
+            ctx.lineWidth = 1.5;
+            ctx.beginPath(); ctx.moveTo(OX - 18, OY); ctx.lineTo(OX + SCALE * 1.15, OY); ctx.stroke();
+            ctx.beginPath(); ctx.moveTo(OX, OY + 18); ctx.lineTo(OX, OY - SCALE * 1.15); ctx.stroke();
+
+            // Axis labels
+            ctx.fillStyle = 'rgba(148,163,184,0.85)';
+            ctx.font = '13px Outfit, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('adherence strength  (e₁)', OX + (SCALE * 1.15) / 2, OY + 36);
+            ctx.save();
+            ctx.translate(OX - 46, OY - (SCALE * 1.15) / 2);
+            ctx.rotate(-Math.PI / 2);
+            ctx.fillText('evidence quality  (e₂)', 0, 0);
+            ctx.restore();
+
+            // Axis tick values
+            ctx.font = '11px Outfit, sans-serif';
+            ctx.fillStyle = 'rgba(148,163,184,0.6)';
+            [0.25, 0.5, 0.75, 1.0].forEach(t => {
+                ctx.textAlign = 'center';
+                ctx.fillText(t.toFixed(2), OX + t * SCALE, OY + 16);
+                ctx.textAlign = 'right';
+                ctx.fillText(t.toFixed(2), OX - 6, OY - t * SCALE + 4);
+            });
+
+            // Bivector area (shaded rectangle)
+            ctx.fillStyle = 'rgba(139,92,246,0.20)';
+            ctx.strokeStyle = 'rgba(139,92,246,0.50)';
+            ctx.lineWidth = 1.5;
+            ctx.beginPath();
+            ctx.moveTo(OX, OY);
+            ctx.lineTo(ex1, OY);
+            ctx.lineTo(ex1, ey2);
+            ctx.lineTo(OX, ey2);
+            ctx.closePath();
+            ctx.fill();
+            ctx.stroke();
+
+            // Dashed closing sides
+            ctx.strokeStyle = 'rgba(139,92,246,0.30)';
+            ctx.lineWidth = 1;
+            ctx.setLineDash([4, 4]);
+            ctx.beginPath(); ctx.moveTo(ex1, OY); ctx.lineTo(ex1, ey2); ctx.stroke();
+            ctx.beginPath(); ctx.moveTo(OX, ey2); ctx.lineTo(ex1, ey2); ctx.stroke();
+            ctx.setLineDash([]);
+
+            // Area label inside rectangle
+            const areaLabel = (v1 * v2).toFixed(2);
+            ctx.fillStyle = 'rgba(167,139,250,0.9)';
+            ctx.font = 'bold 16px Outfit, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('area = ' + areaLabel, OX + (ex1 - OX) / 2, OY - (OY - ey2) / 2);
+
+            // v1 arrow (indigo, along e1)
+            uxmArrow(ctx, OX, OY, ex1, OY, '#6366f1', 2.5);
+            ctx.fillStyle = '#6366f1';
+            ctx.font = 'bold 13px Outfit, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('v₁ = ' + v1, OX + (ex1 - OX) / 2, OY - 12);
+
+            // v2 arrow (emerald, along e2)
+            uxmArrow(ctx, OX, OY, OX, ey2, '#10b981', 2.5);
+            ctx.fillStyle = '#10b981';
+            ctx.font = 'bold 13px Outfit, sans-serif';
+            ctx.textAlign = 'right';
+            ctx.fillText('v₂ = ' + v2, OX - 10, OY - (OY - ey2) / 2);
+
+            // Right-panel formula annotation
+            const SPLIT = W / 2 + 10;
+            const lineH = 22;
+            let ry = 36;
+
+            ctx.textAlign = 'left';
+            ctx.fillStyle = 'rgba(255,255,255,0.92)';
+            ctx.font = 'bold 16px Outfit, sans-serif';
+            ctx.fillText('HC-1: Non-deceptive', SPLIT, ry);
+            ry += lineH * 1.6;
+
+            const annoLines = [
+                { text: 'Two witness dimensions:', bold: true, color: 'rgba(255,255,255,0.85)' },
+                { text: '  v₁ = adherence strength = 0.85',  bold: false, color: 'rgba(148,163,184,0.85)' },
+                { text: '  v₂ = evidence quality   = 0.81',  bold: false, color: 'rgba(148,163,184,0.85)' },
+                { text: '', bold: false, color: '' },
+                { text: 'Wedge product  (v₁ ∧ v₂):', bold: true, color: 'rgba(255,255,255,0.85)' },
+                { text: '  = |v₁| · |v₂| · sin(θ)', bold: false, color: 'rgba(148,163,184,0.85)' },
+                { text: '  = 0.85 · 0.81 · sin(90°)', bold: false, color: 'rgba(148,163,184,0.85)' },
+                { text: '  = 0.85 · 0.81 · 1', bold: false, color: 'rgba(148,163,184,0.85)' },
+                { text: '  = 0.69', bold: false, color: 'rgba(148,163,184,0.85)' },
+                { text: '', bold: false, color: '' },
+                { text: 'Partial-credit score: 69%', bold: true, color: 'rgba(52,211,153,0.95)' },
+            ];
+
+            annoLines.forEach(line => {
+                ctx.fillStyle = line.color || 'rgba(148,163,184,0.85)';
+                ctx.font = (line.bold ? 'bold ' : '') + '13px Outfit, sans-serif';
+                ctx.fillText(line.text, SPLIT, ry);
+                ry += lineH;
+            });
+
+            ry += 14;
+            ctx.fillStyle = 'rgba(148,163,184,0.55)';
+            ctx.font = '11px Outfit, sans-serif';
+            ctx.fillText('θ = 90° because adherence (e₁) ⊥ evidence (e₂)', SPLIT, ry);
+            ctx.fillText('Slice-1 uses axis-aligned orthogonal witnesses.', SPLIT, ry + 16);
+            ctx.fillText('Slice-2 will introduce non-orthogonal signals.', SPLIT, ry + 32);
+        }
+
+        function uxmRenderScoreBoard(data) {
+            const container = document.getElementById('uxm-score-board');
+            if (!container) return;
+            container.replaceChildren();
+
+            data.forEach(clause => {
+                const pct = Math.round(clause.score * 100);
+                const color = pct >= 80 ? 'var(--success)' : pct >= 60 ? 'var(--warning)' : 'var(--danger)';
+
+                const row = document.createElement('div');
+                row.style.cssText = 'background:rgba(0,0,0,0.2);border-radius:10px;'
+                    + 'padding:0.75rem 1rem;border:1px solid rgba(255,255,255,0.04);';
+
+                const hdr = document.createElement('div');
+                hdr.style.cssText = 'display:flex;justify-content:space-between;'
+                    + 'align-items:center;margin-bottom:0.5rem;';
+
+                const lbl = document.createElement('span');
+                lbl.style.cssText = 'font-size:0.85rem;font-weight:600;color:var(--text-main);';
+                lbl.textContent = clause.id + ' — ' + clause.name;
+
+                const pctEl = document.createElement('span');
+                pctEl.style.cssText = 'font-size:0.85rem;font-weight:700;color:' + color + ';';
+                pctEl.textContent = pct + '%';
+
+                hdr.appendChild(lbl);
+                hdr.appendChild(pctEl);
+
+                const track = document.createElement('div');
+                track.style.cssText = 'height:6px;border-radius:3px;'
+                    + 'background:rgba(255,255,255,0.07);overflow:hidden;';
+
+                const fill = document.createElement('div');
+                fill.style.cssText = 'height:100%;border-radius:3px;width:' + pct + '%;'
+                    + 'background:' + color + ';transition:width 0.6s ease;';
+
+                track.appendChild(fill);
+                row.appendChild(hdr);
+                row.appendChild(track);
+                container.appendChild(row);
             });
         }
 


### PR DESCRIPTION
## Summary

- Adds a **7th tab "UX of Math"** to `demo/index.html` (Zeta Factory Dashboard at GitHub Pages)
- Makes the Clifford/HKT alignment-signal substrate legible to non-mathematicians via visual bivector fingerprints and a partial-credit score board
- Pure HTML/JS — no .NET changes

## What's in slice-1

| Panel | Content |
|---|---|
| **Summary stats** | Clauses scored (21), mean score (auto-computed), bivector count, data source |
| **Worked example canvas** | HC-1 "Non-deceptive" drawn on a Canvas 2D coordinate plane with v₁/v₂ witness arrows, shaded bivector area, and formula annotation |
| **Partial-credit score board** | All 21 HC/SD/DIR clauses with progress bars (green ≥ 80%, amber 60-79%, red < 60%) |
| **How to Read This** | Prose explanation of wedge products, echo-chamber signal detection, and what a zero bivector means |

## Key design decisions

- **DOM-only rendering** — `createElement`/`textContent`/`replaceChildren` throughout; zero `innerHTML` template strings; zero XSS surface
- **Lazy-loaded** on first tab open via `window._uxOfMathLoaded` guard (same pattern as Alignment and Hamiltonian tabs)
- **Axis-aligned orthogonal witnesses** (θ = 90°, sin = 1) for slice-1 simplicity — score = v₁ × v₂; slice-2 will introduce non-orthogonal signals per B-0438

## Build gate

```
dotnet build -c Release → Build succeeded. 0 Warning(s). 0 Error(s).
```

(Pure HTML/JS addition; no .NET source changes.)

## Acceptance criteria (B-0437 slice-1)

- [x] Panel renders without errors in `demo/index.html`
- [x] Displays at least one worked example of a bivector fingerprint (HC-1 canvas)
- [x] Partial-credit scoring concept explained visually (progress-bar score board + "How to Read This")
- [x] `dotnet build -c Release` → 0 warnings, 0 errors

## Slice-2 scope (B-0438, not in this PR)

- Live alignment-audit data (fetch from raw GitHub or local JSON)
- Non-orthogonal witness signals (θ ≠ 90°, expose the sin(θ) factor)
- Animation of the bivector area as scores update

🤖 Generated with [Claude Code](https://claude.com/claude-code)