### PR TITLE
fix(B-0402): shadow observer freshness-threshold guard (fix #3 — prevent new-console zsh abort)

### DIFF
--- a/tools/shadow/get-frontmost-state.applescript
+++ b/tools/shadow/get-frontmost-state.applescript
@@ -1,0 +1,32 @@
+-- get-frontmost-state.applescript
+-- Returns minimal state about the frontmost application: pid + name.
+-- Cheap query — no AXValue/AXFocusedUIElement traversal, no key injection.
+--
+-- Used by the shadow observer's freshness-threshold guard (B-0402.fix3):
+-- skip AX-heavy detection + restore-arrow keypresses while a newly-focused
+-- window is still settling, to avoid interfering with shell init (e.g.
+-- zsh .zshrc plugins loading in a new terminal that just became frontmost).
+--
+-- Return format (single stdout line):
+--
+--   <pid>|<app-name>
+--
+-- where:
+--   pid       integer process ID of the frontmost application
+--   app-name  display name of the frontmost application (e.g. "Terminal")
+--
+-- Returns empty string on any accessibility failure (no permission, no
+-- frontmost app, etc.) — caller treats empty as "unknown, skip cycle."
+
+on run
+    try
+        tell application "System Events"
+            set frontApp to first application process whose frontmost is true
+            set frontPid to unix id of frontApp
+            set frontName to name of frontApp
+        end tell
+        return (frontPid as text) & "|" & frontName
+    on error
+        return ""
+    end try
+end run

--- a/tools/shadow/launchd/com.zeta.shadow-observer.plist
+++ b/tools/shadow/launchd/com.zeta.shadow-observer.plist
@@ -32,6 +32,13 @@
       was erased by an autonomous-loop cron tick. Non-destructive: no-op
       when no autocomplete + cursor at end of input. NOT suppressed by
       --dry-run (the two flags are orthogonal).
+    - --freshness-threshold-ms 5000: skip AX-heavy detection + restore-arrow
+      keypresses while the frontmost window has been frontmost for less than
+      5 seconds. Prevents interference with shell init (e.g. zsh .zshrc
+      loading in a freshly-opened terminal). Fix #3 from the 2026-05-16
+      observation that the prior --restore-arrow + AX-poll combination on
+      a still-initializing new terminal could abort zsh interactive init,
+      requiring a reboot to recover.
 -->
 <plist version="1.0">
 <dict>
@@ -50,6 +57,8 @@
         <string>3000</string>
         <string>--dry-run</string>
         <string>--restore-arrow</string>
+        <string>--freshness-threshold-ms</string>
+        <string>5000</string>
         <string>--log-file</string>
         <string>{{REPO_ROOT}}/tools/shadow/shadow-observer.log</string>
     </array>

--- a/tools/shadow/shadow-observer.test.ts
+++ b/tools/shadow/shadow-observer.test.ts
@@ -115,6 +115,55 @@ describe("shadow-observer — dry-run once mode", () => {
   });
 });
 
+describe("shadow-observer — freshness guard (fix #3 for new-console zsh abort)", () => {
+  test("checkWindowFresh returns false on first sighting (window too fresh)", async () => {
+    const { checkWindowFresh } = await import("./shadow-observer.ts");
+    const history = new Map<string, number>();
+    const result = checkWindowFresh({ pid: 1234, name: "Terminal" }, 5000, 1_000_000, history);
+    expect(result).toBe(false);
+    expect(history.get("1234|Terminal")).toBe(1_000_000);
+  });
+
+  test("checkWindowFresh returns true after threshold elapsed", async () => {
+    const { checkWindowFresh } = await import("./shadow-observer.ts");
+    const history = new Map<string, number>([["1234|Terminal", 1_000_000]]);
+    expect(checkWindowFresh({ pid: 1234, name: "Terminal" }, 5000, 1_004_999, history)).toBe(false);
+    expect(checkWindowFresh({ pid: 1234, name: "Terminal" }, 5000, 1_005_000, history)).toBe(true);
+    expect(checkWindowFresh({ pid: 1234, name: "Terminal" }, 5000, 1_010_000, history)).toBe(true);
+  });
+
+  test("checkWindowFresh threshold 0 always returns true (guard disabled)", async () => {
+    const { checkWindowFresh } = await import("./shadow-observer.ts");
+    const history = new Map<string, number>();
+    expect(checkWindowFresh({ pid: 1234, name: "Terminal" }, 0, 1_000_000, history)).toBe(true);
+    expect(history.size).toBe(0); // disabled means no history mutation
+  });
+
+  test("runOneCycle returns skipped-fresh-window + skips detection when window fresh", async () => {
+    const { runOneCycle, _resetFrontmostHistory } = await import("./shadow-observer.ts");
+    _resetFrontmostHistory();
+    const config: ShadowConfig = {
+      delayMs: 0,
+      dryRun: true,
+      logFile: "/dev/null",
+      loopIntervalMs: 0,
+      once: true,
+      restoreArrow: false,
+      freshnessThresholdMs: 5000,
+    };
+    let detectCalled = false;
+    const detectFn = async () => { detectCalled = true; return "should-not-fire"; };
+    const acceptFn = async () => true;
+    const restoreArrowFn = async () => ({ verdict: "should-not-fire", delta: "" });
+    const getFrontmostStateFn = async () => ({ pid: 9999, name: "iTerm2" });
+    const fixedNow = () => 1_000_000;
+
+    const verdict = await runOneCycle(config, detectFn, acceptFn, restoreArrowFn, getFrontmostStateFn, fixedNow);
+    expect(verdict).toBe("skipped-fresh-window");
+    expect(detectCalled).toBe(false);
+  });
+});
+
 describe("shadow-observer — runOneCycle unit (injected fns)", () => {
   const baseConfig: ShadowConfig = {
     delayMs: 0,
@@ -123,6 +172,7 @@ describe("shadow-observer — runOneCycle unit (injected fns)", () => {
     loopIntervalMs: 0,
     once: true,
     restoreArrow: false,
+    freshnessThresholdMs: 0,
   };
 
   test("returns no-suggestion when detectFn returns null", async () => {
@@ -413,6 +463,7 @@ describe("shadow-observer — --detect-cmd CLI integration (slice 2)", () => {
       loopIntervalMs: 0,
       once: true,
       restoreArrow: false,
+    freshnessThresholdMs: 0,
     };
     const result = await runOneCycle(baseConfig, async () => null);
     expect(result).toBe("no-suggestion");
@@ -659,6 +710,7 @@ describe("shadow-observer — runOneCycle full cycle paths (slice 3)", () => {
       loopIntervalMs: 0,
       once: true,
       restoreArrow: false,
+    freshnessThresholdMs: 0,
     };
   }
 

--- a/tools/shadow/shadow-observer.test.ts
+++ b/tools/shadow/shadow-observer.test.ts
@@ -162,6 +162,48 @@ describe("shadow-observer — freshness guard (fix #3 for new-console zsh abort)
     expect(verdict).toBe("skipped-fresh-window");
     expect(detectCalled).toBe(false);
   });
+
+  test("runOneCycle skips cycle when frontmost probe returns null (per docstring contract)", async () => {
+    const { runOneCycle, _resetFrontmostHistory } = await import("./shadow-observer.ts");
+    _resetFrontmostHistory();
+    const config: ShadowConfig = {
+      delayMs: 0,
+      dryRun: true,
+      logFile: "/dev/null",
+      loopIntervalMs: 0,
+      once: true,
+      restoreArrow: true,
+      freshnessThresholdMs: 5000,
+    };
+    let detectCalled = false;
+    let restoreCalled = false;
+    const detectFn = async () => { detectCalled = true; return "should-not-fire"; };
+    const acceptFn = async () => true;
+    const restoreArrowFn = async () => { restoreCalled = true; return { verdict: "should-not-fire", delta: "" }; };
+    const getFrontmostStateFn = async () => null;
+    const fixedNow = () => 1_000_000;
+
+    const verdict = await runOneCycle(config, detectFn, acceptFn, restoreArrowFn, getFrontmostStateFn, fixedNow);
+    expect(verdict).toBe("skipped-fresh-window");
+    expect(detectCalled).toBe(false);
+    expect(restoreCalled).toBe(false);
+  });
+
+  test("checkWindowFresh evicts oldest entry when history reaches FRONTMOST_HISTORY_MAX", async () => {
+    const { checkWindowFresh, FRONTMOST_HISTORY_MAX } = await import("./shadow-observer.ts");
+    const history = new Map<string, number>();
+    // Fill to capacity
+    for (let i = 0; i < FRONTMOST_HISTORY_MAX; i++) {
+      checkWindowFresh({ pid: 1000 + i, name: "App" }, 5000, 1_000_000 + i, history);
+    }
+    expect(history.size).toBe(FRONTMOST_HISTORY_MAX);
+    expect(history.has("1000|App")).toBe(true);
+    // One more insertion → oldest evicted
+    checkWindowFresh({ pid: 9999, name: "NewApp" }, 5000, 2_000_000, history);
+    expect(history.size).toBe(FRONTMOST_HISTORY_MAX);
+    expect(history.has("1000|App")).toBe(false);
+    expect(history.has("9999|NewApp")).toBe(true);
+  });
 });
 
 describe("shadow-observer — runOneCycle unit (injected fns)", () => {

--- a/tools/shadow/shadow-observer.ts
+++ b/tools/shadow/shadow-observer.ts
@@ -330,7 +330,13 @@ export interface FrontmostState {
  *  `${pid}|${name}`. Value is the ms-since-epoch when this combination
  *  was first observed as frontmost. Module-level state is consistent with
  *  the procedural shape of this file; `_resetFrontmostHistory` is exported
- *  for test isolation. */
+ *  for test isolation.
+ *
+ *  Bounded to FRONTMOST_HISTORY_MAX entries — when full, the oldest
+ *  insertion is evicted (Map preserves insertion order). Bound prevents
+ *  unbounded growth on long-running launch agents that observe many
+ *  distinct pids across app restarts. */
+export const FRONTMOST_HISTORY_MAX = 256;
 const frontmostHistory: Map<string, number> = new Map();
 
 /** Test helper — clears the per-process frontmost history. */
@@ -373,12 +379,15 @@ export async function getFrontmostState(
   return { pid, name };
 }
 
-/** Pure freshness check. Updates `frontmostHistory` as a side-effect
- *  (records first-seen for the key) so subsequent cycles can measure
- *  age. Returns true if the window has been frontmost for at least
- *  `thresholdMs`, false if it's too fresh (caller should skip the cycle).
+/** Freshness check with side-effect: records first-seen ms in `history`
+ *  on first sighting so subsequent cycles can measure age. Returns true
+ *  if the window has been frontmost for at least `thresholdMs`, false
+ *  if too fresh (caller should skip the cycle).
  *
- *  Threshold of 0 disables the guard (always returns true). */
+ *  When `history` grows past FRONTMOST_HISTORY_MAX, evicts the oldest
+ *  insertion (Map preserves insertion order) to keep memory bounded.
+ *
+ *  Threshold of 0 disables the guard (always returns true; no mutation). */
 export function checkWindowFresh(
   state: FrontmostState,
   thresholdMs: number,
@@ -389,6 +398,10 @@ export function checkWindowFresh(
   const key = `${state.pid}|${state.name}`;
   const firstSeen = history.get(key);
   if (firstSeen === undefined) {
+    if (history.size >= FRONTMOST_HISTORY_MAX) {
+      const oldestKey = history.keys().next().value;
+      if (oldestKey !== undefined) history.delete(oldestKey);
+    }
     history.set(key, nowMs);
     return false; // first sighting → too fresh
   }
@@ -406,9 +419,26 @@ export async function runOneCycle(
   // Freshness guard: skip AX-heavy detection + restore-arrow keypresses
   // while the frontmost window is still settling. Prevents interference
   // with shell init (e.g. zsh .zshrc loading in a freshly-opened terminal).
+  //
+  // Per `getFrontmostState`'s contract, null = "unknown, skip cycle" — so a
+  // probe failure (no accessibility permission, osascript error) also skips
+  // the AX-heavy work below, not just a too-fresh window.
   if (config.freshnessThresholdMs > 0) {
     const state = await getFrontmostStateFn();
-    if (state !== null && !checkWindowFresh(state, config.freshnessThresholdMs, nowMs())) {
+    if (state === null) {
+      log(
+        {
+          timestamp: new Date().toISOString(),
+          type: "skipped-fresh-window",
+          content: "frontmost-unknown (probe returned null)",
+          delayMs: config.delayMs,
+          dryRun: config.dryRun,
+        },
+        config.logFile,
+      );
+      return "skipped-fresh-window";
+    }
+    if (!checkWindowFresh(state, config.freshnessThresholdMs, nowMs())) {
       log(
         {
           timestamp: new Date().toISOString(),

--- a/tools/shadow/shadow-observer.ts
+++ b/tools/shadow/shadow-observer.ts
@@ -55,11 +55,19 @@ export interface ShadowConfig {
   loopMs?: number;
   once: boolean;
   restoreArrow: boolean;
+  /** Skip AX-heavy detection + restore-arrow keypresses while the frontmost
+   *  window has been frontmost for less than this many milliseconds.
+   *  Prevents interference with shell init (e.g. zsh .zshrc loading in a
+   *  freshly-opened terminal). CLI default 0 (disabled) so test fixtures
+   *  see deterministic detection on first cycle; production sets 5000ms via
+   *  the launchd plist (`--freshness-threshold-ms 5000`) — explicit-flag
+   *  discipline keeps the production safety choice visible in the config. */
+  freshnessThresholdMs: number;
 }
 
 export interface ShadowEvent {
   timestamp: string;
-  type: "started" | "detected" | "accepted" | "overridden" | "no-suggestion" | "error" | "restore-arrow";
+  type: "started" | "detected" | "accepted" | "overridden" | "no-suggestion" | "error" | "restore-arrow" | "skipped-fresh-window";
   content?: string;
   /** v2 delta-detect: the suffix-extension of the input field's text after the → press
    *  (the restored autocomplete content). Empty when no text changed (the
@@ -309,12 +317,112 @@ export async function acceptGreyText(config: ShadowConfig): Promise<boolean> {
   return (await proc.exited) === 0;
 }
 
+/** Minimal state describing the frontmost application.
+ *  Returned by `getFrontmostState` (cheap query — no AXValue traversal).
+ *  Used by the freshness-threshold guard to skip AX-heavy cycles while a
+ *  newly-focused window is still settling. */
+export interface FrontmostState {
+  pid: number;
+  name: string;
+}
+
+/** Per-process history of frontmost-window first-seen timestamps. Key is
+ *  `${pid}|${name}`. Value is the ms-since-epoch when this combination
+ *  was first observed as frontmost. Module-level state is consistent with
+ *  the procedural shape of this file; `_resetFrontmostHistory` is exported
+ *  for test isolation. */
+const frontmostHistory: Map<string, number> = new Map();
+
+/** Test helper — clears the per-process frontmost history. */
+export function _resetFrontmostHistory(): void {
+  frontmostHistory.clear();
+}
+
+/** Query the frontmost application's pid + name via osascript. Cheap (no
+ *  AXValue traversal, no key injection). Returns null on any error or
+ *  non-darwin platform — caller treats null as "unknown, skip cycle." */
+export async function getFrontmostState(
+  _runner?: OsascriptRunner,
+  _platform?: string,
+): Promise<FrontmostState | null> {
+  const platform = _platform ?? process.platform;
+  if (platform !== "darwin") return null;
+
+  const runner = _runner ?? runOsascript;
+  const scriptPath = join(import.meta.dir, "get-frontmost-state.applescript");
+
+  let result: { exitCode: number; stdout: string; stderr: string };
+  try {
+    result = await runner(scriptPath);
+  } catch {
+    return null;
+  }
+  if (result.exitCode !== 0) return null;
+
+  const trimmed = result.stdout.trim();
+  if (trimmed.length === 0) return null;
+
+  const sepIdx = trimmed.indexOf("|");
+  if (sepIdx === -1) return null;
+
+  const pidStr = trimmed.slice(0, sepIdx);
+  const name = trimmed.slice(sepIdx + 1);
+  const pid = parseInt(pidStr, 10);
+  if (!Number.isFinite(pid) || pid <= 0 || name.length === 0) return null;
+
+  return { pid, name };
+}
+
+/** Pure freshness check. Updates `frontmostHistory` as a side-effect
+ *  (records first-seen for the key) so subsequent cycles can measure
+ *  age. Returns true if the window has been frontmost for at least
+ *  `thresholdMs`, false if it's too fresh (caller should skip the cycle).
+ *
+ *  Threshold of 0 disables the guard (always returns true). */
+export function checkWindowFresh(
+  state: FrontmostState,
+  thresholdMs: number,
+  nowMs: number,
+  history: Map<string, number> = frontmostHistory,
+): boolean {
+  if (thresholdMs <= 0) return true;
+  const key = `${state.pid}|${state.name}`;
+  const firstSeen = history.get(key);
+  if (firstSeen === undefined) {
+    history.set(key, nowMs);
+    return false; // first sighting → too fresh
+  }
+  return nowMs - firstSeen >= thresholdMs;
+}
+
 export async function runOneCycle(
   config: ShadowConfig,
   detectFn: DetectFn = detectGreyText,
   acceptFn: AcceptFn = acceptGreyText,
   restoreArrowFn: RestoreArrowFn = () => pressRestoreArrow(config),
-): Promise<"accepted" | "no-suggestion" | "overridden" | "error"> {
+  getFrontmostStateFn: () => Promise<FrontmostState | null> = getFrontmostState,
+  nowMs: () => number = Date.now,
+): Promise<"accepted" | "no-suggestion" | "overridden" | "error" | "skipped-fresh-window"> {
+  // Freshness guard: skip AX-heavy detection + restore-arrow keypresses
+  // while the frontmost window is still settling. Prevents interference
+  // with shell init (e.g. zsh .zshrc loading in a freshly-opened terminal).
+  if (config.freshnessThresholdMs > 0) {
+    const state = await getFrontmostStateFn();
+    if (state !== null && !checkWindowFresh(state, config.freshnessThresholdMs, nowMs())) {
+      log(
+        {
+          timestamp: new Date().toISOString(),
+          type: "skipped-fresh-window",
+          content: `${state.name} (pid ${state.pid}) frontmost <${config.freshnessThresholdMs}ms`,
+          delayMs: config.delayMs,
+          dryRun: config.dryRun,
+        },
+        config.logFile,
+      );
+      return "skipped-fresh-window";
+    }
+  }
+
   if (config.restoreArrow) {
     let result: RestoreArrowResult;
     try {
@@ -511,6 +619,7 @@ export function parseConfig(argv: string[]): ShadowConfig {
       "loop-interval": { type: "string", default: "1000" },
       "log-file": { type: "string", default: "tools/shadow/shadow-observer.log" },
       "restore-arrow": { type: "boolean", default: false },
+      "freshness-threshold-ms": { type: "string", default: "0" },
     },
     strict: true,
   });
@@ -541,6 +650,12 @@ export function parseConfig(argv: string[]): ShadowConfig {
     loopMs = parsed;
   }
 
+  const freshnessThresholdMs = parseInt(values["freshness-threshold-ms"] ?? "0", 10);
+  if (!Number.isFinite(freshnessThresholdMs) || freshnessThresholdMs < 0) {
+    console.error("Error: --freshness-threshold-ms must be a non-negative integer (milliseconds)");
+    process.exit(1);
+  }
+
   const base = {
     delayMs,
     dryRun: values["dry-run"] ?? false,
@@ -548,6 +663,7 @@ export function parseConfig(argv: string[]): ShadowConfig {
     loopIntervalMs,
     logFile: values["log-file"] ?? "tools/shadow/shadow-observer.log",
     restoreArrow: values["restore-arrow"] ?? false,
+    freshnessThresholdMs,
   };
   const detectCmd = values["detect-cmd"];
   const withDetect = detectCmd !== undefined ? { ...base, detectCmd } : base;


### PR DESCRIPTION
## Summary

Fix #3 for the 2026-05-16 shadow loop bug: a pid-aware freshness threshold prevents the observer from running AX queries + restore-arrow keypresses on newly-focused terminal windows that are still in shell-init. Aaron experienced the bug as "aborted my zsh user stuff" requiring a reboot to recover.

## Root cause

The disabled production plist (`com.zeta.shadow-observer.plist.disabled-2026-05-16T20-42-35Z`) ran with `--dry-run --restore-arrow --loop-interval 2000`. The dry-run flag only suppresses the destructive Enter-to-accept; `--restore-arrow` runs unconditionally per the existing plist comment ("the two flags are orthogonal"). Result: every 2 seconds, `restore-arrow.applescript` fired in the frontmost terminal — sampling `AXValue` via `AXFocusedUIElement`, pressing `key code 124` (right arrow), then re-sampling. On a newly-opened terminal mid-zsh init, this combination (AX queries on partially-built terminal widget + keypress injection during zsh setup) could plausibly abort init.

## Fix

Pid-aware freshness threshold: before any AX-heavy work in `runOneCycle`, query frontmost app pid+name via a new cheap AppleScript (`get-frontmost-state.applescript`); skip the cycle entirely if that window has been frontmost for less than `freshnessThresholdMs`. Default 5000ms in production (set explicitly via the launchd plist's `--freshness-threshold-ms 5000` flag).

## Diff

- `tools/shadow/get-frontmost-state.applescript` (NEW, 32 lines) — minimal pid+name query, no AX traversal, no key injection
- `tools/shadow/shadow-observer.ts` (+120 lines): `FrontmostState` type, `getFrontmostState` fn, `checkWindowFresh` pure fn, `frontmostHistory` Map, `_resetFrontmostHistory` test helper, `freshnessThresholdMs` config field, CLI flag, early-exit in `runOneCycle` with new `"skipped-fresh-window"` verdict
- `tools/shadow/shadow-observer.test.ts` (+52 lines): `freshnessThresholdMs: 0` added to existing 3 fixtures, 4 new tests for freshness behavior (66 pass total, was 62)
- `tools/shadow/launchd/com.zeta.shadow-observer.plist` (+9 lines): `--freshness-threshold-ms 5000` in `ProgramArguments`; comment block explaining fix #3 rationale

## CLI default = 0 (disabled); production default = 5000 (enabled via plist)

Tests + ad-hoc CLI invocations get deterministic first-cycle detection; production safety choice is visible in the plist config rather than hidden in a CLI default. This composes with the explicit-flag-in-deployment-config discipline.

## Test plan

- [x] All 66 existing tests pass (+4 new freshness tests)
- [x] markdownlint clean
- [x] plist `plutil -lint` passes (template syntax)
- [ ] Post-merge: run `bun tools/shadow/launchd/install-launchagent.ts` to reinstall plist with new flag
- [ ] Post-install: verify new terminal opens without zsh-init interference

## Composes with

- B-0402 (shadow observer original substrate)
- The 2026-05-16 disabled plist (root-cause evidence)
- The existing `detect-grey-text.applescript` lines 40-49 comment (prior failure-mode preservation — same family: querying AX of unprepared windows has side effects)
- `.claude/rules/shadow-star-shorthand-autocomplete-marker.md` (the shadow infrastructure that produces `(shadow*)` markers when accepted suggestions get shipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)