### PR TITLE
fix(B-0835 Bug 6+7): multi-protocol name resolution — Avahi hardening + NetBIOS (nmbd) + DHCP-hostname; reliability for 'i can't ping it by name' (Aaron 2026-05-27)

### DIFF
--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -46,23 +46,78 @@
   networking.networkmanager.enable = true;
   networking.firewall.enable = true;
 
-  # iter-5.1 (B-0792): Avahi mDNS publishing so cluster nodes resolve
-  # via `<hostname>.local` from operator Mac (Bonjour) + Linux peers
-  # (nss-mdns) on the LAN without IP-discovery step. Without this,
-  # `ssh zeta@control-plane.local` fails to resolve even though the
-  # node is up. Empirical anchor: 2026-05-26 iter-4.2 PC1 test
-  # surfaced the gap.
+  # iter-5.1 (B-0792): Avahi mDNS publishing — `<hostname>.local`
+  # resolution via Bonjour (macOS) + nss-mdns (Linux peers).
+  # Empirical 2026-05-27 (Aaron node-e5a176 control-plane test): mDNS
+  # alone proved unreliable — operator's Mac (en0 ethernet, also on
+  # WiFi) could ping by IP + SSH but Bonjour resolution timed out;
+  # unicast mDNS query to port 5353/udp also timed out from the Mac
+  # even though the install completed. Multi-protocol additive
+  # belt-and-suspenders below addresses the reliability gap without
+  # removing the operator's preferred Bonjour-style mechanism.
   services.avahi = {
     enable = true;
     nssmdns4 = true;
-    openFirewall = true;  # firewall hole for mDNS (5353/udp)
+    nssmdns6 = true;       # IPv6 nss-mdns alongside IPv4 (some operator
+                           # macOS configs prefer AAAA queries first)
+    openFirewall = true;   # firewall hole for mDNS (5353/udp)
+    ipv4 = true;
+    ipv6 = true;
+    reflector = true;      # forward mDNS across multiple subnets (operator
+                           # mac on one segment + node on another via router)
     publish = {
       enable = true;
       addresses = true;
       workstation = true;
       domain = true;
+      hinfo = true;        # host info record — additional discoverability
+      userServices = true; # advertise user services so dns-sd browses see node
     };
   };
+
+  # iter-5.5 (B-0835 Bug 7 — Aaron 2026-05-27 reliability ask):
+  # NetBIOS name resolution via Samba's nmbd as additive belt-and-
+  # suspenders alongside Avahi mDNS. NetBIOS uses UDP broadcast on
+  # 137 (vs mDNS multicast on 5353) — different failure modes; if
+  # the network drops IGMP/multicast but allows broadcast,
+  # `node-e5a176` resolves via NetBIOS where `node-e5a176.local`
+  # fails via mDNS. Windows + macOS + Linux all speak NetBIOS via
+  # nmblookup / smbutil / nss-winbind.
+  #
+  # Operator usage (from any host on the LAN):
+  #   nmblookup node-e5a176          # Linux/macOS NetBIOS lookup
+  #   smbutil lookup node-e5a176     # macOS native NetBIOS
+  #   ping node-e5a176               # may work if nsswitch has wins
+  services.samba = {
+    enable = true;
+    openFirewall = true;   # 137/udp (NetBIOS-NS), 138/udp (NetBIOS-DGM),
+                           # 139/tcp (NetBIOS-SSN), 445/tcp (SMB).
+                           # We only need 137/udp for name resolution;
+                           # the rest are firewalled at the file-share
+                           # layer (no shares declared = no SMB exposure).
+    settings = {
+      global = {
+        "workgroup" = "ZETA";
+        "server string" = "Zeta cluster node %h";
+        "netbios name" = config.networking.hostName;
+        # Disable SMB file-sharing entirely — this Samba instance
+        # exists ONLY for NetBIOS name advertisement, NOT file shares.
+        # No shares declared below the global section.
+        "server min protocol" = "SMB3";
+        "smb ports" = "445";  # don't bind 139
+        "disable netbios" = "no";
+        "name resolve order" = "bcast host";
+      };
+    };
+  };
+
+  # DHCP-hostname registration: NetworkManager already advertises the
+  # hostname via DHCP option 12 by default. Many home routers register
+  # DHCP client hostnames as DNS names (e.g., `node-e5a176.lan` from
+  # Asus/Netgear/Eero). This is the 3rd reliability layer — operator's
+  # router becomes a fallback name resolver for `<hostname>` and
+  # `<hostname>.lan` (or `.home`/`.localdomain` depending on router).
+  # No additional NixOS config needed beyond NetworkManager being on.
 
   services.openssh = {
     enable = true;

--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -48,8 +48,8 @@
 
   # iter-5.1 (B-0792): Avahi mDNS publishing — `<hostname>.local`
   # resolution via Bonjour (macOS) + nss-mdns (Linux peers).
-  # Empirical 2026-05-27 (Aaron node-e5a176 control-plane test): mDNS
-  # alone proved unreliable — operator's Mac (en0 ethernet, also on
+  # Empirical 2026-05-27 (control-plane physical-hardware-support test):
+  # mDNS alone proved unreliable — operator's Mac (en0 ethernet, also on
   # WiFi) could ping by IP + SSH but Bonjour resolution timed out;
   # unicast mDNS query to port 5353/udp also timed out from the Mac
   # even though the install completed. Multi-protocol additive
@@ -75,7 +75,7 @@
     };
   };
 
-  # iter-5.5 (B-0835 Bug 7 — Aaron 2026-05-27 reliability ask):
+  # iter-5.5 (B-0835 Bug 7 — operator 2026-05-27 reliability ask):
   # NetBIOS name resolution via Samba's nmbd as additive belt-and-
   # suspenders alongside Avahi mDNS. NetBIOS uses UDP broadcast on
   # 137 (vs mDNS multicast on 5353) — different failure modes; if
@@ -88,28 +88,41 @@
   #   nmblookup node-e5a176          # Linux/macOS NetBIOS lookup
   #   smbutil lookup node-e5a176     # macOS native NetBIOS
   #   ping node-e5a176               # may work if nsswitch has wins
+  #
+  # SECURITY DISCIPLINE (P0+P1 fixes from PR #5387 Copilot review):
+  # We run ONLY nmbd (NetBIOS name daemon on 137/udp + 138/udp), NOT
+  # smbd (SMB file-sharing daemon on 139/tcp + 445/tcp). This is
+  # genuinely "NetBIOS-only" — zero SMB attack surface:
+  #   - services.samba.smbd.enable = false  (no smbd process)
+  #   - services.samba.nmbd.enable = true   (nmbd ONLY)
+  #   - services.samba.openFirewall = false (we control firewall manually)
+  #   - networking.firewall.allowedUDPPorts = [ 137 138 ] (NetBIOS only)
+  # Reviewer caught the prior `openFirewall = true` + `smb ports = "445"`
+  # config that opened 139/tcp + 445/tcp despite the "name resolution
+  # only" claim. Now genuinely true.
   services.samba = {
     enable = true;
-    openFirewall = true;   # 137/udp (NetBIOS-NS), 138/udp (NetBIOS-DGM),
-                           # 139/tcp (NetBIOS-SSN), 445/tcp (SMB).
-                           # We only need 137/udp for name resolution;
-                           # the rest are firewalled at the file-share
-                           # layer (no shares declared = no SMB exposure).
+    openFirewall = false;  # we open ONLY 137/138 UDP below; no SMB ports
+    smbd.enable = false;   # NO SMB file-sharing daemon
+    nmbd.enable = true;    # NetBIOS name daemon ONLY
     settings = {
       global = {
         "workgroup" = "ZETA";
         "server string" = "Zeta cluster node %h";
         "netbios name" = config.networking.hostName;
-        # Disable SMB file-sharing entirely — this Samba instance
-        # exists ONLY for NetBIOS name advertisement, NOT file shares.
-        # No shares declared below the global section.
-        "server min protocol" = "SMB3";
-        "smb ports" = "445";  # don't bind 139
         "disable netbios" = "no";
         "name resolve order" = "bcast host";
       };
     };
   };
+
+  # Explicit NetBIOS-only firewall holes (P0 fix per PR #5387 review):
+  # 137/udp = NetBIOS-NS (name service queries)
+  # 138/udp = NetBIOS-DGM (datagram service for browse-list announcements)
+  # We do NOT open 139/tcp (NetBIOS-SSN) or 445/tcp (SMB) since smbd is
+  # disabled. This is genuinely "NetBIOS name resolution only" — no SMB
+  # file-share surface exposed even if smbd accidentally got re-enabled.
+  networking.firewall.allowedUDPPorts = [ 137 138 ];
 
   # DHCP-hostname registration: NetworkManager already advertises the
   # hostname via DHCP option 12 by default. Many home routers register


### PR DESCRIPTION
## Summary

Aaron 2026-05-27 (verbatim):

> *\"my mac is ethernet connected and i connected to the same wifi as it but i still can't ping could it be something else or can we make hostname more reliable?  maybe a netbios or something?  i like ashai or whatever it is but can we make it reliable?  i think this is looking very good.\"*

Empirical: ping by IP works ✓, SSH works ✓, but Bonjour resolution times out AND unicast mDNS query to port 5353/udp times out (actual no-response, not connection-attempt noise). Avahi alone proved unreliable.

## Multi-protocol additive approach

Operator's preferred Avahi/Bonjour stays + 2 fallback mechanisms added (different protocols, different failure modes):

### Bug 6 — Avahi hardening

- \`nssmdns6 = true\` (IPv6 nss-mdns alongside IPv4; some macOS configs prefer AAAA queries first)
- \`ipv4 + ipv6\` explicit
- \`reflector = true\` (forwards mDNS across subnets — composes with multi-segment LAN setups)
- \`publish.hinfo + publish.userServices\` (additional discoverability)

### Bug 7 — NetBIOS via Samba's nmbd (belt-and-suspenders)

NetBIOS uses UDP broadcast on port 137 (vs mDNS multicast on 5353) — **different failure modes**. If network drops IGMP/multicast but allows broadcast (common on home/SMB switches), \`node-e5a176\` resolves via NetBIOS where \`node-e5a176.local\` fails via mDNS.

Operator usage (any LAN host):
\`\`\`bash
nmblookup node-e5a176          # Linux/macOS NetBIOS lookup
smbutil lookup node-e5a176     # macOS native NetBIOS
ping node-e5a176               # if nsswitch has wins
\`\`\`

Samba is enabled for NetBIOS name-advertisement **only** (no shares declared = no SMB file-share exposure).

### DHCP-hostname registration (3rd layer)

NetworkManager already advertises hostname via DHCP option 12 by default. Many home routers register DHCP client hostnames as DNS names (\`node-e5a176.lan\` from Asus/Netgear/Eero). No config change needed.

## Operator now has 3 name-resolution mechanisms

| # | Lookup | Mechanism | Failure mode |
|---|---|---|---|
| 1 | \`node-e5a176.local\` | mDNS multicast | IGMP filtering, multicast drop |
| 2 | \`node-e5a176\` (via nmblookup) | NetBIOS broadcast | Different protocol; works when mDNS fails |
| 3 | \`node-e5a176.lan\` | Router DHCP+DNS | Depends on router support |
| 4 | IP (192.168.4.128) | Always reliable | Need \`arp -a\` first if IP not memorized |

## Test plan

- [ ] CI passes
- [ ] Next ISO build picks up multi-protocol stack
- [ ] On next install: validate all 3 mechanisms; document which work on operator's specific LAN

## Composes with

B-0792 (injected-hostname) · iter-5.4.1 self-registration (PR #5380 carries MAC + hostname for correlation) · [B-0848](docs/backlog/P2/B-0848-node-local-claude-agent-stewards-own-registration-pr-then-reports-k8s-cluster-status-operator-interactive-login-pattern-aaron-2026-05-26.md) (node-local Claude needs reliable name resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)