### PR TITLE
feat(agentic-org): persist policy observations

### DIFF
--- a/agentic-organization/apps/workers/README.md
+++ b/agentic-organization/apps/workers/README.md
@@ -3,8 +3,9 @@
 `apps/workers` is the first runtime-host shell for Agentic
 Organization. It is intentionally small and NodeNext-first so the
 process boundary can be tested before NestJS, real NATS clients,
-CockroachDB connection pools, Kubernetes manifests, or process
-supervisors are introduced.
+Kubernetes manifests, or process supervisors are introduced. It now has
+the first durable Cockroach composition seam, but the actual connection
+pool implementation remains an outer process adapter.
 
 ## Responsibility
 
@@ -16,6 +17,8 @@ Current duties:
   Kubernetes can later provide through ConfigMaps and Secrets;
 - compose the runtime through a single app-level factory so concrete
   adapters stay outside domain and package code;
+- compose the durable Cockroach adapter set through one generic SQL
+  executor;
 - run the package-level Organization worker cycle;
 - run the NATS JetStream consumer adapter cycle;
 - pass configured NATS batch size, stream name, and durable consumer
@@ -35,9 +38,13 @@ The app currently receives ports that tests can fake:
 - `NatsJetStreamEventConsumer`;
 - `WorkerRuntimeTelemetrySink`.
 
-Future concrete process wiring can bind these ports to CockroachDB,
-NATS, OTLP/logging, health checks, readiness checks, and graceful
-shutdown without changing runtime rule evaluation.
+`composeDurableWorkerRuntimePorts` is the first durable app seam. It
+binds a generic Cockroach executor into the reusable
+`state-cockroach` adapter factory, then wires Cockroach-backed outbox and
+event-ingestion stores into the package-level worker host. Future
+concrete process wiring can bind the same ports to a real Cockroach
+connection pool, NATS, OTLP/logging, health checks, readiness checks,
+and graceful shutdown without changing runtime rule evaluation.
 
 ## Environment
 
@@ -48,18 +55,24 @@ Required runtime values:
 
 - `AGENTIC_ORG_ENV`;
 - `AGENTIC_ORG_ID`;
+- `COCKROACH_DATABASE_URL`;
 - `NATS_STREAM`;
 - `NATS_DURABLE`;
-- `NATS_INBOUND_BATCH_SIZE`.
+- `NATS_INBOUND_BATCH_SIZE`;
+- `WORKER_INBOUND_BATCH_SIZE`;
+- `WORKER_OUTBOX_BATCH_SIZE`.
 
-URLs, credentials, and other sensitive adapter settings belong in later
-adapter config bound by the composition root. They should come from
-Kubernetes Secrets or ExternalSecrets in the full AI cluster, not from
-domain packages.
+URLs, credentials, and other sensitive adapter settings are process
+configuration owned by this app boundary. In the full AI cluster they
+should come from Kubernetes Secrets or ExternalSecrets, not from domain
+packages.
 
 ## Composition Root
 
 `composeWorkerRuntime` is the app-level seam where already-constructed
-ports are connected to the runtime. Today tests provide fake ports. The
-next production slice should construct real CockroachDB, NATS, and
-telemetry adapters here while preserving the same package contracts.
+ports are connected to the runtime. `composeDurableWorkerRuntimePorts`
+is the app-level seam where Cockroach-backed state adapters are built
+from a generic SQL executor and connected to the worker host. Today
+tests provide fake clients and ports. The next production slice should
+construct the actual CockroachDB, NATS, and telemetry clients here while
+preserving the same package contracts.

--- a/agentic-organization/apps/workers/src/config.ts
+++ b/agentic-organization/apps/workers/src/config.ts
@@ -5,17 +5,33 @@ const decimalIntegerPattern = /^[0-9]+$/;
 export const WorkerProcessEnvName = {
   AgenticOrgEnv: "AGENTIC_ORG_ENV",
   AgenticOrgId: "AGENTIC_ORG_ID",
+  CockroachDatabaseUrl: "COCKROACH_DATABASE_URL",
   NatsDurable: "NATS_DURABLE",
   NatsInboundBatchSize: "NATS_INBOUND_BATCH_SIZE",
   NatsStream: "NATS_STREAM",
+  WorkerInboundBatchSize: "WORKER_INBOUND_BATCH_SIZE",
+  WorkerOutboxBatchSize: "WORKER_OUTBOX_BATCH_SIZE",
 } as const;
 
 export type WorkerProcessEnvName = (typeof WorkerProcessEnvName)[keyof typeof WorkerProcessEnvName];
 
 export type WorkerProcessEnvironment = Partial<Record<WorkerProcessEnvName, string | undefined>>;
 
-export function parseWorkerRuntimeConfigFromEnv(env: WorkerProcessEnvironment): WorkerRuntimeConfig {
+export type WorkerDurableRuntimeConfig = {
+  cockroachDatabaseUrl: string;
+  workerInboundBatchSize: number;
+  workerOutboxBatchSize: number;
+};
+
+export type WorkerProcessConfig = WorkerRuntimeConfig & WorkerDurableRuntimeConfig;
+
+export function parseWorkerRuntimeConfigFromEnv(env: WorkerProcessEnvironment): WorkerProcessConfig {
   return {
+    cockroachDatabaseUrl: readRequiredEnvValue(
+      env,
+      WorkerProcessEnvName.CockroachDatabaseUrl,
+      WorkerRuntimeConfigErrorCode.MissingCockroachDatabaseUrl,
+    ),
     environment: readRequiredEnvValue(
       env,
       WorkerProcessEnvName.AgenticOrgEnv,
@@ -37,6 +53,8 @@ export function parseWorkerRuntimeConfigFromEnv(env: WorkerProcessEnvironment): 
       WorkerRuntimeConfigErrorCode.MissingNatsDurableName,
     ),
     natsInboundBatchSize: parseNatsInboundBatchSize(env[WorkerProcessEnvName.NatsInboundBatchSize]),
+    workerInboundBatchSize: parseWorkerInboundBatchSize(env[WorkerProcessEnvName.WorkerInboundBatchSize]),
+    workerOutboxBatchSize: parseWorkerOutboxBatchSize(env[WorkerProcessEnvName.WorkerOutboxBatchSize]),
   };
 }
 
@@ -55,16 +73,28 @@ function readRequiredEnvValue(
 }
 
 function parseNatsInboundBatchSize(value: string | undefined): number {
+  return parsePositiveDecimalInteger(value, WorkerRuntimeConfigErrorCode.InvalidNatsInboundBatchSize);
+}
+
+function parseWorkerInboundBatchSize(value: string | undefined): number {
+  return parsePositiveDecimalInteger(value, WorkerRuntimeConfigErrorCode.InvalidWorkerInboundBatchSize);
+}
+
+function parseWorkerOutboxBatchSize(value: string | undefined): number {
+  return parsePositiveDecimalInteger(value, WorkerRuntimeConfigErrorCode.InvalidWorkerOutboxBatchSize);
+}
+
+function parsePositiveDecimalInteger(value: string | undefined, errorCode: WorkerRuntimeConfigErrorCode): number {
   const trimmedValue = value?.trim();
 
   if (trimmedValue === undefined || trimmedValue.length === 0 || !decimalIntegerPattern.test(trimmedValue)) {
-    throw new WorkerRuntimeConfigError(WorkerRuntimeConfigErrorCode.InvalidNatsInboundBatchSize);
+    throw new WorkerRuntimeConfigError(errorCode);
   }
 
   const parsedValue = Number(trimmedValue);
 
   if (!Number.isSafeInteger(parsedValue) || parsedValue < 1) {
-    throw new WorkerRuntimeConfigError(WorkerRuntimeConfigErrorCode.InvalidNatsInboundBatchSize);
+    throw new WorkerRuntimeConfigError(errorCode);
   }
 
   return parsedValue;

--- a/agentic-organization/apps/workers/src/durable-composition.ts
+++ b/agentic-organization/apps/workers/src/durable-composition.ts
@@ -1,0 +1,84 @@
+import {
+  createOutboxPublisher,
+  resolveAgenticMessagingDomain,
+  type EventPublisher,
+} from "../../../packages/messaging/src/index.ts";
+import type { NatsJetStreamEventConsumer } from "../../../packages/messaging-nats/src/index.ts";
+import {
+  evaluateV0AutomationRules,
+  createEventIngestionProcessor,
+  type EventPayloadHashCalculator,
+} from "../../../packages/runtime/src/index.ts";
+import { InboundEventConsumerName } from "../../../packages/state/src/index.ts";
+import {
+  createCockroachDurableStateAdapters,
+  type CockroachOrganizationSqlExecutor,
+} from "../../../packages/state-cockroach/src/index.ts";
+import {
+  createOrganizationWorkerHost,
+  type InboundEventSource,
+  type OrganizationWorkerHost,
+} from "../../../packages/workers/src/index.ts";
+import type { WorkerProcessConfig } from "./config.ts";
+import type { WorkerRuntimeTelemetrySink } from "./worker-runtime.ts";
+
+export type DurableWorkerRuntimeAdapters = {
+  cockroachExecutor: CockroachOrganizationSqlExecutor;
+  eventPublisher: EventPublisher;
+  inboundEventSource: InboundEventSource;
+  natsEventConsumer: NatsJetStreamEventConsumer;
+  telemetrySink: WorkerRuntimeTelemetrySink;
+};
+
+export type DurableWorkerRuntimeUtilities = {
+  calculatePayloadHash: EventPayloadHashCalculator;
+  createId: (prefix: string) => string;
+  now: () => string;
+};
+
+export type DurableWorkerRuntimePorts = {
+  organizationWorkerHost: OrganizationWorkerHost;
+  natsEventConsumer: NatsJetStreamEventConsumer;
+  telemetrySink: WorkerRuntimeTelemetrySink;
+};
+
+export type ComposeDurableWorkerRuntimePortsInput = {
+  config: WorkerProcessConfig;
+  durableAdapters: DurableWorkerRuntimeAdapters;
+  runtimeUtilities: DurableWorkerRuntimeUtilities;
+};
+
+export function composeDurableWorkerRuntimePorts(
+  input: ComposeDurableWorkerRuntimePortsInput,
+): DurableWorkerRuntimePorts {
+  const stateAdapters = createCockroachDurableStateAdapters({
+    executor: input.durableAdapters.cockroachExecutor,
+  });
+  const eventIngestionProcessor = createEventIngestionProcessor({
+    store: stateAdapters.eventIngestionStore,
+    evaluateRules: evaluateV0AutomationRules,
+    consumerName: InboundEventConsumerName.V0AutomationPlanner,
+    calculatePayloadHash: input.runtimeUtilities.calculatePayloadHash,
+    now: input.runtimeUtilities.now,
+    createId: input.runtimeUtilities.createId,
+  });
+  const outboxPublisher = createOutboxPublisher({
+    outboxSource: stateAdapters.outboxEventSource,
+    eventPublisher: input.durableAdapters.eventPublisher,
+    environment: input.config.environment,
+    resolveDomain: resolveAgenticMessagingDomain,
+    now: input.runtimeUtilities.now,
+  });
+
+  return {
+    organizationWorkerHost: createOrganizationWorkerHost({
+      outboxPublisher,
+      inboundEventSource: input.durableAdapters.inboundEventSource,
+      eventIngestionProcessor,
+      outboxBatchSize: input.config.workerOutboxBatchSize,
+      inboundBatchSize: input.config.workerInboundBatchSize,
+    }),
+    natsEventConsumer: input.durableAdapters.natsEventConsumer,
+    telemetrySink: input.durableAdapters.telemetrySink,
+  };
+}

--- a/agentic-organization/apps/workers/src/index.ts
+++ b/agentic-organization/apps/workers/src/index.ts
@@ -1,5 +1,18 @@
-export { WorkerProcessEnvName, parseWorkerRuntimeConfigFromEnv, type WorkerProcessEnvironment } from "./config.ts";
+export {
+  WorkerProcessEnvName,
+  parseWorkerRuntimeConfigFromEnv,
+  type WorkerDurableRuntimeConfig,
+  type WorkerProcessConfig,
+  type WorkerProcessEnvironment,
+} from "./config.ts";
 export { composeWorkerRuntime, type ComposeWorkerRuntimeInput, type WorkerRuntimePorts } from "./composition.ts";
+export {
+  composeDurableWorkerRuntimePorts,
+  type ComposeDurableWorkerRuntimePortsInput,
+  type DurableWorkerRuntimeAdapters,
+  type DurableWorkerRuntimePorts,
+  type DurableWorkerRuntimeUtilities,
+} from "./durable-composition.ts";
 export {
   WorkerRuntimeConfigError,
   WorkerRuntimeConfigErrorCode,

--- a/agentic-organization/apps/workers/src/worker-runtime.ts
+++ b/agentic-organization/apps/workers/src/worker-runtime.ts
@@ -31,6 +31,9 @@ export const WorkerRuntimeFailureStage = {
 export type WorkerRuntimeFailureStage = (typeof WorkerRuntimeFailureStage)[keyof typeof WorkerRuntimeFailureStage];
 
 export const WorkerRuntimeConfigErrorCode = {
+  InvalidWorkerInboundBatchSize: "invalid_worker_inbound_batch_size",
+  InvalidWorkerOutboxBatchSize: "invalid_worker_outbox_batch_size",
+  MissingCockroachDatabaseUrl: "missing_cockroach_database_url",
   InvalidNatsInboundBatchSize: "invalid_nats_inbound_batch_size",
   MissingEnvironment: "missing_environment",
   MissingNatsDurableName: "missing_nats_durable_name",

--- a/agentic-organization/apps/workers/test/durable-worker-composition.test.ts
+++ b/agentic-organization/apps/workers/test/durable-worker-composition.test.ts
@@ -1,0 +1,195 @@
+import { deepEqual, equal } from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  AgenticAggregateType,
+  AgenticEventType,
+  SupervisorChainLevel,
+  createAgenticEventEnvelope,
+} from "../../../packages/domain/src/index.ts";
+import type { EventPublication } from "../../../packages/messaging/src/index.ts";
+import type { NatsJetStreamConsumeBatchResult } from "../../../packages/messaging-nats/src/index.ts";
+import type { CockroachOrganizationSqlExecutor } from "../../../packages/state-cockroach/src/index.ts";
+import { WorkerCycleStatus } from "../../../packages/workers/src/index.ts";
+import { composeDurableWorkerRuntimePorts, type WorkerRuntimeTelemetrySink } from "../src/index.ts";
+
+describe("durable worker runtime composition", () => {
+  test("wires Cockroach outbox and event ingestion adapters into the worker host", async () => {
+    const cockroachExecutor = createRecordingCockroachExecutor();
+    const eventPublisher = createRecordingEventPublisher();
+    const telemetrySink = createNoopTelemetrySink();
+    const ports = composeDurableWorkerRuntimePorts({
+      config: {
+        cockroachDatabaseUrl: "postgresql://agentic-org@cockroachdb-public:26257/agentic_org",
+        environment: "dev",
+        organizationId: "org-lfg",
+        natsStreamName: "agentic-org-events",
+        natsDurableName: "agentic-org-v0-automation-planner",
+        natsInboundBatchSize: 25,
+        workerInboundBatchSize: 10,
+        workerOutboxBatchSize: 5,
+      },
+      durableAdapters: {
+        cockroachExecutor,
+        eventPublisher,
+        inboundEventSource: {
+          pullNextBatch: async () => [createSupervisorSignalEnvelope()],
+        },
+        natsEventConsumer: {
+          processNextBatch: async () => createEmptyNatsBatch(),
+        },
+        telemetrySink,
+      },
+      runtimeUtilities: {
+        calculatePayloadHash: () => "sha256:event-payload-001",
+        createId: (prefix) => `${prefix}-001`,
+        now: () => "2026-05-26T00:00:00.000Z",
+      },
+    });
+
+    const workerCycle = await ports.organizationWorkerHost.runOnce();
+
+    equal(workerCycle.status, WorkerCycleStatus.Worked);
+    deepEqual(cockroachExecutor.statementNames, [
+      "claim_unpublished_outbox_events",
+      "mark_outbox_event_published",
+      "find_inbox_receipt",
+      "claim_pending_inbox_receipt",
+      "insert_reaction_plan",
+      "mark_inbox_receipt_processed",
+    ]);
+    deepEqual(
+      eventPublisher.publications.map((publication) => publication.subject),
+      ["agentic-org.dev.org-lfg.supervisor_signal.sent"],
+    );
+  });
+});
+
+function createSupervisorSignalEnvelope() {
+  return createAgenticEventEnvelope({
+    eventId: "evt-supervisor-signal-001",
+    eventType: AgenticEventType.SupervisorSignalSent,
+    occurredAt: "2026-05-26T00:00:00.000Z",
+    actor: {
+      agentId: "agent-001",
+      hatAssignmentId: "hat-assignment-001",
+    },
+    scope: {
+      organizationId: "org-lfg",
+      projectId: "project-agentic-org",
+      teamId: "team-runtime",
+      workItemId: "work-item-001",
+    },
+    aggregate: {
+      aggregateId: "supervisor-signal-001",
+      aggregateType: AgenticAggregateType.SupervisorSignal,
+      aggregateVersion: 1,
+    },
+    trace: {
+      commandId: "cmd-001",
+      correlationId: "corr-001",
+      causationId: "cause-001",
+      traceId: "trace-001",
+      idempotencyKey: "idem-001",
+    },
+    payload: {
+      targetHatAssignmentId: "hat-assignment-manager-001",
+      targetLevel: SupervisorChainLevel.Manager,
+    },
+  });
+}
+
+function createRecordingCockroachExecutor(): CockroachOrganizationSqlExecutor & {
+  statementNames: string[];
+} {
+  const statementNames: string[] = [];
+
+  return {
+    statementNames,
+    execute: async <Row = Record<string, unknown>>(statement: { name: string }) => {
+      statementNames.push(statement.name);
+
+      if (statement.name === "claim_unpublished_outbox_events") {
+        return {
+          rows: [
+            {
+              outbox_event_id: "outbox-001",
+              envelope_json: createSupervisorSignalEnvelope(),
+            },
+          ] as Row[],
+        };
+      }
+
+      if (statement.name === "mark_outbox_event_published") {
+        return {
+          rows: [{ outbox_event_id: "outbox-001" }] as Row[],
+        };
+      }
+
+      return {
+        rows: [] as Row[],
+      };
+    },
+    executeTransaction: async <Result>(
+      operation: (executor: {
+        execute: <Row = Record<string, unknown>>(statement: { name: string }) => Promise<{ rows: Row[] }>;
+      }) => Promise<Result>,
+    ) =>
+      await operation({
+        execute: async <Row = Record<string, unknown>>(statement: { name: string }) => {
+          statementNames.push(statement.name);
+
+          if (statement.name === "claim_pending_inbox_receipt") {
+            return {
+              rows: [{ claim_status: "processed" }] as Row[],
+            };
+          }
+
+          if (statement.name === "mark_inbox_receipt_processed") {
+            return {
+              rows: [{ event_id: "evt-supervisor-signal-001" }] as Row[],
+            };
+          }
+
+          return {
+            rows: [] as Row[],
+          };
+        },
+      }),
+  };
+}
+
+function createRecordingEventPublisher(): {
+  publications: EventPublication[];
+  publish: (publication: EventPublication) => Promise<void>;
+} {
+  const publications: EventPublication[] = [];
+
+  return {
+    publications,
+    publish: async (publication) => {
+      publications.push(publication);
+    },
+  };
+}
+
+function createNoopTelemetrySink(): WorkerRuntimeTelemetrySink {
+  return {
+    record: async () => undefined,
+  };
+}
+
+function createEmptyNatsBatch(): NatsJetStreamConsumeBatchResult {
+  return {
+    receivedCount: 0,
+    processedCount: 0,
+    duplicateCount: 0,
+    payloadConflictCount: 0,
+    invalidCount: 0,
+    failedCount: 0,
+    acknowledgedCount: 0,
+    negativeAcknowledgedCount: 0,
+    terminatedCount: 0,
+    deadLetteredCount: 0,
+  };
+}

--- a/agentic-organization/apps/workers/test/worker-config.test.ts
+++ b/agentic-organization/apps/workers/test/worker-config.test.ts
@@ -14,33 +14,51 @@ describe("worker runtime config parsing", () => {
       parseWorkerRuntimeConfigFromEnv({
         [WorkerProcessEnvName.AgenticOrgEnv]: " dev ",
         [WorkerProcessEnvName.AgenticOrgId]: " org-lfg ",
+        [WorkerProcessEnvName.CockroachDatabaseUrl]: " postgresql://agentic-org@cockroachdb-public:26257/agentic_org ",
         [WorkerProcessEnvName.NatsStream]: " agentic-org-events ",
         [WorkerProcessEnvName.NatsDurable]: " agentic-org-v0-automation-planner ",
         [WorkerProcessEnvName.NatsInboundBatchSize]: "25",
+        [WorkerProcessEnvName.WorkerInboundBatchSize]: "15",
+        [WorkerProcessEnvName.WorkerOutboxBatchSize]: "10",
       }),
       {
+        cockroachDatabaseUrl: "postgresql://agentic-org@cockroachdb-public:26257/agentic_org",
         environment: "dev",
         organizationId: "org-lfg",
         natsStreamName: "agentic-org-events",
         natsDurableName: "agentic-org-v0-automation-planner",
         natsInboundBatchSize: 25,
+        workerInboundBatchSize: 15,
+        workerOutboxBatchSize: 10,
       },
     );
   });
 
   test("rejects missing required env values with typed errors", () => {
-    try {
-      parseWorkerRuntimeConfigFromEnv({
+    assertConfigError(
+      {
+        [WorkerProcessEnvName.AgenticOrgId]: "org-lfg",
+        [WorkerProcessEnvName.CockroachDatabaseUrl]: "postgresql://agentic-org@cockroachdb-public:26257/agentic_org",
+        [WorkerProcessEnvName.NatsStream]: "agentic-org-events",
+        [WorkerProcessEnvName.NatsDurable]: "agentic-org-v0-automation-planner",
+        [WorkerProcessEnvName.NatsInboundBatchSize]: "25",
+        [WorkerProcessEnvName.WorkerInboundBatchSize]: "15",
+        [WorkerProcessEnvName.WorkerOutboxBatchSize]: "10",
+      },
+      WorkerRuntimeConfigErrorCode.MissingEnvironment,
+    );
+    assertConfigError(
+      {
+        [WorkerProcessEnvName.AgenticOrgEnv]: "dev",
         [WorkerProcessEnvName.AgenticOrgId]: "org-lfg",
         [WorkerProcessEnvName.NatsStream]: "agentic-org-events",
         [WorkerProcessEnvName.NatsDurable]: "agentic-org-v0-automation-planner",
         [WorkerProcessEnvName.NatsInboundBatchSize]: "25",
-      });
-      throw new Error("expected config parsing to fail");
-    } catch (error) {
-      equal(error instanceof WorkerRuntimeConfigError, true);
-      equal((error as WorkerRuntimeConfigError).code, WorkerRuntimeConfigErrorCode.MissingEnvironment);
-    }
+        [WorkerProcessEnvName.WorkerInboundBatchSize]: "15",
+        [WorkerProcessEnvName.WorkerOutboxBatchSize]: "10",
+      },
+      WorkerRuntimeConfigErrorCode.MissingCockroachDatabaseUrl,
+    );
   });
 
   test("rejects invalid numeric env values with typed errors", () => {
@@ -48,9 +66,12 @@ describe("worker runtime config parsing", () => {
       parseWorkerRuntimeConfigFromEnv({
         [WorkerProcessEnvName.AgenticOrgEnv]: "dev",
         [WorkerProcessEnvName.AgenticOrgId]: "org-lfg",
+        [WorkerProcessEnvName.CockroachDatabaseUrl]: "postgresql://agentic-org@cockroachdb-public:26257/agentic_org",
         [WorkerProcessEnvName.NatsStream]: "agentic-org-events",
         [WorkerProcessEnvName.NatsDurable]: "agentic-org-v0-automation-planner",
         [WorkerProcessEnvName.NatsInboundBatchSize]: "not-a-number",
+        [WorkerProcessEnvName.WorkerInboundBatchSize]: "15",
+        [WorkerProcessEnvName.WorkerOutboxBatchSize]: "10",
       });
       throw new Error("expected config parsing to fail");
     } catch (error) {
@@ -61,19 +82,58 @@ describe("worker runtime config parsing", () => {
 
   test("rejects non-decimal or unsafe batch sizes with typed errors", () => {
     for (const batchSize of ["1.5", "1e3", "9007199254740992"]) {
-      try {
-        parseWorkerRuntimeConfigFromEnv({
+      assertConfigError(
+        {
           [WorkerProcessEnvName.AgenticOrgEnv]: "dev",
           [WorkerProcessEnvName.AgenticOrgId]: "org-lfg",
+          [WorkerProcessEnvName.CockroachDatabaseUrl]: "postgresql://agentic-org@cockroachdb-public:26257/agentic_org",
           [WorkerProcessEnvName.NatsStream]: "agentic-org-events",
           [WorkerProcessEnvName.NatsDurable]: "agentic-org-v0-automation-planner",
           [WorkerProcessEnvName.NatsInboundBatchSize]: batchSize,
-        });
-        throw new Error("expected config parsing to fail");
-      } catch (error) {
-        equal(error instanceof WorkerRuntimeConfigError, true);
-        equal((error as WorkerRuntimeConfigError).code, WorkerRuntimeConfigErrorCode.InvalidNatsInboundBatchSize);
-      }
+          [WorkerProcessEnvName.WorkerInboundBatchSize]: "15",
+          [WorkerProcessEnvName.WorkerOutboxBatchSize]: "10",
+        },
+        WorkerRuntimeConfigErrorCode.InvalidNatsInboundBatchSize,
+      );
+      assertConfigError(
+        {
+          [WorkerProcessEnvName.AgenticOrgEnv]: "dev",
+          [WorkerProcessEnvName.AgenticOrgId]: "org-lfg",
+          [WorkerProcessEnvName.CockroachDatabaseUrl]: "postgresql://agentic-org@cockroachdb-public:26257/agentic_org",
+          [WorkerProcessEnvName.NatsStream]: "agentic-org-events",
+          [WorkerProcessEnvName.NatsDurable]: "agentic-org-v0-automation-planner",
+          [WorkerProcessEnvName.NatsInboundBatchSize]: "25",
+          [WorkerProcessEnvName.WorkerInboundBatchSize]: batchSize,
+          [WorkerProcessEnvName.WorkerOutboxBatchSize]: "10",
+        },
+        WorkerRuntimeConfigErrorCode.InvalidWorkerInboundBatchSize,
+      );
+      assertConfigError(
+        {
+          [WorkerProcessEnvName.AgenticOrgEnv]: "dev",
+          [WorkerProcessEnvName.AgenticOrgId]: "org-lfg",
+          [WorkerProcessEnvName.CockroachDatabaseUrl]: "postgresql://agentic-org@cockroachdb-public:26257/agentic_org",
+          [WorkerProcessEnvName.NatsStream]: "agentic-org-events",
+          [WorkerProcessEnvName.NatsDurable]: "agentic-org-v0-automation-planner",
+          [WorkerProcessEnvName.NatsInboundBatchSize]: "25",
+          [WorkerProcessEnvName.WorkerInboundBatchSize]: "15",
+          [WorkerProcessEnvName.WorkerOutboxBatchSize]: batchSize,
+        },
+        WorkerRuntimeConfigErrorCode.InvalidWorkerOutboxBatchSize,
+      );
     }
   });
 });
+
+function assertConfigError(
+  env: Parameters<typeof parseWorkerRuntimeConfigFromEnv>[0],
+  code: WorkerRuntimeConfigErrorCode,
+): void {
+  try {
+    parseWorkerRuntimeConfigFromEnv(env);
+    throw new Error("expected config parsing to fail");
+  } catch (error) {
+    equal(error instanceof WorkerRuntimeConfigError, true);
+    equal((error as WorkerRuntimeConfigError).code, code);
+  }
+}

--- a/agentic-organization/docs/ALWAYS_ON_ORCHESTRATION_RUNTIME.md
+++ b/agentic-organization/docs/ALWAYS_ON_ORCHESTRATION_RUNTIME.md
@@ -55,6 +55,14 @@ Initial workers:
 
 These are boring system processes. Hermes agents may reason about their outputs, but the workers keep the runtime awake.
 
+V0 starts with the smallest durable worker slice: the NodeNext
+`apps/workers` host composes the `OutboxPublisherWorker` lane and the
+first inbound event-ingestion lane against Cockroach-backed ports. It is
+not the whole always-on worker taxonomy yet. Scheduler, trigger,
+reaction execution, leases, dead letters, reconcilers, budget, anomaly,
+and observability coverage workers should be added as separate lanes or
+hosts after the durable composition seam is proven.
+
 ## Durable Triggers
 
 Triggers are first-class runtime objects.

--- a/agentic-organization/docs/FIRST_IMPLEMENTATION_SLICE.md
+++ b/agentic-organization/docs/FIRST_IMPLEMENTATION_SLICE.md
@@ -259,19 +259,25 @@ Hermes runs, MCP calls, and UI evidence.
   work.
 - `apps/workers` validates required process config before any loop can
   start: environment, Organization ID, NATS stream, durable consumer,
-  and positive NATS inbound batch size.
+  CockroachDB URL, positive NATS inbound batch size, positive worker
+  inbound batch size, and positive worker outbox batch size.
 - `apps/workers` parses required runtime values from typed environment
   names: `AGENTIC_ORG_ENV`, `AGENTIC_ORG_ID`, `NATS_STREAM`,
-  `NATS_DURABLE`, and `NATS_INBOUND_BATCH_SIZE`. String values are
-  trimmed, and NATS inbound batch size must be a safe positive decimal
-  integer.
+  `NATS_DURABLE`, `NATS_INBOUND_BATCH_SIZE`, `COCKROACH_DATABASE_URL`,
+  `WORKER_INBOUND_BATCH_SIZE`, and `WORKER_OUTBOX_BATCH_SIZE`. String
+  values are trimmed, and all batch sizes must be safe positive decimal
+  integers.
 - `apps/workers` treats any non-happy NATS consumer counter as degraded:
   failed, dead-lettered, invalid, payload-conflict,
   negative-acknowledged, or terminated messages.
-- `apps/workers` exposes an app-level composition factory that receives
-  typed config plus already-constructed ports. Future real CockroachDB,
-  NATS, and telemetry adapters bind at this app seam instead of leaking
-  process or secret concerns into reusable packages.
+- `apps/workers` exposes app-level composition factories that receive
+  typed config plus already-constructed ports. The durable worker
+  composition seam now binds a generic Cockroach executor into the
+  `state-cockroach` adapter factory, then wires Cockroach-backed outbox
+  and event-ingestion stores into the worker host. Future real
+  CockroachDB client construction, NATS, and telemetry adapters bind at
+  this app seam instead of leaking process or secret concerns into
+  reusable packages.
 - Observability projections now include policy decision ID and policy
   version in event span attributes and workflow visibility records when
   an accepted command emits a policy-backed event envelope.
@@ -282,9 +288,9 @@ Hermes runs, MCP calls, and UI evidence.
 
 ## Next Slice
 
-The next slice should add the first real process adapter factories below
-`apps/workers`: concrete NATS pull/publish client construction, durable
-CockroachDB outbox/inbox/policy-observation adapter construction, and a
+The next slice should add concrete process client construction below
+`apps/workers`: real CockroachDB pool binding for the generic SQL
+executor, concrete NATS pull/publish client construction, and a
 telemetry sink that can later send structured logs and metrics into the
 full-ai-cluster LGTM stack. Keep URLs, credentials, and connection pools
 in app adapter config fed by Kubernetes Secret or ExternalSecret values,

--- a/agentic-organization/docs/FIRST_IMPLEMENTATION_SLICE.md
+++ b/agentic-organization/docs/FIRST_IMPLEMENTATION_SLICE.md
@@ -50,8 +50,8 @@ send_supervisor_signal
 ## Checkpoint Boundary
 
 The implemented slice does not yet create discussion anchors, graph
-nodes, hat assignments, hat tokens, policy decisions, prompt-flow runs,
-Hermes runs, or reviewer gates. Those remain V0 follow-on commands.
+nodes, hat assignments, hat tokens, prompt-flow runs, Hermes runs, or
+reviewer gates. Those remain V0 follow-on commands.
 
 Capability-request-shaped inputs should continue to enter through
 `send_supervisor_signal`. The target supervisor triage step decides
@@ -65,12 +65,12 @@ escalate.
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@agentic-org/domain`          | event envelope, command/event constants, aggregate constants, supervisor-chain communication types, hat communication briefs, work item state machine, shared records |
 | `@agentic-org/application`     | command pipeline, command-handler registry, state-store ports, idempotency conflict handling, supervisor signal handler                                               |
-| `@agentic-org/policy`          | command authorization port, hat-authority port, policy-decision observation port, active/expired/revoked/scope/tool denial decisions, typed policy denial reasons     |
+| `@agentic-org/policy`          | command authorization port, hat-authority port, policy-decision observation/store/reader ports, active/expired/revoked/scope/tool denial decisions, typed reasons     |
 | `@agentic-org/state`           | generic state-store/outbox-source ports plus the in-memory Organization state-store factory fake                                                                      |
-| `@agentic-org/state-cockroach` | first replaceable durable SQL implementation of the state-store/outbox-source ports, backed by CockroachDB                                                            |
+| `@agentic-org/state-cockroach` | first replaceable durable SQL implementation of state-store, outbox-source, event-ingestion, and policy-observation ports, backed by CockroachDB                      |
 | `@agentic-org/messaging`       | stable `agentic-org.<env>.<org>.<domain>.<event>` subject builder, outbox publisher, event publisher port, and typed domain resolver                                  |
 | `@agentic-org/messaging-nats`  | NATS JetStream publisher and consumer adapter contracts with canonical JSON payloads, headers, message IDs, ack/nack, termination, and DLQ policy                     |
-| `@agentic-org/observability`   | OpenTelemetry/LGTM span attribute projection for event envelopes and NATS consumer batch summaries                                                                    |
+| `@agentic-org/observability`   | OpenTelemetry/LGTM and workflow-visibility projections for event envelopes, NATS batches, worker cycles, and policy observations                                      |
 | `@agentic-org/runtime`         | first rule that plans triage for the target supervisor when a chain signal is sent                                                                                    |
 | `@agentic-org/workers`         | process-boundary run-once worker host that composes outbox publishing and inbound event ingestion through ports                                                       |
 | `@agentic-org/governance`      | package dependency-boundary checks that prevent application code from importing concrete state/runtime adapters                                                       |
@@ -138,6 +138,12 @@ Hermes runs, MCP calls, and UI evidence.
   outbox, or idempotency state. It records a policy decision observation
   through a dedicated generic port so denied attempts are visible without
   pretending a business state transition succeeded.
+- Policy decision observations now have a generic durable store/reader
+  contract. The first Cockroach adapter records observations
+  idempotently by policy decision ID plus canonical observation hash,
+  rejects conflicting evidence for the same policy decision ID, and
+  supports scoped queries by organization, project, team, work item,
+  actor, hat assignment, and decision status.
 - If policy decision observation fails for a denied command, the command
   still rejects before handler dispatch, idempotency lookup, or business
   persistence with a typed `policy_observation_failed` error.
@@ -269,20 +275,22 @@ Hermes runs, MCP calls, and UI evidence.
 - Observability projections now include policy decision ID and policy
   version in event span attributes and workflow visibility records when
   an accepted command emits a policy-backed event envelope.
+- Policy-denial observations now project into UI- and agent-readable
+  workflow visibility with `policy_denied` weak-point indicators,
+  trace/log/metrics links, supervisor-chain context, and the denied
+  command/tool/scope.
 
 ## Next Slice
 
 The next slice should add the first real process adapter factories below
 `apps/workers`: concrete NATS pull/publish client construction, durable
-CockroachDB outbox/inbox adapter construction, and a telemetry sink that
-can later send structured logs and metrics into the full-ai-cluster LGTM
-stack. Keep URLs, credentials, and connection pools in app adapter config
-fed by Kubernetes Secret or ExternalSecret values, never in domain
-packages. Add a durable-state integration test using CockroachDB as the
-first cluster-backed implementation once a local/dev connection is
-available. After that, add a durable policy-decision observation adapter
-behind `PolicyDecisionObservationPort` and project policy decision
-observations into UI/agent-readable workflow visibility.
+CockroachDB outbox/inbox/policy-observation adapter construction, and a
+telemetry sink that can later send structured logs and metrics into the
+full-ai-cluster LGTM stack. Keep URLs, credentials, and connection pools
+in app adapter config fed by Kubernetes Secret or ExternalSecret values,
+never in domain packages. Add a durable-state integration test using
+CockroachDB as the first cluster-backed implementation once a local/dev
+connection is available.
 
 Do not make the next slice a pile of bespoke request commands. Build the
 generic supervisor triage lifecycle first, then let specialized

--- a/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
+++ b/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
@@ -168,13 +168,18 @@ tool-denied authority returns a typed `policy_denied` result.
 The pipeline now records denied decisions through a generic policy
 decision observation port, rejects cleanly if that observation fails, and
 projects allowed policy decisions onto audit and outbox effects before
-command persistence.
+command persistence. Denied observations now have a generic durable
+store/reader contract, a first Cockroach implementation, and a
+canonical-hash conflict guard so contradictory duplicate evidence is not
+hidden as replay. The UI/agent-readable visibility projection marks
+policy denials as weak points without pretending denied commands changed
+business state.
 
-The remaining gaps are richer authority semantics and durable
-visibility adapters: tests still need unauthorized source hats, invalid
+The remaining gaps are richer authority semantics and cluster-backed
+integration proof: tests still need unauthorized source hats, invalid
 target supervisors, and missing assignments, and the system still needs a
-durable policy-decision observation adapter plus UI/agent projections for
-policy decision observations.
+real Cockroach-backed integration run plus process-level adapter wiring
+below `apps/workers`.
 
 ### Command Surface Closure
 

--- a/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
+++ b/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
@@ -177,9 +177,10 @@ business state.
 
 The remaining gaps are richer authority semantics and cluster-backed
 integration proof: tests still need unauthorized source hats, invalid
-target supervisors, and missing assignments, and the system still needs a
-real Cockroach-backed integration run plus process-level adapter wiring
-below `apps/workers`.
+target supervisors, and missing assignments. The system now has a
+durable worker composition seam below `apps/workers`, but it still needs
+a real Cockroach-backed integration run and concrete process client
+construction for Cockroach, NATS, and telemetry.
 
 ### Command Surface Closure
 

--- a/agentic-organization/docs/OBSERVABILITY_AND_SELF_HEALING.md
+++ b/agentic-organization/docs/OBSERVABILITY_AND_SELF_HEALING.md
@@ -162,12 +162,19 @@ The operations UI should make weak points visible at every hierarchy:
 - work item timelines;
 - agent schedules and runs;
 - review, QA, security, architecture, delivery, and outcome gates;
+- Cockroach durable adapter health;
 - NATS, Temporal, Dapr, Hermes, Hindsight, MCP, and k8s adapter health.
 
 Every view should support drilling from summary to evidence. A red or
 degraded status without a trace, log query, metric panel, event ID or
 policy decision/command ID, work item, and suggested action is not good
 enough for this platform.
+
+Startup and composition failures count as observable runtime failures.
+If the worker process cannot construct or validate its Cockroach, NATS,
+or telemetry adapters, the failure should produce explicit startup
+evidence and a degraded/readiness signal rather than disappearing before
+agents and operators can inspect it.
 
 ## Implementation Rule
 

--- a/agentic-organization/docs/OBSERVABILITY_AND_SELF_HEALING.md
+++ b/agentic-organization/docs/OBSERVABILITY_AND_SELF_HEALING.md
@@ -25,6 +25,7 @@ visibility record.
 Required movements include:
 
 - command accepted or rejected;
+- denied policy decision observed;
 - domain event written;
 - outbox publication;
 - NATS consumer handling;
@@ -44,8 +45,8 @@ queryable evidence and diagnosis surfaces.
 
 ## Workflow Visibility Record
 
-`@agentic-org/observability` owns the first typed record builder. The
-record projects a canonical event envelope into the fields a UI,
+`@agentic-org/observability` owns the first typed record builders. Event
+visibility projects a canonical event envelope into the fields a UI,
 monitor, or agent reviewer needs:
 
 - observation kind;
@@ -63,6 +64,24 @@ monitor, or agent reviewer needs:
 This is intentionally generic. It is not a QA-only, capability-request,
 or platform-incident-only tool. It is the common visibility shape that
 all packages can extend and all runtime hosts can emit.
+
+Policy-denial visibility is a sibling projection. It does not synthesize
+a fake event for a denied command. Instead it projects the durable policy
+decision observation directly into:
+
+- command, correlation, causation, trace, and idempotency IDs;
+- organization, project, optional team, and optional work item scope;
+- agent and hat assignment;
+- attempted tool type;
+- supervisor-chain source and target levels;
+- policy decision ID, policy version, and denial reason;
+- Grafana links for traces, logs, and metrics;
+- a `policy_denied` weak-point indicator.
+
+Agents should use those records to understand whether a denial points to
+a missing grant, wrong scope, stale hat assignment, or training gap, then
+route follow-up through supervisor-chain communication and normal work
+commands.
 
 ## Weak-Point Indicators
 
@@ -146,8 +165,9 @@ The operations UI should make weak points visible at every hierarchy:
 - NATS, Temporal, Dapr, Hermes, Hindsight, MCP, and k8s adapter health.
 
 Every view should support drilling from summary to evidence. A red or
-degraded status without a trace, log query, metric panel, event ID,
-work item, and suggested action is not good enough for this platform.
+degraded status without a trace, log query, metric panel, event ID or
+policy decision/command ID, work item, and suggested action is not good
+enough for this platform.
 
 ## Implementation Rule
 

--- a/agentic-organization/docs/TECHNICAL_CA_PACKAGE_ARCHITECTURE.md
+++ b/agentic-organization/docs/TECHNICAL_CA_PACKAGE_ARCHITECTURE.md
@@ -306,9 +306,14 @@ metrics, structured logs, readiness, and graceful shutdown.
 does not introduce NestJS yet. It composes the package-level worker host
 and the NATS consumer adapter, parses typed process environment values
 into runtime config, records telemetry through a sink port, and reports
-healthy/degraded status. Its current required environment contract is
-`AGENTIC_ORG_ENV`, `AGENTIC_ORG_ID`, `NATS_STREAM`, `NATS_DURABLE`, and
-`NATS_INBOUND_BATCH_SIZE`. Concrete NATS clients, CockroachDB pools,
+healthy/degraded status. Its durable composition seam receives a generic
+Cockroach SQL executor, creates the Cockroach-backed command state,
+outbox, event-ingestion, and policy-observation adapter set, and wires
+the outbox/event-ingestion ports into the worker host. Its current
+required environment contract is `AGENTIC_ORG_ENV`, `AGENTIC_ORG_ID`,
+`COCKROACH_DATABASE_URL`, `NATS_STREAM`, `NATS_DURABLE`,
+`NATS_INBOUND_BATCH_SIZE`, `WORKER_INBOUND_BATCH_SIZE`, and
+`WORKER_OUTBOX_BATCH_SIZE`. Concrete NATS clients, CockroachDB pools,
 readiness endpoints, structured logging, and shutdown hooks still belong
 to later process-adapter wiring.
 
@@ -318,6 +323,13 @@ should know which concrete adapter implementation is being used. Domain,
 application, runtime, worker, and observability packages must stay free
 of process environment, Kubernetes Secret, ExternalSecret, connection
 pool, and client-construction details.
+
+The `state-cockroach` package now owns a generic SQL executor adapter and
+migration runner. The executor adapts a process-provided Cockroach client
+interface to the narrower statement executor contracts used by command
+state, outbox, event ingestion, and policy observations. This keeps the
+real database client and connection pool outside package code while
+still giving `apps/workers` one durable factory to compose.
 
 ## SOLID Rules
 
@@ -754,14 +766,28 @@ is introduced: non-secret operational values are parsed from typed env
 names, while URLs, credentials, and client construction remain reserved
 for process adapter factories supplied by the composition root.
 
-Minimum runtime environment contract:
+Current `apps/workers` process environment contract:
 
 ```text
 AGENTIC_ORG_ENV
 AGENTIC_ORG_ID
+COCKROACH_DATABASE_URL
 NATS_STREAM
 NATS_DURABLE
 NATS_INBOUND_BATCH_SIZE
+WORKER_INBOUND_BATCH_SIZE
+WORKER_OUTBOX_BATCH_SIZE
+```
+
+`COCKROACH_DATABASE_URL` is a secret-backed process adapter input. In
+the cluster it must be sourced from a Kubernetes Secret populated by
+External Secrets from Vault, not from a plain manifest or reusable
+package default.
+
+Future full deployment adapter environment will add service-specific
+values as their process adapters become real:
+
+```text
 TEMPORAL_ADDRESS
 HINDSIGHT_URL
 HERMES_URL
@@ -987,9 +1013,10 @@ Grafana.
    review staffing, QA staffing, blocker escalation, and late run
    incidents.
 10. Add runtime hosts. The first NodeNext `apps/workers` host now parses
-    typed process config and composes the worker and NATS consumer loops
-    through ports; NestJS API and richer worker process wiring are still
-    pending.
+    typed process config, composes the worker and NATS consumer loops
+    through ports, and has a durable Cockroach composition seam for
+    outbox/event-ingestion-backed worker execution; NestJS API and real
+    process client wiring are still pending.
 11. Add UI projections for work board, review center, and evidence
     timeline.
 12. Add real cluster adapters one at a time.

--- a/agentic-organization/docs/TECHNICAL_CA_PACKAGE_ARCHITECTURE.md
+++ b/agentic-organization/docs/TECHNICAL_CA_PACKAGE_ARCHITECTURE.md
@@ -135,11 +135,11 @@ legal transitions. It does not execute side effects.
 
 ### Layer 1: Application and Policy
 
-| Package                      | Owns                                                                                                      |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `@agentic-org/application`   | command handlers, handler registry, use cases, transaction orchestration, ports, command result contracts |
-| `@agentic-org/policy`        | RBAC, hat authority checks, OPA/Rego adapter boundary, policy decisions, denial reasons                   |
-| `@agentic-org/observability` | correlation envelope, OpenTelemetry helpers, required span attributes, trace propagation                  |
+| Package                      | Owns                                                                                                                        |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `@agentic-org/application`   | command handlers, handler registry, use cases, transaction orchestration, ports, command result contracts                   |
+| `@agentic-org/policy`        | RBAC, hat authority checks, OPA/Rego adapter boundary, policy decisions, denial reasons, observation store and reader ports |
+| `@agentic-org/observability` | correlation envelope, OpenTelemetry helpers, workflow visibility, required span attributes, trace propagation               |
 
 The application layer is the Organization OS command layer. It is where
 the runtime asks the Organization to do something.
@@ -166,22 +166,22 @@ calling them.
 
 ### Layer 3: State, Messaging, and Runtime Adapters
 
-| Package                                  | Owns                                                                                                           |
-| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `@agentic-org/state`                     | generic state-store, outbox-source, inbox, idempotency, transaction, and lease ports                           |
-| `@agentic-org/state-cockroach`           | first replaceable durable SQL implementation of state-store and outbox-source ports                            |
-| `@agentic-org/messaging`                 | NATS envelope builder, subject builder, JetStream publisher, consumer, DLQ, replay contracts                   |
-| `@agentic-org/messaging-nats`            | NATS JetStream implementation of publisher and consumer ports, canonical JSON, headers, ack/nack, and DLQ      |
-| `@agentic-org/workers`                   | small worker process boundary that composes outbox publishing, inbound ingestion, and schedulers through ports |
-| `@agentic-org/workflows-temporal`        | Temporal workflow and activity contracts, task queues, workflow clients                                        |
-| `@agentic-org/actors-dapr`               | Dapr actor interfaces, actor implementations, reminders, actor state projection                                |
-| `@agentic-org/mcp`                       | MCP schemas, tool registry, preflight checks, policy-checked tool handlers                                     |
-| `@agentic-org/hermes`                    | Hermes session adapter, run adapter, callback contract, run context builder                                    |
-| `@agentic-org/memory`                    | Hindsight adapter, hat-scoped recall/retain/reflect, memory attribution, memory health                         |
-| `@agentic-org/k8s-hats`                  | generated or checked Hat, HatBinding, HatSwap, HatPolicy types, informers, projection decoding                 |
-| `@agentic-org/openziti`                  | OpenZiti transport adapter, identity/config access, connectivity checks                                        |
-| `@agentic-org/credential-proxy`          | credential request adapter, scoped credential use, audit hooks                                                 |
-| `@agentic-org/adapters-agentic-services` | temporary wrappers around reused `agentic-services` primitives                                                 |
+| Package                                  | Owns                                                                                                                      |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `@agentic-org/state`                     | generic state-store, outbox-source, inbox, idempotency, transaction, and lease ports                                      |
+| `@agentic-org/state-cockroach`           | first replaceable durable SQL implementation of state-store, outbox-source, event-ingestion, and policy-observation ports |
+| `@agentic-org/messaging`                 | NATS envelope builder, subject builder, JetStream publisher, consumer, DLQ, replay contracts                              |
+| `@agentic-org/messaging-nats`            | NATS JetStream implementation of publisher and consumer ports, canonical JSON, headers, ack/nack, and DLQ                 |
+| `@agentic-org/workers`                   | small worker process boundary that composes outbox publishing, inbound ingestion, and schedulers through ports            |
+| `@agentic-org/workflows-temporal`        | Temporal workflow and activity contracts, task queues, workflow clients                                                   |
+| `@agentic-org/actors-dapr`               | Dapr actor interfaces, actor implementations, reminders, actor state projection                                           |
+| `@agentic-org/mcp`                       | MCP schemas, tool registry, preflight checks, policy-checked tool handlers                                                |
+| `@agentic-org/hermes`                    | Hermes session adapter, run adapter, callback contract, run context builder                                               |
+| `@agentic-org/memory`                    | Hindsight adapter, hat-scoped recall/retain/reflect, memory attribution, memory health                                    |
+| `@agentic-org/k8s-hats`                  | generated or checked Hat, HatBinding, HatSwap, HatPolicy types, informers, projection decoding                            |
+| `@agentic-org/openziti`                  | OpenZiti transport adapter, identity/config access, connectivity checks                                                   |
+| `@agentic-org/credential-proxy`          | credential request adapter, scoped credential use, audit hooks                                                            |
+| `@agentic-org/adapters-agentic-services` | temporary wrappers around reused `agentic-services` primitives                                                            |
 
 Adapters are replaceable. The Organization should be able to run a V0
 slice with in-process fakes, then swap in Temporal, Dapr, Hermes,
@@ -267,8 +267,10 @@ state persistence. Denied decisions are sent to a generic
 audit and outbox effects before command outcome persistence. OPA
 bundles, Kubernetes hat CRD watches, JWT validation, Organization DB
 assignment lookups, credential-proxy checks, and durable policy
-observation stores are later adapter implementations behind that policy
-boundary.
+observation stores are adapter implementations behind that policy
+boundary. The first durable observation implementation is the Cockroach
+adapter, but the command pipeline still depends only on the generic
+`PolicyDecisionObservationPort`.
 
 State-store ports are async at the application boundary. In-memory
 adapters may resolve immediately, but durable SQL, transactional outbox,
@@ -416,10 +418,13 @@ type AgenticEventEnvelope<TPayload> = {
 ```
 
 The current command-authorization slice records denied decisions through
-a generic policy observation port and attaches allowed policy decisions
-to audit/outbox effects. A durable policy-observation adapter and
-UI/agent-readable projection should be added before real API, MCP,
-Hermes, Temporal, or Dapr entrypoints are exposed.
+a generic policy observation port, persists those observations through a
+replaceable `PolicyDecisionObservationStore`, and attaches allowed policy
+decisions to audit/outbox effects. The first Cockroach policy-observation
+adapter stores a canonical observation hash so matching replays are
+idempotent while conflicting governance evidence is rejected. Its
+UI/agent-readable weak-point projection is now in place before real API,
+MCP, Hermes, Temporal, or Dapr entrypoints are exposed.
 
 No app should publish raw NATS payloads directly. Publishing should go
 through `@agentic-org/messaging`.
@@ -895,6 +900,10 @@ package should standardize:
   UI- and agent-readable health, stage, trace, scope, aggregate, and
   weak-point indicator fields, including policy decision ID and policy
   version when present.
+- policy-decision observation visibility records that project denied
+  command, tool, supervisor-chain, actor, scope, decision ID/version, and
+  denial reason into `policy_denied` weak-point indicators agents can
+  use to find authority, scope, and tool-grant gaps.
 - NATS consumer batch attributes for stream, durable consumer, received,
   processed, duplicate, payload-conflict, invalid, failed,
   acknowledged, negative-acknowledged, terminated, and dead-lettered

--- a/agentic-organization/docs/V0_POLICY_AND_RUNTIME_BOUNDARIES.md
+++ b/agentic-organization/docs/V0_POLICY_AND_RUNTIME_BOUNDARIES.md
@@ -151,6 +151,24 @@ full-ai-cluster/k8s/applications/agentic-organization/
   ServiceAccount/RBAC
 ```
 
+The TypeScript worker host now has the first durable composition seam
+that maps this cluster contract into package ports:
+
+```text
+ExternalSecret / Secret
+  -> COCKROACH_DATABASE_URL + worker/NATS batch env
+  -> apps/workers config parser
+  -> process-provided Cockroach client
+  -> state-cockroach generic SQL executor
+  -> Cockroach durable adapter factory
+  -> worker outbox + event-ingestion ports
+  -> Organization worker host
+```
+
+The concrete Cockroach client and pool are still process concerns. The
+application, runtime, policy, messaging, and worker packages see only
+generic Organization ports.
+
 The first docs-only and app-code PRs do not need deployment YAML. When
 deployment is added, it should follow the existing App-of-Apps model:
 

--- a/agentic-organization/docs/V0_POLICY_AND_RUNTIME_BOUNDARIES.md
+++ b/agentic-organization/docs/V0_POLICY_AND_RUNTIME_BOUNDARIES.md
@@ -67,9 +67,9 @@ V0 must enforce:
 - every denial returns a structured reason agents can learn from;
 - every denied command is observed through a policy decision observation
   port without creating successful business state;
-- durable policy decision observation storage and UI projection are added
-  before real API, MCP, Hermes, Temporal, or Dapr entrypoints are
-  exposed.
+- durable policy decision observation storage and UI/agent projection are
+  available before real API, MCP, Hermes, Temporal, or Dapr entrypoints
+  are exposed.
 
 ## MCP Preflight
 

--- a/agentic-organization/docs/V0_SCHEMA_AND_COMMANDS.md
+++ b/agentic-organization/docs/V0_SCHEMA_AND_COMMANDS.md
@@ -349,6 +349,14 @@ together. The first durable adapter uses CockroachDB, but the command
 model only depends on generic state ports. A worker publishes outbox
 rows to NATS JetStream and marks them published.
 
+The first Cockroach adapter set is composed through a generic SQL
+executor and durable adapter factory. The same executor shape backs
+command state, outbox publishing, event ingestion, policy observations,
+and the core migration runner. App hosts may bind that executor to a
+real Cockroach client, but domain, application, runtime, policy,
+messaging, and worker packages must not depend on the concrete client or
+connection pool.
+
 Subject shape:
 
 ```text

--- a/agentic-organization/docs/V0_SCHEMA_AND_COMMANDS.md
+++ b/agentic-organization/docs/V0_SCHEMA_AND_COMMANDS.md
@@ -103,18 +103,18 @@ matters.
 
 ### Runtime, Memory, Security, and Audit
 
-| Table                 | V0 responsibility                                                                                                                     |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `hermes_runs`         | Organization binding to a Hermes execution session                                                                                    |
-| `mcp_tool_calls`      | governed tool call attempts and results                                                                                               |
-| `memory_events`       | Hindsight recall, retain, reflect, and review attribution                                                                             |
-| `credential_requests` | requests to expand credential proxy or external tool scope                                                                            |
-| `signals`             | durable internal signals consumed by workers and UI read models                                                                       |
-| `audit_events`        | append-only policy and state-change audit trail with policy decision evidence when allowed                                            |
-| `outbox_events`       | transactional event publication source for NATS                                                                                       |
-| `policy_observations` | denied policy decision observations for UI, agents, and audit projections; allowed decisions are projected onto audit/outbox evidence |
-| `runtime_leases`      | scheduler, reconciler, and worker leases                                                                                              |
-| `idempotency_keys`    | command deduplication records                                                                                                         |
+| Table                 | V0 responsibility                                                                                                                                        |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hermes_runs`         | Organization binding to a Hermes execution session                                                                                                       |
+| `mcp_tool_calls`      | governed tool call attempts and results                                                                                                                  |
+| `memory_events`       | Hindsight recall, retain, reflect, and review attribution                                                                                                |
+| `credential_requests` | requests to expand credential proxy or external tool scope                                                                                               |
+| `signals`             | durable internal signals consumed by workers and UI read models                                                                                          |
+| `audit_events`        | append-only policy and state-change audit trail with policy decision evidence when allowed                                                               |
+| `outbox_events`       | transactional event publication source for NATS                                                                                                          |
+| `policy_observations` | durable, queryable denied policy decision observations for UI, agents, and audit projections; allowed decisions are projected onto audit/outbox evidence |
+| `runtime_leases`      | scheduler, reconciler, and worker leases                                                                                                                 |
+| `idempotency_keys`    | command deduplication records                                                                                                                            |
 
 ## V0 Enums
 
@@ -275,8 +275,18 @@ Every command handler must:
 Accepted command audit and outbox effects should carry the policy
 decision that allowed the command. Denied commands should not create
 business audit, outbox, or idempotency state; they should be observed
-through the policy decision observation port and later persisted by a
-dedicated durable adapter.
+through the policy decision observation port and persisted by a dedicated
+durable adapter.
+
+Policy observations are keyed by policy decision ID and include command,
+actor, hat assignment, organization, project, optional team/work item,
+tool type, supervisor-chain source/target levels, trace IDs, policy
+version, idempotency key, denial reason, a canonical observation hash,
+and the canonical observation JSON. Replays with the same policy
+decision ID and hash are idempotent; replays with the same policy
+decision ID and different evidence are conflicts and must not be hidden
+as safe duplicates. Readers must support scoped queries for agent/UI
+review without exposing CockroachDB types to application code.
 
 ## V0 Commands
 

--- a/agentic-organization/packages/README.md
+++ b/agentic-organization/packages/README.md
@@ -7,19 +7,19 @@ host, or Kubernetes deployment is introduced.
 
 ## Package Boundary
 
-| Package           | Current responsibility                                                                                                     |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `domain`          | typed command names, event names, aggregate names, work item state machine, event envelope, shared records                 |
-| `application`     | command pipeline, handler registry, idempotency handling, state-store ports, first supervisor-chain signal command handler |
-| `policy`          | generic command authorization port, hat-authority port, decision observation/store/reader ports, and typed denial reasons  |
-| `state`           | generic state-store and outbox-source ports plus the in-memory Organization state-store factory fake                       |
-| `state-cockroach` | first replaceable durable SQL adapter for state-store, outbox-source, event-ingestion, and policy-observation ports        |
-| `messaging`       | NATS subject contract, outbox publisher port, event publisher port, and domain resolver without a live NATS dependency     |
-| `messaging-nats`  | NATS JetStream publisher and consumer adapter contracts with canonical JSON, headers, ack/nack, and DLQ policy             |
-| `observability`   | LGTM/OpenTelemetry and workflow-visibility projection from events, NATS batches, worker cycles, and policy observations    |
-| `runtime`         | first event-to-automation reaction rule                                                                                    |
-| `workers`         | process-boundary worker host that composes outbox publishing and inbound ingestion through ports only                      |
-| `governance`      | package dependency-boundary checks that keep core packages SOLID and adapter-free                                          |
+| Package           | Current responsibility                                                                                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `domain`          | typed command names, event names, aggregate names, work item state machine, event envelope, shared records                                                          |
+| `application`     | command pipeline, handler registry, idempotency handling, state-store ports, first supervisor-chain signal command handler                                          |
+| `policy`          | generic command authorization port, hat-authority port, decision observation/store/reader ports, and typed denial reasons                                           |
+| `state`           | generic state-store and outbox-source ports plus the in-memory Organization state-store factory fake                                                                |
+| `state-cockroach` | first replaceable durable SQL adapter, generic SQL executor, migration runner, and adapter factory for state, outbox, event-ingestion, and policy-observation ports |
+| `messaging`       | NATS subject contract, outbox publisher port, event publisher port, and domain resolver without a live NATS dependency                                              |
+| `messaging-nats`  | NATS JetStream publisher and consumer adapter contracts with canonical JSON, headers, ack/nack, and DLQ policy                                                      |
+| `observability`   | LGTM/OpenTelemetry and workflow-visibility projection from events, NATS batches, worker cycles, and policy observations                                             |
+| `runtime`         | first event-to-automation reaction rule                                                                                                                             |
+| `workers`         | process-boundary worker host that composes outbox publishing and inbound ingestion through ports only                                                               |
+| `governance`      | package dependency-boundary checks that keep core packages SOLID and adapter-free                                                                                   |
 
 ## Slice Rule
 
@@ -45,10 +45,14 @@ supervisor-chain signal command
   -> automation reaction plan
 ```
 
-CockroachDB and NATS package adapters now exist behind these contracts;
-live process and cluster bindings for CockroachDB, JetStream publishing,
-Temporal, Dapr, Hermes, Hindsight, and the hat-system CRDs come next.
-They should not redefine command names, event names, state names,
+CockroachDB and NATS package adapters now exist behind these contracts.
+`state-cockroach` exposes one generic SQL executor seam, a migration
+runner, and a durable adapter factory so app hosts can bind Cockroach
+once and receive the command state, outbox, event-ingestion, and policy
+observation ports together. Live client construction for CockroachDB,
+JetStream publishing, Temporal, Dapr, Hermes, Hindsight, and the
+hat-system CRDs still belongs in process or cluster bindings. Those
+bindings must not redefine command names, event names, state names,
 correlation fields, or policy authority. CockroachDB is the first
 durable state adapter because it exists in `full-ai-cluster`; application
 and messaging code must remain database-agnostic so a later durable

--- a/agentic-organization/packages/README.md
+++ b/agentic-organization/packages/README.md
@@ -11,12 +11,12 @@ host, or Kubernetes deployment is introduced.
 | ----------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `domain`          | typed command names, event names, aggregate names, work item state machine, event envelope, shared records                 |
 | `application`     | command pipeline, handler registry, idempotency handling, state-store ports, first supervisor-chain signal command handler |
-| `policy`          | generic command authorization port, hat-authority port, decision observation port, and typed denial reasons                |
+| `policy`          | generic command authorization port, hat-authority port, decision observation/store/reader ports, and typed denial reasons  |
 | `state`           | generic state-store and outbox-source ports plus the in-memory Organization state-store factory fake                       |
-| `state-cockroach` | first replaceable durable SQL adapter for the state-store/outbox-source ports, backed by CockroachDB                       |
+| `state-cockroach` | first replaceable durable SQL adapter for state-store, outbox-source, event-ingestion, and policy-observation ports        |
 | `messaging`       | NATS subject contract, outbox publisher port, event publisher port, and domain resolver without a live NATS dependency     |
 | `messaging-nats`  | NATS JetStream publisher and consumer adapter contracts with canonical JSON, headers, ack/nack, and DLQ policy             |
-| `observability`   | LGTM/OpenTelemetry attribute projection from Agentic event envelopes and NATS consumer batch summaries                     |
+| `observability`   | LGTM/OpenTelemetry and workflow-visibility projection from events, NATS batches, worker cycles, and policy observations    |
 | `runtime`         | first event-to-automation reaction rule                                                                                    |
 | `workers`         | process-boundary worker host that composes outbox publishing and inbound ingestion through ports only                      |
 | `governance`      | package dependency-boundary checks that keep core packages SOLID and adapter-free                                          |
@@ -45,8 +45,9 @@ supervisor-chain signal command
   -> automation reaction plan
 ```
 
-CockroachDB, JetStream publishing, Temporal, Dapr, Hermes, Hindsight,
-and the hat-system CRDs come next as adapters behind these contracts.
+CockroachDB and NATS package adapters now exist behind these contracts;
+live process and cluster bindings for CockroachDB, JetStream publishing,
+Temporal, Dapr, Hermes, Hindsight, and the hat-system CRDs come next.
 They should not redefine command names, event names, state names,
 correlation fields, or policy authority. CockroachDB is the first
 durable state adapter because it exists in `full-ai-cluster`; application
@@ -71,6 +72,16 @@ outbox effects before durable command persistence. Future OPA,
 hat-system, JWT, Organization DB, or policy-observation adapters must
 implement these ports instead of leaking vendor clients into command
 code.
+
+The policy package separates observation from durability:
+`PolicyDecisionObservationPort` is the command-pipeline dependency,
+`PolicyDecisionObservationStore` records idempotent durable observations,
+and `PolicyDecisionObservationReader` exposes queryable governance
+evidence for UI and agents. Observation stores must distinguish matching
+replay from conflicting evidence; the Cockroach adapter does that with a
+canonical observation hash while keeping the hash behind the generic
+policy contracts. CockroachDB is only the first implementation of those
+generic contracts.
 
 Production source and test source are separated by package. Application
 code lives under `packages/<name>/src`; tests live under

--- a/agentic-organization/packages/application/src/command-pipeline.ts
+++ b/agentic-organization/packages/application/src/command-pipeline.ts
@@ -152,6 +152,7 @@ function createCommandAuthorizationRequest(command: PipelineCommand): CommandAut
       correlationId: command.correlationId,
       causationId: command.causationId,
       traceId: command.traceId,
+      idempotencyKey: command.idempotencyKey,
     },
   };
 }
@@ -180,6 +181,7 @@ function createPolicyDecisionObservation(
       correlationId: command.correlationId,
       causationId: command.causationId,
       traceId: command.traceId,
+      idempotencyKey: command.idempotencyKey,
     },
     decision,
     observedAt,

--- a/agentic-organization/packages/application/src/command-pipeline.ts
+++ b/agentic-organization/packages/application/src/command-pipeline.ts
@@ -2,6 +2,7 @@ import type { CommandHandlerRegistry } from "./command-handler-registry.ts";
 import { CommandErrorCode, CommandResultStatus, type CommandResult } from "./command-result.ts";
 import type { SendSupervisorSignalCommand } from "./handlers/send-supervisor-signal.ts";
 import {
+  PolicyDecisionObservationPersistenceStatus,
   PolicyDecisionStatus,
   type CommandAuthorizationPort,
   type CommandAuthorizationRequest,
@@ -51,9 +52,12 @@ async function executeCommand(
 
   if (authorizationDecision.status === PolicyDecisionStatus.Denied) {
     try {
-      await dependencies.policyDecisionObservationPort.observePolicyDecision(
+      const observationResult = await dependencies.policyDecisionObservationPort.observePolicyDecision(
         createPolicyDecisionObservation(command, authorizationDecision, dependencies.now()),
       );
+      if (observationResult.status === PolicyDecisionObservationPersistenceStatus.Conflict) {
+        return createPolicyObservationConflictResult(authorizationDecision);
+      }
     } catch {
       return {
         status: CommandResultStatus.Rejected,
@@ -244,6 +248,23 @@ function createIdempotencyConflictResult(): CommandResult {
     error: {
       code: CommandErrorCode.IdempotencyConflict,
       message: "idempotency key was reused with a different request hash",
+    },
+  };
+}
+
+function createPolicyObservationConflictResult(decision: Extract<PolicyDecision, { status: "denied" }>): CommandResult {
+  return {
+    status: CommandResultStatus.Rejected,
+    idempotency: {
+      replayed: false,
+    },
+    error: {
+      code: CommandErrorCode.PolicyObservationConflict,
+      message: "command denied but policy decision observation conflicts with existing governance evidence",
+      policyDecisionId: decision.decisionId,
+      policyVersion: decision.policyVersion,
+      reason: decision.reason,
+      observationFailureReason: "policy_decision_observation_conflict",
     },
   };
 }

--- a/agentic-organization/packages/application/src/command-result.ts
+++ b/agentic-organization/packages/application/src/command-result.ts
@@ -11,6 +11,7 @@ export type CommandResultStatus = (typeof CommandResultStatus)[keyof typeof Comm
 export const CommandErrorCode = {
   IdempotencyConflict: "idempotency_conflict",
   PolicyDenied: "policy_denied",
+  PolicyObservationConflict: "policy_observation_conflict",
   PolicyObservationFailed: "policy_observation_failed",
   UnsupportedCommand: "unsupported_command",
 } as const;

--- a/agentic-organization/packages/application/test/command-pipeline.test.ts
+++ b/agentic-organization/packages/application/test/command-pipeline.test.ts
@@ -4,6 +4,7 @@ import { describe, test } from "node:test";
 import { CommandType, SupervisorChainLevel, SupervisorSignalToolType } from "../../domain/src/index.ts";
 import {
   HatAuthorityDecisionStatus,
+  PolicyDecisionObservationPersistenceStatus,
   PolicyDecisionStatus,
   type CommandAuthorizationPort,
   type CommandAuthorizationRequest,
@@ -304,6 +305,31 @@ describe("command pipeline idempotency", () => {
     equal(stateStoreFactory.findCallCount, 0);
     equal(stateStoreFactory.recordedOutcomes.length, 0);
   });
+
+  test("distinguishes conflicting policy observations from transient observation failures", async () => {
+    const stateStoreFactory = createRecordingCommandStateStoreFactory<CommandResult>();
+    const deniedHandler = createRecordingCommandHandler();
+    const pipeline = createCommandPipeline({
+      stateStoreFactory,
+      commandAuthorizationPort: createDenyingCommandAuthorizationPort("policy-decision-denied-001"),
+      policyDecisionObservationPort: createRecordingPolicyDecisionObservationPort(
+        PolicyDecisionObservationPersistenceStatus.Conflict,
+      ),
+      handlerRegistry: createCommandHandlerRegistry([deniedHandler]),
+      now: () => "2026-05-25T20:00:00.000Z",
+      createId: (prefix) => `${prefix}-001`,
+    });
+
+    const result = await pipeline.execute(command);
+
+    equal(result.status, CommandResultStatus.Rejected);
+    equal(result.error?.code, CommandErrorCode.PolicyObservationConflict);
+    equal(result.error?.policyDecisionId, "policy-decision-denied-001");
+    equal(result.error?.observationFailureReason, "policy_decision_observation_conflict");
+    equal(deniedHandler.executeCallCount, 0);
+    equal(stateStoreFactory.findCallCount, 0);
+    equal(stateStoreFactory.recordedOutcomes.length, 0);
+  });
 });
 
 type RecordingCommandStateStoreFactory<Result> = CommandStateStoreFactory<Result> & {
@@ -347,7 +373,9 @@ function createAllowingCommandAuthorizationPort(): CommandAuthorizationPort {
   };
 }
 
-function createRecordingPolicyDecisionObservationPort(): PolicyDecisionObservationPort & {
+function createRecordingPolicyDecisionObservationPort(
+  status: PolicyDecisionObservationPersistenceStatus = PolicyDecisionObservationPersistenceStatus.Recorded,
+): PolicyDecisionObservationPort & {
   observations: PolicyDecisionObservation[];
 } {
   const observations: PolicyDecisionObservation[] = [];
@@ -356,6 +384,7 @@ function createRecordingPolicyDecisionObservationPort(): PolicyDecisionObservati
     observations,
     observePolicyDecision: async (observation) => {
       observations.push(observation);
+      return { status };
     },
   };
 }

--- a/agentic-organization/packages/application/test/command-pipeline.test.ts
+++ b/agentic-organization/packages/application/test/command-pipeline.test.ts
@@ -243,6 +243,7 @@ describe("command pipeline idempotency", () => {
           correlationId: command.correlationId,
           causationId: command.causationId,
           traceId: command.traceId,
+          idempotencyKey: command.idempotencyKey,
         },
         decision: {
           status: PolicyDecisionStatus.Denied,
@@ -273,6 +274,7 @@ describe("command pipeline idempotency", () => {
         correlationId: command.correlationId,
         causationId: command.causationId,
         traceId: command.traceId,
+        idempotencyKey: command.idempotencyKey,
       },
     });
     equal(deniedHandler.executeCallCount, 0);

--- a/agentic-organization/packages/observability/src/index.ts
+++ b/agentic-organization/packages/observability/src/index.ts
@@ -20,10 +20,14 @@ export {
 } from "./worker-cycle-attributes.ts";
 export {
   VisibilityHealth,
+  PolicyDecisionVisibilityStage,
   WeakPointIndicatorType,
   WorkflowObservationKind,
+  buildPolicyDecisionObservationVisibilityRecord,
   buildWorkflowVisibilityRecord,
+  type BuildPolicyDecisionObservationVisibilityRecordInput,
   type BuildWorkflowVisibilityRecordInput,
+  type PolicyDecisionObservationVisibilityRecord,
   type VisibilityLinks,
   type WeakPointIndicator,
   type WorkflowVisibilityRecord,

--- a/agentic-organization/packages/observability/src/workflow-visibility.ts
+++ b/agentic-organization/packages/observability/src/workflow-visibility.ts
@@ -1,4 +1,9 @@
 import type { AgenticAggregateType, AgenticEventEnvelope, AgenticEventType } from "../../domain/src/index.ts";
+import {
+  PolicyDecisionStatus,
+  type PolicyDecisionObservation,
+  type PolicyDenialReason,
+} from "../../policy/src/index.ts";
 
 export const WorkflowObservationKind = {
   SupervisorSignal: "supervisor_signal",
@@ -8,6 +13,7 @@ export const WorkflowObservationKind = {
   HermesRun: "hermes_run",
   Gate: "gate",
   ScheduleBlock: "schedule_block",
+  PolicyDecision: "policy_decision",
 } as const;
 
 export type WorkflowObservationKind = (typeof WorkflowObservationKind)[keyof typeof WorkflowObservationKind];
@@ -34,6 +40,14 @@ export const WeakPointIndicatorType = {
 } as const;
 
 export type WeakPointIndicatorType = (typeof WeakPointIndicatorType)[keyof typeof WeakPointIndicatorType];
+
+export const PolicyDecisionVisibilityStage = {
+  Allowed: "policy_allowed",
+  Denied: "policy_denied",
+} as const;
+
+export type PolicyDecisionVisibilityStage =
+  (typeof PolicyDecisionVisibilityStage)[keyof typeof PolicyDecisionVisibilityStage];
 
 export type VisibilityLinks = {
   traceUrl: string;
@@ -75,12 +89,44 @@ export type WorkflowVisibilityRecord = {
   weakPointIndicators: WeakPointIndicator[];
 };
 
+export type PolicyDecisionObservationVisibilityRecord = {
+  observationKind: typeof WorkflowObservationKind.PolicyDecision;
+  health: VisibilityHealth;
+  stage: PolicyDecisionVisibilityStage;
+  occurredAt: string;
+  commandId: string;
+  commandType: PolicyDecisionObservation["commandType"];
+  correlationId: string;
+  causationId: string;
+  traceId: string;
+  idempotencyKey: string;
+  organizationId: string;
+  projectId: string;
+  teamId?: string;
+  workItemId?: string;
+  agentId: string;
+  hatAssignmentId: string;
+  toolType?: PolicyDecisionObservation["toolType"];
+  sourceLevel?: NonNullable<PolicyDecisionObservation["supervisorChain"]>["sourceLevel"];
+  targetLevel?: NonNullable<PolicyDecisionObservation["supervisorChain"]>["targetLevel"];
+  policyDecisionId: string;
+  policyVersion: string;
+  policyDecisionStatus: PolicyDecisionObservation["decision"]["status"];
+  policyDenialReason?: PolicyDenialReason;
+  links: VisibilityLinks;
+  weakPointIndicators: WeakPointIndicator[];
+};
+
 export type BuildWorkflowVisibilityRecordInput = {
   observationKind: WorkflowObservationKind;
   health: VisibilityHealth;
   stage: string;
   links: VisibilityLinks;
   weakPointIndicators?: WeakPointIndicator[];
+};
+
+export type BuildPolicyDecisionObservationVisibilityRecordInput = {
+  links: VisibilityLinks;
 };
 
 export function buildWorkflowVisibilityRecord(
@@ -122,6 +168,72 @@ export function buildWorkflowVisibilityRecord(
   if (envelope.policy !== undefined) {
     record.policyDecisionId = envelope.policy.decisionId;
     record.policyVersion = envelope.policy.policyVersion;
+  }
+
+  return record;
+}
+
+export function buildPolicyDecisionObservationVisibilityRecord(
+  observation: PolicyDecisionObservation,
+  input: BuildPolicyDecisionObservationVisibilityRecordInput,
+): PolicyDecisionObservationVisibilityRecord {
+  const record: PolicyDecisionObservationVisibilityRecord = {
+    observationKind: WorkflowObservationKind.PolicyDecision,
+    health:
+      observation.decision.status === PolicyDecisionStatus.Denied ? VisibilityHealth.Blocked : VisibilityHealth.Healthy,
+    stage:
+      observation.decision.status === PolicyDecisionStatus.Denied
+        ? PolicyDecisionVisibilityStage.Denied
+        : PolicyDecisionVisibilityStage.Allowed,
+    occurredAt: observation.observedAt,
+    commandId: observation.commandId,
+    commandType: observation.commandType,
+    correlationId: observation.trace.correlationId,
+    causationId: observation.trace.causationId,
+    traceId: observation.trace.traceId,
+    idempotencyKey: observation.trace.idempotencyKey,
+    organizationId: observation.scope.organizationId,
+    projectId: observation.scope.projectId,
+    agentId: observation.actor.agentId,
+    hatAssignmentId: observation.actor.hatAssignmentId,
+    policyDecisionId: observation.decision.decisionId,
+    policyVersion: observation.decision.policyVersion,
+    policyDecisionStatus: observation.decision.status,
+    links: input.links,
+    weakPointIndicators:
+      observation.decision.status === PolicyDecisionStatus.Denied
+        ? [
+            {
+              indicatorType: WeakPointIndicatorType.PolicyDenied,
+              summary: `Policy denied ${observation.commandType} for ${observation.toolType ?? "unspecified_tool"}`,
+              suggestedAction: "Review hat authority, scope, and tool grant before retrying the command",
+            },
+          ]
+        : [],
+  };
+
+  if (observation.scope.teamId !== undefined) {
+    record.teamId = observation.scope.teamId;
+  }
+
+  if (observation.scope.workItemId !== undefined) {
+    record.workItemId = observation.scope.workItemId;
+  }
+
+  if (observation.toolType !== undefined) {
+    record.toolType = observation.toolType;
+  }
+
+  if (observation.supervisorChain?.sourceLevel !== undefined) {
+    record.sourceLevel = observation.supervisorChain.sourceLevel;
+  }
+
+  if (observation.supervisorChain?.targetLevel !== undefined) {
+    record.targetLevel = observation.supervisorChain.targetLevel;
+  }
+
+  if (observation.decision.status === PolicyDecisionStatus.Denied) {
+    record.policyDenialReason = observation.decision.reason;
   }
 
   return record;

--- a/agentic-organization/packages/observability/test/workflow-visibility.test.ts
+++ b/agentic-organization/packages/observability/test/workflow-visibility.test.ts
@@ -4,15 +4,19 @@ import { describe, test } from "node:test";
 import {
   AgenticAggregateType,
   AgenticEventType,
+  CommandType,
   SupervisorChainLevel,
   SupervisorSignalStatus,
   SupervisorSignalToolType,
   createAgenticEventEnvelope,
 } from "../../domain/src/index.ts";
+import { HatAuthorityDecisionStatus, PolicyDecisionStatus } from "../../policy/src/index.ts";
 import {
+  PolicyDecisionVisibilityStage,
   VisibilityHealth,
   WeakPointIndicatorType,
   WorkflowObservationKind,
+  buildPolicyDecisionObservationVisibilityRecord,
   buildWorkflowVisibilityRecord,
 } from "../src/workflow-visibility.ts";
 
@@ -109,6 +113,89 @@ describe("workflow visibility records", () => {
             indicatorType: WeakPointIndicatorType.BlockedWork,
             summary: "Work is waiting on supervisor triage",
             suggestedAction: "Engineering manager should triage the signal",
+          },
+        ],
+      },
+    );
+  });
+
+  test("builds policy-denial visibility for agent and UI weak-point review", () => {
+    deepEqual(
+      buildPolicyDecisionObservationVisibilityRecord(
+        {
+          commandId: "cmd-supervisor-signal-001",
+          commandType: CommandType.SendSupervisorSignal,
+          actor: {
+            agentId: "agent-developer-001",
+            hatAssignmentId: "hat-assignment-dev-001",
+          },
+          scope: {
+            organizationId: "org-lfg",
+            projectId: "project-agentic-org",
+            teamId: "team-runtime",
+            workItemId: "work-outbox-001",
+          },
+          toolType: SupervisorSignalToolType.ReportBlocker,
+          supervisorChain: {
+            sourceLevel: SupervisorChainLevel.TeamMember,
+            targetLevel: SupervisorChainLevel.Manager,
+          },
+          trace: {
+            correlationId: "corr-supervisor-signal-001",
+            causationId: "cause-team-work-001",
+            traceId: "trace-supervisor-signal-001",
+            idempotencyKey: "idem-supervisor-signal-001",
+          },
+          decision: {
+            status: PolicyDecisionStatus.Denied,
+            decisionId: "policy-decision-denied-001",
+            policyVersion: "policy-v1",
+            reason: HatAuthorityDecisionStatus.ToolDenied,
+          },
+          observedAt: "2026-05-25T20:00:00.000Z",
+        },
+        {
+          links: {
+            traceUrl: "https://grafana.example/explore?trace=trace-supervisor-signal-001",
+            logsUrl: "https://grafana.example/explore?logs=work-outbox-001",
+            metricsUrl: "https://grafana.example/d/agentic-org",
+          },
+        },
+      ),
+      {
+        observationKind: WorkflowObservationKind.PolicyDecision,
+        health: VisibilityHealth.Blocked,
+        stage: PolicyDecisionVisibilityStage.Denied,
+        occurredAt: "2026-05-25T20:00:00.000Z",
+        commandId: "cmd-supervisor-signal-001",
+        commandType: CommandType.SendSupervisorSignal,
+        correlationId: "corr-supervisor-signal-001",
+        causationId: "cause-team-work-001",
+        traceId: "trace-supervisor-signal-001",
+        idempotencyKey: "idem-supervisor-signal-001",
+        organizationId: "org-lfg",
+        projectId: "project-agentic-org",
+        teamId: "team-runtime",
+        workItemId: "work-outbox-001",
+        agentId: "agent-developer-001",
+        hatAssignmentId: "hat-assignment-dev-001",
+        toolType: SupervisorSignalToolType.ReportBlocker,
+        sourceLevel: SupervisorChainLevel.TeamMember,
+        targetLevel: SupervisorChainLevel.Manager,
+        policyDecisionId: "policy-decision-denied-001",
+        policyVersion: "policy-v1",
+        policyDecisionStatus: PolicyDecisionStatus.Denied,
+        policyDenialReason: HatAuthorityDecisionStatus.ToolDenied,
+        links: {
+          traceUrl: "https://grafana.example/explore?trace=trace-supervisor-signal-001",
+          logsUrl: "https://grafana.example/explore?logs=work-outbox-001",
+          metricsUrl: "https://grafana.example/d/agentic-org",
+        },
+        weakPointIndicators: [
+          {
+            indicatorType: WeakPointIndicatorType.PolicyDenied,
+            summary: "Policy denied send_supervisor_signal for report_blocker",
+            suggestedAction: "Review hat authority, scope, and tool grant before retrying the command",
           },
         ],
       },

--- a/agentic-organization/packages/policy/src/index.ts
+++ b/agentic-organization/packages/policy/src/index.ts
@@ -41,6 +41,7 @@ export type CommandAuthorizationTrace = {
   correlationId: string;
   causationId: string;
   traceId: string;
+  idempotencyKey: string;
 };
 
 export type CommandAuthorizationSupervisorChain = {
@@ -100,6 +101,55 @@ export type PolicyDecisionObservation = {
   observedAt: string;
 };
 
+export const PolicyDecisionObservationPersistenceStatus = {
+  Recorded: "recorded",
+  Duplicate: "duplicate",
+  Conflict: "conflict",
+} as const;
+
+export type PolicyDecisionObservationPersistenceStatus =
+  (typeof PolicyDecisionObservationPersistenceStatus)[keyof typeof PolicyDecisionObservationPersistenceStatus];
+
+export type RecordPolicyDecisionObservationResult =
+  | {
+      status: typeof PolicyDecisionObservationPersistenceStatus.Recorded;
+    }
+  | {
+      status: typeof PolicyDecisionObservationPersistenceStatus.Duplicate;
+    }
+  | {
+      status: typeof PolicyDecisionObservationPersistenceStatus.Conflict;
+    };
+
+export const PolicyDecisionObservationErrorCode = {
+  Conflict: "policy_decision_observation_conflict",
+} as const;
+
+export type PolicyDecisionObservationErrorCode =
+  (typeof PolicyDecisionObservationErrorCode)[keyof typeof PolicyDecisionObservationErrorCode];
+
+export class PolicyDecisionObservationConflictError extends Error {
+  readonly code = PolicyDecisionObservationErrorCode.Conflict;
+  readonly policyDecisionId: string;
+
+  constructor(policyDecisionId: string) {
+    super("policy decision observation conflicts with existing governance evidence");
+    this.name = "PolicyDecisionObservationConflictError";
+    this.policyDecisionId = policyDecisionId;
+  }
+}
+
+export type PolicyDecisionObservationQuery = {
+  organizationId: string;
+  projectId?: string;
+  teamId?: string;
+  workItemId?: string;
+  agentId?: string;
+  hatAssignmentId?: string;
+  decisionStatus?: PolicyDecisionStatus;
+  limit: number;
+};
+
 export type HatAuthorityPort = {
   evaluateHatAuthority: (request: HatAuthorityRequest) => Promise<HatAuthorityDecision>;
 };
@@ -112,8 +162,24 @@ export type PolicyDecisionObservationPort = {
   observePolicyDecision: (observation: PolicyDecisionObservation) => Promise<void>;
 };
 
+export type PolicyDecisionObservationStore = {
+  recordPolicyDecisionObservation: (
+    observation: PolicyDecisionObservation,
+  ) => Promise<RecordPolicyDecisionObservationResult>;
+};
+
+export type PolicyDecisionObservationReader = {
+  findPolicyDecisionObservations: (
+    query: PolicyDecisionObservationQuery,
+  ) => Promise<readonly PolicyDecisionObservation[]>;
+};
+
 export type CreateCommandAuthorizationPortInput = {
   hatAuthorityPort: HatAuthorityPort;
+};
+
+export type CreatePolicyDecisionObservationPortInput = {
+  store: PolicyDecisionObservationStore;
 };
 
 export function createCommandAuthorizationPort(input: CreateCommandAuthorizationPortInput): CommandAuthorizationPort {
@@ -139,6 +205,20 @@ export function createCommandAuthorizationPort(input: CreateCommandAuthorization
         policyVersion: hatAuthorityDecision.policyVersion,
         reason: hatAuthorityDecision.status,
       };
+    },
+  };
+}
+
+export function createPolicyDecisionObservationPort(
+  input: CreatePolicyDecisionObservationPortInput,
+): PolicyDecisionObservationPort {
+  return {
+    observePolicyDecision: async (observation) => {
+      const result = await input.store.recordPolicyDecisionObservation(observation);
+
+      if (result.status === PolicyDecisionObservationPersistenceStatus.Conflict) {
+        throw new PolicyDecisionObservationConflictError(observation.decision.decisionId);
+      }
     },
   };
 }

--- a/agentic-organization/packages/policy/src/index.ts
+++ b/agentic-organization/packages/policy/src/index.ts
@@ -121,24 +121,6 @@ export type RecordPolicyDecisionObservationResult =
       status: typeof PolicyDecisionObservationPersistenceStatus.Conflict;
     };
 
-export const PolicyDecisionObservationErrorCode = {
-  Conflict: "policy_decision_observation_conflict",
-} as const;
-
-export type PolicyDecisionObservationErrorCode =
-  (typeof PolicyDecisionObservationErrorCode)[keyof typeof PolicyDecisionObservationErrorCode];
-
-export class PolicyDecisionObservationConflictError extends Error {
-  readonly code = PolicyDecisionObservationErrorCode.Conflict;
-  readonly policyDecisionId: string;
-
-  constructor(policyDecisionId: string) {
-    super("policy decision observation conflicts with existing governance evidence");
-    this.name = "PolicyDecisionObservationConflictError";
-    this.policyDecisionId = policyDecisionId;
-  }
-}
-
 export type PolicyDecisionObservationQuery = {
   organizationId: string;
   projectId?: string;
@@ -159,7 +141,7 @@ export type CommandAuthorizationPort = {
 };
 
 export type PolicyDecisionObservationPort = {
-  observePolicyDecision: (observation: PolicyDecisionObservation) => Promise<void>;
+  observePolicyDecision: (observation: PolicyDecisionObservation) => Promise<RecordPolicyDecisionObservationResult>;
 };
 
 export type PolicyDecisionObservationStore = {
@@ -213,12 +195,6 @@ export function createPolicyDecisionObservationPort(
   input: CreatePolicyDecisionObservationPortInput,
 ): PolicyDecisionObservationPort {
   return {
-    observePolicyDecision: async (observation) => {
-      const result = await input.store.recordPolicyDecisionObservation(observation);
-
-      if (result.status === PolicyDecisionObservationPersistenceStatus.Conflict) {
-        throw new PolicyDecisionObservationConflictError(observation.decision.decisionId);
-      }
-    },
+    observePolicyDecision: async (observation) => await input.store.recordPolicyDecisionObservation(observation),
   };
 }

--- a/agentic-organization/packages/policy/test/command-authorization.test.ts
+++ b/agentic-organization/packages/policy/test/command-authorization.test.ts
@@ -106,6 +106,7 @@ function createCommandAuthorizationRequest() {
       correlationId: "corr-supervisor-signal-001",
       causationId: "cause-team-work-001",
       traceId: "trace-supervisor-signal-001",
+      idempotencyKey: "idem-supervisor-signal-001",
     },
   };
 }

--- a/agentic-organization/packages/policy/test/policy-decision-observation.test.ts
+++ b/agentic-organization/packages/policy/test/policy-decision-observation.test.ts
@@ -1,10 +1,9 @@
-import { equal, rejects } from "node:assert/strict";
+import { equal } from "node:assert/strict";
 import { describe, test } from "node:test";
 
 import { CommandType, SupervisorChainLevel, SupervisorSignalToolType } from "../../domain/src/index.ts";
 import {
   HatAuthorityDecisionStatus,
-  PolicyDecisionObservationConflictError,
   PolicyDecisionObservationPersistenceStatus,
   PolicyDecisionStatus,
   createPolicyDecisionObservationPort,
@@ -18,8 +17,9 @@ describe("policy decision observation port", () => {
     const port = createPolicyDecisionObservationPort({ store });
     const observation = createDeniedPolicyDecisionObservation();
 
-    await port.observePolicyDecision(observation);
+    const result = await port.observePolicyDecision(observation);
 
+    equal(result.status, PolicyDecisionObservationPersistenceStatus.Recorded);
     equal(store.recordedObservations.length, 1);
     equal(store.recordedObservations[0], observation);
   });
@@ -30,23 +30,21 @@ describe("policy decision observation port", () => {
     });
     const port = createPolicyDecisionObservationPort({ store });
 
-    await port.observePolicyDecision(createDeniedPolicyDecisionObservation());
+    const result = await port.observePolicyDecision(createDeniedPolicyDecisionObservation());
 
+    equal(result.status, PolicyDecisionObservationPersistenceStatus.Duplicate);
     equal(store.recordedObservations.length, 1);
   });
 
-  test("rejects conflicting observations instead of hiding contradictory governance evidence", async () => {
+  test("returns conflicting observations instead of hiding contradictory governance evidence", async () => {
     const store = createRecordingPolicyDecisionObservationStore({
       status: PolicyDecisionObservationPersistenceStatus.Conflict,
     });
     const port = createPolicyDecisionObservationPort({ store });
 
-    await rejects(
-      async () => await port.observePolicyDecision(createDeniedPolicyDecisionObservation()),
-      (error) =>
-        error instanceof PolicyDecisionObservationConflictError &&
-        error.policyDecisionId === "policy-decision-denied-001",
-    );
+    const result = await port.observePolicyDecision(createDeniedPolicyDecisionObservation());
+
+    equal(result.status, PolicyDecisionObservationPersistenceStatus.Conflict);
   });
 });
 

--- a/agentic-organization/packages/policy/test/policy-decision-observation.test.ts
+++ b/agentic-organization/packages/policy/test/policy-decision-observation.test.ts
@@ -1,0 +1,104 @@
+import { equal, rejects } from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { CommandType, SupervisorChainLevel, SupervisorSignalToolType } from "../../domain/src/index.ts";
+import {
+  HatAuthorityDecisionStatus,
+  PolicyDecisionObservationConflictError,
+  PolicyDecisionObservationPersistenceStatus,
+  PolicyDecisionStatus,
+  createPolicyDecisionObservationPort,
+  type PolicyDecisionObservation,
+  type PolicyDecisionObservationStore,
+} from "../src/index.ts";
+
+describe("policy decision observation port", () => {
+  test("records denied policy observations through a generic store", async () => {
+    const store = createRecordingPolicyDecisionObservationStore();
+    const port = createPolicyDecisionObservationPort({ store });
+    const observation = createDeniedPolicyDecisionObservation();
+
+    await port.observePolicyDecision(observation);
+
+    equal(store.recordedObservations.length, 1);
+    equal(store.recordedObservations[0], observation);
+  });
+
+  test("treats duplicate observations as already durable", async () => {
+    const store = createRecordingPolicyDecisionObservationStore({
+      status: PolicyDecisionObservationPersistenceStatus.Duplicate,
+    });
+    const port = createPolicyDecisionObservationPort({ store });
+
+    await port.observePolicyDecision(createDeniedPolicyDecisionObservation());
+
+    equal(store.recordedObservations.length, 1);
+  });
+
+  test("rejects conflicting observations instead of hiding contradictory governance evidence", async () => {
+    const store = createRecordingPolicyDecisionObservationStore({
+      status: PolicyDecisionObservationPersistenceStatus.Conflict,
+    });
+    const port = createPolicyDecisionObservationPort({ store });
+
+    await rejects(
+      async () => await port.observePolicyDecision(createDeniedPolicyDecisionObservation()),
+      (error) =>
+        error instanceof PolicyDecisionObservationConflictError &&
+        error.policyDecisionId === "policy-decision-denied-001",
+    );
+  });
+});
+
+function createRecordingPolicyDecisionObservationStore(
+  input: { status?: PolicyDecisionObservationPersistenceStatus } = {},
+): PolicyDecisionObservationStore & {
+  recordedObservations: PolicyDecisionObservation[];
+} {
+  const recordedObservations: PolicyDecisionObservation[] = [];
+
+  return {
+    recordedObservations,
+    recordPolicyDecisionObservation: async (observation) => {
+      recordedObservations.push(observation);
+      return {
+        status: input.status ?? PolicyDecisionObservationPersistenceStatus.Recorded,
+      };
+    },
+  };
+}
+
+function createDeniedPolicyDecisionObservation(): PolicyDecisionObservation {
+  return {
+    commandId: "cmd-supervisor-signal-001",
+    commandType: CommandType.SendSupervisorSignal,
+    actor: {
+      agentId: "agent-developer-001",
+      hatAssignmentId: "hat-assignment-dev-001",
+    },
+    scope: {
+      organizationId: "org-lfg",
+      projectId: "project-agentic-org",
+      teamId: "team-runtime",
+      workItemId: "work-outbox-001",
+    },
+    toolType: SupervisorSignalToolType.ReportBlocker,
+    supervisorChain: {
+      sourceLevel: SupervisorChainLevel.TeamMember,
+      targetLevel: SupervisorChainLevel.Manager,
+    },
+    trace: {
+      correlationId: "corr-supervisor-signal-001",
+      causationId: "cause-team-work-001",
+      traceId: "trace-supervisor-signal-001",
+      idempotencyKey: "idem-supervisor-signal-001",
+    },
+    decision: {
+      status: PolicyDecisionStatus.Denied,
+      decisionId: "policy-decision-denied-001",
+      policyVersion: "policy-v1",
+      reason: HatAuthorityDecisionStatus.ToolDenied,
+    },
+    observedAt: "2026-05-25T20:00:00.000Z",
+  };
+}

--- a/agentic-organization/packages/state-cockroach/migrations/0001_agentic_org_core_state.sql
+++ b/agentic-organization/packages/state-cockroach/migrations/0001_agentic_org_core_state.sql
@@ -81,3 +81,28 @@ CREATE TABLE IF NOT EXISTS agentic_org_idempotency_records (
   request_hash STRING NOT NULL,
   result_json JSONB NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS agentic_org_policy_observations (
+  policy_decision_id STRING PRIMARY KEY,
+  policy_version STRING NOT NULL,
+  decision_status STRING NOT NULL,
+  denial_reason STRING,
+  command_id STRING NOT NULL,
+  command_type STRING NOT NULL,
+  organization_id STRING NOT NULL,
+  project_id STRING NOT NULL,
+  team_id STRING,
+  work_item_id STRING,
+  actor_agent_id STRING NOT NULL,
+  actor_hat_assignment_id STRING NOT NULL,
+  tool_type STRING,
+  source_level STRING,
+  target_level STRING,
+  correlation_id STRING NOT NULL,
+  causation_id STRING NOT NULL,
+  trace_id STRING NOT NULL,
+  idempotency_key STRING NOT NULL,
+  observation_hash STRING NOT NULL,
+  observation_json JSONB NOT NULL,
+  observed_at TIMESTAMPTZ NOT NULL
+);

--- a/agentic-organization/packages/state-cockroach/src/cockroach-durable-state-adapters.ts
+++ b/agentic-organization/packages/state-cockroach/src/cockroach-durable-state-adapters.ts
@@ -1,0 +1,51 @@
+import type { CommandStateStoreFactory } from "../../application/src/ports.ts";
+import type { OutboxEventSource } from "../../state/src/index.ts";
+import type { EventIngestionStore } from "../../state/src/index.ts";
+import type { CockroachGenericSqlExecutor } from "./cockroach-sql-executor.ts";
+import { createCockroachCommandStateStoreFactory, type CockroachSqlExecutor } from "./cockroach-command-state-store.ts";
+import {
+  createCockroachEventIngestionStore,
+  type CockroachEventIngestionSqlExecutor,
+} from "./cockroach-event-ingestion-store.ts";
+import { createCockroachOutboxEventSource, type CockroachOutboxSqlExecutor } from "./cockroach-outbox-event-source.ts";
+import {
+  createCockroachPolicyDecisionObservationStore,
+  type CockroachPolicyDecisionObservationSqlExecutor,
+  type CockroachPolicyDecisionObservationStore,
+} from "./cockroach-policy-decision-observation-store.ts";
+
+export type CockroachOrganizationSqlExecutor = CockroachGenericSqlExecutor &
+  CockroachSqlExecutor &
+  CockroachOutboxSqlExecutor &
+  CockroachEventIngestionSqlExecutor &
+  CockroachPolicyDecisionObservationSqlExecutor;
+
+export type CockroachDurableStateAdapters<Result> = {
+  commandStateStoreFactory: CommandStateStoreFactory<Result>;
+  outboxEventSource: OutboxEventSource;
+  eventIngestionStore: EventIngestionStore;
+  policyDecisionObservationStore: CockroachPolicyDecisionObservationStore;
+};
+
+export type CreateCockroachDurableStateAdaptersInput = {
+  executor: CockroachOrganizationSqlExecutor;
+};
+
+export function createCockroachDurableStateAdapters<Result>(
+  input: CreateCockroachDurableStateAdaptersInput,
+): CockroachDurableStateAdapters<Result> {
+  return {
+    commandStateStoreFactory: createCockroachCommandStateStoreFactory<Result>({
+      executor: input.executor,
+    }),
+    outboxEventSource: createCockroachOutboxEventSource({
+      executor: input.executor,
+    }),
+    eventIngestionStore: createCockroachEventIngestionStore({
+      executor: input.executor,
+    }),
+    policyDecisionObservationStore: createCockroachPolicyDecisionObservationStore({
+      executor: input.executor,
+    }),
+  };
+}

--- a/agentic-organization/packages/state-cockroach/src/cockroach-migration-runner.ts
+++ b/agentic-organization/packages/state-cockroach/src/cockroach-migration-runner.ts
@@ -1,0 +1,32 @@
+import type { CockroachGenericSqlExecutor } from "./cockroach-sql-executor.ts";
+import type { CockroachSchemaMigration } from "./cockroach-schema.ts";
+
+export const CockroachMigrationStatement = {
+  ApplyMigration: "apply_migration",
+} as const;
+
+export type CockroachMigrationStatement =
+  (typeof CockroachMigrationStatement)[keyof typeof CockroachMigrationStatement];
+
+export type CockroachMigrationRunner = {
+  applyMigrations: () => Promise<void>;
+};
+
+export type CreateCockroachMigrationRunnerInput = {
+  executor: CockroachGenericSqlExecutor;
+  migrations: readonly CockroachSchemaMigration[];
+};
+
+export function createCockroachMigrationRunner(input: CreateCockroachMigrationRunnerInput): CockroachMigrationRunner {
+  return {
+    applyMigrations: async () => {
+      for (const migration of input.migrations) {
+        await input.executor.execute({
+          name: CockroachMigrationStatement.ApplyMigration,
+          sql: migration.sql,
+          parameters: [],
+        });
+      }
+    },
+  };
+}

--- a/agentic-organization/packages/state-cockroach/src/cockroach-policy-decision-observation-store.ts
+++ b/agentic-organization/packages/state-cockroach/src/cockroach-policy-decision-observation-store.ts
@@ -143,10 +143,35 @@ function createRecordPolicyDecisionObservationStatement(
 }
 
 function createPolicyDecisionObservationHash(observation: PolicyDecisionObservation): string {
-  return `sha256:${createHash("sha256").update(stringifyCanonicalJson(observation)).digest("hex")}`;
+  return `sha256:${createHash("sha256").update(stringifyCanonicalJson(createHashableObservation(observation))).digest("hex")}`;
+}
+
+function createHashableObservation(observation: PolicyDecisionObservation): Omit<PolicyDecisionObservation, "observedAt"> {
+  const hashableObservation: Omit<PolicyDecisionObservation, "observedAt"> = {
+    commandId: observation.commandId,
+    commandType: observation.commandType,
+    actor: observation.actor,
+    scope: observation.scope,
+    trace: observation.trace,
+    decision: observation.decision,
+  };
+
+  if (observation.toolType !== undefined) {
+    hashableObservation.toolType = observation.toolType;
+  }
+
+  if (observation.supervisorChain !== undefined) {
+    hashableObservation.supervisorChain = observation.supervisorChain;
+  }
+
+  return hashableObservation;
 }
 
 function stringifyCanonicalJson(value: unknown): string {
+  if (value === undefined) {
+    return "null";
+  }
+
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value);
   }
@@ -157,6 +182,7 @@ function stringifyCanonicalJson(value: unknown): string {
 
   const record = value as Record<string, unknown>;
   const properties = Object.keys(record)
+    .filter((key) => record[key] !== undefined)
     .sort()
     .map((key) => `${JSON.stringify(key)}:${stringifyCanonicalJson(record[key])}`);
 

--- a/agentic-organization/packages/state-cockroach/src/cockroach-policy-decision-observation-store.ts
+++ b/agentic-organization/packages/state-cockroach/src/cockroach-policy-decision-observation-store.ts
@@ -1,0 +1,251 @@
+import { createHash } from "node:crypto";
+
+import {
+  PolicyDecisionObservationPersistenceStatus,
+  PolicyDecisionStatus,
+  type PolicyDecisionObservation,
+  type PolicyDecisionObservationQuery,
+  type PolicyDecisionObservationReader,
+  type PolicyDecisionObservationStore,
+  type RecordPolicyDecisionObservationResult,
+} from "../../policy/src/index.ts";
+import { CockroachTableName } from "./cockroach-schema.ts";
+
+export const CockroachPolicyDecisionObservationStoreStatement = {
+  RecordPolicyDecisionObservation: "record_policy_decision_observation",
+  FindPolicyDecisionObservationHash: "find_policy_decision_observation_hash",
+  FindPolicyDecisionObservations: "find_policy_decision_observations",
+} as const;
+
+export type CockroachPolicyDecisionObservationStoreStatement =
+  (typeof CockroachPolicyDecisionObservationStoreStatement)[keyof typeof CockroachPolicyDecisionObservationStoreStatement];
+
+export type CockroachPolicyDecisionObservationSqlStatement = {
+  name: CockroachPolicyDecisionObservationStoreStatement;
+  sql: string;
+  parameters: readonly unknown[];
+};
+
+export type CockroachPolicyDecisionObservationSqlResult<Row = Record<string, unknown>> = {
+  rows: readonly Row[];
+};
+
+export type CockroachPolicyDecisionObservationSqlExecutor = {
+  execute: <Row = Record<string, unknown>>(
+    statement: CockroachPolicyDecisionObservationSqlStatement,
+  ) => Promise<CockroachPolicyDecisionObservationSqlResult<Row>>;
+};
+
+export type CockroachPolicyDecisionObservationStore = PolicyDecisionObservationStore & PolicyDecisionObservationReader;
+
+export type CreateCockroachPolicyDecisionObservationStoreInput = {
+  executor: CockroachPolicyDecisionObservationSqlExecutor;
+};
+
+export function createCockroachPolicyDecisionObservationStore(
+  input: CreateCockroachPolicyDecisionObservationStoreInput,
+): CockroachPolicyDecisionObservationStore {
+  return {
+    recordPolicyDecisionObservation: async (observation) =>
+      await recordPolicyDecisionObservation(input.executor, observation),
+    findPolicyDecisionObservations: async (query) => await findPolicyDecisionObservations(input.executor, query),
+  };
+}
+
+async function recordPolicyDecisionObservation(
+  executor: CockroachPolicyDecisionObservationSqlExecutor,
+  observation: PolicyDecisionObservation,
+): Promise<RecordPolicyDecisionObservationResult> {
+  const observationHash = createPolicyDecisionObservationHash(observation);
+  const result = await executor.execute<{ policy_decision_id: string }>(
+    createRecordPolicyDecisionObservationStatement(observation, observationHash),
+  );
+
+  if (result.rows[0] === undefined) {
+    const existingHash = await findExistingPolicyDecisionObservationHash(executor, observation.decision.decisionId);
+
+    if (existingHash !== observationHash) {
+      return {
+        status: PolicyDecisionObservationPersistenceStatus.Conflict,
+      };
+    }
+
+    return {
+      status: PolicyDecisionObservationPersistenceStatus.Duplicate,
+    };
+  }
+
+  return {
+    status: PolicyDecisionObservationPersistenceStatus.Recorded,
+  };
+}
+
+async function findExistingPolicyDecisionObservationHash(
+  executor: CockroachPolicyDecisionObservationSqlExecutor,
+  policyDecisionId: string,
+): Promise<string | undefined> {
+  const result = await executor.execute<CockroachPolicyDecisionObservationHashRow>({
+    name: CockroachPolicyDecisionObservationStoreStatement.FindPolicyDecisionObservationHash,
+    sql: `
+      SELECT observation_hash
+      FROM ${CockroachTableName.PolicyObservations}
+      WHERE policy_decision_id = $1
+    `,
+    parameters: [policyDecisionId],
+  });
+
+  return result.rows[0]?.observation_hash;
+}
+
+async function findPolicyDecisionObservations(
+  executor: CockroachPolicyDecisionObservationSqlExecutor,
+  query: PolicyDecisionObservationQuery,
+): Promise<readonly PolicyDecisionObservation[]> {
+  const result = await executor.execute<CockroachPolicyDecisionObservationRow>(
+    createFindPolicyDecisionObservationsStatement(query),
+  );
+
+  return result.rows.map((row) => row.observation_json);
+}
+
+function createRecordPolicyDecisionObservationStatement(
+  observation: PolicyDecisionObservation,
+  observationHash: string,
+): CockroachPolicyDecisionObservationSqlStatement {
+  return {
+    name: CockroachPolicyDecisionObservationStoreStatement.RecordPolicyDecisionObservation,
+    sql: CockroachPolicyDecisionObservationSql.RecordPolicyDecisionObservation,
+    parameters: [
+      observation.decision.decisionId,
+      observation.decision.policyVersion,
+      observation.decision.status,
+      observation.decision.status === PolicyDecisionStatus.Denied ? observation.decision.reason : null,
+      observation.commandId,
+      observation.commandType,
+      observation.scope.organizationId,
+      observation.scope.projectId,
+      observation.scope.teamId ?? null,
+      observation.scope.workItemId ?? null,
+      observation.actor.agentId,
+      observation.actor.hatAssignmentId,
+      observation.toolType ?? null,
+      observation.supervisorChain?.sourceLevel ?? null,
+      observation.supervisorChain?.targetLevel ?? null,
+      observation.trace.correlationId,
+      observation.trace.causationId,
+      observation.trace.traceId,
+      observation.trace.idempotencyKey,
+      observationHash,
+      observation,
+      observation.observedAt,
+    ],
+  };
+}
+
+function createPolicyDecisionObservationHash(observation: PolicyDecisionObservation): string {
+  return `sha256:${createHash("sha256").update(stringifyCanonicalJson(observation)).digest("hex")}`;
+}
+
+function stringifyCanonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stringifyCanonicalJson(item)).join(",")}]`;
+  }
+
+  const record = value as Record<string, unknown>;
+  const properties = Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stringifyCanonicalJson(record[key])}`);
+
+  return `{${properties.join(",")}}`;
+}
+
+function createFindPolicyDecisionObservationsStatement(
+  query: PolicyDecisionObservationQuery,
+): CockroachPolicyDecisionObservationSqlStatement {
+  const conditions: string[] = [];
+  const parameters: unknown[] = [];
+
+  addCondition(conditions, parameters, "organization_id", query.organizationId);
+  addOptionalCondition(conditions, parameters, "project_id", query.projectId);
+  addOptionalCondition(conditions, parameters, "team_id", query.teamId);
+  addOptionalCondition(conditions, parameters, "work_item_id", query.workItemId);
+  addOptionalCondition(conditions, parameters, "actor_agent_id", query.agentId);
+  addOptionalCondition(conditions, parameters, "actor_hat_assignment_id", query.hatAssignmentId);
+  addOptionalCondition(conditions, parameters, "decision_status", query.decisionStatus);
+
+  const limitParameter = parameters.length + 1;
+  parameters.push(query.limit);
+
+  return {
+    name: CockroachPolicyDecisionObservationStoreStatement.FindPolicyDecisionObservations,
+    sql: `
+      SELECT observation_json
+      FROM ${CockroachTableName.PolicyObservations}
+      WHERE ${conditions.join(" AND ")}
+      ORDER BY observed_at DESC
+      LIMIT $${limitParameter}
+    `,
+    parameters,
+  };
+}
+
+function addCondition(conditions: string[], parameters: unknown[], columnName: string, value: unknown): void {
+  parameters.push(value);
+  conditions.push(`${columnName} = $${parameters.length}`);
+}
+
+function addOptionalCondition(
+  conditions: string[],
+  parameters: unknown[],
+  columnName: string,
+  value: unknown | undefined,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  addCondition(conditions, parameters, columnName, value);
+}
+
+type CockroachPolicyDecisionObservationRow = {
+  observation_json: PolicyDecisionObservation;
+};
+
+type CockroachPolicyDecisionObservationHashRow = {
+  observation_hash: string;
+};
+
+const CockroachPolicyDecisionObservationSql = {
+  RecordPolicyDecisionObservation: `
+    INSERT INTO ${CockroachTableName.PolicyObservations} (
+      policy_decision_id,
+      policy_version,
+      decision_status,
+      denial_reason,
+      command_id,
+      command_type,
+      organization_id,
+      project_id,
+      team_id,
+      work_item_id,
+      actor_agent_id,
+      actor_hat_assignment_id,
+      tool_type,
+      source_level,
+      target_level,
+      correlation_id,
+      causation_id,
+      trace_id,
+      idempotency_key,
+      observation_hash,
+      observation_json,
+      observed_at
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
+    ON CONFLICT (policy_decision_id) DO NOTHING
+    RETURNING policy_decision_id
+  `,
+} as const;

--- a/agentic-organization/packages/state-cockroach/src/cockroach-schema.ts
+++ b/agentic-organization/packages/state-cockroach/src/cockroach-schema.ts
@@ -13,6 +13,7 @@ export const CockroachTableName = {
   OutboxEvents: "agentic_org_outbox_events",
   ReactionPlans: "agentic_org_reaction_plans",
   IdempotencyRecords: "agentic_org_idempotency_records",
+  PolicyObservations: "agentic_org_policy_observations",
 } as const;
 
 export type CockroachTableName = (typeof CockroachTableName)[keyof typeof CockroachTableName];
@@ -33,6 +34,7 @@ export function createCockroachCoreStateMigration(): CockroachSchemaMigration {
       createInboxReceiptsTableSql(),
       createReactionPlansTableSql(),
       createIdempotencyRecordsTableSql(),
+      createPolicyObservationsTableSql(),
     ].join("\n\n"),
   };
 }
@@ -139,5 +141,33 @@ CREATE TABLE IF NOT EXISTS ${CockroachTableName.ReactionPlans} (
   project_id STRING NOT NULL,
   work_item_id STRING NOT NULL,
   action_json JSONB NOT NULL
+);`.trim();
+}
+
+function createPolicyObservationsTableSql(): string {
+  return `
+CREATE TABLE IF NOT EXISTS ${CockroachTableName.PolicyObservations} (
+  policy_decision_id STRING PRIMARY KEY,
+  policy_version STRING NOT NULL,
+  decision_status STRING NOT NULL,
+  denial_reason STRING,
+  command_id STRING NOT NULL,
+  command_type STRING NOT NULL,
+  organization_id STRING NOT NULL,
+  project_id STRING NOT NULL,
+  team_id STRING,
+  work_item_id STRING,
+  actor_agent_id STRING NOT NULL,
+  actor_hat_assignment_id STRING NOT NULL,
+  tool_type STRING,
+  source_level STRING,
+  target_level STRING,
+  correlation_id STRING NOT NULL,
+  causation_id STRING NOT NULL,
+  trace_id STRING NOT NULL,
+  idempotency_key STRING NOT NULL,
+  observation_hash STRING NOT NULL,
+  observation_json JSONB NOT NULL,
+  observed_at TIMESTAMPTZ NOT NULL
 );`.trim();
 }

--- a/agentic-organization/packages/state-cockroach/src/cockroach-sql-executor.ts
+++ b/agentic-organization/packages/state-cockroach/src/cockroach-sql-executor.ts
@@ -1,0 +1,51 @@
+export type CockroachAnySqlStatement = {
+  name: string;
+  sql: string;
+  parameters: readonly unknown[];
+};
+
+export type CockroachAnySqlResult<Row = Record<string, unknown>> = {
+  rows: readonly Row[];
+};
+
+export type CockroachSqlClient = {
+  query: <Row = Record<string, unknown>>(
+    sql: string,
+    parameters: readonly unknown[],
+  ) => Promise<CockroachAnySqlResult<Row>>;
+  transaction: <Result>(operation: (client: CockroachSqlClient) => Promise<Result>) => Promise<Result>;
+};
+
+export type CockroachGenericSqlTransactionExecutor = {
+  execute: <Row = Record<string, unknown>>(statement: CockroachAnySqlStatement) => Promise<CockroachAnySqlResult<Row>>;
+};
+
+export type CockroachGenericSqlExecutor = CockroachGenericSqlTransactionExecutor & {
+  executeTransaction: <Result>(
+    operation: (executor: CockroachGenericSqlTransactionExecutor) => Promise<Result>,
+  ) => Promise<Result>;
+};
+
+export type CreateCockroachSqlExecutorInput = {
+  client: CockroachSqlClient;
+};
+
+export function createCockroachSqlExecutor(input: CreateCockroachSqlExecutorInput): CockroachGenericSqlExecutor {
+  return createExecutorForClient(input.client);
+}
+
+function createExecutorForClient(client: CockroachSqlClient): CockroachGenericSqlExecutor {
+  return {
+    execute: async (statement) => await client.query(statement.sql, statement.parameters),
+    executeTransaction: async (operation) =>
+      await client.transaction(
+        async (transactionClient) => await operation(createTransactionExecutor(transactionClient)),
+      ),
+  };
+}
+
+function createTransactionExecutor(client: CockroachSqlClient): CockroachGenericSqlTransactionExecutor {
+  return {
+    execute: async (statement) => await client.query(statement.sql, statement.parameters),
+  };
+}

--- a/agentic-organization/packages/state-cockroach/src/index.ts
+++ b/agentic-organization/packages/state-cockroach/src/index.ts
@@ -23,6 +23,15 @@ export {
   type CreateCockroachEventIngestionStoreInput,
 } from "./cockroach-event-ingestion-store.ts";
 export {
+  CockroachPolicyDecisionObservationStoreStatement,
+  createCockroachPolicyDecisionObservationStore,
+  type CockroachPolicyDecisionObservationSqlExecutor,
+  type CockroachPolicyDecisionObservationSqlResult,
+  type CockroachPolicyDecisionObservationSqlStatement,
+  type CockroachPolicyDecisionObservationStore,
+  type CreateCockroachPolicyDecisionObservationStoreInput,
+} from "./cockroach-policy-decision-observation-store.ts";
+export {
   CockroachCoreStateMigrationName,
   CockroachTableName,
   createCockroachCoreStateMigration,

--- a/agentic-organization/packages/state-cockroach/src/index.ts
+++ b/agentic-organization/packages/state-cockroach/src/index.ts
@@ -7,6 +7,18 @@ export {
   type CreateCockroachCommandStateStoreFactoryInput,
 } from "./cockroach-command-state-store.ts";
 export {
+  createCockroachDurableStateAdapters,
+  type CockroachDurableStateAdapters,
+  type CockroachOrganizationSqlExecutor,
+  type CreateCockroachDurableStateAdaptersInput,
+} from "./cockroach-durable-state-adapters.ts";
+export {
+  CockroachMigrationStatement,
+  createCockroachMigrationRunner,
+  type CockroachMigrationRunner,
+  type CreateCockroachMigrationRunnerInput,
+} from "./cockroach-migration-runner.ts";
+export {
   CockroachOutboxEventSourceStatement,
   createCockroachOutboxEventSource,
   type CockroachOutboxSqlExecutor,
@@ -37,3 +49,12 @@ export {
   createCockroachCoreStateMigration,
   type CockroachSchemaMigration,
 } from "./cockroach-schema.ts";
+export {
+  createCockroachSqlExecutor,
+  type CockroachAnySqlResult,
+  type CockroachAnySqlStatement,
+  type CockroachGenericSqlExecutor,
+  type CockroachGenericSqlTransactionExecutor,
+  type CockroachSqlClient,
+  type CreateCockroachSqlExecutorInput,
+} from "./cockroach-sql-executor.ts";

--- a/agentic-organization/packages/state-cockroach/test/cockroach-durable-state-adapters.test.ts
+++ b/agentic-organization/packages/state-cockroach/test/cockroach-durable-state-adapters.test.ts
@@ -1,0 +1,97 @@
+import { deepEqual } from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { CommandType, SupervisorChainLevel, SupervisorSignalToolType } from "../../domain/src/index.ts";
+import { HatAuthorityDecisionStatus, PolicyDecisionStatus } from "../../policy/src/index.ts";
+import {
+  createCockroachDurableStateAdapters,
+  type CockroachAnySqlStatement,
+  type CockroachOrganizationSqlExecutor,
+} from "../src/index.ts";
+
+describe("cockroach durable state adapters", () => {
+  test("builds all durable Organization state ports from one generic executor", async () => {
+    const executor = createRecordingOrganizationSqlExecutor();
+    const adapters = createCockroachDurableStateAdapters({
+      executor,
+    });
+
+    await adapters.commandStateStoreFactory.createCommandStateStore().findIdempotencyRecord("idem-001");
+    await adapters.outboxEventSource.claimUnpublishedOutboxEvents({ batchSize: 10 });
+    await adapters.eventIngestionStore.findInboxReceipt({
+      eventId: "evt-001",
+      consumerName: "v0_automation_planner",
+    });
+    await adapters.policyDecisionObservationStore.recordPolicyDecisionObservation({
+      commandId: "cmd-001",
+      commandType: CommandType.SendSupervisorSignal,
+      actor: {
+        agentId: "agent-001",
+        hatAssignmentId: "hat-assignment-001",
+      },
+      scope: {
+        organizationId: "org-lfg",
+        projectId: "project-agentic-org",
+      },
+      toolType: SupervisorSignalToolType.ReportBlocker,
+      supervisorChain: {
+        sourceLevel: SupervisorChainLevel.TeamMember,
+        targetLevel: SupervisorChainLevel.Manager,
+      },
+      trace: {
+        correlationId: "corr-001",
+        causationId: "cause-001",
+        traceId: "trace-001",
+        idempotencyKey: "idem-001",
+      },
+      decision: {
+        status: PolicyDecisionStatus.Denied,
+        decisionId: "policy-decision-001",
+        policyVersion: "policy-v1",
+        reason: HatAuthorityDecisionStatus.ToolDenied,
+      },
+      observedAt: "2026-05-26T00:00:00.000Z",
+    });
+
+    deepEqual(executor.statementNames, [
+      "find_idempotency_record",
+      "claim_unpublished_outbox_events",
+      "find_inbox_receipt",
+      "record_policy_decision_observation",
+    ]);
+  });
+});
+
+function createRecordingOrganizationSqlExecutor(): CockroachOrganizationSqlExecutor & {
+  statementNames: string[];
+} {
+  const statementNames: string[] = [];
+
+  return {
+    statementNames,
+    execute: async <Row = Record<string, unknown>>(statement: CockroachAnySqlStatement) => {
+      statementNames.push(statement.name);
+
+      return {
+        rows:
+          statement.name === "record_policy_decision_observation"
+            ? ([{ policy_decision_id: "policy-decision-001" }] as Row[])
+            : ([] as Row[]),
+      };
+    },
+    executeTransaction: async <Result>(
+      operation: (executor: {
+        execute: <Row = Record<string, unknown>>(statement: CockroachAnySqlStatement) => Promise<{ rows: Row[] }>;
+      }) => Promise<Result>,
+    ) =>
+      await operation({
+        execute: async <Row = Record<string, unknown>>(statement: CockroachAnySqlStatement) => {
+          statementNames.push(statement.name);
+
+          return {
+            rows: [] as Row[],
+          };
+        },
+      }),
+  };
+}

--- a/agentic-organization/packages/state-cockroach/test/cockroach-migration-runner.test.ts
+++ b/agentic-organization/packages/state-cockroach/test/cockroach-migration-runner.test.ts
@@ -1,0 +1,58 @@
+import { deepEqual } from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  CockroachMigrationStatement,
+  createCockroachCoreStateMigration,
+  createCockroachMigrationRunner,
+  type CockroachAnySqlStatement,
+  type CockroachGenericSqlExecutor,
+} from "../src/index.ts";
+
+describe("cockroach migration runner", () => {
+  test("applies the core state migration through the generic SQL executor", async () => {
+    const executor = createRecordingSqlExecutor();
+    const migration = createCockroachCoreStateMigration();
+    const runner = createCockroachMigrationRunner({
+      executor,
+      migrations: [migration],
+    });
+
+    await runner.applyMigrations();
+
+    deepEqual(executor.statements, [
+      {
+        name: CockroachMigrationStatement.ApplyMigration,
+        sql: migration.sql,
+        parameters: [],
+      },
+    ]);
+  });
+});
+
+function createRecordingSqlExecutor(): CockroachGenericSqlExecutor & {
+  statements: { name: string; sql: string; parameters: readonly unknown[] }[];
+} {
+  const statements: { name: string; sql: string; parameters: readonly unknown[] }[] = [];
+
+  return {
+    statements,
+    execute: async <Row = Record<string, unknown>>(statement: CockroachAnySqlStatement) => {
+      statements.push(statement);
+
+      return {
+        rows: [] as Row[],
+      };
+    },
+    executeTransaction: async (operation) =>
+      await operation({
+        execute: async <Row = Record<string, unknown>>(statement: CockroachAnySqlStatement) => {
+          statements.push(statement);
+
+          return {
+            rows: [] as Row[],
+          };
+        },
+      }),
+  };
+}

--- a/agentic-organization/packages/state-cockroach/test/cockroach-policy-decision-observation-store.test.ts
+++ b/agentic-organization/packages/state-cockroach/test/cockroach-policy-decision-observation-store.test.ts
@@ -1,0 +1,211 @@
+import { deepEqual, equal } from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { CommandType, SupervisorChainLevel, SupervisorSignalToolType } from "../../domain/src/index.ts";
+import {
+  HatAuthorityDecisionStatus,
+  PolicyDecisionObservationPersistenceStatus,
+  PolicyDecisionStatus,
+  type PolicyDecisionObservation,
+} from "../../policy/src/index.ts";
+import {
+  CockroachPolicyDecisionObservationStoreStatement,
+  createCockroachPolicyDecisionObservationStore,
+  type CockroachPolicyDecisionObservationSqlExecutor,
+  type CockroachPolicyDecisionObservationSqlResult,
+  type CockroachPolicyDecisionObservationSqlStatement,
+} from "../src/cockroach-policy-decision-observation-store.ts";
+
+describe("cockroach policy decision observation store", () => {
+  test("records denied policy observations as an idempotent governance ledger row", async () => {
+    const executor = createRecordingExecutor();
+    const store = createCockroachPolicyDecisionObservationStore({ executor });
+
+    const result = await store.recordPolicyDecisionObservation(createDeniedPolicyDecisionObservation());
+
+    equal(result.status, PolicyDecisionObservationPersistenceStatus.Recorded);
+    deepEqual(
+      executor.statements.map((statement) => statement.name),
+      [CockroachPolicyDecisionObservationStoreStatement.RecordPolicyDecisionObservation],
+    );
+    deepEqual(executor.statements[0]?.parameters, [
+      "policy-decision-denied-001",
+      "policy-v1",
+      PolicyDecisionStatus.Denied,
+      HatAuthorityDecisionStatus.ToolDenied,
+      "cmd-supervisor-signal-001",
+      CommandType.SendSupervisorSignal,
+      "org-lfg",
+      "project-agentic-org",
+      "team-runtime",
+      "work-outbox-001",
+      "agent-developer-001",
+      "hat-assignment-dev-001",
+      SupervisorSignalToolType.ReportBlocker,
+      SupervisorChainLevel.TeamMember,
+      SupervisorChainLevel.Manager,
+      "corr-supervisor-signal-001",
+      "cause-team-work-001",
+      "trace-supervisor-signal-001",
+      "idem-supervisor-signal-001",
+      createDeniedPolicyDecisionObservationHash(),
+      createDeniedPolicyDecisionObservation(),
+      "2026-05-25T20:00:00.000Z",
+    ]);
+  });
+
+  test("returns duplicate when the decision row already exists", async () => {
+    const executor = createRecordingExecutor({
+      recordInserted: false,
+      existingObservationHash: createDeniedPolicyDecisionObservationHash(),
+    });
+    const store = createCockroachPolicyDecisionObservationStore({ executor });
+
+    const result = await store.recordPolicyDecisionObservation(createDeniedPolicyDecisionObservation());
+
+    equal(result.status, PolicyDecisionObservationPersistenceStatus.Duplicate);
+  });
+
+  test("returns conflict when the decision row exists with different observation evidence", async () => {
+    const executor = createRecordingExecutor({
+      recordInserted: false,
+      existingObservationHash: "sha256:different-observation-payload",
+    });
+    const store = createCockroachPolicyDecisionObservationStore({ executor });
+
+    const result = await store.recordPolicyDecisionObservation(createDeniedPolicyDecisionObservation());
+
+    equal(result.status, PolicyDecisionObservationPersistenceStatus.Conflict);
+    deepEqual(
+      executor.statements.map((statement) => statement.name),
+      [
+        CockroachPolicyDecisionObservationStoreStatement.RecordPolicyDecisionObservation,
+        CockroachPolicyDecisionObservationStoreStatement.FindPolicyDecisionObservationHash,
+      ],
+    );
+  });
+
+  test("queries observations by work item through typed visibility filters", async () => {
+    const executor = createRecordingExecutor({
+      queryRows: [
+        {
+          observation_json: createDeniedPolicyDecisionObservation(),
+          team_id: null,
+          work_item_id: null,
+          tool_type: null,
+          source_level: null,
+          target_level: null,
+        },
+      ],
+    });
+    const store = createCockroachPolicyDecisionObservationStore({ executor });
+
+    const observations = await store.findPolicyDecisionObservations({
+      organizationId: "org-lfg",
+      projectId: "project-agentic-org",
+      workItemId: "work-outbox-001",
+      decisionStatus: PolicyDecisionStatus.Denied,
+      limit: 25,
+    });
+
+    deepEqual(
+      executor.statements.map((statement) => statement.name),
+      [CockroachPolicyDecisionObservationStoreStatement.FindPolicyDecisionObservations],
+    );
+    equal(executor.statements[0]?.sql.includes("organization_id = $1"), true);
+    equal(executor.statements[0]?.sql.includes("project_id = $2"), true);
+    equal(executor.statements[0]?.sql.includes("work_item_id = $3"), true);
+    equal(executor.statements[0]?.sql.includes("decision_status = $4"), true);
+    deepEqual(executor.statements[0]?.parameters, [
+      "org-lfg",
+      "project-agentic-org",
+      "work-outbox-001",
+      PolicyDecisionStatus.Denied,
+      25,
+    ]);
+    deepEqual(observations, [createDeniedPolicyDecisionObservation()]);
+  });
+});
+
+type RecordingPolicyDecisionObservationExecutor = CockroachPolicyDecisionObservationSqlExecutor & {
+  statements: CockroachPolicyDecisionObservationSqlStatement[];
+};
+
+function createRecordingExecutor(
+  input: {
+    recordInserted?: boolean;
+    existingObservationHash?: string;
+    queryRows?: readonly Record<string, unknown>[];
+  } = {},
+): RecordingPolicyDecisionObservationExecutor {
+  const statements: CockroachPolicyDecisionObservationSqlStatement[] = [];
+
+  return {
+    statements,
+    execute: async <Row = Record<string, unknown>>(statement: CockroachPolicyDecisionObservationSqlStatement) => {
+      statements.push(statement);
+
+      if (statement.name === CockroachPolicyDecisionObservationStoreStatement.RecordPolicyDecisionObservation) {
+        return {
+          rows: input.recordInserted === false ? [] : ([{ policy_decision_id: "policy-decision-denied-001" }] as Row[]),
+        };
+      }
+
+      if (statement.name === CockroachPolicyDecisionObservationStoreStatement.FindPolicyDecisionObservationHash) {
+        return {
+          rows:
+            input.existingObservationHash === undefined
+              ? []
+              : ([
+                  {
+                    observation_hash: input.existingObservationHash,
+                  },
+                ] as Row[]),
+        } satisfies CockroachPolicyDecisionObservationSqlResult<Row>;
+      }
+
+      return {
+        rows: (input.queryRows ?? []) as Row[],
+      };
+    },
+  };
+}
+
+function createDeniedPolicyDecisionObservationHash(): string {
+  return "sha256:fdfd0685215f28c0e416fa01fade4abb95e5d8a179862c698acc54d12ae30d24";
+}
+
+function createDeniedPolicyDecisionObservation(): PolicyDecisionObservation {
+  return {
+    commandId: "cmd-supervisor-signal-001",
+    commandType: CommandType.SendSupervisorSignal,
+    actor: {
+      agentId: "agent-developer-001",
+      hatAssignmentId: "hat-assignment-dev-001",
+    },
+    scope: {
+      organizationId: "org-lfg",
+      projectId: "project-agentic-org",
+      teamId: "team-runtime",
+      workItemId: "work-outbox-001",
+    },
+    toolType: SupervisorSignalToolType.ReportBlocker,
+    supervisorChain: {
+      sourceLevel: SupervisorChainLevel.TeamMember,
+      targetLevel: SupervisorChainLevel.Manager,
+    },
+    trace: {
+      correlationId: "corr-supervisor-signal-001",
+      causationId: "cause-team-work-001",
+      traceId: "trace-supervisor-signal-001",
+      idempotencyKey: "idem-supervisor-signal-001",
+    },
+    decision: {
+      status: PolicyDecisionStatus.Denied,
+      decisionId: "policy-decision-denied-001",
+      policyVersion: "policy-v1",
+      reason: HatAuthorityDecisionStatus.ToolDenied,
+    },
+    observedAt: "2026-05-25T20:00:00.000Z",
+  };
+}

--- a/agentic-organization/packages/state-cockroach/test/cockroach-policy-decision-observation-store.test.ts
+++ b/agentic-organization/packages/state-cockroach/test/cockroach-policy-decision-observation-store.test.ts
@@ -66,6 +66,35 @@ describe("cockroach policy decision observation store", () => {
     equal(result.status, PolicyDecisionObservationPersistenceStatus.Duplicate);
   });
 
+  test("treats observation timestamp drift as a duplicate replay", async () => {
+    const executor = createRecordingExecutor({
+      recordInserted: false,
+      existingObservationHash: createDeniedPolicyDecisionObservationHash(),
+    });
+    const store = createCockroachPolicyDecisionObservationStore({ executor });
+
+    const result = await store.recordPolicyDecisionObservation({
+      ...createDeniedPolicyDecisionObservation(),
+      observedAt: "2026-05-25T20:05:00.000Z",
+    });
+
+    equal(result.status, PolicyDecisionObservationPersistenceStatus.Duplicate);
+  });
+
+  test("hashes omitted and undefined optional evidence the same way as JSON persistence", async () => {
+    const omittedExecutor = createRecordingExecutor();
+    const undefinedExecutor = createRecordingExecutor();
+    const omittedStore = createCockroachPolicyDecisionObservationStore({ executor: omittedExecutor });
+    const undefinedStore = createCockroachPolicyDecisionObservationStore({ executor: undefinedExecutor });
+
+    await omittedStore.recordPolicyDecisionObservation(createMinimalDeniedPolicyDecisionObservation());
+    await undefinedStore.recordPolicyDecisionObservation(
+      createMinimalDeniedPolicyDecisionObservationWithUndefinedOptionals(),
+    );
+
+    equal(getRecordedObservationHash(omittedExecutor), getRecordedObservationHash(undefinedExecutor));
+  });
+
   test("returns conflict when the decision row exists with different observation evidence", async () => {
     const executor = createRecordingExecutor({
       recordInserted: false,
@@ -172,7 +201,11 @@ function createRecordingExecutor(
 }
 
 function createDeniedPolicyDecisionObservationHash(): string {
-  return "sha256:fdfd0685215f28c0e416fa01fade4abb95e5d8a179862c698acc54d12ae30d24";
+  return "sha256:ed890dae6f9a6afb4330ae282e70b23da4c14e1efc3831de68711d3604f29743";
+}
+
+function getRecordedObservationHash(executor: RecordingPolicyDecisionObservationExecutor): unknown {
+  return executor.statements[0]?.parameters[19];
 }
 
 function createDeniedPolicyDecisionObservation(): PolicyDecisionObservation {
@@ -208,4 +241,45 @@ function createDeniedPolicyDecisionObservation(): PolicyDecisionObservation {
     },
     observedAt: "2026-05-25T20:00:00.000Z",
   };
+}
+
+function createMinimalDeniedPolicyDecisionObservation(): PolicyDecisionObservation {
+  return {
+    commandId: "cmd-supervisor-signal-001",
+    commandType: CommandType.SendSupervisorSignal,
+    actor: {
+      agentId: "agent-developer-001",
+      hatAssignmentId: "hat-assignment-dev-001",
+    },
+    scope: {
+      organizationId: "org-lfg",
+      projectId: "project-agentic-org",
+    },
+    trace: {
+      correlationId: "corr-supervisor-signal-001",
+      causationId: "cause-team-work-001",
+      traceId: "trace-supervisor-signal-001",
+      idempotencyKey: "idem-supervisor-signal-001",
+    },
+    decision: {
+      status: PolicyDecisionStatus.Denied,
+      decisionId: "policy-decision-denied-001",
+      policyVersion: "policy-v1",
+      reason: HatAuthorityDecisionStatus.ToolDenied,
+    },
+    observedAt: "2026-05-25T20:00:00.000Z",
+  };
+}
+
+function createMinimalDeniedPolicyDecisionObservationWithUndefinedOptionals(): PolicyDecisionObservation {
+  return {
+    ...createMinimalDeniedPolicyDecisionObservation(),
+    toolType: undefined,
+    supervisorChain: undefined,
+    scope: {
+      ...createMinimalDeniedPolicyDecisionObservation().scope,
+      teamId: undefined,
+      workItemId: undefined,
+    },
+  } as unknown as PolicyDecisionObservation;
 }

--- a/agentic-organization/packages/state-cockroach/test/cockroach-schema.test.ts
+++ b/agentic-organization/packages/state-cockroach/test/cockroach-schema.test.ts
@@ -19,7 +19,13 @@ describe("cockroach core state schema", () => {
     ok(migration.sql.includes(`CREATE TABLE IF NOT EXISTS ${CockroachTableName.InboxReceipts}`));
     ok(migration.sql.includes(`CREATE TABLE IF NOT EXISTS ${CockroachTableName.ReactionPlans}`));
     ok(migration.sql.includes(`CREATE TABLE IF NOT EXISTS ${CockroachTableName.IdempotencyRecords}`));
+    ok(migration.sql.includes(`CREATE TABLE IF NOT EXISTS ${CockroachTableName.PolicyObservations}`));
+    ok(migration.sql.includes("decision_status STRING NOT NULL"));
+    ok(migration.sql.includes("denial_reason STRING"));
+    ok(migration.sql.includes("observation_json JSONB NOT NULL"));
+    ok(migration.sql.includes("observation_hash STRING NOT NULL"));
     ok(migration.sql.includes("trace_id STRING NOT NULL"));
+    ok(migration.sql.includes("idempotency_key STRING NOT NULL"));
     ok(migration.sql.includes("correlation_id STRING NOT NULL"));
     ok(migration.sql.includes("policy_decision_id STRING"));
     ok(migration.sql.includes("policy_version STRING"));

--- a/agentic-organization/packages/state-cockroach/test/cockroach-sql-executor.test.ts
+++ b/agentic-organization/packages/state-cockroach/test/cockroach-sql-executor.test.ts
@@ -1,0 +1,81 @@
+import { deepEqual, equal } from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  CockroachCommandStateStoreStatement,
+  createCockroachSqlExecutor,
+  type CockroachSqlClient,
+} from "../src/index.ts";
+
+describe("cockroach SQL executor", () => {
+  test("adapts a generic Cockroach client to statement executors", async () => {
+    const client = createRecordingCockroachClient();
+    const executor = createCockroachSqlExecutor({ client });
+
+    const result = await executor.execute<{ idempotency_key: string }>({
+      name: CockroachCommandStateStoreStatement.FindIdempotencyRecord,
+      sql: "SELECT idempotency_key FROM idempotency_records WHERE idempotency_key = $1",
+      parameters: ["idem-001"],
+    });
+
+    deepEqual(client.queries, [
+      {
+        sql: "SELECT idempotency_key FROM idempotency_records WHERE idempotency_key = $1",
+        parameters: ["idem-001"],
+      },
+    ]);
+    deepEqual(result.rows, [{ idempotency_key: "idem-001" }]);
+  });
+
+  test("runs transaction statements against the transaction client", async () => {
+    const client = createRecordingCockroachClient();
+    const transactionClient = createRecordingCockroachClient();
+    client.transactionClient = transactionClient;
+    const executor = createCockroachSqlExecutor({ client });
+
+    const result = await executor.executeTransaction(async (transaction) => {
+      await transaction.execute({
+        name: CockroachCommandStateStoreStatement.InsertAuditEvent,
+        sql: "INSERT INTO audit_events (audit_event_id) VALUES ($1)",
+        parameters: ["audit-001"],
+      });
+
+      return "committed";
+    });
+
+    equal(result, "committed");
+    equal(client.transactionCount, 1);
+    deepEqual(transactionClient.queries, [
+      {
+        sql: "INSERT INTO audit_events (audit_event_id) VALUES ($1)",
+        parameters: ["audit-001"],
+      },
+    ]);
+  });
+});
+
+type RecordingCockroachClient = CockroachSqlClient & {
+  queries: { sql: string; parameters: readonly unknown[] }[];
+  transactionClient?: RecordingCockroachClient;
+  transactionCount: number;
+};
+
+function createRecordingCockroachClient(): RecordingCockroachClient {
+  const client: RecordingCockroachClient = {
+    queries: [],
+    transactionCount: 0,
+    query: async <Row = Record<string, unknown>>(sql: string, parameters: readonly unknown[]) => {
+      client.queries.push({ sql, parameters });
+
+      return {
+        rows: [{ idempotency_key: "idem-001" }] as Row[],
+      };
+    },
+    transaction: async (operation) => {
+      client.transactionCount += 1;
+      return await operation(client.transactionClient ?? client);
+    },
+  };
+
+  return client;
+}

--- a/agentic-organization/packages/test-node.d.ts
+++ b/agentic-organization/packages/test-node.d.ts
@@ -8,11 +8,11 @@ declare module "node:assert/strict" {
 
 declare module "node:crypto" {
   export type Hash = {
-    update(data: string): Hash;
+    update(data: string | Uint8Array): Hash;
     digest(encoding: "hex"): string;
   };
 
-  export function createHash(algorithm: "sha256"): Hash;
+  export function createHash(algorithm: "sha1" | "sha256"): Hash;
 }
 
 declare module "node:test" {

--- a/agentic-organization/packages/test-node.d.ts
+++ b/agentic-organization/packages/test-node.d.ts
@@ -2,7 +2,17 @@ declare module "node:assert/strict" {
   export function deepEqual(actual: unknown, expected: unknown): void;
   export function equal(actual: unknown, expected: unknown, message?: string): void;
   export function ok(value: unknown): asserts value;
+  export function rejects(action: () => Promise<unknown>, expected?: (error: unknown) => boolean): Promise<void>;
   export function throws(action: () => void, expected?: RegExp): void;
+}
+
+declare module "node:crypto" {
+  export type Hash = {
+    update(data: string): Hash;
+    digest(encoding: "hex"): string;
+  };
+
+  export function createHash(algorithm: "sha256"): Hash;
 }
 
 declare module "node:test" {

--- a/openspec/specs/agentic-organization/spec.md
+++ b/openspec/specs/agentic-organization/spec.md
@@ -473,7 +473,9 @@ live infrastructure adapters are bound by a runtime host.
 - **WHEN** the `apps/workers` runtime host parses process environment
   values
 - **THEN** it reads `AGENTIC_ORG_ENV`, `AGENTIC_ORG_ID`, `NATS_STREAM`,
-  `NATS_DURABLE`, and `NATS_INBOUND_BATCH_SIZE` through typed env names
+  `NATS_DURABLE`, `NATS_INBOUND_BATCH_SIZE`, `COCKROACH_DATABASE_URL`,
+  `WORKER_INBOUND_BATCH_SIZE`, and `WORKER_OUTBOX_BATCH_SIZE` through
+  typed env names
 - **AND** it returns typed runtime configuration for the composition root
 - **AND** packages do not read process environment values directly
 - **AND** URLs, credentials, and connection pools remain process adapter
@@ -488,11 +490,28 @@ live infrastructure adapters are bound by a runtime host.
 - **AND** the composition root returns a runnable worker runtime without
   leaking concrete adapter construction into package code
 
+#### Scenario: Workers app composes durable Cockroach worker ports
+
+- **WHEN** the `apps/workers` durable composition root is created
+- **THEN** it receives typed runtime config, a generic Cockroach SQL
+  executor, an event publisher port, an inbound event source port, a NATS
+  consumer port, telemetry sink, and runtime utilities
+- **AND** it builds Cockroach-backed command state, outbox,
+  event-ingestion, and policy-observation adapters through the
+  `state-cockroach` factory
+- **AND** it wires Cockroach-backed outbox and event-ingestion ports into
+  the package-level worker host
+- **AND** runtime, application, worker, policy, messaging, and
+  observability packages do not receive Cockroach connection pools or
+  vendor client objects
+
 #### Scenario: Workers app rejects invalid process config
 
 - **WHEN** the `apps/workers` runtime host is created with missing
-  environment, missing Organization ID, missing NATS stream, missing
-  durable consumer, or non-positive NATS inbound batch size
+  environment, missing Organization ID, missing Cockroach database URL,
+  missing NATS stream, missing durable consumer, non-positive NATS
+  inbound batch size, non-positive worker inbound batch size, or
+  non-positive worker outbox batch size
 - **THEN** runtime creation fails with a typed configuration error before
   any worker loop can start
 
@@ -515,6 +534,15 @@ live infrastructure adapters are bound by a runtime host.
   batch counts
 - **AND** invalid, payload-conflict, negative-acknowledged, or
   terminated NATS messages also make the runtime result degraded
+
+#### Scenario: Worker adapter startup failures are visible
+
+- **WHEN** Cockroach, NATS, or telemetry adapter construction or
+  readiness validation fails at the worker process boundary
+- **THEN** the worker startup path records explicit failure evidence with
+  stage, message, and configuration source
+- **AND** the process reports degraded or not-ready status instead of
+  hiding the failure before the Organization UI and agents can inspect it
 
 ### Requirement: Telemetry is complete at the event boundary
 

--- a/openspec/specs/agentic-organization/spec.md
+++ b/openspec/specs/agentic-organization/spec.md
@@ -91,6 +91,25 @@ Organization state only by calling Organization commands.
 - **AND** the command handler is not executed
 - **AND** idempotency lookup and command outcome persistence are not run
 
+#### Scenario: Denied policy observations are durable and queryable
+
+- **WHEN** a denied policy decision is observed
+- **THEN** a generic policy observation store can persist the command,
+  actor, hat assignment, scope, tool type, supervisor-chain context,
+  trace IDs, idempotency key, decision ID, policy version, denial reason,
+  canonical observation hash, and canonical observation payload
+- **AND** duplicate observations with the same policy decision ID are
+  treated as already durable only when the canonical observation hash
+  matches
+- **AND** duplicate observations with the same policy decision ID and
+  different evidence are rejected as conflicts rather than hidden as safe
+  replays
+- **AND** readers can query observations by organization, project, team,
+  work item, actor, hat assignment, and decision status without exposing
+  CockroachDB-specific types to application code
+- **AND** CockroachDB is only the first replaceable adapter behind those
+  generic policy contracts
+
 #### Scenario: Package boundaries are checked
 
 - **WHEN** package dependency-boundary tests run
@@ -537,6 +556,18 @@ UI- and agent-readable visibility record.
   tool, policy denial, harness failure, and telemetry gap
 - **AND** the weak-point indicators route follow-up work through normal
   Organization commands and supervisor-chain communication
+
+#### Scenario: Policy denial is projected to workflow visibility
+
+- **WHEN** a denied policy decision observation is projected into
+  workflow visibility
+- **THEN** the record includes command, actor, hat assignment, scope,
+  tool type, supervisor-chain source and target levels, trace IDs,
+  idempotency key, policy decision ID, policy version, denial reason, and
+  evidence-link fields
+- **AND** the record contains a typed policy-denied weak-point indicator
+  so agents can review authority, scope, and tool-grant gaps through the
+  normal Organization improvement lifecycle
 
 ### Requirement: Automation rules create plans before side effects
 


### PR DESCRIPTION
## Summary

Adds the next Agentic Organization runtime slice after #5081:

- persists denied policy decision observations behind generic policy store/reader ports
- adds a CockroachDB policy-observation adapter with scoped query support and canonical observation-hash conflict detection
- projects policy-denial observations into UI/agent workflow visibility records with typed weak-point indicators
- propagates idempotency keys through policy authorization traces
- updates architecture docs and OpenSpec for durable/queryable policy observations and replay-vs-conflict behavior

## Review Notes

- TDD path included a red test for conflicting duplicate policy observations before adding the `observation_hash` guard.
- Subagent review passes covered architecture/SOLID, correctness/TDD, and north-star/docs alignment.
- Final subagent re-review reported no remaining blockers.

## Validation

- `npm test` from `agentic-organization` (77 tests / 26 suites)
- `npm run typecheck` from `agentic-organization`
- `git diff --check origin/main..HEAD`

generated with Codex