### PR TITLE
feat(agentic-org): add live substrate proof harnesses

### DIFF
--- a/agentic-organization/apps/workers/README.md
+++ b/agentic-organization/apps/workers/README.md
@@ -106,6 +106,12 @@ migration runner as a process bootstrapper, and
 through the generic SQL client before the runtime runs. The Cockroach
 worker client also exposes a pool shutdown adapter when the
 process-provided pool supports `end()`.
+`createPgCockroachWorkerPool` is the first optional live-driver binding
+for that pool contract. It dynamically loads a `pg`-compatible driver at
+the app boundary, adapts `Pool.connect()`, `client.query()`,
+`client.release()`, and `Pool.end()` to the generic worker pool
+interfaces, and keeps the reusable state packages free of driver
+imports.
 `connectNatsWorkerAdapters` is the app-level seam where a process
 transport factory becomes the generic NATS publisher, pull-consumer,
 dead-letter publisher, readiness probe, and shutdown port. Dead-letter
@@ -116,6 +122,43 @@ transport dedupe key. `createNatsJsTransportConnectionFactory` is the
 first concrete NATS client-library binding behind that seam. It uses
 `@nats-io/transport-node` for the Node connection and
 `@nats-io/jetstream` for publish, durable pull-consumer fetch,
-readiness, and shutdown. Today tests still use fake clients; the later
-NATS integration proof must exercise a real server, stream, durable
-consumer, credentials/TLS if enabled, and ack timing.
+readiness, and shutdown. The normal tests still use fake clients, while
+the env-gated NATS integration proof exercises a real server, stream,
+durable consumer, publish path, pull path, ack, invalid-envelope DLQ
+handling, readiness, and shutdown.
+
+## Integration Tests
+
+The normal test suite is fake-driven and does not require live cluster
+services. Live proofs are skipped unless their environment variables are
+present.
+
+The Cockroach integration proof is env-gated:
+
+- set `AGENTIC_ORG_COCKROACH_INTEGRATION_DATABASE_URL` to a
+  CockroachDB/PostgreSQL-compatible connection URL;
+- use the root dependency graph, which declares the `pg` driver used by
+  the default app-local pool adapter;
+- run the regular `npm test` command from `agentic-organization/`.
+
+The NATS integration proof is env-gated:
+
+- set `AGENTIC_ORG_NATS_INTEGRATION_SERVERS` to one or more comma-
+  separated NATS server URLs with JetStream enabled;
+- ensure the test process can create and delete per-run streams and
+  durable consumers prefixed by `AGENTIC_ORG_INTEGRATION_EVENTS` and
+  `agentic-org-integration-worker`;
+- run the regular `npm test` command from `agentic-organization/`.
+
+When the Cockroach env var is present, the test applies Organization
+migrations, checks readiness, proves commit and rollback behavior
+through the generic SQL executor, and verifies graceful pool shutdown
+through the generic process shutdown port. When the NATS env var is
+present, the test recreates a small per-run integration stream and
+durable consumer, publishes a canonical event through the worker
+adapter, consumes it through the generic ingestion port, acknowledges
+it, smoke-tests invalid-envelope DLQ handling, and closes the generic
+NATS shutdown port.
+The Cockroach proof also uses a per-run probe table prefixed by
+`agentic_org_integration_probe` and drops it before pool shutdown so a
+shared dev database is not polluted by successful runs.

--- a/agentic-organization/apps/workers/src/adapters/pg-cockroach-worker-pool.ts
+++ b/agentic-organization/apps/workers/src/adapters/pg-cockroach-worker-pool.ts
@@ -1,0 +1,114 @@
+import type { CockroachAnySqlResult } from "../../../../packages/state-cockroach/src/index.ts";
+import type { CockroachWorkerPool, CockroachWorkerPoolClient, CockroachWorkerShutdownPool } from "./cockroach-worker-client.ts";
+
+export const PgCockroachWorkerPoolErrorCode = {
+  InvalidDriverModule: "invalid_driver_module",
+} as const;
+
+export type PgCockroachWorkerPoolErrorCode =
+  (typeof PgCockroachWorkerPoolErrorCode)[keyof typeof PgCockroachWorkerPoolErrorCode];
+
+export const PgCockroachDriverModuleName = {
+  Pg: "pg",
+} as const;
+
+export type PgCockroachDriverModuleName =
+  (typeof PgCockroachDriverModuleName)[keyof typeof PgCockroachDriverModuleName];
+
+export class PgCockroachWorkerPoolError extends Error {
+  readonly code: PgCockroachWorkerPoolErrorCode;
+
+  constructor(input: { code: PgCockroachWorkerPoolErrorCode; message: string; cause?: unknown }) {
+    super(input.message, {
+      cause: input.cause,
+    });
+    this.code = input.code;
+  }
+}
+
+export type PgCockroachQueryResult<Row = Record<string, unknown>> = {
+  rows: Row[];
+};
+
+export type PgCockroachPoolClient = {
+  query: <Row = Record<string, unknown>>(
+    sql: string,
+    parameters?: readonly unknown[],
+  ) => Promise<PgCockroachQueryResult<Row>>;
+  release: () => void;
+};
+
+export type PgCockroachPool = {
+  connect: () => Promise<PgCockroachPoolClient>;
+  end: () => Promise<void>;
+};
+
+export type PgCockroachPoolConstructor = new (input: { connectionString: string }) => PgCockroachPool;
+
+export type PgCockroachDriverModule = {
+  Pool: PgCockroachPoolConstructor;
+};
+
+export type PgCockroachDriverLoader = () => Promise<unknown>;
+
+export type CreatePgCockroachWorkerPoolInput = {
+  databaseUrl: string;
+  loadDriver?: PgCockroachDriverLoader;
+};
+
+export type PgCockroachWorkerPool = CockroachWorkerPool & CockroachWorkerShutdownPool;
+
+export async function createPgCockroachWorkerPool(
+  input: CreatePgCockroachWorkerPoolInput,
+): Promise<PgCockroachWorkerPool> {
+  const driver = assertPgCockroachDriverModule(await (input.loadDriver ?? loadDefaultPgCockroachDriver)());
+  const pool = new driver.Pool({
+    connectionString: input.databaseUrl,
+  });
+
+  return {
+    connect: async () => adaptPgCockroachPoolClient(await pool.connect()),
+    end: async () => {
+      await pool.end();
+    },
+  };
+}
+
+async function loadDefaultPgCockroachDriver(): Promise<unknown> {
+  return await import(PgCockroachDriverModuleName.Pg);
+}
+
+function adaptPgCockroachPoolClient(client: PgCockroachPoolClient): CockroachWorkerPoolClient {
+  return {
+    query: async <Row = Record<string, unknown>>(
+      sql: string,
+      parameters: readonly unknown[] = [],
+    ): Promise<CockroachAnySqlResult<Row>> => {
+      const result = await client.query<Row>(sql, parameters);
+
+      return {
+        rows: result.rows,
+      };
+    },
+    release: () => {
+      client.release();
+    },
+  };
+}
+
+function assertPgCockroachDriverModule(module: unknown): PgCockroachDriverModule {
+  if (
+    typeof module === "object" &&
+    module !== null &&
+    "Pool" in module &&
+    typeof module.Pool === "function"
+  ) {
+    return module as PgCockroachDriverModule;
+  }
+
+  throw new PgCockroachWorkerPoolError({
+    code: PgCockroachWorkerPoolErrorCode.InvalidDriverModule,
+    message: "pg-compatible Cockroach driver module must export Pool",
+    cause: module,
+  });
+}

--- a/agentic-organization/apps/workers/src/index.ts
+++ b/agentic-organization/apps/workers/src/index.ts
@@ -19,6 +19,20 @@ export {
   type CreateCockroachWorkerSqlClientInput,
 } from "./adapters/cockroach-worker-client.ts";
 export {
+  PgCockroachDriverModuleName,
+  PgCockroachWorkerPoolError,
+  PgCockroachWorkerPoolErrorCode,
+  createPgCockroachWorkerPool,
+  type CreatePgCockroachWorkerPoolInput,
+  type PgCockroachDriverLoader,
+  type PgCockroachDriverModule,
+  type PgCockroachPool,
+  type PgCockroachPoolClient,
+  type PgCockroachPoolConstructor,
+  type PgCockroachQueryResult,
+  type PgCockroachWorkerPool,
+} from "./adapters/pg-cockroach-worker-pool.ts";
+export {
   createJsonWorkerTelemetrySink,
   type CreateJsonWorkerTelemetrySinkInput,
   type JsonLineWriter,
@@ -109,3 +123,8 @@ export {
   type WorkerProcessShutdownPort,
   type WorkerProcessShutdownResult,
 } from "./worker-process.ts";
+export {
+  CockroachMigrationStatement,
+  createCockroachSqlExecutor,
+  type CockroachAnySqlStatement,
+} from "../../../packages/state-cockroach/src/index.ts";

--- a/agentic-organization/apps/workers/test/cockroach-integration.test.ts
+++ b/agentic-organization/apps/workers/test/cockroach-integration.test.ts
@@ -1,0 +1,282 @@
+import { deepEqual, equal, ok } from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { env } from "node:process";
+import { describe, test } from "node:test";
+
+import {
+  CockroachMigrationStatement,
+  WorkerDependencyName,
+  WorkerDependencyReadinessStatus,
+  WorkerProcessShutdownStatus,
+  WorkerReadinessStatus,
+  WorkerRuntimeStatus,
+  createCockroachMigrationBootstrapper,
+  createCockroachReadinessProbe,
+  createCockroachSqlExecutor,
+  createCockroachWorkerShutdownPort,
+  createCockroachWorkerSqlClient,
+  createPgCockroachWorkerPool,
+  createWorkerProcess,
+  type CockroachAnySqlStatement,
+} from "../src/index.ts";
+
+const CockroachIntegrationEnvName = {
+  DatabaseUrl: "AGENTIC_ORG_COCKROACH_INTEGRATION_DATABASE_URL",
+} as const;
+
+const CockroachIntegrationTableNamePrefix = {
+  Probe: "agentic_org_integration_probe",
+} as const;
+
+const CockroachIntegrationProbeValue = {
+  Committed: "committed",
+  RolledBack: "rolled_back",
+} as const;
+
+const CockroachIntegrationProbeId = {
+  Commit: "commit-probe",
+  Rollback: "rollback-probe",
+} as const;
+
+const CockroachIntegrationStatementName = {
+  CreateProbeTable: "integration_create_probe_table",
+  DeleteProbe: "integration_delete_probe",
+  DeleteProbeBeforeRollback: "integration_delete_probe_before_rollback",
+  DropProbeTable: "integration_drop_probe_table",
+  InsertProbe: "integration_insert_probe",
+  InsertProbeBeforeRollback: "integration_insert_probe_before_rollback",
+  SelectProbe: "integration_select_probe",
+  SelectRolledBackProbe: "integration_select_rolled_back_probe",
+} as const;
+
+const CockroachIntegrationRuntimeErrorMessage = {
+  RollbackProbe: "rollback probe",
+} as const;
+
+type CockroachIntegrationRun = {
+  sql: CockroachIntegrationSql;
+  tableName: string;
+};
+
+type CockroachIntegrationSql = {
+  CreateProbeTable: string;
+  DeleteProbe: string;
+  DropProbeTable: string;
+  InsertProbe: string;
+  SelectProbe: string;
+};
+
+describe("Cockroach worker live integration", () => {
+  test(
+    "applies migrations, reports readiness, commits transactions, rolls back failures, and shuts down",
+    {
+      skip:
+        env[CockroachIntegrationEnvName.DatabaseUrl] === undefined
+          ? `${CockroachIntegrationEnvName.DatabaseUrl} is not set`
+          : false,
+    },
+    async () => {
+      const databaseUrl = readIntegrationDatabaseUrl();
+      const run = createCockroachIntegrationRun();
+      const pool = await createPgCockroachWorkerPool({
+        databaseUrl,
+      });
+      const sqlClient = createCockroachWorkerSqlClient({
+        pool,
+        maxTransactionAttempts: 2,
+      });
+      const executor = createCockroachSqlExecutor({
+        client: sqlClient,
+      });
+      const executedStatements: string[] = [];
+      const recordingExecutor = createRecordingExecutor(executor, executedStatements);
+      const process = createWorkerProcess({
+        bootstrappers: [
+          createCockroachMigrationBootstrapper({
+            executor: recordingExecutor,
+          }),
+        ],
+        readinessProbes: [
+          createCockroachReadinessProbe({
+            client: sqlClient,
+          }),
+        ],
+        runtime: {
+          runOnce: async () => ({
+            failures: [],
+            natsConsumerBatch: undefined,
+            status: WorkerRuntimeStatus.Healthy,
+            workerCycle: undefined,
+          }),
+        },
+        shutdownPorts: [
+          createCockroachWorkerShutdownPort({
+            pool,
+          }),
+        ],
+      });
+
+      try {
+        const runResult = await process.runOnce();
+
+        equal(runResult.status, WorkerRuntimeStatus.Healthy);
+        equal(runResult.readiness?.status, WorkerReadinessStatus.Ready);
+        deepEqual(runResult.failures, []);
+        ok(executedStatements.includes(CockroachMigrationStatement.ApplyMigration));
+
+        await executor.execute({
+          name: CockroachIntegrationStatementName.CreateProbeTable,
+          sql: run.sql.CreateProbeTable,
+          parameters: [],
+        });
+        await executor.executeTransaction(async (transaction) => {
+          await transaction.execute({
+            name: CockroachIntegrationStatementName.DeleteProbe,
+            sql: run.sql.DeleteProbe,
+            parameters: [CockroachIntegrationProbeId.Commit],
+          });
+          await transaction.execute({
+            name: CockroachIntegrationStatementName.InsertProbe,
+            sql: run.sql.InsertProbe,
+            parameters: [CockroachIntegrationProbeId.Commit, CockroachIntegrationProbeValue.Committed],
+          });
+        });
+
+        const committedProbe = await executor.execute<{ value: string }>({
+          name: CockroachIntegrationStatementName.SelectProbe,
+          sql: run.sql.SelectProbe,
+          parameters: [CockroachIntegrationProbeId.Commit],
+        });
+
+        deepEqual(committedProbe.rows, [{ value: CockroachIntegrationProbeValue.Committed }]);
+
+        await assertRollbackKeepsProbeAbsent(executor, run);
+
+        const readiness = await createCockroachReadinessProbe({
+          client: sqlClient,
+        }).check();
+
+        deepEqual(readiness, {
+          name: WorkerDependencyName.Cockroach,
+          status: WorkerDependencyReadinessStatus.Ready,
+        });
+      } finally {
+        await dropProbeTable(executor, run);
+
+        const shutdownResult = await process.shutdown();
+
+        deepEqual(shutdownResult, {
+          status: WorkerProcessShutdownStatus.Completed,
+          closedPortNames: [WorkerDependencyName.Cockroach],
+          failures: [],
+        });
+      }
+    },
+  );
+});
+
+async function dropProbeTable(
+  executor: ReturnType<typeof createCockroachSqlExecutor>,
+  run: CockroachIntegrationRun,
+): Promise<void> {
+  try {
+    await executor.execute({
+      name: CockroachIntegrationStatementName.DropProbeTable,
+      sql: run.sql.DropProbeTable,
+      parameters: [],
+    });
+  } catch {
+    // Cleanup is best-effort because a failed integration setup may not have created the per-run table.
+  }
+}
+
+async function assertRollbackKeepsProbeAbsent(
+  executor: ReturnType<typeof createCockroachSqlExecutor>,
+  run: CockroachIntegrationRun,
+): Promise<void> {
+  await executor.execute({
+    name: CockroachIntegrationStatementName.DeleteProbeBeforeRollback,
+    sql: run.sql.DeleteProbe,
+    parameters: [CockroachIntegrationProbeId.Rollback],
+  });
+
+  await executor.executeTransaction(async (transaction) => {
+    await transaction.execute({
+      name: CockroachIntegrationStatementName.InsertProbeBeforeRollback,
+      sql: run.sql.InsertProbe,
+      parameters: [CockroachIntegrationProbeId.Rollback, CockroachIntegrationProbeValue.RolledBack],
+    });
+    throw new Error(CockroachIntegrationRuntimeErrorMessage.RollbackProbe);
+  }).catch((error: unknown) => {
+    if (!(error instanceof Error) || error.message !== CockroachIntegrationRuntimeErrorMessage.RollbackProbe) {
+      throw error;
+    }
+  });
+
+  const rolledBackProbe = await executor.execute<{ value: string }>({
+    name: CockroachIntegrationStatementName.SelectRolledBackProbe,
+    sql: run.sql.SelectProbe,
+    parameters: [CockroachIntegrationProbeId.Rollback],
+  });
+
+  deepEqual(rolledBackProbe.rows, []);
+}
+
+function createCockroachIntegrationRun(): CockroachIntegrationRun {
+  const tableName = `${CockroachIntegrationTableNamePrefix.Probe}_${randomUUID().replaceAll("-", "_")}`;
+
+  return {
+    sql: createCockroachIntegrationSql(tableName),
+    tableName,
+  };
+}
+
+function createCockroachIntegrationSql(tableName: string): CockroachIntegrationSql {
+  assertSafeCockroachIdentifier(tableName);
+
+  return {
+    CreateProbeTable: `CREATE TABLE IF NOT EXISTS ${tableName} (id STRING PRIMARY KEY, value STRING NOT NULL)`,
+    DeleteProbe: `DELETE FROM ${tableName} WHERE id = $1`,
+    DropProbeTable: `DROP TABLE IF EXISTS ${tableName}`,
+    InsertProbe: `INSERT INTO ${tableName} (id, value) VALUES ($1, $2)`,
+    SelectProbe: `SELECT value FROM ${tableName} WHERE id = $1`,
+  };
+}
+
+function assertSafeCockroachIdentifier(identifier: string): void {
+  if (!/^[a-z][a-z0-9_]*$/.test(identifier)) {
+    throw new Error(`unsafe Cockroach integration identifier: ${identifier}`);
+  }
+}
+
+function createRecordingExecutor(
+  executor: ReturnType<typeof createCockroachSqlExecutor>,
+  executedStatements: string[],
+): ReturnType<typeof createCockroachSqlExecutor> {
+  return {
+    execute: async (statement) => {
+      executedStatements.push(statement.name);
+      return await executor.execute(statement);
+    },
+    executeTransaction: async (operation) =>
+      await executor.executeTransaction(
+        async (transaction) =>
+          await operation({
+            execute: async (statement: CockroachAnySqlStatement) => {
+              executedStatements.push(statement.name);
+              return await transaction.execute(statement);
+            },
+          }),
+      ),
+  };
+}
+
+function readIntegrationDatabaseUrl(): string {
+  const databaseUrl = env[CockroachIntegrationEnvName.DatabaseUrl];
+
+  if (databaseUrl === undefined || databaseUrl.trim().length === 0) {
+    throw new Error(`${CockroachIntegrationEnvName.DatabaseUrl} is required for Cockroach integration tests`);
+  }
+
+  return databaseUrl.trim();
+}

--- a/agentic-organization/apps/workers/test/nats-integration.test.ts
+++ b/agentic-organization/apps/workers/test/nats-integration.test.ts
@@ -1,0 +1,375 @@
+import { deepEqual } from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { env } from "node:process";
+import { describe, test } from "node:test";
+
+import {
+  AckPolicy,
+  DeliverPolicy,
+  DiscardPolicy,
+  ReplayPolicy,
+  RetentionPolicy,
+  StorageType,
+  jetstream,
+  jetstreamManager,
+} from "@nats-io/jetstream";
+import { connect, type NatsConnection } from "@nats-io/transport-node";
+
+import {
+  AgenticAggregateType,
+  AgenticEventType,
+  createAgenticEventEnvelope,
+  type AgenticEventEnvelope,
+} from "../../../packages/domain/src/index.ts";
+import {
+  AgenticSubjectPrefix,
+  AgenticMessagingDomain,
+  buildAgenticEventSubject,
+} from "../../../packages/messaging/src/index.ts";
+import {
+  createNatsJetStreamEventConsumer,
+} from "../../../packages/messaging-nats/src/index.ts";
+import {
+  EventIngestionOutcomeStatus,
+} from "../../../packages/state/src/index.ts";
+import {
+  WorkerDependencyName,
+  WorkerDependencyReadinessStatus,
+  connectNatsWorkerAdapters,
+  createNatsJsTransportConnectionFactory,
+  type NatsWorkerAdapters,
+} from "../src/index.ts";
+
+const NatsIntegrationEnvName = {
+  Servers: "AGENTIC_ORG_NATS_INTEGRATION_SERVERS",
+} as const;
+
+const NatsIntegrationStaticName = {
+  DeadLetterSubjectSegment: "dead_letter",
+  Environment: "integration",
+  DeadLetterId: "integration-dead-letter",
+} as const;
+
+const NatsIntegrationResourcePrefix = {
+  Durable: "agentic-org-integration-worker",
+  Organization: "org-nats-integration",
+  Stream: "AGENTIC_ORG_INTEGRATION_EVENTS",
+} as const;
+
+const NatsIntegrationFetch = {
+  BatchSize: 1,
+  ExpiresMs: 2_000,
+} as const;
+
+const NatsIntegrationId = {
+  Agent: "agent-nats-integration",
+  Aggregate: "supervisor-signal-nats-integration",
+  Causation: "cause-nats-integration",
+  Command: "command-nats-integration",
+  Correlation: "correlation-nats-integration",
+  Event: "event-nats-integration",
+  HatAssignment: "hat-assignment-nats-integration",
+  IdempotencyKey: "idempotency-nats-integration",
+  Initiative: "initiative-nats-integration",
+  OutboxEvent: "outbox-nats-integration",
+  Project: "project-nats-integration",
+  Team: "team-nats-integration",
+  Trace: "trace-nats-integration",
+  WorkItem: "work-item-nats-integration",
+} as const;
+
+const NatsIntegrationTime = {
+  OccurredAt: "2026-05-27T00:00:00.000Z",
+} as const;
+
+const NatsIntegrationPayload = {
+  InvalidEnvelope: "not a canonical event envelope",
+  Subject: "NATS live integration proof",
+} as const;
+
+describe("NATS worker live integration", () => {
+  test(
+    "publishes a canonical event, consumes it through the generic ingestion port, acknowledges it, and shuts down",
+    {
+      skip:
+        env[NatsIntegrationEnvName.Servers] === undefined
+          ? `${NatsIntegrationEnvName.Servers} is not set`
+          : false,
+    },
+    async () => {
+      const servers = readIntegrationNatsServers();
+      const run = createNatsIntegrationRun();
+      await recreateNatsIntegrationSubstrate(servers, run);
+
+      let adapters: NatsWorkerAdapters | undefined;
+
+      try {
+        adapters = await connectNatsWorkerAdapters({
+          config: {
+            durableName: run.durableName,
+            environment: NatsIntegrationStaticName.Environment,
+            organizationId: run.organizationId,
+            servers,
+            streamName: run.streamName,
+          },
+          deadLetterMessageIdFactory: {
+            createId: () => NatsIntegrationStaticName.DeadLetterId,
+          },
+          transportFactory: createNatsJsTransportConnectionFactory({
+            fetchExpiresMs: NatsIntegrationFetch.ExpiresMs,
+          }),
+        });
+
+        const readiness = await adapters.readinessProbe.check();
+
+        deepEqual(readiness, {
+          name: WorkerDependencyName.Nats,
+          status: WorkerDependencyReadinessStatus.Ready,
+        });
+
+        const envelope = createIntegrationEnvelope(run);
+
+        await adapters.eventPublisher.publish({
+          subject: run.subject,
+          outboxEvent: {
+            outboxEventId: run.outboxEventId,
+            envelope,
+          },
+        });
+
+        const ingestedEnvelopes: AgenticEventEnvelope[] = [];
+        const consumer = createNatsJetStreamEventConsumer({
+          pullConsumer: adapters.pullConsumer,
+          deadLetterPublisher: adapters.deadLetterPublisher,
+          eventIngestionProcessor: {
+            ingest: async (input) => {
+              ingestedEnvelopes.push(input.envelope);
+
+              return {
+                status: EventIngestionOutcomeStatus.Processed,
+                reactionPlans: [],
+              };
+            },
+          },
+        });
+
+        const result = await consumer.processNextBatch({
+          batchSize: NatsIntegrationFetch.BatchSize,
+        });
+
+        deepEqual(result, {
+          receivedCount: 1,
+          processedCount: 1,
+          duplicateCount: 0,
+          payloadConflictCount: 0,
+          invalidCount: 0,
+          failedCount: 0,
+          acknowledgedCount: 1,
+          negativeAcknowledgedCount: 0,
+          terminatedCount: 0,
+          deadLetteredCount: 0,
+        });
+        deepEqual(ingestedEnvelopes, [envelope]);
+
+        await publishInvalidNatsIntegrationMessage(servers, run);
+
+        const deadLetterResult = await consumer.processNextBatch({
+          batchSize: NatsIntegrationFetch.BatchSize,
+        });
+
+        deepEqual(deadLetterResult, {
+          receivedCount: 1,
+          processedCount: 0,
+          duplicateCount: 0,
+          payloadConflictCount: 0,
+          invalidCount: 1,
+          failedCount: 0,
+          acknowledgedCount: 0,
+          negativeAcknowledgedCount: 0,
+          terminatedCount: 1,
+          deadLetteredCount: 1,
+        });
+      } finally {
+        if (adapters !== undefined) {
+          await adapters.shutdown.shutdown();
+        }
+
+        await cleanupNatsIntegrationSubstrate(servers, run);
+      }
+    },
+  );
+});
+
+type NatsIntegrationRun = {
+  durableName: string;
+  eventId: string;
+  organizationId: string;
+  outboxEventId: string;
+  streamName: string;
+  subject: string;
+};
+
+async function recreateNatsIntegrationSubstrate(
+  servers: readonly string[],
+  run: NatsIntegrationRun,
+): Promise<void> {
+  await cleanupNatsIntegrationSubstrate(servers, run);
+
+  const connection = await connect({
+    servers: [...servers],
+  });
+
+  try {
+    const manager = await jetstreamManager(connection);
+
+    await manager.streams.add({
+      name: run.streamName,
+      subjects: [run.subject, createDeadLetterSubjectPattern(run)],
+      retention: RetentionPolicy.Limits,
+      discard: DiscardPolicy.Old,
+      storage: StorageType.Memory,
+      max_msgs: 32,
+    });
+    await manager.consumers.add(run.streamName, {
+      durable_name: run.durableName,
+      ack_policy: AckPolicy.Explicit,
+      deliver_policy: DeliverPolicy.All,
+      replay_policy: ReplayPolicy.Instant,
+      filter_subject: run.subject,
+      max_deliver: 1,
+    });
+  } finally {
+    await closeNatsConnection(connection);
+  }
+}
+
+async function publishInvalidNatsIntegrationMessage(
+  servers: readonly string[],
+  run: NatsIntegrationRun,
+): Promise<void> {
+  const connection = await connect({
+    servers: [...servers],
+  });
+
+  try {
+    const client = jetstream(connection);
+
+    await client.publish(run.subject, NatsIntegrationPayload.InvalidEnvelope);
+  } finally {
+    await closeNatsConnection(connection);
+  }
+}
+
+async function cleanupNatsIntegrationSubstrate(servers: readonly string[], run: NatsIntegrationRun): Promise<void> {
+  const connection = await connect({
+    servers: [...servers],
+  });
+
+  try {
+    const manager = await jetstreamManager(connection);
+
+    await ignoreNatsNotFound(async () => {
+      await manager.consumers.delete(run.streamName, run.durableName);
+    });
+    await ignoreNatsNotFound(async () => {
+      await manager.streams.delete(run.streamName);
+    });
+  } finally {
+    await closeNatsConnection(connection);
+  }
+}
+
+function createIntegrationEnvelope(run: NatsIntegrationRun): AgenticEventEnvelope {
+  return createAgenticEventEnvelope({
+    eventId: run.eventId,
+    eventType: AgenticEventType.SupervisorSignalSent,
+    occurredAt: NatsIntegrationTime.OccurredAt,
+    actor: {
+      agentId: NatsIntegrationId.Agent,
+      hatAssignmentId: NatsIntegrationId.HatAssignment,
+    },
+    scope: {
+      organizationId: run.organizationId,
+      projectId: NatsIntegrationId.Project,
+      initiativeId: NatsIntegrationId.Initiative,
+      teamId: NatsIntegrationId.Team,
+      workItemId: NatsIntegrationId.WorkItem,
+    },
+    aggregate: {
+      aggregateId: NatsIntegrationId.Aggregate,
+      aggregateType: AgenticAggregateType.SupervisorSignal,
+      aggregateVersion: 1,
+    },
+    trace: {
+      commandId: NatsIntegrationId.Command,
+      correlationId: NatsIntegrationId.Correlation,
+      causationId: NatsIntegrationId.Causation,
+      traceId: NatsIntegrationId.Trace,
+      idempotencyKey: NatsIntegrationId.IdempotencyKey,
+    },
+    payload: {
+      subject: NatsIntegrationPayload.Subject,
+    },
+  });
+}
+
+function readIntegrationNatsServers(): readonly string[] {
+  const serverList = env[NatsIntegrationEnvName.Servers];
+
+  if (serverList === undefined || serverList.trim().length === 0) {
+    throw new Error(`${NatsIntegrationEnvName.Servers} is required for NATS integration tests`);
+  }
+
+  const servers = serverList
+    .split(",")
+    .map((server) => server.trim())
+    .filter((server) => server.length > 0);
+
+  if (servers.length === 0) {
+    throw new Error(`${NatsIntegrationEnvName.Servers} must contain at least one server`);
+  }
+
+  return servers;
+}
+
+function createNatsIntegrationRun(): NatsIntegrationRun {
+  const runId = randomUUID();
+  const streamSafeRunId = runId.replaceAll("-", "_").toUpperCase();
+  const organizationId = `${NatsIntegrationResourcePrefix.Organization}-${runId}`;
+
+  return {
+    durableName: `${NatsIntegrationResourcePrefix.Durable}-${runId}`,
+    eventId: `${NatsIntegrationId.Event}-${runId}`,
+    organizationId,
+    outboxEventId: `${NatsIntegrationId.OutboxEvent}-${runId}`,
+    streamName: `${NatsIntegrationResourcePrefix.Stream}_${streamSafeRunId}`,
+    subject: buildAgenticEventSubject({
+      environment: NatsIntegrationStaticName.Environment,
+      organizationId,
+      domain: AgenticMessagingDomain.SupervisorSignal,
+      eventType: AgenticEventType.SupervisorSignalSent,
+    }),
+  };
+}
+
+function createDeadLetterSubjectPattern(run: NatsIntegrationRun): string {
+  return `${AgenticSubjectPrefix.Root}.${NatsIntegrationStaticName.Environment}.${run.organizationId}.${NatsIntegrationStaticName.DeadLetterSubjectSegment}.>`;
+}
+
+async function ignoreNatsNotFound(operation: () => Promise<void>): Promise<void> {
+  try {
+    await operation();
+  } catch (error) {
+    if (!isNatsNotFoundError(error)) {
+      throw error;
+    }
+  }
+}
+
+function isNatsNotFoundError(error: unknown): boolean {
+  return error instanceof Error && error.message.toLowerCase().includes("not found");
+}
+
+async function closeNatsConnection(connection: NatsConnection): Promise<void> {
+  await connection.close();
+}

--- a/agentic-organization/apps/workers/test/pg-cockroach-worker-pool.test.ts
+++ b/agentic-organization/apps/workers/test/pg-cockroach-worker-pool.test.ts
@@ -1,0 +1,150 @@
+import { deepEqual, equal, rejects } from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  PgCockroachWorkerPoolError,
+  PgCockroachWorkerPoolErrorCode,
+  createPgCockroachWorkerPool,
+  type PgCockroachDriverModule,
+} from "../src/index.ts";
+
+const TestCockroachDatabaseUrl = {
+  Local: "postgresql://root@localhost:26257/agentic_org",
+} as const;
+
+const TestSqlStatement = {
+  SelectValue: "SELECT $1::STRING AS value",
+} as const;
+
+describe("pg-compatible Cockroach worker pool adapter", () => {
+  test("loads the pg-compatible driver and adapts query rows through the generic worker pool contract", async () => {
+    const driver = createRecordingPgDriver();
+    const pool = await createPgCockroachWorkerPool({
+      databaseUrl: TestCockroachDatabaseUrl.Local,
+      loadDriver: async () => driver,
+    });
+
+    const client = await pool.connect();
+    const result = await client.query<{ value: string }>(TestSqlStatement.SelectValue, ["agentic-org"]);
+    client.release();
+    await pool.end();
+
+    deepEqual(result.rows, [{ value: "agentic-org" }]);
+    deepEqual(driver.constructedPools, [{ connectionString: TestCockroachDatabaseUrl.Local }]);
+    deepEqual(driver.pool.clients[0]?.queries, [
+      {
+        sql: TestSqlStatement.SelectValue,
+        parameters: ["agentic-org"],
+      },
+    ]);
+    equal(driver.pool.clients[0]?.releaseCount, 1);
+    equal(driver.pool.endCallCount, 1);
+  });
+
+  test("rejects an invalid pg-compatible driver module before creating a pool", async () => {
+    await rejects(
+      async () =>
+        await createPgCockroachWorkerPool({
+          databaseUrl: TestCockroachDatabaseUrl.Local,
+          loadDriver: async () => ({}),
+        }),
+      (error: unknown) =>
+        error instanceof PgCockroachWorkerPoolError &&
+        error.code === PgCockroachWorkerPoolErrorCode.InvalidDriverModule,
+    );
+  });
+});
+
+function createRecordingPgDriver(): PgCockroachDriverModule & {
+  constructedPools: { connectionString: string }[];
+  pool: RecordingPgPool;
+} {
+  const constructedPools: { connectionString: string }[] = [];
+  const pool = createRecordingPgPool();
+
+  return {
+    constructedPools,
+    pool,
+    Pool: class RecordingPoolConstructor implements RecordingPgPool {
+      readonly clients = pool.clients;
+
+      get endCallCount(): number {
+        return pool.endCallCount;
+      }
+
+      constructor(input: { connectionString: string }) {
+        constructedPools.push(input);
+      }
+
+      async connect(): Promise<RecordingPgPoolClient> {
+        return await pool.connect();
+      }
+
+      async end(): Promise<void> {
+        await pool.end();
+      }
+    },
+  };
+}
+
+type RecordingPgPool = {
+  clients: RecordingPgPoolClient[];
+  endCallCount: number;
+  connect: () => Promise<RecordingPgPoolClient>;
+  end: () => Promise<void>;
+};
+
+type RecordingPgPoolClient = {
+  queries: { sql: string; parameters: readonly unknown[] }[];
+  releaseCount: number;
+  query: <Row = Record<string, unknown>>(
+    sql: string,
+    parameters?: readonly unknown[],
+  ) => Promise<{ rows: Row[] }>;
+  release: () => void;
+};
+
+function createRecordingPgPool(): RecordingPgPool {
+  const pool: RecordingPgPool = {
+    clients: [],
+    endCallCount: 0,
+    connect: async () => {
+      const client = createRecordingPgPoolClient();
+      pool.clients.push(client);
+      return client;
+    },
+    end: async () => {
+      pool.endCallCount += 1;
+    },
+  };
+
+  return pool;
+}
+
+function createRecordingPgPoolClient(): RecordingPgPoolClient {
+  return {
+    queries: [],
+    releaseCount: 0,
+    async query<Row = Record<string, unknown>>(sql: string, parameters: readonly unknown[] = []) {
+      this.queries.push({
+        sql,
+        parameters,
+      });
+
+      return {
+        rows: resolveRows<Row>(sql, parameters),
+      };
+    },
+    release() {
+      this.releaseCount += 1;
+    },
+  };
+}
+
+function resolveRows<Row>(sql: string, parameters: readonly unknown[]): Row[] {
+  if (sql === TestSqlStatement.SelectValue) {
+    return [{ value: parameters[0] }] as Row[];
+  }
+
+  return [];
+}

--- a/agentic-organization/docs/FIRST_IMPLEMENTATION_SLICE.md
+++ b/agentic-organization/docs/FIRST_IMPLEMENTATION_SLICE.md
@@ -327,6 +327,18 @@ Hermes runs, MCP calls, and UI evidence.
   Cockroach migration runner and ordered core migrations; the readiness
   probe checks durable-state availability through the generic SQL client
   without importing a database driver into reusable packages.
+- `apps/workers` has a first optional `pg`-compatible live Cockroach
+  pool adapter behind the existing generic worker pool contracts. The
+  adapter is app-local, dynamically loaded, and fake-tested by default;
+  the env-gated integration test uses it only when
+  `AGENTIC_ORG_COCKROACH_INTEGRATION_DATABASE_URL` is present.
+- `apps/workers` has the first env-gated live NATS proof. When
+  `AGENTIC_ORG_NATS_INTEGRATION_SERVERS` is present, the test recreates
+  a small per-run JetStream stream and durable consumer, publishes a
+  canonical event through the worker adapter, consumes it through the
+  generic ingestion port, acknowledges it, smoke-tests DLQ publishing,
+  proves the invalid-envelope consumer DLQ path, checks readiness, and
+  closes the generic NATS shutdown port.
 - Worker-cycle failures can carry structured evidence. Stale outbox
   claim failures now preserve claim ID, current claim ID, outbox event
   ID, event ID, trace ID, and published-at evidence when the durable row
@@ -353,12 +365,17 @@ Hermes runs, MCP calls, and UI evidence.
 The next slice is tracked in the canonical
 [Phased Development Plan](./PHASED_DEVELOPMENT_PLAN.md). The fake-driven
 process lifecycle contract now covers migration bootstrap, readiness
-gating, and graceful shutdown at the port boundary. Next, add
-durable-state and NATS integration tests once local/dev connections are
-available, then wrap the lifecycle contract in a real long-running
-worker host. Keep URLs, credentials, and connection pools in app adapter
-config fed by Kubernetes Secret or ExternalSecret values, never in
-domain packages.
+gating, and graceful shutdown at the port boundary. The Cockroach live
+proof is now env-gated: when a compatible URL and driver are present,
+the same test command proves migrations, readiness, commit, rollback,
+and shutdown against a real substrate. The NATS live proof is also
+env-gated: when a JetStream server is supplied, the same test command
+proves publish, consume, ack, invalid-envelope DLQ handling, readiness,
+and shutdown through the app-local NATS seam. Next, combine Cockroach
+plus NATS into a single end-to-end durable worker proof and then wrap
+the lifecycle contract in a real long-running worker host. Keep URLs,
+credentials, and connection pools in app adapter config fed by
+Kubernetes Secret or ExternalSecret values, never in domain packages.
 
 Do not make the next slice a pile of bespoke request commands. Build the
 generic supervisor triage lifecycle first, then let specialized

--- a/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
+++ b/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
@@ -200,10 +200,15 @@ event-ingestion adapters now expose transaction-batch executor seams so
 the app/runtime layers remain database-generic while durable adapters
 can commit outcome batches atomically.
 
-The remaining gap is integration-level proof against a real CockroachDB
-transaction. The current tests prove the batch boundary and runtime
-recovery behavior; a future local/dev-cluster integration test should
-prove actual rollback behavior with the real adapter binding.
+The remaining gap is making the live substrate proofs routine in CI or a
+dev cluster. The current tests prove the batch boundary and runtime
+recovery behavior. The env-gated Cockroach live test proves migrations,
+readiness, per-run probe table cleanup, commit, rollback, and shutdown when
+`AGENTIC_ORG_COCKROACH_INTEGRATION_DATABASE_URL` plus a `pg`-compatible
+driver are available. The env-gated NATS live test proves JetStream
+stream/durable setup, readiness, canonical event publish, generic
+ingestion-port consume, ack, invalid-envelope DLQ handling, and
+shutdown when `AGENTIC_ORG_NATS_INTEGRATION_SERVERS` is available.
 
 ### Policy And Hat Authority Checkpoint
 
@@ -231,9 +236,13 @@ durable worker composition seam below `apps/workers`, an app-local
 Cockroach pooled-client adapter, Cockroach migration bootstrapper,
 Cockroach readiness probe, NATS process-client construction, process
 lifecycle entrypoint contract, generic shutdown ports, and JSON
-telemetry sink. It still needs a real Cockroach-backed integration run,
-real NATS integration run, a long-running executable worker host, and
-cluster OTEL export wiring.
+telemetry sink. It now has an env-gated Cockroach integration harness
+for real migrations, readiness, transactions, rollback, and shutdown,
+plus an env-gated NATS integration harness for real JetStream publish,
+consume, ack, invalid-envelope DLQ handling, readiness, and shutdown. It
+still needs those live proofs wired into CI/dev-cluster execution, a
+combined Cockroach plus NATS durable worker proof, a long-running
+executable worker host, and cluster OTEL export wiring.
 
 ### Command Surface Closure
 
@@ -316,9 +325,9 @@ labels, dashboard ownership, and alertable degraded-worker signals.
 4. Add `triage_supervisor_signal` as the next real command slice.
 5. Add discussion-anchor enforcement and graph retrieval OpenSpec
    scenarios, then implement the minimal anchor command.
-6. Add real CockroachDB transaction integration coverage for command
-   outcomes and event-ingestion outcomes once a dev connection is
-   available.
+6. Decide whether the env-gated Cockroach integration proof should run
+   in CI through a local service, a k3d profile, or an operator-triggered
+   real-cluster job.
 7. Define UAG v0 as a typed package contract before adding prompt-flow
    execution.
 8. Build one substrate integration at a time, starting with hat-system

--- a/agentic-organization/docs/PHASED_DEVELOPMENT_PLAN.md
+++ b/agentic-organization/docs/PHASED_DEVELOPMENT_PLAN.md
@@ -2617,31 +2617,63 @@ slice.
 
 ### PR 2: Cockroach Integration Proof
 
+Status: implemented as an env-gated live proof harness. The normal suite
+still runs fake-driven, but when
+`AGENTIC_ORG_COCKROACH_INTEGRATION_DATABASE_URL` is present and a
+`pg`-compatible driver is available from the root dependency graph, the
+integration test exercises the live Cockroach/Postgres-compatible path
+through the same app-local ports used by the worker lifecycle.
+
 Build:
 
+- app-local `pg`-compatible pool adapter behind
+  `CockroachWorkerPool`/`CockroachWorkerShutdownPool`; done;
 - real Cockroach transaction adapter using the generic SQL executor;
-- integration test harness gated by env;
-- migration apply test;
-- rollback test.
+  done through the app-local pool adapter;
+- integration test harness gated by env; done;
+- migration apply test; done;
+- readiness test; done;
+- commit and rollback test; done;
+- per-run probe table cleanup; done;
+- graceful shutdown proof through the generic process shutdown port;
+  done.
 
 Done when:
 
-- real transaction rollback is proven;
-- migration runner is proven against Cockroach.
+- real transaction rollback is proven against a provided live
+  Cockroach/Postgres-compatible URL;
+- migration runner is proven against the same URL;
+- integration execution is safe to skip when local/dev cluster
+  dependencies are absent.
 
 ### PR 3: NATS Integration Proof
 
+Status: implemented as an env-gated live proof harness. The normal
+suite remains fake-driven, but when
+`AGENTIC_ORG_NATS_INTEGRATION_SERVERS` is present, the integration test
+recreates a small JetStream stream and durable consumer, then exercises
+the same app-local NATS adapter used by the worker lifecycle.
+
 Build:
 
-- real JetStream publisher construction;
-- real pull consumer construction;
-- local/dev integration tests gated by env;
-- DLQ publish smoke test.
+- real JetStream publisher construction; done;
+- real pull consumer construction; done;
+- local/dev integration tests gated by env; done;
+- readiness check through the durable consumer; done;
+- canonical event publish and generic ingestion-port consume; done;
+- ack proof through the inbound consumer; done;
+- invalid-envelope consumer DLQ path proof; done;
+- generic NATS shutdown port proof; done.
 
 Done when:
 
-- one outbox event publishes to NATS;
-- one inbound NATS event is consumed, deduped, and acknowledged.
+- one outbox event publishes to NATS; done when a live JetStream server
+  is supplied;
+- one inbound NATS event is consumed, deduped, and acknowledged; the
+  live proof covers consume and acknowledge, while durable
+  event-ingestion dedupe remains proven by fake-driven state tests and
+  will move into a full Cockroach plus NATS integration once both live
+  URLs are supplied together.
 
 ### PR 4: Generic Command Registry
 
@@ -2842,13 +2874,14 @@ Use this checklist before marking any phase complete.
 
 Use these questions when we talk through the plan:
 
-1. Should PR 2 use env-gated local Cockroach, a k3d
-   profile, or only env-gated tests against the real cluster?
+1. Should the env-gated Cockroach and NATS live proofs become CI-backed
+   through local services, a k3d profile, or remain operator-triggered
+   against the real cluster for now?
 2. Should the real long-running `apps/workers` executable host land
    before `apps/api`, or should both wrap the same lifecycle/policy
    contracts in parallel?
-3. Should the NATS integration proof use a local JetStream container,
-   k3d, or only env-gated tests against the real cluster?
+3. Should the combined Cockroach plus NATS durable worker proof use local
+   containers, k3d, or only env-gated tests against the real cluster?
 4. Should supervisor triage create discussion anchors implicitly when a
    signal has no anchor, or should it always require an explicit anchor
    created by the prior phase?

--- a/agentic-organization/docs/TECHNICAL_CA_PACKAGE_ARCHITECTURE.md
+++ b/agentic-organization/docs/TECHNICAL_CA_PACKAGE_ARCHITECTURE.md
@@ -323,6 +323,14 @@ worker connection seam, and JSON telemetry sink:
   explicit `BEGIN`, `COMMIT`, `ROLLBACK`, connection release,
   SQLSTATE-based retry, ambiguous-commit preservation semantics, and a
   generic shutdown adapter for process pools that expose `end()`;
+- `apps/workers/src/adapters/pg-cockroach-worker-pool.ts` is the first
+  optional live-driver binding for the Cockroach worker pool contract.
+  It dynamically loads a `pg`-compatible module at the app boundary,
+  validates that it exports `Pool`, and adapts `Pool.connect()`,
+  `client.query()`, `client.release()`, and `Pool.end()` to
+  `CockroachWorkerPool` plus `CockroachWorkerShutdownPool`. This keeps
+  the driver out of reusable packages while giving the worker app a real
+  Cockroach/Postgres-compatible path for integration proof;
 - `apps/workers/src/adapters/nats-worker-connection.ts` adapts a
   process-provided NATS transport connection factory to generic
   `EventPublisher`, `NatsJetStreamPullConsumer`,
@@ -386,6 +394,29 @@ Ambiguous transaction outcomes must stay visible to the worker host and
 operators; the process adapter may attempt rollback cleanup after an
 ambiguous commit, but it must preserve the original ambiguity instead of
 masking it as a rollback failure.
+
+The live Cockroach proof is env-gated rather than always-on. When
+`AGENTIC_ORG_COCKROACH_INTEGRATION_DATABASE_URL` is absent, the normal
+test suite skips the live check. When it is present and a
+`pg`-compatible driver is available from the root dependency graph, the
+test applies the Organization migrations, checks readiness through
+`SELECT 1`, creates a per-run probe table, commits a probe row, rolls
+back a failed probe transaction, drops the per-run table, and closes the
+pool through the generic process shutdown port. This gives us real
+substrate evidence without making local development or reusable package
+tests depend on a cluster.
+
+The live NATS proof follows the same rule. When
+`AGENTIC_ORG_NATS_INTEGRATION_SERVERS` is absent, the normal suite skips
+the live check. When it is present, the test creates a small per-run
+JetStream stream plus durable consumer, binds the app-local `@nats-io`
+transport factory through `connectNatsWorkerAdapters`, checks durable
+readiness, publishes one canonical event, consumes it through the
+generic event-ingestion port, acknowledges it, proves the
+invalid-envelope consumer DLQ path, and closes the connection through
+the generic NATS shutdown port. The reusable packages continue to see
+only publisher, pull-consumer, dead-letter, readiness, and shutdown
+interfaces.
 
 ## SOLID Rules
 

--- a/agentic-organization/packages/test-node.d.ts
+++ b/agentic-organization/packages/test-node.d.ts
@@ -16,8 +16,21 @@ declare module "node:crypto" {
 }
 
 declare module "node:test" {
+  export type TestOptions = {
+    skip?: boolean | string;
+  };
+
   export function describe(name: string, fn: () => void): void;
   export function test(name: string, fn: () => void): void;
+  export function test(name: string, options: TestOptions, fn: () => void | Promise<void>): void;
+}
+
+declare module "node:process" {
+  export const env: Record<string, string | undefined>;
+}
+
+declare module "node:crypto" {
+  export function randomUUID(): string;
 }
 
 declare module "node:fs/promises" {

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@nats-io/jetstream": "3.4.0",
         "@nats-io/transport-node": "3.4.0",
+        "pg": "8.21.0",
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
@@ -341,9 +342,33 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
+    "pg": ["pg@8.21.0", "", { "dependencies": { "pg-cloudflare": "^1.4.0", "pg-connection-string": "^2.13.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.14.0", "pg-types": "2.2.0", "pgpass": "1.0.5" } }, "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
+
+    "pg-connection-string": ["pg-connection-string@2.13.0", "", {}, "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
+
+    "pg-protocol": ["pg-protocol@1.14.0", "", {}, "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
     "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.0", "", {}, "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
@@ -375,6 +400,8 @@
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
     "string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
@@ -404,6 +431,8 @@
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@nats-io/jetstream": "3.4.0",
-    "@nats-io/transport-node": "3.4.0"
+    "@nats-io/transport-node": "3.4.0",
+    "pg": "8.21.0"
   }
 }

--- a/tools/agent-loop/state-machine.ts
+++ b/tools/agent-loop/state-machine.ts
@@ -279,7 +279,7 @@ export function transition(
         tag: "RecordingHeartbeat",
         context: ctx,
         lane: option.lane,
-        note: option.note,
+        ...(option.note === undefined ? {} : { note: option.note }),
       };
     case "EscapeHatch":
       // Escape-hatch routes to operator-attention so operator sees the
@@ -296,7 +296,9 @@ export function transition(
         tag: "NamedBoundedWait",
         context: ctx,
         namedDep: option.namedDep,
-        expectedResolutionIso: option.eta,
+        ...(option.eta === undefined
+          ? {}
+          : { expectedResolutionIso: option.eta }),
       };
     case "RequestOperatorAttention":
       return {
@@ -321,7 +323,9 @@ export function transition(
         tag: "Paused",
         context: ctx,
         reason: option.reason,
-        expectedResumeIso: option.expectedResumeIso,
+        ...(option.expectedResumeIso === undefined
+          ? {}
+          : { expectedResumeIso: option.expectedResumeIso }),
       };
     case "EnterOpenEndedExploration":
       // Per operator 2026-05-28: "there's a menu button for that lol" —

--- a/tools/dora-classify/classify.test.ts
+++ b/tools/dora-classify/classify.test.ts
@@ -109,7 +109,10 @@ describe("classifyCommit", () => {
       "docs/backlog/P1/B-0867-x.md",
     ]));
     expect(r.lane).toBe("mixed");
-    expect(r.distinctLanes.sort()).toEqual(["backlog-row", "operational"]);
+    expect([...r.distinctLanes].sort()).toEqual([
+      "backlog-row",
+      "operational",
+    ]);
   });
 
   test("empty changedFiles → substrate-cascade", () => {

--- a/tools/dora-classify/cli.ts
+++ b/tools/dora-classify/cli.ts
@@ -72,7 +72,12 @@ function parseArgs(argv: readonly string[]): CliArgs | { readonly error: string 
   if (provided > 1) {
     return { error: "specify exactly one of --sha / --since / --range" };
   }
-  return { sha, since, range, aggregate };
+  return {
+    aggregate,
+    ...(sha === undefined ? {} : { sha }),
+    ...(since === undefined ? {} : { since }),
+    ...(range === undefined ? {} : { range }),
+  };
 }
 
 function gitLogShasInRange(args: CliArgs): readonly string[] {


### PR DESCRIPTION
## Summary

- add an app-local `pg`-compatible Cockroach worker pool adapter behind the generic worker pool/shutdown contracts
- add env-gated live Cockroach and NATS proof harnesses for migrations/readiness/transactions/shutdown and JetStream publish/consume/ack/DLQ/shutdown
- keep live resources shared-cluster friendly with per-run Cockroach probe tables and per-run NATS stream/durable/org identifiers
- update Agentic Organization worker, package architecture, north-star, and phased plan docs for the new live substrate proof phase

## Validation

- `npm test` from `agentic-organization/` — 139 tests, 137 passed, 2 skipped live proofs
- `npm run typecheck` from `agentic-organization/` — passed
- `git diff --check origin/main...HEAD` — passed

## Review

- subagent correctness review: no remaining blockers after declaring `pg`, proving the consumer invalid-envelope DLQ path, using per-run NATS resources, and tightening cleanup
- subagent architecture/SOLID review: no remaining blockers after switching Cockroach to a per-run probe table with safe identifier validation and cleanup before pool shutdown