### PR TITLE
fix(postmerge-5221 B-0817): 4 Copilot findings — link/contradiction/mode-conflict/K8s ObjectMeta

### DIFF
--- a/docs/backlog/P2/B-0817-tools-cluster-register-node-ts-operator-invocation-companion-symmetric-to-deregister-for-manual-re-register-after-wipe-aaron-2026-05-26.md
+++ b/docs/backlog/P2/B-0817-tools-cluster-register-node-ts-operator-invocation-companion-symmetric-to-deregister-for-manual-re-register-after-wipe-aaron-2026-05-26.md
@@ -65,7 +65,7 @@ Mirror deregister-node.ts pattern.
 
 **Always optional** (both modes): `--maintainer` (default = `gh api /user --jq .login`), `--push-direct` flag, `--reason` text.
 
-**Hardware fields** (`--ip` + `--mac`): operator-provided only in compose mode. If omitted, the composed `node.yaml` has empty/null hardware fields; operator can later run iter-5.4.1 (B-0812 systemd self-register) on the live node to populate hardware via actual probe. **Auto-SSH-probe at register-tool time is out of scope** (consistent with "Out of scope" section below; Copilot P? on #5221 noticed internal contradiction in the original draft — corrected here).
+**Hardware fields** (`--ip` + `--mac`): operator-provided only in compose mode. If omitted, the composed `node.yaml` OMITS the `hardware` field entirely (the B-0813 CRD declares `hardware: { type: object, additionalProperties: true }` — `type: object` is not nullable, so emitting `hardware: null` would produce a CRD-invalid resource that ArgoCD/the apiserver would reject; omitting is valid since `hardware` is not in any `required:` list). Operator can later run iter-5.4.1 (B-0812 systemd self-register) on the live node to populate hardware via actual probe. **Auto-SSH-probe at register-tool time is out of scope** (consistent with "Out of scope" section below; Copilot P? on #5221 noticed internal contradiction in the original draft — corrected here).
 
 Reject `-`-prefixed values for string flags (avoid silent flag-consumption hazard caught on B-0814).
 
@@ -85,9 +85,10 @@ spec:
   roles:
     - control-plane
     - worker-gpu
-  hardware:
-    # if --from-yaml: pass through verbatim
-    # if compose mode: empty/null until iter-5.4.1 self-register populates
+  # hardware: only present in --from-yaml pass-through mode (verbatim from
+  # operator-supplied yaml); OMITTED in compose mode until iter-5.4.1
+  # self-register populates. CRD declares `hardware: { type: object }` —
+  # not nullable + not required, so omission is valid; `null` would fail.
   registration:
     timestamp: <now>
     method: manual-via-register-node.ts

--- a/docs/backlog/P2/B-0817-tools-cluster-register-node-ts-operator-invocation-companion-symmetric-to-deregister-for-manual-re-register-after-wipe-aaron-2026-05-26.md
+++ b/docs/backlog/P2/B-0817-tools-cluster-register-node-ts-operator-invocation-companion-symmetric-to-deregister-for-manual-re-register-after-wipe-aaron-2026-05-26.md
@@ -20,7 +20,7 @@ tags: [cluster-tooling, register, operator-invocation, gh-auth, ts-rule-0-compli
 
 ## Problem
 
-Today's iter-5.4 substrate has the AUTO path (node self-registers via systemd service at install-time per B-0812 iter-5.4.1) and the MANUAL DEREGISTER path ([B-0814](B-0814-tools-cluster-deregister-node-ts-removes-registered-machine-from-git-sibling-to-iter-5-4-1-self-registration-aaron-2026-05-26.md) `tools/cluster/deregister-node.ts`). Missing: the MANUAL REGISTER path.
+Today's iter-5.4 substrate has the AUTO path (node self-registers via systemd service at install-time per B-0812 iter-5.4.1) and the MANUAL DEREGISTER path ([B-0814](../P1/B-0814-tools-cluster-deregister-node-ts-removes-registered-machine-from-git-sibling-to-iter-5-4-1-self-registration-aaron-2026-05-26.md) `tools/cluster/deregister-node.ts`). Missing: the MANUAL REGISTER path.
 
 Operator-invocation manual register is useful for:
 
@@ -56,31 +56,42 @@ Two operational modes:
 
 ### Sub-target 1 — argument parsing + operator resolution
 
-Mirror deregister-node.ts pattern: `--host` (required + DNS-label-validated), `--roles` (required; comma-separated), `--maintainer` (default = `gh api /user --jq .login`), `--ip` + `--mac` (optional; if absent + node is reachable, probe via ssh; else require), `--from-yaml` (path to pre-composed yaml; alternative to other flags), `--push-direct` flag, `--reason` text.
+Mirror deregister-node.ts pattern.
+
+**Required by mode** (Copilot finding on #5221: original draft had `--host` + `--roles` marked required absolutely while `--from-yaml` was "alternative"; these are mutually exclusive — clarified here):
+
+- **Compose mode** (default; when `--from-yaml` ABSENT): `--host` required + DNS-label-validated; `--roles` required + comma-separated
+- **Pass-through mode** (when `--from-yaml <path>` PRESENT): `--host` + `--roles` IGNORED (yaml is source of truth); only `--maintainer` + `--push-direct` + `--reason` flags apply
+
+**Always optional** (both modes): `--maintainer` (default = `gh api /user --jq .login`), `--push-direct` flag, `--reason` text.
+
+**Hardware fields** (`--ip` + `--mac`): operator-provided only in compose mode. If omitted, the composed `node.yaml` has empty/null hardware fields; operator can later run iter-5.4.1 (B-0812 systemd self-register) on the live node to populate hardware via actual probe. **Auto-SSH-probe at register-tool time is out of scope** (consistent with "Out of scope" section below; Copilot P? on #5221 noticed internal contradiction in the original draft — corrected here).
 
 Reject `-`-prefixed values for string flags (avoid silent flag-consumption hazard caught on B-0814).
 
 ### Sub-target 2 — yaml composition
 
-Build `ClusterNode` CR per the B-0813 schema:
+Build `ClusterNode` CR per the B-0813 schema. **`maintainer` lives under `spec.registration`, NOT under `metadata`** (Copilot finding on #5221: K8s ObjectMeta has a fixed schema + does not allow arbitrary fields; placing the operator name there would be silently dropped by the API server). Use `spec.registration.maintainer` instead; if grouping by maintainer is needed at K8s level, add a standard label like `zeta.lucent-financial-group.com/maintainer: <op>`:
 
 ```yaml
 apiVersion: zeta.lucent-financial-group.com/v1
 kind: ClusterNode
 metadata:
   name: pikachu
-  maintainer: aaron
+  labels:
+    zeta.lucent-financial-group.com/maintainer: aaron
 spec:
   hostname: pikachu
   roles:
     - control-plane
     - worker-gpu
   hardware:
-    # if --from-yaml: pass through
-    # if compose mode: minimal stub OR probe-via-ssh OR operator-provided
+    # if --from-yaml: pass through verbatim
+    # if compose mode: empty/null until iter-5.4.1 self-register populates
   registration:
     timestamp: <now>
     method: manual-via-register-node.ts
+    maintainer: aaron
     reason: <--reason value if provided>
 ```
 


### PR DESCRIPTION
Addresses all 4 Copilot post-merge findings on PR #5221 (B-0817 register-node companion row). All 4 substantive: broken P1/P2 link; internal SSH-probe contradiction; --from-yaml vs --host required-flag mode conflict; K8s ObjectMeta cannot accept arbitrary `maintainer` field.