### PR TITLE
docs(site): Create stable route map for GitHub Pages (B-0302)

### DIFF
--- a/docs/site/routes.md
+++ b/docs/site/routes.md
@@ -1,0 +1,27 @@
+# GitHub Pages Stable Route Map
+
+This document defines the stable URL route map for the Zeta GitHub Pages site, as specified in backlog item [B-0302](../backlog/P1/B-0302-pages-stable-route-map-pre-indexing-freeze-2026-05-08.md). These routes are considered frozen before the site is indexed by search engines to prevent broken links and SEO penalties.
+
+Any future changes to this routing structure MUST be accompanied by a redirect strategy.
+
+## Core Routes
+
+The following routes map the canonical source documents to their public URLs. The URL scheme is designed to be clean, readable, and not expose internal repository structure.
+
+| Public URL Path | Source File | Notes |
+|---|---|---|
+| `/` | `README.md` | The site root and primary landing page. |
+| `/vision/` | `docs/VISION.md` | The project's long-term vision and "About" page. |
+| `/alignment/` | `docs/ALIGNMENT.md` | The core principles of human-agent collaboration. |
+| `/glossary/` | `docs/GLOSSARY.md` | A reference for key terms and concepts. |
+| `/contributing/`| `CONTRIBUTING.md` | The main entry point for new contributors. |
+
+## Future Routes
+
+The following sections are planned but will be implemented in future backlog items.
+
+| Public URL Path | Content Area | Backlog Item |
+|---|---|---|
+| `/research/` | Selected research papers and deep-dives. | B-0304 |
+
+This route map will be used by the Astro configuration to generate the final site structure.


### PR DESCRIPTION
This PR implements backlog item B-0302 by creating the stable URL route map for the GitHub Pages site. This file defines the URL structure before indexing begins.