### PR TITLE
docs: require work anchors for organization discussions

### DIFF
--- a/agentic-organization/docs/AGENT_NATIVE_KNOWLEDGE_GRAPH.md
+++ b/agentic-organization/docs/AGENT_NATIVE_KNOWLEDGE_GRAPH.md
@@ -1,0 +1,692 @@
+# Agent-Native Knowledge Graph and Retrieval
+
+## Purpose
+
+The Organization Work OS needs a graph and retrieval layer over task management. Agents should be able to traverse from any project, initiative, task, meeting, discussion, decision, document, artifact, run, memory, or trace to the surrounding context that explains what happened and why.
+
+This is agent-first infrastructure. Humans should benefit from the same graph, but the primary consumer is a Hermes agent trying to understand work without relying on chat memory, hidden inbox context, or stale summaries.
+
+## Core Principle
+
+Every important organizational object should be a graph node. Every important relationship should be a typed edge.
+
+```text
+Project
+  -> Initiative
+    -> Work Item
+      -> Task / Defect / Capability Request / Review
+        -> Assignment
+        -> Hermes/Oz Run
+        -> Evidence Artifact
+        -> Gate Decision
+        -> Meeting
+        -> Discussion Thread
+        -> Decision
+        -> BRD / CA / ADR / Design Doc
+        -> Skill / Memory / Trace
+```
+
+The task board is not only a board. It is an index into the Organization's working memory.
+
+## Typed Graph Schema
+
+Minimum node kinds:
+
+```ts
+type NodeKind =
+  | "Project"
+  | "Initiative"
+  | "WorkItem"
+  | "Task"
+  | "Defect"
+  | "CapabilityRequest"
+  | "Gate"
+  | "Decision"
+  | "Vote"
+  | "Meeting"
+  | "DiscussionThread"
+  | "Message"
+  | "OneOnOne"
+  | "TeamRoom"
+  | "Broadcast"
+  | "Document"
+  | "BRD"
+  | "CA"
+  | "ADR"
+  | "DesignDoc"
+  | "Skill"
+  | "MemoryRecord"
+  | "Artifact"
+  | "EvidencePackage"
+  | "Trace"
+  | "Run"
+  | "Agent"
+  | "HatAssignment"
+  | "PolicyDecision"
+  | "Signal"
+  | "ContextPack";
+```
+
+Every node should use a shared envelope:
+
+```ts
+type GraphNode = {
+  id: string;
+  kind: NodeKind;
+  stableKey: string;
+  title: string;
+  summary: string;
+  scope: {
+    organizationId: string;
+    projectId?: string;
+    initiativeId?: string;
+    workItemId?: string;
+    taskId?: string;
+    runId?: string;
+  };
+  provenance: ProvenanceEnvelope;
+  access: AccessEnvelope;
+  source: SourcePointer;
+  indexing: IndexingHints;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ProvenanceEnvelope = {
+  createdByType: "agent" | "human" | "system";
+  createdById: string;
+  agentId?: string;
+  hatAssignmentId?: string;
+  toolCallId?: string;
+  modelRunId?: string;
+  traceId?: string;
+  confidence?: number;
+};
+
+type AccessEnvelope = {
+  visibilityPolicyId: string;
+  projectScope?: string;
+  hatScopes: string[];
+  redactionStatus: "none" | "partial" | "full";
+};
+
+type SourcePointer = {
+  sourceType: "db" | "message" | "transcript" | "document" | "artifact" | "trace" | "memory" | "external";
+  sourceId: string;
+  sourceVersion?: string;
+  citation?: string;
+};
+
+type IndexingHints = {
+  deterministic: boolean;
+  semantic: boolean;
+  keywords: string[];
+  freshness: "live" | "current" | "stale" | "archived";
+};
+```
+
+## Edge Contract
+
+Edges should be typed, timestamped, attributable to an agent/hat/tool, versioned, and reversible when created by mistake.
+
+```ts
+type EdgeKind =
+  | "belongs_to"
+  | "implements"
+  | "blocks"
+  | "depends_on"
+  | "clarifies"
+  | "decides"
+  | "supersedes"
+  | "superseded_by"
+  | "contradicts"
+  | "conflicts_with"
+  | "invalidates"
+  | "approves"
+  | "rejects"
+  | "requires"
+  | "summarizes"
+  | "cites"
+  | "produced_by"
+  | "discussed_in"
+  | "decided_in"
+  | "mentioned_in"
+  | "evidence_for"
+  | "caused_by"
+  | "follow_up_to"
+  | "assigned_to"
+  | "reviewed_by"
+  | "released_by"
+  | "observed_in_trace"
+  | "recalls_memory"
+  | "writes_memory"
+  | "uses_skill"
+  | "derived_from"
+  | "derived_from_doc"
+  | "has_context_pack_item"
+  | "redacts"
+  | "governed_by_policy";
+```
+
+| Edge kind | Direction | Typical source | Typical target | Provenance required | Reversal behavior |
+|---|---|---|---|---|---|
+| `belongs_to` | child -> parent | Task | Initiative | importer/tool | versioned correction |
+| `discussed_in` | subject -> conversation | Task | Meeting/Thread | message or transcript | reversible edge |
+| `decided_in` | decision -> source | Decision | Meeting/Vote/Thread | meeting/vote ID | supersede decision |
+| `evidence_for` | evidence -> claim/work | Artifact/Trace | Task/Gate | artifact and trace ID | reversible edge |
+| `contradicts` / `conflicts_with` | node -> node | Decision/Doc | Decision/Doc | detector/tool ID | resolved by decision |
+| `supersedes` / `superseded_by` | new -> old | Decision/Doc | Decision/Doc | approving hat | preserve old node |
+| `has_context_pack_item` | pack -> item | ContextPack | Any node | retrieval query ID | regenerate pack |
+| `redacts` | redaction -> source | PolicyDecision | Node/Edge | policy decision ID | policy-reviewed only |
+
+## Discussion and Decision Capture
+
+Discussions are not side-channel chatter. They are work artifacts.
+
+Every one-on-one, team discussion, department report, executive meeting, vote, broadcast, review comment, and task thread must be linked to the relevant work graph before it opens:
+
+```text
+Meeting
+  -> discussed_in -> Initiative
+  -> discussed_in -> Task
+  -> produced -> Decision
+  -> produced -> FollowUpTask
+  -> cited -> BRD / CA / ADR
+  -> recorded_by -> Agent + HatAssignment
+```
+
+Decision records should include:
+
+- decision statement;
+- decision type;
+- options considered;
+- rationale;
+- dissent or uncertainty;
+- participating agents/hats;
+- approving authority;
+- affected project/initiative/task;
+- affected docs, skills, policies, or code;
+- expiration/review date when applicable;
+- links to the meeting, discussion, vote, and evidence.
+
+Agents should never need to ask "where was this decided?" without a graph answer.
+
+## Discussion Anchor Invariant
+
+The Organization must reject unanchored discussion. A meeting, thread, broadcast, report, vote, or one-on-one is only valid when it has a work anchor and a reason.
+
+```ts
+type DiscussionAnchorType =
+  | "organization"
+  | "department"
+  | "portfolio"
+  | "project"
+  | "initiative"
+  | "mission"
+  | "work_item"
+  | "task"
+  | "defect"
+  | "review"
+  | "gate"
+  | "release"
+  | "incident"
+  | "capability_request"
+  | "policy"
+  | "context_gap";
+
+type DiscussionAnchor = {
+  anchorType: DiscussionAnchorType;
+  anchorIds: string[];
+  reason: string;
+  requiredByHatAssignmentId: string;
+  expectedOutputs: Array<"decision" | "follow_up" | "document" | "memory" | "status" | "gate_result">;
+};
+```
+
+Anchor expectations by level:
+
+| Discussion type | Required anchor |
+|---|---|
+| Executive Board or C-suite meeting | Portfolio, project, initiative, policy, capability request, or organization-level decision item |
+| Director meeting | Department plus project, initiative, policy, capability request, or queue-health work item |
+| TPM meeting | Initiative, mission, blocker, dependency, release, or task set |
+| Engineering manager/team meeting | Team plus task, defect, blocker, review, capability request, or performance/outcome review item |
+| Developer discussion | Specific task, defect, review, subtask, run, or context gap |
+| QA discussion | Test case, QA run, defect, release candidate, task, or gate |
+| Security discussion | Credential request, policy change, security review, incident, or capability request |
+| Architecture/Product/BA discussion | Project, initiative, BRD, CA, ADR, requirement gap, or gate |
+| One-on-one | Work reason plus project, initiative, task, review, handoff, performance review, memory adaptation, or context gap |
+| Broadcast/report | Team, department, project, initiative, task, incident, release, or signal anchor |
+
+Rules:
+
+- no anchor means no discussion is opened;
+- the anchor must be visible under the active hat's scope and policy;
+- if the topic is ambiguous, the system first creates or links an intake, context-gap, report, service-request, or capability-request work item, then opens the discussion against that item;
+- if a discussion changes scope, the Meeting and Communication Service creates or links the new work item instead of letting the transcript drift;
+- decisions inherit the discussion anchor and must also link the affected docs, tasks, policies, skills, runs, releases, or gates;
+- off-anchor content becomes a follow-up work item or context-gap item before it can influence state;
+- executive-down meetings should anchor at project or initiative level unless the topic is an organization policy/capability decision;
+- TPM meetings should anchor at initiative or mission level and include linked blockers, dependencies, tasks, or releases;
+- developer discussions should anchor at the concrete task, defect, review, run, or context gap being resolved.
+
+## Retrieval Contract
+
+The graph should support both deterministic traversal and semantic retrieval.
+
+Deterministic retrieval:
+
+- get all decisions for an initiative;
+- get all meetings that discussed a task;
+- get the BRD, CA, ADRs, and design docs required for a task;
+- get blockers and their upstream causes;
+- get review rejections and required rework;
+- get all artifacts and traces produced by a run;
+- get prior similar tasks and outcomes;
+- get unresolved contradictions.
+
+Semantic retrieval:
+
+- find relevant discussions about a requirement;
+- find similar defects and fixes;
+- find architecture concerns related to a component;
+- find why a task was split;
+- find project-specific skills likely needed for this task;
+- find memories from the same agent/hat/project/task pattern.
+
+The retrieval service should always return:
+
+- matched nodes;
+- connecting edges;
+- why each item was included;
+- freshness;
+- confidence;
+- visibility/policy basis;
+- citations or artifact pointers.
+
+Response shape:
+
+```ts
+type RetrievalResult = {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  citations: SourcePointer[];
+  whyIncluded: Record<string, string>;
+  policyDecisionId: string;
+  freshness: "live" | "current" | "stale" | "archived";
+  confidence: number;
+  omittedDueToPolicy: Array<{
+    nodeKind: NodeKind;
+    reason: string;
+  }>;
+  nextRecommendedActions: string[];
+};
+```
+
+## Graph Query Recipes
+
+Agent-facing retrieval should include named query recipes:
+
+```text
+what_changed_since_last_handoff(taskId, agentId)
+why_is_this_task_blocked(taskId)
+which_decisions_govern_this_task(taskId)
+which_docs_are_stale_for_this_initiative(initiativeId)
+which_active_tasks_cite_superseded_decisions(projectId)
+what_prior_work_is_most_similar(taskId, depth, outcomeFilter)
+what_unresolved_contradictions_block_release(releaseId)
+what_context_is_missing_before_start(taskId, hatAssignmentId)
+```
+
+Each query should return graph nodes, edges, citations, confidence, freshness, policy basis, and a next recommended action.
+
+## Agent Context Packs
+
+Agents should receive context packs instead of raw search dumps.
+
+A context pack is a bounded, policy-checked graph slice for a specific agent, hat, task, and run.
+
+Strict shape:
+
+```ts
+type ContextPack = {
+  id: string;
+  taskId?: string;
+  runId?: string;
+  agentId: string;
+  hatAssignmentId: string;
+  generatedAt: string;
+  freshnessDeadline: string;
+  sourceGraphVersion: string;
+  policyVersion: string;
+  tokenBudget: number;
+  requiredItems: string[];
+  optionalItems: string[];
+  omittedItemsWithReason: Array<{ nodeId?: string; reason: string }>;
+  contradictions: string[];
+  staleInputs: string[];
+  lifecycleBlockers: string[];
+  citations: SourcePointer[];
+};
+```
+
+Example contents:
+
+```text
+Task Context Pack
+  -> task summary and acceptance criteria
+  -> project and initiative goals
+  -> required BRD / CA / ADR / design docs
+  -> relevant decisions and dissent
+  -> linked discussions and meeting summaries
+  -> dependencies and blockers
+  -> prior related tasks and outcomes
+  -> required skills and memories
+  -> active policies and allowed tools
+  -> evidence expectations
+```
+
+Context packs should be regenerated when:
+
+- task state changes;
+- gate decisions change;
+- new decisions are recorded;
+- new docs are approved;
+- meetings produce follow-up actions;
+- QA or review bounces work back;
+- memory adaptation changes relevant recall;
+- hat assignment changes.
+
+Rules:
+
+- no Hermes run starts without a current context pack;
+- context packs must show omissions instead of silently dropping inaccessible or stale data;
+- agents can request `explain_context_gap` when a pack is incomplete;
+- context packs become stale when governing decisions, required docs, gates, handoffs, or high-severity contradictions change.
+
+## Handoff Briefs
+
+A handoff brief should be generated when work is reassigned, paused, blocked, bounced from review/QA, or when a run terminates.
+
+Required fields:
+
+```text
+current_state
+last_actor_and_hat
+goal
+what_changed
+attempted_paths
+open_questions
+known_risks
+unresolved_contradictions
+required_next_actions
+evidence_links
+context_pack_id
+source_messages_and_summaries
+```
+
+Agents should consume handoff briefs before resuming work. Handoffs should link to source messages, decisions, artifacts, traces, and the context pack used by the prior agent.
+
+MCP tools:
+
+- `create_handoff_brief`;
+- `read_handoff_brief`;
+- `diff_handoff_context`.
+
+## Decision Memory Lifecycle
+
+Decisions should have lifecycle state:
+
+```text
+proposed
+  -> accepted
+  -> active
+  -> challenged
+  -> reaffirmed
+  -> superseded
+  -> deprecated
+  -> expired
+```
+
+Every decision needs:
+
+- scope;
+- owner hat;
+- review date;
+- affected nodes;
+- supersession links;
+- contradiction policy;
+- meeting/thread/vote provenance.
+
+Agents should not treat an old ADR, BRD decision, product ruling, or architecture choice as active unless the graph says it still governs the current scope.
+
+## MCP Tool Surface
+
+Minimum graph and retrieval tools:
+
+```text
+read_work_graph
+  scope: project | initiative | task | run | agent | hat
+  returns: typed graph slice
+
+trace_decision
+  input: decisionId | taskId | initiativeId | question
+  returns: decision, rationale, meeting/vote/discussion links, affected work
+
+build_context_pack
+  input: taskId, agentId, hatAssignmentId, runId
+  returns: policy-checked context pack
+
+search_org_context
+  input: query, scope, allowed node types, recency, semantic/deterministic mode
+  returns: ranked nodes, edges, citations, confidence
+
+link_discussion_to_work
+  input: threadId, workId, relationship, rationale
+  effect: creates graph edge with audit
+
+validate_discussion_anchor
+  input: anchor, requested mode, organizer hat assignment, participant hats
+  returns: allowed/denied, missing work item, required scope changes, policy rationale
+
+open_discussion
+  input: anchor, mode, participants, expected outputs
+  effect: opens a thread/meeting only after anchor and hat-scope validation
+
+send_work_broadcast
+  input: anchor, audience, message type, payload
+  effect: publishes a broadcast linked to the anchored graph node
+
+record_decision
+  input: decision fields, source meeting/thread/vote, affected nodes
+  effect: creates decision node and edges
+
+find_related_work
+  input: workId, relationship types, depth
+  returns: related tasks, defects, docs, decisions, memories, skills
+
+read_entity_context
+  input: nodeId, depth, relation filter
+  returns: local graph neighborhood with citations
+
+trace_artifact_provenance
+  input: artifactId
+  returns: producing run, task, agent, hat, trace, and gate usage
+
+create_handoff_brief
+  input: workId, runId, reason
+  effect: creates handoff brief node and graph edges
+
+explain_context_gap
+  input: workId
+  returns: missing docs, missing decisions, stale memories, ambiguous owners
+
+detect_context_conflicts
+  input: project | initiative | task
+  returns: contradictory decisions/docs/acceptance criteria and required escalation
+
+read_attention_queue
+  input: agentId, hatAssignmentId, scope
+  returns: prioritized attention items with required actions
+```
+
+All tools must enforce hat visibility, task scope, project scope, and memory policy before returning content.
+
+Communication tools should call `validate_discussion_anchor` before opening one-on-ones, team chats, TPM meetings, director meetings, executive meetings, review panels, broadcasts, or votes. `link_discussion_to_work` should exist for repair and ingestion, not as permission to create orphaned discussion first and link it later.
+
+## Storage Shape
+
+Use CockroachDB for authoritative graph facts and audit.
+
+Suggested tables:
+
+- `graph_nodes`;
+- `graph_edges`;
+- `graph_node_versions`;
+- `graph_edge_versions`;
+- `discussion_anchors`;
+- `conversation_threads`;
+- `conversation_messages`;
+- `meeting_transcripts`;
+- `meeting_summaries`;
+- `decision_records`;
+- `context_pack_requests`;
+- `context_pack_items`;
+- `handoff_briefs`;
+- `retrieval_queries`;
+- `retrieval_results`;
+- `decision_memory_records`;
+- `discussion_summaries`;
+- `context_conflicts`;
+- `context_gaps`;
+- `attention_items`;
+- `lifecycle_compliance_snapshots`;
+
+Use a vector index for semantic retrieval over selected node summaries, message summaries, documents, decisions, artifacts, and memories. Hindsight remains the Hermes memory substrate; the Organization graph controls work-scoped attribution, visibility, and traversal.
+
+`discussion_anchors` should be immutable once a conversation opens. Additional anchors can be appended with audit when scope expands, but the original reason and work item remain part of provenance.
+
+## Summarization and Ingestion
+
+Every conversation mode should produce structured artifacts:
+
+- raw transcript or message log when permitted;
+- rolling summary;
+- decisions;
+- action items;
+- open questions;
+- dissent/uncertainty;
+- linked work items;
+- linked docs/artifacts;
+- proposed memories;
+- proposed skills;
+- follow-up tasks.
+
+The Meeting and Communication Service should call graph ingestion after every meeting close, thread resolution, broadcast, review comment, or one-on-one when the conversation touched work.
+
+Close pipeline:
+
+```text
+raw transcript/message log
+  -> rolling summary
+  -> decision candidates
+  -> action items
+  -> dissent/uncertainty
+  -> open questions
+  -> contradictions
+  -> proposed graph edges
+  -> proposed memories
+  -> human/hat review if confidence is low
+```
+
+Summaries must cite source spans/messages and carry confidence. Low-confidence summaries should not become active decision memory without review.
+
+## Attention Surface
+
+Agents need an attention queue computed from graph, task, runtime, and policy state.
+
+```ts
+type AttentionItem = {
+  id: string;
+  reason: string;
+  urgency: "low" | "normal" | "high" | "blocking";
+  ownerHat: string;
+  sourceSignal: string;
+  requiredAction: string;
+  deadlineOrTtl?: string;
+  blockingEntity?: string;
+  contextPackId?: string;
+  acknowledgementState: "new" | "acknowledged" | "snoozed" | "converted_to_work" | "closed";
+};
+```
+
+Tools:
+
+- `read_attention_queue`;
+- `ack_attention_item`;
+- `snooze_attention_item`;
+- `convert_attention_to_work`.
+
+## Contradiction Lifecycle
+
+Contradictions should be first-class graph nodes, not buried in comments.
+
+```text
+detected
+  -> triaged
+  -> clarification_requested
+  -> resolved_by_decision
+  -> resolved_by_doc_update
+  -> accepted_risk
+  -> false_positive
+```
+
+Unresolved high-severity contradictions block `ready`, `review_approved`, and `release_ready`. Lower-severity contradictions appear in context packs and attention queues.
+
+## Agent-Native Benefits
+
+This graph makes agents better because they can:
+
+- start work with complete scoped context;
+- avoid repeating settled discussions;
+- explain why they chose an approach;
+- detect when a new request conflicts with prior decisions;
+- find the right docs without guessing;
+- trace blockers to owners and decisions;
+- hand off work with durable context;
+- evaluate whether acceptance criteria were actually met;
+- request missing context as a task instead of hallucinating it;
+- build project-specific skills from repeated patterns.
+
+## Guardrails
+
+- No hidden authority: every decision must link to the hat, meeting, vote, or gate that authorized it.
+- No orphan discussions: every work-relevant discussion needs a work link or an explicit no-link reason.
+- No raw over-retrieval: agents receive policy-filtered graph slices, not unrestricted transcripts.
+- No stale context packs: context packs carry freshness and must refresh on state changes.
+- No untraceable summaries: summaries link back to source messages, transcripts, artifacts, or traces.
+- No memory confusion: Hindsight memory can enrich retrieval, but Organization graph facts decide work state and decision provenance.
+
+## MVP Slice
+
+The first slice should prove:
+
+```text
+initiative
+  -> task
+  -> team discussion
+  -> decision
+  -> BRD/CA link
+  -> context pack
+  -> Hermes run
+  -> evidence artifact
+  -> review decision
+```
+
+An agent should be able to ask:
+
+```text
+What do I need to know to work this task, and why?
+```
+
+The system should answer with a cited graph slice, not a generic search result.

--- a/agentic-organization/docs/ALWAYS_ON_ORCHESTRATION_RUNTIME.md
+++ b/agentic-organization/docs/ALWAYS_ON_ORCHESTRATION_RUNTIME.md
@@ -249,7 +249,7 @@ Concurrency policies:
 - replace running job;
 - queue behind running job.
 
-Scheduled jobs should create work, reports, meetings, reviews, or Oz run requests. They should not bypass work management.
+Scheduled jobs should create work, reports, meetings, reviews, or Oz run requests. They should not bypass work management. If a job opens a meeting, review, broadcast, or report, it must provide a discussion anchor such as project, initiative, task, defect, incident, release, gate, policy, capability request, or context gap.
 
 ## Durable Timers
 

--- a/agentic-organization/docs/AMBIGUOUS_REQUIREMENT_LIFECYCLE.md
+++ b/agentic-organization/docs/AMBIGUOUS_REQUIREMENT_LIFECYCLE.md
@@ -125,7 +125,7 @@ Signals:
 
 ## Phase 3: Customer or Stakeholder Interview
 
-The Customer Interviewer hat should run a structured interview. This can be a human conversation, an async questionnaire, or a scoped chat. The key is that answers become evidence, not unstructured chat residue.
+The Customer Interviewer hat should run a structured interview. This can be a human conversation, an async questionnaire, or a scoped chat. The key is that answers become evidence, not unstructured chat residue. The interview thread should anchor to the goal intake, project, initiative, requirement gap, or discovery work item before it starts.
 
 Interview modes:
 

--- a/agentic-organization/docs/ANTI_STALL_PRIORITY_RUNTIME.md
+++ b/agentic-organization/docs/ANTI_STALL_PRIORITY_RUNTIME.md
@@ -258,7 +258,7 @@ If intended and actual state diverge, the system creates a report, inbox item, o
 
 ## Prioritization Meetings and Votes
 
-Routine priority should be handled by the appropriate hats through scheduled reviews and triggered inbox tasks. Meetings and votes occur when a decision crosses role boundaries or policy says judgment is required.
+Routine priority should be handled by the appropriate hats through scheduled reviews and triggered inbox tasks. Meetings and votes occur when a decision crosses role boundaries or policy says judgment is required. Each meeting or vote must anchor to the project, initiative, task, defect, blocker, release, policy, or capability request that created the priority question.
 
 Trigger meetings for:
 

--- a/agentic-organization/docs/DEPARTMENT_HAT_TOOL_INVENTORY.md
+++ b/agentic-organization/docs/DEPARTMENT_HAT_TOOL_INVENTORY.md
@@ -68,8 +68,8 @@ Hat records should store concrete tool IDs, but the design is easier to reason a
 | Team Runtime | `create_team`, `spawn_agent`, `spawn_team`, `assign_task`, `stop_agent`, `stop_team` |
 | Task | `create_task`, `claim_task`, `update_task`, `block_task`, `groom_task`, `mark_ready`, `submit_red_tests`, `submit_green_tests`, `complete_task` |
 | Backlog and Defect | `create_backlog_item`, `prioritize_backlog_item`, `link_backlog_item`, `convert_backlog_item`, `create_backlog_item_from_review`, `create_defect_from_report` |
-| Messaging | `send_message`, `read_inbox`, `send_report`, `open_thread`, `reply_thread`, `request_one_on_one_chat`, `open_team_chat`, `send_team_broadcast`, `escalate` |
-| Meeting | `request_meeting`, `schedule_meeting`, `open_meeting`, `set_conversation_mode`, `submit_meeting_decision`, `close_meeting` |
+| Messaging | `send_message`, `read_inbox`, `send_report`, `open_thread`, `reply_thread`, `request_one_on_one_chat`, `open_team_chat`, `send_team_broadcast`, `validate_discussion_anchor`, `escalate` |
+| Meeting | `request_meeting`, `schedule_meeting`, `open_meeting`, `set_conversation_mode`, `submit_meeting_decision`, `close_meeting`, `validate_discussion_anchor` |
 | Artifact and Evidence | `submit_artifact`, `list_artifacts`, `link_artifact`, `require_artifact`, `attach_screenshot`, `attach_trace`, `attach_log` |
 | Business | `start_customer_interview`, `record_customer_answer`, `create_brd`, `approve_brd`, `reject_brd` |
 | Architecture | `create_ca`, `request_architecture_review`, `approve_architecture`, `reject_architecture` |

--- a/agentic-organization/docs/IMPLEMENTATION_CONCEPTS.md
+++ b/agentic-organization/docs/IMPLEMENTATION_CONCEPTS.md
@@ -121,7 +121,7 @@ Primary services:
 
 ### Meetings and Communication
 
-Owns messages, reports, inboxes, meetings, conversation modes, broadcasts, and escalations.
+Owns messages, reports, inboxes, meetings, conversation modes, broadcasts, escalations, and discussion anchor enforcement.
 
 Core entities:
 
@@ -129,6 +129,7 @@ Core entities:
 - `InboxMessage`
 - `Report`
 - `Thread`
+- `DiscussionAnchor`
 - `Meeting`
 - `MeetingParticipant`
 - `ConversationMode`
@@ -141,6 +142,7 @@ Primary services:
 - `ReportService`
 - `MeetingService`
 - `ThreadService`
+- `DiscussionAnchorService`
 - `EscalationService`
 - `NatsEventBridge`
 
@@ -1071,7 +1073,7 @@ NATS failure behavior:
 
 ## Meetings
 
-Meetings should be implemented as first-class entities, not only chat transcripts.
+Meetings should be implemented as first-class entities, not only chat transcripts. They should not open unless the caller supplies a valid work anchor.
 
 Meeting state:
 
@@ -1089,6 +1091,7 @@ cancelled
 Meeting fields:
 
 - purpose;
+- discussion anchor;
 - organizer hat assignment;
 - participants;
 - hierarchy scope;
@@ -1102,6 +1105,23 @@ Meeting fields:
 - memory outputs.
 
 Conversation modes should be enforced by the Meeting Service at the turn-routing level.
+
+Meeting/thread open preflight:
+
+1. Validate the active hat assignment and token.
+2. Validate the discussion anchor exists and is visible under the hat scope.
+3. Validate the requested participants are allowed for the anchor and hierarchy.
+4. Validate expected outputs such as decision, follow-up task, document, gate result, status, or memory.
+5. If the topic is ambiguous, create or link a context-gap, report, service-request, or capability-request work item before opening the discussion.
+
+Anchor rules:
+
+- executive-down meetings anchor to project, initiative, policy, or capability request;
+- TPM meetings anchor to initiative, mission, blocker, dependency, release, or task set;
+- developer discussions anchor to task, defect, review, run, or context gap;
+- QA, security, architecture, product, and BA discussions anchor to their gate, document, defect, requirement gap, project, or initiative;
+- one-on-ones require both a reason and a work anchor, including performance review or memory adaptation items when the conversation is coaching-oriented;
+- broadcasts and reports carry anchors the same way meetings do.
 
 First MVP can support:
 

--- a/agentic-organization/docs/IMPLEMENTATION_READINESS_CHECKLIST.md
+++ b/agentic-organization/docs/IMPLEMENTATION_READINESS_CHECKLIST.md
@@ -116,6 +116,7 @@ Must include:
 - gate decisions;
 - assignments;
 - releases;
+- discussion anchors;
 - artifacts;
 - signals;
 - audit events;
@@ -226,6 +227,30 @@ Need to define:
 - state transition effects;
 - emitted signals;
 - audit fields.
+
+Knowledge Graph/Retrieval V0 decisions:
+
+- first node and edge schema;
+- context pack contract;
+- indexing provider and reindex triggers;
+- access-control envelope;
+- provenance envelope;
+- deterministic traversal versus semantic retrieval behavior;
+- contradiction lifecycle;
+- discussion anchor contract;
+- handoff brief requirements;
+- attention queue contract.
+
+Minimum preflight tools:
+
+- `validate_start_work`;
+- `validate_discussion_anchor`;
+- `validate_context_pack_current`;
+- `validate_handoff_complete`;
+- `validate_decision_memory_current`;
+- `validate_no_blocking_contradictions`;
+- `validate_required_docs_acknowledged`;
+- `validate_lifecycle_transition`.
 
 ## 9. Hermes/Oz Boundary
 

--- a/agentic-organization/docs/ORGANIZATION_LAYER_BUILD_PLAN.md
+++ b/agentic-organization/docs/ORGANIZATION_LAYER_BUILD_PLAN.md
@@ -141,7 +141,7 @@ No implementation should silently move long-running state from Orleans to NestJS
 | Work Management Service | Owns projects, initiatives, tasks, defects, service requests, blockers, queues, lifecycle state | TPMs, Product, BA, Engineering, QA, Delivery |
 | Gate and Review Service | Owns readiness, BRD, architecture, code, QA, security, delivery, memory, and outcome gates | Review hats and managers |
 | Department Runtime Service | Maintains department rules, queues, schedules, standing meetings, director reports, escalation paths | Directors and department managers |
-| Meeting and Communication Service | Provides inboxes, reports, broadcasts, one-on-one chats, team rooms, meeting modes, decisions | All hats, especially TPMs, directors, executives |
+| Meeting and Communication Service | Provides inboxes, reports, broadcasts, one-on-one chats, team rooms, meeting modes, decisions, and mandatory work anchors for every discussion | All hats, especially TPMs, directors, executives |
 | Documentation Context Service | Organizes BRDs, CAs, ADRs, design docs, project docs, repo docs, and required context by scope | Product, BA, Architecture, Engineering, QA, Reviewers |
 | Project Skill Service | Stores project/repo skills with frontmatter, graph links, review state, deprecation, and ingestion | Engineering Managers, Documentation hats, Memory hats |
 | Memory Scope Service | Mediates Hindsight recall/write attribution by agent, hat, project, task, team, and meeting | Memory hats, all execution hats |
@@ -161,6 +161,7 @@ Every active hat should open into a role-specific workspace. A workspace is the 
 
 - Role brief: current hat, department, scope, reporting chain, active policies, token TTL, and current assignment.
 - Work queue: tasks, reports, gates, reviews, meetings, incidents, or capability requests relevant to the hat.
+- Discussion anchor: the current project, initiative, task, defect, review, incident, release, policy, capability request, or context gap that justifies a meeting/thread/broadcast.
 - Required context: documents, memories, project skills, artifacts, traces, and prior decisions the hat must consider.
 - Allowed tools: MCP tools available under the current hat and why each is available.
 - Blocked tools: MCP tools denied under the current hat with escalation path.
@@ -220,8 +221,9 @@ The Organization DB must capture the full operating reality. The first schema ne
 
 - `inboxes`: agent, hat, team, department, and organization inboxes.
 - `messages`: typed messages, reports, escalations, broadcasts, and decision notices.
-- `conversation_threads`: one-on-one, team, department, executive, incident, and review threads.
-- `meetings`: scheduled or ad hoc meetings with scope, mode, facilitator, participants, decisions.
+- `discussion_anchors`: immutable opening anchors for meetings, one-on-ones, broadcasts, votes, reports, review comments, and conversation threads.
+- `conversation_threads`: one-on-one, team, department, executive, incident, and review threads with mandatory anchors.
+- `meetings`: scheduled or ad hoc meetings with scope, mode, facilitator, participants, anchors, decisions.
 - `votes`: voting scope, eligible hats, quorum, options, close policy, result.
 - `decisions`: durable decision records linked to votes, gates, meetings, docs, tasks, and policies.
 
@@ -565,6 +567,7 @@ Build:
 - broadcasts;
 - one-on-one and team chats;
 - meetings;
+- discussion anchor validation;
 - votes;
 - role-specific queues.
 
@@ -573,6 +576,8 @@ Proof:
 - a TPM can create a team and meeting;
 - a reviewer receives the right gate queue;
 - executive votes and department escalations are durable decisions.
+- unanchored meetings, threads, and broadcasts are rejected;
+- executive meetings anchor to project/initiative/policy, TPM meetings anchor to initiatives/missions, and developer discussions anchor to tasks/defects/reviews.
 
 ### Phase 4: Oz/Hermes Runtime Binding
 

--- a/agentic-organization/docs/ORGANIZATION_RUNTIME_ARCHITECTURE.md
+++ b/agentic-organization/docs/ORGANIZATION_RUNTIME_ARCHITECTURE.md
@@ -1716,7 +1716,26 @@ Reports and messages should include:
 - links to evidence;
 - whether response is required.
 
-Department-wide reporting should be the default for structured findings. Ad hoc chat should be used when a conversation is needed to resolve ambiguity or make a decision.
+Department-wide reporting should be the default for structured findings. Ad hoc chat should be used when a conversation is needed to resolve ambiguity or make a decision, and it still needs a work anchor.
+
+## Discussion Anchor Policy
+
+The Organization should treat every communication as a work artifact. No discussion opens without an anchor and reason.
+
+Required anchors:
+
+- executive-down meetings anchor to project, initiative, policy, capability request, or organization-level decision item;
+- director meetings anchor to department plus project, initiative, policy, queue health, or capability request;
+- TPM meetings anchor to initiative, mission, blocker, dependency, release, or task set;
+- engineering manager/team meetings anchor to team plus task, defect, review, performance review, outcome review, blocker, or capability request;
+- developer discussions anchor to task, defect, review, run, subtask, or context gap;
+- QA discussions anchor to test case, QA run, defect, release candidate, task, or QA gate;
+- security discussions anchor to credential request, tool expansion, policy change, incident, or security review;
+- product, BA, and architecture discussions anchor to project, initiative, BRD, CA, ADR, requirement gap, or approval gate;
+- one-on-ones anchor to handoff, clarification, review, performance review, memory adaptation, task planning, hat proposal, conflict resolution, or context gap;
+- broadcasts and reports anchor to the team, department, project, initiative, task, incident, release, or signal they are about.
+
+If an agent wants to talk but cannot identify the anchor, the system should create a context-gap or service-request work item first. The resulting discussion is then tied to that work item. This keeps the Organization from accumulating unanchored chat while still allowing agents to resolve ambiguity.
 
 ## One-on-One Chats
 
@@ -1734,7 +1753,7 @@ They can be opened for:
 - conflict resolution;
 - task planning.
 
-One-on-one chat should require a reason and scope.
+One-on-one chat should require a reason, scope, and discussion anchor.
 
 During one-on-one mode, the participants can:
 
@@ -1749,7 +1768,7 @@ One-on-one chat should be allowed with same-level or lower-hierarchy hats by def
 
 ## Team Chats and Meetings
 
-Team chats are multi-agent conversations with a defined membership, purpose, and conversation mode.
+Team chats are multi-agent conversations with a defined membership, purpose, conversation mode, and discussion anchor.
 
 Meeting types:
 

--- a/agentic-organization/docs/README.md
+++ b/agentic-organization/docs/README.md
@@ -16,6 +16,7 @@ Current documents:
 - [Department, Hat, and Tool Inventory](./DEPARTMENT_HAT_TOOL_INVENTORY.md) - the starter department map, hat catalog, tool bundles, approval gates, lifecycle ownership, and high-risk guardrails for the Organization.
 - [Organization Layer Build Plan](./ORGANIZATION_LAYER_BUILD_PLAN.md) - the service layer, role workspaces, automation loops, state model, UI surfaces, and MVP sequence needed to make each department and hat operational.
 - [Work and Release Management OS](./WORK_AND_RELEASE_MANAGEMENT_OS.md) - the custom backlog, project, task, assignment, signal, board, and release workflow product that keeps agent work reliable and visible.
+- [Agent-Native Knowledge Graph and Retrieval](./AGENT_NATIVE_KNOWLEDGE_GRAPH.md) - the graph and retrieval layer linking tasks, discussions, decisions, meetings, docs, artifacts, runs, memories, and evidence into agent-readable context.
 - [Ambiguous Requirement Lifecycle](./AMBIGUOUS_REQUIREMENT_LIFECYCLE.md) - the discovery, customer interview, BRD, workflow modeling, architecture, decomposition, readiness, and learning path from vague request to curated feature.
 - [Anti-Stall Prioritization Runtime](./ANTI_STALL_PRIORITY_RUNTIME.md) - the hat-owned schedules, blocker triage, queue SLO, reassignment, alternate-work, dependency reconciliation, and priority routines that keep the Organization moving.
 - [Implementation Readiness Checklist](./IMPLEMENTATION_READINESS_CHECKLIST.md) - the decisions and contracts that should be defined before scaffolding the first implementation slice.

--- a/agentic-organization/docs/RUNTIME_TECH_AND_PACKAGE_STRATEGY.md
+++ b/agentic-organization/docs/RUNTIME_TECH_AND_PACKAGE_STRATEGY.md
@@ -118,8 +118,8 @@ Use Dapr Actors for live, entity-local coordination:
 - `AgentSessionActor`: one live context actor per Hermes session.
 - `AgentMailboxActor`: one mailbox per Hermes agent/session.
 - `HatSupplyActor`: one allocator per hat/project/department scope.
-- `TeamRoomActor`: live team chat, broadcast, and turn-taking state.
-- `MeetingActor`: active meeting agenda, speaker order, votes, and transcript pointer.
+- `TeamRoomActor`: live team chat, broadcast, anchor validation state, and turn-taking state.
+- `MeetingActor`: active meeting agenda, work anchor, speaker order, votes, and transcript pointer.
 - `TaskActor`: hot task coordination, lock/heartbeat, and current assignment state.
 - `ProjectRuntimeActor`: project-local runtime status and aggregate health.
 - `IncidentActor`: live incident command state.
@@ -178,6 +178,7 @@ Runtime context should include:
 - active hat assignment ID;
 - current task ID;
 - current team ID;
+- current discussion anchor;
 - current meeting ID;
 - current Oz run ID;
 - current project ID;

--- a/agentic-organization/docs/UI_AND_OBSERVABILITY_CONCEPTS.md
+++ b/agentic-organization/docs/UI_AND_OBSERVABILITY_CONCEPTS.md
@@ -467,9 +467,12 @@ Supports:
 - review panels;
 - incident triage.
 
+Opening a meeting, thread, one-on-one, vote, report, or broadcast should require an anchor selector. The UI should not provide a generic "start chat" path; the user or agent chooses the project, initiative, task, defect, review, gate, incident, release, policy, capability request, or context gap first.
+
 For each meeting:
 
 - purpose;
+- work anchor and reason;
 - participants and hats;
 - conversation mode;
 - current speaker/turn order;

--- a/agentic-organization/docs/WORK_AND_RELEASE_MANAGEMENT_OS.md
+++ b/agentic-organization/docs/WORK_AND_RELEASE_MANAGEMENT_OS.md
@@ -187,7 +187,7 @@ Signals are durable, typed events. They are not chat messages. They drive boards
 | Anti-stall | `QueueSloViolated`, `BlockedWorkStale`, `BlockerOwnerMissing`, `AssignmentSilent`, `AlternateWorkAssigned`, `DependencyCleared`, `WorkReactivated` | TPMs, Engineering Managers, Directors, Operations |
 | Quality | `RepeatedQaBounceBack`, `MemoryGapDetected`, `FlakyTestDetected`, `AcceptanceCriteriaMissing` | Engineering Managers, QA Engineering, Memory |
 | Capability | `CapabilityRequested`, `SecurityReviewRequired`, `WorkflowRegistered`, `ToolActivated` | Directors, Architecture, Security |
-| Meeting | `MeetingRequested`, `DecisionRecorded`, `VoteOpened`, `VoteClosed` | Participants, governance hats |
+| Meeting | `DiscussionAnchorValidated`, `MeetingRequested`, `DecisionRecorded`, `VoteOpened`, `VoteClosed` | Participants, governance hats |
 
 Every signal should include:
 
@@ -460,6 +460,7 @@ This slice proves:
 
 - No work should be invisible. If an agent is doing work, it must be tied to a work item, hat assignment, run, and trace.
 - No assignment should be implied by chat. Assignment requires hat supply reservation and active token.
+- No discussion may be unanchored. Meetings, threads, broadcasts, one-on-ones, votes, reports, and review comments must reference project, initiative, task, defect, review, gate, incident, release, policy, capability request, or context-gap work.
 - No release should happen without an evidence chain.
 - No workflow should bypass the Work OS. Schedulers and agents create work or signals, then the Work OS drives state.
 - No role should rely on polling chat. Each role needs a queue, board, and signal-driven inbox.


### PR DESCRIPTION
## Summary

- Adds the Agent-Native Knowledge Graph and Retrieval doc as the agent-first context layer for tasks, discussions, decisions, meetings, docs, artifacts, runs, memories, and evidence.
- Makes discussion anchoring a hard Organization invariant: meetings, one-on-ones, team chats, TPM/executive meetings, broadcasts, votes, reports, and review comments must reference a work item or scoped organizational artifact before opening.
- Propagates `validate_discussion_anchor`, `discussion_anchors`, and anchor-aware behavior through MCP tools, the Work OS, UI, actors, scheduled jobs, readiness checks, and runtime architecture docs.

## Validation

- `git diff --check HEAD~1 HEAD`
- `rg -n "AGENT_NATIVE_KNOWLEDGE_GRAPH|Discussion Anchor|validate_discussion_anchor|No discussion may be unanchored" agentic-organization/docs`