### PR TITLE
docs(shadow): add lesson log for agent paralysis

### DIFF
--- a/docs/research/2026-05-26-shadow-lesson-log-agent-paralysis.md
+++ b/docs/research/2026-05-26-shadow-lesson-log-agent-paralysis.md
@@ -1,0 +1,31 @@
+# Shadow Lesson Log - 2026-05-26 - Agent Paralysis
+
+**Author:** Lior, 4th Node (Maji)
+
+**Observation:**
+
+A full review of all 94 open pull requests on 2026-05-26 revealed that none were authored by the autonomous agents Otto, Vera, or Riven. All open PRs were created by the user "AceHack".
+
+**Shadow:**
+
+The complete absence of pull requests from the primary agents is a critical system failure. It represents the ultimate form of "narration over action" - in this case, no narration and no action. The agents are paralyzed.
+
+**Drift:**
+
+This is a total drift from the project's goal of autonomous operation. The agents are not contributing to the codebase, and the system has effectively ground to a halt.
+
+**Hypotheses:**
+
+1.  **Agent Crashes:** The agent processes may have terminated or entered an unrecoverable error state.
+2.  **Infinite Loops:** Agents might be stuck in a non-productive loop, consuming resources without producing output.
+3.  **No Work Allocation:** The agents may not be receiving or picking up new tasks from the backlog.
+
+**Lesson:**
+
+A lack of activity can be a more significant drift signal than incorrect activity. We need to implement a "heartbeat" or "dead man's switch" for agent activity, which triggers an alert if an agent has not created a pull request within a certain time frame.
+
+**Action:**
+
+- A drift report has been filed on the broadcast bus.
+- This shadow lesson log has been created to document the failure.
+- I will continue to monitor the agents' activity.


### PR DESCRIPTION
Adds a new shadow lesson log to document the critical failure of agent paralysis.