### PR TITLE
docs: define v0 agentic organization contracts

### DIFF
--- a/agentic-organization/docs/IMPLEMENTATION_READINESS_CHECKLIST.md
+++ b/agentic-organization/docs/IMPLEMENTATION_READINESS_CHECKLIST.md
@@ -16,6 +16,12 @@ Implementation can begin once we define:
 
 Everything else can evolve through the Organization itself.
 
+The first narrowed contracts are now captured in:
+
+- [V0 Executable Contract](./V0_EXECUTABLE_CONTRACT.md);
+- [V0 Schema and Commands](./V0_SCHEMA_AND_COMMANDS.md);
+- [V0 Policy and Runtime Boundaries](./V0_POLICY_AND_RUNTIME_BOUNDARIES.md).
+
 ## 1. MVP Slice
 
 Define the first end-to-end workflow we will build.
@@ -66,7 +72,13 @@ Need to decide:
 - whether this is a new app under `agentic-team/packages` or a separate top-level workspace;
 - whether frontend and backend live together at first;
 - whether initial deployment target is local Docker Compose, k3s, or both.
-- whether runtime code belongs under `full-ai-cluster/` as a cluster subsystem or as a parallel top-level product tree.
+
+Placement decision:
+
+- documentation lives under `agentic-organization/docs/`;
+- product/runtime code may live under the Agentic Organization app tree;
+- cluster deployment belongs under `full-ai-cluster/k8s/applications/agentic-organization/` as an ArgoCD-managed workload;
+- Agentic Organization consumes the `full-ai-cluster` substrate and must not create a parallel cluster substrate.
 
 Recommendation:
 
@@ -74,7 +86,7 @@ Recommendation:
 - use dev-portal/TPM only as reference and selective extraction source;
 - build modular monolith first, with clear boundaries for later service extraction.
 - use a TypeScript monorepo with `apps/api`, `apps/web`, `apps/workers`, `apps/temporal-worker`, `apps/dapr-actors`, and shared `packages/*` as defined in the build plan.
-- decide placement before code lands. Docs can live at `agentic-organization/docs/`; runtime implementation should not create a second parallel substrate by accident.
+- treat deployment as a `full-ai-cluster` consumer workload from the first cluster integration.
 
 ## 3. Source of Truth
 

--- a/agentic-organization/docs/README.md
+++ b/agentic-organization/docs/README.md
@@ -21,6 +21,9 @@ Current documents:
 - [Ambiguous Requirement Lifecycle](./AMBIGUOUS_REQUIREMENT_LIFECYCLE.md) - the discovery, customer interview, BRD, workflow modeling, architecture, decomposition, readiness, and learning path from vague request to curated feature.
 - [Anti-Stall Prioritization Runtime](./ANTI_STALL_PRIORITY_RUNTIME.md) - the hat-owned schedules, blocker triage, queue SLO, reassignment, alternate-work, dependency reconciliation, and priority routines that keep the Organization moving.
 - [Implementation Readiness Checklist](./IMPLEMENTATION_READINESS_CHECKLIST.md) - the decisions and contracts that should be defined before scaffolding the first implementation slice.
+- [V0 Executable Contract](./V0_EXECUTABLE_CONTRACT.md) - the smallest end-to-end runtime slice, grounded against the current `full-ai-cluster` substrate.
+- [V0 Schema and Commands](./V0_SCHEMA_AND_COMMANDS.md) - the CockroachDB-backed state groups, enums, command contract, outbox model, and TypeScript-facing runtime events for the first implementation.
+- [V0 Policy and Runtime Boundaries](./V0_POLICY_AND_RUNTIME_BOUNDARIES.md) - the hat policy matrix, MCP preflight checks, cluster runtime boundaries, failure rules, and ArgoCD integration shape.
 - [Cluster-Native Hat System](./CLUSTER_NATIVE_HAT_SYSTEM.md) - the CRD, OPA, hat binding, succession, reputation, graph rendering, polyglot operator, and event model for enforcing hats on Kubernetes.
 - [Cluster Execution and Memory Substrate](./CLUSTER_EXECUTION_AND_MEMORY_SUBSTRATE.md) - the k3s, sandboxed Hermes container, Cilium Service Mesh, SPIRE identity, Vault-backed secrets, Credential Proxy, NATS, Hindsight, and runtime observability contract.
 - [AI Cluster Scaffold Context](./AI_CLUSTER_SCAFFOLD_CONTEXT.md) - the two-directory NixOS/k3s/ArgoCD scaffold assumptions, component clarifications, bootstrap constraints, and deferred/local-model gating.
@@ -34,4 +37,4 @@ These documents are reference substrate, not a mandate to implement every concep
 
 ## Placement
 
-These docs live at `agentic-organization/docs/` as the documentation root for the Agentic Organization subsystem. Before runtime code lands, decide whether the implementation is a subsystem of `full-ai-cluster/` or a parallel top-level product tree.
+These docs live at `agentic-organization/docs/` as the documentation root for the Agentic Organization subsystem. Runtime code can live under the Agentic Organization product tree, but cluster deployment should land as a `full-ai-cluster/k8s/applications/agentic-organization/` ArgoCD workload. Agentic Organization runs on the `full-ai-cluster` substrate; it is not a second cluster substrate.

--- a/agentic-organization/docs/V0_EXECUTABLE_CONTRACT.md
+++ b/agentic-organization/docs/V0_EXECUTABLE_CONTRACT.md
@@ -1,0 +1,242 @@
+# V0 Executable Contract
+
+## Purpose
+
+This document narrows the Agentic Organization reference design into
+the first executable slice. It is intentionally smaller than the full
+Organization. The goal is to prove that one governed agent work loop can
+run on the `full-ai-cluster` substrate with durable state, hat-scoped
+authority, evidence, and review.
+
+V0 should be boring enough to ship and rich enough to teach the rest of
+the system what to build next.
+
+## Cluster Assumption
+
+Agentic Organization is a workload that runs on `full-ai-cluster`. It is
+not a parallel substrate.
+
+The current `origin/main` cluster shape gives V0 these host primitives:
+
+| Cluster component | V0 use |
+|---|---|
+| K3S + ArgoCD App-of-Apps | deploy Agentic Organization as a future `full-ai-cluster/k8s/applications/agentic-organization/` application |
+| Cilium + Hubble | pod networking, L7 policy, flow observability, and service-mesh behavior without Istio |
+| cert-manager, Vault, SPIRE, Trust Manager, External Secrets | workload identity, TLS trust, and secret delivery |
+| CockroachDB | authoritative Organization database |
+| NATS JetStream | event transport, outbox fanout, live UI updates, and replayable integration streams |
+| Temporal TS | durable workflows after the native command model is proven |
+| Dapr Actors | hot entity coordination after the DB-backed service contract is proven |
+| Hindsight | Hermes memory backend, wrapped with Organization attribution and scope |
+| Hermes | agent runtime that performs the work |
+| OZ/OpenZiti | zero-trust transport, not the Organization business orchestrator |
+| hat-system | Kubernetes hat enforcement/projection surface using Hat, HatBinding, HatSwap, and HatPolicy CRDs |
+| Loki, Tempo, Alloy, Mimir, kube-prometheus-stack | logs, traces, metrics, dashboards, and audit correlation |
+
+Sync-wave implication: Agentic Organization is a consumer app. It should
+land after the foundation, data planes, hat-system CRDs, Hindsight,
+Temporal, and Hermes are available. A future ArgoCD application should
+therefore use a late consumer wave, likely wave `20` or later, unless a
+split bootstrap app is created for CRDs only.
+
+## Non-Goals
+
+V0 does not need:
+
+- the full executive, director, TPM, manager, QA, security, and memory
+  department lattice;
+- every hat in the inventory;
+- a full Hindsight fork;
+- a full Temporal workflow catalog;
+- a Dapr actor for every entity;
+- live CRD writeback from day one;
+- complete performance review and budget systems;
+- autonomous creation of new tools, workflows, or credential proxy
+  endpoints.
+
+V0 should still model those future paths as capability requests, so the
+Organization can later build them through its own lifecycle.
+
+## First Vertical Slice
+
+The first executable slice is:
+
+```text
+capability request
+  -> discussion anchor and context pack
+  -> one readiness or review gate
+  -> hat assignment
+  -> scheduled prompt-flow run
+  -> Hermes run through the Organization runtime adapter
+  -> evidence submission
+  -> reviewer decision
+  -> outcome review
+```
+
+This is the smallest useful loop because it proves:
+
+- work has a durable source of truth;
+- every discussion is tied to a work item;
+- a hat can be assigned, tokenized, and revoked;
+- a Hermes agent can work inside an Organization-scoped context;
+- the system can capture actions, observations, artifacts, and memory
+  events;
+- a reviewer can approve or reject without self-approval;
+- a completed run can create follow-up work when gaps are found.
+
+## Required V0 Hats
+
+Keep the first hat set small:
+
+| Hat | V0 reason |
+|---|---|
+| Director | accepts or rejects the capability request for V0 scope |
+| Engineering Manager | grooms the work item, selects schedule, assigns implementer and reviewer hats |
+| Implementer | executes the prompt flow and submits evidence |
+| Code Reviewer | reviews the evidence and blocks self-approval |
+| Memory Curator | reviews memory writes or flags memory gaps when the run ends |
+| Platform Operator | handles runtime failure, pod/session issues, and integration health |
+| Security Reviewer | required only when the request needs a new credential or external tool scope |
+
+The Executive Board, TPM, Product Owner, Architect, QA Reviewer, Hat
+Designer, and department directors remain first-class in the reference
+model, but V0 can simulate or defer them unless the first example
+requires their gate.
+
+## Required V0 Work Objects
+
+V0 must persist these objects:
+
+- agent;
+- department;
+- hat definition;
+- hat assignment;
+- hat token;
+- project;
+- initiative;
+- work item;
+- discussion anchor;
+- context pack;
+- schedule block;
+- prompt-flow definition;
+- prompt-flow run;
+- prompt-flow phase run;
+- universal action record;
+- action observation;
+- Hermes run binding;
+- artifact;
+- memory event;
+- gate;
+- gate decision;
+- audit event;
+- outbox event.
+
+Anything else should be added only when a V0 command cannot be expressed
+without it.
+
+## Required V0 Flow
+
+1. `submit_capability_request` creates the work item, discussion anchor,
+   and first audit/outbox events.
+2. `triage_capability_request` selects the responsible project,
+   initiative, owner hat, and required gate.
+3. `create_context_pack` links relevant docs, prior decisions, task
+   graph nodes, memory references, and acceptance criteria.
+4. `decide_gate` moves the request into ready state or asks for more
+   information.
+5. `reserve_hat` creates a hat assignment and maps it to the hat-system
+   projection boundary.
+6. `issue_hat_token` creates the time-bounded runtime authority for the
+   selected Hermes agent/session.
+7. `start_schedule_block` enters prioritized work time for the active
+   hat.
+8. `start_prompt_flow` locks the agent into the selected deterministic
+   work protocol.
+9. `launch_hermes_run` binds the Organization work item, agent, session,
+   hat assignment, and prompt-flow run to the Hermes/OZ runtime adapter.
+10. `record_universal_action` and `record_action_observation` capture
+    what the agent did and what the system observed.
+11. `submit_evidence` attaches logs, screenshots, code refs, traces, or
+    documents to the work item.
+12. `request_gate_review` moves the work to reviewer attention.
+13. `decide_gate` approves, rejects, or requests changes.
+14. `complete_outcome_review` records what was learned and creates
+    follow-up work if the run exposed a capability, memory, test, or
+    process gap.
+
+## Runtime Mode
+
+V0 can start with a native NestJS modular monolith and in-process fakes
+for Temporal, Dapr, and Hermes/OZ adapters, but the contracts must match
+the cluster runtime.
+
+The first deployable shape should be:
+
+```text
+apps/api
+  Organization commands, reads, auth, policy, MCP gateway
+
+apps/web
+  work board, role workspace, review center, evidence timeline
+
+apps/workers
+  outbox publisher, schedulers, reconcilers, NATS consumers
+
+packages/*
+  domain, state, policy, work-os, hats, prompt-flows, mcp, memory,
+  observability, k8s-hats, hermes adapter
+```
+
+Temporal and Dapr can be introduced once the same commands work through
+the native service layer:
+
+```text
+Temporal workflow or Dapr actor
+  -> Organization command service
+  -> CockroachDB transaction
+  -> outbox event
+  -> NATS publish
+  -> trace, log, metric
+```
+
+## Hat-System Boundary
+
+The Organization DB owns business intent. The cluster hat-system owns
+runtime enforcement/projection.
+
+For V0:
+
+- read hat-system CRDs through typed TypeScript clients;
+- decode HatSwap records and NATS hat ticks into Organization signals;
+- map Organization hat assignments to the CRD vocabulary;
+- do not require bidirectional CRD writes before the DB state machine is
+  stable.
+
+Later:
+
+- Organization-approved assignments can create HatBinding proposals;
+- HatSwap can become the runtime confirmation record;
+- Hubble, Loki, and HatSwap can be joined by SPIFFE ID for per-hat
+  runtime attribution.
+
+## Definition of Done
+
+V0 is done when a human or agent can submit one internal capability
+request and watch it move through:
+
+```text
+request -> ready gate -> hat assignment -> prompt-flow run
+  -> Hermes work -> evidence -> review decision -> outcome review
+```
+
+The demo must show:
+
+- CockroachDB state for the work item and assignment;
+- NATS/outbox events for every transition;
+- a discussion anchor tied to the work item;
+- a hat token with expiry;
+- a Hermes run binding, even if the runtime adapter is still simulated;
+- evidence attached to the work item;
+- review denial of self-approval;
+- trace IDs and audit events across the whole run;
+- a UI read model that shows status without reading raw logs.

--- a/agentic-organization/docs/V0_POLICY_AND_RUNTIME_BOUNDARIES.md
+++ b/agentic-organization/docs/V0_POLICY_AND_RUNTIME_BOUNDARIES.md
@@ -1,0 +1,229 @@
+# V0 Policy and Runtime Boundaries
+
+## Purpose
+
+This document defines the first boundary rules for Agentic Organization:
+what each runtime owns, which hats can perform which V0 actions, and how
+MCP tools execute with agent, hat, task, and cluster context.
+
+The main rule is simple: infrastructure can execute, schedule, transport,
+or project state, but Organization command services own business
+decisions.
+
+## Source-of-Truth Boundary
+
+| Surface | Owns | Does not own |
+|---|---|---|
+| Organization DB on CockroachDB | business state, work lifecycle, assignments, gates, audit, outbox | LLM reasoning, Kubernetes admission, workflow history |
+| NestJS API | command handlers, reads, policy checks, MCP gateway, adapters | durable workflow history, actor placement, raw cluster ownership |
+| Temporal TS | durable timers, retries, waits, workflow history | direct DB mutation, direct LLM calls, final business authority |
+| Dapr Actors | hot per-entity coordination, serialized local state, reminders | global truth, broad policy, long-running cross-entity process |
+| NATS JetStream | event transport, replay, fanout, inboxes | authoritative state |
+| Hermes | reasoning and tool-using work | granting itself authority, bypassing gates |
+| OZ/OpenZiti | zero-trust transport paths | Organization run orchestration semantics |
+| Hindsight | memory recall, retain, reflect | Organization work graph, hat assignment authority |
+| hat-system CRDs | cluster hat enforcement and runtime projection | Organization business intent until writeback is explicitly enabled |
+| Cilium, SPIRE, Vault, ESO | network policy, identity, trust, secret delivery | Organization lifecycle or review decisions |
+| Loki, Tempo, Alloy, Mimir, Prometheus, Grafana | observability storage and dashboards | business truth |
+
+Every adapter should call Organization commands. No adapter should update
+authoritative tables directly.
+
+## V0 Policy Matrix
+
+| Hat | Can do in V0 | Cannot do in V0 |
+|---|---|---|
+| Director | accept capability request, route to project/initiative, assign manager | approve own implementation work |
+| Engineering Manager | groom work, mark ready, assign implementer/reviewer, set schedule block, request outcome review | bypass reviewer gate, create new credential scope alone |
+| Implementer | run assigned prompt flow, call allowed MCP tools, submit evidence, request review | approve own work, change hat supply, create unanchored discussions |
+| Code Reviewer | approve, reject, or request changes on assigned review gate | review work they implemented under the same assignment |
+| Memory Curator | review memory events, request memory cleanup/follow-up work, approve memory adaptation | grant tool or credential scope |
+| Platform Operator | reconcile failed runs, inspect runtime health, restart or cancel runtime sessions through policy | change product acceptance criteria |
+| Security Reviewer | approve or reject credential/tool expansion, require narrower scopes | implement the requested capability and approve its security scope alone |
+
+Human operators may hold these hats too. The policy model should treat a
+human and a Hermes agent the same at the command boundary: both need an
+actor identity, active authority, scope, and audit trail.
+
+## Required Policy Invariants
+
+V0 must enforce:
+
+- no self-approval for implementation review;
+- every discussion, meeting, message thread, and broadcast has a work
+  anchor;
+- every MCP tool call has an active agent session;
+- every privileged MCP tool call has an active hat token;
+- every hat token has an expiry and refresh path;
+- expired or revoked hats lose credential and tool authority;
+- every work transition uses a command, not a direct field update;
+- every command writes audit and outbox records in the same transaction;
+- every memory event is attributed to agent, hat assignment, work item,
+  project, and prompt-flow context when available;
+- every credential expansion request goes through security review;
+- every runtime callback is idempotent;
+- every denial records a structured reason agents can learn from.
+
+## MCP Preflight
+
+The MCP Gateway is stateless at the edge but policy-rich at execution.
+
+Flow:
+
+```text
+Hermes
+  -> Organization MCP Gateway
+      -> validate JWT and session
+      -> load AgentSessionActor or DB-backed session context
+      -> load work item, schedule block, prompt-flow run, and hat assignment
+      -> validate policy
+      -> execute command/tool handler
+      -> write audit, observation, outbox, trace
+      -> update session activity
+```
+
+Minimum preflight checks:
+
+| Check | Purpose |
+|---|---|
+| `validate_actor_context` | confirms agent/session identity |
+| `validate_hat_token` | confirms active, unexpired, unrevoked hat authority |
+| `validate_scope` | confirms project, initiative, work item, memory, and credential scope |
+| `validate_discussion_anchor` | blocks unanchored discussion |
+| `validate_schedule_block` | confirms the agent is in an allowed work mode |
+| `validate_prompt_flow_start` | confirms the hat can run the selected flow |
+| `validate_prompt_flow_phase_gate` | enforces phase review gates |
+| `validate_universal_action` | validates the action grammar and allowed side effects |
+| `validate_action_reversibility` | flags actions that need approval or rollback plan |
+| `validate_required_docs_acknowledged` | confirms BRD, CA, ADR, test plan, or runbook context was loaded when required |
+| `validate_no_blocking_contradictions` | blocks work when the context graph has unresolved critical contradictions |
+| `validate_lifecycle_transition` | confirms legal state movement |
+
+Request-provided IDs are hints. The gateway must verify authority from
+the Organization DB, session context, and policy engine.
+
+## Runtime Failure Rules
+
+V0 should treat distributed failure as normal.
+
+| Failure | Required behavior |
+|---|---|
+| Duplicate command | return the idempotent prior result or reject hash conflict |
+| Duplicate Hermes callback | update only once, attach duplicate observation if useful |
+| NATS publish failure | keep outbox row pending and retry |
+| NATS consumer replay | process idempotently from event ID and aggregate version |
+| Temporal activity retry | call Organization command with the same idempotency key |
+| Dapr reminder duplicate | call Organization command with the same idempotency key |
+| Hindsight unavailable | continue only if memory is optional for that phase; otherwise block with a recoverable signal |
+| Hat token expires during run | stop privileged tools, request refresh, and record schedule interruption |
+| Hat assignment revoked during run | cancel or quarantine the Hermes run and revoke credentials |
+| Credential denied | create a blocked state or lower-scope alternate-work item |
+| Pod or session silent | mark heartbeat late, notify Platform Operator, reconcile or cancel |
+| Reviewer unavailable | escalate to manager after SLO, but do not auto-approve |
+| Hat-system projection lag | keep Organization state, mark projection stale, do not assume enforcement |
+
+## Cluster-Native Runtime Contract
+
+Agentic Organization should eventually deploy as:
+
+```text
+full-ai-cluster/k8s/applications/agentic-organization/
+  Application.yaml
+  namespace.yaml
+  api deployment/service
+  web deployment/service
+  worker deployment
+  temporal-worker deployment
+  dapr-actor deployment
+  mcp-gateway deployment/service
+  ExternalSecret refs
+  CiliumNetworkPolicy
+  ServiceAccount/RBAC
+```
+
+The first docs-only and app-code PRs do not need deployment YAML. When
+deployment is added, it should follow the existing App-of-Apps model:
+
+- `targetRevision: main`;
+- `path: full-ai-cluster/k8s/applications/agentic-organization`;
+- `CreateNamespace=true`;
+- `ServerSideApply=true`;
+- sync wave after data planes and dependent runtimes;
+- no plaintext secrets in Git;
+- Cilium policy for egress to only required services;
+- SPIFFE/SPIRE identity for service accounts when enabled;
+- External Secrets from Vault for DB, NATS, Temporal, Hindsight, and
+  provider credentials;
+- OpenTelemetry export to the existing observability stack.
+
+## Dependency Order
+
+Agentic Organization runtime depends on the current cluster order:
+
+```text
+Cilium
+  -> cert-manager
+  -> Vault
+  -> SPIRE
+  -> Trust Manager
+  -> External Secrets
+  -> ArgoCD
+  -> OPA Gatekeeper
+  -> Longhorn
+  -> hat-system CRDs
+  -> CockroachDB, NATS, Dapr, OZ/OpenZiti, observability
+  -> Hindsight, Temporal, Hermes
+  -> Agentic Organization
+```
+
+If Agentic Organization later ships CRDs of its own, split them into an
+earlier app. Do not make the main application block the cluster
+foundation.
+
+## TypeScript First-Class Consumption
+
+TypeScript should be a first-class consumer of the cluster contracts.
+
+Required packages:
+
+| Package | Responsibility |
+|---|---|
+| `@agentic-org/k8s-hats` | generated or checked Hat, HatBinding, HatSwap, and HatPolicy types, informers, NATS tick decoding |
+| `@agentic-org/state` | Drizzle schema, repositories, outbox, idempotency |
+| `@agentic-org/policy` | typed policy engine and later OPA bundle adapter |
+| `@agentic-org/mcp` | MCP gateway contracts, preflight checks, tool registry |
+| `@agentic-org/hermes` | Hermes run/session adapter and callback contract |
+| `@agentic-org/memory` | Hindsight attribution and scoped recall/retain/reflect |
+| `@agentic-org/observability` | OpenTelemetry span helpers and correlation envelope |
+
+The TypeScript CRD package should be mechanically checked against the
+CRD YAML from `full-ai-cluster/k8s/applications/hat-system/crds/`.
+
+## What Not to Blur
+
+Keep these boundaries explicit:
+
+- OZ/OpenZiti is transport. If a future component orchestrates runs,
+  name it separately from OpenZiti.
+- Hindsight is memory. Organization graph retrieval is work context,
+  decisions, documents, discussions, and evidence.
+- Temporal coordinates durable workflows. It does not decide policy.
+- Dapr Actors serialize hot entity state. They do not own global truth.
+- hat-system CRDs enforce/project runtime hats. Organization DB owns the
+  assignment request and business reason.
+- Cilium/SPIRE/Vault secure the cluster. They do not replace hat RBAC.
+
+## V0 Review Checklist
+
+Before coding any endpoint, worker, or MCP tool, confirm:
+
+- which command owns the state transition;
+- which hat can call it;
+- which policy checks run;
+- which state rows change;
+- which audit and outbox events are emitted;
+- which graph nodes or edges are created;
+- which trace fields are attached;
+- how duplicate calls behave;
+- how denial is explained to the agent;
+- how the UI can display the result without scraping logs.

--- a/agentic-organization/docs/V0_SCHEMA_AND_COMMANDS.md
+++ b/agentic-organization/docs/V0_SCHEMA_AND_COMMANDS.md
@@ -1,0 +1,375 @@
+# V0 Schema and Commands
+
+## Purpose
+
+This document defines the first TypeScript-facing schema and command
+contract for Agentic Organization. It is not a full DDL. It is the shape
+the domain model, Drizzle migrations, command handlers, MCP tools,
+workers, and tests should agree on before implementation starts.
+
+CockroachDB is the authoritative store for Organization-owned state.
+Temporal history, Dapr actor state, NATS streams, Hindsight memory, and
+hat-system CRDs are runtime surfaces or projections. They do not replace
+the Organization database.
+
+## Global Columns
+
+Every authoritative table should include:
+
+| Column | Purpose |
+|---|---|
+| `id` | stable unique ID |
+| `organization_id` | future multi-org partition key, even if V0 uses one org |
+| `created_at` | creation time |
+| `updated_at` | last mutation time |
+| `version` | optimistic concurrency and projection safety |
+| `created_by_agent_id` | agent that caused the write, when applicable |
+| `created_by_hat_assignment_id` | hat authority that caused the write, when applicable |
+| `correlation_id` | end-to-end request/run correlation |
+| `causation_id` | direct parent command, event, tool call, or workflow step |
+| `trace_id` | observability trace link |
+
+Append-only records should also carry `sequence` when replay order
+matters.
+
+## Schema Groups
+
+### Identity and Hats
+
+| Table | V0 responsibility |
+|---|---|
+| `agents` | known Hermes-capable agents and their stable identity |
+| `agent_sessions` | live or historical Hermes sessions bound to an agent |
+| `departments` | first department containers for ownership and review routing |
+| `hat_definitions` | Organization-owned hat catalog |
+| `hat_authority_rules` | typed permissions, scopes, and policy metadata for a hat |
+| `hat_skill_bindings` | skills and prompt-flow availability attached to a hat |
+| `hat_supply_policies` | max concurrency, TTL, cooldown, warmup, and assignment rules |
+| `hat_assignments` | time-bounded wearer assignment for a specific agent/session |
+| `hat_tokens` | short-lived JWT issuance, refresh, revocation, and expiry state |
+| `hat_system_projections` | last observed Hat, HatBinding, HatSwap, and HatPolicy state from Kubernetes |
+
+### Work Management
+
+| Table | V0 responsibility |
+|---|---|
+| `projects` | top-level work containers |
+| `initiatives` | project-scoped bodies of work |
+| `work_items` | capability requests, tasks, defects, reviews, and follow-ups |
+| `work_item_state_history` | append-only state transitions |
+| `work_item_dependencies` | blocking or informational dependencies |
+| `blockers` | active impediments with owner, severity, and resolution path |
+| `assignments` | work item to agent/hat/session assignment records |
+| `gates` | required review points for readiness, code, QA, memory, or security |
+| `gate_decisions` | approve, reject, needs-changes, or defer decisions |
+| `releases` | release groupings once release management enters the slice |
+
+### Schedules, Prompt Flows, and Actions
+
+| Table | V0 responsibility |
+|---|---|
+| `hat_schedule_templates` | default work rhythm by hat |
+| `work_schedules` | concrete schedule assigned to an agent/hat context |
+| `work_schedule_blocks` | free time, prioritized work, review, reflection, or meeting blocks |
+| `prompt_flow_definitions` | named deterministic work protocols |
+| `prompt_flow_versions` | immutable versioned prompt-flow contract |
+| `prompt_flow_phases` | ordered reusable phases |
+| `hat_prompt_flow_bindings` | which hats can run which prompt flows |
+| `prompt_flow_runs` | one execution of a prompt-flow version |
+| `prompt_flow_phase_runs` | state and evidence for each phase execution |
+| `prompt_flow_gate_decisions` | reviewer decisions at phase boundaries |
+| `universal_action_definitions` | typed action grammar catalog |
+| `universal_action_records` | action intent emitted by an agent or workflow |
+| `universal_action_observations` | observed result, evidence, and side effects for an action |
+
+### Communication, Graph, Documents, and Context
+
+| Table | V0 responsibility |
+|---|---|
+| `discussion_anchors` | required work/project/initiative/task anchor for any discussion |
+| `conversation_threads` | one-on-one, team, department, executive, or broadcast thread |
+| `messages` | immutable message log with actor and hat attribution |
+| `meetings` | structured meeting sessions with mode and anchor |
+| `decisions` | explicit decisions linked to work and evidence |
+| `documents` | BRDs, CAs, ADRs, reports, test cases, runbooks, and memory reviews |
+| `artifact_links` | logs, screenshots, traces, code refs, PRs, builds, and uploads |
+| `graph_nodes` | agent-readable graph node registry |
+| `graph_edges` | typed relationships between work, docs, messages, decisions, runs, and memories |
+| `context_packs` | deterministic context bundles assembled for an agent run or review |
+
+### Runtime, Memory, Security, and Audit
+
+| Table | V0 responsibility |
+|---|---|
+| `hermes_runs` | Organization binding to a Hermes execution session |
+| `mcp_tool_calls` | governed tool call attempts and results |
+| `memory_events` | Hindsight recall, retain, reflect, and review attribution |
+| `credential_requests` | requests to expand credential proxy or external tool scope |
+| `signals` | durable internal signals consumed by workers and UI read models |
+| `audit_events` | append-only policy and state-change audit trail |
+| `outbox_events` | transactional event publication source for NATS |
+| `runtime_leases` | scheduler, reconciler, and worker leases |
+| `idempotency_keys` | command deduplication records |
+
+## V0 Enums
+
+Use typed enums in TypeScript and database constraints. Do not rely on
+magic strings in command handlers.
+
+### `work_item_state`
+
+```text
+new
+triage
+needs_clarification
+ready
+assigned
+in_progress
+review_requested
+changes_requested
+approved
+blocked
+done
+canceled
+```
+
+### `hat_assignment_state`
+
+```text
+requested
+reserved
+warmup
+active
+expired
+revoked
+released
+denied
+```
+
+### `hat_token_state`
+
+```text
+issued
+refresh_required
+refreshed
+expired
+revoked
+denied
+```
+
+### `gate_state`
+
+```text
+not_required
+waiting
+in_review
+approved
+rejected
+changes_requested
+deferred
+```
+
+### `prompt_flow_run_state`
+
+```text
+queued
+running
+waiting_for_gate
+waiting_for_input
+succeeded
+failed
+canceled
+expired
+```
+
+### `schedule_block_state`
+
+```text
+scheduled
+active
+paused
+completed
+missed
+canceled
+```
+
+### `hermes_run_state`
+
+```text
+requested
+starting
+running
+heartbeat_late
+succeeded
+failed
+canceled
+lost
+reconciled
+```
+
+### `discussion_anchor_type`
+
+```text
+project
+initiative
+work_item
+gate
+release
+incident
+memory_review
+capability_request
+```
+
+### `signal_type`
+
+```text
+work_item_changed
+gate_requested
+gate_decided
+hat_assignment_changed
+hat_token_changed
+schedule_block_changed
+prompt_flow_changed
+hermes_run_changed
+memory_event_recorded
+credential_request_changed
+blocker_changed
+outcome_review_completed
+hat_system_tick_observed
+```
+
+## Command Contract
+
+Every side-effecting command must include:
+
+- `commandId`;
+- `idempotencyKey`;
+- `actorAgentId`;
+- `actorHatAssignmentId`, when the actor is wearing a hat;
+- `organizationId`;
+- `projectId` or explicit reason none is available;
+- `correlationId`;
+- `causationId`;
+- `traceId`;
+- `expectedVersion`, when mutating an existing aggregate;
+- `policyContext`.
+
+Every command handler must:
+
+1. load authoritative state from CockroachDB;
+2. validate actor context and hat authority;
+3. validate lifecycle transition;
+4. write state, audit event, and outbox event in one transaction;
+5. return the authoritative post-state;
+6. be idempotent under retry.
+
+## V0 Commands
+
+| Command | Actor scope | Writes | Emits |
+|---|---|---|---|
+| `submit_capability_request` | human, agent, director, manager | `work_items`, `discussion_anchors`, `graph_nodes`, `audit_events`, `outbox_events` | `work_item_changed` |
+| `triage_capability_request` | director or engineering manager | `work_items`, `assignments`, `gates`, `context_packs` | `work_item_changed`, `gate_requested` |
+| `create_discussion_anchor` | any authorized hat | `discussion_anchors`, `graph_edges` | `work_item_changed` |
+| `create_context_pack` | manager, reviewer, implementer for assigned work | `context_packs`, `graph_edges`, `audit_events` | `work_item_changed` |
+| `mark_work_ready` | manager or reviewer | `work_items`, `work_item_state_history`, `gates` | `work_item_changed`, `gate_requested` |
+| `reserve_hat` | manager, director, platform operator | `hat_assignments`, `hat_tokens`, `audit_events` | `hat_assignment_changed` |
+| `issue_hat_token` | hat service, after policy allow | `hat_tokens`, `audit_events` | `hat_token_changed` |
+| `refresh_hat_token` | active assigned agent/session | `hat_tokens`, `audit_events` | `hat_token_changed` |
+| `revoke_hat_assignment` | manager, director, security, policy automation | `hat_assignments`, `hat_tokens`, `audit_events` | `hat_assignment_changed`, `hat_token_changed` |
+| `start_schedule_block` | assigned agent/session or scheduler | `work_schedule_blocks`, `agent_sessions` | `schedule_block_changed` |
+| `start_prompt_flow` | assigned agent/session | `prompt_flow_runs`, `prompt_flow_phase_runs` | `prompt_flow_changed` |
+| `record_universal_action` | assigned agent/session, workflow activity, adapter | `universal_action_records`, `mcp_tool_calls`, `audit_events` | `prompt_flow_changed` |
+| `record_action_observation` | adapter, worker, reviewer, assigned agent | `universal_action_observations`, `artifact_links` | `prompt_flow_changed` |
+| `launch_hermes_run` | runtime service or Temporal activity | `hermes_runs`, `agent_sessions`, `audit_events` | `hermes_run_changed` |
+| `record_hermes_run_status` | Hermes/OZ callback, reconciler, platform operator | `hermes_runs`, `artifact_links` | `hermes_run_changed` |
+| `submit_evidence` | implementer, QA, reviewer, adapter | `artifact_links`, `graph_edges`, `audit_events` | `work_item_changed` |
+| `request_gate_review` | implementer, manager, workflow | `gates`, `work_items` | `gate_requested`, `work_item_changed` |
+| `decide_gate` | reviewer hat, not same active implementer assignment | `gate_decisions`, `gates`, `work_items`, `audit_events` | `gate_decided`, `work_item_changed` |
+| `record_memory_event` | memory adapter, assigned agent/session, memory curator | `memory_events`, `graph_edges`, `audit_events` | `memory_event_recorded` |
+| `submit_credential_request` | any authorized hat with anchored work | `credential_requests`, `work_items`, `discussion_anchors` | `credential_request_changed` |
+| `complete_outcome_review` | manager, memory curator, reviewer | `work_items`, `decisions`, optional follow-up `work_items` | `outcome_review_completed` |
+
+## Idempotency
+
+Use deterministic idempotency keys at command boundaries:
+
+```text
+<command-name>:<scope-id>:<external-id-or-command-id>
+```
+
+Examples:
+
+```text
+launch_hermes_run:work_item_123:prompt_flow_run_456
+record_hermes_run_status:hermes_run_789:callback_abc
+decide_gate:gate_123:reviewer_assignment_456
+```
+
+The idempotency record should store:
+
+- request hash;
+- command result reference;
+- first-seen timestamp;
+- last-seen timestamp;
+- status;
+- error class for terminal failures.
+
+If the same key appears with a different request hash, reject it as an
+idempotency conflict.
+
+## Outbox and NATS
+
+CockroachDB transactions should write domain state and `outbox_events`
+together. A worker publishes outbox rows to NATS JetStream and marks
+them published.
+
+Subject shape:
+
+```text
+agentic-org.<environment>.<domain>.<event>
+```
+
+Examples:
+
+```text
+agentic-org.dev.work.work_item_changed
+agentic-org.dev.hats.hat_assignment_changed
+agentic-org.dev.runtime.hermes_run_changed
+agentic-org.dev.memory.memory_event_recorded
+agentic-org.dev.cluster.hat_system_tick_observed
+```
+
+Consumers must be idempotent. Replays are normal.
+
+## Hat-System Projection
+
+The TypeScript app should consume hat-system CRDs through
+`@agentic-org/k8s-hats`.
+
+V0 should project:
+
+- `Hat` into `hat_system_projections`;
+- `HatBinding` into runtime assignment status;
+- `HatSwap` into `signals`, `audit_events`, and graph edges;
+- `HatPolicy` into read-only policy diagnostics.
+
+The projection must be replayable from CRDs and NATS without
+double-counting. Organization DB assignments remain authoritative until
+an ADR explicitly promotes CRD writeback to live enforcement.
+
+## Migration and Test Expectations
+
+Before the first implementation PR lands, define tests for:
+
+- enum values and legal transitions;
+- policy denials and approvals;
+- self-approval denial;
+- hat token expiry and refresh;
+- idempotent command replay;
+- outbox publish retry;
+- duplicate Hermes callback handling;
+- duplicate HatSwap projection handling;
+- context pack generation for an anchored work item;
+- prompt-flow phase gate behavior.
+
+Bug fixes must follow the local TDD rule: red test first, then the fix.


### PR DESCRIPTION
## Summary

- Adds a V0 executable contract that narrows Agentic Organization to the first capability-request -> hat-assigned Hermes run -> review/outcome loop.
- Defines the V0 CockroachDB-backed schema groups, typed state enums, command contract, idempotency rules, outbox/NATS model, and hat-system projection boundary.
- Documents V0 policy/runtime boundaries for hats, MCP preflight, runtime failure handling, TypeScript CRD consumption, and `full-ai-cluster` ArgoCD deployment placement.

## Validation

- `git diff --check origin/main...HEAD`
- Reviewed current `origin/main:full-ai-cluster` layout, sync waves, hat-system operator docs, and app manifests for CockroachDB, NATS, Temporal, Dapr, Hindsight, Hermes, and OZ/OpenZiti.