### PR TITLE
shard(tick): 1833Z — B-0533 Slice B.1 scanner shipped; substrate-honest correction (10 dead xrefs, not 20+)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/1833Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/1833Z.md
@@ -1,0 +1,76 @@
+# Tick 1833Z — B-0533 Slice B.1 scanner shipped; substrate-honest correction (10 dead xrefs, not 20+)
+
+## Headline
+
+- [PR #3546](https://github.com/Lucent-Financial-Group/Zeta/pull/3546) (1820Z shard) MERGED.
+- [PR #3548](https://github.com/Lucent-Financial-Group/Zeta/pull/3548) — **B-0533 Slice B.1**: §33 migration dead-xref scanner (`tools/hygiene/audit-section-33-migration-xrefs.ts`, 284 LOC). Detect-only, structured markdown output. Auto-merge armed (MERGEABLE).
+- **Substrate-honest correction**: scanner produced empirical baseline of **10 dead xrefs** (9 DeepSeek + 1 Riven), not the 20+ from my 1807Z rough scan. My earlier estimate was a false positive from sloppy grep parsing of `docs/research/*lior*` pattern (literal match, not a real file ref). B-0533 row needs updating; deferring to a follow-up.
+- Real finding the scanner surfaced beyond the manual sweep: **B-0159:135 still has the dead xref that PR #3529 missed** (PR #3529 fixed line 17 but not line 135 — same file referenced twice).
+- Cron sentinel `575d1226` live.
+
+## The scanner
+
+`tools/hygiene/audit-section-33-migration-xrefs.ts`:
+
+- Follows the `audit-rule-cross-refs.ts` template
+- Indexes `memory/persona/*/conversations/` for migrated basenames (147 files indexed in first run)
+- Walks live-nav surfaces (147 entries × 2196 .md files scanned)
+- Pattern: `docs/research/<basename>.md` where basename is in the migrated index
+- Output: by-persona summary + detail (filepath:line) + suggested new path
+- Exit 0 always (detect-only initially; Slice B.4 will promote to error)
+
+## Empirical baseline (first run)
+
+```
+Migrated files indexed: 147
+Live-nav .md files scanned: 2196
+Dead xrefs found: 10
+
+deepseek: 9
+riven: 1
+```
+
+## Decomposition for B-0533 Slice B
+
+This tick covers B.1. Remaining slices (decomposed from B-0533's original "two-slice" framing):
+
+| Sub-slice | Scope | Status |
+|---|---|---|
+| B.1 | Scanner script | **This tick** (PR #3548) |
+| B.2 | Test file (DST fixtures) | Pending |
+| B.3 | Wire into `gate.yml` as warn-only | Pending |
+| B.4 | Promote to error after baseline cleanup | Pending |
+| Slice A (sweep) | Per-persona dead-xref fixes | DeepSeek POC merged (PR #3544); 9 more to go |
+
+The decomposition could be reflected as B-0535/6/7/8 children if the row gets re-decomposed, OR tracked inline on B-0533 as sub-checklist. Deferring the row update to a follow-up.
+
+## Per-tick discipline trace
+
+1. **Refresh**: PR #3546 confirmed MERGED.
+2. **Holding-discipline**: no named-dep wait → speculative work, highest-leverage = mechanization.
+3. **Pick work**: B-0533 Slice B.1 scanner (template available, well-scoped).
+4. **Verify**: ran scanner; output matches stricter manual scan (10 hits); surfaced 1 new finding PR #3529 missed.
+5. **Shard**: this file.
+6. **CronList**: sentinel live.
+7. **Visibility**: PR #3548 + this shard.
+
+## 7-tick parallel-substantive pattern
+
+| Tick | Substantive landing | Notable |
+|---|---|---|
+| 1718Z | Cron re-arm + §33 cascade survey shard | Re-armed catch-43 sentinel |
+| 1731Z | 2 MEMORY.md off-by-one fixes (PR #3526) | Self-audit caught own bugs |
+| 1749Z | Codex P2 xref fix (PR #3529) | Post-merge thread audit |
+| 1757Z | Vera attribution Otto→Lior (PR #3535) + 3 threads resolved | Substantive thread replies |
+| 1807Z | B-0533 backlog row (PR #3540) | Class-level pattern captured |
+| 1820Z | B-0533 Slice A POC (PR #3544) | Inline annotation convention |
+| **1833Z** | **B-0533 Slice B.1 scanner (PR #3548)** | **Mechanization shipped** |
+
+Mechanization = catch-once-then-lint pattern operating at substrate-architecture scope. The §33 dead-xref class is now machine-detectable; future-migration dead-xrefs surface at PR-time once gate.yml wiring lands (Slice B.3).
+
+## Composes with
+
+- [`.claude/rules/encoding-rules-without-mechanizing.md`](../../../../../../.claude/rules/encoding-rules-without-mechanizing.md) — mechanization is the discipline-substrate transition
+- [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — speculative work compounds across multi-tick spans
+- [B-0532](../../../../../backlog/P3/B-0532-backlog-graph-consistency-lint-parent-child-status-mismatch-2026-05-15.md) — sibling lint mechanization pattern
+- `tools/hygiene/audit-rule-cross-refs.ts` — template (handles backlog-ID + brace-glob + cross-rule refs); the §33 scanner uses simpler logic (just file-basename lookup)


### PR DESCRIPTION
## Summary

Tick 1833Z. B-0533 Slice B.1 scanner shipped as [PR #3548](https://github.com/Lucent-Financial-Group/Zeta/pull/3548). Empirical baseline: 10 dead xrefs (9 DeepSeek + 1 Riven). My 1807Z rough scan estimate of \"20+\" was false-positive — substrate-honest correction recorded.

Scanner caught a real finding the manual sweep missed: \`docs/backlog/P1/B-0159-...md:135\` still has the dead xref that [PR #3529](https://github.com/Lucent-Financial-Group/Zeta/pull/3529) only fixed at line 17.

## Test plan

- [x] Shard at canonical path
- [ ] CI green
- [ ] Auto-merge arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)