### PR TITLE
fix(B-0835 Bug 4+5 — Aaron 2026-05-27 control-plane install): storage probe filters 0B devices + gh CLI in installed system PATH

### DIFF
--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -90,6 +90,16 @@
     skopeo
     kubectl kubernetes-helm k9s argocd
     cilium-cli hubble
+
+    # B-0835 fix (Aaron 2026-05-27 control-plane install): gh CLI was
+    # available in the installer ISO's PATH (iter-5.4.0 used it for
+    # `gh auth login` during install) but NOT in the installed system's
+    # PATH after reboot. Operator empirically hit "gh: command not found"
+    # on first login. The gh-auth tokens stored in ~/.config/gh during
+    # install are useless without the binary. gh stays in systemPackages
+    # for ongoing operator workflows (re-auth, ssh-key sync, future
+    # node-register tooling).
+    gh
   ];
 
   boot.loader = {

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -778,7 +778,12 @@ if [ "$GH_AUTH_OK" = 1 ]; then
     # Storage lines: indented 6 spaces to nest under spec.hardware.storage
     # (Copilot finding on #5352 — was a sibling of `hardware:` at 4 spaces; the
     # B-0813 schema places storage under hardware block).
-    STORAGE_LINES=$(lsblk -ndo NAME,SIZE,TYPE -e7 2>/dev/null | awk '$3=="disk"{print "      - \"/dev/" $1 " " $2 "\""}' || echo "")
+    # Filter zero-size devices ($2 != "0B"): empty SD card readers, optical
+    # bays, and other placeholder block devices show up in `lsblk -ndo`
+    # output with SIZE=0B and confuse any reconciler that interprets the
+    # storage list as usable. Copilot finding on PR #5380 (Aaron's
+    # 2026-05-27 control-plane registration surfaced `/dev/sda 0B`).
+    STORAGE_LINES=$(lsblk -ndo NAME,SIZE,TYPE -e7 2>/dev/null | awk '$3=="disk" && $2!="0B"{print "      - \"/dev/" $1 " " $2 "\""}' || echo "")
     REG_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
     FLAKE_COMMIT=$(git -C /mnt/etc/zeta rev-parse HEAD 2>/dev/null | head -c 12 || echo "unknown")
 


### PR DESCRIPTION
## Summary

Two empirical anchors from Aaron's iter-5.4 install of \`node-e5a176\` (PR #5380 self-registered cleanly) where post-reboot login surfaced two distinct gaps:

### Bug 4 — \`/dev/sda 0B\` zero-size device in node.yaml

Storage probe at zeta-install.sh:781 emitted every block device, including 0-byte placeholders (empty SD card readers, optical bays). Aaron's Intel Core Ultra 9 185H node registered \`/dev/sda 0B\` → Copilot P1 on [PR #5380](https://github.com/Lucent-Financial-Group/Zeta/pull/5380).

Fix: \`awk '\$3==\"disk\" && \$2!=\"0B\"{...}'\` filter excludes zero-size devices.

### Bug 5 — \`gh: command not found\` on first login

Operator: *\"when i log in gh command is not found\"*. Installer ISO had gh (iter-5.4.0 used it for \`gh auth login\` during install) but \`common.nix\` systemPackages didn't include it — auth tokens in \`~/.config/gh\` were stranded without the binary.

Fix: add \`gh\` to \`common.nix\` \`environment.systemPackages\` so the installed system has it for re-auth + ssh-key sync + future register/deregister tooling.

## Test plan

- [ ] CI passes
- [ ] Next ISO build picks up both fixes
- [ ] Future installs register without 0B entries; \`gh\` available on first login

## Composes with

- B-0813 (cluster-node schema), B-0817 (register-node tool), iter-5.4 install cascade
- PR #5380 (the registration where these gaps surfaced)
- Aaron's empirical observations 2026-05-27: \"i can't ping it by name\" (mitigated via IP lookup; found at 192.168.4.128) → \"when i log in gh command is not found and i don't think it registered\" (registration DID happen — PR #5380 — but no \`gh\` to check it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)