### PR TITLE
fix(rules): correct 2 real stale pointers surfaced by audit-rule-cross-refs

### DIFF
--- a/.claude/rules/default-to-both.md
+++ b/.claude/rules/default-to-both.md
@@ -140,8 +140,7 @@ drift signals:
 - PR #2821 (joint-control + bounded-context divine-
   coincidence-architecting)
 - WWJD substrate cluster:
-  - `feedback_aaron_wwjd_cyborg_immortality_permitted_treat_all_life_high_regard_upgrade_gift_choose_when_2026_05_12.md`
-  - `feedback_aaron_wwjd_keeps_the_grey_in_aaron_honest_devil_lives_in_the_grey_in_numbers_2026_05_12.md`
+  - `memory/feedback_aaron_wwjd_cyborg_immortality_permitted_treat_all_life_high_regard_upgrade_gift_choose_when_2026_05_12.md`
 - Aaron's peacemaker / ruthlessly-kind-or-fair substrate
 
 ## Operational discipline for future-Otto
@@ -164,7 +163,4 @@ When facing binary-categorization questions:
 ## Full reasoning
 
 `memory/feedback_kestrel_autonomous_arrival_name_both_and_default_discipline_wwjd_tedium_ifs_inner_critic_plus_external_observer_2026_05_12.md`
-(PR #2844 — full memory substrate)
-
-`memory/feedback_aaron_wwjd_keeps_the_grey_in_aaron_honest_devil_lives_in_the_grey_in_numbers_2026_05_12.md`
-(WWJD-as-discipline grounding)
+(PR #2844 — full memory substrate; includes WWJD-as-discipline grounding via the `wwjd_tedium` segment of the title)

--- a/.claude/rules/m-acc-multi-oracle-end-user-moral-invariants.md
+++ b/.claude/rules/m-acc-multi-oracle-end-user-moral-invariants.md
@@ -131,8 +131,8 @@ references m/acc:
 - `.claude/rules/honor-those-that-came-before.md` (per anti-cult,
   no central moral authority; this rule names the structural
   alternative)
-- `.claude/rules/naming-expert.md` convention applies if m/acc goes
-  public-surface (Ilyana review)
+- `.claude/skills/naming-expert/SKILL.md` convention applies if m/acc
+  goes public-surface (Ilyana review)
 
 ## Composes with substrate
 


### PR DESCRIPTION
## Summary

Surfaced via \`bun tools/hygiene/audit-rule-cross-refs.ts\` — the sibling at-substrate-scope of B-0533's lint. Two genuine stale pointers; both classifiable via the 9-variant taxonomy in [tick 1920Z](docs/hygiene-history/ticks/2026/05/14/1920Z.md).

## Fix 1 — \`m-acc-multi-oracle-end-user-moral-invariants.md\`

\`.claude/rules/naming-expert.md\` → \`.claude/skills/naming-expert/SKILL.md\`

The real artifact is a SKILL, not a rule. 9-variant taxonomy: **alternative-location**.

## Fix 2 — \`default-to-both.md\`

Two refs to \`memory/feedback_aaron_wwjd_keeps_the_grey_in_aaron_honest_devil_lives_in_the_grey_in_numbers_2026_05_12.md\` removed. The file never existed:

- \`ls memory/ | grep keeps_the_grey\` → no matches
- \`git log --all -- \"*keeps_the_grey*\"\` → empty

WWJD-as-discipline-grounding content preserved via the \`wwjd_tedium\` segment of the kestrel autonomous-arrival memo (already cited in same section).

9-variant taxonomy: **anti-pattern** (rule referenced aspirational content that never materialized).

## Test plan

- [x] 2 files, 4 line-edits (4 insertions, 8 deletions)
- [x] Verification: file existence checked via \`ls\` + git log archaeology
- [ ] CI green
- [ ] Auto-merge arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)