### PR TITLE
fix(loop-tick): exclude drain cycles from zero-PR backoff (Codex P1 follow-up on #4146)

### DIFF
--- a/.claude/bin/claude-loop-tick.ts
+++ b/.claude/bin/claude-loop-tick.ts
@@ -175,12 +175,19 @@ function heartbeat(): void {
         const elapsed = Date.now() - lastTime;
 
         // Compute zero-PR backoff multiplier from recent ratings.
-        // Counts trailing cycles where produced_pr=false. After the threshold,
-        // multiplier grows linearly up to backoffMaxMultiplier. Cleared on
-        // first produced_pr=true. The effective interval is
-        // claudeIntervalMs * backoffMultiplier; default config yields up to
-        // 30x slowdown (e.g., 60s -> 30min) when the system is in push-hang
-        // famine or otherwise consistently failing to ship.
+        // Counts trailing PICKUP-MODE cycles where produced_pr=false. Drain-mode
+        // cycles (thread-resolution / merge work on existing PRs) are SKIPPED
+        // when counting because they don't ever set produced_pr=true even when
+        // useful work happens. After the threshold, multiplier grows linearly
+        // up to backoffMaxMultiplier. Cleared on first pickup-mode
+        // produced_pr=true. The effective interval is claudeIntervalMs *
+        // backoffMultiplier; default config yields up to 30x slowdown
+        // (e.g., 60s -> 30min) when pickup mode is in push-hang famine or
+        // otherwise consistently failing to ship.
+        //
+        // (Codex P1 fix on PR #4146: drain cycles excluded to prevent
+        //  healthy drain periods from falsely triggering backoff that
+        //  would delay review-thread handling and merges.)
         let consecutiveZeroPrCycles = 0;
         try {
             const ratings = readFileSync(ratingsFile, "utf8").trim().split("\n").reverse();
@@ -188,6 +195,7 @@ function heartbeat(): void {
                 if (!line) continue;
                 try {
                     const r = JSON.parse(line);
+                    if (r.mode !== "pickup") continue; // skip drain cycles
                     if (r.produced_pr === true) break;
                     if (r.produced_pr === false) consecutiveZeroPrCycles += 1;
                 } catch { /* malformed line; skip */ }


### PR DESCRIPTION
Follow-up on [#4146](https://github.com/Lucent-Financial-Group/Zeta/pull/4146): the zero-PR backoff Codex flagged as a P1 issue shipped to main before this fix could land on its branch.

## Finding (Codex on #4146)

Zero-PR backoff increments on every `produced_pr=false`, but drain-mode runs (thread-resolution / merge work on existing PRs) NEVER set `produced_pr=true`. A healthy drain-only period (e.g., 5 PRs all going through review) would falsely look like consecutive zero-PR failures and ratchet to 30x slowdown — delaying review-thread handling and merges.

## Fix

`if (r.mode !== "pickup") continue;` — skip drain cycles entirely when counting.

Drain mode is excluded because its success signal is NOT `produced_pr` (no new PR is created) but rather thread-resolution + merge — which we don't currently track as a discrete success metric. Future work could add a `produced_merge: true` field to drain ratings and unify the counter.

Backoff now only triggers when pickup-mode (the cycle that's SUPPOSED to create new PRs) consistently fails. Healthy drain operation no longer slows the loop down.

## Why this took a follow-up PR

I was authoring the fix-commit when #4146 auto-merged. My fix-commit (`bb75cf2`) was created but `PATCH /refs/heads/<branch>` returned 422 because the branch had already been auto-deleted on merge. Created a fresh branch off main with the same fix instead. The fix-commit on the orphan branch is functionally equivalent to this PR's `0d6c5bd`.

Composes with #4146 (merged); applies the Codex P1 correction.

Co-Authored-By: Claude <noreply@anthropic.com>