### PR TITLE
ci(infra): build installer ISO on PRs + main + release publish

### DIFF
--- a/.github/workflows/build-installer-iso.yml
+++ b/.github/workflows/build-installer-iso.yml
@@ -2,7 +2,8 @@
 #
 # Builds the Zeta cluster installer ISO from infra/nixos/hosts/installer/
 # via the repo-root flake. Runs on every PR that touches the flake/infra,
-# every push to main, and on tag push (to attach the ISO to a Release).
+# every push to main, and on release publish (to attach the ISO to the
+# Release as a downloadable asset).
 #
 # Why on a Linux runner and not the existing macOS gate matrix:
 #   The ISO target is `x86_64-linux`. Building it on macOS requires the
@@ -52,6 +53,10 @@ concurrency:
 jobs:
   build:
     name: build-iso
+    # Skip on release events — attach-to-release rebuilds at the tag so the
+    # asset matches the release exactly. Running both would build the ISO
+    # twice per release publish for no added verification.
+    if: github.event_name != 'release'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
@@ -91,7 +96,14 @@ jobs:
         id: iso
         run: |
           set -euo pipefail
-          iso_path=$(find result/iso -name 'zeta-installer-*.iso' | head -1)
+          # Deterministic single-match: -print -quit returns at most one path
+          # and exits immediately. find ... | head -1 races on multi-match
+          # and silently picks whichever line printed first.
+          iso_path=$(find result/iso -name 'zeta-installer-*.iso' -print -quit)
+          if [[ -z "${iso_path}" || ! -e "${iso_path}" ]]; then
+            echo "::error::No installer ISO found under result/iso/ (looked for zeta-installer-*.iso)" >&2
+            exit 1
+          fi
           iso_name=$(basename "$iso_path")
           iso_size=$(stat -c%s "$iso_path" | numfmt --to=iec --suffix=B)
           iso_sha256=$(sha256sum "$iso_path" | awk '{print $1}')
@@ -134,6 +146,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Match the build job: full history + tags so `git describe`
+          # style versioning and flake.lock pinning are reproducible at
+          # the tag. Default fetch-depth: 1 omits tags/history and risks
+          # silent drift on release builds.
+          fetch-depth: 0
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
@@ -156,9 +174,19 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          iso_path=$(find result/iso -name 'zeta-installer-*.iso' | head -1)
-          sha256sum "$iso_path" | awk '{print $1}' > "${iso_path}.sha256"
+          # Deterministic single-match (same pattern as build job).
+          iso_path=$(find result/iso -name 'zeta-installer-*.iso' -print -quit)
+          if [[ -z "${iso_path}" || ! -e "${iso_path}" ]]; then
+            echo "::error::No installer ISO found under result/iso/ (looked for zeta-installer-*.iso)" >&2
+            exit 1
+          fi
+          # iso_path resolves into /nix/store/... via the result/ symlink,
+          # which is read-only. Write the .sha256 sidecar to the workspace
+          # (RUNNER_TEMP is writable) so the upload step doesn't EROFS.
+          iso_name=$(basename "$iso_path")
+          sha256_path="${RUNNER_TEMP:-/tmp}/${iso_name}.sha256"
+          sha256sum "$iso_path" | awk '{print $1}' > "$sha256_path"
           gh release upload "$RELEASE_TAG" \
             "$iso_path" \
-            "${iso_path}.sha256" \
+            "$sha256_path" \
             --clobber

--- a/.github/workflows/build-installer-iso.yml
+++ b/.github/workflows/build-installer-iso.yml
@@ -67,11 +67,13 @@ jobs:
         # locally. Enables flakes + nix-command by default.
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
-      - name: Set up Nix store cache
-        # Reduces cold-build time from ~15min to ~3min by reusing the
-        # /nix/store across runs. Pull-only on PRs from forks to avoid
-        # cache-poisoning vectors.
-        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+      # NOTE: previously had `DeterminateSystems/magic-nix-cache-action`
+      # here but it now requires FlakeHub auth (FlakeHub.com account /
+      # organization registration), which the project doesn't have set
+      # up. Removed to unblock builds. First-build cost is ~10-15 min
+      # instead of ~3 min cached. Follow-up to add `actions/cache` on
+      # /nix/store or `nix-community/cache-nix-action` (no FlakeHub
+      # auth required) is tracked separately.
 
       - name: Show flake metadata
         run: nix flake metadata --json | jq '{description, lastModified, revision}'
@@ -93,10 +95,12 @@ jobs:
           iso_name=$(basename "$iso_path")
           iso_size=$(stat -c%s "$iso_path" | numfmt --to=iec --suffix=B)
           iso_sha256=$(sha256sum "$iso_path" | awk '{print $1}')
-          echo "path=$iso_path"     >> "$GITHUB_OUTPUT"
-          echo "name=$iso_name"     >> "$GITHUB_OUTPUT"
-          echo "size=$iso_size"     >> "$GITHUB_OUTPUT"
-          echo "sha256=$iso_sha256" >> "$GITHUB_OUTPUT"
+          {
+            echo "path=$iso_path"
+            echo "name=$iso_name"
+            echo "size=$iso_size"
+            echo "sha256=$iso_sha256"
+          } >> "$GITHUB_OUTPUT"
           {
             echo "## Installer ISO built"
             echo ""
@@ -134,8 +138,8 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
-      - name: Set up Nix store cache
-        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+      # magic-nix-cache-action removed — requires FlakeHub auth not yet
+      # set up. See note in the build job above.
 
       - name: Rebuild ISO for the tagged release
         # Re-builds at the tag so the ISO ships exactly the source the

--- a/.github/workflows/build-installer-iso.yml
+++ b/.github/workflows/build-installer-iso.yml
@@ -15,8 +15,9 @@
 # Discipline (per .github/workflows/gate.yml):
 #   - Runner pinned to ubuntu-24.04 (not -latest)
 #   - Third-party actions SHA-pinned with trailing # vX.Y.Z comments
-#   - permissions: contents: read at workflow level (tag-push job
-#     elevates to contents: write only for the release-attach step)
+#   - permissions: contents: read at workflow level. The
+#     `attach-to-release` job elevates to `contents: write` only
+#     for itself (release-asset upload).
 #   - Concurrency: workflow-scoped, cancel-in-progress only for PRs
 #   - github.event.* values that may be attacker-controlled (release
 #     tag names, etc.) are passed via env: not interpolated into
@@ -191,12 +192,23 @@ jobs:
             exit 1
           fi
           # iso_path resolves into /nix/store/... via the result/ symlink,
-          # which is read-only. Write the .sha256 sidecar to the workspace
-          # (RUNNER_TEMP is writable) so the upload step doesn't EROFS.
+          # which is read-only. Write the .sha256 sidecar to RUNNER_TEMP
+          # (writable) so the upload step doesn't EROFS.
           iso_name=$(basename "$iso_path")
           sha256_path="${RUNNER_TEMP:-/tmp}/${iso_name}.sha256"
-          sha256sum "$iso_path" | awk '{print $1}' > "$sha256_path"
-          gh release upload "$RELEASE_TAG" \
+          # Use the standard `sha256sum` format (`<hash>  <filename>`)
+          # so consumers can verify with `sha256sum --check`.
+          ( cd "$(dirname "$iso_path")" && sha256sum "$iso_name" ) > "$sha256_path"
+          # Refuse to upload if RELEASE_TAG looks like a flag-injection
+          # vector. Tag names can legally start with `-`, which would
+          # make `gh release upload "$RELEASE_TAG" ...` parse the tag as
+          # a flag. Hard-fail if so — release operators should rename.
+          case "$RELEASE_TAG" in
+            -*) echo "::error::RELEASE_TAG starts with '-' which is a flag-injection risk: $RELEASE_TAG" >&2; exit 1 ;;
+          esac
+          # `--` separator: belt + suspenders defense against any future
+          # argv-injection vector even if the tag-name check above is
+          # bypassed somehow.
+          gh release upload --clobber -- "$RELEASE_TAG" \
             "$iso_path" \
-            "$sha256_path" \
-            --clobber
+            "$sha256_path"

--- a/.github/workflows/build-installer-iso.yml
+++ b/.github/workflows/build-installer-iso.yml
@@ -1,0 +1,160 @@
+# .github/workflows/build-installer-iso.yml
+#
+# Builds the Zeta cluster installer ISO from infra/nixos/hosts/installer/
+# via the repo-root flake. Runs on every PR that touches the flake/infra,
+# every push to main, and on tag push (to attach the ISO to a Release).
+#
+# Why on a Linux runner and not the existing macOS gate matrix:
+#   The ISO target is `x86_64-linux`. Building it on macOS requires the
+#   nix-darwin `linux-builder` VM (Apple Virtualization.framework +
+#   Rosetta 2). That works locally for maintainers, but the gate CI
+#   already runs on ubuntu-24.04 — building directly there is faster,
+#   cheaper, and uses no cross-compile.
+#
+# Discipline (per .github/workflows/gate.yml):
+#   - Runner pinned to ubuntu-24.04 (not -latest)
+#   - Third-party actions SHA-pinned with trailing # vX.Y.Z comments
+#   - permissions: contents: read at workflow level (tag-push job
+#     elevates to contents: write only for the release-attach step)
+#   - Concurrency: workflow-scoped, cancel-in-progress only for PRs
+#   - github.event.* values that may be attacker-controlled (release
+#     tag names, etc.) are passed via env: not interpolated into
+#     run: lines, per the GitHub Actions injection guide.
+
+name: build-installer-iso
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'infra/nixos/**'
+      - '.github/workflows/build-installer-iso.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'infra/nixos/**'
+      - '.github/workflows/build-installer-iso.yml'
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-installer-iso-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: build-iso
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Need full history so the flake.lock pinning is reproducible
+          # and any `git describe` style versioning works.
+          fetch-depth: 0
+
+      - name: Install Nix
+        # Determinate Systems Nix installer — same one maintainers use
+        # locally. Enables flakes + nix-command by default.
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Set up Nix store cache
+        # Reduces cold-build time from ~15min to ~3min by reusing the
+        # /nix/store across runs. Pull-only on PRs from forks to avoid
+        # cache-poisoning vectors.
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+
+      - name: Show flake metadata
+        run: nix flake metadata --json | jq '{description, lastModified, revision}'
+
+      - name: Check flake evaluates
+        # Cheap eval-only check — catches typos, missing imports,
+        # undefined attributes before paying for a full build.
+        run: nix flake check --no-build --show-trace
+
+      - name: Build installer ISO
+        # The actual build. Produces result/iso/zeta-installer-*.iso.
+        run: nix build .#installer-iso --print-build-logs
+
+      - name: Locate ISO + capture metadata
+        id: iso
+        run: |
+          set -euo pipefail
+          iso_path=$(find result/iso -name 'zeta-installer-*.iso' | head -1)
+          iso_name=$(basename "$iso_path")
+          iso_size=$(stat -c%s "$iso_path" | numfmt --to=iec --suffix=B)
+          iso_sha256=$(sha256sum "$iso_path" | awk '{print $1}')
+          echo "path=$iso_path"     >> "$GITHUB_OUTPUT"
+          echo "name=$iso_name"     >> "$GITHUB_OUTPUT"
+          echo "size=$iso_size"     >> "$GITHUB_OUTPUT"
+          echo "sha256=$iso_sha256" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Installer ISO built"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| File   | \`$iso_name\` |"
+            echo "| Size   | $iso_size |"
+            echo "| SHA256 | \`$iso_sha256\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload ISO as workflow artifact
+        # Available for download from the workflow run page for ~90 days.
+        # Anyone reviewing the PR can grab it and dd it to a USB stick
+        # without needing Nix installed locally.
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: ${{ steps.iso.outputs.name }}
+          path: ${{ steps.iso.outputs.path }}
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 0   # ISO is already compressed; re-zipping wastes time
+
+  attach-to-release:
+    name: attach-iso-to-release
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: write   # needed to upload the ISO as a release asset
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Set up Nix store cache
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+
+      - name: Rebuild ISO for the tagged release
+        # Re-builds at the tag so the ISO ships exactly the source the
+        # release advertises. The build job above already produced one,
+        # but artifacts and release assets are different stores.
+        run: nix build .#installer-iso --print-build-logs
+
+      - name: Upload ISO + SHA256 to the release
+        # Release tag_name is set by whoever created the release —
+        # treated as attacker-controlled per the GH Actions injection
+        # guide. Passed via env, never interpolated into the shell.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          iso_path=$(find result/iso -name 'zeta-installer-*.iso' | head -1)
+          sha256sum "$iso_path" | awk '{print $1}' > "${iso_path}.sha256"
+          gh release upload "$RELEASE_TAG" \
+            "$iso_path" \
+            "${iso_path}.sha256" \
+            --clobber

--- a/.github/workflows/build-installer-iso.yml
+++ b/.github/workflows/build-installer-iso.yml
@@ -97,14 +97,21 @@ jobs:
         id: iso
         run: |
           set -euo pipefail
-          # Deterministic single-match: -print -quit returns at most one path
-          # and exits immediately. find ... | head -1 races on multi-match
-          # and silently picks whichever line printed first.
-          iso_path=$(find result/iso -name 'zeta-installer-*.iso' -print -quit)
-          if [[ -z "${iso_path}" || ! -e "${iso_path}" ]]; then
+          # Enforce single match. Multiple matches would be a substrate
+          # surprise (build layout changed?) and silently picking one
+          # is worse than failing loudly.
+          mapfile -t iso_candidates < <(find result/iso -maxdepth 1 -type f -name 'zeta-installer-*.iso' | sort)
+          if [ "${#iso_candidates[@]}" -eq 0 ]; then
             echo "::error::No installer ISO found under result/iso/ (looked for zeta-installer-*.iso)" >&2
+            ls -la result/iso/ >&2 || true
             exit 1
           fi
+          if [ "${#iso_candidates[@]}" -gt 1 ]; then
+            echo "::error::Multiple installer ISOs under result/iso/; expected exactly one:" >&2
+            printf '  %s\n' "${iso_candidates[@]}" >&2
+            exit 1
+          fi
+          iso_path="${iso_candidates[0]}"
           iso_name=$(basename "$iso_path")
           iso_size=$(stat -c%s "$iso_path" | numfmt --to=iec --suffix=B)
           iso_sha256=$(sha256sum "$iso_path" | awk '{print $1}')
@@ -185,12 +192,21 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          # Deterministic single-match (same pattern as build job).
-          iso_path=$(find result/iso -name 'zeta-installer-*.iso' -print -quit)
-          if [[ -z "${iso_path}" || ! -e "${iso_path}" ]]; then
+          # Enforce single match — release assets are publicly downloaded
+          # and silently picking one when multiple exist would be worse
+          # than failing loudly.
+          mapfile -t iso_candidates < <(find result/iso -maxdepth 1 -type f -name 'zeta-installer-*.iso' | sort)
+          if [ "${#iso_candidates[@]}" -eq 0 ]; then
             echo "::error::No installer ISO found under result/iso/ (looked for zeta-installer-*.iso)" >&2
+            ls -la result/iso/ >&2 || true
             exit 1
           fi
+          if [ "${#iso_candidates[@]}" -gt 1 ]; then
+            echo "::error::Multiple installer ISOs under result/iso/; refusing to upload an arbitrary one to release ${RELEASE_TAG}:" >&2
+            printf '  %s\n' "${iso_candidates[@]}" >&2
+            exit 1
+          fi
+          iso_path="${iso_candidates[0]}"
           # iso_path resolves into /nix/store/... via the result/ symlink,
           # which is read-only. Write the .sha256 sidecar to RUNNER_TEMP
           # (writable) so the upload step doesn't EROFS.

--- a/.github/workflows/build-installer-iso.yml
+++ b/.github/workflows/build-installer-iso.yml
@@ -137,16 +137,26 @@ jobs:
 
   attach-to-release:
     name: attach-iso-to-release
-    needs: build
+    # No `needs: build`. The build job is skipped on release events
+    # (see its own `if: github.event_name != 'release'`); declaring
+    # `needs: build` here would short-circuit attach-to-release to
+    # "skipped" too because skipped-by-`if` propagates through
+    # `needs:` by default. The two jobs are independent: attach-to-
+    # release builds the ISO itself at the release tag, with its
+    # own ref pinning.
     if: github.event_name == 'release'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: write   # needed to upload the ISO as a release asset
     steps:
-      - name: Checkout
+      - name: Checkout at the release tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # Explicit ref pin: on release events GITHUB_REF defaults
+          # to the tag, but pinning explicitly is defense in depth
+          # against payload variation (and reads more clearly).
+          ref: ${{ github.event.release.tag_name }}
           # Match the build job: full history + tags so `git describe`
           # style versioning and flake.lock pinning are reproducible at
           # the tag. Default fetch-depth: 1 omits tags/history and risks

--- a/infra/nixos/hosts/installer/configuration.nix
+++ b/infra/nixos/hosts/installer/configuration.nix
@@ -73,7 +73,13 @@
   # SSH key into `users.users.nixos.openssh.authorizedKeys.keys` here
   # before building the ISO.
   services.openssh = {
-    enable = false;
+    # mkForce: upstream installation-cd-minimal.nix enables SSH by
+    # default. We force it OFF to keep the installer console-only
+    # by default (per the no-credentials-in-Git security posture
+    # documented above). Without mkForce, the module-merge fails
+    # eval with `option 'services.openssh.enable' has conflicting
+    # definition values: true (upstream) vs false (ours)`.
+    enable = lib.mkForce false;
     settings = {
       PermitRootLogin = lib.mkForce "prohibit-password";
       PasswordAuthentication = lib.mkForce false;

--- a/infra/nixos/modules/gpu.nix
+++ b/infra/nixos/modules/gpu.nix
@@ -14,16 +14,27 @@
   # Permit unfree packages (NVIDIA driver, cuda)
   # ---------------------------------------------------------------------------
   nixpkgs.config.allowUnfreePredicate = pkg:
-    builtins.elem (lib.getName pkg) [
+    let
+      name = lib.getName pkg;
+    in
+    # Explicit nvidia driver components
+    builtins.elem name [
       "nvidia-x11"
       "nvidia-settings"
       "nvidia-persistenced"
-      "cuda_cudart"
-      "cuda_nvcc"
-      "cuda-merged"
-      "libcublas"
-      "libcudnn"
-    ];
+      "nvidia-docker"
+      "nvidia-container-toolkit"
+    ]
+    # CUDA toolchain — `cuda_*` covers cuda_cudart, cuda_nvcc, cuda_cuobjdump,
+    # cuda_nvprune, cuda_cccl, cuda_nvtx, cuda_profiler_api, etc.
+    || lib.hasPrefix "cuda" name
+    # CUDA support libraries — libcublas, libcurand, libcusolver, libcusparse,
+    # libcufft, libcudnn, libnpp, libnvjpeg, libnvjitlink, ...
+    || lib.hasPrefix "libcu" name
+    || lib.hasPrefix "libnv" name
+    || lib.hasPrefix "libnp" name
+    # The umbrella package that pulls everything together
+    || name == "cuda-merged";
 
   # ---------------------------------------------------------------------------
   # Kernel modules + driver

--- a/infra/nixos/modules/gpu.nix
+++ b/infra/nixos/modules/gpu.nix
@@ -25,8 +25,12 @@
       "nvidia-docker"
       "nvidia-container-toolkit"
     ]
-    # CUDA toolchain — `cuda_*` covers cuda_cudart, cuda_nvcc, cuda_cuobjdump,
-    # cuda_nvprune, cuda_cccl, cuda_nvtx, cuda_profiler_api, etc.
+    # CUDA toolchain — `cuda`-prefixed packages: covers cuda_cudart,
+    # cuda_nvcc, cuda_cuobjdump, cuda_nvprune, cuda_cccl, cuda_nvtx,
+    # cuda_profiler_api, AND the underscore-less variants like
+    # cudatoolkit + cudaPackages.* aliases. The predicate is
+    # intentionally broader than the underscore-only set because
+    # nixpkgs uses both spellings depending on the package generation.
     || lib.hasPrefix "cuda" name
     # CUDA support libraries — libcublas, libcurand, libcusolver, libcusparse,
     # libcufft, libcudnn, libnpp, libnvjpeg, libnvjitlink, ...


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/build-installer-iso.yml\` — Linux runner builds the \`.#installer-iso\` flake output on every PR touching the flake/infra, every push to main, manual dispatch, and release publish. Removes the local-Nix-required dependency for testing changes to the ISO.

## Why a CI build path

The installer ISO target is \`x86_64-linux\`. On Apple Silicon Macs (most maintainers' workstations), building it requires the nix-darwin \`linux-builder\` VM setup. CI on ubuntu-24.04 builds it directly — no cross-compile, no local Nix install, no APFS-volume gymnastics.

Anyone reviewing a flake-touching PR can now grab the rebuilt ISO from the workflow artifact and \`dd\` it to a USB stick without any local toolchain.

## Pipeline

| Step | What |
|---|---|
| Checkout | Full history (reproducible flake.lock pinning) |
| Install Nix | \`DeterminateSystems/nix-installer-action@v22\` |
| Cache | \`magic-nix-cache-action@v13\` for /nix/store reuse |
| Eval check | \`nix flake check --no-build\` fail-fast |
| Build | \`nix build .#installer-iso --print-build-logs\` |
| Metadata | path/name/size/sha256 → step summary |
| Upload | Workflow artifact, 90d retention, no re-compression |

A second job (\`attach-to-release\`) fires only on release-publish events: rebuilds the ISO at the tag and uploads it + its SHA256 to the release assets.

## Security

- Runner pinned to \`ubuntu-24.04\` (not \`-latest\`); matches \`gate.yml\` convention
- Third-party actions SHA-pinned with trailing \`# vX.Y.Z\` comments
- Workflow-level \`permissions: contents: read\`; only \`attach-to-release\` elevates to \`contents: write\` and only for the upload step
- \`github.event.release.tag_name\` (attacker-controllable) passed via \`env: RELEASE_TAG\` not interpolated into shell — per the GH Actions injection guide flagged by the security-reminder PreToolUse hook

## Test plan

- [ ] Workflow triggers on this PR (flake.nix isn't touched, but the workflow file path is)
- [ ] First green run produces a downloadable \`zeta-installer-24.11.iso\` artifact
- [ ] SHA256 in the step summary matches the artifact

## Composes with

- #4897 (installer config)
- #4898 (flake.nix + modules + per-host configs + k8s applications)
- #4903 (runbook fix)
- #4904 (brew/nix permissions)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>