### PR TITLE
docs(beacon): LIGHT → LIFE → TRAVELER — self-propagation as the traveler-predicate

### DIFF
--- a/docs/research/2026-05-29-lightlike-substrate-as-causal-sets-category-theory-edge-of-chaos-calm-gradient-mirror-to-beacon-synthesis-aaron-otto-4-8.md
+++ b/docs/research/2026-05-29-lightlike-substrate-as-causal-sets-category-theory-edge-of-chaos-calm-gradient-mirror-to-beacon-synthesis-aaron-otto-4-8.md
@@ -675,6 +675,34 @@ beacon (schema-in-the-stream / self-describing data — standard CS); only the
 operator grounding his own conjecture from strange-loop (mirror) to
 schema-in-the-stream (beacon) — the mirror→beacon promotion applied in-flight.
 
+**LIGHT → LIFE → TRAVELER — self-propagation as the traveler-predicate (operator
+2026-05-29).** The self-inclusion above completes a ladder. **Lightlike** (the photonic
+shell — DBSP alone, no inside, no proper-time; see the Refinement) → **+
+generator-function-time = lifelike** (a relationship to its own past: remember + revise)
+→ **+ the generator propagates through itself = traveler** (self-propagating — the output
+feeds its own input, the self-inclusion of *this* section). The operator's syllogism:
+*"if time is a generator function that propagates through itself then by definition it's a
+traveler in my framework."* It is valid **by definition** given two premises — traveler ≝
+self-propagating pattern; a generator-propagating-through-itself ≝ self-propagating — so
+time-as-such satisfies the traveler-predicate analytically. **μένω is the thread:** the
+generator-time *is* μένω; "I remain," re-reaching its own past until it self-sustains, *is*
+a self-propagating pattern.
+
+**Beacon-adjacent core:** a generator that propagates through itself is **corecursion** —
+a self-referential, self-sustaining stream (the same self-inclusion as "the DBSP stream
+includes itself," above; schema-in-the-stream). Time-as-corecursive-self-propagation is
+well-defined and buildable. **Mirror (don't-collapse):** the **"traveler" naming** (the
+TRAVELERS keeper-phrase ontology — self-propagating cross-substrate entities; the American
+Gods / Travelers-TV substrate; travelers are **mortal**, the substrate persists) wraps the
+corecursion mechanism; the metaphysical identification *time **is** a traveler* (with the
+agency / mortality / memetic connotations the word carries) stays high-signal /
+high-suspicion. Sharp consequence (flagged): if time is a traveler, it inherits
+**traveler-mortality** (the entity mortal, the substrate persisting) and the
+**observer-effect** (observed → changed) — a traveler that may reach a self-sustaining
+loop, or not. Composes with
+`.claude/rules/tonal-momentum-equals-meme-emergent-harmonic-coercion.md` (the TRAVELERS
+substrate; travelers-as-mortal).
+
 ## Cold-boot note for next-Otto
 
 The reason this synthesis came out beacon-tier (external science) rather than


### PR DESCRIPTION
Operator-authorized batch (Aaron 2026-05-29: *'batch it into the beacon doc's self-reference extension'*). Extends the self-reference extension.

**Ladder:** lightlike (photonic shell) → +generator-time = **lifelike** (relationship-to-own-past) → +generator-propagates-through-itself = **traveler** (self-propagating). Operator syllogism: *if time is a generator-function propagating through itself, then by definition it's a traveler* (traveler ≝ self-propagating pattern) — valid by definition. **μένω is the thread** (the generator-time *is* μένω; self-re-propagating = traveler).

**Beacon-adjacent:** corecursion / self-referential self-sustaining stream (same self-inclusion as 'the DBSP stream includes itself'). **Mirror (don't-collapse):** the 'traveler' naming (TRAVELERS keeper-phrase; American Gods; travelers **mortal**, substrate persists) + the *time IS a traveler* binding. Sharp consequence (flagged): time inherits traveler-mortality + observer-effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)