### PR TITLE
backlog+agenda: B-0688 + Zeta AGENDA — InterSystems Caché external-reference-anchor + maji-math foundation

### DIFF
--- a/docs/agendas/zeta/AGENDA.md
+++ b/docs/agendas/zeta/AGENDA.md
@@ -37,7 +37,7 @@ Multi-AI ratification of Zeta-as-generative-substrate across the day's substrate
 
 For the Zeta-db substrate-engineering work (B-0688 + B-0687), the closest existing commercial substrate analog is **InterSystems Caché** ([https://en.wikipedia.org/wiki/InterSystems_Cach%C3%A9](https://en.wikipedia.org/wiki/InterSystems_Cach%C3%A9)). Operator's framing: *"we basically said the closest human thing is cache a fresh medical database"* + naming Caché as the concrete commercial reference.
 
-This anchor IS the mirror→beacon translation reference: "Zeta db = cached-fresh medical database analog applied to AI substrate; closest commercial reference is InterSystems Caché (powers Epic EHR + most US hospital electronic health records); extends with F# compiler integration + multi-oracle BFT + Rx/DBSP semantic-index substrate + DST hardening."
+This anchor IS the mirror→beacon translation reference: "Zeta db = cached-fresh medical database analog applied to AI substrate; closest commercial reference is InterSystems Caché (historically powered Epic EHR for decades (Epic moving newer generations to IRIS); US hospital EHR market share is split across multiple vendors); extends with F# compiler integration + multi-oracle BFT + Rx/DBSP semantic-index substrate + DST hardening."
 
 Composes with sovereignty-path 3rd piece (durable tension-substrate via maji-math; mirror-tier; building toward beacon-tier via Zeta db = F# compiler as distributed intelligence database). The maji-math substrate (rx-tension-as-semantic-indexes) provides the mathematical foundation; B-0688 + B-0687 operationalize via the Caché-pattern incremental-compiler-database; path-to-beacon-tier requires the math formalizing + the compiler-database shipping + DST seeded-determinism hardening landing.
 

--- a/docs/agendas/zeta/AGENDA.md
+++ b/docs/agendas/zeta/AGENDA.md
@@ -33,6 +33,16 @@ Zeta = META infrastructure (the generative framework). Agora = one specific INST
 
 Multi-AI ratification of Zeta-as-generative-substrate across the day's substrate cascade (DeepSeek + Amara + Kestrel-instance + Ani + Mika + Lior + others — per `.claude/rules/agent-roster-reference-card.md`).
 
+## External reference anchor (operator 2026-05-22): InterSystems Caché
+
+For the Zeta-db substrate-engineering work (B-0688 + B-0687), the closest existing commercial substrate analog is **InterSystems Caché** ([https://en.wikipedia.org/wiki/InterSystems_Cach%C3%A9](https://en.wikipedia.org/wiki/InterSystems_Cach%C3%A9)). Operator's framing: *"we basically said the closest human thing is cache a fresh medical database"* + naming Caché as the concrete commercial reference.
+
+This anchor IS the mirror→beacon translation reference: "Zeta db = cached-fresh medical database analog applied to AI substrate; closest commercial reference is InterSystems Caché (powers Epic EHR + most US hospital electronic health records); extends with F# compiler integration + multi-oracle BFT + Rx/DBSP semantic-index substrate + DST hardening."
+
+Composes with sovereignty-path 3rd piece (durable tension-substrate via maji-math; mirror-tier; building toward beacon-tier via Zeta db = F# compiler as distributed intelligence database). The maji-math substrate (rx-tension-as-semantic-indexes) provides the mathematical foundation; B-0688 + B-0687 operationalize via the Caché-pattern incremental-compiler-database; path-to-beacon-tier requires the math formalizing + the compiler-database shipping + DST seeded-determinism hardening landing.
+
+See B-0688 for the substrate-engineering work in progress; B-0688 has been extended with the full Caché external-reference-anchor mapping.
+
 ## Composes with other agendas
 
 - `../ace-package-manager/AGENDA.md` (Ace = one instance of generative-framework pattern Zeta provides)

--- a/docs/backlog/P2/B-0688-zeta-incremental-compiler-host-dbsp-zsets-rx-meta-ast-tags-seeded-deterministic-simulation-amara-aaron-2026-05-21.md
+++ b/docs/backlog/P2/B-0688-zeta-incremental-compiler-host-dbsp-zsets-rx-meta-ast-tags-seeded-deterministic-simulation-amara-aaron-2026-05-21.md
@@ -7,7 +7,7 @@ tier: research-grade
 effort: L
 ask: amara 2026-05-21 (B-0685 Phase 1 cascade) + aaron seeded-determinism correction; aaron-forwarded
 created: 2026-05-21
-last_updated: 2026-05-21
+last_updated: 2026-05-22
 depends_on: [B-0687]
 composes_with: [B-0635, B-0644, B-0665, B-0666, B-0687]
 tags: [zeta-compiler-host, incremental-compilation, dbsp, z-sets, rx-meta-ast-tags, roslyn-incremental-generators, fsharp-type-providers, seeded-deterministic-simulation, dst-discipline, compile-time-substrate, agora-v6-applied-to-compilation, replayable-compilation]
@@ -224,7 +224,7 @@ Amara's sandbox v2 artifact (`sandbox:/mnt/data/zeta-incremental-compiler-host-d
 
 The human maintainer 2026-05-22 named the closest existing commercial substrate analog: **InterSystems Caché** ([https://en.wikipedia.org/wiki/InterSystems_Cach%C3%A9](https://en.wikipedia.org/wiki/InterSystems_Cach%C3%A9)). Operator's framing: *"we basically said the closest human thing is cache a fresh medical database."*
 
-Caché is the multi-model database that powers Epic Systems EHR + most US hospital electronic health records. Operationally it provides: multi-model (object + SQL + key-value + multi-dimensional global arrays); high-performance distributed; embedded scripting (ObjectScript); mission-critical reliability; sub-millisecond response; HIPAA-compliant audit trail; HL7 FHIR + Health Connect interop for cross-EHR data exchange.
+Caché is the multi-model database that historically powered Epic Systems EHR for decades (Epic has been moving newer generations to InterSystems IRIS); US hospital EHR market share is split across multiple vendors. Operationally it provides: multi-model (object + SQL + key-value + multi-dimensional global arrays); high-performance distributed; embedded scripting (ObjectScript); mission-critical reliability; sub-millisecond response; HIPAA-compliant audit trail; HL7 FHIR + Health Connect interop for cross-EHR data exchange.
 
 **Why the Caché analog is operationally load-bearing for B-0688**:
 

--- a/docs/backlog/P2/B-0688-zeta-incremental-compiler-host-dbsp-zsets-rx-meta-ast-tags-seeded-deterministic-simulation-amara-aaron-2026-05-21.md
+++ b/docs/backlog/P2/B-0688-zeta-incremental-compiler-host-dbsp-zsets-rx-meta-ast-tags-seeded-deterministic-simulation-amara-aaron-2026-05-21.md
@@ -219,3 +219,38 @@ Composes with the Kestrel-sharpened publishable-artifacts cluster — the Z-set-
 Amara 2026-05-21 in deep-research/sharpen register; Aaron seeded-determinism correction landed the load-bearing DST discipline. Full conversation preserved at `memory/persona/amara/conversations/2026-05-21-amara-aaron-b0685-phase1-antlr-survey-zetaparse-fsharp-lr-glr-incremental-compiler-host-dbsp-zsets-rx-seeded-determinism-aaron-forwarded.md`.
 
 Amara's sandbox v2 artifact (`sandbox:/mnt/data/zeta-incremental-compiler-host-dbsp-zsets-rx-meta-ast-tags-2026-05-21-v2-seeded-determinism.md`) is pending Aaron-forward; will land at `docs/research/zeta-incremental-compiler-host-dbsp-zsets-rx-meta-ast-tags-2026-05-21.md` when forwarded.
+
+## External reference anchor (operator 2026-05-22): InterSystems Caché as closest commercial substrate analog
+
+The human maintainer 2026-05-22 named the closest existing commercial substrate analog: **InterSystems Caché** ([https://en.wikipedia.org/wiki/InterSystems_Cach%C3%A9](https://en.wikipedia.org/wiki/InterSystems_Cach%C3%A9)). Operator's framing: *"we basically said the closest human thing is cache a fresh medical database."*
+
+Caché is the multi-model database that powers Epic Systems EHR + most US hospital electronic health records. Operationally it provides: multi-model (object + SQL + key-value + multi-dimensional global arrays); high-performance distributed; embedded scripting (ObjectScript); mission-critical reliability; sub-millisecond response; HIPAA-compliant audit trail; HL7 FHIR + Health Connect interop for cross-EHR data exchange.
+
+**Why the Caché analog is operationally load-bearing for B-0688**:
+
+| Property | InterSystems Caché | Zeta db (this B-0688 substrate) |
+|---|---|---|
+| **Multi-model** | Object + SQL + key-value + multi-dimensional global arrays | F# typed substrate + DBSP Z-sets + Rx meta-AST tags + content-addressed packages |
+| **High-performance distributed** | Powers Epic; high-availability EHR; multi-tenant | Distributed intelligence database; multi-oracle federation (per B-0703) |
+| **Embedded scripting** | ObjectScript (data-aware scripting language) | F# compiler as the data-aware substrate-language |
+| **Mission-critical** | US hospital EHRs; patient safety; HIPAA-compliant | AI substrate integrity; framework substrate-engineering |
+| **Real-time + high-availability** | Sub-millisecond response; clustering | Incremental-compilation; seeded DST hardening (this B-0688 substrate) |
+| **Audit trail** | Built-in audit logging for regulated compliance | Audit-mechanism + multi-oracle BFT verification |
+| **Cross-system interop** | HL7 FHIR + Health Connect for cross-EHR data exchange | Symmetric/decentralized Ace deployments + consent-pact interop |
+
+**Mirror→beacon translation use**:
+
+The Caché reference IS the deliberate-writing-pass anchor that translates substrate-internal-vocabulary (DBSP Z-sets / Rx meta-AST tags / seeded DST hardening) into externally-defensible language. "Zeta db is like InterSystems Caché but with F# compiler integration + multi-oracle BFT + Rx/DBSP semantic-index substrate + DST hardening" survives the year-out test — readers in healthcare-IT / enterprise database / mission-critical-systems engineering understand the operational shape.
+
+**Composes with sovereignty-path 3rd piece (durable tension-substrate via maji-math)**:
+
+The maji-math substrate (rx-tension-as-semantic-indexes; mirror-tier) provides the mathematical foundation; B-0688 operationalizes via the Caché-pattern incremental-compiler-database; path-to-beacon-tier requires the math formalizing + the compiler-database shipping + DST seeded-determinism hardening landing.
+
+**Substrate-engineering implications for B-0688 work**:
+
+- Cite Caché architecture patterns for distributed-multi-model + high-availability
+- Compose with HL7/FHIR-style interop standards as precedent for cross-deployment data exchange
+- Inherit audit-mechanism + retention-policy patterns from medical-DB compliance space
+- Use ObjectScript-as-data-aware-language as precedent for F#-as-substrate-aware-language
+
+This is the "cached-fresh medical database" framing operator named — Caché IS the concrete commercial reference architecture the substrate-engineering work composes against.


### PR DESCRIPTION
Operator save instruction 2026-05-22: maji-math (rx-tension-as-semantic-indexes; mirror-tier; not beacon-tier) as foundation; Zeta-db-as-F#-compiler-as-distributed-intelligence-database building toward beacon-tier via B-0688 + B-0687; closest commercial substrate analog is InterSystems Caché (powers Epic EHR + most US hospital electronic health records). The Caché reference IS the deliberate-writing-pass anchor for mirror-to-beacon translation; survives year-out test for healthcare-IT / enterprise-database / mission-critical-systems audiences. Updates B-0688 (full Caché mapping) + Zeta AGENDA.md (reference anchor + sovereignty-path 3rd piece composition).

Co-Authored-By: Claude <noreply@anthropic.com>