### PR TITLE
chore: regenerate BACKLOG.md index — add missing B-0494/B-0495/B-0496 rows

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -287,6 +287,9 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0491](backlog/P1/B-0491-dawn-universal-biz-templates-persona-map-2026-05-14.md)** B-0429.7 — Dawn + Universal business templates persona map
 - [ ] **[B-0492](backlog/P1/B-0492-cross-product-persona-reuse-refused-registry-2026-05-14.md)** B-0429.8 — Cross-product persona reuse map + refused-personas registry
 - [ ] **[B-0493](backlog/P1/B-0493-skill-catalog-persona-crossref-2026-05-14.md)** B-0429.9 — Skill catalog × persona cross-reference
+- [ ] **[B-0494](backlog/P1/B-0494-circuit-breaker-live-bus-snapshot-2026-05-14.md)** Circuit breaker viz — slice-2: wire renderCircuitBreakerTab() to live bus snapshot
+- [x] **[B-0495](backlog/P1/B-0495-hamiltonian-viz-slice-1-static-scaffold-2026-05-14.md)** Hamiltonian viz — slice-1: static panel scaffold in demo/index.html
+- [ ] **[B-0496](backlog/P1/B-0496-hamiltonian-viz-slice-2-live-github-api-2026-05-14.md)** Hamiltonian viz — slice-2: live GitHub API commit fetch → trajectory
 
 ## P2 — research-grade
 


### PR DESCRIPTION
## Summary

- Three P1 backlog rows (B-0494, B-0495, B-0496) added via recent PRs were missing from `docs/BACKLOG.md` generated index
- B-0495 (Hamiltonian viz slice-1) correctly marked `[x]` — closed by PR #3135
- Fixes the non-required `check docs/BACKLOG.md generated-index drift` CI check that was failing on PR #3138

## Test plan

- [x] `bun tools/backlog/generate-index.ts --check` → `ok: matches generator output`
- [x] `git diff --stat` shows exactly 3 lines added (the 3 missing P1 rows)
- CI `check docs/BACKLOG.md generated-index drift` should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)