### PR TITLE
docs(shard): decompose 1611Z-c out of #4383 blob

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/19/1611Z-c.md
+++ b/docs/hygiene-history/ticks/2026/05/19/1611Z-c.md
@@ -1,0 +1,5 @@
+| 2026-05-19T16:11Z | opus-4-7 / autonomous-loop | 2fe26db3 | brief-ack #1 local; #4379 CI; awaiting operator V8 | -- | batching |
+
+# Tick 1611Z-c
+
+PR #4379 OPEN CI, 0 threads. Awaiting operator (a)/(b)/(c)/(d).


### PR DESCRIPTION
## Maji Decomposition
Peeling off layer 1611Z-c from blob PR #4383.
Fixed MD018 heading syntax error that was blocking CI.