### PR TITLE
test(B-0156): co-located tests for check-tick-history-shard-schema.ts (9 tests)

### DIFF
--- a/tools/hygiene/check-tick-history-shard-schema.test.ts
+++ b/tools/hygiene/check-tick-history-shard-schema.test.ts
@@ -1,0 +1,112 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import type { ScanResult } from "./check-tick-history-shard-schema";
+
+type ScanOne = (shardPath: string) => ScanResult;
+
+let TMPDIR: string;
+let scanOne: ScanOne;
+let priorRepoRoot: string | undefined;
+
+beforeAll(async () => {
+  TMPDIR = mkdtempSync(join(tmpdir(), "shard-schema-test-"));
+  priorRepoRoot = process.env["REPO_ROOT"];
+  process.env["REPO_ROOT"] = TMPDIR;
+  const mod = await import("./check-tick-history-shard-schema");
+  scanOne = mod.scanOne;
+});
+
+afterAll(() => {
+  if (priorRepoRoot === undefined) delete process.env["REPO_ROOT"];
+  else process.env["REPO_ROOT"] = priorRepoRoot;
+  if (TMPDIR) rmSync(TMPDIR, { recursive: true, force: true });
+});
+
+function writeShard(relPath: string, content: string): string {
+  const full = join(TMPDIR, "docs/hygiene-history/ticks", relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content);
+  return full;
+}
+
+const SIX_COLS = "| 2026-05-17T12:34Z | a | b | c | d | e |\n";
+
+describe("scanOne", () => {
+  test("accepts a valid HHMMZ.md shard", () => {
+    const path = writeShard("2026/05/17/1234Z.md", SIX_COLS);
+    const result = scanOne(path);
+
+    expect(result.ok).toBe(true);
+    expect(result.violation).toBeUndefined();
+  });
+
+  test("accepts HHMMZ-<hex>.md filename variant", () => {
+    const path = writeShard("2026/05/17/1234Z-abc123.md", SIX_COLS);
+    const result = scanOne(path);
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("accepts col1 with seconds (HH:MM:SSZ) when minutes match filename", () => {
+    const content = "| 2026-05-17T12:34:56Z | a | b | c | d | e |\n";
+    const path = writeShard("2026/05/17/1234Z.md", content);
+    const result = scanOne(path);
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("flags filename that does not match any schema regex", () => {
+    const path = writeShard("2026/05/17/foo.md", SIX_COLS);
+    const result = scanOne(path);
+
+    expect(result.ok).toBe(false);
+    expect(result.violation).toContain("filename does not match");
+  });
+
+  test("flags col1 date mismatch with path date", () => {
+    const content = "| 2026-05-18T12:34Z | a | b | c | d | e |\n";
+    const path = writeShard("2026/05/17/1234Z.md", content);
+    const result = scanOne(path);
+
+    expect(result.ok).toBe(false);
+    expect(result.violation).toContain("does not match path date");
+  });
+
+  test("flags col1 time mismatch with filename time", () => {
+    const content = "| 2026-05-17T12:35Z | a | b | c | d | e |\n";
+    const path = writeShard("2026/05/17/1234Z.md", content);
+    const result = scanOne(path);
+
+    expect(result.ok).toBe(false);
+    expect(result.violation).toContain("does not match filename");
+  });
+
+  test("flags first row with fewer than 6 columns (7+ pipes)", () => {
+    const content = "| 2026-05-17T12:34Z | only one col |\n";
+    const path = writeShard("2026/05/17/1234Z.md", content);
+    const result = scanOne(path);
+
+    expect(result.ok).toBe(false);
+    expect(result.violation).toContain("pipes");
+  });
+
+  test("flags empty file", () => {
+    const path = writeShard("2026/05/17/1234Z.md", "");
+    const result = scanOne(path);
+
+    expect(result.ok).toBe(false);
+    expect(result.violation).toBe("file is empty");
+  });
+
+  test("flags col1 missing leading pipe-space-timestamp format", () => {
+    const content = "|2026-05-17T12:34Z | a | b | c | d | e |\n";
+    const path = writeShard("2026/05/17/1234Z.md", content);
+    const result = scanOne(path);
+
+    expect(result.ok).toBe(false);
+    expect(result.violation).toContain("col1 must be exactly");
+  });
+});

--- a/tools/hygiene/check-tick-history-shard-schema.ts
+++ b/tools/hygiene/check-tick-history-shard-schema.ts
@@ -35,7 +35,7 @@ const HASH_RE = /^(\d{4})(\d{2})Z-[0-9a-f]+$/;
 const COL1_RE = /^\|\s(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?Z)\s\|\s/;
 const SHARD_PREFIX = "docs/hygiene-history/ticks/";
 
-interface ScanResult {
+export interface ScanResult {
   path: string;
   ok: boolean;
   violation?: string;
@@ -49,7 +49,7 @@ function repoRelative(p: string): string {
   return normalizeToPosix(relative(ROOT, p));
 }
 
-function scanOne(shardPath: string): ScanResult {
+export function scanOne(shardPath: string): ScanResult {
   const pathRel = repoRelative(resolve(ROOT, shardPath));
   const base = basename(shardPath, ".md");
 


### PR DESCRIPTION
## Summary

Smallest bounded slice of B-0156 — addresses acceptance criterion 2 ("each
TS sibling has at least one bun test covering its primary entry path") for
the Phase 2 schema port at `tools/hygiene/check-tick-history-shard-schema.ts`.
The `.sh` original was retired in PR #1986; the `.ts` had no co-located test.

## What

- `tools/hygiene/check-tick-history-shard-schema.ts`: export `scanOne` and
  `ScanResult` (2-line change; no behavior change).
- `tools/hygiene/check-tick-history-shard-schema.test.ts`: 9 cases
  - 3 acceptance paths: `HHMMZ.md`, `HHMMZ-<hex>.md`, `HH:MM:SSZ` col1
  - 6 violation paths: bad filename, col1 date/time mismatches,
    insufficient pipes, empty file, col1 format error
- Dynamic-import pattern so `REPO_ROOT` is set to a tmpdir before module
  load; captures + restores prior `REPO_ROOT` to keep env clean across
  the broader `bun test` run.

## Why

The B-0156 row's audit shows all 6 non-install `.sh` files now have
working `.ts` siblings (Phase 5 sweep done), but criterion 2 (test
coverage) was unverified for the 3 hygiene ports. The schema port is
the smallest (~5KB) and has the most testable surface (per-shard
validator returning structured `ScanResult`). This PR ships exactly
one bounded step toward closing B-0156.

## Checks

- `bun test tools/hygiene/check-tick-history-shard-schema.test.ts`:
  **9/9 pass**
- `bun test tools/hygiene/`: **181/181 pass** (no regression — and
  the env-restore in `afterAll` actually unblocked the broader suite
  by avoiding `REPO_ROOT` pollution)
- `bun tools/hygiene/check-tick-history-shard-schema.ts`: production
  CLI runs unchanged; pre-existing repo shard violations preserved

## B-0156 status after this PR

The row's audit baseline (3 remaining `.sh` files) is now stale — the
re-verification command in the row's self-test section shows zero
remaining non-install `.sh` files without `.ts` siblings. After this
PR, two `.ts` ports remain without co-located tests
(`snapshot-github-settings.ts`, `check-github-settings-drift.ts`); both
are candidates for follow-on slices.

## Test plan

- [x] Tests pass standalone
- [x] Tests pass in broader hygiene suite
- [x] Production CLI unaffected
- [x] Pushed claim branch before write work (otto-bg/b0156-schema-test-2026-05-17)
- [x] Isolated worktree (`.claude/worktrees/agile-doodling-iverson`); did not touch root checkout
- [x] Branch guard verified pre-commit
- [x] `git ls-tree HEAD` = 53 entries (no commit-tree corruption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)