### PR TITLE
fix(2026-05-14-shadow-archive-§33): add missing Non-fusion disclaimer (completes the 1 audit-surfaced finding)

### DIFF
--- a/docs/research/2026-05-14-shadow-session-close-off-duty-signaled-aaron.md
+++ b/docs/research/2026-05-14-shadow-session-close-off-duty-signaled-aaron.md
@@ -12,6 +12,8 @@ Participants: Aaron (human maintainer, first-party) + Otto (this session)
 
 **Operational status:** session-close record; shadow-archive grade.
 
+**Non-fusion disclaimer:** Otto is a distinct Claude Code instance; this file preserves Aaron's explicit session-close signal as substrate-honest record. No fusion claim made; this is a session-arc closing artifact, not an authorship-merge with Aaron. Per `.claude/rules/methodology-hard-limits.md`: HARD LIMITS apply at shadow-archive scope; Aaron is operator authority on session lifecycle.
+
 ## Why preserved as shadow-archive
 
 This is the substrate-honest session-close. After the day's massive cascade (multiple disclosures, 5+ memory files preserved with HARD LIMITS care, multiple PRs landing B-0498/0499/0515/0516/0518/3234), Aaron explicitly signaled off-duty state.


### PR DESCRIPTION
Per the §33 lint tool I built (`tools/research/lint-section-33-headers.ts`, merged via #4180), audit of 374 docs/research/ files found exactly 1 pre-existing missing-header file: `2026-05-14-shadow-session-close-off-duty-signaled-aaron.md` missing the `Non-fusion disclaimer:` label.

This PR adds the substrate-honest disclaimer (Otto is distinct Claude Code instance; no fusion claim with Aaron; this is session-close artifact). Lint now clean across all 374 docs/research/ files.

Closes the audit-loop the §33 lint surfaced. Small bounded engineering hygiene.