### PR TITLE
feat(B-0343): git-blob-SHA seed tree — read-only idempotency comparison basis (bounded slice 3)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -98,12 +98,16 @@ describe("gitBlobSha", () => {
 });
 
 describe("computeSeedTree", () => {
-  test("pairs each resolved path with the git blob SHA of its bytes, in input order", () => {
+  test("pairs each resolved path with the git blob SHA of its bytes, canonically sorted by path", () => {
     const root = mkdtempSync(join(tmpdir(), "b0343-seed-tree-"));
     writeFileSync(join(root, "a.txt"), "hello\n");
     writeFileSync(join(root, "b.txt"), "");
 
-    expect(computeSeedTree(["a.txt", "b.txt"], root)).toEqual([
+    // Intentionally UNSORTED input: the documented contract is that output is
+    // canonically sorted by path regardless of caller order. Asserting against
+    // sorted output means this test fails if `computeSeedTree` ever reverts to
+    // preserving input order.
+    expect(computeSeedTree(["b.txt", "a.txt"], root)).toEqual([
       { path: "a.txt", sha: "ce013625030ba8dba906f756967f9e9ca394464a" },
       { path: "b.txt", sha: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391" },
     ]);

--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { parseSeedManifest, resolveSeedFiles } from "./seed-test-repo.ts";
+import { computeSeedTree, gitBlobSha, parseSeedManifest, resolveSeedFiles } from "./seed-test-repo.ts";
 
 describe("parseSeedManifest", () => {
   test("extracts include and exclude entries from fenced yaml", () => {
@@ -72,5 +75,41 @@ describe("resolveSeedFiles", () => {
 
   test("empty candidate list resolves to empty set", () => {
     expect(resolveSeedFiles([], manifest)).toEqual([]);
+  });
+});
+
+describe("gitBlobSha", () => {
+  // Canonical `git hash-object` values: `git hash-object --stdin < /dev/null`
+  // and `printf 'hello\n' | git hash-object --stdin`. Hardcoding them proves the
+  // implementation matches git's own blob identity (which GitHub's API returns).
+  test("empty content matches git's empty-blob SHA", () => {
+    expect(gitBlobSha(new Uint8Array(0))).toBe("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391");
+  });
+
+  test("'hello\\n' matches git hash-object", () => {
+    expect(gitBlobSha(Buffer.from("hello\n", "utf8"))).toBe("ce013625030ba8dba906f756967f9e9ca394464a");
+  });
+
+  test("uses raw byte length, not character count, for multi-byte content", () => {
+    // "é" is 2 bytes in UTF-8; the header must read `blob 2\0`, not `blob 1\0`.
+    // `printf 'é' | git hash-object --stdin` → this SHA.
+    expect(gitBlobSha(Buffer.from("é", "utf8"))).toBe("4b04fff51468d8ab5201ab02b725dc477bc7cb45");
+  });
+});
+
+describe("computeSeedTree", () => {
+  test("pairs each resolved path with the git blob SHA of its bytes, in input order", () => {
+    const root = mkdtempSync(join(tmpdir(), "b0343-seed-tree-"));
+    writeFileSync(join(root, "a.txt"), "hello\n");
+    writeFileSync(join(root, "b.txt"), "");
+
+    expect(computeSeedTree(["a.txt", "b.txt"], root)).toEqual([
+      { path: "a.txt", sha: "ce013625030ba8dba906f756967f9e9ca394464a" },
+      { path: "b.txt", sha: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391" },
+    ]);
+  });
+
+  test("empty resolved set produces empty tree", () => {
+    expect(computeSeedTree([], tmpdir())).toEqual([]);
   });
 });

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -147,13 +147,18 @@ export function gitBlobSha(content: Uint8Array): string {
  * Read each resolved seed file and pair it with its git blob SHA, sorted by path.
  * Read-only (one `readFileSync` per resolved file); no mutation, no network, no gh.
  * The resulting set is the "desired state" an idempotency slice diffs against the
- * target repo's tree. Input is assumed already resolved+sorted by `resolveSeedFiles`.
+ * target repo's tree. Output is canonically sorted by path REGARDLESS of input
+ * order — this matches git's own path-sorted tree representation and makes the
+ * idempotency comparison basis stable even if a caller passes an unsorted set
+ * (`resolveSeedFiles` already sorts, but the contract does not depend on it).
  */
 export function computeSeedTree(resolved: readonly string[], root: string): readonly SeedTreeEntry[] {
-  return resolved.map((path) => ({
-    path,
-    sha: gitBlobSha(readFileSync(join(root, path))),
-  }));
+  return resolved
+    .map((path) => ({
+      path,
+      sha: gitBlobSha(readFileSync(join(root, path))),
+    }))
+    .sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
 }
 
 /**

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -18,7 +18,9 @@
  */
 
 import { parseArgs } from "node:util";
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 type ExitCode = 0 | 1;
@@ -27,6 +29,18 @@ type ManifestSection = "include" | "exclude";
 interface SeedManifest {
   readonly include: readonly string[];
   readonly exclude: readonly string[];
+}
+
+/**
+ * One resolved seed file paired with its git blob SHA — the content-addressable
+ * identity GitHub's git-data/contents API returns verbatim for the same bytes.
+ * A future idempotency slice (AC 3) compares this `{path, sha}` set against the
+ * target repo's tree, so "is the repo already seeded with exactly these files?"
+ * becomes a pure set comparison with no remote-content download.
+ */
+interface SeedTreeEntry {
+  readonly path: string;
+  readonly sha: string;
 }
 
 const MANIFEST_DISPLAY_PATH = "docs/bootstrap-razor/SEED-MANIFEST.md";
@@ -119,6 +133,30 @@ export function resolveSeedFiles(
 }
 
 /**
+ * Git's content-addressable blob identity: `sha1("blob " + byteLength + "\0" + content)`.
+ * Byte-identical to `git hash-object` and to the `sha` GitHub returns in git-tree
+ * and contents API responses. Pure — operates on the given bytes only. Uses the
+ * raw byte length (NOT character count) so multi-byte content hashes correctly.
+ */
+export function gitBlobSha(content: Uint8Array): string {
+  const header = Buffer.from(`blob ${content.length}\0`, "ascii");
+  return createHash("sha1").update(header).update(content).digest("hex");
+}
+
+/**
+ * Read each resolved seed file and pair it with its git blob SHA, sorted by path.
+ * Read-only (one `readFileSync` per resolved file); no mutation, no network, no gh.
+ * The resulting set is the "desired state" an idempotency slice diffs against the
+ * target repo's tree. Input is assumed already resolved+sorted by `resolveSeedFiles`.
+ */
+export function computeSeedTree(resolved: readonly string[], root: string): readonly SeedTreeEntry[] {
+  return resolved.map((path) => ({
+    path,
+    sha: gitBlobSha(readFileSync(join(root, path))),
+  }));
+}
+
+/**
  * Read-only filesystem scan: collect the concrete files under each rooted
  * include pattern. Scans include patterns directly (never a recursive glob
  * from root) to avoid walking gitignored mirror trees. No mutation, no
@@ -143,11 +181,14 @@ function emitDryRun(manifest: SeedManifest, root: string): void {
 
   const candidates = collectSeedCandidates(root, manifest);
   const resolved = resolveSeedFiles(candidates, manifest);
-  console.log(`Resolved concrete seed files (${resolved.length}):`);
-  for (const file of resolved) console.log(`  • ${file}`);
+  const tree = computeSeedTree(resolved, root);
+  console.log(`Resolved concrete seed files with git blob SHAs (${tree.length}):`);
+  for (const { path, sha } of tree) console.log(`  • ${sha}  ${path}`);
 
+  console.log("These blob SHAs are the idempotency comparison basis (AC 3):");
+  console.log("a follow-up slice diffs them against the target repo's git tree.");
   console.log("Provenance commit would link to B-0193 / B-0343.");
-  console.log("Idempotency + gh create + real seeding: follow-up slice.");
+  console.log("gh create + real seeding + commit: follow-up slice.");
 }
 
 export function main(argv: readonly string[]): ExitCode {


### PR DESCRIPTION
## What

Bounded **slice 3** of B-0343 (test-repo seeding script). Adds the content-addressable representation of the resolved seed set — each resolved file paired with its **git blob SHA** — as the read-only prerequisite for AC 3 (idempotency).

Builds on the merged manifest-reader + `--dry-run` + glob-resolution slices (PRs #2716 / #2722 / #2723 / #5992).

## Why this slice / why now

The script's own slice-2 comment names the prerequisite: *"idempotency = compare the resolved set against the target repo"*. A git blob SHA is `sha1("blob " + byteLength + "\0" + content)` — byte-identical to `git hash-object` and to the `sha` GitHub returns in its git-data/tree + contents API responses. Computing these locally turns AC 3's "is the repo already seeded with exactly these files?" into a **pure `{path, sha}` set-equality check with zero remote-content download**.

Smallest **safe** step: still **no `gh`, no network, no repo mutation** — only a read-only `readFileSync` per resolved file. `gh` create + real seeding + commit remain follow-up slices.

## Changes

- `gitBlobSha(content)` — exported pure fn; uses raw **byte** length (not char count) so multi-byte content hashes correctly.
- `computeSeedTree(resolved, root)` — read-only, returns sorted `{path, sha}` set; one `readFileSync` per resolved file; no mutation/network/gh.
- `--dry-run` now prints `<sha>  <path>` per resolved file as the explicit AC 3 comparison basis.
- Tests cross-check empty / `"hello\n"` / multi-byte `"é"` against **canonical `git hash-object` values**.

## Focused checks (run locally)

| Check | Result |
|---|---|
| `bun test tools/bootstrap-razor/seed-test-repo.test.ts` | **11 pass / 0 fail** |
| `bunx tsc -p tsconfig.json --noEmit` | **0 errors in changed files** (pre-existing unrelated NATS errors in `agentic-organization/apps/workers/` only) |
| `bun tools/bootstrap-razor/seed-test-repo.ts --dry-run` | prints resolved files with blob SHAs ✓ |
| `printf '…' \| git hash-object --stdin` cross-check | all 3 fixtures match git's output ✓ |

Notably, the empirical test run **caught a guessed `"é"` SHA fixture** (verify-before-asserting); the implementation already produced git's real value, and the fixture was corrected to the verified SHA.

Commit canary clean: `git ls-tree HEAD~1 = git ls-tree HEAD = 63` (no tree collapse).

Closes a slice of B-0343; AC 3 (idempotency) + repo creation + commit logic remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)