### PR TITLE
feat(b-0852.3a-prep): capture USB UUID during iter-4.2 ESP probe — closes precondition #3 for Step 6.95-picker (operator-blocking 're-enter credentials over and over' pain point)

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -338,6 +338,66 @@ if [ -n "$PUBKEY_FILE" ]; then
     sudo cat "$PUBKEY_FILE"
   } | sudo tee "$PUBKEY_DST" > /dev/null
   echo "[iter-4.2]   wrote $PUBKEY_LINE_COUNT pubkey line(s) to operator-ssh-keys.txt"
+
+  # ── B-0852.3a-prep: capture USB UUID for cred-blob binding ────
+  # The B-0852 cred-blob encryption derives its key from
+  # HKDF(USB-UUID || stretched-passphrase, salt, info) per
+  # tools/installer/zeta-creds-crypto.ts deriveKey. The picker at
+  # Step 6.95-picker reads /etc/zeta/usb-uuid to know which UUID to
+  # bind the blob to. Without this file, the picker SKIPS (per its
+  # current gate condition), and the operator has to enter
+  # credentials over and over on every reboot (operator pain point
+  # named 2026-05-27: "i'm witing on the tool to be resable so i
+  # don't have to enter credentals over and over everytime").
+  #
+  # We're already at the ESP we just read the pubkey from. Capture
+  # its UUID via blkid + write to /etc/zeta/usb-uuid (and to
+  # /mnt/etc/zeta/usb-uuid so it survives the install). This closes
+  # one of the three preconditions blocking the picker; the other
+  # two (ZETA_CREDS_PICKER=1 + ZETA_CREDS_PASSPHRASE) follow in
+  # subsequent sub-rows.
+  USB_UUID_DEV=""
+  # Derive the partition device that hosts PUBKEY_FILE.
+  if [ -n "${part:-}" ] && [ -b "${part:-}" ]; then
+    # Try 2 case: we mounted ESP ourselves; $part is the partition.
+    USB_UUID_DEV="$part"
+  else
+    # Try 1 case: PUBKEY_FILE was on an already-mounted FS.
+    # findmnt -no SOURCE <dir> returns the source device.
+    PUBKEY_DIR="$(dirname "$PUBKEY_FILE")"
+    if command -v findmnt >/dev/null 2>&1; then
+      # Walk up the path until findmnt finds a mount point.
+      probe_dir="$PUBKEY_DIR"
+      while [ "$probe_dir" != "/" ]; do
+        src=$(findmnt -no SOURCE "$probe_dir" 2>/dev/null || true)
+        if [ -n "$src" ] && [ -b "$src" ]; then
+          USB_UUID_DEV="$src"
+          break
+        fi
+        probe_dir="$(dirname "$probe_dir")"
+      done
+    fi
+  fi
+
+  if [ -n "$USB_UUID_DEV" ] && command -v blkid >/dev/null 2>&1; then
+    USB_UUID_VAL=$(sudo blkid -o value -s UUID "$USB_UUID_DEV" 2>/dev/null || true)
+    if [ -n "$USB_UUID_VAL" ]; then
+      sudo mkdir -p /etc/zeta /mnt/etc/zeta
+      echo "$USB_UUID_VAL" | sudo tee /etc/zeta/usb-uuid >/dev/null
+      echo "$USB_UUID_VAL" | sudo tee /mnt/etc/zeta/usb-uuid >/dev/null
+      sudo chmod 0644 /etc/zeta/usb-uuid /mnt/etc/zeta/usb-uuid
+      echo "[B-0852.3a-prep]   captured USB UUID: $USB_UUID_VAL (device: $USB_UUID_DEV)"
+      echo "[B-0852.3a-prep]   wrote /etc/zeta/usb-uuid + /mnt/etc/zeta/usb-uuid"
+      echo "[B-0852.3a-prep]   precondition #3 satisfied for Step 6.95-picker"
+    else
+      echo "[B-0852.3a-prep]   WARN: blkid returned empty UUID for $USB_UUID_DEV;"
+      echo "[B-0852.3a-prep]         /etc/zeta/usb-uuid NOT written; picker will SKIP"
+    fi
+  else
+    echo "[B-0852.3a-prep]   WARN: could not derive USB partition device OR blkid unavailable;"
+    echo "[B-0852.3a-prep]         /etc/zeta/usb-uuid NOT written; picker will SKIP"
+  fi
+
   sudo umount "$PROBE_MOUNT" 2>/dev/null || true
   if [ "$PUBKEY_LINE_COUNT" -gt 0 ]; then
     INJECT_OK=1


### PR DESCRIPTION
## Summary

Operator-blocking pain point 2026-05-27: *\"i'm witing on the tool to be resable so i don't have to enter credentals over and over everytime.\"*

Root cause: the B-0852 cred-persistence picker at Step 6.95-picker has 3 gate preconditions:

1. \`ZETA_CREDS_PICKER=1\` env var
2. \`ZETA_CREDS_PASSPHRASE\` env var
3. \`/etc/zeta/usb-uuid\` file present

Of these, precondition #3 was NEVER auto-populated by the installer — nothing in \`zeta-install.sh\` writes that file. Result: picker SKIPs on every install regardless of operator intent. The crypto substrate at \`tools/installer/zeta-creds-crypto.ts\` (scrypt → HKDF chain binding key to USB-UUID) requires the UUID to be available, but the binding side was wired before the capture side existed.

## What changed

After the existing iter-4.2 ESP-probe finds \`PUBKEY_FILE\`, piggyback a `blkid` call to capture the USB filesystem UUID and write it to:

- \`/etc/zeta/usb-uuid\` (installer environment)
- \`/mnt/etc/zeta/usb-uuid\` (installed system — survives reboot)

## Algorithm

1. Determine the partition device hosting \`PUBKEY_FILE\`:
   - Try-2 path (we mounted ESP ourselves): use \`\$part\` variable
   - Try-1 path (already-mounted FS): walk up dirs with `findmnt -no SOURCE` until we find the mountpoint's source device
2. `sudo blkid -o value -s UUID <device>` → UUID
3. Write to both target paths + chmod 0644
4. Echo confirmation OR specific warning on failure

## What this does NOT yet do (subsequent sub-rows)

- Set \`ZETA_CREDS_PICKER=1\` (precondition #1)
- Prompt for passphrase to set \`ZETA_CREDS_PASSPHRASE\` (precondition #2; future sub-row matching iter-5.3 password-prompt pattern)
- Add restore-on-boot path that auto-fires when blob exists (future sub-row; uses existing \`zeta-creds-restore.ts\`)

This iteration is the SMALLEST SHIPPABLE ADVANCE — closes one of three preconditions without touching the picker invocation control-flow. Picker still SKIPs by default; subsequent sub-rows flip the other two preconditions to default-ON.

## Local validation

- `bash -n` syntax PASS
- 60 lines added; surgical to the iter-4.2 block

## Composes with

- B-0789 / iter-4.2 (existing ESP-probe + pubkey-injection substrate this commit piggybacks on)
- B-0852 / Step 6.95-picker (the picker that consumes \`/etc/zeta/usb-uuid\`)
- `tools/installer/zeta-creds-crypto.ts` (the HKDF-UUID-binding this UUID feeds)
- `tools/installer/zeta-creds-picker.ts` (existing TS impl that reads \`/etc/zeta/usb-uuid\`)
- `full-ai-cluster/INJECTION-POINTS.md` (catalog of injection points; this work makes in-flight item #5 more concrete)
- PR #5635 (cluster-type menu; different scope; no conflict)

## Test plan

- [x] Branch guard checked before commit
- [x] Tree-count canary 61
- [x] Local `bash -n` syntax check
- [ ] CI: build-ai-cluster-iso (TRIGGERED via `full-ai-cluster/usb-nixos-installer/**` path)
- [ ] Once merged + ISO rebuilds, the UUID gets captured on real boot — operator can then set \`ZETA_CREDS_PICKER=1 ZETA_CREDS_PASSPHRASE=...\` to opt into picker (next sub-rows will flip default-ON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)