### PR TITLE
feat(b-0503): openRecoveryPR core function + RecoveryAdapters + 14 tests

### DIFF
--- a/tools/bg/missed-substrate-recovery.test.ts
+++ b/tools/bg/missed-substrate-recovery.test.ts
@@ -1,0 +1,269 @@
+#!/usr/bin/env bun
+import { describe, it, expect } from "bun:test";
+import type { CascadeFinding } from "./missed-substrate-detector";
+import {
+  buildRecoveryBranchName,
+  buildRecoveryPRBody,
+  openRecoveryPR,
+  type RecoveryAdapters,
+  type RecoveryResult,
+} from "./missed-substrate-recovery";
+
+// ─────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────
+
+function makeFinding(overrides: Partial<CascadeFinding> = {}): CascadeFinding {
+  return {
+    prNumber: 1234,
+    branchName: "feat/some-feature",
+    missingCommits: ["aaaa111", "bbbb222"],
+    urgency: "medium",
+    ...overrides,
+  };
+}
+
+type AdapterCallLog = {
+  checkRecoveryPRExists: string[];
+  gitCreateBranch: Array<{ branch: string; base: string }>;
+  gitCherryPick: string[];
+  gitPush: string[];
+  ghPrCreate: Array<{ title: string; body: string; head: string }>;
+};
+
+function newCallLog(): AdapterCallLog {
+  return {
+    checkRecoveryPRExists: [],
+    gitCreateBranch: [],
+    gitCherryPick: [],
+    gitPush: [],
+    ghPrCreate: [],
+  };
+}
+
+type AdapterStubOverrides = Partial<{
+  checkRecoveryPRExists: (branchName: string) => boolean;
+  gitCreateBranch: (branch: string, base: string) => boolean;
+  gitCherryPick: (sha: string) => "ok" | "conflict" | "error";
+  gitPush: (branch: string) => boolean;
+  ghPrCreate: (title: string, body: string, head: string) => string | null;
+}>;
+
+function stubAdapters(
+  log: AdapterCallLog,
+  overrides: AdapterStubOverrides = {},
+): RecoveryAdapters {
+  return {
+    checkRecoveryPRExists: (branchName) => {
+      log.checkRecoveryPRExists.push(branchName);
+      return overrides.checkRecoveryPRExists?.(branchName) ?? false;
+    },
+    gitCreateBranch: (branch, base) => {
+      log.gitCreateBranch.push({ branch, base });
+      return overrides.gitCreateBranch?.(branch, base) ?? true;
+    },
+    gitCherryPick: (sha) => {
+      log.gitCherryPick.push(sha);
+      return overrides.gitCherryPick?.(sha) ?? "ok";
+    },
+    gitPush: (branch) => {
+      log.gitPush.push(branch);
+      return overrides.gitPush?.(branch) ?? true;
+    },
+    ghPrCreate: (title, body, head) => {
+      log.ghPrCreate.push({ title, body, head });
+      // NOTE: don't use `??` here — when an override returns `null` (the
+      // legitimate "PR-create failed" signal), `??` would collapse to the
+      // default URL and the error-branch test would never trigger.
+      if (overrides.ghPrCreate) return overrides.ghPrCreate(title, body, head);
+      return "https://github.com/example/test/pull/9999";
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// buildRecoveryBranchName
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildRecoveryBranchName", () => {
+  it("produces deterministic output for a fixed Date", () => {
+    const ts = new Date(Date.UTC(2026, 4, 15, 12, 34, 56));
+    expect(buildRecoveryBranchName(3500, ts)).toBe("recovery/3500-20260515123456");
+  });
+
+  it("emits 14 digit timestamp segment", () => {
+    const ts = new Date(Date.UTC(2026, 0, 1, 0, 0, 0));
+    const name = buildRecoveryBranchName(1, ts);
+    expect(name).toMatch(/^recovery\/1-\d{14}$/);
+  });
+
+  it("encodes only safe characters (digits, /, -)", () => {
+    const ts = new Date(Date.UTC(2026, 11, 31, 23, 59, 59));
+    const name = buildRecoveryBranchName(42, ts);
+    expect(name).toMatch(/^[0-9/\-a-z]+$/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// buildRecoveryPRBody
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildRecoveryPRBody", () => {
+  it("contains the original PR number, branch name, and all commit SHAs", () => {
+    const body = buildRecoveryPRBody(makeFinding({
+      prNumber: 9876,
+      branchName: "feat/x",
+      missingCommits: ["sha1", "sha2", "sha3"],
+      urgency: "high",
+    }));
+    expect(body).toContain("**#9876**");
+    expect(body).toContain("feat/x");
+    expect(body).toContain("- sha1");
+    expect(body).toContain("- sha2");
+    expect(body).toContain("- sha3");
+    expect(body).toContain("**high**");
+    expect(body).toContain("Auto-generated");
+  });
+
+  it("handles single-commit findings", () => {
+    const body = buildRecoveryPRBody(makeFinding({ missingCommits: ["just-one"] }));
+    expect(body).toContain("- just-one");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// openRecoveryPR
+// ─────────────────────────────────────────────────────────────────────
+
+describe("openRecoveryPR — opened", () => {
+  it("happy path: no existing PR, cherry-picks succeed, push+PR succeed", () => {
+    const log = newCallLog();
+    const adapters = stubAdapters(log);
+    const r = openRecoveryPR(makeFinding(), false, adapters);
+
+    expect(r.status).toBe("opened");
+    if (r.status !== "opened") throw new Error("narrowing");
+    expect(r.prUrl).toBe("https://github.com/example/test/pull/9999");
+    expect(r.cherryPickedCount).toBe(2);
+
+    expect(log.checkRecoveryPRExists.length).toBe(1);
+    expect(log.gitCreateBranch.length).toBe(1);
+    expect(log.gitCreateBranch[0]!.base).toBe("origin/main");
+    expect(log.gitCherryPick).toEqual(["aaaa111", "bbbb222"]);
+    expect(log.gitPush.length).toBe(1);
+    expect(log.ghPrCreate.length).toBe(1);
+    expect(log.ghPrCreate[0]!.head).toMatch(/^recovery\/1234-/);
+  });
+
+  it("PR title encodes prNumber + missing commits count", () => {
+    const log = newCallLog();
+    const r = openRecoveryPR(
+      makeFinding({ prNumber: 7777, missingCommits: ["a", "b", "c"] }),
+      false,
+      stubAdapters(log),
+    );
+    expect(r.status).toBe("opened");
+    expect(log.ghPrCreate[0]!.title).toContain("#7777");
+    expect(log.ghPrCreate[0]!.title).toContain("3 missed commits");
+  });
+});
+
+describe("openRecoveryPR — already-exists", () => {
+  it("returns already-exists when checkRecoveryPRExists returns true; no mutations", () => {
+    const log = newCallLog();
+    const adapters = stubAdapters(log, { checkRecoveryPRExists: () => true });
+    const r = openRecoveryPR(makeFinding(), false, adapters);
+
+    expect(r.status).toBe("already-exists");
+    if (r.status !== "already-exists") throw new Error("narrowing");
+    expect(r.reason).toContain("already open");
+
+    // No mutations should have happened.
+    expect(log.gitCreateBranch.length).toBe(0);
+    expect(log.gitCherryPick.length).toBe(0);
+    expect(log.gitPush.length).toBe(0);
+    expect(log.ghPrCreate.length).toBe(0);
+  });
+});
+
+describe("openRecoveryPR — dry-run", () => {
+  it("does not call gitCreateBranch and returns prUrl=\"dry-run\"", () => {
+    const log = newCallLog();
+    const r = openRecoveryPR(makeFinding(), true, stubAdapters(log));
+
+    expect(r.status).toBe("opened");
+    if (r.status !== "opened") throw new Error("narrowing");
+    expect(r.prUrl).toBe("dry-run");
+    expect(r.cherryPickedCount).toBe(0);
+
+    // Dry-run still checks for existing PR (idempotency) but performs no mutations.
+    expect(log.checkRecoveryPRExists.length).toBe(1);
+    expect(log.gitCreateBranch.length).toBe(0);
+    expect(log.gitCherryPick.length).toBe(0);
+    expect(log.gitPush.length).toBe(0);
+    expect(log.ghPrCreate.length).toBe(0);
+  });
+});
+
+describe("openRecoveryPR — cherry-pick-conflict", () => {
+  it("returns cherry-pick-conflict on the conflicting sha; push NOT called", () => {
+    const log = newCallLog();
+    // Conflict on the 2nd commit specifically.
+    const adapters = stubAdapters(log, {
+      gitCherryPick: (sha) => (sha === "bbbb222" ? "conflict" : "ok"),
+    });
+    const r = openRecoveryPR(makeFinding(), false, adapters);
+
+    expect(r.status).toBe("cherry-pick-conflict");
+    if (r.status !== "cherry-pick-conflict") throw new Error("narrowing");
+    expect(r.sha).toBe("bbbb222");
+    expect(r.attemptedCount).toBe(2);
+
+    // Branch was created; push was NOT called because cherry-pick aborted.
+    expect(log.gitCreateBranch.length).toBe(1);
+    expect(log.gitCherryPick).toEqual(["aaaa111", "bbbb222"]);
+    expect(log.gitPush.length).toBe(0);
+    expect(log.ghPrCreate.length).toBe(0);
+  });
+});
+
+describe("openRecoveryPR — error branches", () => {
+  it("returns error when gitCreateBranch fails", () => {
+    const log = newCallLog();
+    const r = openRecoveryPR(makeFinding(), false, stubAdapters(log, { gitCreateBranch: () => false }));
+    expect(r.status).toBe("error");
+    if (r.status !== "error") throw new Error("narrowing");
+    expect(r.reason).toContain("git checkout -b");
+    expect(log.gitCherryPick.length).toBe(0);
+  });
+
+  it("returns error when gitCherryPick returns \"error\"", () => {
+    const log = newCallLog();
+    const r = openRecoveryPR(
+      makeFinding(),
+      false,
+      stubAdapters(log, { gitCherryPick: () => "error" }),
+    );
+    expect(r.status).toBe("error");
+    if (r.status !== "error") throw new Error("narrowing");
+    expect(r.reason).toContain("git cherry-pick");
+    expect(log.gitPush.length).toBe(0);
+  });
+
+  it("returns error when gitPush fails", () => {
+    const log = newCallLog();
+    const r = openRecoveryPR(makeFinding(), false, stubAdapters(log, { gitPush: () => false }));
+    expect(r.status).toBe("error");
+    if (r.status !== "error") throw new Error("narrowing");
+    expect(r.reason).toContain("git push");
+    expect(log.ghPrCreate.length).toBe(0);
+  });
+
+  it("returns error when ghPrCreate returns null", () => {
+    const log = newCallLog();
+    const r = openRecoveryPR(makeFinding(), false, stubAdapters(log, { ghPrCreate: () => null }));
+    expect(r.status).toBe("error");
+    if (r.status !== "error") throw new Error("narrowing");
+    expect(r.reason).toContain("gh pr create");
+  });
+});

--- a/tools/bg/missed-substrate-recovery.ts
+++ b/tools/bg/missed-substrate-recovery.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env bun
+/**
+ * tools/bg/missed-substrate-recovery.ts
+ *
+ * Core function for opening a recovery PR when missed-substrate-detector
+ * surfaces a cascade gap. Pure-function-with-adapters shape: all I/O
+ * (git, gh) is injected so the function is unit-testable without touching
+ * the filesystem or making real GitHub calls.
+ *
+ * Per B-0503 (slice 5a of B-0442); wiring into pollOnce + real adapter
+ * implementations are scope for B-0504.
+ */
+
+import type { CascadeFinding } from "./missed-substrate-detector";
+
+export type RecoveryAdapters = {
+  /** Returns true if an open recovery PR already exists for this branch. */
+  checkRecoveryPRExists: (branchName: string) => boolean;
+  /** `git checkout -b <branch> <base>`; true on success. */
+  gitCreateBranch: (branch: string, base: string) => boolean;
+  /** `git cherry-pick <sha>`; distinguishes merge conflict from other errors. */
+  gitCherryPick: (sha: string) => "ok" | "conflict" | "error";
+  /** `git push origin <branch>`; true on success. */
+  gitPush: (branch: string) => boolean;
+  /** `gh pr create --title ... --body ... --head ... --base main`; PR URL or null. */
+  ghPrCreate: (title: string, body: string, head: string) => string | null;
+};
+
+export type RecoveryResult =
+  | { status: "opened"; prUrl: string; cherryPickedCount: number }
+  | { status: "already-exists"; reason: string }
+  | { status: "cherry-pick-conflict"; sha: string; attemptedCount: number }
+  | { status: "error"; reason: string };
+
+/**
+ * Deterministic recovery-branch name: `recovery/<prNumber>-<YYYYMMDDHHMMSS>`.
+ * Pure function; no I/O. Uses UTC components from the provided Date so the
+ * output is reproducible given the same inputs.
+ */
+export function buildRecoveryBranchName(prNumber: number, ts: Date): string {
+  const stamp = ts.toISOString().replace(/[-:T]/g, "").slice(0, 14);
+  return `recovery/${prNumber}-${stamp}`;
+}
+
+/**
+ * Markdown body for the recovery PR. Lists `missingCommits`, references the
+ * original `prNumber`, surfaces the detector's urgency, and notes that the
+ * PR was auto-generated.
+ */
+export function buildRecoveryPRBody(finding: CascadeFinding): string {
+  const commitList = finding.missingCommits.map((s) => `- ${s}`).join("\n");
+  return [
+    `## Auto-generated recovery PR`,
+    ``,
+    `Original merged PR: **#${finding.prNumber}** (branch \`${finding.branchName}\`)`,
+    ``,
+    `Missing commits detected by \`missed-substrate-detector\`:`,
+    commitList,
+    ``,
+    `Urgency at detection time: **${finding.urgency}**`,
+    ``,
+    `> This PR was opened automatically. Review before merging.`,
+  ].join("\n");
+}
+
+/**
+ * Core recovery workflow. Composed with `adapters` so all I/O is injectable.
+ * Steps:
+ *   1. Check for existing open recovery PR; if yes, return `already-exists`.
+ *   2. If `dryRun`, return `opened` with `prUrl="dry-run"` and no mutations.
+ *   3. `git checkout -b <recoveryBranch> origin/main`.
+ *   4. For each commit in `finding.missingCommits`: cherry-pick. On conflict
+ *      return `cherry-pick-conflict` immediately (no push).
+ *   5. `git push origin <recoveryBranch>`.
+ *   6. `gh pr create --title ... --body ... --head ... --base main`.
+ *
+ * Uses `new Date()` internally for the branch-name timestamp; the idempotency
+ * gate (`checkRecoveryPRExists`) is the load-bearing uniqueness mechanism.
+ * `buildRecoveryBranchName` is exported separately for deterministic unit tests.
+ */
+export function openRecoveryPR(
+  finding: CascadeFinding,
+  dryRun: boolean,
+  adapters: RecoveryAdapters,
+): RecoveryResult {
+  const recoveryBranch = buildRecoveryBranchName(finding.prNumber, new Date());
+
+  if (adapters.checkRecoveryPRExists(recoveryBranch)) {
+    return { status: "already-exists", reason: `PR for ${recoveryBranch} already open` };
+  }
+
+  if (dryRun) {
+    return { status: "opened", prUrl: "dry-run", cherryPickedCount: 0 };
+  }
+
+  if (!adapters.gitCreateBranch(recoveryBranch, "origin/main")) {
+    return { status: "error", reason: `git checkout -b ${recoveryBranch} origin/main failed` };
+  }
+
+  let attemptedCount = 0;
+  for (const sha of finding.missingCommits) {
+    const cpResult = adapters.gitCherryPick(sha);
+    attemptedCount++;
+    if (cpResult === "conflict") {
+      return { status: "cherry-pick-conflict", sha, attemptedCount };
+    }
+    if (cpResult === "error") {
+      return { status: "error", reason: `git cherry-pick ${sha} failed` };
+    }
+  }
+
+  if (!adapters.gitPush(recoveryBranch)) {
+    return { status: "error", reason: `git push origin ${recoveryBranch} failed` };
+  }
+
+  const title = `recovery(#${finding.prNumber}): ${finding.missingCommits.length} missed commits`;
+  const body = buildRecoveryPRBody(finding);
+  const prUrl = adapters.ghPrCreate(title, body, recoveryBranch);
+  if (prUrl === null) {
+    return { status: "error", reason: "gh pr create failed" };
+  }
+
+  return { status: "opened", prUrl, cherryPickedCount: attemptedCount };
+}


### PR DESCRIPTION
## Summary

Closes [B-0503](https://github.com/Lucent-Financial-Group/Zeta/blob/main/docs/backlog/P1/B-0503-b0442-slice5a-open-recovery-pr-core-function-2026-05-14.md) — the first atomic sub-slice of B-0442's pending slice 5 ("optionally auto-opens recovery PR with the missing commits").

## What lands

- `tools/bg/missed-substrate-recovery.ts` (124 lines) — `RecoveryAdapters` interface, `RecoveryResult` discriminated union, `buildRecoveryBranchName`, `buildRecoveryPRBody`, `openRecoveryPR` composed workflow. Pure function + injected adapters → unit-testable without git or gh calls.
- `tools/bg/missed-substrate-recovery.test.ts` (265 lines) — 14 tests covering every `RecoveryResult` arm: opened (happy path + title encoding), already-exists, dry-run, cherry-pick-conflict (push NOT called on abort), and the 4 error branches.

## What this row does NOT do (deferred to B-0504)

- Wiring into `pollOnce` / `DetectorConfig` / `parseArgs`
- `--auto-recover` / `--dry-run` CLI flags
- Real adapter implementations (need `spawnSync` wrappers validated per the security note)

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test tools/bg/missed-substrate-recovery.test.ts` — 14 pass / 0 fail / 56 expect calls
- [x] `bun test tools/bg/missed-substrate-detector.test.ts` — 24 pass (baseline unchanged)
- [x] `semgrep --config .semgrep.yml --error` — 0 findings
- [ ] CI green
- [ ] Auto-merge fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)