### PR TITLE
fix(B-0557): truly cwd-independent — import.meta.dir fallback

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0758Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0758Z.md
@@ -1,0 +1,68 @@
+# Tick 2026-05-16T07:58Z — Otto-CLI
+
+Thirtieth tick of the resume-session series. Rate healthy
+(4888/5000). Closed B-0272 (Atari ROM canonicalizer) as **pure
+drift** — 10th class-#1 close of the session.
+
+## Refresh result
+
+| Surface | State |
+|---|---|
+| Cron sentinel | Alive (`bd1c7739`) |
+| Rate limit (GraphQL) | 4888/5000 at tick-open; ~4800 after audit + close |
+| `origin/main` | At `b707acc` (PR #3814 merged last tick) |
+| PR #3816 (last tick shard) | OPEN (assumed wait-ci; not polled) |
+
+## Audit: B-0272 — PURE DRIFT (class #1)
+
+Picked B-0272 (`Atari 2600 ROM canonical naming via TOSEC/No-Intro hash lookup`). Single primary artifact: `tools/roms/canonicalize.ts`.
+
+**Per-acceptance grep** (zero gh):
+
+| Acceptance | Verified |
+|---|---|
+| Script at `tools/roms/canonicalize.ts` | ✓ exists (8953 bytes) |
+| Renames ROMs to TOSEC canonical names | ✓ — `renameSync` import + match-and-rename loop |
+| Reports unmatched hashes | ✓ — schema includes `matched: bool` field |
+
+Provenance: PRs [#2166](https://github.com/Lucent-Financial-Group/Zeta/pull/2166), [#2168](https://github.com/Lucent-Financial-Group/Zeta/pull/2168), [#2172](https://github.com/Lucent-Financial-Group/Zeta/pull/2172) — all merged 2026-05-09. 7-day drift gap.
+
+**Closed via [PR #3820](https://github.com/Lucent-Financial-Group/Zeta/pull/3820)** + Resolution section mapping 3/3 acceptance items.
+
+## Drift-audit progress tally
+
+| Class | Count | Latest |
+|---|---|---|
+| 1 (Pure drift, closed) | **10** | **B-0272 (this tick)** |
+| 2 (Partial, Status-annotated) | 4 | — |
+| 3 (Multi-slice, verified-self-documenting) | 1 | B-0440 |
+| 4 (Multi-slice, all children closed, closed) | 1 | B-0159 |
+| FP-2 (shared-tool + API-absent) | 2 | B-0509 |
+| FP-3 (shared-tool + content-work-not-done) | 1 | B-0346 |
+| **Total triaged** | **19 of ~38** | |
+
+**50% milestone**: 19 candidates triaged, ~19 remaining. Half-way
+through the audit-backlog from one cascade window.
+
+## Pattern observation: pure-drift rate stabilizing
+
+Across 19 triaged candidates:
+
+- **10 pure-drift (53%)** — work shipped, status flag never flipped
+- **5 partial/multi-slice (26%)** — needs annotation OR self-documenting
+- **3 FP (16%)** — audit tool's noise floor
+
+The ~53% pure-drift rate is consistent across the cascade. The
+audit tool's signal is meaningful even with ~16% FP rate.
+
+## Sentinel + close
+
+`CronList`: `bd1c7739` alive.
+
+## Visibility signal
+
+- B-0272 closed via PR #3820 (10th pure-drift; 50%-of-audit-backlog milestone)
+- Pure-drift rate stabilizing at ~53% across the audit set
+- Sentinel `bd1c7739` alive
+- Rate ~4800/5000 (normal tier)
+- ~19 audit candidates remaining

--- a/tools/hygiene/audit-backlog-status-drift.ts
+++ b/tools/hygiene/audit-backlog-status-drift.ts
@@ -38,24 +38,35 @@
 //   64  argument error
 
 import { readdirSync, readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { execFileSync } from "node:child_process";
 
 /**
- * Detect the repo root via `git rev-parse --show-toplevel`. Falls back to the
- * current working directory if git isn't available or this isn't a git repo.
+ * Detect the repo root. Strategy (in order of preference):
+ *
+ *   1. `git rev-parse --show-toplevel` from cwd — works when invoked from
+ *      anywhere inside a git worktree.
+ *   2. Derive from this file's own location (`import.meta.dir`) — works
+ *      when invoked from outside any git repo (e.g., `cd /tmp && bun
+ *      /path/to/tools/hygiene/audit-backlog-status-drift.ts`). The tool
+ *      lives at `<repo>/tools/hygiene/`, so the repo root is two levels
+ *      up from this file.
  *
  * Invariant: relative-path reads inside this tool resolve against the repo
- * root regardless of where the tool was invoked from. Without this, running
- * the tool from any subdirectory would false-negative every existsSync check.
+ * root regardless of where the tool was invoked from — including from
+ * outside any git repo.
  *
- * Per B-0557 slice 3.
+ * Per B-0557 slice 3 (initial via git rev-parse) + this fix (true
+ * cwd-independence via import.meta.dir fallback).
  */
 export function detectRepoRoot(): string {
     try {
         return execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf-8" }).trim();
     } catch {
-        return process.cwd();
+        // Fallback: this file lives at <repo>/tools/hygiene/<name>.ts;
+        // resolve two levels up to reach the repo root. import.meta.dir is
+        // Bun-native and gives the directory containing THIS module file.
+        return resolve(import.meta.dir, "../..");
     }
 }
 


### PR DESCRIPTION
## Summary

- Closes the scope gap that Copilot flagged on [PR #3819](https://github.com/Lucent-Financial-Group/Zeta/pull/3819): slice 3's cwd-independence acceptance bullet (\`cd /tmp && bun /path/to/...\`) was only partially shipped — `git rev-parse --show-toplevel` from /tmp fails (no git repo), and my fallback to `process.cwd()` returned /tmp which has no backlog.
- Fix: when `git rev-parse` fails, fall back to `path.resolve(import.meta.dir, "../..")`. The tool lives at `<repo>/tools/hygiene/X.ts` so two levels up reaches the repo root regardless of cwd.

## Verification

**Smoke from /tmp** (the original failing case):

```
$ cd /tmp && bun /path/to/tools/hygiene/audit-backlog-status-drift.ts --json | head -5
# Now produces the same 33+ candidate output as running from the repo root
# (was previously empty `[]`).
```

## Test plan

- [x] `bun test` → 20 pass / 0 fail / 40 expect calls (no regression)
- [x] Smoke from /tmp now produces 33+ candidates (was empty)
- [x] `git rev-parse` still preferred when available (subdir-of-repo case)
- [x] Closes the scope-honesty gap on PR #3819

## Unblocks PR #3819

Once this PR lands, [PR #3819](https://github.com/Lucent-Financial-Group/Zeta/pull/3819) (B-0557 close-row) can resolve its outstanding thread — slice 3's acceptance is now fully shipped, not partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)