### PR TITLE
feat(B-0343): pure parseSeedRefUpdateResponse — POST/PATCH /git/refs response → object.sha (read-side pair of buildSeedRefUpdateRequest)

### DIFF
--- a/tools/bootstrap-razor/seed-test-repo.test.ts
+++ b/tools/bootstrap-razor/seed-test-repo.test.ts
@@ -18,6 +18,7 @@ import {
   parseSeedBlobResponse,
   parseSeedCommitResponse,
   parseSeedManifest,
+  parseSeedRefUpdateResponse,
   parseSeedTreeResponse,
   resolveSeedFiles,
   seedCommitMessage,
@@ -769,5 +770,88 @@ describe("buildSeedRefUpdateRequest", () => {
     const updated = buildSeedRefUpdateRequest("o", "r", "main", sha, true);
     expect(created.body.sha).toBe(sha);
     expect(updated.body.sha).toBe(sha);
+  });
+});
+
+describe("parseSeedRefUpdateResponse", () => {
+  // A trimmed-but-realistic git/refs response — identical schema for POST (201, fresh
+  // branch) and PATCH (200, fast-forward). The one field the seeder reads is the NESTED
+  // object.sha (the commit the ref now points at), plus the top-level ref/node_id/url it
+  // ignores (proves selective reading + that it does NOT read the top-level ref label).
+  const updated = {
+    ref: "refs/heads/main",
+    node_id: "MDM6UmVmMTpyZWZzL2hlYWRzL21haW4=",
+    url: "https://api.github.com/repos/Lucent-Financial-Group/zeta-recreation-experiment/git/refs/heads/main",
+    object: {
+      type: "commit",
+      sha: "aa218f56b14c9653891f9e74264a383fa43fefbd",
+      url: "https://api.github.com/repos/Lucent-Financial-Group/zeta-recreation-experiment/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd",
+    },
+  };
+
+  test("extracts the nested object.sha, ignoring ref/node_id/url", () => {
+    expect(parseSeedRefUpdateResponse(updated)).toEqual({ sha: "aa218f56b14c9653891f9e74264a383fa43fefbd" });
+  });
+
+  test("reads NESTED object.sha, NOT the top-level ref label", () => {
+    // object.sha is the content confirmation (the commit the ref points at); the
+    // top-level `ref` is just the branch name. Assert the result is the commit SHA,
+    // never the ref string.
+    const info = parseSeedRefUpdateResponse(updated);
+    expect(info).toEqual({ sha: "aa218f56b14c9653891f9e74264a383fa43fefbd" });
+    expect(info).not.toEqual({ sha: "refs/heads/main" });
+  });
+
+  test("the sha confirms the seed landed where buildSeedRefUpdateRequest aimed it", () => {
+    const info = parseSeedRefUpdateResponse(updated);
+    if (typeof info === "string") throw new Error(`expected info, got refusal: ${info}`);
+    // The whole chain's invariant: the SHA the ref reports back equals the commitSha the
+    // request threaded in. Equality here is the seed-landed confirmation.
+    const sha = "aa218f56b14c9653891f9e74264a383fa43fefbd";
+    expect(info.sha).toBe(buildSeedRefUpdateRequest("LFG", "r", "main", sha, false).body.sha);
+  });
+
+  test("one parser handles both POST (201) and PATCH (200) — same schema", () => {
+    // GitHub documents create + update refs as the same response schema; the seeder's
+    // POST(fresh) and PATCH(fast-forward) both yield this shape, so one parser suffices.
+    const fromPatch = { ...updated, ref: "refs/heads/feat/x" };
+    expect(parseSeedRefUpdateResponse(updated)).toEqual({ sha: "aa218f56b14c9653891f9e74264a383fa43fefbd" });
+    expect(parseSeedRefUpdateResponse(fromPatch)).toEqual({ sha: "aa218f56b14c9653891f9e74264a383fa43fefbd" });
+  });
+
+  test("success is a {sha} object, not a bare string (disambiguates the error channel)", () => {
+    expect(typeof parseSeedRefUpdateResponse(updated)).toBe("object");
+  });
+
+  test("non-object responses are refused (null, array, scalar)", () => {
+    expect(typeof parseSeedRefUpdateResponse(null)).toBe("string");
+    expect(typeof parseSeedRefUpdateResponse([updated])).toBe("string");
+    expect(typeof parseSeedRefUpdateResponse("aa218f5")).toBe("string");
+    expect(typeof parseSeedRefUpdateResponse(42)).toBe("string");
+  });
+
+  test("missing or non-object `object` field is refused (no nested SHA to read)", () => {
+    const { object, ...rest } = updated;
+    expect(parseSeedRefUpdateResponse(rest)).toContain("object");
+    expect(typeof parseSeedRefUpdateResponse({ ...updated, object: "commit" })).toBe("string");
+    expect(typeof parseSeedRefUpdateResponse({ ...updated, object: null })).toBe("string");
+    expect(typeof parseSeedRefUpdateResponse({ ...updated, object: [updated.object] })).toBe("string");
+  });
+
+  test("missing string object.sha is refused (seed-landed confirmation cannot be made)", () => {
+    const { sha, ...objRest } = updated.object;
+    expect(parseSeedRefUpdateResponse({ ...updated, object: objRest })).toContain("sha");
+  });
+
+  test("a non-string object.sha of the right name is still refused", () => {
+    expect(typeof parseSeedRefUpdateResponse({ ...updated, object: { ...updated.object, sha: 12345 } })).toBe(
+      "string",
+    );
+  });
+
+  test("type-checks only — any string object.sha is accepted verbatim (no SHA-format validation)", () => {
+    // Same restraint as parseSeedCommitResponse: a malformed SHA surfaces as a 422 at the
+    // ref-update call, never reaching this success path.
+    expect(parseSeedRefUpdateResponse({ object: { sha: "not-a-real-sha" } })).toEqual({ sha: "not-a-real-sha" });
   });
 });

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -773,6 +773,54 @@ export function buildSeedRefUpdateRequest(
 }
 
 /**
+ * Pure parser: the read-side pair of `buildSeedRefUpdateRequest`, closing the
+ * git-data write chain (blobs → tree → commit → ref). Both endpoints
+ * `buildSeedRefUpdateRequest` produces — `POST /repos/{owner}/{repo}/git/refs` (201,
+ * fresh branch) and `PATCH /repos/{owner}/{repo}/git/refs/heads/{branch}` (200,
+ * fast-forward) — return the SAME ref schema: `{ "ref": "refs/heads/...", "node_id":
+ * "...", "url": "...", "object": { "type": "commit", "sha": "...", "url": "..." } }`
+ * (verified against docs.github.com/en/rest/git/refs, API version 2026-03-10). One
+ * parser handles both, mirroring how the single `buildSeedRefUpdateRequest` produces
+ * both request shapes.
+ *
+ * Reads the NESTED `object.sha` — the commit the ref now points at — NOT the top-level
+ * `ref` name. `object.sha` is the seed's confirmation field: the caller asserts it
+ * equals the `commitSha` it threaded in (`parseSeedCommitResponse`'s output), proving
+ * the create/fast-forward landed the seed branch at the intended commit and not some
+ * diverged tip. The top-level `ref` is the branch label, not a content check, so it is
+ * ignored.
+ *
+ * Returns `{ sha }` on success, or an error string (same `T | string` convention as
+ * `parseSeedCommitResponse` / `parseSeedTreeResponse` / `parseSeedBlobResponse` /
+ * `parseCreateRepoResponse`) when the response is unusable. The success type is the
+ * single-field object `{ sha }` rather than a bare string so `typeof result ===
+ * "string"` means "error" unambiguously — a bare-string success would collide with the
+ * error channel. Type-check only, no SHA-format validation (same restraint as
+ * `parseSeedCommitResponse`): a malformed SHA would have surfaced as a 422 at the
+ * ref-update call, never reaching this success path.
+ *
+ * Refusals:
+ *   - not an object (null, array, scalar)        → malformed
+ *   - `object` missing / non-object / null/array → malformed (no nested SHA to read)
+ *   - `object.sha` missing or non-string         → malformed (the confirmation the seed
+ *     landed cannot be made; the run reports failure rather than a false success)
+ *
+ * Pure: no network, no gh, no filesystem; operates only on the already-parsed JSON value.
+ */
+export function parseSeedRefUpdateResponse(response: unknown): { readonly sha: string } | string {
+  if (typeof response !== "object" || response === null || Array.isArray(response)) {
+    return "ref-update response is not an object";
+  }
+  const { object } = response as Record<string, unknown>;
+  if (typeof object !== "object" || object === null || Array.isArray(object)) {
+    return "ref-update response missing object `object`";
+  }
+  const { sha } = object as Record<string, unknown>;
+  if (typeof sha !== "string") return "ref-update response missing string `object.sha`";
+  return { sha };
+}
+
+/**
  * Read-only filesystem scan: collect the concrete files under each rooted
  * include pattern. Scans include patterns directly (never a recursive glob
  * from root) to avoid walking gitignored mirror trees. No mutation, no

--- a/tools/bootstrap-razor/seed-test-repo.ts
+++ b/tools/bootstrap-razor/seed-test-repo.ts
@@ -813,7 +813,7 @@ export function parseSeedRefUpdateResponse(response: unknown): { readonly sha: s
   }
   const { object } = response as Record<string, unknown>;
   if (typeof object !== "object" || object === null || Array.isArray(object)) {
-    return "ref-update response missing object `object`";
+    return "ref-update response missing object field `object`";
   }
   const { sha } = object as Record<string, unknown>;
   if (typeof sha !== "string") return "ref-update response missing string `object.sha`";


### PR DESCRIPTION
## What

Pure `parseSeedRefUpdateResponse` — the read-side pair of `buildSeedRefUpdateRequest`, **closing the git-data write chain** (blobs → tree → commit → **ref**). Continues the same tiny-pure-function cadence as #6011 (`parseSeedTreeResponse`) and #6013 (`parseSeedCommitResponse`).

## Why this is the smallest safe slice

`buildSeedRefUpdateRequest` (the final write-chain link) was the **only** `build*Request` left without a paired `parse*Response`. Every other pair already exists (blob/tree/commit/get-tree/create-repo). This adds the missing read-side, making the whole write chain symmetric — and is the *last* link, so no further parse-pair slice exists after it.

## Design

- **One parser, both endpoints.** GitHub documents create (`POST /git/refs`, 201) and update (`PATCH /git/refs/heads/{branch}`, 200) as the **same** response schema — `{ ref, node_id, url, object: { type, sha (40 chars), url } }`. The single `buildSeedRefUpdateRequest` produces both request shapes, so one parser mirrors it.
- **Reads NESTED `object.sha`, not top-level `ref`.** `object.sha` is the commit the ref now points at — the seed-landed *confirmation* field (caller asserts it `==` the threaded `commitSha`). The top-level `ref` is just the branch label and is ignored.
- **Same conventions as siblings:** `T | string` (so `typeof result === "string"` means "error" unambiguously); type-check-only, no SHA-format validation (a malformed SHA surfaces as a 422 at the ref-update call, never reaching this success path).
- **Refusals:** non-object response; missing/non-object `object`; missing/non-string `object.sha`.
- **Purely additive:** +48 source (fn + doc), +84 test (import + 10-test `describe`); **0 deletions**.

## Search-first authority (Otto-364)

Response shape verified live against [docs.github.com/en/rest/git/refs](https://docs.github.com/en/rest/git/refs) (API version 2026-03-10): create + update return the *same* schema as get-a-reference; nested `object.sha` is 40 chars; POST → 201, PATCH → 200.

## Focused checks

- `bun test tools/bootstrap-razor/seed-test-repo.test.ts` → **103 pass / 0 fail** (146 expect calls; +10 new tests)
- `bunx tsc --noEmit` → **0 errors in `tools/bootstrap-razor/`** (the only tsc errors are pre-existing `agentic-organization/apps/workers/` NATS module-resolution issues, unrelated to this change)

Parent: B-0193 · Row: B-0343 (`docs/backlog/P1/B-0343-test-repo-seeding-script-ts-b0193.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)