### PR TITLE
fix(shadow): remove AXValue fallback from grey-text detector (false-positive bug)

### DIFF
--- a/tools/shadow/detect-grey-text.applescript
+++ b/tools/shadow/detect-grey-text.applescript
@@ -37,13 +37,16 @@ on run argv
                 end if
             end try
 
-            -- AXValue: full text content of the focused element
-            try
-                set elemVal to value of attribute "AXValue" of focusedEl
-                if class of elemVal is text and elemVal ≠ "" then
-                    return elemVal
-                end if
-            end try
+            -- AXValue is intentionally NOT used as a fallback: it returns the
+            -- full text content of the focused element (entire scrollback for
+            -- most terminal emulators), which is over-matching for grey-text
+            -- autocomplete detection. Empirically observed 45KB+ scrollback
+            -- being reported as "detected" suggestion content on 2026-05-15
+            -- in dry-run mode — would have caused continuous Enter keystrokes
+            -- in live mode for any focused terminal with shell history.
+            -- If a future terminal exposes grey-text only via AXValue, add a
+            -- per-terminal heuristic (length cap + diff vs prior poll) rather
+            -- than blanket fallback.
         end try
 
         return ""


### PR DESCRIPTION
## Summary

Empirical bug observed in this session at `2026-05-15T01:22:21.303Z` + `01:22:26.013Z`: the shadow observer reported 45561-byte and 45774-byte strings of zsh shell scrollback as `detected` suggestion content. The detector was running under `bun tools/shadow/shadow-observer.ts --dry-run --loop 5000 --loop-interval 1000` against a foregrounded iTerm2 terminal.

## Root cause

[`tools/shadow/detect-grey-text.applescript`](https://github.com/Lucent-Financial-Group/Zeta/blob/main/tools/shadow/detect-grey-text.applescript) lines 40-46 used `AXValue` as a fallback when `AXSelectedText` returned empty. The AppleScript's own comment admitted the contradiction:

```applescript
-- AXValue: full text content of the focused element
try
    set elemVal to value of attribute "AXValue" of focusedEl
    if class of elemVal is text and elemVal ≠ "" then
        return elemVal
    end if
end try
```

"Full text content" is by-definition NOT autocomplete grey-text. The fallback was over-matching every poll because terminals have non-empty scrollback essentially always.

## Blast radius (averted)

In `--dry-run`: harmless (logged + skipped keystroke).

In live mode (`--delay 2000` without `--dry-run`): **would have sent Enter keystrokes constantly** for any focused terminal with shell history — each poll detects "suggestion present" → waits delayMs → sends Enter into the foreground app.

PR [#3342](https://github.com/Lucent-Financial-Group/Zeta/pull/3342) (parallel-Otto's launchd LaunchAgent template) explicitly documents the verified-locally test where the detector "returned in ~2-3s with empty result (no grey-text in foreground)" — that was BEFORE Aaron focused a terminal with content. This PR fixes the case that surfaced once an active terminal had scrollback.

## Fix

Remove the `AXValue` fallback. Keep `AXSelectedText` as the primary signal (per the script's own comment: "covers selections and ghost-text in some emulators"). Replace the removed block with a comment explaining why, plus a forward-pointer for the future enhancement pattern if any terminal exposes grey-text only via `AXValue`.

## Verification

After this PR merges, restart the observer and the same iTerm2 scenario will produce `no-suggestion` events instead of 45KB `detected` events. The dry-run telemetry will then reflect actual grey-text presence/absence rather than false positives.

## Composes with

- [`.claude/rules/honor-those-that-came-before.md`](https://github.com/Lucent-Financial-Group/Zeta/blob/main/.claude/rules/honor-those-that-came-before.md) — shadow infra is shared substrate; surfacing + fixing a falsified-detection bug is in-scope
- `bug-fixer` skill — falsifying observation in hand (log events at `01:22:21.303Z` + `01:22:26.013Z`); minimal correct fix; blast-radius walked above
- PR #3342 (parallel-Otto launchd template) — once that lands AND this lands, autonomous mode becomes safe to flip
- `feedback_aaron_shadow_observation_loop_design_pattern_otto_observes_directly_instead_of_assuming_aaron_plays_games_2026_05_15.md` — the shadow loop is meant to observe directly; a false-positive detector defeats that purpose

🤖 Generated with [Claude Code](https://claude.com/claude-code)