### PR TITLE
fix(hygiene): catch extensionless shell shebang drift

### DIFF
--- a/tools/hygiene/check-bash-retirement-inventory.test.ts
+++ b/tools/hygiene/check-bash-retirement-inventory.test.ts
@@ -204,6 +204,7 @@ describe("buildInventoryReport", () => {
       writeFileSync(join(repo, "scripts", "extensionless-bash-env-s"), "#!/usr/bin/env -S bash -eu\n");
       writeFileSync(join(repo, "scripts", "extensionless-sh"), "#!/bin/sh\n");
       writeFileSync(join(repo, "scripts", "extensionless-bun"), "#!/usr/bin/env bun\n");
+      writeFileSync(join(repo, "scripts", "dotted-shell-shebang.txt"), "#!/usr/bin/env bash\n");
       writeFileSync(join(repo, "tools", "lean4", "vendor.sh"), "#!/usr/bin/env bash\n");
       writeFileSync(join(repo, "README.md"), "not shell\n");
       runGit(["add", "."], repo);

--- a/tools/hygiene/check-bash-retirement-inventory.test.ts
+++ b/tools/hygiene/check-bash-retirement-inventory.test.ts
@@ -200,6 +200,10 @@ describe("buildInventoryReport", () => {
       writeFileSync(join(repo, "scripts", "c.zsh"), "#!/usr/bin/env zsh\n");
       writeFileSync(join(repo, "scripts", "d.ksh"), "#!/usr/bin/env ksh\n");
       writeFileSync(join(repo, "scripts", "e.command"), "#!/usr/bin/env bash\n");
+      writeFileSync(join(repo, "scripts", "extensionless-bash"), "#!/usr/bin/env bash\n");
+      writeFileSync(join(repo, "scripts", "extensionless-bash-env-s"), "#!/usr/bin/env -S bash -eu\n");
+      writeFileSync(join(repo, "scripts", "extensionless-sh"), "#!/bin/sh\n");
+      writeFileSync(join(repo, "scripts", "extensionless-bun"), "#!/usr/bin/env bun\n");
       writeFileSync(join(repo, "tools", "lean4", "vendor.sh"), "#!/usr/bin/env bash\n");
       writeFileSync(join(repo, "README.md"), "not shell\n");
       runGit(["add", "."], repo);
@@ -210,6 +214,9 @@ describe("buildInventoryReport", () => {
         "scripts/c.zsh",
         "scripts/d.ksh",
         "scripts/e.command",
+        "scripts/extensionless-bash",
+        "scripts/extensionless-bash-env-s",
+        "scripts/extensionless-sh",
       ]);
     } finally {
       rmSync(repo, { recursive: true, force: true });

--- a/tools/hygiene/check-bash-retirement-inventory.ts
+++ b/tools/hygiene/check-bash-retirement-inventory.ts
@@ -13,7 +13,7 @@
 //   bun tools/hygiene/check-bash-retirement-inventory.ts --json
 
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 type ExitCode = 0 | 1 | 2;
@@ -67,6 +67,7 @@ export interface InventoryReport {
 const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
 export const RETAINED_SHELL_SCOPE = "repo-wide setup/bootstrap/service-wrapper/installer/dev-cluster allowlist";
 export const TRACKED_SHELL_FILE_GLOBS: readonly string[] = ["*.sh", "*.bash", "*.zsh", "*.ksh", "*.command"];
+const SHELL_FAMILY_SHEBANG_RE = /^#!.*(?:^|[/\s])(bash|sh|zsh|ksh)(?:\s|$)/;
 
 export const EXPECTED_RETAINED_SHELL: readonly string[] = [
   ".gemini/service/install-lior-service.sh",
@@ -169,16 +170,24 @@ function runGit(args: readonly string[], cwd?: string): string {
 
 export function trackedNonLeanShellFilesFromGit(cwd?: string): readonly string[] {
   const repoRoot = runGit(["rev-parse", "--show-toplevel"], cwd).trim();
-  const raw = runGit(["ls-files", "-z", ...TRACKED_SHELL_FILE_GLOBS], repoRoot);
+  const raw = runGit(["ls-files", "-z"], repoRoot);
   return raw
     .split("\0")
     .filter((file): file is string => file.length > 0)
     .filter((file) => existsSync(join(repoRoot, file)))
     .filter((file) => !file.startsWith("tools/lean4/"))
+    .filter((file) => isTrackedShellFamilyFile(repoRoot, file))
     .sort((a, b) => a.localeCompare(b));
 }
 
 export const trackedNonLeanBashFilesFromGit = trackedNonLeanShellFilesFromGit;
+
+function isTrackedShellFamilyFile(repoRoot: string, file: string): boolean {
+  if (TRACKED_SHELL_FILE_GLOBS.some((glob) => file.endsWith(glob.slice(1)))) return true;
+
+  const firstLine = readFileSync(join(repoRoot, file), "utf8").split(/\r?\n/, 1)[0] ?? "";
+  return SHELL_FAMILY_SHEBANG_RE.test(firstLine);
+}
 
 function inspectAllowlistIntegrity(expectedRetained: readonly string[]): AllowlistIntegrity {
   const counts = new Map<string, number>();

--- a/tools/hygiene/check-bash-retirement-inventory.ts
+++ b/tools/hygiene/check-bash-retirement-inventory.ts
@@ -67,7 +67,7 @@ export interface InventoryReport {
 const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
 export const RETAINED_SHELL_SCOPE = "repo-wide setup/bootstrap/service-wrapper/installer/dev-cluster allowlist";
 export const TRACKED_SHELL_FILE_GLOBS: readonly string[] = ["*.sh", "*.bash", "*.zsh", "*.ksh", "*.command"];
-const SHELL_FAMILY_SHEBANG_RE = /^#!.*(?:^|[/\s])(bash|sh|zsh|ksh)(?:\s|$)/;
+const SHELL_FAMILY_SHEBANG_RE = /^#!.*[/\s](bash|sh|zsh|ksh)(?:\s|$)/;
 
 export const EXPECTED_RETAINED_SHELL: readonly string[] = [
   ".gemini/service/install-lior-service.sh",

--- a/tools/hygiene/check-bash-retirement-inventory.ts
+++ b/tools/hygiene/check-bash-retirement-inventory.ts
@@ -13,8 +13,8 @@
 //   bun tools/hygiene/check-bash-retirement-inventory.ts --json
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { closeSync, existsSync, openSync, readSync } from "node:fs";
+import { basename, join } from "node:path";
 
 type ExitCode = 0 | 1 | 2;
 type Mode = "report" | "enforce" | "json";
@@ -65,8 +65,10 @@ export interface InventoryReport {
 }
 
 const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
+const SHEBANG_READ_BYTES = 512;
+const SHELL_FILE_EXTENSIONS: readonly string[] = [".sh", ".bash", ".zsh", ".ksh", ".command"];
 export const RETAINED_SHELL_SCOPE = "repo-wide setup/bootstrap/service-wrapper/installer/dev-cluster allowlist";
-export const TRACKED_SHELL_FILE_GLOBS: readonly string[] = ["*.sh", "*.bash", "*.zsh", "*.ksh", "*.command"];
+export const TRACKED_SHELL_FILE_GLOBS: readonly string[] = SHELL_FILE_EXTENSIONS.map((extension) => `*${extension}`);
 const SHELL_FAMILY_SHEBANG_RE = /^#!.*[/\s](bash|sh|zsh|ksh)(?:\s|$)/;
 
 export const EXPECTED_RETAINED_SHELL: readonly string[] = [
@@ -183,10 +185,25 @@ export function trackedNonLeanShellFilesFromGit(cwd?: string): readonly string[]
 export const trackedNonLeanBashFilesFromGit = trackedNonLeanShellFilesFromGit;
 
 function isTrackedShellFamilyFile(repoRoot: string, file: string): boolean {
-  if (TRACKED_SHELL_FILE_GLOBS.some((glob) => file.endsWith(glob.slice(1)))) return true;
+  if (SHELL_FILE_EXTENSIONS.some((extension) => file.endsWith(extension))) return true;
+  if (basename(file).includes(".")) return false;
 
-  const firstLine = readFileSync(join(repoRoot, file), "utf8").split(/\r?\n/, 1)[0] ?? "";
+  const firstLine = readFirstLine(join(repoRoot, file));
   return SHELL_FAMILY_SHEBANG_RE.test(firstLine);
+}
+
+function readFirstLine(path: string): string {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, "r");
+    const buffer = Buffer.alloc(SHEBANG_READ_BYTES);
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead).toString("utf8").split(/\r?\n/, 1)[0] ?? "";
+  } catch {
+    return "";
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
 }
 
 function inspectAllowlistIntegrity(expectedRetained: readonly string[]): AllowlistIntegrity {


### PR DESCRIPTION
## Summary
- extend the bash-retirement inventory guard to scan tracked extensionless shell-family shebangs
- keep Bun shebangs out of the shell-family inventory
- add focused fixture coverage for bash, env -S bash, sh, and Bun shebang cases

## Checks
- bun test tools/hygiene/check-bash-retirement-inventory.test.ts
- bun tools/hygiene/check-bash-retirement-inventory.ts --enforce
- git diff --check