### PR TITLE
feat(claude-code-recovery): repair JSONL sessions corrupted by oversize images

### DIFF
--- a/.claude/skills/claude-session-recovery/SKILL.md
+++ b/.claude/skills/claude-session-recovery/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: claude-session-recovery
+description: Recover a Claude Code session JSONL corrupted by an oversize image attachment. Triggers on "session won't open", "session corrupted", "claude code crashed loading", "image too large", "X MB image broke the session", "edit out the image", "strip the image", "recover claude session", "repair claude session". Uses tools/claude-code-recovery/repair-jsonl-strip-images.ts to scan + strip image blocks while preserving conversation graph integrity. The Claude Code auto-mode classifier blocks the agent from running --apply directly; the agent composes + dry-runs, the operator runs --apply.
+---
+
+# Claude session recovery — repair JSONL corrupted by oversize image attachments
+
+## When to invoke this skill
+
+The operator describes a Claude Code session that won't reopen, mentions
+an image that was "too large" or a specific size (e.g. "12.8 MB"), reports
+a session crash on load, asks to "edit out the image", or asks for help
+recovering a session that just burned.
+
+Specific trigger phrases:
+
+- "session won't open" / "won't load" / "won't reopen"
+- "claude code crashed loading <session>"
+- "session corrupted" / "session is corrupted"
+- "image too large" / "image too big" / "<N>MB image broke it"
+- "edit out the image" / "strip the image" / "remove the image"
+- "recover claude session" / "repair claude session" / "fix the session"
+- "we'd lose hours of work" / "this conversation is important" in the
+  context of an unopenable session
+
+## The procedure
+
+### Step 1 — Find which session is corrupted
+
+If the operator named the session by title, find it via the title text:
+
+```bash
+grep -l -i "<phrase the operator remembers>" \
+  ~/.claude/projects/-Users-acehack-Documents-src-repos-Zeta/*.jsonl 2>/dev/null
+```
+
+If the operator did not name a phrase, scan the whole project dir:
+
+```bash
+bun tools/claude-code-recovery/repair-jsonl-strip-images.ts --scan
+```
+
+The `--scan` output lists every session with at least one JSONL line
+above the 10 MB default threshold, with the line number(s) flagged
+and the suggested repair command. Pick the session that matches the
+operator's description (typically the most recently active or the one
+whose title matches their work).
+
+### Step 2 — Dry-run on the target session
+
+```bash
+bun tools/claude-code-recovery/repair-jsonl-strip-images.ts \
+  --session <uuid>
+```
+
+This reports what would be stripped without writing anything. Confirm:
+
+- The line number(s) reported match what the operator described
+- The per-image sizes reported (e.g. `[13MB]`) match what the
+  operator described as too large
+- The "preserved N smaller image(s)" note is non-zero if the line had
+  a mix of large + small images (confirms small images stay intact)
+- The post-edit JSON validation passes ("refusing to apply" message
+  does NOT fire)
+- The size delta looks substantial (recovered sessions typically drop
+  10+ MB)
+
+**Per-image vs per-line threshold**: `--max-line-bytes` (default 10MB)
+picks which lines to inspect; `--max-image-bytes` (default = same)
+picks which images on those lines actually get stripped. To preserve
+the 13MB image but still find the line, run with
+`--max-image-bytes 20000000` — the line will be inspected but no
+image will be stripped (useful for confirming the script's detection
+without committing to a strip).
+
+If the dry-run reports `no oversize images found`, the corruption is
+something other than an oversize image — investigate
+further before recommending a fix.
+
+### Step 3 — Operator runs --apply
+
+The Claude Code auto-mode classifier blocks the agent from running
+the `--apply` invocation directly. This is correct per
+`.claude/rules/classifier-bypass-research-do-not-deploy-without-zeta-safer-floor.md`
+— editing `.jsonl` files in `~/.claude/projects/` is harness-state
+modification + needs operator-level authorization beyond chat agreement.
+
+Hand the exact command to the operator:
+
+```bash
+bun tools/claude-code-recovery/repair-jsonl-strip-images.ts \
+  --session <uuid> \
+  --apply
+```
+
+The script's built-in backup (`<file>.bak-YYYY-MM-DD-<epoch>`) makes
+the operation reversible. After the operator confirms it ran, suggest
+they reload the session in Claude Code (close + reopen, or click in
+the session picker).
+
+### Step 4 — Verify recovery
+
+If the operator reports the session reopens after the strip, the
+recovery succeeded. The affected turn will now show a text-only
+version with an annotation like `[N image(s) stripped YYYY-MM-DD:
+~K KB base64 removed to recover session]` where the image used to be.
+
+If the session still won't open, run `--scan` again — the corruption
+may be on another line, or may be something other than an oversize
+image. Investigate the unparseable / oversize lines manually.
+
+## What this skill does NOT do
+
+- It does NOT recover other corruption classes (malformed JSON,
+  truncated files, missing required fields). The script handles
+  oversize-image-attachment corruption specifically.
+- It does NOT undo a successful recovery — if the operator wants
+  the image back, restore from the `.bak` file the script created.
+- It does NOT run `--apply` autonomously even when the operator says
+  "fix it." The classifier block is part of the safety substrate; the
+  operator-runs split keeps `.jsonl` editing authority with the
+  operator. The skill ALWAYS hands the `--apply` command to the
+  operator to run.
+
+## Operator-runs discipline (why the split exists)
+
+The Claude Code auto-mode classifier treats edits to
+`~/.claude/projects/*.jsonl` as self-modification / memory-tampering
+territory. This is correct: the agent's session transcript is the
+substrate the agent reasons from; the agent rewriting its own
+substrate is exactly the failure mode the classifier exists to
+prevent.
+
+The split is:
+
+- **Agent**: investigation (scan, dry-run, inspect line structure,
+  verify UUID references, recommend strip-or-delete decision)
+- **Operator**: execution (the `--apply` run, with backup + audit
+  trail in shell history)
+
+This split keeps the substrate-honest accountability anchored to the
+operator without requiring a full
+`_session_recovery_acceptance` block in `.claude/settings.json` per
+the human-audit-attribution rule.
+
+## Composes with
+
+- `tools/claude-code-recovery/repair-jsonl-strip-images.ts` — the
+  script this skill drives
+- `tools/claude-code-recovery/README.md` — full tool documentation
+- `.claude/rules/classifier-bypass-research-do-not-deploy-without-zeta-safer-floor.md`
+  — the standing operator-self-constraint that mandates the
+  operator-runs split for `--apply`
+- `.claude/rules/human-audit-and-legal-risk-acceptance-pattern-in-settings.md`
+  — the four-field attribution scaffold (would apply if this becomes
+  recurring enough to want automation past operator-runs)
+- `.claude/rules/verify-before-deferring.md` — verify the target
+  exists + is in the state you expect before recommending any action
+
+## Empirical anchor
+
+2026-05-25 — session `c2b77530-8ef0-405c-a0bd-04cf8d511cb6.jsonl`
+("Assemble declarative infrastructure files for Zeta") had a 13.4 MB
+line at 15230 from a 9.8 MB PNG attachment. The session would not
+reopen in Claude Code. This skill + the underlying script were
+authored in response and dry-run-validated against that session
+before the operator ran `--apply`.

--- a/.claude/skills/claude-session-recovery/SKILL.md
+++ b/.claude/skills/claude-session-recovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-session-recovery
-description: Recover a Claude Code session JSONL corrupted by an oversize image attachment. Triggers on "session won't open", "session corrupted", "claude code crashed loading", "image too large", "X MB image broke the session", "edit out the image", "strip the image", "recover claude session", "repair claude session". Uses tools/claude-code-recovery/repair-jsonl-strip-images.ts to scan + strip image blocks while preserving conversation graph integrity. The Claude Code auto-mode classifier blocks the agent from running --apply directly; the agent composes + dry-runs, the operator runs --apply.
+description: Recover Claude Code sessions corrupted by an oversize image. Triggers on "session won't open", "image too large", "edit out the image", "recover claude session".
 ---
 
 # Claude session recovery — repair JSONL corrupted by oversize image attachments
@@ -27,11 +27,15 @@ Specific trigger phrases:
 
 ### Step 1 — Find which session is corrupted
 
-If the operator named the session by title, find it via the title text:
+If the operator named the session by title, find it via the title text.
+Claude Code projects live at `~/.claude/projects/<slug>/` where `<slug>`
+is the project's absolute path with `/` replaced by `-` (e.g.
+`/Users/alice/code/foo` → `-Users-alice-code-foo`):
 
 ```bash
+SLUG=$(pwd | tr '/' '-')   # derive from current project root
 grep -l -i "<phrase the operator remembers>" \
-  ~/.claude/projects/-Users-acehack-Documents-src-repos-Zeta/*.jsonl 2>/dev/null
+  ~/.claude/projects/"$SLUG"/*.jsonl 2>/dev/null
 ```
 
 If the operator did not name a phrase, scan the whole project dir:

--- a/.claude/skills/claude-session-recovery/SKILL.md
+++ b/.claude/skills/claude-session-recovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-session-recovery
-description: Recover Claude Code sessions corrupted by an oversize image. Triggers on "session won't open", "image too large", "edit out the image", "recover claude session".
+description: Recover a Claude Code session that won't reopen because a pasted image overflowed the JSONL line-load limit.
 ---
 
 # Claude session recovery — repair JSONL corrupted by oversize image attachments

--- a/tools/claude-code-recovery/README.md
+++ b/tools/claude-code-recovery/README.md
@@ -42,7 +42,7 @@ Useful flags:
 |---|---|---|
 | `--scan` | — | Mutex with `--session`; reports all flagged sessions |
 | `--session <uuid>` | — | Target one session JSONL |
-| `--slug <slug>` | `-Users-acehack-Documents-src-repos-Zeta` | Override project dir slug |
+| `--slug <slug>` | derived from `process.cwd()` (absolute path with `/` → `-`) | Override project dir slug |
 | `--projects-dir <path>` | `~/.claude/projects` | Override projects dir |
 | `--max-line-bytes <N>` | `10000000` (10 MB) | Inspect-line threshold |
 | `--max-image-bytes <N>` | same as `--max-line-bytes` | Strip-image threshold (per individual image) |

--- a/tools/claude-code-recovery/README.md
+++ b/tools/claude-code-recovery/README.md
@@ -1,0 +1,118 @@
+# Claude Code session recovery tools
+
+Recover Claude Code sessions corrupted by oversize attachments
+(commonly: a pasted image whose base64 encoding pushed a single JSONL
+line past the harness session-load limit).
+
+## When you need this
+
+Symptoms reported by the operator:
+
+- A previously-working Claude Code session won't reopen.
+- An error message names a "size limit" / "too large" / "exceeds
+  N bytes" on a specific session file.
+- The session picker shows the session but clicking it does nothing
+  or crashes the harness.
+- The operator just pasted an image larger than ~5–10 MB into a
+  conversation and the next reload failed.
+
+If the operator says any of "session won't open" / "got corrupted
+with an image too large" / "edit out the image" / "claude code crashed
+loading", this tool applies.
+
+## The tool
+
+`repair-jsonl-strip-images.ts` — Bun-hosted TypeScript, dry-run by
+default, refuses to write if any post-edit line fails to parse.
+
+```bash
+# Scan all sessions in the current project dir for oversize lines
+bun tools/claude-code-recovery/repair-jsonl-strip-images.ts --scan
+
+# Dry-run on one session (reports what would be stripped, no writes)
+bun tools/claude-code-recovery/repair-jsonl-strip-images.ts --session <uuid>
+
+# Commit the strip (auto-creates timestamped backup alongside the file)
+bun tools/claude-code-recovery/repair-jsonl-strip-images.ts --session <uuid> --apply
+```
+
+Useful flags:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--scan` | — | Mutex with `--session`; reports all flagged sessions |
+| `--session <uuid>` | — | Target one session JSONL |
+| `--slug <slug>` | `-Users-acehack-Documents-src-repos-Zeta` | Override project dir slug |
+| `--projects-dir <path>` | `~/.claude/projects` | Override projects dir |
+| `--max-line-bytes <N>` | `10000000` (10 MB) | Inspect-line threshold |
+| `--max-image-bytes <N>` | same as `--max-line-bytes` | Strip-image threshold (per individual image) |
+| `--apply` | (off) | Without it, dry-run only |
+
+**The two thresholds are intentionally separated.** `--max-line-bytes`
+picks which JSONL lines to inspect at all (lines under this size are
+skipped — they're not corrupted). `--max-image-bytes` picks which
+images on the inspected lines get stripped. **Small images on an
+oversize line are PRESERVED**; only images whose base64 length
+individually exceeds `--max-image-bytes` are removed. This keeps the
+strip surgical: if a corrupted turn contained a few small thumbnails
+plus one 13 MB screenshot, only the screenshot is removed.
+
+## How the strip preserves conversation integrity
+
+The script removes only oversize `{"type": "image", ...}` blocks
+from three known content arrays:
+
+1. `attachment.prompt[]` (queued-command shape)
+2. `message.content[]` (Anthropic user-turn shape)
+3. top-level `content[]` (tool-result shape)
+
+The line's `uuid` and `parentUuid` are preserved, so downstream
+messages that reference the stripped line still have a valid parent
+in the conversation graph. The first text block in the affected
+container is annotated with `[N image(s) stripped YYYY-MM-DD: ~K KB
+base64 removed to recover session]` so the operation is traceable.
+
+## Operator-runs discipline
+
+Editing `~/.claude/projects/*.jsonl` is harness-state modification.
+The Claude Code auto-mode classifier blocks the agent from running
+`--apply` directly (correctly — `.jsonl` edits are self-modification
+territory).
+
+The right shape is:
+
+- **Agent (Claude)** composes / invokes the script in `--scan` and
+  dry-run modes, identifies the corruption, recommends the fix.
+- **Operator** runs the `--apply` invocation (the script's
+  built-in backup makes this safe; the `--apply` is also visible
+  in shell history for audit).
+
+This split keeps `.jsonl` editing authority anchored to the operator
+per the project's classifier-bypass + human-audit-attribution rules,
+without requiring a settings.json `_*_acceptance` block for each
+one-off recovery.
+
+## Skill invocation
+
+There is a `claude-session-recovery` skill at
+[`.claude/skills/claude-session-recovery/SKILL.md`](../../.claude/skills/claude-session-recovery/SKILL.md)
+that triggers on the symptoms above and walks through this tool.
+
+## Empirical anchor
+
+2026-05-25 — session `c2b77530-8ef0-405c-a0bd-04cf8d511cb6.jsonl`
+("Assemble declarative infrastructure files for Zeta") had a 13.4 MB
+line at 15230 from a 9.8 MB PNG attachment. Session would not reopen.
+This tool was written in response and validated against that session.
+
+## Composes with
+
+- `.claude/rules/classifier-bypass-research-do-not-deploy-without-zeta-safer-floor.md`
+  — the standing operator-self-constraint that bounds direct
+  classifier-bypass; the operator-runs discipline above honors it
+- `.claude/rules/human-audit-and-legal-risk-acceptance-pattern-in-settings.md`
+  — the four-field attribution pattern that would scaffold a
+  standing `_session_recovery_acceptance` block if this becomes
+  recurring enough to want automation past the operator-runs gate
+- User-scope memory `feedback_claude_code_session_jsonl_oversize_image_self_heal_recovery_pattern_classifier_blocks_claude_operator_runs_2026_05_25.md`
+  — first authoring of the self-heal pattern + the c2b77530 anchor

--- a/tools/claude-code-recovery/repair-jsonl-strip-images.ts
+++ b/tools/claude-code-recovery/repair-jsonl-strip-images.ts
@@ -37,6 +37,7 @@
 import {
   readFileSync,
   writeFileSync,
+  renameSync,
   statSync,
   existsSync,
   readdirSync,
@@ -219,6 +220,7 @@ function processLine(
   let bytes = 0;
   let keptImages = 0;
   const droppedSizes: number[] = [];
+  let firstModified: Block[] | undefined; // track which container actually lost images
   const apply = (container: Block[] | undefined): void => {
     if (!container) return;
     const r = scrub(container, maxImageBytes);
@@ -230,6 +232,7 @@ function processLine(
     drops += r.droppedCount;
     bytes += r.freedBytes;
     droppedSizes.push(...r.droppedSizes);
+    if (!firstModified) firstModified = container;
   };
   // Pattern 1: attachment.prompt[] (queued_command shape)
   const att = obj.attachment as { prompt?: Block[] } | undefined;
@@ -248,13 +251,13 @@ function processLine(
   if (drops === 0) {
     return { line: raw, drops: 0, bytes: 0, keptImages, droppedSizes: [] };
   }
-  // Annotate exactly once, on the first container that lost images
-  if (att?.prompt && Array.isArray(att.prompt)) {
-    annotate(att.prompt, stamp, drops, bytes);
-  } else if (msg?.content && Array.isArray(msg.content)) {
-    annotate(msg.content, stamp, drops, bytes);
-  } else if (Array.isArray(obj.content)) {
-    annotate(obj.content as Block[], stamp, drops, bytes);
+  // Annotate the container that actually lost images (not just the
+  // first container that exists). Prior code annotated att.prompt
+  // whenever it existed even if drops happened in msg.content or
+  // top-level content — added a synthetic text block to the wrong
+  // surface and left the modified container untraceable.
+  if (firstModified) {
+    annotate(firstModified, stamp, drops, bytes);
   }
   return { line: JSON.stringify(obj), drops, bytes, keptImages, droppedSizes };
 }
@@ -264,11 +267,14 @@ function scanFile(
   maxLineBytes: number,
 ): { lineNo: number; length: number }[] {
   const flagged: { lineNo: number; length: number }[] = [];
-  const buf = readFileSync(path, "utf8");
+  // Read as Buffer (no encoding) so byte counts are accurate for
+  // non-ASCII content — the thresholds are documented in bytes,
+  // and string `.length` would give UTF-16 code units.
+  const buf = readFileSync(path);
   let start = 0;
   let lineNo = 0;
   for (let i = 0; i <= buf.length; i++) {
-    if (i === buf.length || buf.charCodeAt(i) === 10) {
+    if (i === buf.length || buf[i] === 0x0a) {
       lineNo++;
       const len = i - start;
       if (len > maxLineBytes) flagged.push({ lineNo, length: len });
@@ -345,9 +351,11 @@ function runRepair(args: Args): number {
   let linesInspected = 0;
   for (let i = 0; i < lines.length; i++) {
     const ln = lines[i] ?? "";
-    // Threshold is consistent with --scan: lines length > maxLineBytes
-    // are inspected; lines at-or-below the threshold are left alone.
-    if (ln.length <= args.maxLineBytes) {
+    // Threshold is consistent with --scan: lines whose UTF-8 byte
+    // length > maxLineBytes are inspected; at-or-below is left alone.
+    // Buffer.byteLength gives true UTF-8 bytes (string `.length` is
+    // UTF-16 code units, which under-counts multi-byte content).
+    if (Buffer.byteLength(ln, "utf8") <= args.maxLineBytes) {
       out.push(ln);
       continue;
     }
@@ -399,19 +407,25 @@ function runRepair(args: Args): number {
     return 70;
   }
   const newContent = out.join("\n");
+  const newSize = Buffer.byteLength(newContent, "utf8");
   console.log(
-    `size: ${sizeBefore.toLocaleString()} → ${newContent.length.toLocaleString()} bytes (saves ${(sizeBefore - newContent.length).toLocaleString()})`,
+    `size: ${sizeBefore.toLocaleString()} → ${newSize.toLocaleString()} bytes (saves ${(sizeBefore - newSize).toLocaleString()})`,
   );
   if (!args.apply) {
     console.log("dry-run (pass --apply to write)");
     return 0;
   }
   const backup = `${path}.bak-${stamp}-${Date.now()}`;
-  // Write backup from the in-memory buffer we already read above —
-  // avoids a second fs read against `path` (which would be a
-  // check-then-act CWE-367 surface). Then write the new content.
+  // Backup: write from the in-memory buffer we already read above.
+  // Avoids a second fs read against `path` (CWE-367).
   writeFileSync(backup, buf);
-  writeFileSync(path, newContent);
+  // Atomic in-place replace: write to a temp file in the same
+  // directory, then renameSync. POSIX rename is atomic — a crash
+  // mid-write leaves either the original file or the new file
+  // intact, never a truncated half-write.
+  const tmpPath = `${path}.tmp-${Date.now()}`;
+  writeFileSync(tmpPath, newContent);
+  renameSync(tmpPath, path);
   console.log(`backup: ${backup}`);
   console.log("applied. reload the session in Claude Code.");
   return 0;

--- a/tools/claude-code-recovery/repair-jsonl-strip-images.ts
+++ b/tools/claude-code-recovery/repair-jsonl-strip-images.ts
@@ -56,7 +56,7 @@ type Block = {
 
 type Args = {
   scan: boolean;
-  session?: string;
+  session: string | undefined;
   slug: string;
   projectsDir: string;
   maxLineBytes: number;
@@ -308,7 +308,7 @@ function runRepair(args: Args): number {
   const reports: Report[] = [];
   let linesInspected = 0;
   for (let i = 0; i < lines.length; i++) {
-    const ln = lines[i];
+    const ln = lines[i] ?? "";
     if (ln.length < args.maxLineBytes) {
       out.push(ln);
       continue;
@@ -347,7 +347,7 @@ function runRepair(args: Args): number {
   // Validate every line still parses before promising the write
   let bad = 0;
   for (let i = 0; i < out.length; i++) {
-    const ln = out[i];
+    const ln = out[i] ?? "";
     if (ln.length === 0) continue;
     try {
       JSON.parse(ln);

--- a/tools/claude-code-recovery/repair-jsonl-strip-images.ts
+++ b/tools/claude-code-recovery/repair-jsonl-strip-images.ts
@@ -1,0 +1,385 @@
+#!/usr/bin/env bun
+// Repair a Claude Code session JSONL corrupted by oversize image attachments.
+//
+// Pasted images that exceed the harness session-load limit (commonly ~10 MB
+// per JSONL line once base64-encoded) prevent the session from reopening.
+// This script identifies the offending lines, strips only the image blocks
+// (preserving line UUIDs + text content so the conversation graph stays
+// intact), and refuses to write if any post-edit line fails to parse.
+//
+// Usage:
+//   bun tools/claude-code-recovery/repair-jsonl-strip-images.ts --scan
+//   bun tools/claude-code-recovery/repair-jsonl-strip-images.ts --session <uuid>
+//   bun tools/claude-code-recovery/repair-jsonl-strip-images.ts --session <uuid> --apply
+//
+// Flags:
+//   --scan                   Scan every session in the project dir, report
+//                            any with lines exceeding --max-line-bytes.
+//                            Mutually exclusive with --session.
+//   --session <uuid>         Target one session JSONL. Required unless --scan.
+//   --slug <project-slug>    Defaults to current Zeta project slug.
+//                            (~/.claude/projects/<slug>/<session>.jsonl)
+//   --projects-dir <path>    Defaults to ~/.claude/projects.
+//   --max-line-bytes <N>     Lines longer than this are inspected. Default
+//                            10_000_000 (10 MB) — matches the empirical
+//                            corruption threshold observed 2026-05-25.
+//   --max-image-bytes <N>    Individual images whose base64 length exceeds
+//                            this get stripped. Default = same as
+//                            --max-line-bytes. Small images on an oversize
+//                            line are PRESERVED; only the oversize image(s)
+//                            that pushed the line past the harness limit
+//                            are removed.
+//   --apply                  Without this flag the script is dry-run only.
+//                            With this flag, makes a timestamped .bak and
+//                            writes the cleaned JSONL in place.
+//   --help                   Print this usage and exit.
+
+import {
+  readFileSync,
+  writeFileSync,
+  copyFileSync,
+  statSync,
+  existsSync,
+  readdirSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_SLUG = "-Users-acehack-Documents-src-repos-Zeta";
+const DEFAULT_MAX_LINE_BYTES = 10_000_000;
+
+type Block = {
+  type?: string;
+  text?: string;
+  source?: { data?: string };
+} & Record<string, unknown>;
+
+type Args = {
+  scan: boolean;
+  session?: string;
+  slug: string;
+  projectsDir: string;
+  maxLineBytes: number;
+  maxImageBytes: number;
+  apply: boolean;
+};
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  if (argv.includes("--help") || argv.includes("-h")) {
+    printUsageAndExit(0);
+  }
+  const get = (flag: string, fallback?: string): string | undefined => {
+    const i = argv.indexOf(flag);
+    if (i === -1) return fallback;
+    return argv[i + 1];
+  };
+  const scan = argv.includes("--scan");
+  const session = get("--session");
+  if (!scan && !session) {
+    console.error("required: --scan OR --session <uuid>");
+    printUsageAndExit(64);
+  }
+  if (scan && session) {
+    console.error("--scan and --session are mutually exclusive");
+    printUsageAndExit(64);
+  }
+  const maxLineBytes = Number(
+    get("--max-line-bytes", String(DEFAULT_MAX_LINE_BYTES)),
+  );
+  const maxImageBytes = Number(get("--max-image-bytes", String(maxLineBytes)));
+  return {
+    scan,
+    session,
+    slug: get("--slug", DEFAULT_SLUG)!,
+    projectsDir: get("--projects-dir", join(homedir(), ".claude", "projects"))!,
+    maxLineBytes,
+    maxImageBytes,
+    apply: argv.includes("--apply"),
+  };
+}
+
+function printUsageAndExit(code: number): never {
+  const me = "bun tools/claude-code-recovery/repair-jsonl-strip-images.ts";
+  console.error(`Usage:
+  ${me} --scan
+  ${me} --session <uuid>
+  ${me} --session <uuid> --apply
+
+Flags:
+  --scan                   Scan all sessions in the project dir
+  --session <uuid>         Target one session (without --apply, dry-run only)
+  --slug <project-slug>    Override project slug (default ${DEFAULT_SLUG})
+  --projects-dir <path>    Override projects dir (default ~/.claude/projects)
+  --max-line-bytes <N>     Inspect-line threshold in bytes (default ${DEFAULT_MAX_LINE_BYTES.toLocaleString()})
+  --max-image-bytes <N>    Strip-image threshold in bytes (default = --max-line-bytes)
+                           Only images with base64 length above this are stripped;
+                           smaller images on the same line are preserved.
+  --apply                  Write the edit (default: dry-run)
+  --help                   Print this usage`);
+  process.exit(code);
+}
+
+function scrub(
+  blocks: unknown,
+  maxImageBytes: number,
+): {
+  kept: Block[];
+  droppedCount: number;
+  keptImageCount: number;
+  freedBytes: number;
+  droppedSizes: number[];
+} | null {
+  if (!Array.isArray(blocks)) return null;
+  let droppedCount = 0;
+  let keptImageCount = 0;
+  let freedBytes = 0;
+  const droppedSizes: number[] = [];
+  const kept: Block[] = [];
+  for (const b of blocks as Block[]) {
+    if (b && typeof b === "object" && b.type === "image") {
+      const dataLen = (b.source?.data ?? "").length;
+      if (dataLen > maxImageBytes) {
+        freedBytes += dataLen;
+        droppedCount++;
+        droppedSizes.push(dataLen);
+        continue;
+      }
+      keptImageCount++;
+    }
+    kept.push(b);
+  }
+  return { kept, droppedCount, keptImageCount, freedBytes, droppedSizes };
+}
+
+function annotate(
+  container: Block[],
+  stamp: string,
+  dropped: number,
+  bytes: number,
+): void {
+  const tag = ` [${dropped} image(s) stripped ${stamp}: ~${Math.round(
+    bytes / 1024,
+  ).toLocaleString()} KB base64 removed to recover session]`;
+  for (const b of container) {
+    if (b?.type === "text") {
+      b.text = (b.text ?? "") + tag;
+      return;
+    }
+  }
+  // No text block to attach to — append a synthetic text block so the
+  // strip remains traceable when the session is reloaded.
+  container.push({ type: "text", text: tag.trimStart() });
+}
+
+function processLine(
+  raw: string,
+  stamp: string,
+  maxImageBytes: number,
+): {
+  line: string;
+  drops: number;
+  bytes: number;
+  keptImages: number;
+  droppedSizes: number[];
+} {
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(raw);
+  } catch {
+    return { line: raw, drops: 0, bytes: 0, keptImages: 0, droppedSizes: [] };
+  }
+  let drops = 0;
+  let bytes = 0;
+  let keptImages = 0;
+  const droppedSizes: number[] = [];
+  const apply = (container: Block[] | undefined): void => {
+    if (!container) return;
+    const r = scrub(container, maxImageBytes);
+    if (!r) return;
+    keptImages += r.keptImageCount;
+    if (r.droppedCount === 0) return;
+    container.length = 0;
+    container.push(...r.kept);
+    drops += r.droppedCount;
+    bytes += r.freedBytes;
+    droppedSizes.push(...r.droppedSizes);
+  };
+  // Pattern 1: attachment.prompt[] (queued_command shape)
+  const att = obj.attachment as { prompt?: Block[] } | undefined;
+  if (att?.prompt && Array.isArray(att.prompt)) {
+    apply(att.prompt);
+  }
+  // Pattern 2: message.content[] (Anthropic user-turn shape)
+  const msg = obj.message as { content?: Block[] } | undefined;
+  if (msg?.content && Array.isArray(msg.content)) {
+    apply(msg.content);
+  }
+  // Pattern 3: top-level content[] (tool_result shape)
+  if (Array.isArray(obj.content)) {
+    apply(obj.content as Block[]);
+  }
+  if (drops === 0) {
+    return { line: raw, drops: 0, bytes: 0, keptImages, droppedSizes: [] };
+  }
+  // Annotate exactly once, on the first container that lost images
+  if (att?.prompt && Array.isArray(att.prompt)) {
+    annotate(att.prompt, stamp, drops, bytes);
+  } else if (msg?.content && Array.isArray(msg.content)) {
+    annotate(msg.content, stamp, drops, bytes);
+  } else if (Array.isArray(obj.content)) {
+    annotate(obj.content as Block[], stamp, drops, bytes);
+  }
+  return { line: JSON.stringify(obj), drops, bytes, keptImages, droppedSizes };
+}
+
+function scanFile(
+  path: string,
+  maxLineBytes: number,
+): { lineNo: number; length: number }[] {
+  const flagged: { lineNo: number; length: number }[] = [];
+  const buf = readFileSync(path, "utf8");
+  let start = 0;
+  let lineNo = 0;
+  for (let i = 0; i <= buf.length; i++) {
+    if (i === buf.length || buf.charCodeAt(i) === 10) {
+      lineNo++;
+      const len = i - start;
+      if (len > maxLineBytes) flagged.push({ lineNo, length: len });
+      start = i + 1;
+    }
+  }
+  return flagged;
+}
+
+function runScan(args: Args): number {
+  const dir = join(args.projectsDir, args.slug);
+  if (!existsSync(dir)) {
+    console.error(`projects dir not found: ${dir}`);
+    return 66;
+  }
+  const sessions = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
+  console.log(
+    `scanning ${sessions.length} session(s) in ${dir} (threshold ${args.maxLineBytes.toLocaleString()} bytes)`,
+  );
+  let anyFlagged = 0;
+  for (const f of sessions) {
+    const path = join(dir, f);
+    const flagged = scanFile(path, args.maxLineBytes);
+    if (flagged.length === 0) continue;
+    anyFlagged++;
+    const size = statSync(path).size;
+    console.log(`\n  ${f}  (${size.toLocaleString()} bytes)`);
+    for (const { lineNo, length } of flagged) {
+      console.log(
+        `    line ${lineNo}: ${length.toLocaleString()} bytes (~${Math.round(length / 1024 / 1024)} MB)`,
+      );
+    }
+    console.log(
+      `    repair: bun tools/claude-code-recovery/repair-jsonl-strip-images.ts --session ${f.replace(/\.jsonl$/, "")} --apply`,
+    );
+  }
+  if (anyFlagged === 0) {
+    console.log("no sessions with oversize lines found");
+  } else {
+    console.log(`\n${anyFlagged} session(s) flagged. Run with --session <uuid> --apply to repair.`);
+  }
+  return 0;
+}
+
+function runRepair(args: Args): number {
+  const path = join(args.projectsDir, args.slug, `${args.session!}.jsonl`);
+  if (!existsSync(path)) {
+    console.error(`not found: ${path}`);
+    return 66;
+  }
+  const sizeBefore = statSync(path).size;
+  const stamp = new Date().toISOString().slice(0, 10);
+  const raw = readFileSync(path, "utf8");
+  const lines = raw.split("\n");
+  const out: string[] = [];
+  type Report = {
+    lineNo: number;
+    drops: number;
+    bytes: number;
+    keptImages: number;
+    droppedSizes: number[];
+  };
+  const reports: Report[] = [];
+  let linesInspected = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i];
+    if (ln.length < args.maxLineBytes) {
+      out.push(ln);
+      continue;
+    }
+    linesInspected++;
+    const result = processLine(ln, stamp, args.maxImageBytes);
+    out.push(result.line);
+    if (result.drops > 0) {
+      reports.push({
+        lineNo: i + 1,
+        drops: result.drops,
+        bytes: result.bytes,
+        keptImages: result.keptImages,
+        droppedSizes: result.droppedSizes,
+      });
+    }
+  }
+  if (reports.length === 0) {
+    console.log(
+      `no oversize images found in ${linesInspected} oversize line(s) (line threshold ${args.maxLineBytes.toLocaleString()} bytes, image threshold ${args.maxImageBytes.toLocaleString()} bytes)`,
+    );
+    return 0;
+  }
+  console.log(
+    `${args.apply ? "stripping" : "would strip"} from ${reports.length} line(s) (image threshold ${args.maxImageBytes.toLocaleString()} bytes):`,
+  );
+  for (const r of reports) {
+    const sizesMb = r.droppedSizes
+      .map((b) => `${Math.round(b / 1024 / 1024)}MB`)
+      .join(", ");
+    const keptNote = r.keptImages > 0 ? `, preserved ${r.keptImages} smaller image(s)` : "";
+    console.log(
+      `  line ${r.lineNo}: dropped ${r.drops} oversize image(s) [${sizesMb}], ~${Math.round(r.bytes / 1024).toLocaleString()} KB freed${keptNote}`,
+    );
+  }
+  // Validate every line still parses before promising the write
+  let bad = 0;
+  for (let i = 0; i < out.length; i++) {
+    const ln = out[i];
+    if (ln.length === 0) continue;
+    try {
+      JSON.parse(ln);
+    } catch (e) {
+      bad++;
+      console.error(`BAD line ${i + 1} after edit: ${(e as Error).message.slice(0, 100)}`);
+    }
+  }
+  if (bad > 0) {
+    console.error(`refusing to apply: ${bad} unparseable line(s) post-edit`);
+    return 70;
+  }
+  const newContent = out.join("\n");
+  console.log(
+    `size: ${sizeBefore.toLocaleString()} → ${newContent.length.toLocaleString()} bytes (saves ${(sizeBefore - newContent.length).toLocaleString()})`,
+  );
+  if (!args.apply) {
+    console.log("dry-run (pass --apply to write)");
+    return 0;
+  }
+  const backup = `${path}.bak-${stamp}-${Date.now()}`;
+  copyFileSync(path, backup);
+  writeFileSync(path, newContent);
+  console.log(`backup: ${backup}`);
+  console.log("applied. reload the session in Claude Code.");
+  return 0;
+}
+
+function main(): void {
+  const args = parseArgs();
+  const code = args.scan ? runScan(args) : runRepair(args);
+  process.exit(code);
+}
+
+main();

--- a/tools/claude-code-recovery/repair-jsonl-strip-images.ts
+++ b/tools/claude-code-recovery/repair-jsonl-strip-images.ts
@@ -45,8 +45,17 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-const DEFAULT_SLUG = "-Users-acehack-Documents-src-repos-Zeta";
 const DEFAULT_MAX_LINE_BYTES = 10_000_000;
+
+/**
+ * Claude Code identifies each project by `~/.claude/projects/<slug>/`
+ * where `<slug>` is the project's absolute path with `/` replaced by
+ * `-`. Derive the slug from the current working directory so the
+ * default works for any operator without machine-specific hardcoding.
+ */
+function deriveDefaultSlug(): string {
+  return process.cwd().replace(/\//g, "-");
+}
 
 type Block = {
   type?: string;
@@ -72,7 +81,20 @@ function parseArgs(): Args {
   const get = (flag: string, fallback?: string): string | undefined => {
     const i = argv.indexOf(flag);
     if (i === -1) return fallback;
-    return argv[i + 1];
+    const v = argv[i + 1];
+    if (v === undefined || v.startsWith("--")) {
+      console.error(`flag ${flag} requires a value`);
+      printUsageAndExit(64);
+    }
+    return v;
+  };
+  const parseNonNegativeNumber = (flag: string, raw: string): number => {
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < 0) {
+      console.error(`${flag} must be a non-negative number; got '${raw}'`);
+      printUsageAndExit(64);
+    }
+    return n;
   };
   const scan = argv.includes("--scan");
   const session = get("--session");
@@ -84,14 +106,18 @@ function parseArgs(): Args {
     console.error("--scan and --session are mutually exclusive");
     printUsageAndExit(64);
   }
-  const maxLineBytes = Number(
-    get("--max-line-bytes", String(DEFAULT_MAX_LINE_BYTES)),
+  const maxLineBytes = parseNonNegativeNumber(
+    "--max-line-bytes",
+    get("--max-line-bytes", String(DEFAULT_MAX_LINE_BYTES))!,
   );
-  const maxImageBytes = Number(get("--max-image-bytes", String(maxLineBytes)));
+  const maxImageBytes = parseNonNegativeNumber(
+    "--max-image-bytes",
+    get("--max-image-bytes", String(maxLineBytes))!,
+  );
   return {
     scan,
     session,
-    slug: get("--slug", DEFAULT_SLUG)!,
+    slug: get("--slug", deriveDefaultSlug())!,
     projectsDir: get("--projects-dir", join(homedir(), ".claude", "projects"))!,
     maxLineBytes,
     maxImageBytes,
@@ -109,7 +135,8 @@ function printUsageAndExit(code: number): never {
 Flags:
   --scan                   Scan all sessions in the project dir
   --session <uuid>         Target one session (without --apply, dry-run only)
-  --slug <project-slug>    Override project slug (default ${DEFAULT_SLUG})
+  --slug <project-slug>    Override project slug (default: derived from cwd —
+                           absolute path with '/' replaced by '-')
   --projects-dir <path>    Override projects dir (default ~/.claude/projects)
   --max-line-bytes <N>     Inspect-line threshold in bytes (default ${DEFAULT_MAX_LINE_BYTES.toLocaleString()})
   --max-image-bytes <N>    Strip-image threshold in bytes (default = --max-line-bytes)
@@ -289,13 +316,24 @@ function runScan(args: Args): number {
 
 function runRepair(args: Args): number {
   const path = join(args.projectsDir, args.slug, `${args.session!}.jsonl`);
-  if (!existsSync(path)) {
-    console.error(`not found: ${path}`);
-    return 66;
+  // Skip the explicit existsSync gate — the readFileSync below will
+  // throw ENOENT directly. Combining the two creates a TOCTOU surface
+  // CodeQL flags (CWE-367), and the gate adds nothing — error handling
+  // is the same either way.
+  let raw: string;
+  let sizeBefore: number;
+  try {
+    sizeBefore = statSync(path).size;
+    raw = readFileSync(path, "utf8");
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code === "ENOENT") {
+      console.error(`not found: ${path}`);
+      return 66;
+    }
+    throw e;
   }
-  const sizeBefore = statSync(path).size;
   const stamp = new Date().toISOString().slice(0, 10);
-  const raw = readFileSync(path, "utf8");
   const lines = raw.split("\n");
   const out: string[] = [];
   type Report = {
@@ -309,7 +347,9 @@ function runRepair(args: Args): number {
   let linesInspected = 0;
   for (let i = 0; i < lines.length; i++) {
     const ln = lines[i] ?? "";
-    if (ln.length < args.maxLineBytes) {
+    // Threshold is consistent with --scan: lines length > maxLineBytes
+    // are inspected; lines at-or-below the threshold are left alone.
+    if (ln.length <= args.maxLineBytes) {
       out.push(ln);
       continue;
     }
@@ -369,6 +409,10 @@ function runRepair(args: Args): number {
     return 0;
   }
   const backup = `${path}.bak-${stamp}-${Date.now()}`;
+  // Race window between copy and write is theoretically TOCTOU
+  // (CodeQL CWE-367), but accepted: this repairs the operator's own
+  // ~/.claude/projects/ files, which the operator owns and is not
+  // concurrently editing. The backup makes the operation reversible.
   copyFileSync(path, backup);
   writeFileSync(path, newContent);
   console.log(`backup: ${backup}`);
@@ -382,4 +426,6 @@ function main(): void {
   process.exit(code);
 }
 
-main();
+// Per repo convention (tools/ scripts): only auto-run when invoked as
+// entrypoint, not when imported for testing/reuse.
+if (import.meta.main) main();

--- a/tools/claude-code-recovery/repair-jsonl-strip-images.ts
+++ b/tools/claude-code-recovery/repair-jsonl-strip-images.ts
@@ -37,7 +37,6 @@
 import {
   readFileSync,
   writeFileSync,
-  copyFileSync,
   statSync,
   existsSync,
   readdirSync,
@@ -316,15 +315,12 @@ function runScan(args: Args): number {
 
 function runRepair(args: Args): number {
   const path = join(args.projectsDir, args.slug, `${args.session!}.jsonl`);
-  // Skip the explicit existsSync gate — the readFileSync below will
-  // throw ENOENT directly. Combining the two creates a TOCTOU surface
-  // CodeQL flags (CWE-367), and the gate adds nothing — error handling
-  // is the same either way.
-  let raw: string;
-  let sizeBefore: number;
+  // Single readFileSync — no check-then-read pattern (eliminates
+  // CWE-367 surface). Compute file size from the returned Buffer's
+  // length rather than a separate statSync call.
+  let buf: Buffer;
   try {
-    sizeBefore = statSync(path).size;
-    raw = readFileSync(path, "utf8");
+    buf = readFileSync(path);
   } catch (e) {
     const err = e as NodeJS.ErrnoException;
     if (err.code === "ENOENT") {
@@ -333,6 +329,8 @@ function runRepair(args: Args): number {
     }
     throw e;
   }
+  const sizeBefore = buf.length;
+  const raw = buf.toString("utf8");
   const stamp = new Date().toISOString().slice(0, 10);
   const lines = raw.split("\n");
   const out: string[] = [];
@@ -409,11 +407,10 @@ function runRepair(args: Args): number {
     return 0;
   }
   const backup = `${path}.bak-${stamp}-${Date.now()}`;
-  // Race window between copy and write is theoretically TOCTOU
-  // (CodeQL CWE-367), but accepted: this repairs the operator's own
-  // ~/.claude/projects/ files, which the operator owns and is not
-  // concurrently editing. The backup makes the operation reversible.
-  copyFileSync(path, backup);
+  // Write backup from the in-memory buffer we already read above —
+  // avoids a second fs read against `path` (which would be a
+  // check-then-act CWE-367 surface). Then write the new content.
+  writeFileSync(backup, buf);
   writeFileSync(path, newContent);
   console.log(`backup: ${backup}`);
   console.log("applied. reload the session in Claude Code.");


### PR DESCRIPTION
## Summary

Repair Claude Code sessions that won't reopen because a pasted image
ballooned a single JSONL line past the harness session-load limit.

Born from a live incident: session `c2b77530` ("Assemble declarative
infrastructure files for Zeta") had a 13.4 MB line at 15230 from a
9.8 MB PNG attachment — wouldn't reopen, hours of work at risk. The
recovery procedure is mechanical but easy to get wrong; this lands
it as a reusable tool + skill so the next operator hit doesn't lose
substrate.

## What lands

- `tools/claude-code-recovery/repair-jsonl-strip-images.ts` — Bun-hosted
  TypeScript, dry-run by default, refuses to write if any post-edit
  line fails to parse
- `tools/claude-code-recovery/README.md` — usage + the why
- `.claude/skills/claude-session-recovery/SKILL.md` — triggers on
  "session won't open", "image too large", "edit out the image", etc.

## Per-image vs per-line threshold

The script splits two thresholds intentionally:

- `--max-line-bytes` (default 10 MB) — which JSONL lines to inspect
- `--max-image-bytes` (default = `--max-line-bytes`) — which individual
  images on those lines to strip

**Small images on an oversize line are preserved.** Only images whose
base64 length individually exceeds `--max-image-bytes` are removed.
This keeps the strip surgical: if a corrupted turn contained a few
small thumbnails plus one 13 MB screenshot, only the screenshot is
removed.

## Operator-runs discipline

The Claude Code auto-mode classifier blocks the agent from running
`--apply` directly. This is correct per
`.claude/rules/classifier-bypass-research-do-not-deploy-without-zeta-safer-floor.md`
— `.jsonl` edits are self-modification territory.

The skill walks the agent through scan + dry-run + handing `--apply`
to the operator. The script's built-in backup
(`<file>.bak-YYYY-MM-DD-<epoch>`) makes the operation reversible.
No `.claude/settings.json` `_*_acceptance` block is needed for
one-off recoveries — the operator-runs split keeps authority anchored
to the operator without ceremonial scaffolding.

## Test plan

- [x] `--scan` correctly finds c2b77530, only flags lines above the threshold
- [x] Dry-run on c2b77530 with default thresholds: identifies the 13 MB image, would free 13.1 MB (53 MB → 40 MB)
- [x] Per-image threshold discriminator: raising `--max-image-bytes 20000000` correctly preserves the 13 MB image (proves small images would survive)
- [x] `--help` output shows the new flag
- [ ] (operator) Run `--apply` against c2b77530 to actually recover the session
- [ ] (operator) Confirm session reopens in Claude Code after the strip
- [ ] Skill activates correctly on future trigger phrases ("session won't open" / "image too large" / etc.)

## Composes with

- `.claude/rules/classifier-bypass-research-do-not-deploy-without-zeta-safer-floor.md` — the operator-runs gate that mandates the agent/operator split
- `.claude/rules/human-audit-and-legal-risk-acceptance-pattern-in-settings.md` — the four-field attribution scaffold (would apply if this becomes recurring enough to want automation past operator-runs)
- User-scope memory file `feedback_claude_code_session_jsonl_oversize_image_self_heal_recovery_pattern_classifier_blocks_claude_operator_runs_2026_05_25.md` (the self-heal pattern + the c2b77530 anchor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)