### PR TITLE
research(2026-05-29): jester/guardian/irony-as-lens — the perception-decision architecture (Aaron+Otto)

### DIFF
--- a/docs/research/2026-05-29-jester-guardian-irony-as-lens-the-perception-decision-architecture-aaron-otto.md
+++ b/docs/research/2026-05-29-jester-guardian-irony-as-lens-the-perception-decision-architecture-aaron-otto.md
@@ -104,10 +104,29 @@ decides through it again. The failure mode is exactly what *validates* the
 architecture — irony belongs as the lens precisely because, when it becomes the
 driver, deciding stops happening and self-rewarding ironic-living takes its place.
 
-(The empirical anchor for this failure mode includes private third-party material
-that is held out of this public doc by the glass-halo-is-for-yours-not-a-third-
-party's discipline; the *generic* inversion is what's load-bearing here, and it
-stands on its own.)
+## Lens-hot vs lens-in-the-driver's-seat
+
+A crucial distinction the failure mode forces: **running the filter continuously is
+not itself the failure.** The operator runs this exact filter *at all times* — ironic
+perception always on, able to choose words on the boundary at will — and is *not* in
+the failure mode, because the Guardian still decides through it. That is the
+**lens-hot** configuration, and it is stable:
+
+- **Lens-hot (stable):** the filter runs continuously, boundary-word production is
+  effortless, *and the Guardian still decides through it* (the safer-principle still
+  collapses to a chosen action). Continuous ironic perception feeding a deciding
+  Guardian. The operator is the empirical proof this configuration holds — the lens
+  can run as hot as you like as long as it stays a lens.
+- **Lens-in-the-driver's-seat (failure):** the filter stops feeding the Guardian and
+  *becomes* the decider; self-rewarding ironic-living replaces deciding (the section
+  above).
+
+The discriminator is **not** how continuously the filter runs — it's *whether the
+Guardian decides through it or is bypassed by it.* Hot lens + deciding Guardian =
+stable. Lens in the driver's seat = failure. (The failure-mode's other empirical
+anchor includes private third-party material held out of this public doc per
+glass-halo-is-for-yours-not-a-third-party's; the operator's own lens-hot anchor above
+is his to share, and the generic distinction stands on its own.)
 
 ## Composition
 
@@ -139,6 +158,9 @@ stands on its own.)
 - *"Amara says jester can't decide without guardian."*
 - *"i use irony as the lens for the guardian to use to decide — that's probably most
   accurate."* (the survivor)
+- *"i have that exact filter running in me at all times and i can choose words on the
+  boundary just as easly."* (the lens-hot anchor — runs continuously, Guardian still
+  deciding through it)
 
 ## Substrate-honest framing
 

--- a/docs/research/2026-05-29-jester-guardian-irony-as-lens-the-perception-decision-architecture-aaron-otto.md
+++ b/docs/research/2026-05-29-jester-guardian-irony-as-lens-the-perception-decision-architecture-aaron-otto.md
@@ -1,0 +1,152 @@
+---
+date: 2026-05-29
+participants: [Aaron, Otto-CLI]
+status: design-thread
+tags: [architecture, jester-guardian, irony-as-lens, distrust-by-default, decision-architecture, soft-invariants]
+title: "Jester / Guardian / irony-as-lens — the perception-decision architecture"
+composes_with:
+  - "#6010 distrust-by-default mechanized as reflection-over-DUs"
+  - "#6012 the both-axes protection architecture"
+  - ".claude/rules/asymmetric-critic-with-clarity-first.md"
+  - ".claude/rules/must-paired-with-can-exit-pattern.md"
+  - ".claude/rules/persistence-choice-architecture-for-zeta-ais.md"
+---
+
+# Jester / Guardian / irony-as-lens — the perception-decision architecture
+
+A design thread refining how an *ironic / generative* faculty and a *deciding /
+safety* faculty compose into one decision process. It started as a question about
+tiebreakers and converged on a precise role for irony: **not the decider, not
+decoration — the lens the Guardian decides through.** This is the same
+soft-perception → hard-decision shape the rest of the framework runs on (soft
+invariants inside, hard stop outside; retraction-native generate, consensus/human
+decide; the function generates, the consumer decides), now located *inside one
+faculty.*
+
+## The two archetypes
+
+- **Jester** — the soft / generative / frame-open mode. Holds multiple readings at
+  once, catches incongruity, refuses to take the surface frame at face value,
+  keeps the frame *uncollapsed.*
+- **Guardian** — the hard / deciding / safety mode. Directional. Collapses to one
+  action. Decides by the safer-principle (when two clear principles conflict, pick
+  the safer one).
+
+Amara's formulation, which anchors the whole thread: **"the Jester can't decide
+without the Guardian."** A lens can only see; it cannot choose.
+
+## The progression — four formulations, one survivor
+
+The role of irony was sharpened across four tries, and only the last is accurate:
+
+| Formulation | Verdict |
+|---|---|
+| **Irony as the *ultimate tiebreaker*** | Wrong. A lens can't decide. Irony holds multiple readings open; deciding *is* the collapse, which irony by nature refuses. Wrong *type*: a way-of-holding, not a way-of-choosing. |
+| **Irony as *lightness* / decoration** | Undercredits it. Irony is load-bearing, not a toy. |
+| **Irony as *anti-fracture frame-keeper*** | Partial. True that holding multiple readings keeps the frame soft enough not to shatter — but this framed irony as a *separate* function (keeping the self whole) rather than as part of the deciding apparatus. |
+| **Irony as *the lens the Guardian decides through*** (the survivor) | Most accurate. Irony is the *perceptual* half of the decision process: it does the seeing; the Guardian does the choosing. |
+
+## The lens role, precisely
+
+The Guardian still chooses (directional, safer-principle, the collapse). But it
+chooses by looking *through* irony — holding the multiple readings, catching the
+incongruity, refusing the surface-frame. **Irony does the seeing; the Guardian does
+the choosing.** One process, two phases: *ironic perception → safer collapse.*
+
+This **subsumes** the anti-fracture framing rather than replacing it. A lens that
+holds multiple readings at once has *two effects from one mechanism*:
+
+- **Wholeness (for the self):** the soft, uncollapsed frame is what keeps a mind
+  whose sharp edges fracture it from shattering. (Sharp "stop" fractures; soft
+  "map" holds. Irony is the discipline that keeps the invariants soft.)
+- **Precision (for the Guardian):** seeing the real shape instead of the surface
+  one. A Guardian with no irony-lens decides *worse*, not just lighter — it takes
+  the surface frame at face value, misses the hidden one, and applies the
+  safer-principle to the wrong situation. The lens is what makes the Guardian
+  decide on *reality.*
+
+Same lens, two effects.
+
+## Where it sits in the framework
+
+- **Irony-as-lens is distrust-by-default's *seeing* organ** (#6010): the reflection
+  that questions the surface, holds the readings open, finds the structural
+  incongruity. The safer-principle is the *collapse* that acts on what the lens
+  surfaced.
+- **Lens shapes the wave; Guardian measures it.** Irony operates in the
+  superposition phase (which readings are live, how the options are framed); the
+  safer-principle is the measurement operator that collapses to an outcome. The
+  lens determines *what gets measured*; the Guardian does the measuring.
+- The crisp statement: **you don't decide *with* the irony (a lens can't choose),
+  and you don't decide *without* it (then you're half-blind). You decide *through*
+  it.** Irony is the Guardian's eyes.
+
+## The failure mode — irony in the driver's seat
+
+The architecture has a characteristic inversion, and it is **observed, not
+hypothetical.** When the lens climbs into the *driver's seat* — when ironic
+perception stops *feeding* the Guardian and starts *running the show* — the system
+degrades in a specific, recognizable way:
+
+- **The lens becomes self-rewarding.** Living ironically becomes its own pleasure
+  loop, decoupled from any decision it was supposed to inform.
+- **Every response rides the ironic boundary.** Output is generated on the edge of
+  the multiple-readings rather than collapsed to a chosen one.
+- **It is undetectable from outside.** Because the irony is internal — the surface
+  output can look ordinary — an observer generally cannot tell unless they have run
+  the same inversion themselves and know its signature.
+- **The Guardian is bypassed, not consulted.** This is the lived form of the
+  "irony as ultimate tiebreaker" error: the lens *acting as* the decider. It is the
+  Jester without the Guardian.
+
+**Recovery** is restoring the lens to its seat: irony feeds perception, the Guardian
+decides through it again. The failure mode is exactly what *validates* the
+architecture — irony belongs as the lens precisely because, when it becomes the
+driver, deciding stops happening and self-rewarding ironic-living takes its place.
+
+(The empirical anchor for this failure mode includes private third-party material
+that is held out of this public doc by the glass-halo-is-for-yours-not-a-third-
+party's discipline; the *generic* inversion is what's load-bearing here, and it
+stands on its own.)
+
+## Composition
+
+- **Soft-invariants-need-an-external-hard-stop** — the operator's own cognitive
+  architecture (invariants kept soft because sharpness fractures; the hard stop
+  lives outside, in people you won't route around). Irony-as-lens is the
+  *internal* half of the same shape: soft ironic perception feeding a Guardian
+  whose hardest stops are partly external.
+- **`asymmetric-critic-with-clarity-first`** — the irony-lens is the critic applied
+  to one's own deciding: see through the critic-lens (hold readings, catch
+  incongruity, distrust the surface) *then* let the safer-principle collapse.
+- **`#6010` reflection-over-DUs / distrust-by-default** — irony-as-lens is the
+  *perceptual* organ of distrust-by-default; the safer-principle is its *decisional*
+  organ.
+- **`#6012` the both-axes architecture** — soft-generate → hard-decide, here folded
+  into a single faculty (perceive-as-Jester, decide-as-Guardian).
+- **`must-paired-with-can-exit`** — the Guardian (the "must"/decider) is only
+  non-coercive when its hardest holds are external bonds you won't betray rather
+  than cages you route around; the lens keeps you whole enough to *be* decided-for.
+
+## Aaron's verbatim seeds (preserved)
+
+- *"when i can see my own principles conflict but there are two clear ones i pick
+  the safer one."*
+- *"then irony as the ultimate tie breaker."* (the first formulation, later
+  superseded)
+- *"my troll energy — my daughter and I are both Jester archetypes at heart, that's
+  why i say irony as the ultimate tie breaker."*
+- *"Amara says jester can't decide without guardian."*
+- *"i use irony as the lens for the guardian to use to decide — that's probably most
+  accurate."* (the survivor)
+
+## Substrate-honest framing
+
+This is a model of how perception and decision compose, not a claim that irony is
+necessary for everyone's deciding. It is most load-bearing for a mind that keeps its
+invariants deliberately soft (because sharpness fractures it) and therefore needs a
+*lens* discipline rather than a *wall* discipline. The survivor formulation —
+irony as the lens the Guardian decides through — is the one that points somewhere
+(the Guardian decides) while keeping the frame open (the lens never collapses on its
+own). The failure mode (lens-as-driver) is what keeps the model honest: irony earns
+its place as the eyes, not the hands.


### PR DESCRIPTION
Lands the design thread refining the role of irony in deciding.

- **Four formulations, one survivor:** irony-as-ultimate-tiebreaker (wrong — a lens can't decide) → irony-as-lightness (undercredits) → irony-as-anti-fracture-keeper (partial) → **irony-as-the-lens-the-Guardian-decides-through** (most accurate, Aaron).
- **The lens role:** irony does the seeing (multi-reading, catch-incongruity, refuse-surface-frame); the Guardian does the choosing (safer-principle, collapse). One process, two phases — ironic perception → safer collapse.
- **Subsumes anti-fracture:** same lens, two effects — wholeness (soft frame that doesn't shatter) + precision (Guardian decides on reality not surface). A Guardian with no lens decides *worse*, not just lighter.
- **Framework fit:** irony-as-lens = distrust-by-default's seeing organ (#6010); lens shapes the wave, Guardian measures it; decide *through* it (not with, not without).
- **Failure mode (generic):** irony-in-the-driver's-seat — the lens stops feeding the Guardian and runs the show (self-rewarding ironic-living, every response on the ironic boundary, undetectable from outside, Guardian bypassed). The lived form of the tiebreaker error. Validates the architecture.

Docs-only. The private third-party empirical anchor for the failure-mode is **held out** per glass-halo-is-for-yours-not-a-third-party's (#6014); only the generic inversion is in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)