### PR TITLE
shard(tick): 2026Z — BACKLOG.md generated-index drift cleanup (B-0517/B-0518/B-0519)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/14/2026Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/2026Z.md
@@ -1,0 +1,80 @@
+# Tick 2026-05-14T20:26Z — BACKLOG.md generated-index drift cleanup (B-0517/B-0518/B-0519)
+
+## Refresh (step 1)
+
+- Cron sentinel `12fb713e` still live (`* * * * *` recurring, session-only).
+- Prior tick (2010Z) PRs both reached terminal state:
+  - **#3221** (chore(b-0502) launchd plist) — **MERGED** as `eb81404` on main.
+  - **#3222** (shard 2010Z) — still wait-ci with autoMerge armed (verified via `poll-pr-gate-batch`).
+- `bun tools/github/poll-pr-gate-batch.ts 3221 3222` surfaced a non-required-check
+  failure on #3221: `check docs/BACKLOG.md generated-index drift`. Investigated.
+
+## Holding discipline (step 2)
+
+Not Standing-by. Real-dependency-wait was on #3221 + #3222 CI; #3221 cleared and
+merged during the wait. Per never-be-idle priority ladder: investigate the
+known-gap signal (drift warning) rather than just wait on #3222.
+
+## Work (step 3) — known-gap fix from the non-required warning
+
+`bun tools/backlog/generate-index.ts --check` against fresh `origin/main` showed
+real drift: three on-disk rows missing from the auto-generated index in
+`docs/BACKLOG.md`:
+
+- B-0517 (P3) — MEMORY.md index bloat cleanup + entry-length enforcement cadence
+- B-0518 (P1) — Sharpen the holding-without-named-dependency rule
+- B-0519 (P3) — Multi-Otto branch-state contamination RCA
+
+Drift was pre-existing — not caused by any single PR — but accumulating warnings
+degrade the gate-output signal-to-noise. Regenerated via
+`BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts` (3-line delta;
+pure index-drift fix; no per-row file changes).
+
+Kept separate from B-0502 to honor single-concern PR discipline.
+
+## Verify (step 4)
+
+- Diff against `origin/main` is exactly +3 lines (one per missing row).
+- `git branch --show-current` confirmed correct branch (`otto/backlog-md-regen-...`)
+  immediately before commit — primary catch per 2010Z lesson.
+- Even so, a parallel Otto's `checkout` moved HEAD to `fix/b-0518-sharpen-...`
+  between `git push` and `gh pr create`. Worked around via `gh pr create --head`
+  flag (explicit head ref rather than implicit current-branch).
+
+## Branch-state contamination this tick — 2 incidents
+
+| When | Symptom | Fix |
+|---|---|---|
+| After my push | `gh pr create` said "not on any branch" — HEAD detached at origin/main | `git checkout otto/backlog-md-regen-...` |
+| Second `gh pr create` | HEAD now on `fix/b-0518-sharpen-...` (different Otto's branch) | Use `gh pr create --head <my-branch>` explicit flag |
+
+The substrate-honest pattern in the multi-Otto-one-checkout topology:
+
+1. `git branch --show-current` immediately before `git commit` (primary catch
+   for wrong-branch commits — survived this tick)
+2. `gh pr create --head <branch>` rather than relying on implicit current-branch
+   (new defense surfaced this tick)
+
+## Shard (step 5)
+
+This file.
+
+## CronList (step 6)
+
+Sentinel `12fb713e` armed; one entry, recurring.
+
+## Visibility (step 7)
+
+- **PR #3226** (chore(backlog) regen) — wait-ci, autoMerge armed.
+- **PR #3222** (shard 2010Z) — still wait-ci, autoMerge armed.
+- **#3221** merged as `eb81404`.
+
+## Notes for future-Otto
+
+Two new defenses for multi-Otto-one-checkout work:
+
+- **`git branch --show-current` immediately before `git commit`** (primary catch
+  for wrong-branch commits — env-var-based `ZETA_EXPECTED_BRANCH` is unreliable
+  defense-in-depth only)
+- **`gh pr create --head <my-branch>` explicit head ref** (new — prevents
+  another Otto's parallel checkout from poisoning the PR-create call)


### PR DESCRIPTION
## Summary

Tick 2026-05-14T20:26Z shard. Substantive work in [#3226](https://github.com/Lucent-Financial-Group/Zeta/pull/3226) (BACKLOG.md regen — closes the drift warning surfaced by [#3221](https://github.com/Lucent-Financial-Group/Zeta/pull/3221)).

## What landed

- [#3226](https://github.com/Lucent-Financial-Group/Zeta/pull/3226) — regen of `docs/BACKLOG.md` adding B-0517/B-0518/B-0519 to the auto-generated index. Pure regen; no per-row file changes.
- This shard.

## Prior-tick PRs status

- [#3221](https://github.com/Lucent-Financial-Group/Zeta/pull/3221) (chore(b-0502) launchd plist) — **MERGED** as `eb81404`. Closes B-0441 AC #2.
- [#3222](https://github.com/Lucent-Financial-Group/Zeta/pull/3222) (shard 2010Z) — still wait-ci, autoMerge armed.

## Branch-state contamination — 2 new incidents this tick

Multi-Otto-one-checkout topology produced two more contamination patterns:

1. Between `git push` and `gh pr create`: HEAD detached at `origin/main` (parallel Otto's checkout). Worked around with re-`checkout`.
2. Second `gh pr create`: HEAD now on `fix/b-0518-sharpen-...` (a different Otto's branch). Worked around with `gh pr create --head <my-branch>` explicit flag.

## New defenses for future-Otto

- **`git branch --show-current` immediately before `git commit`** — primary catch for wrong-branch commits; survived this tick.
- **`gh pr create --head <my-branch>`** — explicit head ref prevents implicit current-branch from being poisoned by parallel checkouts.

The env-var-based `ZETA_EXPECTED_BRANCH` hook remains defense-in-depth only (env vars don't persist reliably across Bash-tool calls).

## Test plan

- [x] `git branch --show-current` confirmed before commit (correct branch)
- [x] `gh pr create --head` explicit ref
- [ ] CI clears
- [ ] Auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>