### PR TITLE
chore(hygiene): exclude .gemini/{launchd,service}/*.plist from machine-specific-content audit

### DIFF
--- a/tools/hygiene/audit-machine-specific-content.ts
+++ b/tools/hygiene/audit-machine-specific-content.ts
@@ -72,7 +72,7 @@ const PATTERN_NAMES: readonly string[] = [
 ];
 
 const EXCLUDE_RE =
-  /^(docs\/ROUND-HISTORY\.md|docs\/hygiene-history\/|docs\/DECISIONS\/|tools\/hygiene\/audit-machine-specific-content\.(sh|ts)|\.gemini\/(launchd|service)\/.*\.plist)/;
+  /^(docs\/ROUND-HISTORY\.md|docs\/hygiene-history\/|docs\/DECISIONS\/|tools\/hygiene\/audit-machine-specific-content\.(sh|ts)|\.gemini\/(launchd|service)\/[^/]+\.plist$)/;
 
 const SPAWN_MAX_BUFFER = 64 * 1024 * 1024; // 64 MiB
 

--- a/tools/hygiene/audit-machine-specific-content.ts
+++ b/tools/hygiene/audit-machine-specific-content.ts
@@ -17,9 +17,16 @@
 //   - Windows home paths: `C:\Users\<name>` (both backslash and
 //     forward-slash forms)
 //
-// Excluded from the scan: history surfaces (ROUND-HISTORY.md,
-// hygiene-history/, DECISIONS/) and this audit script itself
-// (its patterns ARE examples).
+// Excluded from the scan:
+//   - History surfaces (ROUND-HISTORY.md, hygiene-history/, DECISIONS/)
+//   - This audit script itself (its patterns ARE examples).
+//   - launchd / service plist files under .gemini/launchd/ and
+//     .gemini/service/ — those are the CANONICAL home for machine-
+//     specific paths by design (maintainer-only artifacts with a
+//     maintainer-note comment explaining the paths are machine-
+//     specific and must be regenerated per-machine before
+//     `launchctl load`). Flagging them as gaps is a false-positive
+//     that creates ongoing audit noise.
 //
 // Usage:
 //   bun tools/hygiene/audit-machine-specific-content.ts            # summary
@@ -65,7 +72,7 @@ const PATTERN_NAMES: readonly string[] = [
 ];
 
 const EXCLUDE_RE =
-  /^(docs\/ROUND-HISTORY\.md|docs\/hygiene-history\/|docs\/DECISIONS\/|tools\/hygiene\/audit-machine-specific-content\.(sh|ts))/;
+  /^(docs\/ROUND-HISTORY\.md|docs\/hygiene-history\/|docs\/DECISIONS\/|tools\/hygiene\/audit-machine-specific-content\.(sh|ts)|\.gemini\/(launchd|service)\/.*\.plist)/;
 
 const SPAWN_MAX_BUFFER = 64 * 1024 * 1024; // 64 MiB
 


### PR DESCRIPTION
## Summary

The machine-specific-content audit ([tools/hygiene/audit-machine-specific-content.ts](tools/hygiene/audit-machine-specific-content.ts)) was flagging 4 launchd / service `.plist` files as gaps even though those files are the **canonical home for machine-specific paths by design**. Each plist carries a maintainer-note comment explaining the paths must be regenerated per-machine before `launchctl load` — they are maintainer-only artifacts, not portable substrate.

## Change

Added `\.gemini\/(launchd|service)\/.*\.plist` to the `EXCLUDE_RE` regex + a docstring entry explaining the rationale (so future contributors don't cargo-cult the exclusion).

## Before / after

| Total gaps | Plist false-positives in flagged list |
|------------|---------------------------------------|
| 50 (before) | 4 (`.gemini/launchd/com.zeta.{backlog-ready-notifier,lior-loop,missed-substrate-detector}.plist` + `.gemini/service/com.lucent.zeta.lior.plist`) |
| 46 (after) | 0 |

Exact delta = the 4 plist files. No other findings affected:

- `tools/hygiene/audit-ci-cache-paths.ts:/home/<name>/` — still flagged (real gap)
- `.claude/skills/documentation-agent/SKILL.md:C:\Users\<name>` — still flagged (real gap)
- `memory/feedback_path_hygiene.md:C:\Users\<name>` — still flagged (real gap)

## Test plan

- [x] `bun tools/hygiene/audit-machine-specific-content.ts` exits 0; total drops from 50 → 46
- [x] `bun tools/hygiene/audit-machine-specific-content.ts --enforce` still exits 2 (gaps remain) — audit behavior intact
- [x] `bun tools/hygiene/audit-machine-specific-content.ts --list | grep "\.plist"` returns empty — false-positives gone
- [x] Composite branch-guard used for commit
- [x] `gh pr create --head` explicit ref

## Why this is a hygiene win

Audit noise creates ongoing false-positive cost. Every PR's CI surfaces these 4 findings; every contributor reading the audit output learns to filter them mentally. The signal-to-noise improves by ~8% (4/50) — small but compounding across every audit run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>