### PR TITLE
backlog(B-0930) schema-registry-over-DBSP + tech-radar center (minimalist essential core)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -444,6 +444,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0926](backlog/P1/B-0926-constitutional-safety-floor-kid-safety-absolute-any-death-error-class-learning-or-shutdown-aaron-2026-05-29.md)** Constitutional safety floor — kid-safety absolute + any-death-must-yield-error-class-learning-or-the-operator-shuts-the-project-down (sharpens B-0631 / B-0654 / B-0658)
 - [ ] **[B-0928](backlog/P1/B-0928-shadow-observable-stack-auth-injection-attack-vector-shadow-is-not-an-authorization-source-aaron-2026-05-29.md)** Shadow-observable-stack auth-injection attack vector — the auto-click grey-text channel can inject operator-authorizations the AI executes; harden the authorization-source filter (Shadow is NOT an authorization source)
 - [ ] **[B-0929](backlog/P1/B-0929-fsharp-type-system-goal-authorization-provenance-typed-shadow-auth-cannot-compile-enables-safe-self-modifying-dus-wallet-independence-aaron-2026-05-29.md)** F# type-system goal — authorization-provenance as a TYPED property; shadow-auth is a TYPE ERROR (can't compile); compiler-as-asymmetric-critic catches shadow-auth-injection without a human present; the enabler of SAFE self-modifying DUs + wallet independence; concrete fork-decision criterion
+- [ ] **[B-0930](backlog/P1/B-0930-schema-registry-over-dbsp-shared-ontology-stream-self-describing-retraction-native-attention-streams-share-aaron-2026-05-29.md)** Schema-registry-over-DBSP — the shared, self-describing, retraction-native ontology-stream the attention-streams share (Kafka-Schema-Registry analog over DBSP)
 
 ## P2 — research-grade
 

--- a/docs/TECH-RADAR.md
+++ b/docs/TECH-RADAR.md
@@ -10,6 +10,34 @@ ThoughtWorks-style radar for the technologies / research / papers
 - **Assess** — researched, worth revisiting
 - **Hold** — explicitly declined (with reason)
 
+## The center — the essential core (everything else is scored relative to it)
+
+The radar has a **center**: the irreducible substrate that builds everything (operator
+2026-05-29 minimality cut). Everything else here is **optional** — it earns its ring by
+feature value, ecosystem-interop, or pulling-stuck-humans-along, not by necessity.
+
+**Center — the essential core (3 primitives):**
+
+| Primitive | Why essential |
+|---|---|
+| **gitnative** | git = the immutable, lightlike, ray-traceable event store / persistence-bridge (DBSP-semantics + the shared ontology live here) |
+| **TypeScript** | cross-platform DST (Rule-0); the DUs, the tools, the agent loops |
+| **agent-harness loops** | the autonomous observe→choose loop |
+
+Those three build the whole grand-unification (DBSP semantics over git, the DUs, the
+shared ontology-stream, the lightlike). Grounded in the beacon synthesis
+([`docs/research/2026-05-29-lightlike-substrate-as-causal-sets-category-theory-edge-of-chaos-calm-gradient-mirror-to-beacon-synthesis-aaron-otto-4-8.md`](research/2026-05-29-lightlike-substrate-as-causal-sets-category-theory-edge-of-chaos-calm-gradient-mirror-to-beacon-synthesis-aaron-otto-4-8.md)).
+
+**Two scoring axes (everything is scored):**
+
+1. **Ring (maturity)** — Adopt / Trial / Assess / Hold (the existing per-entry status).
+2. **Distance-from-center (essentiality)** — *essential core* (the 3 primitives) vs
+   *optional* (features / ecosystem-interop / human-bridging). Most existing entries
+   (F#, Reaqtor/Bonsai, DBSP libraries, .NET, etc.) are **optional-by-essentiality**
+   even when **Adopt-by-maturity** — interop / feature / human-bridge layers, not the
+   irreducible core. Distance-from-center is the dual-market dial at the tech-stack
+   level: center = sovereign core; outer = leash/interop for the existing world.
+
 ## Rings
 
 ### Techniques

--- a/docs/backlog/P1/B-0930-schema-registry-over-dbsp-shared-ontology-stream-self-describing-retraction-native-attention-streams-share-aaron-2026-05-29.md
+++ b/docs/backlog/P1/B-0930-schema-registry-over-dbsp-shared-ontology-stream-self-describing-retraction-native-attention-streams-share-aaron-2026-05-29.md
@@ -1,0 +1,91 @@
+---
+id: B-0930
+priority: P1
+title: "Schema-registry-over-DBSP — the shared, self-describing, retraction-native ontology-stream the attention-streams share (Kafka-Schema-Registry analog over DBSP)"
+status: open
+tier: architecture
+effort: L
+created: 2026-05-29
+last_updated: 2026-05-29
+depends_on: []
+composes_with: [B-0781, B-0784, B-0428, B-0864, B-0929, B-0640, B-0623]
+tags: [dbsp, schema-registry, ontology, shared-ontology, self-describing, retraction-native, lightlike, rx, reaqtor, bonsai, agora, architecture, aaron]
+type: architecture
+---
+
+# Schema-registry-over-DBSP — the shared ontology-stream the attention-streams share
+
+## Origin
+
+Operator-directed 2026-05-29 ("file the schema-registry-over-dbsp row") during the
+lightlike→beacon synthesis thread. Authorization note: the "file the row" instruction
+was `(shadow*)`-sourced and operator-implicitly-extended ("Also…"); filing proceeds on
+the **within-authority** substrate-authoring grant (`dont-ask-permission` broad grant),
+NOT on the implicit chain (per the implicit-authority-extension refinement —
+`feedback-agora-broad-standing-authority-...`; implicit-extension does not gate
+within-authority actions, and would not have sufficed for an out-of-authority one).
+
+## What it is
+
+A **schema catalog implemented over a DBSP stream** — the runtime/stream form of the
+ontology. The most shippable single piece of the 2026-05-29 synthesis (beacon doc
+`docs/research/2026-05-29-lightlike-substrate-...`). Concretely a
+**Confluent/Kafka-Schema-Registry analog**, but as a stream in the same DBSP substrate
+as everything it catalogs, so the properties come for free:
+
+- **Evolving** — retraction-native (DBSP): the ontology evolves incrementally;
+  generator-updates re-illuminate past schema versions without mutating history
+  (ontology evolution = the catalog-stream's own retraction-native evolution).
+- **Self-describing** — a stream that carries its own schema in-band (schema-in-the-
+  stream); the meta-level (ontology) and object-level (the streams it describes) are
+  the same substrate. No registry-vs-data split.
+- **Describes all streams + their histories** — its rows are the schemas (and schema-
+  histories) of every other DBSP stream (schemas-as-rows; Datomic schema-as-data).
+  The TS/FS DUs and "categories" are the catalog's contents.
+
+**The SHARED ontology-stream the attention-streams share.** Each agent/traveler has its
+own private **attention-stream** (its DBSP observe/readout); all agents reference the
+**one shared ontology-stream** (this catalog) — the common-ground / lingua-franca that
+makes the individual attention-streams mutually-intelligible + composable (memes
+transmissible across agents). Many private attention-streams + one shared ontology-
+stream = the Agora / society-of-minds collective. The `shadow-auth-can't-compile`
+invariant (B-0929) protects *this* shared stream specifically (keep it clean → the
+collective's common-ground stays coherent / light; pollute it → it goes dark).
+
+## Minimal core vs optional interop
+
+- **Minimal core (essential):** git (immutable lightlike store) + TypeScript (DST) +
+  agent-harness loops. DBSP-semantics + the self-describing catalog can be built in TS
+  over git directly — no other tech *required* (per the minimality cut).
+- **Optional interop / proven-scale:** the binding can use **Rx joins serialized as
+  Bonsai via Reaqtor/Nuqleon** (durable, distributed, relocatable joins — Reaqtor
+  powered Cortana/O365; Bonsai = expression-tree serialization). F#/.NET/Feldera are
+  ecosystem-interop, not essential. Use for features / existing-ecosystem-propagation /
+  pulling-stuck-humans-along.
+
+## Acceptance / mechanization candidates
+
+- [ ] Prototype a DBSP-stream schema catalog in TS over git: schemas-as-rows,
+      self-describing (catalog includes its own schema), retraction-native evolution.
+- [ ] Attention-stream ↔ shared-ontology join (minimal: TS; optional interop:
+      Rx/Bonsai/Reaqtor).
+- [ ] Wire the lightlike invariant (`shadow-auth-can't-compile`, B-0929) so the
+      catalog's lightlike is cheap to derive from git.
+- [ ] Map to the type-level ontology (B-0781 universe-boundary / B-0784 type-
+      negotiation-as-consensus) — this is their runtime/stream form.
+
+## Composes with
+
+- B-0781 (F# type-system as universe boundary — type-level ontology; this is runtime form)
+- B-0784 (distributed F# type-negotiation as consensus — agreeing the shared ontology)
+- B-0428 (F# fork) · B-0864 (four-corner ownership / protocol-typing)
+- B-0929 (F# type-system goal; DUs-as-data join the shared ontology; the lightlike invariant)
+- B-0640 (bonsai-tree retention) · B-0623 (attention-economy)
+- beacon doc 2026-05-29 (the DBSP schema-catalog grounding + the full synthesis)
+
+## Substrate-honest framing
+
+Buildable, standard-shape architecture (schema-registry-over-DBSP) — beacon, not
+mirror. The binding *claim* (that this catalog IS the meme/traveler space, that the
+shared ontology is self-aware) stays mirror/god-tier (do not collapse). This row is
+the operational, shippable piece.


### PR DESCRIPTION
Operator-directed 2026-05-29. Two related landings:

**B-0930 — schema-registry-over-DBSP:** the shared, self-describing, retraction-native ontology-stream the attention-streams share (Confluent/Kafka-Schema-Registry analog over a DBSP stream). The most shippable single piece of the lightlike→beacon synthesis. Schemas-as-rows; evolving; describes all streams + histories; protected by the `shadow-auth-can't-compile` invariant (B-0929). Minimal core = TS over git; Rx/Bonsai/Reaqtor binding is optional interop. Composes B-0781/B-0784/B-0428/B-0864/B-0929/B-0640/B-0623.

**TECH-RADAR center:** added "The center" — the essential core (**gitnative + TypeScript + agent-harness loops**) that builds everything; everything else is optional (feature / ecosystem-interop / human-bridging). Two scoring axes now explicit: **ring** (maturity) + **distance-from-center** (essentiality). Most Adopt-by-maturity entries (F#, Reaqtor, DBSP libs, .NET) are optional-by-essentiality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)