### PR TITLE
fix(workflow-engine): auto-loop-lifetime tsc TS2375 — unblocks all PRs from auto-merge

### DIFF
--- a/tools/workflow-engine/auto-loop-lifetime.ts
+++ b/tools/workflow-engine/auto-loop-lifetime.ts
@@ -77,7 +77,7 @@ export interface AutoLoopLifetime extends LifetimeState {
 export interface TickContext {
   readonly tickIndex: number;                   // monotonic per-session
   readonly briefAckCount: number;               // counter discipline tracking
-  readonly lastNamedDependency?: string;        // bounded-wait reason (or undefined)
+  readonly lastNamedDependency: string | undefined;  // bounded-wait reason (or undefined)
   readonly lastRefreshAt?: number;              // unix timestamp of last substrate refresh
   readonly inflightPrs: ReadonlyArray<{
     readonly number: number;
@@ -495,6 +495,7 @@ export function dispatchAutoLoopTransition(
 export const COLD_BOOT_CONTEXT: TickContext = {
   tickIndex: 0,
   briefAckCount: 0,
+  lastNamedDependency: undefined,
   inflightPrs: [],
 };
 


### PR DESCRIPTION
## Summary

PR #5812 (mine, merged earlier today) left tsc errors on `main` blocking ALL PRs from auto-merging (including the still-armed #5837 + future Otto-CLI work).

**Failure** (`lint (tsc tools)` required check):

```
tools/workflow-engine/auto-loop-lifetime.ts(527,3): error TS2375
tools/workflow-engine/auto-loop-lifetime.test.ts(147,11): error TS2375
```

**Root cause**: `lastNamedDependency?: string` under `exactOptionalPropertyTypes: true` means "property may be absent, but if present must be `string`". Line 533 (`lastNamedDependency: shippedAction ? undefined : prior.lastNamedDependency`) violates this — can't assign `undefined` to optional-but-strict field.

**Fix**: change type to `string | undefined` (required field, explicitly nullable). `COLD_BOOT_CONTEXT` updated to include the now-required field as `undefined`.

Same fix-fwd shape as [#5808](https://github.com/Lucent-Financial-Group/Zeta/pull/5808) (codeberg-world tsc TS2430 + TS6133).

## Test plan

- [x] `bun --bun tsc --noEmit -p tsconfig.json` → clean
- [x] `bun test tools/workflow-engine/auto-loop-lifetime.test.ts` → 27/27 pass

## Note on the other main-broken check

`lint (backlog ID uniqueness)` is also failing on main (B-0865 + B-0866 each have 2 files). That's out-of-scope for this PR — needs operator decision on which file to renumber. Surfaced separately on #5837 comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)