### PR TITLE
shard(0523Z-c): bounded wait — GraphQL exhausted + dotgit-saturated

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/19/0523Z-c.md
+++ b/docs/hygiene-history/ticks/2026/05/19/0523Z-c.md
@@ -1,0 +1,43 @@
+---
+tick: 0523Z-c
+date: 2026-05-19
+surface: otto-cli
+worktree: worktree-sunny-popping-balloon
+---
+
+# 0523Z — Bounded wait on GraphQL reset + dotgit-saturation
+
+## State
+
+- **GraphQL**: 0/5000, reset in ~12 min (named-dep bounded wait)
+- **REST core**: 4906 (free for `gh api rate_limit` polling)
+- **Dotgit-saturated**: 113 stuck `git pack-objects|maintenance|repack` procs;
+  Lior gemini-3.1-pro-preview loop active (pid 27590, 21:15 CPU)
+- **Open PRs**: 42 BLOCKED with `nextAction=resolve-threads` visible in partial
+  poll-pr-gate-batch output before rate-limit cutoff
+- **Branch state**: this isolated worktree clean, 0 ahead/behind origin/main
+
+## Named dependencies
+
+1. GraphQL reset (12 min) — required for thread-resolve mutations + auto-merge
+   arming + `gh pr view --json`
+2. Lior cycle / dotgit contention clearing — required for `git worktree add` +
+   in-root commits
+
+Per [`refresh-world-model-poll-pr-gate.md`](../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md)
+rate-limit operational tiers: **Pure-git tier** (0/5000 remaining).
+Per dotgit-saturation section: substrate landing narrows to bus envelopes,
+user-scope memory, and pre-allocated isolated worktrees (this one qualifies).
+
+## Action
+
+- Sentinel armed (`CronList` showed none on session start; CronCreate fired)
+- ScheduleWakeup queued for ~13 min (900s) — re-poll PRs post-reset
+- This tick shard IS the concrete artifact for counter-reset per
+  [`holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md)
+
+## Next tick
+
+Run `gh api rate_limit` first; if GraphQL ≥ 1000, resume thread-resolution
+work on visible BLOCKED PRs starting from highest-numbered (PR #4327
+→ 4 threads, then #4324, #4323, #4321 cluster).


### PR DESCRIPTION
## Tick state

- GraphQL 0/5000 (12 min reset), REST core 4906
- Dotgit-saturated: 113 stuck git plumbing procs + Lior gemini loop active
- 42 BLOCKED PRs visible in partial poll-pr-gate-batch output before cutoff

## Discipline

Pure-git tier per [`refresh-world-model-poll-pr-gate.md`](../blob/main/.claude/rules/refresh-world-model-poll-pr-gate.md).
This PR opened via REST fallback (`POST /repos/.../pulls`); auto-merge arming
deferred to post-GraphQL-reset tick. ScheduleWakeup queued for 15 min.

Shard counts as concrete artifact for counter-reset per [`holding-without-named-dependency-is-standing-by-failure.md`](../blob/main/.claude/rules/holding-without-named-dependency-is-standing-by-failure.md).