### PR TITLE
feat(B-0164.1): detect→file glue for review-thread disagreements (dual-loop AC #2)

### DIFF
--- a/tools/hygiene/divergence-shard.test.ts
+++ b/tools/hygiene/divergence-shard.test.ts
@@ -5,9 +5,11 @@ import { dirname, join } from "node:path";
 
 import {
   type DivergenceInput,
+  type ReviewThreadDisagreementInput,
   detectReviewThreadDisagreement,
   buildDivergenceShard,
   divergenceShardRelPath,
+  fileReviewThreadDisagreement,
   shortContentHash,
   writeDivergenceShard,
   writeShardAtPath,
@@ -326,5 +328,92 @@ describe("writeDivergenceShard", () => {
         loopB: { ...INPUT.loopB, body: sameBody },
       }),
     ).toThrow(/no divergence to preserve/);
+  });
+});
+
+describe("fileReviewThreadDisagreement (detect → file glue, AC #2)", () => {
+  const DIVERGENCE_DIR = "docs/hygiene-history/divergences";
+
+  const DETECT_INPUT: ReviewThreadDisagreementInput = {
+    tick: TICK,
+    operativeAuthorization: INPUT.operativeAuthorization,
+    loopA: {
+      identity: INPUT.loopA.identity,
+      prNumber: 4147,
+      threadId: "PRRT_kwExample",
+      conclusion: "resolve",
+      body: "The finding matches the known false-positive table class.",
+    },
+    loopB: {
+      identity: INPUT.loopB.identity,
+      prNumber: 4147,
+      threadId: "PRRT_kwExample",
+      conclusion: "needs-fix",
+      body: "The lint finding reproduces locally and should stay open.",
+    },
+  };
+
+  test("files a shard when conclusions differ on the same thread", () => {
+    withTempRoot((root) => {
+      const outcome = fileReviewThreadDisagreement(root, DETECT_INPUT);
+      expect(outcome.kind).toBe("filed");
+      if (outcome.kind !== "filed") throw new Error("expected filed outcome");
+      expect(outcome.write.status).toBe("written");
+      // The shard exists at the content-addressed path and carries both conclusions.
+      const abs = join(root, outcome.write.relPath);
+      expect(existsSync(abs)).toBe(true);
+      const md = readFileSync(abs, "utf8");
+      expect(md).toContain("Conclusion: resolve");
+      expect(md).toContain("Conclusion: needs-fix");
+      expect(outcome.divergenceInput.topic).toBe("PR #4147 thread PRRT_kwExample");
+    });
+  });
+
+  test("writes no shard when conclusions agree (same-conclusion)", () => {
+    withTempRoot((root) => {
+      const outcome = fileReviewThreadDisagreement(root, {
+        ...DETECT_INPUT,
+        loopB: { ...DETECT_INPUT.loopB, conclusion: " Resolve " },
+      });
+      expect(outcome).toEqual({ kind: "no-disagreement", reason: "same-conclusion" });
+      expect(existsSync(join(root, DIVERGENCE_DIR))).toBe(false);
+    });
+  });
+
+  test("writes no shard when the observations are on different threads", () => {
+    withTempRoot((root) => {
+      const outcome = fileReviewThreadDisagreement(root, {
+        ...DETECT_INPUT,
+        loopB: { ...DETECT_INPUT.loopB, prNumber: 4148 },
+      });
+      expect(outcome).toEqual({ kind: "no-disagreement", reason: "different-thread" });
+      expect(existsSync(join(root, DIVERGENCE_DIR))).toBe(false);
+    });
+  });
+
+  test("re-running the same disagreement is an idempotent-noop filing", () => {
+    withTempRoot((root) => {
+      const first = fileReviewThreadDisagreement(root, DETECT_INPUT);
+      const again = fileReviewThreadDisagreement(root, DETECT_INPUT);
+      expect(first.kind).toBe("filed");
+      expect(again.kind).toBe("filed");
+      if (again.kind !== "filed") throw new Error("expected filed outcome");
+      expect(again.write.status).toBe("idempotent-noop");
+      if (first.kind === "filed") {
+        expect(again.write.relPath).toBe(first.write.relPath);
+      }
+    });
+  });
+
+  test("validation throws before any I/O (no divergence dir created)", () => {
+    withTempRoot((root) => {
+      expect(() =>
+        fileReviewThreadDisagreement(root, {
+          ...DETECT_INPUT,
+          loopA: { ...DETECT_INPUT.loopA, threadId: " " },
+        }),
+      ).toThrow(/loopA.threadId/);
+      expect(existsSync(join(root, DIVERGENCE_DIR))).toBe(false);
+    });
   });
 });

--- a/tools/hygiene/divergence-shard.test.ts
+++ b/tools/hygiene/divergence-shard.test.ts
@@ -241,13 +241,63 @@ describe("detectReviewThreadDisagreement", () => {
         ...base,
         loopA: { ...base.loopA, conclusion: " " },
       }),
-    ).toThrow(/review conclusion/);
+    ).toThrow(/loopA\.conclusion/);
     expect(() =>
       detectReviewThreadDisagreement({
         ...base,
         loopA: { ...base.loopA, body: " " },
       }),
-    ).toThrow(/review body/);
+    ).toThrow(/loopA\.body/);
+  });
+
+  test("rejects blank conclusion/body even on no-disagreement paths (Copilot #6068)", () => {
+    // base is same-thread + same-conclusion (the no-disagreement: same-conclusion
+    // branch). Previously a blank body here was silently accepted as clean
+    // because body was only validated on the disagreement path.
+    const sameConclusion = {
+      tick: TICK,
+      operativeAuthorization: INPUT.operativeAuthorization,
+      loopA: {
+        identity: INPUT.loopA.identity,
+        prNumber: 4147,
+        threadId: "thread-a",
+        conclusion: "resolve",
+        body: "False positive.",
+      },
+      loopB: {
+        identity: INPUT.loopB.identity,
+        prNumber: 4147,
+        threadId: "thread-a",
+        conclusion: "resolve",
+        body: "Also false positive.",
+      },
+    };
+    expect(() =>
+      detectReviewThreadDisagreement({
+        ...sameConclusion,
+        loopB: { ...sameConclusion.loopB, body: " " },
+      }),
+    ).toThrow(/loopB\.body/);
+
+    // different-thread branch returns before the conclusion comparison, so a
+    // blank conclusion/body must be rejected by the eager validation, not slip
+    // through as a clean different-thread outcome.
+    const differentThread = {
+      ...sameConclusion,
+      loopB: { ...sameConclusion.loopB, prNumber: 9999 },
+    };
+    expect(() =>
+      detectReviewThreadDisagreement({
+        ...differentThread,
+        loopA: { ...differentThread.loopA, conclusion: " " },
+      }),
+    ).toThrow(/loopA\.conclusion/);
+    expect(() =>
+      detectReviewThreadDisagreement({
+        ...differentThread,
+        loopB: { ...differentThread.loopB, body: " " },
+      }),
+    ).toThrow(/loopB\.body/);
   });
 });
 
@@ -412,7 +462,15 @@ describe("fileReviewThreadDisagreement (detect → file glue, AC #2)", () => {
           ...DETECT_INPUT,
           loopA: { ...DETECT_INPUT.loopA, threadId: " " },
         }),
-      ).toThrow(/loopA.threadId/);
+      ).toThrow(/loopA\.threadId/);
+      // A blank body on a same-conclusion pair must throw before any I/O too,
+      // not be silently treated as a clean no-disagreement outcome (#6068).
+      expect(() =>
+        fileReviewThreadDisagreement(root, {
+          ...DETECT_INPUT,
+          loopB: { ...DETECT_INPUT.loopB, conclusion: DETECT_INPUT.loopA.conclusion, body: " " },
+        }),
+      ).toThrow(/loopB\.body/);
       expect(existsSync(join(root, DIVERGENCE_DIR))).toBe(false);
     });
   });

--- a/tools/hygiene/divergence-shard.ts
+++ b/tools/hygiene/divergence-shard.ts
@@ -182,10 +182,23 @@ function perspectiveFromObservation(observation: ReviewThreadObservation): LoopP
  * does not write a shard. Callers can hand the returned divergenceInput to
  * writeDivergenceShard once they have two observations from the same thread
  * whose machine-comparable conclusions differ.
+ *
+ * Validation is EAGER: every required string field (thread id, conclusion,
+ * body) of both observations is checked non-blank up front, before the
+ * no-disagreement branch decision and before any downstream I/O. Lazy
+ * validation (body only on the disagreement path; conclusion only on the
+ * same-thread path) silently accepted malformed observations as clean
+ * no-disagreement outcomes -- e.g. a same-conclusion pair with a blank body,
+ * or a different-thread pair with a blank conclusion (Copilot PR #6068
+ * finding). A malformed observation must be rejected regardless of branch.
  */
 export function detectReviewThreadDisagreement(input: ReviewThreadDisagreementInput): ReviewThreadDisagreementResult {
   const aThreadId = nonBlank(input.loopA.threadId, "loopA.threadId");
   const bThreadId = nonBlank(input.loopB.threadId, "loopB.threadId");
+  nonBlank(input.loopA.conclusion, "loopA.conclusion");
+  nonBlank(input.loopB.conclusion, "loopB.conclusion");
+  nonBlank(input.loopA.body, "loopA.body");
+  nonBlank(input.loopB.body, "loopB.body");
 
   if (input.loopA.prNumber !== input.loopB.prNumber || aThreadId !== bThreadId) {
     return { kind: "no-disagreement", reason: "different-thread" };

--- a/tools/hygiene/divergence-shard.ts
+++ b/tools/hygiene/divergence-shard.ts
@@ -100,6 +100,24 @@ export interface WriteResult {
   readonly status: WriteStatus;
 }
 
+/**
+ * Outcome of detecting two loops' review-thread conclusions and, on a genuine
+ * disagreement, filing the divergence shard. "filed" carries the WriteResult
+ * (path + written/idempotent/collision status) plus the DivergenceInput that
+ * produced it; "no-disagreement" carries the reason and means no shard was
+ * written.
+ */
+export type ReviewThreadShardOutcome =
+  | {
+      readonly kind: "no-disagreement";
+      readonly reason: ReviewThreadNoDisagreementReason;
+    }
+  | {
+      readonly kind: "filed";
+      readonly write: WriteResult;
+      readonly divergenceInput: DivergenceInput;
+    };
+
 const TICK_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z$/;
 const DIVERGENCE_ROOT = "docs/hygiene-history/divergences";
 
@@ -328,4 +346,38 @@ export function writeDivergenceShard(repoRoot: string, input: DivergenceInput): 
   // path.relative handles the separator boundary + cross-platform normalisation
   // correctly, avoiding the prefix-collision edge cases of a manual slice.
   return { relPath: relative(repoRoot, result.absPath), status: result.status };
+}
+
+/**
+ * Operational unit of B-0164.1 AC #2 ("a divergence shard is filed whenever
+ * conclusions differ"): detect whether two loops' observations on the SAME PR
+ * review thread disagree and, only then, file the divergence shard under
+ * `repoRoot`. Composes the pure detector (detectReviewThreadDisagreement) with
+ * the I/O writer (writeDivergenceShard) so a caller fires the protocol step in
+ * one call instead of hand-threading the DivergenceInput between the two.
+ *
+ *   - same thread, differing normalized conclusions → file the shard ("filed",
+ *     carrying the WriteResult so the caller sees written / idempotent-noop /
+ *     collision-resolved).
+ *   - same conclusion OR different thread → no write ("no-disagreement").
+ *
+ * Stays below the blocked end-to-end boundary: it never auto-resolves the
+ * GitHub thread (AC #1) and never overwrites a differing shard (the writer's
+ * fail-closed-OR-idempotent rule). Validation throws from the detector (blank
+ * thread id / conclusion / body) surface BEFORE any I/O. The writer's
+ * byte-identical-bodies guard cannot fire on detector output: a "disagreement"
+ * means normalized conclusions differ, and each perspective body is prefixed
+ * with its trimmed (case-preserving) conclusion, so the two bodies are always
+ * distinct.
+ */
+export function fileReviewThreadDisagreement(repoRoot: string, input: ReviewThreadDisagreementInput): ReviewThreadShardOutcome {
+  const detection = detectReviewThreadDisagreement(input);
+  if (detection.kind === "no-disagreement") {
+    return detection;
+  }
+  return {
+    kind: "filed",
+    write: writeDivergenceShard(repoRoot, detection.divergenceInput),
+    divergenceInput: detection.divergenceInput,
+  };
 }


### PR DESCRIPTION
## What

Adds `fileReviewThreadDisagreement` to `tools/hygiene/divergence-shard.ts` — the **detect→file composing function** that operationalizes B-0164.1 **AC #2** ("a divergence shard is filed whenever conclusions differ") as a single call.

Prior slices landed the three pieces but not the seam:
- `detectReviewThreadDisagreement` (pure detector, #6067) returns a `DivergenceInput` *or* a `no-disagreement` reason.
- `writeDivergenceShard` (fail-closed-OR-idempotent writer).
- `divergence-reconcile.ts` (morning-reconciliation reader, #6066, AC #4).

Until now, AC #2's verb had **no entry point** — a caller had to detect, branch on `kind`, then hand-thread `divergenceInput` into the writer. This slice collapses that into the one operational unit the protocol describes.

## Behaviour

| Input | Outcome |
|---|---|
| same thread, differing normalized conclusions | `{ kind: "filed", write, divergenceInput }` — shard written |
| same conclusion | `{ kind: "no-disagreement", reason: "same-conclusion" }` — no write |
| different thread | `{ kind: "no-disagreement", reason: "different-thread" }` — no write |
| blank thread id / conclusion / body | throws **before any I/O** |

## Why it stays safe / in-scope

- **Below the blocked end-to-end boundary** (no concurrent-loop harness needed): never auto-resolves the GitHub thread (AC #1), never submits a GitHub review, never changes the shard schema.
- **Never overwrites divergence evidence**: delegates to the writer's fail-closed-OR-idempotent rule.
- **The writer's byte-identical-bodies guard provably cannot fire on detector output**: a `disagreement` means *normalized* conclusions differ, and each perspective body is prefixed with its trimmed (case-preserving) conclusion ⇒ the two bodies are always distinct.

## Focused checks (run in dedicated worktree off `origin/main`)

- `bun test tools/hygiene/divergence-shard.test.ts tools/hygiene/divergence-reconcile.test.ts` → **42 pass / 0 fail** (37 prior + 5 new).
- `bunx tsc --noEmit` → **0 errors in changed files**. One pre-existing global `TS2688 "Cannot find type definition file for 'bun'"` artifact appears (fresh-worktree `@types/bun` resolution; `bun test` passes because Bun ships its own types) — unrelated to this change.
- `git diff --check` → clean.

This change is **TS-only** (no `.fs`/`.cs` touched); the dotnet build gate is unaffected.

## Backlog

B-0164.1 (P1) — PR-review disagreement-preservation protocol (dual-loop AC #2). Parent B-0164. The end-to-end live dual-review + morning-reconciliation workflow remains the **blocked** impl child pending B-0160 (concurrent-loop harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
