### PR TITLE
feat(B-0343): pure buildSeedRefUpdateRequest — commit SHA → git-refs API payload (bounded slice 8)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import {
   buildSeedCommitRequest,
+  buildSeedRefUpdateRequest,
   buildSeedTreeRequest,
   computeSeedTree,
   diffSeedTree,
@@ -332,5 +333,55 @@ describe("buildSeedCommitRequest", () => {
 
   test("carries the provenance message for the given file count", () => {
     expect(buildSeedCommitRequest("t", "p", 1).message).toBe(seedCommitMessage(1));
+  });
+});
+
+describe("buildSeedRefUpdateRequest", () => {
+  test("new ref → POST /git/refs with FULL refs/heads/<branch> body", () => {
+    expect(
+      buildSeedRefUpdateRequest("LFG", "seed-repo", "main", "deadbeef", false),
+    ).toEqual({
+      method: "POST",
+      path: "repos/LFG/seed-repo/git/refs",
+      body: { ref: "refs/heads/main", sha: "deadbeef" },
+    });
+  });
+
+  test("existing ref → PATCH with SHORT heads/<branch> suffix and force:false", () => {
+    expect(
+      buildSeedRefUpdateRequest("LFG", "seed-repo", "main", "deadbeef", true),
+    ).toEqual({
+      method: "PATCH",
+      path: "repos/LFG/seed-repo/git/refs/heads/main",
+      body: { sha: "deadbeef", force: false },
+    });
+  });
+
+  test("PATCH path uses SHORT heads/ form, never the double refs/heads/heads/ 404 trap", () => {
+    // The git/refs/ path already carries the refs/ prefix; the suffix must be the
+    // short `heads/<branch>` form. A `refs/heads/<branch>` suffix yields a 404.
+    const patch = buildSeedRefUpdateRequest("LFG", "r", "feat/x", "sha", true);
+    expect(patch.path).toBe("repos/LFG/r/git/refs/heads/feat/x");
+    expect(patch.path).not.toContain("refs/heads/heads/");
+  });
+
+  test("POST body uses FULL refs/heads/ form (short form yields a 422)", () => {
+    const post = buildSeedRefUpdateRequest("LFG", "r", "feat/x", "sha", false);
+    if (post.method !== "POST") throw new Error("expected POST for a new ref");
+    expect(post.body.ref).toBe("refs/heads/feat/x");
+  });
+
+  test("force is always false — seed only fast-forwards, never clobbers", () => {
+    const patch = buildSeedRefUpdateRequest("o", "r", "main", "s", true);
+    if (patch.method !== "PATCH") throw new Error("expected PATCH for an existing ref");
+    expect(patch.body.force).toBe(false);
+  });
+
+  test("commit SHA flows verbatim into both endpoint shapes", () => {
+    const sha = "aa218f56b14c9653891f9e74264a383fa43fefbd";
+    const created = buildSeedRefUpdateRequest("o", "r", "main", sha, false);
+    const updated = buildSeedRefUpdateRequest("o", "r", "main", sha, true);
+    expect(created.body.sha).toBe(sha);
+    expect(updated.body.sha).toBe(sha);
   });
 });

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -117,6 +117,34 @@ export interface GitCommitRequest {
   readonly parents: readonly string[];
 }
 
+/**
+ * The git-refs API call that points the seed branch at the new commit — the last
+ * git-data write step after `buildSeedCommitRequest`, named by that builder's doc
+ * comment ("→ `PATCH /git/refs/heads/<branch>` to fast-forward the ref"). GitHub
+ * splits this across two endpoints with DIFFERENT shapes (verified against
+ * docs.github.com/en/rest/git/refs, API version 2022-11-28):
+ *   - branch does NOT exist yet → `POST /repos/{owner}/{repo}/git/refs` with a body
+ *     naming the FULL ref `refs/heads/<branch>` plus the commit `sha`.
+ *   - branch already exists      → `PATCH /repos/{owner}/{repo}/git/refs/heads/<branch>`
+ *     with `{ sha, force }`. The `git/refs/` path already carries the `refs/` prefix,
+ *     so the path suffix is the SHORT `heads/<branch>` form, NOT `refs/heads/<branch>`.
+ * The two `path` values therefore encode the FULL-vs-SHORT distinction GitHub's two
+ * endpoints require; getting it wrong yields a 404 (PATCH `refs/heads/heads/...`) or a
+ * 422 (POST with a short ref). A discriminated union on `method` lets the network slice
+ * dispatch with no further branching: POST the create body, or PATCH the update body.
+ */
+export type GitRefUpdateRequest =
+  | {
+      readonly method: "POST";
+      readonly path: string;
+      readonly body: { readonly ref: string; readonly sha: string };
+    }
+  | {
+      readonly method: "PATCH";
+      readonly path: string;
+      readonly body: { readonly sha: string; readonly force: boolean };
+    };
+
 const MANIFEST_DISPLAY_PATH = "docs/bootstrap-razor/SEED-MANIFEST.md";
 const MANIFEST_PATH = fileURLToPath(new URL("../../docs/bootstrap-razor/SEED-MANIFEST.md", import.meta.url));
 // Repo root = two levels up from tools/bootstrap-razor/.
@@ -394,6 +422,38 @@ export function buildSeedCommitRequest(
     tree: treeSha,
     parents: parentSha === null ? [] : [parentSha],
   };
+}
+
+/**
+ * Pure builder for the seed's git-refs API call — the final write-chain link, taking
+ * the commit SHA `buildSeedCommitRequest`'s body produced once `POST /git/commits`
+ * returns it, and pointing the seed branch at it. `refExists` selects the endpoint:
+ * a brand-new repo whose seed branch does not exist yet CREATES it (`POST`); an
+ * existing branch is fast-forwarded (`PATCH`). This is the same fresh-vs-existing fork
+ * `buildSeedCommitRequest` makes on `parentSha === null` — kept pure so both paths are
+ * unit-tested before any repo mutation exists.
+ *
+ * `force` is always false: the seed only ever fast-forwards. A non-fast-forward means
+ * the branch diverged from the tree the diff was computed against, so the PATCH must
+ * fail loudly (HTTP 422) rather than clobber peer commits — the same non-coercion
+ * discipline as `git push --force-with-lease`. Pure: operates on its arguments only;
+ * no gh, no network, no filesystem. The network slice that follows is the whole flow
+ * end-to-end: `POST /git/blobs` (each create/update file) → `POST /git/trees`
+ * (`buildSeedTreeRequest` with `base_tree`) → `POST /git/commits`
+ * (`buildSeedCommitRequest`) → this request → done.
+ */
+export function buildSeedRefUpdateRequest(
+  owner: string,
+  repo: string,
+  branch: string,
+  commitSha: string,
+  refExists: boolean,
+): GitRefUpdateRequest {
+  const base = `repos/${owner}/${repo}/git/refs`;
+  if (!refExists) {
+    return { method: "POST", path: base, body: { ref: `refs/heads/${branch}`, sha: commitSha } };
+  }
+  return { method: "PATCH", path: `${base}/heads/${branch}`, body: { sha: commitSha, force: false } };
 }
 
 /**


### PR DESCRIPTION
## B-0343 bounded slice 8 — `buildSeedRefUpdateRequest`

The **final git-data write-chain link** for the bootstrap-razor seed flow, named explicitly by slice 7's (`buildSeedCommitRequest`) doc comment: *"→ `PATCH /git/refs/heads/<branch>` to fast-forward the ref."*

Takes the commit SHA `POST /git/commits` returns and points the seed branch at it. Pure: no `gh`, no network, no filesystem — one more unit-tested transformation before any repo mutation exists, consistent with the established one-pure-function-per-slice pattern (slices 5/6/7: PRs #5997/#5998/#5999).

### What it adds
- `GitRefUpdateRequest` discriminated union (`POST` create vs `PATCH` update).
- `buildSeedRefUpdateRequest(owner, repo, branch, commitSha, refExists)` builder.

### The two-endpoint subtlety (search-first, Otto-364)
Verified against [docs.github.com/en/rest/git/refs](https://docs.github.com/en/rest/git/refs) (API version 2022-11-28):

| Case | Endpoint | Body | Ref form |
|------|----------|------|----------|
| New branch (`refExists=false`) | `POST /repos/{o}/{r}/git/refs` | `{ ref, sha }` | **FULL** `refs/heads/<branch>` |
| Existing branch (`refExists=true`) | `PATCH /repos/{o}/{r}/git/refs/heads/<branch>` | `{ sha, force }` | **SHORT** `heads/<branch>` suffix (path already carries `refs/`) |

Getting the form wrong yields a 404 (`PATCH refs/heads/heads/...`) or a 422 (POST short ref) — both covered by tests. This mirrors slice 7's fresh-vs-existing fork (`parentSha === null`).

`force` is always `false`: the seed only fast-forwards. A non-fast-forward means the branch diverged from the tree the diff was computed against, so it fails loudly (422) rather than clobbering peer commits — same non-coercion discipline as `git push --force-with-lease`.

### Slice chain now complete (pure write side)
`parse → diff → buildTree → buildCommit → buildRef`. Future network slice = `POST /git/blobs` → `POST /git/trees` → `POST /git/commits` → this → done.

## Focused checks
- `bun test tools/bootstrap-razor/seed-test-repo.test.ts` → **41 pass, 0 fail** (35 → 41; +6 new tests covering both endpoint shapes, the FULL/SHORT ref forms, `force:false`, and SHA passthrough).
- `bun run typecheck` (`tsc --noEmit`, repo tsconfig) → **0 errors in `tools/bootstrap-razor/`**. (8 pre-existing errors remain, all in `agentic-organization/apps/workers/` — missing `@nats-io/*` packages from an unrelated foundation commit; not touched by this PR.)
- `bun tools/bootstrap-razor/seed-test-repo.ts --dry-run` → still emits the manifest seed plan with no side effects.
- Commit canary: `git ls-tree HEAD` = `HEAD~1` = 63 (tree intact, no collapse).

Scope: pure builder + tests only. No `gh`, no repo creation, no dry-run wiring (consistent with slice 7). LFG/AceHack-only authorization scope unchanged.

operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)