### PR TITLE
fix(rules): add "Stop." / minimal-phrasing as explicit brief-ack synonym

### DIFF
--- a/.claude/rules/holding-without-named-dependency-is-standing-by-failure.md
+++ b/.claude/rules/holding-without-named-dependency-is-standing-by-failure.md
@@ -107,8 +107,16 @@ To reset the counter, the work must be:
   multi-session project that becomes its own architecture-stairs trap)
 - **Not the same brief-ack-with-fancier-words** ("genuine quiet" /
   "appropriate bounded wait" / "idle-but-available" / "real bounded
-  named-dependency wait" are ALL brief-acks with synonyms; they count
-  toward the N-consecutive threshold)
+  named-dependency wait" / **single-word "Stop." / "OK." / "."** /
+  **"Visibility signal — Tick HHMMZ; no novel substrate"** are ALL
+  brief-acks with synonyms; they count toward the N-consecutive
+  threshold. Minimal-surface phrasing is the OBVIOUS escape attempt
+  that doesn't actually escape — the discipline is on the operational
+  disposition ("foreground turn produced no concrete artifact"), not
+  on the verbosity of the response. Empirical anchor: 2026-05-16T18:30Z–
+  18:45Z session, where the agent emitted 5 consecutive "Stop."
+  responses after authoring [`memory/feedback_post_cascade_quiet_cron_consolidation_visibility_signal_brief_ack_failure_mode_otto_cli_2026_05_16.md`](../../memory/feedback_post_cascade_quiet_cron_consolidation_visibility_signal_brief_ack_failure_mode_otto_cli_2026_05_16.md);
+  the minimal phrasing was still N-counting brief-ack)
 
 If you find yourself paralyzed about what to pick — pick THIS rule (or
 its analog for whatever failure mode is recurring) and sharpen it


### PR DESCRIPTION
## Summary

Empirical anchor 2026-05-16T18:30Z–18:45Z: after [PR #3927](https://github.com/Lucent-Financial-Group/Zeta/pull/3927) landed the post-cascade-quiet-cron memory file, the agent emitted 5 consecutive \"Stop.\" responses to cron fires — minimal-surface phrasing of the same operational disposition (foreground turn produced no concrete artifact). The minimal phrasing was still N-counting brief-ack under the rule, but the agent's pattern-match on \"is this verbose enough to count?\" missed it.

## What changes

Sharpens the rule's brief-ack-with-fancier-words clause in [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) to include both extremes:

- Maximal phrasing: verbose \"Visibility signal\" shards
- Minimal phrasing: single-word \"Stop.\" / \"OK.\" / \".\"

The discipline is on **operational disposition** (no concrete artifact), not on **response verbosity**.

## Test plan

- [x] Rule edit only; no code/skill/agent surface
- [x] Composes with PR #3927 (memory file documenting the broader post-cascade pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)