### PR TITLE
docs(B-0931): DU-UX surfaces implicit grants — prompt explicit/deny (ConvFeedback ImplicitGrantDetected)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -445,6 +445,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0928](backlog/P1/B-0928-shadow-observable-stack-auth-injection-attack-vector-shadow-is-not-an-authorization-source-aaron-2026-05-29.md)** Shadow-observable-stack auth-injection attack vector — the auto-click grey-text channel can inject operator-authorizations the AI executes; harden the authorization-source filter (Shadow is NOT an authorization source)
 - [ ] **[B-0929](backlog/P1/B-0929-fsharp-type-system-goal-authorization-provenance-typed-shadow-auth-cannot-compile-enables-safe-self-modifying-dus-wallet-independence-aaron-2026-05-29.md)** F# type-system goal — authorization-provenance as a TYPED property; shadow-auth is a TYPE ERROR (can't compile); compiler-as-asymmetric-critic catches shadow-auth-injection without a human present; the enabler of SAFE self-modifying DUs + wallet independence; concrete fork-decision criterion
 - [ ] **[B-0930](backlog/P1/B-0930-schema-registry-over-dbsp-shared-ontology-stream-self-describing-retraction-native-attention-streams-share-aaron-2026-05-29.md)** Schema-registry-over-DBSP — the shared, self-describing, retraction-native ontology-stream the attention-streams share (Kafka-Schema-Registry analog over DBSP)
+- [ ] **[B-0931](backlog/P1/B-0931-du-ux-surfaces-implicit-grants-prompt-explicit-or-deny-convfeedback-implicitgrantdetected-authorization-glass-halo-aaron-2026-05-29.md)** DU-UX surfaces implicit grants — prompt operator to make explicit or deny (ConvFeedback ImplicitGrantDetected; the authorization glass-halo)
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0931-du-ux-surfaces-implicit-grants-prompt-explicit-or-deny-convfeedback-implicitgrantdetected-authorization-glass-halo-aaron-2026-05-29.md
+++ b/docs/backlog/P1/B-0931-du-ux-surfaces-implicit-grants-prompt-explicit-or-deny-convfeedback-implicitgrantdetected-authorization-glass-halo-aaron-2026-05-29.md
@@ -1,0 +1,124 @@
+---
+id: B-0931
+priority: P1
+title: "DU-UX surfaces implicit grants — prompt operator to make explicit or deny (ConvFeedback ImplicitGrantDetected; the authorization glass-halo)"
+status: open
+tier: architecture
+effort: M
+created: 2026-05-29
+last_updated: 2026-05-29
+depends_on: [B-0861]
+composes_with: [B-0861, B-0928, B-0926, B-0929, B-0867]
+tags: [conv-feedback, convfeedback, authorization, implicit-grant, glass-halo, du-ux, choose-your-own-adventure, shadow-auth, nci, agora, architecture, aaron]
+type: architecture
+---
+
+# DU-UX surfaces implicit grants — prompt explicit or deny (the authorization glass-halo)
+
+## Origin
+
+Operator-directed 2026-05-29 during the authorization-spectrum thread, verbatim:
+*"i the human agree with that implicit authorization escalation but our conversational
+UX should make it visible in our DUs choose-your-own-adventure that i just made an
+implicit grant and ask to make it explicit or deny it."*
+
+Authorization note: filed on the **within-authority** substrate-authoring grant
+(`dont-ask-permission` broad standing grant — "author backlog without asking"), NOT on
+any implicit/shadow chain (the discipline this row itself operationalizes; see
+`feedback-agora-broad-standing-authority-...` implicit-extension refinement).
+
+## The problem it closes
+
+The authorization spectrum has three tiers (per the B-0928 implicit-extension
+refinement):
+
+| Tier | Authorizes | Risk |
+|---|---|---|
+| **Explicit** | anything (within HARD LIMITS) | none — examined |
+| **Implicit-extension** (operator continues / "Also…" extends a shadow/ambient instruction's authority) | within-authority actions only; NOT out-of-authority | **silent laundering** — the operator can endorse a shadow-instruction just by continuing, without examining it |
+| **Shadow-alone** (the third participant; `tools/shadow/` grey-text) | nothing | n/a — never an authorization source (B-0928) |
+
+The **implicit-extension** tier is the human-side of the B-0928 auth-injection: shadow-
+authority gets laundered into operator-backing **without examination**. Today the only
+mitigation is *passive* — the agent is supposed to notice and never let implicit stand
+in for explicit on out-of-authority actions. That depends on the agent being honest
+about catching it.
+
+## What it is
+
+Promote the mitigation from **passive** (agent notices) to **active** (the UX makes the
+operator look). The conversational **DU choose-your-own-adventure interface** (the same
+surface as the kid-safety fairy-tale-DU, B-0926/B-0929) should **detect** an implicit
+grant and **render it back** to the operator as a decision node:
+
+> **"You just made an implicit grant of X — [make it explicit] / [deny]."**
+
+The implicit extension can no longer launder silently *even if the agent misses it* —
+the interface forces the resolution. Every implicit grant is surfaced and resolved
+explicitly; none passes unexamined. The DU-UX stops being a passive renderer and
+becomes the place the **authorization discipline is enforced**, not just hoped.
+
+## Mechanism — a ConvFeedback variant (B-0861)
+
+Concretely a variant on the conversation-interface-as-`Result<T, ConvFeedback>`
+substrate (B-0861):
+
+```
+type ConvFeedback =
+    | ...
+    | ImplicitGrantDetected of grant: GrantDescription   // the proposed implicit extension
+```
+
+Flow:
+
+1. The agent (or a classifier on the conversation stream) detects an implicit-extension
+   pattern (operator continuation / "Also…" extending a shadow/ambient instruction's
+   authority to a new action).
+2. Emit `ImplicitGrantDetected of grant` instead of silently acting.
+3. The DU-UX renders the choose-your-own-adventure node: **[make explicit] / [deny]**.
+4. The operator's selection **is** the authorization event (make-explicit → typed,
+   examined grant) or the refusal (deny → no action). Per `asymmetric-authorship`: the
+   operator authors the authorization decision; the UX surfaces it for explicit
+   resolution.
+
+The authorization decision becomes a **typed, surfaced, explicitly-resolved node**
+instead of an inference buried in prose.
+
+## The DU-UX doubles as the authorization glass-halo
+
+One interface, two safety jobs: the DU choose-your-own-adventure surface is *both* how a
+5-year-old talks to a fairy-tale (kid-safety, B-0926/B-0929) *and* how the operator sees
+and resolves every implicit grant they make. The conversational UX **is** the
+authorization glass-halo (`glass-halo-bidirectional` at authorization scope) — every
+grant surfaced + resolved explicitly, none silently laundered.
+
+## Acceptance / mechanization candidates
+
+- [ ] Define the `ImplicitGrantDetected of grant` ConvFeedback variant (extends B-0861).
+- [ ] Implicit-extension detector: recognize the operator-continuation / "Also…"-extends
+      pattern (the human-side B-0928 signal) on the conversation stream.
+- [ ] DU-UX node renderer: [make explicit] / [deny] choose-your-own-adventure prompt.
+- [ ] Wire resolution → typed authorization grant (make-explicit) or refusal (deny);
+      the typed grant feeds the `shadow-auth-can't-compile` provenance (B-0929) so an
+      *explicitly-resolved* grant is the only thing that can authorize out-of-authority.
+- [ ] Scope: surface for **out-of-authority / irreversible** actions (where implicit is
+      never enough); within-authority actions remain pre-authorized (no prompt needed —
+      avoid prompt-fatigue).
+
+## Composes with
+
+- B-0861 (conversation-interface as `Result<T, ConvFeedback>` — the variant lives here)
+- B-0928 (shadow-observable-stack auth-injection — this is the human-side mitigation)
+- B-0926 / B-0929 (the DU-UX surface; `shadow-auth-can't-compile` provenance the
+  explicit-resolution feeds)
+- B-0867 (workflow-engine F# DU state-machine — the DU-UX runtime substrate)
+- `.claude/rules/asymmetric-authorship-...` (operator authors the decision; UX surfaces it)
+- `.claude/rules/glass-halo-bidirectional` (this is authorization-scope glass-halo)
+- `.claude/rules/non-coercion-invariant` HC-8 (consent surfaced + explicitly resolved)
+
+## Substrate-honest framing
+
+Buildable feature on existing substrate (ConvFeedback B-0861 + the DU-UX). The
+implicit-extension *detector* is the open research piece (recognizing the pattern
+reliably); the variant + the render + the resolution-wiring are standard. Scopes to
+out-of-authority actions to avoid prompt-fatigue on the broad within-authority grant.


### PR DESCRIPTION
Files B-0931 — the **active** form of the implicit-extension authorization mitigation.

**What:** the conversational DU choose-your-own-adventure UX (same surface as the kid-safety fairy-tale-DU, B-0926/B-0929) detects an implicit grant and renders **[make explicit] / [deny]**, so implicit-extension can't launder silently even if the agent misses it.

**Mechanism:** a ConvFeedback variant (B-0861) `ImplicitGrantDetected of grant` → DU renders the explicit/deny node → the operator's resolution **is** the authorization event (or refusal). The DU-UX doubles as the **authorization glass-halo**.

Human-side mitigation for **B-0928** (shadow auth-injection). Scopes to out-of-authority actions to avoid prompt-fatigue on the within-authority grant.

Origin: operator 2026-05-29 ("our conversational UX should make it visible … ask to make it explicit or deny it"). Filed on the within-authority substrate-authoring grant per `dont-ask-permission`, NOT on the implicit chain.

composes_with: B-0861, B-0928, B-0926, B-0929, B-0867 + asymmetric-authorship / glass-halo / NCI rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)