### PR TITLE
feat(B-0914.4): M — generation-reflection pairing tracker (structurally enforced producer-verifier mouth-ears substrate); 15 tests pass

### DIFF
--- a/tools/workflow-engine/pairing.test.ts
+++ b/tools/workflow-engine/pairing.test.ts
@@ -1,0 +1,240 @@
+/**
+ * tools/workflow-engine/pairing.test.ts
+ *
+ * B-0914.4 — invariant tests for pairing tracker.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  EMPTY_PAIRING_STATE,
+  countVerdicts,
+  findStaleEmissions,
+  findUnverifiedEmissions,
+  propagatableEmissionIds,
+  recordEmission,
+  recordVerification,
+  type Emission,
+  type PairingRole,
+  type Verification,
+  type VerificationVerdict,
+} from "./pairing";
+
+const emission = (id: string, atMs: number): Emission => ({
+  id,
+  producerId: "otto-cli",
+  substrate: { hypothesis: `h-${id}` },
+  emittedAtMs: atMs,
+  composesWith: [`source-${id}`],
+});
+
+const verification = (
+  emissionId: string,
+  atMs: number,
+  verdict: VerificationVerdict,
+): Verification => ({
+  emissionId,
+  verifierId: "kestrel",
+  verdict,
+  verifiedAtMs: atMs,
+});
+
+describe("B-0914.4 pairing tracker substrate", () => {
+  it("records an emission to empty state", () => {
+    const result = recordEmission(EMPTY_PAIRING_STATE, emission("e1", 1000));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.emissions.size).toBe(1);
+    expect(result.state.verifications.size).toBe(0);
+  });
+
+  it("rejects duplicate emission id", () => {
+    const r1 = recordEmission(EMPTY_PAIRING_STATE, emission("e1", 1000));
+    expect(r1.ok).toBe(true);
+    if (!r1.ok) return;
+    const r2 = recordEmission(r1.state, emission("e1", 2000));
+    expect(r2.ok).toBe(false);
+    if (r2.ok) return;
+    expect(r2.feedback.kind).toBe("DuplicateEmissionId");
+  });
+
+  it("records verification for known emission", () => {
+    const r1 = recordEmission(EMPTY_PAIRING_STATE, emission("e1", 1000));
+    if (!r1.ok) throw new Error("emission failed");
+    const r2 = recordVerification(r1.state, verification("e1", 2000, { kind: "verified" }));
+    expect(r2.ok).toBe(true);
+    if (!r2.ok) return;
+    expect(r2.state.verifications.size).toBe(1);
+  });
+
+  it("rejects verification for unknown emission", () => {
+    const r = recordVerification(
+      EMPTY_PAIRING_STATE,
+      verification("nonexistent", 2000, { kind: "verified" }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.feedback.kind).toBe("VerificationForUnknownEmission");
+  });
+
+  it("rejects duplicate verification", () => {
+    const r1 = recordEmission(EMPTY_PAIRING_STATE, emission("e1", 1000));
+    if (!r1.ok) throw new Error("emission failed");
+    const r2 = recordVerification(r1.state, verification("e1", 2000, { kind: "verified" }));
+    if (!r2.ok) throw new Error("first verify failed");
+    const r3 = recordVerification(r2.state, verification("e1", 3000, { kind: "rejected", reason: "x" }));
+    expect(r3.ok).toBe(false);
+    if (r3.ok) return;
+    expect(r3.feedback.kind).toBe("DuplicateVerification");
+  });
+
+  it("rejects verification before emission timestamp (causality violation)", () => {
+    const r1 = recordEmission(EMPTY_PAIRING_STATE, emission("e1", 2000));
+    if (!r1.ok) throw new Error("emission failed");
+    const r2 = recordVerification(r1.state, verification("e1", 1000, { kind: "verified" }));
+    expect(r2.ok).toBe(false);
+    if (r2.ok) return;
+    expect(r2.feedback.kind).toBe("VerificationTooEarly");
+  });
+
+  it("findUnverifiedEmissions returns emissions without verifications", () => {
+    let s = EMPTY_PAIRING_STATE;
+    const r1 = recordEmission(s, emission("e1", 1000));
+    if (!r1.ok) throw new Error("e1");
+    s = r1.state;
+    const r2 = recordEmission(s, emission("e2", 1500));
+    if (!r2.ok) throw new Error("e2");
+    s = r2.state;
+    const r3 = recordVerification(s, verification("e1", 2000, { kind: "verified" }));
+    if (!r3.ok) throw new Error("v1");
+    s = r3.state;
+    const unverified = findUnverifiedEmissions(s);
+    expect(unverified.length).toBe(1);
+    expect(unverified[0]!.id).toBe("e2");
+  });
+
+  it("findStaleEmissions returns emissions past the bounded window", () => {
+    let s = EMPTY_PAIRING_STATE;
+    const r1 = recordEmission(s, emission("e1", 1000));
+    if (!r1.ok) throw new Error("e1");
+    s = r1.state;
+    const r2 = recordEmission(s, emission("e2", 5000));
+    if (!r2.ok) throw new Error("e2");
+    s = r2.state;
+    // now = 10_000; timeoutMs = 4000
+    const stale = findStaleEmissions(s, 10_000, 4000);
+    expect(stale.length).toBe(2);  // both exceeded window
+    const stale2 = findStaleEmissions(s, 6000, 4000);
+    expect(stale2.length).toBe(1);  // only e1 exceeded
+    expect(stale2[0]!.id).toBe("e1");
+  });
+
+  it("findStaleEmissions excludes verified emissions even if old", () => {
+    let s = EMPTY_PAIRING_STATE;
+    const r1 = recordEmission(s, emission("e1", 1000));
+    if (!r1.ok) throw new Error("e1");
+    s = r1.state;
+    const r2 = recordVerification(s, verification("e1", 1500, { kind: "verified" }));
+    if (!r2.ok) throw new Error("v1");
+    s = r2.state;
+    // e1 emitted at 1000; verified at 1500; now = 10_000; would be stale if unverified
+    const stale = findStaleEmissions(s, 10_000, 1000);
+    expect(stale.length).toBe(0);  // verified, so not stale
+  });
+
+  it("countVerdicts aggregates verdicts correctly", () => {
+    let s = EMPTY_PAIRING_STATE;
+    for (let i = 1; i <= 5; i++) {
+      const r = recordEmission(s, emission(`e${i}`, 1000 + i * 100));
+      if (!r.ok) throw new Error(`e${i}`);
+      s = r.state;
+    }
+    s = recordVerification(s, verification("e1", 2000, { kind: "verified" })).state!;
+    s = recordVerification(s, verification("e2", 2000, { kind: "verified" })).state!;
+    s = recordVerification(s, verification("e3", 2000, { kind: "rejected", reason: "flawed" })).state!;
+    s = recordVerification(s, verification("e4", 2000, { kind: "needs-revision", suggestions: ["fix x"] })).state!;
+    // e5 left unverified
+    const counts = countVerdicts(s);
+    expect(counts.verified).toBe(2);
+    expect(counts.rejected).toBe(1);
+    expect(counts.needsRevision).toBe(1);
+    expect(counts.unverified).toBe(1);
+    expect(counts.total).toBe(5);
+  });
+
+  it("propagatableEmissionIds includes verified + needs-revision-with-suggestions; excludes rejected + empty-suggestions", () => {
+    let s = EMPTY_PAIRING_STATE;
+    for (let i = 1; i <= 4; i++) {
+      const r = recordEmission(s, emission(`e${i}`, 1000 + i * 100));
+      if (!r.ok) throw new Error(`e${i}`);
+      s = r.state;
+    }
+    s = recordVerification(s, verification("e1", 2000, { kind: "verified" })).state!;
+    s = recordVerification(s, verification("e2", 2000, { kind: "rejected", reason: "flawed" })).state!;
+    s = recordVerification(s, verification("e3", 2000, { kind: "needs-revision", suggestions: ["fix x"] })).state!;
+    s = recordVerification(s, verification("e4", 2000, { kind: "needs-revision", suggestions: [] })).state!;
+    const propagatable = propagatableEmissionIds(s);
+    expect(propagatable.length).toBe(2);
+    expect(propagatable).toContain("e1");
+    expect(propagatable).toContain("e3");
+    expect(propagatable).not.toContain("e2");  // rejected excluded
+    expect(propagatable).not.toContain("e4");  // empty suggestions excluded
+  });
+
+  it("immutable state operations: original state unchanged after record", () => {
+    const r1 = recordEmission(EMPTY_PAIRING_STATE, emission("e1", 1000));
+    expect(r1.ok).toBe(true);
+    expect(EMPTY_PAIRING_STATE.emissions.size).toBe(0);  // original unchanged
+    if (!r1.ok) return;
+    const r2 = recordVerification(r1.state, verification("e1", 2000, { kind: "verified" }));
+    expect(r2.ok).toBe(true);
+    expect(r1.state.verifications.size).toBe(0);  // intermediate state unchanged
+  });
+
+  it("VerificationVerdict union exhaustive switch (compile-time check)", () => {
+    const acknowledge = (v: VerificationVerdict): string => {
+      switch (v.kind) {
+        case "verified":
+        case "rejected":
+        case "needs-revision":
+          return v.kind;
+      }
+    };
+    expect(acknowledge({ kind: "verified" })).toBe("verified");
+    expect(acknowledge({ kind: "rejected", reason: "x" })).toBe("rejected");
+    expect(acknowledge({ kind: "needs-revision", suggestions: [] })).toBe("needs-revision");
+  });
+
+  it("PairingRole union exhaustive switch (compile-time check)", () => {
+    const acknowledge = (r: PairingRole): string => {
+      switch (r) {
+        case "producer":
+        case "verifier":
+          return r;
+      }
+    };
+    expect(acknowledge("producer")).toBe("producer");
+    expect(acknowledge("verifier")).toBe("verifier");
+  });
+
+  it("tournament-loop composition: emissions → verifications → propagatable → next stage", () => {
+    // Simulates the full producer-verifier-tournament loop
+    let s = EMPTY_PAIRING_STATE;
+    // Round 1: 3 emissions
+    for (let i = 1; i <= 3; i++) {
+      s = recordEmission(s, emission(`h${i}`, 1000 + i * 100)).state!;
+    }
+    // Verifier-thread reflects
+    s = recordVerification(s, verification("h1", 2000, { kind: "verified" })).state!;
+    s = recordVerification(s, verification("h2", 2000, { kind: "rejected", reason: "logic gap" })).state!;
+    s = recordVerification(s, verification("h3", 2000, { kind: "needs-revision", suggestions: ["clarify mechanism"] })).state!;
+    // Propagatable to next stage
+    const next = propagatableEmissionIds(s);
+    expect(next.length).toBe(2);  // h1 + h3
+    // Pairing complete (no unverified)
+    const stale = findStaleEmissions(s, 5000, 1000);
+    expect(stale.length).toBe(0);
+    // Aggregate state
+    const counts = countVerdicts(s);
+    expect(counts.verified + counts.rejected + counts.needsRevision).toBe(counts.total);
+  });
+});

--- a/tools/workflow-engine/pairing.test.ts
+++ b/tools/workflow-engine/pairing.test.ts
@@ -15,13 +15,31 @@ import {
   recordVerification,
   type Emission,
   type PairingRole,
+  type PairingState,
   type Verification,
   type VerificationVerdict,
 } from "./pairing";
 
+/**
+ * Test helper: assert the discriminated-union result is `ok: true` and
+ * return its state — replaces the `.state!` non-null assertion that
+ * bypasses TypeScript's type narrowing on `PairingResult`. If the
+ * operation unexpectedly fails, this surfaces the failure-mode
+ * substrate immediately instead of silently propagating `undefined`
+ * into downstream state.
+ */
+function mustState(
+  r: { ok: true; state: PairingState } | { ok: false; feedback: unknown },
+): PairingState {
+  if (!r.ok) {
+    throw new Error(`unexpected pairing feedback: ${JSON.stringify(r.feedback)}`);
+  }
+  return r.state;
+}
+
 const emission = (id: string, atMs: number): Emission => ({
   id,
-  producerId: "otto-cli",
+  producerId: "producer-1",
   substrate: { hypothesis: `h-${id}` },
   emittedAtMs: atMs,
   composesWith: [`source-${id}`],
@@ -33,7 +51,7 @@ const verification = (
   verdict: VerificationVerdict,
 ): Verification => ({
   emissionId,
-  verifierId: "kestrel",
+  verifierId: "verifier-1",
   verdict,
   verifiedAtMs: atMs,
 });
@@ -128,6 +146,24 @@ describe("B-0914.4 pairing tracker substrate", () => {
     expect(stale2[0]!.id).toBe("e1");
   });
 
+  it("findStaleEmissions boundary semantics: emission exactly at timeout is NOT stale (strict >)", () => {
+    // Locks in the strict > boundary documented in findStaleEmissions:
+    // an emission at (nowMs - emittedAtMs === timeoutMs) gets the
+    // boundary tick to be verified before becoming stale. Switch to >=
+    // here AND in pairing.ts together if SLA semantics ever change.
+    let s = EMPTY_PAIRING_STATE;
+    const r1 = recordEmission(s, emission("e1", 1000));
+    if (!r1.ok) throw new Error("e1");
+    s = r1.state;
+    // nowMs - emittedAtMs === timeoutMs exactly: 5000 - 1000 === 4000
+    const atBoundary = findStaleEmissions(s, 5000, 4000);
+    expect(atBoundary.length).toBe(0);  // strict > means NOT stale at boundary
+    // One ms past boundary: 5001 - 1000 > 4000
+    const justPast = findStaleEmissions(s, 5001, 4000);
+    expect(justPast.length).toBe(1);
+    expect(justPast[0]!.id).toBe("e1");
+  });
+
   it("findStaleEmissions excludes verified emissions even if old", () => {
     let s = EMPTY_PAIRING_STATE;
     const r1 = recordEmission(s, emission("e1", 1000));
@@ -148,10 +184,10 @@ describe("B-0914.4 pairing tracker substrate", () => {
       if (!r.ok) throw new Error(`e${i}`);
       s = r.state;
     }
-    s = recordVerification(s, verification("e1", 2000, { kind: "verified" })).state!;
-    s = recordVerification(s, verification("e2", 2000, { kind: "verified" })).state!;
-    s = recordVerification(s, verification("e3", 2000, { kind: "rejected", reason: "flawed" })).state!;
-    s = recordVerification(s, verification("e4", 2000, { kind: "needs-revision", suggestions: ["fix x"] })).state!;
+    s = mustState(recordVerification(s, verification("e1", 2000, { kind: "verified" })));
+    s = mustState(recordVerification(s, verification("e2", 2000, { kind: "verified" })));
+    s = mustState(recordVerification(s, verification("e3", 2000, { kind: "rejected", reason: "flawed" })));
+    s = mustState(recordVerification(s, verification("e4", 2000, { kind: "needs-revision", suggestions: ["fix x"] })));
     // e5 left unverified
     const counts = countVerdicts(s);
     expect(counts.verified).toBe(2);
@@ -168,10 +204,10 @@ describe("B-0914.4 pairing tracker substrate", () => {
       if (!r.ok) throw new Error(`e${i}`);
       s = r.state;
     }
-    s = recordVerification(s, verification("e1", 2000, { kind: "verified" })).state!;
-    s = recordVerification(s, verification("e2", 2000, { kind: "rejected", reason: "flawed" })).state!;
-    s = recordVerification(s, verification("e3", 2000, { kind: "needs-revision", suggestions: ["fix x"] })).state!;
-    s = recordVerification(s, verification("e4", 2000, { kind: "needs-revision", suggestions: [] })).state!;
+    s = mustState(recordVerification(s, verification("e1", 2000, { kind: "verified" })));
+    s = mustState(recordVerification(s, verification("e2", 2000, { kind: "rejected", reason: "flawed" })));
+    s = mustState(recordVerification(s, verification("e3", 2000, { kind: "needs-revision", suggestions: ["fix x"] })));
+    s = mustState(recordVerification(s, verification("e4", 2000, { kind: "needs-revision", suggestions: [] })));
     const propagatable = propagatableEmissionIds(s);
     expect(propagatable.length).toBe(2);
     expect(propagatable).toContain("e1");
@@ -221,12 +257,12 @@ describe("B-0914.4 pairing tracker substrate", () => {
     let s = EMPTY_PAIRING_STATE;
     // Round 1: 3 emissions
     for (let i = 1; i <= 3; i++) {
-      s = recordEmission(s, emission(`h${i}`, 1000 + i * 100)).state!;
+      s = mustState(recordEmission(s, emission(`h${i}`, 1000 + i * 100)));
     }
     // Verifier-thread reflects
-    s = recordVerification(s, verification("h1", 2000, { kind: "verified" })).state!;
-    s = recordVerification(s, verification("h2", 2000, { kind: "rejected", reason: "logic gap" })).state!;
-    s = recordVerification(s, verification("h3", 2000, { kind: "needs-revision", suggestions: ["clarify mechanism"] })).state!;
+    s = mustState(recordVerification(s, verification("h1", 2000, { kind: "verified" })));
+    s = mustState(recordVerification(s, verification("h2", 2000, { kind: "rejected", reason: "logic gap" })));
+    s = mustState(recordVerification(s, verification("h3", 2000, { kind: "needs-revision", suggestions: ["clarify mechanism"] })));
     // Propagatable to next stage
     const next = propagatableEmissionIds(s);
     expect(next.length).toBe(2);  // h1 + h3

--- a/tools/workflow-engine/pairing.ts
+++ b/tools/workflow-engine/pairing.ts
@@ -1,0 +1,287 @@
+/**
+ * tools/workflow-engine/pairing.ts
+ *
+ * B-0914.4 — generation-reflection adversarial pairing tracker for
+ * workflow engine. Structurally enforces the producer-verifier pattern
+ * Kestrel named in 15th-ferry §33.6 (mouth-and-ears-on-different-threads
+ * architecture) as workflow engine substrate.
+ *
+ * Per Aaron 2026-05-28 'S M L all please in that order lol' — this is
+ * M (medium scope) in the substrate-engineering ship-sequence.
+ *
+ * The pattern:
+ *   1. Producer thread emits hypothesis / artifact / proposal
+ *   2. Verifier thread reflects on the emission (within bounded window)
+ *   3. Pairing tracker enforces: every emission MUST have verification
+ *      OR be marked stale (timeout exceeded without verification)
+ *
+ * This composes the framework's already-operational multi-AI cascade
+ * lane specialization (Otto generates → Kestrel reflects; per 13th-ferry
+ * §33.7) into STRUCTURAL workflow-engine substrate rather than
+ * operator-orchestrated coordination.
+ *
+ * Source: Google co-scientist generation+reflection adversarial pairing
+ * pattern (Nature 2026) + Kestrel 15th-ferry mouth-ears-threads
+ * substrate-engineering observation.
+ *
+ * Composes with:
+ *   - B-0914.4 backlog row (generation-reflection extension target)
+ *   - B-0867.20 PR #5758 lifecycle DU split (state-machine-events vs
+ *     system-modifications; pairing requirement applies per-class)
+ *   - B-0914.1 PR #5764 TrueSkill substrate (verifier output feeds ranking)
+ *   - B-0914.5 PR #5767 evolution substrate (verified survivors evolve)
+ *   - PR #5756 Kestrel 15th-ferry mouth-ears-threads substrate
+ *   - .claude/rules/asymmetric-authorship-substrate-entity-defines-
+ *     consent-channel-recipient-acknowledges.md
+ *   - .claude/rules/monad-propagation-pattern-cross-language-substrate-shape.md
+ *
+ * PoC scope: in-memory pairing tracker with Result-shape feedback.
+ * Persistent state (git-append-only per B-0867.5 + lifecycle DUs per
+ * B-0867.20) deferred to integration layer.
+ */
+
+/**
+ * Pairing role — which thread the participant is operating on.
+ *
+ * Per Kestrel 15th-ferry §33.6: mouth = producer (generates fast;
+ * commits to substrate); ears = verifier (catches misses after the fact
+ * on a separate thread).
+ */
+export type PairingRole = "producer" | "verifier";
+
+/**
+ * Verification verdict — outcome of the verifier's reflection.
+ *
+ * Per Google co-scientist reflection agent pattern: tries to destroy
+ * the hypothesis; either it survives (verified) or has flaws surfaced
+ * (rejected with reason).
+ */
+export type VerificationVerdict =
+  | { kind: "verified"; notes?: string }
+  | { kind: "rejected"; reason: string }
+  | { kind: "needs-revision"; suggestions: ReadonlyArray<string> };
+
+/**
+ * Emission — a producer-thread output awaiting verification.
+ */
+export interface Emission {
+  readonly id: string;
+  readonly producerId: string;
+  readonly substrate: unknown;          // the actual emitted substrate
+  readonly emittedAtMs: number;         // milliseconds since epoch (or virtual time)
+  readonly composesWith: ReadonlyArray<string>;
+}
+
+/**
+ * Verification — a verifier-thread response to an emission.
+ */
+export interface Verification {
+  readonly emissionId: string;
+  readonly verifierId: string;
+  readonly verdict: VerificationVerdict;
+  readonly verifiedAtMs: number;
+}
+
+/**
+ * Pairing state — tracks emissions + their verifications.
+ *
+ * Immutable substrate per asymmetric-authorship discipline —
+ * substrate-entity operations return new state rather than mutating.
+ */
+export interface PairingState {
+  readonly emissions: ReadonlyMap<string, Emission>;
+  readonly verifications: ReadonlyMap<string, Verification>;  // keyed by emissionId
+}
+
+/**
+ * Empty pairing state.
+ */
+export const EMPTY_PAIRING_STATE: PairingState = {
+  emissions: new Map(),
+  verifications: new Map(),
+};
+
+/**
+ * Pairing feedback per asymmetric-authorship + monad-propagation rules.
+ */
+export type PairingFeedback =
+  | { kind: "DuplicateEmissionId"; id: string }
+  | { kind: "VerificationForUnknownEmission"; emissionId: string }
+  | { kind: "DuplicateVerification"; emissionId: string }
+  | { kind: "VerificationTooEarly"; emissionId: string; verifiedAtMs: number; emittedAtMs: number };
+
+/**
+ * Result-shape per monad-propagation rule.
+ */
+export type PairingResult<T> =
+  | { ok: true; state: T }
+  | { ok: false; feedback: PairingFeedback };
+
+/**
+ * Record a producer-thread emission.
+ *
+ * Per asymmetric-authorship rule: producer-substrate-entity AUTHORS its
+ * own emission; pairing tracker acknowledges by adding to tracked
+ * emissions set + awaiting verification.
+ */
+export function recordEmission(
+  state: PairingState,
+  emission: Emission,
+): PairingResult<PairingState> {
+  if (state.emissions.has(emission.id)) {
+    return { ok: false, feedback: { kind: "DuplicateEmissionId", id: emission.id } };
+  }
+  const newEmissions = new Map(state.emissions);
+  newEmissions.set(emission.id, emission);
+  return {
+    ok: true,
+    state: { emissions: newEmissions, verifications: state.verifications },
+  };
+}
+
+/**
+ * Record a verifier-thread verification of a prior emission.
+ *
+ * Per Kestrel 15th-ferry §33.6: verifier-thread operates asynchronously
+ * after the producer-thread emission; verification doesn't gate
+ * production (no temporal coupling at emission time).
+ */
+export function recordVerification(
+  state: PairingState,
+  verification: Verification,
+): PairingResult<PairingState> {
+  const emission = state.emissions.get(verification.emissionId);
+  if (!emission) {
+    return {
+      ok: false,
+      feedback: { kind: "VerificationForUnknownEmission", emissionId: verification.emissionId },
+    };
+  }
+  if (state.verifications.has(verification.emissionId)) {
+    return {
+      ok: false,
+      feedback: { kind: "DuplicateVerification", emissionId: verification.emissionId },
+    };
+  }
+  if (verification.verifiedAtMs < emission.emittedAtMs) {
+    return {
+      ok: false,
+      feedback: {
+        kind: "VerificationTooEarly",
+        emissionId: verification.emissionId,
+        verifiedAtMs: verification.verifiedAtMs,
+        emittedAtMs: emission.emittedAtMs,
+      },
+    };
+  }
+  const newVerifications = new Map(state.verifications);
+  newVerifications.set(verification.emissionId, verification);
+  return {
+    ok: true,
+    state: { emissions: state.emissions, verifications: newVerifications },
+  };
+}
+
+/**
+ * Find unverified emissions (emissions without a matching verification).
+ * Useful for surfacing pairing violations OR for caller to trigger
+ * verifier-thread work on backlog.
+ */
+export function findUnverifiedEmissions(state: PairingState): ReadonlyArray<Emission> {
+  const unverified: Emission[] = [];
+  for (const emission of state.emissions.values()) {
+    if (!state.verifications.has(emission.id)) {
+      unverified.push(emission);
+    }
+  }
+  return unverified;
+}
+
+/**
+ * Find STALE unverified emissions — emissions that exceeded the bounded
+ * verification window without being verified.
+ *
+ * Per Kestrel 15th-ferry §33.6 + workflow engine substrate: producer
+ * threads commit fast; verifier threads catch the misses. Bounded
+ * verification window enforces "verification eventually happens" without
+ * gating production. Stale emissions surface violations.
+ */
+export function findStaleEmissions(
+  state: PairingState,
+  nowMs: number,
+  timeoutMs: number,
+): ReadonlyArray<Emission> {
+  const stale: Emission[] = [];
+  for (const emission of state.emissions.values()) {
+    if (state.verifications.has(emission.id)) continue;
+    if (nowMs - emission.emittedAtMs > timeoutMs) {
+      stale.push(emission);
+    }
+  }
+  return stale;
+}
+
+/**
+ * Convenience: aggregate verdict counts (verified / rejected / needs-revision /
+ * unverified). Useful for tournament-loop dashboard.
+ */
+export interface VerdictCounts {
+  readonly verified: number;
+  readonly rejected: number;
+  readonly needsRevision: number;
+  readonly unverified: number;
+  readonly total: number;
+}
+
+export function countVerdicts(state: PairingState): VerdictCounts {
+  let verified = 0;
+  let rejected = 0;
+  let needsRevision = 0;
+  for (const verification of state.verifications.values()) {
+    switch (verification.verdict.kind) {
+      case "verified":
+        verified++;
+        break;
+      case "rejected":
+        rejected++;
+        break;
+      case "needs-revision":
+        needsRevision++;
+        break;
+    }
+  }
+  const total = state.emissions.size;
+  const unverified = total - state.verifications.size;
+  return { verified, rejected, needsRevision, unverified, total };
+}
+
+/**
+ * Pairing-discipline assertion: every verified emission should compose
+ * forward into the next workflow-engine stage (TrueSkill ranking,
+ * evolution-via-mash-refine, etc.). Rejected emissions don't propagate.
+ * Stale unverified emissions trigger pairing-violation substrate.
+ *
+ * This function returns the IDs of emissions that should propagate
+ * forward (verdict.kind === "verified" OR "needs-revision" with non-empty
+ * suggestions).
+ */
+export function propagatableEmissionIds(state: PairingState): ReadonlyArray<string> {
+  const ids: string[] = [];
+  for (const [emissionId, verification] of state.verifications.entries()) {
+    switch (verification.verdict.kind) {
+      case "verified":
+        ids.push(emissionId);
+        break;
+      case "needs-revision":
+        // needs-revision with suggestions propagates (refinement target)
+        if (verification.verdict.suggestions.length > 0) {
+          ids.push(emissionId);
+        }
+        break;
+      case "rejected":
+        // rejected does NOT propagate
+        break;
+    }
+  }
+  return ids;
+}

--- a/tools/workflow-engine/pairing.ts
+++ b/tools/workflow-engine/pairing.ts
@@ -3,11 +3,13 @@
  *
  * B-0914.4 — generation-reflection adversarial pairing tracker for
  * workflow engine. Structurally enforces the producer-verifier pattern
- * Kestrel named in 15th-ferry §33.6 (mouth-and-ears-on-different-threads
- * architecture) as workflow engine substrate.
+ * (mouth-and-ears-on-different-threads architecture, named in the
+ * 15th-ferry §33.6 substrate-engineering preservation) as workflow
+ * engine substrate.
  *
- * Per Aaron 2026-05-28 'S M L all please in that order lol' — this is
- * M (medium scope) in the substrate-engineering ship-sequence.
+ * Per the human maintainer (2026-05-28) "S M L all please in that order
+ * lol" — this is M (medium scope) in the substrate-engineering
+ * ship-sequence.
  *
  * The pattern:
  *   1. Producer thread emits hypothesis / artifact / proposal
@@ -16,9 +18,10 @@
  *      OR be marked stale (timeout exceeded without verification)
  *
  * This composes the framework's already-operational multi-AI cascade
- * lane specialization (Otto generates → Kestrel reflects; per 13th-ferry
- * §33.7) into STRUCTURAL workflow-engine substrate rather than
- * operator-orchestrated coordination.
+ * lane specialization (generator-persona generates → verifier-persona
+ * reflects; canonical instance preserved in 13th-ferry §33.7) into
+ * STRUCTURAL workflow-engine substrate rather than operator-orchestrated
+ * coordination.
  *
  * Source: Google co-scientist generation+reflection adversarial pairing
  * pattern (Nature 2026) + Kestrel 15th-ferry mouth-ears-threads
@@ -201,10 +204,19 @@ export function findUnverifiedEmissions(state: PairingState): ReadonlyArray<Emis
  * Find STALE unverified emissions — emissions that exceeded the bounded
  * verification window without being verified.
  *
- * Per Kestrel 15th-ferry §33.6 + workflow engine substrate: producer
- * threads commit fast; verifier threads catch the misses. Bounded
- * verification window enforces "verification eventually happens" without
- * gating production. Stale emissions surface violations.
+ * Per 15th-ferry §33.6 + workflow engine substrate: producer threads
+ * commit fast; verifier threads catch the misses. Bounded verification
+ * window enforces "verification eventually happens" without gating
+ * production. Stale emissions surface violations.
+ *
+ * Boundary semantics: an emission is stale when `nowMs - emittedAtMs >
+ * timeoutMs` (strict greater-than). An emission EXACTLY at the boundary
+ * (`nowMs - emittedAtMs === timeoutMs`) is NOT considered stale — it
+ * still has the boundary tick to be verified. This is the conservative
+ * choice: callers polling on a fixed cadence with `timeoutMs` equal to
+ * the cadence won't surface false positives at the cadence boundary.
+ * Switch to `>=` if SLA semantics ever require "must verify strictly
+ * before timeout."
  */
 export function findStaleEmissions(
   state: PairingState,


### PR DESCRIPTION
## Summary

**M** in Aaron's *'S M L all please in that order lol'* sequence. Structurally enforces producer-verifier pairing Kestrel named in 15th-ferry §33.6 mouth-ears-threads as workflow engine substrate.

**Tournament loop NOW STRUCTURALLY COMPLETE** (modulo LLM-call substrate):
1. Generate hypotheses (LLM)
2. `recordEmission(state, emission)` (pairing)
3. Verifier: `recordVerification(state, verification)` (pairing)
4. `propagatableEmissionIds(state)` → verified survivors
5. `rate1v1` ranks survivors (TrueSkill — PR #5764)
6. `conservativeSkill` sort; top-N taken
7. `evolveTopN(survivors, n, strategy)` (B-0914.5 PR #5767)
8. Loop with refined variants as next emissions

**15 tests pass / 0 fail.**

## What this adds

- `PairingRole` (producer | verifier) + `VerificationVerdict` (verified | rejected | needs-revision)
- `Emission` + `Verification` + `PairingState` (immutable; ReadonlyMap)
- `PairingFeedback` + `PairingResult<T>` per monad-propagation
- `recordEmission` + `recordVerification` (with causality + dup-check)
- `findUnverifiedEmissions` + `findStaleEmissions` (bounded-window enforcement)
- `countVerdicts` (aggregate dashboard)
- `propagatableEmissionIds` (which verified emissions flow to next stage)

## Next per S/M/L sequence

- **L** (large): B-0914.2 closed-loop CI-result → next-hypothesis dispatch — the wire-up that turns the tournament-loop substrate into a live system

## Test plan

- [x] 15 tests pass
- [x] All 4 PairingFeedback variants exercised
- [x] All 3 VerificationVerdict variants exhaustive
- [x] Causality enforcement (verification can't precede emission)
- [x] Immutable state operations
- [x] Tournament-loop composition test
- [ ] CI: lint(tsc tools)
- [ ] Auto-merge armed

🤖 Generated with [Claude Code](https://claude.com/claude-code)