### PR TITLE
hygiene: format stale worktree auditor

### DIFF
--- a/docs/claims/codex-loop-stale-worktree-prettier-20260526.md
+++ b/docs/claims/codex-loop-stale-worktree-prettier-20260526.md
@@ -1,0 +1,35 @@
+# Claim: codex-loop-stale-worktree-prettier-20260526
+
+claimed-at: 2026-05-26T23:56:00Z
+agent: Codex
+session: codex/desktop-loop
+surface: codex-desktop-heartbeat
+origin: vera-desktop-loop
+branch: claim/codex-loop-stale-worktree-prettier-20260526
+worktree: /Users/acehack/.local/share/zeta-codex-loop/Zeta-worktrees/codex-loop-stale-worktree-prettier-20260526
+
+## Scope
+
+Trajectory: factory hygiene tooling.
+
+Bounded step: normalize the stale-worktree audit tool and its focused test to
+the repository Prettier style so the existing formatter gate can cover this
+tool without a local exception.
+
+## Paths
+
+- tools/hygiene/audit-stale-worktrees.ts
+- tools/hygiene/audit-stale-worktrees.test.ts
+- docs/claims/codex-loop-stale-worktree-prettier-20260526.md
+
+## Non-Scope
+
+- No behavioral changes to stale-worktree detection or pruning.
+- No cleanup of peer worktrees.
+- No edits in the contested root checkout.
+
+## Acceptance Check
+
+- `bun test tools/hygiene/audit-stale-worktrees.test.ts`
+- `node_modules/.bin/prettier --check tools/hygiene/audit-stale-worktrees.ts tools/hygiene/audit-stale-worktrees.test.ts`
+- `node_modules/.bin/tsc --noEmit -p tsconfig.json`

--- a/tools/hygiene/audit-stale-worktrees.test.ts
+++ b/tools/hygiene/audit-stale-worktrees.test.ts
@@ -5,119 +5,110 @@ import { describe, expect, test } from "bun:test";
 import { parseWorktreePorcelain, renderReport } from "./audit-stale-worktrees.ts";
 
 describe("parseWorktreePorcelain", () => {
-    test("parses a single live worktree block", () => {
-        const stdout = [
-            "worktree /Users/foo/repo",
-            "HEAD abc1234567890",
-            "branch refs/heads/main",
-            "",
-        ].join("\n");
-        const entries = parseWorktreePorcelain(stdout);
-        expect(entries).toHaveLength(1);
-        expect(entries[0]!.path).toBe("/Users/foo/repo");
-        expect(entries[0]!.branch).toBe("refs/heads/main");
-        expect(entries[0]!.prunable).toBe(false);
-    });
+  test("parses a single live worktree block", () => {
+    const stdout = ["worktree /Users/foo/repo", "HEAD abc1234567890", "branch refs/heads/main", ""].join("\n");
+    const entries = parseWorktreePorcelain(stdout);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.path).toBe("/Users/foo/repo");
+    expect(entries[0]!.branch).toBe("refs/heads/main");
+    expect(entries[0]!.prunable).toBe(false);
+  });
 
-    test("parses a prunable worktree block", () => {
-        const stdout = [
-            "worktree /tmp/zeta-stale",
-            "HEAD def4567890abc",
-            "branch refs/heads/some-old-branch",
-            "prunable gitdir file points to non-existent location",
-            "",
-        ].join("\n");
-        const entries = parseWorktreePorcelain(stdout);
-        expect(entries).toHaveLength(1);
-        expect(entries[0]!.path).toBe("/tmp/zeta-stale");
-        expect(entries[0]!.prunable).toBe(true);
-    });
+  test("parses a prunable worktree block", () => {
+    const stdout = [
+      "worktree /tmp/zeta-stale",
+      "HEAD def4567890abc",
+      "branch refs/heads/some-old-branch",
+      "prunable gitdir file points to non-existent location",
+      "",
+    ].join("\n");
+    const entries = parseWorktreePorcelain(stdout);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.path).toBe("/tmp/zeta-stale");
+    expect(entries[0]!.prunable).toBe(true);
+  });
 
-    test("parses multiple blocks separated by blank lines", () => {
-        const stdout = [
-            "worktree /repo/a",
-            "HEAD aaa",
-            "branch refs/heads/a",
-            "",
-            "worktree /repo/b",
-            "HEAD bbb",
-            "branch refs/heads/b",
-            "prunable orphan",
-            "",
-            "worktree /repo/c",
-            "HEAD ccc",
-            "",
-        ].join("\n");
-        const entries = parseWorktreePorcelain(stdout);
-        expect(entries).toHaveLength(3);
-        expect(entries[1]!.prunable).toBe(true);
-        expect(entries[2]!.branch).toBeNull();
-    });
+  test("parses multiple blocks separated by blank lines", () => {
+    const stdout = [
+      "worktree /repo/a",
+      "HEAD aaa",
+      "branch refs/heads/a",
+      "",
+      "worktree /repo/b",
+      "HEAD bbb",
+      "branch refs/heads/b",
+      "prunable orphan",
+      "",
+      "worktree /repo/c",
+      "HEAD ccc",
+      "",
+    ].join("\n");
+    const entries = parseWorktreePorcelain(stdout);
+    expect(entries).toHaveLength(3);
+    expect(entries[1]!.prunable).toBe(true);
+    expect(entries[2]!.branch).toBeNull();
+  });
 
-    test("handles a detached HEAD worktree (no branch line)", () => {
-        const stdout = ["worktree /repo/detached", "HEAD abcdef", "detached", ""].join("\n");
-        const entries = parseWorktreePorcelain(stdout);
-        expect(entries).toHaveLength(1);
-        expect(entries[0]!.branch).toBeNull();
-    });
+  test("handles a detached HEAD worktree (no branch line)", () => {
+    const stdout = ["worktree /repo/detached", "HEAD abcdef", "detached", ""].join("\n");
+    const entries = parseWorktreePorcelain(stdout);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.branch).toBeNull();
+  });
 
-    test("returns an empty array for empty input", () => {
-        expect(parseWorktreePorcelain("")).toHaveLength(0);
-    });
+  test("returns an empty array for empty input", () => {
+    expect(parseWorktreePorcelain("")).toHaveLength(0);
+  });
 });
 
 describe("renderReport", () => {
-    test("renders a healthy report (no stale entries)", () => {
-        const fixed = new Date("2026-05-14T00:00:00Z");
-        const md = renderReport(
-            {
-                totalWorktrees: 3,
-                healthy: 3,
-                stalePathExists: [],
-                stalePathMissing: [],
-            },
-            fixed,
-            null,
-        );
-        expect(md).toContain("Total worktrees: 3");
-        expect(md).toContain("Healthy: 3");
-        expect(md).toContain("Stale, path missing on disk: 0");
-        expect(md).not.toContain("## Stale worktrees");
-    });
+  test("renders a healthy report (no stale entries)", () => {
+    const fixed = new Date("2026-05-14T00:00:00Z");
+    const md = renderReport(
+      {
+        totalWorktrees: 3,
+        healthy: 3,
+        stalePathExists: [],
+        stalePathMissing: [],
+      },
+      fixed,
+      null,
+    );
+    expect(md).toContain("Total worktrees: 3");
+    expect(md).toContain("Healthy: 3");
+    expect(md).toContain("Stale, path missing on disk: 0");
+    expect(md).not.toContain("## Stale worktrees");
+  });
 
-    test("renders a stale-path-missing table", () => {
-        const fixed = new Date("2026-05-14T00:00:00Z");
-        const md = renderReport(
-            {
-                totalWorktrees: 2,
-                healthy: 1,
-                stalePathExists: [],
-                stalePathMissing: [
-                    { path: "/tmp/zeta-stale", head: "abc", branch: "refs/heads/feature/x", prunable: true },
-                ],
-            },
-            fixed,
-            null,
-        );
-        expect(md).toContain("Stale, path missing on disk: 1");
-        expect(md).toContain("| `/tmp/zeta-stale` | `refs/heads/feature/x` |");
-    });
+  test("renders a stale-path-missing table", () => {
+    const fixed = new Date("2026-05-14T00:00:00Z");
+    const md = renderReport(
+      {
+        totalWorktrees: 2,
+        healthy: 1,
+        stalePathExists: [],
+        stalePathMissing: [{ path: "/tmp/zeta-stale", head: "abc", branch: "refs/heads/feature/x", prunable: true }],
+      },
+      fixed,
+      null,
+    );
+    expect(md).toContain("Stale, path missing on disk: 1");
+    expect(md).toContain("| `/tmp/zeta-stale` | `refs/heads/feature/x` |");
+  });
 
-    test("renders prune output when provided", () => {
-        const fixed = new Date("2026-05-14T00:00:00Z");
-        const md = renderReport(
-            {
-                totalWorktrees: 1,
-                healthy: 0,
-                stalePathExists: [],
-                stalePathMissing: [
-                    { path: "/tmp/zeta-stale", head: null, branch: null, prunable: true },
-                ],
-            },
-            fixed,
-            "Removing worktrees/zeta-stale\n",
-        );
-        expect(md).toContain("## Prune output");
-        expect(md).toContain("Removing worktrees/zeta-stale");
-    });
+  test("renders prune output when provided", () => {
+    const fixed = new Date("2026-05-14T00:00:00Z");
+    const md = renderReport(
+      {
+        totalWorktrees: 1,
+        healthy: 0,
+        stalePathExists: [],
+        stalePathMissing: [{ path: "/tmp/zeta-stale", head: null, branch: null, prunable: true }],
+      },
+      fixed,
+      "Removing worktrees/zeta-stale\n",
+    );
+    expect(md).toContain("## Prune output");
+    expect(md).toContain("Removing worktrees/zeta-stale");
+  });
 });

--- a/tools/hygiene/audit-stale-worktrees.ts
+++ b/tools/hygiene/audit-stale-worktrees.ts
@@ -45,178 +45,178 @@ import { spawnSync } from "node:child_process";
 type AuditExitCode = 0 | 64 | 128;
 
 interface Args {
-    readonly report: string | null;
-    readonly prune: boolean;
+  readonly report: string | null;
+  readonly prune: boolean;
 }
 
 interface WorktreeEntry {
-    readonly path: string;
-    readonly head: string | null;
-    readonly branch: string | null;
-    readonly prunable: boolean;
+  readonly path: string;
+  readonly head: string | null;
+  readonly branch: string | null;
+  readonly prunable: boolean;
 }
 
 interface AuditResult {
-    readonly totalWorktrees: number;
-    readonly stalePathExists: WorktreeEntry[]; // path exists but git flagged prunable
-    readonly stalePathMissing: WorktreeEntry[]; // path missing on disk
-    readonly healthy: number;
+  readonly totalWorktrees: number;
+  readonly stalePathExists: WorktreeEntry[]; // path exists but git flagged prunable
+  readonly stalePathMissing: WorktreeEntry[]; // path missing on disk
+  readonly healthy: number;
 }
 
 function parseArgs(argv: string[]): { kind: "args"; args: Args } | { kind: "error"; message: string } {
-    let report: string | null = null;
-    let prune = false;
-    let i = 0;
-    while (i < argv.length) {
-        const a = argv[i]!;
-        if (a === "--report") {
-            const next = argv[i + 1];
-            if (!next) return { kind: "error", message: "--report requires a path" };
-            report = next;
-            i += 2;
-        } else if (a === "--prune") {
-            prune = true;
-            i += 1;
-        } else {
-            return { kind: "error", message: `Unknown argument: ${a}` };
-        }
+  let report: string | null = null;
+  let prune = false;
+  let i = 0;
+  while (i < argv.length) {
+    const a = argv[i]!;
+    if (a === "--report") {
+      const next = argv[i + 1];
+      if (!next) return { kind: "error", message: "--report requires a path" };
+      report = next;
+      i += 2;
+    } else if (a === "--prune") {
+      prune = true;
+      i += 1;
+    } else {
+      return { kind: "error", message: `Unknown argument: ${a}` };
     }
-    return { kind: "args", args: { report, prune } };
+  }
+  return { kind: "args", args: { report, prune } };
 }
 
 function parseWorktreePorcelain(stdout: string): WorktreeEntry[] {
-    const entries: WorktreeEntry[] = [];
-    const blocks = stdout.split("\n\n");
-    for (const block of blocks) {
-        if (!block.trim()) continue;
-        const lines = block.split("\n");
-        let path = "";
-        let head: string | null = null;
-        let branch: string | null = null;
-        let prunable = false;
-        for (const line of lines) {
-            if (line.startsWith("worktree ")) path = line.slice(9);
-            else if (line.startsWith("HEAD ")) head = line.slice(5);
-            else if (line.startsWith("branch ")) branch = line.slice(7);
-            else if (line === "prunable" || line.startsWith("prunable ")) prunable = true;
-        }
-        if (path) entries.push({ path, head, branch, prunable });
+  const entries: WorktreeEntry[] = [];
+  const blocks = stdout.split("\n\n");
+  for (const block of blocks) {
+    if (!block.trim()) continue;
+    const lines = block.split("\n");
+    let path = "";
+    let head: string | null = null;
+    let branch: string | null = null;
+    let prunable = false;
+    for (const line of lines) {
+      if (line.startsWith("worktree ")) path = line.slice(9);
+      else if (line.startsWith("HEAD ")) head = line.slice(5);
+      else if (line.startsWith("branch ")) branch = line.slice(7);
+      else if (line === "prunable" || line.startsWith("prunable ")) prunable = true;
     }
-    return entries;
+    if (path) entries.push({ path, head, branch, prunable });
+  }
+  return entries;
 }
 
 function audit(): AuditResult | { error: string; code: AuditExitCode } {
-    const list = spawnSync("git", ["worktree", "list", "--porcelain"], { encoding: "utf8" });
-    if (list.status !== 0) {
-        return { error: `git worktree list failed: ${list.stderr}`, code: 128 };
+  const list = spawnSync("git", ["worktree", "list", "--porcelain"], { encoding: "utf8" });
+  if (list.status !== 0) {
+    return { error: `git worktree list failed: ${list.stderr}`, code: 128 };
+  }
+
+  const entries = parseWorktreePorcelain(list.stdout);
+  const stalePathExists: WorktreeEntry[] = [];
+  const stalePathMissing: WorktreeEntry[] = [];
+  let healthy = 0;
+
+  for (const entry of entries) {
+    if (entry.prunable && !existsSync(entry.path)) {
+      stalePathMissing.push(entry);
+    } else if (entry.prunable) {
+      stalePathExists.push(entry);
+    } else {
+      healthy++;
     }
+  }
 
-    const entries = parseWorktreePorcelain(list.stdout);
-    const stalePathExists: WorktreeEntry[] = [];
-    const stalePathMissing: WorktreeEntry[] = [];
-    let healthy = 0;
-
-    for (const entry of entries) {
-        if (entry.prunable && !existsSync(entry.path)) {
-            stalePathMissing.push(entry);
-        } else if (entry.prunable) {
-            stalePathExists.push(entry);
-        } else {
-            healthy++;
-        }
-    }
-
-    return {
-        totalWorktrees: entries.length,
-        stalePathExists,
-        stalePathMissing,
-        healthy,
-    };
+  return {
+    totalWorktrees: entries.length,
+    stalePathExists,
+    stalePathMissing,
+    healthy,
+  };
 }
 
 function runPrune(): { ok: boolean; output: string } {
-    const r = spawnSync("git", ["worktree", "prune", "--expire=now", "-v"], { encoding: "utf8" });
-    return { ok: r.status === 0 || r.status === 1, output: (r.stdout || "") + (r.stderr || "") };
+  const r = spawnSync("git", ["worktree", "prune", "--expire=now", "-v"], { encoding: "utf8" });
+  return { ok: r.status === 0 || r.status === 1, output: (r.stdout || "") + (r.stderr || "") };
 }
 
 function renderReport(result: AuditResult, now: Date, pruned: string | null): string {
-    const lines: string[] = [];
-    lines.push("# git-worktree staleness audit");
+  const lines: string[] = [];
+  lines.push("# git-worktree staleness audit");
+  lines.push("");
+  lines.push(`Generated: ${now.toISOString()}`);
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(`- Total worktrees: ${result.totalWorktrees}`);
+  lines.push(`- Healthy: ${result.healthy}`);
+  lines.push(`- Stale, path missing on disk: ${result.stalePathMissing.length}`);
+  lines.push(`- Stale, path still exists (manual triage): ${result.stalePathExists.length}`);
+  lines.push("");
+  if (result.stalePathMissing.length > 0) {
+    lines.push("## Stale worktrees (path missing — safe to prune)");
     lines.push("");
-    lines.push(`Generated: ${now.toISOString()}`);
-    lines.push("");
-    lines.push("## Summary");
-    lines.push("");
-    lines.push(`- Total worktrees: ${result.totalWorktrees}`);
-    lines.push(`- Healthy: ${result.healthy}`);
-    lines.push(`- Stale, path missing on disk: ${result.stalePathMissing.length}`);
-    lines.push(`- Stale, path still exists (manual triage): ${result.stalePathExists.length}`);
-    lines.push("");
-    if (result.stalePathMissing.length > 0) {
-        lines.push("## Stale worktrees (path missing — safe to prune)");
-        lines.push("");
-        lines.push("| Path | Branch |");
-        lines.push("|------|--------|");
-        for (const e of result.stalePathMissing) {
-            lines.push(`| \`${e.path}\` | ${e.branch ? `\`${e.branch}\`` : "_(detached)_"} |`);
-        }
-        lines.push("");
+    lines.push("| Path | Branch |");
+    lines.push("|------|--------|");
+    for (const e of result.stalePathMissing) {
+      lines.push(`| \`${e.path}\` | ${e.branch ? `\`${e.branch}\`` : "_(detached)_"} |`);
     }
-    if (result.stalePathExists.length > 0) {
-        lines.push("## Stale worktrees (path still exists — investigate before prune)");
-        lines.push("");
-        lines.push("| Path | Branch |");
-        lines.push("|------|--------|");
-        for (const e of result.stalePathExists) {
-            lines.push(`| \`${e.path}\` | ${e.branch ? `\`${e.branch}\`` : "_(detached)_"} |`);
-        }
-        lines.push("");
+    lines.push("");
+  }
+  if (result.stalePathExists.length > 0) {
+    lines.push("## Stale worktrees (path still exists — investigate before prune)");
+    lines.push("");
+    lines.push("| Path | Branch |");
+    lines.push("|------|--------|");
+    for (const e of result.stalePathExists) {
+      lines.push(`| \`${e.path}\` | ${e.branch ? `\`${e.branch}\`` : "_(detached)_"} |`);
     }
-    if (pruned !== null) {
-        lines.push("## Prune output");
-        lines.push("");
-        lines.push("```");
-        lines.push(pruned.trim() || "(no entries pruned)");
-        lines.push("```");
-        lines.push("");
-    }
-    return lines.join("\n");
+    lines.push("");
+  }
+  if (pruned !== null) {
+    lines.push("## Prune output");
+    lines.push("");
+    lines.push("```");
+    lines.push(pruned.trim() || "(no entries pruned)");
+    lines.push("```");
+    lines.push("");
+  }
+  return lines.join("\n");
 }
 
 function main(argv: string[]): AuditExitCode {
-    const parsed = parseArgs(argv);
-    if (parsed.kind === "error") {
-        console.error(`error: ${parsed.message}`);
-        return 64;
-    }
+  const parsed = parseArgs(argv);
+  if (parsed.kind === "error") {
+    console.error(`error: ${parsed.message}`);
+    return 64;
+  }
 
-    const r = audit();
-    if ("error" in r) {
-        console.error(r.error);
-        return r.code;
-    }
+  const r = audit();
+  if ("error" in r) {
+    console.error(r.error);
+    return r.code;
+  }
 
-    let pruneOutput: string | null = null;
-    if (parsed.args.prune && r.stalePathMissing.length > 0) {
-        const p = runPrune();
-        pruneOutput = p.output;
-        if (!p.ok) console.error("git worktree prune exited non-zero (continuing — some entries may have pruned)");
-    }
+  let pruneOutput: string | null = null;
+  if (parsed.args.prune && r.stalePathMissing.length > 0) {
+    const p = runPrune();
+    pruneOutput = p.output;
+    if (!p.ok) console.error("git worktree prune exited non-zero (continuing — some entries may have pruned)");
+  }
 
-    const report = renderReport(r, new Date(), pruneOutput);
+  const report = renderReport(r, new Date(), pruneOutput);
 
-    if (parsed.args.report) {
-        writeFileSync(parsed.args.report, report);
-        console.log(`wrote ${parsed.args.report}`);
-    } else {
-        console.log(report);
-    }
+  if (parsed.args.report) {
+    writeFileSync(parsed.args.report, report);
+    console.log(`wrote ${parsed.args.report}`);
+  } else {
+    console.log(report);
+  }
 
-    return 0;
+  return 0;
 }
 
 if (import.meta.main) {
-    process.exit(main(process.argv.slice(2)));
+  process.exit(main(process.argv.slice(2)));
 }
 
 export { audit, parseWorktreePorcelain, renderReport };


### PR DESCRIPTION
## Summary
- normalize `audit-stale-worktrees` and its focused test to the repository Prettier style
- add a Codex claim record for the bounded formatting slice
- leave stale-worktree audit behavior unchanged

## Checks
- `bun test tools/hygiene/audit-stale-worktrees.test.ts`
- `node_modules/.bin/prettier --check tools/hygiene/audit-stale-worktrees.ts tools/hygiene/audit-stale-worktrees.test.ts`
- `node_modules/.bin/tsc --noEmit -p tsconfig.json`
