### PR TITLE
feat(agentic-org): add work anchor domain lifecycle

### DIFF
--- a/agentic-organization/apps/workers/src/index.ts
+++ b/agentic-organization/apps/workers/src/index.ts
@@ -154,7 +154,9 @@ export {
   type WorkerProcessEntrypointResult,
 } from "./worker-process-entrypoint.ts";
 export {
+  CockroachTableName,
   CockroachMigrationStatement,
   createCockroachSqlExecutor,
+  createCockroachWorkAnchorKernelMigration,
   type CockroachAnySqlStatement,
 } from "../../../packages/state-cockroach/src/index.ts";

--- a/agentic-organization/apps/workers/test/cockroach-integration.test.ts
+++ b/agentic-organization/apps/workers/test/cockroach-integration.test.ts
@@ -5,6 +5,7 @@ import { describe, test } from "node:test";
 
 import {
   CockroachMigrationStatement,
+  CockroachTableName,
   WorkerDependencyName,
   WorkerDependencyReadinessStatus,
   WorkerProcessShutdownStatus,
@@ -12,6 +13,7 @@ import {
   WorkerRuntimeStatus,
   createCockroachMigrationBootstrapper,
   createCockroachReadinessProbe,
+  createCockroachWorkAnchorKernelMigration,
   createCockroachSqlExecutor,
   createCockroachWorkerShutdownPort,
   createCockroachWorkerSqlClient,
@@ -47,6 +49,15 @@ const CockroachIntegrationStatementName = {
   InsertProbeBeforeRollback: "integration_insert_probe_before_rollback",
   SelectProbe: "integration_select_probe",
   SelectRolledBackProbe: "integration_select_rolled_back_probe",
+  ApplyWorkAnchorMigration: "integration_apply_work_anchor_migration",
+  CreateLegacyWorkItemsTable: "integration_create_legacy_work_items_table",
+  DropLegacyWorkItemsTable: "integration_drop_legacy_work_items_table",
+  InsertDuplicateSequence: "integration_insert_duplicate_sequence",
+  InsertInvalidSequence: "integration_insert_invalid_sequence",
+  InsertLegacyWorkItem: "integration_insert_legacy_work_item",
+  InsertWorkItemStateHistory: "integration_insert_work_item_state_history",
+  InsertWorkItemWithoutTrace: "integration_insert_work_item_without_trace",
+  SelectLegacyWorkItem: "integration_select_legacy_work_item",
 } as const;
 
 const CockroachIntegrationRuntimeErrorMessage = {
@@ -64,6 +75,31 @@ type CockroachIntegrationSql = {
   DropProbeTable: string;
   InsertProbe: string;
   SelectProbe: string;
+};
+
+type WorkAnchorMigrationRun = {
+  sql: {
+    CreateLegacyWorkItemsTable: string;
+    DropLegacyWorkItemsTable: string;
+    InsertDuplicateSequence: string;
+    InsertInvalidSequence: string;
+    InsertLegacyWorkItem: string;
+    InsertWorkItemStateHistory: string;
+    InsertWorkItemWithoutTrace: string;
+    SelectLegacyWorkItem: string;
+    WorkAnchorMigration: string;
+  };
+  workItemsTableName: string;
+  workItemStateHistoryTableName: string;
+};
+
+type LegacyWorkItemRow = {
+  causation_id: string;
+  correlation_id: string;
+  trace_id: string;
+  updated_at: Date;
+  version: string;
+  work_item_type: string;
 };
 
 describe("Cockroach worker live integration", () => {
@@ -173,6 +209,94 @@ describe("Cockroach worker live integration", () => {
       }
     },
   );
+
+  test(
+    "upgrades a legacy work-items table through the work-anchor kernel migration",
+    {
+      skip:
+        env[CockroachIntegrationEnvName.DatabaseUrl] === undefined
+          ? `${CockroachIntegrationEnvName.DatabaseUrl} is not set`
+          : false,
+    },
+    async () => {
+      const databaseUrl = readIntegrationDatabaseUrl();
+      const run = createWorkAnchorMigrationRun();
+      const pool = await createPgCockroachWorkerPool({
+        databaseUrl,
+      });
+      const sqlClient = createCockroachWorkerSqlClient({
+        pool,
+        maxTransactionAttempts: 2,
+      });
+      const executor = createCockroachSqlExecutor({
+        client: sqlClient,
+      });
+
+      try {
+        await executor.execute({
+          name: CockroachIntegrationStatementName.CreateLegacyWorkItemsTable,
+          sql: run.sql.CreateLegacyWorkItemsTable,
+          parameters: [],
+        });
+        await executor.execute({
+          name: CockroachIntegrationStatementName.InsertLegacyWorkItem,
+          sql: run.sql.InsertLegacyWorkItem,
+          parameters: [],
+        });
+        await executor.execute({
+          name: CockroachIntegrationStatementName.ApplyWorkAnchorMigration,
+          sql: run.sql.WorkAnchorMigration,
+          parameters: [],
+        });
+
+        const rows = await executor.execute<LegacyWorkItemRow>({
+          name: CockroachIntegrationStatementName.SelectLegacyWorkItem,
+          sql: run.sql.SelectLegacyWorkItem,
+          parameters: [],
+        });
+
+        equal(rows.rows.length, 1);
+        equal(rows.rows[0]?.work_item_type, "task");
+        equal(rows.rows[0]?.version, "1");
+        equal(rows.rows[0]?.correlation_id, "migration-backfill");
+        equal(rows.rows[0]?.causation_id, "migration-backfill");
+        equal(rows.rows[0]?.trace_id, "migration-backfill");
+        equal(rows.rows[0]?.updated_at.toISOString(), "2026-05-01T12:00:00.000Z");
+
+        await assertInsertFails(executor, {
+          name: CockroachIntegrationStatementName.InsertWorkItemWithoutTrace,
+          sql: run.sql.InsertWorkItemWithoutTrace,
+          parameters: [],
+        });
+
+        await executor.execute({
+          name: CockroachIntegrationStatementName.InsertWorkItemStateHistory,
+          sql: run.sql.InsertWorkItemStateHistory,
+          parameters: [],
+        });
+
+        await assertInsertFails(executor, {
+          name: CockroachIntegrationStatementName.InsertDuplicateSequence,
+          sql: run.sql.InsertDuplicateSequence,
+          parameters: [],
+        });
+        await assertInsertFails(executor, {
+          name: CockroachIntegrationStatementName.InsertInvalidSequence,
+          sql: run.sql.InsertInvalidSequence,
+          parameters: [],
+        });
+      } finally {
+        await executor.execute({
+          name: CockroachIntegrationStatementName.DropLegacyWorkItemsTable,
+          sql: run.sql.DropLegacyWorkItemsTable,
+          parameters: [],
+        }).catch(() => undefined);
+        await createCockroachWorkerShutdownPort({
+          pool,
+        }).shutdown();
+      }
+    },
+  );
 });
 
 async function dropProbeTable(
@@ -241,6 +365,211 @@ function createCockroachIntegrationSql(tableName: string): CockroachIntegrationS
     InsertProbe: `INSERT INTO ${tableName} (id, value) VALUES ($1, $2)`,
     SelectProbe: `SELECT value FROM ${tableName} WHERE id = $1`,
   };
+}
+
+function createWorkAnchorMigrationRun(): WorkAnchorMigrationRun {
+  const suffix = randomUUID().replaceAll("-", "_");
+  const workItemsTableName = `${CockroachTableName.WorkItems}_${suffix}`;
+  const workItemStateHistoryTableName = `${CockroachTableName.WorkItemStateHistory}_${suffix}`;
+  assertSafeCockroachIdentifier(workItemsTableName);
+  assertSafeCockroachIdentifier(workItemStateHistoryTableName);
+
+  return {
+    sql: createWorkAnchorMigrationSql(workItemsTableName, workItemStateHistoryTableName),
+    workItemsTableName,
+    workItemStateHistoryTableName,
+  };
+}
+
+function createWorkAnchorMigrationSql(
+  workItemsTableName: string,
+  workItemStateHistoryTableName: string,
+): WorkAnchorMigrationRun["sql"] {
+  const workAnchorMigration = createCockroachWorkAnchorKernelMigration().sql
+    .replaceAll(CockroachTableName.WorkItems, workItemsTableName)
+    .replaceAll(CockroachTableName.WorkItemStateHistory, workItemStateHistoryTableName);
+
+  return {
+    CreateLegacyWorkItemsTable: `
+CREATE TABLE IF NOT EXISTS ${workItemsTableName} (
+  work_item_id STRING PRIMARY KEY,
+  organization_id STRING NOT NULL,
+  project_id STRING NOT NULL,
+  title STRING NOT NULL,
+  description STRING NOT NULL,
+  state STRING NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  created_by_agent_id STRING NOT NULL,
+  created_by_hat_assignment_id STRING NOT NULL
+);`.trim(),
+    DropLegacyWorkItemsTable: `
+DROP TABLE IF EXISTS ${workItemStateHistoryTableName};
+DROP TABLE IF EXISTS ${workItemsTableName};`.trim(),
+    InsertLegacyWorkItem: `
+INSERT INTO ${workItemsTableName} (
+  work_item_id,
+  organization_id,
+  project_id,
+  title,
+  description,
+  state,
+  created_at,
+  created_by_agent_id,
+  created_by_hat_assignment_id
+) VALUES (
+  'legacy-work-item',
+  'org-live-migration',
+  'project-live-migration',
+  'Legacy work item',
+  'Legacy row before V3 migration',
+  'created',
+  '2026-05-01T12:00:00.000Z',
+  'agent-live-migration',
+  'hat-live-migration'
+);`.trim(),
+    InsertWorkItemWithoutTrace: `
+INSERT INTO ${workItemsTableName} (
+  work_item_id,
+  organization_id,
+  project_id,
+  title,
+  description,
+  state,
+  created_at,
+  created_by_agent_id,
+  created_by_hat_assignment_id,
+  work_item_type,
+  updated_at,
+  version
+) VALUES (
+  'missing-trace-work-item',
+  'org-live-migration',
+  'project-live-migration',
+  'Missing trace item',
+  'Should fail because trace columns have no durable defaults',
+  'created',
+  '2026-05-01T12:00:00.000Z',
+  'agent-live-migration',
+  'hat-live-migration',
+  'task',
+  '2026-05-01T12:00:00.000Z',
+  1
+);`.trim(),
+    InsertWorkItemStateHistory: `
+INSERT INTO ${workItemStateHistoryTableName} (
+  work_state_transition_id,
+  organization_id,
+  project_id,
+  work_item_id,
+  sequence,
+  from_state,
+  to_state,
+  evidence_artifact_ids,
+  transitioned_at,
+  transitioned_by_agent_id,
+  transitioned_by_hat_assignment_id,
+  correlation_id,
+  causation_id,
+  trace_id
+) VALUES (
+  'transition-1',
+  'org-live-migration',
+  'project-live-migration',
+  'legacy-work-item',
+  1,
+  'created',
+  'intake',
+  '[]':::JSONB,
+  '2026-05-01T12:10:00.000Z',
+  'agent-live-migration',
+  'hat-live-migration',
+  'correlation-live-migration',
+  'causation-live-migration',
+  'trace-live-migration'
+);`.trim(),
+    InsertDuplicateSequence: `
+INSERT INTO ${workItemStateHistoryTableName} (
+  work_state_transition_id,
+  organization_id,
+  project_id,
+  work_item_id,
+  sequence,
+  from_state,
+  to_state,
+  evidence_artifact_ids,
+  transitioned_at,
+  transitioned_by_agent_id,
+  transitioned_by_hat_assignment_id,
+  correlation_id,
+  causation_id,
+  trace_id
+) VALUES (
+  'transition-duplicate',
+  'org-live-migration',
+  'project-live-migration',
+  'legacy-work-item',
+  1,
+  'intake',
+  'triage',
+  '[]':::JSONB,
+  '2026-05-01T12:20:00.000Z',
+  'agent-live-migration',
+  'hat-live-migration',
+  'correlation-live-migration',
+  'causation-live-migration',
+  'trace-live-migration'
+);`.trim(),
+    InsertInvalidSequence: `
+INSERT INTO ${workItemStateHistoryTableName} (
+  work_state_transition_id,
+  organization_id,
+  project_id,
+  work_item_id,
+  sequence,
+  from_state,
+  to_state,
+  evidence_artifact_ids,
+  transitioned_at,
+  transitioned_by_agent_id,
+  transitioned_by_hat_assignment_id,
+  correlation_id,
+  causation_id,
+  trace_id
+) VALUES (
+  'transition-invalid',
+  'org-live-migration',
+  'project-live-migration',
+  'other-work-item',
+  0,
+  'created',
+  'intake',
+  '[]':::JSONB,
+  '2026-05-01T12:30:00.000Z',
+  'agent-live-migration',
+  'hat-live-migration',
+  'correlation-live-migration',
+  'causation-live-migration',
+  'trace-live-migration'
+);`.trim(),
+    SelectLegacyWorkItem: `
+SELECT work_item_type, updated_at, version, correlation_id, causation_id, trace_id
+FROM ${workItemsTableName}
+WHERE work_item_id = 'legacy-work-item';`.trim(),
+    WorkAnchorMigration: workAnchorMigration,
+  };
+}
+
+async function assertInsertFails(
+  executor: ReturnType<typeof createCockroachSqlExecutor>,
+  statement: CockroachAnySqlStatement,
+): Promise<void> {
+  let didFail = false;
+  try {
+    await executor.execute(statement);
+  } catch {
+    didFail = true;
+  }
+  ok(didFail);
 }
 
 function assertSafeCockroachIdentifier(identifier: string): void {

--- a/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
+++ b/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
@@ -79,6 +79,17 @@ and `UI_AND_OBSERVABILITY_CONCEPTS.md` reject unanchored discussions.
 Meetings, one-on-ones, broadcasts, votes, review comments, reports, and
 team threads must reference work before they can affect state.
 
+First implementation progress: the domain now has a minimal typed work
+item lifecycle (`created`, `intake`, `triage`, `ready`, `in_progress`,
+`blocked`, `review`, `done`) plus V0 defect guards for creation,
+readiness, assignment, and scheduling. Work item type is required on the
+domain record, and transition records carry evidence, assignment, and
+schedule references so later UI/graph/agent review can explain why a
+transition was legal. The remaining gap is durable
+project/initiative/work-anchor persistence and command handlers that
+validate anchor existence before supervisor signals, discussions, and
+meetings can mutate state.
+
 ### Scheduled Agent Time
 
 `AGENT_WORK_RHYTHM_AND_PROMPT_FLOWS.md`,

--- a/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
+++ b/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
@@ -85,10 +85,18 @@ item lifecycle (`created`, `intake`, `triage`, `ready`, `in_progress`,
 readiness, assignment, and scheduling. Work item type is required on the
 domain record, and transition records carry evidence, assignment, and
 schedule references so later UI/graph/agent review can explain why a
-transition was legal. The remaining gap is durable
-project/initiative/work-anchor persistence and command handlers that
-validate anchor existence before supervisor signals, discussions, and
-meetings can mutate state.
+transition was legal. The Cockroach schema now has an additive
+`0003_agentic_org_work_anchor_kernel` migration for projects,
+initiatives, work anchor targets, work item state history, and upgraded
+work item trace/type/version columns. V1 remains legacy instead of being
+rewritten, generated SQL is checked against migration files, and DB
+constraints derive from domain enum values. Migration backfill defaults
+are dropped after legacy rows are patched so future writes still require
+real command provenance, legacy `updated_at` is preserved from
+`created_at`, and state-history sequence constraints protect replay
+order. The remaining gap is command handlers and generic state ports
+that validate anchor existence before supervisor signals, discussions,
+and meetings can mutate state.
 
 ### Scheduled Agent Time
 

--- a/agentic-organization/docs/PHASED_DEVELOPMENT_PLAN.md
+++ b/agentic-organization/docs/PHASED_DEVELOPMENT_PLAN.md
@@ -984,7 +984,15 @@ initiative, work item, or anchor-target persistence yet.
    - work state transition. First domain record types added; durable
      persistence and commands are still pending.
 3. Add Cockroach schema for minimal projects, initiatives, work items,
-   and work anchor targets.
+   and work anchor targets. First durable schema slice done with
+   `0003_agentic_org_work_anchor_kernel`: V1 remains the legacy core
+   migration, V3 additively creates project, initiative, work anchor
+   target, and work item state-history tables, upgrades existing
+   `work_items` with work type, trace, version, and update columns,
+   drops migration-only defaults after backfill so future writes require
+   real command provenance, preserves legacy `updated_at` from
+   `created_at`, constrains replay sequence and enum columns from domain
+   constants, and tests generated SQL against checked-in migration files.
 4. Add commands:
    - `create_project`;
    - `create_initiative`;

--- a/agentic-organization/docs/PHASED_DEVELOPMENT_PLAN.md
+++ b/agentic-organization/docs/PHASED_DEVELOPMENT_PLAN.md
@@ -973,13 +973,16 @@ initiative, work item, or anchor-target persistence yet.
 ### Code Steps
 
 1. Reconcile the V0 work item states across docs and implementation,
-   including how `created` maps to the current `intake` concept.
+   including how `created` maps to the current `intake` concept. First
+   domain slice done with `created`, `intake`, `triage`, `ready`,
+   `in_progress`, `blocked`, `review`, and `done`.
 2. Add the minimal domain records for:
    - project;
    - initiative;
    - work item;
    - work anchor target;
-   - work state transition.
+   - work state transition. First domain record types added; durable
+     persistence and commands are still pending.
 3. Add Cockroach schema for minimal projects, initiatives, work items,
    and work anchor targets.
 4. Add commands:
@@ -998,6 +1001,9 @@ initiative, work item, or anchor-target persistence yet.
    - review;
    - done.
 6. Add the first type-specific lifecycle policy records for defects.
+   First domain guards added: defects must start in `created`, require
+   triage fields and evidence before `ready`, and require engineer
+   assignment plus a scheduled work block before `in_progress`.
 7. Emit audit and outbox events for every work state transition.
 8. Add a minimal work-status query/read model for workers, agents, and
    future UI/API hosts.

--- a/agentic-organization/docs/V0_SCHEMA_AND_COMMANDS.md
+++ b/agentic-organization/docs/V0_SCHEMA_AND_COMMANDS.md
@@ -67,6 +67,23 @@ matters.
 | `gate_decisions`          | approve, reject, needs-changes, or defer decisions                                     |
 | `releases`                | release groupings once release management enters the slice                             |
 
+The first Cockroach-backed Work Anchor Kernel migration is
+`0003_agentic_org_work_anchor_kernel`. It is additive over the legacy
+`0001_agentic_org_core_state` table shape: V1 remains the historical
+bootstrap migration, while V3 creates projects, initiatives, work anchor
+targets, and state history, then upgrades `work_items` with
+`initiative_id`, required `work_item_type`, `updated_at`, `version`,
+`correlation_id`, `causation_id`, and `trace_id`. The V3 migration
+keeps a visible `migration-backfill` value for legacy trace columns so
+old rows remain queryable without pretending they came from a real
+agent command. Those migration defaults are dropped before the migration
+sets the columns `NOT NULL`, so new command handlers must still provide
+real trace fields through the command contract. `updated_at` is added
+without a default and backfilled from `created_at` so legacy work items
+preserve their original timestamp. `work_item_state_history` is
+append-only with positive per-work-item sequence numbers so replay order
+cannot be duplicated or zero-filled.
+
 ### Schedules, Prompt Flows, and Actions
 
 | Table                           | V0 responsibility                                                  |
@@ -372,10 +389,13 @@ rows to NATS JetStream and marks them published.
 The first Cockroach adapter set is composed through a generic SQL
 executor and durable adapter factory. The same executor shape backs
 command state, outbox publishing, event ingestion, policy observations,
-and the core migration runner. App hosts may bind that executor to a
-real Cockroach client, but domain, application, runtime, policy,
-messaging, and worker packages must not depend on the concrete client or
-connection pool.
+and the core migration runner. Generated migration SQL and checked-in
+`packages/state-cockroach/migrations/*.sql` files are tested for exact
+synchronization so app bootstrappers and file-based migration consumers
+observe the same schema. App hosts may bind that executor to a real
+Cockroach client, but domain, application, runtime, policy, messaging,
+and worker packages must not depend on the concrete client or connection
+pool.
 
 Subject shape:
 
@@ -412,6 +432,19 @@ double-counting. Organization DB assignments remain authoritative until
 an ADR explicitly promotes CRD writeback to live enforcement.
 
 ## Migration and Test Expectations
+
+Current executable migration contract:
+
+- `0001_agentic_org_core_state` is the legacy core schema and should not
+  be rewritten to include later work-anchor concepts;
+- `0002_agentic_org_outbox_claim_fence` is the additive outbox claim ID
+  migration;
+- `0003_agentic_org_work_anchor_kernel` is the additive Work Anchor
+  Kernel migration;
+- generated SQL must match the checked-in migration files exactly;
+- database constraints for work item state, work item type, project
+  status, and initiative status must be generated from TypeScript domain
+  enums rather than repeated as hand-typed magic strings.
 
 Before the first implementation PR lands, define tests for:
 

--- a/agentic-organization/docs/V0_SCHEMA_AND_COMMANDS.md
+++ b/agentic-organization/docs/V0_SCHEMA_AND_COMMANDS.md
@@ -124,19 +124,39 @@ magic strings in command handlers.
 ### `work_item_state`
 
 ```text
-new
+created
+intake
 triage
-needs_clarification
 ready
-assigned
 in_progress
-review_requested
-changes_requested
-approved
 blocked
+review
 done
-canceled
 ```
+
+The first implemented TypeScript enum is intentionally narrower than the
+full future workflow matrix. `created` is the mechanical creation state;
+`intake` is where the Organization classifies the work before triage;
+`triage` is where required fields and evidence are gathered; `ready`
+means the item can be scheduled/assigned; `in_progress`, `blocked`,
+`review`, and `done` cover the first execution loop. Richer states such
+as business approval, architecture approval, QA signoff, merge, release,
+and outcome review should be layered as gates or type-specific lifecycle
+records before they are promoted into the shared base enum.
+
+Defect work items have V0 lifecycle guards:
+
+- defects must start in `created`;
+- defects cannot move from `triage` to `ready` until triage fields and
+  required evidence exist;
+- defects cannot move from `ready` to `in_progress` until an engineer hat
+  assignment and scheduled work block exist.
+
+`work_item_type` is required on the domain record so type-specific
+lifecycle policy cannot be bypassed by omission. Work state transition
+records must keep the evidence artifact IDs, assigned engineer hat
+assignment, and scheduled work block references that justified the
+transition.
 
 ### `hat_assignment_state`
 

--- a/agentic-organization/docs/WORK_AND_RELEASE_MANAGEMENT_OS.md
+++ b/agentic-organization/docs/WORK_AND_RELEASE_MANAGEMENT_OS.md
@@ -69,29 +69,27 @@ This structure should be flexible enough for internal platform work and product/
 ### Work Item States
 
 ```text
-intake
-  -> classified
-  -> discovery
-  -> needs_business_approval
-  -> needs_architecture
-  -> ready
-  -> planned
-  -> assigned
-  -> in_progress
-  -> blocked
-  -> review
-  -> needs_rework
-  -> qa_review
-  -> qa_reproducible
-  -> delivery_review
-  -> approved
-  -> merged
-  -> released
-  -> outcome_review
-  -> done
+created -> intake -> triage -> ready -> in_progress
+in_progress -> blocked -> in_progress
+in_progress -> review
+review -> in_progress
+review -> done
 ```
 
-The state machine should allow workflow-specific subsets. For example, a credential request does not need code review, but it does need security review. A documentation task may not need QA, but it may need architecture or product approval.
+The V0 shared state machine is intentionally small. Workflow-specific
+states such as discovery, business approval, architecture approval, QA
+review, merge, release, and outcome review should first appear as gates,
+state history, and type-specific lifecycle policy records. Once those
+records prove stable, the Organization can promote any truly universal
+state into the shared enum.
+
+Defects use the first type-specific lifecycle policy: they start in
+`created`, cannot enter `ready` until triage fields and evidence exist,
+and cannot enter `in_progress` until an engineer hat assignment and
+scheduled work block exist. Work item type is required on the domain
+record so defect policy cannot be skipped by omitting the type. State
+transition records must preserve the evidence artifact IDs and the
+assignment/schedule references that made the transition legal.
 
 ### Requirement Maturity States
 

--- a/agentic-organization/packages/domain/src/index.ts
+++ b/agentic-organization/packages/domain/src/index.ts
@@ -13,7 +13,14 @@ export {
   type CreateAgenticEventEnvelopeInput,
   type PolicyDecisionEvidence,
 } from "./event-envelope.ts";
-export { WorkItemState, assertWorkItemTransition, createInitialWorkItemState } from "./work-item-state-machine.ts";
+export {
+  WorkItemState,
+  WorkItemType,
+  assertInitialWorkItemState,
+  assertWorkItemTransition,
+  createInitialWorkItemState,
+  type WorkItemTransitionContext,
+} from "./work-item-state-machine.ts";
 export {
   ReactionPlanActionType,
   ReactionPlanReason,
@@ -45,7 +52,12 @@ export type {
   AuditEvent,
   DiscussionAnchor,
   IdempotencyRecord,
+  Initiative,
   OutboxEvent,
+  Project,
   SupervisorSignal,
+  WorkAnchorTarget,
   WorkItem,
+  WorkStateTransition,
 } from "./records.ts";
+export { InitiativeStatus, ProjectStatus } from "./records.ts";

--- a/agentic-organization/packages/domain/src/records.ts
+++ b/agentic-organization/packages/domain/src/records.ts
@@ -4,17 +4,78 @@ import type {
   SupervisorSignalStatus,
   SupervisorSignalToolType,
 } from "./supervisor-communication.ts";
-import type { WorkItemState } from "./work-item-state-machine.ts";
+import type { WorkItemState, WorkItemType } from "./work-item-state-machine.ts";
+
+export const ProjectStatus = {
+  Active: "active",
+  Archived: "archived",
+} as const;
+
+export type ProjectStatus = (typeof ProjectStatus)[keyof typeof ProjectStatus];
+
+export const InitiativeStatus = {
+  Proposed: "proposed",
+  Active: "active",
+  Completed: "completed",
+  Archived: "archived",
+} as const;
+
+export type InitiativeStatus = (typeof InitiativeStatus)[keyof typeof InitiativeStatus];
+
+export type Project = {
+  projectId: string;
+  organizationId: string;
+  name: string;
+  status: ProjectStatus;
+  createdAt: string;
+  createdBy: AgenticActor;
+};
+
+export type Initiative = {
+  initiativeId: string;
+  organizationId: string;
+  projectId: string;
+  title: string;
+  status: InitiativeStatus;
+  createdAt: string;
+  createdBy: AgenticActor;
+};
 
 export type WorkItem = {
   workItemId: string;
   organizationId: string;
   projectId: string;
+  initiativeId?: string;
+  workItemType: WorkItemType;
   title: string;
   description: string;
   state: WorkItemState;
   createdAt: string;
   createdBy: AgenticActor;
+};
+
+export type WorkAnchorTarget = {
+  workAnchorTargetId: string;
+  organizationId: string;
+  projectId: string;
+  initiativeId?: string;
+  workItemId: string;
+  createdAt: string;
+  createdBy: AgenticActor;
+};
+
+export type WorkStateTransition = {
+  workStateTransitionId: string;
+  organizationId: string;
+  projectId: string;
+  workItemId: string;
+  fromState: WorkItemState;
+  toState: WorkItemState;
+  evidenceArtifactIds: readonly string[];
+  assignedEngineerHatAssignmentId?: string;
+  scheduledWorkBlockId?: string;
+  transitionedAt: string;
+  transitionedBy: AgenticActor;
 };
 
 export type SupervisorSignal = {

--- a/agentic-organization/packages/domain/src/work-item-state-machine.ts
+++ b/agentic-organization/packages/domain/src/work-item-state-machine.ts
@@ -1,24 +1,93 @@
 export const WorkItemState = {
-  New: "new",
+  Created: "created",
+  Intake: "intake",
   Triage: "triage",
   Ready: "ready",
-  Approved: "approved",
+  InProgress: "in_progress",
+  Blocked: "blocked",
+  Review: "review",
+  Done: "done",
 } as const;
 
 export type WorkItemState = (typeof WorkItemState)[keyof typeof WorkItemState];
 
+export const WorkItemType = {
+  Defect: "defect",
+  Task: "task",
+} as const;
+
+export type WorkItemType = (typeof WorkItemType)[keyof typeof WorkItemType];
+
+export type WorkItemTransitionContext = {
+  workItemType?: WorkItemType | undefined;
+  hasTriageFields?: boolean | undefined;
+  hasRequiredEvidence?: boolean | undefined;
+  assignedEngineerHatAssignmentId?: string | undefined;
+  scheduledWorkBlockId?: string | undefined;
+};
+
 const allowedTransitions = new Map<WorkItemState, ReadonlySet<WorkItemState>>([
-  [WorkItemState.New, new Set([WorkItemState.Triage])],
+  [WorkItemState.Created, new Set([WorkItemState.Intake])],
+  [WorkItemState.Intake, new Set([WorkItemState.Triage])],
   [WorkItemState.Triage, new Set([WorkItemState.Ready])],
-  [WorkItemState.Ready, new Set([WorkItemState.Approved])],
+  [WorkItemState.Ready, new Set([WorkItemState.InProgress])],
+  [WorkItemState.InProgress, new Set([WorkItemState.Blocked, WorkItemState.Review])],
+  [WorkItemState.Blocked, new Set([WorkItemState.InProgress])],
+  [WorkItemState.Review, new Set([WorkItemState.InProgress, WorkItemState.Done])],
 ]);
 
 export function createInitialWorkItemState(): WorkItemState {
-  return WorkItemState.New;
+  return WorkItemState.Created;
 }
 
-export function assertWorkItemTransition(fromState: WorkItemState, toState: WorkItemState): void {
+export function assertInitialWorkItemState(workItemType: WorkItemType, initialState: WorkItemState): void {
+  if (workItemType === WorkItemType.Defect && initialState !== WorkItemState.Created) {
+    throw new Error("defect work items must start in created");
+  }
+}
+
+export function assertWorkItemTransition(
+  fromState: WorkItemState,
+  toState: WorkItemState,
+  context: WorkItemTransitionContext = {},
+): void {
   if (!allowedTransitions.get(fromState)?.has(toState)) {
     throw new Error(`illegal work item transition from ${fromState} to ${toState}`);
   }
+
+  assertDefectTransitionRequirements(fromState, toState, context);
+}
+
+function assertDefectTransitionRequirements(
+  fromState: WorkItemState,
+  toState: WorkItemState,
+  context: WorkItemTransitionContext,
+): void {
+  if (context.workItemType !== WorkItemType.Defect) {
+    return;
+  }
+
+  if (fromState === WorkItemState.Triage && toState === WorkItemState.Ready) {
+    if (context.hasTriageFields !== true) {
+      throw new Error("defect ready transition requires triage fields");
+    }
+
+    if (context.hasRequiredEvidence !== true) {
+      throw new Error("defect ready transition requires evidence");
+    }
+  }
+
+  if (fromState === WorkItemState.Ready && toState === WorkItemState.InProgress) {
+    if (isBlank(context.assignedEngineerHatAssignmentId)) {
+      throw new Error("defect in_progress transition requires assigned engineer");
+    }
+
+    if (isBlank(context.scheduledWorkBlockId)) {
+      throw new Error("defect in_progress transition requires scheduled work block");
+    }
+  }
+}
+
+function isBlank(value: string | undefined): boolean {
+  return value === undefined || value.trim().length === 0;
 }

--- a/agentic-organization/packages/domain/test/work-item-state-machine.test.ts
+++ b/agentic-organization/packages/domain/test/work-item-state-machine.test.ts
@@ -1,17 +1,84 @@
 import { equal, throws } from "node:assert/strict";
 import { describe, test } from "node:test";
 
-import { WorkItemState, assertWorkItemTransition, createInitialWorkItemState } from "../src/work-item-state-machine.ts";
+import {
+  WorkItemState,
+  WorkItemType,
+  assertInitialWorkItemState,
+  assertWorkItemTransition,
+  createInitialWorkItemState,
+} from "../src/work-item-state-machine.ts";
 
 describe("work item state machine", () => {
-  test("new work starts in the typed new state", () => {
-    equal(createInitialWorkItemState(), WorkItemState.New);
+  test("new work starts in the typed created state", () => {
+    equal(createInitialWorkItemState(), WorkItemState.Created);
   });
 
   test("allows only explicit typed lifecycle transitions", () => {
-    assertDoesNotThrow(() => assertWorkItemTransition(WorkItemState.New, WorkItemState.Triage));
+    assertDoesNotThrow(() => assertWorkItemTransition(WorkItemState.Created, WorkItemState.Intake));
+    assertDoesNotThrow(() => assertWorkItemTransition(WorkItemState.Intake, WorkItemState.Triage));
+    assertDoesNotThrow(() => assertWorkItemTransition(WorkItemState.Triage, WorkItemState.Ready, {
+      hasRequiredEvidence: true,
+      hasTriageFields: true,
+    }));
+    assertDoesNotThrow(() => assertWorkItemTransition(WorkItemState.Ready, WorkItemState.InProgress, {
+      assignedEngineerHatAssignmentId: "hat-assignment-engineer-001",
+      scheduledWorkBlockId: "schedule-block-001",
+    }));
 
-    throws(() => assertWorkItemTransition(WorkItemState.New, WorkItemState.Approved), /illegal work item transition/);
+    throws(
+      () => assertWorkItemTransition(WorkItemState.Created, WorkItemState.Ready),
+      /illegal work item transition/,
+    );
+  });
+
+  test("defects cannot start outside the created state", () => {
+    assertDoesNotThrow(() => assertInitialWorkItemState(WorkItemType.Defect, WorkItemState.Created));
+
+    throws(
+      () => assertInitialWorkItemState(WorkItemType.Defect, WorkItemState.Ready),
+      /defect work items must start in created/,
+    );
+  });
+
+  test("defects cannot enter ready until triage fields and required evidence exist", () => {
+    throws(
+      () => assertWorkItemTransition(WorkItemState.Triage, WorkItemState.Ready, {
+        workItemType: WorkItemType.Defect,
+        hasRequiredEvidence: true,
+        hasTriageFields: false,
+      }),
+      /defect ready transition requires triage fields/,
+    );
+
+    throws(
+      () => assertWorkItemTransition(WorkItemState.Triage, WorkItemState.Ready, {
+        workItemType: WorkItemType.Defect,
+        hasRequiredEvidence: false,
+        hasTriageFields: true,
+      }),
+      /defect ready transition requires evidence/,
+    );
+  });
+
+  test("defects cannot enter in progress until an engineer is assigned and scheduled", () => {
+    throws(
+      () => assertWorkItemTransition(WorkItemState.Ready, WorkItemState.InProgress, {
+        workItemType: WorkItemType.Defect,
+        assignedEngineerHatAssignmentId: "",
+        scheduledWorkBlockId: "schedule-block-001",
+      }),
+      /defect in_progress transition requires assigned engineer/,
+    );
+
+    throws(
+      () => assertWorkItemTransition(WorkItemState.Ready, WorkItemState.InProgress, {
+        workItemType: WorkItemType.Defect,
+        assignedEngineerHatAssignmentId: "hat-assignment-engineer-001",
+        scheduledWorkBlockId: " ",
+      }),
+      /defect in_progress transition requires scheduled work block/,
+    );
   });
 });
 

--- a/agentic-organization/packages/observability/test/span-attributes.test.ts
+++ b/agentic-organization/packages/observability/test/span-attributes.test.ts
@@ -41,7 +41,7 @@ describe("agentic observability span attributes", () => {
         policyVersion: "policy-v1",
       },
       payload: {
-        state: WorkItemState.New,
+        state: WorkItemState.Created,
       },
     });
 

--- a/agentic-organization/packages/state-cockroach/migrations/0003_agentic_org_work_anchor_kernel.sql
+++ b/agentic-organization/packages/state-cockroach/migrations/0003_agentic_org_work_anchor_kernel.sql
@@ -1,0 +1,114 @@
+CREATE TABLE IF NOT EXISTS agentic_org_projects (
+  project_id STRING PRIMARY KEY,
+  organization_id STRING NOT NULL,
+  name STRING NOT NULL,
+  status STRING NOT NULL CONSTRAINT agentic_org_projects_status_check CHECK (status IN ('active', 'archived')),
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  version INT8 NOT NULL,
+  created_by_agent_id STRING NOT NULL,
+  created_by_hat_assignment_id STRING NOT NULL,
+  correlation_id STRING NOT NULL,
+  causation_id STRING NOT NULL,
+  trace_id STRING NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS agentic_org_initiatives (
+  initiative_id STRING PRIMARY KEY,
+  organization_id STRING NOT NULL,
+  project_id STRING NOT NULL,
+  title STRING NOT NULL,
+  status STRING NOT NULL CONSTRAINT agentic_org_initiatives_status_check CHECK (status IN ('proposed', 'active', 'completed', 'archived')),
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  version INT8 NOT NULL,
+  created_by_agent_id STRING NOT NULL,
+  created_by_hat_assignment_id STRING NOT NULL,
+  correlation_id STRING NOT NULL,
+  causation_id STRING NOT NULL,
+  trace_id STRING NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS agentic_org_work_anchor_targets (
+  work_anchor_target_id STRING PRIMARY KEY,
+  organization_id STRING NOT NULL,
+  project_id STRING NOT NULL,
+  initiative_id STRING,
+  work_item_id STRING NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  version INT8 NOT NULL,
+  created_by_agent_id STRING NOT NULL,
+  created_by_hat_assignment_id STRING NOT NULL,
+  correlation_id STRING NOT NULL,
+  causation_id STRING NOT NULL,
+  trace_id STRING NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS agentic_org_work_item_state_history (
+  work_state_transition_id STRING PRIMARY KEY,
+  organization_id STRING NOT NULL,
+  project_id STRING NOT NULL,
+  work_item_id STRING NOT NULL,
+  sequence INT8 NOT NULL CONSTRAINT agentic_org_work_item_state_history_sequence_positive_check CHECK (sequence > 0),
+  from_state STRING NOT NULL CONSTRAINT agentic_org_work_item_state_history_from_state_check CHECK (from_state IN ('created', 'intake', 'triage', 'ready', 'in_progress', 'blocked', 'review', 'done')),
+  to_state STRING NOT NULL CONSTRAINT agentic_org_work_item_state_history_to_state_check CHECK (to_state IN ('created', 'intake', 'triage', 'ready', 'in_progress', 'blocked', 'review', 'done')),
+  evidence_artifact_ids JSONB NOT NULL,
+  assigned_engineer_hat_assignment_id STRING,
+  scheduled_work_block_id STRING,
+  transitioned_at TIMESTAMPTZ NOT NULL,
+  transitioned_by_agent_id STRING NOT NULL,
+  transitioned_by_hat_assignment_id STRING NOT NULL,
+  correlation_id STRING NOT NULL,
+  causation_id STRING NOT NULL,
+  trace_id STRING NOT NULL,
+  UNIQUE (work_item_id, sequence)
+);
+
+ALTER TABLE IF EXISTS agentic_org_work_items
+  ADD COLUMN IF NOT EXISTS initiative_id STRING;
+
+ALTER TABLE IF EXISTS agentic_org_work_items
+  ADD COLUMN IF NOT EXISTS work_item_type STRING DEFAULT 'task';
+
+ALTER TABLE IF EXISTS agentic_org_work_items
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;
+
+ALTER TABLE IF EXISTS agentic_org_work_items
+  ADD COLUMN IF NOT EXISTS version INT8 DEFAULT 1;
+
+ALTER TABLE IF EXISTS agentic_org_work_items
+  ADD COLUMN IF NOT EXISTS correlation_id STRING DEFAULT 'migration-backfill';
+
+ALTER TABLE IF EXISTS agentic_org_work_items
+  ADD COLUMN IF NOT EXISTS causation_id STRING DEFAULT 'migration-backfill';
+
+ALTER TABLE IF EXISTS agentic_org_work_items
+  ADD COLUMN IF NOT EXISTS trace_id STRING DEFAULT 'migration-backfill';
+
+ALTER TABLE IF EXISTS agentic_org_work_items
+  ALTER COLUMN work_item_type DROP DEFAULT,
+  ALTER COLUMN version DROP DEFAULT,
+  ALTER COLUMN correlation_id DROP DEFAULT,
+  ALTER COLUMN causation_id DROP DEFAULT,
+  ALTER COLUMN trace_id DROP DEFAULT;
+
+UPDATE agentic_org_work_items
+  SET work_item_type = COALESCE(work_item_type, 'task'),
+      updated_at = COALESCE(updated_at, created_at),
+      version = COALESCE(version, 1),
+      correlation_id = COALESCE(correlation_id, 'migration-backfill'),
+      causation_id = COALESCE(causation_id, 'migration-backfill'),
+      trace_id = COALESCE(trace_id, 'migration-backfill');
+
+ALTER TABLE IF EXISTS agentic_org_work_items
+  ALTER COLUMN work_item_type SET NOT NULL,
+  ALTER COLUMN updated_at SET NOT NULL,
+  ALTER COLUMN version SET NOT NULL,
+  ALTER COLUMN correlation_id SET NOT NULL,
+  ALTER COLUMN causation_id SET NOT NULL,
+  ALTER COLUMN trace_id SET NOT NULL;
+
+ALTER TABLE IF EXISTS agentic_org_work_items
+  ADD CONSTRAINT IF NOT EXISTS agentic_org_work_items_work_item_type_check CHECK (work_item_type IN ('defect', 'task')),
+  ADD CONSTRAINT IF NOT EXISTS agentic_org_work_items_state_check CHECK (state IN ('created', 'intake', 'triage', 'ready', 'in_progress', 'blocked', 'review', 'done'));

--- a/agentic-organization/packages/state-cockroach/src/cockroach-schema.ts
+++ b/agentic-organization/packages/state-cockroach/src/cockroach-schema.ts
@@ -1,13 +1,20 @@
+import { InitiativeStatus, ProjectStatus, WorkItemState, WorkItemType } from "../../domain/src/index.ts";
+
 export const CockroachCoreStateMigrationName = {
   CoreStateV1: "0001_agentic_org_core_state",
   OutboxClaimFenceV2: "0002_agentic_org_outbox_claim_fence",
+  WorkAnchorKernelV3: "0003_agentic_org_work_anchor_kernel",
 } as const;
 
 export type CockroachCoreStateMigrationName =
   (typeof CockroachCoreStateMigrationName)[keyof typeof CockroachCoreStateMigrationName];
 
 export const CockroachTableName = {
+  Projects: "agentic_org_projects",
+  Initiatives: "agentic_org_initiatives",
   WorkItems: "agentic_org_work_items",
+  WorkAnchorTargets: "agentic_org_work_anchor_targets",
+  WorkItemStateHistory: "agentic_org_work_item_state_history",
   SupervisorSignals: "agentic_org_supervisor_signals",
   AuditEvents: "agentic_org_audit_events",
   InboxReceipts: "agentic_org_inbox_receipts",
@@ -19,6 +26,28 @@ export const CockroachTableName = {
 
 export type CockroachTableName = (typeof CockroachTableName)[keyof typeof CockroachTableName];
 
+export const CockroachCheckConstraintName = {
+  ProjectStatus: "agentic_org_projects_status_check",
+  InitiativeStatus: "agentic_org_initiatives_status_check",
+  WorkItemType: "agentic_org_work_items_work_item_type_check",
+  WorkItemState: "agentic_org_work_items_state_check",
+  WorkItemStateHistoryFromState: "agentic_org_work_item_state_history_from_state_check",
+  WorkItemStateHistorySequencePositive: "agentic_org_work_item_state_history_sequence_positive_check",
+  WorkItemStateHistoryToState: "agentic_org_work_item_state_history_to_state_check",
+} as const;
+
+export type CockroachCheckConstraintName =
+  (typeof CockroachCheckConstraintName)[keyof typeof CockroachCheckConstraintName];
+
+export const CockroachSchemaBackfillValue = {
+  WorkItemTypeTask: WorkItemType.Task,
+  Version: "1",
+  Trace: "migration-backfill",
+} as const;
+
+export type CockroachSchemaBackfillValue =
+  (typeof CockroachSchemaBackfillValue)[keyof typeof CockroachSchemaBackfillValue];
+
 export type CockroachSchemaMigration = {
   name: CockroachCoreStateMigrationName;
   sql: string;
@@ -28,7 +57,7 @@ export function createCockroachCoreStateMigration(): CockroachSchemaMigration {
   return {
     name: CockroachCoreStateMigrationName.CoreStateV1,
     sql: [
-      createWorkItemsTableSql(),
+      createLegacyWorkItemsTableSql(),
       createSupervisorSignalsTableSql(),
       createAuditEventsTableSql(),
       createOutboxEventsTableSql(),
@@ -47,11 +76,59 @@ export function createCockroachOutboxClaimFenceMigration(): CockroachSchemaMigra
   };
 }
 
-export function createCockroachCoreStateMigrations(): readonly CockroachSchemaMigration[] {
-  return [createCockroachCoreStateMigration(), createCockroachOutboxClaimFenceMigration()];
+export function createCockroachWorkAnchorKernelMigration(): CockroachSchemaMigration {
+  return {
+    name: CockroachCoreStateMigrationName.WorkAnchorKernelV3,
+    sql: createWorkAnchorKernelMigrationSql(),
+  };
 }
 
-function createWorkItemsTableSql(): string {
+export function createCockroachCoreStateMigrations(): readonly CockroachSchemaMigration[] {
+  return [
+    createCockroachCoreStateMigration(),
+    createCockroachOutboxClaimFenceMigration(),
+    createCockroachWorkAnchorKernelMigration(),
+  ];
+}
+
+function createProjectsTableSql(): string {
+  return `
+CREATE TABLE IF NOT EXISTS ${CockroachTableName.Projects} (
+  project_id STRING PRIMARY KEY,
+  organization_id STRING NOT NULL,
+  name STRING NOT NULL,
+  status STRING NOT NULL CONSTRAINT ${CockroachCheckConstraintName.ProjectStatus} CHECK (status IN (${createSqlStringList(Object.values(ProjectStatus))})),
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  version INT8 NOT NULL,
+  created_by_agent_id STRING NOT NULL,
+  created_by_hat_assignment_id STRING NOT NULL,
+  correlation_id STRING NOT NULL,
+  causation_id STRING NOT NULL,
+  trace_id STRING NOT NULL
+);`.trim();
+}
+
+function createInitiativesTableSql(): string {
+  return `
+CREATE TABLE IF NOT EXISTS ${CockroachTableName.Initiatives} (
+  initiative_id STRING PRIMARY KEY,
+  organization_id STRING NOT NULL,
+  project_id STRING NOT NULL,
+  title STRING NOT NULL,
+  status STRING NOT NULL CONSTRAINT ${CockroachCheckConstraintName.InitiativeStatus} CHECK (status IN (${createSqlStringList(Object.values(InitiativeStatus))})),
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  version INT8 NOT NULL,
+  created_by_agent_id STRING NOT NULL,
+  created_by_hat_assignment_id STRING NOT NULL,
+  correlation_id STRING NOT NULL,
+  causation_id STRING NOT NULL,
+  trace_id STRING NOT NULL
+);`.trim();
+}
+
+function createLegacyWorkItemsTableSql(): string {
   return `
 CREATE TABLE IF NOT EXISTS ${CockroachTableName.WorkItems} (
   work_item_id STRING PRIMARY KEY,
@@ -63,6 +140,48 @@ CREATE TABLE IF NOT EXISTS ${CockroachTableName.WorkItems} (
   created_at TIMESTAMPTZ NOT NULL,
   created_by_agent_id STRING NOT NULL,
   created_by_hat_assignment_id STRING NOT NULL
+);`.trim();
+}
+
+function createWorkAnchorTargetsTableSql(): string {
+  return `
+CREATE TABLE IF NOT EXISTS ${CockroachTableName.WorkAnchorTargets} (
+  work_anchor_target_id STRING PRIMARY KEY,
+  organization_id STRING NOT NULL,
+  project_id STRING NOT NULL,
+  initiative_id STRING,
+  work_item_id STRING NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  version INT8 NOT NULL,
+  created_by_agent_id STRING NOT NULL,
+  created_by_hat_assignment_id STRING NOT NULL,
+  correlation_id STRING NOT NULL,
+  causation_id STRING NOT NULL,
+  trace_id STRING NOT NULL
+);`.trim();
+}
+
+function createWorkItemStateHistoryTableSql(): string {
+  return `
+CREATE TABLE IF NOT EXISTS ${CockroachTableName.WorkItemStateHistory} (
+  work_state_transition_id STRING PRIMARY KEY,
+  organization_id STRING NOT NULL,
+  project_id STRING NOT NULL,
+  work_item_id STRING NOT NULL,
+  sequence INT8 NOT NULL CONSTRAINT ${CockroachCheckConstraintName.WorkItemStateHistorySequencePositive} CHECK (sequence > 0),
+  from_state STRING NOT NULL CONSTRAINT ${CockroachCheckConstraintName.WorkItemStateHistoryFromState} CHECK (from_state IN (${createSqlStringList(Object.values(WorkItemState))})),
+  to_state STRING NOT NULL CONSTRAINT ${CockroachCheckConstraintName.WorkItemStateHistoryToState} CHECK (to_state IN (${createSqlStringList(Object.values(WorkItemState))})),
+  evidence_artifact_ids JSONB NOT NULL,
+  assigned_engineer_hat_assignment_id STRING,
+  scheduled_work_block_id STRING,
+  transitioned_at TIMESTAMPTZ NOT NULL,
+  transitioned_by_agent_id STRING NOT NULL,
+  transitioned_by_hat_assignment_id STRING NOT NULL,
+  correlation_id STRING NOT NULL,
+  causation_id STRING NOT NULL,
+  trace_id STRING NOT NULL,
+  UNIQUE (work_item_id, sequence)
 );`.trim();
 }
 
@@ -124,6 +243,67 @@ function createOutboxClaimFenceMigrationSql(): string {
   return `
 ALTER TABLE IF EXISTS ${CockroachTableName.OutboxEvents}
   ADD COLUMN IF NOT EXISTS claim_id STRING;`.trim();
+}
+
+function createWorkAnchorKernelMigrationSql(): string {
+  return [
+    createProjectsTableSql(),
+    createInitiativesTableSql(),
+    createWorkAnchorTargetsTableSql(),
+    createWorkItemStateHistoryTableSql(),
+    `
+ALTER TABLE IF EXISTS ${CockroachTableName.WorkItems}
+  ADD COLUMN IF NOT EXISTS initiative_id STRING;`.trim(),
+    `
+ALTER TABLE IF EXISTS ${CockroachTableName.WorkItems}
+  ADD COLUMN IF NOT EXISTS work_item_type STRING DEFAULT '${CockroachSchemaBackfillValue.WorkItemTypeTask}';`.trim(),
+    `
+ALTER TABLE IF EXISTS ${CockroachTableName.WorkItems}
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;`.trim(),
+    `
+ALTER TABLE IF EXISTS ${CockroachTableName.WorkItems}
+  ADD COLUMN IF NOT EXISTS version INT8 DEFAULT ${CockroachSchemaBackfillValue.Version};`.trim(),
+    `
+ALTER TABLE IF EXISTS ${CockroachTableName.WorkItems}
+  ADD COLUMN IF NOT EXISTS correlation_id STRING DEFAULT '${CockroachSchemaBackfillValue.Trace}';`.trim(),
+    `
+ALTER TABLE IF EXISTS ${CockroachTableName.WorkItems}
+  ADD COLUMN IF NOT EXISTS causation_id STRING DEFAULT '${CockroachSchemaBackfillValue.Trace}';`.trim(),
+    `
+ALTER TABLE IF EXISTS ${CockroachTableName.WorkItems}
+  ADD COLUMN IF NOT EXISTS trace_id STRING DEFAULT '${CockroachSchemaBackfillValue.Trace}';`.trim(),
+    `
+ALTER TABLE IF EXISTS ${CockroachTableName.WorkItems}
+  ALTER COLUMN work_item_type DROP DEFAULT,
+  ALTER COLUMN version DROP DEFAULT,
+  ALTER COLUMN correlation_id DROP DEFAULT,
+  ALTER COLUMN causation_id DROP DEFAULT,
+  ALTER COLUMN trace_id DROP DEFAULT;`.trim(),
+    `
+UPDATE ${CockroachTableName.WorkItems}
+  SET work_item_type = COALESCE(work_item_type, '${CockroachSchemaBackfillValue.WorkItemTypeTask}'),
+      updated_at = COALESCE(updated_at, created_at),
+      version = COALESCE(version, ${CockroachSchemaBackfillValue.Version}),
+      correlation_id = COALESCE(correlation_id, '${CockroachSchemaBackfillValue.Trace}'),
+      causation_id = COALESCE(causation_id, '${CockroachSchemaBackfillValue.Trace}'),
+      trace_id = COALESCE(trace_id, '${CockroachSchemaBackfillValue.Trace}');`.trim(),
+    `
+ALTER TABLE IF EXISTS ${CockroachTableName.WorkItems}
+  ALTER COLUMN work_item_type SET NOT NULL,
+  ALTER COLUMN updated_at SET NOT NULL,
+  ALTER COLUMN version SET NOT NULL,
+  ALTER COLUMN correlation_id SET NOT NULL,
+  ALTER COLUMN causation_id SET NOT NULL,
+  ALTER COLUMN trace_id SET NOT NULL;`.trim(),
+    `
+ALTER TABLE IF EXISTS ${CockroachTableName.WorkItems}
+  ADD CONSTRAINT IF NOT EXISTS ${CockroachCheckConstraintName.WorkItemType} CHECK (work_item_type IN (${createSqlStringList(Object.values(WorkItemType))})),
+  ADD CONSTRAINT IF NOT EXISTS ${CockroachCheckConstraintName.WorkItemState} CHECK (state IN (${createSqlStringList(Object.values(WorkItemState))}));`.trim(),
+  ].join("\n\n");
+}
+
+function createSqlStringList(values: readonly string[]): string {
+  return values.map((value) => `'${value}'`).join(", ");
 }
 
 function createIdempotencyRecordsTableSql(): string {

--- a/agentic-organization/packages/state-cockroach/src/index.ts
+++ b/agentic-organization/packages/state-cockroach/src/index.ts
@@ -46,11 +46,14 @@ export {
   type CreateCockroachPolicyDecisionObservationStoreInput,
 } from "./cockroach-policy-decision-observation-store.ts";
 export {
+  CockroachCheckConstraintName,
   CockroachCoreStateMigrationName,
+  CockroachSchemaBackfillValue,
   CockroachTableName,
   createCockroachCoreStateMigrations,
   createCockroachCoreStateMigration,
   createCockroachOutboxClaimFenceMigration,
+  createCockroachWorkAnchorKernelMigration,
   type CockroachSchemaMigration,
 } from "./cockroach-schema.ts";
 export {

--- a/agentic-organization/packages/state-cockroach/test/cockroach-schema.test.ts
+++ b/agentic-organization/packages/state-cockroach/test/cockroach-schema.test.ts
@@ -1,12 +1,17 @@
 import { equal, ok } from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import { describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
 
+import { InitiativeStatus, ProjectStatus, WorkItemState, WorkItemType } from "../../domain/src/index.ts";
 import {
   CockroachCoreStateMigrationName,
+  CockroachSchemaBackfillValue,
   CockroachTableName,
   createCockroachCoreStateMigrations,
   createCockroachCoreStateMigration,
   createCockroachOutboxClaimFenceMigration,
+  createCockroachWorkAnchorKernelMigration,
 } from "../src/cockroach-schema.ts";
 
 describe("cockroach core state schema", () => {
@@ -53,5 +58,74 @@ describe("cockroach core state schema", () => {
 
     equal(migrations[0]?.name, CockroachCoreStateMigrationName.CoreStateV1);
     equal(migrations[1]?.name, CockroachCoreStateMigrationName.OutboxClaimFenceV2);
+    equal(migrations[2]?.name, CockroachCoreStateMigrationName.WorkAnchorKernelV3);
+  });
+
+  test("declares an additive work-anchor kernel migration for existing databases", () => {
+    const migration = createCockroachWorkAnchorKernelMigration();
+
+    equal(migration.name, CockroachCoreStateMigrationName.WorkAnchorKernelV3);
+    ok(migration.sql.includes(`CREATE TABLE IF NOT EXISTS ${CockroachTableName.Projects}`));
+    ok(migration.sql.includes(`CREATE TABLE IF NOT EXISTS ${CockroachTableName.Initiatives}`));
+    ok(migration.sql.includes(`CREATE TABLE IF NOT EXISTS ${CockroachTableName.WorkAnchorTargets}`));
+    ok(migration.sql.includes(`CREATE TABLE IF NOT EXISTS ${CockroachTableName.WorkItemStateHistory}`));
+    ok(migration.sql.includes(`ALTER TABLE IF EXISTS ${CockroachTableName.WorkItems}`));
+    ok(migration.sql.includes("ADD COLUMN IF NOT EXISTS initiative_id STRING"));
+    ok(migration.sql.includes("ADD COLUMN IF NOT EXISTS work_item_type STRING DEFAULT"));
+    ok(migration.sql.includes("ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ"));
+    ok(migration.sql.includes("ADD COLUMN IF NOT EXISTS version INT8 DEFAULT"));
+    ok(migration.sql.includes("ADD COLUMN IF NOT EXISTS correlation_id STRING DEFAULT"));
+    ok(migration.sql.includes("ADD COLUMN IF NOT EXISTS causation_id STRING DEFAULT"));
+    ok(migration.sql.includes("ADD COLUMN IF NOT EXISTS trace_id STRING DEFAULT"));
+    ok(migration.sql.includes("ALTER COLUMN work_item_type DROP DEFAULT"));
+    ok(!migration.sql.includes("ALTER COLUMN updated_at DROP DEFAULT"));
+    ok(migration.sql.includes("ALTER COLUMN version DROP DEFAULT"));
+    ok(migration.sql.includes("ALTER COLUMN correlation_id DROP DEFAULT"));
+    ok(migration.sql.includes("ALTER COLUMN causation_id DROP DEFAULT"));
+    ok(migration.sql.includes("ALTER COLUMN trace_id DROP DEFAULT"));
+    ok(migration.sql.includes("UPDATE"));
+    ok(migration.sql.includes("SET work_item_type = COALESCE"));
+    ok(migration.sql.includes(`'${CockroachSchemaBackfillValue.WorkItemTypeTask}'`));
+    ok(migration.sql.includes("ALTER COLUMN work_item_type SET NOT NULL"));
+    ok(migration.sql.includes("ALTER COLUMN updated_at SET NOT NULL"));
+    ok(migration.sql.includes("ALTER COLUMN version SET NOT NULL"));
+    ok(migration.sql.includes("ALTER COLUMN correlation_id SET NOT NULL"));
+    ok(migration.sql.includes("ALTER COLUMN causation_id SET NOT NULL"));
+    ok(migration.sql.includes("ALTER COLUMN trace_id SET NOT NULL"));
+    ok(migration.sql.includes("ADD CONSTRAINT IF NOT EXISTS"));
+    ok(migration.sql.includes(createCheckConstraintValues(Object.values(WorkItemState))));
+    ok(migration.sql.includes(createCheckConstraintValues(Object.values(WorkItemType))));
+    ok(migration.sql.includes(createCheckConstraintValues(Object.values(ProjectStatus))));
+    ok(migration.sql.includes(createCheckConstraintValues(Object.values(InitiativeStatus))));
+    ok(migration.sql.includes("CONSTRAINT agentic_org_work_item_state_history_sequence_positive_check CHECK (sequence > 0)"));
+    ok(migration.sql.includes("UNIQUE (work_item_id, sequence)"));
+    equal(CockroachSchemaBackfillValue.WorkItemTypeTask, WorkItemType.Task);
+    ok(migration.sql.includes("updated_at TIMESTAMPTZ NOT NULL"));
+    ok(migration.sql.includes("version INT8 NOT NULL"));
+    ok(migration.sql.includes("correlation_id STRING NOT NULL"));
+    ok(migration.sql.includes("causation_id STRING NOT NULL"));
+    ok(migration.sql.includes("trace_id STRING NOT NULL"));
+    ok(migration.sql.includes("sequence INT8 NOT NULL"));
+    ok(migration.sql.includes("evidence_artifact_ids JSONB NOT NULL"));
+    ok(migration.sql.includes("assigned_engineer_hat_assignment_id STRING"));
+    ok(migration.sql.includes("scheduled_work_block_id STRING"));
+  });
+
+  test("keeps generated migrations synchronized with checked-in SQL files", async () => {
+    for (const migration of createCockroachCoreStateMigrations()) {
+      equal(normalizeSql(migration.sql), normalizeSql(await readMigrationSqlFile(migration.name)));
+    }
   });
 });
+
+function createCheckConstraintValues(values: readonly string[]): string {
+  return values.map((value) => `'${value}'`).join(", ");
+}
+
+async function readMigrationSqlFile(migrationName: CockroachCoreStateMigrationName): Promise<string> {
+  return readFile(fileURLToPath(new URL(`../migrations/${migrationName}.sql`, import.meta.url)), "utf8");
+}
+
+function normalizeSql(sql: string): string {
+  return sql.replace(/\r\n/g, "\n").trim();
+}


### PR DESCRIPTION
## Summary
- add the first Work Anchor Kernel V0 domain lifecycle for work items
- replace the old `new/approved` placeholder state rail with `created -> intake -> triage -> ready -> in_progress`, plus blocked/review/done loops
- add defect lifecycle guards for created, ready, and in-progress transitions
- require work item type on domain records and add project/initiative/work-anchor/transition record types with typed status constants
- update docs to show what is implemented now versus the remaining durable schema/command work

## Validation
- npm test: 157 tests, 154 passed, 3 skipped env-gated live integrations
- npm run typecheck
- git diff --check origin/main...HEAD

## Review
- subagent review found blank-ID, optional work-item-type, status-export, transition-evidence, and doc graph issues
- fixes were applied and the full validation gate was rerun