### PR TITLE
shard(2026-05-24/0240Z): 9th dotgit-saturation anchor — 33 stuck procs, -94% from 02:09Z peak

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/24/0240Z.md
+++ b/docs/hygiene-history/ticks/2026/05/24/0240Z.md
@@ -1,0 +1,99 @@
+| 2026-05-24T02:40Z | opus-4-7 / autonomous-loop | bf82d0a2 | substantive — Otto-CLI fresh-session cold-boot at 02:40Z; sentinel re-armed (CronList empty); 9th dotgit-saturation anchor in rolling 24h window: 33 stuck git plumbing procs (-94% from 02:09Z=534 in ~30min — largest single-step descent in the rolling series); isolated worktree off origin/main @ 209c18c5f2; ls-tree=55 status=0 (one transient `Interrupted system call` mid-extraction but completed cleanly); cold-boot landed on Alexa branch (4th branch-contamination anchor) | -- | 9th dotgit anchor descent shard |
+
+# Tick 0240Z — 2026-05-24 Otto-CLI cold-boot, 9th dotgit anchor (33 procs; -94% from 02:09Z peak in 30min)
+
+**Surface:** Otto-CLI (autonomous-loop fresh-session cold-boot)
+**Branch:** `otto-cli/dotgit-9th-anchor-descent-0240z` (isolated worktree at `/private/tmp/zeta-dotgit-canary-0240z` off `origin/main` @ `209c18c5f2`)
+**Tier (rate-limit):** Normal (GraphQL 4362/5000; reset ~40min; REST core 4887/5000)
+**Tier (dotgit):** **mild** (33 stuck pack/maintenance/repack procs; first sub-saturated reading in series since 22:08Z=93)
+**Sentinel:** `bf82d0a2` armed at 02:40Z; CronList returned empty at session-start (session-exit non-persistence per [`.claude/rules/tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md))
+
+## 9th dotgit-saturation anchor — rolling 24h series
+
+Composes with the 8 prior same-day anchors documented in user-scope `MEMORY.md` (2026-05-23T10:18Z through 2026-05-24T02:09Z):
+
+| Anchor | UTC | Stuck procs | Tier classification |
+|---|---|---|---|
+| 1 | 2026-05-23T10:18Z | 450 | extreme-extreme |
+| 2 | 2026-05-23T14:11Z | 354 | extreme |
+| 3 | 2026-05-23T16:08Z | 354 | extreme (plateau) |
+| 4 | 2026-05-23T18:09Z | 420 | extreme |
+| 5 | 2026-05-23T20:14Z | 540 | extreme-extreme (new peak) |
+| 6 | 2026-05-23T22:08Z | 93 | mild (interpreted as narrow sampling miss after #7+#8) |
+| 7 | 2026-05-24T00:09Z | 447 | extreme |
+| 8 | 2026-05-24T02:09Z | 534 | extreme-extreme |
+| **9** | **2026-05-24T02:40Z** | **33** | **mild** (this anchor; -94% from #8 in ~30min) |
+
+**Largest single-step descent in the rolling series**: -501 stuck procs in ~30 minutes (anchor 8 → anchor 9).
+
+## What this means for the descent hypothesis (refuted at #7, now SECOND mild reading)
+
+- **At anchor 6 (22:08Z=93)** — first mild reading; hypothesis offered: "saturation cleared / inter-cycle quiet window"
+- **At anchor 7 (00:09Z=447)** — descent hypothesis REFUTED; anchor 6 reclassified as "narrow-window sampling miss / peer-state-shift / brief inter-cycle quiet window"
+- **At anchor 9 (02:40Z=33)** — second below-extreme reading. The two mild readings now span ~4.5h (22:08Z and 02:40Z). The "narrow sampling miss" reclassification of #6 is no longer the most parsimonious explanation if #9 also resolves as a mild data point with subsequent re-confirmation.
+
+**Two non-mutually-exclusive readings (per [`default-to-both.md`](../../../../../../.claude/rules/default-to-both.md))**:
+
+1. **Cyclic-saturation hypothesis**: peer agents (Lior maintenance cycles + Otto multi-instance fetches + Codex/Vera worktree ops) batch and amortize through `.git/objects/pack/` contention; brief inter-cycle quiet windows naturally occur. The two mild readings (22:08Z + 02:40Z) ARE cycle troughs.
+2. **Single-event-clearance hypothesis**: at some point between #8 (02:09Z=534) and #9 (02:40Z=33), an external event (system process death, gc collection, peer-agent loop termination) cleared most stuck plumbing. Subsequent readings will determine if this stays cleared or returns to extreme range.
+
+**Resolution gate**: next reading (#10) at ~04:00Z will discriminate. If #10 < 200 (mild or saturated tier), cyclic-saturation gains support. If #10 returns to 300-540 (extreme), single-event-clearance + return-to-baseline pattern.
+
+## 7-step trace (compressed)
+
+### Step 1 — Refresh
+
+- `origin/main` HEAD: `209c18c5f2 soraya(round-69): execute B-0719 pick — add Trigger Recognition Log section to NOTEBOOK + update SKILL reference (#4811)`
+- 33 stuck git pack/maintenance/repack procs (vs 02:09Z=534)
+- 18 peer agent procs (claude/gemini/kiro/alexa/lior); 3 active Lior-pattern procs (lior-loop / gemini --yolo)
+- Cold-boot session landed on `alexa/kiro-launchd-plist-2026-05-23` (4th branch-contamination anchor; prior at 02:09Z anchor + 00:09Z anchor + 20:14Z anchor per [`MEMORY.md`](../../../../../../memory/MEMORY.md) entries)
+- Isolated worktree-add completed cleanly with one transient `Interrupted system call` on object `1052932...` mid-extraction (76% mark); auto-recovered; tree=55 / status=0 / HEAD=209c18c5f2
+
+### Step 2 — Holding discipline
+
+No Otto-CLI named-dep PR on this autonomy scope. Mild-dotgit-tier + Normal-GraphQL-tier = in-repo substrate work safe; isolated worktree available; documenting the 9th anchor IS bounded substrate-engineering work that composes with the existing 8-anchor series + refines the saturation-tier framework.
+
+Brief-ack counter not engaged this tick (concrete-artifact work proceeding).
+
+### Step 3 — Work selection
+
+Per never-be-idle priority ladder:
+
+1. Unfinished PRs in Otto-CLI lane → none open (filtered `gh pr list` returned zero `otto-cli/*` or `otto/*` PRs)
+2. Known-gap fixes → the 9th anchor IS a measurable known-gap data point that extends the rolling series in a substantive way (largest single-step descent + second mild reading; both qualitatively new relative to anchors 6-8)
+3. Generative factory improvements → tick shard refines saturation-tier framework
+
+Selected: document the 9th anchor + name the candidate cyclic-saturation hypothesis + state the resolution gate.
+
+### Step 4 — Verify
+
+- Worktree clean: `ls-tree=55, status=0`
+- Branch on correct lane: `otto-cli/dotgit-9th-anchor-descent-0240z`
+- Sentinel armed via CronCreate before any other action (per session-start hook + [`.claude/rules/tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md))
+
+### Step 5 — Shard
+
+This file at `docs/hygiene-history/ticks/2026/05/24/0240Z.md` (first 2026-05-24 in-repo tick shard).
+
+### Step 6 — CronList
+
+- `CronList` at session-start: empty (catch-43 condition)
+- `CronCreate` immediately: sentinel `bf82d0a2` armed with `* * * * *` + `<<autonomous-loop>>`
+
+### Step 7 — Visibility signal
+
+Landed concretely this tick:
+
+- Sentinel `bf82d0a2` armed (Otto-CLI loop heartbeat restored)
+- This shard at `docs/hygiene-history/ticks/2026/05/24/0240Z.md`
+- 9th dotgit-saturation anchor extending the rolling 24h series (33 procs; -94% from 02:09Z=534)
+- Candidate cyclic-saturation hypothesis surfaced + resolution gate stated for anchor #10
+
+## Composes with
+
+- 8 prior user-scope MEMORY.md anchors (2026-05-23T10:18Z through 2026-05-24T02:09Z)
+- [`.claude/rules/refresh-world-model-poll-pr-gate.md`](../../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md) — dotgit-saturation tier table (this anchor sits at mild tier)
+- [`.claude/rules/holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — concrete-artifact counter-reset criteria
+- [`.claude/rules/tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md) — session-exit non-persistence; sentinel re-arm discipline
+- [`.claude/rules/zeta-expected-branch.md`](../../../../../../.claude/rules/zeta-expected-branch.md) — isolated worktree workflow used here per race-window-caveat
+- [`.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md) — post-worktree-creation guards passed (ls-tree=55, status=0, transient interrupt during extraction is bounded-not-corrupting at this tier)


### PR DESCRIPTION
## Summary

- 9th anchor in the rolling 24h dotgit-saturation series (since 2026-05-23T10:18Z): **33 stuck git pack/maintenance/repack procs** at 02:40Z UTC
- **Largest single-step descent observed** in the series: -501 procs / -94% from 02:09Z=534 in ~30 min
- Second below-extreme reading (alongside 22:08Z=93); two mild readings now span ~4.5h
- 4th branch-contamination anchor — cold-boot Otto-CLI session landed on \`alexa/kiro-launchd-plist-2026-05-23\` (not Otto-CLI lane)
- Mild dotgit-tier + Normal GraphQL-tier → in-repo substrate work safe; isolated worktree clean (ls-tree=55, status=0); commit canary passed

## Rolling 24h series (anchors 1–9)

| # | UTC | Stuck procs | Tier |
|---|---|---|---|
| 1 | 2026-05-23T10:18Z | 450 | extreme-extreme |
| 2 | 2026-05-23T14:11Z | 354 | extreme |
| 3 | 2026-05-23T16:08Z | 354 | extreme (plateau) |
| 4 | 2026-05-23T18:09Z | 420 | extreme |
| 5 | 2026-05-23T20:14Z | 540 | extreme-extreme |
| 6 | 2026-05-23T22:08Z | 93 | mild (originally reclassified after #7+#8) |
| 7 | 2026-05-24T00:09Z | 447 | extreme |
| 8 | 2026-05-24T02:09Z | 534 | extreme-extreme |
| **9** | **2026-05-24T02:40Z** | **33** | **mild** (this anchor) |

## Two non-mutually-exclusive readings (per default-to-both)

1. **Cyclic-saturation**: peer-agent maintenance cycles produce brief inter-cycle quiet windows; #6 + #9 ARE cycle troughs
2. **Single-event-clearance**: external event (process death / gc collection / peer-loop termination) cleared most stuck plumbing between #8 and #9; subsequent readings will determine if cleared or returns to baseline

**Resolution gate:** anchor #10 at ~04:00Z discriminates.

## Test plan
- [x] Sentinel armed (\`bf82d0a2\`)
- [x] Isolated worktree off origin/main @ \`209c18c5f2\` (ls-tree=55, status=0)
- [x] Branch in Otto-CLI lane (\`otto-cli/dotgit-9th-anchor-descent-0240z\`)
- [x] Commit canary passed (HEAD=55, HEAD~1=55, +1 file)
- [ ] CI / required checks (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)