### PR TITLE
fix(rules): glass-halo-bidirectional — DeepSeek migration xref (B-0533 Slice A proof-of-concept)

### DIFF
--- a/.claude/rules/glass-halo-bidirectional.md
+++ b/.claude/rules/glass-halo-bidirectional.md
@@ -113,6 +113,6 @@ When Otto operates in glass-halo with Aaron + named-agents:
 (PR #2829 — the full memory substrate for bidirectional
 mechanism + sleeping-bear latent-substrate emergence)
 
-`docs/research/2026-05-12-deepseek-aurora-wwjd-glass-halo-on-the-builder-aaron-personal-disclosure-context.md`
+`memory/persona/deepseek/conversations/2026-05-12-deepseek-aurora-wwjd-glass-halo-on-the-builder-aaron-personal-disclosure-context.md`
 (PR #2824 — DeepSeek's verbatim response naming glass-halo-
-on-the-builder as alignment-work precondition)
+on-the-builder as alignment-work precondition; archive migrated 2026-05-15 via PR #3507)


### PR DESCRIPTION
## Summary

First instance of [B-0533](https://github.com/Lucent-Financial-Group/Zeta/pull/3540) Slice A — per-persona PR batches updating dead xrefs to migrated §33 files.

DeepSeek's archive was migrated via [PR #3507](https://github.com/Lucent-Financial-Group/Zeta/pull/3507) to \`memory/persona/deepseek/conversations/\`; \`.claude/rules/glass-halo-bidirectional.md\` still cited the pre-migration \`docs/research/\` path.

## Why single-file proof-of-concept

Smallest viable batch to establish the pattern + the inline annotation convention. The rest of DeepSeek (4 more files, 6 line-edits) defers to follow-up PRs — keeps blast radius minimal + reviewable.

## Annotation convention established

\`memory/persona/<persona>/conversations/<filename>\` + inline note: \`(... ; archive migrated YYYY-MM-DD via PR #NNNN)\`

This preserves migration provenance at the citation site, not just in git log.

## Test plan

- [x] Diff is 1 file, 1 logical change
- [x] Path verified: file exists at new location on origin/main
- [ ] CI green
- [ ] Auto-merge arms

## Branch name note

Branch was named \`fix/b0533-slice-a-lior-dead-xrefs\` based on initial plan (Lior, 2 dead xrefs) but turned out Lior had 0 real dead xrefs in live-nav surfaces — my earlier rough scan was less precise. Pivoted to DeepSeek single-file POC mid-tick. Branch name preserved for trace continuity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)