### PR TITLE
test(hygiene): cover check-github-settings-drift parseArgs (B-0156 AC#2)

### DIFF
--- a/tools/hygiene/check-github-settings-drift.test.ts
+++ b/tools/hygiene/check-github-settings-drift.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { parseArgs } from "./check-github-settings-drift";
+
+let priorGhRepo: string | undefined;
+
+beforeEach(() => {
+  priorGhRepo = process.env["GH_REPO"];
+  delete process.env["GH_REPO"];
+});
+
+afterEach(() => {
+  if (priorGhRepo === undefined) delete process.env["GH_REPO"];
+  else process.env["GH_REPO"] = priorGhRepo;
+});
+
+describe("parseArgs", () => {
+  test("--repo OWNER/NAME → success and default expected path", async () => {
+    const result = await parseArgs(["--repo", "Lucent-Financial-Group/Zeta"]);
+
+    expect(result.kind).toBe("args");
+    if (result.kind === "args") {
+      expect(result.args.repo).toBe("Lucent-Financial-Group/Zeta");
+      expect(result.args.expected).toMatch(/github-settings\.expected\.json$/);
+    }
+  });
+
+  test("--expected PATH overrides default", async () => {
+    const result = await parseArgs([
+      "--repo",
+      "AceHack/Zeta",
+      "--expected",
+      "/tmp/custom-snapshot.json",
+    ]);
+
+    expect(result.kind).toBe("args");
+    if (result.kind === "args") {
+      expect(result.args.expected).toBe("/tmp/custom-snapshot.json");
+    }
+  });
+
+  test("--repo without value returns an error", async () => {
+    const result = await parseArgs(["--repo"]);
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("--repo requires OWNER/NAME argument");
+    }
+  });
+
+  test("--expected without value returns an error", async () => {
+    const result = await parseArgs(["--repo", "owner/name", "--expected"]);
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("--expected requires PATH argument");
+    }
+  });
+
+  test("unknown flag returns an error", async () => {
+    const result = await parseArgs(["--bogus"]);
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("unknown arg");
+    }
+  });
+
+  test("falls back to GH_REPO env var when no argv", async () => {
+    process.env["GH_REPO"] = "env/zeta";
+    const result = await parseArgs([]);
+
+    expect(result.kind).toBe("args");
+    if (result.kind === "args") {
+      expect(result.args.repo).toBe("env/zeta");
+    }
+  });
+
+  test("explicit --repo overrides GH_REPO env var", async () => {
+    process.env["GH_REPO"] = "env/zeta";
+    const result = await parseArgs(["--repo", "argv/zeta"]);
+
+    expect(result.kind).toBe("args");
+    if (result.kind === "args") {
+      expect(result.args.repo).toBe("argv/zeta");
+    }
+  });
+});

--- a/tools/hygiene/check-github-settings-drift.ts
+++ b/tools/hygiene/check-github-settings-drift.ts
@@ -54,7 +54,7 @@ type ParseResult =
   | { readonly kind: "args"; readonly args: Args }
   | { readonly kind: "error"; readonly message: string };
 
-async function parseArgs(argv: readonly string[]): Promise<ParseResult> {
+export async function parseArgs(argv: readonly string[]): Promise<ParseResult> {
   let repo = "";
   let expected = resolve(SCRIPT_DIR, "github-settings.expected.json");
   let i = 0;


### PR DESCRIPTION
## Summary

Closes one of three B-0156 Acceptance Criterion #2 gaps by adding `tools/hygiene/check-github-settings-drift.test.ts` (7 tests, 15 expects). Exports `parseArgs` from the drift checker so its argv parsing paths are testable; no behavior change to the CLI.

B-0156 AC#2 requires each non-install `.sh→.ts` port to have at least one `bun test` covering its primary entry path. Audit on 2026-05-17 found:

| Port | Test status |
|---|---|
| `tools/hygiene/snapshot-github-settings.ts` | ✓ has test |
| `tools/hygiene/check-github-settings-drift.ts` | **this PR** |
| `tools/hygiene/check-tick-history-shard-schema.ts` | ✓ has test |
| `tools/peer-call/amara.ts` | follow-up |
| `tools/peer-call/ani.ts` | follow-up |
| `tools/profile.ts` | ✓ has test |

## Coverage

Mirrors `tools/hygiene/snapshot-github-settings.test.ts` conventions (sibling-port `parseArgs` tests, hermetic `GH_REPO` save/restore, no `gh` CLI dependency).

- `--repo OWNER/NAME` with default expected path
- `--expected PATH` override
- `--repo` / `--expected` without value (error paths)
- unknown flag error path
- `GH_REPO` env var fallback
- argv > env precedence

The `gh repo view` fallback path (last-resort default resolution) is intentionally not covered here — the sibling test takes the same approach, and a hermetic CLI mock is outside the bounded scope of this slice.

## Substrate-drift note (B-0156 row body)

B-0156's row body claims **3 `.sh` ports remaining**:

- `tools/profile.sh`
- `tools/peer-call/amara.sh`
- `tools/peer-call/ani.sh`

All 3 are **already ported AND their `.sh` siblings deleted on disk**. The remaining real work on B-0156 is the AC#2 test-coverage gap (3 of 6 ports lack tests), not porting. A follow-up row update is appropriate but outside this slice's bounded scope per the "exactly one bounded step" discipline.

## Test plan

- [x] `bun test tools/hygiene/check-github-settings-drift.test.ts` → 7 pass / 0 fail / 15 expects
- [x] `bun test tools/hygiene/snapshot-github-settings.test.ts` regression check → 14 pass / 0 fail (unchanged; export was additive)
- [x] CLI smoke: `bun tools/hygiene/check-github-settings-drift.ts --bogus` exits 2 with "unknown arg" (expected)
- [x] Worktree freshness canary: `git ls-tree HEAD | wc -l = 53` (matches expected; no commit-tree corruption per `.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`)
- [ ] CI gate

operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)