### PR TITLE
feat(B-0535): wire backlog ID-uniqueness lint to gate.yml

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -764,6 +764,32 @@ jobs:
       - name: Run audit-section-33-migration-xrefs (--enforce)
         run: bun tools/hygiene/audit-section-33-migration-xrefs.ts --enforce
 
+  lint-backlog-id-uniqueness:
+    # Fail if any B-NNNN ID is claimed by more than one backlog row file.
+    # Cross-agent ID-allocation collisions (Otto-CLI vs Otto-Desktop on
+    # B-0444 2026-05-13; Lior vs Otto-CLI on B-0532+B-0533 2026-05-15) cost
+    # ~15 min coordination effort each at observed ~20% rate. The
+    # duplicate-ID detection logic was added to audit-backlog-items.ts
+    # 2026-05-14 (PR #3249, Copilot caught two files claiming B-0329 on
+    # PR #3247) but ran detect-only — this job is the CI gate that turns
+    # codified-but-not-enforced into a control.
+    #
+    # B-0535 — sibling of lint-section-33-migration-xrefs + lint-archive-
+    # header-section33: catch-once-then-lint pattern at ID-allocation scope.
+    name: lint (backlog ID uniqueness)
+    timeout-minutes: 2
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        run: ./tools/setup/install.sh
+
+      - name: Run audit-backlog-items (--enforce-duplicate-ids)
+        run: bun tools/hygiene/audit-backlog-items.ts --enforce-duplicate-ids
+
   lint-no-empty-dirs:
     # Fail if a committed directory has no files — almost always a
     # forgotten artefact (an agent-created skill folder without a

--- a/tools/hygiene/audit-backlog-items.ts
+++ b/tools/hygiene/audit-backlog-items.ts
@@ -34,11 +34,14 @@
 //      PR #3247; PR #3249 added this audit class).
 //
 // Usage:
-//   bun tools/hygiene/audit-backlog-items.ts
+//   bun tools/hygiene/audit-backlog-items.ts                       # detect-only
+//   bun tools/hygiene/audit-backlog-items.ts --enforce-duplicate-ids
+//       # exit non-zero on duplicate-ID groups (B-0535 CI gate)
 //
 // Exit codes:
-//   0 -- survey ran (findings reported in body)
-//   1 -- fatal invocation error (e.g., backlog dir missing)
+//   0 -- survey ran (findings reported in body); detect-only mode
+//   1 -- fatal invocation error (e.g., backlog dir missing) OR
+//        duplicate-ID groups found AND --enforce-duplicate-ids set
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -601,6 +604,15 @@ async function main(): Promise<number> {
     return 1;
   }
 
+  const argv = process.argv.slice(2);
+  const enforceDuplicateIds = argv.includes("--enforce-duplicate-ids");
+  for (const arg of argv) {
+    if (arg !== "--enforce-duplicate-ids") {
+      process.stderr.write(`error: unknown argument: ${arg}\n`);
+      return 1;
+    }
+  }
+
   const today = nowIso();
   const nowEpoch = Math.floor(Date.now() / 1000);
 
@@ -651,6 +663,13 @@ async function main(): Promise<number> {
     "  memory/feedback_decision_graph_emergent_from_archaeologies_and_flywheel_aaron_2026_05_03.md",
   );
   console.log("  (typed-edge backlog graph).");
+
+  if (enforceDuplicateIds && duplicateIdGroups > 0) {
+    process.stderr.write(
+      `\nerror: ${duplicateIdGroups} duplicate-ID group(s) found; --enforce-duplicate-ids set (B-0535 gate)\n`,
+    );
+    return 1;
+  }
 
   return 0;
 }


### PR DESCRIPTION
## Summary

Substrate-honest correction to [B-0535](docs/backlog/P3/B-0535-backlog-id-uniqueness-lint-extension-of-b0532-2026-05-15.md)'s original framing: the duplicate-ID detection logic ALREADY EXISTS in \`audit-backlog-items.ts\` (item 8, added [PR #3249](https://github.com/Lucent-Financial-Group/Zeta/pull/3249) 2026-05-14). The actual gap was CI wiring, not implementation.

## Changes

| File | Change |
|---|---|
| \`tools/hygiene/audit-backlog-items.ts\` | Add \`--enforce-duplicate-ids\` CLI flag; exit 1 if duplicate-ID groups > 0 |
| \`.github/workflows/gate.yml\` | Add \`lint-backlog-id-uniqueness\` job (sibling of \`lint-section-33-migration-xrefs\`) |

## Catches the empirically-observed failure class

| Collision | Date | Cost |
|---|---|---|
| B-0444 (Otto-CLI vs Otto-Desktop) | 2026-05-13 | [PR #3053](https://github.com/Lucent-Financial-Group/Zeta/pull/3053) renumber, ~15 min |
| B-0532 + B-0533 (Lior PR #3545 vs Otto-CLI) | 2026-05-15 | Ongoing review, ~15 min comment + coordination |
| B-0329 (the row that surfaced the need) | 2026-05-14 | [PR #3247](https://github.com/Lucent-Financial-Group/Zeta/pull/3247) Copilot catch + [PR #3249](https://github.com/Lucent-Financial-Group/Zeta/pull/3249) detection |

## Test plan

- [x] \`bun tools/hygiene/audit-backlog-items.ts\` runs as before (detect-only)
- [x] \`bun tools/hygiene/audit-backlog-items.ts --enforce-duplicate-ids\` exits 0 on baseline (0 groups)
- [x] Unknown flag rejected with stderr error + exit 1
- [ ] CI green (including the new \`lint (backlog ID uniqueness)\` job itself running on this PR)
- [ ] Auto-merge arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)