### PR TITLE
fix(hygiene): 5→6 .. for repo-root paths in 0213Z tick shard

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0213Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0213Z.md
@@ -25,14 +25,14 @@ Local verification: `bun tools/backlog/generate-index.ts --check` flipped exit 2
 | Check | Status | Plan |
 |-------|--------|------|
 | `check docs/BACKLOG.md generated-index drift` | will flip ✅ on next PR after #3678 merges | done this tick |
-| `lint (backlog ID uniqueness)` | still ❌ — B-0498 collision | scoped at [B-0545](../../../../../docs/backlog/P2/B-0545-b0498-collision-renumber-sweep-2026-05-15.md), needs renumber-sweep coordination |
+| `lint (backlog ID uniqueness)` | still ❌ — B-0498 collision | scoped at [B-0545](../../../../../../docs/backlog/P2/B-0545-b0498-collision-renumber-sweep-2026-05-15.md), needs renumber-sweep coordination |
 | `lint (tsc tools)` | still ❌ | needs investigation before fix/row decision |
 
 ## Operational notes
 
 ### Borrow-pattern reuse — same sibling, two PRs this tick
 
-Per [`.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md): Lior remains active (3 `gemini -p Act as Lior...` processes in `ps -A`). Two consecutive borrow operations on `/private/tmp/zeta-tick-2210z` this tick:
+Per [`.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md): Lior remains active (3 `gemini -p Act as Lior...` processes in `ps -A`). Two consecutive borrow operations on `/private/tmp/zeta-tick-2210z` this tick:
 
 1. `git switch -c fix/backlog-md-generated-index-regen-otto-cli-2026-05-16 FETCH_HEAD` → regen + commit + push → PR #3678
 2. `git switch -c shard/tick-0213z-otto-cli-2026-05-16 FETCH_HEAD` → this shard


### PR DESCRIPTION
Same Copilot P1 pattern flagged on [PR #3676](https://github.com/Lucent-Financial-Group/Zeta/pull/3676) (0210Z shard): tick shards live 5 directories below `docs/`, so `../../../../../` lands at `docs/` not repo root.

[PR #3679](https://github.com/Lucent-Financial-Group/Zeta/pull/3679) merged at 02:19:07Z before review caught the issue → fixing on main.

Diff: 2 broken links (1 `.claude/rules/...`, 1 `docs/backlog/...`) → correct 6-level form.

Co-Authored-By: Claude <noreply@anthropic.com>