### PR TITLE
feat(b-0852.3b): cred-blob passphrase prompt at Step 6.56 + unset-after-picker discipline (closes precondition #2 for cred-persistence picker)

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -508,6 +508,77 @@ else
 fi
 echo
 
+# ── Step 6.56: B-0852.3b cred-blob passphrase prompt ────────────
+#
+# Operator pain point 2026-05-27: "i'm witing on the tool to be
+# resable so i don't have to enter credentals over and over
+# everytime."
+#
+# The B-0852 cred-persistence picker at Step 6.95-picker requires 3
+# preconditions to fire:
+#
+#   1. ZETA_CREDS_PICKER=1
+#   2. ZETA_CREDS_PASSPHRASE (this step)
+#   3. /etc/zeta/usb-uuid     (closed by B-0852.3a-prep at iter-4.2)
+#
+# This step closes precondition #2 by prompting the operator for a
+# passphrase + exporting it as ZETA_CREDS_PASSPHRASE so Step 6.95-picker
+# can sudo --preserve-env it into the picker subprocess.
+#
+# Same operator-typed-once-on-console pattern as iter-5.3 password;
+# same security rationale (per the constitutional rail at
+# zeta-install.sh line 452: "secrets shouldn't transit non-operator
+# surfaces; operator-typed at install time is the safest path").
+#
+# Press Enter to SKIP — the picker stays disabled in that case + the
+# operator continues entering credentials per-reboot (current behavior).
+echo
+echo "[B-0852.3b] ── cred-blob passphrase prompt (B-0852 Phase 1) ──"
+echo "[B-0852.3b] Set a passphrase to encrypt your credentials onto"
+echo "[B-0852.3b] this USB. Future boots can RESTORE creds via the"
+echo "[B-0852.3b] same passphrase (no more re-entering gh login etc."
+echo "[B-0852.3b] on every reboot). Encryption: AES-256-GCM with key"
+echo "[B-0852.3b] derived via scrypt -> HKDF chain bound to this USB's"
+echo "[B-0852.3b] UUID (per tools/installer/zeta-creds-crypto.ts)."
+echo "[B-0852.3b]"
+echo "[B-0852.3b] Press Enter to SKIP (no cred-blob persistence;"
+echo "[B-0852.3b] keeps current per-reboot re-entry behavior)."
+echo
+ZETA_CREDS_PASSPHRASE_INPUT=""
+ZETA_CREDS_PASSPHRASE_CONFIRM=""
+# -s = silent (hidden); -p = inline prompt
+read -r -s -p "[B-0852.3b] Passphrase (or Enter to skip): " ZETA_CREDS_PASSPHRASE_INPUT
+echo
+if [ -n "$ZETA_CREDS_PASSPHRASE_INPUT" ]; then
+  read -r -s -p "[B-0852.3b] Confirm:                          " ZETA_CREDS_PASSPHRASE_CONFIRM
+  echo
+  if [ "$ZETA_CREDS_PASSPHRASE_INPUT" != "$ZETA_CREDS_PASSPHRASE_CONFIRM" ]; then
+    echo "[B-0852.3b]   WARN: passphrases don't match; skipping (no cred-blob persistence)"
+    ZETA_CREDS_PASSPHRASE_INPUT=""
+  fi
+fi
+unset ZETA_CREDS_PASSPHRASE_CONFIRM
+if [ -n "$ZETA_CREDS_PASSPHRASE_INPUT" ]; then
+  # Export for picker subprocess at Step 6.95-picker via
+  # sudo --preserve-env=ZETA_CREDS_PASSPHRASE. The picker reads it
+  # via --passphrase-env which references the env-var-NAME only (NOT
+  # the value), so the passphrase itself never appears in argv.
+  # Per zeta-creds-picker.ts SECURITY (Copilot review on PR #5450):
+  # this pattern was the explicit fix for the previous argv-leak
+  # vulnerability.
+  export ZETA_CREDS_PASSPHRASE="$ZETA_CREDS_PASSPHRASE_INPUT"
+  unset ZETA_CREDS_PASSPHRASE_INPUT
+  echo "[B-0852.3b]   passphrase captured + exported as ZETA_CREDS_PASSPHRASE"
+  echo "[B-0852.3b]   precondition #2 satisfied for Step 6.95-picker"
+  echo "[B-0852.3b]   (will be unset immediately after picker completes)"
+else
+  echo "[B-0852.3b]   skipped — no cred-blob persistence this install"
+  echo "[B-0852.3b]   (operator continues per-reboot cred re-entry; rotate"
+  echo "[B-0852.3b]   later by re-running zeta-install.sh OR manually setting"
+  echo "[B-0852.3b]   ZETA_CREDS_PASSPHRASE + ZETA_CREDS_PICKER=1 + booting)"
+fi
+echo
+
 # ── Step 6.6: iter-5.2 hostname injection (B-0792) ──────────────
 #
 # Per the maintainer 2026-05-26: "since our different roles are
@@ -1238,6 +1309,13 @@ if [ -d "$ZETA_HOME" ]; then
       HOME="$ZETA_HOME" BUN_INSTALL="$ZETA_HOME/.bun" \
       bash -c "set -o pipefail; eval \"\$(mise activate bash 2>/dev/null || true)\"; cd '$ZETA_HOME/Zeta' && bun tools/installer/zeta-creds-picker.ts --usb-uuid '$USB_UUID' --output /esp/zeta-creds.enc --passphrase-env ZETA_CREDS_PASSPHRASE" || \
         echo "[iter-5.5.0]   WARN: picker exited non-zero; cred-blob may be partial"
+    # B-0852.3b discipline: unset passphrase from installer-script env
+    # IMMEDIATELY after picker completes to minimize env-exposure window.
+    # The passphrase was operator-entered at Step 6.56; the only legitimate
+    # consumer is the picker subprocess we just spawned; subsequent install
+    # steps don't need it.
+    unset ZETA_CREDS_PASSPHRASE
+    echo "[iter-5.5.0]   ZETA_CREDS_PASSPHRASE unset from installer env (post-picker)"
   else
     echo "[iter-5.5.0]   SKIP 6.95-picker (set ZETA_CREDS_PICKER=1 + ZETA_CREDS_PASSPHRASE + /etc/zeta/usb-uuid to enable)"
   fi


### PR DESCRIPTION
## Summary

Closes precondition #2 of 3 blocking the B-0852 cred-persistence picker. Together with PR #5637 (precondition #3 USB-UUID capture), only precondition #1 (\`ZETA_CREDS_PICKER=1\` default flip) remains before the picker auto-fires for every install where the operator provided a passphrase.

Operator pain point 2026-05-27: *\"i'm witing on the tool to be resable so i don't have to enter credentals over and over everytime.\"*

## What changed

Adds Step 6.56 between iter-5.3 password (Step 6.55) and iter-5.2 hostname (Step 6.6):

```
[B-0852.3b] ── cred-blob passphrase prompt (B-0852 Phase 1) ──
[B-0852.3b] Set a passphrase to encrypt your credentials onto
[B-0852.3b] this USB. Future boots can RESTORE creds via the
[B-0852.3b] same passphrase (no more re-entering gh login etc.
[B-0852.3b] on every reboot). Encryption: AES-256-GCM with key
[B-0852.3b] derived via scrypt -> HKDF chain bound to this USB's
[B-0852.3b] UUID (per tools/installer/zeta-creds-crypto.ts).
[B-0852.3b]
[B-0852.3b] Press Enter to SKIP (no cred-blob persistence;
[B-0852.3b] keeps current per-reboot re-entry behavior).

[B-0852.3b] Passphrase (or Enter to skip): ****
[B-0852.3b] Confirm:                          ****
[B-0852.3b]   passphrase captured + exported as ZETA_CREDS_PASSPHRASE
[B-0852.3b]   precondition #2 satisfied for Step 6.95-picker
```

## Security discipline

- **Silent entry** (-s; not echoed) — same pattern as iter-5.3 password
- **Confirm prompt** — mismatch silently skips with warning
- **Empty skip** — operator can opt out cleanly by pressing Enter
- **NEVER in argv** — picker reads `--passphrase-env ZETA_CREDS_PASSPHRASE` (env-var-NAME only, not value); per Copilot review on PR #5450 that fixed prior argv-leak
- **Unset immediately after picker** — added at Step 6.95-picker; minimal env-exposure window (prompt at 6.56 → picker at 6.95 → unset right after picker exits)

## Constitutional rail compliance

Per `zeta-install.sh` line 452 verbatim: *\"secrets shouldn't transit non-operator surfaces; operator-typed at install time is the safest path.\"*

This prompt IS the operator-typed-once-on-console pattern; same security rationale as iter-5.3 password (Step 6.55) + WiFi nmtui in `zeta-first-boot.sh`.

## Precondition-closing status

| Precondition | Status |
|---|---|
| #1 `ZETA_CREDS_PICKER=1` | Still gated (next sub-row: B-0852.3c default-flip with operator-opt-out) |
| #2 `ZETA_CREDS_PASSPHRASE` | **CLOSED by this PR** |
| #3 `/etc/zeta/usb-uuid` | Closed by PR #5637 (B-0852.3a-prep iter-4.2 ESP-probe UUID capture) |

Once B-0852.3c lands, all 3 preconditions satisfied by default + picker fires for every install where operator provided a passphrase. That IS the operator's *\"don't re-enter credentials over and over\"* solution.

## Local validation

- `bash -n` syntax PASS
- ~70 lines added to Step 6.55 → 6.6 region + 4 lines added to Step 6.95-picker for the unset discipline

## Composes with

- PR #5637 (B-0852.3a-prep USB UUID capture; precondition #3)
- Step 6.95-picker (existing iter-5.5.0 picker invocation; now gets `ZETA_CREDS_PASSPHRASE` auto-set by this prompt)
- `tools/installer/zeta-creds-picker.ts` (existing TS impl that consumes the passphrase via `--passphrase-env`)
- iter-5.3 password prompt (Step 6.55) — same pattern
- Constitutional rail at `zeta-install.sh` line 452

## Test plan

- [x] Branch guard checked before commit
- [x] Tree-count canary 61
- [x] Local `bash -n` syntax check
- [ ] CI: build-ai-cluster-iso (TRIGGERED via `full-ai-cluster/usb-nixos-installer/**` path)
- [ ] Once merged + ISO rebuilds: operator can boot, get passphrase prompt at Step 6.56, set `ZETA_CREDS_PICKER=1` env var (precondition #1; not yet default), have picker auto-fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)