### PR TITLE
feat(B-0343): pure parseSeedTreeResponse — POST /git/trees response → tree SHA (read-side pair of buildSeedTreeRequest)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -17,25 +17,28 @@ import {
   parseGitTreeResponse,
   parseSeedBlobResponse,
   parseSeedManifest,
+  parseSeedTreeResponse,
   resolveSeedFiles,
   seedCommitMessage,
 } from "./seed-test-repo.ts";
 
 describe("parseSeedManifest", () => {
   test("extracts include and exclude entries from fenced yaml", () => {
-    const manifest = parseSeedManifest([
-      "intro",
-      "```yaml",
-      "include:",
-      "  - openspec/specs/**/spec.md",
-      "  - src/Core/README.md          # if exists",
-      "",
-      "exclude:",
-      "  - AGENTS.md",
-      "  - docs/**  # except bootstrap-razor/ itself",
-      "```",
-      "outro",
-    ].join("\n"));
+    const manifest = parseSeedManifest(
+      [
+        "intro",
+        "```yaml",
+        "include:",
+        "  - openspec/specs/**/spec.md",
+        "  - src/Core/README.md          # if exists",
+        "",
+        "exclude:",
+        "  - AGENTS.md",
+        "  - docs/**  # except bootstrap-razor/ itself",
+        "```",
+        "outro",
+      ].join("\n"),
+    );
 
     expect(manifest).toEqual({
       include: ["openspec/specs/**/spec.md", "src/Core/README.md"],
@@ -83,10 +86,7 @@ describe("resolveSeedFiles", () => {
 
   test("result is sorted", () => {
     const candidates = ["tools/tla/specs/Z.tla", "tools/tla/specs/A.tla"];
-    expect(resolveSeedFiles(candidates, manifest)).toEqual([
-      "tools/tla/specs/A.tla",
-      "tools/tla/specs/Z.tla",
-    ]);
+    expect(resolveSeedFiles(candidates, manifest)).toEqual(["tools/tla/specs/A.tla", "tools/tla/specs/Z.tla"]);
   });
 
   test("empty candidate list resolves to empty set", () => {
@@ -121,8 +121,7 @@ describe("buildCreateRepoRequest", () => {
         name: "zeta-recreation-experiment",
         private: true,
         auto_init: false,
-        description:
-          "B-0193 bootstrap-razor recreation test repo (seeded by tools/bootstrap-razor/seed-test-repo.ts)",
+        description: "B-0193 bootstrap-razor recreation test repo (seeded by tools/bootstrap-razor/seed-test-repo.ts)",
       },
     });
   });
@@ -379,18 +378,14 @@ describe("diffSeedTree", () => {
 
   test("differing blob SHA → update, not idempotent", () => {
     const diff = diffSeedTree([a], [{ path: "a.txt", sha: "OLD" }]);
-    expect(diff.entries).toEqual([
-      { path: "a.txt", action: "update", desiredSha: "aaa", existingSha: "OLD" },
-    ]);
+    expect(diff.entries).toEqual([{ path: "a.txt", action: "update", desiredSha: "aaa", existingSha: "OLD" }]);
     expect(diff.idempotent).toBe(false);
   });
 
   test("extraneous target file is reported but does NOT break idempotency", () => {
     // Target has the desired file (matching) plus an extra file (e.g. auto-README).
     const diff = diffSeedTree([a], [a, c]);
-    expect(diff.entries).toEqual([
-      { path: "a.txt", action: "unchanged", desiredSha: "aaa", existingSha: "aaa" },
-    ]);
+    expect(diff.entries).toEqual([{ path: "a.txt", action: "unchanged", desiredSha: "aaa", existingSha: "aaa" }]);
     expect(diff.extraneous).toEqual([c]);
     expect(diff.idempotent).toBe(true);
   });
@@ -515,10 +510,7 @@ describe("buildSeedTreeRequest", () => {
 
   test("create + update become 100644 blob entries carrying the DESIRED sha", () => {
     // desired: a (matches → unchanged, dropped), b (differs → update), c (absent → create)
-    const diff = diffSeedTree(
-      [a, b, { path: "c.txt", sha: "ccc" }],
-      [a, { path: "b.txt", sha: "OLD" }],
-    );
+    const diff = diffSeedTree([a, b, { path: "c.txt", sha: "ccc" }], [a, { path: "b.txt", sha: "OLD" }]);
     expect(buildSeedTreeRequest(diff)).toEqual([
       // b.txt update carries desiredSha "bbb", NOT the existing "OLD"
       { path: "b.txt", mode: "100644", type: "blob", sha: "bbb" },
@@ -539,7 +531,13 @@ describe("buildSeedTreeRequest", () => {
 
   test("output stays path-sorted (inherits diffSeedTree's canonical order)", () => {
     const plan = buildSeedTreeRequest(
-      diffSeedTree([{ path: "z.txt", sha: "zzz" }, { path: "a.txt", sha: "aaa" }], []),
+      diffSeedTree(
+        [
+          { path: "z.txt", sha: "zzz" },
+          { path: "a.txt", sha: "aaa" },
+        ],
+        [],
+      ),
     );
     expect(plan.map((e) => e.path)).toEqual(["a.txt", "z.txt"]);
   });
@@ -549,6 +547,71 @@ describe("buildSeedTreeRequest", () => {
     const diff = diffSeedTree([a], [a, { path: "README.md", sha: "readme" }]);
     expect(diff.extraneous).toEqual([{ path: "README.md", sha: "readme" }]);
     expect(buildSeedTreeRequest(diff)).toEqual([]); // a.txt unchanged, README extraneous → nothing to write
+  });
+});
+
+describe("parseSeedTreeResponse", () => {
+  // A trimmed-but-realistic POST /repos/{owner}/{repo}/git/trees (201) response: the one
+  // field the seeder reads (sha = the NEW tree's SHA), plus the `url` and `tree` it ignores
+  // (proves selective reading). truncated:false is the normal create path.
+  const created = {
+    url: "https://api.github.com/repos/Lucent-Financial-Group/zeta-recreation-experiment/git/trees/cd8274d15fa3ae2ab983129fb037999f264ba9a7",
+    sha: "cd8274d15fa3ae2ab983129fb037999f264ba9a7",
+    tree: [{ path: "a.txt", mode: "100644", type: "blob", sha: "aaa" }],
+    truncated: false,
+  };
+
+  test("extracts the new tree sha, ignoring url + tree", () => {
+    expect(parseSeedTreeResponse(created)).toEqual({ sha: "cd8274d15fa3ae2ab983129fb037999f264ba9a7" });
+  });
+
+  test("the sha is what buildSeedCommitRequest's treeSha argument takes", () => {
+    const info = parseSeedTreeResponse(created);
+    if (typeof info === "string") throw new Error(`expected info, got refusal: ${info}`);
+    // The commit step threads this SHA forward: buildSeedCommitRequest(info.sha, parentSha, n).
+    expect(buildSeedCommitRequest(info.sha, null, 1).tree).toBe("cd8274d15fa3ae2ab983129fb037999f264ba9a7");
+  });
+
+  test("success is a {sha} object, not a bare string (disambiguates the error channel)", () => {
+    expect(typeof parseSeedTreeResponse(created)).toBe("object");
+  });
+
+  test("non-object responses are refused (null, array, scalar)", () => {
+    expect(typeof parseSeedTreeResponse(null)).toBe("string");
+    expect(typeof parseSeedTreeResponse([created])).toBe("string");
+    expect(typeof parseSeedTreeResponse("cd8274d")).toBe("string");
+    expect(typeof parseSeedTreeResponse(42)).toBe("string");
+  });
+
+  test("truncated:true is refused — created tree is incomplete, commit would miss seed files", () => {
+    // Opposite rationale to parseGitTreeResponse's truncated refusal: there a truncated READ
+    // would mis-diff; here a truncated WRITE means the seed itself is short.
+    expect(parseSeedTreeResponse({ ...created, truncated: true })).toContain("truncated");
+  });
+
+  test("truncated:false (and absent truncated) pass — only the literal true refuses", () => {
+    expect(parseSeedTreeResponse({ ...created, truncated: false })).toEqual({
+      sha: "cd8274d15fa3ae2ab983129fb037999f264ba9a7",
+    });
+    const { truncated, ...noTruncated } = created;
+    expect(parseSeedTreeResponse(noTruncated)).toEqual({
+      sha: "cd8274d15fa3ae2ab983129fb037999f264ba9a7",
+    });
+  });
+
+  test("missing string sha is refused (commit step has no tree to reference)", () => {
+    const { sha, ...rest } = created;
+    expect(parseSeedTreeResponse(rest)).toContain("sha");
+  });
+
+  test("a non-string sha of the right name is still refused", () => {
+    expect(typeof parseSeedTreeResponse({ ...created, sha: 12345 })).toBe("string");
+  });
+
+  test("type-checks only — any string sha is accepted verbatim (no SHA-format validation)", () => {
+    // Same restraint as parseSeedBlobResponse: a malformed SHA surfaces as a 422 at the
+    // commit-create call, not here.
+    expect(parseSeedTreeResponse({ sha: "not-a-real-sha" })).toEqual({ sha: "not-a-real-sha" });
   });
 });
 
@@ -597,9 +660,7 @@ describe("buildSeedCommitRequest", () => {
 
 describe("buildSeedRefUpdateRequest", () => {
   test("new ref → POST /git/refs with FULL refs/heads/<branch> body", () => {
-    expect(
-      buildSeedRefUpdateRequest("LFG", "seed-repo", "main", "deadbeef", false),
-    ).toEqual({
+    expect(buildSeedRefUpdateRequest("LFG", "seed-repo", "main", "deadbeef", false)).toEqual({
       method: "POST",
       path: "repos/LFG/seed-repo/git/refs",
       body: { ref: "refs/heads/main", sha: "deadbeef" },
@@ -607,9 +668,7 @@ describe("buildSeedRefUpdateRequest", () => {
   });
 
   test("existing ref → PATCH with SHORT heads/<branch> suffix and force:false", () => {
-    expect(
-      buildSeedRefUpdateRequest("LFG", "seed-repo", "main", "deadbeef", true),
-    ).toEqual({
+    expect(buildSeedRefUpdateRequest("LFG", "seed-repo", "main", "deadbeef", true)).toEqual({
       method: "PATCH",
       path: "repos/LFG/seed-repo/git/refs/heads/main",
       body: { sha: "deadbeef", force: false },

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -305,13 +305,8 @@ function matchesAny(path: string, patterns: readonly string[]): boolean {
  * encoded here (the include list does not name those files, so they are
  * neither included nor a false-exclude here).
  */
-export function resolveSeedFiles(
-  candidates: readonly string[],
-  manifest: SeedManifest,
-): readonly string[] {
-  return candidates
-    .filter((path) => matchesAny(path, manifest.include) && !matchesAny(path, manifest.exclude))
-    .sort();
+export function resolveSeedFiles(candidates: readonly string[], manifest: SeedManifest): readonly string[] {
+  return candidates.filter((path) => matchesAny(path, manifest.include) && !matchesAny(path, manifest.exclude)).sort();
 }
 
 /**
@@ -356,10 +351,7 @@ export function computeSeedTree(resolved: readonly string[], root: string): read
  * no network, no gh. This is the comparison `computeSeedTree`'s slice named as
  * its handoff; a follow-up slice fetches the target tree via gh and feeds it in.
  */
-export function diffSeedTree(
-  desired: readonly SeedTreeEntry[],
-  existing: readonly SeedTreeEntry[],
-): SeedTreeDiff {
+export function diffSeedTree(desired: readonly SeedTreeEntry[], existing: readonly SeedTreeEntry[]): SeedTreeDiff {
   const byPath = new Map(existing.map((entry) => [entry.path, entry.sha]));
   const desiredPaths = new Set(desired.map((entry) => entry.path));
   const byPathSort = (a: { path: string }, b: { path: string }): number =>
@@ -620,6 +612,51 @@ export function buildSeedTreeRequest(diff: SeedTreeDiff): readonly GitTreeReques
 }
 
 /**
+ * Pure parser: the read-side pair of `buildSeedTreeRequest`, one step past
+ * `parseSeedBlobResponse` in the git-data write chain. Turns GitHub's
+ * `POST /repos/{owner}/{repo}/git/trees` (201) response — `{ "sha": "...", "url": "...",
+ * "tree": [...], "truncated": bool }` (verified against docs.github.com/en/rest/git/trees,
+ * API version 2026-03-10) — into the one field the next step consumes: the NEW tree's
+ * `sha`. That SHA is what `buildSeedCommitRequest`'s `treeSha` argument takes, so the
+ * network slice that follows is: take this SHA → `POST /git/commits` with it → fast-forward
+ * the ref. Distinct from `parseGitTreeResponse`, which parses the *read* (`GET .../git/trees/
+ * <sha>?recursive=1`) into the diff's `existing` entries; this parses the *write* response
+ * into the single SHA the write chain threads forward.
+ *
+ * Returns `{ sha }` on success, or an error string (same `T | string` convention as
+ * `parseSeedBlobResponse` / `parseCreateRepoResponse`) when the response is unusable. The
+ * success type is the single-field object `{ sha }` rather than a bare string so the
+ * `typeof result === "string"` test means "error" unambiguously — a bare-string success
+ * would collide with the error channel. Type-check only, no SHA-format validation (same
+ * restraint as `parseSeedBlobResponse`): a malformed SHA would surface as a 422 at the
+ * commit-create call, not here.
+ *
+ * Refusals:
+ *   - not an object (null, array, scalar)  → malformed
+ *   - `truncated: true`                    → the tree we submitted exceeded GitHub's max
+ *     entry limit, so the CREATED tree object is incomplete — a commit built on it would
+ *     be missing seed files. Rejected loudly rather than committing a partial seed. (Same
+ *     refusal as `parseGitTreeResponse`, opposite rationale: there a truncated READ would
+ *     mis-diff a missing path as a "create"; here a truncated WRITE means the seed itself
+ *     is short.)
+ *   - `sha` missing or non-string          → malformed (the commit step has no tree to
+ *     reference; the seed cannot proceed)
+ *
+ * Pure: no network, no gh, no filesystem; operates only on the already-parsed JSON value.
+ */
+export function parseSeedTreeResponse(response: unknown): { readonly sha: string } | string {
+  if (typeof response !== "object" || response === null || Array.isArray(response)) {
+    return "tree-create response is not an object";
+  }
+  const { sha, truncated } = response as Record<string, unknown>;
+  if (truncated === true) {
+    return "tree-create response is truncated — submitted tree exceeded the entry limit, created tree is incomplete";
+  }
+  if (typeof sha !== "string") return "tree-create response missing string `sha`";
+  return { sha };
+}
+
+/**
  * The provenance commit message for the seed (AC: "clear provenance message linking
  * back to B-0193"). A conventional-commit subject naming the file count, then a body
  * citing the seed manifest as the source-of-truth and the B-0193 parent / B-0343 slice
@@ -653,11 +690,7 @@ export function seedCommitMessage(fileCount: number): string {
  * filesystem. The network slice that follows is: submit this body → take the returned
  * commit SHA → `PATCH /git/refs/heads/<branch>` to fast-forward the ref.
  */
-export function buildSeedCommitRequest(
-  treeSha: string,
-  parentSha: string | null,
-  fileCount: number,
-): GitCommitRequest {
+export function buildSeedCommitRequest(treeSha: string, parentSha: string | null, fileCount: number): GitCommitRequest {
   return {
     message: seedCommitMessage(fileCount),
     tree: treeSha,


### PR DESCRIPTION
## What

One bounded slice of **B-0343** (test-repo seeding script) following the established pure-function-per-PR cadence (#6007 `buildGetTreeRequest`, #6008 `parseCreateRepoResponse`, #6009 `parseSeedBlobResponse`).

Adds `parseSeedTreeResponse` — the **read-side pair of `buildSeedTreeRequest`**, the next parser in the git-data write chain (`blobs → trees → commits → refs`), one step past `parseSeedBlobResponse`.

It turns GitHub's `POST /repos/{owner}/{repo}/git/trees` (201) response `{ sha, url, tree, truncated }` into the single field the next step consumes — the **new tree's `sha`** — which feeds `buildSeedCommitRequest(treeSha, …)`.

Pure: no `gh`, no network, no filesystem; operates only on already-parsed JSON. Same `T | string` convention + single-field `{ sha }` success wrapper as the sibling parsers.

### Refusals
- non-object (null / array / scalar) → malformed
- `truncated: true` → submitted tree exceeded GitHub's entry limit, so the **created** tree is incomplete; a commit built on it would miss seed files. Loud refusal rather than a partial seed. *(Opposite rationale to `parseGitTreeResponse`'s truncated refusal: there a truncated READ mis-diffs a missing path as a "create"; here a truncated WRITE means the seed itself is short.)*
- `sha` missing / non-string → malformed (commit step has no tree to reference)

Distinct from `parseGitTreeResponse`, which parses the **GET read** (`git/trees/<sha>?recursive=1`) into the diff's `existing` entries; this parses the **POST write** response into the one SHA the chain threads forward.

## Re-decomposition (per "assume decomposition mistakes")

B-0343's M-effort "create + seed + 4 ACs" is too broad for one atomic step — the row itself has been built as a sequence of pure request-builder / response-parser pairs, with the impure `gh` network slice deferred until all pure pieces are unit-tested. This PR adds exactly one such pair-half. Remaining unimplemented parsers in the chain: `parseSeedCommitResponse`, `parseSeedRefUpdateResponse` (future slices), then the thin network shell.

## Checks run (focused)

| Check | Result |
|---|---|
| `bun test tools/bootstrap-razor/seed-test-repo.test.ts` | **84 pass / 0 fail** (9 new tests) |
| `bun run typecheck` (`tsc --noEmit`, whole repo) | **0 errors** |
| `prettier@3.8.3 --check` (both files) | **clean** |
| `git ls-tree` commit canary (parent vs HEAD) | 63 == 63 (no tree collapse) |
| push ground-truth (`git ls-remote` == local HEAD) | verified |

**Honest note:** `eslint` could not be run via `bunx` in this background-worker env (the repo's eslint config is TypeScript-based and `bunx`'s isolated install lacked `jiti`). CI runs `lint:typescript` with installed deps and will gate it there. The new code is whitespace-clean per prettier and type-clean per tsc.

Response shape verified against [docs.github.com/en/rest/git/trees](https://docs.github.com/en/rest/git/trees) (API version 2026-03-10).

Parent: B-0193 · Slice: B-0343

🤖 Generated with [Claude Code](https://claude.com/claude-code)
