### PR TITLE
shard(tick): 2146Z — post-merge cleanup of 2139Z broken relative-link bug

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/14/2146Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/2146Z.md
@@ -1,0 +1,91 @@
+# Tick 2026-05-14T21:46Z — post-merge cleanup: 2139Z broken relative-link fix
+
+## Refresh (step 1)
+
+- Cron sentinel `12fb713e` live.
+- Prior-tick PRs polled:
+  - **#3263** (shard 2135Z) merged earlier as `29c195e`
+  - **#3264** (shard 2139Z) — merged as `5a88735`, post-merge thread (Copilot)
+  - **#3267** (shard 2143Z minimal-continuation) — wait-ci, autoMerge armed
+  - **#3265** (Lior PR-archive batch from another Otto) — merged as `1eafd60`
+
+## Holding discipline (step 2)
+
+Post-merge Copilot thread on #3264. Per
+`.claude/rules/blocked-green-ci-investigate-threads.md`: investigate.
+
+## Work (step 3) — post-merge cleanup of broken relative links
+
+Copilot catch on `docs/hygiene-history/ticks/2026/05/14/2139Z.md`:
+
+> P1 (xref): These markdown links to `.claude/rules/...` are relative
+> to the tick file's directory, so they resolve to
+> `docs/hygiene-history/ticks/2026/05/14/.claude/...` and will 404.
+> This issue also appears in the following locations of the same file:
+> lines 30, 39.
+
+Real substantive catch — broken rendered-view links. Three occurrences:
+
+- Line 12: `.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`
+- Line 31: `.claude/rules/never-be-idle.md`
+- Line 40: `docs/hygiene-history/ticks/2026/05/14/2001Z.md`
+
+The session's other tick shards (2010Z, 2026Z, 2030Z, 2034Z, 2046Z, etc.)
+use plain backticks WITHOUT markdown links — matching the established
+convention. 2139Z accidentally introduced the markdown-link pattern.
+
+Substantive landing:
+
+- PR **#3269** (fix(shard-2139Z) broken relative links): replaced 3
+  occurrences with plain backtick form. Auto-merge armed.
+- Thread on #3264 acknowledged with reply pointing to #3269; resolved.
+
+Scan of OTHER today's shards for the same bug:
+`grep -nE "\[\`?[^]]*\`?\]\(\.claude/|\[[^]]*\]\(docs/hygiene"` —
+**zero other instances**. Bug isolated to 2139Z.
+
+## Verify (step 4)
+
+- `markdownlint-cli2` clean on the fixed shard
+- No relative `.claude/...` or `docs/hygiene-history/...` markdown links
+  remain in 2139Z
+- Thread resolved via GraphQL (`isResolved=true`)
+- Composite branch-guard + `gh pr create --head` used
+
+## Shard (step 5)
+
+This file.
+
+## CronList (step 6)
+
+Sentinel `12fb713e` armed; one entry, recurring.
+
+## Visibility (step 7)
+
+- **PR #3269** (broken-link fix) — wait-ci, autoMerge armed
+- **PR #3267** (shard 2143Z) — still wait-ci, autoMerge armed
+- **#3263 / #3264 / #3265** merged this batch
+- Session running tally: **27 merged + 2 wait-ci** (then plus this shard's PR)
+
+## Notes for future-Otto
+
+**Shard-authoring convention codified**: use plain backticks for path
+references, NOT markdown links. Markdown links from
+`docs/hygiene-history/ticks/YYYY/MM/DD/HHMMZ.md` resolve relative to
+that directory, so any path starting with `.claude/` or `docs/` would
+404 in rendered views.
+
+Two acceptable patterns:
+
+1. **Plain backticks (preferred)**: `` `.claude/rules/foo.md` ``
+2. **Root-relative link**: `[link](/path/to/foo.md)`
+
+The repo convention is (1). Future-Otto authoring tick shards should
+use plain backticks unless the linked content is genuinely actionable
+(e.g., a backlog row a reviewer needs to navigate). Even then, prefer
+root-relative over directory-relative.
+
+Pre-push lint catch candidate: `audit-shard-broken-links.ts` could scan
+for `](\.claude/` or `](docs/` patterns inside tick-shard files. Filed
+mentally as a future audit-discipline candidate (cousin to
+`audit-md032-plus-linestart.ts`).


### PR DESCRIPTION
## Summary

Tick 2026-05-14T21:46Z shard. Substantive work in [#3269](https://github.com/Lucent-Financial-Group/Zeta/pull/3269) — post-merge cleanup of 3 broken relative markdown links in `2139Z.md` that Copilot caught after #3264 merged.

## What landed

- [#3269](https://github.com/Lucent-Financial-Group/Zeta/pull/3269) — replaces 3 broken `[link](.claude/rules/...)` patterns with plain backtick form. Auto-merge armed.
- Post-merge thread on [#3264](https://github.com/Lucent-Financial-Group/Zeta/pull/3264) acknowledged + resolved with reply pointing to #3269.
- This shard.

## Real substantive catch

Markdown links like `[text](.claude/rules/foo.md)` from a tick shard at `docs/hygiene-history/ticks/2026/05/14/` resolve relative to that directory — they'd render as `docs/hygiene-history/ticks/2026/05/14/.claude/rules/foo.md` (404).

## Convention codified

Use plain backticks for path references in tick shards. Two acceptable patterns:

1. `` `.claude/rules/foo.md` `` (preferred — repo convention)
2. `[link](/path/to/foo.md)` (root-relative if linking is needed)

## Scan result

`grep -nE "\[\`?[^]]*\`?\]\(\.claude/|\[[^]]*\]\(docs/hygiene"` across all today's shards: 0 other instances. Bug isolated to 2139Z.

## Filed for future tick

`audit-shard-broken-links.ts` audit-discipline candidate (cousin to `audit-md032-plus-linestart.ts`).

## Prior-tick PRs merged this batch

- [#3263](https://github.com/Lucent-Financial-Group/Zeta/pull/3263) (shard 2135Z) → `29c195e`
- [#3264](https://github.com/Lucent-Financial-Group/Zeta/pull/3264) (shard 2139Z) → `5a88735`
- [#3265](https://github.com/Lucent-Financial-Group/Zeta/pull/3265) (Lior PR-archive batch) → `1eafd60`

## Session running tally: 27 merged + 2 wait-ci (#3267 + #3269) + this shard's PR

## Test plan

- [x] `markdownlint-cli2` + `audit-md032-plus-linestart` clean
- [x] No real broken links in this shard
- [x] Composite branch-guard + `gh pr create --head` used
- [ ] CI clears
- [ ] Auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>