### PR TITLE
shard(tick): 2131Z — PR #3256 plus-at-line-start fix (Copilot review)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/14/2131Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/2131Z.md
@@ -1,0 +1,88 @@
+# Tick 2026-05-14T21:31Z — PR #3256 `+`-at-line-start fix per Copilot review
+
+## Refresh (step 1)
+
+- Cron sentinel `12fb713e` live.
+- 2 in-flight PRs polled (#3256 / #3258):
+  - **#3256** (shard 2123Z) — BLOCKED + 1 unresolved Copilot thread
+  - **#3258** (shard 2128Z) — wait-ci, autoMerge armed
+
+## Holding discipline (step 2)
+
+Per `blocked-green-ci-investigate-threads.md`: investigate threads on
+PR #3256.
+
+## Work (step 3) — fix `+`-at-line-start MD032 false-trigger
+
+Copilot catch on `docs/hygiene-history/ticks/2026/05/14/2123Z.md:45`:
+
+> P1: This wrapped continuation starts with `+` inside a `-` bullet,
+> which markdownlint parses as a nested list item using a different
+> bullet style. The repository guideline explicitly calls this out as
+> CI-breaking; move the plus to the previous line or reword it as prose.
+
+Substantive catch — real lint hazard, not nit. Line was:
+
+```text
+- Authored `docs/backlog/P1/B-0461-...md`
+  following B-0459's shape (123 lines: frontmatter + AC + scope clarification
+  + dependency chain + composes_with + pre-start checklist)
+```
+
+The leading `+` on line 45 reads as a new list item starting a `+`
+bullet. The repo even has a dedicated audit tool
+(`tools/hygiene/audit-md032-plus-linestart.ts`) specifically for
+detecting this class.
+
+Fix: rewrote as prose — "(123 lines covering frontmatter, AC, scope
+clarification, dependency chain, composes_with, and pre-start
+checklist)" — no line starts with `+` or any bullet char.
+
+Pushed commit `9c4590e` to #3256's branch; thread resolved with reply.
+
+## Proactive sweep
+
+`bun tools/hygiene/audit-md032-plus-linestart.ts --list | grep
+"ticks/2026/05/14"` after fix: **empty**. No other shards today have
+the pattern.
+
+## Verify (step 4)
+
+- `markdownlint-cli2` clean on the fixed shard
+- `audit-md032-plus-linestart --list` reports 0 violations across today's shards
+- Thread resolved via GraphQL mutation
+- Composite branch-guard + `gh pr create --head` used
+
+## Shard (step 5)
+
+This file.
+
+## CronList (step 6)
+
+Sentinel `12fb713e` armed; one entry, recurring.
+
+## Visibility (step 7)
+
+- **PR #3256** (shard 2123Z) — fix `9c4590e` pushed, thread resolved,
+  CI re-running; autoMerge stays armed
+- **PR #3258** (shard 2128Z) — still wait-ci, autoMerge armed
+
+## Notes for future-Otto
+
+The repo has TWO markdownlint-adjacent audit tools for shard-authoring
+hygiene:
+
+| Tool | Catches |
+|---|---|
+| `audit-md032-plus-linestart.ts` | continuation lines that accidentally start with `+` |
+| `markdownlint-cli2` (with repo config) | MD032 blanks-around-lists + other configured rules |
+
+Running both before pushing a tick shard prevents the same class of
+finding from reaching CI / Copilot review. The 2119Z shard added MD032
+discipline; this tick adds the `+`-at-line-start companion.
+
+Pattern: when authoring a tick shard with structured content (bulleted
+descriptions of file structure, summaries of frontmatter sections), use
+plain prose for the description rather than `+`-separated lists inside
+existing `-` bullets. The structure can still be communicated; the lint
+gate stops complaining.


### PR DESCRIPTION
## Summary

Tick 2026-05-14T21:31Z shard. Substantive work was a thread fix on [#3256](https://github.com/Lucent-Financial-Group/Zeta/pull/3256): Copilot caught a wrapped continuation line starting with `+` inside a `-` bullet — markdownlint parses that as a new list item with a different bullet style.

## What landed

- **Commit `9c4590e` on PR [#3256](https://github.com/Lucent-Financial-Group/Zeta/pull/3256)'s branch** — rewrote the wrapped continuation as prose so no line starts with `+`. Thread resolved.
- This shard.

## Repo has dedicated audit for this class

The fix used [`tools/hygiene/audit-md032-plus-linestart.ts`](tools/hygiene/audit-md032-plus-linestart.ts) for the proactive sweep — empty result across all today's shards after the fix.

## Pre-push catch

Pre-lint of this shard caught a fresh MD018 (ATX-heading-missing-space): line starting with `#3256.` parsed as an ATX heading missing a space. Prefixed with `PR ` so the line doesn't start with `#`. Cheap pre-push lint catches it before CI.

## Pattern codified

When authoring tick shards with structured content (bulleted descriptions of file sections), use plain prose for the description rather than `+`-separated lists inside existing `-` bullets. Also avoid `#NNN` at line start when referencing PRs — prefix with `PR `.

## Test plan

- [x] `markdownlint-cli2` clean on the fixed 2123Z shard
- [x] `markdownlint-cli2` clean on this shard
- [x] `audit-md032-plus-linestart --list` empty across today's shards
- [x] Thread resolved via GraphQL
- [x] Composite branch-guard + `gh pr create --head` used
- [ ] CI clears
- [ ] Auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>