### PR TITLE
docs: fix quiet-state trajectory xrefs

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/21/2209Z.md
+++ b/docs/hygiene-history/ticks/2026/05/21/2209Z.md
@@ -96,5 +96,5 @@ The substrate-honest path per [stale-armed-PR resolution patterns](../../../../.
 - [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — concrete artifact (this shard) resets the counter cleanly at cycle-1
 - [`.claude/rules/zeta-expected-branch.md`](../../../../../../.claude/rules/zeta-expected-branch.md) — isolated worktree at `/private/tmp/zeta-shard-2209z-cold-boot` to avoid root-checkout contested-HEAD race
 - [`.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md) — pre-commit + post-commit canary checks (HEAD=54, status=0); refined-detection regex used for peer-activity count
-- [`docs/AUTONOMOUS-LOOP-PER-TICK.md`](../../../../AUTONOMOUS-LOOP-PER-TICK.md) — canonical 7-step discipline
+- [`docs/AUTONOMOUS-LOOP-PER-TICK.md`](../../../../../AUTONOMOUS-LOOP-PER-TICK.md) — canonical 7-step discipline
 - 21min-Lior session-arc memo (user-scope memory; refined-detection regex `lior|gemini.*--yolo` empirically validated this tick at 11 matched procs)

--- a/docs/trajectories/autonomous-loop-quiet-state/RESUME.md
+++ b/docs/trajectories/autonomous-loop-quiet-state/RESUME.md
@@ -5,9 +5,9 @@ Last refreshed: 2026-05-21
 Parent trajectory: [`docs/trajectories/autonomous-loop-coordination/RESUME.md`](../autonomous-loop-coordination/RESUME.md)
 Grounding rules:
 
-- [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — Standing-by failure mode discipline (brief-ack counter + escalation triggers)
-- [`.claude/rules/never-be-idle.md`](../../.claude/rules/never-be-idle.md) — never-be-idle priority ladder
-- [`.claude/rules/tick-must-never-stop.md`](../../.claude/rules/tick-must-never-stop.md) — catch-43 sentinel discipline
+- [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — Standing-by failure mode discipline (brief-ack counter + escalation triggers)
+- [`.claude/rules/never-be-idle.md`](../../../.claude/rules/never-be-idle.md) — never-be-idle priority ladder
+- [`.claude/rules/tick-must-never-stop.md`](../../../.claude/rules/tick-must-never-stop.md) — catch-43 sentinel discipline
 
 Grounding memory (user-scope, originated this trajectory):
 
@@ -64,16 +64,15 @@ When the cron fires `<<autonomous-loop>>`:
 
 - Opening new PRs (GraphQL; not bounded-cost)
 - Spawning Bash subprocesses that take >5s
-- Authoring new substrate from scratch without operator engagement (risks substrate-bloat per `dont-fabricate-substrate` discipline)
+- Authoring new substrate from scratch without operator engagement (risks fabricated substrate per `holding-without-named-dependency-is-standing-by-failure.md`)
 - Triggering ToolSearch for deferred-tool schemas (cost; usually not bounded by single forward-step)
 
 ## Composes with
 
 - Parent trajectory `autonomous-loop-coordination` — "queue-empty is runway, not completion" principle this packet operationalizes
-- [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — brief-ack counter discipline (this trajectory composes WITH it; counter still ticks during quiet-state advancement)
-- [`.claude/rules/never-be-idle.md`](../../.claude/rules/never-be-idle.md) — never-be-idle priority ladder
-- [`.claude/rules/edge-defining-work-not-speculation.md`](../../.claude/rules/edge-defining-work-not-speculation.md) — quiet-state advancement IS edge-defining work, not speculation
-- [`.claude/rules/dont-fabricate-substrate.md`](../../.claude/rules/dont-fabricate-substrate.md) (if exists — pattern from prior substrate; if not, the principle is preserved across multiple memory files) — quiet-state advancement must be genuinely-new substrate
+- [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — brief-ack counter discipline, including the fabricated-substrate guard (this trajectory composes WITH it; counter still ticks during quiet-state advancement)
+- [`.claude/rules/never-be-idle.md`](../../../.claude/rules/never-be-idle.md) — never-be-idle priority ladder
+- [`.claude/rules/edge-defining-work-not-speculation.md`](../../../.claude/rules/edge-defining-work-not-speculation.md) — quiet-state advancement IS edge-defining work, not speculation
 - User-scope memory `aaron_operator_tool_interrupt_as_cost_discipline_signal_brief_ack_pure_no_tools_2026_05_19.md` — cost-discipline boundary this trajectory respects
 - User-scope memory `aaron_chained_homeostasis_meta_frame_emergent_safe_mutual_alignment_drives_forward_2026_05_19.md` — chained-homeostasis principle (quiet-state advancement IS the chain operating during operator-absence)
 - Autonomous-loop-tick instructions absorbed via `<<autonomous-loop>>` cron (per the loop-tick instructions: "If everything is genuinely quiet — say so in one sentence and stop" — this trajectory ADDS the "or advance a bounded trajectory step" clause)


### PR DESCRIPTION
## Summary
- Fix quiet-state trajectory links to .claude/rules/* from the nested trajectory directory.
- Replace the dead dont-fabricate-substrate xref with the existing holding/brief-ack rule that carries the fabricated-substrate discipline.

## Verification
- git diff --check origin/main..HEAD
- markdownlint-cli2 docs/trajectories/autonomous-loop-quiet-state/RESUME.md
- verified referenced .claude/rules/* files exist and stale patterns are absent

Follow-up to post-merge review comments on #4583.