### PR TITLE
fix(pr-3657): 0043Z shard — Copilot P1 redundancy (CI lint fix counted twice)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0043Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0043Z.md
@@ -53,7 +53,7 @@ The Round 45 historical entry now matches the post-PR-3636 + post-PR-3639 substr
 | 00:36Z | [#3646](https://github.com/Lucent-Financial-Group/Zeta/pull/3646) | Last PR #3614 finding (Round 45 positioning) | 1 (pure relocation) |
 | 00:43Z | [#3650](https://github.com/Lucent-Financial-Group/Zeta/pull/3650) (this tick) | 2 P1 threads on merged PR #3646 | 2 (TOC + Round 45 narrative caveats) |
 
-**Total**: 12 P1 thread findings addressed across the session (5 + 1 + 3 + 1 + 2 from the table above; row 00:18Z is a CI markdownlint fix with no review threads), plus 1 CI lint fix, plus 5 tick shards landed.
+**Total**: 12 P1 thread findings addressed across the session (5 + 1 + 3 + 1 + 2 from the table above; the 00:18Z row is the single CI-only tick — a markdownlint MD037 fix with no review threads), plus 5 tick shards landed.
 
 ## Operational notes
 


### PR DESCRIPTION
## Summary

Addresses the 1 unresolved Copilot P1 thread on now-merged [PR #3657](https://github.com/Lucent-Financial-Group/Zeta/pull/3657).

The Total sentence in the 0043Z shard noted that row 00:18Z is a CI markdownlint fix, then immediately added "plus 1 CI lint fix" — reads as if the CI fix is being counted twice (or two separate CI fixes). Reworded to make explicit there was exactly one CI-only tick; dropped the redundant clause.

```
- **Total**: 12 P1 thread findings ... row 00:18Z is a CI markdownlint fix with no review threads), plus 1 CI lint fix, plus 5 tick shards landed.
+ **Total**: 12 P1 thread findings ... the 00:18Z row is the single CI-only tick — a markdownlint MD037 fix with no review threads), plus 5 tick shards landed.
```

## Test plan

- [x] Local markdownlint-cli2 passes
- [x] Pre/post-commit ls-tree canary clean (53/53; Lior gone this tick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)