### PR TITLE
feat(B-0533): Slice B.1 — §33 migration dead-xref scanner

### DIFF
--- a/tools/hygiene/audit-section-33-migration-xrefs.ts
+++ b/tools/hygiene/audit-section-33-migration-xrefs.ts
@@ -1,0 +1,284 @@
+#!/usr/bin/env bun
+// audit-section-33-migration-xrefs.ts — detect dead xrefs to migrated archive files
+//
+// B-0533 Slice B.1 scanner. Mechanizes the dead-xref class Codex P2 caught on
+// PR #3513 (Riven section-33 archive migration). The migration pattern moves
+// files from docs/research/<basename> to memory/persona/<persona>/conversations/<basename>
+// but does not auto-update backlinks. Live-nav surfaces (rules, backlog rows,
+// memory feedback files) accumulate dead xrefs silently.
+//
+// This script walks live-nav surfaces and, for each docs/research/<basename>
+// reference, checks whether <basename> has been migrated. If migrated, reports
+// a stale-xref candidate with the canonical new path.
+//
+// Scope (Slice B.1 — detect-only scanner):
+//
+//   - Walks .claude/rules/, .claude/agents/, .claude/commands/, .claude/skills/
+//   - Walks memory/*.md (top-level memory files; NOT persona folders — those
+//     are migrated archives + may carry their own provenance trail)
+//   - Walks docs/backlog/
+//   - Walks repo-root *.md (CLAUDE.md, AGENTS.md, README.md, etc.)
+//
+// Out of scope (excluded surfaces — frozen historical archives):
+//
+//   - docs/history/pr-reviews/** (frozen PR-review snapshots)
+//   - docs/hygiene-history/ticks/** (frozen tick shards)
+//   - docs/pr-discussions/** (frozen PR-discussion archives)
+//   - docs/research/** (sibling migration candidates; internal xrefs are provenance trail)
+//   - memory/persona/**/conversations/** (migrated archives — internal xrefs are provenance trail)
+//   - references/upstreams/** (other people's code; gitignored)
+//
+// Usage:
+//
+//   bun tools/hygiene/audit-section-33-migration-xrefs.ts                # detect-only
+//   bun tools/hygiene/audit-section-33-migration-xrefs.ts --report PATH  # write markdown report
+//
+// Exit codes:
+//
+//   0   always (detect-only; humans triage candidates before fixing)
+//   64  argument error
+//
+// Composes with: audit-rule-cross-refs.ts (template), B-0532 (sibling lint pattern),
+// B-0533 (parent row).
+
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const PERSONA_BASE = "memory/persona";
+const LIVE_NAV_SURFACES = [".claude/rules", ".claude/agents", ".claude/commands", ".claude/skills", "memory", "docs/backlog"];
+const ROOT_MD = ["CLAUDE.md", "AGENTS.md", "README.md", "GOVERNANCE.md"];
+
+type AuditExitCode = 0 | 64;
+
+interface Args {
+    readonly report: string | null;
+}
+
+interface DeadXref {
+    readonly fromFile: string;
+    readonly lineNumber: number;
+    readonly basename: string;
+    readonly persona: string;
+    readonly newPath: string;
+    readonly line: string;
+}
+
+interface AuditResult {
+    readonly migratedFilesIndexed: number;
+    readonly surfacesScanned: number;
+    readonly deadXrefs: DeadXref[];
+}
+
+function parseArgs(argv: string[]): { kind: "args"; args: Args } | { kind: "error"; message: string } {
+    let report: string | null = null;
+    let i = 0;
+    while (i < argv.length) {
+        const a = argv[i]!;
+        if (a === "--report") {
+            const next = argv[i + 1];
+            if (!next) return { kind: "error", message: "--report requires a path" };
+            report = next;
+            i += 2;
+        } else {
+            return { kind: "error", message: `Unknown argument: ${a}` };
+        }
+    }
+    return { kind: "args", args: { report } };
+}
+
+// Build basename to persona index by walking memory/persona/*/conversations/
+function indexMigratedFiles(base: string): Map<string, string> {
+    const index = new Map<string, string>();
+    if (!existsSync(base)) return index;
+    const personas = readdirSync(base).filter((p) => {
+        const full = join(base, p);
+        return existsSync(full) && statSync(full).isDirectory();
+    });
+    for (const persona of personas) {
+        const conversationsDir = join(base, persona, "conversations");
+        if (!existsSync(conversationsDir) || !statSync(conversationsDir).isDirectory()) continue;
+        for (const f of readdirSync(conversationsDir)) {
+            if (!f.endsWith(".md")) continue;
+            index.set(f, persona);
+        }
+    }
+    return index;
+}
+
+// Walk a directory recursively, returning .md file paths
+function walkMd(dir: string): string[] {
+    if (!existsSync(dir) || !statSync(dir).isDirectory()) return [];
+    const results: string[] = [];
+    const entries = readdirSync(dir);
+    for (const entry of entries) {
+        const full = join(dir, entry);
+        let st;
+        try {
+            st = statSync(full);
+        } catch {
+            continue;
+        }
+        if (st.isDirectory()) {
+            results.push(...walkMd(full));
+        } else if (st.isFile() && entry.endsWith(".md")) {
+            results.push(full);
+        }
+    }
+    return results;
+}
+
+function collectLiveNavFiles(): string[] {
+    const files: string[] = [];
+
+    for (const subdir of LIVE_NAV_SURFACES) {
+        if (subdir === "memory") {
+            // memory/ — top-level only; explicitly exclude persona/ (migrated archives)
+            if (!existsSync(subdir)) continue;
+            for (const entry of readdirSync(subdir)) {
+                if (entry === "persona") continue;
+                const full = join(subdir, entry);
+                let st;
+                try {
+                    st = statSync(full);
+                } catch {
+                    continue;
+                }
+                if (st.isFile() && entry.endsWith(".md")) {
+                    files.push(full);
+                }
+            }
+        } else if (subdir === "docs/backlog") {
+            files.push(...walkMd(subdir));
+        } else {
+            // .claude/rules, .claude/agents, .claude/commands, .claude/skills
+            files.push(...walkMd(subdir));
+        }
+    }
+
+    // Root .md files
+    for (const f of ROOT_MD) {
+        if (existsSync(f)) files.push(f);
+    }
+
+    return files.sort();
+}
+
+// Find docs/research/<basename> references in a file, where <basename> is
+// a key in the migrated index. Returns lines with their 1-indexed line numbers.
+function findDeadXrefs(filePath: string, migratedIndex: Map<string, string>): DeadXref[] {
+    const content = readFileSync(filePath, "utf8");
+    const lines = content.split("\n");
+    const found: DeadXref[] = [];
+
+    // Match docs/research/<basename> where basename ends in .md
+    const pattern = /docs\/research\/([^\s`)"'<>\[\]]+\.md)/g;
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]!;
+        pattern.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = pattern.exec(line)) !== null) {
+            const basename = m[1]!;
+            const persona = migratedIndex.get(basename);
+            if (persona !== undefined) {
+                found.push({
+                    fromFile: filePath,
+                    lineNumber: i + 1,
+                    basename,
+                    persona,
+                    newPath: `memory/persona/${persona}/conversations/${basename}`,
+                    line: line.trim().slice(0, 200),
+                });
+            }
+        }
+    }
+    return found;
+}
+
+function audit(): AuditResult {
+    const migratedIndex = indexMigratedFiles(PERSONA_BASE);
+    const liveNavFiles = collectLiveNavFiles();
+    const deadXrefs: DeadXref[] = [];
+    for (const f of liveNavFiles) {
+        deadXrefs.push(...findDeadXrefs(f, migratedIndex));
+    }
+    return {
+        migratedFilesIndexed: migratedIndex.size,
+        surfacesScanned: liveNavFiles.length,
+        deadXrefs,
+    };
+}
+
+function renderReport(result: AuditResult, now: Date): string {
+    const lines: string[] = [];
+    lines.push("# Section-33 migration dead-xref audit");
+    lines.push("");
+    lines.push(`Generated: ${now.toISOString()}`);
+    lines.push("");
+    lines.push("## Summary");
+    lines.push("");
+    lines.push(`- Migrated files indexed: ${result.migratedFilesIndexed}`);
+    lines.push(`- Live-nav .md files scanned: ${result.surfacesScanned}`);
+    lines.push(`- Dead xrefs found: ${result.deadXrefs.length}`);
+    lines.push("");
+
+    if (result.deadXrefs.length === 0) {
+        lines.push("_No dead xrefs found._");
+        lines.push("");
+        return lines.join("\n");
+    }
+
+    // Group by persona
+    const byPersona = new Map<string, DeadXref[]>();
+    for (const xref of result.deadXrefs) {
+        const list = byPersona.get(xref.persona) ?? [];
+        list.push(xref);
+        byPersona.set(xref.persona, list);
+    }
+
+    lines.push("## By persona");
+    lines.push("");
+    lines.push("| Persona | Dead xrefs |");
+    lines.push("|---|---|");
+    for (const [persona, xrefs] of [...byPersona.entries()].sort()) {
+        lines.push(`| ${persona} | ${xrefs.length} |`);
+    }
+    lines.push("");
+
+    lines.push("## Detail");
+    lines.push("");
+    for (const [persona, xrefs] of [...byPersona.entries()].sort()) {
+        lines.push(`### ${persona}`);
+        lines.push("");
+        for (const x of xrefs) {
+            lines.push(`- \`${relative(".", x.fromFile)}:${x.lineNumber}\` -> \`docs/research/${x.basename}\` (should be \`${x.newPath}\`)`);
+        }
+        lines.push("");
+    }
+    return lines.join("\n");
+}
+
+function main(argv: string[]): AuditExitCode {
+    const parsed = parseArgs(argv);
+    if (parsed.kind === "error") {
+        console.error(`error: ${parsed.message}`);
+        return 64;
+    }
+
+    const result = audit();
+    const report = renderReport(result, new Date());
+
+    if (parsed.args.report) {
+        writeFileSync(parsed.args.report, report);
+        console.log(`wrote ${parsed.args.report}`);
+    } else {
+        console.log(report);
+    }
+
+    return 0;
+}
+
+if (import.meta.main) {
+    process.exit(main(process.argv.slice(2)));
+}
+
+export { audit, collectLiveNavFiles, findDeadXrefs, indexMigratedFiles, renderReport };


### PR DESCRIPTION
## Summary

[B-0533](docs/backlog/P3/B-0533-section33-migration-dead-xref-sweep-and-lint-2026-05-15.md) Slice B.1. Mechanizes the dead-xref class Codex P2 caught on [PR #3513](https://github.com/Lucent-Financial-Group/Zeta/pull/3513) (Riven §33 archive migration).

## Empirical baseline (first run on \`origin/main\`)

\`\`\`
- Migrated files indexed: 147
- Live-nav .md files scanned: 2196
- Dead xrefs found: 10
\`\`\`

| Persona | Dead xrefs |
|---|---|
| deepseek | 9 |
| riven | 1 (PR #3529 fixed line 17, missed line 135 of B-0159) |

Substrate-honest correction to [B-0533](docs/backlog/P3/B-0533-section33-migration-dead-xref-sweep-and-lint-2026-05-15.md): the row's rough estimate of \"20+\" was a false positive from sloppy grep parsing. Real count is **10** (9 + 1).

## Scope (Slice B.1)

- **Detect-only**: exit 0 always; humans triage candidates before fixing
- **Walks**: \`.claude/{rules,agents,commands,skills}/\`, \`memory/*.md\` (top-level only; \`persona/\` excluded), \`docs/backlog/\`, repo-root \`*.md\`
- **Skips**: frozen historical archives (\`docs/history\`, \`docs/hygiene-history\`, \`docs/pr-discussions\`, \`docs/research\` itself, \`memory/persona/**/conversations/\`)

## Follow-up slices (separate PRs)

- **Slice B.2**: test file (DST-friendly fixtures)
- **Slice B.3**: wire into \`.github/workflows/gate.yml\` as warn-only
- **Slice B.4**: promote to error after baseline cleanup

## Test plan

- [x] \`bun tools/hygiene/audit-section-33-migration-xrefs.ts\` runs locally, returns exit 0
- [x] Output is structured markdown with by-persona table + detail
- [x] Real findings verified (line 135 of B-0159 surfaced — PR #3529's manual sweep missed it)
- [ ] CI green (lint passes, no warnings)
- [ ] Auto-merge arms

## Composes with

- \`tools/hygiene/audit-rule-cross-refs.ts\` (template)
- [B-0532](docs/backlog/P3/B-0532-backlog-graph-consistency-lint-parent-child-status-mismatch-2026-05-15.md) (sibling lint pattern)
- [B-0533](docs/backlog/P3/B-0533-section33-migration-dead-xref-sweep-and-lint-2026-05-15.md) (parent row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)