### PR TITLE
shard(tick): 2026-05-16T03:10Z — baseline mechanism resolves immutability question (PR #3699)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0310Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0310Z.md
@@ -1,0 +1,88 @@
+# Tick 2026-05-16T03:10Z — Otto-CLI
+
+**Surface**: Otto-CLI (Claude Code, Opus 4.7 1M context, autonomous-loop tick)
+**Parent tick**: [2026-05-16T03:04Z](0304Z.md) — Copilot round-2 on PR #3692
+
+## What landed this tick
+
+[PR #3699](https://github.com/Lucent-Financial-Group/Zeta/pull/3699) — `feat(audit): add --baseline flag + initial baseline of 10 grandfathered findings`
+
+**Resolves the baseline-cleanup question deferred since tick 8** via option D — a `--baseline <path>` grandfather mechanism. Avoids the tick-shard-immutability tension entirely: don't edit historical shards; track what's grandfathered so new violations still fail CI.
+
+Same shape as Stryker `--reset` or ESLint suppressions.
+
+## Mechanism
+
+| Flag combination | Behavior |
+|------------------|----------|
+| (none) | detect-only; list all findings |
+| `--baseline <path>` | partition findings into baseline-matched vs new; only list NEW in human output |
+| `--enforce` | exit 1 on ANY finding (legacy behavior) |
+| `--enforce --baseline <path>` | exit 1 ONLY on NEW findings (gate behavior) |
+| `--json` | adds `newFindings`, `baselineMatched`, `baselineLoaded` fields |
+| `--baseline /missing` | exit 64 with structured error |
+
+Match key is `(file, line, target)` triple. `reason` and `resolved` are NOT part of the match — a finding's resolution path can change without invalidating the baseline entry, but if the link target shape itself changes, the entry no longer applies (which is intentional).
+
+## Initial baseline ships with 10 findings
+
+`tools/hygiene/audit-tick-shard-relative-paths.baseline.json` (1.8 KB) freezes the empirical baseline from the 2026-05-16T02:48Z run on origin/main:
+
+- 1 in 0852Z.md (line 1) — moved `docs/research/...` reference
+- 5 in 1436Z.md (lines 6×2, 30, 36×2) — wrong-depth `..` for backlog rows + a `.claude/rules/` reference
+- 3 in 0329Z.md (lines 6, 7, 20) — same wrong-depth pattern for backlog rows
+- 1 in 2158Z.md (line 29) — borderline `docs/foo.md` placeholder
+
+## Operational race this tick
+
+Push timing:
+
+1. 03:08:39Z — PR #3692 (4-commit audit script + filters + Copilot fixups) MERGED via auto-merge
+2. 03:08:45Z (approx) — my baseline-feature commit `1b01cf1` pushed to `feat/audit-tick-shard-relative-paths-otto-cli-2026-05-16`
+3. Commit landed on remote but PR was already closed → orphaned
+
+Recovery: created fresh branch `feat/audit-baseline-mechanism-otto-cli-2026-05-16` off main, cherry-picked the commit, opened PR #3699. Clean.
+
+**Lesson**: stacked PRs on auto-merged branches can race the merge. When pushing follow-on commits to an armed-but-not-yet-merged PR's branch, the safer pattern is "fresh branch off main + cherry-pick". The first-push-wins discipline (already in `claim-acquire-before-worktree-work.md`) extends to "first-merge-wins" at this scope.
+
+## Transient state on PR #3699's CI
+
+Running the audit on PR #3699's branch (cherry-picked + new shards merged) shows 11 findings: 10 grandfathered + 1 NEW. The 1 NEW is `0249Z.md:4 → 0240Z.md` — my 0249Z shard cites 0240Z as parent-tick, but `0240Z.md` hasn't merged to main yet (PR #3690 is armed + awaiting CI).
+
+Will self-resolve when #3690 merges. PR #3699 ships the mechanism only (no `--enforce --baseline` wired to CI yet), so the transient new finding is harmless.
+
+## State at tick end
+
+| PR | State |
+|----|-------|
+| [#3690](https://github.com/Lucent-Financial-Group/Zeta/pull/3690) (0240Z shard, tick 6) | OPEN, armed |
+| ~~[#3692](https://github.com/Lucent-Financial-Group/Zeta/pull/3692)~~ | MERGED 03:08:39Z |
+| ~~[#3697](https://github.com/Lucent-Financial-Group/Zeta/pull/3697)~~ | MERGED 03:04:32Z |
+| [#3698](https://github.com/Lucent-Financial-Group/Zeta/pull/3698) (0304Z shard, tick 10) | OPEN, armed |
+| [#3699](https://github.com/Lucent-Financial-Group/Zeta/pull/3699) (this tick) | OPEN, armed |
+| (this shard) | shard PR pending |
+
+## Audit-script PR lifecycle status
+
+| Step | Tick | PR | Status |
+|------|------|----|--------|
+| Discovery | 3 | n/a | done |
+| Narrow fix per-shard | 3 | #3676, #3680 | merged |
+| Scanner authored | 7 | #3692 | merged |
+| Filter improvement (17→10) | 8 | #3692 (fixup) | merged |
+| Quality findings round 1 (4 fixes) | 9 | #3692 (fixup) | merged |
+| Quality findings round 2 (2 fixes, cross-platform) | 10 | #3692 (fixup) | merged |
+| **Baseline mechanism** | **11 (this)** | **#3699** | **armed** |
+| CI enforce wire | next | (gate.yml addition) | pending |
+
+The baseline mechanism unblocks the CI-gate wire-up. Next-tick can wire `--enforce --baseline` as a non-required check without breaking on the 10 pre-existing findings.
+
+## Holding-discipline state
+
+Concrete substrate landed this tick (the baseline mechanism + initial baseline file). Counter resets per "actually picking real decomposition work" clause. Pivoted cleanly from a stuck-decision (immutability question deferred since tick 8) to a deliberate substrate landing.
+
+## Next-tick candidates
+
+1. **Wire CI gate** for the audit: add `lint (tick-shard relative-paths)` job to `.github/workflows/gate.yml` invoking `bun tools/hygiene/audit-tick-shard-relative-paths.ts --enforce --baseline tools/hygiene/audit-tick-shard-relative-paths.baseline.json`
+2. **Monitor remaining 3 armed PRs to merge** (#3690, #3698, #3699)
+3. **B-0545 renumber-sweep** (claim active until 2026-05-17T01:44Z)


### PR DESCRIPTION
Tick 11: --baseline flag added to the tick-shard audit. Resolves the immutability question deferred since tick 8 by choosing grandfather mechanism (option D) — don't edit shards; track baseline; new violations still fail --enforce.

PR #3692 merged 03:08:39Z and raced my baseline-feature push by ~6s; recovered via cherry-pick onto fresh branch ([PR #3699](https://github.com/Lucent-Financial-Group/Zeta/pull/3699)).

Audit lifecycle now at 7 steps (discovery → narrow-fix → scanner → filter → quality-r1 → quality-r2 → baseline). CI-gate wire-up is the next-tick candidate, unblocked.

Co-Authored-By: Claude <noreply@anthropic.com>