### PR TITLE
feat(rules): replace local find with git ls-tree on origin/main for ID-allocation discipline

### DIFF
--- a/.claude/rules/otto-channels-reference-card.md
+++ b/.claude/rules/otto-channels-reference-card.md
@@ -73,7 +73,10 @@ on-disk state:
    the top, missing B-0527 + B-0528 (which were taken by PRs #3334 + #3342
    on `origin/main`). The mis-allocation was caught by Copilot review but
    reached a public PR-comment first; correction comment had to follow.
-   See `docs/hygiene-history/ticks/2026/05/15/0742Z.md` for the trace.
+   See [PR #3381](https://github.com/Lucent-Financial-Group/Zeta/pull/3381)
+   (which lands `docs/hygiene-history/ticks/2026/05/15/0742Z.md` carrying
+   the full trace), plus the correction comment on
+   [PR #3323](https://github.com/Lucent-Financial-Group/Zeta/pull/3323).
 
 2. **In-flight check** — what peer Otto is filing right now:
 

--- a/.claude/rules/otto-channels-reference-card.md
+++ b/.claude/rules/otto-channels-reference-card.md
@@ -55,14 +55,25 @@ Allocating a new monotonically-increasing ID across multi-Otto surfaces
 items if numeric, etc.) requires checking BOTH ambient surfaces — not just
 on-disk state:
 
-1. **On-disk check** — what's currently merged:
+1. **Merged-state check via `origin/main`** — what's currently merged
+   (regardless of local worktree state):
 
    ```bash
-   # Portable across GNU + BSD find (macOS/Linux). The `B-NNNN` pattern only
-   # appears once per filename in practice, so extracting from full paths is safe.
-   find docs/backlog -name "B-*.md" -type f \
-     | grep -oE "B-[0-9]+" | sort -u -t- -k2 -n | tail -3
+   git fetch origin main
+   git ls-tree -r origin/main -- docs/backlog/ \
+     | awk '{print $4}' | grep -oE "B-[0-9]+" | sort -u -t- -k2 -n | tail -5
    ```
+
+   **Important**: do NOT use `find docs/backlog -name "B-*.md"` on the local
+   worktree. The local working tree may be on a stale HEAD (detached from
+   an abandoned rebase, on a feature branch that's behind, etc.), which
+   gives misleading "what's free" answers. Empirical anchor: tick 0742Z
+   on 2026-05-15 — Otto-CLI's primary worktree was stuck on detached HEAD
+   `65c7865` from an 8h-stale Lior rebase; local `find` showed B-0526 as
+   the top, missing B-0527 + B-0528 (which were taken by PRs #3334 + #3342
+   on `origin/main`). The mis-allocation was caught by Copilot review but
+   reached a public PR-comment first; correction comment had to follow.
+   See `docs/hygiene-history/ticks/2026/05/15/0742Z.md` for the trace.
 
 2. **In-flight check** — what peer Otto is filing right now:
 

--- a/.claude/rules/otto-channels-reference-card.md
+++ b/.claude/rules/otto-channels-reference-card.md
@@ -59,7 +59,11 @@ on-disk state:
    (regardless of local worktree state):
 
    ```bash
-   git fetch origin main
+   # `git fetch origin` (no branch arg) updates ALL configured remote-tracking
+   # refs reliably; the form `git fetch origin main` updates FETCH_HEAD but
+   # may not refresh refs/remotes/origin/main under all configs (refspec
+   # overrides, partial-clone, etc.).
+   git fetch origin
    git ls-tree -r origin/main -- docs/backlog/ \
      | awk '{print $4}' | grep -oE "B-[0-9]+" | sort -u -t- -k2 -n | tail -5
    ```
@@ -69,10 +73,10 @@ on-disk state:
    an abandoned rebase, on a feature branch that's behind, etc.), which
    gives misleading "what's free" answers. Empirical anchor: tick 0742Z
    on 2026-05-15 — Otto-CLI's primary worktree was stuck on detached HEAD
-   `65c7865` from an 8h-stale Lior rebase; local `find` showed B-0526 as
-   the top, missing B-0527 + B-0528 (which were taken by PRs #3334 + #3342
-   on `origin/main`). The mis-allocation was caught by Copilot review but
-   reached a public PR-comment first; correction comment had to follow.
+   `65c7865` from an 8h-stale peer-agent rebase; local `find` showed B-0526
+   as the top, missing B-0527 + B-0528 (which were taken by PRs #3334 +
+   #3342 on `origin/main`). The mis-allocation was caught by Copilot review
+   but reached a public PR-comment first; correction comment had to follow.
    See [PR #3381](https://github.com/Lucent-Financial-Group/Zeta/pull/3381)
    (which lands `docs/hygiene-history/ticks/2026/05/15/0742Z.md` carrying
    the full trace), plus the correction comment on


### PR DESCRIPTION
## Summary

Updates the ID-allocation discipline in [\`.claude/rules/otto-channels-reference-card.md\`](.claude/rules/otto-channels-reference-card.md) to use \`git fetch origin main\` + \`git ls-tree -r origin/main\` instead of local \`find docs/backlog\`. Empirical anchor: tick 0742Z's "B-0528 free" misallocation that reached a public PR comment before Copilot caught it.

**Root cause of the failure mode**: when Otto-CLI's primary worktree is stuck on a stale HEAD (detached from an abandoned rebase, a feature branch behind main, etc.), local \`find docs/backlog\` returns stale state. The fix queries the remote ref directly so the answer is independent of local worktree state.

## Test plan

- [x] \`bun x markdownlint-cli2 .claude/rules/otto-channels-reference-card.md\` → 0 violations
- [x] Empirical anchor (0742Z incident) cited
- [x] Composes with refresh-before-decide.md
- [ ] CI required checks pass
- [ ] Auto-merge fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)