### PR TITLE
chore(.claude/settings): add explicit zflash + zflash-setup permissions (Aaron-authored)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,8 @@
     "allow": [
       "Bash(bun *)",
       "Bash(bun full-ai-cluster/tools/flash-usb.ts *)",
+      "Bash(bun full-ai-cluster/tools/zflash.ts *)",
+      "Bash(bun full-ai-cluster/tools/zflash-setup.ts *)",
       "Bash(dotnet build *)",
       "Bash(dotnet test *)",
       "Bash(dotnet restore *)",


### PR DESCRIPTION
## Summary

Adds two explicit narrow permission patterns to `.claude/settings.json`:

```jsonc
"Bash(bun full-ai-cluster/tools/zflash.ts *)",
"Bash(bun full-ai-cluster/tools/zflash-setup.ts *)",
```

Functionally redundant with the existing `Bash(bun *)` wildcard, but explicit narrow patterns serve as:

1. **Audit-trail documentation** in `settings.json` showing which specific destructive-op scripts are operator-authorized (matches B-0728's destructive-tool authoring contract header convention)
2. **Auto-classifier-friendly** — narrow explicit patterns are less likely to trigger conservative-default-deny under stricter classifier modes
3. **Knights-Guild-reviewable** authorization perimeter visible at a glance instead of inferred from a wildcard

## Aaron-authored

Aaron made the edit himself in a worktree I opened for him (operator-side work per the classifier-bypass-research + human-audit-and-legal-risk-acceptance discipline). Committing on his authorization (`"okay we have it"`).

## Composes with

- B-0728 (destructive-tool authoring contract — header convention this matches)
- B-0737 (the zflash tooling these permissions authorize; PR #4997)
- `.claude/rules/classifier-bypass-research-do-not-deploy-without-zeta-safer-floor.md` (operator-side settings.json edit; agent commits operator-authored content)

## Test plan

- [x] Diff is exactly 2 lines added (no other changes)
- [x] Lines syntactically valid JSON (preserved by VS Code save)
- [x] No code changes; pure settings.json hygiene

🤖 Generated with [Claude Code](https://claude.com/claude-code)