### PR TITLE
feat(B-0852.2b rebased): persist + restore CLIs composing full cred-persistence stack (19 integration tests; replaces conflict-dirty #5422)

### DIFF
--- a/tools/installer/zeta-creds-envelope.ts
+++ b/tools/installer/zeta-creds-envelope.ts
@@ -42,8 +42,12 @@ export const MAGIC = Buffer.from("ZCV1", "ascii");
 /** Header length: magic (4) + reserved (4) = 8 bytes. */
 export const HEADER_LEN = 8;
 
-/** Total minimum blob size (header + 4 length prefixes + min 1-byte ciphertext). */
-export const MIN_BLOB_LEN = HEADER_LEN + 2 + 32 + 2 + 12 + 2 + 16 + 4 + 1;
+/**
+ * Total minimum blob size (header + 4 length prefixes + 0-byte ciphertext).
+ * AES-GCM permits empty plaintext/ciphertext, so the minimum includes a
+ * 0-length ciphertext per Copilot review on PR #5422.
+ */
+export const MIN_BLOB_LEN = HEADER_LEN + 2 + 32 + 2 + 12 + 2 + 16 + 4;
 
 /**
  * Serialize an Envelope to the on-disk wire format.

--- a/tools/installer/zeta-creds-persist-restore.test.ts
+++ b/tools/installer/zeta-creds-persist-restore.test.ts
@@ -145,7 +145,9 @@ describe("persist → restore round-trip via tmpdir", () => {
     // Restore
     const restoreRoot = join(tmp, "restore-target");
     const blobRead = readFileSync(persistArgs.output);
-    const written = applyPlan(blobRead, UUID, PASS, null, restoreRoot);
+    const plan = planRestore(blobRead, UUID, PASS, null, restoreRoot);
+    if ("error" in plan) throw new Error(plan.error);
+    const written = applyPlan(plan);
     expect(written).toBe(1);
     // gh-cli writes to <root>/<homedir>/.config/gh/hosts.yml
     const ghPath = resolveCredPaths(DEFAULT_MANIFEST.credentials.find((c) => c.id === "gh-cli")!, restoreRoot)[0]!;
@@ -167,7 +169,9 @@ describe("persist → restore round-trip via tmpdir", () => {
     writeFileSync(persistArgs.output, blob);
 
     const restoreRoot = join(tmp, "restore-target-2");
-    const written = applyPlan(readFileSync(persistArgs.output), UUID, PASS, "otto", restoreRoot);
+    const plan = planRestore(readFileSync(persistArgs.output), UUID, PASS, "otto", restoreRoot);
+    if ("error" in plan) throw new Error(plan.error);
+    const written = applyPlan(plan);
     expect(written).toBe(1);
     const claudePath = resolveCredPaths(DEFAULT_MANIFEST.credentials.find((c) => c.id === "claude")!, restoreRoot)[0]!;
     const restored = readFileSync(claudePath, "utf8");

--- a/tools/installer/zeta-creds-persist-restore.test.ts
+++ b/tools/installer/zeta-creds-persist-restore.test.ts
@@ -1,0 +1,274 @@
+// zeta-creds-persist-restore.test.ts — B-0852.2b CLI integration tests.
+//
+// Covers the full persist → restore round-trip via temp-dir filesystem
+// (not just pure-function units; the CLI surfaces have FS I/O).
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildBlob, composeBundle, parseArgs as parsePersistArgs } from "./zeta-creds-persist";
+import { applyPlan, parseArgs as parseRestoreArgs, planRestore, resolveCredPaths } from "./zeta-creds-restore";
+import { DEFAULT_MANIFEST } from "./zeta-creds-manifest";
+
+const UUID = "test-uuid-1234-5678-9abc";
+const PASS = "integration-test-passphrase";
+
+describe("parsePersistArgs", () => {
+  it("accepts well-formed args with --passphrase-env", () => {
+    const result = parsePersistArgs(
+      ["--usb-uuid", UUID, "--output", "/tmp/blob", "--passphrase-env", "TP", "--bake-cred", "gh-cli=ghp_x"],
+      { TP: PASS },
+    );
+    if ("error" in result) throw new Error(result.error);
+    expect(result.usbUuid).toBe(UUID);
+    expect(result.output).toBe("/tmp/blob");
+    expect(result.passphrase).toBe(PASS);
+    expect(result.bakeCredArgs.length).toBe(1);
+  });
+
+  it("rejects missing --usb-uuid", () => {
+    const result = parsePersistArgs(["--output", "/tmp/x", "--passphrase-env", "PP"], { PP: "x" });
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects missing --output", () => {
+    const result = parsePersistArgs(["--usb-uuid", UUID, "--passphrase-env", "PP"], { PP: "x" });
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects empty --passphrase-env", () => {
+    const result = parsePersistArgs(["--usb-uuid", UUID, "--output", "/tmp/x", "--passphrase-env", "MISSING"], {});
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects unknown flag", () => {
+    const result = parsePersistArgs(["--bogus"], {});
+    expect("error" in result).toBe(true);
+  });
+});
+
+describe("composeBundle", () => {
+  it("composes global cred (gh-cli; personaScoped:false)", () => {
+    const args = {
+      usbUuid: UUID,
+      output: "x",
+      passphrase: PASS,
+      persona: null,
+      bakeCredArgs: ["gh-cli=test-token-value"],
+    };
+    const bundle = composeBundle(args);
+    if ("error" in bundle) throw new Error(bundle.error);
+    expect(bundle.globalCreds["gh-cli"]).toBeDefined();
+    expect(Object.keys(bundle.personaCreds).length).toBe(0);
+  });
+
+  it("composes persona cred when --persona given", () => {
+    const args = {
+      usbUuid: UUID,
+      output: "x",
+      passphrase: PASS,
+      persona: "otto",
+      bakeCredArgs: ['claude={"creds":"value"}'],
+    };
+    const bundle = composeBundle(args);
+    if ("error" in bundle) throw new Error(bundle.error);
+    expect(bundle.personaCreds.otto!.claude).toBeDefined();
+  });
+
+  it("rejects personaScoped cred without --persona", () => {
+    const args = {
+      usbUuid: UUID,
+      output: "x",
+      passphrase: PASS,
+      persona: null,
+      bakeCredArgs: ['claude={"creds":"value"}'],
+    };
+    const result = composeBundle(args);
+    expect("error" in result).toBe(true);
+  });
+
+  it("rejects unknown cred id", () => {
+    const args = {
+      usbUuid: UUID,
+      output: "x",
+      passphrase: PASS,
+      persona: null,
+      bakeCredArgs: ["nonexistent=value"],
+    };
+    const result = composeBundle(args);
+    expect("error" in result).toBe(true);
+  });
+});
+
+describe("resolveCredPaths", () => {
+  const entry = DEFAULT_MANIFEST.credentials.find((c) => c.id === "gh-cli")!;
+
+  it("expands ~ to home dir under target-root", () => {
+    const paths = resolveCredPaths(entry, "/mnt");
+    expect(paths[0]).toContain("/mnt/");
+    expect(paths[0]).toContain(".config/gh/hosts.yml");
+  });
+
+  it("respects target-root for absolute paths", () => {
+    const sshEntry = DEFAULT_MANIFEST.credentials.find((c) => c.id === "ssh-operator-pubkey")!;
+    const paths = resolveCredPaths(sshEntry, "/mnt");
+    expect(paths[0]).toBe("/mnt/etc/zeta/operator-authorized-keys");
+  });
+});
+
+describe("persist → restore round-trip via tmpdir", () => {
+  let tmp: string;
+
+  beforeAll(() => {
+    tmp = mkdtempSync(join(tmpdir(), "zeta-creds-2b-test-"));
+  });
+
+  afterAll(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("global cred (gh-cli) round-trips via blob through tmpdir", () => {
+    // Persist
+    const persistArgs = {
+      usbUuid: UUID,
+      output: join(tmp, "blob1.enc"),
+      passphrase: PASS,
+      persona: null,
+      bakeCredArgs: ["gh-cli=PERSISTED-TOKEN-VALUE"],
+    };
+    const bundle = composeBundle(persistArgs);
+    if ("error" in bundle) throw new Error(bundle.error);
+    const blob = buildBlob(bundle, persistArgs.usbUuid, persistArgs.passphrase);
+    writeFileSync(persistArgs.output, blob);
+
+    // Restore
+    const restoreRoot = join(tmp, "restore-target");
+    const blobRead = readFileSync(persistArgs.output);
+    const written = applyPlan(blobRead, UUID, PASS, null, restoreRoot);
+    expect(written).toBe(1);
+    // gh-cli writes to <root>/<homedir>/.config/gh/hosts.yml
+    const ghPath = resolveCredPaths(DEFAULT_MANIFEST.credentials.find((c) => c.id === "gh-cli")!, restoreRoot)[0]!;
+    const restored = readFileSync(ghPath, "utf8");
+    expect(restored).toBe("PERSISTED-TOKEN-VALUE");
+  });
+
+  it("persona cred (claude under otto) round-trips", () => {
+    const persistArgs = {
+      usbUuid: UUID,
+      output: join(tmp, "blob2.enc"),
+      passphrase: PASS,
+      persona: "otto",
+      bakeCredArgs: ['claude={"creds":"OTTO-CLAUDE"}'],
+    };
+    const bundle = composeBundle(persistArgs);
+    if ("error" in bundle) throw new Error(bundle.error);
+    const blob = buildBlob(bundle, persistArgs.usbUuid, persistArgs.passphrase);
+    writeFileSync(persistArgs.output, blob);
+
+    const restoreRoot = join(tmp, "restore-target-2");
+    const written = applyPlan(readFileSync(persistArgs.output), UUID, PASS, "otto", restoreRoot);
+    expect(written).toBe(1);
+    const claudePath = resolveCredPaths(DEFAULT_MANIFEST.credentials.find((c) => c.id === "claude")!, restoreRoot)[0]!;
+    const restored = readFileSync(claudePath, "utf8");
+    expect(restored).toBe('{"creds":"OTTO-CLAUDE"}');
+  });
+
+  it("planRestore reports wrong passphrase as code 5", () => {
+    const persistArgs = {
+      usbUuid: UUID,
+      output: join(tmp, "blob3.enc"),
+      passphrase: PASS,
+      persona: null,
+      bakeCredArgs: ["gh-cli=ANY"],
+    };
+    const bundle = composeBundle(persistArgs);
+    if ("error" in bundle) throw new Error(bundle.error);
+    const blob = buildBlob(bundle, persistArgs.usbUuid, persistArgs.passphrase);
+
+    const plan = planRestore(blob, UUID, "WRONG-PASSPHRASE", null, "/tmp/dontcare");
+    if (!("error" in plan)) throw new Error("expected error from wrong passphrase");
+    expect(plan.code).toBe(5);
+  });
+
+  it("planRestore reports wrong UUID as code 5 (defeats copy-to-different-USB)", () => {
+    const persistArgs = {
+      usbUuid: UUID,
+      output: join(tmp, "blob4.enc"),
+      passphrase: PASS,
+      persona: null,
+      bakeCredArgs: ["gh-cli=ANY"],
+    };
+    const bundle = composeBundle(persistArgs);
+    if ("error" in bundle) throw new Error(bundle.error);
+    const blob = buildBlob(bundle, persistArgs.usbUuid, persistArgs.passphrase);
+
+    const plan = planRestore(blob, "different-uuid", PASS, null, "/tmp/dontcare");
+    if (!("error" in plan)) throw new Error("expected error from wrong UUID");
+    expect(plan.code).toBe(5);
+  });
+
+  it("planRestore reports tampered blob as code 5", () => {
+    const persistArgs = {
+      usbUuid: UUID,
+      output: join(tmp, "blob5.enc"),
+      passphrase: PASS,
+      persona: null,
+      bakeCredArgs: ["gh-cli=ANY"],
+    };
+    const bundle = composeBundle(persistArgs);
+    if ("error" in bundle) throw new Error(bundle.error);
+    const blob = buildBlob(bundle, persistArgs.usbUuid, persistArgs.passphrase);
+
+    // Flip a byte in the middle of the ciphertext region
+    const tampered = Buffer.from(blob);
+    tampered[blob.length - 10] = tampered[blob.length - 10]! ^ 0x01;
+
+    const plan = planRestore(tampered, UUID, PASS, null, "/tmp/dontcare");
+    if (!("error" in plan)) throw new Error("expected error from tampered blob");
+    expect(plan.code).toBe(5);
+  });
+
+  it("planRestore reports invalid magic header as code 4", () => {
+    const plan = planRestore(
+      Buffer.from("not a valid blob at all just text bytes" + "x".repeat(200)),
+      UUID,
+      PASS,
+      null,
+      "/tmp/dontcare",
+    );
+    if (!("error" in plan)) throw new Error("expected error from invalid header");
+    expect(plan.code).toBe(4);
+  });
+});
+
+describe("parseRestoreArgs", () => {
+  it("accepts well-formed args", () => {
+    const result = parseRestoreArgs(
+      [
+        "--usb-uuid",
+        UUID,
+        "--input",
+        "/x.enc",
+        "--passphrase-env",
+        "PP",
+        "--persona",
+        "otto",
+        "--target-root",
+        "/mnt",
+        "--dry-run",
+      ],
+      { PP: PASS },
+    );
+    if ("error" in result) throw new Error(result.error);
+    expect(result.persona).toBe("otto");
+    expect(result.targetRoot).toBe("/mnt");
+    expect(result.dryRun).toBe(true);
+  });
+
+  it("default target-root is /", () => {
+    const result = parseRestoreArgs(["--usb-uuid", UUID, "--input", "/x", "--passphrase-env", "PP"], { PP: "x" });
+    if ("error" in result) throw new Error(result.error);
+    expect(result.targetRoot).toBe("/");
+  });
+});

--- a/tools/installer/zeta-creds-persist.ts
+++ b/tools/installer/zeta-creds-persist.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env bun
+// zeta-creds-persist.ts — write encrypted cred-blob to ESP. B-0852.2b CLI.
+//
+// Reads --bake-cred args + per-cred handler validation + crypto encrypt +
+// envelope serialize → writes to --output (e.g., /esp/zeta-creds.enc).
+//
+// Composes:
+//   - tools/installer/zeta-creds-crypto.ts (B-0852.1; encrypt)
+//   - tools/installer/zeta-creds-manifest.ts (B-0852.5; cred catalog)
+//   - tools/installer/zeta-cred-handlers.ts (B-0852.10; parse + validate args)
+//   - tools/installer/zeta-creds-envelope.ts (B-0852.2a; wire format + bundle)
+//
+// Usage:
+//   bun tools/installer/zeta-creds-persist.ts \
+//     --usb-uuid <uuid> \
+//     --output /esp/zeta-creds.enc \
+//     [--passphrase-file <path> | --passphrase-env <VAR> | (interactive prompt)] \
+//     [--persona <name>] \
+//     [--bake-cred <id>=<value-source>] ...
+//
+// Per .claude/rules/non-coercion-invariant.md HC-8: operator authority over
+// own creds; passphrase NEVER logged; --bake-cred error messages redact
+// value-source contents per B-0852.10 P0 security discipline.
+
+import { writeFileSync, readFileSync, existsSync } from "node:fs";
+import { encrypt } from "./zeta-creds-crypto";
+import { DEFAULT_HANDLERS, resolveBakeCred } from "./zeta-cred-handlers";
+import { encodeBundle, serializeEnvelope, type CredBundle } from "./zeta-creds-envelope";
+import { DEFAULT_MANIFEST } from "./zeta-creds-manifest";
+
+interface Args {
+  readonly usbUuid: string;
+  readonly output: string;
+  readonly passphrase: string;
+  readonly persona: string | null;
+  readonly bakeCredArgs: readonly string[];
+}
+
+/** Parse CLI args. Pure (no I/O). Returns args OR error message. */
+export function parseArgs(argv: readonly string[], env: NodeJS.ProcessEnv): Args | { readonly error: string } {
+  let usbUuid: string | null = null;
+  let output: string | null = null;
+  let passphraseFile: string | null = null;
+  let passphraseEnv: string | null = null;
+  let persona: string | null = null;
+  const bakeCredArgs: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    const next = (): string => {
+      if (i + 1 >= argv.length) throw new Error(`${arg} requires a value`);
+      return argv[++i]!;
+    };
+    try {
+      if (arg === "--usb-uuid") usbUuid = next();
+      else if (arg === "--output") output = next();
+      else if (arg === "--passphrase-file") passphraseFile = next();
+      else if (arg === "--passphrase-env") passphraseEnv = next();
+      else if (arg === "--persona") persona = next();
+      else if (arg === "--bake-cred") bakeCredArgs.push(next());
+      else return { error: `unknown flag: ${arg}` };
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  if (!usbUuid) return { error: "--usb-uuid required" };
+  if (!output) return { error: "--output required" };
+
+  // Resolve passphrase source. Interactive prompt handled by caller (main); this
+  // path is exercised when --passphrase-file or --passphrase-env is given.
+  let passphrase: string | null = null;
+  if (passphraseFile) {
+    if (!existsSync(passphraseFile)) return { error: `--passphrase-file not found: ${passphraseFile}` };
+    passphrase = readFileSync(passphraseFile, "utf8").replace(/\r?\n$/, "");
+    if (passphrase.length === 0) return { error: "--passphrase-file is empty" };
+  } else if (passphraseEnv) {
+    const v = env[passphraseEnv];
+    if (v === undefined || v === null || v === "") {
+      return { error: `--passphrase-env ${passphraseEnv} not set or empty` };
+    }
+    passphrase = v;
+  }
+  if (passphrase === null)
+    return {
+      error:
+        "passphrase source required (interactive prompt not supported in this entry-point; use --passphrase-file or --passphrase-env)",
+    };
+
+  return { usbUuid, output, passphrase, persona, bakeCredArgs };
+}
+
+/** Compose a CredBundle from --bake-cred args + manifest. Pure (in test mode). */
+export function composeBundle(args: Args): CredBundle | { readonly error: string } {
+  const globalCreds: Record<string, Buffer> = {};
+  const personaCreds: Record<string, Record<string, Buffer>> = {};
+
+  for (const arg of args.bakeCredArgs) {
+    const result = resolveBakeCred(arg, DEFAULT_HANDLERS);
+    if ("error" in result) return { error: `bake-cred parse failed: ${result.error}` };
+
+    // Look up manifest entry to determine personaScoped
+    const manifestEntry = DEFAULT_MANIFEST.credentials.find((c) => c.id === result.ok.id);
+    if (!manifestEntry) return { error: `cred id "${result.ok.id}" not declared in manifest` };
+
+    if (manifestEntry.personaScoped) {
+      if (!args.persona) return { error: `cred "${result.ok.id}" is personaScoped; --persona required` };
+      personaCreds[args.persona] ??= {};
+      personaCreds[args.persona]![result.ok.id] = result.ok.value;
+    } else {
+      globalCreds[result.ok.id] = result.ok.value;
+    }
+  }
+
+  return { schemaVersion: 1, globalCreds, personaCreds };
+}
+
+/** Pure pipeline (no FS write): bundle → encrypt → serialize. */
+export function buildBlob(bundle: CredBundle, usbUuid: string, passphrase: string): Buffer {
+  const plaintext = encodeBundle(bundle);
+  const env = encrypt(plaintext, usbUuid, passphrase);
+  return serializeEnvelope(env);
+}
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2);
+  const parsed = parseArgs(argv, process.env);
+  if ("error" in parsed) {
+    console.error(`zeta-creds-persist: ${parsed.error}`);
+    return 2;
+  }
+  const bundle = composeBundle(parsed);
+  if ("error" in bundle) {
+    console.error(`zeta-creds-persist: ${bundle.error}`);
+    return 3;
+  }
+  const blob = buildBlob(bundle, parsed.usbUuid, parsed.passphrase);
+  writeFileSync(parsed.output, blob);
+  console.log(`zeta-creds-persist: wrote ${blob.length} bytes to ${parsed.output}`);
+  console.log(`  globalCreds: ${Object.keys(bundle.globalCreds).join(", ") || "(none)"}`);
+  for (const [persona, creds] of Object.entries(bundle.personaCreds)) {
+    console.log(`  personaCreds[${persona}]: ${Object.keys(creds).join(", ")}`);
+  }
+  return 0;
+}
+
+if (import.meta.main) {
+  main().then((code) => process.exit(code));
+}

--- a/tools/installer/zeta-creds-persist.ts
+++ b/tools/installer/zeta-creds-persist.ts
@@ -14,9 +14,13 @@
 //   bun tools/installer/zeta-creds-persist.ts \
 //     --usb-uuid <uuid> \
 //     --output /esp/zeta-creds.enc \
-//     [--passphrase-file <path> | --passphrase-env <VAR> | (interactive prompt)] \
+//     ( --passphrase-file <path> | --passphrase-env <VAR> ) \
 //     [--persona <name>] \
 //     [--bake-cred <id>=<value-source>] ...
+//
+// Interactive passphrase prompts are NOT implemented in this CLI — caller
+// must supply --passphrase-file or --passphrase-env. Interactive prompting
+// is the wrapping NixOS module's responsibility (B-0852.4).
 //
 // Per .claude/rules/non-coercion-invariant.md HC-8: operator authority over
 // own creds; passphrase NEVER logged; --bake-cred error messages redact
@@ -36,7 +40,17 @@ interface Args {
   readonly bakeCredArgs: readonly string[];
 }
 
-/** Parse CLI args. Pure (no I/O). Returns args OR error message. */
+/**
+ * Parse CLI args. Reads filesystem ONLY for --passphrase-file (existence
+ * check + read). Returns Args OR structured error message.
+ *
+ * SECURITY: Error messages NEVER include the passphrase value itself, AND
+ * the env-var NAME passed as --passphrase-env value is not echoed back in
+ * error strings (CodeQL clear-text-logging finding on PR #5422: the
+ * var-name was tainted by env-access flow; omitting it avoids the false-
+ * positive AND avoids the genuine "operator might paste a long secret in
+ * argv if they confuse env-var-name with literal-secret" footgun).
+ */
 export function parseArgs(argv: readonly string[], env: NodeJS.ProcessEnv): Args | { readonly error: string } {
   let usbUuid: string | null = null;
   let output: string | null = null;
@@ -67,24 +81,29 @@ export function parseArgs(argv: readonly string[], env: NodeJS.ProcessEnv): Args
   if (!usbUuid) return { error: "--usb-uuid required" };
   if (!output) return { error: "--output required" };
 
-  // Resolve passphrase source. Interactive prompt handled by caller (main); this
-  // path is exercised when --passphrase-file or --passphrase-env is given.
+  // Resolve passphrase source. Interactive prompt is NOT implemented in this
+  // entry-point — caller must supply --passphrase-file or --passphrase-env.
   let passphrase: string | null = null;
   if (passphraseFile) {
     if (!existsSync(passphraseFile)) return { error: `--passphrase-file not found: ${passphraseFile}` };
-    passphrase = readFileSync(passphraseFile, "utf8").replace(/\r?\n$/, "");
+    try {
+      passphrase = readFileSync(passphraseFile, "utf8").replace(/\r?\n$/, "");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { error: `--passphrase-file read failed: ${msg}` };
+    }
     if (passphrase.length === 0) return { error: "--passphrase-file is empty" };
   } else if (passphraseEnv) {
     const v = env[passphraseEnv];
     if (v === undefined || v === null || v === "") {
-      return { error: `--passphrase-env ${passphraseEnv} not set or empty` };
+      // SECURITY: omit env-var name from error (CodeQL taint via passphraseEnv)
+      return { error: "--passphrase-env target var is not set or is empty" };
     }
     passphrase = v;
   }
   if (passphrase === null)
     return {
-      error:
-        "passphrase source required (interactive prompt not supported in this entry-point; use --passphrase-file or --passphrase-env)",
+      error: "passphrase source required: pass --passphrase-file <path> or --passphrase-env <VAR>",
     };
 
   return { usbUuid, output, passphrase, persona, bakeCredArgs };
@@ -135,7 +154,13 @@ async function main(): Promise<number> {
     return 3;
   }
   const blob = buildBlob(bundle, parsed.usbUuid, parsed.passphrase);
-  writeFileSync(parsed.output, blob);
+  try {
+    writeFileSync(parsed.output, blob);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`zeta-creds-persist: write to ${parsed.output} failed: ${msg}`);
+    return 4;
+  }
   console.log(`zeta-creds-persist: wrote ${blob.length} bytes to ${parsed.output}`);
   console.log(`  globalCreds: ${Object.keys(bundle.globalCreds).join(", ") || "(none)"}`);
   for (const [persona, creds] of Object.entries(bundle.personaCreds)) {

--- a/tools/installer/zeta-creds-restore.ts
+++ b/tools/installer/zeta-creds-restore.ts
@@ -11,10 +11,14 @@
 //   bun tools/installer/zeta-creds-restore.ts \
 //     --usb-uuid <uuid> \
 //     --input /esp/zeta-creds.enc \
-//     [--passphrase-file <path> | --passphrase-env <VAR> | (interactive)] \
+//     ( --passphrase-file <path> | --passphrase-env <VAR> ) \
 //     [--persona <name>] \
 //     [--target-root /  (default: filesystem root; for tests use tmp dir)] \
 //     [--dry-run]  (print what would be written; don't write)
+//
+// Interactive passphrase prompts are NOT implemented in this CLI — caller
+// must supply --passphrase-file or --passphrase-env. Interactive prompting
+// is the wrapping NixOS module's responsibility (B-0852.4).
 //
 // Exit codes:
 //   0 success
@@ -30,7 +34,7 @@
 // the failure rather than silently degrading.
 
 import { writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 import { decrypt } from "./zeta-creds-crypto";
 import { decodeBundle, parseEnvelope } from "./zeta-creds-envelope";
@@ -45,7 +49,15 @@ interface Args {
   readonly dryRun: boolean;
 }
 
-/** Parse CLI args. Pure (env lookup + FS existence check for passphrase-file only). */
+/**
+ * Parse CLI args. Reads filesystem ONLY for --passphrase-file. Returns
+ * Args OR structured error message.
+ *
+ * SECURITY: Error messages NEVER include the passphrase value itself, AND
+ * the env-var NAME passed as --passphrase-env value is not echoed back in
+ * error strings (CodeQL clear-text-logging finding on PR #5422 — see
+ * sibling note in zeta-creds-persist.ts).
+ */
 export function parseArgs(argv: readonly string[], env: NodeJS.ProcessEnv): Args | { readonly error: string } {
   let usbUuid: string | null = null;
   let input: string | null = null;
@@ -81,19 +93,24 @@ export function parseArgs(argv: readonly string[], env: NodeJS.ProcessEnv): Args
   let passphrase: string | null = null;
   if (passphraseFile) {
     if (!existsSync(passphraseFile)) return { error: `--passphrase-file not found: ${passphraseFile}` };
-    passphrase = readFileSync(passphraseFile, "utf8").replace(/\r?\n$/, "");
+    try {
+      passphrase = readFileSync(passphraseFile, "utf8").replace(/\r?\n$/, "");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { error: `--passphrase-file read failed: ${msg}` };
+    }
     if (passphrase.length === 0) return { error: "--passphrase-file is empty" };
   } else if (passphraseEnv) {
     const v = env[passphraseEnv];
     if (v === undefined || v === null || v === "") {
-      return { error: `--passphrase-env ${passphraseEnv} not set or empty` };
+      // SECURITY: omit env-var name from error (CodeQL taint via passphraseEnv)
+      return { error: "--passphrase-env target var is not set or is empty" };
     }
     passphrase = v;
   }
   if (passphrase === null)
     return {
-      error:
-        "passphrase source required (interactive prompt not supported in this entry-point; use --passphrase-file or --passphrase-env)",
+      error: "passphrase source required: pass --passphrase-file <path> or --passphrase-env <VAR>",
     };
 
   return { usbUuid, input, passphrase, persona, targetRoot, dryRun };
@@ -116,11 +133,17 @@ export function resolveCredPaths(entry: CredentialEntry, targetRoot: string): re
 
 /** Plan + summarize what would be written (for dry-run + logging). */
 export interface RestorePlan {
-  readonly writes: readonly { readonly path: string; readonly bytes: number }[];
+  readonly writes: readonly { readonly path: string; readonly bytes: number; readonly value: Buffer }[];
   readonly skipped: readonly { readonly id: string; readonly reason: string }[];
   readonly errors: readonly string[];
 }
 
+/**
+ * Decrypt + decode the blob + plan writes per manifest. Single decrypt
+ * (scrypt is expensive — per Copilot review on PR #5422 the prior split
+ * planRestore+applyPlan doubled scrypt cost). applyPlan() now takes a
+ * RestorePlan rather than re-decrypting.
+ */
 export function planRestore(
   blob: Buffer,
   usbUuid: string,
@@ -137,7 +160,7 @@ export function planRestore(
   const bundle = decodeBundle(plaintext);
   if ("error" in bundle) return { error: `bundle decode: ${bundle.error}`, code: 6 };
 
-  const writes: { path: string; bytes: number }[] = [];
+  const writes: { path: string; bytes: number; value: Buffer }[] = [];
   const skipped: { id: string; reason: string }[] = [];
   const errors: string[] = [];
 
@@ -154,7 +177,7 @@ export function planRestore(
     }
     const paths = resolveCredPaths(entry, targetRoot);
     // Write to FIRST path only (canonical); other paths are alternates the caller may symlink
-    writes.push({ path: paths[0]!, bytes: value.length });
+    writes.push({ path: paths[0]!, bytes: value.length, value });
   }
 
   // Persona creds (only restore the requested persona's section)
@@ -175,7 +198,7 @@ export function planRestore(
           continue;
         }
         const paths = resolveCredPaths(entry, targetRoot);
-        writes.push({ path: paths[0]!, bytes: value.length });
+        writes.push({ path: paths[0]!, bytes: value.length, value });
       }
     } else if (Object.keys(bundle.personaCreds).length > 0) {
       skipped.push({
@@ -184,9 +207,9 @@ export function planRestore(
       });
     }
   } else if (Object.keys(bundle.personaCreds).length > 0) {
-    for (const persona of Object.keys(bundle.personaCreds)) {
-      for (const id of Object.keys(bundle.personaCreds[persona]!)) {
-        skipped.push({ id: `${persona}/${id}`, reason: `persona-scoped cred; --persona not specified` });
+    for (const personaName of Object.keys(bundle.personaCreds)) {
+      for (const id of Object.keys(bundle.personaCreds[personaName]!)) {
+        skipped.push({ id: `${personaName}/${id}`, reason: `persona-scoped cred; --persona not specified` });
       }
     }
   }
@@ -195,40 +218,18 @@ export function planRestore(
   return { writes, skipped, errors: [] };
 }
 
-/** Apply the plan (FS writes). Caller must have done planRestore first. */
-export function applyPlan(
-  blob: Buffer,
-  usbUuid: string,
-  passphrase: string,
-  persona: string | null,
-  targetRoot: string,
-): number {
-  const env = parseEnvelope(blob);
-  if ("error" in env) throw new Error(`envelope parse: ${env.error}`);
-  const plaintext = decrypt(env, usbUuid, passphrase);
-  if ("error" in plaintext) throw new Error(`decrypt: ${plaintext.error}`);
-  const bundle = decodeBundle(plaintext);
-  if ("error" in bundle) throw new Error(`bundle decode: ${bundle.error}`);
-
+/**
+ * Apply a plan returned by planRestore. NO re-decrypt (per Copilot review
+ * on PR #5422 — the prior implementation re-decrypted, doubling scrypt
+ * cost + extending passphrase-derived-key lifetime in memory). Returns
+ * the count of writes performed.
+ */
+export function applyPlan(plan: RestorePlan): number {
   let writeCount = 0;
-  for (const [id, value] of Object.entries(bundle.globalCreds)) {
-    const entry = DEFAULT_MANIFEST.credentials.find((c) => c.id === id);
-    if (!entry || entry.personaScoped) continue;
-    const paths = resolveCredPaths(entry, targetRoot);
-    mkdirSync(dirname(paths[0]!), { recursive: true });
-    writeFileSync(paths[0]!, value);
+  for (const w of plan.writes) {
+    mkdirSync(dirname(w.path), { recursive: true });
+    writeFileSync(w.path, w.value);
     writeCount++;
-  }
-  if (persona) {
-    const personaSection = bundle.personaCreds[persona] ?? {};
-    for (const [id, value] of Object.entries(personaSection)) {
-      const entry = DEFAULT_MANIFEST.credentials.find((c) => c.id === id);
-      if (!entry || !entry.personaScoped) continue;
-      const paths = resolveCredPaths(entry, targetRoot);
-      mkdirSync(dirname(paths[0]!), { recursive: true });
-      writeFileSync(paths[0]!, value);
-      writeCount++;
-    }
   }
   return writeCount;
 }
@@ -244,7 +245,14 @@ async function main(): Promise<number> {
     console.error(`zeta-creds-restore: input file not found: ${parsed.input}`);
     return 3;
   }
-  const blob = readFileSync(parsed.input);
+  let blob: Buffer;
+  try {
+    blob = readFileSync(parsed.input);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`zeta-creds-restore: input file read failed: ${msg}`);
+    return 3;
+  }
   const plan = planRestore(blob, parsed.usbUuid, parsed.passphrase, parsed.persona, parsed.targetRoot);
   if ("error" in plan) {
     console.error(`zeta-creds-restore: ${plan.error}`);
@@ -256,7 +264,7 @@ async function main(): Promise<number> {
     for (const s of plan.skipped) console.log(`  SKIP  ${s.id}: ${s.reason}`);
     return 0;
   }
-  const written = applyPlan(blob, parsed.usbUuid, parsed.passphrase, parsed.persona, parsed.targetRoot);
+  const written = applyPlan(plan);
   console.log(`zeta-creds-restore: wrote ${written} creds (target-root: ${parsed.targetRoot})`);
   for (const s of plan.skipped) console.log(`  SKIP ${s.id}: ${s.reason}`);
   return 0;

--- a/tools/installer/zeta-creds-restore.ts
+++ b/tools/installer/zeta-creds-restore.ts
@@ -1,0 +1,267 @@
+#!/usr/bin/env bun
+// zeta-creds-restore.ts — read encrypted cred-blob from ESP + restore to disk.
+// B-0852.2b CLI sibling to zeta-creds-persist.ts.
+//
+// Composes:
+//   - tools/installer/zeta-creds-crypto.ts (B-0852.1; decrypt)
+//   - tools/installer/zeta-creds-manifest.ts (B-0852.5; cred catalog → paths)
+//   - tools/installer/zeta-creds-envelope.ts (B-0852.2a; wire format + bundle)
+//
+// Usage:
+//   bun tools/installer/zeta-creds-restore.ts \
+//     --usb-uuid <uuid> \
+//     --input /esp/zeta-creds.enc \
+//     [--passphrase-file <path> | --passphrase-env <VAR> | (interactive)] \
+//     [--persona <name>] \
+//     [--target-root /  (default: filesystem root; for tests use tmp dir)] \
+//     [--dry-run]  (print what would be written; don't write)
+//
+// Exit codes:
+//   0 success
+//   2 arg parse error
+//   3 file read failure
+//   4 envelope parse failure
+//   5 decrypt failure (wrong passphrase / wrong UUID / tampered blob)
+//   6 bundle decode failure
+//   7 manifest missing cred id present in blob (mismatch)
+//
+// Per .claude/rules/non-coercion-invariant.md HC-8: operator authority over
+// own creds; passphrase NEVER logged; required-cred write failure surfaces
+// the failure rather than silently degrading.
+
+import { writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { decrypt } from "./zeta-creds-crypto";
+import { decodeBundle, parseEnvelope } from "./zeta-creds-envelope";
+import { DEFAULT_MANIFEST, type CredentialEntry } from "./zeta-creds-manifest";
+
+interface Args {
+  readonly usbUuid: string;
+  readonly input: string;
+  readonly passphrase: string;
+  readonly persona: string | null;
+  readonly targetRoot: string;
+  readonly dryRun: boolean;
+}
+
+/** Parse CLI args. Pure (env lookup + FS existence check for passphrase-file only). */
+export function parseArgs(argv: readonly string[], env: NodeJS.ProcessEnv): Args | { readonly error: string } {
+  let usbUuid: string | null = null;
+  let input: string | null = null;
+  let passphraseFile: string | null = null;
+  let passphraseEnv: string | null = null;
+  let persona: string | null = null;
+  let targetRoot = "/";
+  let dryRun = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    const next = (): string => {
+      if (i + 1 >= argv.length) throw new Error(`${arg} requires a value`);
+      return argv[++i]!;
+    };
+    try {
+      if (arg === "--usb-uuid") usbUuid = next();
+      else if (arg === "--input") input = next();
+      else if (arg === "--passphrase-file") passphraseFile = next();
+      else if (arg === "--passphrase-env") passphraseEnv = next();
+      else if (arg === "--persona") persona = next();
+      else if (arg === "--target-root") targetRoot = next();
+      else if (arg === "--dry-run") dryRun = true;
+      else return { error: `unknown flag: ${arg}` };
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  if (!usbUuid) return { error: "--usb-uuid required" };
+  if (!input) return { error: "--input required" };
+
+  let passphrase: string | null = null;
+  if (passphraseFile) {
+    if (!existsSync(passphraseFile)) return { error: `--passphrase-file not found: ${passphraseFile}` };
+    passphrase = readFileSync(passphraseFile, "utf8").replace(/\r?\n$/, "");
+    if (passphrase.length === 0) return { error: "--passphrase-file is empty" };
+  } else if (passphraseEnv) {
+    const v = env[passphraseEnv];
+    if (v === undefined || v === null || v === "") {
+      return { error: `--passphrase-env ${passphraseEnv} not set or empty` };
+    }
+    passphrase = v;
+  }
+  if (passphrase === null)
+    return {
+      error:
+        "passphrase source required (interactive prompt not supported in this entry-point; use --passphrase-file or --passphrase-env)",
+    };
+
+  return { usbUuid, input, passphrase, persona, targetRoot, dryRun };
+}
+
+/** Resolve manifest entry's paths relative to target-root + ~ expansion. */
+export function resolveCredPaths(entry: CredentialEntry, targetRoot: string): readonly string[] {
+  return entry.paths.map((p) => {
+    if (p.startsWith("~/")) {
+      // ~ refers to caller's home (root user during install); restore happens
+      // pre-user-home so ~ resolution is best-effort here.
+      return resolve(targetRoot, homedir().replace(/^\//, ""), p.slice(2));
+    }
+    if (p.startsWith("/")) {
+      return resolve(targetRoot, p.slice(1));
+    }
+    return resolve(targetRoot, p);
+  });
+}
+
+/** Plan + summarize what would be written (for dry-run + logging). */
+export interface RestorePlan {
+  readonly writes: readonly { readonly path: string; readonly bytes: number }[];
+  readonly skipped: readonly { readonly id: string; readonly reason: string }[];
+  readonly errors: readonly string[];
+}
+
+export function planRestore(
+  blob: Buffer,
+  usbUuid: string,
+  passphrase: string,
+  persona: string | null,
+  targetRoot: string,
+): RestorePlan | { readonly error: string; readonly code: 4 | 5 | 6 | 7 } {
+  const env = parseEnvelope(blob);
+  if ("error" in env) return { error: `envelope parse: ${env.error}`, code: 4 };
+
+  const plaintext = decrypt(env, usbUuid, passphrase);
+  if ("error" in plaintext) return { error: `decrypt: ${plaintext.error}`, code: 5 };
+
+  const bundle = decodeBundle(plaintext);
+  if ("error" in bundle) return { error: `bundle decode: ${bundle.error}`, code: 6 };
+
+  const writes: { path: string; bytes: number }[] = [];
+  const skipped: { id: string; reason: string }[] = [];
+  const errors: string[] = [];
+
+  // Global creds
+  for (const [id, value] of Object.entries(bundle.globalCreds)) {
+    const entry = DEFAULT_MANIFEST.credentials.find((c) => c.id === id);
+    if (!entry) {
+      errors.push(`blob contains unknown cred id "${id}" (not in default manifest)`);
+      continue;
+    }
+    if (entry.personaScoped) {
+      skipped.push({ id, reason: `manifest declares personaScoped:true but blob put in globalCreds` });
+      continue;
+    }
+    const paths = resolveCredPaths(entry, targetRoot);
+    // Write to FIRST path only (canonical); other paths are alternates the caller may symlink
+    writes.push({ path: paths[0]!, bytes: value.length });
+  }
+
+  // Persona creds (only restore the requested persona's section)
+  if (persona) {
+    const personaSection = bundle.personaCreds[persona];
+    if (personaSection) {
+      for (const [id, value] of Object.entries(personaSection)) {
+        const entry = DEFAULT_MANIFEST.credentials.find((c) => c.id === id);
+        if (!entry) {
+          errors.push(`blob persona ${persona} contains unknown cred id "${id}"`);
+          continue;
+        }
+        if (!entry.personaScoped) {
+          skipped.push({
+            id,
+            reason: `manifest declares personaScoped:false but blob put in personaCreds[${persona}]`,
+          });
+          continue;
+        }
+        const paths = resolveCredPaths(entry, targetRoot);
+        writes.push({ path: paths[0]!, bytes: value.length });
+      }
+    } else if (Object.keys(bundle.personaCreds).length > 0) {
+      skipped.push({
+        id: `(persona-section)`,
+        reason: `requested persona "${persona}" not in blob; available: ${Object.keys(bundle.personaCreds).join(", ")}`,
+      });
+    }
+  } else if (Object.keys(bundle.personaCreds).length > 0) {
+    for (const persona of Object.keys(bundle.personaCreds)) {
+      for (const id of Object.keys(bundle.personaCreds[persona]!)) {
+        skipped.push({ id: `${persona}/${id}`, reason: `persona-scoped cred; --persona not specified` });
+      }
+    }
+  }
+
+  if (errors.length > 0) return { error: errors.join("; "), code: 7 };
+  return { writes, skipped, errors: [] };
+}
+
+/** Apply the plan (FS writes). Caller must have done planRestore first. */
+export function applyPlan(
+  blob: Buffer,
+  usbUuid: string,
+  passphrase: string,
+  persona: string | null,
+  targetRoot: string,
+): number {
+  const env = parseEnvelope(blob);
+  if ("error" in env) throw new Error(`envelope parse: ${env.error}`);
+  const plaintext = decrypt(env, usbUuid, passphrase);
+  if ("error" in plaintext) throw new Error(`decrypt: ${plaintext.error}`);
+  const bundle = decodeBundle(plaintext);
+  if ("error" in bundle) throw new Error(`bundle decode: ${bundle.error}`);
+
+  let writeCount = 0;
+  for (const [id, value] of Object.entries(bundle.globalCreds)) {
+    const entry = DEFAULT_MANIFEST.credentials.find((c) => c.id === id);
+    if (!entry || entry.personaScoped) continue;
+    const paths = resolveCredPaths(entry, targetRoot);
+    mkdirSync(dirname(paths[0]!), { recursive: true });
+    writeFileSync(paths[0]!, value);
+    writeCount++;
+  }
+  if (persona) {
+    const personaSection = bundle.personaCreds[persona] ?? {};
+    for (const [id, value] of Object.entries(personaSection)) {
+      const entry = DEFAULT_MANIFEST.credentials.find((c) => c.id === id);
+      if (!entry || !entry.personaScoped) continue;
+      const paths = resolveCredPaths(entry, targetRoot);
+      mkdirSync(dirname(paths[0]!), { recursive: true });
+      writeFileSync(paths[0]!, value);
+      writeCount++;
+    }
+  }
+  return writeCount;
+}
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2);
+  const parsed = parseArgs(argv, process.env);
+  if ("error" in parsed) {
+    console.error(`zeta-creds-restore: ${parsed.error}`);
+    return 2;
+  }
+  if (!existsSync(parsed.input)) {
+    console.error(`zeta-creds-restore: input file not found: ${parsed.input}`);
+    return 3;
+  }
+  const blob = readFileSync(parsed.input);
+  const plan = planRestore(blob, parsed.usbUuid, parsed.passphrase, parsed.persona, parsed.targetRoot);
+  if ("error" in plan) {
+    console.error(`zeta-creds-restore: ${plan.error}`);
+    return plan.code;
+  }
+  if (parsed.dryRun) {
+    console.log(`zeta-creds-restore (DRY RUN; ${plan.writes.length} writes would happen):`);
+    for (const w of plan.writes) console.log(`  WRITE ${w.path} (${w.bytes} bytes)`);
+    for (const s of plan.skipped) console.log(`  SKIP  ${s.id}: ${s.reason}`);
+    return 0;
+  }
+  const written = applyPlan(blob, parsed.usbUuid, parsed.passphrase, parsed.persona, parsed.targetRoot);
+  console.log(`zeta-creds-restore: wrote ${written} creds (target-root: ${parsed.targetRoot})`);
+  for (const s of plan.skipped) console.log(`  SKIP ${s.id}: ${s.reason}`);
+  return 0;
+}
+
+if (import.meta.main) {
+  main().then((code) => process.exit(code));
+}


### PR DESCRIPTION
## Summary

Re-land of PR #5422 substrate after parent PR #5421 (B-0852.2a envelope) squash-merged. Rebased onto origin/main; same 2 commits (feat + 14-finding fix-pass), conflict resolved by dropping the now-redundant .2a commit.

## Why a fresh PR instead of force-push

PR #5422 went DIRTY post-#5421 merge (chain-PR rebase requirement). Force-pushing the rebased commits onto #5422 was blocked by auto-mode classifier (destructive remote-history rewrite without explicit operator authorization). The substrate-honest non-destructive alternative is a fresh branch + fresh PR; #5422 will be closed substrate-honestly with cross-link to this PR.

## Changes (same as #5422)

- \`tools/installer/zeta-creds-persist.ts\` — persist CLI; composes crypto + manifest + handlers + envelope
- \`tools/installer/zeta-creds-restore.ts\` — restore CLI; single-decrypt RestorePlan + apply
- \`tools/installer/zeta-creds-persist-restore.test.ts\` — 19 integration tests covering full round-trip + error paths

All 14 Copilot review findings from #5422 already addressed in commit \`2a7371b3d\`:
- P0: CodeQL clear-text-logging fix (omit env-var name from error strings)
- P1: applyPlan double-decrypt eliminated (RestorePlan carries Buffer values)
- 5 error-handling bugs (readFileSync/writeFileSync try/catch wrapping; new exit code 4)
- MIN_BLOB_LEN off-by-one (AES-GCM permits 0-byte ciphertext)
- Doc corrections + unused import removal

## Test plan

- [x] All 36 tests pass (19 persist/restore + 17 envelope)
- [x] Per .claude/rules/agent-worktree-hygiene-never-hold-main-...: isolated worktree at /private/tmp/zeta-b0852-2b-clis-0744Z; never touched operator's primary checkout
- [x] Per .claude/rules/non-coercion-invariant.md HC-8: operator authority over own creds; passphrase NEVER logged
- [x] Per .claude/rules/methodology-hard-limits.md: clinical/security floor stays operative; no live-USB workarounds; substrate batches into next ISO cycle
- [x] Per .claude/rules/classifier-bypass-research-do-not-deploy-without-zeta-safer-floor.md: classifier correctly blocked force-push; non-destructive alternative used instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)