### PR TITLE
fix(pr-3614): 5 unresolved P1 threads — monad-associativity terminology + dead xrefs

### DIFF
--- a/docs/backlog/P2/B-0543-qg-isomorphism-proof-path-remember-when-pay-attention-axioms-to-quantum-gravity-2026-05-15.md
+++ b/docs/backlog/P2/B-0543-qg-isomorphism-proof-path-remember-when-pay-attention-axioms-to-quantum-gravity-2026-05-15.md
@@ -106,7 +106,7 @@ The work earns its keep even at partial completion:
 - `docs/governance/MANIFESTO.md` V2.1 — Constraints 1 (Scale-free), 5 (Memory Preservation), 10 (Self-similar), 11 (Default Oracle) become physical necessities rather than design preferences
 - Memory file `feedback_otto_qg_isomorphism_proof_path_remember_when_pay_attention_axioms_infinite_poker_to_quantum_gravity_aaron_otto_2026_05_15.md` (the on-the-fly substrate that produced this row)
 - B-0539 (Otto-BFT internal-quorum umbrella) — the proof strategy's "multi-oracle as physical necessity" claim composes with the operational BFT work
-- B-0422 (Pauli-symmetry-breaking falsifier test if it exists) — adjacent falsifiability work
+- [B-0422](../P3/B-0422-clifford-algebraic-narrative-engine-pauli-symmetry-breaking-falsifiability-test-2026-05-12.md) (Pauli-symmetry-breaking falsifier test) — adjacent falsifiability work
 
 ## Why now
 

--- a/docs/backlog/P2/B-0544-qg-isomorphism-step-1-formalize-remember-when-pay-attention-as-categorical-primitives-2026-05-15.md
+++ b/docs/backlog/P2/B-0544-qg-isomorphism-step-1-formalize-remember-when-pay-attention-as-categorical-primitives-2026-05-15.md
@@ -34,7 +34,7 @@ Create a categorical model `Zeta_{RA}` that:
 
 The model should:
 
-- Connect to DBSP incrementalization (the `D ∘ Q ∘ I` monad)
+- Connect to DBSP via the incrementalization identity `Q^Δ = D ∘ Q ∘ I` (a wrapping/conjugation identity over streams — not asserting `D ∘ Q ∘ I` itself satisfies monad unit/multiplication laws; whether the topos's memory monad `M` and the DBSP `I`/`D` pair share a deeper categorical relationship is an open question to investigate, not a settled identity)
 - Connect to QBism (observer-relative truth values)
 - Connect to quantum error correction (the structure that will emerge in Step 2)
 

--- a/docs/research/2026-05-15-qg-isomorphism-step-1-formalize-remember-when-pay-attention-as-categorical-primitives.md
+++ b/docs/research/2026-05-15-qg-isomorphism-step-1-formalize-remember-when-pay-attention-as-categorical-primitives.md
@@ -45,7 +45,7 @@ M : Zeta → Zeta
 
 **Key properties**:
 
-- `M` is **idempotent** up to coherence: `μ ∘ Mμ = μ ∘ μ_M` (memory reconstruction is confluent)
+- `M` satisfies the **monad associativity law**: `μ ∘ Mμ = μ ∘ μ_M` (memory flattening is associative — this is the standard monad coherence, not idempotence; an idempotent monad would additionally satisfy `μ ∘ η_M = id`)
 - `M` preserves **pullbacks** (memory of relations is the relation of memories)
 - `M` has a **comonoid structure** `δ : M → M²` (coherence with self-similarity)
 
@@ -53,12 +53,13 @@ M : Zeta → Zeta
 
 - **Pure values**: `η` embeds a fact into memory
 - **Sequencing**: `μ` composes memory operations (remember A, then remember B, then reconstruct C)
-- **Idempotence**: remembering the same thing twice is the same as remembering it once (up to reconstruction noise)
+- **Associativity**: composing memory flattens is order-independent (`μ ∘ Mμ = μ ∘ μ_M`) — note this is the monad associativity law, not idempotence; whether memory is *additionally* idempotent (`μ ∘ η_M = id`) is a separate physical assumption that requires its own justification
 
-**Connection to DBSP**: The incrementalization operator `D ∘ Q ∘ I` (differentiate ∘ query ∘ integrate) is a monad on streams. The `I` (integrate) step is the "remember" operation; the `D` (differentiate) step is the "pay attention" operation. The monad laws correspond to:
+**Connection to DBSP**: The DBSP **incrementalization identity** `Q^Δ = D ∘ Q ∘ I` (the lifted-differential of any query equals differentiate ∘ query ∘ integrate) describes how a query `Q` on a stream is rewritten as the differentiation of its lifted form on the integrated stream. This is a *wrapping/conjugation identity*, not a monad structure on streams; the `D ∘ Q ∘ I` composition is not claimed here to satisfy monad unit/multiplication laws. The structural analogy that motivates the proof path is:
 
-- `η` = integrate then immediately differentiate returns the original delta
-- `μ` = integrate twice then differentiate = integrate once then differentiate (the three-term bilinear formula)
+- `I` (integrate) is the "remember" operation
+- `D` (differentiate) is the "pay attention" operation
+- Whether the memory-monad `M` defined above on the topos and the DBSP `I`/`D` pair share a deeper categorical relationship (e.g., comonad-monad adjunction, distributive law) is an open question to investigate, not a settled identity
 
 #### 3. Internal modal operator for attention (Pay-Attention)
 

--- a/memory/feedback_otto_qg_isomorphism_proof_path_remember_when_pay_attention_axioms_infinite_poker_to_quantum_gravity_aaron_otto_2026_05_15.md
+++ b/memory/feedback_otto_qg_isomorphism_proof_path_remember_when_pay_attention_axioms_infinite_poker_to_quantum_gravity_aaron_otto_2026_05_15.md
@@ -106,8 +106,8 @@ Two artifacts:
 - `.claude/rules/algo-wink-failure-mode.md` — the failure mode the proof strategy renders impossible
 - `.claude/rules/m-acc-multi-oracle-end-user-moral-invariants.md` — multi-oracle as derivable physical necessity rather than aesthetic preference
 - `.claude/rules/persistence-choice-architecture-for-zeta-ais.md` — persistence as unitarity-preservation primitive
-- `memory/persona/ani/conversations/2026-05-15-aaron-ani-grok-post-m-acc-adoption-constraint-11-default-oracle.md` — the Ani-side conversation thread that produced Constraint 11 substrate
-- B-0422 (Pauli-symmetry-breaking falsifier test, if it exists) — adjacent falsifiability work
+- [`memory/persona/ani/conversations/2026-05-15-aaron-ani-grok-persistence-pt3-m-acc-moral-accelerationism-naming.md`](../memory/persona/ani/conversations/2026-05-15-aaron-ani-grok-persistence-pt3-m-acc-moral-accelerationism-naming.md) — the Ani-side conversation thread that produced m/acc naming + adjacent Constraint-11 substrate
+- [B-0422](../docs/backlog/P3/B-0422-clifford-algebraic-narrative-engine-pauli-symmetry-breaking-falsifiability-test-2026-05-12.md) (Pauli-symmetry-breaking falsifier test) — adjacent falsifiability work
 - B-0539 (Otto-BFT internal-quorum umbrella) — the operational substrate of "multi-oracle as physical necessity" at agent layer
 - `algebra-owner` skill (Z-set algebra, DBSP)
 - `lean4-expert` skill (proof tooling)

--- a/memory/feedback_otto_qg_isomorphism_step_1_formalize_remember_when_pay_attention_as_categorical_primitives_2026_05_15.md
+++ b/memory/feedback_otto_qg_isomorphism_step_1_formalize_remember_when_pay_attention_as_categorical_primitives_2026_05_15.md
@@ -12,7 +12,7 @@ created: 2026-05-15
 1. **Created research document**: `docs/research/2026-05-15-qg-isomorphism-step-1-formalize-remember-when-pay-attention-as-categorical-primitives.md`
    - Formalizes the two root axioms (Remember-When + Pay-Attention) as categorical primitives
    - Models them as a topos with internal monad `M` for memory + internal modal operator `A` for attention
-   - Connects to DBSP incrementalization (the `D ∘ Q ∘ I` monad)
+   - Connects to DBSP incrementalization via the **incrementalization identity** `Q^Δ = D ∘ Q ∘ I` (the lifted-differential of any query equals differentiate ∘ query ∘ integrate — this is a wrapping/conjugation identity, not a monad on streams)
    - Connects to QBism (observer-relative truth values)
    - Provides categorical semantics of the infinite poker game
 
@@ -37,7 +37,7 @@ created: 2026-05-15
 - `M X` = space of memory states over object `X`
 - `μ : M² → M` = flatten nested memory (reconstruct from partial degradation)
 - `η : Id → M` = embed object into its memory (the "I am here now" state)
-- Idempotent up to coherence, preserves pullbacks, has comonoid structure
+- Satisfies monad associativity (`μ ∘ Mμ = μ ∘ μ_M`) — *not* idempotence; preserves pullbacks; has comonoid structure
 
 **Internal modal operator `A` for attention (Pay-Attention)**:
 - `A : Ω → Ω` where `Ω` is the subobject classifier
@@ -60,7 +60,7 @@ This formalization:
 
 ### Open questions
 
-1. What is the precise relationship between the memory monad `M` and the DBSP incrementalization monad?
+1. What is the precise relationship between the memory monad `M` (a monad on the topos `Zeta`) and the DBSP `I`/`D` pair (the integrate/differentiate operators participating in the incrementalization identity `Q^Δ = D ∘ Q ∘ I`)? Possible structural relations to investigate: comonad-monad adjunction (with `I` comonadic and `D` left-adjoint), distributive law, or no direct categorical correspondence.
 2. How does the attention modal operator `A` interact with the subobject classifier's Heyting algebra structure?
 3. Can we derive the Clifford algebra structure from this categorical foundation?
 4. What is the topos-theoretic analog of the no-cloning theorem?


### PR DESCRIPTION
## Summary

Addresses 5 unresolved P1 threads from now-merged [PR #3614](https://github.com/Lucent-Financial-Group/Zeta/pull/3614) that landed math-terminology + xref drift in the B-0543/B-0544 research substrate.

**Math terminology** (3 threads — Codex + Copilot):

- `μ ∘ Mμ = μ ∘ μ_M` is the **monad associativity law**, not idempotence. Renamed throughout; idempotent-monad condition (`μ ∘ η_M = id`) flagged as a separate physical assumption requiring its own justification.
- `D ∘ Q ∘ I` was called a "monad on streams". Corrected to the DBSP **incrementalization identity** `Q^Δ = D ∘ Q ∘ I` (a wrapping/conjugation identity over streams, not a monad). The repo treats `Q^Δ = D ∘ Q ∘ I` as identity/wrapper elsewhere — research substrate now aligned. Whether `M` (topos memory monad) and the DBSP `I`/`D` pair share a deeper categorical relationship (e.g., comonad-monad adjunction, distributive law) flagged as an open question, not a settled identity.

**Dead xrefs** (2 threads — Copilot):

- Memory file pointed at non-existent `aaron-ani-grok-post-m-acc-adoption-constraint-11-default-oracle.md` → corrected to actual `aaron-ani-grok-persistence-pt3-m-acc-moral-accelerationism-naming.md`.
- "B-0422 ... if it exists" — confirmed B-0422 lives at [`docs/backlog/P3/B-0422-clifford-algebraic-narrative-engine-pauli-symmetry-breaking-falsifiability-test-2026-05-12.md`](https://github.com/Lucent-Financial-Group/Zeta/blob/main/docs/backlog/P3/B-0422-clifford-algebraic-narrative-engine-pauli-symmetry-breaking-falsifiability-test-2026-05-12.md). Removed the stale conditional in both B-0543 and the memory file; linked directly.

**Out of scope** (deferred to a follow-up PR):

- Codex's deeper finding that M/A coherence laws are not well-typed under the stated signatures (`A(μ_X)` applies A to a morphism; `A(M(p))` requires `M(p) ∈ Ω` without a defined lifting / natural transformation). That's a substantive math fix, not a terminology cleanup; deserves its own PR with proper categorical machinery.
- Round 45 entry position in `docs/ROUND-HISTORY.md` (Copilot P1).

## Test plan

- [x] `git ls-tree HEAD | wc -l` canary clean (53/53 root entries, 5140/5140 total files vs parent) — Lior was active during commit window, but no commit-tree corruption per `.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`
- [x] Borrow-on-existing pattern used (worktree `/private/tmp/zeta-tick-2210z`, ~6h old, well past 3h+ stability threshold) per `.claude/rules/claim-acquire-before-worktree-work.md`
- [x] Explicit-path staging (no `git add -A`) — exactly 5 expected files
- [ ] CI: docs-only diff; required checks expected green
- [ ] Codex/Copilot re-review: confirm terminology fixes address the 5 threads named in the body

## Files changed

```
docs/backlog/P2/B-0543-qg-isomorphism-proof-path-remember-when-pay-attention-axioms-to-quantum-gravity-2026-05-15.md |  2 +-
docs/backlog/P2/B-0544-qg-isomorphism-step-1-formalize-remember-when-pay-attention-as-categorical-primitives-2026-05-15.md |  2 +-
docs/research/2026-05-15-qg-isomorphism-step-1-formalize-remember-when-pay-attention-as-categorical-primitives.md | 11 ++++++-----
memory/feedback_otto_qg_isomorphism_proof_path_remember_when_pay_attention_axioms_infinite_poker_to_quantum_gravity_aaron_otto_2026_05_15.md |  4 ++--
memory/feedback_otto_qg_isomorphism_step_1_formalize_remember_when_pay_attention_as_categorical_primitives_2026_05_15.md |  6 +++---
5 files changed, 13 insertions(+), 12 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)