### PR TITLE
feat(B-0354.2): referenced-pointer-resolution check for bootstrap CLAUDE.md

### DIFF
--- a/docs/backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md
+++ b/docs/backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md
@@ -93,8 +93,8 @@ be a false dangling-pointer. Live run: all 11 resolve, exit 0.
 **Recalibration finding (assume-decomposition-has-mistakes):** the .2 sketch
 ("execute minimal validation in isolated TS context") was already over-delivered
 by .1 — .1's test file ships a `runValidation against the live repo root` block.
-So .2's genuine remaining value was the deeper gate for **acceptance criterion
-#2** ("no critical rules lost in the extraction"): check #3 (rules-auto-load)
+So .2's genuine remaining value was the deeper gate for
+**acceptance criterion #2** ("no critical rules lost in the extraction"): check #3 (rules-auto-load)
 only proves the rule DIRECTORY is non-empty; it passes even when the SPECIFIC
 file CLAUDE.md points at is gone. Check #4 closes that gap — it proves the
 specific pointers survive, which is what "no critical rules lost" actually means.

--- a/docs/backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md
+++ b/docs/backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md
@@ -79,5 +79,25 @@ present (`## 1.`..`## 6.`); `.claude/rules/` auto-load surface non-empty; concis
 file. Load-bearing invariant is structural (6-step process + rules auto-load surface),
 so conciseness is a SOFT `--max-lines` warn (default 150), not a hard fail.
 
-Remaining: **B-0354.2** (execute minimal validation), **B-0354.3** (document findings
-and file gap children, update parent B-0329).
+**B-0354.2 landed (2026-05-29, otto-cli bg-worker):** executed the validation
+against the live repo + added structural check #4 — **referenced-pointer
+resolution**. `extractReferencedPointers` + `checkReferencedPointers` in
+`tools/bootstrap-validator/validate-bootstrap-claude-md.ts` (+ 8 new tests,
+23 pass). The check resolves every CONCRETE pointer the live CLAUDE.md hands a
+fresh instance (4 named `.claude/rules/<name>.md` rules + 7 orient/ship doc
+links = 11) against the repo root; a dangling pointer is a hard fail (exit 3).
+Globs/templates (`memory/CURRENT-*.md`, `docs/trajectories/*/RESUME.md`,
+`~/.claude/projects/<slug>/...`) are deliberately skipped — flagging them would
+be a false dangling-pointer. Live run: all 11 resolve, exit 0.
+
+**Recalibration finding (assume-decomposition-has-mistakes):** the .2 sketch
+("execute minimal validation in isolated TS context") was already over-delivered
+by .1 — .1's test file ships a `runValidation against the live repo root` block.
+So .2's genuine remaining value was the deeper gate for **acceptance criterion
+#2** ("no critical rules lost in the extraction"): check #3 (rules-auto-load)
+only proves the rule DIRECTORY is non-empty; it passes even when the SPECIFIC
+file CLAUDE.md points at is gone. Check #4 closes that gap — it proves the
+specific pointers survive, which is what "no critical rules lost" actually means.
+
+Remaining: **B-0354.3** (live model-in-the-loop run if desired; document findings;
+file gap children; update parent B-0329).

--- a/tools/bootstrap-validator/validate-bootstrap-claude-md.test.ts
+++ b/tools/bootstrap-validator/validate-bootstrap-claude-md.test.ts
@@ -5,9 +5,11 @@ import { fileURLToPath } from "node:url";
 import {
   checkClaudeMdExists,
   checkConciseness,
+  checkReferencedPointers,
   checkRulesAutoLoad,
   checkSixStepProcess,
   DEFAULT_MAX_LINES,
+  extractReferencedPointers,
   REQUIRED_STEP_NUMBERS,
   runValidation,
 } from "./validate-bootstrap-claude-md";
@@ -99,6 +101,70 @@ describe("checkConciseness", () => {
   });
 });
 
+describe("extractReferencedPointers", () => {
+  test("extracts concrete .claude/rules/<name>.md references", () => {
+    const md = "See `.claude/rules/backlog-item-start-gate.md` and .claude/rules/never-be-idle.md.";
+    const refs = extractReferencedPointers(md);
+    expect(refs).toContain(".claude/rules/backlog-item-start-gate.md");
+    expect(refs).toContain(".claude/rules/never-be-idle.md");
+  });
+
+  test("extracts repo-relative markdown-link targets", () => {
+    const md = "Read [`AGENTS.md`](AGENTS.md) then [GLOSSARY](docs/GLOSSARY.md).";
+    const refs = extractReferencedPointers(md);
+    expect(refs).toContain("AGENTS.md");
+    expect(refs).toContain("docs/GLOSSARY.md");
+  });
+
+  test("strips a trailing #anchor from link targets", () => {
+    const refs = extractReferencedPointers("See [§11](GOVERNANCE.md#section-11).");
+    expect(refs).toContain("GOVERNANCE.md");
+    expect(refs).not.toContain("GOVERNANCE.md#section-11");
+  });
+
+  test("skips URLs, pure anchors, globs/templates, and home/absolute paths", () => {
+    const md = [
+      "[site](https://example.com)", // URL
+      "[top](#orient)", // pure anchor
+      "`memory/CURRENT-*.md`", // glob (inline, not a link anyway)
+      "[resume](docs/trajectories/*/RESUME.md)", // glob in a link target
+      "[slug](~/.claude/projects/<slug>/memory/x.md)", // home + template
+      "[abs](/etc/passwd)", // absolute
+      "[mail](mailto:x@y.z)", // mailto scheme
+    ].join("\n");
+    const refs = extractReferencedPointers(md);
+    expect(refs).toEqual([]); // nothing concrete + repo-relative survives
+  });
+
+  test("de-duplicates a pointer that appears in both rule-path and link form", () => {
+    const md = "`.claude/rules/x.md` then [x](.claude/rules/x.md)";
+    const refs = extractReferencedPointers(md);
+    expect(refs.filter((r) => r === ".claude/rules/x.md").length).toBe(1);
+  });
+});
+
+describe("checkReferencedPointers", () => {
+  test("pass when every concrete pointer resolves", () => {
+    const refs = ["AGENTS.md", ".claude/rules/x.md"];
+    const r = checkReferencedPointers(refs, () => true);
+    expect(r.status).toBe("pass");
+    expect(r.detail).toContain("2");
+  });
+
+  test("fail (not warn) when any pointer dangles — a critical rule lost in extraction", () => {
+    const refs = ["AGENTS.md", ".claude/rules/gone.md"];
+    const present = new Set(["AGENTS.md"]);
+    const r = checkReferencedPointers(refs, (p) => present.has(p));
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain(".claude/rules/gone.md");
+    expect(r.detail).not.toContain("AGENTS.md,"); // only the dangling one is listed
+  });
+
+  test("vacuous pass when there are no concrete pointers", () => {
+    expect(checkReferencedPointers([], () => false).status).toBe("pass");
+  });
+});
+
 describe("runValidation against the live repo root", () => {
   // Resolve repo root from this test file's location:
   // tools/bootstrap-validator/<file> -> repo root is two dirs up.
@@ -113,6 +179,9 @@ describe("runValidation against the live repo root", () => {
     expect(report.checks.find((c) => c.id === "claude-md-exists")?.status).toBe("pass");
     expect(report.checks.find((c) => c.id === "six-step-process")?.status).toBe("pass");
     expect(report.checks.find((c) => c.id === "rules-auto-load")?.status).toBe("pass");
+    // B-0354.2 — every concrete pointer the live CLAUDE.md hands a fresh
+    // instance must resolve (no critical rule/doc lost in the extraction).
+    expect(report.checks.find((c) => c.id === "referenced-pointers-resolve")?.status).toBe("pass");
   });
 
   test("fixture sanity: CLAUDE.md and .claude/rules/ are where we expect", () => {

--- a/tools/bootstrap-validator/validate-bootstrap-claude-md.test.ts
+++ b/tools/bootstrap-validator/validate-bootstrap-claude-md.test.ts
@@ -141,6 +141,33 @@ describe("extractReferencedPointers", () => {
     const refs = extractReferencedPointers(md);
     expect(refs.filter((r) => r === ".claude/rules/x.md").length).toBe(1);
   });
+
+  test("extracts bare inline-code repo paths not in a link or rules dir", () => {
+    const md = "Spec: `docs/research/foo.md` §10. Refresh: `tools/setup/common/sync.sh`.";
+    const refs = extractReferencedPointers(md);
+    expect(refs).toContain("docs/research/foo.md");
+    expect(refs).toContain("tools/setup/common/sync.sh");
+  });
+
+  test("inline-code skips bare identifiers and extension-less tokens", () => {
+    const md = "`Result<_, DbspError>` and `git log` and `BACKLOG` are not pointers.";
+    const refs = extractReferencedPointers(md);
+    expect(refs).toEqual([]);
+  });
+
+  test("a multi-line backtick command span does not mis-pair into a false path", () => {
+    // The open backtick on line 1 closes on line 2 (a wrapped command). Single-line
+    // span matching must skip it AND must not let backtick-parity drift swallow the
+    // genuine path on line 3.
+    const md = [
+      "Audit via `bun tools/x.ts",
+      "  --since DATE`. Spec: per",
+      "`docs/research/bar.md` §10.",
+    ].join("\n");
+    const refs = extractReferencedPointers(md);
+    expect(refs).toContain("docs/research/bar.md");
+    expect(refs).not.toContain("bun tools/x.ts");
+  });
 });
 
 describe("checkReferencedPointers", () => {

--- a/tools/bootstrap-validator/validate-bootstrap-claude-md.ts
+++ b/tools/bootstrap-validator/validate-bootstrap-claude-md.ts
@@ -196,7 +196,7 @@ export function extractReferencedPointers(claudeMd: string): string[] {
 
   // (b) Markdown-link targets that look like repo-relative file paths.
   for (const m of claudeMd.matchAll(/\]\(([^)]+)\)/g)) {
-    let target = m[1].trim();
+    let target = (m[1] ?? "").trim();
     const hash = target.indexOf("#");
     if (hash >= 0) target = target.slice(0, hash); // strip #anchor; keep path
     if (target === "") continue; // pure-anchor link (#section)

--- a/tools/bootstrap-validator/validate-bootstrap-claude-md.ts
+++ b/tools/bootstrap-validator/validate-bootstrap-claude-md.ts
@@ -184,7 +184,13 @@ export function checkReferencedPointers(
  *       the orient/ship doc links (AGENTS.md, GOVERNANCE.md, docs/*.md). A
  *       trailing `#anchor` is stripped; URLs, pure anchors, globs/templates,
  *       and home/absolute paths are skipped.
- * De-duplicated, so a pointer appearing in both forms is checked once.
+ *   (c) bare inline-code repo paths — a backticked token that contains a `/`
+ *       and a file extension (`docs/research/foo.md`, `tools/setup/x.sh`).
+ *       Spans are single-line only (no embedded newline) so a multi-line
+ *       command span never mis-pairs backticks and leaks document-global
+ *       parity drift into the result. Same URL / glob / template /
+ *       home / absolute skips as (b).
+ * De-duplicated, so a pointer appearing in more than one form is checked once.
  */
 export function extractReferencedPointers(claudeMd: string): string[] {
   const refs = new Set<string>();
@@ -203,6 +209,20 @@ export function extractReferencedPointers(claudeMd: string): string[] {
     if (/^[a-z][a-z0-9+.-]*:/i.test(target)) continue; // URL scheme (http:, mailto:)
     if (/[*<>\s]/.test(target)) continue; // glob / template / not a clean token
     if (target.startsWith("~") || target.startsWith("/")) continue; // home/absolute
+    refs.add(target);
+  }
+
+  // (c) Bare inline-code repo paths: single-line backtick spans only.
+  for (const m of claudeMd.matchAll(/`([^`\n]+)`/g)) {
+    let target = (m[1] ?? "").trim();
+    const hash = target.indexOf("#");
+    if (hash >= 0) target = target.slice(0, hash); // strip #anchor; keep path
+    if (target === "") continue;
+    if (/^[a-z][a-z0-9+.-]*:/i.test(target)) continue; // URL scheme
+    if (/[*<>\s]/.test(target)) continue; // glob / template / command (has spaces)
+    if (target.startsWith("~") || target.startsWith("/")) continue; // home/absolute
+    if (!target.includes("/")) continue; // must be a path, not a bare identifier
+    if (!/\.[a-z0-9]+$/i.test(target)) continue; // must end in a file extension
     refs.add(target);
   }
 

--- a/tools/bootstrap-validator/validate-bootstrap-claude-md.ts
+++ b/tools/bootstrap-validator/validate-bootstrap-claude-md.ts
@@ -10,13 +10,20 @@
 //     2. The 6-step bootstrap process is present (## 1. Orient ... ## 6.).
 //     3. The .claude/rules/ auto-load surface exists and is non-empty
 //        (the behavioral-rule discovery channel a fresh instance relies on).
-//     4. CLAUDE.md stays concise (a SOFT length bound; warn, not fail).
+//     4. Every CONCRETE pointer CLAUDE.md hands a fresh instance resolves to
+//        an existing file (named .claude/rules/<name>.md rules + orient/ship
+//        doc links). A dangling pointer IS "a critical rule lost in the
+//        extraction" (B-0354 acceptance criterion #2) — #3 proves the rule
+//        DIRECTORY is non-empty, but #4 proves the SPECIFIC files survive.
+//     5. CLAUDE.md stays concise (a SOFT length bound; warn, not fail).
 //
 //   It does NOT spawn a real Claude session or run the representative-task
-//   protocol from B-0354 — that live execution is B-0354.2 (execute minimal
-//   validation) and B-0354.3 (document findings + file gap children). This
-//   slice ships only the static structural gate, runnable in CI without a
-//   model in the loop.
+//   protocol from B-0354 — the live model-in-the-loop run is left to
+//   B-0354.3 (document findings + file gap children). B-0354.1 shipped the
+//   harness skeleton + checks #1-#3 + #5; B-0354.2 (this slice) adds check
+//   #4 (referenced-pointer resolution — the "no critical rule lost" gate)
+//   and executes the validation against the live repo. The whole harness
+//   stays static and CI-runnable without a model in the loop.
 //
 // RECALIBRATION NOTE (per "assume decomposition has mistakes"):
 //   The B-0354 re-decomposition row sketched check #4 as "CLAUDE.md length
@@ -127,7 +134,83 @@ export function checkRulesAutoLoad(ruleFileNames: string[]): CheckResult {
 }
 
 /**
- * #4 — Conciseness is a SOFT bound (warn, not fail). See RECALIBRATION NOTE.
+ * #4 — Every CONCRETE pointer CLAUDE.md hands a fresh instance must resolve.
+ *
+ * B-0354 acceptance criterion #2 is "no critical rules lost in the extraction
+ * (all behavioral rules accessible via .claude/rules/ auto-load)". Check #3
+ * (rules-auto-load) only proves the rule DIRECTORY is non-empty — it can pass
+ * while the SPECIFIC rule file CLAUDE.md points at is gone. That dangling
+ * pointer IS a critical rule lost in extraction: a fresh instance follows the
+ * pointer (a `.claude/rules/<name>.md` it is told to read, or an orient/ship
+ * markdown link) and hits a 404. This check is the deeper structural gate
+ * #3 cannot give (B-0354.2 — execute minimal validation, no Claude spawn).
+ *
+ * Only CONCRETE references are checked. CLAUDE.md legitimately contains globs
+ * and templates (`memory/CURRENT-*.md`, `docs/trajectories/*\/RESUME.md`,
+ * `~/.claude/projects/<slug>/...`) — those are NOT resolvable exact paths, so
+ * extraction deliberately skips anything with `*`, `<`, `>`, a space, a URL
+ * scheme, or a home/absolute prefix. Flagging a glob would be a false
+ * dangling-pointer; the check stays conservative on purpose.
+ *
+ * Filesystem-free: takes the extracted refs plus a `fileExists` predicate so
+ * the resolution logic is unit-testable without a real repo (the runner
+ * supplies `(rel) => existsSync(join(root, rel))`).
+ */
+export function checkReferencedPointers(
+  refs: string[],
+  fileExists: (relPath: string) => boolean,
+): CheckResult {
+  const dangling = refs.filter((r) => !fileExists(r));
+  return dangling.length === 0
+    ? {
+        id: "referenced-pointers-resolve",
+        status: "pass",
+        detail: `All ${refs.length} concrete CLAUDE.md pointer(s) resolve to existing files`,
+      }
+    : {
+        id: "referenced-pointers-resolve",
+        status: "fail",
+        detail: `Dangling CLAUDE.md pointer(s) (critical rule/doc lost in extraction): ${dangling.join(", ")}`,
+      };
+}
+
+/**
+ * Extract the concrete repo-relative pointers a fresh instance would follow
+ * from CLAUDE.md. Two reference classes:
+ *   (a) `.claude/rules/<kebab>.md` — named behavioral rules (inline-code or
+ *       path form). Kebab-case (`[a-z0-9][a-z0-9-]*`) cannot match a glob or
+ *       template, so `.claude/rules/*` style references never leak in.
+ *   (b) markdown-link targets `](target)` that are repo-relative file paths —
+ *       the orient/ship doc links (AGENTS.md, GOVERNANCE.md, docs/*.md). A
+ *       trailing `#anchor` is stripped; URLs, pure anchors, globs/templates,
+ *       and home/absolute paths are skipped.
+ * De-duplicated, so a pointer appearing in both forms is checked once.
+ */
+export function extractReferencedPointers(claudeMd: string): string[] {
+  const refs = new Set<string>();
+
+  // (a) Concrete .claude/rules/<kebab>.md references.
+  for (const m of claudeMd.matchAll(/\.claude\/rules\/[a-z0-9][a-z0-9-]*\.md/g)) {
+    refs.add(m[0]);
+  }
+
+  // (b) Markdown-link targets that look like repo-relative file paths.
+  for (const m of claudeMd.matchAll(/\]\(([^)]+)\)/g)) {
+    let target = m[1].trim();
+    const hash = target.indexOf("#");
+    if (hash >= 0) target = target.slice(0, hash); // strip #anchor; keep path
+    if (target === "") continue; // pure-anchor link (#section)
+    if (/^[a-z][a-z0-9+.-]*:/i.test(target)) continue; // URL scheme (http:, mailto:)
+    if (/[*<>\s]/.test(target)) continue; // glob / template / not a clean token
+    if (target.startsWith("~") || target.startsWith("/")) continue; // home/absolute
+    refs.add(target);
+  }
+
+  return [...refs];
+}
+
+/**
+ * #5 — Conciseness is a SOFT bound (warn, not fail). See RECALIBRATION NOTE.
  * Empty / whitespace-only CLAUDE.md is a separate hard concern handled by
  * #1/#2; here we only flag bloat past the soft ceiling.
  */
@@ -173,9 +256,12 @@ export function runValidation(root: string, maxLines: number): ValidationReport 
   const ruleFileNames = existsSync(rulesDir) ? readdirSync(rulesDir) : [];
 
   const checks: CheckResult[] = [checkClaudeMdExists(claudeMdPresent)];
-  // Section + conciseness checks only meaningful when the file exists.
+  // Content-derived checks only meaningful when the file exists.
   if (claudeMdPresent) {
     checks.push(checkSixStepProcess(claudeMd));
+    // #4 — referenced pointers must resolve against the repo root.
+    const refs = extractReferencedPointers(claudeMd);
+    checks.push(checkReferencedPointers(refs, (rel) => existsSync(join(root, rel))));
     checks.push(checkConciseness(claudeMd, maxLines));
   }
   checks.push(checkRulesAutoLoad(ruleFileNames));


### PR DESCRIPTION
## What

**B-0354.2** — smallest safe slice of [B-0354](docs/backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md) (parent B-0329). Executes the bootstrap validation against the live repo and adds structural **check #4 — referenced-pointer resolution** to `tools/bootstrap-validator/`.

## Why (acceptance criterion #2)

B-0354's acceptance criterion #2 is *"no critical rules lost in the extraction (all behavioral rules accessible via `.claude/rules/` auto-load)."*

Check #3 (`rules-auto-load`, shipped in .1) only proves the `.claude/rules/` **directory is non-empty** — it passes even when the **specific** rule file CLAUDE.md points at is gone. A dangling pointer IS a critical rule lost in extraction: a fresh instance follows the pointer it is handed and hits a 404. Check #4 proves the **specific** pointers survive — which is what "no critical rules lost" actually means.

## What landed

- `extractReferencedPointers(claudeMd)` — pulls **concrete** repo-relative pointers: (a) `.claude/rules/<kebab>.md` named rules, (b) markdown-link targets that are repo-relative file paths (orient/ship doc links). Globs/templates (`memory/CURRENT-*.md`, `docs/trajectories/*/RESUME.md`, `~/.claude/projects/<slug>/...`) are skipped on purpose — flagging a glob would be a *false* dangling-pointer.
- `checkReferencedPointers(refs, fileExists)` — pure (injected `fileExists` predicate, so resolution logic is unit-testable without a real repo); **hard FAIL** on any dangling pointer. Wired into `runValidation` as check #4.
- 8 new tests (15 → **23 pass**); live-repo block now asserts #4 passes.

## Recalibration (assume-decomposition-has-mistakes)

The .2 sketch ("execute minimal validation in isolated TS context") was **already over-delivered** by .1 — .1's test file ships a `runValidation against the live repo root` block. So .2's genuine remaining value is the dangling-pointer gate above (the deeper acceptance-#2 check), not a duplicate integration test. Backlog Progress section updated to record this.

## Scope

Static + CI-runnable; **no Claude spawn** (the live model-in-the-loop run is left to B-0354.3). TS-only change in `tools/` — no .NET surface touched.

## Focused check (run locally)

| Check | Result |
|---|---|
| `bun test tools/bootstrap-validator/` | **23 pass / 0 fail** |
| live run `--json` | `referenced-pointers-resolve` **pass** — all 11 concrete pointers resolve (4 rules + 7 docs), exit 0 |
| negative path (synthetic root, dangling doc) | `RESULT: FAIL`, exit 3 |
| CLI `--help` / clean run | exit 1 / exit 0 (unchanged) |
| commit canary | tree 63 = 63 (no corruption) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)