### PR TITLE
feat(B-0343): pure buildSeedCommitRequest — seed tree SHA → POST /git/commits payload (bounded slice 7)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  buildSeedCommitRequest,
   buildSeedTreeRequest,
   computeSeedTree,
   diffSeedTree,
@@ -11,6 +12,7 @@ import {
   parseGitTreeResponse,
   parseSeedManifest,
   resolveSeedFiles,
+  seedCommitMessage,
 } from "./seed-test-repo.ts";
 
 describe("parseSeedManifest", () => {
@@ -287,5 +289,48 @@ describe("buildSeedTreeRequest", () => {
     const diff = diffSeedTree([a], [a, { path: "README.md", sha: "readme" }]);
     expect(diff.extraneous).toEqual([{ path: "README.md", sha: "readme" }]);
     expect(buildSeedTreeRequest(diff)).toEqual([]); // a.txt unchanged, README extraneous → nothing to write
+  });
+});
+
+describe("seedCommitMessage", () => {
+  test("subject names the file count, body cites the manifest + B-0193/B-0343 lineage", () => {
+    const message = seedCommitMessage(7);
+    const [subject, ...rest] = message.split("\n");
+    expect(subject).toBe("chore(B-0343): seed bootstrap-razor recreation test repo (7 files)");
+    const body = rest.join("\n");
+    expect(body).toContain("docs/bootstrap-razor/SEED-MANIFEST.md");
+    expect(body).toContain("B-0193");
+    expect(body).toContain("B-0343");
+  });
+
+  test("pluralizes the count noun (1 file vs N files)", () => {
+    expect(seedCommitMessage(1)).toContain("(1 file)");
+    expect(seedCommitMessage(2)).toContain("(2 files)");
+  });
+
+  test("subject and body are separated by a blank line (git convention)", () => {
+    // git treats the first blank-line-delimited block as the subject; assert the
+    // second line is empty so tools that render subject/body split correctly.
+    expect(seedCommitMessage(3).split("\n")[1]).toBe("");
+  });
+});
+
+describe("buildSeedCommitRequest", () => {
+  test("existing ref → parent SHA wrapped in a one-element array", () => {
+    expect(buildSeedCommitRequest("treeSha", "parentSha", 2)).toEqual({
+      message: seedCommitMessage(2),
+      tree: "treeSha",
+      parents: ["parentSha"],
+    });
+  });
+
+  test("brand-new repo (null parent) → empty parents array (root commit)", () => {
+    const request = buildSeedCommitRequest("treeSha", null, 5);
+    expect(request.parents).toEqual([]);
+    expect(request.tree).toBe("treeSha");
+  });
+
+  test("carries the provenance message for the given file count", () => {
+    expect(buildSeedCommitRequest("t", "p", 1).message).toBe(seedCommitMessage(1));
   });
 });

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -99,6 +99,24 @@ export interface GitTreeRequestEntry {
   readonly sha: string;
 }
 
+/**
+ * The `POST /repos/{owner}/{repo}/git/commits` request body for the seed commit —
+ * the next git-data step after `buildSeedTreeRequest`'s tree is submitted. `tree`
+ * is the SHA `POST /git/trees` returns; `parents` is the target ref's current commit
+ * SHA wrapped in a one-element array, OR the empty array for a brand-new repo's root
+ * commit (GitHub accepts `parents: []` as a parentless root commit). `message` carries
+ * the provenance line linking back to B-0193 / B-0343 so the recreation experiment's
+ * history is self-documenting (AC: "commits the seed with a clear provenance message
+ * linking back to B-0193"). GitHub's commit API accepts more optional fields
+ * (`author`, `committer`, `signature`) — the seed sets none, letting the token's
+ * identity author the commit, so they are intentionally unrepresented.
+ */
+export interface GitCommitRequest {
+  readonly message: string;
+  readonly tree: string;
+  readonly parents: readonly string[];
+}
+
 const MANIFEST_DISPLAY_PATH = "docs/bootstrap-razor/SEED-MANIFEST.md";
 const MANIFEST_PATH = fileURLToPath(new URL("../../docs/bootstrap-razor/SEED-MANIFEST.md", import.meta.url));
 // Repo root = two levels up from tools/bootstrap-razor/.
@@ -330,6 +348,52 @@ export function buildSeedTreeRequest(diff: SeedTreeDiff): readonly GitTreeReques
   return diff.entries
     .filter((entry) => entry.action !== "unchanged")
     .map((entry) => ({ path: entry.path, mode: "100644", type: "blob", sha: entry.desiredSha }));
+}
+
+/**
+ * The provenance commit message for the seed (AC: "clear provenance message linking
+ * back to B-0193"). A conventional-commit subject naming the file count, then a body
+ * citing the seed manifest as the source-of-truth and the B-0193 parent / B-0343 slice
+ * lineage. Pure: a string function of the file count only. `fileCount` pluralizes the
+ * subject ("1 file" vs "N files"); it is the count of files the seed WRITES (the diff's
+ * create + update entries), so a re-seed that touches one file reads naturally. The
+ * idempotent path never reaches a commit at all (`buildSeedTreeRequest` returns the
+ * empty plan), so this is only ever called with `fileCount >= 1`.
+ */
+export function seedCommitMessage(fileCount: number): string {
+  const noun = fileCount === 1 ? "file" : "files";
+  return [
+    `chore(B-0343): seed bootstrap-razor recreation test repo (${fileCount} ${noun})`,
+    "",
+    `Seeded from ${MANIFEST_DISPLAY_PATH} per B-0193 AC 1`,
+    "(bootstrap razor + 23-hour recreation test).",
+    "",
+    "Parent: B-0193",
+    "Slice:  B-0343",
+  ].join("\n");
+}
+
+/**
+ * Pure builder for the seed commit's `POST /git/commits` body — the mirror of
+ * `buildSeedTreeRequest` one step further down the git-data write chain. Takes the
+ * tree SHA the prior `POST /git/trees` returned, the target ref's current commit SHA
+ * (or `null` for a brand-new repo with no commits yet), and the file count for the
+ * provenance message. The `parentSha === null` case maps to `parents: []` — a root
+ * commit — so a freshly-`gh`-created empty repo and an existing-ref fast-forward share
+ * one builder. Pure: operates on the three arguments only; no gh, no network, no
+ * filesystem. The network slice that follows is: submit this body → take the returned
+ * commit SHA → `PATCH /git/refs/heads/<branch>` to fast-forward the ref.
+ */
+export function buildSeedCommitRequest(
+  treeSha: string,
+  parentSha: string | null,
+  fileCount: number,
+): GitCommitRequest {
+  return {
+    message: seedCommitMessage(fileCount),
+    tree: treeSha,
+    parents: parentSha === null ? [] : [parentSha],
+  };
 }
 
 /**


### PR DESCRIPTION
## What

B-0343 bounded slice 7. Adds the next **pure** link in the git-data write chain after [slice 6](https://github.com/Lucent-Financial-Group/Zeta/pull/5998)'s `buildSeedTreeRequest`: the seed **commit-request builder** plus its provenance-message generator.

This directly satisfies the B-0343 "What" §3 — *"commits the seed with a clear provenance message linking back to B-0193"*.

### Added (all pure — no gh, no network, no filesystem)

- **`seedCommitMessage(fileCount)`** — conventional-commit subject with pluralized file count (`1 file` vs `N files`), then a body citing `docs/bootstrap-razor/SEED-MANIFEST.md` as the source-of-truth and the **B-0193 parent / B-0343 slice** lineage.
- **`buildSeedCommitRequest(treeSha, parentSha, fileCount)`** — builds the `POST /git/commits` body. `parentSha === null` → `parents: []` (root commit for a brand-new repo); a non-null parent → one-element array (existing-ref fast-forward). One builder covers both repo states.
- **`GitCommitRequest`** interface documenting the request shape (`message` / `tree` / `parents`).

### Pipeline position

```
manifest → resolveSeedFiles → computeSeedTree (desired)
  → diffSeedTree(desired, existing) → buildSeedTreeRequest (POST /git/trees)
  → buildSeedCommitRequest (POST /git/commits)   ← THIS SLICE
  → [follow-up] PATCH /git/refs (fast-forward)
```

The network slice that follows is trivial: submit body → take returned commit SHA → `PATCH /git/refs/heads/<branch>` to fast-forward. Still **no repo mutation** in this PR.

## Why this slice

Per the repo's pure-function-first slicing discipline (DST-friendly, Rule 0): every network step is decomposed into a pure `(input) → output` builder that's unit-testable with zero I/O. The commit builder is the cleanest next slice — pure string/object construction with no filesystem dependency (unlike a blob builder, which would need file bytes).

## Checks

- `bun test tools/bootstrap-razor/seed-test-repo.test.ts` → **35 pass / 0 fail** (6 new across `seedCommitMessage` + `buildSeedCommitRequest`).
- `bunx tsc --noEmit` → **0 errors** in `tools/bootstrap-razor/`.

## Scope discipline

- Isolated worktree off `origin/main`; claim acquired (`otto-cli` / B-0343); operator primary checkout untouched.
- One bounded step. No repo creation, no `gh` calls, no `--dry-run` output change (the existing dry-run already exercises the prior slices).

operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)