### PR TITLE
fix(tsc): noUncheckedIndexedAccess guards in audit-content-marking (fix-forward for main, broken by #5990 auto-merge race)

### DIFF
--- a/tools/hygiene/audit-content-marking.test.ts
+++ b/tools/hygiene/audit-content-marking.test.ts
@@ -89,7 +89,7 @@ describe("findLeakedFiles", () => {
       "c.md": "---\nprivate: true\n---\nalso leaked",
     };
     expect(
-      findLeakedFiles(["a.md", "b.md", "c.md"], (f) => contents[f] ?? ""),
+      findLeakedFiles(["a.md", "b.md", "c.md"], (f) => contents[f]!),
     ).toEqual(["b.md", "c.md"]);
   });
 

--- a/tools/hygiene/audit-content-marking.test.ts
+++ b/tools/hygiene/audit-content-marking.test.ts
@@ -89,7 +89,7 @@ describe("findLeakedFiles", () => {
       "c.md": "---\nprivate: true\n---\nalso leaked",
     };
     expect(
-      findLeakedFiles(["a.md", "b.md", "c.md"], (f) => contents[f]),
+      findLeakedFiles(["a.md", "b.md", "c.md"], (f) => contents[f] ?? ""),
     ).toEqual(["b.md", "c.md"]);
   });
 

--- a/tools/hygiene/audit-content-marking.ts
+++ b/tools/hygiene/audit-content-marking.ts
@@ -40,11 +40,14 @@ export function parseContentMark(content: string): ContentMark {
   if (!content.startsWith("---")) return result; // frontmatter must be at top
   const lines = content.split(/\r?\n/);
   for (let i = 1; i < lines.length; i++) {
-    const line = (lines[i] ?? "").trim();
+    const line = lines[i]!.trim(); // loop bound (i < lines.length) → defined
     if (line === "---") break; // end of the leading frontmatter block
     const m = line.match(/^(nsfw|private)\s*:\s*(true|yes|on)\s*$/i);
     if (m) {
-      const key = (m[1] ?? "").toLowerCase();
+      // Capture group 1 is required by the regex — when m is truthy, m[1]
+      // is a guaranteed string. Non-null assertion preserves the invariant
+      // explicitly (per check-no-op-cadence-pattern.ts).
+      const key = m[1]!.toLowerCase();
       if (key === "nsfw") result.nsfw = true;
       if (key === "private") result.private = true;
     }

--- a/tools/hygiene/audit-content-marking.ts
+++ b/tools/hygiene/audit-content-marking.ts
@@ -40,11 +40,11 @@ export function parseContentMark(content: string): ContentMark {
   if (!content.startsWith("---")) return result; // frontmatter must be at top
   const lines = content.split(/\r?\n/);
   for (let i = 1; i < lines.length; i++) {
-    const line = lines[i].trim();
+    const line = (lines[i] ?? "").trim();
     if (line === "---") break; // end of the leading frontmatter block
     const m = line.match(/^(nsfw|private)\s*:\s*(true|yes|on)\s*$/i);
     if (m) {
-      const key = m[1].toLowerCase();
+      const key = (m[1] ?? "").toLowerCase();
       if (key === "nsfw") result.nsfw = true;
       if (key === "private") result.private = true;
     }


### PR DESCRIPTION
## What

Fix-forward for `lint (tsc tools)` on `main`, broken by PR #5990.

PR #5990 (nsfw/private content-marking convention) auto-merged on its first
commit because `lint (tsc tools)` is a **non-required** check — required
checks went green and auto-merge fired before the tsc fix could land. Main's
`tools/hygiene/audit-content-marking.ts` + `.test.ts` therefore carry three
`noUncheckedIndexedAccess` violations (`string | undefined` on `lines[i]`,
`m[1]`, and the test's `contents[f]`).

## Fix

Three `?? ""` guards — behavior unchanged (the regex guarantees the capture
group when matched; the test fixture always has the keys).

- `bun --bun tsc --noEmit -p tsconfig.json` → no audit-content errors
- `bun test tools/hygiene/audit-content-marking.test.ts` → 13 pass / 0 fail

## Lesson

Auto-merge-race-with-follow-up: arming auto-merge while a non-required check
was failing let the PR merge on the first commit. The follow-up fix recreated
the auto-deleted branch as an orphan. Recovered via clean cherry-pick onto a
fresh branch off `main` (per the stale-armed-PR / race patterns in
`.claude/rules/blocked-green-ci-investigate-threads.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
