### PR TITLE
docs(autonomous-loop): Step 1a — unfinished-PR check before new work

### DIFF
--- a/docs/AUTONOMOUS-LOOP-PER-TICK.md
+++ b/docs/AUTONOMOUS-LOOP-PER-TICK.md
@@ -78,6 +78,46 @@ non-git-mutating work, and log the failure in the tick shard for
 future-Otto context. The safe assumption under unknown state is to
 avoid operations that contend on `.git/objects/pack`.
 
+#### Step 1a — Unfinished-PR check (Aaron 2026-05-23)
+
+After refresh, query for unfinished PRs authored by this agent
+surface that need attention BEFORE picking new speculative work:
+
+```bash
+gh pr list --state open \
+  --search "author:@me head:otto-cli/* OR head:otto-desktop/* OR head:otto-vscode/* OR head:otto/* -label:\"deferred-to-human\"" \
+  --json number,title,createdAt,mergeable,updatedAt \
+  --limit 50
+```
+
+For each unfinished PR returned, apply
+[`.claude/rules/pr-triage-tiers.md`](../.claude/rules/pr-triage-tiers.md)
+classification (Tier 1 redundant / Tier 2 recoverable / Tier 3
+superseded / Tier 4 re-derivable / Tier 5 deferred-to-human). Act
+on Tier 1-4 closes immediately (substrate-honest comment +
+`gh pr close`). For Tier 5, tag `deferred-to-human` via
+`gh pr edit <N> --add-label "deferred-to-human"` and post the
+substrate-at-risk comment; future scans skip these.
+
+**Lane discipline** (per [`.claude/rules/agent-roster-reference-card.md`](../.claude/rules/agent-roster-reference-card.md)):
+filter to YOUR surface's branch prefixes — Lior owns `lior/*`,
+peer Otto-CLI vs Otto-Desktop vs Otto-VSCode each own their
+surface-tagged prefixes. Do NOT triage another agent's lane
+unless explicit coordination has transferred ownership.
+
+**Substrate-honest framing**: this step prevents cross-session
+amnesia — each cold-boot picks new work without seeing the
+unfinished PRs the same surface left behind. Aaron 2026-05-23:
+*"plase updates your background server for this... lirs background
+service is what's leaving prs sometime so we are updateing to check
+for unfinsihed prs first when it starts"* — the same fix applies
+to Otto.
+
+**Only proceed to Step 3 (pick new work) if no unfinished PRs
+need attention.** Step 2 (Holding discipline) still applies if
+the unfinished-PR check itself surfaces a real bounded wait
+(e.g., PR in CI awaiting required check).
+
 ### 2. Apply Holding-without-named-dependency discipline
 
 [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md).


### PR DESCRIPTION
## Summary

Companion to merged PR #4761 (rules/pr-triage-tiers + `deferred-to-human` label). Adds **Step 1a** between Steps 1 and 2 of the canonical per-tick discipline: after refresh, query for unfinished PRs authored by this agent surface, classify per the Tier 1-5 framework, and act on Tier 1-4 closes BEFORE picking new speculative work.

## Why

Aaron 2026-05-23: *"lirs background service is what's leaving prs sometime so we are updateing to check for unfinsihed prs first when it starts, maybe yours should do the same"*. This is Otto's version of that fix at the canonical-discipline scope — applies to all three Otto surfaces (CLI / Desktop / queued B-0448 cloud routine) which cite this file as their one-source-of-truth.

## What lands

- Concrete `gh pr list` query with surface-lane-prefix filter + `-label:deferred-to-human` exclusion
- Reference to `.claude/rules/pr-triage-tiers.md` for classification (PR #4761)
- Lane discipline reminder (don't triage other agents' PRs)
- Substrate-honest framing of cross-session amnesia failure mode this prevents
- Explicit gate: only proceed to Step 3 (pick new work) if no unfinished PRs need attention

## Commit details

Landed via git plumbing (`commit-tree` with temp index from `origin/main`) to bypass contested-local-working-tree where peer Otto-CLI has unpushed edits to this file. `origin/main` was 3 days stale on this file at commit time (commit `7d6f3ff4f`); this is the next change. Peer-Otto's local edits will rebase cleanly when they push since this insertion is additive (Step 1a between existing Steps 1 and 2, no overlap with Step 4 tick-shard-gate work where peer edits live).

## Test plan

- [x] Insertion adds 40 lines between Steps 1 and 2 of canonical
- [x] All cross-references resolve correctly (`.claude/rules/pr-triage-tiers.md`, `.claude/rules/agent-roster-reference-card.md`)
- [x] Bash query uses proper escaping for `--search` argument
- [ ] CI green (markdown lint + path-depth check)
- [ ] Auto-merge fires once green