### PR TITLE
fix(B-0789 iter-4.2): readFile redesign — eliminate Nix-injection class entirely (closes residual ${...} antiquotation vector from #5086)

### DIFF
--- a/full-ai-cluster/nixos/modules/operator-ssh-keys.nix
+++ b/full-ai-cluster/nixos/modules/operator-ssh-keys.nix
@@ -2,33 +2,50 @@
 #
 # Operator SSH public keys for the `zeta` user.
 #
-# This file ships as an EMPTY STUB in the repo. zeta-install.sh
-# overwrites it during install with the contents of the boot USB's
-# `/zeta-authorized-keys.pub` file (which zflash-setup.ts copies from
-# the operator's `~/.ssh/id_ed25519.pub` by default, or whichever key
-# was passed via `--ssh-key <path>`).
+# Per #5086 Copilot P0 + the iter-4.2 readFile redesign: this module
+# reads pubkeys from a SIBLING `operator-ssh-keys.txt` file rather
+# than embedding them inline as Nix string literals. Rationale:
 #
-# After install, the operator can SSH-in to the cluster node as the
-# `zeta` user using the matching private key on their workstation.
+# - Eliminates the Nix-string-injection class entirely. Pubkey content
+#   sourced from a USB-supplied file NEVER goes through the Nix string
+#   parser (no need to escape `\`, `"`, or `${...}` interpolation
+#   sequences). Untrusted content is data, not code.
+# - Simpler write path. zeta-install.sh just `sudo tee`s the pubkey
+#   file content into operator-ssh-keys.txt; no sed-escape pipeline.
+# - Same edit-and-rebuild operator workflow for the v1 fallback path:
+#   operators can edit operator-ssh-keys.txt directly + `sudo nixos-
+#   rebuild switch --flake /etc/zeta/full-ai-cluster#<host>`.
 #
-# Multi-key support: zflash-setup.ts accepts `--ssh-key <path>`
-# repeatedly; the resulting `/zeta-authorized-keys.pub` is a multi-line
-# file with one pubkey per line; zeta-install.sh injects each line as
-# a separate entry below. Per B-0789 the per-context (ServiceTitan vs
-# personal vs LFG-only) attribution-chain framing lives in
-# maintainers/aaron/legal-entities/inventory.md; this module just
-# carries the public-key material the operator chose.
+# Format of operator-ssh-keys.txt:
+# - One OpenSSH pubkey per line (ssh-ed25519 / ssh-rsa / ecdsa-sha2-* /
+#   sk-ssh-ed25519@openssh.com / sk-ecdsa-sha2-*)
+# - Lines starting with `#` are comments + ignored
+# - Blank lines are ignored
 #
-# Manual edit path: operators can edit this file directly + re-run
-# `sudo nixos-rebuild switch` to add/remove keys without reflashing
-# the USB.
+# iter-4.2 zero-typing path: zflash on macOS writes the operator's
+# ~/.ssh/id_ed25519.pub (or --ssh-key <path>) to the boot USB's FAT
+# ESP as `zeta-authorized-keys.pub`. zeta-install.sh probes for that
+# file + writes its content directly to operator-ssh-keys.txt before
+# `nixos-install`. Per B-0789 the per-context attribution-chain
+# framing (ServiceTitan / personal / LFG-only) lives in
+# maintainers/aaron/legal-entities/inventory.md.
+#
+# Multi-key support: operator-ssh-keys.txt is a multi-line file;
+# every non-comment / non-blank line becomes a separate
+# authorizedKeys.keys entry.
 
 { config, pkgs, lib, ... }:
 
-{
-  users.users.zeta.openssh.authorizedKeys.keys = [
-    # Populated by zeta-install.sh from /zeta-authorized-keys.pub on
-    # the boot USB. Empty by default — the operator can also paste
-    # ssh-ed25519 / ssh-rsa lines here manually + nixos-rebuild.
-  ];
+let
+  keysFile = ./operator-ssh-keys.txt;
+  rawLines = lib.splitString "\n" (builtins.readFile keysFile);
+  isValidKeyLine = line:
+    let trimmed = lib.removePrefix " " (lib.removeSuffix " " line);
+    in trimmed != ""
+       && !(lib.hasPrefix "#" trimmed);
+in {
+  users.users.zeta.openssh.authorizedKeys.keys =
+    if builtins.pathExists keysFile
+    then builtins.filter isValidKeyLine rawLines
+    else [ ];
 }

--- a/full-ai-cluster/nixos/modules/operator-ssh-keys.txt
+++ b/full-ai-cluster/nixos/modules/operator-ssh-keys.txt
@@ -1,0 +1,17 @@
+# operator-ssh-keys.txt — operator SSH pubkeys for the `zeta` user.
+#
+# Read by sibling `operator-ssh-keys.nix` via builtins.readFile.
+# Format: one OpenSSH pubkey per line.
+# Lines starting with `#` are comments + ignored.
+# Blank lines are ignored.
+#
+# iter-4.2 zero-typing path: zeta-install.sh populates this file from
+# the boot USB's `zeta-authorized-keys.pub` (written by zflash from
+# ~/.ssh/id_ed25519.pub) before nixos-install.
+#
+# Manual edit path: operators can edit this file directly + run
+#   sudo nixos-rebuild switch --flake /etc/zeta/full-ai-cluster#<host>
+# to add/remove keys without re-flashing the USB.
+#
+# Example (replace with real pubkey content):
+#   ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI... operator@workstation

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -236,7 +236,11 @@ sudo nixos-generate-config --root /mnt --force
 # after first login.
 echo
 echo "[iter-4.2] probing boot USB for operator SSH pubkey ..."
-PUBKEY_DST="/mnt/etc/zeta/full-ai-cluster/nixos/modules/operator-ssh-keys.nix"
+# Per #5086 readFile redesign: write the pubkey content directly to
+# operator-ssh-keys.txt; the sibling operator-ssh-keys.nix reads via
+# builtins.readFile. NO Nix string parsing of USB-supplied content
+# → zero injection surface, zero escaping complexity.
+PUBKEY_DST="/mnt/etc/zeta/full-ai-cluster/nixos/modules/operator-ssh-keys.txt"
 PROBE_MOUNT="/tmp/zeta-boot-esp"
 sudo mkdir -p "$PROBE_MOUNT"
 
@@ -290,49 +294,35 @@ fi
 if [ -n "$PUBKEY_FILE" ]; then
   echo "[iter-4.2]   found: $PUBKEY_FILE"
 
-  # Per #5083 Copilot P0: read via `sudo cat` since the pubkey file may be
-  # on a root-owned mount (/mnt/* or /tmp/zeta-boot-esp); plain shell redirect
-  # would fail as the unprivileged user and `set -e` aborts the install.
-  # OpenSSH pubkey type prefixes (per `sshd(8)` AuthorizedKeysFile):
-  # ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp{256,384,521},
-  # sk-ecdsa-sha2-nistp256@openssh.com, sk-ssh-ed25519@openssh.com.
-  KEY_LINES=()
-  while IFS= read -r line; do
-    case "$line" in
-      ssh-ed25519\ *|ssh-rsa\ *|ssh-dss\ *|ecdsa-sha2-*\ *|sk-ssh-ed25519@*\ *|sk-ecdsa-sha2-*\ *) KEY_LINES+=("$line") ;;
-    esac
-  done < <(sudo cat "$PUBKEY_FILE")
-
-  if [ ${#KEY_LINES[@]} -gt 0 ]; then
-    # Per #5083 Copilot P0/security: Nix string-escape the pubkey content
-    # before interpolating into the Nix file. Without this, a key comment
-    # containing `"` or `\` produces invalid Nix; a maliciously-crafted
-    # line on the USB could inject Nix code at install time. Nix double-
-    # quoted strings escape via `\\` → `\\\\` and `"` → `\"`. We apply
-    # both transformations with sed; ordering matters (backslash first).
-    {
-      echo '# operator-ssh-keys.nix — populated by iter-4.2 zeta-install.sh probe.'
-      echo "# Source: $PUBKEY_FILE (boot USB ESP)"
-      echo "# Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-      echo
-      echo '{ config, pkgs, lib, ... }:'
-      echo
-      echo '{'
-      echo '  users.users.zeta.openssh.authorizedKeys.keys = ['
-      for line in "${KEY_LINES[@]}"; do
-        escaped=$(printf '%s' "$line" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
-        printf '    "%s"\n' "$escaped"
-      done
-      echo '  ];'
-      echo '}'
-    } | sudo tee "$PUBKEY_DST" > /dev/null
-    echo "[iter-4.2]   injected ${#KEY_LINES[@]} pubkey(s) into operator-ssh-keys.nix"
-    sudo umount "$PROBE_MOUNT" 2>/dev/null || true
+  # Per #5086 readFile redesign: write the USB pubkey content directly
+  # to operator-ssh-keys.txt. The sibling operator-ssh-keys.nix reads
+  # via builtins.readFile + splits on newlines + filters blank/comment
+  # lines. NO Nix string parsing of USB content → no escaping needed
+  # (eliminates the entire Nix-injection class, not just current vectors).
+  #
+  # Per #5083 Copilot P0 (still applies): read via `sudo cat` since the
+  # pubkey file may live on a root-owned mount (/mnt/* or /tmp/zeta-boot-
+  # esp); plain shell redirect would fail as the unprivileged user and
+  # `set -e` would abort the install.
+  PUBKEY_LINE_COUNT=$(sudo cat "$PUBKEY_FILE" | grep -c '^ssh-\|^ecdsa-sha2-\|^sk-ssh-\|^sk-ecdsa-sha2-' || true)
+  {
+    echo "# operator-ssh-keys.txt — populated by iter-4.2 zeta-install.sh"
+    echo "# Source: $PUBKEY_FILE (boot USB ESP)"
+    echo "# Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "#"
+    echo "# Read by sibling operator-ssh-keys.nix via builtins.readFile."
+    echo "# Edit + sudo nixos-rebuild switch --flake /etc/zeta/full-ai-cluster#<host>"
+    echo "# to update without re-flashing the USB."
+    echo
+    sudo cat "$PUBKEY_FILE"
+  } | sudo tee "$PUBKEY_DST" > /dev/null
+  echo "[iter-4.2]   wrote $PUBKEY_LINE_COUNT pubkey line(s) to operator-ssh-keys.txt"
+  sudo umount "$PROBE_MOUNT" 2>/dev/null || true
+  if [ "$PUBKEY_LINE_COUNT" -gt 0 ]; then
     INJECT_OK=1
   else
-    echo "[iter-4.2]   WARN: $PUBKEY_FILE contained no valid ssh-* lines"
-    echo "[iter-4.2]          operator-ssh-keys.nix stub stays empty"
-    sudo umount "$PROBE_MOUNT" 2>/dev/null || true
+    echo "[iter-4.2]   WARN: 0 valid ssh-*/ecdsa-*/sk-* lines in source file"
+    echo "[iter-4.2]          (operator-ssh-keys.nix will produce empty keys list)"
   fi
 else
   echo


### PR DESCRIPTION
## Summary

Per the maintainer's 2026-05-26 *"take your time with the security fix"* + *"you can do whatever you think is best"* signals. PR #5086 (already merged at `0b9f5ea`) shipped the minimal sed-escape that the Copilot finding asked for — but on second review I found it MISSES Nix's `${expr}` antiquotation. If a pubkey comment contains `${anything}`, it'd evaluate at install time — same Nix-injection class, different vector.

Adding `$` to the sed pipeline would fix that specific vector but the underlying problem stays: untrusted USB content going through a Nix string parser is whack-a-mole.

**This PR eliminates the class entirely** — pubkey content never goes through the Nix string parser.

## Redesign

- `operator-ssh-keys.nix` reads pubkey list from a sibling `operator-ssh-keys.txt` file via `builtins.readFile` + `lib.splitString "\n"` + `builtins.filter` (skip blank + comment lines). **Untrusted content is data, never code.**
- `operator-ssh-keys.txt` (new file): stub in repo with comment header; populated by `zeta-install.sh` during install.
- `zeta-install.sh`: simplified to `sudo cat $PUBKEY_FILE | sudo tee operator-ssh-keys.txt` (with header lines). The sed-escape + Nix-string-generation code from #5086 is REMOVED — replaced with the simpler tee write.
- Manual edit path unchanged: operator edits `operator-ssh-keys.txt` directly + `nixos-rebuild`.

## Threat-model after redesign

| Attack vector | Pre-#5086 | Post-#5086 (current main) | Post-this-PR |
|---|---|---|---|
| `"` in pubkey comment | Invalid Nix | Escaped → safe | Data → safe |
| `\` in pubkey comment | Invalid Nix | Escaped → safe | Data → safe |
| `${...}` antiquotation | **CODE EXEC** | **CODE EXEC** (sed missed `$`) | Data → safe |
| `''${...}''` indented-string antiquotation | N/A | N/A | Data → safe |
| Any future Nix escape syntax | Class | Whack-a-mole | Class eliminated |

## Files

- `full-ai-cluster/nixos/modules/operator-ssh-keys.nix`: switch from inline keys to `builtins.readFile ./operator-ssh-keys.txt` + filter
- `full-ai-cluster/nixos/modules/operator-ssh-keys.txt`: new stub file with comment header
- `full-ai-cluster/usb-nixos-installer/zeta-install.sh`: simplified inject block (tee replaces sed-escape Nix-gen)

## Composes with

- PR #5083 (iter-4.2 substrate that #5086 fix-forwarded; this PR is the second-pass thorough fix)
- PR #5086 (sed-escape fix-forward for `\` + `"` + the other 4 findings; this PR supersedes the Nix-string-gen part of that PR with the readFile design)

## Test plan

- [x] shellcheck clean on zeta-install.sh
- [x] readFile design uses standard NixOS lib functions (`lib.splitString`, `lib.hasPrefix`, `builtins.filter`, `builtins.readFile`, `builtins.pathExists`)
- [ ] CI passes (gate workflow + CodeQL)
- [ ] Maintainer's next iter-4.2 flash uses this design — first end-to-end test

🤖 Generated with [Claude Code](https://claude.com/claude-code)