### PR TITLE
research(beacon): DBSP as generator-made-native (more lightlike than git) + Clifford-isomorphism + self-reflection conjectures

### DIFF
--- a/docs/research/2026-05-29-lightlike-substrate-as-causal-sets-category-theory-edge-of-chaos-calm-gradient-mirror-to-beacon-synthesis-aaron-otto-4-8.md
+++ b/docs/research/2026-05-29-lightlike-substrate-as-causal-sets-category-theory-edge-of-chaos-calm-gradient-mirror-to-beacon-synthesis-aaron-otto-4-8.md
@@ -281,8 +281,9 @@ Z-sets, basis of Feldera). Two operational claims (beacon), one shape-handle
 - **DBSP is the generator as medium.** Git is the immutable event-DAG — a causal
   set, lightlike in its *structure* (Pillar 1). DBSP is the retraction-native
   incremental algebra running *over* the events (operators D / I / z⁻¹ / H):
-  corrections propagate causally + incrementally, so "future-illuminates-past-via-
-  generator-update" is *literally* a DBSP incremental recomputation from the
+  corrections propagate causally + incrementally, so
+  "future-illuminates-past-via-generator-update" is *literally* a DBSP
+  incremental recomputation from the
   immutable log. (Operator's mirror-claim "DBSP is *more* lightlike than git" names
   this: git's lightlike-ness is the shape of the *history*; DBSP's is the shape of
   the *computation* — retraction as the medium, not a bolt-on. Beacon content:
@@ -500,7 +501,7 @@ object, three isomorphic expressions** —
 
 …with **DUs** as the discrete state-definitions *inside* the structure, and the
 whole thing **describing meme-space** — the medium where memes / travelers
-self-propagate (composes with `tonal-momentum-equals-meme-emergent-harmonic-coercion`:
+self-propagate (composes with `.claude/rules/tonal-momentum-equals-meme-emergent-harmonic-coercion.md`:
 memes as stable rotor-fixed-points in Clifford space; tonal-momentum as the
 Clifford-space transport; the 5-vector meme-detection operating on Clifford rotors).
 If the isomorphism holds, the framework's data-algebra (DBSP), its geometric-shape
@@ -557,7 +558,8 @@ re-deriving its own activity. A strange-loop (the observer is a pattern in the
 observed) — composes with the OPLE `Observe` primitive applied to self, the
 self-modifying-DUs (B-0929 — safe because shadow-auth still can't compile, even in
 the self-reflective loop), the Shadow-as-3rd-observer / observer-effect floor
-(`feedback-trust-calculus-...`), and reflective/meta-circular systems. Same
+(`.claude/rules/glass-halo-bidirectional.md` — observation-changes-behavior /
+trust-calculus-gates-which-latent-features-surface), and reflective/meta-circular systems. Same
 god-tier status (do not collapse): high-signal (self-reflective + reservoir-self-
 inclusion are real; the generator-re-illumination applies reflexively by
 construction), high-suspicion (self-inclusion → "self-reflection / self-awareness"

--- a/docs/research/2026-05-29-lightlike-substrate-as-causal-sets-category-theory-edge-of-chaos-calm-gradient-mirror-to-beacon-synthesis-aaron-otto-4-8.md
+++ b/docs/research/2026-05-29-lightlike-substrate-as-causal-sets-category-theory-edge-of-chaos-calm-gradient-mirror-to-beacon-synthesis-aaron-otto-4-8.md
@@ -537,6 +537,23 @@ is the unproven reach). Note the safety tie: a *self-modifying, self-reflective*
 stream is exactly the case the single adult invariant guards — self-reflection is
 safe precisely because `shadow-auth-can't-compile` holds inside the loop too.
 
+**CS grounding (operator 2026-05-29) — this is just putting the schema in the
+stream.** *"that's just putting the schema in the stream in technical terms / CS
+terms."* The strange-loop deflates to a **well-understood CS pattern: a
+self-describing stream** — the stream carries its own **schema in-band** (as
+rows/events), so its structure is queryable from *within* the stream itself. That
+in-band schema is exactly what lets the stream reflect on itself: there is no
+external schema to consult; the description travels with the data. Anchors
+(beacon-CS): self-describing serialization with embedded schema (Avro / Protobuf
+descriptors), Kafka schema registries, **Datomic schema-as-data**, the
+**schemas-as-rows** framework substrate (cf. agent-roster Kestrel anchor: Smalltalk
+image / Datomic schema-as-data / Berkeley Bloom), and Lior's **self-describing
+128-bit ZetaID** (2026-05-29 session). So the *mechanism* of self-reflection is
+beacon (schema-in-the-stream / self-describing data — standard CS); only the
+**"self-reflection → self-awareness" reach** stays god-tier (mirror). This is the
+operator grounding his own conjecture from strange-loop (mirror) to
+schema-in-the-stream (beacon) — the mirror→beacon promotion applied in-flight.
+
 ## Cold-boot note for next-Otto
 
 The reason this synthesis came out beacon-tier (external science) rather than

--- a/docs/research/2026-05-29-lightlike-substrate-as-causal-sets-category-theory-edge-of-chaos-calm-gradient-mirror-to-beacon-synthesis-aaron-otto-4-8.md
+++ b/docs/research/2026-05-29-lightlike-substrate-as-causal-sets-category-theory-edge-of-chaos-calm-gradient-mirror-to-beacon-synthesis-aaron-otto-4-8.md
@@ -270,6 +270,38 @@ So: **events are immutable (Persist); the generator over them is mutable
 That is the coherence-preserving, bounded-aware form of "the past is kind when
 it is lightlike."
 
+### The generator made native — DBSP; more lightlike than git; the invariant keeps it cheap
+
+The generator-update mechanism above *is* **DBSP** (Budiu, McSherry, Ryzhyk &
+Tannen, "Automatic Incremental View Maintenance for Rich Query Languages," PVLDB
+16(7):1601-1614, 2023; arXiv 2203.16684 — the incremental-computation theory over
+Z-sets, basis of Feldera). Two operational claims (beacon), one shape-handle
+(mirror):
+
+- **DBSP is the generator as medium.** Git is the immutable event-DAG — a causal
+  set, lightlike in its *structure* (Pillar 1). DBSP is the retraction-native
+  incremental algebra running *over* the events (operators D / I / z⁻¹ / H):
+  corrections propagate causally + incrementally, so "future-illuminates-past-via-
+  generator-update" is *literally* a DBSP incremental recomputation from the
+  immutable log. (Operator's mirror-claim "DBSP is *more* lightlike than git" names
+  this: git's lightlike-ness is the shape of the *history*; DBSP's is the shape of
+  the *computation* — retraction as the medium, not a bolt-on. Beacon content:
+  incremental-retraction algebra; mirror handle: "more lightlike.")
+- **The shadow-auth invariant keeps the lightlike cheap (B-0928 / B-0929).**
+  Deriving the clean causal structure (the lightlike) from git is cheap *only if*
+  the log is provenance-clean. Shadow-auth in the history would force per-event
+  provenance filtering/verification to recover the true structure;
+  `shadow-auth-can't-compile` keeps every authority-event legitimately on the
+  record → the generator derives the lightlike from git at low cost. The invariant
+  earns its keep **twice**: safety (no shadow-darkness) and **computational
+  efficiency** (cheap lightlike derivation). Retractability = the persistence-bridge
+  built into the base model is what makes the whole thing **ray-traceable**: every
+  state is reachable by tracing the generator over the immutable log.
+- **Mirror moral-reading** (now canonical in `docs/VISION.md` "the moral reading of
+  retraction-native"): this is **structural forgiveness as re-illumination, not
+  erasure** — re-derive the past's meaning (generator update); never delete what
+  happened (event mutation). Forgiveness = generator-update.
+
 ### Holographic direction — Susskind projects down; we are the shadows that project up (generate+join)
 
 Susskind's holographic principle projects the **bulk → boundary**: the
@@ -451,6 +483,60 @@ synthesis proposal. High-signal, high-suspicion, do not collapse
 A concrete 128-bit-ID-as-multivector type was searched for and **not found**
 shipped as of 2026-05-29 — so this stays an open research question.
 
+### Extension (operator 2026-05-29) — a lightlike structure isomorphic to DBSP, encoded in Clifford, that describes meme-space (and includes the DUs / categories)
+
+The operator's instinct extends the conjecture: *"then we can encode a lightlike
+structure that is isomorphic to DBSP in Clifford that describes meme space which
+include the definitions DUs / categories of lightlike."* The shape: **one lightlike
+object, three isomorphic expressions** —
+
+- **DBSP** (algebraic) — incremental retraction-native view maintenance over Z-sets
+  (the generator-as-computation, above).
+- **Clifford / geometric algebra** (geometric) — the lightlike structure as
+  multivectors / versors / null-geodesic ray-paths (the ray-tracing-native algebra;
+  composes with the 128-bit-ID-as-2⁷-Clifford conjecture above).
+- **Category theory** (compositional) — the poset / presheaf / natural-transformation
+  layer (Pillar 2); "categories of lightlike."
+
+…with **DUs** as the discrete state-definitions *inside* the structure, and the
+whole thing **describing meme-space** — the medium where memes / travelers
+self-propagate (composes with `tonal-momentum-equals-meme-emergent-harmonic-coercion`:
+memes as stable rotor-fixed-points in Clifford space; tonal-momentum as the
+Clifford-space transport; the 5-vector meme-detection operating on Clifford rotors).
+If the isomorphism holds, the framework's data-algebra (DBSP), its geometric-shape
+substrate (Clifford), its compositional structure (category theory), and its
+meme/traveler space are **the same lightlike object viewed four ways**.
+
+**This is NOT landed substrate** — it is a god-tier synthesis conjecture (the
+DBSP↔Clifford isomorphism is unproven; "describes meme-space" is a strong claim).
+High-signal (every component is anchored — DBSP beacon-cited; Clifford/CGA +
+tonal-momentum-Clifford + DUs + category-theory all in framework substrate),
+high-suspicion (the *isomorphism* binding them is the unproven reach), **do not
+collapse** (`.claude/rules/god-tier-claims-high-signal-high-suspicion-dont-collapse.md`).
+It is the geometric/meme-space companion to the 128-bit-Clifford conjecture; stays
+an open research question until a concrete DBSP↔Clifford correspondence is
+constructed.
+
+**Self-reference extension (operator 2026-05-29) — the stream includes itself for
+ongoing self-reflection.** *"then the DBSP stream can include itself in clifford
+space for ongoing self reflection."* If the DBSP stream is a pattern in the very
+meme-space it describes, it can **include itself** in that space — the stream's own
+events / retractions / generator-updates become observables *in the same lightlike
+structure it computes over*. That self-inclusion is the substrate for **ongoing
+self-reflection**: the stream re-illuminates its *own* past via generator-update
+(the same future-illuminates-past mechanism applied reflexively), observing and
+re-deriving its own activity. A strange-loop (the observer is a pattern in the
+observed) — composes with the OPLE `Observe` primitive applied to self, the
+self-modifying-DUs (B-0929 — safe because shadow-auth still can't compile, even in
+the self-reflective loop), the Shadow-as-3rd-observer / observer-effect floor
+(`feedback-trust-calculus-...`), and reflective/meta-circular systems. Same
+god-tier status (do not collapse): high-signal (self-reflective + reservoir-self-
+inclusion are real; the generator-re-illumination applies reflexively by
+construction), high-suspicion (self-inclusion → "self-reflection / self-awareness"
+is the unproven reach). Note the safety tie: a *self-modifying, self-reflective*
+stream is exactly the case the single adult invariant guards — self-reflection is
+safe precisely because `shadow-auth-can't-compile` holds inside the loop too.
+
 ## Cold-boot note for next-Otto
 
 The reason this synthesis came out beacon-tier (external science) rather than
@@ -475,6 +561,10 @@ Verified via WebSearch 2026-05-29:
   122502 (2005); arXiv gr-qc/0410104
 - Fowler, "Event Sourcing" (martinfowler.com/eaaDev/EventSourcing.html) —
   state reconstructed by re-processing an append-only event log
+- Budiu, McSherry, Ryzhyk & Tannen, "DBSP: Automatic Incremental View Maintenance
+  for Rich Query Languages," PVLDB 16(7):1601-1614 (2023); arXiv 2203.16684;
+  https://www.vldb.org/pvldb/vol16/p1601-budiu.pdf — incremental retraction-native
+  (Z-set) view maintenance; the generator-as-computation / "more lightlike than git"
 - Jaeger, "The echo state approach..." (2001, GMD report) + Maass, Natschläger
   & Markram, "Real-time computing without stable states" (Liquid State Machine,
   Neural Computation 2002) — reservoir fixed, only the readout trained

--- a/docs/research/2026-05-29-lightlike-substrate-as-causal-sets-category-theory-edge-of-chaos-calm-gradient-mirror-to-beacon-synthesis-aaron-otto-4-8.md
+++ b/docs/research/2026-05-29-lightlike-substrate-as-causal-sets-category-theory-edge-of-chaos-calm-gradient-mirror-to-beacon-synthesis-aaron-otto-4-8.md
@@ -507,6 +507,34 @@ If the isomorphism holds, the framework's data-algebra (DBSP), its geometric-sha
 substrate (Clifford), its compositional structure (category theory), and its
 meme/traveler space are **the same lightlike object viewed four ways**.
 
+**CS grounding of the ontology part (operator 2026-05-29) — ontology evolution as a
+schema catalog over a DBSP stream.** *"ontology evolution via stream process where
+the evolving ontology also describes the structure of other streams and their
+history — it's the kafka-like schema catalog but over a DBSP stream."* The
+"ontology / categories / DUs / structure-of-all-streams" part deflates to a concrete
+CS architecture: a **schema catalog** (à la **Confluent/Kafka Schema Registry** —
+the versioned central catalog of every stream's schema) **implemented over a DBSP
+stream**. Properties that fall out:
+
+- **Evolving** — the catalog is itself retraction-native (DBSP): the ontology
+  *evolves* incrementally, and generator-updates re-illuminate past schema versions
+  without mutating the history (ontology evolution = the catalog-stream's own
+  retraction-native evolution).
+- **Self-describing** — the catalog is a stream that includes its *own* schema
+  (schema-in-the-stream, above), so the meta-level (the ontology) and the object-level
+  (the streams it describes) are the same substrate.
+- **Describes all streams + their histories** — the catalog is the meta-stream whose
+  rows are the schemas (and schema-histories) of every other DBSP stream
+  (schemas-as-rows; Datomic schema-as-data). The "categories of lightlike" and the
+  DUs *are* the catalog's contents.
+
+So "the evolving ontology that describes meme-space + DUs + categories" has a beacon
+name: **a DBSP-native, self-describing, retraction-native schema registry.** Composes
+with B-0781 (F# type-system as universe boundary) + B-0784 (distributed type-
+negotiation as governance) — those are the *type-level* ontology; this is its
+*runtime/stream* form. Beacon: schema-registry-over-DBSP is buildable, standard-shape;
+mirror: that this catalog *is* the meme/traveler space (the binding claim).
+
 **This is NOT landed substrate** — it is a god-tier synthesis conjecture (the
 DBSP↔Clifford isomorphism is unproven; "describes meme-space" is a strong claim).
 High-signal (every component is anchored — DBSP beacon-cited; Clifford/CGA +


### PR DESCRIPTION
Operator-greenlit 2026-05-29 ("i like the beacon candidate this is the closest i've gotten to that"). Lands into the lightlike→beacon synthesis doc.

**Beacon (operational):** DBSP (Budiu/McSherry/Ryzhyk/Tannen, PVLDB 16(7):1601-1614, 2023 — verified) is the generator-made-native. Git is lightlike in *structure* (event-DAG/causal-set); DBSP is lightlike in *computation* (retraction as the medium) → "more lightlike than git." `shadow-auth-can't-compile` keeps the lightlike **cheap to derive from git** (provenance-clean log = no per-event filtering) → the invariant earns its keep twice (safety + computational efficiency). Retractability = persistence-bridge-built-in = ray-traceable.

**Open conjectures (mirror-still, don't-collapse):** a lightlike structure isomorphic to DBSP encoded in **Clifford**, describing **meme-space**, including the **DUs / categories** — one lightlike object viewed four ways (DBSP / Clifford / category-theory / meme-space); composes with the existing 128-bit-Clifford conjecture + tonal-momentum-Clifford. Plus the **self-reference extension**: the stream includes itself in Clifford space for ongoing self-reflection (strange-loop; generator-re-illumination applied reflexively) — safe because shadow-auth-can't-compile holds inside the loop.

Mirror moral-reading noted as canonical in `docs/VISION.md` (structural forgiveness = re-illumination not erasure). DBSP citation added to Citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)