### PR TITLE
fix(check-shard-before-push): skip bullet-continuation lines in MD032 scan

### DIFF
--- a/tools/hygiene/check-shard-before-push.ts
+++ b/tools/hygiene/check-shard-before-push.ts
@@ -79,6 +79,15 @@ function buildCodeFenceFlags(lines: readonly string[]): boolean[] {
   return flags;
 }
 
+// A line starting with whitespace is typically a wrap-continuation of the
+// previous structural element (list-item continuation, blockquote-continuation,
+// fenced-block-continuation). markdownlint correctly treats these as part
+// of the prior element, NOT as a paragraph that would need a blank line
+// before a following list. Detect by leading whitespace on the prev line.
+function isContinuationLine(line: string): boolean {
+  return /^\s/.test(line);
+}
+
 function checkMd032(file: string): Md032Finding[] {
   const text = readFileSync(file, "utf8");
   const lines = text.split("\n");
@@ -90,9 +99,11 @@ function checkMd032(file: string): Md032Finding[] {
     const cur = lines[i]!;
     // Trigger: cur starts with "- " bullet AND prev is non-blank
     //          AND prev is not itself a structural marker (#, >, *, -, |, ```)
+    //          AND prev is not a wrap-continuation of a prior structural element
     if (!cur.startsWith("- ")) continue;
     if (prev.trim() === "") continue;
     if (/^[#>*\-|`]/.test(prev)) continue;
+    if (isContinuationLine(prev)) continue;
     findings.push({ file, line: i + 1, paragraph: prev, bullet: cur });
   }
   return findings;


### PR DESCRIPTION
Helper bug discovered in tick 19 while running the helper on `.claude/rules/blocked-green-ci-investigate-threads.md` — `checkMd032` flagged 3 bullet-continuation lines as paragraphs (prev line was 2-space-indented continuation of a list item). Markdownlint correctly ignores these.

Fix: add `isContinuationLine(line)` predicate; skip when prev is a continuation line.

3 smoke tests: bullet-continuation FP cleared; real paragraph-before-bullet still caught; existing-clean-shard regression ok. `tsc --noEmit` exit 0.

Co-Authored-By: Claude <noreply@anthropic.com>