### PR TITLE
fix(B-0525): canonical Constraint 2 wording "Lock/Wait-free" (Copilot P1 follow-up)

### DIFF
--- a/docs/agendas/zeta/AGENDA.md
+++ b/docs/agendas/zeta/AGENDA.md
@@ -47,7 +47,7 @@ See B-0688 for the substrate-engineering work in progress; B-0688 has been exten
 
 Zeta IS the generative framework that operationalizes the manifesto's eleven constraints + m/acc orientation as substrate-engineering primitives:
 
-- **Constraints 1-4** (Scale-free / Lock-Wait-free / Weight-free / Bounded Mobility) ↔ Zeta's substrate-engineering primitives — the always-active discipline set
+- **Constraints 1-4** (Scale-free / Lock/Wait-free / Weight-free / Bounded Mobility) ↔ Zeta's substrate-engineering primitives — the always-active discipline set
 - **Constraint 5 (Memory Preservation Guarantee)** ↔ Zeta DB = F# compiler as distributed intelligence database (B-0688); preservation is the DB's first job
 - **Constraint 7 (Deterministic Simulation Testing)** ↔ Zeta substrate is DST-friendly throughout; seeded determinism is the universal-DST gate
 - **Constraint 8 (Data Vault 2.0)** ↔ DBSP Z-sets + DV2.0 substrate operates throughout Zeta's data layer


### PR DESCRIPTION
## Summary

Follow-up to PR #4751 (which merged before this Copilot P1 fix could be pushed):

Manifesto line 54 is `### 2. Lock/Wait-free` (slash). PR #4751's `docs/agendas/zeta/AGENDA.md` cited it as "Lock-Wait-free" (hyphen) — drift from canonical wording.

This 1-line fix realigns the citation to the manifesto's exact wording. Same wording-discipline lesson as PR #4748 (Constraint 11 vs Multi-Oracle Principle): keep citation text byte-aligned with manifesto headings so future search/grep work uniformly.

Diff: 1 line. `Lock-Wait-free` → `Lock/Wait-free` in `docs/agendas/zeta/AGENDA.md:50`.

## Composes with

- PR #4751 (slice 4 — this is the post-merge wording-fix follow-up)
- PR #4748 (slice 2 — earlier wording-discipline lesson)
- B-0525 (parent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)