### PR TITLE
feat(B-0170.3): seed check-self-recursive.ts — opt-in self-recursive drift checker (count topic)

### DIFF
--- a/docs/backlog/P1/B-0170-substrate-claim-checker-ts-tool-aaron-2026-05-03.md
+++ b/docs/backlog/P1/B-0170-substrate-claim-checker-ts-tool-aaron-2026-05-03.md
@@ -7,7 +7,7 @@ tier: tooling
 effort: M
 ask: Otto 2026-05-03 self-grading, surfaced via drift instances (the verify-then-claim memo's body table is canonical) across 9+ PRs in single session despite naming the verify-then-claim discipline; manual discipline provably insufficient against trained-prior pull
 created: 2026-05-03
-last_updated: 2026-05-11
+last_updated: 2026-05-20
 depends_on: []
 decomposition: decomposed
 classification: buildable-now
@@ -51,7 +51,7 @@ Per the verify-then-claim catalogue:
 | Empirical-output drift | v0.9 | "command returns X" vs actual output |
 | Convention drift | v0.9 | recommended pattern matches canonical convention |
 | Path-form drift | ✓ shipped | fully-qualified vs bare paths consistent across document |
-| Self-recursive drift | v0.9 | the memo about X contains its own X |
+| Self-recursive drift | ✓ shipped (v0.9.0 — count-topic only via `self-check:` frontmatter directive; other topics deferred) | the memo about X contains its own X |
 | Cross-surface count drift (frontmatter ↔ body ↔ section heading ↔ carved sentence ↔ MEMORY.md) | ✓ shipped (v0.8 — frontmatter description vs body table; full cross-surface v0.9) | five surfaces should match consistent N |
 
 ## Hooks integration (planned, not v0)

--- a/tools/substrate-claim-checker/README.md
+++ b/tools/substrate-claim-checker/README.md
@@ -3,7 +3,7 @@
 Substrate-claim-checker per the verify-then-claim discipline memo
 (`memory/feedback_verify_then_claim_discipline_dominant_failure_mode_substrate_authoring_otto_2026_05_03.md`).
 
-Catches 5 B-0170 check-types:
+Catches 6 B-0170 check-types:
 
 - **Count drift** (v0.4.4) — between narrative claims (e.g. "18+ drift
   instances", "13-row table", "5 procedure skills") and the actual
@@ -23,9 +23,13 @@ Catches 5 B-0170 check-types:
   an earlier ADR when the earlier ADR lacks the reciprocal top-of-file
   `Superseded by` marker naming the superseding ADR. Implemented in
   `check-convention.ts`.
+- **Self-recursive drift** (v0.9.0) — a memo declaring itself ABOUT a
+  drift sub-class violates that same discipline within its own body.
+  Opt-in via a `self-check:` frontmatter directive. Implemented in
+  `check-self-recursive.ts`.
 
-The remaining deferred check-types include semantic-equivalence,
-empirical-output, and self-recursive drift.
+The remaining deferred check-types are semantic-equivalence and
+empirical-output drift.
 
 ## Usage
 
@@ -72,9 +76,9 @@ input error).
 - **Existence drift** (file/dir/tool claimed to exist; doesn't) — shipped v0.5
 - **Path-form drift** (fully-qualified vs bare paths inconsistent) — shipped v0.7
 - **Convention drift** (recommended pattern doesn't match canonical) — shipped v0.9
+- **Self-recursive drift** (the memo about drift contains its own drift) — shipped v0.9.0 (count-topic only; others deferred per B-0170.3 slice)
 - **Semantic-equivalence drift** (command substitution claims) — v1
 - **Empirical-output drift** (run-the-command-and-compare) — v1
-- **Self-recursive drift** (the memo about drift contains its own drift) — v1
 
 ## Composes with
 
@@ -280,3 +284,60 @@ Exit codes: `0` clean, `1` drift detected or input error.
   matching. A document with a 15-row drift table and a 3-row
   sub-classes table would pass a "15 sub-classes" claim
   (false negative). v0.9 noun-matching would address this.
+
+## v0.9.0 — `check-self-recursive.ts` (self-recursive drift)
+
+The sixth sub-class checker, covering **self-recursive drift** —
+the meta-failure where a memo declares itself ABOUT a drift
+sub-class and then violates that same discipline within its own
+body. Per the verify-then-claim memo's taxonomy: "the memo about
+drift contains its own drift."
+
+### Opt-in via frontmatter
+
+Files declare their self-check topic explicitly:
+
+```yaml
+---
+self-check: count
+---
+```
+
+OR list form:
+
+```yaml
+---
+self-check: [count]
+---
+```
+
+The directive is operationally honest — no heuristic topic
+detection. A file only participates in self-recursive checks if
+it opts in.
+
+### Supported topics (v0.9.0)
+
+- `count` — composes `check-counts.ts`; a memo about count drift
+  should not contain its own count drift.
+
+Adding additional topics (existence, path-forms, cross-surface,
+convention) is a 1-line dispatch each; deferred to follow-up
+slices per the B-0170 done-criteria.
+
+### Usage
+
+```bash
+bun tools/substrate-claim-checker/check-self-recursive.ts <file>
+bun tools/substrate-claim-checker/check-self-recursive.ts <file> ...
+```
+
+Exit codes: `0` clean (or no `self-check:` directive); `1` drift
+detected or input error.
+
+### Behavior notes
+
+- Files without frontmatter or without `self-check:` are no-ops
+  (exit 0).
+- Unknown topic tokens are dropped with a stderr warning so
+  misspellings do not silently disable the check.
+- A directive containing only unknown topics is a no-op (exit 0).

--- a/tools/substrate-claim-checker/check-self-recursive.test.ts
+++ b/tools/substrate-claim-checker/check-self-recursive.test.ts
@@ -64,6 +64,28 @@ describe("parseDirective", () => {
     expect(parseDirective(`"count"`)).toEqual(["count"]);
     expect(parseDirective(`["count"]`)).toEqual(["count"]);
   });
+
+  test("strips YAML inline comments from bare-token directive", () => {
+    // Regression for the false-negative where `self-check: count # note`
+    // was parsed as topic `count # note` and silently no-op'd.
+    expect(parseDirective("count # enable for this memo")).toEqual(["count"]);
+    expect(parseDirective("count   #trailing")).toEqual(["count"]);
+  });
+
+  test("strips YAML inline comments after array form", () => {
+    expect(parseDirective("[count] # outer note")).toEqual(["count"]);
+    expect(parseDirective("[count, count] #dup-with-note")).toEqual([
+      "count",
+      "count",
+    ]);
+  });
+
+  test("preserves `#` inside a quoted token (no preceding whitespace)", () => {
+    // `#` not preceded by whitespace is not a comment marker in YAML.
+    // After quote-strip the literal "count#x" is rejected as unknown topic,
+    // which is the substrate-honest outcome (we don't invent a new topic).
+    expect(parseDirective("count#x")).toEqual([]);
+  });
 });
 
 describe("checkFile", () => {

--- a/tools/substrate-claim-checker/check-self-recursive.test.ts
+++ b/tools/substrate-claim-checker/check-self-recursive.test.ts
@@ -222,4 +222,29 @@ Claims 99 rows.
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test("dispatches a repeated topic only once (no finding amplification)", () => {
+    const dir = tmp();
+    try {
+      const content = `---
+self-check: [count, count]
+---
+
+# Body claims 5 sub-classes.
+
+| a | b |
+|---|---|
+| 1 | 2 |
+`;
+      const f = write(dir, "dupe-dispatch.md", content);
+      const result = checkFile(f);
+      expect(result.ok).toBe(true);
+      // Without the dispatch-level dedup, the count checker would
+      // fire twice and emit each drift finding twice.
+      expect(result.findings.length).toBe(1);
+      expect(result.findings[0]!.topic).toBe("count");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tools/substrate-claim-checker/check-self-recursive.test.ts
+++ b/tools/substrate-claim-checker/check-self-recursive.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for substrate-claim-checker / check-self-recursive.ts.
+ *
+ * Run with `bun test tools/substrate-claim-checker/check-self-recursive.test.ts`.
+ *
+ * Covers:
+ *   - parseDirective: bare token, array form, unknown topics, quotes
+ *   - checkFile: no frontmatter, no directive, drift case, clean case,
+ *     missing file, array directive dispatch
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { checkFile, parseDirective } from "./check-self-recursive.ts";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), "self-recursive-test-"));
+}
+
+function write(dir: string, name: string, content: string): string {
+  const p = join(dir, name);
+  writeFileSync(p, content);
+  return p;
+}
+
+describe("parseDirective", () => {
+  let origErr: typeof console.error;
+
+  beforeEach(() => {
+    // Suppress unsupported-topic warnings during these tests.
+    origErr = console.error;
+    console.error = () => {};
+  });
+
+  afterEach(() => {
+    console.error = origErr;
+  });
+
+  test("parses bare topic", () => {
+    expect(parseDirective("count")).toEqual(["count"]);
+  });
+
+  test("parses single-element array", () => {
+    expect(parseDirective("[count]")).toEqual(["count"]);
+  });
+
+  test("parses array preserving order and duplicates", () => {
+    expect(parseDirective("[count, count]")).toEqual(["count", "count"]);
+  });
+
+  test("drops unknown topics", () => {
+    expect(parseDirective("[count, future-topic]")).toEqual(["count"]);
+  });
+
+  test("handles empty / whitespace directive", () => {
+    expect(parseDirective("")).toEqual([]);
+    expect(parseDirective("   ")).toEqual([]);
+    expect(parseDirective("[]")).toEqual([]);
+  });
+
+  test("strips surrounding quotes around each token", () => {
+    expect(parseDirective(`"count"`)).toEqual(["count"]);
+    expect(parseDirective(`["count"]`)).toEqual(["count"]);
+  });
+});
+
+describe("checkFile", () => {
+  test("no frontmatter -> no findings", () => {
+    const dir = tmp();
+    try {
+      const f = write(dir, "no-fm.md", "# No frontmatter\n\nbody\n");
+      const result = checkFile(f);
+      expect(result.ok).toBe(true);
+      expect(result.findings).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("frontmatter without self-check -> no findings", () => {
+    const dir = tmp();
+    try {
+      const body =
+        "---\ntitle: a memo\n---\n\n# Body\n\nClaims 5 rows below.\n\n| a | b |\n|---|---|\n| 1 | 2 |\n";
+      const f = write(dir, "no-directive.md", body);
+      const result = checkFile(f);
+      expect(result.ok).toBe(true);
+      expect(result.findings).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("detects self-recursive count drift (claim 5 vs actual 2)", () => {
+    const dir = tmp();
+    try {
+      const content = `---
+self-check: count
+---
+
+# Count-drift memo
+
+The taxonomy below covers 5 sub-classes.
+
+| name | what |
+|---|---|
+| one | a |
+| two | b |
+`;
+      const f = write(dir, "self-recursive.md", content);
+      const result = checkFile(f);
+      expect(result.ok).toBe(true);
+      expect(result.findings.length).toBeGreaterThan(0);
+      expect(result.findings[0]!.topic).toBe("count");
+      expect(result.findings[0]!.reason).toContain("5");
+      expect(result.findings[0]!.reason).toContain("2");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("clean self-check file passes (claim 2 vs actual 2)", () => {
+    const dir = tmp();
+    try {
+      const content = `---
+self-check: count
+---
+
+# Clean memo
+
+The taxonomy below covers 2 sub-classes.
+
+| name | what |
+|---|---|
+| one | a |
+| two | b |
+`;
+      const f = write(dir, "clean.md", content);
+      const result = checkFile(f);
+      expect(result.ok).toBe(true);
+      expect(result.findings).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("array directive dispatches to count checker", () => {
+    const dir = tmp();
+    try {
+      const content = `---
+self-check: [count]
+---
+
+# Memo
+
+Body has 10 rows.
+
+| a | b |
+|---|---|
+| 1 | 2 |
+`;
+      const f = write(dir, "array.md", content);
+      const result = checkFile(f);
+      expect(result.ok).toBe(true);
+      expect(result.findings.length).toBeGreaterThan(0);
+      expect(result.findings[0]!.topic).toBe("count");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("unknown-only directive treated as no-op", () => {
+    const dir = tmp();
+    const origErr = console.error;
+    console.error = () => {};
+    try {
+      const content = `---
+self-check: future-topic
+---
+
+# Body
+
+Claims 99 rows.
+
+| a |
+|---|
+| 1 |
+`;
+      const f = write(dir, "unknown.md", content);
+      const result = checkFile(f);
+      expect(result.ok).toBe(true);
+      expect(result.findings).toEqual([]);
+    } finally {
+      console.error = origErr;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("missing file returns ok:false", () => {
+    const origErr = console.error;
+    console.error = () => {};
+    try {
+      const result = checkFile("/nonexistent/path/file.md");
+      expect(result.ok).toBe(false);
+      expect(result.findings).toEqual([]);
+    } finally {
+      console.error = origErr;
+    }
+  });
+
+  test("directory path returns ok:false", () => {
+    const dir = tmp();
+    const origErr = console.error;
+    console.error = () => {};
+    try {
+      const result = checkFile(dir);
+      expect(result.ok).toBe(false);
+    } finally {
+      console.error = origErr;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tools/substrate-claim-checker/check-self-recursive.ts
+++ b/tools/substrate-claim-checker/check-self-recursive.ts
@@ -57,14 +57,40 @@ export interface Finding {
 const SUPPORTED_TOPICS: ReadonlySet<string> = new Set<SelfCheckTopic>(["count"]);
 
 /**
+ * Strip a YAML inline comment from the directive, respecting flow-sequence
+ * brackets. A `#` preceded by whitespace (or at the start of the directive)
+ * begins an inline comment that runs to end of line, but only when not
+ * inside `[...]` flow-sequence brackets.
+ */
+function stripInlineComment(s: string): string {
+  let depth = 0;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (c === "[") depth++;
+    else if (c === "]") depth--;
+    else if (
+      c === "#" &&
+      depth === 0 &&
+      (i === 0 || /\s/.test(s[i - 1]!))
+    ) {
+      return s.slice(0, i).trimEnd();
+    }
+  }
+  return s;
+}
+
+/**
  * Parse the `self-check:` frontmatter directive into a topic list.
  *
  * Accepts: bare token `count`, or array form `[count]` / `[count, x]`.
+ * YAML inline comments (`# ...` preceded by whitespace, outside flow
+ * brackets) are stripped before tokenisation, so
+ * `self-check: count # enable for this memo` is treated as `count`.
  * Unknown topics are dropped with a stderr warning so misspellings do
  * not silently disable the check.
  */
 export function parseDirective(raw: string): SelfCheckTopic[] {
-  const stripped = raw.trim();
+  const stripped = stripInlineComment(raw.trim());
   if (stripped === "") return [];
 
   let parts: string[];

--- a/tools/substrate-claim-checker/check-self-recursive.ts
+++ b/tools/substrate-claim-checker/check-self-recursive.ts
@@ -119,10 +119,17 @@ export function checkFile(
   if (topics.length === 0) return { findings: [], ok: true };
 
   const findings: Finding[] = [];
+  const dispatched = new Set<SelfCheckTopic>();
+  let allInnerOk = true;
   for (const topic of topics) {
+    if (dispatched.has(topic)) continue;
+    dispatched.add(topic);
     if (topic === "count") {
       const result = checkCounts(filePath);
-      if (!result.ok) continue;
+      if (!result.ok) {
+        allInnerOk = false;
+        continue;
+      }
       for (const f of result.findings) {
         const op = f.claimIsMinimum ? ">=" : "==";
         findings.push({
@@ -135,7 +142,7 @@ export function checkFile(
     }
   }
 
-  return { findings, ok: true };
+  return { findings, ok: allInnerOk };
 }
 
 export function main(): number {

--- a/tools/substrate-claim-checker/check-self-recursive.ts
+++ b/tools/substrate-claim-checker/check-self-recursive.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env bun
+/**
+ * substrate-claim-checker / check-self-recursive.ts (v0.9.0)
+ *
+ * Self-recursive drift sub-class checker — catches the meta-failure
+ * where a memo declaring itself to be ABOUT a drift sub-class then
+ * violates that same discipline within its own body.
+ *
+ * Per the verify-then-claim memo's 7-class taxonomy (B-0170):
+ *   "the memo about drift contains its own drift"
+ *
+ * Mechanism is operationally honest — no heuristic topic detection.
+ * Files opt in by declaring a topic via frontmatter:
+ *
+ *   ---
+ *   self-check: count
+ *   ---
+ *
+ * OR list form:
+ *
+ *   ---
+ *   self-check: [count]
+ *   ---
+ *
+ * Supported topics (v0.9.0):
+ *   - "count" — composes check-counts.ts; a memo about count-drift
+ *     should not contain its own count-drift
+ *
+ * Adding additional topics (existence, path-forms, cross-surface,
+ * convention) is a 1-line dispatch each; deferred to follow-up
+ * slices per B-0170 done-criteria to keep this slice bounded.
+ *
+ * Usage:
+ *   bun tools/substrate-claim-checker/check-self-recursive.ts <file>
+ *   bun tools/substrate-claim-checker/check-self-recursive.ts <file> ...
+ *
+ * Exit code:
+ *   0  no self-recursive drift detected (or no self-check directive)
+ *   1  self-recursive drift detected, input error, or no inputs given
+ */
+
+import { readFileSync } from "node:fs";
+import { checkFile as checkCounts } from "./check-counts.ts";
+import { parseFrontmatter } from "./check-cross-surface.ts";
+
+export type SelfCheckTopic = "count";
+
+export interface Finding {
+  file: string;
+  topic: SelfCheckTopic;
+  /** Line number reported by the underlying checker. */
+  line: number;
+  /** Composed reason string from the underlying checker. */
+  reason: string;
+}
+
+const SUPPORTED_TOPICS: ReadonlySet<string> = new Set<SelfCheckTopic>(["count"]);
+
+/**
+ * Parse the `self-check:` frontmatter directive into a topic list.
+ *
+ * Accepts: bare token `count`, or array form `[count]` / `[count, x]`.
+ * Unknown topics are dropped with a stderr warning so misspellings do
+ * not silently disable the check.
+ */
+export function parseDirective(raw: string): SelfCheckTopic[] {
+  const stripped = raw.trim();
+  if (stripped === "") return [];
+
+  let parts: string[];
+  if (stripped.startsWith("[") && stripped.endsWith("]")) {
+    parts = stripped.slice(1, -1).split(",");
+  } else {
+    parts = [stripped];
+  }
+
+  const out: SelfCheckTopic[] = [];
+  for (const p of parts) {
+    const tok = p.trim().replace(/^["']|["']$/g, "");
+    if (tok === "") continue;
+    if (SUPPORTED_TOPICS.has(tok)) {
+      out.push(tok as SelfCheckTopic);
+    } else {
+      console.error(
+        `warning: self-check topic "${tok}" not supported (v0.9.0 supports: count)`,
+      );
+    }
+  }
+  return out;
+}
+
+export function checkFile(
+  filePath: string,
+): { findings: Finding[]; ok: boolean } {
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      console.error(`error: file not found: ${filePath}`);
+    } else if (code === "EISDIR") {
+      console.error(`error: not a regular file (directory): ${filePath}`);
+    } else {
+      console.error(
+        `error: read failed for ${filePath}: ${(err as Error).message}`,
+      );
+    }
+    return { findings: [], ok: false };
+  }
+
+  const fm = parseFrontmatter(content);
+  if (!fm) return { findings: [], ok: true };
+
+  const directive = fm.fields["self-check"];
+  if (!directive) return { findings: [], ok: true };
+
+  const topics = parseDirective(directive);
+  if (topics.length === 0) return { findings: [], ok: true };
+
+  const findings: Finding[] = [];
+  for (const topic of topics) {
+    if (topic === "count") {
+      const result = checkCounts(filePath);
+      if (!result.ok) continue;
+      for (const f of result.findings) {
+        const op = f.claimIsMinimum ? ">=" : "==";
+        findings.push({
+          file: filePath,
+          topic: "count",
+          line: f.line,
+          reason: `claim "${f.claim}" (expected ${op} ${f.claimedCount}) vs actual ${f.actualCount} (${f.context})`,
+        });
+      }
+    }
+  }
+
+  return { findings, ok: true };
+}
+
+export function main(): number {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error(
+      "usage: bun tools/substrate-claim-checker/check-self-recursive.ts <file> [<file> ...]",
+    );
+    return 1;
+  }
+
+  let totalFindings = 0;
+  let inputErrors = 0;
+
+  for (const arg of args) {
+    const { findings, ok } = checkFile(arg);
+    if (!ok) {
+      inputErrors++;
+      continue;
+    }
+    for (const f of findings) {
+      console.log(
+        `${f.file}:${f.line}: self-recursive drift (${f.topic}) — ${f.reason}`,
+      );
+      totalFindings++;
+    }
+  }
+
+  if (inputErrors > 0) {
+    console.error(`\n${inputErrors} input error(s).`);
+    return 1;
+  }
+  if (totalFindings > 0) {
+    console.log(`\n${totalFindings} self-recursive drift finding(s).`);
+    return 1;
+  }
+  console.log("no self-recursive drift detected.");
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}


### PR DESCRIPTION
## Summary

Smallest safe slice for **B-0170.3** (self-recursive-drift checker TS — "the memo about drift contains its own drift").

Sixth `substrate-claim-checker` sub-class. Operationally honest opt-in: files declare a topic via a `self-check:` frontmatter directive; no heuristic topic detection.

v0.9.0 supports only the `count` topic — composes the existing `check-counts.ts` against the file itself. Adding additional topics (existence, path-forms, cross-surface, convention) is a 1-line dispatch each, deferred to follow-up slices per B-0170 done-criteria.

## What landed

- `tools/substrate-claim-checker/check-self-recursive.ts` — new checker (CLI + library `checkFile` + `parseDirective`)
- `tools/substrate-claim-checker/check-self-recursive.test.ts` — 14 focused tests
- `tools/substrate-claim-checker/README.md` — v0.9.0 section + sub-class table updated
- `docs/backlog/P1/B-0170-...md` — sub-class table row for "Self-recursive drift" updated to shipped; `last_updated` bumped

## Focused check outcomes

```
bun test tools/substrate-claim-checker/check-self-recursive.test.ts
  14 pass, 0 fail (28 expect() calls)

bun test tools/substrate-claim-checker/
  131 pass, 0 fail (302 expect() calls; no regressions)

CLI smoke:
  drift file (claims "7 sub-classes" vs 2-row table) → exit 1
  clean file (no self-check directive)               → exit 0
```

Commit-tree canary clean (`git ls-tree HEAD | wc -l` = 53 root entries, matches `origin/main`).

## How the directive works

```yaml
---
self-check: count
---
```

OR list form:

```yaml
---
self-check: [count]
---
```

Unknown topics are dropped with a stderr warning so misspellings don't silently disable the check. A directive containing only unknown topics is a no-op (exit 0).

## What this slice is NOT

- Does not add new topics beyond `count` (deferred per scope)
- Does not auto-detect topics from filenames (operationally honest opt-in only)
- Does not wire pre-commit / commit-msg / CI hooks (B-0170 done-criteria items 2 + 3 are separate)
- Does not seed fixtures (B-0170.4 is the fixture-coverage row)

## Test plan

- [x] Focused tests pass (`bun test tools/substrate-claim-checker/check-self-recursive.test.ts`)
- [x] Full checker suite passes (`bun test tools/substrate-claim-checker/`)
- [x] CLI smoke tests (drift-detection + clean-pass)
- [x] Commit-tree canary verified (53 root entries pre + post commit)
- [ ] CodeQL / Copilot review on PR

## Composes with

- B-0170 (parent row) — sixth sub-class shipped of seven
- `check-counts.ts` — composed for the `count` topic
- `check-cross-surface.ts` — `parseFrontmatter` reused
- `memory/feedback_verify_then_claim_discipline_dominant_failure_mode_substrate_authoring_otto_2026_05_03.md` — discipline this tool mechanizes

operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)