### PR TITLE
fix(0822Z): 2 path-audit findings (self-ref + user-scope memory link)

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/21/0822Z.md
+++ b/docs/hygiene-history/ticks/2026/05/21/0822Z.md
@@ -24,7 +24,7 @@ prior_shard: 0603Z
 
 Fresh cold-boot — no prior brief-acks. Per [`tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md): `CronList` returned **no scheduled jobs** at session start. Sentinel re-armed via `CronCreate "* * * * *" "<<autonomous-loop>>"` immediately (catch-43 defense; job `0e3430cc`).
 
-Saturation context per yesterday's [`feedback_21min_lior_stable_saturation_session_arc_counter_discipline_intact_5_anchors_otto_cli_2026_05_21.md`](../../../../../../memory/feedback_21min_lior_stable_saturation_session_arc_counter_discipline_intact_5_anchors_otto_cli_2026_05_21.md) (user-scope; index entry referenced from `MEMORY.md`): the multi-Otto / Lior-cycling saturation has been operating for 12+ hours across multiple cold-boots. The 0603Z cold-boot landed 4 CLEAN-PR merges + canary catch + this rule extension. Now 2h 19min later, the saturation continues; Lior is still actively pushing.
+Saturation context per yesterday's `feedback_21min_lior_stable_saturation_session_arc_counter_discipline_intact_5_anchors_otto_cli_2026_05_21.md` (user-scope only at `~/.claude/projects/.../memory/`; not in-repo; index entry referenced from user-scope `MEMORY.md`): the multi-Otto / Lior-cycling saturation has been operating for 12+ hours across multiple cold-boots. The 0603Z cold-boot landed 4 CLEAN-PR merges + canary catch + this rule extension. Now 2h 19min later, the saturation continues; Lior is still actively pushing.
 
 ## Work picked (Step 3)
 
@@ -54,7 +54,7 @@ Per [`backlog-item-start-gate.md`](../../../../../../.claude/rules/backlog-item-
 
 ## Tick shard (Step 5)
 
-This file at [`docs/hygiene-history/ticks/2026/05/21/0822Z.md`](docs/hygiene-history/ticks/2026/05/21/0822Z.md). Authored from isolated worktree.
+This file at `docs/hygiene-history/ticks/2026/05/21/0822Z.md`. Authored from isolated worktree.
 
 ## CronList (Step 6)
 


### PR DESCRIPTION
## Summary

- **Bug 1 (line 57)**: self-reference link `[`docs/.../0822Z.md`](docs/.../0822Z.md)` resolved as relative-to-current-file produced doubled path. Fix: drop link syntax.
- **Bug 2 (line 27)**: linked a user-scope-only memory file as if it were in-repo at `memory/`. The prose explicitly said "user-scope" but the link contradicted that. Fix: drop link, retain explicit `~/.claude/projects/.../memory/` citation.

Both were caught by `audit-tick-shard-relative-paths.ts --enforce --baseline` running as the non-required `lint (tick-shard relative-paths)` check. They've been polluting every downstream PR's lint signal (including PR #4523 which just merged).

Local re-run reports `0 new findings (19 grandfathered, none new)`.

Surfaced via PR #4523 review-cycle investigation per `blocked-green-ci-investigate-threads.md`: BLOCKED + green-required-CI ≠ flake; investigate; found 2 real bugs (1 self-reference, 1 user-scope-vs-in-repo confusion).

## Test plan

- [x] Local audit: `bun tools/hygiene/audit-tick-shard-relative-paths.ts --enforce --baseline tools/hygiene/audit-tick-shard-relative-paths.baseline.json` → 0 new findings
- [x] Both fixes preserve the substrate intent (line 27 retains user-scope citation; line 57 retains filename in inline code)
- [x] No baseline.json edit needed (the bugs were genuinely new, not grandfathered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)