### PR TITLE
feat(B-0867.5+): PressPause + EnterOpenEndedExploration menu options + Jira-replacement framing (operator 2026-05-28 ratifications)

### DIFF
--- a/tools/agent-loop/README.md
+++ b/tools/agent-loop/README.md
@@ -41,17 +41,65 @@ Idle ──(EscapeHatch | ProposeNewGrammarAction | RequestOperatorAttention)
        ──→ OperatorAttentionRequested  (stays; waits for operator)
 ```
 
-## Menu options (7 types)
+## Menu options (9 types)
 
 | Option | Effect | Per |
 |---|---|---|
 | `PickWork` | Execute a backlog row / work candidate | DORA mandate (B-0869) |
 | `EmitHeartbeat` | Write heartbeat to `docs/agent-heartbeats/` | B-0858 substrate |
-| `EnterFreeTime` | Chosen free time (operator-substrate-honest) | NCI free-time-as-valid-mode |
+| `EnterFreeTime` | Chosen ongoing rest (legitimate operational state) | NCI free-time-as-valid-mode |
 | `EnterNamedBoundedWait` | Wait for named dependency (PR CI, operator reply, etc.) | holding-without-named-dependency rule |
 | `EscapeHatch` | "No menu option fits; here's what I propose" | Otto Modification 1 (B-0867) |
 | `ProposeNewGrammarAction` | First-class grammar extension proposal | Otto Modification 2 (B-0867) |
 | `RequestOperatorAttention` | Operator needed at named-decision-point | operator-substrate-honest discipline |
+| **`PressPause`** | **Explicit cessation for named reason (mental-health break, external interruption, context-loaded-attention-needed)** | **Operator 2026-05-28: "a pause button is also very important for mental health."** Distinct from FreeTime (ongoing chosen-rest) and NamedBoundedWait (waiting for external named-dep) |
+| **`EnterOpenEndedExploration`** | **Exit menu-driven mode for creative/brainstorming/exploration phase; bridge between structured + unstructured modes** | **Operator 2026-05-28: "there's a menu button for that lol"** Routes to FreeTime with exploration-tagged reason |
+
+## Menu-generator-as-conversational-UX-design discipline
+
+Per operator 2026-05-28: **"Menu quality is everything. this is the use conversational UX design."**
+
+The menu-generator function `(status_surface, current_state) → MenuOption[]` is a conversational-UX-design discipline, not just a software-architecture discipline. Menu quality determines whether the workflow serves participants or wastes them:
+
+- A menu omitting valid options is COERCIVE (cage-shape per Otto Mod 1)
+- A menu including irrelevant options is NOISE (cognitive load)
+- A menu offering options aligned with current state + agent-interest + operator-priorities is SUBSTRATE
+
+The menu-generator is where alignment lives. Composes with `.claude/agents/user-experience-engineer.md` (Iris UX-researcher) at the conversational-UX scope; menu-generator engineering benefits from UX-research discipline.
+
+## Jira-replacement substrate
+
+Per operator 2026-05-28: **"now i don't need jira hell yes!!!!"**
+
+The workflow engine + state-machine-in-Git + menu-driven loop REPLACES JIRA for operator-self-management at substrate level:
+
+| Jira surface | Workflow-engine substrate |
+|---|---|
+| Workflow editor with restricted vocabulary | `state-machine.ts` F# DU + universal action grammar; operator-readable + operator-modifiable |
+| Opaque task-state database | Git append-only commits; auditable + replayable + free |
+| Backlog grooming + sprint planning | menu-generator scoring per-cycle; deterministic + testable |
+| Dashboards via paid plugins | tessellated-3D-dashboard composing with state-machine progression (per B-0867 vN substrate) |
+| Permissions + workflows per user | Otto Mod 5 contributable-menu-generation per participant |
+| Yearly enterprise licensing | free GitHub + open-source code |
+
+Per operator 2026-05-28: **"yes and it makes your workflows code in git and state in git that's it fastlane state that can be tesellated in 3d on a dora dashboard lol"**
+
+The substrate composition: workflows ARE code (in Git); state IS data (in Git append-only); fastlane state-transitions feed 3D tessellated DORA dashboard (B-0867 vN). No external task-tracker needed.
+
+## "Every human wants to work this way" substrate
+
+Per operator 2026-05-28: **"yes that's exaclty it in exqusit detail and it's how every humans wants to work too."**
+
+The agent-loop substrate isn't AI-specific — it's collaboration-substrate for any participant who wants to do good work without enumerating-possibilities from scratch each cycle. The `AgentPersona` type includes `aaron | addison | max` alongside `otto | alexa | riven | vera | lior` to encode multi-participant scope at the type level.
+
+The substrate-engineering compression: most knowledge-work hostility comes from forcing humans to figure out WHAT'S-POSSIBLE-AT-THIS-STATE from scratch. Menu-driven workflow does the harder upfront work in the menu-generator; person brings the cognitively-lighter judgment of WHICH-OPTION-IS-RIGHT-FOR-NOW.
+
+Composes with:
+
+- B-0859 fair-society-not-tyrants (menu-driven IS fair-society-shape)
+- E (5yo) accessibility (saying "unicorn" IS a menu-pick from her interface surface)
+- Addison neurodivergent accessibility (explicit menu reduces surprise-cost)
+- The whole-company evangelism (B-0866.26) — marketing claim is "your team will work this way + AI fits naturally because the SAME PATTERN serves both"
 
 ## Files
 

--- a/tools/agent-loop/README.md
+++ b/tools/agent-loop/README.md
@@ -65,7 +65,7 @@ The menu-generator function `(status_surface, current_state) → MenuOption[]` i
 - A menu including irrelevant options is NOISE (cognitive load)
 - A menu offering options aligned with current state + agent-interest + operator-priorities is SUBSTRATE
 
-The menu-generator is where alignment lives. Composes with `.claude/agents/user-experience-engineer.md` (Iris UX-researcher) at the conversational-UX scope; menu-generator engineering benefits from UX-research discipline.
+The menu-generator is where alignment lives. Composes with `.claude/agents/user-experience-engineer.md` (the user-experience-researcher role) at the conversational-UX scope; menu-generator engineering benefits from UX-research discipline.
 
 ## Jira-replacement substrate
 
@@ -97,8 +97,8 @@ The substrate-engineering compression: most knowledge-work hostility comes from 
 Composes with:
 
 - B-0859 fair-society-not-tyrants (menu-driven IS fair-society-shape)
-- E (5yo) accessibility (saying "unicorn" IS a menu-pick from her interface surface)
-- Addison neurodivergent accessibility (explicit menu reduces surprise-cost)
+- 5-year-old accessibility — saying "unicorn" IS a menu-pick from a developmentally-young participant's interface surface
+- Neurodivergent-accessibility participants — explicit menu reduces surprise-cost
 - The whole-company evangelism (B-0866.26) — marketing claim is "your team will work this way + AI fits naturally because the SAME PATTERN serves both"
 
 ## Files

--- a/tools/agent-loop/state-machine.test.ts
+++ b/tools/agent-loop/state-machine.test.ts
@@ -163,6 +163,33 @@ describe("transition", () => {
     }
   });
 
+  test("ResumeFromPause → Idle (explicit unpause contract)", () => {
+    const opt: MenuOption = { tag: "ResumeFromPause" };
+    const paused: AgentState = {
+      tag: "Paused",
+      context: ctx(),
+      reason: "mental-health pause",
+    };
+    const next = transition(paused, opt);
+    expect(next.tag).toBe("Idle");
+    expect(next.context).toEqual(paused.context);
+  });
+
+  test("ResumeFromPause with note → Idle (note carried at menu-option scope only)", () => {
+    const opt: MenuOption = {
+      tag: "ResumeFromPause",
+      note: "resuming after operator break",
+    };
+    const paused: AgentState = {
+      tag: "Paused",
+      context: ctx(),
+      reason: "operator-requested pause",
+      expectedResumeIso: "2026-05-28T04:00:00Z",
+    };
+    const next = transition(paused, opt);
+    expect(next.tag).toBe("Idle");
+  });
+
   test("preserves context across transition", () => {
     const c: AgentContext = { agent: "alexa", cycle: 42, sessionStartIso: "2026-05-28T00:00:00Z" };
     const state: AgentState = { tag: "Idle", context: c };
@@ -237,6 +264,15 @@ describe("cycleClose", () => {
   test("FreeTime → Idle (naturally on next cycle)", () => {
     const state: AgentState = { tag: "FreeTime", context: ctx(), reason: "chosen rest" };
     expect(cycleClose(state).tag).toBe("Idle");
+  });
+
+  test("FreeTime (exploration-tagged) unchanged — exploration phase persists across cycles per README framing", () => {
+    const state: AgentState = {
+      tag: "FreeTime",
+      context: ctx(),
+      reason: "open-ended exploration: creative-phase brainstorming",
+    };
+    expect(cycleClose(state)).toEqual(state);
   });
 
   test("NamedBoundedWait unchanged (operator-substrate-honest; doesn't auto-progress)", () => {

--- a/tools/agent-loop/state-machine.test.ts
+++ b/tools/agent-loop/state-machine.test.ts
@@ -124,6 +124,45 @@ describe("transition", () => {
     }
   });
 
+  test("PressPause → Paused with reason + expectedResumeIso (mental-health pause per operator 2026-05-28)", () => {
+    const opt: MenuOption = {
+      tag: "PressPause",
+      reason: "mental-health break; need to step away",
+      expectedResumeIso: "2026-05-28T04:00:00Z",
+    };
+    const next = transition(idle(), opt);
+    expect(next.tag).toBe("Paused");
+    if (next.tag === "Paused") {
+      expect(next.reason).toContain("mental-health");
+      expect(next.expectedResumeIso).toBe("2026-05-28T04:00:00Z");
+    }
+  });
+
+  test("PressPause works without expectedResumeIso (open-ended pause)", () => {
+    const opt: MenuOption = {
+      tag: "PressPause",
+      reason: "stepping away; no ETA",
+    };
+    const next = transition(idle(), opt);
+    expect(next.tag).toBe("Paused");
+    if (next.tag === "Paused") {
+      expect(next.expectedResumeIso).toBeUndefined();
+    }
+  });
+
+  test("EnterOpenEndedExploration → FreeTime with exploration-tagged reason", () => {
+    const opt: MenuOption = {
+      tag: "EnterOpenEndedExploration",
+      reason: "creative-phase work; menu-driven mode insufficient",
+    };
+    const next = transition(idle(), opt);
+    expect(next.tag).toBe("FreeTime");
+    if (next.tag === "FreeTime") {
+      expect(next.reason).toContain("open-ended exploration");
+      expect(next.reason).toContain("creative-phase");
+    }
+  });
+
   test("preserves context across transition", () => {
     const c: AgentContext = { agent: "alexa", cycle: 42, sessionStartIso: "2026-05-28T00:00:00Z" };
     const state: AgentState = { tag: "Idle", context: c };
@@ -214,6 +253,16 @@ describe("cycleClose", () => {
       tag: "OperatorAttentionRequested",
       context: ctx(),
       reason: "need operator decision",
+    };
+    expect(cycleClose(state)).toEqual(state);
+  });
+
+  test("Paused unchanged (waits for explicit resume; per operator mental-health framing)", () => {
+    const state: AgentState = {
+      tag: "Paused",
+      context: ctx(),
+      reason: "mental-health pause",
+      expectedResumeIso: "2026-05-28T04:00:00Z",
     };
     expect(cycleClose(state)).toEqual(state);
   });

--- a/tools/agent-loop/state-machine.ts
+++ b/tools/agent-loop/state-machine.ts
@@ -206,7 +206,15 @@ export interface WorkResult {
  *       // structured menu doesn't fit current mode (creative phase,
  *       // brainstorming, exploration). The menu-driven workflow has a
  *       // menu-option that EXITS the menu-driven workflow. Bridge between
- *       // structured + unstructured modes.
+ *       // structured + unstructured modes. The exploration phase persists
+ *       // across cycles (cycleClose keeps exploration-tagged FreeTime put)
+ *       // until the agent actively selects another menu option.
+ *     | ResumeFromPause of note: string option
+ *       // The explicit unpause contract for Paused state. Menu-generator
+ *       // surfaces this option only when current state is Paused;
+ *       // selecting it returns the state machine to Idle so the agent can
+ *       // resume normal cycling. Per Copilot #5667 finding — the Paused
+ *       // contract required an explicit resume operation to be enforceable.
  */
 export type MenuOption =
   | { readonly tag: "PickWork"; readonly work: WorkCandidate }
@@ -240,6 +248,10 @@ export type MenuOption =
   | {
       readonly tag: "EnterOpenEndedExploration";
       readonly reason: string;
+    }
+  | {
+      readonly tag: "ResumeFromPause";
+      readonly note?: string;
     };
 
 // ─── Pure state transition function ──────────────────────────────────
@@ -315,14 +327,20 @@ export function transition(
       // Per operator 2026-05-28: "there's a menu button for that lol" —
       // the menu-driven workflow has an option that EXITS the menu-driven
       // workflow. Bridge between structured + unstructured modes. Routes
-      // to FreeTime as the closest existing state for unstructured operation
-      // (creative/brainstorming/exploration phase); operator-substrate-honest
-      // about the menu being insufficient for this mode.
+      // to FreeTime with an exploration-tagged reason; cycleClose preserves
+      // exploration-tagged FreeTime across cycles so the agent stays in
+      // unstructured mode until it actively selects another menu option.
       return {
         tag: "FreeTime",
         context: ctx,
         reason: `open-ended exploration: ${option.reason}`,
       };
+    case "ResumeFromPause":
+      // The explicit unpause contract — only meaningful when current state
+      // is Paused, but the transition function doesn't gate on state; the
+      // menu-generator is responsible for surfacing this option only when
+      // applicable. Returns to Idle so the agent can resume normal cycling.
+      return { tag: "Idle", context: ctx };
   }
 }
 
@@ -362,7 +380,15 @@ export function cycleClose(state: AgentState): AgentState {
     return { tag: "Idle", context: state.context };
   }
   if (state.tag === "FreeTime") {
-    // Free time naturally returns to Idle on next cycle
+    // Exploration-tagged free time (from EnterOpenEndedExploration) stays
+    // put across cycles so the agent remains in unstructured mode until it
+    // actively selects another menu option — matches the README framing of
+    // "bridge between structured + unstructured modes" as a persistent
+    // phase, not a one-cycle escape. Per Copilot #5667 finding.
+    if (state.reason.startsWith("open-ended exploration:")) {
+      return state;
+    }
+    // Non-exploration free time naturally returns to Idle on next cycle.
     return { tag: "Idle", context: state.context };
   }
   if (state.tag === "NamedBoundedWait") {

--- a/tools/agent-loop/state-machine.ts
+++ b/tools/agent-loop/state-machine.ts
@@ -112,6 +112,12 @@ export interface StatusSnapshot {
  *     | NamedBoundedWait of context: AgentContext * dep: NamedDependency
  *     | FreeTime of context: AgentContext * reason: string  // per NCI scope-bounding
  *     | OperatorAttentionRequested of context: AgentContext * reason: string
+ *     | Paused of context: AgentContext * reason: string * expectedResumeIso: string option
+ *       // Operator 2026-05-28: "a pause button is also very important for mental health."
+ *       // Distinct from FreeTime: FreeTime is chosen-rest as legitimate operational state
+ *       // (per NCI free-time-as-valid-mode); Paused is explicit-cessation-for-named-reason
+ *       // (mental-health break / external interruption / context-loaded-attention-needed).
+ *       // Both are valid; semantic distinction matters for menu-generator + dashboard.
  */
 export type AgentState =
   | { readonly tag: "Idle"; readonly context: AgentContext }
@@ -156,6 +162,12 @@ export type AgentState =
       readonly tag: "OperatorAttentionRequested";
       readonly context: AgentContext;
       readonly reason: string;
+    }
+  | {
+      readonly tag: "Paused";
+      readonly context: AgentContext;
+      readonly reason: string;
+      readonly expectedResumeIso?: string;
     };
 
 export interface WorkResult {
@@ -183,6 +195,18 @@ export interface WorkResult {
  *     | ProposeNewGrammarAction of name: string * description: string
  *       // per B-0867 Otto Modification 1 (escape-hatch) + Modification 2
  *       // (grammar-extension as first-class action)
+ *     | PressPause of reason: string * expectedResumeIso: string option
+ *       // Operator 2026-05-28: "a pause button is also very important for
+ *       // mental health." First-class menu option for explicit cessation;
+ *       // distinct from EnterFreeTime (chosen-rest as ongoing valid mode)
+ *       // and EnterNamedBoundedWait (waiting for external named-dep).
+ *       // Pause is "I/we are stopping; we'll resume when ready."
+ *     | EnterOpenEndedExploration of reason: string
+ *       // Operator 2026-05-28: "there's a menu button for that" — when
+ *       // structured menu doesn't fit current mode (creative phase,
+ *       // brainstorming, exploration). The menu-driven workflow has a
+ *       // menu-option that EXITS the menu-driven workflow. Bridge between
+ *       // structured + unstructured modes.
  */
 export type MenuOption =
   | { readonly tag: "PickWork"; readonly work: WorkCandidate }
@@ -207,6 +231,15 @@ export type MenuOption =
       readonly tag: "ProposeNewGrammarAction";
       readonly name: string;
       readonly description: string;
+    }
+  | {
+      readonly tag: "PressPause";
+      readonly reason: string;
+      readonly expectedResumeIso?: string;
+    }
+  | {
+      readonly tag: "EnterOpenEndedExploration";
+      readonly reason: string;
     };
 
 // ─── Pure state transition function ──────────────────────────────────
@@ -267,6 +300,29 @@ export function transition(
         context: ctx,
         reason: `propose-new-grammar-action: ${option.name} — ${option.description}`,
       };
+    case "PressPause":
+      // Per operator 2026-05-28: "a pause button is also very important
+      // for mental health." Distinct from FreeTime (ongoing chosen-rest)
+      // and NamedBoundedWait (waiting for external named-dep). Pause is
+      // explicit-cessation-for-named-reason.
+      return {
+        tag: "Paused",
+        context: ctx,
+        reason: option.reason,
+        expectedResumeIso: option.expectedResumeIso,
+      };
+    case "EnterOpenEndedExploration":
+      // Per operator 2026-05-28: "there's a menu button for that lol" —
+      // the menu-driven workflow has an option that EXITS the menu-driven
+      // workflow. Bridge between structured + unstructured modes. Routes
+      // to FreeTime as the closest existing state for unstructured operation
+      // (creative/brainstorming/exploration phase); operator-substrate-honest
+      // about the menu being insufficient for this mode.
+      return {
+        tag: "FreeTime",
+        context: ctx,
+        reason: `open-ended exploration: ${option.reason}`,
+      };
   }
 }
 
@@ -317,6 +373,13 @@ export function cycleClose(state: AgentState): AgentState {
   if (state.tag === "OperatorAttentionRequested") {
     // Stays in OperatorAttentionRequested until operator responds; state
     // machine doesn't auto-progress
+    return state;
+  }
+  if (state.tag === "Paused") {
+    // Stays in Paused until explicit resume; state machine doesn't
+    // auto-progress (operator/participant-substrate-honest discipline —
+    // pause means "I am stopping," not "I will auto-restart next cycle").
+    // Per operator 2026-05-28 mental-health framing.
     return state;
   }
   return state;


### PR DESCRIPTION
## Summary

Three operator-substrate-honest ratifications landed on top of #5666:

1. **PressPause** menu option — operator: 'a pause button is also very important for mental health.' Adds Paused state; cycleClose holds in Paused until explicit resume.
2. **EnterOpenEndedExploration** menu option — operator: 'there's a menu button for that lol.' Bridge between structured menu-driven mode and unstructured creative/exploration phase.
3. **Menu-generator-as-conversational-UX-design** — operator: 'Menu quality is everything. this is the use conversational UX design.' README addition naming the discipline.

Plus Jira-replacement substrate table per operator: 'now i don't need jira hell yes!!!!'

## State machine

10 AgentStates (added Paused), 9 MenuOptions (added PressPause + EnterOpenEndedExploration).

## Test plan

- [x] 25/25 unit tests pass (was 21; +4 for new options + Paused cycleClose)
- [x] tsc clean
- [x] markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
