### PR TITLE
feat(B-0506): mechanize stale-worktree audit — audit-stale-worktrees.ts (clean branch)

### DIFF
--- a/tools/hygiene/audit-stale-worktrees.test.ts
+++ b/tools/hygiene/audit-stale-worktrees.test.ts
@@ -1,0 +1,123 @@
+// audit-stale-worktrees.test.ts — basic correctness tests for the
+// worktree-staleness auditor.
+
+import { describe, expect, test } from "bun:test";
+import { parseWorktreePorcelain, renderReport } from "./audit-stale-worktrees.ts";
+
+describe("parseWorktreePorcelain", () => {
+    test("parses a single live worktree block", () => {
+        const stdout = [
+            "worktree /Users/foo/repo",
+            "HEAD abc1234567890",
+            "branch refs/heads/main",
+            "",
+        ].join("\n");
+        const entries = parseWorktreePorcelain(stdout);
+        expect(entries).toHaveLength(1);
+        expect(entries[0]!.path).toBe("/Users/foo/repo");
+        expect(entries[0]!.branch).toBe("refs/heads/main");
+        expect(entries[0]!.prunable).toBe(false);
+    });
+
+    test("parses a prunable worktree block", () => {
+        const stdout = [
+            "worktree /tmp/zeta-stale",
+            "HEAD def4567890abc",
+            "branch refs/heads/some-old-branch",
+            "prunable gitdir file points to non-existent location",
+            "",
+        ].join("\n");
+        const entries = parseWorktreePorcelain(stdout);
+        expect(entries).toHaveLength(1);
+        expect(entries[0]!.path).toBe("/tmp/zeta-stale");
+        expect(entries[0]!.prunable).toBe(true);
+    });
+
+    test("parses multiple blocks separated by blank lines", () => {
+        const stdout = [
+            "worktree /repo/a",
+            "HEAD aaa",
+            "branch refs/heads/a",
+            "",
+            "worktree /repo/b",
+            "HEAD bbb",
+            "branch refs/heads/b",
+            "prunable orphan",
+            "",
+            "worktree /repo/c",
+            "HEAD ccc",
+            "",
+        ].join("\n");
+        const entries = parseWorktreePorcelain(stdout);
+        expect(entries).toHaveLength(3);
+        expect(entries[1]!.prunable).toBe(true);
+        expect(entries[2]!.branch).toBeNull();
+    });
+
+    test("handles a detached HEAD worktree (no branch line)", () => {
+        const stdout = ["worktree /repo/detached", "HEAD abcdef", "detached", ""].join("\n");
+        const entries = parseWorktreePorcelain(stdout);
+        expect(entries).toHaveLength(1);
+        expect(entries[0]!.branch).toBeNull();
+    });
+
+    test("returns an empty array for empty input", () => {
+        expect(parseWorktreePorcelain("")).toHaveLength(0);
+    });
+});
+
+describe("renderReport", () => {
+    test("renders a healthy report (no stale entries)", () => {
+        const fixed = new Date("2026-05-14T00:00:00Z");
+        const md = renderReport(
+            {
+                totalWorktrees: 3,
+                healthy: 3,
+                stalePathExists: [],
+                stalePathMissing: [],
+            },
+            fixed,
+            null,
+        );
+        expect(md).toContain("Total worktrees: 3");
+        expect(md).toContain("Healthy: 3");
+        expect(md).toContain("Stale, path missing on disk: 0");
+        expect(md).not.toContain("## Stale worktrees");
+    });
+
+    test("renders a stale-path-missing table", () => {
+        const fixed = new Date("2026-05-14T00:00:00Z");
+        const md = renderReport(
+            {
+                totalWorktrees: 2,
+                healthy: 1,
+                stalePathExists: [],
+                stalePathMissing: [
+                    { path: "/tmp/zeta-stale", head: "abc", branch: "refs/heads/feature/x", prunable: true },
+                ],
+            },
+            fixed,
+            null,
+        );
+        expect(md).toContain("Stale, path missing on disk: 1");
+        expect(md).toContain("| `/tmp/zeta-stale` | `refs/heads/feature/x` |");
+    });
+
+    test("renders prune output when provided", () => {
+        const fixed = new Date("2026-05-14T00:00:00Z");
+        const md = renderReport(
+            {
+                totalWorktrees: 1,
+                healthy: 0,
+                stalePathExists: [],
+                stalePathMissing: [
+                    { path: "/tmp/zeta-stale", head: null, branch: null, prunable: true },
+                ],
+            },
+            fixed,
+            "Removing worktrees/zeta-stale\n",
+        );
+        expect(md).toContain("## Prune output");
+        expect(md).toContain("Removing worktrees/zeta-stale");
+    });
+});

--- a/tools/hygiene/audit-stale-worktrees.ts
+++ b/tools/hygiene/audit-stale-worktrees.ts
@@ -1,0 +1,222 @@
+#!/usr/bin/env bun
+// audit-stale-worktrees.ts — detect git-worktree admin entries whose working-
+// directory has been deleted, recovering from the "branch already used by
+// worktree at <missing-path>" lockout pattern.
+//
+// Mechanizes B-0506 Phase 2 (worktree-prune cadence). Empirically, parallel-
+// Otto sessions on the same maintainer machine accumulate stale worktree
+// admin entries (`.git/worktrees/<name>/`) that point to `/private/tmp/zeta-*`
+// directories which have been cleaned up by OS retention. The next agent's
+// `git checkout <branch>` fails with "branch already used by worktree."
+//
+// What this does:
+//
+//   - Enumerate `git worktree list --porcelain` entries
+//   - For each entry, test whether the working-directory path exists on disk
+//   - Report stale entries (markdown summary)
+//   - With `--prune`, run `git worktree prune --expire=now -v` to remove them
+//
+// Out of scope (next slice if needed):
+//
+//   - Per-Otto-process worktree isolation (substantial design per B-0519 RCA)
+//   - GHA cron wire-up (a separate yml; would compose with
+//     factory-hygiene-audit-cadence.yml)
+//
+// Usage:
+//
+//   bun tools/hygiene/audit-stale-worktrees.ts                # detect-only
+//   bun tools/hygiene/audit-stale-worktrees.ts --prune        # also run `git worktree prune --expire=now`
+//   bun tools/hygiene/audit-stale-worktrees.ts --report PATH  # write markdown report
+//
+// Exit codes:
+//
+//   0   detect-only mode, or prune ran successfully
+//   64  argument error
+//   128 not inside a git worktree
+//
+// DST-friendliness:
+//
+//   The "Generated" timestamp is the only non-deterministic surface. Per
+//   `typescript.md` universal-DST gate.
+
+import { existsSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+type AuditExitCode = 0 | 64 | 128;
+
+interface Args {
+    readonly report: string | null;
+    readonly prune: boolean;
+}
+
+interface WorktreeEntry {
+    readonly path: string;
+    readonly head: string | null;
+    readonly branch: string | null;
+    readonly prunable: boolean;
+}
+
+interface AuditResult {
+    readonly totalWorktrees: number;
+    readonly stalePathExists: WorktreeEntry[]; // path exists but git flagged prunable
+    readonly stalePathMissing: WorktreeEntry[]; // path missing on disk
+    readonly healthy: number;
+}
+
+function parseArgs(argv: string[]): { kind: "args"; args: Args } | { kind: "error"; message: string } {
+    let report: string | null = null;
+    let prune = false;
+    let i = 0;
+    while (i < argv.length) {
+        const a = argv[i]!;
+        if (a === "--report") {
+            const next = argv[i + 1];
+            if (!next) return { kind: "error", message: "--report requires a path" };
+            report = next;
+            i += 2;
+        } else if (a === "--prune") {
+            prune = true;
+            i += 1;
+        } else {
+            return { kind: "error", message: `Unknown argument: ${a}` };
+        }
+    }
+    return { kind: "args", args: { report, prune } };
+}
+
+function parseWorktreePorcelain(stdout: string): WorktreeEntry[] {
+    const entries: WorktreeEntry[] = [];
+    const blocks = stdout.split("\n\n");
+    for (const block of blocks) {
+        if (!block.trim()) continue;
+        const lines = block.split("\n");
+        let path = "";
+        let head: string | null = null;
+        let branch: string | null = null;
+        let prunable = false;
+        for (const line of lines) {
+            if (line.startsWith("worktree ")) path = line.slice(9);
+            else if (line.startsWith("HEAD ")) head = line.slice(5);
+            else if (line.startsWith("branch ")) branch = line.slice(7);
+            else if (line === "prunable" || line.startsWith("prunable ")) prunable = true;
+        }
+        if (path) entries.push({ path, head, branch, prunable });
+    }
+    return entries;
+}
+
+function audit(): AuditResult | { error: string; code: AuditExitCode } {
+    const list = spawnSync("git", ["worktree", "list", "--porcelain"], { encoding: "utf8" });
+    if (list.status !== 0) {
+        return { error: `git worktree list failed: ${list.stderr}`, code: 128 };
+    }
+
+    const entries = parseWorktreePorcelain(list.stdout);
+    const stalePathExists: WorktreeEntry[] = [];
+    const stalePathMissing: WorktreeEntry[] = [];
+    let healthy = 0;
+
+    for (const entry of entries) {
+        if (entry.prunable && !existsSync(entry.path)) {
+            stalePathMissing.push(entry);
+        } else if (entry.prunable) {
+            stalePathExists.push(entry);
+        } else {
+            healthy++;
+        }
+    }
+
+    return {
+        totalWorktrees: entries.length,
+        stalePathExists,
+        stalePathMissing,
+        healthy,
+    };
+}
+
+function runPrune(): { ok: boolean; output: string } {
+    const r = spawnSync("git", ["worktree", "prune", "--expire=now", "-v"], { encoding: "utf8" });
+    return { ok: r.status === 0 || r.status === 1, output: (r.stdout || "") + (r.stderr || "") };
+}
+
+function renderReport(result: AuditResult, now: Date, pruned: string | null): string {
+    const lines: string[] = [];
+    lines.push("# git-worktree staleness audit");
+    lines.push("");
+    lines.push(`Generated: ${now.toISOString()}`);
+    lines.push("");
+    lines.push("## Summary");
+    lines.push("");
+    lines.push(`- Total worktrees: ${result.totalWorktrees}`);
+    lines.push(`- Healthy: ${result.healthy}`);
+    lines.push(`- Stale, path missing on disk: ${result.stalePathMissing.length}`);
+    lines.push(`- Stale, path still exists (manual triage): ${result.stalePathExists.length}`);
+    lines.push("");
+    if (result.stalePathMissing.length > 0) {
+        lines.push("## Stale worktrees (path missing — safe to prune)");
+        lines.push("");
+        lines.push("| Path | Branch |");
+        lines.push("|------|--------|");
+        for (const e of result.stalePathMissing) {
+            lines.push(`| \`${e.path}\` | ${e.branch ? `\`${e.branch}\`` : "_(detached)_"} |`);
+        }
+        lines.push("");
+    }
+    if (result.stalePathExists.length > 0) {
+        lines.push("## Stale worktrees (path still exists — investigate before prune)");
+        lines.push("");
+        lines.push("| Path | Branch |");
+        lines.push("|------|--------|");
+        for (const e of result.stalePathExists) {
+            lines.push(`| \`${e.path}\` | ${e.branch ? `\`${e.branch}\`` : "_(detached)_"} |`);
+        }
+        lines.push("");
+    }
+    if (pruned !== null) {
+        lines.push("## Prune output");
+        lines.push("");
+        lines.push("```");
+        lines.push(pruned.trim() || "(no entries pruned)");
+        lines.push("```");
+        lines.push("");
+    }
+    return lines.join("\n");
+}
+
+function main(argv: string[]): AuditExitCode {
+    const parsed = parseArgs(argv);
+    if (parsed.kind === "error") {
+        console.error(`error: ${parsed.message}`);
+        return 64;
+    }
+
+    const r = audit();
+    if ("error" in r) {
+        console.error(r.error);
+        return r.code;
+    }
+
+    let pruneOutput: string | null = null;
+    if (parsed.args.prune && r.stalePathMissing.length > 0) {
+        const p = runPrune();
+        pruneOutput = p.output;
+        if (!p.ok) console.error("git worktree prune exited non-zero (continuing — some entries may have pruned)");
+    }
+
+    const report = renderReport(r, new Date(), pruneOutput);
+
+    if (parsed.args.report) {
+        writeFileSync(parsed.args.report, report);
+        console.log(`wrote ${parsed.args.report}`);
+    } else {
+        console.log(report);
+    }
+
+    return 0;
+}
+
+if (import.meta.main) {
+    process.exit(main(process.argv.slice(2)));
+}
+
+export { audit, parseWorktreePorcelain, renderReport };


### PR DESCRIPTION
Implements [B-0506](docs/backlog/P3/B-0506-stale-worktree-prune-cadence-mechanization-2026-05-14.md) Phase 2 / [B-0519](docs/backlog/P3/B-0519-multi-otto-branch-state-contamination-rca-2026-05-14.md) cheap mechanization.

**Three hygiene tools now share the same pattern**:
- [PR #3202](https://github.com/Lucent-Financial-Group/Zeta/pull/3202) — rule cross-refs audit
- [PR #3208](https://github.com/Lucent-Financial-Group/Zeta/pull/3208) — MEMORY.md bloat audit
- This PR — stale-worktree audit

What it does:
- Enumerates `git worktree list --porcelain`
- For each prunable entry, tests whether its working-dir path exists
- Reports stale entries; with `--prune`, runs `git worktree prune --expire=now -v`

Live first-run: 163 worktrees, 0 stale (post-prune at 1817Z).

Tests: 8 pass / 21 `expect` calls.

(Replaces closed #3224 which had branch-state contamination — B-0519 pattern.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)