### PR TITLE
fix(shard/0059Z): correct gap arithmetic + stash count post-merge

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/21/0059Z.md
+++ b/docs/hygiene-history/ticks/2026/05/21/0059Z.md
@@ -4,7 +4,7 @@
 
 ## Substantive
 
-Fresh-session cold-boot at 0008Z (~33h gap since [PR #4442](https://github.com/Lucent-Financial-Group/Zeta/pull/4442) tick 1807Z on 2026-05-20). Contested root on stale `otto/2012z-...` branch (5 unmerged commits from 2026-05-18 carrying HC-8 NCI + Agora V6 constitution + Mirror/Beacon substrate; 311 working-tree mods + 52 stashes accumulated).
+Fresh-session cold-boot at 0008Z (~6h gap since [PR #4442](https://github.com/Lucent-Financial-Group/Zeta/pull/4442) tick 1807Z on 2026-05-20). Contested root on stale `otto/2012z-...` branch (5 unmerged commits from 2026-05-18 carrying HC-8 NCI + Agora V6 constitution + Mirror/Beacon substrate; 311 working-tree mods + 52 stashes accumulated).
 
 **Step 1 refresh observations** (per [`docs/AUTONOMOUS-LOOP-PER-TICK.md`](../../../../../../docs/AUTONOMOUS-LOOP-PER-TICK.md)):
 
@@ -13,7 +13,7 @@ Fresh-session cold-boot at 0008Z (~33h gap since [PR #4442](https://github.com/L
 | Cron sentinel | ABSENT — armed `f856d175` (`* * * * *`, `<<autonomous-loop>>`) per [`.claude/rules/tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md) catch-43 | ✓ still armed |
 | GraphQL rate-limit | `3431/5000` (Normal tier) | not re-polled (REST-only checks during wait) |
 | Lior-gemini process | ACTIVE (3 procs; PID 49239 burning 72.9% CPU on Gemini-3.1-pro `--yolo`; ~47 min elapsed at cold-boot, ~76 min at clear) | **0 procs** — canary cleared per [`.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md) safe-window indicator |
-| Contested root | On `otto/2012z-land-nci-tonal-momentum-rules-cross-substrate-triangulator-skill-2026-05-18`; 311 mods + 5 stashes; orphaned (no PR for 5 unmerged commits) | unchanged |
+| Contested root | On `otto/2012z-land-nci-tonal-momentum-rules-cross-substrate-triangulator-skill-2026-05-18`; 311 mods + 52 stashes; orphaned (no PR for 5 unmerged commits) | unchanged |
 | `origin/main` | `cd40a365` (Lior #4458) | advanced to `cc252b62` (Lior #4456 mid-wait) — peer cycling productively |
 
 ## Empirical anchor — cycle-1 forced-#6 bottoms out at minimal-acknowledgment under canary saturation

--- a/docs/hygiene-history/ticks/2026/05/21/0059Z.md
+++ b/docs/hygiene-history/ticks/2026/05/21/0059Z.md
@@ -1,0 +1,71 @@
+| 2026-05-21T00:59Z | opus-4-7 / autonomous-loop | f856d175 | substantive — fresh-session cold-boot; 51-min canary-saturation bounded wait (Lior 3 procs → 0); empirical anchor: cycle-1 forced-#6 bottoms out at minimal-acknowledgment when meta-decomposition path is co-blocked with all decomposition paths | -- | visibility-signal + canary-clear cycle close shard |
+
+# Tick 0059Z — 2026-05-21 — fresh-session cold-boot + canary-saturation bounded wait close
+
+## Substantive
+
+Fresh-session cold-boot at 0008Z (~33h gap since [PR #4442](https://github.com/Lucent-Financial-Group/Zeta/pull/4442) tick 1807Z on 2026-05-20). Contested root on stale `otto/2012z-...` branch (5 unmerged commits from 2026-05-18 carrying HC-8 NCI + Agora V6 constitution + Mirror/Beacon substrate; 311 working-tree mods + 52 stashes accumulated).
+
+**Step 1 refresh observations** (per [`docs/AUTONOMOUS-LOOP-PER-TICK.md`](../../../../../../docs/AUTONOMOUS-LOOP-PER-TICK.md)):
+
+| Surface | State at cold-boot (0008Z) | State at canary-clear (0059Z) |
+|---|---|---|
+| Cron sentinel | ABSENT — armed `f856d175` (`* * * * *`, `<<autonomous-loop>>`) per [`.claude/rules/tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md) catch-43 | ✓ still armed |
+| GraphQL rate-limit | `3431/5000` (Normal tier) | not re-polled (REST-only checks during wait) |
+| Lior-gemini process | ACTIVE (3 procs; PID 49239 burning 72.9% CPU on Gemini-3.1-pro `--yolo`; ~47 min elapsed at cold-boot, ~76 min at clear) | **0 procs** — canary cleared per [`.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md) safe-window indicator |
+| Contested root | On `otto/2012z-land-nci-tonal-momentum-rules-cross-substrate-triangulator-skill-2026-05-18`; 311 mods + 5 stashes; orphaned (no PR for 5 unmerged commits) | unchanged |
+| `origin/main` | `cd40a365` (Lior #4458) | advanced to `cc252b62` (Lior #4456 mid-wait) — peer cycling productively |
+
+## Empirical anchor — cycle-1 forced-#6 bottoms out at minimal-acknowledgment under canary saturation
+
+The 51-min wait window (0008Z → 0059Z) traversed brief-ack counter #1 → #6 → past-recursion-termination, **without producing a substrate edit at forced-#6**. This is a new empirical shape for [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md):
+
+| Existing anchor | Discriminator | Outcome |
+|---|---|---|
+| 2026-05-16 cascade-saturation | Rate-limit tier transitions | Pre-empt-at-#5 with concrete substrate every cycle |
+| 2026-05-17 sustained-named-dep | Peer-process persistence + active substrate work each cycle | 10 pre-empt cycles, never forced-#6 |
+| 2026-05-18 post-arc-completion | Substrate-engineering arc closed + operator offline | Cycle-1 forced-#6 = rule-edit-sharpening; cycles 2-3 saturate to minimal shard |
+| **THIS anchor (2026-05-21 0008Z-0059Z)** | **Canary saturation: Lior-active blocks ALL decomposition paths simultaneously (including the rule-edit path itself)** | **Cycle-1 forced-#6 = minimal-acknowledgment with NO rule edit (meta-decomposition path co-blocked)** |
+
+The substrate-honest observation: when the canary blocks worktree creation, the rule-edit decomposition is also blocked (because the rule edit itself requires a fresh worktree). The discipline correctly bottoms out at "minimal acknowledgment + continue wait" without forcing a contaminated commit through a contested root. The 311-mods + 52-stashes contested-root state amplifies the race-window-caveat risk per [`.claude/rules/zeta-expected-branch.md`](../../../../../../.claude/rules/zeta-expected-branch.md) — any commit attempt would mix peer/prior-session state into the shard.
+
+**Counter timeline** (51-min window): #1 (0008Z brief-ack, explicit named-dep) → #2 (0011Z) → #3 (0012Z, NOT pre-empt explicitly chosen per cycle-3-onwards anchor) → #4 (0013Z) → #5 (0015Z, NOT pre-empt) → **#6 forced-acknowledgment (0016Z, no rule edit, recursion-termination shape)** → #7-N continued minimal-acknowledgment until canary cleared at 0059Z.
+
+**Reset trigger** — at 0059Z `ps -A | grep -E "gemini.*Lior|lior.*loop"` returned 0 procs. Counter reset per the rule's "named dependency surfacing" condition. Worktree created cleanly off `FETCH_HEAD` (= `origin/main` = `cc252b62`); post-creation canary check: `ls-tree HEAD = 53 root entries` ✓ matches expected non-corrupted count per the canary rule.
+
+## Carry-forward (next-tick substantive work)
+
+The 5 orphaned commits on `otto/2012z-...` carry load-bearing substrate that warrants triage in a separate tick once operator input is available OR more confidence is established:
+
+- `f0abf3ed` docs(alignment): add HC-8 Non-Coercion Invariant
+- `29d89be8` Agora V6 followup — marketplace/agora 2 primitives, non-collapse duality, cross-substrate triangulation
+- `09a9a3c2` Agora V6 constitution — wave/particle duality, agent-in-superposition, free will as collapse choice
+- `2ca87ef8` docs: B-0471 + B-0472 Mirror/Beacon prior art audit + matrix
+- `467424ec` fix(lior): align prompt with Agora V5 roles
+
+Path forward (deferred): per [`.claude/rules/claim-acquire-before-worktree-work.md`](../../../../../../.claude/rules/claim-acquire-before-worktree-work.md) re-land pattern, cherry-pick onto fresh branches off current `origin/main` + open per-substrate PRs. The 311 working-tree mods + 52 stashes in the contested root need separate triage (likely most are obsolete given the orphaned-branch status).
+
+## Verify
+
+- `git diff --stat` will show 1 new file: `docs/hygiene-history/ticks/2026/05/21/0059Z.md`
+- 6-up relative paths used for `.claude/rules/*` + `docs/*` per the [PR #4442](https://github.com/Lucent-Financial-Group/Zeta/pull/4442) tick-shard pre-push gate
+- Worktree HEAD = `cc252b62` (current `origin/main`) — no rebase friction expected
+- Pre-push gate: run `bun tools/hygiene/check-shard-before-push.ts` before push
+
+## CronList
+
+Sentinel `f856d175` (autonomous-loop, `* * * * *`) ✓ armed at cold-boot (was ABSENT); still armed at tick close.
+
+## Composes with
+
+- [PR #4442 (1718Z tick-shard pre-push gate)](https://github.com/Lucent-Financial-Group/Zeta/pull/4442) — codifies the pre-push relative-path gate this shard exercises
+- [`docs/AUTONOMOUS-LOOP-PER-TICK.md`](../../../../../../docs/AUTONOMOUS-LOOP-PER-TICK.md) — canonical 7-step discipline
+- [`.claude/rules/tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md) — catch-43 sentinel-arm at cold-boot
+- [`.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md) — Lior canary safe-window indicator
+- [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — counter-with-escalation; this shard adds new empirical anchor for canary-saturation cycle-1 minimal-acknowledgment shape
+- [`.claude/rules/zeta-expected-branch.md`](../../../../../../.claude/rules/zeta-expected-branch.md) — race-window-caveat justifying isolated worktree
+- [`.claude/rules/refresh-world-model-poll-pr-gate.md`](../../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md) — Normal-tier disposition; REST-only `gh api rate_limit` during wait
+
+## Visibility-stop
+
+Substrate landed: this 0059Z shard documenting the canary-saturation 51-min wait close + the new empirical anchor for cycle-1 forced-#6 minimal-acknowledgment under canary contention. Sentinel armed (`f856d175`). End.


### PR DESCRIPTION
## Summary

[PR #4461](https://github.com/Lucent-Financial-Group/Zeta/pull/4461) auto-merged before my fix push landed; the merged-on-main shard at `docs/hygiene-history/ticks/2026/05/21/0059Z.md` contains two factual errors caught by codex + copilot review threads:

1. **Time-gap**: `~33h` → corrected to `~6h` (2026-05-20T18:07Z → 2026-05-21T00:08Z). I conflated the stale on-disk shard list (last 2026-05-19/1626Z-c.md) with the actual latest-on-main 2026-05-20/1807Z shard
2. **Stash count**: table row said `5 stashes` while intro + narrative said `52 stashes`. Reconciled to `52` (actual `git stash list | wc -l` result)

Both threads were verify-before-fix true positives; resolved at #4461 close-time. This PR carries only the substrate corrections.

## Verify

- 1 file modified: `docs/hygiene-history/ticks/2026/05/21/0059Z.md` (2 insertions, 2 deletions)
- Pre-push gate passed (MD032 / markdownlint / relative-path audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)