### PR TITLE
feat(B-0343): pure buildGetTreeRequest — GET /git/trees/{sha}?recursive=1 read request (read-side pair)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -8,6 +8,7 @@ import {
   buildSeedBlobRequest,
   buildSeedCommitRequest,
   buildSeedRefUpdateRequest,
+  buildGetTreeRequest,
   buildSeedTreeRequest,
   computeSeedTree,
   diffSeedTree,
@@ -280,6 +281,44 @@ describe("diffSeedTree", () => {
 
   test("empty desired and empty target → vacuously idempotent", () => {
     expect(diffSeedTree([], [])).toEqual({ entries: [], extraneous: [], idempotent: true });
+  });
+});
+
+describe("buildGetTreeRequest", () => {
+  test("constructs the recursive git-trees read path", () => {
+    expect(buildGetTreeRequest("Lucent-Financial-Group", "zeta-recreation-experiment", "deadbeef")).toEqual({
+      path: "repos/Lucent-Financial-Group/zeta-recreation-experiment/git/trees/deadbeef?recursive=1",
+    });
+  });
+
+  test("recursive=1 is always present (load-bearing — full-tree blob listing, not top-level only)", () => {
+    // Without recursive=1 GitHub returns only top-level entries, so a nested blob
+    // would be absent and mis-diff as a spurious create. The builder pins it.
+    expect(buildGetTreeRequest("o", "r", "t").path).toContain("?recursive=1");
+  });
+
+  test("owner / repo / tree SHA flow verbatim into the path", () => {
+    const sha = "aa218f56b14c9653891f9e74264a383fa43fefbd";
+    expect(buildGetTreeRequest("o", "r", sha).path).toBe(`repos/o/r/git/trees/${sha}?recursive=1`);
+  });
+
+  test("path has no leading slash (gh api convention, matches the other builders)", () => {
+    // Sibling builders use bare `orgs/...` / `repos/...` paths for `gh api`; a leading
+    // slash would break the relative-path form. Pin it so this read request agrees.
+    expect(buildGetTreeRequest("o", "r", "t").path.startsWith("/")).toBe(false);
+  });
+
+  test("the built read path's response is what parseGitTreeResponse consumes (read-side pair)", () => {
+    // This request fetches the tree; parseGitTreeResponse parses the response. Assert the
+    // pair lines up: a response shaped per this endpoint parses into the diff's basis.
+    const req = buildGetTreeRequest("o", "r", "rootTreeSha");
+    expect(req.path).toContain("git/trees/rootTreeSha");
+    const existing = parseGitTreeResponse({
+      truncated: false,
+      tree: [{ path: "a.txt", type: "blob", sha: "aaa" }],
+    });
+    if (typeof existing === "string") throw new Error(existing);
+    expect(existing).toEqual([{ path: "a.txt", sha: "aaa" }]);
   });
 });
 

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -58,6 +58,17 @@ interface GitTreeResponse {
   readonly truncated: boolean;
 }
 
+/**
+ * A read-only `GET` request — the seed flow's git-data READS carry no body, so
+ * (unlike the write builders' `{path, body}` shape) a read request is just its
+ * `path`. `gh api <path>` defaults to GET, so the network slice that follows runs
+ * `gh api <path>` and feeds the parsed JSON to the matching parser. This is the
+ * shape `buildGetTreeRequest` returns; future ref/commit read builders return it too.
+ */
+export interface GitReadRequest {
+  readonly path: string;
+}
+
 /** One desired seed path classified against the target repo's current tree. */
 type SeedFileAction = "unchanged" | "create" | "update";
 
@@ -351,6 +362,34 @@ export function diffSeedTree(
   const idempotent = entries.every((entry) => entry.action === "unchanged");
 
   return { entries, extraneous, idempotent };
+}
+
+/**
+ * Pure builder for the `GET /repos/{owner}/{repo}/git/trees/{treeSha}?recursive=1`
+ * read request — the REQUEST half of the read-side pair whose RESPONSE half is
+ * `parseGitTreeResponse` (the parser's own doc comment names this exact endpoint as
+ * its source). The seeding flow reads the target repo's tree this way to build the
+ * idempotency `existing` set: a future ref → commit read chain yields `treeSha` (the
+ * tree a commit points at), this request fetches that tree, and `parseGitTreeResponse`
+ * turns the response into the `{path, sha}` blobs `diffSeedTree` diffs against.
+ *
+ * `recursive=1` is LOAD-BEARING and the whole reason this is a builder, not an inline
+ * string at the call site: WITHOUT it GitHub returns only the tree's TOP-LEVEL entries
+ * (immediate children, with sub-directories as unexpanded `type: "tree"` rows), so a
+ * blob nested under any directory would be absent from the parsed set and mis-diff as a
+ * spurious "create" — exactly the duplicate-write `parseGitTreeResponse`'s `truncated`
+ * guard also protects against. WITH it GitHub walks the whole tree and lists every blob
+ * by full path, which is the only shape the path-keyed diff can consume. (Any truthy
+ * value enables recursion; `1` is the documented idiom.) The recursive tree is capped at
+ * 100,000 entries / 7 MB and sets `truncated: true` past that — the parser rejects a
+ * truncated response, so this request and that guard compose into a safe idempotency
+ * basis. Verified against docs.github.com/en/rest/git/trees, API version 2026-03-10:
+ * `GET /repos/{owner}/{repo}/git/trees/{tree_sha}`, `recursive` query parameter.
+ *
+ * Pure: operates on its three string arguments only; no gh, no network, no filesystem.
+ */
+export function buildGetTreeRequest(owner: string, repo: string, treeSha: string): GitReadRequest {
+  return { path: `repos/${owner}/${repo}/git/trees/${treeSha}?recursive=1` };
 }
 
 /**


### PR DESCRIPTION
## B-0343 bounded slice — read-request builder for the git-trees idempotency fetch

Parent: **B-0193** (bootstrap razor + 23-hour recreation test). Slice scope: one pure request-builder. No network, no `gh`, no repo mutation.

### What this adds

The seed flow's **write** chain is complete (create → blob → tree → commit → ref). The **read** side already had its response *parser* (`parseGitTreeResponse`) but was missing the *request* that produces what it parses. This slice closes that gap:

- **`buildGetTreeRequest(owner, repo, treeSha) → GitReadRequest`** — returns `{ path: "repos/{owner}/{repo}/git/trees/{treeSha}?recursive=1" }`.
- **`GitReadRequest`** interface — reads carry no body (`gh api` defaults to GET), distinct from the write builders' `{ path, body }` shape. Future ref/commit read builders reuse it.

### Why `recursive=1` is load-bearing

WITHOUT it GitHub returns only the tree's **top-level** entries (sub-directories as unexpanded `type: "tree"` rows), so a nested blob would be absent from the parsed set and mis-diff as a spurious **"create"** — a duplicate write. The builder pins it once so no call site has to remember; it composes with `parseGitTreeResponse`'s existing `truncated` guard into a safe idempotency basis.

### API verification (search-first)

Endpoint + `recursive` param confirmed current against [docs.github.com/en/rest/git/trees](https://docs.github.com/en/rest/git/trees), `X-GitHub-Api-Version: 2026-03-10` — `GET /repos/{owner}/{repo}/git/trees/{tree_sha}`, recursive tree capped at 100,000 entries / 7 MB (sets `truncated: true` past that). Matches the file's existing doc-comment citations.

### Where it fits in the read chain

A future ref → commit read chain yields `treeSha` → this request fetches that tree → `parseGitTreeResponse` turns the response into the `{path, sha}` blobs `diffSeedTree` consumes. Network slice (`gh api`) remains a later, separately-bounded step.

### Focused checks

| Check | Result |
|---|---|
| `bun test tools/bootstrap-razor/seed-test-repo.test.ts` | **58 pass / 0 fail** (+5 new cases) |
| `bunx tsc --noEmit -p tsconfig.json` | clean for `tools/bootstrap-razor/`; only pre-existing unrelated `agentic-organization/` NATS module-resolution errors remain |
| `bun seed-test-repo.ts --dry-run` | still renders the existing seed plan (no CLI wiring this slice) |

Commit-tree canary: parent tree 63 == HEAD tree 63 (no corruption).

operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)