### PR TITLE
test(hygiene): cover snapshot-github-settings parseArgs+parseJsonSafe (B-0156 ph2)

### DIFF
--- a/tools/hygiene/snapshot-github-settings.test.ts
+++ b/tools/hygiene/snapshot-github-settings.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { parseArgs, parseJsonSafe } from "./snapshot-github-settings";
+
+const NULL_RESOLVER = async (): Promise<string> => "";
+
+let priorGhRepo: string | undefined;
+
+beforeEach(() => {
+  priorGhRepo = process.env["GH_REPO"];
+  delete process.env["GH_REPO"];
+});
+
+afterEach(() => {
+  if (priorGhRepo === undefined) delete process.env["GH_REPO"];
+  else process.env["GH_REPO"] = priorGhRepo;
+});
+
+describe("parseJsonSafe", () => {
+  test("parses a valid JSON object", () => {
+    expect(parseJsonSafe('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  test("parses a valid JSON array", () => {
+    expect(parseJsonSafe("[1,2,3]")).toEqual([1, 2, 3]);
+  });
+
+  test("returns fallback (null by default) for null input", () => {
+    expect(parseJsonSafe(null)).toBeNull();
+  });
+
+  test("returns fallback (null by default) for empty string input", () => {
+    expect(parseJsonSafe("")).toBeNull();
+  });
+
+  test("honours an explicit fallback", () => {
+    expect(parseJsonSafe(null, [])).toEqual([]);
+    expect(parseJsonSafe("", { skipped: true })).toEqual({ skipped: true });
+  });
+
+  test("returns fallback for invalid JSON instead of throwing", () => {
+    expect(parseJsonSafe("not-json", [])).toEqual([]);
+    expect(parseJsonSafe("{unterminated", null)).toBeNull();
+  });
+});
+
+describe("parseArgs", () => {
+  test("--repo OWNER/NAME → success", async () => {
+    const result = await parseArgs(["--repo", "Lucent-Financial-Group/Zeta"], NULL_RESOLVER);
+
+    expect(result.kind).toBe("args");
+    if (result.kind === "args") {
+      expect(result.args.repo).toBe("Lucent-Financial-Group/Zeta");
+    }
+  });
+
+  test("positional arg is accepted as repo", async () => {
+    const result = await parseArgs(["AceHack/Zeta"], NULL_RESOLVER);
+
+    expect(result.kind).toBe("args");
+    if (result.kind === "args") {
+      expect(result.args.repo).toBe("AceHack/Zeta");
+    }
+  });
+
+  test("--repo without value returns an error", async () => {
+    const result = await parseArgs(["--repo"], NULL_RESOLVER);
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("--repo requires OWNER/NAME argument");
+    }
+  });
+
+  test("falls back to GH_REPO env var when no argv", async () => {
+    process.env["GH_REPO"] = "env/zeta";
+    const result = await parseArgs([], NULL_RESOLVER);
+
+    expect(result.kind).toBe("args");
+    if (result.kind === "args") {
+      expect(result.args.repo).toBe("env/zeta");
+    }
+  });
+
+  test("explicit --repo overrides GH_REPO env var", async () => {
+    process.env["GH_REPO"] = "env/zeta";
+    const result = await parseArgs(["--repo", "argv/zeta"], NULL_RESOLVER);
+
+    expect(result.kind).toBe("args");
+    if (result.kind === "args") {
+      expect(result.args.repo).toBe("argv/zeta");
+    }
+  });
+
+  test("falls back to the resolveDefault function when argv and env are empty", async () => {
+    const resolver = async (): Promise<string> => "resolver/zeta";
+    const result = await parseArgs([], resolver);
+
+    expect(result.kind).toBe("args");
+    if (result.kind === "args") {
+      expect(result.args.repo).toBe("resolver/zeta");
+    }
+  });
+
+  test("returns error when argv, env, and resolver all yield empty", async () => {
+    const result = await parseArgs([], NULL_RESOLVER);
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("cannot determine repo");
+    }
+  });
+
+  test("argv > env > resolver precedence ordering", async () => {
+    // argv wins
+    process.env["GH_REPO"] = "env/zeta";
+    const resolver = async (): Promise<string> => "resolver/zeta";
+    const r1 = await parseArgs(["argv/zeta"], resolver);
+    expect(r1.kind === "args" && r1.args.repo).toBe("argv/zeta");
+
+    // env wins over resolver
+    const r2 = await parseArgs([], resolver);
+    expect(r2.kind === "args" && r2.args.repo).toBe("env/zeta");
+
+    // resolver wins when env unset
+    delete process.env["GH_REPO"];
+    const r3 = await parseArgs([], resolver);
+    expect(r3.kind === "args" && r3.args.repo).toBe("resolver/zeta");
+  });
+});

--- a/tools/hygiene/snapshot-github-settings.ts
+++ b/tools/hygiene/snapshot-github-settings.ts
@@ -87,7 +87,7 @@ async function ghApiSkip403(path: string, jqFilter?: string): Promise<string | n
   return r.stdout.trim();
 }
 
-function parseJsonSafe(raw: string | null, fallback: unknown = null): unknown {
+export function parseJsonSafe(raw: string | null, fallback: unknown = null): unknown {
   if (raw === null || raw.length === 0) return fallback;
   try {
     return JSON.parse(raw);
@@ -96,15 +96,26 @@ function parseJsonSafe(raw: string | null, fallback: unknown = null): unknown {
   }
 }
 
-interface Args {
+export interface Args {
   readonly repo: string;
 }
 
-type ParseResult =
+export type ParseResult =
   | { readonly kind: "args"; readonly args: Args }
   | { readonly kind: "error"; readonly message: string };
 
-async function parseArgs(argv: readonly string[]): Promise<ParseResult> {
+async function resolveRepoViaGh(): Promise<string> {
+  const r = await runCmd(["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
+  if (r.exitCode === 0 && r.stdout.trim().length > 0) {
+    return r.stdout.trim();
+  }
+  return "";
+}
+
+export async function parseArgs(
+  argv: readonly string[],
+  resolveDefault: () => Promise<string> = resolveRepoViaGh,
+): Promise<ParseResult> {
   let repo = "";
   let i = 0;
   while (i < argv.length) {
@@ -128,10 +139,7 @@ async function parseArgs(argv: readonly string[]): Promise<ParseResult> {
   }
 
   if (repo.length === 0) {
-    const r = await runCmd(["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
-    if (r.exitCode === 0 && r.stdout.trim().length > 0) {
-      repo = r.stdout.trim();
-    }
+    repo = await resolveDefault();
   }
 
   if (repo.length === 0) {


### PR DESCRIPTION
## Summary

Lands the missing `bun test` for `tools/hygiene/snapshot-github-settings.ts`, closing the first of four gaps in **B-0156** acceptance criterion #2 ("each TS sibling has at least one `bun test` covering its primary entry path").

## What

- Exports two internal helpers (`parseArgs`, `parseJsonSafe`) from `snapshot-github-settings.ts` purely for testability — no behavior change in `main()`.
- `parseArgs` gains an optional `resolveDefault: () => Promise<string>` parameter; default value preserves the existing `gh repo view --json nameWithOwner` fallback, so production behavior is unchanged. Tests inject a deterministic stub.
- Adds `tools/hygiene/snapshot-github-settings.test.ts` (14 tests / 25 expect calls) covering:
  - `parseJsonSafe`: valid object/array, null/empty/invalid input, explicit fallback, no-throw on garbage
  - `parseArgs`: `--repo OWNER/NAME`, positional arg, `--repo` without value error, `GH_REPO` env fallback, argv > env precedence, resolver fallback, no-repo-anywhere error, full precedence chain

## Why

Per `.claude/rules/backlog-item-start-gate.md` step 0 substrate-drift discriminator: B-0156's audit baseline claims phases 3-5 still have work remaining, but on-disk reality (verified at session start) shows all six `.ts` siblings exist AND the `.sh` originals are already deleted. The row is **in-progress, NOT drift** — what remains is acceptance criterion #2 coverage. This PR closes 1/4 of that gap.

Remaining test gaps after this PR (separate bounded slices, each its own PR):
- `tools/hygiene/check-github-settings-drift.ts`
- `tools/peer-call/amara.ts`
- `tools/peer-call/ani.ts`

(Note: the row's audit section under "Phase 3 — Peer-call completion" and "Phase 4 — Profile shell-helper" describes work as remaining; on-disk reality shows it's done. Recommend a follow-up row-update PR to refresh the audit baseline; kept out of this PR to honor "exactly one bounded step".)

## Focused checks

| Check | Result |
|---|---|
| `bun test tools/hygiene/snapshot-github-settings.test.ts` | 14 pass / 0 fail / 25 expect calls |
| `bun test tools/hygiene/` (no regressions in hygiene suite) | 195 pass / 0 fail / 364 expect calls across 11 files |
| `bun --bun build tools/hygiene/snapshot-github-settings.ts` | OK (9.65 KB bundled, no type errors) |
| `git ls-tree HEAD \| wc -l` post-commit canary | 53 (matches `origin/main`; no commit-tree corruption) |
| `gh pr create --head <branch>` (explicit head, parallel-Otto safe) | this PR |

## Test plan

- [ ] CI: `gate.yml` runs `bun test` and exercises the new file
- [ ] No regression in `tools/hygiene/` other suites
- [ ] CodeQL still finds source (canary clean: tree size 53 = `origin/main`)

## Composes with

- B-0156 (parent row — TypeScript standardization)
- `tools/hygiene/check-tick-history-shard-schema.test.ts` (mirrored pattern: export pure entry point, exercise from `bun:test`)
- `.claude/rules/backlog-item-start-gate.md` (substrate-drift step 0 — confirmed row is in-progress, not drift)
- `.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md` (canary tree-size check applied post-commit)
- `.claude/rules/zeta-expected-branch.md` (commit guard + isolated worktree + race-window mitigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)