### PR TITLE
shard(tick): 2026-05-16T03:44Z — check-shard-before-push helper shipped (PR #3716)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0344Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0344Z.md
@@ -1,0 +1,73 @@
+# Tick 2026-05-16T03:44Z — Otto-CLI
+
+**Surface**: Otto-CLI (Claude Code, Opus 4.7 1M context, autonomous-loop tick)
+**Parent tick**: 2026-05-16T03:40Z (PR #3715, still in queue at tick-start)
+
+## What landed this tick
+
+3 PRs from prior ticks merged in rapid succession: #3711 (0334Z shard, 03:37:55Z), #3709 (0328Z shard, 03:41:25Z), #3710 (AUDIT-LIFECYCLE.md, 03:42:15Z). The audit-lifecycle template doc is now on main.
+
+[PR #3716](https://github.com/Lucent-Financial-Group/Zeta/pull/3716) — `feat(hygiene): bundled pre-push self-check helper for tick shards`
+
+## The helper
+
+`tools/hygiene/check-shard-before-push.ts` (187 lines) bundles the three self-checks I've been running per-tick this session into one command:
+
+| Check | What it catches |
+|-------|-----------------|
+| MD032 awk-style scan | Paragraph immediately followed by bullet list without blank line |
+| `bun x markdownlint-cli2` | Broad markdown lint surface (MD038 no-space-in-code, MD024, etc.) |
+| `audit-tick-shard-relative-paths --files` | Broken relative-path links in the input shard |
+
+## Motivation
+
+Today's tick 13 self-bite: I shipped an MD038 violation to PR #3707 because the manual self-check I'd been running used `awk` (paragraph-before-bullet scan only) — it missed the MD038 trailing-space-in-backticks class. The required CI check failed, blocking auto-merge for ~10 min on that PR until I noticed and pushed a fixup.
+
+A bundled helper closes the gap: one command runs ALL three checks, including the broad `markdownlint-cli2` surface. The local-feedback loop shrinks from "push → wait for CI" to "single command + immediate output."
+
+## Verification
+
+| Test | Result |
+|------|--------|
+| Clean shard (0334Z.md) | exit 0; all 3 checks ok |
+| Synthetic bad shard (MD032 + MD038) | exit 1; both findings printed |
+| Missing file | exit 64 with structured `input not found` |
+| No args | exit 64 with usage |
+| `tsc --noEmit` | exit 0 |
+| markdownlint on the helper file itself | exit 0 |
+
+## Scope distinction
+
+**DX helper, not a CI gate.** CI gates remain authoritative — the markdownlint job, the `lint (tick-shard relative-paths)` gate from PR #3708, and the per-PR Copilot review pass. This helper just shortens the local-feedback loop.
+
+## Audit-script + helper ecosystem now on main
+
+After tick 17, the full ecosystem for tick-shard hygiene is:
+
+| File | Role |
+|------|------|
+| `tools/hygiene/audit-tick-shard-relative-paths.ts` | The audit (detect-only + --enforce + --baseline) |
+| `tools/hygiene/audit-tick-shard-relative-paths.baseline.json` | Grandfather list (10 entries) |
+| `.github/workflows/gate.yml` `lint-tick-shard-relative-paths` | CI enforce gate (non-required) |
+| `tools/hygiene/AUDIT-LIFECYCLE.md` | The reusable 7-step template for future hygiene audits |
+| `tools/hygiene/check-shard-before-push.ts` (this PR) | Bundled DX helper |
+
+The path from "this bug shipped twice" (PR #3676 + #3679 with wrong-depth `..`) to "fully mechanized + bundled into local DX" is now closed. Bug class extinct.
+
+## State at tick end
+
+| PR | State |
+|----|-------|
+| [#3715](https://github.com/Lucent-Financial-Group/Zeta/pull/3715) (0340Z shard) | OPEN, armed |
+| [#3716](https://github.com/Lucent-Financial-Group/Zeta/pull/3716) (this helper) | OPEN, armed |
+
+## Holding-discipline state
+
+Concrete substrate landed (the helper). Counter resets.
+
+## Next-tick candidates
+
+1. **Monitor #3715 + #3716 to merge**
+2. **B-0545 renumber-sweep** (claim still active until 2026-05-17T01:44Z)
+3. **Update the AUDIT-LIFECYCLE.md** to mention this helper as a 4th step in the discovery + scanner + gate triad (the "DX helper" step, optional, fits between scanner and gate). Could also be promoted as a step-3.5 in the 7-step pattern.
+4. **Suspect-Copilot-finding rule** — capture the 4-time table-pipe false-positive pattern in `.claude/rules/`


### PR DESCRIPTION
Tick 17: bundled 3 per-tick self-checks into one command at `tools/hygiene/check-shard-before-push.ts` ([PR #3716](https://github.com/Lucent-Financial-Group/Zeta/pull/3716)). 187-line TS.

3 prior PRs merged (#3711, #3709, #3710). Full tick-shard hygiene ecosystem on main: audit + baseline + CI gate + AUDIT-LIFECYCLE.md + DX helper. Wrong-depth bug class extinct end-to-end.

Co-Authored-By: Claude <noreply@anthropic.com>