### PR TITLE
docs(tick): fix PR 3741 shard link

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0438Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0438Z.md
@@ -38,7 +38,7 @@ This tick exposed a recurring pattern:
 4. **HEAD desync mid-chain**: an earlier shard commit (`6015c61`) landed on the previous tick's branch instead of the just-created branch, suggesting Lior's cleanup may touch HEAD/index files
 
 The shipped tool that detects this exact failure class is
-[`tools/orchestrator-checks/cron-sentinel-mutex.ts`](../../../tools/orchestrator-checks/cron-sentinel-mutex.ts) — which only catches **Otto-CLI peers**, not Lior. The
+[`tools/orchestrator-checks/cron-sentinel-mutex.ts`](../../../../../../tools/orchestrator-checks/cron-sentinel-mutex.ts) — which only catches **Otto-CLI peers**, not Lior. The
 [`.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md)
 rule documents the Lior-specific class with the strongest available mitigations (process-list check before worktree create, atomic commit chains).
 


### PR DESCRIPTION
## Summary
- Fix the broken relative link to tools/orchestrator-checks/cron-sentinel-mutex.ts in the 2026-05-16 0438Z tick shard.
- Preserves the PR #3741 Copilot/CI finding after #3741 merged before the fix could land there.

## Verification
- git diff --check origin/main...HEAD
- bun tools/hygiene/audit-tick-shard-relative-paths.ts --enforce --baseline tools/hygiene/audit-tick-shard-relative-paths.baseline.json
- bun tools/hygiene/check-tick-history-order.ts
- bun run lint:markdown docs/hygiene-history/ticks/2026/05/16/0438Z.md