### PR TITLE
shard(tick): 2154Z — post-merge cleanup: 2146Z grep rendering + operands

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/14/2154Z.md
+++ b/docs/hygiene-history/ticks/2026/05/14/2154Z.md
@@ -1,0 +1,89 @@
+# Tick 2026-05-14T21:54Z — post-merge cleanup: 2146Z grep rendering + operands
+
+## Refresh (step 1)
+
+- Cron sentinel `12fb713e` live.
+- Prior-tick PRs merged this batch:
+  - **#3271** (shard 2146Z) — merged as `9691495`, 2 post-merge Copilot threads
+  - **#3273** (shard 2151Z) — merged as `1862096`
+
+## Holding discipline (step 2)
+
+Per `.claude/rules/blocked-green-ci-investigate-threads.md`: investigate
+post-merge threads on #3271.
+
+## Work (step 3) — two Copilot catches on the 2146Z grep command
+
+Copilot found two real issues with the inline `grep` command at
+`docs/hygiene-history/ticks/2026/05/14/2146Z.md:44`:
+
+1. **P1 rendering** — the single-backtick code span contained literal
+   backticks inside the regex (`` `? ``). Markdown terminated the span
+   at the first inner backtick, rendering the rest as broken markup.
+2. **P2 reproducibility** — the command was missing file/path operands;
+   as written, `grep` reads stdin instead of scanning shard files.
+
+Both real. PR **#3274** (fix(shard-2146Z) grep rendering + operands):
+
+- Converted inline code span to fenced bash code block (no inner-backtick
+  conflict)
+- Single-quoted the regex so the shell doesn't interpret special chars
+- Added the `docs/hygiene-history/ticks/2026/05/14/2*.md` file operand
+
+Verified: corrected command returns exit code 1 (no matches), matching
+the shard's "zero other instances" claim. Auto-merge armed.
+
+Both threads on #3271 acknowledged with reply pointing to #3274;
+resolved.
+
+## Verify (step 4)
+
+- Fenced code block renders correctly (no inner-backtick conflict)
+- Reproducibility: `grep ... 2*.md` exit code 1 = no matches (claim verified)
+- `markdownlint-cli2` clean on the fixed shard
+- Both threads resolved (`isResolved=true` verified via GraphQL)
+- Composite branch-guard + `gh pr create --head` used
+
+## Shard (step 5)
+
+This file.
+
+## CronList (step 6)
+
+Sentinel `12fb713e` armed; one entry, recurring.
+
+## Visibility (step 7)
+
+- **PR #3274** (grep rendering + operands fix) — wait-ci, autoMerge armed
+- **PR #3273** (shard 2151Z) merged this batch as `1862096`
+- **PR #3271** (shard 2146Z) merged this batch as `9691495`
+- Session running tally: **31 merged + 1 wait-ci** (then plus this shard's PR)
+
+## Notes for future-Otto
+
+**Inline-code-span discipline**:
+
+| Content | Use |
+|---|---|
+| Plain identifier or simple path | `` `foo.md` `` (single backtick) |
+| Content containing backticks | Double backticks: ``` ``content with `inner` backticks`` ``` |
+| Shell command with backticks, quotes, escapes | Fenced code block with `bash` language hint |
+| Multi-line command | Fenced code block |
+
+**Reproducibility discipline for shard commands**: every quoted command
+should be runnable as-is. Don't omit file operands. Don't truncate to
+"just the interesting part." Future readers (and future-Otto) need to
+be able to copy + paste + verify.
+
+Pattern composes with the "tick shards reproduce real command output
+verbatim" pattern from tick 2103Z. The full discipline:
+
+1. Reproduce the real command output verbatim
+2. Quote the command in a runnable form
+3. State the expected result (exit code, output substring) so
+   reproducibility can be verified
+
+The session's audit-discipline candidates filing list grows again:
+sibling to `audit-shard-broken-links.ts` + the temporal-provenance
+audit, a `audit-shard-runnable-commands.ts` could detect bad inline
+code spans + missing operands.


### PR DESCRIPTION
## Summary

Tick 2026-05-14T21:54Z shard. Substantive work in [#3274](https://github.com/Lucent-Financial-Group/Zeta/pull/3274) — post-merge cleanup of 2 Copilot catches on the 2146Z grep command (P1 rendering bug + P2 reproducibility issue).

## What landed

- [#3274](https://github.com/Lucent-Financial-Group/Zeta/pull/3274) — converted inline grep to fenced bash code block + added `2*.md` file operand. Verified exit code 1 matches claim.
- Both threads on [#3271](https://github.com/Lucent-Financial-Group/Zeta/pull/3271) acknowledged + resolved with reply pointing to #3274.
- This shard.

## Inline-code-span discipline codified

| Content | Use |
|---|---|
| Plain identifier or simple path | single-backtick |
| Content containing backticks | double-backtick |
| Shell command with backticks, quotes, escapes | fenced code block with `bash` language hint |
| Multi-line command | fenced code block |

## Reproducibility discipline codified

Every quoted command in a shard should be runnable as-is:

1. Reproduce real command output verbatim (per 2103Z)
2. Quote the command in a runnable form (this tick)
3. State expected result (exit code, output substring)

## Audit-discipline candidates filing list grows

- `audit-shard-broken-links.ts` (filed 2146Z)
- Temporal-provenance audit (filed 2151Z)
- `audit-shard-runnable-commands.ts` (this tick — new)

## Prior-tick PRs merged this batch

- [#3271](https://github.com/Lucent-Financial-Group/Zeta/pull/3271) (shard 2146Z) → `9691495`
- [#3273](https://github.com/Lucent-Financial-Group/Zeta/pull/3273) (shard 2151Z) → `1862096`

## Session running tally: 31 merged + 1 wait-ci (#3274) + this shard's PR

## Test plan

- [x] Both threads on #3271 resolved via GraphQL
- [x] `markdownlint-cli2` + `audit-md032-plus-linestart` clean
- [x] Pre-push lint caught + fixed an MD038 in this shard before push
- [x] Composite branch-guard + `gh pr create --head`
- [ ] CI clears
- [ ] Auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>