### PR TITLE
shard(tick): 2026-05-16T02:52Z — audit filter triage (17→10) + baseline-cleanup question

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0252Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0252Z.md
@@ -1,0 +1,97 @@
+# Tick 2026-05-16T02:52Z — Otto-CLI
+
+**Surface**: Otto-CLI (Claude Code, Opus 4.7 1M context, autonomous-loop tick)
+**Parent tick**: [2026-05-16T02:49Z](0249Z.md) — tick-shard relative-path audit shipped (PR #3692)
+
+## What landed this tick
+
+Fixup commit `e945016` pushed to [PR #3692](https://github.com/Lucent-Financial-Group/Zeta/pull/3692) branch — `fix(audit): skip placeholder targets`
+
+## Triage of the 17 baseline findings → filter improvement
+
+Pre-filter (tick 7): 17 findings on the full baseline run.
+
+Triage analysis this tick split the 17 into two categories:
+
+### Category A — false positives (7 findings, ~41%)
+
+Tick shards sometimes contain inline `[label](path-shape)` constructs as **pattern illustrations within prose**, not real navigation links. Examples flagged by the audit:
+
+| Path target | Why it's a placeholder |
+|-------------|------------------------|
+| `path` | pure identifier |
+| `otto-kenji-...` | ellipsis-marked example |
+| `.claude/...` | ellipsis placeholder |
+| `docs/...` | ellipsis placeholder |
+| `docs/api(v2` | fragmentary malformed syntax |
+| `docs/research/...amara-...md` | ellipsis-marked example |
+
+### Category B — real broken links (10 findings, ~59%)
+
+Survived the filter — wrong-depth `..` patterns + one borderline `docs/foo.md` example. Concentrated in 2 shards:
+
+- `docs/hygiene-history/ticks/2026/05/15/1436Z.md` — 5 broken links (wrong-depth `..` for backlog rows + `.claude/rules/` reference)
+- `docs/hygiene-history/ticks/2026/05/15/0329Z.md` — 3 broken links (same wrong-depth pattern)
+- `docs/hygiene-history/ticks/2026/04/29/0852Z.md` — 1 link to a `docs/research/...` file (probable migration target)
+- `docs/hygiene-history/ticks/2026/05/14/2158Z.md:29` — 1 link to `docs/foo.md` (borderline example)
+
+### Filter implementation
+
+```ts
+function isPlaceholderTarget(target: string): boolean {
+  if (target.includes("...")) return true;           // ellipsis placeholder
+  if (target.includes("(") || target.includes(")")) return true;  // malformed/fragment
+  if (!target.includes("/") && !target.includes(".")) return true; // pure identifier
+  return false;
+}
+```
+
+Applied before `checkLink` resolves the path. Reduces baseline from 17 → 10.
+
+## The baseline-cleanup question (open for next-tick)
+
+The 10 surviving findings are in tick shards. **Tick-shard immutability discipline** (per the `claim-acquire-before-worktree-work.md` rule's "ID allocation discipline" section + various other surfaces) says historical shards shouldn't be in-place-edited.
+
+Two readings of the discipline:
+
+1. **Strict reading**: never edit a merged shard. → Baseline-cleanup PR is infeasible; the 10 stay as historical residue forever. Audit stays detect-only forever or needs a grandfather mechanism.
+2. **Pragmatic reading**: don't alter historical CONTENT, but broken navigation is an operational defect (the reader can't reach the cited substrate). Fix as bug, not as rewrite.
+
+The §33 audit's baseline cleanup (PR #3552) operated on **mutable surfaces** (rules, memory, backlog rows) — not tick shards. So there's no direct precedent for the strict-vs-pragmatic question at tick-shard scope.
+
+**This tick declines to unilaterally edit.** The question is real and worth a deliberate decision (not slipped into another speculative tick). Candidate paths:
+
+- Add a `--baseline <file>` flag to the audit; freeze the 10 in a baseline file; enforce only on `new_findings - baseline`. Same shape as Stryker baseline / ESLint suppressions.
+- File a backlog row for "Tick-shard relative-path baseline cleanup vs immutability discipline" — let the human or a coordination tick make the call.
+
+Next tick or a deliberate coordination tick can pick one.
+
+## State at tick end
+
+| PR | State |
+|----|-------|
+| [#3690](https://github.com/Lucent-Financial-Group/Zeta/pull/3690) (0240Z shard, tick 6) | OPEN, un-armed |
+| [#3692](https://github.com/Lucent-Financial-Group/Zeta/pull/3692) (audit + this fixup) | OPEN, un-armed; 2 commits (initial + filter improvement) |
+| [#3693](https://github.com/Lucent-Financial-Group/Zeta/pull/3693) (0249Z shard, tick 7) | OPEN, un-armed |
+| (this tick) | this shard |
+
+GraphQL still 0/5000 (resets in 158s at 02:55:28Z). REST sufficient for fixup push (used `git push`, no API).
+
+## Operational notes
+
+### Filter design lesson
+
+The first audit baseline gave **noisy useful signal** — 17 findings with ~41% false-positive rate. The triage broke down the FP class cleanly (placeholder syntax in prose) and produced a single 16-line filter that fixed them all. Pattern: ship MVP detect-only → triage real-world findings → improve precision → iterate.
+
+The §33 audit followed the same pattern (PR #3548 scanner → P3 cleanup → enforce). Three iterations on a 4-week scale; here it was three iterations within one tick session. Cadence varies; pattern is the same.
+
+### Holding-discipline state
+
+Substantive substrate landed (fixup commit on #3692 + this shard). Counter resets per "actually picking real decomposition work" clause.
+
+## Next-tick candidates
+
+1. **Arm auto-merge on PR #3690 + #3692 + #3693** once GraphQL resets at 02:55:28Z (use `gh pr merge N --auto --squash`)
+2. **Decide on baseline cleanup strategy** for the 10 remaining findings — `--baseline` flag implementation OR file backlog row OR explicit "detect-only forever" decision
+3. **B-0545 renumber-sweep** (still pending; prior session's claim from 01:44Z; check at 25:44 from then = 02:44Z+ to see if claim TTL'd)
+4. **Wire CI gate** for the audit, contingent on baseline-cleanup decision

--- a/docs/hygiene-history/ticks/2026/05/16/0252Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0252Z.md
@@ -50,7 +50,7 @@ Applied before `checkLink` resolves the path. Reduces baseline from 17 → 10.
 
 ## The baseline-cleanup question (open for next-tick)
 
-The 10 surviving findings are in tick shards. **Tick-shard immutability discipline** (per the `claim-acquire-before-worktree-work.md` rule's "ID allocation discipline" section + various other surfaces) says historical shards shouldn't be in-place-edited.
+The 10 surviving findings are in tick shards. **Tick-shard immutability discipline** — canonical statement at `docs/hygiene-history/ticks/README.md`: "Each shard is an immutable per-tick event" per the Git-native CQRS / Event Sourcing framing — says historical shards shouldn't be in-place-edited.
 
 Two readings of the discipline:
 
@@ -93,5 +93,5 @@ Substantive substrate landed (fixup commit on #3692 + this shard). Counter reset
 
 1. **Arm auto-merge on PR #3690 + #3692 + #3693** once GraphQL resets at 02:55:28Z (use `gh pr merge N --auto --squash`)
 2. **Decide on baseline cleanup strategy** for the 10 remaining findings — `--baseline` flag implementation OR file backlog row OR explicit "detect-only forever" decision
-3. **B-0545 renumber-sweep** (still pending; prior session's claim from 01:44Z; check at 25:44 from then = 02:44Z+ to see if claim TTL'd)
+3. **B-0545 renumber-sweep** (still pending; prior session's claim from 01:44Z still active under the bus-claim 24h TTL, which expires at 2026-05-17T01:44Z; check before duplicating)
 4. **Wire CI gate** for the audit, contingent on baseline-cleanup decision


### PR DESCRIPTION
Tick 8 substantive landing: filter improvement on PR #3692's audit script (`isPlaceholderTarget` skips ellipsis/paren/identifier placeholders), reducing baseline 17 → 10 findings. The 10 remaining are real wrong-depth `..` bugs in 2 shards.

Open question for next tick: tick-shard immutability discipline strict vs pragmatic — can the 10 be edited in-place (treat as bug-fix), or do they need a grandfather mechanism (Stryker-baseline-style)?

GraphQL rate-limit still 0; resets 02:55:28Z. 3 PRs queued un-armed: #3690 #3692 #3693.

Co-Authored-By: Claude <noreply@anthropic.com>