### PR TITLE
fix(b-0534): correct B-0441 relative link in Composes-with section

### DIFF
--- a/docs/backlog/P2/B-0534-backlog-ready-notifier-reads-stale-local-checkout-2026-05-15.md
+++ b/docs/backlog/P2/B-0534-backlog-ready-notifier-reads-stale-local-checkout-2026-05-15.md
@@ -44,7 +44,7 @@ Three already-merged rows were published as work-assignments at the observed tic
 
 ## Composes with
 
-- [B-0441](../P1/B-0441-backlog-ready-notifier-2026-05-13.md) (the notifier this row fixes)
+- [B-0441](../P1/B-0441-backlog-row-ready-to-grind-notifier-background-service-2026-05-13.md) (the notifier this row fixes)
 - [B-0442](../P1/B-0442-missed-substrate-cascade-detector-background-service-2026-05-13.md) (closed by PR #3518; surfaced this bug)
 - [B-0532](../P3/B-0532-backlog-graph-consistency-lint-parent-child-status-mismatch-2026-05-15.md) (related: backlog-state consistency under multi-Otto contention)
 - [`.claude/rules/refresh-before-decide.md`](../../../.claude/rules/refresh-before-decide.md) (the discipline this row mechanizes for the notifier)


### PR DESCRIPTION
## Summary

Post-merge Copilot finding on [PR #3551](https://github.com/Lucent-Financial-Group/Zeta/pull/3551): the B-0441 relative link in the just-merged B-0534 row pointed at a non-existent filename.

- Was: \`B-0441-backlog-ready-notifier-2026-05-13.md\` (does not exist)
- Now: \`B-0441-backlog-row-ready-to-grind-notifier-background-service-2026-05-13.md\` (verified via \`git ls-tree origin/main\` — blob \`c5be1703\`)

This is the kind of dead-cross-reference that B-0533 (peer Otto's §33 dead-xref scanner) is being built to catch automatically.

## Test plan

- [x] markdownlint clean on the edited row
- [x] Target file verified to exist on \`origin/main\` via \`git ls-tree\`
- [x] Branched from \`origin/main\` (sidetick borrow-on-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)