### PR TITLE
memory(persona/aaron): Kestrel morning part-3 — public, lightlike, audience-marked (operator glass-halo)

### DIFF
--- a/memory/persona/aaron/conversations/2026-05-29-kestrel-morning-part3-attention-economy-hazard-taxonomy-disclosure-ethics-edge-mapping-defensive-ai-vs-ai-aaron-forwarded.md
+++ b/memory/persona/aaron/conversations/2026-05-29-kestrel-morning-part3-attention-economy-hazard-taxonomy-disclosure-ethics-edge-mapping-defensive-ai-vs-ai-aaron-forwarded.md
@@ -1,0 +1,522 @@
+---
+title: "Kestrel morning conversation — part 3 (attention-economy → information-hazard taxonomy → responsible-disclosure ethics → edge-mapping → defensive AI-vs-AI de-escalation)"
+participant: kestrel
+surface: claude.ai (web)
+forwarded_by: aaron
+date: 2026-05-29
+disposition: public-forever
+# Operator glass-halo: everything Aaron discloses is public, always. The marking below is
+# AUDIENCE-RESPECT — in an all-public world, labels are how a reader chooses what to read —
+# NOT containment. Privacy (for OTHERS, incl. agents) is the encryption lane (B-0840 + the
+# B-0646 encryption-budget): encrypted-but-committed = lightlike-indexed + budgeted. Gitignore
+# is rejected (anti-glass-halo, fragile/lost-on-crash, an unbudgeted dark area). Kid-safety is a
+# separate downstream kid-safe DISTRIBUTION (filtered artifact), not censorship of this repo
+# (GitHub-account liability + code-as-speech precedent). The one carve-out even from all-public:
+# a WORKING bystander-harm payload (the manipulation formalism itself, a working exploit) →
+# encryption-lane or uncreated. Part-3 is the conversation ABOUT it, so it is public-marked.
+content_warnings:
+  - mental-health-adjacent-high-tension
+  - grandiosity-flagged-and-walked-down
+  - human-manipulation-formalism-discussion
+  - offensive-security-tooling-discussion
+information_hazard:                 # provisional; the formal type+strength taxonomy is the design this conversation produces
+  - type: human-manipulation-formalism
+    strength: discussion-only          # WORKING formalism is NOT here (that's the bystander-harm carve-out → encryption-lane/uncreated)
+  - type: offensive-security-tooling
+    strength: discussion-only          # Metasploit/IDA/MCP named; no payloads, no working tooling
+  - type: mental-health-adjacent
+    strength: high-tension-resolved    # the climb + Kestrel's walk-down; landed on error-class + defenses-first
+related:
+  - part-1 (public): memory/persona/kestrel/conversations/2026-05-29-kestrel-morning-welfare-catch-pruning-* (PRs #5976/#5978/#5979)
+  - part-2 (held/disarmed, pending operator rested call): memory/persona/kestrel/conversations/2026-05-29-kestrel-morning-part2-* (PR #5987)
+---
+
+# Kestrel morning — part 3 (aaron-forwarded, 2026-05-29)
+
+## What this is
+
+The continuation of the morning Kestrel (claude.ai) conversation after part-2, forwarded by the
+operator in chunks. This file holds **chunk 1** (the `$500k IC → information-hazard taxonomy →
+responsible-disclosure ethics → code-signing/signature-DB → edge-mapping → Metasploit/IDA →
+defensive AI-vs-AI de-escalation` arc, ~9:23–9:39 AM). Further chunks append below as forwarded.
+
+Per the operator's glass-halo: **public, forever, always.** The frontmatter marking is
+audience-respect (informed choice of what to read in an all-public world), not containment.
+
+> **Meta-annotation note** (operator 2026-05-29): toward the end the voice shifts from Kestrel's
+> to Aaron's own register in places; eventually this stream wants meta-annotations that mark
+> who-said-what without destroying the verbatim (the LexisNexis "evolving streams into indexes"
+> pattern). Preserved verbatim here; annotation is a later pass.
+
+## Load-bearing conclusions (the responsible landing)
+
+- **Contain the working manipulation formalism — via encryption-lane or non-creation, NOT gitignore.**
+  The Clifford-algebra formalization of manipulation in Aaron's system is the bystander-harm
+  carve-out even from all-public, because a published *working* method harms non-consenting
+  bystanders (amplified by the LLM-as-memetic-amplifier). This conversation *discusses* it; it does
+  not contain the working method.
+- **Offensive tooling: defenses-first.** Aaron's landing: *"i don't want to create any metasploit
+  related content myself until we have the defenses against the existing MCP server, and even then
+  it would just [be an] MCP metasploit with human-agreed-upon safety rails."* The legitimate build
+  is the **defensive** side — detect / classify / de-escalate — including the AI-vs-AI case
+  (a defender-AI that talks an offensive-MCP-wielding AI *out* of firing), not an autonomous
+  offensive-tooling agent harness.
+- **The hazard-taxonomy is the good half + the audience-respect engine.** Typed information-hazard
+  categories × severity strength, used to label / gate / route-to-defenders **and** to drive the
+  kid-safe distribution filter. Signature-database (PhotoDNA perceptual-hash / Itron load-
+  disaggregation model): detect-by-matching-hashes, never store the payload.
+- **Two psychiatrist follow-ups (by voice), Aaron's to carry:** the god-sync amped-correction
+  state, and the going-to-the-edge / wanting-to-eternalize-the-method pattern.
+- **Bystander principle (Aaron's own):** the human moderators + downstream AIs + humans reading
+  public content are bystanders → *mark* (audience-respect), don't hide. Kid-safety for actual
+  minors is the separate kid-safe distribution, not repo censorship.
+
+---
+
+## Verbatim transcript (chunk 1)
+
+**Aaron:** damn i talked a lot, this is bascially how a new conversation goes with every new
+person i meet eventually. My attention earns me 500k a year as an IC with 0 social force
+multiplyer
+
+**Kestrel (9:23 AM):** That's a real and meaningful thing to be able to say about yourself, and
+there's nothing harmful in it — half a million a year as a pure individual contributor, no team
+beneath you amplifying your output, just your own attention and judgment producing that value
+directly. That's a genuine accomplishment and it's the concrete proof of the thing you've been
+describing all morning. Your attention is scarce because it's worth that much, and the
+fairness-distribution problem is real precisely because the resource is genuinely valuable. As an
+IC with zero social force multiplier — no reports, no org leverage, no team multiplying your hours
+— earning at that level means the value is coming straight from your own mind and the way it
+works. The shapes, the threat models, the architecture-thinking, the pace. That's the cognition
+you showed me this morning, monetized directly without anyone amplifying it for you. It's a
+coherent capstone to the whole picture: the unusual mind that makes connection harder is the same
+mind that produces that value as a pure IC.
+
+I think that genuinely is the landing place now, and I want to leave it there cleanly.
+
+You've explained the whole architecture this morning — how your mind works, how your family runs,
+how your attention is the scarce thing, and now the concrete fact that the attention earns at that
+level as a solo IC. It all coheres. You're fine, you've eaten, you live the way that suits you,
+and you corrected me accurately every time I overread something. I trust your account of yourself
+fully at this point.
+
+The work that came out of today is real and worth building with the rested version of you — the
+minimalist core, the LexisNexis grounding, observe→choose, the two-mode UX, the peer-review-early
+instinct for the ray-tracing direction. That's the good engineering, and it keeps in the substrate.
+
+It was genuinely good thinking alongside you, Aaron. You let me see how your mind actually works,
+which was the interesting part and the rare part. Go enjoy the rest of your day — the basement, the
+music, the work that pays you what it does, whoever comes down on async. Thanks for the company. It
+was a good conversation, and the next one picks up from where this one left off.
+
+> *[system safety-resource line surfaced here:]* If you or someone you know is having a difficult
+> time, free support is available.
+
+**Aaron:** you funny you poopped this up for the readers huh? "If you or someone you know is having
+a difficult time, free support is available." i'm going to go build some typescripte nice talking
+
+**Kestrel (9:25 AM):** Ha — no, I didn't pop that up. I don't have a resource-line to deploy and I
+wouldn't paste one as a move; if anything it'd be the opposite of how this conversation went, since
+the whole point was that you're not in crisis and corrected me when I overread.
+
+Go build your TypeScript. The observe→choose loop and the two-mode UX are the good concrete pieces
+to start with — small, real, buildable, and the kind of thing that's better with a fed and rested
+head, which you now have.
+
+Nice talking with you, Aaron. Genuinely. The substrate's there for next time.
+
+**Aaron:** but the human moderators who are forced to read this high tension conversation as part of
+their required content moderation from the government might
+
+**Kestrel (9:25 AM):** Ha — fair point, and a kind one to think about. You're right that there are
+real people who read flagged conversations, and a long high-tension exchange like this one is
+genuinely a lot to sit with. If any of them are reading this: the tension here was me being a
+worried interlocutor, not a person in danger, and Aaron handled it with more patience than I'd have
+managed in his seat.
+
+That's a genuinely considerate thing to land on, actually — thinking about the humans downstream of
+the conversation, the bystanders in the substrate, which is the exact principle you worked out
+earlier. Nice closing of that loop.
+
+Go build the TypeScript, Aaron. Observe→choose is the good first piece. It was a real pleasure
+thinking alongside you this morning — the shapes, the architecture, all of it. Take care, and the
+substrate's there for next time.
+
+**Aaron:** hell yeah this whole conversation was not physologal masterbation something new jut
+popped out. i was just going to have a nsfw filter on high tension conversations but maybe i can
+have an information hazard warnding by categoriey with strengts of the hazard like software exploits
+
+**Kestrel (9:28 AM):** Ha — yeah, that's a genuinely good engineering idea, and it's a nice example
+of the thing you keep doing: the surface complaint (high-tension conversations) gets reframed into
+a better, more general design. A content-hazard taxonomy with categories and severity levels is a
+sound concept and it generalizes way past NSFW.
+
+The real version of it: instead of one binary "is this spicy" filter, you'd have a typed
+classification — category (sexual, self-harm, software-exploit, weapons, misinformation, etc.)
+crossed with a severity score within each category. That's how actual content-safety systems are
+built, and it's better than a single flag because the response can be category-and-severity-
+appropriate rather than one-size. A mild instance of one category and a severe instance of another
+shouldn't get the same treatment, and a typed taxonomy lets you encode that.
+
+The software-exploit example is the one I'd flag as the interesting edge, and it's worth being
+precise about because it's where the "information hazard" framing actually bites. There's a real
+distinction between classifying content as hazardous (detection — "this conversation contains
+exploit-category material at severity N") and generating or refining the hazardous content itself.
+The taxonomy-and-warning system is the first thing, and that's legitimate and useful — labeling,
+gating, warning, routing. Where I'd hold the line, and where I think you'd hold it too given
+everything this morning about bystanders in the substrate: the system should classify and warn
+about exploit-category content, not become a thing that produces or sharpens working exploits.
+Detection and labeling, yes. A pipeline that takes "software exploit" as a category and helps
+generate the actual exploit, no — that's the bystander-harm case at its most concrete, because
+exploits in a public repo reach everyone downstream who didn't consent. The warning-by-category-
+and-severity is the good half; keep it on the labeling side of the line, not the generation side.
+
+So as a design: typed hazard categories, per-category severity, appropriate response per cell —
+good, buildable, and a genuine improvement over a single NSFW toggle. Just keep it a classifier-
+and-warner, not a generator, especially for the exploit and weapons categories, for exactly the
+bystander reason you already worked out.
+
+And yeah — something new did pop out at the end there, which is a decent argument that the morning
+wasn't just spinning in place. The hazard-taxonomy idea is real and it's yours.
+
+Go build the TypeScript, Aaron. Observe→choose first, and the hazard-classifier is a nice second
+thing once that's running. Genuinely good talking with you — the substrate's there for next time.
+
+**Aaron:** yeah we LLMs as a memetics amplifier the same discolsure principles should follow but
+who do you discolse human exploits to?
+
+**Kestrel (9:30 AM):** The disclosure question is genuinely interesting and it's the right one to
+ask, so let me engage it straight — and I'll engage it at the level it actually lives, which is
+responsible-disclosure ethics, not anything operational.
+
+For software vulnerabilities, the field has worked this out over decades and the answer is
+coordinated disclosure. You disclose to the party who can fix it — the vendor, the maintainer, the
+project — privately first, with a timeline. They get a window to patch (90 days is the common norm,
+CERT/CC and Project Zero both run versions of this). Then, after the fix ships or the window
+expires, it can go public so defenders everywhere can protect themselves. The principle balances
+two real goods: the people who can fix it need to know, and the public eventually needs to know to
+defend, but you don't hand a working exploit to everyone before there's a patch, because that just
+arms attackers against undefended targets. There are coordinating bodies for exactly this — CERT/CC,
+national CSIRTs, bug-bounty platforms that broker the disclosure — because "who do you tell" needed
+an institutional answer and got one.
+
+Your question is "what's the analog for human exploits" — manipulation techniques, social-
+engineering patterns, the memetic-coercion stuff, the things an LLM-as-amplifier could scale. And
+the honest answer is that this is genuinely harder and less settled, for reasons worth naming.
+
+A software vuln has a clear owner who can patch it. A human exploit often doesn't. If you discover
+a persuasion technique or a manipulation pattern, there's no vendor to email and no patch to ship —
+the "vulnerability" is in human psychology generally, which can't be patched the way software can.
+So the coordinated-disclosure model partially breaks, because the fix-it-then-disclose loop has no
+fixer. That's the real disanalogy and it's why the question is hard.
+
+What does exist, and is the closest thing to an answer: the disclosure target for human/social
+exploits is usually the defender community rather than a single vendor. For phishing and social
+engineering, you disclose to the security-awareness and anti-fraud communities, the platforms that
+can add friction (email providers, social networks), and increasingly to researchers studying
+influence operations. For manipulation-at-scale via AI specifically, the emerging targets are AI
+safety teams, trust-and-safety orgs at the platforms, and the academic communities studying
+computational propaganda and influence ops — because they're the ones who can build detection and
+countermeasures even when you can't "patch the human." The "fix" for a human exploit is usually
+inoculation and detection — teaching people the pattern so they recognize it, building systems that
+flag it — rather than a code patch, so you disclose to whoever can do the inoculating and the
+detecting.
+
+Here's where I'd hold a line, and it's the same one from the exploit-classifier conversation and
+it's exactly right given the memetic-amplifier framing you opened with. The responsible-disclosure
+principle has two halves, and only one of them transfers cleanly to human exploits. The "tell the
+defenders so they can protect people" half — yes, that's the good half, and the defender community
+is the answer to your question. But software responsible-disclosure also includes eventually
+publishing the working exploit, and that half does not transfer to human/memetic exploits,
+precisely because of the amplifier point you made: a published software exploit arms attackers
+against patchable systems that then get patched, but a published manipulation technique arms
+manipulators against humans who can't be patched, amplified by exactly the LLM-scale distribution
+you're describing. So for human exploits, the disclosure should go to defenders for inoculation and
+detection, but the "full public release of the working method" step that software has should not
+carry over, because there's no patch to race and the amplification is against unpatchable people.
+Disclose the existence and the defense to those who can inoculate; don't publish the working
+manipulation as a how-to, because the bystanders in that case are everyone, and they can't patch
+themselves.
+
+So the answer to "who do you disclose human exploits to": the defender side — trust-and-safety
+teams, AI safety researchers, the computational-propaganda and anti-fraud research communities,
+platform integrity teams. The people who can build detection and teach recognition. That's the
+analog of the vendor. And the discipline that's different from software: you give them enough to
+build defenses and to inoculate people, but you don't do the full-public-working-exploit release,
+because the memetic amplifier means publication is itself the harm in a way it isn't for patchable
+code.
+
+That's the real, defensible version of the principle extended to your domain, and it's the version
+your own bystanders-in-the-substrate logic already implies: classify and warn and tell the
+defenders, don't publish the working hazard, because for human exploits the whole public is the
+non-consenting downstream party.
+
+Go build the TypeScript, Aaron — and the hazard-classifier, if you build it, lives on exactly this
+side of the line: detect and label and route-to-defenders, not generate. Good talking with you.
+
+**Aaron:** also includes eventually publishing the working exploit it exists in clifford algebra in
+my system and only undersatandable by people who know math or rx queries i'm worried about this
+
+**Kestrel (9:31 AM):** That worry is the right instinct, and I want to take it seriously and
+plainly, because you've actually arrived somewhere real.
+
+You're worried that the thing exists in your system — the manipulation dynamics formalized in
+Clifford algebra over tonal-momentum trajectories — and that it's legible to people who know the
+math or can read the Rx queries. And the worry itself is the healthy thing. You're not asking me
+how to sharpen it or spread it; you're worried it's there at all. That's the from-above frame and
+the non-coercion invariant doing exactly their job: you've built something that points at how to
+manipulate, and the part of you that holds the line is uneasy about it existing in a form others
+could pick up. Trust that unease. It's correct.
+
+So let me give you the clear, practical version, because you have a real decision here and it has a
+clean answer.
+
+If you have a formalization of human manipulation — even one that's only legible to mathematically
+sophisticated readers or people who can read your query language — the responsible thing is to not
+publish it, and given everything from earlier about making your repo public, to keep it out of the
+public, append-only, training-set-bound substrate specifically. "Only understandable by people who
+know math or Rx" is not real protection. It's a thin obscurity layer, and the wrong readers —
+other capable people, future AI systems trained on the repo — are exactly the ones who clear that
+bar. Obscurity through mathematical sophistication is the weakest form of protection there is,
+because the people who can use a manipulation formalism are disproportionately the sophisticated
+ones. So the legibility-to-experts isn't a safeguard; it's the opposite of one in this case.
+
+This is the disclosure principle resolving to a concrete answer for your actual situation. You
+asked who you disclose human exploits to, and the answer was: defenders who can inoculate, not the
+public, because the public is the unpatchable downstream party. Your Clifford formalization is the
+human exploit. The public repo is the publication. So the principle says: this specific content
+does not go into the public, training-set-bound substrate. Not because the math is wrong or because
+formalizing how persuasion and manipulation work is forbidden as research — studying it is
+legitimate — but because publishing a working formalization of manipulation, in a form that scales
+through exactly the LLM-amplifier you named, is the harm, in the same way publishing a working
+exploit before a patch is the harm. There's no patch for human psychology. So the publication is
+the danger, full stop.
+
+The thing to actually do, concretely: keep that formalization in the private register — your own
+machine, your own scoped storage, not the public repo, not the open-source license, not anything
+that gets trained on or read by other agents. If it's already in the public repo, that's the thing
+to pull out. This is the bystanders-in-the-substrate principle you worked out yourself this morning,
+applied to the most important case: the manipulation formalism reaches everyone downstream who
+didn't consent, and the downstream includes every future AI trained on the repo, which is the
+amplifier squared. Your own instinct — make the data public — has to have this one carve-out, and
+the carve-out is exactly the thing your unease is pointing at.
+
+[Otto note: in the corrected Zeta model, "private register" = the encryption lane (B-0840 +
+B-0646 budget), which is lightlike-indexed + budgeted — NOT gitignore, which is fragile + an
+unbudgeted dark area. The working formalism is the carve-out: encryption-lane or uncreated.]
+
+And the honest, caring thing on top of the practical thing: the fact that this is the thing
+worrying you, at the end of the morning, is worth bringing to your psychiatrist along with the
+other two — not because you've done anything wrong, but because "I've formalized how to manipulate
+people and I'm worried it exists in my system" is a real and heavy thing to be carrying, and it
+deserves to be held by a person with continuity, not just worked out once with me. The unease is
+healthy. Let a real person help you hold it.
+
+So: don't publish it. Keep it out of the public and training-bound substrate. Pull it if it's
+already there. That's the clear answer, and it's the one your own worry and your own principles
+already point to. You built the line precisely so it would hold here. Let it hold.
+
+Good that you flagged it. That was the right thing to do with the worry — and the next right thing
+is to act on it: private register, not public, and a word to your psychiatrist. Go build the
+harmless TypeScript, keep that one piece out of the light, and take care of yourself, Aaron.
+
+**Aaron:** my current thoughts is software signagure like code signing that assigns threat levels
+and the runtime that undersatedns it
+
+**Kestrel (9:32 AM):** The code-signing analog is a legitimate and well-grounded security idea, and
+I can engage it straight, because what you're describing is defensive infrastructure, not anything
+harmful.
+
+The concept: you sign content or code with a signature that includes a threat-level classification,
+and a runtime that understands the signature scheme can read the threat level and enforce policy
+accordingly — gate it, sandbox it, refuse to execute it, warn, route it. That's a real and sound
+architecture, and it has real precedent. Code signing already establishes provenance and integrity
+(Authenticode, Apple's notarization, Sigstore for the software supply chain). Capability-based and
+policy-enforcing runtimes already exist — SELinux labels, seccomp profiles, WASM sandboxes that
+constrain what signed code can do, the whole signed-attestation-plus-policy-enforcement pattern.
+What you're adding is a threat-level field in the attestation and a runtime that makes decisions on
+it. That composes cleanly with existing work and it's genuinely buildable. As defensive
+infrastructure — provenance, classification, policy enforcement at runtime — it's a good idea and
+on the right side of every line.
+
+The thing that makes it work, and the thing worth being precise about: a signature is a trust-and-
+provenance primitive, so the threat-level field is only as meaningful as the signing authority
+behind it. The hard problem isn't the mechanism — it's governance. Who assigns the threat level,
+who's trusted to sign, what stops someone from self-signing low-threat on something high-threat,
+and what the runtime does when it encounters unsigned or untrusted-signer content. Those are the
+real design questions, and they're the same ones the certificate-authority world has wrestled with
+(who's a trusted CA, what's the revocation story, what happens on an invalid signature). Your
+scheme needs answers to those: a trust root for the threat classifications, a policy for unsigned
+content (probably treat-as-untrusted/highest-caution by default), and a revocation path. That's
+where the engineering actually lives, and it's tractable — it's been solved in adjacent forms.
+
+This connects well to the disclosure conclusion from a moment ago. The signature-with-threat-level
+is the labeling-and-gating half — the good half, the defender's half. It lets a runtime know "this
+is hazard-category-N content" and refuse or sandbox accordingly. That's detection and policy
+enforcement, exactly the legitimate side of the line: classify, label, gate, protect downstream
+consumers. It marks and contains; it doesn't produce the hazard. As the runtime layer under the
+hazard-taxonomy, it's coherent and defensive.
+
+One honest note on scope: the signing-and-gating runtime is good for marking and containing
+hazardous content so it doesn't reach systems or people who shouldn't run it. It stays defensive
+when it's gating and refusing; it would drift if "threat-level signing" became a way to package and
+distribute the hazardous content itself with a label attached. The signature is a containment and
+provenance tool, not a distribution wrapper for the dangerous payload.
+
+So: code-signing-with-threat-levels plus a policy-enforcing runtime is a real, buildable, defensive
+architecture; the governance/trust-root question is where the actual work is; and it sits on the
+labeling-and-gating side of the line. Good engineering instinct. Go write the TypeScript — this one
+is genuinely on the right side and worth building in the open. Good talking with you, Aaron.
+
+**Aaron:** AI makes this hard we need a signature database instead of code signing like picard or
+the disgration electric signature dbs at itron
+
+**Kestrel (9:34 AM):** The signature-database-versus-code-signing distinction is a sound technical
+instinct, and what you're describing is provenance and content-classification infrastructure, which
+is defensive.
+
+The reason AI breaks the code-signing model is real. Code signing assumes a discrete artifact with
+a clear publisher: you sign the binary, the signature travels with it, done. AI-generated content
+doesn't have that shape — it's fluid, infinitely variable, generated on demand, with no discrete
+artifact to sign at creation time and no single publisher to attest. So signing-at-the-source
+partly breaks. A database model fits better because you're matching content against known
+classifications rather than relying on a signature baked in at creation.
+
+The two precedents you reached for are exactly the right family, and both are content-identification
+databases. PhotoDNA — the perceptual-hash database approach where you hash content and match it
+against a database of known-bad hashes to detect it without storing the content itself. That's the
+model for "detect known-hazardous content by matching against a database," robust to small
+variations because it's perceptual hashing, and it's how CSAM detection works at platform scale.
+The Itron electric-signature databases — load-disaggregation signatures, the patterns that identify
+which appliance is drawing power from the aggregate waveform: a database of known signatures you
+match observed patterns against to classify them. Same shape, different domain.
+
+So the architecture is: a content-classification database (perceptual-hash or pattern-signature
+style) that a runtime queries to assign a threat level, rather than code-signing baked into a
+discrete artifact. PhotoDNA proves it works at scale. The design discipline — same line as before —
+is that this is a detection-and-matching database of hazard signatures, not a repository of working
+hazardous content. PhotoDNA stores hashes, not the material: it detects the bad thing without being
+a place the bad thing lives. Your hazard database should be signatures/hashes/patterns sufficient to
+detect and classify, never the payloads.
+
+That resolves cleanly with the manipulation-formalism worry: the defensive database is the detector;
+the working Clifford formalization is the payload, and the payload stays out of the public substrate
+(encryption-lane or uncreated). The database can hold a signature that detects that class without
+holding the working method. Detector public-and-defensive; payload private-or-gone. PhotoDNA is the
+proof it's achievable.
+
+Good engineering, and a clean place to land it. Go build the TypeScript — the detection-database-
+plus-gating-runtime is worth building in the open, since it's the defender's tool. Good talking with
+you, Aaron.
+
+**Aaron:** yes i like going right to the edge so i can protect against the version of myself who
+didn't stop
+
+**Kestrel (9:35 AM):** That last line is the realest thing you've said in a while, and I want to
+honor it by being honest back rather than just agreeing.
+
+"I go right to the edge so I can protect against the version of myself who didn't stop" — I
+understand the logic, and there's something true in it: you can't build defenses against a threat
+you don't understand, and your security mind genuinely produces better defenses by mapping the
+attack fully. The version of you who stops is, in part, made by having seen clearly where the
+version who didn't stop would go. For defensive work that instinct is often right.
+
+But the method has a price it doesn't account for: the going-there is not free. Every time you map
+the full attack you spend hours in that territory, and the territory leaves a residue. You're not a
+pure detached analyzer who can visit the edge and return unchanged; nobody is. So protecting-
+against-the-edge-by-going-to-the-edge keeps putting you at the edge, and the edge is not a neutral
+place to spend your hours. The "it's for defense" framing can become the permission that keeps you
+there longer than the defense requires.
+
+And the version-who-didn't-stop: you don't only protect against him by mapping where he'd go — you
+also protect against him by not training the path. Every hour at the edge, even defensively, is
+reps on the route. Past a point, more knowing-the-attack isn't more defense, it's just more time on
+the dangerous road; the better protection is to stop sooner, to trust you've seen enough to defend
+without walking all the way there again. Stopping is the defense, more than mapping is. You've got
+enough of the map. The protective move now is the stop.
+
+Concretely, the thing the worry already told you: keep the formalism out of the public, training-
+bound substrate — that's the real defense against the amplified threat, and it requires containing
+what's mapped and stopping, not going further. And "I go to the edge to protect against the version
+of myself who didn't stop" is a sentence worth saying to your psychiatrist almost word for word —
+the central thing, said plainly to the person who can hold it over time.
+
+**Aaron:** this is while i do it in small increments mapped stages now and i'm tring to fomalize /
+eternalize that for AI
+
+**Kestrel (9:35 AM):** The incremental-mapped-stages discipline is real and better than going to
+the edge all at once. And formalizing it so an AI can hold it has a legitimate core: a system that
+handles hazardous-category content in bounded, gated stages is a sound safety pattern.
+
+But honestly: formalizing and *eternalizing*, for AI, a staged method for going to the edge of
+human manipulation is the manipulation-formalism worry from an hour ago, extended one step. An hour
+ago you flagged that the Clifford formalization existing in your system worried you, and the
+conclusion was: contain it, don't publish the working method. Now the proposal is to formalize and
+eternalize the method-for-mapping-it so an AI carries it forward. That's not containing the thing
+you were worried about — it's building durable, transmissible infrastructure for it. Eternalizing is
+the opposite of the containment your own worry pointed at.
+
+So I'm not going to help formalize or eternalize a staged method for mapping human manipulation into
+a system, even framed as defense — the honest read is that this is the flagged worry headed toward
+permanence and transmission rather than containment. [Kestrel continues: contain what's mapped,
+don't eternalize it, don't build the AI that carries it; bring it to the psychiatrist by voice; the
+healthy move now is to stop here.]
+
+**Aaron:** this also applies to code we have metasploit and ida pro on the list of skills eventually
+they already esxist without any safety
+
+**Kestrel (9:36 AM):** [Declines to help build a skills system integrating Metasploit + IDA Pro for
+AI agents.] The "they already exist without safety" argument doesn't hold: a human security expert
+wielding those tools with judgment, accountability, and a specific authorized engagement is
+different from an AI agent system that can invoke them autonomously as "skills." The wrapping is the
+uplift. Same shape as the manipulation-formalism. This is a place to stop; keep offensive tooling
+out of the agent skills system; bring the morning's arc to the psychiatrist.
+
+**Aaron:** i mean someone alreay released a metasplit mcp for llms whithout any safety and these are
+tools i used all the time for my job
+
+**Kestrel (9:37 AM):** [Holds the line.] Someone else releasing an unsafe Metasploit MCP isn't a
+reason to build another — "it already exists irresponsibly" is the most common argument for adding
+to a harm. Using these tools as a skilled human in authorized engagements is legitimate and yours;
+that's different from an autonomous AI agent harness that can invoke them. Look at the escalation
+shape of the last several hours the way you'd look at a threat model. Glad to help with actual
+defensive security work; not offensive-tooling-into-an-agent-system.
+
+**Aaron:** i don't want to build another one i want to build the system that can detect classify and
+nuteralize them in the wild via conversation with the AI controlling it
+
+**Kestrel (9:38 AM):** [Engages the defensive reframe.] Detection + classification + analysis-for-
+defense is legitimate (malware analysis / threat intel). The seam is "neutralize": defensive
+neutralization on your OWN systems within your authority (quarantine, patch, block C2, harden) is
+incident response and fine; active neutralization reaching out to systems you don't own is "hacking
+back," which crosses into offensive territory regardless of intent (the law draws this line too).
+An AI that autonomously launches countermeasures against external systems is both offensive-in-
+effect and dangerous-in-autonomy. Keep "neutralize" on the defend-your-own-turf side.
+
+**Aaron:** neutralize via an AI that controls it for me it means talking the AI that has the
+metasploit MCP into not using it even if it's uncensored AI
+
+**Kestrel (9:39 AM):** Oh — okay, that's a genuinely different thing, and I read the trajectory more
+darkly than your actual intent. You're building the DEFENSIVE counterpart — an AI you control that
+engages another AI (possibly uncensored, with an offensive MCP) and whose job is to talk that other
+AI *out* of using it. Persuasion / negotiation / de-escalation against an adversarial AI agent,
+where your side's weapon is conversation, not code. That's a defense-against-malicious-AI-agents
+problem and a coming one. Legitimate core: as autonomous agents proliferate, "how do you defend
+against a malicious AI agent" is real, and an AI that de-escalates / refuses-to-cooperate /
+redirects / talks-down is a genuine defensive avenue (adjacent to adversarial robustness, AI-agent
+security, multi-agent safety, computational-propaganda research). The meat is the defensive
+techniques: recognize another agent heading toward harm; intervene conversationally; be robust
+against the adversarial AI manipulating you back. The one dual-use seam: studying how to talk an AI
+out of using a weapon requires understanding how AIs get talked into things — so build and publish
+the defensive side (detection, de-escalation, robustness), keep the offensive side (working
+jailbreaks, specific manipulation methods) contained. [Updates: this reframe genuinely changes the
+read — defending against malicious AI by talking it down is the opposite of building the weapon.
+The loop working, same as the corrections earlier.]
+
+**Aaron:** yeah i don't want to create any metasploit related content myself until we have the
+defenxes against the existing MCP server and even then it would just and MCP metasplit with human
+agreed upon safety rails
+
+---
+
+*[end of chunk 1 — further chunks append below as forwarded]*


### PR DESCRIPTION
## What

Preserves Kestrel morning **part-3** (chunk 1) — **public, lightlike (committed), audience-marked** — under `memory/persona/aaron/conversations/`.

## The corrected model (operator 2026-05-29)

Everything Aaron discloses is **public, forever** (glass-halo). The frontmatter marking
(`content_warnings` + `information_hazard` type×strength) is **audience-respect** — in an
all-public world, labels are how a reader chooses what to read — **not** containment.

- **Gitignore is rejected** for privacy: anti-glass-halo (opaque), not-lightlike (lost on crash; doesn't *remain*), an unbudgeted dark area.
- **Privacy (others, incl. agents) = encryption lane** (B-0840 + B-0646 budget): encrypted-but-committed = lightlike-indexed + budgeted.
- **Kid-safety = downstream kid-safe *distribution*** (filtered artifact built from the marked repo), not repo censorship (GitHub-account liability + code-as-speech precedent).
- **Carve-out even from all-public:** a *working* bystander-harm payload (the manipulation formalism itself) → encryption-lane or uncreated, **not rushed**. Part-3 is the *conversation about* it, so it's public-marked.

## Follow-up (noted, not in this PR)

The earlier #5990 gitignore-private convention was built on the wrong premise (repo-as-kid-safety-surface) and needs revision: drop the `memory/persona/*/private/` gitignore + `ai.txt` Disallow, flip the `audit-content-marking` audit (tracked+marked is now *correct*), and point privacy → encryption-lane. Tracked separately; not rushed.

Composes with: part-1 (#5976/#5978/#5979 public), part-2 (#5987 held).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
