### PR TITLE
fix(post-merge): add git prefix to switch -c snippets in 0226Z shard (Copilot P1 #3685)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0226Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0226Z.md
@@ -65,8 +65,8 @@ Per the goal of this tick (clear the CI failure), option (b) is right-sized. If 
 
 `/private/tmp/zeta-tick-2210z`:
 
-1. `switch -c fix/tsc-riven-... FETCH_HEAD` → fix + commit + push → PR #3684
-2. `switch -c shard/tick-0226z-... FETCH_HEAD` → this shard
+1. `git switch -c fix/tsc-riven-... FETCH_HEAD` → fix + commit + push → PR #3684
+2. `git switch -c shard/tick-0226z-... FETCH_HEAD` → this shard
 
 Sibling worktree picked up node_modules this tick (`bun install --frozen-lockfile` to enable local tsc verification) — adds dep state to this worktree but stays gitignored (no commit pollution).
 


### PR DESCRIPTION
PR [#3685](https://github.com/Lucent-Financial-Group/Zeta/pull/3685) merged at 02:34:01Z with 3 unresolved Copilot P1 threads on `docs/hygiene-history/ticks/2026/05/16/0226Z.md`. Triage:

| Line | Finding | Verdict |
|------|---------|---------|
| 4 | Dead link to 0218Z.md | **STALE** — file now on main (PR #3681 merged 02:35:01Z, seconds after #3685) |
| 39/44 | Extra leading `\|` in tables (`\|\| PR | State |`) | **FALSE POSITIVE** — direct `awk` inspection shows correct single-pipe 2-column and 4-column tables |
| 68/69 | `switch -c …` missing `git` prefix | **REAL** — both `switch -c` snippets fail in a clean shell without an alias; lines 68 + 69 both affected |

This PR addresses the real finding (line 68 + 69 prepend `git`). 2 broken / 1 false positive / 2 real findings.

Co-Authored-By: Claude <noreply@anthropic.com>