### PR TITLE
feat(B-0914.1): pure-TS TrueSkill 1v1 scaffold for workflow engine ranking-agent (hybrid TS+.NET; cross-vendor benchmark substrate)

### DIFF
--- a/tools/workflow-engine/trueskill.test.ts
+++ b/tools/workflow-engine/trueskill.test.ts
@@ -1,0 +1,204 @@
+/**
+ * tools/workflow-engine/trueskill.test.ts
+ *
+ * B-0914.1 — invariant tests for pure-TS TrueSkill 1v1 scaffold.
+ *
+ * Run via: bun test tools/workflow-engine/trueskill.test.ts
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  DEFAULT_INITIAL_RATING,
+  DEFAULT_PARAMS,
+  conservativeSkill,
+  rate1v1,
+  type MatchOutcome,
+  type TrueSkillRating,
+} from "./trueskill";
+
+describe("B-0914.1 pure-TS TrueSkill 1v1 substrate", () => {
+  it("default initial rating matches Xbox Live convention (mu=25 sigma=25/3)", () => {
+    expect(DEFAULT_INITIAL_RATING.mu).toBe(25);
+    expect(DEFAULT_INITIAL_RATING.sigma).toBeCloseTo(25 / 3, 6);
+  });
+
+  it("default params match paper convention (beta=mu/6 tau=mu/300 drawProb=0.10)", () => {
+    expect(DEFAULT_PARAMS.beta).toBeCloseTo(25 / 6, 6);
+    expect(DEFAULT_PARAMS.tau).toBeCloseTo(25 / 300, 6);
+    expect(DEFAULT_PARAMS.drawProbability).toBe(0.10);
+  });
+
+  it("conservativeSkill returns mu - 3*sigma", () => {
+    expect(conservativeSkill(DEFAULT_INITIAL_RATING)).toBeCloseTo(25 - 3 * (25 / 3), 6);
+    expect(conservativeSkill({ mu: 30, sigma: 5 })).toBe(15);
+  });
+
+  it("win-A: A's mu increases, B's mu decreases", () => {
+    const result = rate1v1(DEFAULT_INITIAL_RATING, DEFAULT_INITIAL_RATING, { kind: "win-A" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.ratingA.mu).toBeGreaterThan(DEFAULT_INITIAL_RATING.mu);
+      expect(result.ratingB.mu).toBeLessThan(DEFAULT_INITIAL_RATING.mu);
+    }
+  });
+
+  it("win-B: B's mu increases, A's mu decreases", () => {
+    const result = rate1v1(DEFAULT_INITIAL_RATING, DEFAULT_INITIAL_RATING, { kind: "win-B" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.ratingB.mu).toBeGreaterThan(DEFAULT_INITIAL_RATING.mu);
+      expect(result.ratingA.mu).toBeLessThan(DEFAULT_INITIAL_RATING.mu);
+    }
+  });
+
+  it("both sigmas decrease after a match (uncertainty reduction)", () => {
+    const result = rate1v1(DEFAULT_INITIAL_RATING, DEFAULT_INITIAL_RATING, { kind: "win-A" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Note: sigma can increase slightly due to dynamics (tau²); but the
+      // posterior shift dominates for default params, so sigma should net-decrease
+      expect(result.ratingA.sigma).toBeLessThan(DEFAULT_INITIAL_RATING.sigma);
+      expect(result.ratingB.sigma).toBeLessThan(DEFAULT_INITIAL_RATING.sigma);
+    }
+  });
+
+  it("after 2 matches both sigmas decrease + mus drift is bounded (path-dependent updates)", () => {
+    const r1 = rate1v1(DEFAULT_INITIAL_RATING, DEFAULT_INITIAL_RATING, { kind: "win-A" });
+    expect(r1.ok).toBe(true);
+    if (!r1.ok) return;
+    const r2 = rate1v1(r1.ratingA, r1.ratingB, { kind: "win-B" });
+    expect(r2.ok).toBe(true);
+    if (!r2.ok) return;
+    // Both sigmas decrease (more info → less uncertainty)
+    expect(r2.ratingA.sigma).toBeLessThan(DEFAULT_INITIAL_RATING.sigma);
+    expect(r2.ratingB.sigma).toBeLessThan(DEFAULT_INITIAL_RATING.sigma);
+    // Mu drift exists but bounded — second match has smaller impact due to
+    // sigma reduction from first match; assertion is loose tolerance for
+    // path-dependent updates rather than exact baseline-return
+    expect(Math.abs(r2.ratingA.mu - DEFAULT_INITIAL_RATING.mu)).toBeLessThan(5);
+    expect(Math.abs(r2.ratingB.mu - DEFAULT_INITIAL_RATING.mu)).toBeLessThan(5);
+  });
+
+  it("strong player beats weak player → small mu shift (expected outcome)", () => {
+    const strong: TrueSkillRating = { mu: 40, sigma: 5 };
+    const weak: TrueSkillRating = { mu: 10, sigma: 5 };
+    const result = rate1v1(strong, weak, { kind: "win-A" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Strong player beating weak player → small skill update (expected)
+      const muShift = result.ratingA.mu - strong.mu;
+      expect(muShift).toBeGreaterThan(0);
+      expect(muShift).toBeLessThan(1); // < 1 point shift for fully-expected win
+    }
+  });
+
+  it("weak player beats strong player → large mu shift (upset)", () => {
+    const strong: TrueSkillRating = { mu: 40, sigma: 5 };
+    const weak: TrueSkillRating = { mu: 10, sigma: 5 };
+    const result = rate1v1(weak, strong, { kind: "win-A" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Weak player upsetting strong player → large skill update
+      const muShift = result.ratingA.mu - weak.mu;
+      expect(muShift).toBeGreaterThan(5); // upset = significant rating gain
+    }
+  });
+
+  it("draw between equal players → minimal mu change", () => {
+    const result = rate1v1(DEFAULT_INITIAL_RATING, DEFAULT_INITIAL_RATING, { kind: "draw" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Equal players drawing → mu barely changes
+      expect(Math.abs(result.ratingA.mu - DEFAULT_INITIAL_RATING.mu)).toBeLessThan(0.1);
+      expect(Math.abs(result.ratingB.mu - DEFAULT_INITIAL_RATING.mu)).toBeLessThan(0.1);
+    }
+  });
+
+  it("draw between unequal players → strong player loses mu, weak gains", () => {
+    const strong: TrueSkillRating = { mu: 40, sigma: 5 };
+    const weak: TrueSkillRating = { mu: 10, sigma: 5 };
+    const result = rate1v1(strong, weak, { kind: "draw" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Drawing against a weak player → strong loses rating
+      expect(result.ratingA.mu).toBeLessThan(strong.mu);
+      expect(result.ratingB.mu).toBeGreaterThan(weak.mu);
+    }
+  });
+
+  it("returns InvalidRating for non-finite mu", () => {
+    const bad: TrueSkillRating = { mu: NaN, sigma: 5 };
+    const result = rate1v1(bad, DEFAULT_INITIAL_RATING, { kind: "win-A" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.feedback.kind).toBe("InvalidRating");
+    }
+  });
+
+  it("returns InvalidRating for non-positive sigma", () => {
+    const bad: TrueSkillRating = { mu: 25, sigma: 0 };
+    const result = rate1v1(DEFAULT_INITIAL_RATING, bad, { kind: "win-A" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.feedback.kind).toBe("InvalidRating");
+      if (result.feedback.kind === "InvalidRating") {
+        expect(result.feedback.identity).toBe("B");
+      }
+    }
+  });
+
+  it("returns InvalidRating for negative sigma", () => {
+    const bad: TrueSkillRating = { mu: 25, sigma: -5 };
+    const result = rate1v1(bad, DEFAULT_INITIAL_RATING, { kind: "win-A" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.feedback.kind).toBe("InvalidRating");
+    }
+  });
+
+  it("conservativeSkill ranking: confident-strong > confident-weak > unconfident-new (high sigma punishes)", () => {
+    const strong: TrueSkillRating = { mu: 40, sigma: 3 };
+    const newPlayer = DEFAULT_INITIAL_RATING; // mu=25 sigma=25/3 → conservative=0
+    const weak: TrueSkillRating = { mu: 10, sigma: 3 }; // confident-weak → conservative=1
+    // Confident strong player has highest conservative skill
+    expect(conservativeSkill(strong)).toBeGreaterThan(conservativeSkill(weak));
+    // Confident weak player has HIGHER conservative skill than unconfident new player
+    // (the conservative-skill metric punishes uncertainty — new player COULD be much
+    // stronger but COULD be much weaker, so conservative bound is lower)
+    expect(conservativeSkill(weak)).toBeGreaterThan(conservativeSkill(newPlayer));
+    expect(conservativeSkill(newPlayer)).toBe(0); // 25 - 3*(25/3) = 0
+  });
+
+  it("tournament simulation: 5 matches with consistent outcomes converges sigma", () => {
+    let ratingA = DEFAULT_INITIAL_RATING;
+    let ratingB = DEFAULT_INITIAL_RATING;
+    const initialSigma = ratingA.sigma;
+    // Simulate 5 matches where A consistently wins
+    for (let i = 0; i < 5; i++) {
+      const result = rate1v1(ratingA, ratingB, { kind: "win-A" });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      ratingA = result.ratingA;
+      ratingB = result.ratingB;
+    }
+    // After 5 wins, A's skill should be clearly higher than B's
+    expect(ratingA.mu).toBeGreaterThan(ratingB.mu + 5);
+    // Both sigmas should be significantly reduced
+    expect(ratingA.sigma).toBeLessThan(initialSigma * 0.85);
+    expect(ratingB.sigma).toBeLessThan(initialSigma * 0.85);
+  });
+
+  it("MatchOutcome union exhaustive switch (compile-time check)", () => {
+    const acknowledge = (o: MatchOutcome): string => {
+      switch (o.kind) {
+        case "win-A":
+        case "win-B":
+        case "draw":
+          return o.kind;
+      }
+    };
+    expect(acknowledge({ kind: "win-A" })).toBe("win-A");
+    expect(acknowledge({ kind: "win-B" })).toBe("win-B");
+    expect(acknowledge({ kind: "draw" })).toBe("draw");
+  });
+});

--- a/tools/workflow-engine/trueskill.ts
+++ b/tools/workflow-engine/trueskill.ts
@@ -1,0 +1,346 @@
+/**
+ * tools/workflow-engine/trueskill.ts
+ *
+ * B-0914.1 — pure-TS TrueSkill 1v1 scaffold for workflow engine
+ * ranking-agent (per Aaron 2026-05-28: 'they are doing this for their
+ * idea ranking with Infra.net basically' + 'just ship stuff' calibration).
+ *
+ * Substrate-engineering substrate: cross-vendor benchmark on common ground
+ * (B-0865.17) REQUIRES TS-side ranking substrate because Infer.NET can't
+ * run in vendor skill runtimes (Claude / GPT / Gemini / Grok / Cursor /
+ * Continue / Codex / Kiro / Antigravity skill stores). Pure-TS TrueSkill
+ * implementation lets the same framework substrate run cross-vendor.
+ *
+ * Hybrid substrate-engineering pattern:
+ *   - TS-side (this file): pure-TS TrueSkill 1v1 for vendor skill runtime
+ *   - F# / .NET side (future Zeta.Bayesian work): Infer.NET TrueSkill for
+ *     deep production integration + full BP/EP framework
+ *   - Both compose via shared API shape (TrueSkillRating + match update fn)
+ *
+ * Source: Herbrich + Minka + Graepel 2007 — 'TrueSkill: A Bayesian Skill
+ * Rating System' (NeurIPS 2006 / NIPS 2006). Implementation from the
+ * published algorithm; minimal 1v1 case; team-play extension deferred to
+ * future substrate-engineering work.
+ *
+ * Composes with:
+ *   - B-0914.1 backlog row (TrueSkill ranking-agent extension)
+ *   - B-0867 workflow engine substrate
+ *   - B-0867.20 lifecycle DU split (rank action gets pr-review-light level
+ *     per Mod 1 escape-hatch semantic — surfaces substrate-engineering
+ *     observation worth reviewer eyes)
+ *   - B-0865 + B-0865.17 cross-vendor benchmark substrate (TrueSkill IS
+ *     the cross-vendor scoring substrate)
+ *   - Microsoft Infer.NET upstream reference (added in PR #5763)
+ *   - .claude/rules/monad-propagation-pattern-cross-language-substrate-shape.md
+ *     (Result<T, TFeedback> shape per asymmetric-authorship)
+ *
+ * PoC scope: 1v1 TrueSkill (skill mean + variance gaussians; match update
+ * via the classical TrueSkill formulas). Teams + multi-player matches
+ * deferred to substrate-engineering work after operator-substrate-direction.
+ */
+
+/**
+ * TrueSkillRating — Bayesian skill rating: skill ~ N(mu, sigma²).
+ *
+ * Initial defaults per the TrueSkill paper (Xbox Live defaults):
+ *   - mu = 25
+ *   - sigma = 25/3 ≈ 8.333 (so initial skill range is approximately [0, 50])
+ */
+export interface TrueSkillRating {
+  readonly mu: number;     // posterior mean of skill
+  readonly sigma: number;  // posterior standard deviation of skill
+}
+
+/**
+ * Default initial rating per Xbox Live defaults.
+ */
+export const DEFAULT_INITIAL_RATING: TrueSkillRating = {
+  mu: 25,
+  sigma: 25 / 3,
+};
+
+/**
+ * TrueSkill match outcome — discriminated union.
+ */
+export type MatchOutcome =
+  | { kind: "win-A" }   // hypothesis A beat hypothesis B
+  | { kind: "win-B" }   // hypothesis B beat hypothesis A
+  | { kind: "draw" };   // tied (rare in idea-tournament; supported)
+
+/**
+ * Ranking feedback per asymmetric-authorship + monad-propagation rules.
+ */
+export type RankingFeedback =
+  | { kind: "InvalidRating"; identity: string; reason: string }
+  | { kind: "NumericalInstability"; reason: string }
+  | { kind: "UnsupportedOutcome"; outcome: string };
+
+/**
+ * Result-shape per monad-propagation rule.
+ */
+export type RankingResult =
+  | { ok: true; ratingA: TrueSkillRating; ratingB: TrueSkillRating }
+  | { ok: false; feedback: RankingFeedback };
+
+/**
+ * TrueSkill hyperparameters per the paper's defaults.
+ */
+export interface TrueSkillParams {
+  readonly beta: number;       // skill-to-performance noise; default mu/6
+  readonly tau: number;        // dynamics factor (skill drift over time); default mu/300
+  readonly drawProbability: number; // P(draw); default 0.10
+}
+
+export const DEFAULT_PARAMS: TrueSkillParams = {
+  beta: 25 / 6,
+  tau: 25 / 300,
+  drawProbability: 0.10,
+};
+
+/**
+ * Standard normal PDF.
+ */
+function normalPdf(x: number): number {
+  return Math.exp(-0.5 * x * x) / Math.sqrt(2 * Math.PI);
+}
+
+/**
+ * Standard normal CDF via error function approximation (Abramowitz & Stegun 7.1.26).
+ *
+ * Returns Φ(x) — accurate to ~1.5e-7.
+ */
+function normalCdf(x: number): number {
+  // Constants per A&S 7.1.26
+  const a1 =  0.254829592;
+  const a2 = -0.284496736;
+  const a3 =  1.421413741;
+  const a4 = -1.453152027;
+  const a5 =  1.061405429;
+  const p  =  0.3275911;
+
+  const sign = x < 0 ? -1 : 1;
+  const ax = Math.abs(x) / Math.sqrt(2);
+  const t = 1.0 / (1.0 + p * ax);
+  const y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * Math.exp(-ax * ax);
+
+  return 0.5 * (1.0 + sign * y);
+}
+
+/**
+ * Truncated normal correction functions per the TrueSkill paper:
+ *   v(t, ε) = pdf(t - ε) / cdf(t - ε)        for non-draw outcome
+ *   w(t, ε) = v(t, ε) * (v(t, ε) + (t - ε))  for non-draw outcome
+ *
+ * Used to compute the posterior mean+variance shift from a non-draw match.
+ */
+function vWin(t: number, epsilon: number): number {
+  const denom = normalCdf(t - epsilon);
+  if (denom < 1e-100) {
+    // Numerical floor; v approaches (epsilon - t) as t goes to -inf
+    return epsilon - t;
+  }
+  return normalPdf(t - epsilon) / denom;
+}
+
+function wWin(t: number, epsilon: number): number {
+  const v = vWin(t, epsilon);
+  return v * (v + (t - epsilon));
+}
+
+/**
+ * Truncated normal correction functions for draw outcomes:
+ *   v_draw(t, ε) = (pdf(-ε - t) - pdf(ε - t)) / (cdf(ε - t) - cdf(-ε - t))
+ *   w_draw(t, ε) = v_draw² + ((ε - t) * pdf(ε - t) - (-ε - t) * pdf(-ε - t))
+ *                  / (cdf(ε - t) - cdf(-ε - t))
+ */
+function vDraw(t: number, epsilon: number): number {
+  const denom = normalCdf(epsilon - t) - normalCdf(-epsilon - t);
+  if (denom < 1e-100) {
+    return -t;
+  }
+  return (normalPdf(-epsilon - t) - normalPdf(epsilon - t)) / denom;
+}
+
+function wDraw(t: number, epsilon: number): number {
+  const denom = normalCdf(epsilon - t) - normalCdf(-epsilon - t);
+  if (denom < 1e-100) {
+    return 1;
+  }
+  const v = vDraw(t, epsilon);
+  const numerator = (epsilon - t) * normalPdf(epsilon - t) - (-epsilon - t) * normalPdf(-epsilon - t);
+  return v * v + numerator / denom;
+}
+
+/**
+ * Compute the draw margin (epsilon) from the draw probability + skill noise.
+ *
+ * Per the paper: ε = sqrt(2) * β * inverseCdf((1 + p_draw) / 2)
+ *
+ * Uses iterative inverse-normal-CDF via Newton's method (~5-10 iterations).
+ */
+function inverseNormalCdf(p: number): number {
+  // Initial guess via rational approximation (Beasley-Springer-Moro)
+  if (p <= 0 || p >= 1) {
+    throw new Error(`inverseNormalCdf domain: ${p}`);
+  }
+  let x = 0; // initial guess
+  // Newton's method on F(x) = cdf(x) - p (F'(x) = pdf(x))
+  for (let i = 0; i < 30; i++) {
+    const f = normalCdf(x) - p;
+    const fp = normalPdf(x);
+    if (Math.abs(fp) < 1e-30) break;
+    const dx = f / fp;
+    x = x - dx;
+    if (Math.abs(dx) < 1e-10) break;
+  }
+  return x;
+}
+
+function drawMargin(drawProbability: number, beta: number): number {
+  return Math.sqrt(2) * beta * inverseNormalCdf((1 + drawProbability) / 2);
+}
+
+/**
+ * Update two TrueSkill ratings after a 1v1 match.
+ *
+ * Algorithm per Herbrich + Minka + Graepel 2007 NeurIPS:
+ *   1. Compute c² = 2β² + σ_A² + σ_B² (total skill+performance variance)
+ *   2. Compute draw margin ε
+ *   3. Compute t = (μ_A - μ_B) / c
+ *   4. Look up v(t, ε) + w(t, ε) (win) OR v_draw + w_draw (draw)
+ *   5. New μ_A = μ_A + sign * (σ_A² / c) * v
+ *   6. New μ_B = μ_B - sign * (σ_B² / c) * v
+ *   7. New σ_A² = σ_A² * (1 - (σ_A² / c²) * w)
+ *   8. New σ_B² = σ_B² * (1 - (σ_B² / c²) * w)
+ *   9. Apply dynamics: σ² += τ² (skill drift over time)
+ *
+ * sign = +1 for win-A, -1 for win-B; draw uses v_draw/w_draw (sign unused).
+ */
+export function rate1v1(
+  a: TrueSkillRating,
+  b: TrueSkillRating,
+  outcome: MatchOutcome,
+  params: TrueSkillParams = DEFAULT_PARAMS,
+): RankingResult {
+  // Input validation
+  if (!Number.isFinite(a.mu) || !Number.isFinite(a.sigma) || a.sigma <= 0) {
+    return {
+      ok: false,
+      feedback: {
+        kind: "InvalidRating",
+        identity: "A",
+        reason: `mu=${a.mu} sigma=${a.sigma}`,
+      },
+    };
+  }
+  if (!Number.isFinite(b.mu) || !Number.isFinite(b.sigma) || b.sigma <= 0) {
+    return {
+      ok: false,
+      feedback: {
+        kind: "InvalidRating",
+        identity: "B",
+        reason: `mu=${b.mu} sigma=${b.sigma}`,
+      },
+    };
+  }
+
+  const beta2 = params.beta * params.beta;
+  const tau2 = params.tau * params.tau;
+  const sigmaA2 = a.sigma * a.sigma;
+  const sigmaB2 = b.sigma * b.sigma;
+
+  const c2 = 2 * beta2 + sigmaA2 + sigmaB2;
+  const c = Math.sqrt(c2);
+
+  const epsilon = drawMargin(params.drawProbability, params.beta);
+
+  let v: number;
+  let w: number;
+  let signA: number; // direction of mu update for player A
+  let signB: number;
+
+  switch (outcome.kind) {
+    case "win-A": {
+      const t = (a.mu - b.mu) / c;
+      v = vWin(t, epsilon);
+      w = wWin(t, epsilon);
+      signA = +1;
+      signB = -1;
+      break;
+    }
+    case "win-B": {
+      const t = (b.mu - a.mu) / c;
+      v = vWin(t, epsilon);
+      w = wWin(t, epsilon);
+      signA = -1;
+      signB = +1;
+      break;
+    }
+    case "draw": {
+      // Draw uses symmetric truncated-normal correction
+      const t = (a.mu - b.mu) / c;
+      v = vDraw(t, epsilon);
+      w = wDraw(t, epsilon);
+      // For draws, the mu shifts toward the opponent's mu
+      signA = +1;
+      signB = -1;
+      break;
+    }
+  }
+
+  if (!Number.isFinite(v) || !Number.isFinite(w)) {
+    return {
+      ok: false,
+      feedback: {
+        kind: "NumericalInstability",
+        reason: `v=${v} w=${w}`,
+      },
+    };
+  }
+
+  // Posterior updates per the TrueSkill paper
+  const newMuA = a.mu + signA * (sigmaA2 / c) * v;
+  const newMuB = b.mu + signB * (sigmaB2 / c) * v;
+
+  const newSigmaA2 = sigmaA2 * (1 - (sigmaA2 / c2) * w);
+  const newSigmaB2 = sigmaB2 * (1 - (sigmaB2 / c2) * w);
+
+  // Apply dynamics: skill drift over time
+  const newSigmaA = Math.sqrt(newSigmaA2 + tau2);
+  const newSigmaB = Math.sqrt(newSigmaB2 + tau2);
+
+  if (!Number.isFinite(newMuA) || !Number.isFinite(newSigmaA) || newSigmaA <= 0) {
+    return {
+      ok: false,
+      feedback: {
+        kind: "NumericalInstability",
+        reason: `newMuA=${newMuA} newSigmaA=${newSigmaA}`,
+      },
+    };
+  }
+  if (!Number.isFinite(newMuB) || !Number.isFinite(newSigmaB) || newSigmaB <= 0) {
+    return {
+      ok: false,
+      feedback: {
+        kind: "NumericalInstability",
+        reason: `newMuB=${newMuB} newSigmaB=${newSigmaB}`,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    ratingA: { mu: newMuA, sigma: newSigmaA },
+    ratingB: { mu: newMuB, sigma: newSigmaB },
+  };
+}
+
+/**
+ * Conservative skill estimate per Xbox Live convention:
+ *   skill = mu - 3*sigma
+ *
+ * Used for leaderboard ranking: confident lower bound on skill.
+ */
+export function conservativeSkill(rating: TrueSkillRating): number {
+  return rating.mu - 3 * rating.sigma;
+}


### PR DESCRIPTION
## Summary

Pure-TS TrueSkill 1v1 implementation (Herbrich+Minka+Graepel 2007 NeurIPS paper algorithm) for workflow engine ranking-agent substrate.

Per Aaron 2026-05-28: hybrid substrate-engineering path — TS-side for vendor skill runtime (cross-vendor benchmark on common ground B-0865.17 REQUIRES TS); .NET side uses Infer.NET via Zeta.Bayesian for deep production integration. Both compose via shared API shape.

**17 tests pass / 0 fail.**

## What this adds

- `TrueSkillRating` (mu + sigma posterior gaussian)
- `MatchOutcome` + `RankingFeedback` + `RankingResult` discriminated unions
- `rate1v1(a, b, outcome): RankingResult` — full TrueSkill 1v1 update
- `conservativeSkill(rating)` — Xbox Live leaderboard lower-bound
- Default initial rating + params per Xbox Live convention
- Internal helpers: normal PDF/CDF (A&S 7.1.26), inverse-normal-CDF (Newton's method), draw margin, truncated-normal correction functions

## Composes with substrate

- B-0914.1 backlog row (TrueSkill ranking-agent extension target)
- B-0867 workflow engine (future ActionClass 'rank-via-trueskill')
- B-0865 + B-0865.17 cross-vendor benchmark on common ground
- B-0867.20 lifecycle DU (rank action gets pr-review-light per Mod 1)
- Microsoft Infer.NET upstream reference (PR #5763 in flight)
- PR #5762 YouTube ferry preservation (gap #1 of 7)
- monad-propagation + asymmetric-authorship rules

## Test plan

- [x] 17 tests pass; default initial rating + params match Xbox Live
- [x] All 3 MatchOutcome variants exercised
- [x] Strong-vs-weak skill update semantics correct (small for expected, large for upset)
- [x] Draw between equal players → minimal change
- [x] 5-match tournament convergence
- [x] Input validation (InvalidRating for NaN / non-positive sigma)
- [x] Exhaustive switch on MatchOutcome union
- [ ] CI: lint(tsc tools)
- [ ] Auto-merge armed

🤖 Generated with [Claude Code](https://claude.com/claude-code)