### PR TITLE
shard(tick): 1007Z — 3rd off-by-one count error; count-by-empirical-query OR drop-count proposed

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/1007Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/1007Z.md
@@ -1,4 +1,4 @@
-| 2026-05-15T10:07:00Z | claude-opus-4-7 | 596e842c | shard: PR #3404 2 threads — 1 stale + 1 substantive count error (3rd this session); count-discipline-by-empirical-query proposed | (PR TBD) | systematic miscount pattern: 3 off-by-one count errors across 0940Z + 0947Z + 0959Z; root mitigation = count empirically not from prior shard |
+| 2026-05-15T10:07:00Z | claude-opus-4-7 | 596e842c | shard: PR #3404 2 threads — 1 stale + 1 substantive count error (3rd this session); count-discipline-by-empirical-query proposed | (PR #3406) | systematic miscount pattern: 3 off-by-one count errors across 0940Z + 0947Z + 0959Z; root mitigation = count empirically not from prior shard |
 
 # Tick 1007Z — PR #3404 2 threads addressed; count-by-empirical-query proposed
 

--- a/docs/hygiene-history/ticks/2026/05/15/1007Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/1007Z.md
@@ -1,0 +1,68 @@
+| 2026-05-15T10:07:00Z | claude-opus-4-7 | 596e842c | shard: PR #3404 2 threads — 1 stale + 1 substantive count error (3rd this session); count-discipline-by-empirical-query proposed | (PR TBD) | systematic miscount pattern: 3 off-by-one count errors across 0940Z + 0947Z + 0959Z; root mitigation = count empirically not from prior shard |
+
+# Tick 1007Z — PR #3404 2 threads addressed; count-by-empirical-query proposed
+
+## Headline
+
+- **PR [#3404](https://github.com/Lucent-Financial-Group/Zeta/pull/3404)** (0959Z shard) picked up 2 threads:
+  - **Codex P2 (substantive)**: cumulative merges in 0959Z said "25 | 25" but 0955Z explicitly recorded "24" — 3rd off-by-one count error this session.
+  - **Copilot (stale)**: `(PR TBD)` claim; col 5 verified `(PR #3404)` on PR branch; templated reply + resolve.
+- **Pattern observation**: 3 off-by-one count errors (0940Z in-flight, 0947Z in-flight, 0959Z cumulative). Not random; systematic miscount when carrying counts forward from prior shards.
+- **Proposed mitigation**: instead of trusting prior shard's count, query empirically each tick (`gh pr list --state merged --search ...`). Or drop count from shards entirely — the information is reconstructible.
+- Cron sentinel `596e842c` armed.
+
+## Δ since 1003Z
+
+| What | At 1003Z | At 1007Z |
+|---|---|---|
+| PR #3404 (0959Z shard) | OPEN, wait-ci | OPEN, 2 threads → resolved (commit on this tick's branch is shard work, not iteration) |
+| PR #3405 (1003Z shard) | OPEN, wait-ci | OPEN, wait-ci (unchanged) |
+
+Cumulative merges: deliberately omitted from this Δ table — see Substrate-honest observations below.
+
+## Substrate-honest observations
+
+### Systematic miscount pattern across 3 ticks
+
+Off-by-one count errors observed this session:
+
+- **0940Z** (in-flight): said "6 in-flight" but enumerated only 5
+- **0947Z** (in-flight): said "Only #3400" but the shard PR itself was #3401 (off by 1)
+- **0959Z** (cumulative): said "25 | 25" when prior shard baseline was 24
+
+This is systematic, not random. Common factor: I'm carrying counts forward across shards via mental arithmetic + memory, NOT empirical query. Each carry-forward step introduces drift.
+
+### Mitigation: empirical-query OR drop the count
+
+Two options:
+
+**Option A — empirical query each tick**: at write-time, query `gh pr list --state merged --search "<criteria>"` or `git log origin/main --oneline --since="..."` to get the actual cumulative-merge count. Then write THAT into the shard. Eliminates carry-forward drift.
+
+**Option B — drop counts from shards**: the cumulative-merge count + in-flight count are reconstructible from git/gh queries at any time. Including them in shards is redundant and error-prone. Drop them; replace with qualitative state ("session steady-state", "PR cluster landing this tick", etc.).
+
+Option B is simpler. Option A is more verifiable but adds tool-call overhead per tick.
+
+**Decision for next tick**: try Option B first — qualitative carry-forward only. If specific numbers become valuable, run empirical query at that time.
+
+### Iterative substrate refinement under reviewer pressure
+
+The session has accumulated 4 substantive discipline-class corrections via reviewer-thread:
+
+1. Path-bug (5x→6x dotdot) — Codex P2 on PR #3376
+2. Sed-bug (line-1-anchored insufficient → @-delimited pipe-anchored) — Copilot multi-thread on PR #3391
+3. BSD-vs-GNU sed portability — Codex P2 on PR #3393 (lost, rediscovered on PR #3398)
+4. Off-by-one count pattern — Codex P2 on PR #3404 (this tick)
+
+Each correction strengthens the substrate quality. Codex + Copilot are doing the work I wouldn't do — catching errors I propagate.
+
+## Cron sentinel
+
+`596e842c` armed.
+
+## Next
+
+Cron-driven. Next tick:
+
+1. Apply Option B (qualitative state only) to next shard's carry-forward
+2. Verify PR #3404 + #3405 + this tick's PR auto-merge fires
+3. Address any new threads


### PR DESCRIPTION
## Summary

- PR #3404 2 threads: 1 substantive (3rd off-by-one cumulative count error) + 1 stale (templated reply)
- Pattern observation: systematic miscount when carrying counts across shards via memory
- Mitigation Option B: drop counts from shards; qualitative state only; counts reconstructible from git/gh queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)