### PR TITLE
feat(B-0164.1): divergence reconciliation reader (dual-loop AC #4)

### DIFF
--- a/tools/hygiene/divergence-reconcile.test.ts
+++ b/tools/hygiene/divergence-reconcile.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  type DivergenceInput,
+  buildDivergenceShard,
+  divergenceShardRelPath,
+  writeDivergenceShard,
+} from "./divergence-shard";
+import {
+  findPendingShards,
+  isReconciliationPending,
+  parseShardMeta,
+  reconciliationBody,
+  scanDivergenceDir,
+} from "./divergence-reconcile";
+
+// Build fixtures via the WRITER so the reader is tested against exactly what the
+// writer emits — a writer<->reader round-trip that catches schema drift between
+// the two halves of the protocol.
+function inputAt(tick: string, aBody: string, bBody: string): DivergenceInput {
+  return {
+    tick,
+    loopA: {
+      identity: { agent: "otto", model: "claude-opus-4-8", harness: "claude-code" },
+      body: aBody,
+    },
+    loopB: {
+      identity: { agent: "codex-loop", model: "gpt-5.5", harness: "codex" },
+      body: bBody,
+    },
+    topic: `PR #4147 thread <id> — ${aBody.slice(0, 12)}`,
+    disagreementSummary: "Loop A and Loop B reached different conclusions on the same thread.",
+    operativeAuthorization: 'aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing"',
+  };
+}
+
+const PENDING_SHARD = buildDivergenceShard(inputAt("2026-05-10T11:48:00Z", "resolve A", "do not resolve B"));
+
+/** Replace the maintainer placeholder with a real decision (reconciled state). */
+function reconcile(shard: string, decision: string): string {
+  const idx = shard.indexOf("## Reconciliation");
+  return `${shard.slice(0, idx)}## Reconciliation\n\n${decision}\n`;
+}
+
+function withTempRoot<T>(fn: (root: string) => T): T {
+  const root = mkdtempSync(join(tmpdir(), "reconcile-test-"));
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("reconciliationBody", () => {
+  test("returns the section text for a writer-emitted shard", () => {
+    const body = reconciliationBody(PENDING_SHARD);
+    expect(body).not.toBeNull();
+    expect(body).toContain("Leave blank until morning reconciliation");
+  });
+  test("returns null when there is no Reconciliation section", () => {
+    expect(reconciliationBody("---\ntype: divergence\n---\n\n## Loop A perspective\n\nx")).toBeNull();
+  });
+});
+
+describe("isReconciliationPending", () => {
+  test("a writer-emitted shard is pending (placeholder comments only)", () => {
+    expect(isReconciliationPending(PENDING_SHARD)).toBe(true);
+  });
+  test("a shard with a filled decision is not pending", () => {
+    expect(isReconciliationPending(reconcile(PENDING_SHARD, "accept-loop-b — B reproduces locally. (Aaron)"))).toBe(false);
+  });
+  test("a file with no Reconciliation section is not pending", () => {
+    expect(isReconciliationPending("---\ntype: divergence\n---\n\n## Loop A perspective\n\nx")).toBe(false);
+  });
+});
+
+describe("parseShardMeta", () => {
+  test("extracts tick, topic, and both loop agents from a writer-emitted shard", () => {
+    const meta = parseShardMeta(PENDING_SHARD);
+    expect(meta).not.toBeNull();
+    expect(meta!.tick).toBe("2026-05-10T11:48:00Z");
+    expect(meta!.topic).toContain("PR #4147 thread <id>");
+    expect(meta!.loopAAgent).toBe("otto");
+    expect(meta!.loopBAgent).toBe("codex-loop");
+  });
+  test("returns null for a non-divergence frontmatter (README-style file)", () => {
+    expect(parseShardMeta("---\ntitle: not a shard\n---\n\nbody")).toBeNull();
+  });
+  test("returns null when there is no frontmatter at all", () => {
+    expect(parseShardMeta("# just a markdown doc\n\nno frontmatter")).toBeNull();
+  });
+});
+
+describe("findPendingShards", () => {
+  test("returns only pending shards, oldest-first, excluding reconciled + non-shards", () => {
+    const newer = buildDivergenceShard(inputAt("2026-05-12T09:00:00Z", "newer A", "newer B"));
+    const older = buildDivergenceShard(inputAt("2026-05-09T08:00:00Z", "older A", "older B"));
+    const reconciled = reconcile(
+      buildDivergenceShard(inputAt("2026-05-11T07:00:00Z", "done A", "done B")),
+      "accept-loop-a — settled. (Aaron)",
+    );
+    const files = [
+      { relPath: "d/newer.md", content: newer },
+      { relPath: "d/reconciled.md", content: reconciled },
+      { relPath: "d/older.md", content: older },
+      { relPath: "d/README.md", content: "---\ntitle: x\n---\nnot a shard" },
+    ];
+    const pending = findPendingShards(files);
+    expect(pending.map((p) => p.relPath)).toEqual(["d/older.md", "d/newer.md"]);
+    expect(pending[0]!.tick).toBe("2026-05-09T08:00:00Z");
+  });
+});
+
+describe("scanDivergenceDir", () => {
+  test("returns [] when the divergence directory is absent", () => {
+    withTempRoot((root) => {
+      expect(scanDivergenceDir(root)).toEqual([]);
+    });
+  });
+
+  test("surfaces a writer-written shard, then drops it once reconciled", () => {
+    withTempRoot((root) => {
+      const input = inputAt("2026-05-10T11:48:00Z", "resolve A", "do not resolve B");
+      const { relPath } = writeDivergenceShard(root, input);
+      // sanity: writer chose the canonical content-addressed path
+      expect(relPath).toBe(divergenceShardRelPath(input.tick, input.loopA.body, input.loopB.body));
+
+      const before = scanDivergenceDir(root);
+      expect(before).toHaveLength(1);
+      expect(before[0]!.relPath).toBe(relPath);
+      expect(before[0]!.loopAAgent).toBe("otto");
+      expect(before[0]!.loopBAgent).toBe("codex-loop");
+
+      // Maintainer fills the Reconciliation section in place → no longer pending.
+      writeFileSync(join(root, relPath), reconcile(buildDivergenceShard(input), "accept-loop-b — (Aaron)"));
+      expect(scanDivergenceDir(root)).toHaveLength(0);
+    });
+  });
+
+  test("skips README.md and ignores non-shard markdown", () => {
+    withTempRoot((root) => {
+      const dir = join(root, "docs/hygiene-history/divergences/2026/05/10");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(root, "docs/hygiene-history/divergences/README.md"), "# README\n\n## Reconciliation outcomes\n\nprose");
+      writeFileSync(join(dir, "stray.md"), "---\ntitle: not a shard\n---\n\n## Reconciliation\n\n");
+      writeFileSync(join(dir, "114800Z-deadbeef.md"), PENDING_SHARD);
+      const pending = scanDivergenceDir(root);
+      expect(pending).toHaveLength(1);
+      expect(dirname(pending[0]!.relPath)).toBe("docs/hygiene-history/divergences/2026/05/10");
+    });
+  });
+});

--- a/tools/hygiene/divergence-reconcile.test.ts
+++ b/tools/hygiene/divergence-reconcile.test.ts
@@ -75,6 +75,15 @@ describe("isReconciliationPending", () => {
   test("a file with no Reconciliation section is not pending", () => {
     expect(isReconciliationPending("---\ntype: divergence\n---\n\n## Loop A perspective\n\nx")).toBe(false);
   });
+  test("spliced/nested comments are stripped to a fixpoint, not one pass", () => {
+    // A single `.replace(/<!--…-->/g, "")` pass leaves a residual `<!-- -->`
+    // here: removing the inner comment splices `<!` + `-- -->` into a fresh
+    // comment the pass already scanned past. The fixpoint loop strips it
+    // fully, so a comment-only body still reads as pending. (Regression for
+    // CodeQL js/incomplete-multi-character-sanitization.)
+    const md = "---\ntype: divergence\n---\n\n## Reconciliation\n\n<!<!-- -->-- -->\n";
+    expect(isReconciliationPending(md)).toBe(true);
+  });
 });
 
 describe("parseShardMeta", () => {

--- a/tools/hygiene/divergence-reconcile.ts
+++ b/tools/hygiene/divergence-reconcile.ts
@@ -87,8 +87,25 @@ export function reconciliationBody(markdown: string): string | null {
 export function isReconciliationPending(markdown: string): boolean {
   const body = reconciliationBody(markdown);
   if (body === null) return false;
-  const stripped = body.replace(/<!--[\s\S]*?-->/g, "").trim();
-  return stripped.length === 0;
+  return stripHtmlComments(body).trim().length === 0;
+}
+
+/**
+ * Remove HTML comment blocks (`<!-- … -->`) to a fixpoint. A single `/g` pass is
+ * incomplete sanitization: removing one match can splice the surrounding text
+ * into a fresh `<!-- … -->` (e.g. `<!--<!---->-->` leaves a residual `<!--`),
+ * so we re-run until the string stops shrinking. Termination is guaranteed —
+ * each changing pass strictly deletes characters. (CodeQL js/incomplete-multi-
+ * character-sanitization.)
+ */
+function stripHtmlComments(text: string): string {
+  let out = text;
+  let prev: string;
+  do {
+    prev = out;
+    out = out.replace(/<!--[\s\S]*?-->/g, "");
+  } while (out !== prev);
+  return out;
 }
 
 /** Value of an `agent:` line nested under `parentKey:` in a frontmatter block. */

--- a/tools/hygiene/divergence-reconcile.ts
+++ b/tools/hygiene/divergence-reconcile.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env bun
+// divergence-reconcile.ts — reader for the morning-reconciliation half of the
+// dual-loop disagreement-preservation protocol (B-0164.1, AC #4).
+//
+// The WRITER half (divergence-shard.ts) files a shard whenever two loops reach
+// different conclusions on the same substrate-class commitment (AC #2). This is
+// the complementary READER half: it scans the divergence directory and surfaces
+// every shard whose `## Reconciliation` section is still empty — the exact set
+// the README says "morning reconciliation reads ... with empty Reconciliation
+// sections." That list IS the "one read" of AC #4 ("the morning reconciliation
+// can resolve the thread in one read + one action"): the reader produces the
+// read; the maintainer fills the section + resolves the thread (the action).
+//
+// This is the UNBLOCKED slice of B-0164.1: parsing existing shard files needs no
+// concurrent-loop harness, so it is fully testable in isolation against shards
+// the writer emits. The end-to-end protocol (two loops reviewing the same thread
+// live) remains the blocked impl child pending B-0160.
+//
+// Pure functions (no I/O): reconciliationBody, isReconciliationPending,
+//   parseShardMeta, findPendingShards.
+// I/O function: scanDivergenceDir (delegates classification to the pure layer).
+//
+// Schema source of truth: docs/hygiene-history/divergences/README.md
+// Writer companion:        tools/hygiene/divergence-shard.ts
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+
+// Mirrors DIVERGENCE_ROOT in divergence-shard.ts. Both files reflect the path
+// the README fixes as the source of truth; a comment-cited copy keeps the
+// reader's blast radius to this one file (no writer edit needed).
+const DIVERGENCE_ROOT = "docs/hygiene-history/divergences";
+
+/** Frontmatter fields the reconciliation reader surfaces for "one read". */
+export interface ShardMeta {
+  /** ISO 8601 UTC, seconds precision, e.g. "2026-05-10T11:48:00Z". */
+  readonly tick: string;
+  /** The substrate path or topic in conflict. */
+  readonly topic: string;
+  /** Loop A's named agent identifier (e.g. "otto"). */
+  readonly loopAAgent: string;
+  /** Loop B's named agent identifier (e.g. "codex-loop"). */
+  readonly loopBAgent: string;
+}
+
+/** A shard awaiting morning reconciliation, with its repo-relative path. */
+export interface PendingShard extends ShardMeta {
+  readonly relPath: string;
+}
+
+/** A YAML double-quoted scalar is a JSON string; unquote leniently. */
+function unquote(value: string): string {
+  const t = value.trim();
+  if (t.startsWith('"')) {
+    try {
+      return JSON.parse(t) as string;
+    } catch {
+      return t;
+    }
+  }
+  return t;
+}
+
+/**
+ * The text of the `## Reconciliation` section (everything from after its heading
+ * to the next `## ` heading, or EOF — the schema places it last). Returns null
+ * when the file has no such section.
+ */
+export function reconciliationBody(markdown: string): string | null {
+  const heading = /^## Reconciliation[ \t]*$/m.exec(markdown);
+  if (!heading) return null;
+  let rest = markdown.slice(heading.index + heading[0].length);
+  // Defensive: cut at the next `## ` heading if the schema ever grows a section
+  // after Reconciliation. Per the current README it is the final section.
+  const next = rest.search(/\n## /);
+  if (next !== -1) rest = rest.slice(0, next);
+  return rest;
+}
+
+/**
+ * True when a shard's `## Reconciliation` section carries only the maintainer-
+ * fills-in placeholder (HTML comments + whitespace) — i.e. it is still awaiting
+ * morning reconciliation. A shard with no Reconciliation section is treated as
+ * not-pending (it is malformed, not a reconciliation to-do).
+ */
+export function isReconciliationPending(markdown: string): boolean {
+  const body = reconciliationBody(markdown);
+  if (body === null) return false;
+  const stripped = body.replace(/<!--[\s\S]*?-->/g, "").trim();
+  return stripped.length === 0;
+}
+
+/** Value of an `agent:` line nested under `parentKey:` in a frontmatter block. */
+function nestedAgent(frontmatter: string, parentKey: string): string | null {
+  const lines = frontmatter.split("\n");
+  const start = lines.findIndex((l) => new RegExp(`^${parentKey}:`).test(l));
+  if (start === -1) return null;
+  for (let i = start + 1; i < lines.length; i++) {
+    const l = lines[i]!;
+    if (/^[A-Za-z_]/.test(l)) break; // next unindented top-level key ends the block
+    const am = /^\s+agent:[ \t]*(.+)$/.exec(l);
+    if (am) return unquote(am[1]!);
+  }
+  return null;
+}
+
+/**
+ * Parse a divergence shard's frontmatter into the reconciliation-relevant
+ * fields. Returns null when the text is not a divergence shard (no frontmatter,
+ * or `type:` is not `divergence`) — so non-shard files (README, stray docs) are
+ * filtered out by construction.
+ */
+export function parseShardMeta(markdown: string): ShardMeta | null {
+  const fm = /^---\n([\s\S]*?)\n---/.exec(markdown);
+  if (!fm) return null;
+  const block = fm[1]!;
+  const typeM = /^type:[ \t]*(\S+)/m.exec(block);
+  if (!typeM || typeM[1] !== "divergence") return null;
+  const tickM = /^tick:[ \t]*(.+)$/m.exec(block);
+  const topicM = /^topic:[ \t]*(.+)$/m.exec(block);
+  return {
+    tick: tickM ? unquote(tickM[1]!) : "",
+    topic: topicM ? unquote(topicM[1]!) : "",
+    loopAAgent: nestedAgent(block, "loop-a") ?? "?",
+    loopBAgent: nestedAgent(block, "loop-b") ?? "?",
+  };
+}
+
+/**
+ * Pure classification: from a set of files, return the divergence shards whose
+ * Reconciliation section is still empty, oldest-first (ISO 8601 ticks sort
+ * lexicographically == chronologically; ties break on path for determinism).
+ * Non-shard files and already-reconciled shards are excluded.
+ */
+export function findPendingShards(
+  files: ReadonlyArray<{ relPath: string; content: string }>,
+): PendingShard[] {
+  const pending: PendingShard[] = [];
+  for (const { relPath, content } of files) {
+    const meta = parseShardMeta(content);
+    if (meta === null) continue; // not a divergence shard
+    if (!isReconciliationPending(content)) continue; // already reconciled
+    pending.push({ relPath, ...meta });
+  }
+  pending.sort((a, b) =>
+    a.tick < b.tick ? -1
+    : a.tick > b.tick ? 1
+    : a.relPath < b.relPath ? -1
+    : a.relPath > b.relPath ? 1
+    : 0,
+  );
+  return pending;
+}
+
+/**
+ * Walk `<repoRoot>/<divergenceRel>` for `.md` shards (excluding README.md) and
+ * return those awaiting reconciliation. Filesystem-reading; delegates all
+ * classification to the pure layer. Returns [] when the directory is absent.
+ */
+export function scanDivergenceDir(
+  repoRoot: string,
+  divergenceRel: string = DIVERGENCE_ROOT,
+): PendingShard[] {
+  const root = join(repoRoot, divergenceRel);
+  if (!existsSync(root)) return [];
+  const files: { relPath: string; content: string }[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const abs = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(abs);
+        continue;
+      }
+      if (!entry.name.endsWith(".md")) continue;
+      if (entry.name === "README.md") continue;
+      files.push({ relPath: relative(repoRoot, abs), content: readFileSync(abs, "utf8") });
+    }
+  };
+  walk(root);
+  return findPendingShards(files);
+}
+
+function repoRoot(): string {
+  try {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+// This is a morning-reconciliation READER, not a CI gate: pending shards are a
+// human to-do, not a build failure, so it always exits 0. The report goes to
+// stdout so it can be piped.
+if (import.meta.main) {
+  const pending = scanDivergenceDir(repoRoot());
+  if (pending.length === 0) {
+    process.stdout.write("No unreconciled divergence shards. Nothing to reconcile.\n");
+    process.exit(0);
+  }
+  process.stdout.write(
+    `${pending.length} unreconciled divergence shard(s) — oldest first:\n\n`,
+  );
+  for (const s of pending) {
+    process.stdout.write(`  ${s.relPath}\n`);
+    process.stdout.write(`    tick:  ${s.tick}\n`);
+    process.stdout.write(`    topic: ${s.topic}\n`);
+    process.stdout.write(`    loops: ${s.loopAAgent} vs ${s.loopBAgent}\n\n`);
+  }
+  process.stdout.write(
+    "Per docs/hygiene-history/divergences/README.md: read each shard, decide " +
+      "(accept-loop-a | accept-loop-b | accept-both | escalate), fill the " +
+      "## Reconciliation section in place, then resolve the thread.\n",
+  );
+  process.exit(0);
+}


### PR DESCRIPTION
## What

Adds `tools/hygiene/divergence-reconcile.ts` — the **reader** half of the
PR-review disagreement-preservation protocol (B-0164.1, AC #4).

The divergence-shard **writer** (`tools/hygiene/divergence-shard.ts`, AC #2)
already files a shard whenever two loops disagree. This is the complementary
**reader** the morning-reconciliation step needs: it scans
`docs/hygiene-history/divergences/**`, parses each `type: divergence` shard,
and surfaces every shard whose `## Reconciliation` section is still empty
(maintainer-placeholder comments only). That ordered (oldest-first) list IS
the "one read" of AC #4 — the maintainer fills the section + resolves the
thread (the action).

## Why this slice (re-decomposition)

Per the task's "assume decomposition has mistakes":

- The row's prior re-decomp (Riven 2026-05-11) proposed a **no-substrate-mutation**
  PR. Per `substrate-or-it-didnt-happen.md` that is weather, not substrate.
- Per `verify-existing-substrate-before-authoring.md`, the **writer** half already
  exists (the Riven re-decomps never mention `divergence-shard.ts`). Minting a
  writer again would be parallel substrate.
- The genuine smallest **unblocked + valuable** slice is the missing **reader**
  half — directly satisfying AC #4 without needing the blocked dual-loop harness.

## Surface

| Function | Kind | Role |
|---|---|---|
| `reconciliationBody` | pure | extract the `## Reconciliation` section text |
| `isReconciliationPending` | pure | true iff section is placeholder/empty |
| `parseShardMeta` | pure | tick + topic + both loop agents (null for non-shards) |
| `findPendingShards` | pure | filter to pending, oldest-first (ISO tick sort) |
| `scanDivergenceDir` | I/O | walk dir, skip README.md, delegate to pure layer |
| CLI (`import.meta.main`) | I/O | morning-reconciliation report (reader, **not** a CI gate → exits 0) |

The test imports the writer's `buildDivergenceShard` / `writeDivergenceShard`
so the reader is proven **round-trip-compatible** with what the writer emits —
a schema-drift catch between the two halves.

## Out of scope (unchanged)

- The divergence-shard schema (B-0164 AC #4 / PR #2475).
- How PR reviews are submitted to GitHub.
- The blocked dual-loop execution harness (B-0160) — the impl child remains
  blocked; this reader is the unblocked complement.

## Focused checks

- `bun test tools/hygiene/divergence-reconcile.test.ts tools/hygiene/divergence-shard.test.ts`
  → **32 pass, 0 fail** (reader 12 + writer 20; writer unchanged, no regression)
- `bunx tsc --noEmit` → **0 errors in new files** (8 pre-existing errors live in
  `agentic-organization/apps/workers/` NATS adapters — unrelated to this change)
- CLI smoke test against the repo → `No unreconciled divergence shards`
  (the only shard on disk is the reconciled example)

## Notes

- Dedicated claim branch off `origin/main` in an isolated worktree; root checkout
  untouched. Bus claim acquired for B-0164.1 (`otto-cli`).
- operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)