### PR TITLE
fix(postmerge-5121): 2 Copilot findings — OS-scope shellHook + §24 reframe

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -136,17 +136,19 @@ jobs:
           iso_abs="$(pwd)/${iso_candidates[0]}"
           cd ..
           # 7z source-of-truth:
-          #   - CI (this workflow): relies on ubuntu-24.04 runners'
-          #     default 7z install (verified present on the standard
-          #     runner image).
-          #   - Local dev laptops: tools/setup/manifests/{brew,apt}
-          #     declare p7zip / p7zip-full so install.sh's macos.sh /
-          #     linux.sh paths install it during host-setup refresh.
-          # The CI runner-image pre-install is the load-bearing source
-          # here (this workflow does NOT run install.sh). Manifests
-          # cover local-dev parity only. If we ever switch off
-          # ubuntu-24.04, add an explicit "apt-get install -y
-          # p7zip-full" step before this line.
+          # (a) tools/setup/manifests/{brew,apt} declare p7zip /
+          #     p7zip-full as the canonical dependency for ALL
+          #     install.sh consumers per GOVERNANCE.md §24 (dev
+          #     laptops, CI runners, devcontainer images).
+          # (b) This SPECIFIC workflow does NOT invoke install.sh
+          #     today; it relies on ubuntu-24.04 runner-image's
+          #     default 7z pre-install (verified present on the
+          #     standard image) as a shortcut so we skip the
+          #     install.sh cost per workflow run.
+          # If we drop the ubuntu-24.04 pin OR the runner-image
+          # pre-install, the apt manifest already declares the dep
+          # — either invoke install.sh here or add an explicit
+          # apt-get install p7zip-full step before this line.
           bun tools/ci/audit-installer-iso-content.ts --iso "$iso_abs"
 
       - name: Locate ISO + capture metadata

--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -147,8 +147,11 @@ jobs:
           #     install.sh cost per workflow run.
           # If we drop the ubuntu-24.04 pin OR the runner-image
           # pre-install, the apt manifest already declares the dep
-          # — either invoke install.sh here or add an explicit
-          # apt-get install p7zip-full step before this line.
+          # — either invoke install.sh here OR add an explicit
+          # `sudo apt-get update && sudo apt-get install -y
+          # p7zip-full` step before this line (the `-y` matters in
+          # CI: without it apt-get prompts interactively and the
+          # workflow run hangs).
           bun tools/ci/audit-installer-iso-content.ts --iso "$iso_abs"
 
       - name: Locate ISO + capture metadata

--- a/full-ai-cluster/flake.nix
+++ b/full-ai-cluster/flake.nix
@@ -192,7 +192,17 @@
           ];
           shellHook = ''
             echo "zeta-ai-cluster admin shell."
-            echo "  Host setup (rare):    bash tools/setup/install.sh"
+            # install.sh hint: only show on hosts where it actually works
+            # (macOS = brew path, Debian/Ubuntu = apt path). On NixOS it
+            # would error on apt-get, so we say nothing rather than point
+            # the operator at a broken path (Copilot post-merge on #5121).
+            if [ "$(uname -s)" = "Darwin" ]; then
+              echo "  Host setup (rare):    bash tools/setup/install.sh"
+            elif [ -r /etc/os-release ] && grep -qE '^ID(_LIKE)?=.*(debian|ubuntu)' /etc/os-release; then
+              echo "  Host setup (rare):    bash tools/setup/install.sh"
+            fi
+            # NixOS users: tooling comes via this devShell's nix-managed
+            # packages above; no install.sh equivalent needed.
             echo "  Build USB ISO:        nix build .#installer-iso"
             echo "  Build host system:    nixos-rebuild build --flake .#<host>"
             echo "  Talk to cluster:      kubectl / k9s / argocd / cilium / hubble"


### PR DESCRIPTION
## Summary

Addresses 2 Copilot post-merge findings on #5121.

- **flake.nix shellHook** — install.sh hint was unconditional; conflicted with the preceding "fails on NixOS" comment. Scoped the hint to macOS + Debian/Ubuntu (where install.sh actually works); NixOS gets no hint (tooling comes via devShell nix-managed packages).
- **workflow comment** — "local-dev parity only" understated the manifests' role per §24. Reframed: manifests ARE the canonical declaration for ALL install.sh consumers; THIS workflow doesn't invoke install.sh as a per-run-cost shortcut.

### Behavioral change (substrate-honest update — earlier claim of "no behavior change" was incomplete)

The shellHook IS now conditional on host OS, so user-facing output of `nix develop` changes:
- macOS hosts: print the `Host setup (rare): bash tools/setup/install.sh` hint (unchanged behavior)
- Debian/Ubuntu Linux hosts: same hint (unchanged behavior)
- NixOS hosts: hint suppressed (new behavior — was previously a footgun pointing operators at a path that errors on `apt-get`)

No code-execution change; only a one-line output difference per OS.

### Follow-on fix (commit `3562f925e` on this branch)

Per Copilot finding on this PR: the workflow comment's documented future-proof fallback "if we drop the ubuntu-24.04 pre-install, add `apt-get install p7zip-full`" would hang interactively in CI without `-y`. Reworded to `sudo apt-get update && sudo apt-get install -y p7zip-full` with an inline note explaining why `-y` matters.

## Test plan

- [x] flake.nix shellHook conditional reads cleanly (uname -s + /etc/os-release ID check)
- [x] No syntax break in YAML or Nix
- [x] All 3 OS branches verified mentally: macOS prints hint, Debian/Ubuntu prints hint, NixOS prints nothing
- [x] apt-get fallback documented with `-y` to avoid CI hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)