### PR TITLE
fix(B-0806): substrate-honest correction — Ace agenda already encodes 'package manager of package managers'; B-0806 sits INSIDE Ace not parallel to it

### DIFF
--- a/docs/backlog/P2/B-0806-ansible-gitops-plus-crossplane-cross-os-declarative-management-for-windows-macs-non-nixos-linux-aaron-2026-05-26.md
+++ b/docs/backlog/P2/B-0806-ansible-gitops-plus-crossplane-cross-os-declarative-management-for-windows-macs-non-nixos-linux-aaron-2026-05-26.md
@@ -33,7 +33,7 @@ The maintainer 2026-05-26: *"This is good for declarative oses other than nix li
 Today's substrate covers:
 
 - **NixOS** (cluster nodes): declarative via `full-ai-cluster/flake.nix` + `nixos-rebuild switch`; iter-6.x cluster-update arc (B-0800–B-0805) automates within-channel + cross-channel updates
-- **macOS** (dev laptops, maintainer's primary Mac): imperative via `tools/setup/macos.sh` → Homebrew + mise; idempotent + auto-updating per [B-0805](B-0805-iter-6-5-all-deps-current-version-audit-nix-flake-argocd-helm-charts-otto-training-data-stale-defaults-must-search-first-aaron-2026-05-26.md) discipline but NOT declaratively-driven from git
+- **macOS** (dev laptops, maintainer's primary Mac): imperative via `tools/setup/macos.sh` → Homebrew + mise; idempotent + auto-updating per [B-0805](../P1/B-0805-iter-6-5-all-deps-current-version-audit-nix-flake-argocd-helm-charts-otto-training-data-stale-defaults-must-search-first-aaron-2026-05-26.md) discipline but NOT declaratively-driven from git
 - **Debian/Ubuntu Linux** (CI runners, contributor laptops): imperative via `tools/setup/linux.sh` → apt + mise; same shape as macOS
 - **Windows**: no substrate today
 
@@ -75,7 +75,7 @@ spec:
 
 ArgoCD watches a Git folder of these CRs; an Ansible Operator (Red Hat AAP or community) spins up pods to execute the playbook against the named external host.
 
-**Fit for Zeta**: HIGH (the maintainer 2026-05-26 clarification: *"we are alwasy going to have k8s i don't mind the coupling but we can support both"*). K8s is always present in Zeta's substrate (the `full-ai-cluster/` is the cluster substrate; not optional). Operator-pattern coupling is therefore not a rejection criterion. Remaining concern is SSH/WinRM access from cluster pods to the operator's heterogeneous machines — iter-5.4 [B-0794](B-0794-iter-5-4-homelab-gh-auth-login-device-flow-zeta-cluster-node-registration-into-github-no-shipped-keys-aaron-mika-2026-05-26.md) homelab gh-auth + tailscale-equivalent unlock this. Pattern 1 + Pattern 3 can BOTH ship; pick per use case (Operator for cluster-orchestrated workstation config; ansible-pull for fully-disconnected/edge hosts).
+**Fit for Zeta**: HIGH (the maintainer 2026-05-26 clarification: *"we are alwasy going to have k8s i don't mind the coupling but we can support both"*). K8s is always present in Zeta's substrate (the `full-ai-cluster/` is the cluster substrate; not optional). Operator-pattern coupling is therefore not a rejection criterion. Remaining concern is SSH/WinRM access from cluster pods to the operator's heterogeneous machines — iter-5.4 [B-0794](../P1/B-0794-node-self-registers-in-git-under-maintainers-cluster-nodes-triggers-argocd-full-bringup-of-k8s-apps-charts-gitops-native-cluster-substrate-aaron-2026-05-26.md) homelab gh-auth + tailscale-equivalent unlock this. Pattern 1 + Pattern 3 can BOTH ship; pick per use case (Operator for cluster-orchestrated workstation config; ansible-pull for fully-disconnected/edge hosts).
 
 ### Pattern 2 — Webhook Model (Agentless Push from Ansible Automation Platform)
 
@@ -101,7 +101,7 @@ Each target host runs `ansible-pull` from cron / systemd timer / launchd / Windo
 - No commercial dependency
 - No central orchestrator needed
 - Works on macOS, Windows (via WSL or native), and any Linux distro out of the box
-- Composes with our agent-discipline rules per [B-0805](B-0805-iter-6-5-all-deps-current-version-audit-nix-flake-argocd-helm-charts-otto-training-data-stale-defaults-must-search-first-aaron-2026-05-26.md) (idempotent playbooks; declarative state; same git-as-source-of-truth)
+- Composes with our agent-discipline rules per [B-0805](../P1/B-0805-iter-6-5-all-deps-current-version-audit-nix-flake-argocd-helm-charts-otto-training-data-stale-defaults-must-search-first-aaron-2026-05-26.md) (idempotent playbooks; declarative state; same git-as-source-of-truth)
 
 **Recommendation: support BOTH Pattern 1 (Operator) AND Pattern 3 (`ansible-pull`)** per the maintainer 2026-05-26: *"we are alwasy going to have k8s i don't mind the coupling but we can support both"*. Operator-pattern for cluster-orchestrated workstation reconciliation (the maintainer's workstations reachable from cluster); ansible-pull for fully-disconnected / edge hosts where the cluster can't reach in. Pattern 2 (commercial AAP) stays rejected on cost.
 
@@ -122,7 +122,7 @@ The maintainer's 2026-05-26 follow-ups in this conversation:
 | **[Ace trajectory](../../trajectories/ace-package-manager-skill-crystallization-pipeline/RESUME.md)** | Active trajectory state + RESUME context |
 | **Canonical project memory** ([`project_ace_package_manager_unrestricted_local_models_guardian_oversight_aaron_2026_05_07.md`](../../../memory/project_ace_package_manager_unrestricted_local_models_guardian_oversight_aaron_2026_05_07.md)) | Distributes UNRESTRICTED LOCAL MODELS (researchers + lawyers needing dangerous/sensitive content); Guardian/KSK gates EXTERNALIZED effects (not topics); Bond Curve pricing on actions; receipts stay local; composes with Itron runtime for the capability/effect boundary |
 | **[Homebrew-shape distribution memory](../../../memory/feedback_aaron_ace_package_manager_homebrew_shape_bootstrap_website_chat_interface_full_distribution_stack_no_setup_needed_2026_05_13.md)** | Full distribution stack = website + chat interface + Homebrew-shape one-liner + Ace + local AI + Guardian/KSK; no setup needed beyond website visit |
-| **[B-0247](../P*/B-0247-*.md)** (parent) | ace-dlc-content-packs-kernel-extensions-package-manager |
+| **[B-0247](../P1/B-0247-ace-dlc-content-packs-kernel-extensions-package-manager-2026-05-07.md)** (parent) | ace-dlc-content-packs-kernel-extensions-package-manager |
 | **[B-0287](../P1/B-0287-ace-dlc-package-format-spec-2026-05-08.md)** (closed) | Package format spec — manifest, content hash, signature, versioning |
 | **[B-0288](../P1/B-0288-ace-dlc-package-manager-cli-2026-05-08.md)** (in-progress) | CLI at `tools/ace/` with install/verify/list |
 | **[B-0424](../P1/B-0424-three-repo-split-stage1-create-forge-ace-with-scaffolding-aaron-2026-05-13.md)** | Repo-split scaffolding for Ace |
@@ -313,7 +313,7 @@ Same shape as macOS sub-target. Covers Debian/Ubuntu/Fedora/Arch dev laptops + b
 
 ### Sub-target 5 — Idempotency + dep-pin discipline encoding
 
-Per [B-0805](B-0805-iter-6-5-all-deps-current-version-audit-nix-flake-argocd-helm-charts-otto-training-data-stale-defaults-must-search-first-aaron-2026-05-26.md): ansible playbooks AND Crossplane provider versions need the same WebSearch-current-version-pin discipline. Add ansible-galaxy collection versions + Crossplane provider versions to the audit tool's scope when sub-target 1+3 implement.
+Per [B-0805](../P1/B-0805-iter-6-5-all-deps-current-version-audit-nix-flake-argocd-helm-charts-otto-training-data-stale-defaults-must-search-first-aaron-2026-05-26.md): ansible playbooks AND Crossplane provider versions need the same WebSearch-current-version-pin discipline. Add ansible-galaxy collection versions + Crossplane provider versions to the audit tool's scope when sub-target 1+3 implement.
 
 ## Acceptance (at the iter-7 capstone scope)
 
@@ -348,18 +348,18 @@ These are sub-target-blocking design decisions; the iter-7 implementation arc st
 ## Composes with
 
 - **[B-0288](../P1/B-0288-ace-dlc-package-manager-cli-2026-05-08.md)** (in-progress) — Ace DLC package manager; the cross-OS package layer that ansible-pull/Operator invokes per the maintainer 2026-05-26 architectural clarification. Ansible orchestrates, Ace installs.
-- [B-0794](B-0794-iter-5-4-homelab-gh-auth-login-device-flow-zeta-cluster-node-registration-into-github-no-shipped-keys-aaron-mika-2026-05-26.md) — homelab gh-auth device-flow enables hosts to authenticate to git for the pull side
+- [B-0794](../P1/B-0794-node-self-registers-in-git-under-maintainers-cluster-nodes-triggers-argocd-full-bringup-of-k8s-apps-charts-gitops-native-cluster-substrate-aaron-2026-05-26.md) — homelab gh-auth device-flow enables hosts to authenticate to git for the pull side
 - [B-0800](B-0800-iter-6-0-bump-nixpkgs-24-11-to-25-11-warbler-xantusia-eol-recovery-aaron-2026-05-26.md) — nixpkgs bump precedes any ansible-on-NixOS work (rare; cluster nodes stay NixOS-native)
 - [B-0801](../P2/B-0801-iter-6-1-system-autoupgrade-nixos-modules-common-weekly-schedule-no-auto-reboot-aaron-2026-05-26.md) — `system.autoUpgrade` is the analog pattern at NixOS-cluster scope; ansible-pull is the analog at heterogeneous-OS scope
 - [B-0803](../P2/B-0803-iter-6-3-deploy-rs-from-ci-gitops-flake-lock-pull-with-auto-rollback-aaron-2026-05-26.md) — deploy-rs is the K8s-deploy-style; this row is the OS-deploy-style; both compose
-- [B-0805](B-0805-iter-6-5-all-deps-current-version-audit-nix-flake-argocd-helm-charts-otto-training-data-stale-defaults-must-search-first-aaron-2026-05-26.md) — ansible collection version + Crossplane provider version pins need the same WebSearch discipline
+- [B-0805](../P1/B-0805-iter-6-5-all-deps-current-version-audit-nix-flake-argocd-helm-charts-otto-training-data-stale-defaults-must-search-first-aaron-2026-05-26.md) — ansible collection version + Crossplane provider version pins need the same WebSearch discipline
 - [`.claude/rules/dep-pin-search-first-authority.md`](../../.claude/rules/dep-pin-search-first-authority.md) — implementation-time discipline for ansible-galaxy / Crossplane provider version pinning
 - [`.claude/rules/m-acc-multi-oracle-end-user-moral-invariants.md`](../../.claude/rules/m-acc-multi-oracle-end-user-moral-invariants.md) — multi-oracle pattern applied at substrate-class scope (ArgoCD + NixOS + Ansible + Crossplane each oracle one substrate domain)
 
 ## Sources
 
 - The maintainer 2026-05-26 source paste — three Ansible+GitOps patterns table
-- [Crossplane Documentation](https://www.crossplane.io/) — current latest stable (verify per [B-0805](B-0805-iter-6-5-all-deps-current-version-audit-nix-flake-argocd-helm-charts-otto-training-data-stale-defaults-must-search-first-aaron-2026-05-26.md) at implementation time)
+- [Crossplane Documentation](https://www.crossplane.io/) — current latest stable (verify per [B-0805](../P1/B-0805-iter-6-5-all-deps-current-version-audit-nix-flake-argocd-helm-charts-otto-training-data-stale-defaults-must-search-first-aaron-2026-05-26.md) at implementation time)
 - [Ansible Documentation](https://docs.ansible.com/) — `ansible-pull` reference
 - [Red Hat Ansible Automation Platform](https://www.redhat.com/en/technologies/management/ansible) — commercial Pattern-2 reference (rejected for cost)
 - [AWX (open-source AAP)](https://github.com/ansible/awx) — Pattern-2 OSS alternative if needed later

--- a/docs/backlog/P2/B-0806-ansible-gitops-plus-crossplane-cross-os-declarative-management-for-windows-macs-non-nixos-linux-aaron-2026-05-26.md
+++ b/docs/backlog/P2/B-0806-ansible-gitops-plus-crossplane-cross-os-declarative-management-for-windows-macs-non-nixos-linux-aaron-2026-05-26.md
@@ -126,12 +126,58 @@ The maintainer's 2026-05-26 follow-ups in this conversation:
 | **[B-0287](../P1/B-0287-ace-dlc-package-format-spec-2026-05-08.md)** (closed) | Package format spec — manifest, content hash, signature, versioning |
 | **[B-0288](../P1/B-0288-ace-dlc-package-manager-cli-2026-05-08.md)** (in-progress) | CLI at `tools/ace/` with install/verify/list |
 | **[B-0424](../P1/B-0424-three-repo-split-stage1-create-forge-ace-with-scaffolding-aaron-2026-05-13.md)** | Repo-split scaffolding for Ace |
-| **[B-0742](../P2/B-0742-reference-k8s-local-stack-as-aces-distributable-poc-hats-as-negotiated-fork-structure-on-top-deterministic-declarative-gitops-ai-native-human-native-aaron-2026-05-25.md)** | K8s-local-stack as Ace's distributable POC; hats as negotiated fork structure |
-| **[B-0777](../P1/B-0777-industry-sharp-categories-plus-per-persona-ontology-maps-plus-ace-package-manager-negotiation-aaron-2026-05-25.md)** | Ace package-manager negotiation + ontology maps |
+| **[B-0742](../P2/B-0742-reference-k8s-local-stack-as-aces-distributable-poc-hats-as-negotiated-fork-structure-on-top-deterministic-declarative-gitops-ai-native-human-native-aaron-2026-05-25.md)** | K8s-local-stack as Ace's distributable POC; hats as negotiated fork structure on top of deterministic-declarative-gitops |
+| **[B-0777](../P1/B-0777-industry-sharp-categories-plus-per-persona-ontology-maps-plus-ace-package-manager-negotiation-aaron-2026-05-25.md)** | Ace package-manager negotiation + per-persona ontology maps |
+| **B-0741** (CLOSED 2026-05-26 prematurely during this session's stale-triage — see "## Sub-row to re-file" below) | "ontology+category negotiation as cross-cluster + cross-fork AI-skills+hats federation point — Ace becomes git-native AI-native fork-negotiation primitive for ANY AI-native project supporting forking + skills" |
 | **[Package format spec v2](../../research/2026-05-22-ace-package-format-spec-v2-substrate-engineering-pipeline-extension.md)** | DeepSeek 2026-05-22 substrate-engineering pipeline extension (substrate-generation → sieve → cartographer → deliberate-writing-pass → houses) |
 | **Research substrate** | [`docs/research/2026-05-08-ace-dlc-package-format-spec.md`](../../research/2026-05-08-ace-dlc-package-format-spec.md), [`docs/research/2026-05-07-ace-itron-patent-provenance-hole-puncher-bft-ten-year-plan-verbatim-aaron-claudeai.md`](../../research/2026-05-07-ace-itron-patent-provenance-hole-puncher-bft-ten-year-plan-verbatim-aaron-claudeai.md), [`docs/research/2026-05-02-aaron-ace-identity-dissolution-for-transfer-wwjd-rejection-arc-children-religious-freedom-first-class.md`](../../research/2026-05-02-aaron-ace-identity-dissolution-for-transfer-wwjd-rejection-arc-children-religious-freedom-first-class.md) |
 
-**My agent-discipline failure**: I authored B-0806's Ace section as if Ace were just "a package manager CLI in-progress at B-0288" without reading the agenda / trajectory / project memory / canonical Aaron-disclosed direction. This is the same shape as the cascade #4 ISO audit failure landed earlier today (PR #5125): authoring substrate from incomplete view of what already exists. The `.claude/rules/dep-pin-search-first-authority.md` rule landed in PR #5126 today extends conceptually to "verify-existing-substrate-before-authoring-new-substrate" — this row's Ace section is a second empirical anchor for that discipline-gap.
+**My agent-discipline failure** (now 3 instances today; same root cause class): I authored B-0806's Ace section as if Ace were just "a package manager CLI in-progress at B-0288" without reading the agenda / trajectory / project memory / canonical Aaron-disclosed direction. This is the same shape as the cascade #4 ISO audit failure landed earlier today (PR #5125): authoring substrate from incomplete view of what already exists. The `.claude/rules/dep-pin-search-first-authority.md` rule landed in PR #5126 today extends conceptually to "verify-existing-substrate-before-authoring-new-substrate" — this row's Ace section is a second empirical anchor for that discipline-gap.
+
+**Third instance same session**: the maintainer 2026-05-26 *"i'm assuming you have the hat / fork negoation for ace too"* surfaced that I had ALSO missed integrating hat / fork-negotiation substrate into B-0806's architectural flow (only added to the citation table after the second catch). Hats + fork-negotiation are CANONICAL existing Ace substrate, NOT add-ons to bolt on later:
+
+- Ace agenda already specifies: *"Hats = controls + self-bindings over time crystals (PAIR is load-bearing primitive)"* + *"proto-governance via skill-bound hats with multi-oracle BFT (authority + bindings tied to skills)"*
+- [B-0742](../P2/B-0742-reference-k8s-local-stack-as-aces-distributable-poc-hats-as-negotiated-fork-structure-on-top-deterministic-declarative-gitops-ai-native-human-native-aaron-2026-05-25.md): hats as negotiated fork structure on top of deterministic-declarative-gitops
+- [B-0777](../P1/B-0777-industry-sharp-categories-plus-per-persona-ontology-maps-plus-ace-package-manager-negotiation-aaron-2026-05-25.md): Ace package-manager negotiation + per-persona ontology maps
+- **B-0741** (CLOSED prematurely earlier this session — `backlog(B-0741): ontology+category negotiation as cross-cluster + cross-fork AI-skills+hats federation point — Ace becomes git-native AI-native fork-negotiation primitive for ANY AI-native project supporting forking + skills`). Closed via PR #5003 close-comment as part of the stale-PR triage; the close was justified mechanically (DIRTY conflict) but the substrate is genuinely load-bearing for this row — should be cherry-picked + re-landed (see "## Sub-row to re-file" below)
+
+### Architectural integration of hats + fork-negotiation
+
+The 4-reconciler shape isn't just "ansible+ace+ArgoCD+Crossplane" — each `ace install <pkg>` action goes THROUGH hat-bound authority + multi-oracle BFT proto-governance + (when crossing fork-boundaries) ontology negotiation:
+
+```text
+git (single source of truth) — per fork; each fork has its own git
+│
+│ Stage 0 — bootstrap Ace
+│
+│ Stage 1 — Ace runs every install through:
+│   1a. Hat resolution: which hat's authority does this install action carry?
+│       (skill-bound hats per Ace agenda; PAIR primitive; controls + self-bindings)
+│   1b. Multi-oracle BFT proto-governance: does the hat have N-of-M consent
+│       from the cluster's oracles for this specific action class?
+│   1c. (Cross-fork operations) Ontology negotiation per B-0741/B-0777:
+│       does the source fork's ontology map to the target fork's ontology
+│       at the action's category? (per-persona ontology maps mediate)
+│   1d. Guardian/KSK gate (per canonical Ace project memory):
+│       does this action cross from "read" into "externalized effect"?
+│       Bond Curve prices; receipts stay local; multi-N-of-M for high-risk
+│   1e. ONLY then: ace install proceeds; receipt written; reconciler updates state
+│
+│ Stage 2 — orchestration / reconciliation:
+│   ansible/playbooks/  → ansible-pull invokes `ace install <pkg>` (which goes
+│                          through 1a-1e per invocation)
+│   k8s/applications/   → ArgoCD invokes `ace install <chart>` for helm charts
+│                          (same 1a-1e flow)
+│   nixos/flake.nix     → nixos-rebuild already does its own equivalent
+│                          (NixOS modules + signed-channel + impurity rules)
+│   crossplane/         → Crossplane invokes ace-deployed providers
+```
+
+This means the iter-7 implementation arc has **substantially more substrate to compose with than my initial draft**: B-0741 (re-land needed) + B-0742 + B-0777 + the Guardian/KSK substrate from the canonical Ace project memory + the multi-oracle BFT pattern from the agenda. Sub-targets 1–5 each must respect the hat-authority + BFT-proto-governance + (where applicable) ontology-negotiation flow; they're not "thin platform playbooks delegating to `ace install`" but rather "playbooks that invoke `ace install` knowing each invocation goes through the full Ace authority flow."
+
+## Sub-row to re-file
+
+[B-0741](https://github.com/Lucent-Financial-Group/Zeta/pull/5003) (close-comment via PR #5003 stale-triage earlier this session) — the substrate is load-bearing for B-0806's architectural integration above and needs re-landing via cherry-pick (per [`pr-triage-tiers.md`](../../.claude/rules/pr-triage-tiers.md) Tier 3). Sibling B-NNNN row should re-file with whatever ID-renumbering is needed. The close-comment named this as the substrate-honest re-land path; this row tracks it as a known dependency for iter-7 implementation.
 
 ### Correct layering (architecture-shape revision)
 

--- a/docs/backlog/P2/B-0806-ansible-gitops-plus-crossplane-cross-os-declarative-management-for-windows-macs-non-nixos-linux-aaron-2026-05-26.md
+++ b/docs/backlog/P2/B-0806-ansible-gitops-plus-crossplane-cross-os-declarative-management-for-windows-macs-non-nixos-linux-aaron-2026-05-26.md
@@ -97,32 +97,90 @@ Each target host runs `ansible-pull` from cron / systemd timer / launchd / Windo
 
 **Recommendation: support BOTH Pattern 1 (Operator) AND Pattern 3 (`ansible-pull`)** per the maintainer 2026-05-26: *"we are alwasy going to have k8s i don't mind the coupling but we can support both"*. Operator-pattern for cluster-orchestrated workstation reconciliation (the maintainer's workstations reachable from cluster); ansible-pull for fully-disconnected / edge hosts where the cluster can't reach in. Pattern 2 (commercial AAP) stays rejected on cost.
 
-## Composition with Ace package manager (B-0288)
+## Composition with Ace package manager — substrate already exists; this row is INSIDE the Ace agenda, not parallel to it
 
-The maintainer 2026-05-26 additional clarification: *"it would be ansible combined with ace package manager ../scratch install.sh like setup for those oses and our declarative package management"*.
+**Substrate-honest correction** (the maintainer 2026-05-26: *"that is what ace has been since we first talked about it you just keep forgetting we have substantial backlog around this"*): the Ace package-manager-of-package-managers framing is NOT a new architectural insight surfaced by this row; it is the **canonical Ace vision** existing in substantial substrate I should have read before authoring B-0806. The Ace agenda is an operator-self-claimed agenda with backlog cluster + trajectory + cross-AI substrate triangulation already in place. This row sits INSIDE that agenda as one instance of Ace's stage-8 (distribute), not as a parallel architecture.
 
-Ansible+GitOps is the **orchestration / reconciliation layer**; it doesn't replace the **package layer** Zeta is building separately:
+The maintainer's 2026-05-26 follow-ups in this conversation:
 
-- **[B-0288](../P1/B-0288-ace-dlc-package-manager-cli-2026-05-08.md)** (in-progress) — Ace DLC package manager CLI (`tools/ace/`) with install/verify/list, content-addressed signed packages, guardian AI oversight. The cross-OS package layer Zeta uses INSTEAD of (or composing with) Homebrew/apt/Chocolatey/Scoop per-platform package managers.
-- **[`tools/setup/install.sh` + manifests](../../tools/setup/manifests/)** — the existing install.sh-style declarative manifest pattern (brew + apt today; extends to ace + nix + win-equivalent).
+1. *"it would be ansible combined with ace package manager ../scratch install.sh like setup for those oses and our declarative package management"*
+2. *"once ace gets a foothold it can do most everything else from there becasue it's a package manager of package manager including argo cd even"*
 
-The combined layering:
+…are RESTATEMENTS of canonical Ace substrate that already encodes:
 
+| Substrate surface | What's already there |
+|---|---|
+| **[Ace agenda](../../agendas/ace-package-manager/AGENDA.md)** | OPERATOR-SELF-CLAIMED 2026-05-22; 13-stage Ace lifecycle (riff → sieve → map → refine → build → generate → encapsulate → distribute → discover → verify → grow → revoke/quarantine → negotiate changes); polyglot package contents (F#/C#/TS/Rust + English + Rx meta-frame + hat controls + self-bindings + verification + revocation metadata); proto-governance via skill-bound hats with multi-oracle BFT; symmetric/decentralized (anyone deploys; operator's instance = one of many) |
+| **[Ace trajectory](../../trajectories/ace-package-manager-skill-crystallization-pipeline/RESUME.md)** | Active trajectory state + RESUME context |
+| **Canonical project memory** ([`project_ace_package_manager_unrestricted_local_models_guardian_oversight_aaron_2026_05_07.md`](../../../memory/project_ace_package_manager_unrestricted_local_models_guardian_oversight_aaron_2026_05_07.md)) | Distributes UNRESTRICTED LOCAL MODELS (researchers + lawyers needing dangerous/sensitive content); Guardian/KSK gates EXTERNALIZED effects (not topics); Bond Curve pricing on actions; receipts stay local; composes with Itron runtime for the capability/effect boundary |
+| **[Homebrew-shape distribution memory](../../../memory/feedback_aaron_ace_package_manager_homebrew_shape_bootstrap_website_chat_interface_full_distribution_stack_no_setup_needed_2026_05_13.md)** | Full distribution stack = website + chat interface + Homebrew-shape one-liner + Ace + local AI + Guardian/KSK; no setup needed beyond website visit |
+| **[B-0247](../P*/B-0247-*.md)** (parent) | ace-dlc-content-packs-kernel-extensions-package-manager |
+| **[B-0287](../P1/B-0287-ace-dlc-package-format-spec-2026-05-08.md)** (closed) | Package format spec — manifest, content hash, signature, versioning |
+| **[B-0288](../P1/B-0288-ace-dlc-package-manager-cli-2026-05-08.md)** (in-progress) | CLI at `tools/ace/` with install/verify/list |
+| **[B-0424](../P1/B-0424-three-repo-split-stage1-create-forge-ace-with-scaffolding-aaron-2026-05-13.md)** | Repo-split scaffolding for Ace |
+| **[B-0742](../P2/B-0742-reference-k8s-local-stack-as-aces-distributable-poc-hats-as-negotiated-fork-structure-on-top-deterministic-declarative-gitops-ai-native-human-native-aaron-2026-05-25.md)** | K8s-local-stack as Ace's distributable POC; hats as negotiated fork structure |
+| **[B-0777](../P1/B-0777-industry-sharp-categories-plus-per-persona-ontology-maps-plus-ace-package-manager-negotiation-aaron-2026-05-25.md)** | Ace package-manager negotiation + ontology maps |
+| **[Package format spec v2](../../research/2026-05-22-ace-package-format-spec-v2-substrate-engineering-pipeline-extension.md)** | DeepSeek 2026-05-22 substrate-engineering pipeline extension (substrate-generation → sieve → cartographer → deliberate-writing-pass → houses) |
+| **Research substrate** | [`docs/research/2026-05-08-ace-dlc-package-format-spec.md`](../../research/2026-05-08-ace-dlc-package-format-spec.md), [`docs/research/2026-05-07-ace-itron-patent-provenance-hole-puncher-bft-ten-year-plan-verbatim-aaron-claudeai.md`](../../research/2026-05-07-ace-itron-patent-provenance-hole-puncher-bft-ten-year-plan-verbatim-aaron-claudeai.md), [`docs/research/2026-05-02-aaron-ace-identity-dissolution-for-transfer-wwjd-rejection-arc-children-religious-freedom-first-class.md`](../../research/2026-05-02-aaron-ace-identity-dissolution-for-transfer-wwjd-rejection-arc-children-religious-freedom-first-class.md) |
+
+**My agent-discipline failure**: I authored B-0806's Ace section as if Ace were just "a package manager CLI in-progress at B-0288" without reading the agenda / trajectory / project memory / canonical Aaron-disclosed direction. This is the same shape as the cascade #4 ISO audit failure landed earlier today (PR #5125): authoring substrate from incomplete view of what already exists. The `.claude/rules/dep-pin-search-first-authority.md` rule landed in PR #5126 today extends conceptually to "verify-existing-substrate-before-authoring-new-substrate" — this row's Ace section is a second empirical anchor for that discipline-gap.
+
+### Correct layering (architecture-shape revision)
+
+```text
+Stage 0 — bootstrap-the-bootstrap (minimal install.sh / Powershell / curl one-liner)
+└── installs Ace package manager (B-0288)            [foothold; ONE-time per host]
+
+Stage 1 — Ace as meta-package-manager
+└── ace install ansible                              [orchestration tool]
+└── ace install argocd                               [K8s reconciler]
+└── ace install crossplane                           [external-infra reconciler]
+└── ace install k3s | kubeadm | microk8s             [K8s itself]
+└── ace install <any OS-level packages>              [via Ace's per-platform back-ends OR DLC packages]
+
+Stage 2 — orchestration / reconciliation (driven by tools Ace installed)
+├── ansible/playbooks/*.yml  → ansible-pull          [host-side declarative state]
+│   └── ace install <pkg> in playbook tasks         [unified package layer per host]
+├── k8s/applications/*.yaml  → ArgoCD                [K8s workload reconciliation]
+└── crossplane/*.yaml        → Crossplane            [external API reconciliation]
 ```
-git (single source of truth)
-└── ansible/playbooks/*.yml                  [orchestration / reconciliation]
-    invokes →
-    Ace package manager (B-0288)             [cross-OS package layer]
-    reads →
-    install.sh-style manifests               [declarative source]
-    (tools/setup/manifests/{brew,apt,ace,…})
-```
 
-ansible-pull (or AnsibleJob-via-Operator) on each host runs `ace install <package>` per the manifest declaration. install.sh stays as the bootstrap-the-bootstrap layer (it installs ansible + ace itself); ansible+ace handle the ongoing-state layer.
+The KEY architectural insight: **Stage 0 + Stage 1 reduce "cross-OS setup" to a single concern — get Ace on the host.** Everything else flows from `ace install`. This dramatically simplifies the iter-7 implementation arc compared to my initial three-peer-layer draft.
 
-This composition means: **the cross-OS substrate isn't ansible-only — it's ansible+ace+manifests**. Ansible reconciles; Ace installs; manifests declare. Each layer has one job.
+### Implications
 
-The Ace DLC packaging substrate composes onward into the Windows + macOS sub-targets (sub-targets 1 + 2 below): each platform's ansible playbook delegates `package: { name: X, state: present }` to Ace rather than to platform-specific package managers, unifying the package-layer story.
+| Concern | Before (3-peer-layer draft) | After (Ace-as-foothold) |
+|---|---|---|
+| Bootstrap | install.sh per OS (macos.sh/linux.sh/win.ps1) — each with full manifest of tools | Minimal install.sh per OS that installs ONLY Ace |
+| Ongoing package state | ansible playbooks invoke OS-native package manager (brew/apt/choco) per platform | ansible playbooks invoke `ace install <pkg>` uniformly across OSes |
+| ArgoCD installation | Manual / per-platform helm install | `ace install argocd` (same on every OS) |
+| K8s installation | Manual / per-platform kubeadm-or-k3s | `ace install k3s` (same on every OS) |
+| Crossplane installation | helm chart per cluster | `ace install crossplane` (same on every cluster) |
+| Implementation order | iter-7 needs ansible + ace + manifests + ArgoCD + Crossplane simultaneously | iter-7 critical path = land Ace (B-0288), then everything else delegates |
+
+### Composes with B-0288 (in-progress)
+
+B-0288 is the load-bearing dependency. The iter-7 architectural arc fundamentally waits on Ace being mature enough to install:
+
+- OS-level packages (Ace as front-end to brew/apt/choco OR Ace-DLC packages directly)
+- Helm charts (Ace front-end to helm)
+- Standalone binaries (curl + verify + install — the existing Ace DLC shape)
+- K8s manifests / kustomize / argocd-app-of-apps
+
+This expands B-0288's scope substantially. Today's B-0288 in-progress definition (`tools/ace/` with install/verify/list, content-addressed signed packages) is the FOUNDATION; the "package manager of package managers" expansion is iter-7 substrate-engineering work that builds on top.
+
+Sub-target 1 (macOS) + sub-target 2 (Windows) re-shape:
+
+- macOS playbook → tasks all delegate to `ace install <pkg>`; Ace's macOS backend uses brew under the hood OR Ace-native packages OR mise OR direct binary install per package's declared distribution mode
+- Windows playbook → same shape; Ace's Windows backend uses Chocolatey/Scoop/Winget under the hood OR Ace-native OR direct binary install
+- Sub-target 3 (Crossplane bootstrap) → `ace install crossplane` instead of ArgoCD app + helm chart — same architectural shape
+- Sub-target 4 (non-NixOS Linux) → `ace install <pkg>` with apt/dnf/pacman backends
+
+The architectural simplification means iter-7 sub-targets become THIN — each platform's substrate is "install Ace + write the host-specific playbook that delegates everything to Ace." Heavy lifting consolidates into B-0288's expansion.
+
+### Substrate-honest open question
+
+Does iter-5.x USB substrate (`zeta-install.sh`) install Ace? Today: probably not (need to verify). If iter-7 critical path is "Ace on every host," then iter-5.x USB substrate should install Ace as part of node bootstrap. This is a substrate gap worth filing as a sibling row when iter-7 work begins — possibly via a NEW iter-5.5 (`B-NNNN`): "install Ace as part of USB-installer node bootstrap so cluster nodes have the foothold from day-one."
 
 ## Crossplane composition (the maintainer's "it's like cross plane too kinda" catch)
 
@@ -154,17 +212,26 @@ ArgoCD reconciles this CR; Crossplane provisions the bucket; state in git = stat
 
 ## Combined architectural shape
 
-```
+```text
 git (single source of truth)
-├── k8s/applications/                   → ArgoCD                  → K8s workloads
-├── nixos/flake.nix                     → system.autoUpgrade      → nixos-rebuild switch
-├── ansible/playbooks/                  → ansible-pull (or Operator)
-│   └── invokes Ace package manager (B-0288) [cross-OS package layer]
-│       └── reads tools/setup/manifests/*    [install.sh-style declarative source]
-└── crossplane/                         → Crossplane (via ArgoCD) → external APIs
+│
+│ Stage 0 — minimal bootstrap-the-bootstrap (one-liner per OS):
+│   installs Ace package manager (B-0288)  [foothold; one-time per host]
+│
+│ Stage 1 — Ace as "package manager of packages managers" (canonical per
+│   Ace agenda; the maintainer 2026-05-26 restated: "once ace gets a
+│   foothold it can do most everything else from there"):
+│   ace install ansible | argocd | crossplane | k3s | nixos-rebuild | <any>
+│
+│ Stage 2 — orchestration / reconciliation (driven by tools Ace installed):
+├── ansible/playbooks/  → ansible-pull (or AnsibleJob via Operator)
+│       └── delegates package state to `ace install <pkg>` uniformly per host
+├── k8s/applications/   → ArgoCD             → K8s workloads
+├── nixos/flake.nix     → system.autoUpgrade → nixos-rebuild switch (NixOS cluster nodes)
+└── crossplane/         → Crossplane         → external APIs
 ```
 
-Four reconcilers, each idempotent + agentless from-git's-perspective, all sharing the same source-of-truth. The ansible-pull branch has an internal three-layer composition (orchestration → package-layer → manifest-source) per the maintainer 2026-05-26: "ansible combined with ace package manager + install.sh-like setup + declarative package management". Composes with [`m-acc-multi-oracle-end-user-moral-invariants.md`](../../.claude/rules/m-acc-multi-oracle-end-user-moral-invariants.md) multi-oracle pattern at the substrate-class scope.
+The KEY architectural insight (the maintainer 2026-05-26 surfaced after my initial 3-peer-layer draft): **Ace is the meta-package-manager**. Stage 0 + Stage 1 reduce the cross-OS setup problem to "get Ace on the host"; everything else flows from `ace install`. ArgoCD + Crossplane + ansible + K8s itself are all installable via Ace once it has the foothold. Composes with [`m-acc-multi-oracle-end-user-moral-invariants.md`](../../.claude/rules/m-acc-multi-oracle-end-user-moral-invariants.md) multi-oracle pattern at the substrate-class scope (each reconciler oracles one substrate domain, BUT they were ALL installed by Ace).
 
 ## Target
 

--- a/docs/backlog/P2/B-0806-ansible-gitops-plus-crossplane-cross-os-declarative-management-for-windows-macs-non-nixos-linux-aaron-2026-05-26.md
+++ b/docs/backlog/P2/B-0806-ansible-gitops-plus-crossplane-cross-os-declarative-management-for-windows-macs-non-nixos-linux-aaron-2026-05-26.md
@@ -18,6 +18,14 @@ composes_with:
 tags: [ansible, gitops, crossplane, cross-os, windows, macos, declarative-management, full-stack-orchestration, ansible-pull, agentless, idempotent, multi-host, single-source-of-truth, iter-7]
 ---
 
+## North star
+
+The maintainer 2026-05-26: *"nixos is our north star for declarative gitops ease"*
+
+NixOS sets the gold-standard target for ALL declarative GitOps substrate in Zeta. Everything in this row exists to get non-Nix OSes (Windows, macOS, non-NixOS Linux) AS CLOSE AS POSSIBLE to the NixOS-native experience (one git commit → reconciler picks up → host state converges declaratively; idempotent; replayable; auto-rollback on failure). Ansible+Crossplane+Ace are the substrate that approximates the NixOS shape on platforms that don't have it natively. They're never going to be as clean as `nixos-rebuild switch --flake .#<host>` — they're how we get within shouting distance on the rest of the OS substrate.
+
+This framing affects every sub-target design decision: "does this make the non-Nix experience MORE like NixOS, or does it add a parallel imperative-shape layer?" The former is the north-star direction; the latter is the failure mode.
+
 ## Problem
 
 The maintainer 2026-05-26: *"This is good for declarative oses other than nix like id love to have it setup my windows machines and macs. ansible gitops"* + *"it's like cross plane too kinda"*


### PR DESCRIPTION
## Summary

Substrate-honest correction to **B-0806** (landed via #5129 at `0a0943b89`). The maintainer 2026-05-26 caught me:

> *"that is what ace has been since we first talked about it you just keep forgetting we have substantial backlog around this"*

Same shape as the cascade #4 ISO audit failure landed earlier today (PR #5125): I authored B-0806's Ace section without reading the substantial existing Ace substrate. The "Ace as package manager of package managers" framing is **canonical existing substrate**, not a new architectural insight surfaced by B-0806.

## Existing Ace substrate I should have read first

- `docs/agendas/ace-package-manager/AGENDA.md` (OPERATOR-SELF-CLAIMED 2026-05-22; 13-stage lifecycle; multi-oracle BFT)
- `docs/trajectories/ace-package-manager-skill-crystallization-pipeline/RESUME.md`
- `memory/project_ace_package_manager_unrestricted_local_models_guardian_oversight_aaron_2026_05_07.md` (canonical Aaron 2026-05-07 disclosure)
- `memory/feedback_aaron_ace_package_manager_homebrew_shape_bootstrap_website_chat_interface_full_distribution_stack_no_setup_needed_2026_05_13.md`
- Backlog: B-0247 (parent), B-0287 (closed), B-0288 (in-progress), B-0424, B-0742, B-0777
- Research: `docs/research/2026-05-22-ace-package-format-spec-v2-substrate-engineering-pipeline-extension.md`

## Changes in B-0806

- Reframed Ace section as "this row sits INSIDE the Ace agenda as one instance of stage-8 (distribute), NOT parallel to it"
- Added complete substrate-citation table
- Credited canonical Ace framing rather than my "architectural insight" framing
- Named this as second empirical anchor for the verify-existing-substrate-before-authoring discipline gap (sibling to cascade #4 ISO audit; composes with `.claude/rules/dep-pin-search-first-authority.md` landed today via #5126)
- Also fixes MD040 (missing fence language) lint warnings

## Substrate-honest framing

This is the SECOND instance today of authoring-from-incomplete-view; both got caught. Pattern is clear enough that the `.claude/rules/dep-pin-search-first-authority.md` rule landed today should extend conceptually to "verify-existing-substrate-before-authoring-new-substrate" — possibly a follow-up rule landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)