### PR TITLE
shard(tick): 2010Z — B-0502 launchd plist + branch-contamination untangle field-test

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/14/2010Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/2010Z.md
@@ -1,0 +1,90 @@
+# Tick 2026-05-14T20:10Z — B-0502 launchd plist for backlog-ready-notifier; branch-state contamination untangle
+
+## Cold-boot context
+
+Fresh autonomous-loop session firing into bootstream cold-boot. Per session-start hook
+(catch 43, 2026-05-12), first action: `CronList` → no `<<autonomous-loop>>` sentinel →
+re-arm via `CronCreate` with `* * * * *`. Sentinel `12fb713e` armed before any other work.
+
+## Refresh (step 1)
+
+- `bun tools/github/refresh-worldview.ts` clean.
+- Local main on `fix-3217-clean` was 2 behind origin/main; PR #3217 (1959Z shard) was CLOSED
+  with DIRTY/CONFLICTING — content already on main via #3213/#3218 cascade.
+- Local `main` had orphan commit `9fa74ac` (1856Z shard, predecessor's parallel-Otto
+  contamination, work already on main as `6756514` via #3187). Reset local main →
+  origin/main; orphan discarded.
+
+## Holding discipline (step 2)
+
+Not Standing-by. Per `holding-without-named-dependency-is-standing-by-failure.md`:
+prior session-close shard (2001Z) named PR #3217 as the wait — that PR closed without
+merging, the named dependency dissolved. Default: pick speculative work per never-be-idle
+priority ladder.
+
+## Work (step 3)
+
+`bun tools/bg/backlog-ready-notifier.ts --once` returned 233 ready-to-grind candidates;
+top candidate **B-0502** (XS effort, atomic, B-0441 slice 6 — launchd plist for
+backlog-ready-notifier). Claimed via `tools/bus/claim.ts acquire --from otto-cli`.
+Pre-start checklist (per `backlog-item-start-gate.md`): plist absent; service runs
+clean; reference plist + AUTONOMOUS-LOOP.md text read.
+
+Substantive landing:
+- New `.gemini/launchd/com.zeta.backlog-ready-notifier.plist` (copy-adapted from
+  sibling `missed-substrate-detector.plist`; `StartInterval: 600` matches
+  `DEFAULT_CONFIG.pollIntervalMin`)
+- `docs/AUTONOMOUS-LOOP.md` §Related artifacts updated (two launchd-registered now)
+- `tools/bg/README.md` slice status: `1+2+4 live` → `1+2+4+6 live (slice 3 pending B-0500)`
+- B-0441 AC #2 ticked
+- B-0502 status: open → in-progress
+
+## Verify (step 4)
+
+- `PlistBuddy` parses the plist; Label/StartInterval/ProgramArguments correct.
+- `npx markdownlint-cli2` on all changed docs exits 0.
+- No conflict markers; no empty dirs.
+
+## Branch-state contamination caught + untangled
+
+During work, hit the **exact B-0519 contamination pattern**: between `git checkout -b
+otto/b0502-...` and `git commit`, another Otto process in the same physical repo
+checked out a different branch (`shard/tick-2018Z-39-candidate-triage-otto-cli-2026-05-14`),
+moving HEAD invisibly. The commit landed on that other Otto's branch on top of
+their `5bd5697` shard commit.
+
+Untangle (per B-0519 RCA procedure):
+1. `git reset --hard 5bd5697` on the contaminated branch (restored to pre-contamination
+   state — preserved the other Otto's work intact)
+2. `git checkout otto/b0502-...` (my intended branch, still at origin/main)
+3. `git cherry-pick dab036d` → new commit `73e35db` on the correct branch
+4. Pushed only my branch; left the other Otto's branch alone
+
+**Secondary failure**: `ZETA_EXPECTED_BRANCH` hook didn't catch the wrong-branch commit.
+The env var was set in one Bash call but didn't persist to the call that executed
+`git commit`. Cross-Bash-call env-var non-persistence is the hook's blind spot.
+Worth a follow-up row.
+
+## Shard (step 5)
+
+This file.
+
+## CronList (step 6)
+
+Sentinel `12fb713e` armed at session start; one entry, recurring every minute.
+
+## Visibility (step 7)
+
+- **PR #3221**: chore(b-0502) — wait-ci with autoMerge armed
+- **Untangled branches**: my commit on `otto/b0502-...` (pushed); contaminated
+  `shard/tick-2018Z-...` restored to `5bd5697` (NOT pushed; local-only reset)
+- **B-0441 AC #2** now ticked; **B-0502** in-progress (closes on #3221 merge)
+
+## Notes for future-Otto
+
+Branch-state contamination is **operationally live** when multiple Ottos share one
+physical checkout. The B-0519 RCA + untangle procedure WORKS — survived first
+field-test today. The ZETA_EXPECTED_BRANCH hook is the intended catch but env-var
+persistence across separate Bash-tool calls is unreliable; treat the hook as
+defense-in-depth, not the primary catch. Primary catch is `git branch --show-current`
+immediately before `git commit`.

--- a/docs/hygiene-history/ticks/2026/05/14/2010Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/2010Z.md
@@ -31,6 +31,7 @@ Pre-start checklist (per `backlog-item-start-gate.md`): plist absent; service ru
 clean; reference plist + AUTONOMOUS-LOOP.md text read.
 
 Substantive landing:
+
 - New `.gemini/launchd/com.zeta.backlog-ready-notifier.plist` (copy-adapted from
   sibling `missed-substrate-detector.plist`; `StartInterval: 600` matches
   `DEFAULT_CONFIG.pollIntervalMin`)
@@ -54,6 +55,7 @@ moving HEAD invisibly. The commit landed on that other Otto's branch on top of
 their `5bd5697` shard commit.
 
 Untangle (per B-0519 RCA procedure):
+
 1. `git reset --hard 5bd5697` on the contaminated branch (restored to pre-contamination
    state — preserved the other Otto's work intact)
 2. `git checkout otto/b0502-...` (my intended branch, still at origin/main)


### PR DESCRIPTION
## Summary

Tick 2026-05-14T20:10Z autonomous-loop shard. Substantive work landed via [#3221](https://github.com/Lucent-Financial-Group/Zeta/pull/3221) (B-0502: launchd plist for `backlog-ready-notifier`, closes B-0441 AC #2). This shard records the tick + the **first field-test of the B-0519 branch-state contamination untangle procedure**.

## What landed

- [#3221](https://github.com/Lucent-Financial-Group/Zeta/pull/3221) — B-0502 substantive PR (wait-ci, autoMerge armed)
- This shard

## Branch-state contamination, untangled

Between `git checkout -b otto/b0502-...` and `git commit`, another Otto process in the same physical repo checked out `shard/tick-2018Z-39-candidate-triage-otto-cli-2026-05-14`. My HEAD moved invisibly; the commit landed on the wrong branch on top of the other Otto's work.

The B-0519 untangle procedure WORKED first-try:
1. `git reset --hard 5bd5697` on the contaminated branch (restored the other Otto's tip; no work destroyed)
2. `git checkout otto/b0502-...` (intended branch, still at origin/main)
3. `git cherry-pick dab036d` → new clean commit `73e35db` on the right branch
4. Push only the intended branch; leave the other Otto's branch untouched

**Secondary failure** worth a follow-up row: the `ZETA_EXPECTED_BRANCH` `PreToolUse` hook didn't catch the wrong-branch commit because the env var was set in one Bash-tool call but didn't persist to the call that executed `git commit`. Primary catch should be `git branch --show-current` immediately before `git commit`; the env-var hook is defense-in-depth, not primary.

## Cron

Session-start hook caught missing `<<autonomous-loop>>` sentinel (per catch 43 rule). Armed `12fb713e` at start — `* * * * *` recurring.

## Test plan

- [x] Tick file lives at `docs/hygiene-history/ticks/2026/05/14/2010Z.md` (per per-tick discipline)
- [x] No conflict markers, markdownlint clean
- [x] PR #3221 visible as the substantive landing
- [ ] CI gate clears
- [ ] Auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>