### PR TITLE
fix(postmerge-5210): 5 Copilot findings — prompt copy + comment accuracy + path + banner-password truth + sk-* FIDO key support

### DIFF
--- a/full-ai-cluster/nixos/modules/operator-authorized-keys.nix
+++ b/full-ai-cluster/nixos/modules/operator-authorized-keys.nix
@@ -29,9 +29,15 @@
 # apply.
 #
 # Format: standard authorized_keys file. One pubkey per line. Comments
-# starting with `#` allowed; blank lines allowed. Filtered to only
-# lines starting with `ssh-` (ssh-rsa/ssh-ed25519/ssh-dss/etc.) +
-# `ecdsa-sha2-...` (for ECDSA pubkeys).
+# starting with `#` allowed; blank lines allowed. Filtered to lines
+# starting with any supported pubkey-algorithm prefix:
+#   - `ssh-`     — ssh-rsa, ssh-ed25519, ssh-dss
+#   - `ecdsa-`   — ecdsa-sha2-nistp256/384/521
+#   - `sk-ssh-`  — FIDO/U2F security-key-backed Ed25519 (RFC8709)
+#   - `sk-ecdsa-` — FIDO/U2F security-key-backed ECDSA
+# GitHub stores all of the above when operators register them; the
+# existing operator-ssh-keys.nix substrate documents sk-* support so
+# this module keeps parity (Copilot P1 finding on PR #5210 fix-fwd).
 
 { config, pkgs, lib, ... }:
 
@@ -44,13 +50,17 @@ let
     else "";
 
   # Split on newlines + filter out comments + blank lines + only keep
-  # lines that look like SSH pubkeys (start with ssh- or ecdsa-).
+  # lines that look like SSH pubkeys. Supported prefixes per the
+  # comment block above include FIDO/U2F sk-* types so operators with
+  # security-key-only GitHub setups aren't silently dropped.
   splitLines = lib.strings.splitString "\n" rawContents;
+  validPrefixes = [ "ssh-" "ecdsa-" "sk-ssh-" "sk-ecdsa-" ];
+  hasValidPrefix = s: lib.lists.any (p: lib.hasPrefix p s) validPrefixes;
   isKeyLine = line:
     let trimmed = lib.strings.trim line;
     in trimmed != ""
        && !(lib.hasPrefix "#" trimmed)
-       && (lib.hasPrefix "ssh-" trimmed || lib.hasPrefix "ecdsa-" trimmed);
+       && hasValidPrefix trimmed;
   operatorKeys = lib.lists.filter isKeyLine splitLines;
 in
 {

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -577,9 +577,12 @@ echo
 # Outputs:
 #   /mnt/etc/zeta/operator-authorized-keys (one pubkey per line)
 #
-# Skippable: operator can press Enter to skip if they prefer fallback
-# to iter-4.2 statically-baked maintainer keys. NOT skippable if iter-
-# 4.2 injection also failed (logged so operator knows the gap).
+# Skippable (warning-only when iter-4.2 also failed): operator can type
+# 'n' to skip if they prefer fallback to iter-4.2 statically-baked
+# maintainer keys (or manual config-edit per iter-4 v1 if iter-4.2
+# also was skipped/failed). The Copilot-P1-corrected behavior matches
+# the implementation: always allow skip, log loudly when neither path
+# succeeded.
 #
 # Composes with iter-4.2 (static keys; additive) + iter-5.3 password
 # prompt (console-login fallback) + iter-5.2 hostname (which.local
@@ -591,7 +594,8 @@ echo "[iter-5.4.0] ── homelab gh-auth + operator SSH-pubkey copy ──"
 echo "[iter-5.4.0] Authenticate to GitHub to auto-copy your SSH pubkeys"
 echo "[iter-5.4.0] to the installed node's authorized_keys. This makes"
 echo "[iter-5.4.0] ssh-from-your-Mac work without manual config-edit + rebuild."
-echo "[iter-5.4.0] Press Enter to skip (fallback to iter-4.2 static keys"
+echo "[iter-5.4.0] Default is YES (recommended); press Enter to proceed"
+echo "[iter-5.4.0] OR type 'n' to skip (fallback to iter-4.2 static keys"
 echo "[iter-5.4.0] if injected, OR manual config-edit per the iter-4 v1 flow)."
 echo
 read -r -p "[iter-5.4.0] Run gh auth login now? [Y/n]: " GH_AUTH_REPLY
@@ -601,7 +605,7 @@ if [[ "$GH_AUTH_REPLY" =~ ^[Yy]$ ]]; then
     echo "[iter-5.4.0]   WARN: gh binary not on PATH; skipping (likely"
     echo "[iter-5.4.0]         installer ISO bug — gh should be in"
     echo "[iter-5.4.0]         environment.systemPackages of"
-    echo "[iter-5.4.0]         usb-nixos-installer/nixos/installer/configuration.nix)"
+    echo "[iter-5.4.0]         full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix)"
   else
     echo "[iter-5.4.0]   running 'gh auth login' (interactive)..."
     echo
@@ -655,10 +659,21 @@ echo "================================================================"
 echo "  ZETA CLUSTER NODE INSTALL COMPLETE"
 echo "================================================================"
 echo
-echo "  Initial login credentials (rotate immediately after first login):"
+echo "  Initial login credentials:"
 echo
 echo "    user:     zeta"
-echo "    password: zeta-change-me"
+# Banner must reflect iter-5.3's actual outcome (Copilot P1 finding on
+# #5210 fix-fwd): if operator set a custom password via Step 6.55, the
+# old hard-coded "password: zeta-change-me" line lied to them. Print
+# the truth per the captured state.
+if [ -f /mnt/etc/zeta/initial-hashedpassword ]; then
+  echo "    password: (the value you set during iter-5.3 prompt;"
+  echo "               iter-4.x default 'zeta-change-me' is NOT in effect)"
+else
+  echo "    password: zeta-change-me   (iter-4.x default; iter-5.3 prompt"
+  echo "                                was skipped or unavailable)"
+  echo "                rotate via 'passwd zeta' after first login"
+fi
 echo
 if [ "$GH_AUTH_OK" = 1 ] && [ "$GH_KEY_COUNT" != "0" ]; then
   echo "  iter-5.4.0 GH-AUTH + OPERATOR-PUBKEY INJECTION: SUCCESS ($GH_KEY_COUNT keys)"


### PR DESCRIPTION
## Summary

Addresses all 5 Copilot post-merge findings on #5210 (iter-5.4.0 just landed at e30b567e6). All 5 substantive; all real:

| # | Pri | Finding | Fix |
|---|---|---|---|
| 1 | P0 | Prompt copy "Press Enter to skip" but default is Y → Enter runs gh-auth | Rewrote copy to match `[Y/n]` default-Y behavior |
| 2 | P1 | Comment claims "NOT skippable if iter-4.2 also failed" but impl always allows skip | Rewrote comment to reflect reality (always-skippable + warning) |
| 3 | P2 | Warning references `usb-nixos-installer/...` missing `full-ai-cluster/` prefix | Path corrected |
| 4 | P1 | Banner always prints `password: zeta-change-me` but iter-5.3 lets operator customize | Conditional banner: reads /mnt/etc/zeta/initial-hashedpassword existence |
| 5 | P1 | `isKeyLine` only accepts ssh- + ecdsa-, silently drops sk-* FIDO/U2F keys GitHub stores | Refactored to validPrefixes list including `sk-ssh-` + `sk-ecdsa-` per existing operator-ssh-keys.nix parity |

## Substrate-honest note

Findings #5 (sk-* FIDO) is operationally load-bearing — operators with security-key-only GitHub setups would have had ALL their keys silently dropped. The existing operator-ssh-keys.nix module explicitly documents sk-* support; verifying that BEFORE authoring this fix (per the verify-existing-substrate-before-authoring rule landed today via #5131) caught the parity gap.

Auto-merge armed; threads resolved on #5210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)