### PR TITLE
fix(B-0891): fix-fwd 4 tsc errors in zflash test-harness PoC (exactOptionalPropertyTypes + noUncheckedIndexedAccess)

### DIFF
--- a/tools/zflash/test-harness/run.ts
+++ b/tools/zflash/test-harness/run.ts
@@ -82,17 +82,19 @@ function parseArgs(argv: ReadonlyArray<string>): ParsedArgs | { error: string } 
     }
     const id = args[scenarioIdx + 1] as ScenarioId;
     const positional = args.filter((a, i) => i !== scenarioIdx && i !== scenarioIdx + 1 && !a.startsWith("--"));
-    if (positional.length === 0) {
+    const isoPath = positional[0];
+    if (positional.length === 0 || isoPath === undefined) {
       return { error: "--scenario requires an ISO path positional argument" };
     }
-    return { mode: "scenario", scenarioId: id, isoPath: positional[0] };
+    return { mode: "scenario", scenarioId: id, isoPath };
   }
   if (args.includes("--all")) {
     const positional = args.filter((a) => !a.startsWith("--"));
-    if (positional.length === 0) {
+    const isoPath = positional[0];
+    if (positional.length === 0 || isoPath === undefined) {
       return { error: "--all requires an ISO path positional argument" };
     }
-    return { mode: "all", isoPath: positional[0] };
+    return { mode: "all", isoPath };
   }
   return { error: `unrecognized arguments: ${args.join(" ")}` };
 }
@@ -171,12 +173,15 @@ function runComposingScenario(scenario: Scenario, isoPath: string): ScenarioResu
     stdio: "inherit",
   });
   const durationMs = Date.now() - start;
-  return {
-    id: scenario.id,
-    status: result.status === 0 ? "passed" : "failed",
-    durationMs,
-    message: result.status === 0 ? undefined : `delegated harness exited ${result.status}`,
-  };
+  const passed = result.status === 0;
+  return passed
+    ? { id: scenario.id, status: "passed", durationMs }
+    : {
+        id: scenario.id,
+        status: "failed",
+        durationMs,
+        message: `delegated harness exited ${result.status}`,
+      };
 }
 
 function reportScaffolded(scenario: Scenario): ScenarioResult {

--- a/tools/zflash/test-harness/scenarios.test.ts
+++ b/tools/zflash/test-harness/scenarios.test.ts
@@ -65,7 +65,9 @@ describe("B-0891 scenarios.ts invariants", () => {
   });
 
   it("validateScenarios catches duplicate id", () => {
-    const dup = [...SCENARIOS, { ...SCENARIOS[0] }];
+    const first = SCENARIOS[0];
+    if (!first) throw new Error("SCENARIOS unexpectedly empty");
+    const dup = [...SCENARIOS, { ...first }];
     expect(() => validateScenarios(dup)).toThrow();
   });
 


### PR DESCRIPTION
## Summary

Fix-fwd for PR #5724 (zflash test-harness PoC) which race-merged through with non-required ``lint(tsc tools)`` failure per ``blocked-green-ci-investigate-threads.md`` auto-merge-race-with-follow-up-commit anti-pattern.

## Fixes

4 errors under TS strict mode (``exactOptionalPropertyTypes`` + ``noUncheckedIndexedAccess``):

| File | Line | Error | Fix |
|---|---|---|---|
| ``run.ts`` | 88, 95 | ``isoPath: string \| undefined`` not assignable to optional ``isoPath?: string`` | reify ``positional[0]`` into typed local + explicit ``undefined`` check before return |
| ``run.ts`` | 174 | ``message: undefined`` fails exactOptionalPropertyTypes | conditional return — omit ``message`` field when passing |
| ``scenarios.test.ts`` | 68 | ``{ ...SCENARIOS[0] }`` widens because indexed access returns ``Scenario \| undefined`` | reify ``first`` into typed local + assert before spread |

## Gate verification

- ``bunx tsc --noEmit`` (tools/zflash) → 0 errors
- ``bun test tools/zflash/test-harness/`` → 12 pass / 0 fail / 26 expect()
- Commit canary HEAD~1=61 HEAD=61

## Composes-with

- PR #5724 (B-0891 PoC — the race-merged base)
- ``blocked-green-ci-investigate-threads.md`` auto-merge-race-with-follow-up-commit anti-pattern
- ``zeta-expected-branch.md`` race-window-caveat (isolated worktree workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)