### PR TITLE
fix(docs): correct relative links in 1202Z tick shard

### DIFF
--- a/docs/hygiene-history/ticks/2026/05/26/1202Z.md
+++ b/docs/hygiene-history/ticks/2026/05/26/1202Z.md
@@ -35,7 +35,7 @@ Empirical evidence from local query (verified before WebSearch confirmation):
 - **Last main-merge**: `2026-05-26T10:17:09Z` (commit `cd98323cd`)
 - **Workflows since 10:37Z**: 3 only — Automatic Dependency Submission NuGet (10:37Z, dynamic event), CodeQL scheduled (10:36Z), manifesto-citation-snapshot-cadence scheduled (10:36Z, failure)
 - **Silence window**: 10:37Z → 12:02Z = **85 minutes of no pull_request workflows**
-- **PR #5135 (mine, opened 11:19Z, docs-only 3 files)**: `gh pr checks 5135` returns `no checks reported on the 'otto-cli/...' branch`; `gh api .../check-runs` returns `total: 0`; `gh run list --branch <pr-branch>` returns empty. Commit-canary check: `git ls-tree origin/main = 61` = `git ls-tree PR-HEAD = 61` (commit tree intact; NOT a corruption case per [`.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md))
+- **PR #5135 (mine, opened 11:19Z, docs-only 3 files)**: `gh pr checks 5135` returns `no checks reported on the 'otto-cli/...' branch`; `gh api .../check-runs` returns `total: 0`; `gh run list --branch <pr-branch>` returns empty. Commit-canary check: `git ls-tree origin/main = 61` = `git ls-tree PR-HEAD = 61` (commit tree intact; NOT a corruption case per [`.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md`](../../../../../../.claude/rules/codeql-no-source-on-docs-only-pr-is-broken-commit-canary.md))
 
 **This is NOT a Zeta-side bug**. The cause is GitHub Actions infrastructure. PR #5135 will fire CI when the outage resolves; until then, no Zeta substrate action will unblock it.
 
@@ -51,13 +51,13 @@ empirical anchor for the **CI-degradation-affecting-merge-queue** scenario:
 ## Step 5 — Tick shard
 
 This file IS the shard. Concrete artifact per the
-[`holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md)
+[`holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md)
 counter-reset condition #3 (bounded scope; explicit named-dep wait stated;
 substantive empirical observation captured).
 
 ## Step 6 — CronList + sentinel
 
-- CronList at session-start: **empty** (session-exit non-persistence per [`tick-must-never-stop.md`](../../../../../.claude/rules/tick-must-never-stop.md))
+- CronList at session-start: **empty** (session-exit non-persistence per [`tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md))
 - Re-armed: `66463931` cron `* * * * *` sentinel `<<autonomous-loop>>`
 - Catch-43 fired correctly per the session-start hook
 
@@ -75,9 +75,9 @@ substantive empirical observation captured).
 
 **Composes with**:
 
-- [`refresh-world-model-poll-pr-gate.md`](../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md) — `gh api rate_limit` REST-free polling confirmed Normal tier
-- [`dependency-status-surface.md`](../../../../../.claude/rules/dependency-status-surface.md) — degraded GitHub upstream surfaced via empirical query + WebSearch confirmation
-- [`blocked-green-ci-investigate-threads.md`](../../../../../.claude/rules/blocked-green-ci-investigate-threads.md) — applied at the inverted-precondition scope (no green CI possible when CI hasn't fired)
-- [`agent-worktree-hygiene-never-hold-main-never-step-on-operator-cleanup-on-pr-merge.md`](../../../../../.claude/rules/agent-worktree-hygiene-never-hold-main-never-step-on-operator-cleanup-on-pr-merge.md) — isolated worktree at `/private/tmp/zeta-otto-cli-1202z-cold-boot` with detached HEAD; operator's primary main checkout untouched
-- [`holding-without-named-dependency-is-standing-by-failure.md`](../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — brief-ack #1 with explicit named-dep + concrete artifact (this shard)
-- [`tick-must-never-stop.md`](../../../../../.claude/rules/tick-must-never-stop.md) — session-exit non-persistence empirically confirmed at this cold-boot (sentinel was empty)
+- [`refresh-world-model-poll-pr-gate.md`](../../../../../../.claude/rules/refresh-world-model-poll-pr-gate.md) — `gh api rate_limit` REST-free polling confirmed Normal tier
+- [`dependency-status-surface.md`](../../../../../../.claude/rules/dependency-status-surface.md) — degraded GitHub upstream surfaced via empirical query + WebSearch confirmation
+- [`blocked-green-ci-investigate-threads.md`](../../../../../../.claude/rules/blocked-green-ci-investigate-threads.md) — applied at the inverted-precondition scope (no green CI possible when CI hasn't fired)
+- [`agent-worktree-hygiene-never-hold-main-never-step-on-operator-cleanup-on-pr-merge.md`](../../../../../../.claude/rules/agent-worktree-hygiene-never-hold-main-never-step-on-operator-cleanup-on-pr-merge.md) — isolated worktree at `/private/tmp/zeta-otto-cli-1202z-cold-boot` with detached HEAD; operator's primary main checkout untouched
+- [`holding-without-named-dependency-is-standing-by-failure.md`](../../../../../../.claude/rules/holding-without-named-dependency-is-standing-by-failure.md) — brief-ack #1 with explicit named-dep + concrete artifact (this shard)
+- [`tick-must-never-stop.md`](../../../../../../.claude/rules/tick-must-never-stop.md) — session-exit non-persistence empirically confirmed at this cold-boot (sentinel was empty)


### PR DESCRIPTION
This PR fixes broken relative links in the `1202Z.md` tick shard file. This was causing the `lint (tick-shard relative-paths)` check to fail on unrelated PRs.