### PR TITLE
chore(b-0488): close out row after PR #3235 merge

### DIFF
--- a/docs/backlog/P1/B-0488-ksk-persona-map-2026-05-14.md
+++ b/docs/backlog/P1/B-0488-ksk-persona-map-2026-05-14.md
@@ -1,7 +1,8 @@
 ---
 id: B-0488
 priority: P1
-status: in-progress
+status: closed
+closed_by: "PR #3235 (2026-05-14)"
 title: "B-0429.4 — KSK (Kinetic Safeguard Kernel) persona map"
 type: planning
 origin: B-0429 decomposition (Otto, 2026-05-14)
@@ -65,12 +66,12 @@ With:
 
 ## Definition of done
 
-- [ ] Template from B-0485 applied
-- [ ] Grey-hat / ethical researcher primary persona fully documented
-- [ ] At least 2 refused personas with explicit HARD LIMITS rationale
-- [ ] Output doc committed at canonical path
-- [ ] B-0492 `composes_with:` pointer backfilled
-- [ ] B-0488 status set to `closed` with PR link
+- [x] Template from B-0485 applied
+- [x] Grey-hat / ethical researcher primary persona fully documented (folded into `ksk-security-engineer` per glossary's "small bit of code that gets disproportionate review" framing — engineering itself IS the ethical-research operating mode for this product)
+- [x] At least 2 refused personas with explicit HARD LIMITS rationale (R1 `ksk-refused-weapons-control` + R2 `ksk-refused-apt-operator`)
+- [x] Output doc committed at canonical path (`docs/personas/ksk-personas.md`)
+- [x] B-0492 `composes_with:` pointer backfilled (already present in B-0492 frontmatter — verified 2026-05-14)
+- [x] B-0488 status set to `closed` with PR link (PR #3235; this commit)
 
 ## Why P1
 


### PR DESCRIPTION
## Summary

Closes out [B-0488](docs/backlog/P1/B-0488-ksk-persona-map-2026-05-14.md) after the substantive work landed via [#3235](https://github.com/Lucent-Financial-Group/Zeta/pull/3235).

## Changes (metadata only)

- `status`: `in-progress` → `closed`
- `closed_by`: `"PR #3235 (2026-05-14)"` (frontmatter field added)
- All 6 Definition-of-done checkboxes ticked with specifics:
  - Template from B-0485 applied
  - Grey-hat / ethical-researcher framing folded into `ksk-security-engineer` (per glossary's "small bit of code that gets disproportionate review" framing)
  - 2 refused personas (R1 `ksk-refused-weapons-control` + R2 `ksk-refused-apt-operator`) with HARD LIMITS rationale
  - Output doc at `docs/personas/ksk-personas.md`
  - B-0492 `composes_with` pointer was already in place (verified — see B-0492 frontmatter line 23)
  - Row status closed with PR link

Pure metadata + checkbox-tick row close-out. No behavioural changes.

## Why this is a separate PR

The substantive work + the row close-out were intentionally separated:

- **#3235** = the actual deliverable (`docs/personas/ksk-personas.md` + the in-progress status flip)
- **This PR** = the metadata close-out (status → closed, DoD checkboxes ticked, closed_by link)

Keeping the substantive PR focused on the deliverable (per single-concern PR discipline) means the row-close-out lands as its own small atomic change that's easy to review.

## Test plan

- [x] Composite branch-guard used for the commit
- [x] `gh pr create --head` explicit ref
- [x] No behavioural files changed (single backlog-row metadata edit)
- [ ] CI clears
- [ ] Auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>