### PR TITLE
feat(B-0343): glob-resolve seed manifest to concrete file set (bounded slice 2)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseSeedManifest } from "./seed-test-repo.ts";
+import { parseSeedManifest, resolveSeedFiles } from "./seed-test-repo.ts";
 
 describe("parseSeedManifest", () => {
   test("extracts include and exclude entries from fenced yaml", () => {
@@ -22,5 +22,55 @@ describe("parseSeedManifest", () => {
       include: ["openspec/specs/**/spec.md", "src/Core/README.md"],
       exclude: ["AGENTS.md", "docs/**"],
     });
+  });
+});
+
+describe("resolveSeedFiles", () => {
+  const manifest = {
+    include: ["openspec/specs/**/spec.md", "tools/tla/specs/*.tla", "src/Core/README.md"],
+    exclude: ["src/**/*.fs", "docs/**"],
+  };
+
+  test("keeps include-matched paths and drops non-matches", () => {
+    const candidates = [
+      "openspec/specs/foo/spec.md",
+      "tools/tla/specs/Bar.tla",
+      "src/Core/README.md",
+      "tools/hygiene/audit.ts", // matches no include
+    ];
+    expect(resolveSeedFiles(candidates, manifest)).toEqual([
+      "openspec/specs/foo/spec.md",
+      "src/Core/README.md",
+      "tools/tla/specs/Bar.tla",
+    ]);
+  });
+
+  test("a path matching no include pattern never appears", () => {
+    const candidates = [
+      "src/Core/README.md", // included, not excluded → kept
+      "src/Core/Engine.fs", // matches no include → dropped
+    ];
+    expect(resolveSeedFiles(candidates, manifest)).toEqual(["src/Core/README.md"]);
+  });
+
+  test("exclude wins over include (include ∧ ¬exclude)", () => {
+    const overlap = {
+      include: ["src/**/*.md"],
+      exclude: ["src/Core/**"],
+    };
+    const candidates = ["src/Core/README.md", "src/Other/README.md"];
+    expect(resolveSeedFiles(candidates, overlap)).toEqual(["src/Other/README.md"]);
+  });
+
+  test("result is sorted", () => {
+    const candidates = ["tools/tla/specs/Z.tla", "tools/tla/specs/A.tla"];
+    expect(resolveSeedFiles(candidates, manifest)).toEqual([
+      "tools/tla/specs/A.tla",
+      "tools/tla/specs/Z.tla",
+    ]);
+  });
+
+  test("empty candidate list resolves to empty set", () => {
+    expect(resolveSeedFiles([], manifest)).toEqual([]);
   });
 });

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -1,8 +1,20 @@
 #!/usr/bin/env bun
 /**
- * B-0343 smallest safe slice (re-decomposed per "assume decomposition mistakes" rule).
- * Bounded step: manifest reader + --dry-run only. No gh, no create, no repo mutation.
- * Follow-up slices will add gh api + idempotency + commit logic.
+ * B-0343 bounded slice 2 (re-decomposed per "assume decomposition mistakes" rule).
+ * Builds on the merged manifest-reader + --dry-run stub (PRs #2716/#2722/#2723).
+ *
+ * This slice adds glob RESOLUTION: turning the manifest's include/exclude
+ * patterns into the concrete file set that would be seeded. Still no gh,
+ * no create, no repo mutation — only a read-only filesystem scan of the
+ * include-pattern subtrees. This is the prerequisite computation for
+ * AC 1 ("seed exactly the files listed") and AC 3 (idempotency = compare
+ * the resolved set against the target repo). Follow-up slices will add
+ * gh api + idempotency + commit logic.
+ *
+ * Scan discipline: candidate collection scans each ROOTED include pattern
+ * directly (e.g. `tools/tla/specs/*.tla`), never a recursive glob from the
+ * repo root, so the gitignored `references/upstreams/` mirror is never
+ * walked (.claude/rules/references-upstreams-not-our-code-search-excludes.md).
  */
 
 import { parseArgs } from "node:util";
@@ -19,6 +31,8 @@ interface SeedManifest {
 
 const MANIFEST_DISPLAY_PATH = "docs/bootstrap-razor/SEED-MANIFEST.md";
 const MANIFEST_PATH = fileURLToPath(new URL("../../docs/bootstrap-razor/SEED-MANIFEST.md", import.meta.url));
+// Repo root = two levels up from tools/bootstrap-razor/.
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 
 function usage(): string {
   return [
@@ -78,12 +92,60 @@ function readManifest(path: string): SeedManifest | string {
   return manifest;
 }
 
-function emitDryRun(manifest: SeedManifest): void {
+/**
+ * True when `path` matches any of `patterns`. Uses the same Bun.Glob engine
+ * as candidate collection (`scanSync`) so resolution and scanning agree on
+ * `**`/`*` semantics. Pure — operates on strings only, touches no filesystem.
+ */
+function matchesAny(path: string, patterns: readonly string[]): boolean {
+  return patterns.some((pattern) => new Bun.Glob(pattern).match(path));
+}
+
+/**
+ * Pure resolver: from a candidate file list, keep paths that match an include
+ * pattern AND match no exclude pattern (exclude wins). Independently testable
+ * without a filesystem. The honest manifest semantics are include ∧ ¬exclude;
+ * the "except bootstrap-razor/ itself" prose note in the manifest is NOT
+ * encoded here (the include list does not name those files, so they are
+ * neither included nor a false-exclude here).
+ */
+export function resolveSeedFiles(
+  candidates: readonly string[],
+  manifest: SeedManifest,
+): readonly string[] {
+  return candidates
+    .filter((path) => matchesAny(path, manifest.include) && !matchesAny(path, manifest.exclude))
+    .sort();
+}
+
+/**
+ * Read-only filesystem scan: collect the concrete files under each rooted
+ * include pattern. Scans include patterns directly (never a recursive glob
+ * from root) to avoid walking gitignored mirror trees. No mutation, no
+ * network, no gh.
+ */
+function collectSeedCandidates(root: string, manifest: SeedManifest): readonly string[] {
+  const found = new Set<string>();
+  for (const pattern of manifest.include) {
+    for (const file of new Bun.Glob(pattern).scanSync({ cwd: root, onlyFiles: true, dot: true })) {
+      found.add(file);
+    }
+  }
+  return [...found];
+}
+
+function emitDryRun(manifest: SeedManifest, root: string): void {
   console.log(`[B-0343] DRY-RUN: read ${MANIFEST_DISPLAY_PATH}`);
-  console.log(`Would seed exactly these manifest include entries (${manifest.include.length}):`);
-  for (const item of manifest.include) console.log(`  - ${item}`);
-  console.log(`Would exclude these manifest entries (${manifest.exclude.length}):`);
+  console.log(`Manifest include patterns (${manifest.include.length}):`);
+  for (const item of manifest.include) console.log(`  + ${item}`);
+  console.log(`Manifest exclude patterns (${manifest.exclude.length}):`);
   for (const item of manifest.exclude) console.log(`  - ${item}`);
+
+  const candidates = collectSeedCandidates(root, manifest);
+  const resolved = resolveSeedFiles(candidates, manifest);
+  console.log(`Resolved concrete seed files (${resolved.length}):`);
+  for (const file of resolved) console.log(`  • ${file}`);
+
   console.log("Provenance commit would link to B-0193 / B-0343.");
   console.log("Idempotency + gh create + real seeding: follow-up slice.");
 }
@@ -109,7 +171,7 @@ export function main(argv: readonly string[]): ExitCode {
       process.stderr.write(`${manifest}\n`);
       return 1;
     }
-    emitDryRun(manifest);
+    emitDryRun(manifest, REPO_ROOT);
     return 0;
   }
 


### PR DESCRIPTION
## B-0343 bounded slice 2 — glob-resolve manifest patterns to concrete seed file set

Parent: B-0193 (bootstrap razor). Row: `docs/backlog/P1/B-0343-test-repo-seeding-script-ts-b0193.md`.

### Substrate-drift check (start-gate step 0)
`tools/bootstrap-razor/seed-test-repo.ts` already exists; three B-0343 PRs are merged (#2716/#2722/#2723 — the "smallest safe slice" stub). Discriminator result: **in-progress, NOT drift**. ACs 1, 2, 4 met by the stub; **AC 3 (idempotency) explicitly deferred** in the stub (`"Idempotency + gh create + real seeding: follow-up slice"`). This PR takes the next bounded step toward AC 3 without redoing the stub.

### What this slice adds
The stub's `--dry-run` echoed manifest **patterns**. This slice resolves them to the **concrete file set** — the prerequisite computation for AC 1 ("seed exactly the files listed") and AC 3 (idempotency = compare resolved set vs target repo). Still **no `gh`, no repo creation, no mutation** — only a read-only filesystem scan.

- `resolveSeedFiles(candidates, manifest)` — pure `include ∧ ¬exclude` resolver, exclude-wins, sorted; independently testable without a filesystem.
- `collectSeedCandidates(root, manifest)` — read-only scan of each **rooted** include pattern via `Bun.Glob.scanSync`. Never a recursive glob from repo root → the gitignored `references/upstreams/` mirror is never walked (per `.claude/rules/references-upstreams-not-our-code-search-excludes.md`).
- `--dry-run` now lists the **39 resolved concrete seed files**. Same `Bun.Glob` engine for resolution + scan, so `**`/`*` semantics agree.

### Finding (surfaced, not fixed — out of scope)
Resolved count (39) and OpenSpec spec count (9) diverge from `SEED-MANIFEST.md`'s documented estimate (~47 total / 6 OpenSpec specs); the `openspec/specs/**/overlays/**` pattern resolves to nothing (no overlays exist yet). Surfacing this estimate-vs-reality drift is exactly the value of resolution over pattern-echoing. Manifest-metric reconciliation belongs to a separate row.

### Focused checks
- `bun test tools/bootstrap-razor/seed-test-repo.test.ts` → **6/6 pass** (5 new `resolveSeedFiles` cases + 1 existing `parseSeedManifest`).
- `bunx tsc --noEmit -p tsconfig.json` → **0 errors in the touched file**. (The single repo-wide `TS2688 Cannot find type definition file for 'bun'` is a pre-existing baseline unrelated to this change; the native `bun test` typechecker is clean.)
- `bun tools/bootstrap-razor/seed-test-repo.ts --dry-run` → resolves 39 files cleanly, no side effects.
- No F#/C# touched → `dotnet build` gate not applicable (TS-only change under `tools/`).

### Scope discipline
One bounded step. No `gh` calls, no repo creation, no network. AC 1 (repo creation) + AC 3 (idempotency) remain follow-up slices; this PR builds the resolved-set computation both depend on.

operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
