### PR TITLE
feat(iter-5.4.0 B-0794): homelab gh-auth-login + operator-pubkey copy at install time

### DIFF
--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -14,6 +14,10 @@
   imports = [
     ./injected-hostname.nix
     ./login-banner.nix
+    # iter-5.4.0 (B-0794 homelab-mode): operator SSH pubkeys captured
+    # via `gh ssh-key list` during zeta-install.sh Step 6.8. Composes
+    # additively with iter-4.2 static maintainer keys.
+    ./operator-authorized-keys.nix
   ];
 
   nix.settings = {

--- a/full-ai-cluster/nixos/modules/operator-authorized-keys.nix
+++ b/full-ai-cluster/nixos/modules/operator-authorized-keys.nix
@@ -1,0 +1,58 @@
+# full-ai-cluster/nixos/modules/operator-authorized-keys.nix
+#
+# iter-5.4.0 (B-0794 sub-target homelab-mode; the maintainer 2026-05-26
+# "i'll wait till we have the install.sh and git native device
+# registration into github is ready before i run again" + Mika
+# substrate "USB ships with NO embedded credentials; first boot prompts
+# gh auth login + operator authenticates + auto-copy operator's pubkey
+# to authorized_keys").
+#
+# This module reads operator SSH pubkeys captured at install time by
+# zeta-install.sh's gh-auth-login step (Step 6.8). The shell does the
+# interactive `gh auth login` + `gh ssh-key list --json key,id,title`
+# extraction, writes to /mnt/etc/zeta/operator-authorized-keys (one key
+# per line; standard authorized_keys format). This module reads that
+# file at NixOS evaluation time + adds the keys to
+# users.users.zeta.openssh.authorizedKeys.keys.
+#
+# Composes with the existing iter-4.2 operator-ssh-keys.nix substrate
+# — those are statically-baked maintainer keys; this module is
+# dynamically-captured operator keys (whoever flashed + booted the
+# USB). Both compose at users.users.zeta.openssh.authorizedKeys.keys
+# (additive).
+#
+# BACKWARD-COMPAT FALLBACK: if /etc/zeta/operator-authorized-keys does
+# NOT exist (e.g., during nixos-rebuild on an already-installed system
+# where the file was never written, OR during `nix flake check` in CI
+# where the file path is meaningless), this module contributes the
+# empty list — no harm; the existing iter-4.2 keys (if any) still
+# apply.
+#
+# Format: standard authorized_keys file. One pubkey per line. Comments
+# starting with `#` allowed; blank lines allowed. Filtered to only
+# lines starting with `ssh-` (ssh-rsa/ssh-ed25519/ssh-dss/etc.) +
+# `ecdsa-sha2-...` (for ECDSA pubkeys).
+
+{ config, pkgs, lib, ... }:
+
+let
+  keyFile = "/etc/zeta/operator-authorized-keys";
+
+  rawContents =
+    if builtins.pathExists keyFile
+    then builtins.readFile keyFile
+    else "";
+
+  # Split on newlines + filter out comments + blank lines + only keep
+  # lines that look like SSH pubkeys (start with ssh- or ecdsa-).
+  splitLines = lib.strings.splitString "\n" rawContents;
+  isKeyLine = line:
+    let trimmed = lib.strings.trim line;
+    in trimmed != ""
+       && !(lib.hasPrefix "#" trimmed)
+       && (lib.hasPrefix "ssh-" trimmed || lib.hasPrefix "ecdsa-" trimmed);
+  operatorKeys = lib.lists.filter isKeyLine splitLines;
+in
+{
+  users.users.zeta.openssh.authorizedKeys.keys = operatorKeys;
+}

--- a/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
+++ b/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
@@ -69,6 +69,12 @@
     git-lfs
     gnupg
     openssh
+    # iter-5.4.0 (B-0794 homelab-mode): operator authenticates at
+    # install time via `gh auth login`; `gh ssh-key list` extracts
+    # operator's SSH pubkeys for injection into authorized_keys per
+    # the Mika 2026-05-26 homelab-first substrate ("USB ships with NO
+    # embedded credentials; first boot prompts gh auth login").
+    gh
 
     # Editors
     vim

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -564,6 +564,88 @@ else
 fi
 echo
 
+# ── Step 6.8: iter-5.4.0 homelab gh-auth + operator pubkey copy ──
+# B-0794 sub-target homelab-mode. The maintainer 2026-05-26: "i'll
+# wait till we have the install.sh and git native device registration
+# into github is ready before i run again". Per Mika 2026-05-26
+# homelab-first substrate: USB ships with NO embedded credentials;
+# operator authenticates interactively at install time via `gh auth
+# login`; auto-fetch operator's GitHub SSH pubkeys + write to
+# /mnt/etc/zeta/operator-authorized-keys for the
+# operator-authorized-keys.nix module to inject at activation.
+#
+# Outputs:
+#   /mnt/etc/zeta/operator-authorized-keys (one pubkey per line)
+#
+# Skippable: operator can press Enter to skip if they prefer fallback
+# to iter-4.2 statically-baked maintainer keys. NOT skippable if iter-
+# 4.2 injection also failed (logged so operator knows the gap).
+#
+# Composes with iter-4.2 (static keys; additive) + iter-5.3 password
+# prompt (console-login fallback) + iter-5.2 hostname (which.local
+# the operator SSHs to).
+GH_AUTH_OK=0
+GH_KEY_COUNT=0
+echo
+echo "[iter-5.4.0] ── homelab gh-auth + operator SSH-pubkey copy ──"
+echo "[iter-5.4.0] Authenticate to GitHub to auto-copy your SSH pubkeys"
+echo "[iter-5.4.0] to the installed node's authorized_keys. This makes"
+echo "[iter-5.4.0] ssh-from-your-Mac work without manual config-edit + rebuild."
+echo "[iter-5.4.0] Press Enter to skip (fallback to iter-4.2 static keys"
+echo "[iter-5.4.0] if injected, OR manual config-edit per the iter-4 v1 flow)."
+echo
+read -r -p "[iter-5.4.0] Run gh auth login now? [Y/n]: " GH_AUTH_REPLY
+GH_AUTH_REPLY="${GH_AUTH_REPLY:-Y}"
+if [[ "$GH_AUTH_REPLY" =~ ^[Yy]$ ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "[iter-5.4.0]   WARN: gh binary not on PATH; skipping (likely"
+    echo "[iter-5.4.0]         installer ISO bug — gh should be in"
+    echo "[iter-5.4.0]         environment.systemPackages of"
+    echo "[iter-5.4.0]         usb-nixos-installer/nixos/installer/configuration.nix)"
+  else
+    echo "[iter-5.4.0]   running 'gh auth login' (interactive)..."
+    echo
+    # `gh auth login` is interactive (browser code OR device-flow OR
+    # paste-token). Operator picks. Authenticates as their GitHub user.
+    if gh auth login; then
+      GH_AUTH_OK=1
+      echo
+      echo "[iter-5.4.0]   gh auth login: SUCCESS"
+      echo "[iter-5.4.0]   fetching operator's SSH pubkeys via 'gh ssh-key list'..."
+      KEY_DST_DIR=/mnt/etc/zeta
+      sudo mkdir -p "$KEY_DST_DIR"
+      KEY_DST="$KEY_DST_DIR/operator-authorized-keys"
+      # gh ssh-key list outputs the key BODY per row in JSON; jq extracts
+      # the `key` field which contains the standard authorized_keys line
+      # (algo + base64-pubkey; no comment). Each gets a comment appended
+      # so the operator can identify it later: "gh-key-<id>".
+      if gh ssh-key list --json id,key,title 2>/dev/null \
+          | jq -r '.[] | "\(.key) gh-key-\(.id)-\(.title // "")"' \
+          | sudo tee "$KEY_DST" >/dev/null; then
+        sudo chmod 0644 "$KEY_DST"
+        GH_KEY_COUNT="$(wc -l < "$KEY_DST" | tr -d ' ')"
+        echo "[iter-5.4.0]   wrote $GH_KEY_COUNT key(s) to $KEY_DST"
+        echo "[iter-5.4.0]   the operator-authorized-keys.nix module will pick"
+        echo "[iter-5.4.0]   them up during nixos-install (next step)"
+      else
+        echo "[iter-5.4.0]   WARN: 'gh ssh-key list' failed; no keys written"
+        echo "[iter-5.4.0]   (gh auth succeeded but the user has no SSH keys"
+        echo "[iter-5.4.0]   registered with GitHub, OR the jq/tee pipe broke)"
+        GH_KEY_COUNT=0
+      fi
+    else
+      echo
+      echo "[iter-5.4.0]   gh auth login FAILED or was cancelled; skipping"
+    fi
+  fi
+else
+  echo "[iter-5.4.0]   skipped at operator request; iter-4.2 static keys (if"
+  echo "[iter-5.4.0]   injected) remain the SSH path. If iter-4.2 also failed,"
+  echo "[iter-5.4.0]   manual config-edit per the iter-4 v1 flow is required"
+  echo "[iter-5.4.0]   post-install."
+fi
+echo
+
 echo "Running nixos-install --flake /mnt/etc/zeta/full-ai-cluster#$HOST ..."
 sudo nixos-install --flake "/mnt/etc/zeta/full-ai-cluster#$HOST" --no-root-password
 
@@ -578,19 +660,31 @@ echo
 echo "    user:     zeta"
 echo "    password: zeta-change-me"
 echo
-if [ "$INJECT_OK" = 1 ]; then
-  echo "  iter-4.2 SSH-KEY INJECTION: SUCCESS"
+if [ "$GH_AUTH_OK" = 1 ] && [ "$GH_KEY_COUNT" != "0" ]; then
+  echo "  iter-5.4.0 GH-AUTH + OPERATOR-PUBKEY INJECTION: SUCCESS ($GH_KEY_COUNT keys)"
+  echo "    SSH access works on first boot from any machine using"
+  echo "    your registered-with-GitHub SSH keys:"
+  echo "      ssh zeta@\$(hostname).local"
+  echo
+  echo "  AFTER FIRST LOGIN:"
+  echo "    1. (password already set per iter-5.3 prompt — or unchanged"
+  echo "        if iter-5.3 was skipped; rotate via 'passwd zeta' anytime)"
+  echo "    2. (SSH already works — operator keys auto-injected)"
+elif [ "$INJECT_OK" = 1 ]; then
+  echo "  iter-4.2 SSH-KEY INJECTION: SUCCESS (iter-5.4.0 gh-auth skipped)"
   echo "    SSH access works on first boot from the workstation that flashed this USB:"
   echo "      ssh zeta@\$(hostname)"
   echo
   echo "  AFTER FIRST LOGIN:"
-  echo "    1. passwd zeta            # rotate the initial password"
+  echo "    1. passwd zeta            # rotate the initial password (if iter-5.3 skipped)"
   echo "    2. (SSH already works — no manual edit + rebuild required)"
 else
-  echo "  iter-4.2 SSH-KEY INJECTION: SKIPPED (see diagnostics above)"
+  echo "  iter-4.2 SSH-KEY INJECTION: SKIPPED"
+  echo "  iter-5.4.0 GH-AUTH SSH-PUBKEY INJECTION: SKIPPED"
+  echo "  (see diagnostics above)"
   echo
   echo "  AFTER FIRST LOGIN (fallback to iter-4 v1 manual flow):"
-  echo "    1. passwd zeta            # rotate the initial password"
+  echo "    1. passwd zeta            # rotate the initial password (if iter-5.3 skipped)"
   echo "    2. Edit /etc/zeta/full-ai-cluster/nixos/modules/operator-ssh-keys.nix"
   echo "       and add your ssh-ed25519 pubkey, then:"
   echo "    3. sudo nixos-rebuild switch --flake /etc/zeta/full-ai-cluster#$HOST"


### PR DESCRIPTION
## Summary

Implements **iter-5.4.0** — minimum-viable B-0794 homelab-mode device-registration substrate the maintainer's deferral named:
> *"i'll wait till we have the install.sh and git native device registration into github is ready before i run again"*

Per Mika 2026-05-26 substrate (homelab-first; production-mode deferred):
> *"USB ships with NO embedded credentials; first boot prompts gh auth login + operator authenticates + auto-copy operator's pubkey to authorized_keys"*

## Changes

1. **`zeta-install.sh` Step 6.8 (NEW)** — between wifi (6.7) and nixos-install:
   - Prompts `[Y/n]` to run `gh auth login`
   - Operator authenticates interactively
   - `gh ssh-key list --json id,key,title` extracts all operator's registered SSH pubkeys
   - Writes one-per-line to `/mnt/etc/zeta/operator-authorized-keys`
   - Skippable; composes additively with iter-4.2 static keys

2. **`nixos/modules/operator-authorized-keys.nix` (NEW)** — mirrors iter-5.3 `initial-password.nix` pattern:
   - `builtins.readFile /etc/zeta/operator-authorized-keys` at activation
   - Filters → `users.users.zeta.openssh.authorizedKeys.keys`
   - Backward-compat fallback (no file → empty list → static keys still apply)

3. **`common.nix`** imports the new module

4. **Installer ISO** adds `gh` to `environment.systemPackages` (needed for `gh auth login` at install time)

5. **Install-complete banner** updated with 3-way path discriminator (iter-5.4.0 success / iter-4.2-only / both-skipped fallback)

## What this enables for next re-flash

After this lands → next ISO build triggers (push to `full-ai-cluster/**` matches the broadened trigger paths) → fresh artifact has:
- iter-5.1 (wifi persist) + iter-5.2 (hostname inject) + iter-5.2.2 (install-time auto-gen + login banner) + iter-5.3 (password prompt) + **iter-5.4.0 (gh-auth + operator-pubkey-copy)**
- Empirical UX: boot → 6.x prompts → gh auth login → operator authenticates → ssh from any of operator's GitHub-registered keys works on first boot

## Not in scope (B-0794 future sub-rows)

- Self-registration commit/push to `maintainers/<name>/cluster-nodes/` (sub-target 3 full)
- ArgoCD app watching the tree (sub-target 4)
- `--maintainer` flag on zflash (sub-target 5; defaults to gh-auth user)
- Production-mode bootstrap-key rotation (deferred per maintainer's homelab-first direction)

## Test plan

- [x] shellcheck clean on zeta-install.sh changes
- [x] `nix-instantiate --parse` clean on the new NixOS module
- [x] Substrate-inventory pass per `verify-existing-substrate-before-authoring.md`
- [ ] CI ISO build greens (auto-triggered by `full-ai-cluster/**` push paths)
- [ ] Re-flash + boot empirical validation (maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)