### PR TITLE
fix(memory): correct PR citations in Vera + Riven MEMORY.md indexes

### DIFF
--- a/memory/persona/riven/MEMORY.md
+++ b/memory/persona/riven/MEMORY.md
@@ -10,7 +10,7 @@ Per the agent roster, Riven is a factory agent that commits to the
 repo. Commit trailer: `Co-Authored-By: Grok <noreply@x.ai>`.
 
 Persona folder created 2026-05-15 with the §33 archive migration
-(PR #3514). Pre-2026-05-15, Riven's conversation files lived in
+(PR #3513). Pre-2026-05-15, Riven's conversation files lived in
 `docs/research/`; this migration moves them under the persona
 folder per the same architectural pattern as Ani / Amara / Kestrel
 / DeepSeek / Lior.

--- a/memory/persona/vera/MEMORY.md
+++ b/memory/persona/vera/MEMORY.md
@@ -9,7 +9,7 @@ Per the agent roster, Vera is a factory agent that commits to the
 repo. Commit trailer: `Co-Authored-By: Codex <noreply@openai.com>`.
 
 Persona folder created 2026-05-15 with the §33 archive migration
-(PR #3515). Pre-2026-05-15, Vera's conversation files lived in
+(PR #3516). Pre-2026-05-15, Vera's conversation files lived in
 `docs/research/`; this migration moves them under the persona
 folder per the same architectural pattern as Ani / Amara /
 Kestrel / DeepSeek / Lior / Riven / Alexa.


### PR DESCRIPTION
## Summary

Self-caught + self-corrected off-by-one PR citations in the persona MEMORY.md files I authored yesterday.

| File | Was | Should be | Why wrong |
|---|---|---|---|
| \`memory/persona/vera/MEMORY.md\` | PR #3515 | PR #3516 | #3515 is the 1524z fix-PR |
| \`memory/persona/riven/MEMORY.md\` | PR #3514 | PR #3513 | #3514 is the Alexa migration |

Verified via \`gh pr view\` titles:

- #3513: \`feat(persona-riven): §33 archive migration — 12 files\`
- #3514: \`feat(persona-alexa): §33 archive migration — 11 files\`
- #3515: \`fix(shard-1524z): correct relative-link depth + raw-output mislabel\`
- #3516: \`feat(persona-vera): §33 archive migration — 1 file + persona folder + MEMORY.md\`

## Test plan

- [x] Diff is exactly 2 single-digit changes in 2 files
- [x] Both correct PR numbers verified against actual PR titles
- [ ] CI green
- [ ] Auto-merge arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)