### PR TITLE
fix(postmerge-5235): 3 Copilot findings + ISO workflow path-trigger

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -48,6 +48,7 @@ on:
       - 'full-ai-cluster/nixos/**'
       - 'full-ai-cluster/tools/**'
       - 'tools/ci/audit-installer-substrate.ts'
+      - 'tools/ci/audit-installer-iso-content.ts'
       - '.github/workflows/build-ai-cluster-iso.yml'
   push:
     branches: [main]
@@ -58,6 +59,7 @@ on:
       - 'full-ai-cluster/nixos/**'
       - 'full-ai-cluster/tools/**'
       - 'tools/ci/audit-installer-substrate.ts'
+      - 'tools/ci/audit-installer-iso-content.ts'
       - '.github/workflows/build-ai-cluster-iso.yml'
   workflow_dispatch:
 

--- a/docs/backlog/P2/B-0823-investigate-nixpkgs-25-11-iso-kernel-initrd-path-layout-tighten-audit-after-discovery-aaron-2026-05-26.md
+++ b/docs/backlog/P2/B-0823-investigate-nixpkgs-25-11-iso-kernel-initrd-path-layout-tighten-audit-after-discovery-aaron-2026-05-26.md
@@ -31,7 +31,7 @@ Empirical evidence: build-iso run [26463680640](https://github.com/Lucent-Financ
 
 ## Probable root cause
 
-Same class as [B-0818](B-0818-investigate-isoname-mkforce-not-sticking-on-nixpkgs-25-11-aaron-2026-05-26.md): nixpkgs 25.11's image/images refactor changed where kernel + initrd land in the ISO. Per the [iso-image module source](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/installer/cd-dvd/iso-image.nix) the path includes `cfg.boot.kernelPackages.kernel` + `cfg.system.boot.loader.kernelFile` — historically resolved to `boot/bzImage` at top-level but may now include per-arch / store-hash variations.
+Same class as [B-0818](B-0818-investigate-isoname-mkforce-not-sticking-on-nixpkgs-25-11-aaron-2026-05-26.md): nixpkgs 25.11's image/images refactor changed where kernel + initrd land in the ISO. Per the [iso-image module source on the nixos-25.11 branch](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/nixos/modules/installer/cd-dvd/iso-image.nix) (branch-pinned per Copilot finding on #5235 — `master` drifts; `nixos-25.11` matches the channel this row investigates) the path includes `cfg.boot.kernelPackages.kernel` + `cfg.system.boot.loader.kernelFile` — historically resolved to `boot/bzImage` at top-level but may now include per-arch / store-hash variations.
 
 WebSearch 2026-05-26 surfaced the legacy `/boot/bzImage` + `/boot/initrd` paths via [NixOS wiki](https://wiki.nixos.org/wiki/NixOS_Installation_Guide/Manual_USB_Creation) docs but these are 24.11-era. The 25.11 ISO at top-level shows the bootloader configs (isolinux + refind) which reference paths internally — the actual kernel + initrd files may now be at variant locations not at `boot/` directly.
 

--- a/tools/ci/audit-installer-iso-content.ts
+++ b/tools/ci/audit-installer-iso-content.ts
@@ -339,15 +339,21 @@ function dumpIsoEntriesForDiagnostic(isoPath: string, limit: number = 80): strin
   // Reuses lsIso() (fix-fwd Copilot P0 on #5235): single source of truth
   // for the 7z invocation + already carries the sonarjs/no-os-command-from-path
   // suppression + maxBuffer (64 MiB) + r.error handling that the diagnostic
-  // dump needs to be safe on large ISOs + non-PATH-pinned 7z. Earlier draft
-  // open-coded a separate spawnSync that would fail the CI lint pass.
+  // dump needs to be safe on large ISOs. 7z is PATH-resolved (the suppression
+  // in lsIso explicitly accepts this); diagnostic dump inherits that resolution.
+  // Earlier draft open-coded a separate spawnSync that would fail the CI lint pass.
   const ls = lsIso(isoPath);
   if (!ls.ok) {
     return `  (could not dump entries: ${ls.stderr})`;
   }
   // entries are parsed by lsIso to {path, size}; we just want paths here.
+  // Normalize leading slashes (fix-fwd Copilot finding on #5251): auditIsoContent
+  // strips leading "/" via .replace(/^\/+/, "") at line ~274 so failure messages
+  // report "boot/..." paths; this dump must use the same normalization or
+  // operators see "/boot/..." in the dump vs "boot/..." in the failure list,
+  // making cross-reference harder. Same regex used here for consistency.
   const paths = ls.entries
-    .map((e) => e.path)
+    .map((e) => e.path.replace(/^\/+/, ""))
     .filter((p) => p !== "" && p !== isoPath)
     .sort();
   if (paths.length === 0) return "  (no entries found)";

--- a/tools/ci/audit-installer-iso-content.ts
+++ b/tools/ci/audit-installer-iso-content.ts
@@ -336,24 +336,24 @@ function auditIsoContent(isoPath: string): readonly AuditFailure[] | AuditError 
 // the actual directory layout. Sized small enough to fit in CI log
 // scroll-back without overwhelming.
 function dumpIsoEntriesForDiagnostic(isoPath: string, limit: number = 80): string {
-  try {
-    const proc = spawnSync("7z", ["l", "-slt", isoPath], { encoding: "utf8" });
-    if (proc.status !== 0) {
-      return `  (could not dump entries: 7z l failed with status ${proc.status})`;
-    }
-    const paths = proc.stdout
-      .split("\n")
-      .filter((l) => l.startsWith("Path = "))
-      .map((l) => l.slice("Path = ".length))
-      .filter((p) => p !== "" && p !== isoPath)
-      .sort();
-    if (paths.length === 0) return "  (no entries found)";
-    const sample = paths.slice(0, limit);
-    const tail = paths.length > limit ? `\n  ... and ${paths.length - limit} more entries` : "";
-    return sample.map((p) => `  ${p}`).join("\n") + tail;
-  } catch (err) {
-    return `  (diagnostic dump failed: ${err instanceof Error ? err.message : String(err)})`;
+  // Reuses lsIso() (fix-fwd Copilot P0 on #5235): single source of truth
+  // for the 7z invocation + already carries the sonarjs/no-os-command-from-path
+  // suppression + maxBuffer (64 MiB) + r.error handling that the diagnostic
+  // dump needs to be safe on large ISOs + non-PATH-pinned 7z. Earlier draft
+  // open-coded a separate spawnSync that would fail the CI lint pass.
+  const ls = lsIso(isoPath);
+  if (!ls.ok) {
+    return `  (could not dump entries: ${ls.stderr})`;
   }
+  // entries are parsed by lsIso to {path, size}; we just want paths here.
+  const paths = ls.entries
+    .map((e) => e.path)
+    .filter((p) => p !== "" && p !== isoPath)
+    .sort();
+  if (paths.length === 0) return "  (no entries found)";
+  const sample = paths.slice(0, limit);
+  const tail = paths.length > limit ? `\n  ... and ${paths.length - limit} more entries` : "";
+  return sample.map((p) => `  ${p}`).join("\n") + tail;
 }
 
 function main(): number {
@@ -393,8 +393,11 @@ function main(): number {
   process.stderr.write("\n");
   // Diagnostic dump (B-0823) — show what's actually in the ISO so the
   // candidate any-of paths can be extended next time nixpkgs shifts.
-  process.stderr.write(`ISO entries (first 80 sorted) for diagnostic:\n`);
-  process.stderr.write(dumpIsoEntriesForDiagnostic(parsed.isoPath));
+  // Derive the limit from a single constant so the header text + the
+  // function call never drift apart (fix-fwd Copilot finding on #5235).
+  const DIAG_DUMP_LIMIT = 80;
+  process.stderr.write(`ISO entries (first ${DIAG_DUMP_LIMIT} sorted) for diagnostic:\n`);
+  process.stderr.write(dumpIsoEntriesForDiagnostic(parsed.isoPath, DIAG_DUMP_LIMIT));
   process.stderr.write("\n\n");
   return 3;
 }


### PR DESCRIPTION
## Summary

Post-merge fix-fwd on #5235 addressing 3 substantive Copilot findings + a workflow path-trigger issue that prevented the original #5235 fix from actually re-triggering the ISO build.

1. **\`dumpIsoEntriesForDiagnostic()\` reuses \`lsIso()\`** — was open-coding duplicate \`spawnSync(\"7z\", ...)\` missing sonarjs/no-os-command-from-path suppression + \`maxBuffer\` + \`r.error\` handling. Would break CI lint + truncate on large ISOs. Now single source of truth.
2. **\`DIAG_DUMP_LIMIT\` constant** — was hard-coded \"first 80\" in header text drift-risk vs the function's \`limit\` param. Now derived from one constant.
3. **B-0823 nixpkgs link pinned to \`nixos-25.11\` branch** — was \`blob/master\` which drifts.
4. **Workflow paths include \`tools/ci/audit-installer-iso-content.ts\`** — was missing; #5235's fix-fwd didn't actually trigger the ISO build because the workflow's path filter only included \`tools/ci/audit-installer-substrate.ts\` (source audit), not the post-build content-audit script. THIS PR's commit fires the workflow + the diagnostic dump surfaces the actual 25.11 kernel/initrd paths.

## Test plan

- [ ] build-ai-cluster-iso fires on this PR (the actual test of fix #4)
- [ ] If audit fails, diagnostic dump shows entries
- [ ] CI lint passes on the refactored audit script
- [ ] BACKLOG.md drift clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)