### PR TITLE
feat(b-0852.3c): flip ZETA_CREDS_PICKER default-ON with 4-path operator-opt-out — closes precondition #1 (the 3-of-3 closer for cred-persistence picker)

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -1219,17 +1219,47 @@ if [ -d "$ZETA_HOME" ]; then
   # logins so picker decides per-cred bake-vs-defer + the device-flow steps handle the
   # deferred subset.
   #
-  # Default: SKIP (backward compat with automated installs). Opt-in via
-  # ZETA_CREDS_PICKER=1 + ZETA_CREDS_PASSPHRASE + /etc/zeta/usb-uuid.
+  # Default behavior (B-0852.3c flip, 2026-05-27): AUTO-ENABLE when
+  # both /etc/zeta/usb-uuid (PR #5637 closes this) and
+  # ZETA_CREDS_PASSPHRASE (PR #5638 closes this via Step 6.56 prompt)
+  # are present. Explicit opt-out via ZETA_CREDS_PICKER=0 (env or
+  # /etc/zeta/no-picker marker file).
+  #
+  # Rationale: with all 3 preconditions auto-populated by the install
+  # flow, the picker becomes the operator's "don't re-enter credentials
+  # over and over" solution. Backward compat preserved: any automated
+  # install that doesn't want the picker can opt out via
+  # ZETA_CREDS_PICKER=0 OR by NOT entering a passphrase at Step 6.56
+  # (empty passphrase keeps current per-reboot re-entry behavior).
+  #
+  # Three opt-out paths (any one disables the picker):
+  #   1. ZETA_CREDS_PICKER=0 env var
+  #   2. /etc/zeta/no-picker marker file present
+  #   3. Operator entered empty passphrase at Step 6.56 (no PASSPHRASE)
   #
   # SECURITY (Copilot review on PR #5450): the passphrase is FORWARDED VIA SUDO
   # --preserve-env=ZETA_CREDS_PASSPHRASE, NOT inlined in bash -c arg-string (the
   # latter leaked the literal passphrase into the process arglist visible to ps).
   # The picker reads it via --passphrase-env which references the env-var-NAME only.
-  if [ -n "${ZETA_CREDS_PICKER:-}" ] && [ "$ZETA_CREDS_PICKER" = "1" ] && \
-     [ -f /etc/zeta/usb-uuid ] && [ -n "${ZETA_CREDS_PASSPHRASE:-}" ]; then
+  PICKER_OPT_OUT=0
+  if [ "${ZETA_CREDS_PICKER:-1}" = "0" ]; then
+    PICKER_OPT_OUT=1
+    PICKER_SKIP_REASON="ZETA_CREDS_PICKER=0 (env opt-out)"
+  elif [ -f /etc/zeta/no-picker ]; then
+    PICKER_OPT_OUT=1
+    PICKER_SKIP_REASON="/etc/zeta/no-picker marker present (file opt-out)"
+  elif [ ! -f /etc/zeta/usb-uuid ]; then
+    PICKER_OPT_OUT=1
+    PICKER_SKIP_REASON="/etc/zeta/usb-uuid missing (B-0852.3a-prep did not capture UUID)"
+  elif [ -z "${ZETA_CREDS_PASSPHRASE:-}" ]; then
+    PICKER_OPT_OUT=1
+    PICKER_SKIP_REASON="ZETA_CREDS_PASSPHRASE empty (operator skipped passphrase at Step 6.56)"
+  fi
+  if [ "$PICKER_OPT_OUT" = "0" ]; then
     USB_UUID="$(cat /etc/zeta/usb-uuid)"
-    echo "[iter-5.5.0] ── 6.95-picker: B-0852.3a cred-picker (operator interactive) ──"
+    echo "[iter-5.5.0] ── 6.95-picker: B-0852.3a cred-picker (DEFAULT-ON per B-0852.3c) ──"
+    echo "[iter-5.5.0]   passphrase from Step 6.56; usb-uuid from B-0852.3a-prep"
+    echo "[iter-5.5.0]   to opt out: set ZETA_CREDS_PICKER=0 OR touch /etc/zeta/no-picker"
     # mise activate inside bash -c matches sibling 6.95a-claude/gemini/codex
     # patterns at lines 1119-1141; without it, bun is not on the PATH the
     # subshell sees (mise installs bun via shims; activate sets PATH).
@@ -1238,8 +1268,12 @@ if [ -d "$ZETA_HOME" ]; then
       HOME="$ZETA_HOME" BUN_INSTALL="$ZETA_HOME/.bun" \
       bash -c "set -o pipefail; eval \"\$(mise activate bash 2>/dev/null || true)\"; cd '$ZETA_HOME/Zeta' && bun tools/installer/zeta-creds-picker.ts --usb-uuid '$USB_UUID' --output /esp/zeta-creds.enc --passphrase-env ZETA_CREDS_PASSPHRASE" || \
         echo "[iter-5.5.0]   WARN: picker exited non-zero; cred-blob may be partial"
+    # B-0852.3b discipline: unset passphrase from installer-script env
+    # IMMEDIATELY after picker completes to minimize env-exposure window.
+    unset ZETA_CREDS_PASSPHRASE
+    echo "[iter-5.5.0]   ZETA_CREDS_PASSPHRASE unset from installer env (post-picker)"
   else
-    echo "[iter-5.5.0]   SKIP 6.95-picker (set ZETA_CREDS_PICKER=1 + ZETA_CREDS_PASSPHRASE + /etc/zeta/usb-uuid to enable)"
+    echo "[iter-5.5.0]   SKIP 6.95-picker: $PICKER_SKIP_REASON"
   fi
 
   # 6.95b — interactive claude login (mirror iter-5.4.0 gh auth login)


### PR DESCRIPTION
## Summary

**LAST blocker** for the operator pain point named 2026-05-27: *\"i'm witing on the tool to be resable so i don't have to enter credentals over and over everytime.\"*

Together with [PR #5637](https://github.com/Lucent-Financial-Group/Zeta/pull/5637) (precondition #3 USB-UUID capture) + [PR #5638](https://github.com/Lucent-Financial-Group/Zeta/pull/5638) (precondition #2 passphrase prompt), this PR closes the last precondition. Post-merge: picker auto-fires for every install where operator entered a passphrase at Step 6.56.

## Precondition-closing status (post all 3 PRs)

| # | Precondition | Status | PR |
|---|---|---|---|
| 1 | `ZETA_CREDS_PICKER=1` | DEFAULT-ON with 4-path opt-out | **THIS PR** |
| 2 | `ZETA_CREDS_PASSPHRASE` | Auto-populated by Step 6.56 prompt | #5638 |
| 3 | `/etc/zeta/usb-uuid` | Auto-captured at iter-4.2 ESP probe | #5637 |

## What changed

Gate condition restructured from generic-AND-check to explicit-opt-out logic enumerating 4 disable conditions:

1. `ZETA_CREDS_PICKER=0` env var (explicit env opt-out)
2. `/etc/zeta/no-picker` marker file (file opt-out)
3. `/etc/zeta/usb-uuid` missing (precondition #3 failure path)
4. `ZETA_CREDS_PASSPHRASE` empty (operator skipped passphrase at Step 6.56)

Each opt-out case echoes the **SPECIFIC reason** the picker is being skipped; the previous behavior emitted only a generic \"set ZETA_CREDS_PICKER=1 + ... to enable\" message that masked which precondition was actually missing.

## Backward compatibility

- Automated installs that don't want picker: `ZETA_CREDS_PICKER=0` OR `touch /etc/zeta/no-picker` BEFORE running `zeta-install.sh`
- Operator who doesn't want cred-blob this install: press Enter at Step 6.56 passphrase prompt (empty passphrase auto-opts-out)
- Existing scripts that set `ZETA_CREDS_PICKER=1` explicitly: still work (flip is default-when-unset; explicit-1 still works)

## End-to-end operator experience (post all 3 PRs)

1. Boot live-USB; `zeta-install.sh` runs
2. Step 6.56: passphrase prompt (silent entry; confirm; mismatch silently skips)
3. iter-4.2: captures USB UUID → `/etc/zeta/usb-uuid`
4. Step 6.95-picker: auto-fires; encrypts cred-blob to `/esp/zeta-creds.enc`
5. `ZETA_CREDS_PASSPHRASE` unset from installer env (PR #5638 discipline)
6. **(Follow-up B-0852.3d)**: restore-on-boot path reads blob → operator never re-enters credentials

## Local validation

- `bash -n` syntax PASS
- ~30 lines added/restructured around gate condition

## Composes with

- PR #5637 (B-0852.3a-prep USB UUID capture)
- PR #5638 (B-0852.3b passphrase prompt + unset-after-picker)
- `tools/installer/zeta-creds-picker.ts` (existing TS impl; no changes; this PR only changes the install-script gate)
- `full-ai-cluster/INJECTION-POINTS.md` (catalog; in-flight item #5 substrate now operator-facing)

## Test plan

- [x] Branch guard checked before commit
- [x] Tree-count canary 61
- [x] Local `bash -n` syntax check
- [ ] CI: build-ai-cluster-iso (TRIGGERED via `full-ai-cluster/usb-nixos-installer/**` path)
- [ ] Once all 3 PRs merge + ISO rebuilds: operator boots, enters passphrase at Step 6.56, picker auto-fires + writes cred-blob to USB ESP

🤖 Generated with [Claude Code](https://claude.com/claude-code)