### PR TITLE
feat(B-0529): add-pipe-row-header.ts — backfill tool for shard schema

### DIFF
--- a/tools/hygiene/add-pipe-row-header.test.ts
+++ b/tools/hygiene/add-pipe-row-header.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  alreadyCompliant,
+  buildHeader,
+  parseShardPath,
+} from "./add-pipe-row-header";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+const SHARD_PREFIX = "docs/hygiene-history/ticks";
+
+function shardPath(rel: string): string {
+  return resolve(REPO_ROOT, rel);
+}
+
+function infoFor(rel: string) {
+  const info = parseShardPath(shardPath(rel));
+  if (!info) throw new Error(`fixture path did not parse: ${rel}`);
+  return info;
+}
+
+describe("parseShardPath", () => {
+  test("accepts HHMMZ.md form (bare)", () => {
+    const info = parseShardPath(shardPath(`${SHARD_PREFIX}/2026/05/17/0012Z.md`));
+    expect(info).not.toBeNull();
+    expect(info?.iso).toBe("2026-05-17T00:12Z");
+  });
+
+  test("accepts HHMMZ-<hex>.md form (minute-grain + hash)", () => {
+    const info = parseShardPath(
+      shardPath(`${SHARD_PREFIX}/2026/05/17/0012Z-abc123.md`),
+    );
+    expect(info).not.toBeNull();
+    expect(info?.iso).toBe("2026-05-17T00:12Z");
+  });
+
+  test("accepts HHMMSSZ-<hex>.md form (second-grain + hash)", () => {
+    const info = parseShardPath(
+      shardPath(`${SHARD_PREFIX}/2026/05/17/001234Z-abc123.md`),
+    );
+    expect(info).not.toBeNull();
+    expect(info?.iso).toBe("2026-05-17T00:12:34Z");
+  });
+
+  test("rejects README.md", () => {
+    const info = parseShardPath(shardPath(`${SHARD_PREFIX}/README.md`));
+    expect(info).toBeNull();
+  });
+
+  test("rejects files outside the shard prefix", () => {
+    const info = parseShardPath(shardPath("docs/hygiene-history/loop-tick-history.md"));
+    expect(info).toBeNull();
+  });
+
+  test("rejects non-.md extensions", () => {
+    const info = parseShardPath(shardPath(`${SHARD_PREFIX}/2026/05/17/0012Z.txt`));
+    expect(info).toBeNull();
+  });
+
+  test("rejects malformed filename (no HHMMZ pattern)", () => {
+    const info = parseShardPath(shardPath(`${SHARD_PREFIX}/2026/05/17/something.md`));
+    expect(info).toBeNull();
+  });
+
+  test("rejects malformed path date components", () => {
+    const info = parseShardPath(shardPath(`${SHARD_PREFIX}/abcd/05/17/0012Z.md`));
+    expect(info).toBeNull();
+  });
+});
+
+describe("alreadyCompliant", () => {
+  const info = infoFor(`${SHARD_PREFIX}/2026/05/17/0012Z.md`);
+
+  test("true for valid pipe-row matching path timestamp (HH:MM)", () => {
+    const content =
+      "| 2026-05-17T00:12Z | retrofit | unknown | retrofit | none | none |\n\n# Body\n";
+    expect(alreadyCompliant(content, info)).toBe(true);
+  });
+
+  test("true for HH:MM:SS form matching path date+hour+min (validator ignores seconds)", () => {
+    const content =
+      "| 2026-05-17T00:12:34Z | retrofit | unknown | retrofit | none | none |\n";
+    expect(alreadyCompliant(content, info)).toBe(true);
+  });
+
+  test("false when pipe-row timestamp date does NOT match path", () => {
+    const content =
+      "| 2020-01-01T00:12Z | wrong | wrong | wrong | wrong | wrong |\n# Body\n";
+    expect(alreadyCompliant(content, info)).toBe(false);
+  });
+
+  test("false when pipe-row timestamp hour/min does NOT match filename", () => {
+    const content =
+      "| 2026-05-17T05:30Z | retrofit | unknown | retrofit | none | none |\n";
+    expect(alreadyCompliant(content, info)).toBe(false);
+  });
+
+  test("false for H1 first line", () => {
+    const content = "# Tick 0012Z — example\n\nBody\n";
+    expect(alreadyCompliant(content, info)).toBe(false);
+  });
+
+  test("false for empty content", () => {
+    expect(alreadyCompliant("", info)).toBe(false);
+  });
+
+  test("false for whitespace-only content", () => {
+    expect(alreadyCompliant("\n\n   \n", info)).toBe(false);
+  });
+
+  test("false for too-few pipes (< 7)", () => {
+    const content = "| 2026-05-17T00:12Z | a | b | c | d |\n";
+    expect(alreadyCompliant(content, info)).toBe(false);
+  });
+
+  test("false when first line has pipes but bad timestamp format", () => {
+    const content = "| not-a-timestamp | a | b | c | d | e |\n";
+    expect(alreadyCompliant(content, info)).toBe(false);
+  });
+
+  test("skips leading blank lines to find first non-empty", () => {
+    const content =
+      "\n\n| 2026-05-17T00:12Z | a | b | c | d | e |\n\n# Body\n";
+    expect(alreadyCompliant(content, info)).toBe(true);
+  });
+});
+
+describe("buildHeader", () => {
+  test("produces a 7-pipe row with the given ISO timestamp", () => {
+    const header = buildHeader("2026-05-17T00:12Z");
+    const firstLine = header.split("\n")[0];
+    expect(firstLine).toBeDefined();
+    const pipeCount = (firstLine?.match(/\|/g) ?? []).length;
+    expect(pipeCount).toBeGreaterThanOrEqual(7);
+  });
+
+  test("first row matches the validator's COL1_RE pattern", () => {
+    const header = buildHeader("2026-05-17T00:12Z");
+    const firstLine = header.split("\n")[0] ?? "";
+    expect(firstLine).toMatch(
+      /^\|\s\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?Z\s\|\s/,
+    );
+  });
+
+  test("ends with double newline to separate from existing body", () => {
+    const header = buildHeader("2026-05-17T00:12Z");
+    expect(header.endsWith("\n\n")).toBe(true);
+  });
+
+  test("prepending makes a non-compliant body compliant for the matching shard", () => {
+    const info = infoFor(`${SHARD_PREFIX}/2026/05/17/0012Z.md`);
+    const body = "# Tick 0012Z — example\n\nbody text\n";
+    const prepended = buildHeader("2026-05-17T00:12Z") + body;
+    expect(alreadyCompliant(prepended, info)).toBe(true);
+  });
+
+  test("uses honest 'retrofit' placeholders rather than fabricated content", () => {
+    const header = buildHeader("2026-05-17T00:12Z");
+    expect(header).toContain("retrofit");
+    expect(header).toContain("none");
+  });
+});
+
+describe("atomic write behavior (processOne with --write)", () => {
+  // These tests exercise the script via REPO_ROOT override + tmpdir
+  // fixtures, validating that:
+  //   - the tempfile rename pattern produces durable shard content
+  //   - the body of the original file is preserved below the new header
+
+  function makeRepo(): string {
+    return mkdtempSync(join(tmpdir(), "add-pipe-row-header-test-"));
+  }
+
+  test("--write produces a validator-compliant first line for an H1 shard", async () => {
+    const repo = makeRepo();
+    try {
+      const shardRel = `${SHARD_PREFIX}/2026/05/17/0001Z.md`;
+      const shardAbs = join(repo, shardRel);
+      mkdirSync(join(repo, `${SHARD_PREFIX}/2026/05/17`), { recursive: true });
+      writeFileSync(shardAbs, "# Tick 0001Z — fixture\n\nbody\n", "utf8");
+
+      // Drive the script via Bun subprocess to exercise the real main().
+      const proc = Bun.spawn(
+        [
+          "bun",
+          "tools/hygiene/add-pipe-row-header.ts",
+          "--write",
+          "--files",
+          shardRel,
+        ],
+        {
+          cwd: REPO_ROOT,
+          env: { ...process.env, REPO_ROOT: repo },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      await proc.exited;
+
+      const content = readFileSync(shardAbs, "utf8");
+      const firstLine = content.split("\n")[0] ?? "";
+      expect(firstLine).toMatch(
+        /^\| 2026-05-17T00:01Z \| retrofit \| unknown \| retrofit/,
+      );
+      // Original body must be preserved.
+      expect(content).toContain("# Tick 0001Z — fixture");
+      expect(content).toContain("body");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("--write leaves no tempfile behind after success", async () => {
+    const repo = makeRepo();
+    try {
+      const shardRel = `${SHARD_PREFIX}/2026/05/17/0002Z.md`;
+      const shardAbs = join(repo, shardRel);
+      mkdirSync(join(repo, `${SHARD_PREFIX}/2026/05/17`), { recursive: true });
+      writeFileSync(shardAbs, "# Tick 0002Z\nbody\n", "utf8");
+
+      const proc = Bun.spawn(
+        [
+          "bun",
+          "tools/hygiene/add-pipe-row-header.ts",
+          "--write",
+          "--files",
+          shardRel,
+        ],
+        {
+          cwd: REPO_ROOT,
+          env: { ...process.env, REPO_ROOT: repo },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      await proc.exited;
+
+      // Only the shard should exist in the parent dir — no `.tmp-*` siblings.
+      const { readdirSync } = await import("node:fs");
+      const entries = readdirSync(join(repo, `${SHARD_PREFIX}/2026/05/17`));
+      const tempLeaks = entries.filter((e) => e.includes(".tmp-"));
+      expect(tempLeaks).toEqual([]);
+      expect(entries).toContain("0002Z.md");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("argument-parser fail-closed behaviors (via subprocess)", () => {
+  // Each test exercises main() via Bun.spawn to surface real exit codes.
+
+  async function run(args: string[]): Promise<{ exit: number; stderr: string }> {
+    const proc = Bun.spawn(
+      ["bun", "tools/hygiene/add-pipe-row-header.ts", ...args],
+      {
+        cwd: REPO_ROOT,
+        env: { ...process.env, REPO_ROOT: "/nonexistent-tmpdir-for-test" },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+    return { exit: proc.exitCode ?? 0, stderr };
+  }
+
+  test("--files with no paths exits non-zero", async () => {
+    const { exit, stderr } = await run(["--files"]);
+    expect(exit).toBe(1);
+    expect(stderr).toContain("--files specified but no paths");
+  });
+
+  test("unknown flag --file (typo) exits non-zero", async () => {
+    const { exit, stderr } = await run(["--file", "foo"]);
+    expect(exit).toBe(1);
+    expect(stderr).toContain("unrecognized flag");
+  });
+
+  test("stray positional outside --files exits non-zero", async () => {
+    const { exit, stderr } = await run(["random-arg"]);
+    expect(exit).toBe(1);
+    expect(stderr).toContain("unexpected positional");
+  });
+});

--- a/tools/hygiene/add-pipe-row-header.ts
+++ b/tools/hygiene/add-pipe-row-header.ts
@@ -69,7 +69,7 @@ function repoRelative(p: string): string {
   return normalizeToPosix(relative(ROOT, p));
 }
 
-function parseShardPath(absPath: string): ShardInfo | null {
+export function parseShardPath(absPath: string): ShardInfo | null {
   const rel = repoRelative(absPath);
   if (!rel.startsWith(SHARD_PREFIX)) return null;
   if (!rel.endsWith(".md")) return null;
@@ -122,8 +122,7 @@ function firstNonEmptyLine(content: string): string | null {
 //      path/filename. A shard with a pipe-row whose timestamp does
 //      NOT match the path would still fail the validator; treating
 //      it as compliant here would silently skip a real violation.
-//      (Copilot P1 + Codex P2 catch on PR #3990.)
-function alreadyCompliant(content: string, info: ShardInfo): boolean {
+export function alreadyCompliant(content: string, info: ShardInfo): boolean {
   const first = firstNonEmptyLine(content);
   if (!first) return false;
   const pipeCount = (first.match(/\|/g) ?? []).length;
@@ -137,7 +136,7 @@ function alreadyCompliant(content: string, info: ShardInfo): boolean {
   return parsedIso.slice(0, 16) === info.iso.slice(0, 16);
 }
 
-function buildHeader(iso: string): string {
+export function buildHeader(iso: string): string {
   // Placeholders for fields we cannot reconstruct from the path alone.
   // The H1 body below carries the substantive content; the pipe-row
   // exists for validator + machine-parseability.
@@ -236,7 +235,7 @@ export function processOne(absPath: string, write: boolean): Action {
   // an interruption or disk-full mid-write would corrupt the shard body
   // this tool is trying to PRESERVE. Same-directory rename is atomic
   // on POSIX. Tempfile name includes pid+timestamp to prevent collisions
-  // between concurrent writers. (Copilot P1 catch on PR #3990.)
+  // between concurrent writers.
   const tempPath = `${absPath}.tmp-${process.pid}-${Date.now()}`;
   try {
     writeFileSync(tempPath, newContent, "utf8");
@@ -257,11 +256,15 @@ export function processOne(absPath: string, write: boolean): Action {
   }
 }
 
+const KNOWN_FLAGS = new Set(["--write", "--files"]);
+
 export function main(argv: string[]): number {
   let write = false;
   let filesFlagSeen = false;
   const files: string[] = [];
   let inFiles = false;
+  const unknownFlags: string[] = [];
+  const strayPositional: string[] = [];
 
   for (const a of argv) {
     if (a === "--write") {
@@ -272,14 +275,37 @@ export function main(argv: string[]): number {
       inFiles = true;
     } else if (inFiles) {
       files.push(a);
+    } else if (a.startsWith("--")) {
+      // Reject unknown flags. A typo like `--file <path>` (missing `s`)
+      // would otherwise leave filesFlagSeen=false and fall through to a
+      // full-tree write. Fail-closed on unrecognized options.
+      if (!KNOWN_FLAGS.has(a)) unknownFlags.push(a);
+    } else {
+      // Positional args outside --files mode have no defined meaning.
+      // Tracking them lets us surface caller mistakes before they
+      // become silent no-ops or bulk writes.
+      strayPositional.push(a);
     }
+  }
+
+  if (unknownFlags.length > 0) {
+    process.stderr.write(
+      `error: unrecognized flag(s): ${unknownFlags.join(", ")}; known flags: --write, --files\n`,
+    );
+    return 1;
+  }
+
+  if (strayPositional.length > 0) {
+    process.stderr.write(
+      `error: unexpected positional argument(s): ${strayPositional.join(", ")}; paths only allowed after --files\n`,
+    );
+    return 1;
   }
 
   // Fail-closed: `--files` with zero paths must NOT silently fall back
   // to a full-tree scan. Under `--write`, that would prepend headers
-  // across all 359 non-compliant shards from a caller typo or an
-  // empty dynamically-generated file list. Treat as explicit error.
-  // (Codex P1 finding on PR #3990.)
+  // across all non-compliant shards from a caller typo or an empty
+  // dynamically-generated file list. Treat as explicit error.
   if (filesFlagSeen && files.length === 0) {
     process.stderr.write(
       "error: --files specified but no paths provided; refusing to fall back to full-tree scan\n",
@@ -288,13 +314,32 @@ export function main(argv: string[]): number {
   }
 
   let shards: string[];
+  let droppedInputs: string[] = [];
   if (filesFlagSeen) {
-    shards = files
-      .map((p) => resolve(ROOT, p))
-      .filter((p) => repoRelative(p).startsWith(SHARD_PREFIX))
-      .filter((p) => repoRelative(p).endsWith(".md"))
-      .filter((p) => basename(p) !== "README.md")
-      .filter(isFile);
+    const resolvedInputs = files.map((p) => ({
+      input: p,
+      abs: resolve(ROOT, p),
+    }));
+    shards = [];
+    for (const { input, abs } of resolvedInputs) {
+      const rel = repoRelative(abs);
+      const keep =
+        rel.startsWith(SHARD_PREFIX) &&
+        rel.endsWith(".md") &&
+        basename(abs) !== "README.md" &&
+        isFile(abs);
+      if (keep) shards.push(abs);
+      else droppedInputs.push(input);
+    }
+    // Fail-closed: silently dropping paths that don't exist, aren't .md,
+    // or sit outside the shard tree turns typos and stale generated path
+    // lists into `scanned 0` clean runs. Surface them as errors instead.
+    if (droppedInputs.length > 0) {
+      process.stderr.write(
+        `error: --files paths filtered out (missing, outside shard tree, or not .md): ${droppedInputs.join(", ")}\n`,
+      );
+      return 1;
+    }
   } else {
     if (!isDir(SHARD_DIR)) {
       process.stderr.write(`error: ${SHARD_DIR} does not exist\n`);
@@ -332,7 +377,15 @@ export function main(argv: string[]): number {
       `errors=${counts["error"]}\n`,
   );
 
-  return counts["error"] > 0 ? 1 : 0;
+  // Exit non-zero when any shards were left unprocessed for reasons that
+  // a --write caller would want to know about. `skip-unparseable-name`
+  // counts as a failure: it means a file matched our shard-tree scope
+  // but the filename didn't fit any known HHMMZ form, so the validator
+  // would still reject it. Treating that as a clean run lets validator-
+  // breaking files slip through a --write automation.
+  // `skip-empty` is also surfaced — an empty shard file is malformed.
+  const unprocessed = counts["error"] + counts["skip-unparseable-name"] + counts["skip-empty"];
+  return unprocessed > 0 ? 1 : 0;
 }
 
 if (import.meta.main) {

--- a/tools/hygiene/add-pipe-row-header.ts
+++ b/tools/hygiene/add-pipe-row-header.ts
@@ -30,7 +30,14 @@
 //   1   one or more files could not be processed
 //   2   tick shard directory missing
 
-import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { basename, join, relative, resolve } from "node:path";
 
 const ROOT = resolve(process.env["REPO_ROOT"] ?? process.cwd());
@@ -107,12 +114,27 @@ function firstNonEmptyLine(content: string): string | null {
   return null;
 }
 
-function alreadyCompliant(content: string): boolean {
+// Mirrors the validator's compliance contract:
+//   1. First non-empty line has ≥7 pipes (≥6 columns)
+//   2. First column matches COL1_RE (| ISO-8601 timestamp |)
+//   3. Parsed timestamp's YYYY-MM-DDTHH:MM prefix matches info.iso —
+//      the validator enforces date+hour+minute matching against the
+//      path/filename. A shard with a pipe-row whose timestamp does
+//      NOT match the path would still fail the validator; treating
+//      it as compliant here would silently skip a real violation.
+//      (Copilot P1 + Codex P2 catch on PR #3990.)
+function alreadyCompliant(content: string, info: ShardInfo): boolean {
   const first = firstNonEmptyLine(content);
   if (!first) return false;
   const pipeCount = (first.match(/\|/g) ?? []).length;
   if (pipeCount < 7) return false;
-  return COL1_RE.test(first);
+  const match = COL1_RE.exec(first);
+  if (!match) return false;
+  const parsedIso = match[1] ?? "";
+  // Validator checks YYYY-MM-DD (slice 0-10) + HH (11-13) + MIN (14-16);
+  // it does NOT check seconds. The slice(0, 16) prefix captures exactly
+  // the validator's matching surface for both HH:MMZ and HH:MM:SSZ forms.
+  return parsedIso.slice(0, 16) === info.iso.slice(0, 16);
 }
 
 function buildHeader(iso: string): string {
@@ -198,7 +220,7 @@ export function processOne(absPath: string, write: boolean): Action {
     return { rel: info.rel, status: "skip-empty" };
   }
 
-  if (alreadyCompliant(content)) {
+  if (alreadyCompliant(content, info)) {
     return { rel: info.rel, status: "skip-already-compliant" };
   }
 
@@ -209,10 +231,24 @@ export function processOne(absPath: string, write: boolean): Action {
     return { rel: info.rel, status: "would-prepend" };
   }
 
+  // Atomic write: write to a same-directory temp file, then rename.
+  // Direct writeFileSync truncates the original before bytes are durable —
+  // an interruption or disk-full mid-write would corrupt the shard body
+  // this tool is trying to PRESERVE. Same-directory rename is atomic
+  // on POSIX. Tempfile name includes pid+timestamp to prevent collisions
+  // between concurrent writers. (Copilot P1 catch on PR #3990.)
+  const tempPath = `${absPath}.tmp-${process.pid}-${Date.now()}`;
   try {
-    writeFileSync(absPath, newContent, "utf8");
+    writeFileSync(tempPath, newContent, "utf8");
+    renameSync(tempPath, absPath);
     return { rel: info.rel, status: "prepended" };
   } catch (e) {
+    // Clean up tempfile if rename failed after write succeeded.
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      /* tempfile may not exist if write failed before creating it */
+    }
     return {
       rel: info.rel,
       status: "error",

--- a/tools/hygiene/add-pipe-row-header.ts
+++ b/tools/hygiene/add-pipe-row-header.ts
@@ -223,21 +223,36 @@ export function processOne(absPath: string, write: boolean): Action {
 
 export function main(argv: string[]): number {
   let write = false;
+  let filesFlagSeen = false;
   const files: string[] = [];
   let inFiles = false;
 
   for (const a of argv) {
     if (a === "--write") {
       write = true;
+      inFiles = false;
     } else if (a === "--files") {
+      filesFlagSeen = true;
       inFiles = true;
     } else if (inFiles) {
       files.push(a);
     }
   }
 
+  // Fail-closed: `--files` with zero paths must NOT silently fall back
+  // to a full-tree scan. Under `--write`, that would prepend headers
+  // across all 359 non-compliant shards from a caller typo or an
+  // empty dynamically-generated file list. Treat as explicit error.
+  // (Codex P1 finding on PR #3990.)
+  if (filesFlagSeen && files.length === 0) {
+    process.stderr.write(
+      "error: --files specified but no paths provided; refusing to fall back to full-tree scan\n",
+    );
+    return 1;
+  }
+
   let shards: string[];
-  if (files.length > 0) {
+  if (filesFlagSeen) {
     shards = files
       .map((p) => resolve(ROOT, p))
       .filter((p) => repoRelative(p).startsWith(SHARD_PREFIX))

--- a/tools/hygiene/add-pipe-row-header.ts
+++ b/tools/hygiene/add-pipe-row-header.ts
@@ -1,0 +1,289 @@
+#!/usr/bin/env bun
+// add-pipe-row-header.ts — backfill validator-compliant pipe-row first
+// line to tick shards that currently start with H1 (or any non-pipe
+// content). Implements B-0529 Option 3 ("hybrid"): pipe-row first line
+// + H1-rich body below.
+//
+// The pipe-row schema (per `docs/hygiene-history/ticks/README.md`):
+//   | <ISO 8601 UTC timestamp> | <model id> | <cron sentinel> | <body> | <PR ref> | <observation> |
+//
+// We retrofit with placeholders for fields we cannot reconstruct from
+// the path alone (model id / cron sentinel / PR ref / observation).
+// The H1 body that follows is the substantive content; placeholders in
+// the pipe-row are honest about being retrofit rather than
+// archaeologically reconstructing claims.
+//
+// Validator: `tools/hygiene/check-tick-history-shard-schema.ts`
+// Backlog row: `docs/backlog/P2/B-0529-tick-shard-schema-validator-vs-practice-drift-2026-05-15.md`
+// Rule 0: TypeScript (no .sh) per `.claude/rules/rule-0-no-sh-files.md`.
+//
+// Usage:
+//   bun tools/hygiene/add-pipe-row-header.ts                       # dry-run, full scan
+//   bun tools/hygiene/add-pipe-row-header.ts --write               # write, full scan
+//   bun tools/hygiene/add-pipe-row-header.ts --files <paths>       # restrict to paths
+//   bun tools/hygiene/add-pipe-row-header.ts --write --files <p>   # restrict + write
+//
+// Run from the repo root, or set REPO_ROOT env var.
+//
+// Exit codes:
+//   0   dry-run completed OR all writes succeeded
+//   1   one or more files could not be processed
+//   2   tick shard directory missing
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { basename, join, relative, resolve } from "node:path";
+
+const ROOT = resolve(process.env["REPO_ROOT"] ?? process.cwd());
+const SHARD_DIR = join(ROOT, "docs/hygiene-history/ticks");
+const SHARD_PREFIX = "docs/hygiene-history/ticks/";
+
+// Filename forms accepted by the validator:
+//   HHMMZ.md          — bare
+//   HHMMZ-<hex>.md    — minute-grain + hash
+//   HHMMSSZ-<hex>.md  — second-grain + hash
+const BARE_RE = /^(\d{4})Z$/;
+const HASH_MIN_RE = /^(\d{4})Z-[0-9a-f]+$/;
+const HASH_SEC_RE = /^(\d{6})Z-[0-9a-f]+$/;
+
+// Validator's COL1_RE check (mirror of check-tick-history-shard-schema.ts).
+const COL1_RE = /^\|\s(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?Z)\s\|\s/;
+
+interface ShardInfo {
+  abs: string;
+  rel: string;
+  iso: string;
+}
+
+function normalizeToPosix(p: string): string {
+  return p.replaceAll("\\", "/");
+}
+
+function repoRelative(p: string): string {
+  return normalizeToPosix(relative(ROOT, p));
+}
+
+function parseShardPath(absPath: string): ShardInfo | null {
+  const rel = repoRelative(absPath);
+  if (!rel.startsWith(SHARD_PREFIX)) return null;
+  if (!rel.endsWith(".md")) return null;
+  const base = basename(rel, ".md");
+  if (base === "README") return null;
+
+  const parts = rel.replace(SHARD_PREFIX, "").split("/");
+  if (parts.length < 4) return null;
+  const yyyy = parts[0];
+  const mm = parts[1];
+  const dd = parts[2];
+  if (!yyyy || !mm || !dd) return null;
+  if (!/^\d{4}$/.test(yyyy) || !/^\d{2}$/.test(mm) || !/^\d{2}$/.test(dd)) {
+    return null;
+  }
+
+  const bare = BARE_RE.exec(base);
+  const hashMin = HASH_MIN_RE.exec(base);
+  const hashSec = HASH_SEC_RE.exec(base);
+
+  let iso: string;
+  if (bare) {
+    const hhmm = bare[1] ?? "";
+    iso = `${yyyy}-${mm}-${dd}T${hhmm.slice(0, 2)}:${hhmm.slice(2, 4)}Z`;
+  } else if (hashMin) {
+    const hhmm = hashMin[1] ?? "";
+    iso = `${yyyy}-${mm}-${dd}T${hhmm.slice(0, 2)}:${hhmm.slice(2, 4)}Z`;
+  } else if (hashSec) {
+    const hhmmss = hashSec[1] ?? "";
+    iso = `${yyyy}-${mm}-${dd}T${hhmmss.slice(0, 2)}:${hhmmss.slice(2, 4)}:${hhmmss.slice(4, 6)}Z`;
+  } else {
+    return null;
+  }
+
+  return { abs: absPath, rel, iso };
+}
+
+function firstNonEmptyLine(content: string): string | null {
+  for (const line of content.split("\n")) {
+    if (line.trim().length > 0) return line;
+  }
+  return null;
+}
+
+function alreadyCompliant(content: string): boolean {
+  const first = firstNonEmptyLine(content);
+  if (!first) return false;
+  const pipeCount = (first.match(/\|/g) ?? []).length;
+  if (pipeCount < 7) return false;
+  return COL1_RE.test(first);
+}
+
+function buildHeader(iso: string): string {
+  // Placeholders for fields we cannot reconstruct from the path alone.
+  // The H1 body below carries the substantive content; the pipe-row
+  // exists for validator + machine-parseability.
+  return `| ${iso} | retrofit | unknown | retrofit (see body below) | none | none |\n\n`;
+}
+
+function findShards(dir: string): string[] {
+  const out: string[] = [];
+  function walk(d: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(d);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(d, entry);
+      try {
+        const st = statSync(full);
+        if (st.isDirectory()) walk(full);
+        else if (entry.endsWith(".md") && entry !== "README.md") out.push(full);
+      } catch {
+        /* skip unreadable */
+      }
+    }
+  }
+  walk(dir);
+  return out;
+}
+
+function isDir(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isFile(p: string): boolean {
+  try {
+    return statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+interface Action {
+  rel: string;
+  status:
+    | "skip-already-compliant"
+    | "skip-unparseable-name"
+    | "skip-empty"
+    | "would-prepend"
+    | "prepended"
+    | "error";
+  detail?: string;
+}
+
+export function processOne(absPath: string, write: boolean): Action {
+  const info = parseShardPath(absPath);
+  if (!info) {
+    return {
+      rel: repoRelative(absPath),
+      status: "skip-unparseable-name",
+    };
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(absPath, "utf8");
+  } catch (e) {
+    return {
+      rel: info.rel,
+      status: "error",
+      detail: e instanceof Error ? e.message : String(e),
+    };
+  }
+
+  if (content.length === 0) {
+    return { rel: info.rel, status: "skip-empty" };
+  }
+
+  if (alreadyCompliant(content)) {
+    return { rel: info.rel, status: "skip-already-compliant" };
+  }
+
+  const header = buildHeader(info.iso);
+  const newContent = header + content;
+
+  if (!write) {
+    return { rel: info.rel, status: "would-prepend" };
+  }
+
+  try {
+    writeFileSync(absPath, newContent, "utf8");
+    return { rel: info.rel, status: "prepended" };
+  } catch (e) {
+    return {
+      rel: info.rel,
+      status: "error",
+      detail: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+export function main(argv: string[]): number {
+  let write = false;
+  const files: string[] = [];
+  let inFiles = false;
+
+  for (const a of argv) {
+    if (a === "--write") {
+      write = true;
+    } else if (a === "--files") {
+      inFiles = true;
+    } else if (inFiles) {
+      files.push(a);
+    }
+  }
+
+  let shards: string[];
+  if (files.length > 0) {
+    shards = files
+      .map((p) => resolve(ROOT, p))
+      .filter((p) => repoRelative(p).startsWith(SHARD_PREFIX))
+      .filter((p) => repoRelative(p).endsWith(".md"))
+      .filter((p) => basename(p) !== "README.md")
+      .filter(isFile);
+  } else {
+    if (!isDir(SHARD_DIR)) {
+      process.stderr.write(`error: ${SHARD_DIR} does not exist\n`);
+      return 2;
+    }
+    shards = findShards(SHARD_DIR);
+  }
+
+  const counts: Record<Action["status"], number> = {
+    "skip-already-compliant": 0,
+    "skip-unparseable-name": 0,
+    "skip-empty": 0,
+    "would-prepend": 0,
+    prepended: 0,
+    error: 0,
+  };
+
+  for (const s of shards) {
+    const action = processOne(s, write);
+    counts[action.status]++;
+    if (action.status === "would-prepend" || action.status === "prepended") {
+      process.stdout.write(`${action.status}: ${action.rel}\n`);
+    } else if (action.status === "error") {
+      process.stderr.write(
+        `error: ${action.rel} — ${action.detail ?? "unknown"}\n`,
+      );
+    }
+  }
+
+  const mode = write ? "WRITE" : "DRY-RUN";
+  process.stderr.write(
+    `[${mode}] scanned ${shards.length}; compliant=${counts["skip-already-compliant"]} ` +
+      `would-prepend=${counts["would-prepend"]} prepended=${counts["prepended"]} ` +
+      `unparseable=${counts["skip-unparseable-name"]} empty=${counts["skip-empty"]} ` +
+      `errors=${counts["error"]}\n`,
+  );
+
+  return counts["error"] > 0 ? 1 : 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Summary

Implements [B-0529](docs/backlog/P2/B-0529-tick-shard-schema-validator-vs-practice-drift-2026-05-15.md) Option 3 ("hybrid") via a one-shot TS tool: `tools/hygiene/add-pipe-row-header.ts`.

The tick-shard validator at [`tools/hygiene/check-tick-history-shard-schema.ts`](tools/hygiene/check-tick-history-shard-schema.ts) requires a pipe-delimited first row matching the path/filename timestamp. Lived convention drifted to H1-first multi-section format. Full dry-run today: **946 shards scanned, 585 compliant, 359 would-prepend, 2 unparseable.**

This PR ships the **script only**. Bulk retrofit (359 file changes) is a separate slice per B-0529's scope discipline — the blast radius warrants its own review.

## Behavior

- Default: dry-run (lists `would-prepend` candidates + summary)
- `--write`: actually prepends pipe-row to non-compliant shards
- `--files <paths>`: restrict to specific files

Retrofit pipe-row uses honest placeholders for fields not reconstructable from path alone:

```text
| 2026-MM-DDTHH:MMZ | retrofit | unknown | retrofit (see body below) | none | none |
```

The H1-rich body below is preserved unchanged — that's where the substantive content lives.

## How it found the drift live

Surfaced this tick via Copilot review on the just-merged [PR #3983](https://github.com/Lucent-Financial-Group/Zeta/pull/3983) tick shard. Copilot flagged that the shard's H1 first line violates the validator. Investigation matched B-0529's existing analysis exactly. Per [`skill-router-as-substrate-inventory.md`](.claude/rules/skill-router-as-substrate-inventory.md): inventory-before-authoring discipline — B-0529 already exists, this PR fulfills its Recommendation rather than creating a duplicate row.

## Test plan

- [x] Dry-run on already-compliant shard (`2026/05/03/0039Z.md`) → skipped
- [x] Dry-run on non-compliant shard (`2026/05/16/2341Z.md`) → would-prepend
- [x] Full repo dry-run → 946 scanned, 585+359+2 = 946 categorized (no double-count)
- [ ] Unit tests for `parseShardPath` / `alreadyCompliant` / `buildHeader` — **deferred** (follow-up; the tool pattern in `tools/hygiene/` has many test files but not all hygiene scripts have one)
- [ ] CI lint / build passes (will surface on PR)
- [ ] **Bulk retrofit PR — separate slice** (not in this PR)

## Composes with

- [`docs/backlog/P2/B-0529-tick-shard-schema-validator-vs-practice-drift-2026-05-15.md`](docs/backlog/P2/B-0529-tick-shard-schema-validator-vs-practice-drift-2026-05-15.md)
- [`tools/hygiene/check-tick-history-shard-schema.ts`](tools/hygiene/check-tick-history-shard-schema.ts) (the validator)
- [`docs/hygiene-history/ticks/README.md`](docs/hygiene-history/ticks/README.md) (schema docs)
- [`.claude/rules/rule-0-no-sh-files.md`](.claude/rules/rule-0-no-sh-files.md) (TS not bash)
- [`.claude/rules/skill-router-as-substrate-inventory.md`](.claude/rules/skill-router-as-substrate-inventory.md) (inventory before authoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)