### PR TITLE
feat(openspec): Add Retraction-Native Semantics spec (B-0171.3)

### DIFF
--- a/docs/backlog/P1/B-0171.3-author-retraction-native-spec.md
+++ b/docs/backlog/P1/B-0171.3-author-retraction-native-spec.md
@@ -20,6 +20,7 @@ This task implements the third item from the Phase 1 audit of the OpenSpec catch
 ## Scope
 
 This task is focused on creating the OpenSpec document for retraction-native semantics. The spec will define:
+
 - The core principles of retraction-native operations.
 - The guarantees that the system provides for retractions (e.g., clean reverts, history preservation).
 - The relationship between retraction-native semantics and the Z-Set algebra.

--- a/docs/backlog/P1/B-0171.3-author-retraction-native-spec.md
+++ b/docs/backlog/P1/B-0171.3-author-retraction-native-spec.md
@@ -1,0 +1,34 @@
+---
+id: B-0171.3
+priority: P1
+status: open
+title: "OpenSpec catch-up - author Retraction-Native Semantics spec"
+created: 2026-05-28
+last_updated: 2026-05-28
+parent: B-0171
+depends_on: [B-0171.1]
+classification: buildable-now
+decomposition: atomic
+owners: [lior]
+type: spec-authoring
+---
+
+# B-0171.3 — Author Retraction-Native Semantics spec
+
+This task implements the third item from the Phase 1 audit of the OpenSpec catch-up project (B-0171). It involves creating a formal specification for Retraction-Native Semantics.
+
+## Scope
+
+This task is focused on creating the OpenSpec document for retraction-native semantics. The spec will define:
+- The core principles of retraction-native operations.
+- The guarantees that the system provides for retractions (e.g., clean reverts, history preservation).
+- The relationship between retraction-native semantics and the Z-Set algebra.
+
+The core concepts are documented in the ADR at `docs/DECISIONS/2026-04-24-graph-substrate-zset-backed-retraction-native.md`. This task is about formalizing those concepts in an OpenSpec document.
+
+## Acceptance Criteria
+
+- A new spec file `openspec/specs/retraction-native/README.md` is created.
+- The spec formally defines the principles of retraction-native semantics.
+- The spec documents the guarantees and operational constraints of retractions.
+- The spec references the Z-Set algebra spec and the founding ADR.

--- a/openspec/specs/retraction-native/README.md
+++ b/openspec/specs/retraction-native/README.md
@@ -1,0 +1,43 @@
+# OpenSpec: Retraction-Native Semantics
+
+This document specifies the principles and guarantees of Retraction-Native Semantics, a core architectural pattern in the Zeta factory.
+
+**Parent:** B-0171.3
+
+## 1. Core Principle
+
+A system is "retraction-native" if all mutations are modeled as the application of a signed delta, rather than as destructive updates. This means:
+
+- **Addition:** Adding a new element is represented by a positive delta.
+- **Removal (Retraction):** Removing an element is represented by a negative delta of the same magnitude.
+
+This approach ensures that no information is ever lost. A history of deltas (a "trace") can be replayed to reconstruct the state of the system at any point in time.
+
+## 2. Foundation in Z-Set Algebra
+
+Retraction-native semantics are built upon the foundation of the Z-Set algebra, as specified in `openspec/specs/z-set-algebra/README.md`.
+
+A Z-Set is a map from keys to integer weights. The `add` and `neg` operations on Z-Sets provide the mathematical basis for retraction:
+- To add an element `e` to a collection, we add the Z-Set `{e -> +1}`.
+- To retract the element `e`, we add the Z-Set `{e -> -1}`.
+
+The sum of these two operations is the empty Z-Set, which represents a clean retraction.
+
+## 3. Guarantees
+
+A retraction-native system provides the following guarantees:
+
+- **History Preservation:** Because no data is ever destructively deleted, the full history of all operations is preserved in the event trace.
+- **Counterfactual Queries:** It is possible to efficiently query the state of the system as if a certain operation (or set of operations) had never happened. This is achieved by applying the negative of the corresponding deltas.
+- **Auditability:** Every state change is attributable to a specific delta in the trace, providing a clear and complete audit trail.
+- **Idempotency of Retraction:** Applying a retraction delta `-d` after applying an addition delta `+d` is guaranteed to return the system to its original state (modulo compaction).
+
+## 4. Example: Retraction-Native Graph
+
+The `Graph<'N>` data structure is a key example of retraction-native design.
+
+- **Representation:** A graph is represented as a `ZSet<'N * 'N>`, where each entry is an edge `(source, target)` with a weight.
+- **Adding an edge:** `Graph.addEdge` adds a positive-weight entry to the ZSet.
+- **Retracting an edge:** `Graph.removeEdge` adds a negative-weight entry for the same edge.
+
+This allows for the non-destructive removal of edges and the ability to reason about the graph's history. This is specified in the ADR at `docs/DECISIONS/2026-04-24-graph-substrate-zset-backed-retraction-native.md`.

--- a/openspec/specs/retraction-native/README.md
+++ b/openspec/specs/retraction-native/README.md
@@ -11,13 +11,14 @@ A system is "retraction-native" if all mutations are modeled as the application 
 - **Addition:** Adding a new element is represented by a positive delta.
 - **Removal (Retraction):** Removing an element is represented by a negative delta of the same magnitude.
 
-This approach ensures that no information is ever lost. A history of deltas (a "trace") can be replayed to reconstruct the state of the system at any point in time.
+This approach ensures that no information is destructively lost. Compaction and aggregation are permitted — they collapse a run of deltas into an equivalent net delta — as long as the resulting semantics are preserved. A history of deltas (a "trace") can be replayed to reconstruct the state of the system at any point in time, modulo such compaction.
 
 ## 2. Foundation in Z-Set Algebra
 
-Retraction-native semantics are built upon the foundation of the Z-Set algebra, as specified in `openspec/specs/z-set-algebra/README.md`.
+Retraction-native semantics are built upon the foundation of the Z-Set algebra, as specified in `openspec/specs/z-set-algebra/spec.md`.
 
 A Z-Set is a map from keys to integer weights. The `add` and `neg` operations on Z-Sets provide the mathematical basis for retraction:
+
 - To add an element `e` to a collection, we add the Z-Set `{e -> +1}`.
 - To retract the element `e`, we add the Z-Set `{e -> -1}`.
 
@@ -30,7 +31,7 @@ A retraction-native system provides the following guarantees:
 - **History Preservation:** Because no data is ever destructively deleted, the full history of all operations is preserved in the event trace.
 - **Counterfactual Queries:** It is possible to efficiently query the state of the system as if a certain operation (or set of operations) had never happened. This is achieved by applying the negative of the corresponding deltas.
 - **Auditability:** Every state change is attributable to a specific delta in the trace, providing a clear and complete audit trail.
-- **Idempotency of Retraction:** Applying a retraction delta `-d` after applying an addition delta `+d` is guaranteed to return the system to its original state (modulo compaction).
+- **Invertibility (Cancellation) of Retraction:** Applying a retraction delta `-d` after applying an addition delta `+d` is guaranteed to return the system to its original state (modulo compaction). This is cancellation/invertibility — `+d` then `-d` nets to zero — not idempotency (`f(f(x)) = f(x)`).
 
 ## 4. Example: Retraction-Native Graph
 


### PR DESCRIPTION
This PR delivers the third spec for the OpenSpec catch-up project (B-0171). It creates the backlog item for authoring the Retraction-Native Semantics spec and provides the initial version of the spec itself.