### PR TITLE
feat(hygiene): add duplicate-ID audit class to audit-backlog-items.ts

### DIFF
--- a/tools/hygiene/audit-backlog-items.ts
+++ b/tools/hygiene/audit-backlog-items.ts
@@ -28,6 +28,10 @@
 //   6. Top-10 most-blocked rows (rows whose depends_on chain blocks the most
 //      downstream rows)
 //   7. Unclosed-but-merged rows (head-keyword matches recent merged-PR title)
+//   8. Duplicate IDs (multiple files claiming the same `id: B-NNNN`) —
+//      factory-wide uniqueness violation per tools/backlog/README.md.
+//      Surfaced 2026-05-14 (Copilot caught two files claiming B-0329 on
+//      PR #3247; PR #3249 added this audit class).
 //
 // Usage:
 //   bun tools/hygiene/audit-backlog-items.ts
@@ -543,6 +547,54 @@ async function reportMergedCandidates(
   console.log("");
 }
 
+function reportDuplicateIds(rows: readonly BacklogRow[]): number {
+  console.log(
+    "## 8. Duplicate IDs (factory-wide uniqueness violation)",
+  );
+  console.log("");
+  const byId = new Map<string, BacklogRow[]>();
+  for (const r of rows) {
+    const list = byId.get(r.id);
+    if (list === undefined) {
+      byId.set(r.id, [r]);
+    } else {
+      list.push(r);
+    }
+  }
+  const duplicates: Array<readonly [string, readonly BacklogRow[]]> = [];
+  for (const [id, list] of byId) {
+    if (list.length > 1) duplicates.push([id, list]);
+  }
+  duplicates.sort((a, b) => a[0].localeCompare(b[0]));
+  console.log(`**Duplicate-ID groups: ${duplicates.length}**`);
+  if (duplicates.length > 0) {
+    console.log("");
+    for (const [id, list] of duplicates) {
+      console.log(`### ${id} (${list.length} files claim this ID)`);
+      for (const r of list) {
+        console.log(
+          `  - ${r.path} (tier=${r.tier}, status=${r.status})`,
+        );
+      }
+      console.log("");
+    }
+    console.log(
+      "Resolution: renumber all-but-one of the colliding files to the next",
+    );
+    console.log(
+      "available B-NNNN ID; update frontmatter `id:`, body heading, and add a",
+    );
+    console.log(
+      "`renumbered_from:` breadcrumb. Per tools/backlog/README.md, backlog",
+    );
+    console.log(
+      "IDs must be factory-wide unique so edge references resolve unambiguously.",
+    );
+  }
+  console.log("");
+  return duplicates.length;
+}
+
 async function main(): Promise<number> {
   if (!existsSync(BACKLOG_ROOT)) {
     process.stderr.write(`ERROR: ${BACKLOG_ROOT} not found\n`);
@@ -580,6 +632,8 @@ async function main(): Promise<number> {
   const ghAvailable = await hasCommand("gh");
   await reportMergedCandidates(rows, ghAvailable);
 
+  const duplicateIdGroups = reportDuplicateIds(rows);
+
   console.log("## Summary");
   console.log("");
   console.log(`  - Total backlog rows: ${totalRows}`);
@@ -588,6 +642,7 @@ async function main(): Promise<number> {
     `  - Broken composes_with edges (B-NNNN refs only): ${brokenComposes}`,
   );
   console.log(`  - Orphan rows (no incoming graph edge): ${orphanCount}`);
+  console.log(`  - Duplicate-ID groups: ${duplicateIdGroups}`);
   console.log("");
   console.log(
     "Composes with: tools/hygiene/audit-lost-files.ts (sibling pattern),",


### PR DESCRIPTION
## Summary

Adds an 8th audit class to [`tools/hygiene/audit-backlog-items.ts`](tools/hygiene/audit-backlog-items.ts) that detects multiple per-row files claiming the same `id: B-NNNN` — a factory-wide uniqueness violation per `tools/backlog/README.md`.

## Why now

PR [#3247](https://github.com/Lucent-Financial-Group/Zeta/pull/3247)'s review surfaced the issue: Copilot caught two files both claiming `id: B-0329`. The collision was renumbered out-of-band, but the audit-time gap remained — no automated check would have caught the collision at author-time. This commit closes that gap by extending the existing audit tool.

## Output format

Mirrors the sibling `report*` functions in the same file:

```text
## 8. Duplicate IDs (factory-wide uniqueness violation)
**Duplicate-ID groups: N**
### B-NNNN (M files claim this ID)
  - <path1> (tier=Px, status=...)
  - <path2> ...
Resolution: renumber all-but-one ... + renumbered_from breadcrumb
```

Summary block also gets a new line: `Duplicate-ID groups: N`.

## Verifies live

When run today on `origin/main` branch (before [#3247](https://github.com/Lucent-Financial-Group/Zeta/pull/3247) merges):

```text
## 8. Duplicate IDs (factory-wide uniqueness violation)

**Duplicate-ID groups: 1**

### B-0329 (2 files claim this ID)
  - docs/backlog/P1/B-0329-new-surface-audit-alignment-check.md (tier=P1, status=open)
  - docs/backlog/P1/B-0329-claude-md-as-process-not-doctrine.md (tier=P1, status=open)
```

Once #3247 merges (renaming the new file to B-0520), the audit will report 0 duplicate-ID groups.

## Pattern compliance

Extends the existing tool per [`skill-router-as-substrate-inventory.md`](.claude/rules/skill-router-as-substrate-inventory.md): "extend or correct it instead of duplicating." `audit-backlog-items.ts` already audited 7 ID-integrity classes (broken edges, orphan rows, top-blocked, etc.); the 8th composes naturally.

## Test plan

- [x] `bun tools/hygiene/audit-backlog-items.ts` runs cleanly (audit completes)
- [x] Duplicate-ID class fires correctly on the current main state (1 group: B-0329)
- [x] `tsc --noEmit` clean
- [x] Summary line surfaces in the output
- [x] Composite branch-guard + `gh pr create --head` used
- [ ] CI clears
- [ ] Auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>