### PR TITLE
feat(autonomous-loop): wire cron-sentinel-mutex into Step 1 refresh

### DIFF
--- a/docs/AUTONOMOUS-LOOP-PER-TICK.md
+++ b/docs/AUTONOMOUS-LOOP-PER-TICK.md
@@ -38,6 +38,41 @@ Never act on stale state. Minimum refresh:
 - `bun tools/github/poll-pr-gate-batch.ts --all-open` — current state of all my open PRs
 - `git fetch origin main && git status` — main HEAD + local state
 - `CronList` — verify the autonomous-loop sentinel is still armed
+- `bun tools/orchestrator-checks/cron-sentinel-mutex.ts --json` — detect concurrent Otto-CLI peer sessions
+  ([B-0530](backlog/P3/B-0530-cron-sentinel-mutex-prevent-otto-cli-self-contention-2026-05-15.md);
+  Pattern 8 of [B-0519](backlog/P3/B-0519-multi-otto-branch-state-contamination-rca-2026-05-14.md))
+
+#### When peers are detected
+
+If the mutex check reports `peerDetected: true` (or exits with code
+1..250), the tick body should:
+
+1. **Avoid `git worktree add`** — the worktree-prune-race RCA in PR
+   #3370 documents that concurrent `git worktree add` from a peer
+   Otto-CLI on the same `.git/` directory causes
+   `Interrupted system call` failures on `.git/objects/pack` followed
+   by git's automatic rollback of the partially-populated worktree.
+   If a worktree is genuinely needed, prefer the
+   ["borrow-on-existing pattern"](../.claude/rules/claim-acquire-before-worktree-work.md)
+   landed in PR #3377.
+2. **Continue with non-git-mutating work** — bus envelope publishing,
+   read-only audits, planning, etc. are safe and don't contend.
+3. **Bus-publish a deferral envelope** if substrate observation
+   matters past this tick:
+
+   ```bash
+   bun tools/bus/bus.ts publish --from otto-cli --to '*' \
+     --topic shadow-catch \
+     --payload '{"finding":"tick deferred — peer Otto-CLI detected", ...}'
+   ```
+
+4. **Re-check next tick** — peer-Otto-CLI sessions typically wrap
+   their cron-tick work within 1-3 minutes; the contention window
+   resolves naturally.
+
+If the mutex exits with code 251 (`PGREP_ERROR_EXIT`), the mutex
+itself is unreliable — proceed with normal work but log the failure
+in the tick shard for future-Otto context.
 
 ### 2. Apply Holding-without-named-dependency discipline
 

--- a/docs/AUTONOMOUS-LOOP-PER-TICK.md
+++ b/docs/AUTONOMOUS-LOOP-PER-TICK.md
@@ -45,7 +45,8 @@ Never act on stale state. Minimum refresh:
 #### When peers are detected
 
 If the mutex check reports `peerDetected: true` (or exits with code
-1..250), the tick body should:
+2..250 — `Math.min(1 + peerCount, 250)`; exit 1 is not reachable when
+peers are detected), the tick body should:
 
 1. **Avoid `git worktree add`** — the worktree-prune-race RCA in PR
    #3370 documents that concurrent `git worktree add` from a peer
@@ -63,16 +64,19 @@ If the mutex check reports `peerDetected: true` (or exits with code
    ```bash
    bun tools/bus/bus.ts publish --from otto-cli --to '*' \
      --topic shadow-catch \
-     --payload '{"finding":"tick deferred — peer Otto-CLI detected", ...}'
+     --payload '{"finding":"tick deferred — peer Otto-CLI detected"}'
    ```
 
 4. **Re-check next tick** — peer-Otto-CLI sessions typically wrap
    their cron-tick work within 1-3 minutes; the contention window
    resolves naturally.
 
-If the mutex exits with code 251 (`PGREP_ERROR_EXIT`), the mutex
-itself is unreliable — proceed with normal work but log the failure
-in the tick shard for future-Otto context.
+If the mutex exits with code 251 (`PGREP_ERROR_EXIT`), pgrep itself
+failed — mutex state is unknown. Treat the same as peer-detected for
+git-mutating operations: **defer `git worktree add`**, continue with
+non-git-mutating work, and log the failure in the tick shard for
+future-Otto context. The safe assumption under unknown state is to
+avoid operations that contend on `.git/objects/pack`.
 
 ### 2. Apply Holding-without-named-dependency discipline
 


### PR DESCRIPTION
## Summary

Closes the deferred follow-up from [PR #3375](https://github.com/Lucent-Financial-Group/Zeta/pull/3375): wire the cron-sentinel-mutex (now on main as `tools/orchestrator-checks/cron-sentinel-mutex.ts`) into the canonical per-tick discipline so the `<<autonomous-loop>>` tick body invokes it during Step 1 refresh.

## What changes

`docs/AUTONOMOUS-LOOP-PER-TICK.md` Step 1 gains:

- A 4th bullet in the refresh list: `bun tools/orchestrator-checks/cron-sentinel-mutex.ts --json`
- A new "When peers are detected" sub-section documenting 4 deferral steps:
  1. Avoid `git worktree add` (worktree-prune-race rationale, PR #3370)
  2. Continue with non-git-mutating work (bus, audits, planning)
  3. Bus-publish a deferral envelope if substrate matters past this tick
  4. Re-check next tick (contention windows resolve in 1-3 min)
- Special case: exit code 251 (`PGREP_ERROR_EXIT`) — proceed but log

## Design choice: advisory, not gate

The discipline reports peer state; the tick body decides. Matches the mutex's design in PR #3375 (returns structured `MutexResult`, not a process kill). Lets the tick body do non-conflicting parallel work (bus envelopes, read-only audits) even when peer Otto-CLI is mid-worktree-add.

## 3-surface canonical convergence

Per the file's existing role, this update propagates to:

- Otto-CLI (auto-loaded next cold-boot)
- Otto-Desktop routine (cites `docs/AUTONOMOUS-LOOP-PER-TICK.md` from `tools/routines/autonomous-loop/SKILL.md`)
- B-0448 cloud routine (when shipped — will cite this file)

## Composes with

- [PR #3370](https://github.com/Lucent-Financial-Group/Zeta/pull/3370) — worktree-prune-race root cause + B-0519 Pattern 8
- [PR #3375](https://github.com/Lucent-Financial-Group/Zeta/pull/3375) — mutex implementation
- [PR #3377](https://github.com/Lucent-Financial-Group/Zeta/pull/3377) — borrow-on-existing pattern (alternative under peer contention)
- [PR #3386](https://github.com/Lucent-Financial-Group/Zeta/pull/3386) — bulk rule-link depth fix on affected shards

## Test plan
- [x] Markdownlint clean
- [x] Both relative links verified to resolve
- [ ] CI green
- [ ] Auto-merge fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)