### PR TITLE
fix: require executable gcc path in Docker harness

### DIFF
--- a/tools/ci/dockerfiles/nixos-install-sh-test/Dockerfile
+++ b/tools/ci/dockerfiles/nixos-install-sh-test/Dockerfile
@@ -73,7 +73,7 @@ RUN set -eu; \
     nixpkgs.glibc; \
     mkdir -p /usr/local/bin; \
     cc_path="$(command -v gcc)"; \
-    test -n "$cc_path"; \
+    test -x "$cc_path"; \
     ln -sf "$cc_path" /usr/local/bin/cc; \
     mkdir -p /usr/local/nix-compat-lib; \
     for lib in \


### PR DESCRIPTION
## Summary
- tighten the Docker NixOS install-sh harness gcc path guard from non-empty to executable
- keep the existing command -v lookup while failing earlier if PATH resolves a non-executable gcc path

## Checks
- git diff --check origin/main...HEAD
- codex loop health: ok, no lock before push

Co-Authored-By: Codex <noreply@openai.com>