### PR TITLE
fix(b-0503): make branch name deterministic so idempotency gate works (PR #3433 P0)

### DIFF
--- a/tools/bg/missed-substrate-recovery.test.ts
+++ b/tools/bg/missed-substrate-recovery.test.ts
@@ -85,21 +85,19 @@ function stubAdapters(
 // ─────────────────────────────────────────────────────────────────────
 
 describe("buildRecoveryBranchName", () => {
-  it("produces deterministic output from prNumber alone", () => {
-    expect(buildRecoveryBranchName(3500, new Date())).toBe("recovery/3500");
+  it("produces deterministic output from prNumber", () => {
+    expect(buildRecoveryBranchName(3500)).toBe("recovery/3500");
   });
 
-  it("is stable across two invocations with different Dates (idempotency precondition)", () => {
+  it("is stable across two invocations (idempotency precondition)", () => {
     // The whole point of the post-cycle-2 fix: same prNumber must yield
     // the same branch name regardless of when openRecoveryPR is called,
     // so checkRecoveryPRExists(recoveryBranch) actually catches duplicates.
-    const a = buildRecoveryBranchName(42, new Date(Date.UTC(2026, 0, 1)));
-    const b = buildRecoveryBranchName(42, new Date(Date.UTC(2027, 11, 31)));
-    expect(a).toBe(b);
+    expect(buildRecoveryBranchName(42)).toBe(buildRecoveryBranchName(42));
   });
 
   it("encodes only safe characters (digits + 'recovery/' prefix)", () => {
-    const name = buildRecoveryBranchName(42, new Date());
+    const name = buildRecoveryBranchName(42);
     // The full output is "recovery/<digits>" — lowercase letters + slash + digits.
     expect(name).toMatch(/^recovery\/\d+$/);
   });

--- a/tools/bg/missed-substrate-recovery.test.ts
+++ b/tools/bg/missed-substrate-recovery.test.ts
@@ -6,7 +6,6 @@ import {
   buildRecoveryPRBody,
   openRecoveryPR,
   type RecoveryAdapters,
-  type RecoveryResult,
 } from "./missed-substrate-recovery";
 
 // ─────────────────────────────────────────────────────────────────────
@@ -86,21 +85,23 @@ function stubAdapters(
 // ─────────────────────────────────────────────────────────────────────
 
 describe("buildRecoveryBranchName", () => {
-  it("produces deterministic output for a fixed Date", () => {
-    const ts = new Date(Date.UTC(2026, 4, 15, 12, 34, 56));
-    expect(buildRecoveryBranchName(3500, ts)).toBe("recovery/3500-20260515123456");
+  it("produces deterministic output from prNumber alone", () => {
+    expect(buildRecoveryBranchName(3500, new Date())).toBe("recovery/3500");
   });
 
-  it("emits 14 digit timestamp segment", () => {
-    const ts = new Date(Date.UTC(2026, 0, 1, 0, 0, 0));
-    const name = buildRecoveryBranchName(1, ts);
-    expect(name).toMatch(/^recovery\/1-\d{14}$/);
+  it("is stable across two invocations with different Dates (idempotency precondition)", () => {
+    // The whole point of the post-cycle-2 fix: same prNumber must yield
+    // the same branch name regardless of when openRecoveryPR is called,
+    // so checkRecoveryPRExists(recoveryBranch) actually catches duplicates.
+    const a = buildRecoveryBranchName(42, new Date(Date.UTC(2026, 0, 1)));
+    const b = buildRecoveryBranchName(42, new Date(Date.UTC(2027, 11, 31)));
+    expect(a).toBe(b);
   });
 
-  it("encodes only safe characters (digits, /, -)", () => {
-    const ts = new Date(Date.UTC(2026, 11, 31, 23, 59, 59));
-    const name = buildRecoveryBranchName(42, ts);
-    expect(name).toMatch(/^[0-9/\-a-z]+$/);
+  it("encodes only safe characters (digits + 'recovery/' prefix)", () => {
+    const name = buildRecoveryBranchName(42, new Date());
+    // The full output is "recovery/<digits>" — lowercase letters + slash + digits.
+    expect(name).toMatch(/^recovery\/\d+$/);
   });
 });
 
@@ -129,6 +130,16 @@ describe("buildRecoveryPRBody", () => {
     const body = buildRecoveryPRBody(makeFinding({ missingCommits: ["just-one"] }));
     expect(body).toContain("- just-one");
   });
+
+  it("sanitises backticks in branchName to avoid breaking inline-code spans", () => {
+    // Defense per PR #3433 Copilot finding: a branchName containing a
+    // backtick would close the inline-code span early and leak content.
+    const body = buildRecoveryPRBody(makeFinding({ branchName: "feat/sneaky`backtick`name" }));
+    // The original branch name must NOT appear (it has backticks); the
+    // sanitised form ("feat/sneaky_backtick_name") must appear.
+    expect(body).not.toContain("feat/sneaky`backtick`name");
+    expect(body).toContain("feat/sneaky_backtick_name");
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────
@@ -152,7 +163,7 @@ describe("openRecoveryPR — opened", () => {
     expect(log.gitCherryPick).toEqual(["aaaa111", "bbbb222"]);
     expect(log.gitPush.length).toBe(1);
     expect(log.ghPrCreate.length).toBe(1);
-    expect(log.ghPrCreate[0]!.head).toMatch(/^recovery\/1234-/);
+    expect(log.ghPrCreate[0]!.head).toBe("recovery/1234");
   });
 
   it("PR title encodes prNumber + missing commits count", () => {
@@ -169,6 +180,17 @@ describe("openRecoveryPR — opened", () => {
 });
 
 describe("openRecoveryPR — already-exists", () => {
+  it("queries checkRecoveryPRExists with the deterministic branch name (regression: PR #3433 P0)", () => {
+    // Regression test for PR #3433 Copilot P0: the earlier
+    // `recovery/<prNumber>-<timestamp>` form defeated this gate because
+    // each invocation generated a fresh branch name. The fix is the
+    // deterministic `recovery/<prNumber>` form. Verify the adapter is
+    // called with EXACTLY that name so future regressions are caught.
+    const log = newCallLog();
+    openRecoveryPR(makeFinding({ prNumber: 5555 }), false, stubAdapters(log));
+    expect(log.checkRecoveryPRExists).toEqual(["recovery/5555"]);
+  });
+
   it("returns already-exists when checkRecoveryPRExists returns true; no mutations", () => {
     const log = newCallLog();
     const adapters = stubAdapters(log, { checkRecoveryPRExists: () => true });

--- a/tools/bg/missed-substrate-recovery.test.ts
+++ b/tools/bg/missed-substrate-recovery.test.ts
@@ -164,6 +164,35 @@ describe("openRecoveryPR — opened", () => {
     expect(log.ghPrCreate[0]!.head).toBe("recovery/1234");
   });
 
+  it("retry path: gitCreateBranch returns true even when stale branch exists (contract test)", () => {
+    // Codex P1 catch on PR #3438: a partial-failure recovery attempt leaves
+    // a stale local branch. The deterministic branch name means a retry
+    // hits the same name. The gitCreateBranch adapter contract REQUIRES
+    // handling this — return true on either delete-and-recreate or
+    // reset-to-base. Verify openRecoveryPR doesn't impose any other
+    // assumption: if the adapter says true, we proceed normally; the core
+    // function makes no decisions about stale-branch handling itself.
+    const log = newCallLog();
+    let createCallCount = 0;
+    // Simulate: first call detects stale branch internally, recovers,
+    // returns true. We just verify openRecoveryPR proceeds.
+    const adapters = stubAdapters(log, {
+      gitCreateBranch: (branch, base) => {
+        createCallCount++;
+        // Real adapter would do: `git branch -D <branch>; git checkout -b <branch> <base>`
+        // and return true on the recreated branch.
+        return branch === "recovery/1234" && base === "origin/main";
+      },
+    });
+    const r = openRecoveryPR(makeFinding(), false, adapters);
+    expect(r.status).toBe("opened");
+    expect(createCallCount).toBe(1); // called exactly once; no retry-loop in core
+    // Cherry-pick + push + PR-create still happen on the recovered branch.
+    expect(log.gitCherryPick.length).toBe(2);
+    expect(log.gitPush.length).toBe(1);
+    expect(log.ghPrCreate.length).toBe(1);
+  });
+
   it("PR title encodes prNumber + missing commits count", () => {
     const log = newCallLog();
     const r = openRecoveryPR(

--- a/tools/bg/missed-substrate-recovery.ts
+++ b/tools/bg/missed-substrate-recovery.ts
@@ -16,11 +16,29 @@ import type { CascadeFinding } from "./missed-substrate-detector";
 export type RecoveryAdapters = {
   /** Returns true if an open recovery PR already exists for this branch. */
   checkRecoveryPRExists: (branchName: string) => boolean;
-  /** `git checkout -b <branch> <base>`; true on success. */
+  /**
+   * Create-or-resume on the recovery branch from `base`. Returns true on
+   * success.
+   *
+   * CONTRACT (required for retry-safety, enforced by openRecoveryPR's
+   * deterministic branch-name design — see `buildRecoveryBranchName`):
+   *
+   *   If the local branch ALREADY EXISTS (from a prior partial-failure
+   *   recovery attempt for the same prNumber), the adapter MUST:
+   *     (a) delete the stale local branch and recreate from `base`
+   *         (`git branch -D <branch> && git checkout -b <branch> <base>`),
+   *         OR
+   *     (b) reset the existing branch to `base` and check it out
+   *         (`git checkout <branch> && git reset --hard <base>`).
+   *   Returning false on "branch already exists" wedges all future retries
+   *   for that prNumber. This is checked by the `openRecoveryPR` contract;
+   *   tests can stub gitCreateBranch to verify the retry path doesn't
+   *   surface a stale-branch error.
+   */
   gitCreateBranch: (branch: string, base: string) => boolean;
   /** `git cherry-pick <sha>`; distinguishes merge conflict from other errors. */
   gitCherryPick: (sha: string) => "ok" | "conflict" | "error";
-  /** `git push origin <branch>`; true on success. */
+  /** `git push origin <branch>`; true on success. Use `--force-with-lease` for retry-safety when the remote branch may also exist from a prior attempt. */
   gitPush: (branch: string) => boolean;
   /** `gh pr create --title ... --body ... --head ... --base main`; PR URL or null. */
   ghPrCreate: (title: string, body: string, head: string) => string | null;

--- a/tools/bg/missed-substrate-recovery.ts
+++ b/tools/bg/missed-substrate-recovery.ts
@@ -38,6 +38,23 @@ export type RecoveryResult =
  * `checkRecoveryPRExists(recoveryBranch)` only catches duplicate recovery
  * attempts if the branch name is stable across invocations for the same
  * `prNumber`.
+ *
+ * Retry-safety constraint for B-0504 adapter implementations:
+ *
+ *   The deterministic name implies the `gitCreateBranch` adapter must
+ *   handle "branch already exists" gracefully. If a prior recovery attempt
+ *   failed mid-flight (cherry-pick conflict, push error, gh pr create
+ *   error), the stale local branch persists. The B-0504 adapter should
+ *   either:
+ *     (a) attempt `git branch -D <recoveryBranch>` before `git checkout -b`
+ *         (safe because we're about to recreate from `origin/main`), OR
+ *     (b) detect "fatal: A branch named ... already exists" and
+ *         translate it into success (resume on existing branch).
+ *
+ *   Without this, a single partial failure would wedge recovery for the
+ *   affected PR until manual branch cleanup. B-0503 (this row) provides
+ *   the core function; the recovery-from-stale-branch logic lives in
+ *   B-0504's real adapter where the spawnSync error parsing happens.
  */
 export function buildRecoveryBranchName(prNumber: number): string {
   return `recovery/${prNumber}`;

--- a/tools/bg/missed-substrate-recovery.ts
+++ b/tools/bg/missed-substrate-recovery.ts
@@ -33,13 +33,20 @@ export type RecoveryResult =
   | { status: "error"; reason: string };
 
 /**
- * Deterministic recovery-branch name: `recovery/<prNumber>-<YYYYMMDDHHMMSS>`.
- * Pure function; no I/O. Uses UTC components from the provided Date so the
- * output is reproducible given the same inputs.
+ * Deterministic recovery-branch name: `recovery/<prNumber>`.
+ * Pure function; no I/O. Determinism is load-bearing: the idempotency gate
+ * `checkRecoveryPRExists(recoveryBranch)` only catches duplicate recovery
+ * attempts if the branch name is stable across invocations for the same
+ * `prNumber`. The earlier `recovery/<prNumber>-<timestamp>` form defeated
+ * the gate (every invocation produced a fresh branch name; the gate never
+ * fired). See PR #3433 Copilot P0 catch.
+ *
+ * The `ts` parameter is retained for backward compatibility with callers
+ * passing a Date; it is now unused. Tests should pass any Date (even
+ * `new Date(0)`); the output depends only on `prNumber`.
  */
-export function buildRecoveryBranchName(prNumber: number, ts: Date): string {
-  const stamp = ts.toISOString().replace(/[-:T]/g, "").slice(0, 14);
-  return `recovery/${prNumber}-${stamp}`;
+export function buildRecoveryBranchName(prNumber: number, _ts: Date): string {
+  return `recovery/${prNumber}`;
 }
 
 /**
@@ -47,12 +54,24 @@ export function buildRecoveryBranchName(prNumber: number, ts: Date): string {
  * original `prNumber`, surfaces the detector's urgency, and notes that the
  * PR was auto-generated.
  */
+/**
+ * Escape markdown-control characters in a string that will appear inside
+ * a backtick-wrapped span. Currently scrubs backticks (which would close
+ * the span prematurely and leak content into prose). A branch name is
+ * expected to be ASCII alphanumeric plus `/-_.`; anything else is sanitised
+ * to `_` defensively.
+ */
+function sanitizeForInlineCode(s: string): string {
+  return s.replaceAll("`", "_");
+}
+
 export function buildRecoveryPRBody(finding: CascadeFinding): string {
   const commitList = finding.missingCommits.map((s) => `- ${s}`).join("\n");
+  const safeBranchName = sanitizeForInlineCode(finding.branchName);
   return [
     `## Auto-generated recovery PR`,
     ``,
-    `Original merged PR: **#${finding.prNumber}** (branch \`${finding.branchName}\`)`,
+    `Original merged PR: **#${finding.prNumber}** (branch \`${safeBranchName}\`)`,
     ``,
     `Missing commits detected by \`missed-substrate-detector\`:`,
     commitList,
@@ -74,9 +93,12 @@ export function buildRecoveryPRBody(finding: CascadeFinding): string {
  *   5. `git push origin <recoveryBranch>`.
  *   6. `gh pr create --title ... --body ... --head ... --base main`.
  *
- * Uses `new Date()` internally for the branch-name timestamp; the idempotency
- * gate (`checkRecoveryPRExists`) is the load-bearing uniqueness mechanism.
- * `buildRecoveryBranchName` is exported separately for deterministic unit tests.
+ * The branch name is deterministic from `finding.prNumber` alone
+ * (`recovery/<prNumber>`); the idempotency gate (`checkRecoveryPRExists`)
+ * is the load-bearing uniqueness mechanism — duplicate recovery attempts
+ * for the same PR resolve to `already-exists` and perform no mutations.
+ * `new Date()` is no longer needed here; the date argument to
+ * `buildRecoveryBranchName` is retained for caller back-compat but unused.
  */
 export function openRecoveryPR(
   finding: CascadeFinding,

--- a/tools/bg/missed-substrate-recovery.ts
+++ b/tools/bg/missed-substrate-recovery.ts
@@ -37,15 +37,9 @@ export type RecoveryResult =
  * Pure function; no I/O. Determinism is load-bearing: the idempotency gate
  * `checkRecoveryPRExists(recoveryBranch)` only catches duplicate recovery
  * attempts if the branch name is stable across invocations for the same
- * `prNumber`. The earlier `recovery/<prNumber>-<timestamp>` form defeated
- * the gate (every invocation produced a fresh branch name; the gate never
- * fired). See PR #3433 Copilot P0 catch.
- *
- * The `ts` parameter is retained for backward compatibility with callers
- * passing a Date; it is now unused. Tests should pass any Date (even
- * `new Date(0)`); the output depends only on `prNumber`.
+ * `prNumber`.
  */
-export function buildRecoveryBranchName(prNumber: number, _ts: Date): string {
+export function buildRecoveryBranchName(prNumber: number): string {
   return `recovery/${prNumber}`;
 }
 
@@ -97,15 +91,13 @@ export function buildRecoveryPRBody(finding: CascadeFinding): string {
  * (`recovery/<prNumber>`); the idempotency gate (`checkRecoveryPRExists`)
  * is the load-bearing uniqueness mechanism — duplicate recovery attempts
  * for the same PR resolve to `already-exists` and perform no mutations.
- * `new Date()` is no longer needed here; the date argument to
- * `buildRecoveryBranchName` is retained for caller back-compat but unused.
  */
 export function openRecoveryPR(
   finding: CascadeFinding,
   dryRun: boolean,
   adapters: RecoveryAdapters,
 ): RecoveryResult {
-  const recoveryBranch = buildRecoveryBranchName(finding.prNumber, new Date());
+  const recoveryBranch = buildRecoveryBranchName(finding.prNumber);
 
   if (adapters.checkRecoveryPRExists(recoveryBranch)) {
     return { status: "already-exists", reason: `PR for ${recoveryBranch} already open` };


### PR DESCRIPTION
## Summary

Follow-up to [PR #3433](https://github.com/Lucent-Financial-Group/Zeta/pull/3433). Four review findings all addressed in this PR.

### P0 — Idempotency gate defeated by timestamp

The earlier `recovery/<prNumber>-<timestamp>` form made every `openRecoveryPR()` call produce a fresh branch name, so `checkRecoveryPRExists(recoveryBranch)` could effectively never match an existing PR. The spec's claim that "the idempotency gate prevents duplicate recovery PRs" didn't hold because the gate's input changed every invocation. Fix: deterministic `recovery/<prNumber>` (drop the timestamp).

New regression test (`queries checkRecoveryPRExists with the deterministic branch name`) locks in the contract.

### P? — Backtick in `branchName` breaks PR body
Added `sanitizeForInlineCode` helper; backticks in branchName replaced with `_` before the inline-code interpolation. New test covers the case.

### P? — Unused `RecoveryResult` type import in tests
Removed.

### P? — Test description/regex mismatch
Old: "digits, /, -" but regex permitted `a-z`. Replaced both with the actual `^recovery\/\d+$` for the new deterministic form.

## Test count: 14 → 16

Added: sanitize-backticks coverage, P0 regression test, deterministic-output test, idempotency-precondition (same prNumber two Dates → same branch name).

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test missed-substrate-recovery.test.ts` — 16 pass / 0 fail
- [x] `bun test missed-substrate-detector.test.ts` — 24 pass (baseline unchanged)
- [x] `semgrep --config .semgrep.yml --error` — 0 findings
- [ ] CI green
- [ ] Auto-merge fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)