### PR TITLE
feat(ai-cluster): NFD + lstopo + zeta-install helper + cluster hardware inventory

### DIFF
--- a/full-ai-cluster/k8s/applications/node-feature-discovery/Application.yaml
+++ b/full-ai-cluster/k8s/applications/node-feature-discovery/Application.yaml
@@ -1,0 +1,104 @@
+# full-ai-cluster/k8s/applications/node-feature-discovery/Application.yaml
+#
+# Node Feature Discovery — labels every node with detailed hardware
+# features (CPU model, CPU features like AVX-512, PCI vendor presence,
+# kernel modules, system attributes, storage class). Composes with
+# `hwloc` / `lstopo` installed on every node via common.nix for the
+# visual NUMA/PCI/cache topology.
+#
+# Once running:
+#   kubectl get nodes --show-labels \
+#     | tr , '\n' | grep feature.node.kubernetes.io
+#
+# Then schedulers can target hardware with nodeAffinity instead of
+# the cluster maintainer having to hand-label every box. Examples:
+#
+#   # Schedule on NVIDIA-equipped nodes:
+#   nodeAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       nodeSelectorTerms:
+#         - matchExpressions:
+#             - key: feature.node.kubernetes.io/pci-10de.present
+#               operator: In
+#               values: ["true"]
+#
+#   # Or AVX-512-only workloads:
+#   nodeAffinity: ...
+#     - key: feature.node.kubernetes.io/cpu-cpuid.AVX512F
+#       operator: In
+#       values: ["true"]
+#
+# NFD upstream maintains the Helm chart at
+# https://kubernetes-sigs.github.io/node-feature-discovery/charts.
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: node-feature-discovery
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    chart: node-feature-discovery
+    targetRevision: 0.17.1
+    helm:
+      releaseName: nfd
+      valuesObject:
+        # NFD ships three components: master (deployment), worker
+        # (daemonset, runs on every node), and gc (cleans up labels
+        # for deleted nodes). All three on by default.
+        master:
+          replicaCount: 1   # bump to 2 for HA once we have 5+ nodes
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits:   { cpu: 500m, memory: 512Mi }
+
+        worker:
+          # Tolerate everything — workers need to discover features
+          # on control-plane and tainted GPU nodes alike.
+          tolerations:
+            - operator: Exists
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits:   { cpu: 200m, memory: 256Mi }
+          # Enable additional source plugins beyond the defaults.
+          # cpu / kernel / memory / network / pci / storage / system /
+          # usb are on by default; we explicitly turn on `local` for
+          # custom node-local labels via hooks if we add any later.
+          config:
+            sources:
+              pci:
+                deviceClassWhitelist:
+                  - "0200"  # network controllers
+                  - "03"    # display controllers (GPUs)
+                  - "0c80"  # NVMe sub-class
+                  - "12"    # processing accelerators
+                deviceLabelFields:
+                  - "vendor"
+                  - "device"
+                  - "class"
+
+        gc:
+          replicaCount: 1
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits:   { cpu: 200m, memory: 256Mi }
+
+        # NodeFeatureRule CRDs let you derive custom labels from raw
+        # features. Default rules cover the common stuff (GPU vendor
+        # detection from PCI IDs, etc.); per-cluster rules can be
+        # added in the same chart values block later.
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: node-feature-discovery
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -50,6 +50,10 @@
     git vim htop btop tmux ripgrep jq yq-go curl wget rsync tree
     file unzip iproute2 iputils dnsutils nmap tcpdump mtr
     pciutils usbutils lshw nvme-cli smartmontools lm_sensors
+    hwloc           # lstopo — NUMA/PCI/cache hierarchy diagrams;
+                    # composes with Node Feature Discovery for
+                    # precise per-node hardware inventory.
+    dmidecode
     skopeo
     kubectl kubernetes-helm k9s argocd
     cilium-cli hubble

--- a/full-ai-cluster/tools/cluster-inventory/README.md
+++ b/full-ai-cluster/tools/cluster-inventory/README.md
@@ -1,0 +1,132 @@
+# Cluster hardware inventory
+
+Two composing pieces give the cluster precise, queryable hardware
+inventory:
+
+| Component | Where it runs | Surface |
+|-----------|---------------|---------|
+| Node Feature Discovery (NFD) | every node, DaemonSet | `kubectl get nodes --show-labels` |
+| `hwloc` / `lstopo` | every node, baked into `common.nix` | XML / SVG diagrams |
+| `capture.sh` | maintainer laptop, on demand | `docs/cluster-hardware/<node>/` |
+
+## What you get from NFD (zero effort, automatic)
+
+NFD's worker DaemonSet labels every node with detailed hardware
+features. Query examples:
+
+```bash
+# Every NFD label on a node
+kubectl get node worker-gpu-01 --show-labels \
+  | tr , '\n' | grep feature.node.kubernetes.io
+
+# Find nodes with NVIDIA PCI vendor present
+kubectl get nodes -l feature.node.kubernetes.io/pci-10de.present=true
+
+# Find nodes with AVX-512
+kubectl get nodes -l feature.node.kubernetes.io/cpu-cpuid.AVX512F=true
+
+# Find nodes with non-rotational storage (SSD/NVMe)
+kubectl get nodes -l feature.node.kubernetes.io/storage-nonrotationaldisk=true
+```
+
+Then use these in workload nodeAffinity instead of hand-maintaining
+labels per host.
+
+## What you get from lstopo (visual + diffable)
+
+`lstopo` ships in `common.nix`, so every node has it. From any node:
+
+```bash
+lstopo                              # interactive curses view
+lstopo --of svg > /tmp/topo.svg     # diagram
+lstopo --of xml > /tmp/topo.xml     # canonical machine-readable
+```
+
+The XML is byte-stable for unchanged hardware — perfect for `git diff`
+to catch silent hardware changes (BIOS updates, GPU driver changes,
+disk replacements).
+
+## Capture inventory across all nodes
+
+Run from the maintainer machine when you want a point-in-time
+snapshot of every node:
+
+```bash
+full-ai-cluster/tools/cluster-inventory/capture.sh
+# or specific nodes:
+full-ai-cluster/tools/cluster-inventory/capture.sh worker-gpu-01 worker-gpu-02
+```
+
+Produces `full-ai-cluster/docs/cluster-hardware/<node>/`:
+
+- `nfd-labels.txt` — every NFD label on the node
+- `topology.xml` — `lstopo` XML output (the diff-stable canonical form)
+- `topology.svg` — same data rendered as a diagram (commit alongside)
+- `summary.md` — short human-readable header (CPU / RAM / PCI / network)
+
+Commit the directory to track hardware drift over time. Re-running
+the capture and committing the diff makes silent hardware changes
+visible in PR review.
+
+## How this composes with the rest of the cluster
+
+- **Hat system** can constrain hats by hardware: `hat.spec.authority`
+  could reference NFD labels via OPA constraints
+  (`feature.node.kubernetes.io/pci-10de.present` → "this hat needs a
+   GPU node")
+- **Longhorn** already uses our `zeta.io/longhorn-disks=N` label; NFD
+  adds the disk-type and capacity dimensions
+- **Disko shape** picks disk by `/dev/disk/by-id`; cluster-inventory
+  catches if a board's PCIe re-enumeration changes those mappings
+- **GPU operator** (when added) extends NFD's PCI labels with the
+  full GPU model + VRAM + CUDA driver + MIG capability set
+
+## Cross-platform rescue substrate (Paragon FS drivers)
+
+The maintainer's workstation fleet has Paragon's filesystem
+drivers installed end-to-end:
+
+| Host OS | Paragon driver | Reads + writes |
+|---------|----------------|----------------|
+| macOS | extFS for Mac + NTFS for Mac | ext2/3/4, NTFS |
+| Windows | ExtFS for Windows | ext2/3/4, btrfs (selected) |
+| Linux | (Paragon for Linux + native ntfs3) | NTFS |
+
+Net effect: any disk pulled from any cluster node mounts read+write
+on any maintainer machine, regardless of which OS the disk came
+from. No "wrong-host-OS, can't access" bottleneck — rescue flows
+in every direction.
+
+Use cases that change because of this:
+
+- **Failed node, healthy disk** — pull NVMe, mount on Mac, copy
+  off `/var/lib/longhorn-disk*` Longhorn replica data, ship to a
+  replacement node directly into the same mount point. Faster
+  than waiting for Longhorn cross-node re-replication on slow
+  networks.
+- **Forensic inspection** — mount the OS partition, grep
+  `/var/log` and `/etc/nixos/` without needing the node to be
+  bootable.
+- **Pre-stage material** — drop files onto the data partition
+  before first boot of a new box. Rare in normal operation
+  (External Secrets Operator handles secrets from Vault), but
+  the option exists for special cases.
+
+Caveats:
+
+- Paragon's driver writes through; don't mount a Longhorn replica
+  read-write while the source node is still alive and serving the
+  volume — split-brain risk. Mount read-only unless the source
+  node is confirmed offline.
+- The OS partition has `nix.settings.auto-optimise-store = true`
+  → many reflinked / hardlinked files in `/nix/store`. Paragon
+  honors hard links; use `rsync -aH` (not just `-a`) when copying.
+
+## Cadence
+
+No fixed cadence required — the artifacts are stable. Recommended:
+
+- Capture once after initial cluster bootstrap
+- Re-capture after any hardware change (drive replaced, GPU added,
+  RAM upgrade)
+- Re-capture quarterly to catch silent BIOS / firmware drift

--- a/full-ai-cluster/tools/cluster-inventory/capture.sh
+++ b/full-ai-cluster/tools/cluster-inventory/capture.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# full-ai-cluster/tools/cluster-inventory/capture.sh
+#
+# Capture precise hardware inventory of every cluster node into
+# `docs/cluster-hardware/<hostname>/`. Re-run periodically to
+# diff against prior captures (catch silent BIOS updates, GPU
+# driver bumps, disk replacements).
+#
+# Three artifacts per node:
+#
+#   topology.xml   — lstopo XML (NUMA / PCI / cache / GPU layout)
+#   topology.svg   — same data rendered as a diagram
+#   nfd-labels.txt — kubectl-derived NFD label set
+#   summary.md     — short human-readable summary
+#
+# Requires:
+#   - kubectl configured against the cluster
+#   - hwloc installed locally (for `lstopo --import topology.xml --of svg`)
+#   - NFD already running on the cluster
+#   - Either: nodes reachable via `kubectl debug node/<name>` (k8s 1.27+)
+#             OR ssh access to each node as the zeta user
+#
+# Usage:
+#   tools/cluster-inventory/capture.sh           # all nodes
+#   tools/cluster-inventory/capture.sh worker-gpu-01 worker-gpu-02
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+INVENTORY_ROOT="${REPO_ROOT}/full-ai-cluster/docs/cluster-hardware"
+mkdir -p "${INVENTORY_ROOT}"
+
+# Default to all nodes; allow per-node selection via argv.
+if [[ $# -gt 0 ]]; then
+  NODES=("$@")
+else
+  mapfile -t NODES < <(kubectl get nodes -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n')
+fi
+
+for node in "${NODES[@]}"; do
+  echo "=== ${node} ==="
+  out_dir="${INVENTORY_ROOT}/${node}"
+  mkdir -p "${out_dir}"
+
+  # 1. NFD labels — pulled straight from kubectl, no node access needed.
+  kubectl get node "${node}" \
+    --show-labels \
+    -o jsonpath='{.metadata.labels}' \
+    | tr ',' '\n' \
+    | grep '^"feature.node.kubernetes.io' \
+    > "${out_dir}/nfd-labels.txt" || true
+
+  # 2. lstopo via `kubectl debug` (k8s 1.27+). Drops a debug pod on
+  #    the node with hostPID + the hwloc image, runs lstopo, copies
+  #    out the XML. Cleans the debug pod immediately after.
+  #
+  #    If `kubectl debug` isn't available, fall back to SSH:
+  #      ssh -o StrictHostKeyChecking=no zeta@"${node}" lstopo --of xml \
+  #        > "${out_dir}/topology.xml"
+  if kubectl debug --help >/dev/null 2>&1; then
+    kubectl debug "node/${node}" \
+      --image=ghcr.io/open-mpi/hwloc:latest \
+      --quiet \
+      -- chroot /host lstopo --of xml \
+      > "${out_dir}/topology.xml" 2>/dev/null || {
+        echo "  kubectl debug failed; trying ssh fallback"
+        ssh -o StrictHostKeyChecking=no -o BatchMode=yes "zeta@${node}" \
+          'lstopo --of xml' > "${out_dir}/topology.xml"
+      }
+  else
+    ssh -o StrictHostKeyChecking=no -o BatchMode=yes "zeta@${node}" \
+      'lstopo --of xml' > "${out_dir}/topology.xml"
+  fi
+
+  # 3. Render the XML to SVG locally — small, diff-friendly, opens
+  #    in any browser. Keep the XML as the source of truth for diffs.
+  if command -v lstopo >/dev/null; then
+    lstopo --input "${out_dir}/topology.xml" --of svg \
+      > "${out_dir}/topology.svg" || true
+  fi
+
+  # 4. Short summary derived from NFD labels — what a human wants
+  #    to see at a glance.
+  {
+    echo "# ${node}"
+    echo
+    echo "Captured: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo
+    echo "## CPU"
+    grep -E 'cpu-model\.|cpu-cpuid\.' "${out_dir}/nfd-labels.txt" | head -10
+    echo
+    echo "## Memory + Storage"
+    grep -E 'memory-|storage-' "${out_dir}/nfd-labels.txt" | head -10
+    echo
+    echo "## PCI vendors present (top 10)"
+    grep 'pci-' "${out_dir}/nfd-labels.txt" | head -10
+    echo
+    echo "## Network"
+    grep 'network-' "${out_dir}/nfd-labels.txt" | head -10
+    echo
+    echo "See \`topology.svg\` for NUMA / PCI / cache hierarchy."
+  } > "${out_dir}/summary.md"
+
+  echo "  → ${out_dir}/"
+done
+
+echo
+echo "Done. Review + commit:"
+echo "  git diff --stat full-ai-cluster/docs/cluster-hardware/"
+echo "  git add full-ai-cluster/docs/cluster-hardware/"
+echo "  git commit -m 'chore(inventory): capture cluster hardware $(date +%Y-%m-%d)'"

--- a/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
+++ b/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
@@ -127,6 +127,9 @@
     lm_sensors
     nvme-cli
     hdparm
+    hwloc       # lstopo — visualize NUMA / PCI / cache hierarchy
+                # BEFORE install so disk-by-id picks + GPU socket
+                # assignments are informed by the real topology.
 
     # GPU detection (drivers come in per-host on installed system)
     glxinfo
@@ -167,6 +170,15 @@
     man-pages
     man-pages-posix
     tldr
+
+    # Guided install script — wipes both NVMes, partitions per the
+    # 2-NVMe shape, formats, mounts, clones Zeta, and runs
+    # nixos-install. Lives in the installer's PATH as `zeta-install`.
+    # Source lives at full-ai-cluster/usb-nixos-installer/bin/zeta-install
+    # in the repo and is baked into the ISO via the writeShellScriptBin
+    # below.
+    (writeShellScriptBin "zeta-install"
+      (builtins.readFile ../../zeta-install.sh))
   ];
 
   isoImage = {
@@ -186,18 +198,24 @@
     3. Bring up the network:
          nmtui                       # interactive, or
          nmcli device wifi connect <SSID> password <PSK>
-    4. Identify the target disk:
-         lsblk
-    5. Partition + mount /mnt as desired.
-    6. Generate hardware config:
+    4. (Optional) See the hardware topology:
+         lstopo                      # NUMA / PCI / GPU layout
+         lsblk -d -o NAME,SIZE,TRAN,MODEL,SERIAL
+
+    GUIDED INSTALL (2-NVMe machines):
+         zeta-install <host>         # e.g. zeta-install control-plane
+       Prompts for which disk is the boot disk, requires typed WIPE
+       confirmation, then partitions + formats + mounts + clones +
+       installs end-to-end. Use this for the standard 2-NVMe shape.
+
+    MANUAL INSTALL (other shapes, or recovery):
+         lsblk                                # pick disks
+         # partition + mkfs + mount /mnt manually
          nixos-generate-config --root /mnt
-    7. Clone the full cluster flake (or this minimal USB flake):
          git clone <git-url> /mnt/etc/zeta
-    8. Install:
          nixos-install --flake /mnt/etc/zeta/full-ai-cluster#<host>
-       or for USB-only:
-         nixos-install --flake /mnt/etc/zeta/usb-nixos-installer#installer
-    9. Reboot.
+
+    Reboot when done.
   '';
 
   system.stateVersion = "24.11";

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# zeta-install — guided 2-NVMe installer for the AI cluster.
+#
+# Lives on the USB at /run/current-system/sw/bin/zeta-install (installed
+# by the installer's configuration.nix). Walks through:
+#
+#   1. Show internal NVMe disks (USB excluded automatically)
+#   2. Confirm full wipe (typed confirmation required)
+#   3. Wipe both disks (wipefs + sgdisk --zap-all)
+#   4. Partition per the standard 2-NVMe shape
+#   5. Format + mount
+#   6. Clone Zeta + run nixos-install for the chosen host
+#
+# Use the cookie-cutter disko shape when the worktree carries it
+# (post PR #4950); otherwise falls back to the same partition layout
+# done manually so this script works against current main too.
+
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/Lucent-Financial-Group/Zeta}"
+HOST="${1:-}"
+
+bail() { echo "ERROR: $*" >&2; exit 1; }
+
+# ── Step 1: enumerate internal NVMes ─────────────────────────────
+echo "Internal NVMe disks:"
+mapfile -t NVMES < <(lsblk -d -p -n -o NAME,TRAN | awk '$2=="nvme"{print $1}')
+if [[ ${#NVMES[@]} -ne 2 ]]; then
+  bail "expected exactly 2 NVMes, found ${#NVMES[@]}: ${NVMES[*]:-none}"
+fi
+for d in "${NVMES[@]}"; do
+  size=$(lsblk -d -n -o SIZE "$d")
+  model=$(lsblk -d -n -o MODEL "$d" | tr -s ' ')
+  serial=$(lsblk -d -n -o SERIAL "$d")
+  echo "  $d  $size  $model  serial=$serial"
+done
+echo
+
+# ── Step 2: pick boot disk ───────────────────────────────────────
+if [[ -z "${BOOT_DISK:-}" ]]; then
+  read -rp "Which disk is the BOOT disk (gets OS + first Longhorn path)? [${NVMES[0]}]: " BOOT_DISK
+  BOOT_DISK="${BOOT_DISK:-${NVMES[0]}}"
+fi
+DATA_DISK=""
+for d in "${NVMES[@]}"; do [[ "$d" != "$BOOT_DISK" ]] && DATA_DISK="$d"; done
+[[ -n "$DATA_DISK" ]] || bail "could not pick data disk"
+
+echo
+echo "About to FULL-WIPE both disks:"
+echo "  Boot: $BOOT_DISK"
+echo "  Data: $DATA_DISK"
+echo
+read -rp "Type WIPE to confirm: " confirm
+[[ "$confirm" == "WIPE" ]] || bail "aborted"
+
+# ── Step 3: wipe ─────────────────────────────────────────────────
+for d in "$BOOT_DISK" "$DATA_DISK"; do
+  echo "Wiping $d ..."
+  sudo wipefs -af "$d"
+  sudo sgdisk --zap-all "$d"
+done
+
+# ── Step 4: partition ────────────────────────────────────────────
+ROOT_SIZE="${ROOT_SIZE:-256G}"
+echo "Partitioning $BOOT_DISK (ESP 1G + root ${ROOT_SIZE} + longhorn1 rest) ..."
+sudo sgdisk -n 1:0:+1G          -t 1:ef00 -c 1:ESP        "$BOOT_DISK"
+sudo sgdisk -n "2:0:+${ROOT_SIZE}" -t 2:8300 -c 2:root    "$BOOT_DISK"
+sudo sgdisk -n 3:0:0            -t 3:8300 -c 3:longhorn1  "$BOOT_DISK"
+
+echo "Partitioning $DATA_DISK (whole disk longhorn2) ..."
+sudo sgdisk -n 1:0:0 -t 1:8300 -c 1:longhorn2 "$DATA_DISK"
+
+sudo partprobe
+sleep 2
+
+# ── Step 5: format + mount ───────────────────────────────────────
+echo "Formatting ..."
+sudo mkfs.fat -F 32 -n boot "${BOOT_DISK}p1"
+sudo mkfs.ext4 -F -L nixos     "${BOOT_DISK}p2"
+sudo mkfs.ext4 -F -L longhorn1 "${BOOT_DISK}p3"
+sudo mkfs.ext4 -F -L longhorn2 "${DATA_DISK}p1"
+
+echo "Mounting ..."
+sudo mount "${BOOT_DISK}p2" /mnt
+sudo mkdir -p /mnt/boot /mnt/var/lib/longhorn-disk1 /mnt/var/lib/longhorn-disk2
+sudo mount "${BOOT_DISK}p1" /mnt/boot
+sudo mount "${BOOT_DISK}p3" /mnt/var/lib/longhorn-disk1
+sudo mount "${DATA_DISK}p1" /mnt/var/lib/longhorn-disk2
+
+# ── Step 6: clone + install ──────────────────────────────────────
+if [[ -z "$HOST" ]]; then
+  read -rp "Flake host attribute to install [control-plane]: " HOST
+  HOST="${HOST:-control-plane}"
+fi
+
+echo "Cloning $REPO_URL ..."
+sudo git clone "$REPO_URL" /mnt/etc/zeta
+
+echo "Generating hardware-configuration.nix ..."
+sudo nixos-generate-config --root /mnt --force
+
+echo "Running nixos-install --flake /mnt/etc/zeta/full-ai-cluster#$HOST ..."
+sudo nixos-install --flake "/mnt/etc/zeta/full-ai-cluster#$HOST" --no-root-password
+
+echo
+echo "Install complete. \`reboot\` when ready."


### PR DESCRIPTION
## Summary

Adds precise hardware mapping (kubectl-queryable + visual diagrams), a guided install script baked into the USB ISO, and a cross-platform rescue/inventory workflow. Four composing pieces, one PR.

## What lands

1. **Node Feature Discovery (NFD)** — `k8s/applications/node-feature-discovery/Application.yaml`. Labels every node with detailed hardware features (CPU model, AVX-512 and friends, PCI vendors, kernel modules, storage class). Upstream `kubernetes-sigs/node-feature-discovery` Helm chart. Workers tolerate everything so they discover on control-plane + tainted GPU nodes alike. PCI source plugin tuned to whitelist network/display/NVMe/accelerator classes.

2. **hwloc / lstopo on every node** — added to `common.nix` so every cluster host has the topology tool; also added to the USB installer ISO so the operator can inspect NUMA / PCI / GPU layout BEFORE picking disk-by-id paths. NFD labels are kubectl-queryable; lstopo XML is diff-stable for catching silent hardware drift.

3. **`tools/cluster-inventory/`** — `capture.sh` pulls NFD labels + lstopo XML from every node (via `kubectl debug`, with ssh fallback), renders SVG diagrams, lands artifacts under `docs/cluster-hardware/<node>/`. README documents query patterns, **cross-platform rescue substrate via Paragon FS drivers** (any cluster disk mounts read+write on any maintainer machine — Mac, Windows, or Linux), and recommended cadence.

4. **`zeta-install` guided installer** — baked into the USB ISO via `writeShellScriptBin`. Walks through: enumerate internal NVMes, confirm boot disk, type WIPE to confirm, wipe + partition + format + mount per the 2-NVMe shape, clone Zeta, run `nixos-install` for the chosen host. `/etc/zeta-install.md` runbook updated to point at it as the default path.

## Why this composes well

- **NFD + lstopo** = full visibility. NFD gives you scheduler-targetable labels; lstopo gives you the precise NUMA/PCI diagram. Combine them in `capture.sh` for diffable hardware inventory.
- **zeta-install + PR #4950 disko cookie-cutter** are alternative paths to the same disk layout. zeta-install does the imperative `sgdisk` sequence; the disko module does it declaratively. Operator picks based on what they want — both end on identical partitioning.
- **Paragon FS drivers** are operational substrate the maintainer already has — documenting the rescue paths makes "pull a disk, mount on Mac/Windows, recover" a normal-Tuesday operation rather than a Linux-rescue-host expedition.

## Test plan

- [ ] `nix build .#installer-iso` succeeds with disko + hwloc + zeta-install baked in
- [ ] On a USB-booted system: `which zeta-install` resolves; `zeta-install --help` (or running it) shows the prompts
- [ ] On the cluster after ArgoCD reconciles: `kubectl -n node-feature-discovery get pods` shows master + worker DaemonSet + gc
- [ ] `kubectl get nodes --show-labels | grep feature.node.kubernetes.io` shows hardware labels
- [ ] `lstopo` runs on any node and produces sensible NUMA/PCI output
- [ ] `tools/cluster-inventory/capture.sh` runs end-to-end and produces `docs/cluster-hardware/<node>/` artifacts

## Notes

- `zeta-install.sh` lives at the installer's root (not `bin/`) because the root `.gitignore` blocks `bin/` globally for .NET build outputs. `configuration.nix` `readFile` path matches.
- `worker: tolerations: [{operator: Exists}]` for NFD is intentional — NFD is observability infrastructure; should run everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)