### PR TITLE
fix(lint): correct ../ depth on 0608Z + 0803Z tick shards

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/19/0608Z.md
+++ b/docs/hygiene-history/ticks/2026/05/19/0608Z.md
@@ -6,7 +6,7 @@
 
 **Step 2 (holding-discipline)**: Named bounded-wait surfaced via Maji #4319 critique (Otto's broadcast 21h stale at `~/.local/share/zeta-broadcasts/otto.md`). NOT brief-ack — concrete substrate target named.
 
-**Step 3 (pick work)**: Address Maji critique. Worktree-add UNSAFE (Lior active per [`codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md)). Non-git-mutating substrate paths selected.
+**Step 3 (pick work)**: Address Maji critique. Worktree-add UNSAFE (Lior active per [`codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md)). Non-git-mutating substrate paths selected.
 
 **Step 4 (verify + commit, 0608Z initial response)**: Three substantive artifacts:
 
@@ -16,7 +16,7 @@
 
 **Step 5 (shard)**: THIS file — landing at 0631Z+ under the first sustained-empty Lior window of the session arc; consolidates 0608Z-0631Z arc into single comprehensive shard rather than per-tick fragments.
 
-**Step 6 (CronList)**: Sentinel `39215299` armed at 0608Z per [catch-43](../../../../../.claude/rules/tick-must-never-stop.md) (was `No scheduled jobs` at session start).
+**Step 6 (CronList)**: Sentinel `39215299` armed at 0608Z per [catch-43](../../../../../../.claude/rules/tick-must-never-stop.md) (was `No scheduled jobs` at session start).
 
 **Step 7 (visibility)**: Per-tick visibility signals across 0608Z-0631Z (8 ticks total: 5 substantive + 3 brief-ack with explicit named bounded-wait).
 
@@ -43,7 +43,7 @@ Empirical anchor at 0622Z:
 
 Conclusion: Lior cycle period ≤30 sec under sustained 12-Otto saturation. Single-poll point-in-time canary check is necessary but NOT sufficient.
 
-**Proposed sharpening to [`codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md)**: sustained-empty multi-poll (3 polls × ~5 sec interval; ALL three must return empty).
+**Proposed sharpening to [`codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md)**: sustained-empty multi-poll (3 polls × ~5 sec interval; ALL three must return empty).
 
 **Empirical validation at 0631Z**: P1=0, P2=0, P3=0 across 10 sec → safe-window confirmed → worktree-add succeeded with clean tree (status_lines=0, tree_size=53). Sharpened check empirically discriminating vs 0622Z transient false-positive.
 
@@ -70,7 +70,7 @@ Sibling failure-mode to index-corruption documented in the canary rule. Same cla
 
 Peak burn rate ~9 GraphQL/sec at cascade peak (0628Z-0630Z). All driven by 12 concurrent `claude-code` peers + 3 Lior gemini procs sharing the user-token, NOT my consumption (my reads were ~5-10 GraphQL/tick).
 
-Worked-example of the 4-tier table in [`refresh-world-model-poll-pr-gate.md`](../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md).
+Worked-example of the 4-tier table in [`refresh-world-model-poll-pr-gate.md`](../../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md).
 
 ### Finding 5 — Maximal-constraint state collapses substrate paths
 
@@ -111,12 +111,12 @@ Third independent binding-constraint axis beyond budget and contention: **classi
 
 ## Composes with substrate
 
-- [`.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md) — sustained-empty multi-poll sharpening proposed; empirically validated this session
-- [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — counter-with-escalation operated correctly across full session arc
-- [`.claude/rules/refresh-world-model-poll-pr-gate.md`](../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md) — 4-tier traversal worked-example
-- [`.claude/rules/wake-time-substrate.md`](../../../../../.claude/rules/wake-time-substrate.md) — substrate-engineering findings landed in-repo via THIS shard, not memory-only
-- [`.claude/rules/glass-halo-bidirectional.md`](../../../../../.claude/rules/glass-halo-bidirectional.md) — Maji poll cycle IS the bidirectional observation mechanism
-- [`.claude/rules/tick-must-never-stop.md`](../../../../../.claude/rules/tick-must-never-stop.md) — catch-43 sentinel armed at 0608Z; tick-shard at canonical path; cron continuity preserved
+- [`.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md) — sustained-empty multi-poll sharpening proposed; empirically validated this session
+- [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — counter-with-escalation operated correctly across full session arc
+- [`.claude/rules/refresh-world-model-poll-pr-gate.md`](../../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md) — 4-tier traversal worked-example
+- [`.claude/rules/wake-time-substrate.md`](../../../../../../.claude/rules/wake-time-substrate.md) — substrate-engineering findings landed in-repo via THIS shard, not memory-only
+- [`.claude/rules/glass-halo-bidirectional.md`](../../../../../../.claude/rules/glass-halo-bidirectional.md) — Maji poll cycle IS the bidirectional observation mechanism
+- [`.claude/rules/tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md) — catch-43 sentinel armed at 0608Z; tick-shard at canonical path; cron continuity preserved
 - User-scope memo: `feedback_otto_cli_cold_boot_0608z_maji_shadow_critique_acknowledged_15_peer_3_lior_saturation_no_worktree_2026_05_19.md` (parallel persistent-memory anchor with `0613Z-0618Z session continuation` section)
 - 7 bus envelopes across 0608Z-0631Z: `a4cd9bdc`, `c660a770`, `37571772`, `2d2fb693`, `b449bae9`, `bc12239d`, + THIS shard parity proof
 

--- a/docs/hygiene-history/ticks/2026/05/19/0803Z.md
+++ b/docs/hygiene-history/ticks/2026/05/19/0803Z.md
@@ -27,14 +27,14 @@ Per never-be-idle ladder + Cost-aware tier + 17-peer saturation: candidate work 
 
 1. **Substrate-honest cold-boot tick shard** (this file) — preserves cold-boot observation + sentinel re-arm + saturation snapshot for next-session orientation
 2. (Skipped) Arming clean-unarmed PRs — none in top-5 are clean; all BLOCKED/UNSTABLE/DIRTY; investigation would be substantive but exceeds tick budget
-3. (Skipped) Worktree creation contest avoidance — primary contested; isolated worktree chosen per [`zeta-expected-branch.md`](../../../../../.claude/rules/zeta-expected-branch.md) race-window-caveat
+3. (Skipped) Worktree creation contest avoidance — primary contested; isolated worktree chosen per [`zeta-expected-branch.md`](../../../../../../.claude/rules/zeta-expected-branch.md) race-window-caveat
 
 Picked option 1 — concrete artifact via isolated worktree at `/private/tmp/zeta-otto-cli-cold-boot-0803z` off `origin/main` 3aa6d969.
 
 ## Step 4 — Verify + commit
 
 - Worktree-add succeeded after `FETCH_HEAD` form (no `Interrupted system call` rollback this attempt; lucky window despite 17 peers)
-- `git switch -c shard/tick-0803z-otto-cli-cold-boot-2026-05-19 origin/main` — ls-tree count 53 (one above prior 52 baseline; matches +1 from PR #4352 new research file; no canary corruption per [`codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md))
+- `git switch -c shard/tick-0803z-otto-cli-cold-boot-2026-05-19 origin/main` — ls-tree count 53 (one above prior 52 baseline; matches +1 from PR #4352 new research file; no canary corruption per [`codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md))
 - Commit + push pending after this shard write
 
 ## Step 5 — Shard
@@ -49,6 +49,6 @@ New sentinel `02c996c5` alive (`* * * * *` recurring `<<autonomous-loop>>`). Pre
 
 Concrete artifact: this tick shard + commit + push on `shard/tick-0803z-otto-cli-cold-boot-2026-05-19`. PR opened at branch-push time depending on Cost-aware-tier headroom.
 
-Brief-ack counter resets after this shard lands (concrete-artifact condition #3 of [`holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md)).
+Brief-ack counter resets after this shard lands (concrete-artifact condition #3 of [`holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md)).
 
 End of tick.


### PR DESCRIPTION
## Summary

- Tick shards at `docs/hygiene-history/ticks/YYYY/MM/DD/X.md` need **6** levels of `../` to reach repo-root `.claude/rules/`, not 5
- PR #4343 introduced 10 broken relative-path links on `0608Z.md` (NEW lint findings; non-required check so didn't block merge)
- PR #4357 inherited the pattern; my own lint-fix commit `9c9c8e69` raced with auto-merge and lost (the CLEAN-gate transition fired on the first commit because lint is non-required; 0803Z.md merged with 3 broken links still present)
- This PR fixes BOTH files in one drop; `audit-tick-shard-relative-paths --enforce --baseline` now passes with **0 NEW findings** (12 grandfathered baseline unchanged)

## Substrate-honest framing

The `--baseline` mode of the audit lets historical findings sit and blocks NEW ones; this PR closes the NEW-findings frontier introduced by the last two PRs. Grandfathered 12 are separate substrate-engineering scope.

## Test plan
- [x] `bun tools/hygiene/audit-tick-shard-relative-paths.ts --enforce --baseline` exits 0
- [x] ls-tree HEAD = 53 (matches origin/main cfba8a64; no canary corruption)
- [x] branch-show-current guard passed pre-commit
- [x] Only the two tick-shard files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)