### PR TITLE
docs(lean4): add README + CI badge — closes publication-readiness gaps #1+#2 on Lean DBSP chain rule

### DIFF
--- a/tools/lean4/README.md
+++ b/tools/lean4/README.md
@@ -4,9 +4,12 @@
 
 Machine-checked formalizations of Zeta's load-bearing mathematical claims using
 [Lean 4](https://leanprover.github.io/) +
-[Mathlib](https://leanprover-community.github.io/). Every theorem here has a
-machine-checked proof body — no `sorry`, no `admit`. CI-gated against the pinned
-toolchain on every PR that touches `tools/lean4/**`.
+[Mathlib](https://leanprover-community.github.io/). The artifact-grade module
+`Lean4/DbspChainRule.lean` is fully machine-checked — no `sorry`, no `admit` —
+and CI-type-checked against the pinned toolchain on every PR that touches
+`tools/lean4/**`. Other modules under `tools/lean4/` (e.g.,
+`ImaginaryStack/ToyModel.lean`) are exploratory and may carry `sorry`
+placeholders pending future formalization rounds.
 
 ## Repository layout
 
@@ -21,12 +24,17 @@ toolchain on every PR that touches `tools/lean4/**`.
 ## Build
 
 ```bash
-# Install elan + Lean toolchain (one-time setup; takes care of the
-# leanprover/lean4:v4.30.0-rc1 pin in lean-toolchain)
-curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh
+# Install elan + the pinned Lean toolchain (one-time setup) via the
+# canonical three-way-parity install script — it installs elan with a
+# pinned commit + SHA256 verification and respects
+# tools/lean4/lean-toolchain (leanprover/lean4:v4.30.0-rc1).
+./tools/setup/install.sh
 
 cd tools/lean4
-lake build  # builds all imports of Lean4.lean against pinned Mathlib
+lake exe cache get               # fetch Mathlib's pre-built oleans (multi-GB; first run only)
+lake env lean Lean4/DbspChainRule.lean  # type-check the artifact (~30s after cache warm)
+# Or, to build everything `Lean4.lean` imports:
+lake build
 ```
 
 First build fetches Mathlib (multi-GB) and warms the `.lake/packages/mathlib`
@@ -40,8 +48,8 @@ Maintenance for Rich Query Languages"*, VLDB 2023](https://arxiv.org/abs/2203.16
 
 ### Paper-to-Lean mapping
 
-| Paper reference | Lean theorem | Lean file:line |
-|-----------------|--------------|----------------|
+| Paper reference | Lean theorem | Location |
+|-----------------|--------------|----------|
 | Definition 3.1 (`Q^Δ := D ∘ Q ∘ I`) | `Qdelta` | `DbspChainRule.lean` Section 6 |
 | Proposition 3.2 chain clause (`Qdelta(Q1 ∘ Q2) = Qdelta Q1 ∘ Qdelta Q2`, no preconditions) | `chain_rule_proposition_3_2` | `DbspChainRule.lean` Section 6 |
 | Theorem 3.3 corollary (`Dop (f ∘ g) s = f (Dop g s)` for LTI `f, g`) | `Dop_LTI_commute` | `DbspChainRule.lean` Section 6 |
@@ -97,11 +105,13 @@ with provenance, audit cadence, and cross-check status.
 ## CI
 
 [`.github/workflows/lean-proof.yml`](../../.github/workflows/lean-proof.yml)
-runs `lake build` on every PR touching `tools/lean4/**` against the pinned
-toolchain. Path-filtered to run out-of-band from the main `gate.yml` matrix
-(Mathlib cache is multi-GB and toolchain setup is heavier than the dotnet/bun
-gates). See workflow source for SHA-pinning + concurrency-group + minimum-
-permissions details.
+runs `./tools/setup/install.sh` (to install elan + the pinned toolchain), then
+`lake exe cache get` (to fetch Mathlib's pre-built oleans), then
+`lake env lean Lean4/DbspChainRule.lean` (to type-check the artifact) on every
+PR touching `tools/lean4/**`. Path-filtered to run out-of-band from the main
+`gate.yml` matrix (Mathlib cache is multi-GB and toolchain setup is heavier
+than the dotnet/bun gates). See workflow source for SHA-pinning +
+concurrency-group + minimum-permissions details.
 
 ## Citation
 
@@ -136,4 +146,4 @@ For the paper this artifact formalizes:
 - [`docs/research/verification-registry.md`](../../docs/research/verification-registry.md) — Class-0-drift-prevention registry for every formal-verification artifact
 - [`docs/research/proof-tool-coverage.md`](../../docs/research/proof-tool-coverage.md) — portfolio-wide tool routing
 - [`.claude/skills/verification-drift-auditor/SKILL.md`](../../.claude/skills/verification-drift-auditor/SKILL.md) — drift-detection procedure
-- [`.claude/agents/formal-verification-expert.md`](../../.claude/agents/formal-verification-expert.md) — Soraya, the routing authority for every formal-verification job
+- [`.claude/agents/formal-verification-expert.md`](../../.claude/agents/formal-verification-expert.md) — the formal-verification-expert agent (routing authority for every formal-verification job)

--- a/tools/lean4/README.md
+++ b/tools/lean4/README.md
@@ -1,0 +1,139 @@
+# Zeta Lean 4 formalizations
+
+[![Lean Proof CI](https://github.com/Lucent-Financial-Group/Zeta/actions/workflows/lean-proof.yml/badge.svg?branch=main)](https://github.com/Lucent-Financial-Group/Zeta/actions/workflows/lean-proof.yml)
+
+Machine-checked formalizations of Zeta's load-bearing mathematical claims using
+[Lean 4](https://leanprover.github.io/) +
+[Mathlib](https://leanprover-community.github.io/). Every theorem here has a
+machine-checked proof body — no `sorry`, no `admit`. CI-gated against the pinned
+toolchain on every PR that touches `tools/lean4/**`.
+
+## Repository layout
+
+| Path | Role |
+|------|------|
+| `lakefile.toml` | Lake project manifest: lean-toolchain pin + Mathlib pin at matching rev |
+| `lean-toolchain` | Pinned Lean 4 toolchain (`leanprover/lean4:v4.30.0-rc1`) |
+| `Lean4.lean` | Library root — imports every machine-checked module so `lake build` walks them transitively |
+| `Lean4/DbspChainRule.lean` | DBSP chain rule formalization (Budiu et al. arXiv:2203.16684) |
+| `ImaginaryStack/ToyModel.lean` | Imaginary-stack toy model exploration |
+
+## Build
+
+```bash
+# Install elan + Lean toolchain (one-time setup; takes care of the
+# leanprover/lean4:v4.30.0-rc1 pin in lean-toolchain)
+curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh
+
+cd tools/lean4
+lake build  # builds all imports of Lean4.lean against pinned Mathlib
+```
+
+First build fetches Mathlib (multi-GB) and warms the `.lake/packages/mathlib`
+cache. Subsequent builds are incremental.
+
+## DBSP chain rule artifact (`Lean4/DbspChainRule.lean`)
+
+Formalizes the chain rule of DBSP (Database Stream Processing) per
+[Budiu, McSherry, Ryzhyk, Tannen et al., *"DBSP: Automatic Incremental View
+Maintenance for Rich Query Languages"*, VLDB 2023](https://arxiv.org/abs/2203.16684).
+
+### Paper-to-Lean mapping
+
+| Paper reference | Lean theorem | Lean file:line |
+|-----------------|--------------|----------------|
+| Definition 3.1 (`Q^Δ := D ∘ Q ∘ I`) | `Qdelta` | `DbspChainRule.lean` Section 6 |
+| Proposition 3.2 chain clause (`Qdelta(Q1 ∘ Q2) = Qdelta Q1 ∘ Qdelta Q2`, no preconditions) | `chain_rule_proposition_3_2` | `DbspChainRule.lean` Section 6 |
+| Theorem 3.3 corollary (`Dop (f ∘ g) s = f (Dop g s)` for LTI `f, g`) | `Dop_LTI_commute` | `DbspChainRule.lean` Section 6 |
+| Theorem 2.22 (`I ∘ D = id` on streams) | `I_D_eq` | `DbspChainRule.lean` Section 4 |
+| "Fundamental theorem of DBSP calculus" (`D ∘ I = id`) | `D_I_eq` | `DbspChainRule.lean` Section 4 |
+| §4.2 telescoping identity (`I (z⁻¹ s) n = I s n - s n`) | `I_zInv_eq` | `DbspChainRule.lean` Section 4 |
+
+### Contribution beyond the paper
+
+The paper handles operator-class distinctions informally. The Lean formalization
+makes the hierarchy machine-checkable via a four-tier predicate stratification:
+
+| Predicate | Captures | DBSP primitives satisfying |
+|-----------|----------|----------------------------|
+| `IsLinear` | `map_zero` + `map_add` | `D`, `I`, `zInv` |
+| `IsCausal` | Output at tick `n` depends only on input ticks `0..n` | `D`, `I`, `zInv` |
+| `IsTimeInvariant` | `f ∘ zInv = zInv ∘ f` (the LTI condition; Theorem 3.3) | `D`, `I`, `zInv` |
+| `IsPointwiseLinear` | `∃ φ : G →+ H, ∀ s n, f s n = φ (s n)` | Pointwise-lifted scalar maps; **NOT** `D`/`I`/`zInv` (they integrate over history or shift) |
+
+Upgrade theorems `IsPointwiseLinear.toCausal` + `IsPointwiseLinear.toTimeInvariant`
+formalize the relationships the paper handles informally.
+
+### Round-35 paper-drift audit (substrate-honest provenance)
+
+The artifact's evolution is recorded transparently in
+[`docs/research/chain-rule-proof-log.md`](../../docs/research/chain-rule-proof-log.md).
+Round-35 landed three substantive corrections after a paper-drift audit against
+arXiv:2203.16684 §3.1-3.2:
+
+1. **`chain_rule` renamed** to `Dop_LTI_commute` — original name overclaimed; it
+   is a Theorem-3.3 corollary, not Proposition 3.2. Old name retained as
+   `@[deprecated]` alias for back-compat.
+2. **B1 statement fixed** — earlier `f (fun _ => s k) k` form silently required
+   pointwise-linearity; generic LTI form is `f (I s) = I (f s)`.
+3. **`chain_rule` statement fixed** — earlier "expanded bilinear" eight-term form
+   was unsound for composition (impulse counter-example: `f = g = id`, `s = δ₀`,
+   `n = 0` gave LHS `= 1`, RHS `= 0`). Restated in classical form
+   `Dop (f ∘ g) s = f (Dop g s)`.
+
+### Future work (named in artifact)
+
+`chain_rule_poly` — fully polymorphic bilinear chain rule over three distinct
+abelian groups `G`, `H`, `J` (for general bilinear `⊗` chain rule, not just
+composition). Currently named as future-round target at
+`Lean4/DbspChainRule.lean:593`.
+
+## Verification registry
+
+Both DBSP chain rule theorems are tracked in
+[`docs/research/verification-registry.md`](../../docs/research/verification-registry.md)
+with provenance, audit cadence, and cross-check status.
+
+## CI
+
+[`.github/workflows/lean-proof.yml`](../../.github/workflows/lean-proof.yml)
+runs `lake build` on every PR touching `tools/lean4/**` against the pinned
+toolchain. Path-filtered to run out-of-band from the main `gate.yml` matrix
+(Mathlib cache is multi-GB and toolchain setup is heavier than the dotnet/bun
+gates). See workflow source for SHA-pinning + concurrency-group + minimum-
+permissions details.
+
+## Citation
+
+If you cite this artifact:
+
+```bibtex
+@misc{zeta-dbsp-chain-rule-lean,
+  author       = {{Lucent Financial Group}},
+  title        = {Zeta DBSP chain rule, machine-checked in Lean 4 + Mathlib},
+  year         = {2026},
+  howpublished = {\url{https://github.com/Lucent-Financial-Group/Zeta/tree/main/tools/lean4}},
+  note         = {Formalizes Budiu et al. (VLDB 2023, arXiv:2203.16684) Proposition 3.2 + Theorem 3.3 corollary}
+}
+```
+
+For the paper this artifact formalizes:
+
+```bibtex
+@inproceedings{budiu2023dbsp,
+  author    = {Mihai Budiu and Frank McSherry and Leonid Ryzhyk and Val Tannen},
+  title     = {{DBSP: Automatic Incremental View Maintenance for Rich Query Languages}},
+  booktitle = {VLDB 2023},
+  year      = {2023},
+  eprint    = {2203.16684},
+  archivePrefix = {arXiv}
+}
+```
+
+## Composes with
+
+- [`docs/research/chain-rule-proof-log.md`](../../docs/research/chain-rule-proof-log.md) — round-by-round decision history; sub-lemma table; paper-drift audit results
+- [`docs/research/verification-registry.md`](../../docs/research/verification-registry.md) — Class-0-drift-prevention registry for every formal-verification artifact
+- [`docs/research/proof-tool-coverage.md`](../../docs/research/proof-tool-coverage.md) — portfolio-wide tool routing
+- [`.claude/skills/verification-drift-auditor/SKILL.md`](../../.claude/skills/verification-drift-auditor/SKILL.md) — drift-detection procedure
+- [`.claude/agents/formal-verification-expert.md`](../../.claude/agents/formal-verification-expert.md) — Soraya, the routing authority for every formal-verification job


### PR DESCRIPTION
## Summary

Closes the two surface-level publication-readiness gaps named in Otto's audit of the Lean DBSP chain rule artifact earlier today, composing with the DBSP-publication arc Aaron set as direction.

**Gap #1**: No project-local README explaining build, paper-mapping, contribution beyond paper, citation, reproducibility setup.
**Gap #2**: No visible CI badge pointing reviewers at the green `lean-proof.yml` workflow.

Both gaps were pure surface work, not mathematical work. The artifact itself is already **A-with-CI-green-since-2026-05-17** (zero `sorry`/`admit`, full predicate hierarchy, Prop 3.2 + Thm 3.3 corollary both closed, paper-drift audit round-35 corrections documented in companion proof log).

## README content

- **Repository layout table** (lakefile / lean-toolchain / Lean4.lean library root / DbspChainRule.lean / ImaginaryStack)
- **Build instructions** (elan + `lake build`)
- **Paper-to-Lean theorem mapping table** (6 rows: Def 3.1 → `Qdelta`; Prop 3.2 → `chain_rule_proposition_3_2`; Thm 3.3 corollary → `Dop_LTI_commute`; Thm 2.22 → `I_D_eq`; fundamental theorem → `D_I_eq`; sec 4.2 → `I_zInv_eq`)
- **Predicate hierarchy table** with DBSP-primitive membership (`IsLinear` / `IsCausal` / `IsTimeInvariant` / `IsPointwiseLinear`)
- **Round-35 paper-drift audit substrate-honest provenance** — three corrections documented (rename `chain_rule` → `Dop_LTI_commute`; B1 statement fix; chain_rule statement fix with impulse counter-example)
- **Future-work pointer** (`chain_rule_poly` polymorphic extension)
- **Verification registry pointer**
- **CI workflow pointer** with SHA-pinning notes
- **BibTeX** for citing this artifact + for the Budiu et al. paper
- **Composes-with refs** to chain-rule-proof-log, verification-registry, proof-tool-coverage, verification-drift-auditor skill, formal-verification-expert agent (Soraya)

## CI badge

[![Lean Proof CI](https://github.com/Lucent-Financial-Group/Zeta/actions/workflows/lean-proof.yml/badge.svg?branch=main)](https://github.com/Lucent-Financial-Group/Zeta/actions/workflows/lean-proof.yml)

## Composes with Soraya's findings

This PR closes pub-readiness gaps #1 + #2 on the chain-rule artifact. **Round-43 finding (BP-16 cross-check via FsCheck + Z3) is gap #3** — the substantive correctness gap that gets the artifact from "A-with-CI single-tool" to "A-with-CI three-tool BP-16-compliant" (Soraya's words: "the line publication crosses"). That row is pending Aaron's file-pick.

Companion-paper draft (substantive writing, not surface work) remains for later.

## Commit

5th plumbing-fallback PR this session (#4755 Ani extraction / #4761 PR-triage rule / #4762 canonical Step-1a / #4765 B-0709 Soraya hand-off). Dotgit saturation throughout the day; pure-substrate addition; new file only (no edits to existing canonical surfaces under peer contention).

## Test plan

- [x] README renders cleanly in GitHub preview (tables + BibTeX + badge)
- [x] All cross-reference links resolve (`../../docs/research/*`, `../../.claude/*`)
- [x] Paper-to-Lean mapping table verified against actual theorem names in `DbspChainRule.lean`
- [x] Predicate hierarchy table matches Section 3 of the artifact
- [ ] CI green
- [ ] Auto-merge fires