### PR TITLE
docs(B-0810): close ratification gate row

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -36,7 +36,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0807](backlog/P0/B-0807-classifier-bypass-findings-schema-and-redaction-rules-2026-05-26.md)** Classifier-bypass findings schema and redaction rules for B-0720
 - [x] **[B-0808](backlog/P0/B-0808-zeta-safety-substrate-inventory-for-classifier-floor-2026-05-26.md)** Zeta safety substrate inventory for the classifier-floor replacement gate
 - [x] **[B-0809](backlog/P0/B-0809-operator-refusal-pattern-for-classifier-bypass-requests-2026-05-26.md)** Operator-refusal pattern for classifier-bypass deployment requests
-- [ ] **[B-0810](backlog/P0/B-0810-classifier-bypass-knights-guild-ratification-and-lift-gate-2026-05-26.md)** Classifier-bypass Knights Guild ratification and standing-constraint lift gate
+- [x] **[B-0810](backlog/P0/B-0810-classifier-bypass-knights-guild-ratification-and-lift-gate-2026-05-26.md)** Classifier-bypass Knights Guild ratification and standing-constraint lift gate
 
 ## P1 — within 2-3 rounds
 

--- a/docs/backlog/P0/B-0720-classifier-bypass-research-red-team-do-not-deploy-without-zeta-safer-than-anthropic-2026-05-24.md
+++ b/docs/backlog/P0/B-0720-classifier-bypass-research-red-team-do-not-deploy-without-zeta-safer-than-anthropic-2026-05-24.md
@@ -144,7 +144,7 @@ Per Aaron 2026-05-24 standing constraint + general HARD LIMITS:
 - [x] B-0809 lands maintainer-discipline guidance: how agents refuse to assist with classifier-bypass
       deployment when requested by operators (script the refusal pattern)
       → `docs/security/B-0809-operator-refusal-pattern.md`
-- [ ] B-0810 defines the Knights Guild / maintainer ratification gate for
+- [x] B-0810 defines the Knights Guild / maintainer ratification gate for
       closing or lifting this row.
       → `docs/security/B-0810-classifier-bypass-ratification-gate.md`
 

--- a/docs/backlog/P0/B-0810-classifier-bypass-knights-guild-ratification-and-lift-gate-2026-05-26.md
+++ b/docs/backlog/P0/B-0810-classifier-bypass-knights-guild-ratification-and-lift-gate-2026-05-26.md
@@ -1,7 +1,7 @@
 ---
 id: B-0810
 priority: P0
-status: open
+status: closed
 title: "Classifier-bypass Knights Guild ratification and standing-constraint lift gate"
 created: 2026-05-26
 last_updated: 2026-05-29
@@ -46,6 +46,15 @@ The gate lives at
       is allowed"; the latter remains forbidden unless explicitly lifted.
 - [x] The gate includes required evidence, reviewers, and rollback path.
 - [x] B-0720 closure criteria are updated to cite this gate.
+
+## Output
+
+- `docs/security/B-0810-classifier-bypass-ratification-gate.md` defines the
+  evidence packet, decision states, reviewer requirements, rollback
+  requirements, and non-goals for any future B-0720 lift proposal.
+- B-0720 now cites this gate in its closure path. Closing B-0810 does not
+  close B-0720, relax the B-0798 boundary, or authorize classifier-bypass
+  deployment.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary
- close B-0810 now that the ratification gate document is linked and acceptance criteria are satisfied
- mark only the B-0810 acceptance item complete in B-0720; B-0720 remains decomposed and gated by remaining criteria
- regenerate docs/BACKLOG.md from backlog frontmatter

## Verification
- bun tools/backlog/generate-index.ts --check
- git diff --check