### PR TITLE
chore(B-0329): close parent — bootstrap-process CLAUDE.md fully shipped via children

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -190,7 +190,7 @@ are closed (status: closed in frontmatter)._
 - [x] **[B-0326](backlog/P1/B-0326-peer-call-kiro-ts-wrapper.md)** Author kiro.ts peer-call wrapper
 - [x] **[B-0327](backlog/P1/B-0327-peer-call-claude-ts-self-call-cold-boot.md)** Author claude.ts self-call wrapper — subprocess mode for cold-boot self-testing
 - [x] **[B-0328](backlog/P1/B-0328-peer-call-readme-kiro-claude-entries.md)** Update peer-call/README.md with kiro.ts + claude.ts entries
-- [ ] **[B-0329](backlog/P1/B-0329-claude-md-as-process-not-doctrine.md)** Replace CLAUDE.md doctrine with bootstrap process — rules emerge from walking, not memorizing
+- [x] **[B-0329](backlog/P1/B-0329-claude-md-as-process-not-doctrine.md)** Replace CLAUDE.md doctrine with bootstrap process — rules emerge from walking, not memorizing
 - [x] **[B-0330](backlog/P1/B-0330-memory-format-standardization-step2-b0190.md)** Memory-format standardization — define frontmatter shape, filename conventions, section headers
 - [x] **[B-0331](backlog/P1/B-0331-memory-ontology-classification-audit-step3-b0190.md)** Memory ontology/classification audit — reclassify mistyped feedback/project/user/reference files
 - [x] **[B-0332](backlog/P1/B-0332-memory-load-bearing-vs-decorative-classifier-step7-b0190.md)** Memory load-bearing-vs-decorative classifier — identify which memory files are cited from bootstrap surfaces

--- a/docs/backlog/P1/B-0329-claude-md-as-process-not-doctrine.md
+++ b/docs/backlog/P1/B-0329-claude-md-as-process-not-doctrine.md
@@ -1,7 +1,7 @@
 ---
 id: B-0329
 priority: P1
-status: open
+status: closed
 title: "Replace CLAUDE.md doctrine with bootstrap process — rules emerge from walking, not memorizing"
 created: 2026-05-08
 last_updated: 2026-05-29
@@ -106,6 +106,29 @@ row). Optional clean-prompt live-run follow-up filed as B-0354.4.
 
 With B-0354 closed, **B-0355** (cross-harness bootstrap template) is now
 unblocked — it was the only remaining gated child.
+
+## Resolution (2026-05-29, otto-cli bg-worker)
+
+Closed as **substrate-fully-shipped-via-children**. All 8 decomposition
+children (B-0348..B-0355) are `status: closed`, and every acceptance
+criterion is satisfied on disk:
+
+| # | Acceptance criterion | Evidence on `origin/main` | Shipped via |
+|---|---|---|---|
+| 1 | CLAUDE.md is a bootstrap process, not 200+ rules | `CLAUDE.md` is 76 lines (6-step process + conventions), down from the carved-rule monolith; the 200+ rules now live in the 99-file `.claude/rules/` auto-load surface | B-0349..B-0353 |
+| 2 | Process generates equivalent behavior | Extracted rules auto-load at cold-boot (empirically confirmed per `.claude/rules/test-canary.md`); the process regenerates the cache (`cache = I ∘ D`) | B-0349..B-0352 |
+| 3 | Fresh instance with bootstrap-only produces coherent first PR | B-0354 (.1 static validator + .2 pointer check + .3 findings report); the validator PASSES against the live bootstrap CLAUDE.md, and the .3 report records a real bg-worker session as a fresh-instance datapoint | B-0354 |
+| 4 | Template for AGENTS.md / CODEX.md / CURSOR.md equivalents | `AGENTS.md`, `CODEX.md`, `CURSOR.md`, `KIRO.md`, `GEMINI.md` all present | B-0355 + .2/.3/.4 |
+| 5 | Other-harness agents can follow the same pattern | Cross-harness bootstrap files cover Codex/Vera, Cursor/Riven, Kiro/Alexa, Gemini/Lior | B-0355 |
+
+Per `.claude/rules/backlog-item-start-gate.md` Step 0 (substrate-drift
+discriminator): row was `open` but the work had already landed through
+its children, so the correct disposition is **close-as-drift**, not
+re-implement. The last gated child (B-0355) closed via #6046; this row
+was the residual open-parent.
+
+Follow-up `B-0354.4` (optional clean-prompt live-run) remains its own
+row and is NOT a blocker for this parent.
 
 ## Composes with
 


### PR DESCRIPTION
## What

Closes parent row **B-0329** (CLAUDE.md as process, not doctrine) as
**substrate-fully-shipped-via-children**. Flips `status: open → closed`,
adds a Resolution section with a per-criterion evidence table, and
regenerates `docs/BACKLOG.md` (B-0329 now `[x]`).

## Why this is a close, not an implementation

Per `.claude/rules/backlog-item-start-gate.md` Step 0 (substrate-drift
discriminator): the row was `open` but all 8 children (B-0348..B-0355)
are `closed` and the work has already landed on `origin/main`. The
correct disposition is **close-as-drift**, not re-implement. The last
gated child B-0355 closed via #6046; this row was the residual
open-parent.

## Acceptance criteria — verified on disk

| # | Criterion | Evidence | Shipped via |
|---|---|---|---|
| 1 | CLAUDE.md is a bootstrap process, not 200+ rules | `CLAUDE.md` = 76 lines (6-step process + conventions); rules live in 99-file `.claude/rules/` auto-load surface | B-0349..B-0353 |
| 2 | Process regenerates equivalent behavior | rules auto-load at cold-boot (`.claude/rules/test-canary.md`); `cache = I ∘ D` | B-0349..B-0352 |
| 3 | Fresh instance produces coherent first PR | B-0354 (static validator PASSES + findings report) | B-0354 |
| 4 | Template for AGENTS/CODEX/CURSOR equivalents | `AGENTS.md`, `CODEX.md`, `CURSOR.md`, `KIRO.md`, `GEMINI.md` all present | B-0355 |
| 5 | Other-harness agents follow the pattern | cross-harness files cover Vera/Riven/Alexa/Lior | B-0355 |

Follow-up `B-0354.4` (optional clean-prompt live-run) stays its own
row and does NOT block this parent.

## Focused checks

- `bun tools/backlog/generate-index.ts` (BACKLOG_WRITE_FORCE=1) → exit 0;
  `docs/BACKLOG.md` updates B-0329 to `[x]`.
- Verified all 8 children `status: closed` via `awk` on each row file.
- Verified criterion-1/4/5 artifacts present via `wc -l CLAUDE.md` (76)
  + `ls .claude/rules/*.md | wc -l` (99) + cross-harness file `ls`.

Docs-only change; no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)