### PR TITLE
feat(b-0852.4): flip zeta.credsRestore default-on with interactive mode via common.nix — closes the loop on 'don't re-enter credentials over and over' at installed-system-boot scope

### DIFF
--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -35,15 +35,45 @@
     # ships the TS implementation; imported here so every node type
     # has the same module surface.
     ./zeta-self-register.nix
-    # B-0852.4a/d: boot-time credential restore from ESP. Disabled by
-    # default until host configs opt in via `zeta.credsRestore.enable = true;`
-    # AND operator pre-stages a passphrase source. Composes with B-0855.1
-    # zeta-self-register (which already declares
-    # `after = "zeta-creds-restore.service"`) so cred-restore fires before
-    # self-register on first boot. Imported here so every node type has
-    # the same module surface.
+    # B-0852.4a/d: boot-time credential restore from ESP.
+    #
+    # 2026-05-27 (B-0852.4 default-on flip): now enabled by default
+    # across all hosts with passphraseMode = "interactive". The unit's
+    # ConditionPathExists guard (blob + uuid + script + bun shim) means
+    # first boot before any cred-blob exists is a clean no-op; on
+    # subsequent boots the unit fires + systemd-ask-password prompts
+    # the operator ONCE for the passphrase + the restore CLI populates
+    # /home/zeta/.config/{gh,claude,gemini,codex} from the encrypted
+    # blob on the USB ESP. This closes the operator pain point named
+    # 2026-05-27: "i'm witing on the tool to be resable so i don't
+    # have to enter credentals over and over everytime."
+    #
+    # Composes with the install-side substrate cascade (PRs #5637 +
+    # #5638 + #5639) that wires Step 6.56 passphrase prompt +
+    # iter-4.2 USB-UUID capture + default-on picker. Once all those
+    # install-side preconditions are met + first install completes
+    # with cred-blob written to /esp/zeta-creds.enc, every subsequent
+    # boot of the installed system fires the restore service.
+    #
+    # Composes with B-0855.1 zeta-self-register (which already
+    # declares `after = "zeta-creds-restore.service"`) so cred-restore
+    # fires BEFORE self-register on each boot.
+    #
+    # Per-host opt-out: set `zeta.credsRestore.enable = false;` in
+    # that host's configuration.nix. Per-host passphraseMode override:
+    # `zeta.credsRestore.passphraseMode = "file";` for nodes where
+    # tty1 interactive prompt is inappropriate (e.g., headless +
+    # pre-staged `/run/zeta-creds-passphrase`).
     ./zeta-creds-restore.nix
   ];
+
+  # B-0852.4 default-on flip (operator pain point closure 2026-05-27).
+  # Both options use lib.mkDefault so per-host configs may override
+  # without conflict warnings.
+  zeta.credsRestore = {
+    enable = lib.mkDefault true;
+    passphraseMode = lib.mkDefault "interactive";
+  };
 
   nix.settings = {
     experimental-features = [ "nix-command" "flakes" ];


### PR DESCRIPTION
## Summary

Closes the loop on the operator pain point named 2026-05-27. The B-0852 install-side cascade (PRs #5637 + #5638 + #5639) writes the encrypted cred-blob; this PR enables the installed system to READ it at every subsequent boot.

## What changed

Single 2-line addition to `common.nix` (+ multi-line comment update):

\`\`\`nix
zeta.credsRestore = {
  enable = lib.mkDefault true;
  passphraseMode = lib.mkDefault \"interactive\";
};
\`\`\`

Inherits across all hosts that import `common.nix` (control-plane, worker-gpu, worker-template, future configs).

## Why safe

The module's `systemd.services.zeta-creds-restore` unit has `ConditionPathExists` guards for blob + uuid + script + bun shim. On any host without a written cred-blob (first install before picker fires, OR fresh install where operator skipped Step 6.56), the unit no-ops cleanly. No failure mode.

On hosts WITH a blob, `systemd-ask-password` prompts on tty1 at boot for the passphrase. Operator types ONCE per boot; restore CLI decrypts blob + writes `/home/zeta/.config/{gh,claude,gemini,codex}` per the declarative manifest.

## Why interactive (not file)

- **File mode** requires operator to pre-stage `/run/zeta-creds-passphrase` BEFORE service start — not auto-restore
- **Interactive mode** prompts the operator ONCE at boot via tty1 (well-established systemd pattern) — IS auto-restore

Per-host opt-out path preserved: set `zeta.credsRestore.passphraseMode = \"file\"` for headless / cluster scenarios where tty1 prompting is inappropriate.

## Why mkDefault

Per-host configs can override without conflict warnings; common module sets fleet default; individual hosts can override per their substrate.

## End-to-end operator experience (post all 4 PRs)

| Step | What happens | PR |
|---|---|---|
| First install: boot live-USB | zeta-install.sh runs | — |
| Step 6.56 | Passphrase prompt | #5638 |
| iter-4.2 | USB UUID captured to /etc/zeta/usb-uuid | #5637 |
| Step 6.95-picker | Auto-fires; writes /esp/zeta-creds.enc | #5639 |
| Operator | Goes through gh/claude/gemini/codex device-flow logins ONCE | — |
| Picker | Bundles them into the encrypted blob | — |
| Subsequent boots | zeta-creds-restore.service fires | **THIS PR** |
| systemd-ask-password | Prompts on tty1 ONCE | **THIS PR** |
| Restore CLI | Decrypts blob + writes /home/zeta/.config/{gh,claude,gemini,codex} | **THIS PR** |
| Operator | NEVER re-enters gh/claude/gemini/codex device-flow | **CLOSES LOOP** |

## Composes with

- PR #5637 (B-0852.3a-prep USB UUID capture)
- PR #5638 (B-0852.3b passphrase prompt + unset-after-picker)
- PR #5639 (B-0852.3c default-flip with 4-path opt-out)
- `full-ai-cluster/nixos/modules/zeta-creds-restore.nix` (existing module; 214 lines; no changes needed)
- `tools/installer/zeta-creds-restore.ts` (existing TS impl)
- B-0855.1 zeta-self-register (declares `After = \"zeta-creds-restore.service\"`; ordering preserved)
- `full-ai-cluster/INJECTION-POINTS.md` (catalog; in-flight item #5 now operator-facing end-to-end)

## Test plan

- [x] Branch guard checked before commit
- [x] Tree-count canary 61
- [ ] CI: build-ai-cluster-iso (TRIGGERED via `full-ai-cluster/nixos/modules/disko-shapes/**`? — actually this file is `full-ai-cluster/nixos/modules/common.nix` which is NOT in the workflow's trigger path; ISO won't rebuild from this PR alone. Combined with the install-substrate PRs (#5637/#5638/#5639) that DO trigger ISO rebuild, the substrate ships together once those merge)
- [ ] Once merged + ISO rebuilds + first install completes: every subsequent boot fires the restore service + prompts ONCE for passphrase + restores creds

🤖 Generated with [Claude Code](https://claude.com/claude-code)