### PR TITLE
backlog(B-0774 + B-0775): etcd-less options (kine adapter family) + HA-k8s-that-scales-beyond-etcd (CockroachDB / NATS super-cluster / Karmada / cell-based)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -705,6 +705,8 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0762](backlog/P2/B-0762-ai-auto-submit-back-telemetry-fixes-from-in-the-wild-installs-adoption-cost-to-zero-flywheel-aaron-2026-05-25.md)** AI auto-submit-back telemetry + fixes from in-the-wild installs — adoption-cost-to-zero flywheel
 - [ ] **[B-0764](backlog/P2/B-0764-cncf-ecosystem-as-force-multipliers-behind-zeta-interfaces-keda-dapr-opa-oam-kubevela-plus-ace-and-ontology-negotiation-aaron-2026-05-25.md)** CNCF ecosystem as force multipliers behind Zeta interfaces — KEDA, DAPR, OPA, OAM/KubeVela + Ace + ontology negotiation
 - [ ] **[B-0772](backlog/P2/B-0772-observable-cluster-fabric-universal-device-plugins-plus-reticulum-mesh-plus-polyglot-rx-streams-aaron-2026-05-25.md)** Observable cluster fabric — universal device plugins (NPU/GPU/audio/etc.) + Reticulum mesh (AllJoyn-successor) + polyglot Rx streams in every language
+- [ ] **[B-0774](backlog/P2/B-0774-etcdless-options-kine-adapter-dqlite-postgres-nats-zeta-native-dbsp-aaron-2026-05-25.md)** Etcd-less k8s options — kine adapter family (SQLite/Postgres/MySQL/NATS/Dqlite) + Zeta-native DBSP+Raft endgame
+- [ ] **[B-0775](backlog/P2/B-0775-ha-kubernetes-that-scales-beyond-etcd-cockroach-nats-supercluster-karmada-cluster-api-cell-based-aaron-2026-05-25.md)** HA Kubernetes that scales beyond etcd — CockroachDB / NATS super-cluster / Karmada / KubeStellar / Cluster API / cell-based architecture
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-0774-etcdless-options-kine-adapter-dqlite-postgres-nats-zeta-native-dbsp-aaron-2026-05-25.md
+++ b/docs/backlog/P2/B-0774-etcdless-options-kine-adapter-dqlite-postgres-nats-zeta-native-dbsp-aaron-2026-05-25.md
@@ -1,0 +1,216 @@
+---
+id: B-0774
+priority: P2
+status: open
+title: Etcd-less k8s options — kine adapter family (SQLite/Postgres/MySQL/NATS/Dqlite) + Zeta-native DBSP+Raft endgame
+effort: M
+ask: aaron 2026-05-25
+created: 2026-05-25
+last_updated: 2026-05-25
+depends_on:
+  - B-0756
+composes_with:
+  - B-0428
+  - B-0747
+  - B-0754
+  - B-0763
+  - B-0765
+  - B-0766
+  - B-0772
+  - B-0773
+tags: [cluster, k8s, etcd, kine, dqlite, postgres, nats, dbsp, consensus, ha]
+---
+
+## Problem
+
+Aaron 2026-05-25 mid-iter-3-CI-wait, after the digital-twin
+framing (B-0773): *"are there etcdless"* — naming a real
+substrate question: alternatives to etcd as the k8s control-
+plane backing store.
+
+B-0756 HA control-plane assumed k3s embedded etcd as the default
+HA path. That's one path; multiple etcd-less paths exist + some
+compose better with Zeta substrate (especially B-0772 fabric +
+B-0773 digital twin).
+
+## Existing etcd-less options
+
+| Option | Backend | Maturity | Best fit |
+|---|---|---|---|
+| **microk8s** (Canonical) | **Dqlite** (SQLite + Raft) | Production; widely deployed | Single-binary k8s with built-in HA via Dqlite quorum; Canonical's flagship; well-engineered |
+| **k3s + kine + SQLite** | SQLite via [kine](https://github.com/k3s-io/kine) | Production; default for k3s single-node | Single-node lab; no HA via this path |
+| **k3s + kine + PostgreSQL** | Postgres (or CockroachDB / Aurora / YugabyteDB / Neon) | Production | HA pushed to DB; works with any PG-compatible distributed DB; operator inherits DB-side quorum |
+| **k3s + kine + MySQL** | MySQL / MariaDB | Production | Same shape; less common; HA via Galera/MaxScale/PXC |
+| **k3s + kine + NATS JetStream** | NATS JetStream | Production; recent | Mesh-friendly; composes with B-0772 Reticulum-adjacent thinking |
+| **k0s + kine + various** | Same kine options | Production | Mirantis's alternative; same backend options |
+| **MicroShift** (Red Hat) | kine + SQLite by default; pluggable | Production; edge-focused | Red Hat's micro-k8s for edge |
+| **Zeta-native** (B-0766 wave 4) | **DBSP + Raft, retraction-native** | Future endgame | Native etcd-replacement; composes with B-0773 digital twin |
+
+## Why kine is the load-bearing standard interface
+
+[Kine](https://github.com/k3s-io/kine) is an etcd-API shim:
+backends translate etcd v3 gRPC calls into native operations.
+Per B-0765 ServiceTitan-route, kine IS the existing standard
+interface that abstracts the etcd-or-not choice:
+
+- Operator writes k8s manifests as normal (no change)
+- kube-apiserver speaks etcd v3 gRPC (no change)
+- kine translates calls to the chosen backend (SQLite / PG /
+  MySQL / NATS / Dqlite / DBSP / ...)
+- Backend choice becomes a deployment-time decision, not an
+  application-code decision
+
+This is the pattern Zeta wants: **kine is the interface; the
+backend is swappable**. Aligns perfectly with B-0763
+operator-in-the-negotiation-high-seat — kine puts the operator
+in the seat for control-plane backing store; vendors / backends
+compete underneath; operator swaps via kine config.
+
+## Per-backend-choice trade-offs (concrete)
+
+| Backend | HA story | Perf | Operational complexity | Composes with Zeta substrate |
+|---|---|---|---|---|
+| **etcd** (B-0756 default) | k3s embedded etcd with Raft quorum (3/5/7 nodes) | Excellent | Medium (etcd needs careful tuning at scale) | Standard; no special composition |
+| **Dqlite** (microk8s) | Built-in Raft quorum; no separate cluster needed | Good for small-to-medium | Low (Canonical packages it cleanly) | Bridge possible but not native to Zeta |
+| **PostgreSQL** (via kine) | HA via PG-compatible distributed DB (CockroachDB / YugabyteDB / Aurora-Limitless) | Good (PG indexes are mature) | Medium-high (operator runs another DB cluster) | Native: per B-0763 vendor-swap, the DB itself is swappable; per B-0773, twin events can live in same PG cluster as control plane |
+| **NATS JetStream** (via kine) | Built-in JetStream replication (Raft-based) | Excellent for write-heavy | Medium | **Excellent native fit**: NATS subjects ARE Rx-Observable-shaped; per B-0772 fabric, the control plane is just another Observable stream. Composes with Reticulum-mesh-adjacent thinking. |
+| **DBSP + Raft** (Zeta-native, B-0766 wave 4) | Raft quorum on Zeta-native consensus engine; DBSP retraction-native semantics | Highest (algebra-grounded) | Lowest once shipped (substrate-native) | **Best native fit**: control-plane state = twin state per B-0773; cluster operations are first-class DBSP events; ARC-AGI benchmark (B-0761) can include consensus-store quality as a scoring dimension |
+
+## Target
+
+Document + ship **kine-as-the-interface** for Zeta cluster
+control-plane backing store. Operators choose backend per:
+
+- Single-node lab: kine + SQLite (current k3s default)
+- Small cluster (3-7 nodes): kine + Dqlite OR k3s embedded etcd
+- Medium cluster (10-50 nodes): kine + PostgreSQL (CockroachDB
+  recommended for HA without additional ops)
+- Workload-heavy / mesh-native: kine + NATS JetStream
+- Zeta-native target (future): kine + Zeta DBSP backend (per
+  B-0766 wave 4)
+
+## Acceptance
+
+- [ ] Document kine-as-interface in
+      `docs/cluster-control-plane-backing-store.md`: per-
+      backend trade-offs, recommended choices per cluster size
+- [ ] Update B-0756 HA control-plane row to reference kine
+      adapter family as the binary-compatible alternative to
+      embedded etcd (not a competitor; complementary)
+- [ ] Per-backend Zeta substrate:
+      - `modules/control-plane-backing-store/sqlite.nix`
+        (current default; documented)
+      - `modules/control-plane-backing-store/dqlite.nix`
+        (microk8s-style)
+      - `modules/control-plane-backing-store/postgres.nix`
+        (with CockroachDB sub-config)
+      - `modules/control-plane-backing-store/nats.nix`
+        (JetStream)
+- [ ] Zeta-first-boot role keystroke prompt (B-0754) extended
+      to include backing-store choice for control-plane role:
+      'a' SQLite (lab), 's' Dqlite (small HA), 'p' Postgres,
+      'n' NATS JetStream, 'e' embedded etcd (default for
+      compatibility)
+- [ ] Auto-discovery (B-0757) advertises chosen backing store
+      per cluster; subsequent nodes joining the same cluster
+      use the same store
+- [ ] Per-backend migration path: documented + tested for each
+      pairwise transition (operator can swap backing store at
+      operator-driven cadence; not stranded on initial choice)
+- [ ] DBSP backend research spike (per B-0766 wave 4): does
+      kine support pluggable backends easily enough that Zeta
+      could write `kine-zeta-dbsp` as a fork OR contribute the
+      backend upstream? Initial answer based on kine's
+      pluggability docs + Frank McSherry's DBSP substrate
+
+## Composes with substrate
+
+- B-0428 — F# fork for AI safety (the substrate base for
+  future Zeta-native DBSP backing store)
+- B-0747 — git-native per-machine state (each backend choice
+  is per-machine config; declarative + GitOps-reconciled)
+- B-0754 — zero-typing first-boot (backing-store choice
+  added to keystroke prompt for control-plane role)
+- B-0756 — HA control-plane (this row sharpens — etcd-less
+  options are alternative HA paths, not parallel scope)
+- B-0763 — cloud-native plugins fit Zeta interfaces (kine IS
+  the operator-facing interface; backends are swappable
+  vendors)
+- B-0765 — ServiceTitan route (kine IS the existing standard
+  interface Zeta plugs into; per the playbook)
+- B-0766 — slow-replace k8s (Zeta-native DBSP backing store
+  is wave 4 control-plane territory)
+- B-0767 — Zeta-native scheduler (composes naturally with
+  any kine backend; scheduler subscribes via kube-apiserver
+  watch which is etcd-API agnostic per kine)
+- B-0772 — observable+controllable cluster fabric (control-
+  plane events are first-class Observables regardless of
+  backing store; kine bridges)
+- B-0773 — cluster as digital twin (control-plane state IS
+  twin state; backing store choice = twin storage choice;
+  per B-0773 'and/or' framing, operator picks proportion
+  per stream class)
+
+## Why NATS JetStream is particularly interesting for Zeta
+
+Worth calling out separately. NATS JetStream as kine backend
+composes with:
+
+- B-0772 Rx Observable fabric: NATS subjects ARE Observable-
+  shaped natively; the control plane becomes just another
+  stream operators can subscribe to via Rx
+- B-0289 / Reticulum mesh: NATS leaf-node + Reticulum bridge
+  could deliver control-plane events over mesh transport
+  (radio-fallback, federated clusters, edge sites)
+- B-0773 digital twin: NATS streams are event-store-native by
+  design; using NATS for control plane means the twin's
+  control-plane substrate is event-sourced from day 1
+- B-0762 telemetry: NATS has built-in subject hierarchy that
+  composes with telemetry envelope routing
+
+Recommendation: NATS JetStream is the preferred etcd-less
+backend for Zeta substrate alignment, UNTIL Zeta-native DBSP
+backend ships per B-0766 wave 4.
+
+## What this preserves
+
+The B-0756 HA control-plane row's existing path (k3s embedded
+etcd) stays valid + remains the safest default for operators
+who want zero deviation from upstream k8s patterns. This row
+ADDS etcd-less options; doesn't deprecate etcd.
+
+Operator choice is preserved:
+
+| Operator profile | Recommendation |
+|---|---|
+| First-time, single-node lab | k3s + kine + SQLite (current default) |
+| Small HA cluster (3-7 nodes), prefers upstream defaults | k3s embedded etcd (B-0756) |
+| Small HA cluster, prefers single-binary | microk8s + Dqlite |
+| Medium cluster, has DB ops capacity | k3s + kine + Postgres (CockroachDB for HA) |
+| Workload-heavy / mesh-native / future Zeta substrate | k3s + kine + NATS JetStream |
+| Future Zeta-native | k3s + kine + Zeta DBSP backend (B-0766 wave 4) |
+
+## Out of scope
+
+- Implementing the Zeta DBSP backend — that's B-0766 wave 4;
+  this row only references it
+- Recommending specific Postgres-compatible distributed DB
+  for HA — CockroachDB / Aurora / YugabyteDB / Neon all
+  viable; let operator pick based on their existing infra
+- Per-backend perf benchmarks — separate sub-row when there's
+  empirical comparison data from actual cluster operations
+- Migration tooling between backends — separate sub-row;
+  documented patterns first; automation later
+
+## Origin
+
+Aaron 2026-05-25 mid-iter-3-CI-wait, asking *"are there
+etcdless"* after the digital-twin framing (B-0773). Real
+substrate question: etcd-less options exist (microk8s+Dqlite;
+kine adapter family); each composes differently with Zeta
+substrate; some (NATS JetStream particularly) align well with
+Zeta's observable fabric (B-0772) + digital twin (B-0773);
+Zeta-native DBSP backend is the long-game endgame (B-0766 wave
+4). Sharpens B-0756 HA control-plane row by naming the
+backing-store choice as a first-class operator decision rather
+than an etcd-only default.

--- a/docs/backlog/P2/B-0775-ha-kubernetes-that-scales-beyond-etcd-cockroach-nats-supercluster-karmada-cluster-api-cell-based-aaron-2026-05-25.md
+++ b/docs/backlog/P2/B-0775-ha-kubernetes-that-scales-beyond-etcd-cockroach-nats-supercluster-karmada-cluster-api-cell-based-aaron-2026-05-25.md
@@ -1,0 +1,260 @@
+---
+id: B-0775
+priority: P2
+status: open
+title: HA Kubernetes that scales beyond etcd — CockroachDB / NATS super-cluster / Karmada / KubeStellar / Cluster API / cell-based architecture
+effort: L
+ask: aaron 2026-05-25
+created: 2026-05-25
+last_updated: 2026-05-25
+depends_on:
+  - B-0756
+  - B-0774
+composes_with:
+  - B-0289
+  - B-0757
+  - B-0758
+  - B-0763
+  - B-0764
+  - B-0765
+  - B-0766
+  - B-0767
+  - B-0772
+  - B-0773
+tags: [cluster, k8s, ha, scale, federation, karmada, cockroachdb, nats, cluster-api, cell-based, multi-cluster]
+---
+
+## Problem
+
+Aaron 2026-05-25 mid-iter-3-CI-wait, sharpening B-0774
+(etcd-less options): *"ha installs of kubernets that scales
+better"*. Scale dimension is broader than just etcd backend
+choice. Etcd has known scale ceilings (~5K nodes per cluster
+typical; ~8 GB state limit; write throughput limited by Raft
+consensus). Beyond that, the substrate pattern changes from
+"single cluster + bigger backend" to "many clusters + federation
+layer."
+
+B-0774 covered etcd-less BACKEND options (kine adapter family).
+This row covers SCALE-BEYOND-ETCD ARCHITECTURE options that
+go beyond changing the backend — federation, cell-based,
+multi-cluster orchestration.
+
+## Real options that scale beyond etcd's single-cluster ceiling
+
+| Approach | Pattern | Scale ceiling | Mature today |
+|---|---|---|---|
+| **kine + CockroachDB** (B-0774) | Single cluster; etcd replaced with horizontally-scalable distributed SQL | Hundreds of nodes per cluster; multi-region replication via CockroachDB Serverless / Aurora-Limitless | Yes |
+| **kine + NATS JetStream + super-cluster** (B-0774) | Single cluster's control-plane events; NATS leaf-nodes + super-cluster federates control plane geographically | Federated globally; control plane events flow over mesh | Yes; NATS super-cluster production |
+| **Karmada** (CNCF graduated) | Multi-cluster federation with policy-based scheduling | 1000s of nodes across N member clusters; tested at Huawei + Vipshop production | Yes; CNCF graduated 2024 |
+| **KubeStellar** | Multi-cluster + edge-aware federation; "workload transport" via OCM | Edge-scale (many small clusters; thousands) | Yes; production; CNCF sandbox |
+| **vCluster** (Loft Labs) | Virtual k8s clusters running INSIDE a host cluster | Per-tenant scale; host cluster scale x tenants | Yes; production; OSS + commercial |
+| **Cluster API** (CAPI; CNCF Cluster Lifecycle) | Declarative cluster lifecycle as k8s CRDs; orchestrates many clusters from one management cluster | Cell-based: many clusters of clusters | Yes; production; widely deployed |
+| **OpenStack Magnum + Cluster API** | Cluster API on OpenStack substrate | Cell-based + IaaS | Yes (enterprise) |
+| **Liqo** | Peer-to-peer cluster sharing; resource borrowing | Cooperative federation | Yes; less mature |
+| **Cell-based custom** (Borg / Tupperware shape) | Many smaller clusters with orchestration layer above; operator pattern | Hyperscale (Google / Meta scale) | Custom; well-documented patterns |
+| **Zeta-native** (B-0766 wave 4 + cell-based) | DBSP + Raft consensus per cell; Zeta scheduler federates cells | Designed for cell-based scale from day 1 | Future endgame |
+
+## Per-option fit for Zeta substrate
+
+### Tier 1 (best Zeta-substrate fit)
+
+**kine + NATS JetStream + super-cluster**
+(extends B-0774 NATS recommendation):
+
+- NATS subjects ARE Observable-shaped (per B-0772 Rx fabric)
+- NATS super-cluster federates globally with leaf-nodes
+- Reticulum bridge (per B-0289) for radio-fallback control plane
+- Twin events (per B-0773) flow over same NATS substrate
+- Composes naturally with B-0772 + B-0773 + B-0289
+
+Scale: hundreds-of-thousands of nodes federated globally via
+NATS super-cluster mesh. Control plane substrate IS the twin
+event store.
+
+**Karmada** (CNCF graduated):
+
+- Standard interface (CNCF graduated — per B-0765 ServiceTitan
+  route)
+- Multi-cluster API operators already know
+- Production-tested at scale (Huawei / Vipshop)
+- Operator workloads target Karmada CRDs (PropagationPolicy,
+  OverridePolicy, ResourceBinding); Karmada handles
+  cross-cluster distribution
+- Composes with B-0758 unRAID-style edge clusters (each edge
+  site = one member cluster)
+
+Scale: thousands of nodes across N member clusters; Karmada
+operator chooses cluster topology (one big + many small; many
+medium; etc.).
+
+### Tier 2 (specific use cases)
+
+**Cluster API (CAPI)**:
+
+- Pattern for managing many clusters as k8s objects from a
+  management cluster
+- Each cell-based deployment instantiates clusters via CAPI;
+  Zeta cluster substrate becomes the per-cluster bootstrap
+  Cluster API targets
+- Composes with B-0773 digital twin: each cluster IS a twin;
+  Cluster API manages many twins
+
+**vCluster**:
+
+- Per-tenant virtual k8s; host cluster runs N tenant clusters
+- Useful for SaaS-style Zeta deployment where each customer
+  gets isolated cluster substrate on shared infra
+- Composes with B-0769 VC-meta-playbook substrate-honest
+  variant (multi-tenant control structure injection while
+  preserving operator-keeps-the-value)
+
+**KubeStellar**:
+
+- Edge-aware federation
+- Composes with B-0758 unRAID-style edge nodes
+- Workload-transport pattern via OCM (Open Cluster Management)
+
+### Tier 3 (custom / future)
+
+**Cell-based custom + Zeta-native** (B-0766 wave 4):
+
+- Hyperscale operators (Google Borg, Meta Tupperware, Twitter
+  Aurora) all use cell-based patterns
+- Many smaller clusters; orchestration layer above
+- Zeta-native control plane (B-0766 wave 4) designed for
+  cell-based scale from day 1 via DBSP retraction-native
+  semantics + cell-aware scheduler (B-0767)
+- Endgame; substantial implementation effort; future row
+
+## Target
+
+Document + ship **per-scale-tier recommendation**:
+
+| Cluster scale | Recommended approach | Substrate rows |
+|---|---|---|
+| **1-5 nodes** (lab, home, small business) | Single cluster; k3s embedded etcd OR kine + SQLite | B-0754, B-0756 |
+| **5-50 nodes** (small production, edge site) | Single cluster; k3s + kine + NATS JetStream | B-0774 |
+| **50-500 nodes** (medium production) | Single cluster; k3s + kine + CockroachDB | B-0774 |
+| **500-5000 nodes** (large production) | NATS super-cluster (federate control plane geographically) OR Karmada multi-cluster | This row Tier 1 |
+| **5000+ nodes** (hyperscale) | Cell-based + Karmada; many smaller clusters + federation | This row Tier 1 + custom |
+| **Multi-region / multi-cloud** | Karmada + per-region clusters; OR NATS super-cluster with leaf-nodes per region | This row Tier 1 |
+| **Edge** (many tiny clusters) | KubeStellar OR Karmada + B-0758 unRAID-style edge nodes | This row Tier 2 + B-0758 |
+| **Multi-tenant SaaS** | vCluster on host cluster + tenant-per-vCluster | This row Tier 2 + B-0769 |
+
+## Acceptance
+
+- [ ] Document the scale tiers in
+      `docs/cluster-scale-architecture.md` — per-tier
+      recommendation + substrate rows; per-operator-profile
+      guidance per B-0759 first-time-CLI-user persona
+- [ ] First federation-mode implementation: NATS super-cluster
+      configuration as a `modules/control-plane-federation-nats.nix`
+      module; operator opts in via single config flag
+- [ ] Karmada integration: NixOS module that deploys Karmada
+      as the federation layer; tested with 2 member clusters
+      minimum
+- [ ] Per-tier migration paths: operator can migrate UP the
+      tier hierarchy as cluster grows (5 → 50 → 500 → ...)
+      without manifest changes (per B-0763 vendor-swap pattern)
+- [ ] Zeta-first-boot (B-0754) role keystroke extended for
+      federation member: 'm' for "member of existing cluster
+      via Karmada" (joining a federated cluster instead of
+      bootstrapping new)
+- [ ] Auto-discovery (B-0757) extended to multi-cluster:
+      mDNS query for Karmada control plane on local network;
+      Reticulum bridge for federated control plane across
+      sites
+- [ ] Reference deployments per tier: 5-node, 50-node,
+      500-node sample configs; published as ARC-AGI benchmark
+      scenarios per B-0761
+- [ ] Cost-comparison surface per tier: per-tier infra cost
+      estimate (CockroachDB vs NATS vs Karmada vs custom
+      cell-based); operator-facing tool per B-0763 vendor-swap
+
+## Composes with
+
+- B-0289 — Reticulum mesh (federation transport beyond
+  internet; radio-fallback)
+- B-0756 — HA control-plane (this row sharpens to scale
+  dimension; B-0774 sharpens to backend dimension; together
+  cover the HA design space)
+- B-0757 — cluster auto-discovery (multi-cluster discovery
+  via mDNS / Reticulum / Karmada)
+- B-0758 — USB-persistent OS unRAID-style (edge nodes
+  composing into federation per Tier 2 KubeStellar /
+  Karmada)
+- B-0763 — cloud-native plugins fit Zeta interfaces
+  (Karmada / CockroachDB / NATS are existing standards Zeta
+  plugs into)
+- B-0764 — CNCF force multipliers (Karmada is CNCF
+  graduated; KubeStellar CNCF sandbox; Cluster API CNCF
+  Cluster Lifecycle; all adopted)
+- B-0765 — ServiceTitan route (each Tier 1+ option is the
+  existing standards interface Zeta plugs into)
+- B-0766 — slow-replace k8s (Zeta-native cell-based control
+  plane is wave 4+ territory)
+- B-0767 — Zeta-native scheduler (federation-aware
+  scheduling composes; multi-cluster placement decisions)
+- B-0769 — VC meta-playbook (multi-tenant scale via vCluster
+  is one substrate-honest expansion path)
+- B-0772 — observable+controllable cluster fabric (multi-
+  cluster fabric: every cluster's observables federated via
+  NATS super-cluster / Karmada APIs)
+- B-0773 — cluster as digital twin (cluster-of-twins:
+  Karmada manages many twins; CAPI manages twin lifecycles)
+- B-0774 — etcd-less options (this row builds on B-0774's
+  backend choices + extends to multi-cluster architecture)
+
+## Substrate-honest scale framing
+
+The substrate-honest claim: **scale ceiling depends on
+ARCHITECTURE choice, not just on BACKEND choice**. B-0774
+named backend options that scale better than etcd at single-
+cluster scope; this row names ARCHITECTURE options that scale
+beyond single-cluster scope entirely.
+
+Operator's actual decision tree:
+
+1. **What's my scale goal?** (1-5 / 5-50 / 50-500 / 500-5000 /
+   5000+ / multi-region / edge / multi-tenant)
+2. **Per-tier substrate recommendation** (this row's table)
+3. **Per-tier substrate rows** (B-0774 for single-cluster
+   scale; this row for multi-cluster scale)
+4. **Operator-in-the-negotiation-high-seat** preserved (per
+   B-0763): every choice swappable; not stranded on initial
+   architecture decision; migration paths documented
+
+## What this preserves vs prevents
+
+**Preserves**: B-0756 simple-HA-via-etcd default for operators
+who want zero-architecture-decision. Default stays simple.
+
+**Prevents**: Zeta substrate accidentally claiming "scales to
+N nodes" without naming WHICH architecture pattern at that N.
+Different patterns scale to different N; substrate-honest is
+to name the pattern + tier.
+
+## Out of scope
+
+- Implementing every option in detail — handle per-tier as
+  separate rows when operator demand surfaces
+- Comparing Karmada vs vCluster vs KubeStellar feature-by-
+  feature — depends on operator's specific use case; document
+  decision-factors instead
+- Hyperscale ($billion+ infra) cost optimization — out of
+  scope for the row; v1 ships substrate; cost optimization
+  is per-operator engagement
+- Replacing CNCF federation projects with Zeta-native — long
+  game per B-0766; not this row's v1
+
+## Origin
+
+Aaron 2026-05-25 mid-iter-3-CI-wait, sharpening B-0774
+etcd-less options with the scale dimension: *"ha installs of
+kubernets that scales better"*. Real substrate question;
+scale-beyond-etcd is architecture choice not just backend
+choice; multiple options (Karmada / KubeStellar / vCluster /
+Cluster API / cell-based + NATS super-cluster / CockroachDB)
+compose differently with Zeta substrate; this row names the
+per-tier recommendation + the substrate composition for each.


### PR DESCRIPTION
Two related questions from Aaron mid-iter-3-wait, bundled into one PR (both backlog rows; no code):

**B-0774** ('are there etcdless'): kine is the load-bearing standard interface; operator chooses backend (Dqlite via microk8s; SQLite / Postgres / MySQL / NATS via k3s+kine; Zeta-native DBSP+Raft via B-0766 wave 4). NATS JetStream backend particularly composes with B-0772 Rx fabric + B-0289 Reticulum + B-0773 digital twin.

**B-0775** ('ha installs of kubernets that scales better'): scale ceiling depends on ARCHITECTURE not just BACKEND. Per-tier recommendation table covering 1-5 / 5-50 / 50-500 / 500-5000 / 5000+ / multi-region / edge / multi-tenant. Options include kine+CockroachDB, NATS super-cluster, Karmada (CNCF graduated), KubeStellar, vCluster, Cluster API, cell-based custom, Zeta-native cell-based (B-0766 wave 4+ endgame).

Both sharpen B-0756 HA control-plane. Compose with B-0289 / B-0763 / B-0764 / B-0765 / B-0772 / B-0773.