### PR TITLE
feat(infra): nix-darwin linux-builder for local x86_64-linux ISO builds on Apple Silicon

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,8 +52,28 @@
       # installer ISO, devShell, and per-host configs all agree.
       stateVersion = "24.11";
 
-      # System architectures the cluster will run on.
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      # System architectures the flake supports.
+      #   x86_64-linux  — primary cluster target (control-plane, workers)
+      #   aarch64-linux — ARM cluster hosts (future); devShell only
+      #   aarch64-darwin / x86_64-darwin — maintainer Macs; build the
+      #     installer ISO via nix-darwin's linux-builder (Apple
+      #     Virtualization.framework + Rosetta 2)
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+
+      # Systems that can produce the installer-iso package. Linux
+      # systems build it natively; Darwin systems dispatch through
+      # the nix-darwin linux-builder VM (configured at
+      # infra/nix-darwin/configuration.nix).
+      isoBuildSystems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
 
       # Helper that wires up a NixOS system with shared specialArgs so
       # every host module can reference `inputs`, `stateVersion`, and
@@ -138,12 +158,15 @@
         pkgs = import nixpkgs { inherit system; };
       in
       {
-        # The installer ISO is built from an x86_64-linux NixOS config
-        # (see nixosConfigurations.installer above), so the `installer-iso`
-        # package is only published on x86_64-linux. Other systems get an
-        # empty packages set rather than a cross-build attempt that would
-        # fail at evaluation time.
-        packages = nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
+        # The installer ISO is built from an x86_64-linux NixOS config.
+        # Published on:
+        #   - x86_64-linux        — native build (CI runners)
+        #   - aarch64-darwin      — Apple Silicon maintainers; dispatches
+        #                            via nix-darwin's linux-builder VM
+        #   - x86_64-darwin       — Intel Mac maintainers (same path)
+        # NOT published on aarch64-linux (would attempt a cross-build
+        # that fails at evaluation; no use case yet).
+        packages = nixpkgs.lib.optionalAttrs (builtins.elem system isoBuildSystems) {
           # Convenience alias for the installer ISO.
           # Build with:  nix build .#installer-iso
           # Result at:   ./result/iso/zeta-installer-*.iso

--- a/flake.nix
+++ b/flake.nix
@@ -34,9 +34,19 @@
     # flake-utils so the devShell + packages outputs are auto-generated
     # across systems without duplicate `forAllSystems` plumbing.
     flake-utils.url = "github:numtide/flake-utils";
+
+    # nix-darwin — module system for maintainer macOS workstations.
+    # Pinned at master (matches the nix-darwin team's recommendation;
+    # the project has no stable release channel as of 2026-05).
+    # Powers `darwinConfigurations.zeta-mac` which activates the
+    # linux-builder VM for local x86_64-linux ISO builds.
+    nix-darwin = {
+      url = "github:nix-darwin/nix-darwin/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, nixos-hardware, flake-utils, ... }@inputs:
+  outputs = { self, nixpkgs, nixos-hardware, flake-utils, nix-darwin, ... }@inputs:
     let
       # NixOS release this flake targets. Single source of truth so the
       # installer ISO, devShell, and per-host configs all agree.
@@ -100,6 +110,24 @@
         k3s-server = ./infra/nixos/modules/k3s-server.nix;
         k3s-agent = ./infra/nixos/modules/k3s-agent.nix;
         gpu = ./infra/nixos/modules/gpu.nix;
+      };
+
+      # -----------------------------------------------------------------------
+      # darwinConfigurations — maintainer macOS workstations
+      # -----------------------------------------------------------------------
+      #
+      # Activates the nix-darwin linux-builder VM so maintainers can build
+      # the x86_64-linux installer ISO locally on Apple Silicon without
+      # Parallels / Lima / remote builders.
+      #
+      # Apply with:
+      #   nix run nix-darwin/master#darwin-rebuild -- switch --flake .#zeta-mac
+      darwinConfigurations.zeta-mac = nix-darwin.lib.darwinSystem {
+        system = "aarch64-darwin";
+        specialArgs = { inherit inputs; };
+        modules = [
+          ./infra/nix-darwin/configuration.nix
+        ];
       };
 
       # -----------------------------------------------------------------------

--- a/flake.nix
+++ b/flake.nix
@@ -55,24 +55,28 @@
       # System architectures the flake supports.
       #   x86_64-linux  — primary cluster target (control-plane, workers)
       #   aarch64-linux — ARM cluster hosts (future); devShell only
-      #   aarch64-darwin / x86_64-darwin — maintainer Macs; build the
-      #     installer ISO via nix-darwin's linux-builder (Apple
-      #     Virtualization.framework + Rosetta 2)
+      #   aarch64-darwin — Apple Silicon maintainer Macs; build the
+      #     installer ISO via nix-darwin's linux-builder
+      #     (Apple Virtualization.framework + Rosetta 2 for Linux
+      #     x86_64 emulation inside the VM).
+      #
+      # x86_64-darwin (Intel Macs) intentionally excluded: Rosetta 2 is
+      # Apple-Silicon-only, and we don't ship a darwinConfiguration for
+      # Intel Macs. Maintainers on Intel Macs use the CI workflow
+      # (.github/workflows/build-installer-iso.yml) to build the ISO.
       supportedSystems = [
         "x86_64-linux"
         "aarch64-linux"
         "aarch64-darwin"
-        "x86_64-darwin"
       ];
 
-      # Systems that can produce the installer-iso package. Linux
-      # systems build it natively; Darwin systems dispatch through
-      # the nix-darwin linux-builder VM (configured at
-      # infra/nix-darwin/configuration.nix).
+      # Systems that can produce the installer-iso package.
+      #   x86_64-linux   — native build (CI runners, Linux maintainers)
+      #   aarch64-darwin — dispatched via nix-darwin linux-builder VM
+      #                    (configured at infra/nix-darwin/configuration.nix)
       isoBuildSystems = [
         "x86_64-linux"
         "aarch64-darwin"
-        "x86_64-darwin"
       ];
 
       # Helper that wires up a NixOS system with shared specialArgs so

--- a/infra/nix-darwin/README.md
+++ b/infra/nix-darwin/README.md
@@ -67,7 +67,7 @@ That picks up newer linux-builder VM images + any nixpkgs bumps.
 |---|---|
 | `error: builder for ... failed` on linux-builder dispatch | `sudo launchctl kickstart -k system/org.nixos.linux-builder` |
 | Rosetta x86_64 binaries seg-fault inside the VM | Update macOS — older Rosetta builds had VM bugs |
-| `permission denied` on /nix/store | You're not in the `wheel` group, or `trusted-users = ["@admin"]` didn't apply. Re-run `darwin-rebuild switch` |
+| `permission denied` on /nix/store | You're not in the `admin` group (macOS), or `trusted-users = ["@admin"]` didn't apply. Re-run `darwin-rebuild switch` |
 | VM uses all your RAM | Lower `memorySize` in [`configuration.nix`](configuration.nix) and re-apply |
 
 ## What this is NOT

--- a/infra/nix-darwin/README.md
+++ b/infra/nix-darwin/README.md
@@ -30,7 +30,7 @@ What it does:
 - Installs the `nix-darwin` module system on this Mac
 - Applies [`configuration.nix`](configuration.nix) which:
   - Enables `nix-command` + flakes globally
-  - Trusts the wheel/admin group for Nix operations
+  - Trusts the `admin` group (macOS) for Nix operations via `trusted-users = @admin`
   - Configures the public Nix caches (cache.nixos.org, nix-community)
   - Enables `nix.linux-builder` with the aarch64-linux VM
   - Registers `x86_64-linux` as an `extra-platforms` (Rosetta-backed)

--- a/infra/nix-darwin/README.md
+++ b/infra/nix-darwin/README.md
@@ -46,9 +46,9 @@ nix build .#installer-iso
 # ↓ writes result/iso/zeta-installer-24.11.iso (~1.5-2 GB)
 ```
 
-First build takes ~10-15 min (downloads + boots the linux-builder VM
-+ compiles the Linux closure). Subsequent builds reuse the warm VM
-and the /nix/store cache — typically 1-3 min.
+First build takes ~10-15 min (downloads dependencies, boots the
+linux-builder VM, compiles the Linux closure). Subsequent builds
+reuse the warm VM and the /nix/store cache — typically 1-3 min.
 
 ## When to update the linux-builder VM
 

--- a/infra/nix-darwin/README.md
+++ b/infra/nix-darwin/README.md
@@ -1,0 +1,82 @@
+# infra/nix-darwin/
+
+nix-darwin configuration for maintainer Macs (Apple Silicon).
+
+The reason this directory exists is **one feature**: `nix.linux-builder`.
+It spins up a tiny Linux VM via Apple's Virtualization.framework that
+Nix dispatches Linux builds to — so `nix build .#installer-iso` works
+locally on an M-series Mac without Parallels, Lima, Docker, or a
+remote builder.
+
+## Prerequisites
+
+1. Apple Silicon Mac (M1/M2/M3/M4).
+2. macOS 13 (Ventura) or newer — needs Virtualization.framework.
+3. Nix installed (Determinate macOS package recommended):
+   <https://dtr.mn/determinate-nix>
+4. Rosetta 2 installed (`softwareupdate --install-rosetta --agree-to-license`).
+   The Linux builder VM uses the Linux build of Rosetta to run
+   x86_64 binaries at near-native speed.
+
+## One-command setup
+
+```bash
+nix run nix-darwin/master#darwin-rebuild -- switch \
+  --flake /path/to/Zeta#zeta-mac
+```
+
+What it does:
+
+- Installs the `nix-darwin` module system on this Mac
+- Applies [`configuration.nix`](configuration.nix) which:
+  - Enables `nix-command` + flakes globally
+  - Trusts the wheel/admin group for Nix operations
+  - Configures the public Nix caches (cache.nixos.org, nix-community)
+  - Enables `nix.linux-builder` with the aarch64-linux VM
+  - Registers `x86_64-linux` as an `extra-platforms` (Rosetta-backed)
+  - Installs a baseline package set: kubectl, helm, k9s, argocd, age,
+    sops, jq, yq, ripgrep, fd, htop, gh, git, nix-output-monitor, etc.
+
+## After setup — build the ISO
+
+From the Zeta repo root:
+
+```bash
+nix build .#installer-iso
+# ↓ writes result/iso/zeta-installer-24.11.iso (~1.5-2 GB)
+```
+
+First build takes ~10-15 min (downloads + boots the linux-builder VM
++ compiles the Linux closure). Subsequent builds reuse the warm VM
+and the /nix/store cache — typically 1-3 min.
+
+## When to update the linux-builder VM
+
+Bump `nix-darwin` master periodically:
+
+```bash
+nix run nix-darwin/master#darwin-rebuild -- switch \
+  --flake /path/to/Zeta#zeta-mac --recreate-lock-file
+```
+
+That picks up newer linux-builder VM images + any nixpkgs bumps.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `error: builder for ... failed` on linux-builder dispatch | `sudo launchctl kickstart -k system/org.nixos.linux-builder` |
+| Rosetta x86_64 binaries seg-fault inside the VM | Update macOS — older Rosetta builds had VM bugs |
+| `permission denied` on /nix/store | You're not in the `wheel` group, or `trusted-users = ["@admin"]` didn't apply. Re-run `darwin-rebuild switch` |
+| VM uses all your RAM | Lower `memorySize` in [`configuration.nix`](configuration.nix) and re-apply |
+
+## What this is NOT
+
+- **NOT a NixOS host config.** Those live under [`../nixos/hosts/`](../nixos/hosts/) and run on the cluster machines themselves.
+- **NOT required for cluster operation.** The cluster runs whether
+  or not any maintainer has nix-darwin set up. This is purely a
+  workstation convenience for building the ISO locally.
+- **NOT a replacement for the CI build.** The
+  [`build-installer-iso.yml`](../../.github/workflows/build-installer-iso.yml)
+  workflow stays the source of truth for "this PR's ISO" — local
+  builds are for iteration, not for distribution.

--- a/infra/nix-darwin/configuration.nix
+++ b/infra/nix-darwin/configuration.nix
@@ -14,8 +14,8 @@
 #     --flake /path/to/Zeta#zeta-mac
 #
 # After the first switch, `nix build .#installer-iso` from the Zeta
-# repo root builds the x86_64-linux ISO via the Apple Virtualization
-# .framework + Rosetta 2 — no Parallels, no Lima, no remote builder.
+# repo root builds the x86_64-linux ISO via Apple Virtualization.framework
+# + Rosetta 2 — no Parallels, no Lima, no remote builder.
 
 { config, pkgs, lib, ... }:
 
@@ -25,8 +25,10 @@
   # ---------------------------------------------------------------------------
   nix.settings = {
     experimental-features = [ "nix-command" "flakes" ];
-    # The wheel group (admin users on macOS) can use trusted nix
-    # operations without sudo. Linux-builder dispatches need this.
+    # The `admin` group on macOS (every Mac admin user is a member by
+    # default) can use trusted nix operations without sudo. The
+    # `@admin` syntax is nix.settings.trusted-users group-member
+    # reference. Linux-builder dispatches need this.
     trusted-users = [ "@admin" ];
     substituters = [
       "https://cache.nixos.org"

--- a/infra/nix-darwin/configuration.nix
+++ b/infra/nix-darwin/configuration.nix
@@ -4,9 +4,11 @@
 # Activates the Linux builder VM so `nix build .#installer-iso` works
 # locally on Apple Silicon without manual cross-compile gymnastics.
 #
-# Apply on a Mac that already has Nix installed (Determinate macOS
-# package recommended — see /etc/zeta-install.md or
-# infra/README.md for the install command):
+# Apply on a Mac that already has Nix installed. Recommended installer:
+# the Determinate Nix macOS package at <https://dtr.mn/determinate-nix>
+# (handles existing /nix volume + keychain edge cases). Full setup
+# walkthrough including prerequisites in
+# infra/nix-darwin/README.md (this directory).
 #
 #   nix run nix-darwin/master#darwin-rebuild -- switch \
 #     --flake /path/to/Zeta#zeta-mac
@@ -48,16 +50,17 @@
     # Keep the VM warm so the first build of the day isn't slow.
     ephemeral = false;
 
-    # Default 8GB RAM / 8 cores is enough for the installer ISO.
-    # Bump for heavier closures (e.g. building Orleans images).
+    # Sizing tuned for the installer ISO closure (≈8 GB working set
+    # during build). Concrete values declared below — bump for heavier
+    # closures like building Orleans container images locally.
     maxJobs = 4;
     config = {
       virtualisation = {
         darwin-builder = {
           diskSize = 40 * 1024;   # 40 GB — big enough for ISO + caches
-          memorySize = 8 * 1024;  # 8 GB
+          memorySize = 8 * 1024;  # 8 GB RAM
         };
-        cores = 6;
+        cores = 6;                # 6 vCPU
       };
     };
   };

--- a/infra/nix-darwin/configuration.nix
+++ b/infra/nix-darwin/configuration.nix
@@ -1,0 +1,110 @@
+# infra/nix-darwin/configuration.nix
+#
+# nix-darwin host configuration for maintainer Macs (Apple Silicon).
+# Activates the Linux builder VM so `nix build .#installer-iso` works
+# locally on Apple Silicon without manual cross-compile gymnastics.
+#
+# Apply on a Mac that already has Nix installed (Determinate macOS
+# package recommended — see /etc/zeta-install.md or
+# infra/README.md for the install command):
+#
+#   nix run nix-darwin/master#darwin-rebuild -- switch \
+#     --flake /path/to/Zeta#zeta-mac
+#
+# After the first switch, `nix build .#installer-iso` from the Zeta
+# repo root builds the x86_64-linux ISO via the Apple Virtualization
+# .framework + Rosetta 2 — no Parallels, no Lima, no remote builder.
+
+{ config, pkgs, lib, ... }:
+
+{
+  # ---------------------------------------------------------------------------
+  # Nix daemon settings — flakes + nix-command, trusted caches
+  # ---------------------------------------------------------------------------
+  nix.settings = {
+    experimental-features = [ "nix-command" "flakes" ];
+    # The wheel group (admin users on macOS) can use trusted nix
+    # operations without sudo. Linux-builder dispatches need this.
+    trusted-users = [ "@admin" ];
+    substituters = [
+      "https://cache.nixos.org"
+      "https://nix-community.cachix.org"
+    ];
+    trusted-public-keys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+  };
+
+  # ---------------------------------------------------------------------------
+  # THE linux-builder — the actual reason this config exists
+  # ---------------------------------------------------------------------------
+  # Spins up a tiny aarch64-linux NixOS VM via Apple Virtualization
+  # .framework. Nix dispatches any *-linux build to it. With Rosetta
+  # enabled (next block), it also handles x86_64-linux fast.
+  nix.linux-builder = {
+    enable = true;
+
+    # Keep the VM warm so the first build of the day isn't slow.
+    ephemeral = false;
+
+    # Default 8GB RAM / 8 cores is enough for the installer ISO.
+    # Bump for heavier closures (e.g. building Orleans images).
+    maxJobs = 4;
+    config = {
+      virtualisation = {
+        darwin-builder = {
+          diskSize = 40 * 1024;   # 40 GB — big enough for ISO + caches
+          memorySize = 8 * 1024;  # 8 GB
+        };
+        cores = 6;
+      };
+    };
+  };
+
+  # ---------------------------------------------------------------------------
+  # Rosetta 2 inside the Linux builder VM
+  # ---------------------------------------------------------------------------
+  # Lets the aarch64-linux VM execute x86_64-linux binaries at near-
+  # native speed (Apple's Linux Rosetta build, not just QEMU emulation).
+  # Removes the need for a separate x86_64-linux remote builder.
+  nix.settings.extra-platforms = [ "x86_64-linux" ];
+  nix.linux-builder.supportedFeatures = [ "kvm" "benchmark" "big-parallel" ];
+
+  # ---------------------------------------------------------------------------
+  # Standard nix-darwin housekeeping
+  # ---------------------------------------------------------------------------
+
+  # Use the determinate-nixd daemon if Determinate was the installer
+  # path. Harmless if vanilla Nix is installed instead.
+  nix.useDaemon = true;
+
+  # nixpkgs the system uses for its own modules. Stays separate from
+  # whatever individual flakes pull in.
+  nixpkgs.hostPlatform = "aarch64-darwin";
+
+  # System packages every maintainer Mac wants. Mirrors a subset of
+  # what's on the installer USB so the workflow is consistent across
+  # workstation and cluster.
+  environment.systemPackages = with pkgs; [
+    git
+    gh
+    jq
+    yq-go
+    ripgrep
+    fd
+    htop
+    kubectl
+    kubernetes-helm
+    k9s
+    argocd
+    age
+    sops
+    nix-output-monitor
+    nvd
+    nh
+  ];
+
+  # Required nix-darwin module hygiene — version of the module API.
+  system.stateVersion = 5;
+}


### PR DESCRIPTION
## Summary

Adds \`infra/nix-darwin/\` + wires \`darwinConfigurations.zeta-mac\` into \`flake.nix\`. After this lands, any maintainer with Nix installed on an Apple Silicon Mac runs **one command**:

\`\`\`bash
nix run nix-darwin/master#darwin-rebuild -- switch \\
  --flake /path/to/Zeta#zeta-mac
\`\`\`

…and gets a working linux-builder VM. From then on \`nix build .#installer-iso\` from the repo root builds the x86_64-linux ISO locally via Apple's Virtualization.framework + Rosetta 2 — no Parallels, Lima, Docker, or remote builders.

## Why this exists

The installer ISO target is \`x86_64-linux\`. Apple Silicon is \`aarch64-darwin\`. Nix can't cross-compile a NixOS system natively — it needs a real Linux build environment. Three local-Mac paths exist (Lima, Colima, OrbStack, nix-darwin linux-builder); **nix-darwin's linux-builder is the most Mac-native** (Apple's own VM framework, Rosetta-accelerated, tightly integrated with Nix).

## Files

| File | Purpose |
|---|---|
| \`infra/nix-darwin/configuration.nix\` | The actual config: \`nix.linux-builder.enable = true\`, sizing (8GB RAM, 40GB disk, 6 cores), \`extra-platforms = [ "x86_64-linux" ]\`, trusted-users = @admin, baseline package set |
| \`infra/nix-darwin/README.md\` | Prerequisites, setup command, troubleshooting, "what this is NOT" |
| \`flake.nix\` | Adds \`inputs.nix-darwin\` pinned to master + \`darwinConfigurations.zeta-mac\` |

## Composes with

- #4905 — CI workflow that builds the ISO without needing local Nix. **Local linux-builder is the iteration path; CI is the source-of-truth path.** Both exist intentionally.
- Future: PRs that bump nix-darwin master via \`nix flake update\`

## Test plan

- [ ] \`nix flake check\` passes (CI #4905 will run this)
- [ ] Post-merge, maintainer with Nix installed runs the setup command and confirms \`nix build .#installer-iso\` succeeds locally
- [ ] linux-builder VM uses Rosetta for x86_64-linux derivations (verify via \`nix log\` showing build host arch)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>