### PR TITLE
feat(B-0164.1): reconcileDivergenceShard — I/O write-back glue for dual-loop AC #4 "one action"

### DIFF
--- a/tools/hygiene/divergence-reconcile.test.ts
+++ b/tools/hygiene/divergence-reconcile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -17,6 +17,7 @@ import {
   isReconciliationDecision,
   isReconciliationPending,
   parseShardMeta,
+  reconcileDivergenceShard,
   reconciliationBody,
   scanDivergenceDir,
 } from "./divergence-reconcile";
@@ -245,6 +246,103 @@ describe("fillReconciliation", () => {
       const filled = fillReconciliation(buildDivergenceShard(input), "accept-loop-b", "B reproduces locally. (Aaron)");
       writeFileSync(join(root, relPath), filled);
       expect(scanDivergenceDir(root)).toHaveLength(0);
+    });
+  });
+});
+
+describe("reconcileDivergenceShard (read → fillReconciliation → write-back, AC #4 'one action')", () => {
+  test("full AC #4 loop: write pending shard → scan finds it → reconcile → scan is empty", () => {
+    withTempRoot((root) => {
+      const input = inputAt("2026-05-10T11:48:00Z", "resolve A", "do not resolve B");
+      const { relPath } = writeDivergenceShard(root, input);
+      // "one read": the reader surfaces the pending shard.
+      expect(scanDivergenceDir(root).map((p) => p.relPath)).toEqual([relPath]);
+
+      // "one action": land the decision in place.
+      const result = reconcileDivergenceShard(root, relPath, "accept-loop-b", "B reproduces locally. (Aaron)");
+      expect(result).toEqual({ relPath, decision: "accept-loop-b" });
+
+      // The shard is no longer pending, and the on-disk content carries the decision.
+      expect(scanDivergenceDir(root)).toHaveLength(0);
+      const md = readFileSync(join(root, relPath), "utf8");
+      expect(isReconciliationPending(md)).toBe(false);
+      expect(reconciliationBody(md)!.trim()).toBe("accept-loop-b\n\nB reproduces locally. (Aaron)");
+    });
+  });
+
+  test("writes a decision-only section when no note is given", () => {
+    withTempRoot((root) => {
+      const { relPath } = writeDivergenceShard(root, inputAt("2026-05-10T11:48:00Z", "A", "B"));
+      reconcileDivergenceShard(root, relPath, "escalate");
+      expect(reconciliationBody(readFileSync(join(root, relPath), "utf8"))!.trim()).toBe("escalate");
+    });
+  });
+
+  test("preserves divergence evidence: only the Reconciliation section changes", () => {
+    withTempRoot((root) => {
+      const input = inputAt("2026-05-10T11:48:00Z", "resolve A", "do not resolve B");
+      const { relPath } = writeDivergenceShard(root, input);
+      const before = readFileSync(join(root, relPath), "utf8");
+
+      reconcileDivergenceShard(root, relPath, "accept-both");
+      const after = readFileSync(join(root, relPath), "utf8");
+
+      // Everything up to and including the `## Reconciliation` heading is byte-identical:
+      // both loop perspectives + the disagreement summary survive verbatim.
+      const len = before.indexOf("## Reconciliation") + "## Reconciliation".length;
+      expect(after.slice(0, len)).toBe(before.slice(0, len));
+      expect(after).toContain("## Loop A perspective");
+      expect(after).toContain("## Loop B perspective");
+      expect(after).toContain("## Disagreement summary");
+    });
+  });
+
+  test("throws (no write) when no shard exists at the path", () => {
+    withTempRoot((root) => {
+      const relPath = "docs/hygiene-history/divergences/2026/05/10/114800Z-deadbeef.md";
+      expect(() => reconcileDivergenceShard(root, relPath, "accept-loop-a")).toThrow(/no divergence shard at/);
+      expect(existsSync(join(root, relPath))).toBe(false);
+    });
+  });
+
+  test("throws (file unchanged) when the target is not a divergence shard", () => {
+    withTempRoot((root) => {
+      // A markdown file that HAS a `## Reconciliation` heading but is NOT a
+      // divergence shard (no type: divergence frontmatter) — a mistyped relPath.
+      const relPath = "docs/notes/stray.md";
+      const abs = join(root, relPath);
+      mkdirSync(dirname(abs), { recursive: true });
+      const stray = "---\ntitle: not a shard\n---\n\n## Reconciliation\n\n<!-- placeholder -->\n";
+      writeFileSync(abs, stray);
+      expect(() => reconcileDivergenceShard(root, relPath, "accept-loop-a")).toThrow(/not a divergence shard/);
+      // Fail-closed: the non-shard file is left exactly as it was.
+      expect(readFileSync(abs, "utf8")).toBe(stray);
+    });
+  });
+
+  test("re-run on an already-reconciled shard fails closed (prior decision not erased)", () => {
+    withTempRoot((root) => {
+      const { relPath } = writeDivergenceShard(root, inputAt("2026-05-10T11:48:00Z", "A", "B"));
+      reconcileDivergenceShard(root, relPath, "accept-loop-a", "first decision");
+      const afterFirst = readFileSync(join(root, relPath), "utf8");
+      // A second reconcile must throw (via fillReconciliation's already-reconciled guard)...
+      expect(() => reconcileDivergenceShard(root, relPath, "accept-loop-b")).toThrow(/already reconciled/);
+      // ...and leave the first decision intact.
+      expect(readFileSync(join(root, relPath), "utf8")).toBe(afterFirst);
+      expect(afterFirst).toContain("first decision");
+    });
+  });
+
+  test("rejects an invalid decision before any write (runtime callers pass raw strings)", () => {
+    withTempRoot((root) => {
+      const { relPath } = writeDivergenceShard(root, inputAt("2026-05-10T11:48:00Z", "A", "B"));
+      const before = readFileSync(join(root, relPath), "utf8");
+      expect(() =>
+        reconcileDivergenceShard(root, relPath, "accept-loop-c" as ReconciliationDecision),
+      ).toThrow(/invalid reconciliation decision/);
+      // Still pending; file unchanged (validation precedes the write).
+      expect(readFileSync(join(root, relPath), "utf8")).toBe(before);
+      expect(scanDivergenceDir(root)).toHaveLength(1);
     });
   });
 });

--- a/tools/hygiene/divergence-reconcile.test.ts
+++ b/tools/hygiene/divergence-reconcile.test.ts
@@ -75,7 +75,7 @@ describe("isReconciliationPending", () => {
     expect(isReconciliationPending(PENDING_SHARD)).toBe(true);
   });
   test("a shard with a filled decision is not pending", () => {
-    expect(isReconciliationPending(reconcile(PENDING_SHARD, "accept-loop-b — B reproduces locally. (Aaron)"))).toBe(false);
+    expect(isReconciliationPending(reconcile(PENDING_SHARD, "accept-loop-b — B reproduces locally. (human maintainer)"))).toBe(false);
   });
   test("a file with no Reconciliation section is not pending", () => {
     expect(isReconciliationPending("---\ntype: divergence\n---\n\n## Loop A perspective\n\nx")).toBe(false);
@@ -114,7 +114,7 @@ describe("findPendingShards", () => {
     const older = buildDivergenceShard(inputAt("2026-05-09T08:00:00Z", "older A", "older B"));
     const reconciled = reconcile(
       buildDivergenceShard(inputAt("2026-05-11T07:00:00Z", "done A", "done B")),
-      "accept-loop-a — settled. (Aaron)",
+      "accept-loop-a — settled. (human maintainer)",
     );
     const files = [
       { relPath: "d/newer.md", content: newer },
@@ -149,7 +149,7 @@ describe("scanDivergenceDir", () => {
       expect(before[0]!.loopBAgent).toBe("codex-loop");
 
       // Maintainer fills the Reconciliation section in place → no longer pending.
-      writeFileSync(join(root, relPath), reconcile(buildDivergenceShard(input), "accept-loop-b — (Aaron)"));
+      writeFileSync(join(root, relPath), reconcile(buildDivergenceShard(input), "accept-loop-b — (human maintainer)"));
       expect(scanDivergenceDir(root)).toHaveLength(0);
     });
   });
@@ -183,7 +183,7 @@ describe("isReconciliationDecision / RECONCILIATION_DECISIONS", () => {
     expect(isReconciliationDecision("escalate")).toBe(true);
     expect(isReconciliationDecision("accept-loop-c")).toBe(false);
     expect(isReconciliationDecision("")).toBe(false);
-    expect(isReconciliationDecision("accept-loop-b — (Aaron)")).toBe(false);
+    expect(isReconciliationDecision("accept-loop-b — (human maintainer)")).toBe(false);
   });
 });
 
@@ -195,8 +195,8 @@ describe("fillReconciliation", () => {
   });
 
   test("appends an optional note below the decision", () => {
-    const filled = fillReconciliation(PENDING_SHARD, "accept-loop-b", "B reproduces locally. (Aaron)");
-    expect(reconciliationBody(filled)!.trim()).toBe("accept-loop-b\n\nB reproduces locally. (Aaron)");
+    const filled = fillReconciliation(PENDING_SHARD, "accept-loop-b", "B reproduces locally. (human maintainer)");
+    expect(reconciliationBody(filled)!.trim()).toBe("accept-loop-b\n\nB reproduces locally. (human maintainer)");
     expect(isReconciliationPending(filled)).toBe(false);
   });
 
@@ -243,7 +243,7 @@ describe("fillReconciliation", () => {
       const { relPath } = writeDivergenceShard(root, input);
       expect(scanDivergenceDir(root)).toHaveLength(1);
       // Reconstruct exactly what the writer wrote (writeDivergenceShard == buildDivergenceShard(input)).
-      const filled = fillReconciliation(buildDivergenceShard(input), "accept-loop-b", "B reproduces locally. (Aaron)");
+      const filled = fillReconciliation(buildDivergenceShard(input), "accept-loop-b", "B reproduces locally. (human maintainer)");
       writeFileSync(join(root, relPath), filled);
       expect(scanDivergenceDir(root)).toHaveLength(0);
     });
@@ -259,14 +259,14 @@ describe("reconcileDivergenceShard (read → fillReconciliation → write-back, 
       expect(scanDivergenceDir(root).map((p) => p.relPath)).toEqual([relPath]);
 
       // "one action": land the decision in place.
-      const result = reconcileDivergenceShard(root, relPath, "accept-loop-b", "B reproduces locally. (Aaron)");
+      const result = reconcileDivergenceShard(root, relPath, "accept-loop-b", "B reproduces locally. (human maintainer)");
       expect(result).toEqual({ relPath, decision: "accept-loop-b" });
 
       // The shard is no longer pending, and the on-disk content carries the decision.
       expect(scanDivergenceDir(root)).toHaveLength(0);
       const md = readFileSync(join(root, relPath), "utf8");
       expect(isReconciliationPending(md)).toBe(false);
-      expect(reconciliationBody(md)!.trim()).toBe("accept-loop-b\n\nB reproduces locally. (Aaron)");
+      expect(reconciliationBody(md)!.trim()).toBe("accept-loop-b\n\nB reproduces locally. (human maintainer)");
     });
   });
 
@@ -305,11 +305,35 @@ describe("reconcileDivergenceShard (read → fillReconciliation → write-back, 
     });
   });
 
+  test("rejects a relPath that escapes the divergence root (no write)", () => {
+    withTempRoot((root) => {
+      // A traversal payload and an absolute path both resolve outside
+      // docs/hygiene-history/divergences/; the guard rejects before any I/O so
+      // a write-back helper can never be steered to clobber unrelated files.
+      const victim = "docs/IMPORTANT.md";
+      const victimAbs = join(root, victim);
+      mkdirSync(dirname(victimAbs), { recursive: true });
+      writeFileSync(victimAbs, "do not clobber\n");
+
+      const traversal = "docs/hygiene-history/divergences/../../IMPORTANT.md";
+      expect(() => reconcileDivergenceShard(root, traversal, "accept-loop-a")).toThrow(
+        /outside the divergence root/,
+      );
+      expect(() => reconcileDivergenceShard(root, "/etc/passwd", "accept-loop-a")).toThrow(
+        /outside the divergence root/,
+      );
+      // Fail-closed: the file the traversal pointed at is untouched.
+      expect(readFileSync(victimAbs, "utf8")).toBe("do not clobber\n");
+    });
+  });
+
   test("throws (file unchanged) when the target is not a divergence shard", () => {
     withTempRoot((root) => {
       // A markdown file that HAS a `## Reconciliation` heading but is NOT a
       // divergence shard (no type: divergence frontmatter) — a mistyped relPath.
-      const relPath = "docs/notes/stray.md";
+      // Kept inside the divergence root so the "not a shard" guard is what
+      // fires (the path-containment guard would otherwise reject it first).
+      const relPath = "docs/hygiene-history/divergences/stray.md";
       const abs = join(root, relPath);
       mkdirSync(dirname(abs), { recursive: true });
       const stray = "---\ntitle: not a shard\n---\n\n## Reconciliation\n\n<!-- placeholder -->\n";

--- a/tools/hygiene/divergence-reconcile.ts
+++ b/tools/hygiene/divergence-reconcile.ts
@@ -19,19 +19,24 @@
 // Pure functions (no I/O): reconciliationBody, isReconciliationPending,
 //   isReconciliationDecision, fillReconciliation, parseShardMeta,
 //   findPendingShards.
-// I/O function: scanDivergenceDir (delegates classification to the pure layer).
+// I/O functions: scanDivergenceDir (reader — delegates classification to the
+//   pure layer) + reconcileDivergenceShard (writer — lands fillReconciliation's
+//   output back in place).
 //
 // The reader surfaces the "one read" of AC #4; fillReconciliation produces the
-// shard-side of the "one action" (the in-place `## Reconciliation` edit) so the
-// maintainer's decision is applied deterministically + validated rather than by
-// hand. It stays below the blocked end-to-end boundary: it returns markdown and
-// never writes, never touches GitHub, never resolves the live thread.
+// shard-side of the "one action" (the in-place `## Reconciliation` edit) and
+// reconcileDivergenceShard is the I/O glue that LANDS that edit — reading the
+// shard, applying fillReconciliation, and writing the reconciled markdown back
+// in place. Together they are the full "one action" of AC #4, mirroring how
+// fileReviewThreadDisagreement (divergence-shard.ts, AC #2) composes the pure
+// detector with the writer. It stays below the blocked end-to-end boundary: it
+// never touches GitHub, never resolves the live PR thread.
 //
 // Schema source of truth: docs/hygiene-history/divergences/README.md
 // Writer companion:        tools/hygiene/divergence-shard.ts
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 
 // Mirrors DIVERGENCE_ROOT in divergence-shard.ts. Both files reflect the path
@@ -276,6 +281,72 @@ export function scanDivergenceDir(
   };
   walk(root);
   return findPendingShards(files);
+}
+
+/** Outcome of landing a reconciliation decision on a shard file. */
+export interface ReconcileResult {
+  /** Repo-relative path of the shard that was reconciled. */
+  readonly relPath: string;
+  /** The decision that was written into the `## Reconciliation` section. */
+  readonly decision: ReconciliationDecision;
+}
+
+/**
+ * Apply a morning-reconciliation decision to a PENDING divergence shard and
+ * write the reconciled markdown back IN PLACE — the I/O "one action" of AC #4
+ * ("the morning reconciliation can resolve the thread in one read + one
+ * action"). scanDivergenceDir produces the read; this lands the maintainer's
+ * decision, composing the pure shard-side transform (fillReconciliation) with a
+ * single in-place write. It mirrors fileReviewThreadDisagreement
+ * (divergence-shard.ts, AC #2), which composes the pure detector with the writer.
+ *
+ * The in-place overwrite IS the README-prescribed update
+ * (docs/hygiene-history/divergences/README.md "Reconciliation outcomes": "the
+ * shard is updated in place (not deleted) so the divergence history is preserved
+ * permanently"). This is the deliberate OPPOSITE of the divergence WRITER's
+ * never-overwrite-differing-content rule: the writer guards uncommitted
+ * divergence evidence, whereas reconciliation transforms a pending placeholder
+ * into a decided section. fillReconciliation preserves every byte up to and
+ * including the `## Reconciliation` heading — both loop perspectives and the
+ * disagreement summary survive verbatim — and git preserves the
+ * pre-reconciliation revision, so no divergence evidence is erased.
+ *
+ * Fail-closed, all validation surfaced BEFORE the write so a rejected call never
+ * mutates the file:
+ *   - no shard at <repoRoot>/<relPath> → throw (clear message), no write.
+ *   - not a divergence shard (parseShardMeta returns null: missing frontmatter
+ *     or type != divergence) → throw, no write. Guards against a mistyped
+ *     relPath pointing at some other markdown that happens to carry a
+ *     `## Reconciliation` heading.
+ *   - invalid decision / no `## Reconciliation` section / already-reconciled
+ *     shard → fillReconciliation throws, no write (a prior human decision is
+ *     never silently erased; a second reconcile run on the same shard fails
+ *     closed rather than re-deciding).
+ *
+ * Stays below the blocked end-to-end boundary: never touches GitHub, never
+ * resolves the live PR thread (that half remains the blocked impl child pending
+ * B-0160).
+ */
+export function reconcileDivergenceShard(
+  repoRoot: string,
+  relPath: string,
+  decision: ReconciliationDecision,
+  note?: string,
+): ReconcileResult {
+  const abs = join(repoRoot, relPath);
+  if (!existsSync(abs)) {
+    throw new Error(`cannot reconcile: no divergence shard at ${relPath}`);
+  }
+  const original = readFileSync(abs, "utf8");
+  if (parseShardMeta(original) === null) {
+    throw new Error(`cannot reconcile: ${relPath} is not a divergence shard (missing frontmatter or type != divergence)`);
+  }
+  // fillReconciliation validates eagerly (decision vocabulary + section present
+  // + still pending) and throws before we touch the file. Compute the
+  // reconciled markdown first; only write once it has succeeded.
+  const reconciled = fillReconciliation(original, decision, note);
+  writeFileSync(abs, reconciled);
+  return { relPath, decision };
 }
 
 function repoRoot(): string {

--- a/tools/hygiene/divergence-reconcile.ts
+++ b/tools/hygiene/divergence-reconcile.ts
@@ -37,7 +37,7 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { join, relative } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 // Mirrors DIVERGENCE_ROOT in divergence-shard.ts. Both files reflect the path
 // the README fixes as the source of truth; a comment-cited copy keeps the
@@ -333,11 +333,30 @@ export function reconcileDivergenceShard(
   decision: ReconciliationDecision,
   note?: string,
 ): ReconcileResult {
-  const abs = join(repoRoot, relPath);
-  if (!existsSync(abs)) {
-    throw new Error(`cannot reconcile: no divergence shard at ${relPath}`);
+  // Constrain relPath to the divergence root before any I/O. A write-back
+  // helper that does join(repoRoot, relPath) blindly can be steered to clobber
+  // unrelated files via an absolute path or "../" traversal; bound it to
+  // docs/hygiene-history/divergences/ (the only place shards live).
+  const divergenceRoot = resolve(repoRoot, DIVERGENCE_ROOT);
+  const abs = resolve(repoRoot, relPath);
+  const within = relative(divergenceRoot, abs);
+  if (within === "" || within.startsWith("..") || isAbsolute(within)) {
+    throw new Error(
+      `cannot reconcile: ${relPath} is outside the divergence root (${DIVERGENCE_ROOT})`,
+    );
   }
-  const original = readFileSync(abs, "utf8");
+  // Read directly and treat a missing file as a signal rather than pre-checking
+  // with existsSync — the check-then-read gap is a TOCTOU race (CWE-367), and
+  // the error path is the same friendly message either way.
+  let original: string;
+  try {
+    original = readFileSync(abs, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`cannot reconcile: no divergence shard at ${relPath}`);
+    }
+    throw err;
+  }
   if (parseShardMeta(original) === null) {
     throw new Error(`cannot reconcile: ${relPath} is not a divergence shard (missing frontmatter or type != divergence)`);
   }


### PR DESCRIPTION
## What

Adds `reconcileDivergenceShard(repoRoot, relPath, decision, note?)` to
`tools/hygiene/divergence-reconcile.ts` — the I/O glue that **lands** a
morning-reconciliation decision back into a divergence shard in place. This is
the I/O "one action" of **B-0164.1 dual-loop AC #4** ("the morning
reconciliation can resolve the thread in one read + one action").

## Why — symmetric completion of AC #4

AC #4 was asymmetrically complete versus AC #2:

| | AC #2 (file on disagreement) | AC #4 (resolve in one read + one action) |
|---|---|---|
| pure core | `detectReviewThreadDisagreement` (#6067) | `fillReconciliation` (#6069) |
| I/O glue | `fileReviewThreadDisagreement` (#6068) | **(missing — this PR)** |

AC #2 had both halves; AC #4 had the reader (`scanDivergenceDir` = "one read",
#6066) and the *pure* shard-side transform (`fillReconciliation` returns
reconciled markdown but never writes), so the CLI told the maintainer to fill
the section *by hand*. `reconcileDivergenceShard` is the missing I/O shell:
read the shard → apply `fillReconciliation` → write the reconciled markdown
back **in place**, mirroring how `fileReviewThreadDisagreement` composes the
pure detector with the writer.

## Design — in-place write is the deliberate opposite of the divergence writer

The in-place overwrite is the README-prescribed update
(`docs/hygiene-history/divergences/README.md` §"Reconciliation outcomes":
*"the shard is updated in place (not deleted) so the divergence history is
preserved permanently"*). This is the intentional **opposite** of the
divergence *writer*'s never-overwrite-differing-content rule:

- the **writer** guards uncommitted divergence evidence (fail-closed-OR-idempotent);
- **reconciliation** transforms a pending placeholder into a decided section.

Safety comes from `fillReconciliation`, which preserves every byte up to and
including the `## Reconciliation` heading — **both loop perspectives + the
disagreement summary survive verbatim** — and git preserves the
pre-reconciliation revision. No divergence evidence is erased.

## Fail-closed (all validation before the write)

- absent shard at `<repoRoot>/<relPath>` → throw, no write.
- not a divergence shard (`parseShardMeta` returns null) → throw, **file left
  unchanged** (guards a mistyped `relPath` pointing at unrelated markdown that
  happens to carry a `## Reconciliation` heading).
- invalid decision / no `## Reconciliation` section / already-reconciled shard
  → `fillReconciliation` throws, no write (a prior human decision is never
  silently re-decided; a second reconcile run fails closed).

## Below the blocked boundary

Never touches GitHub, never resolves the live PR thread — that end-to-end half
remains the blocked impl child pending B-0160 (concurrent dual-loop harness).

## Focused checks

- `bun test tools/hygiene/divergence-reconcile.test.ts tools/hygiene/divergence-shard.test.ts`
  → **61 pass / 0 fail** (7 new tests: full write→scan→reconcile→scan loop,
  decision-only + note, divergence-evidence-preserved, absent-file throw,
  not-a-shard fail-closed, already-reconciled re-run fail-closed, invalid-decision
  fail-closed).
- `bun run typecheck` (`tsc --noEmit`) → **0 errors in changed files**. The only
  typecheck errors are pre-existing `@nats-io/*` module-resolution failures in
  `agentic-organization/apps/workers/`, unrelated to this change.
- Commit canary: `git ls-tree HEAD` == `HEAD~1` == 66 (no tree collapse).

## Scope

One bounded step, TS-only, additive (1 new exported function + 1 new result
type + 7 tests). No `.fs`/.NET surface touched. Claim acquired via
`tools/bus/claim.ts` as `otto-cli` for B-0164.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
