### PR TITLE
fix(tick-shard-paths): correct 3 grandfathered links in 0329Z.md + trim baseline

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/15/0329Z.md
+++ b/docs/hygiene-history/ticks/2026/05/15/0329Z.md
@@ -3,8 +3,8 @@
 ## Headline
 
 - PR [#3342](https://github.com/Lucent-Financial-Group/Zeta/pull/3342): three review cycles closed this tick (11 + 1 + 7 = 19 findings addressed; one P1 deferred to backlog). Gate state: BLOCKED wait-ci, 0 failed, 0 unresolved threads, auto-merge armed. Three commits landed: `970c774` + `19af54f` + `7084bb3`.
-- [B-0519 RCA](../../../../backlog/P3/B-0519-multi-otto-branch-state-contamination-rca-2026-05-14.md) updated: Pattern 7 "Abandoned rebase state in shared `.git/` dir" added with field-test pointer + cheap-mechanization sketch (stale-rebase-state diagnostic). Committed in `f6789dd`.
-- [B-0528](../../../../backlog/P3/B-0528-shadow-launchd-installer-unit-tests-2026-05-15.md) filed for the deferred test-coverage P1. Committed in `cd4964e`. Effort: S; P3 because behavior is correct (smoke-tested) — tests harden against regression.
+- [B-0519 RCA](../../../../../backlog/P3/B-0519-multi-otto-branch-state-contamination-rca-2026-05-14.md) updated: Pattern 7 "Abandoned rebase state in shared `.git/` dir" added with field-test pointer + cheap-mechanization sketch (stale-rebase-state diagnostic). Committed in `f6789dd`.
+- [B-0528](../../../../../backlog/P3/B-0528-shadow-launchd-installer-unit-tests-2026-05-15.md) filed for the deferred test-coverage P1. Committed in `cd4964e`. Effort: S; P3 because behavior is correct (smoke-tested) — tests harden against regression.
 - Two prior worktrees pruned (`/tmp/zeta-otto-cli-fix-3339-mdlint`, `/tmp/zeta-otto-cli-fix-3349-threads` — both branches merged this morning).
 
 ## Review-cycle-3 findings (this tick, post-`970c774`)
@@ -17,7 +17,7 @@
 | Copilot P2 | ts:306 | `import.meta.main` guard but functions not exported | Added `export` to main, parseArgs, requireAbsolute, tryDetect, xmlEscape, substitutePlaceholders, plutilLint, Args interface |
 | Copilot P1 | shard:51 | "PREFER" snippet in 0305Z shard still showed rename-then-write pattern | Updated to 3-pattern progression with the canonical write-temp-then-atomic-replace |
 | Codex P2 | ts:257 (line of prev commit) | Rename-then-write still leaves canonical path empty in brief window | Replaced with availability-preserving pattern: read-old-into-memory → write temp → atomic replace → side-car backup. Canonical path never empty |
-| Copilot P1 | ts:185 | No unit tests for safety-critical helpers | Deferred to [B-0528](../../../../backlog/P3/B-0528-shadow-launchd-installer-unit-tests-2026-05-15.md) (substrate-honest scope management); PR comment linked the row |
+| Copilot P1 | ts:185 | No unit tests for safety-critical helpers | Deferred to [B-0528](../../../../../backlog/P3/B-0528-shadow-launchd-installer-unit-tests-2026-05-15.md) (substrate-honest scope management); PR comment linked the row |
 
 ## Substrate-honest review-cycle observations
 

--- a/tools/hygiene/audit-tick-shard-relative-paths.baseline.json
+++ b/tools/hygiene/audit-tick-shard-relative-paths.baseline.json
@@ -10,21 +10,6 @@
     "target": "docs/foo.md"
   },
   {
-    "file": "docs/hygiene-history/ticks/2026/05/15/0329Z.md",
-    "line": 6,
-    "target": "../../../../backlog/P3/B-0519-multi-otto-branch-state-contamination-rca-2026-05-14.md"
-  },
-  {
-    "file": "docs/hygiene-history/ticks/2026/05/15/0329Z.md",
-    "line": 7,
-    "target": "../../../../backlog/P3/B-0528-shadow-launchd-installer-unit-tests-2026-05-15.md"
-  },
-  {
-    "file": "docs/hygiene-history/ticks/2026/05/15/0329Z.md",
-    "line": 20,
-    "target": "../../../../backlog/P3/B-0528-shadow-launchd-installer-unit-tests-2026-05-15.md"
-  },
-  {
     "file": "docs/hygiene-history/ticks/2026/05/18/0436Z.md",
     "line": 45,
     "target": "../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md"


### PR DESCRIPTION
## Summary

Slow-steady audit-baseline cleanup, batch 2 (post #4525). 0329Z.md at `docs/hygiene-history/ticks/2026/05/15/` (6 levels deep from repo root) had 3 grandfathered `docs/backlog/` links with 4 `..` instead of 5. Same one-too-few-`..` bug class as #4523/#4524/#4525.

## Fixes

- Line 6: `backlog/P3/B-0519-...md`: 4 `..` → 5 `..`
- Line 7: `backlog/P3/B-0528-...md`: 4 `..` → 5 `..`
- Line 20: `backlog/P3/B-0528-...md`: 4 `..` → 5 `..`

## Baseline trim

3 entries for 0329Z.md removed (34 → 31). Local audit: `scanned 1137 tick shards; 11 broken relative-path links (11 grandfathered by baseline, 0 new)`. Down from 14 grandfathered post-#4525.

## Test plan

- [x] Local `audit-tick-shard-relative-paths.ts --enforce --baseline` reports 0 new findings
- [x] Substrate unchanged (only relative-path depth corrected; prose identical)
- [x] Pattern matches the broader cluster; continuing slow-steady cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)