### PR TITLE
feat(fsharp-zetaid): Timestamp uses int64<ms> units of measure (Mika V9.3 minimal delta against PR #4548 baseline)

### DIFF
--- a/src/Core.FSharp.ZetaId/Codec.fs
+++ b/src/Core.FSharp.ZetaId/Codec.fs
@@ -10,8 +10,10 @@ module ZetaIdCodec =
     let private layout = BitLayout.Default
 
     /// Timestamp is packed into a 48-bit field; valid range [0, 2^48 - 1].
-    [<Literal>]
-    let private MaxTimestamp = 281474976710655L  // (1L <<< 48) - 1L
+    /// Typed with the `ms` measure to compose with ZetaObservation.Timestamp
+    /// (per Mika V9.3). `[<Literal>]` removed — measure-typed values can't be
+    /// F# literals; this is a regular let-binding (computed once per module init).
+    let private MaxTimestamp : int64<ms> = 281474976710655L<ms>  // (1L <<< 48) - 1L
 
     let private setBits (id: System.UInt128) (field: BitField) (fieldValue: uint64) : System.UInt128 =
         let mask = (System.UInt128.One <<< field.Width) - System.UInt128.One
@@ -37,10 +39,10 @@ module ZetaIdCodec =
         if isNull (box env) then
             raise (System.ArgumentNullException("env"))
 
-        if obs.Timestamp < 0L || obs.Timestamp > MaxTimestamp then
+        if obs.Timestamp < 0L<ms> || obs.Timestamp > MaxTimestamp then
             raise (System.ArgumentOutOfRangeException(
                 "obs", obs.Timestamp :> obj,
-                sprintf "ZetaObservation.Timestamp must be 0..%d (48-bit field). Values outside this range would silently truncate and collide." MaxTimestamp))
+                sprintf "ZetaObservation.Timestamp must be 0..%d ms (48-bit field). Values outside this range would silently truncate and collide." (int64 MaxTimestamp)))
 
         validateEnumField (byte obs.Version)    5 "Version"
         validateEnumField (byte obs.Chromosome) 5 "Chromosome"
@@ -82,7 +84,7 @@ module ZetaIdCodec =
 
         let mutable id = System.UInt128.Zero
         id <- setBits id layout.Version    (uint64 (byte obs.Version))
-        id <- setBits id layout.Timestamp  (uint64 obs.Timestamp)
+        id <- setBits id layout.Timestamp  (uint64 (int64 obs.Timestamp))
         id <- setBits id layout.Chromosome (uint64 (byte obs.Chromosome))
         id <- setBits id layout.Category   (uint64 (byte obs.Category))
         id <- setBits id layout.Firefly    (uint64 (byte obs.Firefly))
@@ -103,7 +105,7 @@ module ZetaIdCodec =
         let toByte field = byte (getBits id field)
         {
             Version    = LanguagePrimitives.EnumOfValue<byte, IdVersion>   (toByte layout.Version)
-            Timestamp  = int64 (getBits id layout.Timestamp)
+            Timestamp  = LanguagePrimitives.Int64WithMeasure<ms> (int64 (getBits id layout.Timestamp))
             Chromosome = LanguagePrimitives.EnumOfValue<byte, Chromosome>  (toByte layout.Chromosome)
             Category   = LanguagePrimitives.EnumOfValue<byte, Category>    (toByte layout.Category)
             Firefly    = LanguagePrimitives.EnumOfValue<byte, Firefly>     (toByte layout.Firefly)

--- a/src/Core.FSharp.ZetaId/Types.fs
+++ b/src/Core.FSharp.ZetaId/Types.fs
@@ -1,5 +1,11 @@
 namespace Zeta.Core.FSharp.ZetaId
 
+/// Milliseconds units of measure. Duplicated locally (not imported from
+/// `src/Core/Units.fs`) to preserve the zero-external-dependencies discipline
+/// of the production library. Per Mika V9.3 substrate (2026-05-21).
+[<Measure>]
+type ms
+
 /// Version field — 5 bits. Currently V1 only.
 /// Mirrors `src/Core.CSharp.ZetaId/IdVersion.cs`.
 type IdVersion =
@@ -167,7 +173,7 @@ module Momentum =
 /// Observation record. All fields explicit; no default-init shortcuts.
 type ZetaObservation = {
     Version: IdVersion
-    Timestamp: int64
+    Timestamp: int64<ms>
     Chromosome: Chromosome
     Category: Category
     Firefly: Firefly

--- a/tests/Tests.FSharp/ZetaId/CrossVerifyTests.fs
+++ b/tests/Tests.FSharp/ZetaId/CrossVerifyTests.fs
@@ -70,7 +70,7 @@ let private toMomentum (v: FlatVector) : Momentum =
 let private toObservation (v: FlatVector) : ZetaObservation =
     {
         Version    = LanguagePrimitives.EnumOfValue<byte, IdVersion>   (checkByte v.Version "Version")
-        Timestamp  = v.Timestamp
+        Timestamp  = LanguagePrimitives.Int64WithMeasure<ms> v.Timestamp
         Chromosome = LanguagePrimitives.EnumOfValue<byte, Chromosome>  (checkByte v.Chromosome "Chromosome")
         Category   = LanguagePrimitives.EnumOfValue<byte, Category>    (checkByte v.Category "Category")
         Firefly    = LanguagePrimitives.EnumOfValue<byte, Firefly>     (checkByte v.Firefly "Firefly")


### PR DESCRIPTION
## Summary

Adds F# units-of-measure to the ZetaId F# implementation's `Timestamp` field. Mika V9.3 minimal delta (~16 lines) against the PR #4548 baseline. Preserves zero-dep discipline by duplicating the `ms` measure locally rather than referencing `src/Core/Units.fs`.

## What changes

| File | Lines | Change |
|---|---|---|
| `src/Core.FSharp.ZetaId/Types.fs` | +6 / -1 | Add `[<Measure>] type ms` at top; change `Timestamp: int64` → `Timestamp: int64<ms>` |
| `src/Core.FSharp.ZetaId/Codec.fs` | +8 / -6 | Type `MaxTimestamp : int64<ms> = 281474976710655L<ms>` (removes `[<Literal>]` — measure values can't be F# literals); update timestamp range-check + `int64` strip at bit-pack time + `LanguagePrimitives.Int64WithMeasure<ms>` wrap at unpack time |
| `tests/Tests.FSharp/ZetaId/CrossVerifyTests.fs` | +1 / -1 | Wrap `v.Timestamp` with `LanguagePrimitives.Int64WithMeasure<ms>` in `toObservation` |

**Total: 16 lines insertions + 8 deletions across 3 files.**

## Why

Compile-time safety. With `int64<ms>` typing on `Timestamp`, the F# compiler catches:

- Passing a raw `int64` (unitless) where `int64<ms>` is expected — compile error
- Mixing `int64<ms>` with `int64<seconds>` or other unit types — compile error
- Arithmetic between measures requires explicit conversion — caught at type-check

This is the F#-idiomatic version of the C# implementation's `long Timestamp` field. C# can't express this without custom type wrappers; F# gets it for free via units of measure.

## Why duplicate the `ms` measure locally

`src/Core/Units.fs` already defines `[<Measure>] type ms`. Importing it would add `Zeta.Core` as a ProjectReference to `Zeta.Core.FSharp.ZetaId.fsproj`, breaking the zero-external-dependencies discipline that mirrors the C# implementation. The 4-line `[<Measure>] type ms` definition is duplicated locally to preserve the zero-dep contract. Per Mika V9.3 substrate (`memory/persona/amara/conversations/*` for the substrate-engineering arc that led here).

## What didn't change

- `BitLayout.fs` untouched — TopDown + BottomUp cross-check discipline preserved
- Authority + Momentum modules untouched — smart constructors + named-collision validation preserved
- Pack-time revalidation from PR #4551 inherited (this PR is a delta on the post-cleanup baseline)
- Zero PackageReferences in production library — discipline preserved
- 3-file split matching C# canonical MA0048 file-per-type pattern — preserved

## Empirical verification

```text
dotnet build tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --nologo
Build succeeded. 0 Warning(s). 0 Error(s). Time Elapsed 00:00:19.27

dotnet test --filter "FullyQualifiedName~CrossVerify"
Passed! - Failed: 0, Passed: 1, Skipped: 0, Total: 1, Duration: 78 ms
```

12/12 canonical vectors still match TS + C# hex byte-for-byte. The measure-type change is purely additive at the type-system layer; bit-packing semantics unchanged.

## Authorship

Mika authored the V9.3 delta design after the V9 → V9.1 → V9.2 substrate-engineering arc. Otto-CLI implemented the delta against the shipped baseline.

The original substrate-engineering conversation arc:

- **V9** (initial draft) — diverged from canonical (Firefly cardinality wrong, Location underscores fail CA1707, Location only 6 of 11 values, namespace `Zeta.Core` breaks separate-project pattern)
- **V9.1** — fixed canonical-value drift but still single-file replacement instead of delta
- **V9.2** — namespace + `ms` measure duplicated locally + Location names match C# canonical
- **V9.3** — refactored to ~6-line surgical delta against shipped 3-file split (this PR)

The iteration arc preserves the substrate-engineering pattern: external design author (Mika) + implementer (Otto-CLI) + maintainer (Aaron) operating across the trust gradient from PR #4549 (the trust-gradient coordination policy applies here at the substrate-design-iteration scope).

## Composes with rules

- `.claude/rules/fsharp-anchor-dotnet-build-sanity-check.md` — F# compiler-as-asymmetric-critic verified clean post-measure-typing
- `.claude/rules/m-acc-multi-oracle-end-user-moral-invariants.md` — multi-oracle parity preserved (F# adds measure-type safety that C#/TS can't express; same canonical hex byte-for-byte)
- `.claude/rules/zeta-ships-with-skills-immediate-value.md` — F# implementation extends with measure-safety improvement; ships in same PR cycle
- `.claude/rules/edge-defining-work-not-speculation.md` — V9.3 IS edge-defining work (measure-units-on-domain-types is uncommon enough to be notable)
- `.claude/rules/all-complexity-is-accidental-in-greenfield.md` — local duplication of 4-line `ms` measure vs cross-project dependency: chose accidental-complexity-stays-accidental (local definition) over essential-complexity (dependency)

## Composes with substrate

- PR #4548 (F# Core ZetaId 3rd peer oracle) — the baseline this PR delta-extends
- PR #4551 (post-merge cleanups) — the post-cleanup baseline this PR inherits Pack-time revalidation from
- PR #4549 (trust-gradient coordination policy archive) — the substrate-engineering pattern that produced this iteration arc
- `src/Core/Units.fs` — the canonical `ms` measure this PR duplicates locally for zero-dep discipline
- `memory/persona/amara/conversations/*` — the 4-archive Amara cascade that produced the substrate-engineering momentum

## Test plan

- [x] `dotnet build` succeeds 0 warnings 0 errors with measure-typed Timestamp
- [x] `dotnet test` cross-verify 12/12 still passes (measure-units don't change canonical hex)
- [x] Zero PackageReferences in production library preserved
- [x] 3-file structure preserved
- [x] BottomUp layout cross-check preserved (untouched)
- [x] Pack-time revalidation from PR #4551 inherited
- [x] Branch landed off latest main (`ace94f2a` base; PR #4551 included)