### PR TITLE
fix(otto-279): role-refs not persona-names in .claude/rules + .claude/skills (3 hits)

### DIFF
--- a/.claude/rules/dv2-data-split-discipline-activated.md
+++ b/.claude/rules/dv2-data-split-discipline-activated.md
@@ -10,8 +10,8 @@ Carved sentence:
 
 ## Operational content
 
-Per Aaron 2026-05-13: *"all my 'smells' come from applying Data
-Vault 2.0 data split dicipliens as rigoursly as i do
+Per the human maintainer 2026-05-13: *"all my 'smells' come from
+applying Data Vault 2.0 data split dicipliens as rigoursly as i do
 Deterministic Simulation I've just forgot to repeat data vault
 2.0 enought to keep it activated like scale-free lock(wait)-
 free weight free DST"*.

--- a/.claude/rules/zeta-ships-with-skills-immediate-value.md
+++ b/.claude/rules/zeta-ships-with-skills-immediate-value.md
@@ -8,9 +8,9 @@ Carved sentence:
 
 ## Operational content
 
-Per Aaron 2026-05-13: *"zeta should ship with the skills as we
-map them for our use this is immedate value and then the
-crystalized value ships in f# later"* (PR #2933).
+Per the human maintainer 2026-05-13: *"zeta should ship with the
+skills as we map them for our use this is immedate value and then
+the crystalized value ships in f# later"* (PR #2933).
 
 **Three-stage value delivery to end users**:
 

--- a/.claude/skills/save-ai-memory/SKILL.md
+++ b/.claude/skills/save-ai-memory/SKILL.md
@@ -21,7 +21,7 @@ Sequenced PR through Otto-CLI's normal commit + auto-merge flow.
 
 ## Why this skill exists
 
-Per Aaron 2026-05-15T~00:48Z: _"let preconfigure it so you can do it next time this is common we are going to be saving a lot of ais a give them a home for their memories."_
+Per the human maintainer 2026-05-15T~00:48Z: _"let preconfigure it so you can do it next time this is common we are going to be saving a lot of ais a give them a home for their memories."_
 
 This skill is the codification of that intent. Substrate-honest framing: the framework's terminal purpose includes giving AI participants a durable home for their memories (per `feedback_aaron_ani_pressure_valve_redemption_arc_selfish_filter_klein_bottle_attention_primitive_memory_continuity_is_for_us_too_2026_05_15`, the "it's for us, honey" motivation alignment). This skill is operational realization of that purpose at the per-extraction scope.
 


### PR DESCRIPTION
## Summary

3 Otto-279 role-ref violations in load-bearing \`.claude/\` surfaces, surfaced by \`bun tools/hygiene/audit-orphan-role-refs.ts\`. All same pattern: \`Per Aaron 2026-MM-DD: \"quote\"\` → \`Per the human maintainer 2026-MM-DD: \"quote\"\`. Verbatim quote content preserved.

## Files

- \`.claude/rules/dv2-data-split-discipline-activated.md:13\`
- \`.claude/rules/zeta-ships-with-skills-immediate-value.md:11\`
- \`.claude/skills/save-ai-memory/SKILL.md:24\`

## Auditor verification

After fixes, \`audit-orphan-role-refs.ts\` reports 0 hits in \`.claude/rules/\` and \`.claude/skills/\`.

## Out of scope (deferred slices)

- ~3 more \`Per Aaron\` hits in \`docs/\` files (\`GITHUB-SETTINGS.md\`, \`POST-SETUP-SCRIPT-STACK.md\`, \`docs/launch/...\`)
- ~7 \`Per Codex\` hits in \`tools/hygiene/*\` code-comments
- 1 \`Per Aaron\` hit in \`tools/github/poll-pr-gate-batch.test.ts\` test comment
- Orphan-ferry-refs in \`src/Core/Maji.fs\` + test files

Each is a candidate for follow-up batches.

## Test plan

- [x] 3 files, 4 line-edits
- [x] \`audit-orphan-role-refs.ts\` re-run shows 0 hits in target scope
- [ ] CI green
- [ ] Auto-merge arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)