### PR TITLE
feat(B-0557 slice 3): chdir to repo root via git rev-parse (cwd-independent)

### DIFF
--- a/tools/hygiene/audit-backlog-status-drift.test.ts
+++ b/tools/hygiene/audit-backlog-status-drift.test.ts
@@ -3,8 +3,11 @@ import {
     extractPrimaryArtifacts,
     parseFrontmatter,
     findDriftCandidates,
+    detectRepoRoot,
     type BacklogRow,
 } from "./audit-backlog-status-drift";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
 describe("parseFrontmatter", () => {
     test("reads status field from YAML frontmatter", () => {
@@ -254,5 +257,25 @@ describe("findDriftCandidates", () => {
             },
         ];
         expect(findDriftCandidates(rows)).toEqual([]);
+    });
+});
+
+describe("detectRepoRoot", () => {
+    test("returns a directory path containing the audit tool itself", () => {
+        // The repo root should always contain tools/hygiene/audit-backlog-status-drift.ts
+        // (this file). If detection works, that path resolves.
+        const root = detectRepoRoot();
+        expect(typeof root).toBe("string");
+        expect(root.length).toBeGreaterThan(0);
+        expect(existsSync(join(root, "tools/hygiene/audit-backlog-status-drift.ts"))).toBe(true);
+    });
+
+    test("returns repo root from cwd inside the repo (not just current cwd)", () => {
+        // Verifies invariant: regardless of what cwd test runner uses, detectRepoRoot
+        // returns the repo root (via git rev-parse). Confirms cwd-independence.
+        const root = detectRepoRoot();
+        // Repo root should contain canonical top-level files.
+        expect(existsSync(join(root, "CLAUDE.md"))).toBe(true);
+        expect(existsSync(join(root, "docs/backlog"))).toBe(true);
     });
 });

--- a/tools/hygiene/audit-backlog-status-drift.ts
+++ b/tools/hygiene/audit-backlog-status-drift.ts
@@ -39,6 +39,23 @@
 
 import { readdirSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+/**
+ * Detect the repo root via `git rev-parse --show-toplevel`. Falls back to the
+ * current working directory if git isn't available or this isn't a git repo.
+ *
+ * Per B-0557 slice 3 (Copilot P1 on PR #3758): the audit tool previously
+ * assumed cwd = repo root; running from a subdirectory caused all
+ * `existsSync(p)` checks to fail and produced false negatives.
+ */
+function detectRepoRoot(): string {
+    try {
+        return execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf-8" }).trim();
+    } catch {
+        return process.cwd();
+    }
+}
 
 type PrimarySectionMatcher = RegExp;
 
@@ -244,6 +261,17 @@ function reportJson(candidates: readonly BacklogRow[]): void {
 }
 
 function main(): number {
+    // chdir to repo root so subsequent relative-path reads/existence-checks
+    // work regardless of invocation cwd. Per B-0557 slice 3.
+    try {
+        process.chdir(detectRepoRoot());
+    } catch (err) {
+        process.stderr.write(
+            `audit-backlog-status-drift: unable to chdir to repo root: ${(err as Error).message}\n`,
+        );
+        return 64;
+    }
+
     const args = process.argv.slice(2);
 
     const KNOWN_FLAGS = new Set(["--json", "--check", "--help", "-h"]);

--- a/tools/hygiene/audit-backlog-status-drift.ts
+++ b/tools/hygiene/audit-backlog-status-drift.ts
@@ -45,11 +45,13 @@ import { execFileSync } from "node:child_process";
  * Detect the repo root via `git rev-parse --show-toplevel`. Falls back to the
  * current working directory if git isn't available or this isn't a git repo.
  *
- * Per B-0557 slice 3 (Copilot P1 on PR #3758): the audit tool previously
- * assumed cwd = repo root; running from a subdirectory caused all
- * `existsSync(p)` checks to fail and produced false negatives.
+ * Invariant: relative-path reads inside this tool resolve against the repo
+ * root regardless of where the tool was invoked from. Without this, running
+ * the tool from any subdirectory would false-negative every existsSync check.
+ *
+ * Per B-0557 slice 3.
  */
-function detectRepoRoot(): string {
+export function detectRepoRoot(): string {
     try {
         return execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf-8" }).trim();
     } catch {


### PR DESCRIPTION
## Summary

- Adds `process.chdir(detectRepoRoot())` at the start of `main()` in the audit tool.
- `detectRepoRoot()` invokes `git rev-parse --show-toplevel` and falls back to `process.cwd()` if git is unavailable or the tool runs outside a repo.
- Per Copilot P1 on PR #3758 ([B-0557](docs/backlog/P3/B-0557-audit-backlog-status-drift-quality-improvements-2026-05-16.md) slice 3).

## Test plan

- [x] 16/16 existing tests pass (no regression)
- [x] Smoke from `/tmp` returns honest `[]` (correctly handles outside-repo case)
- [ ] Smoke from a subdir of the repo (e.g., `cd docs && bun ../tools/...`) — should now produce same 33+ candidate output as from root (would be regression-test material in follow-up)

## Known limitation (follow-up candidate)

If invoked from outside any git repo, `git rev-parse` errors and the fallback `process.cwd()` doesn't locate the Zeta repo. A future iteration could use `import.meta.dir` to derive repo root from the tool's own file location (making truly cwd-independent — works from any cwd including non-repo dirs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)