### PR TITLE
fix(B-0832): nmtui auto-relaunch loop on no-internet — Esc to refresh without breaking install (operator 2026-05-26)

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
@@ -31,6 +31,11 @@ HOST="${HOST:-control-plane}"
 REPO_URL="${REPO_URL:-https://github.com/Lucent-Financial-Group/Zeta}"
 ETHERNET_WAIT_SECS="${ETHERNET_WAIT_SECS:-30}"
 ROLE_PROMPT_SECS="${ROLE_PROMPT_SECS:-10}"
+# B-0832 nmtui retry-prompt timeout — operator window to press 's' for
+# shell-drop OR any other key (or wait) for nmtui re-launch. Mirrors
+# the ROLE_PROMPT_SECS env-override pattern so the timeout is tunable
+# without source edits.
+NMTUI_RETRY_PROMPT_SECS="${NMTUI_RETRY_PROMPT_SECS:-10}"
 
 # ── Role pick: 10-sec single-keystroke prompt ─────────────────────────
 # Defaults to whatever the ISO's /etc/zeta-firstboot.conf shipped with
@@ -151,12 +156,12 @@ else
     # No internet yet — give operator the choice to retry or escape
     echo
     echo "[zeta-first-boot] No internet after nmtui session ${NMTUI_ATTEMPTS}."
-    echo "                  Press 's' within 10s to drop to shell, OR"
+    echo "                  Press 's' within ${NMTUI_RETRY_PROMPT_SECS}s to drop to shell, OR"
     echo "                  press any other key (or wait) to re-launch nmtui"
     echo "                  to refresh the wifi scan."
     echo
     CHOICE=""
-    read -n 1 -s -t 10 -p "  > " CHOICE || true
+    read -r -n 1 -s -t "${NMTUI_RETRY_PROMPT_SECS}" -p "  > " CHOICE || true
     echo
     case "$CHOICE" in
       s|S)

--- a/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
@@ -109,10 +109,25 @@ else
   echo
   echo "[2/3] No ethernet internet detected. Launching wifi setup (nmtui)."
   echo "      After connecting, quit nmtui to continue install."
+  echo "      Esc out without connecting → nmtui re-launches to refresh scan."
   echo
   read -n 1 -s -t 5 -p "  Press any key to launch nmtui (or wait 5s) ..." || true
   echo
   echo
+  # B-0832 nmtui auto-relaunch-on-no-internet loop (operator 2026-05-26):
+  #
+  # Old behavior: launch nmtui once; if no internet on exit → drop_to_shell.
+  # That broke the install flow when operator hit Esc to refresh the wifi
+  # scan (empirical 2026-05-26 1st USB physical-test session — see B-0832).
+  #
+  # New behavior: loop nmtui until either (a) has_internet succeeds OR
+  # (b) operator explicitly requests shell-drop via 's' keystroke. Esc
+  # out of nmtui without connecting just re-launches nmtui (refresh-
+  # friendly UX — operator can Esc + re-scan as needed).
+  #
+  # Per operator 2026-05-26: "i want to be able to refresh the network
+  # withing breaking the script". This loop is the substrate-honest fix.
+  #
   # nmtui returns 0 on quit regardless of whether connection succeeded.
   # Absolute path: defense-in-depth alongside the systemd unit's
   # environment.PATH override (set in configuration.nix on
@@ -120,18 +135,40 @@ else
   # Both defenses together fix B-0754 iteration-1 'nmtui: command not
   # found' (nmtui IS installed in the ISO via networkmanager in
   # systemPackages; the issue was PATH inheritance into the unit).
-  if ! /run/current-system/sw/bin/nmtui; then
-    echo "[zeta-first-boot] nmtui failed."
-    drop_to_shell
-  fi
-  # Give NetworkManager a moment to actually establish + DHCP
-  sleep 3
-  if ! has_internet; then
-    echo "[zeta-first-boot] No internet after nmtui. Check connection and"
-    echo "                  re-run zeta-install $HOST when network is up."
-    drop_to_shell
-  fi
-  echo "  wifi ok"
+  NMTUI_ATTEMPTS=0
+  while true; do
+    NMTUI_ATTEMPTS=$((NMTUI_ATTEMPTS + 1))
+    if ! /run/current-system/sw/bin/nmtui; then
+      echo "[zeta-first-boot] nmtui failed to launch (attempt ${NMTUI_ATTEMPTS})."
+      drop_to_shell
+    fi
+    # Give NetworkManager a moment to actually establish + DHCP
+    sleep 3
+    if has_internet; then
+      echo "  wifi ok (after ${NMTUI_ATTEMPTS} nmtui session(s))"
+      break
+    fi
+    # No internet yet — give operator the choice to retry or escape
+    echo
+    echo "[zeta-first-boot] No internet after nmtui session ${NMTUI_ATTEMPTS}."
+    echo "                  Press 's' within 10s to drop to shell, OR"
+    echo "                  press any other key (or wait) to re-launch nmtui"
+    echo "                  to refresh the wifi scan."
+    echo
+    CHOICE=""
+    read -n 1 -s -t 10 -p "  > " CHOICE || true
+    echo
+    case "$CHOICE" in
+      s|S)
+        echo "[zeta-first-boot] Dropping to shell at operator request."
+        drop_to_shell
+        ;;
+      *)
+        echo "[zeta-first-boot] Re-launching nmtui for refresh ..."
+        echo
+        ;;
+    esac
+  done
 fi
 
 echo


### PR DESCRIPTION
## What

Operator 2026-05-26 during 3rd USB physical test: *"i want to be able to refresh the network withing breaking the script"*.

Old behavior: nmtui launched ONCE; if no internet on exit → drop_to_shell (broke install flow). Esc was destructive.

New behavior: loop nmtui until \`has_internet\` OR operator explicit 's' for shell. Esc out refreshes; 's' escape-hatch preserved.

## Operator flow

- **Esc out of nmtui without connecting** → nmtui re-launches with fresh wifi scan (operator can refresh as needed)
- **Connect successfully** → script continues to zeta-install
- **Need shell access** → press 's' at the post-attempt prompt within 10s

\`NMTUI_ATTEMPTS\` counter tracks session count + logs in success message ("wifi ok (after N nmtui session(s))").

## Composes with

- B-0832 (nmtui WiFi rescan empirical anchor row)
- \`.claude/rules/non-coercion-invariant.md\` HC-8 (operator agency preserved via 's' escape-hatch)
- \`.claude/rules/substrate-or-it-didnt-happen.md\` (substrate-honest UX matches operator's Esc-to-refresh expectation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)