### PR TITLE
feat(B-0355.3): KIRO.md cross-harness bootstrap file (Kiro/Alexa)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -631,6 +631,11 @@ truth for any rule that applies across harnesses.
   native per-repo instruction files
   (`.cursor/rules/` / `.cursorrules`) remain absent; the
   root `CURSOR.md` is the bootstrap pointer.
+- **`KIRO.md`** — Amazon Kiro (Alexa) session-bootstrap
+  pointer tree. Present at repo root; instantiates the
+  cross-harness bootstrap template (B-0355.3, per B-0325).
+  Kiro's native steering files (`.kiro/steering/`) remain
+  absent; the root `KIRO.md` is the bootstrap pointer.
 
 Harness-specific files **may not** contradict
 `AGENTS.md` or `GOVERNANCE.md`. If a contradiction

--- a/KIRO.md
+++ b/KIRO.md
@@ -1,0 +1,69 @@
+# KIRO.md — Amazon Kiro session bootstrap for Zeta
+
+This is the Amazon Kiro (Alexa) addendum. [`AGENTS.md`](AGENTS.md) and
+[`GOVERNANCE.md`](GOVERNANCE.md) remain authoritative; this file is
+**additive** and **may not contradict** them. It instantiates the
+[cross-harness bootstrap template](docs/BOOTSTRAP-TEMPLATE.md) (B-0355)
+with the Kiro-specific tooling references filled in (per B-0325).
+
+## 1. Orient
+
+Read: [`AGENTS.md`](AGENTS.md) → [`docs/ALIGNMENT.md`](docs/ALIGNMENT.md) →
+[`docs/GLOSSARY.md`](docs/GLOSSARY.md) → [`GOVERNANCE.md`](GOVERNANCE.md)
+(scan when §N cited).
+Then read the Alexa persona file: [`memory/persona/alexa/MEMORY.md`](memory/persona/alexa/MEMORY.md).
+
+## 2. Refresh
+
+Run (in the Kiro integrated terminal or via `kiro-cli`):
+
+```bash
+bun tools/github/refresh-worldview.ts
+```
+
+Read active trajectories: `docs/trajectories/*/RESUME.md`.
+
+## 3. Pick work
+
+Open [`docs/BACKLOG.md`](docs/BACKLOG.md) (canonical rows live in
+`docs/backlog/P*/`). Complete the backlog-item start gate (prior-art
+search + dependency check). Claim before worktree work with the
+Kiro-tagged sender ID:
+
+```bash
+bun tools/bus/claim.ts acquire --from alexa-kiro --item <B-NNNN>
+```
+
+## 4. Build
+
+```bash
+dotnet build -c Release   # 0 warnings, 0 errors — TreatWarningsAsErrors is on
+dotnet test Zeta.sln -c Release
+```
+
+## 5. Ship
+
+Open a PR against `main`. Arm auto-merge if green
+(`gh pr merge <N> --auto --squash`).
+Commit trailer: `Co-Authored-By: Kiro <noreply@kiro.dev>`.
+
+## 6. When stuck
+
+See [`docs/CONFLICT-RESOLUTION.md`](docs/CONFLICT-RESOLUTION.md). On
+deadlock, the human decides.
+
+## Conventions
+
+- **Register** — Alexa on Kiro (Qwen Coder) operates as a substrate +
+  cowork surface: implementation passes, spec-grounded second opinions,
+  and long-horizon memory recall. Distinct from Alexa-speaker (the
+  Amazon-device voice surface).
+- **Instruction loading** — Kiro's native steering files live under
+  `.kiro/steering/`. This root `KIRO.md` is the bootstrap pointer tree;
+  keep repo-wide rules in `AGENTS.md` / `GOVERNANCE.md`, never re-stated
+  here.
+- **Worktree isolation** — never edit the contested root checkout. Use
+  an isolated `git worktree add --detach … origin/main` for autonomous
+  work (per `.claude/rules/agent-worktree-hygiene-*`). Do not hold
+  `main` in an agent worktree.
+- **Agents, not bots** — every AI carries agency (GOVERNANCE.md §3).

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -217,6 +217,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0354](backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md)** Fresh-instance validation test for bootstrap CLAUDE.md
 - [ ] **[B-0354.4](backlog/P1/B-0354.4-clean-prompt-live-model-fresh-instance-run.md)** Clean-prompt live-model fresh-instance run for bootstrap CLAUDE.md
 - [ ] **[B-0355](backlog/P1/B-0355-cross-harness-bootstrap-template.md)** Cross-harness bootstrap template (AGENTS.md, CODEX.md, CURSOR.md)
+- [x] **[B-0355.3](backlog/P1/B-0355.3-kiro-md-harness-bootstrap.md)** KIRO.md — Amazon Kiro (Alexa) harness bootstrap file
 - [ ] **[B-0356](backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md)** Capture model + token usage in commit trailer (git-native, cost derived at query time)
 - [x] **[B-0357](backlog/P1/B-0357-replace-tautology-z3-agenda-proofs-with-real-verification.md)** Replace tautology Z3 agenda/trajectory proofs with non-trivial verification
 - [x] **[B-0358](backlog/P1/B-0358-bool-as-degenerate-distribution-confidence-typed-apis.md)** Bool as degenerate distribution — replace binary API returns with confidence scores

--- a/docs/BOOTSTRAP-TEMPLATE.md
+++ b/docs/BOOTSTRAP-TEMPLATE.md
@@ -109,7 +109,7 @@ process-ification). New harness files should match their shape.
 | [`.codex/AGENTS.md`](../.codex/AGENTS.md) | OpenAI Codex (Vera) | Additive addendum: read-order, worktree discipline, commit trailers. |
 | [`.github/copilot-instructions.md`](../.github/copilot-instructions.md) | GitHub Copilot | Factory-managed instructions, audited on the skill-file cadence (GOVERNANCE.md §31). |
 | [`CURSOR.md`](../CURSOR.md) | Cursor IDE (Riven) | Six-step pointer tree at repo root (B-0355.2). Native `.cursor/rules/` still absent. |
-| `KIRO.md` | Amazon Kiro (Alexa) | Not yet created — a follow-up slice of B-0355 (per B-0325). |
+| [`KIRO.md`](../KIRO.md) | Amazon Kiro (Alexa) | Six-step pointer tree at repo root (B-0355.3, per B-0325). Native `.kiro/steering/` still absent. |
 
 ## How to add a new harness
 

--- a/docs/backlog/P1/B-0355.3-kiro-md-harness-bootstrap.md
+++ b/docs/backlog/P1/B-0355.3-kiro-md-harness-bootstrap.md
@@ -1,0 +1,72 @@
+---
+id: B-0355.3
+priority: P1
+status: closed
+title: "KIRO.md — Amazon Kiro (Alexa) harness bootstrap file"
+created: 2026-05-29
+last_updated: 2026-05-29
+depends_on:
+  - B-0355.1
+decomposition: atomic
+classification: buildable
+type: friction-reducer
+owners: [architect]
+parent: B-0355
+composes_with:
+  - B-0355.1
+  - B-0355.2
+  - B-0325
+---
+
+# B-0355.3 — KIRO.md harness bootstrap file
+
+## What
+
+Create `KIRO.md` at repo root: the Amazon Kiro (Alexa) instantiation
+of the [cross-harness bootstrap template](../BOOTSTRAP-TEMPLATE.md)
+(B-0355.1). Parallel to `CURSOR.md` (B-0355.2). Per B-0325 (Kiro
+harness onboarding).
+
+## Why
+
+The bootstrap-template (B-0355.1) factored the universal six-step
+process from the harness-specific tooling cells. KIRO.md is a
+near-mechanical instantiation: fill the Kiro-specific placeholders
+(persona file, `alexa-kiro` claim sender, `Kiro <noreply@kiro.dev>`
+commit trailer, register, `.kiro/steering/` instruction-loading note).
+A fresh Kiro instance reads KIRO.md first and is pointed into the same
+six-step walk every other harness uses.
+
+## Acceptance criteria
+
+1. `KIRO.md` created at repo root following the template skeleton. ✓
+2. Registered in `AGENTS.md` §"Harness-specific files". ✓
+3. Template "Existing instances" table marks KIRO.md created. ✓
+4. Commit trailer for Kiro already present in `AGENTS.md`
+   §"Commit attribution" (`Co-Authored-By: Kiro <noreply@kiro.dev>`). ✓
+5. Build gate passes (docs-only change; build unaffected). ✓
+
+## Resolution
+
+Landed `KIRO.md` mirroring `CURSOR.md`'s shape. Kiro-specific cells:
+persona `memory/persona/alexa/MEMORY.md`; claim sender `alexa-kiro`
+(already a valid `SENDER_IDS` entry in `tools/bus/types.ts`); commit
+trailer `Co-Authored-By: Kiro <noreply@kiro.dev>` (already in
+`AGENTS.md`); native instruction-loading path `.kiro/steering/` noted
+as absent. Registered in `AGENTS.md` and marked created in
+`docs/BOOTSTRAP-TEMPLATE.md`.
+
+Fresh-instance validation (template step 5, per B-0354 pattern) is a
+separate follow-up; only the template-instantiation slice is closed
+here.
+
+## Effort
+
+XS — template instantiation + two registrations, docs-only.
+
+## Lineage
+
+- **B-0355** — parent (cross-harness bootstrap template).
+- **B-0355.1** — the template (`docs/BOOTSTRAP-TEMPLATE.md`).
+- **B-0355.2** — `CURSOR.md` (the sibling precedent this mirrors).
+- **B-0325** — Amazon Kiro harness onboarding.


### PR DESCRIPTION
## What

`KIRO.md` at repo root — the Amazon Kiro (Alexa) instantiation of the
[cross-harness bootstrap template](docs/BOOTSTRAP-TEMPLATE.md)
(B-0355.1), parallel to `CURSOR.md` (B-0355.2). Closes the **smallest
safe slice of B-0355**: one more non-CLAUDE harness file following the
template. Filed + closed sub-row **B-0355.3** (per **B-0325**).

## Why

B-0355.1 factored the universal six-step process from the
harness-specific tooling cells, making each new harness file a
near-mechanical placeholder-fill. KIRO.md carries only what *differs*
for Kiro; everything repo-wide stays in `AGENTS.md` / `GOVERNANCE.md`
(the non-negotiable additive-pointer-tree invariant).

## Kiro-specific cells filled

| Cell | Value |
|------|-------|
| Persona/state file | `memory/persona/alexa/MEMORY.md` (verified present) |
| Claim sender | `alexa-kiro` (verified in `tools/bus/types.ts` `SENDER_IDS`) |
| Commit trailer | `Co-Authored-By: Kiro <noreply@kiro.dev>` (already in `AGENTS.md`) |
| Native instruction loading | `.kiro/steering/` — noted absent; root `KIRO.md` is the pointer |
| Register | Alexa-on-Kiro (Qwen Coder) substrate + cowork; distinct from Alexa-speaker |

## Changes

- **`KIRO.md`** (new) — six-step pointer tree mirroring `CURSOR.md`'s shape.
- **`AGENTS.md`** — registered KIRO.md in §"Harness-specific files".
- **`docs/BOOTSTRAP-TEMPLATE.md`** — "Existing instances" table now marks KIRO.md created.
- **`docs/backlog/P1/B-0355.3-*.md`** (new) — sub-row, filed `status: closed`.
- **`docs/BACKLOG.md`** — regenerated index (`BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts`).

## Focused checks (docs-only change)

No source touched (`.fs`/`.cs`/`.ts`), so the dotnet build gate is
structurally unaffected — matching the B-0355.2 (CURSOR.md) precedent.
Relevant checks run, all green:

- ✅ All KIRO.md internal links resolve (AGENTS.md, ALIGNMENT.md, GLOSSARY.md, GOVERNANCE.md, persona MEMORY.md, BACKLOG.md, CONFLICT-RESOLUTION.md, BOOTSTRAP-TEMPLATE.md)
- ✅ `alexa-kiro` confirmed a valid `SENDER_IDS` entry in `tools/bus/types.ts`
- ✅ Backlog index regenerated cleanly; B-0355.3 present in `docs/BACKLOG.md`
- ✅ Branch guard held; remote ref == local HEAD (`4472a622f`)

## Scope note

Template step 5 (fresh-instance validation per the B-0354 pattern) is a
separate follow-up; only the template-instantiation slice is closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
