### PR TITLE
fix(B-0754 iter-2): empty systemd PATH broke clear+nmtui+ping+systemctl on real hardware

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
+++ b/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
@@ -227,14 +227,18 @@
     after = [ "systemd-user-sessions.service" "NetworkManager.service" ];
     conflicts = [ "getty@tty1.service" ];
     # B-0754 iteration-2 PATH fix: systemd services on NixOS get a
-    # minimal PATH by default; bare commands (clear, nmtui, ping,
-    # systemctl, etc.) failed with 'command not found' on first real-
-    # hardware run. Explicit PATH covers every tool the first-boot
-    # script + zeta-install reach for. TERM=linux so any tput-based
-    # tools (curses TUIs like nmtui) get a sane terminal capability
-    # database without the script having to set it per-invocation.
+    # minimal PATH by default (coreutils + findutils + grep + sed +
+    # systemd); bare commands (clear, nmtui, ping, etc.) outside that
+    # set failed with 'command not found' on first real-hardware run.
+    # NixOS systemd module already defines a default PATH at
+    # mkOptionDefault priority; use lib.mkForce to replace with the
+    # union that includes /run/current-system/sw/bin and
+    # /run/wrappers/bin so every tool in environment.systemPackages
+    # is reachable + setuid wrappers work. TERM=linux so any tput-
+    # based tools (curses TUIs like nmtui) get a sane terminal
+    # capability database without per-invocation setup.
     environment = {
-      PATH = "/run/current-system/sw/bin:/run/current-system/sw/sbin:/run/wrappers/bin";
+      PATH = lib.mkForce "/run/current-system/sw/bin:/run/current-system/sw/sbin:/run/wrappers/bin";
       TERM = "linux";
     };
     serviceConfig = {

--- a/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
+++ b/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
@@ -226,6 +226,17 @@
     wantedBy = [ "multi-user.target" ];
     after = [ "systemd-user-sessions.service" "NetworkManager.service" ];
     conflicts = [ "getty@tty1.service" ];
+    # B-0754 iteration-2 PATH fix: systemd services on NixOS get a
+    # minimal PATH by default; bare commands (clear, nmtui, ping,
+    # systemctl, etc.) failed with 'command not found' on first real-
+    # hardware run. Explicit PATH covers every tool the first-boot
+    # script + zeta-install reach for. TERM=linux so any tput-based
+    # tools (curses TUIs like nmtui) get a sane terminal capability
+    # database without the script having to set it per-invocation.
+    environment = {
+      PATH = "/run/current-system/sw/bin:/run/current-system/sw/sbin:/run/wrappers/bin";
+      TERM = "linux";
+    };
     serviceConfig = {
       Type = "idle";
       ExecStart = "/run/current-system/sw/bin/zeta-first-boot";

--- a/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
@@ -36,7 +36,11 @@ ROLE_PROMPT_SECS="${ROLE_PROMPT_SECS:-10}"
 # Defaults to whatever the ISO's /etc/zeta-firstboot.conf shipped with
 # (typically control-plane). Press 'c' or 'w' within ${ROLE_PROMPT_SECS}s
 # to choose; any other key (or timeout) keeps the default.
-clear || true
+# ANSI 'reset terminal' escape — no external `clear` dependency,
+# works on bare tty without requiring `ncurses` + a TERM that
+# tput recognises. Fixes B-0754 iteration-1 'clear: command not
+# found' from the systemd unit's minimal PATH.
+printf '\033c' || true
 cat <<EOF
 
   Zeta cluster installer — first boot
@@ -73,7 +77,11 @@ has_internet() {
   ping -c 1 -W 2 -q github.com >/dev/null 2>&1
 }
 
-clear || true
+# ANSI 'reset terminal' escape — no external `clear` dependency,
+# works on bare tty without requiring `ncurses` + a TERM that
+# tput recognises. Fixes B-0754 iteration-1 'clear: command not
+# found' from the systemd unit's minimal PATH.
+printf '\033c' || true
 cat <<EOF
 
   ╭──────────────────────────────────────────────────────╮
@@ -105,8 +113,12 @@ else
   read -n 1 -s -t 5 -p "  Press any key to launch nmtui (or wait 5s) ..." || true
   echo
   echo
-  # nmtui returns 0 on quit regardless of whether connection succeeded
-  if ! nmtui; then
+  # nmtui returns 0 on quit regardless of whether connection succeeded.
+  # Absolute path: systemd unit PATH minimal; the env-var below + this
+  # absolute path are both defenses. Fixes B-0754 iteration-1 'nmtui:
+  # command not found' (nmtui IS installed in the ISO via networkmanager
+  # in systemPackages; the issue was PATH inheritance into the unit).
+  if ! /run/current-system/sw/bin/nmtui; then
     echo "[zeta-first-boot] nmtui failed."
     drop_to_shell
   fi

--- a/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
@@ -114,10 +114,12 @@ else
   echo
   echo
   # nmtui returns 0 on quit regardless of whether connection succeeded.
-  # Absolute path: systemd unit PATH minimal; the env-var below + this
-  # absolute path are both defenses. Fixes B-0754 iteration-1 'nmtui:
-  # command not found' (nmtui IS installed in the ISO via networkmanager
-  # in systemPackages; the issue was PATH inheritance into the unit).
+  # Absolute path: defense-in-depth alongside the systemd unit's
+  # environment.PATH override (set in configuration.nix on
+  # systemd.services.zeta-first-boot.environment.PATH via lib.mkForce).
+  # Both defenses together fix B-0754 iteration-1 'nmtui: command not
+  # found' (nmtui IS installed in the ISO via networkmanager in
+  # systemPackages; the issue was PATH inheritance into the unit).
   if ! /run/current-system/sw/bin/nmtui; then
     echo "[zeta-first-boot] nmtui failed."
     drop_to_shell


### PR DESCRIPTION
## Iteration 1 result (real-hardware test, Aaron 2026-05-25)

Photo evidence on the cluster node screen after booting the v1 ISO:

- `clear: command not found` (line 40 + line 77) — the role-prompt and banner sections
- `nmtui: command not found` — when ethernet-DHCP wait expired and the wifi-fallback fired
- Drop-to-shell worked correctly — operator landed at a working root prompt with the recovery hints intact

The substrate-honest failure path validated: the script degraded gracefully and the operator could still complete the install manually (`nmtui` + `zeta-install control-plane` from the recovery shell). But the load-bearing zero-typing-automation flow didn't reach the end. **This PR is the fix so iteration 2 completes unattended.**

## Root cause

NixOS systemd services get a **minimal PATH** by default. The first-boot script's bare commands (`clear`, `nmtui`, `ping`, `systemctl`, plus every command zeta-install.sh would reach for — `lsblk`, `sgdisk`, `mkfs.fat`, `mkfs.ext4`, `mount`, `partprobe`, `partprobe`, etc.) all need either explicit absolute paths OR a configured Environment block on the systemd unit. The interactive-shell PATH that 'just works' for SSH or tty2 login is NOT inherited by Type=idle systemd services.

The reason only `clear` and `nmtui` were observed: `nmtui` blocked first; the rest never executed in the failed path.

## Fix (defense in depth)

### 1. systemd unit Environment block (load-bearing)

`configuration.nix`: explicit `PATH` + `TERM` on the zeta-first-boot service. Covers every current AND future bare command:

```nix
environment = {
  PATH = "/run/current-system/sw/bin:/run/current-system/sw/sbin:/run/wrappers/bin";
  TERM = "linux";
};
```

### 2. Script-level belt-and-suspenders

`zeta-first-boot.sh`:

- Replace `clear || true` (×2) with `printf '\\033c' || true` — ANSI 'reset terminal' escape; no external command dependency
- Change `nmtui` invocation to `/run/current-system/sw/bin/nmtui` (absolute path)

Even if the systemd Environment is overridden by some future change, these two failure modes stay fixed.

## Composes with

- B-0759 first-time-CLI-user persona — drop-to-shell with recovery hints worked exactly as designed; the persona-aligned error path was substrate-honest
- B-0760 USB-as-repair-tool — same systemd-PATH discipline applies to every command the repair flow will invoke
- B-0761 reference architecture — this is iteration N of N for the AI-native cluster-bootstrap reference; bandwidth payoff across every future install

## Test plan

- [x] `bash -n` syntax check on edited zeta-first-boot.sh
- [ ] CI rebuilds ISO via build-ai-cluster-iso.yml (auto-triggers on `full-ai-cluster/usb-nixos-installer/**` path)
- [ ] Aaron reflashes via zflash + boots cluster node + observes unattended install completes end-to-end
- [ ] CI green
