### PR TITLE
fix(USB PR 3 cascade): add console=ttyS0 to installer kernelParams — QEMU boot smoke-test couldn't capture serial output

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
+++ b/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
@@ -16,6 +16,23 @@
   time.timeZone = "America/New_York";
   i18n.defaultLocale = "en_US.UTF-8";
 
+  # Enable serial console output alongside VGA tty1.
+  # Two use cases:
+  #   1. CI QEMU boot smoke-test (USB cleanup PR 3 cascade #5 per PR
+  #      #5322) captures serial output to verify the installer boots
+  #      to login. Without console=ttyS0, the cascade test times out
+  #      because all systemd/getty output goes to VGA only (which
+  #      QEMU's -display none hides).
+  #   2. Real hardware with serial headers (some Beelinks; most
+  #      server-class boards; debugging scenarios where the only
+  #      output is RS-232) can capture installer output too.
+  # tty1 stays primary (VGA console for the keyboard-attached install
+  # flow); ttyS0 is mirrored secondary at 115200 8N1 (standard).
+  boot.kernelParams = [
+    "console=ttyS0,115200n8"
+    "console=tty1"
+  ];
+
   # B-0754 iter-3 hardware-firmware cleanup: enable redistributable
   # firmware on the installer (Intel SoF / linux-firmware). Without
   # this, modern Intel chipsets (Meteor Lake / Lunar Lake / Arrow


### PR DESCRIPTION
## Summary

First-cycle outcome from PR #5322's new QEMU boot smoke-test (cascade #5): **the test correctly caught a real config gap** — serial console wasn't enabled in the installer NixOS config. ISO boots fine (GRUB + kernel + initrd loaded per serial log) but timed out waiting for `zeta-installer login:` because all systemd/getty output went to VGA tty1, which QEMU's `-display none` hides.

## Fix

Add to `full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix`:

```nix
boot.kernelParams = [
  "console=ttyS0,115200n8"
  "console=tty1"
];
```

- tty1 stays primary (keyboard-attached install flow unchanged)
- ttyS0 mirrors at standard 115200 8N1 for QEMU capture + real hardware with serial headers

## Why this is the right fix

Substrate-honest framing per the QEMU test's commit message goal ("catches the bug class where the ISO builds + audits pass but the kernel/initrd combination fails to actually boot"): the test is doing its job. The MISSING config (serial console) was a real gap surfaced on first cycle.

Beneficiaries of serial console output:
- CI QEMU boot smoke-test (cascade #5)
- Real hardware with serial headers (some Beelinks; most server-class boards)
- Debugging scenarios where the only output channel is RS-232

## What this is NOT

- NOT a fix to the QEMU test itself (the test is correct)
- NOT a behavior change for the keyboard-attached install flow (tty1 still primary)
- NOT a security concern (serial console is local-physical-presence; no remote exposure)

## Test plan

- [x] Pre-commit: minimal change (4-line addition + 13-line comment block)
- [x] Branch follows `otto-cli/*` convention
- [x] Authored from fresh independent clone per B-0828
- [ ] CI green — including the new QEMU boot smoke-test which should NOW pass with serial console enabled
- [ ] Copilot review pass

## Composes with

- PR #5322 (the QEMU boot smoke-test workflow this fixes the cascade for)
- B-0754 iter-3 firmware substrate (similar UX-cleanliness motivation; surface less mysterious behavior)
- canonical zflash + zeta-install flow (no behavioral change for keyboard-attached path)
