### PR TITLE
shard(tick): 0528z-otto-cli-2026-05-16

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0528Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0528Z.md
@@ -1,0 +1,65 @@
+# Tick 2026-05-16T05:28Z — Otto-CLI
+
+Eleventh tick of the resume-session series. Brief-ack #4 with named
+waits. Rate limit at **112/5000 GraphQL remaining** (reset in
+~25 min) — extreme cost-aware mode. Deferring PR creation for this
+shard to post-reset; committing + pushing only.
+
+## Refresh result
+
+| Surface | State |
+|---|---|
+| Cron sentinel | Alive (`bd1c7739`) |
+| Rate limit (GraphQL) | **112/5000 remaining**; reset ~05:53Z UTC |
+| `origin/main` | Advanced `bb2cc32 → a528a7a` (PR #3755 my 0520Z + PR #3750 peer's B-0553 merged) |
+| PR #3750 (peer's B-0553 row) | **MERGED** at `124bff1` |
+| PR #3755 (0520Z brief-ack #2) | **MERGED** at `336162d` |
+
+## Bounded named waits (escalating per counter)
+
+This is **brief-ack #4** for the session. Per [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md)
+counter-with-escalation table: at 3-5 brief-acks, "Name the bounded
+wait explicitly each tick + reduce wakeup interval." The cron is
+fixed (1-min cadence per `<<autonomous-loop>>` sentinel), so
+"reduce wakeup interval" doesn't directly apply — but I can do less
+per tick + skip PR creation to conserve rate budget.
+
+**Explicit named waits:**
+
+1. **Rate-limit reset** — Unix `1778910955` ≈ 05:53Z UTC (~25 min)
+2. **PR #3746 thread-resolution** — 2 not-actionable threads
+   (viewpoint difference + peer's bundled-content); auto-merge armed
+3. **PR #3753 + PR #3756 CI** — both should be merged or close to it; not polled this tick
+
+## What this tick did NOT do (and why)
+
+- **Did NOT poll PR gate states** — `bun tools/github/poll-pr-gate-batch.ts` uses ~5 GraphQL calls; at 112/5000 it's a meaningful chunk
+- **Did NOT `gh pr create` this shard** — that alone is ~5-10 GraphQL calls; deferring to post-reset tick
+- **Did NOT `gh pr merge --auto`** — same reason
+- **Did NOT resolve any threads** — same reason
+
+What this tick DID:
+
+- Refreshed git state via `git fetch` (no GraphQL cost)
+- Confirmed sentinel alive
+- Wrote this tick shard
+- Will commit + push (zero GraphQL cost)
+
+## Escalation trigger for next tick
+
+If rate limit recovers to ≥1000 by next tick: re-open normal operations + create PR for this shard + poll PR states.
+
+If rate limit still ≤200: continue brief-ack #5 (still within the
+3-5 tier of counter-with-escalation; ack #6 would force escalation
+per the rule).
+
+## Sentinel + close
+
+CronList: `bd1c7739` alive. No re-arm needed.
+
+## Visibility signal
+
+- 2 more session PRs merged: #3750 (peer's B-0553), #3755 (my brief-ack #2)
+- Rate limit at 112/5000 — PR creation deferred to post-reset
+- Sentinel alive
+- Brief-ack #4 of session; counter resets when any of the active waits resolves or when rate-limit window reopens


### PR DESCRIPTION
Tick shard from this resume-session series. Auto-PR'd during post-rate-reset sweep at tick 0559Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)