### PR TITLE
feat(B-0581): decompose slice 1 - gh auth refresh wrapper script

### DIFF
--- a/tools/auth/gh-auth-refresh-wrapper.ts
+++ b/tools/auth/gh-auth-refresh-wrapper.ts
@@ -1,0 +1,64 @@
+import { spawn } from "bun";
+
+async function main() {
+  const scopes = process.argv.slice(2).join(",");
+  if (!scopes) {
+    console.error("Usage: bun run tools/auth/gh-auth-refresh-wrapper.ts <scopes>");
+    process.exit(1);
+  }
+
+  console.log(`Starting gh auth refresh for scopes: ${scopes}`);
+  
+  const proc = spawn({
+    cmd: ["gh", "auth", "refresh", "-h", "github.com", "-s", scopes],
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const decoder = new TextDecoder();
+  let codeCaptured = false;
+
+  const handleOutput = async (stream: ReadableStream, isStderr: boolean) => {
+    const out = isStderr ? process.stderr : process.stdout;
+    for await (const chunk of stream) {
+      const text = decoder.decode(chunk);
+      out.write(text);
+      
+      // Look for the Y/N prompt
+      if (text.includes("? Authenticate Git with your GitHub credentials?")) {
+        proc.stdin.write("Y\n");
+        proc.stdin.flush();
+      }
+
+      // Look for the one-time code
+      const codeMatch = text.match(/! First copy your one-time code: ([A-Z0-9-]+)/);
+      if (codeMatch && !codeCaptured) {
+        const code = codeMatch[1];
+        codeCaptured = true;
+        console.log(`\n\n`);
+        console.log(`========================================================`);
+        console.log(`🚀 ONE-TIME CODE CAPTURED: ${code} 🚀`);
+        console.log(`========================================================`);
+        console.log(`\n`);
+        
+        // Optionally pump Enter if the process expects it, but wait for user to copy.
+        // The script just needs to surface it prominently for now.
+      }
+    }
+  };
+
+  Promise.all([
+    handleOutput(proc.stdout, false),
+    handleOutput(proc.stderr, true)
+  ]).catch(console.error);
+
+  const exitCode = await proc.exited;
+  console.log(`\ngh auth refresh exited with code ${exitCode}`);
+  process.exit(exitCode);
+}
+
+main().catch((err) => {
+  console.error("Error running wrapper:", err);
+  process.exit(1);
+});

--- a/tools/auth/gh-auth-refresh-wrapper.ts
+++ b/tools/auth/gh-auth-refresh-wrapper.ts
@@ -16,11 +16,14 @@ export async function main(): Promise<number> {
     stderr: "pipe",
   });
 
-  const decoder = new TextDecoder();
   let codeCaptured = false;
 
   const handleOutput = async (stream: ReadableStream, isStderr: boolean) => {
     const out = isStderr ? process.stderr : process.stdout;
+    // Per-invocation TextDecoder: TextDecoder is stateful (retains partial
+    // multi-byte sequences between decode() calls). Two concurrent handleOutput
+    // calls (stdout + stderr) sharing one decoder can corrupt cross-stream output.
+    const decoder = new TextDecoder();
     // Buffer text across chunks: gh output may split prompts across
     // arbitrary chunk boundaries, so per-chunk includes() can miss them.
     let buffer = "";

--- a/tools/auth/gh-auth-refresh-wrapper.ts
+++ b/tools/auth/gh-auth-refresh-wrapper.ts
@@ -1,14 +1,14 @@
 import { spawn } from "bun";
 
-async function main() {
+export async function main(): Promise<number> {
   const scopes = process.argv.slice(2).join(",");
   if (!scopes) {
     console.error("Usage: bun run tools/auth/gh-auth-refresh-wrapper.ts <scopes>");
-    process.exit(1);
+    return 1;
   }
 
   console.log(`Starting gh auth refresh for scopes: ${scopes}`);
-  
+
   const proc = spawn({
     cmd: ["gh", "auth", "refresh", "-h", "github.com", "-s", scopes],
     stdin: "pipe",
@@ -21,18 +21,27 @@ async function main() {
 
   const handleOutput = async (stream: ReadableStream, isStderr: boolean) => {
     const out = isStderr ? process.stderr : process.stdout;
+    // Buffer text across chunks: gh output may split prompts across
+    // arbitrary chunk boundaries, so per-chunk includes() can miss them.
+    let buffer = "";
+    const PROMPT = "? Authenticate Git with your GitHub credentials?";
+    let promptHandled = false;
     for await (const chunk of stream) {
       const text = decoder.decode(chunk);
       out.write(text);
-      
-      // Look for the Y/N prompt
-      if (text.includes("? Authenticate Git with your GitHub credentials?")) {
+      buffer += text;
+
+      // Look for the Y/N prompt in accumulated buffer.
+      if (!promptHandled && buffer.includes(PROMPT)) {
         proc.stdin.write("Y\n");
         proc.stdin.flush();
+        promptHandled = true;
+        // Trim consumed prompt to bound buffer growth.
+        buffer = buffer.slice(buffer.indexOf(PROMPT) + PROMPT.length);
       }
 
-      // Look for the one-time code
-      const codeMatch = text.match(/! First copy your one-time code: ([A-Z0-9-]+)/);
+      // Look for the one-time code in accumulated buffer.
+      const codeMatch = buffer.match(/! First copy your one-time code: ([A-Z0-9-]+)/);
       if (codeMatch && !codeCaptured) {
         const code = codeMatch[1];
         codeCaptured = true;
@@ -41,24 +50,34 @@ async function main() {
         console.log(`🚀 ONE-TIME CODE CAPTURED: ${code} 🚀`);
         console.log(`========================================================`);
         console.log(`\n`);
-        
-        // Optionally pump Enter if the process expects it, but wait for user to copy.
-        // The script just needs to surface it prominently for now.
+      }
+
+      // Keep buffer bounded across long sessions.
+      if (buffer.length > 16384) {
+        buffer = buffer.slice(-8192);
       }
     }
   };
 
-  Promise.all([
+  // Capture handler promises and await them before exit; otherwise
+  // trailing stdout/stderr (e.g. the one-time code banner) can be
+  // dropped when process.exit fires before the output pumps drain.
+  const handlersPromise = Promise.all([
     handleOutput(proc.stdout, false),
-    handleOutput(proc.stderr, true)
+    handleOutput(proc.stderr, true),
   ]).catch(console.error);
 
   const exitCode = await proc.exited;
+  await handlersPromise;
   console.log(`\ngh auth refresh exited with code ${exitCode}`);
-  process.exit(exitCode);
+  return exitCode;
 }
 
-main().catch((err) => {
-  console.error("Error running wrapper:", err);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error("Error running wrapper:", err);
+      process.exit(1);
+    });
+}

--- a/tools/auth/gh-auth-refresh-wrapper.ts
+++ b/tools/auth/gh-auth-refresh-wrapper.ts
@@ -50,6 +50,13 @@ export async function main(): Promise<number> {
         console.log(`🚀 ONE-TIME CODE CAPTURED: ${code} 🚀`);
         console.log(`========================================================`);
         console.log(`\n`);
+        // gh waits at "Press Enter to open github.com in your browser..."
+        // after printing the code. Pump a newline so the device flow
+        // continues to the token-store step; without this the wrapper
+        // hangs indefinitely because the child stdin is piped and the
+        // operator can't satisfy the prompt manually.
+        proc.stdin.write("\n");
+        proc.stdin.flush();
       }
 
       // Keep buffer bounded across long sessions.


### PR DESCRIPTION
Slices off the first operational step of B-0581 from PR #3961 to adhere to the bias for action and prevent shadow/metadata drift. Implements the script to spawn gh auth refresh, pump Y/n, and prominently capture the one-time code.