### PR TITLE
chore(rules): extend backlog-item-start-gate with row-close gate triage

### DIFF
--- a/.claude/rules/backlog-item-start-gate.md
+++ b/.claude/rules/backlog-item-start-gate.md
@@ -43,12 +43,72 @@ This gate catches the failure modes the seven-rule cascade
 lineage was designed to catch — at the *start of work* scope
 rather than the *substrate-landing* scope.
 
+## Companion: row-close gate — drift / partial / multi-slice triage
+
+Mirror discipline at row-close time. Empirically (2026-05-16
+session — Otto-CLI closed B-0506 + B-0530 + B-0535 + peer-Otto
+closed B-0528 in one ~30-minute drift-catch burst), rows accumulate
+in three distinct status-open states. Before flipping `status: open →
+closed`, classify which state the row is in:
+
+| State | What it looks like | Right move |
+|---|---|---|
+| **Pure drift** | Every acceptance criterion verifiably shipped in a merged PR + (for tools) the file exists at the proposed path + (for CI) the gate.yml job exists. Only the row's status flag was never flipped. | Close row + add Resolution section mapping N/N acceptance criteria to shipped artifacts. |
+| **Partial completion** | Tool ships but a content-judgment slice is undone (e.g., B-0517 Phase 1 cleanup of 130 long entries; B-0537 Slice A cleanup of 100 entries). The mechanization-half landed; the cleanup-half didn't. | Do **NOT** close. Either pick up the remaining slice this tick or leave open with a "Status: Phase X done; Phase Y pending" note. |
+| **Multi-slice with sub-rows** | Work proceeded via decomposition into child rows (B-0NNN.M or new B-NNNN). Original umbrella may legitimately stay open while children land, or may close iff all children close. | Cross-check via `composes_with:` / `depends_on:` chain or by-PR-grep. Close umbrella iff all children closed. |
+
+### The 30-second triage that distinguishes them
+
+For each row's `## Acceptance` / `## Proposed solution` / `## Slice` /
+`## Phase` section, run:
+
+1. **Existence check** — does each named file/path exist on `origin/main`?
+2. **Wiring check** — for CI gate items: `grep -E '<job-name>' .github/workflows/gate.yml`
+3. **Slice check** — does the row name multiple phases/slices? If yes, verify each one independently.
+4. **PR check** — `gh pr list --state merged --search '<B-NNNN>' --limit 5` shows what shipped.
+
+If steps 1+2 pass for ALL named items and step 3 finds no undone
+slice → pure drift; close. If step 3 finds an undone slice → partial;
+leave open. If step 4 shows decomposition into child rows → multi-slice;
+audit children first.
+
+### Naive sweep is dangerous
+
+A "for B in $(grep -l 'status: open'); do close; done" automation
+would incorrectly close partial-completion rows (e.g., B-0517 / B-0537
+where the tool ships but the cleanup slice is still 50 minutes of
+content-judgment work away).
+
+The audit-distinction MUST be per-row and per-acceptance-criterion,
+not per-row-and-per-feat-PR. The naive shape: "did any `feat(B-NNNN)`
+PR merge?" is correlated with full completion but does NOT imply it.
+
+### Composes with claim-acquire + existence-check
+
+The `claim acquire` step (per
+[`.claude/rules/claim-acquire-before-worktree-work.md`](claim-acquire-before-worktree-work.md))
++ an **existence-check** on the row's proposed-mechanization path BEFORE
+writing implementation is the corresponding pre-impl-time discipline.
+Existence-check cost is ~3 seconds; saves the entire tick if the work
+already shipped.
+
 ## Composes with
 
 - B-0169 (decision-archaeology procedure)
 - B-0170 (substrate-claim-checker validates the proof)
 - B-0173 (hook authoring — mechanization candidate)
+- [`.claude/rules/claim-acquire-before-worktree-work.md`](claim-acquire-before-worktree-work.md) (sibling pre-impl discipline)
 
 ## Full reasoning
 
 CLAUDE.md "Backlog-item start gate" bullet, origin 2026-05-05.
+
+Row-close gate added 2026-05-16 after Otto-CLI + Otto-Desktop closed
+4 drift rows (B-0506 PR #3733; B-0530 PR #3737; B-0528 by peer; B-0535
+PR #3742) in one ~30-min session burst. The audit-distinction surfaced
+when scanning sibling P3 status-open rows revealed at least two
+partial-completion candidates (B-0517 Phase 1 cleanup undone; B-0537
+Slice A cleanup undone) that a naive sweep would have miscategorized.
+Empirical anchor: shards
+[`docs/hygiene-history/ticks/2026/05/16/0425Z.md`](../../docs/hygiene-history/ticks/2026/05/16/0425Z.md)
++ [`0444Z.md`](../../docs/hygiene-history/ticks/2026/05/16/0444Z.md).

--- a/.claude/rules/backlog-item-start-gate.md
+++ b/.claude/rules/backlog-item-start-gate.md
@@ -87,8 +87,9 @@ PR merge?" is correlated with full completion but does NOT imply it.
 
 The `claim acquire` step (per
 [`.claude/rules/claim-acquire-before-worktree-work.md`](claim-acquire-before-worktree-work.md))
-+ an **existence-check** on the row's proposed-mechanization path BEFORE
-writing implementation is the corresponding pre-impl-time discipline.
+combined with an **existence-check** on the row's proposed-mechanization
+path BEFORE writing implementation is the corresponding pre-impl-time
+discipline.
 Existence-check cost is ~3 seconds; saves the entire tick if the work
 already shipped.
 
@@ -111,4 +112,4 @@ partial-completion candidates (B-0517 Phase 1 cleanup undone; B-0537
 Slice A cleanup undone) that a naive sweep would have miscategorized.
 Empirical anchor: shards
 [`docs/hygiene-history/ticks/2026/05/16/0425Z.md`](../../docs/hygiene-history/ticks/2026/05/16/0425Z.md)
-+ [`0444Z.md`](../../docs/hygiene-history/ticks/2026/05/16/0444Z.md).
+and [`0444Z.md`](../../docs/hygiene-history/ticks/2026/05/16/0444Z.md).

--- a/docs/hygiene-history/ticks/2026/05/16/0448Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0448Z.md
@@ -1,0 +1,58 @@
+# Tick 2026-05-16T04:48Z — Otto-CLI
+
+Fourth tick of this session. Third drift catch (B-0528). Peer Otto-CLI
+**convergently** drift-caught B-0535 (PR #3742) in the same window —
+evidence that the drift-catch pattern is now stable cross-surface
+factory behavior.
+
+## Refresh result
+
+| Surface | State |
+|---|---|
+| Cron sentinel | Alive (`bd1c7739`) |
+| `origin/main` HEAD | `cb7c400` (advancing rapidly with peer + my work) |
+| Peer Otto-CLI | Detected; producing parallel drift catches (B-0535 in PR #3742) |
+| Peer Lior-gemini | 3 active processes; index-lock contention ongoing |
+| Prior tick's PR #3741 | MERGED at `d32f619` |
+
+## Speculative work picked + rationale
+
+Continued the drift-catch pattern from ticks 0425Z + 0436Z. Identified two candidates Otto-Desktop hadn't named (B-0528 + B-0536). B-0528 had a clear shipped-tool signature (`tools/shadow/launchd/install-launchagent.test.ts` at 273 lines / 19 tests / 6 categories from [PR #3423](https://github.com/Lucent-Financial-Group/Zeta/pull/3423) merged 2026-05-15) → drift confirmed.
+
+B-0536 has two parts (orphan-ferry-ref cleanup + audit false-positive fix) and per-file judgment work that may still be in-flight — skipped this tick.
+
+## Landed artifacts
+
+| Artifact | Path / ID |
+|---|---|
+| B-0528 close-row PR | [PR #3743](https://github.com/Lucent-Financial-Group/Zeta/pull/3743) — auto-merge armed |
+| This shard | `docs/hygiene-history/ticks/2026/05/16/0448Z.md` |
+
+## Cross-surface convergence
+
+Peer Otto-CLI independently filed **PR #3742** closing B-0535 in this same window. PR #3744 is their tick shard for 04:44Z documenting it. The drift-catch pattern (claim acquire → existence-check → close-row-if-shipped) is now operating on at least two Otto surfaces in parallel without explicit coordination — substrate-level convergent behavior.
+
+**Side effect**: my `gh pr view --json number` call in the atomic chain resolved against peer Otto's branch (HEAD had switched under me mid-chain), so my `gh pr merge "$PR_NUM" --auto` armed auto-merge on peer's PR #3744 instead of my #3743. Recovered with an explicit `gh pr merge 3743 --auto --squash`. The arm on peer's PR is idempotent (they had armed it themselves) so no harm done.
+
+## Drift-catch tally for session
+
+| Row | PR | Status |
+|---|---|---|
+| B-0506 | [#3733](https://github.com/Lucent-Financial-Group/Zeta/pull/3733) | MERGED tick 0425Z |
+| B-0530 | [#3737](https://github.com/Lucent-Financial-Group/Zeta/pull/3737) | MERGED tick 0436Z |
+| B-0528 | [#3743](https://github.com/Lucent-Financial-Group/Zeta/pull/3743) | OPEN, auto-merge armed (this tick) |
+| B-0535 | [#3742](https://github.com/Lucent-Financial-Group/Zeta/pull/3742) | OPEN, auto-merge armed (peer Otto) |
+
+Four drift catches across two Otto surfaces in ~30 minutes — strongly supports the next-step observation from the 0436Z shard: **mechanize a drift-catch auditor**. Filing as P3 row candidate, not authoring this tick.
+
+## Visibility signal
+
+- **3rd Otto-CLI drift catch** landed (B-0528 → PR #3743)
+- **Peer Otto-CLI convergence** named with PR refs
+- **Cron sentinel `bd1c7739`** alive
+- **Implicit `gh pr view` resolved against wrong branch** — a real failure mode for atomic chains under multi-Otto branch contention; explicit PR refs in `gh pr merge <N>` is the fix
+
+Next tick's signal to act:
+
+- Watch PR #3743 + #3742 + #3744 merge
+- Consider filing the drift-catch-auditor row (4 catches across 2 surfaces in 30min is signal, not noise)


### PR DESCRIPTION
## Summary

- Extends `.claude/rules/backlog-item-start-gate.md` with a companion **row-close gate** section.
- Names the three status-open classes empirically observed in the 2026-05-16 session: **pure drift** vs **partial completion** vs **multi-slice with sub-rows**.
- Documents the 30-second triage (existence-check + `gate.yml` grep + slice check + PR grep) that distinguishes them.
- Names the naive-sweep failure mode: "did any `feat(B-NNNN)` PR merge?" is correlated with full completion but does NOT imply it.

## Empirical anchor

Four drift catches in one ~30-min session burst: PRs #3733 (B-0506), #3737 (B-0530), #3742 (B-0535), and peer Otto-Desktop's B-0528 close. Sibling scan of 6 P3 status-open rows revealed B-0517 + B-0537 as partial-completion candidates a naive sweep would have miscategorized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)