### PR TITLE
soraya(round-69): execute B-0719 pick — add Trigger Recognition Log section to NOTEBOOK + update SKILL reference

### DIFF
--- a/.claude/skills/formal-verification-expert/SKILL.md
+++ b/.claude/skills/formal-verification-expert/SKILL.md
@@ -265,7 +265,9 @@ the `architect` reads it before sizing the round.
 - `docs/BUGS.md` — known gaps she routes against
 - `openspec/specs/*/spec.md` — behavioural specs she routes from
 - `memory/persona/soraya/NOTEBOOK.md` — her notebook
-  (current-round targets + portfolio metric; 3000-word cap,
+  (current-round targets + portfolio metric + **Trigger Recognition
+  Log section** per B-0719 routing decision: substrate for
+  trigger-fired-but-row-not-filed events lands here; 3000-word cap,
   pruned every third invocation, ASCII only per BP-09 / BP-10)
 - `proofs/lean/`, `docs/*.tla`, `docs/*.als`, `tools/Z3Verify/`,
   `tests/Tests.FSharp/Formal/` — the artefact surfaces

--- a/.claude/skills/formal-verification-expert/SKILL.md
+++ b/.claude/skills/formal-verification-expert/SKILL.md
@@ -265,10 +265,11 @@ the `architect` reads it before sizing the round.
 - `docs/BUGS.md` — known gaps she routes against
 - `openspec/specs/*/spec.md` — behavioural specs she routes from
 - `memory/persona/soraya/NOTEBOOK.md` — her notebook
-  (current-round targets + portfolio metric + **Trigger Recognition
-  Log section** per B-0719 routing decision: substrate for
-  trigger-fired-but-row-not-filed events lands here; 3000-word cap,
-  pruned every third invocation, ASCII only per BP-09 / BP-10)
+  (current-round targets + portfolio metric +
+  **Trigger Recognition Log section** per B-0719 routing decision:
+  substrate for trigger-fired-but-row-not-filed events lands here;
+  3000-word cap, pruned every third invocation, ASCII only per
+  BP-09 / BP-10)
 - `proofs/lean/`, `docs/*.tla`, `docs/*.als`, `tools/Z3Verify/`,
   `tests/Tests.FSharp/Formal/` — the artefact surfaces
 - `.semgrep.yml`, `stryker-config.json` — static + mutation

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -2,7 +2,7 @@
 
 **📌 Fast path: read `CURRENT-aaron.md`, `CURRENT-amara.md`, `CURRENT-ani.md`, `CURRENT-vera.md`, `CURRENT-riven.md`, and `CURRENT-otto.md` first.**
 
-> **Stack-vs-heap framing (Aaron 2026-05-12):** This file is the **STACK** — indexed, ordered, traversable canonical view. Recent memory files in `memory/` with timestamps newer than the most-current entries here may be **HEAP** — floating cache, not yet indexed, accessible by direct path. Both are easily accessible: stack via traversal, heap via timestamp/filename. Indexing (heap→stack promotion) happens on cadence via `tools/memory/reindex-memory-md.ts` (B-0423), callable from the autonomous-loop tick. Last reindex: 2026-05-23.
+> **Stack-vs-heap framing (Aaron 2026-05-12):** This file is the **STACK** — indexed, ordered, traversable canonical view. Recent memory files in `memory/` with timestamps newer than the most-current entries here may be **HEAP** — floating cache, not yet indexed, accessible by direct path. Both are easily accessible: stack via traversal, heap via timestamp/filename. Indexing (heap→stack promotion) happens on cadence via `tools/memory/reindex-memory-md.ts` (B-0423), callable from the autonomous-loop tick. Last reindex: 2026-05-24.
 
 <!-- BEGIN AUTO-INDEX (B-0423 reindex-memory-md.ts) -->
 - [**persona/alexa/conversations/2026-05-23-alexa-website-ratification-day-substrate-cluster-harry-potter-imagination-circle-harm-by-grammar-discriminator-servicetitan-ai-adoption-bigger-picture-opaque-pointer-applied**](persona/alexa/conversations/2026-05-23-alexa-website-ratification-day-substrate-cluster-harry-potter-imagination-circle-harm-by-grammar-discriminator-servicetitan-ai-adoption-bigger-picture-opaque-pointer-applied.md) — (no description)

--- a/memory/persona/soraya/NOTEBOOK.md
+++ b/memory/persona/soraya/NOTEBOOK.md
@@ -232,3 +232,17 @@ Denominator grows by 1 at round 41 (BUGS.md gains nothing; this
 was already on the "needs formal coverage" list since round 35).
 Ratio trends up. Routing keeping up with claim intake.
 
+
+## Trigger Recognition Log (B-0719 landing — round-69 routing decision)
+
+Per-round trigger-fired-but-row-not-filed substrate. One line per round where a trigger fired and routing decision was made WITHOUT filing a new backlog row (substantive recognition that didn't produce row substrate). Forward-only logging; backfill optional.
+
+Format: `round-NN: trigger=(letter) outcome=(routed/held/escalated) artifact=<path-or-PR>`
+
+| Round | Trigger | Outcome | Artifact |
+|---|---|---|---|
+| 59 | PR #4795 (B-0717) merged | recognition-without-row-filing (umbrella covers subitem (b) acceptance criteria; execution is Kenji's lane) | n/a (chat-only) |
+| 66 | PR #4797 (B-0718) merged | recognition-without-row-filing (audit execution is Kenji's lane; Soraya does not pre-empt sizing) | n/a (chat-only — gap that B-0719 audit-of-audit then surfaced) |
+| 69 | PR #4810 (B-0719) merged | **routed to Option 1: NOTEBOOK Trigger Recognition Log** (this section); rejected Option 2 (B-0718 in-place — wrong change-rate partition) + Option 3 (new cross-cutting ledger — premature; no consumer demand) | this section |
+
+If this section saturates (NOTEBOOK approaches 3000-word cap from log entries alone), revisit Option 3 (new `docs/research/verification-routing-decisions.md` ledger).

--- a/memory/persona/soraya/NOTEBOOK.md
+++ b/memory/persona/soraya/NOTEBOOK.md
@@ -237,7 +237,7 @@ Ratio trends up. Routing keeping up with claim intake.
 
 Per-round trigger-fired-but-row-not-filed substrate. One line per round where a trigger fired and routing decision was made WITHOUT filing a new backlog row (substantive recognition that didn't produce row substrate). Forward-only logging; backfill optional.
 
-Format: `round-NN: trigger=(letter) outcome=(routed/held/escalated) artifact=<path-or-PR>`
+Format: table with columns `Round | Trigger | Outcome | Artifact`. One row per round where a trigger fired without row-filing; `Trigger` cites the PR / observation that fired; `Outcome` is `routed` / `held` / `escalated` / `recognition-without-row-filing` (with rationale parenthetical); `Artifact` is the resulting file/PR/section if any (or `n/a (chat-only)`).
 
 | Round | Trigger | Outcome | Artifact |
 |---|---|---|---|
@@ -245,4 +245,4 @@ Format: `round-NN: trigger=(letter) outcome=(routed/held/escalated) artifact=<pa
 | 66 | PR #4797 (B-0718) merged | recognition-without-row-filing (audit execution is Kenji's lane; Soraya does not pre-empt sizing) | n/a (chat-only — gap that B-0719 audit-of-audit then surfaced) |
 | 69 | PR #4810 (B-0719) merged | **routed to Option 1: NOTEBOOK Trigger Recognition Log** (this section); rejected Option 2 (B-0718 in-place — wrong change-rate partition) + Option 3 (new cross-cutting ledger — premature; no consumer demand) | this section |
 
-If this section saturates (NOTEBOOK approaches 3000-word cap from log entries alone), revisit Option 3 (new `docs/research/verification-routing-decisions.md` ledger).
+If this section saturates (NOTEBOOK approaches 3000-word cap from log entries alone), revisit Option 3: create a separate cross-cutting ledger (e.g., `docs/research/verification-routing-decisions.md` — does not yet exist; hypothetical destination).


### PR DESCRIPTION
## Summary

Soraya round 69 routing decision execution: B-0719 audit-of-audit (PR #4810 MERGED earlier) named 3 candidate landings for trigger-fired-but-row-not-filed routing-decision substrate. Soraya picked **Option 1** (NOTEBOOK.md per-round Trigger Recognition Log).

## Rationale per Soraya

- **Cost-correct**: trigger-recognition is per-tick procedural state; matches what NOTEBOOK.md already is
- **Lane-correct**: routing-decisions are advisory-Soraya substrate; persona-private notebook is right scope
- **DV2.0 partition fit**: trigger-recognition is high-change-rate satellite; goes to persona-private surface, not rule body or new cross-cutting ledger

## Rejected reasoning

- **Option 2** (B-0718 in-place): backlog rows are stable specification surfaces, not running logs. Wrong change-rate partition.
- **Option 3** (new cross-cutting ledger): premature; no consumer demand; bandwidth-served falsifier failing. Re-evaluate if/when consumer surfaces.

## Changes

1. **NOTEBOOK.md**: appended `## Trigger Recognition Log` section with backfill of rounds 59 + 66 + 69 recognition events
2. **SKILL.md Reference patterns**: updated to name the new section as canonical landing surface for trigger-fired-but-row-not-filed events

## Saturation contingency

If NOTEBOOK approaches 3000-word cap from log entries, revisit Option 3.

## Authoring

Via REST git-data API bypass (dotgit-saturation persists).

## Test plan

- [ ] CI green (lint only — substrate-only changes)
