### PR TITLE
feat(B-0852.4a+4d): NixOS module zeta-creds-restore.nix + wire into cluster common.nix imports — last gate for end-to-end USB cred-persistence test (Aaron 2026-05-27 USB priority)

### DIFF
--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -35,6 +35,14 @@
     # ships the TS implementation; imported here so every node type
     # has the same module surface.
     ./zeta-self-register.nix
+    # B-0852.4a/d: boot-time credential restore from ESP. Disabled by
+    # default until host configs opt in via `zeta.credsRestore.enable = true;`
+    # AND operator pre-stages a passphrase source. Composes with B-0855.1
+    # zeta-self-register (which already declares
+    # `after = "zeta-creds-restore.service"`) so cred-restore fires before
+    # self-register on first boot. Imported here so every node type has
+    # the same module surface.
+    ./zeta-creds-restore.nix
   ];
 
   nix.settings = {

--- a/full-ai-cluster/nixos/modules/zeta-creds-restore.nix
+++ b/full-ai-cluster/nixos/modules/zeta-creds-restore.nix
@@ -133,7 +133,23 @@ in
         ExecStart = pkgs.writeShellScript "zeta-creds-restore-start" ''
           set -euo pipefail
 
-          USB_UUID="$(cat ${cfg.usbUuidPath})"
+          # Cleanup in EXIT trap (not ExecStopPost): Type=oneshot +
+          # RemainAfterExit=true keeps the unit in active state after
+          # ExecStart returns, so ExecStopPost doesn't fire on normal
+          # successful boot (Copilot P0 finding on PR #5476). Trap
+          # fires on ANY exit path — success or failure.
+          cleanup() {
+            rm -f /run/zeta-creds-passphrase-temp
+            ${lib.optionalString (cfg.passphraseMode == "file") ''
+              # File-mode: also delete the operator-staged passphrase
+              rm -f ${cfg.passphraseFile}
+            ''}
+          }
+          trap cleanup EXIT
+
+          # Strip whitespace from UUID (Copilot P1 finding): `cat`
+          # includes trailing newline if file ends with one.
+          USB_UUID="$(tr -d '[:space:]' < ${cfg.usbUuidPath})"
           if [ -z "$USB_UUID" ]; then
             echo "zeta-creds-restore: empty USB UUID at ${cfg.usbUuidPath}; aborting"
             exit 1
@@ -148,7 +164,7 @@ in
               fi
             '' else ''
               # interactive mode: prompt operator via systemd-ask-password
-              # Write to temp file (zeta-readable) so restore CLI can consume
+              # Write to temp file (root-readable) so restore CLI can consume
               PASSPHRASE_PATH="/run/zeta-creds-passphrase-temp"
               PASSPHRASE="$(${pkgs.systemd}/bin/systemd-ask-password \
                 --timeout=300 \
@@ -160,7 +176,6 @@ in
               umask 0177
               echo -n "$PASSPHRASE" > "$PASSPHRASE_PATH"
               chmod 0400 "$PASSPHRASE_PATH"
-              chown ${cfg.user}:${cfg.group} "$PASSPHRASE_PATH"
               unset PASSPHRASE
             ''
           }
@@ -170,22 +185,26 @@ in
             PERSONA_ARGS="--persona ${cfg.persona}"
           ''}
 
-          sudo -u ${cfg.user} \
-            HOME="${cfg.home}" \
-            ${bunShimPath} ${cfg.scriptPath} \
-              --usb-uuid "$USB_UUID" \
-              --input ${cfg.blobPath} \
-              --passphrase-file "$PASSPHRASE_PATH" \
-              --target-root / \
-              $PERSONA_ARGS
-        '';
-        ExecStopPost = pkgs.writeShellScript "zeta-creds-restore-cleanup" ''
-          # Always clean up passphrase files on stop (success OR failure)
-          rm -f /run/zeta-creds-passphrase-temp
-          ${lib.optionalString (cfg.passphraseMode == "file") ''
-            # File-mode: also delete the operator-staged passphrase
-            rm -f ${cfg.passphraseFile}
-          ''}
+          # Run as ROOT (Copilot P0 finding): the default cred manifest
+          # includes /etc/* paths (operator-authorized-keys, ssh_host_*)
+          # that only root can write. Post-restore chown step fixes
+          # ownership for ${cfg.home} paths so user-facing creds end
+          # up zeta-owned not root-owned.
+          ${bunShimPath} ${cfg.scriptPath} \
+            --usb-uuid "$USB_UUID" \
+            --input ${cfg.blobPath} \
+            --passphrase-file "$PASSPHRASE_PATH" \
+            --target-root / \
+            $PERSONA_ARGS
+
+          # Post-restore ownership fix: chown ${cfg.home} entries that
+          # the manifest writes into (~/.config/gh, ~/.config/claude,
+          # ~/.gemini, ~/.codex, etc.) so the zeta user can read them.
+          # Only chown files OWNED BY ROOT (operator's pre-existing
+          # configs stay untouched).
+          if [ -d "${cfg.home}" ]; then
+            find "${cfg.home}" -maxdepth 4 -user root -exec chown ${cfg.user}:${cfg.group} {} + 2>/dev/null || true
+          fi
         '';
         Restart = "on-failure";
         RestartSec = "30s";

--- a/full-ai-cluster/nixos/modules/zeta-creds-restore.nix
+++ b/full-ai-cluster/nixos/modules/zeta-creds-restore.nix
@@ -1,0 +1,195 @@
+# full-ai-cluster/nixos/modules/zeta-creds-restore.nix
+#
+# B-0852.4a: NixOS service surface for boot-time credential restore from
+# ESP. Consumes the encrypted blob written at install-time by the
+# B-0852.3a picker (PR #5450); decrypts via the B-0852.2b restore CLI
+# (PR #5425) using the USB UUID and operator passphrase; populates
+# per-cred paths on the installed system before user-facing services
+# (e.g., zeta-self-register.service) start.
+#
+# The service is intentionally disabled by default until a host config
+# enables it AND a passphrase source is provided. Ordering: fires
+# AFTER local-fs.target (ESP mounted), BEFORE zeta-self-register.service
+# (which already declares `After = "zeta-creds-restore.service"` per
+# B-0855.1 module).
+#
+# Two passphrase modes:
+#   - file (default; simpler; suitable for automated installs):
+#       Reads /run/zeta-creds-passphrase (operator pre-stages this).
+#       File is deleted on service stop.
+#   - interactive (operator-driven first boot; nicer UX):
+#       Uses systemd-ask-password on tty1 at boot. Operator types
+#       passphrase. (Implementation note: this mode currently writes
+#       a temporary file with the entered passphrase; B-0852.4b
+#       follow-on row may switch to stdin pipe to restore CLI for
+#       tighter handling.)
+#
+# Per .claude/rules/non-coercion-invariant.md HC-8: operator authority
+# over own creds; passphrase NEVER logged; required-cred restore
+# failure surfaces (RestartSec retry) rather than silently degrading.
+# Optional creds: the restore CLI itself reports skipped/error per
+# cred; this module doesn't second-guess that policy.
+
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.zeta.credsRestore;
+  bunShimPath = "${cfg.home}/.local/share/mise/shims/bun";
+in
+{
+  options.zeta.credsRestore = {
+    enable = lib.mkEnableOption "Zeta boot-time credential restore from ESP";
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "zeta";
+      description = "User that owns restored credential files.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "users";
+      description = "Primary group for restored credential files.";
+    };
+
+    home = lib.mkOption {
+      type = lib.types.str;
+      default = "/home/zeta";
+      description = "Home directory of the zeta user.";
+    };
+
+    repoRoot = lib.mkOption {
+      type = lib.types.str;
+      default = "${cfg.home}/Zeta";
+      description = "Path to the checked-out Zeta repository on the installed node.";
+    };
+
+    scriptPath = lib.mkOption {
+      type = lib.types.str;
+      default = "${cfg.repoRoot}/tools/installer/zeta-creds-restore.ts";
+      description = "Bun TypeScript entrypoint for restore CLI (B-0852.2b).";
+    };
+
+    blobPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/esp/zeta-creds.enc";
+      description = "Path to encrypted cred-blob written by picker (B-0852.3a) at install time.";
+    };
+
+    usbUuidPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/zeta/usb-uuid";
+      description = "Path to file containing the USB UUID used as KDF binding (iter-4.2 ESP write).";
+    };
+
+    passphraseMode = lib.mkOption {
+      type = lib.types.enum [ "file" "interactive" ];
+      default = "file";
+      description = "How to obtain the passphrase: file (pre-staged at /run) or interactive (systemd-ask-password).";
+    };
+
+    passphraseFile = lib.mkOption {
+      type = lib.types.str;
+      default = "/run/zeta-creds-passphrase";
+      description = "When passphraseMode=file: read passphrase from this path (deleted on stop).";
+    };
+
+    persona = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Optional persona name; when set, restores persona-scoped credentials for that persona.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.zeta-creds-restore = {
+      description = "Zeta credential restore from ESP at boot (B-0852.4a)";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "local-fs.target" ];
+      after = [
+        "local-fs.target"
+      ];
+      # B-0855.1 zeta-self-register.service declares
+      # `after = "zeta-creds-restore.service"`; ordering enforced there.
+
+      unitConfig = {
+        ConditionPathExists = [
+          cfg.blobPath
+          cfg.usbUuidPath
+          cfg.scriptPath
+          bunShimPath
+        ];
+      };
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = "root";  # needs root to read /run passphrase + drop to zeta user via sudo
+        WorkingDirectory = cfg.repoRoot;
+        Environment = [
+          "HOME=${cfg.home}"
+          "PATH=${cfg.home}/.local/share/mise/shims:${cfg.home}/.bun/bin:/run/current-system/sw/bin:/usr/bin:/bin"
+        ];
+        ExecStart = pkgs.writeShellScript "zeta-creds-restore-start" ''
+          set -euo pipefail
+
+          USB_UUID="$(cat ${cfg.usbUuidPath})"
+          if [ -z "$USB_UUID" ]; then
+            echo "zeta-creds-restore: empty USB UUID at ${cfg.usbUuidPath}; aborting"
+            exit 1
+          fi
+
+          ${
+            if cfg.passphraseMode == "file" then ''
+              PASSPHRASE_PATH="${cfg.passphraseFile}"
+              if [ ! -f "$PASSPHRASE_PATH" ]; then
+                echo "zeta-creds-restore: passphrase file $PASSPHRASE_PATH missing (passphraseMode=file)"
+                exit 1
+              fi
+            '' else ''
+              # interactive mode: prompt operator via systemd-ask-password
+              # Write to temp file (zeta-readable) so restore CLI can consume
+              PASSPHRASE_PATH="/run/zeta-creds-passphrase-temp"
+              PASSPHRASE="$(${pkgs.systemd}/bin/systemd-ask-password \
+                --timeout=300 \
+                "Zeta cred-blob passphrase: ")"
+              if [ -z "$PASSPHRASE" ]; then
+                echo "zeta-creds-restore: empty passphrase from systemd-ask-password"
+                exit 1
+              fi
+              umask 0177
+              echo -n "$PASSPHRASE" > "$PASSPHRASE_PATH"
+              chmod 0400 "$PASSPHRASE_PATH"
+              chown ${cfg.user}:${cfg.group} "$PASSPHRASE_PATH"
+              unset PASSPHRASE
+            ''
+          }
+
+          PERSONA_ARGS=""
+          ${lib.optionalString (cfg.persona != null) ''
+            PERSONA_ARGS="--persona ${cfg.persona}"
+          ''}
+
+          sudo -u ${cfg.user} \
+            HOME="${cfg.home}" \
+            ${bunShimPath} ${cfg.scriptPath} \
+              --usb-uuid "$USB_UUID" \
+              --input ${cfg.blobPath} \
+              --passphrase-file "$PASSPHRASE_PATH" \
+              --target-root / \
+              $PERSONA_ARGS
+        '';
+        ExecStopPost = pkgs.writeShellScript "zeta-creds-restore-cleanup" ''
+          # Always clean up passphrase files on stop (success OR failure)
+          rm -f /run/zeta-creds-passphrase-temp
+          ${lib.optionalString (cfg.passphraseMode == "file") ''
+            # File-mode: also delete the operator-staged passphrase
+            rm -f ${cfg.passphraseFile}
+          ''}
+        '';
+        Restart = "on-failure";
+        RestartSec = "30s";
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Two commits bundled — the NixOS module + the common.nix import — together completing the end-to-end USB cred-persistence chain.

**Commit 1 (B-0852.4a)**: \`full-ai-cluster/nixos/modules/zeta-creds-restore.nix\` — systemd service \`zeta-creds-restore.service\` that decrypts \`/esp/zeta-creds.enc\` at boot (via B-0852.2b restore CLI), populates per-cred files, fires before B-0855.1 \`zeta-self-register.service\`. Two passphrase modes (file / interactive); disabled by default; opt-in per host config.

**Commit 2 (B-0852.4d)**: adds \`./zeta-creds-restore.nix\` to \`full-ai-cluster/nixos/modules/common.nix\` imports list right after \`./zeta-self-register.nix\` — every cluster node now inherits the module surface; per-host opt-in via \`zeta.credsRestore.enable = true;\`.

## End-to-end USB test path now complete

1. Reflash USB with ISO carrying these changes
2. Boot, run installer with ZETA_CREDS_PICKER=1 + ZETA_CREDS_PASSPHRASE=...
3. Step 6.95-picker writes \`/esp/zeta-creds.enc\` (B-0852.3a, PR #5450 in flight)
4. Operator enables \`zeta.credsRestore.enable = true;\` in host config + pre-stages \`/run/zeta-creds-passphrase\`
5. Reboot → \`zeta-creds-restore.service\` fires → blob decrypted → per-cred files populated
6. \`zeta-self-register.service\` fires next per B-0855.1 ordering

## Test plan

- [x] \`nix-instantiate --parse\` on both files → PARSE OK
- [x] Module disabled by default (opt-in via host config)
- [x] AgencySignature v1 trailers on both commits
- [x] Per .claude/rules/agent-worktree-hygiene-...: isolated worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)