### PR TITLE
docs(rules): otto-channels — symptom→fix mapping for stale `origin/main` ref wedge

### DIFF
--- a/.claude/rules/otto-channels-reference-card.md
+++ b/.claude/rules/otto-channels-reference-card.md
@@ -68,6 +68,19 @@ on-disk state:
      | awk '{print $4}' | grep -oE "B-[0-9]+" | sort -u -t- -k2 -n | tail -5
    ```
 
+   **Symptom → fix mapping** (recorded 2026-05-15 after recurring
+   multi-Otto contention this session): if `git fetch origin main`
+   prints `! <oldsha>..<newsha>  main  -> origin/main  (unable to
+   update local ref)`, the local remote-tracking ref didn't update
+   even though `FETCH_HEAD` did. Switch to `git fetch origin` (no
+   branch arg) — the all-refs form acquires whatever ref-lock is
+   held differently and reliably updates `refs/remotes/origin/main`.
+   If branch creation is urgent and the fetch is still wedged,
+   `git switch -c <new-branch> FETCH_HEAD` bypasses the stale
+   `origin/main` ref entirely. Empirical anchors: ticks 1632Z + 1719Z
+   + 1737Z hit the wedge; tick 1752Z's `git fetch origin` (no arg)
+   cleared it on first call (`33c527e..ae5dc2e main -> origin/main`).
+
    **Important**: do NOT use `find docs/backlog -name "B-*.md"` on the local
    worktree. The local working tree may be on a stale HEAD (detached from
    an abandoned rebase, on a feature branch that's behind, etc.), which


### PR DESCRIPTION
## Summary

Adds a "Symptom → fix mapping" paragraph to the existing ID-allocation discipline section of [`otto-channels-reference-card.md`](../tree/feat/rule-fetch-origin-no-arg-clean-otto-cli-2026-05-15/.claude/rules/otto-channels-reference-card.md). The rule already documents that \`git fetch origin\` (no branch arg) updates remote-tracking refs reliably; this commit makes the trigger condition explicit so future-Otto can find it by searching for the error message they're seeing.

Symptom (verbatim from terminal):

```
! 33c527e..ae5dc2e  main       -> origin/main  (unable to update local ref)
```

Fix:

```bash
git fetch origin                                              # no branch arg → updates origin/main reliably
# OR if branch creation is urgent:
git switch -c <new-branch> FETCH_HEAD                         # bypass the stale origin/main ref
```

Empirical anchors (this session):

- Tick 1632Z, 1719Z, 1737Z all hit the wedge with \`git fetch origin main\`
- Tick 1752Z's \`git fetch origin\` (no arg) cleared it on first call: \`33c527e..ae5dc2e main -> origin/main\`

## Test plan

- [x] markdownlint clean on the edited rule
- [x] Branched from \`origin/main\` (verified `git diff origin/main --stat\` = 1 file, 13 insertions, 0 deletions)
- [x] Recovered cleanly from a peer-Otto-CLI worktree contention that initially landed my commit on peer's \`shard/tick-1757z\` branch — used \`git update-ref\` to repoint peer's branch back to their commit, then cherry-picked mine onto this fresh branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)