### PR TITLE
fix(B-0789 iter-4.2 fixfwd): 5 Copilot findings on #5083 (3 P0 incl Nix-injection + 2 P1) before maintainer test

### DIFF
--- a/full-ai-cluster/tools/zflash.ts
+++ b/full-ai-cluster/tools/zflash.ts
@@ -261,13 +261,19 @@ async function injectPubkeyToUsb(pubkeyPath: string): Promise<void> {
   // Read pubkey content
   const pubkey = readFileSync(pubkeyPath, "utf8").trim();
   const firstLine = pubkey.split("\n")[0] ?? "";
-  if (!/^ssh-(ed25519|rsa|ecdsa|dss)\s+/.test(firstLine)) {
+  // Per #5083 Copilot P1: broaden to all OpenSSH pubkey type tokens
+  // per sshd(8) AuthorizedKeysFile. Validates structurally: type token
+  // (one of ssh-*, ecdsa-sha2-*, sk-ssh-*, sk-ecdsa-sha2-*) + space +
+  // base64-shaped material (allow any non-whitespace; the actual base64
+  // decode happens on the cluster side).
+  const VALID_PUBKEY = /^(ssh-(ed25519|rsa|dss)|ecdsa-sha2-\S+|sk-ssh-ed25519@\S+|sk-ecdsa-sha2-\S+)\s+\S+/;
+  if (!VALID_PUBKEY.test(firstLine)) {
     try {
       execFileSync("diskutil", ["unmount", espPart], { stdio: "ignore" });
     } catch {
       /* ignore */
     }
-    dumpDiagnostics(`${pubkeyPath} first line is not a valid ssh-* pubkey`);
+    dumpDiagnostics(`${pubkeyPath} first line is not a recognized OpenSSH pubkey (expected ssh-ed25519 / ssh-rsa / ssh-dss / ecdsa-sha2-* / sk-ssh-ed25519@* / sk-ecdsa-sha2-*)`);
     bail(3, `iter-4.2 inject failed: ${pubkeyPath} is not a recognized SSH pubkey format.`);
   }
 
@@ -332,7 +338,14 @@ async function main() {
       if (!next || next.startsWith("-")) {
         bail(2, "--ssh-key requires a path argument (e.g., --ssh-key ~/.ssh/id_ed25519.pub)");
       }
-      sshKeyOverride = resolve(next);
+      // Per #5083 Copilot P1: Node's path.resolve doesn't expand `~/` to
+      // homedir; raw `--ssh-key ~/.ssh/id_ed25519.pub` would resolve to
+      // a literal `~/.ssh/...` path under cwd and fail existence checks.
+      // Expand leading `~/` (and bare `~`) to homedir() before resolve.
+      const expanded = next === "~" || next.startsWith("~/")
+        ? join(homedir(), next.slice(next === "~" ? 1 : 2))
+        : next;
+      sshKeyOverride = resolve(expanded);
       i++;
       continue;
     }

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -243,9 +243,18 @@ sudo mkdir -p "$PROBE_MOUNT"
 PUBKEY_FILE=""
 INJECT_OK=0
 
-# Try 1: scan already-mounted filesystems
-PUBKEY_FILE=$(sudo find /iso /run /mnt /boot \
-  -maxdepth 5 -name "zeta-authorized-keys.pub" -type f 2>/dev/null | head -1)
+# Try 1: scan already-mounted filesystems.
+# Per #5083 Copilot P0: under `set -euo pipefail`, `find` exits non-zero
+# if any start-path doesn't exist (e.g., `/iso` on some installers),
+# aborting the whole install. Filter to existing dirs first.
+SEARCH_DIRS=()
+for d in /iso /run /mnt /boot; do
+  [ -d "$d" ] && SEARCH_DIRS+=("$d")
+done
+if [ ${#SEARCH_DIRS[@]} -gt 0 ]; then
+  PUBKEY_FILE=$(sudo find "${SEARCH_DIRS[@]}" \
+    -maxdepth 5 -name "zeta-authorized-keys.pub" -type f 2>/dev/null | head -1 || true)
+fi
 
 # Try 2: probe likely-USB block devices for a FAT partition with the pubkey.
 # Skip BOOT_DISK + DATA_DISKS (install targets).
@@ -281,14 +290,26 @@ fi
 if [ -n "$PUBKEY_FILE" ]; then
   echo "[iter-4.2]   found: $PUBKEY_FILE"
 
+  # Per #5083 Copilot P0: read via `sudo cat` since the pubkey file may be
+  # on a root-owned mount (/mnt/* or /tmp/zeta-boot-esp); plain shell redirect
+  # would fail as the unprivileged user and `set -e` aborts the install.
+  # OpenSSH pubkey type prefixes (per `sshd(8)` AuthorizedKeysFile):
+  # ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp{256,384,521},
+  # sk-ecdsa-sha2-nistp256@openssh.com, sk-ssh-ed25519@openssh.com.
   KEY_LINES=()
   while IFS= read -r line; do
     case "$line" in
-      ssh-ed25519\ *|ssh-rsa\ *|ssh-ecdsa\ *|ssh-dss\ *|ecdsa-*) KEY_LINES+=("$line") ;;
+      ssh-ed25519\ *|ssh-rsa\ *|ssh-dss\ *|ecdsa-sha2-*\ *|sk-ssh-ed25519@*\ *|sk-ecdsa-sha2-*\ *) KEY_LINES+=("$line") ;;
     esac
-  done < "$PUBKEY_FILE"
+  done < <(sudo cat "$PUBKEY_FILE")
 
   if [ ${#KEY_LINES[@]} -gt 0 ]; then
+    # Per #5083 Copilot P0/security: Nix string-escape the pubkey content
+    # before interpolating into the Nix file. Without this, a key comment
+    # containing `"` or `\` produces invalid Nix; a maliciously-crafted
+    # line on the USB could inject Nix code at install time. Nix double-
+    # quoted strings escape via `\\` → `\\\\` and `"` → `\"`. We apply
+    # both transformations with sed; ordering matters (backslash first).
     {
       echo '# operator-ssh-keys.nix — populated by iter-4.2 zeta-install.sh probe.'
       echo "# Source: $PUBKEY_FILE (boot USB ESP)"
@@ -299,7 +320,8 @@ if [ -n "$PUBKEY_FILE" ]; then
       echo '{'
       echo '  users.users.zeta.openssh.authorizedKeys.keys = ['
       for line in "${KEY_LINES[@]}"; do
-        printf '    "%s"\n' "$line"
+        escaped=$(printf '%s' "$line" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+        printf '    "%s"\n' "$escaped"
       done
       echo '  ];'
       echo '}'


### PR DESCRIPTION
## Summary

PR #5083 (iter-4.2 substrate) auto-merged with required checks green; 5 substantive Copilot findings landed post-merge. All real; the Nix-injection P0 is security-relevant; install-script P0s would abort the install on real hardware under `set -euo pipefail`. **Fix-forward before maintainer tests iter-4.2 end-to-end on PC 1.**

## P0 fixes (would actually break install or open security hole)

| Thread | Fix |
|---|---|
| `PRRT_kwDOSF9kNM6Erhtf` | `find /iso /run /mnt /boot` aborts install when start-path missing → filter to existing dirs only via `SEARCH_DIRS` array + `\|\| true` defense |
| `PRRT_kwDOSF9kNM6Erhto` | `while read < $PUBKEY_FILE` fails on root-owned mounts → read via `sudo cat` process substitution |
| `PRRT_kwDOSF9kNM6Erhty` | **NIX CODE INJECTION** in `operator-ssh-keys.nix` if pubkey comment has `"` or `\` → sed-escape `\\` → `\\\\` then `"` → `\"` (Nix double-quoted string rules; backslash first) |

## P1 fixes

| Thread | Fix |
|---|---|
| `PRRT_kwDOSF9kNM6ErhuB` | `resolve('~/path')` doesn't expand `~/` in Node → expand leading `~/` (and bare `~`) to `homedir()` before `resolve()` |
| `PRRT_kwDOSF9kNM6ErhuK` | Pubkey regex/glob missed `ecdsa-sha2-nistp{256,384,521}` + FIDO `sk-ssh-ed25519@*` / `sk-ecdsa-sha2-*` → broaden to OpenSSH-spec prefixes per `sshd(8) AuthorizedKeysFile` |

## Files

- `full-ai-cluster/tools/zflash.ts`: `~/` expansion + broader pubkey regex
- `full-ai-cluster/usb-nixos-installer/zeta-install.sh`: filtered find paths, `sudo cat` read, Nix string escape, broader pubkey glob

## Test plan

- [x] shellcheck clean on zeta-install.sh
- [x] zflash.ts --help parses post-fix
- [x] Five threads on #5083 to be resolved post-merge via `resolveReviewThread`
- [ ] CI passes (gate workflow + CodeQL)
- [ ] Maintainer's next iter-4.2 USB flash uses this fix-forward — first end-to-end test

🤖 Generated with [Claude Code](https://claude.com/claude-code)