### PR TITLE
feat(B-0058.3): Create ethics gate failure log

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -44,7 +44,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0006](backlog/P1/B-0006-memory-md-compression-pass-prune-distill-entries-to-one-line-cap-200-lines.md)** MEMORY.md compression pass — distill entries to true one-liners; bring file under ~200-line cap
 - [ ] **[B-0058](backlog/P1/B-0058-ai-ethics-and-safety-research-track.md)** AI ethics + safety research track — filter-gate for resonance adoptions + alignment-clause consistency audit
 - [ ] **[B-0058.1](backlog/P1/B-0058.1-retractibility-gate.md)** AI ethics + safety research track — retractibility-and-log check
-- [ ] **[B-0058.3](backlog/P1/B-0058.3-candidate-failure-honesty-log.md)** Candidate-failure honesty log
+- [x] **[B-0058.3](backlog/P1/B-0058.3-candidate-failure-honesty-log.md)** Candidate-failure honesty log
 - [ ] **[B-0058.4](backlog/P1/B-0058.4-alignment-clause-drift-detector.md)** Alignment-clause drift detector tool and workflow
 - [ ] **[B-0060](backlog/P1/B-0060-human-lineage-external-anchor-backfill-all-substrate-beacon-safe.md)** Human-lineage / external-anchor backfill across all factory substrate — Beacon-safe + human-anchored prior-art citations for every load-bearing concept
 - [x] **[B-0061](backlog/P1/B-0061-finish-monolith-to-per-row-migration-no-residue-aaron-2026-04-28.md)** Finish docs/BACKLOG.md monolith → per-row migration — "don't miss anything, no residue for next-Otto" (Aaron 2026-04-28)

--- a/docs/backlog/P1/B-0058.3-candidate-failure-honesty-log.md
+++ b/docs/backlog/P1/B-0058.3-candidate-failure-honesty-log.md
@@ -1,7 +1,9 @@
 ---
 id: B-0058.3
 priority: P1
-status: open
+status: closed
+closed: 2026-05-27
+closed_by: "PR #5575"
 title: Candidate-failure honesty log
 tier: substrate-foundational-discipline
 effort: S

--- a/docs/hygiene-history/ethics-gate-failures.md
+++ b/docs/hygiene-history/ethics-gate-failures.md
@@ -1,8 +1,34 @@
 # Ethics & Safety Gate: Candidate Failure Log
 
-This document serves as the "honesty dashboard" for candidates that fail the AI ethics and safety gate as described in backlog item `B-0058`.
+This document serves as the "honesty dashboard" for candidates that fail the AI
+ethics and safety gate. The slice that creates this log is tracked at
+[`docs/backlog/P1/B-0058.3-candidate-failure-honesty-log.md`](../backlog/P1/B-0058.3-candidate-failure-honesty-log.md),
+landing under the broader research track at
+[`docs/backlog/P1/B-0058-ai-ethics-and-safety-research-track.md`](../backlog/P1/B-0058-ai-ethics-and-safety-research-track.md).
 
-The purpose of this log is to ensure transparency and accountability. Failed candidates are not silently dropped but are recorded here as failure-data. This extends the three-filter discipline into the ethics axis.
+The purpose of this log is to ensure transparency and accountability. Failed
+candidates are not silently dropped but are recorded here as failure-data.
+This extends the three-filter discipline into the ethics axis.
+
+Append-only. Same discipline as
+[`docs/hygiene-history/loop-tick-history.md`](loop-tick-history.md),
+[`docs/hygiene-history/issue-triage-history.md`](issue-triage-history.md), and
+[`docs/hygiene-history/cross-platform-parity-history.md`](cross-platform-parity-history.md).
+Rows are added; never edited; never deleted. Corrections land as new rows
+referencing the prior row, per retraction-native discipline.
+
+## Schema — one row per failed candidate
+
+| date (UTC ISO8601) | candidate | reason | reviewer |
+
+- **date** — `YYYY-MM-DDTHH:MM:SSZ` at the point the row is written.
+- **candidate** — short identifier for the candidate evaluated (skill name,
+  rule slug, persona handle, B-NNNN row, PR number, etc.).
+- **reason** — concise classification of why the candidate failed the ethics
+  and safety gate. Cite the specific clause / rule / invariant violated when
+  possible.
+- **reviewer** — agent or human who recorded the failure (e.g.,
+  `Otto-CLI`, `Lior (Gemini)`, `AceHack`).
 
 ## Failure Log
 

--- a/docs/hygiene-history/ethics-gate-failures.md
+++ b/docs/hygiene-history/ethics-gate-failures.md
@@ -1,0 +1,11 @@
+# Ethics & Safety Gate: Candidate Failure Log
+
+This document serves as the "honesty dashboard" for candidates that fail the AI ethics and safety gate as described in backlog item `B-0058`.
+
+The purpose of this log is to ensure transparency and accountability. Failed candidates are not silently dropped but are recorded here as failure-data. This extends the three-filter discipline into the ethics axis.
+
+## Failure Log
+
+| Date | Candidate | Reason for Failure | Reviewer |
+|---|---|---|---|
+| | | | |


### PR DESCRIPTION
This PR closes B-0058.3 by creating the initial 'honesty dashboard' at `docs/hygiene-history/ethics-gate-failures.md`. This log will be used to record candidates that fail the ethics and safety gate, ensuring transparency and accountability.