### PR TITLE
chore(b-0139): decompose F# artifact inventory into B-0329

### DIFF
--- a/docs/backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md
+++ b/docs/backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md
@@ -4,10 +4,11 @@ priority: P1
 status: in-progress
 title: Pre-substrate Kenji-era Otto-lineage work inventory — past recovery branches, worktrees, built artifacts not yet referenced in substrate
 created: 2026-05-01
-last_updated: 2026-05-08
+last_updated: 2026-05-15
 depends_on: []
+children: [B-0329]
 type: friction-reducer
-decomposition: blob
+decomposition: sliceable
 ---
 
 # B-0139 — Pre-substrate Kenji-era inventory

--- a/docs/backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md
+++ b/docs/backlog/P1/B-0139-pre-substrate-kenji-era-otto-work-inventory-aaron-2026-05-01.md
@@ -5,7 +5,7 @@ status: in-progress
 title: Pre-substrate Kenji-era Otto-lineage work inventory — past recovery branches, worktrees, built artifacts not yet referenced in substrate
 created: 2026-05-01
 last_updated: 2026-05-15
-depends_on: []
+depends_on: [B-0329]
 children: [B-0329]
 type: friction-reducer
 decomposition: sliceable

--- a/docs/backlog/P1/B-0329-kenji-era-fsharp-artifact-inventory-2026-05-15.md
+++ b/docs/backlog/P1/B-0329-kenji-era-fsharp-artifact-inventory-2026-05-15.md
@@ -5,6 +5,7 @@ status: open
 title: Kenji-era F# src/Core/ artifact inventory (decomposition of B-0139)
 created: 2026-05-15
 last_updated: 2026-05-15
+parent: B-0139
 depends_on: []
 decomposition: atomic
 type: friction-reducer

--- a/docs/backlog/P1/B-0329-kenji-era-fsharp-artifact-inventory-2026-05-15.md
+++ b/docs/backlog/P1/B-0329-kenji-era-fsharp-artifact-inventory-2026-05-15.md
@@ -1,0 +1,26 @@
+---
+id: B-0329
+priority: P1
+status: open
+title: Kenji-era F# src/Core/ artifact inventory (decomposition of B-0139)
+created: 2026-05-15
+last_updated: 2026-05-15
+depends_on: []
+decomposition: atomic
+type: friction-reducer
+---
+
+# B-0329 — Kenji-era F# src/Core/ artifact inventory
+
+**Origin:** Decomposed from blob row B-0139 (Pre-substrate Kenji-era Otto-lineage work inventory).
+
+## What
+Inventory of Kenji-era work in the `src/Core/` codebase (F# implementation) that is not yet referenced in substrate memory files. This is one slice of the broader B-0139 inventory effort.
+
+## Acceptance criteria
+1. Produce a built-artifact inventory of Kenji-era F# work in `src/Core/`.
+2. Cross-reference each artifact against existing substrate references.
+3. Identify unreferenced artifacts for future MEMORY.md backfill.
+
+## Effort
+S (small, under a day)


### PR DESCRIPTION
Backlog decomposition: peeled off the F# src/Core/ artifact inventory slice from blob row B-0139 into a new atomic row B-0329.