### PR TITLE
fix(infra): pin nix-darwin to nix-darwin-24.11 release branch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -149,7 +149,7 @@
       # Parallels / Lima / remote builders.
       #
       # Apply with:
-      #   nix run nix-darwin/master#darwin-rebuild -- switch --flake .#zeta-mac
+      #   nix run nix-darwin/nix-darwin-24.11#darwin-rebuild -- switch --flake .#zeta-mac
       darwinConfigurations.zeta-mac = nix-darwin.lib.darwinSystem {
         system = "aarch64-darwin";
         specialArgs = { inherit inputs; };

--- a/flake.nix
+++ b/flake.nix
@@ -36,12 +36,16 @@
     flake-utils.url = "github:numtide/flake-utils";
 
     # nix-darwin — module system for maintainer macOS workstations.
-    # Pinned at master (matches the nix-darwin team's recommendation;
-    # the project has no stable release channel as of 2026-05).
+    # MUST be pinned to a release branch matching the nixpkgs release
+    # we use (nixos-24.11 above → nix-darwin-24.11). nix-darwin
+    # asserts the branches match at eval time:
+    #   "nix-darwin and Nixpkgs branches in use must match"
+    # Bump this branch in lockstep with the nixpkgs.url release above.
+    #
     # Powers `darwinConfigurations.zeta-mac` which activates the
     # linux-builder VM for local x86_64-linux ISO builds.
     nix-darwin = {
-      url = "github:nix-darwin/nix-darwin/master";
+      url = "github:nix-darwin/nix-darwin/nix-darwin-24.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/infra/nix-darwin/README.md
+++ b/infra/nix-darwin/README.md
@@ -21,7 +21,7 @@ remote builder.
 ## One-command setup
 
 ```bash
-nix run nix-darwin/master#darwin-rebuild -- switch \
+nix run nix-darwin/nix-darwin-24.11#darwin-rebuild -- switch \
   --flake /path/to/Zeta#zeta-mac
 ```
 
@@ -55,7 +55,7 @@ reuse the warm VM and the /nix/store cache — typically 1-3 min.
 Bump `nix-darwin` master periodically:
 
 ```bash
-nix run nix-darwin/master#darwin-rebuild -- switch \
+nix run nix-darwin/nix-darwin-24.11#darwin-rebuild -- switch \
   --flake /path/to/Zeta#zeta-mac --recreate-lock-file
 ```
 

--- a/infra/nix-darwin/configuration.nix
+++ b/infra/nix-darwin/configuration.nix
@@ -10,7 +10,7 @@
 # walkthrough including prerequisites in
 # infra/nix-darwin/README.md (this directory).
 #
-#   nix run nix-darwin/master#darwin-rebuild -- switch \
+#   nix run nix-darwin/nix-darwin-24.11#darwin-rebuild -- switch \
 #     --flake /path/to/Zeta#zeta-mac
 #
 # After the first switch, `nix build .#installer-iso` from the Zeta


### PR DESCRIPTION
## Summary

Hot-fix: pin \`nix-darwin\` input to the release branch matching our nixpkgs pin (\`nix-darwin-24.11\` ↔ \`nixos-24.11\`).

## Why now

CI (\`build-installer-iso\` workflow from PR #4905) caught this on \`nix flake check\`:

\`\`\`
error:
  nix-darwin and Nixpkgs branches in use must match, but you are
  currently using nix-darwin master with Nixpkgs nixos-24.11
\`\`\`

PR #4906 (which added the nix-darwin input) pinned it to \`master\` based on stale guidance. nix-darwin > 25.x added a hard assertion enforcing branch-match.

## Composes with

- #4906 (added the nix-darwin input — this fix corrects the pin)
- #4905 (the CI workflow that surfaced the bug — should pass on next re-trigger after this lands)

## Test plan

- [ ] \`nix flake check\` evaluates cleanly on \`origin/main\` after merge
- [ ] PR #4905's \`build-iso\` job passes on next CI run

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>