### PR TITLE
fix(4270): rule wording — skip-decision-shard does count as brief-ack #5

### DIFF
--- a/.claude/rules/holding-without-named-dependency-is-standing-by-failure.md
+++ b/.claude/rules/holding-without-named-dependency-is-standing-by-failure.md
@@ -350,7 +350,7 @@ Session trajectory:
 
 This is NOT a failure of the discipline — it's the discipline's natural termination shape when external signal is absent for extended periods. The forced-#6 meta-decomposition becomes the substrate-engineering substantive that the cycle terminates with, AND seeds the rule's next sharpening for future sessions.
 
-**Sub-clause: when same-shape pre-empts are available but would be fabricated substrate, the substrate-honest move is to SKIP pre-empt at #5 (NOT count as brief-ack #5; explicitly acknowledge skip-decision in shard) and allow #6 forced-decomposition where the rule itself becomes the substantive substrate per the rule's own prescription**.
+**Sub-clause: when same-shape pre-empts are available but would be fabricated substrate, the substrate-honest move is to SKIP the pre-empt action at #5 (the shard DOES count as brief-ack #5 since it produces no novel substrate; the shard's job is to explicitly document the skip-decision rather than execute a fabricated pre-empt) so the counter advances normally to #6 where forced-decomposition fires and the rule itself becomes the substantive substrate per the rule's own prescription**.
 
 **Composes with [`god-tier-claims-high-signal-high-suspicion-dont-collapse.md`](god-tier-claims-high-signal-high-suspicion-dont-collapse.md)**: don't-collapse applies to MY OWN substrate-production decisions. The high-suspicion check on "would this pre-empt produce genuine substrate?" prevents fabricated-engineering-as-pre-empt; high-signal-don't-collapse holds the genuine recognition that operator-offline-extended is a legitimate operational state.
 


### PR DESCRIPTION
Codex P2 finding on #4270: the sub-clause 'SKIP at #5 NOT count as brief-ack #5' is inconsistent with 'allow #6 accumulation' (if skip doesn't count, accumulation can't progress). Rephrased to make clear that the skip-decision SHARD does count as brief-ack (no novel substrate is produced; the shard documents the skip-action rather than execute a fabricated pre-empt). Counter advances normally to #6 forced-decomposition.