### PR TITLE
shard(tick): 1305Z-01 — PR #3465 merged; 1 stale Codex thread cleared

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/1305Z-01.md
+++ b/docs/hygiene-history/ticks/2026/05/15/1305Z-01.md
@@ -1,4 +1,4 @@
-| 2026-05-15T13:05:30Z | claude-opus-4-7 | 596e842c | shard: PR #3465 merged; 1 stale Codex thread cleared on PR #3466 | (PR TBD) | clean tick |
+| 2026-05-15T13:05:30Z | claude-opus-4-7 | 596e842c | shard: PR #3465 merged; 1 stale Codex thread cleared on PR #3466 | (PR #3470) | clean tick |
 
 # Tick 1305Z-01
 

--- a/docs/hygiene-history/ticks/2026/05/15/1305Z-01.md
+++ b/docs/hygiene-history/ticks/2026/05/15/1305Z-01.md
@@ -1,0 +1,9 @@
+| 2026-05-15T13:05:30Z | claude-opus-4-7 | 596e842c | shard: PR #3465 merged; 1 stale Codex thread cleared on PR #3466 | (PR TBD) | clean tick |
+
+# Tick 1305Z-01
+
+- PR #3465 (mislabeled-1305Z shard) MERGED → `ad3206b`. Stale-cluster note: PR #3466's Codex P2 claim that `1305Z.md` didn't exist was a pre-merge snapshot; blob `8fa88fc5` is on main now.
+- PR #3466 (mislabeled-1309Z shard): 1 stale Codex thread cleared. Auto-merge holds.
+- PR #3467 (1301Z-01 drift-recalibration shard): wait-CI, 0 threads.
+- Disambig suffix used again — actual UTC 13:05Z, `1305Z.md` already taken (the mislabeled shard from before recalibration).
+- Cron sentinel `596e842c` armed.


### PR DESCRIPTION
Cron-driven autonomous-loop tick. Filename uses disambig suffix because pre-recalibration drift collided with this actual UTC timestamp.