### PR TITLE
fix(tick-shard-paths): correct 7 grandfathered links in 0603Z.md + trim baseline

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/21/0603Z.md
+++ b/docs/hygiene-history/ticks/2026/05/21/0603Z.md
@@ -15,11 +15,11 @@ graphql_remaining_at_start: 2859
 - `git fetch origin main` clean; main HEAD `b55b9064`
 - Last shard on main: `0249Z.md` (PR #4490) — 318 working-tree mods triage with discriminator's 4th surface
 - Gap from prior shard: 0249Z → 0603Z = ~3h 14min
-- Rate limit: 2859/5000 GraphQL → Normal tier per [`refresh-world-model-poll-pr-gate.md`](../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md) operational tiers
+- Rate limit: 2859/5000 GraphQL → Normal tier per [`refresh-world-model-poll-pr-gate.md`](../../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md) operational tiers
 
 ## Holding-discipline check (Step 2)
 
-Fresh cold-boot — no prior brief-acks. Per [`tick-must-never-stop.md`](../../../../../.claude/rules/tick-must-never-stop.md): CronList returned **no scheduled jobs**. Sentinel re-armed via `CronCreate "* * * * *" "<<autonomous-loop>>"` (catch 43 defense).
+Fresh cold-boot — no prior brief-acks. Per [`tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md): CronList returned **no scheduled jobs**. Sentinel re-armed via `CronCreate "* * * * *" "<<autonomous-loop>>"` (catch 43 defense).
 
 ## Work picked (Step 3)
 
@@ -38,7 +38,7 @@ Picked: direct-merge on CLEAN PRs sitting without merge action. 4 CLEAN candidat
 
 ## Canary catch (Step 4)
 
-**Broken-commit canary fired on first commit attempt.** Per [`codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md):
+**Broken-commit canary fired on first commit attempt.** Per [`codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md):
 
 - `git worktree add /private/tmp/zeta-otto-cli-0603z-shard b55b9064` succeeded with directory populated (44 entries via `ls -la`)
 - However, `git switch -c shard/...` reported tree size 53 BUT the worktree's index was actually empty/stale (peer Otto lock-cleanup race during multi-instance saturation per the canary rule's documented root cause)
@@ -50,7 +50,7 @@ Picked: direct-merge on CLEAN PRs sitting without merge action. 4 CLEAN candidat
 
 ## Tick shard (Step 5)
 
-This file at `docs/hygiene-history/ticks/2026/05/21/0603Z.md`. Written from isolated worktree at `/private/tmp/zeta-otto-cli-0603z-shard` (created off `b55b9064` per [`zeta-expected-branch.md`](../../../../../.claude/rules/zeta-expected-branch.md) race-window-caveat — root worktree on contaminated branch + multi-Otto saturation).
+This file at `docs/hygiene-history/ticks/2026/05/21/0603Z.md`. Written from isolated worktree at `/private/tmp/zeta-otto-cli-0603z-shard` (created off `b55b9064` per [`zeta-expected-branch.md`](../../../../../../.claude/rules/zeta-expected-branch.md) race-window-caveat — root worktree on contaminated branch + multi-Otto saturation).
 
 `git ls-tree HEAD | wc -l` after reset = 53 (clean baseline). Will re-verify post-commit.
 
@@ -74,6 +74,6 @@ Sentinel re-armed at tick start (job `0d40ff23`, `* * * * *` cadence, `<<autonom
 
 **Composes with**:
 
-- [`codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md) — empirical addition: stale-index.lock-as-precursor pattern
-- [`blocked-green-ci-investigate-threads.md`](../../../../../.claude/rules/blocked-green-ci-investigate-threads.md) — 4 CLEAN PRs sitting un-armed is the "merge backlog" failure mode at low-friction scope
-- [`holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — cold-boot tick with concrete artifact (4 merges + this shard + canary catch+empirical addition) satisfies counter-reset condition #3
+- [`codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md) — empirical addition: stale-index.lock-as-precursor pattern
+- [`blocked-green-ci-investigate-threads.md`](../../../../../../.claude/rules/blocked-green-ci-investigate-threads.md) — 4 CLEAN PRs sitting un-armed is the "merge backlog" failure mode at low-friction scope
+- [`holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — cold-boot tick with concrete artifact (4 merges + this shard + canary catch+empirical addition) satisfies counter-reset condition #3

--- a/tools/hygiene/audit-tick-shard-relative-paths.baseline.json
+++ b/tools/hygiene/audit-tick-shard-relative-paths.baseline.json
@@ -118,40 +118,5 @@
     "file": "docs/hygiene-history/ticks/2026/05/19/0007Z-c.md",
     "line": 7,
     "target": "../../../../../../docs/backlog/P1/B-0668-compositional-dbsp-frame-architecture-gnostic-2d-base-plus-two-wolves-emotion-meta-plus-clifford-rx-bonsai-meta-tagged-dims-plus-fsharp-ce-composition-operator-aaron-2026-05-19.md"
-  },
-  {
-    "file": "docs/hygiene-history/ticks/2026/05/21/0603Z.md",
-    "line": 18,
-    "target": "../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md"
-  },
-  {
-    "file": "docs/hygiene-history/ticks/2026/05/21/0603Z.md",
-    "line": 22,
-    "target": "../../../../../.claude/rules/tick-must-never-stop.md"
-  },
-  {
-    "file": "docs/hygiene-history/ticks/2026/05/21/0603Z.md",
-    "line": 41,
-    "target": "../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md"
-  },
-  {
-    "file": "docs/hygiene-history/ticks/2026/05/21/0603Z.md",
-    "line": 53,
-    "target": "../../../../../.claude/rules/zeta-expected-branch.md"
-  },
-  {
-    "file": "docs/hygiene-history/ticks/2026/05/21/0603Z.md",
-    "line": 77,
-    "target": "../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md"
-  },
-  {
-    "file": "docs/hygiene-history/ticks/2026/05/21/0603Z.md",
-    "line": 78,
-    "target": "../../../../../.claude/rules/blocked-green-ci-investigate-threads.md"
-  },
-  {
-    "file": "docs/hygiene-history/ticks/2026/05/21/0603Z.md",
-    "line": 79,
-    "target": "../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md"
   }
 ]


### PR DESCRIPTION
## Summary

Slow-steady audit-baseline cleanup, batch 3 (post #4526). 0603Z.md (today's earlier cold-boot shard) had 7 grandfathered `.claude/rules/` links with 5 `..` instead of 6.

Same one-too-few-`..` bug class as #4523/#4524/#4525/#4526. The pattern recurs in EVERY tick shard authored from inside `docs/hygiene-history/ticks/YYYY/MM/DD/` because the author miscounts the depth (it's 6 levels: docs → hygiene-history → ticks → YYYY → MM → DD).

## Fixes (all single-pattern global replace)

Lines 18, 22, 41, 53, 77, 78, 79 — all `../../../../../.claude/rules/` → `../../../../../../.claude/rules/`.

## Baseline trim

7 entries for 0603Z.md removed (31 → 24). Local audit: `scanned 1137 tick shards; 4 broken relative-path links (4 grandfathered by baseline, 0 new)`. Down from 11 grandfathered post-#4526. Cleanup nearing completion.

## Test plan

- [x] Local `audit-tick-shard-relative-paths.ts --enforce --baseline` reports 0 new findings
- [x] Substrate unchanged (only relative-path depth corrected; prose identical)
- [x] Pattern matches the broader cluster

## Out of scope but worth tracking

The recurrence in EVERY new shard suggests substrate-level mitigation candidates:

- Teach `audit-tick-shard-relative-paths.ts` to emit the correct path when reporting violations
- Extend the shard authoring template / autocomplete to default to 6 `..`
- Pre-commit hook that auto-fixes obviously-wrong-depth paths in tick shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)