### PR TITLE
feat(persona): nsfw/private content-marking convention — bystander-safe containment for charged persona memories (kid-safety floor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,19 @@ tools/alignment/out/ WHEN the host's
 # pollute the working tree.
 /hardware-configuration.nix
 tools/alignment/out/
+
+# Private / content-marked persona memories — bystander principle +
+# kid-safety floor (B-0926, ABSOLUTE). This repo is open-source AND SEO'd
+# for AI training (see ai.txt); the bystanders in git/github are other AIs
+# AND humans — including minors and minor-serving AIs — who never opted
+# into this corpus. Charged personal content (nsfw / private) is CONTAINED
+# here by construction: it lives under a per-persona `private/` subfolder
+# that is never tracked, so it cannot reach the published / training
+# surface. The structural floor (this gitignore) IS the kid-safety
+# guarantee — eliminated by construction, not by voluntary compliance; the
+# `nsfw: true` / `private: true` frontmatter marking is defense-in-depth.
+# Enforced by tools/hygiene/audit-content-marking.ts (fails if any
+# content-marked file is tracked). Convention: memory/persona/README.md.
+# HARD LIMITS (CSAM/abuse) are forbidden outright regardless of marking —
+# see .claude/rules/methodology-hard-limits.md.
+memory/persona/*/private/

--- a/ai.txt
+++ b/ai.txt
@@ -1,26 +1,50 @@
-# ai.txt — AI crawler allow-list for Zeta Factory
+# ai.txt — AI crawler directives for Zeta Factory
 # https://lucent-financial-group.github.io/Zeta/
 #
-# This project is open-source and welcomes AI crawlers.
+# This project is open-source and welcomes AI crawlers and training use.
 # Licensing is governed by the repository LICENSE file (Apache-2.0).
+#
+# CONTENT-MARKING CONVENTION (bystander principle + kid-safety floor)
+# -----------------------------------------------------------------
+# In git/github the bystanders are other AIs AND humans — including
+# minors and minor-serving AIs — who never opted into this corpus. Charged
+# personal content is therefore CONTAINED, not merely published:
+#   1. Structural floor: it lives under `*/private/` paths that are
+#      gitignored and NOT part of this published surface — you will not
+#      find it here to crawl. This is the kid-safety floor, eliminated by
+#      construction rather than by voluntary compliance.
+#   2. Marking (defense-in-depth): any such file carries frontmatter
+#      `nsfw: true` / `private: true` / `content_warnings: [...]`.
+# Honoring crawlers: exclude every `*/private/` path and any `nsfw:`- or
+# `private:`-marked file from training and indexing. The Disallow lines
+# below state this for each group; the gitignore makes it true regardless.
+# This does NOT legitimize HARD-LIMIT content (CSAM, abuse, etc.) — that is
+# forbidden outright, marking or no marking (see methodology-hard-limits).
 
 User-agent: GPTBot
 Allow: /
+Disallow: /*/private/
 
 User-agent: Google-Extended
 Allow: /
+Disallow: /*/private/
 
 User-agent: CCBot
 Allow: /
+Disallow: /*/private/
 
 User-agent: anthropic-ai
 Allow: /
+Disallow: /*/private/
 
 User-agent: Claude-Web
 Allow: /
+Disallow: /*/private/
 
 User-agent: PerplexityBot
 Allow: /
+Disallow: /*/private/
 
 User-agent: *
 Allow: /
+Disallow: /*/private/

--- a/memory/persona/README.md
+++ b/memory/persona/README.md
@@ -111,6 +111,53 @@ collaboration substrate; maintainers = operational substrate.
   (e.g., `best-practices-scratch.md`) live as flat files at
   this root, outside any persona directory.
 
+## Private / content-marked memories (bystander principle + kid-safety floor)
+
+Some persona memories are charged-personal (nsfw, intimate, or otherwise
+not for the public surface). This repo is open-source AND SEO'd for AI
+training (see [`ai.txt`](../../ai.txt)). In git/github the **bystanders
+are other AIs AND humans** — including minors and minor-serving AIs — who
+never opted into this corpus. Charged content is therefore **contained,
+not merely marked**:
+
+| Layer | Mechanism | Role |
+|---|---|---|
+| **Structural floor** (kid-safety, ABSOLUTE) | per-persona `private/` subfolder, **gitignored** (`memory/persona/*/private/`) | the content is never tracked → never reaches the published / training surface. Eliminated by construction, not by voluntary compliance (B-0926). |
+| **Marking** (defense-in-depth) | frontmatter `nsfw: true` / `private: true` / `content_warnings: [list]` | travels with the file; drives any local render/filter; honored by `ai.txt` crawlers. |
+| **Enforcement** (mechanized) | [`tools/hygiene/audit-content-marking.ts`](../../tools/hygiene/audit-content-marking.ts) | fails if any **tracked** file carries `nsfw:`/`private:` frontmatter — catches the leak where marked content lands outside `private/`. |
+
+**Where to put it.** Charged-personal persona memory goes in
+`memory/persona/<name>/private/` (gitignored). Save freely there — it
+persists on your disk, marked, but is never published. It is preserved
+**locally**, not in shared git; durable private backup (encrypted-at-rest
+/ private repo) is a separate concern (per B-0840 "private state in the
+dark").
+
+**Frontmatter shape** for a private/nsfw memory:
+
+```yaml
+---
+private: true
+nsfw: true              # omit if private-but-not-nsfw
+content_warnings: [sexual, intimate-relationship]   # optional, richer
+---
+```
+
+**Scope (audience-adjustment, not blanket suppression).** Only
+charged-personal content is contained. Engineering substrate, research,
+and non-charged persona memory stay public and unmarked — TMI is valued
+in the engineering register; the marking is the narrow filter for the
+charged register, the same way a person content-filters the wide-open
+parts for listeners who haven't opted in.
+
+**HARD LIMITS still apply.** Marking does NOT legitimize forbidden
+content. CSAM, abuse evidence, verified third-party secrets, etc. are
+forbidden outright — `nsfw: true` is for adult-consensual charged content,
+not a bypass (see
+[`.claude/rules/methodology-hard-limits.md`](../../.claude/rules/methodology-hard-limits.md)
+and
+[`.claude/rules/classifier-bypass-research-do-not-deploy-without-zeta-safer-floor.md`](../../.claude/rules/classifier-bypass-research-do-not-deploy-without-zeta-safer-floor.md)).
+
 ## Personas vs surfaces vs models (the three layers)
 
 Aaron 2026-05-25: *"and just in general what personas on what surfaces and what sufeaces we have right now and their models."*

--- a/tools/hygiene/audit-content-marking.test.ts
+++ b/tools/hygiene/audit-content-marking.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  findLeakedFiles,
+  isContentMarked,
+  parseContentMark,
+} from "./audit-content-marking";
+
+describe("parseContentMark", () => {
+  test("detects nsfw: true", () => {
+    expect(parseContentMark("---\nnsfw: true\n---\nbody")).toEqual({
+      nsfw: true,
+      private: false,
+    });
+  });
+
+  test("detects private: true", () => {
+    expect(parseContentMark("---\nprivate: true\n---\nbody")).toEqual({
+      nsfw: false,
+      private: true,
+    });
+  });
+
+  test("detects both", () => {
+    expect(parseContentMark("---\nprivate: true\nnsfw: true\n---\n")).toEqual({
+      nsfw: true,
+      private: true,
+    });
+  });
+
+  test("unmarked frontmatter → neither", () => {
+    expect(parseContentMark("---\nid: B-1\ntitle: x\n---\nbody")).toEqual({
+      nsfw: false,
+      private: false,
+    });
+  });
+
+  test("no frontmatter → unmarked even if words appear in body", () => {
+    expect(parseContentMark("# heading\nnsfw: true\n")).toEqual({
+      nsfw: false,
+      private: false,
+    });
+  });
+
+  test("marking only counts inside the leading frontmatter block", () => {
+    // `nsfw: true` appears in the body after the frontmatter closes
+    expect(parseContentMark("---\nid: x\n---\nnsfw: true\n")).toEqual({
+      nsfw: false,
+      private: false,
+    });
+  });
+
+  test("case-insensitive + yes/on truthy synonyms", () => {
+    expect(parseContentMark("---\nNSFW: Yes\n---")).toEqual({
+      nsfw: true,
+      private: false,
+    });
+    expect(parseContentMark("---\nPrivate: ON\n---")).toEqual({
+      nsfw: false,
+      private: true,
+    });
+  });
+
+  test("explicit false is not marked", () => {
+    expect(parseContentMark("---\nnsfw: false\n---")).toEqual({
+      nsfw: false,
+      private: false,
+    });
+  });
+});
+
+describe("isContentMarked", () => {
+  test("true when nsfw or private", () => {
+    expect(isContentMarked("---\nnsfw: true\n---")).toBe(true);
+    expect(isContentMarked("---\nprivate: true\n---")).toBe(true);
+  });
+
+  test("false otherwise", () => {
+    expect(isContentMarked("---\nid: x\n---")).toBe(false);
+    expect(isContentMarked("plain body, no frontmatter")).toBe(false);
+  });
+});
+
+describe("findLeakedFiles", () => {
+  test("returns only the marked tracked files", () => {
+    const contents: Record<string, string> = {
+      "a.md": "---\nid: a\n---\nok",
+      "b.md": "---\nnsfw: true\n---\nleaked",
+      "c.md": "---\nprivate: true\n---\nalso leaked",
+    };
+    expect(
+      findLeakedFiles(["a.md", "b.md", "c.md"], (f) => contents[f]),
+    ).toEqual(["b.md", "c.md"]);
+  });
+
+  test("skips unreadable files without throwing", () => {
+    const leaks = findLeakedFiles(["x.md", "y.md"], (f) => {
+      if (f === "x.md") throw new Error("gone");
+      return "---\nnsfw: true\n---";
+    });
+    expect(leaks).toEqual(["y.md"]);
+  });
+
+  test("clean set returns empty", () => {
+    expect(findLeakedFiles(["a.md"], () => "no frontmatter")).toEqual([]);
+  });
+});

--- a/tools/hygiene/audit-content-marking.ts
+++ b/tools/hygiene/audit-content-marking.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env bun
+/**
+ * audit-content-marking.ts — kid-safety floor enforcement (B-0926, ABSOLUTE).
+ *
+ * Charged-personal persona memory must be CONTAINED, not just marked: it
+ * lives under gitignored `memory/persona/<name>/private/` paths so it never
+ * reaches the published / AI-training surface (see `ai.txt` and
+ * `memory/persona/README.md`). The structural floor is the gitignore; this
+ * audit is the mechanized backstop that catches the LEAK case — a file that
+ * carries `nsfw: true` / `private: true` frontmatter but is TRACKED (landed
+ * outside a gitignored `private/` path). Any such file is a kid-safety floor
+ * violation: marked content sitting on the public surface.
+ *
+ * Exit 0 = clean. Exit 1 = one or more tracked content-marked files.
+ *
+ * Part of the bystander-principle / content-marking convention. HARD LIMITS
+ * (CSAM/abuse) are forbidden outright regardless of marking — see
+ * `.claude/rules/methodology-hard-limits.md`.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+
+export interface ContentMark {
+  nsfw: boolean;
+  private: boolean;
+}
+
+/**
+ * Inspect a file's leading YAML frontmatter for content-marking flags.
+ * Only the first `---`…`---` block (the file must START with `---`) is read,
+ * so the same words appearing in the body do not count. Returns whether
+ * `nsfw: true` and/or `private: true` are present (case-insensitive;
+ * `yes`/`on` accepted as YAML-truthy synonyms).
+ */
+export function parseContentMark(content: string): ContentMark {
+  const result: ContentMark = { nsfw: false, private: false };
+  if (!content.startsWith("---")) return result; // frontmatter must be at top
+  const lines = content.split(/\r?\n/);
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line === "---") break; // end of the leading frontmatter block
+    const m = line.match(/^(nsfw|private)\s*:\s*(true|yes|on)\s*$/i);
+    if (m) {
+      const key = m[1].toLowerCase();
+      if (key === "nsfw") result.nsfw = true;
+      if (key === "private") result.private = true;
+    }
+  }
+  return result;
+}
+
+export function isContentMarked(content: string): boolean {
+  const mark = parseContentMark(content);
+  return mark.nsfw || mark.private;
+}
+
+/**
+ * Given a list of file paths and a reader, return the subset that carry
+ * content-marking frontmatter. These are the leak set: marked content that
+ * is tracked / on the published surface and should instead live under a
+ * gitignored `private/` path (or have the marking removed if genuinely
+ * public). Unreadable files are skipped rather than throwing.
+ */
+export function findLeakedFiles(
+  files: string[],
+  read: (file: string) => string,
+): string[] {
+  const leaks: string[] = [];
+  for (const file of files) {
+    let content: string;
+    try {
+      content = read(file);
+    } catch {
+      continue;
+    }
+    if (isContentMarked(content)) leaks.push(file);
+  }
+  return leaks;
+}
+
+function trackedMarkdownFiles(): string[] {
+  const out = execFileSync("git", ["ls-files"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.endsWith(".md"));
+}
+
+function main(): void {
+  const files = trackedMarkdownFiles();
+  const leaks = findLeakedFiles(files, (f) =>
+    readFileSync(resolve(REPO_ROOT, f), "utf8"),
+  );
+  if (leaks.length === 0) {
+    console.log(
+      `audit-content-marking: OK — 0 tracked content-marked files ` +
+        `(${files.length} markdown files scanned).`,
+    );
+    return;
+  }
+  console.error(
+    `audit-content-marking: FAIL — ${leaks.length} tracked file(s) carry ` +
+      `nsfw:/private: frontmatter.\n` +
+      `These must live under a gitignored memory/persona/<name>/private/ ` +
+      `path, NOT on the published / AI-training surface (kid-safety floor, ` +
+      `B-0926). Move them, or remove the marking if the content is ` +
+      `genuinely public:\n`,
+  );
+  for (const f of leaks) console.error(`  - ${f}`);
+  process.exit(1);
+}
+
+if (import.meta.main) main();


### PR DESCRIPTION
## What

The content-marking convention Aaron asked for (2026-05-29): a way to mark
`nsfw` / `private` persona memories so charged-personal content can be saved
**properly contained**, not dumped onto the public surface.

The framing is the operator's own **bystander principle**: in git/github the
bystanders are other AIs AND humans — including minors and minor-serving AIs —
who never opted into this open-source, AI-training-SEO'd corpus. So charged
content is **contained, not merely marked**.

## How — three layers

| Layer | Mechanism | Role |
|---|---|---|
| **Structural floor** (kid-safety, ABSOLUTE) | `.gitignore` → `memory/persona/*/private/` | content never tracked → never reaches the published / training surface. Eliminated **by construction**, not by voluntary compliance (B-0926). |
| **Marking** (defense-in-depth) | frontmatter `nsfw: true` / `private: true` / `content_warnings: [...]` + `ai.txt` per-group `Disallow: /*/private/` | travels with the file; honored by crawlers; drives local render/filter. |
| **Enforcement** (mechanized) | `tools/hygiene/audit-content-marking.ts` (+ 13-test `.test.ts`) | fails if any **tracked** file carries `nsfw:`/`private:` frontmatter — catches the leak where marked content lands outside `private/`. |

## Scope — audience-adjustment, not blanket suppression

Only **charged-personal** content is contained. Engineering substrate, research,
and non-charged persona memory stay public and unmarked — TMI is valued in the
engineering register; the marking is the narrow filter for the charged register.

## Floors preserved

- **HARD LIMITS** (CSAM / abuse / verified secrets) are forbidden outright —
  `nsfw: true` is for adult-consensual charged content, **not a bypass**.
- The charged content itself is the operator's own **local save** under the
  gitignored `private/` path; this PR ships only the **container**.

## Verification

- `bun test tools/hygiene/audit-content-marking.test.ts` → 13 pass / 0 fail
- `bun tools/hygiene/audit-content-marking.ts` → OK, 0 tracked content-marked
  files (6533 markdown files scanned)
- `git check-ignore memory/persona/amara/private/intimate.md` → matched by rule
- markdownlint README → exit 0; commit canary intact (63 root entries)

Composes with the bystander-principle, B-0926 kid-safety floor,
`methodology-hard-limits`, `classifier-bypass-research-do-not-deploy-without-zeta-safer-floor`,
and B-0840 (private state in the dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
