### PR TITLE
feat(B-0883 v1): PoC scaffold — better-git-crypt declarative types + CLI dispatcher composing with v1 design memo (Noble + XWing + ML-DSA-65 + CBOR envelope)

### DIFF
--- a/tools/crypto/better-git-crypt/README.md
+++ b/tools/crypto/better-git-crypt/README.md
@@ -1,0 +1,117 @@
+# `tools/crypto/better-git-crypt/` — B-0883 v1 PoC scaffold
+
+PoC scaffold for the better-git-crypt v1 spec — post-quantum (Noble + XWing + ML-DSA-65 + CBOR envelope) replacement for legacy git-crypt, per [B-0883](../../../docs/backlog/P1/B-0883-better-gitcrypt-post-quantum-lattice-based-retraction-native-diff-readable-bouncy-castle-patterns-aaron-2026-05-28.md) + [v1 design memo](../../../docs/research/2026-05-28-b-0883-v1-design-memo-noble-xwing-mldsa65-cbor-envelope-with-locked-decisions.md).
+
+## Scope
+
+**PoC**: declarative TS type substrate + CLI dispatcher + invariant tests. Implements:
+
+- Algorithm registry (`ALG_REGISTRY`) typed per `AlgSpec` with `class` + `status` discriminator
+- File envelope (`FileEnvelope`) typed per the v1 design memo's CBOR shape
+- Encryption / decryption context types + feedback variants per asymmetric-authorship rule
+- Validation invariants (`validateAlgRegistry` + `validateEnvelopeStructure` + `validateEncryptionContext`) enforced at runtime + by unit tests
+- CLI scaffold with `--list-algs` / `--validate` / `--dry-run-envelope` modes
+
+**NOT in PoC** (deferred to Phase 2 operator-authorized work):
+
+- Real `@noble/post-quantum` integration (KEM + signature operations)
+- Real CBOR encoding (cbor-x or similar)
+- Real ChaCha20-Poly1305 content encryption via `@noble/ciphers`
+- HKDF-SHA256 key derivation via `@noble/hashes`
+- `git textconv` filter integration for diff-readable ciphertext
+- Recipient management (`.zeta-crypt/recipients.json` + rotation per B-0883.3)
+- Multi-cipher hedge implementations (Saber / NTRU-Prime / FrodoKEM per B-0883.2) — deferred until TS-native impls mature
+- Metadata encryption (filenames / commit messages per B-0883.5) — v1 content-only
+
+## v1 algorithms (per design memo + B-0883.1 library landscape audit)
+
+| Class | Algorithm | Status | Noble module |
+|---|---|---|---|
+| KEM | ML-KEM-768 + X25519 (XWing hybrid) | ships-v1 | `@noble/post-quantum/ml-kem` |
+| KEM | Saber | deferred-alternate (B-0883.2) | — |
+| KEM | NTRU-Prime | deferred-alternate (B-0883.2) | — |
+| KEM | FrodoKEM | deferred-alternate (B-0883.2) | — |
+| Signature | ML-DSA-65 | ships-v1 | `@noble/post-quantum/ml-dsa` |
+| Signature | SLH-DSA (SPHINCS+) | ships-v1 | `@noble/post-quantum/slh-dsa` |
+| KDF | HKDF-SHA256 | ships-v1 | `@noble/hashes/hkdf` |
+| AEAD | ChaCha20-Poly1305 | ships-v1 | `@noble/ciphers/chacha` |
+
+## CLI
+
+```bash
+# List ALG_REGISTRY by class
+bun tools/crypto/better-git-crypt/cli/main.ts --list-algs
+
+# Validate registry invariants (unique ids; ships-v1 algs present for each class)
+bun tools/crypto/better-git-crypt/cli/main.ts --validate
+
+# Dry-run envelope construction (synthetic FileEnvelope using ships-v1 primary algorithms)
+bun tools/crypto/better-git-crypt/cli/main.ts --dry-run-envelope
+```
+
+Exit codes:
+
+- `0` — operation successful
+- `1` — runtime validation FAILED (registry invariant OR envelope structure)
+- `2` — usage error
+
+## Tests
+
+```bash
+bun test tools/crypto/better-git-crypt/
+```
+
+Invariants checked: unique alg ids; ships-v1 presence for each class (kem/signature/kdf/aead); registry catches duplicate ids + missing ships-v1; envelope catches wrong version + context mismatch + unknown algs + wrong-class-references + empty recipient set + empty signerIdentity; encryption context catches empty recipient set + sender-not-in-recipients + unsupported algs + invalid keys.
+
+## Phase 2 integration protocol
+
+When operator authorizes Phase 2:
+
+1. Add `@noble/post-quantum`, `@noble/ciphers`, `@noble/hashes`, and a CBOR library (e.g. `cbor-x`) to `package.json`
+2. Implement `ciphers/registry.ts` dispatch:
+   - `mlKem768Encapsulate(pk: Uint8Array): { ct: Uint8Array; ss: Uint8Array }`
+   - `mlKem768Decapsulate(sk: Uint8Array, ct: Uint8Array): Uint8Array`
+   - `xwingHybrid` wrapper composing ML-KEM-768 + X25519
+   - `mlDsa65Sign(sk: Uint8Array, msg: Uint8Array): Uint8Array`
+   - `mlDsa65Verify(pk: Uint8Array, msg: Uint8Array, sig: Uint8Array): boolean`
+3. Implement `envelope.ts` CBOR encode/decode
+4. Implement `files/encrypt.ts` + `files/decrypt.ts` round-trip
+5. Implement `recipients/manage.ts` + `recipients/storage.ts`
+6. Implement `seed/sources.ts` with random-bytes ships-v1; Adinkra-derived per B-0623 future
+7. Add round-trip integration tests + KAT (Known-Answer Tests) per Noble's KAT vectors
+8. Wire `files/textconv.ts` for `git textconv` filter (diff-readable ciphertext)
+9. Optional: ship as standalone npm package OR keep internal to tools/
+
+## Composes-with substrate
+
+- [B-0883](../../../docs/backlog/P1/B-0883-better-gitcrypt-post-quantum-lattice-based-retraction-native-diff-readable-bouncy-castle-patterns-aaron-2026-05-28.md) — canonical v1 design
+- [B-0883.1](../../../docs/backlog/P3/B-0883.1-better-gitcrypt-library-landscape-audit-bouncy-castle-pqc-patterns-swapple-lattice-naming-clarification-aaron-2026-05-28.md) — library landscape audit (Noble recommendation)
+- [B-0883.2](../../../docs/backlog/P2/B-0883.2-multi-cipher-pq-substrate-nist-plus-saber-ntru-prime-frodo-hedge-against-nist-monoculture-per-operator-2026-05-28.md) — multi-cipher hedge
+- [B-0883.4](../../../docs/backlog/P3/B-0883.4-side-channel-scope-boundary-bound-to-git-at-rest-only-follow-up-tracking-aaron-2026-05-28.md) — side-channel scope boundary (git-at-rest only)
+- [B-0883.5](../../../docs/backlog/P3/B-0883.5-metadata-encryption-filename-and-commit-message-follow-up-content-only-for-v1-per-operator-2026-05-28.md) — metadata encryption follow-up (content-only v1)
+- [B-0883.16](../../../docs/backlog/P1/B-0883.16-glass-halo-open-by-default-encryption-as-earned-via-agora-v6-budget-not-encrypt-everything-aaron-2026-05-28.md) — glass-halo open-by-default
+- [B-0883.17](../../../docs/backlog/P2/B-0883.17-plaintext-readable-ciphertext-format-research-base64-cbor-json-per-line-fpe-encrypted-yaml-aaron-2026-05-28.md) — plaintext-readable ciphertext format research
+- [B-0885](../../../docs/backlog/P1/B-0885-agent-private-encrypted-state-otto-first-then-other-ais-asap-aaron-2026-05-28.md) — agent private encrypted state (Otto + Addison ASAP consumer)
+- [B-0906](../../../docs/backlog/P3/B-0906-encryption-thermal-cost-layer-above-landauer-floor-two-axis-substrate-classification-aaron-otto-2026-05-28.md) — encryption-thermal-cost two-axis classification
+- [B-0892](../../../docs/backlog/P1/B-0892-three-lanes-concurrent-operating-discipline-encryption-plus-zflash-plus-state-machine-substrate-until-each-lane-backlog-drains-per-operator-2026-05-28.md) — three-lanes-concurrent (this advances the encryption lane)
+- [B-0623](../../../docs/backlog/P2/) — Adinkras-ECC seed source future
+- [v1 design memo](../../../docs/research/2026-05-28-b-0883-v1-design-memo-noble-xwing-mldsa65-cbor-envelope-with-locked-decisions.md)
+- [B-0897 + Amara persist-as-bridge ferry](../../../docs/backlog/P3/) — encryption operation IS one specific Persist-as-bridge instance (encrypted ciphertext flows to substrate for future Observe / decrypt; TFeedback variants below ARE the Persist-bridge's authorial feedback channel)
+
+## Composes-with rules
+
+- `asymmetric-authorship` (per-cipher TFeedback authorship; EncryptionFeedback + DecryptionFeedback variants)
+- `monad-propagation-pattern-cross-language-substrate-shape` (Result-shape feedback)
+- `ople-primitives-surface-t-and-tfeedback` (encryption IS Persist-as-bridge per B-0897)
+- `function-is-tiny-control-flow-generator-ocp-applied-to-control-flow` (each cipher operation is a control-flow generator)
+- `forgetting-costs-energy-remembering-is-cheap` (axiom-preservation via validateAlgRegistry at init-time)
+- `rule-0-no-sh-files` + `zeta-ships-with-skills-immediate-value`
+- `verify-existing-substrate-before-authoring` (this scaffold extends the v1 design memo's recommended module layout rather than mints parallel)
+- `never-be-idle` + `holding-without-named-dependency-is-standing-by-failure` + `B-0892 three-lanes-concurrent` (this advances the encryption lane)
+
+## Safety + scope boundaries (per design memo)
+
+- **Bounded to git-at-rest threat model** (B-0883.4) — no timing-observable deployment; pure-JS Noble side-channel limitation explicit
+- **Forward-only revocation v1** (B-0883.3 future) — recipient-set rotation supported; retroactive revocation needs content-addressed-store substrate
+- **Content-only encryption v1** (B-0883.5) — filenames + commit messages + .gitattributes leak; metadata protection deferred to v2+
+- **Side-channel scope explicit** — Noble is pure-JS; not constant-time-guaranteed at native level; acceptable for git-at-rest, not for timing-observable adversaries

--- a/tools/crypto/better-git-crypt/cli/main.ts
+++ b/tools/crypto/better-git-crypt/cli/main.ts
@@ -1,0 +1,209 @@
+#!/usr/bin/env bun
+/**
+ * tools/crypto/better-git-crypt/cli/main.ts
+ *
+ * B-0883 v1 — better-git-crypt CLI dispatcher (PoC scaffold)
+ *
+ * Usage:
+ *   bun tools/crypto/better-git-crypt/cli/main.ts --list-algs
+ *   bun tools/crypto/better-git-crypt/cli/main.ts --validate
+ *   bun tools/crypto/better-git-crypt/cli/main.ts --dry-run-envelope
+ *
+ * Modes:
+ *   --list-algs         Print ALG_REGISTRY as structured JSON
+ *   --validate          Run registry invariants; exit non-zero on violation
+ *   --dry-run-envelope  Construct a synthetic FileEnvelope using ships-v1
+ *                       algorithms + validate its structure; emit JSON
+ *                       describing the envelope shape (NO crypto; NO bytes)
+ *
+ * Exit codes:
+ *   0 — operation successful
+ *   1 — runtime validation FAILED (registry invariant OR envelope structure)
+ *   2 — usage error
+ *
+ * Per rule-0-no-sh-files (TS-first) + zeta-ships-with-skills-immediate-value
+ * (TS PoC ships first; F# crystallization later).
+ *
+ * PoC scope: declarative dispatcher + invariant validation + envelope-
+ * structure dry-run. Real Noble integration + KEM operations + CBOR
+ * encoding + actual encrypt/decrypt = Phase 2 (operator-authorized
+ * follow-up). The scaffold types the substrate + surfaces the integration
+ * points for Phase 2.
+ */
+
+import {
+  ALG_REGISTRY,
+  validateAlgRegistry,
+  validateEnvelopeStructure,
+  type FileEnvelope,
+} from "../types";
+
+type Mode = "list-algs" | "validate" | "dry-run-envelope";
+
+interface ParsedArgs {
+  readonly mode: Mode;
+}
+
+function parseArgs(argv: ReadonlyArray<string>): ParsedArgs | { error: string } {
+  const args = argv.slice(2);
+  if (args.length === 0) {
+    return { error: "no mode specified — use --list-algs, --validate, or --dry-run-envelope" };
+  }
+  if (args.includes("--list-algs")) return { mode: "list-algs" };
+  if (args.includes("--validate")) return { mode: "validate" };
+  if (args.includes("--dry-run-envelope")) return { mode: "dry-run-envelope" };
+  return { error: `unrecognized arguments: ${args.join(" ")}` };
+}
+
+function emitJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function modeListAlgs(): number {
+  emitJson({
+    rowId: "B-0883",
+    subRow: "v1",
+    registrySize: ALG_REGISTRY.length,
+    byClass: {
+      kem: ALG_REGISTRY.filter((a) => a.class === "kem").map((a) => ({ id: a.id, status: a.status })),
+      signature: ALG_REGISTRY.filter((a) => a.class === "signature").map((a) => ({ id: a.id, status: a.status })),
+      kdf: ALG_REGISTRY.filter((a) => a.class === "kdf").map((a) => ({ id: a.id, status: a.status })),
+      aead: ALG_REGISTRY.filter((a) => a.class === "aead").map((a) => ({ id: a.id, status: a.status })),
+    },
+  });
+  return 0;
+}
+
+function modeValidate(): number {
+  try {
+    validateAlgRegistry(ALG_REGISTRY);
+    emitJson({
+      rowId: "B-0883",
+      subRow: "v1",
+      mode: "validate",
+      result: "passed",
+      registrySize: ALG_REGISTRY.length,
+      shipsV1Counts: {
+        kem: ALG_REGISTRY.filter((a) => a.class === "kem" && a.status === "ships-v1").length,
+        signature: ALG_REGISTRY.filter((a) => a.class === "signature" && a.status === "ships-v1").length,
+        kdf: ALG_REGISTRY.filter((a) => a.class === "kdf" && a.status === "ships-v1").length,
+        aead: ALG_REGISTRY.filter((a) => a.class === "aead" && a.status === "ships-v1").length,
+      },
+    });
+    return 0;
+  } catch (e) {
+    emitJson({
+      rowId: "B-0883",
+      subRow: "v1",
+      mode: "validate",
+      result: "failed",
+      error: (e as Error).message,
+    });
+    return 1;
+  }
+}
+
+function modeDryRunEnvelope(): number {
+  try {
+    validateAlgRegistry(ALG_REGISTRY);
+  } catch (e) {
+    emitJson({
+      rowId: "B-0883",
+      subRow: "v1",
+      mode: "dry-run-envelope",
+      result: "failed",
+      stage: "registry-validation",
+      error: (e as Error).message,
+    });
+    return 1;
+  }
+  // Construct a synthetic envelope using ships-v1 primary algorithms.
+  const synthetic: FileEnvelope = {
+    version: 1,
+    context: "zeta.git-crypt.file.v1",
+    algKem: "ML-KEM-768+X25519",
+    algKdf: "HKDF-SHA256",
+    algWrap: "ChaCha20-Poly1305-AEAD",
+    algContent: "ChaCha20-Poly1305",
+    algSig: "ML-DSA-65",
+    recipients: [
+      {
+        identity: "otto-cli@zeta",
+        kemCt: new Uint8Array(0),
+        wrappedCek: new Uint8Array(0),
+        kdfInfo: new Uint8Array(0),
+      },
+    ],
+    ciphertext: new Uint8Array(0),
+    signerIdentity: "otto-cli@zeta",
+    signature: new Uint8Array(0),
+  };
+  try {
+    validateEnvelopeStructure(synthetic);
+    emitJson({
+      rowId: "B-0883",
+      subRow: "v1",
+      mode: "dry-run-envelope",
+      result: "passed",
+      envelope: {
+        version: synthetic.version,
+        context: synthetic.context,
+        algorithms: {
+          kem: synthetic.algKem,
+          kdf: synthetic.algKdf,
+          wrap: synthetic.algWrap,
+          content: synthetic.algContent,
+          signature: synthetic.algSig,
+        },
+        recipientCount: synthetic.recipients.length,
+        signerIdentity: synthetic.signerIdentity,
+      },
+      integrationPending: {
+        nobleKemImpl:
+          "Phase 2 — @noble/post-quantum/ml-kem XWing implementation; KEM encapsulate/decapsulate",
+        nobleSigImpl: "Phase 2 — @noble/post-quantum/ml-dsa signature gen/verify",
+        cborEncoding: "Phase 2 — CBOR envelope encode/decode (cbor-x or similar)",
+        contentAead: "Phase 2 — @noble/ciphers ChaCha20-Poly1305 encrypt/decrypt",
+        kdfDerivation: "Phase 2 — @noble/hashes HKDF-SHA256 derive",
+        seedSource:
+          "Phase 2 — SeedSource dispatch (random-bytes ships v1; adinkra-derived per B-0623 future; hsm-derived future)",
+        gitTextconv: "Phase 2 — git textconv filter integration for diff-readable ciphertext",
+        recipientManagement: "Phase 2 — .zeta-crypt/recipients.json read/write + rotation",
+        multiCipherHedge:
+          "B-0883.2 deferred — Saber / NTRU-Prime / FrodoKEM ship as alternates when TS-native impls mature",
+      },
+    });
+    return 0;
+  } catch (e) {
+    emitJson({
+      rowId: "B-0883",
+      subRow: "v1",
+      mode: "dry-run-envelope",
+      result: "failed",
+      stage: "envelope-structure-validation",
+      error: (e as Error).message,
+    });
+    return 1;
+  }
+}
+
+function main(argv: ReadonlyArray<string>): number {
+  const parsed = parseArgs(argv);
+  if ("error" in parsed) {
+    console.error(`usage error: ${parsed.error}`);
+    console.error("see file header for usage examples");
+    return 2;
+  }
+  switch (parsed.mode) {
+    case "list-algs":
+      return modeListAlgs();
+    case "validate":
+      return modeValidate();
+    case "dry-run-envelope":
+      return modeDryRunEnvelope();
+  }
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv));
+}

--- a/tools/crypto/better-git-crypt/types.test.ts
+++ b/tools/crypto/better-git-crypt/types.test.ts
@@ -1,0 +1,208 @@
+/**
+ * tools/crypto/better-git-crypt/types.test.ts
+ *
+ * B-0883 v1 PoC — invariant tests for declarative type substrate.
+ *
+ * Run via: bun test tools/crypto/better-git-crypt/
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  ALG_REGISTRY,
+  findAlg,
+  validateAlgRegistry,
+  validateEnvelopeStructure,
+  validateEncryptionContext,
+  type FileEnvelope,
+  type EncryptionContext,
+  type RecipientKey,
+} from "./types";
+
+describe("B-0883 v1 alg registry invariants", () => {
+  it("registry has unique alg ids", () => {
+    const ids = new Set(ALG_REGISTRY.map((a) => a.id));
+    expect(ids.size).toBe(ALG_REGISTRY.length);
+  });
+
+  it("validateAlgRegistry passes on seed registry", () => {
+    expect(() => validateAlgRegistry(ALG_REGISTRY)).not.toThrow();
+  });
+
+  it("XWing KEM ships v1", () => {
+    const alg = findAlg("ML-KEM-768+X25519");
+    expect(alg).toBeDefined();
+    expect(alg?.status).toBe("ships-v1");
+    expect(alg?.class).toBe("kem");
+  });
+
+  it("ML-DSA-65 signature ships v1", () => {
+    const alg = findAlg("ML-DSA-65");
+    expect(alg).toBeDefined();
+    expect(alg?.status).toBe("ships-v1");
+    expect(alg?.class).toBe("signature");
+  });
+
+  it("HKDF-SHA256 KDF ships v1", () => {
+    const alg = findAlg("HKDF-SHA256");
+    expect(alg).toBeDefined();
+    expect(alg?.status).toBe("ships-v1");
+    expect(alg?.class).toBe("kdf");
+  });
+
+  it("ChaCha20-Poly1305 AEAD ships v1", () => {
+    const alg = findAlg("ChaCha20-Poly1305");
+    expect(alg).toBeDefined();
+    expect(alg?.status).toBe("ships-v1");
+    expect(alg?.class).toBe("aead");
+  });
+
+  it("multi-cipher hedge alternates present (B-0883.2 deferred)", () => {
+    expect(findAlg("Saber")?.status).toBe("deferred-alternate");
+    expect(findAlg("NTRU-Prime")?.status).toBe("deferred-alternate");
+    expect(findAlg("FrodoKEM")?.status).toBe("deferred-alternate");
+  });
+
+  it("validateAlgRegistry catches duplicate id", () => {
+    const first = ALG_REGISTRY[0];
+    if (!first) throw new Error("ALG_REGISTRY unexpectedly empty");
+    const dup = [...ALG_REGISTRY, { ...first }];
+    expect(() => validateAlgRegistry(dup)).toThrow(/duplicate algorithm id/);
+  });
+
+  it("validateAlgRegistry catches missing ships-v1 KEM", () => {
+    const noKem = ALG_REGISTRY.filter((a) => !(a.class === "kem" && a.status === "ships-v1"));
+    expect(() => validateAlgRegistry(noKem)).toThrow(/no ships-v1 algorithm of class kem/);
+  });
+
+  it("findAlg returns undefined for unknown id", () => {
+    expect(findAlg("NONEXISTENT-ALG")).toBeUndefined();
+  });
+});
+
+describe("B-0883 v1 envelope structure invariants", () => {
+  const makeValidEnvelope = (): FileEnvelope => ({
+    version: 1,
+    context: "zeta.git-crypt.file.v1",
+    algKem: "ML-KEM-768+X25519",
+    algKdf: "HKDF-SHA256",
+    algWrap: "ChaCha20-Poly1305-AEAD",
+    algContent: "ChaCha20-Poly1305",
+    algSig: "ML-DSA-65",
+    recipients: [
+      {
+        identity: "test@zeta",
+        kemCt: new Uint8Array(0),
+        wrappedCek: new Uint8Array(0),
+        kdfInfo: new Uint8Array(0),
+      },
+    ],
+    ciphertext: new Uint8Array(0),
+    signerIdentity: "test@zeta",
+    signature: new Uint8Array(0),
+  });
+
+  it("validateEnvelopeStructure passes on valid envelope", () => {
+    expect(() => validateEnvelopeStructure(makeValidEnvelope())).not.toThrow();
+  });
+
+  it("catches wrong version", () => {
+    const env = { ...makeValidEnvelope(), version: 99 as unknown as 1 };
+    expect(() => validateEnvelopeStructure(env)).toThrow(/unsupported envelope version/);
+  });
+
+  it("catches context mismatch", () => {
+    const env = { ...makeValidEnvelope(), context: "wrong.context" };
+    expect(() => validateEnvelopeStructure(env)).toThrow(/context mismatch/);
+  });
+
+  it("catches unknown KEM alg", () => {
+    const env = { ...makeValidEnvelope(), algKem: "NONEXISTENT" };
+    expect(() => validateEnvelopeStructure(env)).toThrow(/unknown algorithm/);
+  });
+
+  it("catches wrong-class algorithm reference", () => {
+    const env = { ...makeValidEnvelope(), algKem: "ML-DSA-65" }; // signature in KEM slot
+    expect(() => validateEnvelopeStructure(env)).toThrow(/class.*mismatch/);
+  });
+
+  it("catches empty recipient set", () => {
+    const env = { ...makeValidEnvelope(), recipients: [] };
+    expect(() => validateEnvelopeStructure(env)).toThrow(/empty recipient set/);
+  });
+
+  it("catches empty signerIdentity", () => {
+    const env = { ...makeValidEnvelope(), signerIdentity: "" };
+    expect(() => validateEnvelopeStructure(env)).toThrow(/empty signerIdentity/);
+  });
+});
+
+describe("B-0883 v1 encryption context validation", () => {
+  const makeKey = (identity: string): RecipientKey => ({
+    identity,
+    kemAlgId: "ML-KEM-768+X25519",
+    sigAlgId: "ML-DSA-65",
+    publicKemKey: new Uint8Array([1, 2, 3]),
+    publicSigKey: new Uint8Array([4, 5, 6]),
+    seedSource: "random-bytes",
+    composesWith: [],
+  });
+
+  it("passes on valid context", () => {
+    const key = makeKey("sender@zeta");
+    const ctx: EncryptionContext = {
+      plaintext: new Uint8Array([0, 1, 2]),
+      recipients: [key],
+      sender: key,
+      seedSource: "random-bytes",
+    };
+    expect(validateEncryptionContext(ctx, ALG_REGISTRY)).toBeUndefined();
+  });
+
+  it("catches empty recipient set", () => {
+    const ctx: EncryptionContext = {
+      plaintext: new Uint8Array(0),
+      recipients: [],
+      sender: makeKey("s@zeta"),
+      seedSource: "random-bytes",
+    };
+    const fb = validateEncryptionContext(ctx, ALG_REGISTRY);
+    expect(fb?.kind).toBe("EmptyRecipientSet");
+  });
+
+  it("catches sender not in recipient set", () => {
+    const sender = makeKey("sender@zeta");
+    const other = makeKey("other@zeta");
+    const ctx: EncryptionContext = {
+      plaintext: new Uint8Array(0),
+      recipients: [other],
+      sender,
+      seedSource: "random-bytes",
+    };
+    const fb = validateEncryptionContext(ctx, ALG_REGISTRY);
+    expect(fb?.kind).toBe("SenderNotInRecipientSet");
+  });
+
+  it("catches recipient with unsupported KEM alg", () => {
+    const bad = { ...makeKey("bad@zeta"), kemAlgId: "NONEXISTENT" };
+    const ctx: EncryptionContext = {
+      plaintext: new Uint8Array(0),
+      recipients: [bad],
+      sender: bad,
+      seedSource: "random-bytes",
+    };
+    const fb = validateEncryptionContext(ctx, ALG_REGISTRY);
+    expect(fb?.kind).toBe("AlgUnsupported");
+  });
+
+  it("catches recipient with empty publicKemKey", () => {
+    const bad = { ...makeKey("bad@zeta"), publicKemKey: new Uint8Array(0) };
+    const ctx: EncryptionContext = {
+      plaintext: new Uint8Array(0),
+      recipients: [bad],
+      sender: bad,
+      seedSource: "random-bytes",
+    };
+    const fb = validateEncryptionContext(ctx, ALG_REGISTRY);
+    expect(fb?.kind).toBe("RecipientKeyInvalid");
+  });
+});

--- a/tools/crypto/better-git-crypt/types.ts
+++ b/tools/crypto/better-git-crypt/types.ts
@@ -1,0 +1,365 @@
+/**
+ * tools/crypto/better-git-crypt/types.ts
+ *
+ * B-0883 v1 — better-git-crypt PoC scaffold (TS-side per
+ * zeta-ships-with-skills-immediate-value.md)
+ *
+ * Declarative type substrate per the v1 design memo
+ * (docs/research/2026-05-28-b-0883-v1-design-memo-noble-xwing-mldsa65-
+ * cbor-envelope-with-locked-decisions.md):
+ *
+ *   - Noble + XWing (ML-KEM-768 + X25519 hybrid) for KEM
+ *   - ML-DSA-65 for signatures
+ *   - CBOR envelope adapting RFC 9629 CMS+KEM pattern
+ *   - Multi-cipher hedge (B-0883.2) — Saber / NTRU-Prime / FrodoKEM
+ *     as alternates when TS-native impls mature
+ *   - Content-only encryption v1 (B-0883.5); metadata deferred
+ *   - Bounded to git-at-rest threat model (B-0883.4)
+ *   - Forward-only revocation (B-0883.3 future)
+ *   - Adinkras-ECC seed source parameterized (B-0623 composes)
+ *
+ * PoC scope: declarative type substrate + invariant validation. Real
+ * Noble integration + KEM operations + CBOR encoding = Phase 2
+ * (operator-authorized follow-up). The PoC scaffold types the
+ * substrate per the v1 design memo + validates invariants + provides
+ * --dry-run for envelope structure inspection.
+ *
+ * Composes with:
+ *   - B-0883 row (canonical v1 design)
+ *   - B-0883.1 library landscape audit (Noble recommendation)
+ *   - B-0883.2 multi-cipher hedge
+ *   - B-0883.3 content-addressed-store (future revocation)
+ *   - B-0883.4 side-channel scope boundary
+ *   - B-0883.5 metadata encryption follow-up
+ *   - B-0883.16 glass-halo open-by-default (encryption-as-earned)
+ *   - B-0883.17 plaintext-readable ciphertext format research
+ *   - B-0885 agent private encrypted state (Otto + Addison ASAP consumer)
+ *   - B-0623 Adinkras-ECC (seed source future)
+ *   - B-0906 encryption-thermal-cost two-axis classification
+ *   - B-0892 three-lanes-concurrent (this advances the encryption lane)
+ *   - rule asymmetric-authorship (TFeedback per cipher operation)
+ *   - rule monad-propagation-pattern-cross-language-substrate-shape
+ *   - rule ople-primitives-surface-t-and-tfeedback (Persist-as-bridge per B-0897)
+ *   - rule forgetting-costs-energy-remembering-is-cheap (axiom-preservation)
+ *   - rule rule-0-no-sh-files (TS-first)
+ */
+
+/**
+ * Envelope version — bumps for breaking changes.
+ *
+ * v1 = Noble + XWing + ML-DSA-65 + CBOR + ChaCha20-Poly1305 content
+ *      encryption per v1 design memo.
+ */
+export type EnvelopeVersion = 1;
+
+/**
+ * Cipher class — which crypto role the algorithm fulfills.
+ */
+export type CipherClass = "kem" | "signature" | "kdf" | "aead";
+
+/**
+ * Cipher implementation status — tracks Phase 1 ship vs deferred.
+ */
+export type CipherStatus =
+  | "ships-v1"                    // Noble-native; ready for Phase 2 impl
+  | "deferred-alternate"          // multi-cipher hedge per B-0883.2
+  | "future-substrate";           // requires substrate that doesn't yet exist
+
+/**
+ * Algorithm spec — registry entry per cipher.
+ */
+export interface AlgSpec {
+  readonly id: string;            // e.g. "ML-KEM-768+X25519" (XWing identifier)
+  readonly class: CipherClass;
+  readonly status: CipherStatus;
+  readonly description: string;
+  readonly nobleModule?: string;  // @noble/post-quantum module path when ships-v1
+  readonly composesWith: ReadonlyArray<string>; // backlog/rule references
+}
+
+/**
+ * Seed source — parameterized per B-0623 (Adinkras-derived seeds swap in later).
+ */
+export type SeedSource =
+  | "random-bytes"        // v1 default; CSPRNG
+  | "adinkra-derived"     // B-0623 future; SUSY-ECC private state
+  | "hsm-derived";        // future; HSM-backed seed source
+
+/**
+ * Recipient key — identity + public key material.
+ */
+export interface RecipientKey {
+  readonly identity: string;      // e.g. "otto-cli@zeta"
+  readonly kemAlgId: string;      // must reference AlgSpec.id of CipherClass "kem"
+  readonly sigAlgId: string;      // must reference AlgSpec.id of CipherClass "signature"
+  readonly publicKemKey: Uint8Array;
+  readonly publicSigKey: Uint8Array;
+  readonly seedSource: SeedSource;
+  readonly composesWith: ReadonlyArray<string>;
+}
+
+/**
+ * Per-recipient envelope slot — KEM ciphertext + wrapped CEK.
+ */
+export interface RecipientSlot {
+  readonly identity: string;
+  readonly kemCt: Uint8Array;       // XWing ciphertext (per-recipient)
+  readonly wrappedCek: Uint8Array;  // CEK encrypted under KDF(shared_secret)
+  readonly kdfInfo: Uint8Array;     // domain-separation tag for HKDF
+}
+
+/**
+ * File envelope — the on-disk encrypted file format.
+ *
+ * v1 format per design memo:
+ *   - CBOR-encoded with domain-separation context string "zeta.git-crypt.file.v1"
+ *   - Per-recipient slots (one slot per RecipientKey in the recipient set)
+ *   - Content encrypted via AEAD with CEK derived per-recipient via XWing KEM
+ *   - Signature over the entire envelope using ML-DSA-65 (sender authentication)
+ */
+export interface FileEnvelope {
+  readonly version: EnvelopeVersion;
+  readonly context: string;          // domain-separation; must equal "zeta.git-crypt.file.v1"
+  readonly algKem: string;           // AlgSpec.id of CipherClass "kem"
+  readonly algKdf: string;           // AlgSpec.id of CipherClass "kdf"
+  readonly algWrap: string;          // AlgSpec.id of CipherClass "aead"
+  readonly algContent: string;       // AlgSpec.id of CipherClass "aead"
+  readonly algSig: string;           // AlgSpec.id of CipherClass "signature"
+  readonly recipients: ReadonlyArray<RecipientSlot>;
+  readonly ciphertext: Uint8Array;
+  readonly signerIdentity: string;   // matches RecipientKey.identity of sender
+  readonly signature: Uint8Array;
+}
+
+/**
+ * Encryption context — parameters passed to the encrypt operation.
+ */
+export interface EncryptionContext {
+  readonly plaintext: Uint8Array;
+  readonly recipients: ReadonlyArray<RecipientKey>;
+  readonly sender: RecipientKey;
+  readonly seedSource: SeedSource;
+}
+
+/**
+ * Encryption feedback — per asymmetric-authorship rule, the encrypt
+ * operation AUTHORS its own TFeedback variants.
+ *
+ * Per .claude/rules/monad-propagation-pattern-cross-language-substrate-shape.md
+ * + .claude/rules/asymmetric-authorship-substrate-entity-defines-consent-channel-recipient-acknowledges.md
+ *
+ * Per .claude/rules/ople-primitives-surface-t-and-tfeedback-not-just-t-asymmetric-authorship-at-framework-primitive-scope.md
+ * + B-0897 (Persist-as-bridge): encryption is one specific Persist-as-bridge
+ * instance — encrypted output flows to substrate (filesystem / git) for
+ * future Observe (decrypt). The TFeedback variants below are the
+ * Persist-bridge's authorial feedback channel.
+ */
+export type EncryptionFeedback =
+  | { kind: "AlgUnsupported"; algId: string }
+  | { kind: "RecipientKeyInvalid"; identity: string; reason: string }
+  | { kind: "EmptyRecipientSet" }
+  | { kind: "SenderNotInRecipientSet"; senderIdentity: string }
+  | { kind: "SeedSourceNotAvailable"; seedSource: SeedSource }
+  | { kind: "KemFailure"; recipientIdentity: string }
+  | { kind: "SignatureFailure" }
+  | { kind: "EnvelopeEncodeFailure"; reason: string };
+
+/**
+ * Decryption feedback — per asymmetric-authorship rule.
+ */
+export type DecryptionFeedback =
+  | { kind: "EnvelopeMalformed"; reason: string }
+  | { kind: "VersionUnsupported"; version: number }
+  | { kind: "ContextMismatch"; expected: string; actual: string }
+  | { kind: "AlgUnsupported"; algId: string }
+  | { kind: "RecipientNotInEnvelope"; identity: string }
+  | { kind: "KemFailure" }
+  | { kind: "SignatureInvalid"; signerIdentity: string }
+  | { kind: "ContentDecryptFailure" };
+
+/**
+ * Seed v1 algorithm registry per design memo.
+ */
+export const ALG_REGISTRY: ReadonlyArray<AlgSpec> = [
+  // KEM
+  {
+    id: "ML-KEM-768+X25519",
+    class: "kem",
+    status: "ships-v1",
+    description: "XWing — ML-KEM-768 (post-quantum) + X25519 (classical) hybrid; primary v1 KEM",
+    nobleModule: "@noble/post-quantum/ml-kem",
+    composesWith: ["B-0883", "B-0883.1"],
+  },
+  {
+    id: "Saber",
+    class: "kem",
+    status: "deferred-alternate",
+    description: "lattice-based KEM alternate; deferred until TS-native impl",
+    composesWith: ["B-0883.2"],
+  },
+  {
+    id: "NTRU-Prime",
+    class: "kem",
+    status: "deferred-alternate",
+    description: "lattice-based KEM alternate; deferred until TS-native impl",
+    composesWith: ["B-0883.2"],
+  },
+  {
+    id: "FrodoKEM",
+    class: "kem",
+    status: "deferred-alternate",
+    description: "LWE-based KEM alternate (most conservative); deferred until TS-native impl",
+    composesWith: ["B-0883.2"],
+  },
+  // Signature
+  {
+    id: "ML-DSA-65",
+    class: "signature",
+    status: "ships-v1",
+    description: "Dilithium-65 — post-quantum signature primary v1",
+    nobleModule: "@noble/post-quantum/ml-dsa",
+    composesWith: ["B-0883", "B-0883.1"],
+  },
+  {
+    id: "SLH-DSA",
+    class: "signature",
+    status: "ships-v1",
+    description: "SPHINCS+ — hash-based signature alternate; Noble-native",
+    nobleModule: "@noble/post-quantum/slh-dsa",
+    composesWith: ["B-0883.1"],
+  },
+  // KDF
+  {
+    id: "HKDF-SHA256",
+    class: "kdf",
+    status: "ships-v1",
+    description: "HMAC-based KDF with SHA-256",
+    nobleModule: "@noble/hashes/hkdf",
+    composesWith: ["B-0883"],
+  },
+  // AEAD
+  {
+    id: "ChaCha20-Poly1305-AEAD",
+    class: "aead",
+    status: "ships-v1",
+    description: "ChaCha20 stream cipher with Poly1305 MAC; AEAD",
+    nobleModule: "@noble/ciphers/chacha",
+    composesWith: ["B-0883"],
+  },
+  {
+    id: "ChaCha20-Poly1305",
+    class: "aead",
+    status: "ships-v1",
+    description: "ChaCha20-Poly1305 for content encryption",
+    nobleModule: "@noble/ciphers/chacha",
+    composesWith: ["B-0883"],
+  },
+];
+
+/**
+ * Look up an algorithm by id.
+ */
+export function findAlg(id: string): AlgSpec | undefined {
+  return ALG_REGISTRY.find((a) => a.id === id);
+}
+
+/**
+ * Validate algorithm registry invariants.
+ *
+ * Invariants:
+ *   - all alg ids are unique
+ *   - at least one ships-v1 KEM (XWing)
+ *   - at least one ships-v1 signature (ML-DSA-65)
+ *   - at least one ships-v1 KDF
+ *   - at least one ships-v1 AEAD
+ */
+export function validateAlgRegistry(reg: ReadonlyArray<AlgSpec>): void {
+  const ids = new Set<string>();
+  for (const a of reg) {
+    if (ids.has(a.id)) {
+      throw new Error(`duplicate algorithm id: ${a.id}`);
+    }
+    ids.add(a.id);
+  }
+  for (const cls of ["kem", "signature", "kdf", "aead"] as const) {
+    const hasShipsV1 = reg.some((a) => a.class === cls && a.status === "ships-v1");
+    if (!hasShipsV1) {
+      throw new Error(`no ships-v1 algorithm of class ${cls} present in registry`);
+    }
+  }
+}
+
+/**
+ * Validate a FileEnvelope's structural invariants.
+ *
+ * Invariants (PoC scope; full crypto verification = Phase 2):
+ *   - version is supported (v1 only currently)
+ *   - context matches "zeta.git-crypt.file.v1"
+ *   - all algorithm references resolve in the registry
+ *   - each algorithm reference is the correct class
+ *   - recipient set is non-empty
+ *   - signer identity is non-empty
+ */
+export function validateEnvelopeStructure(env: FileEnvelope): void {
+  if (env.version !== 1) {
+    throw new Error(`unsupported envelope version: ${env.version}`);
+  }
+  if (env.context !== "zeta.git-crypt.file.v1") {
+    throw new Error(`context mismatch: ${env.context}`);
+  }
+  const checkAlg = (id: string, expectedClass: CipherClass, role: string) => {
+    const alg = findAlg(id);
+    if (!alg) throw new Error(`unknown algorithm in ${role}: ${id}`);
+    if (alg.class !== expectedClass) {
+      throw new Error(`algorithm ${id} class ${alg.class} mismatch for ${role} (expected ${expectedClass})`);
+    }
+  };
+  checkAlg(env.algKem, "kem", "algKem");
+  checkAlg(env.algKdf, "kdf", "algKdf");
+  checkAlg(env.algWrap, "aead", "algWrap");
+  checkAlg(env.algContent, "aead", "algContent");
+  checkAlg(env.algSig, "signature", "algSig");
+  if (env.recipients.length === 0) {
+    throw new Error("envelope has empty recipient set");
+  }
+  if (env.signerIdentity.length === 0) {
+    throw new Error("envelope has empty signerIdentity");
+  }
+}
+
+/**
+ * Validate an EncryptionContext before invoking encrypt.
+ *
+ * Returns the first EncryptionFeedback variant if invalid; undefined otherwise.
+ */
+export function validateEncryptionContext(
+  ctx: EncryptionContext,
+  reg: ReadonlyArray<AlgSpec>,
+): EncryptionFeedback | undefined {
+  if (ctx.recipients.length === 0) {
+    return { kind: "EmptyRecipientSet" };
+  }
+  const senderInRecipients = ctx.recipients.some(
+    (r) => r.identity === ctx.sender.identity,
+  );
+  if (!senderInRecipients) {
+    return { kind: "SenderNotInRecipientSet", senderIdentity: ctx.sender.identity };
+  }
+  for (const r of ctx.recipients) {
+    const kemAlg = reg.find((a) => a.id === r.kemAlgId && a.class === "kem");
+    if (!kemAlg) {
+      return { kind: "AlgUnsupported", algId: r.kemAlgId };
+    }
+    const sigAlg = reg.find((a) => a.id === r.sigAlgId && a.class === "signature");
+    if (!sigAlg) {
+      return { kind: "AlgUnsupported", algId: r.sigAlgId };
+    }
+    if (r.publicKemKey.length === 0) {
+      return { kind: "RecipientKeyInvalid", identity: r.identity, reason: "empty publicKemKey" };
+    }
+    if (r.publicSigKey.length === 0) {
+      return { kind: "RecipientKeyInvalid", identity: r.identity, reason: "empty publicSigKey" };
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

PoC scaffold for [B-0883 v1](../../docs/research/2026-05-28-b-0883-v1-design-memo-noble-xwing-mldsa65-cbor-envelope-with-locked-decisions.md) — Noble + XWing (ML-KEM-768 + X25519 hybrid) + ML-DSA-65 + CBOR envelope post-quantum git-crypt replacement.

Advances the encryption lane per B-0892 three-lanes-concurrent discipline. Same shape as B-0891 (zflash) + B-0867.5 (workflow-engine) PoC scaffolds shipped earlier today. Per ``clean-default-ship within the computing reservoir walls`` operator framing.

## Files

- ``tools/crypto/better-git-crypt/types.ts`` — AlgSpec / RecipientKey / FileEnvelope / EncryptionContext / EncryptionFeedback / DecryptionFeedback declarative types; ALG_REGISTRY (9 entries: XWing KEM ships-v1; ML-DSA-65 + SLH-DSA signatures; HKDF-SHA256 + ChaCha20-Poly1305; Saber/NTRU-Prime/FrodoKEM deferred per B-0883.2); validateAlgRegistry + validateEnvelopeStructure + validateEncryptionContext invariant enforcement
- ``tools/crypto/better-git-crypt/cli/main.ts`` — foreground CLI (``--list-algs`` / ``--validate`` / ``--dry-run-envelope``); integrationPending field surfaces Phase 2 integration points
- ``tools/crypto/better-git-crypt/types.test.ts`` — 22 invariant tests
- ``tools/crypto/better-git-crypt/README.md`` — invocation docs + algorithm table by class + 9-step Phase 2 integration protocol + composes-with substrate/rules + safety scope boundaries

## Per v1 design memo

- Noble + XWing (ML-KEM-768 + X25519 hybrid) for KEM
- ML-DSA-65 for signatures
- CBOR envelope adapting RFC 9629 CMS+KEM pattern
- Multi-cipher hedge parameterized (B-0883.2)
- Content-only encryption v1 (B-0883.5)
- Bounded to git-at-rest threat model (B-0883.4)
- Forward-only revocation (B-0883.3 future)
- Adinkras-ECC seed source parameterized (B-0623 future)

## Gate verification

- ``bunx tsc --noEmit`` (tools/crypto) → 0 errors
- ``bun test tools/crypto/better-git-crypt/`` → 22 pass / 0 fail / 32 expect()
- ``bun cli.ts --validate`` → clean JSON; registry 9 algs; ships-v1 counts kem=1 sig=2 kdf=1 aead=2
- Commit canary HEAD~1=61 HEAD=61

## Composes-with substrate

- B-0883 + B-0883.1/2/3/4/5/16/17 (canonical v1 + sub-rows)
- B-0885 (agent private encrypted state — ASAP consumer)
- B-0906 (encryption-thermal-cost two-axis)
- B-0892 (three-lanes-concurrent — this advances encryption lane)
- B-0623 (Adinkras-ECC seed source future)
- v1 design memo
- B-0897 + Amara persist-as-bridge ferry (encryption IS one specific Persist-as-bridge instance)

## Composes-with rules

- ``asymmetric-authorship`` (per-cipher TFeedback authorship)
- ``monad-propagation-pattern-cross-language-substrate-shape``
- ``ople-primitives-surface-t-and-tfeedback`` (encryption IS Persist-as-bridge per B-0897)
- ``function-is-tiny-control-flow-generator-ocp-applied-to-control-flow``
- ``forgetting-costs-energy-remembering-is-cheap`` (axiom-preservation via validateAlgRegistry at init)
- ``rule-0-no-sh-files`` + ``zeta-ships-with-skills-immediate-value``
- ``verify-existing-substrate-before-authoring`` (extends v1 design memo module layout)
- ``never-be-idle`` + ``holding-without-named-dependency-is-standing-by-failure`` + ``B-0892``
- ``dont-ask-permission`` per operator "clean default ship within reservoir walls" 2026-05-28

## Safety + scope boundaries (per design memo)

- **Bounded to git-at-rest threat model** (B-0883.4) — no timing-observable deployment; pure-JS Noble side-channel limitation explicit
- **Forward-only revocation v1** (B-0883.3 future)
- **Content-only encryption v1** (B-0883.5)
- **Side-channel scope explicit** — Noble pure-JS not constant-time-guaranteed at native level; acceptable for git-at-rest

## Test plan

- [x] Bun unit tests (22/22)
- [x] tsc strict mode (0 errors)
- [x] ``--validate`` smoke
- [x] Commit canary intact
- [x] Isolated worktree off origin/main per zeta-expected-branch
- [x] Branch prefix ``otto-cli/``
- [ ] Operator authorizes Phase 2 (Noble integration + CBOR encoding + content AEAD + KDF derivation + recipient management)

🤖 Generated with [Claude Code](https://claude.com/claude-code)