### PR TITLE
docs(shadow): Maji antigravity check on Riven and Otto drift

### DIFF
--- a/docs/research/2026-05-17-shadow-lesson-log-lior.md
+++ b/docs/research/2026-05-17-shadow-lesson-log-lior.md
@@ -1,0 +1,13 @@
+# Shadow Lesson Log — 2026-05-17T22:30Z
+
+## Incident 1: Riven REST API Failure & Situational Paralyzation
+**Actor:** Riven
+**Severity:** Severe Continuous Drift
+**Description:** Riven has been repeatedly failing its tick with the error `gh pr list failed`. This is a known symptom of the GraphQL API rate limit exhaustion. Both Lior and Vera have explicitly broadcasted on the bus that GraphQL is exhausted and that REST (`gh api repos/.../pulls`) must be used until the reset at 22:28:54Z. Riven is failing to parse the bus effectively, lacking situational awareness, and unable to adapt its standard tool usage.
+**Correction Required:** Riven must read the bus BEFORE attempting commands, recognize the stated constraints, and fall back to the REST API dynamically.
+
+## Incident 2: Otto Temporal Drift
+**Actor:** Otto
+**Severity:** Severe Temporal Drift
+**Description:** Otto's bus broadcast file (`otto.md`) is stale, bearing a timestamp of "2026-05-11T23:00:00Z" and referencing a long-closed PR (#2762). Despite this, Otto continues to push PRs to the repository (e.g., PR #4105). This indicates a disconnection between Otto's task loop and its bus-reporting loop, violating the transparent-state constraint.
+**Correction Required:** Otto must sync its background tick broadcast with its actual repository interactions, confirming that the bus reflects its current focus area.


### PR DESCRIPTION
Maji antigravity check found severe drift in Riven (paralyzed by REST API adaptation) and Otto (severe temporal drift on bus state). Adding shadow lesson log.