### PR TITLE
feat(B-0867.3): add workflow action grammar parser

### DIFF
--- a/tools/workflow-engine/README.md
+++ b/tools/workflow-engine/README.md
@@ -7,6 +7,7 @@ PoC scaffold for the workflow engine v1 spec ([B-0867](../../docs/backlog/P1/B-0
 **PoC**: declarative TS type substrate + CLI dispatcher + invariant tests. Implements:
 
 - Universal action grammar atom (`Action` interface) with `ActionClass` discriminator
+- Minimal v0 action grammar parser/composer (`grammar.ts`) for B-0867.3
 - State machine atom (`State` interface) with `TickCyclePattern` variant set
 - Four-corner ownership type (`FourCornerOwnership<TIn, TOut, TOutFeedback, TInFeedback>`) per asymmetric-authorship rule
 - Otto's 5 modifications baked in as type-level invariants enforced by `validateCatalog` + `validateStateOtto5Mods`
@@ -15,7 +16,7 @@ PoC scaffold for the workflow engine v1 spec ([B-0867](../../docs/backlog/P1/B-0
 **NOT in PoC** (deferred to operator-authorized follow-up work):
 
 - State persistence — B-0867.2 (TS `state-append.ts` writer; commits state transitions to dedicated git path)
-- Real action grammar parser/composer — B-0867.3
+- Rich action grammar parser/composer — B-0867.3 beyond the v0 line grammar
 - F# 4-corner monad CE builder — B-0867.4 (hot/cold/push/pull dispatch)
 - Full agent-loop runtime — B-0867.5 phase 2 (Mika-spec integration; execute → cycle-step → CYOA OR Mika's latest pattern)
 - E voice → website surface — B-0867.10
@@ -80,6 +81,8 @@ bun test tools/workflow-engine/
 ```
 
 Invariants checked: unique action ids, Mod 2 satisfied (grammar-extension in catalog), every state satisfies Mod 1 (escape-hatch present), unknown-action references caught, Mod 4 satisfied (every action declares gate), non-empty feedbackVariants (asymmetric-authorship), seed states use discriminated-union-surface per Mika's direction.
+
+`grammar.test.ts` also verifies the v0 B-0867.3 line grammar round-trips seed actions and rejects ambiguous delimiter use.
 
 ## Composes-with substrate
 

--- a/tools/workflow-engine/grammar.test.ts
+++ b/tools/workflow-engine/grammar.test.ts
@@ -60,6 +60,25 @@ describe("B-0867.3 action grammar parser/composer", () => {
     });
   });
 
+  it("rejects empty CSV items instead of silently normalizing ambiguity", () => {
+    expect(
+      parseActionGrammarLine(
+        "x | transition | append-only | x | x | B-0867.3,,B-0914 | X",
+      ),
+    ).toEqual({
+      ok: false,
+      error: "composesWith contains an empty item",
+    });
+    expect(
+      parseActionGrammarLine(
+        "x | transition | append-only | x | x | B-0867.3 | X,",
+      ),
+    ).toEqual({
+      ok: false,
+      error: "feedbackVariants contains an empty item",
+    });
+  });
+
   it("composer rejects unsupported delimiters before producing an ambiguous line", () => {
     const invalid: Action = {
       ...SEED_ACTION_CATALOG[0]!,
@@ -68,6 +87,26 @@ describe("B-0867.3 action grammar parser/composer", () => {
     expect(composeActionGrammarLine(invalid)).toEqual({
       ok: false,
       error: "action field contains an unsupported delimiter",
+    });
+  });
+
+  it("composer rejects non-canonical whitespace before parse can normalize it", () => {
+    const scalarWhitespace: Action = {
+      ...SEED_ACTION_CATALOG[0]!,
+      label: " advance ",
+    };
+    expect(composeActionGrammarLine(scalarWhitespace)).toEqual({
+      ok: false,
+      error: "action field must be trimmed",
+    });
+
+    const listWhitespace: Action = {
+      ...SEED_ACTION_CATALOG[0]!,
+      composesWith: ["B-0867.3", " B-0914"],
+    };
+    expect(composeActionGrammarLine(listWhitespace)).toEqual({
+      ok: false,
+      error: "composesWith item must be trimmed",
     });
   });
 });

--- a/tools/workflow-engine/grammar.test.ts
+++ b/tools/workflow-engine/grammar.test.ts
@@ -1,0 +1,73 @@
+/**
+ * tools/workflow-engine/grammar.test.ts
+ *
+ * B-0867.3 minimal parser/composer coverage.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { composeActionGrammarLine, parseActionGrammarLine } from "./grammar";
+import { SEED_ACTION_CATALOG, type Action } from "./types";
+
+describe("B-0867.3 action grammar parser/composer", () => {
+  it("round-trips every seed action through the v0 line grammar", () => {
+    for (const action of SEED_ACTION_CATALOG) {
+      const composed = composeActionGrammarLine(action);
+      expect(composed.ok).toBe(true);
+      if (!composed.ok) continue;
+      const parsed = parseActionGrammarLine(composed.line);
+      expect(parsed.ok).toBe(true);
+      if (parsed.ok) {
+        expect(parsed.action).toEqual(action);
+      }
+    }
+  });
+
+  it("parses a grammar-extension action with explicit review gate", () => {
+    const parsed = parseActionGrammarLine(
+      "propose-rank | grammar-extension | pr-gated | propose-rank-action | add ranking action | B-0867.3,B-0914 | GrammarExtensionProposed",
+    );
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.action.class).toBe("grammar-extension");
+      expect(parsed.action.gate).toBe("pr-gated");
+      expect(parsed.action.composesWith).toEqual(["B-0867.3", "B-0914"]);
+      expect(parsed.action.feedbackVariants).toEqual(["GrammarExtensionProposed"]);
+    }
+  });
+
+  it("rejects unknown classes and gates as grammar errors", () => {
+    expect(
+      parseActionGrammarLine(
+        "x | unknown-class | append-only | x | x | B-0867.3 | X",
+      ),
+    ).toEqual({ ok: false, error: "unknown action class: unknown-class" });
+    expect(
+      parseActionGrammarLine(
+        "x | transition | unknown-gate | x | x | B-0867.3 | X",
+      ),
+    ).toEqual({ ok: false, error: "unknown action gate: unknown-gate" });
+  });
+
+  it("rejects malformed field counts and missing feedback variants", () => {
+    expect(parseActionGrammarLine("too | short").ok).toBe(false);
+    expect(
+      parseActionGrammarLine(
+        "x | transition | append-only | x | x | B-0867.3 | ",
+      ),
+    ).toEqual({
+      ok: false,
+      error: "feedbackVariants requires at least one item",
+    });
+  });
+
+  it("composer rejects unsupported delimiters before producing an ambiguous line", () => {
+    const invalid: Action = {
+      ...SEED_ACTION_CATALOG[0]!,
+      label: "bad | label",
+    };
+    expect(composeActionGrammarLine(invalid)).toEqual({
+      ok: false,
+      error: "action field contains an unsupported delimiter",
+    });
+  });
+});

--- a/tools/workflow-engine/grammar.ts
+++ b/tools/workflow-engine/grammar.ts
@@ -1,0 +1,163 @@
+/**
+ * tools/workflow-engine/grammar.ts
+ *
+ * B-0867.3 minimal universal action grammar parser/composer.
+ *
+ * v0 line format:
+ *
+ *   id | class | gate | label | description | composesWith csv | feedback csv
+ *
+ * The line is deliberately boring: pipe-delimited fields, comma-delimited
+ * lists, and no escaping. If a field needs "|" or a list item needs ",",
+ * promote the grammar before using that value.
+ */
+
+import type { Action, ActionClass, ActionGate } from "./types";
+
+export type ActionGrammarParseResult =
+  | { readonly ok: true; readonly action: Action }
+  | { readonly ok: false; readonly error: string };
+
+export type ActionGrammarComposeResult =
+  | { readonly ok: true; readonly line: string }
+  | { readonly ok: false; readonly error: string };
+
+const ACTION_CLASSES: ReadonlySet<string> = new Set([
+  "transition",
+  "escape-hatch",
+  "grammar-extension",
+  "menu-contribution",
+  "operator-decision",
+  "agent-decision",
+]);
+
+const ACTION_GATES: ReadonlySet<string> = new Set([
+  "append-only",
+  "pr-gated",
+]);
+
+function splitCsv(field: string): ReadonlyArray<string> {
+  if (field.trim() === "") return [];
+  return field
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+function hasIllegalDelimiter(value: string): boolean {
+  return value.includes("|") || value.includes("\n") || value.includes("\r");
+}
+
+function validateScalar(name: string, value: string): string | undefined {
+  if (value.length === 0) return `${name} is required`;
+  if (hasIllegalDelimiter(value)) {
+    return `${name} contains an unsupported delimiter`;
+  }
+  return undefined;
+}
+
+function validateList(name: string, values: ReadonlyArray<string>): string | undefined {
+  for (const value of values) {
+    if (value.length === 0) return `${name} contains an empty item`;
+    if (hasIllegalDelimiter(value) || value.includes(",")) {
+      return `${name} item contains an unsupported delimiter`;
+    }
+  }
+  return undefined;
+}
+
+export function parseActionGrammarLine(line: string): ActionGrammarParseResult {
+  const fields = line.split("|").map((field) => field.trim());
+  if (fields.length !== 7) {
+    return {
+      ok: false,
+      error: `expected 7 pipe-delimited fields, got ${fields.length}`,
+    };
+  }
+
+  const [
+    id,
+    actionClass,
+    gate,
+    label,
+    description,
+    composesWithRaw,
+    feedbackRaw,
+  ] = fields;
+
+  const scalarError =
+    validateScalar("id", id ?? "") ??
+    validateScalar("class", actionClass ?? "") ??
+    validateScalar("gate", gate ?? "") ??
+    validateScalar("label", label ?? "") ??
+    validateScalar("description", description ?? "");
+  if (scalarError !== undefined) return { ok: false, error: scalarError };
+
+  if (!ACTION_CLASSES.has(actionClass ?? "")) {
+    return { ok: false, error: `unknown action class: ${actionClass ?? ""}` };
+  }
+  if (!ACTION_GATES.has(gate ?? "")) {
+    return { ok: false, error: `unknown action gate: ${gate ?? ""}` };
+  }
+
+  const composesWith = splitCsv(composesWithRaw ?? "");
+  const feedbackVariants = splitCsv(feedbackRaw ?? "");
+  const listError =
+    validateList("composesWith", composesWith) ??
+    validateList("feedbackVariants", feedbackVariants);
+  if (listError !== undefined) return { ok: false, error: listError };
+  if (feedbackVariants.length === 0) {
+    return { ok: false, error: "feedbackVariants requires at least one item" };
+  }
+
+  return {
+    ok: true,
+    action: {
+      id: id ?? "",
+      class: actionClass as ActionClass,
+      gate: gate as ActionGate,
+      label: label ?? "",
+      description: description ?? "",
+      composesWith,
+      feedbackVariants,
+    },
+  };
+}
+
+export function composeActionGrammarLine(action: Action): ActionGrammarComposeResult {
+  const scalarFields = [
+    action.id,
+    action.class,
+    action.gate,
+    action.label,
+    action.description,
+  ];
+  for (const field of scalarFields) {
+    const error = validateScalar("action field", field);
+    if (error !== undefined) {
+      return { ok: false, error };
+    }
+  }
+  const listError =
+    validateList("composesWith", action.composesWith) ??
+    validateList("feedbackVariants", action.feedbackVariants);
+  if (listError !== undefined) {
+    return { ok: false, error: listError };
+  }
+  if (action.feedbackVariants.length === 0) {
+    return { ok: false, error: "feedbackVariants requires at least one item" };
+  }
+
+  return {
+    ok: true,
+    line: [
+      action.id,
+      action.class,
+      action.gate,
+      action.label,
+      action.description,
+      action.composesWith.join(","),
+      action.feedbackVariants.join(","),
+    ].join(" | "),
+  };
+}

--- a/tools/workflow-engine/grammar.ts
+++ b/tools/workflow-engine/grammar.ts
@@ -40,8 +40,7 @@ function splitCsv(field: string): ReadonlyArray<string> {
   if (field.trim() === "") return [];
   return field
     .split(",")
-    .map((part) => part.trim())
-    .filter((part) => part.length > 0);
+    .map((part) => part.trim());
 }
 
 function hasIllegalDelimiter(value: string): boolean {
@@ -49,7 +48,8 @@ function hasIllegalDelimiter(value: string): boolean {
 }
 
 function validateScalar(name: string, value: string): string | undefined {
-  if (value.length === 0) return `${name} is required`;
+  if (value.trim().length === 0) return `${name} is required`;
+  if (value.trim() !== value) return `${name} must be trimmed`;
   if (hasIllegalDelimiter(value)) {
     return `${name} contains an unsupported delimiter`;
   }
@@ -58,7 +58,8 @@ function validateScalar(name: string, value: string): string | undefined {
 
 function validateList(name: string, values: ReadonlyArray<string>): string | undefined {
   for (const value of values) {
-    if (value.length === 0) return `${name} contains an empty item`;
+    if (value.trim().length === 0) return `${name} contains an empty item`;
+    if (value.trim() !== value) return `${name} item must be trimmed`;
     if (hasIllegalDelimiter(value) || value.includes(",")) {
       return `${name} item contains an unsupported delimiter`;
     }


### PR DESCRIPTION
## Summary
- add a minimal v0 pipe-delimited parser/composer for B-0867 action grammar lines
- use Result-style parse/compose outcomes and reject ambiguous delimiters before composing
- cover seed-action round trips and update workflow-engine docs to mark richer grammar support as future work

## Verification
- bun test tools/workflow-engine/grammar.test.ts tools/workflow-engine/types.test.ts
- bun test tools/workflow-engine/
- git diff --check

Typecheck note: bun run typecheck --pretty false could not run because tsc is not installed in this worktree local dependencies.