### PR TITLE
fix(postmerge-5694): replace persona names in docs/playbooks/README.md with role-refs

### DIFF
--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -48,11 +48,16 @@ Playbooks compose with the playbook-substrate cluster:
 The conversational-document path is for ANY traveler, not just humans
 (per [`docs/backlog/P1/B-0867.21-...md`](../backlog/P1/B-0867.21-two-path-interface-discriminated-union-execute-vs-conversational-declare-intent-aaron-ani-2026-05-28.md)).
 
-- Otto (any surface) MAY author `memory/persona/otto/playbooks/<name>.md`
-- Alexa / Riven / Vera / Lior similarly per their persona directories
+- Any agent (any surface) MAY author `memory/persona/<persona>/playbooks/<name>.md`
+  in its own persona directory
 - Any agent MAY propose `docs/playbooks/<name>.md` system playbooks
   (subject to operator review per standard system-doc conventions per
   [`.claude/rules/honor-those-that-came-before.md`](../../.claude/rules/honor-those-that-came-before.md))
+- The roster of currently-active personas (canonical mapping
+  persona-name → role) lives in `.claude/rules/agent-roster-reference-card.md`
+  per the roster-mapping carve-out — that file is the resolution surface
+  consumers use to bind role-refs in this README to specific persona
+  directories
 
 ## Composition with the async-scatterbrains operator-experience design property
 


### PR DESCRIPTION
## Summary

Fix-forward for PR #5694 (merged at \`79c65845\` 2026-05-28T03:42Z). Copilot P1 thread filed AFTER auto-merge fired (race window per `.claude/rules/blocked-green-ci-investigate-threads.md` auto-merge-race-with-follow-up-commit anti-pattern at thread scope).

**Copilot finding** (thread \`PRRT_kwDOSF9kNM6FSam_\`): \`docs/playbooks/README.md\` lines 51-52 introduced direct persona names ("Otto", "Alexa", "Riven", "Vera", "Lior") in a current-state doc under \`docs/\`, violating \`docs/AGENT-BEST-PRACTICES.md\` "No name attribution in code, docs, or skills" rule.

\`docs/playbooks/README.md\` is NOT in:
- the **closed list** of history/research surfaces (memory/, docs/backlog/, docs/research/, etc.)
- the **roster-mapping carve-out** (.claude/skills/, .claude/agents/, AGENTS.md, GOVERNANCE.md, etc.)

So role-refs required everywhere.

## Fix

- "Otto (any surface)" + "Alexa / Riven / Vera / Lior similarly" → "Any agent (any surface) MAY author ... in its own persona directory"
- Added explicit pointer to \`.claude/rules/agent-roster-reference-card.md\` as the canonical roster-mapping resolution surface (consumers bind role-refs here to specific persona directories per the carve-out discipline)

## Test plan

- [ ] CI green
- [ ] grep for persona names in `docs/playbooks/README.md` returns 0 matches
- [ ] Cross-references still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)