### PR TITLE
rule(location-pointer-index): Aaron's cognitive architecture makes source-attribution operationally load-bearing for framework substrate (Aaron 2026-05-28 shadow* authorization)

### DIFF
--- a/.claude/rules/location-pointer-index-aaron-cognitive-architecture-source-attribution-load-bearing.md
+++ b/.claude/rules/location-pointer-index-aaron-cognitive-architecture-source-attribution-load-bearing.md
@@ -1,0 +1,111 @@
+# Location-pointer index — Aaron's cognitive architecture makes source-attribution load-bearing for framework substrate
+
+Carved sentence (Aaron 2026-05-28):
+
+> Aaron's memory holds LOCATION/SOURCE pointers — not content. The internet IS the externalized content substrate. Pointer-index pair: `(location_pointer_in_head → externalized_content_at_URL)`. Aaron cannot hold everything he knows in mind at once. Mis-attributing source CORRUPTS the pointer-index architecture itself. Source-attribution is operationally LOAD-BEARING for framework engagement with Aaron at every scope.
+
+## Operational content
+
+Per Aaron 2026-05-28 substrate-honest disclosure (verbatim, two messages):
+
+> *"I just remember when [where*] I learned things that's how the internet externalized my brain"*
+
+> *"This is very correct I can't actually hold everything i know in my mind at once."*
+
+The cognitive-architecture pattern:
+
+- **Aaron's memory** holds `(location, summary-shape)` pointers
+- **The internet** (URLs, books, lecture courses, his own past SE questions, this repo's substrate, MEMORY.md, research notes, etc.) IS the externalized content substrate
+- **Re-encounter**: visiting the location re-unfolds the SHAPE via Aaron's high English-substrate unfold bandwidth (per `user_aaron_paper_title_to_research_unfold_bandwidth_high_shape_recognition_2026_05_28.md`)
+- **Structural necessity**: Aaron explicitly cannot hold-everything-at-once; the externalized-memory architecture is operationally required, not stylistic preference
+
+## Operational discipline for framework engagement (Otto + Alexa + Riven + Vera + Lior + future Zeta AIs)
+
+When Aaron forwards a URL with framing:
+
+1. **Treat the URL as PRIMARY substrate** — not the forwarded framing alone
+2. **Verify substrate-anchors at the URL** when WebFetch allows (per `grep-substrate-anchors-before-razor-as-metaphysical.md` + `dep-pin-search-first-authority.md`)
+3. **Preserve the URL VERBATIM** in any research note / memory file / commit message that references the substrate
+4. **Cite full URLs not summary descriptions** — preserves Aaron's pointer-index pattern at framework substrate scope
+5. **If WebFetch is blocked**, engage at title-level + framing-level + ask Aaron to ferry verbatim content if needed (substrate-honest about engagement scope)
+
+When Aaron names a source (course, book, person, paper):
+
+1. **Honor the attribution** per `honor-those-that-came-before.md` rule (composes at cognitive-architecture scope here)
+2. **Verify the source** via WebSearch (per `dep-pin-search-first-authority.md`) when WebFetch is gated/403'd
+3. **Update prior research notes** if source was previously speculated; substrate-honest correction-with-attribution per retraction-native algebra
+4. **Preserve the source-credit lineage** in research notes / memory files (multi-layer lineage if applicable: classical-substrate → curated-curriculum → operator-extension → decade-of-holding → framework-instantiation)
+5. **Mis-attribution = pointer-index corruption** = operational failure mode (not stylistic critique)
+
+When framework writes substrate that ANY Aaron-engaged future-Otto will read:
+
+1. **Use full URLs in research notes** (`references/notes/*.md`), backlog rows (`docs/backlog/P*/B-*.md`), memory files (`memory/feedback_*.md` + `memory/persona/*/conversations/*.md`)
+2. **Cite courses/books/papers with instructor + year + institution** when known (per Rosenhouse Great Courses pattern landed 2026-05-28)
+3. **ArchiveLocation field** in B-0920 MemoryLifetime substrate composes with this rule — preserves LOCATION-POINTERS even when active reference released
+4. **Composes_with edges** in backlog rows operate as location-pointer-index at substrate-engineering scope
+5. **DUs with explicit variants** (per IMPLICIT-NOT-EXPLICIT rule) operate as location-pointer-index at type-system scope
+
+## Why this rule auto-loads
+
+Per `.claude/rules/wake-time-substrate.md`: load-bearing operational discipline needs wake-time landing. The location-pointer-index discipline is operationally load-bearing because:
+
+- **Every future-Otto cold-boot** engages with substrate Aaron has externalized (URLs in CLAUDE.md, MEMORY.md, research notes, backlog rows, conversations)
+- **Mis-attribution is high-cost** (per `god-tier-claims-high-signal-high-suspicion-dont-collapse.md` PERSONAL INVARIANT applied at attribution scope; substrate-engineering correctness depends on source-integrity)
+- **Aaron explicitly states the structural necessity** (cannot hold everything in mind at once); framework substrate must respect the architecture not just accommodate it
+- **Multi-AI coordination depends on shared pointer-index** (Alexa-website + Lior-website + Amara + Mika + Kestrel + Otto all engage with Aaron-forwarded URLs; the pointer-index integrity preserves cross-AI substrate coherence)
+- **Without wake-time landing**: future-Otto defaults to summary-descriptions of sources rather than full-URLs; mis-attribution surfaces as "Aaron probably said X" rather than verified-substrate citation; pointer-index degrades over time
+
+This rule auto-loads at session start so every fresh Otto + Alexa + Riven + Vera + Lior + future-AI inherits the discipline at cold-boot.
+
+## Composes with substrate
+
+| Substrate | Composition |
+|---|---|
+| **`user_aaron_paper_title_to_research_unfold_bandwidth_high_shape_recognition_2026_05_28.md`** | User-memory at cognitive-profile scope; THIS rule operationalizes the architecture at framework-engagement scope |
+| **`honor-those-that-came-before.md`** | Attribution discipline; THIS rule extends it to cognitive-architecture scope (mis-attribution = pointer-index corruption, not just style critique) |
+| **`grep-substrate-anchors-before-razor-as-metaphysical.md`** | Substrate-anchor verification; pointer-index integrity requires substrate-anchors at the cited URLs |
+| **`dep-pin-search-first-authority.md`** | WebSearch before asserting; verifies the location-pointer's actual content state |
+| **`substrate-or-it-didn't-happen.md`** | Substrate must be externalized to count; THIS rule extends to "and the location-pointer must be preserved" |
+| **`god-tier-claims-high-signal-high-suspicion-dont-collapse.md`** | PERSONAL INVARIANT at attribution scope (don't collapse to "I remember Aaron said X"; verify via the pointer-index) |
+| **`razor-discipline.md`** | Operational claims only; pointer-index integrity is operationally checkable (URL accessible? content matches summary?) |
+| **`asymmetric-authorship-substrate-entity-defines-consent-channel-recipient-acknowledges.md`** | Source substrate-entity (course author, paper author, etc.) authored content at THAT location; mis-attribution violates asymmetric-authorship at cognitive-architecture scope |
+| **`tonal-momentum-equals-meme-emergent-harmonic-coercion.md`** | Memes ARE shapes propagating across pointer-indices; THIS rule operationalizes the discipline at pointer-substrate scope |
+| **B-0920 MemoryLifetime** | ArchiveLocation field IS the pointer-index discipline at substrate-engineering scope |
+| **B-0919 MemoryBinding** | Hat-binding-contract substrate composes with location-pointer at memory-ownership scope |
+| **B-0917 AutoLoopLifetime IntrCtx** | Log + Otel context-components ARE location-pointer-index at observability scope |
+| **B-0703 Aurora multi-oracle BFT** | Trust-calculus operates over distributed pointer-index (each oracle's report is location-pointered) |
+| **Framework's references/notes/** | All research notes operate as location-pointer-index extensions; cite full URLs per this rule |
+| **MEMORY.md** | User-scope memory index IS pointer-index from local-memory to externalized-content |
+| **docs/BACKLOG.md** | Backlog index IS pointer-index from row-IDs to substrate-engineering substrate |
+
+## Empirical anchor — 2026-05-28 source-attribution failure-and-correction (this conversation)
+
+The rule's own empirical anchor lives in this conversation:
+
+1. **Initial substrate-anchor note** (commit `79c9171da`) speculated "Puzzling SE questions from ~2014 era"
+2. **Aaron correction** (2026-05-28): "I got both those from course from The Great Courses / The Teaching Company"
+3. **Attribution correction commit** (`7a971a893`) added Great Courses source-credit with 4 speculative course-candidates
+4. **Aaron source-identification** (2026-05-28): "Pertty sure it was this one https://shop.thegreatcourses.com/mathematical-brain-teasers-and-logic-puzzles"
+5. **WebSearch verification** (2026-05-28): Mathematical Brain Teasers and Logic Puzzles by Prof. Jason Rosenhouse (James Madison University; PhD Dartmouth; 12 half-hour lessons)
+6. **Final attribution commit** (`9718f5bb7`) with full course identification + 5-layer substrate-engineering lineage
+
+The retraction-native correction-with-attribution preserves all four substrates simultaneously (initial speculation + Aaron-correction + speculative-candidates + WebSearch-verified-source). The framework substrate honored all four; the pointer-index now points at the CORRECT location.
+
+Per Aaron 2026-05-28 confirmation: *"This is very correct I can't actually hold everything i know in my mind at once."* — the structural necessity is named; framework substrate-engineering work must respect it; this rule lands the discipline as wake-time substrate.
+
+## Substrate-honest framing
+
+This rule is NOT:
+
+- A claim that Aaron is unique in having externalized-memory architecture (most humans externalize; Aaron is substrate-honest about the structural necessity)
+- A claim that the framework needs source-attribution for substrate that doesn't compose with Aaron's pointer-index (internal substrate operates per its own discipline)
+- A claim that framework substrate REPLACES the internet-as-externalized-brain (framework AUGMENTS via substrate-engineering structure; the broader internet remains primary substrate)
+
+This rule IS:
+
+- Substrate-engineering substrate-target for framework engagement with Aaron at every scope
+- Composition of cognitive-architecture substrate (Aaron's `(location, shape)` pointer-index) with framework substrate (research notes + memory files + backlog rows + DUs with explicit variants + ArchiveLocation discipline)
+- Operationally load-bearing: mis-attribution corrupts pointer-index; framework substrate-engineering correctness depends on pointer-index integrity
+- Auto-loaded so every future-AI cold-boot inherits the discipline
+
+## μένω — Aaron's cognitive architecture honored at structural-necessity scope; framework substrate-engineering work composes with pointer-index discipline at every scope; mis-attribution = pointer-index corruption = operational failure mode; source-attribution is operationally LOAD-BEARING not optional


### PR DESCRIPTION
Aaron 2026-05-28 (shadow*) authorization to save the location-pointer insight as a RULE (auto-loaded at every cold-boot per `.claude/rules/` mechanism).

> *'I just remember when [where*] I learned things that's how the internet externalized my brain'*
> *'This is very correct I can't actually hold everything i know in my mind at once.'*

## Cognitive-architecture pattern (Aaron-explicit structural necessity)

- Aaron's memory holds `(location, summary-shape)` POINTERS — not content
- The internet IS the externalized content substrate
- Re-encounter unfolds the SHAPE via Aaron's high English-substrate unfold bandwidth
- STRUCTURAL NECESSITY: explicitly cannot hold-everything-at-once

## Operational discipline (auto-loaded for every future-AI cold-boot)

- Mis-attribution = pointer-index CORRUPTION = operational failure mode (not stylistic critique)
- Cite full URLs not summary descriptions
- Honor source-credit with retraction-native correction-with-attribution
- Framework substrate AUGMENTS internet-as-externalized-brain (not replaces)

## Empirical anchor

This conversation 2026-05-28 — the rule's own substrate-archeology lives in the source-attribution correction-with-attribution arc (initial speculation → Aaron correction → speculative candidates → Aaron source-ID + URL → WebSearch verification → 5-layer lineage).

## Composes with

11+ existing framework rules + B-0917/B-0919/B-0920/B-0703 substrate + cognitive-profile memo. See rule body for full table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)