### PR TITLE
feat(B-0852.5): declarative cred-manifest schema + validator — pure types + DEFAULT_MANIFEST (6 entries) + 21 unit tests (Aaron 2026-05-27 declarative discipline)

### DIFF
--- a/tools/installer/zeta-creds-manifest.test.ts
+++ b/tools/installer/zeta-creds-manifest.test.ts
@@ -1,0 +1,196 @@
+// zeta-creds-manifest.test.ts — B-0852.5 acceptance tests.
+//
+// Validates schema definition + validator behavior:
+//   - DEFAULT_MANIFEST is internally consistent (passes its own validator)
+//   - validateManifest accepts well-formed input
+//   - validateManifest rejects malformed input with specific error messages
+//   - Per-credential validation: id, paths, flags, notes
+
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_MANIFEST, validateManifest } from "./zeta-creds-manifest";
+
+describe("DEFAULT_MANIFEST", () => {
+  it("passes its own validator", () => {
+    const result = validateManifest(DEFAULT_MANIFEST);
+    if ("error" in result) {
+      throw new Error(`DEFAULT_MANIFEST validation failed: ${result.error.join("; ")}`);
+    }
+    expect(result.ok.credentials.length).toBe(DEFAULT_MANIFEST.credentials.length);
+  });
+
+  it("declares all 4 vendor credentials Phase 1 needs (gh + claude + gemini + codex)", () => {
+    const ids = DEFAULT_MANIFEST.credentials.map((c) => c.id);
+    expect(ids).toContain("gh-cli");
+    expect(ids).toContain("claude");
+    expect(ids).toContain("gemini");
+    expect(ids).toContain("codex");
+  });
+
+  it("declares ssh-host-keys as optional (required:false; regen on fresh OK)", () => {
+    const entry = DEFAULT_MANIFEST.credentials.find((c) => c.id === "ssh-host-keys");
+    expect(entry).toBeDefined();
+    expect(entry!.required).toBe(false);
+  });
+
+  it("declares ssh-operator-pubkey as required (composes with iter-4.2 ESP write)", () => {
+    const entry = DEFAULT_MANIFEST.credentials.find((c) => c.id === "ssh-operator-pubkey");
+    expect(entry).toBeDefined();
+    expect(entry!.required).toBe(true);
+  });
+
+  it("declares vendor CLIs as personaScoped:true (per-AI identity B-0847)", () => {
+    for (const id of ["claude", "gemini", "codex"]) {
+      const entry = DEFAULT_MANIFEST.credentials.find((c) => c.id === id);
+      expect(entry!.personaScoped).toBe(true);
+    }
+  });
+
+  it("declares gh-cli as personaScoped:false (today; future B-0847 may flip)", () => {
+    const entry = DEFAULT_MANIFEST.credentials.find((c) => c.id === "gh-cli");
+    expect(entry!.personaScoped).toBe(false);
+  });
+
+  it("declares all entries with non-empty paths", () => {
+    for (const entry of DEFAULT_MANIFEST.credentials) {
+      expect(entry.paths.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("validateManifest — accepts well-formed input", () => {
+  it("accepts minimal valid manifest (1 entry)", () => {
+    const minimal = {
+      schemaVersion: 1,
+      credentials: [
+        {
+          id: "test",
+          paths: ["~/.test/creds"],
+          personaScoped: false,
+          required: true,
+        },
+      ],
+    };
+    const result = validateManifest(minimal);
+    expect("ok" in result).toBe(true);
+  });
+
+  it("accepts entries with optional notes field", () => {
+    const withNotes = {
+      schemaVersion: 1,
+      credentials: [
+        {
+          id: "test",
+          paths: ["~/.test/creds"],
+          personaScoped: false,
+          required: true,
+          notes: "test fixture",
+        },
+      ],
+    };
+    const result = validateManifest(withNotes);
+    expect("ok" in result).toBe(true);
+  });
+});
+
+describe("validateManifest — rejects malformed input", () => {
+  it("rejects non-object input", () => {
+    expect("error" in validateManifest(null)).toBe(true);
+    expect("error" in validateManifest(undefined)).toBe(true);
+    expect("error" in validateManifest("string")).toBe(true);
+    expect("error" in validateManifest(42)).toBe(true);
+    expect("error" in validateManifest([])).toBe(true);
+  });
+
+  it("rejects wrong schemaVersion", () => {
+    const result = validateManifest({
+      schemaVersion: 2,
+      credentials: [{ id: "x", paths: ["/x"], personaScoped: false, required: true }],
+    });
+    if (!("error" in result)) throw new Error("expected error");
+    expect(result.error.some((e) => e.includes("schemaVersion"))).toBe(true);
+  });
+
+  it("rejects missing credentials array", () => {
+    const result = validateManifest({ schemaVersion: 1 });
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects empty credentials array", () => {
+    const result = validateManifest({ schemaVersion: 1, credentials: [] });
+    if (!("error" in result)) throw new Error("expected error");
+    expect(result.error.some((e) => e.includes("non-empty"))).toBe(true);
+  });
+
+  it("rejects duplicate ids", () => {
+    const dup = {
+      schemaVersion: 1,
+      credentials: [
+        { id: "x", paths: ["/x"], personaScoped: false, required: true },
+        { id: "x", paths: ["/y"], personaScoped: true, required: false },
+      ],
+    };
+    const result = validateManifest(dup);
+    if (!("error" in result)) throw new Error("expected error");
+    expect(result.error.some((e) => e.includes("duplicates"))).toBe(true);
+  });
+
+  it("rejects empty id", () => {
+    const result = validateManifest({
+      schemaVersion: 1,
+      credentials: [{ id: "", paths: ["/x"], personaScoped: false, required: true }],
+    });
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects empty paths array", () => {
+    const result = validateManifest({
+      schemaVersion: 1,
+      credentials: [{ id: "x", paths: [], personaScoped: false, required: true }],
+    });
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects paths containing empty strings", () => {
+    const result = validateManifest({
+      schemaVersion: 1,
+      credentials: [{ id: "x", paths: ["/x", ""], personaScoped: false, required: true }],
+    });
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects non-boolean personaScoped", () => {
+    const result = validateManifest({
+      schemaVersion: 1,
+      credentials: [{ id: "x", paths: ["/x"], personaScoped: "yes", required: true }],
+    });
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects non-boolean required", () => {
+    const result = validateManifest({
+      schemaVersion: 1,
+      credentials: [{ id: "x", paths: ["/x"], personaScoped: false, required: "yes" }],
+    });
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects non-string notes", () => {
+    const result = validateManifest({
+      schemaVersion: 1,
+      credentials: [{ id: "x", paths: ["/x"], personaScoped: false, required: true, notes: 42 }],
+    });
+    expect("error" in result).toBe(true);
+  });
+
+  it("accumulates multiple errors in one pass", () => {
+    const result = validateManifest({
+      schemaVersion: 99,
+      credentials: [
+        { id: "", paths: [], personaScoped: "no", required: 1 },
+        { id: "", paths: ["x"], personaScoped: false, required: true },
+      ],
+    });
+    if (!("error" in result)) throw new Error("expected error");
+    expect(result.error.length).toBeGreaterThan(2);
+  });
+});

--- a/tools/installer/zeta-creds-manifest.ts
+++ b/tools/installer/zeta-creds-manifest.ts
@@ -1,0 +1,180 @@
+// zeta-creds-manifest.ts — declarative credential-manifest schema for B-0852.
+//
+// B-0852 sub-row .5 (smallest pure-data substrate slice). No runtime deps;
+// pure types + parser + validator. Composes with:
+//   - tools/installer/zeta-creds-crypto.ts (B-0852.1; cipher layer)
+//   - tools/installer/zeta-creds-persist.ts (B-0852.2; consumes manifest)
+//   - tools/installer/zeta-creds-restore.ts (B-0852.2; consumes manifest)
+//   - full-ai-cluster/usb-nixos-installer/zeta-creds-manifest.yaml (canonical deployed copy)
+//
+// The discipline (Aaron 2026-05-27): "the keep credentials options we should
+// declare each credential we need and save and restore so it's not so
+// imparative too." Adding a new credential type = manifest edit, NOT a code
+// change. Persist/restore code reads the manifest + iterates.
+
+/** A single credential entry in the manifest. */
+export interface CredentialEntry {
+  /** Stable identifier (e.g., "gh-cli"). Used as map key in encrypted blob. */
+  readonly id: string;
+  /** Absolute or `~`-relative paths to capture/restore. */
+  readonly paths: readonly string[];
+  /**
+   * If true: the credential is captured/restored PER PERSONA
+   * (otto / alexa / riven / vera / lior). The encrypted blob nests this
+   * credential under each persona's section.
+   *
+   * If false: single global instance (one identity per host).
+   */
+  readonly personaScoped: boolean;
+  /**
+   * If true: failure to persist/restore this credential is a HARD ERROR.
+   * If false: degrade gracefully (warn + continue; common for optional creds
+   * like SSH host keys which regen on first boot).
+   */
+  readonly required: boolean;
+  /** Human-readable notes (optional; for operator-facing manifest review). */
+  readonly notes?: string;
+}
+
+/** The full manifest. */
+export interface Manifest {
+  /** Schema version; bumps when CredentialEntry shape changes. */
+  readonly schemaVersion: 1;
+  /** Per-credential entries, ordered as authored. */
+  readonly credentials: readonly CredentialEntry[];
+}
+
+/** The default manifest shipped with B-0852 Phase 1. */
+export const DEFAULT_MANIFEST: Manifest = {
+  schemaVersion: 1,
+  credentials: [
+    {
+      id: "gh-cli",
+      paths: ["~/.config/gh/hosts.yml"],
+      personaScoped: false,
+      required: true,
+      notes: "GitHub CLI token + host config. Per-AI identity (B-0847) future may flip personaScoped:true.",
+    },
+    {
+      id: "claude",
+      paths: ["~/.config/claude/credentials.json", "~/.claude/.credentials.json"],
+      personaScoped: true,
+      required: true,
+      notes: "Anthropic Claude Code CLI credentials. Per-persona slot.",
+    },
+    {
+      id: "gemini",
+      paths: ["~/.gemini/oauth_creds.json"],
+      personaScoped: true,
+      required: true,
+      notes: "Google Gemini CLI OAuth creds. Per-persona slot.",
+    },
+    {
+      id: "codex",
+      paths: ["~/.codex/auth.json"],
+      personaScoped: true,
+      required: true,
+      notes: "OpenAI Codex CLI auth. Per-persona slot.",
+    },
+    {
+      id: "ssh-host-keys",
+      paths: [
+        "/etc/ssh/ssh_host_ed25519_key",
+        "/etc/ssh/ssh_host_ed25519_key.pub",
+        "/etc/ssh/ssh_host_rsa_key",
+        "/etc/ssh/ssh_host_rsa_key.pub",
+      ],
+      personaScoped: false,
+      required: false,
+      notes:
+        "Optional. Regen on fresh installs is acceptable; persist for SSH-known-hosts continuity across re-installs.",
+    },
+    {
+      id: "ssh-operator-pubkey",
+      paths: ["/etc/zeta/operator-authorized-keys", "/etc/ssh/authorized_keys.d/zeta-operator"],
+      personaScoped: false,
+      required: true,
+      notes: "Operator's SSH pubkey injected by iter-4.2 ESP write. Composes with that channel.",
+    },
+  ],
+};
+
+/**
+ * Structured validation result. Either { ok: manifest } or { error: messages }.
+ * Substrate-honest: failure IS a value (no throws at caller scope).
+ */
+export type ValidateResult = { readonly ok: Manifest } | { readonly error: readonly string[] };
+
+/**
+ * Validate a parsed manifest object. Pure function; no I/O.
+ *
+ * Checks:
+ *   - schemaVersion is the supported value
+ *   - credentials is non-empty array
+ *   - each entry has all required fields with correct types
+ *   - id values are unique across the manifest
+ *   - paths is non-empty
+ *
+ * @param raw - any value (typically from YAML.parse / JSON.parse)
+ * @returns ValidateResult
+ */
+export function validateManifest(raw: unknown): ValidateResult {
+  const errors: string[] = [];
+
+  if (!isObject(raw)) {
+    return { error: ["manifest must be an object"] };
+  }
+
+  if (raw.schemaVersion !== 1) {
+    errors.push(`schemaVersion must be 1; got ${JSON.stringify(raw.schemaVersion)}`);
+  }
+
+  if (!Array.isArray(raw.credentials)) {
+    errors.push("credentials must be an array");
+    return { error: errors };
+  }
+
+  if (raw.credentials.length === 0) {
+    errors.push("credentials array must be non-empty");
+  }
+
+  const seenIds = new Set<string>();
+  raw.credentials.forEach((entry: unknown, i: number) => {
+    if (!isObject(entry)) {
+      errors.push(`credentials[${i}] must be an object`);
+      return;
+    }
+    if (typeof entry.id !== "string" || entry.id.length === 0) {
+      errors.push(`credentials[${i}].id must be a non-empty string`);
+    } else if (seenIds.has(entry.id)) {
+      errors.push(`credentials[${i}].id "${entry.id}" duplicates an earlier entry`);
+    } else {
+      seenIds.add(entry.id);
+    }
+    if (!Array.isArray(entry.paths) || entry.paths.length === 0) {
+      errors.push(`credentials[${i}].paths must be a non-empty array`);
+    } else if (!entry.paths.every((p: unknown): boolean => typeof p === "string" && p.length > 0)) {
+      errors.push(`credentials[${i}].paths must contain only non-empty strings`);
+    }
+    if (typeof entry.personaScoped !== "boolean") {
+      errors.push(`credentials[${i}].personaScoped must be a boolean`);
+    }
+    if (typeof entry.required !== "boolean") {
+      errors.push(`credentials[${i}].required must be a boolean`);
+    }
+    if (entry.notes !== undefined && typeof entry.notes !== "string") {
+      errors.push(`credentials[${i}].notes must be a string if present`);
+    }
+  });
+
+  if (errors.length > 0) {
+    return { error: errors };
+  }
+
+  return { ok: raw as unknown as Manifest };
+}
+
+/** Type guard for plain object (non-array, non-null). */
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

B-0852 sub-row .5 — smallest pure-data substrate slice. Composes with B-0852.1 crypto module (PR #5411) as the data-shape layer to the cipher layer.

Aaron 2026-05-27 discipline: *"the keep credentials options we should declare each credential we need and save and restore so it's not so imparative too."* Adding a new credential type = manifest edit, NOT a code change.

## Files

| File | Lines | Purpose |
|---|---|---|
| `tools/installer/zeta-creds-manifest.ts` | ~180 | `CredentialEntry` + `Manifest` types; `DEFAULT_MANIFEST`; `validateManifest()` |
| `tools/installer/zeta-creds-manifest.test.ts` | ~200 | 21 acceptance tests |

## DEFAULT_MANIFEST entries (6)

| id | personaScoped | required | Purpose |
|---|---|---|---|
| gh-cli | false | true | `~/.config/gh/hosts.yml` (B-0847 may flip future) |
| claude | true | true | `~/.config/claude/credentials.json` |
| gemini | true | true | `~/.gemini/oauth_creds.json` |
| codex | true | true | `~/.codex/auth.json` |
| ssh-host-keys | false | false | Optional; regen on fresh OK |
| ssh-operator-pubkey | false | true | iter-4.2 ESP-write channel compose |

## Test output

```
 21 pass
 0 fail
 37 expect() calls
Ran 21 tests across 1 file. [111.00ms]
```

Covers DEFAULT_MANIFEST internal consistency + Phase 1 vendor coverage + personaScoped flags + happy-path validation + 12 rejection cases (non-object, wrong schemaVersion, duplicate ids, empty paths, type mismatches, error accumulation).

## What this is NOT

- NOT the persist/restore CLI (B-0852.2)
- NOT the deployed YAML manifest (separate file under `full-ai-cluster/usb-nixos-installer/`)
- NOT the NixOS module (B-0852.4)
- NOT a YAML parser (validator runs on already-parsed objects; YAML parsing is sibling concern in B-0852.2)

## Composes with

- **B-0852** (parent row)
- **B-0852.1** (PR #5411) — crypto module; cipher layer (this row is data layer)
- **B-0852.2** (next) — persist/restore CLIs consume both .1 + .5
- **B-0847** — per-AI GitHub identity; future personaScoped:true flip for gh-cli
- iter-4.2 ESP SSH pubkey injection (composes with ssh-operator-pubkey entry)

## Test plan

- [x] 21 tests pass via `bun test tools/installer/zeta-creds-manifest.test.ts`
- [x] Format clean (prettier)
- [ ] CI passes typecheck + format + test gates
- [ ] No third-party deps added (verified: bun:test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)