### PR TITLE
feat(B-0354.1): static structural validator for bootstrap CLAUDE.md

### DIFF
--- a/docs/backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md
+++ b/docs/backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md
@@ -4,7 +4,7 @@ priority: P1
 status: open
 title: "Fresh-instance validation test for bootstrap CLAUDE.md"
 created: 2026-05-09
-last_updated: 2026-05-09
+last_updated: 2026-05-29
 depends_on:
   - B-0353
 decomposition: multi-child (re-decomp pass 1, smallest safe slice)
@@ -80,4 +80,4 @@ file. Load-bearing invariant is structural (6-step process + rules auto-load sur
 so conciseness is a SOFT `--max-lines` warn (default 150), not a hard fail.
 
 Remaining: **B-0354.2** (execute minimal validation), **B-0354.3** (document findings
-+ file gap children, update parent B-0329).
+and file gap children, update parent B-0329).

--- a/docs/backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md
+++ b/docs/backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md
@@ -63,3 +63,21 @@ Re-decomp assumes prior "atomic" classification was mistaken (test protocol is i
 - B-0354.3: Document findings + file any gap children; update parent B-0329
 
 Each child: one PR, run `bun` checks + build gate, no broad test execution yet.
+
+## Progress
+
+**B-0354.1 landed (2026-05-29, otto-cli bg-worker):** static structural-validation
+harness skeleton at `tools/bootstrap-validator/validate-bootstrap-claude-md.ts`
+(+ `.test.ts`, 15 tests pass). Checks: CLAUDE.md exists; 6-step bootstrap process
+present (`## 1.`..`## 6.`); `.claude/rules/` auto-load surface non-empty; conciseness
+(soft warn). CLI flags `--json` / `--root` / `--max-lines` / `--help`; exit codes
+0 pass / 1 usage / 3 fail. No Claude spawn (that is B-0354.2/.3).
+
+**Recalibration finding (assume-decomposition-has-mistakes):** the child sketch's
+"CLAUDE.md length <50" bound is empirically wrong — the live bootstrap CLAUDE.md is
+~76 lines and that IS the correct bootstrap form. Hard `<50` would fail a correct
+file. Load-bearing invariant is structural (6-step process + rules auto-load surface),
+so conciseness is a SOFT `--max-lines` warn (default 150), not a hard fail.
+
+Remaining: **B-0354.2** (execute minimal validation), **B-0354.3** (document findings
++ file gap children, update parent B-0329).

--- a/tools/bootstrap-validator/validate-bootstrap-claude-md.test.ts
+++ b/tools/bootstrap-validator/validate-bootstrap-claude-md.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  checkClaudeMdExists,
+  checkConciseness,
+  checkRulesAutoLoad,
+  checkSixStepProcess,
+  DEFAULT_MAX_LINES,
+  REQUIRED_STEP_NUMBERS,
+  runValidation,
+} from "./validate-bootstrap-claude-md";
+
+// A minimal well-formed bootstrap CLAUDE.md (the shape a fresh instance needs).
+const GOOD_BOOTSTRAP = [
+  "# CLAUDE.md — bootstrap",
+  "",
+  "## 1. Orient",
+  "Read AGENTS.md.",
+  "## 2. Refresh",
+  "Run the refresh tool.",
+  "## 3. Pick work",
+  "Open BACKLOG.md.",
+  "## 4. Build gate",
+  "dotnet build.",
+  "## 5. Ship",
+  "Open a PR.",
+  "## 6. When stuck",
+  "See CONFLICT-RESOLUTION.md.",
+  "## Conventions",
+  "- Agents, not bots.",
+].join("\n");
+
+describe("checkClaudeMdExists", () => {
+  test("pass when present", () => {
+    expect(checkClaudeMdExists(true).status).toBe("pass");
+  });
+  test("fail when absent", () => {
+    expect(checkClaudeMdExists(false).status).toBe("fail");
+  });
+});
+
+describe("checkSixStepProcess", () => {
+  test("pass when all 6 numbered sections present", () => {
+    const r = checkSixStepProcess(GOOD_BOOTSTRAP);
+    expect(r.status).toBe("pass");
+  });
+
+  test("fail when a section is missing", () => {
+    const missing4 = GOOD_BOOTSTRAP.split("\n")
+      .filter((l) => !l.startsWith("## 4."))
+      .join("\n");
+    const r = checkSixStepProcess(missing4);
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("## 4.");
+  });
+
+  test("does not count steps outside 1..6", () => {
+    const r = checkSixStepProcess("## 7. Extra\n## 1. A\n## 2. B");
+    expect(r.status).toBe("fail"); // only 1 and 2 present; 3-6 missing
+  });
+
+  test("requires a non-empty title after the number", () => {
+    // "## 3." with no title text should not satisfy the section.
+    const noTitle = GOOD_BOOTSTRAP.replace("## 3. Pick work", "## 3.");
+    expect(checkSixStepProcess(noTitle).status).toBe("fail");
+  });
+
+  test("REQUIRED_STEP_NUMBERS is exactly 1..6", () => {
+    expect([...REQUIRED_STEP_NUMBERS]).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});
+
+describe("checkRulesAutoLoad", () => {
+  test("pass when >=1 .md rule present", () => {
+    expect(checkRulesAutoLoad(["a.md", "README", "b.md"]).status).toBe("pass");
+  });
+  test("fail when no .md rules", () => {
+    expect(checkRulesAutoLoad([]).status).toBe("fail");
+    expect(checkRulesAutoLoad(["notes.txt"]).status).toBe("fail");
+  });
+});
+
+describe("checkConciseness", () => {
+  test("pass under soft ceiling", () => {
+    expect(checkConciseness(GOOD_BOOTSTRAP, DEFAULT_MAX_LINES).status).toBe("pass");
+  });
+  test("warn (not fail) over soft ceiling", () => {
+    const big = Array.from({ length: 200 }, (_, i) => `line ${i}`).join("\n");
+    const r = checkConciseness(big, DEFAULT_MAX_LINES);
+    expect(r.status).toBe("warn");
+  });
+  test("76-line bootstrap form passes default ceiling (recalibration anchor)", () => {
+    // The actual bootstrap CLAUDE.md is ~76 lines; the decomposition's <50
+    // bound would wrongly fail it. Conciseness must pass at default 150.
+    const seventySix = Array.from({ length: 76 }, (_, i) => `line ${i}`).join("\n");
+    expect(checkConciseness(seventySix, DEFAULT_MAX_LINES).status).toBe("pass");
+  });
+});
+
+describe("runValidation against the live repo root", () => {
+  // Resolve repo root from this test file's location:
+  // tools/bootstrap-validator/<file> -> repo root is two dirs up.
+  const here = fileURLToPath(import.meta.url);
+  const repoRoot = join(here, "..", "..", "..");
+
+  test("the live bootstrap CLAUDE.md passes all hard checks", () => {
+    const report = runValidation(repoRoot, DEFAULT_MAX_LINES);
+    // Self-validating: this slice ships only when the repo it ships into
+    // already satisfies the structural gate.
+    expect(report.ok).toBe(true);
+    expect(report.checks.find((c) => c.id === "claude-md-exists")?.status).toBe("pass");
+    expect(report.checks.find((c) => c.id === "six-step-process")?.status).toBe("pass");
+    expect(report.checks.find((c) => c.id === "rules-auto-load")?.status).toBe("pass");
+  });
+
+  test("fixture sanity: CLAUDE.md and .claude/rules/ are where we expect", () => {
+    expect(existsSync(join(repoRoot, "CLAUDE.md"))).toBe(true);
+    expect(readFileSync(join(repoRoot, "CLAUDE.md"), "utf8").length).toBeGreaterThan(0);
+  });
+
+  test("missing-CLAUDE.md root fails ok", () => {
+    const report = runValidation("/nonexistent-zeta-root-xyz", DEFAULT_MAX_LINES);
+    expect(report.ok).toBe(false);
+  });
+});

--- a/tools/bootstrap-validator/validate-bootstrap-claude-md.ts
+++ b/tools/bootstrap-validator/validate-bootstrap-claude-md.ts
@@ -1,0 +1,254 @@
+#!/usr/bin/env bun
+// validate-bootstrap-claude-md.ts — structural validator for the
+// bootstrap-only CLAUDE.md (B-0354.1, smallest safe slice of B-0354).
+//
+// WHAT THIS IS (and is NOT):
+//   This is the static structural-validation HARNESS SKELETON. It checks
+//   that the bootstrap CLAUDE.md has the shape a fresh Claude Code instance
+//   depends on:
+//     1. CLAUDE.md exists at the repo root.
+//     2. The 6-step bootstrap process is present (## 1. Orient ... ## 6.).
+//     3. The .claude/rules/ auto-load surface exists and is non-empty
+//        (the behavioral-rule discovery channel a fresh instance relies on).
+//     4. CLAUDE.md stays concise (a SOFT length bound; warn, not fail).
+//
+//   It does NOT spawn a real Claude session or run the representative-task
+//   protocol from B-0354 — that live execution is B-0354.2 (execute minimal
+//   validation) and B-0354.3 (document findings + file gap children). This
+//   slice ships only the static structural gate, runnable in CI without a
+//   model in the loop.
+//
+// RECALIBRATION NOTE (per "assume decomposition has mistakes"):
+//   The B-0354 re-decomposition row sketched check #4 as "CLAUDE.md length
+//   <50". That bound is empirically wrong: the current bootstrap CLAUDE.md is
+//   ~76 lines and that IS the correct bootstrap form (Sections 1-6 + a short
+//   Conventions block). A hard <50 would fail a correct file. The load-bearing
+//   invariant is STRUCTURAL (the 6-step process + the rules auto-load surface),
+//   not a magic line count. So conciseness is a SOFT warn against a generous
+//   ceiling (default 150), and section-presence + rules-presence are the hard
+//   fails. The threshold is a tunable --max-lines, not a buried constant.
+//
+// Usage:
+//   bun tools/bootstrap-validator/validate-bootstrap-claude-md.ts
+//   bun tools/bootstrap-validator/validate-bootstrap-claude-md.ts --json
+//   bun tools/bootstrap-validator/validate-bootstrap-claude-md.ts --root <path>
+//   bun tools/bootstrap-validator/validate-bootstrap-claude-md.ts --max-lines 150
+//   bun tools/bootstrap-validator/validate-bootstrap-claude-md.ts --help
+//
+// Exit codes:
+//   0 — all hard checks passed (warns are allowed)
+//   1 — usage error (bad args, or --help shown)
+//   3 — one or more hard checks FAILED (validation failure)
+//
+// Origin: B-0354.1. Convention-matched to tools/cold-start-check.ts
+// (shebang, leading-comment-as-help, --json, ESM-safe self-path, explicit
+// exit codes). Composes with the .claude/rules/ auto-load empirical anchor
+// (.claude/rules/test-canary.md) and the claude-code-loading-taxonomy rule.
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ESM-safe self-path (bun runs this file as ESM; no CommonJS __filename).
+const SELF_PATH = fileURLToPath(import.meta.url);
+
+export type CheckStatus = "pass" | "fail" | "warn";
+
+export interface CheckResult {
+  /** Stable machine-readable id for the check. */
+  id: string;
+  /** Whether this check is load-bearing (fail blocks) or advisory (warn only). */
+  status: CheckStatus;
+  /** Human-readable one-liner. */
+  detail: string;
+}
+
+/** The six numbered bootstrap-process sections a fresh instance follows. */
+export const REQUIRED_STEP_NUMBERS = [1, 2, 3, 4, 5, 6] as const;
+
+/** Default soft ceiling for CLAUDE.md line count (recalibrated; see header). */
+export const DEFAULT_MAX_LINES = 150;
+
+// ── Pure check functions (filesystem-free; directly unit-testable) ──────────
+
+/** #1 — CLAUDE.md must exist at the repo root. */
+export function checkClaudeMdExists(claudeMdPresent: boolean): CheckResult {
+  return claudeMdPresent
+    ? { id: "claude-md-exists", status: "pass", detail: "CLAUDE.md present at repo root" }
+    : { id: "claude-md-exists", status: "fail", detail: "CLAUDE.md MISSING at repo root" };
+}
+
+/**
+ * #2 — The 6-step bootstrap process must be present.
+ * Detects `## N. ...` H2 headings for N in 1..6. A fresh instance reads these
+ * to learn the Orient/Refresh/Pick/Build/Ship/Stuck loop.
+ */
+export function checkSixStepProcess(claudeMd: string): CheckResult {
+  const found = new Set<number>();
+  for (const line of claudeMd.split("\n")) {
+    const m = /^##\s+(\d+)\.\s+\S/.exec(line);
+    if (m) {
+      const n = Number(m[1]);
+      if (n >= 1 && n <= 6) found.add(n);
+    }
+  }
+  const missing = REQUIRED_STEP_NUMBERS.filter((n) => !found.has(n));
+  return missing.length === 0
+    ? {
+        id: "six-step-process",
+        status: "pass",
+        detail: "All 6 bootstrap-process sections present (## 1..## 6)",
+      }
+    : {
+        id: "six-step-process",
+        status: "fail",
+        detail: `Missing bootstrap-process section(s): ${missing.map((n) => `## ${n}.`).join(", ")}`,
+      };
+}
+
+/**
+ * #3 — The .claude/rules/ auto-load surface must exist and be non-empty.
+ * This is the behavioral-rule discovery channel a fresh instance depends on;
+ * if it is empty, doctrine extracted out of CLAUDE.md is lost.
+ */
+export function checkRulesAutoLoad(ruleFileNames: string[]): CheckResult {
+  const mdRules = ruleFileNames.filter((f) => f.endsWith(".md"));
+  return mdRules.length > 0
+    ? {
+        id: "rules-auto-load",
+        status: "pass",
+        detail: `.claude/rules/ auto-load surface present (${mdRules.length} rule file(s))`,
+      }
+    : {
+        id: "rules-auto-load",
+        status: "fail",
+        detail: ".claude/rules/ has no .md auto-load rules (behavioral doctrine unreachable)",
+      };
+}
+
+/**
+ * #4 — Conciseness is a SOFT bound (warn, not fail). See RECALIBRATION NOTE.
+ * Empty / whitespace-only CLAUDE.md is a separate hard concern handled by
+ * #1/#2; here we only flag bloat past the soft ceiling.
+ */
+export function checkConciseness(claudeMd: string, maxLines: number): CheckResult {
+  const lineCount = claudeMd.split("\n").length;
+  return lineCount <= maxLines
+    ? {
+        id: "conciseness",
+        status: "pass",
+        detail: `CLAUDE.md is ${lineCount} line(s) (<= soft ceiling ${maxLines})`,
+      }
+    : {
+        id: "conciseness",
+        status: "warn",
+        detail: `CLAUDE.md is ${lineCount} line(s) (> soft ceiling ${maxLines}); bootstrap may be drifting toward doctrine`,
+      };
+}
+
+// ── Filesystem runner ───────────────────────────────────────────────────────
+
+export interface ValidationReport {
+  root: string;
+  maxLines: number;
+  checks: CheckResult[];
+  /** true iff no check has status "fail". */
+  ok: boolean;
+}
+
+/**
+ * Run all structural checks against a repo root. Pure-ish: reads the
+ * filesystem but delegates every decision to the exported check functions
+ * above so the logic is unit-testable without a real repo.
+ */
+export function runValidation(root: string, maxLines: number): ValidationReport {
+  const claudeMdPath = join(root, "CLAUDE.md");
+  const rulesDir = join(root, ".claude", "rules");
+
+  const claudeMdPresent = existsSync(claudeMdPath);
+  const claudeMd = claudeMdPresent ? readFileSync(claudeMdPath, "utf8") : "";
+  const ruleFileNames = existsSync(rulesDir) ? readdirSync(rulesDir) : [];
+
+  const checks: CheckResult[] = [checkClaudeMdExists(claudeMdPresent)];
+  // Section + conciseness checks only meaningful when the file exists.
+  if (claudeMdPresent) {
+    checks.push(checkSixStepProcess(claudeMd));
+    checks.push(checkConciseness(claudeMd, maxLines));
+  }
+  checks.push(checkRulesAutoLoad(ruleFileNames));
+
+  const ok = !checks.some((c) => c.status === "fail");
+  return { root, maxLines, checks, ok };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+
+interface Args {
+  json: boolean;
+  help: boolean;
+  root: string;
+  maxLines: number;
+}
+
+function printHelp(): void {
+  const src = readFileSync(SELF_PATH, "utf8");
+  for (const line of src.split("\n")) {
+    if (line.startsWith("//")) console.log(line.replace(/^\/\/ ?/, ""));
+    else if (line.startsWith("#!")) continue;
+    else break;
+  }
+}
+
+function parseArgs(argv: string[]): Args | { error: string } {
+  const args: Args = { json: false, help: false, root: process.cwd(), maxLines: DEFAULT_MAX_LINES };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--json") args.json = true;
+    else if (a === "--help" || a === "-h") args.help = true;
+    else if (a === "--root") {
+      const v = argv[++i];
+      if (!v) return { error: "--root requires a path" };
+      args.root = v;
+    } else if (a === "--max-lines") {
+      const v = argv[++i];
+      const n = Number(v);
+      if (!Number.isFinite(n) || n <= 0) return { error: "--max-lines requires a positive integer" };
+      args.maxLines = n;
+    } else {
+      return { error: `unknown argument: ${a}` };
+    }
+  }
+  return args;
+}
+
+function main(): number {
+  const parsed = parseArgs(process.argv.slice(2));
+  if ("error" in parsed) {
+    console.error(`Error: ${parsed.error}`);
+    return 1;
+  }
+  if (parsed.help) {
+    printHelp();
+    return 1;
+  }
+
+  const report = runValidation(parsed.root, parsed.maxLines);
+
+  if (parsed.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    const glyph: Record<CheckStatus, string> = { pass: "✓", fail: "✗", warn: "!" };
+    console.log(`bootstrap CLAUDE.md validation — root: ${report.root}`);
+    for (const c of report.checks) {
+      console.log(`  ${glyph[c.status]} [${c.id}] ${c.detail}`);
+    }
+    console.log(report.ok ? "RESULT: PASS (no hard-check failures)" : "RESULT: FAIL");
+  }
+
+  return report.ok ? 0 : 3;
+}
+
+// Only run when invoked directly, not when imported by the test file.
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/tools/bootstrap-validator/validate-bootstrap-claude-md.ts
+++ b/tools/bootstrap-validator/validate-bootstrap-claude-md.ts
@@ -132,7 +132,10 @@ export function checkRulesAutoLoad(ruleFileNames: string[]): CheckResult {
  * #1/#2; here we only flag bloat past the soft ceiling.
  */
 export function checkConciseness(claudeMd: string, maxLines: number): CheckResult {
-  const lineCount = claudeMd.split("\n").length;
+  // Normalize CRLF and strip a single trailing newline so the line count
+  // is deterministic — a POSIX trailing newline must not over-count by 1
+  // and trip a false `warn` when CLAUDE.md is exactly `maxLines` lines.
+  const lineCount = claudeMd.replace(/\r\n/g, "\n").replace(/\n$/, "").split("\n").length;
   return lineCount <= maxLines
     ? {
         id: "conciseness",
@@ -207,12 +210,18 @@ function parseArgs(argv: string[]): Args | { error: string } {
     else if (a === "--help" || a === "-h") args.help = true;
     else if (a === "--root") {
       const v = argv[++i];
-      if (!v) return { error: "--root requires a path" };
+      // Reject a missing value AND a dash-prefixed next token (e.g.
+      // `--root --json`) so a usage error stays exit 1 rather than
+      // validating against a bogus `--json` root.
+      if (!v || v.startsWith("-")) return { error: "--root requires a path" };
       args.root = v;
     } else if (a === "--max-lines") {
       const v = argv[++i];
+      // Same dash-prefix guard; require a positive INTEGER (reject floats
+      // like `1.5` which `Number()` would otherwise accept).
+      if (!v || v.startsWith("-")) return { error: "--max-lines requires a positive integer" };
       const n = Number(v);
-      if (!Number.isFinite(n) || n <= 0) return { error: "--max-lines requires a positive integer" };
+      if (!Number.isInteger(n) || n <= 0) return { error: "--max-lines requires a positive integer" };
       args.maxLines = n;
     } else {
       return { error: `unknown argument: ${a}` };


### PR DESCRIPTION
## What

Smallest safe slice of **B-0354** (fresh-instance validation test for bootstrap CLAUDE.md) — child **B-0354.1**: the static structural-validation **harness skeleton**.

Ships `tools/bootstrap-validator/validate-bootstrap-claude-md.ts` + `.test.ts`. Validates the shape a fresh Claude Code instance depends on, with **no Claude spawn** (live execution is B-0354.2; findings/gap-filing is B-0354.3).

### Checks
| id | hard/soft | meaning |
|---|---|---|
| `claude-md-exists` | fail | CLAUDE.md present at repo root |
| `six-step-process` | fail | `## 1.`..`## 6.` bootstrap process present |
| `rules-auto-load` | fail | `.claude/rules/` auto-load surface non-empty (behavioral-doctrine discovery channel) |
| `conciseness` | **warn** | CLAUDE.md within soft `--max-lines` ceiling (default 150) |

CLI: `--json` / `--root <path>` / `--max-lines <n>` / `--help`. Exit codes **0** pass / **1** usage / **3** fail. Convention-matched to `tools/cold-start-check.ts` (shebang, leading-comment-as-help, ESM-safe self-path).

## Recalibration (assume-decomposition-has-mistakes)

The B-0354 child sketch specified `conciseness` as "CLAUDE.md length **<50**". That bound is **empirically wrong** — the live bootstrap CLAUDE.md is **~76 lines** and that *is* the correct bootstrap form (Sections 1-6 + a short Conventions block). A hard `<50` would fail a correct file. The load-bearing invariant is **structural** (6-step process + rules auto-load surface), so conciseness is a **soft `--max-lines` warn** (default 150), not a hard fail. Recorded as a Progress note on the B-0354 row.

## Focused checks (run on this branch)

- `bun test tools/bootstrap-validator/validate-bootstrap-claude-md.test.ts` → **15 pass / 0 fail** (21 expect() calls). Includes a self-validation against the live repo root and the 76-line recalibration anchor.
- CLI exit-code matrix verified: live repo `→ 0`, bad `--root` `→ 3`, `--help` `→ 1`, bad arg `→ 1`.
- `--json` output verified well-formed.

**Build gate:** TS + docs only; no F#/.NET sources touched, so `dotnet build -c Release` is unaffected by this slice (not re-run for a non-.NET change).

## Scope discipline

One bounded step, one PR. Claim `B-0354.1` acquired via `tools/bus/claim.ts` (otto-cli). Authored in an isolated worktree off fresh `origin/main`; contested root checkout untouched.

Remaining children: **B-0354.2** (execute minimal validation), **B-0354.3** (document findings + file gap children, update parent B-0329).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
