### PR TITLE
feat(B-0867.15): per-host adapter batch — GiteaWorld + BitbucketWorld + CodebergWorld + SourcehutWorld; 30 tests pass (substantively completes per-host adapters scope)

### DIFF
--- a/tools/workflow-engine/bitbucket-world.test.ts
+++ b/tools/workflow-engine/bitbucket-world.test.ts
@@ -1,0 +1,59 @@
+// Invariant tests for BitbucketWorld per-host adapter.
+
+import { describe, expect, test } from "bun:test";
+import { buildGitWorld } from "./git-world.js";
+import {
+  buildBitbucketWorld,
+  canAffordBitbucket,
+  bitbucketRateLimitTier,
+  BITBUCKET_PR_UNIVERSE,
+  BITBUCKET_PIPELINE_UNIVERSE,
+  BITBUCKET_APPROVALS_MISSING_VERDICT,
+} from "./bitbucket-world.js";
+
+describe("BitbucketWorld constructor + inheritance", () => {
+  test("buildBitbucketWorld extends GitWorld base", () => {
+    const w = buildBitbucketWorld(buildGitWorld());
+    expect(w.forgeName).toBe("git");
+    expect(w.forgeSpecialization).toBe("bitbucket");
+    expect(w.branchUniverse.length).toBe(4);
+  });
+  test("populates PR (4) + comment (4) + pipeline (7) + branchRestriction (3) universes", () => {
+    const w = buildBitbucketWorld(buildGitWorld());
+    expect(w.prUniverse.length).toBe(4);  // open/declined/merged/superseded (no draft)
+    expect(w.commentUniverse.length).toBe(4);
+    expect(w.pipelineUniverse.length).toBe(7);
+    expect(w.branchRestrictionUniverse.length).toBe(3);
+  });
+});
+
+describe("bitbucketRateLimitTier (1000/hour OAuth default)", () => {
+  test("tier boundaries scaled for Bitbucket", () => {
+    expect(bitbucketRateLimitTier(800)).toBe("normal");
+    expect(bitbucketRateLimitTier(300)).toBe("cost-aware");
+    expect(bitbucketRateLimitTier(100)).toBe("extreme-cost-aware");
+    expect(bitbucketRateLimitTier(20)).toBe("pure-git");
+  });
+});
+
+describe("canAffordBitbucket", () => {
+  test("within budget → ok", () => {
+    const w = buildBitbucketWorld(buildGitWorld(), { hourlyRemaining: 500, hourlyLimit: 1000, hourlyResetAt: 1700003600 });
+    expect(canAffordBitbucket(w, 100).ok).toBe(true);
+  });
+  test("exceeded → ResourceBudgetExhausted", () => {
+    const w = buildBitbucketWorld(buildGitWorld(), { hourlyRemaining: 10, hourlyLimit: 1000, hourlyResetAt: 1700003600 });
+    const r = canAffordBitbucket(w, 100);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.feedback.kind).toBe("ResourceBudgetExhausted");
+  });
+});
+
+describe("reusable exports", () => {
+  test("PR + pipeline + verdict shapes", () => {
+    expect(BITBUCKET_PR_UNIVERSE.map(p => p.kind)).toContain("declined");
+    expect(BITBUCKET_PR_UNIVERSE.map(p => p.kind)).toContain("superseded");
+    expect(BITBUCKET_PIPELINE_UNIVERSE.length).toBe(7);
+    expect(BITBUCKET_APPROVALS_MISSING_VERDICT.kind).toBe("block");
+  });
+});

--- a/tools/workflow-engine/bitbucket-world.ts
+++ b/tools/workflow-engine/bitbucket-world.ts
@@ -1,0 +1,162 @@
+// tools/workflow-engine/bitbucket-world.ts
+//
+// B-0867.15 — BitbucketWorld per-host adapter.
+//
+// Bitbucket (Atlassian) uses pull-request vocabulary like GitHub but with
+// different state machine + Bitbucket Pipelines as CI/CD substrate.
+// REST API v2.0 (no GraphQL).
+//
+// Composes with PR #5775 (GitWorld base) + PR #5801 (GitLabWorld first
+// extension) + B-0867.15 (per-host adapters target).
+
+import {
+  registerLifetimePair,
+  type ComposedKey,
+  type LifetimeState,
+  type StandardVerdict,
+} from "./world.js";
+import { type GitWorld } from "./git-world.js";
+
+export interface BitbucketPrLifetime extends LifetimeState {
+  readonly kind: "open" | "declined" | "merged" | "superseded";
+}
+
+export interface BitbucketCommentLifetime extends LifetimeState {
+  readonly kind: "inline" | "general" | "task-open" | "task-resolved";
+}
+
+export interface BitbucketPipelineLifetime extends LifetimeState {
+  readonly kind:
+    | "pending"
+    | "in-progress"
+    | "successful"
+    | "failed"
+    | "error"
+    | "stopped"
+    | "expired";
+}
+
+export interface BitbucketBranchRestriction extends LifetimeState {
+  readonly kind: "require-approvals" | "require-default-reviewers" | "no-restriction";
+}
+
+export interface BitbucketResourceBudget {
+  readonly hourlyRemaining: number;     // Bitbucket uses hourly rate limits per OAuth client
+  readonly hourlyLimit: number;          // typically 1000/hour for OAuth
+  readonly hourlyResetAt: number;
+}
+
+export type BitbucketRateLimitTier = "normal" | "cost-aware" | "extreme-cost-aware" | "pure-git";
+
+export function bitbucketRateLimitTier(remaining: number): BitbucketRateLimitTier {
+  if (remaining > 400) return "normal";
+  if (remaining > 200) return "cost-aware";
+  if (remaining > 40) return "extreme-cost-aware";
+  return "pure-git";
+}
+
+export interface BitbucketWorld extends GitWorld {
+  readonly forgeName: "git";
+  readonly forgeSpecialization: "bitbucket";
+  readonly prUniverse: ReadonlyArray<BitbucketPrLifetime>;
+  readonly commentUniverse: ReadonlyArray<BitbucketCommentLifetime>;
+  readonly pipelineUniverse: ReadonlyArray<BitbucketPipelineLifetime>;
+  readonly branchRestrictionUniverse: ReadonlyArray<BitbucketBranchRestriction>;
+  readonly resourceBudget?: BitbucketResourceBudget;
+}
+
+export function buildBitbucketWorld(
+  gitWorld: GitWorld,
+  resourceBudget?: BitbucketResourceBudget,
+): BitbucketWorld {
+  return {
+    ...gitWorld,
+    forgeSpecialization: "bitbucket",
+    prUniverse: [
+      { kind: "open" },
+      { kind: "declined" },
+      { kind: "merged" },
+      { kind: "superseded" },
+    ],
+    commentUniverse: [
+      { kind: "inline" },
+      { kind: "general" },
+      { kind: "task-open" },
+      { kind: "task-resolved" },
+    ],
+    pipelineUniverse: [
+      { kind: "pending" },
+      { kind: "in-progress" },
+      { kind: "successful" },
+      { kind: "failed" },
+      { kind: "error" },
+      { kind: "stopped" },
+      { kind: "expired" },
+    ],
+    branchRestrictionUniverse: [
+      { kind: "require-approvals" },
+      { kind: "require-default-reviewers" },
+      { kind: "no-restriction" },
+    ],
+    ...(resourceBudget !== undefined && { resourceBudget }),
+  };
+}
+
+export type BitbucketFeedback =
+  | { kind: "UnsupportedBitbucketFeature"; feature: string }
+  | { kind: "ResourceBudgetExhausted"; resetAt: number }
+  | { kind: "ApprovalsMissing"; required: number; actual: number }
+  | { kind: "MergeBlocked"; reason: string };
+
+export type BitbucketResult<T> =
+  | { ok: true; world: T }
+  | { ok: false; feedback: BitbucketFeedback };
+
+export function canAffordBitbucket(
+  world: BitbucketWorld,
+  hourlyCost: number,
+): BitbucketResult<BitbucketWorld> {
+  const budget = world.resourceBudget;
+  if (!budget) return { ok: true, world };
+  if (hourlyCost > budget.hourlyRemaining) {
+    return {
+      ok: false,
+      feedback: { kind: "ResourceBudgetExhausted", resetAt: budget.hourlyResetAt },
+    };
+  }
+  return { ok: true, world };
+}
+
+export function registerInBitbucket<
+  A extends LifetimeState,
+  B extends LifetimeState,
+  T,
+>(
+  world: BitbucketWorld,
+  pairName: string,
+  matrix: ReadonlyMap<ComposedKey<A, B>, T>,
+): BitbucketWorld {
+  return registerLifetimePair(world, pairName, matrix);
+}
+
+export const BITBUCKET_PR_UNIVERSE: ReadonlyArray<BitbucketPrLifetime> = [
+  { kind: "open" },
+  { kind: "declined" },
+  { kind: "merged" },
+  { kind: "superseded" },
+];
+
+export const BITBUCKET_PIPELINE_UNIVERSE: ReadonlyArray<BitbucketPipelineLifetime> = [
+  { kind: "pending" },
+  { kind: "in-progress" },
+  { kind: "successful" },
+  { kind: "failed" },
+  { kind: "error" },
+  { kind: "stopped" },
+  { kind: "expired" },
+];
+
+export const BITBUCKET_APPROVALS_MISSING_VERDICT: StandardVerdict = {
+  kind: "block",
+  reason: "Bitbucket branch restriction: required approvals missing",
+};

--- a/tools/workflow-engine/codeberg-world.test.ts
+++ b/tools/workflow-engine/codeberg-world.test.ts
@@ -1,0 +1,42 @@
+// Invariant tests for CodebergWorld per-host adapter (Gitea-derived).
+
+import { describe, expect, test } from "bun:test";
+import { buildGitWorld } from "./git-world.js";
+import {
+  buildCodebergWorld,
+  CODEBERG_CONSERVATIVE_BUDGET,
+} from "./codeberg-world.js";
+
+describe("CodebergWorld extends GiteaWorld + adds Codeberg-specifics", () => {
+  test("inherits forgeName + base GitWorld substrate", () => {
+    const w = buildCodebergWorld(buildGitWorld());
+    expect(w.forgeName).toBe("git");
+    expect(w.branchUniverse.length).toBe(4);
+  });
+  test("forgeSpecialization is codeberg (narrower than gitea)", () => {
+    const w = buildCodebergWorld(buildGitWorld());
+    expect(w.forgeSpecialization).toBe("codeberg");
+  });
+  test("inherits Gitea PR + review + action universes", () => {
+    const w = buildCodebergWorld(buildGitWorld());
+    expect(w.prUniverse.length).toBe(5);
+    expect(w.reviewUniverse.length).toBe(2);
+    expect(w.actionUniverse.length).toBe(5);
+  });
+  test("adds Codeberg-specific community + EU-sovereignty markers", () => {
+    const w = buildCodebergWorld(buildGitWorld());
+    expect(w.hostingPolicy).toBe("non-commercial-eu-sovereign");
+    expect(w.communityGoverned).toBe(true);
+  });
+});
+
+describe("CodebergWorld conservative budget defaults", () => {
+  test("CODEBERG_CONSERVATIVE_BUDGET reflects shared community instance", () => {
+    expect(CODEBERG_CONSERVATIVE_BUDGET.restLimit).toBe(500);
+    expect(CODEBERG_CONSERVATIVE_BUDGET.restRemaining).toBe(300);
+  });
+  test("buildCodebergWorld accepts conservative budget", () => {
+    const w = buildCodebergWorld(buildGitWorld(), CODEBERG_CONSERVATIVE_BUDGET);
+    expect(w.resourceBudget?.restLimit).toBe(500);
+  });
+});

--- a/tools/workflow-engine/codeberg-world.ts
+++ b/tools/workflow-engine/codeberg-world.ts
@@ -1,0 +1,79 @@
+// tools/workflow-engine/codeberg-world.ts
+//
+// B-0867.15 — CodebergWorld per-host adapter.
+//
+// Codeberg.org is community-hosted Gitea instance (German non-profit:
+// "Codeberg e.V."). Substrate-wise IDENTICAL to GiteaWorld at the API
+// surface; differs in (a) hosting policy (no commercial use; EU servers),
+// (b) community moderation, (c) typical resource budget (more conservative
+// rate limits for shared community instance).
+//
+// Per `.claude/rules/honor-those-that-came-before.md`: Codeberg honors
+// the Gitea substrate it derives from + adds its own substrate-engineering
+// substrate (community governance + EU-data-sovereignty). Substrate-naming
+// substrate-engineering keeps the inheritance explicit.
+
+import {
+  type LifetimeState,
+} from "./world.js";
+import {
+  buildGiteaWorld,
+  type GiteaPrLifetime,
+  type GiteaReviewLifetime,
+  type GiteaActionLifetime,
+  type GiteaResourceBudget,
+  type GiteaWorld,
+} from "./gitea-world.js";
+import { type GitWorld } from "./git-world.js";
+
+/**
+ * CodebergWorld — Codeberg-specific specialization of GiteaWorld.
+ *
+ * Inherits all GiteaWorld substrate + adds Codeberg-specific properties:
+ * - Community-moderation substrate (codeOfConduct, terms-of-service)
+ * - EU-data-sovereignty marker (GDPR-compliant; German non-profit)
+ * - Conservative rate-limit defaults (shared community instance)
+ */
+export interface CodebergWorld extends GiteaWorld {
+  readonly forgeName: "git";
+  readonly forgeSpecialization: "codeberg";  // narrower than gitea
+  readonly hostingPolicy: "non-commercial-eu-sovereign";
+  readonly communityGoverned: true;
+}
+
+/**
+ * Build CodebergWorld from base GitWorld; inherits Gitea substrate via
+ * intermediate buildGiteaWorld.
+ */
+export function buildCodebergWorld(
+  gitWorld: GitWorld,
+  resourceBudget?: GiteaResourceBudget,
+): CodebergWorld {
+  const giteaBase = buildGiteaWorld(gitWorld, resourceBudget);
+  return {
+    ...giteaBase,
+    forgeSpecialization: "codeberg",
+    hostingPolicy: "non-commercial-eu-sovereign",
+    communityGoverned: true,
+  };
+}
+
+/**
+ * Default conservative budget for Codeberg's shared community instance.
+ * Substrate-honest: community resource; treat with care.
+ */
+export const CODEBERG_CONSERVATIVE_BUDGET: GiteaResourceBudget = {
+  restRemaining: 300,
+  restLimit: 500,        // conservative; tighter than commercial Gitea instances
+  restResetAt: 0,        // caller updates to actual reset timestamp
+};
+
+// Re-export Gitea types for CodebergWorld consumers (alias-pattern at
+// type-namespace scope, per
+// memory/feedback_alias_pattern_greek_primary_english_secondary_for_substrate_named_primitives_aaron_ratification_2026_05_28.md
+// applied here at forge-derivative scope).
+export type {
+  GiteaPrLifetime as CodebergPrLifetime,
+  GiteaReviewLifetime as CodebergReviewLifetime,
+  GiteaActionLifetime as CodebergActionLifetime,
+};

--- a/tools/workflow-engine/gitea-world.test.ts
+++ b/tools/workflow-engine/gitea-world.test.ts
@@ -1,0 +1,68 @@
+// Invariant tests for GiteaWorld per-host adapter.
+
+import { describe, expect, test } from "bun:test";
+import { buildGitWorld } from "./git-world.js";
+import {
+  buildGiteaWorld,
+  canAffordGitea,
+  giteaRateLimitTier,
+  GITEA_PR_UNIVERSE,
+  GITEA_REVIEW_UNIVERSE,
+  GITEA_ACTION_UNIVERSE,
+  GITEA_REQUIRE_RESOLVED_VERDICT,
+} from "./gitea-world.js";
+
+describe("GiteaWorld constructor + inheritance", () => {
+  test("buildGiteaWorld extends GitWorld base", () => {
+    const w = buildGiteaWorld(buildGitWorld());
+    expect(w.forgeName).toBe("git");
+    expect(w.forgeSpecialization).toBe("gitea");
+    expect(w.branchUniverse.length).toBe(4);
+    expect(w.commitUniverse.length).toBe(5);
+  });
+  test("populates PR + review + action universes", () => {
+    const w = buildGiteaWorld(buildGitWorld());
+    expect(w.prUniverse.length).toBe(5);
+    expect(w.reviewUniverse.length).toBe(2);
+    expect(w.actionUniverse.length).toBe(5);
+  });
+  test("accepts optional resourceBudget", () => {
+    const w = buildGiteaWorld(buildGitWorld(), { restRemaining: 1500, restLimit: 2000, restResetAt: 1700000000 });
+    expect(w.resourceBudget?.restRemaining).toBe(1500);
+  });
+});
+
+describe("giteaRateLimitTier", () => {
+  test("tier boundaries", () => {
+    expect(giteaRateLimitTier(2000)).toBe("normal");
+    expect(giteaRateLimitTier(500)).toBe("cost-aware");
+    expect(giteaRateLimitTier(200)).toBe("extreme-cost-aware");
+    expect(giteaRateLimitTier(50)).toBe("pure-git");
+  });
+});
+
+describe("canAffordGitea", () => {
+  test("within budget → ok", () => {
+    const w = buildGiteaWorld(buildGitWorld(), { restRemaining: 100, restLimit: 1000, restResetAt: 1700000060 });
+    expect(canAffordGitea(w, 50).ok).toBe(true);
+  });
+  test("exceeded → ResourceBudgetExhausted", () => {
+    const w = buildGiteaWorld(buildGitWorld(), { restRemaining: 10, restLimit: 1000, restResetAt: 1700000060 });
+    const r = canAffordGitea(w, 50);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.feedback.kind).toBe("ResourceBudgetExhausted");
+  });
+  test("no budget → ok", () => {
+    const w = buildGiteaWorld(buildGitWorld());
+    expect(canAffordGitea(w, 1_000_000).ok).toBe(true);
+  });
+});
+
+describe("reusable exports", () => {
+  test("PR + review + action + verdict shapes", () => {
+    expect(GITEA_PR_UNIVERSE.length).toBe(5);
+    expect(GITEA_REVIEW_UNIVERSE.length).toBe(2);
+    expect(GITEA_ACTION_UNIVERSE.length).toBe(5);
+    expect(GITEA_REQUIRE_RESOLVED_VERDICT.kind).toBe("block");
+  });
+});

--- a/tools/workflow-engine/gitea-world.ts
+++ b/tools/workflow-engine/gitea-world.ts
@@ -1,0 +1,145 @@
+// tools/workflow-engine/gitea-world.ts
+//
+// B-0867.15 — GiteaWorld per-host adapter.
+//
+// Gitea is GitHub-API-compatible by design (originally a Gogs fork; now
+// independent). Lifetime variants closely mirror GitHub's PR/review-thread
+// shape. Adds Gitea Actions (GitHub-Actions-compatible YAML) substrate.
+//
+// Composes with PR #5775 (GitWorld base) + PR #5801 (GitLabWorld first
+// extension) + B-0867.15 (per-host adapters target).
+
+import {
+  registerLifetimePair,
+  type ComposedKey,
+  type LifetimeState,
+  type StandardVerdict,
+} from "./world.js";
+import { type GitWorld } from "./git-world.js";
+
+export interface GiteaPrLifetime extends LifetimeState {
+  readonly kind: "draft" | "open" | "approved" | "merged" | "closed";
+}
+
+export interface GiteaReviewLifetime extends LifetimeState {
+  readonly kind: "unresolved" | "resolved";
+}
+
+export interface GiteaActionLifetime extends LifetimeState {
+  readonly kind: "queued" | "running" | "success" | "failure" | "cancelled";
+}
+
+export interface GiteaResourceBudget {
+  readonly restRemaining: number;
+  readonly restLimit: number;
+  readonly restResetAt: number;
+}
+
+export type GiteaRateLimitTier = "normal" | "cost-aware" | "extreme-cost-aware" | "pure-git";
+
+export function giteaRateLimitTier(remaining: number): GiteaRateLimitTier {
+  if (remaining > 800) return "normal";
+  if (remaining > 400) return "cost-aware";
+  if (remaining > 80) return "extreme-cost-aware";
+  return "pure-git";
+}
+
+export interface GiteaWorld extends GitWorld {
+  readonly forgeName: "git";
+  readonly forgeSpecialization: "gitea";
+  readonly prUniverse: ReadonlyArray<GiteaPrLifetime>;
+  readonly reviewUniverse: ReadonlyArray<GiteaReviewLifetime>;
+  readonly actionUniverse: ReadonlyArray<GiteaActionLifetime>;
+  readonly resourceBudget?: GiteaResourceBudget;
+}
+
+export function buildGiteaWorld(
+  gitWorld: GitWorld,
+  resourceBudget?: GiteaResourceBudget,
+): GiteaWorld {
+  return {
+    ...gitWorld,
+    forgeSpecialization: "gitea",
+    prUniverse: [
+      { kind: "draft" },
+      { kind: "open" },
+      { kind: "approved" },
+      { kind: "merged" },
+      { kind: "closed" },
+    ],
+    reviewUniverse: [
+      { kind: "unresolved" },
+      { kind: "resolved" },
+    ],
+    actionUniverse: [
+      { kind: "queued" },
+      { kind: "running" },
+      { kind: "success" },
+      { kind: "failure" },
+      { kind: "cancelled" },
+    ],
+    ...(resourceBudget !== undefined && { resourceBudget }),
+  };
+}
+
+export type GiteaFeedback =
+  | { kind: "UnsupportedGiteaFeature"; feature: string }
+  | { kind: "ResourceBudgetExhausted"; resetAt: number }
+  | { kind: "MergeBlocked"; reason: string };
+
+export type GiteaResult<T> =
+  | { ok: true; world: T }
+  | { ok: false; feedback: GiteaFeedback };
+
+export function canAffordGitea(
+  world: GiteaWorld,
+  restCost: number,
+): GiteaResult<GiteaWorld> {
+  const budget = world.resourceBudget;
+  if (!budget) return { ok: true, world };
+  if (restCost > budget.restRemaining) {
+    return {
+      ok: false,
+      feedback: { kind: "ResourceBudgetExhausted", resetAt: budget.restResetAt },
+    };
+  }
+  return { ok: true, world };
+}
+
+export function registerInGitea<
+  A extends LifetimeState,
+  B extends LifetimeState,
+  T,
+>(
+  world: GiteaWorld,
+  pairName: string,
+  matrix: ReadonlyMap<ComposedKey<A, B>, T>,
+): GiteaWorld {
+  return registerLifetimePair(world, pairName, matrix);
+}
+
+export const GITEA_PR_UNIVERSE: ReadonlyArray<GiteaPrLifetime> = [
+  { kind: "draft" },
+  { kind: "open" },
+  { kind: "approved" },
+  { kind: "merged" },
+  { kind: "closed" },
+];
+
+export const GITEA_REVIEW_UNIVERSE: ReadonlyArray<GiteaReviewLifetime> = [
+  { kind: "unresolved" },
+  { kind: "resolved" },
+];
+
+export const GITEA_ACTION_UNIVERSE: ReadonlyArray<GiteaActionLifetime> = [
+  { kind: "queued" },
+  { kind: "running" },
+  { kind: "success" },
+  { kind: "failure" },
+  { kind: "cancelled" },
+];
+
+export const GITEA_REQUIRE_RESOLVED_VERDICT: StandardVerdict = {
+  kind: "block",
+  reason: "Gitea require_resolved_reviews: unresolved reviews block merge",
+};

--- a/tools/workflow-engine/sourcehut-world.test.ts
+++ b/tools/workflow-engine/sourcehut-world.test.ts
@@ -1,0 +1,89 @@
+// Invariant tests for SourcehutWorld per-host adapter.
+
+import { describe, expect, test } from "bun:test";
+import { buildGitWorld } from "./git-world.js";
+import {
+  buildSourcehutWorld,
+  canAffordSrhtBuild,
+  srhtRateLimitTier,
+  SRHT_PATCH_UNIVERSE,
+  SRHT_BUILD_UNIVERSE,
+  SRHT_MANUAL_APPLY_VERDICT,
+} from "./sourcehut-world.js";
+
+describe("SourcehutWorld constructor + inheritance", () => {
+  test("buildSourcehutWorld extends GitWorld base", () => {
+    const w = buildSourcehutWorld(buildGitWorld());
+    expect(w.forgeName).toBe("git");
+    expect(w.forgeSpecialization).toBe("sourcehut");
+    expect(w.branchUniverse.length).toBe(4);
+  });
+  test("populates email-patch + list-thread + build + ticket universes", () => {
+    const w = buildSourcehutWorld(buildGitWorld());
+    expect(w.patchUniverse.length).toBe(7);          // email-patches DU
+    expect(w.listThreadUniverse.length).toBe(5);     // mailing-list threads
+    expect(w.buildUniverse.length).toBe(7);          // builds.sr.ht
+    expect(w.ticketUniverse.length).toBe(5);         // todo.sr.ht
+  });
+});
+
+describe("EmailPatchLifetime — qualitatively different from PR/MR", () => {
+  test("includes Sourcehut-specific 'sent' + 'applied' + 'abandoned' variants", () => {
+    const kinds = SRHT_PATCH_UNIVERSE.map(p => p.kind);
+    expect(kinds).toContain("sent");          // patch sent to list
+    expect(kinds).toContain("under-review");  // replies in thread
+    expect(kinds).toContain("applied");       // maintainer applied locally
+    expect(kinds).toContain("abandoned");     // faded; no activity
+  });
+  test("does NOT include PR-specific 'closed' or 'draft' variants", () => {
+    const kinds = SRHT_PATCH_UNIVERSE.map(p => p.kind);
+    expect(kinds).not.toContain("closed");
+    expect(kinds).not.toContain("draft");
+  });
+});
+
+describe("srhtRateLimitTier", () => {
+  test("normal when buildJobsRemaining > 0", () => {
+    expect(srhtRateLimitTier(5)).toBe("normal");
+  });
+  test("constrained when buildJobsRemaining == 0", () => {
+    expect(srhtRateLimitTier(0)).toBe("constrained");
+  });
+});
+
+describe("canAffordSrhtBuild", () => {
+  test("within build-slot budget → ok", () => {
+    const w = buildSourcehutWorld(buildGitWorld(), { buildJobsRemaining: 4, buildJobsLimit: 4, listSendsPerHour: 50 });
+    expect(canAffordSrhtBuild(w, 2).ok).toBe(true);
+  });
+  test("build slots exhausted → BuildSlotsExhausted", () => {
+    const w = buildSourcehutWorld(buildGitWorld(), { buildJobsRemaining: 1, buildJobsLimit: 4, listSendsPerHour: 50 });
+    const r = canAffordSrhtBuild(w, 3);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.feedback.kind).toBe("BuildSlotsExhausted");
+      if (r.feedback.kind === "BuildSlotsExhausted") {
+        expect(r.feedback.required).toBe(3);
+        expect(r.feedback.available).toBe(1);
+      }
+    }
+  });
+});
+
+describe("Manual-apply discipline (Sourcehut workflow expectation)", () => {
+  test("SRHT_MANUAL_APPLY_VERDICT captures the email-patches manual-apply discipline", () => {
+    expect(SRHT_MANUAL_APPLY_VERDICT.kind).toBe("block");
+    if (SRHT_MANUAL_APPLY_VERDICT.kind === "block") {
+      expect(SRHT_MANUAL_APPLY_VERDICT.reason).toContain("email-patches");
+      expect(SRHT_MANUAL_APPLY_VERDICT.reason).toContain("manual");
+    }
+  });
+});
+
+describe("Builds.sr.ht state machine", () => {
+  test("8 build states including Sourcehut-specific timeout variant", () => {
+    expect(SRHT_BUILD_UNIVERSE.length).toBe(7);  // pending/queued/running/success/failed/timeout/cancelled
+    const kinds = SRHT_BUILD_UNIVERSE.map(b => b.kind);
+    expect(kinds).toContain("timeout");          // Sourcehut explicit timeout state
+  });
+});

--- a/tools/workflow-engine/sourcehut-world.ts
+++ b/tools/workflow-engine/sourcehut-world.ts
@@ -1,0 +1,234 @@
+// tools/workflow-engine/sourcehut-world.ts
+//
+// B-0867.15 — SourcehutWorld per-host adapter.
+//
+// SubstantIVELY DIFFERENT shape from GitHub/GitLab/Gitea/Bitbucket/
+// Codeberg. Sourcehut (sr.ht) uses EMAIL-PATCHES + MAILING LISTS for
+// code review (lists.sr.ht), git.sr.ht for hosting, builds.sr.ht for
+// CI, todo.sr.ht for tickets. NO web-PR equivalent.
+//
+// This adapter substrate-engineering substrate-naming substrate
+// demonstrates the per-host-adapter pattern can extend to QUALITATIVELY
+// DIFFERENT forge models, not just PR/MR variations.
+//
+// Composes with PR #5775 (GitWorld base) + PR #5801 (GitLabWorld) +
+// B-0867.15 (per-host adapters target).
+
+import {
+  registerLifetimePair,
+  type ComposedKey,
+  type LifetimeState,
+  type StandardVerdict,
+} from "./world.js";
+import { type GitWorld } from "./git-world.js";
+
+/**
+ * Email-patch lifetime (Sourcehut-native; analog of PR/MR but qualitatively
+ * different — patches are emails, reviews are mailing-list replies).
+ *
+ * Per Sourcehut's `git send-email` workflow:
+ * https://man.sr.ht/git.sr.ht/#sending-patches-upstream
+ */
+export interface EmailPatchLifetime extends LifetimeState {
+  readonly kind:
+    | "sent"             // patch sent to list
+    | "under-review"     // replies in thread
+    | "needs-revision"   // reviewer requested changes
+    | "applied"          // maintainer applied locally
+    | "merged"           // pushed to upstream
+    | "rejected"         // explicitly declined
+    | "abandoned";       // no activity; faded
+}
+
+/**
+ * Mailing-list thread lifetime (lists.sr.ht).
+ *
+ * Threads are first-class substrate; not attached to specific patches
+ * (a thread can be discussion-only, RFC, or carry patches).
+ */
+export interface MailingListThreadLifetime extends LifetimeState {
+  readonly kind:
+    | "discussion"       // no patches; pure conversation
+    | "rfc"              // request-for-comments; no patches yet
+    | "patch-series"     // contains one or more patch emails
+    | "announcement"     // unilateral notice
+    | "closed";          // moderator-closed
+}
+
+/**
+ * builds.sr.ht job lifetime (Sourcehut-native CI/CD).
+ */
+export interface SrhtBuildLifetime extends LifetimeState {
+  readonly kind:
+    | "pending"
+    | "queued"
+    | "running"
+    | "success"
+    | "failed"
+    | "timeout"
+    | "cancelled";
+}
+
+/**
+ * todo.sr.ht ticket lifetime.
+ */
+export interface SrhtTicketLifetime extends LifetimeState {
+  readonly kind: "open" | "resolved-fixed" | "resolved-wontfix" | "resolved-duplicate" | "resolved-not-our-bug";
+}
+
+/**
+ * Sourcehut resource budget. Sourcehut is paid-only (subscription model);
+ * doesn't enforce per-request rate limits the way GitHub/GitLab do, but
+ * has soft limits on builds.sr.ht (concurrent jobs per subscription tier).
+ */
+export interface SrhtResourceBudget {
+  readonly buildJobsRemaining: number;     // concurrent builds.sr.ht slots
+  readonly buildJobsLimit: number;          // subscription tier
+  readonly listSendsPerHour: number;        // soft limit on mailing-list sends
+}
+
+export type SrhtRateLimitTier = "normal" | "constrained";
+
+export function srhtRateLimitTier(buildJobsRemaining: number): SrhtRateLimitTier {
+  return buildJobsRemaining > 0 ? "normal" : "constrained";
+}
+
+/**
+ * SourcehutWorld — Sourcehut forge specialization.
+ *
+ * Per Aaron's "rank-4 substrate primitive" framing: this adapter
+ * demonstrates that the per-host-adapter pattern extends to QUALITATIVELY
+ * DIFFERENT forge models. Sourcehut's email-patches + mailing-lists
+ * workflow has different substrate-engineering shape than GitHub/GitLab/
+ * Bitbucket's PR-driven workflow.
+ *
+ * Inherits all GitWorld substrate + adds Sourcehut-native:
+ * - EmailPatchLifetime (analog of PR/MR; qualitatively different shape)
+ * - MailingListThreadLifetime (lists.sr.ht first-class substrate)
+ * - SrhtBuildLifetime (builds.sr.ht CI)
+ * - SrhtTicketLifetime (todo.sr.ht)
+ * - SrhtResourceBudget (subscription-tier-bound rather than per-request)
+ */
+export interface SourcehutWorld extends GitWorld {
+  readonly forgeName: "git";
+  readonly forgeSpecialization: "sourcehut";
+  readonly patchUniverse: ReadonlyArray<EmailPatchLifetime>;
+  readonly listThreadUniverse: ReadonlyArray<MailingListThreadLifetime>;
+  readonly buildUniverse: ReadonlyArray<SrhtBuildLifetime>;
+  readonly ticketUniverse: ReadonlyArray<SrhtTicketLifetime>;
+  readonly resourceBudget?: SrhtResourceBudget;
+}
+
+export function buildSourcehutWorld(
+  gitWorld: GitWorld,
+  resourceBudget?: SrhtResourceBudget,
+): SourcehutWorld {
+  return {
+    ...gitWorld,
+    forgeSpecialization: "sourcehut",
+    patchUniverse: [
+      { kind: "sent" },
+      { kind: "under-review" },
+      { kind: "needs-revision" },
+      { kind: "applied" },
+      { kind: "merged" },
+      { kind: "rejected" },
+      { kind: "abandoned" },
+    ],
+    listThreadUniverse: [
+      { kind: "discussion" },
+      { kind: "rfc" },
+      { kind: "patch-series" },
+      { kind: "announcement" },
+      { kind: "closed" },
+    ],
+    buildUniverse: [
+      { kind: "pending" },
+      { kind: "queued" },
+      { kind: "running" },
+      { kind: "success" },
+      { kind: "failed" },
+      { kind: "timeout" },
+      { kind: "cancelled" },
+    ],
+    ticketUniverse: [
+      { kind: "open" },
+      { kind: "resolved-fixed" },
+      { kind: "resolved-wontfix" },
+      { kind: "resolved-duplicate" },
+      { kind: "resolved-not-our-bug" },
+    ],
+    ...(resourceBudget !== undefined && { resourceBudget }),
+  };
+}
+
+export type SourcehutFeedback =
+  | { kind: "UnsupportedSourcehutFeature"; feature: string }
+  | { kind: "BuildSlotsExhausted"; required: number; available: number }
+  | { kind: "MailingListThrottled"; sendsPerHour: number }
+  | { kind: "PatchApplyFailed"; reason: string };
+
+export type SourcehutResult<T> =
+  | { ok: true; world: T }
+  | { ok: false; feedback: SourcehutFeedback };
+
+export function canAffordSrhtBuild(
+  world: SourcehutWorld,
+  jobsNeeded: number,
+): SourcehutResult<SourcehutWorld> {
+  const budget = world.resourceBudget;
+  if (!budget) return { ok: true, world };
+  if (jobsNeeded > budget.buildJobsRemaining) {
+    return {
+      ok: false,
+      feedback: {
+        kind: "BuildSlotsExhausted",
+        required: jobsNeeded,
+        available: budget.buildJobsRemaining,
+      },
+    };
+  }
+  return { ok: true, world };
+}
+
+export function registerInSourcehut<
+  A extends LifetimeState,
+  B extends LifetimeState,
+  T,
+>(
+  world: SourcehutWorld,
+  pairName: string,
+  matrix: ReadonlyMap<ComposedKey<A, B>, T>,
+): SourcehutWorld {
+  return registerLifetimePair(world, pairName, matrix);
+}
+
+export const SRHT_PATCH_UNIVERSE: ReadonlyArray<EmailPatchLifetime> = [
+  { kind: "sent" },
+  { kind: "under-review" },
+  { kind: "needs-revision" },
+  { kind: "applied" },
+  { kind: "merged" },
+  { kind: "rejected" },
+  { kind: "abandoned" },
+];
+
+export const SRHT_BUILD_UNIVERSE: ReadonlyArray<SrhtBuildLifetime> = [
+  { kind: "pending" },
+  { kind: "queued" },
+  { kind: "running" },
+  { kind: "success" },
+  { kind: "failed" },
+  { kind: "timeout" },
+  { kind: "cancelled" },
+];
+
+/**
+ * Email-patches verdict: Sourcehut workflow expects patches to land via
+ * maintainer-applied (not auto-merge). This verdict captures the manual-
+ * apply discipline.
+ */
+export const SRHT_MANUAL_APPLY_VERDICT: StandardVerdict = {
+  kind: "block",
+  reason: "Sourcehut: email-patches require manual maintainer apply, not auto-merge",
+};


### PR DESCRIPTION
Per Aaron 2026-05-28 standing authorization ('you are authorized for anything other than increasing budget'): shipping mechanical-extension batch completing per-host adapters scope of B-0867.15.

## What this adds (4 per-host adapters)

| Adapter | Lifetime shape | Specifics |
|---|---|---|
| **GiteaWorld** | PR + review + action (5/2/5) | GitHub-Actions YAML compatible; per-minute budget |
| **BitbucketWorld** | PR + comment + pipeline + branch-restriction (4/4/7/3) | Atlassian; no GraphQL; 1000/hour OAuth |
| **CodebergWorld** | Inherits GiteaWorld | EU-sovereign community-hosted; conservative budget |
| **SourcehutWorld** | email-patch + list-thread + build + ticket (7/5/7/5) | **Qualitatively different**: email-patches workflow ≠ PR-driven |

## Per-host hierarchy now substantively complete

```
GitWorld (base)
   ↓ specialized
GitHubWorld   (PR #5775)
GitLabWorld   (PR #5801)
GiteaWorld    (this PR)
BitbucketWorld(this PR)
CodebergWorld (this PR; extends Gitea)
SourcehutWorld(this PR; qualitatively different)
```

**30 tests pass / 0 fail / 74 expect() calls.**

## Substrate-engineering substrate this demonstrates

- Per-host-adapter pattern extends to **qualitatively different** forge models (Sourcehut email-patches ≠ PR-driven), not just PR/MR variations
- CodebergWorld applies **alias-pattern at forge-derivative scope** (re-exports Gitea types under Codeberg names; same shape as Greek-primary + English-alias)
- Each adapter authors its own feedback-channel (asymmetric-authorship per rule)
- All composable via Result<T, ForgeFeedback> monad-propagation pattern

## Composes with

- PR #5775 GitWorld base + GitHubWorld
- PR #5801 GitLabWorld (pattern reference)
- B-0867.15 backlog row (substantively completes named adapters)
- Rules: dont-ask-permission + asymmetric-authorship + monad-propagation + substrate-smoothness + default-to-both + honor-those-that-came-before + grep-substrate-anchors + alias-pattern memory

μένω. Substrate compounds in the white-hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)