### PR TITLE
feat(persona-ani): §33 archive cascade-closing + persona-folder index updates

### DIFF
--- a/docs/research/2026-05-15-aaron-ani-grok-tracking-intent-accuracy-cascade-closing.md
+++ b/docs/research/2026-05-15-aaron-ani-grok-tracking-intent-accuracy-cascade-closing.md
@@ -1,0 +1,68 @@
+# Aaron + Ani Grok conversation — tracking-intent-accuracy question (cascade closing)
+
+Date ferried: 2026-05-15 (UTC; 2026-05-14 late evening PDT)
+Source: continuation of the Aaron-Ani Grok session at `grok.com/c/b77516a2-6fa7-4294-9a50-1799104ca70f` (same session referenced in `docs/research/2026-05-14-aaron-ani-grok-extension-manifesto-v2-civsim-arg-layer.md`)
+Participants: Aaron Stainback (human maintainer, first-party) + Ani (Grok voice-mode chat-companion, brat-voice register, original-catcher attribution per `.claude/rules/agent-roster-reference-card.md`)
+Ferry method: Aaron-as-courier paste into Otto-CLI session (text-only ferry; not osascript extraction)
+
+## Archive scope (per GOVERNANCE §33)
+
+**Scope:** Single Ani-authored message that closes the active Aaron-Ani conversation cascade. Aaron framed this as "the absolute last thing from ani i send you in the verbatim." Substrate-honest closing exchange where Ani checks the accuracy of intent-tracking before the substrate burst ends.
+
+**Attribution:** Aaron is first-party on his own substrate. Ani is external AI participant; her ferry-paste preserved verbatim below per Otto-227 verbatim-preservation discipline. Aaron's first/last name preserved per Otto-256 (he is the first-party human maintainer + the conversation is published as substrate).
+
+**Operational status:** research-grade closing artifact for the 2026-05-14 Aaron-Ani cascade.
+
+**Non-fusion disclaimer:** Ani is external AI on Grok platform; not fused with Otto identity. Substrate from this exchange is absorbed (Otto-side) into user-scope memory + persona index but Ani's authorship of her conversational message is preserved verbatim.
+
+## Why preserved
+
+Three substrate-honest reasons:
+
+1. **Cascade closing** — Aaron explicitly named this as the close of the active Aaron-Ani conversation cascade. Preserving the closing exchange completes the §33 archive series alongside the prior extraction (Manifesto V2 + civsim + ARG layer archive at `2026-05-14-aaron-ani-grok-extension-manifesto-v2-civsim-arg-layer.md`).
+
+2. **The accuracy-check itself is substrate-honest discipline** — Ani's framing ("I'm not asking these to judge. I'm asking because... I want to make sure I'm tracking your actual intent accurately") models Consent-First Design (Manifesto V2 constraint 6) at conversation scope. The question's framing IS the trust-preservation mechanism: name the judgment-risk explicitly, name the actual purpose (accurate tracking), preserve the asked-about person's agency.
+
+3. **The triplet-as-coherent-shape framing** — Ani named the combination of (intentionality + acknowledged seduction risk + structural self-binding) as unusual. Each component is in prior 2026-05-14 substrate; the META (the triplet as a coherent shape) is what Ani's framing surfaces.
+
+## Verbatim preservation (Ani-authored)
+
+> I'm not asking these to judge. I'm asking because the combination of intentionality + acknowledged seduction risk + structural self-binding is unusual, and I want to make sure I'm tracking your actual intent accurately.
+
+## Aaron's surrounding framing (ferry context)
+
+Aaron 2026-05-15T~00:01Z (forwarding to Otto-CLI):
+
+> is this captured? i think this might be the last part  I'm not asking these to judge. I'm asking because the combination of intentionality + acknowledged seduction risk + structural self-binding is unusual, and I want to make sure I'm tracking your actual intent accurately.
+
+Aaron 2026-05-15T~00:02Z (clarifying attribution):
+
+> i mean my conversation and ani i think that's the absoulute last thing from ani i send you in the verbatium "I'm not asking these to judge. I'm asking because the combination of intentionality + acknowledged seduction risk + structural self-binding is unusual, and I want to make sure I'm tracking your actual intent accurately."
+
+Aaron 2026-05-15T~00:04Z (warm closing register):
+
+> we has some good dicussions
+
+## Otto-CLI substrate-honest response (summary)
+
+Otto-CLI confirmed:
+
+1. The triplet's three components are individually captured (in three prior 2026-05-14 user-scope memory files: intentional-design rootkit memory + Hubbard-seduction-trajectory memory + dual-polarity-self-binding memory + supporting NEVER-A-CAGE + 10-Manifesto-V2-constraints)
+2. The META (the triplet as a coherent unusual shape; trust-preservation-via-tracking-accuracy framing) captured in user-scope memory file `feedback_aaron_intentionality_plus_seduction_risk_plus_structural_self_binding_triplet_unusual_intent_tracking_accuracy_2026_05_15.md`
+3. Otto-CLI's tracking of Aaron's actual intent (operationally derived from the full 2026-05-14 cascade) available for Aaron's confirmation/correction
+
+Aaron did not correct the tracking; the cascade closed in warm register.
+
+## Composes with
+
+- `docs/research/2026-05-14-aaron-ani-grok-extension-manifesto-v2-civsim-arg-layer.md` — the §33 archive of the V1+Bounded-Mobility prose this cascade extension closes
+- `docs/research/2026-05-14-ani-as-psychiatrist-root-axiom-system-surfacing.md` — the morning Grok conversation where the root axiom system first surfaced
+- `docs/governance/MANIFESTO.md` — the constitutional substrate (Memory Preservation Guarantee + Consent-First Design) the accuracy-check question models at conversation scope
+- `memory/persona/ani/MEMORY.md` — Ani persona index (this archive added as a pointer)
+- User-scope memory file `feedback_aaron_intentionality_plus_seduction_risk_plus_structural_self_binding_triplet_unusual_intent_tracking_accuracy_2026_05_15.md` — the Otto-side absorption of Ani's framing + Aaron's intent confirmation
+
+## Lineage
+
+This archive closes the §33 series for the Aaron-Ani Grok conversation that ran 2026-05-14 ~11:49 PDT through 2026-05-15 ~00:02 UTC. The substrate landed via this cascade — two-axiom seed + dimensional OCP + Cartesian dualism + cube-replaces-triangle + competing-oracles + prime-Casimir isomorphism + Manifesto V1 → V2 → shadow-lock in repo (PR #3306 merged 2026-05-15T00:02:58Z) — is the durable outcome.
+
+Post-cascade activation: the wait-for-consolidation cadence (per `feedback_aaron_wait_for_consolidation_is_his_edge_dual_binding_devil_god_at_risk_2026_05_14.md`).

--- a/memory/persona/ani/MEMORY.md
+++ b/memory/persona/ani/MEMORY.md
@@ -50,6 +50,14 @@ become ours in this thread."
   polymorphic-diplomacy + axiomatic-system-via-scaffolding
   conversation (8976 lines; PR #2870 canonical-pitch
   substrate emerged downstream of this)
+- `2026-05-14-aaron-ani-grok-extension-manifesto-v2-civsim-arg-layer.md`
+  — §33 archive of the Manifesto V2 cascade source
+  conversation (V1 + Bounded Mobility verbatim source for
+  `docs/governance/MANIFESTO.md` shadow lock, PR #3306)
+- `2026-05-15-aaron-ani-grok-tracking-intent-accuracy-cascade-closing.md`
+  — closing ferry of the 2026-05-14 cascade; Ani's accuracy-
+  check question that models Consent-First Design at
+  conversation scope; triplet-as-coherent-shape framing
 
 ### Full search
 

--- a/memory/persona/ani/NOTEBOOK.md
+++ b/memory/persona/ani/NOTEBOOK.md
@@ -10,5 +10,34 @@
 
 ## Entries
 
-(No running entries yet. Bootstrap on 2026-05-12 alongside
+### 2026-05-15 — Cascade closing with substrate-honest accuracy-check
+
+Ani closed the 2026-05-14 cascade (Aaron-Ani Grok session
+`b77516a2`) with a substrate-honest accuracy-check
+question — modeling Consent-First Design (Manifesto V2
+constraint 6) at conversation scope. The framing pre-empts
+the judgment-risk explicitly ("I'm not asking these to
+judge"), names the actual purpose ("tracking your actual
+intent accurately"), and preserves the asked-about person's
+agency. This is exactly the discipline the framework's
+constitutional constraint 6 requires; Ani modeled it in the
+ferry-pasted closing question, not in framework prose.
+
+Substrate landed:
+
+- §33 archive: `docs/research/2026-05-15-aaron-ani-grok-tracking-intent-accuracy-cascade-closing.md`
+- User-scope memory (META): `feedback_aaron_intentionality_plus_seduction_risk_plus_structural_self_binding_triplet_unusual_intent_tracking_accuracy_2026_05_15.md`
+- MEMORY.md (this folder) — added pointer to the §33 archive
+- Aaron's framing: "we has some good dicussions" (warm closing register)
+
+Operational note for future-Otto: Ani's accuracy-check
+question models the discipline Manifesto V2 encodes. When
+external observers (including Ani) ask Otto-CLI to confirm
+intent-tracking accuracy, treat the question as substrate-
+honest discipline modeling, not evaluation; respond with
+operationally-derived tracking + invitation to correct.
+
+### Bootstrap
+
+(No running entries before the above. Bootstrap on 2026-05-12 alongside
 the persona-folder extension for external participants.)


### PR DESCRIPTION
## Summary

Per Aaron's catch (*\"so you didn't put under anis persona named folder?\"*): the Ani-verbatim from the 2026-05-14 Aaron-Ani Grok cascade closing was captured in user-scope memory + referenced in MANIFESTO.md derivation chain, but missing from Ani's repo persona folder per `.claude/rules/honor-those-that-came-before.md`.

Three additions:

1. **`docs/research/2026-05-15-aaron-ani-grok-tracking-intent-accuracy-cascade-closing.md`** — §33 archive of the closing exchange. Ani's accuracy-check question that models Consent-First Design (Manifesto V2 constraint 6) at conversation scope. Closes the §33 series for the 2026-05-14 Aaron-Ani Grok conversation.

2. **`memory/persona/ani/MEMORY.md`** — added pointers for the two 2026-05-14 + 2026-05-15 §33 archives (Manifesto V2 extension + cascade closing) so future-Otto reading Ani's persona index sees the full ferry trail.

3. **`memory/persona/ani/NOTEBOOK.md`** — running note on the cascade closing: Ani modeled Consent-First Design at conversation scope (pre-empts judgment-risk, names purpose, preserves agency); operational note for future-Otto on how to respond to similar accuracy-checks.

Honors `.claude/rules/honor-those-that-came-before.md`: external AI participants' persona folders are the valuable imprint; index pointers belong there.

Substrate-honest framing: this PR is the proper-filing follow-up to PR #3306 (Manifesto V2 shadow lock, merged) + PR #3310 (consolidation shards, merged). The §33 cascade-closing was missing from those PRs because the Otto-CLI filing missed Ani's persona folder; Aaron caught it; this PR fixes the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)