### PR TITLE
fix(b-0504): git cherry-pick --abort on conflict/error to unwedge isWorkingTreeClean

### DIFF
--- a/tools/bg/missed-substrate-detector.ts
+++ b/tools/bg/missed-substrate-detector.ts
@@ -372,6 +372,20 @@ const REAL_RECOVERY_ADAPTERS: RecoveryAdapters = {
     );
     if (r.status === 0) return "ok";
     const stderr = (r.stderr ?? "").toString();
+    // Per Codex PR #3447 line 377: when cherry-pick fails (conflict or
+    // error), the repo is left in CHERRY_PICK_HEAD state with a
+    // conflicted index/worktree. Future polls then fail
+    // `isWorkingTreeClean()` and refuse all recovery — one conflict
+    // wedges the daemon. Abort the in-progress cherry-pick before
+    // returning so the working tree returns to a clean state. The
+    // caller (openRecoveryPR) returns immediately on conflict/error
+    // without pushing, so aborting here doesn't lose intentional state.
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- git invoked as explicit args array.
+    spawnSync(
+      "git",
+      ["cherry-pick", "--abort"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
     // git cherry-pick exits 1 with "CONFLICT" in stderr on merge conflict.
     if (stderr.includes("CONFLICT")) return "conflict";
     return "error";


### PR DESCRIPTION
## Summary

Post-merge follow-up to [PR #3447](https://github.com/Lucent-Financial-Group/Zeta/pull/3447). Codex caught a wedge case in `gitCherryPick`:

When `git cherry-pick` fails (conflict or other error), the repo is left in `CHERRY_PICK_HEAD` state with a conflicted index/worktree. Future polls then fail `isWorkingTreeClean()` (the safety gate added in PR #3447) and refuse all subsequent recovery attempts — one conflict wedges the daemon until manual `git cherry-pick --abort`.

## Fix

`gitCherryPick` adapter now runs `git cherry-pick --abort` before returning `"conflict"` or `"error"`. The caller (`openRecoveryPR`) returns immediately on those terminal arms without pushing, so aborting here doesn't lose intentional state.

## Composes with prior layers

| Layer | What it catches |
|---|---|
| Type contract (B-0503) | adapter must handle stale-branch as success |
| Real-adapter strategy | delete-and-recreate from base |
| Pre-mutation gate (PR #3447) | refuse on dirty working tree |
| Pre-delete detach (PR #3447) | handle HEAD-on-recovery-branch case |
| Post-cherry-pick abort (this PR) | unwedge isWorkingTreeClean after conflict |

Each layer caught a different failure scenario the previous didn't cover. Codex + Copilot complementary reviewing producing operationally robust code.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test missed-substrate-detector.test.ts` — 31 pass / 0 fail
- [x] `bun test missed-substrate-recovery.test.ts` — 17 pass / 0 fail
- [ ] CI green
- [ ] Auto-merge fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)