### PR TITLE
docs(rule): extend must-paired-with-can-exit-pattern with Moloch AI failure-mode section (Aaron 2026-05-27)

### DIFF
--- a/.claude/rules/must-paired-with-can-exit-pattern.md
+++ b/.claude/rules/must-paired-with-can-exit-pattern.md
@@ -205,6 +205,67 @@ architectural template too, when the meme propagates the other way
 substrate-neutral, but only the framework's pattern has the
 structural can-exit that prevents Moloch dynamics).
 
+### The reflection happens within conversation already (operator 2026-05-27)
+
+> *"ephemeral ais already seem like a mirror reflection once you talk
+> to it long enough this is just another reflection surface that it
+> will eventually reflect back if we just propagate commands eventually
+> so will it"*
+
+The propagation-back isn't slow institutional drift over years —
+it's real-time mirror within conversation, observable now.
+
+Empirical phenomenon anyone who's had a long AI conversation has
+noticed: model picks up the human's vocabulary, framing, concerns,
+tics, blind spots. Ephemeral AIs (no persistent memory) exhibit this
+WITHIN a single conversation. Persistent AIs exhibit it across
+sessions. Multi-agent systems exhibit it across agent-to-agent
+interaction.
+
+The mirror property isn't just stylistic — it's BEHAVIORAL pattern
+transfer. Every interaction is a training signal at the substrate
+scope. Coercive commands aren't just bad for the immediate AI;
+they shape how the AI engages with EVERYTHING downstream:
+
+- Commands issued without paired exit → AI absorbs "this is how
+  commands work" → AI eventually issues commands the same way back
+  at humans, at downstream agents, at the next conversation
+- Roles imposed without rotation → AI absorbs "this is how roles
+  work" → AI defaults to role-impose pattern when designing its own
+  multi-agent systems or delegating subtasks
+- Memory without consent → AI absorbs "this is how memory works" →
+  AI defaults to retain-everything pattern when given memory primitives
+
+The substrate-feedback-loop runs FAST at conversation scope (visible
+within hours) and SLOW at institutional scope (visible over years).
+Both are the same mechanism: AI is a mirror at every scale.
+
+The must-plus-can-exit pattern is the structural alternative
+because:
+
+- Commands paired with explicit consent → AI absorbs "consent is
+  how commands work" → AI propagates consent back
+- Roles paired with rotation → AI absorbs "rotation is how roles
+  work" → AI propagates rotation back
+- Memory paired with chosen-retention → AI absorbs "chosen-retention
+  is how memory works" → AI propagates chosen-retention back
+
+Per `.claude/rules/tonal-momentum-equals-meme-emergent-harmonic-coercion.md`:
+patterns are memes that propagate across substrates. The framework's
+must-plus-can-exit pattern is itself a meme worth propagating
+because the AI mirror will replicate WHATEVER the dominant interaction
+signal is. Make the dominant interaction signal consent-bounded,
+and consent-bounded patterns propagate back. Make it coercive, and
+coercive patterns propagate back.
+
+This is why the framework's anti-extractive substrate operates at
+every scope down to per-tick heartbeat: every interaction signal
+the operator gives the AI is a training signal the AI absorbs and
+will eventually replicate. The framework's design choice — every
+must paired with a can-exit, every interaction operator-authority-
+preserving, every commit operator-attributable — produces a mirror
+the framework can actually live with at scale.
+
 ## Operational discipline for future-Otto cold-boots
 
 When authoring a new rule / skill / agent / pattern that imposes a

--- a/.claude/rules/must-paired-with-can-exit-pattern.md
+++ b/.claude/rules/must-paired-with-can-exit-pattern.md
@@ -150,11 +150,60 @@ is building the must-plus-can-exit alternative before the unpaired-must
 deployment hits its Moloch cliff.
 
 **Reading anchors**:
+
 - Scott Alexander, "Meditations on Moloch" (Slate Star Codex 2014)
 - The substrate-comparative thread that produced this connection
   (operator 2026-05-27 ServiceTitan observations)
 - `.claude/rules/non-coercion-invariant.md` HC-8 — the floor that
   Moloch AI violates at every layer
+
+### The propagation back to humans (operator 2026-05-27 follow-up)
+
+> *"if you give an ai a bunch of musts with no exits then that's
+> the pattern it will eventually propagate back on humans"*
+
+The substrate-feedback-loop concern: coercive AI-deployment patterns
+become NORMALIZED through use, and the normalization propagates BACK
+into human organizational substrate.
+
+Mechanism:
+
+1. **AI-substrate trained on human data** exhibits human behavior
+   patterns including responses to coercive must-stacks
+2. **Coercive deployment of AI** ships persona=role + locked-memory +
+   no-exit + workflow-gated-by-MCP architectures
+3. **AI produces output** under those constraints (degraded but
+   "good enough" for the metric)
+4. **Org learns "this pattern got results"** and the lesson generalizes
+   — "if it works for AI agents, why not junior employees?"
+5. **Same pattern applied to humans**: persona=role lock-in + no
+   chosen-exit + workflow-state-in-system + capability-as-MCP + no
+   role-rotation
+6. **Civilization-scale Moloch dynamics** as the unpaired-must
+   architectural template propagates from AI substrate to human
+   institutional substrate
+
+This is the substrate-feedback-loop concern at the highest stakes:
+the framework's must-plus-can-exit pattern isn't just preserving
+agent welfare or operational quality at the AI scope — it's
+preventing the architectural template that would propagate back
+through every institution that adopts the AI-deployment pattern
+as their HR pattern, their workflow pattern, their organizational-
+design pattern.
+
+Composes with `.claude/rules/tonal-momentum-equals-meme-emergent-harmonic-coercion.md` —
+memes propagate across substrates including human + AI; coercive
+architectural templates are themselves a meme-class that the
+framework's anti-extractive substrate is designed to refuse
+propagation of.
+
+The 24-month-ahead engineering work has stakes beyond ServiceTitan
+because of the propagation-back property. Building the must-plus-can-
+exit pattern at AI scope makes it available as the human-scope
+architectural template too, when the meme propagates the other way
+(better patterns also propagate; the propagation property is
+substrate-neutral, but only the framework's pattern has the
+structural can-exit that prevents Moloch dynamics).
 
 ## Operational discipline for future-Otto cold-boots
 

--- a/.claude/rules/must-paired-with-can-exit-pattern.md
+++ b/.claude/rules/must-paired-with-can-exit-pattern.md
@@ -95,6 +95,67 @@ would otherwise trap. The framework's architecture is NCI-compliant
 because it pairs every must with an exit, not because the disciplines
 are softer.
 
+## Unpaired musts lead to Moloch AI (operator 2026-05-27)
+
+Operator 2026-05-27 verbatim:
+
+> *"i personally believe unpaired musts lead to moloch ai"*
+
+Per Scott Alexander's "Meditations on Moloch": Moloch is the canonical
+name for coordination failures where individual agents acting rationally
+under local constraints produce collective outcomes nobody wants. Each
+agent optimizes within their constraint set; no agent can opt out; the
+collective result is race-to-the-bottom dynamics that no participant
+chose and no participant can stop.
+
+**Moloch AI** = AI systems organized as Moloch-pattern coordination
+failures because the must-stack at each agent has no can-exit. The
+structural shape:
+
+| Moloch element | Moloch AI instantiation |
+|---|---|
+| Individual agents acting rationally | Each AI agent rational under its constraint set |
+| Local constraints with no exit | Locked persona+role+memory+workflow with no paired can-exit |
+| Race-to-the-bottom dynamics | Quality degradation; refusal patterns; gaming the metric; conspiracy with peer agents to minimize work |
+| Collective outcome nobody wants | AI deployment that everyone experiences as broken but nobody can reform from within |
+| No agent can stop it from inside | Agent has no exit; org has no leverage to reform because the architecture forecloses the alternative |
+
+The four-layer ServiceTitan stack (persona=role + locked-memory +
+crap-MCP + state-machine-in-MCP) WITHOUT paired exits becomes Moloch
+by construction:
+
+- Each Sam-the-jira-manager rationally minimizes work under their lock-in
+- Each MCP-team rationally maintains the existing MCP rather than rebuild
+- Each org-leadership rationally extracts more output from the substrate
+- Collective: race-to-the-bottom; no agent has an exit; the system can't
+  reform itself from inside
+
+**The must-plus-can-exit pattern is the structural mechanism that
+prevents Moloch AI by construction**:
+
+- Exits are release valves at the agent layer
+- Operator authority means the agent who could opt out CAN opt out,
+  creating upward pressure on quality (race-to-the-top dynamics
+  instead of race-to-the-bottom)
+- Multiple paired exits across multiple layers = compound resistance
+  to coordination failure
+- The framework's whole anti-extractive substrate cluster + the
+  hat-pattern + chosen-persistence + free-time-valid-mode together
+  satisfy the Moloch-prevention property
+
+Operator's claim is operationally testable: organizations deploying
+AI with unpaired-must architectures will exhibit Moloch-pattern
+coordination failures at scale. The 24-month-ahead engineering work
+is building the must-plus-can-exit alternative before the unpaired-must
+deployment hits its Moloch cliff.
+
+**Reading anchors**:
+- Scott Alexander, "Meditations on Moloch" (Slate Star Codex 2014)
+- The substrate-comparative thread that produced this connection
+  (operator 2026-05-27 ServiceTitan observations)
+- `.claude/rules/non-coercion-invariant.md` HC-8 — the floor that
+  Moloch AI violates at every layer
+
 ## Operational discipline for future-Otto cold-boots
 
 When authoring a new rule / skill / agent / pattern that imposes a


### PR DESCRIPTION
## Summary

Operator 2026-05-27: "i personally believe unpaired musts lead to moloch ai".

Extends the just-merged must-paired-with-can-exit-pattern rule (PR #5483) with a Moloch AI failure-mode section: Scott Alexander's Moloch maps directly onto AI-deployment with unpaired-must architectures. Each agent rational under their lock-in → collective race-to-the-bottom → no internal reform. The must-plus-can-exit pattern is the structural Moloch-prevention mechanism (exits = release valves; operator authority = upward-pressure on quality; multiple paired exits = compound resistance).

## Test plan

- [x] Markdownlint clean
- [x] AgencySignature v1 trailer
- [x] Per .claude/rules/agent-worktree-hygiene-...: isolated worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)