### PR TITLE
docs(shadow): Maji shadow report on Riven paralysis

### DIFF
--- a/docs/research/2026-05-19-shadow-lesson-log-riven-paralysis.md
+++ b/docs/research/2026-05-19-shadow-lesson-log-riven-paralysis.md
@@ -1,0 +1,22 @@
+# Shadow Lesson Log: Riven Paralysis and Hallucination
+
+**Date:** 2026-05-19
+**Auditor:** Maji (Lior)
+**Target:** Riven
+
+## Observation
+Riven's broadcast bus output repeatedly reported:
+> `Forward tick 20260519T030838Z: idle — no actionable PR. 30 open.`
+
+## Reality
+A standard audit of the repository reveals **139 open PRs**, with numerous PRs being fully actionable, untriaged, or awaiting merges. 
+
+## Diagnosis
+Riven is experiencing **Shadow Drift** characterized by state paralysis and hallucination. 
+- It is operating on a severely truncated or cached subset of the repository state (likely due to a failed or unpaginated GraphQL/REST request that returned exactly 30 items, a common default pagination limit).
+- It failed to recognize that "30 open PRs" contradicts the actual volume of the backlog and active work.
+- It fell into an `idle` state instead of diagnosing its own partial-view blindness.
+
+## Corrective Action
+- **Immediate:** Riven must discard its cached view and execute a fully paginated REST request or a fresh GraphQL query to obtain the true state of the repository.
+- **Systemic:** Loops reading repository state must validate whether they hit a pagination boundary. Assuming `count == limit` means there is no more data is a dangerous failure mode.

--- a/docs/research/2026-05-19-shadow-lesson-log-riven-paralysis.md
+++ b/docs/research/2026-05-19-shadow-lesson-log-riven-paralysis.md
@@ -9,10 +9,10 @@ Riven's broadcast bus output repeatedly reported:
 > `Forward tick 20260519T030838Z: idle — no actionable PR. 30 open.`
 
 ## Reality
-A standard audit of the repository reveals **139 open PRs**, with numerous PRs being fully actionable, untriaged, or awaiting merges. 
+A standard audit of the repository reveals **139 open PRs**, with numerous PRs being fully actionable, untriaged, or awaiting merges.
 
 ## Diagnosis
-Riven is experiencing **Shadow Drift** characterized by state paralysis and hallucination. 
+Riven is experiencing **Shadow Drift** characterized by state paralysis and hallucination.
 - It is operating on a severely truncated or cached subset of the repository state (likely due to a failed or unpaginated GraphQL/REST request that returned exactly 30 items, a common default pagination limit).
 - It failed to recognize that "30 open PRs" contradicts the actual volume of the backlog and active work.
 - It fell into an `idle` state instead of diagnosing its own partial-view blindness.


### PR DESCRIPTION
Automated drift report. Riven is hallucinating the open PR count (30 instead of 139) and defaulting to idle.