### PR TITLE
feat(shadow): v2 delta-detection — restore-arrow logs what got restored

### DIFF
--- a/tools/shadow/restore-arrow.applescript
+++ b/tools/shadow/restore-arrow.applescript
@@ -1,38 +1,111 @@
--- restore-arrow.applescript
+-- restore-arrow.applescript (v2 — delta-detection)
 -- Press the right-arrow key (key code 124) in the frontmost terminal if
 -- (and only if) the frontmost application is a known terminal emulator.
+-- Sample the focused element's text value BEFORE and AFTER the press,
+-- then return a delta describing what (if anything) appeared.
 --
 -- Rationale: when an autonomous-loop cron tick fires a prompt in the
--- Claude Code CLI, any grey-text autocomplete suggestion currently shown
--- in the input field is erased. Pressing → restores the suggestion as
--- typed text (or accepts it character-by-character, depending on the
--- emulator). When no suggestion exists and the cursor is at the end of
--- the typed input, → is a no-op. When the cursor is mid-line, → moves
--- the cursor right by one character (non-destructive; documented caveat).
+-- Claude Code CLI, any grey-text autocomplete in the input field is
+-- erased. Pressing → restores the suggestion as typed text. The delta
+-- catches the restored content for the log so the maintainer can audit
+-- (a) which suggestions actually got restored, and (b) whether anything
+-- accidentally got captured that wasn't autocomplete (e.g. their own
+-- typing between samples).
 --
--- Returns one of:
---   "pressed:<frontApp>"           — press succeeded
---   "skipped:not-terminal:<app>"   — frontmost is not a known terminal
---   "skipped:no-frontmost"         — couldn't read frontmost app
+-- Return format (single stdout line, fields separated by ASCII Unit
+-- Separator char id 31):
+--
+--   <verdict><delta-content>
+--
+-- where:
+--   verdict      ∈ { "pressed:<app>", "skipped:<reason>", "error:<reason>" }
+--   delta-content   the substring that appeared AFTER the press but was
+--                   not present BEFORE. Empty when no text changed (the
+--                   common case: no autocomplete + cursor at end of input
+--                   → → is a no-op).
+--
+-- The delta is computed as: if the BEFORE text is a prefix of the AFTER
+-- text, delta = AFTER's suffix beyond BEFORE. Otherwise delta = AFTER in
+-- full (signals an unusual non-extension change). Both samples are
+-- capped to the trailing 500 characters of AXValue to avoid pulling in
+-- terminal scrollback (which can be 45KB+).
 --
 -- Requires: System Preferences → Privacy & Security → Accessibility
 -- access for the host (bun, osascript, or terminal as applicable).
 
+on tailText(t, n)
+    -- Return the last n characters of t (or all of t if shorter).
+    -- AppleScript text-class assumed; non-text values caller-rejected.
+    set L to length of t
+    if L <= n then return t
+    return text (L - n + 1) thru L of t
+end tailText
+
+on safeSample(frontApp)
+    -- Sample AXValue of the focused element of frontApp, capped to the
+    -- trailing 500 characters. Returns "" on any accessibility failure
+    -- (no permission, no focused element, non-text value, etc.) — never
+    -- raises, so the caller can always treat the result as a string.
+    try
+        tell application "System Events"
+            set focusedEl to value of attribute "AXFocusedUIElement" of frontApp
+        end tell
+        try
+            tell application "System Events"
+                set v to value of attribute "AXValue" of focusedEl
+            end tell
+            if class of v is text then
+                return my tailText(v, 500)
+            end if
+        end try
+    end try
+    return ""
+end safeSample
+
+on computeDelta(vBefore, vAfter)
+    -- Suffix-extension delta: if vBefore is a prefix of vAfter, return
+    -- the suffix of vAfter beyond vBefore. Otherwise return vAfter
+    -- whole (signals an unusual non-extension change worth logging).
+    -- Empty string when nothing changed (the common no-op case).
+    if vAfter is equal to vBefore then return ""
+    set bLen to length of vBefore
+    set aLen to length of vAfter
+    if bLen = 0 then return vAfter
+    if aLen < bLen then return vAfter
+    -- Cheap prefix check via head extraction
+    set head to text 1 thru bLen of vAfter
+    if head is equal to vBefore then
+        if aLen = bLen then return ""
+        return text (bLen + 1) thru aLen of vAfter
+    end if
+    return vAfter
+end computeDelta
+
 on run
+    set sep to (ASCII character 31)
+
     tell application "System Events"
         try
             set frontApp to first application process whose frontmost is true
         on error
-            return "skipped:no-frontmost"
+            return "skipped:no-frontmost" & sep & ""
         end try
-
         set frontAppName to name of frontApp
         set knownTerminals to {"Terminal", "iTerm2", "iTerm", "Warp", "Hyper", "Alacritty", "kitty"}
         if knownTerminals does not contain frontAppName then
-            return "skipped:not-terminal:" & frontAppName
+            return "skipped:not-terminal:" & frontAppName & sep & ""
         end if
-
-        key code 124  -- right arrow
-        return "pressed:" & frontAppName
     end tell
+
+    set vBefore to my safeSample(frontApp)
+
+    tell application "System Events"
+        key code 124  -- right arrow
+    end tell
+    delay 0.05
+
+    set vAfter to my safeSample(frontApp)
+    set deltaText to my computeDelta(vBefore, vAfter)
+
+    return "pressed:" & frontAppName & sep & deltaText
 end run

--- a/tools/shadow/shadow-observer.test.ts
+++ b/tools/shadow/shadow-observer.test.ts
@@ -3,8 +3,8 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
-import { runOneCycle, log, detectViaCommand, detectGreyTextMacOS, parseConfig } from "./shadow-observer.ts";
-import type { ShadowConfig, ShadowEvent, OsascriptRunner } from "./shadow-observer.ts";
+import { runOneCycle, log, detectViaCommand, detectGreyTextMacOS, parseConfig, parseRestoreArrowOutput, RESTORE_ARROW_SEP } from "./shadow-observer.ts";
+import type { ShadowConfig, ShadowEvent, OsascriptRunner, RestoreArrowResult } from "./shadow-observer.ts";
 
 const SCRIPT = join(import.meta.dir, "shadow-observer.ts");
 let TEST_DIR: string;
@@ -164,7 +164,7 @@ describe("shadow-observer — runOneCycle unit (injected fns)", () => {
 
   test("restoreArrow=false skips the press (restoreArrowFn never called)", async () => {
     let pressed = 0;
-    const restoreArrowFn = async () => { pressed++; return "pressed:Terminal"; };
+    const restoreArrowFn = async () => { pressed++; return { verdict: "pressed:Terminal", delta: "" }; };
     const result = await runOneCycle(baseConfig, async () => null, undefined, restoreArrowFn);
     expect(result).toBe("no-suggestion");
     expect(pressed).toBe(0);
@@ -173,7 +173,7 @@ describe("shadow-observer — runOneCycle unit (injected fns)", () => {
   test("restoreArrow=true invokes restoreArrowFn exactly once per cycle", async () => {
     const cfg = { ...baseConfig, restoreArrow: true };
     let pressed = 0;
-    const restoreArrowFn = async () => { pressed++; return "pressed:Terminal"; };
+    const restoreArrowFn = async () => { pressed++; return { verdict: "pressed:Terminal", delta: "" }; };
     const result = await runOneCycle(cfg, async () => null, undefined, restoreArrowFn);
     expect(result).toBe("no-suggestion");
     expect(pressed).toBe(1);
@@ -181,7 +181,7 @@ describe("shadow-observer — runOneCycle unit (injected fns)", () => {
 
   test("restoreArrowFn throw is captured as error verdict, never crashes the cycle", async () => {
     const cfg = { ...baseConfig, restoreArrow: true };
-    const restoreArrowFn = async (): Promise<string> => { throw new Error("osascript-died"); };
+    const restoreArrowFn = async (): Promise<RestoreArrowResult> => { throw new Error("osascript-died"); };
     const result = await runOneCycle(cfg, async () => null, undefined, restoreArrowFn);
     expect(result).toBe("no-suggestion");
   });
@@ -189,9 +189,77 @@ describe("shadow-observer — runOneCycle unit (injected fns)", () => {
   test("restoreArrow=true fires even under dry-run (orthogonal to acceptGreyText safety)", async () => {
     const cfg = { ...baseConfig, restoreArrow: true, dryRun: true };
     let pressed = 0;
-    const restoreArrowFn = async () => { pressed++; return "pressed:Terminal"; };
+    const restoreArrowFn = async () => { pressed++; return { verdict: "pressed:Terminal", delta: "" }; };
     await runOneCycle(cfg, async () => null, undefined, restoreArrowFn);
     expect(pressed).toBe(1);
+  });
+
+  test("v2 delta is captured in log event (delta + deltaLen fields)", async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "zeta-shadow-delta-test-"));
+    try {
+      const cfg = { ...baseConfig, restoreArrow: true, logFile: join(tmpDir, "log") };
+      const restoreArrowFn = async () => ({ verdict: "pressed:Terminal", delta: "restored-autocomplete-content" });
+      await runOneCycle(cfg, async () => null, undefined, restoreArrowFn);
+      const events = readFileSync(join(tmpDir, "log"), "utf-8").split("\n").filter(Boolean).map((l) => JSON.parse(l) as ShadowEvent);
+      const restoreEvent = events.find((e) => e.type === "restore-arrow");
+      expect(restoreEvent).toBeDefined();
+      expect(restoreEvent!.content).toBe("pressed:Terminal");
+      expect(restoreEvent!.delta).toBe("restored-autocomplete-content");
+      expect(restoreEvent!.deltaLen).toBe(29);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("v2 empty delta still logs deltaLen=0 (the common no-op restore)", async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "zeta-shadow-delta-test-"));
+    try {
+      const cfg = { ...baseConfig, restoreArrow: true, logFile: join(tmpDir, "log") };
+      const restoreArrowFn = async () => ({ verdict: "pressed:Terminal", delta: "" });
+      await runOneCycle(cfg, async () => null, undefined, restoreArrowFn);
+      const events = readFileSync(join(tmpDir, "log"), "utf-8").split("\n").filter(Boolean).map((l) => JSON.parse(l) as ShadowEvent);
+      const restoreEvent = events.find((e) => e.type === "restore-arrow");
+      expect(restoreEvent!.delta).toBe("");
+      expect(restoreEvent!.deltaLen).toBe(0);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("shadow-observer — parseRestoreArrowOutput unit (v2 delta-detect)", () => {
+  test("pressed verdict with delta: parses verdict + delta on Unit-Separator delimiter", () => {
+    const r = parseRestoreArrowOutput(`pressed:Terminal${RESTORE_ARROW_SEP}some-restored-text\n`);
+    expect(r.verdict).toBe("pressed:Terminal");
+    expect(r.delta).toBe("some-restored-text");
+  });
+
+  test("pressed verdict with empty delta: still parses cleanly", () => {
+    const r = parseRestoreArrowOutput(`pressed:iTerm2${RESTORE_ARROW_SEP}\n`);
+    expect(r.verdict).toBe("pressed:iTerm2");
+    expect(r.delta).toBe("");
+  });
+
+  test("skipped verdict carries empty delta", () => {
+    const r = parseRestoreArrowOutput(`skipped:not-terminal:Safari${RESTORE_ARROW_SEP}\n`);
+    expect(r.verdict).toBe("skipped:not-terminal:Safari");
+    expect(r.delta).toBe("");
+  });
+
+  test("legacy v1 output (no separator) yields verdict-only result", () => {
+    const r = parseRestoreArrowOutput("pressed:Terminal\n");
+    expect(r.verdict).toBe("pressed:Terminal");
+    expect(r.delta).toBe("");
+  });
+
+  test("delta containing newlines is preserved (only trailing newlines stripped)", () => {
+    const r = parseRestoreArrowOutput(`pressed:Terminal${RESTORE_ARROW_SEP}line-1\nline-2\n`);
+    expect(r.delta).toBe("line-1\nline-2");
+  });
+
+  test("delta containing leading whitespace is preserved (autocomplete may start with space)", () => {
+    const r = parseRestoreArrowOutput(`pressed:Terminal${RESTORE_ARROW_SEP} starts-with-space`);
+    expect(r.delta).toBe(" starts-with-space");
   });
 });
 

--- a/tools/shadow/shadow-observer.ts
+++ b/tools/shadow/shadow-observer.ts
@@ -61,13 +61,46 @@ export interface ShadowEvent {
   timestamp: string;
   type: "started" | "detected" | "accepted" | "overridden" | "no-suggestion" | "error" | "restore-arrow";
   content?: string;
+  /** v2 delta-detect: the suffix-extension of the input field's text after the → press
+   *  (the restored autocomplete content). Empty when no text changed (the
+   *  common no-op case). Present only on `restore-arrow` events. */
+  delta?: string;
+  /** v2 delta-detect: character length of delta. Cheap at-a-glance scan of the log
+   *  to find non-trivial restores without scrolling the content. */
+  deltaLen?: number;
   delayMs: number;
   dryRun: boolean;
 }
 
+/** v2 delta-detect: structured result from pressRestoreArrow. The
+ *  AppleScript returns one stdout line "<verdict><delta>" (ASCII Unit
+ *  Separator); this type is the parsed form. */
+export interface RestoreArrowResult {
+  /** "pressed:<app>" | "skipped:<reason>" | "error:<reason>" */
+  verdict: string;
+  /** The restored content (suffix-extension) if any; empty string when nothing changed. */
+  delta: string;
+}
+
 export type DetectFn = () => Promise<string | null>;
 export type AcceptFn = (config: ShadowConfig) => Promise<boolean>;
-export type RestoreArrowFn = () => Promise<string>;
+export type RestoreArrowFn = () => Promise<RestoreArrowResult>;
+
+/** ASCII Unit Separator — delimiter between verdict and delta in the
+ *  restore-arrow AppleScript output. Unlikely to appear in user input. */
+export const RESTORE_ARROW_SEP = "";
+
+/** Parse the restore-arrow AppleScript stdout line into verdict + delta. */
+export function parseRestoreArrowOutput(raw: string): RestoreArrowResult {
+  const idx = raw.indexOf(RESTORE_ARROW_SEP);
+  if (idx === -1) {
+    // v1 AppleScript without sep — verdict only, no delta material
+    return { verdict: raw.trim(), delta: "" };
+  }
+  // Don't trim the delta — leading/trailing whitespace may be meaningful
+  // for autocomplete-restored content. The verdict portion is trimmed.
+  return { verdict: raw.slice(0, idx).trim(), delta: raw.slice(idx + 1).replace(/\n+$/, "") };
+}
 
 export function log(event: ShadowEvent, logFile: string): void {
   const line = JSON.stringify(event);
@@ -231,10 +264,10 @@ export async function pressRestoreArrow(
   _config: ShadowConfig,
   _runner?: OsascriptRunner,
   _platform?: string,
-): Promise<string> {
+): Promise<RestoreArrowResult> {
   const platform = _platform ?? process.platform;
   if (platform !== "darwin") {
-    return "skipped:not-macos";
+    return { verdict: "skipped:not-macos", delta: "" };
   }
 
   const runner = _runner ?? runOsascript;
@@ -244,14 +277,17 @@ export async function pressRestoreArrow(
   try {
     result = await runner(scriptPath);
   } catch (err) {
-    return `error:${String(err)}`;
+    return { verdict: `error:${String(err)}`, delta: "" };
   }
 
   if (result.exitCode !== 0) {
-    return `error:osascript-exit-${result.exitCode}`;
+    return { verdict: `error:osascript-exit-${result.exitCode}`, delta: "" };
   }
-  const trimmed = result.stdout.trim();
-  return trimmed.length > 0 ? trimmed : "error:empty-output";
+
+  if (result.stdout.length === 0) {
+    return { verdict: "error:empty-output", delta: "" };
+  }
+  return parseRestoreArrowOutput(result.stdout);
 }
 
 export async function acceptGreyText(config: ShadowConfig): Promise<boolean> {
@@ -280,17 +316,19 @@ export async function runOneCycle(
   restoreArrowFn: RestoreArrowFn = () => pressRestoreArrow(config),
 ): Promise<"accepted" | "no-suggestion" | "overridden" | "error"> {
   if (config.restoreArrow) {
-    let verdict: string;
+    let result: RestoreArrowResult;
     try {
-      verdict = await restoreArrowFn();
+      result = await restoreArrowFn();
     } catch (err) {
-      verdict = `error:${String(err)}`;
+      result = { verdict: `error:${String(err)}`, delta: "" };
     }
     log(
       {
         timestamp: new Date().toISOString(),
         type: "restore-arrow",
-        content: verdict,
+        content: result.verdict,
+        delta: result.delta,
+        deltaLen: result.delta.length,
         delayMs: config.delayMs,
         dryRun: config.dryRun,
       },


### PR DESCRIPTION
## Summary

Extends the \`--restore-arrow\` flag (shipped in #3923) to capture what text appeared after the → press. Before/after sampling of the focused element's \`AXValue\` (capped to trailing 500 chars to avoid scrollback) plus suffix-extension delta computation. The restored content lands in new \`delta\` + \`deltaLen\` fields on the \`restore-arrow\` event.

## v1 vs v2

\`\`\`
v1: {\"type\":\"restore-arrow\",\"content\":\"pressed:Terminal\"}
v2: {\"type\":\"restore-arrow\",\"content\":\"pressed:Terminal\",
     \"delta\":\"the autocomplete that got restored\",\"deltaLen\":36}
\`\`\`

## Delta semantics

- **Empty delta** — no text change (common: no autocomplete present + cursor at end of input → → is a no-op).
- **Non-empty delta** — restored content. Typically the autocomplete suggestion the cron-tick erased; occasionally captures unrelated text changes (accepted edge case per maintainer judgment).
- **Computation** — suffix-extension: if AFTER starts with BEFORE, delta = AFTER's suffix beyond BEFORE. Otherwise delta = AFTER in full (flags unusual non-extension changes in the log).

## Why AXValue (not AXSelectedText)

v1 detection (grey-text-as-selection) uses AXSelectedText. v2 sampling (white-text-after-restore) uses AXValue capped to the last 500 chars — because once → commits the autocomplete, it's no longer a selection. AXValue scoped to focused-element + size cap avoids the 45KB-scrollback bug \`detect-grey-text.applescript\` explicitly avoids.

## Wire format

AppleScript returns a single stdout line \`<verdict>⟨US⟩<delta>\` where ⟨US⟩ is ASCII Unit Separator (char id 31). TS parser splits on first US occurrence; legacy v1 output (no separator) yields verdict-only result with empty delta — **full backward-compat** with any reader that hasn't been redeployed.

## Test plan

- [x] 62/62 unit tests pass (54 pre-existing + 8 new)
- [x] 6 \`parseRestoreArrowOutput\` cases (with/without delta, skipped, legacy v1, newlines, leading-whitespace-preserved)
- [x] 2 \`runOneCycle\` integration cases (delta-in-event-log, empty-delta-still-logs-deltaLen-zero)
- [x] All 5 v1 tests refactored from string-return to RestoreArrowResult struct

## Origin

Maintainer 2026-05-16T18:32Z: *\"ship the v2 delta detection\"* — closing the design loop deferred at v1 ship time. Composes with the prediction-engine framing maintainer named at PR #3923 merge: autocomplete surfaces what they were about to type because the prediction model is conditioned on conversation context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)