### PR TITLE
feat(ai-cluster): local dev cluster via k3d + ArgoCD sync-wave dependency graph

### DIFF
--- a/full-ai-cluster/dev-cluster/DOCKER-DESKTOP.md
+++ b/full-ai-cluster/dev-cluster/DOCKER-DESKTOP.md
@@ -1,0 +1,128 @@
+# Docker Desktop settings for the dev cluster
+
+The dev cluster (`./up.sh`) runs a 3-node K3S cluster inside
+Docker — k3d uses Docker containers AS the K8s nodes. Plus
+Cilium, ArgoCD, NFD, hat-system, and ~25 other Applications.
+Docker Desktop's default resource allocation isn't enough; the
+cluster will OOM or thrash if you don't bump it.
+
+## Resource sizing (GUI — Docker Desktop → Settings → Resources)
+
+| Setting | Default | Recommended for this cluster |
+|---------|---------|------------------------------|
+| CPUs | 2 | **6** (4 minimum if your Mac is constrained) |
+| Memory | 8 GB | **16 GB** (12 GB minimum) |
+| Swap | 1 GB | leave at default |
+| Virtual disk limit | 64 GB | **128 GB** (containers + images + volumes) |
+
+If you have an M1/M2/M3/M4 Pro or Max, push CPU + memory higher.
+The Cilium agent alone wants ~512 MB per node × 3 nodes; ArgoCD
++ controllers + workloads adds up fast.
+
+## Kubernetes toggle: OFF
+
+Docker Desktop ships its own Kubernetes (`Settings → Kubernetes →
+Enable Kubernetes`). **Turn this OFF**. We use k3d, which creates
+its own clusters as Docker containers. Having Docker Desktop's K8s
+on as well creates a competing context and confuses kubectl.
+
+If it's already enabled, disable it + click "Reset Kubernetes
+Cluster" to clean up.
+
+## File sharing: defaults are fine
+
+K3d doesn't need any host paths mounted into the cluster. The
+default file-sharing settings (typically `/Users`, `/Volumes`,
+`/private`, `/tmp`, `/var/folders`) are fine.
+
+## Network: defaults are fine
+
+K3d creates a named Docker network (`zeta-dev` per
+`k3d-config.yaml`) and manages its own bridge. Docker Desktop's
+default network settings work without changes.
+
+## CLI-able things
+
+A few Docker config items CAN be set via CLI / file edit without
+the GUI:
+
+### Registry mirrors (for faster pulls)
+
+If your network has slow access to `ghcr.io` / `docker.io`, add
+a mirror via `~/.docker/daemon.json`:
+
+```json
+{
+  "registry-mirrors": [
+    "https://your-mirror.example.com"
+  ]
+}
+```
+
+Restart Docker Desktop after editing.
+
+### Docker contexts (multiple Docker engines)
+
+If you run Docker on a remote machine sometimes (e.g., the
+bare-metal cluster's node) and want to talk to it from your Mac:
+
+```bash
+docker context create remote --docker host=ssh://zeta@worker-gpu-01
+docker context use remote     # switch to remote
+docker context use default    # switch back to local Desktop
+```
+
+This is how the dev cluster pattern extends to the bare-metal
+cluster — same `docker` CLI, different context.
+
+### buildx for multi-arch builds
+
+The dev cluster runs on the Mac (ARM64 on Apple Silicon); the
+bare-metal cluster is x86_64. Multi-arch image builds via buildx:
+
+```bash
+docker buildx create --name multiarch --use
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t k3d-zeta-dev-registry:5000/my-app:dev --push .
+```
+
+## Verify after configuration
+
+```bash
+docker info | grep -E 'CPUs|Memory|Storage Driver'
+# Expect: CPUs >= 4, Memory >= 12GiB
+
+docker network ls            # before ./up.sh: just defaults
+# After ./up.sh:             zeta-dev          bridge    local
+```
+
+## When things go sideways
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `./up.sh` hangs at Cilium install | Resource starvation | Bump CPU/memory in Docker Desktop |
+| ArgoCD apps stuck in Progressing | Same as above | Same as above |
+| `kubectl get pods -A` shows lots of Pending | Resource starvation | Same as above |
+| `docker ps` shows containers exiting | OOM | Bump memory, drop a node from k3d-config (`agents: 1`) |
+| Slow image pulls | Network or no registry mirror | Configure registry mirror above |
+| "context k3d-zeta-dev not found" | k3d cluster gone | Run `./up.sh` again |
+| Docker Desktop won't start | Various | `~/Library/Containers/com.docker.docker → Logs/` |
+
+## Treating Docker as shared substrate
+
+This config doc represents the maintainer-collaborative stance —
+Docker Desktop on the workstation is a shared resource between
+"agent doing dev cluster work" and "human running other Docker
+workloads." Settings here cover the dev-cluster need; if other
+workloads have conflicting needs (e.g., a tight memory limit for
+testing), the dev cluster's `k3d-config.yaml` can scale agents
+down to fit:
+
+```yaml
+# k3d-config.yaml
+agents: 1   # instead of 2, halves the memory pressure
+```
+
+Single-node dev still reconciles the App-of-Apps correctly; just
+less multi-node behavior to observe (Longhorn replica placement,
+NFD-per-node labels, ArgoCD nodeAffinity scheduling).

--- a/full-ai-cluster/dev-cluster/DOCKER-DESKTOP.md
+++ b/full-ai-cluster/dev-cluster/DOCKER-DESKTOP.md
@@ -16,8 +16,8 @@ cluster will OOM or thrash if you don't bump it.
 | Virtual disk limit | 64 GB | **128 GB** (containers + images + volumes) |
 
 If you have an M1/M2/M3/M4 Pro or Max, push CPU + memory higher.
-The Cilium agent alone wants ~512 MB per node × 3 nodes; ArgoCD
-+ controllers + workloads adds up fast.
+The Cilium agent alone wants ~512 MB per node × 3 nodes; add
+ArgoCD, its controllers, and the rest of the workloads on top.
 
 ## Kubernetes toggle: OFF
 

--- a/full-ai-cluster/dev-cluster/README.md
+++ b/full-ai-cluster/dev-cluster/README.md
@@ -52,7 +52,10 @@ cd full-ai-cluster/dev-cluster
 kubectl -n argocd get applications -w
 
 # Open the UI
-kubectl -n argocd port-forward svc/argocd-server 8443:443 &
+# k3d-config.yaml already publishes the cluster's load-balancer on
+# host port 8443 → 443. The LoadBalancer Service ArgoCD's chart
+# requests gets picked up by k3d's bundled klipper-LB and surfaces
+# through that mapping — no kubectl port-forward needed.
 kubectl -n argocd get secret argocd-initial-admin-secret \
   -o jsonpath='{.data.password}' | base64 -d ; echo
 open https://localhost:8443

--- a/full-ai-cluster/dev-cluster/README.md
+++ b/full-ai-cluster/dev-cluster/README.md
@@ -1,0 +1,133 @@
+# Dev cluster — local k3d parity with prod
+
+The bare-metal AI cluster (`nixos/hosts/*`) and the dev cluster
+here run the **same workloads from the same git ref** via
+ArgoCD. The substrate of the cluster is the same; only the
+shape differs.
+
+## Why this works
+
+ArgoCD reads `full-ai-cluster/k8s/applications/` as an App-of-Apps,
+recursively. The dev cluster runs ArgoCD configured against the
+same path. Every workload reconciles into both clusters
+identically — Cilium, NFD, hat-system, OPA Gatekeeper, Vault,
+SPIRE, cert-manager, Trust Manager, External Secrets, ArgoCD
+itself if you bootstrap-in-place.
+
+What differs between dev and prod:
+
+| | Dev (k3d) | Prod (NixOS bare-metal) |
+|--|-----------|-------------------------|
+| Substrate | Docker containers as "nodes" | Physical machines |
+| Node count | 1 server + 2 agents | 1+ control-plane + N workers |
+| CNI | Cilium (kube-proxy replacement) | Cilium (same) |
+| Storage | local-path-provisioner | Longhorn (multi-disk) |
+| GPU | none | NVIDIA / AMD / Intel |
+| Identity | SPIRE (same chart) | SPIRE (same chart) |
+| Secrets | Vault (in-cluster dev mode) | Vault (HA + Sealed Secrets) |
+| Network MTU | Docker default | Real NIC MTU |
+| Persistence | Lost on `./down.sh` | Across reboots |
+
+Apps that don't make sense in dev are excluded by the root
+App-of-Apps `exclude:` glob in `up.sh`:
+
+- `longhorn/**` — no second NVMe to back it; local-path-provisioner
+  handles PVCs in dev
+- `ollama/**`, `vllm/**`, `deepseek-coder/**`, `qwen-coder/**` — no
+  GPU. Remove from the exclude list if you have an Apple Silicon
+  Mac + a model server that runs on MPS (vLLM nightly does).
+
+## Bring it up
+
+```bash
+# Pre-requirements (one-time):
+brew install k3d kubectl helm
+# + Docker Desktop or Colima
+
+cd full-ai-cluster/dev-cluster
+./up.sh                       # main branch
+./up.sh feat/my-pr-2026-05-25 # dev-test a PR before merging
+
+# Watch reconciliation
+kubectl -n argocd get applications -w
+
+# Open the UI
+kubectl -n argocd port-forward svc/argocd-server 8443:443 &
+kubectl -n argocd get secret argocd-initial-admin-secret \
+  -o jsonpath='{.data.password}' | base64 -d ; echo
+open https://localhost:8443
+```
+
+## Tear down
+
+```bash
+./down.sh
+```
+
+Removes the cluster, the registry, and clears the kubectl context.
+Idempotent — safe to re-run.
+
+## Multiple dev clusters at once
+
+Docker Desktop's multi-cluster support means you can run multiple
+k3d clusters in parallel. Adjust `metadata.name` and the
+`hostPort` for the registry + load-balancer ports in
+`k3d-config.yaml`, then `up.sh` against a copy of the config.
+Pattern: per-PR dev clusters for parallel dev-testing.
+
+## Pushing dev images
+
+The k3d cluster comes with a local Docker registry at
+`localhost:5000` (in-cluster: `k3d-zeta-dev-registry:5000`).
+Auto-trusted by K3S. Workflow for a dev iteration of any in-repo
+image:
+
+```bash
+docker build -t k3d-zeta-dev-registry:5000/my-app:dev .
+docker push k3d-zeta-dev-registry:5000/my-app:dev
+
+# Reference in your Application:
+image: k3d-zeta-dev-registry:5000/my-app:dev
+```
+
+## What this composes with
+
+- **`zeta-install` on the bare-metal install path** — same
+  workloads on both substrates means the same `Application.yaml`
+  files end up reconciling on both. Dev-test a chart change
+  here, then ship; prod ArgoCD picks it up automatically.
+- **NFD + lstopo (PR #4951)** — runs identically in dev. NFD
+  labels are still present; lstopo on dev nodes shows the
+  k3d container's view of the underlying Mac topology.
+- **disko cookie-cutter (PR #4950)** — bare-metal-only by
+  design. Dev cluster bypasses disko (containers don't have
+  block devices to partition).
+- **hat-system operator (PR #4930)** — runs in dev exactly as
+  in prod. Use the dev cluster to dev-test hat / hat-binding
+  CRDs and OPA throttle constraints before they hit prod.
+
+## Multi-cluster ArgoCD pattern (future)
+
+When the bare-metal cluster comes up, register it as a second
+destination on the same ArgoCD (or run ArgoCD on the bare-metal
+cluster and have dev's ArgoCD federate). The directory layout
+already supports it via ApplicationSets:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+spec:
+  generators:
+    - clusters: {}
+  template:
+    spec:
+      source:
+        path: full-ai-cluster/k8s/applications
+      destination:
+        server: '{{server}}'
+        # ...
+```
+
+Same git ref, multiple destinations. The dev/prod parity stays
+clean because the spec carries no environment-specific bits;
+overlays handle that.

--- a/full-ai-cluster/dev-cluster/SYNC-WAVES.md
+++ b/full-ai-cluster/dev-cluster/SYNC-WAVES.md
@@ -1,0 +1,124 @@
+# ArgoCD sync waves — App-of-Apps dependency ordering
+
+ArgoCD reconciles all Applications under the root App-of-Apps
+in parallel by default. That breaks for apps with cross-app
+dependencies (e.g., a workload needs Vault before it can pull
+its secret, or needs the hat-system CRDs before its HatBindings
+can be created).
+
+Solution: per-app `argocd.argoproj.io/sync-wave` annotation on
+each `Application.yaml`. Lower waves reconcile first.
+
+## The dependency graph
+
+```
+Bootstrap (K3S manifests, BEFORE ArgoCD takes over):
+  Cilium → cert-manager → Vault → SPIRE → Trust Manager → ESO → ArgoCD
+
+ArgoCD App-of-Apps (after ArgoCD is up):
+
+  Wave -90  argocd                    self-management
+  Wave -80  cilium                    adopt CNI (already running from bootstrap)
+  Wave -70  cert-manager              adopt (already running from bootstrap)
+  Wave -60  vault                     adopt (already running from bootstrap)
+  Wave -50  spire                     adopt (already running from bootstrap)
+  Wave -45  trust-manager             adopt (already running from bootstrap)
+  Wave -40  external-secrets          adopt; ESO consumes Vault + cert-manager
+  Wave -30  sealed-secrets            secrets layer co-equal with ESO
+  Wave -25  open-policy-agent         OPA Gatekeeper — must precede any app with constraints
+  Wave -20  node-feature-discovery    labels nodes; other apps can targetAffinity off NFD labels
+  Wave -15  longhorn                  storage class — must precede any PVC user
+  Wave -10  hat-system                CRDs must exist before any HatBinding-creating workload
+  Wave   0  kube-prometheus-stack     observability core (default wave)
+  Wave   0  loki / mimir / tempo / alloy   observability data planes
+  Wave   0  argo-rollouts / argo-workflows
+  Wave   0  nats / redis / cockroachdb / weaviate     data planes
+  Wave   0  dapr                      runtime
+  Wave   0  oz                        OpenZiti overlay
+  Wave  10  hindsight                 needs PostgreSQL (bundled) + Vault secret for LLM key
+  Wave  10  orleans                   needs CockroachDB + NATS up
+  Wave  10  temporal                  needs CockroachDB up
+  Wave  20  hermes                    needs Vault secret for LLM key + Hindsight + OZ + Orleans
+  Wave  30  gitlab / forgejo          source-of-truth services; come up last so all dependent
+                                       observability + storage is ready
+  Wave  50  ollama / vllm / deepseek-coder / qwen-coder   GPU model servers; manual-sync-only
+                                       in default config — these waves apply when enabled
+```
+
+## Why this order
+
+- **Self-management first**: a broken ArgoCD upgrade fails fast,
+  before downstream apps get half-reconciled by a degraded ArgoCD.
+- **Foundation second** (CNI, cert-manager, Vault, SPIRE, Trust
+  Manager, ESO): everything else depends on these. They were
+  already installed by the K3S bootstrap manifests; the App-of-Apps
+  ADOPTS them (chart-managed from here forward).
+- **Gatekeeper before workloads**: OPA constraints applied to a
+  resource that landed BEFORE the constraint do nothing. Land
+  policies first, then workloads.
+- **Hat-system CRDs early**: any future workload may want to declare
+  HatBindings or be subject to Hat-related policies. CRDs need to
+  exist when the workload reconciles.
+- **Data planes before consumers**: CockroachDB / NATS / Redis /
+  Weaviate / PostgreSQL must be Ready before apps that connect.
+- **Apps with secret dependencies late**: Hermes pulls the LLM API
+  key from Vault via ESO. ESO must have synced the secret to a
+  k8s Secret object before Hermes pods start. Sync wave gives ESO
+  a head start.
+- **Source-of-truth services last**: GitLab + Forgejo (mutually
+  exclusive, only one default-on) should come up after everything
+  observability / storage / runtime is ready, so first-boot
+  health-checks succeed.
+- **GPU model servers manually**: `automated:` removed from the
+  Application specs for Ollama / vLLM / deepseek-coder / qwen-coder.
+  Sync wave applies if a maintainer enables automated sync per-host
+  but the default is OFF — these need explicit `argocd app sync`.
+
+## What about cycles
+
+There are no cycles in this graph (verified by walking the edges
+above). If one shows up — e.g., a workload claims to depend on
+something that depends back — that's a design bug. Resolve by
+either:
+
+1. Splitting the workload into two (the part that doesn't depend
+   on the back-edge lands earlier)
+2. Adding a stub / mock for the back-edge that lets bootstrap
+   complete, then promoting it to the real thing in a later wave
+
+## How to add a new app
+
+In your new `Application.yaml`:
+
+```yaml
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"   # pick wave per the table above
+```
+
+Picking the wave:
+
+- Pure standalone (no other-app deps) → wave 0
+- Adds CRDs other apps use → wave -10 to -20
+- Consumes Vault secrets via ESO → wave 10
+- Consumes another in-cluster service that itself has wave 0 → wave 10
+- Bootstrap-foundation adopting an already-running thing → wave -50 to -90
+- Source-of-truth (GitLab/Forgejo class) → wave 30
+- GPU model server → wave 50 + manual sync only
+
+If unsure, default to 0 and adjust if reconciliation gets stuck.
+
+## What ArgoCD actually does with waves
+
+Within a single Application's resources, sync-waves order CRDs /
+namespaces / RBAC before workloads. ACROSS Applications under an
+App-of-Apps, the SAME annotation on each child Application
+orders the children. Lower wave reconciles first; higher waves
+wait until the prior wave's resources are Healthy.
+
+A wave that contains an unhealthy resource blocks all higher
+waves until it recovers or the operator manually intervenes
+(`argocd app sync <name>` with `--retry-limit 0`).
+
+This is what makes dev/prod parity reliable: same Applications,
+same waves, same reconciliation order on both substrates.

--- a/full-ai-cluster/dev-cluster/down.sh
+++ b/full-ai-cluster/dev-cluster/down.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# full-ai-cluster/dev-cluster/down.sh
+#
+# Tear down the local dev cluster + its registry. Idempotent.
+
+set -euo pipefail
+
+if k3d cluster list 2>/dev/null | grep -q '^zeta-dev '; then
+  echo "Deleting k3d cluster zeta-dev ..."
+  k3d cluster delete zeta-dev
+fi
+
+if k3d registry list 2>/dev/null | grep -q '^k3d-zeta-dev-registry '; then
+  echo "Deleting k3d registry zeta-dev-registry ..."
+  k3d registry delete zeta-dev-registry || true
+fi
+
+# kubectl context cleanup — k3d removes its own context on cluster
+# delete but the kubeconfig file may carry stale current-context.
+if kubectl config current-context 2>/dev/null | grep -q '^k3d-zeta-dev$'; then
+  kubectl config unset current-context || true
+fi
+
+echo "Dev cluster torn down."

--- a/full-ai-cluster/dev-cluster/k3d-config.yaml
+++ b/full-ai-cluster/dev-cluster/k3d-config.yaml
@@ -15,11 +15,11 @@
 #
 # Why this matches prod: ArgoCD reconciles the SAME
 # `k8s/applications/` directory into both clusters. The only
-# environment-specific deltas live under `dev-cluster/overlays/`
-# (e.g., Longhorn replaced by local-path-provisioner; GPU
-# device plugin disabled). Everything else — Cilium, ArgoCD,
-# NFD, hat-system, OPA, Vault, SPIRE, cert-manager — runs the
-# same code on both substrates.
+# environment-specific deltas live in up.sh's root App-of-Apps
+# `exclude:` glob (cilium installed directly via Helm with dev
+# values; Longhorn → local-path-provisioner; no GPU stack).
+# Everything else — ArgoCD, NFD, hat-system, OPA, Vault, SPIRE,
+# cert-manager — runs the same code on both substrates.
 #
 # Usage: `./up.sh` (it reads this file).
 # Docs: https://k3d.io/v5/usage/configfile/
@@ -52,8 +52,9 @@ ports:
     nodeFilters: [loadbalancer]
 
 # K3S server args — mirror prod's CNI-takeover stance so Cilium can
-# install cleanly. `--write-kubeconfig-mode=644` so non-root users
-# on the host can `kubectl` without sudo.
+# install cleanly. Host kubeconfig perms are handled by k3d itself
+# (writes to ~/.kube/config when `kubeconfig.updateDefaultKubeconfig`
+# is true below); no extra --write-kubeconfig-mode flag needed.
 options:
   k3s:
     extraArgs:

--- a/full-ai-cluster/dev-cluster/k3d-config.yaml
+++ b/full-ai-cluster/dev-cluster/k3d-config.yaml
@@ -1,0 +1,79 @@
+# full-ai-cluster/dev-cluster/k3d-config.yaml
+#
+# k3d cluster config for local dev/test. Brings up a 1-server +
+# 2-agent K3S cluster inside Docker that mirrors the bare-metal
+# prod cluster's substrate as closely as possible:
+#
+#   - K3S server with the same CNI-takeover flags as prod
+#     (--flannel-backend=none --disable-kube-proxy
+#      --disable-network-policy --disable=traefik)
+#   - Two agents so multi-node behavior (Longhorn replicas,
+#     ArgoCD reconciliation, NFD daemonsets) is observable
+#   - A local registry so dev container images don't round-trip
+#     to ghcr.io for every push
+#   - Port forwards so ArgoCD UI is reachable at localhost:8443
+#
+# Why this matches prod: ArgoCD reconciles the SAME
+# `k8s/applications/` directory into both clusters. The only
+# environment-specific deltas live under `dev-cluster/overlays/`
+# (e.g., Longhorn replaced by local-path-provisioner; GPU
+# device plugin disabled). Everything else — Cilium, ArgoCD,
+# NFD, hat-system, OPA, Vault, SPIRE, cert-manager — runs the
+# same code on both substrates.
+#
+# Usage: `./up.sh` (it reads this file).
+# Docs: https://k3d.io/v5/usage/configfile/
+
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: zeta-dev
+
+servers: 1
+agents: 2
+
+image: rancher/k3s:v1.31.2-k3s1
+
+network: zeta-dev   # named docker network so cilium can reach pods
+
+# Local registry — k3d auto-configures K3S to trust it. Push dev
+# images via: docker tag X k3d-zeta-dev-registry:5000/X && docker push
+registries:
+  create:
+    name: zeta-dev-registry
+    host: "0.0.0.0"
+    hostPort: "5000"
+
+# Port forwards: ArgoCD UI + an HTTPS port for ingress experimentation.
+ports:
+  - port: "8443:443"
+    nodeFilters: [loadbalancer]
+  - port: "8080:80"
+    nodeFilters: [loadbalancer]
+
+# K3S server args — mirror prod's CNI-takeover stance so Cilium can
+# install cleanly. `--write-kubeconfig-mode=644` so non-root users
+# on the host can `kubectl` without sudo.
+options:
+  k3s:
+    extraArgs:
+      # Disable bundled CNI / kube-proxy / network-policy — Cilium
+      # takes all three.
+      - arg: --flannel-backend=none
+        nodeFilters: [server:*]
+      - arg: --disable-kube-proxy
+        nodeFilters: [server:*]
+      - arg: --disable-network-policy
+        nodeFilters: [server:*]
+      # Skip the bundled HelmChart-Traefik install; ArgoCD ships
+      # its own ingress story (we use Cilium Gateway API in prod).
+      - arg: --disable=traefik
+        nodeFilters: [server:*]
+      # Node labels so workloads can target the dev cluster:
+      - arg: --node-label=zeta.io/env=dev
+        nodeFilters: [all]
+      - arg: --node-label=zeta.io/substrate=k3d
+        nodeFilters: [all]
+  kubeconfig:
+    updateDefaultKubeconfig: true
+    switchCurrentContext: true

--- a/full-ai-cluster/dev-cluster/up.sh
+++ b/full-ai-cluster/dev-cluster/up.sh
@@ -99,10 +99,19 @@ spec:
     directory:
       recurse: true
       include: '{*/Application.yaml,Application.yaml}'
-      # Skip apps that don't belong in dev (GPU stack, Longhorn).
-      # These reconcile in prod but are excluded here via the
-      # exclude glob.
-      exclude: '{longhorn/**,ollama/**,vllm/**,deepseek-coder/**,qwen-coder/**}'
+      # Skip apps that don't belong in dev:
+      #   cilium/**  — up.sh already installed Cilium directly via
+      #                Helm with dev-cluster-specific values
+      #                (kubeProxyReplacement, k3d-zeta-dev API host).
+      #                The cilium/Application.yaml under
+      #                k8s/applications/ targets PROD config
+      #                (k8sServiceHost: control-plane.zeta.local) and
+      #                would clobber the dev install.
+      #   longhorn/** — no second NVMe to replicate to in dev;
+      #                local-path-provisioner handles PVCs.
+      #   ollama / vllm / deepseek-coder / qwen-coder — GPU stack;
+      #                no GPUs on the Mac (or on CI runners).
+      exclude: '{cilium/**,longhorn/**,ollama/**,vllm/**,deepseek-coder/**,qwen-coder/**}'
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/full-ai-cluster/dev-cluster/up.sh
+++ b/full-ai-cluster/dev-cluster/up.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# full-ai-cluster/dev-cluster/up.sh
+#
+# Bring up the local dev cluster end-to-end:
+#   1. Create the k3d cluster from k3d-config.yaml
+#   2. Install Cilium (the chicken-and-egg CNI from prod's bootstrap)
+#   3. Install ArgoCD
+#   4. Apply the root App-of-Apps pointing at this repo's
+#      k8s/applications/ directory
+#
+# After this completes, ArgoCD reconciles the SAME workloads it
+# would in prod, with two exceptions noted in the dev-overlays
+# section of README.md (no Longhorn, no GPU device plugin).
+#
+# Usage: ./up.sh [git-ref]
+#
+# git-ref defaults to `main`. Pass a PR branch to dev-test before
+# merging:
+#   ./up.sh feat/my-branch-2026-05-25
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GIT_REF="${1:-main}"
+
+# ── Pre-flight ────────────────────────────────────────────────
+for cmd in docker k3d kubectl helm; do
+  command -v "$cmd" >/dev/null || {
+    echo "ERROR: $cmd not found. Install with:"
+    case "$cmd" in
+      docker) echo "  Docker Desktop or Colima (https://docs.docker.com/desktop/install/mac-install/)" ;;
+      k3d)    echo "  brew install k3d" ;;
+      kubectl) echo "  brew install kubectl" ;;
+      helm)   echo "  brew install helm" ;;
+    esac
+    exit 1
+  }
+done
+
+# ── Step 1: k3d cluster ───────────────────────────────────────
+if k3d cluster list 2>/dev/null | grep -q '^zeta-dev '; then
+  echo "Cluster zeta-dev already exists. Use ./down.sh to recreate."
+else
+  echo "Creating k3d cluster zeta-dev ..."
+  k3d cluster create --config "${SCRIPT_DIR}/k3d-config.yaml"
+fi
+
+kubectl config use-context k3d-zeta-dev
+
+# ── Step 2: Cilium CNI (chicken-and-egg — without this, no pods
+# schedule because flannel/kube-proxy are disabled) ───────────
+if ! kubectl -n kube-system get ds cilium >/dev/null 2>&1; then
+  echo "Installing Cilium ..."
+  helm repo add cilium https://helm.cilium.io >/dev/null 2>&1 || true
+  helm repo update cilium >/dev/null
+  helm install cilium cilium/cilium \
+    --version 1.16.4 \
+    --namespace kube-system \
+    --set kubeProxyReplacement=true \
+    --set k8sServiceHost=k3d-zeta-dev-server-0 \
+    --set k8sServicePort=6443 \
+    --set hubble.enabled=true \
+    --set hubble.relay.enabled=true \
+    --set hubble.ui.enabled=true \
+    --set ipam.mode=kubernetes \
+    --wait
+fi
+
+# ── Step 3: ArgoCD ────────────────────────────────────────────
+if ! kubectl get ns argocd >/dev/null 2>&1; then
+  echo "Installing ArgoCD ..."
+  kubectl create namespace argocd
+  helm repo add argo https://argoproj.github.io/argo-helm >/dev/null 2>&1 || true
+  helm repo update argo >/dev/null
+  helm install argocd argo/argo-cd \
+    --version 7.7.5 \
+    --namespace argocd \
+    --set server.service.type=LoadBalancer \
+    --wait
+fi
+
+# ── Step 4: root App-of-Apps pointing at this repo ────────────
+# Uses GIT_REF so dev can pin to a feature branch.
+echo "Applying root App-of-Apps (git ref: ${GIT_REF}) ..."
+cat <<EOF | kubectl apply -f -
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: zeta-root-dev
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Lucent-Financial-Group/Zeta
+    targetRevision: ${GIT_REF}
+    path: full-ai-cluster/k8s/applications
+    directory:
+      recurse: true
+      include: '{*/Application.yaml,Application.yaml}'
+      # Skip apps that don't belong in dev (GPU stack, Longhorn).
+      # These reconcile in prod but are excluded here via the
+      # exclude glob.
+      exclude: '{longhorn/**,ollama/**,vllm/**,deepseek-coder/**,qwen-coder/**}'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+EOF
+
+# ── Done ──────────────────────────────────────────────────────
+cat <<EOF
+
+Dev cluster up. Same substrate as prod, minus Longhorn + GPU stack.
+
+  kubectl get nodes                       # 1 server + 2 agents, env=dev label
+  kubectl -n argocd get applications      # ArgoCD reconciling app-of-apps
+  kubectl -n argocd port-forward svc/argocd-server 8443:443
+  open https://localhost:8443             # ArgoCD UI (initial password below)
+
+  kubectl -n argocd get secret argocd-initial-admin-secret \\
+    -o jsonpath='{.data.password}' | base64 -d ; echo
+
+Tear down: ./down.sh
+EOF

--- a/full-ai-cluster/dev-cluster/up.sh
+++ b/full-ai-cluster/dev-cluster/up.sh
@@ -23,6 +23,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GIT_REF="${1:-main}"
 
+# Reject git refs that aren't safe to interpolate into the heredoc
+# below. Branch names, tags, and SHAs all fit a narrow charset.
+# Anything with whitespace / newlines / YAML metacharacters gets
+# rejected — otherwise a creative ref name could inject extra YAML
+# keys into the Application spec.
+case "$GIT_REF" in
+  *[!a-zA-Z0-9._/-]* | ''|/*|*/|*//*)
+    echo "ERROR: git-ref must match [a-zA-Z0-9._/-]+ (got: '${GIT_REF}')" >&2
+    exit 1 ;;
+esac
+
 # ── Pre-flight ────────────────────────────────────────────────
 for cmd in docker k3d kubectl helm; do
   command -v "$cmd" >/dev/null || {
@@ -49,12 +60,14 @@ kubectl config use-context k3d-zeta-dev
 
 # ── Step 2: Cilium CNI (chicken-and-egg — without this, no pods
 # schedule because flannel/kube-proxy are disabled) ───────────
-if ! kubectl -n kube-system get ds cilium >/dev/null 2>&1; then
+# Version kept aligned with full-ai-cluster/k8s/bootstrap/cilium-install.yaml
+# so dev exercises the same chart that lands in prod.
+if ! helm -n kube-system status cilium >/dev/null 2>&1; then
   echo "Installing Cilium ..."
   helm repo add cilium https://helm.cilium.io >/dev/null 2>&1 || true
   helm repo update cilium >/dev/null
   helm install cilium cilium/cilium \
-    --version 1.16.4 \
+    --version 1.16.5 \
     --namespace kube-system \
     --set kubeProxyReplacement=true \
     --set k8sServiceHost=k3d-zeta-dev-server-0 \
@@ -67,17 +80,33 @@ if ! kubectl -n kube-system get ds cilium >/dev/null 2>&1; then
 fi
 
 # ── Step 3: ArgoCD ────────────────────────────────────────────
-if ! kubectl get ns argocd >/dev/null 2>&1; then
+# Helm release check (vs `kubectl get ns argocd`) — namespace
+# existing doesn't imply the chart was installed; an earlier failed
+# install can leave the ns behind. `helm status` is the canonical
+# release-exists test.
+# Version kept aligned with full-ai-cluster/k8s/bootstrap/argocd-install.yaml
+# AND full-ai-cluster/k8s/applications/argocd/Application.yaml so the
+# adoption in the self-management wave is a no-op.
+if ! helm -n argocd status argocd >/dev/null 2>&1; then
   echo "Installing ArgoCD ..."
-  kubectl create namespace argocd
+  kubectl create namespace argocd >/dev/null 2>&1 || true
   helm repo add argo https://argoproj.github.io/argo-helm >/dev/null 2>&1 || true
   helm repo update argo >/dev/null
   helm install argocd argo/argo-cd \
-    --version 7.7.5 \
+    --version 7.7.10 \
     --namespace argocd \
     --set server.service.type=LoadBalancer \
     --wait
 fi
+
+# Wait for the Application CRD to be Established before applying
+# the root App-of-Apps. On a fresh install the CRDs land via the
+# Helm hooks; kubectl apply against an un-Established CRD fails
+# with "no matches for kind 'Application'".
+kubectl wait --for=condition=Established \
+  --timeout=120s \
+  crd/applications.argoproj.io \
+  >/dev/null 2>&1 || true
 
 # ── Step 4: root App-of-Apps pointing at this repo ────────────
 # Uses GIT_REF so dev can pin to a feature branch.

--- a/full-ai-cluster/k8s/applications/alloy/Application.yaml
+++ b/full-ai-cluster/k8s/applications/alloy/Application.yaml
@@ -4,6 +4,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: alloy
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/argo-rollouts/Application.yaml
+++ b/full-ai-cluster/k8s/applications/argo-rollouts/Application.yaml
@@ -3,6 +3,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: argo-rollouts
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/argo-workflows/Application.yaml
+++ b/full-ai-cluster/k8s/applications/argo-workflows/Application.yaml
@@ -3,6 +3,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: argo-workflows
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/argocd/Application.yaml
+++ b/full-ai-cluster/k8s/applications/argocd/Application.yaml
@@ -1,0 +1,54 @@
+# full-ai-cluster/k8s/applications/argocd/Application.yaml
+#
+# ArgoCD self-management. ArgoCD was already installed by the K3S
+# bootstrap manifests (full-ai-cluster/k8s/bootstrap/argocd-install.yaml);
+# this Application adopts the existing installation so subsequent
+# chart upgrades / value tweaks land via git → ArgoCD instead of
+# requiring a bootstrap-manifest edit + K3S server restart.
+#
+# Sync wave -90: must be in the EARLY wave so ArgoCD reconciles
+# itself before reconciling other apps. If a chart bump here would
+# break ArgoCD, having it land first means downstream apps don't
+# get half-reconciled by a broken ArgoCD mid-wave.
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-90"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://argoproj.github.io/argo-helm
+    chart: argo-cd
+    targetRevision: 7.7.5
+    helm:
+      releaseName: argocd
+      valuesObject:
+        server:
+          service:
+            type: LoadBalancer
+        configs:
+          params:
+            # Allow server-side apply for ServerSideApply syncOption
+            # to do the right thing on CRD upgrades.
+            server.repo.server.timeout.seconds: "300"
+        notifications:
+          enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: false        # never let ArgoCD prune itself
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      # Ignore the resources-finalizer the bootstrap installer
+      # already added — preserves the existing release.
+      - ApplyOutOfSyncOnly=true

--- a/full-ai-cluster/k8s/applications/argocd/Application.yaml
+++ b/full-ai-cluster/k8s/applications/argocd/Application.yaml
@@ -25,20 +25,27 @@ spec:
   source:
     repoURL: https://argoproj.github.io/argo-helm
     chart: argo-cd
-    targetRevision: 7.7.5
+    # Keep aligned with full-ai-cluster/k8s/bootstrap/argocd-install.yaml
+    # `spec.version`. A drift between the bootstrap version and this
+    # self-management version would cause ArgoCD to immediately try to
+    # downgrade/upgrade itself on first reconcile — wedge risk in the
+    # earliest sync wave.
+    targetRevision: 7.7.10
     helm:
       releaseName: argocd
       valuesObject:
+        # Mirror the bootstrap values so adopting this Application is
+        # a no-op transition. Subsequent value changes happen here.
+        global:
+          domain: argocd.zeta.local
         server:
           service:
-            type: LoadBalancer
+            type: ClusterIP   # ingress lands separately
         configs:
           params:
-            # Allow server-side apply for ServerSideApply syncOption
-            # to do the right thing on CRD upgrades.
-            server.repo.server.timeout.seconds: "300"
+            server.insecure: true   # TLS terminated upstream once ingress lands
         notifications:
-          enabled: true
+          enabled: false
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/full-ai-cluster/k8s/applications/cert-manager/Application.yaml
+++ b/full-ai-cluster/k8s/applications/cert-manager/Application.yaml
@@ -5,6 +5,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-70"
   name: cert-manager
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/cilium/Application.yaml
+++ b/full-ai-cluster/k8s/applications/cilium/Application.yaml
@@ -6,6 +6,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-80"
   name: cilium
   namespace: argocd
   finalizers:

--- a/full-ai-cluster/k8s/applications/cockroachdb/Application.yaml
+++ b/full-ai-cluster/k8s/applications/cockroachdb/Application.yaml
@@ -4,6 +4,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: cockroachdb
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/dapr/Application.yaml
+++ b/full-ai-cluster/k8s/applications/dapr/Application.yaml
@@ -3,6 +3,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: dapr
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/deepseek-coder/Application.yaml
+++ b/full-ai-cluster/k8s/applications/deepseek-coder/Application.yaml
@@ -9,6 +9,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
   name: deepseek-coder
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/external-secrets/Application.yaml
+++ b/full-ai-cluster/k8s/applications/external-secrets/Application.yaml
@@ -12,6 +12,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-40"
   name: external-secrets
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/forgejo/Application.yaml
+++ b/full-ai-cluster/k8s/applications/forgejo/Application.yaml
@@ -10,6 +10,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
   name: forgejo
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/gitlab/Application.yaml
+++ b/full-ai-cluster/k8s/applications/gitlab/Application.yaml
@@ -3,6 +3,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
   name: gitlab
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/hat-system/Application.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/Application.yaml
@@ -15,6 +15,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
   name: hat-system
   namespace: argocd
   finalizers:

--- a/full-ai-cluster/k8s/applications/hermes/Application.yaml
+++ b/full-ai-cluster/k8s/applications/hermes/Application.yaml
@@ -18,6 +18,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
   name: hermes
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/hindsight/Application.yaml
+++ b/full-ai-cluster/k8s/applications/hindsight/Application.yaml
@@ -8,6 +8,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
   name: hindsight
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/kube-prometheus-stack/Application.yaml
+++ b/full-ai-cluster/k8s/applications/kube-prometheus-stack/Application.yaml
@@ -3,6 +3,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: kube-prometheus-stack
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/loki/Application.yaml
+++ b/full-ai-cluster/k8s/applications/loki/Application.yaml
@@ -3,6 +3,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: loki
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/longhorn/Application.yaml
+++ b/full-ai-cluster/k8s/applications/longhorn/Application.yaml
@@ -5,6 +5,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-15"
   name: longhorn
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/mimir/Application.yaml
+++ b/full-ai-cluster/k8s/applications/mimir/Application.yaml
@@ -5,6 +5,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: mimir
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/nats/Application.yaml
+++ b/full-ai-cluster/k8s/applications/nats/Application.yaml
@@ -3,6 +3,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: nats
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/node-feature-discovery/Application.yaml
+++ b/full-ai-cluster/k8s/applications/node-feature-discovery/Application.yaml
@@ -34,6 +34,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-20"
   name: node-feature-discovery
   namespace: argocd
   finalizers:

--- a/full-ai-cluster/k8s/applications/ollama/Application.yaml
+++ b/full-ai-cluster/k8s/applications/ollama/Application.yaml
@@ -12,6 +12,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
   name: ollama
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/open-policy-agent/Application.yaml
+++ b/full-ai-cluster/k8s/applications/open-policy-agent/Application.yaml
@@ -3,6 +3,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-25"
   name: open-policy-agent
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/orleans/Application.yaml
+++ b/full-ai-cluster/k8s/applications/orleans/Application.yaml
@@ -9,6 +9,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
   name: orleans
   namespace: argocd
   finalizers:

--- a/full-ai-cluster/k8s/applications/oz/Application.yaml
+++ b/full-ai-cluster/k8s/applications/oz/Application.yaml
@@ -8,6 +8,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: openziti-controller
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/qwen-coder/Application.yaml
+++ b/full-ai-cluster/k8s/applications/qwen-coder/Application.yaml
@@ -4,6 +4,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
   name: qwen-coder
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/redis/Application.yaml
+++ b/full-ai-cluster/k8s/applications/redis/Application.yaml
@@ -3,6 +3,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: redis
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/sealed-secrets/Application.yaml
+++ b/full-ai-cluster/k8s/applications/sealed-secrets/Application.yaml
@@ -4,6 +4,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-30"
   name: sealed-secrets
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/spire/Application.yaml
+++ b/full-ai-cluster/k8s/applications/spire/Application.yaml
@@ -10,6 +10,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-50"
   name: spire
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/tempo/Application.yaml
+++ b/full-ai-cluster/k8s/applications/tempo/Application.yaml
@@ -3,6 +3,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: tempo
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/temporal/Application.yaml
+++ b/full-ai-cluster/k8s/applications/temporal/Application.yaml
@@ -3,6 +3,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
   name: temporal
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/trust-manager/Application.yaml
+++ b/full-ai-cluster/k8s/applications/trust-manager/Application.yaml
@@ -10,6 +10,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-45"
   name: trust-manager
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/vault/Application.yaml
+++ b/full-ai-cluster/k8s/applications/vault/Application.yaml
@@ -5,6 +5,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-60"
   name: vault
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/vllm/Application.yaml
+++ b/full-ai-cluster/k8s/applications/vllm/Application.yaml
@@ -10,6 +10,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
   name: vllm
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]

--- a/full-ai-cluster/k8s/applications/weaviate/Application.yaml
+++ b/full-ai-cluster/k8s/applications/weaviate/Application.yaml
@@ -3,6 +3,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: weaviate
   namespace: argocd
   finalizers: [ resources-finalizer.argocd.argoproj.io ]


### PR DESCRIPTION
## Summary

Closes the dev/prod parity loop: same workloads from the same git ref reconcile into both substrates (local k3d on Mac + bare-metal NixOS cluster) via ArgoCD. Sync-wave annotations on every Application make the dependency order explicit so things land in the correct sequence on both clusters — and the dev cluster catches ordering issues on a feature branch BEFORE they touch prod.

## What lands

1. **`full-ai-cluster/dev-cluster/`** — k3d + Docker Desktop-based local cluster matching prod's substrate shape:
   - `k3d-config.yaml` — 1 server + 2 agents, K3S with same Cilium-takeover flags as prod, local Docker registry at `localhost:5000`, LoadBalancer port forwards
   - `up.sh` — end-to-end bring-up (k3d → Cilium → ArgoCD → root App-of-Apps at any git ref; default `main`, pass a PR branch to dev-test before merging)
   - `down.sh` — idempotent teardown
   - `README.md` — dev/prod parity table + multi-cluster patterns
   - `DOCKER-DESKTOP.md` — Docker Desktop GUI settings (resource sizing matters; defaults will OOM) + CLI-able items
   - `SYNC-WAVES.md` — full dependency graph + per-app wave assignment

2. **`k8s/applications/argocd/Application.yaml`** — ArgoCD self-management. Adopts the existing K3S-bootstrap installation so chart upgrades land via git → ArgoCD instead of bootstrap-manifest edits. Wave -90.

3. **Sync-wave annotation on all 34 existing Applications**:

| Wave | Apps |
|-----:|------|
| -90 | argocd (self-management) |
| -80 | cilium |
| -70 | cert-manager |
| -60 | vault |
| -50 | spire |
| -45 | trust-manager |
| -40 | external-secrets |
| -30 | sealed-secrets |
| -25 | open-policy-agent (must precede policy-using apps) |
| -20 | node-feature-discovery |
| -15 | longhorn (storage class precedes PVC users) |
| -10 | hat-system (CRDs precede HatBinding workloads) |
|   0 | observability core, data planes, runtime (default wave) |
|  10 | hindsight / orleans / temporal (need data planes up) |
|  20 | hermes (needs Vault secret synced + dependencies) |
|  30 | gitlab / forgejo (source-of-truth services land last) |
|  50 | ollama / vllm / deepseek-coder / qwen-coder (GPU; manual-sync) |

## Why dev/prod parity now

Aaron's framing: \"prod and dev machine become same with argocd\". The bare-metal cluster reconciles `full-ai-cluster/k8s/applications/` from main; the dev cluster reconciles the same path from the branch under test. ArgoCD is the bridge. The only environment-specific deltas live in the dev-cluster's exclude glob (no Longhorn — local-path-provisioner instead; no GPU stack).

Dev workflow becomes:

```bash
./dev-cluster/up.sh feat/my-pr-2026-05-25   # dev-test on branch
# observe; tweak; commit; iterate
./dev-cluster/down.sh                       # teardown
# merge to main; prod ArgoCD picks up automatically
```

## Why sync-waves now

ArgoCD reconciles App-of-Apps children in parallel by default. That breaks for:
- Workloads referencing Vault secrets that ESO hasn't synced yet
- Resources using OPA Gatekeeper constraints that haven't installed
- HatBindings created before the hat-system CRDs exist
- Apps that need PVCs before Longhorn storage class registers

Sync-waves make the dependency graph explicit. The dev cluster is the first place this manifests; better to catch it there than in prod.

## Test plan

- [ ] `./up.sh` (default `main`) brings up a 3-node cluster, installs Cilium + ArgoCD, applies the root App-of-Apps
- [ ] `kubectl -n argocd get applications` shows apps reconciling in sync-wave order
- [ ] Apps in wave -80 through -10 reach Healthy before wave 0 apps start
- [ ] Wave-20 hermes shows OutOfSync (replicas:0 placeholder) but no errors
- [ ] `./up.sh feat/some-branch` correctly retargets the root App at that branch
- [ ] `./down.sh` is idempotent (safe to run twice)
- [ ] `./dev-cluster/DOCKER-DESKTOP.md` resource recommendations are followed; no OOM under normal reconcile

## Notes

- Docker Desktop resource sizing is critical — defaults (2 CPU / 8 GB) will OOM. Doc recommends 6 CPU / 16 GB / 128 GB disk.
- Docker Desktop's Kubernetes toggle should be OFF (competing context with k3d).
- The `argocd/Application.yaml` adopts the existing chart release with `ApplyOutOfSyncOnly=true` — safe on top of the bootstrap-installed ArgoCD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)