### PR TITLE
test(B-0156): smoke tests for tools/profile.ts CLI dispatcher

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/17/0057Z.md
+++ b/docs/hygiene-history/ticks/2026/05/17/0057Z.md
@@ -1,0 +1,93 @@
+---
+tick: 2026-05-17T00:57Z
+surface: otto-cli-background-worker
+operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"
+---
+
+# Tick 2026-05-17 0057Z — B-0156 AC #2 smoke test for tools/profile.ts
+
+## Surface
+
+Otto-CLI background-worker session in dedicated worktree
+`/Users/acehack/.local/share/zeta-claude-loop/Zeta/.claude/worktrees/deep-brewing-wall`.
+Branch `otto/b0156-profile-test-2026-05-16` off `origin/main`.
+No peer-agent (Lior) activity detected. Cron sentinel armed
+at session start per
+[`tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md).
+
+## Refresh (Step 1)
+
+- `git fetch origin main` — clean fast-forward
+- `gh api rate_limit` → `graphql_remaining: 0`, reset in 2 min.
+  Pure-git tier per
+  [`refresh-world-model-poll-pr-gate.md`](../../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md):
+  defer `gh pr create` until reset; commit + push proceed.
+- `bun tools/bus/claim.ts acquire --from otto-cli --item B-0156
+  --branch otto/b0156-profile-test-2026-05-16` → exit 0, envelope
+  `1212b4d3-9448-4a7b-97ef-c1253edda8d5`.
+
+## Substrate-drift discriminator (Step 0 per [`backlog-item-start-gate.md`](../../../../../../.claude/rules/backlog-item-start-gate.md))
+
+B-0156's "Non-install `.sh` files without TS sibling (3 ports
+remaining)" section listed `tools/profile.sh`,
+`tools/peer-call/amara.sh`, `tools/peer-call/ani.sh`. Direct
+existence check:
+
+```
+MISSING: tools/profile.sh        / EXISTS: tools/profile.ts
+MISSING: tools/peer-call/amara.sh / EXISTS: tools/peer-call/amara.ts
+MISSING: tools/peer-call/ani.sh   / EXISTS: tools/peer-call/ani.ts
+```
+
+All three `.sh` removed; Phase 5 sweep already complete. The
+audit baseline is stale, but the row is NOT pure-drift: AC #2
+("each TS sibling has at least one `bun test` covering its
+primary entry path") is unmet for `tools/profile.ts`. The
+peer-call ports are covered by `tools/peer-call/smoke.test.ts`
+(B-0421 acceptance #4). `tools/profile.ts` has no test.
+
+In-progress, not drift. Proceed with bounded slice.
+
+## Work picked (Step 3)
+
+Add `tools/profile.test.ts` — smoke tests for the CLI dispatcher
+in `tools/profile.ts`. Scope mirrors
+`tools/peer-call/smoke.test.ts`: validates dispatch surface, not
+the underlying `dotnet-counters` / `dotnet-trace` / `dotnet-gcdump`
+invocations (those tools aren't guaranteed in CI).
+
+Nine tests:
+
+1. File exists at canonical path.
+2. No-args → help + exit 0.
+3. `-h` → help + exit 0.
+4. `--help` → help + exit 0.
+5. Unknown command → exit 64 (EX_USAGE).
+6. `counters` without pid → exit 64 + stderr usage.
+7. `trace` without pid → exit 64 + stderr usage.
+8. `gcdump` without pid → exit 64 + stderr usage.
+9. Help text references every documented subcommand (catches
+   doc-drift where a case-branch is added without updating the
+   default help block).
+
+## Verify (Step 4)
+
+```
+bun test tools/profile.test.ts
+ 9 pass / 0 fail / 21 expect() calls / 1158ms
+```
+
+## Commit + push (Step 5)
+
+Branch `otto/b0156-profile-test-2026-05-16` pushed; PR creation
+deferred to post-rate-limit-reset tick (reset at 00:58:25Z, ~1
+min after this shard).
+
+## Cron (Step 6)
+
+`<<autonomous-loop>>` sentinel armed at session start (job
+`96b6891d`, `* * * * *`).
+
+## Visibility (Step 7)
+
+Tick shard committed. Stop.

--- a/tools/profile.test.ts
+++ b/tools/profile.test.ts
@@ -1,0 +1,110 @@
+// profile.test.ts — smoke tests for tools/profile.ts CLI dispatcher.
+//
+// B-0156 AC #2: each TS sibling of a ported .sh has at least one
+// `bun test` covering its primary entry path. profile.ts is the
+// last of the three Phase 3/4 ports lacking explicit test coverage
+// (amara.ts + ani.ts are covered by tools/peer-call/smoke.test.ts).
+//
+// Scope: VALIDATES CLI DISPATCH ONLY, NOT DOTNET TOOL INVOCATION.
+//
+// profile.ts is a thin dispatcher over dotnet-counters / dotnet-trace
+// / dotnet-gcdump / BenchmarkDotNet / reportgenerator. Those tools
+// are not guaranteed installed in CI, so the live subcommands cannot
+// be tested without mocks. This suite exercises the dispatch surface
+// instead:
+//
+//   1. The file exists at the canonical path.
+//   2. Empty / -h / --help arguments print usage and exit 0.
+//   3. Unknown commands print usage and exit 64 (EX_USAGE).
+//   4. Subcommands that require a pid exit 64 when pid is missing.
+//   5. The help text references every documented subcommand (catches
+//      doc-drift where a case-branch is added without updating the
+//      default help block).
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PROFILE_PATH = resolve(dirname(fileURLToPath(import.meta.url)), "profile.ts");
+
+function run(args: readonly string[]): {
+  status: number;
+  stdout: string;
+  stderr: string;
+} {
+  const result = spawnSync("bun", [PROFILE_PATH, ...args], {
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+const DOCUMENTED_SUBCOMMANDS = [
+  "install",
+  "counters",
+  "trace",
+  "gcdump",
+  "bench",
+  "coverage",
+] as const;
+
+describe("tools/profile.ts (B-0156 AC #2)", () => {
+  test("exists at the canonical path", () => {
+    expect(existsSync(PROFILE_PATH)).toBe(true);
+  });
+
+  test("no-args prints help and exits 0", () => {
+    const result = run([]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("DBSP profiling helper");
+  });
+
+  test("-h prints help and exits 0", () => {
+    const result = run(["-h"]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("DBSP profiling helper");
+  });
+
+  test("--help prints help and exits 0", () => {
+    const result = run(["--help"]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("DBSP profiling helper");
+  });
+
+  test("unknown command exits 64 (EX_USAGE)", () => {
+    const result = run(["definitely-not-a-real-subcommand"]);
+    expect(result.status).toBe(64);
+  });
+
+  test("counters without pid exits 64", () => {
+    const result = run(["counters"]);
+    expect(result.status).toBe(64);
+    expect(result.stderr).toContain("usage:");
+  });
+
+  test("trace without pid exits 64", () => {
+    const result = run(["trace"]);
+    expect(result.status).toBe(64);
+    expect(result.stderr).toContain("usage:");
+  });
+
+  test("gcdump without pid exits 64", () => {
+    const result = run(["gcdump"]);
+    expect(result.status).toBe(64);
+    expect(result.stderr).toContain("usage:");
+  });
+
+  test("help text references every documented subcommand", () => {
+    const result = run([]);
+    expect(result.status).toBe(0);
+    for (const sub of DOCUMENTED_SUBCOMMANDS) {
+      expect(result.stdout).toContain(sub);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `tools/profile.test.ts` — 9 smoke tests covering the CLI
dispatch surface of `tools/profile.ts`. Closes the last gap in
[B-0156](../blob/main/docs/backlog/P1/B-0156-typescript-standardization-non-install-scripts-aaron-2026-05-01.md)
acceptance criterion #2 ("each TS sibling has at least one
`bun test` covering its primary entry path").

`amara.ts` + `ani.ts` are already covered by
`tools/peer-call/smoke.test.ts` (B-0421 #4). `profile.ts` was
the lone remaining TS port without a sibling test.

## Scope discipline — dispatch only, NOT live dotnet tools

Mirrors `tools/peer-call/smoke.test.ts`: validates the
switch-statement entry path, NOT the `dotnet-counters` /
`dotnet-trace` / `dotnet-gcdump` / `BenchmarkDotNet` /
`reportgenerator` invocations. Those tools are not guaranteed
installed in CI, so live subcommand testing is out of scope.

The 9 tests:

1. File exists at canonical path
2. No-args → help + exit 0
3. `-h` → help + exit 0
4. `--help` → help + exit 0
5. Unknown command → exit 64 (EX_USAGE)
6. `counters` without pid → exit 64 + stderr usage
7. `trace` without pid → exit 64 + stderr usage
8. `gcdump` without pid → exit 64 + stderr usage
9. Help text references every documented subcommand
   (doc-drift catcher — every `case` in the switch must
   appear in the default `printf` help block)

## Substrate-drift step-0 result

Per
[`backlog-item-start-gate.md`](../blob/main/.claude/rules/backlog-item-start-gate.md):

- B-0156's "3 ports remaining" audit baseline is stale —
  all three `.sh` files (`profile.sh`, `peer-call/amara.sh`,
  `peer-call/ani.sh`) have been deleted; TS siblings present.
- Phase 5 (bash sweep) already complete.
- BUT row is NOT pure-drift: AC #2 unmet for `profile.ts`.
- Bounded slice = add the missing test. This PR.

After this PR lands, AC #2 is fully met across all 6
non-install TS ports. The remaining ACs (#5 package.json
script update audit, #6 no-regression confirmation) can be
addressed in follow-up slices or the row can be closed
substrate-honestly.

## Test plan

- [x] `bun test tools/profile.test.ts` → 9 pass / 0 fail
      / 21 expect() calls / 1158ms
- [x] No new `.sh` introduced; no `.py` introduced
- [x] No changes to `tools/profile.ts` itself (test-only PR)
- [ ] CI green on required checks

## Operative authorization

aaron 2026-05-14: "- **Devil-pole** (edge-runner drive):
keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)