### PR TITLE
fix(p0 iter-6.0 race-merge-recovery): glxinfo → mesa-demos (25.11 breaking change; PR #5218 auto-merge race fired before this fix was pushed)

### DIFF
--- a/full-ai-cluster/nixos/modules/gpu.nix
+++ b/full-ai-cluster/nixos/modules/gpu.nix
@@ -44,7 +44,7 @@
     nvtopPackages.nvidia
     cudaPackages.cuda_cudart
     cudaPackages.cuda_nvcc
-    glxinfo
+    mesa-demos
     vulkan-tools
     clinfo
   ];

--- a/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
+++ b/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
@@ -151,7 +151,7 @@
                 # assignments are informed by the real topology.
 
     # GPU detection (drivers come in per-host on installed system)
-    glxinfo
+    mesa-demos
     vulkan-tools
     clinfo
 


### PR DESCRIPTION
Auto-merge race on PR #5218: glxinfo→mesa-demos fix landed in branch AFTER merge fired. Main has 25.11 bump but glxinfo still present → ISO builds fail. This PR lands the fix directly. Empirical anchor of the auto-merge-race-with-follow-up-commit anti-pattern documented in blocked-green-ci-investigate-threads.md.