### PR TITLE
feat(B-0343): pure parseSeedBlobResponse — POST /git/blobs response → blob SHA (read-side pair of buildSeedBlobRequest)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -15,6 +15,7 @@ import {
   gitBlobSha,
   parseCreateRepoResponse,
   parseGitTreeResponse,
+  parseSeedBlobResponse,
   parseSeedManifest,
   resolveSeedFiles,
   seedCommitMessage,
@@ -276,6 +277,55 @@ describe("buildSeedBlobRequest", () => {
 
   test("encoding is always the base64 literal", () => {
     expect(buildSeedBlobRequest(Buffer.from("x", "utf8")).encoding).toBe("base64");
+  });
+});
+
+describe("parseSeedBlobResponse", () => {
+  // A trimmed-but-realistic POST /repos/{owner}/{repo}/git/blobs (201) response: the one
+  // field the seeder reads (sha), plus the `url` it ignores (proves selective reading).
+  // SHA is the content-addressable identity gitBlobSha predicts for the same bytes.
+  const created = {
+    url: "https://api.github.com/repos/Lucent-Financial-Group/zeta-recreation-experiment/git/blobs/3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15",
+    sha: "3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15",
+  };
+
+  test("extracts the sha, ignoring the url", () => {
+    expect(parseSeedBlobResponse(created)).toEqual({ sha: "3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15" });
+  });
+
+  test("the sha is what buildSeedTreeRequest's entries reference", () => {
+    const info = parseSeedBlobResponse(created);
+    if (typeof info === "string") throw new Error(`expected info, got refusal: ${info}`);
+    // Each tree entry carries the uploaded blob's SHA; this parser is where it comes from.
+    expect(info.sha).toBe("3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15");
+  });
+
+  test("success is a {sha} object, not a bare string (disambiguates the error channel)", () => {
+    // A bare-string success would collide with the error-string return; the object wrapper
+    // makes `typeof result === "string"` mean "error" unambiguously.
+    expect(typeof parseSeedBlobResponse(created)).toBe("object");
+  });
+
+  test("non-object responses are refused (null, array, scalar)", () => {
+    expect(typeof parseSeedBlobResponse(null)).toBe("string");
+    expect(typeof parseSeedBlobResponse([created])).toBe("string");
+    expect(typeof parseSeedBlobResponse("3a0f86f")).toBe("string");
+    expect(typeof parseSeedBlobResponse(42)).toBe("string");
+  });
+
+  test("missing string sha is refused (tree entry would reference nothing)", () => {
+    const { sha, ...rest } = created;
+    expect(parseSeedBlobResponse(rest)).toContain("sha");
+  });
+
+  test("a non-string sha of the right name is still refused", () => {
+    expect(typeof parseSeedBlobResponse({ ...created, sha: 12345 })).toBe("string");
+  });
+
+  test("type-checks only — any string sha is accepted verbatim (no SHA-format validation)", () => {
+    // Same restraint as parseCreateRepoResponse (which never format-checks its URLs):
+    // a malformed SHA surfaces as a 422 at the tree-create call, not here.
+    expect(parseSeedBlobResponse({ sha: "not-a-real-sha" })).toEqual({ sha: "not-a-real-sha" });
   });
 });
 

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -559,6 +559,42 @@ export function buildSeedBlobRequest(content: Uint8Array): GitBlobRequest {
 }
 
 /**
+ * Pure parser: the read-side pair of `buildSeedBlobRequest`, the mirror of
+ * `parseCreateRepoResponse` at the FIRST git-data write step. Turns GitHub's
+ * `POST /repos/{owner}/{repo}/git/blobs` (201) response — `{ "url": "...", "sha": "..." }`
+ * (verified against docs.github.com/en/rest/git/blobs, API version 2026-03-10) — into
+ * the one field the seeding flow consumes: the blob `sha`. That SHA is the same
+ * content-addressable identity `gitBlobSha` already predicts for the same bytes
+ * (`buildSeedBlobRequest`'s doc comment), so the flow does not need it to LEARN the
+ * SHA — it needs it to reference each uploaded blob in `buildSeedTreeRequest`'s tree
+ * entries, and (a future verify slice) to confirm the server's SHA matches the
+ * prediction, catching any encoding/corruption bug before the tree is assembled.
+ *
+ * Returns `{ sha }` on success, or an error string (same `T | string` convention as
+ * `parseCreateRepoResponse` / `parseGitTreeResponse`) when the response is unusable.
+ * The success type is the single-field object `{ sha }` rather than a bare string so
+ * the `typeof result === "string"` test means "error" unambiguously — a bare-string
+ * success would collide with the error channel. Type-check only, no SHA-format
+ * validation (same restraint as `parseCreateRepoResponse`, which never format-checks
+ * its URLs): a malformed SHA would surface as a 422 at the tree-create call, not here.
+ *
+ * Refusals:
+ *   - not an object (null, array, scalar)  → malformed
+ *   - `sha` missing or non-string          → malformed (a missing SHA leaves the tree
+ *     entry with nothing to reference; the seed cannot proceed)
+ *
+ * Pure: no network, no gh, no filesystem; operates only on the already-parsed JSON value.
+ */
+export function parseSeedBlobResponse(response: unknown): { readonly sha: string } | string {
+  if (typeof response !== "object" || response === null || Array.isArray(response)) {
+    return "blob-create response is not an object";
+  }
+  const { sha } = response as Record<string, unknown>;
+  if (typeof sha !== "string") return "blob-create response missing string `sha`";
+  return { sha };
+}
+
+/**
  * Pure write-side bridge — the mirror of `parseGitTreeResponse`. Where the parser
  * turns the target repo's git tree INTO the diff's `existing` input, this turns the
  * diff's verdict INTO the `tree` array a `POST /git/trees` call submits to write the


### PR DESCRIPTION
## What

Smallest safe slice of **B-0343** (test-repo seeding script). Adds the pure read-side parser `parseSeedBlobResponse` — the mirror of `parseCreateRepoResponse` at the **first git-data write step**, pairing the existing `buildSeedBlobRequest`.

Turns GitHub's `POST /repos/{owner}/{repo}/git/blobs` (201) response — `{ url, sha }` — into the one field the seeding flow consumes: the blob `sha`. That SHA is the content-addressable identity `buildSeedTreeRequest`'s tree entries reference (and the same value `gitBlobSha` already predicts for the bytes, so a future verify slice can check upload integrity).

```ts
export function parseSeedBlobResponse(response: unknown): { readonly sha: string } | string
```

## Why this shape

- **`{ sha }` object, not a bare string** — a bare-string success would collide with the error-string channel; the wrapper keeps `typeof result === "string"` meaning "error" unambiguously (same `T | string` convention as `parseCreateRepoResponse` / `parseGitTreeResponse`).
- **Type-check only, no SHA-format validation** — same restraint as `parseCreateRepoResponse` (which never format-checks its URLs). A malformed SHA surfaces as a 422 at the tree-create call, not here.
- Pure: no network, no gh, no filesystem.

## Slice cadence

Continues the flow-order read-side-pair cadence: `buildCreateRepoRequest`→`parseCreateRepoResponse` (#6008), `buildGetTreeRequest` (#6007). `buildSeedBlobRequest` was the first unpaired write-builder; this pairs it. Follow-up slices: `parseSeedTreeResponse`, `parseSeedCommitResponse`, `parseSeedRefUpdateResponse`.

## Focused checks (isolated worktree off `origin/main` `ca011b140`)

- `bun test tools/bootstrap-razor/seed-test-repo.test.ts` → **75 pass, 0 fail** (+7 new tests for `parseSeedBlobResponse`)
- `bun tools/bootstrap-razor/seed-test-repo.ts --dry-run` → exit 0 (ServiceTitan authz guard still refuses correctly)
- `tsc --strict` on both files → **0 errors** in `bootstrap-razor` (only a benign `--ignoreConfig` `@types/node` resolution artifact, unrelated to the change)
- Commit canary: parent tree 63 = head tree 63 (no collapse)

operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)