### PR TITLE
feat(B-0792 iter-5.2.1): auto-generate node-<6hex> hostname default — operator can rename later via digital-twin (Aaron 2026-05-26)

### DIFF
--- a/full-ai-cluster/tools/zflash.ts
+++ b/full-ai-cluster/tools/zflash.ts
@@ -900,24 +900,34 @@ async function main() {
 
   // Pre-flight: determine if iter-4.2 inject will run + which key
   const pubkeyPath = sshKeyOverride ?? DEFAULT_SSH_KEY;
+  let willInject = !noInject;
+  if (willInject && !existsSync(pubkeyPath)) {
+    process.stderr.write(
+      `\nzflash: iter-4.2 inject skipped — pubkey not found at ${pubkeyPath}\n` +
+        `  (proceeding with flash; cluster node will need manual operator-ssh-keys.nix\n` +
+        `   edit + nixos-rebuild on first login per iter-4 v1 fallback)\n\n`,
+    );
+    willInject = false;
+  }
 
   // iter-5.2.1 (B-0792): if operator didn't pass --host, auto-generate
   // a random unique hostname `node-<6hex>` (24-bit entropy = ~16M
   // possible names, negligible collision risk for any homelab cluster
   // size; node-by-node mDNS uniqueness preserved). Operator can rename
-  // later via the digital-twin substrate per B-0794 self-registration:
-  // edit the node-config YAML in maintainers/<name>/cluster-nodes/<node>/
-  // → ArgoCD reconciles → hostname updates.
+  // later via the digital-twin substrate planned under B-0794 (node
+  // self-registration; not yet shipped — see B-0794 row for the
+  // target node-config substrate that will host the rename mechanism).
   //
   // The maintainer 2026-05-26: "can we have it auto generate the host
   // name we can change later via digital twin after it self registers."
   //
   // Auto-gen happens only when --host was NOT passed (preserves
-  // operator intent when they did pick a name). The generated name is
-  // logged CLEARLY pre-flash so the operator knows what to ssh to
-  // post-install. Skipped entirely when --no-inject is set (no ESP
-  // write to carry the name anyway).
-  if (hostOverride === null && !noInject) {
+  // operator intent when they did pick a name) AND when iter-4.2
+  // inject will actually run (gated on `willInject` so we never
+  // promise an ssh target for a hostname that won't be written to
+  // the USB ESP — finalized AFTER the pubkey existence check so
+  // missing-pubkey path doesn't print a misleading ssh promise).
+  if (hostOverride === null && willInject) {
     // Web Crypto: 3 random bytes → 6 hex chars; node-XXXXXX. Prefix
     // `node-` keeps the namespace clean (operator-named hosts can
     // avoid the `node-` prefix to distinguish from auto-named).
@@ -927,19 +937,9 @@ async function main() {
     hostOverride = `node-${hex}`;
     process.stdout.write(
       `\niter-5.2.1: --host not specified; auto-generated hostname: ${hostOverride}\n` +
-        `             (rename later via digital-twin substrate per B-0794)\n` +
+        `             (rename later via B-0794 digital-twin substrate when shipped)\n` +
         `             cluster will be reachable as: ssh zeta@${hostOverride}.local\n\n`,
     );
-  }
-
-  let willInject = !noInject;
-  if (willInject && !existsSync(pubkeyPath)) {
-    process.stderr.write(
-      `\nzflash: iter-4.2 inject skipped — pubkey not found at ${pubkeyPath}\n` +
-        `  (proceeding with flash; cluster node will need manual operator-ssh-keys.nix\n` +
-        `   edit + nixos-rebuild on first login per iter-4 v1 fallback)\n\n`,
-    );
-    willInject = false;
   }
 
   // Stdio inherit — child handles all I/O directly (readline, sudo Touch ID

--- a/full-ai-cluster/tools/zflash.ts
+++ b/full-ai-cluster/tools/zflash.ts
@@ -900,6 +900,38 @@ async function main() {
 
   // Pre-flight: determine if iter-4.2 inject will run + which key
   const pubkeyPath = sshKeyOverride ?? DEFAULT_SSH_KEY;
+
+  // iter-5.2.1 (B-0792): if operator didn't pass --host, auto-generate
+  // a random unique hostname `node-<6hex>` (24-bit entropy = ~16M
+  // possible names, negligible collision risk for any homelab cluster
+  // size; node-by-node mDNS uniqueness preserved). Operator can rename
+  // later via the digital-twin substrate per B-0794 self-registration:
+  // edit the node-config YAML in maintainers/<name>/cluster-nodes/<node>/
+  // → ArgoCD reconciles → hostname updates.
+  //
+  // The maintainer 2026-05-26: "can we have it auto generate the host
+  // name we can change later via digital twin after it self registers."
+  //
+  // Auto-gen happens only when --host was NOT passed (preserves
+  // operator intent when they did pick a name). The generated name is
+  // logged CLEARLY pre-flash so the operator knows what to ssh to
+  // post-install. Skipped entirely when --no-inject is set (no ESP
+  // write to carry the name anyway).
+  if (hostOverride === null && !noInject) {
+    // Web Crypto: 3 random bytes → 6 hex chars; node-XXXXXX. Prefix
+    // `node-` keeps the namespace clean (operator-named hosts can
+    // avoid the `node-` prefix to distinguish from auto-named).
+    const rand = new Uint8Array(3);
+    crypto.getRandomValues(rand);
+    const hex = Array.from(rand, (b) => b.toString(16).padStart(2, "0")).join("");
+    hostOverride = `node-${hex}`;
+    process.stdout.write(
+      `\niter-5.2.1: --host not specified; auto-generated hostname: ${hostOverride}\n` +
+        `             (rename later via digital-twin substrate per B-0794)\n` +
+        `             cluster will be reachable as: ssh zeta@${hostOverride}.local\n\n`,
+    );
+  }
+
   let willInject = !noInject;
   if (willInject && !existsSync(pubkeyPath)) {
     process.stderr.write(


### PR DESCRIPTION
Composes iter-5.2 --host mechanism with B-0794 digital-twin substrate. Zero-typing default when --host omitted: generate `node-<6hex>` via Web Crypto (24-bit entropy, ~16M names, negligible collision). Operator-named hosts take priority. Logged clearly pre-flash. Aaron 2026-05-26: 'can we have it auto generate the host name we can change later via digital twin after it self registers.'