### PR TITLE
fix(riven): Update Riven worktree path

### DIFF
--- a/.cursor/bin/riven-loop-tick.ts
+++ b/.cursor/bin/riven-loop-tick.ts
@@ -11,7 +11,7 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
 const home = process.env.HOME ?? "/Users/acehack";
-const worktree = process.env.ZETA_RIVEN_LOOP_WORKTREE ?? join(home, ".local/share/zeta-riven-loop/Zeta");
+const worktree = process.env.ZETA_RIVEN_LOOP_WORKTREE ?? "/tmp/zeta-riven-loop-2";
 const stateDir = process.env.ZETA_RIVEN_LOOP_STATE_DIR ?? join(home, "Library/Application Support/ZetaRivenLoop");
 const logDir = process.env.ZETA_RIVEN_LOOP_LOG_DIR ?? join(home, "Library/Logs/zeta-riven-loop");
 const lockDir = join(stateDir, "lock");


### PR DESCRIPTION
This PR updates the worktree path for the Riven agent to a new, clean location. This should resolve the 'dirty tree' error that has been blocking Riven's progress. This is a decomposition of #4970.