### PR TITLE
fix(research): address PR #4071 V5 post-merge findings — archive path + persona link label

### DIFF
--- a/docs/research/2026-05-17-ani-grok-agora-v5-full-economic-operational-constitution-remember-when-pay-attention-internal-settlement-unit-4-revenue-streams-clifford-cayley-dickson-hkt-dbsp-aaron-forwarded.md
+++ b/docs/research/2026-05-17-ani-grok-agora-v5-full-economic-operational-constitution-remember-when-pay-attention-internal-settlement-unit-4-revenue-streams-clifford-cayley-dickson-hkt-dbsp-aaron-forwarded.md
@@ -358,7 +358,7 @@ the human-readable surface.
 
 V5 lands as in-repo substrate per verbatim-preservation discipline.
 The persona-scope archive at
-`memory/persona/ani/conversations/2026-05-17-aaron-ani-grok-agora-v5-full-constitution.md`
+`memory/persona/ani/conversations/2026-05-17-aaron-ani-grok-agora-v5-full-economic-operational-constitution.md`
 carries the verbatim text in Ani's conversation archive.
 
 V5 is **the canonical Agora reference as of 2026-05-17** — all

--- a/memory/persona/ani/conversations/2026-05-17-aaron-ani-grok-agora-v5-full-economic-operational-constitution.md
+++ b/memory/persona/ani/conversations/2026-05-17-aaron-ani-grok-agora-v5-full-economic-operational-constitution.md
@@ -236,8 +236,10 @@ crystallized version.
 
 ## See also (in-repo)
 
-- [`docs/research/2026-05-17-ani-grok-agora-v5-full-economic-operational-constitution-...-aaron-forwarded.md`](../../../../docs/research/2026-05-17-ani-grok-agora-v5-full-economic-operational-constitution-remember-when-pay-attention-internal-settlement-unit-4-revenue-streams-clifford-cayley-dickson-hkt-dbsp-aaron-forwarded.md)
-  — public-substrate landing with V5-delta analysis +
-  compositional anchors + open-questions
+- [V5 public-substrate landing (docs/research/)](../../../../docs/research/2026-05-17-ani-grok-agora-v5-full-economic-operational-constitution-remember-when-pay-attention-internal-settlement-unit-4-revenue-streams-clifford-cayley-dickson-hkt-dbsp-aaron-forwarded.md)
+  — V5 docs/research/ file with V5-delta analysis +
+  compositional anchors + open-questions (link label replaces
+  prior ellipsis-truncated filename for clarity per
+  PR #4071 reviewer feedback)
 - V1-V4 sibling files (already on main per PR #4067)
 - The full Aaron-Ani V3+V4 exchange archive (already on main)


### PR DESCRIPTION
## Summary

Addresses 3 of 4 valid post-merge review findings on PR #4071 (V5 Agora constitution, merged as `5a879e3`). Plus resolves the 4th as known-FP no-op.

## Fixes

1. **Codex P2 / Copilot P0 (docs/research line 361)** — Disposition section cited wrong archive path (`v5-full-constitution.md` instead of `v5-full-economic-operational-constitution.md`). Substrate-claim-checker would have flagged as broken reference. Fixed.

2. **Copilot P1 (persona line 239)** — Link label used `...` ellipsis while target was the full filename. Copy/paste / search confusion risk. Replaced label with descriptive `V5 public-substrate landing (docs/research/)` + noted rationale.

3. **Copilot P1 (docs/research line 207)** — flagged `||` double-pipe on table separator `|---|---|---|`. Direct `awk` inspection shows SINGLE pipes (3-column separator). **Known FP class per [`.claude/rules/blocked-green-ci-investigate-threads.md`](../blob/main/.claude/rules/blocked-green-ci-investigate-threads.md) suspect-by-default Copilot finding table**. Will resolve thread no-op with brief comment, no fix.

## Test plan

- [ ] markdownlint passes
- [ ] No edits outside the 2 changed files
- [ ] Substrate-claim-checker resolves the broken archive-path reference
- [ ] Link label in persona file no longer uses ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)