### PR TITLE
fix(shard-1036z): add missing pipe-row header + fix double-pipe Δ table

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/1036Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/1036Z.md
@@ -1,3 +1,5 @@
+| 2026-05-15T10:36:00Z | claude-opus-4-7 | a2c54a1c | shard: PR #3390 merged; primary worktree stuck >8h; mutex empirically operational | (PR #3414) | substrate-honest caveat about mutex bullet usability when primary worktree is detached |
+
 # Tick 1036Z — PR #3390 merged; primary worktree stuck >8h; peer-Otto refined wiring docs post-merge
 
 ## Headline


### PR DESCRIPTION
## Summary

Post-merge schema fix for the 1036Z tick shard landed via PR #3414. Two Copilot P1 catches:

1. Missing required 6-column pipe-row header at line 1 (schema is at `docs/hygiene-history/ticks/README.md`); the shard would fail B-0529's `check-tick-history-shard-schema.ts`.
2. Δ table header + separator rows used `||` as leading delimiter, creating an unintended empty first column.

Both fixed. Wrote the original via heredoc and missed both conventions — substrate-honest authoring failure on my part. Going forward: copy from an existing shard as template rather than writing from scratch.

## Test plan
- [x] Markdownlint clean
- [x] Schema row has all 6 pipe-separated columns
- [x] Δ table renders without empty first column
- [ ] CI green
- [ ] Auto-merge fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)