### PR TITLE
fix(shard/0059Z): correct gap arithmetic + stash count

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/21/0059Z.md
+++ b/docs/hygiene-history/ticks/2026/05/21/0059Z.md
@@ -4,7 +4,7 @@
 
 ## Substantive
 
-Fresh-session cold-boot at 0008Z (~33h gap since [PR #4442](https://github.com/Lucent-Financial-Group/Zeta/pull/4442) tick 1807Z on 2026-05-20). Contested root on stale `otto/2012z-...` branch (5 unmerged commits from 2026-05-18 carrying HC-8 NCI + Agora V6 constitution + Mirror/Beacon substrate; 311 working-tree mods + 52 stashes accumulated).
+Fresh-session cold-boot at 0008Z (~6h gap since [PR #4442](https://github.com/Lucent-Financial-Group/Zeta/pull/4442) tick 1807Z on 2026-05-20). Contested root on stale `otto/2012z-...` branch (5 unmerged commits from 2026-05-18 carrying HC-8 NCI + Agora V6 constitution + Mirror/Beacon substrate; 311 working-tree mods + 52 stashes accumulated).
 
 **Step 1 refresh observations** (per [`docs/AUTONOMOUS-LOOP-PER-TICK.md`](../../../../../../docs/AUTONOMOUS-LOOP-PER-TICK.md)):
 
@@ -13,7 +13,7 @@ Fresh-session cold-boot at 0008Z (~33h gap since [PR #4442](https://github.com/L
 | Cron sentinel | ABSENT — armed `f856d175` (`* * * * *`, `<<autonomous-loop>>`) per [`.claude/rules/tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md) catch-43 | ✓ still armed |
 | GraphQL rate-limit | `3431/5000` (Normal tier) | not re-polled (REST-only checks during wait) |
 | Lior-gemini process | ACTIVE (3 procs; PID 49239 burning 72.9% CPU on Gemini-3.1-pro `--yolo`; ~47 min elapsed at cold-boot, ~76 min at clear) | **0 procs** — canary cleared per [`.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md) safe-window indicator |
-| Contested root | On `otto/2012z-land-nci-tonal-momentum-rules-cross-substrate-triangulator-skill-2026-05-18`; 311 mods + 5 stashes; orphaned (no PR for 5 unmerged commits) | unchanged |
+| Contested root | On `otto/2012z-land-nci-tonal-momentum-rules-cross-substrate-triangulator-skill-2026-05-18`; 311 mods + 52 stashes; orphaned (no PR for 5 unmerged commits) | unchanged |
 | `origin/main` | `cd40a365` (Lior #4458) | advanced to `cc252b62` (Lior #4456 mid-wait) — peer cycling productively |
 
 ## Empirical anchor — cycle-1 forced-#6 bottoms out at minimal-acknowledgment under canary saturation


### PR DESCRIPTION
## Summary

[PR #4461](https://github.com/Lucent-Financial-Group/Zeta/pull/4461) auto-merged before this fix landed; the merged-on-main shard contains two factual errors caught by codex + copilot reviews:

1. **Time-gap**: `~33h` → `~6h` (2026-05-20T18:07Z → 2026-05-21T00:08Z). I conflated stale on-disk shard listing with actual latest-on-main shard
2. **Stash count**: table row said `5 stashes` while intro + narrative said `52 stashes`. Reconciled to `52` (the actual `git stash list | wc -l` result)

Supersedes [#4465](https://github.com/Lucent-Financial-Group/Zeta/pull/4465) which had a rebase conflict (its head branch carried the now-squash-merged original commit as well).

## Verify

- 1 file modified: `docs/hygiene-history/ticks/2026/05/21/0059Z.md` (2 insertions, 2 deletions)
- Pre-push gate passed (MD032 / markdownlint / relative-path audit)
- Branch is fresh off current `origin/main`; cherry-picked just the fix commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)