### PR TITLE
fix(tsc): exclude self-typechecking agentic-organization/ from factory top-level tsc scope

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,8 @@
     "**/.lake/**",
     "tools/lean4/.lake/**",
     "tools/alloy/**",
-    "tools/tla/**"
+    "tools/tla/**",
+    "agentic-organization",
+    "agentic-organization/**"
   ]
 }


### PR DESCRIPTION
## What

Add `agentic-organization/**` to the factory top-level `tsconfig.json` `exclude` list.

## Why

The factory top-level `tsconfig.json` globs `include: ["**/*.ts"]` and did **not** exclude `agentic-organization/` — a **self-contained Node sub-project** with its own `tsconfig.json` and its own `typecheck` script:

```jsonc
// agentic-organization/package.json
"typecheck": "npx -p typescript@6.0.3 tsc -p tsconfig.json"
// + node --experimental-strip-types, "type":"module", Node >=22.12 — deliberately NOT Bun-typed
```

Folding that sub-project into the factory's **Bun-typed** top-level tsc (`types:["bun"]`, bundler resolution, `erasableSyntaxOnly`) is a scoping bug.

### How it surfaced

PR #6071 (a draft) added `agentic-organization/apps/workers/src/node-process-host.d.ts`. Because that file has no `import`/`export`, TS treats it as a **global script**, so its `declare const process: NodeProcessHost` becomes a **global** declaration. Once the factory's `**/*.ts` glob pulled it in, it **shadowed Bun's real `process` global** across the entire factory tree:

- **135 tsc errors** across **87 unrelated factory files** (`tools/`, `.codex/`, `full-ai-cluster/tools/`)
- `process.cwd / chdir / kill / pid / getuid / stdin` → `does not exist on type 'NodeProcessHost'`
- PR #6071 touches *none* of those files — only a global type pollution could break them.

### Verified PR-introduced, not pre-existing

`main`'s latest two `gate` runs are **green** (`b7fe942a7`, `b26c889`). `main` is green today only because few `agentic-org` `.ts` files exist on it *yet* — **any** agentic-org TS PR breaks the factory `lint (tsc tools)`. This is a latent factory-config bug.

## Fix rationale

Excluding `agentic-organization/**` is **zero-coverage-loss** — the sub-project keeps type-checking itself via its own `typecheck` script — and is consistent with the existing `tools/alloy`, `tools/tla`, `references/upstreams` excludes for other non-factory-TS areas.

## Verification

`bun --bun tsc --noEmit -p tsconfig.json` (the exact `lint (tsc tools)` CI command) exits **0** with the exclude in place.

## Relationship to PR #6071

This unblocks #6071's `lint (tsc tools)` once that branch picks up `main`. A forward-signal comment is posted on #6071 with the full root-cause + the optional `export {}` module-scoping note (#6071's branch is Max's; not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)