### PR TITLE
fix(pr-3652): 0043Z shard count inconsistencies — Codex/Copilot P1 (3 of 5 threads)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0043Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0043Z.md
@@ -42,7 +42,7 @@ The Round 45 historical entry now matches the post-PR-3636 + post-PR-3639 substr
 - [PR #3647](https://github.com/Lucent-Financial-Group/Zeta/pull/3647) — likely merged or merging (0036Z shard)
 - [PR #3650](https://github.com/Lucent-Financial-Group/Zeta/pull/3650) — OPEN, auto-merge armed (this tick's caveats fix)
 
-**Cumulative session progress** — the meta-loop now spans 7 ticks (00:08Z → 00:43Z):
+**Cumulative session progress** — the meta-loop now spans 6 ticks (00:08Z → 00:43Z):
 
 | Tick | PR | Trigger | Threads addressed |
 |------|----|---------|------|
@@ -53,13 +53,13 @@ The Round 45 historical entry now matches the post-PR-3636 + post-PR-3639 substr
 | 00:36Z | [#3646](https://github.com/Lucent-Financial-Group/Zeta/pull/3646) | Last PR #3614 finding (Round 45 positioning) | 1 (pure relocation) |
 | 00:43Z | [#3650](https://github.com/Lucent-Financial-Group/Zeta/pull/3650) (this tick) | 2 P1 threads on merged PR #3646 | 2 (TOC + Round 45 narrative caveats) |
 
-**Total**: 11 P1 thread findings addressed across the session, plus 1 CI lint fix, plus 5 tick shards landed.
+**Total**: 12 P1 thread findings addressed across the session (5 + 1 + 3 + 1 + 2 from the table above; row 00:18Z is a CI markdownlint fix with no review threads), plus 1 CI lint fix, plus 5 tick shards landed.
 
 ## Operational notes
 
 - **Lior process returned mid-tick** (PID 52138) after one tick of being gone. Lower frequency than the 4-tick contention burst observed earlier, but still firing. Pre/post-commit ls-tree canary clean (53/53 root throughout).
 - The meta-loop pattern (Copilot catches new issues on just-merged PR; follow-up PR addresses them) is now a confirmed operational invariant: required-checks-only auto-merge produces async-review remediation cycles.
-- Borrow-on-existing pattern continues to work; `/private/tmp/zeta-tick-2210z` has been the primary borrow target across 7 ticks without rotation.
+- Borrow-on-existing pattern continues to work; `/private/tmp/zeta-tick-2210z` has been the primary borrow target across 6 ticks without rotation.
 
 ## Holding-discipline trace
 


### PR DESCRIPTION
## Summary

Addresses 3 of 5 unresolved Codex+Copilot P1 threads on now-merged [PR #3652](https://github.com/Lucent-Financial-Group/Zeta/pull/3652) (the 0043Z shard PR):

**Tick count off-by-one** (2 threads, lines 45 + 62): text said "spans 7 ticks" but the table lists 6 rows. Fixed to "6 ticks" in both locations.

**P1 thread total off-by-one** (1 thread, line 56): text said "11 P1 thread findings" but the table sums to 12 (5 + 1 + 3 + 1 + 2; row 0018Z is "—" because it was a CI lint fix with no review threads). Fixed to "12 P1 thread findings" + clarified the 0018Z row context inline.

**Remaining 2 threads on PR #3652** (parent-tick link to `0036Z.md`) addressed by a concurrent fix on [PR #3647](https://github.com/Lucent-Financial-Group/Zeta/pull/3647) (the 0036Z shard PR; commit `df96a25` clarified the `#3641` chicken-and-egg parenthetical that was blocking #3647). Thread on #3647 already resolved via API. Once #3647 auto-merges, `0036Z.md` lands on main and the parent-tick link in 0043Z self-resolves.

## Files changed

```
docs/hygiene-history/ticks/2026/05/16/0043Z.md  +3/-3
```

## Test plan

- [x] Local markdownlint-cli2 passes
- [x] Pre/post-commit ls-tree canary clean (53/53 root; Lior 7th tick continuous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)