### PR TITLE
fix(backlog): renumber ZetaID v2 row to B-0893

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -840,7 +840,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0887.1](backlog/P2/B-0887.1-pr-discipline-rules-cross-host-framing-audit-existing-rules-encode-github-specific-learning-otto-pushback-2026-05-28.md)** PR-discipline rules cross-host framing audit — existing rules encode years of GitHub-specific learning; audit which translate to Zeta-native / cross-host and which need rewrites
 - [ ] **[B-0887.2](backlog/P2/B-0887.2-move-sonatype-guide-invocation-into-playbook-substrate-drop-pr-gated-review-no-vendor-lockin-aaron-2026-05-28.md)** Move sonatype-guide invocation into playbook substrate — drop PR-gated review; no vendor lockin per operator 2026-05-28 "we are getting rid of PRs mostly for playbooks
 - [ ] **[B-0888](backlog/P2/B-0888-cross-track-substrate-sync-policy-cloud-github-vs-usb-local-gitlab-intentional-divergence-vs-auto-sync-otto-pushback-2026-05-28.md)** Cross-track substrate-sync policy — cloud-GitHub vs USB-local-GitLab; intentional divergence vs auto-sync-via-push-to-both-remotes vs hybrid
-- [ ] **[B-0892](backlog/P2/B-0892-zetaid-v2-128-bit-structured-encoding-snowflake-ulid-family-kestrel-2026-05-28.md)** ZetaID v2 — 128-bit structured encoding (Snowflake/ULID family with timestamp + trajectory + persona + lifecycle-stage + random)
+- [ ] **[B-0893](backlog/P2/B-0893-zetaid-v2-128-bit-structured-encoding-snowflake-ulid-family-kestrel-2026-05-28.md)** ZetaID v2 — 128-bit structured encoding (Snowflake/ULID family with timestamp + trajectory + persona + lifecycle-stage + random)
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P1/B-0874-github-actions-recursion-as-infinite-runtime-platform-no-pr-swarm-mode-ani-kestrel-2026-05-28.md
+++ b/docs/backlog/P1/B-0874-github-actions-recursion-as-infinite-runtime-platform-no-pr-swarm-mode-ani-kestrel-2026-05-28.md
@@ -9,10 +9,10 @@ created: 2026-05-28
 last_updated: 2026-05-28
 depends_on:
   - B-0867
-  - B-0892
+  - B-0893
 composes_with:
   - B-0867
-  - B-0892
+  - B-0893
   - B-0872
   - B-0873
 tags:
@@ -61,7 +61,7 @@ Turn GitHub Actions into an infinite recursive compute platform for the agent-lo
 - Bounded-iteration safety (per Kestrel's push-cycle-limit B-0867.17 framing) — workflows include a max-recursion-depth + abandonment-condition guard
 - Skill distribution: `.claude/skills/agent-loop-swarm/SKILL.md` wraps the swarm-spawn so any GitHub-authenticated agent can invoke it
 - Documentation: rate-limit analysis showing GraphQL vs REST vs Git differential
-- Composes with B-0892 (ZetaID generator) — events use ZetaIDs as primary keys; no merge conflicts via unique filenames
+- Composes with B-0893 (ZetaID generator) — events use ZetaIDs as primary keys; no merge conflicts via unique filenames
 
 ## Sequencing
 

--- a/docs/backlog/P2/B-0867.2-git-append-only-state-persist-typescript-tool-event-sourcing-layer-kestrel-2026-05-28.md
+++ b/docs/backlog/P2/B-0867.2-git-append-only-state-persist-typescript-tool-event-sourcing-layer-kestrel-2026-05-28.md
@@ -12,7 +12,7 @@ depends_on:
 composes_with:
   - B-0867
   - B-0858
-  - B-0892
+  - B-0893
   - B-0872
   - B-0867.14
 tags:
@@ -59,7 +59,7 @@ Event file path: `agent-state/{persona}/{trajectory}/events/YYYY/MM/DD/{zetaId}.
 ## Composes with
 
 - B-0867.14 (branch protection: path-scoped append-only carve-out) — required for direct-push semantics
-- B-0892 (ZetaID v2) — events use ZetaIDs as primary keys + filenames
+- B-0893 (ZetaID v2) — events use ZetaIDs as primary keys + filenames
 - B-0872 (OTel composition) — events carry trace_id + span_id
 - B-0858 (heartbeat folder substrate) — heartbeat events are one event_type; this layer generalizes the pattern
 

--- a/docs/backlog/P2/B-0872-otel-trace-id-composition-with-zetaid-baggage-propagation-kestrel-2026-05-28.md
+++ b/docs/backlog/P2/B-0872-otel-trace-id-composition-with-zetaid-baggage-propagation-kestrel-2026-05-28.md
@@ -8,11 +8,11 @@ ask: kestrel via aaron 2026-05-28
 created: 2026-05-28
 last_updated: 2026-05-28
 depends_on:
-  - B-0892
+  - B-0893
   - B-0867
 composes_with:
   - B-0867
-  - B-0892
+  - B-0893
   - B-0869
 tags:
   - opentelemetry
@@ -50,7 +50,7 @@ Wire OpenTelemetry trace-IDs through the agent-loop substrate so every state-mac
 
 ## Scope
 
-This row is the OTEL WIRING ONLY. ZetaID generation lives in B-0892; event-sourcing in B-0867.2; observability backend selection is operator-decision.
+This row is the OTEL WIRING ONLY. ZetaID generation lives in B-0893; event-sourcing in B-0867.2; observability backend selection is operator-decision.
 
 ## Substrate-honest framing
 

--- a/docs/backlog/P2/B-0873-trajectory-async-review-surface-operator-preferred-top-level-lens-aaron-2026-05-28.md
+++ b/docs/backlog/P2/B-0873-trajectory-async-review-surface-operator-preferred-top-level-lens-aaron-2026-05-28.md
@@ -12,7 +12,7 @@ depends_on:
 composes_with:
   - B-0867
   - B-0869
-  - B-0892
+  - B-0893
   - B-0872
 tags:
   - trajectory-async-review

--- a/docs/backlog/P2/B-0893-zetaid-v2-128-bit-structured-encoding-snowflake-ulid-family-kestrel-2026-05-28.md
+++ b/docs/backlog/P2/B-0893-zetaid-v2-128-bit-structured-encoding-snowflake-ulid-family-kestrel-2026-05-28.md
@@ -1,6 +1,7 @@
 ---
-id: B-0892
-renumbered_from: B-0871
+id: B-0893
+renumbered_from: B-0892
+renumbered_from_original: B-0871
 priority: P2
 status: open
 title: ZetaID v2 — 128-bit structured encoding (Snowflake/ULID family with timestamp + trajectory + persona + lifecycle-stage + random)


### PR DESCRIPTION
## Summary
- renumber the P2 ZetaID v2 row from B-0892 to B-0893 after the merged three-lanes row claimed B-0892
- update ZetaID generator references in dependent backlog rows
- regenerate docs/BACKLOG.md

## Verification
- bun tools/hygiene/audit-backlog-items.ts --enforce-duplicate-ids
- bun tools/backlog/generate-index.ts --check
- rg stale B-0892/ZetaID references; only the intended P1 B-0892 row remains

Root checkout stayed read-only; all edits were made in a dedicated Codex claim worktree.