### PR TITLE
fix(postmerge #5379): qemu-full-install-test 4 Copilot P1 fixes — iter-5.1 marker (was pre-install) + artifact upload + trigger paths + early-exit race

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -49,6 +49,9 @@ on:
       - 'full-ai-cluster/tools/**'
       - 'tools/ci/audit-installer-substrate.ts'
       - 'tools/ci/audit-installer-iso-content.ts'
+      - 'tools/ci/qemu-boot-test.ts'
+      - 'tools/ci/qemu-full-install-test.ts'
+      - 'tools/ci/test-iter-54-install-flow.test.ts'
       - '.github/workflows/build-ai-cluster-iso.yml'
   push:
     branches: [main]
@@ -60,6 +63,9 @@ on:
       - 'full-ai-cluster/tools/**'
       - 'tools/ci/audit-installer-substrate.ts'
       - 'tools/ci/audit-installer-iso-content.ts'
+      - 'tools/ci/qemu-boot-test.ts'
+      - 'tools/ci/qemu-full-install-test.ts'
+      - 'tools/ci/test-iter-54-install-flow.test.ts'
       - '.github/workflows/build-ai-cluster-iso.yml'
   workflow_dispatch:
 
@@ -221,6 +227,13 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         continue-on-error: true
         working-directory: full-ai-cluster
+        # SERIAL_LOG_OUT_PATH points to a workspace-relative path so the
+        # serial log survives the test step + can be uploaded as artifact
+        # in the subsequent step (per Copilot post-merge finding on PR
+        # #5379: prior tmpdir path was outside workspace + lost on runner
+        # exit).
+        env:
+          SERIAL_LOG_OUT_PATH: ${{ github.workspace }}/qemu-full-install-serial.log
         run: |
           set -euo pipefail
           mapfile -t iso_candidates < <(find result/iso -maxdepth 1 -type f \( -name 'zeta-installer-*.iso' -o -name 'nixos-minimal-*.iso' \) | sort)
@@ -230,7 +243,21 @@ jobs:
           fi
           iso_abs=$(readlink -f "${iso_candidates[0]}")
           echo "Full-install testing ISO: $iso_abs"
+          echo "Serial log out path: $SERIAL_LOG_OUT_PATH"
           bun ../tools/ci/qemu-full-install-test.ts "$iso_abs"
+
+      # Upload serial log as workflow artifact regardless of test outcome
+      # so debug post-mortem is always possible. `if: always()` because
+      # failure case is the most interesting — successful runs have
+      # nothing to debug. Per Copilot post-merge finding on PR #5379.
+      - name: Upload QEMU full-install serial log
+        if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: qemu-full-install-serial-log
+          path: qemu-full-install-serial.log
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Locate ISO + capture metadata
         id: iso

--- a/tools/ci/qemu-full-install-test.ts
+++ b/tools/ci/qemu-full-install-test.ts
@@ -64,13 +64,26 @@ import { existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-// Success marker: the `[iter-5.3]` prefix appears at the password-prompt
-// line in zeta-install.sh. Reaching this point PROVES the install
-// completed: partition + format + nixos-install + iter-4.2 SSH pubkey
-// probe + iter-5.2 hostname injection. The next phase (iter-5.3 password
-// prompt) requires operator-stdin which we don't provide in this starter
-// — that's deferred to follow-up PR work.
-const SUCCESS_MARKER = "[iter-5.3]";
+// Success marker: the `[iter-5.1]` prefix appears at the wifi-persistence
+// step in zeta-install.sh (Step 6.7; line 527). This is the correct
+// post-nixos-install marker because it fires AFTER:
+//   - Steps 1-5 (partition + format + mount)
+//   - Step 6 (clone + install) including the nixos-install invocation
+//   - Step 6.5 iter-4.2 SSH pubkey probe
+//   - Step 6.55 iter-5.3 password prompt (gracefully skipped in CI when
+//     stdin returns empty — INJECTED_PW="" → default-keep path)
+//   - Step 6.6 iter-5.2 hostname injection
+// And BEFORE:
+//   - Step 6.8 iter-5.4.0 gh auth prompt (which hangs in CI without
+//     operator stdin to type 'n' OR mock GH device-code endpoint per
+//     B-0833 Approach A)
+//
+// Per Copilot post-merge finding on PR #5379: the prior `[iter-5.3]`
+// marker fired BEFORE the actual `nixos-install` invocation (Step 6.55
+// is at line 372 of zeta-install.sh; the `sudo nixos-install` call is
+// at line 980), so the test could pass without proving the install
+// actually completed. `[iter-5.1]` correctly comes AFTER nixos-install.
+const SUCCESS_MARKER = "[iter-5.1]";
 
 // Hard-fail markers — if any of these appear, fail fast instead of
 // waiting for timeout. Add more as empirical failure modes are observed.
@@ -245,7 +258,11 @@ async function main(): Promise<never> {
 
   const tmpDir = mkdtempSync(join(tmpdir(), "zeta-qemu-full-install-test-"));
   const diskPath = join(tmpDir, "install-target.qcow2");
-  const serialLogPath = join(tmpDir, "serial.log");
+  // Env-overridable serial log path so CI workflow can write to a
+  // known workspace-relative path for artifact upload (per Copilot
+  // post-merge finding on PR #5379: prior tmpdir path was outside
+  // workspace + lost on runner exit).
+  const serialLogPath = process.env.SERIAL_LOG_OUT_PATH ?? join(tmpDir, "serial.log");
 
   console.log(`[qemu-full-install-test] ISO: ${isoPath}`);
   console.log(`[qemu-full-install-test] Virtual disk: ${diskPath} (${DISK_SIZE_GB}GB qcow2 sparse)`);
@@ -264,12 +281,34 @@ async function main(): Promise<never> {
   });
 
   let qemuExited = false;
-  qemu.on("exit", (code) => {
-    qemuExited = true;
-    console.log(`[qemu-full-install-test] QEMU exited with code ${code}`);
+  let qemuExitCode: number | null = null;
+  const qemuExitPromise = new Promise<InstallResult>((res) => {
+    qemu.on("exit", (code) => {
+      qemuExited = true;
+      qemuExitCode = code;
+      console.log(`[qemu-full-install-test] QEMU exited with code ${code}`);
+      // Per Copilot post-merge finding on PR #5379: if QEMU exits early
+      // (bad args, KVM/device failure, disk attach error), the marker-
+      // wait would otherwise sit through the full 30-min timeout
+      // pointlessly. Race the marker wait against this exit so we fail
+      // immediately when QEMU dies before the marker can appear.
+      const tail = existsSync(serialLogPath)
+        ? readFileSync(serialLogPath, "utf8").slice(-2000)
+        : "(serial log empty or never created)";
+      res({
+        exitCode: 1,
+        reason: `FAILURE — QEMU exited prematurely with code ${code} before "${SUCCESS_MARKER}" was observed (bad args / KVM unavailable / disk error / device-init failure)`,
+        serialLogTail: tail,
+      });
+    });
   });
 
-  const result = await waitForInstallProgress(serialLogPath);
+  // Race the marker-wait against QEMU early-exit. Whichever resolves
+  // first wins; both check the serial log + report consistently.
+  const result = await Promise.race([
+    waitForInstallProgress(serialLogPath),
+    qemuExitPromise,
+  ]);
 
   if (!qemuExited) {
     console.log(`[qemu-full-install-test] Killing QEMU (PID ${qemu.pid})`);
@@ -278,6 +317,9 @@ async function main(): Promise<never> {
       if (!qemuExited) qemu.kill("SIGKILL");
     }, 5000);
   }
+  // Suppress unused-var warning — qemuExitCode is read in the exit
+  // handler above; this acknowledges the captured value to lint.
+  void qemuExitCode;
 
   console.log("");
   console.log("=== Result ===");


### PR DESCRIPTION
## What

4 substantive Copilot findings on freshly-merged PR #5379. All P1; all legit substrate-engineering corrections.

## Fixes

### 1. SUCCESS_MARKER iter-5.3 → iter-5.1

Copilot was right: \`[iter-5.3]\` (zeta-install.sh:372) fires BEFORE the actual \`sudo nixos-install\` invocation (line 980). Test could pass without proving install completed.

\`[iter-5.1]\` (Step 6.7 wifi persistence at line 527) correctly comes AFTER:
- nixos-install
- iter-4.2 SSH pubkey
- iter-5.3 password (skipped gracefully in CI on empty stdin)
- iter-5.2 hostname injection

AND BEFORE:
- iter-5.4.0 gh auth prompt (which would hang in CI without B-0833 mock device-code endpoint)

### 2. Workspace-relative serial log path

\`SERIAL_LOG_OUT_PATH\` env var lets workflow point log to \`\${{ github.workspace }}/qemu-full-install-serial.log\` so it survives test step.

### 3. Artifact upload step

\`actions/upload-artifact@v4.6.2\` (SHA-pinned) with \`if: always()\` so log survives even when test fails. 7-day retention.

### 4. Workflow trigger paths

Added missing trigger paths so PRs changing ONLY these helpers actually run the workflow:
- \`tools/ci/qemu-boot-test.ts\`
- \`tools/ci/qemu-full-install-test.ts\`
- \`tools/ci/test-iter-54-install-flow.test.ts\`

### 5. QEMU early-exit race (5th fix; same scope)

\`Promise.race\` between marker-wait and QEMU child-exit. If QEMU exits early (bad args / KVM failure / disk error), test fails immediately instead of waiting full 30min timeout.

## Security

\`github.workspace\` in \`env:\` block — GitHub-controlled value (expands to workspace path); no attacker-controllable interpolation in \`run:\` commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)