### PR TITLE
shard(tick): 2059Z — PR #3239 Copilot thread fix (end-anchored plist regex)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/14/2059Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/2059Z.md
@@ -45,7 +45,8 @@ Property-tested with 8 cases (all pass):
 Audit total unchanged at 46 — all 4 real plist files still excluded.
 
 Pushed as new commit `673fbd0` on the PR branch; thread resolved via
-`gh api graphql resolveReviewThread`. CI re-running for the new commit;
+`gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"<id>"}) { thread { isResolved } } }'`
+(GraphQL mutation passed via `-f query=`, not a CLI subcommand). CI re-running for the new commit;
 autoMerge stays armed.
 
 ## Verify (step 4)

--- a/docs/hygiene-history/ticks/2026/05/14/2059Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/2059Z.md
@@ -1,0 +1,88 @@
+# Tick 2026-05-14T20:59Z — PR #3239 Copilot thread fix (end-anchored plist regex)
+
+## Refresh (step 1)
+
+- Cron sentinel `12fb713e` live.
+- 4 in-flight PRs polled (#3239/#3240/#3244/#3245):
+  - **#3239** gate reported `UNKNOWN` — investigated per
+    `.claude/rules/blocked-green-ci-investigate-threads.md`. Required CI
+    7/7 green, autoMerge armed, but `unresolvedThreads: 1`.
+  - Other 3 still wait-ci with autoMerge armed.
+
+## Holding discipline (step 2)
+
+Not Standing-by. Named real-dependency-wait (CI) on all 4; the #3239
+thread is an actionable input, not a wait. Per
+`blocked-green-ci-investigate-threads.md`: the block is almost always a
+small set of threads with addressable findings. Investigate first.
+
+## Work (step 3) — fix #3239 Copilot review thread
+
+Copilot caught a subtle regex bug in the plist-exclusion change from
+2046Z: `\.gemini\/(launchd|service)\/.*\.plist` isn't end-anchored, so
+EXCLUDE_RE would also match files like `foo.plist.bak` or `foo.plist.md`
+under those dirs. Real concern, not nit.
+
+Fix:
+
+- Tightened to `\.gemini\/(launchd|service)\/[^/]+\.plist$`
+  - `[^/]+` — no subdir traversal in the filename slot
+  - `\.plist$` — end-anchored (true plist extension)
+
+Property-tested with 8 cases (all pass):
+
+| Path | Expected | Got |
+|---|---|---|
+| `.gemini/launchd/com.zeta.foo.plist` | excluded | excluded ✓ |
+| `.gemini/service/bar.plist` | excluded | excluded ✓ |
+| `.gemini/launchd/foo.plist.bak` | NOT | NOT ✓ |
+| `.gemini/launchd/foo.plist.md` | NOT | NOT ✓ |
+| `.gemini/launchd/sub/dir/foo.plist` | NOT | NOT ✓ |
+| `.gemini/other/foo.plist` | NOT | NOT ✓ |
+| `docs/hygiene-history/x.md` | excluded | excluded ✓ |
+| `docs/ROUND-HISTORY.md` | excluded | excluded ✓ |
+
+Audit total unchanged at 46 — all 4 real plist files still excluded.
+
+Pushed as new commit `673fbd0` on the PR branch; thread resolved via
+`gh api graphql resolveReviewThread`. CI re-running for the new commit;
+autoMerge stays armed.
+
+## Verify (step 4)
+
+- Property test 8/8 pass (1 BLOCKED-with-green-CI thread → addressed)
+- Audit total: 46 (unchanged — real plists still excluded)
+- Composite branch-guard used at commit time
+- Thread resolved via GraphQL mutation; verified `isResolved=true`
+
+## Shard (step 5)
+
+This file.
+
+## CronList (step 6)
+
+Sentinel `12fb713e` armed; one entry, recurring.
+
+## Visibility (step 7)
+
+- **PR #3239** (audit hygiene) — thread resolved + new commit `673fbd0`
+  pushed. Required CI re-running; autoMerge still armed.
+- **#3240 / #3244 / #3245** — wait-ci, autoMerge armed.
+
+## Notes for future-Otto
+
+`blocked-green-ci-investigate-threads.md` rule paid off this tick. The
+gate-poller reported `UNKNOWN` once, then `BLOCKED` with 0 failed
+checks + autoMerge armed. The block was 1 thread, not a CI failure.
+Per the rule: "The block is almost always a small set of threads with
+addressable findings." Investigated immediately, found the Copilot
+catch, fixed in ~3 min.
+
+The Copilot review was substantively correct — not a noise nit. Real
+regex bug that would have caused future over-exclusion. Treating
+Copilot's review as signal (verify the claim, fix if real, resolve)
+beats dismissing it.
+
+Property-testing the regex with a one-off `/tmp/zeta-regex-test/` Bun
+script took ~30 sec and produced 8 pass/fail data points that made the
+fix verifiable. Cheap; durable for the PR-body evidence table.


### PR DESCRIPTION
## Summary

Tick 2026-05-14T20:59Z shard. Substantive work was a thread fix on [#3239](https://github.com/Lucent-Financial-Group/Zeta/pull/3239) — Copilot caught a real regex bug (un-anchored `.plist` would over-exclude `foo.plist.bak` / `foo.plist.md`). Fixed + property-tested + thread resolved.

## What landed

- **Commit `673fbd0` on #3239's branch** — tightened regex to `\.gemini\/(launchd|service)\/[^/]+\.plist$` (end-anchored, no subdir traversal). 8/8 property tests pass; audit total unchanged at 46.
- This shard.

## Pattern this tick

[`blocked-green-ci-investigate-threads.md`](.claude/rules/blocked-green-ci-investigate-threads.md) paid off. The gate-poller reported `UNKNOWN` once then `BLOCKED` with 0 failed checks + autoMerge armed. The block was 1 thread with an addressable finding, not a CI failure. Investigated immediately, fixed in ~3 minutes.

## Why the Copilot review was substantive

The flag was not a nit. `EXCLUDE_RE.test(path)` with `.*\.plist` matches `foo.plist.bak`, `foo.plist.md`, `foo.plist.anything` — over-exclusion. End-anchoring with `\.plist$` + `[^/]+` for the filename slot eliminates the over-match without changing behavior for real plist files.

## Prior-tick PRs status

- [#3240](https://github.com/Lucent-Financial-Group/Zeta/pull/3240) (shard 2046Z) — wait-ci, autoMerge armed
- [#3244](https://github.com/Lucent-Financial-Group/Zeta/pull/3244) (B-0488 close-out) — wait-ci, autoMerge armed
- [#3245](https://github.com/Lucent-Financial-Group/Zeta/pull/3245) (shard 2055Z) — wait-ci, autoMerge armed

## Test plan

- [x] Property test: 8/8 cases pass for tightened regex
- [x] Audit total: 46 (unchanged — real plists still excluded)
- [x] Thread resolved via GraphQL `resolveReviewThread` mutation
- [x] Composite branch-guard + `gh pr create --head` used
- [ ] CI clears on the new #3239 commit + auto-merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>