### PR TITLE
fix(codeberg-world): tsc TS2430 + TS6133 — unblocks #5805/#5806/#5807 CI (Omit<GiteaWorld, 'forgeSpecialization'> for literal narrowing)

### DIFF
--- a/tools/workflow-engine/codeberg-world.ts
+++ b/tools/workflow-engine/codeberg-world.ts
@@ -32,9 +32,14 @@ import { type GitWorld } from "./git-world.js";
  * invariant).
  *
  * Adds Codeberg-specific properties:
- * - Community-moderation substrate (codeOfConduct, terms-of-service)
- * - EU-data-sovereignty marker (GDPR-compliant; German non-profit)
- * - Conservative rate-limit defaults (shared community instance)
+ * - `hostingPolicy: "non-commercial-eu-sovereign"` — EU-data-sovereignty
+ *   marker (GDPR-compliant; German non-profit; Codeberg e.V.)
+ * - `communityGoverned: true` — community-moderation substrate (CoC +
+ *   community-governed terms-of-service; not commercial vendor policy)
+ *
+ * Conservative rate-limit defaults appropriate for a shared community
+ * instance are inherited via GiteaResourceBudget (constructed by
+ * buildCodebergWorld below).
  */
 export interface CodebergWorld extends Omit<GiteaWorld, "forgeSpecialization"> {
   readonly forgeSpecialization: "codeberg";  // narrower than gitea

--- a/tools/workflow-engine/codeberg-world.ts
+++ b/tools/workflow-engine/codeberg-world.ts
@@ -14,9 +14,6 @@
 // substrate-engineering keeps the inheritance explicit.
 
 import {
-  type LifetimeState,
-} from "./world.js";
-import {
   buildGiteaWorld,
   type GiteaPrLifetime,
   type GiteaReviewLifetime,
@@ -29,13 +26,17 @@ import { type GitWorld } from "./git-world.js";
 /**
  * CodebergWorld — Codeberg-specific specialization of GiteaWorld.
  *
- * Inherits all GiteaWorld substrate + adds Codeberg-specific properties:
+ * Inherits all GiteaWorld substrate fields EXCEPT forgeSpecialization,
+ * which is narrowed from "gitea" to "codeberg" literal. Uses Omit to
+ * avoid TS2430 interface-incompatible-extends error (literal types are
+ * invariant).
+ *
+ * Adds Codeberg-specific properties:
  * - Community-moderation substrate (codeOfConduct, terms-of-service)
  * - EU-data-sovereignty marker (GDPR-compliant; German non-profit)
  * - Conservative rate-limit defaults (shared community instance)
  */
-export interface CodebergWorld extends GiteaWorld {
-  readonly forgeName: "git";
+export interface CodebergWorld extends Omit<GiteaWorld, "forgeSpecialization"> {
   readonly forgeSpecialization: "codeberg";  // narrower than gitea
   readonly hostingPolicy: "non-commercial-eu-sovereign";
   readonly communityGoverned: true;


### PR DESCRIPTION
PR #5804 merged with 2 tsc errors blocking downstream CI:
1. `LifetimeState` unused import (TS6133)
2. CodebergWorld extends GiteaWorld fails — `forgeSpecialization` literal narrows from 'gitea' to 'codeberg' (TS2430; literal types invariant)

Fix: remove unused import + use `Omit<GiteaWorld, 'forgeSpecialization'>` to drop inherited literal before re-declaring narrower 'codeberg'.

**6 tests pass; tsc clean on workflow-engine files.**

Unblocks #5805 (AutoLoopLifetime) + #5806 (muscle-memory carving) + #5807 (trajectory carving) tsc gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)