### PR TITLE
docs(site): Create contributor on-ramp document for Pages (B-0303)

### DIFF
--- a/docs/site/on-ramp.md
+++ b/docs/site/on-ramp.md
@@ -6,13 +6,15 @@ This document provides a high-level guide for new contributors, mapping differen
 
 The Zeta project is a large and complex software factory, but there are many ways to contribute, regardless of your background. Find the persona that best fits you below to get started.
 
+> **Note:** The personas below are a simplified subset chosen for this public Pages on-ramp. The canonical, full contributor-persona taxonomy lives in [**CONTRIBUTOR-PERSONAS.md**](https://github.com/Lucent-Financial-Group/Zeta/blob/main/docs/CONTRIBUTOR-PERSONAS.md); consult it for the complete first-contact shape.
+
 ### The Drive-By Contributor
 
 *Found a typo? Noticed a broken link? Want to report a bug?*
 
 This is the easiest way to get involved.
 
-- **To get started:** Read our [**CONTRIBUTING.md**](../../CONTRIBUTING.md) file for instructions on how to submit issues and pull requests for simple fixes.
+- **To get started:** Read our [**CONTRIBUTING.md**](https://github.com/Lucent-Financial-Group/Zeta/blob/main/CONTRIBUTING.md) file for instructions on how to submit issues and pull requests for simple fixes.
 
 ### The Systems Engineer
 
@@ -20,7 +22,7 @@ This is the easiest way to get involved.
 
 The factory's tooling and infrastructure are constantly evolving.
 
-- **To dive in:** Start with the [**ARCHITECTURE.md**](../../docs/ARCHITECTURE.md) document for a high-level overview.
+- **To dive in:** Start with the [**ARCHITECTURE.md**](https://github.com/Lucent-Financial-Group/Zeta/blob/main/docs/ARCHITECTURE.md) document for a high-level overview.
 - **To see the code:** Explore the `tools/` directory to see the scripts and programs that run the factory.
 
 ### The AI Researcher
@@ -29,7 +31,7 @@ The factory's tooling and infrastructure are constantly evolving.
 
 The core of Zeta is a research project into measurable AI alignment.
 
-- **To understand the vision:** Read the [**VISION.md**](../../docs/VISION.md) and [**ALIGNMENT.md**](../../docs/ALIGNMENT.md) documents.
+- **To understand the vision:** Read the [**VISION.md**](https://github.com/Lucent-Financial-Group/Zeta/blob/main/docs/VISION.md) and [**ALIGNMENT.md**](https://github.com/Lucent-Financial-Group/Zeta/blob/main/docs/ALIGNMENT.md) documents.
 - **To see the research:** Explore the `docs/research/` directory for deep-dives into the theoretical underpinnings of the project.
 
 ### The Formal Verification Expert

--- a/docs/site/on-ramp.md
+++ b/docs/site/on-ramp.md
@@ -1,0 +1,35 @@
+# Contributor On-Ramp
+
+This document provides a high-level guide for new contributors, mapping different interests and skillsets to the right entry points in the Zeta repository. It is the source for the main "Contribute" section of the public GitHub Pages site.
+
+## How Can I Contribute?
+
+The Zeta project is a large and complex software factory, but there are many ways to contribute, regardless of your background. Find the persona that best fits you below to get started.
+
+### The Drive-By Contributor
+*Found a typo? Noticed a broken link? Want to report a bug?*
+
+This is the easiest way to get involved.
+- **To get started:** Read our [**CONTRIBUTING.md**](../../CONTRIBUTING.md) file for instructions on how to submit issues and pull requests for simple fixes.
+
+### The Systems Engineer
+*Interested in the core machinery, the build system, CI/CD, and the tools that power the factory?*
+
+The factory's tooling and infrastructure are constantly evolving.
+- **To dive in:** Start with the [**ARCHITECTURE.md**](../../docs/ARCHITECTURE.md) document for a high-level overview.
+- **To see the code:** Explore the `tools/` directory to see the scripts and programs that run the factory.
+
+### The AI Researcher
+*Fascinated by the principles of agentic software development, alignment, and the long-term vision?*
+
+The core of Zeta is a research project into measurable AI alignment.
+- **To understand the vision:** Read the [**VISION.md**](../../docs/VISION.md) and [**ALIGNMENT.md**](../../docs/ALIGNMENT.md) documents.
+- **To see the research:** Explore the `docs/research/` directory for deep-dives into the theoretical underpinnings of the project.
+
+### The Formal Verification Expert
+*Do you speak TLA+ or Alloy? Interested in proving the correctness of distributed systems and protocols?*
+
+Formal methods are a cornerstone of our approach to safety and reliability.
+- **To see the specs:** Explore the `openspec/` directory for our TLA+ and Alloy specifications. Contributions to improve these specs or add new ones are highly valued.
+
+This document serves as a starting point. The best way to get involved is to find an area that interests you, read the relevant documentation, and start a discussion by opening an issue.

--- a/docs/site/on-ramp.md
+++ b/docs/site/on-ramp.md
@@ -7,29 +7,37 @@ This document provides a high-level guide for new contributors, mapping differen
 The Zeta project is a large and complex software factory, but there are many ways to contribute, regardless of your background. Find the persona that best fits you below to get started.
 
 ### The Drive-By Contributor
+
 *Found a typo? Noticed a broken link? Want to report a bug?*
 
 This is the easiest way to get involved.
+
 - **To get started:** Read our [**CONTRIBUTING.md**](../../CONTRIBUTING.md) file for instructions on how to submit issues and pull requests for simple fixes.
 
 ### The Systems Engineer
+
 *Interested in the core machinery, the build system, CI/CD, and the tools that power the factory?*
 
 The factory's tooling and infrastructure are constantly evolving.
+
 - **To dive in:** Start with the [**ARCHITECTURE.md**](../../docs/ARCHITECTURE.md) document for a high-level overview.
 - **To see the code:** Explore the `tools/` directory to see the scripts and programs that run the factory.
 
 ### The AI Researcher
+
 *Fascinated by the principles of agentic software development, alignment, and the long-term vision?*
 
 The core of Zeta is a research project into measurable AI alignment.
+
 - **To understand the vision:** Read the [**VISION.md**](../../docs/VISION.md) and [**ALIGNMENT.md**](../../docs/ALIGNMENT.md) documents.
 - **To see the research:** Explore the `docs/research/` directory for deep-dives into the theoretical underpinnings of the project.
 
 ### The Formal Verification Expert
+
 *Do you speak TLA+ or Alloy? Interested in proving the correctness of distributed systems and protocols?*
 
 Formal methods are a cornerstone of our approach to safety and reliability.
+
 - **To see the specs:** Explore the `openspec/` directory for our TLA+ and Alloy specifications. Contributions to improve these specs or add new ones are highly valued.
 
 This document serves as a starting point. The best way to get involved is to find an area that interests you, read the relevant documentation, and start a discussion by opening an issue.


### PR DESCRIPTION
This PR implements backlog item B-0303 by creating the contributor on-ramp document, which will serve as the main 'Contribute' section of the GitHub Pages site.