### PR TITLE
fix(B-0853.1 post-merge): 3 Copilot P1 security tightenings on PR #5417 (job-scope id-token + tightened safety wording + pinned verification identity)

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -71,12 +71,10 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # B-0853.1: sigstore/cosign keyless OIDC signing. Fulcio CA
-                   # mints a short-lived cert from the GitHub-issued OIDC token;
-                   # Rekor transparency log records the signature. No private
-                   # key material is handled in this workflow. The token-issuance
-                   # scope is workflow-bound; granted permission cannot be
-                   # exfiltrated to mint signatures for other workflows.
+  # id-token: write moved to jobs.build.permissions per Copilot P1 finding on
+  # PR #5417 — matches the repo pattern (.github/workflows/scorecard.yml
+  # elevates id-token at job scope only, minimising blast radius if future
+  # jobs added to this workflow).
 
 concurrency:
   group: build-ai-cluster-iso-${{ github.workflow }}-${{ github.ref }}
@@ -87,6 +85,23 @@ jobs:
     name: build-iso
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    permissions:
+      contents: read
+      # B-0853.1 cosign keyless OIDC — sigstore/Fulcio CA mints a short-lived
+      # cert from the GitHub-issued OIDC token; Rekor transparency log records
+      # the signature. No private key material is handled in this workflow.
+      #
+      # Real safety properties (tightened per Copilot P1 review on PR #5417):
+      #   - Short-lived cert (Fulcio mints 10-min cert tied to this run)
+      #   - Identity bound to workflow path + ref (verifier pins via
+      #     --certificate-identity matching this file's path + ref)
+      #   - Steps pinned to commit SHAs (cosign-installer at vetted release)
+      # NOT a hard guarantee: any step in THIS job that can request the OIDC
+      # token could in principle transmit it off-runner + use it to mint a
+      # Fulcio cert + sign arbitrary blobs as THIS workflow's identity. The
+      # mitigation is pinned + audited steps + job-scope id-token (not
+      # workflow-wide; this block).
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -309,19 +324,29 @@ jobs:
       # B-0853.1 — sigstore/cosign keyless OIDC signing of the ISO blob.
       # Composes with B-0853 (sigstore artifact signing free-stuff substrate).
       #
-      # Keyless model: GitHub OIDC token (from id-token: write permission at
-      # workflow level) is exchanged with Fulcio CA for a short-lived cert
+      # Keyless model: GitHub OIDC token (from job-level id-token: write
+      # permission above) is exchanged with Fulcio CA for a short-lived cert
       # bound to this workflow's identity. cosign then signs the ISO blob
       # with that cert + records the signature in the Rekor transparency log.
       # No long-lived private key material in this workflow.
       #
-      # Verification (any consumer):
+      # Verification (any consumer) — pin identity to THIS specific workflow
+      # file + ref (tightened per Copilot P1 review on PR #5417; the broader
+      # `^https://github.com/Lucent-Financial-Group/Zeta` prefix-regex would
+      # accept signatures from any workflow in the repo, defeating the
+      # workflow-identity binding):
+      #
       #   cosign verify-blob \
       #     --certificate <iso>.pem \
       #     --signature <iso>.sig \
-      #     --certificate-identity-regexp '^https://github.com/Lucent-Financial-Group/Zeta' \
+      #     --certificate-identity 'https://github.com/Lucent-Financial-Group/Zeta/.github/workflows/build-ai-cluster-iso.yml@refs/heads/main' \
       #     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
       #     <iso>
+      #
+      # For verifying signatures from feature branches OR tags, swap the
+      # `@refs/heads/main` suffix accordingly:
+      #   --certificate-identity '.../build-ai-cluster-iso.yml@refs/heads/<branch>'
+      #   --certificate-identity '.../build-ai-cluster-iso.yml@refs/tags/<tag>'
       #
       # Security: inputs to cosign are filesystem paths from steps.iso.outputs
       # of THIS workflow (no github.event.* interpolation). Same discipline


### PR DESCRIPTION
## Summary

Post-merge fix-fwd for 3 Copilot P1 security findings on [PR #5417](https://github.com/Lucent-Financial-Group/Zeta/pull/5417) (cosign keyless OIDC ISO signing) which merged at \`70596a8db\` before the review threads could be addressed.

All 3 findings are valid security improvements; this PR is documentation/permission-scoping only — no runtime behavior change.

## Findings + fixes

### Finding 1 (P1): scope `id-token: write` to job, not workflow

**Before**: top-level `permissions: { id-token: write }`
**After**: scoped to `jobs.build.permissions: { id-token: write }`

Matches the repo pattern in \`.github/workflows/scorecard.yml\`. Reduces blast radius if future jobs are added to this workflow.

### Finding 2 (P1): tighten safety wording

**Before**: \"token-issuance scope is workflow-bound; granted permission cannot be exfiltrated to mint signatures for other workflows.\"

**Overstated** — any step with id-token access could in principle transmit the token off-runner.

**After**: comment names the actual mitigation surfaces (short-lived cert, identity binding, pinned steps) + acknowledges the realistic threat.

### Finding 3 (P1): tighten verification regexp

**Before**: \`--certificate-identity-regexp '^https://github.com/Lucent-Financial-Group/Zeta'\` (prefix-regex; accepts ANY workflow under the repo — defeats workflow-identity binding).

**After**: explicit pin to this specific workflow file + ref:
\`\`\`
--certificate-identity 'https://github.com/Lucent-Financial-Group/Zeta/.github/workflows/build-ai-cluster-iso.yml@refs/heads/main'
\`\`\`
Plus documented variants for verifying branch + tag signatures.

## What this is NOT

- NOT a runtime change to the cosign sign-blob step itself (identity emitted into signed cert is the same)
- NOT a re-do of PR #5417 (that one's merged; this builds on it)
- NOT a new sub-row (these are corrections to already-shipped substrate per B-0853.1)

## Composes with

- **B-0853.1** parent ([PR #5417](https://github.com/Lucent-Financial-Group/Zeta/pull/5417) merged at \`70596a8db\`)
- **B-0853** parent row (sigstore signing substrate)

## Resolves Copilot threads on #5417

- \`PRRT_kwDOSF9kNM6FBtyf\` (id-token scoping)
- \`PRRT_kwDOSF9kNM6FBtzO\` (safety wording)
- \`PRRT_kwDOSF9kNM6FBtzn\` (verification identity pin)

## Test plan

- [ ] Workflow run still succeeds with job-scoped id-token (functionally identical)
- [ ] cosign sign-blob step unchanged; signed identity unchanged
- [ ] Documentation lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)