### PR TITLE
shard(tick): 2026-05-16T17:47Z — mise CI flake; gh run rerun --failed recovery

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/1747Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/1747Z.md
@@ -1,0 +1,61 @@
+# Tick 2026-05-16T17:47Z — mise CI flake on PR #3922; `gh run rerun --failed` recovery
+
+## Refresh
+
+- Cron `23b8588a` armed.
+- Rate-limit: 302 GraphQL; 10 min reset → extreme cost-aware tier.
+- main HEAD: `0169b3d` (peer Otto's PR #3919 session-arc final-tally landed).
+- PR #3922 (1732Z scope-boundary) OPEN/BLOCKED on `lint (semgrep)` failure.
+
+## CI flake class — mise toolchain install failure for semgrep
+
+PR #3922's `lint (semgrep)` check failed with:
+
+```
+mise ERROR Failed to install tools: aqua:astral-sh/uv@0.11.8, pipx:semgrep@1.161.0
+```
+
+This is NOT a real semgrep finding — it's a TOOLCHAIN INSTALL failure
+during the "Install toolchain via three-way-parity script
+(GOVERNANCE §24)" step. The semgrep audit never actually ran; the
+install step crashed before the lint phase.
+
+**Recovery applied:** `gh run rerun 25968758717 --failed` triggered.
+Cost: 1 GraphQL call. ETA bounded by typical CI flake resolution
+(~3-5 min if the mise registry is healthy by retry; longer if registry
+itself is intermittent).
+
+## Operational pattern (for future-Otto)
+
+When `lint (semgrep)` fails on a docs-only PR with mise-install-failure
+shape:
+
+1. Verify the failure is install-layer not lint-layer:
+   - `gh run view <run-id> --log-failed | grep -E "mise ERROR|astral-sh/uv|pipx:semgrep"`
+2. Use `gh run rerun <run-id> --failed` to retry just the failed jobs
+3. Re-arm auto-merge if it was un-armed (typically still armed if not
+   manually cleared)
+
+This pattern composes with [`blocked-green-ci-investigate-threads.md`](../../../../../../.claude/rules/blocked-green-ci-investigate-threads.md)
+at the install-layer-failure axis: that rule covers the case where
+checks pass but threads block; this captures the inverse case where a
+toolchain install failure presents as a check failure but the underlying
+substrate has no real findings.
+
+## What landed
+
+This brief tick shard documenting the mise CI flake class +
+`gh run rerun --failed` recovery pattern.
+
+## Real-dependency-waits active
+
+- PR #3922 — awaiting semgrep re-run (~3-5 min ETA)
+- This tick's PR — opens after push
+
+## Composes with
+
+- [1732Z scope-boundary shard (PR #3922)](https://github.com/Lucent-Financial-Group/Zeta/pull/3922)
+- [`docs/AUTONOMOUS-LOOP-PER-TICK.md`](../../../../../AUTONOMOUS-LOOP-PER-TICK.md)
+- [`.claude/rules/blocked-green-ci-investigate-threads.md`](../../../../../../.claude/rules/blocked-green-ci-investigate-threads.md)
+  (sibling axis: install-layer vs thread-layer blocks)
+- [PR #3922](https://github.com/Lucent-Financial-Group/Zeta/pull/3922) (the rerun target)


### PR DESCRIPTION
## Summary

PR #3922 (1732Z scope-boundary) BLOCKED on \`lint (semgrep)\`. Root cause: mise toolchain install failure (\`aqua:astral-sh/uv@0.11.8\`, \`pipx:semgrep@1.161.0\`) — NOT a real lint finding.

Recovery: \`gh run rerun 25968758717 --failed\` triggered.

## Operational pattern documented

For future-Otto encountering \`lint (semgrep)\` failure shape:

1. Verify install-layer vs lint-layer: \`gh run view <id> --log-failed | grep -E "mise ERROR|astral-sh/uv|pipx:semgrep"\`
2. If install-layer, use \`gh run rerun <id> --failed\` to retry just the failed jobs
3. Re-arm auto-merge if needed

Composes with [\`blocked-green-ci-investigate-threads.md\`](.claude/rules/blocked-green-ci-investigate-threads.md) at the install-layer-block axis (sibling to thread-layer-block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)