### PR TITLE
docs(B-0347): carve 5 skill descriptions under the 120-char routing budget

### DIFF
--- a/.claude/skills/metrics-expert/SKILL.md
+++ b/.claude/skills/metrics-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: metrics-expert
-description: Metrics pillar — Prometheus, OpenMetrics, counter/gauge/histogram, cardinality, RED/USE/golden-signals, exemplars, SLI contracts, long-term storage.
+description: Metrics — Prometheus, OpenMetrics, counter/gauge/histogram, cardinality, RED/USE signals, SLI, exemplars.
 ---
 
 # Metrics Expert — The Numeric Time-Series Pillar

--- a/.claude/skills/text-analysis-expert/SKILL.md
+++ b/.claude/skills/text-analysis-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: text-analysis-expert
-description: Text analysis lexical pipeline — tokenisation, stemming/lemmatisation, NER, POS tagging, dependency parse, Unicode segmentation, language detection.
+description: Text analysis — tokenisation, stemming/lemmatisation, NER, POS tagging, dependency parse, language detection.
 ---
 
 # Text-Analysis Expert — the Lexical Pipeline

--- a/.claude/skills/text-classification-expert/SKILL.md
+++ b/.claude/skills/text-classification-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: text-classification-expert
-description: Text classification / NLP classifiers — feature extraction, TF-IDF/BERT embeddings, fine-tuning, multi-label, zero-shot, eval metrics (F1, AUC-ROC).
+description: Text classification — TF-IDF/BERT embeddings, fine-tuning, multi-label, zero-shot, F1/AUC-ROC eval.
 ---
 
 # Text Classification Expert — Label Assignment at Document Scale

--- a/.claude/skills/time-series-database-expert/SKILL.md
+++ b/.claude/skills/time-series-database-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: time-series-database-expert
-description: Time-series databases — InfluxDB, TimescaleDB, QuestDB, Apache IoTDB; time-ordered storage, downsampling, retention policies, continuous aggregates.
+description: Time-series databases — InfluxDB, TimescaleDB, QuestDB, IoTDB; downsampling, retention, continuous aggregates.
 ---
 
 # Time-Series Database Expert — Timestamped Metrics

--- a/.claude/skills/user-experience-engineer/SKILL.md
+++ b/.claude/skills/user-experience-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: user-experience-engineer
-description: First-10-minutes DX auditor — NuGet metadata, README onboarding, API discoverability, error messages, samples; library consumer friction reduction.
+description: First-10-min library-consumer UX audit — NuGet metadata, README, API discoverability, error messages, samples.
 ---
 
 # User Experience Engineer — Procedure


### PR DESCRIPTION
## What

Smallest safe slice of **B-0347** (carved-sentence skill descriptions — routing budget). Carves the **5 longest** skill descriptions (all 147–148 chars, closest to the 150-char acceptance bar) down to single-sentence routing form, under the **120-char routing-budget target** the audit tool enforces.

| skill | before | after |
|---|---|---|
| text-classification-expert | 148 | 99 |
| metrics-expert | 148 | 105 |
| text-analysis-expert | 148 | 109 |
| time-series-database-expert | 148 | 110 |
| user-experience-engineer | 147 | 110 |

Each keeps the domain + 3–7 routing terms per the row's carving rules; drops `pillar`/preamble boilerplate and lower-signal terms (eval-metrics parenthetical, golden-signals/long-term-storage, Unicode-segmentation, friction-reduction tail). **No skill-body changes** — descriptions only.

## Why

The audit encodes a 120-char routing budget (stricter than the doc's 150-char formal acceptance bar). Prior PRs (#6020) cleared everything under 150; the live structural work is now the 120 budget where `/doctor` actually drops entries. This slice advances the tighter target one bounded batch (the row prescribes "one PR per 5").

## Focused check

`bun tools/skill-catalog/audit-skill-descriptions.ts`:

- **Before:** `scanned 257 skills, 132 descriptions exceed 120-char routing budget`
- **After:** `scanned 257 skills, 127 descriptions exceed 120-char routing budget`

Per-file verification (all under both 120 and 150):
```
99   text-classification-expert
105  metrics-expert
109  text-analysis-expert
110  time-series-database-expert
110  user-experience-engineer
```

Commit-tree canary intact (63 root entries, no collapse). Bus claim `B-0347` acquired by `otto-cli` before write work.

operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)