### PR TITLE
fix(backlog): sweep dangling cross-refs to renamed b0471/b0472 research docs (PR #4136 followup)

### DIFF
--- a/docs/backlog/P1/B-0474-mirror-beacon-axis-adr-2026-05-14.md
+++ b/docs/backlog/P1/B-0474-mirror-beacon-axis-adr-2026-05-14.md
@@ -84,7 +84,7 @@ Required sections:
 - `docs/DECISIONS/2026-05-14-product-repo-split-decisions.md`
 - `docs/DECISIONS/2026-05-14-product-repo-glue-mechanism.md`
 - `memory/feedback_otto_356_mirror_internal_vs_beacon_external_language_register_discipline_2026_04_27.md`
-- `docs/research/2026-05-14-mirror-beacon-two-axis-classification-matrix-b0472.md`
+- `docs/research/2026-05-18-mirror-beacon-two-axis-classification-matrix-b0472.md`
 - `docs/research/2026-05-14-mirror-beacon-promotion-gate-protocol-b0473.md`
 
 ## Closing B-0426


### PR DESCRIPTION
## Summary

Sweeps 3 backlog rows for dangling cross-references to the OLD `docs/research/2026-05-14-mirror-beacon-{axis-prior-art-audit-b0471, two-axis-classification-matrix-b0472}.md` paths that were renamed to `2026-05-18-...` via [PR #4136](https://github.com/Lucent-Financial-Group/Zeta/pull/4136) commit [`46b44d34`](https://github.com/Lucent-Financial-Group/Zeta/commit/46b44d34) during this session.

## Files touched

- [`docs/backlog/P1/B-0473-mirror-beacon-promotion-gate-protocol-2026-05-14.md`](docs/backlog/P1/B-0473-mirror-beacon-promotion-gate-protocol-2026-05-14.md) — 1 cross-ref updated
- [`docs/backlog/P1/B-0474-mirror-beacon-axis-adr-2026-05-14.md`](docs/backlog/P1/B-0474-mirror-beacon-axis-adr-2026-05-14.md) — 1 cross-ref updated
- [`docs/backlog/P1/B-0479-axis3-adr-code-english-formal-verification-design-2026-05-14.md`](docs/backlog/P1/B-0479-axis3-adr-code-english-formal-verification-design-2026-05-14.md) — 1 cross-ref updated

## Out of scope

Other `2026-05-14-mirror-beacon-*` refs in these files point to **planned-but-not-shipped files** (B-0473 research doc + B-0474 ADR). Those are legitimate forward-refs to substrate that doesn't yet exist; out of scope for this sweep.

## Test plan

- [x] Verified b0471/b0472 paths now resolve on main (renamed in #4136)
- [x] Verified remaining 2026-05-14-mirror-beacon-* refs point to non-existent forward-refs (B-0473 research + B-0474 ADR; legitimate planning)
- [x] No content changes beyond the path substitution

🤖 Generated with [Claude Code](https://claude.com/claude-code)