### PR TITLE
feat(B-0343): pure buildCreateRepoRequest — POST /orgs/{org}/repos with LFG/AceHack authz guard (step 0)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  buildCreateRepoRequest,
   buildSeedBlobRequest,
   buildSeedCommitRequest,
   buildSeedRefUpdateRequest,
@@ -106,6 +107,63 @@ describe("gitBlobSha", () => {
     // "é" is 2 bytes in UTF-8; the header must read `blob 2\0`, not `blob 1\0`.
     // `printf 'é' | git hash-object --stdin` → this SHA.
     expect(gitBlobSha(Buffer.from("é", "utf8"))).toBe("4b04fff51468d8ab5201ab02b725dc477bc7cb45");
+  });
+});
+
+describe("buildCreateRepoRequest", () => {
+  test("authorized org → POST /orgs/<org>/repos with the repo name", () => {
+    expect(buildCreateRepoRequest("Lucent-Financial-Group", "zeta-recreation-experiment")).toEqual({
+      path: "orgs/Lucent-Financial-Group/repos",
+      body: {
+        name: "zeta-recreation-experiment",
+        private: true,
+        auto_init: false,
+        description:
+          "B-0193 bootstrap-razor recreation test repo (seeded by tools/bootstrap-razor/seed-test-repo.ts)",
+      },
+    });
+  });
+
+  test("AceHack is also authorized", () => {
+    const req = buildCreateRepoRequest("AceHack", "r");
+    if (typeof req === "string") throw new Error(`expected a request, got refusal: ${req}`);
+    expect(req.path).toBe("orgs/AceHack/repos");
+  });
+
+  test("ServiceTitan is refused (authorization scope: LFG or AceHack only)", () => {
+    const result = buildCreateRepoRequest("ServiceTitan", "r");
+    expect(typeof result).toBe("string");
+    expect(result).toContain("ServiceTitan");
+    expect(result).toContain("unauthorized");
+  });
+
+  test("any other org is refused (default-deny, not an allowlist gap)", () => {
+    // A look-alike org that is NOT in AUTHORIZED_ORGS must be refused too — the guard
+    // is an allowlist, so the refusal does not depend on naming ServiceTitan specifically.
+    expect(typeof buildCreateRepoRequest("Lucent-Financial", "r")).toBe("string");
+    expect(typeof buildCreateRepoRequest("acehack", "r")).toBe("string"); // case-sensitive slug
+  });
+
+  test("auto_init is always false (keeps the repo empty for the seed's root commit)", () => {
+    const req = buildCreateRepoRequest("AceHack", "r");
+    if (typeof req === "string") throw new Error(req);
+    // false here is load-bearing: an auto-initialized README would break
+    // buildSeedCommitRequest(parentSha=null)→parents:[] and show as extraneous.
+    expect(req.body.auto_init).toBe(false);
+  });
+
+  test("private defaults to true but is overridable", () => {
+    const def = buildCreateRepoRequest("AceHack", "r");
+    const pub = buildCreateRepoRequest("AceHack", "r", { private: false });
+    if (typeof def === "string" || typeof pub === "string") throw new Error("expected requests");
+    expect(def.body.private).toBe(true);
+    expect(pub.body.private).toBe(false);
+  });
+
+  test("description is overridable", () => {
+    const req = buildCreateRepoRequest("AceHack", "r", { description: "custom" });
+    if (typeof req === "string") throw new Error(req);
+    expect(req.body.description).toBe("custom");
   });
 });
 

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -84,6 +84,34 @@ interface SeedTreeDiff {
 }
 
 /**
+ * The `POST /orgs/{org}/repos` request body for the recreation-experiment repo —
+ * STEP 0, run once before any git-data write (the create that the blob → tree →
+ * commit → ref chain below seeds into). `name` is the new repo's name; `private`
+ * is true by default because this is a throwaway experiment repo, not a published
+ * artifact (caller may override); `description` carries provenance back to the
+ * seeding tool. `auto_init` is always FALSE and that is LOAD-BEARING: `auto_init:
+ * true` makes GitHub write an initial README commit, which would (a) break the
+ * seed's root-commit path (`buildSeedCommitRequest(parentSha=null)` → `parents: []`
+ * only works on a repo with no commits) and (b) report that README as `extraneous`
+ * in every idempotency diff. Keeping the repo empty lets the seed flow author the
+ * root commit and create the branch fresh (`buildSeedRefUpdateRequest(refExists=false)`
+ * → POST). Verified against docs.github.com/en/rest/repos/repos, API version
+ * 2026-03-10: `POST /orgs/{org}/repos`, `name` required, `private`/`auto_init`/
+ * `description` optional. GitHub's create-repo API accepts many more optional fields
+ * (`homepage`, `has_issues`, `gitignore_template`, `license_template`, …) — the seed
+ * sets none, so they are intentionally unrepresented.
+ */
+export interface GitCreateRepoRequest {
+  readonly path: string;
+  readonly body: {
+    readonly name: string;
+    readonly private: boolean;
+    readonly auto_init: false;
+    readonly description: string;
+  };
+}
+
+/**
  * The `POST /repos/{owner}/{repo}/git/blobs` request body for one seed file — the
  * FIRST git-data write step, run once per create/update file before the tree is
  * assembled. `content` is the file's bytes base64-encoded; `encoding` is always
@@ -373,6 +401,57 @@ export function parseGitTreeResponse(response: unknown): readonly SeedTreeEntry[
 }
 
 /**
+ * The two GitHub orgs the seeder is authorized to create the recreation-experiment
+ * repo in (Aaron 2026-05-05, recorded in this row's "Authorization scope": LFG or
+ * AceHack only — NOT ServiceTitan). Names are the literal GitHub org slugs. This is
+ * the single source of truth for `buildCreateRepoRequest`'s scope guard; widening
+ * the authorization means editing this list (and re-confirming the org is one the
+ * operator authorized), never bypassing the guard at a call site.
+ */
+const AUTHORIZED_ORGS = ["Lucent-Financial-Group", "AceHack"] as const;
+
+/**
+ * Pure builder for the experiment repo's `POST /orgs/{org}/repos` body — STEP 0 of
+ * the whole seeding flow, the create that precedes the blob → tree → commit → ref
+ * write chain. The org is checked against `AUTHORIZED_ORGS` FIRST: an unauthorized
+ * org (anything but LFG / AceHack — most importantly ServiceTitan, named off-limits
+ * in this row's authorization scope) returns an error string rather than a request,
+ * so the guard is enforced at the builder, not left to a call site to remember. The
+ * `T | string` return is the same convention as `readManifest` / `parseGitTreeResponse`:
+ * a `string` result is the refusal reason, a `GitCreateRepoRequest` is the green light.
+ *
+ * `options.private` defaults to true (throwaway experiment repo, not a published
+ * artifact); `options.description` defaults to a provenance line naming the seeding
+ * tool. `auto_init` is hard-wired false — see `GitCreateRepoRequest` for why an
+ * auto-initialized README would break the seed's root-commit + fresh-branch paths.
+ * Pure: operates on its arguments only; no gh, no network, no filesystem. The network
+ * slice that follows is: this request (only if it is a request, not a refusal string)
+ * → `POST /git/blobs` per create file → `POST /git/trees` → `POST /git/commits` →
+ * `POST /git/refs` (the new repo is empty, so the seed always takes the create-branch
+ * `refExists=false` path).
+ */
+export function buildCreateRepoRequest(
+  org: string,
+  repo: string,
+  options?: { readonly private?: boolean; readonly description?: string },
+): GitCreateRepoRequest | string {
+  if (!(AUTHORIZED_ORGS as readonly string[]).includes(org)) {
+    return `unauthorized org "${org}" — seeding is scoped to ${AUTHORIZED_ORGS.join(" or ")} only (NOT ServiceTitan, per B-0343 authorization scope)`;
+  }
+  return {
+    path: `orgs/${org}/repos`,
+    body: {
+      name: repo,
+      private: options?.private ?? true,
+      auto_init: false,
+      description:
+        options?.description ??
+        "B-0193 bootstrap-razor recreation test repo (seeded by tools/bootstrap-razor/seed-test-repo.ts)",
+    },
+  };
+}
+
+/**
  * Pure builder for one seed file's `POST /git/blobs` body — the FIRST git-data write
  * step, the mirror of `gitBlobSha` (which predicts the SHA the same bytes will get).
  * Base64-encodes the raw bytes and tags `encoding: "base64"` so the upload is lossless
@@ -544,7 +623,29 @@ function emitDryRun(manifest: SeedManifest, root: string): void {
   }
 
   console.log("Provenance commit would link to B-0193 / B-0343.");
-  console.log("gh create + real seeding + commit: follow-up slice.");
+
+  // Step 0 of the flow: create the empty experiment repo (AC 1). Shown here for an
+  // EXAMPLE authorized org/repo — `--dry-run` performs no creation (AC 4). The scope
+  // guard refuses any org but LFG / AceHack, so the off-limits ServiceTitan case is
+  // demonstrated alongside the authorized one to make the authorization scope visible.
+  const exampleOrg = AUTHORIZED_ORGS[0];
+  const createReq = buildCreateRepoRequest(exampleOrg, "zeta-recreation-experiment");
+  if (typeof createReq === "string") {
+    console.log(`POST /orgs create plan: REFUSED — ${createReq}`);
+  } else {
+    console.log(`POST /${createReq.path} create plan (example, no creation performed):`);
+    console.log(
+      `  name=${createReq.body.name} private=${createReq.body.private} auto_init=${createReq.body.auto_init}`,
+    );
+  }
+  const refused = buildCreateRepoRequest("ServiceTitan", "zeta-recreation-experiment");
+  console.log(
+    `Authorization scope guard (ServiceTitan): ${
+      typeof refused === "string" ? `REFUSED — ${refused}` : "ALLOWED (BUG — should be refused)"
+    }`,
+  );
+
+  console.log("gh network integration (real create + seed + commit): follow-up slice.");
 }
 
 export function main(argv: readonly string[]): ExitCode {

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -402,8 +402,9 @@ export function parseGitTreeResponse(response: unknown): readonly SeedTreeEntry[
 
 /**
  * The two GitHub orgs the seeder is authorized to create the recreation-experiment
- * repo in (Aaron 2026-05-05, recorded in this row's "Authorization scope": LFG or
- * AceHack only — NOT ServiceTitan). Names are the literal GitHub org slugs. This is
+ * repo in (operator authorization 2026-05-05, recorded in this row's "Authorization
+ * scope": LFG or AceHack only — NOT ServiceTitan). Names are the literal GitHub org
+ * slugs. This is
  * the single source of truth for `buildCreateRepoRequest`'s scope guard; widening
  * the authorization means editing this list (and re-confirming the org is one the
  * operator authorized), never bypassing the guard at a call site.


### PR DESCRIPTION
## What

Adds `buildCreateRepoRequest` — the **one missing link** in B-0343's seed write chain. The blob → tree → commit → ref builders all shipped (slices 6–9); the logically-first step, **repo CREATE** (AC 1 step 1, "Creates a new repo in LFG or AceHack org"), was the last gap. This slice fills it as a pure builder in the same family as the rest.

## Why this is the smallest safe slice

- **Pure**: no network, no `gh`, no filesystem — `(org, repo, options?) → GitCreateRepoRequest | string`.
- **Additive**: one new export + one new interface + 7 new test cases + dry-run demonstration. No existing behavior changed.
- **Carries the load-bearing authz guard** the row names explicitly: `org ∈ {Lucent-Financial-Group, AceHack}`; any other org (esp. **ServiceTitan**, named off-limits per Aaron 2026-05-05) returns a refusal string. Allowlist / default-deny — refusal does not depend on naming ServiceTitan specifically.

## Design notes

- `T | string` return matches `readManifest` / `parseGitTreeResponse`: a string is the refusal reason, a request is the green light. The guard lives at the builder, not at a call site.
- **`auto_init: false` is load-bearing** — an auto-initialized README would break the seed's root-commit path (`buildSeedCommitRequest(parentSha=null)` → `parents: []`) and report as `extraneous` in every idempotency diff. Documented inline.
- `private` defaults true (throwaway experiment repo); overridable.
- `AUTHORIZED_ORGS` const = single source of truth for the scope guard.

## API currency (Otto-364 search-first)

Endpoint + body verified current against [docs.github.com/en/rest/repos/repos](https://docs.github.com/en/rest/repos/repos), `X-GitHub-Api-Version: 2026-03-10` — matches the file's existing doc comments.

## Focused checks

| Check | Outcome |
|---|---|
| `bun test tools/bootstrap-razor/seed-test-repo.test.ts` | **53 pass / 0 fail** (73 expect calls; +7 new cases) |
| `--dry-run` output | renders step-0 create plan + demonstrates ServiceTitan refusal (AC 1 step 1 + AC 4 visible) |
| `tsc --noEmit` | clean for this file (only pre-existing `agentic-organization/` module-resolution errors remain) |
| commit canary | HEAD tree 63 = parent tree 63 (no corruption; 2 intended files only) |

## Scope

Bounded to the pure builder + tests + dry-run wiring. The real `gh` network integration (create → seed → commit → push) remains a follow-up slice — the dry-run note now reads "gh network integration (real create + seed + commit): follow-up slice."

🤖 Generated with [Claude Code](https://claude.com/claude-code)