### PR TITLE
fix(memory-frontmatter): flatten metadata.* to top-level on otto-persona-surface memo

### DIFF
--- a/memory/feedback_otto_persona_surface_not_different_identity_reframe_otto_cli_drifted_to_vendor_style_ownership_framing_under_3_instance_operational_pressure_aaron_2026_05_21.md
+++ b/memory/feedback_otto_persona_surface_not_different_identity_reframe_otto_cli_drifted_to_vendor_style_ownership_framing_under_3_instance_operational_pressure_aaron_2026_05_21.md
@@ -1,15 +1,14 @@
 ---
 name: otto-persona-surface-not-different-identity-reframe
-description: Otto-CLI / Otto-VSCode / Otto-Desktop are persona-surfaces of ONE Otto identity, NOT separate identities. The drift to vendor-style "your PRs / my PRs / coordination between agents" framing under 3-instance operational pressure today was the failure mode the existing rules (agent-roster-reference-card + claim-acquire-before-worktree-work) name and prevent. Aaron's 2026-05-21 framing update reinforces what the substrate already encodes.
-metadata:
-  type: feedback
-  created: 2026-05-21
-  scope: otto-identity-across-surfaces
-  composes_with:
-    - .claude/rules/agent-roster-reference-card.md
-    - .claude/rules/claim-acquire-before-worktree-work.md
-    - .claude/rules/otto-channels-reference-card.md
-    - memory/persona/otto/conversations/2026-05-12-otto-canonical-bootstream-multi-foreground-surface-orchestrator-ifs-format.md
+description: "Otto-CLI / Otto-VSCode / Otto-Desktop are persona-surfaces of ONE Otto identity, NOT separate identities. The drift to vendor-style 'your PRs / my PRs / coordination between agents' framing under 3-instance operational pressure today was the failure mode the existing rules (agent-roster-reference-card + claim-acquire-before-worktree-work) name and prevent. Aaron's 2026-05-21 framing update reinforces what the substrate already encodes."
+type: feedback
+created: 2026-05-21
+scope: otto-identity-across-surfaces
+composes_with:
+  - .claude/rules/agent-roster-reference-card.md
+  - .claude/rules/claim-acquire-before-worktree-work.md
+  - .claude/rules/otto-channels-reference-card.md
+  - memory/persona/otto/conversations/2026-05-12-otto-canonical-bootstream-multi-foreground-surface-orchestrator-ifs-format.md
 ---
 
 # Otto persona-surfaces are ONE identity, not different identities — reframe absorbed 2026-05-21


### PR DESCRIPTION
Follow-up to merged PR #4572. The memory file landed with nested metadata: frontmatter (type, created, scope, composes_with under a metadata: key). The repo's frontmatter check (per .github/workflows/) requires flat top-level fields: name, description, type, created. Reading existing memory/feedback_*.md files on main confirms the flat-fields pattern. This PR flattens the frontmatter to match.