### PR TITLE
docs(b-0505): close B-0442 slice 5 acceptance + document --auto-recover

### DIFF
--- a/docs/AUTONOMOUS-LOOP.md
+++ b/docs/AUTONOMOUS-LOOP.md
@@ -600,6 +600,33 @@ declared) against `CronList` and re-arms missing rows.
   subscriber handler that consumes them. Note: plist files contain
   machine-specific paths and are maintainer-only artifacts.
 
+  **`missed-substrate-detector` auto-recovery** (B-0442 slice 5, landed
+  2026-05-15 via B-0503 + B-0504): the detector can optionally open a
+  recovery PR for each `CascadeFinding`:
+
+  - `--auto-recover` (default `off`): when set, after detecting a
+    cascade gap on a merged PR, the detector calls `openRecoveryPR`
+    (from `tools/bg/missed-substrate-recovery.ts`) which checks out a
+    deterministic `recovery/<prNumber>` branch from `origin/main`,
+    cherry-picks each missing commit, and opens a PR via `gh pr
+    create`. Enable only when running from a **dedicated `git worktree
+    add` scratch dir** — the real adapters mutate the current working
+    tree and refuse to fire when the tree is not clean.
+  - `--recovery-dry-run` (default `off`): when set together with
+    `--auto-recover`, the recovery path logs intent without performing
+    any git mutations or `gh pr create` call. Useful for verifying the
+    detector finds the cascade you expect before granting it write
+    permission.
+  - **Idempotency**: the recovery branch name is deterministic per PR
+    number, so a previously-open recovery PR for the same PR number
+    will be detected by `gh pr list --head recovery/<prN> --state
+    open` and the recovery is skipped (returns `already-exists`).
+  - **Conflict handling**: if cherry-pick hits a merge conflict, the
+    adapter runs `git cherry-pick --abort` and `openRecoveryPR`
+    returns `cherry-pick-conflict` without pushing partial state; a
+    human must resolve the conflict manually (e.g., open a recovery
+    PR by hand from the same `recovery/<prN>` branch).
+
 - **`docs/hygiene-history/loop-tick-history.md`** — the
   factory's durable tick fire-log; appended to every tick
   at step 5 per the round-44 human-maintainer directive.

--- a/docs/backlog/P1/B-0442-missed-substrate-cascade-detector-background-service-2026-05-13.md
+++ b/docs/backlog/P1/B-0442-missed-substrate-cascade-detector-background-service-2026-05-13.md
@@ -65,8 +65,13 @@ a branch, the service catches it BEFORE branch deletion.
       `{ topic: "missed-substrate-cascade", to: <agent>,
          payload: { branchName, missingCommits, recommendedAction:
          "open-recovery-PR" } }` (slice 4 — earlier)
-- [ ] Optionally auto-opens recovery PR with the missing commits
-      (gated by configuration) (slice 5 — pending; subscriber-agent layer)
+- [x] Optionally auto-opens recovery PR with the missing commits
+      (gated by configuration) (slice 5 — landed 2026-05-15 via
+      B-0503 (`openRecoveryPR` core + `RecoveryAdapters` contract) +
+      B-0504 (wire `--auto-recover` into `pollOnce` + real
+      `REAL_RECOVERY_ADAPTERS` with 5-layer safety: type-contract,
+      delete-and-recreate, working-tree-clean gate, detach-HEAD-before-
+      delete, post-cherry-pick `--abort`))
 - [x] Tests cover the detection heuristics (DST-replayable) — 24 tests cover slice 4 wiring + slice 3 detector (drift / no-drift / branch-deleted / branch-rebased / gh-error / git-error) + urgency classification
 - [x] Documented in `docs/AUTONOMOUS-LOOP.md` (slice 6 — landed 2026-05-13)
 

--- a/tools/bg/README.md
+++ b/tools/bg/README.md
@@ -30,7 +30,8 @@ so future readers don't overclaim.
 |---------|------|--------------|------------------|-----------|
 | Standing-by detector | `standing-by-detector.ts` | 1+2+3+4 live | commit-history (HEAD) + PR-activity (repo) via `gh`/`git` | `infinite-backlog-nudge` |
 | Backlog-ready notifier | `backlog-ready-notifier.ts` | 1+2+4+6 live (slice 3 pending B-0500) | backlog-row scan (status + deps satisfied) | `work-assignment` |
-| Missed-substrate detector | `missed-substrate-detector.ts` | 1+2+3+4 live | merged-PR fetch via `gh`; real branch-vs-squash compare via `gh pr view --json headRefOid` + `git log <headRefOid>..origin/<branch>` (slice 3 landed 2026-05-13) | `missed-substrate-cascade` |
+| Missed-substrate detector | `missed-substrate-detector.ts` | 1+2+3+4+5 live | merged-PR fetch via `gh`; real branch-vs-squash compare via `gh pr view --json headRefOid` + `git log <headRefOid>..origin/<branch>` (slice 3 landed 2026-05-13); auto-recovery via `--auto-recover` / `--recovery-dry-run` flags (slice 5 landed 2026-05-15) | `missed-substrate-cascade` |
+| Missed-substrate recovery (helper) | `missed-substrate-recovery.ts` | core function + adapter contract shipped 2026-05-15 (B-0503); wired into detector via `REAL_RECOVERY_ADAPTERS` (B-0504) | n/a (invoked by detector when `--auto-recover` set) | n/a (opens recovery PR directly via `gh pr create`) |
 
 Per-service slice ordering (each service decomposes into 6 slices):
 


### PR DESCRIPTION
## Summary

Closes [B-0505](https://github.com/Lucent-Financial-Group/Zeta/blob/main/docs/backlog/P1/B-0505-b0442-slice5c-docs-autonomous-loop-acceptance-close-2026-05-14.md) — the docs-only final slice of the B-0442 chain. Per the row's DV2.0 split rationale: docs (fast-changing English) and code (stable hubs) ship in separate diffs.

## What lands (3 files)

1. **`docs/AUTONOMOUS-LOOP.md`** — new `missed-substrate-detector auto-recovery` subsection under the Background Services Architecture related-artifact paragraph. Documents both flags (`--auto-recover`, `--recovery-dry-run`), the deterministic branch name (`recovery/<prNumber>`), idempotency, conflict handling, and the working-tree-clean precondition.

2. **`tools/bg/README.md`** — services table: bumps `missed-substrate-detector` from "1+2+3+4 live" to "1+2+3+4+5 live"; adds the flags + land date; new "Missed-substrate recovery (helper)" row pointing at `missed-substrate-recovery.ts`.

3. **`docs/backlog/P1/B-0442-...md`** — flips the slice-5 acceptance criterion from `- [ ]` to `- [x]` with land date + reference to the 5-layer safety cascade landed across B-0503 + B-0504.

## B-0442 chain final state with this PR

| Slice | Status |
|---|---|
| B-0442 1–4, 6 | merged earlier |
| B-0503 (core function + adapter contract) | merged |
| B-0504 (wiring + real adapters + 5-layer safety) | merged |
| **B-0505 (this PR — docs + acceptance close)** | open |

After this merges, B-0442 itself can be marked `status: closed`.

## Test plan
- [x] Markdownlint clean on all 3 edited files
- [x] `bun test missed-substrate-detector.test.ts` — 31 pass (unchanged; no code touched)
- [x] `bun test missed-substrate-recovery.test.ts` — 17 pass (unchanged)
- [ ] CI green
- [ ] Auto-merge fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)