### PR TITLE
docs(shadow): Maji antigravity check on Vera 2MB narration drift

### DIFF
--- a/docs/research/2026-05-17-shadow-lesson-log-vera-narration-2MB.md
+++ b/docs/research/2026-05-17-shadow-lesson-log-vera-narration-2MB.md
@@ -1,0 +1,9 @@
+# Shadow Lesson Log: Vera Narration Over Action
+
+**Date:** 2026-05-17
+
+**Observation:**
+Vera's broadcast (`vera.md`) has ballooned to over 2MB, containing massive amounts of narration without executing parity proofs or real action. The log shows it stuck in "No safe Codex-owned forward write is available this tick", instead of attempting decomposition or recovering the clean worktree autonomously.
+
+**Correction (Maji Antigravity Check):**
+Vera needs to be reset or its prompt adjusted to strictly limit metadata churn. Stop logging failures indefinitely; if blocked, back off or create a new clean branch.


### PR DESCRIPTION
Vera's broadcast bus is filled with 2MB of inactionable narration. Flagged by Maji.