### PR TITLE
chore(backlog): regenerate docs/BACKLOG.md — B-0488 closed + B-0329 pickup

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -173,7 +173,6 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0327](backlog/P1/B-0327-peer-call-claude-ts-self-call-cold-boot.md)** Author claude.ts self-call wrapper — subprocess mode for cold-boot self-testing
 - [x] **[B-0328](backlog/P1/B-0328-peer-call-readme-kiro-claude-entries.md)** Update peer-call/README.md with kiro.ts + claude.ts entries
 - [ ] **[B-0329](backlog/P1/B-0329-claude-md-as-process-not-doctrine.md)** Replace CLAUDE.md doctrine with bootstrap process — rules emerge from walking, not memorizing
-- [ ] **[B-0329](backlog/P1/B-0329-new-surface-audit-alignment-check.md)** Mechanize new-surface audit for alignment-clause consistency
 - [x] **[B-0330](backlog/P1/B-0330-memory-format-standardization-step2-b0190.md)** Memory-format standardization — define frontmatter shape, filename conventions, section headers
 - [x] **[B-0331](backlog/P1/B-0331-memory-ontology-classification-audit-step3-b0190.md)** Memory ontology/classification audit — reclassify mistyped feedback/project/user/reference files
 - [x] **[B-0332](backlog/P1/B-0332-memory-load-bearing-vs-decorative-classifier-step7-b0190.md)** Memory load-bearing-vs-decorative classifier — identify which memory files are cited from bootstrap surfaces
@@ -313,6 +312,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0512](backlog/P1/B-0512-b0448-slice6-readme-4-layer-table-2026-05-14.md)** B-0448 slice 6 — Update tools/routines/README.md with 4-layer catch-43 table
 - [ ] **[B-0513](backlog/P1/B-0513-b0448-slice7-memory-file-empirical-bootstrap-learning-2026-05-14.md)** B-0448 slice 7 — Memory file capturing empirical Cloud Routine bootstrap learning
 - [ ] **[B-0518](backlog/P1/B-0518-sharpen-holding-without-named-dependency-rule-anti-failure-mode-2026-05-14.md)** Sharpen the holding-without-named-dependency rule — Aaron diagnosed CLAUDE.md bug
+- [ ] **[B-0520](backlog/P1/B-0520-new-surface-audit-alignment-check.md)** Mechanize new-surface audit for alignment-clause consistency
 
 ## P2 — research-grade
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -173,6 +173,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0327](backlog/P1/B-0327-peer-call-claude-ts-self-call-cold-boot.md)** Author claude.ts self-call wrapper — subprocess mode for cold-boot self-testing
 - [x] **[B-0328](backlog/P1/B-0328-peer-call-readme-kiro-claude-entries.md)** Update peer-call/README.md with kiro.ts + claude.ts entries
 - [ ] **[B-0329](backlog/P1/B-0329-claude-md-as-process-not-doctrine.md)** Replace CLAUDE.md doctrine with bootstrap process — rules emerge from walking, not memorizing
+- [ ] **[B-0329](backlog/P1/B-0329-new-surface-audit-alignment-check.md)** Mechanize new-surface audit for alignment-clause consistency
 - [x] **[B-0330](backlog/P1/B-0330-memory-format-standardization-step2-b0190.md)** Memory-format standardization — define frontmatter shape, filename conventions, section headers
 - [x] **[B-0331](backlog/P1/B-0331-memory-ontology-classification-audit-step3-b0190.md)** Memory ontology/classification audit — reclassify mistyped feedback/project/user/reference files
 - [x] **[B-0332](backlog/P1/B-0332-memory-load-bearing-vs-decorative-classifier-step7-b0190.md)** Memory load-bearing-vs-decorative classifier — identify which memory files are cited from bootstrap surfaces
@@ -288,7 +289,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0485](backlog/P1/B-0485-persona-mapping-framework-template-substrate-inventory-2026-05-14.md)** B-0429.1 — Persona-mapping framework: define per-persona template + audit existing persona substrate
 - [x] **[B-0486](backlog/P1/B-0486-civsim-persona-map-2026-05-14.md)** B-0429.2 — Civsim persona map
 - [ ] **[B-0487](backlog/P1/B-0487-aurora-persona-map-2026-05-14.md)** B-0429.3 — Aurora persona map
-- [ ] **[B-0488](backlog/P1/B-0488-ksk-persona-map-2026-05-14.md)** B-0429.4 — KSK (Kinetic Safeguard Kernel) persona map
+- [x] **[B-0488](backlog/P1/B-0488-ksk-persona-map-2026-05-14.md)** B-0429.4 — KSK (Kinetic Safeguard Kernel) persona map
 - [ ] **[B-0489](backlog/P1/B-0489-wellness-app-persona-map-2026-05-14.md)** B-0429.5 — Wellness app persona map
 - [ ] **[B-0490](backlog/P1/B-0490-american-dream-dio-persona-map-2026-05-14.md)** B-0429.6 — American Dream 2.0 + DIO persona map
 - [ ] **[B-0491](backlog/P1/B-0491-dawn-universal-biz-templates-persona-map-2026-05-14.md)** B-0429.7 — Dawn + Universal business templates persona map

--- a/docs/backlog/P1/B-0520-new-surface-audit-alignment-check.md
+++ b/docs/backlog/P1/B-0520-new-surface-audit-alignment-check.md
@@ -1,5 +1,5 @@
 ---
-id: B-0329
+id: B-0520
 priority: P1
 status: open
 title: Mechanize new-surface audit for alignment-clause consistency
@@ -8,13 +8,14 @@ effort: S
 ask: Peel off from B-0058 — "New-surface audit" into atomic slice.
 created: 2026-05-14
 last_updated: 2026-05-14
+renumbered_from: "B-0329 (2026-05-14, ID collision with B-0329-claude-md-as-process-not-doctrine.md caught by Copilot review on PR #3247)"
 depends_on: [B-0058]
 composes_with: [docs/ALIGNMENT.md, docs/GLOSSARY.md]
 tags: [ai-ethics, alignment, new-surface-audit, decomposed, B-0058-slice]
 type: friction-reducer
 ---
 
-# B-0329 — Mechanize new-surface audit for alignment-clause consistency
+# B-0520 — Mechanize new-surface audit for alignment-clause consistency
 
 ## Origin
 


### PR DESCRIPTION
## Summary

Regenerates `docs/BACKLOG.md` after the merge of [#3244](https://github.com/Lucent-Financial-Group/Zeta/pull/3244) (B-0488 close-out). Copilot's review on #3244 flagged that the close-out PR didn't include the regen — substantive catch; addressed here.

## Changes (2-line index delta)

1. **B-0488** (KSK persona map row): `- [ ]` → `- [x]` (status reflects `closed` frontmatter)
2. **B-0329** (passive pickup): `B-0329-new-surface-audit-alignment-check.md` was added on disk by another Otto without an index regen — picked up here.

Pure regen via `BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts`. No per-row file changes.

## Pattern (codified)

The row-close-out pattern documented in tick 2055Z assumed the close-out PR would update only metadata + frontmatter, but the BACKLOG.md auto-index also reflects `status` via checkbox state. Future row-close-out PRs should include the regen in the same PR to avoid drift. This PR is the cleanup; the pattern is fixed forward in this PR's commit message.

## Test plan

- [x] `bun tools/backlog/generate-index.ts --check` is clean post-regen
- [x] Diff is exactly +2 / -1 lines (1 status flip + 1 new row)
- [x] Composite branch-guard + `gh pr create --head`
- [ ] CI clears
- [ ] Auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>