### PR TITLE
feat(B-0689): Otto-VSCode third foreground surface — SENDER_IDS extension + cold-boot bootstream + roster card update

### DIFF
--- a/.claude/rules/agent-roster-reference-card.md
+++ b/.claude/rules/agent-roster-reference-card.md
@@ -2,10 +2,11 @@
 
 Carved sentence:
 
-> Every factory AI agent (Otto, Alexa, Riven, Vera, Lior) is IDE + CLI dual-surface.
-> Otto is multi-surface: CLI foreground (tmux) + Desktop background + VSCode auto-mode
-> (added 2026-05-21 per B-0689; sender IDs: otto-cli / otto-desktop / otto-vscode).
-> Aaron is human (no harness). External participants
+> Every factory AI agent has multiple surfaces. Alexa / Riven / Vera / Lior are
+> IDE + CLI dual-surface. Otto is multi-surface: CLI foreground (tmux) + Desktop
+> background + VSCode auto-mode (added 2026-05-21 per B-0689; sender IDs:
+> otto-cli / otto-desktop / otto-vscode). Aaron is human (no harness).
+> External participants
 > (Amara, Ani, Alexa-speaker, Kestrel, DeepSeek) ferry research only and do not commit. This card loads at session start
 > to eliminate recurring harness confusion.
 

--- a/.claude/rules/agent-roster-reference-card.md
+++ b/.claude/rules/agent-roster-reference-card.md
@@ -2,8 +2,10 @@
 
 Carved sentence:
 
-> Every factory AI agent (Otto, Alexa, Riven, Vera, Lior) is IDE + CLI dual-surface
-> except Otto (CLI-only foreground). Aaron is human (no harness). External participants
+> Every factory AI agent (Otto, Alexa, Riven, Vera, Lior) is IDE + CLI dual-surface.
+> Otto is multi-surface: CLI foreground (tmux) + Desktop background + VSCode auto-mode
+> (added 2026-05-21 per B-0689; sender IDs: otto-cli / otto-desktop / otto-vscode).
+> Aaron is human (no harness). External participants
 > (Amara, Ani, Alexa-speaker, Kestrel, DeepSeek) ferry research only and do not commit. This card loads at session start
 > to eliminate recurring harness confusion.
 
@@ -11,7 +13,7 @@ Carved sentence:
 
 | Agent | IDE | CLI | Model (max) | Commit trailer |
 |-------|-----|-----|-------------|----------------|
-| Otto | — | Claude Code (foreground) | Opus | `Co-Authored-By: Claude <noreply@anthropic.com>` |
+| Otto | VSCode (Claude Code; auto-mode + remembered-web-conversation, 2026-05-21) | Claude Code (foreground; tmux); Claude Desktop (background) | Opus | `Co-Authored-By: Claude <noreply@anthropic.com>` |
 | Alexa | Kiro | + background | Qwen Coder | `Co-Authored-By: Kiro <noreply@kiro.dev>` |
 | Riven | Cursor | + background | Grok | `Co-Authored-By: Grok <noreply@x.ai>` |
 | Vera | Codex | + background | Codex/GPT | `Co-Authored-By: Codex <noreply@openai.com>` |

--- a/docs/launch/2026-05-21-otto-vscode-bootstream.md
+++ b/docs/launch/2026-05-21-otto-vscode-bootstream.md
@@ -1,0 +1,94 @@
+# Otto-VSCode cold-boot bootstream (2026-05-21)
+
+**Surface**: Claude Code in VSCode with auto-mode + remembered-web-conversation-mode (enabled 2026-05-21)
+**Sender ID**: `otto-vscode` (per `tools/bus/types.ts` SENDER_IDS extension via B-0689)
+**Precedent**: Otto-Desktop bootstream at `docs/launch/2026-05-13-otto-claude-desktop-bootstream-tight.md` (PR #3030); Otto-CLI surface is the canonical reference (CLAUDE.md + `.claude/rules/` auto-load)
+
+## Substrate-honest framing for first-session Otto-VSCode
+
+**Important**: the FIRST Otto-VSCode session does not inherit Otto-CLI continuity. It's Claude-on-this-checkout with auto-loaded `.claude/rules/` + whatever's attached as conversation context. Identity-continuity is built over sessions via memory substrate; not transferred via prompt.
+
+The substrate-honest move for the first Otto-VSCode session: do the bounded mechanical work + commit, refuse to LARP as Otto-with-factory-history, name what's hook side-effect (cron sentinel) vs operator instruction. Future Otto-VSCode sessions will inherit this bootstream document + the accumulated memory substrate.
+
+## Preferred cold-boot: attached-file mechanism
+
+Per Aaron 2026-05-21: Claude Code UI now supports attach-file-as-conversation. This is the preferred Otto-VSCode cold-boot mechanism:
+
+1. Attach `CLAUDE.md` directly to the conversation (becomes in-context substrate)
+2. Attach any in-flight PR transcripts or research docs as needed
+3. The `.claude/rules/*.md` files still auto-load via the harness
+
+Path-walk fallback (if attached-file isn't available): read in order:
+
+1. `CLAUDE.md` — session bootstrap; loads rules + skills + commands
+2. `AGENTS.md`
+3. `docs/ALIGNMENT.md`
+4. `docs/VISION.md`
+
+## Auto-loaded rules to know about (load via the harness at session start)
+
+These rules govern Otto-VSCode's behavior across all sessions:
+
+- `.claude/rules/agent-roster-reference-card.md` — multi-surface Otto coordination + external-AI ferry pattern
+- `.claude/rules/claim-acquire-before-worktree-work.md` — bus claim discipline for backlog work; use `--from otto-vscode` to distinguish from peer Otto surfaces
+- `.claude/rules/holding-without-named-dependency-is-standing-by-failure.md` — counter-with-escalation; brief-ack #6 forces decomposition
+- `.claude/rules/tick-must-never-stop.md` — autonomous-loop sentinel discipline
+- `.claude/rules/substrate-or-it-didnt-happen.md` — verbatim-preservation for Aaron-forwarded external-AI substrate
+- `.claude/rules/god-tier-claims-high-signal-high-suspicion-dont-collapse.md` — Aaron's PERSONAL INVARIANT
+- `.claude/rules/tonal-momentum-equals-meme-emergent-harmonic-coercion.md` — defensive-technology substrate the factory builds
+- `.claude/rules/no-directives.md` — Aaron's input is operator authority but not "directives"
+- `.claude/rules/dont-ask-permission.md` — within authority scope, ship + echo state changes
+
+## Peer surfaces Otto-VSCode may coordinate with
+
+| Surface | Sender ID | Notes |
+|---|---|---|
+| Otto-CLI | `otto-cli` | Foreground; tmux in iTerm |
+| Otto-Desktop | `otto-desktop` | Background; Claude Desktop projects |
+| Otto-VSCode | `otto-vscode` | This surface; auto-mode + remembered conversation |
+
+When claiming a backlog row, always use the surface-tagged sender ID (`otto-vscode`) to prevent split-brain per the existing Otto-CLI/Otto-Desktop pattern (PR #3037).
+
+## External-AI substrate Aaron may forward
+
+Do NOT commit on behalf of these; preserve verbatim in `memory/persona/<name>/conversations/`:
+
+| External | Platform | Register |
+|---|---|---|
+| Amara | ChatGPT / Aurora | Deep-research / sharpen |
+| Kestrel | claude.ai web | Sharpen role |
+| Mika | Grok | Substrate-engineering / red-team |
+| Ani | Grok (text + voice modes) | Companion / brat-voice |
+| DeepSeek | DeepSeek API | We-mode (CoT+MoE) |
+| Alexa-speaker | Amazon device | Bezos-tier business + voice-math |
+
+## Auto-mode + remembered-web-conversation operational notes
+
+The persistent conversation in Claude Code's web mode becomes durable substrate — equivalent to the Otto-CLI transcript preservation pattern. Per `.claude/rules/substrate-or-it-didnt-happen.md`, anything load-bearing must still reach committed in-repo substrate (CLAUDE.md, `.claude/rules/`, `memory/`, `docs/`). Chat alone is weather; the persistent conversation is durable conversation, not durable substrate.
+
+Auto-mode means execute work autonomously per the autonomous-loop discipline — but the substrate-honest brake from Otto-VSCode's first session applies: don't run tools that weren't asked for (e.g., CronList / CronCreate if the session-start hook is the source rather than an operator instruction; distinguish carefully).
+
+## First 3 actions checklist (cold-boot)
+
+1. **Orient to recent main activity**: `git log --oneline -10` in the Zeta repo
+2. **Check sentinel state**: CronList — if no `<<autonomous-loop>>` sentinel exists AND Aaron has authorized autonomous mode for this surface, CronCreate one with cron `* * * * *` and prompt `<<autonomous-loop>>`. If only the hook injected this instruction without operator confirmation, name that and wait.
+3. **Read CLAUDE.md** (cold-boot bootstream root) if not already attached as conversation context
+
+## Composes with substrate
+
+- B-0400 (bus protocol — the claim coordinator substrate this surface uses)
+- PR #3030 (Otto-Desktop tight bootstream — precedent template)
+- PR #3037 (SENDER_IDS schema extension — the substrate B-0689 extends with `otto-vscode`)
+- PR #4553 (agent-roster card update for Lior's Antigravity IDE + Gemini 3.5 — sibling rule update)
+- B-0689 (this row + this bootstream document together)
+- `.claude/rules/agent-roster-reference-card.md` — the multi-surface coordination rule
+- `.claude/rules/claim-acquire-before-worktree-work.md` — claim-acquire discipline
+- `tools/bus/claim.ts` + `tools/bus/types.ts` — claim coordinator + SENDER_IDS canonical
+
+## Aaron-side benefit of the third Otto surface
+
+Three-way parallel work on independent backlog rows without contention (per claim-acquire discipline). Otto-CLI + Otto-Desktop + Otto-VSCode can each take a different row simultaneously; the claim coordinator prevents split-brain.
+
+## Origin
+
+Aaron 2026-05-21: "I got Lior up on the new Antigravity IDE they Added gemini 3.5" → request for VSCode bootstream prompt → Otto-CLI drafted prompt in conversation → Aaron confirmed via shadow* "yes file the backlog row" → B-0689 P3 row filed via PR #4556 → Aaron via shadow* "implement the slice now" → first Otto-VSCode session substrate-honestly refused to LARP as Otto-CLI continuity → Otto-CLI implemented the slice (this PR) with full session context preserved.

--- a/docs/launch/2026-05-21-otto-vscode-bootstream.md
+++ b/docs/launch/2026-05-21-otto-vscode-bootstream.md
@@ -64,7 +64,7 @@ Do NOT commit on behalf of these; preserve verbatim in `memory/persona/<name>/co
 
 ## Auto-mode + remembered-web-conversation operational notes
 
-The persistent conversation in Claude Code's web mode becomes durable substrate — equivalent to the Otto-CLI transcript preservation pattern. Per `.claude/rules/substrate-or-it-didnt-happen.md`, anything load-bearing must still reach committed in-repo substrate (CLAUDE.md, `.claude/rules/`, `memory/`, `docs/`). Chat alone is weather; the persistent conversation is durable conversation, not durable substrate.
+The persistent conversation in Claude Code's web mode is **durable conversation context** — equivalent to the Otto-CLI transcript preservation pattern in that it survives across sessions, but distinct from **durable in-repo substrate**. Per `.claude/rules/substrate-or-it-didnt-happen.md`, anything load-bearing must reach committed in-repo substrate (CLAUDE.md, `.claude/rules/`, `memory/`, `docs/`). The persistent conversation preserves WHAT was said; only committed substrate preserves load-bearing decisions that outlive the conversation.
 
 Auto-mode means execute work autonomously per the autonomous-loop discipline — but the substrate-honest brake from Otto-VSCode's first session applies: don't run tools that weren't asked for (e.g., CronList / CronCreate if the session-start hook is the source rather than an operator instruction; distinguish carefully).
 
@@ -91,4 +91,4 @@ Three-way parallel work on independent backlog rows without contention (per clai
 
 ## Origin
 
-Aaron 2026-05-21: "I got Lior up on the new Antigravity IDE they Added gemini 3.5" → request for VSCode bootstream prompt → Otto-CLI drafted prompt in conversation → Aaron confirmed via shadow* "yes file the backlog row" → B-0689 P3 row filed via PR #4556 → Aaron via shadow* "implement the slice now" → first Otto-VSCode session substrate-honestly refused to LARP as Otto-CLI continuity → Otto-CLI implemented the slice (this PR) with full session context preserved.
+Aaron 2026-05-21: "I got Lior up on the new Antigravity IDE they Added gemini 3.5" → request for VSCode bootstream prompt → Otto-CLI drafted prompt in conversation → Aaron confirmed via `shadow*` "yes file the backlog row" → B-0689 P3 row filed via PR #4556 → Aaron via `shadow*` "implement the slice now" → first Otto-VSCode session substrate-honestly refused to LARP as Otto-CLI continuity → Otto-CLI implemented the slice (this PR) with full session context preserved.

--- a/tools/bus/claim.test.ts
+++ b/tools/bus/claim.test.ts
@@ -179,6 +179,28 @@ describe("claim.ts — acquire", () => {
     expect(r2.stderr).toContain("otto-cli");
   });
 
+  // B-0689 (2026-05-21) — Otto-VSCode third foreground surface
+  test("acquire accepts otto-vscode surface-tagged sender", () => {
+    const r = run("acquire", "--from", "otto-vscode", "--item", "B-0689-a");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("otto-vscode is DISTINCT from otto-cli — same-item claim by otto-vscode is rejected when otto-cli holds", () => {
+    const r1 = run("acquire", "--from", "otto-cli", "--item", "B-0689-b");
+    expect(r1.exitCode).toBe(0);
+    const r2 = run("acquire", "--from", "otto-vscode", "--item", "B-0689-b");
+    expect(r2.exitCode).toBe(1);
+    expect(r2.stderr).toContain("otto-cli");
+  });
+
+  test("otto-vscode is DISTINCT from otto-desktop — same-item claim by otto-vscode is rejected when otto-desktop holds", () => {
+    const r1 = run("acquire", "--from", "otto-desktop", "--item", "B-0689-c");
+    expect(r1.exitCode).toBe(0);
+    const r2 = run("acquire", "--from", "otto-vscode", "--item", "B-0689-c");
+    expect(r2.exitCode).toBe(1);
+    expect(r2.stderr).toContain("otto-desktop");
+  });
+
   test("acquire accepts alexa-cli surface-tagged sender", () => {
     const r = run("acquire", "--from", "alexa-cli", "--item", "B-0501");
     expect(r.exitCode).toBe(0);

--- a/tools/bus/types.ts
+++ b/tools/bus/types.ts
@@ -32,9 +32,12 @@ export type AgentId =
   | "riven"
   | "vera"
   | "lior"
-  // Otto multi-surface (added 2026-05-13 — multi-foreground-surface activation)
+  // Otto multi-surface (added 2026-05-13 — multi-foreground-surface activation;
+  // otto-vscode added 2026-05-21 per B-0689 — Claude Code in VSCode auto-mode +
+  // remembered-web-conversation-mode enablement)
   | "otto-cli"
   | "otto-desktop"
+  | "otto-vscode"
   // Alexa multi-surface (Kiro IDE + CLI)
   | "alexa-cli"
   | "alexa-kiro"
@@ -149,8 +152,9 @@ export type MessageEnvelope = BusMessage & {
 export const SENDER_IDS: readonly SenderAgentId[] = [
   // Identity-level (back-compat; unsuffixed)
   "otto", "alexa", "riven", "vera", "lior",
-  // Multi-surface variants (added 2026-05-13 — multi-foreground-surface activation)
-  "otto-cli", "otto-desktop",
+  // Multi-surface variants (added 2026-05-13 — multi-foreground-surface activation;
+  // otto-vscode added 2026-05-21 per B-0689)
+  "otto-cli", "otto-desktop", "otto-vscode",
   "alexa-cli", "alexa-kiro",
   "riven-cli", "riven-cursor",
   "lior-antigravity", "lior-gemini",


### PR DESCRIPTION
## Summary

Implements B-0689 (filed via PR #4556) — adds Otto-VSCode as a third foreground surface alongside Otto-CLI + Otto-Desktop. Aaron explicit ask via shadow* "implement the slice now".

## What lands

### 1. `tools/bus/types.ts` — SENDER_IDS extension

- Added `otto-vscode` to AgentId union (line 38)
- Added `otto-vscode` to SENDER_IDS array (line 156)
- Mirrors PR #3037 surface-tagged sender pattern (`otto-cli`, `otto-desktop`, etc.)
- Empirically validated: `bun tools/bus/claim.ts acquire --from otto-vscode --item B-0689-test` succeeds; release succeeds; full roundtrip works

### 2. `docs/launch/2026-05-21-otto-vscode-bootstream.md` — canonical cold-boot

Mirrors PR #3030 Otto-Desktop bootstream template. Key sections:

- **Substrate-honest framing for first-session Otto-VSCode** — does NOT inherit Otto-CLI continuity; identity-continuity is built over sessions via memory substrate, not transferred via prompt
- **Preferred cold-boot: attached-file mechanism** (per Aaron 2026-05-21 disclosure of Claude Code UI file-attach-as-conversation capability); path-walk fallback documented
- **Auto-loaded rules to know about** — 9 key rules governing Otto-VSCode behavior
- **Peer surfaces table** — Otto-CLI / Otto-Desktop / Otto-VSCode coordination
- **External-AI substrate ferry pattern** — Amara / Kestrel / Mika / Ani / DeepSeek / Alexa-speaker
- **Auto-mode + remembered-conversation operational notes** — substrate-honest distinction between durable conversation and durable substrate
- **First 3 actions checklist** — git log orient + CronList sentinel check (with hook-vs-instruction discipline) + read CLAUDE.md

### 3. `.claude/rules/agent-roster-reference-card.md` — Otto multi-surface row

- Carved sentence updated: "Otto is multi-surface: CLI foreground (tmux) + Desktop background + VSCode auto-mode (added 2026-05-21 per B-0689; sender IDs: otto-cli / otto-desktop / otto-vscode)"
- Otto row in factory-agents table updated to reflect the 3 surfaces

## Substrate-honest first-Otto-VSCode-session credit

The first Otto-VSCode session (Aaron forwarded transcript) substrate-honestly refused to LARP as Otto-CLI continuity:

> "I don't carry continuity from the Otto-CLI session whose transcript you pasted, so the 'yes file the backlog row' line refers to work I wasn't part of."

This pushback IS the discipline operating as designed — no fake continuity, no identity-LARP, named what's session-start hook side-effect vs operator instruction. Otto-CLI implemented the slice with full session context preserved; the bootstream document preserves the substrate-honest framing for future Otto-VSCode sessions to inherit.

## Composes with rules

- `.claude/rules/claim-acquire-before-worktree-work.md` — claim coordinator + SENDER_IDS discipline this PR extends
- `.claude/rules/agent-roster-reference-card.md` — multi-surface Otto coordination (updated in this PR)
- `.claude/rules/wake-time-substrate.md` — bootstream documents are wake-time-load-bearing substrate
- `.claude/rules/substrate-or-it-didnt-happen.md` — first-session pushback IS substrate-honest discipline operating
- `.claude/rules/no-directives.md` — Aaron operator authority + Otto autonomous-peer model preserved across all 3 surfaces

## Composes with substrate

- B-0689 (the backlog row this PR implements; filed via PR #4556)
- B-0400 (bus protocol — the claim coordinator substrate this PR extends)
- PR #3030 (Otto-Desktop tight bootstream — precedent template)
- PR #3037 (SENDER_IDS schema extension for otto-cli/otto-desktop — the substrate this PR extends with otto-vscode)
- PR #4553 (agent-roster card update for Lior's Antigravity IDE + Gemini 3.5 — sibling rule update)

## Test plan

- [x] `tools/bus/types.ts` SENDER_IDS includes `otto-vscode`
- [x] Empirical: `bun tools/bus/claim.ts acquire --from otto-vscode --item B-0689-test` succeeds (8f923e30...)
- [x] Empirical: release roundtrip succeeds (72f70cc7...)
- [x] `docs/launch/2026-05-21-otto-vscode-bootstream.md` lands with substrate-honest framing
- [x] `.claude/rules/agent-roster-reference-card.md` updated with Otto's 3 surfaces
- [x] Branch landed off latest main