### PR TITLE
feat(B-0852.1): TS crypto module — HKDF-SHA256 + AES-256-GCM for credential persistence (pure functions; 18 unit tests; smallest concrete substrate slice)

### DIFF
--- a/tools/installer/zeta-creds-crypto.test.ts
+++ b/tools/installer/zeta-creds-crypto.test.ts
@@ -1,0 +1,190 @@
+// zeta-creds-crypto.test.ts — B-0852.1 acceptance tests.
+//
+// Validates the threat-model claims in zeta-creds-crypto.ts:
+//   - Round-trip: plaintext survives encrypt → decrypt with same (UUID, passphrase)
+//   - Wrong passphrase: decrypt returns error (not garbled plaintext)
+//   - Wrong UUID (copy-to-different-USB attack): decrypt returns error
+//   - Tampered ciphertext: GCM auth tag rejects
+//   - Tampered tag: GCM auth tag rejects
+//   - Tampered salt: key derives differently → auth tag rejects
+//   - HKDF determinism: same inputs → same key
+//   - Salt + IV freshness: encrypt is non-deterministic per call
+
+import { describe, expect, it } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { IV_LEN, KEY_LEN, SALT_LEN, TAG_LEN, decrypt, deriveKey, encrypt, type Envelope } from "./zeta-creds-crypto";
+
+const UUID = "9e8d7c6b-5a49-3827-1605-fedcba987654";
+const ALT_UUID = "00000000-0000-0000-0000-000000000000";
+const PASS = "correct horse battery staple";
+const WRONG_PASS = "Tr0ub4dor&3";
+const PT = Buffer.from(
+  JSON.stringify({
+    gh: { token: "ghp_fake_for_test_only" },
+    claude: { credentials: "fake" },
+    persona: "otto",
+  }),
+);
+
+describe("deriveKey", () => {
+  it("returns 32-byte AES-256 key", () => {
+    const salt = randomBytes(SALT_LEN);
+    const key = deriveKey(UUID, PASS, salt);
+    expect(key.length).toBe(KEY_LEN);
+  });
+
+  it("is deterministic for fixed inputs", () => {
+    const salt = randomBytes(SALT_LEN);
+    const a = deriveKey(UUID, PASS, salt);
+    const b = deriveKey(UUID, PASS, salt);
+    expect(a.equals(b)).toBe(true);
+  });
+
+  it("differs when UUID differs (binds to USB)", () => {
+    const salt = randomBytes(SALT_LEN);
+    const a = deriveKey(UUID, PASS, salt);
+    const b = deriveKey(ALT_UUID, PASS, salt);
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it("differs when passphrase differs", () => {
+    const salt = randomBytes(SALT_LEN);
+    const a = deriveKey(UUID, PASS, salt);
+    const b = deriveKey(UUID, WRONG_PASS, salt);
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it("differs when salt differs", () => {
+    const s1 = randomBytes(SALT_LEN);
+    const s2 = randomBytes(SALT_LEN);
+    const a = deriveKey(UUID, PASS, s1);
+    const b = deriveKey(UUID, PASS, s2);
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it("rejects wrong-length salt", () => {
+    expect(() => deriveKey(UUID, PASS, randomBytes(16))).toThrow();
+  });
+});
+
+describe("encrypt", () => {
+  it("returns envelope with correct field sizes", () => {
+    const env = encrypt(PT, UUID, PASS);
+    expect(env.salt.length).toBe(SALT_LEN);
+    expect(env.iv.length).toBe(IV_LEN);
+    expect(env.tag.length).toBe(TAG_LEN);
+    expect(env.ciphertext.length).toBe(PT.length); // GCM is stream cipher mode → same length
+  });
+
+  it("is non-deterministic across calls (fresh salt + IV per call)", () => {
+    const a = encrypt(PT, UUID, PASS);
+    const b = encrypt(PT, UUID, PASS);
+    expect(Buffer.from(a.salt).equals(Buffer.from(b.salt))).toBe(false);
+    expect(Buffer.from(a.iv).equals(Buffer.from(b.iv))).toBe(false);
+    expect(Buffer.from(a.ciphertext).equals(Buffer.from(b.ciphertext))).toBe(false);
+  });
+});
+
+describe("decrypt — happy path", () => {
+  it("round-trips plaintext with correct UUID + passphrase", () => {
+    const env = encrypt(PT, UUID, PASS);
+    const result = decrypt(env, UUID, PASS);
+    if ("error" in result) throw new Error(`unexpected error: ${result.error}`);
+    expect(result.equals(PT)).toBe(true);
+  });
+
+  it("handles empty plaintext", () => {
+    const env = encrypt(Buffer.alloc(0), UUID, PASS);
+    const result = decrypt(env, UUID, PASS);
+    if ("error" in result) throw new Error(`unexpected error: ${result.error}`);
+    expect(result.length).toBe(0);
+  });
+
+  it("handles large plaintext (1 MiB)", () => {
+    const big = randomBytes(1024 * 1024);
+    const env = encrypt(big, UUID, PASS);
+    const result = decrypt(env, UUID, PASS);
+    if ("error" in result) throw new Error(`unexpected error: ${result.error}`);
+    expect(result.equals(big)).toBe(true);
+  });
+});
+
+describe("decrypt — security rejections", () => {
+  it("rejects wrong passphrase (returns error; not garbled plaintext)", () => {
+    const env = encrypt(PT, UUID, PASS);
+    const result = decrypt(env, UUID, WRONG_PASS);
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects wrong UUID — defeats copy-to-different-USB attack", () => {
+    const env = encrypt(PT, UUID, PASS);
+    const result = decrypt(env, ALT_UUID, PASS);
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects tampered ciphertext (single byte flip)", () => {
+    const env = encrypt(PT, UUID, PASS);
+    const tampered: Envelope = {
+      salt: env.salt,
+      iv: env.iv,
+      tag: env.tag,
+      ciphertext: flipByte(env.ciphertext, 0),
+    };
+    const result = decrypt(tampered, UUID, PASS);
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects tampered tag", () => {
+    const env = encrypt(PT, UUID, PASS);
+    const tampered: Envelope = {
+      salt: env.salt,
+      iv: env.iv,
+      tag: flipByte(env.tag, 0),
+      ciphertext: env.ciphertext,
+    };
+    const result = decrypt(tampered, UUID, PASS);
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects tampered salt (key derives differently)", () => {
+    const env = encrypt(PT, UUID, PASS);
+    const tampered: Envelope = {
+      salt: flipByte(env.salt, 0),
+      iv: env.iv,
+      tag: env.tag,
+      ciphertext: env.ciphertext,
+    };
+    const result = decrypt(tampered, UUID, PASS);
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects wrong IV length", () => {
+    const env = encrypt(PT, UUID, PASS);
+    const malformed: Envelope = {
+      salt: env.salt,
+      iv: randomBytes(8), // wrong size
+      tag: env.tag,
+      ciphertext: env.ciphertext,
+    };
+    const result = decrypt(malformed, UUID, PASS);
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects wrong tag length", () => {
+    const env = encrypt(PT, UUID, PASS);
+    const malformed: Envelope = {
+      salt: env.salt,
+      iv: env.iv,
+      tag: randomBytes(8), // wrong size
+      ciphertext: env.ciphertext,
+    };
+    const result = decrypt(malformed, UUID, PASS);
+    expect("error" in result).toBe(true);
+  });
+});
+
+function flipByte(buf: Uint8Array, index: number): Buffer {
+  const copy = Buffer.from(buf);
+  copy[index] = copy[index]! ^ 0x01;
+  return copy;
+}

--- a/tools/installer/zeta-creds-crypto.test.ts
+++ b/tools/installer/zeta-creds-crypto.test.ts
@@ -18,10 +18,12 @@ const UUID = "9e8d7c6b-5a49-3827-1605-fedcba987654";
 const ALT_UUID = "00000000-0000-0000-0000-000000000000";
 const PASS = "correct horse battery staple";
 const WRONG_PASS = "Tr0ub4dor&3";
+// Test fixture uses non-token-prefix strings so secret-scanners don't fire
+// false-positive alerts (no "ghp_" / "gho_" / "ghu_" / "sk-" etc. prefixes).
 const PT = Buffer.from(
   JSON.stringify({
-    gh: { token: "ghp_fake_for_test_only" },
-    claude: { credentials: "fake" },
+    gh: { token: "TEST-FIXTURE-NOT-A-REAL-TOKEN-deadbeef-cafebabe" },
+    claude: { credentials: "TEST-FIXTURE-NOT-REAL" },
     persona: "otto",
   }),
 );
@@ -179,6 +181,19 @@ describe("decrypt — security rejections", () => {
       ciphertext: env.ciphertext,
     };
     const result = decrypt(malformed, UUID, PASS);
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects wrong salt length (returns error; not throws)", () => {
+    const env = encrypt(PT, UUID, PASS);
+    const malformed: Envelope = {
+      salt: randomBytes(16), // wrong size — deriveKey would throw if called
+      iv: env.iv,
+      tag: env.tag,
+      ciphertext: env.ciphertext,
+    };
+    const result = decrypt(malformed, UUID, PASS);
+    // Must return structured error (locks in the no-throw contract for callers).
     expect("error" in result).toBe(true);
   });
 });

--- a/tools/installer/zeta-creds-crypto.ts
+++ b/tools/installer/zeta-creds-crypto.ts
@@ -1,0 +1,134 @@
+// zeta-creds-crypto.ts — pure crypto primitives for B-0852 credential persistence.
+//
+// B-0852 sub-row .1 (smallest concrete substrate slice). Pure functions; no I/O.
+// Composes with:
+//   - tools/installer/zeta-creds-persist.ts (B-0852.2; consumes encrypt)
+//   - tools/installer/zeta-creds-restore.ts (B-0852.2; consumes decrypt)
+//   - docs/backlog/P1/B-0852-credential-persistence-on-usb-esp-*.md
+//
+// Threat model (Phase 1 scope; per row body):
+//   - Attacker has physical USB access → blob on ESP is readable as a file
+//   - Attacker can copy ESP contents to a different-UUID USB
+//   - Attacker does NOT have operator passphrase
+//   - Operator passphrase is typed at boot; never persisted to disk
+//
+// Defense:
+//   - HKDF-SHA256 binds key to BOTH (USB UUID || passphrase) so blob copied
+//     to a different-UUID USB cannot be decrypted (assuming passphrase secret)
+//   - AES-256-GCM authenticated encryption rejects tampered ciphertext
+//   - Wrong passphrase produces a different key → GCM auth tag verification
+//     fails → decrypt returns error (NOT garbled plaintext)
+//
+// Phase 3 (NOT this row): hardware-bound keys (TPM / YubiKey / Touch-ID-derived)
+//   to defeat the "attacker stole USB AND knows passphrase AND knows UUID" case.
+
+import { createCipheriv, createDecipheriv, hkdfSync, randomBytes } from "node:crypto";
+
+/** AES-256-GCM key size (bytes). */
+export const KEY_LEN = 32;
+
+/** AES-GCM IV size (bytes); 12 is the AES-GCM spec recommendation. */
+export const IV_LEN = 12;
+
+/** AES-GCM authentication tag size (bytes). */
+export const TAG_LEN = 16;
+
+/** HKDF salt length (bytes); ships per-blob in the envelope. */
+export const SALT_LEN = 32;
+
+/** HKDF info string — bound to this row's substrate-engineering purpose. */
+export const HKDF_INFO = Buffer.from("zeta-b0852-cred-persistence-v1");
+
+/**
+ * Envelope written to /esp/zeta-creds.enc. Wire format is a single binary
+ * blob (Phase 1 implementation will length-prefix-pack salt+iv+tag+ciphertext).
+ * This module returns the structured object; serialization is a sibling
+ * concern (B-0852.2 persist CLI).
+ */
+export interface Envelope {
+  readonly salt: Uint8Array;
+  readonly iv: Uint8Array;
+  readonly tag: Uint8Array;
+  readonly ciphertext: Uint8Array;
+}
+
+/**
+ * Derive AES-256 key from USB UUID + operator passphrase using HKDF-SHA256.
+ *
+ * Binding to USB UUID is the substrate-engineering anti-defeat measure named
+ * by Aaron 2026-05-27: "we can put a key on the usb too if wnated tied to the
+ * uuid so it can't be copied to uuid".
+ *
+ * @param usbUuid - the USB stick's filesystem UUID (operator-provided; e.g.
+ *                  from `blkid -s UUID -o value /dev/disk6s1`)
+ * @param passphrase - operator passphrase typed at boot
+ * @param salt - 32 random bytes; freshly generated per encryption, stored in
+ *               the envelope; required at decrypt time
+ * @returns 32-byte AES-256 key
+ */
+export function deriveKey(usbUuid: string, passphrase: string, salt: Uint8Array): Buffer {
+  if (salt.length !== SALT_LEN) {
+    throw new Error(`salt must be ${SALT_LEN} bytes; got ${salt.length}`);
+  }
+  // HKDF input keying material: USB UUID || passphrase. Both must match at
+  // decrypt time. Order-sensitive (UUID first then passphrase per convention).
+  const ikm = Buffer.concat([Buffer.from(usbUuid, "utf8"), Buffer.from("|", "utf8"), Buffer.from(passphrase, "utf8")]);
+  const derived = hkdfSync("sha256", ikm, salt, HKDF_INFO, KEY_LEN);
+  return Buffer.from(derived);
+}
+
+/**
+ * Encrypt plaintext with AES-256-GCM. Generates fresh salt + IV per call.
+ *
+ * @param plaintext - cred-blob bytes (cleartext)
+ * @param usbUuid - USB filesystem UUID (bound into key derivation)
+ * @param passphrase - operator passphrase
+ * @returns envelope { salt, iv, tag, ciphertext } ready for serialization
+ */
+export function encrypt(plaintext: Uint8Array, usbUuid: string, passphrase: string): Envelope {
+  const salt = randomBytes(SALT_LEN);
+  const iv = randomBytes(IV_LEN);
+  const key = deriveKey(usbUuid, passphrase, salt);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return { salt, iv, tag, ciphertext };
+}
+
+/**
+ * Decrypt envelope. Returns plaintext on success OR { error } on:
+ *   - wrong passphrase (auth tag verification fails)
+ *   - wrong USB UUID (auth tag verification fails)
+ *   - tampered ciphertext (auth tag verification fails)
+ *   - tampered tag (auth tag verification fails)
+ *   - tampered salt (key derives differently → auth tag verification fails)
+ *
+ * Operationally: any error means the operator should fall through to the
+ * picker's option (2) fresh-login OR option (3) operator-provided PAT path
+ * per the row's auth-method picker semantics.
+ *
+ * @param envelope - serialized blob contents
+ * @param usbUuid - USB filesystem UUID
+ * @param passphrase - operator passphrase
+ * @returns plaintext on success OR { error: string } on any failure
+ */
+export function decrypt(envelope: Envelope, usbUuid: string, passphrase: string): Buffer | { readonly error: string } {
+  if (envelope.iv.length !== IV_LEN) {
+    return { error: `iv must be ${IV_LEN} bytes; got ${envelope.iv.length}` };
+  }
+  if (envelope.tag.length !== TAG_LEN) {
+    return { error: `tag must be ${TAG_LEN} bytes; got ${envelope.tag.length}` };
+  }
+  const key = deriveKey(usbUuid, passphrase, envelope.salt);
+  const decipher = createDecipheriv("aes-256-gcm", key, envelope.iv);
+  decipher.setAuthTag(envelope.tag);
+  try {
+    const plaintext = Buffer.concat([decipher.update(envelope.ciphertext), decipher.final()]);
+    return plaintext;
+  } catch (err) {
+    // node:crypto throws on auth-tag mismatch. Return as structured error
+    // so callers don't need try/catch (substrate-honest: failure IS a value).
+    const msg = err instanceof Error ? err.message : String(err);
+    return { error: `decryption failed (wrong passphrase / wrong UUID / tampered blob): ${msg}` };
+  }
+}

--- a/tools/installer/zeta-creds-crypto.ts
+++ b/tools/installer/zeta-creds-crypto.ts
@@ -13,16 +13,22 @@
 //   - Operator passphrase is typed at boot; never persisted to disk
 //
 // Defense:
-//   - HKDF-SHA256 binds key to BOTH (USB UUID || passphrase) so blob copied
+//   - scrypt (memory-hard work-factor KDF; OWASP 2026 defaults N=2^17 r=8 p=1)
+//     stretches the low-entropy operator passphrase into a high-entropy
+//     intermediate — makes brute-force attempts memory-prohibitively expensive
+//     on GPU/ASIC (security-review HIGH finding 2026-05-27 fix; HKDF alone
+//     assumes high-entropy IKM which passphrases violate)
+//   - HKDF-SHA256 then binds the stretched secret to USB UUID so blob copied
 //     to a different-UUID USB cannot be decrypted (assuming passphrase secret)
 //   - AES-256-GCM authenticated encryption rejects tampered ciphertext
-//   - Wrong passphrase produces a different key → GCM auth tag verification
-//     fails → decrypt returns error (NOT garbled plaintext)
+//   - Wrong passphrase produces a different scrypt output → different HKDF
+//     key → GCM auth tag verification fails → decrypt returns error
+//     (NOT garbled plaintext)
 //
 // Phase 3 (NOT this row): hardware-bound keys (TPM / YubiKey / Touch-ID-derived)
 //   to defeat the "attacker stole USB AND knows passphrase AND knows UUID" case.
 
-import { createCipheriv, createDecipheriv, hkdfSync, randomBytes } from "node:crypto";
+import { createCipheriv, createDecipheriv, hkdfSync, randomBytes, scryptSync } from "node:crypto";
 
 /** AES-256-GCM key size (bytes). */
 export const KEY_LEN = 32;
@@ -33,11 +39,29 @@ export const IV_LEN = 12;
 /** AES-GCM authentication tag size (bytes). */
 export const TAG_LEN = 16;
 
-/** HKDF salt length (bytes); ships per-blob in the envelope. */
+/** Salt length (bytes); shared between scrypt + HKDF; ships per-blob in envelope. */
 export const SALT_LEN = 32;
 
 /** HKDF info string — bound to this row's substrate-engineering purpose. */
 export const HKDF_INFO = Buffer.from("zeta-b0852-cred-persistence-v1");
+
+/**
+ * scrypt cost parameters (OWASP-recommended 2026 defaults for password-derived keys).
+ *
+ * N=2^17 (~128MB memory cost) makes brute-force exponentially expensive on GPU/ASIC
+ * because the attacker needs to commit ~128MB of memory PER GUESS. r=8 + p=1 are
+ * standard. Operational cost: ~1-2s per derivation on modern CPU (operator types
+ * passphrase ONCE at boot; this latency is acceptable; brute-force latency is the
+ * defense).
+ *
+ * NOTE: must allow node:crypto to bypass its default `maxmem` (32MB); we set
+ * `maxmem: 256 * 1024 * 1024` (256MB) which comfortably accommodates N=2^17.
+ */
+export const SCRYPT_N = 1 << 17;
+export const SCRYPT_R = 8;
+export const SCRYPT_P = 1;
+export const SCRYPT_MAXMEM = 256 * 1024 * 1024;
+export const SCRYPT_STRETCHED_LEN = 32;
 
 /**
  * Envelope written to /esp/zeta-creds.enc. Wire format is a single binary
@@ -53,26 +77,50 @@ export interface Envelope {
 }
 
 /**
- * Derive AES-256 key from USB UUID + operator passphrase using HKDF-SHA256.
+ * Derive AES-256 key from USB UUID + operator passphrase via scrypt → HKDF chain.
  *
- * Binding to USB UUID is the substrate-engineering anti-defeat measure named
- * by Aaron 2026-05-27: "we can put a key on the usb too if wnated tied to the
- * uuid so it can't be copied to uuid".
+ * **Two-layer derivation** (security-review HIGH finding 2026-05-27 fix):
+ *
+ *   1. scrypt(passphrase, salt) → stretched 32 bytes
+ *      - Memory-hard work-factor-tunable KDF (N=2^17 ~128MB; ~1-2s on modern CPU)
+ *      - Makes low-entropy passphrases brute-force-resistant (HKDF alone assumes
+ *        high-entropy IKM; passphrases violate that assumption)
+ *      - OWASP 2026 recommended parameters
+ *   2. HKDF-SHA256(usbUuid || stretched, salt, info) → 32 byte AES-256 key
+ *      - Binds key to USB UUID for the copy-to-different-UUID-attack defense
+ *        named by Aaron 2026-05-27: "we can put a key on the usb too if wnated
+ *        tied to the uuid so it can't be copied to uuid"
+ *      - HKDF's high-entropy IKM assumption is now satisfied (scrypt output is
+ *        cryptographically random)
+ *
+ * Both layers must produce matching outputs at decrypt time for the AES-GCM
+ * auth tag to verify. Wrong passphrase → different scrypt output → different
+ * HKDF key → GCM auth tag fails → structured error returned (not garbled
+ * plaintext).
  *
  * @param usbUuid - the USB stick's filesystem UUID (operator-provided; e.g.
  *                  from `blkid -s UUID -o value /dev/disk6s1`)
  * @param passphrase - operator passphrase typed at boot
  * @param salt - 32 random bytes; freshly generated per encryption, stored in
- *               the envelope; required at decrypt time
+ *               the envelope; required at decrypt time; shared between scrypt
+ *               + HKDF (same salt across different functions with different
+ *               parameters is safe per modern crypto guidance)
  * @returns 32-byte AES-256 key
  */
 export function deriveKey(usbUuid: string, passphrase: string, salt: Uint8Array): Buffer {
   if (salt.length !== SALT_LEN) {
     throw new Error(`salt must be ${SALT_LEN} bytes; got ${salt.length}`);
   }
-  // HKDF input keying material: USB UUID || passphrase. Both must match at
-  // decrypt time. Order-sensitive (UUID first then passphrase per convention).
-  const ikm = Buffer.concat([Buffer.from(usbUuid, "utf8"), Buffer.from("|", "utf8"), Buffer.from(passphrase, "utf8")]);
+  // Layer 1: scrypt stretches low-entropy passphrase into high-entropy intermediate.
+  const stretched = scryptSync(passphrase, salt, SCRYPT_STRETCHED_LEN, {
+    N: SCRYPT_N,
+    r: SCRYPT_R,
+    p: SCRYPT_P,
+    maxmem: SCRYPT_MAXMEM,
+  });
+  // Layer 2: HKDF binds the stretched secret to the USB UUID via IKM concatenation.
+  // UUID first then stretched (order-sensitive; documented; decrypt must match).
+  const ikm = Buffer.concat([Buffer.from(usbUuid, "utf8"), Buffer.from("|", "utf8"), stretched]);
   const derived = hkdfSync("sha256", ikm, salt, HKDF_INFO, KEY_LEN);
   return Buffer.from(derived);
 }

--- a/tools/installer/zeta-creds-crypto.ts
+++ b/tools/installer/zeta-creds-crypto.ts
@@ -161,12 +161,17 @@ export function encrypt(plaintext: Uint8Array, usbUuid: string, passphrase: stri
  * @returns plaintext on success OR { error: string } on any failure
  */
 export function decrypt(envelope: Envelope, usbUuid: string, passphrase: string): Buffer | { readonly error: string } {
+  if (envelope.salt.length !== SALT_LEN) {
+    return { error: `salt must be ${SALT_LEN} bytes; got ${envelope.salt.length}` };
+  }
   if (envelope.iv.length !== IV_LEN) {
     return { error: `iv must be ${IV_LEN} bytes; got ${envelope.iv.length}` };
   }
   if (envelope.tag.length !== TAG_LEN) {
     return { error: `tag must be ${TAG_LEN} bytes; got ${envelope.tag.length}` };
   }
+  // deriveKey would throw on wrong-length salt; we validated above so this
+  // can't fail at the deriveKey call site for that reason.
   const key = deriveKey(usbUuid, passphrase, envelope.salt);
   const decipher = createDecipheriv("aes-256-gcm", key, envelope.iv);
   decipher.setAuthTag(envelope.tag);


### PR DESCRIPTION
## Summary

Smallest concrete substrate slice of B-0852 cred-persistence. Pure crypto functions; no I/O; 18 unit tests covering the threat model.

## Threat model (Phase 1 scope per B-0852 row body)

- HKDF-SHA256 binds key to `(USB-UUID || passphrase)` — copying ESP contents to a different-UUID USB cannot decrypt (defeats "copy to uuid" attack named by Aaron 2026-05-27)
- AES-256-GCM authenticated encryption rejects tampered ciphertext/tag/salt
- Wrong passphrase → different derived key → GCM auth tag fails → returns `{ error }` (NOT garbled plaintext)
- Phase 3 (NOT this row): hardware-bound keys defer the "stole USB + knows pass + knows UUID" case

## Files

| File | Lines | Purpose |
|---|---|---|
| `tools/installer/zeta-creds-crypto.ts` | ~135 | `deriveKey` + `encrypt` + `decrypt` pure module |
| `tools/installer/zeta-creds-crypto.test.ts` | ~190 | 18 acceptance tests |

## Test output

```
 18 pass
 0 fail
 23 expect() calls
Ran 18 tests across 1 file. [103.00ms]
```

Tests cover: round-trip (small/empty/1MiB), wrong passphrase, wrong UUID (copy-to-different-USB attack), tampered ciphertext (byte flip), tampered tag, tampered salt, malformed IV/tag sizes, HKDF determinism, HKDF independence (UUID/passphrase/salt sensitivity), salt + IV freshness across calls.

## Composes with

- **B-0852** (parent row) — credential persistence on USB ESP + boot-sequence auth-method picker
- **B-0852.2** (next sub-row) — TS persist/restore CLIs consuming this module's `encrypt`/`decrypt`
- **B-0852.5** (sibling sub-row) — declarative cred-manifest schema (this module is the cipher layer; manifest is the data-shape layer)
- node:crypto `hkdfSync` + `createCipheriv("aes-256-gcm", ...)` — standard primitives; no third-party dep

## What this is NOT

- NOT the persist/restore CLI (B-0852.2)
- NOT the cred-manifest schema (B-0852.5)
- NOT the NixOS module (B-0852.4)
- NOT serialization of the envelope (B-0852.2 will length-prefix-pack salt+iv+tag+ciphertext)
- NOT hardware-bound keys (Phase 3; explicit deferral)

## Test plan

- [x] `bun test tools/installer/zeta-creds-crypto.test.ts` → 18 pass
- [x] `prettier --check` clean
- [ ] CI passes typecheck + format + test gates
- [ ] No third-party dep added (verified: node:crypto + bun:test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)