### PR TITLE
feat(B-0355.4): CODEX.md cross-harness bootstrap file (Codex/Vera)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -617,10 +617,13 @@ truth for any rule that applies across harnesses.
 - **`GEMINI.md`** — Gemini CLI equivalent. Present
   at repo root; bootstrap pointer tree for fresh
   Gemini instances (per B-0538).
-- **`CODEX.md`** or **`.codex/AGENTS.md`** —
-  OpenAI Codex equivalent. Present at
-  `.codex/AGENTS.md`; it is additive and may not
-  contradict this file or `GOVERNANCE.md`.
+- **`CODEX.md`** — OpenAI Codex (Vera) session-bootstrap
+  pointer tree. Present at repo root; instantiates the
+  cross-harness bootstrap template (B-0355.4). It points
+  into the Codex-owned deep addendum at `.codex/AGENTS.md`
+  (host-loop mechanics, origin trailers, background-agent
+  discipline). Both are additive and may not contradict
+  this file or `GOVERNANCE.md`.
 - **`.github/copilot-instructions.md`** — GitHub
   Copilot Workspace / Chat instructions. Present
   and factory-managed; audited on the same cadence

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,79 @@
+# CODEX.md — OpenAI Codex session bootstrap for Zeta
+
+This is the OpenAI Codex (Vera) addendum. [`AGENTS.md`](AGENTS.md) and
+[`GOVERNANCE.md`](GOVERNANCE.md) remain authoritative; this file is
+**additive** and **may not contradict** them. It instantiates the
+[cross-harness bootstrap template](docs/BOOTSTRAP-TEMPLATE.md) (B-0355)
+with the Codex-specific tooling references filled in. The deep Codex
+host-loop mechanics live in [`.codex/AGENTS.md`](.codex/AGENTS.md)
+(Codex-owned); this root file is the cross-harness-discoverable pointer
+tree into the same six-step process.
+
+## 1. Orient
+
+Read: [`AGENTS.md`](AGENTS.md) → [`docs/ALIGNMENT.md`](docs/ALIGNMENT.md) →
+[`docs/GLOSSARY.md`](docs/GLOSSARY.md) → [`GOVERNANCE.md`](GOVERNANCE.md)
+(scan when §N cited).
+Then read the Codex addendum + state file:
+[`.codex/AGENTS.md`](.codex/AGENTS.md) → [`.codex/CURRENT-codex.md`](.codex/CURRENT-codex.md).
+
+## 2. Refresh
+
+Run:
+
+```bash
+bun tools/github/refresh-worldview.ts
+```
+
+Read active trajectories: `docs/trajectories/*/RESUME.md`.
+
+## 3. Pick work
+
+Open [`docs/BACKLOG.md`](docs/BACKLOG.md) (canonical rows live in
+`docs/backlog/P*/`). Complete the backlog-item start gate (prior-art
+search + dependency check). Claim before worktree work with the
+Codex-tagged sender ID:
+
+```bash
+bun tools/bus/claim.ts acquire --from vera-codex --item <B-NNNN>
+```
+
+Codex sessions additionally follow the claim-branch + heartbeat
+discipline in [`docs/AGENT-CLAIM-PROTOCOL.md`](docs/AGENT-CLAIM-PROTOCOL.md)
+and [`.codex/AGENTS.md`](.codex/AGENTS.md) when other agents share the
+machine.
+
+## 4. Build
+
+```bash
+dotnet build -c Release   # 0 warnings, 0 errors — TreatWarningsAsErrors is on
+dotnet test Zeta.sln -c Release
+```
+
+## 5. Ship
+
+Open a PR against `main`. Arm auto-merge if green
+(`gh pr merge <N> --auto --squash`).
+Commit trailer: `Co-Authored-By: Codex <noreply@openai.com>`.
+
+## 6. When stuck
+
+See [`docs/CONFLICT-RESOLUTION.md`](docs/CONFLICT-RESOLUTION.md). On
+deadlock, the human decides.
+
+## Conventions
+
+- **Register** — Vera operates the implementation peer axis: concrete
+  builds, large-context synthesis, getting the work shipped.
+- **Speaker prefix** — Codex / Vera prefixes user-visible chat updates
+  with `Vera:` while multiple agent surfaces are active (per `AGENTS.md`
+  §"Visible speaker prefixes").
+- **Ownership boundary** — Codex owns `.codex/**` content; other
+  harnesses point into it but do not routine-edit it. The deep host-loop
+  mechanics, origin trailers, and background-agent discipline stay in
+  [`.codex/AGENTS.md`](.codex/AGENTS.md), never re-stated here.
+- **Worktree isolation** — never edit the contested root checkout. Write
+  from a dedicated worktree off `origin/main` (per
+  `.claude/rules/agent-worktree-hygiene-*` + `docs/AGENT-CLAIM-PROTOCOL.md`).
+  Do not hold `main` in an agent worktree.
+- **Agents, not bots** — every AI carries agency (GOVERNANCE.md §3).

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -218,6 +218,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0354.4](backlog/P1/B-0354.4-clean-prompt-live-model-fresh-instance-run.md)** Clean-prompt live-model fresh-instance run for bootstrap CLAUDE.md
 - [ ] **[B-0355](backlog/P1/B-0355-cross-harness-bootstrap-template.md)** Cross-harness bootstrap template (AGENTS.md, CODEX.md, CURSOR.md)
 - [x] **[B-0355.3](backlog/P1/B-0355.3-kiro-md-harness-bootstrap.md)** KIRO.md — Amazon Kiro (Alexa) harness bootstrap file
+- [x] **[B-0355.4](backlog/P1/B-0355.4-codex-md-harness-bootstrap.md)** CODEX.md — OpenAI Codex (Vera) harness bootstrap file
 - [ ] **[B-0356](backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md)** Capture model + token usage in commit trailer (git-native, cost derived at query time)
 - [x] **[B-0357](backlog/P1/B-0357-replace-tautology-z3-agenda-proofs-with-real-verification.md)** Replace tautology Z3 agenda/trajectory proofs with non-trivial verification
 - [x] **[B-0358](backlog/P1/B-0358-bool-as-degenerate-distribution-confidence-typed-apis.md)** Bool as degenerate distribution — replace binary API returns with confidence scores

--- a/docs/BOOTSTRAP-TEMPLATE.md
+++ b/docs/BOOTSTRAP-TEMPLATE.md
@@ -106,7 +106,8 @@ process-ification). New harness files should match their shape.
 |------|---------|--------|
 | [`CLAUDE.md`](../CLAUDE.md) | Claude Code | Canonical six-step process + Conventions pointer tree (B-0353). |
 | [`GEMINI.md`](../GEMINI.md) | Gemini CLI / Antigravity (Lior) | Boot sequence pointing into shared factory physics + persona file (B-0538). |
-| [`.codex/AGENTS.md`](../.codex/AGENTS.md) | OpenAI Codex (Vera) | Additive addendum: read-order, worktree discipline, commit trailers. |
+| [`CODEX.md`](../CODEX.md) | OpenAI Codex (Vera) | Six-step pointer tree at repo root (B-0355.4); points into `.codex/AGENTS.md` for deep host-loop mechanics. |
+| [`.codex/AGENTS.md`](../.codex/AGENTS.md) | OpenAI Codex (Vera) | Codex-owned deep addendum: read-order, worktree discipline, commit/origin trailers, background-agent discipline. |
 | [`.github/copilot-instructions.md`](../.github/copilot-instructions.md) | GitHub Copilot | Factory-managed instructions, audited on the skill-file cadence (GOVERNANCE.md §31). |
 | [`CURSOR.md`](../CURSOR.md) | Cursor IDE (Riven) | Six-step pointer tree at repo root (B-0355.2). Native `.cursor/rules/` still absent. |
 | [`KIRO.md`](../KIRO.md) | Amazon Kiro (Alexa) | Six-step pointer tree at repo root (B-0355.3, per B-0325). Native `.kiro/steering/` still absent. |

--- a/docs/backlog/P1/B-0355.4-codex-md-harness-bootstrap.md
+++ b/docs/backlog/P1/B-0355.4-codex-md-harness-bootstrap.md
@@ -1,0 +1,83 @@
+---
+id: B-0355.4
+priority: P1
+status: closed
+title: "CODEX.md — OpenAI Codex (Vera) harness bootstrap file"
+created: 2026-05-29
+last_updated: 2026-05-29
+depends_on:
+  - B-0355.1
+decomposition: atomic
+classification: buildable
+type: friction-reducer
+owners: [architect]
+parent: B-0355
+composes_with:
+  - B-0355.2
+  - B-0355.3
+---
+
+# B-0355.4 — CODEX.md harness bootstrap file
+
+## What
+
+Create `CODEX.md` at repo root: the OpenAI Codex (Vera) instantiation
+of the [cross-harness bootstrap template](../BOOTSTRAP-TEMPLATE.md)
+(B-0355.1). Parallel to `CURSOR.md` (B-0355.2) and `KIRO.md` (B-0355.3).
+This is the harness file named directly in the parent title
+("AGENTS.md, CODEX.md, CURSOR.md") and the last major harness without a
+root six-step pointer tree.
+
+## Why
+
+The bootstrap-template (B-0355.1) factored the universal six-step
+process from the harness-specific tooling cells. `.codex/AGENTS.md`
+already carries a rich Codex addendum, but it predates the template
+(last touched 2026-05-13) and does not follow the six-step shape — and
+`.codex/**` is Codex-owned (routine edits should come from a Codex
+session). The cross-harness-discoverable root `CODEX.md` achieves the
+template-conforming Codex bootstrap **without crossing the Codex
+ownership boundary**: it is a thin six-step pointer tree at repo root
+that points *into* `.codex/AGENTS.md` for the deep host-loop mechanics,
+composing-with rather than editing-over.
+
+## Acceptance criteria
+
+1. `CODEX.md` created at repo root following the template skeleton. ✓
+2. Registered in `AGENTS.md` §"Harness-specific files" (the entry
+   already anticipated a root `CODEX.md`). ✓
+3. Template "Existing instances" table adds a CODEX.md row and clarifies
+   the `.codex/AGENTS.md` row as the Codex-owned deep addendum. ✓
+4. Commit trailer for Codex already present in `AGENTS.md`
+   §"Commit attribution" (`Co-Authored-By: Codex <noreply@openai.com>`). ✓
+5. `.codex/**` untouched (Codex ownership boundary respected). ✓
+6. Build gate unaffected (docs-only change). ✓
+
+## Resolution
+
+Landed `CODEX.md` mirroring `CURSOR.md` / `KIRO.md` shape. Codex-specific
+cells: addendum + state files `.codex/AGENTS.md` → `.codex/CURRENT-codex.md`;
+claim sender `vera-codex` (already a valid `SENDER_IDS` entry) plus the
+claim-branch + heartbeat discipline in `docs/AGENT-CLAIM-PROTOCOL.md`;
+commit trailer `Co-Authored-By: Codex <noreply@openai.com>` (already in
+`AGENTS.md`); `Vera:` speaker prefix; Codex ownership boundary noted
+(`.codex/**` stays Vera's lane). Registered in `AGENTS.md` and added to
+the `docs/BOOTSTRAP-TEMPLATE.md` "Existing instances" table.
+
+Process-ifying `.codex/AGENTS.md` itself into the six-step shape is a
+Codex-lane follow-up (Vera), deliberately not done here to respect the
+ownership boundary. Fresh-instance validation (template step 5, per the
+B-0354 pattern) is also a separate follow-up; only the
+template-instantiation slice is closed here.
+
+## Effort
+
+XS — template instantiation + two registrations, docs-only.
+
+## Lineage
+
+- **B-0355** — parent (cross-harness bootstrap template); title names
+  AGENTS.md, CODEX.md, CURSOR.md — this closes the CODEX.md member.
+- **B-0355.1** — the template (`docs/BOOTSTRAP-TEMPLATE.md`).
+- **B-0355.2** — `CURSOR.md` (sibling precedent).
+- **B-0355.3** — `KIRO.md` (sibling precedent).


### PR DESCRIPTION
## What

Adds root **`CODEX.md`** — the OpenAI Codex (Vera) instantiation of the
[cross-harness bootstrap template](docs/BOOTSTRAP-TEMPLATE.md) (B-0355.1),
mirroring `CURSOR.md` (B-0355.2) and `KIRO.md` (B-0355.3). Closes the
`CODEX.md` member of the parent title *"Cross-harness bootstrap template
(AGENTS.md, CODEX.md, CURSOR.md)"*.

Files (docs-only, 5):
- `CODEX.md` (new) — six-step pointer tree, Codex-specific cells filled.
- `AGENTS.md` — registry entry updated (the slot already anticipated a root `CODEX.md`).
- `docs/BOOTSTRAP-TEMPLATE.md` — Existing-instances table: CODEX.md row added; `.codex/AGENTS.md` clarified as the Codex-owned deep addendum.
- `docs/backlog/P1/B-0355.4-codex-md-harness-bootstrap.md` (new) — slice row, status closed.
- `docs/BACKLOG.md` — index regenerated (+1 row).

## Why this shape (ownership-respecting)

Acceptance criterion 2 names `.codex/AGENTS.md`, but that file is
**Codex-owned** ("routine edits should come from a Codex session") and
predates the template (last touched 2026-05-13). Rather than cross the
ownership boundary, root `CODEX.md` is a thin six-step pointer tree that
points *into* `.codex/AGENTS.md` for the deep host-loop mechanics —
composing-with, not editing-over. `.codex/**` is untouched (verified
pre-commit). Process-ifying `.codex/AGENTS.md` itself is deferred to
Vera's lane.

## Focused checks

- `bun tools/backlog/lint-frontmatter.ts` → **CLEAN on B-0355.4** (no
  findings; the row carries no `depends_on`/`composes_with` redundancy —
  one degree cleaner than the .3 precedent).
- `bun tools/backlog/generate-index.ts --check` → drift was exactly the
  B-0355.4 insertion; regenerated with `BACKLOG_WRITE_FORCE=1`; index now
  lists the row in sorted position.
- Commit canary: parent tree 65 → HEAD 66 root entries (+1 = new root
  `CODEX.md`); no tree collapse.
- **Build gate: unaffected.** Diff touches zero `.fs`/`.cs`/`.fsproj`
  files (markdown-only), so `dotnet build -c Release` is provably
  unchanged; a full build was not run to avoid minutes of cost for zero
  signal (substrate-honest; matches the B-0355.3 docs-only precedent).

operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
