### PR TITLE
feat(B-0164.1): divergence-shard writer — unblocked tooling slice

### DIFF
--- a/tools/hygiene/divergence-shard.test.ts
+++ b/tools/hygiene/divergence-shard.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  type DivergenceInput,
+  buildDivergenceShard,
+  divergenceShardRelPath,
+  shortContentHash,
+  writeDivergenceShard,
+  writeShardAtPath,
+} from "./divergence-shard";
+
+const TICK = "2026-05-10T11:48:00Z";
+
+const INPUT: DivergenceInput = {
+  tick: TICK,
+  loopA: {
+    identity: { agent: "otto", model: "claude-opus-4-8", harness: "claude-code" },
+    body: "Resolve thread: the finding is a false positive (table double-pipe class).",
+  },
+  loopB: {
+    identity: { agent: "codex-loop", model: "gpt-5.5", harness: "codex" },
+    body: "Do not resolve: the finding reproduces under local lint; needs a fix.",
+  },
+  topic: 'PR #4147 thread PRRT_kwExample — "double-pipe" lint finding',
+  disagreementSummary:
+    "Both loops reviewed the same thread; Loop A reads it as a known false-positive class, Loop B reproduces it locally. The observable delta is resolve-vs-fix.",
+  operativeAuthorization: 'aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing"',
+};
+
+function withTempRoot<T>(fn: (root: string) => T): T {
+  const root = mkdtempSync(join(tmpdir(), "diverge-test-"));
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("shortContentHash", () => {
+  test("is 8 lowercase hex chars", () => {
+    expect(shortContentHash("a", "b")).toMatch(/^[0-9a-f]{8}$/);
+  });
+  test("is deterministic for identical inputs", () => {
+    expect(shortContentHash("alpha", "beta")).toBe(shortContentHash("alpha", "beta"));
+  });
+  test("differs when bodies differ", () => {
+    expect(shortContentHash("alpha", "beta")).not.toBe(shortContentHash("alpha", "gamma"));
+  });
+  test("swapping loop-A/loop-B bodies changes the hash", () => {
+    // README spec hashes the bare concatenation (no delimiter): "ab"+"c" vs
+    // "c"+"ab" → "abc" vs "cab", which differ. (Bodies that concatenate to the
+    // same string — e.g. "x"+"yy" vs "xy"+"y" — do collide; that is the
+    // schema's defined behaviour, faithfully reproduced here.)
+    expect(shortContentHash("ab", "c")).not.toBe(shortContentHash("c", "ab"));
+  });
+});
+
+describe("divergenceShardRelPath", () => {
+  test("produces the canonical YYYY/MM/DD/HHMMSSZ-<hash>.md shape", () => {
+    const p = divergenceShardRelPath(TICK, "a", "b");
+    expect(p).toBe(
+      `docs/hygiene-history/divergences/2026/05/10/114800Z-${shortContentHash("a", "b")}.md`,
+    );
+  });
+  test("rejects a tick that is not ISO 8601 UTC seconds precision", () => {
+    expect(() => divergenceShardRelPath("2026-05-10T11:48Z", "a", "b")).toThrow(/invalid tick/);
+    expect(() => divergenceShardRelPath("not-a-date", "a", "b")).toThrow(/invalid tick/);
+  });
+});
+
+describe("buildDivergenceShard", () => {
+  const md = buildDivergenceShard(INPUT);
+
+  test("has type: divergence frontmatter and both loop identities", () => {
+    expect(md).toContain("type: divergence");
+    expect(md).toContain("agent: otto");
+    expect(md).toContain('model: "claude-opus-4-8"');
+    expect(md).toContain("harness: claude-code");
+    expect(md).toContain("agent: codex-loop");
+    expect(md).toContain('model: "gpt-5.5"');
+  });
+
+  test("quotes the tick and topic as YAML strings", () => {
+    expect(md).toContain(`tick: "${TICK}"`);
+    expect(md).toContain("topic: ");
+    // topic contains embedded double-quotes; JSON/YAML escaping must apply
+    expect(md).toContain('\\"double-pipe\\"');
+  });
+
+  test("carries all four required body sections in order", () => {
+    const idxA = md.indexOf("## Loop A perspective");
+    const idxB = md.indexOf("## Loop B perspective");
+    const idxSummary = md.indexOf("## Disagreement summary");
+    const idxRecon = md.indexOf("## Reconciliation");
+    expect(idxA).toBeGreaterThanOrEqual(0);
+    expect(idxA).toBeLessThan(idxB);
+    expect(idxB).toBeLessThan(idxSummary);
+    expect(idxSummary).toBeLessThan(idxRecon);
+  });
+
+  test("attributes each perspective with agent (model, harness)", () => {
+    expect(md).toContain("otto (claude-opus-4-8, claude-code): Resolve thread:");
+    expect(md).toContain("codex-loop (gpt-5.5, codex): Do not resolve:");
+  });
+
+  test("leaves Reconciliation as a maintainer-fills-in placeholder", () => {
+    expect(md).toContain("Leave blank until morning reconciliation");
+    expect(md).toContain("accept-loop-a | accept-loop-b | accept-both (explicit divergence) | escalate");
+  });
+
+  test("is standalone-readable (no external context: PR/topic + delta present)", () => {
+    // AC #3: shard readable as a standalone reconciliation document. The topic
+    // is YAML/JSON-escaped in frontmatter, so assert its distinctive substring
+    // rather than byte-equality through the escaping layer.
+    expect(md).toContain("PR #4147 thread PRRT_kwExample");
+    expect(md).toContain("double-pipe");
+    expect(md).toContain(INPUT.disagreementSummary);
+  });
+
+  test("rejects a malformed tick", () => {
+    expect(() => buildDivergenceShard({ ...INPUT, tick: "2026/05/10" })).toThrow(/invalid tick/);
+  });
+});
+
+describe("writeShardAtPath (fail-closed-OR-idempotent)", () => {
+  test("writes when the path is free", () => {
+    withTempRoot((root) => {
+      const p = join(root, "a/b/c/shard.md");
+      const r = writeShardAtPath(p, "hello");
+      expect(r.status).toBe("written");
+      expect(r.absPath).toBe(p);
+      expect(readFileSync(p, "utf8")).toBe("hello");
+    });
+  });
+
+  test("is an idempotent noop when identical content already exists", () => {
+    withTempRoot((root) => {
+      const p = join(root, "shard.md");
+      mkdirSync(dirname(p), { recursive: true });
+      writeFileSync(p, "same");
+      const r = writeShardAtPath(p, "same");
+      expect(r.status).toBe("idempotent-noop");
+      expect(r.absPath).toBe(p);
+    });
+  });
+
+  test("fail-closes to a unique suffix when differing content occupies the path", () => {
+    withTempRoot((root) => {
+      const p = join(root, "shard.md");
+      mkdirSync(dirname(p), { recursive: true });
+      writeFileSync(p, "ORIGINAL — must not be overwritten");
+      const r = writeShardAtPath(p, "DIFFERENT content");
+      expect(r.status).toBe("collision-resolved");
+      expect(r.absPath).toBe(join(root, "shard-2.md"));
+      // original is preserved (divergence evidence not erased)
+      expect(readFileSync(p, "utf8")).toBe("ORIGINAL — must not be overwritten");
+      expect(readFileSync(r.absPath, "utf8")).toBe("DIFFERENT content");
+    });
+  });
+
+  test("collision resolution is itself idempotent on a re-run", () => {
+    withTempRoot((root) => {
+      const p = join(root, "shard.md");
+      mkdirSync(dirname(p), { recursive: true });
+      writeFileSync(p, "ORIGINAL");
+      const first = writeShardAtPath(p, "SECOND");
+      const second = writeShardAtPath(p, "SECOND");
+      expect(first.absPath).toBe(join(root, "shard-2.md"));
+      expect(second.status).toBe("idempotent-noop");
+      expect(second.absPath).toBe(join(root, "shard-2.md"));
+    });
+  });
+});
+
+describe("writeDivergenceShard", () => {
+  test("writes to the canonical content-addressed path under repoRoot", () => {
+    withTempRoot((root) => {
+      const r = writeDivergenceShard(root, INPUT);
+      expect(r.status).toBe("written");
+      expect(r.relPath).toBe(
+        divergenceShardRelPath(TICK, INPUT.loopA.body, INPUT.loopB.body),
+      );
+      expect(existsSync(join(root, r.relPath))).toBe(true);
+    });
+  });
+
+  test("identical re-run is an idempotent noop (content-addressing)", () => {
+    withTempRoot((root) => {
+      writeDivergenceShard(root, INPUT);
+      const again = writeDivergenceShard(root, INPUT);
+      expect(again.status).toBe("idempotent-noop");
+    });
+  });
+
+  test("refuses to file when loop bodies are byte-identical (no divergence)", () => {
+    const sameBody = "identical conclusion";
+    expect(() =>
+      writeDivergenceShard("/tmp/unused", {
+        ...INPUT,
+        loopA: { ...INPUT.loopA, body: sameBody },
+        loopB: { ...INPUT.loopB, body: sameBody },
+      }),
+    ).toThrow(/no divergence to preserve/);
+  });
+});

--- a/tools/hygiene/divergence-shard.ts
+++ b/tools/hygiene/divergence-shard.ts
@@ -22,7 +22,7 @@
 // Schema source of truth: docs/hygiene-history/divergences/README.md
 
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 /** A single loop's identity for attribution in the shard frontmatter. */
@@ -176,9 +176,14 @@ export function writeShardAtPath(
   absPath: string,
   content: string,
 ): { absPath: string; status: WriteStatus } {
-  if (!existsSync(absPath)) {
-    mkdirSync(dirname(absPath), { recursive: true });
-    writeFileSync(absPath, content);
+  // Atomic exclusive create ("wx" === O_CREAT | O_EXCL): create-if-absent is a
+  // single kernel operation, so there is no existsSync->writeFileSync TOCTOU
+  // window for a competing process to win, and it refuses to write through a
+  // pre-planted symlink. The EEXIST throw IS the signal that the file already
+  // exists -- exceptions-as-signals over a defensive pre-check (per
+  // .claude/rules/force-push-with-lease-authorization-policy.md). Resolves the
+  // CodeQL "file system race condition" + "insecure temporary file" findings.
+  if (tryExclusiveWrite(absPath, content)) {
     return { absPath, status: "written" };
   }
   if (readFileSync(absPath, "utf8") === content) {
@@ -189,14 +194,31 @@ export function writeShardAtPath(
   const dotMd = absPath.endsWith(".md") ? absPath.slice(0, -3) : absPath;
   for (let n = 2; ; n++) {
     const candidate = `${dotMd}-${n}.md`;
-    if (!existsSync(candidate)) {
-      mkdirSync(dirname(candidate), { recursive: true });
-      writeFileSync(candidate, content);
+    if (tryExclusiveWrite(candidate, content)) {
       return { absPath: candidate, status: "collision-resolved" };
     }
     if (readFileSync(candidate, "utf8") === content) {
       return { absPath: candidate, status: "idempotent-noop" };
     }
+  }
+}
+
+/**
+ * Atomically create `absPath` with `content` using an exclusive write flag.
+ * Returns true if this call created the file, false if it already existed.
+ * Any error other than EEXIST is re-thrown (a genuine I/O failure, not a
+ * "someone else has it" signal).
+ */
+function tryExclusiveWrite(absPath: string, content: string): boolean {
+  mkdirSync(dirname(absPath), { recursive: true });
+  try {
+    writeFileSync(absPath, content, { flag: "wx" });
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      return false;
+    }
+    throw err;
   }
 }
 

--- a/tools/hygiene/divergence-shard.ts
+++ b/tools/hygiene/divergence-shard.ts
@@ -1,0 +1,229 @@
+#!/usr/bin/env bun
+// divergence-shard.ts — writer for substrate-divergence shard files.
+//
+// Implements the tooling glue for B-0164.1 (PR-review disagreement-
+// preservation protocol, dual-loop AC #2). Given two loops' conclusions on
+// the same substrate-class commitment (e.g. a PR-review thread), this module
+// produces a divergence shard conforming to the schema landed in B-0164 AC #4
+// (docs/hygiene-history/divergences/README.md, PR #2475) and writes it to the
+// canonical path under the fail-closed-OR-idempotent rule.
+//
+// This is the UNBLOCKED slice of B-0164.1: building + filing a shard given two
+// conclusions needs no concurrent-loop harness, so it is fully testable in
+// isolation. The end-to-end protocol (detecting that two loops reviewed the
+// same thread; morning reconciliation) remains the blocked impl child pending
+// B-0160.
+//
+// Pure functions (no I/O): shortContentHash, divergenceShardRelPath,
+//   buildDivergenceShard.
+// I/O function: writeDivergenceShard (delegates the 3-way decision to
+//   writeShardAtPath, exported for direct testing).
+//
+// Schema source of truth: docs/hygiene-history/divergences/README.md
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/** A single loop's identity for attribution in the shard frontmatter. */
+export interface LoopIdentity {
+  /** Named agent identifier, e.g. "otto", "codex-loop", "vera". */
+  readonly agent: string;
+  /** Model ID string, e.g. "claude-opus-4-8", "gpt-5.5". */
+  readonly model: string;
+  /** Harness name, e.g. "claude-code", "codex". */
+  readonly harness: string;
+}
+
+/** One loop's perspective: who said it + the full framing of the position. */
+export interface LoopPerspective {
+  readonly identity: LoopIdentity;
+  /** Full framing of the position (the body of the perspective section). */
+  readonly body: string;
+}
+
+/** Everything needed to build a divergence shard. */
+export interface DivergenceInput {
+  /** ISO 8601 UTC, seconds precision, e.g. "2026-05-10T11:48:00Z". */
+  readonly tick: string;
+  readonly loopA: LoopPerspective;
+  readonly loopB: LoopPerspective;
+  /** The substrate path or topic in conflict (e.g. "PR #4147 thread <id>"). */
+  readonly topic: string;
+  /** One-paragraph neutral summary for morning reconciliation. */
+  readonly disagreementSummary: string;
+  /** operative-authorization frontmatter value (verbatim quote). */
+  readonly operativeAuthorization: string;
+}
+
+/** Outcome of a write attempt. */
+export type WriteStatus =
+  | "written" // new file created
+  | "idempotent-noop" // identical content already at path; left as-is
+  | "collision-resolved"; // differing content at path; wrote to unique suffix
+
+export interface WriteResult {
+  /** Repo-relative path the shard was (or would have been) written to. */
+  readonly relPath: string;
+  readonly status: WriteStatus;
+}
+
+const TICK_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z$/;
+const DIVERGENCE_ROOT = "docs/hygiene-history/divergences";
+
+/**
+ * 8 hex chars from sha256(loopABody + loopBBody) per the README naming rule.
+ * Content-addressing: identical bodies → identical hash → identical path
+ * (enables the idempotent re-write case).
+ */
+export function shortContentHash(loopABody: string, loopBBody: string): string {
+  return createHash("sha256")
+    .update(loopABody + loopBBody)
+    .digest("hex")
+    .slice(0, 8);
+}
+
+/**
+ * Canonical repo-relative shard path:
+ *   docs/hygiene-history/divergences/YYYY/MM/DD/HHMMSSZ-<short-content-hash>.md
+ *
+ * Parses `tick` by regex (TZ-free, DST-deterministic — the value is already
+ * UTC). Throws on a tick that is not ISO 8601 UTC seconds precision.
+ */
+export function divergenceShardRelPath(
+  tick: string,
+  loopABody: string,
+  loopBBody: string,
+): string {
+  const m = TICK_RE.exec(tick);
+  if (!m) {
+    throw new Error(
+      `invalid tick "${tick}": expected ISO 8601 UTC seconds precision, e.g. 2026-05-10T11:48:00Z`,
+    );
+  }
+  const [, yyyy, mm, dd, hh, min, ss] = m;
+  const hash = shortContentHash(loopABody, loopBBody);
+  return `${DIVERGENCE_ROOT}/${yyyy}/${mm}/${dd}/${hh}${min}${ss}Z-${hash}.md`;
+}
+
+/** YAML double-quoted scalar (JSON escaping is a valid YAML subset). */
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+/**
+ * Build the full shard markdown (frontmatter + 4 required body sections) per
+ * docs/hygiene-history/divergences/README.md. Pure: no I/O, no clock, no hash
+ * of anything other than the explicit inputs.
+ */
+export function buildDivergenceShard(input: DivergenceInput): string {
+  if (!TICK_RE.test(input.tick)) {
+    throw new Error(
+      `invalid tick "${input.tick}": expected ISO 8601 UTC seconds precision`,
+    );
+  }
+  const a = input.loopA;
+  const b = input.loopB;
+  const attrib = (p: LoopPerspective) =>
+    `${p.identity.agent} (${p.identity.model}, ${p.identity.harness})`;
+
+  return `---
+tick: ${yamlString(input.tick)}
+type: divergence
+loop-a:
+  agent: ${a.identity.agent}
+  model: ${yamlString(a.identity.model)}
+  harness: ${a.identity.harness}
+loop-b:
+  agent: ${b.identity.agent}
+  model: ${yamlString(b.identity.model)}
+  harness: ${b.identity.harness}
+topic: ${yamlString(input.topic)}
+operative-authorization: ${yamlString(input.operativeAuthorization)}
+---
+
+## Loop A perspective
+
+${attrib(a)}: ${a.body}
+
+## Loop B perspective
+
+${attrib(b)}: ${b.body}
+
+## Disagreement summary
+
+${input.disagreementSummary}
+
+## Reconciliation
+
+<!-- Leave blank until morning reconciliation. The human maintainer fills this in. -->
+<!-- Options: accept-loop-a | accept-loop-b | accept-both (explicit divergence) | escalate -->
+`;
+}
+
+/**
+ * Write `content` to `absPath` under the fail-closed-OR-idempotent rule:
+ *   - path free            → write it ("written")
+ *   - exists, identical    → leave as-is ("idempotent-noop")
+ *   - exists, differs      → never overwrite; write to the next free
+ *                            "-N" suffix path ("collision-resolved")
+ *
+ * Returns the absolute path actually written (or left) and the status.
+ * Exported for direct testing of the 3-way decision without manufacturing a
+ * hash collision.
+ */
+export function writeShardAtPath(
+  absPath: string,
+  content: string,
+): { absPath: string; status: WriteStatus } {
+  if (!existsSync(absPath)) {
+    mkdirSync(dirname(absPath), { recursive: true });
+    writeFileSync(absPath, content);
+    return { absPath, status: "written" };
+  }
+  if (readFileSync(absPath, "utf8") === content) {
+    return { absPath, status: "idempotent-noop" };
+  }
+  // Differing content at the target path: fail closed, never overwrite.
+  // Choose the next free unique-suffix path.
+  const dotMd = absPath.endsWith(".md") ? absPath.slice(0, -3) : absPath;
+  for (let n = 2; ; n++) {
+    const candidate = `${dotMd}-${n}.md`;
+    if (!existsSync(candidate)) {
+      mkdirSync(dirname(candidate), { recursive: true });
+      writeFileSync(candidate, content);
+      return { absPath: candidate, status: "collision-resolved" };
+    }
+    if (readFileSync(candidate, "utf8") === content) {
+      return { absPath: candidate, status: "idempotent-noop" };
+    }
+  }
+}
+
+/**
+ * Build + write a divergence shard under `repoRoot`. Enforces AC #2's intent:
+ * a divergence shard records a CONFLICT, so byte-identical loop bodies (no
+ * divergence to preserve) are rejected.
+ */
+export function writeDivergenceShard(
+  repoRoot: string,
+  input: DivergenceInput,
+): WriteResult {
+  if (input.loopA.body === input.loopB.body) {
+    throw new Error(
+      "refusing to file a divergence shard: loop bodies are byte-identical (no divergence to preserve)",
+    );
+  }
+  const relPath = divergenceShardRelPath(
+    input.tick,
+    input.loopA.body,
+    input.loopB.body,
+  );
+  const content = buildDivergenceShard(input);
+  const result = writeShardAtPath(join(repoRoot, relPath), content);
+  // Recompute the repo-relative path in case collision-resolution changed it.
+  const finalRel = result.absPath.startsWith(join(repoRoot, ""))
+    ? result.absPath.slice(join(repoRoot, "").length).replace(/^[/\\]/, "")
+    : result.absPath;
+  return { relPath: finalRel, status: result.status };
+}

--- a/tools/hygiene/divergence-shard.ts
+++ b/tools/hygiene/divergence-shard.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env bun
 // divergence-shard.ts — writer for substrate-divergence shard files.
 //
 // Implements the tooling glue for B-0164.1 (PR-review disagreement-
@@ -22,8 +21,8 @@
 // Schema source of truth: docs/hygiene-history/divergences/README.md
 
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { closeSync, mkdirSync, openSync, readFileSync, writeSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
 
 /** A single loop's identity for attribution in the shard frontmatter. */
 export interface LoopIdentity {
@@ -211,15 +210,27 @@ export function writeShardAtPath(
  */
 function tryExclusiveWrite(absPath: string, content: string): boolean {
   mkdirSync(dirname(absPath), { recursive: true });
+  let fd: number;
   try {
-    writeFileSync(absPath, content, { flag: "wx" });
-    return true;
+    // openSync with the "wx" flag (O_CREAT | O_EXCL) is the canonical exclusive
+    // create: a single kernel op that fails with EEXIST rather than following a
+    // pre-planted symlink or racing a competing writer. Using the dedicated
+    // descriptor form (rather than writeFileSync's options-object flag) is what
+    // the CodeQL insecure-temporary-file dataflow query models as a secure
+    // create, so it clears the finding substantively, not by suppression.
+    fd = openSync(absPath, "wx");
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "EEXIST") {
       return false;
     }
     throw err;
   }
+  try {
+    writeSync(fd, content);
+  } finally {
+    closeSync(fd);
+  }
+  return true;
 }
 
 /**
@@ -244,8 +255,7 @@ export function writeDivergenceShard(
   const content = buildDivergenceShard(input);
   const result = writeShardAtPath(join(repoRoot, relPath), content);
   // Recompute the repo-relative path in case collision-resolution changed it.
-  const finalRel = result.absPath.startsWith(join(repoRoot, ""))
-    ? result.absPath.slice(join(repoRoot, "").length).replace(/^[/\\]/, "")
-    : result.absPath;
-  return { relPath: finalRel, status: result.status };
+  // path.relative handles the separator boundary + cross-platform normalisation
+  // correctly, avoiding the prefix-collision edge cases of a manual slice.
+  return { relPath: relative(repoRoot, result.absPath), status: result.status };
 }


### PR DESCRIPTION
## What

The **unblocked tooling slice** of B-0164.1 (PR-review disagreement-preservation
protocol, dual-loop AC #2): a divergence-shard **writer**.

`tools/hygiene/divergence-shard.ts` builds + files a shard conforming to the
schema landed in **B-0164 AC #4** (`docs/hygiene-history/divergences/README.md`,
PR #2475), given two loops' conclusions on the same substrate-class commitment.

## Why this is the smallest safe slice (and why it's NOT blocked)

The row is `classification: blocked` because the **end-to-end protocol** needs two
loops running concurrently (B-0160). But building + filing a shard *given two
conclusions* needs no concurrent-loop harness — it is pure, deterministic, and
DST-testable in isolation. The row explicitly scopes "any tooling glue needed to
detect that two loops have reviewed the same thread" and "divergence-shard
integration" as **in scope**, and the protocol's load-bearing step is "a
divergence shard is filed."

This is a stronger smallest-safe slice than the prior re-decomposition's
"PR with no substrate mutation" (substrate-honestly hollow per Rule 0 /
"prefer F#/TS code over docs" / "substrate or it didn't happen").

The blocked remainder (detecting two loops reviewed the same thread; morning
reconciliation flow) stays the impl child pending B-0160.

## Surface

- `divergenceShardRelPath` — content-addressed canonical path
  `YYYY/MM/DD/HHMMSSZ-<8hex sha256(loopA+loopB)>.md`; **TZ-free regex tick parse**
  (DST-deterministic — value is already UTC).
- `buildDivergenceShard` — pure builder; 4 required body sections + frontmatter
  with proper YAML/JSON string escaping. (AC #3: standalone-readable.)
- `writeShardAtPath` — **fail-closed-OR-idempotent** write per the README's
  unique-filename rule: write-if-free / noop-if-identical / never-overwrite-
  differing-content (writes to next free `-N` suffix → divergence evidence is
  never erased). Exported for direct testing without manufacturing a hash collision.
- `writeDivergenceShard` — refuses byte-identical loop bodies (AC #2 intent:
  a shard records a *conflict*).

## ACs advanced (tooling layer)

- **AC #2** (shard filed whenever conclusions differ) — `writeDivergenceShard`
  files on divergence; refuses non-divergence.
- **AC #3** (standalone-readable reconciliation doc) — frontmatter + topic +
  both attributed perspectives + neutral delta summary + empty Reconciliation
  placeholder, all in one file.

Faithful to the README spec: hash is over the **bare concatenation**
`loop-a-body + loop-b-body` (no delimiter added — that would diverge from the
landed B-0164 AC #4 schema).

## Focused checks

- `bun test tools/hygiene/divergence-shard.test.ts` → **20 pass / 0 fail** (45 expect() calls).
  Covers: hash determinism/order-sensitivity, canonical path shape, malformed-tick
  rejection, all 4 frontmatter+body sections, attribution lines, the 3-way write
  decision (written / idempotent-noop / collision-resolved + original preserved),
  and the byte-identical-body refusal.
- `bunx tsc --noEmit` → **clean** on both files.
- TS-only change under `tools/hygiene/` — no .NET surface touched, so the
  `dotnet build` gate is unaffected; `bun test` is the relevant focused gate.

Closes nothing (row stays open; this advances the unblocked layer). Claimed via
`bun tools/bus/claim.ts acquire --from otto-cli --item B-0164.1`.

operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
