### PR TITLE
fix(audit-tick-shard-relative-paths): skip inline code spans + empty baseline

### DIFF
--- a/tools/hygiene/audit-tick-shard-relative-paths.baseline.json
+++ b/tools/hygiene/audit-tick-shard-relative-paths.baseline.json
@@ -1,7 +1,1 @@
-[
-  {
-    "file": "docs/hygiene-history/ticks/2026/05/14/2158Z.md",
-    "line": 29,
-    "target": "docs/foo.md"
-  }
-]
+[]

--- a/tools/hygiene/audit-tick-shard-relative-paths.test.ts
+++ b/tools/hygiene/audit-tick-shard-relative-paths.test.ts
@@ -1,0 +1,63 @@
+// audit-tick-shard-relative-paths.test.ts — tests for stripInlineCodeSpans.
+//
+// The inline-code-span stripper is the load-bearing logic for the audit's
+// FP-class fix on tick shards that include markdown-link EXAMPLES inside
+// double-backtick wrapped code spans (e.g. `` `[link](docs/foo.md)` ``
+// in 2158Z.md). Without the stripper the audit treats the prose example
+// as a real link and flags it as broken.
+
+import { describe, expect, test } from "bun:test";
+import { stripInlineCodeSpans } from "./audit-tick-shard-relative-paths.ts";
+
+describe("stripInlineCodeSpans", () => {
+  test("strips single-backtick code spans", () => {
+    expect(stripInlineCodeSpans("see `code` example")).toBe("see        example");
+  });
+
+  test("strips double-backtick code spans containing single backticks", () => {
+    // The 2158Z.md FP-class anchor: double-backtick wrap is the standard
+    // pattern for showing a single-backtick example in prose.
+    const input = "Inline code spans (`` `[link](docs/foo.md)` ``)";
+    const stripped = stripInlineCodeSpans(input);
+    expect(stripped).not.toContain("[link](docs/foo.md)");
+    expect(stripped).not.toContain("`");
+  });
+
+  test("preserves byte offsets via space replacement", () => {
+    const input = "before `code` after";
+    expect(stripInlineCodeSpans(input).length).toBe(input.length);
+  });
+
+  test("leaves text outside backticks intact", () => {
+    expect(stripInlineCodeSpans("plain prose")).toBe("plain prose");
+    expect(stripInlineCodeSpans("")).toBe("");
+  });
+
+  test("unbalanced backticks are emitted literally (don't swallow rest of line)", () => {
+    // A single stray backtick must not consume to end-of-line; otherwise the
+    // stripper would mask real links downstream of typos.
+    const input = "stray ` and [link](docs/real.md)";
+    expect(stripInlineCodeSpans(input)).toContain("[link](docs/real.md)");
+  });
+
+  test("multiple code spans on one line", () => {
+    const input = "a `b` c `d` e";
+    expect(stripInlineCodeSpans(input)).toBe("a     c     e");
+  });
+
+  test("triple-backtick run requires matching triple-backtick close (CommonMark)", () => {
+    const input = "x ``` y `` z ``` w";
+    // The opening ``` (run of 3) closes only at the matching ``` (run of 3),
+    // so the inner `` (run of 2) is part of the code span.
+    const out = stripInlineCodeSpans(input);
+    // Preserves length; outer x/w preserved; backticks all stripped.
+    expect(out.length).toBe(input.length);
+    expect(out[0]).toBe("x");
+    expect(out[out.length - 1]).toBe("w");
+    expect(out).not.toContain("`");
+  });
+
+  test("backticks adjacent to text are stripped correctly", () => {
+    expect(stripInlineCodeSpans("`code`text")).toBe("      text");
+  });
+});

--- a/tools/hygiene/audit-tick-shard-relative-paths.ts
+++ b/tools/hygiene/audit-tick-shard-relative-paths.ts
@@ -261,6 +261,51 @@ function buildCodeFenceFlags(lines: readonly string[]): boolean[] {
   return flags;
 }
 
+// CommonMark inline code spans: a run of N backticks opens a code span
+// that closes at the next run of EXACTLY N backticks. This handles the
+// double-backtick wrap pattern used to display single-backtick examples
+// in prose (e.g. `` `[link](docs/foo.md)` `` — the inner literal is a
+// prose illustration, not a real markdown link). Replaces each code-span
+// span (including the surrounding delimiters) with spaces of the same
+// length so byte offsets are preserved.
+export function stripInlineCodeSpans(line: string): string {
+  const out: string[] = [];
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] !== "`") {
+      out.push(line[i]!);
+      i++;
+      continue;
+    }
+    let run = 0;
+    while (i + run < line.length && line[i + run] === "`") run++;
+    let j = i + run;
+    let found = -1;
+    while (j < line.length) {
+      if (line[j] === "`") {
+        let close = 0;
+        while (j + close < line.length && line[j + close] === "`") close++;
+        if (close === run) {
+          found = j;
+          break;
+        }
+        j += close;
+      } else {
+        j++;
+      }
+    }
+    if (found === -1) {
+      for (let k = 0; k < run; k++) out.push("`");
+      i += run;
+    } else {
+      const end = found + run;
+      for (let k = i; k < end; k++) out.push(" ");
+      i = end;
+    }
+  }
+  return out.join("");
+}
+
 function extractLinks(file: string): LinkRef[] {
   const text = readFileSync(file, "utf8");
   const lines = text.split("\n");
@@ -268,11 +313,11 @@ function extractLinks(file: string): LinkRef[] {
   const out: LinkRef[] = [];
   for (let i = 0; i < lines.length; i++) {
     if (fenceFlags[i]) continue;
-    const line = lines[i]!;
+    const stripped = stripInlineCodeSpans(lines[i]!);
     MD_LINK_RE.lastIndex = 0;
-    let m: RegExpExecArray | null;
-    while ((m = MD_LINK_RE.exec(line)) !== null) {
-      const target = m[1]!;
+    let match: RegExpExecArray | null;
+    while ((match = MD_LINK_RE.exec(stripped)) !== null) {
+      const target = match[1]!;
       if (isRelativeTarget(target) && !isPlaceholderTarget(target)) {
         out.push({ file, line: i + 1, target });
       }


### PR DESCRIPTION
## Summary

Closes the audit-baseline cleanup arc. Adds `stripInlineCodeSpans` to handle the CommonMark inline-code-span pattern that `2158Z.md` (the FP-class anchor) explicitly describes:

> A correct implementation needs to:
> 1. Skip content inside inline code spans (single + double backtick)
> 2. Skip content inside fenced code blocks

Fence-block skipping was already implemented. Inline code spans were not. The 2158Z FP fired on line 29:

```text
- Inline code spans (`` `[link](docs/foo.md)` ``)
```

The double-backtick wrap pattern is standard CommonMark for displaying a single-backtick example in prose. The audit was treating the inner `[link](docs/foo.md)` as a real markdown link.

## Implementation

CommonMark inline code span rule: a run of N backticks opens a code span that closes at the next run of EXACTLY N backticks. The `stripInlineCodeSpans` function scans left-to-right, finds matched runs, and replaces the entire span (open delim + content + close delim) with spaces of the same length so byte offsets are preserved.

Unbalanced backticks (stray ` without a matching closer) are emitted literally rather than consuming to end-of-line — a safety property verified by test.

## Test suite (new)

Created `audit-tick-shard-relative-paths.test.ts` (the audit tool had no test file previously). 8 tests, 0 failures:

- Single-backtick code spans stripped
- Double-backtick wrapping single-backtick examples (the 2158Z anchor)
- Byte-offset preservation via space replacement
- Plain text unchanged
- Unbalanced backticks emitted literally
- Multiple code spans on one line
- Triple-backtick run requires triple-backtick close
- Backticks adjacent to text

## Audit state on main with fix

`scanned 1139 tick shards; 0 broken relative-path links`. Baseline emptied to `[]`. Future PRs introducing new broken relative-path links fail the gate against zero baseline (no zombie cover).

## Cleanup arc — final state

| PR | Baseline | Active findings |
|---|---|---|
| Pre-arc | 39 | 19 |
| Post-#4524 (0822Z) | 39 | 19 |
| Post-#4525 (1436Z) | 34 | 14 |
| Post-#4526 (0329Z) | 31 | 11 |
| Post-#4531 (0603Z re-land) | 24 | 4 |
| Post-#4533 (sweep) | 2 | 2 |
| Post-#4534 (0852Z pivot) | 1 | 1 |
| Post-this (audit-tool fix) | **0** | **0** |

## Composition

- Follows the substrate-honest pivot pattern from #4534 (Codex P1 catch on tick-shard immutability): this PR's fix is net-new audit-tool code + new test file + baseline trim — none of which edit historical artifacts; immutability discipline doesn't apply.
- The fix path matches what 2158Z.md itself describes as the correct implementation (substrate-prediction validated).

## Test plan

- [x] `bun test tools/hygiene/audit-tick-shard-relative-paths.test.ts` → 8 pass / 0 fail / 13 expect()
- [x] `bun tools/hygiene/audit-tick-shard-relative-paths.ts --enforce --baseline tools/hygiene/audit-tick-shard-relative-paths.baseline.json` → `ok: scanned 1139 tick shards; 0 broken relative-path links`
- [x] Baseline file is `[]` (empty array; valid JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)