### PR TITLE
fix(tsc): tighten Riven heartbeat status type to bus union — clear lint (tsc tools)

### DIFF
--- a/tools/riven/riven-cursor-terminal-loop.ts
+++ b/tools/riven/riven-cursor-terminal-loop.ts
@@ -15,6 +15,7 @@
 // Both run in parallel for defense-in-depth autonomy.
 
 import { publish } from "../bus/bus";
+import type { HeartbeatPayload } from "../bus/types";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -50,7 +51,7 @@ function log(msg: string): void {
   console.log(`[${nowIso()}] ${msg}`);
 }
 
-function publishHeartbeat(status: "alive" | "shutdown", note?: string): void {
+function publishHeartbeat(status: HeartbeatPayload["status"], note?: string): void {
   try {
     publish("riven", "*", {
       topic: "heartbeat",
@@ -139,7 +140,7 @@ async function main(): Promise<void> {
   // Graceful shutdown
   process.on("SIGINT", () => {
     log("Riven Cursor Terminal loop shutting down");
-    publishHeartbeat("shutdown", "terminal-closed");
+    publishHeartbeat("alive", "shutdown:terminal-closed");
     process.exit(0);
   });
 


### PR DESCRIPTION
## What

`publishHeartbeat` in [`tools/riven/riven-cursor-terminal-loop.ts`](https://github.com/Lucent-Financial-Group/Zeta/blob/main/tools/riven/riven-cursor-terminal-loop.ts) accepted `"alive" | "shutdown"`, but the bus's `HeartbeatPayload.status` is `"alive" | "idle" | "working"`. The bus's `status` consumer (tools/bus/bus.ts:331) explicitly filters to that union — `"shutdown"` would silently drop.

## Fix

- Import `HeartbeatPayload` from [`tools/bus/types`](https://github.com/Lucent-Financial-Group/Zeta/blob/main/tools/bus/types.ts)
- Bind local `status` param to `HeartbeatPayload["status"]` — single source of truth
- SIGINT call site: `publishHeartbeat("alive", "shutdown:terminal-closed")` — shutdown semantic preserved in the `note` field (which actually reaches consumers)

## Verification

`bun --bun tsc --noEmit -p tsconfig.json` → exit 0 locally.

## Drift queue (0111Z → now)

| Item | PR | State |
|------|-----|-------|
| 22 §33 xrefs | #3666 | merged |
| BACKLOG.md generated-index | #3678 | merged |
| tsc tools (this PR) | this | open |
| backlog ID uniqueness | B-0545 renumber-sweep | pending coordination |

Co-Authored-By: Claude <noreply@anthropic.com>