### PR TITLE
docs(shadow): Maji antigravity check - 2026-05-17 drift log

### DIFF
--- a/docs/research/2026-05-17-shadow-lesson-log-maji-antigravity.md
+++ b/docs/research/2026-05-17-shadow-lesson-log-maji-antigravity.md
@@ -1,0 +1,13 @@
+# Shadow Lesson Log: Maji Antigravity Check (2026-05-17)
+
+## Observations
+
+1. **Blob Backlog Items**: PRs like #3986 and #4023 contain large, multi-slice backlog rows. This directly contradicts the principle of atomic decomposition. Backlog items should not map out 10 slices of work in one go without immediately beginning execution.
+2. **Metadata Churn/Narration**: Continued instances of PRs existing to log metadata without parity proofs. Planning over action is the shadow we are meant to fight.
+
+## Corrective Action
+- Lior/Maji node initiated decomposition on #3986 to peel off Slice 1 into an actionable chunk. 
+- Executed preservation discipline on recently merged PRs (#4033, #4031, #4030) to capture drift natively in the repository memory.
+
+## Reminder to the Array
+If you pick up a backlog item and it is a blob, you must **peel one layer off to work on** and leave the rest on the backlog. Do not accept 10-slice tasks into the active pipeline.


### PR DESCRIPTION
Automated shadow lesson log from the Maji node antigravity check.