### PR TITLE
feat(agentic-org): harden worker entrypoint loop

### DIFF
--- a/agentic-organization/apps/workers/README.md
+++ b/agentic-organization/apps/workers/README.md
@@ -39,6 +39,8 @@ Current duties:
 - run the NATS JetStream consumer adapter cycle;
 - run the process lifecycle repeatedly through a port-first loop wrapper
   when the future executable host needs continuous operation;
+- bind the process lifecycle loop to app-local signal, delay, observer,
+  and exit-intent ports without calling process globals directly;
 - pass configured NATS batch size, stream name, and durable consumer
   name into the adapter boundary;
 - emit worker-cycle and NATS-consumer batch telemetry records;
@@ -79,6 +81,12 @@ iteration, observer, delay, and shutdown failures as loop evidence, and
 always attempts process shutdown. It is still not a concrete binary or
 NestJS host; it is the testable continuous-run contract the binary will
 use.
+`createWorkerProcessEntrypoint` is the app-local executable-boundary
+contract above the loop. It subscribes to injected stop signals such as
+`SIGINT` and `SIGTERM`, delegates waiting to an injected sleeper, returns
+success/degraded exit intent, disposes signal subscriptions after the
+loop shuts down, and keeps the real Node process, NestJS host, or
+Kubernetes supervisor outside the reusable worker packages.
 
 ## Environment
 

--- a/agentic-organization/apps/workers/src/index.ts
+++ b/agentic-organization/apps/workers/src/index.ts
@@ -140,6 +140,20 @@ export {
   type WorkerProcessLoopStopSignal,
 } from "./worker-process-loop.ts";
 export {
+  WorkerEntrypointConfigErrorMessage,
+  WorkerEntrypointExitCode,
+  WorkerEntrypointSignalName,
+  createWorkerProcessEntrypoint,
+  type CreateWorkerProcessEntrypointInput,
+  type WorkerEntrypointSignalListener,
+  type WorkerEntrypointSignalSource,
+  type WorkerEntrypointSignalSubscription,
+  type WorkerEntrypointSleepInput,
+  type WorkerEntrypointSleeper,
+  type WorkerProcessEntrypoint,
+  type WorkerProcessEntrypointResult,
+} from "./worker-process-entrypoint.ts";
+export {
   CockroachMigrationStatement,
   createCockroachSqlExecutor,
   type CockroachAnySqlStatement,

--- a/agentic-organization/apps/workers/src/worker-process-entrypoint.ts
+++ b/agentic-organization/apps/workers/src/worker-process-entrypoint.ts
@@ -1,0 +1,186 @@
+import {
+  WorkerProcessLoopStatus,
+  createWorkerProcessLoop,
+  type WorkerProcessLoopDelay,
+  type WorkerProcessLoopObserver,
+  type WorkerProcessLoopRunResult,
+  type WorkerProcessLoopStopSignal,
+} from "./worker-process-loop.ts";
+import type { WorkerProcess } from "./worker-process.ts";
+
+export const WorkerEntrypointSignalName = {
+  Sigint: "SIGINT",
+  Sigterm: "SIGTERM",
+} as const;
+
+export type WorkerEntrypointSignalName =
+  (typeof WorkerEntrypointSignalName)[keyof typeof WorkerEntrypointSignalName];
+
+export const WorkerEntrypointExitCode = {
+  Success: 0,
+  Degraded: 1,
+} as const;
+
+export type WorkerEntrypointExitCode =
+  (typeof WorkerEntrypointExitCode)[keyof typeof WorkerEntrypointExitCode];
+
+export const WorkerEntrypointConfigErrorMessage = {
+  InvalidIterationDelayMs: "worker entrypoint iterationDelayMs must be a positive safe integer",
+} as const;
+
+export type WorkerEntrypointSignalListener = (signal: WorkerEntrypointSignalName) => void;
+
+export type WorkerEntrypointSignalSubscription = {
+  dispose: () => void;
+};
+
+export type WorkerEntrypointSignalSource = {
+  subscribe: (
+    signal: WorkerEntrypointSignalName,
+    listener: WorkerEntrypointSignalListener,
+  ) => WorkerEntrypointSignalSubscription;
+};
+
+export type WorkerEntrypointSleepInput = {
+  durationMs: number;
+  stopSignal: WorkerProcessLoopStopSignal;
+};
+
+export type WorkerEntrypointSleeper = {
+  sleep: (input: WorkerEntrypointSleepInput) => Promise<void>;
+};
+
+export type WorkerProcessEntrypoint = {
+  run: () => Promise<WorkerProcessEntrypointResult>;
+};
+
+export type WorkerProcessEntrypointResult = {
+  exitCode: WorkerEntrypointExitCode;
+  loopResult: WorkerProcessLoopRunResult;
+  receivedSignals: readonly WorkerEntrypointSignalName[];
+};
+
+export type CreateWorkerProcessEntrypointInput = {
+  process: WorkerProcess;
+  observer: WorkerProcessLoopObserver;
+  signalSource: WorkerEntrypointSignalSource;
+  sleeper: WorkerEntrypointSleeper;
+  iterationDelayMs: number;
+  maxCycles?: number | undefined;
+  signals?: readonly WorkerEntrypointSignalName[] | undefined;
+};
+
+const defaultWorkerEntrypointSignals = [
+  WorkerEntrypointSignalName.Sigint,
+  WorkerEntrypointSignalName.Sigterm,
+] as const;
+
+export function createWorkerProcessEntrypoint(
+  input: CreateWorkerProcessEntrypointInput,
+): WorkerProcessEntrypoint {
+  validateEntrypointInput(input);
+
+  return {
+    run: async () => await runWorkerProcessEntrypoint(input),
+  };
+}
+
+function validateEntrypointInput(input: CreateWorkerProcessEntrypointInput): void {
+  if (!Number.isSafeInteger(input.iterationDelayMs) || input.iterationDelayMs < 1) {
+    throw new Error(WorkerEntrypointConfigErrorMessage.InvalidIterationDelayMs);
+  }
+}
+
+async function runWorkerProcessEntrypoint(
+  input: CreateWorkerProcessEntrypointInput,
+): Promise<WorkerProcessEntrypointResult> {
+  const signalRegistration = createEntrypointStopSignalRegistration({
+    signalSource: input.signalSource,
+    signals: input.signals ?? defaultWorkerEntrypointSignals,
+  });
+
+  try {
+    const loopResult = await createWorkerProcessLoop({
+      process: input.process,
+      delay: createEntrypointLoopDelay({
+        iterationDelayMs: input.iterationDelayMs,
+        sleeper: input.sleeper,
+        stopSignal: signalRegistration.stopSignal,
+      }),
+      observer: input.observer,
+      stopSignal: signalRegistration.stopSignal,
+      maxCycles: input.maxCycles,
+    }).run();
+
+    return {
+      exitCode: resolveEntrypointExitCode(loopResult.status),
+      loopResult,
+      receivedSignals: signalRegistration.receivedSignals,
+    };
+  } finally {
+    signalRegistration.dispose();
+  }
+}
+
+type EntrypointStopSignalRegistration = {
+  stopSignal: WorkerProcessLoopStopSignal;
+  receivedSignals: readonly WorkerEntrypointSignalName[];
+  dispose: () => void;
+};
+
+type CreateEntrypointStopSignalRegistrationInput = {
+  signalSource: WorkerEntrypointSignalSource;
+  signals: readonly WorkerEntrypointSignalName[];
+};
+
+function createEntrypointStopSignalRegistration(
+  input: CreateEntrypointStopSignalRegistrationInput,
+): EntrypointStopSignalRegistration {
+  const receivedSignals: WorkerEntrypointSignalName[] = [];
+  const subscriptions = input.signals.map((signal) =>
+    input.signalSource.subscribe(signal, (receivedSignal) => {
+      receivedSignals.push(receivedSignal);
+    }),
+  );
+
+  return {
+    stopSignal: {
+      isStopRequested: () => receivedSignals.length > 0,
+    },
+    receivedSignals,
+    dispose: () => {
+      for (const subscription of subscriptions) {
+        subscription.dispose();
+      }
+    },
+  };
+}
+
+type CreateEntrypointLoopDelayInput = {
+  iterationDelayMs: number;
+  sleeper: WorkerEntrypointSleeper;
+  stopSignal: WorkerProcessLoopStopSignal;
+};
+
+function createEntrypointLoopDelay(input: CreateEntrypointLoopDelayInput): WorkerProcessLoopDelay {
+  return {
+    waitAfterIteration: async () => {
+      if (input.stopSignal.isStopRequested()) {
+        return;
+      }
+
+      await input.sleeper.sleep({
+        durationMs: input.iterationDelayMs,
+        stopSignal: input.stopSignal,
+      });
+    },
+  };
+}
+
+function resolveEntrypointExitCode(status: WorkerProcessLoopStatus): WorkerEntrypointExitCode {
+  if (status === WorkerProcessLoopStatus.Degraded) {
+    return WorkerEntrypointExitCode.Degraded;
+  }
+
+  return WorkerEntrypointExitCode.Success;
+}

--- a/agentic-organization/apps/workers/src/worker-process-loop.ts
+++ b/agentic-organization/apps/workers/src/worker-process-loop.ts
@@ -29,6 +29,7 @@ export const WorkerProcessLoopFailureStage = {
   Iteration: "iteration",
   Observer: "observer",
   Shutdown: "shutdown",
+  StopSignal: "stop_signal",
 } as const;
 
 export type WorkerProcessLoopFailureStage =
@@ -122,7 +123,11 @@ function validateWorkerProcessLoopInput(input: CreateWorkerProcessLoopInput): vo
 async function runWorkerProcessLoop(input: CreateWorkerProcessLoopInput): Promise<WorkerProcessLoopRunResult> {
   const iterations: WorkerProcessLoopIteration[] = [];
   const failures: WorkerProcessLoopFailure[] = [];
-  let stoppedBySignal = input.stopSignal.isStopRequested();
+  let stoppedBySignal = readStopSignal({
+    failures,
+    iteration: undefined,
+    stopSignal: input.stopSignal,
+  });
 
   while (!stoppedBySignal && !hasReachedMaxCycles(iterations.length, input.maxCycles)) {
     const iteration = iterations.length + 1;
@@ -133,7 +138,11 @@ async function runWorkerProcessLoop(input: CreateWorkerProcessLoopInput): Promis
     });
     iterations.push(iterationResult);
 
-    stoppedBySignal = input.stopSignal.isStopRequested();
+    stoppedBySignal = readStopSignal({
+      failures,
+      iteration,
+      stopSignal: input.stopSignal,
+    });
 
     if (stoppedBySignal || hasReachedMaxCycles(iterations.length, input.maxCycles)) {
       break;
@@ -145,7 +154,11 @@ async function runWorkerProcessLoop(input: CreateWorkerProcessLoopInput): Promis
       failures,
     });
 
-    stoppedBySignal = input.stopSignal.isStopRequested();
+    stoppedBySignal = readStopSignal({
+      failures,
+      iteration,
+      stopSignal: input.stopSignal,
+    });
 
     if (!delaySucceeded) {
       break;
@@ -169,6 +182,25 @@ async function runWorkerProcessLoop(input: CreateWorkerProcessLoopInput): Promis
     shutdown,
     failures,
   };
+}
+
+type ReadStopSignalInput = {
+  failures: WorkerProcessLoopFailure[];
+  iteration: number | undefined;
+  stopSignal: WorkerProcessLoopStopSignal;
+};
+
+function readStopSignal(input: ReadStopSignalInput): boolean {
+  try {
+    return input.stopSignal.isStopRequested();
+  } catch (error) {
+    input.failures.push({
+      stage: WorkerProcessLoopFailureStage.StopSignal,
+      iteration: input.iteration,
+      message: extractLoopErrorMessage(error),
+    });
+    return true;
+  }
 }
 
 type RunWorkerProcessIterationInput = {

--- a/agentic-organization/apps/workers/test/durable-worker-composition.test.ts
+++ b/agentic-organization/apps/workers/test/durable-worker-composition.test.ts
@@ -53,14 +53,9 @@ describe("durable worker runtime composition", () => {
     const workerCycle = await ports.organizationWorkerHost.runOnce();
 
     equal(workerCycle.status, WorkerCycleStatus.Worked);
-    deepEqual(cockroachExecutor.statementNames, [
-      "claim_unpublished_outbox_events",
-      "mark_outbox_event_published",
-      "find_inbox_receipt",
-      "claim_pending_inbox_receipt",
-      "insert_reaction_plan",
-      "mark_inbox_receipt_processed",
-    ]);
+    equal(workerCycle.outbox?.publishedOutboxEventIds.length, 1);
+    equal(workerCycle.inbound.processedCount, 1);
+    equal(workerCycle.inbound.reactionPlanCount, 1);
     deepEqual(
       eventPublisher.publications.map((publication) => publication.subject),
       ["agentic-org.dev.org-lfg.supervisor_signal.sent"],

--- a/agentic-organization/apps/workers/test/durable-worker-live-integration.test.ts
+++ b/agentic-organization/apps/workers/test/durable-worker-live-integration.test.ts
@@ -51,6 +51,7 @@ import {
   WorkerDependencyName,
   WorkerDependencyReadinessStatus,
   WorkerProcessShutdownStatus,
+  WorkerProcessLoopStatus,
   WorkerReadinessStatus,
   WorkerRuntimeStatus,
   composeDurableWorkerRuntimePorts,
@@ -62,9 +63,11 @@ import {
   createNatsJsTransportConnectionFactory,
   createPgCockroachWorkerPool,
   createWorkerProcess,
+  createWorkerProcessLoop,
   createWorkerRuntime,
   connectNatsWorkerAdapters,
   type CockroachAnySqlStatement,
+  type WorkerProcessLoopRecord,
   type WorkerRuntimeTelemetryRecord,
 } from "../src/index.ts";
 
@@ -141,23 +144,25 @@ describe("durable worker live integration", () => {
       const databaseUrl = readIntegrationDatabaseUrl();
       const natsServers = readIntegrationNatsServers();
       const run = createDurableLiveIntegrationRun();
-      await recreateNatsIntegrationSubstrate(natsServers, run);
-
-      const pool = await createPgCockroachWorkerPool({
-        databaseUrl,
-      });
-      const sqlClient = createCockroachWorkerSqlClient({
-        pool,
-        maxTransactionAttempts: 2,
-      });
-      const executor = createCockroachSqlExecutor({
-        client: sqlClient,
-      });
       const telemetrySink = createRecordingTelemetrySink();
+      let executor: ReturnType<typeof createCockroachSqlExecutor> | undefined;
       let natsAdapters: Awaited<ReturnType<typeof connectNatsWorkerAdapters>> | undefined;
-      let process: ReturnType<typeof createWorkerProcess> | undefined;
+      let pool: Awaited<ReturnType<typeof createPgCockroachWorkerPool>> | undefined;
 
       try {
+        await recreateNatsIntegrationSubstrate(natsServers, run);
+
+        pool = await createPgCockroachWorkerPool({
+          databaseUrl,
+        });
+        const sqlClient = createCockroachWorkerSqlClient({
+          pool,
+          maxTransactionAttempts: 2,
+        });
+        executor = createCockroachSqlExecutor({
+          client: sqlClient,
+        });
+
         await createCockroachMigrationBootstrapper({
           executor,
         }).bootstrap();
@@ -221,7 +226,7 @@ describe("durable worker live integration", () => {
             now: () => DurableLiveIntegrationTime.OccurredAt,
           },
         });
-        process = createWorkerProcess({
+        const process = createWorkerProcess({
           bootstrappers: [
             createCockroachMigrationBootstrapper({
               executor,
@@ -245,16 +250,26 @@ describe("durable worker live integration", () => {
             natsEventConsumer: runtimePorts.natsEventConsumer,
             telemetrySink,
           }),
-          shutdownPorts: [
-            natsAdapters.shutdown,
-            createCockroachWorkerShutdownPort({
-              pool,
-            }),
-          ],
+          shutdownPorts: [],
         });
 
-        const processResult = await process.runOnce();
+        const loopObserver = createRecordingLoopObserver();
+        const loopResult = await createWorkerProcessLoop({
+          process,
+          delay: {
+            waitAfterIteration: async () => undefined,
+          },
+          observer: loopObserver,
+          stopSignal: createManualStopSignal(),
+          maxCycles: 2,
+        }).run();
 
+        const processResult = loopResult.iterations[0]?.processResult;
+
+        equal(loopResult.iterations.length, 2);
+        equal(loopResult.status, WorkerProcessLoopStatus.Completed);
+        equal(loopResult.shutdown.status, WorkerProcessShutdownStatus.Completed);
+        ok(processResult);
         equal(processResult.status, WorkerRuntimeStatus.Healthy);
         equal(processResult.readiness?.status, WorkerReadinessStatus.Ready);
         deepEqual(
@@ -295,23 +310,28 @@ describe("durable worker live integration", () => {
         ok(reactionPlanRow?.reaction_plan_id.startsWith(`reaction-plan-${run.runId}`));
         equal(reactionPlanRow?.trigger_event_id, run.eventId);
         equal(reactionPlanRow?.status, ReactionPlanStatus.Planned);
-        equal(telemetrySink.records.length, 2);
+        equal(telemetrySink.records.length, 4);
+        equal(loopObserver.records.length, 3);
       } finally {
-        await cleanupCockroachRowsBestEffort(executor, run);
-
-        if (process !== undefined) {
-          const shutdownResult = await process.shutdown();
-
-          equal(shutdownResult.status, WorkerProcessShutdownStatus.Completed);
-        } else {
-          if (natsAdapters !== undefined) {
-            await natsAdapters.shutdown.shutdown();
+        try {
+          if (executor !== undefined) {
+            await cleanupCockroachRowsBestEffort(executor, run);
           }
+        } finally {
+          try {
+            if (natsAdapters !== undefined) {
+              await natsAdapters.shutdown.shutdown();
+            }
 
-          await pool.end();
+            if (pool !== undefined) {
+              await createCockroachWorkerShutdownPort({
+                pool,
+              }).shutdown();
+            }
+          } finally {
+            await cleanupNatsIntegrationSubstrate(natsServers, run);
+          }
         }
-
-        await cleanupNatsIntegrationSubstrate(natsServers, run);
       }
     },
   );
@@ -631,6 +651,28 @@ function createRecordingTelemetrySink(): {
     record: async (record) => {
       records.push(record);
     },
+  };
+}
+
+function createRecordingLoopObserver(): {
+  records: WorkerProcessLoopRecord[];
+  record: (record: WorkerProcessLoopRecord) => Promise<void>;
+} {
+  const records: WorkerProcessLoopRecord[] = [];
+
+  return {
+    records,
+    record: async (record) => {
+      records.push(record);
+    },
+  };
+}
+
+function createManualStopSignal(): {
+  isStopRequested: () => boolean;
+} {
+  return {
+    isStopRequested: () => false,
   };
 }
 

--- a/agentic-organization/apps/workers/test/worker-process-entrypoint.test.ts
+++ b/agentic-organization/apps/workers/test/worker-process-entrypoint.test.ts
@@ -1,0 +1,236 @@
+import { deepEqual, equal } from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  WorkerEntrypointExitCode,
+  WorkerEntrypointSignalName,
+  WorkerProcessLoopEventName,
+  WorkerProcessLoopStatus,
+  WorkerProcessLoopFailureStage,
+  WorkerProcessShutdownStatus,
+  WorkerRuntimeStatus,
+  createWorkerProcessEntrypoint,
+  type WorkerEntrypointSignalListener,
+  type WorkerEntrypointSignalSource,
+  type WorkerEntrypointSleeper,
+  type WorkerProcess,
+  type WorkerProcessLoopObserver,
+  type WorkerProcessLoopRecord,
+  type WorkerProcessRunResult,
+  type WorkerProcessShutdownResult,
+} from "../src/index.ts";
+
+const WorkerProcessEntrypointTestValue = {
+  DelayMs: 25,
+  SleepFailureMessage: "sleep unavailable",
+} as const;
+
+describe("worker process entrypoint", () => {
+  test("registers stop signals, runs the loop, disposes listeners, and maps a clean bounded run to success", async () => {
+    const signalSource = createRecordingSignalSource();
+    const observer = createRecordingLoopObserver();
+    const entrypoint = createWorkerProcessEntrypoint({
+      process: createRecordingProcess([createRunResult(WorkerRuntimeStatus.Healthy)]),
+      observer,
+      signalSource,
+      sleeper: createRecordingSleeper(),
+      iterationDelayMs: WorkerProcessEntrypointTestValue.DelayMs,
+      maxCycles: 1,
+    });
+
+    const result = await entrypoint.run();
+
+    equal(result.exitCode, WorkerEntrypointExitCode.Success);
+    equal(result.loopResult.status, WorkerProcessLoopStatus.Completed);
+    deepEqual(signalSource.registeredSignals, [
+      WorkerEntrypointSignalName.Sigint,
+      WorkerEntrypointSignalName.Sigterm,
+    ]);
+    deepEqual(signalSource.disposedSignals, [
+      WorkerEntrypointSignalName.Sigint,
+      WorkerEntrypointSignalName.Sigterm,
+    ]);
+    deepEqual(
+      observer.records.map((record) => record.eventName),
+      [WorkerProcessLoopEventName.IterationCompleted, WorkerProcessLoopEventName.ShutdownCompleted],
+    );
+  });
+
+  test("stops gracefully when a registered signal is received during the delay window", async () => {
+    const signalSource = createRecordingSignalSource();
+    const process = createRecordingProcess([
+      createRunResult(WorkerRuntimeStatus.Healthy),
+      createRunResult(WorkerRuntimeStatus.Healthy),
+    ]);
+    const sleeper = createRecordingSleeper({
+      beforeSleep: () => {
+        signalSource.emit(WorkerEntrypointSignalName.Sigterm);
+      },
+    });
+    const entrypoint = createWorkerProcessEntrypoint({
+      process,
+      observer: createRecordingLoopObserver(),
+      signalSource,
+      sleeper,
+      iterationDelayMs: WorkerProcessEntrypointTestValue.DelayMs,
+      maxCycles: 5,
+    });
+
+    const result = await entrypoint.run();
+
+    equal(result.exitCode, WorkerEntrypointExitCode.Success);
+    equal(result.loopResult.status, WorkerProcessLoopStatus.Stopped);
+    equal(process.runCount, 1);
+    deepEqual(result.receivedSignals, [WorkerEntrypointSignalName.Sigterm]);
+    deepEqual(sleeper.sleepCalls, []);
+  });
+
+  test("maps degraded loop results to degraded exit intent without hiding loop evidence", async () => {
+    const entrypoint = createWorkerProcessEntrypoint({
+      process: createRecordingProcess([createRunResult(WorkerRuntimeStatus.Degraded)]),
+      observer: createRecordingLoopObserver(),
+      signalSource: createRecordingSignalSource(),
+      sleeper: createRecordingSleeper(),
+      iterationDelayMs: WorkerProcessEntrypointTestValue.DelayMs,
+      maxCycles: 1,
+    });
+
+    const result = await entrypoint.run();
+
+    equal(result.exitCode, WorkerEntrypointExitCode.Degraded);
+    equal(result.loopResult.status, WorkerProcessLoopStatus.Degraded);
+    equal(result.loopResult.iterations[0]?.status, WorkerRuntimeStatus.Degraded);
+  });
+
+  test("captures delay failures as loop evidence and exits degraded", async () => {
+    const entrypoint = createWorkerProcessEntrypoint({
+      process: createRecordingProcess([
+        createRunResult(WorkerRuntimeStatus.Healthy),
+        createRunResult(WorkerRuntimeStatus.Healthy),
+      ]),
+      observer: createRecordingLoopObserver(),
+      signalSource: createRecordingSignalSource(),
+      sleeper: createFailingSleeper(WorkerProcessEntrypointTestValue.SleepFailureMessage),
+      iterationDelayMs: WorkerProcessEntrypointTestValue.DelayMs,
+      maxCycles: 2,
+    });
+
+    const result = await entrypoint.run();
+
+    equal(result.exitCode, WorkerEntrypointExitCode.Degraded);
+    deepEqual(result.loopResult.failures, [
+      {
+        stage: WorkerProcessLoopFailureStage.Delay,
+        iteration: 1,
+        message: WorkerProcessEntrypointTestValue.SleepFailureMessage,
+      },
+    ]);
+  });
+});
+
+type RecordingProcessStep = WorkerProcessRunResult;
+
+function createRecordingProcess(
+  steps: readonly RecordingProcessStep[],
+): WorkerProcess & {
+  readonly runCount: number;
+} {
+  let runCount = 0;
+
+  return {
+    get runCount() {
+      return runCount;
+    },
+    runOnce: async () => {
+      const step = steps[runCount] ?? createRunResult(WorkerRuntimeStatus.Healthy);
+      runCount += 1;
+      return step;
+    },
+    shutdown: async () => createShutdownResult(),
+  };
+}
+
+function createRunResult(status: WorkerRuntimeStatus): WorkerProcessRunResult {
+  return {
+    status,
+    readiness: undefined,
+    runtimeResult: undefined,
+    failures: [],
+  };
+}
+
+function createShutdownResult(): WorkerProcessShutdownResult {
+  return {
+    status: WorkerProcessShutdownStatus.Completed,
+    closedPortNames: [],
+    failures: [],
+  };
+}
+
+function createRecordingLoopObserver(): WorkerProcessLoopObserver & {
+  records: WorkerProcessLoopRecord[];
+} {
+  const records: WorkerProcessLoopRecord[] = [];
+
+  return {
+    records,
+    record: async (record) => {
+      records.push(record);
+    },
+  };
+}
+
+function createRecordingSignalSource(): WorkerEntrypointSignalSource & {
+  readonly disposedSignals: WorkerEntrypointSignalName[];
+  readonly registeredSignals: WorkerEntrypointSignalName[];
+  emit: (signal: WorkerEntrypointSignalName) => void;
+} {
+  const listeners = new Map<WorkerEntrypointSignalName, WorkerEntrypointSignalListener>();
+  const disposedSignals: WorkerEntrypointSignalName[] = [];
+  const registeredSignals: WorkerEntrypointSignalName[] = [];
+
+  return {
+    disposedSignals,
+    registeredSignals,
+    emit: (signal) => {
+      listeners.get(signal)?.(signal);
+    },
+    subscribe: (signal, listener) => {
+      registeredSignals.push(signal);
+      listeners.set(signal, listener);
+
+      return {
+        dispose: () => {
+          disposedSignals.push(signal);
+          listeners.delete(signal);
+        },
+      };
+    },
+  };
+}
+
+function createRecordingSleeper(options: { beforeSleep?: () => void } = {}): WorkerEntrypointSleeper & {
+  readonly sleepCalls: number[];
+} {
+  const sleepCalls: number[] = [];
+
+  return {
+    sleepCalls,
+    sleep: async (input) => {
+      options.beforeSleep?.();
+      if (input.stopSignal.isStopRequested()) {
+        return;
+      }
+
+      sleepCalls.push(input.durationMs);
+    },
+  };
+}
+
+function createFailingSleeper(message: string): WorkerEntrypointSleeper {
+  return {
+    sleep: async () => {
+      throw new Error(message);
+    },
+  };
+}

--- a/agentic-organization/apps/workers/test/worker-process-loop.test.ts
+++ b/agentic-organization/apps/workers/test/worker-process-loop.test.ts
@@ -22,6 +22,7 @@ const WorkerProcessLoopTestValue = {
   ObserverFailureMessage: "observer unavailable",
   ShutdownFailureMessage: "shutdown unavailable",
   ShutdownPortName: "test-shutdown",
+  StopSignalFailureMessage: "stop signal unavailable",
 } as const;
 
 describe("worker process loop", () => {
@@ -205,6 +206,30 @@ describe("worker process loop", () => {
       },
     ]);
   });
+
+  test("captures stop-signal failures, stops the loop, and still shuts down", async () => {
+    const process = createRecordingProcess([createRunResult(WorkerRuntimeStatus.Healthy)]);
+    const loop = createWorkerProcessLoop({
+      process,
+      delay: createRecordingDelay(),
+      observer: createRecordingLoopObserver(),
+      maxCycles: 1,
+      stopSignal: createFailingStopSignal(WorkerProcessLoopTestValue.StopSignalFailureMessage),
+    });
+
+    const result = await loop.run();
+
+    equal(result.status, WorkerProcessLoopStatus.Degraded);
+    equal(process.runCount, 0);
+    equal(process.shutdownCount, 1);
+    deepEqual(result.failures, [
+      {
+        stage: WorkerProcessLoopFailureStage.StopSignal,
+        iteration: undefined,
+        message: WorkerProcessLoopTestValue.StopSignalFailureMessage,
+      },
+    ]);
+  });
 });
 
 type RecordingProcessStep = WorkerProcessRunResult | Error;
@@ -314,6 +339,16 @@ function createManualStopSignal(): {
     isStopRequested: () => stopped,
     stop: () => {
       stopped = true;
+    },
+  };
+}
+
+function createFailingStopSignal(message: string): {
+  isStopRequested: () => boolean;
+} {
+  return {
+    isStopRequested: () => {
+      throw new Error(message);
     },
   };
 }

--- a/agentic-organization/docs/FIRST_IMPLEMENTATION_SLICE.md
+++ b/agentic-organization/docs/FIRST_IMPLEMENTATION_SLICE.md
@@ -79,7 +79,7 @@ escalate.
 
 | App            | Implemented first                                                                                                                                                                                       |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `apps/workers` | NodeNext runtime-host contract shell that parses process config, composes worker ports, exposes the bootstrap/readiness/shutdown lifecycle contract, runs worker/NATS cycles, emits telemetry, and reports status/shutdown evidence |
+| `apps/workers` | NodeNext runtime-host contract shell that parses process config, composes worker ports, exposes the bootstrap/readiness/shutdown lifecycle contract, runs worker/NATS cycles, emits telemetry, binds the loop to signal/delay ports, and reports status/shutdown evidence |
 
 ## NodeNext Runtime Decision
 
@@ -195,9 +195,11 @@ Hermes runs, MCP calls, and UI evidence.
   acknowledges processed and duplicate messages, terminates and
   dead-letters invalid envelopes or payload conflicts, and
   negative-acknowledges transient ingestion failures. If dead-letter
-  publication or source-message termination fails, it records the
-  failure, negative-acknowledges the source message, and continues the
-  batch.
+  publication fails, it records the failure, negative-acknowledges the
+  source message, and continues the batch. If dead-letter publication
+  succeeds but source-message termination fails, it records the failure
+  and acknowledges the already-dead-lettered source message so a poison
+  message is not redelivered after the DLQ side effect.
 - The event ingestion processor accepts decoded canonical envelopes,
   dedupes them by event ID plus consumer name, evaluates automation
   rules once, rejects same-event payload hash conflicts, and persists
@@ -329,6 +331,13 @@ Hermes runs, MCP calls, and UI evidence.
   shutdown failures as loop evidence; and always attempts process
   shutdown. It is still a port-first app boundary, not a NestJS host or
   concrete binary.
+- `apps/workers` has a first executable-boundary entrypoint contract
+  above that loop. `createWorkerProcessEntrypoint` subscribes to typed
+  stop signals through an injected signal source, delegates waiting to an
+  injected sleeper, disposes signal subscriptions after shutdown, returns
+  success or degraded exit intent instead of calling `process.exit`, and
+  preserves the full loop result for telemetry, supervisor diagnosis, and
+  future Kubernetes/NestJS process wrappers.
 - `apps/workers` has an app-local Cockroach migration bootstrapper and
   Cockroach readiness probe. The bootstrapper reuses the generic
   Cockroach migration runner and ordered core migrations; the readiness
@@ -350,11 +359,12 @@ Hermes runs, MCP calls, and UI evidence.
   When both `AGENTIC_ORG_COCKROACH_INTEGRATION_DATABASE_URL` and
   `AGENTIC_ORG_NATS_INTEGRATION_SERVERS` are present, the test writes a
   real `send_supervisor_signal` command outcome to Cockroach, runs the
-  process worker cycle, publishes the durable outbox event to NATS,
-  consumes it through the NATS consumer, records the inbox receipt and
-  supervisor-triage reaction plan in Cockroach, captures worker/NATS
-  telemetry records, and shuts down both adapters through generic
-  process shutdown ports.
+  process worker loop for two cycles, publishes the durable outbox event
+  to NATS, consumes it through the NATS consumer, records the inbox
+  receipt and supervisor-triage reaction plan in Cockroach, captures
+  worker/NATS telemetry records, proves the second cycle has no duplicate
+  side effects, and shuts down both adapters through generic process
+  shutdown ports or guarded cleanup.
 - Worker-cycle failures can carry structured evidence. Stale outbox
   claim failures now preserve claim ID, current claim ID, outbox event
   ID, event ID, trace ID, and published-at evidence when the durable row
@@ -389,12 +399,12 @@ env-gated: when a JetStream server is supplied, the same test command
 proves publish, consume, ack, invalid-envelope DLQ handling, readiness,
 and shutdown through the app-local NATS seam. The combined durable
 worker proof now ties both together when both env vars are present. The
-first long-running worker loop wrapper now exists as a port-first
-contract. Next is the concrete executable entrypoint that binds process
-signals and delay policy to that loop, then the next command surface
-slice. Keep URLs, credentials, and connection pools in app adapter
-config fed by Kubernetes Secret or ExternalSecret values, never in
-domain packages.
+first long-running worker loop wrapper and executable-boundary
+entrypoint now exist as port-first contracts. Next is the next command
+surface slice, then the concrete Node/NestJS host can wrap the same
+entrypoint with real process globals. Keep URLs, credentials, and
+connection pools in app adapter config fed by Kubernetes Secret or
+ExternalSecret values, never in domain packages.
 
 Do not make the next slice a pile of bespoke request commands. Build the
 generic supervisor triage lifecycle first, then let specialized

--- a/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
+++ b/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
@@ -240,9 +240,15 @@ telemetry sink. It now has an env-gated Cockroach integration harness
 for real migrations, readiness, transactions, rollback, and shutdown,
 plus an env-gated NATS integration harness for real JetStream publish,
 consume, ack, invalid-envelope DLQ handling, readiness, and shutdown. It
-still needs those live proofs wired into CI/dev-cluster execution, a
-combined Cockroach plus NATS durable worker proof, a long-running
-executable worker host, and cluster OTEL export wiring.
+now also has an env-gated combined Cockroach plus NATS durable worker
+proof: the test writes a real command outcome to Cockroach, runs the
+process through the worker loop for two cycles, publishes the outbox to
+NATS, consumes it back, records inbox and reaction-plan state, verifies
+the second cycle does not duplicate durable side effects, and guards
+NATS cleanup even when Cockroach setup fails. It still needs those live
+proofs wired into CI/dev-cluster execution, a concrete Node/NestJS
+process host around the existing entrypoint contract, and cluster OTEL
+export wiring.
 
 ### Command Surface Closure
 

--- a/agentic-organization/docs/PHASED_DEVELOPMENT_PLAN.md
+++ b/agentic-organization/docs/PHASED_DEVELOPMENT_PLAN.md
@@ -63,16 +63,22 @@ The current executable spine includes:
 - `apps/workers` process loop contract that repeatedly invokes the
   process lifecycle through injected delay, observer, and stop-signal
   ports, captures loop weak points, and always attempts shutdown.
+- `apps/workers` executable-boundary entrypoint contract that subscribes
+  to typed stop signals through an injected signal source, delegates wait
+  policy to an injected sleeper, returns success/degraded exit intent,
+  and disposes signal listeners after shutdown without using process
+  globals in reusable packages.
 - env-gated live substrate proofs for Cockroach, NATS, and the combined
   durable worker path that writes a command outcome to Cockroach,
   publishes the outbox through NATS, consumes it back, records durable
   inbox/reaction-plan state, emits telemetry, and shuts down generic
   process adapters.
 
-The next implementation slice after the loop wrapper is to add the
-concrete executable entrypoint that binds process signals and delay
-policy to the loop, then continue with the next generic
-command/work-anchor surfaces. Keep the live substrate checks gated by
+The next implementation slice after the entrypoint contract is to
+continue with the next generic command/work-anchor surfaces, then wrap
+the same entrypoint with a concrete Node/NestJS host when process
+globals and Kubernetes deployment concerns are ready. Keep the live
+substrate checks gated by
 environment until the team decides whether CI should provide Cockroach
 and NATS services.
 
@@ -820,9 +826,12 @@ infrastructure.
    health; Cockroach and NATS done. Telemetry readiness remains deferred
    until the sink has an external destination.
 10. Add a process lifecycle entrypoint contract only after factories are
-    contract-tested; done as `createWorkerProcess`. A real long-running
-    executable worker host remains a later adapter step.
-11. Add an early full-ai-cluster contract checkpoint without deployment
+    contract-tested; done as `createWorkerProcess`.
+11. Add a loop-bound executable entrypoint contract that binds signal,
+    delay, observer, and exit-intent concerns through ports; done as
+    `createWorkerProcessEntrypoint`. A concrete Node/NestJS process host
+    remains a later adapter step.
+12. Add an early full-ai-cluster contract checkpoint without deployment
     YAML:
     - required env names;
     - Secret/ExternalSecret names;
@@ -2700,20 +2709,23 @@ Build:
 - compose the durable worker runtime from Cockroach executor, NATS
   publisher, NATS pull consumer, DLQ publisher, and telemetry sink ports;
   done;
-- run one worker process cycle through bootstrap, readiness, runtime,
-  and shutdown; done;
+- run the worker process through the process loop for two cycles,
+  including bootstrap, readiness, runtime, loop summary, and shutdown
+  evidence; done;
 - prove outbox publication to NATS and durable `published_at` marking;
   done when both live substrates are supplied;
 - prove NATS consumption, ack, Cockroach inbox receipt, and
   supervisor-triage reaction-plan persistence; done when both live
   substrates are supplied;
-- clean up per-run Cockroach rows and NATS resources; done.
+- clean up per-run Cockroach rows and NATS resources through guarded
+  cleanup that still removes NATS resources if Cockroach setup fails;
+  done.
 
 Done when:
 
 - one Organization command can cross the real durable path from command
   state to outbox, NATS, inbox, reaction plan, telemetry, readiness, and
-  shutdown without reusable packages importing vendor clients;
+  loop evidence without reusable packages importing vendor clients;
 - local runs stay green without live services.
 
 ### PR 3.6: Worker Process Loop Wrapper
@@ -2742,6 +2754,33 @@ Done when:
   continuous operation;
 - tests prove the loop remains observable, stoppable, and safe to
   shut down even when dependencies fail.
+
+### PR 3.7: Worker Process Entrypoint Contract
+
+Status: implemented as a fake-driven app-local contract. It still does
+not construct Cockroach, NATS, NestJS, Kubernetes, or telemetry
+exporters.
+
+Build:
+
+- add `createWorkerProcessEntrypoint` above `createWorkerProcessLoop`;
+  done;
+- subscribe to typed stop signals through an injected signal source;
+  done for `SIGINT` and `SIGTERM`;
+- delegate wait policy to an injected sleeper instead of using timers
+  directly; done;
+- map completed or stopped loop results to success exit intent and
+  degraded loop results to degraded exit intent; done;
+- always dispose signal subscriptions after loop shutdown; done;
+- preserve received signals and the full loop result for telemetry,
+  supervisor diagnosis, and future Kubernetes/NestJS wrappers; done.
+
+Done when:
+
+- a concrete Node or NestJS host can wrap the entrypoint without
+  changing worker lifecycle, loop, or runtime packages;
+- tests prove signal-driven stop, degraded exit mapping, delay failure
+  evidence, and listener disposal.
 
 ### PR 4: Generic Command Registry
 

--- a/agentic-organization/docs/TECHNICAL_CA_PACKAGE_ARCHITECTURE.md
+++ b/agentic-organization/docs/TECHNICAL_CA_PACKAGE_ARCHITECTURE.md
@@ -382,6 +382,17 @@ while preserving completed iteration results. This gives the future
 worker binary a small, testable always-on control loop without turning
 the app host into business logic.
 
+The first executable-boundary entrypoint contract now exists in
+`apps/workers/src/worker-process-entrypoint.ts`. It sits above the
+continuous loop and owns only executable concerns: subscribing to typed
+stop signals, delegating wait policy to a sleeper port, returning
+success/degraded exit intent, preserving received signal evidence, and
+disposing subscriptions after shutdown. It deliberately does not call
+`process.exit`, construct timers directly, or reach into Node process
+globals; a future Node or NestJS host can adapt real `process.on`,
+`setTimeout`, Kubernetes lifecycle hooks, and pod termination behavior
+behind the same ports.
+
 The `apps/workers` composition root receives typed config plus
 already-constructed ports. This is the only place the worker process
 should know which concrete adapter implementation is being used. Domain,
@@ -433,14 +444,16 @@ both live substrate variables are present. It applies Cockroach
 migrations through the app bootstrapper, writes a real
 `send_supervisor_signal` command outcome through the generic command
 pipeline and Cockroach state-store factory, connects a per-run NATS
-stream/durable consumer through the app-local NATS seam, runs one worker
-process cycle, publishes the outbox event, consumes it back through the
-NATS consumer, records the inbox receipt and supervisor-triage reaction
-plan in Cockroach, emits worker/NATS telemetry records through the sink
-port, and shuts down both process adapters through generic shutdown
-ports. This is the first live proof that the durable command, outbox,
-NATS, inbox, reaction-plan, readiness, telemetry, and shutdown seams
-compose without letting vendor clients leak into reusable packages.
+stream/durable consumer through the app-local NATS seam, runs the worker
+process through the loop for two cycles, publishes the outbox event,
+consumes it back through the NATS consumer, records the inbox receipt
+and supervisor-triage reaction plan in Cockroach, proves the second
+cycle does not duplicate durable side effects, emits worker/NATS
+telemetry records through the sink port, and guards both Cockroach and
+NATS cleanup when setup fails. This is the first live proof that the
+durable command, outbox, NATS, inbox, reaction-plan, readiness,
+telemetry, loop, and cleanup seams compose without letting vendor
+clients leak into reusable packages.
 
 ## SOLID Rules
 
@@ -745,12 +758,14 @@ decodes canonical JSON envelopes and calls the runtime ingestion
 processor, but it owns JetStream-style decisions: ack processed and
 duplicate messages, terminate plus dead-letter invalid envelopes and
 payload conflicts, and negative-acknowledge transient ingestion
-failures. If dead-letter publishing or source-message termination
-fails, it records the failure, negative-acknowledges the source message
-for retry, and continues the fetched batch so one broken DLQ path cannot
-starve unrelated messages. This keeps runtime rules deterministic and
-transport-neutral while still making live NATS behavior testable before
-a Nest worker process exists.
+failures. If dead-letter publishing fails, it records the failure,
+negative-acknowledges the source message for retry, and continues the
+fetched batch. If dead-letter publishing succeeds but source-message
+termination fails, it records the failure and acknowledges the
+already-dead-lettered source message so a poison message is not
+redelivered after the DLQ side effect. This keeps runtime rules
+deterministic and transport-neutral while still making live NATS behavior
+testable before a Nest worker process exists.
 
 ### Stream and Consumer Manifests
 

--- a/agentic-organization/packages/messaging-nats/src/nats-jetstream-event-consumer.ts
+++ b/agentic-organization/packages/messaging-nats/src/nats-jetstream-event-consumer.ts
@@ -167,6 +167,8 @@ type TerminateWithDeadLetterInput = {
 };
 
 async function terminateWithDeadLetter(input: TerminateWithDeadLetterInput): Promise<void> {
+  let deadLetterPublished = false;
+
   try {
     await input.deadLetterPublisher.publish({
       sourceSubject: input.message.subject,
@@ -174,15 +176,39 @@ async function terminateWithDeadLetter(input: TerminateWithDeadLetterInput): Pro
       headers: input.message.headers,
       reason: input.reason,
     });
+    deadLetterPublished = true;
     input.result.deadLetteredCount += 1;
     await input.message.terminate();
     input.result.terminatedCount += 1;
   } catch {
     input.result.failedCount += 1;
+
+    if (deadLetterPublished) {
+      await acknowledgeDeadLetteredMessage({
+        message: input.message,
+        result: input.result,
+      });
+      return;
+    }
+
     await negativeAcknowledgeFailedMessage({
       message: input.message,
       result: input.result,
     });
+  }
+}
+
+type AcknowledgeDeadLetteredMessageInput = {
+  message: NatsJetStreamInboundMessage;
+  result: NatsJetStreamConsumeBatchResult;
+};
+
+async function acknowledgeDeadLetteredMessage(input: AcknowledgeDeadLetteredMessageInput): Promise<void> {
+  try {
+    await input.message.acknowledge();
+    input.result.acknowledgedCount += 1;
+  } catch {
+    input.result.failedCount += 1;
   }
 }
 

--- a/agentic-organization/packages/messaging-nats/test/nats-jetstream-event-consumer.test.ts
+++ b/agentic-organization/packages/messaging-nats/test/nats-jetstream-event-consumer.test.ts
@@ -156,7 +156,7 @@ describe("NATS JetStream event consumer", () => {
     equal(result.acknowledgedCount, 1);
   });
 
-  test("negative-acknowledges payload conflicts when message termination fails", async () => {
+  test("acknowledges payload conflicts when termination fails after dead-letter publication", async () => {
     const envelope = createEnvelope();
     const message = createRecordingInboundMessage({
       payload: JSON.stringify(envelope),
@@ -173,15 +173,13 @@ describe("NATS JetStream event consumer", () => {
       batchSize: 10,
     });
 
-    deepEqual(message.ackActions, [
-      NatsInboundMessageAckAction.Terminate,
-      NatsInboundMessageAckAction.NegativeAcknowledge,
-    ]);
+    deepEqual(message.ackActions, [NatsInboundMessageAckAction.Terminate, NatsInboundMessageAckAction.Acknowledge]);
     equal(result.payloadConflictCount, 1);
     equal(result.failedCount, 1);
     equal(result.deadLetteredCount, 1);
     equal(result.terminatedCount, 0);
-    equal(result.negativeAcknowledgedCount, 1);
+    equal(result.negativeAcknowledgedCount, 0);
+    equal(result.acknowledgedCount, 1);
     equal(deadLetterPublisher.messages.length, 1);
   });
 


### PR DESCRIPTION
## Summary

- add a port-first worker process entrypoint for signal handling, delay policy, listener disposal, and success/degraded exit intent
- harden the worker loop so stop-signal failures are captured as degraded evidence while shutdown still runs
- prevent NATS poison-message redelivery after a successful DLQ write by acknowledging when terminate fails post-DLQ
- update the durable live proof to exercise the process loop, guard cleanup, and document the current runtime boundary

## Validation

- `npm test` from `agentic-organization/` (`151` tests, `148` passed, `3` env-gated skipped)
- `npm run typecheck` from `agentic-organization/`
- `git diff --check origin/main...HEAD`

## Review

- Follow-up subagent review found no remaining blockers on correctness, SOLID, or north-star alignment.
