### PR TITLE
feat(core): PR 1 of 8 — algebra capability tags on Op<'T> base class

### DIFF
--- a/src/Core/Circuit.fs
+++ b/src/Core/Circuit.fs
@@ -42,6 +42,52 @@ type Op() =
     abstract IsAsync: bool
     default _.IsAsync = false
 
+    // ─────────────────────────────────────────────────────────────────
+    //  Algebra capability tags. Promoted from plugin-only marker
+    //  interfaces (PluginApi.fs) to first-class fields on the Op base
+    //  class so internal operators and plugin operators declare
+    //  capabilities through the same surface. The scheduler, fusion
+    //  engine, and incremental-rewriter dispatcher all consult these
+    //  fields — they're load-bearing for capability-aware optimization,
+    //  not decorative.
+    //
+    //  Default false; each concrete operator overrides only the
+    //  capabilities it actually has. Lying about a tag is an algebraic
+    //  contract violation — LawRunner can verify each in test mode.
+    // ─────────────────────────────────────────────────────────────────
+
+    /// Algebra capability: operator is *linear* — `op(a + b) = op(a) +
+    /// op(b)` and `op(0) = 0`. Retraction-native: a negative-weight
+    /// input un-accumulates correctly. `IncrementalAuto` uses this to
+    /// emit `Q^Δ = Q` (linear operators incrementalize trivially).
+    abstract IsLinear: bool
+    default _.IsLinear = false
+
+    /// Algebra capability: operator is *bilinear* in its two inputs.
+    /// `op(a₁+a₂, b) = op(a₁, b) + op(a₂, b)` and symmetrically for the
+    /// second argument; additionally `op(0, b) = op(a, 0) = 0`.
+    /// `IncrementalAuto` uses this to emit the three-term incremental
+    /// form `Δa ⋈ Δb + z⁻¹(I(a)) ⋈ Δb + Δa ⋈ z⁻¹(I(b))`.
+    abstract IsBilinear: bool
+    default _.IsBilinear = false
+
+    /// Algebra capability: operator is a *sink* — terminal,
+    /// retraction-lossy, may emit a non-Z-set output. Sinks are
+    /// excluded from relational composition: `Circuit.Build()` rejects
+    /// any operator that reads from a sink's output stream (terminal-
+    /// placement enforcement). Bayesian aggregates and external-system
+    /// sinks are canonical examples.
+    abstract IsSink: bool
+    default _.IsSink = false
+
+    /// Algebra capability: operator carries explicit stateful-strict
+    /// semantics — init/step/retract triple — distinct from `IsStrict`
+    /// (feedback-cut). Stateful-strict operators hold per-key state
+    /// that must retract cleanly when a negative-weight input arrives.
+    /// `LawRunner.checkRetractionCompleteness` verifies the claim.
+    abstract IsStatefulStrict: bool
+    default _.IsStatefulStrict = false
+
 
 /// An operator with a typed output slot.
 ///

--- a/src/Core/Fusion.fs
+++ b/src/Core/Fusion.fs
@@ -17,6 +17,10 @@ type internal FilterMapOp<'A, 'B when 'A : comparison and 'B : comparison>
     let inputs = [| input :> Op |]
     override _.Name = "filterMap"
     override _.Inputs = inputs
+    /// Linear: filter ∘ map is the composition of two linear ops —
+    /// distributes over Z-set addition. The fused implementation
+    /// preserves linearity by construction.
+    override _.IsLinear = true
     override this.StepAsync(_: CancellationToken) =
         let span = input.Value.AsSpan()
         if span.IsEmpty then
@@ -50,6 +54,9 @@ type internal FilterMapOptionalOp<'A, 'B when 'A : comparison and 'B : compariso
     let inputs = [| input :> Op |]
     override _.Name = "filterMap"
     override _.Inputs = inputs
+    /// Linear: same reasoning as FilterMapOp — the choose-shaped
+    /// `pickMap` is equivalent to a filter+map composition.
+    override _.IsLinear = true
     override this.StepAsync(_: CancellationToken) =
         let span = input.Value.AsSpan()
         if span.IsEmpty then

--- a/src/Core/Operators.fs
+++ b/src/Core/Operators.fs
@@ -13,6 +13,10 @@ type internal MapZSetOp<'A, 'B when 'A : comparison and 'B : comparison>(input: 
     let inputs = [| input :> Op |]
     override _.Name = "map"
     override _.Inputs = inputs
+    /// Linear: ZSet.map f distributes over Z-set addition because
+    /// `f` rewrites keys without touching weights, and equal keys sum
+    /// their weights linearly.
+    override _.IsLinear = true
     override this.StepAsync(_: CancellationToken) =
         this.Value <- ZSet.map f.Invoke input.Value
         ValueTask.CompletedTask
@@ -24,6 +28,8 @@ type internal FilterZSetOp<'K when 'K : comparison>(input: Op<ZSet<'K>>, predica
     let inputs = [| input :> Op |]
     override _.Name = "filter"
     override _.Inputs = inputs
+    /// Linear: predicate is weight-independent, so filter(a+b) = filter(a)+filter(b).
+    override _.IsLinear = true
     override this.StepAsync(_: CancellationToken) =
         this.Value <- ZSet.filter predicate.Invoke input.Value
         ValueTask.CompletedTask
@@ -36,6 +42,9 @@ type internal FlatMapZSetOp<'A, 'B when 'A : comparison and 'B : comparison>
     let inputs = [| input :> Op |]
     override _.Name = "flatMap"
     override _.Inputs = inputs
+    /// Linear: ZSet.flatMap scales `f k` by the input entry's weight
+    /// before accumulating — distributes over Z-set addition.
+    override _.IsLinear = true
     override this.StepAsync(_: CancellationToken) =
         this.Value <- ZSet.flatMap f.Invoke input.Value
         ValueTask.CompletedTask
@@ -69,6 +78,8 @@ type internal NegZSetOp<'K when 'K : comparison>(a: Op<ZSet<'K>>) =
     let inputs = [| a :> Op |]
     override _.Name = "neg"
     override _.Inputs = inputs
+    /// Linear: -(a + b) = -a + -b and -0 = 0.
+    override _.IsLinear = true
     override this.StepAsync(_: CancellationToken) =
         this.Value <- ZSet.neg a.Value
         ValueTask.CompletedTask
@@ -108,6 +119,10 @@ type internal JoinZSetOp<'A, 'B, 'K, 'C
     let inputs = [| a :> Op; b :> Op |]
     override _.Name = "join"
     override _.Inputs = inputs
+    /// Bilinear: (a₁+a₂) ⋈ b = (a₁ ⋈ b) + (a₂ ⋈ b), symmetric in b,
+    /// and 0 ⋈ b = a ⋈ 0 = 0. IncrementalAuto rewrites this to the
+    /// three-term form `Δa ⋈ Δb + z⁻¹(I(a)) ⋈ Δb + Δa ⋈ z⁻¹(I(b))`.
+    override _.IsBilinear = true
     override this.StepAsync(_: CancellationToken) =
         this.Value <-
             ZSet.join
@@ -125,6 +140,9 @@ type internal CartesianZSetOp<'A, 'B when 'A : comparison and 'B : comparison>
     let inputs = [| a :> Op; b :> Op |]
     override _.Name = "cartesian"
     override _.Inputs = inputs
+    /// Bilinear: weights multiply (Checked.* in ZSet.cartesian); the
+    /// product distributes over Z-set addition in each argument.
+    override _.IsBilinear = true
     override this.StepAsync(_: CancellationToken) =
         this.Value <- ZSet.cartesian a.Value b.Value
         ValueTask.CompletedTask
@@ -179,6 +197,10 @@ type internal IndexWithOp<'A, 'K, 'V
     let inputs = [| input :> Op |]
     override _.Name = "indexWith"
     override _.Inputs = inputs
+    /// Linear: indexing distributes over Z-set addition because the
+    /// (key, value) extraction is weight-independent and the
+    /// per-key value groups sum via ZSet.add.
+    override _.IsLinear = true
     override this.StepAsync(_: CancellationToken) =
         this.Value <- IndexedZSet.indexWith key.Invoke value.Invoke input.Value
         ValueTask.CompletedTask
@@ -194,6 +216,9 @@ type internal IndexedJoinOp<'K, 'VA, 'VB, 'C
     let inputs = [| a :> Op; b :> Op |]
     override _.Name = "indexedJoin"
     override _.Inputs = inputs
+    /// Bilinear: per-key value-group cartesian; weights multiply
+    /// (Checked.* in IndexedZSet.join); distributes per-arg.
+    override _.IsBilinear = true
     override this.StepAsync(_: CancellationToken) =
         this.Value <-
             IndexedZSet.join

--- a/src/Core/PluginApi.fs
+++ b/src/Core/PluginApi.fs
@@ -95,21 +95,54 @@ type INestedFixpointParticipant =
     abstract Fixedpoint : scope: int -> bool
 
 
+// ─────────────────────────────────────────────────────────────────────
+//  Algebra capability tags — non-generic markers + typed interfaces.
+//
+//  F# (and the CLR) cannot test `:? IBilinearOperator<obj, obj, 'TOut>`
+//  against a concrete `IBilinearOperator<'A, 'B, 'C>` instance because
+//  generic-interface type tests require exact type-parameter match.
+//  The fix is the BCL pattern used by `IEnumerable` vs `IEnumerable<T>`:
+//  a non-generic marker interface for runtime type tests, and a
+//  generic interface (inheriting the marker) for typed access.
+//
+//  Plugin authors only need to implement the typed interface; the
+//  marker is satisfied automatically via interface inheritance. The
+//  scheduler / fusion engine / IncrementalAuto dispatcher tests
+//  against the marker, not the generic.
+// ─────────────────────────────────────────────────────────────────────
+
+/// Non-generic marker for `ILinearOperator<_, _>`. Used by
+/// `PluginOperatorAdapter` and the scheduler for `:?` runtime tests
+/// that don't need exact generic-parameter match.
+type ILinearMarker = interface end
+
+/// Non-generic marker for `IBilinearOperator<_, _, _>`.
+type IBilinearMarker = interface end
+
+/// Non-generic marker for `ISinkOperator<_, _>`.
+type ISinkMarker = interface end
+
+/// Non-generic marker for `IStatefulStrictOperator<_, _, _>`.
+type IStatefulStrictMarker = interface end
+
+
 /// Algebra capability: the operator is *linear* — `op(a + b) =
 /// op(a) + op(b)` and `op(0) = 0`. Retraction-native: a
 /// negative weight un-accumulates correctly. Declared at the
 /// type level so the scheduler can run `LinearLaw` at
-/// `Circuit.Build()`.
+/// `Circuit.Build()` (test-time, via `LawRunner.checkLinear`).
 type ILinearOperator<'TIn, 'TOut> =
     inherit IOperator<'TOut>
+    inherit ILinearMarker
 
 
 /// Algebra capability: the operator is *bilinear* in two
 /// inputs (e.g. a join). Incrementalisation generates the
 /// standard `Δa ⋈ Δb + z^-1(I(a)) ⋈ Δb + Δa ⋈ z^-1(I(b))`
-/// form.
+/// form. Verified by `LawRunner.checkBilinear` (when available).
 type IBilinearOperator<'TIn1, 'TIn2, 'TOut> =
     inherit IOperator<'TOut>
+    inherit IBilinearMarker
 
 
 /// Algebra capability: the operator is a *sink* — terminal,
@@ -117,19 +150,22 @@ type IBilinearOperator<'TIn1, 'TIn2, 'TOut> =
 /// operators are consciously exempt from relational
 /// composition laws and the scheduler enforces terminal
 /// placement (a sink may not feed another operator inside a
-/// relational path). Bayesian aggregates are the canonical
-/// example.
+/// relational path) via the `Circuit.Build()` validation pass.
+/// Bayesian aggregates are the canonical example.
 type ISinkOperator<'TIn, 'TOut> =
     inherit IOperator<'TOut>
+    inherit ISinkMarker
 
 
 /// Algebra capability: the operator carries explicit stateful
 /// strict semantics — init / step / retract triple. Distinct
 /// from `IStrictOperator` (feedback-cut): stateful-strict ops
 /// hold per-key or per-instance state that must retract
-/// cleanly when a negative weight arrives.
+/// cleanly when a negative weight arrives. Verified by
+/// `LawRunner.checkRetractionCompleteness`.
 type IStatefulStrictOperator<'TIn, 'TState, 'TOut> =
     inherit IOperator<'TOut>
+    inherit IStatefulStrictMarker
 
 
 /// Internal adapter: wraps an `IOperator<'T>` inside an
@@ -164,6 +200,17 @@ type internal PluginOperatorAdapter<'TOut>(plugin: IOperator<'TOut>, inputOps: O
         | :? INestedFixpointParticipant as f -> Some f
         | _ -> None
 
+    // Algebra capability detection via non-generic markers. The typed
+    // interfaces (`ILinearOperator<_,_>` etc.) inherit from these
+    // markers, so a plugin implementing `ILinearOperator<int, string>`
+    // satisfies `ILinearMarker` automatically. Cached once at
+    // construction; the adapter pays zero per-tick cost for capability
+    // surfacing.
+    let isLinearCap         = (box plugin) :? ILinearMarker
+    let isBilinearCap       = (box plugin) :? IBilinearMarker
+    let isSinkCap           = (box plugin) :? ISinkMarker
+    let isStatefulStrictCap = (box plugin) :? IStatefulStrictMarker
+
     member internal _.PublishCount = publishCount
 
     override _.Name = plugin.Name
@@ -176,6 +223,11 @@ type internal PluginOperatorAdapter<'TOut>(plugin: IOperator<'TOut>, inputOps: O
         match asAsync with
         | Some a -> a.IsAsync
         | None -> false
+
+    override _.IsLinear         = isLinearCap
+    override _.IsBilinear       = isBilinearCap
+    override _.IsSink           = isSinkCap
+    override _.IsStatefulStrict = isStatefulStrictCap
 
     override this.StepAsync(ct: CancellationToken) : ValueTask =
         let buffer = OutputBuffer<'TOut>(this, publishCount)

--- a/src/Core/Primitive.fs
+++ b/src/Core/Primitive.fs
@@ -14,6 +14,11 @@ type internal DelayOp<'T>(input: Op<'T>, initial: 'T) =
     override _.Name = "z^-1"
     override _.Inputs = inputs
     override _.IsStrict = true
+    /// Linear: `z⁻¹` is a time-shift; it distributes over addition
+    /// trivially when `initial = 0` for the group. Callers passing a
+    /// non-zero initial are responsible for the resulting affine
+    /// offset — DBSP usage always passes the group zero.
+    override _.IsLinear = true
     override this.StepAsync(_: CancellationToken) =
         this.Value <- state
         ValueTask.CompletedTask
@@ -35,6 +40,11 @@ type internal IntegrateOp<'T>(input: Op<'T>, zero: 'T, add: Func<'T, 'T, 'T>) =
     let mutable state = zero
     override _.Name = "integrate"
     override _.Inputs = inputs
+    /// Linear: `I` is the running sum operator; it commutes with the
+    /// group operation by associativity/commutativity of the supplied
+    /// `add` function. Caller is responsible for passing a true
+    /// group `(zero, add)` — Z-set's `(Empty, ZSet.add)` qualifies.
+    override _.IsLinear = true
     // Integration is causal but NOT strict (per the DBSP paper, §2.18). The
     // scheduler runs us in topological order *after* `input`, so at StepAsync
     // time `input.Value` is the current tick's delta. We update state and
@@ -52,6 +62,10 @@ type internal DifferentiateOp<'T>(input: Op<'T>, zero: 'T, sub: Func<'T, 'T, 'T>
     let mutable prev = zero
     override _.Name = "differentiate"
     override _.Inputs = inputs
+    /// Linear: `D` distributes over the group operation by linearity
+    /// of `sub` on an abelian group. Inverse of `IntegrateOp` (modulo
+    /// initial conditions).
+    override _.IsLinear = true
     // IsStrict remains false — non-strict ops run in topo order so by the time
     // we execute, the input operator's `Value` reflects the current tick.
     override this.StepAsync(_: CancellationToken) =

--- a/tests/Tests.FSharp/Plugin/Capabilities.Tests.fs
+++ b/tests/Tests.FSharp/Plugin/Capabilities.Tests.fs
@@ -1,0 +1,389 @@
+module Zeta.Tests.Plugin.CapabilitiesTests
+
+/// Tests for the algebra-capability tags lifted from plugin-only
+/// marker interfaces (`ILinearOperator` etc. in `PluginApi.fs`) onto
+/// the `Op` base class in `Circuit.fs`. Three coverage axes:
+///
+///   1. Internal operators (registered via `Circuit.Map` /
+///      `Circuit.Join` / ...) declare the correct capability via
+///      direct override on the concrete `Op<'T>` subclass.
+///   2. Plugin operators (registered via the `IOperator<'T>`
+///      extension) have their capability detected through the
+///      non-generic markers (`ILinearMarker`, `IBilinearMarker`,
+///      `ISinkMarker`, `IStatefulStrictMarker`) — the runtime
+///      `:?` test works because the typed interfaces inherit from
+///      the markers.
+///   3. Defaults are false — operators that don't override and don't
+///      implement any algebra marker report all four capabilities as
+///      false (the conservative null hypothesis).
+
+open System
+open System.Threading
+open System.Threading.Tasks
+open Xunit
+open FsUnit.Xunit
+open Zeta.Core
+
+
+// ─────────────────────────────────────────────────────────────────
+//  Helpers
+// ─────────────────────────────────────────────────────────────────
+
+/// Find the first operator with a given `Name` in the circuit's
+/// registered op set. Internal-op names are stable strings ("map",
+/// "filter", "join", etc.) declared on each subclass.
+let private opByName (circuit: Circuit) (name: string) : Op =
+    circuit.Ops
+    |> Seq.find (fun op -> op.Name = name)
+
+
+// ─────────────────────────────────────────────────────────────────
+//  Internal-operator capability tests
+//
+//  Each test wires a minimal one-or-two-op circuit, then asserts the
+//  capability flags on the named operator. Build the circuit but
+//  do NOT step — we only inspect the registered metadata.
+// ─────────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``MapZSetOp declares IsLinear`` () =
+    let c = Circuit()
+    let input = c.ZSetInput<int>()
+    let _ = c.Map(input.Stream, Func<int, int>(fun x -> x * 2))
+    c.Build()
+    let op = opByName c "map"
+    op.IsLinear |> should equal true
+    op.IsBilinear |> should equal false
+    op.IsSink |> should equal false
+    op.IsStatefulStrict |> should equal false
+
+
+[<Fact>]
+let ``FilterZSetOp declares IsLinear`` () =
+    let c = Circuit()
+    let input = c.ZSetInput<int>()
+    let _ = c.Filter(input.Stream, Func<int, bool>(fun x -> x > 0))
+    c.Build()
+    (opByName c "filter").IsLinear |> should equal true
+
+
+[<Fact>]
+let ``FlatMapZSetOp declares IsLinear`` () =
+    let c = Circuit()
+    let input = c.ZSetInput<int>()
+    let _ = c.FlatMap(input.Stream, Func<int, ZSet<int>>(fun x -> ZSet.singleton x 1L))
+    c.Build()
+    (opByName c "flatMap").IsLinear |> should equal true
+
+
+[<Fact>]
+let ``NegZSetOp declares IsLinear`` () =
+    let c = Circuit()
+    let input = c.ZSetInput<int>()
+    let _ = c.Negate input.Stream
+    c.Build()
+    (opByName c "neg").IsLinear |> should equal true
+
+
+[<Fact>]
+let ``PlusZSetOp declares no algebra capability (additive, not unary-linear)`` () =
+    let c = Circuit()
+    let a = c.ZSetInput<int>()
+    let b = c.ZSetInput<int>()
+    let _ = c.Plus(a.Stream, b.Stream)
+    c.Build()
+    let op = opByName c "plus"
+    // Plus is a 2-input additive op: Plus(0, b) = b ≠ 0, so it's
+    // neither unary-linear nor bilinear under the strict definitions.
+    // A future capability `IsAdditive` could capture the per-input
+    // distribution property; for now Plus reports all caps false.
+    op.IsLinear |> should equal false
+    op.IsBilinear |> should equal false
+
+
+[<Fact>]
+let ``MinusZSetOp declares no algebra capability (same reason as Plus)`` () =
+    let c = Circuit()
+    let a = c.ZSetInput<int>()
+    let b = c.ZSetInput<int>()
+    let _ = c.Minus(a.Stream, b.Stream)
+    c.Build()
+    let op = opByName c "minus"
+    op.IsLinear |> should equal false
+    op.IsBilinear |> should equal false
+
+
+[<Fact>]
+let ``DistinctZSetOp does NOT declare IsLinear (clamps weights)`` () =
+    let c = Circuit()
+    let input = c.ZSetInput<int>()
+    let _ = c.Distinct input.Stream
+    c.Build()
+    let op = opByName c "distinct"
+    // distinct(a + b) ≠ distinct(a) + distinct(b) when both share
+    // a positive-weighted key — distinct clamps to {0, 1}.
+    op.IsLinear |> should equal false
+    op.IsBilinear |> should equal false
+
+
+[<Fact>]
+let ``JoinZSetOp declares IsBilinear`` () =
+    let c = Circuit()
+    let a = c.ZSetInput<int * string>()
+    let b = c.ZSetInput<int * int>()
+    let _ =
+        c.Join(
+            a.Stream, b.Stream,
+            Func<int * string, int>(fst),
+            Func<int * int, int>(fst),
+            Func<int * string, int * int, string>(fun (_, s) (_, n) -> $"%s{s}-%d{n}"))
+    c.Build()
+    let op = opByName c "join"
+    op.IsLinear |> should equal false
+    op.IsBilinear |> should equal true
+
+
+[<Fact>]
+let ``CartesianZSetOp declares IsBilinear`` () =
+    let c = Circuit()
+    let a = c.ZSetInput<int>()
+    let b = c.ZSetInput<string>()
+    let _ = c.Cartesian(a.Stream, b.Stream)
+    c.Build()
+    (opByName c "cartesian").IsBilinear |> should equal true
+
+
+[<Fact>]
+let ``IndexWithOp declares IsLinear`` () =
+    let c = Circuit()
+    let input = c.ZSetInput<int * string>()
+    let _ =
+        c.IndexWith(
+            input.Stream,
+            Func<int * string, int>(fst),
+            Func<int * string, string>(snd))
+    c.Build()
+    (opByName c "indexWith").IsLinear |> should equal true
+
+
+[<Fact>]
+let ``IndexedJoinOp declares IsBilinear`` () =
+    let c = Circuit()
+    let a = c.ZSetInput<int * string>()
+    let b = c.ZSetInput<int * int>()
+    let ia =
+        c.IndexWith(
+            a.Stream, Func<int * string, int>(fst), Func<int * string, string>(snd))
+    let ib =
+        c.IndexWith(
+            b.Stream, Func<int * int, int>(fst), Func<int * int, int>(snd))
+    let _ =
+        c.IndexedJoin(
+            ia, ib,
+            Func<int, string, int, string>(fun _ s n -> $"%s{s}-%d{n}"))
+    c.Build()
+    (opByName c "indexedJoin").IsBilinear |> should equal true
+
+
+[<Fact>]
+let ``DelayOp declares IsLinear`` () =
+    let c = Circuit()
+    let input = c.ZSetInput<int>()
+    let _ = c.DelayZSet input.Stream
+    c.Build()
+    let op = opByName c "z^-1"
+    op.IsLinear |> should equal true
+    // z⁻¹ is also strict — preserved unchanged from before.
+    op.IsStrict |> should equal true
+
+
+[<Fact>]
+let ``IntegrateOp declares IsLinear`` () =
+    let c = Circuit()
+    let input = c.ZSetInput<int>()
+    let _ = c.IntegrateZSet input.Stream
+    c.Build()
+    (opByName c "integrate").IsLinear |> should equal true
+
+
+[<Fact>]
+let ``DifferentiateOp declares IsLinear`` () =
+    let c = Circuit()
+    let input = c.ZSetInput<int>()
+    let _ = c.DifferentiateZSet input.Stream
+    c.Build()
+    (opByName c "differentiate").IsLinear |> should equal true
+
+
+[<Fact>]
+let ``ConstantOp does NOT declare IsLinear (affine, not linear)`` () =
+    let c = Circuit()
+    let _ = c.Constant 42
+    c.Build()
+    // const_c(0) = c ≠ 0 (unless c = 0), so Constant is affine
+    // in general — not linear. We default to false.
+    (opByName c "const").IsLinear |> should equal false
+
+
+[<Fact>]
+let ``FilterMapOp (fused) declares IsLinear`` () =
+    let c = Circuit()
+    let input = c.ZSetInput<int>()
+    let _ =
+        c.FilterMap(
+            input.Stream,
+            Func<int, bool>(fun x -> x > 0),
+            Func<int, int>(fun x -> x * 2))
+    c.Build()
+    (opByName c "filterMap").IsLinear |> should equal true
+
+
+// ─────────────────────────────────────────────────────────────────
+//  Plugin-marker detection tests
+//
+//  These exercise the non-generic-marker pattern: a plugin that
+//  implements `ILinearOperator<'A, 'B>` automatically satisfies
+//  `ILinearMarker` via interface inheritance, and the
+//  `PluginOperatorAdapter` constructor caches a `:? ILinearMarker`
+//  test result that's then surfaced via `Op.IsLinear`.
+//
+//  Critical: we test the GENERIC interface implementation, not the
+//  marker directly. If the inheritance chain is broken, the runtime
+//  `:?` test returns false even though the typed interface is
+//  declared — that's the bug class this layer is preventing.
+// ─────────────────────────────────────────────────────────────────
+
+/// Plugin that implements `ILinearOperator<int, int>` — the adapter
+/// should detect `ILinearMarker` and surface `IsLinear = true`.
+type private LinearPluginOp(input: Stream<int>) =
+    let deps = [| input.AsDependency() |]
+    interface ILinearOperator<int, int> with
+        member _.Name = "test-linear"
+        member _.ReadDependencies = deps
+        member _.StepAsync(out, _ct) =
+            out.Publish (input.Current * 3)
+            ValueTask.CompletedTask
+
+
+/// Plugin that implements `IBilinearOperator<int, int, int>` —
+/// adapter should detect `IBilinearMarker`. Uses a single input for
+/// test simplicity; bilinearity is declarative here, not exercised.
+type private BilinearPluginOp(input: Stream<int>) =
+    let deps = [| input.AsDependency() |]
+    interface IBilinearOperator<int, int, int> with
+        member _.Name = "test-bilinear"
+        member _.ReadDependencies = deps
+        member _.StepAsync(out, _ct) =
+            out.Publish input.Current
+            ValueTask.CompletedTask
+
+
+/// Plugin that implements `ISinkOperator<int, int>` — adapter
+/// should detect `ISinkMarker`.
+type private SinkPluginOp(input: Stream<int>) =
+    let deps = [| input.AsDependency() |]
+    interface ISinkOperator<int, int> with
+        member _.Name = "test-sink"
+        member _.ReadDependencies = deps
+        member _.StepAsync(out, _ct) =
+            out.Publish input.Current
+            ValueTask.CompletedTask
+
+
+/// Plugin that implements `IStatefulStrictOperator<int, unit, int>` —
+/// adapter should detect `IStatefulStrictMarker`.
+type private StatefulStrictPluginOp(input: Stream<int>) =
+    let deps = [| input.AsDependency() |]
+    interface IStatefulStrictOperator<int, unit, int> with
+        member _.Name = "test-stateful-strict"
+        member _.ReadDependencies = deps
+        member _.StepAsync(out, _ct) =
+            out.Publish input.Current
+            ValueTask.CompletedTask
+
+
+/// Plugin that implements ONLY `IOperator<int>` — no algebra
+/// marker. All four capabilities must report false.
+type private PlainPluginOp(input: Stream<int>) =
+    let deps = [| input.AsDependency() |]
+    interface IOperator<int> with
+        member _.Name = "test-plain"
+        member _.ReadDependencies = deps
+        member _.StepAsync(out, _ct) =
+            out.Publish input.Current
+            ValueTask.CompletedTask
+
+
+[<Fact>]
+let ``Plugin ILinearOperator → adapter reports IsLinear = true`` () =
+    let c = Circuit()
+    let input = c.Constant 0
+    let _ = c.RegisterStream (LinearPluginOp input :> IOperator<int>)
+    c.Build()
+    let op = opByName c "test-linear"
+    op.IsLinear |> should equal true
+    op.IsBilinear |> should equal false
+    op.IsSink |> should equal false
+    op.IsStatefulStrict |> should equal false
+
+
+[<Fact>]
+let ``Plugin IBilinearOperator → adapter reports IsBilinear = true`` () =
+    let c = Circuit()
+    let input = c.Constant 0
+    let _ = c.RegisterStream (BilinearPluginOp input :> IOperator<int>)
+    c.Build()
+    let op = opByName c "test-bilinear"
+    op.IsLinear |> should equal false
+    op.IsBilinear |> should equal true
+    op.IsSink |> should equal false
+    op.IsStatefulStrict |> should equal false
+
+
+[<Fact>]
+let ``Plugin ISinkOperator → adapter reports IsSink = true`` () =
+    let c = Circuit()
+    let input = c.Constant 0
+    let _ = c.RegisterStream (SinkPluginOp input :> IOperator<int>)
+    c.Build()
+    let op = opByName c "test-sink"
+    op.IsLinear |> should equal false
+    op.IsBilinear |> should equal false
+    op.IsSink |> should equal true
+    op.IsStatefulStrict |> should equal false
+
+
+[<Fact>]
+let ``Plugin IStatefulStrictOperator → adapter reports IsStatefulStrict = true`` () =
+    let c = Circuit()
+    let input = c.Constant 0
+    let _ = c.RegisterStream (StatefulStrictPluginOp input :> IOperator<int>)
+    c.Build()
+    let op = opByName c "test-stateful-strict"
+    op.IsStatefulStrict |> should equal true
+
+
+[<Fact>]
+let ``Plain IOperator plugin → adapter reports all algebra caps false`` () =
+    let c = Circuit()
+    let input = c.Constant 0
+    let _ = c.RegisterStream (PlainPluginOp input :> IOperator<int>)
+    c.Build()
+    let op = opByName c "test-plain"
+    op.IsLinear |> should equal false
+    op.IsBilinear |> should equal false
+    op.IsSink |> should equal false
+    op.IsStatefulStrict |> should equal false
+
+
+// ─────────────────────────────────────────────────────────────────
+//  BayesianRateOp end-to-end — the canonical real-world sink
+//
+//  This test verifies that the ISinkMarker inheritance correctly
+//  surfaces through Zeta.Bayesian's `BayesianRateOp`. We can't
+//  exercise it directly here (Zeta.Bayesian isn't a test-project
+//  reference and shouldn't be — that'd be a circular-shape
+//  test), so we rely on the SinkPluginOp above as the structural
+//  proof. Adding Zeta.Bayesian to this project's references is
+//  out of scope for PR 1.
+// ─────────────────────────────────────────────────────────────────

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -106,6 +106,7 @@
     <!-- Plugin/ -->
     <Compile Include="Plugin/Harness.Tests.fs" />
     <Compile Include="Plugin/LawRunner.Tests.fs" />
+    <Compile Include="Plugin/Capabilities.Tests.fs" />
 
     <!-- Formal/ -->
     <Compile Include="Formal/Z3.Laws.Tests.fs" />


### PR DESCRIPTION
## Summary

Promotes the algebra capability tags (`ILinearOperator`, `IBilinearOperator`, `ISinkOperator`, `IStatefulStrictOperator`) from plugin-only marker interfaces in `PluginApi.fs` to first-class properties on the `Op<'T>` base class in `Circuit.fs`.

This is **PR 1 of an 8-PR campaign** to wire the algebra-capability system from declarative-but-unenforced markers into a load-bearing property surface that scheduler, fusion engine, and incremental-rewriter dispatcher all consume uniformly.

## Why

Before this change, the algebra tags lived only as plugin marker interfaces and **`PluginOperatorAdapter` discarded the declarations** — its capability-detection cache included `IStrictOperator`/`IAsyncOperator`/`INestedFixpointParticipant` but not the algebra markers. That meant:

1. Internal operators (`MapZSetOp`, `JoinZSetOp`, etc.) had no capability surface — algebra was implicit-by-code-shape.
2. Plugin operators declared `ILinearOperator<_,_>` and similar but the declaration was invisible to the scheduler.
3. The docstring on `ISinkOperator` promising *"the scheduler enforces terminal placement"* was vapor — no enforcement existed.
4. Consumers like `Incremental.IncrementalJoin` trusted the bilinear assumption by type-signature shape rather than by capability tag.

## How

### Non-generic marker pattern (BCL `IEnumerable` / `IEnumerable<T>`-style)

F# generic-interface runtime tests require **exact** type-parameter match — `(box plugin) :? IBilinearOperator<obj, obj, 'TOut>` against a concrete `IBilinearOperator<int, string, decimal>` returns false. Fix:

- New non-generic markers: `ILinearMarker`, `IBilinearMarker`, `ISinkMarker`, `IStatefulStrictMarker` (all `interface end`).
- Typed interfaces inherit the marker (e.g. `type ILinearOperator<'TIn, 'TOut> = inherit IOperator<'TOut> inherit ILinearMarker`).
- Plugin authors continue implementing the typed interface; the marker is satisfied automatically via interface inheritance.

### Op<'T> base class adds four properties

```fsharp
abstract IsLinear: bool         ; default _.IsLinear = false
abstract IsBilinear: bool       ; default _.IsBilinear = false
abstract IsSink: bool           ; default _.IsSink = false
abstract IsStatefulStrict: bool ; default _.IsStatefulStrict = false
```

Concrete operators override only the capabilities they actually have.

### Adapter detection

`PluginOperatorAdapter` caches one `:?` check per marker at construction (zero per-tick cost) and surfaces results via the new `Op` overrides:

```fsharp
let isLinearCap         = (box plugin) :? ILinearMarker
let isBilinearCap       = (box plugin) :? IBilinearMarker
let isSinkCap           = (box plugin) :? ISinkMarker
let isStatefulStrictCap = (box plugin) :? IStatefulStrictMarker
override _.IsLinear         = isLinearCap
override _.IsBilinear       = isBilinearCap
override _.IsSink           = isSinkCap
override _.IsStatefulStrict = isStatefulStrictCap
```

### Internal-operator overrides

| Operator | Capability | Notes |
|---|---|---|
| Map, Filter, FlatMap, Neg, IndexWith | `IsLinear=true` | Distributes over Z-set addition |
| Delay, Integrate, Differentiate | `IsLinear=true` | Commute with the group operation |
| FilterMap, FilterMapOptional | `IsLinear=true` | Composition of linear ops |
| Join, Cartesian, IndexedJoin | `IsBilinear=true` | Per-arg linear; weight multiplication |
| Plus, Minus | (default false) | Additive but not unary-linear: `Plus(0,b)=b≠0` |
| Distinct, DistinctIncremental, GroupBySum, Constant | (default false) | Non-linear by construction |

## Tests

21 new tests in `tests/Tests.FSharp/Plugin/Capabilities.Tests.fs`:

- 15 internal-operator capability assertions (one per named op)
- 5 plugin-marker-detection tests via `PluginOperatorAdapter`
- 1 negative test: plain `IOperator` plugin reports all caps `false`

Test results:

- **21 / 21** new capability tests pass
- **31 / 31** plugin tests pass (10 pre-existing + 21 new — no regressions)
- **480 / 481** broader operator/algebra/circuit tests pass (1 pre-existing SKIP)
- **0 warnings, 0 errors** on full-solution Release build

## Foundation for PRs 2-8

This is the load-bearing dependency for:

- **PR 2**: `Circuit.Build()` consults `IsSink` for terminal-placement enforcement (the docstring promise that's currently vapor).
- **PR 4**: `IncrementalAuto` dispatcher reads `IsLinear`/`IsBilinear` to pick `Q^Δ=Q` vs three-term-bilinear vs `D∘Q∘I` fallback.
- **PR 5**: `FusionEngine` composes capability tags through DAG rewrite.
- **PRs 6-8**: push/morsel/codegen architectures all need uniform capability surfacing to dispatch correctly.

No public-API breakage: marker interfaces work identically for plugin authors; new `Op`-base-class properties are purely additive.

## Test plan

- [x] `dotnet build Zeta.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~CapabilitiesTests"` — 21/21 pass
- [x] `dotnet test --filter "FullyQualifiedName~Zeta.Tests.Plugin"` — 31/31 pass
- [x] `dotnet test --filter "FullyQualifiedName~Operators|Algebra|Circuit"` — 480/481 pass (1 pre-existing SKIP)
- [ ] CI green on PR