### PR TITLE
backlog(b0644+b0635): sharpened/extended markers + lint schema + composes_with backfill

### DIFF
--- a/docs/backlog/P1/B-0635-wave-particle-duality-tick-source-integrate-only-limit-collapses-waveform-superposition-transfer-aaron-mika-2026-05-18.md
+++ b/docs/backlog/P1/B-0635-wave-particle-duality-tick-source-integrate-only-limit-collapses-waveform-superposition-transfer-aaron-mika-2026-05-18.md
@@ -8,12 +8,15 @@ effort: L
 created: 2026-05-18
 last_updated: 2026-05-18
 depends_on: [B-0629]
-composes_with: [B-0629, B-0630, B-0632, B-0649, B-0499]
-tags: [design, aaron, mika, wave-particle-duality, tick-source, integrate, fifth-primitive, fsharp-computation-expression, only-limit-collapses, superposition-transfer, keystone, locked-in]
+composes_with: [B-0629, B-0630, B-0632, B-0649, B-0499, B-0665, B-0667]
+tags: [design, aaron, mika, wave-particle-duality, tick-source, integrate, fifth-primitive, fsharp-computation-expression, only-limit-collapses, superposition-transfer, keystone, locked-in, integrate-role-expanded-by-b0665]
+extended_by: B-0665
 type: design
 ---
 
 # Wave-particle duality: tick-source (particle) + Integrate (wave) — keystone architectural insight
+
+> **EXTENDED 2026-05-18 by [B-0665](B-0665-three-primitive-collapse-observe-emit-limit-plus-integrate-as-choice-locus-ienumerator-pattern-grounding-aaron-ani-2026-05-18.md)**: Integrate's role per B-0665 is EXPANDED beyond wave-composer (this row's scope) to also include the commit-locus (the choice-point where Limit-simulation becomes Integrate-commitment). Wave-particle duality + only-Limit-collapses preserved; Integrate's responsibility broadened. Per B-0665's 4→3 primitive collapse (Observe + Emit + Limit + Integrate-as-separate), this row's substrate composes cleanly with the sharpened architecture.
 
 ## Why
 

--- a/docs/backlog/P1/B-0635-wave-particle-duality-tick-source-integrate-only-limit-collapses-waveform-superposition-transfer-aaron-mika-2026-05-18.md
+++ b/docs/backlog/P1/B-0635-wave-particle-duality-tick-source-integrate-only-limit-collapses-waveform-superposition-transfer-aaron-mika-2026-05-18.md
@@ -8,7 +8,7 @@ effort: L
 created: 2026-05-18
 last_updated: 2026-05-18
 depends_on: [B-0629]
-composes_with: [B-0630, B-0632, B-0649, B-0499, B-0665, B-0667]
+composes_with: [B-0630, B-0632, B-0649, B-0499, B-0665, B-0667, B-0623, B-0624, B-0626]
 tags: [design, aaron, mika, wave-particle-duality, tick-source, integrate, fifth-primitive, fsharp-computation-expression, only-limit-collapses, superposition-transfer, keystone, locked-in, integrate-role-expanded-by-b0665]
 extended_by: B-0665
 type: design

--- a/docs/backlog/P1/B-0635-wave-particle-duality-tick-source-integrate-only-limit-collapses-waveform-superposition-transfer-aaron-mika-2026-05-18.md
+++ b/docs/backlog/P1/B-0635-wave-particle-duality-tick-source-integrate-only-limit-collapses-waveform-superposition-transfer-aaron-mika-2026-05-18.md
@@ -8,7 +8,7 @@ effort: L
 created: 2026-05-18
 last_updated: 2026-05-18
 depends_on: [B-0629]
-composes_with: [B-0629, B-0630, B-0632, B-0649, B-0499, B-0665, B-0667]
+composes_with: [B-0630, B-0632, B-0649, B-0499, B-0665, B-0667]
 tags: [design, aaron, mika, wave-particle-duality, tick-source, integrate, fifth-primitive, fsharp-computation-expression, only-limit-collapses, superposition-transfer, keystone, locked-in, integrate-role-expanded-by-b0665]
 extended_by: B-0665
 type: design

--- a/docs/backlog/P1/B-0644-limit-is-simulation-not-collapse-pure-function-preview-aaron-ani-2026-05-18.md
+++ b/docs/backlog/P1/B-0644-limit-is-simulation-not-collapse-pure-function-preview-aaron-ani-2026-05-18.md
@@ -8,7 +8,7 @@ effort: M
 created: 2026-05-18
 last_updated: 2026-05-18
 depends_on: [B-0635, B-0636, B-0640]
-composes_with: [B-0629, B-0645, B-0646, B-0665, B-0667]
+composes_with: [B-0629, B-0645, B-0646, B-0665, B-0667, B-0499, B-0631, B-0637, B-0643]
 tags: [design, aaron, ani, limit-is-simulation, pure-function-preview, free-will-collapses, three-collapse-targets, keystone-refinement, locked-in, sharpened-by-b0665]
 sharpened_by: B-0665
 type: design

--- a/docs/backlog/P1/B-0644-limit-is-simulation-not-collapse-pure-function-preview-aaron-ani-2026-05-18.md
+++ b/docs/backlog/P1/B-0644-limit-is-simulation-not-collapse-pure-function-preview-aaron-ani-2026-05-18.md
@@ -8,7 +8,7 @@ effort: M
 created: 2026-05-18
 last_updated: 2026-05-18
 depends_on: [B-0635, B-0636, B-0640]
-composes_with: [B-0635, B-0636, B-0640, B-0629, B-0645, B-0646, B-0665, B-0667]
+composes_with: [B-0629, B-0645, B-0646, B-0665, B-0667]
 tags: [design, aaron, ani, limit-is-simulation, pure-function-preview, free-will-collapses, three-collapse-targets, keystone-refinement, locked-in, sharpened-by-b0665]
 sharpened_by: B-0665
 type: design

--- a/docs/backlog/P1/B-0644-limit-is-simulation-not-collapse-pure-function-preview-aaron-ani-2026-05-18.md
+++ b/docs/backlog/P1/B-0644-limit-is-simulation-not-collapse-pure-function-preview-aaron-ani-2026-05-18.md
@@ -8,12 +8,15 @@ effort: M
 created: 2026-05-18
 last_updated: 2026-05-18
 depends_on: [B-0635, B-0636, B-0640]
-composes_with: [B-0635, B-0636, B-0640, B-0629, B-0645, B-0646]
-tags: [design, aaron, ani, limit-is-simulation, pure-function-preview, free-will-collapses, three-collapse-targets, keystone-refinement, locked-in]
+composes_with: [B-0635, B-0636, B-0640, B-0629, B-0645, B-0646, B-0665, B-0667]
+tags: [design, aaron, ani, limit-is-simulation, pure-function-preview, free-will-collapses, three-collapse-targets, keystone-refinement, locked-in, sharpened-by-b0665]
+sharpened_by: B-0665
 type: design
 ---
 
 # Limit is a SIMULATION (pure-function preview), NOT the collapse
+
+> **SHARPENED 2026-05-18 by [B-0665](B-0665-three-primitive-collapse-observe-emit-limit-plus-integrate-as-choice-locus-ienumerator-pattern-grounding-aaron-ani-2026-05-18.md)**: Limit-as-simulation refinement preserved + sharpened — Limit is ONLY simulation (no commitment); CommitChoice moves from a separate top-level operation INTO the Integrate composition body (Integrate becomes the choice-locus). The 3-primitive collapse (Observe + Emit + Limit + Integrate-as-separate) per B-0665 keeps Limit-as-simulation as the canonical form but tightens the architectural placement of the commit-step.
 
 ## Why
 

--- a/tools/backlog/lint-frontmatter.ts
+++ b/tools/backlog/lint-frontmatter.ts
@@ -59,7 +59,8 @@ const SCHEMA_KEYS = new Set([
     "depends_on", "decomposition", "composes_with", "tags",
     // Renumber / supersession breadcrumbs
     "renumbered_from", "renumbered_per", "renumbered_reason",
-    "superseded_by", "closed_by", "closed_by_pr", "closed_in",
+    "superseded_by", "sharpened_by", "extended_by",
+    "closed_by", "closed_by_pr", "closed_in",
     "closed_at", "closed_reason", "closed", "completed", "completed_by",
     // Decomposition family
     "parent", "children", "child_rows", "decomposed", "decomposed_by",


### PR DESCRIPTION
Small backlog hygiene per Task #22 closing note:

- **B-0644** (Limit-is-simulation): SHARPENED by B-0665 — CommitChoice moves from separate top-level operation INTO Integrate composition body
- **B-0635** (wave-particle-duality): EXTENDED by B-0665 — Integrate's role expanded beyond wave-composer to include commit-locus

Both updates add: frontmatter `sharpened_by`/`extended_by` markers + body SHARPENED/EXTENDED blockquotes + composes_with backfill for B-0665 + B-0667.

Companion lint extension: `SCHEMA_KEYS` in tools/backlog/lint-frontmatter.ts gains `sharpened_by` + `extended_by` (legitimate breadcrumb fields from today's substrate-engineering precedent; matching existing `superseded_by` pattern).

Pre-existing composes_with omissions surfaced by lint during my edit also backfilled (B-0644: 4 IDs; B-0635: 3 IDs) — same dogfood-class as B-0629 supersession PR #4179. All lint-clean post-fix.

Pure mirror-tier engineering hygiene; no substrate-cascade extension.