### PR TITLE
feat(tools/inventory): amazon-orders-extract.ts — human-driven personal-order extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,7 @@ tools/alloy/classes/
 
 # Shadow observer runtime log — machine-local, regenerated per boot.
 tools/shadow/shadow-observer.log
+
+# Personal data extracted by tools/inventory/amazon-orders-extract.ts — never appropriate for git commit by default
+amazon-orders-full.json
+amazon-orders-hardware-filtered.json

--- a/.gitignore
+++ b/.gitignore
@@ -189,5 +189,5 @@ tools/alloy/classes/
 tools/shadow/shadow-observer.log
 
 # Personal data extracted by tools/inventory/amazon-orders-extract.ts — never appropriate for git commit by default
-amazon-orders-full.json
-amazon-orders-hardware-filtered.json
+amazon-items-full.json
+amazon-items-hardware-filtered.json

--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,4 @@ tools/shadow/shadow-observer.log
 # Personal data extracted by tools/inventory/amazon-orders-extract.ts — never appropriate for git commit by default
 amazon-items-full.json
 amazon-items-hardware-filtered.json
+amazon-items-partial.json

--- a/tools/inventory/README.md
+++ b/tools/inventory/README.md
@@ -4,53 +4,68 @@ Reusable utilities for inventory + asset tracking.
 
 ## amazon-orders-extract.ts
 
-One-time extraction of personal Amazon order history into local JSON
-files. Run by a HUMAN-actor (not by an agent — agent-driven scraping of
-authenticated personal accounts is blocked by the safety classifier per
-the B-0582 destructive-verb-refusal-gate principle).
+Extraction of personal Amazon order history into local JSON files.
+**Run by a human-actor — not agent-invocable** (agent-driven scraping
+of authenticated personal accounts is blocked by the safety classifier
+per the B-0582 destructive-verb-refusal-gate principle).
 
-Outputs two local files in the current working directory:
+Outputs go to `~/.local/share/zeta-inventory/amazon/<year>/`:
 
-- `amazon-orders-full.json` — titles + prices + dates per order (give to
-  accountant or other purpose-specific destination; **not for git
-  commit**)
-- `amazon-orders-hardware-filtered.json` — hardware-keyword subset
+- `amazon-items-full.json` — title + URL + date + price per item
+  (personal financial data; never appropriate for git commit by default)
+- `amazon-items-hardware-filtered.json` — hardware-keyword subset
   (review then optionally commit to Zeta as B-0590 hardware inventory
   substrate, with PII stripped if desired)
+- `amazon-items-partial.json` — per-page checkpoint (v2.3+; written
+  after every page; lets a crashed run resume from where it died)
 
 ### Usage
 
 ```bash
-bun install playwright            # first time only
-bunx playwright install chromium  # first time only
-bun tools/inventory/amazon-orders-extract.ts            # extracts 2025 (default)
-bun tools/inventory/amazon-orders-extract.ts 2024       # extracts 2024
+bun tools/inventory/amazon-orders-extract.ts            # current year
+bun tools/inventory/amazon-orders-extract.ts 2025       # specific year
+bun tools/inventory/amazon-orders-extract.ts 2025 --restart   # ignore partial
 ```
 
-The script launches Playwright in HEADED mode. Complete sign-in in the
-opened browser window when prompted; auto-extraction proceeds after.
+First run auto-installs `playwright` + the chromium binary.
+
+The script launches Playwright in headed mode and pauses for a
+press-Enter confirmation after the orders page loads. Complete sign-in
+in the opened browser window if prompted; press Enter in the terminal
+when ready; extraction then walks each pagination page.
+
+### Resume from partial
+
+If a page-22 crash leaves `amazon-items-partial.json` with pages 1-21
+recorded, the next run reads that file, skips the completed pages, and
+resumes at page 22. Pass `--restart` to ignore the partial and start
+fresh.
 
 ### Output files are gitignored
 
-`amazon-orders-full.json` and `amazon-orders-hardware-filtered.json` are
-listed in the repo's `.gitignore`. They contain personal financial data
-+ adjacent-party purchase info; never appropriate for git commit by
-default. The hardware-only subset MAY be committed after manual review
-strips PII (dates / prices / order IDs / household-orbit items).
+`amazon-items-full.json`, `amazon-items-hardware-filtered.json`, and
+`amazon-items-partial.json` are listed in the repo's `.gitignore`. They
+contain personal financial data + adjacent-party purchase info; never
+appropriate for git commit by default. The hardware-only subset MAY be
+committed after manual review strips PII (dates / prices / order IDs /
+household-orbit items).
 
 ### Reusable for other accounts
 
 The script is generic — anyone can run it on their own Amazon account.
-No hardcoded credentials, no Aaron-specific paths. Future extension
-(per Aaron's 2026-05-16 framing): multi-account / multi-vendor
-consolidation for assets the operator is authorized to query.
+No hardcoded credentials, no operator-specific paths. Future extension
+(per the human maintainer's 2026-05-16 framing): multi-account /
+multi-vendor consolidation for assets the operator is authorized to
+query.
 
 ### Composes with
 
-- [B-0582](docs/backlog/) — destructive-verb refusal gate; agent-driven
-  scraping of authenticated personal accounts is appropriately refused
-  at the classifier layer; human-driven script is the legitimate path
-- B-0590 — fleet replication + hardware inventory substrate; this
-  script's hardware-filtered output feeds that row's inventory section
-- Future B-NNNN — multi-account consolidation (Aaron 2026-05-16
-  "killer feature" framing)
+- [B-0582](../../docs/backlog/P1/B-0582-destructive-verb-refusal-gate-substrate-level-2026-05-16.md)
+  — destructive-verb refusal gate; agent-driven scraping of authenticated
+  personal accounts is appropriately refused at the classifier layer;
+  human-driven script is the legitimate path
+- [B-0590](../../docs/backlog/P2/B-0590-fleet-replication-20-machines-bare-metal-os-install-kvm-mini-pcs-2026-05-16.md)
+  — fleet replication + hardware inventory substrate; this script's
+  hardware-filtered output feeds that row's inventory section
+- Future B-NNNN — multi-account consolidation (the human maintainer's
+  2026-05-16 "killer feature" framing)

--- a/tools/inventory/README.md
+++ b/tools/inventory/README.md
@@ -1,0 +1,56 @@
+# tools/inventory/
+
+Reusable utilities for inventory + asset tracking.
+
+## amazon-orders-extract.ts
+
+One-time extraction of personal Amazon order history into local JSON
+files. Run by a HUMAN-actor (not by an agent — agent-driven scraping of
+authenticated personal accounts is blocked by the safety classifier per
+the B-0582 destructive-verb-refusal-gate principle).
+
+Outputs two local files in the current working directory:
+
+- `amazon-orders-full.json` — titles + prices + dates per order (give to
+  accountant or other purpose-specific destination; **not for git
+  commit**)
+- `amazon-orders-hardware-filtered.json` — hardware-keyword subset
+  (review then optionally commit to Zeta as B-0590 hardware inventory
+  substrate, with PII stripped if desired)
+
+### Usage
+
+```bash
+bun install playwright            # first time only
+bunx playwright install chromium  # first time only
+bun tools/inventory/amazon-orders-extract.ts            # extracts 2025 (default)
+bun tools/inventory/amazon-orders-extract.ts 2024       # extracts 2024
+```
+
+The script launches Playwright in HEADED mode. Complete sign-in in the
+opened browser window when prompted; auto-extraction proceeds after.
+
+### Output files are gitignored
+
+`amazon-orders-full.json` and `amazon-orders-hardware-filtered.json` are
+listed in the repo's `.gitignore`. They contain personal financial data
++ adjacent-party purchase info; never appropriate for git commit by
+default. The hardware-only subset MAY be committed after manual review
+strips PII (dates / prices / order IDs / household-orbit items).
+
+### Reusable for other accounts
+
+The script is generic — anyone can run it on their own Amazon account.
+No hardcoded credentials, no Aaron-specific paths. Future extension
+(per Aaron's 2026-05-16 framing): multi-account / multi-vendor
+consolidation for assets the operator is authorized to query.
+
+### Composes with
+
+- [B-0582](docs/backlog/) — destructive-verb refusal gate; agent-driven
+  scraping of authenticated personal accounts is appropriately refused
+  at the classifier layer; human-driven script is the legitimate path
+- B-0590 — fleet replication + hardware inventory substrate; this
+  script's hardware-filtered output feeds that row's inventory section
+- Future B-NNNN — multi-account consolidation (Aaron 2026-05-16
+  "killer feature" framing)

--- a/tools/inventory/amazon-orders-extract.ts
+++ b/tools/inventory/amazon-orders-extract.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+/// <reference lib="dom" />
 /**
  * Personal Amazon order-history extractor (v2.3).
  *
@@ -166,8 +167,8 @@ async function main(): Promise<void> {
   try { chmodSync(SESSION_FILE, 0o600); } catch { /* permissions best-effort */ }
 
   const totalPages = await page.evaluate(() => {
-    const items = Array.from(document.querySelectorAll(".a-pagination li, ul.a-pagination li, [aria-label*='pagination'] li"));
-    const numbers = items.map((li) => li.textContent?.trim() ?? "").filter((t) => /^\d+$/.test(t));
+    const items = Array.from(document.querySelectorAll<Element>(".a-pagination li, ul.a-pagination li, [aria-label*='pagination'] li"));
+    const numbers = items.map((li: Element) => li.textContent?.trim() ?? "").filter((t: string) => /^\d+$/.test(t));
     return numbers.length > 0 ? Math.max(...numbers.map(Number)) : 1;
   });
   console.log(`Detected total pages: ${totalPages}`);

--- a/tools/inventory/amazon-orders-extract.ts
+++ b/tools/inventory/amazon-orders-extract.ts
@@ -69,13 +69,14 @@ interface Partial {
   items: Item[];
 }
 
-function ensureModule(name: string): boolean {
-  try { require.resolve(name); return true; } catch { return false; }
+async function ensureModule(name: string): Promise<boolean> {
+  try { await import(name); return true; } catch { return false; }
 }
 
-function installIfMissing(): void {
-  if (!ensureModule("playwright")) {
+async function installIfMissing(): Promise<void> {
+  if (!(await ensureModule("playwright"))) {
     console.log("Installing playwright (first-run setup)...");
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- first-run bootstrap: invoking the user's bun from $PATH is intentional + the script itself runs via `bun ...` so the same PATH governs invocation
     const r = spawnSync("bun", ["install", "playwright"], { stdio: "inherit" });
     if (r.status !== 0) { console.error("Failed. Run manually: bun install playwright"); process.exit(1); }
   }
@@ -90,6 +91,7 @@ async function ensureChromium(): Promise<void> {
     const msg = String(err);
     if (msg.includes("Executable doesn't exist") || msg.includes("Looks like Playwright Test or Playwright was just installed")) {
       console.log("Installing chromium binary (first-run setup)...");
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- first-run bootstrap: invoking bunx from $PATH is intentional + matches the parent bun invocation
       const r = spawnSync("bunx", ["playwright", "install", "chromium"], { stdio: "inherit" });
       if (r.status !== 0) { console.error("Failed. Run manually: bunx playwright install chromium"); process.exit(1); }
     } else { throw err; }
@@ -129,10 +131,14 @@ function loadPartial(): Partial {
 
 function writePartial(state: Partial): void {
   writeFileSync(PARTIAL_FILE, JSON.stringify(state, null, 2));
+  // Best-effort 0600 on partial — same rationale as session file: file
+  // contains real personal-purchase data + (in future) accounting-grade
+  // titles/dates/prices the maintainer is preserving for their accountant.
+  try { chmodSync(PARTIAL_FILE, 0o600); } catch { /* best-effort */ }
 }
 
 async function main(): Promise<void> {
-  installIfMissing();
+  await installIfMissing();
   await ensureChromium();
   mkdirSync(YEAR_DIR, { recursive: true });
 
@@ -238,6 +244,7 @@ async function main(): Promise<void> {
     FULL_OUT,
     JSON.stringify({ year: YEAR, totalPages, itemCount: state.items.length, items: state.items }, null, 2),
   );
+  try { chmodSync(FULL_OUT, 0o600); } catch { /* best-effort — personal financial data */ }
   console.log(`\nWrote ${FULL_OUT} — ${state.items.length} items`);
 
   const hardwareItems = state.items.filter((i) => HARDWARE_KEYWORDS.test(i.title));
@@ -245,6 +252,7 @@ async function main(): Promise<void> {
     HARDWARE_OUT,
     JSON.stringify({ year: YEAR, itemCount: hardwareItems.length, items: hardwareItems }, null, 2),
   );
+  try { chmodSync(HARDWARE_OUT, 0o600); } catch { /* best-effort — personal financial data */ }
   console.log(`Wrote ${HARDWARE_OUT} — ${hardwareItems.length} hardware-matching items`);
 
   // Browser-context cleanup AFTER, each in its own try-with-timeout so a

--- a/tools/inventory/amazon-orders-extract.ts
+++ b/tools/inventory/amazon-orders-extract.ts
@@ -1,33 +1,38 @@
 #!/usr/bin/env bun
 /**
- * Personal Amazon order-history extractor (v2.2).
+ * Personal Amazon order-history extractor (v2.3).
  *
  * RUN BY HUMAN, NOT BY OTTO. Per B-0582 destructive-verb-refusal-gate.
  *
- * v2.2 changes vs v2.1:
- *   - Container-agnostic extraction: instead of finding `.order-card`
- *     containers (Amazon's selectors change; v1+v2 found 0 orders for
- *     Aaron 2026-05-16), find every `/dp/` link directly + walk up the
- *     DOM tree to find an ancestor containing a date/price pattern.
- *     Robust against selector drift.
- *   - Per-item records (instead of per-order grouping) — each item is
- *     one row with title + nearest date + nearest price ancestor data.
+ * v2.3 changes vs v2.2:
+ *   - **Per-page incremental writes** — after every page extraction,
+ *     the in-progress accumulator is written to disk. A crash mid-run
+ *     no longer loses all data; the partial file has everything up
+ *     through the last completed page. (Aaron 2026-05-16: browser
+ *     crashed on page 22 of 23, losing all 22 pages of in-memory data
+ *     with v2.2.)
+ *   - Resume-from-partial: if a partial file exists for the year, the
+ *     script reads it on startup, skips pages already completed, and
+ *     resumes from the next un-extracted page. Pass --restart to
+ *     ignore existing partial and start fresh.
  *
- * v2.1 features retained:
+ * v2.x features retained:
  *   - Auto-installs playwright + chromium on first run
  *   - Session persistence — subsequent runs skip login
  *   - Output: ~/.local/share/zeta-inventory/amazon/<year>/
  *   - Default year = current year
- *   - Press-Enter pause after browser opens (keeps browser open until
- *     user confirms — sidesteps any wait-for-selector timing issue)
- *   - Verbose error logging
+ *   - Press-Enter pause after browser opens (keeps it open until user
+ *     confirms — sidesteps wait-for-selector timing issues)
+ *   - Container-agnostic extraction (finds /dp/ links, walks ancestors
+ *     for date + price)
  *
  * Usage:
  *     bun /tmp/amazon-orders-extract.ts          # current year
- *     bun /tmp/amazon-orders-extract.ts 2024     # specific year
+ *     bun /tmp/amazon-orders-extract.ts 2025     # specific year
+ *     bun /tmp/amazon-orders-extract.ts 2025 --restart   # ignore partial
  */
 
-import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
@@ -35,11 +40,14 @@ import { homedir } from "node:os";
 const HARDWARE_KEYWORDS =
   /\b(Beelink|Minisforum|GMKtec|ASUS\s+NUC|Intel\s+NUC|Framework|Mini.?PC|GPU|Graphics\s+Card|NVIDIA|GeForce|Radeon|Ryzen|Intel\s+Core|Core\s+Ultra|NPU|AI\s+CPU|OCuLink|Thunderbolt|PCIe|DDR\d|RAM\s+\d|SSD|NVMe|M\.2|HDD|switch|router|ethernet|network|KVM|PiKVM|JetKVM|Tinypilot|Comet\s+Pro|Lantronix|monitor|display|UPS|rack|server|NAS|workstation|motherboard|CPU|processor|cooler|fan|PSU|power\s+supply|case|chassis|cable|adapter|hub|dock|usb)\b/i;
 
-const YEAR = process.argv[2] ?? new Date().getFullYear().toString();
+const args = process.argv.slice(2);
+const RESTART = args.includes("--restart");
+const YEAR = args.find((a) => /^\d{4}$/.test(a)) ?? new Date().getFullYear().toString();
 const BASE_URL = `https://www.amazon.com/your-orders/orders?timeFilter=year-${YEAR}`;
 const DATA_ROOT = join(homedir(), ".local/share/zeta-inventory/amazon");
 const SESSION_FILE = join(DATA_ROOT, "playwright-session.json");
 const YEAR_DIR = join(DATA_ROOT, YEAR);
+const PARTIAL_FILE = join(YEAR_DIR, "amazon-items-partial.json");
 const FULL_OUT = join(YEAR_DIR, "amazon-items-full.json");
 const HARDWARE_OUT = join(YEAR_DIR, "amazon-items-hardware-filtered.json");
 
@@ -51,9 +59,11 @@ interface Item {
   nearbyPrice: string | null;
 }
 
-// ────────────────────────────────────────────────────────────────────
-// First-run deps auto-install
-// ────────────────────────────────────────────────────────────────────
+interface Partial {
+  year: string;
+  completedPages: number[];
+  items: Item[];
+}
 
 function ensureModule(name: string): boolean {
   try { require.resolve(name); return true; } catch { return false; }
@@ -82,10 +92,6 @@ async function ensureChromium(): Promise<void> {
   }
 }
 
-// ────────────────────────────────────────────────────────────────────
-// Press-Enter pause (browser stays open until user confirms)
-// ────────────────────────────────────────────────────────────────────
-
 async function pressEnterToContinue(prompt: string): Promise<void> {
   console.log("");
   console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
@@ -100,9 +106,26 @@ async function pressEnterToContinue(prompt: string): Promise<void> {
   process.stdin.pause();
 }
 
-// ────────────────────────────────────────────────────────────────────
-// Main
-// ────────────────────────────────────────────────────────────────────
+function loadPartial(): Partial {
+  if (RESTART || !existsSync(PARTIAL_FILE)) {
+    return { year: YEAR, completedPages: [], items: [] };
+  }
+  try {
+    const data = JSON.parse(readFileSync(PARTIAL_FILE, "utf-8")) as Partial;
+    if (data.year !== YEAR) {
+      console.log(`Partial file is for year ${data.year}, current year ${YEAR} — ignoring`);
+      return { year: YEAR, completedPages: [], items: [] };
+    }
+    console.log(`Resuming from partial: ${data.completedPages.length} pages already completed (${data.items.length} items so far)`);
+    return data;
+  } catch {
+    return { year: YEAR, completedPages: [], items: [] };
+  }
+}
+
+function writePartial(state: Partial): void {
+  writeFileSync(PARTIAL_FILE, JSON.stringify(state, null, 2));
+}
 
 async function main(): Promise<void> {
   installIfMissing();
@@ -110,8 +133,10 @@ async function main(): Promise<void> {
   mkdirSync(YEAR_DIR, { recursive: true });
 
   const { chromium } = await import("playwright");
-  console.log(`Extracting Amazon orders for year ${YEAR}...`);
+  console.log(`Extracting Amazon orders for year ${YEAR}${RESTART ? " (--restart)" : ""}...`);
   console.log(`Output directory: ${YEAR_DIR}`);
+
+  const state = loadPartial();
 
   const browser = await chromium.launch({ headless: false });
   const sessionOpts = existsSync(SESSION_FILE) ? { storageState: SESSION_FILE } : {};
@@ -127,36 +152,33 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Press-Enter pause — let user log in + verify orders are loaded.
   await pressEnterToContinue(
     `Amazon orders page is open in the browser.\n` +
       (existsSync(SESSION_FILE)
         ? "Session was reused. Verify you can see your orders, then press Enter."
-        : "If sign-in is required, complete it in the browser. Verify you can see your orders. Then press Enter."),
+        : "If sign-in is required, complete it. Verify you can see your orders. Then press Enter."),
   );
 
-  // Save session for next run (whether reused or fresh login)
   await ctx.storageState({ path: SESSION_FILE });
 
-  // Detect pagination — try multiple patterns
   const totalPages = await page.evaluate(() => {
-    const pagiItems = Array.from(document.querySelectorAll(".a-pagination li, ul.a-pagination li, [aria-label*='pagination'] li"));
-    const numbers = pagiItems.map((li) => li.textContent?.trim() ?? "").filter((t) => /^\d+$/.test(t));
+    const items = Array.from(document.querySelectorAll(".a-pagination li, ul.a-pagination li, [aria-label*='pagination'] li"));
+    const numbers = items.map((li) => li.textContent?.trim() ?? "").filter((t) => /^\d+$/.test(t));
     return numbers.length > 0 ? Math.max(...numbers.map(Number)) : 1;
   });
   console.log(`Detected total pages: ${totalPages}`);
-  if (totalPages === 1) {
-    console.log("Warning: only 1 page detected. If you expected more, pagination detection may have failed.");
-    console.log("Will still try to extract items from the current page.");
+  if (state.completedPages.length > 0) {
+    console.log(`Will skip pages already in partial: ${state.completedPages.join(",")}`);
   }
 
-  const allItems: Item[] = [];
   for (let p = 1; p <= totalPages; p++) {
-    if (p > 1) {
+    if (state.completedPages.includes(p)) continue;
+
+    if (p > 1 || state.completedPages.length > 0) {
       try {
         await page.goto(`${BASE_URL}&startIndex=${(p - 1) * 10}`);
         await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
-        await page.waitForTimeout(1500); // give JS render extra time
+        await page.waitForTimeout(1500);
       } catch (err) {
         console.warn(`Page ${p} navigation failed: ${String(err).split('\n')[0]} — skipping`);
         continue;
@@ -165,7 +187,7 @@ async function main(): Promise<void> {
     let items: Item[] = [];
     try {
       items = await page.evaluate(({ pageNumber }: { pageNumber: number }) => {
-        const HARDCODED_FALSE_POSITIVE_PREFIXES = /^(Buy it again|Track package|Order details|View invoice|Return|Replace|Write a|Get product support|Archive order|Hide order|Share gift receipt|Leave seller feedback|Track shipment|View your item|Manage|Order summary)/i;
+        const HARDCODED = /^(Buy it again|Track package|Order details|View invoice|Return|Replace|Write a|Get product support|Archive order|Hide order|Share gift receipt|Leave seller feedback|Track shipment|View your item|Manage|Order summary)/i;
         const allLinks = Array.from(document.querySelectorAll("a[href*='/dp/'], a[href*='/gp/product/']"));
         const seen = new Set<string>();
         const result: Item[] = [];
@@ -174,25 +196,17 @@ async function main(): Promise<void> {
           const title = (link.textContent ?? "").trim();
           const href = link.href ?? "";
           if (title.length < 5 || title.length > 300) return;
-          if (HARDCODED_FALSE_POSITIVE_PREFIXES.test(title)) return;
-          // Dedupe by URL — same product link appears multiple times per order card
+          if (HARDCODED.test(title)) return;
           const dedup = href.split("?")[0];
           if (seen.has(dedup)) return;
           seen.add(dedup);
-          // Walk up ancestors looking for date + price patterns
           let date: string | null = null;
           let price: string | null = null;
           let cur: HTMLElement | null = link.parentElement;
           for (let depth = 0; depth < 10 && cur && (!date || !price); depth++, cur = cur.parentElement) {
             const text = cur.textContent ?? "";
-            if (!date) {
-              const m = text.match(/(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2},?\s+\d{4}/);
-              if (m) date = m[0];
-            }
-            if (!price) {
-              const m = text.match(/\$[\d,]+\.\d{2}/);
-              if (m) price = m[0];
-            }
+            if (!date) { const m = text.match(/(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2},?\s+\d{4}/); if (m) date = m[0]; }
+            if (!price) { const m = text.match(/\$[\d,]+\.\d{2}/); if (m) price = m[0]; }
           }
           result.push({ page: pageNumber, title, url: dedup, date, nearbyPrice: price });
         });
@@ -203,18 +217,21 @@ async function main(): Promise<void> {
       continue;
     }
     console.log(`Page ${p}: ${items.length} unique items`);
-    allItems.push(...items);
+    state.items.push(...items);
+    state.completedPages.push(p);
+    // CHECKPOINT — write partial after every page so a crash preserves progress
+    writePartial(state);
   }
 
   await ctx.storageState({ path: SESSION_FILE });
 
   writeFileSync(
     FULL_OUT,
-    JSON.stringify({ year: YEAR, totalPages, itemCount: allItems.length, items: allItems }, null, 2),
+    JSON.stringify({ year: YEAR, totalPages, itemCount: state.items.length, items: state.items }, null, 2),
   );
-  console.log(`\nWrote ${FULL_OUT} — ${allItems.length} items`);
+  console.log(`\nWrote ${FULL_OUT} — ${state.items.length} items`);
 
-  const hardwareItems = allItems.filter((i) => HARDWARE_KEYWORDS.test(i.title));
+  const hardwareItems = state.items.filter((i) => HARDWARE_KEYWORDS.test(i.title));
   writeFileSync(
     HARDWARE_OUT,
     JSON.stringify({ year: YEAR, itemCount: hardwareItems.length, items: hardwareItems }, null, 2),

--- a/tools/inventory/amazon-orders-extract.ts
+++ b/tools/inventory/amazon-orders-extract.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env bun
+/**
+ * Personal Amazon order-history extractor.
+ *
+ * RUN BY AARON (human-actor), NOT BY OTTO.
+ * Otto cannot scrape your authenticated Amazon session per the classifier
+ * (B-0582 destructive-verb gate working as designed). You running this
+ * script bypasses the agent-as-scraper concern entirely — it's your code,
+ * your auth, your data, your file.
+ *
+ * Uses Playwright in HEADED mode so you log in once interactively in the
+ * opened browser window; the script then auto-paginates through all
+ * orders for the specified year.
+ *
+ * Output (both in current working directory):
+ *   amazon-orders-full.json
+ *     — titles + prices + dates per order (full data for your accountant)
+ *   amazon-orders-hardware-filtered.json
+ *     — hardware-keyword subset (review then optionally commit to Zeta as
+ *       B-0590 hardware inventory substrate)
+ *
+ * Neither file is for git commit by default. If you put this script in
+ * tools/personal/ in Zeta, add these to .gitignore:
+ *     amazon-orders-full.json
+ *     amazon-orders-hardware-filtered.json
+ *
+ * Usage:
+ *     bun install playwright            # first time only
+ *     bunx playwright install chromium  # first time only
+ *     bun /tmp/amazon-orders-extract.ts          # extracts 2025 (default)
+ *     bun /tmp/amazon-orders-extract.ts 2024     # extracts 2024
+ */
+
+import { chromium, type Page } from "playwright";
+import { writeFileSync } from "node:fs";
+
+const HARDWARE_KEYWORDS =
+  /\b(Beelink|Minisforum|GMKtec|ASUS\s+NUC|Intel\s+NUC|Framework|Mini.?PC|GPU|Graphics\s+Card|NVIDIA|GeForce|Radeon|Ryzen|Intel\s+Core|Core\s+Ultra|NPU|AI\s+CPU|OCuLink|Thunderbolt|PCIe|DDR\d|RAM\s+\d|SSD|NVMe|M\.2|HDD|switch|router|ethernet|network|KVM|PiKVM|JetKVM|Tinypilot|Comet\s+Pro|Lantronix|monitor|display|UPS|rack|server|NAS|workstation|motherboard|CPU|processor|cooler|fan|PSU|power\s+supply|case|chassis|cable|adapter|hub|dock|usb)\b/i;
+
+const YEAR = process.argv[2] ?? "2025";
+const BASE_URL = `https://www.amazon.com/your-orders/orders?timeFilter=year-${YEAR}`;
+const ORDER_SELECTOR =
+  ".order-card, .js-order-card, [data-component='OrderCard']";
+
+interface Order {
+  page: number;
+  date: string | null;
+  orderTotal: string | null;
+  items: string[];
+}
+
+async function extractCurrentPage(page: Page, pageNumber: number): Promise<Order[]> {
+  return await page.evaluate(
+    ({ pageNumber, orderSelector }) => {
+      const cards = document.querySelectorAll(orderSelector);
+      const orders: Order[] = [];
+      cards.forEach((card) => {
+        const text = card.textContent ?? "";
+        const dateMatch = text.match(
+          /(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2},?\s+\d{4}/,
+        );
+        const totalMatch = text.match(/\$[\d,]+\.\d{2}/);
+        const itemLinks = card.querySelectorAll(
+          "a[href*='/dp/'], a[href*='/gp/product/']",
+        );
+        const items: string[] = [];
+        itemLinks.forEach((a) => {
+          const t = (a.textContent ?? "").trim();
+          if (
+            t.length > 5 &&
+            t.length < 300 &&
+            !t.match(
+              /^(Buy it again|Track package|Order details|View invoice|Return|Replace|Write a|Get product support|Archive order)/i,
+            )
+          ) {
+            items.push(t);
+          }
+        });
+        if (items.length > 0) {
+          orders.push({
+            page: pageNumber,
+            date: dateMatch ? dateMatch[0] : null,
+            orderTotal: totalMatch ? totalMatch[0] : null,
+            items: [...new Set(items)],
+          });
+        }
+      });
+      return orders;
+    },
+    { pageNumber, orderSelector: ORDER_SELECTOR },
+  );
+}
+
+async function main(): Promise<void> {
+  console.log(`Extracting Amazon orders for year ${YEAR}...`);
+  console.log("Launching Playwright (headed). Browser window will open.");
+
+  const browser = await chromium.launch({ headless: false });
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+
+  await page.goto(BASE_URL);
+  console.log("If sign-in is required, complete it in the opened window.");
+  console.log("Waiting up to 5 minutes for orders page to render...");
+
+  await page.waitForSelector(ORDER_SELECTOR, { timeout: 5 * 60 * 1000 });
+  console.log("Orders page rendered. Extracting...");
+
+  // Detect total pages from pagination
+  const totalPages = await page.evaluate(() => {
+    const items = Array.from(document.querySelectorAll(".a-pagination li"));
+    const numericLabels = items
+      .map((li) => li.textContent?.trim() ?? "")
+      .filter((t) => /^\d+$/.test(t));
+    return numericLabels.length > 0
+      ? Math.max(...numericLabels.map(Number))
+      : 1;
+  });
+  console.log(`Detected total pages: ${totalPages}`);
+
+  const allOrders: Order[] = [];
+  for (let p = 1; p <= totalPages; p++) {
+    if (p > 1) {
+      const startIndex = (p - 1) * 10;
+      await page.goto(`${BASE_URL}&startIndex=${startIndex}`);
+      try {
+        await page.waitForSelector(ORDER_SELECTOR, { timeout: 30_000 });
+      } catch {
+        console.warn(`Page ${p}: no orders rendered within 30s, skipping`);
+        continue;
+      }
+      await page.waitForTimeout(800); // small politeness delay
+    }
+    const orders = await extractCurrentPage(page, p);
+    console.log(`Page ${p}: ${orders.length} orders`);
+    allOrders.push(...orders);
+  }
+
+  // Full file (for accountant)
+  writeFileSync(
+    "amazon-orders-full.json",
+    JSON.stringify(
+      { year: YEAR, totalPages, orderCount: allOrders.length, orders: allOrders },
+      null,
+      2,
+    ),
+  );
+  console.log(
+    `\nWrote amazon-orders-full.json — ${allOrders.length} orders (give to accountant)`,
+  );
+
+  // Hardware-filtered subset (for Zeta substrate review)
+  const hardwareOrders = allOrders
+    .map((o) => ({ ...o, items: o.items.filter((i) => HARDWARE_KEYWORDS.test(i)) }))
+    .filter((o) => o.items.length > 0);
+  writeFileSync(
+    "amazon-orders-hardware-filtered.json",
+    JSON.stringify(
+      { year: YEAR, orderCount: hardwareOrders.length, orders: hardwareOrders },
+      null,
+      2,
+    ),
+  );
+  console.log(
+    `Wrote amazon-orders-hardware-filtered.json — ${hardwareOrders.length} orders matching hardware keywords (review before committing)`,
+  );
+
+  await browser.close();
+  console.log("\nDone. Review the hardware-filtered file before any git commit.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/inventory/amazon-orders-extract.ts
+++ b/tools/inventory/amazon-orders-extract.ts
@@ -227,9 +227,12 @@ async function main(): Promise<void> {
     writePartial(state);
   }
 
-  await ctx.storageState({ path: SESSION_FILE });
-  try { chmodSync(SESSION_FILE, 0o600); } catch { /* permissions best-effort */ }
-
+  // FS-only cleanup FIRST — these don't depend on the browser context, so
+  // they always succeed regardless of post-navigation-timeout chromium state.
+  // v2.3 had a freeze where storageState() / browser.close() hung after a
+  // page-23 navigation timeout, preventing FULL_OUT + HARDWARE_OUT writes.
+  // Move FS writes ahead of context operations so the user always has files
+  // on disk even when the browser is degraded.
   writeFileSync(
     FULL_OUT,
     JSON.stringify({ year: YEAR, totalPages, itemCount: state.items.length, items: state.items }, null, 2),
@@ -243,8 +246,26 @@ async function main(): Promise<void> {
   );
   console.log(`Wrote ${HARDWARE_OUT} — ${hardwareItems.length} hardware-matching items`);
 
-  await browser.close();
+  // Browser-context cleanup AFTER, each in its own try-with-timeout so a
+  // hung context can't prevent the next step or the script from exiting.
+  await withTimeout("session-save", 5000, async () => {
+    await ctx.storageState({ path: SESSION_FILE });
+    try { chmodSync(SESSION_FILE, 0o600); } catch { /* best-effort */ }
+  });
+  await withTimeout("browser-close", 5000, () => browser.close());
+
   console.log("\nDone. Review the hardware-filtered file before any git commit.");
+}
+
+async function withTimeout(label: string, ms: number, fn: () => Promise<unknown>): Promise<void> {
+  try {
+    await Promise.race([
+      fn(),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), ms)),
+    ]);
+  } catch (err) {
+    console.warn(`Cleanup step "${label}" failed/timed out (${String(err).split('\n')[0]}) — continuing`);
+  }
 }
 
 main().catch((err) => {

--- a/tools/inventory/amazon-orders-extract.ts
+++ b/tools/inventory/amazon-orders-extract.ts
@@ -1,32 +1,30 @@
 #!/usr/bin/env bun
 /**
- * Personal Amazon order-history extractor (v2 — less friction).
+ * Personal Amazon order-history extractor (v2.2).
  *
- * RUN BY A HUMAN-actor, NOT BY OTTO.
- * Otto can't scrape your authenticated Amazon session per the safety
- * classifier (B-0582 destructive-verb gate working as designed). You
- * running this script is the legitimate path — your code, your auth,
- * your data, your file.
+ * RUN BY HUMAN, NOT BY OTTO. Per B-0582 destructive-verb-refusal-gate.
  *
- * What's new in v2 (vs v1):
- *   - Auto-installs missing playwright + chromium on first run (no manual prereqs)
- *   - Session persistence — after first login, subsequent runs reuse the
- *     cookies and skip the login step entirely
- *   - Predictable output location: ~/.local/share/zeta-inventory/amazon/<year>/
- *     (no need to remember where you ran from)
- *   - Default year = current year (no arg needed for the common case)
+ * v2.2 changes vs v2.1:
+ *   - Container-agnostic extraction: instead of finding `.order-card`
+ *     containers (Amazon's selectors change; v1+v2 found 0 orders for
+ *     Aaron 2026-05-16), find every `/dp/` link directly + walk up the
+ *     DOM tree to find an ancestor containing a date/price pattern.
+ *     Robust against selector drift.
+ *   - Per-item records (instead of per-order grouping) — each item is
+ *     one row with title + nearest date + nearest price ancestor data.
  *
- * Outputs (in ~/.local/share/zeta-inventory/amazon/<year>/):
- *   amazon-orders-full.json
- *     — titles + prices + dates per order (for accountant; never to git)
- *   amazon-orders-hardware-filtered.json
- *     — hardware-keyword subset (review then optionally commit to B-0590)
+ * v2.1 features retained:
+ *   - Auto-installs playwright + chromium on first run
+ *   - Session persistence — subsequent runs skip login
+ *   - Output: ~/.local/share/zeta-inventory/amazon/<year>/
+ *   - Default year = current year
+ *   - Press-Enter pause after browser opens (keeps browser open until
+ *     user confirms — sidesteps any wait-for-selector timing issue)
+ *   - Verbose error logging
  *
- * Usage (after first run that auto-installs):
- *     bun tools/inventory/amazon-orders-extract.ts          # current year
- *     bun tools/inventory/amazon-orders-extract.ts 2024     # specific year
- *
- * The browser opens headed. First run: log in. Subsequent runs: skip login.
+ * Usage:
+ *     bun /tmp/amazon-orders-extract.ts          # current year
+ *     bun /tmp/amazon-orders-extract.ts 2024     # specific year
  */
 
 import { mkdirSync, writeFileSync, existsSync } from "node:fs";
@@ -39,18 +37,18 @@ const HARDWARE_KEYWORDS =
 
 const YEAR = process.argv[2] ?? new Date().getFullYear().toString();
 const BASE_URL = `https://www.amazon.com/your-orders/orders?timeFilter=year-${YEAR}`;
-const ORDER_SELECTOR = ".order-card, .js-order-card, [data-component='OrderCard']";
 const DATA_ROOT = join(homedir(), ".local/share/zeta-inventory/amazon");
 const SESSION_FILE = join(DATA_ROOT, "playwright-session.json");
 const YEAR_DIR = join(DATA_ROOT, YEAR);
-const FULL_OUT = join(YEAR_DIR, "amazon-orders-full.json");
-const HARDWARE_OUT = join(YEAR_DIR, "amazon-orders-hardware-filtered.json");
+const FULL_OUT = join(YEAR_DIR, "amazon-items-full.json");
+const HARDWARE_OUT = join(YEAR_DIR, "amazon-items-hardware-filtered.json");
 
-interface Order {
+interface Item {
   page: number;
+  title: string;
+  url: string;
   date: string | null;
-  orderTotal: string | null;
-  items: string[];
+  nearbyPrice: string | null;
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -58,48 +56,52 @@ interface Order {
 // ────────────────────────────────────────────────────────────────────
 
 function ensureModule(name: string): boolean {
-  try {
-    require.resolve(name);
-    return true;
-  } catch {
-    return false;
-  }
+  try { require.resolve(name); return true; } catch { return false; }
 }
 
 function installIfMissing(): void {
   if (!ensureModule("playwright")) {
     console.log("Installing playwright (first-run setup)...");
     const r = spawnSync("bun", ["install", "playwright"], { stdio: "inherit" });
-    if (r.status !== 0) {
-      console.error("Failed to install playwright. Run manually: bun install playwright");
-      process.exit(1);
-    }
+    if (r.status !== 0) { console.error("Failed. Run manually: bun install playwright"); process.exit(1); }
   }
 }
 
 async function ensureChromium(): Promise<void> {
-  // Lazy-import after install
   const { chromium } = await import("playwright");
   try {
-    const browser = await chromium.launch({ headless: true });
-    await browser.close();
+    const b = await chromium.launch({ headless: true });
+    await b.close();
   } catch (err) {
     const msg = String(err);
     if (msg.includes("Executable doesn't exist") || msg.includes("Looks like Playwright Test or Playwright was just installed")) {
       console.log("Installing chromium binary (first-run setup)...");
       const r = spawnSync("bunx", ["playwright", "install", "chromium"], { stdio: "inherit" });
-      if (r.status !== 0) {
-        console.error("Failed to install chromium. Run manually: bunx playwright install chromium");
-        process.exit(1);
-      }
-    } else {
-      throw err;
-    }
+      if (r.status !== 0) { console.error("Failed. Run manually: bunx playwright install chromium"); process.exit(1); }
+    } else { throw err; }
   }
 }
 
 // ────────────────────────────────────────────────────────────────────
-// Extraction
+// Press-Enter pause (browser stays open until user confirms)
+// ────────────────────────────────────────────────────────────────────
+
+async function pressEnterToContinue(prompt: string): Promise<void> {
+  console.log("");
+  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log(prompt);
+  console.log("Press ENTER in this terminal when you're ready to continue.");
+  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log("");
+  await new Promise<void>((resolve) => {
+    process.stdin.once("data", () => resolve());
+    process.stdin.resume();
+  });
+  process.stdin.pause();
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Main
 // ────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
@@ -116,105 +118,114 @@ async function main(): Promise<void> {
   const ctx = await browser.newContext(sessionOpts);
   const page = await ctx.newPage();
 
-  await page.goto(BASE_URL);
-
-  // Detect if login is required (sign-in URL contains /ap/signin)
-  if (page.url().includes("/ap/signin")) {
-    console.log("Sign-in required. Complete login in the opened browser window.");
-    console.log("Subsequent runs will skip this step (session is saved).");
-    console.log("Waiting up to 5 minutes for sign-in to complete...");
-    await page.waitForSelector(ORDER_SELECTOR, { timeout: 5 * 60 * 1000 });
-    // Save session so future runs skip login
-    await ctx.storageState({ path: SESSION_FILE });
-    console.log(`Session saved to ${SESSION_FILE} — future runs will skip login.`);
-  } else {
-    console.log("Session reused — skipped sign-in.");
-    await page.waitForSelector(ORDER_SELECTOR, { timeout: 30_000 });
+  try {
+    await page.goto(BASE_URL);
+  } catch (err) {
+    console.error(`goto(${BASE_URL}) failed:`, err);
+    await pressEnterToContinue("Press Enter to close the browser and exit.");
+    await browser.close();
+    process.exit(1);
   }
 
+  // Press-Enter pause — let user log in + verify orders are loaded.
+  await pressEnterToContinue(
+    `Amazon orders page is open in the browser.\n` +
+      (existsSync(SESSION_FILE)
+        ? "Session was reused. Verify you can see your orders, then press Enter."
+        : "If sign-in is required, complete it in the browser. Verify you can see your orders. Then press Enter."),
+  );
+
+  // Save session for next run (whether reused or fresh login)
+  await ctx.storageState({ path: SESSION_FILE });
+
+  // Detect pagination — try multiple patterns
   const totalPages = await page.evaluate(() => {
-    const items = Array.from(document.querySelectorAll(".a-pagination li"));
-    const numericLabels = items
-      .map((li) => li.textContent?.trim() ?? "")
-      .filter((t) => /^\d+$/.test(t));
-    return numericLabels.length > 0
-      ? Math.max(...numericLabels.map(Number))
-      : 1;
+    const pagiItems = Array.from(document.querySelectorAll(".a-pagination li, ul.a-pagination li, [aria-label*='pagination'] li"));
+    const numbers = pagiItems.map((li) => li.textContent?.trim() ?? "").filter((t) => /^\d+$/.test(t));
+    return numbers.length > 0 ? Math.max(...numbers.map(Number)) : 1;
   });
   console.log(`Detected total pages: ${totalPages}`);
-
-  const allOrders: Order[] = [];
-  for (let p = 1; p <= totalPages; p++) {
-    if (p > 1) {
-      await page.goto(`${BASE_URL}&startIndex=${(p - 1) * 10}`);
-      try {
-        await page.waitForSelector(ORDER_SELECTOR, { timeout: 30_000 });
-      } catch {
-        console.warn(`Page ${p}: no orders rendered within 30s, skipping`);
-        continue;
-      }
-      await page.waitForTimeout(800);
-    }
-    const orders = await page.evaluate(
-      ({ pageNumber, orderSelector }: { pageNumber: number; orderSelector: string }) => {
-        const cards = document.querySelectorAll(orderSelector);
-        const result: Order[] = [];
-        cards.forEach((card) => {
-          const text = card.textContent ?? "";
-          const dateMatch = text.match(/(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2},?\s+\d{4}/);
-          const totalMatch = text.match(/\$[\d,]+\.\d{2}/);
-          const itemLinks = card.querySelectorAll("a[href*='/dp/'], a[href*='/gp/product/']");
-          const items: string[] = [];
-          itemLinks.forEach((a) => {
-            const t = (a.textContent ?? "").trim();
-            if (
-              t.length > 5 &&
-              t.length < 300 &&
-              !t.match(/^(Buy it again|Track package|Order details|View invoice|Return|Replace|Write a|Get product support|Archive order)/i)
-            ) {
-              items.push(t);
-            }
-          });
-          if (items.length > 0) {
-            result.push({
-              page: pageNumber,
-              date: dateMatch ? dateMatch[0] : null,
-              orderTotal: totalMatch ? totalMatch[0] : null,
-              items: [...new Set(items)],
-            });
-          }
-        });
-        return result;
-      },
-      { pageNumber: p, orderSelector: ORDER_SELECTOR },
-    );
-    console.log(`Page ${p}: ${orders.length} orders`);
-    allOrders.push(...orders);
+  if (totalPages === 1) {
+    console.log("Warning: only 1 page detected. If you expected more, pagination detection may have failed.");
+    console.log("Will still try to extract items from the current page.");
   }
 
-  // Refresh session state on every successful run (cookies rotate)
+  const allItems: Item[] = [];
+  for (let p = 1; p <= totalPages; p++) {
+    if (p > 1) {
+      try {
+        await page.goto(`${BASE_URL}&startIndex=${(p - 1) * 10}`);
+        await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+        await page.waitForTimeout(1500); // give JS render extra time
+      } catch (err) {
+        console.warn(`Page ${p} navigation failed: ${String(err).split('\n')[0]} — skipping`);
+        continue;
+      }
+    }
+    let items: Item[] = [];
+    try {
+      items = await page.evaluate(({ pageNumber }: { pageNumber: number }) => {
+        const HARDCODED_FALSE_POSITIVE_PREFIXES = /^(Buy it again|Track package|Order details|View invoice|Return|Replace|Write a|Get product support|Archive order|Hide order|Share gift receipt|Leave seller feedback|Track shipment|View your item|Manage|Order summary)/i;
+        const allLinks = Array.from(document.querySelectorAll("a[href*='/dp/'], a[href*='/gp/product/']"));
+        const seen = new Set<string>();
+        const result: Item[] = [];
+        allLinks.forEach((a) => {
+          const link = a as HTMLAnchorElement;
+          const title = (link.textContent ?? "").trim();
+          const href = link.href ?? "";
+          if (title.length < 5 || title.length > 300) return;
+          if (HARDCODED_FALSE_POSITIVE_PREFIXES.test(title)) return;
+          // Dedupe by URL — same product link appears multiple times per order card
+          const dedup = href.split("?")[0];
+          if (seen.has(dedup)) return;
+          seen.add(dedup);
+          // Walk up ancestors looking for date + price patterns
+          let date: string | null = null;
+          let price: string | null = null;
+          let cur: HTMLElement | null = link.parentElement;
+          for (let depth = 0; depth < 10 && cur && (!date || !price); depth++, cur = cur.parentElement) {
+            const text = cur.textContent ?? "";
+            if (!date) {
+              const m = text.match(/(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2},?\s+\d{4}/);
+              if (m) date = m[0];
+            }
+            if (!price) {
+              const m = text.match(/\$[\d,]+\.\d{2}/);
+              if (m) price = m[0];
+            }
+          }
+          result.push({ page: pageNumber, title, url: dedup, date, nearbyPrice: price });
+        });
+        return result;
+      }, { pageNumber: p });
+    } catch (err) {
+      console.warn(`Page ${p} extract failed: ${String(err).split('\n')[0]} — skipping`);
+      continue;
+    }
+    console.log(`Page ${p}: ${items.length} unique items`);
+    allItems.push(...items);
+  }
+
   await ctx.storageState({ path: SESSION_FILE });
 
   writeFileSync(
     FULL_OUT,
-    JSON.stringify({ year: YEAR, totalPages, orderCount: allOrders.length, orders: allOrders }, null, 2),
+    JSON.stringify({ year: YEAR, totalPages, itemCount: allItems.length, items: allItems }, null, 2),
   );
-  console.log(`\nWrote ${FULL_OUT} — ${allOrders.length} orders`);
+  console.log(`\nWrote ${FULL_OUT} — ${allItems.length} items`);
 
-  const hardwareOrders = allOrders
-    .map((o) => ({ ...o, items: o.items.filter((i) => HARDWARE_KEYWORDS.test(i)) }))
-    .filter((o) => o.items.length > 0);
+  const hardwareItems = allItems.filter((i) => HARDWARE_KEYWORDS.test(i.title));
   writeFileSync(
     HARDWARE_OUT,
-    JSON.stringify({ year: YEAR, orderCount: hardwareOrders.length, orders: hardwareOrders }, null, 2),
+    JSON.stringify({ year: YEAR, itemCount: hardwareItems.length, items: hardwareItems }, null, 2),
   );
-  console.log(`Wrote ${HARDWARE_OUT} — ${hardwareOrders.length} hardware-matching orders`);
+  console.log(`Wrote ${HARDWARE_OUT} — ${hardwareItems.length} hardware-matching items`);
 
   await browser.close();
   console.log("\nDone. Review the hardware-filtered file before any git commit.");
 }
 
 main().catch((err) => {
-  console.error(err);
+  console.error("\nUnexpected error:", err);
   process.exit(1);
 });

--- a/tools/inventory/amazon-orders-extract.ts
+++ b/tools/inventory/amazon-orders-extract.ts
@@ -1,46 +1,50 @@
 #!/usr/bin/env bun
 /**
- * Personal Amazon order-history extractor.
+ * Personal Amazon order-history extractor (v2 — less friction).
  *
- * RUN BY AARON (human-actor), NOT BY OTTO.
- * Otto cannot scrape your authenticated Amazon session per the classifier
- * (B-0582 destructive-verb gate working as designed). You running this
- * script bypasses the agent-as-scraper concern entirely — it's your code,
- * your auth, your data, your file.
+ * RUN BY A HUMAN-actor, NOT BY OTTO.
+ * Otto can't scrape your authenticated Amazon session per the safety
+ * classifier (B-0582 destructive-verb gate working as designed). You
+ * running this script is the legitimate path — your code, your auth,
+ * your data, your file.
  *
- * Uses Playwright in HEADED mode so you log in once interactively in the
- * opened browser window; the script then auto-paginates through all
- * orders for the specified year.
+ * What's new in v2 (vs v1):
+ *   - Auto-installs missing playwright + chromium on first run (no manual prereqs)
+ *   - Session persistence — after first login, subsequent runs reuse the
+ *     cookies and skip the login step entirely
+ *   - Predictable output location: ~/.local/share/zeta-inventory/amazon/<year>/
+ *     (no need to remember where you ran from)
+ *   - Default year = current year (no arg needed for the common case)
  *
- * Output (both in current working directory):
+ * Outputs (in ~/.local/share/zeta-inventory/amazon/<year>/):
  *   amazon-orders-full.json
- *     — titles + prices + dates per order (full data for your accountant)
+ *     — titles + prices + dates per order (for accountant; never to git)
  *   amazon-orders-hardware-filtered.json
- *     — hardware-keyword subset (review then optionally commit to Zeta as
- *       B-0590 hardware inventory substrate)
+ *     — hardware-keyword subset (review then optionally commit to B-0590)
  *
- * Neither file is for git commit by default. If you put this script in
- * tools/personal/ in Zeta, add these to .gitignore:
- *     amazon-orders-full.json
- *     amazon-orders-hardware-filtered.json
+ * Usage (after first run that auto-installs):
+ *     bun tools/inventory/amazon-orders-extract.ts          # current year
+ *     bun tools/inventory/amazon-orders-extract.ts 2024     # specific year
  *
- * Usage:
- *     bun install playwright            # first time only
- *     bunx playwright install chromium  # first time only
- *     bun /tmp/amazon-orders-extract.ts          # extracts 2025 (default)
- *     bun /tmp/amazon-orders-extract.ts 2024     # extracts 2024
+ * The browser opens headed. First run: log in. Subsequent runs: skip login.
  */
 
-import { chromium, type Page } from "playwright";
-import { writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
 
 const HARDWARE_KEYWORDS =
   /\b(Beelink|Minisforum|GMKtec|ASUS\s+NUC|Intel\s+NUC|Framework|Mini.?PC|GPU|Graphics\s+Card|NVIDIA|GeForce|Radeon|Ryzen|Intel\s+Core|Core\s+Ultra|NPU|AI\s+CPU|OCuLink|Thunderbolt|PCIe|DDR\d|RAM\s+\d|SSD|NVMe|M\.2|HDD|switch|router|ethernet|network|KVM|PiKVM|JetKVM|Tinypilot|Comet\s+Pro|Lantronix|monitor|display|UPS|rack|server|NAS|workstation|motherboard|CPU|processor|cooler|fan|PSU|power\s+supply|case|chassis|cable|adapter|hub|dock|usb)\b/i;
 
-const YEAR = process.argv[2] ?? "2025";
+const YEAR = process.argv[2] ?? new Date().getFullYear().toString();
 const BASE_URL = `https://www.amazon.com/your-orders/orders?timeFilter=year-${YEAR}`;
-const ORDER_SELECTOR =
-  ".order-card, .js-order-card, [data-component='OrderCard']";
+const ORDER_SELECTOR = ".order-card, .js-order-card, [data-component='OrderCard']";
+const DATA_ROOT = join(homedir(), ".local/share/zeta-inventory/amazon");
+const SESSION_FILE = join(DATA_ROOT, "playwright-session.json");
+const YEAR_DIR = join(DATA_ROOT, YEAR);
+const FULL_OUT = join(YEAR_DIR, "amazon-orders-full.json");
+const HARDWARE_OUT = join(YEAR_DIR, "amazon-orders-hardware-filtered.json");
 
 interface Order {
   page: number;
@@ -49,64 +53,85 @@ interface Order {
   items: string[];
 }
 
-async function extractCurrentPage(page: Page, pageNumber: number): Promise<Order[]> {
-  return await page.evaluate(
-    ({ pageNumber, orderSelector }) => {
-      const cards = document.querySelectorAll(orderSelector);
-      const orders: Order[] = [];
-      cards.forEach((card) => {
-        const text = card.textContent ?? "";
-        const dateMatch = text.match(
-          /(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2},?\s+\d{4}/,
-        );
-        const totalMatch = text.match(/\$[\d,]+\.\d{2}/);
-        const itemLinks = card.querySelectorAll(
-          "a[href*='/dp/'], a[href*='/gp/product/']",
-        );
-        const items: string[] = [];
-        itemLinks.forEach((a) => {
-          const t = (a.textContent ?? "").trim();
-          if (
-            t.length > 5 &&
-            t.length < 300 &&
-            !t.match(
-              /^(Buy it again|Track package|Order details|View invoice|Return|Replace|Write a|Get product support|Archive order)/i,
-            )
-          ) {
-            items.push(t);
-          }
-        });
-        if (items.length > 0) {
-          orders.push({
-            page: pageNumber,
-            date: dateMatch ? dateMatch[0] : null,
-            orderTotal: totalMatch ? totalMatch[0] : null,
-            items: [...new Set(items)],
-          });
-        }
-      });
-      return orders;
-    },
-    { pageNumber, orderSelector: ORDER_SELECTOR },
-  );
+// ────────────────────────────────────────────────────────────────────
+// First-run deps auto-install
+// ────────────────────────────────────────────────────────────────────
+
+function ensureModule(name: string): boolean {
+  try {
+    require.resolve(name);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
+function installIfMissing(): void {
+  if (!ensureModule("playwright")) {
+    console.log("Installing playwright (first-run setup)...");
+    const r = spawnSync("bun", ["install", "playwright"], { stdio: "inherit" });
+    if (r.status !== 0) {
+      console.error("Failed to install playwright. Run manually: bun install playwright");
+      process.exit(1);
+    }
+  }
+}
+
+async function ensureChromium(): Promise<void> {
+  // Lazy-import after install
+  const { chromium } = await import("playwright");
+  try {
+    const browser = await chromium.launch({ headless: true });
+    await browser.close();
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("Executable doesn't exist") || msg.includes("Looks like Playwright Test or Playwright was just installed")) {
+      console.log("Installing chromium binary (first-run setup)...");
+      const r = spawnSync("bunx", ["playwright", "install", "chromium"], { stdio: "inherit" });
+      if (r.status !== 0) {
+        console.error("Failed to install chromium. Run manually: bunx playwright install chromium");
+        process.exit(1);
+      }
+    } else {
+      throw err;
+    }
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Extraction
+// ────────────────────────────────────────────────────────────────────
+
 async function main(): Promise<void> {
+  installIfMissing();
+  await ensureChromium();
+  mkdirSync(YEAR_DIR, { recursive: true });
+
+  const { chromium } = await import("playwright");
   console.log(`Extracting Amazon orders for year ${YEAR}...`);
-  console.log("Launching Playwright (headed). Browser window will open.");
+  console.log(`Output directory: ${YEAR_DIR}`);
 
   const browser = await chromium.launch({ headless: false });
-  const ctx = await browser.newContext();
+  const sessionOpts = existsSync(SESSION_FILE) ? { storageState: SESSION_FILE } : {};
+  const ctx = await browser.newContext(sessionOpts);
   const page = await ctx.newPage();
 
   await page.goto(BASE_URL);
-  console.log("If sign-in is required, complete it in the opened window.");
-  console.log("Waiting up to 5 minutes for orders page to render...");
 
-  await page.waitForSelector(ORDER_SELECTOR, { timeout: 5 * 60 * 1000 });
-  console.log("Orders page rendered. Extracting...");
+  // Detect if login is required (sign-in URL contains /ap/signin)
+  if (page.url().includes("/ap/signin")) {
+    console.log("Sign-in required. Complete login in the opened browser window.");
+    console.log("Subsequent runs will skip this step (session is saved).");
+    console.log("Waiting up to 5 minutes for sign-in to complete...");
+    await page.waitForSelector(ORDER_SELECTOR, { timeout: 5 * 60 * 1000 });
+    // Save session so future runs skip login
+    await ctx.storageState({ path: SESSION_FILE });
+    console.log(`Session saved to ${SESSION_FILE} — future runs will skip login.`);
+  } else {
+    console.log("Session reused — skipped sign-in.");
+    await page.waitForSelector(ORDER_SELECTOR, { timeout: 30_000 });
+  }
 
-  // Detect total pages from pagination
   const totalPages = await page.evaluate(() => {
     const items = Array.from(document.querySelectorAll(".a-pagination li"));
     const numericLabels = items
@@ -121,49 +146,69 @@ async function main(): Promise<void> {
   const allOrders: Order[] = [];
   for (let p = 1; p <= totalPages; p++) {
     if (p > 1) {
-      const startIndex = (p - 1) * 10;
-      await page.goto(`${BASE_URL}&startIndex=${startIndex}`);
+      await page.goto(`${BASE_URL}&startIndex=${(p - 1) * 10}`);
       try {
         await page.waitForSelector(ORDER_SELECTOR, { timeout: 30_000 });
       } catch {
         console.warn(`Page ${p}: no orders rendered within 30s, skipping`);
         continue;
       }
-      await page.waitForTimeout(800); // small politeness delay
+      await page.waitForTimeout(800);
     }
-    const orders = await extractCurrentPage(page, p);
+    const orders = await page.evaluate(
+      ({ pageNumber, orderSelector }: { pageNumber: number; orderSelector: string }) => {
+        const cards = document.querySelectorAll(orderSelector);
+        const result: Order[] = [];
+        cards.forEach((card) => {
+          const text = card.textContent ?? "";
+          const dateMatch = text.match(/(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2},?\s+\d{4}/);
+          const totalMatch = text.match(/\$[\d,]+\.\d{2}/);
+          const itemLinks = card.querySelectorAll("a[href*='/dp/'], a[href*='/gp/product/']");
+          const items: string[] = [];
+          itemLinks.forEach((a) => {
+            const t = (a.textContent ?? "").trim();
+            if (
+              t.length > 5 &&
+              t.length < 300 &&
+              !t.match(/^(Buy it again|Track package|Order details|View invoice|Return|Replace|Write a|Get product support|Archive order)/i)
+            ) {
+              items.push(t);
+            }
+          });
+          if (items.length > 0) {
+            result.push({
+              page: pageNumber,
+              date: dateMatch ? dateMatch[0] : null,
+              orderTotal: totalMatch ? totalMatch[0] : null,
+              items: [...new Set(items)],
+            });
+          }
+        });
+        return result;
+      },
+      { pageNumber: p, orderSelector: ORDER_SELECTOR },
+    );
     console.log(`Page ${p}: ${orders.length} orders`);
     allOrders.push(...orders);
   }
 
-  // Full file (for accountant)
-  writeFileSync(
-    "amazon-orders-full.json",
-    JSON.stringify(
-      { year: YEAR, totalPages, orderCount: allOrders.length, orders: allOrders },
-      null,
-      2,
-    ),
-  );
-  console.log(
-    `\nWrote amazon-orders-full.json — ${allOrders.length} orders (give to accountant)`,
-  );
+  // Refresh session state on every successful run (cookies rotate)
+  await ctx.storageState({ path: SESSION_FILE });
 
-  // Hardware-filtered subset (for Zeta substrate review)
+  writeFileSync(
+    FULL_OUT,
+    JSON.stringify({ year: YEAR, totalPages, orderCount: allOrders.length, orders: allOrders }, null, 2),
+  );
+  console.log(`\nWrote ${FULL_OUT} — ${allOrders.length} orders`);
+
   const hardwareOrders = allOrders
     .map((o) => ({ ...o, items: o.items.filter((i) => HARDWARE_KEYWORDS.test(i)) }))
     .filter((o) => o.items.length > 0);
   writeFileSync(
-    "amazon-orders-hardware-filtered.json",
-    JSON.stringify(
-      { year: YEAR, orderCount: hardwareOrders.length, orders: hardwareOrders },
-      null,
-      2,
-    ),
+    HARDWARE_OUT,
+    JSON.stringify({ year: YEAR, orderCount: hardwareOrders.length, orders: hardwareOrders }, null, 2),
   );
-  console.log(
-    `Wrote amazon-orders-hardware-filtered.json — ${hardwareOrders.length} orders matching hardware keywords (review before committing)`,
-  );
+  console.log(`Wrote ${HARDWARE_OUT} — ${hardwareOrders.length} hardware-matching orders`);
 
   await browser.close();
   console.log("\nDone. Review the hardware-filtered file before any git commit.");

--- a/tools/inventory/amazon-orders-extract.ts
+++ b/tools/inventory/amazon-orders-extract.ts
@@ -2,15 +2,18 @@
 /**
  * Personal Amazon order-history extractor (v2.3).
  *
- * RUN BY HUMAN, NOT BY OTTO. Per B-0582 destructive-verb-refusal-gate.
+ * Human-driven only — not agent-invocable. Agent-driven scraping of
+ * authenticated personal accounts is refused at the safety-classifier
+ * layer per B-0582 (destructive-verb-refusal-gate). The legitimate
+ * path is the operator running this script in their own session.
  *
  * v2.3 changes vs v2.2:
  *   - **Per-page incremental writes** — after every page extraction,
  *     the in-progress accumulator is written to disk. A crash mid-run
  *     no longer loses all data; the partial file has everything up
- *     through the last completed page. (Aaron 2026-05-16: browser
- *     crashed on page 22 of 23, losing all 22 pages of in-memory data
- *     with v2.2.)
+ *     through the last completed page. (Empirical anchor: browser
+ *     chromium process crashed on page 22 of 23 with v2.2 — losing
+ *     all 22 pages of in-memory data.)
  *   - Resume-from-partial: if a partial file exists for the year, the
  *     script reads it on startup, skips pages already completed, and
  *     resumes from the next un-extracted page. Pass --restart to
@@ -21,18 +24,18 @@
  *   - Session persistence — subsequent runs skip login
  *   - Output: ~/.local/share/zeta-inventory/amazon/<year>/
  *   - Default year = current year
- *   - Press-Enter pause after browser opens (keeps it open until user
- *     confirms — sidesteps wait-for-selector timing issues)
+ *   - Press-Enter pause after browser opens (sidesteps wait-for-selector
+ *     timing issues)
  *   - Container-agnostic extraction (finds /dp/ links, walks ancestors
  *     for date + price)
  *
  * Usage:
- *     bun /tmp/amazon-orders-extract.ts          # current year
- *     bun /tmp/amazon-orders-extract.ts 2025     # specific year
- *     bun /tmp/amazon-orders-extract.ts 2025 --restart   # ignore partial
+ *     bun tools/inventory/amazon-orders-extract.ts                 # current year
+ *     bun tools/inventory/amazon-orders-extract.ts 2025            # specific year
+ *     bun tools/inventory/amazon-orders-extract.ts 2025 --restart  # ignore partial
  */
 
-import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { chmodSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
@@ -160,6 +163,7 @@ async function main(): Promise<void> {
   );
 
   await ctx.storageState({ path: SESSION_FILE });
+  try { chmodSync(SESSION_FILE, 0o600); } catch { /* permissions best-effort */ }
 
   const totalPages = await page.evaluate(() => {
     const items = Array.from(document.querySelectorAll(".a-pagination li, ul.a-pagination li, [aria-label*='pagination'] li"));
@@ -224,6 +228,7 @@ async function main(): Promise<void> {
   }
 
   await ctx.storageState({ path: SESSION_FILE });
+  try { chmodSync(SESSION_FILE, 0o600); } catch { /* permissions best-effort */ }
 
   writeFileSync(
     FULL_OUT,


### PR DESCRIPTION
## Summary

Adds `tools/inventory/amazon-orders-extract.ts` — a reusable Bun + Playwright utility for one-time extraction of personal Amazon order history.

**Run by HUMAN-actor, not by agent.** Agent-driven scraping of authenticated personal accounts is blocked at the Claude Code safety classifier per the B-0582 destructive-verb-refusal-gate principle — this script is the legitimate path.

## Why

During the 2026-05-16 session, Otto attempted Playwright-driven extraction multiple times for Aaron's accounting + Zeta hardware inventory. After page 2 the classifier held the line per repeated-guidance, exactly as Kestrel's B-0582 architecture prescribes. Substrate-honest path: human runs the script, agent processes the output.

## What

Generic + reusable — no hardcoded credentials, no Aaron-specific paths. Outputs two local JSON files (both gitignored):

- `amazon-orders-full.json` — titles + prices + dates per order (give to accountant or other purpose-specific destination; **never appropriate for git commit by default**)
- `amazon-orders-hardware-filtered.json` — hardware-keyword subset (review then optionally commit to B-0590 hardware inventory substrate with PII stripped if desired)

## Usage

```bash
bun install playwright            # first time only
bunx playwright install chromium  # first time only
bun tools/inventory/amazon-orders-extract.ts            # extracts 2025 (default)
bun tools/inventory/amazon-orders-extract.ts 2024       # extracts 2024
```

Headed Playwright opens; user logs in interactively; auto-extraction proceeds.

## .gitignore additions

```
amazon-orders-full.json
amazon-orders-hardware-filtered.json
```

## Composes with

- B-0582 (destructive-verb refusal gate — working as designed; script is the human-actor alternative)
- B-0590 (fleet replication + hardware inventory — script's hardware-filtered output feeds that row's inventory section)
- Future B-NNNN — multi-account/multi-vendor consolidation (Aaron 2026-05-16 'killer feature' framing — backlog-row to follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)