### PR TITLE
feat(pr-preservation): implement idempotency check and CRLF/LF hygiene

### DIFF
--- a/tools/codex-loop-tick.test.ts
+++ b/tools/codex-loop-tick.test.ts
@@ -73,7 +73,7 @@ describe("codex-loop-tick service contract", () => {
     expect(prompt).toContain("Cold-start by reading the repo rules before deciding");
     expect(prompt).toContain("`AGENTS.md`, `.codex/AGENTS.md`, `docs/ALIGNMENT.md`");
     expect(prompt).toContain("/tmp/zeta-home/.local/share/zeta-broadcasts/");
-    expect(prompt).toContain("running `bun tools/github/refresh-worldview.ts`");
+    expect(prompt).toContain("bun tools/github/refresh-worldview.ts");
     expect(prompt).toContain("from the current loop worktree");
     expect(prompt).toContain("Prefer repo-native TypeScript/Bun tools over ad-hoc shell pipelines");
     expect(prompt).toContain("this background loop is the manager of its own subagents");

--- a/tools/pr-preservation/archive-pr.ts
+++ b/tools/pr-preservation/archive-pr.ts
@@ -30,7 +30,7 @@
 //      pullRequest: null / formatter errors)
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
@@ -787,12 +787,27 @@ export function main(argv: readonly string[]): number {
   }
 
   const archivedAt = nowIsoUtcSecs();
-  const content = formatArchive({ fetched, archivedAt });
+  const content = formatArchive({ fetched, archivedAt }).replace(/\r\n/g, "\n");
 
   const existing = findExistingArchive(outDir, args.pr);
   const path =
     existing ??
     join(outDir, `PR-${String(args.pr).padStart(4, "0")}-${makeSlug(fetched.pr.title ?? "untitled")}.md`);
+
+  if (existing) {
+    try {
+      const existingContent = readFileSync(existing, "utf8").replace(/\r\n/g, "\n");
+      const normalize = (s: string) => s.replace(/^archived_at: .*/m, 'archived_at: "PLACEHOLDER"');
+      if (normalize(content) === normalize(existingContent)) {
+        process.stdout.write(
+          `skipped writing ${path} (only archived_at timestamp changed)\n`,
+        );
+        return 0;
+      }
+    } catch {
+      // If reading fails, proceed to write the new archive
+    }
+  }
 
   writeFileSync(path, content);
   process.stdout.write(


### PR DESCRIPTION
## Summary

Addresses Lior PR discussion archive issues:
- **Spurious Timestamp-Only Diffs**: `tools/pr-preservation/archive-pr.ts` now reads any existing discussion archive for the PR first, and performs a normalization comparison where `archived_at` is masked. If no other metadata or thread changes exist, it skips writing entirely, preventing spurious timestamp-only diffs.
- **CRLF/LF Line Endings Leakage**: Enforces all generated content to replace `\r\n` with `\n` prior to comparing or writing.
- **Worldview Refresh Test Failure**: Fixed the prompt assertion test in `tools/codex-loop-tick.test.ts` to correctly expect the `refresh-worldview.ts` script without backticks, matching the timeout wrapper.

## Verification
- Verified against local PR #5016 (safely outputs `skipped writing ... (only archived_at timestamp changed)`).
- Full `bun test` test suite completed successfully (1422 passed, 0 failed).

Co-Authored-By: Gemini <noreply@google.com>