### PR TITLE
fix(shard-2139Z): replace broken relative markdown links with backtick paths

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/14/2139Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/2139Z.md
@@ -9,7 +9,7 @@
 ## Holding discipline (step 2)
 
 **Named real-dependency-wait** per
-[`holding-without-named-dependency-is-standing-by-failure.md`](.claude/rules/holding-without-named-dependency-is-standing-by-failure.md):
+`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`:
 the dependency is PR #3263 CI clearing + autoMerge firing. Not
 Standing-by.
 
@@ -28,7 +28,7 @@ Quick audit pass on freshly-merged main:
 | `audit-orphan-role-refs` | many | most in `docs/history/pr-reviews/**` (archive); active-rule citations may be false positives |
 
 No clean single-tick atom surfaced. Per
-[`never-be-idle.md`](.claude/rules/never-be-idle.md): meta-check passes
+`.claude/rules/never-be-idle.md`: meta-check passes
 — there ISN'T a structural factory change that would have made any of
 the above into a directed task. The big residuals (`audit-rule-cross-refs`,
 `audit-orphan-role-refs`) are themselves at the right shape — they
@@ -36,8 +36,8 @@ report on classes of substrate the audit can't auto-resolve.
 
 ## Work (step 3) — minimal by intent
 
-Per the 2001Z precedent's
-[minimal-shard pattern](docs/hygiene-history/ticks/2026/05/14/2001Z.md):
+Per the 2001Z precedent's minimal-shard pattern
+(`docs/hygiene-history/ticks/2026/05/14/2001Z.md`):
 when CI-wait is real + bounded + no actionable atom exists, the
 substrate-honest tick output IS the shard itself. This is distinct from
 Standing-by-failure: the dependency is named (PR #3263), the no-new-


### PR DESCRIPTION
## Summary

Post-merge cleanup of [#3264](https://github.com/Lucent-Financial-Group/Zeta/pull/3264). Copilot caught that three markdown links in `2139Z.md` used relative paths that resolve to `docs/hygiene-history/ticks/2026/05/14/.claude/...` — broken in any rendered view.

## Changes

Replaced 3 broken relative links with plain backtick paths (matching the established shard-authoring convention):

| Line | Before | After |
|---|---|---|
| 12 | `[link](.claude/rules/holding-without-...md)` | `` `.claude/rules/holding-without-...md` `` |
| 31 | `[link](.claude/rules/never-be-idle.md)` | `` `.claude/rules/never-be-idle.md` `` |
| 40 | `[link](docs/hygiene-history/ticks/2026/05/14/2001Z.md)` | `` `docs/hygiene-history/ticks/2026/05/14/2001Z.md` `` |

## Why backticks over root-relative

Copilot suggested either `/.claude/rules/...` (root-relative) or plain backticks. The repo's existing tick shards (2001Z, 2010Z, 2026Z, etc.) use plain backticks without link — chose that for consistency.

## Scan of other shards

`grep -nE "\[\`?[^]]*\`?\]\(\.claude/|\[[^]]*\]\(docs/hygiene" docs/hygiene-history/ticks/2026/05/14/2*.md` returns 0 other instances. Bug isolated to 2139Z.

## Test plan

- [x] `markdownlint-cli2` clean
- [x] No relative `.claude/...` or `docs/hygiene-history/...` links remain in 2139Z
- [x] Composite branch-guard + `gh pr create --head` used
- [ ] CI clears
- [ ] Auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>