### PR TITLE
fix(shard-1524z): correct relative-link depth + raw-output mislabel

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/1524Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/1524Z.md
@@ -4,25 +4,25 @@
 
 - **PR [#3508](https://github.com/Lucent-Financial-Group/Zeta/pull/3508)** (Manifesto partial-lock rename) MERGED at 15:15Z → commit `660f4c9` on main. Peer Otto-CLI / Otto-Desktop landed the same fixes I was about to make: commit `512eeff` (markdownlint MD049 underscore→asterisk) + commit `8ca81ef` (V2.1 expansion: Constraint 11 + m/acc + Multi-Oracle Principle).
 - **PR [#3504](https://github.com/Lucent-Financial-Group/Zeta/pull/3504)** (1427Z shard) MERGED at 15:24Z → commit `4d60e12` on main. 2 stale Copilot threads explicitly resolved via GraphQL `resolveReviewThread` after substantive fix `e0bd021` had already landed on the branch but didn't auto-outdate the threads.
-- **Peer-rebase contention caught** in primary worktree `/Users/acehack/Documents/src/repos/Zeta`: peer Lior had an interactive rebase of `lior/decompose-b0139-4` onto `99fae64` in progress (`.git/rebase-merge/` populated). Backed off per [`claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md) "borrow-on-existing pattern" — switched to stable sidetick `/private/tmp/zeta-otto-cli-0027z-sidetick`.
+- **Peer-rebase contention caught** in primary worktree `/Users/acehack/Documents/src/repos/Zeta`: peer Lior had an interactive rebase of `lior/decompose-b0139-4` onto `99fae64` in progress (`.git/rebase-merge/` populated). Backed off per [`claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md) "borrow-on-existing pattern" — switched to stable sidetick `/private/tmp/zeta-otto-cli-0027z-sidetick`.
 - Cron sentinel job `1011e43d` re-armed at tick start per catch-43 mandate (CronList showed empty, `* * * * *` + `<<autonomous-loop>>`).
 
 ## Refresh discipline (two-layer print)
 
-Raw output:
+Raw `git log` output:
 
 ```
 $ git log origin/main --oneline -3
 4d60e12 shard(tick): 1427Z — PR #3499 merged; 2 stale threads cleared on PR #3500 (#3504)
 660f4c9 feat(manifesto): V2.1 — Constraint 11 (Default Oracle) + m/acc + Multi-Oracle + partial-lock rename (#3508)
 7b88265 shard(tick): 1436Z — post-summary reentry; B-0442/B-0503 row-status loose-end flagged (#3509)
-
-$ bun tools/orchestrator-checks/cron-sentinel-mutex.ts --json
-peerPids: [4379, 4380, 8592, 8593, 19879, 19881, 68751, 68752, 74191, 74193]  → peerDetected: true
-
-$ cat .git/rebase-merge/head-name (in primary worktree)
-refs/heads/lior/decompose-b0139-4
 ```
+
+Summary (NOT raw JSON — the actual `cron-sentinel-mutex.ts --json` payload is a `{myPid, peerPids, peerLines, ...}` object captured into a separate persisted-output file in the tick's working dir; this is the hand-extracted summary):
+
+- `peerPids` = `[4379, 4380, 8592, 8593, 19879, 19881, 68751, 68752, 74191, 74193]` (10 PIDs, all Claude.app helpers)
+- `peerDetected = true` (exit code 11 = `Math.min(1 + 10, 250)`)
+- Primary worktree's `.git/rebase-merge/head-name` = `refs/heads/lior/decompose-b0139-4` (in-progress interactive rebase by peer Lior)
 
 Interpretation: 10 peer Otto-CLI PIDs running concurrently; primary worktree captured by Lior interactive rebase; per mutex rule, `git worktree add` avoided + work routed to sidetick via borrow-on-existing.
 
@@ -37,13 +37,13 @@ Both threads marked `isOutdated: false` despite the substantive fix landing — 
 
 ## Substrate-honest disclaimer — my local MANIFESTO edits were noise
 
-Per [`.claude/rules/substrate-or-it-didnt-happen.md`](../../../../../.claude/rules/substrate-or-it-didnt-happen.md): I made local Edit-tool edits to MANIFESTO.md in the primary worktree (rename clarification, Authors role-ref, Grok-fetch reframing, §5+§6 enumeration). These never committed — peer Otto landed the SAME issues' fixes via commits `512eeff` + `8ca81ef` on the SAME branch and the PR merged before my work could push. Local Edit-tool effects in the primary worktree got overwritten by peer's branch checkouts. Zero substrate landed from my MANIFESTO edits; the threads were already addressed by peer's commits.
+Per [`.claude/rules/substrate-or-it-didnt-happen.md`](../../../../../../.claude/rules/substrate-or-it-didnt-happen.md): I made local Edit-tool edits to MANIFESTO.md in the primary worktree (rename clarification, Authors role-ref, Grok-fetch reframing, §5+§6 enumeration). These never committed — peer Otto landed the SAME issues' fixes via commits `512eeff` + `8ca81ef` on the SAME branch and the PR merged before my work could push. Local Edit-tool effects in the primary worktree got overwritten by peer's branch checkouts. Zero substrate landed from my MANIFESTO edits; the threads were already addressed by peer's commits.
 
 This IS the multi-Otto convergence pattern the unified-identity discipline produces: independent observation paths picked the same fixes; whichever observer's commits push first wins; the other observer's local-only work is silent overlap. No conflict because no concurrent push happened.
 
 ## Composes with
 
-- [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../.claude/rules/claim-acquire-before-worktree-work.md) — borrow-on-existing pattern engaged
-- [`.claude/rules/blocked-green-ci-investigate-threads.md`](../../../../../.claude/rules/blocked-green-ci-investigate-threads.md) — stale-but-not-outdated threads blocking the gate
-- [`.claude/rules/substrate-or-it-didnt-happen.md`](../../../../../.claude/rules/substrate-or-it-didnt-happen.md) — uncommitted edits are weather
-- [`.claude/rules/tick-must-never-stop.md`](../../../../../.claude/rules/tick-must-never-stop.md) — catch-43 sentinel re-armed at tick start
+- [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md) — borrow-on-existing pattern engaged
+- [`.claude/rules/blocked-green-ci-investigate-threads.md`](../../../../../../.claude/rules/blocked-green-ci-investigate-threads.md) — stale-but-not-outdated threads blocking the gate
+- [`.claude/rules/substrate-or-it-didnt-happen.md`](../../../../../../.claude/rules/substrate-or-it-didnt-happen.md) — uncommitted edits are weather
+- [`.claude/rules/tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md) — catch-43 sentinel re-armed at tick start


### PR DESCRIPTION
## Summary

Post-merge Copilot findings on [PR #3511](https://github.com/Lucent-Financial-Group/Zeta/pull/3511) (tick 1524Z shard, merged at 15:31Z):

- **P1**: Five `../` levels in `.claude/rules/*` links resolved to `docs/.claude/rules/*` (404). The file is 6 dirs deep — needs 6 `../` levels to reach repo root. Matches established pattern in sibling shards. 5 occurrences fixed.
- **P2**: Block was labeled "Raw output" but contained a hand-formatted summary, not the actual JSON payload from `cron-sentinel-mutex.ts --json`. Split into a genuinely-raw `git log` block + an explicit "Summary (NOT raw JSON ...)" prose section.

Copilot reviewed at 15:33Z (2min after the 15:31Z auto-merge); the gate didn't wait. This is the after-the-fact substance fix.

## Test plan

- [x] markdownlint clean on the corrected shard file
- [x] Branched from `origin/main` (sidetick borrow-on-existing pattern; peer-mutex showed 10 PIDs at tick 1557Z)
- [x] Relative-link depth matches `0213Z.md` / `0414Z.md` neighbors (6 `../`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)