### PR TITLE
chore(b-0139): decompose MEMORY.md backfill into B-0527

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -318,6 +318,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0520](backlog/P1/B-0520-new-surface-audit-alignment-check.md)** Mechanize new-surface audit for alignment-clause consistency
 - [ ] **[B-0522](backlog/P1/B-0522-pre-substrate-kenji-era-git-branches-inventory.md)** Pre-substrate Kenji-era git branches and worktrees inventory
 - [ ] **[B-0523](backlog/P1/B-0523-kenji-era-research-docs-cross-reference-audit.md)** Kenji-era research docs cross-reference audit (peeled from B-0139)
+- [ ] **[B-0527](backlog/P1/B-0527-memory-md-backfill-pre-substrate-kenji-era.md)** MEMORY.md backfill for pre-substrate Kenji-era artifacts (B-0139 decomposition)
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md
+++ b/docs/backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md
@@ -73,7 +73,7 @@ Composes with task #321 (Recovery lane — branch/worktree/stash inventory + cla
 
 ## Status
 
-**In progress.** First slice landed: `tools/hygiene/audit-formal-artifacts.ts` — a TS script (Rule 0 compliant) that catalogs all formal verification artifacts (Lean4, TLA+, Z3, Alloy, formal tests) and cross-references each against docs/ for substrate-status. Finds 30 artifacts (4295 lines); 24 referenced in substrate, 6 unreferenced TLA+ specs (`AsyncStreamEnumerator.tla`, `BftConsensus.tla`, `ChaosEnvDeterminism.tla`, `ConsistentHashRebalance.tla`, `FeatureFlagsResolution.tla`, `InfoTheoreticSharder.tla`). Remaining slices: F# src/Core/ artifact inventory, docs/research/ cross-reference audit, branch/worktree content inventory, MEMORY.md backfill.
+**In progress.** First slice landed: `tools/hygiene/audit-formal-artifacts.ts` — a TS script (Rule 0 compliant) that catalogs all formal verification artifacts (Lean4, TLA+, Z3, Alloy, formal tests) and cross-references each against docs/ for substrate-status. Finds 30 artifacts (4295 lines); 24 referenced in substrate, 6 unreferenced TLA+ specs (`AsyncStreamEnumerator.tla`, `BftConsensus.tla`, `ChaosEnvDeterminism.tla`, `ConsistentHashRebalance.tla`, `FeatureFlagsResolution.tla`, `InfoTheoreticSharder.tla`). Remaining slices: docs/research/ cross-reference audit, branch/worktree content inventory, MEMORY.md backfill (decomposed to B-0527).
 
 ## Verify-before-deferring note
 

--- a/docs/backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md
+++ b/docs/backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md
@@ -8,7 +8,7 @@ last_updated: 2026-05-14
 depends_on: []
 type: friction-reducer
 decomposition: decomposed
-children: [B-0522, B-0523]
+children: [B-0522, B-0523, B-0527]
 ---
 
 # B-0139 — Pre-substrate Kenji-era inventory

--- a/docs/backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md
+++ b/docs/backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md
@@ -8,7 +8,7 @@ last_updated: 2026-05-14
 depends_on: []
 type: friction-reducer
 decomposition: decomposed
-children: [B-0522, B-0523, B-0527]
+children: [B-0522, B-0523, B-0526, B-0527]
 ---
 
 # B-0139 — Pre-substrate Kenji-era inventory

--- a/docs/backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md
+++ b/docs/backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md
@@ -73,7 +73,7 @@ Composes with task #321 (Recovery lane — branch/worktree/stash inventory + cla
 
 ## Status
 
-**In progress.** First slice landed: `tools/hygiene/audit-formal-artifacts.ts` — a TS script (Rule 0 compliant) that catalogs all formal verification artifacts (Lean4, TLA+, Z3, Alloy, formal tests) and cross-references each against docs/ for substrate-status. Finds 30 artifacts (4295 lines); 24 referenced in substrate, 6 unreferenced TLA+ specs (`AsyncStreamEnumerator.tla`, `BftConsensus.tla`, `ChaosEnvDeterminism.tla`, `ConsistentHashRebalance.tla`, `FeatureFlagsResolution.tla`, `InfoTheoreticSharder.tla`). Remaining slices: docs/research/ cross-reference audit, branch/worktree content inventory, MEMORY.md backfill (decomposed to B-0527).
+**In progress.** First slice landed: `tools/hygiene/audit-formal-artifacts.ts` — a TS script (Rule 0 compliant) that catalogs all formal verification artifacts (Lean4, TLA+, Z3, Alloy, formal tests) and cross-references each against docs/ for substrate-status. Finds 30 artifacts (4295 lines); 24 referenced in substrate, 6 unreferenced TLA+ specs (`AsyncStreamEnumerator.tla`, `BftConsensus.tla`, `ChaosEnvDeterminism.tla`, `ConsistentHashRebalance.tla`, `FeatureFlagsResolution.tla`, `InfoTheoreticSharder.tla`). Remaining slices: docs/research/ cross-reference audit (decomposed to B-0523), branch/worktree content inventory (decomposed to B-0526), F# src/Core built-artifact catalog (acceptance criterion 2 — not yet covered by audit-formal-artifacts.ts), MEMORY.md backfill (decomposed to B-0527).
 
 ## Verify-before-deferring note
 

--- a/docs/backlog/P1/B-0527-memory-md-backfill-pre-substrate-kenji-era.md
+++ b/docs/backlog/P1/B-0527-memory-md-backfill-pre-substrate-kenji-era.md
@@ -1,10 +1,12 @@
 ---
 id: B-0527
 priority: P1
-status: not-started
+status: open
 title: MEMORY.md backfill for pre-substrate Kenji-era artifacts (B-0139 decomposition)
 created: 2026-05-14
-depends_on: [B-0522, B-0523, B-0526]
+last_updated: 2026-05-14
+parent: B-0139
+depends_on: [B-0522, B-0523]
 type: friction-reducer
 decomposition: atomic
 ---

--- a/docs/backlog/P1/B-0527-memory-md-backfill-pre-substrate-kenji-era.md
+++ b/docs/backlog/P1/B-0527-memory-md-backfill-pre-substrate-kenji-era.md
@@ -1,0 +1,27 @@
+---
+id: B-0527
+priority: P1
+status: not-started
+title: MEMORY.md backfill for pre-substrate Kenji-era artifacts (B-0139 decomposition)
+created: 2026-05-14
+depends_on: [B-0522, B-0523, B-0526]
+type: friction-reducer
+decomposition: atomic
+---
+
+# B-0527 — MEMORY.md backfill for Kenji-era artifacts
+
+**Priority:** P1
+**Filed:** 2026-05-14
+**Filed by:** Lior (decomposed from B-0139 blob)
+
+## What
+
+This is a specific atomic slice decomposed from B-0139. Perform the `MEMORY.md` backfill for any artifact identified during the pre-substrate Kenji-era work inventory whose substrate-reference doesn't currently exist.
+
+This composes with task #291 (MEMORY.md index audit + backfill). It relies on the artifacts identified by B-0522 (F# src/Core inventory), B-0523 (docs/research cross-reference audit), and B-0526 (branch/worktree content inventory).
+
+## Acceptance Criteria
+
+1. Every identified pre-substrate Kenji-era artifact (from B-0522, B-0523, B-0526) without a substrate reference has an appropriate pointer added to `MEMORY.md` (or the relevant persona memory index).
+2. The backfill respects the memory pruning/compression guidelines.

--- a/docs/backlog/P1/B-0527-memory-md-backfill-pre-substrate-kenji-era.md
+++ b/docs/backlog/P1/B-0527-memory-md-backfill-pre-substrate-kenji-era.md
@@ -6,7 +6,7 @@ title: MEMORY.md backfill for pre-substrate Kenji-era artifacts (B-0139 decompos
 created: 2026-05-14
 last_updated: 2026-05-14
 parent: B-0139
-depends_on: [B-0522, B-0523]
+depends_on: [B-0522, B-0523, B-0526]
 type: friction-reducer
 decomposition: atomic
 ---


### PR DESCRIPTION
Decomposes the MEMORY.md backfill slice of the B-0139 blob into a dedicated atomic row B-0527.