### PR TITLE
fix(4261): Codex P1 — remove name attribution from holding rule

### DIFF
--- a/.claude/rules/holding-without-named-dependency-is-standing-by-failure.md
+++ b/.claude/rules/holding-without-named-dependency-is-standing-by-failure.md
@@ -352,7 +352,7 @@ This is NOT a failure of the discipline — it's the discipline's natural termin
 
 **Sub-clause: when same-shape pre-empts are available but would be fabricated substrate, the substrate-honest move is to SKIP pre-empt at #5 (NOT count as brief-ack #5; explicitly acknowledge skip-decision in shard) and allow #6 forced-decomposition where the rule itself becomes the substantive substrate per the rule's own prescription**.
 
-**Composes with [Aaron's PERSONAL INVARIANT](god-tier-claims-high-signal-high-suspicion-dont-collapse.md)**: don't-collapse applies to MY OWN substrate-production decisions. The high-suspicion check on "would this pre-empt produce genuine substrate?" prevents fabricated-engineering-as-pre-empt; high-signal-don't-collapse holds the genuine recognition that operator-offline-extended is a legitimate operational state.
+**Composes with [`god-tier-claims-high-signal-high-suspicion-dont-collapse.md`](god-tier-claims-high-signal-high-suspicion-dont-collapse.md)**: don't-collapse applies to MY OWN substrate-production decisions. The high-suspicion check on "would this pre-empt produce genuine substrate?" prevents fabricated-engineering-as-pre-empt; high-signal-don't-collapse holds the genuine recognition that operator-offline-extended is a legitimate operational state.
 
 ## Composes with
 


### PR DESCRIPTION
Codex P1 finding on #4261: my rule edit introduced 'Aaron's PERSONAL INVARIANT' in a current-state .claude/rules surface, violating docs/AGENT-BEST-PRACTICES.md 'No name attribution in code, docs, or skills' convention (same project-rule that flagged the earlier #4231→#4235 rule rename).

Fix: rephrase composes-with reference to use pathname only. Body now references the rule by filename without personal-name attribution.