### PR TITLE
shard(tick): 2004Z — Otto-279 role-ref discipline fixed in docs/ surfaces (3 hits)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/2004Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/2004Z.md
@@ -1,0 +1,62 @@
+# Tick 2004Z — Otto-279 role-ref discipline fixed in docs/ surfaces (3 hits)
+
+## Headline
+
+- All prior-tick PRs merged: [PR #3567](https://github.com/Lucent-Financial-Group/Zeta/pull/3567) (B-0532 hard-error slice, MERGED 19:59:31Z), [PR #3569](https://github.com/Lucent-Financial-Group/Zeta/pull/3569) (1952Z quiet shard, MERGED), [PR #3570](https://github.com/Lucent-Financial-Group/Zeta/pull/3570) (Otto-279 .claude/ batch, MERGED), [PR #3571](https://github.com/Lucent-Financial-Group/Zeta/pull/3571) (1959Z shard, MERGED).
+- [PR #3572](https://github.com/Lucent-Financial-Group/Zeta/pull/3572) — **Otto-279 docs/ batch**: 3 hits in `docs/GITHUB-SETTINGS.md`, `docs/POST-SETUP-SCRIPT-STACK.md`, `docs/launch/2026-05-13-...md`. Auto-merge armed.
+- Cron sentinel `575d1226` live.
+
+## Audit-first-then-decide pattern in action
+
+Prior tick (1959Z) established: when running an audit produces real findings, the audit IS the speculative work. This tick continues that pattern:
+
+1. Refresh state → all prior-tick PRs merged
+2. Run `audit-orphan-role-refs.ts` against current main (post-1959Z fixes)
+3. Filter live findings → 3 remaining `Per Aaron` hits in `docs/*` + 1 `orphan-ferry-ref` (different class)
+4. Pick smallest atomic batch → 3 `Per Aaron` fixes (same shape as last tick at `docs/` scope)
+
+The pattern produces durable substrate WITHOUT manufacturing-findings risk — the audit determines whether real work exists.
+
+## Coverage delta
+
+After [PR #3570](https://github.com/Lucent-Financial-Group/Zeta/pull/3570) (last tick) + this PR:
+
+| Otto-279 surface | Hits before session | Hits after this PR |
+|---|---|---|
+| `.claude/rules/` | 2 | **0** |
+| `.claude/skills/` | 1 | **0** |
+| `docs/` (live, non-history) | 3 | **0** (pending #3572 merge) |
+| `tools/hygiene/audit-*.ts` | ~7 (Per Codex) | unchanged (different batch) |
+| `tools/github/poll-pr-gate-batch.test.ts` | 1 (Per Aaron) | unchanged |
+| `src/Core/Maji.fs` + tests | multiple (orphan-ferry-ref) | unchanged |
+
+6 fixes shipped across 2 ticks. Remaining work is one of two distinct classes (Per Codex in tools/, orphan-ferry-refs in code/tests) — each its own follow-up batch.
+
+## Per-tick discipline trace
+
+1. **Refresh**: prior-tick PRs all merged.
+2. **Holding-discipline**: no named-deps → speculative work tier.
+3. **Pick work**: audit-orphan-role-refs re-run → 3 docs/ `Per Aaron` hits → atomic batch.
+4. **Verify**: scanner after fix shows 0 docs/* `Per Aaron` hits.
+5. **Shard**: this file.
+6. **CronList**: sentinel live.
+7. **Visibility**: PR #3572 + this shard.
+
+## 18-tick session arc
+
+| Phase | Ticks | Focus |
+|---|---|---|
+| B-0533 §33 discipline arc | 1718Z–1855Z | 6 PRs (catch→mechanize→gate) |
+| Stale-pointer + cross-Otto | 1907Z–1924Z | 4 PRs |
+| Backlog-graph hygiene (B-0535 + B-0532) | 1931Z–1949Z | 4 PRs (cluster shipped) |
+| Cluster-completion plateau | 1952Z | Quiet checkpoint |
+| Otto-279 role-ref discipline | 1959Z, 2004Z | 2 PRs (6 fixes) |
+
+The Otto-279 batch work is now sized at "1 surface per tick" — natural per-tick atomic scope.
+
+## Composes with
+
+- [`.claude/rules/honor-those-that-came-before.md`](../../../../../../.claude/rules/honor-those-that-came-before.md) — persona-naming discipline at heart of Otto-279
+- `tools/hygiene/audit-orphan-role-refs.ts` — detection tool driving the cleanup
+- [PR #3570](https://github.com/Lucent-Financial-Group/Zeta/pull/3570) — sibling batch (.claude/ scope) merged last tick
+- 1959Z shard — "audit FIRST, then decide" pattern established


### PR DESCRIPTION
## Summary

Tick 2004Z. Otto-279 cleanup batch #2 — 3 hits in docs/ live surfaces fixed via [PR #3572](https://github.com/Lucent-Financial-Group/Zeta/pull/3572). Same pattern as last tick's .claude/ batch. Audit-first-then-decide discipline continues.

## Test plan

- [x] Shard at canonical path
- [ ] CI green
- [ ] Auto-merge arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)