### PR TITLE
fix(3823): correct partial/multi-slice tally

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/16/0758Z.md
+++ b/docs/hygiene-history/ticks/2026/05/16/0758Z.md
@@ -49,7 +49,7 @@ through the audit-backlog from one cascade window.
 Across 19 triaged candidates:
 
 - **10 pure-drift (53%)** — work shipped, status flag never flipped
-- **5 partial/multi-slice (26%)** — needs annotation OR self-documenting
+- **6 partial/multi-slice (32%)** — needs annotation OR self-documenting (Class 2 + 3 + 4 = 4 + 1 + 1)
 - **3 FP (16%)** — audit tool's noise floor
 
 The ~53% pure-drift rate is consistent across the cascade. The


### PR DESCRIPTION
## Summary

Replacement for closed/unmerged PR #3823.

Corrects the partial/multi-slice tally from 5 (26%) to 6 (32%) after Codex and Copilot both flagged math drift.

## Context

The previous PR #3823 was closed without merge on 2026-05-16. This branch preserves the corrected commit on a fresh Codex-owned ref: `codex/pr3823-rebased-vera-20260516`.

## Verification

- Branch pushed and verified on GitHub at `ff84f13f855e301b831cd7862340775506c8b237`
- Replacement worktree clean before PR creation
- Root checkout treated as contested; no root writes performed