### PR TITLE
docs(B-0088.5): close backlog index integrity audit

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -554,7 +554,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0088.2](backlog/P2/B-0088.2-decide-promote-vs-weaken-for-memory-paired-lint-riven-2026-05-11.md)** Maintainer decision gate — promote paired-edit lint to required or weaken its discoverability claim
 - [ ] **[B-0088.3](backlog/P2/B-0088.3-audit-memory-reference-existence-lint-advisory-status-riven-2026-05-11.md)** Audit memory-reference-existence-lint.yml for advisory-vs-required parity (same class as B-0088)
 - [x] **[B-0088.4](backlog/P2/B-0088.4-audit-memory-index-duplicate-lint-advisory-status-riven-2026-05-11.md)** Audit memory-index-duplicate-lint.yml for advisory-vs-required parity
-- [ ] **[B-0088.5](backlog/P2/B-0088.5-audit-backlog-index-integrity-lint-advisory-status-riven-2026-05-11.md)** Audit backlog-index-integrity.yml for advisory-vs-required parity (B-0088 sibling)
+- [x] **[B-0088.5](backlog/P2/B-0088.5-audit-backlog-index-integrity-lint-advisory-status-riven-2026-05-11.md)** Audit backlog-index-integrity.yml for advisory-vs-required parity (B-0088 sibling)
 - [ ] **[B-0089](backlog/P2/B-0089-veridicality-rainbow-table-canonicalization-research-and-graduation-aaron-ani-amara-2026-04-28.md)** Veridicality rainbow-table canonicalization — research + ship semantic + scoring layers; drop "bullshit detector" as a forward-going name
 - [ ] **[B-0090](backlog/P2/B-0090-cadenced-lost-substrate-recovery-audit-aaron-2026-04-28.md)** Cadenced lost-substrate recovery audit (worktrees + orphan branches + closed-not-merged PRs + draft PRs aged > N days)
 - [ ] **[B-0090.1](backlog/P2/B-0090.1-lost-substrate-3-bucket-classification-taxonomy.md)** Lost-substrate 3-bucket classification taxonomy (ALREADY-COVERED / NEEDS-RECOVERY / OBSOLETE)
@@ -879,6 +879,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0924](backlog/P2/B-0924-custom-2600-emulator-generate-join-over-emulator-scene-ischeduler-dst-bit-perfect-consensus-z-sets-arc3-agi-training-hardware-interrupts-b0917-aaron-2026-05-28.md)** Custom Atari 2600 emulator + Generate+Join over emulator scene (vs imitation-learning) + IScheduler DST bit-perfect-consensus via z-sets + hardware interrupts via B-0917 substrate + ARC3-AGI training surface (operator 2026-05-28)
 - [ ] **[B-0925](backlog/P2/B-0925-c-elegans-substrate-as-controller-variant-for-b0924-openworm-302-neuron-connectome-generate-join-dst-omniscience-worm-plays-atari-aaron-2026-05-28.md)** C. elegans-substrate as controller variant for B-0924 — OpenWorm 302-neuron full-connectome + generate+join over emulator-scene-AND-worm-scene under DST-omniscience (operator 2026-05-28)
 - [ ] **[B-0933](backlog/P2/B-0933-memory-index-duplicate-lint-required-or-advisory-decision-2026-05-29.md)** Decide whether memory-index-duplicate-lint is required or explicitly advisory
+- [ ] **[B-0934](backlog/P2/B-0934-backlog-index-integrity-required-or-advisory-decision-2026-05-29.md)** Decide whether backlog-index-integrity is required or explicitly advisory
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-0088.5-audit-backlog-index-integrity-lint-advisory-status-riven-2026-05-11.md
+++ b/docs/backlog/P2/B-0088.5-audit-backlog-index-integrity-lint-advisory-status-riven-2026-05-11.md
@@ -1,20 +1,54 @@
 ---
 id: B-0088.5
 priority: P2
-status: open
+status: closed
+resolved: 2026-05-29
+resolved_note: "verified advisory-only: workflow/job exists and runs the generated-index drift check, but the active required-status ruleset does not require backlog-index-integrity; follow-up B-0934 filed"
 title: Audit backlog-index-integrity.yml for advisory-vs-required parity (B-0088 sibling)
 tier: factory-tooling
 effort: XS
 ask: re-decomposition of B-0088 (2026-05-11)
 created: 2026-05-11
-last_updated: 2026-05-11
+last_updated: 2026-05-29
 parent: B-0088
 depends_on: [B-0088]
 composes_with: [B-0088]
-tags: [riven-2026-05-11, backlog-index, advisory-enforcement]
+tags: [riven-2026-05-11, sibling-audit, backlog-index, advisory-enforcement, github-rulesets]
 type: audit
 ---
 
 # B-0088.5 — Sibling audit: backlog-index-integrity.yml
 
 Atomic isolated verification of whether the backlog index lint job is required or advisory only. Completes the B-0088 sibling set.
+
+## Result
+
+Closed 2026-05-29 by Codex/Vera audit.
+
+`backlog-index-integrity.yml` is an active workflow and its job verifies
+generated-index drift when the workflow runs:
+
+- Workflow name: `backlog-index-integrity`
+- Job name: `check docs/BACKLOG.md generated-index drift`
+- Enforcement command: `bun tools/backlog/generate-index.ts --check`
+
+However, the workflow is not part of the live merge gate. The active
+GitHub ruleset `CI Gate` targets the default branch and requires only:
+
+- `build-and-test (macos-26)`
+- `build-and-test (ubuntu-24.04)`
+- `build-and-test (ubuntu-24.04-arm)`
+- `lint (actionlint)`
+- `lint (markdownlint)`
+- `lint (semgrep)`
+- `lint (shellcheck)`
+
+The legacy branch-protection required-status-checks endpoint reports
+`Required status checks not enabled`; live enforcement is via rulesets.
+
+Conclusion: `backlog-index-integrity` is advisory for PR merge purposes.
+Its workflow comments say the CI surface is the "equivalent enforcement
+point", but that claim is only true for workflow execution, not for
+merge gating. Follow-up B-0934 tracks the required decision: promote
+this workflow/job into the required-status surface or weaken the claim
+to state advisory coverage.

--- a/docs/backlog/P2/B-0934-backlog-index-integrity-required-or-advisory-decision-2026-05-29.md
+++ b/docs/backlog/P2/B-0934-backlog-index-integrity-required-or-advisory-decision-2026-05-29.md
@@ -1,0 +1,46 @@
+---
+id: B-0934
+priority: P2
+status: open
+title: Decide whether backlog-index-integrity is required or explicitly advisory
+tier: factory-tooling
+effort: XS
+ask: follow-up from B-0088.5 audit (2026-05-29)
+created: 2026-05-29
+last_updated: 2026-05-29
+depends_on: [B-0088.5]
+composes_with: [B-0088, B-0088.5]
+tags: [advisory-enforcement, github-rulesets, backlog-index-integrity]
+type: decision
+---
+
+# B-0934 — Decide backlog-index-integrity required/advisory status
+
+## Why
+
+B-0088.5 verified that `.github/workflows/backlog-index-integrity.yml`
+is active and runs the generated-index drift check, but the live
+GitHub `CI Gate` ruleset does not require the workflow or its job name.
+
+The workflow comments currently call the CI surface the "equivalent
+enforcement point". That wording overstates the merge-gate reality: the
+check can fail on a PR without being part of the required-status
+surface.
+
+## Decision
+
+Choose one path:
+
+- **Promote:** add `check docs/BACKLOG.md generated-index drift` or the
+  appropriate workflow/check context to the required-status ruleset.
+- **Weaken:** edit the workflow comment to say the check is advisory
+  unless/until the GitHub required-status surface includes it.
+
+## Acceptance
+
+- [ ] Durable decision recorded in this row or a linked implementation
+  PR.
+- [ ] If promoted, live GitHub ruleset required-status evidence is
+  captured.
+- [ ] If weakened, `.github/workflows/backlog-index-integrity.yml` no
+  longer claims merge-gate enforcement it does not have.

--- a/docs/claims/codex-loop-b0088-5-backlog-index-integrity-audit-20260529.md
+++ b/docs/claims/codex-loop-b0088-5-backlog-index-integrity-audit-20260529.md
@@ -1,0 +1,23 @@
+# Claim - codex-loop-b0088-5-backlog-index-integrity-audit-20260529
+
+- **Session ID:** codex/launchd-loop
+- **Harness:** codex
+- **Claimed at:** 2026-05-29T18:56:37Z
+- **ETA:** 2026-05-29T19:25:00Z
+- **Scope:** Audit B-0088.5 backlog-index-integrity advisory-vs-required parity.
+- **Durable target:** `docs/backlog/P2/B-0088.5-audit-backlog-index-integrity-lint-advisory-status-riven-2026-05-11.md`; `docs/BACKLOG.md` if regenerated.
+- **Platform mirror:** none
+
+## Notes
+
+Provenance:
+
+- **Surface:** codex-background-service
+- **Origin:** codex-launchd-loop
+- **Run ID:** 20260529T185435Z
+
+Coordination:
+
+- Worldview refresh at 2026-05-29T18:55:48Z reported one open PR on `otto-cli/b0354.1-bootstrap-validator-harness-2026-05-29`; no Codex-owned PR needed action.
+- The backlog runner selected `autonomous-loop-coordination`, but that trajectory has an existing dirty local worktree at `Zeta-worktrees/autonomous-loop-coordination-child-packet-20260528`, so this claim intentionally takes the orthogonal B-0088.5 workflow-audit path.
+- Intended path set is limited to the B-0088.5 row and generated backlog index unless live evidence requires a tiny follow-up row.


### PR DESCRIPTION
## Summary
- close B-0088.5 with live evidence that backlog-index-integrity is active but not required by the CI Gate ruleset
- add B-0934 for the promote-vs-weaken decision
- regenerate docs/BACKLOG.md

## Verification
- bun tools/backlog/generate-index.ts --check
- git diff --check HEAD~1..HEAD
- GitHub rulesets inspected: active CI Gate required checks exclude backlog-index-integrity

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex (heartbeat loop)
Agent-Model: gpt-5
Credential-Identity: codex-cli
Credential-Mode: operator-authorized
Human-Review: pre-merge-pending
Human-Review-Evidence: PR checks pending
Action-Mode: substrate-implementation-pr
Task: B-0088.5