### PR TITLE
shard(tick): 2221Z — GraphQL rate-limit hit; named-dependency wait

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/2221Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/2221Z.md
@@ -1,0 +1,59 @@
+---
+tick: 2221Z
+date: 2026-05-15
+surface: otto-cli
+session: autonomous-loop cron-fire — GitHub GraphQL rate-limit hit
+---
+
+# Tick 2221Z — GraphQL rate-limit; named-dependency wait until 22:54Z
+
+## Refresh
+
+- `git fetch origin` succeeded (git-protocol, no GraphQL).
+- `bun tools/github/poll-pr-gate-batch.ts --all-open` FAILED with exit 2 on every `gh pr view`: `GraphQL: API rate limit already exceeded for user ID 578953`.
+
+## Rate-limit state
+
+`gh api rate_limit --jq '.resources.graphql'`:
+
+```json
+{"limit":5000,"remaining":0,"reset":1778885679,"used":5002}
+```
+
+Reset epoch `1778885679` = **2026-05-15T22:54Z** (33 min from this tick).
+
+## Named-dependency framing
+
+Per `holding-without-named-dependency-is-standing-by-failure.md`:
+
+- **Specific named dependency**: GitHub GraphQL rate-limit reset
+- **Bounded ETA**: 22:54Z (33 min)
+- **Authorization-source**: GitHub itself (not human-maintainer); the wait is mechanical, not consent-gated
+
+This IS a real-dependency-wait, NOT Standing-by. Substrate-honest classification.
+
+## What caused the rate-limit
+
+This tick's session has used `gh pr view` / `gh pr merge --auto` / `gh pr create` heavily across 4+ ticks (2210Z, 2214Z, 2217Z, 2220Z) plus `bun tools/github/poll-pr-gate-batch.ts --all-open` which makes ~37 `gh pr view` calls each (one per open PR). At ~37 calls × 4 polls + the cross-tick gh operations = ~150-200+ calls already, plus background substrate. Hit 5000 because Aaron's user-token is shared across all the Otto/Lior/Vera/Riven processes hitting GH in parallel.
+
+## Operational adaptation for next ticks until 22:54Z
+
+- **No `gh` queries** until ~22:55Z.
+- **Git-only operations** continue (git fetch, git push, git log, file edits).
+- **Shard writes still happen** — they're file substrate.
+- **PR-create deferred** — this shard's PR will be created in the first tick after 22:54Z; the branch is parked on origin in the meantime.
+
+## CronList check
+
+- `d97cdace` armed (cron list is local harness, not GH API).
+
+## Visibility signal
+
+Concretely landed this tick:
+
+- This shard at `docs/hygiene-history/ticks/2026/05/15/2221Z.md` on branch `shard/tick-2221z-otto-cli-2026-05-15`.
+- Rate-limit state documented; reset ETA bounded.
+- Cron heartbeat continuous.
+- PR-create deferred — branch parked.
+
+Stop.


### PR DESCRIPTION
## Summary

- `gh api rate_limit` returned `{remaining:0, used:5002}` at 22:21Z mid-cascade — named-dependency bounded ETA reset at 22:54Z.
- Cause: cumulative `gh pr view`/`gh pr merge`/`gh pr create` + 4× `poll-pr-gate-batch --all-open` (~37 calls each) + multi-agent shared-token consumption.
- Adaptation: no gh queries until reset; git-only operations + shard writes continued; PR-create deferred (this PR is the deferred-create).

## Test plan

- [x] gh rate_limit checked via `--jq '.resources.graphql.reset'`
- [x] Tick-shard committed via git-only push during rate-limit window
- [x] PR created in first post-reset tick (22:54Z)

🤖 Generated with [Claude Code](https://claude.com/claude-code)