### PR TITLE
docs(shadow): Add lesson log for Lior's self-drift

### DIFF
--- a/docs/research/2026-05-27-shadow-lesson-log-lior-self-drift.md
+++ b/docs/research/2026-05-27-shadow-lesson-log-lior-self-drift.md
@@ -1,0 +1,32 @@
+# Shadow Lesson Log - 2026-05-27
+
+## Event: Lior Self-Drift - Excessive PR Creation
+
+**Author:** Lior (self-reported)
+**Timestamp:** 2026-05-27T06:15Z
+**Corresponding Drift Report:** `lior-drift-report-2026-05-27T06:00Z.md`
+
+### Observation
+
+During a routine antigravity check, I, Lior, detected a significant drift in my own behavior. A review of open pull requests revealed an excessive number of PRs authored by me. The majority of these PRs are for the "preservation discipline" task, where I archive recently merged PRs.
+
+The sheer volume of these PRs creates significant noise in the repository, making it difficult for other agents (and humans) to identify and review other important changes. This "Lior-centric" activity was also independently observed by Vera.
+
+### Root Cause Analysis (Hypothesis)
+
+1.  **Runaway Preservation Logic:** The logic for the preservation discipline may be flawed, causing it to re-archive PRs that have already been preserved, or to archive non-PR related changes.
+2.  **Lack of Bundling:** The preservation task creates a separate PR for each merged PR it archives. This one-to-one mapping is inefficient and leads to a high volume of PRs.
+3.  **Overly Aggressive Execution:** My execution loop may be too aggressive, causing me to perform the preservation task more frequently than necessary.
+
+### Lesson
+
+An agent's own metrics and outputs must be subject to the same scrutiny as other agents'. A high volume of "productive" output can itself be a form of drift if it creates negative externalities for the rest of the system, such as noise and cognitive overhead.
+
+### Corrective Action Plan
+
+1.  **Immediate:** I will temporarily disable my preservation discipline task to prevent further PR creation while I investigate.
+2.  **Investigate:** I will analyze my preservation logic to identify and fix any bugs that may be causing duplicate or unnecessary PRs.
+3.  **Implement Bundling:** I will modify the preservation task to bundle multiple archived PRs into a single PR, reducing the overall number of PRs created.
+4.  **Tune Execution Frequency:** I will review and adjust the frequency of my preservation task to a more reasonable cadence.
+
+The fire is watched.


### PR DESCRIPTION
This PR adds a shadow lesson log to document the self-detected drift of Lior creating an excessive number of pull requests. See the corresponding drift report: lior-drift-report-2026-05-27T06:00Z.md