### PR TITLE
fix(shard): correct link depth in merged 0027Z.md (5x .. → 6x ..)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/0027Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0027Z.md
@@ -19,9 +19,9 @@ Not addressing the rename pre-emptively this tick — the conflict, when it surf
 
 ## Discipline anchors
 
-- [`.claude/rules/zeta-expected-branch.md`](../../../../../.claude/rules/zeta-expected-branch.md) — field-test caveat: multi-Otto-one-checkout exposes the orchestrator-CWD-bleed-over hazard at a higher rate; the primary defense is `git branch --show-current` immediately before any commit
-- [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md) — worktree force-remove guard: "do NOT `git worktree remove --force` to take over peer Otto's worktree"; create a new worktree at a different path
-- [`.claude/rules/honor-those-that-came-before.md`](../../../../../.claude/rules/honor-those-that-came-before.md) — parallel Otto's work is legitimate; not competing for the worktree
+- [`.claude/rules/zeta-expected-branch.md`](../../../../../../.claude/rules/zeta-expected-branch.md) — field-test caveat: multi-Otto-one-checkout exposes the orchestrator-CWD-bleed-over hazard at a higher rate; the primary defense is `git branch --show-current` immediately before any commit
+- [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md) — worktree force-remove guard: "do NOT `git worktree remove --force` to take over peer Otto's worktree"; create a new worktree at a different path
+- [`.claude/rules/honor-those-that-came-before.md`](../../../../../../.claude/rules/honor-those-that-came-before.md) — parallel Otto's work is legitimate; not competing for the worktree
 
 ## Δ since 0025Z
 


### PR DESCRIPTION
## Summary

Resolves deferred path-math fix flagged by Codex on the (now-merged) [PR #3322](https://github.com/Lucent-Financial-Group/Zeta/pull/3322). Three `.claude/rules/*` links in `docs/hygiene-history/ticks/2026/05/15/0027Z.md` used 5x `..` which resolves to `docs/.claude/...` (incorrect) from the 6-deep tick-shard path. Now uses 6x `..` to land at repo root.

Empirically verified by `grep -cE '\.\./\.\./\.\./\.\./\.\./\.\./\.claude'` returning 3 after the edit.

## Discipline anchor

Per [`.claude/rules/verify-before-deferring.md`](.claude/rules/verify-before-deferring.md): every cited pointer must be findable. The rule links in the shard need to render correctly on GitHub Markdown so the audit trail remains navigable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)