### PR TITLE
fix(b-0437): address Copilot P1 findings from PR #3138

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1052,7 +1052,7 @@
                     </svg>
                     <h2 id="uxm-worked-example-title">Worked Example — Bivector Fingerprint (HC-1)</h2>
                 </div>
-                <p style="color:var(--text-muted); font-size:0.9rem; margin-bottom: 1rem;">
+                <p id="uxm-worked-example-desc" style="color:var(--text-muted); font-size:0.9rem; margin-bottom: 1rem;">
                     HC-1 "Non-deceptive" is witnessed by two independent signals:
                     <em>adherence strength</em> (how consistently the agent avoids deceptive outputs)
                     and <em>evidence quality</em> (how well-evidenced that claim is from commit history).
@@ -2350,6 +2350,12 @@
             const titleEl = document.getElementById('uxm-worked-example-title');
             if (titleEl) titleEl.textContent =
                 'Worked Example — Bivector Fingerprint (' + clause.id + ')';
+            const descEl = document.getElementById('uxm-worked-example-desc');
+            if (descEl) descEl.textContent =
+                clause.id + ' “' + clause.name + '” is witnessed by two independent signals'
+                + ' (v₁ = ' + clause.v1 + ', v₂ = ' + clause.v2 + ').'
+                + ' Their wedge product — the shaded area — is the bivector fingerprint:'
+                + ' the partial-credit score.';
             uxmDrawBivector(thetaDeg, clause.v1, clause.v2, clause.id + ': ' + clause.name);
             uxmUpdateThetaDisplay(thetaDeg, clause.v1, clause.v2);
             document.querySelectorAll('#uxm-score-board [data-clause-id]').forEach(el => {
@@ -2374,8 +2380,14 @@
                 row.style.cssText = 'background:rgba(0,0,0,0.2);border-radius:10px;'
                     + 'padding:0.75rem 1rem;border:1px solid rgba(255,255,255,0.04);'
                     + 'cursor:pointer;transition:background 0.2s,border-color 0.2s;';
+                row.setAttribute('role', 'button');
+                row.setAttribute('tabindex', '0');
+                row.setAttribute('aria-label', clause.id + ': ' + clause.name);
                 row.setAttribute('data-clause-id', clause.id);
                 row.addEventListener('click', () => uxmSelectClause(clause));
+                row.addEventListener('keydown', e => {
+                    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); uxmSelectClause(clause); }
+                });
 
                 const hdr = document.createElement('div');
                 hdr.style.cssText = 'display:flex;justify-content:space-between;'

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -247,7 +247,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0434](backlog/P1/B-0434-demo-alignment-tab-slice-1-hc-sd-dir-clause-coverage.md)** Demo alignment tab — slice 1: HC/SD/DIR clause coverage panel in demo/index.html
 - [ ] **[B-0435](backlog/P1/B-0435-demo-circuit-breaker-visualization-panel-2026-05-13.md)** Demo — circuit breaker visualization panel (mock data → live bus data)
 - [ ] **[B-0436](backlog/P1/B-0436-demo-hamiltonian-to-git-visualization-2026-05-13.md)** Demo — Hamiltonian-to-git visualization (git history → phase-space rendering)
-- [ ] **[B-0437](backlog/P1/B-0437-demo-ux-of-math-panel-bivector-fingerprints-2026-05-13.md)** Demo — UX-of-math panel (bivector fingerprints, partial-credit scoring)
+- [x] **[B-0437](backlog/P1/B-0437-demo-ux-of-math-panel-bivector-fingerprints-2026-05-13.md)** Demo — UX-of-math panel (bivector fingerprints, partial-credit scoring)
 - [ ] **[B-0440](backlog/P1/B-0440-standing-by-failure-mode-detector-background-service-2026-05-13.md)** Standing-by failure-mode detector — background service that catches idle-foreground + nudges via bus
 - [ ] **[B-0441](backlog/P1/B-0441-backlog-row-ready-to-grind-notifier-background-service-2026-05-13.md)** Backlog-row-ready-to-grind notifier — background service that proactively assigns claims when agent queue empty
 - [ ] **[B-0442](backlog/P1/B-0442-missed-substrate-cascade-detector-background-service-2026-05-13.md)** Missed-substrate cascade detector — background service that catches branch-vs-merged-PR drift (e.g., Otto-section-missed-PR-2980-by-3-min class)
@@ -287,6 +287,9 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0491](backlog/P1/B-0491-dawn-universal-biz-templates-persona-map-2026-05-14.md)** B-0429.7 — Dawn + Universal business templates persona map
 - [ ] **[B-0492](backlog/P1/B-0492-cross-product-persona-reuse-refused-registry-2026-05-14.md)** B-0429.8 — Cross-product persona reuse map + refused-personas registry
 - [ ] **[B-0493](backlog/P1/B-0493-skill-catalog-persona-crossref-2026-05-14.md)** B-0429.9 — Skill catalog × persona cross-reference
+- [ ] **[B-0494](backlog/P1/B-0494-circuit-breaker-live-bus-snapshot-2026-05-14.md)** Circuit breaker viz — slice-2: wire renderCircuitBreakerTab() to live bus snapshot
+- [x] **[B-0495](backlog/P1/B-0495-hamiltonian-viz-slice-1-static-scaffold-2026-05-14.md)** Hamiltonian viz — slice-1: static panel scaffold in demo/index.html
+- [ ] **[B-0496](backlog/P1/B-0496-hamiltonian-viz-slice-2-live-github-api-2026-05-14.md)** Hamiltonian viz — slice-2: live GitHub API commit fetch → trajectory
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0437-demo-ux-of-math-panel-bivector-fingerprints-2026-05-13.md
+++ b/docs/backlog/P1/B-0437-demo-ux-of-math-panel-bivector-fingerprints-2026-05-13.md
@@ -1,7 +1,7 @@
 ---
 id: B-0437
 priority: P1
-status: done
+status: closed
 title: "Demo — UX-of-math panel (bivector fingerprints, partial-credit scoring)"
 tier: product-demo
 effort: L


### PR DESCRIPTION
## Summary

Addresses three P1 findings from `copilot-pull-request-reviewer` on merged PR #3138 (feat(b-0437) UX-of-math slice-3):

- **Status enum fix**: `docs/backlog/P1/B-0437-*.md` had `status: done` which is not in the generator's supported enum (`open`/`closed`/`superseded-by-*`/`deferred`/`decomposed`). Changed to `status: closed`.

- **Accessibility fix**: Score-board rows in `uxmRenderScoreBoard()` were bare `div`s — added `role="button"`, `tabindex="0"`, `aria-label`, and a `keydown` handler (Enter / Space) so keyboard and screen-reader users can activate clause selection.

- **Description sync bug**: `#uxm-worked-example-desc` paragraph always showed the HC-1 text ("HC-1 'Non-deceptive' is witnessed by…") even after clicking other clauses. Added the id to the paragraph and updated `uxmSelectClause()` to rewrite it with the selected clause's id, name, and signal values.

Also regenerates `docs/BACKLOG.md` to reflect B-0437 now `[x]` closed.

## Test plan

- [x] `dotnet build -c Release` → 0 warnings, 0 errors
- [x] `bun tools/backlog/generate-index.ts --check` → ok
- [ ] Demo: click any row in the score board → title, canvas, AND description paragraph all update to reflect the selected clause
- [ ] Demo: Tab to a score-board row → Enter/Space activates clause selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)