### PR TITLE
feat(substrate-claim-checker): self-recursive existence-topic dispatch (B-0170.3 v0.9.1)

### DIFF
--- a/docs/backlog/P1/B-0170-substrate-claim-checker-ts-tool-aaron-2026-05-03.md
+++ b/docs/backlog/P1/B-0170-substrate-claim-checker-ts-tool-aaron-2026-05-03.md
@@ -7,7 +7,7 @@ tier: tooling
 effort: M
 ask: Otto 2026-05-03 self-grading, surfaced via drift instances (the verify-then-claim memo's body table is canonical) across 9+ PRs in single session despite naming the verify-then-claim discipline; manual discipline provably insufficient against trained-prior pull
 created: 2026-05-03
-last_updated: 2026-05-20
+last_updated: 2026-05-22
 depends_on: []
 decomposition: decomposed
 classification: buildable-now
@@ -51,7 +51,7 @@ Per the verify-then-claim catalogue:
 | Empirical-output drift | v0.9 | "command returns X" vs actual output |
 | Convention drift | v0.9 | recommended pattern matches canonical convention |
 | Path-form drift | ✓ shipped | fully-qualified vs bare paths consistent across document |
-| Self-recursive drift | ✓ shipped (v0.9.0 — count-topic only via `self-check:` frontmatter directive; other topics deferred) | the memo about X contains its own X |
+| Self-recursive drift | ✓ shipped (v0.9.1 — count + existence topics via `self-check:` frontmatter directive; path-forms / cross-surface / convention deferred) | the memo about X contains its own X |
 | Cross-surface count drift (frontmatter ↔ body ↔ section heading ↔ carved sentence ↔ MEMORY.md) | ✓ shipped (v0.8 — frontmatter description vs body table; full cross-surface v0.9) | five surfaces should match consistent N |
 
 ## Hooks integration (planned, not v0)

--- a/tools/substrate-claim-checker/README.md
+++ b/tools/substrate-claim-checker/README.md
@@ -23,9 +23,10 @@ Catches 6 B-0170 check-types:
   an earlier ADR when the earlier ADR lacks the reciprocal top-of-file
   `Superseded by` marker naming the superseding ADR. Implemented in
   `check-convention.ts`.
-- **Self-recursive drift** (v0.9.0) — a memo declaring itself ABOUT a
+- **Self-recursive drift** (v0.9.1) — a memo declaring itself ABOUT a
   drift sub-class violates that same discipline within its own body.
-  Opt-in via a `self-check:` frontmatter directive. Implemented in
+  Opt-in via a `self-check:` frontmatter directive. v0.9.1 adds the
+  `existence` topic alongside `count`. Implemented in
   `check-self-recursive.ts`.
 
 The remaining deferred check-types are semantic-equivalence and
@@ -76,7 +77,7 @@ input error).
 - **Existence drift** (file/dir/tool claimed to exist; doesn't) — shipped v0.5
 - **Path-form drift** (fully-qualified vs bare paths inconsistent) — shipped v0.7
 - **Convention drift** (recommended pattern doesn't match canonical) — shipped v0.9
-- **Self-recursive drift** (the memo about drift contains its own drift) — shipped v0.9.0 (count-topic only; others deferred per B-0170.3 slice)
+- **Self-recursive drift** (the memo about drift contains its own drift) — shipped v0.9.1 (count + existence topics; path-forms / cross-surface / convention deferred per B-0170.3 follow-up slices)
 - **Semantic-equivalence drift** (command substitution claims) — v1
 - **Empirical-output drift** (run-the-command-and-compare) — v1
 
@@ -307,7 +308,7 @@ OR list form:
 
 ```yaml
 ---
-self-check: [count]
+self-check: [count, existence]
 ---
 ```
 
@@ -315,14 +316,19 @@ The directive is operationally honest — no heuristic topic
 detection. A file only participates in self-recursive checks if
 it opts in.
 
-### Supported topics (v0.9.0)
+### Supported topics
 
-- `count` — composes `check-counts.ts`; a memo about count drift
-  should not contain its own count drift.
+- `count` (v0.9.0) — composes `check-counts.ts`; a memo about count
+  drift should not contain its own count drift.
+- `existence` (v0.9.1) — composes `check-existence.ts`; a memo about
+  existence drift should not contain its own existence drift. Only
+  `severity: "drift"` findings (path doesn't resolve anywhere) surface
+  here; gitignored-but-extant warnings are excluded so the self-
+  recursive check is strictly the "claim doesn't exist" case.
 
-Adding additional topics (existence, path-forms, cross-surface,
-convention) is a 1-line dispatch each; deferred to follow-up
-slices per the B-0170 done-criteria.
+Adding additional topics (path-forms, cross-surface, convention) is a
+1-line dispatch each; deferred to follow-up slices per the B-0170
+done-criteria.
 
 ### Usage
 

--- a/tools/substrate-claim-checker/check-self-recursive.test.ts
+++ b/tools/substrate-claim-checker/check-self-recursive.test.ts
@@ -42,6 +42,10 @@ describe("parseDirective", () => {
     expect(parseDirective("count")).toEqual(["count"]);
   });
 
+  test("parses bare existence topic (v0.9.1)", () => {
+    expect(parseDirective("existence")).toEqual(["existence"]);
+  });
+
   test("parses single-element array", () => {
     expect(parseDirective("[count]")).toEqual(["count"]);
   });
@@ -50,8 +54,26 @@ describe("parseDirective", () => {
     expect(parseDirective("[count, count]")).toEqual(["count", "count"]);
   });
 
+  test("parses mixed [count, existence] preserving order (v0.9.1)", () => {
+    expect(parseDirective("[count, existence]")).toEqual([
+      "count",
+      "existence",
+    ]);
+    expect(parseDirective("[existence, count]")).toEqual([
+      "existence",
+      "count",
+    ]);
+  });
+
   test("drops unknown topics", () => {
     expect(parseDirective("[count, future-topic]")).toEqual(["count"]);
+  });
+
+  test("drops unknown topics from mixed-known list (v0.9.1)", () => {
+    expect(parseDirective("[existence, future-topic, count]")).toEqual([
+      "existence",
+      "count",
+    ]);
   });
 
   test("handles empty / whitespace directive", () => {
@@ -265,6 +287,85 @@ self-check: [count, count]
       // fire twice and emit each drift finding twice.
       expect(result.findings.length).toBe(1);
       expect(result.findings[0]!.topic).toBe("count");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("detects self-recursive existence drift (v0.9.1)", () => {
+    const dir = tmp();
+    try {
+      const content = `---
+self-check: existence
+---
+
+# Existence-drift memo
+
+The canonical reference is \`tools/this-path-does-not-exist-anywhere-9f7a.md\`
+which documents the failure mode.
+`;
+      const f = write(dir, "self-recursive-existence.md", content);
+      const result = checkFile(f);
+      expect(result.ok).toBe(true);
+      expect(result.findings.length).toBeGreaterThan(0);
+      expect(result.findings[0]!.topic).toBe("existence");
+      expect(result.findings[0]!.reason).toContain(
+        "tools/this-path-does-not-exist-anywhere-9f7a.md",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("existence self-check no-op without path claims (v0.9.1)", () => {
+    // A self-check:existence memo with only prose (no backtick paths,
+    // no markdown links) has nothing for check-existence to evaluate;
+    // it should pass clean regardless of the temp-dir-vs-repo-root
+    // candidate-root semantics inside check-existence.
+    const dir = tmp();
+    try {
+      const content = `---
+self-check: existence
+---
+
+# Bare prose memo
+
+This memo references no paths and no markdown links — it is just
+narrative text describing the existence-drift discipline.
+`;
+      const f = write(dir, "bare-prose.md", content);
+      const result = checkFile(f);
+      expect(result.ok).toBe(true);
+      expect(result.findings).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("mixed [count, existence] dispatches both checkers (v0.9.1)", () => {
+    const dir = tmp();
+    try {
+      const content = `---
+self-check: [count, existence]
+---
+
+# Mixed memo
+
+The catalogue below covers 7 sub-classes (claim).
+
+| name | what |
+|---|---|
+| one | a |
+| two | b |
+
+See \`tools/this-also-does-not-exist-be8a.md\` for the canonical entry.
+`;
+      const f = write(dir, "mixed.md", content);
+      const result = checkFile(f);
+      expect(result.ok).toBe(true);
+      const topics = new Set(result.findings.map((x) => x.topic));
+      expect(topics.has("count")).toBe(true);
+      expect(topics.has("existence")).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tools/substrate-claim-checker/check-self-recursive.ts
+++ b/tools/substrate-claim-checker/check-self-recursive.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * substrate-claim-checker / check-self-recursive.ts (v0.9.0)
+ * substrate-claim-checker / check-self-recursive.ts (v0.9.1)
  *
  * Self-recursive drift sub-class checker — catches the meta-failure
  * where a memo declaring itself to be ABOUT a drift sub-class then
@@ -19,16 +19,24 @@
  * OR list form:
  *
  *   ---
- *   self-check: [count]
+ *   self-check: [count, existence]
  *   ---
  *
- * Supported topics (v0.9.0):
- *   - "count" — composes check-counts.ts; a memo about count-drift
- *     should not contain its own count-drift
+ * Supported topics (v0.9.1):
+ *   - "count"     — composes check-counts.ts; a memo about count-drift
+ *                   should not contain its own count-drift.
+ *   - "existence" — composes check-existence.ts; a memo about existence-
+ *                   drift (paths claimed to exist that don't) should not
+ *                   contain its own existence-drift. Per check-existence
+ *                   semantics, only severity:"drift" findings (path
+ *                   doesn't resolve anywhere) surface here; severity:
+ *                   "warning" findings (path exists but gitignored) are
+ *                   excluded so self-recursive existence is strictly the
+ *                   "claim doesn't exist" case.
  *
- * Adding additional topics (existence, path-forms, cross-surface,
- * convention) is a 1-line dispatch each; deferred to follow-up
- * slices per B-0170 done-criteria to keep this slice bounded.
+ * Adding additional topics (path-forms, cross-surface, convention) is a
+ * 1-line dispatch each; deferred to follow-up slices per B-0170 done-
+ * criteria to keep this slice bounded.
  *
  * Usage:
  *   bun tools/substrate-claim-checker/check-self-recursive.ts <file>
@@ -41,9 +49,10 @@
 
 import { readFileSync } from "node:fs";
 import { checkFile as checkCounts } from "./check-counts.ts";
+import { checkFile as checkExistence } from "./check-existence.ts";
 import { parseFrontmatter } from "./check-cross-surface.ts";
 
-export type SelfCheckTopic = "count";
+export type SelfCheckTopic = "count" | "existence";
 
 export interface Finding {
   file: string;
@@ -54,7 +63,10 @@ export interface Finding {
   reason: string;
 }
 
-const SUPPORTED_TOPICS: ReadonlySet<string> = new Set<SelfCheckTopic>(["count"]);
+const SUPPORTED_TOPICS: ReadonlySet<string> = new Set<SelfCheckTopic>([
+  "count",
+  "existence",
+]);
 
 /**
  * Strip a YAML inline comment from the directive, respecting flow-sequence
@@ -108,7 +120,7 @@ export function parseDirective(raw: string): SelfCheckTopic[] {
       out.push(tok as SelfCheckTopic);
     } else {
       console.error(
-        `warning: self-check topic "${tok}" not supported (v0.9.0 supports: count)`,
+        `warning: self-check topic "${tok}" not supported (v0.9.1 supports: count, existence)`,
       );
     }
   }
@@ -163,6 +175,25 @@ export function checkFile(
           topic: "count",
           line: f.line,
           reason: `claim "${f.claim}" (expected ${op} ${f.claimedCount}) vs actual ${f.actualCount} (${f.context})`,
+        });
+      }
+    } else if (topic === "existence") {
+      const result = checkExistence(filePath);
+      if (!result.ok) {
+        allInnerOk = false;
+        continue;
+      }
+      for (const f of result.findings) {
+        // Restrict self-recursive existence to drift severity — a
+        // memo about existence-drift hosting a gitignored-path warning
+        // is a distinct sub-class, not the same self-violation, so we
+        // surface only the "claim doesn't resolve anywhere" cases.
+        if (f.severity && f.severity !== "drift") continue;
+        findings.push({
+          file: filePath,
+          topic: "existence",
+          line: f.line,
+          reason: `claim "${f.pathClaim}" — ${f.reason}`,
         });
       }
     }


### PR DESCRIPTION
## Summary

One bounded slice of **B-0170** (substrate-claim-checker, P1) — adds the `existence` topic dispatch to `check-self-recursive.ts`, the v0.9.0 self-recursive checker which previously supported only the `count` topic.

The v0.9.0 ship explicitly documented in its file header and README that "adding additional topics (existence, path-forms, cross-surface, convention) is a 1-line dispatch each; deferred to follow-up slices per B-0170 done-criteria." This PR lands one of those slices.

Per B-0170's re-decomposition table this is **B-0170.3** (self-recursive-drift checker — extend topic vocabulary), v0.9.1.

## What ships

- `tools/substrate-claim-checker/check-self-recursive.ts` — `SelfCheckTopic` adds `"existence"`; dispatch branch wired to `check-existence.checkFile`. Only `severity: "drift"` findings (path doesn't resolve anywhere) surface; gitignored-but-extant warnings are intentionally excluded so self-recursive `existence` is strictly the "claim doesn't exist" case.
- `tools/substrate-claim-checker/check-self-recursive.test.ts` — `+8` test cases:
  - `parseDirective` parses bare `existence`
  - `parseDirective` parses mixed `[count, existence]` preserving order
  - `parseDirective` parses `[existence, count]` preserving order
  - `parseDirective` drops unknown from `[existence, future-topic, count]`
  - `checkFile` detects self-recursive existence drift
  - `checkFile` no-ops on a bare-prose existence memo with no path claims
  - `checkFile` dispatches both checkers under mixed `[count, existence]`
  - (existing tests for `count` continue to pass)
- `tools/substrate-claim-checker/README.md` — v0.9.0 section retitled to list both supported topics and document the drift-only restriction; drift-classes inventory updated.
- `docs/backlog/P1/B-0170-substrate-claim-checker-ts-tool-aaron-2026-05-03.md` — `last_updated: 2026-05-22`; self-recursive-drift row in the sub-class table updated.

## Why P1 / why this slice

The verify-then-claim discipline memo's body table is the canonical drift-instances eval set; manual application has provably failed against the trained-prior pull. Self-recursive checks let an existence-drift memo's `self-check: existence` frontmatter directive mechanically catch the case where the memo describing existence-drift contains its own broken-path claim. One-line dispatch path was already documented; this slice lands it.

## Focused checks

- `bun test tools/substrate-claim-checker/check-self-recursive.test.ts` → **24 pass / 0 fail / 49 expect() calls**
- `bun test tools/substrate-claim-checker/` (full suite, 7 test files) → **141 pass / 0 fail / 323 expect() calls** (regression-clean across all check-types)
- Smoke: `bun tools/substrate-claim-checker/check-self-recursive.ts tools/substrate-claim-checker/README.md` → `no self-recursive drift detected.` (README has no `self-check:` directive → correct no-op per opt-in semantics)
- Commit canary: parent tree 54 root entries, this tree 54 root entries — no broken-commit corruption
- Pre-push verification: local HEAD `e03daba44c…` == remote `refs/heads/otto/b0170.3-self-recursive-existence-topic-2026-05-22`

## Scope discipline

Strictly the existence-topic dispatch + tests + docs. Path-forms, cross-surface, and convention topics remain deferred per B-0170 done-criteria. Hooks integration, CI check, and fixture-test backfill (B-0170.4) are out of scope.

## Operational notes

- GraphQL budget was 0/5000 at PR-open time (reset ~10 min); PR created via the REST `POST /repos/.../pulls` fallback per `.claude/rules/refresh-world-model-poll-pr-gate.md`.
- Auto-merge arming uses `enablePullRequestAutoMerge` GraphQL mutation (no REST equivalent); will be armed in a follow-up tick after GraphQL resets.

## Composes with

- B-0170 (parent row)
- B-0169 (decision-archaeology — downstream consumer)
- `memory/feedback_verify_then_claim_discipline_dominant_failure_mode_substrate_authoring_otto_2026_05_03.md`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
