### PR TITLE
docs(rules): correct fetch-form claim — wedge is per-process not per-command-form

### DIFF
--- a/.claude/rules/otto-channels-reference-card.md
+++ b/.claude/rules/otto-channels-reference-card.md
@@ -69,17 +69,30 @@ on-disk state:
    ```
 
    **Symptom → fix mapping** (recorded 2026-05-15 after recurring
-   multi-Otto contention this session): if `git fetch origin main`
-   prints `! <oldsha>..<newsha>  main  -> origin/main  (unable to
-   update local ref)`, the local remote-tracking ref didn't update
-   even though `FETCH_HEAD` did. Switch to `git fetch origin` (no
-   branch arg) — the all-refs form acquires whatever ref-lock is
-   held differently and reliably updates `refs/remotes/origin/main`.
-   If branch creation is urgent and the fetch is still wedged,
-   `git switch -c <new-branch> FETCH_HEAD` bypasses the stale
-   `origin/main` ref entirely. Empirical anchors: ticks 1632Z + 1719Z
-   + 1737Z hit the wedge; tick 1752Z's `git fetch origin` (no arg)
-   cleared it on first call (`33c527e..ae5dc2e main -> origin/main`).
+   multi-Otto contention this session): if a fetch prints
+   `! <oldsha>..<newsha>  main  -> origin/main  (unable to update
+   local ref)`, the local remote-tracking ref didn't update even
+   though `FETCH_HEAD` did. **BOTH the branch-specific form
+   (`git fetch origin main`) AND the no-arg form (`git fetch origin`)
+   can hit this** — the wedge is per-worktree-process ref-lock
+   contention with peer Otto-CLI sessions sharing the same `.git/`
+   directory, not a property of the fetch invocation. Empirical
+   tick 1808Z: primary worktree's `git fetch origin` (no arg) hit
+   the wedge while a sidetick's `git fetch origin` succeeded
+   (`b004681..324dc84 main -> origin/main`) in the same minute.
+
+   **The ultimate workaround** is `git switch -c <new-branch>
+   FETCH_HEAD` — `FETCH_HEAD` always updates regardless of whether
+   the named remote-tracking ref does, so branch creation can
+   bypass the wedge entirely. If you need `origin/main` to actually
+   update (e.g., for `git log origin/main` queries), retry the
+   fetch from a different worktree or wait for the peer to release
+   the ref-lock — the wedge clears on its own within minutes.
+
+   Empirical anchors: ticks 1632Z + 1719Z + 1737Z + 1808Z all hit
+   the wedge with different command forms; tick 1752Z's `git fetch
+   origin` worked. The discriminator is per-process contention, not
+   command shape.
 
    **Important**: do NOT use `find docs/backlog -name "B-*.md"` on the local
    worktree. The local working tree may be on a stale HEAD (detached from


### PR DESCRIPTION
## Summary

[PR #3537](https://github.com/Lucent-Financial-Group/Zeta/pull/3537)'s just-merged claim that \`git fetch origin\` (no branch arg) "reliably updates refs/remotes/origin/main" was empirically contradicted within 4 minutes of merge.

**Tick 1808Z empirical evidence (same minute, different worktrees):**

```
primary worktree:
  git fetch origin
  ! a8424a5..b004681  main -> origin/main  (unable to update local ref)

sidetick worktree:
  git fetch origin
  b004681..324dc84  main -> origin/main  ✓
```

Same command, same \`.git/\` (shared via worktree), different outcome. The discriminator is **per-worktree-process ref-lock contention with peer Otto-CLI**, not the fetch command form.

## What changes

- Both \`git fetch origin main\` AND \`git fetch origin\` can hit the wedge under multi-Otto contention
- The reliable workaround is \`git switch -c <new-branch> FETCH_HEAD\` — \`FETCH_HEAD\` always updates regardless of which named ref is wedged, so branch creation can bypass the wedge entirely
- If \`origin/main\` itself needs to actually update (e.g., for \`git log origin/main\` queries), retry from a different worktree or wait for peer to release the ref-lock (the wedge clears on its own within minutes)
- Empirical anchors expanded to include 1808Z evidence

## Test plan

- [x] markdownlint clean on the edited rule
- [x] \`git diff origin/main --stat\` = 1 file, 24 insertions, 11 deletions
- [x] Self-correction lands within 6 minutes of the original PR's merge — substrate-honest about the empirical update

🤖 Generated with [Claude Code](https://claude.com/claude-code)