### PR TITLE
fix(P0-iter-5.4): nixos-install --fallback is NOT a valid flag → use --option fallback true (empirical USB install failure Aaron 2026-05-27)

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -985,8 +985,11 @@ echo "Running nixos-install --flake /mnt/etc/zeta/full-ai-cluster#$HOST ..."
 #
 # WiFi-reproducibility (empirical 2026-05-26: cache.nixos.org timeouts
 # on same 5 derivations twice in a row over WiFi):
-#   --fallback: build from source if substitute download fails (don't bail
-#               — keeps the install moving even when cache is flaky)
+#   --option fallback true: build from source if substitute download fails
+#               (don't bail — keeps the install moving even when cache is flaky)
+#               (NOTE: this is the Nix-option pass-through form; nixos-install
+#               does NOT accept top-level --fallback flag — empirical 2026-05-27
+#               Aaron USB boot failure: `unknown option '--fallback'`)
 #   --option connect-timeout 10: drop dead substituter connections fast
 #               instead of waiting the default 0 (=no timeout)
 #   --option stalled-download-timeout 60: cut the 300s default by 5×; a
@@ -1000,7 +1003,7 @@ echo "Running nixos-install --flake /mnt/etc/zeta/full-ai-cluster#$HOST ..."
 # tracked at B-0846.
 sudo nixos-install \
   --impure \
-  --fallback \
+  --option fallback true \
   --option connect-timeout 10 \
   --option stalled-download-timeout 60 \
   --option download-attempts 3 \


### PR DESCRIPTION
## Summary

**P0 install blocker fix-fwd.** Aaron's 2026-05-27 USB boot test (ISO ci26490417201 / commit 282648d02) hit:

```
Running nixos-install --flake /mnt/etc/zeta/full-ai-cluster#control-plane --fallback ...
/run/current-system/sw/bin/nixos-install: unknown option `--fallback`
[zeta-first-boot] Install failed. See output above.
```

Install dropped to interactive shell; cluster bring-up completely blocked.

## Root cause

PR #5383 added `--fallback` as a top-level flag to `nixos-install`. The flag exists in `nix-build`/`nix-store` but NOT in `nixos-install`. The Nix-option pass-through convention `--option fallback true` IS supported (same shape as the existing `--option connect-timeout 10` / `--option stalled-download-timeout 60` / `--option download-attempts 3` already in the same invocation).

## Fix

1-line change `--fallback \` → `--option fallback true \` + comment update with empirical anchor.

## Operator unblock (live-USB shell right now)

```bash
sed -i 's|^  --fallback \\|  --option fallback true \\|' /run/current-system/sw/bin/zeta-install
zeta-install control-plane
```

## Composes with

- **B-0835** — installer-config-bugs canonical bag (adds Bug 9 to the catalog)
- **B-0846** — WiFi-reproducibility substrate; this fix preserves the intent (build-from-source fallback) using the correct API
- PR #5383 (the original `--fallback` addition; supersedes via API correction)

## Test plan

- [ ] Next ISO build from this fix → fresh USB flash → first-boot install completes (no `unknown option` error)
- [ ] cache.nixos.org timeout fallback still operates (verify via `--option fallback true` semantics: Nix builds from source when substituter fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)