### PR TITLE
chore(B-0355): close cross-harness bootstrap template — completed via children

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -216,7 +216,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0353](backlog/P1/B-0353-write-bootstrap-process-claude-md.md)** Write bootstrap-process CLAUDE.md (<50 lines)
 - [x] **[B-0354](backlog/P1/B-0354-fresh-instance-validation-bootstrap-claude-md.md)** Fresh-instance validation test for bootstrap CLAUDE.md
 - [ ] **[B-0354.4](backlog/P1/B-0354.4-clean-prompt-live-model-fresh-instance-run.md)** Clean-prompt live-model fresh-instance run for bootstrap CLAUDE.md
-- [ ] **[B-0355](backlog/P1/B-0355-cross-harness-bootstrap-template.md)** Cross-harness bootstrap template (AGENTS.md, CODEX.md, CURSOR.md)
+- [x] **[B-0355](backlog/P1/B-0355-cross-harness-bootstrap-template.md)** Cross-harness bootstrap template (AGENTS.md, CODEX.md, CURSOR.md)
 - [x] **[B-0355.3](backlog/P1/B-0355.3-kiro-md-harness-bootstrap.md)** KIRO.md — Amazon Kiro (Alexa) harness bootstrap file
 - [x] **[B-0355.4](backlog/P1/B-0355.4-codex-md-harness-bootstrap.md)** CODEX.md — OpenAI Codex (Vera) harness bootstrap file
 - [ ] **[B-0356](backlog/P1/B-0356-capture-model-cost-on-every-pr-description.md)** Capture model + token usage in commit trailer (git-native, cost derived at query time)

--- a/docs/backlog/P1/B-0355-cross-harness-bootstrap-template.md
+++ b/docs/backlog/P1/B-0355-cross-harness-bootstrap-template.md
@@ -1,10 +1,10 @@
 ---
 id: B-0355
 priority: P1
-status: open
+status: closed
 title: "Cross-harness bootstrap template (AGENTS.md, CODEX.md, CURSOR.md)"
 created: 2026-05-09
-last_updated: 2026-05-09
+last_updated: 2026-05-29
 depends_on:
   - B-0354
 decomposition: atomic
@@ -55,3 +55,49 @@ not from memorizing harness-specific doctrine.
 ## Effort
 
 S — template + one instance, ~2 hours.
+
+## Resolution (2026-05-29 — completed via children + direct landings)
+
+Closed as **completed**. All four acceptance criteria are satisfied
+by substrate already on `main`; the parent row had drifted `open`
+while the work landed through child rows and direct commits:
+
+1. **Template document** — [`docs/BOOTSTRAP-TEMPLATE.md`](../../BOOTSTRAP-TEMPLATE.md)
+   exists with the six-step skeleton, the non-negotiable invariant,
+   the "Existing instances" registry, and the "How to add a new
+   harness" procedure. ✓
+2. **≥1 non-CLAUDE harness file** — multiple landed:
+   [`CODEX.md`](../../../CODEX.md) (B-0355.4, #6045, closed),
+   [`CURSOR.md`](../../../CURSOR.md) (B-0355.2, #6042),
+   [`KIRO.md`](../../../KIRO.md) (B-0355.3, #6043, closed),
+   [`GEMINI.md`](../../../GEMINI.md) (B-0538), plus
+   `.codex/AGENTS.md` and `.github/copilot-instructions.md`. ✓
+3. **Universal vs harness-specific documented** — `docs/BOOTSTRAP-TEMPLATE.md`
+   §"Universal vs harness-specific" carries the per-step table
+   (universal column + harness-specific fill-in column). ✓
+4. **Build gate** — this close-out is docs-only (backlog-row + index
+   regeneration); no `.cs`/`.fs`/`.fsproj` touched, so the Release
+   build + test surface is unaffected. The harness-file landings
+   that satisfied criteria 1–3 each passed CI on their own PRs
+   (#6042/#6043/#6045). ✓
+
+### Child / sibling rows
+
+- **B-0355.2** — CURSOR.md (merged #6042)
+- **B-0355.3** — KIRO.md (closed, #6043)
+- **B-0355.4** — CODEX.md (closed, #6045)
+
+### Dependency + still-open sibling
+
+The named blocker `depends_on: B-0354` ("Fresh-instance validation
+test for bootstrap CLAUDE.md") is itself **closed** — the dependency
+is satisfied.
+
+The still-open row in the cluster is **B-0354.4** ("Clean-prompt
+live-model fresh-instance run for bootstrap CLAUDE.md"). That is the
+**cluster-wide fresh-instance validation** — step 5 of the template's
+"How to add a new harness" procedure — not part of B-0355's own
+acceptance criteria (template + ≥1 harness file + universal/
+harness-specific doc + build), all of which are met independently.
+B-0354.4 stays open to track that validation work for the broader
+bootstrap cluster (parent B-0329); it does not block closing B-0355.


### PR DESCRIPTION
## What

Closes **B-0355** (Cross-harness bootstrap template). The parent row had drifted `status: open` while all four acceptance criteria were already satisfied on `main` via child rows + direct landings. This is a substrate-honest close-out (no new bootstrap authoring), per `backlog-item-start-gate` Step 0 (drift discriminator).

## Why this is a close-out, not a build

Applied the drift discriminator: read the row's **Acceptance criteria**, existence-checked every primary artifact. All present:

| # | Acceptance criterion | Evidence on `main` |
|---|---|---|
| 1 | Template at `docs/BOOTSTRAP-TEMPLATE.md` | exists — six-step skeleton + non-negotiable invariant + "Existing instances" registry + "How to add a new harness" proc |
| 2 | ≥1 non-CLAUDE harness file | `CODEX.md` (B-0355.4 #6045), `CURSOR.md` (B-0355.2 #6042), `KIRO.md` (B-0355.3 #6043), `GEMINI.md` (B-0538), `.codex/AGENTS.md`, `.github/copilot-instructions.md` |
| 3 | Universal vs harness-specific documented | `docs/BOOTSTRAP-TEMPLATE.md` §"Universal vs harness-specific" per-step table |
| 4 | Build gate | docs-only close-out; no `.cs`/`.fs`/`.fsproj` touched; harness landings passed CI on their own PRs |

Child rows **B-0355.2/.3/.4** are merged/closed. Named blocker `depends_on: B-0354` ("Fresh-instance validation test") is itself **closed** — dependency satisfied. Still-open **B-0354.4** ("clean-prompt live-model fresh-instance run") is cluster-wide validation (template step 5), **not** a B-0355 acceptance criterion, and is left open under parent B-0329.

## Changes

- `docs/backlog/P1/B-0355-cross-harness-bootstrap-template.md` — `status: open → closed`, `last_updated → 2026-05-29`, added **Resolution** section.
- `docs/BACKLOG.md` — regenerated via `BACKLOG_WRITE_FORCE=1 bun tools/backlog/generate-index.ts` (single-line flip `B-0355 [ ] → [x]`).

## Focused checks run

- `bun tools/backlog/generate-index.ts` → `wrote docs/BACKLOG.md`; `git diff --stat` = **1 file, 1 insertion, 1 deletion** (scoped to the B-0355 line — no unrelated rows swept).
- Push verified against ground-truth `git ls-remote` (local SHA == remote SHA) per B-0615.
- No `.NET` build run: zero buildable-source files in the diff (docs/backlog markdown only), so the Release build + test surface is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)