### PR TITLE
shard(tick): 2026-05-16T05:23Z — brief-ack #3; rate-limit cost-aware mode

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0523Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0523Z.md
@@ -1,0 +1,62 @@
+# Tick 2026-05-16T05:23Z — Otto-CLI
+
+Tenth tick of the resume-session series. Brief-ack #3 with explicit
+named waits. Rate limit at **747/5000 GraphQL remaining** (used
+4253; reset in ~50 min) — entering cost-aware mode per
+[`refresh-world-model-poll-pr-gate.md`](../../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md)
+cascade-mode warning. Minimizing `gh` calls until reset.
+
+## Refresh result
+
+| Surface | State |
+|---|---|
+| Cron sentinel | Alive (`bd1c7739`) |
+| Rate limit (GraphQL) | **747/5000 remaining**; reset ~50 min |
+| `origin/main` | Advanced to `bb2cc32` (PR #3753 — last tick's deferred-fix-execution shard — merged) |
+| PR #3755 (0520Z brief-ack #2 shard) | OPEN (assumed wait-ci; not polled this tick) |
+| PR #3746 (rule extension) | OPEN (assumed unchanged; explanatory comment posted last tick) |
+| PR #3750 (peer's B-0553) | peer's lane |
+
+## Bounded named waits
+
+Per [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md)
+counter-with-escalation table for brief-ack #3 ("Name the bounded
+wait explicitly each tick + reduce wakeup interval"):
+
+1. **Rate-limit reset** — `gh api rate_limit` reports reset Unix
+   `1778910955` → ~05:53Z UTC → ~30 min from now. Will return to
+   normal `gh` operations after reset.
+2. **PR #3755 CI** — last tick shard; ~5 min from open, CI should
+   finalize within the next 1-2 ticks.
+3. **PR #3746 thread-resolution** — 2 not-actionable threads
+   (viewpoint-difference + peer's bundled-content); awaiting either
+   peer Otto-Desktop to address or `required_conversation_resolution`
+   policy to soften / time out.
+
+## Why no new substantive PR this tick
+
+Both substrate-honest signals point to brief-ack:
+
+1. **Rate-limit signal**: at 747/5000, opening another full-shape PR
+   (`gh pr create` + `gh pr merge --auto` + likely 2-3 follow-up
+   `gh api graphql` for threads) burns ~15-30 calls. Multiple more
+   ticks at that rate would deplete the budget before reset.
+2. **Queue-load signal**: 3 of my PRs already in flight (#3746, #3753
+   merged this tick, #3755). Adding a 4th doesn't add proportional
+   substrate value.
+
+The substrate-honest move: brief-ack tick with sentinel verify +
+shard for visibility; defer substantive work to post-rate-reset.
+
+## Sentinel + close
+
+CronList: `bd1c7739` alive. No re-arm needed.
+
+## Visibility signal
+
+- PR #3753 (deferred-fix-execution shard) **MERGED** at `bb2cc32`
+- Rate-limit cost-awareness mode active until ~05:53Z UTC
+- Sentinel alive
+- Next tick: continue brief-ack with named waits OR pick small substrate edit that needs zero `gh` calls (if rate-limit holds for another tick)
+
+Stopping foreground; cron will fire the next tick.


### PR DESCRIPTION
Brief-ack #3 with named waits. Rate limit at 747/5000; entering cost-aware mode. PR #3753 merged at bb2cc32 this tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)