### PR TITLE
fix(memory): correct Vera drift attribution Otto → Lior

### DIFF
--- a/memory/persona/vera/MEMORY.md
+++ b/memory/persona/vera/MEMORY.md
@@ -21,7 +21,7 @@ Kestrel / DeepSeek / Lior / Riven / Alexa.
 Migrated 2026-05-15. Currently only 1 Vera-specific file
 (`2026-05-10-shadow-lesson-log-vera-narration.md` — a shadow
 lesson log documenting Vera's narration-over-action drift
-pattern caught by Otto).
+pattern caught by Lior on the antigravity-check node).
 
 A second relevant shadow log (`2026-05-14-shadow-lesson-log-vera-riven-drift.md`)
 covers a JOINT Vera+Riven drift episode; that file lives under


### PR DESCRIPTION
## Summary

Copilot caught a real attribution bug on the already-merged PR [#3516](https://github.com/Lucent-Financial-Group/Zeta/pull/3516) (Vera §33 migration).

The archived lesson log at \`memory/persona/vera/conversations/2026-05-10-shadow-lesson-log-vera-narration.md\` says:

- **Author:** Lior (Antigravity check node)
- \"Lior detected the drift.\"

But \`memory/persona/vera/MEMORY.md\` said \"drift pattern caught by Otto\" — contradictory provenance preserved across the migration.

Fix: \"caught by Otto\" → \"caught by Lior on the antigravity-check node\". Single-character-equivalent change in 1 file; aligns the persona index with the archive content + clarifies Lior's antigravity-check responsibility.

## Test plan

- [x] Diff is 1 file, 1 logical change
- [x] Aligns with archive content (verified via \`git show\`)
- [ ] CI green
- [ ] Auto-merge arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)