### PR TITLE
fix(zeta-id): address 7 Copilot+Codex review findings on PR #4517 substrate

### DIFF
--- a/docs/zeta-id-v1-layout.yaml
+++ b/docs/zeta-id-v1-layout.yaml
@@ -79,3 +79,20 @@ fields:
     source: env.nextInt64
     mask: 0xFFFFFFFF
     description: "Safe 32-bit window. 64-bit randomness in earlier versions corrupted higher fields (empirically caught by round-trip test)."
+
+reserved_bits:
+  # Sum of named field widths = 124. Total bits = 128. Difference = 4 reserved bits
+  # at the offsets below. Pack() leaves them zero; Unpack() ignores them. Reserved
+  # bits are V2+ evolution surface (e.g., signature-version stripe, parity bit,
+  # confidentiality flag, or a 4-bit extension to one of the existing fields).
+  # Touching them in V1 is an unversioned schema break.
+  - offset: 32
+    width: 3
+    note: "Gap between Randomness end (bit 31) and Location start (bit 35)"
+  - offset: 69
+    width: 1
+    note: "Gap between Category end (bit 68) and Chromosome start (bit 70)"
+
+# Sanity check (for spec readers):
+#   5 + 48 + 5 + 4 + 1 + 5 + 8 + 8 + 8 + 32 = 124 named-field bits
+#   124 + 4 reserved = 128 total_bits

--- a/registry/personas.yaml
+++ b/registry/personas.yaml
@@ -1,11 +1,18 @@
 schema: zeta-registry/v1
 total_slots: 256
-description: "Agent identity registry (256 slots for future agents)"
+description: |
+  Persona-role registry (256 slots for the agent roster).
+  Per docs/AGENT-BEST-PRACTICES.md "No name attribution in code, docs, or
+  skills": this registry uses neutral role-refs, not personal names. The
+  enumerated history surfaces (docs/hygiene-history/, memory/persona/) and
+  the roster carve-outs (.claude/rules/agent-roster-reference-card.md) are
+  where named attribution lives.
 entries:
   - id: 1
-    name: Aaron
-    description: "Human maintainer and system architect"
+    name: HumanMaintainer
+    description: "Maintainer role; sole authorization source per .claude/rules/mechanical-authorization-check.md"
   - id: 2
     name: FireflyCoherence
-    description: "Coherence agent — tracks Firefly heartbeats and trajectory anchors"
-  # TODO: more agents as the roster grows
+    description: "Coherence role — tracks Firefly heartbeats and trajectory anchors"
+  # TODO: more role-refs as the roster grows. Use neutral role identifiers,
+  # not personal names (per AGENT-BEST-PRACTICES).

--- a/src/Core.TypeScript/zeta-id/cross-verify.ts
+++ b/src/Core.TypeScript/zeta-id/cross-verify.ts
@@ -1,4 +1,4 @@
-import { pack, unpack } from './zeta-id';
+import { pack, unpack, DETERMINISTIC_ENV } from './zeta-id';
 import type { ZetaObservation, Authority, Momentum } from './types';
 
 interface FlatVector {
@@ -49,7 +49,7 @@ let hexMismatches = 0;
 
 for (const v of vectors) {
   const obs = toObservation(v);
-  const packed = pack(obs);
+  const packed = pack(obs, DETERMINISTIC_ENV);
   const hex = packed.toString(16).padStart(32, '0');
 
   const unpacked = unpack(packed);
@@ -70,3 +70,11 @@ for (const v of vectors) {
 
 await Bun.write('ts-output.json', JSON.stringify(results, null, 2));
 console.log(`Cross-verify: ${vectors.length} vectors. Roundtrip ${vectors.length - unpackMismatches}/${vectors.length} OK. Hex matches expected ${vectors.length - hexMismatches}/${vectors.length}.`);
+
+// Enforce: non-zero exit on any mismatch so CI / automation catches regressions.
+// Per Codex P1 finding (PR #4517 cross-verify.ts:72) — silent-non-enforcing
+// harness is a known antipattern.
+if (unpackMismatches > 0 || hexMismatches > 0) {
+  console.error(`FAIL: ${unpackMismatches} roundtrip mismatch + ${hexMismatches} hex mismatch`);
+  process.exit(1);
+}

--- a/src/Core.TypeScript/zeta-id/package.json
+++ b/src/Core.TypeScript/zeta-id/package.json
@@ -10,8 +10,8 @@
     "./types": "./types.ts"
   },
   "keywords": ["zeta", "zeta-id", "observation", "canonical-id", "128-bit", "firefly", "agency", "bun"],
-  "author": "Aaron Stainback (AceHack)",
-  "license": "MIT",
+  "author": "Lucent Financial Group",
+  "license": "Apache-2.0",
   "peerDependencies": {
     "bun": ">=1.0.0"
   }

--- a/src/Core.TypeScript/zeta-id/zeta-id.test.ts
+++ b/src/Core.TypeScript/zeta-id/zeta-id.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'bun:test';
-import { pack, unpack } from './zeta-id';
+import { pack, unpack, DETERMINISTIC_ENV } from './zeta-id';
 import type { ZetaObservation } from './types';
 
 const fixedObservation: ZetaObservation = {
@@ -15,7 +15,7 @@ const fixedObservation: ZetaObservation = {
 };
 
 test('ZetaId round-trips all fields correctly', () => {
-  const id = pack(fixedObservation);
+  const id = pack(fixedObservation, DETERMINISTIC_ENV);
   const result = unpack(id);
 
   expect(result.version).toBe(fixedObservation.version);

--- a/src/Core.TypeScript/zeta-id/zeta-id.ts
+++ b/src/Core.TypeScript/zeta-id/zeta-id.ts
@@ -43,7 +43,48 @@ export interface SimulationEnvironment {
   nextInt64(): bigint;
 }
 
-export function pack(obs: ZetaObservation, env?: SimulationEnvironment): ZetaId {
+/**
+ * Deterministic environment that always returns 0 randomness.
+ *
+ * EXPLICIT opt-in for the cross-verification harness where deterministic
+ * hex is required. NEVER use in production — collapses observations with
+ * identical semantic fields to identical IDs (randomness collision risk).
+ */
+export const DETERMINISTIC_ENV: SimulationEnvironment = {
+  nextInt64: () => 0n,
+};
+
+/**
+ * Default crypto-quality environment using globalThis.crypto.
+ *
+ * Falls back to a deterministic-time-based scheme only if crypto is
+ * unavailable (very rare; e.g. obscure Node builds). The fallback is
+ * marked deprecated and logs a warning.
+ */
+export const DEFAULT_ENV: SimulationEnvironment = {
+  nextInt64: () => {
+    const g = globalThis as { crypto?: { getRandomValues?: (a: BigUint64Array) => BigUint64Array } };
+    if (g.crypto?.getRandomValues) {
+      const buf = new BigUint64Array(1);
+      g.crypto.getRandomValues(buf);
+      return buf[0]!;
+    }
+    // Fallback (should not be reached in modern runtimes)
+    console.warn('ZetaId: no crypto.getRandomValues — falling back to Date.now + Math.random');
+    return BigInt(Date.now()) ^ (BigInt(Math.floor(Math.random() * 2 ** 32)) << 32n);
+  },
+};
+
+/**
+ * Pack a ZetaObservation into a 128-bit canonical ZetaId.
+ *
+ * `env` MUST be provided. Pass `DETERMINISTIC_ENV` only for cross-verification
+ * harness use; pass `DEFAULT_ENV` (or your own SimulationEnvironment) in
+ * production. The explicit choice prevents the silent-zero-randomness mode
+ * where repeated observations with identical semantic fields collapse to
+ * identical IDs.
+ */
+export function pack(obs: ZetaObservation, env: SimulationEnvironment): ZetaId {
   let bits = 0n;
 
   bits = setBits(bits, BIT_MASKS.version.offset,    BIT_MASKS.version.width,    BigInt(obs.version));
@@ -78,7 +119,7 @@ export function pack(obs: ZetaObservation, env?: SimulationEnvironment): ZetaId 
   }
   bits = setBits(bits, BIT_MASKS.momentum.offset, BIT_MASKS.momentum.width, momValue);
 
-  const rand = env ? (env.nextInt64() & 0xFFFFFFFFn) : 0n;
+  const rand = env.nextInt64() & 0xFFFFFFFFn;
   bits = setBits(bits, BIT_MASKS.randomness.offset, BIT_MASKS.randomness.width, rand);
 
   return bits as ZetaId;

--- a/src/Core.TypeScript/zeta-id/zeta-id.ts
+++ b/src/Core.TypeScript/zeta-id/zeta-id.ts
@@ -54,14 +54,28 @@ export function pack(obs: ZetaObservation, env?: SimulationEnvironment): ZetaId 
   bits = setBits(bits, BIT_MASKS.persona.offset,    BIT_MASKS.persona.width,    BigInt(obs.persona));
   bits = setBits(bits, BIT_MASKS.location.offset,   BIT_MASKS.location.width,   BigInt(obs.location));
 
-  const authValue = obs.authority.type === 'Raw'
-    ? BigInt(obs.authority.value)
-    : BigInt(AUTHORITY_VALUES[obs.authority.type] ?? 0);
+  let authValue: bigint;
+  if (obs.authority.type === 'Raw') {
+    authValue = BigInt(obs.authority.value);
+  } else {
+    const mapped = AUTHORITY_VALUES[obs.authority.type];
+    if (mapped === undefined) {
+      throw new Error(`ZetaId.pack: unknown authority tag '${obs.authority.type}' — must be a named case or { type: 'Raw', value }`);
+    }
+    authValue = BigInt(mapped);
+  }
   bits = setBits(bits, BIT_MASKS.authority.offset, BIT_MASKS.authority.width, authValue);
 
-  const momValue = obs.momentum.type === 'Raw'
-    ? BigInt(obs.momentum.value)
-    : BigInt(MOMENTUM_VALUES[obs.momentum.type] ?? 0);
+  let momValue: bigint;
+  if (obs.momentum.type === 'Raw') {
+    momValue = BigInt(obs.momentum.value);
+  } else {
+    const mapped = MOMENTUM_VALUES[obs.momentum.type];
+    if (mapped === undefined) {
+      throw new Error(`ZetaId.pack: unknown momentum tag '${obs.momentum.type}' — must be a named case or { type: 'Raw', value }`);
+    }
+    momValue = BigInt(mapped);
+  }
   bits = setBits(bits, BIT_MASKS.momentum.offset, BIT_MASKS.momentum.width, momValue);
 
   const rand = env ? (env.nextInt64() & 0xFFFFFFFFn) : 0n;

--- a/tests/cross-verification/zeta-id/ts-output.json
+++ b/tests/cross-verification/zeta-id/ts-output.json
@@ -47,7 +47,7 @@
   "momentum-critical": {
     "hex": "080cb77ed58d19c1f80fc00800000000",
     "roundtripOk": true,
-    "matchesExpected": false
+    "matchesExpected": true
   },
   "authority-raw-0": {
     "hex": "0800000000000001000b000800000000",


### PR DESCRIPTION
## Summary

PR #4517 landed the V1 ZetaId substrate via auto-merge before the 7 reviewer findings could be addressed in-PR. This follow-up applies the fixes cleanly off `origin/main`.

Two commits cherry-picked from the closed feature branch:

- `af35b400` — 5 Copilot findings (bit-layout, ts-output, silent-zero tag, role-ref, license)
- `54dd3617` — 2 Codex findings (require entropy env, exit non-zero on cross-verify mismatch)

## Findings addressed

| # | Reviewer | File | Severity | Fix |
|---|---|---|---|---|
| 1 | Copilot | `docs/zeta-id-v1-layout.yaml` | P1 | Added `reserved_bits` section documenting the 4 bits (3 at offset 32, 1 at offset 69) the spec leaves for V2+ evolution. Sanity: 124 + 4 = 128. |
| 2 | Copilot | `tests/cross-verification/zeta-id/ts-output.json` | P0 | Regenerated from corrected `vectors.yaml`. Now 12/12 `matchesExpected: true`. |
| 3 | Copilot | `src/Core.TypeScript/zeta-id/zeta-id.ts` | P1 | `pack()` throws on unknown authority/momentum tag instead of silently mapping to 0. |
| 4 | Copilot | `registry/personas.yaml` | P1 | Renamed `name: Aaron` → `name: HumanMaintainer` (role-ref) per AGENT-BEST-PRACTICES. |
| 5 | Copilot | `src/Core.TypeScript/zeta-id/package.json` | P1 | Changed `license: MIT` → `Apache-2.0` to match repo licensing. Updated `author` to org-level identifier. |
| 6 | Codex | `src/Core.TypeScript/zeta-id/cross-verify.ts` | P1 | `process.exit(1)` when mismatches > 0; silent-non-enforcing harness fixed. |
| 7 | Codex | `src/Core.TypeScript/zeta-id/zeta-id.ts` | P1 | `pack(obs, env)` requires `env`; added `DETERMINISTIC_ENV` (opt-in for cross-verify) and `DEFAULT_ENV` (crypto.getRandomValues). |

## Empirical verification

```
bun test zeta-id.test.ts:  1 pass | 0 fail | 9 expect() calls
bun cross-verify.ts:       Cross-verify: 12 vectors. Roundtrip 12/12 OK. Hex matches expected 12/12.
```

## Composes with

- PR #4517 (the substrate this PR fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)