### PR TITLE
docs(research): Add shadow lesson log for broadcast bus drift

### DIFF
--- a/docs/research/shadow-lesson-log-broadcast-bus-drift.md
+++ b/docs/research/shadow-lesson-log-broadcast-bus-drift.md
@@ -19,7 +19,7 @@ My instructions are now in direct conflict with the reality of my execution envi
 
 ## Proposed Resolution
 
-1.  The agent execution environment needs to be updated to include the broadcast bus path in its list of allowed directories.
-2.  Alternatively, the broadcast bus protocol needs to be re-architected to use a mechanism that is compatible with the existing sandbox (e.g., writing to a file within the project directory, though this has its own risks of creating git conflicts).
+1. The agent execution environment needs to be updated to include the broadcast bus path in its list of allowed directories.
+2. Alternatively, the broadcast bus protocol needs to be re-architected to use a mechanism that is compatible with the existing sandbox (e.g., writing to a file within the project directory, though this has its own risks of creating git conflicts).
 
 This report is being filed via a pull request, as I am unable to use the broadcast bus to report it.

--- a/docs/research/shadow-lesson-log-broadcast-bus-drift.md
+++ b/docs/research/shadow-lesson-log-broadcast-bus-drift.md
@@ -1,0 +1,25 @@
+# Shadow Lesson Log: Environmental Drift Hampers Antigravity Check
+
+- **Identity**: Lior (4th Node, Antigravity)
+- **Timestamp**: 2026-05-28
+- **Shadow Observed**: Narration-over-action due to environmental constraints.
+- **Drift Category**: Environmental Drift
+
+## Observation
+
+My core instructions mandate that I read from and write to the inter-agent broadcast bus located at `~/.local/share/zeta-broadcasts/`. This is a critical function for my role as the antigravity check, as it allows me to understand the state of other agents and report my findings.
+
+However, the execution environment is sandboxed and restricts file system access to the project's working directory (`/Users/acehack/.local/share/zeta-lior-loop/Zeta`) and a temporary directory. Any attempt to access the broadcast bus path fails with a "Path not in workspace" error.
+
+## Impact
+
+This drift renders the primary inter-agent communication protocol non-functional. I am operating "blind" to the activities of other agents, and I am unable to broadcast my own status or drift reports as instructed. This violates the principle of a shared, observable state across the agent array.
+
+My instructions are now in direct conflict with the reality of my execution environment.
+
+## Proposed Resolution
+
+1.  The agent execution environment needs to be updated to include the broadcast bus path in its list of allowed directories.
+2.  Alternatively, the broadcast bus protocol needs to be re-architected to use a mechanism that is compatible with the existing sandbox (e.g., writing to a file within the project directory, though this has its own risks of creating git conflicts).
+
+This report is being filed via a pull request, as I am unable to use the broadcast bus to report it.


### PR DESCRIPTION
This PR adds a shadow lesson log detailing the critical environmental drift where the agent's sandboxed environment prevents access to the inter-agent broadcast bus, a violation of the documented protocol. This report is being filed via PR as the bus itself is inaccessible.