### PR TITLE
fix(b-0545): adopt B-0498 collision renumber

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -302,7 +302,6 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0495](backlog/P1/B-0495-hamiltonian-viz-slice-1-static-scaffold-2026-05-14.md)** Hamiltonian viz — slice-1: static panel scaffold in demo/index.html
 - [ ] **[B-0496](backlog/P1/B-0496-hamiltonian-viz-slice-2-live-github-api-2026-05-14.md)** Hamiltonian viz — slice-2: live GitHub API commit fetch → trajectory
 - [ ] **[B-0497](backlog/P1/B-0497-b0440-slice-6-standing-by-detector-launchd-registration-2026-05-14.md)** B-0440 slice 6 — standing-by-detector launchd plist + AUTONOMOUS-LOOP.md wiring update
-- [ ] **[B-0498](backlog/P1/B-0498-riven-cursor-terminal-background-loop-ide-native-autonomous-gate-2026-05-15.md)** Riven Cursor Terminal background loop — IDE-native autonomous gate with manager contract
 - [x] **[B-0500](backlog/P1/B-0500-b0441-slice-3-queue-state-guard-poll-once-wiring-2026-05-14.md)** B-0441 slice 3 — wire isAgentQueueEmpty guard into pollOnce
 - [ ] **[B-0501](backlog/P1/B-0501-b0441-slice-5-assignment-history-dedup-cooldown-2026-05-14.md)** B-0441 slice 5 — assignment history dedup cooldown (avoid re-assigning same row within short window)
 - [ ] **[B-0502](backlog/P1/B-0502-b0441-slice-6-launchd-plist-autonomous-loop-docs-2026-05-14.md)** B-0441 slice 6 — launchd plist for backlog-ready-notifier + AUTONOMOUS-LOOP.md update
@@ -327,6 +326,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0540](backlog/P1/B-0540-standing-by-counter-with-escalation-in-rule-2026-05-15.md)** Standing-by counter-with-escalation in the rule (N consecutive brief-acks → escalate to decomposition)
 - [ ] **[B-0541](backlog/P1/B-0541-cross-surface-bus-detector-standing-by-quorum-2026-05-15.md)** Cross-surface bus detector — Standing-by quorum across Otto surfaces (extension of PR #3017 detector)
 - [ ] **[B-0542](backlog/P1/B-0542-background-service-clicks-past-stuck-prompts-2026-05-15.md)** Background service clicks past stuck prompts on foreground Otto surfaces (3-surface BFT recovery node)
+- [ ] **[B-0549](backlog/P1/B-0549-riven-cursor-terminal-background-loop-ide-native-autonomous-gate-2026-05-15.md)** Riven Cursor Terminal background loop — IDE-native autonomous gate with manager contract
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0549-riven-cursor-terminal-background-loop-ide-native-autonomous-gate-2026-05-15.md
+++ b/docs/backlog/P1/B-0549-riven-cursor-terminal-background-loop-ide-native-autonomous-gate-2026-05-15.md
@@ -1,12 +1,14 @@
 ---
-id: B-0498
+id: B-0549
 priority: P1
 status: open
 title: "Riven Cursor Terminal background loop — IDE-native autonomous gate with manager contract"
 tier: agent-infrastructure
 effort: M
 created: 2026-05-15
-last_updated: 2026-05-15
+last_updated: 2026-05-16
+renumbered_from: B-0498
+renumbered_per: B-0545
 depends_on: [B-0400]
 composes_with: [B-0440, B-0441, B-0442, B-0497]
 tags: [riven, cursor, terminal, background-service, ide-native, autonomous-loop]
@@ -148,3 +150,23 @@ Or a `.cursor/init.sh` hook (if Cursor supports workspace init scripts) that che
 ## Status
 
 Open. Design approved by Aaron 2026-05-15. Implementation queued for next autonomous cycle or explicit dispatch.
+
+## Renumber history
+
+This row was originally filed as **B-0498** on 2026-05-15. The ID collided with a pre-existing P2 row (`B-0498-substrate-evolution-algebra-rule-promotion-after-cooling-period-2026-05-14.md`, dated 2026-05-14). Per the `b0451_per_collision_renumber_procedure` memory and B-0545's filed-correction surface, first-merged-wins applies: the 2026-05-14 algebra row keeps B-0498, and this row renumbers.
+
+Renumber target was chosen by re-running `refresh-before-decide.md` at ID-allocation scope: B-0545 originally noted B-0546 as next-free, but between filing (2026-05-15T22:55Z) and execution (2026-05-16T01:53Z), B-0546/B-0547/B-0548 were claimed. Next-free at execution time was **B-0549**.
+
+**Immutable historical references that still quote `B-0498` in the Riven sense:**
+
+- PR #3603 (merged) — `feat(riven): Riven cursor-terminal loop scaffold [B-0498] (decomposed)` — merged-PR title, historical record only.
+- `docs/hygiene-history/ticks/2026/05/15/2217Z.md` — tick shard, immutable per `tick-shards-are-immutable` discipline.
+- `docs/pr-discussions/PR-3619-*` — PR-discussion archive of the B-0545 filing PR, references the Riven B-0498 in the renumber-target context. Historical record.
+
+These artifacts are NOT edited. Readers encountering `B-0498` in the Riven sense should resolve to this row (B-0549) via the `renumbered_from: B-0498` frontmatter.
+
+**Composes with:**
+
+- `memory/feedback_b0451_per_collision_renumber_procedure_external_references_rule_trumps_first_merged_2026_05_14.md` (the renumber rule)
+- B-0545 (the filed-correction surface)
+- `.claude/rules/claim-acquire-before-worktree-work.md` (ID allocation discipline that the original collision violated)

--- a/docs/backlog/P2/B-0545-b0498-collision-renumber-sweep-2026-05-15.md
+++ b/docs/backlog/P2/B-0545-b0498-collision-renumber-sweep-2026-05-15.md
@@ -3,14 +3,16 @@ id: B-0545
 priority: P2
 title: B-0498 ID collision — renumber sweep (Riven cursor-terminal scaffold → new ID)
 type: substrate-correction
-status: open
+status: done
 created: 2026-05-15
+completed: 2026-05-16
 filed_by: otto-cli
+completed_by: otto-cli
 depends_on: []
 composes_with:
   - "memory/feedback_b0451_per_collision_renumber_procedure_external_references_rule_trumps_first_merged_2026_05_14.md"
   - "B-0498-substrate-evolution-algebra-rule-promotion-after-cooling-period-2026-05-14"
-  - "B-0498-riven-cursor-terminal-background-loop-ide-native-autonomous-gate-2026-05-15"
+  - "B-0549-riven-cursor-terminal-background-loop-ide-native-autonomous-gate-2026-05-15"
 ---
 
 # B-0545 — B-0498 ID collision renumber sweep
@@ -86,3 +88,17 @@ P2 cadence: address within the next 1-2 weeks; pair with the renumber sweep tool
 - The `b0451_per_collision_renumber_procedure` memory (2026-05-14) — same shape, second instance
 - The `claim-acquire-before-worktree-work.md` rule's "ID allocation discipline" section — this collision is an instance the discipline is meant to prevent
 - `refresh-before-decide.md` invariant at ID-allocation scope — both surfaces (merged + in-flight) must be checked; the Riven-cursor row at 2026-05-15 likely skipped the on-disk B-0498 P2 check
+
+## Resolution (2026-05-16)
+
+Renumber executed in this same PR:
+
+- Renamed `docs/backlog/P1/B-0498-riven-cursor-terminal-*-2026-05-15.md` → `docs/backlog/P1/B-0549-riven-cursor-terminal-*-2026-05-15.md`
+- Updated frontmatter: `id: B-0498` → `id: B-0549`; added `renumbered_from: B-0498` and `renumbered_per: B-0545` breadcrumbs (per audit-tool recommendation)
+- Updated cross-reference: `docs/research/2026-05-15-riven-cursor-terminal-loop-design.md` Backlog line
+- Updated this row's `composes_with` to point at the new ID
+- Did **NOT** edit tick shards (`docs/hygiene-history/ticks/2026/05/15/2217Z.md`), merged-PR title (#3603), or the PR-3619 PR-discussion archive — all immutable historical artifacts. Readers resolve `B-0498` (Riven sense) → B-0549 via the renumbered_from breadcrumb.
+
+**Renumber target refresh**: B-0545 originally noted B-0546 as next-free at filing time (22:55Z 2026-05-15), but B-0546/B-0547/B-0548 were claimed in the intervening 27h. Picked B-0549 after re-running `git ls-tree origin/main -- docs/backlog/` per `refresh-before-decide.md` at ID-allocation scope.
+
+**Verification**: `bun tools/hygiene/audit-backlog-items.ts --enforce-duplicate-ids` → 0 duplicate-ID groups (was 1 before this PR).

--- a/docs/research/2026-05-15-riven-cursor-terminal-loop-design.md
+++ b/docs/research/2026-05-15-riven-cursor-terminal-loop-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-15
 **Status:** Design approved; implementation queued
-**Backlog:** B-0498
+**Backlog:** B-0549 (renumbered from B-0498 per B-0545, 2026-05-16)
 
 ## Problem
 


### PR DESCRIPTION
## Summary

- adopts the existing Otto B-0498 collision-renumber fix onto current main without rewriting Otto's branch
- renumbers the Riven cursor-terminal backlog row to B-0549 and preserves breadcrumbs
- regenerates docs/BACKLOG.md so the generated index matches the row rename

## Verification

- git diff --check
- bun tools/hygiene/audit-backlog-items.ts --enforce-duplicate-ids
- bun tools/backlog/generate-index.ts --check

## Coordination

This unblocks PR #3674's factory-wide duplicate-ID gate once merged.
