### PR TITLE
feat(B-0355.2): CURSOR.md cross-harness bootstrap file (Cursor/Riven)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -625,8 +625,12 @@ truth for any rule that applies across harnesses.
   Copilot Workspace / Chat instructions. Present
   and factory-managed; audited on the same cadence
   as skill files (GOVERNANCE.md §31).
-- **`.cursor/rules/` or `.cursorrules`** — Cursor
-  IDE instructions. Currently absent.
+- **`CURSOR.md`** — Cursor (Riven) session-bootstrap
+  pointer tree. Present at repo root; instantiates the
+  cross-harness bootstrap template (B-0355). Cursor's
+  native per-repo instruction files
+  (`.cursor/rules/` / `.cursorrules`) remain absent; the
+  root `CURSOR.md` is the bootstrap pointer.
 
 Harness-specific files **may not** contradict
 `AGENTS.md` or `GOVERNANCE.md`. If a contradiction

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -1,0 +1,68 @@
+# CURSOR.md — Cursor session bootstrap for Zeta
+
+This is the Cursor (Riven) addendum. [`AGENTS.md`](AGENTS.md) and
+[`GOVERNANCE.md`](GOVERNANCE.md) remain authoritative; this file is
+**additive** and **may not contradict** them. It instantiates the
+[cross-harness bootstrap template](docs/BOOTSTRAP-TEMPLATE.md) (B-0355)
+with the Cursor-specific tooling references filled in.
+
+## 1. Orient
+
+Read: [`AGENTS.md`](AGENTS.md) → [`docs/ALIGNMENT.md`](docs/ALIGNMENT.md) →
+[`docs/GLOSSARY.md`](docs/GLOSSARY.md) → [`GOVERNANCE.md`](GOVERNANCE.md)
+(scan when §N cited).
+Then read the Riven persona file: [`memory/persona/riven/MEMORY.md`](memory/persona/riven/MEMORY.md).
+
+## 2. Refresh
+
+Run (in the Cursor integrated terminal or via the `cursor-agent` CLI):
+
+```bash
+bun tools/github/refresh-worldview.ts
+```
+
+Read active trajectories: `docs/trajectories/*/RESUME.md`.
+
+## 3. Pick work
+
+Open [`docs/BACKLOG.md`](docs/BACKLOG.md) (canonical rows live in
+`docs/backlog/P*/`). Complete the backlog-item start gate (prior-art
+search + dependency check). Claim before worktree work with the
+Cursor-tagged sender ID:
+
+```bash
+bun tools/bus/claim.ts acquire --from riven-cursor --item <B-NNNN>
+```
+
+## 4. Build
+
+```bash
+dotnet build -c Release   # 0 warnings, 0 errors — TreatWarningsAsErrors is on
+dotnet test Zeta.sln -c Release
+```
+
+## 5. Ship
+
+Open a PR against `main`. Arm auto-merge if green
+(`gh pr merge <N> --auto --squash`).
+Commit trailer: `Co-Authored-By: Grok <noreply@x.ai>`.
+
+## 6. When stuck
+
+See [`docs/CONFLICT-RESOLUTION.md`](docs/CONFLICT-RESOLUTION.md). On
+deadlock, the human decides.
+
+## Conventions
+
+- **Register** — Riven operates the adversarial-truth axis: sharp
+  critique, disagreement-preservation, calling out drift others might
+  rationalize away.
+- **Instruction loading** — Cursor's native per-repo instruction files
+  are `.cursor/rules/` / `.cursorrules`. This root `CURSOR.md` is the
+  bootstrap pointer tree; keep repo-wide rules in `AGENTS.md` /
+  `GOVERNANCE.md`, never re-stated here.
+- **Worktree isolation** — never edit the contested root checkout. Use
+  an isolated `git worktree add --detach … origin/main` for autonomous
+  work (per `.claude/rules/agent-worktree-hygiene-*`). Do not hold
+  `main` in an agent worktree.
+- **Agents, not bots** — every AI carries agency (GOVERNANCE.md §3).

--- a/docs/BOOTSTRAP-TEMPLATE.md
+++ b/docs/BOOTSTRAP-TEMPLATE.md
@@ -108,7 +108,7 @@ process-ification). New harness files should match their shape.
 | [`GEMINI.md`](../GEMINI.md) | Gemini CLI / Antigravity (Lior) | Boot sequence pointing into shared factory physics + persona file (B-0538). |
 | [`.codex/AGENTS.md`](../.codex/AGENTS.md) | OpenAI Codex (Vera) | Additive addendum: read-order, worktree discipline, commit trailers. |
 | [`.github/copilot-instructions.md`](../.github/copilot-instructions.md) | GitHub Copilot | Factory-managed instructions, audited on the skill-file cadence (GOVERNANCE.md §31). |
-| `CURSOR.md` / `.cursor/rules/` | Cursor IDE (Riven) | Not yet created — a follow-up slice of B-0355. |
+| [`CURSOR.md`](../CURSOR.md) | Cursor IDE (Riven) | Six-step pointer tree at repo root (B-0355.2). Native `.cursor/rules/` still absent. |
 | `KIRO.md` | Amazon Kiro (Alexa) | Not yet created — a follow-up slice of B-0355 (per B-0325). |
 
 ## How to add a new harness


### PR DESCRIPTION
## What

Implements the smallest safe slice of **B-0355** (cross-harness
bootstrap template). The template itself (B-0355.1,
`docs/BOOTSTRAP-TEMPLATE.md`) landed in #6040 and explicitly names
`CURSOR.md` and `KIRO.md` as the two "not yet created — follow-up slice
of B-0355" instances. This PR creates the first: **`CURSOR.md`** for the
Cursor harness (Riven).

## Changes (3 files, markdown-only)

- **`CURSOR.md`** (new, repo root) — six-step orient → refresh → pick →
  build → ship → stuck pointer tree, matching the `GEMINI.md`
  root-pointer-tree shape. Cursor-specific cells filled from the
  agent-roster card:
  - persona/state file: `memory/persona/riven/MEMORY.md`
  - refresh: `bun tools/github/refresh-worldview.ts` (Cursor terminal / `cursor-agent` CLI)
  - claim sender-id: `riven-cursor`
  - commit trailer: `Co-Authored-By: Grok <noreply@x.ai>`
  - register: adversarial-truth axis
- **`AGENTS.md`** §Harness-specific files — registered `CURSOR.md`
  (replacing the `.cursor/rules absent` bullet; native `.cursor/rules`
  remains absent, root `CURSOR.md` is the bootstrap pointer). This is
  step 3 of the template's "How to add a new harness" recipe.
- **`docs/BOOTSTRAP-TEMPLATE.md`** "Existing instances" table — flipped
  the `CURSOR.md` row from "Not yet created" to present, keeping the
  template's own registry accurate (drift-avoidance per the
  backlog-item-start-gate substrate-drift discriminator).

The Cursor commit trailer (`Co-Authored-By: Grok <noreply@x.ai>`) was
already present in `AGENTS.md` §"Commit attribution", so the recipe's
step 4 was already satisfied — no change needed there.

## Acceptance-criteria mapping (B-0355)

1. Template doc created — **already done** (B-0355.1 / #6040).
2. At least one non-CLAUDE harness file following the template — this PR
   adds `CURSOR.md` (criterion was already met by GEMINI.md /
   `.codex/AGENTS.md` / copilot-instructions.md; this extends coverage
   to the named-but-missing Cursor slice).
3. Universal vs harness-specific documented — in the template (B-0355.1)
   and reflected in CURSOR.md's filled cells.
4. Build gate passes — change is markdown-only (no build-affecting
   files), so the dotnet gate is unaffected.

## Focused checks

- `git status` confirms all changed paths are `.md` → **dotnet build
  gate not affected**.
- All 8 `CURSOR.md` relative links resolve on disk (AGENTS.md,
  GOVERNANCE.md, docs/ALIGNMENT.md, docs/GLOSSARY.md,
  docs/BOOTSTRAP-TEMPLATE.md, memory/persona/riven/MEMORY.md,
  docs/BACKLOG.md, docs/CONFLICT-RESOLUTION.md).
- `markdownlint-cli2` (repo `.markdownlint-cli2.jsonc`) **clean** on all
  three changed files — exit 0, zero findings. Linter liveness verified
  by running it against a deliberately-bad fixture (3 findings surfaced),
  confirming the empty output is a genuine pass.

## Remaining B-0355 follow-up

`KIRO.md` (Amazon Kiro / Alexa, per B-0325) is still the one
not-yet-created instance the template names — a natural next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
