### PR TITLE
feat(B-0343): pure parseSeedCommitResponse — POST /git/commits response → commit SHA (read-side pair of buildSeedCommitRequest)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -16,6 +16,7 @@ import {
   parseCreateRepoResponse,
   parseGitTreeResponse,
   parseSeedBlobResponse,
+  parseSeedCommitResponse,
   parseSeedManifest,
   parseSeedTreeResponse,
   resolveSeedFiles,
@@ -655,6 +656,73 @@ describe("buildSeedCommitRequest", () => {
 
   test("carries the provenance message for the given file count", () => {
     expect(buildSeedCommitRequest("t", "p", 1).message).toBe(seedCommitMessage(1));
+  });
+});
+
+describe("parseSeedCommitResponse", () => {
+  // A trimmed-but-realistic POST /repos/{owner}/{repo}/git/commits (201) response: the one
+  // field the seeder reads (top-level sha = the NEW commit's SHA), plus the nested tree.sha,
+  // parents, and message it ignores (proves selective reading + that it does NOT read tree.sha).
+  const created = {
+    sha: "7638417db6d59f3c431d3e1f261cc637155684cd",
+    url: "https://api.github.com/repos/Lucent-Financial-Group/zeta-recreation-experiment/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd",
+    message: "chore(B-0343): seed bootstrap-razor recreation test repo (3 files)",
+    tree: { sha: "827efc6d56897b048c772eb4087f854f46256132", url: "https://api.github.com/..." },
+    parents: [{ sha: "cd8274d15fa3ae2ab983129fb037999f264ba9a7", url: "https://api.github.com/..." }],
+  };
+
+  test("extracts the new commit sha, ignoring tree/parents/message", () => {
+    expect(parseSeedCommitResponse(created)).toEqual({ sha: "7638417db6d59f3c431d3e1f261cc637155684cd" });
+  });
+
+  test("reads top-level commit sha, NOT the nested tree.sha", () => {
+    // The ref must point at the COMMIT; pointing it at tree.sha would yield a ref to a
+    // non-commit object. Assert the result is the commit SHA, distinct from tree.sha.
+    expect(parseSeedCommitResponse(created)).toEqual({ sha: "7638417db6d59f3c431d3e1f261cc637155684cd" });
+    expect(parseSeedCommitResponse(created)).not.toEqual({ sha: "827efc6d56897b048c772eb4087f854f46256132" });
+  });
+
+  test("the sha is what buildSeedRefUpdateRequest's commitSha argument takes", () => {
+    const info = parseSeedCommitResponse(created);
+    if (typeof info === "string") throw new Error(`expected info, got refusal: ${info}`);
+    // The ref step threads this SHA forward: buildSeedRefUpdateRequest(owner, repo, branch, info.sha, exists).
+    expect(buildSeedRefUpdateRequest("LFG", "r", "main", info.sha, false).body.sha).toBe(
+      "7638417db6d59f3c431d3e1f261cc637155684cd",
+    );
+  });
+
+  test("success is a {sha} object, not a bare string (disambiguates the error channel)", () => {
+    expect(typeof parseSeedCommitResponse(created)).toBe("object");
+  });
+
+  test("non-object responses are refused (null, array, scalar)", () => {
+    expect(typeof parseSeedCommitResponse(null)).toBe("string");
+    expect(typeof parseSeedCommitResponse([created])).toBe("string");
+    expect(typeof parseSeedCommitResponse("7638417")).toBe("string");
+    expect(typeof parseSeedCommitResponse(42)).toBe("string");
+  });
+
+  test("missing string sha is refused (ref step has no commit to reference)", () => {
+    const { sha, ...rest } = created;
+    expect(parseSeedCommitResponse(rest)).toContain("sha");
+  });
+
+  test("a non-string sha of the right name is still refused", () => {
+    expect(typeof parseSeedCommitResponse({ ...created, sha: 12345 })).toBe("string");
+  });
+
+  test("no truncated refusal — commits API returns no truncated field", () => {
+    // Unlike parseSeedTreeResponse, a commit references exactly one tree, so there is
+    // nothing to truncate; a stray truncated:true must NOT be treated as a refusal.
+    expect(parseSeedCommitResponse({ ...created, truncated: true })).toEqual({
+      sha: "7638417db6d59f3c431d3e1f261cc637155684cd",
+    });
+  });
+
+  test("type-checks only — any string sha is accepted verbatim (no SHA-format validation)", () => {
+    // Same restraint as parseSeedTreeResponse: a malformed SHA surfaces as a 422 at the
+    // ref-update call, not here.
+    expect(parseSeedCommitResponse({ sha: "not-a-real-sha" })).toEqual({ sha: "not-a-real-sha" });
   });
 });
 

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -699,6 +699,48 @@ export function buildSeedCommitRequest(treeSha: string, parentSha: string | null
 }
 
 /**
+ * Pure parser: the read-side pair of `buildSeedCommitRequest`, one step past
+ * `parseSeedTreeResponse` in the git-data write chain. Turns GitHub's
+ * `POST /repos/{owner}/{repo}/git/commits` (201) response — `{ "sha": "...", "tree":
+ * { "sha": "...", "url": "..." }, "parents": [...], "message": "...", ... }` (verified
+ * against docs.github.com/en/rest/git/commits, API version 2026-03-10) — into the one
+ * field the final step consumes: the NEW commit's top-level `sha`. That SHA is what
+ * `buildSeedRefUpdateRequest`'s `commitSha` argument takes, so the network slice that
+ * follows is the last link: take this SHA → `POST`/`PATCH /git/refs` to point the seed
+ * branch at it.
+ *
+ * Returns `{ sha }` on success, or an error string (same `T | string` convention as
+ * `parseSeedTreeResponse` / `parseSeedBlobResponse` / `parseCreateRepoResponse`) when
+ * the response is unusable. The success type is the single-field object `{ sha }`
+ * rather than a bare string so `typeof result === "string"` means "error"
+ * unambiguously — a bare-string success would collide with the error channel. The
+ * top-level `sha` is read, NOT the nested `tree.sha`: the ref must point at the COMMIT,
+ * and pointing it at the tree SHA would yield a ref to a non-commit object (a `git
+ * update-ref` to a tree is malformed). Type-check only, no SHA-format validation (same
+ * restraint as `parseSeedTreeResponse`): a malformed SHA would surface as a 422 at the
+ * ref-update call, not here.
+ *
+ * Refusals:
+ *   - not an object (null, array, scalar)  → malformed
+ *   - `sha` missing or non-string          → malformed (the ref step has no commit to
+ *     reference; the seed cannot proceed)
+ *
+ * Distinct from `parseSeedTreeResponse`, which has a `truncated: true` refusal: the
+ * commits API returns no `truncated` field (a commit references exactly one tree, so
+ * there is nothing to truncate), so that refusal is intentionally absent here.
+ *
+ * Pure: no network, no gh, no filesystem; operates only on the already-parsed JSON value.
+ */
+export function parseSeedCommitResponse(response: unknown): { readonly sha: string } | string {
+  if (typeof response !== "object" || response === null || Array.isArray(response)) {
+    return "commit-create response is not an object";
+  }
+  const { sha } = response as Record<string, unknown>;
+  if (typeof sha !== "string") return "commit-create response missing string `sha`";
+  return { sha };
+}
+
+/**
  * Pure builder for the seed's git-refs API call — the final write-chain link, taking
  * the commit SHA `buildSeedCommitRequest`'s body produced once `POST /git/commits`
  * returns it, and pointing the seed branch at it. `refExists` selects the endpoint:


### PR DESCRIPTION
## What

Adds `parseSeedCommitResponse` — the read-side pair of the already-merged `buildSeedCommitRequest` in `tools/bootstrap-razor/seed-test-repo.ts`. Continues the B-0343 functional-core decomposition (every GitHub git-data call split into a pure `build*Request` + pure `parse*Response`).

Pipeline position: blob → tree → **commit** → ref. With the commit-build (#5999) and its parse now both present, only the ref-update parse pair remains before the seeding flow's pure layer is complete.

```ts
export function parseSeedCommitResponse(response: unknown): { readonly sha: string } | string
```

Turns the `POST /repos/{owner}/{repo}/git/commits` (201) response into the one field the final step consumes: the NEW commit's **top-level** `sha`. That SHA feeds `buildSeedRefUpdateRequest`'s `commitSha` argument (POST/PATCH `/git/refs`).

## Design notes

- **Reads top-level `sha`, NOT nested `tree.sha`** — the ref must point at the COMMIT; pointing at the tree SHA would yield a ref to a non-commit object.
- `{ sha } | string` matches the module-wide Result-over-exception convention (sibling parsers `parseSeedTreeResponse` / `parseSeedBlobResponse` / `parseCreateRepoResponse`); the single-field success object disambiguates the `typeof result === "string"` error channel.
- **No `truncated` refusal** (unlike `parseSeedTreeResponse`): the commits API returns no `truncated` field (a commit references exactly one tree, nothing to truncate), so a stray `truncated:true` must NOT be treated as a refusal — covered by an explicit test.
- Type-check only, no SHA-format validation (same restraint as siblings; a malformed SHA surfaces as a 422 at the ref-update call).
- Pure: no network, no `gh`, no filesystem.

Response shape verified search-first against [docs.github.com/en/rest/git/commits](https://docs.github.com/en/rest/git/commits) (API version 2026-03-10).

## Focused checks

- `bun test tools/bootstrap-razor/seed-test-repo.test.ts` → **93 pass / 0 fail** (9 new tests: top-level-not-tree.sha, commitSha-threads-to-ref-build, non-object/missing/non-string-sha refusals, no-truncated-refusal, type-check-only).
- `tsc --noEmit` (repo-wide) → **0 errors in `tools/bootstrap-razor`** (pre-existing `@nats-io/*` module-decl errors in `agentic-organization/apps/workers/` only, unrelated).
- `prettier --check` → clean.
- `eslint` delta → +1 `sonarjs/function-return-type` (identical to the 6 merged sibling parsers' `T|string` Result convention; `eslint .` is not a merge gate for this convention per today's merges #6008–#6011) + 1 `no-unused-vars` in the test (matches sibling `const { sha, ...rest } = created` destructure-rest pattern).

## Scope

One bounded step (pure parser + tests). Authorization scope unchanged (LFG/AceHack only, never ServiceTitan). No network/gh/IO touched.

Parent: B-0193 · Slice: B-0343

🤖 Generated with [Claude Code](https://claude.com/claude-code)