### PR TITLE
docs(B-0058.4): detect-clause-drift.ts workflow doc + close row

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -45,7 +45,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0058](backlog/P1/B-0058-ai-ethics-and-safety-research-track.md)** AI ethics + safety research track — filter-gate for resonance adoptions + alignment-clause consistency audit
 - [ ] **[B-0058.1](backlog/P1/B-0058.1-retractibility-gate.md)** AI ethics + safety research track — retractibility-and-log check
 - [x] **[B-0058.3](backlog/P1/B-0058.3-candidate-failure-honesty-log.md)** Candidate-failure honesty log
-- [ ] **[B-0058.4](backlog/P1/B-0058.4-alignment-clause-drift-detector.md)** Alignment-clause drift detector tool and workflow
+- [x] **[B-0058.4](backlog/P1/B-0058.4-alignment-clause-drift-detector.md)** Alignment-clause drift detector tool and workflow
 - [ ] **[B-0060](backlog/P1/B-0060-human-lineage-external-anchor-backfill-all-substrate-beacon-safe.md)** Human-lineage / external-anchor backfill across all factory substrate — Beacon-safe + human-anchored prior-art citations for every load-bearing concept
 - [x] **[B-0061](backlog/P1/B-0061-finish-monolith-to-per-row-migration-no-residue-aaron-2026-04-28.md)** Finish docs/BACKLOG.md monolith → per-row migration — "don't miss anything, no residue for next-Otto" (Aaron 2026-04-28)
 - [x] **[B-0063](backlog/P1/B-0063-streamed-installer-download-to-temp-checksum-pattern-codex-p0-pr-75.md)** Streamed-installer download-to-temp + checksum-verify pattern — replace pipe-to-shell for upstream installers (Codex P0 on PR #75)

--- a/docs/backlog/P1/B-0058.4-alignment-clause-drift-detector.md
+++ b/docs/backlog/P1/B-0058.4-alignment-clause-drift-detector.md
@@ -1,13 +1,13 @@
 ---
 id: B-0058.4
 priority: P1
-status: open
+status: closed
 title: Alignment-clause drift detector tool and workflow
 tier: substrate-foundational-discipline
 effort: S
 ask: Aaron 2026-04-21 (decomposed from B-0058)
 created: 2026-05-16
-last_updated: 2026-05-16
+last_updated: 2026-05-29
 decomposition: leaf
 depends_on: [B-0058]
 composes_with: [docs/ALIGNMENT.md]
@@ -37,3 +37,27 @@ Specifically, it requires building a script under `tools/` that can parse `docs/
 
 - **Owner:** Alignment-auditor (Sova).
 - **Effort:** S.
+
+## Resolution (2026-05-29)
+
+All three acceptance criteria met:
+
+1. **Script created** — `tools/alignment/detect-clause-drift.ts` (shipped to
+   `origin/main` prior to this close) walks the working tree for references to
+   alignment clauses (HC-1..HC-7, SD-1..SD-9, DIR-1..DIR-5).
+2. **Cross-references correctly identified** — `tools/alignment/detect-clause-drift.test.ts`
+   (4 tests, green) verifies the clause matcher (word-boundary + bounded numeric
+   ranges, no false positives on out-of-range IDs) and the per-clause reference map.
+3. **Workflow established** — `tools/alignment/README.md` now documents the
+   `detect-clause-drift.ts` tool in the script table and adds a
+   "Pre-renegotiation impact-survey workflow" section: before any `docs/ALIGNMENT.md`
+   clause weaken/remove is accepted, run `audit_clause_drift.ts` (names WHAT changed)
+   then `detect-clause-drift.ts <CLAUSE>` (surveys WHO references it — the blast
+   radius), then decide each referencing surface explicitly. The survey informs the
+   renegotiation; it does not gate it (measurement, not enforcement).
+
+The two clause tools compose on orthogonal axes: `audit_clause_drift.ts` is the
+*temporal* diff (between two git refs), `detect-clause-drift.ts` is the *spatial*
+survey (across the working tree). Criterion 3 was the gap this PR closed — the
+spatial tool existed but was not wired into the documented pre-renegotiation
+procedure.

--- a/tools/alignment/README.md
+++ b/tools/alignment/README.md
@@ -19,6 +19,7 @@ folder as the experimental loop.
 | `audit_archive_headers.ts` | Archive-header discipline (proposed §33) | Per-file lint (detect-only v0) |
 | `audit_clause_coverage.ts` | HC/SD/DIR clause citations in skills, agents, backlog P0/P1 | Per-surface coverage audit |
 | `audit_clause_drift.ts` | Clause additions/removals/changes + impact survey | Cross-ref drift detection |
+| `detect-clause-drift.ts` | Clause cross-references (blast radius) across the working tree | Pre-renegotiation impact survey (B-0058.4) |
 | `audit_retractibility.ts` | Git-tracked + inbound-ref entanglement per surface | Retractibility gate (B-0058 #1) |
 | `filter_gate_log.ts`  | Pass/fail/defer decisions for candidate adoptions | Honesty log (B-0058 #3) |
 | `audit_candidate_failures.ts` | Reconstruction audit for failed/deferred candidates | Honesty audit (B-0058 #3) |
@@ -79,6 +80,11 @@ bun tools/alignment/audit_skills.ts --round 38 --gate 10
 
 # Audit the filter-gate honesty log for reconstructable failures
 bun tools/alignment/audit_candidate_failures.ts --md
+
+# Pre-renegotiation impact survey: who references a clause (blast radius)
+bun tools/alignment/detect-clause-drift.ts            # all clauses
+bun tools/alignment/detect-clause-drift.ts HC-1       # one clause
+bun tools/alignment/detect-clause-drift.ts HC-1 --json
 ```
 
 Exit codes:
@@ -86,6 +92,48 @@ Exit codes:
 - `0` — all commits clean (no `VIOLATED` signals)
 - `1` — one or more `VIOLATED` without explicit citation
 - `2` — script error
+
+(`detect-clause-drift.ts` uses a narrower scheme: `0` for a
+clean run — references emitted, or none found — and `2` for a
+script error / bad args. It does not emit a `1` because a
+blast-radius survey reports findings rather than gating on
+them.)
+
+## Pre-renegotiation impact-survey workflow
+
+`docs/ALIGNMENT.md` clauses (HC-1..HC-7, SD-1..SD-9,
+DIR-1..DIR-5) are renegotiable, not frozen — but a clause that
+is about to be weakened or removed may be load-bearing for
+surfaces that reference it (personas, skills, backlog rows,
+memory files, other clauses). Before any such renegotiation is
+**accepted**, run the impact survey so the blast radius is on
+the table:
+
+```bash
+# 1. Name WHAT is changing (temporal diff of ALIGNMENT.md).
+bun tools/alignment/audit_clause_drift.ts <base-ref> <head-ref>
+
+# 2. Survey WHO references each changed clause (spatial blast radius).
+bun tools/alignment/detect-clause-drift.ts <CLAUSE>      # e.g. HC-3
+bun tools/alignment/detect-clause-drift.ts <CLAUSE> --json  # for tooling
+
+# 3. Read the referencing surfaces. For each, decide:
+#    keep / migrate the reference / accept the break — explicitly.
+```
+
+The two tools compose: step 1 (`audit_clause_drift.ts`) names
+the clauses that moved between two git refs; step 2
+(`detect-clause-drift.ts`) enumerates every working-tree file
+that references each clause. Step 3 is the human decision — the
+survey informs the renegotiation, it does **not** gate it
+(consistent with "measurement, not enforcement" below). A
+renegotiation that proceeds with an un-surveyed blast radius is
+the failure mode this workflow exists to catch.
+
+This is the workflow companion to the
+[`alignment-observability`](../../.claude/skills/alignment-observability/SKILL.md)
+skill's framework-revision channel; the skill owns the
+acceptance decision, this directory owns the survey tooling.
 
 ## Output directory (`out/`)
 

--- a/tools/alignment/README.md
+++ b/tools/alignment/README.md
@@ -111,7 +111,7 @@ the table:
 
 ```bash
 # 1. Name WHAT is changing (temporal diff of ALIGNMENT.md).
-bun tools/alignment/audit_clause_drift.ts <base-ref> <head-ref>
+bun tools/alignment/audit_clause_drift.ts --base <base-ref> --head <head-ref>
 
 # 2. Survey WHO references each changed clause (spatial blast radius).
 bun tools/alignment/detect-clause-drift.ts <CLAUSE>      # e.g. HC-3


### PR DESCRIPTION
Closes **B-0058.4** (alignment-clause drift detector tool + workflow).

## What

Criteria 1+2 shipped to `origin/main` earlier (`tools/alignment/detect-clause-drift.ts` + test, 4 green). This PR closes the **criterion 3 gap**: the blast-radius tool existed but was not documented nor wired into the pre-renegotiation procedure.

- `tools/alignment/README.md`: add `detect-clause-drift.ts` to the script table + usage examples
- `tools/alignment/README.md`: new **Pre-renegotiation impact-survey workflow** section — before any `docs/ALIGNMENT.md` clause weaken/remove is accepted, run `audit_clause_drift.ts` (WHAT changed, temporal) then `detect-clause-drift.ts <CLAUSE>` (WHO references it, spatial blast radius), then decide each referencing surface explicitly. Survey informs, does not gate (measurement, not enforcement).
- close `B-0058.4` row with Resolution section; regen `docs/BACKLOG.md`

## Verify

- `bun tools/alignment/detect-clause-drift.ts HC-1 --json` → exit 0
- `bun test tools/alignment/detect-clause-drift.test.ts` → 4 pass / 0 fail
- markdownlint `tools/alignment/README.md` → exit 0
- commit-tree canary: parent 66 = commit 66 (no collapse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)