### PR TITLE
feat(B-0343): pure parseGitTreeResponse — GitHub tree API → idempotency diff input (bounded slice 5)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -3,7 +3,14 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { computeSeedTree, diffSeedTree, gitBlobSha, parseSeedManifest, resolveSeedFiles } from "./seed-test-repo.ts";
+import {
+  computeSeedTree,
+  diffSeedTree,
+  gitBlobSha,
+  parseGitTreeResponse,
+  parseSeedManifest,
+  resolveSeedFiles,
+} from "./seed-test-repo.ts";
 
 describe("parseSeedManifest", () => {
   test("extracts include and exclude entries from fenced yaml", () => {
@@ -176,5 +183,65 @@ describe("diffSeedTree", () => {
 
   test("empty desired and empty target → vacuously idempotent", () => {
     expect(diffSeedTree([], [])).toEqual({ entries: [], extraneous: [], idempotent: true });
+  });
+});
+
+describe("parseGitTreeResponse", () => {
+  // Shape mirrors GitHub's GET /repos/{owner}/{repo}/git/trees/{sha}?recursive=1.
+  test("keeps blobs as {path, sha}, drops tree + commit entries, sorts by path", () => {
+    const response = {
+      sha: "root",
+      truncated: false,
+      tree: [
+        { path: "z.txt", mode: "100644", type: "blob", sha: "zzz", size: 3, url: "..." },
+        { path: "sub", mode: "040000", type: "tree", sha: "treeSha", url: "..." },
+        { path: "a.txt", mode: "100644", type: "blob", sha: "aaa", size: 1, url: "..." },
+        { path: "vendored", mode: "160000", type: "commit", sha: "submoduleSha" },
+      ],
+    };
+    expect(parseGitTreeResponse(response)).toEqual([
+      { path: "a.txt", sha: "aaa" },
+      { path: "z.txt", sha: "zzz" },
+    ]);
+  });
+
+  test("the parsed blob set feeds diffSeedTree directly (end-to-end bridge)", () => {
+    const existing = parseGitTreeResponse({
+      truncated: false,
+      tree: [{ path: "a.txt", type: "blob", sha: "aaa" }],
+    });
+    // Narrow off the error branch so the diff call type-checks.
+    if (typeof existing === "string") throw new Error(existing);
+    expect(diffSeedTree([{ path: "a.txt", sha: "aaa" }], existing).idempotent).toBe(true);
+  });
+
+  test("empty tree → empty blob set", () => {
+    expect(parseGitTreeResponse({ truncated: false, tree: [] })).toEqual([]);
+  });
+
+  test("truncated response is rejected (unsafe idempotency basis)", () => {
+    const result = parseGitTreeResponse({
+      truncated: true,
+      tree: [{ path: "a.txt", type: "blob", sha: "aaa" }],
+    });
+    expect(typeof result).toBe("string");
+    expect(result).toContain("truncated");
+  });
+
+  test("non-object response is rejected", () => {
+    expect(typeof parseGitTreeResponse(null)).toBe("string");
+    expect(typeof parseGitTreeResponse("oops")).toBe("string");
+  });
+
+  test("missing tree array is rejected", () => {
+    expect(typeof parseGitTreeResponse({ truncated: false })).toBe("string");
+  });
+
+  test("tree entry missing string path/type/sha is rejected", () => {
+    const result = parseGitTreeResponse({
+      truncated: false,
+      tree: [{ path: "a.txt", type: "blob" }], // no sha
+    });
+    expect(typeof result).toBe("string");
   });
 });

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -43,6 +43,21 @@ export interface SeedTreeEntry {
   readonly sha: string;
 }
 
+/**
+ * The subset of GitHub's `GET /repos/{owner}/{repo}/git/trees/{sha}?recursive=1`
+ * response this slice reads. The API returns more fields (`mode`, `size`, `url`)
+ * but idempotency only needs `path`, `type` (to keep blobs, drop sub-trees and
+ * submodule `commit` entries), and `sha` (the same content-addressable blob
+ * identity `gitBlobSha` produces). `truncated` is load-bearing: GitHub caps the
+ * recursive tree at ~100k entries and sets `truncated: true` when it elides some —
+ * an elided tree is NOT a safe idempotency basis (a missing entry would diff as a
+ * spurious "create"), so the parser rejects it rather than silently under-reporting.
+ */
+interface GitTreeResponse {
+  readonly tree: readonly { readonly path: string; readonly type: string; readonly sha: string }[];
+  readonly truncated: boolean;
+}
+
 /** One desired seed path classified against the target repo's current tree. */
 type SeedFileAction = "unchanged" | "create" | "update";
 
@@ -227,6 +242,53 @@ export function diffSeedTree(
   const idempotent = entries.every((entry) => entry.action === "unchanged");
 
   return { entries, extraneous, idempotent };
+}
+
+/**
+ * Pure parser: turn a GitHub git-tree API response into the `{path, sha}` set
+ * `diffSeedTree` consumes as its `existing` (target-repo) argument. This is the
+ * missing bridge between a future `gh api git/trees/<sha>?recursive=1` call and
+ * the already-tested pure diff — isolating it here keeps the network slice that
+ * follows trivial (one fetch + JSON.parse + this function). Pure: no network,
+ * no gh, no filesystem; operates only on the already-parsed JSON value.
+ *
+ * Returns the sorted blob set on success, or an error string (same `T | string`
+ * convention as `readManifest`) when the response is unusable:
+ *   - not an object, or missing a `tree` array            → malformed
+ *   - `truncated: true`                                   → incomplete basis (rejected,
+ *     because a missing entry would mis-diff as a "create" and trigger a duplicate write)
+ *   - a tree entry missing string `path`/`type`/`sha`     → malformed entry
+ *
+ * Non-blob entries (`type === "tree"` directories, `type === "commit"` submodule
+ * gitlinks) are dropped: seeding compares files, and a recursive tree already
+ * lists every blob with its full path, so the directory rows carry no information
+ * the diff needs.
+ */
+export function parseGitTreeResponse(response: unknown): readonly SeedTreeEntry[] | string {
+  if (typeof response !== "object" || response === null) {
+    return "git tree response is not an object";
+  }
+  const candidate = response as Partial<GitTreeResponse>;
+  if (!Array.isArray(candidate.tree)) {
+    return "git tree response missing `tree` array";
+  }
+  if (candidate.truncated === true) {
+    return "git tree response is truncated — cannot use as an idempotency basis";
+  }
+
+  const blobs: SeedTreeEntry[] = [];
+  for (const entry of candidate.tree) {
+    if (typeof entry !== "object" || entry === null) {
+      return "git tree entry is not an object";
+    }
+    const { path, type, sha } = entry as Record<string, unknown>;
+    if (typeof path !== "string" || typeof type !== "string" || typeof sha !== "string") {
+      return "git tree entry missing string path/type/sha";
+    }
+    if (type === "blob") blobs.push({ path, sha });
+  }
+
+  return blobs.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
 }
 
 /**


### PR DESCRIPTION
## What

Bounded slice 5 of **B-0343** (test-repo seeding script). Adds one pure
function, `parseGitTreeResponse`, plus tests.

It is the missing bridge between a future `gh api git/trees/<sha>?recursive=1`
call and the already-merged, already-tested `diffSeedTree` (slice 4):

```
gh tree response (JSON)  ──parseGitTreeResponse──▶  SeedTreeEntry[]  ──▶  diffSeedTree(desired, existing)
```

Still **read-only / pure** — no network, no `gh`, no filesystem, no repo
mutation. Continues the decomposition discipline of slices 3–4 (each slice
adds one pure, unit-tested function so the impure `gh` fetch lands last with
all inputs already verified).

## Why the truncation guard is load-bearing (AC 3 correctness)

GitHub caps the recursive tree at ~100k entries and sets `truncated: true`
when it elides some. An elided tree is **not** a safe idempotency basis: a
file present in the repo but missing from the response would diff as a
spurious `"create"`, producing a false non-idempotent verdict and a
duplicate-write attempt. The parser therefore **rejects** a truncated
response (returns an error string, same `T | string` convention as
`readManifest`) rather than silently under-reporting.

Non-blob entries (`type: "tree"` directories, `type: "commit"` submodule
gitlinks) are dropped — a recursive tree already lists every blob with its
full path, so directory rows carry no information the diff needs.

## Scope discipline

- Authorization scope unchanged (LFG/AceHack only; no `gh` calls in this slice at all).
- `--dry-run` CLI path untouched; no behavioural change to the existing entrypoint.
- gh-fetch wiring (call the API, `JSON.parse`, feed this function) = follow-up slice.

## Focused checks

| Check | Result |
|---|---|
| `bun test tools/bootstrap-razor/seed-test-repo.test.ts` | **24 pass / 0 fail** (7 new `parseGitTreeResponse` cases) |
| `bun tools/bootstrap-razor/seed-test-repo.ts --dry-run` | clean — manifest plan still renders, no regression |
| `bunx tsc --noEmit -p tsconfig.json` | **0 errors in `tools/bootstrap-razor/`** (8 pre-existing errors are NATS module-resolution in `agentic-organization/apps/workers/test/`, unrelated) |
| Commit canary | parent tree 63 == this tree 63 (no tree collapse) |

New tests cover: blob-keeping + tree/commit-dropping + path-sort, the
end-to-end bridge feeding `diffSeedTree`, empty tree, truncation rejection,
non-object rejection, missing-`tree` rejection, malformed-entry rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
