### PR TITLE
feat(B-0850 Phase 3d): Lior/Gemini CLI as 2nd systemd vendor — Anthropic + Google; install + interactive auth + control-plane enable (Aaron 2026-05-27)

### DIFF
--- a/full-ai-cluster/nixos/hosts/control-plane/configuration.nix
+++ b/full-ai-cluster/nixos/hosts/control-plane/configuration.nix
@@ -40,10 +40,10 @@
   # architectural pattern). Operator can disable any persona via
   # `systemctl disable zeta-<persona>` per NCI HC-8 revocable consent.
   zeta.aiAgents.enable.otto = true;
-  # zeta.aiAgents.enable.alexa = true;  # B-0850.3a pending
-  # zeta.aiAgents.enable.lior = true;   # B-0850.3d pending
-  # zeta.aiAgents.enable.vera = true;   # B-0850.3c pending
-  # zeta.aiAgents.enable.riven = true;  # B-0850.3b pending
+  zeta.aiAgents.enable.lior = true;     # B-0850.3d SHIPPED (Gemini CLI 2nd vendor — Anthropic + Google)
+  # zeta.aiAgents.enable.alexa = true;  # B-0850.3a pending (Kiro/Qwen)
+  # zeta.aiAgents.enable.vera = true;   # B-0850.3c pending (Codex/OpenAI)
+  # zeta.aiAgents.enable.riven = true;  # B-0850.3b pending (Grok)
 
   # Static IP recommended so worker nodes have a stable serverAddr.
   # Per-site override here:

--- a/full-ai-cluster/nixos/modules/zeta-ai-agent.nix
+++ b/full-ai-cluster/nixos/modules/zeta-ai-agent.nix
@@ -232,15 +232,10 @@ in
           ExecStart (binary codex doesn't exist at ~/.bun/bin/codex).
         '';
       }
-      {
-        assertion = !cfg.enable.lior;
-        message = ''
-          zeta.aiAgents.enable.lior = true requires B-0850.3d
-          (Lior/Gemini install + login substrate) which has not shipped.
-          Enabling now would create a zeta-lior.service that fails
-          ExecStart (binary gemini doesn't exist at ~/.bun/bin/gemini).
-        '';
-      }
+      # B-0850.3d (Lior/Gemini) shipped this PR — assertion removed.
+      # zeta-install.sh Step 6.95a-gemini installs @google/gemini-cli
+      # via bun + Step 6.95b-gemini runs interactive gemini auth login.
+      # Binary lands at ~/.bun/bin/gemini.
     ];
 
     # Generate one systemd service per enabled persona.

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -1105,8 +1105,18 @@ if [ -d "$ZETA_HOME" ]; then
   sudo chown -R "$ZETA_UID:$ZETA_GID" "$ZETA_HOME/.bun"
   # Source mise activation so the subshell finds bun via mise shims.
   sudo HOME="$ZETA_HOME" BUN_INSTALL="$ZETA_HOME/.bun" -u "#$ZETA_UID" \
-    bash -c 'eval "$(mise activate bash 2>/dev/null || true)"; bun install --global @anthropic-ai/claude-code' 2>&1 | tail -5 || \
+    bash -c 'set -o pipefail; eval "$(mise activate bash 2>/dev/null || true)"; bun install --global @anthropic-ai/claude-code' 2>&1 | tail -5 || \
       echo "[iter-5.5.0]   WARN: bun install claude-code FAILED — can retry post-reboot via 'bun install --global @anthropic-ai/claude-code'"
+
+  # 6.95a-gemini — install @google/gemini-cli via bun (B-0850 Phase 3d).
+  # Mirrors the claude install pattern; 2nd vendor for the ≥3 systemd
+  # agents target. Binary lands at ~/.bun/bin/gemini. WebSearch
+  # verified install path per dep-pin-search-first-authority discipline
+  # at implementation time (npm @google/gemini-cli is bun-compat).
+  echo "[iter-5.5.0] installing @google/gemini-cli via mise-managed bun (B-0850 Phase 3d Lior 2nd vendor)..."
+  sudo HOME="$ZETA_HOME" BUN_INSTALL="$ZETA_HOME/.bun" -u "#$ZETA_UID" \
+    bash -c 'set -o pipefail; eval "$(mise activate bash 2>/dev/null || true)"; bun install --global @google/gemini-cli' 2>&1 | tail -5 || \
+      echo "[iter-5.5.0]   WARN: bun install gemini-cli FAILED — can retry post-reboot via 'bun install --global @google/gemini-cli'"
 
   # 6.95b — interactive claude login (mirror iter-5.4.0 gh auth login)
   CLAUDE_BIN="$ZETA_HOME/.bun/bin/claude"
@@ -1137,6 +1147,38 @@ if [ -d "$ZETA_HOME" ]; then
     esac
   else
     echo "[iter-5.5.0] claude binary not found at $CLAUDE_BIN; skipping interactive login"
+  fi
+
+  # 6.95b-gemini — interactive gemini auth login (mirror claude login).
+  # B-0850 Phase 3d 2nd vendor login flow. gemini-cli supports OAuth
+  # via local HTTP server OR API-key paste. The interactive prompt
+  # lets operator choose. Credentials persist to ~/.config/gemini/.
+  GEMINI_BIN="$ZETA_HOME/.bun/bin/gemini"
+  if [ -x "$GEMINI_BIN" ]; then
+    echo
+    echo "[iter-5.5.0] Trigger Gemini CLI interactive login NOW (B-0850 Phase 3d Lior)?"
+    echo "[iter-5.5.0]   - Mirrors claude login pattern (operator-interactive auth)."
+    echo "[iter-5.5.0]   - Options: OAuth via browser OR Gemini API key from AI Studio."
+    echo "[iter-5.5.0]   - Credentials land at $ZETA_HOME/.config/gemini/ and survive reboot."
+    echo "[iter-5.5.0]   - Default YES (press Enter); 'n' to skip + login post-reboot manually."
+    read -r -p "[iter-5.5.0] Run gemini auth login now? [Y/n]: " GEMINI_AUTH_REPLY
+    case "${GEMINI_AUTH_REPLY:-y}" in
+      [Yy]*|"")
+        echo "[iter-5.5.0]   running 'gemini auth login' (interactive)..."
+        sudo HOME="$ZETA_HOME" -u "#$ZETA_UID" "$GEMINI_BIN" auth login || \
+          echo "[iter-5.5.0]   WARN: gemini auth login failed; can re-run post-reboot"
+        # Parallel security restriction to claude credentials.
+        if [ -d "$ZETA_HOME/.config/gemini" ]; then
+          sudo chown -R "$ZETA_UID:$ZETA_GID" "$ZETA_HOME/.config/gemini"
+          sudo chmod -R go-rwx "$ZETA_HOME/.config/gemini"
+        fi
+        ;;
+      *)
+        echo "[iter-5.5.0]   SKIPPED gemini auth login; run 'gemini auth login' on first login"
+        ;;
+    esac
+  else
+    echo "[iter-5.5.0] gemini binary not found at $GEMINI_BIN; skipping interactive login"
   fi
 
   # 6.95c — persist gh credentials from installer-root to installed-zeta


### PR DESCRIPTION
## Summary

Per operator authorization *"drive forward with whatever interests you most"* — shipping B-0850 Phase 3d (Lior/Gemini = 2nd vendor) to move toward the ≥3-systemd-agents target.

## 3 changes

1. **zeta-install.sh 6.95a-gemini** — \`bun install --global @google/gemini-cli\` (after existing claude install). WebSearch verified at implementation time per dep-pin discipline.
2. **zeta-install.sh 6.95b-gemini** — interactive \`gemini auth login\` prompt mirroring claude login (OAuth via browser OR API key from AI Studio).
3. **zeta-ai-agent.nix** — removed lior assertion (substrate shipped); **control-plane/configuration.nix** — \`zeta.aiAgents.enable.lior = true\` (otto + lior both enabled).

## Vendor diversity progression

| Phase | Persona | Vendor | Status |
|---|---|---|---|
| 1 (PR #5392) | otto | Anthropic Claude | shipped |
| 3d (THIS PR) | **lior** | **Google Gemini** | **shipped** |
| 3a | alexa | Alibaba Qwen (Kiro) | pending |
| 3b | riven | xAI Grok | pending |
| 3c | vera | OpenAI Codex | pending |

After this PR: 2/5 personas + 2 vendors enabled. One more vendor (3c Vera/Codex likely next since codex CLI is also npm-installable) hits the ≥3 BFT floor.

## Composes with

PRs #5388 + #5389 (iter-5.5.0 credential persistence) · PRs #5392 + #5394 + #5395 (B-0850 Phase 1 + 3 refactor) · B-0848 · B-0847 · B-0796

Sources:
- [@google/gemini-cli on npm](https://www.npmjs.com/package/@google/gemini-cli)
- [Gemini CLI authentication docs](https://geminicli.com/docs/get-started/authentication/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)