### PR TITLE
test(issue-75): add deterministic temp path helper

### DIFF
--- a/tests/Tests.FSharp/README.md
+++ b/tests/Tests.FSharp/README.md
@@ -53,6 +53,9 @@ tests/Tests.FSharp/
   leading underscore sorts it first and signals "not a test file"
   at a glance. Helper modules use the namespace
   `Zeta.Tests.Support.*`.
+- Filesystem tests that need unique temp directories use
+  `DeterministicTestPath.nextDir` rather than `Guid.NewGuid()`.
+  The helper uses a process-local counter so rerun paths diff cleanly.
 
 ## Compile order in `Tests.FSharp.fsproj`
 

--- a/tests/Tests.FSharp/Storage/CheckpointStore.Tests.fs
+++ b/tests/Tests.FSharp/Storage/CheckpointStore.Tests.fs
@@ -5,6 +5,7 @@ open System.IO
 open FsUnit.Xunit
 open global.Xunit
 open Zeta.Core
+open Zeta.Tests.Support
 
 
 [<Fact>]
@@ -129,12 +130,7 @@ let ``InMemoryCheckpointStore overwrites on second save`` () =
 // ═══════════════════════════════════════════════════════════════════
 
 let private makeTempDir () =
-    let dir =
-        Path.Combine(
-            Path.GetTempPath(),
-            "zeta-checkpoint-test-" + Guid.NewGuid().ToString("N"))
-    Directory.CreateDirectory dir |> ignore
-    dir
+    DeterministicTestPath.nextDir "zeta-checkpoint-test"
 
 let private cleanupDir (dir: string) =
     if Directory.Exists dir then

--- a/tests/Tests.FSharp/Storage/Durability.Tests.fs
+++ b/tests/Tests.FSharp/Storage/Durability.Tests.fs
@@ -7,6 +7,7 @@ open System.Threading
 open FsUnit.Xunit
 open global.Xunit
 open Zeta.Core
+open Zeta.Tests.Support
 
 
 // ═══════════════════════════════════════════════════════════════════
@@ -28,8 +29,7 @@ let private sibling (root: string) (name: string) : string =
 
 [<Fact>]
 let ``WitnessDurableBackingStore WorkDir matches the directory actually created`` () =
-    let root = Path.Combine(Path.GetTempPath(), "dbsp-wd-" + Guid.NewGuid().ToString("N"))
-    Directory.CreateDirectory root |> ignore
+    let root = DeterministicTestPath.nextDir "dbsp-wd"
     try
         let workDir = Path.Combine(root, "work")
         let witnessDir = Path.Combine(root, "witness")
@@ -52,8 +52,7 @@ let ``WitnessDurableBackingStore canonicalises workDir under CWD churn`` () =
     // the CWD between them. After the fix, `GetFullPath` runs exactly
     // once, so the stored path and the created directory always
     // agree — even if CWD is swapped every instant.
-    let root = Path.Combine(Path.GetTempPath(), "dbsp-cwd-" + Guid.NewGuid().ToString("N"))
-    Directory.CreateDirectory root |> ignore
+    let root = DeterministicTestPath.nextDir "dbsp-cwd"
     let originalCwd = Environment.CurrentDirectory
     try
         let cwdA = sibling root "cwd-a"

--- a/tests/Tests.FSharp/Storage/Spine.Disk.Tests.fs
+++ b/tests/Tests.FSharp/Storage/Spine.Disk.Tests.fs
@@ -6,6 +6,7 @@ open System.IO
 open FsUnit.Xunit
 open global.Xunit
 open Zeta.Core
+open Zeta.Tests.Support
 
 
 // ═══════════════════════════════════════════════════════════════════
@@ -25,7 +26,7 @@ let ``InMemoryBackingStore roundtrips`` () =
 
 [<Fact>]
 let ``DiskBackingStore keeps small batches in memory`` () =
-    let tmp = Path.Combine(Path.GetTempPath(), $"dbsp-disk-test-{Guid.NewGuid()}")
+    let tmp = DeterministicTestPath.nextDir "dbsp-disk-test"
     try
         let store = DiskBackingStore<int>(tmp, inMemoryQuotaBytes = 10_000L) :> IBackingStore<int>
         let batch = ZSet.ofKeys [ 1 ; 2 ; 3 ]
@@ -38,7 +39,7 @@ let ``DiskBackingStore keeps small batches in memory`` () =
 
 [<Fact>]
 let ``DiskBackingStore spills when over quota`` () =
-    let tmp = Path.Combine(Path.GetTempPath(), $"dbsp-spill-test-{Guid.NewGuid()}")
+    let tmp = DeterministicTestPath.nextDir "dbsp-spill-test"
     try
         // Very small quota forces immediate spilling to disk.
         let store = DiskBackingStore<int>(tmp, inMemoryQuotaBytes = 100L) :> IBackingStore<int>
@@ -89,7 +90,7 @@ let ``BackedSpine Clear removes all storage`` () =
 
 [<Fact>]
 let ``DiskBackingStore instances sharing a dir don't clobber each other`` () =
-    let dir = Path.Combine(Path.GetTempPath(), $"dbsp-share-{Guid.NewGuid():N}")
+    let dir = DeterministicTestPath.nextDir "dbsp-share"
     try
         Directory.CreateDirectory dir |> ignore
         // Tiny quota forces immediate spill.
@@ -113,7 +114,7 @@ let ``DiskBackingStore instances sharing a dir don't clobber each other`` () =
 
 [<Fact>]
 let ``DiskBackingStore canonicalises workDir`` () =
-    let dir = Path.Combine(Path.GetTempPath(), $"dbsp-test-{Guid.NewGuid():N}")
+    let dir = DeterministicTestPath.nextDir "dbsp-test"
     try
         let store = DiskBackingStore<int>(dir, inMemoryQuotaBytes = 1024L) :> IBackingStore<int>
         let batch = ZSet.ofKeys [ 1; 2; 3 ]
@@ -127,7 +128,7 @@ let ``DiskBackingStore canonicalises workDir`` () =
 
 [<Fact>]
 let ``DiskBackingStore spill path lives under root`` () =
-    let dir = Path.Combine(Path.GetTempPath(), $"dbsp-test-{Guid.NewGuid():N}")
+    let dir = DeterministicTestPath.nextDir "dbsp-test"
     try
         Directory.CreateDirectory dir |> ignore
         // Small quota forces spill.

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <!-- _Support/ helpers first (they're consumed by subject files below). -->
+    <Compile Include="_Support/DeterministicTestPath.fs" />
     <Compile Include="_Support/ConcurrencyHarness.fs" />
     <Compile Include="_Support/CartelInjector.fs" />
 

--- a/tests/Tests.FSharp/_Support/DeterministicTestPath.fs
+++ b/tests/Tests.FSharp/_Support/DeterministicTestPath.fs
@@ -1,0 +1,32 @@
+namespace Zeta.Tests.Support
+
+open System
+open System.IO
+open System.Threading
+
+[<RequireQualifiedAccess>]
+module DeterministicTestPath =
+    let mutable private counter = 0
+
+    let private sanitize (prefix: string) =
+        let chars =
+            prefix
+            |> Seq.map (fun c ->
+                if Char.IsLetterOrDigit c || c = '-' || c = '_' || c = '.' then c
+                else '-')
+            |> Seq.toArray
+
+        let cleaned = String(chars).Trim('-')
+        if String.IsNullOrWhiteSpace cleaned then "path" else cleaned
+
+    /// Returns a process-local deterministic temp directory for filesystem tests.
+    let nextDir (prefix: string) =
+        let id = Interlocked.Increment(&counter)
+        let root = Path.Combine(Path.GetTempPath(), "zeta-test-paths")
+        let dir = Path.Combine(root, sprintf "%s-%04d" (sanitize prefix) id)
+
+        if Directory.Exists dir then
+            Directory.Delete(dir, true)
+
+        Directory.CreateDirectory dir |> ignore
+        dir


### PR DESCRIPTION
## Summary
- Add `DeterministicTestPath.nextDir` for process-local deterministic filesystem-test directories.
- Replace storage-test `Guid.NewGuid()` temp-directory suffixes with the helper.
- Document the helper as the preferred API for filesystem tests that need unique temp dirs.

Closes #75.

## Verification
- `rg -n "Guid\.NewGuid\(" tests -S` (no test-code calls remain; only historical comment and README guidance)
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~Zeta.Tests.Storage" --logger "console;verbosity=minimal"` (106 passed)