### PR TITLE
feat(B-0343): pure diffSeedTree idempotency comparison (bounded slice 4)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { computeSeedTree, gitBlobSha, parseSeedManifest, resolveSeedFiles } from "./seed-test-repo.ts";
+import { computeSeedTree, diffSeedTree, gitBlobSha, parseSeedManifest, resolveSeedFiles } from "./seed-test-repo.ts";
 
 describe("parseSeedManifest", () => {
   test("extracts include and exclude entries from fenced yaml", () => {
@@ -115,5 +115,66 @@ describe("computeSeedTree", () => {
 
   test("empty resolved set produces empty tree", () => {
     expect(computeSeedTree([], tmpdir())).toEqual([]);
+  });
+});
+
+describe("diffSeedTree", () => {
+  const a = { path: "a.txt", sha: "aaa" };
+  const b = { path: "b.txt", sha: "bbb" };
+  const c = { path: "c.txt", sha: "ccc" };
+
+  test("empty target → every desired path is a create, not idempotent", () => {
+    expect(diffSeedTree([b, a], [])).toEqual({
+      entries: [
+        { path: "a.txt", action: "create", desiredSha: "aaa", existingSha: null },
+        { path: "b.txt", action: "create", desiredSha: "bbb", existingSha: null },
+      ],
+      extraneous: [],
+      idempotent: false,
+    });
+  });
+
+  test("identical target → all unchanged and idempotent", () => {
+    expect(diffSeedTree([a, b], [a, b])).toEqual({
+      entries: [
+        { path: "a.txt", action: "unchanged", desiredSha: "aaa", existingSha: "aaa" },
+        { path: "b.txt", action: "unchanged", desiredSha: "bbb", existingSha: "bbb" },
+      ],
+      extraneous: [],
+      idempotent: true,
+    });
+  });
+
+  test("differing blob SHA → update, not idempotent", () => {
+    const diff = diffSeedTree([a], [{ path: "a.txt", sha: "OLD" }]);
+    expect(diff.entries).toEqual([
+      { path: "a.txt", action: "update", desiredSha: "aaa", existingSha: "OLD" },
+    ]);
+    expect(diff.idempotent).toBe(false);
+  });
+
+  test("extraneous target file is reported but does NOT break idempotency", () => {
+    // Target has the desired file (matching) plus an extra file (e.g. auto-README).
+    const diff = diffSeedTree([a], [a, c]);
+    expect(diff.entries).toEqual([
+      { path: "a.txt", action: "unchanged", desiredSha: "aaa", existingSha: "aaa" },
+    ]);
+    expect(diff.extraneous).toEqual([c]);
+    expect(diff.idempotent).toBe(true);
+  });
+
+  test("mixed create/update/unchanged → not idempotent, entries path-sorted", () => {
+    // desired: a (matches), b (differs → update), c (absent → create); given unsorted.
+    const diff = diffSeedTree([c, b, a], [a, { path: "b.txt", sha: "OLD" }]);
+    expect(diff.entries).toEqual([
+      { path: "a.txt", action: "unchanged", desiredSha: "aaa", existingSha: "aaa" },
+      { path: "b.txt", action: "update", desiredSha: "bbb", existingSha: "OLD" },
+      { path: "c.txt", action: "create", desiredSha: "ccc", existingSha: null },
+    ]);
+    expect(diff.idempotent).toBe(false);
+  });
+
+  test("empty desired and empty target → vacuously idempotent", () => {
+    expect(diffSeedTree([], [])).toEqual({ entries: [], extraneous: [], idempotent: true });
   });
 });

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -38,9 +38,34 @@ interface SeedManifest {
  * target repo's tree, so "is the repo already seeded with exactly these files?"
  * becomes a pure set comparison with no remote-content download.
  */
-interface SeedTreeEntry {
+export interface SeedTreeEntry {
   readonly path: string;
   readonly sha: string;
+}
+
+/** One desired seed path classified against the target repo's current tree. */
+type SeedFileAction = "unchanged" | "create" | "update";
+
+interface SeedDiffEntry {
+  readonly path: string;
+  readonly action: SeedFileAction;
+  readonly desiredSha: string;
+  /** The target's current blob SHA; null only when `action === "create"`. */
+  readonly existingSha: string | null;
+}
+
+/**
+ * Idempotency comparison result (AC 3). `entries` classifies every DESIRED path;
+ * `extraneous` lists files present in the target tree but absent from the desired
+ * set. Extraneous files do NOT break idempotency: seeding only creates/updates the
+ * manifest's files and never deletes (a freshly-created repo's auto-README is
+ * reported, not clobbered). `idempotent` is therefore true exactly when no path
+ * needs a create or an update.
+ */
+interface SeedTreeDiff {
+  readonly entries: readonly SeedDiffEntry[];
+  readonly extraneous: readonly SeedTreeEntry[];
+  readonly idempotent: boolean;
 }
 
 const MANIFEST_DISPLAY_PATH = "docs/bootstrap-razor/SEED-MANIFEST.md";
@@ -159,6 +184,49 @@ export function computeSeedTree(resolved: readonly string[], root: string): read
       sha: gitBlobSha(readFileSync(join(root, path))),
     }))
     .sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+}
+
+/**
+ * Pure idempotency diff (AC 3): classify each DESIRED `{path, sha}` against the
+ * target repo's EXISTING `{path, sha}` tree. Per desired path:
+ *   - absent from existing            → "create"
+ *   - present, same blob SHA          → "unchanged"
+ *   - present, different blob SHA     → "update"
+ * Files present in `existing` but absent from `desired` are reported as
+ * `extraneous` (never deleted — seeding is add/update only). The repo is
+ * idempotent (already seeded with exactly these bytes) when no path needs a
+ * create or update. Pure — operates on the two SHA sets only; no filesystem,
+ * no network, no gh. This is the comparison `computeSeedTree`'s slice named as
+ * its handoff; a follow-up slice fetches the target tree via gh and feeds it in.
+ */
+export function diffSeedTree(
+  desired: readonly SeedTreeEntry[],
+  existing: readonly SeedTreeEntry[],
+): SeedTreeDiff {
+  const byPath = new Map(existing.map((entry) => [entry.path, entry.sha]));
+  const desiredPaths = new Set(desired.map((entry) => entry.path));
+  const byPathSort = (a: { path: string }, b: { path: string }): number =>
+    a.path < b.path ? -1 : a.path > b.path ? 1 : 0;
+
+  const entries = desired
+    .map((entry): SeedDiffEntry => {
+      const existingSha = byPath.get(entry.path);
+      if (existingSha === undefined) {
+        return { path: entry.path, action: "create", desiredSha: entry.sha, existingSha: null };
+      }
+      return {
+        path: entry.path,
+        action: existingSha === entry.sha ? "unchanged" : "update",
+        desiredSha: entry.sha,
+        existingSha,
+      };
+    })
+    .sort(byPathSort);
+
+  const extraneous = existing.filter((entry) => !desiredPaths.has(entry.path)).sort(byPathSort);
+  const idempotent = entries.every((entry) => entry.action === "unchanged");
+
+  return { entries, extraneous, idempotent };
 }
 
 /**


### PR DESCRIPTION
## What

Bounded slice 4 of **B-0343** (test-repo seeding script). Adds a pure
`diffSeedTree(desired, existing)` function — the idempotency comparison core
for **AC 3** ("re-running against an existing repo reports status, does not
duplicate").

Slice 3 ([#5995](https://github.com/Lucent-Financial-Group/Zeta/pull/5995))
computed the desired `{path, sha}` seed tree and named its own handoff:
> *"a follow-up slice diffs them against the target repo's git tree"*

This is that diff.

## Slice progression

| Slice | Adds | I/O |
|---|---|---|
| 1 | manifest reader + `--dry-run` stub | read manifest |
| 2 (#5992) | glob resolution `resolveSeedFiles` | read-only FS scan |
| 3 (#5995) | git-blob-SHA tree `computeSeedTree` (desired state) | read-only FS |
| **4 (this)** | **`diffSeedTree` — desired vs existing** | **pure (none)** |
| later | gh fetch target tree → feed diff → status report | network read |
| later | AC 1: gh repo create + seed + provenance commit | network mutate |

## Behavior

`diffSeedTree(desired, existing)` is **pure** — no filesystem, no network, no
gh. Per desired path:
- absent from existing → `create`
- present, same blob SHA → `unchanged`
- present, different blob SHA → `update`

Files present in the target but absent from desired are reported as
`extraneous` and **never deleted** — seeding is add/update only, so a freshly
created repo's auto-README does not break idempotency. `idempotent` is true
exactly when no path needs a create or update.

`SeedTreeEntry` is now `export`ed (it is `diffSeedTree`'s parameter type).

## Why this slice / safety

Smallest safe next step: zero repo mutation, zero network, fully pure +
independently testable. The risky network-mutating ACs (gh create, commit)
remain later slices, sitting on top of this tested computational core.

## Focused checks

- `bun test tools/bootstrap-razor/seed-test-repo.test.ts` → **17 pass / 0 fail** (6 new `diffSeedTree` cases: empty-target, identical, update, extraneous-but-idempotent, mixed create/update/unchanged path-sorted, vacuous).
- `bun tools/bootstrap-razor/seed-test-repo.ts --dry-run` → unchanged output, no mutation.
- `tsc --noEmit` → clean for the file.
- Commit canary: parent tree 63 = HEAD tree 63 (no collapse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)