### PR TITLE
feat(codex-loop-tick): add B-0615 push-hang awareness + timeout discipline to Vera's spawned prompt

### DIFF
--- a/.codex/bin/codex-loop-tick.ts
+++ b/.codex/bin/codex-loop-tick.ts
@@ -201,9 +201,11 @@ export function buildCodexPrompt(config: {
       "Treat broadcasts as coordination input only; GitHub PR state, remote claim branches, local worktrees, and heartbeat files are authoritative.",
     ].join(" "),
     [
-      "Then refresh the world model before choosing work by running `bun tools/github/refresh-worldview.ts` from the current loop worktree.",
+      "Then refresh the world model before choosing work by running `timeout --kill-after=5s 30s bun tools/github/refresh-worldview.ts` from the current loop worktree.",
       "If that refresh fails, stop and report the exact failure as the blocker instead of guessing from stale state.",
       "Prefer repo-native TypeScript/Bun tools over ad-hoc shell pipelines for PR state, backlog selection, and gate checks.",
+      "Wrap ALL git network operations (`git fetch`, `git push`, `git ls-remote`, `git clone`) in `timeout --kill-after=5s 30s` per the discipline in `.claude/rules/refresh-world-model-poll-pr-gate.md` — under multi-agent saturation, bare git network ops orphan as documented in B-0615.",
+      "PUSH-HANG WORKAROUND: when `git push` silently fails (exit 0, no remote update — B-0615), prefer `bun tools/github/rest-push.ts --file <path> --branch <ref> --message <msg>` which lands the change via REST git-data API instead of git push. Multi-file changes: repeat `--file PATH`. The script bypasses the push transport entirely; REST endpoints remain responsive while push is hung. See PRs #4145, #4146, #4147 for the discipline.",
     ].join(" "),
     [
       "Manager posture: this background loop is the manager of its own subagents or bounded work slices.",


### PR DESCRIPTION
Cross-agent consistency: Vera (Codex) gets the same B-0615 awareness Otto (Claude) got in [PR #4146](https://github.com/Lucent-Financial-Group/Zeta/pull/4146).

## What

Three sentences appended to Vera's `refresh-worldview` prompt block:

1. **Wrap refresh-worldview in `timeout --kill-after=5s 30s`** — was unwrapped, vulnerable to the same fetch-orphan failure mode B-0615 documents.
2. **Generic wrap-all-git-network-ops discipline** per the rule landed in [PR #4145](https://github.com/Lucent-Financial-Group/Zeta/pull/4145).
3. **Push-hang workaround**: when `git push` silently fails (exit 0, no remote update), prefer `bun tools/github/rest-push.ts --file <path> --branch <ref> --message <msg>` (the helper landed in [PR #4147](https://github.com/Lucent-Financial-Group/Zeta/pull/4147)). Multi-file changes: repeat `--file PATH`.

## Why minimal change

Vera's loop already has 15-min interval (vs claude's 60s), so the zero-PR backoff fix from #4146 is lower priority (low burn rate). Push-hang awareness is the cross-cutting high-leverage fix that benefits BOTH agent stacks.

Future work (separate PR if needed): add `produced_pr` tracking to Vera's ratings (currently only `status` is tracked); then port the zero-PR backoff. Smaller scope for now.

## Self-eating dog food

This PR's commit (`f6bb0e9`) was created via REST git-data API because `git push` is still hanging system-wide. The very workaround this PR teaches Vera to use.

## Composes with

- [PR #4145](https://github.com/Lucent-Financial-Group/Zeta/pull/4145) (`refresh-world-model-poll-pr-gate.md` rule documenting the discipline)
- [PR #4146](https://github.com/Lucent-Financial-Group/Zeta/pull/4146) (claude-loop-tick.ts; sibling agent stack)
- [PR #4147](https://github.com/Lucent-Financial-Group/Zeta/pull/4147) (`tools/github/rest-push.ts` helper)
- [PR #4148](https://github.com/Lucent-Financial-Group/Zeta/pull/4148) (drain-mode-exclusion follow-up on #4146)
- [B-0615](docs/backlog/P3/B-0615-claude-code-bash-tool-orphans-git-fetch-subprocesses-under-saturation-self-saturation-feedback-loop-2026-05-18.md) (the open bug class)

Co-Authored-By: Claude <noreply@anthropic.com>