### PR TITLE
feat(tools): flash-usb.ts — safety-railed dd wrapper for the AI-cluster ISO

### DIFF
--- a/full-ai-cluster/tools/README-flash-usb.md
+++ b/full-ai-cluster/tools/README-flash-usb.md
@@ -1,0 +1,103 @@
+# `flash-usb.ts` — safety-railed USB flasher for the AI-cluster ISO
+
+Replaces ad-hoc `dd if=... of=/dev/disk?` with a script that
+refuses to do the wrong thing.
+
+## Usage
+
+```bash
+bun full-ai-cluster/tools/flash-usb.ts <path-to-iso>
+```
+
+Walks through:
+
+1. Verifies platform is macOS
+2. Verifies the ISO path exists, is `.iso`, and has sane size
+3. Enumerates external USB devices via `diskutil -plist`
+4. Refuses if zero or 2+ USB devices found
+5. Refuses if the candidate is internal, the boot disk, or outside
+   sane USB size range
+6. Prints device summary (model, size, protocol, boot-disk delta)
+7. Requires the operator to type the FULL device path to confirm
+   (typing `yes` is rejected — the typed path IS the verification)
+8. Unmounts the disk
+9. `sudo dd` to the raw device (`/dev/rdiskN`) — ~10x faster than
+   the buffered `/dev/diskN` on macOS
+10. Ejects the disk on success
+
+## Why the safety rails
+
+The default ad-hoc workflow is:
+
+```bash
+diskutil list                       # find the USB
+sudo dd if=*.iso of=/dev/rdisk4     # flash
+```
+
+If step 1 picks the wrong number, step 2 destroys a hard drive.
+This script refuses any device that:
+
+- isn't on USB / USB-C bus protocol
+- reports as Internal
+- is the current boot disk
+- has size outside [4 GiB, 256 GiB]
+
+…and demands the operator type the device path back as the
+visual-verification gate. Typing `yes`/`y` wouldn't prove the
+operator looked at the device; typing the path does.
+
+## Agent-execution authorization
+
+The Claude Code classifier blocks ad-hoc `dd` and `diskutil list`
+as composite high-blast-radius operations. To let an autonomous
+agent run THIS script (which has its own gates baked in), add
+to `.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(bun full-ai-cluster/tools/flash-usb.ts *)"
+    ]
+  }
+}
+```
+
+The script's hardcoded gates are what makes that permission grant
+reasonable — every destructive action is still gated by checks
+the maintainer audited once in code review.
+
+## Linux support (TODO)
+
+V1 is macOS-only. Linux equivalent is straightforward but distinct:
+
+- `lsblk -J -d --output NAME,SIZE,MODEL,TRAN,RM,MOUNTPOINT` for
+  enumeration
+- `udevadm info --query=property` for the per-device safety
+  checks
+- `sudo dd if=<iso> of=/dev/sdX bs=4M conv=fsync status=progress`
+
+Filing as a follow-up when a Linux workstation is in the mix.
+
+## Implementation notes
+
+- All subprocess calls use `execFileSync` (argv-array form) — no
+  shell interpolation, no command-injection risk
+- `assertSafeDevicePath` whitelists `/dev/disk\d+$` — belt-and-
+  suspenders even though `diskutil` produces these strings itself
+- Parses `diskutil`'s plist output via `plutil -convert json` for
+  structured access vs string-scraping (much more stable across
+  macOS versions)
+- The `dd` is `spawn`'d with stdio inherited so the operator sees
+  the live progress, and `sudo` can prompt for the password in
+  the same terminal
+- Uses `/dev/rdiskN` (raw character device) — faster than buffered
+  `/dev/diskN` because it bypasses the buffer cache
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Flash completed successfully |
+| 1 | User aborted (typed-path mismatch or interrupted) |
+| 2 | Safety check failed (bad ISO, no USB, wrong device class) |

--- a/full-ai-cluster/tools/flash-usb.ts
+++ b/full-ai-cluster/tools/flash-usb.ts
@@ -1,0 +1,294 @@
+#!/usr/bin/env bun
+// full-ai-cluster/tools/flash-usb.ts
+//
+// Safety-railed `dd` wrapper for flashing the AI-cluster installer
+// ISO to a USB stick on macOS. Built so the maintainer (and any
+// autonomous agent the maintainer authorizes) can flash without
+// risk of picking the wrong device.
+//
+// Why this exists: the classifier blocks ad-hoc `dd` + recon as a
+// composite high-blast-radius operation. A reviewable script with
+// hard-coded safety guards changes the blast-radius calculation —
+// every destructive action is gated by checks the maintainer can
+// audit once in code review, instead of every-invocation trust.
+//
+// Hard refusals (exit 2):
+//   - Not running on macOS (Linux support is TODO)
+//   - ISO arg missing, not a file, or not *.iso
+//   - ISO size outside [200 MiB, 8 GiB] — sanity gate
+//   - Zero or 2+ USB devices connected (ambiguous)
+//   - Selected device is not protocol USB/USB-C
+//   - Selected device is internal
+//   - Selected device is the current boot disk
+//   - Selected device size outside [4 GiB, 256 GiB]
+//
+// Confirmation gate (exit 1):
+//   - Operator must type the FULL device path (e.g. `/dev/disk4`).
+//     `yes`/`y` is REJECTED — typed-path is the verification
+//     that the operator visually checked the device.
+//
+// Then:
+//   - `diskutil unmountDisk` (not eject)
+//   - `sudo dd` with `/dev/rdiskN` (raw device; ~10x faster)
+//   - `bs=4m conv=sync status=progress`
+//   - `diskutil eject` on success
+//
+// Usage:
+//   bun full-ai-cluster/tools/flash-usb.ts <path-to-iso>
+//
+// Authorization for agent execution:
+//   The classifier may block `diskutil list` + `dd` even from this
+//   script. To allow an agent to run it, add to .claude/settings.json:
+//     "permissions": { "allow": [
+//       "Bash(bun full-ai-cluster/tools/flash-usb.ts *)"
+//     ] }
+//   The safety rails in this script are what makes that permission
+//   grant reasonable.
+//
+// Implementation note: all subprocess calls use execFileSync (argv-
+// array form) — never shell interpolation. Inputs that flow into
+// arguments come from diskutil's own JSON output (trusted) or from
+// hardcoded literals, never from user-controlled strings.
+
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { platform } from "node:os";
+import * as readline from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+
+const MIN_ISO_BYTES = 200 * 1024 * 1024;
+const MAX_ISO_BYTES = 8 * 1024 * 1024 * 1024;
+const MIN_USB_BYTES = 4 * 1024 * 1024 * 1024;
+const MAX_USB_BYTES = 256 * 1024 * 1024 * 1024;
+
+function bail(code: number, msg: string): never {
+  process.stderr.write(`flash-usb: ${msg}\n`);
+  process.exit(code);
+}
+
+function human(bytes: number): string {
+  const u = ["B", "KiB", "MiB", "GiB", "TiB"];
+  let i = 0;
+  let n = bytes;
+  while (n >= 1024 && i < u.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  return `${n.toFixed(2)} ${u[i]}`;
+}
+
+// Convert plist XML stdin to JSON via plutil. Safe pipeline because
+// the plist comes from diskutil (trusted), not user input.
+function plistToJson(plistXml: string): unknown {
+  const json = execFileSync("plutil", ["-convert", "json", "-o", "-", "-"], {
+    input: plistXml,
+    encoding: "utf8",
+  });
+  return JSON.parse(json);
+}
+
+function diskutilListPlist(): unknown {
+  const xml = execFileSync(
+    "diskutil",
+    ["list", "-plist", "external", "physical"],
+    { encoding: "utf8" },
+  );
+  return plistToJson(xml);
+}
+
+function diskutilInfo(device: string): Record<string, unknown> {
+  const xml = execFileSync("diskutil", ["info", "-plist", device], {
+    encoding: "utf8",
+  });
+  return plistToJson(xml) as Record<string, unknown>;
+}
+
+function bootDiskIdentifier(): string {
+  // `mount` output -> find row mounting `/` -> extract diskN.
+  const mountOut = execFileSync("mount", [], { encoding: "utf8" });
+  const rootMount = mountOut.split("\n").find((l) => / on \/ \(/.test(l));
+  if (!rootMount) return "";
+  const m = rootMount.match(/^\/dev\/(disk\d+)/);
+  return m ? m[1] : "";
+}
+
+// Whitelist of safe device-identifier shapes. Belt-and-suspenders
+// even though diskutil produces these strings itself.
+function assertSafeDevicePath(device: string): void {
+  if (!/^\/dev\/disk\d+$/.test(device)) {
+    bail(2, `unsafe device path: ${device}`);
+  }
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.length !== 1 || argv[0] === "-h" || argv[0] === "--help") {
+    process.stdout.write(
+      "Usage: bun full-ai-cluster/tools/flash-usb.ts <path-to-iso>\n",
+    );
+    process.exit(argv.length === 1 ? 0 : 2);
+  }
+  const isoPath = argv[0];
+
+  // ── 1. Platform gate ───────────────────────────────────────
+  if (platform() !== "darwin") {
+    bail(
+      2,
+      "this script only supports macOS. For Linux, use the manual flow:\n" +
+        "  lsblk; sudo dd if=<iso> of=/dev/<device> bs=4M status=progress conv=fsync",
+    );
+  }
+
+  // ── 2. ISO gate ────────────────────────────────────────────
+  if (!existsSync(isoPath)) bail(2, `ISO file does not exist: ${isoPath}`);
+  if (!isoPath.endsWith(".iso")) bail(2, `expected *.iso file, got: ${isoPath}`);
+  const isoStat = statSync(isoPath);
+  if (!isoStat.isFile()) bail(2, `ISO path is not a file: ${isoPath}`);
+  if (isoStat.size < MIN_ISO_BYTES || isoStat.size > MAX_ISO_BYTES) {
+    bail(
+      2,
+      `ISO size ${human(isoStat.size)} outside sane range ` +
+        `[${human(MIN_ISO_BYTES)}, ${human(MAX_ISO_BYTES)}]; refusing`,
+    );
+  }
+  process.stdout.write(`ISO: ${isoPath} (${human(isoStat.size)})\n`);
+
+  // ── 3. Enumerate USB devices ───────────────────────────────
+  const list = diskutilListPlist() as {
+    AllDisksAndPartitions: { DeviceIdentifier: string }[];
+  };
+  const externalDevices = list.AllDisksAndPartitions.map(
+    (d) => `/dev/${d.DeviceIdentifier}`,
+  );
+
+  const usbCandidates: { device: string; info: Record<string, unknown> }[] = [];
+  for (const device of externalDevices) {
+    assertSafeDevicePath(device);
+    const info = diskutilInfo(device);
+    const proto = String(info.BusProtocol ?? "");
+    const internal = info.Internal === true;
+    if ((proto === "USB" || proto === "USB-C") && !internal) {
+      usbCandidates.push({ device, info });
+    }
+  }
+
+  if (usbCandidates.length === 0) {
+    bail(
+      2,
+      "no USB devices found.\n" +
+        "Plug in the USB stick, then re-run. If you already plugged it in,\n" +
+        "give the OS a few seconds and try again.",
+    );
+  }
+  if (usbCandidates.length > 1) {
+    process.stderr.write("flash-usb: multiple USB devices found:\n");
+    for (const c of usbCandidates) {
+      const size = Number(c.info.TotalSize ?? 0);
+      const model = String(c.info.MediaName ?? "?");
+      process.stderr.write(`  ${c.device}  ${human(size)}  ${model}\n`);
+    }
+    bail(
+      2,
+      "refusing to pick one. Unplug all but the target USB and re-run, OR\n" +
+        "use manual flow: sudo dd if=<iso> of=/dev/rdiskN bs=4m",
+    );
+  }
+
+  const { device, info } = usbCandidates[0];
+  assertSafeDevicePath(device);
+  const size = Number(info.TotalSize ?? 0);
+  const model = String(info.MediaName ?? info.IORegistryEntryName ?? "?");
+  const removable =
+    info.RemovableMedia === true || info.RemovableMediaOrExternalDevice === true;
+
+  // ── 4. Per-device safety gates ─────────────────────────────
+  if (size < MIN_USB_BYTES || size > MAX_USB_BYTES) {
+    bail(
+      2,
+      `device ${device} size ${human(size)} outside USB range ` +
+        `[${human(MIN_USB_BYTES)}, ${human(MAX_USB_BYTES)}]; refusing\n` +
+        `(this protects against pointing at an external SSD by mistake)`,
+    );
+  }
+
+  const bootDisk = bootDiskIdentifier();
+  const deviceShort = device.replace("/dev/", "");
+  if (bootDisk && deviceShort === bootDisk) {
+    bail(2, `device ${device} IS the boot disk; refusing to overwrite`);
+  }
+
+  // ── 5. Display + typed-path confirmation ───────────────────
+  process.stdout.write("\n");
+  process.stdout.write("USB device identified:\n");
+  process.stdout.write(`  Device:    ${device}\n`);
+  process.stdout.write(`  Model:     ${model}\n`);
+  process.stdout.write(`  Size:      ${human(size)}\n`);
+  process.stdout.write(`  Protocol:  ${info.BusProtocol}\n`);
+  process.stdout.write(`  Removable: ${removable}\n`);
+  process.stdout.write(`  Boot disk: ${bootDisk}  (target is not boot disk)\n`);
+  process.stdout.write("\n");
+  process.stdout.write(`*** ALL DATA ON ${device} WILL BE DESTROYED ***\n\n`);
+  process.stdout.write(
+    `To confirm, type the full device path exactly: ${device}\n`,
+  );
+
+  const rl = readline.createInterface({ input: stdin, output: stdout });
+  const typed = (await rl.question("> ")).trim();
+  rl.close();
+
+  if (typed !== device) {
+    bail(
+      1,
+      `confirmation mismatch (got '${typed}', expected '${device}'). Aborted.`,
+    );
+  }
+
+  // ── 6. Unmount → dd → eject ────────────────────────────────
+  process.stdout.write(`\nUnmounting ${device} ...\n`);
+  execFileSync("diskutil", ["unmountDisk", device], { stdio: "inherit" });
+
+  // /dev/rdiskN is the raw character device — ~10x faster than
+  // the buffered /dev/diskN on macOS.
+  const rawDevice = `/dev/r${deviceShort}`;
+  process.stdout.write(
+    `\nFlashing ${isoPath} → ${rawDevice} ` +
+      `(${human(isoStat.size)}; this takes a few minutes) ...\n\n`,
+  );
+
+  const dd = spawn(
+    "sudo",
+    [
+      "dd",
+      `if=${isoPath}`,
+      `of=${rawDevice}`,
+      "bs=4m",
+      "conv=sync",
+      "status=progress",
+    ],
+    { stdio: "inherit" },
+  );
+
+  const code: number = await new Promise((res) =>
+    dd.on("close", (c) => res(c ?? 1)),
+  );
+
+  if (code !== 0) {
+    bail(code, `dd exited ${code}; partial flash may be on device.`);
+  }
+
+  process.stdout.write(`\nEjecting ${device} ...\n`);
+  try {
+    execFileSync("diskutil", ["eject", device], { stdio: "inherit" });
+  } catch {
+    process.stdout.write(
+      "(eject failed; that is fine — the flash succeeded. " +
+        "Unplug + replug to verify.)\n",
+    );
+  }
+
+  process.stdout.write("\nFlash complete.\n");
+}
+
+main().catch((err) => {
+  bail(1, err instanceof Error ? err.message : String(err));
+});


### PR DESCRIPTION
## Summary

TypeScript script (per Rule 0) at `full-ai-cluster/tools/flash-usb.ts` that wraps `dd` with hard-coded safety guards so picking the wrong device is structurally impossible. Built so the maintainer (and any agent the maintainer authorizes) can flash the AI-cluster installer ISO without `dd if=*.iso of=/dev/disk<typo>` blast-radius risk.

## Hard refusals (exit 2)

- Not running on macOS (Linux is TODO; doc lists manual fallback)
- ISO arg missing, not a file, or not `*.iso`
- ISO size outside [200 MiB, 8 GiB]
- Zero or 2+ USB devices found (ambiguous)
- Candidate is not USB/USB-C protocol
- Candidate reports as Internal
- Candidate IS the current boot disk
- Candidate size outside [4 GiB, 256 GiB]

## Confirmation gate (exit 1)

- Operator must type the FULL device path (e.g. `/dev/disk4`) exactly
- Typing `yes`/`y` is REJECTED — typed-path IS the visual verification

## Flow

`unmount → sudo dd to /dev/rdiskN (raw, ~10x faster) with bs=4m conv=sync status=progress → eject`

## Implementation

- All subprocess calls use `execFileSync` (argv-array, no shell interpolation, no injection risk)
- `assertSafeDevicePath` whitelists `/dev/disk\d+$` — belt-and-suspenders even though `diskutil` produces the strings itself
- Parses `diskutil`'s plist output via `plutil -convert json` for structured access vs string-scraping (stable across macOS versions)

## Agent authorization (after merge)

The classifier blocks ad-hoc `dd` + `diskutil list` as composite high-blast-radius operations. To allow an autonomous agent to run THIS script (which has its own gates baked in), the maintainer can add:

```json
"permissions": { "allow": [
  "Bash(bun full-ai-cluster/tools/flash-usb.ts *)"
] }
```

The safety rails are what makes that permission grant reasonable.

## Test plan

- [ ] `bun tools/flash-usb.ts` (no args) prints usage + exits 2
- [ ] `bun tools/flash-usb.ts /tmp/nonexistent.iso` exits 2 with "does not exist"
- [ ] `bun tools/flash-usb.ts /tmp/tiny.iso` (file <200MiB) exits 2 with size complaint
- [ ] With one USB plugged in + valid ISO: shows device summary; rejects `yes`; accepts the typed path; flashes
- [ ] With two USBs plugged in: refuses (exit 2) and lists both
- [ ] Without any USB: refuses (exit 2) with re-plug suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)