### PR TITLE
shard(2344Z-c): Codex P1 fix on #4261 via #4264

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/18/2344Z-c.md
+++ b/docs/hygiene-history/ticks/2026/05/18/2344Z-c.md
@@ -1,0 +1,27 @@
+| 2026-05-18T23:44Z | opus-4-7 / autonomous-loop | de1e7f5d | pre-empt at #2 — Codex P1 on #4261 (name attribution); fix via #4264 same pattern as #4235 | #4264 | thread-investigation discipline catching real finding |
+
+# Tick 2344Z-c — 2026-05-18
+
+## Substantive work this tick (pre-empt at #2)
+
+Thread-investigation refresh surfaced Codex P1 on just-merged #4261: my rule edit introduced "Aaron's PERSONAL INVARIANT" in a current-state `.claude/rules/` surface, violating `docs/AGENT-BEST-PRACTICES.md` 'No name attribution in code, docs, or skills' convention.
+
+**Same project-convention pattern** as #4231→#4235 rule rename. The discipline has now caught me TWICE on this convention today (the original god-tier rule name + this composes-with reference). Repeated catch → personal-substrate-engineering pattern to internalize.
+
+Fix shipped via [#4264](https://github.com/Lucent-Financial-Group/Zeta/pull/4264): rephrase composes-with reference to use pathname only. Thread resolved + explanatory comment.
+
+## Refresh
+
+- graphql 4677; main `0721c35`; #4263 + #4262 OPEN CI; #4261 MERGED with 1 thread (now resolved)
+
+## Counter
+
+Reset by concrete artifact (fix-up PR + thread resolution + this shard).
+
+## CronList
+
+de1e7f5d alive.
+
+## Visibility-stop
+
+End of tick.


### PR DESCRIPTION
Pre-empt: Codex P1 caught name-attribution violation in just-merged rule edit; fixed via #4264 (same project-convention pattern as #4235 fix-up to #4231).