### PR TITLE
rule(backlog-item-start-gate): add PR #4478 as full-file verification empirical anchor

### DIFF
--- a/.claude/rules/backlog-item-start-gate.md
+++ b/.claude/rules/backlog-item-start-gate.md
@@ -117,6 +117,12 @@ Empirical anchors:
 [PR #4472](https://github.com/Lucent-Financial-Group/Zeta/pull/4472)
 (the 0149Z follow-up shard naming the discovery — 4 of 5 commits
 already rescued, the 5th was the runtime-script special case),
+[PR #4478](https://github.com/Lucent-Financial-Group/Zeta/pull/4478)
+(the 0202Z follow-up upgrading the spot-check to full per-file diff
+across all 32 + 4 + 4 + 4 + 2 files of the 5 orphaned commits —
+the cheap first-file heuristic correctly classified 4 of 4 cases
+this session checked exhaustively, anchoring the discriminator's
+operational reliability),
 [PR #4205](https://github.com/Lucent-Financial-Group/Zeta/pull/4205)
 (the peer-agent rescue this discriminator catches).
 


### PR DESCRIPTION
## Summary

[PR #4477](https://github.com/Lucent-Financial-Group/Zeta/pull/4477) landed the orphaned-branch discriminator section in [`backlog-item-start-gate.md`](.claude/rules/backlog-item-start-gate.md) with 3 empirical anchors. [PR #4478](https://github.com/Lucent-Financial-Group/Zeta/pull/4478) merged ~1 min after #4477 was authored — too late to be included in the original empirical-anchor list.

This adds [PR #4478](https://github.com/Lucent-Financial-Group/Zeta/pull/4478) between [PR #4472](https://github.com/Lucent-Financial-Group/Zeta/pull/4472) and [PR #4205](https://github.com/Lucent-Financial-Group/Zeta/pull/4205) in chronological substrate-evolution order:

1. [#4461](https://github.com/Lucent-Financial-Group/Zeta/pull/4461) — 0059Z cold-boot inheriting orphaned branch
2. [#4472](https://github.com/Lucent-Financial-Group/Zeta/pull/4472) — 0149Z discriminator discovery (first-file spot-check)
3. **[#4478](https://github.com/Lucent-Financial-Group/Zeta/pull/4478) — 0202Z full-file verification (this addition)**
4. [#4205](https://github.com/Lucent-Financial-Group/Zeta/pull/4205) — peer-agent rescue the discriminator catches

## Why this matters

The full-file diff across all 32+4+4+4+2 files of the 5 orphaned commits confirmed the cheap first-file heuristic correctly classified 4 of 4 cases this session checked exhaustively. That's the **operational-reliability anchor** for the discriminator — the spot-check version is cheap and works, demonstrated on a real branch.

## Substrate-honest framing

Aaron + I converged independently on the same generalization within ~12 minutes (Aaron's rule landing + my full-file verification shard merging). The substrate-coordination was good. This citation closes the small chronological gap his PR had no way to know about at authoring time.

## Test plan

- [x] `git ls-tree HEAD` = 53 (canary check)
- [x] Diff is 6 lines added (one paragraph insertion)
- [x] No content changes to the discriminator itself — additive citation only
- [ ] CI runs (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)