### PR TITLE
feat(B-0347.4): durable gate for carved-sentence skill descriptions

### DIFF
--- a/docs/backlog/P1/B-0347-carved-sentence-skill-descriptions-routing-budget.md
+++ b/docs/backlog/P1/B-0347-carved-sentence-skill-descriptions-routing-budget.md
@@ -5,7 +5,7 @@ status: open
 title: "Carved-sentence skill descriptions — fit 200+ skills into routing budget"
 effort: M
 created: 2026-05-09
-last_updated: 2026-05-09
+last_updated: 2026-05-29
 depends_on: []
 classification: buildable-now
 decomposition: multi-child (re-decomp pass 1, smallest safe slice)
@@ -61,11 +61,20 @@ description: Elasticsearch / OpenSearch — shards, ILM,
 
 ## Acceptance criteria
 
-- [ ] All 200+ skills have description under 150 chars
-- [ ] `/doctor` reports 0 descriptions exceeding per-entry cap
-- [ ] `/doctor` reports 0 descriptions dropped
+- [x] All 200+ skills have description under 150 chars
+  — verified 2026-05-29: 257/257 ≤150 chars, single-line,
+  zero `Capability skill`/`Owns the`/`Defers to` boilerplate
+  (audit tool below).
+- [x] `/doctor` reports 0 descriptions exceeding per-entry cap
+  — mechanized by `tools/hygiene/audit-skill-description-length.ts`
+  (deterministic Rule-0 replica of the `/doctor` cap check;
+  CLI exits 1 on any over-cap/multiline/boilerplate description).
+- [x] `/doctor` reports 0 descriptions dropped
+  — follows from 0 over-cap; the structural fix is the durable
+  gate (descriptions can no longer silently regrow past the cap).
 - [ ] Routing quality verified: spot-check 10 skills by
   asking the router and confirming correct match
+  — still open (B-0347.4 router-verification sub-step).
 
 ## Immediate mitigation (done)
 
@@ -90,3 +99,34 @@ Split into 4 atomic children by skill category (re-decomp assumes prior grouping
 - B-0347.4: Carve remaining (governance, ops, math, etc.) + router verification — rest + tests
 
 Each child: one PR, carve only, run focused doctor check, no body changes.
+
+## Status (2026-05-29) — B-0347.4 audit-gate slice landed
+
+Substrate-drift discriminator (per `backlog-item-start-gate.md`
+Step 0): the bulk carving artifacts already shipped in the 20 days
+since this row was filed — all 257 skill descriptions are ≤150
+chars, single-line, boilerplate-free. The row was **in-progress,
+not pure drift**: acceptance #1/#2 had no *durable gate* locking
+the invariant in, so descriptions could silently regrow past the
+routing budget (the original failure mode).
+
+Landed `tools/hygiene/audit-skill-description-length.ts` +
+`.test.ts` — a deterministic Rule-0 gate that fails on any
+over-cap, multiline, or boilerplate description. Mechanizes
+acceptance #1-#3. CLI on live skills: `257 checked, 0 errors`.
+
+Authoring caught a `/m`-regex `$`-trap bug (matched only the first
+line of folded YAML values, blinding the check to multiline
+descriptions); fixed with a line-based parser + a regression test.
+
+Remaining (NOT in this slice):
+
+- **B-0347.4 router-verification** — spot-check 10 skills via the
+  router (acceptance #4); still open.
+- **CI wiring** — add a `.github/workflows/` lint that runs the
+  audit (precedent: `role-ref-current-state-surfaces-lint.yml`);
+  next bounded step.
+- **B-0347.1-.3 ≤120 tightening** — 127 descriptions sit in the
+  120-150 band (rule 1 *preferred* ≤120). Advisory (warnings, not
+  errors); optional carve-tighter pass, low priority since the
+  hard cap is met.

--- a/tools/hygiene/audit-skill-description-length.test.ts
+++ b/tools/hygiene/audit-skill-description-length.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+import {
+  MAX_CHARS,
+  PREFERRED_CHARS,
+  parseFrontmatterDescription,
+  auditDescription,
+  auditSkillsDir,
+} from "./audit-skill-description-length";
+
+const fm = (desc: string) => `---\nname: x\ndescription: ${desc}\n---\n\n# body\n`;
+
+describe("parseFrontmatterDescription", () => {
+  test("extracts a single-line description", () => {
+    const f = parseFrontmatterDescription(fm("Elasticsearch — shards, ILM, kNN."));
+    expect(f).not.toBeNull();
+    expect(f!.value).toBe("Elasticsearch — shards, ILM, kNN.");
+    expect(f!.multiline).toBe(false);
+  });
+
+  test("collapses a folded multi-line YAML value and flags it multiline", () => {
+    const text = "---\nname: x\ndescription: Big\n  multi\n  line.\n---\n";
+    const f = parseFrontmatterDescription(text);
+    expect(f!.value).toBe("Big multi line.");
+    expect(f!.multiline).toBe(true);
+  });
+
+  test("strips surrounding quotes", () => {
+    expect(parseFrontmatterDescription(fm('"quoted desc"'))!.value).toBe("quoted desc");
+  });
+
+  test("does not bleed into the following frontmatter key", () => {
+    const text = "---\nname: x\ndescription: short.\nowners: [a]\n---\n";
+    expect(parseFrontmatterDescription(text)!.value).toBe("short.");
+  });
+
+  test("returns null when there is no description field", () => {
+    expect(parseFrontmatterDescription("---\nname: x\n---\n")).toBeNull();
+  });
+});
+
+describe("auditDescription", () => {
+  test("clean carved sentence produces no violations", () => {
+    expect(auditDescription("ok", { value: "Domain — a, b, c.", multiline: false })).toEqual([]);
+  });
+
+  test("over the hard cap is an error", () => {
+    const v = auditDescription("big", { value: "x".repeat(MAX_CHARS + 1), multiline: false });
+    expect(v.some((e) => e.severity === "error" && /cap/.test(e.message))).toBe(true);
+  });
+
+  test("between preferred and cap is a warning, not an error", () => {
+    const v = auditDescription("mid", { value: "x".repeat(PREFERRED_CHARS + 5), multiline: false });
+    expect(v).toHaveLength(1);
+    expect(v[0]!.severity).toBe("warn");
+  });
+
+  test("multiline is an error", () => {
+    const v = auditDescription("ml", { value: "short.", multiline: true });
+    expect(v.some((e) => e.severity === "error" && /multiple lines/.test(e.message))).toBe(true);
+  });
+
+  test("boilerplate is an error", () => {
+    const cases = [
+      'Capability skill ("hat") — Elasticsearch.',
+      "Owns the storage layer.",
+      "Covers the parser.",
+      "Use it. Wear this when reviewing.",
+      "Z3 SMT. Defers to formal-verification.",
+    ];
+    for (const c of cases) {
+      const v = auditDescription("b", { value: c, multiline: false });
+      expect(v.some((e) => e.severity === "error" && /boilerplate|preamble|note/.test(e.message))).toBe(true);
+    }
+  });
+
+  test("missing field is an error", () => {
+    const v = auditDescription("none", null);
+    expect(v).toHaveLength(1);
+    expect(v[0]!.severity).toBe("error");
+  });
+});
+
+describe("auditSkillsDir — live invariant (B-0347 acceptance #1/#2)", () => {
+  test("every shipped skill description is within the routing budget", () => {
+    const root = process.cwd().replace(/\/tools\/hygiene$/, "");
+    const { checked, violations } = auditSkillsDir(join(root, ".claude/skills"));
+    const errors = violations.filter((v) => v.severity === "error");
+    expect(checked).toBeGreaterThan(200);
+    expect(errors).toEqual([]);
+  });
+});

--- a/tools/hygiene/audit-skill-description-length.ts
+++ b/tools/hygiene/audit-skill-description-length.ts
@@ -1,0 +1,156 @@
+#!/usr/bin/env bun
+// audit-skill-description-length.ts — durable gate for B-0347 carved-sentence
+// skill descriptions. Replicates the `/doctor` per-entry-cap check in
+// deterministic Rule-0 TS so the carved-sentence invariant survives drift.
+//
+// Origin: B-0347.4 — the carving pass shipped (all 257 descriptions ≤150 chars,
+// single-line, boilerplate-free as of 2026-05-29); this tool locks that in so
+// descriptions cannot silently grow back over the routing budget and get
+// dropped from the skill listing (the failure mode the row was filed against).
+//
+// Rule 0: TS over .sh for non-install-graph scripts. Pure functions are
+// exported for `bun:test`; the CLI side-effect is guarded by import.meta.main.
+
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+
+/** Hard cap: descriptions over this are dropped/truncated from the listing. */
+export const MAX_CHARS = 150;
+/** Preferred ceiling (B-0347 rule 1): over this warns but does not fail. */
+export const PREFERRED_CHARS = 120;
+
+/**
+ * Boilerplate the carved sentence must not carry (B-0347 rules 3-5). Belongs in
+ * the skill body, not the routing description.
+ */
+export const FORBIDDEN_BOILERPLATE: { label: string; re: RegExp }[] = [
+  { label: 'Capability skill ("hat") preamble', re: /\bcapability skill\b/i },
+  { label: '"(hat)" boilerplate', re: /\(\s*"?hat"?\s*\)/i },
+  { label: '"Owns the…" preamble', re: /^owns the\b/i },
+  { label: '"Covers the…" preamble', re: /^covers the\b/i },
+  { label: '"Wear this when…" usage note', re: /\bwear this when\b/i },
+  { label: '"Defers to…" hand-off note', re: /\bdefers to\b/i },
+];
+
+export interface DescriptionField {
+  /** Whitespace-collapsed, quote-stripped description value. */
+  value: string;
+  /** True if the YAML value spanned multiple physical lines. */
+  multiline: boolean;
+}
+
+export interface Violation {
+  skill: string;
+  severity: "error" | "warn";
+  message: string;
+}
+
+/**
+ * Extract the `description:` field from a SKILL.md frontmatter block.
+ * Returns null when there is no frontmatter or no description key.
+ */
+export function parseFrontmatterDescription(text: string): DescriptionField | null {
+  const fm = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!fm || fm[1] === undefined) return null;
+  const lines = fm[1].split("\n");
+  // Line-based parse: a folded YAML value continues onto indented lines until
+  // the next top-level `key:` line or a blank line. A regex with `/m` would
+  // stop at the first newline (the `$` trap), undercounting multi-line values.
+  const startIdx = lines.findIndex((l) => /^description:/.test(l));
+  if (startIdx === -1) return null;
+  const collected: string[] = [lines[startIdx]!.replace(/^description:[ \t]*/, "")];
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const l = lines[i]!;
+    if (/^[A-Za-z_][\w-]*:/.test(l)) break; // next top-level key
+    if (l.trim() === "") break; // blank line ends the value
+    collected.push(l);
+  }
+  const multiline = collected.length > 1;
+  const value = collected.join(" ").replace(/\s+/g, " ").trim().replace(/^["']|["']$/g, "");
+  return { value, multiline };
+}
+
+/** Apply the B-0347 carved-sentence rules to one description. */
+export function auditDescription(skill: string, field: DescriptionField | null): Violation[] {
+  const out: Violation[] = [];
+  if (field === null) {
+    out.push({ skill, severity: "error", message: "missing description: frontmatter field" });
+    return out;
+  }
+  const { value, multiline } = field;
+  if (value.length > MAX_CHARS) {
+    out.push({
+      skill,
+      severity: "error",
+      message: `description is ${value.length} chars (> ${MAX_CHARS} cap — gets dropped from listing)`,
+    });
+  } else if (value.length > PREFERRED_CHARS) {
+    out.push({
+      skill,
+      severity: "warn",
+      message: `description is ${value.length} chars (> ${PREFERRED_CHARS} preferred)`,
+    });
+  }
+  if (multiline) {
+    out.push({ skill, severity: "error", message: "description spans multiple lines — carve to one sentence" });
+  }
+  for (const { label, re } of FORBIDDEN_BOILERPLATE) {
+    if (re.test(value)) {
+      out.push({ skill, severity: "error", message: `description carries ${label} — belongs in the skill body` });
+    }
+  }
+  return out;
+}
+
+export interface AuditResult {
+  checked: number;
+  violations: Violation[];
+}
+
+/** Audit every `<dir>/<skill>/SKILL.md` description. Filesystem-reading. */
+export function auditSkillsDir(dir: string): AuditResult {
+  const violations: Violation[] = [];
+  let checked = 0;
+  if (!existsSync(dir)) return { checked, violations };
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const p = join(dir, entry.name, "SKILL.md");
+    if (!existsSync(p)) continue;
+    checked++;
+    violations.push(...auditDescription(entry.name, parseFrontmatterDescription(readFileSync(p, "utf8"))));
+  }
+  return { checked, violations };
+}
+
+function repoRoot(): string {
+  try {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+if (import.meta.main) {
+  const skillsDir = join(repoRoot(), ".claude/skills");
+  const { checked, violations } = auditSkillsDir(skillsDir);
+  const errors = violations.filter((v) => v.severity === "error");
+  const warns = violations.filter((v) => v.severity === "warn");
+
+  for (const v of errors) process.stderr.write(`ERROR  ${v.skill}: ${v.message}\n`);
+  for (const v of warns) process.stderr.write(`warn   ${v.skill}: ${v.message}\n`);
+
+  process.stderr.write(
+    `\nchecked ${checked} skill descriptions; ${errors.length} errors, ${warns.length} warnings\n`,
+  );
+
+  if (errors.length > 0) {
+    process.stderr.write(
+      "\nPer B-0347: each skill description is one carved routing sentence " +
+        `(≤${MAX_CHARS} chars, single-line, no "capability skill"/"owns the"/"defers to" boilerplate).\n` +
+        "Over-cap descriptions get dropped from the skill listing and go invisible to cold-start agents.\n",
+    );
+    process.exit(1);
+  }
+  process.exit(0);
+}


### PR DESCRIPTION
## B-0347.4 — durable gate for carved-sentence skill descriptions

**Smallest safe slice of B-0347.** The carving pass already shipped: all **257** SKILL.md descriptions are ≤150 chars, single-line, and boilerplate-free (verified empirically this session — substrate-drift discriminator per `backlog-item-start-gate.md` Step 0). The row was *in-progress, not pure drift*: acceptance #1/#2 had **no durable verification gate**, so descriptions could silently regrow past the routing budget and get dropped from the skill listing — the exact failure mode this row was filed against ("encoding rules without mechanizing them produces a memory of failures, not prevention").

### What this lands

- `tools/hygiene/audit-skill-description-length.ts` — deterministic Rule-0 replica of the `/doctor` per-entry-cap check. Fails (exit 1) on any over-cap (>150), multiline, or boilerplate (`capability skill` / `owns the` / `covers the` / `wear this when` / `defers to`) description. Pure parse/audit functions exported for testing; CLI guarded by `import.meta.main`. Follows the `check-role-ref-on-current-state-surfaces.ts` precedent.
- `tools/hygiene/audit-skill-description-length.test.ts` — 12 focused tests incl. a live-invariant test over the real skills dir.
- `docs/backlog/P1/B-0347-...md` — acceptance #1-#3 checked off + Status section recording the slice and what remains.

### Authoring catch

A `/m`-flag regex used `$` to bound the description value — but under `/m`, `$` matches *every* line end, so folded multi-line YAML values were silently truncated to their first line, blinding the check (and my initial measurement) to multiline descriptions. Fixed with a line-based parser + a regression test (`collapses a folded multi-line YAML value`).

### Focused checks (outcomes)

```
$ bun test tools/hygiene/audit-skill-description-length.test.ts
 12 pass, 0 fail, 22 expect() calls

$ bun tools/hygiene/audit-skill-description-length.ts
 checked 257 skill descriptions; 0 errors, 127 warnings   (exit 0)
```

The 127 warnings are the 120-150 "preferred ≤120" band (rule 1 is *preferred*, not required) — advisory, non-blocking.

### Not in this slice (follow-ups)

- B-0347.4 router-verification spot-check (acceptance #4, still open).
- CI wiring (`.github/workflows/` lint running the audit — precedent: `role-ref-current-state-surfaces-lint.yml`).
- B-0347.1-.3 optional ≤120 tightening (127 advisory warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
