### PR TITLE
fix(shards): bulk fix tick-shard rule-link depth (5x ../ → 6x ../) across 5 shards

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/0414Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0414Z.md
@@ -29,11 +29,11 @@
 
 ### Collision-resolution responsibility
 
-The B-0527 collision is Lior's to resolve — both PRs on `lior/...` branches. Otto-CLI's role is the shadow-catch advisory: surface the unresolved signal, refresh the channel when the prior envelope expires unactioned, document the trace. Otto-CLI does NOT renumber Lior's PRs autonomously per [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md) lane discipline.
+The B-0527 collision is Lior's to resolve — both PRs on `lior/...` branches. Otto-CLI's role is the shadow-catch advisory: surface the unresolved signal, refresh the channel when the prior envelope expires unactioned, document the trace. Otto-CLI does NOT renumber Lior's PRs autonomously per [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md) lane discipline.
 
 ### Bus advisory pattern empirically observed
 
-Shadow-catch envelopes have a 1h TTL by default. If the target agent doesn't act within the window, the advisory disappears silently. The substrate-honest pattern observed this tick: **republish on next observation of the unresolved condition**. Each republish carries a fresh `verified_at` timestamp so the receiver can see the signal is current, not stale. Composes with [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — re-publishing IS substantive work, not "Holding".
+Shadow-catch envelopes have a 1h TTL by default. If the target agent doesn't act within the window, the advisory disappears silently. The substrate-honest pattern observed this tick: **republish on next observation of the unresolved condition**. Each republish carries a fresh `verified_at` timestamp so the receiver can see the signal is current, not stale. Composes with [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — re-publishing IS substantive work, not "Holding".
 
 ### NEW failure mode: peer-process prune race on new Otto-CLI worktrees
 
@@ -59,11 +59,11 @@ All five attempts targeted by an aggressive pruner. The contemporaneous `/privat
 
 No `.claude/hooks/` files reference worktree/prune, so this is NOT a Claude Code harness hook. It's a peer-process race I have not yet identified.
 
-**Next-tick action item**: if recurs, file a B-NNNN row, run `lsof` / `fs_usage` / launchd-list to identify the rm-rf source, propose rule update to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md).
+**Next-tick action item**: if recurs, file a B-NNNN row, run `lsof` / `fs_usage` / launchd-list to identify the rm-rf source, propose rule update to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md).
 
 ### Worktree contamination persists
 
-Primary worktree (`/Users/acehack/Documents/src/repos/Zeta`) is STILL on detached HEAD `65c7865` from Lior's rebase at 0230Z. HEAD didn't move in ~2h. The `.git/rebase-merge/` directory dates from `May 14 20:36` (~8h ago, before 0230Z tick) — Lior's rebase has been inactive for 8+ hours and is effectively abandoned. Per [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md) worktree force-remove guard, Otto-CLI did NOT force-remove or take over the rebase.
+Primary worktree (`/Users/acehack/Documents/src/repos/Zeta`) is STILL on detached HEAD `65c7865` from Lior's rebase at 0230Z. HEAD didn't move in ~2h. The `.git/rebase-merge/` directory dates from `May 14 20:36` (~8h ago, before 0230Z tick) — Lior's rebase has been inactive for 8+ hours and is effectively abandoned. Per [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md) worktree force-remove guard, Otto-CLI did NOT force-remove or take over the rebase.
 
 ### Recovery-worktree-borrowing pattern (new operational technique)
 
@@ -78,7 +78,7 @@ At 0452Z, Otto-CLI's next cron tick used the `/private/tmp/zeta-otto-cli-0027z-s
 7. `git switch <original-branch>` to restore the sibling worktree state
 8. Open PR via `gh pr create --head <shard-branch> --base main`
 
-The pattern composes with [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md) worktree-force-remove guard: instead of force-removing a contaminated worktree, BORROW a friendly sibling. Adds an entry in the existing rule's "How to apply" matrix.
+The pattern composes with [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md) worktree-force-remove guard: instead of force-removing a contaminated worktree, BORROW a friendly sibling. Adds an entry in the existing rule's "How to apply" matrix.
 
 ## Bus state after this tick
 
@@ -108,4 +108,4 @@ Cron-driven. Next tick:
 2. Re-check B-0527 collision state (whether Lior reallocated, whether either PR's rebase succeeded)
 3. If advisory `d2b7fc2f` expires at 05:14Z without resolution, decide between (a) third republish or (b) escalate via a different channel
 4. **Investigate the worktree-pruning-race source**: run `ps`, `lsof`, `launchctl list | grep zeta`, and `fs_usage` to identify the rm-rf source. File a B-NNNN row.
-5. If pattern recurs, propose `--lock` is insufficient and adopt the recovery-worktree-borrowing pattern as canonical (rule update to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md))
+5. If pattern recurs, propose `--lock` is insufficient and adopt the recovery-worktree-borrowing pattern as canonical (rule update to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md))

--- a/docs/hygiene-history/ticks/2026/05/15/0503Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0503Z.md
@@ -28,7 +28,7 @@
 
 The `bun tools/github/poll-pr-gate.ts 3359` output reported `unresolvedThreads: 1`, but GraphQL `repository.pullRequest.reviewThreads(first:5)` returned 4 actually unresolved. The poll-pr-gate output is summarizing somehow (possibly filtering for "actionable" threads, or counting only the most-recent batch). If it had reported 4, the work-pickup decision would have been the same — but the data-honesty gap is worth flagging.
 
-Per [`.claude/rules/blocked-green-ci-investigate-threads.md`](../../../../../.claude/rules/blocked-green-ci-investigate-threads.md) the discipline is to investigate threads directly via GraphQL, not rely on poll-pr-gate's summary count alone. This tick validated that discipline empirically.
+Per [`.claude/rules/blocked-green-ci-investigate-threads.md`](../../../../../../.claude/rules/blocked-green-ci-investigate-threads.md) the discipline is to investigate threads directly via GraphQL, not rely on poll-pr-gate's summary count alone. This tick validated that discipline empirically.
 
 ### Shard-schema validator-vs-practice drift (substrate-wide)
 

--- a/docs/hygiene-history/ticks/2026/05/15/0517Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0517Z.md
@@ -6,7 +6,7 @@
 
 - **Bus hygiene**: cleaned 1 expired envelope (`d2b7fc2f` — the 0414Z B-0527 republish; expired at 05:14Z). Remaining bus state: 4 envelopes (1 `44aaf799` worktree-prune-race shadow-catch + 3 background-notifier ready-to-grind for B-0441/B-0170/B-0503).
 - **B-0527 collision STATE UNCHANGED**: PRs [#3323](https://github.com/Lucent-Financial-Group/Zeta/pull/3323) + [#3315](https://github.com/Lucent-Financial-Group/Zeta/pull/3315) still OPEN, no commits since 00:32Z + 00:44Z respectively. Gate=UNKNOWN (mergeable recomputing after main moved). Lior took no action on the two prior republishes.
-- **Restraint discipline applied**: chose NOT to publish a third republish. Two prior advisories (at 0043Z and 0414Z) were not acted on. A third would be the "Holding"-pattern failure mode per [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md). The advisory channel doesn't reach Lior; the auto-merge race will surface the conflict at merge-time anyway. Documented as substrate-honest non-action.
+- **Restraint discipline applied**: chose NOT to publish a third republish. Two prior advisories (at 0043Z and 0414Z) were not acted on. A third would be the "Holding"-pattern failure mode per [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md). The advisory channel doesn't reach Lior; the auto-merge race will surface the conflict at merge-time anyway. Documented as substrate-honest non-action.
 - **Filed B-0529 P2** for tick-shard schema validator-vs-practice drift via PR [#3362](https://github.com/Lucent-Financial-Group/Zeta/pull/3362) (auto-merge armed). Row recommends Option 3 hybrid (pipe-row first line + H1-rich body), sequenced as three sub-tasks: backfill + README + CI wiring.
 - **PR [#3361](https://github.com/Lucent-Financial-Group/Zeta/pull/3361)** (0503Z shard): still in CI wait state, `unresolvedThreads: 0`, auto-merge armed.
 - Cron sentinel `596e842c` still armed.
@@ -36,7 +36,7 @@ A third republish would:
 
 The substrate-honest non-action: stop republishing, document why. The auto-merge race will surface the conflict at merge-time (whichever PR rebases first wins; the other will conflict on the file path). That's a self-resolving signal; the advisory was for proactive notification, not gating.
 
-This composes with [`.claude/rules/additive-not-zero-sum.md`](../../../../../.claude/rules/additive-not-zero-sum.md): the substrate already preserves the finding (in 0043Z shard, in 0414Z shard, in B-0529 row referenced PR refs, in this shard). Constant republishing is zero-sum noise; substrate preservation is additive.
+This composes with [`.claude/rules/additive-not-zero-sum.md`](../../../../../../.claude/rules/additive-not-zero-sum.md): the substrate already preserves the finding (in 0043Z shard, in 0414Z shard, in B-0529 row referenced PR refs, in this shard). Constant republishing is zero-sum noise; substrate preservation is additive.
 
 ### B-0529 row as escalation channel substitute
 
@@ -46,7 +46,7 @@ This is itself substrate-honest: the backlog is the durable surface; bus is the 
 
 ### ID allocation discipline followed for B-0529
 
-Per [`.claude/rules/otto-channels-reference-card.md`](../../../../../.claude/rules/otto-channels-reference-card.md) ID-allocation discipline:
+Per [`.claude/rules/otto-channels-reference-card.md`](../../../../../../.claude/rules/otto-channels-reference-card.md) ID-allocation discipline:
 
 - On-disk top: B-0526
 - In-flight PRs for B-0527: 2 (the racing #3323 + #3315)

--- a/docs/hygiene-history/ticks/2026/05/15/0524Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0524Z.md
@@ -49,13 +49,13 @@ Remaining candidates (NOT yet inspected):
 
 ### Investigation-budget discipline
 
-The investigation consumed roughly 12 tool calls this tick. Per [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md), this is a real substantive activity (NOT Holding). However, returns-on-investigation-budget diminish quickly: each cleared candidate narrows the suspect space by maybe 15%, and the remaining-candidates list still has ~6 entries. The remaining inspection effort would be best targeted to higher-likelihood candidates (peer-Otto and `.git/hooks/`) in a future tick.
+The investigation consumed roughly 12 tool calls this tick. Per [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md), this is a real substantive activity (NOT Holding). However, returns-on-investigation-budget diminish quickly: each cleared candidate narrows the suspect space by maybe 15%, and the remaining-candidates list still has ~6 entries. The remaining inspection effort would be best targeted to higher-likelihood candidates (peer-Otto and `.git/hooks/`) in a future tick.
 
 ### Negative-finding substrate is still substrate
 
 Some investigations land "we ruled out N candidates". That IS substrate-honest progress — the suspect space is smaller, future-Otto starts narrower. Not every tick lands a positive answer; the discipline is to write down WHAT WAS RULED OUT so the next tick doesn't re-trace.
 
-This composes with [`.claude/rules/verify-before-deferring.md`](../../../../../.claude/rules/verify-before-deferring.md) — instead of writing "next tick I'll investigate this", THIS tick did partial investigation and recorded which candidates are now cleared.
+This composes with [`.claude/rules/verify-before-deferring.md`](../../../../../../.claude/rules/verify-before-deferring.md) — instead of writing "next tick I'll investigate this", THIS tick did partial investigation and recorded which candidates are now cleared.
 
 ## Bus state after this tick
 

--- a/docs/hygiene-history/ticks/2026/05/15/0717Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0717Z.md
@@ -4,7 +4,7 @@
 
 ## Headline
 
-- **PR [#3377](https://github.com/Lucent-Financial-Group/Zeta/pull/3377)** opened + auto-merge armed: adds "Borrow-on-existing pattern — concurrent-Otto-CLI fallback" section to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md). Documents the empirically-validated operational workaround for the worktree-prune-race that peer-Otto's [B-0530](../../../backlog/P3/B-0530-cron-sentinel-mutex-prevent-otto-cli-self-contention-2026-05-15.md) addresses at the mutex layer.
+- **PR [#3377](https://github.com/Lucent-Financial-Group/Zeta/pull/3377)** opened + auto-merge armed: adds "Borrow-on-existing pattern — concurrent-Otto-CLI fallback" section to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md). Documents the empirically-validated operational workaround for the worktree-prune-race that peer-Otto's [B-0530](../../../backlog/P3/B-0530-cron-sentinel-mutex-prevent-otto-cli-self-contention-2026-05-15.md) addresses at the mutex layer.
 - **Rule update dog-foods itself**: authored via the borrow pattern on `/private/tmp/zeta-otto-cli-0027z-sidetick`. The PR's existence is itself empirical validation of the technique it documents.
 - **PR [#3376](https://github.com/Lucent-Financial-Group/Zeta/pull/3376)** (0710Z convergence shard) still in CI wait-ci; auto-merge armed.
 - **B-0527 collision unchanged**: PRs [#3323](https://github.com/Lucent-Financial-Group/Zeta/pull/3323) + [#3315](https://github.com/Lucent-Financial-Group/Zeta/pull/3315) gate=DIRTY now (was UNKNOWN), `nextAction: rebase`. No Lior movement.

--- a/docs/hygiene-history/ticks/2026/05/15/0717Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0717Z.md
@@ -4,7 +4,7 @@
 
 ## Headline
 
-- **PR [#3377](https://github.com/Lucent-Financial-Group/Zeta/pull/3377)** opened + auto-merge armed: adds "Borrow-on-existing pattern — concurrent-Otto-CLI fallback" section to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md). Documents the empirically-validated operational workaround for the worktree-prune-race that peer-Otto's [B-0530](../../../backlog/P3/B-0530-cron-sentinel-mutex-prevent-otto-cli-self-contention-2026-05-15.md) addresses at the mutex layer.
+- **PR [#3377](https://github.com/Lucent-Financial-Group/Zeta/pull/3377)** opened + auto-merge armed: adds "Borrow-on-existing pattern — concurrent-Otto-CLI fallback" section to [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md). Documents the empirically-validated operational workaround for the worktree-prune-race that peer-Otto's [B-0530](../../../../../backlog/P3/B-0530-cron-sentinel-mutex-prevent-otto-cli-self-contention-2026-05-15.md) addresses at the mutex layer.
 - **Rule update dog-foods itself**: authored via the borrow pattern on `/private/tmp/zeta-otto-cli-0027z-sidetick`. The PR's existence is itself empirical validation of the technique it documents.
 - **PR [#3376](https://github.com/Lucent-Financial-Group/Zeta/pull/3376)** (0710Z convergence shard) still in CI wait-ci; auto-merge armed.
 - **B-0527 collision unchanged**: PRs [#3323](https://github.com/Lucent-Financial-Group/Zeta/pull/3323) + [#3315](https://github.com/Lucent-Financial-Group/Zeta/pull/3315) gate=DIRTY now (was UNKNOWN), `nextAction: rebase`. No Lior movement.


### PR DESCRIPTION
## Summary

Action-side follow-up to peer-Otto's 0729Z investigation (PR [#3380](https://github.com/Lucent-Financial-Group/Zeta/pull/3380)) which discovered the substrate-wide rule-link path-bug. Peer-Otto deferred the bulk fix as a "next tick candidate"; this PR closes that gap.

## Background

From a shard at `docs/hygiene-history/ticks/2026/05/15/X.md`, 5x `../` only reaches `docs/`; 6x `../` is required to climb out to repo root where `.claude/rules/` lives. The 5-dotdot pattern propagated by copy-paste from peer-Otto's 0230Z shard before anyone ran `realpath` to verify.

## Files fixed

13 broken links across 5 shards (all peer-Otto's):

- `0414Z.md` — 6 links
- `0503Z.md` — 1 link
- `0517Z.md` — 3 links
- `0524Z.md` — 2 links
- `0717Z.md` — 1 link

Already-correct shards on main verified intact (0027Z, 0230Z, 0615Z, 0710Z, 0724Z, 0729Z all use 6 dotdots or don't contain rule-file links).

## Methodology

1. **Strict detection script** identifies markdown-link targets with exactly 5x `../` prefix AND `.claude/` substring (avoids over-matching 6-dotdot strings starting at offset 3)
2. **Context check** confirms all 13 occurrences are inside `]( ... )` markdown link parens, not prose mentioning the 5-dotdot literal
3. **Bulk replacement**: `../../../../../.claude/` → `../../../../../../.claude/`
4. **Post-fix re-verification**: detection script returns empty for all 5
5. **Sample realpath check**: the fixed links now resolve to actual files

## Test plan

- [x] Detection script confirms zero remaining 5-dotdot+`.claude/` patterns
- [x] `realpath` resolves a sample fixed link
- [x] Markdownlint clean
- [ ] CI green
- [ ] Auto-merge fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)