### PR TITLE
fix(B-0754 iter-3): per-device partprobe — bare partprobe was hitting the boot USB (/dev/sda) + bailing

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
+++ b/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
@@ -16,6 +16,19 @@
   time.timeZone = "America/New_York";
   i18n.defaultLocale = "en_US.UTF-8";
 
+  # B-0754 iter-3 hardware-firmware cleanup: enable redistributable
+  # firmware on the installer (Intel SoF / linux-firmware). Without
+  # this, modern Intel chipsets (Meteor Lake / Lunar Lake / Arrow
+  # Lake) print scary `ASoC: failed to instantiate card -2` /
+  # `snd_soc_register_card failed -2` errors during boot because
+  # their HD Audio Controller probes a SoundWire codec topology that
+  # needs SoF firmware blobs. Cosmetic — audio is not load-bearing
+  # for cluster substrate — but per B-0759 first-time-CLI-user
+  # persona, scary 'ERROR' lines in dmesg are UX noise we don't
+  # need. Redistributable-only (no allowUnfree needed); ~80MB
+  # added to ISO; covers WiFi/BT/NIC firmware too as a side benefit.
+  hardware.enableRedistributableFirmware = true;
+
   nix.settings = {
     experimental-features = [ "nix-command" "flakes" ];
     auto-optimise-store = true;

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -162,7 +162,18 @@ for d in "${DATA_DISKS[@]}"; do
   i=$((i + 1))
 done
 
-sudo partprobe
+# Per-device partprobe: bare `partprobe` (no args) probes EVERY
+# block device the kernel knows about, including the USB stick we
+# booted from (kernel exposes USB mass-storage as /dev/sda). The
+# booted ISO has mounted partitions on /dev/sda; partprobe rightfully
+# refuses to refresh those + returns non-zero; `set -euo pipefail`
+# then bails the whole install. Fix per B-0754 iter-3 empirical
+# anchor: pass only the disks WE just partitioned.
+echo "Refreshing kernel partition table for installed disks ..."
+sudo partprobe "$BOOT_DISK"
+for d in "${DATA_DISKS[@]}"; do
+  sudo partprobe "$d"
+done
 sleep 2
 
 # ── Step 5: format + mount ────────────────────────────────────────

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -164,15 +164,20 @@ done
 
 # Per-device partprobe: bare `partprobe` (no args) probes EVERY
 # block device the kernel knows about, including the USB stick we
-# booted from (kernel exposes USB mass-storage as /dev/sda). The
-# booted ISO has mounted partitions on /dev/sda; partprobe rightfully
+# booted from (kernel typically exposes USB mass-storage as
+# /dev/sdX — commonly /dev/sda on boards with no SATA disks; the
+# specific letter isn't guaranteed across hardware/boot order, but
+# the failure mode is the same regardless of letter). The booted
+# ISO has mounted partitions on that sdX device; partprobe rightfully
 # refuses to refresh those + returns non-zero; `set -euo pipefail`
 # then bails the whole install. Fix per B-0754 iter-3 empirical
-# anchor: pass only the disks WE just partitioned.
+# anchor: pass only the disks WE just partitioned, with an explicit
+# per-disk failure handler so the abort message names the offending
+# disk + suggests next steps (vs silent set -euo pipefail bail).
 echo "Refreshing kernel partition table for installed disks ..."
-sudo partprobe "$BOOT_DISK"
+sudo partprobe "$BOOT_DISK" || bail "partprobe failed for BOOT disk $BOOT_DISK — check 'dmesg | tail' for kernel detail; manual recovery: 'sudo partprobe $BOOT_DISK' then 'lsblk' to verify partition table"
 for d in "${DATA_DISKS[@]}"; do
-  sudo partprobe "$d"
+  sudo partprobe "$d" || bail "partprobe failed for DATA disk $d — check 'dmesg | tail'; manual recovery: 'sudo partprobe $d' then 'lsblk' to verify partition table"
 done
 sleep 2
 


### PR DESCRIPTION
## Iteration 2 result (cluster node 1, real-hardware test, Aaron 2026-05-25)

Photo evidence on PC 1 shows iter-2 reached 98% of the install path on first try:

- Wifi connected
- Banner shown
- Greedy N-disk enum: both Crucial CT1000P3PSSD8 NVMes correctly identified with serials
- Plan presented (BOOT nvme0n1: ESP 1G + root 256G + longhorn1 rest; DATA nvme1n1: whole disk longhorn2)
- ZETA_AUTO_CONFIRM=WIPE bypass: WORKED
- wipefs + sgdisk on both NVMes: SUCCESS
- GPT partition creation on both NVMes: SUCCESS
- **Then**: `Error: Partition(s) 1 on /dev/sda have been written, but we have been unable to inform the kernel of the change, probably because it/they are in use`
- drop_to_shell fired correctly with recovery hints

## Root cause

zeta-install.sh called bare `sudo partprobe` (no args). partprobe with no args probes EVERY block device the kernel knows about. Linux exposes USB mass-storage as `/dev/sda` when no SATA disks present. The booted live ISO has mounted partitions on /dev/sda; partprobe refuses to refresh (rightfully); returns non-zero; `set -euo pipefail` bails.

The greedy N-disk enum ALREADY correctly excluded the USB (TRAN=usb filter). We never partitioned /dev/sda. The partprobe call was the only blanket-all-devices invocation in the whole script.

## Fix

Per-device partprobe on BOOT_DISK + each DATA_DISKS entry. Never blanket. Never touch /dev/sda.

Aaron 2026-05-25: 'i would rather do it right so it's not ambigious for future me / users' — the script now operates on explicit-target devices throughout, no blanket-system-wide invocations remaining.

## Test plan

- [x] `bash -n` syntax check
- [ ] CI rebuilds ISO via build-ai-cluster-iso.yml
- [ ] Aaron reflashes via zflash + boots cluster node 1 + observes unattended install reaches end-to-end (cluster member after reboot)
- [ ] CI green
