### PR TITLE
feat(B-0164.1): fillReconciliation — shard-side "one action" of dual-loop AC #4

### DIFF
--- a/tools/hygiene/divergence-reconcile.test.ts
+++ b/tools/hygiene/divergence-reconcile.test.ts
@@ -10,7 +10,11 @@ import {
   writeDivergenceShard,
 } from "./divergence-shard";
 import {
+  RECONCILIATION_DECISIONS,
+  type ReconciliationDecision,
+  fillReconciliation,
   findPendingShards,
+  isReconciliationDecision,
   isReconciliationPending,
   parseShardMeta,
   reconciliationBody,
@@ -159,6 +163,88 @@ describe("scanDivergenceDir", () => {
       const pending = scanDivergenceDir(root);
       expect(pending).toHaveLength(1);
       expect(dirname(pending[0]!.relPath)).toBe("docs/hygiene-history/divergences/2026/05/10");
+    });
+  });
+});
+
+const RECONCILIATION_HEADING = "## Reconciliation";
+/** Length of the prefix up to and including the Reconciliation heading. */
+function reconciliationPrefixLen(shard: string): number {
+  return shard.indexOf(RECONCILIATION_HEADING) + RECONCILIATION_HEADING.length;
+}
+
+describe("isReconciliationDecision / RECONCILIATION_DECISIONS", () => {
+  test("the four canonical decisions match the README vocabulary, in order", () => {
+    expect(RECONCILIATION_DECISIONS).toEqual(["accept-loop-a", "accept-loop-b", "accept-both", "escalate"]);
+  });
+  test("accepts a canonical decision and rejects anything else", () => {
+    expect(isReconciliationDecision("accept-both")).toBe(true);
+    expect(isReconciliationDecision("escalate")).toBe(true);
+    expect(isReconciliationDecision("accept-loop-c")).toBe(false);
+    expect(isReconciliationDecision("")).toBe(false);
+    expect(isReconciliationDecision("accept-loop-b — (Aaron)")).toBe(false);
+  });
+});
+
+describe("fillReconciliation", () => {
+  test("fills a pending shard with a decision-only section (no note)", () => {
+    const filled = fillReconciliation(PENDING_SHARD, "accept-loop-a");
+    expect(isReconciliationPending(filled)).toBe(false);
+    expect(reconciliationBody(filled)!.trim()).toBe("accept-loop-a");
+  });
+
+  test("appends an optional note below the decision", () => {
+    const filled = fillReconciliation(PENDING_SHARD, "accept-loop-b", "B reproduces locally. (Aaron)");
+    expect(reconciliationBody(filled)!.trim()).toBe("accept-loop-b\n\nB reproduces locally. (Aaron)");
+    expect(isReconciliationPending(filled)).toBe(false);
+  });
+
+  test("treats a blank/whitespace-only note as no note (note is optional)", () => {
+    expect(reconciliationBody(fillReconciliation(PENDING_SHARD, "escalate", "   \n\t"))!.trim()).toBe("escalate");
+  });
+
+  test("preserves everything up to and including the heading byte-for-byte", () => {
+    const len = reconciliationPrefixLen(PENDING_SHARD);
+    const filled = fillReconciliation(PENDING_SHARD, "accept-both");
+    expect(filled.slice(0, len)).toBe(PENDING_SHARD.slice(0, len));
+  });
+
+  test("preserves a trailing `## ` section after Reconciliation (defensive bounding)", () => {
+    const withTail = `${PENDING_SHARD}\n${"## Provenance"}\n\ntrailing section body\n`;
+    const filled = fillReconciliation(withTail, "accept-both");
+    // The Reconciliation section now carries only the decision...
+    expect(reconciliationBody(filled)!.trim()).toBe("accept-both");
+    // ...and the trailing section survives untouched.
+    expect(filled).toContain("## Provenance");
+    expect(filled).toContain("trailing section body");
+  });
+
+  test("rejects an invalid decision (EAGER, before any work — runtime callers pass raw strings)", () => {
+    expect(() => fillReconciliation(PENDING_SHARD, "accept-loop-c" as ReconciliationDecision)).toThrow(
+      /invalid reconciliation decision/,
+    );
+  });
+
+  test("rejects a shard with no `## Reconciliation` section", () => {
+    expect(() => fillReconciliation("---\ntype: divergence\n---\n\n## Loop A perspective\n\nx", "escalate")).toThrow(
+      /no .## Reconciliation. section/,
+    );
+  });
+
+  test("refuses to overwrite an already-reconciled section (history-preserving)", () => {
+    const reconciled = fillReconciliation(PENDING_SHARD, "accept-loop-a", "first decision");
+    expect(() => fillReconciliation(reconciled, "accept-loop-b")).toThrow(/already reconciled/);
+  });
+
+  test("round-trip: writer files a pending shard, fillReconciliation drops it from the pending scan", () => {
+    withTempRoot((root) => {
+      const input = inputAt("2026-05-10T11:48:00Z", "resolve A", "do not resolve B");
+      const { relPath } = writeDivergenceShard(root, input);
+      expect(scanDivergenceDir(root)).toHaveLength(1);
+      // Reconstruct exactly what the writer wrote (writeDivergenceShard == buildDivergenceShard(input)).
+      const filled = fillReconciliation(buildDivergenceShard(input), "accept-loop-b", "B reproduces locally. (Aaron)");
+      writeFileSync(join(root, relPath), filled);
+      expect(scanDivergenceDir(root)).toHaveLength(0);
     });
   });
 });

--- a/tools/hygiene/divergence-reconcile.ts
+++ b/tools/hygiene/divergence-reconcile.ts
@@ -17,8 +17,15 @@
 // live) remains the blocked impl child pending B-0160.
 //
 // Pure functions (no I/O): reconciliationBody, isReconciliationPending,
-//   parseShardMeta, findPendingShards.
+//   isReconciliationDecision, fillReconciliation, parseShardMeta,
+//   findPendingShards.
 // I/O function: scanDivergenceDir (delegates classification to the pure layer).
+//
+// The reader surfaces the "one read" of AC #4; fillReconciliation produces the
+// shard-side of the "one action" (the in-place `## Reconciliation` edit) so the
+// maintainer's decision is applied deterministically + validated rather than by
+// hand. It stays below the blocked end-to-end boundary: it returns markdown and
+// never writes, never touches GitHub, never resolves the live thread.
 //
 // Schema source of truth: docs/hygiene-history/divergences/README.md
 // Writer companion:        tools/hygiene/divergence-shard.ts
@@ -106,6 +113,79 @@ function stripHtmlComments(text: string): string {
     out = out.replace(/<!--[\s\S]*?-->/g, "");
   } while (out !== prev);
   return out;
+}
+
+/**
+ * The four canonical reconciliation decisions the README fixes
+ * (docs/hygiene-history/divergences/README.md "Reconciliation outcomes").
+ * Machine-comparable values — the gloss "(explicit divergence)" the README
+ * shows beside accept-both is documentation, not part of the value.
+ */
+export const RECONCILIATION_DECISIONS = [
+  "accept-loop-a",
+  "accept-loop-b",
+  "accept-both",
+  "escalate",
+] as const;
+
+/** A morning-reconciliation decision per the README's outcome vocabulary. */
+export type ReconciliationDecision = (typeof RECONCILIATION_DECISIONS)[number];
+
+/** True when `value` is one of the four canonical reconciliation decisions. */
+export function isReconciliationDecision(value: string): value is ReconciliationDecision {
+  return (RECONCILIATION_DECISIONS as readonly string[]).includes(value);
+}
+
+/**
+ * Fill a PENDING shard's `## Reconciliation` section with a decision (and an
+ * optional free-text note), returning the reconciled markdown. This is the
+ * shard-side of AC #4's "one action" ("resolve the thread in one read + one
+ * action"): the reader (scanDivergenceDir) produces the read; this turns the
+ * maintainer's decision into the in-place section edit the README prescribes —
+ * validated and deterministic, instead of a hand-edit.
+ *
+ * Pure: returns the new markdown; never writes, never touches GitHub, never
+ * resolves the live thread (that half stays in the blocked impl child pending
+ * B-0160). Composes with the reader's section logic (reconciliationBody /
+ * isReconciliationPending).
+ *
+ * Fail-closed and history-preserving (per the README "the shard is updated in
+ * place (not deleted) so the divergence history is preserved permanently", and
+ * the writer's never-overwrite-differing-content rule):
+ *   - invalid `decision` → throw, even though the type guards it, because
+ *     runtime callers (CLI args) pass raw strings. EAGER validation matches the
+ *     detector in divergence-shard.ts.
+ *   - no `## Reconciliation` section (malformed shard) → throw.
+ *   - already-reconciled shard (section is not the placeholder) → throw, rather
+ *     than silently overwriting a prior human decision.
+ *
+ * Everything up to and including the `## Reconciliation` heading is preserved
+ * byte-for-byte. A `## ` section after Reconciliation (should the schema ever
+ * grow one) is preserved too, mirroring reconciliationBody's defensive bounding.
+ * A blank/whitespace-only note is treated as no note (the note is optional).
+ */
+export function fillReconciliation(markdown: string, decision: ReconciliationDecision, note?: string): string {
+  if (!isReconciliationDecision(decision)) {
+    throw new Error(
+      `invalid reconciliation decision "${decision}": expected one of ${RECONCILIATION_DECISIONS.join(" | ")}`,
+    );
+  }
+  const heading = /^## Reconciliation[ \t]*$/m.exec(markdown);
+  if (!heading) {
+    throw new Error("cannot fill reconciliation: shard has no `## Reconciliation` section");
+  }
+  if (!isReconciliationPending(markdown)) {
+    throw new Error(
+      "refusing to fill reconciliation: section is already reconciled (overwriting would erase a prior decision)",
+    );
+  }
+  const afterHeading = heading.index + heading[0].length;
+  const rest = markdown.slice(afterHeading);
+  const nextIdx = rest.search(/\n## /);
+  const tail = nextIdx === -1 ? "" : rest.slice(nextIdx);
+  const trimmedNote = note?.trim() ?? "";
+  const body = trimmedNote.length === 0 ? decision : `${decision}\n\n${trimmedNote}`;
+  return `${markdown.slice(0, afterHeading)}\n\n${body}\n${tail}`;
 }
 
 /** Value of an `agent:` line nested under `parentKey:` in a frontmatter block. */


### PR DESCRIPTION
## What

Adds a pure, validated reconciliation-writer to `tools/hygiene/divergence-reconcile.ts`:

```ts
fillReconciliation(markdown, decision, note?) -> reconciled markdown
```

plus the canonical decision vocabulary `RECONCILIATION_DECISIONS` and a type guard `isReconciliationDecision`, sourced verbatim from the README's four outcomes (`accept-loop-a | accept-loop-b | accept-both | escalate`).

## Why this slice (B-0164.1 AC #4)

AC #4: *"the morning reconciliation can resolve the thread in **one read + one action**."*

| Half | Status before | Status after |
|------|---------------|--------------|
| **one read** — surface pending shards | landed (`scanDivergenceDir`, PR #6066) | unchanged |
| **one action** — fill `## Reconciliation` in place | hand-edit; the only reconciliation-writer was a *test-fixture* helper | this PR: real, pure, validated function |

It is the smallest safe next step: the writer (AC #2/#3, PR #6067), detector (AC #2, PR #6067), and detect→file glue (AC #1/#2, PR #6068) all landed; the reader (AC #4 read) landed in PR #6066. The shard-side of the AC #4 *action* was the remaining unblocked unit.

## Below the blocked boundary

Pure: returns markdown, **never writes, never touches GitHub, never resolves the live thread**. The GitHub-thread-resolution half stays in the blocked impl child pending **B-0160** (dual-loop harness). Same unblocked-pure-unit pattern PRs #6067/#6068 established.

## Behaviour (fail-closed, history-preserving)

Per the README (*"the shard is updated in place (not deleted) so the divergence history is preserved permanently"*) + the writer's never-overwrite-differing-content rule:

- invalid `decision` → **throw** (EAGER, before any work — runtime/CLI callers pass raw strings; matches the detector in `divergence-shard.ts`)
- no `## Reconciliation` section → **throw** (malformed shard)
- already-reconciled section → **throw**, rather than silently overwriting a prior human decision

Everything up to and including the `## Reconciliation` heading is preserved byte-for-byte; a `## ` section after Reconciliation (should the schema grow one) is preserved too, mirroring the reader's defensive bounding. A blank/whitespace-only note is treated as no note (the note is optional).

## Focused checks (run in worktree)

- `bun test tools/hygiene/divergence-reconcile.test.ts tools/hygiene/divergence-shard.test.ts` → **54 pass / 0 fail** (12 new tests; existing 42 unchanged — writer↔reader round-trip preserved)
- `bunx tsc --noEmit -p tsconfig.json` → **0 type errors in the divergence tools** (caught + fixed one missing `!` non-null assertion in a new test; pre-existing `@nats-io/*` module-resolution errors in `agentic-organization/` are unrelated to this change)

## Scope

- Blast radius: 2 files, both `tools/hygiene/divergence-reconcile.*`. No `.fs`/`.cs` touched. Existing test-fixture `reconcile` helper left as-is (it inlines decision+note and cannot delegate to the canonical-decision-only function — confirms minimal blast radius).
- Out of scope: CLI wiring of the writer (the reader CLI stays read-only); GitHub thread resolution (blocked on B-0160).

Claim: `B-0164.1` acquired via `tools/bus/claim.ts` (sender `otto-cli`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)