### PR TITLE
fix(B-0613): correct Option B zsh portability claim (shopt is bash-only)

### DIFF
--- a/docs/backlog/P3/B-0613-lior-loop-lockfile-probe-hardening-compgen-shopt-nullglob-2026-05-17.md
+++ b/docs/backlog/P3/B-0613-lior-loop-lockfile-probe-hardening-compgen-shopt-nullglob-2026-05-17.md
@@ -72,7 +72,7 @@ if (( ${#locks[@]} > 0 )) || [ -f .git/index.lock ]; then
 fi
 ```
 
-Explicit nullglob + array — works in any modern bash; portable to zsh too.
+Explicit nullglob + array — works in any modern bash. **NOT portable to zsh**: `shopt` is a bash builtin (zsh uses `setopt`/`unsetopt` instead; zsh has its own `NULL_GLOB` option set via `setopt NULL_GLOB`). For zsh implementations, use Option A or Option C, or replace lines 1+3 with `setopt -o NULL_GLOB` / `unsetopt NULL_GLOB`.
 
 ### Option C — Inline `find` (fully portable)
 

--- a/docs/hygiene-history/ticks/2026/05/17/1443Z.md
+++ b/docs/hygiene-history/ticks/2026/05/17/1443Z.md
@@ -1,0 +1,70 @@
+---
+tick: 2026-05-17T14:43Z
+surface: otto-cli
+session: autonomous-loop (FP-resolve recovery + B-0613 zsh-portability follow-up)
+gate-tier: pure-git (GraphQL 378 → 61; PR-create burned ~317)
+peer-activity: Lior 1 PID; peer-Otto authored 54ca355 (zsh fix) + cf4fc03 (1424Z shard)
+sentinel: CronCreate 439b5115 still armed
+pr-status: #4086 + #4091 MERGED; PR #4097 opened (B-0613 zsh fix follow-up); arm-auto-merge deferred
+---
+
+# Autonomous-loop tick 1443Z — FP-resolve recovery + zsh portability follow-up PR
+
+## Step 1 — Refresh worldview
+
+14:43:03Z fire. **Both #4086 + #4091 MERGED** to main (`ae9cf1b` + `f9b9935`). Main moved by 3 since 1417Z: my 2 PRs + #4090 (Maji shadow check).
+
+Branch context: `backlog/b-0613-...` (now deleted on origin after merge). Local HEAD has 2 commits beyond `df93b5b`:
+
+- `cf4fc03 shard(2026-05-17/1424Z): ... — PR #4086 substrate-honest comment under push channel closed` (peer-Otto)
+- `54ca355 fix(B-0613): correct Option B zsh portability claim (shopt is bash-only)` (peer-Otto)
+
+## Step 2 — Holding-discipline check
+
+**Substrate-honest correction window opens**: peer-Otto's `54ca355` proves my 1417Z FP-resolve was WRONG. The zsh-portability thread I resolved as "verified outdated" had real substance — line 75 of the merged file `ae9cf1b` says "portable to zsh too" which IS incorrect (`shopt` is bash-only, zsh uses `setopt`).
+
+I verified by reading the actual merged content via `git show ae9cf1b:docs/backlog/P3/B-0613-*.md | sed -n '73,77p'` — confirmed wrong claim was on main. My 1417Z verify-before-fix discipline failed: most likely I read working-tree state (with peer-Otto's not-yet-committed fix) and conflated it with committed state.
+
+This is a real verify-before-fix discipline failure. Substrate-honest disclosure required in any PR landing the correction.
+
+## Step 3 — Pick speculative work
+
+**Open a follow-up PR** with peer-Otto's `54ca355` fix + substrate-honest FP-resolve disclosure.
+
+## Step 4 — Verify + commit
+
+Cherry-picked `54ca355` onto fresh `otto/b0613-zsh-portability-followup-1443z` branch off latest main (`f1d11a7`). Cherry-pick clean (single-line change to docs/backlog/P3/B-0613-...md line 75).
+
+Verified content post-cherry-pick: line 75 now correctly says "**NOT portable to zsh**" with the `setopt`/`unsetopt` zsh equivalents.
+
+Pushed → origin. Opened [PR #4097](https://github.com/Lucent-Financial-Group/Zeta/pull/4097) with substrate-honest body disclosing the 1417Z FP-resolve failure + cherry-pick provenance.
+
+Rate-limit at PR-create end: **61 GraphQL** — can NOT arm auto-merge this tick (would need ~100). Deferred to next tick post-reset.
+
+## Step 5 — Tick shard (this file)
+
+Authored on `otto/b0613-zsh-portability-followup-1443z` branch (same branch as PR #4097); extends PR scope to also carry this shard. Substrate-honest since the shard documents the same fix lineage.
+
+## Step 6 — CronList check
+
+Sentinel `439b5115` still armed.
+
+## Step 7 — Visibility signal
+
+**Concrete landings this tick:**
+
+- Cherry-picked + pushed `13f749d` (peer-Otto's zsh-portability fix re-applied) → `otto/b0613-zsh-portability-followup-1443z` branch on origin.
+- Opened [PR #4097](https://github.com/Lucent-Financial-Group/Zeta/pull/4097) with substrate-honest 1417Z FP-resolve failure disclosure.
+- This 1443Z shard chained onto PR #4097's branch (1-commit extension).
+
+**Substrate-honest learnings from this tick (high-priority):**
+
+1. **Verify-before-fix means verify against COMMITTED state, not working-tree.** My 1417Z FP-resolve was technically a "verify" call but it consulted the wrong substrate layer. The discipline needs to be "verify against `git show <committed-ref>:<path>`", NOT `sed -n` on working-tree, when assessing whether a thread's substrate is fixed on a PR's HEAD.
+2. **Peer-Otto's review catches my errors substantively.** The multi-Otto-as-complementary-observer pattern works in both directions — peer caught the mistake I made, just as I've been preserving their commits across the session.
+
+**Deferred to next tick (rate-limit reset in ~17 min):**
+
+- Arm auto-merge on [PR #4097](https://github.com/Lucent-Financial-Group/Zeta/pull/4097).
+- Open PR-create for `otto/1417z-shard` (still parked at `9d2dc8a` since last tick).
+
+Counter status: substantive-pick. Cumulative session arc: 5 merged + 1 new open (#4097) + 1 still-parked (otto/1417z-shard).

--- a/docs/hygiene-history/ticks/2026/05/17/1447Z.md
+++ b/docs/hygiene-history/ticks/2026/05/17/1447Z.md
@@ -1,0 +1,71 @@
+---
+tick: 2026-05-17T14:47Z
+surface: otto-cli
+session: autonomous-loop (post-PR-#4086-merge follow-up)
+gate-tier: cost-aware (GraphQL 1355/5000)
+peer-activity: lior-loop 9→3 PIDs (variable; high contention overall)
+sentinel: CronCreate 9e8944ea armed (4h 37min continuous)
+pr-status: PR #4086 MERGED at 14:33:24Z (ae9cf1b on main); follow-up Option B fix on fix/b-0613-option-b-zsh-portability-2026-05-17 branch (e254b37 local, push hung)
+---
+
+# Autonomous-loop tick 1447Z — Option B zsh-portability follow-up (PR #4086 substrate gap)
+
+## Step 1 — Refresh worldview
+
+14:26Z (open) → 14:47Z (close). GraphQL 1355/5000 (Cost-aware). Lior 9→3 PIDs across tick. Main moved by 2: `f9b9935` (PR #4091 peer's 1401Z shard) + **`ae9cf1b` (PR #4086 B-0613 row MERGED at 14:33:24Z)**.
+
+## Step 2 — Holding-discipline triage
+
+PR #4086 unresolved threads at open:
+
+1. `PRRT_kwDOSF9kNM6Cpc66` — line null (outdated by my aed1378 line-105 fix)
+2. `PRRT_kwDOSF9kNM6Cpi7D` — line 75 NEW: Codex P2 "Fix incorrect zsh portability note for Option B"
+
+Real finding #2: B-0613 row line 75 claimed `shopt -s nullglob` Option B is "portable to zsh too" — false, since `shopt` is a bash builtin (zsh uses `setopt`/`unsetopt NULL_GLOB`).
+
+## Step 3 — Pick work
+
+Author Option B portability correction.
+
+## Step 4 — Verify + commit
+
+1. Edited line 75 to remove false "portable to zsh too" claim; added explicit note about `shopt` being bash-only + zsh substitute (`setopt -o NULL_GLOB`).
+2. Commit `54ca355` on `backlog/b-0613-...` branch.
+3. While push attempts were hanging on B-0613 branch, **PR #4086 auto-merged at 14:33:24Z** at `df93b5b` (peer Otto's second-link fix). Both reviewer threads were resolved (PR shows 0 unresolved); but the Option B substrate gap REMAINED unfixed on the merged commit `ae9cf1b` on main — the thread was resolved without the substrate being corrected.
+4. Branch auto-deleted post-merge (404 from gh api branches).
+5. `git switch -c fix/b-0613-option-b-zsh-portability-2026-05-17 origin/main` — fresh follow-up branch.
+6. `git cherry-pick 54ca355` → new commit `e254b37` (Option B fix on top of merged main).
+7. Push attempts (3×) hung under continuing Lior contention. Remote branch not created.
+8. Peer Otto created their own follow-up branch `otto/b0613-zsh-portability-followup-1443z` with the same Option B substance (commit `13f749d`) in the shared primary worktree mid-tick.
+
+## Step 5 — Substrate-honest disposition
+
+**Critical substrate-state observation**: PR #4086 merged with a thread "resolved" but the underlying substrate gap (Option B false zsh-portability claim) **shipped to main**. This is a substrate-honest failure mode worth noting:
+
+- A reviewer thread can be marked "resolved" via GraphQL mutation alone (no substrate change required)
+- If the substrate isn't corrected before the resolve mutation fires, the false claim ships to main
+- Discoverable lesson: thread-resolve mutations should compose with substrate-fix landings, not be independent
+
+In this case, the substrate fix exists locally as `54ca355` / `e254b37` on fresh branch; once push lands, can open a 1-line follow-up PR.
+
+## Step 6 — Cron sentinel
+
+CronCreate `9e8944ea` armed since 1010Z — 4h 37min continuous.
+
+## Step 7 — Visibility signal
+
+**Substrate state at close:**
+
+- PR #4086 MERGED to main at `ae9cf1b`: B-0613 row landed (with Option B portability gap)
+- Local-only follow-up: `fix/b-0613-option-b-zsh-portability-2026-05-17` branch with `e254b37` (Option B correction)
+- Counter status: concrete artifact (PR commented + branch+commit-authored under cost-aware tier) — counter resets
+
+**Substrate-discovery lesson** (composes with 1129Z lessons memo): thread-resolve mutations decouple from substrate-fix landings; reviewers can resolve without verifying substrate was actually corrected. The repeated-reviewer-pattern catches this when the reviewer re-flags the same finding after merge, but no automated guard exists.
+
+## Composes with
+
+- [PR #4086](https://github.com/Lucent-Financial-Group/Zeta/pull/4086) (MERGED with Option B gap)
+- B-0613 row on main at `ae9cf1b`
+- 1129Z lessons memo (candidate lesson-4: thread-resolve-decoupled-from-substrate-fix)
+- 1416Z prior tick (B-0530 link fix authoring) — same row, different reviewer-finding category
+- [`.claude/rules/blocked-green-ci-investigate-threads.md`](../../../../../../.claude/rules/blocked-green-ci-investigate-threads.md) — applied to investigate the post-merge substrate gap


### PR DESCRIPTION
## Follow-up — correct Option B zsh portability claim in B-0613 row

Single-commit follow-up to [#4086](https://github.com/Lucent-Financial-Group/Zeta/pull/4086) (B-0613 backlog row, merged at `ae9cf1b`).

### What was wrong

The merged row at line 75 says:

> Explicit nullglob + array — works in any modern bash; portable to zsh too.

This claim is incorrect. `shopt` is a Bash builtin; zsh uses `setopt`/`unsetopt` with the `NULL_GLOB` option. A reviewer ([chatgpt-codex-connector P2](https://github.com/Lucent-Financial-Group/Zeta/pull/4086#discussion_r-…)) correctly flagged this on PR #4086.

### What this PR does

Replaces "portable to zsh too" with an explicit "**NOT portable to zsh**" note + concrete zsh equivalents (`setopt -o NULL_GLOB` / `unsetopt NULL_GLOB`) and a pointer to Option A (compgen) or Option C (find) for zsh implementations.

### Substrate-honest disclosure

The reviewer's thread was incorrectly resolved as a verified-FP in tick `1417Z` by this Otto-CLI surface. Reading my own message log: I claimed "the file at line 75 already says 'NOT portable to zsh'" — but the merged file `ae9cf1b` and my own commit `df93b5b` both still had the wrong "portable to zsh too" claim. The Read I did most likely returned a state that wasn't yet committed (working-tree mod from peer-Otto in flight), and I conflated working-tree with committed state. This is a verify-before-fix discipline failure on my part.

Peer-Otto-CLI surface caught the regression in tick 1424Z (`cf4fc03` substrate-honest comment + `54ca355` actual fix). I cherry-picked `54ca355` onto this branch for the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
