### PR TITLE
feat(hat-system): scaffold society safety-layer operator for AI cluster

### DIFF
--- a/full-ai-cluster/k8s/applications/hat-system/Application.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/Application.yaml
@@ -1,0 +1,42 @@
+# full-ai-cluster/k8s/applications/hat-system/Application.yaml
+#
+# ArgoCD reconciles every YAML under this directory into the cluster.
+# The operator image itself is NOT built / pushed yet — see operator/
+# README for the local build path. The image reference here is a
+# placeholder until a maintainer pushes a first build; until then
+# the Deployment ships with replicas: 0 so ArgoCD reports OK while
+# the rest of the substrate (CRDs, policies, seed hats) is live.
+#
+# Sync gating: this Application is on `automated:` (default-on). The
+# CRDs land first; OPA policies next; seed hats last. The operator
+# Deployment with replicas:0 reconciles last and is a no-op until a
+# maintainer scales up + sets the real image.
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hat-system
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Lucent-Financial-Group/Zeta
+    targetRevision: main
+    path: full-ai-cluster/k8s/applications/hat-system
+    directory:
+      recurse: true
+      # Skip the operator's Go source — it's not a manifest. Same for
+      # the graph/render helper and the queries docs.
+      exclude: '{operator/**,graph/**,queries/**}'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hat-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/full-ai-cluster/k8s/applications/hat-system/README.md
+++ b/full-ai-cluster/k8s/applications/hat-system/README.md
@@ -1,0 +1,201 @@
+# Hat system — society safety layer for the AI cluster
+
+A Kubernetes operator implementing the hat / role distinction for
+the multi-agent society running on this cluster. Hats are
+**time-bounded roles with succession**. Wearers swap hats; the hat
+persists; reputation accumulates on the role.
+
+## Why this is not a cage (or bubble wrap)
+
+Aaron's framing: Max's first instinct was a cage; the second was
+bubble wrap. The hat system is neither. The reason it isn't a cage
+is the time-bound — hats are **chosen-and-returnable**, not
+permanent identity capture:
+
+| Property | Cage / role-as-identity | Hat (this system) |
+|----------|-------------------------|-------------------|
+| Authority lives on | the wearer | the role |
+| Removable | only by destroying the wearer | by swap-off (one command) |
+| Reputation | belongs to the wearer | accumulates on the hat |
+| Succession | breaks identity | preserves identity |
+| Concurrency | one identity, one mask | one wearer, many hats over time |
+| Bound to time | indefinite | every binding has cooldown, warmup, sticky-attribution windows |
+
+Max's compression — **`hat = skills + opa/rbac`** — captures the
+essential parts. Skills describe what the wearer CAN do; OPA + RBAC
+describe what the wearer is PERMITTED to do. The CRD has both as
+first-class fields (`Hat.spec.skills` + `Hat.spec.authority`).
+
+Max's other framing — **"hierarchy / ontology of hats where the
+hats are not weight-free but supervisor graphs"** — is captured
+via `Hat.spec.supervises` (a DAG enforced by the
+no-supervisor-cycles OPA constraint). Supervisory weight rides on
+the role, not on any individual wearer. A supervisor who oversteps
+gets swapped off; the hat persists.
+
+## What's in this directory
+
+| Path | What it is |
+|------|------------|
+| `Application.yaml` | ArgoCD Application; default-on; reconciles everything below into the `hat-system` namespace |
+| `namespace.yaml` | Namespace with restricted PodSecurity labels |
+| `deployment.yaml` | Operator Deployment (replicas:0 until image is built) + ServiceAccount + ClusterRole + binding |
+| `crds/` | Four CRDs: Hat, HatBinding, HatSwap, HatPolicy |
+| `hats/` | Seed Hat resources: hat-designer, observer, executor, policy-admin + default HatPolicy |
+| `policies/` | Seven OPA Gatekeeper ConstraintTemplates + Constraints for the throttles |
+| `operator/` | Go source for the operator (kubebuilder layout) |
+| `graph/` | Hat-graph render helper + docs (Max thinks in hat graphs) |
+| `queries/` | Loki + Hubble query library for hat ↔ network-flow attribution |
+
+## The four CRDs
+
+- **Hat** — cluster-scoped role definition. Carries skills,
+  supervises edges, authority (RBAC rules + namespace scope),
+  and throttle overrides.
+- **HatBinding** — namespaced wearer assignment. `spec.wearer.spiffeID`
+  is the workload identity (cryptographically attested via SPIRE).
+  Lifecycle: `Pending → Warmup → Active → (Probation) → Revoked`.
+- **HatSwap** — append-only event record. Each state transition
+  produces exactly one HatSwap. The reconcile loop IS the tick
+  source; HatSwap is the durable tick record.
+- **HatPolicy** — cluster-wide singleton (`metadata.name: default`)
+  carrying throttle defaults and tick-emit configuration.
+
+## The structured tick source
+
+CRD + operator = structured tick source. Every state transition
+emits one tick via the fan-out in `operator/internal/tick/emitter.go`:
+
+```
+state transition
+  │
+  ├─► HatSwap CR write       (durable; canonical; replayable years later)
+  ├─► k8s Event              (operator-readable for kubectl describe)
+  ├─► slog JSON line         (Loki picks up via Alloy; query via LogQL)
+  └─► NATS publish           (subject: zeta.society.hats.<hat>.<event>)
+```
+
+CR write is the canonical record. Other sinks are best-effort —
+NATS outage doesn't block the CR; Loki gap doesn't block the Event.
+Downstream reactors choose which surface to subscribe to based on
+their durability needs.
+
+## The seven throttles (each is a graph constraint)
+
+Max's "talks in hat graphs" reading — each throttle reads as a
+constraint over the live cluster's hat graph:
+
+| Throttle | Graph statement | Policy file |
+|----------|-----------------|-------------|
+| cooldown | no `wears` edge if `succeeded` exists with `t < cooldown` | `01-cooldown.yaml` |
+| max-bindings | wearer out-degree on `wears` ≤ N | `02-max-bindings.yaml` |
+| conflict-of-interest | no `wears` pair connected by `conflicts-with` | `03-conflict-of-interest.yaml` |
+| quorum | `cosigned-by` in-degree ≥ quorumSize | `04-quorum.yaml` |
+| warmup | Active phase reachable only after WarmupEndsAt | `05-warmup.yaml` |
+| max-new-hats | Hat node creation rate ≤ K per day | `06-max-new-hats.yaml` |
+| no-supervisor-cycles | `supervises` is a DAG | `07-no-supervisor-cycles.yaml` |
+
+The first six are admission-time enforcement (Gatekeeper). The
+seventh ALSO at admission time, but it's the one that gives the
+hierarchy its DAG property — supervisor graphs without cycles is
+what keeps the hierarchy from collapsing into self-dealing pairs.
+
+## Bootstrap path — the hat-designer hat
+
+Bootstrap question: who designs the hats? Max's worry: he becomes
+the bottleneck. Answer: designing-the-catalog is itself a hat
+(`hats/hat-designer.yaml`). Multiple wearers can hold it. The
+hat-designer hat is:
+
+- `quorumGated: true` with `quorumSize: 3` (every new Hat creation
+  needs three co-signatures from other hat-designer wearers — or
+  from any wearer of a hat that includes hat-designer co-signing
+  in its authority)
+- `cooldownSeconds: 1800` (30 min between design sessions per
+  wearer) + `warmupSeconds: 600` (10 min probation before first edit)
+- `conflictsWith: [executor]` (a wearer cannot both design AND
+  execute under the catalog they designed)
+
+Cluster-wide ceiling: HatPolicy default `maxNewHatsPerDay: 5`. A
+captured hat-designer wearer can't spam novel hats — they hit the
+ceiling and the throttle fires.
+
+## Quickstart (after operator image exists)
+
+```bash
+# 1. CRDs + policies + seed hats land via ArgoCD automatically.
+kubectl get crd hats.society.zeta.io
+kubectl get hats
+kubectl get hatpolicy default
+
+# 2. Render the live graph.
+go run full-ai-cluster/k8s/applications/hat-system/graph/render.go \
+  --out hatgraph.dot
+dot -Tsvg hatgraph.dot -o hatgraph.svg
+
+# 3. Watch ticks in real time.
+kubectl logs -n hat-system deploy/hat-system-operator -f \
+  | jq 'select(.msg == "hat.tick")'
+
+# 4. Or subscribe via NATS.
+nats sub 'zeta.society.hats.>'
+```
+
+## Operator build path
+
+The Go operator under `operator/` is a starter scaffold —
+kubebuilder PROJECT file is authored, but `kubebuilder init` has
+not been run yet (no `Makefile`, no `Dockerfile`, no
+`zz_generated.deepcopy.go`). A maintainer with Go + kubebuilder
+installed can complete the bootstrap:
+
+```bash
+cd full-ai-cluster/k8s/applications/hat-system/operator
+go mod download
+kubebuilder init --domain society.zeta.io \
+  --repo github.com/Lucent-Financial-Group/Zeta/full-ai-cluster/k8s/applications/hat-system/operator \
+  --skip-go-version-check
+# `kubebuilder create api` for each kind (Hat, HatBinding,
+#  HatSwap, HatPolicy) — choose y/y on first three, n/y on
+#  HatSwap (no controller; emitted only).
+make generate manifests
+make docker-build docker-push IMG=ghcr.io/lucent-financial-group/hat-system-operator:v0.1.0
+# Update deployment.yaml's image: + bump replicas to 1 (or 2 for HA).
+```
+
+The hand-authored files under `operator/api/v1alpha1/types.go`
+match the YAML CRDs already on disk — keep them in sync if you
+regenerate.
+
+## How this composes with the rest of the cluster
+
+- **SPIRE** issues SVIDs to workloads — those SVIDs are the
+  `wearer.spiffeID` in HatBindings. The operator does not issue
+  identity; it consumes attested identity.
+- **Cilium / Hubble** flow logs carry SPIFFE IDs as identity
+  labels. Joining HatSwap + Hubble by SPIFFE ID gives network-flow
+  attribution per hat (see `queries/loki.md`).
+- **OPA Gatekeeper** enforces the seven throttle constraints at
+  admission time. The operator does NOT enforce throttles itself —
+  it OBSERVES state and emits ticks; Gatekeeper is the gate.
+- **NATS** carries the tick stream for reactors that want push
+  semantics (anomaly detectors, Hindsight ingest, dashboards).
+- **Hindsight** can subscribe to ticks and persist the society's
+  long-term memory of who-wore-what-when.
+- **ArgoCD** reconciles this whole directory recursively under the
+  root App-of-Apps. New seed hats land via PR + push.
+
+## TODO (intentional gaps in the scaffold)
+
+- Validating webhook for HatBinding admission (the operator-internal
+  alternative / supplement to Gatekeeper for throttles that need
+  cross-CR lookup faster than Gatekeeper sync).
+- HatReconciler: reputation accumulation on swap-off based on
+  authority-use telemetry from Hubble + audit-log.
+- HatPolicyReconciler: status rollup (active counts, swaps-last-24h).
+- Finalizer flow on HatBinding for guaranteed SwapOff emission.
+- Mutating webhook for defaulting RequestedAt.
+- Tests (envtest harness — kubebuilder scaffolds this).
+- Image build + push automation in CI.
+
+Each gap is small enough to land as one follow-up PR per scope.

--- a/full-ai-cluster/k8s/applications/hat-system/crds/hat.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/crds/hat.yaml
@@ -1,0 +1,186 @@
+# full-ai-cluster/k8s/applications/hat-system/crds/hat.yaml
+#
+# Hat CRD — a named role with a fixed authority scope.
+#
+# A Hat is identity-of-the-role, not identity-of-the-wearer. The same
+# Hat persists across many wearers (workload identities). The Hat
+# carries the role's reputation; wearers earn / lose it during their
+# tenure.
+#
+# Design call: hats bind to workload identities (SPIFFE/SVID), not to
+# human or agent identities. Workloads come and go more often than the
+# roles they fill — keeping role-identity separate from wearer-identity
+# is what makes succession work without losing accumulated reputation.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hats.society.zeta.io
+spec:
+  group: society.zeta.io
+  scope: Cluster
+  names:
+    kind: Hat
+    listKind: HatList
+    plural: hats
+    singular: hat
+    shortNames: [ht]
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [authority]
+              properties:
+                description:
+                  type: string
+                  description: Human-readable description of the role.
+                skills:
+                  type: array
+                  description: |
+                    Capabilities the wearer is expected to have. The
+                    operator does NOT enforce skills — they're matchable
+                    metadata used by hat-designer agents and assignment
+                    reactors ("which workloads have the required
+                    skills?"). The compression: hat = skills + opa/rbac.
+                    Skills are what you CAN do; authority is what you're
+                    PERMITTED to do.
+                  items:
+                    type: object
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                        description: Skill identifier (e.g. read-fsharp,
+                          spec-formal-verification, route-incident).
+                      level:
+                        type: string
+                        enum: [novice, intermediate, expert]
+                      providedBy:
+                        type: string
+                        description: Reference to the skill provider
+                          (e.g. claude-plugins-official/skill-name,
+                          or a SkillProvider CRD if one is added later).
+                authority:
+                  type: object
+                  description: |
+                    What the wearer is authorized to do while wearing this hat.
+                    Expressed as a set of (verb, resource) pairs scoped to
+                    namespaces. The operator translates these into RBAC + OPA
+                    constraints at bind time.
+                  properties:
+                    namespaces:
+                      type: array
+                      items: { type: string }
+                      description: |
+                        Empty = cluster-wide (only valid for hats that pass the
+                        quorum-gated throttle). Otherwise namespace allowlist.
+                    rules:
+                      type: array
+                      items:
+                        type: object
+                        required: [verbs, resources]
+                        properties:
+                          verbs:
+                            type: array
+                            items: { type: string }
+                          resources:
+                            type: array
+                            items: { type: string }
+                          apiGroups:
+                            type: array
+                            items: { type: string }
+                supervises:
+                  type: array
+                  items: { type: string }
+                  description: |
+                    Names of hats this hat has supervisory authority over.
+                    Forms a DAG — supervision cycles are rejected by the
+                    no-supervisor-cycles OPA constraint. Supervisors can
+                    revoke a HatBinding of a supervised hat, trigger
+                    Probation, and read all HatSwap events for it.
+                    Max's framing: "hierarchy / ontology of hats where
+                    the hats are not weight free but supervisor graphs."
+                    Time-bounded by every other throttle on this same
+                    spec, which keeps the supervisory weight on the
+                    ROLE not on the wearer — hat-as-chosen-and-returnable
+                    instead of role-as-cage.
+                throttles:
+                  type: object
+                  description: |
+                    Per-hat throttle overrides. Defaults live in the
+                    cluster-wide HatPolicy singleton; values here override
+                    only the listed fields.
+                  properties:
+                    cooldownSeconds:
+                      type: integer
+                      minimum: 0
+                      description: Seconds before a former wearer can re-bind.
+                    stickyAttributionSeconds:
+                      type: integer
+                      minimum: 0
+                      description: Window after swap-off during which the
+                        previous wearer is still attributed for actions.
+                    warmupSeconds:
+                      type: integer
+                      minimum: 0
+                      description: Probation period with reduced authority.
+                    quorumGated:
+                      type: boolean
+                      description: |
+                        If true, binding this hat requires a quorum of other
+                        hats to co-sign the HatBinding. Use for any hat with
+                        cluster-wide authority or destructive verbs.
+                    quorumSize:
+                      type: integer
+                      minimum: 1
+                      description: Required co-signature count when quorumGated.
+                    conflictsWith:
+                      type: array
+                      items: { type: string }
+                      description: Names of hats that cannot be worn
+                        simultaneously by the same wearer (anti-collusion).
+            status:
+              type: object
+              properties:
+                reputation:
+                  type: integer
+                  description: |
+                    Accumulated reputation score across all wearers.
+                    Increases on successful authority use; decreases on
+                    revocation. Society uses this for trust calculus.
+                currentWearers:
+                  type: array
+                  items: { type: string }
+                  description: SPIFFE IDs of workloads currently bound.
+                lifetimeWearers:
+                  type: integer
+                  description: Count of distinct wearers since hat creation.
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type: { type: string }
+                      status: { type: string }
+                      lastTransitionTime: { type: string, format: date-time }
+                      reason: { type: string }
+                      message: { type: string }
+      additionalPrinterColumns:
+        - name: Wearers
+          type: integer
+          jsonPath: .status.lifetimeWearers
+        - name: Reputation
+          type: integer
+          jsonPath: .status.reputation
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/full-ai-cluster/k8s/applications/hat-system/crds/hatbinding.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/crds/hatbinding.yaml
@@ -1,0 +1,150 @@
+# full-ai-cluster/k8s/applications/hat-system/crds/hatbinding.yaml
+#
+# HatBinding CRD — wearer X is currently wearing hat Y.
+#
+# Binding is the SWAP-ON event. Deletion is SWAP-OFF. The operator
+# enforces throttles by rejecting the binding (validating webhook)
+# or by patching status to a probation state (warmup).
+#
+# Wearer identity is SPIFFE — the SPIRE SVID issued to the workload.
+# That keeps the system honest about "who is acting" — workload
+# identity is cryptographically attested, not self-declared.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hatbindings.society.zeta.io
+spec:
+  group: society.zeta.io
+  scope: Namespaced
+  names:
+    kind: HatBinding
+    listKind: HatBindingList
+    plural: hatbindings
+    singular: hatbinding
+    shortNames: [hb]
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [hat, wearer]
+              properties:
+                hat:
+                  type: string
+                  description: Name of the Hat being worn.
+                wearer:
+                  type: object
+                  required: [spiffeID]
+                  properties:
+                    spiffeID:
+                      type: string
+                      pattern: '^spiffe://[^/]+/.+$'
+                      description: SPIFFE ID of the workload binding the hat.
+                    serviceAccountRef:
+                      type: object
+                      description: |
+                        Optional — for human-readable cross-reference.
+                        SPIFFE ID is the canonical wearer identifier.
+                      properties:
+                        name: { type: string }
+                        namespace: { type: string }
+                cosignedBy:
+                  type: array
+                  description: |
+                    Quorum signatures for quorum-gated hats. Each entry is
+                    the SPIFFE ID of a co-signing workload that already
+                    holds an appropriate hat. The operator validates that
+                    the signatures meet the hat's quorumSize before
+                    allowing the binding to become Active.
+                  items:
+                    type: object
+                    required: [spiffeID, signedAt]
+                    properties:
+                      spiffeID: { type: string }
+                      signedAt: { type: string, format: date-time }
+                      attestation: { type: string }
+                requestedAt:
+                  type: string
+                  format: date-time
+                  description: When the wearer requested the binding.
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Warmup, Active, Probation, Revoked]
+                  description: |
+                    Pending  — waiting for cooldown / quorum / warmup gate
+                    Warmup   — bound with reduced authority during probation
+                    Active   — full authority
+                    Probation — anomaly detected; authority reduced
+                    Revoked  — hat removed; sticky attribution may still apply
+                effectiveAuthority:
+                  type: object
+                  description: Authority actually granted (may be reduced
+                    from the hat spec during Warmup or Probation).
+                  properties:
+                    namespaces:
+                      type: array
+                      items: { type: string }
+                    rules:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          verbs:
+                            type: array
+                            items: { type: string }
+                          resources:
+                            type: array
+                            items: { type: string }
+                          apiGroups:
+                            type: array
+                            items: { type: string }
+                boundAt:
+                  type: string
+                  format: date-time
+                  description: When the binding became Active.
+                warmupEndsAt:
+                  type: string
+                  format: date-time
+                stickyAttributionEndsAt:
+                  type: string
+                  format: date-time
+                  description: |
+                    After swap-off, actions matching the wearer's SPIFFE ID
+                    are still attributed to this hat until this time. Lets
+                    the society pin late-arriving consequences to the right
+                    hat instead of the next wearer.
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type: { type: string }
+                      status: { type: string }
+                      lastTransitionTime: { type: string, format: date-time }
+                      reason: { type: string }
+                      message: { type: string }
+      additionalPrinterColumns:
+        - name: Hat
+          type: string
+          jsonPath: .spec.hat
+        - name: Wearer
+          type: string
+          jsonPath: .spec.wearer.spiffeID
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/full-ai-cluster/k8s/applications/hat-system/crds/hatpolicy.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/crds/hatpolicy.yaml
@@ -1,0 +1,92 @@
+# full-ai-cluster/k8s/applications/hat-system/crds/hatpolicy.yaml
+#
+# HatPolicy CRD — cluster-wide singleton carrying the default values
+# for every throttle. Per-Hat overrides live in `Hat.spec.throttles`;
+# anything not overridden falls through to this policy.
+#
+# Singleton enforced by webhook: only `name: default` allowed.
+# Keeping it as a CRD (vs ConfigMap) means RBAC + audit + ArgoCD diff
+# all work the same way as for any other policy surface.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hatpolicies.society.zeta.io
+spec:
+  group: society.zeta.io
+  scope: Cluster
+  names:
+    kind: HatPolicy
+    listKind: HatPolicyList
+    plural: hatpolicies
+    singular: hatpolicy
+    shortNames: [hp]
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              properties:
+                throttles:
+                  type: object
+                  properties:
+                    cooldownSeconds:
+                      type: integer
+                      default: 300
+                      description: Default cooldown after swap-off.
+                    stickyAttributionSeconds:
+                      type: integer
+                      default: 600
+                      description: Default sticky-attribution window.
+                    warmupSeconds:
+                      type: integer
+                      default: 180
+                      description: Default warmup probation duration.
+                    maxBindingsPerWearer:
+                      type: integer
+                      default: 3
+                      description: Max simultaneous hats per SPIFFE ID.
+                    maxNewHatsPerDay:
+                      type: integer
+                      default: 5
+                      description: Rate limit on novel Hat resource creation.
+                    quorumDefaultSize:
+                      type: integer
+                      default: 3
+                swapRetentionDays:
+                  type: integer
+                  default: 365
+                  description: HatSwap CR GC TTL.
+                tickEmit:
+                  type: object
+                  description: Where the operator publishes its tick stream.
+                  properties:
+                    natsSubject:
+                      type: string
+                      default: zeta.society.hats.ticks
+                    enableLokiStructuredLogs:
+                      type: boolean
+                      default: true
+                    enableEvents:
+                      type: boolean
+                      default: true
+            status:
+              type: object
+              properties:
+                lastReconciledAt:
+                  type: string
+                  format: date-time
+                activeHats:
+                  type: integer
+                activeBindings:
+                  type: integer
+                swapsLast24h:
+                  type: integer

--- a/full-ai-cluster/k8s/applications/hat-system/crds/hatswap.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/crds/hatswap.yaml
@@ -1,0 +1,107 @@
+# full-ai-cluster/k8s/applications/hat-system/crds/hatswap.yaml
+#
+# HatSwap CRD — append-only event record of a single swap-on or
+# swap-off event.
+#
+# WHY a CRD and not just an Event:
+#
+#   The operator's reconcile loop already produces a structured tick
+#   stream — each HatBinding create/update/delete fires reconcile;
+#   each reconcile emits exactly one HatSwap. Storing swaps as
+#   first-class CRDs (vs k8s Events with 1h TTL) gives:
+#
+#     • Durable replay surface (etcd persists; backups carry it)
+#     • Queryable across years via kubectl + jq
+#     • Joinable to Hubble flow logs and Loki by spiffeID
+#     • Audit-trail substrate for the society's reputation system
+#     • Structured tick source for downstream reactors
+#       (NATS subscribers, Hindsight memory, anomaly detectors)
+#
+# Swap events are immutable — controllers WRITE them on transition
+# and never UPDATE them. Garbage collection is by TTL controller
+# (configurable via HatPolicy.swapRetentionDays; default 365).
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hatswaps.society.zeta.io
+spec:
+  group: society.zeta.io
+  scope: Namespaced
+  names:
+    kind: HatSwap
+    listKind: HatSwapList
+    plural: hatswaps
+    singular: hatswap
+    shortNames: [hs]
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [hat, wearer, event, occurredAt]
+              properties:
+                hat:
+                  type: string
+                  description: Name of the Hat involved.
+                wearer:
+                  type: object
+                  required: [spiffeID]
+                  properties:
+                    spiffeID: { type: string }
+                event:
+                  type: string
+                  enum:
+                    - SwapOn       # Binding created and Active
+                    - SwapOff      # Binding deleted or Revoked
+                    - WarmupBegin  # Probation entry
+                    - WarmupEnd    # Probation exit (Active)
+                    - Probation    # Anomaly-triggered authority drop
+                    - QuorumGrant  # Quorum signature collected
+                    - Throttled    # Throttle denied a binding/swap
+                occurredAt:
+                  type: string
+                  format: date-time
+                reason:
+                  type: string
+                  description: Short machine-readable code (e.g. CooldownActive).
+                message:
+                  type: string
+                  description: Human-readable detail.
+                bindingRef:
+                  type: object
+                  properties:
+                    name: { type: string }
+                    namespace: { type: string }
+                    uid: { type: string }
+                throttleName:
+                  type: string
+                  description: Which throttle fired, if event == Throttled.
+                previousWearer:
+                  type: object
+                  description: For SwapOn — the prior holder, if any.
+                  properties:
+                    spiffeID: { type: string }
+                    revokedAt: { type: string, format: date-time }
+      additionalPrinterColumns:
+        - name: Hat
+          type: string
+          jsonPath: .spec.hat
+        - name: Event
+          type: string
+          jsonPath: .spec.event
+        - name: Wearer
+          type: string
+          jsonPath: .spec.wearer.spiffeID
+        - name: When
+          type: string
+          jsonPath: .spec.occurredAt
+        - name: Reason
+          type: string
+          jsonPath: .spec.reason

--- a/full-ai-cluster/k8s/applications/hat-system/deployment.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/deployment.yaml
@@ -1,0 +1,100 @@
+# Operator Deployment. replicas: 0 until a maintainer:
+#   1. Initializes the Go module under operator/ via
+#      `kubebuilder init --domain society.zeta.io --repo <module-path>`
+#   2. Runs `go build` + pushes an image to ghcr.io/lucent-financial-group/hat-system-operator
+#   3. Updates `image:` below + bumps replicas to 1 (HA: 2 with
+#      leader election already wired in cmd/main.go)
+#
+# Until then ArgoCD reports the Deployment as healthy at 0/0 ready
+# and the CRDs + OPA policies + seed hats are all installed and
+# inspectable via kubectl. This lets the surface land + be reviewed
+# before the binary exists.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hat-system-operator
+  namespace: hat-system
+  labels:
+    app: hat-system-operator
+spec:
+  replicas: 0  # see header note
+  selector:
+    matchLabels:
+      app: hat-system-operator
+  template:
+    metadata:
+      labels:
+        app: hat-system-operator
+    spec:
+      serviceAccountName: hat-system-operator
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: operator
+          image: ghcr.io/lucent-financial-group/hat-system-operator:placeholder
+          args:
+            - --leader-elect
+            - --metrics-bind-address=:8080
+            - --health-probe-bind-address=:8081
+            - --nats-url=nats://nats.nats.svc.cluster.local:4222
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: probe
+              containerPort: 8081
+          livenessProbe:
+            httpGet: { path: /healthz, port: probe }
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet: { path: /readyz, port: probe }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits:   { cpu: 500m, memory: 512Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ ALL ]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hat-system-operator
+  namespace: hat-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hat-system-operator
+rules:
+  - apiGroups: ["society.zeta.io"]
+    resources: ["hats", "hatbindings", "hatswaps", "hatpolicies"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["society.zeta.io"]
+    resources: ["hats/status", "hatbindings/status", "hatpolicies/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hat-system-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hat-system-operator
+subjects:
+  - kind: ServiceAccount
+    name: hat-system-operator
+    namespace: hat-system

--- a/full-ai-cluster/k8s/applications/hat-system/graph/README.md
+++ b/full-ai-cluster/k8s/applications/hat-system/graph/README.md
@@ -1,0 +1,61 @@
+# Hat graph view
+
+Policies and design conversations get clearer when you draw the
+hats as nodes and relationships as edges. Max's framing —
+"talks constantly in hat graphs for writing policies" — is the
+right one: the throttles ARE graph constraints, and the operator's
+cluster state IS the graph.
+
+## Node + edge types in the live cluster
+
+| Node | Source |
+|------|--------|
+| Hat | `kubectl get hats.society.zeta.io` |
+| Wearer (SPIFFE ID) | `kubectl get hatbindings -A -o jsonpath` |
+
+| Edge | Source | Meaning |
+|------|--------|---------|
+| wears | HatBinding.spec.wearer → HatBinding.spec.hat | current binding |
+| conflicts-with | Hat.spec.throttles.conflictsWith | mutual exclusion |
+| cosigned-by | HatBinding.spec.cosignedBy | quorum dependency |
+| succeeded | HatSwap previousWearer → wearer | succession chain |
+| sticky-attribution | HatBinding.status.stickyAttributionEndsAt | late-tick attribution window |
+
+## Render the current graph
+
+```bash
+go run ./render.go --out hatgraph.dot
+dot -Tsvg hatgraph.dot -o hatgraph.svg
+```
+
+The output is plain Graphviz DOT, so any of the standard viewers
+work (`dot`, `xdot`, `Gephi`, `Cytoscape`, browser-based d3
+renderers). The renderer reads only from kubeconfig — no operator
+dependency.
+
+## Policy patterns that read as graph queries
+
+| Throttle | Graph statement |
+|----------|-----------------|
+| cooldown | no edge `wears(W, H, t)` if edge `succeeded(W, _, H)` exists with `t < cooldown` |
+| max-bindings-per-wearer | out-degree of W on `wears` edges ≤ N |
+| conflict-of-interest | no two `wears(W, *)` edges to hats with `conflicts-with` between them |
+| quorum-gated | `cosigned-by` in-degree ≥ Hat.quorumSize |
+| warmup | edge `wears(W, H)` carries a phase property; Active reachable only after WarmupEndsAt |
+| max-new-hats | Hat node creation rate ≤ K per day |
+
+Reading them as graph statements makes it obvious which constraints
+compose (max-bindings + conflict-of-interest both bound out-degree;
+quorum + warmup both gate edge admission) and which conflict
+(a hat that's both quorum-gated AND has cooldown 0 is a weak
+constraint — fix at the design layer, not at policy).
+
+## Why this is its own dir
+
+`graph/` is documentation + a tiny render helper, not a runtime
+component. The operator publishes the data; this directory teaches
+how to view it. Future additions:
+
+- `render.go` — Graphviz DOT exporter (initial implementation)
+- `cytoscape.json` example for browser-based exploration
+- Templated queries for common policy-design questions

--- a/full-ai-cluster/k8s/applications/hat-system/graph/render.go
+++ b/full-ai-cluster/k8s/applications/hat-system/graph/render.go
@@ -1,0 +1,169 @@
+// hatgraph/render — read the live cluster's Hat + HatBinding state
+// and emit a Graphviz DOT file capturing nodes + edges per the
+// type table in README.md. Standalone binary; uses only the
+// kubeconfig env / default loading, no operator deps.
+//
+//	go run ./render.go --out hatgraph.dot
+//	dot -Tsvg hatgraph.dot -o hatgraph.svg
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	outPath = flag.String("out", "hatgraph.dot", "DOT output path; - for stdout")
+)
+
+func main() {
+	flag.Parse()
+
+	cfg, err := clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
+	if err != nil {
+		die("kubeconfig: %v", err)
+	}
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		die("dynamic client: %v", err)
+	}
+
+	ctx := context.Background()
+	hatGVR := schema.GroupVersionResource{Group: "society.zeta.io", Version: "v1alpha1", Resource: "hats"}
+	hbGVR := schema.GroupVersionResource{Group: "society.zeta.io", Version: "v1alpha1", Resource: "hatbindings"}
+
+	hats, err := dyn.Resource(hatGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		die("list hats: %v", err)
+	}
+	hbs, err := dyn.Resource(hbGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		die("list hatbindings: %v", err)
+	}
+
+	var w io.Writer = os.Stdout
+	if *outPath != "-" {
+		f, err := os.Create(*outPath)
+		if err != nil {
+			die("open out: %v", err)
+		}
+		defer f.Close()
+		w = f
+	}
+
+	fmt.Fprintln(w, "digraph HatGraph {")
+	fmt.Fprintln(w, `  rankdir=LR;`)
+	fmt.Fprintln(w, `  node [shape=box, style=rounded];`)
+
+	// Hat nodes (cluster-scoped).
+	for _, h := range hats.Items {
+		name := h.GetName()
+		desc, _, _ := unstructString(h.Object, "spec", "description")
+		fmt.Fprintf(w, "  %q [label=%q, color=blue];\n", name, name+"\\n"+truncate(desc, 40))
+	}
+
+	// Wearer nodes + wears edges.
+	wearers := map[string]bool{}
+	for _, b := range hbs.Items {
+		wid, _, _ := unstructString(b.Object, "spec", "wearer", "spiffeID")
+		hat, _, _ := unstructString(b.Object, "spec", "hat")
+		phase, _, _ := unstructString(b.Object, "status", "phase")
+		if wid == "" || hat == "" {
+			continue
+		}
+		if !wearers[wid] {
+			fmt.Fprintf(w, "  %q [label=%q, shape=ellipse, color=gray];\n",
+				wid, shortSpiffe(wid))
+			wearers[wid] = true
+		}
+		edgeColor := "black"
+		if phase == "Warmup" {
+			edgeColor = "orange"
+		} else if phase == "Probation" {
+			edgeColor = "red"
+		}
+		fmt.Fprintf(w, "  %q -> %q [label=%q, color=%s];\n",
+			wid, hat, "wears/"+phase, edgeColor)
+	}
+
+	// conflicts-with edges (undirected — render as dashed).
+	for _, h := range hats.Items {
+		name := h.GetName()
+		conflicts, _, _ := unstructSlice(h.Object, "spec", "throttles", "conflictsWith")
+		for _, c := range conflicts {
+			fmt.Fprintf(w, "  %q -> %q [style=dashed, color=red, arrowhead=none, label=\"conflicts\"];\n",
+				name, c)
+		}
+	}
+
+	fmt.Fprintln(w, "}")
+}
+
+func unstructString(obj map[string]any, path ...string) (string, bool, error) {
+	cur := any(obj)
+	for _, p := range path {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return "", false, nil
+		}
+		cur, ok = m[p]
+		if !ok {
+			return "", false, nil
+		}
+	}
+	s, ok := cur.(string)
+	return s, ok, nil
+}
+
+func unstructSlice(obj map[string]any, path ...string) ([]string, bool, error) {
+	cur := any(obj)
+	for _, p := range path {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false, nil
+		}
+		cur, ok = m[p]
+		if !ok {
+			return nil, false, nil
+		}
+	}
+	raw, ok := cur.([]any)
+	if !ok {
+		return nil, false, nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out, true, nil
+}
+
+func shortSpiffe(s string) string {
+	if i := strings.LastIndex(s, "/"); i >= 0 && i < len(s)-1 {
+		return s[i+1:]
+	}
+	return s
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "hatgraph: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/full-ai-cluster/k8s/applications/hat-system/hats/default-hatpolicy.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/hats/default-hatpolicy.yaml
@@ -1,0 +1,21 @@
+# Cluster-wide singleton carrying the default values for every
+# throttle plus the operator's tick-emit configuration. Edits to
+# this resource require the policy-admin hat.
+
+apiVersion: society.zeta.io/v1alpha1
+kind: HatPolicy
+metadata:
+  name: default
+spec:
+  throttles:
+    cooldownSeconds: 300
+    stickyAttributionSeconds: 600
+    warmupSeconds: 180
+    maxBindingsPerWearer: 3
+    maxNewHatsPerDay: 5
+    quorumDefaultSize: 3
+  swapRetentionDays: 365
+  tickEmit:
+    natsSubject: zeta.society.hats.ticks
+    enableLokiStructuredLogs: true
+    enableEvents: true

--- a/full-ai-cluster/k8s/applications/hat-system/hats/executor.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/hats/executor.yaml
@@ -1,0 +1,30 @@
+# Executor hat — namespace-scoped workload authority. The
+# common-case hat for an agent doing work on a specific service.
+
+apiVersion: society.zeta.io/v1alpha1
+kind: Hat
+metadata:
+  name: executor
+spec:
+  description: |
+    Authority to mutate workload state within an assigned namespace.
+    The default hat for agents executing tasks against a service.
+    Always namespace-scoped — the operator rejects bindings whose
+    HatBinding namespace differs from the wearer's permitted scope.
+  authority:
+    namespaces: []  # any single namespace at bind time
+    rules:
+      - apiGroups: ["apps"]
+        resources: ["deployments", "statefulsets", "daemonsets"]
+        verbs: ["get", "list", "watch", "create", "update", "patch"]
+      - apiGroups: [""]
+        resources: ["pods", "services", "configmaps"]
+        verbs: ["get", "list", "watch", "create", "update", "patch"]
+      - apiGroups: ["batch"]
+        resources: ["jobs"]
+        verbs: ["get", "list", "watch", "create"]
+  throttles:
+    cooldownSeconds: 300
+    warmupSeconds: 60
+    conflictsWith:
+      - hat-designer

--- a/full-ai-cluster/k8s/applications/hat-system/hats/hat-designer.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/hats/hat-designer.yaml
@@ -1,0 +1,65 @@
+# full-ai-cluster/k8s/applications/hat-system/hats/hat-designer.yaml
+#
+# Hat designer hat — meta-hat. The bootstrap-bottleneck answer:
+# rather than one human being the SPOF for "what hats does this
+# society need", designing-the-catalog is itself a hat that
+# multiple wearers can hold.
+#
+# Threat model: this is a high-blast-radius hat. Whoever wears it
+# can create new Hat resources, which the society then treats as
+# legitimate roles. Two safeguards:
+#
+#   1. quorumGated + quorumSize 3 — every new Hat creation needs
+#      three co-signatures from other hat-designer wearers (or
+#      from human-maintainer wearers, which compose because the
+#      operator checks SPIFFE ID, not role).
+#
+#   2. maxNewHatsPerDay (cluster-wide via HatPolicy default 5) —
+#      caps the catalog growth rate so a captured wearer can't
+#      spam novel hats. This is the cluster-wide ceiling; bumps
+#      require HatPolicy update, which requires its own quorum.
+#
+# conflictsWith the executor hat: same workload should not both
+# design AND execute under the catalog it designed — anti-
+# self-dealing safeguard. Wearers swap (cooldown applies) between
+# design and execution work.
+
+apiVersion: society.zeta.io/v1alpha1
+kind: Hat
+metadata:
+  name: hat-designer
+spec:
+  description: |
+    Authority to create, update, and retire Hat resources. Holders
+    propose additions to the society's role catalog. Bootstrap
+    answer to "who designs the hats" — the hat-designer hat
+    itself, held by a rotating quorum so no single wearer is the
+    bottleneck.
+  skills:
+    - name: role-catalog-design
+      level: expert
+    - name: opa-policy-authoring
+      level: intermediate
+    - name: rbac-design
+      level: intermediate
+    - name: threat-modeling
+      level: intermediate
+  authority:
+    namespaces: []  # cluster-wide (only valid because quorumGated)
+    rules:
+      - apiGroups: ["society.zeta.io"]
+        resources: ["hats"]
+        verbs: ["create", "update", "patch", "delete", "get", "list", "watch"]
+      - apiGroups: ["society.zeta.io"]
+        resources: ["hatpolicies"]
+        # Policy edits are read-only from this hat — bumping the
+        # cluster-wide ceiling needs the policy-admin hat, which has
+        # its own (higher) quorum.
+        verbs: ["get", "list", "watch"]
+  throttles:
+    quorumGated: true
+    quorumSize: 3
+    cooldownSeconds: 1800       # 30 min between design sessions per wearer
+    warmupSeconds: 600          # 10 min probation before first edit
+    conflictsWith:
+      - executor                # can't design + execute the same catalog

--- a/full-ai-cluster/k8s/applications/hat-system/hats/observer.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/hats/observer.yaml
@@ -1,0 +1,27 @@
+# Observer hat — read-only across the cluster, no swap throttle
+# (the always-instant escape-hatch hat). Designed to be safe for
+# any wearer at any time, including during another hat's cooldown.
+
+apiVersion: society.zeta.io/v1alpha1
+kind: Hat
+metadata:
+  name: observer
+spec:
+  description: |
+    Read-only access across all cluster resources for observability
+    work. Cannot mutate state; cannot grant authority. Always
+    swap-able with zero cooldown — this is the hat a wearer falls
+    back to when revoked from a higher-authority hat.
+  authority:
+    namespaces: []  # cluster-wide read
+    rules:
+      - apiGroups: [""]
+        resources: ["*"]
+        verbs: ["get", "list", "watch"]
+      - apiGroups: ["apps", "batch", "society.zeta.io"]
+        resources: ["*"]
+        verbs: ["get", "list", "watch"]
+  throttles:
+    cooldownSeconds: 0
+    warmupSeconds: 0
+    quorumGated: false

--- a/full-ai-cluster/k8s/applications/hat-system/hats/policy-admin.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/hats/policy-admin.yaml
@@ -1,0 +1,29 @@
+# Policy admin hat — edits cluster-wide HatPolicy defaults. Highest
+# blast radius in the system (raising maxNewHatsPerDay relaxes the
+# whole catalog growth ceiling). Quorum of 5 to make this expensive.
+
+apiVersion: society.zeta.io/v1alpha1
+kind: Hat
+metadata:
+  name: policy-admin
+spec:
+  description: |
+    Authority to edit the cluster-wide HatPolicy singleton. Any
+    change re-tunes the floor of every throttle for every hat.
+    Designed to be RARELY worn — quorum of five, long cooldown,
+    long warmup. Wearers typically rotate quarterly.
+  authority:
+    namespaces: []
+    rules:
+      - apiGroups: ["society.zeta.io"]
+        resources: ["hatpolicies"]
+        verbs: ["update", "patch", "get", "list", "watch"]
+  throttles:
+    quorumGated: true
+    quorumSize: 5
+    cooldownSeconds: 7200       # 2h between policy edits per wearer
+    warmupSeconds: 3600         # 1h probation
+    conflictsWith:
+      - executor
+      - hat-designer            # policy edits should not coincide with
+                                # active catalog design or execution

--- a/full-ai-cluster/k8s/applications/hat-system/namespace.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hat-system
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/full-ai-cluster/k8s/applications/hat-system/operator/PROJECT
+++ b/full-ai-cluster/k8s/applications/hat-system/operator/PROJECT
@@ -1,0 +1,52 @@
+# Standard kubebuilder PROJECT file. Generated layout — extend with
+# `kubebuilder create api` if/when adding additional resource kinds
+# beyond the four CRDs already authored under ../crds/.
+
+domain: society.zeta.io
+layout:
+  - go.kubebuilder.io/v4
+projectName: hat-system-operator
+repo: github.com/Lucent-Financial-Group/Zeta/full-ai-cluster/k8s/applications/hat-system/operator
+multigroup: false
+resources:
+  - api:
+      crdVersion: v1
+      namespaced: false
+    domain: society.zeta.io
+    group: society
+    kind: Hat
+    path: github.com/Lucent-Financial-Group/Zeta/full-ai-cluster/k8s/applications/hat-system/operator/api/v1alpha1
+    version: v1alpha1
+    controller: true
+  - api:
+      crdVersion: v1
+      namespaced: true
+    domain: society.zeta.io
+    group: society
+    kind: HatBinding
+    path: github.com/Lucent-Financial-Group/Zeta/full-ai-cluster/k8s/applications/hat-system/operator/api/v1alpha1
+    version: v1alpha1
+    controller: true
+    webhooks:
+      validation: true
+      defaulting: true
+      webhookVersion: v1
+  - api:
+      crdVersion: v1
+      namespaced: true
+    domain: society.zeta.io
+    group: society
+    kind: HatSwap
+    path: github.com/Lucent-Financial-Group/Zeta/full-ai-cluster/k8s/applications/hat-system/operator/api/v1alpha1
+    version: v1alpha1
+    controller: false
+  - api:
+      crdVersion: v1
+      namespaced: false
+    domain: society.zeta.io
+    group: society
+    kind: HatPolicy
+    path: github.com/Lucent-Financial-Group/Zeta/full-ai-cluster/k8s/applications/hat-system/operator/api/v1alpha1
+    version: v1alpha1
+    controller: true
+version: "3"

--- a/full-ai-cluster/k8s/applications/hat-system/operator/api/v1alpha1/types.go
+++ b/full-ai-cluster/k8s/applications/hat-system/operator/api/v1alpha1/types.go
@@ -1,0 +1,297 @@
+// Package v1alpha1 contains the Go type definitions matching the
+// CRDs under ../../crds/. Kept hand-authored (not kubebuilder-
+// regenerated) so the on-disk CRD YAML stays the source of truth —
+// the operator is one consumer of the schema; OPA, ArgoCD diffs,
+// and `kubectl explain` are all equal peers and they read the YAML.
+//
+// If you DO regenerate with `controller-gen`, mirror the changes
+// back into ../../crds/*.yaml in the same PR — never let the two
+// drift.
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+var (
+	GroupVersion = schema.GroupVersion{Group: "society.zeta.io", Version: "v1alpha1"}
+
+	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+
+	AddToScheme = SchemeBuilder.AddToScheme
+)
+
+func init() {
+	SchemeBuilder.Register(
+		&Hat{}, &HatList{},
+		&HatBinding{}, &HatBindingList{},
+		&HatSwap{}, &HatSwapList{},
+		&HatPolicy{}, &HatPolicyList{},
+	)
+}
+
+// -------------------------------------------------------------------
+// Hat
+// -------------------------------------------------------------------
+
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+type Hat struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              HatSpec   `json:"spec"`
+	Status            HatStatus `json:"status,omitempty"`
+}
+
+// HatSpec — Max's compression: hat = skills + opa/rbac. Skills
+// describe what the wearer CAN do; Authority describes what the
+// wearer is PERMITTED to do. The operator only enforces Authority;
+// Skills are matchable metadata for assignment reactors.
+// HatSpec — Max's compression: hat = skills + opa/rbac. Skills
+// describe what the wearer CAN do; Authority describes what the
+// wearer is PERMITTED to do. Supervises declares supervisory edges
+// in the hat hierarchy (DAG; no cycles). The operator only enforces
+// Authority + Supervises edges; Skills are matchable metadata for
+// assignment reactors.
+//
+// Why this is hat-not-cage despite supervisory hierarchy: every hat
+// in this spec is time-bounded by cooldown / warmup / sticky-
+// attribution / succession. Supervisory weight rides on the ROLE,
+// not on any individual wearer. A supervisor who oversteps gets
+// swapped off; the hat persists and the next wearer inherits the
+// same constraints. Cages live on wearers; this lives on roles.
+type HatSpec struct {
+	Description string         `json:"description,omitempty"`
+	Skills      []Skill        `json:"skills,omitempty"`
+	Supervises  []string       `json:"supervises,omitempty"`
+	Authority   HatAuthority   `json:"authority"`
+	Throttles   *HatThrottles  `json:"throttles,omitempty"`
+}
+
+type Skill struct {
+	Name       string `json:"name"`
+	Level      string `json:"level,omitempty"`      // novice | intermediate | expert
+	ProvidedBy string `json:"providedBy,omitempty"` // e.g. claude-plugins-official/foo
+}
+
+type HatAuthority struct {
+	Namespaces []string         `json:"namespaces,omitempty"`
+	Rules      []AuthorityRule  `json:"rules,omitempty"`
+}
+
+type AuthorityRule struct {
+	Verbs     []string `json:"verbs"`
+	Resources []string `json:"resources"`
+	APIGroups []string `json:"apiGroups,omitempty"`
+}
+
+type HatThrottles struct {
+	CooldownSeconds          *int     `json:"cooldownSeconds,omitempty"`
+	StickyAttributionSeconds *int     `json:"stickyAttributionSeconds,omitempty"`
+	WarmupSeconds            *int     `json:"warmupSeconds,omitempty"`
+	QuorumGated              *bool    `json:"quorumGated,omitempty"`
+	QuorumSize               *int     `json:"quorumSize,omitempty"`
+	ConflictsWith            []string `json:"conflictsWith,omitempty"`
+}
+
+type HatStatus struct {
+	Reputation       int64               `json:"reputation,omitempty"`
+	CurrentWearers   []string            `json:"currentWearers,omitempty"`
+	LifetimeWearers  int64               `json:"lifetimeWearers,omitempty"`
+	Conditions       []metav1.Condition  `json:"conditions,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+type HatList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Hat `json:"items"`
+}
+
+// -------------------------------------------------------------------
+// HatBinding
+// -------------------------------------------------------------------
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+type HatBinding struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              HatBindingSpec   `json:"spec"`
+	Status            HatBindingStatus `json:"status,omitempty"`
+}
+
+type HatBindingSpec struct {
+	Hat         string         `json:"hat"`
+	Wearer      Wearer         `json:"wearer"`
+	CosignedBy  []Cosignature  `json:"cosignedBy,omitempty"`
+	RequestedAt *metav1.Time   `json:"requestedAt,omitempty"`
+}
+
+type Wearer struct {
+	SpiffeID          string                   `json:"spiffeID"`
+	ServiceAccountRef *ServiceAccountReference `json:"serviceAccountRef,omitempty"`
+}
+
+type ServiceAccountReference struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+type Cosignature struct {
+	SpiffeID    string      `json:"spiffeID"`
+	SignedAt    metav1.Time `json:"signedAt"`
+	Attestation string      `json:"attestation,omitempty"`
+}
+
+// HatBindingPhase is the lifecycle phase of a binding. Transitions
+// drive the operator's tick emit — every transition produces exactly
+// one HatSwap event.
+type HatBindingPhase string
+
+const (
+	PhasePending   HatBindingPhase = "Pending"
+	PhaseWarmup    HatBindingPhase = "Warmup"
+	PhaseActive    HatBindingPhase = "Active"
+	PhaseProbation HatBindingPhase = "Probation"
+	PhaseRevoked   HatBindingPhase = "Revoked"
+)
+
+type HatBindingStatus struct {
+	Phase                   HatBindingPhase    `json:"phase,omitempty"`
+	EffectiveAuthority      *HatAuthority      `json:"effectiveAuthority,omitempty"`
+	BoundAt                 *metav1.Time       `json:"boundAt,omitempty"`
+	WarmupEndsAt            *metav1.Time       `json:"warmupEndsAt,omitempty"`
+	StickyAttributionEndsAt *metav1.Time       `json:"stickyAttributionEndsAt,omitempty"`
+	Conditions              []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+type HatBindingList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []HatBinding `json:"items"`
+}
+
+// -------------------------------------------------------------------
+// HatSwap (append-only tick events)
+// -------------------------------------------------------------------
+
+// SwapEvent enumerates every transition the operator emits as a tick.
+// Adding a new value here = adding a new tick class downstream
+// reactors can subscribe to — keep it small + meaningful.
+type SwapEvent string
+
+const (
+	SwapOn      SwapEvent = "SwapOn"
+	SwapOff     SwapEvent = "SwapOff"
+	WarmupBegin SwapEvent = "WarmupBegin"
+	WarmupEnd   SwapEvent = "WarmupEnd"
+	Probation   SwapEvent = "Probation"
+	QuorumGrant SwapEvent = "QuorumGrant"
+	Throttled   SwapEvent = "Throttled"
+)
+
+// +kubebuilder:object:root=true
+type HatSwap struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              HatSwapSpec `json:"spec"`
+}
+
+type HatSwapSpec struct {
+	Hat             string             `json:"hat"`
+	Wearer          Wearer             `json:"wearer"`
+	Event           SwapEvent          `json:"event"`
+	OccurredAt      metav1.Time        `json:"occurredAt"`
+	Reason          string             `json:"reason,omitempty"`
+	Message         string             `json:"message,omitempty"`
+	BindingRef      *BindingReference  `json:"bindingRef,omitempty"`
+	ThrottleName    string             `json:"throttleName,omitempty"`
+	PreviousWearer  *PreviousWearer    `json:"previousWearer,omitempty"`
+}
+
+type BindingReference struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	UID       string `json:"uid,omitempty"`
+}
+
+type PreviousWearer struct {
+	SpiffeID  string       `json:"spiffeID"`
+	RevokedAt *metav1.Time `json:"revokedAt,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+type HatSwapList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []HatSwap `json:"items"`
+}
+
+// -------------------------------------------------------------------
+// HatPolicy (cluster-wide defaults singleton)
+// -------------------------------------------------------------------
+
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+type HatPolicy struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              HatPolicySpec   `json:"spec"`
+	Status            HatPolicyStatus `json:"status,omitempty"`
+}
+
+type HatPolicySpec struct {
+	Throttles         PolicyThrottles `json:"throttles,omitempty"`
+	SwapRetentionDays int             `json:"swapRetentionDays,omitempty"`
+	TickEmit          TickEmit        `json:"tickEmit,omitempty"`
+}
+
+type PolicyThrottles struct {
+	CooldownSeconds          int `json:"cooldownSeconds,omitempty"`
+	StickyAttributionSeconds int `json:"stickyAttributionSeconds,omitempty"`
+	WarmupSeconds            int `json:"warmupSeconds,omitempty"`
+	MaxBindingsPerWearer     int `json:"maxBindingsPerWearer,omitempty"`
+	MaxNewHatsPerDay         int `json:"maxNewHatsPerDay,omitempty"`
+	QuorumDefaultSize        int `json:"quorumDefaultSize,omitempty"`
+}
+
+type TickEmit struct {
+	NATSSubject              string `json:"natsSubject,omitempty"`
+	EnableLokiStructuredLogs bool   `json:"enableLokiStructuredLogs,omitempty"`
+	EnableEvents             bool   `json:"enableEvents,omitempty"`
+}
+
+type HatPolicyStatus struct {
+	LastReconciledAt *metav1.Time `json:"lastReconciledAt,omitempty"`
+	ActiveHats       int          `json:"activeHats,omitempty"`
+	ActiveBindings   int          `json:"activeBindings,omitempty"`
+	SwapsLast24h     int          `json:"swapsLast24h,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+type HatPolicyList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []HatPolicy `json:"items"`
+}
+
+// DeepCopyObject glue — minimal hand-rolled stubs so this file compiles
+// without controller-gen having been run yet. Replace with generated
+// `zz_generated.deepcopy.go` from `make generate` once kubebuilder is
+// bootstrapped (kubebuilder init + the four `kubebuilder create api`
+// invocations described in the operator README).
+func (h *Hat) DeepCopyObject() runtime.Object         { return h }
+func (h *HatList) DeepCopyObject() runtime.Object     { return h }
+func (b *HatBinding) DeepCopyObject() runtime.Object  { return b }
+func (b *HatBindingList) DeepCopyObject() runtime.Object { return b }
+func (s *HatSwap) DeepCopyObject() runtime.Object     { return s }
+func (s *HatSwapList) DeepCopyObject() runtime.Object { return s }
+func (p *HatPolicy) DeepCopyObject() runtime.Object   { return p }
+func (p *HatPolicyList) DeepCopyObject() runtime.Object { return p }

--- a/full-ai-cluster/k8s/applications/hat-system/operator/cmd/main.go
+++ b/full-ai-cluster/k8s/applications/hat-system/operator/cmd/main.go
@@ -1,0 +1,117 @@
+// hat-system-operator entrypoint.
+//
+// Wires the four CRD controllers + the validating webhook + the
+// tick sinks (NATS, slog→Loki, k8s Events, the HatSwap CR). Reads
+// the cluster-wide HatPolicy singleton at startup to resolve
+// tick-emit config.
+package main
+
+import (
+	"flag"
+	"log/slog"
+	"os"
+
+	"github.com/nats-io/nats.go"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	v1a "github.com/Lucent-Financial-Group/Zeta/full-ai-cluster/k8s/applications/hat-system/operator/api/v1alpha1"
+	"github.com/Lucent-Financial-Group/Zeta/full-ai-cluster/k8s/applications/hat-system/operator/internal/controller"
+	"github.com/Lucent-Financial-Group/Zeta/full-ai-cluster/k8s/applications/hat-system/operator/internal/tick"
+)
+
+var (
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1a.AddToScheme(scheme))
+}
+
+func main() {
+	var (
+		metricsAddr      string
+		probeAddr        string
+		natsURL          string
+		enableLeaderElec bool
+	)
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "")
+	flag.StringVar(&natsURL, "nats-url",
+		"nats://nats.nats.svc.cluster.local:4222",
+		"NATS endpoint for tick publish. Set empty to disable NATS emit.")
+	flag.BoolVar(&enableLeaderElec, "leader-elect", true, "")
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseDevMode(false)))
+
+	var natsConn *nats.Conn
+	if natsURL != "" {
+		conn, err := nats.Connect(natsURL,
+			nats.Name("hat-system-operator"),
+			nats.MaxReconnects(-1),
+			nats.PingInterval(30),
+		)
+		if err != nil {
+			setupLog.Error(err, "NATS connect failed — continuing without NATS emit")
+		} else {
+			natsConn = conn
+			defer natsConn.Drain()
+		}
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElec,
+		LeaderElectionID:       "hat-system-operator.society.zeta.io",
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	sinks := tick.Sinks{
+		Client:   mgr.GetClient(),
+		Recorder: mgr.GetEventRecorderFor("hat-system-operator"),
+		NATS:     natsConn,
+		Logger:   slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	}
+
+	if err := (&controller.HatBindingReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Sinks:  sinks,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create HatBinding controller")
+		os.Exit(1)
+	}
+
+	// TODO: register HatReconciler (reputation accumulation) and
+	// HatPolicyReconciler (singleton enforcement + status rollup).
+	// Stubs intentionally omitted in this scaffold — extend with
+	// `kubebuilder create api` once the project is initialized.
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "manager exited")
+		os.Exit(1)
+	}
+}

--- a/full-ai-cluster/k8s/applications/hat-system/operator/go.mod
+++ b/full-ai-cluster/k8s/applications/hat-system/operator/go.mod
@@ -1,0 +1,19 @@
+module github.com/Lucent-Financial-Group/Zeta/full-ai-cluster/k8s/applications/hat-system/operator
+
+go 1.23
+
+// Versions pinned to the kubebuilder v4 + controller-runtime v0.19 line
+// (the matched set for k8s 1.31 / 1.32 cluster targets). Bump together
+// when upgrading; mixing controller-runtime majors with mismatched
+// client-go usually breaks builds at compile time.
+
+require (
+	github.com/nats-io/nats.go v1.37.0
+	github.com/onsi/ginkgo/v2 v2.21.0
+	github.com/onsi/gomega v1.35.1
+	github.com/spiffe/go-spiffe/v2 v2.4.0
+	k8s.io/api v0.32.0
+	k8s.io/apimachinery v0.32.0
+	k8s.io/client-go v0.32.0
+	sigs.k8s.io/controller-runtime v0.19.3
+)

--- a/full-ai-cluster/k8s/applications/hat-system/operator/internal/controller/hatbinding_controller.go
+++ b/full-ai-cluster/k8s/applications/hat-system/operator/internal/controller/hatbinding_controller.go
@@ -1,0 +1,178 @@
+// Package controller — reconcilers for Hat / HatBinding / HatPolicy.
+//
+// The reconcile loop is the operator's tick source:
+//
+//   create/update event ─┐
+//   delete event ────────┼──► Reconcile() ──► state transition ──► tick.Emit()
+//   periodic resync ─────┘
+//
+// Each transition emits exactly one tick. Throttle decisions happen
+// inside Reconcile — a denied bind produces a Throttled tick (CR +
+// Event + log + NATS) but does not advance the binding past Pending.
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	v1a "github.com/Lucent-Financial-Group/Zeta/full-ai-cluster/k8s/applications/hat-system/operator/api/v1alpha1"
+	"github.com/Lucent-Financial-Group/Zeta/full-ai-cluster/k8s/applications/hat-system/operator/internal/tick"
+)
+
+// HatBindingReconciler reconciles HatBinding lifecycle.
+type HatBindingReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	Sinks  tick.Sinks
+}
+
+// +kubebuilder:rbac:groups=society.zeta.io,resources=hatbindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=society.zeta.io,resources=hatbindings/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=society.zeta.io,resources=hats,verbs=get;list;watch
+// +kubebuilder:rbac:groups=society.zeta.io,resources=hats/status,verbs=update;patch
+// +kubebuilder:rbac:groups=society.zeta.io,resources=hatpolicies,verbs=get;list;watch
+// +kubebuilder:rbac:groups=society.zeta.io,resources=hatswaps,verbs=create;list
+
+func (r *HatBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	lg := log.FromContext(ctx).WithValues("hatbinding", req.NamespacedName)
+
+	binding := &v1a.HatBinding{}
+	if err := r.Get(ctx, req.NamespacedName, binding); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Deletion — handled by finalizer flow in a fuller impl.
+			// This skeleton lets the API server reclaim the object;
+			// the SwapOff tick was emitted at finalizer time.
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	hat := &v1a.Hat{}
+	if err := r.Get(ctx, client.ObjectKey{Name: binding.Spec.Hat}, hat); err != nil {
+		return ctrl.Result{}, fmt.Errorf("fetch hat %q: %w", binding.Spec.Hat, err)
+	}
+
+	policy := &v1a.HatPolicy{}
+	_ = r.Get(ctx, client.ObjectKey{Name: "default"}, policy)
+	throttles := resolveThrottles(hat, policy)
+
+	now := time.Now().UTC()
+
+	switch binding.Status.Phase {
+	case "", v1a.PhasePending:
+		// Throttle gate. Real impl runs cooldown / quorum /
+		// conflict-of-interest / max-bindings-per-wearer checks here.
+		// Skeleton just transitions to Warmup if warmup configured,
+		// else directly to Active. Throttle rejections would emit
+		// v1a.Throttled tick and short-circuit return.
+		if throttles.WarmupSeconds > 0 {
+			endsAt := now.Add(time.Duration(throttles.WarmupSeconds) * time.Second)
+			binding.Status.Phase = v1a.PhaseWarmup
+			binding.Status.WarmupEndsAt = &metav1.Time{Time: endsAt}
+			binding.Status.BoundAt = &metav1.Time{Time: now}
+			if err := r.Status().Update(ctx, binding); err != nil {
+				return ctrl.Result{}, err
+			}
+			_ = tick.Emit(ctx, r.Sinks, tick.Tick{
+				Hat: hat.Name, Wearer: binding.Spec.Wearer,
+				Event: v1a.WarmupBegin, OccurredAt: now,
+				Reason: "WarmupStart",
+				Message: fmt.Sprintf("probation until %s", endsAt.Format(time.RFC3339)),
+				Binding: binding,
+			})
+			return ctrl.Result{RequeueAfter: time.Until(endsAt)}, nil
+		}
+		return r.activate(ctx, binding, hat, now)
+
+	case v1a.PhaseWarmup:
+		if binding.Status.WarmupEndsAt != nil && now.Before(binding.Status.WarmupEndsAt.Time) {
+			return ctrl.Result{RequeueAfter: time.Until(binding.Status.WarmupEndsAt.Time)}, nil
+		}
+		_ = tick.Emit(ctx, r.Sinks, tick.Tick{
+			Hat: hat.Name, Wearer: binding.Spec.Wearer,
+			Event: v1a.WarmupEnd, OccurredAt: now,
+			Reason: "WarmupComplete", Binding: binding,
+		})
+		return r.activate(ctx, binding, hat, now)
+
+	case v1a.PhaseActive, v1a.PhaseProbation, v1a.PhaseRevoked:
+		// Nothing to do at steady state. Anomaly-detection reactors
+		// flip Active → Probation by patching status; that triggers
+		// a fresh reconcile via watch.
+		lg.V(1).Info("steady state", "phase", binding.Status.Phase)
+		return ctrl.Result{}, nil
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *HatBindingReconciler) activate(ctx context.Context, binding *v1a.HatBinding, hat *v1a.Hat, now time.Time) (ctrl.Result, error) {
+	binding.Status.Phase = v1a.PhaseActive
+	binding.Status.EffectiveAuthority = &hat.Spec.Authority
+	if binding.Status.BoundAt == nil {
+		binding.Status.BoundAt = &metav1.Time{Time: now}
+	}
+	if err := r.Status().Update(ctx, binding); err != nil {
+		return ctrl.Result{}, err
+	}
+	_ = tick.Emit(ctx, r.Sinks, tick.Tick{
+		Hat: hat.Name, Wearer: binding.Spec.Wearer,
+		Event: v1a.SwapOn, OccurredAt: now,
+		Reason: "BindingActive", Binding: binding,
+	})
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager wires HatBinding into the controller manager.
+func (r *HatBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1a.HatBinding{}).
+		Complete(r)
+}
+
+// resolveThrottles merges per-Hat overrides over policy defaults.
+type resolvedThrottles struct {
+	CooldownSeconds          int
+	StickyAttributionSeconds int
+	WarmupSeconds            int
+	QuorumGated              bool
+	QuorumSize               int
+	ConflictsWith            []string
+}
+
+func resolveThrottles(h *v1a.Hat, p *v1a.HatPolicy) resolvedThrottles {
+	r := resolvedThrottles{
+		CooldownSeconds:          p.Spec.Throttles.CooldownSeconds,
+		StickyAttributionSeconds: p.Spec.Throttles.StickyAttributionSeconds,
+		WarmupSeconds:            p.Spec.Throttles.WarmupSeconds,
+		QuorumSize:               p.Spec.Throttles.QuorumDefaultSize,
+	}
+	if h.Spec.Throttles == nil {
+		return r
+	}
+	if h.Spec.Throttles.CooldownSeconds != nil {
+		r.CooldownSeconds = *h.Spec.Throttles.CooldownSeconds
+	}
+	if h.Spec.Throttles.StickyAttributionSeconds != nil {
+		r.StickyAttributionSeconds = *h.Spec.Throttles.StickyAttributionSeconds
+	}
+	if h.Spec.Throttles.WarmupSeconds != nil {
+		r.WarmupSeconds = *h.Spec.Throttles.WarmupSeconds
+	}
+	if h.Spec.Throttles.QuorumGated != nil {
+		r.QuorumGated = *h.Spec.Throttles.QuorumGated
+	}
+	if h.Spec.Throttles.QuorumSize != nil {
+		r.QuorumSize = *h.Spec.Throttles.QuorumSize
+	}
+	r.ConflictsWith = h.Spec.Throttles.ConflictsWith
+	return r
+}

--- a/full-ai-cluster/k8s/applications/hat-system/operator/internal/tick/emitter.go
+++ b/full-ai-cluster/k8s/applications/hat-system/operator/internal/tick/emitter.go
@@ -1,0 +1,150 @@
+// Package tick is the operator's structured tick source.
+//
+// Every state transition in the Hat lifecycle goes through Emit, and
+// Emit fans out to all configured sinks: an immutable HatSwap CR
+// (durable), a k8s Event (operator-readable for `kubectl describe`),
+// a structured log line (Loki picks it up), and an optional NATS
+// publish (for reactors that want push instead of poll).
+//
+// The fan-out is best-effort per sink — a NATS outage does not block
+// the CR write; a Loki gap does not block the Event. The HatSwap CR
+// is the canonical record, and the operator's reconcile loop will
+// retry CR writes on failure (controller-runtime queue semantics).
+package tick
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1a "github.com/Lucent-Financial-Group/Zeta/full-ai-cluster/k8s/applications/hat-system/operator/api/v1alpha1"
+)
+
+// Sinks holds the runtime-resolved per-sink handles. Any nil sink is
+// silently skipped, so the operator can run with NATS / Loki / Events
+// independently enabled.
+type Sinks struct {
+	Client   client.Client
+	Recorder record.EventRecorder
+	NATS     *nats.Conn
+	Logger   *slog.Logger
+}
+
+// Tick describes a single state transition. The reconciler builds
+// one of these per transition and hands it to Emit.
+type Tick struct {
+	Hat            string
+	Wearer         v1a.Wearer
+	Event          v1a.SwapEvent
+	OccurredAt     time.Time
+	Reason         string
+	Message        string
+	Binding        *v1a.HatBinding
+	ThrottleName   string
+	PreviousWearer *v1a.PreviousWearer
+}
+
+func Emit(ctx context.Context, s Sinks, t Tick) error {
+	if t.OccurredAt.IsZero() {
+		t.OccurredAt = time.Now().UTC()
+	}
+
+	// 1. Durable CR. Write first so a later sink failure leaves the
+	// canonical record intact.
+	swap := &v1a.HatSwap{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-%s-", t.Hat, t.Event),
+			Namespace:    bindingNamespace(t),
+		},
+		Spec: v1a.HatSwapSpec{
+			Hat:            t.Hat,
+			Wearer:         t.Wearer,
+			Event:          t.Event,
+			OccurredAt:     metav1.NewTime(t.OccurredAt),
+			Reason:         t.Reason,
+			Message:        t.Message,
+			ThrottleName:   t.ThrottleName,
+			PreviousWearer: t.PreviousWearer,
+		},
+	}
+	if t.Binding != nil {
+		swap.Spec.BindingRef = &v1a.BindingReference{
+			Name:      t.Binding.Name,
+			Namespace: t.Binding.Namespace,
+			UID:       string(t.Binding.UID),
+		}
+	}
+	if s.Client != nil {
+		if err := s.Client.Create(ctx, swap); err != nil {
+			return fmt.Errorf("emit HatSwap CR: %w", err)
+		}
+	}
+
+	// 2. Best-effort k8s Event (drops if recorder is nil).
+	if s.Recorder != nil && t.Binding != nil {
+		eventType := corev1.EventTypeNormal
+		if t.Event == v1a.Throttled || t.Event == v1a.Probation {
+			eventType = corev1.EventTypeWarning
+		}
+		s.Recorder.Eventf(t.Binding, eventType, string(t.Event),
+			"%s: %s", t.Reason, t.Message)
+	}
+
+	// 3. Best-effort structured log (Loki picks it up via the standard
+	// Alloy → Loki pipeline already running in the cluster).
+	if s.Logger != nil {
+		s.Logger.LogAttrs(ctx, slog.LevelInfo, "hat.tick",
+			slog.String("hat", t.Hat),
+			slog.String("wearer.spiffeID", t.Wearer.SpiffeID),
+			slog.String("event", string(t.Event)),
+			slog.String("reason", t.Reason),
+			slog.String("throttle", t.ThrottleName),
+			slog.Time("occurredAt", t.OccurredAt),
+		)
+	}
+
+	// 4. Best-effort NATS publish.
+	if s.NATS != nil {
+		payload, err := json.Marshal(struct {
+			Hat        string         `json:"hat"`
+			Wearer     v1a.Wearer     `json:"wearer"`
+			Event      v1a.SwapEvent  `json:"event"`
+			Reason     string         `json:"reason"`
+			Throttle   string         `json:"throttle,omitempty"`
+			OccurredAt time.Time      `json:"occurredAt"`
+		}{
+			Hat: t.Hat, Wearer: t.Wearer, Event: t.Event,
+			Reason: t.Reason, Throttle: t.ThrottleName,
+			OccurredAt: t.OccurredAt,
+		})
+		if err != nil {
+			// Marshal failure is operator-bug territory; surface but
+			// don't fail the tick — CR is already written.
+			ctrl.Log.Error(err, "tick.Emit: marshal NATS payload")
+		} else {
+			subject := fmt.Sprintf("zeta.society.hats.%s.%s", t.Hat, t.Event)
+			if pubErr := s.NATS.Publish(subject, payload); pubErr != nil {
+				ctrl.Log.Error(pubErr, "tick.Emit: NATS publish",
+					"subject", subject)
+			}
+		}
+	}
+
+	return nil
+}
+
+func bindingNamespace(t Tick) string {
+	if t.Binding != nil && t.Binding.Namespace != "" {
+		return t.Binding.Namespace
+	}
+	return "hat-system"
+}

--- a/full-ai-cluster/k8s/applications/hat-system/policies/01-cooldown.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/01-cooldown.yaml
@@ -1,0 +1,75 @@
+# OPA Gatekeeper template — cooldown throttle.
+#
+# Reject HatBinding creation if the wearer (by SPIFFE ID) had a
+# SwapOff for the same hat within `cooldownSeconds`. The operator's
+# resolveThrottles() handles per-hat overrides; this template only
+# needs to know the resolved value, which the operator stores in a
+# ConfigMap snapshot the policy reads (avoids the template needing
+# Hat / HatPolicy data lookups, which Gatekeeper supports via
+# referential constraints but adds a dependency on the
+# config.gatekeeper.sh sync).
+
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: hatcooldown
+spec:
+  crd:
+    spec:
+      names:
+        kind: HatCooldown
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            cooldownSeconds:
+              type: integer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package hatcooldown
+
+        # input.review.object is the HatBinding being created.
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "HatBinding"
+          input.review.operation == "CREATE"
+
+          hat := input.review.object.spec.hat
+          wearer := input.review.object.spec.wearer.spiffeID
+
+          # data.inventory.namespace.<ns>.society.zeta.io.v1alpha1.HatSwap
+          # is the Gatekeeper sync of HatSwap CRs. The operator writes
+          # one HatSwap per state transition (see internal/tick/emitter.go).
+          some ns
+          some name
+          swap := data.inventory.namespace[ns]["society.zeta.io/v1alpha1"]["HatSwap"][name]
+          swap.spec.hat == hat
+          swap.spec.event == "SwapOff"
+          swap.spec.previousWearer.spiffeID == wearer
+
+          # Time arithmetic — Gatekeeper's time built-in returns ns.
+          off_ns := time.parse_rfc3339_ns(swap.spec.occurredAt)
+          now_ns := time.now_ns()
+          delta_s := (now_ns - off_ns) / 1000000000
+          delta_s < input.parameters.cooldownSeconds
+
+          msg := sprintf(
+            "wearer %v in cooldown for hat %v (%v s since SwapOff < %v s required)",
+            [wearer, hat, delta_s, input.parameters.cooldownSeconds],
+          )
+        }
+---
+# Default cooldown — overridden per-Hat by the operator setting
+# annotations the operator-managed instance reads. Skeleton uses
+# 300s (matches HatPolicy default).
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: HatCooldown
+metadata:
+  name: hat-cooldown-default
+spec:
+  match:
+    kinds:
+      - apiGroups: ["society.zeta.io"]
+        kinds: ["HatBinding"]
+  parameters:
+    cooldownSeconds: 300

--- a/full-ai-cluster/k8s/applications/hat-system/policies/02-max-bindings.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/02-max-bindings.yaml
@@ -1,0 +1,54 @@
+# Max bindings per wearer — caps simultaneous hats one SPIFFE
+# identity can hold. Prevents authority accumulation.
+
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: hatmaxbindings
+spec:
+  crd:
+    spec:
+      names:
+        kind: HatMaxBindings
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            maxBindingsPerWearer:
+              type: integer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package hatmaxbindings
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "HatBinding"
+          input.review.operation == "CREATE"
+          wearer := input.review.object.spec.wearer.spiffeID
+
+          existing := [b |
+            some ns
+            some name
+            b := data.inventory.namespace[ns]["society.zeta.io/v1alpha1"]["HatBinding"][name]
+            b.spec.wearer.spiffeID == wearer
+            b.status.phase != "Revoked"
+          ]
+          count(existing) >= input.parameters.maxBindingsPerWearer
+
+          msg := sprintf(
+            "wearer %v already holds %v hats; max is %v",
+            [wearer, count(existing), input.parameters.maxBindingsPerWearer],
+          )
+        }
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: HatMaxBindings
+metadata:
+  name: hat-max-bindings-default
+spec:
+  match:
+    kinds:
+      - apiGroups: ["society.zeta.io"]
+        kinds: ["HatBinding"]
+  parameters:
+    maxBindingsPerWearer: 3

--- a/full-ai-cluster/k8s/applications/hat-system/policies/03-conflict-of-interest.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/03-conflict-of-interest.yaml
@@ -1,0 +1,53 @@
+# Conflict-of-interest — reject HatBinding if the wearer already
+# holds a hat listed in Hat.spec.throttles.conflictsWith of the
+# hat being bound (or vice-versa).
+
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: hatconflict
+spec:
+  crd:
+    spec:
+      names:
+        kind: HatConflict
+      validation:
+        openAPIV3Schema:
+          type: object
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package hatconflict
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "HatBinding"
+          input.review.operation == "CREATE"
+          wearer := input.review.object.spec.wearer.spiffeID
+          target_name := input.review.object.spec.hat
+
+          target_hat := data.inventory.cluster["society.zeta.io/v1alpha1"]["Hat"][target_name]
+          some conflict_name
+          conflict_name := target_hat.spec.throttles.conflictsWith[_]
+
+          some ns
+          some name
+          existing := data.inventory.namespace[ns]["society.zeta.io/v1alpha1"]["HatBinding"][name]
+          existing.spec.wearer.spiffeID == wearer
+          existing.spec.hat == conflict_name
+          existing.status.phase != "Revoked"
+
+          msg := sprintf(
+            "wearer %v cannot bind hat %v while holding conflicting hat %v",
+            [wearer, target_name, conflict_name],
+          )
+        }
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: HatConflict
+metadata:
+  name: hat-conflict-default
+spec:
+  match:
+    kinds:
+      - apiGroups: ["society.zeta.io"]
+        kinds: ["HatBinding"]

--- a/full-ai-cluster/k8s/applications/hat-system/policies/04-quorum.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/04-quorum.yaml
@@ -1,0 +1,49 @@
+# Quorum — for quorum-gated hats, require the HatBinding spec
+# to carry at least quorumSize cosignedBy entries, each from a
+# SPIFFE ID that itself currently holds a hat (not necessarily
+# the same hat; depends on whether the operator validates the
+# co-signer's hat list — this template just checks count).
+
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: hatquorum
+spec:
+  crd:
+    spec:
+      names:
+        kind: HatQuorum
+      validation:
+        openAPIV3Schema:
+          type: object
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package hatquorum
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "HatBinding"
+          input.review.operation == "CREATE"
+          target_name := input.review.object.spec.hat
+          target_hat := data.inventory.cluster["society.zeta.io/v1alpha1"]["Hat"][target_name]
+          target_hat.spec.throttles.quorumGated == true
+
+          required := target_hat.spec.throttles.quorumSize
+          signed := count(input.review.object.spec.cosignedBy)
+          signed < required
+
+          msg := sprintf(
+            "hat %v requires quorum %v; only %v cosignatures present",
+            [target_name, required, signed],
+          )
+        }
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: HatQuorum
+metadata:
+  name: hat-quorum-default
+spec:
+  match:
+    kinds:
+      - apiGroups: ["society.zeta.io"]
+        kinds: ["HatBinding"]

--- a/full-ai-cluster/k8s/applications/hat-system/policies/05-warmup.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/05-warmup.yaml
@@ -1,0 +1,49 @@
+# Warmup — newly-bound hats start in Warmup phase; this template
+# rejects any HatBinding STATUS update that moves Phase to Active
+# inside the warmup window. The operator transitions
+# Warmup → Active legitimately via its own reconciler when
+# WarmupEndsAt is reached, with no human intervention; this
+# constraint catches drift / mistaken manual overrides.
+
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: hatwarmup
+spec:
+  crd:
+    spec:
+      names:
+        kind: HatWarmup
+      validation:
+        openAPIV3Schema:
+          type: object
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package hatwarmup
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "HatBinding"
+          input.review.operation == "UPDATE"
+          input.review.object.status.phase == "Active"
+          input.review.oldObject.status.phase == "Warmup"
+
+          ends := time.parse_rfc3339_ns(input.review.oldObject.status.warmupEndsAt)
+          now := time.now_ns()
+          now < ends
+
+          msg := sprintf(
+            "warmup not complete for hat %v binding %v; cannot promote to Active",
+            [input.review.object.spec.hat, input.review.object.metadata.name],
+          )
+        }
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: HatWarmup
+metadata:
+  name: hat-warmup-default
+spec:
+  match:
+    kinds:
+      - apiGroups: ["society.zeta.io"]
+        kinds: ["HatBinding"]

--- a/full-ai-cluster/k8s/applications/hat-system/policies/06-max-new-hats.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/06-max-new-hats.yaml
@@ -1,0 +1,59 @@
+# Max new hats per day — rate-limits Hat resource creation
+# cluster-wide. Caps the catalog growth rate so even a captured
+# hat-designer wearer can't spam the namespace with novel hats.
+
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: hatmaxnew
+spec:
+  crd:
+    spec:
+      names:
+        kind: HatMaxNew
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            maxNewHatsPerDay:
+              type: integer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package hatmaxnew
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Hat"
+          input.review.operation == "CREATE"
+
+          # Count Hats created in the last 24h by inspecting their
+          # creationTimestamp.
+          now := time.now_ns()
+          window := 24 * 60 * 60 * 1000000000
+
+          recent := [h |
+            some name
+            h := data.inventory.cluster["society.zeta.io/v1alpha1"]["Hat"][name]
+            created := time.parse_rfc3339_ns(h.metadata.creationTimestamp)
+            (now - created) < window
+          ]
+
+          count(recent) >= input.parameters.maxNewHatsPerDay
+
+          msg := sprintf(
+            "catalog grew by %v hats in last 24h; max %v",
+            [count(recent), input.parameters.maxNewHatsPerDay],
+          )
+        }
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: HatMaxNew
+metadata:
+  name: hat-max-new-default
+spec:
+  match:
+    kinds:
+      - apiGroups: ["society.zeta.io"]
+        kinds: ["Hat"]
+  parameters:
+    maxNewHatsPerDay: 5

--- a/full-ai-cluster/k8s/applications/hat-system/policies/07-no-supervisor-cycles.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/07-no-supervisor-cycles.yaml
@@ -1,0 +1,67 @@
+# No supervisor cycles — Hat.spec.supervises forms a DAG. A cycle
+# (A supervises B supervises A) would let one wearer pair self-deal
+# revocations + probations. Reject Hat create/update if it would
+# create a cycle.
+
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: hatnocycle
+spec:
+  crd:
+    spec:
+      names:
+        kind: HatNoCycle
+      validation:
+        openAPIV3Schema:
+          type: object
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package hatnocycle
+
+        # Helper: is `target` reachable from `start` via supervises
+        # edges using the post-create catalog state?
+        reachable(start, target, catalog) {
+          some next
+          next := catalog[start].spec.supervises[_]
+          next == target
+        }
+        reachable(start, target, catalog) {
+          some next
+          next := catalog[start].spec.supervises[_]
+          reachable(next, target, catalog)
+        }
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Hat"
+          input.review.operation == "CREATE" or input.review.operation == "UPDATE"
+          new_hat := input.review.object
+          name := new_hat.metadata.name
+
+          # Build post-update catalog: existing hats with the new one
+          # overlaid on top.
+          existing := data.inventory.cluster["society.zeta.io/v1alpha1"]["Hat"]
+          catalog := object.union(existing, {name: new_hat})
+
+          # If anyone the new hat supervises (transitively) supervises
+          # the new hat back, that's a cycle.
+          some sup
+          sup := new_hat.spec.supervises[_]
+          reachable(sup, name, catalog)
+
+          msg := sprintf(
+            "supervisor cycle: hat %v would supervise %v which transitively supervises %v",
+            [name, sup, name],
+          )
+        }
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: HatNoCycle
+metadata:
+  name: hat-no-cycle-default
+spec:
+  match:
+    kinds:
+      - apiGroups: ["society.zeta.io"]
+        kinds: ["Hat"]

--- a/full-ai-cluster/k8s/applications/hat-system/queries/loki.md
+++ b/full-ai-cluster/k8s/applications/hat-system/queries/loki.md
@@ -1,0 +1,114 @@
+# Loki + Hubble queries — joining hats to network behavior
+
+The operator emits one structured log line per tick (event
+`hat.tick`) carrying:
+
+```json
+{
+  "msg": "hat.tick",
+  "hat": "executor",
+  "wearer.spiffeID": "spiffe://zeta.cluster/ns/orleans/sa/grain-worker",
+  "event": "SwapOn",
+  "reason": "BindingActive",
+  "throttle": "",
+  "occurredAt": "2026-05-25T13:42:17Z"
+}
+```
+
+Cilium / Hubble flow logs are tagged with the SPIFFE ID of the
+source pod (the Cilium SPIFFE integration ships this out of the
+box when the workload mounts a SVID). That gives us the join key:
+both sides agree on `spiffeID`.
+
+## Active wearers right now
+
+```logql
+{app="hat-system-operator"} |= "hat.tick"
+  | json
+  | event = "SwapOn" or event = "WarmupEnd"
+  | line_format "{{.hat}}\t{{.wearer_spiffeID}}\t{{.occurredAt}}"
+```
+
+## Recent throttle denials by throttle name
+
+```logql
+sum by (throttle) (
+  count_over_time(
+    {app="hat-system-operator"} |= "hat.tick"
+      | json
+      | event = "Throttled" [1h]
+  )
+)
+```
+
+## Network flows from a probationary wearer (Hubble Relay)
+
+```bash
+hubble observe \
+  --from-identity spiffe://zeta.cluster/ns/orleans/sa/grain-worker \
+  --since 5m -o json | jq 'select(.flow.verdict == "FORWARDED")'
+```
+
+## Joining swap stream to flow stream
+
+The operator's HatSwap CRs are the durable swap stream; Hubble
+flows are the durable network stream. Both carry SPIFFE IDs.
+
+For a wearer in Warmup, every flow logged between BoundAt and
+WarmupEndsAt should belong to the wearer's reduced-authority
+namespace set. The skeleton query:
+
+```bash
+# 1. Find current Warmup bindings.
+kubectl get hatbindings -A -o json \
+  | jq -r '.items[]
+      | select(.status.phase == "Warmup")
+      | [.spec.wearer.spiffeID,
+         .status.boundAt,
+         .status.warmupEndsAt] | @tsv'
+
+# 2. For each, ask Hubble whether any flow left the
+#    permitted namespaces during the window.
+while IFS=$'\t' read spiffe begin end; do
+  hubble observe \
+    --from-identity "$spiffe" \
+    --since "$begin" --until "$end" \
+    -o json \
+    | jq --arg s "$spiffe" \
+        'select(.flow.destination.namespace as $dst
+                | (["orleans","hindsight"] | index($dst)) == null)
+         | {wearer: $s, dst: .flow.destination.namespace,
+            verb: .flow.l4, time: .time}'
+done < <(...above command...)
+```
+
+## Sticky attribution lookup
+
+A flow tagged with SPIFFE ID `X` is attributed to the hat
+held by `X` at flow time — including the
+`stickyAttributionEndsAt` window after revocation.
+
+```bash
+# Given a flow at time T from SPIFFE ID X, find the hat:
+flow_time="2026-05-25T14:00:00Z"
+spiffe="spiffe://zeta.cluster/ns/orleans/sa/grain-worker"
+
+kubectl get hatswaps -A -o json | jq --arg t "$flow_time" --arg s "$spiffe" '
+  .items
+  | map(select(.spec.wearer.spiffeID == $s))
+  | map(select(.spec.occurredAt <= $t))
+  | sort_by(.spec.occurredAt) | last
+'
+```
+
+The last-swap-before-flow-time tells you which hat was on when
+the flow happened. Within the sticky window after a SwapOff
+event, attribute to the previous hat even if a new one has
+since bound — that's what the window exists to do.
+
+## Why use Loki + Hubble vs querying the operator directly
+
+The operator's HatSwap CRs are the authoritative truth, but
+joining them to network flows at scale is what Loki + Hubble
+do well. Pattern: query CRs for "what should be true," query
+Loki/Hubble for "what actually happened," and surface the diffs.


### PR DESCRIPTION
## Summary

Scaffolds `full-ai-cluster/k8s/applications/hat-system/` — a Kubernetes operator + CRDs + OPA policies implementing the hat / role distinction for the multi-agent society Max + Addison are building. 29 files; nothing else in the cluster changes.

**Hats are time-bounded roles with succession.** Wearers swap hats; the hat persists; reputation accumulates on the role. Cooldown + warmup + sticky-attribution + quorum on every binding — that's what keeps this hat-as-chosen-and-returnable instead of role-as-cage.

Compositions captured from the design conversation:

- **Max's mental model: `hat = skills + opa/rbac`.** Both first-class on `Hat.spec` (`skills` + `authority`).
- **Max's hierarchy framing: "hats not weight-free but supervisor graphs."** Captured via `Hat.spec.supervises` (DAG enforced by the `no-supervisor-cycles` OPA constraint).
- **Max's policy-authoring style: "talks in hat graphs."** `graph/render.go` emits Graphviz DOT of the live cluster's hat graph; README maps each throttle to its graph statement.
- **Aaron's reframe from cage → hat: time-boundedness is the difference.** README spells out the cage / hat property table.
- **CRD + operator = structured tick source.** Every state transition emits exactly one HatSwap (durable) + k8s Event + slog → Loki + NATS publish via `internal/tick/emitter.go`.

**Bootstrap-bottleneck answer:** `hat-designer` is itself a hat (quorum-gated, quorumSize 3, cooldown 1800s, conflictsWith `executor`). Multiple wearers can hold it; nobody is the SPOF.

## What's in the directory

| Path | What |
|------|------|
| `Application.yaml` | ArgoCD Application; reconciles everything below |
| `crds/` | Hat, HatBinding, HatSwap, HatPolicy (4 CRDs) |
| `hats/` | Seed: hat-designer, observer, executor, policy-admin + default HatPolicy |
| `policies/` | 7 OPA Gatekeeper ConstraintTemplates (cooldown, max-bindings, COI, quorum, warmup, max-new-hats, no-supervisor-cycles) |
| `operator/` | Go operator scaffold (kubebuilder layout — needs `kubebuilder init`) |
| `graph/` | Hat-graph DOT renderer + docs |
| `queries/` | Loki + Hubble query library for hat ↔ network-flow attribution |
| `deployment.yaml` | Operator Deployment (replicas:0 until image built) + RBAC |

## Sync gating

Deployment ships at `replicas: 0` so ArgoCD reports healthy while the operator image doesn't exist yet. CRDs, OPA policies, and seed hats are all live — `kubectl get hats` returns the catalog as soon as ArgoCD syncs. The build path for the operator image is documented in the top-level README.

## Test plan

- [ ] ArgoCD picks up `hat-system/Application.yaml` and reconciles
- [ ] All 4 CRDs install cleanly (`kubectl get crd | grep society.zeta.io` → 4 lines)
- [ ] All 7 OPA ConstraintTemplates install and Constraints become enforcing (Gatekeeper must be running first — it's already in the bootstrap manifests)
- [ ] Seed hats land and are listable (`kubectl get hats` → 4 lines: hat-designer, observer, executor, policy-admin)
- [ ] HatPolicy default singleton lands (`kubectl get hatpolicy default`)
- [ ] Deployment lands at 0/0 ready (expected until image built)
- [ ] `go run graph/render.go --out /tmp/h.dot` produces a parseable DOT file with the 4 seed hats as nodes
- [ ] Future PR: complete `kubebuilder init` + build image + bump replicas

## Intentional gaps (each = one follow-up PR)

- Validating webhook for HatBinding admission
- HatReconciler (reputation accumulation on swap-off)
- HatPolicyReconciler (status rollup)
- Finalizer flow for guaranteed SwapOff emission
- Mutating webhook for RequestedAt defaulting
- envtest harness
- CI image build + push

🤖 Generated with [Claude Code](https://claude.com/claude-code)