### PR TITLE
feat(rest-push): --delete + --rename extension mechanizes ID-renumber pattern (B-0650)

### DIFF
--- a/docs/backlog/P3/B-0650-rest-push-delete-rename-extension-mechanizes-id-renumber-pattern-otto-cli-2026-05-18.md
+++ b/docs/backlog/P3/B-0650-rest-push-delete-rename-extension-mechanizes-id-renumber-pattern-otto-cli-2026-05-18.md
@@ -1,0 +1,78 @@
+---
+id: B-0650
+priority: P3
+status: closed
+title: "rest-push.ts --delete + --rename extension — mechanizes ID-renumber pattern (closes the B-0633→B-0649 inline-gh-api workaround) (Otto-CLI 2026-05-18)"
+tier: tooling
+effort: S
+created: 2026-05-18
+last_updated: 2026-05-18
+depends_on: []
+composes_with: [B-0615, B-0648]
+tags: [tooling, otto-cli, rest-push, delete-support, rename-support, id-renumber-mechanization, closed]
+type: tooling
+---
+
+# rest-push.ts `--delete` + `--rename` extension
+
+## Why
+
+During the 2026-05-18 Mika+Ani+Riven substrate cascade (8 PRs, 30+ rows), a B-0633 duplicate-ID was detected by CI (Mika permanent-coliseum row collided with an existing on-main aggregate-tier-counter row). Renumber to B-0649 required a delete+add+modify multi-file commit. `rest-push.ts` only supported add/modify, so the renumber needed an inline `gh api git/blobs|git/trees|git/commits|git/refs` sequence (~50 lines of bash) to land cleanly.
+
+This row mechanizes that pattern into the existing tool so future renumbers / deletes / renames are a one-liner.
+
+## What landed (closed this PR)
+
+Three new flags on `tools/github/rest-push.ts`:
+
+| Flag | Behavior |
+|---|---|
+| `--delete PATH` | Removes `PATH` from the tree (repeatable) |
+| `--rename OLD:NEW` | Deletes `OLD` path + adds `NEW` path with content from local disk at `NEW` (repeatable) |
+| Existing `--file PATH` | Unchanged — adds/modifies a file (repeatable) |
+
+All three compose: a single REST commit can have any combination of adds + deletes + renames.
+
+## Implementation notes
+
+- GitHub git/trees API accepts `sha: null` in a tree entry to mark a path as deleted from the base tree
+- Rename = delete old path + create blob for new path with content from local disk
+- Compiles cleanly via `bun build` (5.93 KB output)
+- All existing usage patterns preserved (no breaking changes to `--file` / `--update` / `--branch` / etc.)
+
+## Worked example (the ID-renumber pattern this closes)
+
+Before this extension, B-0633→B-0649 renumber required inline gh api:
+
+```bash
+# OLD WORKFLOW (now obsolete): ~50 lines of inline gh api calls
+TREE_SHA=$(gh api ...)
+NEW_BLOB=$(gh api ...)
+# ... build tree with sha:null for old path ...
+# ... create commit ...
+# ... PATCH ref ...
+```
+
+After this extension:
+
+```bash
+# NEW WORKFLOW: single rest-push invocation
+bun tools/github/rest-push.ts --update \
+  --rename docs/backlog/P3/B-0633-old-name.md:docs/backlog/P3/B-0649-new-name.md \
+  --file docs/backlog/P1/B-0635-cross-ref-updated.md \
+  --file docs/backlog/P1/B-0636-cross-ref-updated.md \
+  --file docs/backlog/P3/B-0632-cross-ref-updated.md \
+  --branch otto-cli/b0633-renumber-2026-05-18 \
+  --message "rename(b0633→b0649): duplicate-ID resolution + cross-ref updates"
+```
+
+## Composes with
+
+- [B-0615](B-0615-claude-code-bash-tool-orphans-git-fetch-subprocesses-under-saturation-self-saturation-feedback-loop-2026-05-18.md) — push-hang failure mode (the reason rest-push.ts exists)
+- [B-0648](../P1/B-0648-cross-substrate-triangulation-first-class-skill-hat-aaron-2026-05-18.md) — cross-substrate triangulation (B-0633 conflict was caught by Codex thread review on the renumber PR; example of triangulation operating in the small)
+- `tools/github/rest-push.ts` — the tool extended
+- `tools/github/rest-ship.ts` — one-shot push+PR+arm helper (could compose with --delete/--rename in future)
+
+## Closed-row resolution
+
+Code landed in this PR; renumber operations now mechanized. Future ID-collision resolutions, file deprecations, and renames use the one-liner pattern documented above.

--- a/tools/github/rest-push.ts
+++ b/tools/github/rest-push.ts
@@ -1,0 +1,246 @@
+#!/usr/bin/env bun
+// rest-push.ts — REST git-data API bypass for `git push` under saturation.
+//
+// When `git push` silently fails (exit 0, no remote update — see B-0615) under
+// multi-agent saturation, this script lands a single-file change via the
+// GitHub REST git-data API instead. The REST endpoints (POST /git/blobs,
+// /git/trees, /git/commits, /git/refs) are served by different infrastructure
+// than the git-push transport, so they remain responsive while push is hung.
+//
+// Worked example: PR #4145 + #4146 (2026-05-18) — both landed via this
+// pattern after the corresponding `git push` exited 0 with no remote update.
+//
+// Usage:
+//   bun tools/github/rest-push.ts --file <path> --branch <ref> --message <msg> [--base main] [--owner X] [--repo Y]
+//
+// Multi-file changes:
+//   --file PATH ... (repeatable; combines into one commit)
+//   --delete PATH ... (repeatable; deletes a path from the tree)
+//   --rename OLD:NEW ... (repeatable; deletes OLD path and adds NEW path with content from local disk at NEW)
+//
+// Examples:
+//   bun tools/github/rest-push.ts --file CLAUDE.md --branch otto/fix-typo-2026-05-18 \
+//       --message "docs(CLAUDE): fix typo in §3"
+//
+//   bun tools/github/rest-push.ts \
+//       --file .claude/rules/foo.md --file docs/backlog/P3/B-XXXX.md \
+//       --branch otto/b0XXXX-impl-2026-05-18 \
+//       --message "feat(B-XXXX): two-file change\n\n..."
+//
+//   # Rename a backlog row (B-0633 duplicate-ID resolution use case):
+//   bun tools/github/rest-push.ts \
+//       --rename docs/backlog/P3/B-0633-old-name.md:docs/backlog/P3/B-0649-new-name.md \
+//       --file docs/backlog/P1/B-0635-cross-ref-updated.md \
+//       --branch otto/b0633-renumber-2026-05-18 \
+//       --message "rename(b0633→b0649): duplicate-ID resolution + cross-ref updates"
+//
+//   # Pure delete (e.g., remove a deprecated row):
+//   bun tools/github/rest-push.ts --delete docs/backlog/P3/B-0XXX-deprecated.md \
+//       --branch otto/b0XXX-retire-2026-05-18 \
+//       --message "retire(B-0XXX): superseded by B-0YYY"
+//
+// Output: JSON to stdout:
+//   { "branch": "...", "sha": "<commit-sha>", "url": "https://github.com/.../tree/<branch>" }
+//
+// Exit codes:
+//   0  success
+//   1  REST error (network / 4xx / 5xx)
+//   2  bad usage
+//
+// Composes with: PR #4145 (the rule documenting the discipline)
+//                PR #4146 (background-loop awareness)
+//                B-0615 (the open bug class this works around)
+
+import { readFileSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+interface Args {
+    files: string[];
+    deletes: string[];
+    renames: Array<{ old: string; new: string }>;
+    branch: string;
+    message: string;
+    base: string;
+    owner: string;
+    repo: string;
+    update: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+    const args: Args = {
+        files: [],
+        deletes: [],
+        renames: [],
+        branch: "",
+        message: "",
+        base: "main",
+        owner: "Lucent-Financial-Group",
+        repo: "Zeta",
+        update: false,
+    };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        const next = argv[i + 1];
+        if (a === "--file" && next) { args.files.push(next); i++; }
+        else if (a === "--delete" && next) { args.deletes.push(next); i++; }
+        else if (a === "--rename" && next) {
+            const colonIdx = next.indexOf(":");
+            if (colonIdx < 0) {
+                process.stderr.write(`--rename requires OLD:NEW format, got: ${next}\n`);
+                process.exit(2);
+            }
+            args.renames.push({ old: next.slice(0, colonIdx), new: next.slice(colonIdx + 1) });
+            i++;
+        }
+        else if (a === "--branch" && next) { args.branch = next; i++; }
+        else if (a === "--message" && next) { args.message = next; i++; }
+        else if (a === "--base" && next) { args.base = next; i++; }
+        else if (a === "--owner" && next) { args.owner = next; i++; }
+        else if (a === "--repo" && next) { args.repo = next; i++; }
+        else if (a === "--update") { args.update = true; }
+        else if (a === "--help" || a === "-h") {
+            process.stdout.write(`Usage:
+  Create new branch:
+    bun tools/github/rest-push.ts --file <path> --branch <ref> --message <msg> [--base main]
+  Update existing branch (add a commit on top of its current HEAD):
+    bun tools/github/rest-push.ts --update --file <path> --branch <existing-ref> --message <msg>
+
+  --file can be repeated to land multiple files in one commit.
+  --delete PATH can be repeated to delete files from the tree.
+  --rename OLD:NEW can be repeated to delete OLD and add NEW (content read from local disk at NEW).
+  --update: parent commit becomes the current HEAD of <branch> (not main).
+            Uses PATCH refs/heads/<branch> after the commit is created.
+            Fast-forward only; will fail if HEAD has diverged.
+`);
+            process.exit(0);
+        }
+        else { process.stderr.write(`unknown arg: ${a}\n`); process.exit(2); }
+    }
+    if (args.files.length === 0 && args.deletes.length === 0 && args.renames.length === 0) {
+        process.stderr.write("--file, --delete, or --rename required (at least one)\n");
+        process.exit(2);
+    }
+    if (!args.branch) { process.stderr.write("--branch required\n"); process.exit(2); }
+    if (!args.message) { process.stderr.write("--message required\n"); process.exit(2); }
+    return args;
+}
+
+function ghApi(method: string, path: string, body?: object): unknown {
+    const cmdArgs = ["api", "-X", method, path];
+    let stdin: string | undefined;
+    if (body !== undefined) {
+        cmdArgs.push("--input", "-");
+        stdin = JSON.stringify(body);
+    }
+    const result = spawnSync("gh", cmdArgs, { encoding: "utf8", input: stdin, maxBuffer: 16 * 1024 * 1024 });
+    if (result.status !== 0) {
+        throw new Error(`gh ${method} ${path} failed (exit ${result.status}): ${result.stderr.trim() || result.stdout.trim()}`);
+    }
+    try { return JSON.parse(result.stdout); }
+    catch (e) { throw new Error(`gh ${method} ${path} returned non-JSON: ${result.stdout.slice(0, 200)}`); }
+}
+
+function fileMode(path: string): string {
+    // 100755 for executables (preserve x-bit); 100644 otherwise.
+    const st = statSync(path);
+    const isExec = (st.mode & 0o111) !== 0;
+    return isExec ? "100755" : "100644";
+}
+
+function main(): void {
+    const args = parseArgs(process.argv.slice(2));
+    const { owner, repo, base, branch, message, files, deletes, renames, update } = args;
+
+    // 1. Resolve parent commit:
+    //    - create mode: parent is HEAD of <base> (default "main")
+    //    - update mode: parent is HEAD of <branch> itself
+    //   Tree base for diff is always parent commit's tree.
+    const parentRefPath = update
+        ? `repos/${owner}/${repo}/git/matching-refs/heads/${branch}`
+        : `repos/${owner}/${repo}/branches/${base}`;
+    let parentSha: string;
+    if (update) {
+        const matches = ghApi("GET", parentRefPath) as Array<{ ref: string; object: { sha: string } }>;
+        const exactMatch = matches.find((m) => m.ref === `refs/heads/${branch}`);
+        if (!exactMatch) {
+            throw new Error(`--update mode: branch ${branch} does not exist (use create mode without --update)`);
+        }
+        parentSha = exactMatch.object.sha;
+    } else {
+        const baseRef = ghApi("GET", parentRefPath) as { commit: { sha: string } };
+        parentSha = baseRef.commit.sha;
+    }
+    const parentCommit = ghApi("GET", `repos/${owner}/${repo}/git/commits/${parentSha}`) as { tree: { sha: string } };
+    const parentTreeSha = parentCommit.tree.sha;
+
+    // 2. Build tree entries: blobs for adds + renames (new side); sha:null for deletes + renames (old side).
+    //    GitHub treats { sha: null } as "delete this path from the base tree."
+    const treeEntries: Array<{ path: string; mode: string; type: "blob"; sha: string | null }> = [];
+
+    // Adds (--file)
+    for (const path of files) {
+        const content = readFileSync(path);
+        const blob = ghApi("POST", `repos/${owner}/${repo}/git/blobs`, {
+            content: content.toString("base64"),
+            encoding: "base64",
+        }) as { sha: string };
+        treeEntries.push({ path, mode: fileMode(path), type: "blob", sha: blob.sha });
+    }
+
+    // Renames (--rename OLD:NEW): delete OLD, add NEW (content from local disk at NEW path)
+    for (const { old: oldPath, new: newPath } of renames) {
+        const content = readFileSync(newPath);
+        const blob = ghApi("POST", `repos/${owner}/${repo}/git/blobs`, {
+            content: content.toString("base64"),
+            encoding: "base64",
+        }) as { sha: string };
+        // Delete the old path
+        treeEntries.push({ path: oldPath, mode: "100644", type: "blob", sha: null });
+        // Add the new path
+        treeEntries.push({ path: newPath, mode: fileMode(newPath), type: "blob", sha: blob.sha });
+    }
+
+    // Pure deletes (--delete)
+    for (const path of deletes) {
+        treeEntries.push({ path, mode: "100644", type: "blob", sha: null });
+    }
+
+    // 3. Create tree
+    const tree = ghApi("POST", `repos/${owner}/${repo}/git/trees`, {
+        base_tree: parentTreeSha,
+        tree: treeEntries,
+    }) as { sha: string };
+
+    // 4. Create commit (parent is base HEAD or branch HEAD depending on mode)
+    const commit = ghApi("POST", `repos/${owner}/${repo}/git/commits`, {
+        message,
+        tree: tree.sha,
+        parents: [parentSha],
+    }) as { sha: string };
+
+    // 5. Either create or update the branch ref.
+    //    matching-refs (vs straight git/refs/heads/<branch>) handles
+    //    ref paths with slashes more reliably across gh-api versions.
+    if (update) {
+        ghApi("PATCH", `repos/${owner}/${repo}/git/refs/heads/${branch}`, {
+            sha: commit.sha,
+            // No `force: true` — fast-forward only; protects against
+            // accidentally rewriting peer commits if HEAD moved between
+            // our parent-read and our PATCH.
+        });
+    } else {
+        ghApi("POST", `repos/${owner}/${repo}/git/refs`, {
+            ref: `refs/heads/${branch}`,
+            sha: commit.sha,
+        });
+    }
+
+    process.stdout.write(JSON.stringify({
+        branch,
+        sha: commit.sha,
+        url: `https://github.com/${owner}/${repo}/tree/${branch}`,
+        mode: update ? "update" : "create",
+    }) + "\n");
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds two new flags to `tools/github/rest-push.ts`:

| Flag | Behavior |
|---|---|
| `--delete PATH` | Remove path from tree via `sha: null` (repeatable) |
| `--rename OLD:NEW` | Delete OLD + add NEW with content from local disk at NEW (repeatable) |

All three (`--file`, `--delete`, `--rename`) compose in a single REST commit.

## Why

During the 2026-05-18 Mika+Ani+Riven substrate cascade (8 PRs, 30+ rows), a B-0633 duplicate-ID was detected by CI. Renumber to B-0649 required delete+add+modify which `rest-push.ts` didn't support. I had to inline-script `gh api git/blobs|trees|commits|refs` (~50 lines bash) to land cleanly. This extension closes that gap; future ID-renumbers / file deprecations / renames are one-liners.

## Worked example

```bash
bun tools/github/rest-push.ts --update \
  --rename docs/backlog/P3/B-0633-old-name.md:docs/backlog/P3/B-0649-new-name.md \
  --file docs/backlog/P1/B-0635-cross-ref-updated.md \
  --branch otto-cli/b0633-renumber \
  --message "rename(b0633→b0649): duplicate-ID resolution"
```

## Substrate

- B-0650 row landed in this PR (closed-status; mechanization complete)
- Composes with B-0615 (push-hang workaround) + B-0648 (cross-substrate triangulation — Codex thread caught the B-0633 collision that motivated this)

## Test plan

- [x] Bun build compiles cleanly (5.93 KB output)
- [x] --help shows all 3 flags (--file, --delete, --rename) + --update
- [x] No breaking changes to existing usage patterns
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)