### PR TITLE
feat(routines): B-0509 installer extension for cloud-schedule.json

### DIFF
--- a/docs/backlog/P1/B-0509-b0448-slice3-install-ts-cloud-schedule-extension-2026-05-14.md
+++ b/docs/backlog/P1/B-0509-b0448-slice3-install-ts-cloud-schedule-extension-2026-05-14.md
@@ -1,7 +1,7 @@
 ---
 id: B-0509
 priority: P1
-status: open
+status: closed
 title: "B-0448 slice 3 — Extend tools/routines/install.ts to detect + surface cloud-schedule.json"
 type: feature
 origin: B-0448 decomposition (Otto, 2026-05-14)
@@ -82,13 +82,13 @@ Per `.claude/rules/backlog-item-start-gate.md`:
 
 ## Acceptance criteria
 
-- [ ] `readCloudSchedule` exported pure function, mirrors `readSchedule` contract
-- [ ] `syncRoutine` returns `cloudSchedule` field in `SyncResult`
-- [ ] `main` prints Cloud Routine next-step guidance when `cloud-schedule.json` present
-- [ ] Unit tests for `readCloudSchedule` (happy path + missing + parse-error)
-- [ ] `bun tools/routines/install.ts` runs without error on existing routines
+- [x] `readCloudSchedule` exported pure function, mirrors `readSchedule` contract
+- [x] `syncRoutine` returns `cloudSchedule` field in `SyncResult`
+- [x] `main` prints Cloud Routine next-step guidance when `cloud-schedule.json` present
+- [x] Unit tests for `readCloudSchedule` (happy path + missing + parse-error)
+- [x] `bun tools/routines/install.ts` runs without error on existing routines
   (no `cloud-schedule.json` present → no cloud block printed; idempotent)
-- [ ] B-0509 closed with PR link
+- [x] B-0509 closed with PR link
 
 ## Why not merge slices 2 and 3
 

--- a/docs/backlog/P1/B-0509-b0448-slice3-install-ts-cloud-schedule-extension-2026-05-14.md
+++ b/docs/backlog/P1/B-0509-b0448-slice3-install-ts-cloud-schedule-extension-2026-05-14.md
@@ -6,7 +6,7 @@ title: "B-0448 slice 3 — Extend tools/routines/install.ts to detect + surface 
 type: feature
 origin: B-0448 decomposition (Otto, 2026-05-14)
 created: 2026-05-14
-last_updated: 2026-05-14
+last_updated: 2026-05-17
 parent: B-0448
 depends_on:
   - B-0507
@@ -88,7 +88,7 @@ Per `.claude/rules/backlog-item-start-gate.md`:
 - [x] Unit tests for `readCloudSchedule` (happy path + missing + parse-error)
 - [x] `bun tools/routines/install.ts` runs without error on existing routines
   (no `cloud-schedule.json` present → no cloud block printed; idempotent)
-- [x] B-0509 closed with PR link
+- [x] B-0509 closed with PR link — [PR #4014](https://github.com/Lucent-Financial-Group/Zeta/pull/4014)
 
 ## Why not merge slices 2 and 3
 

--- a/tools/routines/install.test.ts
+++ b/tools/routines/install.test.ts
@@ -1,0 +1,86 @@
+import { expect, test, describe } from "bun:test";
+import { readCloudSchedule } from "./install.ts";
+import { join } from "node:path";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+describe("readCloudSchedule", () => {
+  test("happy path - api trigger", () => {
+    const dir = join(tmpdir(), "cloud-schedule-test-1");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "cloud-schedule.json"),
+      JSON.stringify({
+        taskId: "test-1",
+        trigger: { type: "api" }
+      })
+    );
+
+    const result = readCloudSchedule(dir);
+    expect(result.missing).toBe(false);
+    expect(result.parseError).toBeUndefined();
+    expect(result.trigger).toEqual({ type: "api" });
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("happy path - scheduled trigger", () => {
+    const dir = join(tmpdir(), "cloud-schedule-test-2");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "cloud-schedule.json"),
+      JSON.stringify({
+        taskId: "test-2",
+        trigger: { type: "scheduled", cronExpression: "0 9 * * *" }
+      })
+    );
+
+    const result = readCloudSchedule(dir);
+    expect(result.missing).toBe(false);
+    expect(result.parseError).toBeUndefined();
+    expect(result.trigger).toEqual({ type: "scheduled", cronExpression: "0 9 * * *" });
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("missing file", () => {
+    const dir = join(tmpdir(), "cloud-schedule-test-3");
+    mkdirSync(dir, { recursive: true });
+
+    const result = readCloudSchedule(dir);
+    expect(result.missing).toBe(true);
+    expect(result.parseError).toBeUndefined();
+    expect(result.trigger).toBeUndefined();
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("parse error - invalid json", () => {
+    const dir = join(tmpdir(), "cloud-schedule-test-4");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "cloud-schedule.json"), "{ invalid json ");
+
+    const result = readCloudSchedule(dir);
+    expect(result.missing).toBe(false);
+    expect(result.parseError).toBeDefined();
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("parse error - missing trigger field", () => {
+    const dir = join(tmpdir(), "cloud-schedule-test-5");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "cloud-schedule.json"),
+      JSON.stringify({
+        taskId: "test-5"
+      })
+    );
+
+    const result = readCloudSchedule(dir);
+    expect(result.missing).toBe(false);
+    expect(result.parseError).toBe("cloud-schedule.json is missing required field: trigger");
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/tools/routines/install.test.ts
+++ b/tools/routines/install.test.ts
@@ -1,86 +1,172 @@
-import { expect, test, describe } from "bun:test";
+import { expect, test, describe, beforeEach, afterEach } from "bun:test";
 import { readCloudSchedule } from "./install.ts";
 import { join } from "node:path";
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
+
+// Each test gets an isolated mkdtempSync directory and cleans it up in afterEach.
+// Fixes both:
+//   * concurrent / stale test-run collisions (each test gets a unique path)
+//   * CodeQL "Insecure creation of file in os temp dir" alerts (87-90):
+//     fixed-name paths under tmpdir() are racy on multi-user systems.
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cloud-schedule-test-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
 
 describe("readCloudSchedule", () => {
   test("happy path - api trigger", () => {
-    const dir = join(tmpdir(), "cloud-schedule-test-1");
-    mkdirSync(dir, { recursive: true });
     writeFileSync(
       join(dir, "cloud-schedule.json"),
       JSON.stringify({
         taskId: "test-1",
-        trigger: { type: "api" }
-      })
+        trigger: { type: "api" },
+      }),
     );
 
     const result = readCloudSchedule(dir);
     expect(result.missing).toBe(false);
     expect(result.parseError).toBeUndefined();
     expect(result.trigger).toEqual({ type: "api" });
-
-    rmSync(dir, { recursive: true, force: true });
   });
 
   test("happy path - scheduled trigger", () => {
-    const dir = join(tmpdir(), "cloud-schedule-test-2");
-    mkdirSync(dir, { recursive: true });
     writeFileSync(
       join(dir, "cloud-schedule.json"),
       JSON.stringify({
         taskId: "test-2",
-        trigger: { type: "scheduled", cronExpression: "0 9 * * *" }
-      })
+        trigger: { type: "scheduled", cronExpression: "0 9 * * *" },
+      }),
     );
 
     const result = readCloudSchedule(dir);
     expect(result.missing).toBe(false);
     expect(result.parseError).toBeUndefined();
     expect(result.trigger).toEqual({ type: "scheduled", cronExpression: "0 9 * * *" });
+  });
 
-    rmSync(dir, { recursive: true, force: true });
+  test("happy path - github_event trigger", () => {
+    writeFileSync(
+      join(dir, "cloud-schedule.json"),
+      JSON.stringify({
+        trigger: {
+          type: "github_event",
+          event: "pull_request.opened",
+          repos: ["Lucent-Financial-Group/Zeta"],
+        },
+      }),
+    );
+
+    const result = readCloudSchedule(dir);
+    expect(result.missing).toBe(false);
+    expect(result.parseError).toBeUndefined();
+    expect(result.trigger).toEqual({
+      type: "github_event",
+      event: "pull_request.opened",
+      repos: ["Lucent-Financial-Group/Zeta"],
+    });
   });
 
   test("missing file", () => {
-    const dir = join(tmpdir(), "cloud-schedule-test-3");
-    mkdirSync(dir, { recursive: true });
-
     const result = readCloudSchedule(dir);
     expect(result.missing).toBe(true);
     expect(result.parseError).toBeUndefined();
     expect(result.trigger).toBeUndefined();
-
-    rmSync(dir, { recursive: true, force: true });
   });
 
   test("parse error - invalid json", () => {
-    const dir = join(tmpdir(), "cloud-schedule-test-4");
-    mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "cloud-schedule.json"), "{ invalid json ");
 
     const result = readCloudSchedule(dir);
     expect(result.missing).toBe(false);
     expect(result.parseError).toBeDefined();
-
-    rmSync(dir, { recursive: true, force: true });
   });
 
   test("parse error - missing trigger field", () => {
-    const dir = join(tmpdir(), "cloud-schedule-test-5");
-    mkdirSync(dir, { recursive: true });
     writeFileSync(
       join(dir, "cloud-schedule.json"),
       JSON.stringify({
-        taskId: "test-5"
-      })
+        taskId: "test-5",
+      }),
     );
 
     const result = readCloudSchedule(dir);
     expect(result.missing).toBe(false);
     expect(result.parseError).toBe("cloud-schedule.json is missing required field: trigger");
+  });
 
-    rmSync(dir, { recursive: true, force: true });
+  test("parse error - scheduled trigger missing cronExpression", () => {
+    writeFileSync(join(dir, "cloud-schedule.json"), JSON.stringify({ trigger: { type: "scheduled" } }));
+
+    const result = readCloudSchedule(dir);
+    expect(result.missing).toBe(false);
+    expect(result.parseError).toContain("scheduled missing required field: cronExpression");
+    expect(result.trigger).toBeUndefined();
+  });
+
+  test("parse error - scheduled trigger with empty cronExpression", () => {
+    writeFileSync(
+      join(dir, "cloud-schedule.json"),
+      JSON.stringify({ trigger: { type: "scheduled", cronExpression: "   " } }),
+    );
+
+    const result = readCloudSchedule(dir);
+    expect(result.missing).toBe(false);
+    expect(result.parseError).toContain("scheduled missing required field: cronExpression");
+  });
+
+  test("parse error - github_event trigger missing event", () => {
+    writeFileSync(
+      join(dir, "cloud-schedule.json"),
+      JSON.stringify({ trigger: { type: "github_event", repos: ["foo/bar"] } }),
+    );
+
+    const result = readCloudSchedule(dir);
+    expect(result.missing).toBe(false);
+    expect(result.parseError).toContain("github_event missing required field: event");
+  });
+
+  test("parse error - github_event trigger missing repos", () => {
+    writeFileSync(
+      join(dir, "cloud-schedule.json"),
+      JSON.stringify({ trigger: { type: "github_event", event: "issues.opened" } }),
+    );
+
+    const result = readCloudSchedule(dir);
+    expect(result.missing).toBe(false);
+    expect(result.parseError).toContain("github_event missing required field: repos");
+  });
+
+  test("parse error - github_event trigger with empty repos array", () => {
+    writeFileSync(
+      join(dir, "cloud-schedule.json"),
+      JSON.stringify({ trigger: { type: "github_event", event: "issues.opened", repos: [] } }),
+    );
+
+    const result = readCloudSchedule(dir);
+    expect(result.missing).toBe(false);
+    expect(result.parseError).toContain("github_event missing required field: repos");
+  });
+
+  test("parse error - unknown trigger type", () => {
+    writeFileSync(join(dir, "cloud-schedule.json"), JSON.stringify({ trigger: { type: "webhook" } }));
+
+    const result = readCloudSchedule(dir);
+    expect(result.missing).toBe(false);
+    expect(result.parseError).toContain('trigger.type "webhook" is not recognized');
+  });
+
+  test("parse error - trigger.type is not a string", () => {
+    writeFileSync(join(dir, "cloud-schedule.json"), JSON.stringify({ trigger: { type: 42 } }));
+
+    const result = readCloudSchedule(dir);
+    expect(result.missing).toBe(false);
+    expect(result.parseError).toBe("cloud-schedule.json trigger.type must be a string");
   });
 });

--- a/tools/routines/install.ts
+++ b/tools/routines/install.ts
@@ -29,11 +29,7 @@ import { homedir } from "node:os";
 export const DEFAULT_REPO_ROUTINES_DIR = resolve(import.meta.dir);
 export const DEFAULT_RUNTIME_TASKS_DIR = join(homedir(), ".claude", "scheduled-tasks");
 
-export type Action =
-  | "created"
-  | "updated"
-  | "skipped-unchanged"
-  | "skipped-missing-skill";
+export type Action = "created" | "updated" | "skipped-unchanged" | "skipped-missing-skill";
 
 export interface SyncResult {
   taskId: string;
@@ -128,28 +124,71 @@ export function readCloudSchedule(srcDir: string): CloudScheduleResult {
   const path = join(srcDir, "cloud-schedule.json");
   const content = readFileOrUndefined(path);
   if (content === undefined) return { missing: true };
+  let parsed: { trigger?: unknown };
   try {
-    const parsed = JSON.parse(content) as { trigger?: CloudTrigger };
-    if (parsed.trigger !== undefined && typeof parsed.trigger.type === "string") {
-      return { trigger: parsed.trigger, missing: false };
-    }
-    return {
-      missing: false,
-      parseError: "cloud-schedule.json is missing required field: trigger",
-    };
+    parsed = JSON.parse(content) as { trigger?: unknown };
   } catch (err) {
     return {
       missing: false,
       parseError: err instanceof Error ? err.message : String(err),
     };
   }
+  if (parsed.trigger === undefined || parsed.trigger === null || typeof parsed.trigger !== "object") {
+    return {
+      missing: false,
+      parseError: "cloud-schedule.json is missing required field: trigger",
+    };
+  }
+  const trigger = parsed.trigger as { type?: unknown };
+  if (typeof trigger.type !== "string") {
+    return {
+      missing: false,
+      parseError: "cloud-schedule.json trigger.type must be a string",
+    };
+  }
+  // Strict schema validation per tools/routines/cloud-schedule.schema.json:
+  // each trigger.type has its own required fields. A trigger that names a
+  // type but omits the type-specific required fields is malformed and must
+  // fail loudly — silent acceptance would mean a routine whose cron never
+  // fires, or whose github_event listens on nothing, gets installed.
+  switch (trigger.type) {
+    case "scheduled": {
+      const t = trigger as { type: "scheduled"; cronExpression?: unknown };
+      if (typeof t.cronExpression !== "string" || t.cronExpression.trim().length === 0) {
+        return {
+          missing: false,
+          parseError: "cloud-schedule.json trigger.scheduled missing required field: cronExpression (non-empty string)",
+        };
+      }
+      return { trigger: { type: "scheduled", cronExpression: t.cronExpression }, missing: false };
+    }
+    case "github_event": {
+      const t = trigger as { type: "github_event"; event?: unknown; repos?: unknown };
+      if (typeof t.event !== "string" || t.event.trim().length === 0) {
+        return {
+          missing: false,
+          parseError: "cloud-schedule.json trigger.github_event missing required field: event (non-empty string)",
+        };
+      }
+      if (!Array.isArray(t.repos) || t.repos.length === 0 || !t.repos.every((r) => typeof r === "string")) {
+        return {
+          missing: false,
+          parseError: "cloud-schedule.json trigger.github_event missing required field: repos (non-empty string array)",
+        };
+      }
+      return { trigger: { type: "github_event", event: t.event, repos: t.repos }, missing: false };
+    }
+    case "api":
+      return { trigger: { type: "api" }, missing: false };
+    default:
+      return {
+        missing: false,
+        parseError: `cloud-schedule.json trigger.type "${trigger.type}" is not recognized (expected: scheduled | github_event | api)`,
+      };
+  }
 }
 
-export function syncRoutine(
-  taskId: string,
-  repoRoutinesDir: string,
-  runtimeTasksDir: string,
-): SyncResult {
+export function syncRoutine(taskId: string, repoRoutinesDir: string, runtimeTasksDir: string): SyncResult {
   const srcDir = join(repoRoutinesDir, taskId);
   const srcSkill = join(srcDir, "SKILL.md");
   const dstDir = join(runtimeTasksDir, taskId);
@@ -181,13 +220,9 @@ export function syncRoutine(
     taskId,
     action,
     runtimePath: dstSkill,
-    ...(schedule.cronExpression !== undefined
-      ? { cronExpression: schedule.cronExpression }
-      : {}),
+    ...(schedule.cronExpression !== undefined ? { cronExpression: schedule.cronExpression } : {}),
     scheduleMissing: schedule.missing,
-    ...(schedule.parseError !== undefined
-      ? { scheduleParseError: schedule.parseError }
-      : {}),
+    ...(schedule.parseError !== undefined ? { scheduleParseError: schedule.parseError } : {}),
     cloudSchedule,
   };
 }
@@ -200,9 +235,7 @@ export function main(
   console.log(`  source: ${repoRoutinesDir}`);
   console.log(`  target: ${runtimeTasksDir}\n`);
 
-  const routines = listRoutines(repoRoutinesDir).filter(
-    (id) => id !== "install.ts" && !id.endsWith(".md"),
-  );
+  const routines = listRoutines(repoRoutinesDir).filter((id) => id !== "install.ts" && !id.endsWith(".md"));
   if (routines.length === 0) {
     console.log("No routines found under tools/routines/");
     return 0;
@@ -226,9 +259,7 @@ export function main(
     }
   }
 
-  const needsRegistration = results.filter(
-    (r) => r.cronExpression !== undefined,
-  );
+  const needsRegistration = results.filter((r) => r.cronExpression !== undefined);
   if (needsRegistration.length > 0) {
     console.log(`\nNext step — register cron schedules via the scheduled-tasks MCP:`);
     console.log(`(invoke create_scheduled_task from an interactive Claude session, or via direct MCP API call)\n`);
@@ -238,17 +269,21 @@ export function main(
   }
 
   const needsCloudRegistration = results.filter(
-    (r) => r.cloudSchedule && !r.cloudSchedule.missing && r.cloudSchedule.trigger !== undefined
+    (r) => r.cloudSchedule && !r.cloudSchedule.missing && r.cloudSchedule.trigger !== undefined,
   );
   if (needsCloudRegistration.length > 0) {
     console.log(`\nNext step — register Cloud Routines (Anthropic-hosted):`);
     console.log(`  Register via the web UI: https://claude.ai/code/routines\n`);
     for (const r of needsCloudRegistration) {
-      const triggerType = r.cloudSchedule?.trigger?.type;
+      const trigger = r.cloudSchedule?.trigger;
       let details = "";
-      if (r.cloudSchedule?.trigger?.type === "scheduled") details = `cron="${r.cloudSchedule.trigger.cronExpression}"`;
-      if (r.cloudSchedule?.trigger?.type === "github_event") details = `event="${r.cloudSchedule.trigger.event}" repos=[${r.cloudSchedule.trigger.repos.map(x=>`"${x}"`).join(",")}]`;
-      console.log(`  ${r.taskId}: trigger=${triggerType} ${details}`);
+      if (trigger?.type === "scheduled") {
+        details = `cron="${trigger.cronExpression}"`;
+      } else if (trigger?.type === "github_event") {
+        const repos = trigger.repos.map((x) => `"${x}"`).join(",");
+        details = `event="${trigger.event}" repos=[${repos}]`;
+      }
+      console.log(`  ${r.taskId}: trigger=${trigger?.type} ${details}`);
     }
   }
 
@@ -257,7 +292,8 @@ export function main(
     updated: results.filter((r) => r.action === "updated").length,
     unchanged: results.filter((r) => r.action === "skipped-unchanged").length,
     missingSkill: results.filter((r) => r.action === "skipped-missing-skill").length,
-    parseErrors: results.filter((r) => r.scheduleParseError !== undefined).length,
+    parseErrors: results.filter((r) => r.scheduleParseError !== undefined || r.cloudSchedule?.parseError !== undefined)
+      .length,
   };
   console.log(
     `\nDone. created=${summary.created} updated=${summary.updated} unchanged=${summary.unchanged} missing=${summary.missingSkill} parseErrors=${summary.parseErrors}`,
@@ -265,6 +301,8 @@ export function main(
 
   // SKILL.md is required per README. A routine directory with no SKILL.md is
   // a developer mistake, not graceful state. Fail loudly so CI catches it.
+  // Same discipline for cloud-schedule.json parse errors — a malformed cloud
+  // schedule means a routine that would never fire correctly in production.
   return summary.parseErrors > 0 || summary.missingSkill > 0 ? 1 : 0;
 }
 

--- a/tools/routines/install.ts
+++ b/tools/routines/install.ts
@@ -42,6 +42,7 @@ export interface SyncResult {
   cronExpression?: string;
   scheduleMissing?: boolean;
   scheduleParseError?: string;
+  cloudSchedule?: CloudScheduleResult;
 }
 
 export type CloudTrigger =
@@ -123,6 +124,27 @@ export function readSchedule(srcDir: string): ScheduleResult {
   }
 }
 
+export function readCloudSchedule(srcDir: string): CloudScheduleResult {
+  const path = join(srcDir, "cloud-schedule.json");
+  const content = readFileOrUndefined(path);
+  if (content === undefined) return { missing: true };
+  try {
+    const parsed = JSON.parse(content) as { trigger?: CloudTrigger };
+    if (parsed.trigger !== undefined && typeof parsed.trigger.type === "string") {
+      return { trigger: parsed.trigger, missing: false };
+    }
+    return {
+      missing: false,
+      parseError: "cloud-schedule.json is missing required field: trigger",
+    };
+  } catch (err) {
+    return {
+      missing: false,
+      parseError: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 export function syncRoutine(
   taskId: string,
   repoRoutinesDir: string,
@@ -154,6 +176,7 @@ export function syncRoutine(
   }
 
   const schedule = readSchedule(srcDir);
+  const cloudSchedule = readCloudSchedule(srcDir);
   return {
     taskId,
     action,
@@ -165,6 +188,7 @@ export function syncRoutine(
     ...(schedule.parseError !== undefined
       ? { scheduleParseError: schedule.parseError }
       : {}),
+    cloudSchedule,
   };
 }
 
@@ -197,6 +221,9 @@ export function main(
     } else if (r.scheduleMissing) {
       console.log(`  cron:    (no schedule.json — ad-hoc routine, register manually)`);
     }
+    if (r.cloudSchedule?.parseError !== undefined) {
+      console.error(`  cloud-schedule.json malformed: ${r.cloudSchedule.parseError}`);
+    }
   }
 
   const needsRegistration = results.filter(
@@ -207,6 +234,21 @@ export function main(
     console.log(`(invoke create_scheduled_task from an interactive Claude session, or via direct MCP API call)\n`);
     for (const r of needsRegistration) {
       console.log(`  create_scheduled_task(taskId="${r.taskId}", cronExpression="${r.cronExpression}", ...)`);
+    }
+  }
+
+  const needsCloudRegistration = results.filter(
+    (r) => r.cloudSchedule && !r.cloudSchedule.missing && r.cloudSchedule.trigger !== undefined
+  );
+  if (needsCloudRegistration.length > 0) {
+    console.log(`\nNext step — register Cloud Routines (Anthropic-hosted):`);
+    console.log(`  Register via the web UI: https://claude.ai/code/routines\n`);
+    for (const r of needsCloudRegistration) {
+      const triggerType = r.cloudSchedule?.trigger?.type;
+      let details = "";
+      if (r.cloudSchedule?.trigger?.type === "scheduled") details = `cron="${r.cloudSchedule.trigger.cronExpression}"`;
+      if (r.cloudSchedule?.trigger?.type === "github_event") details = `event="${r.cloudSchedule.trigger.event}" repos=[${r.cloudSchedule.trigger.repos.map(x=>`"${x}"`).join(",")}]`;
+      console.log(`  ${r.taskId}: trigger=${triggerType} ${details}`);
     }
   }
 


### PR DESCRIPTION
Delivers B-0509: Extend tools/routines/install.ts to detect + surface cloud-schedule.json
- Exported readCloudSchedule with unit tests
- Added cloudSchedule block to syncRoutine
- Added registration guidance to main
- Marked B-0509 as closed