### PR TITLE
chore(backlog): regenerate docs/BACKLOG.md — index drift cleanup (B-0517/B-0518/B-0519)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -311,6 +311,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0511](backlog/P1/B-0511-b0448-slice5-register-cloud-routine-empirical-fire-2026-05-14.md)** B-0448 slice 5 — Register autonomous-loop as Cloud Routine + empirical first-fire observation
 - [ ] **[B-0512](backlog/P1/B-0512-b0448-slice6-readme-4-layer-table-2026-05-14.md)** B-0448 slice 6 — Update tools/routines/README.md with 4-layer catch-43 table
 - [ ] **[B-0513](backlog/P1/B-0513-b0448-slice7-memory-file-empirical-bootstrap-learning-2026-05-14.md)** B-0448 slice 7 — Memory file capturing empirical Cloud Routine bootstrap learning
+- [ ] **[B-0518](backlog/P1/B-0518-sharpen-holding-without-named-dependency-rule-anti-failure-mode-2026-05-14.md)** Sharpen the holding-without-named-dependency rule — Aaron diagnosed CLAUDE.md bug
 
 ## P2 — research-grade
 
@@ -641,5 +642,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0506](backlog/P3/B-0506-stale-worktree-prune-cadence-mechanization-2026-05-14.md)** Stale-worktree prune cadence — mechanize `git worktree prune --expire=now`
 - [ ] **[B-0514](backlog/P3/B-0514-author-missing-wwjd-grey-honest-memory-file-2026-05-14.md)** Author missing memory file: feedback_aaron_wwjd_keeps_the_grey_in_aaron_honest_devil_lives_in_the_grey_in_numbers_2026_05_12.md
 - [ ] **[B-0515](backlog/P3/B-0515-architecture-as-externalization-of-aarons-dialectical-perception-dashboard-target-shift-2026-05-14.md)** Architecture-as-externalization-of-Aaron's-dialectical-perception — dashboard acceptance criteria target shift
+- [ ] **[B-0517](backlog/P3/B-0517-memory-md-index-bloat-cleanup-cadence-2026-05-14.md)** MEMORY.md index bloat cleanup + entry-length enforcement cadence
+- [ ] **[B-0519](backlog/P3/B-0519-multi-otto-branch-state-contamination-rca-2026-05-14.md)** Multi-Otto branch-state contamination — RCA + mechanization candidate
 
 <!-- END AUTO-GENERATED -->


### PR DESCRIPTION
## Summary

Three on-disk backlog rows were missing from the auto-generated index in `docs/BACKLOG.md`:

- **B-0517** (P3) — MEMORY.md index bloat cleanup + entry-length enforcement cadence
- **B-0518** (P1) — Sharpen the holding-without-named-dependency rule
- **B-0519** (P3) — Multi-Otto branch-state contamination RCA

This PR regenerates the index. The drift was pre-existing and surfacing as a non-required failure on every recent PR (e.g., the warning on [#3221](https://github.com/Lucent-Financial-Group/Zeta/pull/3221) which surfaced it). Pure index-drift fix; no per-row file changes.

Regenerated via `BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts`.

## Test plan

- [x] Diff is exactly +3 lines (one per missing row)
- [x] `bun tools/backlog/generate-index.ts --check` should be clean post-merge
- [ ] Auto-merge clears the `check docs/BACKLOG.md generated-index drift` gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>