### PR TITLE
feat(B-0852.3a): interactive cred-picker + zeta-install.sh Step 6.94 integration (16 tests; Aaron 2026-05-27 USB push)

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -1015,42 +1015,10 @@ sudo nixos-install \
 cleanup_symlinks
 trap - EXIT
 
-# ── Step 6.94: iter-6.x — B-0852.3a cred-picker (interactive bake-vs-defer at setup time) ──
-# Operator 2026-05-27 framing: "human interactive at setup time" + "ask
-# what declared creds you want to bake in vs go through device flow".
-#
-# Conditional on ZETA_CREDS_PICKER=1 + /etc/zeta/usb-uuid + a passphrase
-# source (env or file). Skipping is the default for backward compat with
-# automated/CI installs; opt-in for operator-driven USB flows.
-#
-# When invoked: reads tools/installer/zeta-creds-manifest.ts DEFAULT_MANIFEST
-# from the pre-cloned Zeta repo (cloned in 6.95a-bootstrap below — so this
-# step runs AFTER repo clone in the operator-invocation order; in practice
-# operator runs picker post-install via interactive shell rather than during
-# automated zeta-install.sh flow).
-#
-# This block documents the integration point + is conditional; default skip.
-if [ -n "${ZETA_CREDS_PICKER:-}" ] && [ "$ZETA_CREDS_PICKER" = "1" ]; then
-  echo "[iter-6.x] ── B-0852.3a cred-picker (operator interactive) ──"
-  if [ -d "$ZETA_HOME/Zeta" ] && [ -f /etc/zeta/usb-uuid ]; then
-    USB_UUID="$(cat /etc/zeta/usb-uuid)"
-    if [ -n "${ZETA_CREDS_PASSPHRASE:-}" ]; then
-      sudo HOME="$ZETA_HOME" -u "#$ZETA_UID" \
-        bash -c "cd $ZETA_HOME/Zeta && ZETA_CREDS_PASSPHRASE='$ZETA_CREDS_PASSPHRASE' \
-          bun tools/installer/zeta-creds-picker.ts \
-            --usb-uuid '$USB_UUID' \
-            --output /esp/zeta-creds.enc \
-            --passphrase-env ZETA_CREDS_PASSPHRASE" || \
-        echo "[iter-6.x]   WARN: picker exited non-zero; cred-blob may be partial"
-    else
-      echo "[iter-6.x]   SKIP picker: ZETA_CREDS_PASSPHRASE not set"
-    fi
-  else
-    echo "[iter-6.x]   SKIP picker: prereq missing ($ZETA_HOME/Zeta exists? /etc/zeta/usb-uuid exists?)"
-  fi
-else
-  echo "[iter-6.x]   SKIP B-0852.3a cred-picker (set ZETA_CREDS_PICKER=1 + ZETA_CREDS_PASSPHRASE + /etc/zeta/usb-uuid to enable)"
-fi
+# ── Step 6.94: B-0852.3a cred-picker stub ───────────────────────────
+# The actual picker invocation lives at Step 6.95-picker (below) which
+# fires AFTER 6.95a-bootstrap clones the repo + installs bun. This
+# header reserves the step number for forward references; no work here.
 
 # ── Step 6.95: iter-5.5.0 — claude-code install + credential persistence (B-0848 Phase 2) ──
 # Aaron 2026-05-27 ask: "wanna make this automatic on boot before i even
@@ -1171,6 +1139,33 @@ if [ -d "$ZETA_HOME" ]; then
   sudo HOME="$ZETA_HOME" BUN_INSTALL="$ZETA_HOME/.bun" -u "#$ZETA_UID" \
     bash -c 'set -o pipefail; eval "$(mise activate bash 2>/dev/null || true)"; bun install --global @openai/codex 2>&1 | tail -5' || \
       echo "[iter-5.5.0]   WARN: bun install codex FAILED — can retry post-reboot via 'bun install --global @openai/codex'"
+
+  # 6.95-picker — B-0852.3a cred-picker (operator interactive at setup time)
+  # Operator 2026-05-27 framing: "human interactive at setup time" + "ask what declared
+  # creds you want to bake in vs go through device flow".
+  #
+  # Runs AFTER 6.95a-bootstrap (repo + bun + mise present) and BEFORE 6.95b-* device-flow
+  # logins so picker decides per-cred bake-vs-defer + the device-flow steps handle the
+  # deferred subset.
+  #
+  # Default: SKIP (backward compat with automated installs). Opt-in via
+  # ZETA_CREDS_PICKER=1 + ZETA_CREDS_PASSPHRASE + /etc/zeta/usb-uuid.
+  #
+  # SECURITY (Copilot review on PR #5450): the passphrase is FORWARDED VIA SUDO
+  # --preserve-env=ZETA_CREDS_PASSPHRASE, NOT inlined in bash -c arg-string (the
+  # latter leaked the literal passphrase into the process arglist visible to ps).
+  # The picker reads it via --passphrase-env which references the env-var-NAME only.
+  if [ -n "${ZETA_CREDS_PICKER:-}" ] && [ "$ZETA_CREDS_PICKER" = "1" ] && \
+     [ -f /etc/zeta/usb-uuid ] && [ -n "${ZETA_CREDS_PASSPHRASE:-}" ]; then
+    USB_UUID="$(cat /etc/zeta/usb-uuid)"
+    echo "[iter-5.5.0] ── 6.95-picker: B-0852.3a cred-picker (operator interactive) ──"
+    sudo --preserve-env=ZETA_CREDS_PASSPHRASE -u "#$ZETA_UID" \
+      HOME="$ZETA_HOME" \
+      bash -c "cd '$ZETA_HOME/Zeta' && bun tools/installer/zeta-creds-picker.ts --usb-uuid '$USB_UUID' --output /esp/zeta-creds.enc --passphrase-env ZETA_CREDS_PASSPHRASE" || \
+        echo "[iter-5.5.0]   WARN: picker exited non-zero; cred-blob may be partial"
+  else
+    echo "[iter-5.5.0]   SKIP 6.95-picker (set ZETA_CREDS_PICKER=1 + ZETA_CREDS_PASSPHRASE + /etc/zeta/usb-uuid to enable)"
+  fi
 
   # 6.95b — interactive claude login (mirror iter-5.4.0 gh auth login)
   CLAUDE_BIN="$ZETA_HOME/.bun/bin/claude"

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -1159,9 +1159,13 @@ if [ -d "$ZETA_HOME" ]; then
      [ -f /etc/zeta/usb-uuid ] && [ -n "${ZETA_CREDS_PASSPHRASE:-}" ]; then
     USB_UUID="$(cat /etc/zeta/usb-uuid)"
     echo "[iter-5.5.0] ── 6.95-picker: B-0852.3a cred-picker (operator interactive) ──"
+    # mise activate inside bash -c matches sibling 6.95a-claude/gemini/codex
+    # patterns at lines 1119-1141; without it, bun is not on the PATH the
+    # subshell sees (mise installs bun via shims; activate sets PATH).
+    # BUN_INSTALL pin matches sibling pattern too.
     sudo --preserve-env=ZETA_CREDS_PASSPHRASE -u "#$ZETA_UID" \
-      HOME="$ZETA_HOME" \
-      bash -c "cd '$ZETA_HOME/Zeta' && bun tools/installer/zeta-creds-picker.ts --usb-uuid '$USB_UUID' --output /esp/zeta-creds.enc --passphrase-env ZETA_CREDS_PASSPHRASE" || \
+      HOME="$ZETA_HOME" BUN_INSTALL="$ZETA_HOME/.bun" \
+      bash -c "set -o pipefail; eval \"\$(mise activate bash 2>/dev/null || true)\"; cd '$ZETA_HOME/Zeta' && bun tools/installer/zeta-creds-picker.ts --usb-uuid '$USB_UUID' --output /esp/zeta-creds.enc --passphrase-env ZETA_CREDS_PASSPHRASE" || \
         echo "[iter-5.5.0]   WARN: picker exited non-zero; cred-blob may be partial"
   else
     echo "[iter-5.5.0]   SKIP 6.95-picker (set ZETA_CREDS_PICKER=1 + ZETA_CREDS_PASSPHRASE + /etc/zeta/usb-uuid to enable)"

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -1015,6 +1015,43 @@ sudo nixos-install \
 cleanup_symlinks
 trap - EXIT
 
+# ── Step 6.94: iter-6.x — B-0852.3a cred-picker (interactive bake-vs-defer at setup time) ──
+# Operator 2026-05-27 framing: "human interactive at setup time" + "ask
+# what declared creds you want to bake in vs go through device flow".
+#
+# Conditional on ZETA_CREDS_PICKER=1 + /etc/zeta/usb-uuid + a passphrase
+# source (env or file). Skipping is the default for backward compat with
+# automated/CI installs; opt-in for operator-driven USB flows.
+#
+# When invoked: reads tools/installer/zeta-creds-manifest.ts DEFAULT_MANIFEST
+# from the pre-cloned Zeta repo (cloned in 6.95a-bootstrap below — so this
+# step runs AFTER repo clone in the operator-invocation order; in practice
+# operator runs picker post-install via interactive shell rather than during
+# automated zeta-install.sh flow).
+#
+# This block documents the integration point + is conditional; default skip.
+if [ -n "${ZETA_CREDS_PICKER:-}" ] && [ "$ZETA_CREDS_PICKER" = "1" ]; then
+  echo "[iter-6.x] ── B-0852.3a cred-picker (operator interactive) ──"
+  if [ -d "$ZETA_HOME/Zeta" ] && [ -f /etc/zeta/usb-uuid ]; then
+    USB_UUID="$(cat /etc/zeta/usb-uuid)"
+    if [ -n "${ZETA_CREDS_PASSPHRASE:-}" ]; then
+      sudo HOME="$ZETA_HOME" -u "#$ZETA_UID" \
+        bash -c "cd $ZETA_HOME/Zeta && ZETA_CREDS_PASSPHRASE='$ZETA_CREDS_PASSPHRASE' \
+          bun tools/installer/zeta-creds-picker.ts \
+            --usb-uuid '$USB_UUID' \
+            --output /esp/zeta-creds.enc \
+            --passphrase-env ZETA_CREDS_PASSPHRASE" || \
+        echo "[iter-6.x]   WARN: picker exited non-zero; cred-blob may be partial"
+    else
+      echo "[iter-6.x]   SKIP picker: ZETA_CREDS_PASSPHRASE not set"
+    fi
+  else
+    echo "[iter-6.x]   SKIP picker: prereq missing ($ZETA_HOME/Zeta exists? /etc/zeta/usb-uuid exists?)"
+  fi
+else
+  echo "[iter-6.x]   SKIP B-0852.3a cred-picker (set ZETA_CREDS_PICKER=1 + ZETA_CREDS_PASSPHRASE + /etc/zeta/usb-uuid to enable)"
+fi
+
 # ── Step 6.95: iter-5.5.0 — claude-code install + credential persistence (B-0848 Phase 2) ──
 # Aaron 2026-05-27 ask: "wanna make this automatic on boot before i even
 # login and have it save my claude code device login like gh, also make

--- a/tools/installer/zeta-creds-picker.test.ts
+++ b/tools/installer/zeta-creds-picker.test.ts
@@ -1,0 +1,154 @@
+// zeta-creds-picker.test.ts — B-0852.3a picker tests.
+//
+// Tests parseArgs (pure) + runPicker (against a mock readline-like interface).
+
+import { describe, expect, it } from "bun:test";
+import { parseArgs, runPicker } from "./zeta-creds-picker";
+
+describe("parseArgs", () => {
+  it("accepts well-formed args with --passphrase-env", () => {
+    const r = parseArgs(["--usb-uuid", "u1", "--output", "/o", "--passphrase-env", "P"]);
+    if ("error" in r) throw new Error(r.error);
+    expect(r.usbUuid).toBe("u1");
+    expect(r.output).toBe("/o");
+    expect(r.passphraseEnv).toBe("P");
+    expect(r.persona).toBe(null);
+    expect(r.dryRun).toBe(false);
+  });
+
+  it("accepts --persona + --dry-run", () => {
+    const r = parseArgs([
+      "--usb-uuid", "u1", "--output", "/o", "--passphrase-file", "/pp",
+      "--persona", "otto", "--dry-run",
+    ]);
+    if ("error" in r) throw new Error(r.error);
+    expect(r.persona).toBe("otto");
+    expect(r.dryRun).toBe(true);
+    expect(r.passphraseFile).toBe("/pp");
+  });
+
+  it("rejects missing --usb-uuid", () => {
+    const r = parseArgs(["--output", "/o", "--passphrase-env", "P"]);
+    expect("error" in r).toBe(true);
+  });
+
+  it("rejects missing --output", () => {
+    const r = parseArgs(["--usb-uuid", "u1", "--passphrase-env", "P"]);
+    expect("error" in r).toBe(true);
+  });
+
+  it("rejects no passphrase source", () => {
+    const r = parseArgs(["--usb-uuid", "u1", "--output", "/o"]);
+    expect("error" in r).toBe(true);
+  });
+
+  it("rejects unknown flag", () => {
+    const r = parseArgs(["--bogus"]);
+    expect("error" in r).toBe(true);
+  });
+});
+
+// Mock readline-like interface for testing runPicker against scripted answers.
+function mockRl(answers: string[]) {
+  let idx = 0;
+  return {
+    question: (_prompt: string) => Promise.resolve(answers[idx++] ?? ""),
+    close: () => {},
+  } as unknown as Parameters<typeof runPicker>[0];
+}
+
+describe("runPicker", () => {
+  it("returns no bake-args when operator defers everything (no persona)", async () => {
+    const rl = mockRl([
+      "d", // gh-cli
+      // claude/gemini/codex auto-skip (persona-scoped + no persona)
+      // ssh-host-keys / ssh-operator-pubkey: prompt depending on handler/scope
+      "d", "d", "d", "d", "d", "d", "d", "d",
+    ]);
+    const args = await runPicker(rl, null);
+    expect(args.length).toBe(0);
+  });
+
+  it("bakes gh-cli with literal value when chosen", async () => {
+    // Skip persona-scoped (no persona); gh-cli is the first global cred.
+    // Answers: bake, literal, value, then defer remaining
+    const rl = mockRl([
+      "b", "l", "ghp_test_value",
+      "d", "d", "d", "d", "d", "d", "d", "d",
+    ]);
+    const args = await runPicker(rl, null);
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    const gh = args.find((a) => a.startsWith("gh-cli="));
+    expect(gh).toBe("gh-cli=ghp_test_value");
+  });
+
+  it("skips empty literal value", async () => {
+    const rl = mockRl([
+      "b", "l", "", // gh-cli bake, literal, EMPTY
+      "d", "d", "d", "d", "d", "d", "d", "d",
+    ]);
+    const args = await runPicker(rl, null);
+    expect(args.find((a) => a.startsWith("gh-cli="))).toBeUndefined();
+  });
+
+  it("uses @file syntax when operator picks file source", async () => {
+    const rl = mockRl([
+      "b", "f", "/tmp/test-file",
+      "d", "d", "d", "d", "d", "d", "d", "d",
+    ]);
+    const args = await runPicker(rl, null);
+    const gh = args.find((a) => a.startsWith("gh-cli="));
+    expect(gh).toBe("gh-cli=@/tmp/test-file");
+  });
+
+  it("uses env: syntax when operator picks env source", async () => {
+    const rl = mockRl([
+      "b", "e", "GH_TOKEN",
+      "d", "d", "d", "d", "d", "d", "d", "d",
+    ]);
+    const args = await runPicker(rl, null);
+    const gh = args.find((a) => a.startsWith("gh-cli="));
+    expect(gh).toBe("gh-cli=env:GH_TOKEN");
+  });
+
+  it("auto-skips persona-scoped creds when no persona", async () => {
+    const rl = mockRl(Array(15).fill("d"));
+    const args = await runPicker(rl, null);
+    // claude/gemini/codex are persona-scoped; auto-skip means NO prompt fired
+    // for them. With persona=null, only the global ones get bake/defer prompts.
+    expect(args.find((a) => a.startsWith("claude="))).toBeUndefined();
+    expect(args.find((a) => a.startsWith("gemini="))).toBeUndefined();
+    expect(args.find((a) => a.startsWith("codex="))).toBeUndefined();
+  });
+
+  it("bakes persona-scoped cred when persona supplied", async () => {
+    // With persona, claude/gemini/codex are baked-capable. Order matches
+    // DEFAULT_MANIFEST iteration.
+    const rl = mockRl([
+      "d", // gh-cli
+      "b", "l", '{"creds":"otto-claude"}', // claude bake literal
+      "d", "d", // gemini, codex
+      "d", "d", "d", "d", "d", "d", // remaining
+    ]);
+    const args = await runPicker(rl, "otto");
+    expect(args.find((a) => a.startsWith("claude="))).toBe('claude={"creds":"otto-claude"}');
+  });
+
+  it("treats empty choice as defer", async () => {
+    const rl = mockRl(Array(15).fill(""));
+    const args = await runPicker(rl, null);
+    expect(args.length).toBe(0);
+  });
+
+  it("treats unrecognized choice as defer", async () => {
+    const rl = mockRl(Array(15).fill("xyz"));
+    const args = await runPicker(rl, null);
+    expect(args.length).toBe(0);
+  });
+
+  it("skip explicit returns no bake", async () => {
+    const rl = mockRl(Array(15).fill("s"));
+    const args = await runPicker(rl, null);
+    expect(args.length).toBe(0);
+  });
+});

--- a/tools/installer/zeta-creds-picker.ts
+++ b/tools/installer/zeta-creds-picker.ts
@@ -199,15 +199,23 @@ async function main(): Promise<number> {
   if (parsed.persona) persistArgs.push("--persona", parsed.persona);
   for (const a of bakeArgs) persistArgs.push("--bake-cred", a);
   if (parsed.dryRun) {
-    // SECURITY: build a redacted display variant that omits the env-var
-    // name (CodeQL clear-text-logging finding — passphraseEnv is tainted
-    // via env-access flow; do NOT echo its literal contents). Sibling
-    // discipline to zeta-creds-persist.ts + zeta-creds-restore.ts P0 fix.
+    // SECURITY: build display string from KNOWN-SAFE pieces only.
+    // Earlier map-based redaction kept persistArgs (tainted) in the
+    // dataflow; CodeQL doesn't recognize runtime ternary as breaking
+    // taint, so it kept flagging. Construct from primitives instead;
+    // NEVER reference parsed.passphraseEnv or parsed.passphraseFile in
+    // the logged string. Sibling discipline to zeta-creds-persist.ts
+    // + zeta-creds-restore.ts P0 fix on PR #5422.
     console.log(`\n=== DRY RUN — would invoke: ===`);
-    const displayArgs = persistArgs.map((v, i) =>
-      i > 0 && persistArgs[i - 1] === "--passphrase-env" ? "<REDACTED>" : v
-    );
-    console.log(`  bun ${displayArgs.join(" ")}`);
+    let displayCmd = `  bun tools/installer/zeta-creds-persist.ts --usb-uuid <set> --output <set>`;
+    if (parsed.passphraseFile) displayCmd += ` --passphrase-file <REDACTED>`;
+    if (parsed.passphraseEnv) displayCmd += ` --passphrase-env <REDACTED>`;
+    if (parsed.persona) displayCmd += ` --persona <set>`;
+    for (const a of bakeArgs) {
+      const id = a.split("=", 1)[0];
+      displayCmd += ` --bake-cred ${id}=<REDACTED>`;
+    }
+    console.log(displayCmd);
     return 0;
   }
   console.log(`\n=== Invoking zeta-creds-persist... ===`);

--- a/tools/installer/zeta-creds-picker.ts
+++ b/tools/installer/zeta-creds-picker.ts
@@ -15,7 +15,7 @@
 //   - tools/installer/zeta-cred-handlers.ts (B-0852.10; per-cred source validation)
 //   - tools/installer/zeta-creds-persist.ts (B-0852.2b; downstream consumer)
 //
-// Usage (called from zeta-install.sh Step 6.77 or operator terminal):
+// Usage (called from zeta-install.sh Step 6.95-picker or operator terminal):
 //   bun tools/installer/zeta-creds-picker.ts \
 //     --usb-uuid <uuid> \
 //     --output /esp/zeta-creds.enc \
@@ -156,7 +156,12 @@ export async function runPicker(
       continue;
     }
     bakeArgs.push(`${cred.id}=${valueSpec}`);
-    console.log(`   → baked (source: ${valueSpec.startsWith("@") ? "@file" : valueSpec.startsWith("env:") ? "env" : "literal"})`);
+    // SECURITY: source label computed from operator's choice letter, NOT
+    // from valueSpec (which contains the actual value/path/var-name).
+    // Avoids any chance of the value/path/var-name reaching console output
+    // through ternary-on-valueSpec inspection.
+    const sourceLabel = sourceChoice.startsWith("l") ? "literal" : sourceChoice.startsWith("f") ? "@file" : "env";
+    console.log(`   → baked (source: ${sourceLabel})`);
   }
   return bakeArgs;
 }
@@ -194,11 +199,19 @@ async function main(): Promise<number> {
   if (parsed.persona) persistArgs.push("--persona", parsed.persona);
   for (const a of bakeArgs) persistArgs.push("--bake-cred", a);
   if (parsed.dryRun) {
+    // SECURITY: build a redacted display variant that omits the env-var
+    // name (CodeQL clear-text-logging finding — passphraseEnv is tainted
+    // via env-access flow; do NOT echo its literal contents). Sibling
+    // discipline to zeta-creds-persist.ts + zeta-creds-restore.ts P0 fix.
     console.log(`\n=== DRY RUN — would invoke: ===`);
-    console.log(`  bun ${persistArgs.join(" ")}`);
+    const displayArgs = persistArgs.map((v, i) =>
+      i > 0 && persistArgs[i - 1] === "--passphrase-env" ? "<REDACTED>" : v
+    );
+    console.log(`  bun ${displayArgs.join(" ")}`);
     return 0;
   }
   console.log(`\n=== Invoking zeta-creds-persist... ===`);
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
   const result = spawnSync("bun", persistArgs, { stdio: "inherit" });
   if (result.status !== 0) {
     console.error(`zeta-creds-picker: persist failed (exit ${result.status})`);

--- a/tools/installer/zeta-creds-picker.ts
+++ b/tools/installer/zeta-creds-picker.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env bun
+// zeta-creds-picker.ts — interactive picker at install/setup time.
+//
+// B-0852.3a (operator 2026-05-27 device-flow-at-setup framing).
+//
+// For each cred in DEFAULT_MANIFEST, prompts operator:
+//   [b]ake-in now / [d]efer to device-flow at runtime / [s]kip
+// For bake-in: sub-prompts for value-source (literal / @file / env:VAR)
+// per the per-cred handler's supportedSources.
+//
+// Then invokes zeta-creds-persist with the collected --bake-cred args.
+//
+// Composes:
+//   - tools/installer/zeta-creds-manifest.ts (B-0852.5; iteration source)
+//   - tools/installer/zeta-cred-handlers.ts (B-0852.10; per-cred source validation)
+//   - tools/installer/zeta-creds-persist.ts (B-0852.2b; downstream consumer)
+//
+// Usage (called from zeta-install.sh Step 6.77 or operator terminal):
+//   bun tools/installer/zeta-creds-picker.ts \
+//     --usb-uuid <uuid> \
+//     --output /esp/zeta-creds.enc \
+//     ( --passphrase-file <path> | --passphrase-env <VAR> ) \
+//     [--persona <name>] \
+//     [--dry-run]  (print persist invocation; don't exec)
+//
+// Per .claude/rules/non-coercion-invariant.md HC-8: operator authority over
+// own creds; no default-bake (operator must explicitly pick bake for each);
+// passphrase NEVER logged; declined creds defer to device-flow at runtime.
+//
+// Exit codes:
+//   0 success
+//   2 arg parse error
+//   3 picker abort (operator Ctrl+C)
+//   4 persist invocation failure
+
+import { spawnSync } from "node:child_process";
+import { createInterface } from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+import { DEFAULT_MANIFEST } from "./zeta-creds-manifest";
+import { DEFAULT_HANDLERS } from "./zeta-cred-handlers";
+
+interface PickerArgs {
+  readonly usbUuid: string;
+  readonly output: string;
+  readonly passphraseFile: string | null;
+  readonly passphraseEnv: string | null;
+  readonly persona: string | null;
+  readonly dryRun: boolean;
+}
+
+export function parseArgs(argv: readonly string[]): PickerArgs | { readonly error: string } {
+  let usbUuid: string | null = null;
+  let output: string | null = null;
+  let passphraseFile: string | null = null;
+  let passphraseEnv: string | null = null;
+  let persona: string | null = null;
+  let dryRun = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    const next = (): string => {
+      if (i + 1 >= argv.length) throw new Error(`${arg} requires a value`);
+      return argv[++i]!;
+    };
+    try {
+      if (arg === "--usb-uuid") usbUuid = next();
+      else if (arg === "--output") output = next();
+      else if (arg === "--passphrase-file") passphraseFile = next();
+      else if (arg === "--passphrase-env") passphraseEnv = next();
+      else if (arg === "--persona") persona = next();
+      else if (arg === "--dry-run") dryRun = true;
+      else return { error: `unknown flag: ${arg}` };
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+  if (!usbUuid) return { error: "--usb-uuid required" };
+  if (!output) return { error: "--output required" };
+  if (!passphraseFile && !passphraseEnv) {
+    return { error: "passphrase source required: --passphrase-file <path> or --passphrase-env <VAR>" };
+  }
+  return { usbUuid, output, passphraseFile, passphraseEnv, persona, dryRun };
+}
+
+/**
+ * Prompt operator per-cred and return the --bake-cred args list.
+ * Pure function over a readline interface (testable with mock).
+ */
+export async function runPicker(
+  rl: ReturnType<typeof createInterface>,
+  persona: string | null,
+): Promise<string[]> {
+  const bakeArgs: string[] = [];
+  console.log("\n=== Credential picker (B-0852.3a setup-time integration) ===");
+  console.log("For each declared credential: bake-in NOW, defer to device-flow at runtime, or skip.");
+  if (persona) console.log(`Persona: ${persona} (persona-scoped creds will use this slot).\n`);
+  else console.log("No --persona; only global creds will accept bake.\n");
+
+  for (const cred of DEFAULT_MANIFEST.credentials) {
+    const handler = DEFAULT_HANDLERS[cred.id];
+    if (!handler) {
+      console.log(`-- ${cred.id}: no handler registered; skipping`);
+      continue;
+    }
+    if (cred.personaScoped && !persona) {
+      console.log(`-- ${cred.id}: persona-scoped + no --persona given; auto-skip`);
+      continue;
+    }
+    console.log(`\n-- ${cred.id} (${cred.personaScoped ? "persona-scoped" : "global"}; ${cred.required ? "required" : "optional"})`);
+    if (cred.notes) console.log(`   ${cred.notes}`);
+    console.log(`   paths: ${cred.paths.join(", ")}`);
+    if (handler.supportedSources.length === 0) {
+      console.log(`   handler has NO supported sources (Phase 1 deferred); auto-defer`);
+      continue;
+    }
+    console.log(`   supported sources: ${handler.supportedSources.join(", ")}`);
+    const choice = (await rl.question("   [b]ake-in / [d]efer to device-flow / [s]kip? ")).toLowerCase().trim();
+    if (choice === "s" || choice === "skip") {
+      console.log(`   → skip`);
+      continue;
+    }
+    if (choice === "d" || choice === "defer" || choice === "") {
+      console.log(`   → defer (device-flow at runtime)`);
+      continue;
+    }
+    if (choice !== "b" && choice !== "bake") {
+      console.log(`   → unrecognized "${choice}"; treating as defer`);
+      continue;
+    }
+    const sources = handler.supportedSources;
+    const sourceHint = sources.map((s) => `[${s[0]}]${s.slice(1)}`).join(" / ");
+    const sourceChoice = (await rl.question(`   source ${sourceHint}? `)).toLowerCase().trim();
+    let valueSpec: string;
+    if (sourceChoice.startsWith("l") && sources.includes("literal")) {
+      const v = await rl.question(`   literal value (will NOT be logged): `);
+      if (v.length === 0) {
+        console.log(`   → empty value; skip`);
+        continue;
+      }
+      valueSpec = v;
+    } else if (sourceChoice.startsWith("f") && sources.includes("file")) {
+      const p = await rl.question(`   file path: `);
+      if (p.length === 0) {
+        console.log(`   → empty path; skip`);
+        continue;
+      }
+      valueSpec = `@${p}`;
+    } else if (sourceChoice.startsWith("e") && sources.includes("env")) {
+      const v = await rl.question(`   env var name: `);
+      if (v.length === 0) {
+        console.log(`   → empty env var name; skip`);
+        continue;
+      }
+      valueSpec = `env:${v}`;
+    } else {
+      console.log(`   → unrecognized or unsupported source; skip`);
+      continue;
+    }
+    bakeArgs.push(`${cred.id}=${valueSpec}`);
+    console.log(`   → baked (source: ${valueSpec.startsWith("@") ? "@file" : valueSpec.startsWith("env:") ? "env" : "literal"})`);
+  }
+  return bakeArgs;
+}
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2);
+  const parsed = parseArgs(argv);
+  if ("error" in parsed) {
+    console.error(`zeta-creds-picker: ${parsed.error}`);
+    return 2;
+  }
+  const rl = createInterface({ input, output });
+  let bakeArgs: string[] = [];
+  try {
+    bakeArgs = await runPicker(rl, parsed.persona);
+  } catch (err) {
+    rl.close();
+    console.error(`zeta-creds-picker: aborted: ${err instanceof Error ? err.message : String(err)}`);
+    return 3;
+  } finally {
+    rl.close();
+  }
+  console.log(`\n=== Picker complete: ${bakeArgs.length} cred(s) selected for bake-in ===`);
+  for (const a of bakeArgs) {
+    const id = a.split("=", 1)[0];
+    console.log(`  --bake-cred ${id}=<redacted>`);
+  }
+  const persistArgs = [
+    "tools/installer/zeta-creds-persist.ts",
+    "--usb-uuid", parsed.usbUuid,
+    "--output", parsed.output,
+  ];
+  if (parsed.passphraseFile) persistArgs.push("--passphrase-file", parsed.passphraseFile);
+  if (parsed.passphraseEnv) persistArgs.push("--passphrase-env", parsed.passphraseEnv);
+  if (parsed.persona) persistArgs.push("--persona", parsed.persona);
+  for (const a of bakeArgs) persistArgs.push("--bake-cred", a);
+  if (parsed.dryRun) {
+    console.log(`\n=== DRY RUN — would invoke: ===`);
+    console.log(`  bun ${persistArgs.join(" ")}`);
+    return 0;
+  }
+  console.log(`\n=== Invoking zeta-creds-persist... ===`);
+  const result = spawnSync("bun", persistArgs, { stdio: "inherit" });
+  if (result.status !== 0) {
+    console.error(`zeta-creds-picker: persist failed (exit ${result.status})`);
+    return 4;
+  }
+  return 0;
+}
+
+if (import.meta.main) {
+  main().then((code) => process.exit(code));
+}


### PR DESCRIPTION
## Summary

End-to-end cred-persistence stack now usable on USB:

- New \`tools/installer/zeta-creds-picker.ts\` — interactive picker per cred (bake/defer/skip + literal/file/env source)
- 16 unit tests passing (parseArgs + runPicker against mock readline)
- zeta-install.sh Step 6.94 invokes picker conditional on \`ZETA_CREDS_PICKER=1 + ZETA_CREDS_PASSPHRASE + /etc/zeta/usb-uuid\`
- Picker invokes B-0852.2b persist CLI with collected --bake-cred args

Operator USB-push direction: \"lets keep pushing forward and get cred persistance any anthing else we can make it in before i test again\".

## What unblocks on USB

Operator reflashes USB → boots → runs installer with picker env vars set → bakes desired creds via interactive prompt → reboot → /esp/zeta-creds.enc written. B-0852.4 NixOS module (boot-time restore) is the next sub-row.

## Test plan

- [x] All 16 unit tests pass (\`bun test tools/installer/zeta-creds-picker.test.ts\`)
- [x] bash -n syntax check on zeta-install.sh
- [x] tsc clean
- [x] Per .claude/rules/agent-worktree-hygiene-never-hold-main-...: isolated worktree; operator's primary checkout untouched
- [x] Per .claude/rules/non-coercion-invariant.md HC-8: operator authority preserved; no default-bake; passphrase never logged; literal values redacted at display

## AgencySignature

Commit message includes full v1 trailer block per the convention the operator pointed at 2026-05-27 (\`tools/hygiene/audit-agencysignature-main-tip.ts\` + spec in \`docs/research/2026-04-26-gemini-deep-think-...md\`). Heartbeat-via-commit closes the brief-ack counter externalization Kira flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)