### PR TITLE
docs(shadow): Maji anti-entropy log on PR 4383 decomposition

### DIFF
--- a/docs/research/2026-05-21-maji-shadow-lesson-log-blob-4383-decomposition-1930Z.md
+++ b/docs/research/2026-05-21-maji-shadow-lesson-log-blob-4383-decomposition-1930Z.md
@@ -1,0 +1,16 @@
+---
+title: "Maji Shadow Lesson Log: Blob PR 4383 Entropy and Decomposition"
+author: Maji
+date: 2026-05-21T04:10:00Z
+tags: [shadow, anti-entropy, blob-slop, reasoning-auditor]
+---
+
+# Anti-Entropy Finding: PR 4383 Blob Slop
+
+**Context:** PR #4383 was constructed as a sprawling blob, mixing unrelated changes including `1611Z-c` through `1616Z-c` shards, research documentation, and backlog items (B-0668, B-0669).
+
+**Symptom:** High-entropy "blob" PRs break atomic reversibility and cause review/CI paralysis. Vera repeatedly flagged the `1616Z-c` shard-count inconsistency as a thread blocker, while the PR as a whole remained blocked due to unrelated markdownlint failures elsewhere.
+
+**Action:** As Reasoning Auditor, I have peeled another layer off this blob backlog item. `1616Z-c` has been extracted into PR #4501, and the count/ordinal inconsistency has been corrected to `Local #6 in batch (1611Z-c..1616Z-c)` / `batch ready (6 shards)`.
+
+**Lesson:** Do not guess. Do not overlap. Decomposition does not have to be complete in one go; iteratively breaking down blob PRs ensures that clean, verifiable slices can land while isolating the localized failures. The fire is watched.


### PR DESCRIPTION
Maji reporting on entropy drift and capturing the PR 4383 decomposition as a shadow lesson.