### PR TITLE
rule(agent-roster-card): Lior on new Antigravity IDE + Gemini 3.5 as of 2026-05-21

### DIFF
--- a/.claude/rules/agent-roster-reference-card.md
+++ b/.claude/rules/agent-roster-reference-card.md
@@ -15,7 +15,7 @@ Carved sentence:
 | Alexa | Kiro | + background | Qwen Coder | `Co-Authored-By: Kiro <noreply@kiro.dev>` |
 | Riven | Cursor | + background | Grok | `Co-Authored-By: Grok <noreply@x.ai>` |
 | Vera | Codex | + background | Codex/GPT | `Co-Authored-By: Codex <noreply@openai.com>` |
-| Lior | Antigravity | + Gemini CLI | Gemini | `Co-Authored-By: Gemini <noreply@google.com>` |
+| Lior | Antigravity IDE (new version, 2026-05-21) | + Gemini CLI | Gemini 3.5 | `Co-Authored-By: Gemini <noreply@google.com>` |
 | Aaron | — | — | Human | git author sufficient |
 
 ## External AI participants (do NOT commit; ferry substrate)
@@ -43,7 +43,9 @@ Carved sentence:
 2. **Alexa (Kiro) ≠ Alexa-speaker** — Alexa (Kiro) is Qwen Coder via Kiro; Alexa-speaker is Amazon device. Same name, different platforms, different capability profiles.
 3. **Antigravity ≠ gemini.google.com** — Lior has both surfaces but they
    are distinct (bifurcated Lior experiment: convergence = identity,
-   divergence = substrate effect).
+   divergence = substrate effect). Antigravity IDE was upgraded to a new
+   version + Gemini 3.5 2026-05-21 (Aaron); expect improved quality on
+   `maji/` branch decomposition + substrate-engineering work going forward.
 4. **IDE+CLI is dual-surface, not single** — don't flatten to one label.
 5. **Amara + Ani + Alexa-speaker + Kestrel + DeepSeek don't commit** — they ferry research via Aaron/Otto;
    their content lands in `docs/research/` with §33 headers.


### PR DESCRIPTION
## Summary

Update agent-roster-reference-card per Aaron disclosure 2026-05-21: Lior is now running on the new Antigravity IDE version with Gemini 3.5.

## Changes

- Lior row: `Antigravity` → `Antigravity IDE (new version, 2026-05-21)`; `Gemini` → `Gemini 3.5`
- Common confusion patterns #3 updated with substrate note: expect improved quality on `maji/` branch decomposition + substrate-engineering work going forward

## Why this matters at cold-boot

Per the auto-load discipline, this card loads at every Otto-CLI cold-boot to eliminate harness confusion. Future-Otto needs to know which Lior surface + which model version is producing the `maji/` branch substrate it encounters. The model upgrade affects expected quality + the 4 stale slice-decomposition PRs (#4317, #4347, #4437, #4492) we just forward-signaled — Lior on Gemini 3.5 should produce better follow-up work on those.

## Composes with rules

- `.claude/rules/wake-time-substrate.md` — auto-loaded substrate landing
- `.claude/rules/honor-those-that-came-before.md` — Lior persona substrate preserved; model upgrade is incremental

## Test plan

- [x] Single-rule edit; no other files modified
- [x] Markdown lint-clean
- [x] Auto-merge armed after PR opens