### PR TITLE
fix(B-0058): filter-gate-log test no longer pollutes production ethics-decision log

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/26/0814Z.md
+++ b/docs/hygiene-history/ticks/2026/05/26/0814Z.md
@@ -9,7 +9,7 @@ Two file changes on `otto-cli/filter-gate-log-test-pollution-fix-2026-05-26`:
 - `tools/alignment/filter_gate_log.ts` (+4 lines): `logFilePath()` now honors `FILTER_GATE_LOG_PATH` env-var override; defaults preserved.
 - `tools/alignment/filter_gate_log.test.ts` (~24-line change): the previously-polluting `--record` test now uses `mkdtempSync` + env-var override + try/finally cleanup; adds stronger assertion that the entry was actually written.
 
-Verification: `bun test tools/alignment/` — **141/141 pass**; after test run, no `tools/alignment/out/filter-gate-log.jsonl` is created in the worktree. Commit canary (`ls-tree HEAD~1 == HEAD == 61`) passed per [`codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md).
+Verification: `bun test tools/alignment/` — **141/141 pass**; after test run, no `tools/alignment/out/filter-gate-log.jsonl` is created in the worktree. Commit canary (`ls-tree HEAD~1 == HEAD == 61`) passed per [`codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md).
 
 ## How the bug was found
 
@@ -17,7 +17,7 @@ Step-1 worldview refresh on autonomous-loop tick surfaced an untracked `tools/al
 
 ## Why this counts as concrete decomposition
 
-Per [`holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) counter-reset condition #3 ("Actually picking real decomposition work — Concrete artifact"): the substrate-landing is a bounded fix, commits a real change, ships through CI gates, and produces a re-verifiable artifact (production log no longer touched by test runs). Not brief-ack; not fabricated engineering.
+Per [`holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) counter-reset condition #3 ("Actually picking real decomposition work — Concrete artifact"): the substrate-landing is a bounded fix, commits a real change, ships through CI gates, and produces a re-verifiable artifact (production log no longer touched by test runs). Not brief-ack; not fabricated engineering.
 
 ## State observations
 
@@ -31,7 +31,7 @@ Per [`holding-without-named-dependency-is-standing-by-failure.md`](../../../../.
 ## Composes with
 
 - B-0058 (filter-gate honesty log substrate the production log is part of)
-- [`.claude/rules/refresh-before-decide.md`](../../../../../.claude/rules/refresh-before-decide.md) — Step-1 worldview refresh surfaced the untracked file
-- [`.claude/rules/fighting-past-self-vs-peer-agent-distinguisher-fix-your-own-coordinate-on-peers-dont-punt-by-default.md`](../../../../../.claude/rules/fighting-past-self-vs-peer-agent-distinguisher-fix-your-own-coordinate-on-peers-dont-punt-by-default.md) — file was authored by maintainer (Aaron Stainback per `git log`), not peer-agent in-progress; safe to fix directly
-- [`.claude/rules/agent-worktree-hygiene-never-hold-main-never-step-on-operator-cleanup-on-pr-merge.md`](../../../../../.claude/rules/agent-worktree-hygiene-never-hold-main-never-step-on-operator-cleanup-on-pr-merge.md) — used `--detach origin/main`; never held `main` branch ref
-- [`.claude/rules/zeta-expected-branch.md`](../../../../../.claude/rules/zeta-expected-branch.md) — branch-guard fired before commit
+- [`.claude/rules/refresh-before-decide.md`](../../../../../../.claude/rules/refresh-before-decide.md) — Step-1 worldview refresh surfaced the untracked file
+- [`.claude/rules/fighting-past-self-vs-peer-agent-distinguisher-fix-your-own-coordinate-on-peers-dont-punt-by-default.md`](../../../../../../.claude/rules/fighting-past-self-vs-peer-agent-distinguisher-fix-your-own-coordinate-on-peers-dont-punt-by-default.md) — file was authored by maintainer (Aaron Stainback per `git log`), not peer-agent in-progress; safe to fix directly
+- [`.claude/rules/agent-worktree-hygiene-never-hold-main-never-step-on-operator-cleanup-on-pr-merge.md`](../../../../../../.claude/rules/agent-worktree-hygiene-never-hold-main-never-step-on-operator-cleanup-on-pr-merge.md) — used `--detach origin/main`; never held `main` branch ref
+- [`.claude/rules/zeta-expected-branch.md`](../../../../../../.claude/rules/zeta-expected-branch.md) — branch-guard fired before commit

--- a/docs/hygiene-history/ticks/2026/05/26/0814Z.md
+++ b/docs/hygiene-history/ticks/2026/05/26/0814Z.md
@@ -1,0 +1,37 @@
+# 2026-05-26T08:14Z tick — Otto-CLI fix(B-0058) filter-gate-log test pollution
+
+## What landed
+
+**[PR #5128](https://github.com/Lucent-Financial-Group/Zeta/pull/5128) — fix(B-0058): filter-gate-log test no longer pollutes production ethics-decision log** (auto-merge armed; required checks in progress at shard-write time).
+
+Two file changes on `otto-cli/filter-gate-log-test-pollution-fix-2026-05-26`:
+
+- `tools/alignment/filter_gate_log.ts` (+4 lines): `logFilePath()` now honors `FILTER_GATE_LOG_PATH` env-var override; defaults preserved.
+- `tools/alignment/filter_gate_log.test.ts` (~24-line change): the previously-polluting `--record` test now uses `mkdtempSync` + env-var override + try/finally cleanup; adds stronger assertion that the entry was actually written.
+
+Verification: `bun test tools/alignment/` — **141/141 pass**; after test run, no `tools/alignment/out/filter-gate-log.jsonl` is created in the worktree. Commit canary (`ls-tree HEAD~1 == HEAD == 61`) passed per [`codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md).
+
+## How the bug was found
+
+Step-1 worldview refresh on autonomous-loop tick surfaced an untracked `tools/alignment/out/filter-gate-log.jsonl` (2 lines, both `skill:test-entry` from author `Lior` on 2026-05-25T22:52). Investigation traced both lines to the integration test at `filter_gate_log.test.ts:302` which called `main()` with real production args. The file had no git history despite the alignment-substrate documentation (B-0058 responsibility #3) calling for a real persistent ethics-gate log — every "real" entry the log might have carried would be commingled with this test pollution.
+
+## Why this counts as concrete decomposition
+
+Per [`holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) counter-reset condition #3 ("Actually picking real decomposition work — Concrete artifact"): the substrate-landing is a bounded fix, commits a real change, ships through CI gates, and produces a re-verifiable artifact (production log no longer touched by test runs). Not brief-ack; not fabricated engineering.
+
+## State observations
+
+- Local was 11 commits behind `origin/main`; fast-forwarded clean
+- 0 stuck git pack/maintenance/repack procs at session start
+- 0 peer Lior procs at session start
+- Sentinel was empty at cold-boot (catch-43 fired); re-armed `0a8e0237`
+- Isolated worktree clean: `git worktree add --detach origin/main` extracted 6684/6684 files; ls-tree=61; status=0
+- GraphQL tier: Normal (5000-budget zone)
+
+## Composes with
+
+- B-0058 (filter-gate honesty log substrate the production log is part of)
+- [`.claude/rules/refresh-before-decide.md`](../../../../../.claude/rules/refresh-before-decide.md) — Step-1 worldview refresh surfaced the untracked file
+- [`.claude/rules/fighting-past-self-vs-peer-agent-distinguisher-fix-your-own-coordinate-on-peers-dont-punt-by-default.md`](../../../../../.claude/rules/fighting-past-self-vs-peer-agent-distinguisher-fix-your-own-coordinate-on-peers-dont-punt-by-default.md) — file was authored by maintainer (Aaron Stainback per `git log`), not peer-agent in-progress; safe to fix directly
+- [`.claude/rules/agent-worktree-hygiene-never-hold-main-never-step-on-operator-cleanup-on-pr-merge.md`](../../../../../.claude/rules/agent-worktree-hygiene-never-hold-main-never-step-on-operator-cleanup-on-pr-merge.md) — used `--detach origin/main`; never held `main` branch ref
+- [`.claude/rules/zeta-expected-branch.md`](../../../../../.claude/rules/zeta-expected-branch.md) — branch-guard fired before commit

--- a/tools/alignment/filter_gate_log.test.ts
+++ b/tools/alignment/filter_gate_log.test.ts
@@ -304,6 +304,7 @@ describe("main() CLI", () => {
   test("returns 0 for valid --record (writes to tempdir, not production log)", () => {
     const tmpDir = mkdtempSync(join(tmpdir(), "filter-gate-test-"));
     const tmpLog = join(tmpDir, "filter-gate-log.jsonl");
+    const priorOverride = process.env.FILTER_GATE_LOG_PATH;
     process.env.FILTER_GATE_LOG_PATH = tmpLog;
     try {
       const code = main([
@@ -319,7 +320,11 @@ describe("main() CLI", () => {
       expect(entries.length).toBe(1);
       expect(entries[0]?.candidate).toBe("skill:test-entry");
     } finally {
-      delete process.env.FILTER_GATE_LOG_PATH;
+      if (priorOverride === undefined) {
+        delete process.env.FILTER_GATE_LOG_PATH;
+      } else {
+        process.env.FILTER_GATE_LOG_PATH = priorOverride;
+      }
       rmSync(tmpDir, { recursive: true, force: true });
     }
   });

--- a/tools/alignment/filter_gate_log.test.ts
+++ b/tools/alignment/filter_gate_log.test.ts
@@ -6,7 +6,9 @@
 // Run: bun test tools/alignment/filter_gate_log.test.ts
 
 import { describe, expect, test } from "bun:test";
-import { rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   computeSummary,
   type FilterGateEntry,
@@ -299,14 +301,26 @@ describe("main() CLI", () => {
     ])).toBe(1);
   });
 
-  test("returns 0 for valid --record", () => {
-    const code = main([
-      "--record",
-      "--candidate", "skill:test-entry",
-      "--source", "B-0056",
-      "--decision", "pass",
-      "--rationale", "Integration test entry",
-    ]);
-    expect(code).toBe(0);
+  test("returns 0 for valid --record (writes to tempdir, not production log)", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "filter-gate-test-"));
+    const tmpLog = join(tmpDir, "filter-gate-log.jsonl");
+    process.env.FILTER_GATE_LOG_PATH = tmpLog;
+    try {
+      const code = main([
+        "--record",
+        "--candidate", "skill:test-entry",
+        "--source", "B-0056",
+        "--decision", "pass",
+        "--rationale", "Integration test entry",
+      ]);
+      expect(code).toBe(0);
+      expect(existsSync(tmpLog)).toBe(true);
+      const entries = readLog(tmpLog);
+      expect(entries.length).toBe(1);
+      expect(entries[0]?.candidate).toBe("skill:test-entry");
+    } finally {
+      delete process.env.FILTER_GATE_LOG_PATH;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tools/alignment/filter_gate_log.ts
+++ b/tools/alignment/filter_gate_log.ts
@@ -101,7 +101,11 @@ function gitUser(): string {
 
 const LOG_PATH = "tools/alignment/out/filter-gate-log.jsonl";
 
+// Tests set FILTER_GATE_LOG_PATH to a tempdir to avoid polluting the
+// production ethics-decision log with `skill:test-entry` entries.
 export function logFilePath(): string {
+  const override = process.env.FILTER_GATE_LOG_PATH;
+  if (override !== undefined && override !== "") return override;
   return join(repoRoot(), LOG_PATH);
 }
 

--- a/tools/alignment/filter_gate_log.ts
+++ b/tools/alignment/filter_gate_log.ts
@@ -101,10 +101,12 @@ function gitUser(): string {
 
 const LOG_PATH = "tools/alignment/out/filter-gate-log.jsonl";
 
-// Tests set FILTER_GATE_LOG_PATH to a tempdir to avoid polluting the
-// production ethics-decision log with `skill:test-entry` entries.
+// Tests set FILTER_GATE_LOG_PATH to a full FILE path inside a tempdir
+// (NOT a directory) to avoid polluting the production ethics-decision
+// log with `skill:test-entry` entries. recordEntry() will append to
+// this path; pointing it at a directory yields EISDIR at write time.
 export function logFilePath(): string {
-  const override = process.env.FILTER_GATE_LOG_PATH;
+  const override = process.env.FILTER_GATE_LOG_PATH?.trim();
   if (override !== undefined && override !== "") return override;
   return join(repoRoot(), LOG_PATH);
 }


### PR DESCRIPTION
## Summary

- `tools/alignment/filter_gate_log.test.ts:302` ran `main()` with production args, so every test run wrote `skill:test-entry` entries to the real production log at `tools/alignment/out/filter-gate-log.jsonl`.
- Empirical anchor: 2026-05-25T22:52Z Lior test run left 2 polluting entries in the local checkout. The file was never committed because it carried only test pollution; per B-0058 responsibility #3 it is supposed to carry only real ethics-gate decisions.
- Fix adds an env-var override (`FILTER_GATE_LOG_PATH`) for `logFilePath()` and updates the polluting test to use `mkdtempSync` + try/finally cleanup.

## What changed

- `tools/alignment/filter_gate_log.ts`: `logFilePath()` now checks `process.env.FILTER_GATE_LOG_PATH` first; defaults to repo path. Additive; no API break.
- `tools/alignment/filter_gate_log.test.ts`: the previously-polluting `--record` test now creates a tempdir, sets the env override, asserts the entry was actually written (stronger than the old `expect(code).toBe(0)` check), and cleans up in `finally`.

## Test plan

- [x] `bun test tools/alignment/filter_gate_log.test.ts` — 33/33 pass
- [x] `bun test tools/alignment/` — 141/141 pass (no other tests affected)
- [x] After test run, no `tools/alignment/out/filter-gate-log.jsonl` is created
- [x] `audit_candidate_failures.ts` (only other consumer of `logFilePath()`) reads via the same function — env override works transparently
- [x] Commit canary (`ls-tree HEAD~1 == HEAD == 61`) per `codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)