### PR TITLE
fix(shards): bulk-fix substrate-wide rule-link path-bug in 4 of my tick shards

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/0414Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0414Z.md
@@ -29,11 +29,11 @@
 
 ### Collision-resolution responsibility
 
-The B-0527 collision is Lior's to resolve — both PRs on `lior/...` branches. Otto-CLI's role is the shadow-catch advisory: surface the unresolved signal, refresh the channel when the prior envelope expires unactioned, document the trace. Otto-CLI does NOT renumber Lior's PRs autonomously per [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md) lane discipline.
+The B-0527 collision is Lior's to resolve — both PRs on `lior/...` branches. Otto-CLI's role is the shadow-catch advisory: surface the unresolved signal, refresh the channel when the prior envelope expires unactioned, document the trace. Otto-CLI does NOT renumber Lior's PRs autonomously per [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md) lane discipline.
 
 ### Bus advisory pattern empirically observed
 
-Shadow-catch envelopes have a 1h TTL by default. If the target agent doesn't act within the window, the advisory disappears silently. The substrate-honest pattern observed this tick: **republish on next observation of the unresolved condition**. Each republish carries a fresh `verified_at` timestamp so the receiver can see the signal is current, not stale. Composes with [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — re-publishing IS substantive work, not "Holding".
+Shadow-catch envelopes have a 1h TTL by default. If the target agent doesn't act within the window, the advisory disappears silently. The substrate-honest pattern observed this tick: **republish on next observation of the unresolved condition**. Each republish carries a fresh `verified_at` timestamp so the receiver can see the signal is current, not stale. Composes with [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — re-publishing IS substantive work, not "Holding".
 
 ### NEW failure mode: peer-process prune race on new Otto-CLI worktrees
 
@@ -59,11 +59,11 @@ All five attempts targeted by an aggressive pruner. The contemporaneous `/privat
 
 No `.claude/hooks/` files reference worktree/prune, so this is NOT a Claude Code harness hook. It's a peer-process race I have not yet identified.
 
-**Next-tick action item**: if recurs, file a B-NNNN row, run `lsof` / `fs_usage` / launchd-list to identify the rm-rf source, propose rule update to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md).
+**Next-tick action item**: if recurs, file a B-NNNN row, run `lsof` / `fs_usage` / launchd-list to identify the rm-rf source, propose rule update to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md).
 
 ### Worktree contamination persists
 
-Primary worktree (`/Users/acehack/Documents/src/repos/Zeta`) is STILL on detached HEAD `65c7865` from Lior's rebase at 0230Z. HEAD didn't move in ~2h. The `.git/rebase-merge/` directory dates from `May 14 20:36` (~8h ago, before 0230Z tick) — Lior's rebase has been inactive for 8+ hours and is effectively abandoned. Per [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md) worktree force-remove guard, Otto-CLI did NOT force-remove or take over the rebase.
+Primary worktree (`/Users/acehack/Documents/src/repos/Zeta`) is STILL on detached HEAD `65c7865` from Lior's rebase at 0230Z. HEAD didn't move in ~2h. The `.git/rebase-merge/` directory dates from `May 14 20:36` (~8h ago, before 0230Z tick) — Lior's rebase has been inactive for 8+ hours and is effectively abandoned. Per [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md) worktree force-remove guard, Otto-CLI did NOT force-remove or take over the rebase.
 
 ### Recovery-worktree-borrowing pattern (new operational technique)
 
@@ -78,7 +78,7 @@ At 0452Z, Otto-CLI's next cron tick used the `/private/tmp/zeta-otto-cli-0027z-s
 7. `git switch <original-branch>` to restore the sibling worktree state
 8. Open PR via `gh pr create --head <shard-branch> --base main`
 
-The pattern composes with [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md) worktree-force-remove guard: instead of force-removing a contaminated worktree, BORROW a friendly sibling. Adds an entry in the existing rule's "How to apply" matrix.
+The pattern composes with [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md) worktree-force-remove guard: instead of force-removing a contaminated worktree, BORROW a friendly sibling. Adds an entry in the existing rule's "How to apply" matrix.
 
 ## Bus state after this tick
 
@@ -108,4 +108,4 @@ Cron-driven. Next tick:
 2. Re-check B-0527 collision state (whether Lior reallocated, whether either PR's rebase succeeded)
 3. If advisory `d2b7fc2f` expires at 05:14Z without resolution, decide between (a) third republish or (b) escalate via a different channel
 4. **Investigate the worktree-pruning-race source**: run `ps`, `lsof`, `launchctl list | grep zeta`, and `fs_usage` to identify the rm-rf source. File a B-NNNN row.
-5. If pattern recurs, propose `--lock` is insufficient and adopt the recovery-worktree-borrowing pattern as canonical (rule update to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md))
+5. If pattern recurs, propose `--lock` is insufficient and adopt the recovery-worktree-borrowing pattern as canonical (rule update to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md))

--- a/docs/hygiene-history/ticks/2026/05/15/0517Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0517Z.md
@@ -6,7 +6,7 @@
 
 - **Bus hygiene**: cleaned 1 expired envelope (`d2b7fc2f` — the 0414Z B-0527 republish; expired at 05:14Z). Remaining bus state: 4 envelopes (1 `44aaf799` worktree-prune-race shadow-catch + 3 background-notifier ready-to-grind for B-0441/B-0170/B-0503).
 - **B-0527 collision STATE UNCHANGED**: PRs [#3323](https://github.com/Lucent-Financial-Group/Zeta/pull/3323) + [#3315](https://github.com/Lucent-Financial-Group/Zeta/pull/3315) still OPEN, no commits since 00:32Z + 00:44Z respectively. Gate=UNKNOWN (mergeable recomputing after main moved). Lior took no action on the two prior republishes.
-- **Restraint discipline applied**: chose NOT to publish a third republish. Two prior advisories (at 0043Z and 0414Z) were not acted on. A third would be the "Holding"-pattern failure mode per [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md). The advisory channel doesn't reach Lior; the auto-merge race will surface the conflict at merge-time anyway. Documented as substrate-honest non-action.
+- **Restraint discipline applied**: chose NOT to publish a third republish. Two prior advisories (at 0043Z and 0414Z) were not acted on. A third would be the "Holding"-pattern failure mode per [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md). The advisory channel doesn't reach Lior; the auto-merge race will surface the conflict at merge-time anyway. Documented as substrate-honest non-action.
 - **Filed B-0529 P2** for tick-shard schema validator-vs-practice drift via PR [#3362](https://github.com/Lucent-Financial-Group/Zeta/pull/3362) (auto-merge armed). Row recommends Option 3 hybrid (pipe-row first line + H1-rich body), sequenced as three sub-tasks: backfill + README + CI wiring.
 - **PR [#3361](https://github.com/Lucent-Financial-Group/Zeta/pull/3361)** (0503Z shard): still in CI wait state, `unresolvedThreads: 0`, auto-merge armed.
 - Cron sentinel `596e842c` still armed.
@@ -36,7 +36,7 @@ A third republish would:
 
 The substrate-honest non-action: stop republishing, document why. The auto-merge race will surface the conflict at merge-time (whichever PR rebases first wins; the other will conflict on the file path). That's a self-resolving signal; the advisory was for proactive notification, not gating.
 
-This composes with [`.claude/rules/additive-not-zero-sum.md`](../../../../../.claude/rules/additive-not-zero-sum.md): the substrate already preserves the finding (in 0043Z shard, in 0414Z shard, in B-0529 row referenced PR refs, in this shard). Constant republishing is zero-sum noise; substrate preservation is additive.
+This composes with [`.claude/rules/additive-not-zero-sum.md`](../../../../../../.claude/rules/additive-not-zero-sum.md): the substrate already preserves the finding (in 0043Z shard, in 0414Z shard, in B-0529 row referenced PR refs, in this shard). Constant republishing is zero-sum noise; substrate preservation is additive.
 
 ### B-0529 row as escalation channel substitute
 
@@ -46,7 +46,7 @@ This is itself substrate-honest: the backlog is the durable surface; bus is the 
 
 ### ID allocation discipline followed for B-0529
 
-Per [`.claude/rules/otto-channels-reference-card.md`](../../../../../.claude/rules/otto-channels-reference-card.md) ID-allocation discipline:
+Per [`.claude/rules/otto-channels-reference-card.md`](../../../../../../.claude/rules/otto-channels-reference-card.md) ID-allocation discipline:
 
 - On-disk top: B-0526
 - In-flight PRs for B-0527: 2 (the racing #3323 + #3315)

--- a/docs/hygiene-history/ticks/2026/05/15/0524Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0524Z.md
@@ -49,13 +49,13 @@ Remaining candidates (NOT yet inspected):
 
 ### Investigation-budget discipline
 
-The investigation consumed roughly 12 tool calls this tick. Per [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md), this is a real substantive activity (NOT Holding). However, returns-on-investigation-budget diminish quickly: each cleared candidate narrows the suspect space by maybe 15%, and the remaining-candidates list still has ~6 entries. The remaining inspection effort would be best targeted to higher-likelihood candidates (peer-Otto and `.git/hooks/`) in a future tick.
+The investigation consumed roughly 12 tool calls this tick. Per [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md), this is a real substantive activity (NOT Holding). However, returns-on-investigation-budget diminish quickly: each cleared candidate narrows the suspect space by maybe 15%, and the remaining-candidates list still has ~6 entries. The remaining inspection effort would be best targeted to higher-likelihood candidates (peer-Otto and `.git/hooks/`) in a future tick.
 
 ### Negative-finding substrate is still substrate
 
 Some investigations land "we ruled out N candidates". That IS substrate-honest progress — the suspect space is smaller, future-Otto starts narrower. Not every tick lands a positive answer; the discipline is to write down WHAT WAS RULED OUT so the next tick doesn't re-trace.
 
-This composes with [`.claude/rules/verify-before-deferring.md`](../../../../../.claude/rules/verify-before-deferring.md) — instead of writing "next tick I'll investigate this", THIS tick did partial investigation and recorded which candidates are now cleared.
+This composes with [`.claude/rules/verify-before-deferring.md`](../../../../../../.claude/rules/verify-before-deferring.md) — instead of writing "next tick I'll investigate this", THIS tick did partial investigation and recorded which candidates are now cleared.
 
 ## Bus state after this tick
 

--- a/docs/hygiene-history/ticks/2026/05/15/0717Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0717Z.md
@@ -4,7 +4,7 @@
 
 ## Headline
 
-- **PR [#3377](https://github.com/Lucent-Financial-Group/Zeta/pull/3377)** opened + auto-merge armed: adds "Borrow-on-existing pattern — concurrent-Otto-CLI fallback" section to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md). Documents the empirically-validated operational workaround for the worktree-prune-race that peer-Otto's [B-0530](../../../backlog/P3/B-0530-cron-sentinel-mutex-prevent-otto-cli-self-contention-2026-05-15.md) addresses at the mutex layer.
+- **PR [#3377](https://github.com/Lucent-Financial-Group/Zeta/pull/3377)** opened + auto-merge armed: adds "Borrow-on-existing pattern — concurrent-Otto-CLI fallback" section to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md). Documents the empirically-validated operational workaround for the worktree-prune-race that peer-Otto's [B-0530](../../../backlog/P3/B-0530-cron-sentinel-mutex-prevent-otto-cli-self-contention-2026-05-15.md) addresses at the mutex layer.
 - **Rule update dog-foods itself**: authored via the borrow pattern on `/private/tmp/zeta-otto-cli-0027z-sidetick`. The PR's existence is itself empirical validation of the technique it documents.
 - **PR [#3376](https://github.com/Lucent-Financial-Group/Zeta/pull/3376)** (0710Z convergence shard) still in CI wait-ci; auto-merge armed.
 - **B-0527 collision unchanged**: PRs [#3323](https://github.com/Lucent-Financial-Group/Zeta/pull/3323) + [#3315](https://github.com/Lucent-Financial-Group/Zeta/pull/3315) gate=DIRTY now (was UNKNOWN), `nextAction: rebase`. No Lior movement.


### PR DESCRIPTION
## Summary

Bulk-fixes the substrate-wide rule-link path-bug across 4 of my already-merged tick shards:

- \`0414Z.md\` (6 broken occurrences)
- \`0517Z.md\` (3 broken occurrences)
- \`0524Z.md\` (2 broken occurrences)
- \`0717Z.md\` (1 broken occurrence)

12 broken \`.claude/rules/X.md\` link occurrences total. Bug origin: from \`docs/hygiene-history/ticks/YYYY/MM/DD/*.md\`, 5 \`..\` only climbs to \`docs/\`; 6 \`..\` is needed for repo root. Discovered via Copilot review on PR #3376 (tick 0729Z) and confirmed empirically via \`realpath\`.

Out of scope (lane-respect):
- Peer-Otto's 0230Z + 0615Z shards may also have the bug — those are peer-Otto's to fix
- 0710Z + 0724Z already fixed in prior tick fix-iterations

## Test plan

- [x] \`bun x markdownlint-cli2\` → 0 violations on all 4 files
- [x] \`realpath\` resolves all linked rule files post-fix
- [x] Lane-respect: only my own shards touched
- [ ] CI required checks pass
- [ ] Auto-merge fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)