### PR TITLE
chore(b-0502): launchd plist for backlog-ready-notifier (B-0441 slice 6)

### DIFF
--- a/.gemini/launchd/com.zeta.backlog-ready-notifier.plist
+++ b/.gemini/launchd/com.zeta.backlog-ready-notifier.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.zeta.backlog-ready-notifier</string>
+    <!-- Maintainer-only artifact: paths are machine-specific (/Users/acehack, /opt/homebrew).
+         Run tools/setup/install-launchd-services.sh to regenerate with local paths. -->
+    <key>ProgramArguments</key><array>
+        <string>/opt/homebrew/bin/bun</string>
+        <string>/Users/acehack/Documents/src/repos/Zeta/tools/bg/backlog-ready-notifier.ts</string>
+        <string>--once</string>
+    </array>
+    <key>StartInterval</key><integer>600</integer>
+    <key>RunAtLoad</key><true/>
+    <key>StandardOutPath</key><string>/Users/acehack/Library/Logs/zeta-backlog-ready-notifier/stdout.log</string>
+    <key>StandardErrorPath</key><string>/Users/acehack/Library/Logs/zeta-backlog-ready-notifier/stderr.log</string>
+    <key>EnvironmentVariables</key><dict>
+        <key>HOME</key><string>/Users/acehack</string>
+        <key>PATH</key><string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>WorkingDirectory</key><string>/Users/acehack/Documents/src/repos/Zeta</string>
+</dict>
+</plist>

--- a/docs/AUTONOMOUS-LOOP.md
+++ b/docs/AUTONOMOUS-LOOP.md
@@ -588,12 +588,16 @@ declared) against `CronList` and re-arms missing rows.
   proactive multi-agent loop is augmented by macOS `launchd` background
   daemons that ensure failure modes and deadlocks are broken without
   human intervention. See `tools/bg/`. Currently 4 services exist in
-  `tools/bg/`; only `missed-substrate-detector.ts` is launchd-registered
-  (`.gemini/launchd/com.zeta.missed-substrate-detector.plist`). The other
-  three (`backlog-ready-notifier.ts`, `standing-by-detector.ts`,
-  `audit-duplicate-row-ids.ts`) are invokable on demand via
-  `bun tools/bg/<name>.ts --once` but not yet wired to launchd (B-0441
-  acceptance #2 + B-0442 slice 5+ pending). Note: plist files contain
+  `tools/bg/`; `missed-substrate-detector.ts` and
+  `backlog-ready-notifier.ts` are launchd-registered
+  (`.gemini/launchd/com.zeta.missed-substrate-detector.plist`,
+  `.gemini/launchd/com.zeta.backlog-ready-notifier.plist`). The
+  remaining two (`standing-by-detector.ts`, `audit-duplicate-row-ids.ts`)
+  are invokable on demand via `bun tools/bg/<name>.ts --once` but not
+  yet wired to launchd (B-0497 for standing-by-detector; B-0442
+  slice 5+ for audit-duplicate-row-ids). `backlog-ready-notifier.ts`
+  produces `work-assignment` bus envelopes; see B-0460 for the
+  subscriber handler that consumes them. Note: plist files contain
   machine-specific paths and are maintainer-only artifacts.
 
 - **`docs/hygiene-history/loop-tick-history.md`** — the

--- a/docs/backlog/P1/B-0441-backlog-row-ready-to-grind-notifier-background-service-2026-05-13.md
+++ b/docs/backlog/P1/B-0441-backlog-row-ready-to-grind-notifier-background-service-2026-05-13.md
@@ -37,7 +37,7 @@ provides a less-ambiguous concrete claim — eliminating the
 ## Acceptance criteria
 
 - [ ] Background service `tools/bg/backlog-ready-notifier.ts` exists
-- [ ] Runs under existing launchd / cron infrastructure
+- [x] Runs under existing launchd / cron infrastructure (B-0502 — `.gemini/launchd/com.zeta.backlog-ready-notifier.plist`)
 - [ ] Periodically scans `docs/backlog/P*/B-*.md` for ready-to-grind
       rows (open, no blockers, dependencies satisfied)
 - [ ] Detects agent queue state (commits in last N minutes; current

--- a/docs/backlog/P1/B-0502-b0441-slice-6-launchd-plist-autonomous-loop-docs-2026-05-14.md
+++ b/docs/backlog/P1/B-0502-b0441-slice-6-launchd-plist-autonomous-loop-docs-2026-05-14.md
@@ -1,7 +1,7 @@
 ---
 id: B-0502
 priority: P1
-status: open
+status: in-progress
 title: "B-0441 slice 6 — launchd plist for backlog-ready-notifier + AUTONOMOUS-LOOP.md update"
 tier: factory-infrastructure
 effort: XS

--- a/tools/bg/README.md
+++ b/tools/bg/README.md
@@ -29,7 +29,7 @@ so future readers don't overclaim.
 | Service | File | Slice status | Detection signal | Bus topic |
 |---------|------|--------------|------------------|-----------|
 | Standing-by detector | `standing-by-detector.ts` | 1+2+3+4 live | commit-history (HEAD) + PR-activity (repo) via `gh`/`git` | `infinite-backlog-nudge` |
-| Backlog-ready notifier | `backlog-ready-notifier.ts` | 1+2+4 live | backlog-row scan (status + deps satisfied) | `work-assignment` |
+| Backlog-ready notifier | `backlog-ready-notifier.ts` | 1+2+4+6 live (slice 3 pending B-0500) | backlog-row scan (status + deps satisfied) | `work-assignment` |
 | Missed-substrate detector | `missed-substrate-detector.ts` | 1+2+3+4 live | merged-PR fetch via `gh`; real branch-vs-squash compare via `gh pr view --json headRefOid` + `git log <headRefOid>..origin/<branch>` (slice 3 landed 2026-05-13) | `missed-substrate-cascade` |
 
 Per-service slice ordering (each service decomposes into 6 slices):


### PR DESCRIPTION
## Summary

Closes **B-0441 acceptance #2** (\"Runs under existing launchd / cron infrastructure\") for `backlog-ready-notifier.ts`. Atomic XS slice from B-0502.

## Changes

- **`.gemini/launchd/com.zeta.backlog-ready-notifier.plist`** (new) — copy-adapted from `com.zeta.missed-substrate-detector.plist`:
  - `Label`: `com.zeta.backlog-ready-notifier`
  - `StartInterval`: `600` (10 min — matches `DEFAULT_CONFIG.pollIntervalMin`)
  - `ProgramArguments`: `[bun, .../tools/bg/backlog-ready-notifier.ts, --once]`
  - Log paths under `~/Library/Logs/zeta-backlog-ready-notifier/`
  - Same maintainer-note re machine-specific paths (audit-aware; flagged by `audit-machine-specific-content.ts` alongside sibling plists, as expected — plist files are the canonical home for machine-specific paths)
- **`docs/AUTONOMOUS-LOOP.md`** §Related artifacts — bumped from \"one launchd-registered\" to \"two launchd-registered\"; remaining gap calls out B-0497 (standing-by-detector) and B-0442 slice 5+ (audit-duplicate-row-ids); adds `work-assignment` + B-0460 subscriber-handler note per B-0502 AC.
- **`tools/bg/README.md`** §Current services — slice status `1+2+4 live` → `1+2+4+6 live (slice 3 pending B-0500)`. Slice 3 (queue-state guard, B-0500) has not yet merged, so it stays out of the live set.
- **`docs/backlog/P1/B-0441-...md`** — AC #2 checkbox ticked with pointer to the new plist.
- **`docs/backlog/P1/B-0502-...md`** — status: `open` → `in-progress` (closes when this PR merges).

## Verification

- Plist parses (`PlistBuddy -c \"Print :Label\"` returns `com.zeta.backlog-ready-notifier`; `StartInterval`=600; ProgramArguments resolves correctly)
- `npx markdownlint-cli2` on all changed docs exits 0
- No conflict markers, no empty dirs
- `bun tools/bg/backlog-ready-notifier.ts --once` exits 0 (confirmed at start of tick: 233 ready candidates, 3 envelopes published)

## Why XS effort

Copy-adapt + 3 doc edits. Per B-0502 row.

## Sibling

[B-0497](docs/backlog) — same pattern for `standing-by-detector.ts`. Can merge in any order.

## Branch-contamination footnote

This commit went through an untangle: between `git checkout -b otto/b0502-...` and `git commit`, another Otto process in the same repo checked out a different branch (`shard/tick-2018Z-39-candidate-triage-otto-cli-2026-05-14`), moving HEAD invisibly. The contaminated branch was reset back to its pre-contamination tip (`5bd5697`); the commit was cherry-picked to this branch from there. This is the exact pattern B-0519 RCA catalogued. The `ZETA_EXPECTED_BRANCH` hook didn't fire because env vars don't reliably persist across separate Bash-tool calls — worth a separate row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>