### PR TITLE
fix(B-0835 Bug 1): hostname injection — symlink + --impure so flake eval reads cluster-node-id (same bug class as Bug 3b)

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -826,26 +826,32 @@ else
 fi
 echo
 
-# ── B-0835 Bug 1 fix: pre-stage /etc/zeta/ symlink so flake eval can ──
-# read /etc/zeta/cluster-node-id at build time. The injected-hostname.nix
-# module reads /etc/zeta/cluster-node-id via builtins.pathExists +
-# builtins.readFile at NixOS evaluation time (flake build-time). During
-# nixos-install from live ISO, that path refers to the LIVE ISO (file
-# absent) NOT the install target /mnt/etc/zeta/ (file present from Step
-# 6.6 iter-5.2.2). Without this symlink, injected-hostname.nix falls
-# through to the flake's hardcoded `networking.hostName` and the operator
-# gets the flake-default hostname (e.g., "control-plane") instead of the
-# unique node-<6hex> that iter-5.2.2 generated.
+# ── B-0835 Bug 1 fix: pre-stage per-file symlinks so flake eval can ──
+# read /etc/zeta/* files at build time. Several NixOS modules in the
+# flake use `builtins.pathExists` + `builtins.readFile` on absolute
+# `/etc/zeta/*` paths at evaluation time (flake build-time). During
+# nixos-install from live ISO, those paths refer to the LIVE ISO root
+# (files absent) NOT the install target /mnt/etc/zeta/ (files present
+# from earlier install steps).
 #
-# Symlinking /mnt/etc/zeta → /etc/zeta makes the file visible at the
-# path injected-hostname.nix expects, during the flake-eval phase of
-# nixos-install. After nixos-install completes + pivots into the
-# installed system on next boot, /etc/zeta/cluster-node-id IS at the
-# correct path (it's on the installed root filesystem already), so
-# subsequent rebuilds work without the symlink.
+# Modules affected (same bug class):
+#   - injected-hostname.nix       → /etc/zeta/cluster-node-id (Bug 1)
+#   - operator-authorized-keys.nix → /etc/zeta/operator-authorized-keys
+#                                    (B-0835 sibling — same bug; operator
+#                                    SSH-from-Mac would silently lose
+#                                    iter-5.4.0 captured pubkeys at
+#                                    install-time eval without this fix)
+# NOT affected (uses activation-script instead, per B-0835 Bug 3b fix):
+#   - initial-password.nix → activation reads /etc/zeta/initial-hashedpassword
+#     at boot-time on installed system; doesn't need this symlink
 #
-# Cleanup: remove the symlink after nixos-install so the live ISO is
-# clean (no dangling reference if /mnt is unmounted before reboot).
+# Fix: per-file symlinks (NOT directory-level — /etc/zeta may already
+# exist as a real dir + sym-replacement would lose contents). Only
+# create the symlink if the destination doesn't already exist (handles
+# rebuild-on-installed-system case where /etc/zeta/* are real files).
+#
+# Cleanup: trap-based so removal happens even if nixos-install fails or
+# is Ctrl-C'd. Defense-in-depth via explicit cleanup at end too.
 #
 # Empirical anchor: operator 2026-05-26 physical hardware-support test:
 # login banner showed "control-plane login:" instead of unique
@@ -853,39 +859,46 @@ echo
 # Bug 3b (password) which was fixed via activation-script (different
 # fix because password CAN apply at activation; hostname CANNOT cleanly
 # change at activation because many services bake hostname at build).
-if [ -f "$HOSTNAME_DST" ]; then
-  echo "[B-0835 Bug 1 fix] symlinking $HOSTNAME_DST → /etc/zeta/cluster-node-id for flake eval"
-  sudo mkdir -p /etc/zeta
-  # Only symlink if /etc/zeta/cluster-node-id doesn't already exist
-  # (rebuild-on-installed-system case where it's a real file)
-  if [ ! -e /etc/zeta/cluster-node-id ]; then
-    sudo ln -sf "$HOSTNAME_DST" /etc/zeta/cluster-node-id
-    SYMLINKED_HOSTNAME_FILE=1
-  else
-    echo "[B-0835 Bug 1 fix]   /etc/zeta/cluster-node-id already exists; not symlinking"
-    SYMLINKED_HOSTNAME_FILE=0
+SYMLINKED_FILES=()
+cleanup_symlinks() {
+  # Trap handler — runs on EXIT (success, failure, OR signal). Removes
+  # only the symlinks WE created. Idempotent + safe to re-run.
+  for f in "${SYMLINKED_FILES[@]}"; do
+    [ -L "$f" ] && sudo rm -f "$f"
+  done
+}
+trap cleanup_symlinks EXIT
+sudo mkdir -p /etc/zeta
+maybe_symlink() {
+  local src="$1" dst="$2"
+  if [ -f "$src" ] && [ ! -e "$dst" ]; then
+    sudo ln -sf "$src" "$dst"
+    SYMLINKED_FILES+=("$dst")
+    echo "[B-0835 Bug 1 fix] symlinked $src → $dst (flake-eval visibility)"
+  elif [ -e "$dst" ] && [ ! -L "$dst" ]; then
+    echo "[B-0835 Bug 1 fix]   $dst already exists as real file; not symlinking"
   fi
-else
-  SYMLINKED_HOSTNAME_FILE=0
-fi
+}
+maybe_symlink "$HOSTNAME_DST" /etc/zeta/cluster-node-id
+maybe_symlink /mnt/etc/zeta/operator-authorized-keys /etc/zeta/operator-authorized-keys
 
 echo "Running nixos-install --flake /mnt/etc/zeta/full-ai-cluster#$HOST ..."
-# --impure: required so builtins.pathExists + builtins.readFile in
-# injected-hostname.nix can read the symlinked /etc/zeta/cluster-node-id.
-# Without --impure, flake pure-mode refuses non-store absolute paths
-# even with the symlink in place. Safe here because:
-#   - Only impure read is /etc/zeta/cluster-node-id (operator-chosen
-#     hostname from iter-5.2.2; not a secret)
-#   - Other modules (initial-password.nix) do NOT use builtins.readFile;
-#     they use activation-scripts (per B-0835 Bug 3b fix)
+# --impure: required so builtins.pathExists + builtins.readFile in the
+# affected modules (injected-hostname.nix + operator-authorized-keys.nix)
+# can read the symlinked /etc/zeta/* files. Without --impure, flake
+# pure-mode refuses non-store absolute paths even with symlinks in place.
+# Safe here because:
+#   - Impure reads are operator-chosen hostname + operator's PUBLIC SSH
+#     pubkeys (NOT secrets — pubkeys are public by definition)
+#   - initial-password.nix does NOT use builtins.readFile (per B-0835
+#     Bug 3b fix uses activation-script instead); its hash file (which
+#     IS a secret) doesn't transit the impure-eval path
 sudo nixos-install --impure --flake "/mnt/etc/zeta/full-ai-cluster#$HOST" --no-root-password
 
-# Cleanup the symlink we created (no dangling reference if /mnt is
-# unmounted before reboot).
-if [ "$SYMLINKED_HOSTNAME_FILE" = "1" ]; then
-  sudo rm -f /etc/zeta/cluster-node-id
-  echo "[B-0835 Bug 1 fix] removed symlink (installed system has its own /etc/zeta/cluster-node-id)"
-fi
+# Explicit cleanup at end (defense-in-depth; trap also handles this on
+# success OR failure exit paths).
+cleanup_symlinks
+trap - EXIT
 
 # ── Step 7: print initial credentials (iter-4 — per B-0789) ──────
 echo

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -826,8 +826,66 @@ else
 fi
 echo
 
+# ── B-0835 Bug 1 fix: pre-stage /etc/zeta/ symlink so flake eval can ──
+# read /etc/zeta/cluster-node-id at build time. The injected-hostname.nix
+# module reads /etc/zeta/cluster-node-id via builtins.pathExists +
+# builtins.readFile at NixOS evaluation time (flake build-time). During
+# nixos-install from live ISO, that path refers to the LIVE ISO (file
+# absent) NOT the install target /mnt/etc/zeta/ (file present from Step
+# 6.6 iter-5.2.2). Without this symlink, injected-hostname.nix falls
+# through to the flake's hardcoded `networking.hostName` and the operator
+# gets the flake-default hostname (e.g., "control-plane") instead of the
+# unique node-<6hex> that iter-5.2.2 generated.
+#
+# Symlinking /mnt/etc/zeta → /etc/zeta makes the file visible at the
+# path injected-hostname.nix expects, during the flake-eval phase of
+# nixos-install. After nixos-install completes + pivots into the
+# installed system on next boot, /etc/zeta/cluster-node-id IS at the
+# correct path (it's on the installed root filesystem already), so
+# subsequent rebuilds work without the symlink.
+#
+# Cleanup: remove the symlink after nixos-install so the live ISO is
+# clean (no dangling reference if /mnt is unmounted before reboot).
+#
+# Empirical anchor: operator 2026-05-26 physical hardware-support test:
+# login banner showed "control-plane login:" instead of unique
+# node-<6hex>. Composes with the same path-mismatch class as B-0835
+# Bug 3b (password) which was fixed via activation-script (different
+# fix because password CAN apply at activation; hostname CANNOT cleanly
+# change at activation because many services bake hostname at build).
+if [ -f "$HOSTNAME_DST" ]; then
+  echo "[B-0835 Bug 1 fix] symlinking $HOSTNAME_DST → /etc/zeta/cluster-node-id for flake eval"
+  sudo mkdir -p /etc/zeta
+  # Only symlink if /etc/zeta/cluster-node-id doesn't already exist
+  # (rebuild-on-installed-system case where it's a real file)
+  if [ ! -e /etc/zeta/cluster-node-id ]; then
+    sudo ln -sf "$HOSTNAME_DST" /etc/zeta/cluster-node-id
+    SYMLINKED_HOSTNAME_FILE=1
+  else
+    echo "[B-0835 Bug 1 fix]   /etc/zeta/cluster-node-id already exists; not symlinking"
+    SYMLINKED_HOSTNAME_FILE=0
+  fi
+else
+  SYMLINKED_HOSTNAME_FILE=0
+fi
+
 echo "Running nixos-install --flake /mnt/etc/zeta/full-ai-cluster#$HOST ..."
-sudo nixos-install --flake "/mnt/etc/zeta/full-ai-cluster#$HOST" --no-root-password
+# --impure: required so builtins.pathExists + builtins.readFile in
+# injected-hostname.nix can read the symlinked /etc/zeta/cluster-node-id.
+# Without --impure, flake pure-mode refuses non-store absolute paths
+# even with the symlink in place. Safe here because:
+#   - Only impure read is /etc/zeta/cluster-node-id (operator-chosen
+#     hostname from iter-5.2.2; not a secret)
+#   - Other modules (initial-password.nix) do NOT use builtins.readFile;
+#     they use activation-scripts (per B-0835 Bug 3b fix)
+sudo nixos-install --impure --flake "/mnt/etc/zeta/full-ai-cluster#$HOST" --no-root-password
+
+# Cleanup the symlink we created (no dangling reference if /mnt is
+# unmounted before reboot).
+if [ "$SYMLINKED_HOSTNAME_FILE" = "1" ]; then
+  sudo rm -f /etc/zeta/cluster-node-id
+  echo "[B-0835 Bug 1 fix] removed symlink (installed system has its own /etc/zeta/cluster-node-id)"
+fi
 
 # ── Step 7: print initial credentials (iter-4 — per B-0789) ──────
 echo


### PR DESCRIPTION
## Summary

Fixes B-0835 Bug 1 — login banner showed \`control-plane login:\` instead of unique \`node-<6hex>\`. Same bug class as Bug 3b (build-time-eval vs install-time-write path mismatch).

## Root cause

\`injected-hostname.nix\` reads \`/etc/zeta/cluster-node-id\` via \`builtins.pathExists\` + \`builtins.readFile\` at NixOS evaluation time. During \`nixos-install\` from live ISO:

- \`zeta-install.sh\` Step 6.6 writes \`/mnt/etc/zeta/cluster-node-id\` ✓
- Flake eval reads \`/etc/zeta/cluster-node-id\` (LIVE ISO context; absent)
- Module falls through to flake's hardcoded \`networking.hostName\`
- Operator gets flake-default hostname (\`control-plane\`) instead of unique \`node-<6hex>\`

## Fix

Different from Bug 3b's activation-script approach because hostname CANNOT cleanly change at activation (many services bake hostname at build time).

1. Symlink \`/mnt/etc/zeta/cluster-node-id\` → \`/etc/zeta/cluster-node-id\` BEFORE \`nixos-install\` runs
2. Add \`--impure\` flag so flake pure-mode allows \`builtins.pathExists\` + \`builtins.readFile\` on the non-store path
3. Cleanup symlink AFTER \`nixos-install\` (no dangling reference if /mnt unmounted before reboot)

Subsequent rebuilds on installed system work without symlink (file IS on installed root fs after install).

## Safety

- Only impure read is operator-chosen hostname (not a secret)
- Other modules (initial-password.nix per Bug 3b fix) use activation-scripts so don't need --impure
- Symlink-then-cleanup is idempotent + reversible

## Test plan

- [x] Bash syntax OK (\`bash -n\` passes)
- [x] Idempotent (only symlinks if /etc/zeta/cluster-node-id doesn't already exist)
- [x] Reversible (cleanup removes symlink only if we created it)
- [x] No HARD LIMITS violated (no secrets in symlink target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)