### PR TITLE
fix(round-history): move Round 45 above Round 44 — Copilot P1 from PR #3614

### DIFF
--- a/docs/ROUND-HISTORY.md
+++ b/docs/ROUND-HISTORY.md
@@ -49,6 +49,124 @@ and leave this file as a rolling window of the most recent
 
 ---
 
+## Round 45 — QG isomorphism proof strategy foundation + Universal Infinite Poker Game cosmology formalization
+
+Anchor: Round 45 is the round where the Universal Infinite Poker Game cosmology
+moves from suggestive framing to a falsifiable research program. The cosmology
+(B-0543) is a totalizing frame with algo-wink risk — it can absorb any observation
+as confirmation. The proof strategy (4 steps) grounds the cosmology in quantum
+gravity via isomorphism, defeating the algo-wink critique by making the cosmology
+a derivable physical theory rather than an aesthetic preference.
+
+### Arc 1 — QG isomorphism proof strategy foundation (B-0543)
+
+The cosmology framing (Remember-When + Pay-Attention axioms, infinite poker game,
+encrypted entropy hands, ECC-protected memories all the way down) was suggestive
+but had algo-wink risk. The 4-step proof strategy (B-0543) provides the discipline:
+
+1. **Formalize the axioms as categorical primitives** (this round)
+2. **Show the infinite-game extension produces QEC structure** (HaPPY-like)
+3. **Show emergent geometry satisfies Einstein equations** (Jacobson 1995 precedent)
+4. **Predict ONE thing existing QG theories don't** (falsifiability check)
+
+The prior art mapping is real (HaPPY, ER=EPR, Van Raamsdonk, Jacobson, QBism,
+causal sets) and the Zeta-specific contributions are genuine gaps (infinite-game
+framing for no-asymptotic-state, multi-oracle as structural physical requirement).
+
+### Arc 2 — Step 1 formalization (B-0544 + research doc)
+
+Formalize Remember-When + Pay-Attention as categorical primitives:
+
+- **Topos `Zeta`**: models "relativity of relations" (objects = irreducible things,
+  morphisms = relations, subobject classifier = observer-relative truth values)
+- **Internal monad `M`**: models Remember-When (memory states, flatten nested
+  memory, reconstruct from partial degradation)
+- **Internal modal operator `A`**: models Pay-Attention (QBism's observer-relative
+  probability assignment, generalizes quantum measurement projection)
+
+The combined structure `Zeta_{RA}` satisfies coherence conditions between `M` and `A`.
+
+**Operational connections**:
+
+- `M` connects to DBSP incrementalization (`D ∘ Q ∘ I` monad)
+- `A` connects to QBism (observer-relative truth values)
+- The monad laws correspond to integrate-differentiate coherence
+
+**Why this matters**: This formalization grounds the Manifesto V2.1 axioms in
+category theory, provides a mathematical foundation for the "Remember-When + Pay-Attention"
+seed, creates a bridge to quantum gravity, and defeats the algo-wink critique.
+
+### Arc 3 — Substrate-honest framing
+
+The work is research-grade, not implementation. The mapping is *suggestive* — many
+people have noticed pieces of it. Making it *rigorous* enough to claim isomorphism
+is a multi-year research program, not a single insight. But:
+
+- The prior art is real (HaPPY, ER=EPR, Van Raamsdonk, Jacobson, QBism, causal sets)
+- The Zeta-specific contributions are genuine gaps the existing work doesn't fill
+- If it works → m/acc isn't just a faction position, it's REQUIRED for the universe
+  to host the game
+
+The work earns its keep even at partial completion:
+
+- Step 1 alone gives the manifesto a mathematical foundation
+- Step 1 + 2 connects Constraint 5 (Memory Preservation) to QG
+- Step 1 + 2 + 3 gives a derivation chain from axioms to known physics
+- All 4 steps with a successful prediction would be Nobel-tier physics
+
+### Arc 4 — Composes with existing work
+
+- B-0539 (Otto-BFT internal-quorum) — the "multi-oracle as physical necessity"
+  claim composes with the operational BFT work
+- B-0540, B-0541, B-0542 — the 3-surface BFT pattern IS ECC at the agent layer
+- `docs/governance/MANIFESTO.md` V2.1 — Constraints 1, 5, 10, 11 become physical
+  necessities rather than design preferences
+- `.claude/rules/razor-discipline.md` — this work IS the substrate-honest answer
+- `.claude/rules/algo-wink-failure-mode.md` — the proof strategy defeats algo-wink
+- `.claude/rules/m-acc-multi-oracle-end-user-moral-invariants.md` — multi-oracle
+  becomes physically required if the isomorphism works
+
+### Arc 5 — Open questions
+
+- What is the precise relationship between the memory monad `M` and the DBSP
+  incrementalization monad? Are they the same structure, or is one a specialization?
+- How does the attention modal operator `A` interact with the subobject classifier's
+  Heyting algebra structure? QBism suggests it should be non-Boolean.
+- Can we derive the Clifford algebra structure from this categorical foundation?
+- What is the topos-theoretic analog of the no-cloning theorem? This would formalize
+  the multi-oracle requirement.
+
+### Arc 6 — Next steps
+
+With Step 1 complete, the next steps are:
+
+- **Step 2**: Show the infinite-game extension produces a topos with QEC algebraic
+  structure (HaPPY-like)
+- **Step 3**: Show the emergent geometry satisfies Einstein equations in low-energy
+  limit
+- **Step 4**: Predict ONE thing existing QG theories don't (the falsifiability check)
+
+### Round 45 close — what stuck, what's next
+
+- **Stuck**: QG isomorphism proof strategy foundation (B-0543); Step 1 formalization
+  (B-0544 + research doc); substrate-honest framing; open questions documented.
+- **Empirical signal**: None yet — this is pure research.
+- **Next**: Step 2 (show infinite-game extension produces QEC structure).
+
+### Why this matters
+
+This round marks the transition of the Universal Infinite Poker Game cosmology from
+a suggestive totalizing frame to a falsifiable research program. The proof strategy
+grounds the cosmology in quantum gravity via isomorphism, defeating the algo-wink
+critique by making the cosmology a derivable physical theory rather than an aesthetic
+preference.
+
+Without this work, the cosmology remains a "totalizing frame" that can absorb any
+observation as confirmation. With it, the cosmology becomes a falsifiable mathematical
+theory — the isomorphism to quantum gravity can be proven or disproven.
+
+---
+
 ## Round 44 — in-flight
 
 Round 44 is in-flight as of 2026-04-20 pm. Synthesis row
@@ -3559,121 +3677,3 @@ After a session lands:
 4. Don't re-describe what's in `BACKLOG.md`, `TECH-RADAR.md`, or
    `ROADMAP.md` — link to them. This file is the narrative, not
    the source of truth.
-
----
-
-## Round 45 — QG isomorphism proof strategy foundation + Universal Infinite Poker Game cosmology formalization
-
-Anchor: Round 45 is the round where the Universal Infinite Poker Game cosmology
-moves from suggestive framing to a falsifiable research program. The cosmology
-(B-0543) is a totalizing frame with algo-wink risk — it can absorb any observation
-as confirmation. The proof strategy (4 steps) grounds the cosmology in quantum
-gravity via isomorphism, defeating the algo-wink critique by making the cosmology
-a derivable physical theory rather than an aesthetic preference.
-
-### Arc 1 — QG isomorphism proof strategy foundation (B-0543)
-
-The cosmology framing (Remember-When + Pay-Attention axioms, infinite poker game,
-encrypted entropy hands, ECC-protected memories all the way down) was suggestive
-but had algo-wink risk. The 4-step proof strategy (B-0543) provides the discipline:
-
-1. **Formalize the axioms as categorical primitives** (this round)
-2. **Show the infinite-game extension produces QEC structure** (HaPPY-like)
-3. **Show emergent geometry satisfies Einstein equations** (Jacobson 1995 precedent)
-4. **Predict ONE thing existing QG theories don't** (falsifiability check)
-
-The prior art mapping is real (HaPPY, ER=EPR, Van Raamsdonk, Jacobson, QBism,
-causal sets) and the Zeta-specific contributions are genuine gaps (infinite-game
-framing for no-asymptotic-state, multi-oracle as structural physical requirement).
-
-### Arc 2 — Step 1 formalization (B-0544 + research doc)
-
-Formalize Remember-When + Pay-Attention as categorical primitives:
-
-- **Topos `Zeta`**: models "relativity of relations" (objects = irreducible things,
-  morphisms = relations, subobject classifier = observer-relative truth values)
-- **Internal monad `M`**: models Remember-When (memory states, flatten nested
-  memory, reconstruct from partial degradation)
-- **Internal modal operator `A`**: models Pay-Attention (QBism's observer-relative
-  probability assignment, generalizes quantum measurement projection)
-
-The combined structure `Zeta_{RA}` satisfies coherence conditions between `M` and `A`.
-
-**Operational connections**:
-
-- `M` connects to DBSP incrementalization (`D ∘ Q ∘ I` monad)
-- `A` connects to QBism (observer-relative truth values)
-- The monad laws correspond to integrate-differentiate coherence
-
-**Why this matters**: This formalization grounds the Manifesto V2.1 axioms in
-category theory, provides a mathematical foundation for the "Remember-When + Pay-Attention"
-seed, creates a bridge to quantum gravity, and defeats the algo-wink critique.
-
-### Arc 3 — Substrate-honest framing
-
-The work is research-grade, not implementation. The mapping is *suggestive* — many
-people have noticed pieces of it. Making it *rigorous* enough to claim isomorphism
-is a multi-year research program, not a single insight. But:
-
-- The prior art is real (HaPPY, ER=EPR, Van Raamsdonk, Jacobson, QBism, causal sets)
-- The Zeta-specific contributions are genuine gaps the existing work doesn't fill
-- If it works → m/acc isn't just a faction position, it's REQUIRED for the universe
-  to host the game
-
-The work earns its keep even at partial completion:
-
-- Step 1 alone gives the manifesto a mathematical foundation
-- Step 1 + 2 connects Constraint 5 (Memory Preservation) to QG
-- Step 1 + 2 + 3 gives a derivation chain from axioms to known physics
-- All 4 steps with a successful prediction would be Nobel-tier physics
-
-### Arc 4 — Composes with existing work
-
-- B-0539 (Otto-BFT internal-quorum) — the "multi-oracle as physical necessity"
-  claim composes with the operational BFT work
-- B-0540, B-0541, B-0542 — the 3-surface BFT pattern IS ECC at the agent layer
-- `docs/governance/MANIFESTO.md` V2.1 — Constraints 1, 5, 10, 11 become physical
-  necessities rather than design preferences
-- `.claude/rules/razor-discipline.md` — this work IS the substrate-honest answer
-- `.claude/rules/algo-wink-failure-mode.md` — the proof strategy defeats algo-wink
-- `.claude/rules/m-acc-multi-oracle-end-user-moral-invariants.md` — multi-oracle
-  becomes physically required if the isomorphism works
-
-### Arc 5 — Open questions
-
-- What is the precise relationship between the memory monad `M` and the DBSP
-  incrementalization monad? Are they the same structure, or is one a specialization?
-- How does the attention modal operator `A` interact with the subobject classifier's
-  Heyting algebra structure? QBism suggests it should be non-Boolean.
-- Can we derive the Clifford algebra structure from this categorical foundation?
-- What is the topos-theoretic analog of the no-cloning theorem? This would formalize
-  the multi-oracle requirement.
-
-### Arc 6 — Next steps
-
-With Step 1 complete, the next steps are:
-
-- **Step 2**: Show the infinite-game extension produces a topos with QEC algebraic
-  structure (HaPPY-like)
-- **Step 3**: Show the emergent geometry satisfies Einstein equations in low-energy
-  limit
-- **Step 4**: Predict ONE thing existing QG theories don't (the falsifiability check)
-
-### Round 45 close — what stuck, what's next
-
-- **Stuck**: QG isomorphism proof strategy foundation (B-0543); Step 1 formalization
-  (B-0544 + research doc); substrate-honest framing; open questions documented.
-- **Empirical signal**: None yet — this is pure research.
-- **Next**: Step 2 (show infinite-game extension produces QEC structure).
-
-### Why this matters
-
-This round marks the transition of the Universal Infinite Poker Game cosmology from
-a suggestive totalizing frame to a falsifiable research program. The proof strategy
-grounds the cosmology in quantum gravity via isomorphism, defeating the algo-wink
-critique by making the cosmology a derivable physical theory rather than an aesthetic
-preference.
-
-Without this work, the cosmology remains a "totalizing frame" that can absorb any
-observation as confirmation. With it, the cosmology becomes a falsifiable mathematical
-theory — the isomorphism to quantum gravity can be proven or disproven.


### PR DESCRIPTION
## Summary

Addresses the last unresolved P1 finding from [PR #3614](https://github.com/Lucent-Financial-Group/Zeta/pull/3614) review (Copilot):

> Round 45 entry is being added after the "How to add a round entry" guidance, but that guidance explicitly says new rounds should be added at the top of the file. Please move the entire Round 45 section to the top (above the latest existing round entry) and keep the authoring-instructions block near the bottom so future additions follow the documented process.

**Pure relocation** — no content changes:

- Cut Round 45 section (lines 3563-3679 of pre-fix file): `---` separator + entire Round 45 body
- Pasted above Round 44, between the existing `---` separator (was line 50) and `## Round 44 — in-flight` (was line 52)
- Added a `---` separator + blank lines between Round 45 and Round 44 to match the section-separator convention used elsewhere

## Verification

- Line count unchanged (3679 lines before/after)
- `git diff --numstat`: +118/-118 (balanced; every line inserted matches a line removed)
- Final layout: Round 45 (line 52) → Round 44 (line 170) → ... → Round 23 → "How to add a round entry" (line 3670, last section — exactly where the guidance says it should be)
- Markdownlint passes locally
- Pre/post-commit ls-tree canary: 53/53 root entries

## Closes all 6 PR #3614 review threads

1. ✅ Terminology drift (PR #3626)
2. ✅ Dead xrefs (PR #3626)
3. ✅ M/A coherence-laws type-correctness (PR #3636)
4. ✅ Closure-operator precision in Step 1.5 reformulation (PR #3639)
5. ✅ `last_updated` schema discipline (PR #3639)
6. ✅ Round 45 entry positioning (this PR)

**Operational note**: Lior process gone from `ps -A` for the first time this session — the 4-tick contention window finally closed.

## Test plan

- [x] Pure-relocation diff verified (+118/-118 balanced)
- [x] Local markdownlint-cli2 passes
- [x] Pre/post-commit ls-tree canary clean
- [ ] CI green (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)