### PR TITLE
feat(B-0343): pure buildSeedTreeRequest — idempotency diff → POST /git/trees payload (bounded slice 6)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  buildSeedTreeRequest,
   computeSeedTree,
   diffSeedTree,
   gitBlobSha,
@@ -243,5 +244,48 @@ describe("parseGitTreeResponse", () => {
       tree: [{ path: "a.txt", type: "blob" }], // no sha
     });
     expect(typeof result).toBe("string");
+  });
+});
+
+describe("buildSeedTreeRequest", () => {
+  const a = { path: "a.txt", sha: "aaa" };
+  const b = { path: "b.txt", sha: "bbb" };
+
+  test("create + update become 100644 blob entries carrying the DESIRED sha", () => {
+    // desired: a (matches → unchanged, dropped), b (differs → update), c (absent → create)
+    const diff = diffSeedTree(
+      [a, b, { path: "c.txt", sha: "ccc" }],
+      [a, { path: "b.txt", sha: "OLD" }],
+    );
+    expect(buildSeedTreeRequest(diff)).toEqual([
+      // b.txt update carries desiredSha "bbb", NOT the existing "OLD"
+      { path: "b.txt", mode: "100644", type: "blob", sha: "bbb" },
+      { path: "c.txt", mode: "100644", type: "blob", sha: "ccc" },
+    ]);
+  });
+
+  test("idempotent diff → empty write plan (no tree to submit)", () => {
+    expect(buildSeedTreeRequest(diffSeedTree([a, b], [a, b]))).toEqual([]);
+  });
+
+  test("fresh (empty) repo → every desired path is a create entry", () => {
+    expect(buildSeedTreeRequest(diffSeedTree([b, a], []))).toEqual([
+      { path: "a.txt", mode: "100644", type: "blob", sha: "aaa" },
+      { path: "b.txt", mode: "100644", type: "blob", sha: "bbb" },
+    ]);
+  });
+
+  test("output stays path-sorted (inherits diffSeedTree's canonical order)", () => {
+    const plan = buildSeedTreeRequest(
+      diffSeedTree([{ path: "z.txt", sha: "zzz" }, { path: "a.txt", sha: "aaa" }], []),
+    );
+    expect(plan.map((e) => e.path)).toEqual(["a.txt", "z.txt"]);
+  });
+
+  test("extraneous target files never enter the write plan (seed is add/update only)", () => {
+    // Target has the desired file (matching) plus an extra auto-README.
+    const diff = diffSeedTree([a], [a, { path: "README.md", sha: "readme" }]);
+    expect(diff.extraneous).toEqual([{ path: "README.md", sha: "readme" }]);
+    expect(buildSeedTreeRequest(diff)).toEqual([]); // a.txt unchanged, README extraneous → nothing to write
   });
 });

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -83,6 +83,22 @@ interface SeedTreeDiff {
   readonly idempotent: boolean;
 }
 
+/**
+ * One entry in the `tree` array of GitHub's `POST /repos/{owner}/{repo}/git/trees`
+ * request body. `mode` is always `100644` (a regular non-executable file blob) for
+ * seed content; `type` is always `"blob"`; `sha` references a blob the seeding flow
+ * uploaded just before (a prior `POST /git/blobs` of the file's bytes returns this
+ * same content-addressable SHA). The seed never writes directory rows or executable
+ * bits, so the broader git-tree shape (`040000` sub-trees, `100755` exec, `120000`
+ * symlinks, `160000` submodule gitlinks) is intentionally unrepresented.
+ */
+export interface GitTreeRequestEntry {
+  readonly path: string;
+  readonly mode: "100644";
+  readonly type: "blob";
+  readonly sha: string;
+}
+
 const MANIFEST_DISPLAY_PATH = "docs/bootstrap-razor/SEED-MANIFEST.md";
 const MANIFEST_PATH = fileURLToPath(new URL("../../docs/bootstrap-razor/SEED-MANIFEST.md", import.meta.url));
 // Repo root = two levels up from tools/bootstrap-razor/.
@@ -292,6 +308,31 @@ export function parseGitTreeResponse(response: unknown): readonly SeedTreeEntry[
 }
 
 /**
+ * Pure write-side bridge — the mirror of `parseGitTreeResponse`. Where the parser
+ * turns the target repo's git tree INTO the diff's `existing` input, this turns the
+ * diff's verdict INTO the `tree` array a `POST /git/trees` call submits to write the
+ * seed. Only paths whose action is "create" or "update" appear: "unchanged" paths are
+ * carried implicitly by the request's `base_tree` (the target's current tree), so
+ * re-listing them would be wasted bytes and a needless tree-object churn. Each entry
+ * carries the DESIRED blob SHA (`desiredSha`), which is the same content-addressable
+ * identity a prior `POST /git/blobs` of that file's bytes returns — so the network
+ * slice that follows is: upload each create/update blob → submit this tree (with
+ * base_tree = current ref tree) → create a commit → fast-forward the ref.
+ *
+ * Pure: operates only on the diff; no gh, no network, no filesystem. When the diff
+ * is idempotent (`diff.idempotent === true`) the result is the empty array — the
+ * repo already holds exactly these bytes, so there is no tree to write at all, and
+ * the seeding flow can skip the blob/tree/commit/ref steps entirely (AC 3). Input
+ * order is preserved: `diffSeedTree` already returns `entries` path-sorted, matching
+ * git's own path-sorted tree representation, so the output stays canonically sorted.
+ */
+export function buildSeedTreeRequest(diff: SeedTreeDiff): readonly GitTreeRequestEntry[] {
+  return diff.entries
+    .filter((entry) => entry.action !== "unchanged")
+    .map((entry) => ({ path: entry.path, mode: "100644", type: "blob", sha: entry.desiredSha }));
+}
+
+/**
  * Read-only filesystem scan: collect the concrete files under each rooted
  * include pattern. Scans include patterns directly (never a recursive glob
  * from root) to avoid walking gitignored mirror trees. No mutation, no
@@ -322,6 +363,18 @@ function emitDryRun(manifest: SeedManifest, root: string): void {
 
   console.log("These blob SHAs are the idempotency comparison basis (AC 3):");
   console.log("a follow-up slice diffs them against the target repo's git tree.");
+
+  // Against a FRESH (empty) repo every desired path is a create, so the diff's
+  // write plan equals the full seed. This shows the exact `POST /git/trees` tree
+  // array the seeding flow would submit for a brand-new repo (AC 1). For an
+  // already-seeded repo the network slice fetches the real tree, and an idempotent
+  // diff collapses this to the empty array (no writes).
+  const freshRepoPlan = buildSeedTreeRequest(diffSeedTree(tree, []));
+  console.log(`POST /git/trees write plan for a fresh repo (${freshRepoPlan.length} entries):`);
+  for (const { mode, type, sha, path } of freshRepoPlan) {
+    console.log(`  ${mode} ${type} ${sha}  ${path}`);
+  }
+
   console.log("Provenance commit would link to B-0193 / B-0343.");
   console.log("gh create + real seeding + commit: follow-up slice.");
 }


### PR DESCRIPTION
## What

Bounded slice 6 of **B-0343** (test-repo seeding script). Adds one pure function — `buildSeedTreeRequest` — the **write-side bridge** that mirrors slice 5's `parseGitTreeResponse` (read-side bridge).

| Pipeline stage | Function | Slice |
|---|---|---|
| manifest → patterns | `parseSeedManifest` | merged |
| patterns → resolved files | `resolveSeedFiles` | #5992 |
| resolved → desired tree (blob SHAs) | `gitBlobSha` / `computeSeedTree` | #5995 |
| gh tree response → existing tree | `parseGitTreeResponse` | #5997 |
| desired vs existing → diff | `diffSeedTree` | #5996 |
| **diff → `POST /git/trees` payload** | **`buildSeedTreeRequest`** | **this PR** |

## Behaviour

- Keeps only `create` + `update` diff entries; drops `unchanged` (carried implicitly by the request's `base_tree`).
- Each entry is `{ path, mode: "100644", type: "blob", sha: desiredSha }` — the desired blob SHA, the same content-addressable identity a prior `POST /git/blobs` of the file's bytes returns.
- **Idempotent diff → empty plan** (AC 3): the repo already holds exactly these bytes, so the seeding flow skips blob/tree/commit/ref entirely.
- Output stays path-sorted (inherits `diffSeedTree`'s canonical order, matching git's own tree representation).
- **Pure**: no `gh`, no network, no filesystem. The remaining network slice is now trivial — upload blobs → submit this tree (`base_tree` = current ref tree) → commit → fast-forward ref.

## Dry-run enhancement (AC 1)

`--dry-run` now prints the `POST /git/trees` write plan for a *fresh* repo (diff vs empty target = full seed), demonstrating "seed exactly the manifest's files":

```
POST /git/trees write plan for a fresh repo (N entries):
  100644 blob dc3ad70…  tools/tla/specs/BftConsensus.tla
  ...
```

## Scope discipline

One pure function + types + tests; no `gh`, no repo mutation. Stays within the established pure-function-per-slice decomposition. Authorization scope (LFG/AceHack only, never ServiceTitan) is unaffected — no repo is created or mutated by this slice.

## Checks (run before opening)

- `bun test tools/bootstrap-razor/seed-test-repo.test.ts` → **29 pass / 0 fail** (+5 new tests for `buildSeedTreeRequest`: create/update mapping, idempotent→empty, fresh-repo, sort-preservation, extraneous-excluded).
- `bunx tsc --noEmit -p tsconfig.json` → **clean for this file** (no `bootstrap-razor` errors).
- `bun tools/bootstrap-razor/seed-test-repo.ts --dry-run` → emits the `100644 blob <sha> <path>` plan as expected.

operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)