### PR TITLE
feat(infra): k8s bootstrap + ArgoCD App-of-Apps (PR 4 of Addison's plan)

### DIFF
--- a/infra/k8s/applications/argorollouts/Application.yaml
+++ b/infra/k8s/applications/argorollouts/Application.yaml
@@ -1,0 +1,49 @@
+# infra/k8s/applications/argorollouts/Application.yaml
+#
+# Argo Rollouts — progressive-delivery controller. Replaces
+# kubectl rollout for the apps that need canaries / blue-green
+# / experiment-driven traffic splits. Especially relevant for
+# Orleans Silo upgrades where session affinity matters.
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-rollouts
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://argoproj.github.io/argo-helm
+    chart: argo-rollouts
+    targetRevision: 2.39.5   # Argo Rollouts 1.8 family
+    helm:
+      releaseName: argo-rollouts
+      valuesObject:
+        controller:
+          # Pin replica count to 2 for HA once the cluster has
+          # multiple nodes (PodDisruptionBudget kicks in here too).
+          replicas: 1   # bump to 2 when 2nd control-plane or worker arrives
+
+        # Argo Rollouts dashboard for UI-driven rollout inspection.
+        dashboard:
+          enabled: true
+          serviceType: ClusterIP
+          # Expose via ingress once cert-manager + ingress-nginx are in.
+
+        # Notifications go through the same Argo notifications
+        # engine ArgoCD uses; configure receivers in a separate
+        # ConfigMap App once Slack/email webhooks are wired.
+        notifications:
+          enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argo-rollouts
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infra/k8s/applications/argoworkflows/Application.yaml
+++ b/infra/k8s/applications/argoworkflows/Application.yaml
@@ -1,0 +1,58 @@
+# infra/k8s/applications/argoworkflows/Application.yaml
+#
+# Argo Workflows — DAG-based job scheduler for the cluster. Drives
+# AI pipelines, batch model-training, data preprocessing, anything
+# that wants reified workflow state with retries + parallelism.
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-workflows
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://argoproj.github.io/argo-helm
+    chart: argo-workflows
+    targetRevision: 0.42.5    # Argo Workflows 3.6 family
+    helm:
+      releaseName: argo-workflows
+      valuesObject:
+        controller:
+          # Workflow archive persists completed workflows; useful
+          # for audit trails on AI training runs.
+          workflowDefaults:
+            spec:
+              activeDeadlineSeconds: 86400   # 24h cap on any workflow
+              ttlStrategy:
+                secondsAfterCompletion: 604800   # 7 days retention
+              podGC:
+                strategy: OnPodCompletion
+
+          # Allow the cluster to schedule workflows onto GPU nodes
+          # by tolerating the zeta.io/gpu node label / taint.
+          parallelism: 50
+
+        server:
+          # Disable auth at the server level for in-cluster use;
+          # external access goes through cluster-wide SSO once
+          # cert-manager + ingress land.
+          authModes:
+            - server
+
+        # Workflow Executor — emissary is the modern default.
+        executor:
+          image:
+            tag: ""    # use chart default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argo-workflows
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infra/k8s/applications/gitlab/Application.yaml
+++ b/infra/k8s/applications/gitlab/Application.yaml
@@ -1,0 +1,71 @@
+# infra/k8s/applications/gitlab/Application.yaml
+#
+# Self-hosted GitLab. Per Addison's spec, GitLab is the post-bootstrap
+# Git host — everything after GitLab is installed lives there rather
+# than on GitHub. The repoURL stays on GitHub for THIS Application
+# definition because GitLab can't reference itself before it exists;
+# once GitLab is healthy, future apps can point at the self-hosted URL.
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gitlab
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://charts.gitlab.io/
+    chart: gitlab
+    targetRevision: 8.7.0   # GitLab 17.7 family; bump in lockstep with upstream
+    helm:
+      releaseName: gitlab
+      valuesObject:
+        global:
+          edition: ce
+          hosts:
+            domain: gitlab.zeta.local
+            externalIP: ""   # set to LoadBalancer IP once MetalLB is in
+          ingress:
+            configureCertmanager: false  # cert-manager comes in a later app
+            tls:
+              enabled: false   # turn on after cert-manager + DNS
+          # Initial root password — must be reset on first login.
+          # In production, source from sops-nix decrypted Secret.
+          initialRootPassword:
+            secret: gitlab-initial-root-password
+            key: password
+
+        # Disable bundled components that overlap with cluster services
+        # we install separately:
+        certmanager:
+          install: false       # use cluster-wide cert-manager
+        nginx-ingress:
+          enabled: false       # use ingress-nginx App
+        prometheus:
+          install: false       # use cluster-wide observability stack
+
+        gitlab-runner:
+          install: true        # ship runners alongside GitLab
+          runners:
+            privileged: false  # explicit denial; safer default
+            tags: "kubernetes,zeta-cluster"
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: gitlab
+  syncPolicy:
+    automated:
+      prune: false             # GitLab data is precious — manual prune only
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - SkipDryRunOnMissingResource=true   # GitLab CRDs apply in waves
+    retry:
+      limit: 5
+      backoff:
+        duration: 30s
+        factor: 2
+        maxDuration: 5m

--- a/infra/k8s/applications/orleans/Application.yaml
+++ b/infra/k8s/applications/orleans/Application.yaml
@@ -1,0 +1,35 @@
+# infra/k8s/applications/orleans/Application.yaml
+#
+# ArgoCD-managed Orleans Application. Supersedes the bootstrap
+# manifest at infra/k8s/bootstrap/initial-orleans.yaml once the
+# control-plane has finished initial reconcile.
+#
+# Source path points at the same directory this file lives in;
+# ArgoCD applies every YAML in the directory EXCEPT files matching
+# the App-of-Apps pattern (Application.yaml).
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: orleans
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Lucent-Financial-Group/Zeta
+    targetRevision: main
+    path: infra/k8s/applications/orleans
+    directory:
+      include: '{deployment,service,rbac,configmap}.yaml'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: orleans
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infra/k8s/applications/orleans/configmap.yaml
+++ b/infra/k8s/applications/orleans/configmap.yaml
@@ -1,0 +1,31 @@
+# infra/k8s/applications/orleans/configmap.yaml
+#
+# Orleans cluster configuration. Mounted into the silo pods at
+# /etc/orleans/cluster.json. Values map to OrleansHostBuilder
+# .UseKubernetesHosting() conventions.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orleans-config
+  namespace: orleans
+data:
+  cluster.json: |
+    {
+      "serviceId": "zeta",
+      "clusterId": "zeta-prod",
+      "silo": {
+        "siloPort": 11111,
+        "gatewayPort": 30000
+      },
+      "clustering": {
+        "provider": "kubernetes",
+        "namespace": "orleans"
+      },
+      "telemetry": {
+        "dashboard": {
+          "enabled": true,
+          "port": 8080
+        }
+      }
+    }

--- a/infra/k8s/applications/orleans/deployment.yaml
+++ b/infra/k8s/applications/orleans/deployment.yaml
@@ -1,0 +1,96 @@
+# infra/k8s/applications/orleans/deployment.yaml
+#
+# Orleans Silo StatefulSet. Once ArgoCD takes over this supersedes
+# the bootstrap StatefulSet at infra/k8s/bootstrap/initial-orleans.yaml
+# (same name + namespace, so it reconciles in place).
+#
+# Replicas start at 0 until a real Orleans Silo image is published.
+# Bump to >= 1 and update `image:` once `ghcr.io/lucent-financial-group/...`
+# exists.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: orleans-silo
+  namespace: orleans
+  labels:
+    app.kubernetes.io/name: orleans-silo
+    app.kubernetes.io/part-of: zeta
+    zeta.io/distributed-chron: "true"
+spec:
+  serviceName: orleans-silo
+  replicas: 0  # bump after publishing a real silo image
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: orleans-silo
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: orleans-silo
+        orleans.io/serviceId: zeta
+        orleans.io/clusterId: zeta-prod
+    spec:
+      serviceAccountName: orleans-silo
+      # Spread silos across nodes; ArgoCD applications can override
+      # via patch if specific affinity rules are needed.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: orleans-silo
+      containers:
+        - name: silo
+          image: ghcr.io/lucent-financial-group/zeta-orleans-silo:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: silo
+              containerPort: 11111
+            - name: gateway
+              containerPort: 30000
+            - name: dashboard
+              containerPort: 8080
+          env:
+            - name: ORLEANS_SERVICE_ID
+              value: zeta
+            - name: ORLEANS_CLUSTER_ID
+              value: zeta-prod
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/orleans
+              readOnly: true
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
+          livenessProbe:
+            tcpSocket:
+              port: silo
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          readinessProbe:
+            tcpSocket:
+              port: gateway
+            initialDelaySeconds: 10
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap:
+            name: orleans-config

--- a/infra/k8s/applications/orleans/rbac.yaml
+++ b/infra/k8s/applications/orleans/rbac.yaml
@@ -1,0 +1,38 @@
+# infra/k8s/applications/orleans/rbac.yaml
+#
+# RBAC for Orleans silos to discover peers via the Kubernetes API.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: orleans-silo
+  namespace: orleans
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: orleans-silo
+  namespace: orleans
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "endpoints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: orleans-silo
+  namespace: orleans
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: orleans-silo
+subjects:
+  - kind: ServiceAccount
+    name: orleans-silo
+    namespace: orleans

--- a/infra/k8s/applications/orleans/service.yaml
+++ b/infra/k8s/applications/orleans/service.yaml
@@ -1,0 +1,60 @@
+# infra/k8s/applications/orleans/service.yaml
+#
+# Two services: headless silo-to-silo discovery + ClusterIP
+# client gateway.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: orleans-silo
+  namespace: orleans
+  labels:
+    app.kubernetes.io/name: orleans-silo
+    app.kubernetes.io/part-of: zeta
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: orleans-silo
+  ports:
+    - name: silo
+      port: 11111
+      targetPort: silo
+    - name: gateway
+      port: 30000
+      targetPort: gateway
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: orleans-gateway
+  namespace: orleans
+  labels:
+    app.kubernetes.io/name: orleans-gateway
+    app.kubernetes.io/part-of: zeta
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: orleans-silo
+  ports:
+    - name: gateway
+      port: 30000
+      targetPort: gateway
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: orleans-dashboard
+  namespace: orleans
+  labels:
+    app.kubernetes.io/name: orleans-dashboard
+    app.kubernetes.io/part-of: zeta
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: orleans-silo
+  ports:
+    - name: http
+      port: 8080
+      targetPort: dashboard

--- a/infra/k8s/applications/root-application.yaml
+++ b/infra/k8s/applications/root-application.yaml
@@ -1,0 +1,38 @@
+# infra/k8s/applications/root-application.yaml
+#
+# App-of-Apps root. ArgoCD reads this on first boot (auto-applied
+# by K3S via services.k3s.manifests) and starts watching the
+# infra/k8s/applications/ directory for ArgoCD Application CRs.
+#
+# Adding a new workload to the cluster: drop an Application.yaml
+# under infra/k8s/applications/<name>/ and commit. ArgoCD picks
+# it up on the next sync cycle (~3 minutes).
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: zeta-root
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Lucent-Financial-Group/Zeta
+    targetRevision: main
+    path: infra/k8s/applications
+    directory:
+      recurse: true
+      # Only pick up Application CRs at any depth, not the workload
+      # manifests sitting next to them.
+      include: '{*/Application.yaml,Application.yaml}'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infra/k8s/bootstrap/argocd-install.yaml
+++ b/infra/k8s/bootstrap/argocd-install.yaml
@@ -1,0 +1,32 @@
+# infra/k8s/bootstrap/argocd-install.yaml
+#
+# ArgoCD installation. K3S auto-applies this on first boot via
+# services.k3s.manifests so the cluster becomes self-managing
+# immediately — ArgoCD then reconciles everything else from this
+# same Git repo via the root-application.
+#
+# This file uses kustomize-style remote reference rather than
+# inlining the full ~30k-line upstream manifest. K3S supports
+# kustomize natively for manifests it auto-applies.
+#
+# Pin to a specific ArgoCD release for reproducibility. Bump the
+# tag below to upgrade; ArgoCD itself is then managed declaratively
+# through the same flake-and-merge workflow as the rest of the
+# cluster.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: argocd
+
+resources:
+  # ArgoCD v2.13.2 stable manifest. Bump in lockstep with the
+  # `targetRevision` in infra/k8s/applications/root-application.yaml
+  # so ArgoCD's understanding of itself stays consistent.
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.13.2/manifests/install.yaml
+
+# Site-specific patches go here once we know more about the cluster:
+#   - cmd-params for service-type LoadBalancer
+#   - resource limits for the argocd-server pod on small control-plane
+#   - SSO config (Dex, GitHub OAuth, Okta, etc)
+patches: []

--- a/infra/k8s/bootstrap/argocd-namespace.yaml
+++ b/infra/k8s/bootstrap/argocd-namespace.yaml
@@ -1,0 +1,13 @@
+# infra/k8s/bootstrap/argocd-namespace.yaml
+#
+# Namespace for ArgoCD. Applied by K3S on first boot via
+# services.k3s.manifests in infra/nixos/modules/k3s-server.nix.
+# Must apply before argocd-install.yaml.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+  labels:
+    app.kubernetes.io/name: argocd
+    app.kubernetes.io/part-of: argocd

--- a/infra/k8s/bootstrap/initial-orleans.yaml
+++ b/infra/k8s/bootstrap/initial-orleans.yaml
@@ -1,0 +1,166 @@
+# infra/k8s/bootstrap/initial-orleans.yaml
+#
+# Minimal Orleans Silo deployment applied at K3S first-boot so the
+# distributed-chron substrate (per Addison's spec — "Orleans is a
+# distributed chron. I believe Orleans has attention and memory.")
+# is running before ArgoCD takes over.
+#
+# This is the BOOTSTRAP version — sized for a single-control-plane
+# zero-worker initial install. The ArgoCD-managed version lives at
+# infra/k8s/applications/orleans/ and supersedes this once the
+# control-plane finishes reconciling root-application.
+#
+# Once ArgoCD's Orleans Application is healthy, this bootstrap
+# Deployment can be deleted (or left in place — it'll be reconciled
+# to match the ArgoCD-managed spec).
+#
+# Replace IMAGE placeholder with your published Orleans Silo image.
+# Until a real image is published, this stays as a placeholder so
+# K3S has the manifest schema validated but doesn't actually run
+# anything (replicas: 0).
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: orleans
+  labels:
+    app.kubernetes.io/part-of: zeta
+    zeta.io/distributed-chron: "true"
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: orleans-silo
+  namespace: orleans
+
+---
+# RBAC — Orleans needs to discover other silos via the Kubernetes API
+# (Orleans Kubernetes clustering provider).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: orleans-silo
+  namespace: orleans
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "endpoints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: orleans-silo
+  namespace: orleans
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: orleans-silo
+subjects:
+  - kind: ServiceAccount
+    name: orleans-silo
+    namespace: orleans
+
+---
+# Bootstrap StatefulSet, scaled to 0 until a real image is published.
+# The ArgoCD-managed Application at infra/k8s/applications/orleans/
+# will scale this up once it takes over.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: orleans-silo
+  namespace: orleans
+  labels:
+    app.kubernetes.io/name: orleans-silo
+    app.kubernetes.io/part-of: zeta
+spec:
+  serviceName: orleans-silo
+  replicas: 0  # scaled up by ArgoCD-managed app once an image is published
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: orleans-silo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: orleans-silo
+        # Orleans clustering ID labels — silos with the same
+        # serviceId + clusterId form a cluster.
+        orleans.io/serviceId: zeta
+        orleans.io/clusterId: zeta-prod
+    spec:
+      serviceAccountName: orleans-silo
+      containers:
+        - name: silo
+          image: ghcr.io/lucent-financial-group/zeta-orleans-silo:bootstrap
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: silo
+              containerPort: 11111   # Orleans silo-to-silo
+            - name: gateway
+              containerPort: 30000   # Orleans client gateway
+            - name: dashboard
+              containerPort: 8080    # Optional Orleans dashboard
+          env:
+            - name: ORLEANS_SERVICE_ID
+              value: zeta
+            - name: ORLEANS_CLUSTER_ID
+              value: zeta-prod
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
+
+---
+# Headless service for silo-to-silo discovery.
+apiVersion: v1
+kind: Service
+metadata:
+  name: orleans-silo
+  namespace: orleans
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: orleans-silo
+  ports:
+    - name: silo
+      port: 11111
+      targetPort: silo
+    - name: gateway
+      port: 30000
+      targetPort: gateway
+
+---
+# Client-facing service for Orleans gateway access.
+apiVersion: v1
+kind: Service
+metadata:
+  name: orleans-gateway
+  namespace: orleans
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: orleans-silo
+  ports:
+    - name: gateway
+      port: 30000
+      targetPort: gateway


### PR DESCRIPTION
## Summary

PR 4 of Addison's NixOS-AI-cluster bootstrap plan. Lands the Kubernetes substrate that K3S auto-applies on first boot, then hands off to ArgoCD which reconciles everything else from this same Git repo.

**Base: #4898** (stacked on flake.nix + modules + per-host configs).

## File map

### `infra/k8s/bootstrap/` — K3S auto-applies (via `services.k3s.manifests`)
| File | Purpose |
|---|---|
| `argocd-namespace.yaml` | Namespace `argocd` |
| `argocd-install.yaml` | Kustomize ref → ArgoCD v2.13.2 upstream manifest (pinned) |
| `initial-orleans.yaml` | Minimal Orleans StatefulSet (`replicas: 0` until silo image published); namespace + RBAC + headless silo svc + client gateway svc |

### `infra/k8s/applications/` — ArgoCD watches recursively
| File | Purpose |
|---|---|
| `root-application.yaml` | App-of-Apps root; selects `Application.yaml` at any depth |
| `orleans/Application.yaml` | ArgoCD-managed Orleans (supersedes bootstrap) |
| `orleans/deployment.yaml` | Full Orleans StatefulSet with topology-spread + probes |
| `orleans/service.yaml` | Headless silo + client gateway + dashboard services |
| `orleans/rbac.yaml` | ServiceAccount + Role + RoleBinding for K8s clustering |
| `orleans/configmap.yaml` | Orleans cluster config (serviceId=zeta, clusterId=zeta-prod) |
| `gitlab/Application.yaml` | GitLab CE Helm chart (8.7.0); bundled cert-manager/nginx/prometheus DISABLED; runners ENABLED |
| `argoworkflows/Application.yaml` | Argo Workflows 3.6 family; 7-day retention; parallelism 50 |
| `argorollouts/Application.yaml` | Argo Rollouts 1.8 family with dashboard |

## Bootstrap sequence (when control-plane boots)

1. K3S starts
2. K3S applies `bootstrap/argocd-namespace.yaml` → `bootstrap/argocd-install.yaml` (ArgoCD pods come up)
3. K3S applies `bootstrap/initial-orleans.yaml` (Orleans namespace + scaled-to-0 StatefulSet)
4. K3S applies `applications/root-application.yaml` (App-of-Apps root)
5. ArgoCD finishes installing → reads root Application → discovers child Applications via include glob
6. ArgoCD reconciles orleans/, gitlab/, argoworkflows/, argorollouts/ in parallel
7. Orleans bootstrap StatefulSet is reconciled in-place by the ArgoCD-managed spec

## Add-a-workload flow

```bash
mkdir infra/k8s/applications/<name>/
$EDITOR infra/k8s/applications/<name>/Application.yaml
git commit + push to main
# ArgoCD picks it up on next sync (~3 min)
```

## Image placeholders

- `ghcr.io/lucent-financial-group/zeta-orleans-silo:{bootstrap,latest}` doesn't exist yet — bootstrap + ArgoCD-managed StatefulSets both have `replicas: 0` so nothing tries to pull. Bump replicas once an image is published.
- GitLab `initialRootPassword` references a Secret named `gitlab-initial-root-password` that must be created out-of-band (sops-nix / agenix decrypt) before GitLab installs cleanly.

## Test plan

- [ ] All YAML parses (markdownlint won't catch this; YAML lint if configured will)
- [ ] On a real cluster: `kubectl apply --dry-run=server -f infra/k8s/bootstrap/` succeeds
- [ ] ArgoCD picks up `root-application.yaml` and discovers all 4 child apps

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>