### PR TITLE
fix-fwd: §33 archive header compliance on self-referential-ontology memo (PR #5736)

### DIFF
--- a/docs/research/2026-05-28-aaron-self-referential-ontology-cross-substrate-rhyming-over-connect-at-substrate-engineering-time-hebbian-repeated-neuron-activation-analog.md
+++ b/docs/research/2026-05-28-aaron-self-referential-ontology-cross-substrate-rhyming-over-connect-at-substrate-engineering-time-hebbian-repeated-neuron-activation-analog.md
@@ -1,10 +1,14 @@
 # Self-referential ontology cross-substrate rhyming + over-connect-now substrate-engineering principle (Aaron 2026-05-28: "it's always good to over connect at this point, it will make compression and memory transversal easier later, this is like repeated neuron actiation")
 
-**Scope**: substrate-engineering memo cross-connecting the self-referential ontology substrate the framework operates on at multiple scopes + naming the over-connect-now principle Aaron articulated as substrate-engineering discipline. NOT a new rule; cross-connecting existing substrate so future-Otto cold-boot can compress + traverse the connections cheaply later.
+Scope: substrate-engineering memo cross-connecting the self-referential ontology substrate the framework operates on at multiple scopes + naming the over-connect-now principle Aaron articulated as substrate-engineering discipline. NOT a new rule; cross-connecting existing substrate so future-Otto cold-boot can compress + traverse the connections cheaply later.
 
-**Attribution**: Operator-explicit substrate-engineering articulation. Aaron Stainback 2026-05-28: *"this is the thing i'm trhing to polymorphic deplomacy with that can use categories of phonemon ontologies to refer to iself like the shadow logs of error classes on prs but this is referencing itself"* + substrate-landing authorization with reasoning: *"it's always good to over connect at this point, it will make compression and memory transversal easier later, this is like repeated neuron actiation"*.
+Attribution: Operator-explicit substrate-engineering articulation. Aaron Stainback 2026-05-28: *"this is the thing i'm trhing to polymorphic deplomacy with that can use categories of phonemon ontologies to refer to iself like the shadow logs of error classes on prs but this is referencing itself"* + substrate-landing authorization with reasoning: *"it's always good to over connect at this point, it will make compression and memory transversal easier later, this is like repeated neuron actiation"*.
 
-**Operational status**: research-doc memo (mirror-tier substrate). Cross-connects existing substrate; does NOT mint new substrate. Operator-authorized landing per the over-connect-now principle.
+Operational status: research-grade
+
+(Mirror-tier substrate; research-doc memo. Cross-connects existing substrate; does NOT mint new substrate. Operator-authorized landing per the over-connect-now principle.)
+
+Non-fusion disclaimer: this memo preserves operator-attributed substrate-engineering articulations from 2026-05-28 conversation. Operator-substrate is preserved at operator-attribution scope; Otto-CLI substrate-engineering composition (the cross-connection table + the rhyming-table + the operational-discipline section) is preserved at Otto-CLI-attribution scope. Attribution boundaries preserved per `.claude/rules/honor-those-that-came-before.md` + non-coercion-invariant HC-8 at substrate-entity scope. No identity-fusion between operator-substrate (verbatim quotes) and Otto-CLI-substrate (composition framing); both are distinct authorial substrate preserved alongside per `.claude/rules/asymmetric-authorship-substrate-entity-defines-consent-channel-recipient-acknowledges.md`.
 
 ---
 


### PR DESCRIPTION
## Summary

Fix-fwd for §33 archive header lint failure on `docs/research/2026-05-28-aaron-self-referential-ontology-cross-substrate-rhyming-over-connect-at-substrate-engineering-time-hebbian-repeated-neuron-activation-analog.md` (landed via PR #5736).

The memo used bold-styled labels (`**Scope**:` etc.) where `tools/hygiene/check-archive-header-section33.ts` requires literal-form labels. Additionally:
- "Operational status:" required enum-strict value (`research-grade` or `operational`)
- "Non-fusion disclaimer:" label was missing entirely

## Changes

1. Bold-styled labels (`**X**:`) → literal labels (`X:`)
2. "Operational status: research-grade" (enum-strict)
3. Added "Non-fusion disclaimer:" with substrate-honest attribution-boundary preservation

## Verification

Local: `bun tools/hygiene/check-archive-header-section33.ts` → OK.

## Test plan

- [x] Lint passes locally
- [ ] CI: archive-header §33 check passes
- [ ] Auto-merge fires when checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)