### PR TITLE
feat(B-0343): pure buildSeedBlobRequest — seed bytes → POST /git/blobs body (bounded slice 9)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  buildSeedBlobRequest,
   buildSeedCommitRequest,
   buildSeedRefUpdateRequest,
   buildSeedTreeRequest,
@@ -105,6 +106,40 @@ describe("gitBlobSha", () => {
     // "é" is 2 bytes in UTF-8; the header must read `blob 2\0`, not `blob 1\0`.
     // `printf 'é' | git hash-object --stdin` → this SHA.
     expect(gitBlobSha(Buffer.from("é", "utf8"))).toBe("4b04fff51468d8ab5201ab02b725dc477bc7cb45");
+  });
+});
+
+describe("buildSeedBlobRequest", () => {
+  // Canonical base64 values: `printf 'hello\n' | base64` → "aGVsbG8K";
+  // `printf 'é' | base64` → "w6k=". Hardcoding them pins the wire bytes the
+  // `POST /git/blobs` body carries.
+  test("empty content → empty base64 string", () => {
+    expect(buildSeedBlobRequest(new Uint8Array(0))).toEqual({ content: "", encoding: "base64" });
+  });
+
+  test("'hello\\n' matches base64 of its bytes", () => {
+    expect(buildSeedBlobRequest(Buffer.from("hello\n", "utf8"))).toEqual({
+      content: "aGVsbG8K",
+      encoding: "base64",
+    });
+  });
+
+  test("multi-byte UTF-8 content base64-encodes by raw bytes", () => {
+    // "é" is the 2 bytes C3 A9; base64 of those bytes is "w6k=".
+    expect(buildSeedBlobRequest(Buffer.from("é", "utf8")).content).toBe("w6k=");
+  });
+
+  test("non-UTF-8 binary bytes survive losslessly (why base64, not utf-8)", () => {
+    // 0xFF is not valid UTF-8; a `utf-8` upload would corrupt it. base64 round-trips.
+    const bytes = new Uint8Array([0x00, 0xff, 0x10]);
+    const { content, encoding } = buildSeedBlobRequest(bytes);
+    expect(encoding).toBe("base64");
+    expect(content).toBe("AP8Q");
+    expect(new Uint8Array(Buffer.from(content, "base64"))).toEqual(bytes);
+  });
+
+  test("encoding is always the base64 literal", () => {
+    expect(buildSeedBlobRequest(Buffer.from("x", "utf8")).encoding).toBe("base64");
   });
 });
 

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -84,6 +84,25 @@ interface SeedTreeDiff {
 }
 
 /**
+ * The `POST /repos/{owner}/{repo}/git/blobs` request body for one seed file — the
+ * FIRST git-data write step, run once per create/update file before the tree is
+ * assembled. `content` is the file's bytes base64-encoded; `encoding` is always
+ * `"base64"`. The blobs API also accepts `encoding: "utf-8"`, but seed files can be
+ * binary (or carry mixed/non-UTF-8 bytes), and a `utf-8` upload would corrupt any
+ * non-UTF-8 content — base64 is lossless for arbitrary bytes, so the seeder always
+ * uses it (verified against docs.github.com/en/rest/git/blobs, API version
+ * 2026-03-10: `content`/`encoding` body, `encoding` ∈ {`utf-8`, `base64`}, blobs up
+ * to 100 MB). GitHub returns this blob's SHA, which is byte-identical to the SHA
+ * `gitBlobSha` already predicts for the same bytes — so the seeding flow never has
+ * to round-trip to learn it: it uploads each blob, then submits `buildSeedTreeRequest`'s
+ * tree referencing those same SHAs.
+ */
+export interface GitBlobRequest {
+  readonly content: string;
+  readonly encoding: "base64";
+}
+
+/**
  * One entry in the `tree` array of GitHub's `POST /repos/{owner}/{repo}/git/trees`
  * request body. `mode` is always `100644` (a regular non-executable file blob) for
  * seed content; `type` is always `"blob"`; `sha` references a blob the seeding flow
@@ -354,6 +373,20 @@ export function parseGitTreeResponse(response: unknown): readonly SeedTreeEntry[
 }
 
 /**
+ * Pure builder for one seed file's `POST /git/blobs` body — the FIRST git-data write
+ * step, the mirror of `gitBlobSha` (which predicts the SHA the same bytes will get).
+ * Base64-encodes the raw bytes and tags `encoding: "base64"` so the upload is lossless
+ * for arbitrary (incl. binary) content. Uses the byte length implicitly via `Buffer`'s
+ * base64 codec, so multi-byte and non-UTF-8 content survive intact. Pure: operates on
+ * the given bytes only; no gh, no network, no filesystem. The network slice runs this
+ * once per create/update entry from `buildSeedTreeRequest`'s plan, collecting the
+ * returned SHAs (each equal to `gitBlobSha` of the same file), then submits the tree.
+ */
+export function buildSeedBlobRequest(content: Uint8Array): GitBlobRequest {
+  return { content: Buffer.from(content).toString("base64"), encoding: "base64" };
+}
+
+/**
  * Pure write-side bridge — the mirror of `parseGitTreeResponse`. Where the parser
  * turns the target repo's git tree INTO the diff's `existing` input, this turns the
  * diff's verdict INTO the `tree` array a `POST /git/trees` call submits to write the
@@ -494,6 +527,17 @@ function emitDryRun(manifest: SeedManifest, root: string): void {
   // already-seeded repo the network slice fetches the real tree, and an idempotent
   // diff collapses this to the empty array (no writes).
   const freshRepoPlan = buildSeedTreeRequest(diffSeedTree(tree, []));
+
+  // Step 1 of the git-data write chain: each create/update file is uploaded as a
+  // base64 blob via `POST /git/blobs` BEFORE the tree references its SHA. For a fresh
+  // repo that is every resolved file; an idempotent re-seed uploads nothing. Showing
+  // the per-blob base64 size makes the upload cost visible without performing it.
+  console.log(`POST /git/blobs uploads for a fresh repo (${freshRepoPlan.length} blobs, base64):`);
+  for (const { path } of freshRepoPlan) {
+    const blob = buildSeedBlobRequest(readFileSync(join(root, path)));
+    console.log(`  ${blob.encoding} ${blob.content.length}b  ${path}`);
+  }
+
   console.log(`POST /git/trees write plan for a fresh repo (${freshRepoPlan.length} entries):`);
   for (const { mode, type, sha, path } of freshRepoPlan) {
     console.log(`  ${mode} ${type} ${sha}  ${path}`);


### PR DESCRIPTION
## What

Bounded slice 9 of **B-0343** (test-repo seeding script). Adds the one pure builder still missing from the git-data write chain: the **first** step, `POST /repos/{owner}/{repo}/git/blobs`.

The write chain has four steps; the prior three already had pure builders (all merged):

| Step | API | Builder | Slice |
|------|-----|---------|-------|
| 1 | `POST /git/blobs` | **`buildSeedBlobRequest`** (this PR) | **9** |
| 2 | `POST /git/trees` | `buildSeedTreeRequest` | 6 (#5998) |
| 3 | `POST /git/commits` | `buildSeedCommitRequest` | 7 (#5999) |
| 4 | `PATCH/POST /git/refs` | `buildSeedRefUpdateRequest` | 8 (#6000) |

`buildSeedBlobRequest(content: Uint8Array): GitBlobRequest` base64-encodes the raw bytes and tags `encoding: "base64"`.

## Why base64, not utf-8

Seed files can be binary or carry non-UTF-8 bytes; a `utf-8` upload would corrupt them. base64 is lossless for arbitrary bytes — the universal-safe choice for a generic seeder. The returned blob SHA (from GitHub) is byte-identical to `gitBlobSha`'s prediction for the same bytes, so the network slice never round-trips to learn it: upload each blob, then submit `buildSeedTreeRequest`'s tree referencing those same SHAs.

## API contract verification (Otto-364 search-first)

Verified against [docs.github.com/en/rest/git/blobs](https://docs.github.com/en/rest/git/blobs), API version `2026-03-10`: body is `{content, encoding}`, `encoding ∈ {utf-8, base64}`, blobs up to 100 MB. Response always returns base64-encoded content.

## Scope discipline

Pure: no `gh`, no network, no filesystem — operates on the given bytes only. No repo creation/mutation. Wired into `--dry-run` so it's exercised in the runtime path (shows per-file base64 upload size for a fresh repo, preceding the existing tree write-plan), not only in tests.

## Focused checks

- **`bun test tools/bootstrap-razor/seed-test-repo.test.ts`** → **46 pass / 0 fail** (5 new cases: empty, `hello\n`, multi-byte UTF-8, non-UTF-8 binary round-trip, encoding literal).
- **`bun run typecheck`** (`tsc --noEmit`) → **0 errors in `tools/bootstrap-razor/`** (only pre-existing unrelated errors in `agentic-organization/apps/workers/` for missing `@nats-io/*` deps).
- **`bun tools/bootstrap-razor/seed-test-repo.ts --dry-run`** → exits 0; new `POST /git/blobs uploads (39 blobs, base64)` section renders.
- **`bunx eslint tools/bootstrap-razor/`**: this slice adds 2 `restrict-template-expressions` findings (lines 535/538) — the **identical `${...length}` `console.log` idiom** already present on lines 263/427/510/518/541 and merged through CI in slices 5–8. `lint:typescript` is advisory-not-blocking for this path (precedent: 4 prior slices merged with the same findings). Kept file-consistent rather than wrapping only the two new diagnostic lines in `String()`, which would introduce a style inconsistency.

## Lineage

Parent: B-0193 (bootstrap razor + 23-hour recreation test). Composes_with: B-0193, B-0344.

operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)