### PR TITLE
fix(shard): 0916Z pipe-row col-5 (PR TBD) + body discipline-name ref restore

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/0916Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0916Z.md
@@ -1,4 +1,4 @@
-| 2026-05-15T09:16:00Z | claude-opus-4-7 | 596e842c | shard: PR #3393 merged; 4th stale-(PR #3396) on PR #3394 reply+resolve via templated boilerplate | (PR TBD) | rhythm stable: short ticks, thread-iteration dominant mode, restraint on mechanization holds |
+| 2026-05-15T09:16:00Z | claude-opus-4-7 | 596e842c | shard: PR #3393 merged; 4th stale-(PR TBD) on PR #3394 reply+resolve via templated boilerplate | (PR #3396) | rhythm stable: short ticks, thread-iteration dominant mode, restraint on mechanization holds |
 
 # Tick 0916Z — PR #3393 merged; 4th stale-(PR TBD) on PR #3394
 


### PR DESCRIPTION
## Summary

0916Z.md landed on main via PR #3396 with two bugs from a broken post-create-fix sed:

1. Pipe-row col 5 (PR-ref) still has `(PR TBD)` — should be `(PR #3396)`
2. Body col 4 incorrectly substituted: `4th stale-(PR #3396) on PR #3394` should be `4th stale-(PR TBD) on PR #3394` (generic discipline-name reference)

Root cause: `sed -i '' '1s|(PR TBD)|(PR #NNNN)|' <file>` replaces only the FIRST occurrence on line 1. When body col 4 has `(PR TBD)` text mentions (discussing the discipline name), it gets replaced first, leaving col 5 untouched.

Fix: `sed -i '' '1s@| (PR TBD) |@| (PR #NNNN) |@' <file>` — @-delimited (since | conflicts as delim+literal), pipe-anchored to cell-boundary.

Same fix landed in PR #3395 (still in flight) for 0911Z which had the same bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)