### PR TITLE
feat(zeta-install): cluster-type menu with hardware-detection suggested default (operator-named direction; live-USB install flow)

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -236,9 +236,80 @@ for d in "${DATA_DISKS[@]}"; do
 done
 
 # ── Step 6: clone + install ───────────────────────────────────────
+#
+# B-0857.X (cluster-type menu extension, 2026-05-27): replace the
+# bare free-text prompt with a numbered menu + hardware-detection
+# suggested default. Existing free-text override preserved as
+# "other" option for advanced cases (custom flake host attribute
+# added to nixos/hosts/<name>/ but not yet in the menu).
+#
+# Hardware-detection heuristic (suggested default):
+#   - lspci shows NVIDIA / AMD / Intel GPU       -> worker-gpu
+#   - default                                    -> control-plane
+#
+# Multi-role-on-single-host support (operator 2026-05-27: "letting
+# you select multiple or detecting based on hardware etc..."):
+# the current flake assigns one host attribute per node; multi-role
+# compose-on-single-host is a future B-0792-extension sub-row
+# (requires flake-shape refactor to support role-tagging). This
+# iteration ships the single-attribute menu; the multi-role
+# composition follows when the flake substrate supports it.
 if [[ -z "$HOST" ]]; then
-  read -rp "Flake host attribute to install [control-plane]: " HOST
-  HOST="${HOST:-control-plane}"
+  # Hardware-detection suggested default.
+  SUGGESTED_HOST="control-plane"
+  if command -v lspci >/dev/null 2>&1; then
+    if lspci 2>/dev/null | grep -qiE "(nvidia|vga.*amd|3d.*amd|vga.*intel.*arc|3d.*intel.*arc)"; then
+      SUGGESTED_HOST="worker-gpu"
+    fi
+  fi
+  echo
+  echo "Cluster node type — select host attribute from the flake:"
+  echo
+  echo "  1) control-plane    K3S server + Cilium + ArgoCD bootstrap"
+  echo "                      (Longhorn storage + cpu workloads also run here)"
+  echo "  2) worker-gpu       GPU worker (NVIDIA passthrough + device-plugin"
+  echo "                      + Longhorn storage)"
+  echo "  3) worker-template  Cookie-cutter worker (multi-disk Longhorn;"
+  echo "                      use after copying to nixos/hosts/worker-NN/"
+  echo "                      per PROVISIONING.md)"
+  echo "  4) other            type a custom flake host attribute (advanced;"
+  echo "                      for hosts added under nixos/hosts/ + wired"
+  echo "                      into flake.nix nixosConfigurations)"
+  echo
+  echo "Hardware detection suggests: $SUGGESTED_HOST"
+  if [ "$SUGGESTED_HOST" = "worker-gpu" ]; then
+    echo "  (GPU detected via lspci — likely worker node, not control-plane)"
+  else
+    echo "  (no GPU detected — defaulting to control-plane;"
+    echo "   override below if this is a dedicated CPU-only worker)"
+  fi
+  echo
+  # Default menu choice maps to suggested host.
+  DEFAULT_CHOICE="1"
+  case "$SUGGESTED_HOST" in
+    control-plane)   DEFAULT_CHOICE="1" ;;
+    worker-gpu)      DEFAULT_CHOICE="2" ;;
+    worker-template) DEFAULT_CHOICE="3" ;;
+  esac
+  read -rp "Choice [1-4, default=$DEFAULT_CHOICE]: " MENU_CHOICE
+  MENU_CHOICE="${MENU_CHOICE:-$DEFAULT_CHOICE}"
+  case "$MENU_CHOICE" in
+    1) HOST="control-plane" ;;
+    2) HOST="worker-gpu" ;;
+    3) HOST="worker-template" ;;
+    4)
+      read -rp "Custom flake host attribute: " HOST
+      if [ -z "$HOST" ]; then
+        echo "[ERROR] custom host attribute cannot be empty; aborting" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "[ERROR] invalid choice '$MENU_CHOICE' (expected 1-4); aborting" >&2
+      exit 1
+      ;;
+  esac
+  echo "Selected: $HOST"
 fi
 
 echo "Cloning $REPO_URL ..."


### PR DESCRIPTION
## Summary

Operator 2026-05-27: *\"getting the menu fixed so it has all the cluster types we talked able storage cpu gpu etc... and letting you select multiple or detecting based on hardware etc...\"*

Replaces \`zeta-install.sh\` Step 6 bare \`read -rp \"Flake host attribute to install [control-plane]: \" HOST\` prompt with a proper menu + hardware-detection.

## What changed

```text
Cluster node type — select host attribute from the flake:

  1) control-plane    K3S server + Cilium + ArgoCD bootstrap
                      (Longhorn storage + cpu workloads also run here)
  2) worker-gpu       GPU worker (NVIDIA passthrough + device-plugin
                      + Longhorn storage)
  3) worker-template  Cookie-cutter worker (multi-disk Longhorn;
                      use after copying to nixos/hosts/worker-NN/
                      per PROVISIONING.md)
  4) other            type a custom flake host attribute (advanced;
                      for hosts added under nixos/hosts/ + wired
                      into flake.nix nixosConfigurations)

Hardware detection suggests: worker-gpu
  (GPU detected via lspci — likely worker node, not control-plane)

Choice [1-4, default=2]:
```

## Hardware-detection heuristic

- `lspci` shows NVIDIA / AMD VGA / AMD 3D / Intel Arc → suggests `worker-gpu`
- default → `control-plane`

The detected suggestion sets the menu default; operator hits Enter to accept or types a different number to override. Output explains the suggestion (\"GPU detected\" vs \"no GPU detected\") so the operator knows WHY a particular default is suggested.

## Backward compatibility

The existing pre-set `$HOST` env var continues to short-circuit the menu (the `[[ -z \"$HOST\" ]]` guard is unchanged). Automation passing HOST via env stays working.

## Error handling

- Invalid menu choice → abort with `expected 1-4` error
- Empty custom-host input (option 4) → abort with `cannot be empty` error
- Selected HOST echoed back for operator confirmation

## Multi-role-on-single-host deferred

Operator-named *\"select multiple or detecting based on hardware\"* — the SINGLE-attribute menu + hardware-detection ships in this iteration. The MULTI-ROLE compose-on-single-host (run control-plane + storage + GPU all on one node) requires flake-shape refactor to support role-tagging; deferred to future B-0792-extension sub-row.

## Local validation

- `bash -n` syntax PASS
- Menu branch only fires when HOST is empty + script is interactive; non-interactive runs short-circuit via pre-set HOST as before

## Why this ships during operator-offline window

Per operator 2026-05-27 multi-message correction: *\"i'm counting on you to keep the backlog going even when i'm not here or else why are you in a loop we should just be in a conversation\"* + *\"Addison has called me 4 or 5 times and asked me where are we with usb loosing focus is costing us time to building you a home.\"*

The autonomous-loop's purpose IS to keep substrate moving when operator is offline. Recent Quiet-cycles were the Standing-by failure mode the loop is supposed to prevent. This implementation ships per the loop's actual purpose.

## Composes with

- B-0792 (iter-5.2 hostname injection) — hostname stays separately injected via ESP `zeta-hostname.txt`
- B-0857.2 (install.sh NixOS routing; PR #5620) — install.sh routes to this `zeta-install.sh` on live-USB
- `full-ai-cluster/PROVISIONING.md` — cookie-cutter worker provisioning procedure
- `full-ai-cluster/INJECTION-POINTS.md` — injection points catalog (this menu IS injection point #2 cluster-node-type-selection)

## Test plan

- [x] Branch guard checked before commit
- [x] Tree-count canary 61
- [x] Local Darwin syntax check (`bash -n`)
- [ ] CI: build-ai-cluster-iso (TRIGGERED — path `full-ai-cluster/usb-nixos-installer/**` is in the workflow's trigger list)
- [ ] Once merged + ISO rebuilds, the new menu fires on actual live-USB boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)