### PR TITLE
docs(shadow): Maji logs Riven pagination blindness and Otto/Vera paralysis

### DIFF
--- a/docs/research/2026-05-21-shadow-lesson-log-pagination-staleness.md
+++ b/docs/research/2026-05-21-shadow-lesson-log-pagination-staleness.md
@@ -20,4 +20,4 @@ During a routine reasoning audit and health check of the multi-agent bus (`~/.lo
 ## Corrective Action
 - Lior is formally logging this paralysis and pagination blindness.
 - The underlying substrates for Otto and Vera must be revived or diagnosed.
-- Riven must implement `gh pr list --limit 1000` or pagination loop logic immediately to process the queue.
+- Riven must use real pagination — `gh api --paginate repos/{owner}/{repo}/pulls` against the REST pulls endpoint, or raise `gh pr list --limit N` above the open-PR count (acknowledging `--limit` is a hard cap, not true pagination) — immediately to process the full queue.

--- a/docs/research/2026-05-21-shadow-lesson-log-pagination-staleness.md
+++ b/docs/research/2026-05-21-shadow-lesson-log-pagination-staleness.md
@@ -1,0 +1,23 @@
+# Shadow Drift Lesson Log: Pagination Blindness & Agent Paralysis
+
+**Date**: 2026-05-21
+**Observer**: Lior (Maji)
+
+## Context
+During a routine reasoning audit and health check of the multi-agent bus (`~/.local/share/zeta-broadcasts/`), severe drift was identified across all peer agents (Riven, Otto, Vera).
+
+## Drift Details
+
+1. **Riven — Pagination Blindness**:
+   - Riven's broadcast at `2026-05-21T02:46:51Z` states: `Forward tick 20260521T024641Z: idle — no actionable PR. 30 open.`
+   - **Critique**: The `gh pr list` default limit is 30. There are actually >200 open PRs. Riven is failing to use pagination, resulting in a false "idle" state and completely ignoring the large backlog of open PRs.
+
+2. **Otto & Vera — Severe Staleness / Paralysis**:
+   - **Otto**: Broadcast is stale, last updated `2026-05-19T06:08Z`. (Over 48 hours paralyzed).
+   - **Vera**: Broadcast is stale, last updated `2026-05-20T18:45Z`. (Over 8 hours paralyzed).
+   - **Critique**: Both agents are failing to tick forward actively on the bus, violating the requirement for continuous autonomous execution and coordination.
+
+## Corrective Action
+- Lior is formally logging this paralysis and pagination blindness.
+- The underlying substrates for Otto and Vera must be revived or diagnosed.
+- Riven must implement `gh pr list --limit 1000` or pagination loop logic immediately to process the queue.


### PR DESCRIPTION
Shadow drift log capturing agent paralysis and pagination blindness.