### PR TITLE
fix(injection-points): KDF chain markdown rendering + work-factor-not-entropy wording (supersedes #5608)

### DIFF
--- a/full-ai-cluster/INJECTION-POINTS.md
+++ b/full-ai-cluster/INJECTION-POINTS.md
@@ -113,11 +113,36 @@ Allowlist from `zflash.ts`:
 | **Stage** | Cluster console at install time → encrypted blob persisted to USB ESP after successful auth (post-install service trigger) |
 | **Content class** | **Secret material** (encrypted-at-rest; key never hits disk) |
 | **Operator-driven via** | Boot-sequence auth-method picker (4 options: restore-from-blob / fresh-device-flow / operator-PAT / skip) + operator passphrase |
-| **Encryption** | AES-256-GCM with key derived from `HKDF(USB-UUID \|\| operator-passphrase, salt, info)` |
+| **Encryption** | AES-256-GCM; key derived via 2-layer scrypt → HKDF chain (full mechanism + parameters below) |
 | **ESP filenames** | `/esp/zeta-creds.enc` (encrypted) + `/esp/zeta-creds-manifest.yaml` (declarative + operator-readable) |
 | **Backlog** | [B-0852](../docs/backlog/P1/B-0852-credential-persistence-on-usb-esp-plus-boot-sequence-auth-method-picker-encrypted-blob-bound-to-usb-uuid-plus-operator-passphrase-aaron-2026-05-27.md) (P1, open, M-effort) |
 | **Covers credentials** | per declarative manifest: `gh-cli` (`~/.config/gh/hosts.yml`), `claude` (per-persona), `gemini` (per-persona), `codex` (per-persona), `ssh-host-keys`, `ssh-operator-pubkey` |
 | **Constitutional-rail compliance** | Secret material; encrypted-at-rest on ESP IS allowed because the operator-passphrase + USB-UUID binding means the ESP-stored blob is useless without operator presence — the consent floor stays at operator-typed passphrase, not at USB-physical possession alone |
+
+#### KDF chain detail (mechanism + parameters)
+
+The 32-byte AES-256-GCM key is derived in two layers; full implementation at `tools/installer/zeta-creds-crypto.ts:80-125`.
+
+**Layer 1 — scrypt** (memory-hard work-factor KDF):
+
+```text
+stretched = scrypt(passphrase, salt, length=32, N=2^17, r=8, p=1, maxmem=256MB)
+```
+
+scrypt does NOT increase the underlying entropy of the operator passphrase (a weak passphrase remains weak in information-theoretic terms). What scrypt provides is a tunable **work-factor cost** per guess: each candidate passphrase requires ~128MB of memory and ~1-2 seconds of CPU per derivation. This makes brute-force attacks memory-prohibitively expensive on GPU/ASIC (per the 2026-05-27 security-review HIGH finding: HKDF alone assumes high-entropy IKM, which user-typed passphrases violate; scrypt is the layer that makes the IKM cryptographically suitable for HKDF input).
+
+OWASP 2026 recommended parameters: `N=2^17`, `r=8`, `p=1`.
+
+**Layer 2 — HKDF-SHA256** (binds key to USB UUID):
+
+```text
+ikm  = concat(usbUuid_utf8, "|", stretched)
+key  = HKDF-SHA256(ikm, salt, info="zeta-b0852-cred-persistence-v1", length=32)
+```
+
+HKDF binds the stretched secret to the USB UUID via IKM concatenation. Wrong USB → different IKM → different HKDF output → AES-GCM auth tag verification fails → structured error returned (not garbled plaintext). Defends against copy-blob-to-different-USB attack (operator-named threat 2026-05-27: *"we can put a key on the usb too if wnated tied to the uuid so it can't be copied to uuid"*).
+
+Both layers must reproduce identically at decrypt time for the AES-GCM auth tag to verify; salt is per-blob (generated at encrypt time; stored in envelope; required at decrypt).
 
 ### 6. GitHub-creds-at-flash-time variants (B-0852 picker options 1 + 3)
 

--- a/full-ai-cluster/INJECTION-POINTS.md
+++ b/full-ai-cluster/INJECTION-POINTS.md
@@ -121,7 +121,7 @@ Allowlist from `zflash.ts`:
 
 #### KDF chain detail (mechanism + parameters)
 
-The 32-byte AES-256-GCM key is derived in two layers; full implementation at `tools/installer/zeta-creds-crypto.ts:80-125`.
+The 32-byte AES-256-GCM key is derived in two layers; full implementation in `tools/installer/zeta-creds-crypto.ts` (the `deriveKey` function + the `SCRYPT_*` + `KEY_LEN` + `SALT_LEN` + `HKDF_INFO` constants declared near the top of the file).
 
 **Layer 1 — scrypt** (memory-hard work-factor KDF):
 
@@ -129,9 +129,9 @@ The 32-byte AES-256-GCM key is derived in two layers; full implementation at `to
 stretched = scrypt(passphrase, salt, length=32, N=2^17, r=8, p=1, maxmem=256MB)
 ```
 
-scrypt does NOT increase the underlying entropy of the operator passphrase (a weak passphrase remains weak in information-theoretic terms). What scrypt provides is a tunable **work-factor cost** per guess: each candidate passphrase requires ~128MB of memory and ~1-2 seconds of CPU per derivation. This makes brute-force attacks memory-prohibitively expensive on GPU/ASIC (per the 2026-05-27 security-review HIGH finding: HKDF alone assumes high-entropy IKM, which user-typed passphrases violate; scrypt is the layer that makes the IKM cryptographically suitable for HKDF input).
+scrypt does NOT increase the underlying entropy of the operator passphrase (a weak passphrase remains weak in information-theoretic terms). What scrypt provides is a tunable **work-factor cost** per guess: with the parameters below, each candidate passphrase requires ~128MB of memory and (empirically per `zeta-creds-crypto.ts` Layer 1 source comments, on the maintainer's modern CPU at parameter-selection time) ~1-2 seconds of CPU per derivation. This makes brute-force attacks memory-prohibitively expensive on GPU/ASIC (per the 2026-05-27 security-review HIGH finding documented in the source: HKDF alone assumes high-entropy IKM, which user-typed passphrases violate; scrypt is the layer that makes the IKM cryptographically suitable for HKDF input).
 
-OWASP 2026 recommended parameters: `N=2^17`, `r=8`, `p=1`.
+Parameter selection: `N=2^17`, `r=8`, `p=1` — per [OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#scrypt) recommended scrypt parameters (current at parameter-selection time 2026-05-27; bump procedure: visit the cheat sheet at next security-review cadence, update both the cheat-sheet-citation date here AND the `SCRYPT_N`/`SCRYPT_R`/`SCRYPT_P` constants in `zeta-creds-crypto.ts`). Per-machine operational cost will vary with CPU + memory bandwidth; the ~1-2s figure is anchored to the source-code comment's empirical timing context.
 
 **Layer 2 — HKDF-SHA256** (binds key to USB UUID):
 


### PR DESCRIPTION
## Summary

Supersedes [#5608](https://github.com/Lucent-Financial-Group/Zeta/pull/5608). Two valid Copilot findings on that PR addressed by restructuring the KDF documentation away from inline-code-in-table-cell into a sub-section with proper code blocks below the table.

## Findings + fixes

### Finding 1 (line 116) — markdown rendering

**Was**: \`HKDF(USB-UUID \\|\\| operator-passphrase, salt, info)\` inside a table cell with backslash-escaped pipes that render literally in markdown code spans (readers saw \"\\|\\|\" instead of \"||\").

**Fixed**: Table cell simplified to point at a sub-section below. KDF mechanism documented in code blocks (no pipe-escaping issue inline code in table cells has).

### Finding 2 (line 116) — entropy wording misleading

**Was**: \"stretches low-entropy passphrase into high-entropy intermediate\" — implies scrypt increases entropy of weak passphrases.

**Fixed**: Corrected to substrate-honest wording: scrypt does NOT increase entropy of weak passphrases (information-theoretically); it provides tunable **work-factor cost** per guess, making brute-force memory-prohibitively expensive on GPU/ASIC. Per OWASP guidance + the 2026-05-27 security-review HIGH finding rationale documented in \`zeta-creds-crypto.ts\`.

## Why new-branch path (not force-push)

Same as PR #5620 superseding PR #5606: force-push restricted by autonomous-loop discipline; new-branch path is policy-respected alternative.

## Copilot threads on PR #5608 to resolve when closing

- \`PRRT_kwDOSF9kNM6FNUvq\` (line 116, backslash escaping)
- \`PRRT_kwDOSF9kNM6FNUwj\` (line 116, entropy wording)

## Test plan

- [x] Branch guard checked before commit
- [x] Tree-count canary 61 (no corruption)
- [x] KDF mechanism + parameters preserved verbatim from `tools/installer/zeta-creds-crypto.ts:80-125`
- [x] Operator-named threat verbatim preserved (\"we can put a key on the usb too if wnated tied to the uuid so it can't be copied to uuid\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)