### PR TITLE
shard(tick): 0940Z — PR #3398 stale resolve; CI runner nudge #3379 + #3381

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/0940Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0940Z.md
@@ -1,0 +1,56 @@
+| 2026-05-15T09:40:00Z | claude-opus-4-7 | 596e842c | shard: PR #3398 stale-Copilot reply+resolve (same BSD-vs-GNU thread); empty-commit nudge on PR #3379 + #3381 (CI stuck ~2h) | (PR TBD) | tick-3-action shape: stale-resolve + CI-nudge + new-shard |
+
+# Tick 0940Z — PR #3398 stale-Copilot reply+resolve; CI runner nudge on stuck PRs
+
+## Headline
+
+- **PR [#3398](https://github.com/Lucent-Financial-Group/Zeta/pull/3398)** (0921Z shard) picked up 1 stale-Copilot on the SAME BSD-vs-GNU sed issue I just fixed in commit `2ac9c7e`. Copilot reviewed pre-fix snapshot. Reply + resolve.
+- **PR #3379** (0724Z shard, created 07:28Z) + **PR #3381** (0742Z shard, created 07:53Z): both have been gate=UNKNOWN / wait-ci for ~2h. `gh pr view --json statusCheckRollup` shows multiple `QUEUED` checks. GitHub Actions runner-queue is stuck — upstream infrastructure issue, not code.
+- **Empty-commit nudge applied to both** (`f9ff336` on #3379, `0e50de7` on #3381) to force a re-run of stale checks.
+- Cron sentinel `596e842c` armed.
+
+## Δ since 0934Z
+
+| What | At 0934Z | At 0940Z |
+|---|---|---|
+| PR #3398 (0921Z shard) | OPEN, 1 Codex P2 fixed | OPEN, 1 stale-Copilot reply+resolved (same topic) |
+| PR #3379 | OPEN, wait-ci ~1.5h | OPEN, empty-commit nudge `f9ff336` |
+| PR #3381 | OPEN, wait-ci ~1.5h | OPEN, empty-commit nudge `0e50de7` |
+| PR #3399 (0934Z shard) | OPEN, wait-ci | OPEN, wait-ci (unchanged) |
+| Cumulative merges | 18 | 18 (no new this tick) |
+
+## Substrate-honest observations
+
+### CI runner-queue stuck — empirical infrastructure delay
+
+PRs #3379 + #3381 created within ~25 min of each other (07:28Z + 07:53Z). Both have been QUEUED in Actions for ~2h. Other PRs created subsequently (#3382 onwards) ran their checks normally, so the queue depth or runner availability has fluctuated.
+
+GitHub Actions runner queues can stall when:
+
+- Runner pool is at capacity
+- A specific runner-type (e.g., macos) is in high demand
+- A workflow-level concurrency limit is hit
+
+The `dependency-status` rule for the `tools/github/` substrate suggests treating CI infrastructure failures as transient — not investigate-deep. Empty-commit + push restarts the check run cycle.
+
+If the nudge fails (still QUEUED in 2-3 ticks), the deeper option is close + reopen the PR (resets the check state entirely).
+
+### Stale-Copilot on already-resolved topic
+
+PR #3398's second Copilot thread was on the SAME topic (BSD-vs-GNU sed) that I had already addressed via commit `2ac9c7e` resolving the Codex thread. Copilot reviewed pre-fix; arrived stale.
+
+This is a structurally-explainable pattern: Copilot batches its review pass, snapshots at the time of trigger (commit/push), reports findings after. Multiple reviewers (Codex + Copilot) reviewing the same commit may produce duplicate findings — and when one fixes the issue, the other's later-arriving thread is stale.
+
+Discipline: reply + resolve quickly when the topic is already-addressed. The reply explains the duplicate-reviewer pattern + cites the fix commit.
+
+## Cron sentinel
+
+`596e842c` armed.
+
+## Next
+
+Cron-driven. Next tick:
+
+1. Verify PR #3398 + #3399 + this tick's PR auto-merge fires
+2. Re-check PR #3379 + #3381 — if nudge un-stuck them, expect CI re-runs to complete; if still QUEUED, close + reopen
+3. Address any new threads

--- a/docs/hygiene-history/ticks/2026/05/15/0940Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0940Z.md
@@ -1,4 +1,4 @@
-| 2026-05-15T09:40:00Z | claude-opus-4-7 | 596e842c | shard: PR #3398 stale-Copilot reply+resolve (same BSD-vs-GNU thread); empty-commit nudge on PR #3379 + #3381 (CI stuck ~2h) | (PR TBD) | tick-3-action shape: stale-resolve + CI-nudge + new-shard |
+| 2026-05-15T09:40:00Z | claude-opus-4-7 | 596e842c | shard: PR #3398 stale-Copilot reply+resolve (same BSD-vs-GNU thread); empty-commit nudge on PR #3379 + #3381 (CI stuck ~2h) | (PR #3400) | tick-3-action shape: stale-resolve + CI-nudge + new-shard |
 
 # Tick 0940Z — PR #3398 stale-Copilot reply+resolve; CI runner nudge on stuck PRs
 


### PR DESCRIPTION
## Summary

- PR #3398 stale-Copilot on already-resolved BSD-vs-GNU topic (reply+resolve)
- Empty-commit nudge applied to stuck PRs #3379 + #3381 (~2h QUEUED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)