### PR TITLE
fix(workflow-engine): tsc lint errors — unused vars + type-narrowing (autonomous-loop unblocks #5774-#5778)

### DIFF
--- a/tools/workflow-engine/closed-loop.test.ts
+++ b/tools/workflow-engine/closed-loop.test.ts
@@ -12,6 +12,7 @@ import {
   type CiVerdict,
   type Hypothesis,
   type LoopCallbacks,
+  type LoopFeedback,
 } from "./closed-loop";
 
 interface SubstrateT extends Record<string, unknown> {
@@ -235,7 +236,7 @@ describe("B-0914.2 closed-loop orchestrator", () => {
   });
 
   it("LoopFeedback exhaustive switch (compile-time check)", () => {
-    type Feedback = NonNullable<Awaited<ReturnType<typeof runCycle<SubstrateT>>>> extends { ok: false; feedback: infer F } ? F : never;
+    type Feedback = LoopFeedback;
     const assertNever = (x: never): never => { throw new Error(`unhandled LoopFeedback: ${JSON.stringify(x)}`); };
     const acknowledge = (f: Feedback): string => {
       switch (f.kind) {

--- a/tools/workflow-engine/composed-lifetime.test.ts
+++ b/tools/workflow-engine/composed-lifetime.test.ts
@@ -221,7 +221,8 @@ describe("composed-lifetime double-dispatch substrate", () => {
   it("type-level: ComposedKey is template literal type of A['kind'] : B['kind']", () => {
     const _check1: ComposedKey<WorkflowLifetime, ReviewLifetime> = "draft:pending";
     const _check2: ComposedKey<WorkflowLifetime, ReviewLifetime> = "approved:merged";
-    // Compile-only check; no runtime expectation
-    expect(true).toBe(true);
+    // Compile-only check; reference the bindings to satisfy noUnusedLocals
+    expect(_check1).toBe("draft:pending");
+    expect(_check2).toBe("approved:merged");
   });
 });

--- a/tools/workflow-engine/consensus.test.ts
+++ b/tools/workflow-engine/consensus.test.ts
@@ -208,10 +208,10 @@ describe("B-0914.3 n-parallel + consensus substrate", () => {
     const b: Hypothesis = { mechanism: "ER-stress", evidence: 0.9 };
     const c: Hypothesis = { mechanism: "kinase", evidence: 0.7 };
     // Group by mechanism only (ignore evidence)
-    const result = await runConsensus({
+    const result = await runConsensus<Hypothesis>({
       analyzers: [constantAnalyzer(a), constantAnalyzer(b), constantAnalyzer(c)],
       mechanism: { kind: "majority" },
-      verdictKey: (h) => h.mechanism,
+      verdictKey: (h: Hypothesis) => h.mechanism,
     });
     expect(result.ok).toBe(true);
     if (!result.ok) return;

--- a/tools/workflow-engine/consensus.ts
+++ b/tools/workflow-engine/consensus.ts
@@ -58,8 +58,11 @@ export type ConsensusResult<T> =
 
 /**
  * Agreement metrics — captures the consensus distribution for
- * substrate-honest dashboards.
+ * substrate-honest dashboards. Type parameter `T` is reserved for
+ * future extensions that surface verdict-typed substrate (e.g., topVerdict
+ * field) without breaking the public-API shape.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface AgreementMetrics<T> {
   readonly totalAnalyzers: number;
   readonly successfulAnalyzers: number;
@@ -67,6 +70,7 @@ export interface AgreementMetrics<T> {
   readonly verdictCounts: ReadonlyMap<string, number>;  // keyed by verdict-id
   readonly winnerCount: number;
   readonly winnerFraction: number;  // winnerCount / successfulAnalyzers
+  readonly _typeHint?: T;  // type-anchor; never set at runtime
 }
 
 /**


### PR DESCRIPTION
Autonomous-loop tick caught BLOCKED gate on in-flight PRs (#5774-#5778). 6 tsc errors across 4 files in workflow-engine/. Fixed; tsc clean; 45 tests pass.

## Fixes
- `composed-lifetime.test.ts` (TS6133 ×2): added expect() on type-check bindings
- `consensus.test.ts` (TS18046 ×2): explicit <Hypothesis> type-param + typed callback
- `consensus.ts` (TS6133 ×1): AgreementMetrics<T> _typeHint type-anchor field
- `closed-loop.test.ts` (TS2339/TS2345 ×5): direct LoopFeedback import (Awaited<ReturnType<>> evaluated to never)

## Verification
```
bunx tsc --noEmit -p tsconfig.json  # clean
bun test (3 affected files)         # 45 pass / 0 fail
```

B-0913 dup-ID lint failure is SEPARATE (pre-existing on origin/main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)