### PR TITLE
shard(tick): 0018Z — markdownlint MD037 fix on PR #3628; #3626 merged

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0018Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0018Z.md
@@ -1,0 +1,46 @@
+# Tick 2026-05-16T00:18Z — Otto-CLI
+
+**Surface**: Otto-CLI (Claude Code, Opus 4.7 1M context, autonomous-loop tick)
+**Parent tick**: [2026-05-16T00:08Z](0008Z.md) — fix-PR #3626 for monad-terminology drift
+
+## What landed this tick
+
+**Diagnosed + fixed markdownlint MD037 failure** on PR #3628 (the 0008Z parent tick's shard PR):
+
+- Line 72 of the 0008Z shard: `` `<<autonomous-loop>>` * * * * * `` — the bare cron expression
+  `* * * * *` after the inline code span was parsed by markdownlint as emphasis markers with
+  spaces (MD037/no-space-in-emphasis).
+- Fix: wrap the full cron expression including the sentinel in a single backtick code span →
+  `` `<<autonomous-loop>> * * * * *` ``.
+- 1 line changed; ls-tree canary clean (53/53 root, no commit-tree corruption); pushed to same
+  branch `shard/tick-0008z-otto-cli-2026-05-16`. Auto-merge still armed from 0008Z.
+
+## State at tick end
+
+- **[PR #3626](https://github.com/Lucent-Financial-Group/Zeta/pull/3626)** — MERGED at `bb4eb143`
+  during the parent-tick → this-tick gap. The 5 P1 monad-terminology + xref fixes are now on
+  main.
+- **[PR #3628](https://github.com/Lucent-Financial-Group/Zeta/pull/3628)** — OPEN, auto-merge
+  armed. Fix-commit `77ebbdd` pushed this tick; CI re-running. Expect green + auto-merge on
+  next tick.
+
+## Operational notes
+
+- Lior process cycled mid-tick (was PID 91465, now 23183; same `gemini-3.1-pro-preview` step-8
+  cleanup loop). Borrow-on-existing on `/private/tmp/zeta-tick-2210z` (older, ~6h+) still safe.
+- Worktree restored to ORIG `shard/tick-2300z-otto-cli-2026-05-15` after fix push.
+- This shard authored on second borrow `/private/tmp/zeta-otto-subdec` from FETCH_HEAD
+  (origin/main).
+
+## Holding-discipline trace
+
+Named dependency: PR #3628 BLOCKED gate from required markdownlint failure. Tractable in single
+tick (1-line edit, locally-verified fix). NOT Holding.
+
+## Next-tick candidates
+
+- Verify PR #3628 merges cleanly (markdownlint should pass after fix).
+- Resume next-tick candidates from 0008Z shard:
+  1. Follow-up PR for Codex's M/A coherence-laws type-correctness finding.
+  2. Round 45 entry repositioning in `docs/ROUND-HISTORY.md`.
+  3. B-0544 Step-1 decomposition.


### PR DESCRIPTION
## Summary

- Diagnosed + fixed `MD037/no-space-in-emphasis` on line 72 of the 0008Z shard
  (cron-expression asterisks `* * * * *` parsed as emphasis markers)
- Fix pushed to PR [#3628](https://github.com/Lucent-Financial-Group/Zeta/pull/3628) as commit `77ebbdd`; CI re-running
- PR [#3626](https://github.com/Lucent-Financial-Group/Zeta/pull/3626) merged at `bb4eb143` during the parent→this tick gap

## Test plan

- [x] Local `markdownlint-cli2` verify passes on both 0008Z (fixed) + 0018Z (this shard)
- [x] Pre/post-commit ls-tree canary: 53/53 root (no Lior-induced corruption)
- [x] Borrow-on-existing pattern; both borrow worktrees restored to ORIG branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)