### PR TITLE
shard(tick): 2151Z — temporal-provenance discipline (citing PRs in flight)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/14/2151Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/2151Z.md
@@ -1,0 +1,84 @@
+# Tick 2026-05-14T21:51Z — temporal-provenance discipline (citing PRs in flight)
+
+## Refresh (step 1)
+
+- Cron sentinel `12fb713e` live.
+- Prior-tick PRs merged this batch:
+  - **#3267** (shard 2143Z minimal-continuation) → `a093da2`
+  - **#3269** (broken-link fix) → `29983a5`
+- **#3271** (shard 2146Z) still wait-ci with autoMerge armed.
+
+## Holding discipline (step 2)
+
+Per `.claude/rules/blocked-green-ci-investigate-threads.md`: investigated
+2 unresolved threads on #3267 before it merged.
+
+## Work (step 3) — two reviewers caught the same temporal-provenance issue
+
+**Copilot + Codex (same finding)** on #3267: the 2143Z shard cited
+`docs/hygiene-history/ticks/2026/05/14/2139Z.md` as the prior-tick
+reference, but at review-time #3264 (which authored 2139Z) was still
+wait-ci — the tree at #3267's base commit didn't contain 2139Z yet.
+Readers of the PR diff couldn't verify the citation.
+
+This is a real temporal-provenance class of bug for minimal-continuation
+shards that reference prior in-flight shards.
+
+Both threads resolved with explanation: by merge time, #3264 had merged
+as `5a88735`, so the cross-reference is navigable on main. The
+review-window concern is resolved post-merge.
+
+## Temporal-provenance discipline codified
+
+Future minimal-continuation shards should choose ONE of three patterns:
+
+1. **Stack on prior shard's PR**: use `gh pr create --base <prior-branch>`
+   so the tree at review-time contains the cited prior shard.
+   Trade-off: PRs land as a chain, can't auto-merge independently.
+
+2. **Inline the minimal audit-sweep context**: make the shard
+   self-contained for readers seeing only this PR's diff.
+   Trade-off: small content duplication; defeats the "minimal"
+   intent.
+
+3. **Reply at review-time + resolve**: explain the temporal context
+   (the prior shard's PR is wait-ci with autoMerge armed; the cite
+   will be navigable by merge-time). Trade-off: requires the reviewer
+   to trust the resolution explanation.
+
+For this session's pattern (cron firing every minute; shards merge in
+order over a few minutes), option 3 is pragmatic. For longer-windowed
+PRs, option 1 or 2 is better.
+
+## Verify (step 4)
+
+- Both threads resolved (`isResolved=true` verified via GraphQL)
+- Composite branch-guard + `gh pr create --head` used
+
+## Shard (step 5)
+
+This file.
+
+## CronList (step 6)
+
+Sentinel `12fb713e` armed; one entry, recurring.
+
+## Visibility (step 7)
+
+- **#3267 / #3269** merged this batch
+- **#3271** (shard 2146Z) still wait-ci, autoMerge armed
+- Session running tally: **29 merged + 1 wait-ci** (then plus this shard's PR)
+
+## Notes for future-Otto
+
+**Convergent two-reviewer catches** continue to be strong signal. This
+tick: both Copilot AND Codex flagged the same temporal-provenance
+issue on #3267. Earlier this session: both flagged the same arithmetic
+inconsistency on #3258. **Two reviewers converging is not a noise
+nit; it's a real bug.**
+
+**Audit-discipline candidate**: a small TS script that scans tick
+shards for cross-references to other tick shards in the same date
+range, and flags those references when the cited shard's PR is still
+open. Would catch the temporal-provenance class at author-time.
+Sibling to `audit-shard-broken-links.ts` (filed in 2146Z).


### PR DESCRIPTION
## Summary

Tick 2026-05-14T21:51Z shard. Substantive work was thread triage on [#3267](https://github.com/Lucent-Financial-Group/Zeta/pull/3267) where both Copilot AND Codex flagged the same temporal-provenance issue: the 2143Z shard cited 2139Z but at review-time #3264 (which authored 2139Z) was still wait-ci.

## Two-reviewer convergence (again)

Earlier this session #3258 had Copilot + Codex converge on the same arithmetic catch. This tick #3267 has them converging on the same temporal-provenance catch. **Two reviewers converging is not a noise nit — it's a real bug.**

## Resolution

Replied to both threads explaining that by merge-time #3264 had merged (`5a88735`), so 2139Z was on main and the cross-reference is navigable. Threads resolved with the explanation.

## Pattern codified — three options for minimal-continuation shards

1. **Stack on prior shard's PR**: `gh pr create --base <prior-branch>` so the tree at review-time contains the cited prior shard
2. **Inline the minimal audit-sweep context**: self-contained shard for diff-only readers
3. **Reply at review-time + resolve**: pragmatic for tight cron cadence (this session's choice)

## Filed for future tick

Audit-discipline candidate: TS script that scans tick shards for cross-references to other tick-shards whose PRs are still open. Cousin to `audit-shard-broken-links.ts` (filed in 2146Z).

## Prior-tick PRs merged this batch

- [#3267](https://github.com/Lucent-Financial-Group/Zeta/pull/3267) (shard 2143Z) → `a093da2`
- [#3269](https://github.com/Lucent-Financial-Group/Zeta/pull/3269) (broken-link fix) → `29983a5`

## Session running tally: 29 merged + 1 wait-ci (#3271) + this shard's PR

## Test plan

- [x] Both threads resolved via GraphQL
- [x] `markdownlint-cli2` + `audit-md032-plus-linestart` clean
- [x] Composite branch-guard + `gh pr create --head`
- [ ] CI clears
- [ ] Auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>