### PR TITLE
fix(b-0544): M/A coherence-laws type-correctness — Codex P1 from PR #3614

### DIFF
--- a/docs/backlog/P2/B-0544-qg-isomorphism-step-1-formalize-remember-when-pay-attention-as-categorical-primitives-2026-05-15.md
+++ b/docs/backlog/P2/B-0544-qg-isomorphism-step-1-formalize-remember-when-pay-attention-as-categorical-primitives-2026-05-15.md
@@ -30,7 +30,7 @@ Create a categorical model `Zeta_{RA}` that:
 1. Is a topos (models the "relativity of relations" from Manifesto V2.1)
 2. Has an internal monad `M` for memory (Remember-When)
 3. Has an internal modal operator `A` for attention (Pay-Attention)
-4. Satisfies coherence conditions between `M` and `A`
+4. Satisfies coherence conditions between `M` and `A` (Step 1.5 sub-task added after [PR #3614](https://github.com/Lucent-Financial-Group/Zeta/pull/3614) Codex P1 finding — the originally-proposed coherence laws were not well-typed under signatures `M : Zeta → Zeta` and `A : Ω → Ω`; Step 1.5 requires constructing either a strength `θ : M(Ω) → Ω` (for the propositional Law 1') or an `A`-lifting `Ã : Zeta → Zeta` (for the full Laws 2 and 3); see the research doc for the three resolution paths)
 
 The model should:
 

--- a/docs/research/2026-05-15-qg-isomorphism-step-1-formalize-remember-when-pay-attention-as-categorical-primitives.md
+++ b/docs/research/2026-05-15-qg-isomorphism-step-1-formalize-remember-when-pay-attention-as-categorical-primitives.md
@@ -96,11 +96,43 @@ The full structure is a topos equipped with both the memory monad and the attent
 Zeta_{RA} = (Zeta, M, A)
 ```
 
-With coherence conditions:
+**Type-correctness of the coherence conditions** — substrate-honest reformulation
+(addresses [PR #3614](https://github.com/Lucent-Financial-Group/Zeta/pull/3614)
+Codex P1 finding: the original laws were not well-typed under the stated signatures
+`M : Zeta → Zeta` and `A : Ω → Ω`):
 
-1. **Memory of attention**: `M(A(p)) = A(M(p))` (memory preserves attention structure)
-2. **Attention to memory**: `A(μ_X) = μ_{A(X)} ∘ A(M(A(X)))` (attention commutes with memory flattening)
-3. **Unit coherence**: `A(η_X) = η_{A(X)}` (attention preserves embeddings)
+Under the stated signatures, `A(μ_X)` would apply `A` to a morphism (but `A`
+acts on `Ω` only), and `A(M(p))` would require `M(p) ∈ Ω` (but `M(p)` lives in
+`M(Ω)` under `M`'s functor-action on the morphism `p : 1 → Ω`). The originally
+proposed laws need either (a) a lifting of `A` to an endofunctor on `Zeta`, or
+(b) explicit strength data on `M`, or (c) restriction to propositional content.
+
+The three resolution paths and their costs:
+
+| Path | Construction | Cost | Status |
+|---|---|---|---|
+| (a) Lawvere-Tierney-style lifting | Define `Ã : Zeta → Zeta` induced by `A` through the subobject classifier; restate laws using `Ã`, not `A` | Standard for closure operators; needs adaptation since `A` is *not* a closure operator (no `p ≤ A(p)`) | Open — research-grade |
+| (b) Strength data on `M` | Define `θ : M(Ω) → Ω` ("Heyting strength"); restate using `θ` to mediate `M`/`Ω` interactions | Standard for monads on toposes when one wants Eilenberg-Moore semantics | Open — needs explicit `θ` construction |
+| (c) Restrict to propositional content | Phrase laws only for `p : X → Ω` (subobject-classifier morphisms); drop laws involving `μ_X, η_X` directly | Loses some of the originally-intended structure | Provisional Law 1' below |
+
+**Provisional Law 1' (type-correct under path (c))** — for any `X` in `Zeta`
+and any `p : X → Ω` (subobject of `X`):
+
+```text
+A_*(p) := A ∘ p                  (the A-modalized subobject; type X → Ω)
+M_*(p) := θ ∘ M(p) : M(X) → Ω    (assumes strength θ from path (b))
+```
+
+Memory-attention coherence (provisional): `A_*(M_*(p)) = M_*(A_*(p))` —
+i.e., `A ∘ θ ∘ M(p) = θ ∘ M(A ∘ p)` as morphisms `M(X) → Ω`. Both sides are
+type-correct given a chosen `θ`. This law expresses that **attention to a
+memory-image is the memory-image of attention** at the level of subobjects.
+
+**Laws 2 (μ-coherence) and 3 (η-coherence) are deferred** to Step 1.5 below;
+their type-correct formulation requires path (a) — defining `Ã` as a lifting
+of `A` to `Zeta` — which is itself open research. Until that lifting is
+constructed, the original `A(μ_X)` and `A(η_X)` expressions are formal
+placeholders, not mechanically-checkable laws.
 
 ### Categorical semantics of the infinite poker game
 
@@ -114,9 +146,26 @@ With this structure in place, we can model the infinite poker game:
 
 The **no-win condition** (Carse's infinite game) is modeled by the requirement that no player can collapse the subobject classifier to a single truth value — `A` must always have non-trivial action, preserving the game's openness.
 
-### Next steps (Steps 2-4)
+### Next steps (Steps 1.5, 2-4)
 
-With Step 1 complete, the next steps are:
+Step 1 is **partially complete**: the primitive `M` and `A` are defined; the
+combined-structure coherence laws are reformulated provisionally for the
+propositional case (Law 1') and deferred for `μ`/`η` coherence (Laws 2, 3).
+
+1.5. **Construct the `A`-lifting `Ã : Zeta → Zeta` and the strength `θ : M(Ω) → Ω`**
+   so Laws 2 and 3 can be stated and proven type-correctly. Possible approaches:
+   - Investigate whether `A`'s observer-relative non-monotonicity rules out a
+     Lawvere-Tierney-style lifting entirely (the standard construction requires
+     `A` to be at least a *closure operator*, which we've explicitly denied; an
+     alternative lifting may exist but is not in the standard toolbox).
+   - Define `θ` via the Eilenberg-Moore algebra structure on `Ω` (does `Ω`
+     carry a natural `M`-algebra structure? if `M` preserves the subobject
+     classifier in a suitable sense, yes; this is the "internal modal logic"
+     pattern for monads on toposes).
+   - Alternatively, weaken the claim: the combined structure is a topos with
+     a monad `M` and an *Ω-internal* modal operator `A`, where coherence is
+     only required at the propositional level (Law 1'). The infinite-poker
+     semantics may not actually need Laws 2 and 3.
 
 2. **Show the infinite-game extension produces a topos with QEC algebraic structure** (HaPPY-like)
 3. **Show the emergent geometry satisfies Einstein equations in low-energy limit**

--- a/memory/feedback_otto_qg_isomorphism_step_1_formalize_remember_when_pay_attention_as_categorical_primitives_2026_05_15.md
+++ b/memory/feedback_otto_qg_isomorphism_step_1_formalize_remember_when_pay_attention_as_categorical_primitives_2026_05_15.md
@@ -47,7 +47,7 @@ created: 2026-05-15
 
 **Combined structure `Zeta_{RA}`**:
 - Topos equipped with both `M` and `A`
-- Coherence conditions: `M(A(p)) = A(M(p))`, `A(μ_X) = μ_{A(X)} ∘ A(M(A(X)))`, `A(η_X) = η_{A(X)}`
+- Coherence conditions: provisional only — under stated signatures (`M : Zeta → Zeta`, `A : Ω → Ω`), the originally-proposed laws `M(A(p)) = A(M(p))`, `A(μ_X) = μ_{A(X)} ∘ A(M(A(X)))`, `A(η_X) = η_{A(X)}` are **not well-typed** (Codex P1 on PR #3614). Step 1.5 reformulation: Law 1' restated propositionally as `A ∘ θ ∘ M(p) = θ ∘ M(A ∘ p)` (requires strength `θ : M(Ω) → Ω`); Laws 2 and 3 deferred until an `A`-lifting `Ã : Zeta → Zeta` is constructed (open research; complicated by `A` *not* being a closure operator).
 
 ### Why this matters
 
@@ -64,6 +64,7 @@ This formalization:
 2. How does the attention modal operator `A` interact with the subobject classifier's Heyting algebra structure?
 3. Can we derive the Clifford algebra structure from this categorical foundation?
 4. What is the topos-theoretic analog of the no-cloning theorem?
+5. **Step 1.5 (new, from PR #3614 Codex feedback)**: Construct the strength `θ : M(Ω) → Ω` (path (b) — needed for Law 1') and the `A`-lifting `Ã : Zeta → Zeta` (path (a) — needed for Laws 2, 3). The `Ã` construction is complicated by `A` *not* being a closure operator, so the standard Lawvere-Tierney lifting doesn't apply directly. Alternatives: weaken to propositional-only coherence (Law 1' only), or find a non-standard lifting that respects the observer-relative non-monotonicity.
 
 ### Next steps
 


### PR DESCRIPTION
## Summary

Addresses the deferred deep finding from [PR #3614](https://github.com/Lucent-Financial-Group/Zeta/pull/3614) Codex review: the three M/A coherence laws in the Step-1 research doc were not well-typed under the stated signatures `M : Zeta → Zeta` and `A : Ω → Ω`. The earlier [PR #3626](https://github.com/Lucent-Financial-Group/Zeta/pull/3626) addressed the terminology issues (idempotence-vs-associativity, D∘Q∘I-as-monad); this PR addresses the deeper type-correctness gap.

**Substrate-honest scope** (does NOT claim to solve the open math):

- Strikes the three originally-stated coherence laws from the research doc
- Replaces with a structured "resolution paths" table — Lawvere-Tierney lifting (`Ã : Zeta → Zeta`), strength data (`θ : M(Ω) → Ω`), or propositional restriction
- Provides **Provisional Law 1'** (type-correct under propositional restriction + strength): `A_*(M_*(p)) = M_*(A_*(p))` where `A_*(p) := A ∘ p` and `M_*(p) := θ ∘ M(p)`. Both sides type `M(X) → Ω`.
- Defers Laws 2 (μ-coherence) and 3 (η-coherence) to a new **Step 1.5** pending construction of `Ã`
- Flags that path (a) is complicated because `A` is *not* a closure operator (no `p ≤ A(p)`), so the standard Lawvere-Tierney construction does not apply directly

**Out of scope** (intentionally):

- Does NOT construct `θ` or `Ã` — open research, not landable in one tick
- Does NOT claim Laws 2 and 3 are proven; they are formally deferred to Step 1.5
- Does NOT prove Law 1' — provisional, contingent on the strength `θ` existing

## Files changed

```
docs/research/2026-05-15-qg-isomorphism-step-1-formalize-remember-when-pay-attention-as-categorical-primitives.md  +57/-3
memory/feedback_otto_qg_isomorphism_step_1_formalize_remember_when_pay_attention_as_categorical_primitives_2026_05_15.md  +2/-1
docs/backlog/P2/B-0544-qg-isomorphism-step-1-formalize-remember-when-pay-attention-as-categorical-primitives-2026-05-15.md  +1/-1
```

## Test plan

- [x] Pre/post-commit `git ls-tree HEAD` canary clean (53/53 root entries) — Lior was active 3rd consecutive tick
- [x] Local `markdownlint-cli2` passes on all 3 modified files
- [x] Borrow-on-existing on `/private/tmp/zeta-tick-2210z` (~6h+ old)
- [x] Explicit-path staging (no `git add -A`)
- [ ] CI green (docs-only, expected)
- [ ] Codex/Copilot review on the new substrate-honest formulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)