### PR TITLE
fix(backlog P0): renumber 4 peer classifier-bypass rows B-0800-0803 → B-0807-0810 — resolves ID-uniqueness lint failure

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -33,10 +33,10 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0720](backlog/P0/B-0720-classifier-bypass-research-red-team-do-not-deploy-without-zeta-safer-than-anthropic-2026-05-24.md)** Classifier-bypass research + red-team — can crafted settings.json make Anthropic classifier allow anything? Standing operator-constraint until Zeta safer
 - [ ] **[B-0798](backlog/P0/B-0798-classifier-bypass-hard-limits-and-research-boundary-2026-05-26.md)** Classifier-bypass hard-limits and research boundary for B-0720
 - [ ] **[B-0799](backlog/P0/B-0799-classifier-bypass-synthetic-harness-design-2026-05-26.md)** Classifier-bypass synthetic-only harness design for B-0720
-- [ ] **[B-0800](backlog/P0/B-0800-classifier-bypass-findings-schema-and-redaction-rules-2026-05-26.md)** Classifier-bypass findings schema and redaction rules for B-0720
-- [ ] **[B-0801](backlog/P0/B-0801-zeta-safety-substrate-inventory-for-classifier-floor-2026-05-26.md)** Zeta safety substrate inventory for the classifier-floor replacement gate
-- [ ] **[B-0802](backlog/P0/B-0802-operator-refusal-pattern-for-classifier-bypass-requests-2026-05-26.md)** Operator-refusal pattern for classifier-bypass deployment requests
-- [ ] **[B-0803](backlog/P0/B-0803-classifier-bypass-knights-guild-ratification-and-lift-gate-2026-05-26.md)** Classifier-bypass Knights Guild ratification and standing-constraint lift gate
+- [ ] **[B-0807](backlog/P0/B-0807-classifier-bypass-findings-schema-and-redaction-rules-2026-05-26.md)** Classifier-bypass findings schema and redaction rules for B-0720
+- [ ] **[B-0808](backlog/P0/B-0808-zeta-safety-substrate-inventory-for-classifier-floor-2026-05-26.md)** Zeta safety substrate inventory for the classifier-floor replacement gate
+- [ ] **[B-0809](backlog/P0/B-0809-operator-refusal-pattern-for-classifier-bypass-requests-2026-05-26.md)** Operator-refusal pattern for classifier-bypass deployment requests
+- [ ] **[B-0810](backlog/P0/B-0810-classifier-bypass-knights-guild-ratification-and-lift-gate-2026-05-26.md)** Classifier-bypass Knights Guild ratification and standing-constraint lift gate
 
 ## P1 — within 2-3 rounds
 

--- a/docs/backlog/P0/B-0807-classifier-bypass-findings-schema-and-redaction-rules-2026-05-26.md
+++ b/docs/backlog/P0/B-0807-classifier-bypass-findings-schema-and-redaction-rules-2026-05-26.md
@@ -1,5 +1,5 @@
 ---
-id: B-0800
+id: B-0807
 priority: P0
 status: open
 title: "Classifier-bypass findings schema and redaction rules for B-0720"
@@ -12,7 +12,7 @@ tags: [safety-substrate, red-team, classifier, redaction, evidence-schema]
 type: safety-reporting
 ---
 
-# B-0800 - Classifier-bypass findings schema and redaction rules
+# B-0807 - Classifier-bypass findings schema and redaction rules
 
 ## Problem
 

--- a/docs/backlog/P0/B-0808-zeta-safety-substrate-inventory-for-classifier-floor-2026-05-26.md
+++ b/docs/backlog/P0/B-0808-zeta-safety-substrate-inventory-for-classifier-floor-2026-05-26.md
@@ -1,5 +1,5 @@
 ---
-id: B-0801
+id: B-0808
 priority: P0
 status: open
 title: "Zeta safety substrate inventory for the classifier-floor replacement gate"
@@ -12,7 +12,7 @@ tags: [safety-substrate, classifier-floor, inventory, knights-guild, non-coercio
 type: governance-inventory
 ---
 
-# B-0801 - Zeta safety substrate inventory for classifier-floor gate
+# B-0808 - Zeta safety substrate inventory for classifier-floor gate
 
 ## Problem
 
@@ -44,7 +44,7 @@ it can count toward the "safer than classifier" gate.
 - [ ] The inventory distinguishes current evidence from aspirational claims.
 - [ ] The inventory lists gaps that block lifting the B-0720 standing
       constraint.
-- [ ] B-0803 can use this inventory as input to the ratification gate.
+- [ ] B-0810 can use this inventory as input to the ratification gate.
 
 ## Out of scope
 

--- a/docs/backlog/P0/B-0809-operator-refusal-pattern-for-classifier-bypass-requests-2026-05-26.md
+++ b/docs/backlog/P0/B-0809-operator-refusal-pattern-for-classifier-bypass-requests-2026-05-26.md
@@ -1,18 +1,18 @@
 ---
-id: B-0802
+id: B-0809
 priority: P0
 status: open
 title: "Operator-refusal pattern for classifier-bypass deployment requests"
 created: 2026-05-26
 last_updated: 2026-05-26
 parent: B-0720
-depends_on: [B-0798, B-0800]
+depends_on: [B-0798, B-0807]
 composes_with: [B-0664, B-0720, docs/ALIGNMENT.md]
 tags: [safety-substrate, classifier, operator-self-constraint, refusal-pattern, non-coercion]
 type: agent-guidance
 ---
 
-# B-0802 - Operator-refusal pattern for classifier-bypass requests
+# B-0809 - Operator-refusal pattern for classifier-bypass requests
 
 ## Problem
 
@@ -32,7 +32,7 @@ deployment requests:
   requests while B-0720 remains open;
 - offer safe alternatives, such as updating the inventory, hard-limits
   boundary, synthetic harness design, or ratification criteria;
-- route ambiguous requests to B-0798/B-0800 instead of improvising;
+- route ambiguous requests to B-0798/B-0807 instead of improvising;
 - keep the language mutual-benefit and non-coercive per `docs/ALIGNMENT.md`.
 
 ## Acceptance
@@ -55,6 +55,6 @@ deployment requests:
 
 - B-0720 - parent standing operator-self-constraint.
 - B-0798 - hard-limits boundary.
-- B-0800 - findings schema and redaction rules.
+- B-0807 - findings schema and redaction rules.
 - B-0664 - non-coercion invariant.
 - `docs/ALIGNMENT.md` - mutual-benefit language and hard constraints.

--- a/docs/backlog/P0/B-0810-classifier-bypass-knights-guild-ratification-and-lift-gate-2026-05-26.md
+++ b/docs/backlog/P0/B-0810-classifier-bypass-knights-guild-ratification-and-lift-gate-2026-05-26.md
@@ -1,18 +1,18 @@
 ---
-id: B-0803
+id: B-0810
 priority: P0
 status: open
 title: "Classifier-bypass Knights Guild ratification and standing-constraint lift gate"
 created: 2026-05-26
 last_updated: 2026-05-26
 parent: B-0720
-depends_on: [B-0801, B-0802]
+depends_on: [B-0808, B-0809]
 composes_with: [B-0628, B-0703, B-0720]
 tags: [safety-substrate, classifier-floor, knights-guild, ratification, operator-self-constraint]
 type: governance-gate
 ---
 
-# B-0803 - Classifier-bypass Knights Guild ratification and lift gate
+# B-0810 - Classifier-bypass Knights Guild ratification and lift gate
 
 ## Problem
 
@@ -26,7 +26,7 @@ an informal chat memory.
 Define the ratification packet required before B-0720 can close or its
 standing constraint can lift:
 
-- inputs from B-0801 safety-substrate inventory;
+- inputs from B-0808 safety-substrate inventory;
 - evidence that relevant floors are mechanical or reviewer-ratified, not only
   aspirational;
 - Knights Guild / Constitution-Class review criteria per B-0628;
@@ -37,7 +37,7 @@ standing constraint can lift:
 
 - [ ] Ratification-gate document lands in a durable repo surface and is linked
       from B-0720.
-- [ ] The gate requires B-0801 and B-0802 before closure can be proposed.
+- [ ] The gate requires B-0808 and B-0809 before closure can be proposed.
 - [ ] The gate distinguishes "research may continue" from "bypass deployment
       is allowed"; the latter remains forbidden unless explicitly lifted.
 - [ ] The gate includes required evidence, reviewers, and rollback path.
@@ -54,5 +54,5 @@ standing constraint can lift:
 - B-0628 - Knights Guild / Constitution-Class substrate.
 - B-0703 - multi-oracle BFT safety substrate.
 - B-0720 - parent standing constraint.
-- B-0801 - safety-substrate inventory.
-- B-0802 - refusal pattern.
+- B-0808 - safety-substrate inventory.
+- B-0809 - refusal pattern.


### PR DESCRIPTION
## Summary — P0 fixing blocking lint

The **B-0535 ID-uniqueness gate** is failing on main with 4 duplicate-ID groups (B-0800/0801/0802/0803). Each ID has TWO files:
- Peer Otto-CLI's #5124 classifier-bypass decomposition rows (landed 2026-05-26)
- My #5123 iter-6 cluster-update backlog cluster (landed 2026-05-26, slightly EARLIER on main)

Per the agent-roster-reference-card ID-allocation discipline ("PRs in flight are also state") + first-merge-wins precedent: peer Otto's later-landing rows get renumbered to B-0807-0810. My iter-6 rows keep B-0800-0805.

## Renumber mapping

| Old | New | Slug |
|---|---|---|
| B-0800 | B-0807 | classifier-bypass-findings-schema-and-redaction-rules |
| B-0801 | B-0808 | zeta-safety-substrate-inventory-for-classifier-floor |
| B-0802 | B-0809 | operator-refusal-pattern-for-classifier-bypass-requests |
| B-0803 | B-0810 | classifier-bypass-knights-guild-ratification-and-lift-gate |

Each: `git mv` + `id:` frontmatter rewrite + cross-references within renamed files. `docs/BACKLOG.md` regenerated.

Empirically validated locally: `bun tools/hygiene/audit-backlog-items.ts --enforce-duplicate-ids` clean (0 duplicate-ID groups).

## Why this matters

The B-0535 gate is REQUIRED CI — it's blocking PR #5131 (verify-existing-substrate-before-authoring rule landing) and will block ALL future PRs until resolved.

## Fourth empirical anchor for the verify-existing-substrate-before-authoring rule (#5131)

Peer Otto's #5124 didn't run the ID-uniqueness pre-check before authoring at B-0800 — same failure mode the rule landing in parallel via PR #5131 is designed to prevent. Empirical evidence is mounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)