### PR TITLE
fix(b-0528): gate plutil tests on darwin (PR #3423 cross-platform follow-up)

### DIFF
--- a/tools/shadow/launchd/install-launchagent.test.ts
+++ b/tools/shadow/launchd/install-launchagent.test.ts
@@ -9,6 +9,15 @@
  * with --dry-run so we don't touch `~/Library/LaunchAgents/`.
  */
 import { describe, it, expect } from "bun:test";
+
+// `plutil` is a macOS-only system binary. On Linux CI, the
+// install-launchagent.ts target binary is also macOS-only (the whole
+// LaunchAgent install is macOS), so the tests that exercise the plutil
+// integration are skipped on non-darwin. Pure-helper tests (xmlEscape,
+// substitutePlaceholders, requireAbsolute, tryDetect, argument-validation
+// via subprocess) run cross-platform.
+const IS_DARWIN = process.platform === "darwin";
+const itDarwin = IS_DARWIN ? it : it.skip;
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -79,7 +88,7 @@ describe("xmlEscape", () => {
 });
 
 describe("substitutePlaceholders + xmlEscape (integration)", () => {
-  it("substituted values containing & < > produce plutil-valid plist", () => {
+  itDarwin("substituted values containing & < > produce plutil-valid plist", () => {
     // Use a minimal valid plist template
     const tpl = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -160,7 +169,7 @@ describe("requireAbsolute", () => {
 // ─────────────────────────────────────────────────────────────────────
 
 describe("--dry-run", () => {
-  it("writes rendered plist to stdout, not to ~/Library/LaunchAgents/", () => {
+  itDarwin("writes rendered plist to stdout, not to ~/Library/LaunchAgents/", () => {
     // Use the actual repo template via --repo-root <wt path>, --bun-path /opt/homebrew/bin/bun (or any abs).
     const repoRoot = process.cwd();
     const bunPath = process.execPath;  // bun itself is an absolute path
@@ -227,14 +236,14 @@ describe("tryDetect", () => {
 // ─────────────────────────────────────────────────────────────────────
 
 describe("plutilLint", () => {
-  it("returns without throwing for a valid plist", () => {
+  itDarwin("returns without throwing for a valid plist", () => {
     const valid = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict/></plist>`;
     expect(() => plutilLint(valid)).not.toThrow();
   });
 
-  it("exits with code 1 (via subprocess) for an invalid plist", () => {
+  itDarwin("exits with code 1 (via subprocess) for an invalid plist", () => {
     // plutilLint calls process.exit(1) on failure; can't test in-process.
     const proc = spawnSync(
       "bun",


### PR DESCRIPTION
## Summary

Post-merge fix for [PR #3423](https://github.com/Lucent-Financial-Group/Zeta/pull/3423). Two P0/P1 portability findings:

- **Codex P1**: `plutilLint` called in-process hard-exits the test runner on non-darwin (ENOENT → `process.exit(1)`).
- **Copilot P0**: subprocess `plutil` calls fail on non-darwin (line 98 + 167 + 229), breaking cross-platform test runs.

Both real. `plutil` is macOS-only, and the install-launchagent.ts target (launchd) is also macOS-only — so the pure-helper tests should run cross-platform but the plutil integration tests should skip.

## Approach

```typescript
const IS_DARWIN = process.platform === "darwin";
const itDarwin = IS_DARWIN ? it : it.skip;
```

Applied `itDarwin` to the 4 plutil-touching test cases. Pure helpers (xmlEscape, substitutePlaceholders, requireAbsolute, tryDetect, argument-validation via subprocess) remain `it` for cross-platform coverage.

## Expected results

| Platform | Pass | Skip | Fail |
|---|---|---|---|
| macOS | 19 | 0 | 0 |
| Linux | 15 | 4 | 0 |

Verified on macOS: 19/19 pass.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` on macOS: 19 pass / 0 fail (unchanged)
- [ ] CI green on Linux runners
- [ ] Auto-merge fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)