### PR TITLE
fix(b-0857.2): zeta-hardware-detect.ts tsc strict — explicit-narrow on 2 noUncheckedIndexedAccess sites (#5642 lint fwd)

### DIFF
--- a/tools/installer/zeta-hardware-detect.ts
+++ b/tools/installer/zeta-hardware-detect.ts
@@ -130,7 +130,11 @@ export function classifyStorage(lsblkOutput: string): StorageShape {
     const cols = line.trim().split(/\s+/);
     if (cols.length < 3 || cols[2] !== "disk") continue;
     diskCount++;
-    const [name, rotaStr] = cols;
+    // Explicit-narrow per tsc strict noUncheckedIndexedAccess: array
+    // destructure types as `string | undefined` even after length check.
+    const name = cols[0];
+    const rotaStr = cols[1];
+    if (name === undefined || rotaStr === undefined) continue;
     if (name.startsWith("nvme")) {
       hasNvme = true;
     } else if (rotaStr === "0") {
@@ -155,8 +159,11 @@ export function parseCpuVendor(procCpuinfo: string): string {
  */
 export function parseMemoryGb(procMeminfo: string): number {
   const m = procMeminfo.match(/^MemTotal:\s+(\d+)\s+kB/m);
-  if (!m) return 0;
-  const kb = parseInt(m[1], 10);
+  // Capture group 1 typed as `string | undefined` per tsc strict
+  // noUncheckedIndexedAccess; explicit-narrow before parseInt.
+  const kbStr = m?.[1];
+  if (kbStr === undefined) return 0;
+  const kb = parseInt(kbStr, 10);
   return Math.round(kb / 1024 / 1024);
 }
 


### PR DESCRIPTION
## Summary

PR #5642 landed; \`lint (tsc tools)\` non-required check failed with 2 strict-mode errors. This is the lint-forward fix.

## Errors

- \`classifyStorage:134\` — destructure \`const [name, rotaStr] = cols\` typed as \`string | undefined\` under \`noUncheckedIndexedAccess\` even after \`cols.length < 3\` check
- \`parseMemoryGb:159\` — \`m[1]\` typed as \`string | undefined\` under same flag

Both passed runtime LOGIC; tsc strict can't narrow through array-destructure or chained optional-access without explicit-narrow.

## Fix

Explicit-narrow with \`=== undefined\` guards. No behavior change — 24/24 tests still pass; classify/parse output identical.

## Test plan

- [x] \`bun tsc --noEmit -p tsconfig.json\` clean on zeta-hardware-detect.ts
- [x] \`bun test tools/installer/zeta-hardware-detect.test.ts\` 24 pass / 0 fail
- [x] Tree-count canary 61

## Composes with

- #5642 (the file the lint warning was filed against)
- Future TS additions to tools/installer/ inherit the explicit-narrow discipline

🤖 Generated with [Claude Code](https://claude.com/claude-code)