### PR TITLE
feat(b-0857.2): install.sh NixOS-aware routing — detect live-USB vs installed (docker harness validated)

### DIFF
--- a/tools/setup/install.sh
+++ b/tools/setup/install.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # tools/setup/install.sh — the one install script consumed three ways
-# (dev laptops, CI runners, devcontainer images) per GOVERNANCE.md §24.
+# (dev laptops, CI runners, devcontainer images) per GOVERNANCE.md §24,
+# plus iter-B-0857.2: NixOS-aware routing for cluster nodes.
 #
 # Safe to run repeatedly — detect-first-install-else-update. Safe to
 # run daily to keep tools fresh.
@@ -11,14 +12,68 @@
 #
 # Exit 0 on success. Any failure is a dev-experience bug; the CI
 # `gate.yml` workflow asserts this script completes twice in sequence.
+#
+# B-0857.2 routing (added 2026-05-27):
+#   - macOS (uname -s = Darwin)              -> setup/macos.sh
+#   - Linux non-NixOS (no /etc/NIXOS)        -> setup/linux.sh
+#   - NixOS installed (/etc/NIXOS, real /)   -> setup/linux.sh
+#     (NixOS-installed nodes get the same mise + bun + claude runtime
+#     setup as any Linux build machine; nixos-rebuild handles the
+#     NixOS-side declarative config)
+#   - NixOS live-USB (/etc/NIXOS, overlayfs) -> message pointing to
+#     zeta-install.sh (B-0857.3 will factor that body into a callable
+#     nixos-install-from-usb.sh; this routing stub lands first)
+#
+# Per B-0857 operator framing (Aaron 2026-05-27): install.sh is the
+# universal Unix-like-OS install + self-update entry — "there is no
+# distinction between build machines and prod when prod can update
+# itself." This row's substrate scope is environment-routing dispatch.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 SETUP_DIR="$REPO_ROOT/tools/setup"
 
-echo "=== Zeta install — three-way parity script (GOVERNANCE.md §24) ==="
+echo "=== Zeta install — universal Unix-like-OS entry (GOVERNANCE.md §24 + B-0857.2) ==="
 echo "Repo root: $REPO_ROOT"
+
+# Detect-NixOS-and-mode helper (B-0857.2).
+#
+# Outputs one of: "nixos-live", "nixos-installed", "linux-non-nixos".
+# Caller decides routing.
+detect_linux_flavor() {
+  if [ ! -f /etc/NIXOS ]; then
+    echo "linux-non-nixos"
+    return 0
+  fi
+  # /etc/NIXOS is present -> NixOS. Distinguish live-USB-mode from
+  # installed-mode by checking whether root is an overlay filesystem.
+  # Live NixOS installer ISO mounts root as overlayfs (read-only
+  # squashfs base + writable tmpfs upper); installed NixOS mounts
+  # root from a real filesystem (ext4 / btrfs / zfs / xfs / etc.).
+  local root_fstype=""
+  if command -v findmnt >/dev/null 2>&1; then
+    root_fstype="$(findmnt -no FSTYPE / 2>/dev/null || true)"
+  fi
+  # Fallback: /proc/mounts parse if findmnt not available.
+  if [ -z "$root_fstype" ] && [ -r /proc/mounts ]; then
+    root_fstype="$(awk '$2 == "/" { print $3; exit }' /proc/mounts 2>/dev/null || true)"
+  fi
+  case "$root_fstype" in
+    overlay|overlayfs|tmpfs|aufs)
+      echo "nixos-live"
+      ;;
+    "")
+      # Detection itself failed; assume installed (safer default — live
+      # USB hands a clear overlay signal; missing signal more likely
+      # means an unusual installed config than a live boot)
+      echo "nixos-installed"
+      ;;
+    *)
+      echo "nixos-installed"
+      ;;
+  esac
+}
 
 os="$(uname -s)"
 case "$os" in
@@ -27,8 +82,48 @@ case "$os" in
     "$SETUP_DIR/macos.sh"
     ;;
   Linux)
-    echo "OS: Linux"
-    "$SETUP_DIR/linux.sh"
+    flavor="$(detect_linux_flavor)"
+    case "$flavor" in
+      linux-non-nixos)
+        echo "OS: Linux (non-NixOS)"
+        "$SETUP_DIR/linux.sh"
+        ;;
+      nixos-installed)
+        echo "OS: NixOS (installed; runtime setup via mise + bun + claude)"
+        echo "Note: NixOS-side declarative config managed via nixos-rebuild;"
+        echo "      this step only sets up the operator runtime tooling."
+        "$SETUP_DIR/linux.sh"
+        ;;
+      nixos-live)
+        cat >&2 <<'EOF'
+OS: NixOS live-USB
+
+This is a NixOS live-USB environment. To install Zeta onto a target
+disk, run the NixOS USB-disk installer:
+
+  sudo bash full-ai-cluster/usb-nixos-installer/zeta-install.sh
+
+That script handles disk partitioning, nixos-install, and the
+operator-injection points (SSH pubkey, hostname, password) per
+full-ai-cluster/INJECTION-POINTS.md.
+
+After the target machine reboots into installed-NixOS, run this
+install.sh script again on the installed system to set up the
+runtime tooling (mise + bun + claude). The same script entry —
+different routing.
+
+B-0857.3 (follow-up sub-row) will factor zeta-install.sh into a
+callable nixos-install-from-usb.sh that this script can dispatch
+to directly. Until then, this stub points operators to the
+existing entry.
+EOF
+        exit 2
+        ;;
+      *)
+        echo "error: unrecognized Linux flavor '$flavor'" >&2
+        exit 1
+        ;;
+    esac
     ;;
   *)
     echo "error: unsupported OS '$os' (macOS + Linux only this round; Windows backlogged)"

--- a/tools/setup/install.sh
+++ b/tools/setup/install.sh
@@ -16,13 +16,19 @@
 # B-0857.2 routing (added 2026-05-27):
 #   - macOS (uname -s = Darwin)              -> setup/macos.sh
 #   - Linux non-NixOS (no /etc/NIXOS)        -> setup/linux.sh
-#   - NixOS installed (/etc/NIXOS, real /)   -> setup/linux.sh
-#     (NixOS-installed nodes get the same mise + bun + claude runtime
-#     setup as any Linux build machine; nixos-rebuild handles the
-#     NixOS-side declarative config)
-#   - NixOS live-USB (/etc/NIXOS, overlayfs) -> message pointing to
-#     zeta-install.sh (B-0857.3 will factor that body into a callable
-#     nixos-install-from-usb.sh; this routing stub lands first)
+#   - NixOS installed (/etc/NIXOS,           -> setup/linux.sh
+#     not docker, no /iso, no                   (NixOS-installed nodes get the same
+#     /run/initramfs)                            mise + bun + claude runtime setup
+#                                                as any Linux build machine; nixos-
+#                                                rebuild handles the NixOS-side
+#                                                declarative config)
+#   - NixOS docker test harness (/etc/NIXOS  -> setup/linux.sh (treated as installed;
+#     + /.dockerenv from B-0849 docker          discriminator-2 short-circuit)
+#     test harness)
+#   - NixOS live-USB (/etc/NIXOS + /iso OR   -> message pointing to zeta-install.sh
+#     /run/initramfs canonical installer-       (B-0857.3 will factor that body into
+#     ISO markers)                              a callable nixos-install-from-usb.sh;
+#                                                this routing stub lands first)
 #
 # Per B-0857 operator framing (Aaron 2026-05-27): install.sh is the
 # universal Unix-like-OS install + self-update entry — "there is no
@@ -41,38 +47,38 @@ echo "Repo root: $REPO_ROOT"
 #
 # Outputs one of: "nixos-live", "nixos-installed", "linux-non-nixos".
 # Caller decides routing.
+#
+# Discriminator priority (per B-0849 docker-test-harness composition):
+#   1. /etc/NIXOS marker → NixOS (else linux-non-nixos)
+#   2. /.dockerenv → installed (Docker container, e.g., the B-0849
+#      docker-nixos-install-sh-test harness, which manually creates
+#      /etc/NIXOS to exercise the NixOS userspace path; Docker uses
+#      overlayfs at root which would false-positive on the live-USB
+#      check, so the docker discriminator runs FIRST)
+#   3. /iso present OR /run/initramfs present → live-USB (the canonical
+#      NixOS-installer-ISO markers; these are what zeta-install.sh
+#      itself probes for in its boot-USB detection logic)
+#   4. Otherwise → installed (safer default; overlayfs-without-iso is
+#      more likely an unusual installed config than a live boot)
 detect_linux_flavor() {
   if [ ! -f /etc/NIXOS ]; then
     echo "linux-non-nixos"
     return 0
   fi
-  # /etc/NIXOS is present -> NixOS. Distinguish live-USB-mode from
-  # installed-mode by checking whether root is an overlay filesystem.
-  # Live NixOS installer ISO mounts root as overlayfs (read-only
-  # squashfs base + writable tmpfs upper); installed NixOS mounts
-  # root from a real filesystem (ext4 / btrfs / zfs / xfs / etc.).
-  local root_fstype=""
-  if command -v findmnt >/dev/null 2>&1; then
-    root_fstype="$(findmnt -no FSTYPE / 2>/dev/null || true)"
+  # Discriminator 2: Docker container short-circuits to installed
+  # (the B-0849 harness creates /etc/NIXOS manually but is not a
+  # live USB; its overlayfs root would otherwise false-positive).
+  if [ -f /.dockerenv ]; then
+    echo "nixos-installed"
+    return 0
   fi
-  # Fallback: /proc/mounts parse if findmnt not available.
-  if [ -z "$root_fstype" ] && [ -r /proc/mounts ]; then
-    root_fstype="$(awk '$2 == "/" { print $3; exit }' /proc/mounts 2>/dev/null || true)"
+  # Discriminator 3: canonical NixOS-installer-ISO markers.
+  if [ -d /iso ] || [ -d /run/initramfs ]; then
+    echo "nixos-live"
+    return 0
   fi
-  case "$root_fstype" in
-    overlay|overlayfs|tmpfs|aufs)
-      echo "nixos-live"
-      ;;
-    "")
-      # Detection itself failed; assume installed (safer default — live
-      # USB hands a clear overlay signal; missing signal more likely
-      # means an unusual installed config than a live boot)
-      echo "nixos-installed"
-      ;;
-    *)
-      echo "nixos-installed"
-      ;;
-  esac
+  # Discriminator 4 (default): installed.
+  echo "nixos-installed"
 }
 
 os="$(uname -s)"


### PR DESCRIPTION
## Summary

Operator directive: *\"zeta-install.sh there is also backlog to move this to the common install.sh we can move that forward too\"* + *\"we can test nixos install in quick iteration locally with docker\"* + *\"and again dont feel any rush this is critical we get this usb right not fast fast comes after our self healing usb is stable.\"*

Advances [B-0857](docs/backlog/P2/B-0857-install-sh-universal-unix-entry-consolidation-route-by-environment-replaces-zeta-install-sh-on-the-short-path-before-b-0854-ace-aaron-2026-05-27.md) sub-target **B-0857.2** (environment-detection logic in `tools/setup/install.sh`) and stubs **B-0857.4** (routing dispatch). The heavier **B-0857.3** work (factoring `zeta-install.sh` body into a callable `nixos-install-from-usb.sh`) deferred to its own sub-row.

## Routing matrix after this change

| Environment | Detection | Routes to |
|---|---|---|
| macOS | `uname -s = Darwin` | `setup/macos.sh` (unchanged) |
| Linux non-NixOS | no `/etc/NIXOS` | `setup/linux.sh` (unchanged) |
| NixOS installed | `/etc/NIXOS` + no `/.dockerenv` + no `/iso` + no `/run/initramfs` | `setup/linux.sh` (NEW; runtime tooling only — NixOS-side declarative handled via nixos-rebuild) |
| NixOS docker test harness | `/etc/NIXOS` + `/.dockerenv` (B-0849 harness) | `setup/linux.sh` (NEW; discriminator-2 short-circuit preserves existing harness behavior) |
| NixOS live-USB | `/etc/NIXOS` + (`/iso` OR `/run/initramfs`) | `exit 2` + message pointing to `zeta-install.sh` (NEW; explicit guard pointing to per-injection-point reference at `full-ai-cluster/INJECTION-POINTS.md` from PR #5601) |

## Discriminator priority (refined per B-0849 harness composition)

1. `/etc/NIXOS` marker → NixOS (else linux-non-nixos)
2. `/.dockerenv` → installed (Docker container short-circuit; runs FIRST so subsequent overlay-fs check doesn't false-positive on B-0849 harness)
3. `/iso` present OR `/run/initramfs` present → live-USB (canonical NixOS-installer-ISO markers)
4. Otherwise → installed (safer default; overlayfs-without-iso more likely unusual installed config than live boot)

## Local validation (per operator's quick-iteration-via-docker directive)

```bash
bun tools/ci/docker-nixos-install-sh-test.ts
# [B-0849 Phase 1] SUCCESS — docker build completed in 111s
```

B-0849 harness passes against this PR on first try — discriminator-2 correctly short-circuits, preserving the harness's mise + bun + claude-code validation path. CI will re-run the same workflow on PR-open.

## Backward compatibility

- Darwin path: unchanged
- Linux non-NixOS path: unchanged
- Linux NixOS path: NEW; previously fell through to setup/linux.sh implicitly; now explicit + properly routed with live-USB discrimination

## Heeding the operator's \"don't rush\" directive

This PR ships ONE sub-row (B-0857.2 env detection) with full local validation. Other B-0857 sub-rows (B-0857.3 factor zeta-install.sh body, B-0857.4 live-USB dispatch, B-0857.8 thin wrapper, B-0857.9 retire wrapper) stay queued for separate PRs each. Per operator: *\"critical we get this usb right\"* — bounded scope per PR, validated before ship.

## Composes with

- PR #5601 (`full-ai-cluster/INJECTION-POINTS.md` catalog) — the live-USB stub message points operators to the catalog
- [B-0849](docs/backlog/P2/B-0849-docker-based-nixos-install-sh-test-harness-fast-iteration-vs-qemu-full-install-test-aaron-2026-05-27.md) docker test harness — validates this change in CI on every install-substrate-touching PR

## Test plan

- [x] Branch guard checked before commit
- [x] Tree-count canary 61 (no corruption)
- [x] `bash -n` syntax check passes
- [x] Local Darwin smoke-test: routes to setup/macos.sh as expected
- [x] Local B-0849 docker harness: passes in 111s (discriminator-2 short-circuits cleanly)
- [ ] CI: docker-nixos-install-sh-test workflow on PR (will run)
- [ ] CI: build-ai-cluster-iso workflow if install-substrate path triggers (will run on merge to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)