### PR TITLE
shard(tick): 1749Z — post-merge sweep caught Codex P2 on PR #3513; dead-xref fix shipped

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/1749Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/1749Z.md
@@ -1,0 +1,67 @@
+# Tick 1749Z — post-merge review-thread sweep caught Codex P2 on PR #3513; dead-xref fix shipped
+
+## Headline
+
+- All 3 prior-tick PRs merged: [#3525](https://github.com/Lucent-Financial-Group/Zeta/pull/3525), [#3526](https://github.com/Lucent-Financial-Group/Zeta/pull/3526), [#3528](https://github.com/Lucent-Financial-Group/Zeta/pull/3528). Main HEAD: `33c527e`.
+- **Speculative-work catch**: while auditing post-merge review activity on my Riven §33 migration ([PR #3513](https://github.com/Lucent-Financial-Group/Zeta/pull/3513)), found an unresolved Codex P2 thread flagging dead xrefs from the migration.
+- Filed [PR #3529](https://github.com/Lucent-Financial-Group/Zeta/pull/3529) — 3-file fix updating live-navigation pointers; auto-merge armed. Codex thread replied + resolved with link to follow-up PR.
+- Cron sentinel `575d1226` live.
+
+## The Codex P2 finding
+
+> *"This migration moves documents out of `docs/research/` but does not carry the existing references with it, so active documentation now has dead links."*
+
+Specific dead links identified by Codex:
+
+| File | Line |
+|---|---|
+| `.claude/rules/refresh-before-decide.md` | 28 |
+| `docs/backlog/P1/B-0159-...md` | 17 |
+
+Searching all live navigation surfaces surfaced a third:
+
+| File | Lines |
+|---|---|
+| `memory/feedback_refresh_before_decide_invariant_two_layer_print_dx_claudeai_2026_05_01.md` | 3, 6, 253 |
+
+All three pointed at `docs/research/2026-05-01-claudeai-backlog-driven-dual-pm-loop-with-refresh-discipline.md` which is now at `memory/persona/riven/conversations/2026-05-01-claudeai-backlog-driven-dual-pm-loop-with-refresh-discipline.md`.
+
+## NOT updated (intentional)
+
+Per snapshot-at-time-of-authoring discipline:
+
+- `docs/history/pr-reviews/*` — frozen PR-review state at time of authoring
+- `docs/hygiene-history/ticks/*` — frozen tick shards
+- `docs/pr-discussions/*` — frozen PR-discussion archives
+- Sibling `docs/research/*.md` files — themselves migration candidates; their internal pointers are part of their own provenance trail
+
+This decision is documented in PR #3529's body so future-Otto reviewing the discipline can re-evaluate if needed.
+
+## Per-tick discipline trace
+
+1. **Refresh**: PR-status check → all 3 prior PRs MERGED.
+2. **Holding-discipline**: no named dependency wait → speculative work tier-1 (audit-of-prior-landings).
+3. **Pick work**: post-merge review-activity audit on my recent merged PRs.
+4. **Verify**: `rg` for the specific old path → confirmed 3 live-navigation hits + several frozen-archive hits.
+5. **Shard**: this file.
+6. **CronList**: sentinel live.
+7. **Visibility**: PR #3529 + Codex thread reply + this shard.
+
+## Substrate-honest pattern: parallel-tick audit produces real findings
+
+Across 3 consecutive ticks today (1718Z, 1731Z, 1749Z) the parallel-work-while-CI-runs discipline produced 3 substantive landings:
+
+| Tick | Speculative work | Catch |
+|---|---|---|
+| 1718Z | Survey §33 cascade state | Surfaced 78 claudeai + 16 gemini/codex residuals (held, not picked up) |
+| 1731Z | Audit own MEMORY.md authoring | 2 off-by-one PR citations → PR #3526 |
+| 1749Z | Audit post-merge reviewer findings | Codex P2 dead-xref → PR #3529 |
+
+Generalisable pattern: when CI is bounded-wait, audit yields better than silence. The discipline is recursive — each tick audits the previous tick's work.
+
+## Composes with
+
+- [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — parallel work IS the discipline
+- [`.claude/rules/blocked-green-ci-investigate-threads.md`](../../../../../../.claude/rules/blocked-green-ci-investigate-threads.md) — unresolved threads block merge; post-merge thread audits prevent silent-debt accumulation
+- [`.claude/rules/substrate-or-it-didnt-happen.md`](../../../../../../.claude/rules/substrate-or-it-didnt-happen.md) — the xref fix landed as durable substrate (PR), not just a "I noticed this" mention
+- [`.claude/rules/honor-those-that-came-before.md`](../../../../../../.claude/rules/honor-those-that-came-before.md) — preserving migration provenance via working backlinks


### PR DESCRIPTION
## Summary

Tick 1749Z. Speculative work caught real follow-up: post-merge review-thread audit on already-merged Riven §33 migration ([PR #3513](https://github.com/Lucent-Financial-Group/Zeta/pull/3513)) surfaced an unresolved Codex P2 finding flagging dead xrefs. Fix shipped as [PR #3529](https://github.com/Lucent-Financial-Group/Zeta/pull/3529).

## Test plan

- [x] Shard at canonical path
- [ ] CI green
- [ ] Auto-merge arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)