### PR TITLE
fix(backlog): add missing index entry for B-0753 from PR #5025

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -814,5 +814,6 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0719](backlog/P3/B-0719-soraya-round67-audit-of-audit-recognition-without-row-filing-precedent-2026-05-24.md)** Soraya round-67 forced-decomposition — audit-of-audit: ratify the recognition-without-row-filing precedent (when trigger fires + 'not my lane,' where does the routing-decision substrate land?)
 - [ ] **[B-0725](backlog/P3/B-0725-polyglot-accelerator-hardware-shape-coral-ncs-jetson-fpga-beyond-nvidia-only-2026-05-25.md)** Polyglot-accelerator hardware-shape extension — Coral / NCS / Jetson / FPGA beyond NVIDIA-only; activates as gadgets come out of drawer
 - [ ] **[B-0727](backlog/P3/B-0727-federated-4-tier-cluster-topology-cloud-community-home-business-edge-with-routing-for-weaker-leaves-2026-05-25.md)** Federated peer mesh — 5 resource profiles (cloud/hub, community, home/business, edge, leaf), weight-free routing, NO hierarchy; cloud/hub doesn't hog net neutrality
+- [ ] **[B-0753](backlog/P3/B-0753-noether-decomposition-land-via-pr-2026-05-25.md)** Noether decomposition land via PR — track integration of lior-decompose-4781-shadow-log onto main
 
 <!-- END AUTO-GENERATED -->

--- a/docs/backlog/P3/B-0753-noether-decomposition-land-via-pr-2026-05-25.md
+++ b/docs/backlog/P3/B-0753-noether-decomposition-land-via-pr-2026-05-25.md
@@ -1,0 +1,45 @@
+---
+id: B-0753
+priority: P3
+status: open
+title: Noether decomposition land via PR — track integration of lior-decompose-4781-shadow-log onto main
+created: 2026-05-25
+last_updated: 2026-05-25
+classification: buildable-now
+decomposition: atomic
+owners: [lior, formal-verification-expert]
+type: backlog-tracking
+composes_with:
+  - docs/backlog/P3/B-0002-otto-287-noether-formalization.md
+  - docs/backlog/P3/B-0002.1-noether-formalization-step1.md
+  - docs/backlog/P3/B-0002.2-noether-formalization-step2.md
+  - docs/backlog/P3/B-0002.3-noether-formalization-step3.md
+  - docs/backlog/P3/B-0002.4-noether-formalization-step4.md
+---
+
+# B-0753 — B-0002 Noether decomposition land via PR: track integration of lior-decompose-4781-shadow-log onto main
+
+## Origin
+
+Aaron Stainback / Lior 2026-05-25 BFT loop alignment session. Following the B-0750 (worktree hygiene) and B-0751 (per-agent isolated clones) architectures, the divergent Noether decomposition commits on local `main` were safely reset. This ticket files the substrate-honest follow-up to track landing the Noether decomposition children (`B-0002.1` through `B-0002.4`) on `main` via PR #4926 or a sibling PR.
+
+## Finding
+
+Lior's past-self commits (`54d5b53e7` and `d229514ac`) decomposed `B-0002` (Noether formalization) into four atomic child tickets and preserved PR #4853. These commits reside on remote branch `lior-decompose-4781-shadow-log` and are actively open under **PR #4926** (auto-merge squashed). However, the child ticket files themselves are currently missing on `origin/main` as the PR is still open.
+
+This row tracks the formal path to main for the Noether decomposition substrate so it does not sit permanently on remote branches.
+
+## Acceptance criteria
+
+1. PR #4926 (or a focused Noether decomposition sibling PR) is merged to `origin/main`.
+2. The four child files `B-0002.1-noether-formalization-step1.md` through `B-0002.4-noether-formalization-step4.md` are present on `origin/main`.
+3. The parent `B-0002-otto-287-noether-formalization.md` is updated on `origin/main` to reflect the active child tickets.
+
+## Effort
+
+S (Tracking and integration-merge verification only; the code/prose changes are already written and pushed).
+
+## Composes with
+
+- [`docs/backlog/P3/B-0002-otto-287-noether-formalization.md`](B-0002-otto-287-noether-formalization.md) — the parent row being decomposed
+- PR #4926 — the integration vehicle


### PR DESCRIPTION
This PR fixes the failing 'backlog-index-integrity' check from PR #5025 by adding the missing entry for B-0753 to the main BACKLOG.md index.

This supersedes PR #5025.