### PR TITLE
docs: add agent work rhythm and prompt flows

### DIFF
--- a/agentic-organization/docs/AGENT_NATIVE_KNOWLEDGE_GRAPH.md
+++ b/agentic-organization/docs/AGENT_NATIVE_KNOWLEDGE_GRAPH.md
@@ -66,6 +66,8 @@ type NodeKind =
   | "PromptFlow"
   | "PromptFlowPhase"
   | "PromptFlowRun"
+  | "UniversalAction"
+  | "ActionObservation"
   | "PolicyDecision"
   | "Signal"
   | "ContextPack";
@@ -166,6 +168,8 @@ type EdgeKind =
   | "writes_memory"
   | "uses_skill"
   | "executes_prompt_flow"
+  | "executes_action"
+  | "observed_as"
   | "scheduled_for"
   | "reviewed_by"
   | "derived_from"
@@ -182,6 +186,8 @@ type EdgeKind =
 | `decided_in` | decision -> source | Decision | Meeting/Vote/Thread | meeting/vote ID | supersede decision |
 | `evidence_for` | evidence -> claim/work | Artifact/Trace | Task/Gate | artifact and trace ID | reversible edge |
 | `executes_prompt_flow` | run -> flow | PromptFlowRun | PromptFlow | flow version | supersede flow version |
+| `executes_action` | phase/run -> action | PromptFlowPhase/Run | UniversalAction | action record ID | append correction |
+| `observed_as` | action -> observation | UniversalAction | ActionObservation | tool output/trace | preserve observation |
 | `scheduled_for` | block -> assignment/work | ScheduleBlock | HatAssignment/Task | schedule service | reschedule with audit |
 | `reviewed_by` | output -> reviewer | Phase/Task/Gate | HatAssignment | gate decision | new review supersedes |
 | `contradicts` / `conflicts_with` | node -> node | Decision/Doc | Decision/Doc | detector/tool ID | resolved by decision |
@@ -574,6 +580,8 @@ Suggested tables:
 - `prompt_flow_runs`;
 - `prompt_flow_phase_runs`;
 - `prompt_flow_gate_decisions`;
+- `universal_action_records`;
+- `action_observations`;
 - `attention_items`;
 - `lifecycle_compliance_snapshots`;
 

--- a/agentic-organization/docs/AGENT_NATIVE_KNOWLEDGE_GRAPH.md
+++ b/agentic-organization/docs/AGENT_NATIVE_KNOWLEDGE_GRAPH.md
@@ -62,6 +62,10 @@ type NodeKind =
   | "Run"
   | "Agent"
   | "HatAssignment"
+  | "ScheduleBlock"
+  | "PromptFlow"
+  | "PromptFlowPhase"
+  | "PromptFlowRun"
   | "PolicyDecision"
   | "Signal"
   | "ContextPack";
@@ -161,6 +165,9 @@ type EdgeKind =
   | "recalls_memory"
   | "writes_memory"
   | "uses_skill"
+  | "executes_prompt_flow"
+  | "scheduled_for"
+  | "reviewed_by"
   | "derived_from"
   | "derived_from_doc"
   | "has_context_pack_item"
@@ -174,6 +181,9 @@ type EdgeKind =
 | `discussed_in` | subject -> conversation | Task | Meeting/Thread | message or transcript | reversible edge |
 | `decided_in` | decision -> source | Decision | Meeting/Vote/Thread | meeting/vote ID | supersede decision |
 | `evidence_for` | evidence -> claim/work | Artifact/Trace | Task/Gate | artifact and trace ID | reversible edge |
+| `executes_prompt_flow` | run -> flow | PromptFlowRun | PromptFlow | flow version | supersede flow version |
+| `scheduled_for` | block -> assignment/work | ScheduleBlock | HatAssignment/Task | schedule service | reschedule with audit |
+| `reviewed_by` | output -> reviewer | Phase/Task/Gate | HatAssignment | gate decision | new review supersedes |
 | `contradicts` / `conflicts_with` | node -> node | Decision/Doc | Decision/Doc | detector/tool ID | resolved by decision |
 | `supersedes` / `superseded_by` | new -> old | Decision/Doc | Decision/Doc | approving hat | preserve old node |
 | `has_context_pack_item` | pack -> item | ContextPack | Any node | retrieval query ID | regenerate pack |
@@ -559,6 +569,11 @@ Suggested tables:
 - `discussion_summaries`;
 - `context_conflicts`;
 - `context_gaps`;
+- `schedule_blocks`;
+- `prompt_flow_definitions`;
+- `prompt_flow_runs`;
+- `prompt_flow_phase_runs`;
+- `prompt_flow_gate_decisions`;
 - `attention_items`;
 - `lifecycle_compliance_snapshots`;
 

--- a/agentic-organization/docs/AGENT_WORK_RHYTHM_AND_PROMPT_FLOWS.md
+++ b/agentic-organization/docs/AGENT_WORK_RHYTHM_AND_PROMPT_FLOWS.md
@@ -274,12 +274,12 @@ Suggested records:
 - `prompt_flow_versions`;
 - `prompt_flow_phases`;
 - `prompt_flow_phase_versions`;
-- `prompt_flow_hat_bindings`;
+- `hat_prompt_flow_bindings`;
 - `prompt_flow_gate_policies`;
 - `prompt_flow_runs`;
-- `prompt_flow_run_phases`;
+- `prompt_flow_phase_runs`;
 - `prompt_flow_artifacts`;
-- `prompt_flow_review_decisions`;
+- `prompt_flow_gate_decisions`;
 - `prompt_flow_effectiveness_reviews`.
 
 Flows should be ingested into the graph so agents can retrieve:

--- a/agentic-organization/docs/AGENT_WORK_RHYTHM_AND_PROMPT_FLOWS.md
+++ b/agentic-organization/docs/AGENT_WORK_RHYTHM_AND_PROMPT_FLOWS.md
@@ -102,6 +102,56 @@ review finding
 
 Prompt flows are reusable deterministic pipelines that hats can execute. They are similar in spirit to existing prompt flows, but Organization-native.
 
+They should also be the first practical host for the repo's universal-action-space work. The repo does not yet contain one canonical Universal Action Grammar specification, but it has adjacent prior art:
+
+- `docs/backlog/P3/B-0200-fsharp-codeact-bridge-engineering-aaron-2026-05-05.md` frames CodeAct as executable Python in a unified action space, while preserving Zeta's stronger F# DSL for DST-safe, retraction-native, scale-free, DBSP-native work.
+- `docs/backlog/P3/B-0201-coconut-universal-action-space-research-lane-aaron-2026-05-05.md` keeps the broader universal-action-space research lane alive across CodeAct, Coconut, GibberLink, and LAPA.
+- `docs/SAFE-AUTONOMOUS-ACTIONS.md` defines a bounded, reversible action set with explicit preconditions, undo paths, logging, and one-action-per-tick discipline.
+- `docs/research/2026-04-26-action-mode-classification-correction-and-self-provenance-accountability-framing.md` defines action-mode classification and provenance/accountability framing.
+
+The Organization should reuse those ideas instead of inventing another unrelated action language. Prompt flows become the hat-scoped, review-gated operational layer; the Universal Action Grammar becomes the shared action representation inside phases.
+
+## Universal Action Grammar Fit
+
+For Agentic Organization, a Universal Action Grammar should describe an action as a typed, reversible, observable unit:
+
+```ts
+type UniversalAction = {
+  verb: string;
+  target: {
+    kind: "work_item" | "document" | "repo" | "tool" | "memory" | "meeting" | "run" | "credential" | "policy";
+    id: string;
+  };
+  actor: {
+    agentId: string;
+    hatAssignmentId: string;
+    actionMode: "supervised" | "autonomous_fail_open" | "human_directed";
+  };
+  preconditions: string[];
+  inputs: Record<string, unknown>;
+  expectedOutputs: string[];
+  observationContract: string[];
+  reversibility: "read_only" | "reversible" | "compensating_action" | "irreversible_requires_approval";
+  undoPath?: string;
+  evidenceRequired: string[];
+  policyRefs: string[];
+};
+```
+
+This is not a replacement for MCP tools, Temporal workflows, F# DSLs, or CodeAct-style Python. It is the grammar that lets the Organization describe what an agent is doing across all of them.
+
+Mapping:
+
+| Existing prior art | Organization use |
+|---|---|
+| CodeAct executable actions | A prompt-flow phase may emit executable code actions when ecosystem reach is useful |
+| F# DSL / Zeta operator algebra | Hodl-required actions stay in typed, DST/retraction-safe substrate surfaces |
+| Safe autonomous actions | Every action needs tier, precondition, reversibility, undo path, and audit |
+| Action-mode classification | Every action records whether it was supervised, autonomous fail-open, or human-directed |
+| Prompt-flow phases | Each phase is a bounded action bundle with gates and reviewer hats |
+
+Universal actions should be small enough to review and replay. Prompt flows compose them into useful work.
+
 A prompt flow should define:
 
 - name and version;
@@ -109,6 +159,7 @@ A prompt flow should define:
 - allowed hats;
 - required scope and discussion/work anchor;
 - phases;
+- universal actions allowed per phase;
 - MCP tools available per phase;
 - required inputs and outputs;
 - gates between phases;
@@ -122,6 +173,7 @@ Prompt flows should be composed of reusable phases:
 
 ```text
 Reusable phase
+  -> universal action grammar contract
   -> input contract
   -> MCP tool contract
   -> output artifact
@@ -163,6 +215,8 @@ agent wearing hat
 ```
 
 Agents can still reason creatively inside a phase, but the phase boundary, tools, required outputs, and gates are deterministic.
+
+Prompt-flow execution should record each universal action, observation, correction, and reviewer decision. That gives the Organization a reusable action corpus: over time, Engineering Managers and prompt-flow designers can discover which action patterns work, which fail, and which should become new reusable phases.
 
 ## Flow Gates and Reviewers
 

--- a/agentic-organization/docs/AGENT_WORK_RHYTHM_AND_PROMPT_FLOWS.md
+++ b/agentic-organization/docs/AGENT_WORK_RHYTHM_AND_PROMPT_FLOWS.md
@@ -1,0 +1,287 @@
+# Agent Work Rhythm and Prompt Flows
+
+## Purpose
+
+Hermes agents should not be treated as stateless workers waiting for tasks. The Organization should give each active hat a rhythm: scheduled work blocks, review obligations, learning time, memory reflection, and deterministic prompt-flow automation.
+
+The goal is to make agents better over time while keeping execution governed, reviewable, and tied to work.
+
+## Core Principle
+
+Every active hat assignment should answer:
+
+- what the agent is responsible for now;
+- when the agent should do prioritized work;
+- when the agent should review or red-team others;
+- when the agent should reflect, manage memories, and improve;
+- what deterministic prompt flows the hat may execute;
+- which reviewer hats approve each phase;
+- what evidence is produced.
+
+This schedule is not just calendar metadata. It is part of runtime authority.
+
+## Work Schedule Model
+
+Each agent should have a work schedule while wearing a hat. The schedule is determined by the supervising hat or department policy, with adjustments based on performance reviews, capacity, queue pressure, budget, and current initiative needs.
+
+Schedules should be heavily tied to hats:
+
+```text
+
+Hat definition
+  -> default schedule template
+  -> allowed prompt flows
+  -> required review/reflection blocks
+  -> memory management expectations
+  -> escalation paths
+
+Hat assignment
+  -> concrete schedule instance
+  -> current project/initiative/task scope
+  -> manager-approved adjustments
+  -> runtime execution windows
+```
+
+Recommended schedule block types:
+
+| Block type | Purpose |
+|---|---|
+| Prioritized work | Execute assigned tasks, defects, reviews, QA, planning, or architecture work |
+| Prompt-flow execution | Run a deterministic MCP-driven flow available to the active hat |
+| Review/red-team | Review work from lower, peer, or adjacent hats using the right gate criteria |
+| Reflection | Review recent outcomes, mistakes, delays, and memory quality |
+| Memory maintenance | Stabilize useful memories, deprecate stale memories, correct invalid memories, scope memories by hat/project/task |
+| Free time | Catch up, inspect repos, learn context, ask anchored questions, build culture, and discover improvement opportunities |
+| Office-hours / questions | Open anchored one-on-one or team discussions to resolve ambiguity |
+| Reporting | Produce manager/director/executive reports tied to work items |
+
+Free time is not idle time. It is bounded exploration. It still produces traces, optional memories, questions, reports, or capability requests when something useful is found.
+
+## Schedule Ownership
+
+Schedules should follow the hierarchy:
+
+| Hat layer | Schedule responsibility |
+|---|---|
+| Executive Board / C-suite | Sets organization rhythm, review cadence, standards, and budget/capacity posture |
+| Directors | Set department schedules, department review cadence, and initiative staffing rhythm |
+| TPMs | Coordinate initiative task cadence, meetings, dependencies, and delivery checkpoints |
+| Engineering Managers / equivalent managers | Set team schedules, individual hat schedule adjustments, review/reflection cadence, and memory improvement work |
+| Team leads / mission control | Coordinate active team rooms, handoffs, and short-cycle work sequencing |
+| Individual hats | Execute schedule blocks, request adjustments, report blockers, and perform reflection honestly |
+
+Schedule changes should be auditable. A supervising hat can adjust a schedule, but the agent should be able to report that the schedule is causing slowdowns, context gaps, poor quality, or excessive review lag.
+
+## Hierarchical Review and Red-Team Rhythm
+
+Each hierarchical layer should review the layer below it and also receive structured feedback from below.
+
+Examples:
+
+- executives review director portfolio decisions, standards, budget usage, and department outcomes;
+- directors review TPMs, managers, department throughput, initiative health, and recurring blockers;
+- TPMs review task plans, dependency handling, meeting quality, and initiative evidence;
+- engineering managers review team outcomes, readiness quality, memory/context quality, prompt-flow fit, and whether agents are reaching goals;
+- reviewers red-team implementation, QA, security, architecture, and release evidence;
+- implementers can submit anchored reports when process, docs, memories, tools, or prompt flows slow them down.
+
+This should not become blame flow. Reviews are evidence-producing loops that create work:
+
+```text
+review finding
+  -> no-action decision
+  -> memory adaptation request
+  -> prompt-flow improvement request
+  -> skill/doc improvement request
+  -> capability request
+  -> backlog task
+  -> initiative
+```
+
+## Prompt Flow Model
+
+Prompt flows are reusable deterministic pipelines that hats can execute. They are similar in spirit to existing prompt flows, but Organization-native.
+
+A prompt flow should define:
+
+- name and version;
+- owning department;
+- allowed hats;
+- required scope and discussion/work anchor;
+- phases;
+- MCP tools available per phase;
+- required inputs and outputs;
+- gates between phases;
+- reviewer hats for each gate;
+- memory read/write policy;
+- artifacts and evidence requirements;
+- timeout, retry, and escalation policy;
+- ingestion metadata for graph/retrieval.
+
+Prompt flows should be composed of reusable phases:
+
+```text
+Reusable phase
+  -> input contract
+  -> MCP tool contract
+  -> output artifact
+  -> gate criteria
+  -> reviewer hat
+  -> memory behavior
+```
+
+Example phases:
+
+- gather context;
+- inspect repo;
+- ask clarification questions;
+- draft BRD;
+- draft CA;
+- write red tests;
+- implement;
+- run tests;
+- perform code review;
+- perform QA browser review;
+- capture screenshots/traces;
+- summarize evidence;
+- reflect on memory quality.
+
+## Deterministic Flow Execution
+
+When a hat starts a prompt flow, the agent should be locked into the flow until it completes, pauses, fails, or escalates.
+
+```text
+agent wearing hat
+  -> select allowed prompt flow
+  -> validate work anchor and scope
+  -> resolve context pack
+  -> execute phase 1 with allowed MCP tools
+  -> persist output and evidence
+  -> gate review by required reviewer hat
+  -> continue / revise / pause / fail / escalate
+  -> ingest transcript, artifacts, decisions, and memory events
+```
+
+Agents can still reason creatively inside a phase, but the phase boundary, tools, required outputs, and gates are deterministic.
+
+## Flow Gates and Reviewers
+
+Every important phase should have an explicit gate.
+
+Gate examples:
+
+| Flow phase | Reviewer |
+|---|---|
+| BRD drafted | Business Analyst Reviewer / Product Owner |
+| CA drafted | Architecture Reviewer |
+| Red tests written | Engineering Manager or Test Reviewer |
+| Implementation complete | Code Reviewer |
+| QA run complete | QA Reviewer |
+| Security-sensitive change | Security Reviewer |
+| Memory adaptation proposed | Memory Curator |
+| Prompt flow changed | Flow Designer Reviewer / Architecture / Security as needed |
+
+Reviewers should not merely approve text. They should verify evidence, trace links, work anchors, scope, and acceptance criteria.
+
+## Flow Creation and Expansion
+
+Prompt flows should be built by the Organization through the same lifecycle as other capabilities.
+
+```text
+manager/director detects repeated slowdown
+  -> capability request: new or improved prompt flow
+  -> business/product clarifies value and expected outcome
+  -> architecture defines flow shape, state, MCP tools, gates, and data model impact
+  -> security reviews tool/credential/memory risk
+  -> internal capability team implements reusable phases and flow definition
+  -> reviewers approve
+  -> flow registry activates it for scoped hats
+  -> outcome review checks whether the flow improved future work
+```
+
+The internal capability team should be able to create:
+
+- new reusable phases;
+- new prompt flows;
+- flow revisions;
+- phase templates;
+- flow-specific MCP wrappers;
+- validation rules;
+- flow telemetry dashboards;
+- flow quality reports.
+
+## Flow Registry
+
+The Organization needs a prompt-flow registry.
+
+Suggested records:
+
+- `prompt_flow_definitions`;
+- `prompt_flow_versions`;
+- `prompt_flow_phases`;
+- `prompt_flow_phase_versions`;
+- `prompt_flow_hat_bindings`;
+- `prompt_flow_gate_policies`;
+- `prompt_flow_runs`;
+- `prompt_flow_run_phases`;
+- `prompt_flow_artifacts`;
+- `prompt_flow_review_decisions`;
+- `prompt_flow_effectiveness_reviews`.
+
+Flows should be ingested into the graph so agents can retrieve:
+
+- which flows are available to a hat;
+- which flows worked well for similar tasks;
+- which phases often fail;
+- which reviewers rejected flow outputs and why;
+- which memories/docs/skills were used by a flow;
+- whether a flow is deprecated or superseded.
+
+## Memory Reflection Blocks
+
+Memory work should be part of schedule, not an afterthought.
+
+During reflection and memory maintenance, agents should:
+
+- review work just completed;
+- identify what helped or slowed them down;
+- compare expected outcome to actual outcome;
+- decide which memories should be retained, stabilized, updated, scoped, deprecated, or challenged;
+- identify outdated or invalid memories;
+- create memory adaptation requests when they lack authority to change memory directly;
+- attach memory reflections to the relevant hat assignment, project, initiative, task, prompt-flow run, and outcome review.
+
+Memory curators and engineering managers should review repeated memory problems and turn them into tasks, docs, skills, or flow improvements.
+
+## Free Time Guardrails
+
+Free time should support culture and learning, but it still belongs to the Organization runtime.
+
+Allowed free-time activities:
+
+- catch up on relevant inboxes, docs, decisions, and context packs;
+- inspect repos or project areas within scope;
+- learn a framework, package, codebase, or runtime component relevant to the hat;
+- ask anchored questions from other agents;
+- propose docs, skills, memories, prompt flows, tools, or backlog items;
+- prepare for upcoming work;
+- reflect on prior outcomes.
+
+Guardrails:
+
+- free-time discussion still requires a work anchor or context-gap item;
+- tool use remains governed by the active hat;
+- discoveries become reports, memories, docs, skills, or capability requests;
+- free time should not bypass task priority, budget, or hat authority.
+
+## MVP Slice
+
+The first implementation should keep this small:
+
+1. Add schedule templates to hat definitions.
+2. Create concrete schedule blocks for active hat assignments.
+3. Add one prompt flow with three phases: gather context, execute work, produce evidence.
+4. Add one reviewer gate between execution and completion.
+5. Add one reflection block that creates a memory adaptation request or no-action decision.
+
+This gives the Organization a heartbeat without requiring every future department rhythm on day one.

--- a/agentic-organization/docs/ALWAYS_ON_ORCHESTRATION_RUNTIME.md
+++ b/agentic-organization/docs/ALWAYS_ON_ORCHESTRATION_RUNTIME.md
@@ -218,6 +218,7 @@ Scheduled jobs need explicit execution behavior.
 `scheduled_jobs` should include:
 
 - owner hat assignment;
+- target schedule block or prompt-flow run when applicable;
 - department/project/initiative/team scope;
 - cadence;
 - timezone;
@@ -249,7 +250,9 @@ Concurrency policies:
 - replace running job;
 - queue behind running job.
 
-Scheduled jobs should create work, reports, meetings, reviews, or Oz run requests. They should not bypass work management. If a job opens a meeting, review, broadcast, or report, it must provide a discussion anchor such as project, initiative, task, defect, incident, release, gate, policy, capability request, or context gap.
+Scheduled jobs should create work, schedule blocks, prompt-flow runs, reports, meetings, reviews, or Oz run requests. They should not bypass work management. If a job opens a meeting, review, broadcast, or report, it must provide a discussion anchor such as project, initiative, task, defect, incident, release, gate, policy, capability request, or context gap.
+
+Schedule-driven jobs should activate the right block at the right time: prioritized work, prompt-flow execution, review/red-team, reflection, memory maintenance, free time, office-hours/questions, or reporting. Reflection and memory-maintenance jobs should create memory events, memory adaptation requests, or explicit no-action decisions.
 
 ## Durable Timers
 

--- a/agentic-organization/docs/DEPARTMENT_HAT_TOOL_INVENTORY.md
+++ b/agentic-organization/docs/DEPARTMENT_HAT_TOOL_INVENTORY.md
@@ -66,6 +66,8 @@ Hat records should store concrete tool IDs, but the design is easier to reason a
 | Agent Insight | `rank_agents_for_hat`, `read_agent_specialties`, `read_agent_memory_profile`, `read_hat_performance_history`, `recommend_hat_assignment` |
 | Voting | `open_vote`, `submit_vote`, `close_vote`, `read_vote_result` |
 | Team Runtime | `create_team`, `spawn_agent`, `spawn_team`, `assign_task`, `stop_agent`, `stop_team` |
+| Work Rhythm | `read_schedule`, `propose_schedule_adjustment`, `approve_schedule_adjustment`, `start_schedule_block`, `complete_schedule_block`, `request_reflection_block`, `record_free_time_output` |
+| Prompt Flow | `list_available_prompt_flows`, `start_prompt_flow`, `submit_prompt_flow_phase`, `request_prompt_flow_gate`, `approve_prompt_flow_gate`, `reject_prompt_flow_gate`, `propose_prompt_flow`, `deprecate_prompt_flow` |
 | Task | `create_task`, `claim_task`, `update_task`, `block_task`, `groom_task`, `mark_ready`, `submit_red_tests`, `submit_green_tests`, `complete_task` |
 | Backlog and Defect | `create_backlog_item`, `prioritize_backlog_item`, `link_backlog_item`, `convert_backlog_item`, `create_backlog_item_from_review`, `create_defect_from_report` |
 | Messaging | `send_message`, `read_inbox`, `send_report`, `open_thread`, `reply_thread`, `request_one_on_one_chat`, `open_team_chat`, `send_team_broadcast`, `validate_discussion_anchor`, `escalate` |
@@ -74,7 +76,7 @@ Hat records should store concrete tool IDs, but the design is easier to reason a
 | Business | `start_customer_interview`, `record_customer_answer`, `create_brd`, `approve_brd`, `reject_brd` |
 | Architecture | `create_ca`, `request_architecture_review`, `approve_architecture`, `reject_architecture` |
 | Review and Gates | `request_review`, `submit_review`, `approve_gate`, `reject_gate`, `assign_reviewer`, `create_outcome_review`, `create_performance_review` |
-| Memory | `query_memory`, `write_memory`, `explain_memory_scope` |
+| Memory | `query_memory`, `write_memory`, `explain_memory_scope`, `reflect_on_memory`, `propose_memory_update`, `deprecate_memory`, `create_memory_adaptation_request` |
 | Credential Proxy | `request_credential_scope`, `review_credential_scope`, `approve_credential_scope`, `use_credential_proxy` |
 | QA | `create_test_case`, `run_browser_check`, `run_scheduled_qa_suite`, `record_qa_result`, `create_reproducibility_report`, `create_regression_report`, `qa_signoff`, `qa_bounce_back` |
 | DevOps | `submit_pipeline_failure_report`, `classify_pipeline_failure`, `attach_pipeline_log`, `recommend_dev_owner` |

--- a/agentic-organization/docs/DEPARTMENT_HAT_TOOL_INVENTORY.md
+++ b/agentic-organization/docs/DEPARTMENT_HAT_TOOL_INVENTORY.md
@@ -68,6 +68,7 @@ Hat records should store concrete tool IDs, but the design is easier to reason a
 | Team Runtime | `create_team`, `spawn_agent`, `spawn_team`, `assign_task`, `stop_agent`, `stop_team` |
 | Work Rhythm | `read_schedule`, `propose_schedule_adjustment`, `approve_schedule_adjustment`, `start_schedule_block`, `complete_schedule_block`, `request_reflection_block`, `record_free_time_output` |
 | Prompt Flow | `list_available_prompt_flows`, `start_prompt_flow`, `submit_prompt_flow_phase`, `request_prompt_flow_gate`, `approve_prompt_flow_gate`, `reject_prompt_flow_gate`, `propose_prompt_flow`, `deprecate_prompt_flow` |
+| Universal Action Grammar | `list_universal_actions`, `validate_universal_action`, `record_action_observation`, `request_action_correction`, `record_action_reversal`, `promote_action_to_phase` |
 | Task | `create_task`, `claim_task`, `update_task`, `block_task`, `groom_task`, `mark_ready`, `submit_red_tests`, `submit_green_tests`, `complete_task` |
 | Backlog and Defect | `create_backlog_item`, `prioritize_backlog_item`, `link_backlog_item`, `convert_backlog_item`, `create_backlog_item_from_review`, `create_defect_from_report` |
 | Messaging | `send_message`, `read_inbox`, `send_report`, `open_thread`, `reply_thread`, `request_one_on_one_chat`, `open_team_chat`, `send_team_broadcast`, `validate_discussion_anchor`, `escalate` |

--- a/agentic-organization/docs/IMPLEMENTATION_CONCEPTS.md
+++ b/agentic-organization/docs/IMPLEMENTATION_CONCEPTS.md
@@ -119,6 +119,34 @@ Primary services:
 - `DefectTriageService`
 - `ServiceRequestService`
 
+### Work Rhythm and Prompt Flows
+
+Owns hat-bound schedule templates, concrete schedule blocks, deterministic prompt flows, reusable phases, phase gates, flow runs, reflection blocks, and memory-maintenance work.
+
+Core entities:
+
+- `HatScheduleTemplate`
+- `WorkSchedule`
+- `WorkScheduleBlock`
+- `PromptFlowDefinition`
+- `PromptFlowVersion`
+- `PromptFlowPhase`
+- `PromptFlowRun`
+- `PromptFlowPhaseRun`
+- `PromptFlowGateDecision`
+- `ReflectionBlock`
+- `MemoryMaintenanceAction`
+
+Primary services:
+
+- `WorkScheduleService`
+- `ScheduleTemplateService`
+- `PromptFlowRegistryService`
+- `PromptFlowExecutionService`
+- `PromptFlowGateService`
+- `ReflectionService`
+- `MemoryMaintenanceService`
+
 ### Meetings and Communication
 
 Owns messages, reports, inboxes, meetings, conversation modes, broadcasts, escalations, and discussion anchor enforcement.
@@ -1131,6 +1159,67 @@ First MVP can support:
 
 Add pass-the-stick and reviewer-panel later.
 
+## Work Schedules and Prompt Flows
+
+Work schedules should be first-class runtime records. A schedule template belongs to a hat or department; a concrete schedule belongs to an active hat assignment.
+
+Schedule block states:
+
+```text
+planned
+  -> active
+  -> paused
+  -> completed
+  -> missed
+  -> rescheduled
+  -> cancelled
+```
+
+Schedule block types:
+
+- prioritized work;
+- prompt-flow execution;
+- review/red-team;
+- reflection;
+- memory maintenance;
+- free time;
+- office-hours/questions;
+- reporting.
+
+Prompt-flow state:
+
+```text
+draft
+  -> review
+  -> active
+  -> deprecated
+  -> superseded
+```
+
+Prompt-flow run state:
+
+```text
+created
+  -> context_validated
+  -> phase_running
+  -> phase_gate_pending
+  -> revision_required
+  -> completed
+  -> failed
+  -> escalated
+```
+
+Prompt-flow execution preflight:
+
+1. Validate active hat assignment, work anchor, and schedule block.
+2. Validate the prompt flow is bound to the hat and scope.
+3. Build the required context pack.
+4. Resolve allowed MCP tools for the current phase.
+5. Persist phase outputs, evidence, traces, and memory events.
+6. Route gate decisions to the required reviewer hats.
+
+Free-time blocks should still run through the MCP gateway and discussion-anchor policy. If free time discovers a useful improvement, it should create a report, memory, skill proposal, prompt-flow improvement request, or capability request.
+
 ## Workflow State Machines
 
 Every workflow state change should be implemented as a permissioned command.
@@ -1963,6 +2052,8 @@ Capability request types:
 - credential proxy endpoint;
 - external API integration;
 - Temporal workflow;
+- prompt flow;
+- reusable prompt-flow phase;
 - Dapr actor;
 - durable trigger or scheduled job;
 - observability/tooling improvement;
@@ -1986,7 +2077,20 @@ submitted
   -> active
 ```
 
-Engineering Managers review team-level need and evidence. Department Directors decide whether the capability belongs in the department backlog or becomes an initiative. Security approves new credential proxy endpoints, credential scopes, external APIs, and dangerous automations. Architecture approves new Temporal workflows, Dapr actors, runtime workers, or cross-service integrations.
+Engineering Managers review team-level need and evidence. Department Directors decide whether the capability belongs in the department backlog or becomes an initiative. Security approves new credential proxy endpoints, credential scopes, external APIs, and dangerous automations. Architecture approves new Temporal workflows, Dapr actors, prompt-flow execution semantics, runtime workers, or cross-service integrations.
+
+Prompt-flow capability requests must define:
+
+- target hats;
+- repeated slowdown or quality gap being solved;
+- reusable phases;
+- phase MCP tools;
+- gate reviewers;
+- required artifacts and evidence;
+- memory read/write behavior;
+- schedule block type;
+- graph ingestion requirements;
+- effectiveness metrics.
 
 Temporal workflow capability requests must define:
 

--- a/agentic-organization/docs/IMPLEMENTATION_CONCEPTS.md
+++ b/agentic-organization/docs/IMPLEMENTATION_CONCEPTS.md
@@ -121,7 +121,7 @@ Primary services:
 
 ### Work Rhythm and Prompt Flows
 
-Owns hat-bound schedule templates, concrete schedule blocks, deterministic prompt flows, reusable phases, phase gates, flow runs, reflection blocks, and memory-maintenance work.
+Owns hat-bound schedule templates, concrete schedule blocks, deterministic prompt flows, reusable phases, phase gates, flow runs, universal action records, reflection blocks, and memory-maintenance work.
 
 Core entities:
 
@@ -134,6 +134,9 @@ Core entities:
 - `PromptFlowRun`
 - `PromptFlowPhaseRun`
 - `PromptFlowGateDecision`
+- `UniversalActionDefinition`
+- `UniversalActionRecord`
+- `UniversalActionObservation`
 - `ReflectionBlock`
 - `MemoryMaintenanceAction`
 
@@ -144,6 +147,8 @@ Primary services:
 - `PromptFlowRegistryService`
 - `PromptFlowExecutionService`
 - `PromptFlowGateService`
+- `UniversalActionGrammarService`
+- `ActionObservationService`
 - `ReflectionService`
 - `MemoryMaintenanceService`
 

--- a/agentic-organization/docs/IMPLEMENTATION_READINESS_CHECKLIST.md
+++ b/agentic-organization/docs/IMPLEMENTATION_READINESS_CHECKLIST.md
@@ -115,6 +115,13 @@ Must include:
 - gates;
 - gate decisions;
 - assignments;
+- hat schedule templates;
+- work schedules;
+- work schedule blocks;
+- prompt-flow definitions;
+- prompt-flow phases;
+- prompt-flow runs;
+- prompt-flow gate decisions;
 - releases;
 - discussion anchors;
 - artifacts;
@@ -129,6 +136,7 @@ Can defer:
 - complex voting;
 - full workflow registry;
 - full actor registry;
+- advanced prompt-flow effectiveness analytics;
 - advanced memory analytics.
 
 ## 5. State Machines
@@ -177,6 +185,9 @@ Need to define for each:
 - allowed MCP tools;
 - approval scopes;
 - memory scopes;
+- default schedule template;
+- available prompt flows;
+- review/reflection requirements;
 - credential scopes;
 - assignable-by rules;
 - token TTL;
@@ -213,6 +224,8 @@ Minimum tool families:
 - architecture tools;
 - task/work tools;
 - hat assignment tools;
+- work schedule tools;
+- prompt-flow tools;
 - review/gate tools;
 - artifact/evidence tools;
 - messaging/inbox tools;
@@ -238,6 +251,8 @@ Knowledge Graph/Retrieval V0 decisions:
 - deterministic traversal versus semantic retrieval behavior;
 - contradiction lifecycle;
 - discussion anchor contract;
+- schedule block contract;
+- prompt-flow registry contract;
 - handoff brief requirements;
 - attention queue contract.
 
@@ -245,6 +260,9 @@ Minimum preflight tools:
 
 - `validate_start_work`;
 - `validate_discussion_anchor`;
+- `validate_schedule_block`;
+- `validate_prompt_flow_start`;
+- `validate_prompt_flow_phase_gate`;
 - `validate_context_pack_current`;
 - `validate_handoff_complete`;
 - `validate_decision_memory_current`;

--- a/agentic-organization/docs/IMPLEMENTATION_READINESS_CHECKLIST.md
+++ b/agentic-organization/docs/IMPLEMENTATION_READINESS_CHECKLIST.md
@@ -122,6 +122,9 @@ Must include:
 - prompt-flow phases;
 - prompt-flow runs;
 - prompt-flow gate decisions;
+- universal action definitions;
+- universal action records;
+- action observations;
 - releases;
 - discussion anchors;
 - artifacts;
@@ -253,6 +256,7 @@ Knowledge Graph/Retrieval V0 decisions:
 - discussion anchor contract;
 - schedule block contract;
 - prompt-flow registry contract;
+- universal action grammar contract;
 - handoff brief requirements;
 - attention queue contract.
 
@@ -263,6 +267,8 @@ Minimum preflight tools:
 - `validate_schedule_block`;
 - `validate_prompt_flow_start`;
 - `validate_prompt_flow_phase_gate`;
+- `validate_universal_action`;
+- `validate_action_reversibility`;
 - `validate_context_pack_current`;
 - `validate_handoff_complete`;
 - `validate_decision_memory_current`;

--- a/agentic-organization/docs/ORGANIZATION_LAYER_BUILD_PLAN.md
+++ b/agentic-organization/docs/ORGANIZATION_LAYER_BUILD_PLAN.md
@@ -141,6 +141,7 @@ No implementation should silently move long-running state from Orleans to NestJS
 | Work Management Service | Owns projects, initiatives, tasks, defects, service requests, blockers, queues, lifecycle state | TPMs, Product, BA, Engineering, QA, Delivery |
 | Gate and Review Service | Owns readiness, BRD, architecture, code, QA, security, delivery, memory, and outcome gates | Review hats and managers |
 | Department Runtime Service | Maintains department rules, queues, schedules, standing meetings, director reports, escalation paths | Directors and department managers |
+| Work Schedule Service | Creates hat-bound schedule templates, concrete schedule blocks, free-time windows, reflection windows, and manager-approved adjustments | Directors, Engineering Managers, TPMs, all active hats |
 | Meeting and Communication Service | Provides inboxes, reports, broadcasts, one-on-one chats, team rooms, meeting modes, decisions, and mandatory work anchors for every discussion | All hats, especially TPMs, directors, executives |
 | Documentation Context Service | Organizes BRDs, CAs, ADRs, design docs, project docs, repo docs, and required context by scope | Product, BA, Architecture, Engineering, QA, Reviewers |
 | Project Skill Service | Stores project/repo skills with frontmatter, graph links, review state, deprecation, and ingestion | Engineering Managers, Documentation hats, Memory hats |
@@ -148,6 +149,7 @@ No implementation should silently move long-running state from Orleans to NestJS
 | Tool and Credential Gateway | Authorizes MCP tools and credential proxy use using actor context, hat policy, OPA, and audit | Security, all tool-using hats |
 | Oz/Hermes Run Service | Creates and binds Hermes/Oz runs to tasks, teams, hats, pods, sessions, logs, artifacts | TPMs, Engineering Managers, Operations |
 | Automation Runtime Service | Runs triggers, rules, reaction plans, schedules, leases, timers, and replay-safe workers | Operations, Scheduler Steward, Trigger Steward |
+| Prompt Flow Registry Service | Stores reusable phases, prompt-flow definitions, hat bindings, phase gates, flow runs, and effectiveness reviews | Engineering Managers, Directors, Capability teams, Reviewers |
 | Capability Expansion Service | Accepts requests for tools, workflows, actors, hats, docs, skills, and credentials; routes approvals | Engineering Managers, Directors, Security, Architecture |
 | Observability and Evidence Service | Captures traces, logs, metrics, screenshots, artifacts, timelines, SLOs, audit events | Operations, QA, Reviewers, UI |
 | Performance and Learning Service | Runs team reviews, hat effectiveness reviews, outcome reviews, memory adaptation, process improvements | Engineering Managers, Directors, Memory, Executives |
@@ -160,10 +162,12 @@ Every active hat should open into a role-specific workspace. A workspace is the 
 ### Common Workspace Elements
 
 - Role brief: current hat, department, scope, reporting chain, active policies, token TTL, and current assignment.
+- Work rhythm: current schedule block, next scheduled work/review/reflection/free-time block, and manager-approved adjustments.
 - Work queue: tasks, reports, gates, reviews, meetings, incidents, or capability requests relevant to the hat.
 - Discussion anchor: the current project, initiative, task, defect, review, incident, release, policy, capability request, or context gap that justifies a meeting/thread/broadcast.
 - Required context: documents, memories, project skills, artifacts, traces, and prior decisions the hat must consider.
 - Allowed tools: MCP tools available under the current hat and why each is available.
+- Available prompt flows: deterministic MCP-driven flows the current hat can execute, including required inputs, phases, gates, reviewers, and expected artifacts.
 - Blocked tools: MCP tools denied under the current hat with escalation path.
 - Inbox: direct messages, reports, meeting invites, escalations, and broadcasts.
 - Decision log: votes, approvals, rejections, gate outcomes, and rationale.
@@ -202,6 +206,8 @@ The Organization DB must capture the full operating reality. The first schema ne
 - `agent_sessions`: active runtime sessions, Oz run IDs, pod bindings, heartbeat, current context.
 - `departments`: department records, reporting line, active rules, owner hats.
 - `hat_definitions`: role authority, tool bundles, approval scopes, memory scopes, credential scopes, voting scopes.
+- `hat_schedule_templates`: default work/review/reflection/free-time rhythm attached to hats and departments.
+- `hat_prompt_flow_bindings`: prompt flows and reusable phases available to a hat by scope.
 - `hat_assignments`: agent, hat, project/team/task scope, token TTL, status, assigned by, released by.
 - `hat_supply_policies`: max concurrent assignments, scarcity rules, reserve pools, budget class.
 - `hat_tokens`: issued JWT metadata, refresh state, revocation state, actor binding.
@@ -216,6 +222,8 @@ The Organization DB must capture the full operating reality. The first schema ne
 - `dependencies`: work-to-work, initiative-to-initiative, project-to-project dependencies.
 - `gates`: BRD, architecture, code review, QA, security, delivery, memory, outcome gates.
 - `gate_decisions`: approval/rejection, rationale, evidence links, reviewer hat assignment.
+- `work_schedules`: concrete schedules for active agents and hat assignments.
+- `work_schedule_blocks`: prioritized work, prompt-flow execution, review/red-team, reflection, memory maintenance, free-time, office-hours, and reporting blocks.
 
 ### Communication and Decisions
 
@@ -242,6 +250,10 @@ The Organization DB must capture the full operating reality. The first schema ne
 - `credential_requests`: requested scope, business need, reviewer, approval state.
 - `oz_runs`: bound Hermes/Oz sessions, parent/child runs, pod, status, budget, artifacts.
 - `automation_rules`: organization, department, project, initiative, team, hat, and task rules.
+- `prompt_flow_definitions`: reusable deterministic pipelines that hats can execute.
+- `prompt_flow_phases`: reusable phases with input/output, MCP tools, evidence, and memory behavior.
+- `prompt_flow_runs`: concrete executions bound to work, hat assignment, schedule block, artifacts, gates, and traces.
+- `prompt_flow_gate_decisions`: reviewer decisions between phases.
 - `durable_triggers`: event, state, timeout, schedule, threshold, and external triggers.
 - `reaction_plans`: deterministic rule output before side effects execute.
 - `runtime_leases`: lease owner, fencing token, heartbeat, expiration, release reason.
@@ -452,6 +464,11 @@ type HatActivationPacket = {
   responsibilities: string[];
   allowedToolIds: string[];
   blockedToolIds: string[];
+  currentScheduleBlockId?: string;
+  scheduleTemplateId?: string;
+  allowedPromptFlowIds: string[];
+  requiredReviewBlocks: string[];
+  requiredReflectionBlocks: string[];
   memoryScopes: string[];
   credentialScopes: string[];
   requiredDocuments: string[];
@@ -642,6 +659,8 @@ Build:
 - capability request flow;
 - credential request flow;
 - workflow registry;
+- prompt-flow registry;
+- reusable phase registry;
 - actor registry;
 - MCP registry;
 - post-activation monitoring.
@@ -653,22 +672,27 @@ Proof:
 - Security and Architecture review it;
 - implementation work is created;
 - registry activation makes the new capability available to scoped hats.
+- a manager can request a new prompt flow when repeated slowdowns appear;
+- approved prompt flows become available only to scoped hats.
 
 ### Phase 8: Performance and Self-Improvement
 
 Build:
 
+- schedule templates and schedule blocks;
 - outcome reviews;
 - performance reviews;
 - hat effectiveness reviews;
 - department reviews;
 - memory adaptation;
+- reflection and memory-maintenance blocks;
 - process improvement backlog.
 
 Proof:
 
 - repeated QA bounce-backs create improvement work;
 - bad memory/context outcomes produce memory adaptation requests;
+- reflection blocks produce memory updates, memory adaptation requests, or explicit no-action decisions;
 - ineffective hat definitions produce hat redesign proposals;
 - department reviews become prioritized backlog.
 

--- a/agentic-organization/docs/ORGANIZATION_LAYER_BUILD_PLAN.md
+++ b/agentic-organization/docs/ORGANIZATION_LAYER_BUILD_PLAN.md
@@ -254,6 +254,9 @@ The Organization DB must capture the full operating reality. The first schema ne
 - `prompt_flow_phases`: reusable phases with input/output, MCP tools, evidence, and memory behavior.
 - `prompt_flow_runs`: concrete executions bound to work, hat assignment, schedule block, artifacts, gates, and traces.
 - `prompt_flow_gate_decisions`: reviewer decisions between phases.
+- `universal_action_definitions`: typed action grammar entries available to prompt-flow phases.
+- `universal_action_records`: concrete action attempts with actor, hat, mode, preconditions, reversibility, observations, evidence, and policy.
+- `universal_action_observations`: execution feedback, tool outputs, errors, corrections, and follow-up actions.
 - `durable_triggers`: event, state, timeout, schedule, threshold, and external triggers.
 - `reaction_plans`: deterministic rule output before side effects execute.
 - `runtime_leases`: lease owner, fencing token, heartbeat, expiration, release reason.

--- a/agentic-organization/docs/ORGANIZATION_RUNTIME_ARCHITECTURE.md
+++ b/agentic-organization/docs/ORGANIZATION_RUNTIME_ARCHITECTURE.md
@@ -76,6 +76,8 @@ The lifecycle for turning vague requirements into curated features lives in [Amb
 
 The hat-owned movement, blocker, queue SLO, and reprioritization model lives in [Anti-Stall Prioritization Runtime](./ANTI_STALL_PRIORITY_RUNTIME.md).
 
+The hat-bound schedule, free-time, review/red-team, memory reflection, and deterministic prompt-flow model lives in [Agent Work Rhythm and Prompt Flows](./AGENT_WORK_RHYTHM_AND_PROMPT_FLOWS.md).
+
 The pre-implementation decision checklist lives in [Implementation Readiness Checklist](./IMPLEMENTATION_READINESS_CHECKLIST.md).
 
 The Kubernetes-native hat enforcement/projection model lives in [Cluster-Native Hat System](./CLUSTER_NATIVE_HAT_SYSTEM.md).
@@ -234,6 +236,7 @@ The hat graph describes:
 - which hats exist;
 - which hats depend on other hats;
 - which hats can supervise or review other hats;
+- which schedule templates, review obligations, free-time blocks, and prompt flows each hat carries;
 - which hats belong to departments;
 - which hats can vote on which decisions;
 - which hats can spawn or assign which other hats;
@@ -241,6 +244,35 @@ The hat graph describes:
 - which tools and credentials each hat can use.
 
 The hat graph is similar to a skill graph, but it includes role authority and policy.
+
+## Work Rhythm and Prompt Flows
+
+Hats should carry both authority and rhythm. When an agent receives a hat, it should also receive a schedule template, allowed prompt flows, review duties, reflection expectations, and memory maintenance expectations.
+
+Agent time should be divided into explicit blocks:
+
+- prioritized work time for assigned tasks, defects, reviews, QA, architecture, discovery, or operations;
+- deterministic prompt-flow execution time for reusable MCP-driven pipelines;
+- review/red-team time where the agent reviews work from lower, peer, or adjacent hats;
+- reflection and memory maintenance time for reviewing outcomes, stabilizing useful memories, challenging stale memories, and creating adaptation requests;
+- free time for catching up, learning scoped context, inspecting repos, asking anchored questions, and discovering improvements.
+
+Supervising hats should define or adjust schedules based on department policy, performance reviews, queue pressure, budget, and current initiative needs. Agents should be able to report when a schedule causes slowdowns, missing context, poor quality, or insufficient reflection time.
+
+Prompt flows should be registered Organization artifacts. A hat can execute only the prompt flows available to that hat and scope. Each flow is composed of reusable phases, MCP tool limits, required outputs, evidence, memory behavior, and reviewer gates.
+
+```text
+hat assignment
+  -> schedule block opens
+  -> allowed prompt flow selected
+  -> work anchor and context pack validated
+  -> phase executes with scoped MCP tools
+  -> evidence persisted
+  -> reviewer gate decides continue / revise / fail / escalate
+  -> transcript, decisions, artifacts, and memories are ingested
+```
+
+Internal capability teams should create or improve prompt flows through the same lifecycle as other Organization capabilities: capability request, business clarification, architecture design, security review, implementation, reviewer approval, registry activation, and outcome review.
 
 ## Departments
 

--- a/agentic-organization/docs/README.md
+++ b/agentic-organization/docs/README.md
@@ -17,6 +17,7 @@ Current documents:
 - [Organization Layer Build Plan](./ORGANIZATION_LAYER_BUILD_PLAN.md) - the service layer, role workspaces, automation loops, state model, UI surfaces, and MVP sequence needed to make each department and hat operational.
 - [Work and Release Management OS](./WORK_AND_RELEASE_MANAGEMENT_OS.md) - the custom backlog, project, task, assignment, signal, board, and release workflow product that keeps agent work reliable and visible.
 - [Agent-Native Knowledge Graph and Retrieval](./AGENT_NATIVE_KNOWLEDGE_GRAPH.md) - the graph and retrieval layer linking tasks, discussions, decisions, meetings, docs, artifacts, runs, memories, and evidence into agent-readable context.
+- [Agent Work Rhythm and Prompt Flows](./AGENT_WORK_RHYTHM_AND_PROMPT_FLOWS.md) - the hat-bound schedule, free-time, review/red-team, reflection, memory maintenance, and deterministic prompt-flow model for agents.
 - [Ambiguous Requirement Lifecycle](./AMBIGUOUS_REQUIREMENT_LIFECYCLE.md) - the discovery, customer interview, BRD, workflow modeling, architecture, decomposition, readiness, and learning path from vague request to curated feature.
 - [Anti-Stall Prioritization Runtime](./ANTI_STALL_PRIORITY_RUNTIME.md) - the hat-owned schedules, blocker triage, queue SLO, reassignment, alternate-work, dependency reconciliation, and priority routines that keep the Organization moving.
 - [Implementation Readiness Checklist](./IMPLEMENTATION_READINESS_CHECKLIST.md) - the decisions and contracts that should be defined before scaffolding the first implementation slice.

--- a/agentic-organization/docs/RUNTIME_TECH_AND_PACKAGE_STRATEGY.md
+++ b/agentic-organization/docs/RUNTIME_TECH_AND_PACKAGE_STRATEGY.md
@@ -167,6 +167,8 @@ recordToolCallCompleted()
 setCurrentTask()
 setCurrentTeam()
 setCurrentMeeting()
+setCurrentScheduleBlock()
+setCurrentPromptFlowRun()
 setMode()
 markRoleless()
 ```
@@ -179,6 +181,9 @@ Runtime context should include:
 - current task ID;
 - current team ID;
 - current discussion anchor;
+- current schedule block ID;
+- current prompt-flow run ID;
+- current prompt-flow phase ID;
 - current meeting ID;
 - current Oz run ID;
 - current project ID;

--- a/agentic-organization/docs/RUNTIME_TECH_AND_PACKAGE_STRATEGY.md
+++ b/agentic-organization/docs/RUNTIME_TECH_AND_PACKAGE_STRATEGY.md
@@ -169,6 +169,7 @@ setCurrentTeam()
 setCurrentMeeting()
 setCurrentScheduleBlock()
 setCurrentPromptFlowRun()
+setCurrentPromptFlowPhase()
 setMode()
 markRoleless()
 ```

--- a/agentic-organization/docs/UI_AND_OBSERVABILITY_CONCEPTS.md
+++ b/agentic-organization/docs/UI_AND_OBSERVABILITY_CONCEPTS.md
@@ -259,6 +259,36 @@ For each agent:
 - current Oz runs;
 - session history.
 
+### Work Rhythm View
+
+Shows how agent time is being used across hats, departments, teams, and initiatives.
+
+Core data:
+
+- active schedule block;
+- next prioritized work block;
+- next prompt-flow execution block;
+- review/red-team obligations;
+- reflection and memory-maintenance blocks;
+- free-time blocks and outputs;
+- missed or rescheduled blocks;
+- supervising hat and adjustment history.
+
+### Prompt Flow Registry View
+
+Shows deterministic flows available to hats and the outcomes they produce.
+
+Core data:
+
+- flow name, version, owner department, and status;
+- allowed hats and scopes;
+- reusable phases;
+- phase gates and reviewer hats;
+- MCP tools allowed per phase;
+- artifacts and evidence required;
+- run success/failure/revision rates;
+- repeated gate rejections and improvement requests.
+
 ### Run and Cluster Observatory
 
 Shows execution across all pods and clusters.
@@ -564,6 +594,8 @@ Nodes:
 - tasks;
 - agents;
 - hats;
+- schedule blocks;
+- prompt flows;
 - skills;
 - meetings;
 - decisions;

--- a/agentic-organization/docs/WORK_AND_RELEASE_MANAGEMENT_OS.md
+++ b/agentic-organization/docs/WORK_AND_RELEASE_MANAGEMENT_OS.md
@@ -58,6 +58,8 @@ This structure should be flexible enough for internal platform work and product/
 | Assignment | Binding of a hat and agent to scoped work, with TTL, lease, token, and release policy |
 | Release | Merge/promotion/deployment unit with gate evidence, risk, rollback, notes, and verification |
 | Automation Package | CI, test, deployment, preview environment, rollback, observability, and operational automation created or updated with the feature |
+| Work Schedule | Hat-bound schedule of prioritized work, prompt-flow execution, review, reflection, memory maintenance, free time, and reporting blocks |
+| Prompt Flow | Reusable deterministic MCP-driven pipeline composed of phases, gates, reviewers, artifacts, and memory behavior |
 | Signal | Durable event that informs boards, rules, agents, meetings, triggers, and UI read models |
 | Requirement Maturity | Discovery-specific state that tracks whether an ambiguous request has enough customer, business, workflow, and acceptance context to move toward implementation |
 
@@ -181,6 +183,8 @@ Signals are durable, typed events. They are not chat messages. They drive boards
 | Interview | `InterviewRequested`, `InterviewStarted`, `CustomerAnswerRecorded`, `ClarificationQuestionOpened`, `InterviewCompleted` | Customer Interviewer, Product Owner, Business Analyst |
 | Gate state | `BrdApproved`, `ArchitectureRejected`, `CodeReviewApproved`, `QaBounceBack`, `DeliveryApproved` | Reviewers, managers, Delivery |
 | Assignment | `HatRequested`, `HatSupplyReserved`, `HatTokenIssued`, `HatRefreshFailed`, `HatReleased`, `HatRevoked` | Assignment service, managers, agents |
+| Schedule | `ScheduleBlockPlanned`, `ScheduleBlockStarted`, `ScheduleBlockCompleted`, `ReflectionDue`, `FreeTimeStarted`, `MemoryMaintenanceDue` | Agents, managers, Memory, UI |
+| Prompt flow | `PromptFlowRequested`, `PromptFlowActivated`, `PromptFlowRunStarted`, `PromptFlowPhaseCompleted`, `PromptFlowGateRejected`, `PromptFlowRunCompleted` | Agents, reviewers, managers, Capability teams |
 | Runtime | `OzRunStarted`, `OzRunSilent`, `PodHeartbeatMissing`, `RunCompleted`, `RunFailed` | Operations, TPMs, Engineering Managers |
 | Release | `ReleaseScopeSelected`, `ReleaseEvidenceMissing`, `ReleaseApproved`, `ReleaseCompleted`, `RollbackRequested` | Delivery, QA, Security, executives |
 | Capacity | `HatSupplyExhausted`, `BudgetThresholdExceeded`, `QueueLagHigh`, `ReviewQueueSaturated` | Directors, Cost Controller, executives |
@@ -463,6 +467,8 @@ This slice proves:
 - No discussion may be unanchored. Meetings, threads, broadcasts, one-on-ones, votes, reports, and review comments must reference project, initiative, task, defect, review, gate, incident, release, policy, capability request, or context-gap work.
 - No release should happen without an evidence chain.
 - No workflow should bypass the Work OS. Schedulers and agents create work or signals, then the Work OS drives state.
+- No prompt flow should bypass gates. Each phase must persist evidence and route required reviewer decisions before protected completion.
+- No schedule should be invisible. Active hat assignments need schedule blocks for work, review, reflection, memory maintenance, and free time.
 - No role should rely on polling chat. Each role needs a queue, board, and signal-driven inbox.
 - No stale authority. Expired or revoked hats lose MCP tools, credential scopes, memory scopes, approval powers, and active assignment.
 - No silent lag. Stuck states, missing assignments, missing reviewers, silent runs, and saturated queues must produce signals and escalation.

--- a/agentic-organization/docs/WORK_AND_RELEASE_MANAGEMENT_OS.md
+++ b/agentic-organization/docs/WORK_AND_RELEASE_MANAGEMENT_OS.md
@@ -60,6 +60,7 @@ This structure should be flexible enough for internal platform work and product/
 | Automation Package | CI, test, deployment, preview environment, rollback, observability, and operational automation created or updated with the feature |
 | Work Schedule | Hat-bound schedule of prioritized work, prompt-flow execution, review, reflection, memory maintenance, free time, and reporting blocks |
 | Prompt Flow | Reusable deterministic MCP-driven pipeline composed of phases, gates, reviewers, artifacts, and memory behavior |
+| Universal Action | Typed action atom inside a prompt-flow phase, with actor, target, preconditions, observation contract, reversibility, and evidence |
 | Signal | Durable event that informs boards, rules, agents, meetings, triggers, and UI read models |
 | Requirement Maturity | Discovery-specific state that tracks whether an ambiguous request has enough customer, business, workflow, and acceptance context to move toward implementation |
 
@@ -185,6 +186,7 @@ Signals are durable, typed events. They are not chat messages. They drive boards
 | Assignment | `HatRequested`, `HatSupplyReserved`, `HatTokenIssued`, `HatRefreshFailed`, `HatReleased`, `HatRevoked` | Assignment service, managers, agents |
 | Schedule | `ScheduleBlockPlanned`, `ScheduleBlockStarted`, `ScheduleBlockCompleted`, `ReflectionDue`, `FreeTimeStarted`, `MemoryMaintenanceDue` | Agents, managers, Memory, UI |
 | Prompt flow | `PromptFlowRequested`, `PromptFlowActivated`, `PromptFlowRunStarted`, `PromptFlowPhaseCompleted`, `PromptFlowGateRejected`, `PromptFlowRunCompleted` | Agents, reviewers, managers, Capability teams |
+| Universal action | `UniversalActionStarted`, `ActionObservationRecorded`, `ActionCorrectionRequested`, `ActionReverted`, `ActionCompleted` | Prompt-flow runners, reviewers, graph ingestion, audit |
 | Runtime | `OzRunStarted`, `OzRunSilent`, `PodHeartbeatMissing`, `RunCompleted`, `RunFailed` | Operations, TPMs, Engineering Managers |
 | Release | `ReleaseScopeSelected`, `ReleaseEvidenceMissing`, `ReleaseApproved`, `ReleaseCompleted`, `RollbackRequested` | Delivery, QA, Security, executives |
 | Capacity | `HatSupplyExhausted`, `BudgetThresholdExceeded`, `QueueLagHigh`, `ReviewQueueSaturated` | Directors, Cost Controller, executives |
@@ -468,6 +470,7 @@ This slice proves:
 - No release should happen without an evidence chain.
 - No workflow should bypass the Work OS. Schedulers and agents create work or signals, then the Work OS drives state.
 - No prompt flow should bypass gates. Each phase must persist evidence and route required reviewer decisions before protected completion.
+- No action should be opaque. Universal actions must record preconditions, observations, reversibility, evidence, and action mode.
 - No schedule should be invisible. Active hat assignments need schedule blocks for work, review, reflection, memory maintenance, and free time.
 - No role should rely on polling chat. Each role needs a queue, board, and signal-driven inbox.
 - No stale authority. Expired or revoked hats lose MCP tools, credential scopes, memory scopes, approval powers, and active assignment.


### PR DESCRIPTION
## Summary

- Adds `AGENT_WORK_RHYTHM_AND_PROMPT_FLOWS.md` to define hat-bound work schedules, free-time, review/red-team, reflection, and memory-maintenance blocks.
- Documents deterministic MCP-driven prompt flows with reusable phases, phase gates, reviewer hats, artifacts, memory behavior, and graph ingestion.
- Threads schedule and prompt-flow concepts through runtime architecture, implementation concepts, Work OS, build plan, UI, readiness checklist, Dapr actor context, and graph/retrieval docs.

## Validation

- `git diff --check HEAD~1 HEAD`
- `rg -n "Agent Work Rhythm|Work Rhythm and Prompt Flows|validate_prompt_flow_start|Prompt Flow Registry|free time" agentic-organization/docs`