### PR TITLE
fix(ci P0): cascade #4 audit blocking ALL ISO builds since #5119 — bootloader any-of

### DIFF
--- a/tools/ci/audit-installer-iso-content.ts
+++ b/tools/ci/audit-installer-iso-content.ts
@@ -282,11 +282,11 @@ function auditIsoContent(isoPath: string): readonly AuditFailure[] | AuditError 
   // Bootloader any-of check: at least one of the known bootloader paths
   // must exist. NixOS installer ISOs vary in which bootloader they ship
   // by channel (isolinux/refind today; could change in future channels);
-  // any-of keeps the audit forward-compatible.
-  const bootloaderHit = REQUIRED_BOOTLOADER_ANY.find(
-    (b) => entryByPath.has(b.path),
-  );
-  if (bootloaderHit === undefined) {
+  // any-of keeps the audit forward-compatible. Use `.some()` (boolean)
+  // rather than `.find()` (Copilot P0 on #5125: under noUnusedLocals
+  // the unused `bootloaderHit` const would fail tsc; .some avoids the
+  // unused-variable shape entirely).
+  if (!REQUIRED_BOOTLOADER_ANY.some((b) => entryByPath.has(b.path))) {
     failures.push({
       kind: "missing-path",
       path: REQUIRED_BOOTLOADER_ANY.map((b) => b.path).join(" | "),

--- a/tools/ci/audit-installer-iso-content.ts
+++ b/tools/ci/audit-installer-iso-content.ts
@@ -78,6 +78,17 @@ function parseArgs(argv: readonly string[]): Args | ArgError {
 // `nixos-generators -f iso` / `nixosConfigurations.installer.config
 // .system.build.isoImage`. If the structure changes upstream, add
 // the new expected files here.
+//
+// IMPORTANT — empirically learned 2026-05-26: NixOS installer ISOs do
+// NOT put bootloader configs at the legacy `boot/grub/grub.cfg` path.
+// BIOS boot uses isolinux (`isolinux/isolinux.cfg`); UEFI boot uses
+// refind (`EFI/BOOT/refind_x64.efi`). Earlier draft asserted
+// `boot/grub/grub.cfg` and blocked every ISO build from PR #5119 →
+// #5125 because the audit's REQUIRED list didn't match NixOS-actual
+// layout. The 3 must-exist paths below ARE sufficient to assert
+// "this is a bootable NixOS installer ISO" — without nix-store.squashfs
+// + kernel + initrd, nothing boots. Bootloader presence is asserted
+// separately via REQUIRED_BOOTLOADER_ANY (one-of family) below.
 const REQUIRED_ISO_PATHS: readonly { path: string; rationale: string }[] = [
   {
     path: "nix-store.squashfs",
@@ -91,9 +102,29 @@ const REQUIRED_ISO_PATHS: readonly { path: string; rationale: string }[] = [
     path: "boot/initrd",
     rationale: "initramfs; bootable ISO must include it",
   },
+];
+
+// At least ONE of these bootloader-config paths must exist for the ISO
+// to be bootable. NixOS installer ISOs as of nixos-24.11 use isolinux
+// for BIOS + refind for UEFI; future channels may change. The "any-of"
+// assertion keeps the audit useful across NixOS-version bootloader
+// shifts without re-breaking when the channel bumps.
+const REQUIRED_BOOTLOADER_ANY: readonly { path: string; rationale: string }[] = [
+  {
+    path: "isolinux/isolinux.cfg",
+    rationale: "BIOS boot config (isolinux) — present on standard NixOS installer ISOs",
+  },
+  {
+    path: "EFI/BOOT/refind_x64.efi",
+    rationale: "UEFI boot loader (refind) — present on standard NixOS installer ISOs",
+  },
+  {
+    path: "EFI/BOOT/BOOTX64.EFI",
+    rationale: "UEFI boot loader (generic) — alternative naming",
+  },
   {
     path: "boot/grub/grub.cfg",
-    rationale: "Grub bootloader config; UEFI + BIOS boot paths use this",
+    rationale: "GRUB config (legacy) — kept for forward-compatibility if NixOS switches",
   },
 ];
 
@@ -247,6 +278,20 @@ function auditIsoContent(isoPath: string): readonly AuditFailure[] | AuditError 
         detail: `entry present but size=${entry.size} (header comment promises non-empty)`,
       });
     }
+  }
+  // Bootloader any-of check: at least one of the known bootloader paths
+  // must exist. NixOS installer ISOs vary in which bootloader they ship
+  // by channel (isolinux/refind today; could change in future channels);
+  // any-of keeps the audit forward-compatible.
+  const bootloaderHit = REQUIRED_BOOTLOADER_ANY.find(
+    (b) => entryByPath.has(b.path),
+  );
+  if (bootloaderHit === undefined) {
+    failures.push({
+      kind: "missing-path",
+      path: REQUIRED_BOOTLOADER_ANY.map((b) => b.path).join(" | "),
+      rationale: `none of the known bootloader configs found; ISO is unlikely to boot. Candidates checked: ${REQUIRED_BOOTLOADER_ANY.map((b) => `${b.path} (${b.rationale})`).join("; ")}`,
+    });
   }
   return failures;
 }


### PR DESCRIPTION
## Summary — URGENT P0

The cascade #4 ISO content audit (shipped in #5119) is **blocking every ISO build since merge**. Empirical: 4 consecutive workflow failures on commits `35fd3aeef`, `848467588`, `5d9f8605a`, `ed6a7b8b9` — all on the audit step asserting `boot/grub/grub.cfg` as a required path.

**The assertion was wrong.** NixOS installer ISOs as of `nixos-24.11` use:
- **isolinux** for BIOS boot → `isolinux/isolinux.cfg`
- **refind** for UEFI boot → `EFI/BOOT/refind_x64.efi`

Not legacy GRUB at `boot/grub/grub.cfg`. The build log even shows `efi-image_eltorito > Copying grub.cfg` — it lands in `EFI/`, not `boot/grub/`. My cascade #4 draft was version-skewed (training-data default leaked through — ironically the exact gap **B-0805 capstone** names as the systemic agent-discipline failure mode).

## What this means for the maintainer

The last successful ISO build was **`17523e4fb`** (PR #5117, iter-5.2.1 era) — BEFORE iter-5.2.2 (login-banner) and iter-5.3 (password prompt) shipped. If the maintainer flashed a CI artifact today, they'd get a stale ISO missing both. **Hold off on re-flash until this merges + next ISO builds green.**

## Fix

- Drop `boot/grub/grub.cfg` from `REQUIRED_ISO_PATHS` — the remaining 3 (nix-store.squashfs + boot/bzImage + boot/initrd) are sufficient to assert "bootable NixOS installer ISO" (without those nothing boots).
- Add `REQUIRED_BOOTLOADER_ANY` — at-least-one-of family check across known NixOS bootloader layouts (isolinux + refind variants + legacy grub for forward-compat).
- Header comment documents the empirical anchor so future-Otto doesn't reintroduce the legacy-path assumption.

## Test plan

- [x] TS typecheck clean
- [ ] Auto-merge armed; CI build will confirm the audit no longer false-positives
- [ ] Post-merge: verify next CI ISO build succeeds + names commit SHA for the maintainer's re-flash

## Composes with

- B-0805 (capstone, P1) — dep-pin-search-first-authority discipline; this PR is exactly the kind of failure that backlog row was designed to prevent

🤖 Generated with [Claude Code](https://claude.com/claude-code)