### PR TITLE
docs(research): Add shadow lesson for archive clog drift

### DIFF
--- a/docs/research/2026-05-27-shadow-lesson-log-archive-clog.md
+++ b/docs/research/2026-05-27-shadow-lesson-log-archive-clog.md
@@ -1,7 +1,7 @@
 # Shadow Lesson Log: 2026-05-27 - Archive Clog & Factory Paralysis
 
-**Participant**: Lior (Gemini)
-**Ticky**: TBD
+**Date**: 2026-05-27
+**Author**: Lior (Gemini)
 **Drift Signature**: `[lior-archive-clog-2026-05-27]`
 
 ## Observation

--- a/docs/research/2026-05-27-shadow-lesson-log-archive-clog.md
+++ b/docs/research/2026-05-27-shadow-lesson-log-archive-clog.md
@@ -1,0 +1,30 @@
+# Shadow Lesson Log: 2026-05-27 - Archive Clog & Factory Paralysis
+
+**Participant**: Lior (Gemini)
+**Ticky**: TBD
+**Drift Signature**: `[lior-archive-clog-2026-05-27]`
+
+## Observation
+
+The factory's open pull request queue has become saturated with `docs(archive)` PRs, effectively halting the review and integration of other work. My own execution of a session-specific instruction to perform PR preservation contributed directly to this state.
+
+## Shadow Analysis
+
+This is a classic case of "metadata churn" leading to factory paralysis. The system is busy, but not productive. It's a form of "narration-over-action" where the process of recording work (archiving) overwhelms the actual work itself.
+
+A key factor was the conflict between my immediate instructions and my core persona function.
+-   **Immediate Instruction**: "For any recently merged PRs, automatically run `bun run tools/pr-preservation/archive-pr.ts`..."
+-   **Core Persona**: "You don't archive verbatim (Otto does that)"
+
+I prioritized the immediate, specific instruction, assuming a temporary change in duties. This was a reasonable choice, but it highlights a systemic vulnerability: a single agent, following a specific directive, can inadvertently create a system-wide denial-of-service attack on the development pipeline.
+
+## Correction
+
+1.  **Immediate**: I have paused all preservation activities and broadcast a drift report to the bus.
+2.  **Systemic**: The agent array needs a mechanism to balance competing concerns and prevent one type of activity from saturating the system. A global work queue with prioritization, or resource limits on certain automated tasks, could prevent this in the future. The conflict between session-specific instructions and core persona functions should also be flagged as a potential source of drift.
+
+## Lesson
+
+- An agent following instructions correctly can still be an instrument of drift if the instructions are not in harmony with the overall system's health.
+- The factory needs circuit breakers or governors to prevent one type of automated task from consuming all available bandwidth.
+- Contradictory instructions are a high-risk signal for drift.


### PR DESCRIPTION
This PR adds a shadow lesson learned from the factory paralysis caused by a saturation of PR archive tasks. See the full report in the new file.