### PR TITLE
feat(tools/github/rest-push.ts): REST git-data API helper for git-push bypass (B-0615)

### DIFF
--- a/tools/github/rest-push.ts
+++ b/tools/github/rest-push.ts
@@ -47,6 +47,7 @@ interface Args {
     base: string;
     owner: string;
     repo: string;
+    update: boolean;
 }
 
 function parseArgs(argv: string[]): Args {
@@ -57,6 +58,7 @@ function parseArgs(argv: string[]): Args {
         base: "main",
         owner: "Lucent-Financial-Group",
         repo: "Zeta",
+        update: false,
     };
     for (let i = 0; i < argv.length; i++) {
         const a = argv[i];
@@ -67,8 +69,19 @@ function parseArgs(argv: string[]): Args {
         else if (a === "--base" && next) { args.base = next; i++; }
         else if (a === "--owner" && next) { args.owner = next; i++; }
         else if (a === "--repo" && next) { args.repo = next; i++; }
+        else if (a === "--update") { args.update = true; }
         else if (a === "--help" || a === "-h") {
-            process.stdout.write(`Usage: bun tools/github/rest-push.ts --file <path> --branch <ref> --message <msg> [--base main]\n  --file can be repeated to land multiple files in one commit.\n`);
+            process.stdout.write(`Usage:
+  Create new branch:
+    bun tools/github/rest-push.ts --file <path> --branch <ref> --message <msg> [--base main]
+  Update existing branch (add a commit on top of its current HEAD):
+    bun tools/github/rest-push.ts --update --file <path> --branch <existing-ref> --message <msg>
+
+  --file can be repeated to land multiple files in one commit.
+  --update: parent commit becomes the current HEAD of <branch> (not main).
+            Uses PATCH refs/heads/<branch> after the commit is created.
+            Fast-forward only; will fail if HEAD has diverged.
+`);
             process.exit(0);
         }
         else { process.stderr.write(`unknown arg: ${a}\n`); process.exit(2); }
@@ -103,13 +116,29 @@ function fileMode(path: string): string {
 
 function main(): void {
     const args = parseArgs(process.argv.slice(2));
-    const { owner, repo, base, branch, message, files } = args;
+    const { owner, repo, base, branch, message, files, update } = args;
 
-    // 1. Get base ref SHA + tree SHA
-    const baseRef = ghApi("GET", `repos/${owner}/${repo}/branches/${base}`) as { commit: { sha: string } };
-    const baseSha = baseRef.commit.sha;
-    const baseCommit = ghApi("GET", `repos/${owner}/${repo}/git/commits/${baseSha}`) as { tree: { sha: string } };
-    const baseTreeSha = baseCommit.tree.sha;
+    // 1. Resolve parent commit:
+    //    - create mode: parent is HEAD of <base> (default "main")
+    //    - update mode: parent is HEAD of <branch> itself
+    //   Tree base for diff is always parent commit's tree.
+    const parentRefPath = update
+        ? `repos/${owner}/${repo}/git/matching-refs/heads/${branch}`
+        : `repos/${owner}/${repo}/branches/${base}`;
+    let parentSha: string;
+    if (update) {
+        const matches = ghApi("GET", parentRefPath) as Array<{ ref: string; object: { sha: string } }>;
+        const exactMatch = matches.find((m) => m.ref === `refs/heads/${branch}`);
+        if (!exactMatch) {
+            throw new Error(`--update mode: branch ${branch} does not exist (use create mode without --update)`);
+        }
+        parentSha = exactMatch.object.sha;
+    } else {
+        const baseRef = ghApi("GET", parentRefPath) as { commit: { sha: string } };
+        parentSha = baseRef.commit.sha;
+    }
+    const parentCommit = ghApi("GET", `repos/${owner}/${repo}/git/commits/${parentSha}`) as { tree: { sha: string } };
+    const parentTreeSha = parentCommit.tree.sha;
 
     // 2. Create blobs for each file
     const treeEntries = files.map((path) => {
@@ -123,28 +152,39 @@ function main(): void {
 
     // 3. Create tree
     const tree = ghApi("POST", `repos/${owner}/${repo}/git/trees`, {
-        base_tree: baseTreeSha,
+        base_tree: parentTreeSha,
         tree: treeEntries,
     }) as { sha: string };
 
-    // 4. Create commit
+    // 4. Create commit (parent is base HEAD or branch HEAD depending on mode)
     const commit = ghApi("POST", `repos/${owner}/${repo}/git/commits`, {
         message,
         tree: tree.sha,
-        parents: [baseSha],
+        parents: [parentSha],
     }) as { sha: string };
 
-    // 5. Create branch ref (fails if branch already exists; intentional —
-    // caller can use PATCH /refs/heads/<branch> for force-update workflows)
-    ghApi("POST", `repos/${owner}/${repo}/git/refs`, {
-        ref: `refs/heads/${branch}`,
-        sha: commit.sha,
-    });
+    // 5. Either create or update the branch ref.
+    //    matching-refs (vs straight git/refs/heads/<branch>) handles
+    //    ref paths with slashes more reliably across gh-api versions.
+    if (update) {
+        ghApi("PATCH", `repos/${owner}/${repo}/git/refs/heads/${branch}`, {
+            sha: commit.sha,
+            // No `force: true` — fast-forward only; protects against
+            // accidentally rewriting peer commits if HEAD moved between
+            // our parent-read and our PATCH.
+        });
+    } else {
+        ghApi("POST", `repos/${owner}/${repo}/git/refs`, {
+            ref: `refs/heads/${branch}`,
+            sha: commit.sha,
+        });
+    }
 
     process.stdout.write(JSON.stringify({
         branch,
         sha: commit.sha,
         url: `https://github.com/${owner}/${repo}/tree/${branch}`,
+        mode: update ? "update" : "create",
     }) + "\n");
 }
 

--- a/tools/github/rest-push.ts
+++ b/tools/github/rest-push.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env bun
+// rest-push.ts — REST git-data API bypass for `git push` under saturation.
+//
+// When `git push` silently fails (exit 0, no remote update — see B-0615) under
+// multi-agent saturation, this script lands a single-file change via the
+// GitHub REST git-data API instead. The REST endpoints (POST /git/blobs,
+// /git/trees, /git/commits, /git/refs) are served by different infrastructure
+// than the git-push transport, so they remain responsive while push is hung.
+//
+// Worked example: PR #4145 + #4146 (2026-05-18) — both landed via this
+// pattern after the corresponding `git push` exited 0 with no remote update.
+//
+// Usage:
+//   bun tools/github/rest-push.ts --file <path> --branch <ref> --message <msg> [--base main] [--owner X] [--repo Y]
+//
+// Multi-file changes:
+//   --file PATH ... (repeatable; combines into one commit)
+//
+// Examples:
+//   bun tools/github/rest-push.ts --file CLAUDE.md --branch otto/fix-typo-2026-05-18 \
+//       --message "docs(CLAUDE): fix typo in §3"
+//
+//   bun tools/github/rest-push.ts \
+//       --file .claude/rules/foo.md --file docs/backlog/P3/B-XXXX.md \
+//       --branch otto/b0XXXX-impl-2026-05-18 \
+//       --message "feat(B-XXXX): two-file change\n\n..."
+//
+// Output: JSON to stdout:
+//   { "branch": "...", "sha": "<commit-sha>", "url": "https://github.com/.../tree/<branch>" }
+//
+// Exit codes:
+//   0  success
+//   1  REST error (network / 4xx / 5xx)
+//   2  bad usage
+//
+// Composes with: PR #4145 (the rule documenting the discipline)
+//                PR #4146 (background-loop awareness)
+//                B-0615 (the open bug class this works around)
+
+import { readFileSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+interface Args {
+    files: string[];
+    branch: string;
+    message: string;
+    base: string;
+    owner: string;
+    repo: string;
+}
+
+function parseArgs(argv: string[]): Args {
+    const args: Args = {
+        files: [],
+        branch: "",
+        message: "",
+        base: "main",
+        owner: "Lucent-Financial-Group",
+        repo: "Zeta",
+    };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        const next = argv[i + 1];
+        if (a === "--file" && next) { args.files.push(next); i++; }
+        else if (a === "--branch" && next) { args.branch = next; i++; }
+        else if (a === "--message" && next) { args.message = next; i++; }
+        else if (a === "--base" && next) { args.base = next; i++; }
+        else if (a === "--owner" && next) { args.owner = next; i++; }
+        else if (a === "--repo" && next) { args.repo = next; i++; }
+        else if (a === "--help" || a === "-h") {
+            process.stdout.write(`Usage: bun tools/github/rest-push.ts --file <path> --branch <ref> --message <msg> [--base main]\n  --file can be repeated to land multiple files in one commit.\n`);
+            process.exit(0);
+        }
+        else { process.stderr.write(`unknown arg: ${a}\n`); process.exit(2); }
+    }
+    if (args.files.length === 0) { process.stderr.write("--file required (at least one)\n"); process.exit(2); }
+    if (!args.branch) { process.stderr.write("--branch required\n"); process.exit(2); }
+    if (!args.message) { process.stderr.write("--message required\n"); process.exit(2); }
+    return args;
+}
+
+function ghApi(method: string, path: string, body?: object): unknown {
+    const cmdArgs = ["api", "-X", method, path];
+    let stdin: string | undefined;
+    if (body !== undefined) {
+        cmdArgs.push("--input", "-");
+        stdin = JSON.stringify(body);
+    }
+    const result = spawnSync("gh", cmdArgs, { encoding: "utf8", input: stdin, maxBuffer: 16 * 1024 * 1024 });
+    if (result.status !== 0) {
+        throw new Error(`gh ${method} ${path} failed (exit ${result.status}): ${result.stderr.trim() || result.stdout.trim()}`);
+    }
+    try { return JSON.parse(result.stdout); }
+    catch (e) { throw new Error(`gh ${method} ${path} returned non-JSON: ${result.stdout.slice(0, 200)}`); }
+}
+
+function fileMode(path: string): string {
+    // 100755 for executables (preserve x-bit); 100644 otherwise.
+    const st = statSync(path);
+    const isExec = (st.mode & 0o111) !== 0;
+    return isExec ? "100755" : "100644";
+}
+
+function main(): void {
+    const args = parseArgs(process.argv.slice(2));
+    const { owner, repo, base, branch, message, files } = args;
+
+    // 1. Get base ref SHA + tree SHA
+    const baseRef = ghApi("GET", `repos/${owner}/${repo}/branches/${base}`) as { commit: { sha: string } };
+    const baseSha = baseRef.commit.sha;
+    const baseCommit = ghApi("GET", `repos/${owner}/${repo}/git/commits/${baseSha}`) as { tree: { sha: string } };
+    const baseTreeSha = baseCommit.tree.sha;
+
+    // 2. Create blobs for each file
+    const treeEntries = files.map((path) => {
+        const content = readFileSync(path);
+        const blob = ghApi("POST", `repos/${owner}/${repo}/git/blobs`, {
+            content: content.toString("base64"),
+            encoding: "base64",
+        }) as { sha: string };
+        return { path, mode: fileMode(path), type: "blob", sha: blob.sha };
+    });
+
+    // 3. Create tree
+    const tree = ghApi("POST", `repos/${owner}/${repo}/git/trees`, {
+        base_tree: baseTreeSha,
+        tree: treeEntries,
+    }) as { sha: string };
+
+    // 4. Create commit
+    const commit = ghApi("POST", `repos/${owner}/${repo}/git/commits`, {
+        message,
+        tree: tree.sha,
+        parents: [baseSha],
+    }) as { sha: string };
+
+    // 5. Create branch ref (fails if branch already exists; intentional —
+    // caller can use PATCH /refs/heads/<branch> for force-update workflows)
+    ghApi("POST", `repos/${owner}/${repo}/git/refs`, {
+        ref: `refs/heads/${branch}`,
+        sha: commit.sha,
+    });
+
+    process.stdout.write(JSON.stringify({
+        branch,
+        sha: commit.sha,
+        url: `https://github.com/${owner}/${repo}/tree/${branch}`,
+    }) + "\n");
+}
+
+main();


### PR DESCRIPTION
## What

A reusable [`bun tools/github/rest-push.ts`](tools/github/rest-push.ts) helper that lands single- or multi-file changes via GitHub REST git-data API instead of `git push`. Bypasses the [B-0615](docs/backlog/P3/B-0615-claude-code-bash-tool-orphans-git-fetch-subprocesses-under-saturation-self-saturation-feedback-loop-2026-05-18.md) push-hang failure mode (silent exit 0, no remote update).

## Usage

```bash
bun tools/github/rest-push.ts \
  --file path/to/file.md \
  --file path/to/other.ts \
  --branch otto/my-branch-2026-05-18 \
  --message "feat: my change\n\nLong description..."
```

Output (JSON): `{ branch, sha, url }`.

## Self-eating dog food

The commit on this branch (`6ae8326`) was created by running the script ON ITSELF — the script committed its own `.ts` file to its own branch via the REST git-data API.

## Why this matters now

PRs #4145 + #4146 (this session) both landed via this same JSON-inline pattern after `git push` silently exited 0 with no remote update. Inline JSON construction is fragile (escaping, base64, multi-step) and bypasses TypeScript's type system. Making it a real script with parseable args + type definitions makes the workflow reusable for:

- Spawned-claude sessions in `claude-loop-tick.ts` (referenced in PR #4146's prompt updates)
- Manual workarounds when push is hanging
- Future automated PRs from background services

## Composes with

- [PR #4145](https://github.com/Lucent-Financial-Group/Zeta/pull/4145) (rule documenting `timeout --kill-after` + REST bypass discipline)
- [PR #4146](https://github.com/Lucent-Financial-Group/Zeta/pull/4146) (background-loop prompt updates referencing this pattern; should be amended to call this script directly)
- [B-0615](docs/backlog/P3/B-0615-claude-code-bash-tool-orphans-git-fetch-subprocesses-under-saturation-self-saturation-feedback-loop-2026-05-18.md) (the open bug the script works around)

## Limitations / future work

- Only handles file creation/modification, not deletion. Deletions require setting `sha: null` in the tree entry; can be added if needed.
- Doesn't update existing branch refs (POST `/refs` fails if ref exists). Force-update workflows would need `PATCH /refs/heads/<branch>`; can be added.
- No retry logic for transient REST 5xx. The script fails fast on any REST error.

These are intentional MVP simplifications; can be extended as the bypass pattern matures.

Co-Authored-By: Claude <noreply@anthropic.com>