### PR TITLE
feat(b-0504): wire --auto-recover into pollOnce + real RecoveryAdapters + 7 tests

### DIFF
--- a/tools/bg/missed-substrate-detector.test.ts
+++ b/tools/bg/missed-substrate-detector.test.ts
@@ -15,6 +15,7 @@ import {
   type MergedPR,
   type PRRefsResult,
 } from "./missed-substrate-detector";
+import type { RecoveryResult } from "./missed-substrate-recovery";
 import type { AgentId, MessageEnvelope, SenderAgentId } from "../bus/types";
 
 type FakeCascadeCall = {
@@ -332,5 +333,149 @@ describe("missed-substrate-detector slice 4 (bus publish wiring; slice-3 detect 
       expect(() => parseArgs(["--unknown"])).toThrow(/unknown flag/);
       expect(() => parseArgs(["--agent", "*"])).toThrow(/must be one of/);
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Slice 5b (B-0504): auto-recover wiring
+// ─────────────────────────────────────────────────────────────────────
+
+describe("missed-substrate-detector slice 5b (auto-recover wiring)", () => {
+  // Helper: build a CascadeFinding for tests
+  function makeFinding(prNumber = 1234): CascadeFinding {
+    return {
+      prNumber,
+      branchName: `feat/test-${prNumber}`,
+      missingCommits: ["aaa111", "bbb222"],
+      urgency: "medium",
+    };
+  }
+
+  // Helper: extend the existing `adapters()` helper with an openRecoveryPR
+  // override. Returns the captured RecoveryResult adapter calls.
+  function adaptersWithRecovery(opts: {
+    nowIso: string;
+    fetch: FetchResult;
+    detectCascade?: (pr: MergedPR) => CascadeFinding | null;
+    openRecoveryPR?: (finding: CascadeFinding, dryRun: boolean) => RecoveryResult;
+    recoveryCalls?: Array<{ finding: CascadeFinding; dryRun: boolean }>;
+  }): Adapters {
+    const base = adapters(opts);
+    if (opts.openRecoveryPR !== undefined) {
+      const captured = opts.recoveryCalls ?? [];
+      base.openRecoveryPR = (finding, dryRun) => {
+        captured.push({ finding, dryRun });
+        return opts.openRecoveryPR!(finding, dryRun);
+      };
+    }
+    return base;
+  }
+
+  test("autoRecover=false (default): recoveryAttempts=0; adapter never called", () => {
+    let adapterCalled = false;
+    const config = { ...DEFAULT_CONFIG, once: true };
+    const finding = makeFinding();
+    const result = pollOnce(config, adaptersWithRecovery({
+      nowIso: "2026-05-15T12:00:00Z",
+      fetch: { status: "ok", prs: [{ number: 1234, headRefName: "feat/x", mergedAt: "2026-05-15T11:59:00Z" }], truncated: false },
+      detectCascade: () => finding,
+      openRecoveryPR: () => {
+        adapterCalled = true;
+        return { status: "opened", prUrl: "https://example/pr/1", cherryPickedCount: 2 };
+      },
+    }));
+    expect(result.recoveryAttempts).toBe(0);
+    expect(result.recoveryOpened).toBe(0);
+    expect(adapterCalled).toBe(false);
+  });
+
+  test("autoRecover=true, adapter returns opened: recoveryOpened=1; note contains PR URL", () => {
+    const config = { ...DEFAULT_CONFIG, once: true, autoRecover: true, noPublish: true };
+    const finding = makeFinding();
+    const result = pollOnce(config, adaptersWithRecovery({
+      nowIso: "2026-05-15T12:00:00Z",
+      fetch: { status: "ok", prs: [{ number: 1234, headRefName: "feat/x", mergedAt: "2026-05-15T11:59:00Z" }], truncated: false },
+      detectCascade: () => finding,
+      openRecoveryPR: () => ({ status: "opened", prUrl: "https://example.com/pr/9999", cherryPickedCount: 2 }),
+    }));
+    expect(result.recoveryAttempts).toBe(1);
+    expect(result.recoveryOpened).toBe(1);
+    expect(result.note).toContain("https://example.com/pr/9999");
+  });
+
+  test("autoRecover=true, recoveryDryRun=true: adapter receives dryRun=true; note reflects dry-run", () => {
+    const config = { ...DEFAULT_CONFIG, once: true, autoRecover: true, recoveryDryRun: true, noPublish: true };
+    const finding = makeFinding();
+    const calls: Array<{ finding: CascadeFinding; dryRun: boolean }> = [];
+    const result = pollOnce(config, adaptersWithRecovery({
+      nowIso: "2026-05-15T12:00:00Z",
+      fetch: { status: "ok", prs: [{ number: 1234, headRefName: "feat/x", mergedAt: "2026-05-15T11:59:00Z" }], truncated: false },
+      detectCascade: () => finding,
+      openRecoveryPR: () => ({ status: "opened", prUrl: "dry-run", cherryPickedCount: 0 }),
+      recoveryCalls: calls,
+    }));
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.dryRun).toBe(true);
+    expect(result.recoveryAttempts).toBe(1);
+    expect(result.recoveryOpened).toBe(1);
+    expect(result.note).toContain("dry-run");
+  });
+
+  test("autoRecover=true, adapter returns already-exists: recoveryOpened=0; note contains already-exists", () => {
+    const config = { ...DEFAULT_CONFIG, once: true, autoRecover: true, noPublish: true };
+    const result = pollOnce(config, adaptersWithRecovery({
+      nowIso: "2026-05-15T12:00:00Z",
+      fetch: { status: "ok", prs: [{ number: 1234, headRefName: "feat/x", mergedAt: "2026-05-15T11:59:00Z" }], truncated: false },
+      detectCascade: () => makeFinding(),
+      openRecoveryPR: () => ({ status: "already-exists", reason: "PR for recovery/1234 already open" }),
+    }));
+    expect(result.recoveryAttempts).toBe(1);
+    expect(result.recoveryOpened).toBe(0);
+    expect(result.note).toContain("already-exists");
+  });
+
+  test("autoRecover=true, adapter throws: recoveryOpened=0; note contains 'recovery error'; poll completes", () => {
+    const config = { ...DEFAULT_CONFIG, once: true, autoRecover: true, noPublish: true };
+    const result = pollOnce(config, adaptersWithRecovery({
+      nowIso: "2026-05-15T12:00:00Z",
+      fetch: { status: "ok", prs: [{ number: 1234, headRefName: "feat/x", mergedAt: "2026-05-15T11:59:00Z" }], truncated: false },
+      detectCascade: () => makeFinding(),
+      openRecoveryPR: () => { throw new Error("simulated adapter blowup"); },
+    }));
+    expect(result.recoveryAttempts).toBe(1);
+    expect(result.recoveryOpened).toBe(0);
+    expect(result.note).toContain("recovery error");
+    expect(result.note).toContain("simulated adapter blowup");
+    // The poll itself completed successfully — fetchStatus=ok, no exception.
+    expect(result.fetchStatus).toBe("ok");
+  });
+
+  test("parseArgs sets autoRecover/recoveryDryRun flags + DEFAULT_CONFIG defaults", () => {
+    expect(parseArgs([]).autoRecover).toBe(false);
+    expect(parseArgs([]).recoveryDryRun).toBe(false);
+    expect(parseArgs(["--auto-recover"]).autoRecover).toBe(true);
+    expect(parseArgs(["--recovery-dry-run"]).recoveryDryRun).toBe(true);
+    // --recovery-dry-run without --auto-recover is silently accepted.
+    const c = parseArgs(["--recovery-dry-run"]);
+    expect(c.recoveryDryRun).toBe(true);
+    expect(c.autoRecover).toBe(false);
+    // Combined.
+    const both = parseArgs(["--auto-recover", "--recovery-dry-run"]);
+    expect(both.autoRecover).toBe(true);
+    expect(both.recoveryDryRun).toBe(true);
+  });
+
+  test("autoRecover=true but adapter undefined: recoveryAttempts=0 (treats missing adapter as autoRecover=false)", () => {
+    const config = { ...DEFAULT_CONFIG, once: true, autoRecover: true, noPublish: true };
+    // Don't pass openRecoveryPR to adapters() — it's optional.
+    const result = pollOnce(config, adapters({
+      nowIso: "2026-05-15T12:00:00Z",
+      fetch: { status: "ok", prs: [{ number: 1234, headRefName: "feat/x", mergedAt: "2026-05-15T11:59:00Z" }], truncated: false },
+      detectCascade: () => makeFinding(),
+    }));
+    // Cascade was detected but adapter is missing → recovery skipped silently.
+    expect(result.cascadesDetected).toBe(1);
+    expect(result.recoveryAttempts).toBe(0);
+    expect(result.recoveryOpened).toBe(0);
   });
 });

--- a/tools/bg/missed-substrate-detector.ts
+++ b/tools/bg/missed-substrate-detector.ts
@@ -25,6 +25,11 @@
 import { spawnSync } from "node:child_process";
 import { publish } from "../bus/bus";
 import { AGENT_IDS, SENDER_IDS, type AgentId, type MessageEnvelope, type SenderAgentId } from "../bus/types";
+import {
+  openRecoveryPR,
+  type RecoveryAdapters,
+  type RecoveryResult,
+} from "./missed-substrate-recovery";
 
 export type DetectorConfig = {
   pollIntervalMin: number;
@@ -34,6 +39,12 @@ export type DetectorConfig = {
   noPublish: boolean;
   fromAgent: SenderAgentId;
   toAgent: AgentId;
+  /** Slice 5b (B-0504): when true, pollOnce calls openRecoveryPR for each
+   *  CascadeFinding after detecting cascades. Default false. */
+  autoRecover: boolean;
+  /** Slice 5b (B-0504): when true AND autoRecover is true, recovery runs
+   *  in dry-run mode (no git mutations; log intent only). Default false. */
+  recoveryDryRun: boolean;
 };
 
 export const DEFAULT_CONFIG: DetectorConfig = {
@@ -44,6 +55,8 @@ export const DEFAULT_CONFIG: DetectorConfig = {
   noPublish: false,
   fromAgent: "otto",
   toAgent: "*",
+  autoRecover: false,
+  recoveryDryRun: false,
 };
 
 export type MergedPR = {
@@ -70,6 +83,11 @@ export type PollResult = {
   fetchStatus: "ok" | "gh-error";
   fetchTruncated: boolean;
   publishedEnvelopeIds: string[];
+  /** Slice 5b (B-0504): count of findings for which openRecoveryPR was
+   *  attempted. 0 when config.autoRecover=false or adapter missing. */
+  recoveryAttempts: number;
+  /** Slice 5b (B-0504): count of openRecoveryPR results with status="opened". */
+  recoveryOpened: number;
   note: string;
 };
 
@@ -89,6 +107,15 @@ export type Adapters = {
     to: AgentId,
     finding: CascadeFinding,
   ) => MessageEnvelope;
+  /**
+   * Slice 5b (B-0504): optional recovery adapter. When provided AND
+   * `config.autoRecover === true`, `pollOnce` invokes this for each
+   * `CascadeFinding` after detection. Optional (`?`) so existing tests
+   * that don't exercise the recovery path don't need to provide it;
+   * `pollOnce` treats a missing adapter as `autoRecover=false`
+   * regardless of the config flag.
+   */
+  openRecoveryPR?: (finding: CascadeFinding, dryRun: boolean) => RecoveryResult;
 };
 
 /**
@@ -232,6 +259,94 @@ const REAL_ADAPTERS: Adapters = {
         urgency: finding.urgency,
       },
     }),
+  // Slice 5b (B-0504): production recovery adapter. Composes the pure
+  // `openRecoveryPR` core function (B-0503) with real spawnSync wrappers
+  // for each git/gh sub-operation. See `REAL_RECOVERY_ADAPTERS` below for
+  // the sub-adapter implementations + their security validation.
+  openRecoveryPR: (finding, dryRun) =>
+    openRecoveryPR(finding, dryRun, REAL_RECOVERY_ADAPTERS),
+};
+
+/**
+ * Slice 5b (B-0504): real production sub-adapters for openRecoveryPR.
+ *
+ * Each adapter wraps a `spawnSync` call with args-as-array (no shell, no
+ * injection). Per the B-0503 security note + the `compareBranchToMerged`
+ * pattern, branch names and commit SHAs from `CascadeFinding` are
+ * already validated by `realCascadeDetector` (allow-list regex); these
+ * adapters trust the validated inputs.
+ *
+ * `gitCreateBranch` honors the B-0503 retry-safety contract: if the local
+ * branch already exists (from a prior partial-failure attempt), it deletes
+ * and recreates from `base` so the recovery retry doesn't wedge.
+ */
+const REAL_RECOVERY_ADAPTERS: RecoveryAdapters = {
+  checkRecoveryPRExists: (branchName: string) => {
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- gh invoked as explicit args array; no shell, no injection.
+    const r = spawnSync(
+      "gh",
+      ["pr", "list", "--head", branchName, "--state", "open", "--json", "number"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    if (r.status !== 0) return false; // conservative: assume no existing PR on gh failure
+    try {
+      const parsed = JSON.parse(r.stdout ?? "[]");
+      return Array.isArray(parsed) && parsed.length > 0;
+    } catch {
+      return false;
+    }
+  },
+  gitCreateBranch: (branch: string, base: string) => {
+    // Retry-safety per the B-0503 RecoveryAdapters.gitCreateBranch contract:
+    // if the local branch already exists (prior partial-failure recovery
+    // attempt), delete it before recreating from `base`.
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array.
+    spawnSync("git", ["branch", "-D", branch], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array.
+    const r = spawnSync(
+      "git",
+      ["checkout", "-b", branch, base],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return r.status === 0;
+  },
+  gitCherryPick: (sha: string) => {
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array.
+    const r = spawnSync(
+      "git",
+      ["cherry-pick", sha],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    if (r.status === 0) return "ok";
+    const stderr = (r.stderr ?? "").toString();
+    // git cherry-pick exits 1 with "CONFLICT" in stderr on merge conflict.
+    if (stderr.includes("CONFLICT")) return "conflict";
+    return "error";
+  },
+  gitPush: (branch: string) => {
+    // --force-with-lease honors the B-0503 retry-safety hint: a prior
+    // attempt may have pushed an incomplete branch; --force-with-lease
+    // overwrites only if the remote matches what we last fetched (safer
+    // than --force).
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array.
+    const r = spawnSync(
+      "git",
+      ["push", "--force-with-lease", "origin", branch],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return r.status === 0;
+  },
+  ghPrCreate: (title: string, body: string, head: string) => {
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- gh invoked as explicit args array.
+    const r = spawnSync(
+      "gh",
+      ["pr", "create", "--title", title, "--body", body, "--head", head, "--base", "main"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    if (r.status !== 0) return null;
+    const url = (r.stdout ?? "").toString().trim();
+    return url.length > 0 ? url : null;
+  },
 };
 
 /**
@@ -370,6 +485,8 @@ export function pollOnce(
       fetchStatus: "gh-error",
       fetchTruncated: false,
       publishedEnvelopeIds: [],
+      recoveryAttempts: 0,
+      recoveryOpened: 0,
       note: `gh fetch failed; cannot evaluate drift this tick. ${fetch.reason}`,
     };
   }
@@ -394,6 +511,31 @@ export function pollOnce(
     }
   }
 
+  // Slice 5b (B-0504): recovery loop. Runs only when `config.autoRecover`
+  // is true AND the optional `openRecoveryPR` adapter is provided. Recovery
+  // failures (adapter throws) are logged into recoveryNotes and do NOT
+  // throw — the poll cycle completes successfully even when individual
+  // recovery attempts error out, so the next poll can re-try.
+  let recoveryAttempts = 0;
+  let recoveryOpened = 0;
+  const recoveryNotes: string[] = [];
+  if (config.autoRecover && adapters.openRecoveryPR !== undefined) {
+    for (const finding of findings) {
+      recoveryAttempts++;
+      try {
+        const rr = adapters.openRecoveryPR(finding, config.recoveryDryRun);
+        if (rr.status === "opened") {
+          recoveryOpened++;
+          recoveryNotes.push(`recovery PR ${rr.prUrl} for #${finding.prNumber} (${rr.cherryPickedCount} commits)`);
+        } else {
+          recoveryNotes.push(`recovery ${rr.status} for #${finding.prNumber}`);
+        }
+      } catch (e) {
+        recoveryNotes.push(`recovery error for #${finding.prNumber}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+  }
+
   const truncatedSuffix = fetch.truncated
     ? ` (WARNING: results truncated at fetchLimit=${config.fetchLimit}; raise --fetch-limit or shorten --lookback-min)`
     : "";
@@ -404,6 +546,7 @@ export function pollOnce(
     : publishedEnvelopeIds.length > 0
     ? ` (published ${publishedEnvelopeIds.length} cascade envelope(s))`
     : "";
+  const recoverySuffix = recoveryNotes.length > 0 ? `; ${recoveryNotes.join("; ")}` : "";
 
   return {
     pollAt: pollAt.toISOString(),
@@ -412,8 +555,10 @@ export function pollOnce(
     fetchStatus: "ok",
     fetchTruncated: fetch.truncated,
     publishedEnvelopeIds,
+    recoveryAttempts,
+    recoveryOpened,
     note: findings.length > 0
-      ? `${findings.length} cascade(s) detected in ${fetch.prs.length} merged PR(s)${publishSuffix}${truncatedSuffix}`
+      ? `${findings.length} cascade(s) detected in ${fetch.prs.length} merged PR(s)${publishSuffix}${truncatedSuffix}${recoverySuffix}`
       : fetch.prs.length === 0
       ? `no merged PRs in last ${config.lookbackMin}min lookback window`
       : `${fetch.prs.length} merged PR(s) in last ${config.lookbackMin}min; no cascades detected${truncatedSuffix}`,
@@ -463,7 +608,7 @@ function parseAgentId(raw: string | undefined): AgentId {
   throw new Error(`--to must be one of ${AGENT_IDS.join(", ")}; got "${raw}"`);
 }
 
-const KNOWN_FLAGS = ["--once", "--poll-min", "--lookback-min", "--fetch-limit", "--no-publish", "--agent", "--to"] as const;
+const KNOWN_FLAGS = ["--once", "--poll-min", "--lookback-min", "--fetch-limit", "--no-publish", "--agent", "--to", "--auto-recover", "--recovery-dry-run"] as const;
 
 export function parseArgs(argv: string[]): DetectorConfig {
   const config: DetectorConfig = { ...DEFAULT_CONFIG };
@@ -484,6 +629,10 @@ export function parseArgs(argv: string[]): DetectorConfig {
       config.fromAgent = parseSenderId(argv[++i]);
     } else if (arg === "--to") {
       config.toAgent = parseAgentId(argv[++i]);
+    } else if (arg === "--auto-recover") {
+      config.autoRecover = true;
+    } else if (arg === "--recovery-dry-run") {
+      config.recoveryDryRun = true;
     } else {
       throw new Error(`unknown flag: ${arg}; known flags: ${KNOWN_FLAGS.join(", ")}`);
     }

--- a/tools/bg/missed-substrate-detector.ts
+++ b/tools/bg/missed-substrate-detector.ts
@@ -336,6 +336,23 @@ const REAL_RECOVERY_ADAPTERS: RecoveryAdapters = {
     // Retry-safety per the B-0503 RecoveryAdapters.gitCreateBranch contract:
     // if the local branch already exists (prior partial-failure recovery
     // attempt), delete it before recreating from `base`.
+    //
+    // Per Codex PR #3447 line 344: `git branch -D` CANNOT delete the
+    // currently-checked-out branch — if a previous attempt left HEAD on
+    // `recovery/<prNumber>`, the delete fails AND the subsequent
+    // `checkout -b` fails (branch already exists). Both failures wedge
+    // retries permanently. Mitigation: detach HEAD to `base` first
+    // (`git checkout --detach <base>`), so the recovery branch is no
+    // longer current and `git branch -D` succeeds. Detach is safe
+    // because we're about to `checkout -b` onto a fresh branch anyway;
+    // the intermediate detached state is transient.
+    //
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array.
+    spawnSync(
+      "git",
+      ["checkout", "--detach", base],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
     // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array.
     spawnSync("git", ["branch", "-D", branch], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
     // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array.

--- a/tools/bg/missed-substrate-detector.ts
+++ b/tools/bg/missed-substrate-detector.ts
@@ -263,9 +263,45 @@ const REAL_ADAPTERS: Adapters = {
   // `openRecoveryPR` core function (B-0503) with real spawnSync wrappers
   // for each git/gh sub-operation. See `REAL_RECOVERY_ADAPTERS` below for
   // the sub-adapter implementations + their security validation.
-  openRecoveryPR: (finding, dryRun) =>
-    openRecoveryPR(finding, dryRun, REAL_RECOVERY_ADAPTERS),
+  //
+  // WORKING-TREE SAFETY GATE (per Copilot PR #3447 review on line 349):
+  // the real recovery adapters mutate whatever git checkout this detector
+  // runs in (`git branch -D`, `git checkout -b`, `git cherry-pick`,
+  // `git push --force-with-lease`). Running them against a dirty working
+  // tree would clobber uncommitted work or leak commits into the wrong
+  // tree. We refuse to proceed in non-dry-run mode if the working tree
+  // is not clean — operators are expected to run auto-recovery from a
+  // dedicated scratch worktree (`git worktree add /tmp/zeta-recovery
+  // <branch>` is the canonical shape).
+  openRecoveryPR: (finding, dryRun) => {
+    if (!dryRun && !isWorkingTreeClean()) {
+      return {
+        status: "error",
+        reason:
+          "refusing recovery: working tree is not clean. Run auto-recovery from a dedicated `git worktree add` scratch dir, or pass --recovery-dry-run to skip mutations.",
+      };
+    }
+    return openRecoveryPR(finding, dryRun, REAL_RECOVERY_ADAPTERS);
+  },
 };
+
+/**
+ * Slice 5b (B-0504): pre-mutation safety check. Returns true if `git
+ * status --porcelain` reports no modified/untracked/deleted files in
+ * the current checkout. Used as the gate before `REAL_ADAPTERS.openRecoveryPR`
+ * runs any mutating sub-adapter — see the comment block on that adapter
+ * for the failure mode this prevents.
+ */
+function isWorkingTreeClean(): boolean {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array.
+  const r = spawnSync(
+    "git",
+    ["status", "--porcelain"],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  if (r.status !== 0) return false; // conservative: assume dirty on git error
+  return (r.stdout ?? "").trim().length === 0;
+}
 
 /**
  * Slice 5b (B-0504): real production sub-adapters for openRecoveryPR.


### PR DESCRIPTION
## Summary

Closes [B-0504](https://github.com/Lucent-Financial-Group/Zeta/blob/main/docs/backlog/P1/B-0504-b0442-slice5b-wire-auto-recover-into-pollonce-2026-05-14.md) — wires the `openRecoveryPR` core function (B-0503) into the detector poll loop with config flags, real `spawnSync` adapters, and integration tests. With this PR, [B-0442](https://github.com/Lucent-Financial-Group/Zeta/blob/main/docs/backlog/P0/) slice 5 ("Optionally auto-opens recovery PR with the missing commits") is implemented end-to-end.

## What lands

- **DetectorConfig** gains `autoRecover` + `recoveryDryRun` (both default `false`)
- **parseArgs**: `--auto-recover` + `--recovery-dry-run` flags (added to `KNOWN_FLAGS`)
- **Adapters**: optional `openRecoveryPR?` (existing tests need no change)
- **REAL_RECOVERY_ADAPTERS**: 5 production `spawnSync` wrappers honoring the B-0503 retry-safety contract (`gitCreateBranch` deletes stale local branch best-effort; `gitPush` uses `--force-with-lease`)
- **pollOnce**: recovery loop after cascade detection; failures don't throw (logged into `note`, poll completes)
- **PollResult**: `recoveryAttempts` + `recoveryOpened` fields
- **7 new tests** covering: defaults, opened, dry-run, already-exists, adapter-throw, parseArgs wiring, missing-adapter

## B-0505 (remaining child)

After this PR merges, only **B-0505 (docs + B-0442 acceptance close)** remains in the B-0442 → B-0503/B-0504/B-0505 chain.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test missed-substrate-detector.test.ts` — 31 pass / 0 fail (was 24 baseline + 7 new)
- [x] `bun test missed-substrate-recovery.test.ts` — 17 pass (baseline regression clean)
- [x] `semgrep --config .semgrep.yml --error` — 0 findings
- [ ] CI green
- [ ] Auto-merge fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)