### PR TITLE
fix(hygiene): tolerate admin-only settings counts in drift snapshot

### DIFF
--- a/tools/hygiene/github-settings.expected.json
+++ b/tools/hygiene/github-settings.expected.json
@@ -41,13 +41,13 @@
         "status": "disabled"
       },
       "secret_scanning_non_provider_patterns": {
-        "status": "disabled"
+        "status": "enabled"
       },
       "secret_scanning_push_protection": {
         "status": "enabled"
       },
       "secret_scanning_validity_checks": {
-        "status": "disabled"
+        "status": "enabled"
       }
     },
     "squash_merge_commit_message": "COMMIT_MESSAGES",
@@ -270,6 +270,11 @@
       "state": "active"
     },
     {
+      "name": "factory-hygiene-audit-cadence",
+      "path": ".github/workflows/factory-hygiene-audit-cadence.yml",
+      "state": "active"
+    },
+    {
       "name": "gate",
       "path": ".github/workflows/gate.yml",
       "state": "active"
@@ -295,6 +300,11 @@
       "state": "active"
     },
     {
+      "name": "memory-index-drift",
+      "path": ".github/workflows/memory-index-drift.yml",
+      "state": "active"
+    },
+    {
       "name": "memory-index-duplicate-lint",
       "path": ".github/workflows/memory-index-duplicate-lint.yml",
       "state": "active"
@@ -307,6 +317,11 @@
     {
       "name": "memory-reference-existence-lint",
       "path": ".github/workflows/memory-reference-existence-lint.yml",
+      "state": "active"
+    },
+    {
+      "name": "pages-build-deployment",
+      "path": "dynamic/pages/pages-build-deployment",
       "state": "active"
     },
     {
@@ -327,6 +342,11 @@
     {
       "name": "role-ref-current-state-surfaces-lint",
       "path": ".github/workflows/role-ref-current-state-surfaces-lint.yml",
+      "state": "active"
+    },
+    {
+      "name": "scaffold-stage1-create-repos",
+      "path": ".github/workflows/scaffold-stage1-create-repos.yml",
       "state": "active"
     },
     {
@@ -353,7 +373,7 @@
     }
   ],
   "pages": {
-    "build_type": "workflow",
+    "build_type": "legacy",
     "https_enforced": true,
     "public": true,
     "source": {

--- a/tools/hygiene/github-settings.expected.json
+++ b/tools/hygiene/github-settings.expected.json
@@ -41,13 +41,13 @@
         "status": "disabled"
       },
       "secret_scanning_non_provider_patterns": {
-        "status": "enabled"
+        "status": "disabled"
       },
       "secret_scanning_push_protection": {
         "status": "enabled"
       },
       "secret_scanning_validity_checks": {
-        "status": "enabled"
+        "status": "disabled"
       }
     },
     "squash_merge_commit_message": "COMMIT_MESSAGES",
@@ -270,11 +270,6 @@
       "state": "active"
     },
     {
-      "name": "factory-hygiene-audit-cadence",
-      "path": ".github/workflows/factory-hygiene-audit-cadence.yml",
-      "state": "active"
-    },
-    {
       "name": "gate",
       "path": ".github/workflows/gate.yml",
       "state": "active"
@@ -300,11 +295,6 @@
       "state": "active"
     },
     {
-      "name": "memory-index-drift",
-      "path": ".github/workflows/memory-index-drift.yml",
-      "state": "active"
-    },
-    {
       "name": "memory-index-duplicate-lint",
       "path": ".github/workflows/memory-index-duplicate-lint.yml",
       "state": "active"
@@ -317,11 +307,6 @@
     {
       "name": "memory-reference-existence-lint",
       "path": ".github/workflows/memory-reference-existence-lint.yml",
-      "state": "active"
-    },
-    {
-      "name": "pages-build-deployment",
-      "path": "dynamic/pages/pages-build-deployment",
       "state": "active"
     },
     {
@@ -342,11 +327,6 @@
     {
       "name": "role-ref-current-state-surfaces-lint",
       "path": ".github/workflows/role-ref-current-state-surfaces-lint.yml",
-      "state": "active"
-    },
-    {
-      "name": "scaffold-stage1-create-repos",
-      "path": ".github/workflows/scaffold-stage1-create-repos.yml",
       "state": "active"
     },
     {
@@ -373,7 +353,7 @@
     }
   ],
   "pages": {
-    "build_type": "legacy",
+    "build_type": "workflow",
     "https_enforced": true,
     "public": true,
     "source": {

--- a/tools/hygiene/snapshot-github-settings.test.ts
+++ b/tools/hygiene/snapshot-github-settings.test.ts
@@ -49,6 +49,10 @@ describe("isInsufficientTokenScope403", () => {
     expect(isInsufficientTokenScope403("gh: Resource not accessible by integration (HTTP 403)")).toBe(true);
   });
 
+  test("matches fine-grained PAT token-scope 403s", () => {
+    expect(isInsufficientTokenScope403("gh: Resource not accessible by personal access token (HTTP 403)")).toBe(true);
+  });
+
   test("matches admin-permission 403s", () => {
     expect(isInsufficientTokenScope403("gh: Must have admin rights to Repository. (HTTP 403)")).toBe(true);
   });

--- a/tools/hygiene/snapshot-github-settings.test.ts
+++ b/tools/hygiene/snapshot-github-settings.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { parseArgs, parseJsonSafe } from "./snapshot-github-settings";
+import { isInsufficientTokenScope403, parseArgs, parseJsonSafe } from "./snapshot-github-settings";
 
 const NULL_RESOLVER = async (): Promise<string> => "";
 
@@ -41,6 +41,28 @@ describe("parseJsonSafe", () => {
   test("returns fallback for invalid JSON instead of throwing", () => {
     expect(parseJsonSafe("not-json", [])).toEqual([]);
     expect(parseJsonSafe("{unterminated", null)).toBeNull();
+  });
+});
+
+describe("isInsufficientTokenScope403", () => {
+  test("matches GitHub Actions token-scope 403s", () => {
+    expect(isInsufficientTokenScope403("gh: Resource not accessible by integration (HTTP 403)")).toBe(true);
+  });
+
+  test("matches admin-permission 403s", () => {
+    expect(isInsufficientTokenScope403("gh: Must have admin rights to Repository. (HTTP 403)")).toBe(true);
+  });
+
+  test("does not match secondary rate limits", () => {
+    expect(isInsufficientTokenScope403("gh: You have exceeded a secondary rate limit. (HTTP 403)")).toBe(false);
+  });
+
+  test("does not match generic 403s without a token-scope signature", () => {
+    expect(isInsufficientTokenScope403("gh: Forbidden (HTTP 403)")).toBe(false);
+  });
+
+  test("does not match non-403 errors", () => {
+    expect(isInsufficientTokenScope403("gh: Not Found (HTTP 404)")).toBe(false);
   });
 });
 

--- a/tools/hygiene/snapshot-github-settings.ts
+++ b/tools/hygiene/snapshot-github-settings.ts
@@ -277,17 +277,17 @@ export async function snapshot(repo: string): Promise<string> {
   );
   const codeql = codeqlRaw === null ? { _skipped: "insufficient-token-scope" } : parseJsonSafe(codeqlRaw);
 
-  // Counts — hooks requires admin token; falls back to a sentinel when the
+  // Counts — these admin-level endpoints fall back to a sentinel when the
   // GITHUB_TOKEN in CI lacks that scope (HTTP 403). Other errors remain fatal
   // so transient API failures are not silently hidden from the drift check.
   const webhooksCountRaw = await ghApiSkip403(`/repos/${repo}/hooks`, "length");
-  const deployKeysCountRaw = await ghApi(`/repos/${repo}/keys`, "length");
-  const actionsSecretsCountRaw = await ghApi(`/repos/${repo}/actions/secrets`, ".secrets | length");
+  const deployKeysCountRaw = await ghApiSkip403(`/repos/${repo}/keys`, "length");
+  const actionsSecretsCountRaw = await ghApiSkip403(`/repos/${repo}/actions/secrets`, ".secrets | length");
   const dependabotSecretsCountRaw = await ghApiOptional(`/repos/${repo}/dependabot/secrets`, ".secrets | length");
 
   const webhooksCount = webhooksCountRaw === null ? { _skipped: "insufficient-token-scope" } : (parseInt(webhooksCountRaw, 10) || 0);
-  const deployKeysCount = parseInt(deployKeysCountRaw, 10) || 0;
-  const actionsSecretsCount = parseInt(actionsSecretsCountRaw, 10) || 0;
+  const deployKeysCount = deployKeysCountRaw === null ? { _skipped: "insufficient-token-scope" } : (parseInt(deployKeysCountRaw, 10) || 0);
+  const actionsSecretsCount = actionsSecretsCountRaw === null ? { _skipped: "insufficient-token-scope" } : (parseInt(actionsSecretsCountRaw, 10) || 0);
   const dependabotSecretsCount = parseInt(dependabotSecretsCountRaw ?? "0", 10) || 0;
 
   const result = {

--- a/tools/hygiene/snapshot-github-settings.ts
+++ b/tools/hygiene/snapshot-github-settings.ts
@@ -32,6 +32,28 @@ interface SpawnResult {
   readonly exitCode: number;
 }
 
+const insufficientTokenScope = { _skipped: "insufficient-token-scope" } as const;
+
+const adminLimitedRepoNullFields = [
+  "allow_auto_merge",
+  "allow_merge_commit",
+  "allow_rebase_merge",
+  "allow_squash_merge",
+  "allow_update_branch",
+  "delete_branch_on_merge",
+  "merge_commit_message",
+  "merge_commit_title",
+  "security_and_analysis",
+  "squash_merge_commit_message",
+  "squash_merge_commit_title",
+  "use_squash_pr_title_as_default",
+] as const;
+
+type OptionalScopeResult =
+  | { readonly kind: "ok"; readonly stdout: string }
+  | { readonly kind: "not-found" }
+  | { readonly kind: "insufficient-token-scope" };
+
 async function runCmd(cmd: readonly string[]): Promise<SpawnResult> {
   const proc = Bun.spawn({
     cmd: [...cmd],
@@ -85,6 +107,24 @@ async function ghApiSkip403(path: string, jqFilter?: string): Promise<string | n
     throw new Error(`gh api ${path} failed (exit ${r.exitCode}): ${r.stderr.trim()}`);
   }
   return r.stdout.trim();
+}
+
+async function ghApiOptionalScopeAware(path: string, jqFilter?: string): Promise<OptionalScopeResult> {
+  const args = ["gh", "api", path];
+  if (jqFilter !== undefined) {
+    args.push("--jq", jqFilter);
+  }
+  const r = await runCmd(args);
+  if (r.exitCode === 0) {
+    return { kind: "ok", stdout: r.stdout.trim() };
+  }
+  if (r.stderr.includes("HTTP 403")) {
+    return { kind: "insufficient-token-scope" };
+  }
+  if (r.stderr.includes("HTTP 404")) {
+    return { kind: "not-found" };
+  }
+  throw new Error(`gh api ${path} failed (exit ${r.exitCode}): ${r.stderr.trim()}`);
 }
 
 export function parseJsonSafe(raw: string | null, fallback: unknown = null): unknown {
@@ -149,10 +189,35 @@ export async function parseArgs(
   return { kind: "args", args: { repo } };
 }
 
+function markAdminLimitedNulls(raw: unknown): unknown {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return raw;
+  }
+
+  const obj = { ...(raw as Record<string, unknown>) };
+  for (const key of adminLimitedRepoNullFields) {
+    if (obj[key] === null) {
+      obj[key] = insufficientTokenScope;
+    }
+  }
+  return obj;
+}
+
+function parseOptionalScopeResult(result: OptionalScopeResult): unknown {
+  if (result.kind === "ok") {
+    return parseJsonSafe(result.stdout);
+  }
+  if (result.kind === "insufficient-token-scope") {
+    return insufficientTokenScope;
+  }
+  return null;
+}
+
 export async function snapshot(repo: string): Promise<string> {
   // Repo metadata
-  const repoJson = parseJsonSafe(
-    await ghApi(`/repos/${repo}`, `{
+  const repoJson = markAdminLimitedNulls(
+    parseJsonSafe(
+      await ghApi(`/repos/${repo}`, `{
       allow_auto_merge, allow_forking, allow_merge_commit, allow_rebase_merge, allow_squash_merge,
       allow_update_branch, archived, custom_properties, default_branch,
       delete_branch_on_merge, description, disabled,
@@ -164,6 +229,7 @@ export async function snapshot(repo: string): Promise<string> {
       use_squash_pr_title_as_default, visibility, web_commit_signoff_required,
       security_and_analysis
     }`)
+    )
   );
 
   const defaultBranch = await ghApi(`/repos/${repo}`, ".default_branch");
@@ -173,8 +239,8 @@ export async function snapshot(repo: string): Promise<string> {
   const topics = parseJsonSafe(topicsRaw, []);
 
   // Automated security fixes (optional endpoint)
-  const autoSecFixRaw = await ghApiOptional(`/repos/${repo}/automated-security-fixes`, "{enabled, paused}");
-  const automatedSecurityFixes = parseJsonSafe(autoSecFixRaw);
+  const autoSecFixResult = await ghApiOptionalScopeAware(`/repos/${repo}/automated-security-fixes`, "{enabled, paused}");
+  const automatedSecurityFixes = parseOptionalScopeResult(autoSecFixResult);
 
   // Private vulnerability reporting (optional endpoint)
   const privVulnRaw = await ghApiOptional(`/repos/${repo}/private-vulnerability-reporting`, "{enabled}");
@@ -200,7 +266,18 @@ export async function snapshot(repo: string): Promise<string> {
 
   // Vulnerability alerts: 204 = enabled, 404 = disabled
   const vulnAlertsResult = await runCmd(["gh", "api", `/repos/${repo}/vulnerability-alerts`]);
-  const vulnerabilityAlertsEnabled = vulnAlertsResult.exitCode === 0;
+  const vulnerabilityAlertsEnabled =
+    vulnAlertsResult.exitCode === 0
+      ? true
+      : vulnAlertsResult.stderr.includes("HTTP 403")
+        ? insufficientTokenScope
+        : vulnAlertsResult.stderr.includes("HTTP 404")
+          ? false
+          : (() => {
+              throw new Error(
+                `gh api /repos/${repo}/vulnerability-alerts failed (exit ${vulnAlertsResult.exitCode}): ${vulnAlertsResult.stderr.trim()}`
+              );
+            })();
 
   // Rulesets
   const rulesetIdsRaw = await ghApiOptional(`/repos/${repo}/rulesets`, "[.[].id] | sort | .[]");
@@ -220,7 +297,7 @@ export async function snapshot(repo: string): Promise<string> {
   }
 
   // Branch protection on default branch (optional — may not exist)
-  const protectionRaw = await ghApiOptional(
+  const protectionResult = await ghApiOptionalScopeAware(
     `/repos/${repo}/branches/${defaultBranch}/protection`,
     `{
       required_status_checks: (.required_status_checks // null | if . then {strict, contexts: (.contexts | sort)} else null end),
@@ -235,12 +312,12 @@ export async function snapshot(repo: string): Promise<string> {
       allow_fork_syncing: .allow_fork_syncing.enabled
     }`
   );
-  const protection = parseJsonSafe(protectionRaw);
+  const protection = parseOptionalScopeResult(protectionResult);
 
   // Actions permissions — requires admin token; falls back to a sentinel when the
   // GITHUB_TOKEN in CI lacks that scope (HTTP 403).
   const actionsPermsRaw = await ghApiOptional(`/repos/${repo}/actions/permissions`, "{enabled, allowed_actions}");
-  const actionsPerms = actionsPermsRaw === null ? { _skipped: "insufficient-token-scope" } : parseJsonSafe(actionsPermsRaw);
+  const actionsPerms = actionsPermsRaw === null ? insufficientTokenScope : parseJsonSafe(actionsPermsRaw);
 
   // Actions variables — requires admin token; falls back to a sentinel when the
   // GITHUB_TOKEN in CI lacks that scope (HTTP 403).
@@ -248,7 +325,7 @@ export async function snapshot(repo: string): Promise<string> {
     `/repos/${repo}/actions/variables`,
     "[.variables[]? | {name, value}] | sort_by(.name)"
   );
-  const actionsVars = actionsVarsRaw === null ? { _skipped: "insufficient-token-scope" } : parseJsonSafe(actionsVarsRaw, []);
+  const actionsVars = actionsVarsRaw === null ? insufficientTokenScope : parseJsonSafe(actionsVarsRaw, []);
 
   // Workflows
   const workflowsRaw = await ghApi(
@@ -275,7 +352,7 @@ export async function snapshot(repo: string): Promise<string> {
     `/repos/${repo}/code-scanning/default-setup`,
     "{state, languages: (.languages | sort), query_suite}"
   );
-  const codeql = codeqlRaw === null ? { _skipped: "insufficient-token-scope" } : parseJsonSafe(codeqlRaw);
+  const codeql = codeqlRaw === null ? insufficientTokenScope : parseJsonSafe(codeqlRaw);
 
   // Counts — these admin-level endpoints fall back to a sentinel when the
   // GITHUB_TOKEN in CI lacks that scope (HTTP 403). Other errors remain fatal
@@ -285,9 +362,9 @@ export async function snapshot(repo: string): Promise<string> {
   const actionsSecretsCountRaw = await ghApiSkip403(`/repos/${repo}/actions/secrets`, ".secrets | length");
   const dependabotSecretsCountRaw = await ghApiOptional(`/repos/${repo}/dependabot/secrets`, ".secrets | length");
 
-  const webhooksCount = webhooksCountRaw === null ? { _skipped: "insufficient-token-scope" } : (parseInt(webhooksCountRaw, 10) || 0);
-  const deployKeysCount = deployKeysCountRaw === null ? { _skipped: "insufficient-token-scope" } : (parseInt(deployKeysCountRaw, 10) || 0);
-  const actionsSecretsCount = actionsSecretsCountRaw === null ? { _skipped: "insufficient-token-scope" } : (parseInt(actionsSecretsCountRaw, 10) || 0);
+  const webhooksCount = webhooksCountRaw === null ? insufficientTokenScope : (parseInt(webhooksCountRaw, 10) || 0);
+  const deployKeysCount = deployKeysCountRaw === null ? insufficientTokenScope : (parseInt(deployKeysCountRaw, 10) || 0);
+  const actionsSecretsCount = actionsSecretsCountRaw === null ? insufficientTokenScope : (parseInt(actionsSecretsCountRaw, 10) || 0);
   const dependabotSecretsCount = parseInt(dependabotSecretsCountRaw ?? "0", 10) || 0;
 
   const result = {

--- a/tools/hygiene/snapshot-github-settings.ts
+++ b/tools/hygiene/snapshot-github-settings.ts
@@ -92,6 +92,27 @@ async function ghApiOptional(path: string, jqFilter?: string): Promise<string | 
   return r.stdout.trim();
 }
 
+export function isInsufficientTokenScope403(stderr: string): boolean {
+  if (!stderr.includes("HTTP 403")) {
+    return false;
+  }
+
+  const lower = stderr.toLowerCase();
+  if (lower.includes("secondary rate limit") || lower.includes("abuse detection") || lower.includes("rate limit")) {
+    return false;
+  }
+
+  return (
+    lower.includes("resource not accessible by integration") ||
+    lower.includes("not accessible by integration") ||
+    lower.includes("must have admin rights") ||
+    lower.includes("requires admin") ||
+    lower.includes("insufficient oauth scope") ||
+    lower.includes("missing the required scope") ||
+    lower.includes("requires one of the following oauth scopes")
+  );
+}
+
 // Like ghApiOptional but only silences HTTP 403 token-scope errors; all other
 // failures are fatal so they don't get silently swallowed by the sentinel path.
 async function ghApiSkip403(path: string, jqFilter?: string): Promise<string | null> {
@@ -101,7 +122,7 @@ async function ghApiSkip403(path: string, jqFilter?: string): Promise<string | n
   }
   const r = await runCmd(args);
   if (r.exitCode !== 0) {
-    if (r.stderr.includes("HTTP 403")) {
+    if (isInsufficientTokenScope403(r.stderr)) {
       return null;
     }
     throw new Error(`gh api ${path} failed (exit ${r.exitCode}): ${r.stderr.trim()}`);
@@ -118,7 +139,7 @@ async function ghApiOptionalScopeAware(path: string, jqFilter?: string): Promise
   if (r.exitCode === 0) {
     return { kind: "ok", stdout: r.stdout.trim() };
   }
-  if (r.stderr.includes("HTTP 403")) {
+  if (isInsufficientTokenScope403(r.stderr)) {
     return { kind: "insufficient-token-scope" };
   }
   if (r.stderr.includes("HTTP 404")) {
@@ -266,18 +287,18 @@ export async function snapshot(repo: string): Promise<string> {
 
   // Vulnerability alerts: 204 = enabled, 404 = disabled
   const vulnAlertsResult = await runCmd(["gh", "api", `/repos/${repo}/vulnerability-alerts`]);
-  const vulnerabilityAlertsEnabled =
-    vulnAlertsResult.exitCode === 0
-      ? true
-      : vulnAlertsResult.stderr.includes("HTTP 403")
-        ? insufficientTokenScope
-        : vulnAlertsResult.stderr.includes("HTTP 404")
-          ? false
-          : (() => {
-              throw new Error(
-                `gh api /repos/${repo}/vulnerability-alerts failed (exit ${vulnAlertsResult.exitCode}): ${vulnAlertsResult.stderr.trim()}`
-              );
-            })();
+  let vulnerabilityAlertsEnabled: boolean | typeof insufficientTokenScope;
+  if (vulnAlertsResult.exitCode === 0) {
+    vulnerabilityAlertsEnabled = true;
+  } else if (isInsufficientTokenScope403(vulnAlertsResult.stderr)) {
+    vulnerabilityAlertsEnabled = insufficientTokenScope;
+  } else if (vulnAlertsResult.stderr.includes("HTTP 404")) {
+    vulnerabilityAlertsEnabled = false;
+  } else {
+    throw new Error(
+      `gh api /repos/${repo}/vulnerability-alerts failed (exit ${vulnAlertsResult.exitCode}): ${vulnAlertsResult.stderr.trim()}`
+    );
+  }
 
   // Rulesets
   const rulesetIdsRaw = await ghApiOptional(`/repos/${repo}/rulesets`, "[.[].id] | sort | .[]");

--- a/tools/hygiene/snapshot-github-settings.ts
+++ b/tools/hygiene/snapshot-github-settings.ts
@@ -104,6 +104,7 @@ export function isInsufficientTokenScope403(stderr: string): boolean {
 
   return (
     lower.includes("resource not accessible by integration") ||
+    lower.includes("resource not accessible by personal access token") ||
     lower.includes("not accessible by integration") ||
     lower.includes("must have admin rights") ||
     lower.includes("requires admin") ||


### PR DESCRIPTION
## Summary

- Treat deploy-key and Actions-secret count endpoints as insufficient-token-scope sentinels instead of hard failing on CI GITHUB_TOKEN 403s.
- Treat known admin-limited repository metadata nulls and 403-limited protection/security endpoints as insufficient-token-scope sentinels.
- Preserve real drift detection for fields readable by an admin token; this PR does not decide whether current live settings drift should be accepted into `tools/hygiene/github-settings.expected.json`.

## Verification

- `git diff --check`
- `tsc --ignoreConfig --noEmit --target esnext --module Preserve --moduleResolution bundler --strict --skipLibCheck --types bun --typeRoots /Users/acehack/Documents/src/repos/Zeta/node_modules/@types --allowImportingTsExtensions --rewriteRelativeImportExtensions --erasableSyntaxOnly tools/hygiene/snapshot-github-settings.ts`
- `bun test tools/hygiene/snapshot-github-settings.test.ts`
- `bun tools/hygiene/check-github-settings-drift.ts --repo Lucent-Financial-Group/Zeta` still reports only live policy drift under the admin token: security-and-analysis subfields, added workflows, and Pages build_type.