### PR TITLE
fix(shard-2146Z): convert inline grep to fenced code block + add file operands

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/14/2146Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/2146Z.md
@@ -41,7 +41,12 @@ Substantive landing:
 - Thread on #3264 acknowledged with reply pointing to #3269; resolved.
 
 Scan of OTHER today's shards for the same bug:
-`grep -nE "\[\`?[^]]*\`?\]\(\.claude/|\[[^]]*\]\(docs/hygiene"` —
+
+```bash
+grep -nE '\[`?[^]]*`?\]\(\.claude/|\[[^]]*\]\(docs/hygiene' \
+  docs/hygiene-history/ticks/2026/05/14/2*.md
+```
+
 **zero other instances**. Bug isolated to 2139Z.
 
 ## Verify (step 4)


### PR DESCRIPTION
## Summary

Post-merge cleanup of [#3271](https://github.com/Lucent-Financial-Group/Zeta/pull/3271). Copilot caught two real issues in the 2146Z shard's grep command:

1. **P1 rendering** — single-backtick inline code span contained literal backticks inside the regex (`` `? ``); Markdown terminated the span at the first inner backtick, rendering the rest as broken markup.
2. **P2 reproducibility** — the command was missing file/path operands; as written, `grep` reads stdin instead of scanning shard files.

## Changes

```bash
grep -nE '\[`?[^]]*`?\]\(\.claude/|\[[^]]*\]\(docs/hygiene' \
  docs/hygiene-history/ticks/2026/05/14/2*.md
```

- Fenced code block resolves the rendering issue (no inner-backtick conflict)
- Single-quoted regex prevents shell interpretation of `$`, `\`, etc.
- File operand makes the command actually reproducible

## Verified

Running the corrected command on `origin/main` returns exit code 1 (no matches) — matches the shard's claimed "zero other instances" result.

## Test plan

- [x] Corrected command runs cleanly + produces the claimed result
- [x] `markdownlint-cli2` clean
- [x] Composite branch-guard + `gh pr create --head` used
- [ ] CI clears
- [ ] Auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>