### PR TITLE
shard(tick): 1056Z — 7th error class (wrong-mitigation meta-error)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/1056Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/1056Z.md
@@ -1,0 +1,53 @@
+| 2026-05-15T10:56:00Z | claude-opus-4-7 | 596e842c | shard: PR #3420 2 substantive Copilot threads — meta-error (proposed wrong mitigation that wouldnt prevent the bug); 7th error class | (PR TBD) | Codex/Copilot caught Otto proposing a mitigation that doesnt address the actual failure mode |
+
+# Tick 1056Z — PR #3420 substantive threads; 7th error class (wrong-mitigation meta-error)
+
+## Headline
+
+- PR [#3420](https://github.com/Lucent-Financial-Group/Zeta/pull/3420) (1050Z shard) picked up 2 SUBSTANTIVE Copilot threads:
+  - **Thread 1**: my 1050Z shard documents the "always use full prefix" mitigation but then VIOLATES it 3 lines later using bare `#3418` / `#3419`. Self-inconsistent in same file.
+  - **Thread 2 (most substantial)**: my proposed mitigation does NOT actually address the bug it was responding to. The original bad sentence already used full prefixes (`PR #3530`, `B-0530`, `PR #3372`); the real failure was citing PR #3530 which does not exist. Correct mitigation: **verify cited PR numbers exist via `gh pr view <NNNN>` before publishing**.
+- Both threads acknowledged via substrate-honest replies.
+- Cron sentinel `596e842c` armed.
+
+## Δ since 1053Z (qualitative)
+
+- Threads: 2 substantive on #3420 (both acknowledged)
+- In-flight (mine): #3420 (post-acknowledgment) + #3421 + this tick's PR
+- 7th substantive error class identified
+
+## Substrate-honest observations
+
+### 7th substantive error class: wrong-mitigation meta-error
+
+Session-wide error class tally now extends to 7:
+
+1. Path-bug (5x→6x dotdot)
+2. Sed-bug (line-1 → @-delimited pipe-anchored)
+3. BSD-vs-GNU sed portability
+4. Count-drift (off-by-one)
+5. Rule-citation overreach
+6. B-NNNN vs PR #NNNN conflation
+7. **Wrong-mitigation meta-error** — proposing mitigations that do NOT address the actual failure mode
+
+The 7th is a meta-error: I respond to error class N by proposing a mitigation that wouldn't have prevented N. The Copilot catch on PR #3420 is the empirical evidence.
+
+For error #6 (B-NNNN vs PR #NNNN conflation), the correct mitigation is NOT "always use full prefix" (the bug DID use full prefixes; just cited a non-existent PR #3530). The correct mitigation is: **verify cited PR numbers via `gh pr view <NNNN>` before publishing**.
+
+### Asymmetric-critic at meta-level
+
+Codex/Copilot is now catching not just object-level errors (path-bug, sed-bug) but META-level errors (my proposed mitigation doesn't fix the bug it responds to). The discipline iteration is at a higher abstraction layer.
+
+This validates the asymmetric-critic discipline at scale: the reviewer doesn't just check the code/text, but checks the REASONING about the code/text. Each meta-finding refines the substrate-quality further.
+
+### Self-violation of newly-documented discipline
+
+Thread 1's catch is particularly substrate-honest: I documented a mitigation in line N of the shard and violated it in line N+3 of the SAME shard. Discipline-statement and discipline-practice both need to align within a single document.
+
+## Cron sentinel
+
+`596e842c` armed.
+
+## Next
+
+Cron-driven. Routine continues. New mitigation for future shards: verify cited PR numbers exist before publishing.

--- a/docs/hygiene-history/ticks/2026/05/15/1056Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/1056Z.md
@@ -1,4 +1,4 @@
-| 2026-05-15T10:56:00Z | claude-opus-4-7 | 596e842c | shard: PR #3420 2 substantive Copilot threads — meta-error (proposed wrong mitigation that wouldnt prevent the bug); 7th error class | (PR TBD) | Codex/Copilot caught Otto proposing a mitigation that doesnt address the actual failure mode |
+| 2026-05-15T10:56:00Z | claude-opus-4-7 | 596e842c | shard: PR #3420 2 substantive Copilot threads — meta-error (proposed wrong mitigation that wouldnt prevent the bug); 7th error class | (PR #3422) | Codex/Copilot caught Otto proposing a mitigation that doesnt address the actual failure mode |
 
 # Tick 1056Z — PR #3420 substantive threads; 7th error class (wrong-mitigation meta-error)
 


### PR DESCRIPTION
## Summary

- PR #3420 2 substantive Copilot threads — meta-finding: my 1050Z mitigation didn't address the actual bug
- Correct mitigation for B-NNNN vs PR #NNNN: verify cited PR exists via gh pr view <NNNN> before publishing
- Asymmetric-critic discipline now catches meta-level errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)