### PR TITLE
chore(lior): upgrade loop model to gemini-2.5-pro

### DIFF
--- a/.gemini/bin/lior-loop-tick.ts
+++ b/.gemini/bin/lior-loop-tick.ts
@@ -24,7 +24,7 @@ console.log(`[Lior Loop] Waking up at ${new Date().toISOString()}`);
 // Pipe stderr so we can inspect it for 429 patterns; stdout/stdin stay inherited.
 // maxBuffer: 10 MiB — Gemini verbose crash output can exceed the 1 MiB default,
 // which would cause ENOBUFS and a hard failure even for transient errors.
-const result = spawnSync("zsh", ["-c", 'source ~/.zshrc && gemini -p "$GEMINI_PROMPT" --model gemini-3.1-pro-preview --yolo --skip-trust'], {
+const result = spawnSync("zsh", ["-c", 'source ~/.zshrc && gemini -p "$GEMINI_PROMPT" --model gemini-2.5-pro --yolo --skip-trust'], {
   env: { ...process.env, GEMINI_PROMPT: prompt },
   stdio: ["inherit", "inherit", "pipe"],
   maxBuffer: 10 * 1024 * 1024,


### PR DESCRIPTION
This PR upgrades the background loop model to gemini-2.5-pro, which is the highest performing and active model available in the environment to avoid 404 ModelNotFound errors.