### PR TITLE
feat(agentic-org): generalize command outcomes

### DIFF
--- a/agentic-organization/apps/workers/README.md
+++ b/agentic-organization/apps/workers/README.md
@@ -39,6 +39,8 @@ Current duties:
 - run the NATS JetStream consumer adapter cycle;
 - run the process lifecycle repeatedly through a port-first loop wrapper
   when the future executable host needs continuous operation;
+- bind the process lifecycle loop to app-local signal, delay, observer,
+  and exit-intent ports without calling process globals directly;
 - pass configured NATS batch size, stream name, and durable consumer
   name into the adapter boundary;
 - emit worker-cycle and NATS-consumer batch telemetry records;
@@ -79,6 +81,12 @@ iteration, observer, delay, and shutdown failures as loop evidence, and
 always attempts process shutdown. It is still not a concrete binary or
 NestJS host; it is the testable continuous-run contract the binary will
 use.
+`createWorkerProcessEntrypoint` is the app-local executable-boundary
+contract above the loop. It subscribes to injected stop signals such as
+`SIGINT` and `SIGTERM`, delegates waiting to an injected sleeper, returns
+success/degraded exit intent, disposes signal subscriptions after the
+loop shuts down, and keeps the real Node process, NestJS host, or
+Kubernetes supervisor outside the reusable worker packages.
 
 ## Environment
 

--- a/agentic-organization/apps/workers/src/index.ts
+++ b/agentic-organization/apps/workers/src/index.ts
@@ -140,6 +140,20 @@ export {
   type WorkerProcessLoopStopSignal,
 } from "./worker-process-loop.ts";
 export {
+  WorkerEntrypointConfigErrorMessage,
+  WorkerEntrypointExitCode,
+  WorkerEntrypointSignalName,
+  createWorkerProcessEntrypoint,
+  type CreateWorkerProcessEntrypointInput,
+  type WorkerEntrypointSignalListener,
+  type WorkerEntrypointSignalSource,
+  type WorkerEntrypointSignalSubscription,
+  type WorkerEntrypointSleepInput,
+  type WorkerEntrypointSleeper,
+  type WorkerProcessEntrypoint,
+  type WorkerProcessEntrypointResult,
+} from "./worker-process-entrypoint.ts";
+export {
   CockroachMigrationStatement,
   createCockroachSqlExecutor,
   type CockroachAnySqlStatement,

--- a/agentic-organization/apps/workers/src/worker-process-entrypoint.ts
+++ b/agentic-organization/apps/workers/src/worker-process-entrypoint.ts
@@ -1,0 +1,186 @@
+import {
+  WorkerProcessLoopStatus,
+  createWorkerProcessLoop,
+  type WorkerProcessLoopDelay,
+  type WorkerProcessLoopObserver,
+  type WorkerProcessLoopRunResult,
+  type WorkerProcessLoopStopSignal,
+} from "./worker-process-loop.ts";
+import type { WorkerProcess } from "./worker-process.ts";
+
+export const WorkerEntrypointSignalName = {
+  Sigint: "SIGINT",
+  Sigterm: "SIGTERM",
+} as const;
+
+export type WorkerEntrypointSignalName =
+  (typeof WorkerEntrypointSignalName)[keyof typeof WorkerEntrypointSignalName];
+
+export const WorkerEntrypointExitCode = {
+  Success: 0,
+  Degraded: 1,
+} as const;
+
+export type WorkerEntrypointExitCode =
+  (typeof WorkerEntrypointExitCode)[keyof typeof WorkerEntrypointExitCode];
+
+export const WorkerEntrypointConfigErrorMessage = {
+  InvalidIterationDelayMs: "worker entrypoint iterationDelayMs must be a positive safe integer",
+} as const;
+
+export type WorkerEntrypointSignalListener = (signal: WorkerEntrypointSignalName) => void;
+
+export type WorkerEntrypointSignalSubscription = {
+  dispose: () => void;
+};
+
+export type WorkerEntrypointSignalSource = {
+  subscribe: (
+    signal: WorkerEntrypointSignalName,
+    listener: WorkerEntrypointSignalListener,
+  ) => WorkerEntrypointSignalSubscription;
+};
+
+export type WorkerEntrypointSleepInput = {
+  durationMs: number;
+  stopSignal: WorkerProcessLoopStopSignal;
+};
+
+export type WorkerEntrypointSleeper = {
+  sleep: (input: WorkerEntrypointSleepInput) => Promise<void>;
+};
+
+export type WorkerProcessEntrypoint = {
+  run: () => Promise<WorkerProcessEntrypointResult>;
+};
+
+export type WorkerProcessEntrypointResult = {
+  exitCode: WorkerEntrypointExitCode;
+  loopResult: WorkerProcessLoopRunResult;
+  receivedSignals: readonly WorkerEntrypointSignalName[];
+};
+
+export type CreateWorkerProcessEntrypointInput = {
+  process: WorkerProcess;
+  observer: WorkerProcessLoopObserver;
+  signalSource: WorkerEntrypointSignalSource;
+  sleeper: WorkerEntrypointSleeper;
+  iterationDelayMs: number;
+  maxCycles?: number | undefined;
+  signals?: readonly WorkerEntrypointSignalName[] | undefined;
+};
+
+const defaultWorkerEntrypointSignals = [
+  WorkerEntrypointSignalName.Sigint,
+  WorkerEntrypointSignalName.Sigterm,
+] as const;
+
+export function createWorkerProcessEntrypoint(
+  input: CreateWorkerProcessEntrypointInput,
+): WorkerProcessEntrypoint {
+  validateEntrypointInput(input);
+
+  return {
+    run: async () => await runWorkerProcessEntrypoint(input),
+  };
+}
+
+function validateEntrypointInput(input: CreateWorkerProcessEntrypointInput): void {
+  if (!Number.isSafeInteger(input.iterationDelayMs) || input.iterationDelayMs < 1) {
+    throw new Error(WorkerEntrypointConfigErrorMessage.InvalidIterationDelayMs);
+  }
+}
+
+async function runWorkerProcessEntrypoint(
+  input: CreateWorkerProcessEntrypointInput,
+): Promise<WorkerProcessEntrypointResult> {
+  const signalRegistration = createEntrypointStopSignalRegistration({
+    signalSource: input.signalSource,
+    signals: input.signals ?? defaultWorkerEntrypointSignals,
+  });
+
+  try {
+    const loopResult = await createWorkerProcessLoop({
+      process: input.process,
+      delay: createEntrypointLoopDelay({
+        iterationDelayMs: input.iterationDelayMs,
+        sleeper: input.sleeper,
+        stopSignal: signalRegistration.stopSignal,
+      }),
+      observer: input.observer,
+      stopSignal: signalRegistration.stopSignal,
+      maxCycles: input.maxCycles,
+    }).run();
+
+    return {
+      exitCode: resolveEntrypointExitCode(loopResult.status),
+      loopResult,
+      receivedSignals: signalRegistration.receivedSignals,
+    };
+  } finally {
+    signalRegistration.dispose();
+  }
+}
+
+type EntrypointStopSignalRegistration = {
+  stopSignal: WorkerProcessLoopStopSignal;
+  receivedSignals: readonly WorkerEntrypointSignalName[];
+  dispose: () => void;
+};
+
+type CreateEntrypointStopSignalRegistrationInput = {
+  signalSource: WorkerEntrypointSignalSource;
+  signals: readonly WorkerEntrypointSignalName[];
+};
+
+function createEntrypointStopSignalRegistration(
+  input: CreateEntrypointStopSignalRegistrationInput,
+): EntrypointStopSignalRegistration {
+  const receivedSignals: WorkerEntrypointSignalName[] = [];
+  const subscriptions = input.signals.map((signal) =>
+    input.signalSource.subscribe(signal, (receivedSignal) => {
+      receivedSignals.push(receivedSignal);
+    }),
+  );
+
+  return {
+    stopSignal: {
+      isStopRequested: () => receivedSignals.length > 0,
+    },
+    receivedSignals,
+    dispose: () => {
+      for (const subscription of subscriptions) {
+        subscription.dispose();
+      }
+    },
+  };
+}
+
+type CreateEntrypointLoopDelayInput = {
+  iterationDelayMs: number;
+  sleeper: WorkerEntrypointSleeper;
+  stopSignal: WorkerProcessLoopStopSignal;
+};
+
+function createEntrypointLoopDelay(input: CreateEntrypointLoopDelayInput): WorkerProcessLoopDelay {
+  return {
+    waitAfterIteration: async () => {
+      if (input.stopSignal.isStopRequested()) {
+        return;
+      }
+
+      await input.sleeper.sleep({
+        durationMs: input.iterationDelayMs,
+        stopSignal: input.stopSignal,
+      });
+    },
+  };
+}
+
+function resolveEntrypointExitCode(status: WorkerProcessLoopStatus): WorkerEntrypointExitCode {
+  if (status === WorkerProcessLoopStatus.Degraded) {
+    return WorkerEntrypointExitCode.Degraded;
+  }
+
+  return WorkerEntrypointExitCode.Success;
+}

--- a/agentic-organization/apps/workers/src/worker-process-loop.ts
+++ b/agentic-organization/apps/workers/src/worker-process-loop.ts
@@ -29,6 +29,7 @@ export const WorkerProcessLoopFailureStage = {
   Iteration: "iteration",
   Observer: "observer",
   Shutdown: "shutdown",
+  StopSignal: "stop_signal",
 } as const;
 
 export type WorkerProcessLoopFailureStage =
@@ -122,7 +123,11 @@ function validateWorkerProcessLoopInput(input: CreateWorkerProcessLoopInput): vo
 async function runWorkerProcessLoop(input: CreateWorkerProcessLoopInput): Promise<WorkerProcessLoopRunResult> {
   const iterations: WorkerProcessLoopIteration[] = [];
   const failures: WorkerProcessLoopFailure[] = [];
-  let stoppedBySignal = input.stopSignal.isStopRequested();
+  let stoppedBySignal = readStopSignal({
+    failures,
+    iteration: undefined,
+    stopSignal: input.stopSignal,
+  });
 
   while (!stoppedBySignal && !hasReachedMaxCycles(iterations.length, input.maxCycles)) {
     const iteration = iterations.length + 1;
@@ -133,7 +138,11 @@ async function runWorkerProcessLoop(input: CreateWorkerProcessLoopInput): Promis
     });
     iterations.push(iterationResult);
 
-    stoppedBySignal = input.stopSignal.isStopRequested();
+    stoppedBySignal = readStopSignal({
+      failures,
+      iteration,
+      stopSignal: input.stopSignal,
+    });
 
     if (stoppedBySignal || hasReachedMaxCycles(iterations.length, input.maxCycles)) {
       break;
@@ -145,7 +154,11 @@ async function runWorkerProcessLoop(input: CreateWorkerProcessLoopInput): Promis
       failures,
     });
 
-    stoppedBySignal = input.stopSignal.isStopRequested();
+    stoppedBySignal = readStopSignal({
+      failures,
+      iteration,
+      stopSignal: input.stopSignal,
+    });
 
     if (!delaySucceeded) {
       break;
@@ -169,6 +182,25 @@ async function runWorkerProcessLoop(input: CreateWorkerProcessLoopInput): Promis
     shutdown,
     failures,
   };
+}
+
+type ReadStopSignalInput = {
+  failures: WorkerProcessLoopFailure[];
+  iteration: number | undefined;
+  stopSignal: WorkerProcessLoopStopSignal;
+};
+
+function readStopSignal(input: ReadStopSignalInput): boolean {
+  try {
+    return input.stopSignal.isStopRequested();
+  } catch (error) {
+    input.failures.push({
+      stage: WorkerProcessLoopFailureStage.StopSignal,
+      iteration: input.iteration,
+      message: extractLoopErrorMessage(error),
+    });
+    return true;
+  }
 }
 
 type RunWorkerProcessIterationInput = {

--- a/agentic-organization/apps/workers/test/durable-worker-composition.test.ts
+++ b/agentic-organization/apps/workers/test/durable-worker-composition.test.ts
@@ -53,14 +53,9 @@ describe("durable worker runtime composition", () => {
     const workerCycle = await ports.organizationWorkerHost.runOnce();
 
     equal(workerCycle.status, WorkerCycleStatus.Worked);
-    deepEqual(cockroachExecutor.statementNames, [
-      "claim_unpublished_outbox_events",
-      "mark_outbox_event_published",
-      "find_inbox_receipt",
-      "claim_pending_inbox_receipt",
-      "insert_reaction_plan",
-      "mark_inbox_receipt_processed",
-    ]);
+    equal(workerCycle.outbox?.publishedOutboxEventIds.length, 1);
+    equal(workerCycle.inbound.processedCount, 1);
+    equal(workerCycle.inbound.reactionPlanCount, 1);
     deepEqual(
       eventPublisher.publications.map((publication) => publication.subject),
       ["agentic-org.dev.org-lfg.supervisor_signal.sent"],

--- a/agentic-organization/apps/workers/test/durable-worker-live-integration.test.ts
+++ b/agentic-organization/apps/workers/test/durable-worker-live-integration.test.ts
@@ -28,7 +28,7 @@ import {
   createSendSupervisorSignalHandler,
   CommandResultStatus,
   type CommandResult,
-  type PipelineCommand,
+  type SendSupervisorSignalCommand,
 } from "../../../packages/application/src/index.ts";
 import {
   AgenticMessagingDomain,
@@ -381,7 +381,7 @@ function shouldSkipDurableLiveIntegration(): string | false {
   return false;
 }
 
-function createSupervisorSignalCommand(run: DurableLiveIntegrationRun): PipelineCommand {
+function createSupervisorSignalCommand(run: DurableLiveIntegrationRun): SendSupervisorSignalCommand {
   return {
     commandId: run.commandId,
     type: CommandType.SendSupervisorSignal,
@@ -392,18 +392,24 @@ function createSupervisorSignalCommand(run: DurableLiveIntegrationRun): Pipeline
     traceId: `${DurableLiveIntegrationIdPrefix.Trace}-${run.runId}`,
     organizationId: run.organizationId,
     projectId: `${DurableLiveIntegrationIdPrefix.Project}-${run.runId}`,
-    teamId: `${DurableLiveIntegrationIdPrefix.Team}-${run.runId}`,
-    sourceLevel: SupervisorChainLevel.TeamMember,
-    targetLevel: SupervisorChainLevel.Manager,
     targetHatAssignmentId: `${DurableLiveIntegrationIdPrefix.ManagerHatAssignment}-${run.runId}`,
     actor: {
       agentId: `${DurableLiveIntegrationIdPrefix.Agent}-${run.runId}`,
       hatAssignmentId: `${DurableLiveIntegrationIdPrefix.HatAssignment}-${run.runId}`,
     },
-    toolType: SupervisorSignalToolType.ReportBlocker,
     title: DurableLiveIntegrationStaticName.RequestTitle,
     message: DurableLiveIntegrationStaticName.RequestMessage,
-    relatedWorkItemId: `${DurableLiveIntegrationIdPrefix.WorkItem}-${run.runId}`,
+    policyContext: {
+      scope: {
+        teamId: `${DurableLiveIntegrationIdPrefix.Team}-${run.runId}`,
+        workItemId: `${DurableLiveIntegrationIdPrefix.WorkItem}-${run.runId}`,
+      },
+      toolType: SupervisorSignalToolType.ReportBlocker,
+      supervisorChain: {
+        sourceLevel: SupervisorChainLevel.TeamMember,
+        targetLevel: SupervisorChainLevel.Manager,
+      },
+    },
   };
 }
 

--- a/agentic-organization/apps/workers/test/durable-worker-live-integration.test.ts
+++ b/agentic-organization/apps/workers/test/durable-worker-live-integration.test.ts
@@ -51,6 +51,7 @@ import {
   WorkerDependencyName,
   WorkerDependencyReadinessStatus,
   WorkerProcessShutdownStatus,
+  WorkerProcessLoopStatus,
   WorkerReadinessStatus,
   WorkerRuntimeStatus,
   composeDurableWorkerRuntimePorts,
@@ -62,9 +63,11 @@ import {
   createNatsJsTransportConnectionFactory,
   createPgCockroachWorkerPool,
   createWorkerProcess,
+  createWorkerProcessLoop,
   createWorkerRuntime,
   connectNatsWorkerAdapters,
   type CockroachAnySqlStatement,
+  type WorkerProcessLoopRecord,
   type WorkerRuntimeTelemetryRecord,
 } from "../src/index.ts";
 
@@ -141,23 +144,25 @@ describe("durable worker live integration", () => {
       const databaseUrl = readIntegrationDatabaseUrl();
       const natsServers = readIntegrationNatsServers();
       const run = createDurableLiveIntegrationRun();
-      await recreateNatsIntegrationSubstrate(natsServers, run);
-
-      const pool = await createPgCockroachWorkerPool({
-        databaseUrl,
-      });
-      const sqlClient = createCockroachWorkerSqlClient({
-        pool,
-        maxTransactionAttempts: 2,
-      });
-      const executor = createCockroachSqlExecutor({
-        client: sqlClient,
-      });
       const telemetrySink = createRecordingTelemetrySink();
+      let executor: ReturnType<typeof createCockroachSqlExecutor> | undefined;
       let natsAdapters: Awaited<ReturnType<typeof connectNatsWorkerAdapters>> | undefined;
-      let process: ReturnType<typeof createWorkerProcess> | undefined;
+      let pool: Awaited<ReturnType<typeof createPgCockroachWorkerPool>> | undefined;
 
       try {
+        await recreateNatsIntegrationSubstrate(natsServers, run);
+
+        pool = await createPgCockroachWorkerPool({
+          databaseUrl,
+        });
+        const sqlClient = createCockroachWorkerSqlClient({
+          pool,
+          maxTransactionAttempts: 2,
+        });
+        executor = createCockroachSqlExecutor({
+          client: sqlClient,
+        });
+
         await createCockroachMigrationBootstrapper({
           executor,
         }).bootstrap();
@@ -221,7 +226,7 @@ describe("durable worker live integration", () => {
             now: () => DurableLiveIntegrationTime.OccurredAt,
           },
         });
-        process = createWorkerProcess({
+        const process = createWorkerProcess({
           bootstrappers: [
             createCockroachMigrationBootstrapper({
               executor,
@@ -245,16 +250,26 @@ describe("durable worker live integration", () => {
             natsEventConsumer: runtimePorts.natsEventConsumer,
             telemetrySink,
           }),
-          shutdownPorts: [
-            natsAdapters.shutdown,
-            createCockroachWorkerShutdownPort({
-              pool,
-            }),
-          ],
+          shutdownPorts: [],
         });
 
-        const processResult = await process.runOnce();
+        const loopObserver = createRecordingLoopObserver();
+        const loopResult = await createWorkerProcessLoop({
+          process,
+          delay: {
+            waitAfterIteration: async () => undefined,
+          },
+          observer: loopObserver,
+          stopSignal: createManualStopSignal(),
+          maxCycles: 2,
+        }).run();
 
+        const processResult = loopResult.iterations[0]?.processResult;
+
+        equal(loopResult.iterations.length, 2);
+        equal(loopResult.status, WorkerProcessLoopStatus.Completed);
+        equal(loopResult.shutdown.status, WorkerProcessShutdownStatus.Completed);
+        ok(processResult);
         equal(processResult.status, WorkerRuntimeStatus.Healthy);
         equal(processResult.readiness?.status, WorkerReadinessStatus.Ready);
         deepEqual(
@@ -295,23 +310,28 @@ describe("durable worker live integration", () => {
         ok(reactionPlanRow?.reaction_plan_id.startsWith(`reaction-plan-${run.runId}`));
         equal(reactionPlanRow?.trigger_event_id, run.eventId);
         equal(reactionPlanRow?.status, ReactionPlanStatus.Planned);
-        equal(telemetrySink.records.length, 2);
+        equal(telemetrySink.records.length, 4);
+        equal(loopObserver.records.length, 3);
       } finally {
-        await cleanupCockroachRowsBestEffort(executor, run);
-
-        if (process !== undefined) {
-          const shutdownResult = await process.shutdown();
-
-          equal(shutdownResult.status, WorkerProcessShutdownStatus.Completed);
-        } else {
-          if (natsAdapters !== undefined) {
-            await natsAdapters.shutdown.shutdown();
+        try {
+          if (executor !== undefined) {
+            await cleanupCockroachRowsBestEffort(executor, run);
           }
+        } finally {
+          try {
+            if (natsAdapters !== undefined) {
+              await natsAdapters.shutdown.shutdown();
+            }
 
-          await pool.end();
+            if (pool !== undefined) {
+              await createCockroachWorkerShutdownPort({
+                pool,
+              }).shutdown();
+            }
+          } finally {
+            await cleanupNatsIntegrationSubstrate(natsServers, run);
+          }
         }
-
-        await cleanupNatsIntegrationSubstrate(natsServers, run);
       }
     },
   );
@@ -631,6 +651,28 @@ function createRecordingTelemetrySink(): {
     record: async (record) => {
       records.push(record);
     },
+  };
+}
+
+function createRecordingLoopObserver(): {
+  records: WorkerProcessLoopRecord[];
+  record: (record: WorkerProcessLoopRecord) => Promise<void>;
+} {
+  const records: WorkerProcessLoopRecord[] = [];
+
+  return {
+    records,
+    record: async (record) => {
+      records.push(record);
+    },
+  };
+}
+
+function createManualStopSignal(): {
+  isStopRequested: () => boolean;
+} {
+  return {
+    isStopRequested: () => false,
   };
 }
 

--- a/agentic-organization/apps/workers/test/worker-process-entrypoint.test.ts
+++ b/agentic-organization/apps/workers/test/worker-process-entrypoint.test.ts
@@ -1,0 +1,236 @@
+import { deepEqual, equal } from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  WorkerEntrypointExitCode,
+  WorkerEntrypointSignalName,
+  WorkerProcessLoopEventName,
+  WorkerProcessLoopStatus,
+  WorkerProcessLoopFailureStage,
+  WorkerProcessShutdownStatus,
+  WorkerRuntimeStatus,
+  createWorkerProcessEntrypoint,
+  type WorkerEntrypointSignalListener,
+  type WorkerEntrypointSignalSource,
+  type WorkerEntrypointSleeper,
+  type WorkerProcess,
+  type WorkerProcessLoopObserver,
+  type WorkerProcessLoopRecord,
+  type WorkerProcessRunResult,
+  type WorkerProcessShutdownResult,
+} from "../src/index.ts";
+
+const WorkerProcessEntrypointTestValue = {
+  DelayMs: 25,
+  SleepFailureMessage: "sleep unavailable",
+} as const;
+
+describe("worker process entrypoint", () => {
+  test("registers stop signals, runs the loop, disposes listeners, and maps a clean bounded run to success", async () => {
+    const signalSource = createRecordingSignalSource();
+    const observer = createRecordingLoopObserver();
+    const entrypoint = createWorkerProcessEntrypoint({
+      process: createRecordingProcess([createRunResult(WorkerRuntimeStatus.Healthy)]),
+      observer,
+      signalSource,
+      sleeper: createRecordingSleeper(),
+      iterationDelayMs: WorkerProcessEntrypointTestValue.DelayMs,
+      maxCycles: 1,
+    });
+
+    const result = await entrypoint.run();
+
+    equal(result.exitCode, WorkerEntrypointExitCode.Success);
+    equal(result.loopResult.status, WorkerProcessLoopStatus.Completed);
+    deepEqual(signalSource.registeredSignals, [
+      WorkerEntrypointSignalName.Sigint,
+      WorkerEntrypointSignalName.Sigterm,
+    ]);
+    deepEqual(signalSource.disposedSignals, [
+      WorkerEntrypointSignalName.Sigint,
+      WorkerEntrypointSignalName.Sigterm,
+    ]);
+    deepEqual(
+      observer.records.map((record) => record.eventName),
+      [WorkerProcessLoopEventName.IterationCompleted, WorkerProcessLoopEventName.ShutdownCompleted],
+    );
+  });
+
+  test("stops gracefully when a registered signal is received during the delay window", async () => {
+    const signalSource = createRecordingSignalSource();
+    const process = createRecordingProcess([
+      createRunResult(WorkerRuntimeStatus.Healthy),
+      createRunResult(WorkerRuntimeStatus.Healthy),
+    ]);
+    const sleeper = createRecordingSleeper({
+      beforeSleep: () => {
+        signalSource.emit(WorkerEntrypointSignalName.Sigterm);
+      },
+    });
+    const entrypoint = createWorkerProcessEntrypoint({
+      process,
+      observer: createRecordingLoopObserver(),
+      signalSource,
+      sleeper,
+      iterationDelayMs: WorkerProcessEntrypointTestValue.DelayMs,
+      maxCycles: 5,
+    });
+
+    const result = await entrypoint.run();
+
+    equal(result.exitCode, WorkerEntrypointExitCode.Success);
+    equal(result.loopResult.status, WorkerProcessLoopStatus.Stopped);
+    equal(process.runCount, 1);
+    deepEqual(result.receivedSignals, [WorkerEntrypointSignalName.Sigterm]);
+    deepEqual(sleeper.sleepCalls, []);
+  });
+
+  test("maps degraded loop results to degraded exit intent without hiding loop evidence", async () => {
+    const entrypoint = createWorkerProcessEntrypoint({
+      process: createRecordingProcess([createRunResult(WorkerRuntimeStatus.Degraded)]),
+      observer: createRecordingLoopObserver(),
+      signalSource: createRecordingSignalSource(),
+      sleeper: createRecordingSleeper(),
+      iterationDelayMs: WorkerProcessEntrypointTestValue.DelayMs,
+      maxCycles: 1,
+    });
+
+    const result = await entrypoint.run();
+
+    equal(result.exitCode, WorkerEntrypointExitCode.Degraded);
+    equal(result.loopResult.status, WorkerProcessLoopStatus.Degraded);
+    equal(result.loopResult.iterations[0]?.status, WorkerRuntimeStatus.Degraded);
+  });
+
+  test("captures delay failures as loop evidence and exits degraded", async () => {
+    const entrypoint = createWorkerProcessEntrypoint({
+      process: createRecordingProcess([
+        createRunResult(WorkerRuntimeStatus.Healthy),
+        createRunResult(WorkerRuntimeStatus.Healthy),
+      ]),
+      observer: createRecordingLoopObserver(),
+      signalSource: createRecordingSignalSource(),
+      sleeper: createFailingSleeper(WorkerProcessEntrypointTestValue.SleepFailureMessage),
+      iterationDelayMs: WorkerProcessEntrypointTestValue.DelayMs,
+      maxCycles: 2,
+    });
+
+    const result = await entrypoint.run();
+
+    equal(result.exitCode, WorkerEntrypointExitCode.Degraded);
+    deepEqual(result.loopResult.failures, [
+      {
+        stage: WorkerProcessLoopFailureStage.Delay,
+        iteration: 1,
+        message: WorkerProcessEntrypointTestValue.SleepFailureMessage,
+      },
+    ]);
+  });
+});
+
+type RecordingProcessStep = WorkerProcessRunResult;
+
+function createRecordingProcess(
+  steps: readonly RecordingProcessStep[],
+): WorkerProcess & {
+  readonly runCount: number;
+} {
+  let runCount = 0;
+
+  return {
+    get runCount() {
+      return runCount;
+    },
+    runOnce: async () => {
+      const step = steps[runCount] ?? createRunResult(WorkerRuntimeStatus.Healthy);
+      runCount += 1;
+      return step;
+    },
+    shutdown: async () => createShutdownResult(),
+  };
+}
+
+function createRunResult(status: WorkerRuntimeStatus): WorkerProcessRunResult {
+  return {
+    status,
+    readiness: undefined,
+    runtimeResult: undefined,
+    failures: [],
+  };
+}
+
+function createShutdownResult(): WorkerProcessShutdownResult {
+  return {
+    status: WorkerProcessShutdownStatus.Completed,
+    closedPortNames: [],
+    failures: [],
+  };
+}
+
+function createRecordingLoopObserver(): WorkerProcessLoopObserver & {
+  records: WorkerProcessLoopRecord[];
+} {
+  const records: WorkerProcessLoopRecord[] = [];
+
+  return {
+    records,
+    record: async (record) => {
+      records.push(record);
+    },
+  };
+}
+
+function createRecordingSignalSource(): WorkerEntrypointSignalSource & {
+  readonly disposedSignals: WorkerEntrypointSignalName[];
+  readonly registeredSignals: WorkerEntrypointSignalName[];
+  emit: (signal: WorkerEntrypointSignalName) => void;
+} {
+  const listeners = new Map<WorkerEntrypointSignalName, WorkerEntrypointSignalListener>();
+  const disposedSignals: WorkerEntrypointSignalName[] = [];
+  const registeredSignals: WorkerEntrypointSignalName[] = [];
+
+  return {
+    disposedSignals,
+    registeredSignals,
+    emit: (signal) => {
+      listeners.get(signal)?.(signal);
+    },
+    subscribe: (signal, listener) => {
+      registeredSignals.push(signal);
+      listeners.set(signal, listener);
+
+      return {
+        dispose: () => {
+          disposedSignals.push(signal);
+          listeners.delete(signal);
+        },
+      };
+    },
+  };
+}
+
+function createRecordingSleeper(options: { beforeSleep?: () => void } = {}): WorkerEntrypointSleeper & {
+  readonly sleepCalls: number[];
+} {
+  const sleepCalls: number[] = [];
+
+  return {
+    sleepCalls,
+    sleep: async (input) => {
+      options.beforeSleep?.();
+      if (input.stopSignal.isStopRequested()) {
+        return;
+      }
+
+      sleepCalls.push(input.durationMs);
+    },
+  };
+}
+
+function createFailingSleeper(message: string): WorkerEntrypointSleeper {
+  return {
+    sleep: async () => {
+      throw new Error(message);
+    },
+  };
+}

--- a/agentic-organization/apps/workers/test/worker-process-loop.test.ts
+++ b/agentic-organization/apps/workers/test/worker-process-loop.test.ts
@@ -22,6 +22,7 @@ const WorkerProcessLoopTestValue = {
   ObserverFailureMessage: "observer unavailable",
   ShutdownFailureMessage: "shutdown unavailable",
   ShutdownPortName: "test-shutdown",
+  StopSignalFailureMessage: "stop signal unavailable",
 } as const;
 
 describe("worker process loop", () => {
@@ -205,6 +206,30 @@ describe("worker process loop", () => {
       },
     ]);
   });
+
+  test("captures stop-signal failures, stops the loop, and still shuts down", async () => {
+    const process = createRecordingProcess([createRunResult(WorkerRuntimeStatus.Healthy)]);
+    const loop = createWorkerProcessLoop({
+      process,
+      delay: createRecordingDelay(),
+      observer: createRecordingLoopObserver(),
+      maxCycles: 1,
+      stopSignal: createFailingStopSignal(WorkerProcessLoopTestValue.StopSignalFailureMessage),
+    });
+
+    const result = await loop.run();
+
+    equal(result.status, WorkerProcessLoopStatus.Degraded);
+    equal(process.runCount, 0);
+    equal(process.shutdownCount, 1);
+    deepEqual(result.failures, [
+      {
+        stage: WorkerProcessLoopFailureStage.StopSignal,
+        iteration: undefined,
+        message: WorkerProcessLoopTestValue.StopSignalFailureMessage,
+      },
+    ]);
+  });
 });
 
 type RecordingProcessStep = WorkerProcessRunResult | Error;
@@ -314,6 +339,16 @@ function createManualStopSignal(): {
     isStopRequested: () => stopped,
     stop: () => {
       stopped = true;
+    },
+  };
+}
+
+function createFailingStopSignal(message: string): {
+  isStopRequested: () => boolean;
+} {
+  return {
+    isStopRequested: () => {
+      throw new Error(message);
     },
   };
 }

--- a/agentic-organization/docs/FIRST_IMPLEMENTATION_SLICE.md
+++ b/agentic-organization/docs/FIRST_IMPLEMENTATION_SLICE.md
@@ -79,7 +79,7 @@ escalate.
 
 | App            | Implemented first                                                                                                                                                                                       |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `apps/workers` | NodeNext runtime-host contract shell that parses process config, composes worker ports, exposes the bootstrap/readiness/shutdown lifecycle contract, runs worker/NATS cycles, emits telemetry, and reports status/shutdown evidence |
+| `apps/workers` | NodeNext runtime-host contract shell that parses process config, composes worker ports, exposes the bootstrap/readiness/shutdown lifecycle contract, runs worker/NATS cycles, emits telemetry, binds the loop to signal/delay ports, and reports status/shutdown evidence |
 
 ## NodeNext Runtime Decision
 
@@ -195,9 +195,11 @@ Hermes runs, MCP calls, and UI evidence.
   acknowledges processed and duplicate messages, terminates and
   dead-letters invalid envelopes or payload conflicts, and
   negative-acknowledges transient ingestion failures. If dead-letter
-  publication or source-message termination fails, it records the
-  failure, negative-acknowledges the source message, and continues the
-  batch.
+  publication fails, it records the failure, negative-acknowledges the
+  source message, and continues the batch. If dead-letter publication
+  succeeds but source-message termination fails, it records the failure
+  and acknowledges the already-dead-lettered source message so a poison
+  message is not redelivered after the DLQ side effect.
 - The event ingestion processor accepts decoded canonical envelopes,
   dedupes them by event ID plus consumer name, evaluates automation
   rules once, rejects same-event payload hash conflicts, and persists
@@ -329,6 +331,13 @@ Hermes runs, MCP calls, and UI evidence.
   shutdown failures as loop evidence; and always attempts process
   shutdown. It is still a port-first app boundary, not a NestJS host or
   concrete binary.
+- `apps/workers` has a first executable-boundary entrypoint contract
+  above that loop. `createWorkerProcessEntrypoint` subscribes to typed
+  stop signals through an injected signal source, delegates waiting to an
+  injected sleeper, disposes signal subscriptions after shutdown, returns
+  success or degraded exit intent instead of calling `process.exit`, and
+  preserves the full loop result for telemetry, supervisor diagnosis, and
+  future Kubernetes/NestJS process wrappers.
 - `apps/workers` has an app-local Cockroach migration bootstrapper and
   Cockroach readiness probe. The bootstrapper reuses the generic
   Cockroach migration runner and ordered core migrations; the readiness
@@ -350,11 +359,12 @@ Hermes runs, MCP calls, and UI evidence.
   When both `AGENTIC_ORG_COCKROACH_INTEGRATION_DATABASE_URL` and
   `AGENTIC_ORG_NATS_INTEGRATION_SERVERS` are present, the test writes a
   real `send_supervisor_signal` command outcome to Cockroach, runs the
-  process worker cycle, publishes the durable outbox event to NATS,
-  consumes it through the NATS consumer, records the inbox receipt and
-  supervisor-triage reaction plan in Cockroach, captures worker/NATS
-  telemetry records, and shuts down both adapters through generic
-  process shutdown ports.
+  process worker loop for two cycles, publishes the durable outbox event
+  to NATS, consumes it through the NATS consumer, records the inbox
+  receipt and supervisor-triage reaction plan in Cockroach, captures
+  worker/NATS telemetry records, proves the second cycle has no duplicate
+  side effects, and shuts down both adapters through generic process
+  shutdown ports or guarded cleanup.
 - Worker-cycle failures can carry structured evidence. Stale outbox
   claim failures now preserve claim ID, current claim ID, outbox event
   ID, event ID, trace ID, and published-at evidence when the durable row
@@ -389,12 +399,12 @@ env-gated: when a JetStream server is supplied, the same test command
 proves publish, consume, ack, invalid-envelope DLQ handling, readiness,
 and shutdown through the app-local NATS seam. The combined durable
 worker proof now ties both together when both env vars are present. The
-first long-running worker loop wrapper now exists as a port-first
-contract. Next is the concrete executable entrypoint that binds process
-signals and delay policy to that loop, then the next command surface
-slice. Keep URLs, credentials, and connection pools in app adapter
-config fed by Kubernetes Secret or ExternalSecret values, never in
-domain packages.
+first long-running worker loop wrapper and executable-boundary
+entrypoint now exist as port-first contracts. Next is the next command
+surface slice, then the concrete Node/NestJS host can wrap the same
+entrypoint with real process globals. Keep URLs, credentials, and
+connection pools in app adapter config fed by Kubernetes Secret or
+ExternalSecret values, never in domain packages.
 
 Do not make the next slice a pile of bespoke request commands. Build the
 generic supervisor triage lifecycle first, then let specialized

--- a/agentic-organization/docs/FIRST_IMPLEMENTATION_SLICE.md
+++ b/agentic-organization/docs/FIRST_IMPLEMENTATION_SLICE.md
@@ -64,7 +64,7 @@ escalate.
 | Package                        | Implemented first                                                                                                                                                     |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@agentic-org/domain`          | event envelope, command/event constants, aggregate constants, supervisor-chain communication types, hat communication briefs, work item state machine, shared records |
-| `@agentic-org/application`     | command pipeline, command-handler registry, state-store ports, idempotency conflict handling, supervisor signal handler                                               |
+| `@agentic-org/application`     | generic command pipeline, command-handler registry, state-store ports, idempotency conflict handling, generic command outcome artifacts/events, supervisor signal handler |
 | `@agentic-org/policy`          | command authorization port, hat-authority port, policy-decision observation/store/reader ports, active/expired/revoked/scope/tool denial decisions, typed reasons     |
 | `@agentic-org/state`           | generic state-store/outbox-source ports plus the in-memory Organization state-store factory fake                                                                      |
 | `@agentic-org/state-cockroach` | first replaceable durable SQL implementation of state-store, outbox-source, event-ingestion, and policy-observation ports, backed by CockroachDB                      |
@@ -153,14 +153,31 @@ Hermes runs, MCP calls, and UI evidence.
 - The command pipeline receives state-store factories and command
   handlers through ports instead of constructing in-memory adapters or
   branching on command types.
+- The command pipeline is now generic over Organization command
+  contracts. A second registered command type can pass through policy,
+  idempotency, handler dispatch, and outcome persistence without
+  changing pipeline internals. `send_supervisor_signal` remains the
+  first production command, not the command system's type boundary.
+- The generic command base carries a `policyContext` for optional
+  work-item scope, team scope, tool scope, and supervisor-chain context.
+  Domain payload fields such as signal title/message or future meeting
+  details stay with their command handlers.
 - Command handlers return typed effects; the command pipeline persists
-  the supervisor signal, audit events, outbox events, and idempotency
-  record through one `recordCommandOutcome` port. Handlers do not write
-  piecemeal state.
+  supervisor-signal effects, audit events, outbox events, and
+  idempotency record through one `recordCommandOutcome` port. Handlers
+  do not write piecemeal state. The durable effect vocabulary is still
+  deliberately narrow; the work-anchor kernel is the next slice that
+  will add the next business-effect category without changing the
+  command dispatch contract.
 - Command outcome persistence returns generic committed, replayed, or
   idempotency-conflict results. Durable adapters own idempotency race
   handling and return those generic outcomes without exposing duplicate
   key or vendor errors to application code.
+- Command results now expose generic, UI/MCP/agent-readable metadata:
+  command ID, domain artifacts, committed emitted-event summaries,
+  committed audit event IDs, policy decision evidence, idempotency
+  state, and optional typed compatibility records such as the first
+  supervisor signal artifact.
 - State-store and outbox-source ports are async from the beginning so
   durable SQL, NATS-backed workers, and other real adapters do not
   inherit a fake synchronous shape.

--- a/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
+++ b/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
@@ -240,9 +240,15 @@ telemetry sink. It now has an env-gated Cockroach integration harness
 for real migrations, readiness, transactions, rollback, and shutdown,
 plus an env-gated NATS integration harness for real JetStream publish,
 consume, ack, invalid-envelope DLQ handling, readiness, and shutdown. It
-still needs those live proofs wired into CI/dev-cluster execution, a
-combined Cockroach plus NATS durable worker proof, a long-running
-executable worker host, and cluster OTEL export wiring.
+now also has an env-gated combined Cockroach plus NATS durable worker
+proof: the test writes a real command outcome to Cockroach, runs the
+process through the worker loop for two cycles, publishes the outbox to
+NATS, consumes it back, records inbox and reaction-plan state, verifies
+the second cycle does not duplicate durable side effects, and guards
+NATS cleanup even when Cockroach setup fails. It still needs those live
+proofs wired into CI/dev-cluster execution, a concrete Node/NestJS
+process host around the existing entrypoint contract, and cluster OTEL
+export wiring.
 
 ### Command Surface Closure
 

--- a/agentic-organization/docs/PHASED_DEVELOPMENT_PLAN.md
+++ b/agentic-organization/docs/PHASED_DEVELOPMENT_PLAN.md
@@ -63,16 +63,22 @@ The current executable spine includes:
 - `apps/workers` process loop contract that repeatedly invokes the
   process lifecycle through injected delay, observer, and stop-signal
   ports, captures loop weak points, and always attempts shutdown.
+- `apps/workers` executable-boundary entrypoint contract that subscribes
+  to typed stop signals through an injected signal source, delegates wait
+  policy to an injected sleeper, returns success/degraded exit intent,
+  and disposes signal listeners after shutdown without using process
+  globals in reusable packages.
 - env-gated live substrate proofs for Cockroach, NATS, and the combined
   durable worker path that writes a command outcome to Cockroach,
   publishes the outbox through NATS, consumes it back, records durable
   inbox/reaction-plan state, emits telemetry, and shuts down generic
   process adapters.
 
-The next implementation slice after the loop wrapper is to add the
-concrete executable entrypoint that binds process signals and delay
-policy to the loop, then continue with the next generic
-command/work-anchor surfaces. Keep the live substrate checks gated by
+The next implementation slice after the entrypoint contract is to
+continue with the next generic command/work-anchor surfaces, then wrap
+the same entrypoint with a concrete Node/NestJS host when process
+globals and Kubernetes deployment concerns are ready. Keep the live
+substrate checks gated by
 environment until the team decides whether CI should provide Cockroach
 and NATS services.
 
@@ -820,9 +826,12 @@ infrastructure.
    health; Cockroach and NATS done. Telemetry readiness remains deferred
    until the sink has an external destination.
 10. Add a process lifecycle entrypoint contract only after factories are
-    contract-tested; done as `createWorkerProcess`. A real long-running
-    executable worker host remains a later adapter step.
-11. Add an early full-ai-cluster contract checkpoint without deployment
+    contract-tested; done as `createWorkerProcess`.
+11. Add a loop-bound executable entrypoint contract that binds signal,
+    delay, observer, and exit-intent concerns through ports; done as
+    `createWorkerProcessEntrypoint`. A concrete Node/NestJS process host
+    remains a later adapter step.
+12. Add an early full-ai-cluster contract checkpoint without deployment
     YAML:
     - required env names;
     - Secret/ExternalSecret names;
@@ -2700,20 +2709,23 @@ Build:
 - compose the durable worker runtime from Cockroach executor, NATS
   publisher, NATS pull consumer, DLQ publisher, and telemetry sink ports;
   done;
-- run one worker process cycle through bootstrap, readiness, runtime,
-  and shutdown; done;
+- run the worker process through the process loop for two cycles,
+  including bootstrap, readiness, runtime, loop summary, and shutdown
+  evidence; done;
 - prove outbox publication to NATS and durable `published_at` marking;
   done when both live substrates are supplied;
 - prove NATS consumption, ack, Cockroach inbox receipt, and
   supervisor-triage reaction-plan persistence; done when both live
   substrates are supplied;
-- clean up per-run Cockroach rows and NATS resources; done.
+- clean up per-run Cockroach rows and NATS resources through guarded
+  cleanup that still removes NATS resources if Cockroach setup fails;
+  done.
 
 Done when:
 
 - one Organization command can cross the real durable path from command
   state to outbox, NATS, inbox, reaction plan, telemetry, readiness, and
-  shutdown without reusable packages importing vendor clients;
+  loop evidence without reusable packages importing vendor clients;
 - local runs stay green without live services.
 
 ### PR 3.6: Worker Process Loop Wrapper
@@ -2742,6 +2754,33 @@ Done when:
   continuous operation;
 - tests prove the loop remains observable, stoppable, and safe to
   shut down even when dependencies fail.
+
+### PR 3.7: Worker Process Entrypoint Contract
+
+Status: implemented as a fake-driven app-local contract. It still does
+not construct Cockroach, NATS, NestJS, Kubernetes, or telemetry
+exporters.
+
+Build:
+
+- add `createWorkerProcessEntrypoint` above `createWorkerProcessLoop`;
+  done;
+- subscribe to typed stop signals through an injected signal source;
+  done for `SIGINT` and `SIGTERM`;
+- delegate wait policy to an injected sleeper instead of using timers
+  directly; done;
+- map completed or stopped loop results to success exit intent and
+  degraded loop results to degraded exit intent; done;
+- always dispose signal subscriptions after loop shutdown; done;
+- preserve received signals and the full loop result for telemetry,
+  supervisor diagnosis, and future Kubernetes/NestJS wrappers; done.
+
+Done when:
+
+- a concrete Node or NestJS host can wrap the entrypoint without
+  changing worker lifecycle, loop, or runtime packages;
+- tests prove signal-driven stop, degraded exit mapping, delay failure
+  evidence, and listener disposal.
 
 ### PR 4: Generic Command Registry
 

--- a/agentic-organization/docs/PHASED_DEVELOPMENT_PLAN.md
+++ b/agentic-organization/docs/PHASED_DEVELOPMENT_PLAN.md
@@ -899,23 +899,33 @@ pile of bespoke result types.
    - result artifact schema;
    - emitted event types;
    - required authority/tool;
-   - handler.
+   - handler. First code slice started for command type, generic handler
+     registration, explicit `policyContext`, result artifacts, emitted
+     events, and policy/idempotency flow; explicit schema metadata is
+     still pending, and durable business-effect categories remain
+     intentionally narrow until the work-anchor kernel lands.
 2. Refactor the existing `send_supervisor_signal` registration into the
-   generic registry.
+   generic registry. Done for handler registration and generic pipeline
+   execution.
 3. Normalize command outcome into:
    - status;
    - command ID;
    - idempotency status;
    - policy decision;
-   - emitted events;
-   - audit records;
+   - emitted events derived from committed outbox effects;
+   - audit records derived from committed audit effects;
    - domain artifacts;
-   - failure reason.
+   - failure reason. First code slice done with command ID, policy,
+     emitted event summaries, audit event IDs, artifacts, idempotency,
+     and typed error metadata.
 4. Keep command handlers returning effects, not writing concrete state.
-5. Add typed command error codes for validation, policy denial,
+5. Generalize durable command effects beyond supervisor signals once
+   the work-anchor kernel defines the next persistent business effect
+   category.
+6. Add typed command error codes for validation, policy denial,
    idempotency conflict, persistence conflict, and transient adapter
    failure.
-6. Add command metadata that can feed MCP tools, UI forms, and prompt
+7. Add command metadata that can feed MCP tools, UI forms, and prompt
    flow phase definitions later.
 
 ### Tests First
@@ -923,6 +933,7 @@ pile of bespoke result types.
 Write tests for:
 
 - registering multiple commands without changing pipeline code;
+  first executable test done;
 - unknown command rejection;
 - handler validation failure;
 - allowed policy path;
@@ -2786,14 +2797,18 @@ Done when:
 
 Build:
 
-- command contract registry;
-- generic command outcome;
-- refactor `send_supervisor_signal` into registry;
+- command contract registry; started with generic command base plus
+  handler registration, schema metadata pending;
+- generic command outcome; started with artifacts, emitted event
+  summaries, audit IDs, command ID, policy, idempotency, and errors;
+- refactor `send_supervisor_signal` into registry; done for execution
+  path while preserving compatibility fields;
 - OpenSpec command registry scenarios.
 
 Done when:
 
-- a second command can be added without changing pipeline internals.
+- a second command can be added without changing pipeline internals;
+  satisfied by the first generic pipeline test.
 
 ### PR 5: Work Anchor Kernel V0
 

--- a/agentic-organization/docs/TECHNICAL_CA_PACKAGE_ARCHITECTURE.md
+++ b/agentic-organization/docs/TECHNICAL_CA_PACKAGE_ARCHITECTURE.md
@@ -257,6 +257,17 @@ It must not instantiate the in-memory store or branch on every command
 type. New commands should register a handler; new persistence backends
 should implement the same store-factory port.
 
+The command pipeline is now generic over Organization command contracts.
+The shared command base owns only the policy/idempotency/trace fields:
+command ID, command type, request hash, idempotency key, actor,
+organization/project scope, correlation, causation, trace ID, and an
+optional generic `policyContext`. Command-specific payload stays with
+the handler. Supervisor-chain details, work-item scope, and tool scope
+are policy context, not pipeline payload assumptions. A second
+registered command type can execute through the same pipeline without
+adding a pipeline switch, which keeps future work-anchor, discussion,
+schedule, meeting, review, and Hermes-run commands open for extension.
+
 Policy remains a generic Organization package. The first implementation
 maps a `CommandAuthorizationRequest` to a `HatAuthorityPort` decision:
 active hat authority allows the command, while expired, missing,
@@ -281,9 +292,12 @@ adapter in the cluster, not an application-layer dependency.
 Command handlers must return typed effects, not write state directly.
 The command pipeline owns idempotency lookup and calls one command
 outcome port that records the business state, audit events, outbox
-events, and idempotency record together. This keeps the application
-layer closed to concrete database transactions while still giving
-durable adapters one atomic commit boundary for a command result.
+events, and idempotency record together. In V0, the only concrete
+business-effect category is the supervisor signal; the work-anchor
+kernel must add the next category without changing command dispatch or
+policy flow. This keeps the application layer closed to concrete
+database transactions while still giving durable adapters one atomic
+commit boundary for a command result.
 Durable command adapters should reserve the idempotency record before
 effect rows inside that transaction so an idempotency race aborts before
 supervisor signal, audit, or outbox state becomes visible.
@@ -291,6 +305,18 @@ The command outcome port returns generic committed, replayed, or
 idempotency-conflict results. A vendor adapter may use SQL constraints,
 transaction callbacks, CTEs, or other local mechanics to detect races,
 but application code only receives the generic outcome.
+
+Command outcomes are also generic enough for UI, MCP, and agents to
+consume without knowing every command-specific record. The common result
+surface carries status, command ID, idempotency state, policy evidence,
+artifact summaries, committed emitted-event summaries, committed audit
+event IDs, and typed failure information. The pipeline derives committed
+event/audit metadata from the effects it sends to the outcome port, so
+the result cannot describe different effects than the command attempted
+to persist. Compatibility fields such as `supervisorSignal` can remain
+while the first V0 screens and tests migrate, but new commands should
+expose their durable effects through the artifact and event metadata
+first.
 
 The first worker boundary follows the same rule. `@agentic-org/workers`
 does not create NATS clients, Cockroach clients, Nest modules, Temporal

--- a/agentic-organization/docs/TECHNICAL_CA_PACKAGE_ARCHITECTURE.md
+++ b/agentic-organization/docs/TECHNICAL_CA_PACKAGE_ARCHITECTURE.md
@@ -382,6 +382,17 @@ while preserving completed iteration results. This gives the future
 worker binary a small, testable always-on control loop without turning
 the app host into business logic.
 
+The first executable-boundary entrypoint contract now exists in
+`apps/workers/src/worker-process-entrypoint.ts`. It sits above the
+continuous loop and owns only executable concerns: subscribing to typed
+stop signals, delegating wait policy to a sleeper port, returning
+success/degraded exit intent, preserving received signal evidence, and
+disposing subscriptions after shutdown. It deliberately does not call
+`process.exit`, construct timers directly, or reach into Node process
+globals; a future Node or NestJS host can adapt real `process.on`,
+`setTimeout`, Kubernetes lifecycle hooks, and pod termination behavior
+behind the same ports.
+
 The `apps/workers` composition root receives typed config plus
 already-constructed ports. This is the only place the worker process
 should know which concrete adapter implementation is being used. Domain,
@@ -433,14 +444,16 @@ both live substrate variables are present. It applies Cockroach
 migrations through the app bootstrapper, writes a real
 `send_supervisor_signal` command outcome through the generic command
 pipeline and Cockroach state-store factory, connects a per-run NATS
-stream/durable consumer through the app-local NATS seam, runs one worker
-process cycle, publishes the outbox event, consumes it back through the
-NATS consumer, records the inbox receipt and supervisor-triage reaction
-plan in Cockroach, emits worker/NATS telemetry records through the sink
-port, and shuts down both process adapters through generic shutdown
-ports. This is the first live proof that the durable command, outbox,
-NATS, inbox, reaction-plan, readiness, telemetry, and shutdown seams
-compose without letting vendor clients leak into reusable packages.
+stream/durable consumer through the app-local NATS seam, runs the worker
+process through the loop for two cycles, publishes the outbox event,
+consumes it back through the NATS consumer, records the inbox receipt
+and supervisor-triage reaction plan in Cockroach, proves the second
+cycle does not duplicate durable side effects, emits worker/NATS
+telemetry records through the sink port, and guards both Cockroach and
+NATS cleanup when setup fails. This is the first live proof that the
+durable command, outbox, NATS, inbox, reaction-plan, readiness,
+telemetry, loop, and cleanup seams compose without letting vendor
+clients leak into reusable packages.
 
 ## SOLID Rules
 
@@ -745,12 +758,14 @@ decodes canonical JSON envelopes and calls the runtime ingestion
 processor, but it owns JetStream-style decisions: ack processed and
 duplicate messages, terminate plus dead-letter invalid envelopes and
 payload conflicts, and negative-acknowledge transient ingestion
-failures. If dead-letter publishing or source-message termination
-fails, it records the failure, negative-acknowledges the source message
-for retry, and continues the fetched batch so one broken DLQ path cannot
-starve unrelated messages. This keeps runtime rules deterministic and
-transport-neutral while still making live NATS behavior testable before
-a Nest worker process exists.
+failures. If dead-letter publishing fails, it records the failure,
+negative-acknowledges the source message for retry, and continues the
+fetched batch. If dead-letter publishing succeeds but source-message
+termination fails, it records the failure and acknowledges the
+already-dead-lettered source message so a poison message is not
+redelivered after the DLQ side effect. This keeps runtime rules
+deterministic and transport-neutral while still making live NATS behavior
+testable before a Nest worker process exists.
 
 ### Stream and Consumer Manifests
 

--- a/agentic-organization/packages/application/src/command-contract.ts
+++ b/agentic-organization/packages/application/src/command-contract.ts
@@ -1,0 +1,27 @@
+import type { AgenticActor } from "../../domain/src/index.ts";
+import type { CommandAuthorizationSupervisorChain } from "../../policy/src/index.ts";
+
+export type PipelineCommandPolicyScope = {
+  teamId?: string | undefined;
+  workItemId?: string | undefined;
+};
+
+export type PipelineCommandPolicyContext = {
+  scope?: PipelineCommandPolicyScope | undefined;
+  toolType?: string | undefined;
+  supervisorChain?: CommandAuthorizationSupervisorChain | undefined;
+};
+
+export type PipelineCommand = {
+  commandId: string;
+  type: string;
+  idempotencyKey: string;
+  requestHash: string;
+  correlationId: string;
+  causationId: string;
+  traceId: string;
+  organizationId: string;
+  projectId: string;
+  actor: AgenticActor;
+  policyContext?: PipelineCommandPolicyContext | undefined;
+};

--- a/agentic-organization/packages/application/src/command-handler-registry.ts
+++ b/agentic-organization/packages/application/src/command-handler-registry.ts
@@ -20,10 +20,14 @@ export type CommandHandlerRegistry<Command extends TypedCommand = TypedCommand, 
   resolveHandler: (commandType: Command["type"]) => CommandHandler<Command, Result> | undefined;
 };
 
+export type AnyCommandHandler<Command extends TypedCommand = TypedCommand, Result = unknown> = {
+  [CommandType in Command["type"]]: CommandHandler<Extract<Command, { type: CommandType }>, Result>;
+}[Command["type"]];
+
 export function createCommandHandlerRegistry<Command extends TypedCommand, Result>(
-  handlers: readonly CommandHandler<Command, Result>[],
+  handlers: readonly AnyCommandHandler<Command, Result>[],
 ): CommandHandlerRegistry<Command, Result> {
-  const handlersByCommandType = new Map<Command["type"], CommandHandler<Command, Result>>();
+  const handlersByCommandType = new Map<Command["type"], AnyCommandHandler<Command, Result>>();
 
   for (const handler of handlers) {
     if (handlersByCommandType.has(handler.commandType)) {
@@ -34,6 +38,6 @@ export function createCommandHandlerRegistry<Command extends TypedCommand, Resul
   }
 
   return {
-    resolveHandler: (commandType) => handlersByCommandType.get(commandType),
+    resolveHandler: (commandType) => handlersByCommandType.get(commandType) as CommandHandler<Command, Result> | undefined,
   };
 }

--- a/agentic-organization/packages/application/src/command-pipeline.ts
+++ b/agentic-organization/packages/application/src/command-pipeline.ts
@@ -1,6 +1,6 @@
 import type { CommandHandlerRegistry } from "./command-handler-registry.ts";
+import type { PipelineCommand } from "./command-contract.ts";
 import { CommandErrorCode, CommandResultStatus, type CommandResult } from "./command-result.ts";
-import type { SendSupervisorSignalCommand } from "./handlers/send-supervisor-signal.ts";
 import {
   PolicyDecisionObservationPersistenceStatus,
   PolicyDecisionStatus,
@@ -19,21 +19,21 @@ import {
   type IdGenerator,
 } from "./ports.ts";
 
-export type PipelineCommand = SendSupervisorSignalCommand;
-
-export type CommandPipeline = {
-  execute: (command: PipelineCommand) => Promise<CommandResult>;
+export type CommandPipeline<Command extends PipelineCommand = PipelineCommand> = {
+  execute: (command: Command) => Promise<CommandResult>;
 };
 
-export type CommandPipelineDependencies = Clock &
+export type CommandPipelineDependencies<Command extends PipelineCommand = PipelineCommand> = Clock &
   IdGenerator & {
     stateStoreFactory: CommandStateStoreFactory<CommandResult>;
     commandAuthorizationPort: CommandAuthorizationPort;
     policyDecisionObservationPort: PolicyDecisionObservationPort;
-    handlerRegistry: CommandHandlerRegistry<PipelineCommand, CommandResult>;
+    handlerRegistry: CommandHandlerRegistry<Command, CommandResult>;
   };
 
-export function createCommandPipeline(dependencies: CommandPipelineDependencies): CommandPipeline {
+export function createCommandPipeline<Command extends PipelineCommand = PipelineCommand>(
+  dependencies: CommandPipelineDependencies<Command>,
+): CommandPipeline<Command> {
   const store = dependencies.stateStoreFactory.createCommandStateStore();
 
   return {
@@ -41,10 +41,10 @@ export function createCommandPipeline(dependencies: CommandPipelineDependencies)
   };
 }
 
-async function executeCommand(
-  command: PipelineCommand,
+async function executeCommand<Command extends PipelineCommand>(
+  command: Command,
   store: CommandStateStore<CommandResult>,
-  dependencies: CommandPipelineDependencies,
+  dependencies: CommandPipelineDependencies<Command>,
 ): Promise<CommandResult> {
   const authorizationDecision = await dependencies.commandAuthorizationPort.authorizeCommand(
     createCommandAuthorizationRequest(command),
@@ -56,11 +56,13 @@ async function executeCommand(
         createPolicyDecisionObservation(command, authorizationDecision, dependencies.now()),
       );
       if (observationResult.status === PolicyDecisionObservationPersistenceStatus.Conflict) {
-        return createPolicyObservationConflictResult(authorizationDecision);
+        return createPolicyObservationConflictResult(command, authorizationDecision);
       }
     } catch {
       return {
+        commandId: command.commandId,
         status: CommandResultStatus.Rejected,
+        policy: createPolicyEvidence(authorizationDecision),
         idempotency: {
           replayed: false,
         },
@@ -76,7 +78,9 @@ async function executeCommand(
     }
 
     return {
+      commandId: command.commandId,
       status: CommandResultStatus.Rejected,
+      policy: createPolicyEvidence(authorizationDecision),
       idempotency: {
         replayed: false,
       },
@@ -102,12 +106,16 @@ async function executeCommand(
   }
 
   if (existingRecord) {
-    return createIdempotencyConflictResult();
+    return createIdempotencyConflictResult(command);
   }
 
   const outcome = await dispatchCommand(command, dependencies);
-  const effects =
+  const result =
     outcome.result.status === CommandResultStatus.Accepted
+      ? attachPolicyDecisionToResult(outcome.result, outcome.effects, authorizationDecision)
+      : outcome.result;
+  const effects =
+    result.status === CommandResultStatus.Accepted
       ? attachPolicyDecisionEvidence(outcome.effects, authorizationDecision)
       : createEmptyCommandEffects();
 
@@ -115,7 +123,7 @@ async function executeCommand(
     idempotencyRecord: {
       idempotencyKey: command.idempotencyKey,
       requestHash: command.requestHash,
-      result: outcome.result,
+      result,
     },
     effects,
   });
@@ -130,10 +138,10 @@ async function executeCommand(
   }
 
   if (persistenceResult.status === CommandOutcomePersistenceStatus.IdempotencyConflict) {
-    return createIdempotencyConflictResult();
+    return createIdempotencyConflictResult(command);
   }
 
-  return outcome.result;
+  return result;
 }
 
 function createCommandAuthorizationRequest(command: PipelineCommand): CommandAuthorizationRequest {
@@ -142,16 +150,9 @@ function createCommandAuthorizationRequest(command: PipelineCommand): CommandAut
     commandType: command.type,
     actor: command.actor,
     scope: {
-      organizationId: command.organizationId,
-      projectId: command.projectId,
-      teamId: command.teamId,
-      workItemId: command.relatedWorkItemId,
+      ...createCommandAuthorizationScope(command),
     },
-    toolType: command.toolType,
-    supervisorChain: {
-      sourceLevel: command.sourceLevel,
-      targetLevel: command.targetLevel,
-    },
+    ...createOptionalCommandPolicyContext(command),
     trace: {
       correlationId: command.correlationId,
       causationId: command.causationId,
@@ -171,16 +172,9 @@ function createPolicyDecisionObservation(
     commandType: command.type,
     actor: command.actor,
     scope: {
-      organizationId: command.organizationId,
-      projectId: command.projectId,
-      teamId: command.teamId,
-      workItemId: command.relatedWorkItemId,
+      ...createCommandAuthorizationScope(command),
     },
-    toolType: command.toolType,
-    supervisorChain: {
-      sourceLevel: command.sourceLevel,
-      targetLevel: command.targetLevel,
-    },
+    ...createOptionalCommandPolicyContext(command),
     trace: {
       correlationId: command.correlationId,
       causationId: command.causationId,
@@ -192,11 +186,50 @@ function createPolicyDecisionObservation(
   };
 }
 
-function attachPolicyDecisionEvidence(effects: CommandEffects, decision: PolicyDecision): CommandEffects {
-  const policy = {
-    decisionId: decision.decisionId,
-    policyVersion: decision.policyVersion,
+function createOptionalCommandPolicyContext(
+  command: PipelineCommand,
+): Pick<CommandAuthorizationRequest, "toolType" | "supervisorChain"> {
+  return {
+    ...(command.policyContext?.toolType === undefined ? {} : { toolType: command.policyContext.toolType }),
+    ...(command.policyContext?.supervisorChain === undefined
+      ? {}
+      : { supervisorChain: command.policyContext.supervisorChain }),
   };
+}
+
+function createCommandAuthorizationScope(command: PipelineCommand): CommandAuthorizationRequest["scope"] {
+  return {
+    organizationId: command.organizationId,
+    projectId: command.projectId,
+    ...(command.policyContext?.scope?.teamId === undefined ? {} : { teamId: command.policyContext.scope.teamId }),
+    ...(command.policyContext?.scope?.workItemId === undefined
+      ? {}
+      : { workItemId: command.policyContext.scope.workItemId }),
+  };
+}
+
+function attachPolicyDecisionToResult(
+  result: CommandResult,
+  effects: CommandEffects,
+  decision: PolicyDecision,
+): CommandResult {
+  const policy = createPolicyEvidence(decision);
+
+  return {
+    ...result,
+    policy,
+    emittedEvents: effects.outboxEvents.map((outboxEvent) => ({
+      eventId: outboxEvent.envelope.eventId,
+      eventType: outboxEvent.envelope.eventType,
+      aggregateId: outboxEvent.envelope.aggregate.aggregateId,
+      aggregateType: outboxEvent.envelope.aggregate.aggregateType,
+    })),
+    auditEventIds: effects.auditEvents.map((auditEvent) => auditEvent.auditEventId),
+  };
+}
+
+function attachPolicyDecisionEvidence(effects: CommandEffects, decision: PolicyDecision): CommandEffects {
+  const policy = createPolicyEvidence(decision);
 
   return {
     supervisorSignals: effects.supervisorSignals,
@@ -214,9 +247,9 @@ function attachPolicyDecisionEvidence(effects: CommandEffects, decision: PolicyD
   };
 }
 
-async function dispatchCommand(
-  command: PipelineCommand,
-  dependencies: CommandPipelineDependencies,
+async function dispatchCommand<Command extends PipelineCommand>(
+  command: Command,
+  dependencies: CommandPipelineDependencies<Command>,
 ): Promise<{ result: CommandResult; effects: CommandEffects }> {
   const handler = dependencies.handlerRegistry.resolveHandler(command.type);
 
@@ -226,6 +259,7 @@ async function dispatchCommand(
 
   return {
     result: {
+      commandId: command.commandId,
       status: CommandResultStatus.Rejected,
       idempotency: {
         replayed: false,
@@ -239,8 +273,9 @@ async function dispatchCommand(
   };
 }
 
-function createIdempotencyConflictResult(): CommandResult {
+function createIdempotencyConflictResult(command: PipelineCommand): CommandResult {
   return {
+    commandId: command.commandId,
     status: CommandResultStatus.Rejected,
     idempotency: {
       replayed: false,
@@ -252,9 +287,14 @@ function createIdempotencyConflictResult(): CommandResult {
   };
 }
 
-function createPolicyObservationConflictResult(decision: Extract<PolicyDecision, { status: "denied" }>): CommandResult {
+function createPolicyObservationConflictResult(
+  command: PipelineCommand,
+  decision: Extract<PolicyDecision, { status: "denied" }>,
+): CommandResult {
   return {
+    commandId: command.commandId,
     status: CommandResultStatus.Rejected,
+    policy: createPolicyEvidence(decision),
     idempotency: {
       replayed: false,
     },
@@ -266,6 +306,13 @@ function createPolicyObservationConflictResult(decision: Extract<PolicyDecision,
       reason: decision.reason,
       observationFailureReason: "policy_decision_observation_conflict",
     },
+  };
+}
+
+function createPolicyEvidence(decision: PolicyDecision): NonNullable<CommandResult["policy"]> {
+  return {
+    decisionId: decision.decisionId,
+    policyVersion: decision.policyVersion,
   };
 }
 

--- a/agentic-organization/packages/application/src/command-result.ts
+++ b/agentic-organization/packages/application/src/command-result.ts
@@ -1,4 +1,10 @@
-import type { SupervisorSignal, WorkItem } from "../../domain/src/index.ts";
+import type {
+  AgenticAggregateType,
+  AgenticEventType,
+  PolicyDecisionEvidence,
+  SupervisorSignal,
+  WorkItem,
+} from "../../domain/src/index.ts";
 import type { PolicyDenialReason } from "../../policy/src/index.ts";
 
 export const CommandResultStatus = {
@@ -18,8 +24,35 @@ export const CommandErrorCode = {
 
 export type CommandErrorCode = (typeof CommandErrorCode)[keyof typeof CommandErrorCode];
 
+export const CommandResultArtifactType = {
+  Generic: "generic",
+  SupervisorSignal: "supervisor_signal",
+  WorkItem: "work_item",
+} as const;
+
+export type CommandResultArtifactType =
+  (typeof CommandResultArtifactType)[keyof typeof CommandResultArtifactType];
+
+export type CommandResultArtifact = {
+  artifactType: CommandResultArtifactType | string;
+  artifactId: string;
+  label?: string;
+};
+
+export type CommandResultEmittedEvent = {
+  eventId: string;
+  eventType: AgenticEventType | string;
+  aggregateId: string;
+  aggregateType: AgenticAggregateType | string;
+};
+
 export type CommandResult = {
+  commandId?: string;
   status: CommandResultStatus;
+  artifacts?: readonly CommandResultArtifact[];
+  emittedEvents?: readonly CommandResultEmittedEvent[];
+  auditEventIds?: readonly string[];
+  policy?: PolicyDecisionEvidence;
   workItem?: WorkItem;
   supervisorSignal?: SupervisorSignal;
   idempotency: {

--- a/agentic-organization/packages/application/src/handlers/send-supervisor-signal.ts
+++ b/agentic-organization/packages/application/src/handlers/send-supervisor-signal.ts
@@ -3,7 +3,6 @@ import {
   AgenticEventType,
   CommandType,
   SupervisorSignalStatus,
-  type AgenticActor,
   type AuditEvent,
   type OutboxEvent,
   type SupervisorChainLevel,
@@ -12,7 +11,12 @@ import {
 } from "../../../domain/src/index.ts";
 import { createAgenticEventEnvelope } from "../../../domain/src/index.ts";
 import type { CommandHandler, CommandHandlerOutcome } from "../command-handler-registry.ts";
-import { CommandResultStatus, type CommandResult } from "../command-result.ts";
+import type { PipelineCommand } from "../command-contract.ts";
+import {
+  CommandResultArtifactType,
+  CommandResultStatus,
+  type CommandResult,
+} from "../command-result.ts";
 import type { Clock, IdGenerator } from "../ports.ts";
 
 export const IdPrefix = {
@@ -24,25 +28,24 @@ export const IdPrefix = {
 
 export type IdPrefix = (typeof IdPrefix)[keyof typeof IdPrefix];
 
-export type SendSupervisorSignalCommand = {
-  commandId: string;
-  type: typeof CommandType.SendSupervisorSignal;
-  idempotencyKey: string;
-  requestHash: string;
-  correlationId: string;
-  causationId: string;
-  traceId: string;
-  organizationId: string;
-  projectId: string;
-  teamId: string;
-  sourceLevel: SupervisorChainLevel;
-  targetLevel: SupervisorChainLevel;
-  targetHatAssignmentId: string;
-  actor: AgenticActor;
+export type SendSupervisorSignalPolicyContext = {
+  scope: {
+    teamId: string;
+    workItemId: string;
+  };
   toolType: SupervisorSignalToolType;
+  supervisorChain: {
+    sourceLevel: SupervisorChainLevel;
+    targetLevel: SupervisorChainLevel;
+  };
+};
+
+export type SendSupervisorSignalCommand = PipelineCommand & {
+  type: typeof CommandType.SendSupervisorSignal;
+  targetHatAssignmentId: string;
   title: string;
   message: string;
-  relatedWorkItemId: string;
+  policyContext: SendSupervisorSignalPolicyContext;
 };
 
 export type SendSupervisorSignalDependencies = Clock & IdGenerator;
@@ -59,20 +62,21 @@ export async function sendSupervisorSignal(
   dependencies: SendSupervisorSignalDependencies,
 ): Promise<CommandHandlerOutcome<CommandResult>> {
   const occurredAt = dependencies.now();
+  const signalContext = command.policyContext;
   const supervisorSignal: SupervisorSignal = {
     supervisorSignalId: dependencies.createId(IdPrefix.SupervisorSignal),
     organizationId: command.organizationId,
     projectId: command.projectId,
-    teamId: command.teamId,
-    sourceLevel: command.sourceLevel,
-    targetLevel: command.targetLevel,
+    teamId: signalContext.scope.teamId,
+    sourceLevel: signalContext.supervisorChain.sourceLevel,
+    targetLevel: signalContext.supervisorChain.targetLevel,
     targetHatAssignmentId: command.targetHatAssignmentId,
     sender: command.actor,
-    toolType: command.toolType,
+    toolType: signalContext.toolType,
     status: SupervisorSignalStatus.Sent,
     title: command.title,
     message: command.message,
-    relatedWorkItemId: command.relatedWorkItemId,
+    relatedWorkItemId: signalContext.scope.workItemId,
     createdAt: occurredAt,
   };
 
@@ -94,8 +98,8 @@ export async function sendSupervisorSignal(
       scope: {
         organizationId: command.organizationId,
         projectId: command.projectId,
-        teamId: command.teamId,
-        workItemId: command.relatedWorkItemId,
+        teamId: signalContext.scope.teamId,
+        workItemId: signalContext.scope.workItemId,
       },
       aggregate: {
         aggregateId: supervisorSignal.supervisorSignalId,
@@ -110,10 +114,10 @@ export async function sendSupervisorSignal(
         idempotencyKey: command.idempotencyKey,
       },
       payload: {
-        sourceLevel: command.sourceLevel,
-        targetLevel: command.targetLevel,
+        sourceLevel: signalContext.supervisorChain.sourceLevel,
+        targetLevel: signalContext.supervisorChain.targetLevel,
         targetHatAssignmentId: command.targetHatAssignmentId,
-        toolType: command.toolType,
+        toolType: signalContext.toolType,
         status: SupervisorSignalStatus.Sent,
         title: command.title,
       },
@@ -122,7 +126,24 @@ export async function sendSupervisorSignal(
 
   return {
     result: {
+      commandId: command.commandId,
       status: CommandResultStatus.Accepted,
+      artifacts: [
+        {
+          artifactType: CommandResultArtifactType.SupervisorSignal,
+          artifactId: supervisorSignal.supervisorSignalId,
+          label: supervisorSignal.title,
+        },
+      ],
+      emittedEvents: [
+        {
+          eventId: outboxEvent.envelope.eventId,
+          eventType: outboxEvent.envelope.eventType,
+          aggregateId: outboxEvent.envelope.aggregate.aggregateId,
+          aggregateType: outboxEvent.envelope.aggregate.aggregateType,
+        },
+      ],
+      auditEventIds: [auditEvent.auditEventId],
       supervisorSignal,
       idempotency: {
         replayed: false,

--- a/agentic-organization/packages/application/src/index.ts
+++ b/agentic-organization/packages/application/src/index.ts
@@ -7,12 +7,23 @@ export {
   type TypedCommand,
 } from "./command-handler-registry.ts";
 export {
+  type PipelineCommand,
+  type PipelineCommandPolicyContext,
+  type PipelineCommandPolicyScope,
+} from "./command-contract.ts";
+export {
   createCommandPipeline,
   type CommandPipeline,
   type CommandPipelineDependencies,
-  type PipelineCommand,
 } from "./command-pipeline.ts";
-export { CommandErrorCode, CommandResultStatus, type CommandResult } from "./command-result.ts";
+export {
+  CommandErrorCode,
+  CommandResultArtifactType,
+  CommandResultStatus,
+  type CommandResult,
+  type CommandResultArtifact,
+  type CommandResultEmittedEvent,
+} from "./command-result.ts";
 export {
   createSendSupervisorSignalHandler,
   sendSupervisorSignal,

--- a/agentic-organization/packages/application/test/command-pipeline.test.ts
+++ b/agentic-organization/packages/application/test/command-pipeline.test.ts
@@ -1,7 +1,14 @@
 import { deepEqual, equal } from "node:assert/strict";
 import { describe, test } from "node:test";
 
-import { CommandType, SupervisorChainLevel, SupervisorSignalToolType } from "../../domain/src/index.ts";
+import {
+  AgenticAggregateType,
+  AgenticEventType,
+  CommandType,
+  EventSchemaVersion,
+  SupervisorChainLevel,
+  SupervisorSignalToolType,
+} from "../../domain/src/index.ts";
 import {
   HatAuthorityDecisionStatus,
   PolicyDecisionObservationPersistenceStatus,
@@ -13,9 +20,18 @@ import {
 } from "../../policy/src/index.ts";
 import { createInMemoryOrganizationStoreFactory } from "../../state/src/index.ts";
 import { createCommandHandlerRegistry } from "../src/command-handler-registry.ts";
-import { CommandErrorCode, CommandResultStatus, type CommandResult } from "../src/command-result.ts";
-import { createCommandPipeline, type PipelineCommand } from "../src/command-pipeline.ts";
-import { createSendSupervisorSignalHandler } from "../src/handlers/send-supervisor-signal.ts";
+import {
+  CommandErrorCode,
+  CommandResultArtifactType,
+  CommandResultStatus,
+  type CommandResult,
+} from "../src/command-result.ts";
+import { createCommandPipeline } from "../src/command-pipeline.ts";
+import {
+  createSendSupervisorSignalHandler,
+  type SendSupervisorSignalCommand,
+} from "../src/handlers/send-supervisor-signal.ts";
+import type { PipelineCommand } from "../src/command-contract.ts";
 import {
   CommandOutcomePersistenceStatus,
   type CommandStateStore,
@@ -24,7 +40,7 @@ import {
   type RecordCommandOutcomeResult,
 } from "../src/ports.ts";
 
-const command: PipelineCommand = {
+const command: SendSupervisorSignalCommand = {
   commandId: "cmd-supervisor-signal-001",
   type: CommandType.SendSupervisorSignal,
   idempotencyKey: "idem-supervisor-signal-001",
@@ -34,21 +50,175 @@ const command: PipelineCommand = {
   traceId: "trace-supervisor-signal-001",
   organizationId: "org-lfg",
   projectId: "project-agentic-org",
-  teamId: "team-runtime",
-  sourceLevel: SupervisorChainLevel.TeamMember,
-  targetLevel: SupervisorChainLevel.Manager,
   targetHatAssignmentId: "hat-assignment-em-001",
   actor: {
     agentId: "agent-developer-001",
     hatAssignmentId: "hat-assignment-dev-001",
   },
-  toolType: SupervisorSignalToolType.ReportBlocker,
   title: "Blocked on scoped NATS publisher",
   message: "The team cannot validate the outbox worker until a supervisor routes a scoped NATS publisher decision.",
-  relatedWorkItemId: "work-outbox-001",
+  policyContext: {
+    scope: {
+      teamId: "team-runtime",
+      workItemId: "work-outbox-001",
+    },
+    toolType: SupervisorSignalToolType.ReportBlocker,
+    supervisorChain: {
+      sourceLevel: SupervisorChainLevel.TeamMember,
+      targetLevel: SupervisorChainLevel.Manager,
+    },
+  },
 };
 
+const ApplicationTestCommandType = {
+  RecordGenericArtifact: "test.record_generic_artifact",
+} as const;
+
+type RecordGenericArtifactCommand = PipelineCommand & {
+  type: typeof ApplicationTestCommandType.RecordGenericArtifact;
+  relatedWorkItemId?: string;
+};
+
+type OrganizationTestCommand = SendSupervisorSignalCommand | RecordGenericArtifactCommand;
+
 describe("command pipeline idempotency", () => {
+  test("executes heterogeneous command handlers from one runtime registry", async () => {
+    const genericCommand: RecordGenericArtifactCommand = {
+      commandId: "cmd-generic-artifact-mixed-001",
+      type: ApplicationTestCommandType.RecordGenericArtifact,
+      idempotencyKey: "idem-generic-artifact-mixed-001",
+      requestHash: "hash-generic-artifact-mixed-001",
+      correlationId: "corr-generic-artifact-mixed-001",
+      causationId: "cause-generic-artifact-mixed-001",
+      traceId: "trace-generic-artifact-mixed-001",
+      organizationId: "org-lfg",
+      projectId: "project-agentic-org",
+      actor: {
+        agentId: "agent-developer-001",
+        hatAssignmentId: "hat-assignment-dev-001",
+      },
+    };
+    const pipeline = createCommandPipeline<OrganizationTestCommand>({
+      stateStoreFactory: createRecordingCommandStateStoreFactory<CommandResult>(),
+      commandAuthorizationPort: createAllowingCommandAuthorizationPort(),
+      policyDecisionObservationPort: createRecordingPolicyDecisionObservationPort(),
+      handlerRegistry: createCommandHandlerRegistry<OrganizationTestCommand, CommandResult>([
+        createSendSupervisorSignalHandler(),
+        createGenericArtifactHandler(),
+      ]),
+      now: () => "2026-05-28T21:00:00.000Z",
+      createId: (prefix) => `${prefix}-001`,
+    });
+
+    const supervisorResult = await pipeline.execute(command);
+    const genericResult = await pipeline.execute(genericCommand);
+
+    equal(supervisorResult.status, CommandResultStatus.Accepted);
+    equal(supervisorResult.supervisorSignal?.supervisorSignalId, "supervisor-signal-001");
+    equal(genericResult.status, CommandResultStatus.Accepted);
+    deepEqual(genericResult.artifacts, [
+      {
+        artifactType: CommandResultArtifactType.Generic,
+        artifactId: "generic-artifact-001",
+        label: "Generic command artifact",
+      },
+    ]);
+  });
+
+  test("executes a second registered command type without changing pipeline internals", async () => {
+    const genericCommand: RecordGenericArtifactCommand = {
+      commandId: "cmd-generic-artifact-001",
+      type: ApplicationTestCommandType.RecordGenericArtifact,
+      idempotencyKey: "idem-generic-artifact-001",
+      requestHash: "hash-generic-artifact-001",
+      correlationId: "corr-generic-artifact-001",
+      causationId: "cause-generic-artifact-001",
+      traceId: "trace-generic-artifact-001",
+      organizationId: "org-lfg",
+      projectId: "project-agentic-org",
+      actor: {
+        agentId: "agent-developer-001",
+        hatAssignmentId: "hat-assignment-dev-001",
+      },
+    };
+    const commandAuthorizationPort = createAllowingCommandAuthorizationPort();
+    const pipeline = createCommandPipeline<RecordGenericArtifactCommand>({
+      stateStoreFactory: createRecordingCommandStateStoreFactory<CommandResult>(),
+      commandAuthorizationPort,
+      policyDecisionObservationPort: createRecordingPolicyDecisionObservationPort(),
+      handlerRegistry: createCommandHandlerRegistry([createGenericArtifactHandler()]),
+      now: () => "2026-05-28T21:00:00.000Z",
+      createId: (prefix) => `${prefix}-001`,
+    });
+
+    const result = await pipeline.execute(genericCommand);
+
+    equal(result.status, CommandResultStatus.Accepted);
+    equal(result.commandId, genericCommand.commandId);
+    deepEqual(result.artifacts, [
+      {
+        artifactType: CommandResultArtifactType.Generic,
+        artifactId: "generic-artifact-001",
+        label: "Generic command artifact",
+      },
+    ]);
+    deepEqual(result.emittedEvents, []);
+    deepEqual(commandAuthorizationPort.requests[0], {
+      commandId: genericCommand.commandId,
+      commandType: genericCommand.type,
+      actor: genericCommand.actor,
+      scope: {
+        organizationId: genericCommand.organizationId,
+        projectId: genericCommand.projectId,
+      },
+      trace: {
+        correlationId: genericCommand.correlationId,
+        causationId: genericCommand.causationId,
+        traceId: genericCommand.traceId,
+        idempotencyKey: genericCommand.idempotencyKey,
+      },
+    });
+  });
+
+  test("derives committed event and audit metadata from handler effects", async () => {
+    const genericCommand: RecordGenericArtifactCommand = {
+      commandId: "cmd-generic-artifact-002",
+      type: ApplicationTestCommandType.RecordGenericArtifact,
+      idempotencyKey: "idem-generic-artifact-002",
+      requestHash: "hash-generic-artifact-002",
+      correlationId: "corr-generic-artifact-002",
+      causationId: "cause-generic-artifact-002",
+      traceId: "trace-generic-artifact-002",
+      organizationId: "org-lfg",
+      projectId: "project-agentic-org",
+      actor: {
+        agentId: "agent-developer-001",
+        hatAssignmentId: "hat-assignment-dev-001",
+      },
+    };
+    const pipeline = createCommandPipeline<RecordGenericArtifactCommand>({
+      stateStoreFactory: createRecordingCommandStateStoreFactory<CommandResult>(),
+      commandAuthorizationPort: createAllowingCommandAuthorizationPort(),
+      policyDecisionObservationPort: createRecordingPolicyDecisionObservationPort(),
+      handlerRegistry: createCommandHandlerRegistry([createGenericArtifactHandlerWithEffects()]),
+      now: () => "2026-05-28T21:00:00.000Z",
+      createId: (prefix) => `${prefix}-001`,
+    });
+
+    const result = await pipeline.execute(genericCommand);
+
+    equal(result.status, CommandResultStatus.Accepted);
+    deepEqual(result.emittedEvents, [
+      {
+        eventId: "evt-committed-001",
+        eventType: AgenticEventType.WorkItemChanged,
+        aggregateId: "work-generic-artifact-002",
+        aggregateType: AgenticAggregateType.WorkItem,
+      },
+    ]);
+    deepEqual(result.auditEventIds, ["audit-committed-001"]);
+  });
+
   test("replaying the same idempotency key returns the stored result", async () => {
     const stateStoreFactory = createInMemoryOrganizationStoreFactory<CommandResult>();
     const pipeline = createCommandPipeline({
@@ -97,6 +267,7 @@ describe("command pipeline idempotency", () => {
 
     equal(firstResult.status, CommandResultStatus.Accepted);
     equal(conflictResult.status, CommandResultStatus.Rejected);
+    equal(conflictResult.commandId, command.commandId);
     equal(conflictResult.error?.code, CommandErrorCode.IdempotencyConflict);
     equal(stateStoreFactory.snapshot.supervisorSignals.length, 1);
     equal(stateStoreFactory.snapshot.outboxEvents.length, 1);
@@ -176,6 +347,7 @@ describe("command pipeline idempotency", () => {
     const result = await pipeline.execute(command);
 
     equal(result.status, CommandResultStatus.Rejected);
+    equal(result.commandId, command.commandId);
     equal(result.error?.code, CommandErrorCode.IdempotencyConflict);
     equal(stateStoreFactory.recordedOutcomes.length, 1);
   });
@@ -220,6 +392,11 @@ describe("command pipeline idempotency", () => {
     const result = await pipeline.execute(command);
 
     equal(result.status, CommandResultStatus.Rejected);
+    equal(result.commandId, command.commandId);
+    deepEqual(result.policy, {
+      decisionId: "policy-decision-denied-001",
+      policyVersion: "policy-v1",
+    });
     equal(result.error?.code, CommandErrorCode.PolicyDenied);
     equal(result.error?.policyDecisionId, "policy-decision-denied-001");
     equal(result.error?.policyVersion, "policy-v1");
@@ -232,13 +409,13 @@ describe("command pipeline idempotency", () => {
         scope: {
           organizationId: command.organizationId,
           projectId: command.projectId,
-          teamId: command.teamId,
-          workItemId: command.relatedWorkItemId,
+          teamId: command.policyContext.scope.teamId,
+          workItemId: command.policyContext.scope.workItemId,
         },
-        toolType: command.toolType,
+        toolType: command.policyContext.toolType,
         supervisorChain: {
-          sourceLevel: command.sourceLevel,
-          targetLevel: command.targetLevel,
+          sourceLevel: command.policyContext.supervisorChain.sourceLevel,
+          targetLevel: command.policyContext.supervisorChain.targetLevel,
         },
         trace: {
           correlationId: command.correlationId,
@@ -263,13 +440,13 @@ describe("command pipeline idempotency", () => {
       scope: {
         organizationId: command.organizationId,
         projectId: command.projectId,
-        teamId: command.teamId,
-        workItemId: command.relatedWorkItemId,
+        teamId: command.policyContext.scope.teamId,
+        workItemId: command.policyContext.scope.workItemId,
       },
-      toolType: command.toolType,
+      toolType: command.policyContext.toolType,
       supervisorChain: {
-        sourceLevel: command.sourceLevel,
-        targetLevel: command.targetLevel,
+        sourceLevel: command.policyContext.supervisorChain.sourceLevel,
+        targetLevel: command.policyContext.supervisorChain.targetLevel,
       },
       trace: {
         correlationId: command.correlationId,
@@ -298,6 +475,11 @@ describe("command pipeline idempotency", () => {
     const result = await pipeline.execute(command);
 
     equal(result.status, CommandResultStatus.Rejected);
+    equal(result.commandId, command.commandId);
+    deepEqual(result.policy, {
+      decisionId: "policy-decision-denied-001",
+      policyVersion: "policy-v1",
+    });
     equal(result.error?.code, CommandErrorCode.PolicyObservationFailed);
     equal(result.error?.policyDecisionId, "policy-decision-denied-001");
     equal(result.error?.observationFailureReason, "policy_decision_observation_unavailable");
@@ -323,6 +505,11 @@ describe("command pipeline idempotency", () => {
     const result = await pipeline.execute(command);
 
     equal(result.status, CommandResultStatus.Rejected);
+    equal(result.commandId, command.commandId);
+    deepEqual(result.policy, {
+      decisionId: "policy-decision-denied-001",
+      policyVersion: "policy-v1",
+    });
     equal(result.error?.code, CommandErrorCode.PolicyObservationConflict);
     equal(result.error?.policyDecisionId, "policy-decision-denied-001");
     equal(result.error?.observationFailureReason, "policy_decision_observation_conflict");
@@ -363,13 +550,22 @@ function createRecordingCommandStateStoreFactory<Result>(): RecordingCommandStat
   };
 }
 
-function createAllowingCommandAuthorizationPort(): CommandAuthorizationPort {
+function createAllowingCommandAuthorizationPort(): CommandAuthorizationPort & {
+  requests: CommandAuthorizationRequest[];
+} {
+  const requests: CommandAuthorizationRequest[] = [];
+
   return {
-    authorizeCommand: async () => ({
-      status: PolicyDecisionStatus.Allowed,
-      decisionId: "policy-decision-allow-001",
-      policyVersion: "policy-v1",
-    }),
+    requests,
+    authorizeCommand: async (request) => {
+      requests.push(request);
+
+      return {
+        status: PolicyDecisionStatus.Allowed,
+        decisionId: "policy-decision-allow-001",
+        policyVersion: "policy-v1",
+      };
+    },
   };
 }
 
@@ -425,7 +621,7 @@ function createRecordingCommandHandler() {
     get executeCallCount() {
       return executeCallCount;
     },
-    execute: async () => {
+    execute: async (_recordCommand: PipelineCommand) => {
       executeCallCount += 1;
 
       return {
@@ -442,6 +638,104 @@ function createRecordingCommandHandler() {
         },
       };
     },
+  };
+}
+
+function createGenericArtifactHandler() {
+  return {
+    commandType: ApplicationTestCommandType.RecordGenericArtifact,
+    execute: async (recordCommand: RecordGenericArtifactCommand) => ({
+      result: {
+        commandId: recordCommand.commandId,
+        status: CommandResultStatus.Accepted,
+        artifacts: [
+          {
+            artifactType: CommandResultArtifactType.Generic,
+            artifactId: "generic-artifact-001",
+            label: "Generic command artifact",
+          },
+        ],
+        emittedEvents: [],
+        auditEventIds: [],
+        idempotency: {
+          replayed: false,
+        },
+      },
+      effects: {
+        supervisorSignals: [],
+        auditEvents: [],
+        outboxEvents: [],
+      },
+    }),
+  };
+}
+
+function createGenericArtifactHandlerWithEffects() {
+  return {
+    commandType: ApplicationTestCommandType.RecordGenericArtifact,
+    execute: async (recordCommand: RecordGenericArtifactCommand) => ({
+      result: {
+        commandId: recordCommand.commandId,
+        status: CommandResultStatus.Accepted,
+        artifacts: [
+          {
+            artifactType: CommandResultArtifactType.Generic,
+            artifactId: "generic-artifact-002",
+            label: "Generic command artifact",
+          },
+        ],
+        emittedEvents: [],
+        auditEventIds: [],
+        idempotency: {
+          replayed: false,
+        },
+      },
+      effects: {
+        supervisorSignals: [],
+        auditEvents: [
+          {
+            auditEventId: "audit-committed-001",
+            eventName: AgenticEventType.WorkItemChanged,
+            aggregateId: "work-generic-artifact-002",
+            actor: recordCommand.actor,
+            occurredAt: "2026-05-28T21:00:00.000Z",
+          },
+        ],
+        outboxEvents: [
+          {
+            outboxEventId: "outbox-committed-001",
+            envelope: {
+              eventId: "evt-committed-001",
+              eventType: AgenticEventType.WorkItemChanged,
+              schemaVersion: EventSchemaVersion.AgenticOrgEventV1,
+              occurredAt: "2026-05-28T21:00:00.000Z",
+              scope: {
+                organizationId: recordCommand.organizationId,
+                projectId: recordCommand.projectId,
+                workItemId: "work-generic-artifact-002",
+              },
+              actor: recordCommand.actor,
+              aggregate: {
+                aggregateId: "work-generic-artifact-002",
+                aggregateType: AgenticAggregateType.WorkItem,
+                aggregateVersion: 1,
+              },
+              trace: {
+                commandId: recordCommand.commandId,
+                correlationId: recordCommand.correlationId,
+                causationId: recordCommand.causationId,
+                traceId: recordCommand.traceId,
+                idempotencyKey: recordCommand.idempotencyKey,
+              },
+              replay: {
+                isReplay: false,
+              },
+              payload: {},
+            },
+          },
+        ],
+      },
+    }),
   };
 }
 

--- a/agentic-organization/packages/application/test/send-supervisor-signal.test.ts
+++ b/agentic-organization/packages/application/test/send-supervisor-signal.test.ts
@@ -22,18 +22,24 @@ const command: SendSupervisorSignalCommand = {
   traceId: "trace-supervisor-signal-001",
   organizationId: "org-lfg",
   projectId: "project-agentic-org",
-  teamId: "team-runtime",
-  sourceLevel: SupervisorChainLevel.TeamMember,
-  targetLevel: SupervisorChainLevel.Manager,
   targetHatAssignmentId: "hat-assignment-em-001",
   actor: {
     agentId: "agent-developer-001",
     hatAssignmentId: "hat-assignment-dev-001",
   },
-  toolType: SupervisorSignalToolType.ReportBlocker,
   title: "Blocked on scoped NATS publisher",
   message: "The team cannot validate the outbox worker until a supervisor routes a scoped NATS publisher decision.",
-  relatedWorkItemId: "work-outbox-001",
+  policyContext: {
+    scope: {
+      teamId: "team-runtime",
+      workItemId: "work-outbox-001",
+    },
+    toolType: SupervisorSignalToolType.ReportBlocker,
+    supervisorChain: {
+      sourceLevel: SupervisorChainLevel.TeamMember,
+      targetLevel: SupervisorChainLevel.Manager,
+    },
+  },
 };
 
 describe("send supervisor signal handler", () => {
@@ -58,8 +64,8 @@ describe("send supervisor signal handler", () => {
       scope: {
         organizationId: command.organizationId,
         projectId: command.projectId,
-        teamId: command.teamId,
-        workItemId: command.relatedWorkItemId,
+        teamId: command.policyContext.scope.teamId,
+        workItemId: command.policyContext.scope.workItemId,
       },
       actor: command.actor,
       aggregate: {

--- a/agentic-organization/packages/messaging-nats/src/nats-jetstream-event-consumer.ts
+++ b/agentic-organization/packages/messaging-nats/src/nats-jetstream-event-consumer.ts
@@ -167,6 +167,8 @@ type TerminateWithDeadLetterInput = {
 };
 
 async function terminateWithDeadLetter(input: TerminateWithDeadLetterInput): Promise<void> {
+  let deadLetterPublished = false;
+
   try {
     await input.deadLetterPublisher.publish({
       sourceSubject: input.message.subject,
@@ -174,15 +176,39 @@ async function terminateWithDeadLetter(input: TerminateWithDeadLetterInput): Pro
       headers: input.message.headers,
       reason: input.reason,
     });
+    deadLetterPublished = true;
     input.result.deadLetteredCount += 1;
     await input.message.terminate();
     input.result.terminatedCount += 1;
   } catch {
     input.result.failedCount += 1;
+
+    if (deadLetterPublished) {
+      await acknowledgeDeadLetteredMessage({
+        message: input.message,
+        result: input.result,
+      });
+      return;
+    }
+
     await negativeAcknowledgeFailedMessage({
       message: input.message,
       result: input.result,
     });
+  }
+}
+
+type AcknowledgeDeadLetteredMessageInput = {
+  message: NatsJetStreamInboundMessage;
+  result: NatsJetStreamConsumeBatchResult;
+};
+
+async function acknowledgeDeadLetteredMessage(input: AcknowledgeDeadLetteredMessageInput): Promise<void> {
+  try {
+    await input.message.acknowledge();
+    input.result.acknowledgedCount += 1;
+  } catch {
+    input.result.failedCount += 1;
   }
 }
 

--- a/agentic-organization/packages/messaging-nats/test/nats-jetstream-event-consumer.test.ts
+++ b/agentic-organization/packages/messaging-nats/test/nats-jetstream-event-consumer.test.ts
@@ -156,7 +156,7 @@ describe("NATS JetStream event consumer", () => {
     equal(result.acknowledgedCount, 1);
   });
 
-  test("negative-acknowledges payload conflicts when message termination fails", async () => {
+  test("acknowledges payload conflicts when termination fails after dead-letter publication", async () => {
     const envelope = createEnvelope();
     const message = createRecordingInboundMessage({
       payload: JSON.stringify(envelope),
@@ -173,15 +173,13 @@ describe("NATS JetStream event consumer", () => {
       batchSize: 10,
     });
 
-    deepEqual(message.ackActions, [
-      NatsInboundMessageAckAction.Terminate,
-      NatsInboundMessageAckAction.NegativeAcknowledge,
-    ]);
+    deepEqual(message.ackActions, [NatsInboundMessageAckAction.Terminate, NatsInboundMessageAckAction.Acknowledge]);
     equal(result.payloadConflictCount, 1);
     equal(result.failedCount, 1);
     equal(result.deadLetteredCount, 1);
     equal(result.terminatedCount, 0);
-    equal(result.negativeAcknowledgedCount, 1);
+    equal(result.negativeAcknowledgedCount, 0);
+    equal(result.acknowledgedCount, 1);
     equal(deadLetterPublisher.messages.length, 1);
   });
 

--- a/agentic-organization/packages/policy/src/index.ts
+++ b/agentic-organization/packages/policy/src/index.ts
@@ -1,8 +1,6 @@
 import type {
   AgenticActor,
-  CommandType,
   SupervisorChainLevel,
-  SupervisorSignalToolType,
 } from "../../domain/src/index.ts";
 
 export const PolicyDecisionStatus = {
@@ -51,10 +49,10 @@ export type CommandAuthorizationSupervisorChain = {
 
 export type CommandAuthorizationRequest = {
   commandId: string;
-  commandType: CommandType;
+  commandType: string;
   actor: AgenticActor;
   scope: CommandAuthorizationScope;
-  toolType?: SupervisorSignalToolType;
+  toolType?: string;
   supervisorChain?: CommandAuthorizationSupervisorChain;
   trace: CommandAuthorizationTrace;
 };
@@ -91,10 +89,10 @@ export type PolicyDecision =
 
 export type PolicyDecisionObservation = {
   commandId: string;
-  commandType: CommandType;
+  commandType: string;
   actor: AgenticActor;
   scope: CommandAuthorizationScope;
-  toolType?: SupervisorSignalToolType;
+  toolType?: string;
   supervisorChain?: CommandAuthorizationSupervisorChain;
   trace: CommandAuthorizationTrace;
   decision: PolicyDecision;


### PR DESCRIPTION
## Summary
- harden the worker process entrypoint/loop and NATS DLQ handling from the prior pushed slice
- introduce a generic command contract, heterogeneous command handler registry, and command outcome metadata for agent/UI/MCP consumers
- move supervisor-signal authorization scope into policyContext so policy evidence and persisted effects use the same source of truth
- derive emitted event and audit metadata from committed command effects, and document the remaining generic durable-effect gap for the work-anchor kernel

## Validation
- npm test: 154 tests, 151 passed, 3 skipped env-gated live integrations
- npm run typecheck
- git diff --check

## Review
- subagent review found registry, policy-context, committed metadata, and docs-readiness issues
- fixes were iterated until local tests/typecheck/diff-check passed