### PR TITLE
ci(B-0831 layer-1): extend audit-installer-substrate with iter-5.4 sentinels

### DIFF
--- a/tools/ci/audit-installer-substrate.ts
+++ b/tools/ci/audit-installer-substrate.ts
@@ -95,9 +95,10 @@ const REQUIRED_SENTINELS: readonly SentinelAssertion[] = [
       "admin:public_key", // B-0835 Bug 2b fix — scope-error recovery guidance
       "gh repo clone Lucent-Financial-Group/Zeta", // iter-5.4.1 cluster repo clone
       "register-${NODE_HOSTNAME}-", // iter-5.4.1 registration branch shape
-      // iter-5.4.1 YAML schema sentinels (catches the Copilot findings from #5352
-      // where spec.role was scalar instead of array, spec.maintainer was at wrong
-      // path, spec.storage was a sibling instead of under hardware block).
+      // iter-5.4.1 YAML schema sentinels. Each catches a specific Copilot
+      // finding on PR #5352: spec.role was scalar (should be array),
+      // spec.maintainer was at flat path (should nest under spec.registration),
+      // spec.storage was a sibling of hardware (should nest under spec.hardware).
       "apiVersion: zeta.lucent-financial-group.com/v1", // ClusterNode CRD apiVersion
       "kind: ClusterNode", // CRD kind
       "  roles:", // spec.roles is ARRAY (NOT scalar spec.role) per B-0813 schema

--- a/tools/ci/audit-installer-substrate.ts
+++ b/tools/ci/audit-installer-substrate.ts
@@ -85,8 +85,29 @@ const REQUIRED_SENTINELS: readonly SentinelAssertion[] = [
       "Step 6.7: iter-5.1 wifi persistence", // iter-5.1 NM-profile persist
       "iter-5.2.2", // iter-5.2.2 install-time auto-gen marker
       "/dev/urandom", // install-time hostname generator
+      // ── iter-5.4 sentinels (PR #5364 + #5352 + #5354 substrate) ──
+      "Step 6.8: iter-5.4.0 homelab gh-auth + operator pubkey copy", // iter-5.4.0 anchor
+      "Step 6.9: iter-5.4.1 self-registration commit+push", // iter-5.4.1 self-reg anchor
+      "gh auth login", // device-flow auth invocation
+      "gh auth setup-git", // B-0835 Bug 2a fix — wires git credential helper to gh token
+      "gh ssh-key list", // iter-5.4.0 operator-authorized-keys path
+      "SSH_KEY_ERR_FILE", // B-0835 Bug 2b fix — stderr capture for discrimination
+      "admin:public_key", // B-0835 Bug 2b fix — scope-error recovery guidance
+      "gh repo clone Lucent-Financial-Group/Zeta", // iter-5.4.1 cluster repo clone
+      "register-${NODE_HOSTNAME}-", // iter-5.4.1 registration branch shape
+      // iter-5.4.1 YAML schema sentinels (catches the Copilot findings from #5352
+      // where spec.role was scalar instead of array, spec.maintainer was at wrong
+      // path, spec.storage was a sibling instead of under hardware block).
+      "apiVersion: zeta.lucent-financial-group.com/v1", // ClusterNode CRD apiVersion
+      "kind: ClusterNode", // CRD kind
+      "  roles:", // spec.roles is ARRAY (NOT scalar spec.role) per B-0813 schema
+      "  registration:", // spec.registration block (NOT spec.maintainer flat) per B-0813
+      "  hardware:", // spec.hardware block (storage nests inside) per B-0813
+      // iter-5.4.1 hardware-probe sentinels (catches MAC parsing regression from #5352).
+      "/proc/cpuinfo", // CPU_MODEL extraction
+      "link/ether", // MAC_ADDR parses field AFTER link/ether (not before)
     ],
-    rationale: "iter-4.2 + iter-5.1 + iter-5.2 + iter-5.2.2 substrate must be present in installer script",
+    rationale: "iter-4.2 + iter-5.1 + iter-5.2 + iter-5.2.2 + iter-5.4.0 + iter-5.4.1 (incl. B-0835 Bug 2a/2b fixes) substrate must be present in installer script",
   },
   {
     path: "full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh",


### PR DESCRIPTION
## Layer 1 of 4-layer CI testing approach for iter-5.4 substrate

Aaron asked: *"yeah push forward a bit maybe create some more ci tests how do you want to test the gh login flow?"*

The 4-layer plan:

| Layer | Approach | Cost | Catches |
|---|---|---|---|
| **Layer 1 (THIS PR)** | Source-level sentinel audit | Seconds | Substrate regression (text-level) |
| Layer 2 (next PR) | Behavioral test with mock \`gh\` shim on PATH | ~1s | Conditional-logic regression |
| Layer 3 ([B-0833](https://github.com/Lucent-Financial-Group/Zeta/blob/main/docs/backlog/P1/B-0833-installer-interactive-login-vs-baked-in-keys-ci-test-tension-resolve-without-shipping-credentials-aaron-2026-05-26.md) Approach A) | Mock GH device-code endpoint | ~10s | Real interactive-login flow without humans |
| Layer 4 ([B-0831](https://github.com/Lucent-Financial-Group/Zeta/blob/main/docs/backlog/P1/B-0831-ci-cascade-6-full-install-plus-cluster-auto-join-eliminate-routine-human-physical-usb-test-aaron-2026-05-26.md) cascade #6) | QEMU full-install + cluster auto-join | Minutes | End-to-end including reboot + ArgoCD |

## What this PR adds

Extends \`REQUIRED_SENTINELS\` for \`full-ai-cluster/usb-nixos-installer/zeta-install.sh\` with 14 new substrings:

### (a) iter-5.4 flow anchors
- \`Step 6.8: iter-5.4.0 homelab gh-auth + operator pubkey copy\`
- \`Step 6.9: iter-5.4.1 self-registration commit+push\`
- \`gh auth login\`
- \`gh ssh-key list\`
- \`gh repo clone Lucent-Financial-Group/Zeta\`

### (b) Bug 2a + 2b fix-regression catches (PR #5364)
- \`gh auth setup-git\` — Bug 2a fix
- \`SSH_KEY_ERR_FILE\` — Bug 2b stderr capture
- \`admin:public_key\` — Bug 2b scope-recovery guidance

### (c) ClusterNode YAML schema sentinels (PR #5352 Copilot findings)
- \`apiVersion: zeta.lucent-financial-group.com/v1\`
- \`kind: ClusterNode\`
- \`  roles:\` — spec.roles is ARRAY (was scalar spec.role)
- \`  registration:\` — spec.registration block (was spec.maintainer flat)
- \`  hardware:\` — spec.hardware block (storage was sibling)

### (d) Hardware-probe sentinels (MAC parsing regression catch)
- \`/proc/cpuinfo\` — CPU_MODEL extraction
- \`link/ether\` — MAC parses field AFTER link/ether

### (e) Self-reg branch shape
- \`register-\${NODE_HOSTNAME}-\` — iter-5.4.1 branch name pattern

## Verified

\`\`\`
\$ bun tools/ci/audit-installer-substrate.ts
audit-installer-substrate: PASS — 10 required files + 5 sentinel-file assertions OK
\`\`\`

Runs in the existing \`build-ai-cluster-iso.yml\` workflow on every PR touching the installer surface.

## Composes with

- PR #5364 (Bug 2a + 2b fixes — this audit catches removal)
- PR #5352 (iter-5.4.1 Copilot YAML schema findings — this audit catches regression)
- B-0831 (cascade #6 full-install QEMU; this is layer 1)
- B-0833 (interactive-login vs baked-in-keys; layer 3 of cascade)

## Substrate-honest framing

Layer 1 doesn't test BEHAVIOR — only that the substrate is PRESENT. A future Aaron-edit that accidentally removes \`gh auth setup-git\` would be caught by this layer; an edit that changes \`gh auth setup-git\` to \`gh auth setup-git --hostname github.com\` would still pass (substring match). Layer 2 (mock-gh shim) catches behavioral regressions; this layer is the cheapest first line of defense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)