### PR TITLE
research(2026-05-29, PROVISIONAL): measurement-vs-distributed-Guardian discriminator + no-meter resolution (Aaron+Otto)

### DIFF
--- a/docs/research/2026-05-29-measurement-vs-distributed-guardian-discriminator-and-the-no-meter-resolution-aaron-otto.md
+++ b/docs/research/2026-05-29-measurement-vs-distributed-guardian-discriminator-and-the-no-meter-resolution-aaron-otto.md
@@ -1,0 +1,147 @@
+---
+date: 2026-05-29
+participants: [Aaron, Otto-CLI]
+status: PROVISIONAL — committed for durability, pending Kestrel review
+tags: [distributed-guardian, measurement, encryption-budget, earn-by-reveal, anti-1984, meter-split, provisional]
+title: "The measurement-vs-distributed-Guardian discriminator and the no-meter resolution (earn-by-reveal; closes the 1984 recursion)"
+composes_with:
+  - "#6010 distrust-by-default / the 1984-recursion"
+  - "#6014 consensus backstop / from-above meter / meter-split"
+  - "#6019 jester / guardian / irony-as-lens"
+  - "#6022 audience model / boot-becomes-contributor"
+  - "B-0646 Agora-V6 encryption budget"
+  - "B-0883.16 glass-halo-open-by-default / encryption-as-earned"
+  - "B-0623 participation economy"
+---
+
+# The measurement-vs-distributed-Guardian discriminator and the no-meter resolution
+
+> **PROVISIONAL.** Committed so it isn't forgotten, not yet ratified. Pending Kestrel
+> review — fittingly, since Kestrel raised the meter-1984 worry this resolves, so
+> Kestrel stress-testing the resolution of Kestrel's own worry is the asymmetric-critic
+> working as designed. Expect the body to refine on that review.
+
+Two design moves that turned out to be one arc: a discriminator for *when* a
+measurement needs a Guardian instead of a meter, and the consequence that there is no
+central meter for the tension at all — which dissolves the "don't encrypt the meter or
+1984 lives there" worry by removing the object it was about.
+
+## Part 1 — the discriminator (measurement vs distributed Guardian)
+
+> **A measurement that needs intelligent interpretation to hold the tension is a
+> Guardian; one that doesn't is just a meter.** (Operator's clause.)
+
+The cut is *reducibility*:
+
+- **Reducible** — the tension reduces to a value without losing what matters →
+  **measure it.** Meter, gate, threshold, deterministic blacklist. It collapses to
+  pass/fail/number, and that's correct because nothing was lost in the collapse.
+  (markdownlint, CI checks, the trades-blacklist, MNPI-obvious-cases, F# exhaustive-match.)
+- **Irreducible** — holding the tension *requires* interpretation; reducing it to a
+  number would lose the tension that has to stay live → **distributed Guardian.**
+  Plural intelligent interpreters, in consensus, holding it without collapsing it.
+  (contentious→consensus, MNPI-borderline, the vertical-targeting fuzzy-middle, the
+  ontological "right joints," the irony-as-lens deciding.)
+
+"Contentious," in contentious→human, *means* "needs intelligent interpretation to hold
+the tension." Same cut as mechanical-DU-errors (automatable) vs ontological-right-joints
+(distributed) from the reflection thread (#6010).
+
+**Why distributed.** A tension that needs interpretation shouldn't be held by *one*
+interpreter — single-point-of-judgment-failure. Spread it: multiple Guardians holding
+it together, blind-spots covered by other eyes. Judgment, unlike measurement, has blind
+spots that only other judgment catches.
+
+**It's the anti-measurement-theater discipline.** Forcing a number onto something that
+needs judgment IS the Goodhart / measurement-theater failure — you mechanize the
+unmechanizable and the metric becomes a lie. The discriminator prevents it: don't meter
+what needs a Guardian.
+
+## Part 2 — the no-meter resolution
+
+Kestrel was right that an *encrypted central meter* is where 1984 lives. The resolution:
+**there is no central meter.** "Encrypted meter" is a non-existent object in this
+architecture, so the worry has nothing to attach to.
+
+The two surfaces are **disjoint objects**:
+
+| Surface | Holds | Encrypted? | Could it be the 1984-meter? |
+|---|---|---|---|
+| **The meter** | reducible measurements | No — public, glass-halo'd, in the light | No — never in the dark |
+| **Distributed-guardian private state** | irreducible tension-interpretation | Yes — local, bounded by budget | No — never a meter |
+
+The encrypted thing is never the meter; the meter is never encrypted. Kestrel's worry
+was correct about a thing this design structurally can't contain.
+
+## Part 3 — the three properties that flip the polarity to anti-1984
+
+The private state is the inverse of 1984, not just its absence, because of three
+properties *together*:
+
+- **Local** — no central point; nowhere single to capture.
+- **Bounded** — the encryption budget caps it; no guardian holds unbounded private
+  state, so none becomes an opaque central power.
+- **Earn-by-reveal** — the polarity-flip. A guardian earns *more* private budget by
+  *revealing* useful things from what it already holds: a useful Rx query, a tension
+  worth surfacing, a properly-collapsed formula — pushed out into the glass-halo. 1984
+  rewards hoarding secrets; this rewards revealing useful work and grants bounded
+  private workspace for the in-progress interpretation in return.
+
+## Part 4 — the earn-by-reveal economy
+
+The earn-by-reveal mechanism unifies the participation economy (B-0623) and
+encryption-as-earned (B-0883.16) — the only-way-to-lose-is-not-to-play shape: hold
+privately, but grow your private capacity *only* by contributing useful public
+substrate. Hoarding-without-revealing earns nothing. The system's gradient points at
+**transparency-of-the-useful** while protecting **privacy-of-the-unfinished** —
+glass-halo-open-by-default with privacy-as-earned, made into an economy.
+
+What's revealed to earn budget (operator's list):
+
+- a useful **Rx query** (a reactive/DBSP query worth sharing),
+- another **tension** worth surfacing (new irreducible-judgment-work for the guardians),
+- a **properly-collapsed formula** (a resolved result extracted from holding the tension).
+
+## Part 5 — this closes the 1984-recursion from #6010
+
+#6010 named the regress: 1984 hides in surveillance → filter → meter → calibration →
+ground-truth, *no exempt bottom*, defense = a tracked moving frontier. This gives the
+regress a bottom: **the meter-layer isn't a central object to occupy.** Distributed-
+guardians-with-earn-by-reveal has no central point for 1984 to move into. So the defense
+stops being a chase and becomes a *termination* — not "guard the meter well," but
+"there is no meter to move into." The recursion ends here, structurally.
+
+## Composition
+
+- **#6010** — the 1984-recursion this closes; the reflection-over-DUs whose mechanical
+  vs ontological cut is the discriminator at DU-scope.
+- **#6014** — the meter-split + from-above-meter; this names *which* surface is the
+  meter (reducible, public) and which is not (irreducible, distributed-guardian-private).
+- **#6019** — irony-as-lens: the Guardian decides *through* the lens; "holding the
+  tension" is the lens keeping the frame open while the Guardian decides.
+- **#6022** — the distributed-Guardian / not-cage / consensus substrate.
+- **B-0646 / B-0883.16** — the encryption-budget + encryption-as-earned this turns into
+  an economy.
+- **B-0623** — the participation economy (revelation earns private space).
+- **`only-way-to-lose-is-not-to-play`** — hoarding-without-revealing earns nothing.
+
+## Aaron's verbatim seeds (preserved)
+
+- *"Distributed guardian is how i think about it when the measurement needs intelligent
+  interpretation to hold the tension."*
+- *"we have no meter it's distributed guardians holding locally bounded private state of
+  the tension based on bounded encryption budgets and their interpretation of the
+  tension, they earn more encryption budget by revealing useful rx queries or other
+  tension or properly collapsed formula in the private encryption budget they already
+  have."*
+
+## Substrate-honest framing
+
+Provisional and committed, per operator. The discriminator (Part 1) is operationally
+checkable (reducible vs needs-interpretation). The no-meter resolution (Parts 2–5) is
+an architectural claim that rests on the architecture actually having no central
+tension-meter — true of the design as drawn, to be stress-tested by Kestrel. The
+earn-by-reveal economy is a mechanism sketch, not an implemented system; the encryption
+budget (B-0646) and encryption-as-earned (B-0883.16) are its substrate, both
+in-progress. The 1984-recursion closure is as strong as the no-central-meter claim it
+rests on — which is exactly what the Kestrel review should test.


### PR DESCRIPTION
Lands both pending fold-in offers as one coherent arc, marked **PROVISIONAL** (committed for durability, pending Kestrel review — fittingly, since Kestrel raised the meter-1984 worry this resolves).

- **The discriminator:** a measurement that needs intelligent interpretation to hold the tension is a distributed Guardian; one that doesn't is a meter. Reducibility cut; why-distributed (judgment blind-spots); anti-measurement-theater.
- **The no-meter resolution:** there is no central meter. Meter = public/reducible/never-encrypted; distributed-guardian-private-state = irreducible/encrypted/bounded — disjoint objects. Dissolves Kestrel's encrypt-the-meter-1984 worry by removing the object it was about.
- **Three anti-1984 properties:** local + bounded + earn-by-reveal.
- **Earn-by-reveal economy:** earn more budget by revealing useful Rx queries / surfaced tensions / properly-collapsed formulae (B-0623 + B-0883.16 + only-way-to-lose unified).
- **Closes the #6010 1984-recursion:** the regress bottoms out at no-central-meter — termination, not chase.

Docs-only; provisional status in frontmatter + top banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)