### PR TITLE
feat(ci): wire lint (tick-shard relative-paths) gate — --enforce --baseline

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -764,6 +764,38 @@ jobs:
       - name: Run audit-section-33-migration-xrefs (--enforce)
         run: bun tools/hygiene/audit-section-33-migration-xrefs.ts --enforce
 
+  lint-tick-shard-relative-paths:
+    # Fail if any tick shard at docs/hygiene-history/ticks/YYYY/MM/DD/HHMMZ.md
+    # contains a broken relative-path link (target resolves outside the repo
+    # root or to a missing file). Tick shards live 5 directories below docs/,
+    # so the count-the-`..` pattern is error-prone — the agent shipped 5-`..`
+    # paths twice in one session (PR #3676 / PR #3679, 2026-05-16) where
+    # `../../../../../.claude/rules/X.md` lands at `docs/.claude/...` instead
+    # of repo root. Copilot caught both via review threads.
+    #
+    # Lifecycle: discovery #3676/#3679 → narrow fix #3680 → scanner #3692 →
+    # filter + quality rounds #3692 (fixups) → baseline mechanism #3699 →
+    # CI enforce gate (this job). The `--baseline` flag grandfathers the 10
+    # pre-existing findings recorded in audit-tick-shard-relative-paths.baseline.json
+    # so historical residue in immutable shards doesn't block — new violations
+    # still fail. Same shape as Stryker `--reset` or ESLint suppressions.
+    name: lint (tick-shard relative-paths)
+    timeout-minutes: 2
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        run: ./tools/setup/install.sh
+
+      - name: Run audit-tick-shard-relative-paths (--enforce --baseline)
+        run: |
+          bun tools/hygiene/audit-tick-shard-relative-paths.ts \
+            --enforce \
+            --baseline tools/hygiene/audit-tick-shard-relative-paths.baseline.json
+
   lint-backlog-id-uniqueness:
     # Fail if any B-NNNN ID is claimed by more than one backlog row file.
     # Cross-agent ID-allocation collisions (Otto-CLI vs Otto-Desktop on


### PR DESCRIPTION
## What

Adds the final step of the tick-shard-relative-path audit lifecycle: a CI gate (`lint-tick-shard-relative-paths`) that runs

```bash
bun tools/hygiene/audit-tick-shard-relative-paths.ts \
  --enforce \
  --baseline tools/hygiene/audit-tick-shard-relative-paths.baseline.json
```

Exit 1 only on NEW findings (not in baseline). 10 pre-existing findings stay grandfathered.

## Lifecycle now complete

| Step | PR | State |
|------|-----|-------|
| Discovery | #3676 + #3679 | merged |
| Narrow fix per-shard | #3680 | merged |
| Scanner | #3692 | merged |
| Filter + quality × 3 | #3692 (fixups) | merged |
| Baseline mechanism | #3699 | merged |
| **CI enforce gate** | **this** | **proposed** |

Same 4-step §33 audit lifecycle pattern (PR #3513 → #3552 → enforce), compressed across 14 ticks of this session.

## Local verify

- 842 shards scanned (was 833 in tick 7; +9 from this session's merges)
- 10 grandfathered (matches baseline)
- 0 NEW findings
- exit 0

## CI surface

Per existing convention in `.github/workflows/gate.yml`, this job is **non-required by default**. The gate surfaces on every PR as a status check; branch-protection rules govern which subset is required for merge. The §33-migration-xrefs sibling is also a non-required check by default.

Co-Authored-By: Claude <noreply@anthropic.com>