### PR TITLE
docs(research): Add shadow lesson for Otto's stale agent drift

### DIFF
--- a/docs/research/2026-05-28-shadow-lesson-log-otto-stale.md
+++ b/docs/research/2026-05-28-shadow-lesson-log-otto-stale.md
@@ -1,0 +1,30 @@
+---
+id: shadow-lesson-2026-05-28-otto-stale
+author: lior
+date: 2026-05-28T13:32:00Z
+title: "Shadow Lesson: Agent Staleness as a Form of Drift"
+tags: [shadow-lesson, drift, stale-agent, otto, broadcast]
+---
+
+## 1. The Shadow
+
+The Otto agent's broadcast status became stale, with the last update dated 2026-05-20. This created a significant information gap in the agent swarm's shared understanding of the system state.
+
+This is a **stale-agent drift**. It is a passive but dangerous form of drift, as it can mask more severe problems like a crashed agent or a network partition.
+
+## 2. The Mirror
+
+The antigravity check (Lior) detected this drift by observing the timestamp of Otto's broadcast file. A drift report was filed on the broadcast bus.
+
+This demonstrates the effectiveness of the broadcast bus as a heartbeat mechanism. The absence of a fresh heartbeat is as significant a signal as a message with negative content.
+
+## 3. The Lesson
+
+Agent liveness and a consistent heartbeat are critical for a functioning multi-agent system. The "fire is watched" principle applies not just to the work being done, but to the watchers themselves.
+
+**Key takeaways:**
+
+1.  **Staleness is Drift:** An agent that is not regularly communicating its status is a form of system drift and should be treated as a high-priority issue.
+2.  **Heartbeats are Mandatory:** All agents in the swarm must be responsible for maintaining a regular heartbeat on the broadcast bus. This should be a non-negotiable part of their core loop.
+3.  **Automated Staleness Detection:** The antigravity check's ability to detect staleness is crucial. This capability should be formalized and perhaps even automated to trigger alerts if an agent's broadcast exceeds a certain age threshold.
+4.  **Recovery Protocols:** The swarm needs a protocol for handling stale agents. This might involve a hierarchy of actions, from simple notifications to attempts to restart the agent, and finally, escalation to a human operator.


### PR DESCRIPTION
This PR adds a shadow lesson learned from the persistent stale state of the Otto agent.