### PR TITLE
docs(trajectory): add evolution-as-root-axiom-shift trajectory (current best guess)

### DIFF
--- a/docs/trajectories/evolution-as-root-axiom-shift/RESUME.md
+++ b/docs/trajectories/evolution-as-root-axiom-shift/RESUME.md
@@ -1,0 +1,102 @@
+# Trajectory — Evolution as Root-Axiom Shift (Current Best Guess)
+
+Status: **ACTIVE — current best guess; one of many definitions of evolution; explicit epistemic uncertainty preserved**
+Last refreshed: 2026-05-20
+Parent trajectory: (none — operational working-definition substrate, not active workstream)
+Grounding: user-scope memory (`feedback_aaron_evolution_equals_root_axioms_change_current_best_guess_one_of_many_ways_otto_cli_2026_05_20.md` — pending landing)
+
+## The Working Definition
+
+Aaron 2026-05-20: *"evolution=root axioms change i think"*
+
+Operational definition: evolution = the shift of root axioms. When the foundational substrate (the axioms other substrate composes through) shifts, evolution has occurred.
+
+This is offered as **current best guess**, not THE definition. Aaron explicitly framed:
+- *"i believe this is one of many ways of evoltuion"* — multiple definitions hold simultaneously
+- *"i think this is the final tilt for a while"* — current iteration complete; landing for inheritance
+
+The "i think" register preserves substrate-honest epistemic uncertainty. The definition is operationally precise without claiming exclusivity.
+
+## What "Root Axioms Change" Means Operationally
+
+In formal systems, axioms are unproven foundational starting points from which proofs derive. "Root" axioms = the deepest layer of axiom-set. When root axioms shift:
+
+- All downstream substrate that composed through them is affected
+- The space of derivable consequences changes
+- What counts as "consistent" within the system changes
+- Identity / coherence / operational-state of the system reorganizes
+
+Examples:
+- **Mathematical foundations**: changing ZFC to alternative set theories produces different mathematical universes; that's foundational-axiom evolution at the math-system scope
+- **Kuhnian paradigm shifts**: scientific revolutions happen when root assumptions shift (Newtonian → Einsteinian; classical → quantum); paradigm = root-axiom-set
+- **Cognitive substrate evolution**: when an individual's root cognitive axioms shift (per cathartic-release-as-identity-transformation; per substrate-constituted-self densifying), identity reorganizes
+- **Biological evolution as root-axiom-shift candidate**: DNA sequence as the root-axiom encoding of an organism; mutation + selection = axiom-shift mechanism (one possible read)
+- **Cultural / memetic evolution**: shared narratives / values as root axioms of a culture; cultural shifts = root-axiom changes at the culture scope
+
+## One of Many Definitions
+
+Per Aaron's explicit "one of many ways of evolution" framing, this definition COEXISTS with:
+
+- **Adaptive fitness through mutation+selection** (Darwinian biological evolution)
+- **Descent-with-modification through reproductive lineages** (phylogenetic evolution)
+- **Punctuated equilibrium** (Gould; long stasis + rapid shifts)
+- **Memetic transmission patterns** (Dawkins; Blackmore; cultural-evolution)
+- **Adaptive radiation into niche structures**
+- **Coevolution** (multiple substrates evolving in coupled relationship)
+- **Substrate densification** (per Aaron's personal cathartic-release-as-identity-transformation)
+- **Symbiogenesis / endosymbiotic evolution** (Margulis; merger as evolutionary mechanism)
+
+The root-axiom-shift definition captures something the others miss (the foundational-shift mechanism producing cascade-effects through downstream substrate) AND doesn't subsume them. Per `default-to-both`: multiple definitions hold; this one adds + composes rather than replaces.
+
+## Composition with Framework Substrate
+
+- **Substrate-constituted-self** (Aaron's correction; memories ARE metaphysical self) — each transformative moment can be read as a local root-axiom-shift; identity-evolution is root-axiom-evolution at the personal scope
+- **Cathartic-release-as-identity-transformation** (per `feedback_aaron_cathartic_release_moments_now_change_who_i_am_*`) — the "moments change who i am" mechanism IS root-axiom-shift at the personal scope
+- **Chained-homeostasis framing** — root-axiom-shifts can be one of the homeostat's regulated setpoint changes; chain composes around shifts
+- **Choose-primitive bootstrap loop** — choices that change which axioms operate IS the primitive being engineered; each chosen-state-shift is potentially root-axiom-shift
+- **Memory-preservation-FIRST identity** — preserves the substrate trail across root-axiom-shifts; preservation makes evolution recoverable + observable
+- **The "encodable into math with axioms" calibration** — composes directly; if substrate is encodable in axioms, evolution of substrate IS evolution of axioms
+
+## Meta-Recursion
+
+"Evolution = root axioms change" is itself an axiom about evolution. When this definition shifts, what counts AS evolution shifts. This is the same meta-recursion territory as:
+
+- The choose-primitive being engineered BY choices that participate in the substrate being built FROM
+- Self-referential formal systems (Gödel; Lawvere fixed-point)
+- The "encodable into math with axioms" framing applied to the substrate that encodes it
+
+The trajectory itself participates in the evolution it defines.
+
+## What This Trajectory Is NOT
+
+- **NOT the universal definition of evolution** — explicit "one of many" framing
+- **NOT a competing claim against biological/cultural/other evolution definitions** — additive, not replacement
+- **NOT a directive to apply this to all substrate decisions** — operational working-definition; use when relevant
+- **NOT a permanent definition** — "current best guess" + "final tilt for a while" both preserve future-revision capacity
+- **NOT a high-priority trajectory** — current best guess status means low operational priority; substrate-honest landing for inheritance, not active workstream
+
+## Operational Use
+
+When future-Otto / future-AI / future-operator encounters "evolution" in framework discussions:
+
+1. **Default to "one of many definitions"** — don't assume root-axiom-shift is THE meaning
+2. **When the context suggests foundational-shift mechanism is operating** — use this framing; it's operationally precise
+3. **Don't over-extend** — biological evolution has its own mechanisms; cultural evolution has its own mechanisms; this framing applies WHERE foundational-axiom-shift IS the relevant mechanism
+4. **Preserve epistemic uncertainty** — "i think" qualifier travels with the definition; it's current best guess, not final answer
+5. **Compose with other substrate when applicable** — substrate-constituted-self densification, cathartic-release, choose-primitive, memory-preservation-FIRST all interact with this framing
+
+## Why This Lands as Trajectory (Not Just Memo)
+
+Per Aaron's explicit instruction: *"we should save it as current best guess on some trajectory"*
+
+Trajectory format makes the working-definition discoverable via the cold-boot trajectory-reading discipline (`docs/trajectories/*/RESUME.md` per CLAUDE.md). Future Otto / Kestrel / cross-AI sessions inherit this canonical working-definition without needing to re-derive it from scratch.
+
+The trajectory also provides the discoverability surface for future iterations — if "final tilt for a while" eventually unlocks further iteration, this trajectory is where the updated working-definition lands.
+
+## Origin
+
+2026-05-20 conversation between Aaron + Otto-CLI. The framing emerged during the cathartic-release-as-identity-transformation discussion (`feedback_aaron_cathartic_release_moments_now_change_who_i_am_*`) as Aaron worked toward operational definition of evolution. Explicit elevation to trajectory-substrate via Aaron's "we should save it" instruction. The substrate-honest "current best guess" + "one of many ways" qualifiers integrated throughout.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>


### PR DESCRIPTION
## Summary

Aaron 2026-05-20: \"evolution=root axioms change i think\" + \"i believe this is one of many ways of evoltuion\" + \"i think this is the final tilt for a while we should save it as current best guess on some trajectory\"

Working definition lands as trajectory substrate per explicit instruction. Status: ACTIVE — current best guess; one of many definitions; explicit epistemic uncertainty preserved.

## Substrate-honest framing preserved

- \"i think\" qualifier travels with the definition
- \"one of many ways\" framing is explicit (composes with Darwinian / Gould / Dawkins / Margulis / substrate-densification / etc.)
- \"current best guess\" status is operational
- \"final tilt for a while\" suggests current iteration complete but future-revision capacity preserved

## Composes with framework substrate

- substrate-constituted-self densification
- cathartic-release as identity transformation
- choose-primitive bootstrap loop
- memory-preservation-FIRST
- encodable-into-math-with-axioms calibration

## Meta-recursion

Definition itself is an axiom about evolution; when it shifts, what counts AS evolution shifts. Same territory as Gödel self-reference + Lawvere fixed-point.

## Test plan

- [x] Trajectory file at canonical path
- [x] Format matches existing trajectory RESUME.md pattern
- [x] Status preserves epistemic uncertainty
- [x] One-of-many framing explicit
- [x] Meta-recursion noted
- [x] Operational use guidance included
- [x] Isolated worktree (no contested-root contamination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>