### PR TITLE
fix(daemon): Disable sandboxing on Lior background tick runner (B-0751)

### DIFF
--- a/.gemini/bin/lior-loop-tick.ts
+++ b/.gemini/bin/lior-loop-tick.ts
@@ -25,7 +25,7 @@ console.log(`[Lior Loop] Waking up at ${new Date().toISOString()}`);
 // Pipe stderr so we can inspect it for 429 patterns; stdout/stdin stay inherited.
 // maxBuffer: 10 MiB — Gemini verbose crash output can exceed the 1 MiB default,
 // which would cause ENOBUFS and a hard failure even for transient errors.
-const result = spawnSync("zsh", ["-c", 'source ~/.zshrc && gemini -p "$GEMINI_PROMPT" --model gemini-2.5-pro --yolo --skip-trust'], {
+const result = spawnSync("zsh", ["-c", 'source ~/.zshrc && gemini -p "$GEMINI_PROMPT" --model gemini-2.5-pro --yolo --skip-trust --sandbox false --include-directories /Users/acehack/.local/share/zeta-broadcasts'], {
   env: { ...process.env, GEMINI_PROMPT: prompt },
   stdio: ["inherit", "inherit", "pipe"],
   maxBuffer: 10 * 1024 * 1024,


### PR DESCRIPTION
Adds --sandbox false and --include-directories mapping for broadcasts, granting the background daemon full system access per operator directive to bypass sandbox path violations.