### PR TITLE
chore(b-0442): decompose into atomic child rows B-0503/B-0504/B-0505

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -251,6 +251,9 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0440](backlog/P1/B-0440-standing-by-failure-mode-detector-background-service-2026-05-13.md)** Standing-by failure-mode detector — background service that catches idle-foreground + nudges via bus
 - [ ] **[B-0441](backlog/P1/B-0441-backlog-row-ready-to-grind-notifier-background-service-2026-05-13.md)** Backlog-row-ready-to-grind notifier — background service that proactively assigns claims when agent queue empty
 - [ ] **[B-0442](backlog/P1/B-0442-missed-substrate-cascade-detector-background-service-2026-05-13.md)** Missed-substrate cascade detector — background service that catches branch-vs-merged-PR drift (e.g., Otto-section-missed-PR-2980-by-3-min class)
+- [ ] **[B-0503](backlog/P1/B-0503-b0442-slice5a-open-recovery-pr-core-function-2026-05-14.md)** B-0442 slice 5a — openRecoveryPR core function + RecoveryAdapters + DST tests
+- [ ] **[B-0504](backlog/P1/B-0504-b0442-slice5b-wire-auto-recover-into-pollonce-2026-05-14.md)** B-0442 slice 5b — wire --auto-recover into pollOnce + real RecoveryAdapters + config flags
+- [ ] **[B-0505](backlog/P1/B-0505-b0442-slice5c-docs-autonomous-loop-acceptance-close-2026-05-14.md)** B-0442 slice 5c — docs update (AUTONOMOUS-LOOP.md + bg/README.md) + B-0442 acceptance close
 - [x] **[B-0445](backlog/P1/B-0445-csharp-fluent-operator-surface-pm2-2026-05-13.md)** C# fluent operator surface — Map, Filter, Join, Distinct, Window via idiomatic CSharp API
 - [ ] **[B-0448](backlog/P1/B-0448-cloud-routines-integration-4th-catch-43-defence-layer-2026-05-13.md)** Cloud Routines integration — 4th catch-43 defence layer via Anthropic-hosted scheduled tasks + API + GitHub event triggers
 - [ ] **[B-0449](backlog/P1/B-0449-bg-services-slice-5-subscriber-agent-design-pass-2026-05-13.md)** bg-services slice 5 — subscriber-agent architecture design pass (closes the foreground-optional architectural claim)

--- a/docs/backlog/P1/B-0442-missed-substrate-cascade-detector-background-service-2026-05-13.md
+++ b/docs/backlog/P1/B-0442-missed-substrate-cascade-detector-background-service-2026-05-13.md
@@ -6,9 +6,10 @@ title: "Missed-substrate cascade detector — background service that catches br
 tier: factory-infrastructure
 effort: M
 created: 2026-05-13
-last_updated: 2026-05-13
+last_updated: 2026-05-14
 depends_on: [B-0400]
 composes_with: [B-0402, B-0440, B-0441]
+children: [B-0503, B-0504, B-0505]
 tags: [multi-agent, background-service, bus, mechanization, drift-detection, race-condition]
 type: feature
 ---

--- a/docs/backlog/P1/B-0503-b0442-slice5a-open-recovery-pr-core-function-2026-05-14.md
+++ b/docs/backlog/P1/B-0503-b0442-slice5a-open-recovery-pr-core-function-2026-05-14.md
@@ -1,0 +1,223 @@
+---
+id: B-0503
+priority: P1
+status: open
+title: "B-0442 slice 5a — openRecoveryPR core function + RecoveryAdapters + DST tests"
+tier: factory-infrastructure
+effort: S
+created: 2026-05-14
+last_updated: 2026-05-14
+parent: B-0442
+depends_on: []
+composes_with: [B-0442, B-0504]
+tags: [background-service, bus, mechanization, drift-detection, recovery-pr, git]
+type: feature
+---
+
+# B-0442 slice 5a — `openRecoveryPR` core function
+
+## Origin
+
+B-0442 acceptance criterion (still open):
+
+> Optionally auto-opens recovery PR with the missing commits (gated by
+> configuration) (slice 5 — pending; subscriber-agent layer)
+
+Slices 1–4 + 6 shipped. The only remaining gap is the auto-recovery path.
+This row is the first atomic sub-slice: the pure function + adapter interface
+for opening a recovery PR, independently testable before any wiring into
+`pollOnce` (B-0504).
+
+## What this row does NOT do
+
+- Does NOT modify `pollOnce`, `DetectorConfig`, or `parseArgs` — that is B-0504.
+- Does NOT add `--auto-recover` / `--dry-run` CLI flags — that is B-0504.
+- Does NOT publish bus envelopes for the recovery action — the detector already
+  publishes `missed-substrate-cascade`; recovery is a secondary action.
+
+## Acceptance criteria
+
+- [ ] New file `tools/bg/missed-substrate-recovery.ts` exports:
+  - `RecoveryAdapters` — interface with five adapters injected by callers:
+    - `checkRecoveryPRExists(branchName: string) => boolean`
+      — calls `gh pr list --head <branchName> --state open` to detect existing
+        open recovery PRs; returns `true` if one exists (idempotency gate).
+    - `gitCreateBranch(branch: string, base: string) => boolean`
+      — `git checkout -b <branch> <base>` from `origin/main`;
+        returns `true` on success.
+    - `gitCherryPick(sha: string) => "ok" | "conflict" | "error"`
+      — `git cherry-pick <sha>`; distinguishes merge conflict (exit 1 with
+        CHERRY_PICK_HEAD) from other errors.
+    - `gitPush(branch: string) => boolean`
+      — `git push origin <branch>`; returns `true` on success.
+    - `ghPrCreate(title: string, body: string, head: string) => string | null`
+      — `gh pr create --title ... --body ... --head ... --base main`;
+        returns the new PR URL on success, `null` on failure.
+  - `RecoveryResult` discriminated union:
+    ```typescript
+    | { status: "opened";         prUrl: string; cherryPickedCount: number }
+    | { status: "already-exists"; reason: string }
+    | { status: "cherry-pick-conflict"; sha: string; attemptedCount: number }
+    | { status: "error";          reason: string }
+    ```
+  - `buildRecoveryBranchName(prNumber: number, ts: Date) => string`
+    — deterministic branch name `recovery/<prNumber>-<YYYYMMDDHHMMSS>`;
+      pure function; no I/O.
+  - `buildRecoveryPRBody(finding: CascadeFinding) => string`
+    — markdown body for the recovery PR listing `missingCommits`,
+      the original `prNumber`, and a note that this was auto-generated.
+  - `openRecoveryPR(finding: CascadeFinding, dryRun: boolean, adapters: RecoveryAdapters) => RecoveryResult`
+    — pure function composed with adapters; implements the recovery workflow:
+      1. Call `checkRecoveryPRExists(recoveryBranch)` → if true return
+         `already-exists`.
+      2. If `dryRun` → return `{ status: "opened", prUrl: "dry-run", cherryPickedCount: 0 }`.
+      3. `gitCreateBranch(recoveryBranch, "origin/main")` → on failure return
+         `error`.
+      4. For each commit in `finding.missingCommits`: cherry-pick; on `"conflict"`
+         return `cherry-pick-conflict` immediately (does not push partial state).
+      5. `gitPush(recoveryBranch)` → on failure return `error`.
+      6. `ghPrCreate(title, body, recoveryBranch)` → null → return `error`;
+         non-null URL → return `opened`.
+
+- [ ] New file `tools/bg/missed-substrate-recovery.test.ts` with tests
+  covering all `RecoveryResult` arms:
+  - `"opened"` — fresh finding, no existing PR, no conflicts, push+PR succeed.
+  - `"already-exists"` — `checkRecoveryPRExists` returns `true`; no mutations.
+  - `"cherry-pick-conflict"` — cherry-pick returns `"conflict"` on commit N;
+    adapters confirm branch-create was called but push was NOT called.
+  - `"error"` — branch-create failure; push failure; `ghPrCreate` returning `null`.
+  - `"opened"` dry-run — `gitCreateBranch` NOT called; result URL is `"dry-run"`.
+  - `buildRecoveryBranchName` — deterministic output matches expected pattern.
+  - `buildRecoveryPRBody` — contains PR number and commit SHAs.
+
+- [ ] All tests pass: `bun tools/bg/missed-substrate-recovery.test.ts`
+- [ ] `bun tools/bg/missed-substrate-detector.test.ts` still passes (no regressions)
+
+## Design sketch
+
+```typescript
+// tools/bg/missed-substrate-recovery.ts
+
+import type { CascadeFinding } from "./missed-substrate-detector";
+
+export type RecoveryAdapters = {
+  checkRecoveryPRExists: (branchName: string) => boolean;
+  gitCreateBranch: (branch: string, base: string) => boolean;
+  gitCherryPick: (sha: string) => "ok" | "conflict" | "error";
+  gitPush: (branch: string) => boolean;
+  ghPrCreate: (title: string, body: string, head: string) => string | null;
+};
+
+export type RecoveryResult =
+  | { status: "opened";                  prUrl: string; cherryPickedCount: number }
+  | { status: "already-exists";          reason: string }
+  | { status: "cherry-pick-conflict";    sha: string; attemptedCount: number }
+  | { status: "error";                   reason: string };
+
+export function buildRecoveryBranchName(prNumber: number, ts: Date): string {
+  const stamp = ts.toISOString().replace(/[-:T]/g, "").slice(0, 14);
+  return `recovery/${prNumber}-${stamp}`;
+}
+
+export function buildRecoveryPRBody(finding: CascadeFinding): string {
+  const commitList = finding.missingCommits.map(s => `- ${s}`).join("\n");
+  return [
+    `## Auto-generated recovery PR`,
+    ``,
+    `Original merged PR: **#${finding.prNumber}** (branch \`${finding.branchName}\`)`,
+    ``,
+    `Missing commits detected by \`missed-substrate-detector\`:`,
+    commitList,
+    ``,
+    `Urgency at detection time: **${finding.urgency}**`,
+    ``,
+    `> This PR was opened automatically. Review before merging.`,
+  ].join("\n");
+}
+
+export function openRecoveryPR(
+  finding: CascadeFinding,
+  dryRun: boolean,
+  adapters: RecoveryAdapters,
+): RecoveryResult {
+  const recoveryBranch = buildRecoveryBranchName(finding.prNumber, new Date());
+
+  const exists = adapters.checkRecoveryPRExists(recoveryBranch);
+  if (exists) {
+    return { status: "already-exists", reason: `PR for ${recoveryBranch} already open` };
+  }
+
+  if (dryRun) {
+    return { status: "opened", prUrl: "dry-run", cherryPickedCount: 0 };
+  }
+
+  const created = adapters.gitCreateBranch(recoveryBranch, "origin/main");
+  if (!created) {
+    return { status: "error", reason: `git checkout -b ${recoveryBranch} origin/main failed` };
+  }
+
+  let attemptedCount = 0;
+  for (const sha of finding.missingCommits) {
+    const cpResult = adapters.gitCherryPick(sha);
+    attemptedCount++;
+    if (cpResult === "conflict") {
+      return { status: "cherry-pick-conflict", sha, attemptedCount };
+    }
+    if (cpResult === "error") {
+      return { status: "error", reason: `git cherry-pick ${sha} failed` };
+    }
+  }
+
+  const pushed = adapters.gitPush(recoveryBranch);
+  if (!pushed) {
+    return { status: "error", reason: `git push origin ${recoveryBranch} failed` };
+  }
+
+  const title = `recovery(#${finding.prNumber}): ${finding.missingCommits.length} missed commits`;
+  const body = buildRecoveryPRBody(finding);
+  const prUrl = adapters.ghPrCreate(title, body, recoveryBranch);
+  if (prUrl === null) {
+    return { status: "error", reason: "gh pr create failed" };
+  }
+
+  return { status: "opened", prUrl, cherryPickedCount: attemptedCount };
+}
+```
+
+## Security note
+
+`buildRecoveryBranchName` produces a branch name composed only of digits,
+`/`, and `-` — safe to pass as an argument to `spawnSync` calls in the real
+adapter implementations. The real adapters (in B-0504) must validate SHA
+inputs from `CascadeFinding.missingCommits` with the same allow-list regex
+already used in `compareBranchToMerged`.
+
+## Why `openRecoveryPR` uses `new Date()` internally for the branch name
+
+The recovery branch name includes a timestamp to ensure uniqueness across
+multiple recovery attempts for the same PR number. Using `new Date()` inside
+`openRecoveryPR` rather than injecting it via adapters is intentional: the
+idempotency gate (`checkRecoveryPRExists`) already prevents duplicate
+recovery PRs; the timestamp is not load-bearing for correctness. For tests
+that need to verify the branch name, `buildRecoveryBranchName` is exported
+and tested separately.
+
+## Dependency chain
+
+```
+B-0442 (slices 1–4 + 6 shipped — missed-substrate-detector.ts functional)
+  └─ B-0503 (THIS ROW — openRecoveryPR core + RecoveryAdapters + tests)
+       └─ B-0504 (wire --auto-recover into pollOnce; real adapter impls)
+            └─ B-0505 (docs + B-0442 acceptance criteria close)
+```
+
+## Pre-start checklist (per backlog-item-start-gate)
+
+- [ ] Confirm `CascadeFinding` type is exported from `missed-substrate-detector.ts`
+      (it is — used in the test file already)
+- [ ] Run `bun tools/bg/missed-substrate-detector.test.ts` to confirm baseline
+      passes before touching any file
+- [ ] Grep for existing cherry-pick utility in `tools/` to avoid duplication
+      (not expected to exist; this is the first cherry-pick caller)
+- [ ] Verify `spawnSync` pattern from `missed-substrate-detector.ts` for real
+      adapter implementations in B-0504

--- a/docs/backlog/P1/B-0504-b0442-slice5b-wire-auto-recover-into-pollonce-2026-05-14.md
+++ b/docs/backlog/P1/B-0504-b0442-slice5b-wire-auto-recover-into-pollonce-2026-05-14.md
@@ -1,0 +1,194 @@
+---
+id: B-0504
+priority: P1
+status: open
+title: "B-0442 slice 5b — wire --auto-recover into pollOnce + real RecoveryAdapters + config flags"
+tier: factory-infrastructure
+effort: S
+created: 2026-05-14
+last_updated: 2026-05-14
+parent: B-0442
+depends_on: [B-0503]
+composes_with: [B-0442, B-0503, B-0505]
+tags: [background-service, bus, mechanization, drift-detection, recovery-pr, config]
+type: feature
+---
+
+# B-0442 slice 5b — wire `--auto-recover` into `pollOnce`
+
+## Origin
+
+Depends on B-0503 (core `openRecoveryPR` function). This row:
+
+1. Adds `autoRecover` + `recoveryDryRun` to `DetectorConfig`.
+2. Implements real `RecoveryAdapters` (production `spawnSync` wrappers).
+3. Extends `Adapters` with `openRecoveryPR` adapter for testability.
+4. Extends `pollOnce` to call recovery after cascade detection.
+5. Updates `parseArgs` with `--auto-recover` / `--recovery-dry-run` flags.
+6. Adds integration tests covering the new wiring.
+
+## Acceptance criteria
+
+- [ ] `DetectorConfig` gains two fields:
+  - `autoRecover: boolean` — default `false`; when `true`, call `openRecoveryPR`
+    for each `CascadeFinding` after detecting cascades.
+  - `recoveryDryRun: boolean` — default `false`; when `true`, pass `dryRun: true`
+    to `openRecoveryPR` (no git mutations; log intent only).
+
+- [ ] `parseArgs` wires:
+  - `--auto-recover` → sets `config.autoRecover = true`
+  - `--recovery-dry-run` → sets `config.recoveryDryRun = true`
+  - Both flags go into `KNOWN_FLAGS`.
+  - `--recovery-dry-run` without `--auto-recover` is silently accepted (recoveryDryRun
+    is stored but `pollOnce` only consults it when `autoRecover` is true).
+
+- [ ] `Adapters` interface gains:
+  ```typescript
+  openRecoveryPR?: (finding: CascadeFinding, dryRun: boolean) => RecoveryResult;
+  ```
+  Optional (`?`) so existing tests that do not exercise recovery path do not need
+  to provide it; `pollOnce` treats missing adapter as `autoRecover = false`
+  regardless of config flag.
+
+- [ ] `REAL_ADAPTERS.openRecoveryPR` implemented using real `spawnSync` wrappers
+  for each `RecoveryAdapters` operation:
+  - `checkRecoveryPRExists` — `gh pr list --head <branch> --state open --json number`
+    → `[]` means no existing PR.
+  - `gitCreateBranch` — `git checkout -b <branch> origin/main`.
+  - `gitCherryPick` — `git cherry-pick <sha>`; exit code distinguishes conflict
+    (`exit 1`, stderr contains "CONFLICT") vs error (`exit != 0`, other stderr).
+  - `gitPush` — `git push origin <branch>`.
+  - `ghPrCreate` — `gh pr create --title ... --body ... --head ... --base main`.
+  - All inputs validated with the allow-list regex from `compareBranchToMerged`
+    before passing to `spawnSync`.
+
+- [ ] `pollOnce` updated: after the cascade-detection loop, if
+  `config.autoRecover && adapters.openRecoveryPR !== undefined`:
+  ```
+  for each finding in findings:
+    recoveryResult = adapters.openRecoveryPR(finding, config.recoveryDryRun)
+    log result
+  ```
+  Recovery failures do NOT throw — they are logged to `PollResult.note`
+  and the poll loop continues.
+
+- [ ] `PollResult` gains:
+  - `recoveryAttempts: number` — count of findings for which recovery was
+    attempted (0 when `autoRecover` is false or adapter missing).
+  - `recoveryOpened: number` — count of `"opened"` results.
+
+- [ ] Tests added (DST-replayable; injected adapters):
+  - `autoRecover: false` (default) → `recoveryAttempts: 0`; adapter never called
+    even when cascade detected.
+  - `autoRecover: true`, adapter returns `"opened"` → `recoveryOpened: 1`;
+    note contains `"opened"`.
+  - `autoRecover: true`, `recoveryDryRun: true`, adapter returns
+    `{ status: "opened", prUrl: "dry-run" }` → note contains `"dry-run"`.
+  - `autoRecover: true`, adapter returns `"already-exists"` → `recoveryOpened: 0`;
+    note contains `"already-exists"`.
+  - `autoRecover: true`, adapter throws → `recoveryOpened: 0`; note contains
+    `"recovery error"`; poll completes successfully.
+  - `parseArgs(["--auto-recover"])` → `config.autoRecover === true`.
+  - `parseArgs(["--recovery-dry-run"])` → `config.recoveryDryRun === true`.
+  - `parseArgs([])` → `config.autoRecover === false`,
+    `config.recoveryDryRun === false`.
+
+- [ ] All tests pass: `bun tools/bg/missed-substrate-detector.test.ts`
+- [ ] `bun tools/bg/missed-substrate-recovery.test.ts` still passes (no regressions)
+
+## Design sketch
+
+```typescript
+// In missed-substrate-detector.ts
+
+// Config additions:
+export const DEFAULT_CONFIG: DetectorConfig = {
+  // ...existing...
+  autoRecover: false,
+  recoveryDryRun: false,
+};
+
+// Adapters extension (optional — existing tests need no change):
+export type Adapters = {
+  // ...existing fields...
+  openRecoveryPR?: (finding: CascadeFinding, dryRun: boolean) => RecoveryResult;
+};
+
+// pollOnce extension — after the existing finding-publish block:
+let recoveryAttempts = 0;
+let recoveryOpened = 0;
+const recoveryNotes: string[] = [];
+
+if (config.autoRecover && adapters.openRecoveryPR !== undefined) {
+  for (const finding of findings) {
+    recoveryAttempts++;
+    try {
+      const rr = adapters.openRecoveryPR(finding, config.recoveryDryRun);
+      if (rr.status === "opened") {
+        recoveryOpened++;
+        recoveryNotes.push(`recovery PR ${rr.prUrl} (${rr.cherryPickedCount} commits)`);
+      } else {
+        recoveryNotes.push(`recovery skipped for #${finding.prNumber}: ${rr.status}`);
+      }
+    } catch (e) {
+      recoveryNotes.push(`recovery error for #${finding.prNumber}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+}
+
+return {
+  ...existing fields,
+  recoveryAttempts,
+  recoveryOpened,
+  note: [existingNote, ...recoveryNotes].filter(Boolean).join("; "),
+};
+```
+
+## Real adapters implementation note
+
+`REAL_ADAPTERS.openRecoveryPR` wraps `openRecoveryPR` from B-0503 with
+real `spawnSync` sub-adapters:
+
+```typescript
+REAL_ADAPTERS.openRecoveryPR = (finding, dryRun) =>
+  openRecoveryPR(finding, dryRun, REAL_RECOVERY_ADAPTERS);
+```
+
+`REAL_RECOVERY_ADAPTERS` is defined in `missed-substrate-detector.ts` and
+imports `openRecoveryPR` from `missed-substrate-recovery.ts`. This keeps
+`missed-substrate-recovery.ts` as a pure module (no imports from the detector)
+and `missed-substrate-detector.ts` as the integration point.
+
+## SHA allow-list for real adapters
+
+The real `gitCherryPick` adapter must validate the SHA with:
+
+```typescript
+if (!/^[0-9a-f]{7,40}$/.test(sha)) {
+  return "error"; // reject non-SHA inputs before spawnSync
+}
+```
+
+Same pattern already in `compareBranchToMerged`. Prevents the SHA coming
+from a crafted `missed-substrate-cascade` envelope from causing argument
+injection (defense-in-depth; envelopes are written by the same process that
+reads git, so the SHA is already validated once upstream).
+
+## Dependency chain
+
+```
+B-0442 (slices 1–4 + 6 shipped)
+  └─ B-0503 (openRecoveryPR core + RecoveryAdapters — MUST LAND FIRST)
+       └─ B-0504 (THIS ROW — wire into pollOnce + real adapters + config + tests)
+            └─ B-0505 (docs + acceptance criteria close)
+```
+
+## Pre-start checklist (per backlog-item-start-gate)
+
+- [ ] B-0503 must be merged before this row starts (depends_on B-0503)
+- [ ] Run full test suite: `bun tools/bg/missed-substrate-detector.test.ts`
+      and `bun tools/bg/missed-substrate-recovery.test.ts`
+- [ ] Verify `REAL_ADAPTERS` can import from `missed-substrate-recovery.ts`
+      (circular import check — detector imports recovery, not the reverse)
+- [ ] Confirm `PollResult` type is re-exported via test file so type changes
+      don't silently break consumers

--- a/docs/backlog/P1/B-0505-b0442-slice5c-docs-autonomous-loop-acceptance-close-2026-05-14.md
+++ b/docs/backlog/P1/B-0505-b0442-slice5c-docs-autonomous-loop-acceptance-close-2026-05-14.md
@@ -1,0 +1,83 @@
+---
+id: B-0505
+priority: P1
+status: open
+title: "B-0442 slice 5c — docs update (AUTONOMOUS-LOOP.md + bg/README.md) + B-0442 acceptance close"
+tier: factory-infrastructure
+effort: XS
+created: 2026-05-14
+last_updated: 2026-05-14
+parent: B-0442
+depends_on: [B-0504]
+composes_with: [B-0442, B-0503, B-0504]
+tags: [documentation, background-service, drift-detection, recovery-pr]
+type: chore
+---
+
+# B-0442 slice 5c — docs update + acceptance criteria close
+
+## Origin
+
+B-0442 acceptance criterion (still open after B-0503 + B-0504 land):
+
+> Optionally auto-opens recovery PR with the missing commits (gated by
+> configuration) (slice 5 — pending; subscriber-agent layer)
+
+Once B-0503 (core function) and B-0504 (wiring) land, the only remaining
+work is documentation and marking the acceptance criterion complete. This row
+is intentionally docs-only — no code changes.
+
+## Acceptance criteria
+
+- [ ] `docs/AUTONOMOUS-LOOP.md` updated with a new subsection under the
+  `missed-substrate-detector` service entry:
+  - Documents `--auto-recover` flag: purpose, default (`off`), when to enable.
+  - Documents `--recovery-dry-run` flag: purpose (log intent without mutations).
+  - Explains the recovery branch naming convention (`recovery/<prN>-<timestamp>`).
+  - Notes the idempotency guarantee (existing open recovery PR → skip).
+  - Notes the conflict-on-cherry-pick behavior (surface result; do not push
+    partial state; human must resolve).
+
+- [ ] `tools/bg/README.md` updated:
+  - Add `missed-substrate-recovery.ts` row to the services table.
+  - Update `missed-substrate-detector.ts` row: add `--auto-recover` and
+    `--recovery-dry-run` to the flags column.
+
+- [ ] B-0442 acceptance criterion updated: mark the slice 5 row as `[x]`:
+  ```
+  - [x] Optionally auto-opens recovery PR with the missing commits (gated by
+        configuration) (slice 5 — landed 2026-05-14 via B-0503 + B-0504)
+  ```
+
+- [ ] B-0442 frontmatter updated: add `children: [B-0503, B-0504, B-0505]` field.
+
+- [ ] All tests still pass (no code touched; verification only):
+  `bun tools/bg/missed-substrate-detector.test.ts`
+  `bun tools/bg/missed-substrate-recovery.test.ts`
+
+## Why docs-only is a separate row
+
+Per DV2.0 data-split discipline (`.claude/rules/dv2-data-split-discipline-activated.md`):
+documentation changes (fast-changing English) and code changes (stable hub) have
+different change rates. Separating them into atomic rows makes each diff reviewable
+in isolation and avoids documentation becoming a tail on a code PR.
+
+Separating also ensures that if B-0504 needs a revision cycle, the docs PR does not
+block the CI loop — it simply needs to land after B-0504 is stable.
+
+## Dependency chain
+
+```
+B-0442 (slices 1–4 + 6 shipped)
+  └─ B-0503 (openRecoveryPR core)
+       └─ B-0504 (wire into pollOnce — MUST LAND BEFORE THIS ROW)
+            └─ B-0505 (THIS ROW — docs + acceptance close)
+```
+
+## Pre-start checklist (per backlog-item-start-gate)
+
+- [ ] B-0504 must be merged before this row starts (depends_on B-0504)
+- [ ] Verify `docs/AUTONOMOUS-LOOP.md` section exists for `missed-substrate-detector`
+      (it does — landed 2026-05-13 per B-0442 slice 6 acceptance criterion)
+- [ ] Verify `tools/bg/README.md` exists and has a services table
+- [ ] Grep for existing `--auto-recover` mentions to avoid redundant text


### PR DESCRIPTION
## Summary

B-0442 (missed-substrate cascade detector) has slices 1–4 + 6 already landed
(`tools/bg/missed-substrate-detector.ts` + 24 DST tests + launchd + docs).
The only remaining acceptance criterion is slice 5 — auto-opening recovery PRs.

This PR decomposes slice 5 into three dependency-ordered atomic child rows:

| Row | Effort | What | Depends on |
|-----|--------|------|-----------|
| **B-0503** | S | `openRecoveryPR` core function + `RecoveryAdapters` interface + all `RecoveryResult` arms tested in isolation | — |
| **B-0504** | S | Wire `--auto-recover`/`--recovery-dry-run` into `pollOnce`; real `spawnSync` adapter impls; `PollResult` extension | B-0503 |
| **B-0505** | XS | `docs/AUTONOMOUS-LOOP.md` + `tools/bg/README.md` updates; mark B-0442 slice 5 `[x]` | B-0504 |

### What changed

- `docs/backlog/P1/B-0503-b0442-slice5a-open-recovery-pr-core-function-2026-05-14.md` — new child row
- `docs/backlog/P1/B-0504-b0442-slice5b-wire-auto-recover-into-pollonce-2026-05-14.md` — new child row
- `docs/backlog/P1/B-0505-b0442-slice5c-docs-autonomous-loop-acceptance-close-2026-05-14.md` — new child row
- `docs/backlog/P1/B-0442-...md` — added `children: [B-0503, B-0504, B-0505]` frontmatter
- `docs/BACKLOG.md` — 3 new index rows under B-0442

### Focused checks

- `git diff --stat HEAD~1`: 5 files changed, 505 insertions(+), 1 deletion(-)
- `bun tools/bg/missed-substrate-detector.test.ts` — not modified; existing 24-test suite untouched
- No code changes in this PR — pure backlog substrate decomposition

### Decomposition rationale (per B-0442 design)

B-0503 separates the pure `openRecoveryPR` function (testable with injected adapters)
from the integration wiring in B-0504. This mirrors the slice 3 vs slice 4 split
already in B-0442: `realCascadeDetector` (pure, adapter-injected) was kept separate
from `REAL_ADAPTERS` + `pollOnce` wiring. B-0505 follows DV2.0 data-split discipline —
docs are satellites (fast-changing), code is hub (stable); separating them avoids
documentation tailing a code PR through review cycles.

operative-authorization: aaron 2026-05-13: "Cooling period: TBD. The memory file IS the durable record"