### PR TITLE
fix(ci): authenticate mise via MISE_GITHUB_TOKEN (fixes recurring 403 rate-limit lint flake)

### DIFF
--- a/tools/setup/common/mise.sh
+++ b/tools/setup/common/mise.sh
@@ -25,12 +25,28 @@ if [ "${GITHUB_ACTIONS:-}" = "true" ] &&
    [ -n "${GITHUB_TOKEN:-}" ] &&
    [ -z "${MISE_GITHUB_TOKEN:-}" ] &&
    [ -z "${GITHUB_API_TOKEN:-}" ]; then
-  # GitHub Actions' default GITHUB_TOKEN is scoped to this repository.
-  # mise/aqua may reuse it for release metadata in other repositories
-  # (uv, shellcheck, actionlint), where GitHub returns 404. Prefer a
-  # dedicated mise token if supplied; otherwise fall back to anonymous
-  # public release lookups rather than poisoning them with the repo token.
-  (cd "$REPO_ROOT" && env -u GITHUB_TOKEN mise install)
+  # CI has only the Actions-default GITHUB_TOKEN. Promote it to
+  # MISE_GITHUB_TOKEN — mise's highest-precedence GitHub-auth var
+  # (MISE_GITHUB_TOKEN > GITHUB_API_TOKEN > GITHUB_TOKEN; per
+  # https://mise.jdx.dev/dev-tools/github-tokens.html) — so mise makes
+  # AUTHENTICATED release-metadata calls (1000/hr per-repo) instead of
+  # anonymous (60/hr).
+  #
+  # WHY (2026-05-30): the previous behaviour here was `env -u GITHUB_TOKEN`
+  # (drop the token, look up releases anonymously). Under multi-PR load the
+  # 60/hr anonymous limit exhausts and every tool-release fetch
+  # (semgrep/shellcheck/actionlint/uv) 403s — a recurring flaky CI failure.
+  #
+  # HISTORY NOTE (honor-those-that-came-before): the anonymous fallback was a
+  # deliberate choice to avoid 404s once seen when the *bare* GITHUB_TOKEN was
+  # reused for cross-repo release metadata. Routing the token through mise's
+  # own MISE_GITHUB_TOKEN auth path (rather than leaking the bare env var) is
+  # the supported pattern and reads PUBLIC cross-repo release metadata fine;
+  # it trades the worse, recurring 403-rate-limit flake for the standard
+  # authenticated path. REVERT/ESCALATION: if cross-repo 404s reappear, set a
+  # dedicated fine-grained `MISE_GITHUB_TOKEN` repo secret (still
+  # highest-precedence, so this branch becomes a no-op).
+  (cd "$REPO_ROOT" && MISE_GITHUB_TOKEN="$GITHUB_TOKEN" mise install)
 else
   (cd "$REPO_ROOT" && mise install)
 fi

--- a/tools/setup/common/mise.sh
+++ b/tools/setup/common/mise.sh
@@ -46,7 +46,11 @@ if [ "${GITHUB_ACTIONS:-}" = "true" ] &&
   # authenticated path. REVERT/ESCALATION: if cross-repo 404s reappear, set a
   # dedicated fine-grained `MISE_GITHUB_TOKEN` repo secret (still
   # highest-precedence, so this branch becomes a no-op).
-  (cd "$REPO_ROOT" && MISE_GITHUB_TOKEN="$GITHUB_TOKEN" mise install)
+  # `env -u GITHUB_TOKEN` removes the bare token from the child env (so no
+  # mise plugin / aqua path can read it directly cross-repo — the 404 surface),
+  # while MISE_GITHUB_TOKEN (shell-expanded before env runs) carries the value
+  # via mise's own auth path. Authenticated AND no bare-token leak.
+  (cd "$REPO_ROOT" && env -u GITHUB_TOKEN MISE_GITHUB_TOKEN="$GITHUB_TOKEN" mise install)
 else
   (cd "$REPO_ROOT" && mise install)
 fi


### PR DESCRIPTION
## What this is
The CI "Install toolchain" step (`tools/setup/common/mise.sh`) ran **`env -u GITHUB_TOKEN mise install`** — deliberately *dropping* the token so mise looked up tool releases **anonymously**. Anonymous GitHub API = **60 req/hr**; under multi-PR load that exhausts and every release-metadata fetch (semgrep / shellcheck / actionlint / uv) **403s**. mise logged `No GitHub token was found … GitHub rate limit exceeded`.

Empirically flaked 3+ lint jobs in one session: #6080 (`lint (semgrep)`), #6081 (`lint (no python files)` + `lint (semgrep)`).

## The fix
Promote the Actions `GITHUB_TOKEN` → **`MISE_GITHUB_TOKEN`**, mise's highest-precedence GitHub-auth var (`MISE_GITHUB_TOKEN > GITHUB_API_TOKEN > GITHUB_TOKEN`, per [mise docs](https://mise.jdx.dev/dev-tools/github-tokens.html), verified 2026-05-30) → **authenticated** calls at **1000/hr**. Routing through mise's own auth path (not leaking the bare env var) reads public cross-repo release metadata fine.

## The tradeoff (please be aware)
This **reverses a deliberate prior choice.** The original `env -u GITHUB_TOKEN` was chosen to avoid **404s** once seen when the *bare* `GITHUB_TOKEN` was reused cross-repo. I preserved that history in the code comment + a documented escalation path: **if cross-repo 404s reappear, set a dedicated fine-grained `MISE_GITHUB_TOKEN` repo secret** (still highest-precedence, so this branch no-ops). Net: trades the worse, *recurring* 403-rate-limit flake for the standard authenticated path.

## Scope
Single-source fix — `install.sh` is consumed three ways (dev / CI / devcontainer, GOVERNANCE §24), so this fixes the flake for **every** workflow that runs `install.sh` (gate.yml lint matrix + cadences), not just one.

`bash -n` + `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
