### PR TITLE
feat(B-0557 slice 2): try/catch readFileSync + readdirSync in audit tool

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0644Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0644Z.md
@@ -1,3 +1,5 @@
+| 2026-05-16T06:44Z | claude-opus-4-7 | bd1c7739 | brief-ack; extreme cost-aware tier (468/5000 GraphQL) | n/a | brief-ack-with-named-bounded-dependency |
+
 # Tick 2026-05-16T06:44Z — Otto-CLI
 
 Twenty-first tick of the resume-session series. Rate limit at

--- a/tools/hygiene/audit-backlog-status-drift.ts
+++ b/tools/hygiene/audit-backlog-status-drift.ts
@@ -187,10 +187,31 @@ export function enumerateOpenRows(backlogDir: string = "docs/backlog"): BacklogR
     for (const priority of ["P0", "P1", "P2", "P3", "P4"]) {
         const dir = join(backlogDir, priority);
         if (!existsSync(dir)) continue;
-        for (const file of readdirSync(dir)) {
+        let files: string[];
+        try {
+            files = readdirSync(dir);
+        } catch (err) {
+            // Per B-0557 slice 2 (Copilot P1 on PR #3758): don't let one
+            // unreadable directory abort the whole audit. Warn and continue.
+            process.stderr.write(
+                `audit-backlog-status-drift: unable to read directory ${dir}: ${(err as Error).message}\n`,
+            );
+            continue;
+        }
+        for (const file of files) {
             if (!file.startsWith("B-") || !file.endsWith(".md")) continue;
             const path = join(dir, file);
-            const body = readFileSync(path, "utf-8");
+            let body: string;
+            try {
+                body = readFileSync(path, "utf-8");
+            } catch (err) {
+                // Per B-0557 slice 2: don't let one unreadable row file abort
+                // the whole audit. Warn and skip the row.
+                process.stderr.write(
+                    `audit-backlog-status-drift: unable to read ${path}: ${(err as Error).message}\n`,
+                );
+                continue;
+            }
             const fm = parseFrontmatter(body);
             if (fm.status !== "open") continue;
             const id = fm.id || file.replace(/^(B-\d+(?:\.\d+)?).*/, "$1");

--- a/tools/hygiene/audit-backlog-status-drift.ts
+++ b/tools/hygiene/audit-backlog-status-drift.ts
@@ -194,7 +194,7 @@ export function enumerateOpenRows(backlogDir: string = "docs/backlog"): BacklogR
             // Per B-0557 slice 2 (Copilot P1 on PR #3758): don't let one
             // unreadable directory abort the whole audit. Warn and continue.
             process.stderr.write(
-                `audit-backlog-status-drift: unable to read directory ${dir}: ${(err as Error).message}\n`,
+                `audit-backlog-status-drift: unable to read directory ${dir}: ${(err instanceof Error ? err.message : String(err))}\n`,
             );
             continue;
         }
@@ -208,7 +208,7 @@ export function enumerateOpenRows(backlogDir: string = "docs/backlog"): BacklogR
                 // Per B-0557 slice 2: don't let one unreadable row file abort
                 // the whole audit. Warn and skip the row.
                 process.stderr.write(
-                    `audit-backlog-status-drift: unable to read ${path}: ${(err as Error).message}\n`,
+                    `audit-backlog-status-drift: unable to read ${path}: ${(err instanceof Error ? err.message : String(err))}\n`,
                 );
                 continue;
             }


### PR DESCRIPTION
## Summary

- Addresses Copilot P1 finding from PR #3758: `enumerateOpenRows()` could throw and abort the whole audit on a single unreadable backlog file (permission denied, transient FS error, etc.).
- Fix: wrap both `readdirSync` and `readFileSync` in try/catch; warn to stderr; continue with remaining files.
- Bundles peer Otto-Desktop's tick shard `10fb6e5` (brief-ack extreme cost-aware tier substrate).

## Test plan

- [x] `bun test tools/hygiene/audit-backlog-status-drift.test.ts` → 16 pass / 0 fail / 28 expect calls (no regression)
- [x] `bun tools/hygiene/audit-backlog-status-drift.ts --json` still produces 33+ candidates from main
- [x] Stderr warnings clearly name the failed file(s) when triggered

## Composes with

- [B-0557](docs/backlog/P3/B-0557-audit-backlog-status-drift-quality-improvements-2026-05-16.md) — parent row (2 of 4 slices now in flight, plus PR #3783 for slice 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)