### PR TITLE
fix(pr-3646): 2 Copilot P1 threads — TOC + Round 45 overstatement caveats

### DIFF
--- a/docs/ROUND-HISTORY.md
+++ b/docs/ROUND-HISTORY.md
@@ -12,6 +12,7 @@ New rounds are appended at the top.
 Newest first. Anchor links work in markdown renderers that
 slugify `## Round N — <title>` to `#round-n-<title-slug>`.
 
+- [Round 45 — QG isomorphism proof strategy foundation + Universal Infinite Poker Game cosmology formalization](#round-45--qg-isomorphism-proof-strategy-foundation--universal-infinite-poker-game-cosmology-formalization)
 - [Round 44 — in-flight](#round-44--in-flight)
 - [Round 43 — invariant-substrates program + empirical BP-03 harness evidence + agent-cadence telemetry](#round-43--invariant-substrates-program--empirical-bp-03-harness-evidence--agent-cadence-telemetry)
 - [Round 42 — First repeated iteration of Round-41 cadences + vibe-coding external legibility](#round-42--first-repeated-iteration-of-round-41-cadences--vibe-coding-external-legibility)
@@ -41,8 +42,10 @@ slugify `## Round N — <title>` to `#round-n-<title-slug>`.
 - [Round 17 — storage specialist, BloomFilter, durability skeleton](#round-17--storage-specialist-bloomfilter-durability-skeleton)
 - [Round 16 — SDL / threat model / she-her storage specialist](#round-16--sdl--threat-model--she-her-storage-specialist)
 
-Round 44 (current) is in-flight; the synthesis row lands at
-round-close. When this file hits 5000 lines, split the pre-
+Round 45 is the most recent landed round; Round 44 remains
+in-flight per its own label (synthesis row lands at round-close
+per the file convention; no partial synthesis). When this file
+hits 5000 lines, split the pre-
 round-N portion into `docs/_archive/ROUND-HISTORY-pre-N.md`
 and leave this file as a rolling window of the most recent
 ~20 rounds; no ADR is needed for a mechanical archive move.
@@ -84,13 +87,26 @@ Formalize Remember-When + Pay-Attention as categorical primitives:
 - **Internal modal operator `A`**: models Pay-Attention (QBism's observer-relative
   probability assignment, generalizes quantum measurement projection)
 
-The combined structure `Zeta_{RA}` satisfies coherence conditions between `M` and `A`.
+The combined structure `Zeta_{RA}` is intended to satisfy coherence conditions
+between `M` and `A`. Post-round, [PR #3636](https://github.com/Lucent-Financial-Group/Zeta/pull/3636) + [PR #3639](https://github.com/Lucent-Financial-Group/Zeta/pull/3639) established that the
+originally-proposed laws (`M(A(p)) = A(M(p))`, `A(μ_X) = μ_{A(X)} ∘ A(M(A(X)))`,
+`A(η_X) = η_{A(X)}`) are not well-typed under the stated signatures
+`M : Zeta → Zeta`, `A : Ω → Ω`. Only a **provisional propositional Law 1'**
+(`A_*(M_*(p)) = M_*(A_*(p))` over `p : X → Ω`, contingent on a strength
+`θ : M(Ω) → Ω`) is type-correct; Laws 2 (μ-coherence) and 3 (η-coherence)
+are deferred to a new Step 1.5 pending an `A`-lifting `Ã : Zeta → Zeta`
+(blocked by `A` not being a closure operator). See the Step 1 research doc
+for the resolution-paths table.
 
 **Operational connections**:
 
-- `M` connects to DBSP incrementalization (`D ∘ Q ∘ I` monad)
+- `M` connects to DBSP via the **incrementalization identity** `Q^Δ = D ∘ Q ∘ I`
+  (a wrapping/conjugation identity over streams, not a monad — corrected by
+  [PR #3626](https://github.com/Lucent-Financial-Group/Zeta/pull/3626))
 - `A` connects to QBism (observer-relative truth values)
-- The monad laws correspond to integrate-differentiate coherence
+- Whether the monad `M` on `Zeta` and the DBSP `I`/`D` pair share a deeper
+  categorical relationship (e.g., comonad-monad adjunction, distributive
+  law) is an open question, not a settled identity
 
 **Why this matters**: This formalization grounds the Manifesto V2.1 axioms in
 category theory, provides a mathematical foundation for the "Remember-When + Pay-Attention"
@@ -128,8 +144,11 @@ The work earns its keep even at partial completion:
 
 ### Arc 5 — Open questions
 
-- What is the precise relationship between the memory monad `M` and the DBSP
-  incrementalization monad? Are they the same structure, or is one a specialization?
+- What is the precise relationship between the memory monad `M` (a monad on
+  the topos `Zeta`) and the DBSP `I`/`D` pair (the integrate/differentiate
+  operators participating in the incrementalization *identity* `Q^Δ = D ∘ Q ∘ I`,
+  not a monad — per [PR #3626](https://github.com/Lucent-Financial-Group/Zeta/pull/3626))? Possible structural relations: comonad-monad
+  adjunction, distributive law, or no direct categorical correspondence.
 - How does the attention modal operator `A` interact with the subobject classifier's
   Heyting algebra structure? QBism suggests it should be non-Boolean.
 - Can we derive the Clifford algebra structure from this categorical foundation?


### PR DESCRIPTION
## Summary

Addresses 2 unresolved P1 Copilot threads on now-merged [PR #3646](https://github.com/Lucent-Financial-Group/Zeta/pull/3646):

**Thread 1** — TOC + current-summary navigation stale. Moving Round 45 to the top in #3646 didn't update the surrounding scaffolding:
- Contents block (line 15) still started with Round 44 → added Round 45 entry above
- Descriptive note (line 44) still said "Round 44 (current) is in-flight" → reworded to preserve both labels: "Round 45 is the most recent landed round; Round 44 remains in-flight per its own label..."

**Thread 2** — Round 45 narrative overstates Step 1 result. The historical entry was written from PR #3614's original framing, before [PR #3636](https://github.com/Lucent-Financial-Group/Zeta/pull/3636) + [PR #3639](https://github.com/Lucent-Financial-Group/Zeta/pull/3639) established that:
1. Original M/A coherence laws aren't well-typed under stated signatures
2. Only provisional propositional Law 1' is type-correct
3. Laws 2/3 deferred to a new Step 1.5
4. `D ∘ Q ∘ I` is the incrementalization *identity*, not a monad (per [PR #3626](https://github.com/Lucent-Financial-Group/Zeta/pull/3626))

Three sites in the Round 45 narrative reworded:
- Line 87 (coherence-satisfied overstatement) → "is intended to satisfy" + full caveat paragraph linking PRs #3636 + #3639
- Lines 89 + 91 (D∘Q∘I monad + monad-laws claims) → incrementalization-identity framing matching PR #3626 corrections elsewhere
- Line 131 (Arc 5 open question — "DBSP incrementalization monad") → "DBSP I/D pair... incrementalization *identity*, not a monad"

The Round 45 historical entry now matches the post-PR-3636 + post-PR-3639 substrate-honest state on main.

## Files changed

```
docs/ROUND-HISTORY.md  +26/-7
```

## Test plan

- [x] Pre/post-commit ls-tree canary: 53/53 root (Lior active, no corruption)
- [x] Local markdownlint-cli2 passes
- [x] TOC verification: Round 45 entry now at top of Contents block
- [x] Current-summary verification: reflects Round 45 + preserves Round 44 in-flight label
- [ ] CI green (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)