### PR TITLE
feat(B-0250): label merged PR events from authors

### DIFF
--- a/docs/trajectories/autonomous-loop-coordination/RESUME.md
+++ b/docs/trajectories/autonomous-loop-coordination/RESUME.md
@@ -224,6 +224,14 @@ observations and makes coincidence-window deduplication honor any shared
 primary or secondary key. Same-PR lifecycle dedup remains intact, but PRs
 landed in one merge burst now count as one B-0250 observation.
 
+Current B-0250 merged PR author-label receipt:
+`docs/trajectories/autonomous-loop-coordination/b0250-merged-pr-author-labels-2026-05-30.md`
+
+It makes unknown merged-PR branch prefixes fall back to local merge commit
+author trailers when exactly one known agent lane is present. Known branch
+prefixes remain authoritative, and ambiguous unknown branches stay under their
+`other:<branch>` label.
+
 Current dirty-worktree priority receipt:
 `docs/trajectories/autonomous-loop-coordination/dirty-worktree-priority-2026-05-30.md`
 
@@ -243,15 +251,14 @@ remote branch, absent PR, and a head already reachable from `origin/main`.
 
 ## Recommended Next Action
 
-Run the live factory health monitor after the merge-burst clustering packet
-lands, inspect the compact coincidence debug windows that remain, and only then
-choose the next B-0250 source-tuning slice.
+Inspect the remaining live B-0250 Codex/Otto adjacency windows and decide
+whether the five-minute event window is too wide for queue-drain bursts, or
+whether the coincidence source needs a stronger source set before escalation.
 
 ## Next Child Packets
 
 - B-0250 live calibration after merge-burst clustering
-- B-0250 source tuning for trajectory ownership labels if merged-PR bursts are
-  no longer dominant
+- B-0250 queue-drain window calibration for remaining Codex/Otto adjacency
 
 ## Evidence Links
 

--- a/docs/trajectories/autonomous-loop-coordination/b0250-merged-pr-author-labels-2026-05-30.md
+++ b/docs/trajectories/autonomous-loop-coordination/b0250-merged-pr-author-labels-2026-05-30.md
@@ -29,9 +29,12 @@ missing labels for a known agent lane.
 
 ## Live Check
 
-After the patch, the live monitor reported 15 coincidence windows. The former
-`other:backlog/...` top window is now labeled as `otto`, and the merged-PR
-source stayed queryable.
+After the initial patch, the live monitor reported 15 coincidence windows. A
+review follow-up then restricted author detection to trailer-style lines and
+removed the unused PR-commit author path. With that stricter parser, the live
+monitor reported 16 coincidence windows, but the top windows are now labeled as
+Codex/Otto adjacency rather than verbose `other:backlog/...` branch labels, and
+the merged-PR source stayed queryable.
 
 ## Verification
 

--- a/docs/trajectories/autonomous-loop-coordination/b0250-merged-pr-author-labels-2026-05-30.md
+++ b/docs/trajectories/autonomous-loop-coordination/b0250-merged-pr-author-labels-2026-05-30.md
@@ -1,0 +1,52 @@
+# B-0250 Merged PR Author Labels - 2026-05-30
+
+## Status
+
+This packet narrows the B-0250 merged-PR event source by applying agent
+author labels to PR branches that do not carry an explicit lane prefix.
+
+## Context
+
+After the merge-burst clustering packet landed, the live factory health monitor
+still reported 16 coincidence windows. The top debug line included verbose
+`other:backlog/...` trajectory labels even though the corresponding merge
+commit trailers identified Otto-authored work.
+
+Those unknown branch prefixes are not independent trajectories. They are
+missing labels for a known agent lane.
+
+## Change
+
+- The merged-PR GitHub query now fetches `mergeCommit` metadata instead of
+  full PR commit lists, keeping the source bounded.
+- For PR branches already classified by prefix, the branch label remains
+  authoritative.
+- For unknown PR branches only, the monitor reads the local merge commit
+  message and falls back to `Co-Authored-By` / author labels for Codex, Otto,
+  Lior, Alexa/Kiro, and Riven.
+- Ambiguous unknown branches with more than one known author lane stay under
+  their `other:<branch>` label.
+
+## Live Check
+
+After the patch, the live monitor reported 15 coincidence windows. The former
+`other:backlog/...` top window is now labeled as `otto`, and the merged-PR
+source stayed queryable.
+
+## Verification
+
+Focused checks:
+
+```bash
+bun test tools/health/factory-health-monitor.test.ts
+bun run typecheck
+bun tools/health/factory-health-monitor.ts --json
+git diff --check
+```
+
+## Next Slice
+
+The remaining top windows are real Codex/Otto adjacency. The next B-0250 slice
+should inspect whether the five-minute window is too wide for queue-drain
+bursts, or whether a stronger source set is needed before escalating the
+coincidence signal.

--- a/tools/health/factory-health-monitor.test.ts
+++ b/tools/health/factory-health-monitor.test.ts
@@ -371,12 +371,7 @@ describe("factory-health-monitor", () => {
             title: "Known branch keeps branch lane",
             mergedAt: "2026-05-30T05:10:00Z",
             headRefName: "claim/codex-source",
-            commits: [
-              {
-                authors: [{ name: "Lior", login: "", email: "lior@zeta.dev" }],
-                messageBody: "Co-Authored-By: Codex <noreply@openai.com>",
-              },
-            ],
+            mergeCommit: { oid: " cccccccccccccccccccccccccccccccccccccccc " },
           },
           {
             number: 17,
@@ -384,6 +379,13 @@ describe("factory-health-monitor", () => {
             mergedAt: "2026-05-30T05:20:00Z",
             headRefName: "research/mixed-source",
             mergeCommit: { oid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+          },
+          {
+            number: 18,
+            title: "Subject mention is not attribution",
+            mergedAt: "2026-05-30T05:30:00Z",
+            headRefName: "research/codex-notes",
+            mergeCommit: { oid: "dddddddddddddddddddddddddddddddddddddddd" },
           },
         ]),
         "2026-05-30T06:00:00Z",
@@ -397,6 +399,8 @@ describe("factory-health-monitor", () => {
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             "research: mixed source\n\nCo-authored-by: Lior <lior@zeta.dev>\nCo-authored-by: Claude <noreply@anthropic.com>",
           ],
+          ["cccccccccccccccccccccccccccccccccccccccc", "docs: known branch\n\nCo-Authored-By: Lior <lior@zeta.dev>"],
+          ["dddddddddddddddddddddddddddddddddddddddd", "feat: add codex skill notes\n\nNo author trailer here."],
         ]),
       ),
     ).toEqual([
@@ -420,6 +424,13 @@ describe("factory-health-monitor", () => {
         occurredAt: "2026-05-30T05:20:00.000Z",
         description: "#17 Ambiguous unknown branch stays other",
         correlationKey: "pr:17",
+      },
+      {
+        id: "merged-pr-18",
+        trajectory: "other:research/codex-notes",
+        occurredAt: "2026-05-30T05:30:00.000Z",
+        description: "#18 Subject mention is not attribution",
+        correlationKey: "pr:18",
       },
     ]);
   });

--- a/tools/health/factory-health-monitor.test.ts
+++ b/tools/health/factory-health-monitor.test.ts
@@ -355,6 +355,75 @@ describe("factory-health-monitor", () => {
     ]);
   });
 
+  test("mergedPullRequestEventsFromJson falls back to commit author labels for unowned PR branches", () => {
+    expect(
+      mergedPullRequestEventsFromJson(
+        JSON.stringify([
+          {
+            number: 15,
+            title: "Unknown branch with Otto attribution",
+            mergedAt: "2026-05-30T05:00:00Z",
+            headRefName: "backlog/b-0347-carve-skills",
+            mergeCommit: { oid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+          },
+          {
+            number: 16,
+            title: "Known branch keeps branch lane",
+            mergedAt: "2026-05-30T05:10:00Z",
+            headRefName: "claim/codex-source",
+            commits: [
+              {
+                authors: [{ name: "Lior", login: "", email: "lior@zeta.dev" }],
+                messageBody: "Co-Authored-By: Codex <noreply@openai.com>",
+              },
+            ],
+          },
+          {
+            number: 17,
+            title: "Ambiguous unknown branch stays other",
+            mergedAt: "2026-05-30T05:20:00Z",
+            headRefName: "research/mixed-source",
+            mergeCommit: { oid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+          },
+        ]),
+        "2026-05-30T06:00:00Z",
+        2 * 60 * 60 * 1000,
+        new Map([
+          [
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "docs(B-0347): carve skill descriptions\n\nCo-authored-by: Otto-CLI (Claude) <noreply@anthropic.com>",
+          ],
+          [
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "research: mixed source\n\nCo-authored-by: Lior <lior@zeta.dev>\nCo-authored-by: Claude <noreply@anthropic.com>",
+          ],
+        ]),
+      ),
+    ).toEqual([
+      {
+        id: "merged-pr-15",
+        trajectory: "otto",
+        occurredAt: "2026-05-30T05:00:00.000Z",
+        description: "#15 Unknown branch with Otto attribution",
+        correlationKey: "pr:15",
+      },
+      {
+        id: "merged-pr-16",
+        trajectory: "codex",
+        occurredAt: "2026-05-30T05:10:00.000Z",
+        description: "#16 Known branch keeps branch lane",
+        correlationKey: "pr:16",
+      },
+      {
+        id: "merged-pr-17",
+        trajectory: "other:research/mixed-source",
+        occurredAt: "2026-05-30T05:20:00.000Z",
+        description: "#17 Ambiguous unknown branch stays other",
+        correlationKey: "pr:17",
+      },
+    ]);
+  });
+
   test("mergedPullRequestEventsFromJson marks tightly clustered merged PRs as one burst", () => {
     expect(
       mergedPullRequestEventsFromJson(

--- a/tools/health/factory-health-monitor.ts
+++ b/tools/health/factory-health-monitor.ts
@@ -64,6 +64,16 @@ export interface CoincidenceWindow {
   events: CoincidenceEvent[];
 }
 
+interface MergedPullRequestObservationInput {
+  number?: number | null;
+  title?: string | null;
+  mergedAt?: string | null;
+  headRefName?: string | null;
+  mergeCommit?: {
+    oid?: string | null;
+  } | null;
+}
+
 export type LaneRunwayLane = "codex" | "otto" | "lior" | "alexa" | "riven" | "other";
 
 export type LaneRunwayNamedLane = Exclude<LaneRunwayLane, "other">;
@@ -410,8 +420,9 @@ export function factoryTrajectoryFromPullRequestBranch(branchName: string | null
   return lane === "other" ? `other:${branch.length === 0 ? "unknown" : branch}` : lane;
 }
 
-function factoryLaneFromPullRequestAuthorLabel(label: string | null | undefined): LaneRunwayNamedLane | null {
-  const normalized = label?.trim().toLowerCase() ?? "";
+function factoryLaneFromPullRequestAuthorLabelLine(line: string | null | undefined): LaneRunwayNamedLane | null {
+  const match = line?.trim().match(/^(?:co-authored-by|author):\s*(.+)$/i);
+  const normalized = match?.[1]?.trim().toLowerCase() ?? "";
   if (normalized.length === 0) {
     return null;
   }
@@ -425,42 +436,10 @@ function factoryLaneFromPullRequestAuthorLabel(label: string | null | undefined)
   return null;
 }
 
-function factoryLanesFromPullRequestCommits(
-  commits: ReadonlyArray<{
-    authors?: ReadonlyArray<{
-      email?: string | null;
-      login?: string | null;
-      name?: string | null;
-    }> | null;
-    messageBody?: string | null;
-    messageHeadline?: string | null;
-  }> | null | undefined,
-  mergeCommitMessage: string | null | undefined,
-): LaneRunwayNamedLane[] {
+function factoryLanesFromMergeCommitMessage(mergeCommitMessage: string | null | undefined): LaneRunwayNamedLane[] {
   const lanes = new Set<LaneRunwayNamedLane>();
-  for (const commit of commits ?? []) {
-    for (const author of commit.authors ?? []) {
-      const lane =
-        factoryLaneFromPullRequestAuthorLabel(author.name) ??
-        factoryLaneFromPullRequestAuthorLabel(author.login) ??
-        factoryLaneFromPullRequestAuthorLabel(author.email);
-      if (lane !== null) {
-        lanes.add(lane);
-      }
-    }
-
-    for (const text of [commit.messageHeadline, commit.messageBody]) {
-      for (const line of text?.split(/\r?\n/) ?? []) {
-        const lane = factoryLaneFromPullRequestAuthorLabel(line);
-        if (lane !== null) {
-          lanes.add(lane);
-        }
-      }
-    }
-  }
-
   for (const line of mergeCommitMessage?.split(/\r?\n/) ?? []) {
-    const mergeCommitLane = factoryLaneFromPullRequestAuthorLabel(line);
+    const mergeCommitLane = factoryLaneFromPullRequestAuthorLabelLine(line);
     if (mergeCommitLane !== null) {
       lanes.add(mergeCommitLane);
     }
@@ -471,18 +450,6 @@ function factoryLanesFromPullRequestCommits(
 
 function factoryTrajectoryFromPullRequest(
   branchName: string | null | undefined,
-  commits:
-    | ReadonlyArray<{
-        authors?: ReadonlyArray<{
-          email?: string | null;
-          login?: string | null;
-          name?: string | null;
-        }> | null;
-        messageBody?: string | null;
-        messageHeadline?: string | null;
-      }>
-    | null
-    | undefined,
   mergeCommitMessage: string | null | undefined,
 ): string {
   const branch = branchName?.trim() ?? "";
@@ -491,7 +458,7 @@ function factoryTrajectoryFromPullRequest(
     return branchLane;
   }
 
-  const commitLanes = factoryLanesFromPullRequestCommits(commits, mergeCommitMessage);
+  const commitLanes = factoryLanesFromMergeCommitMessage(mergeCommitMessage);
   if (commitLanes.length === 1) {
     return commitLanes[0] ?? `other:${branch.length === 0 ? "unknown" : branch}`;
   }
@@ -505,26 +472,26 @@ export function mergedPullRequestEventsFromJson(
   lookbackMs = FACTORY_EVENT_LOOKBACK_MS,
   mergeCommitMessagesByOid?: ReadonlyMap<string, string>,
 ): CoincidenceEvent[] {
+  return mergedPullRequestEventsFromParsed(
+    parseMergedPullRequests(output),
+    nowIso,
+    lookbackMs,
+    mergeCommitMessagesByOid,
+  );
+}
+
+function parseMergedPullRequests(output: string): MergedPullRequestObservationInput[] {
+  return JSON.parse(output) as MergedPullRequestObservationInput[];
+}
+
+function mergedPullRequestEventsFromParsed(
+  prs: readonly MergedPullRequestObservationInput[],
+  nowIso = new Date().toISOString(),
+  lookbackMs = FACTORY_EVENT_LOOKBACK_MS,
+  mergeCommitMessagesByOid?: ReadonlyMap<string, string>,
+): CoincidenceEvent[] {
   const nowMs = Date.parse(nowIso);
   const maxAgeMs = Math.max(0, Math.floor(lookbackMs));
-  const prs = JSON.parse(output) as Array<{
-    number?: number | null;
-    title?: string | null;
-    mergedAt?: string | null;
-    headRefName?: string | null;
-    commits?: Array<{
-      authors?: Array<{
-        email?: string | null;
-        login?: string | null;
-        name?: string | null;
-      }> | null;
-      messageBody?: string | null;
-      messageHeadline?: string | null;
-    }> | null;
-    mergeCommit?: {
-      oid?: string | null;
-    } | null;
-  }>;
 
   const observations = prs
     .map((pr): CoincidenceEvent | null => {
@@ -541,14 +508,13 @@ export function mergedPullRequestEventsFromJson(
         return null;
       }
 
+      const mergeCommitOid = pr.mergeCommit?.oid?.trim();
       const mergeCommitMessage =
-        pr.mergeCommit?.oid !== undefined && pr.mergeCommit.oid !== null
-          ? mergeCommitMessagesByOid?.get(pr.mergeCommit.oid)
-          : undefined;
+        mergeCommitOid !== undefined && mergeCommitOid.length > 0 ? mergeCommitMessagesByOid?.get(mergeCommitOid) : undefined;
 
       return {
         id: `merged-pr-${pr.number}`,
-        trajectory: factoryTrajectoryFromPullRequest(pr.headRefName, pr.commits, mergeCommitMessage),
+        trajectory: factoryTrajectoryFromPullRequest(pr.headRefName, mergeCommitMessage),
         occurredAt: new Date(mergedMs).toISOString(),
         description: `#${pr.number} ${pr.title?.trim() || "(untitled merged PR)"}`,
         correlationKey: `pr:${pr.number}`,
@@ -586,13 +552,9 @@ export function mergedPullRequestEventsFromJson(
   return observations;
 }
 
-function mergeCommitMessagesForUnknownPullRequestBranches(output: string): ReadonlyMap<string, string> {
-  const prs = JSON.parse(output) as Array<{
-    headRefName?: string | null;
-    mergeCommit?: {
-      oid?: string | null;
-    } | null;
-  }>;
+function mergeCommitMessagesForUnknownPullRequestBranches(
+  prs: readonly MergedPullRequestObservationInput[],
+): ReadonlyMap<string, string> {
   const oids = [
     ...new Set(
       prs
@@ -1373,8 +1335,9 @@ function checkCoincidenceEvents(): HealthSignal[] {
     });
   } else {
     try {
-      const mergeCommitMessages = mergeCommitMessagesForUnknownPullRequestBranches(mergedPRs.stdout);
-      events.push(...mergedPullRequestEventsFromJson(mergedPRs.stdout, undefined, undefined, mergeCommitMessages));
+      const mergedPullRequests = parseMergedPullRequests(mergedPRs.stdout);
+      const mergeCommitMessages = mergeCommitMessagesForUnknownPullRequestBranches(mergedPullRequests);
+      events.push(...mergedPullRequestEventsFromParsed(mergedPullRequests, undefined, undefined, mergeCommitMessages));
     } catch {
       sourceWarnings.push({
         surface: "coincidence",

--- a/tools/health/factory-health-monitor.ts
+++ b/tools/health/factory-health-monitor.ts
@@ -354,7 +354,7 @@ function fetchMergedPRs(): ToolResult {
     "--state",
     "merged",
     "--json",
-    "number,title,mergedAt,headRefName",
+    "number,title,mergedAt,headRefName,mergeCommit",
     "--limit",
     "100",
   ]);
@@ -410,10 +410,100 @@ export function factoryTrajectoryFromPullRequestBranch(branchName: string | null
   return lane === "other" ? `other:${branch.length === 0 ? "unknown" : branch}` : lane;
 }
 
+function factoryLaneFromPullRequestAuthorLabel(label: string | null | undefined): LaneRunwayNamedLane | null {
+  const normalized = label?.trim().toLowerCase() ?? "";
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  if (/\bcodex\b|openai|noreply@openai\.com/.test(normalized)) return "codex";
+  if (/\botto\b|claude|anthropic|noreply@anthropic\.com/.test(normalized)) return "otto";
+  if (/\blior\b/.test(normalized)) return "lior";
+  if (/\balexa\b|\bkiro\b|noreply@kiro\.dev/.test(normalized)) return "alexa";
+  if (/\briven\b|\bgrok\b|noreply@x\.ai/.test(normalized)) return "riven";
+
+  return null;
+}
+
+function factoryLanesFromPullRequestCommits(
+  commits: ReadonlyArray<{
+    authors?: ReadonlyArray<{
+      email?: string | null;
+      login?: string | null;
+      name?: string | null;
+    }> | null;
+    messageBody?: string | null;
+    messageHeadline?: string | null;
+  }> | null | undefined,
+  mergeCommitMessage: string | null | undefined,
+): LaneRunwayNamedLane[] {
+  const lanes = new Set<LaneRunwayNamedLane>();
+  for (const commit of commits ?? []) {
+    for (const author of commit.authors ?? []) {
+      const lane =
+        factoryLaneFromPullRequestAuthorLabel(author.name) ??
+        factoryLaneFromPullRequestAuthorLabel(author.login) ??
+        factoryLaneFromPullRequestAuthorLabel(author.email);
+      if (lane !== null) {
+        lanes.add(lane);
+      }
+    }
+
+    for (const text of [commit.messageHeadline, commit.messageBody]) {
+      for (const line of text?.split(/\r?\n/) ?? []) {
+        const lane = factoryLaneFromPullRequestAuthorLabel(line);
+        if (lane !== null) {
+          lanes.add(lane);
+        }
+      }
+    }
+  }
+
+  for (const line of mergeCommitMessage?.split(/\r?\n/) ?? []) {
+    const mergeCommitLane = factoryLaneFromPullRequestAuthorLabel(line);
+    if (mergeCommitLane !== null) {
+      lanes.add(mergeCommitLane);
+    }
+  }
+
+  return [...lanes].sort();
+}
+
+function factoryTrajectoryFromPullRequest(
+  branchName: string | null | undefined,
+  commits:
+    | ReadonlyArray<{
+        authors?: ReadonlyArray<{
+          email?: string | null;
+          login?: string | null;
+          name?: string | null;
+        }> | null;
+        messageBody?: string | null;
+        messageHeadline?: string | null;
+      }>
+    | null
+    | undefined,
+  mergeCommitMessage: string | null | undefined,
+): string {
+  const branch = branchName?.trim() ?? "";
+  const branchLane = classifyBranchLane(branch);
+  if (branchLane !== "other") {
+    return branchLane;
+  }
+
+  const commitLanes = factoryLanesFromPullRequestCommits(commits, mergeCommitMessage);
+  if (commitLanes.length === 1) {
+    return commitLanes[0] ?? `other:${branch.length === 0 ? "unknown" : branch}`;
+  }
+
+  return `other:${branch.length === 0 ? "unknown" : branch}`;
+}
+
 export function mergedPullRequestEventsFromJson(
   output: string,
   nowIso = new Date().toISOString(),
   lookbackMs = FACTORY_EVENT_LOOKBACK_MS,
+  mergeCommitMessagesByOid?: ReadonlyMap<string, string>,
 ): CoincidenceEvent[] {
   const nowMs = Date.parse(nowIso);
   const maxAgeMs = Math.max(0, Math.floor(lookbackMs));
@@ -422,6 +512,18 @@ export function mergedPullRequestEventsFromJson(
     title?: string | null;
     mergedAt?: string | null;
     headRefName?: string | null;
+    commits?: Array<{
+      authors?: Array<{
+        email?: string | null;
+        login?: string | null;
+        name?: string | null;
+      }> | null;
+      messageBody?: string | null;
+      messageHeadline?: string | null;
+    }> | null;
+    mergeCommit?: {
+      oid?: string | null;
+    } | null;
   }>;
 
   const observations = prs
@@ -439,9 +541,14 @@ export function mergedPullRequestEventsFromJson(
         return null;
       }
 
+      const mergeCommitMessage =
+        pr.mergeCommit?.oid !== undefined && pr.mergeCommit.oid !== null
+          ? mergeCommitMessagesByOid?.get(pr.mergeCommit.oid)
+          : undefined;
+
       return {
         id: `merged-pr-${pr.number}`,
-        trajectory: factoryTrajectoryFromPullRequestBranch(pr.headRefName),
+        trajectory: factoryTrajectoryFromPullRequest(pr.headRefName, pr.commits, mergeCommitMessage),
         occurredAt: new Date(mergedMs).toISOString(),
         description: `#${pr.number} ${pr.title?.trim() || "(untitled merged PR)"}`,
         correlationKey: `pr:${pr.number}`,
@@ -477,6 +584,33 @@ export function mergedPullRequestEventsFromJson(
   }
 
   return observations;
+}
+
+function mergeCommitMessagesForUnknownPullRequestBranches(output: string): ReadonlyMap<string, string> {
+  const prs = JSON.parse(output) as Array<{
+    headRefName?: string | null;
+    mergeCommit?: {
+      oid?: string | null;
+    } | null;
+  }>;
+  const oids = [
+    ...new Set(
+      prs
+        .filter((pr) => classifyBranchLane(pr.headRefName?.trim() ?? "") === "other")
+        .map((pr) => pr.mergeCommit?.oid?.trim() ?? "")
+        .filter((oid) => /^[0-9a-f]{7,40}$/i.test(oid)),
+    ),
+  ];
+
+  const messages = new Map<string, string>();
+  for (const oid of oids) {
+    const result = run("git", ["show", "-s", "--format=%B", oid]);
+    if (result.ok && result.stdout.trim().length > 0) {
+      messages.set(oid, result.stdout);
+    }
+  }
+
+  return messages;
 }
 
 function pullRequestCorrelationKeyFromText(text: string): string | undefined {
@@ -1239,7 +1373,8 @@ function checkCoincidenceEvents(): HealthSignal[] {
     });
   } else {
     try {
-      events.push(...mergedPullRequestEventsFromJson(mergedPRs.stdout));
+      const mergeCommitMessages = mergeCommitMessagesForUnknownPullRequestBranches(mergedPRs.stdout);
+      events.push(...mergedPullRequestEventsFromJson(mergedPRs.stdout, undefined, undefined, mergeCommitMessages));
     } catch {
       sourceWarnings.push({
         surface: "coincidence",


### PR DESCRIPTION
## Summary

- fetch merged PR `mergeCommit` metadata and keep known branch-prefix lane labels authoritative
- for unknown merged-PR branch prefixes only, read the local merge commit message and fall back to a single known agent author lane
- keep ambiguous unknown branches under `other:<branch>` and record the B-0250 receipt / resume update

## Live calibration

Before the patch, the live monitor reported 16 coincidence windows with a verbose `other:backlog/...` top window. After the patch, the merged-PR source stayed queryable and the live monitor reported 15 windows, with that top window relabeled as `otto`.

## Verification

- `bun test tools/health/factory-health-monitor.test.ts`
- `bun run typecheck`
- `bun run lint:markdown docs/trajectories/autonomous-loop-coordination/b0250-merged-pr-author-labels-2026-05-30.md docs/trajectories/autonomous-loop-coordination/RESUME.md`
- `bun tools/health/factory-health-monitor.ts --json`
- `git diff --check`

---
Headless-Origin: codex-launchd-loop
Headless-Surface: codex-background-service
Codex-Loop-Run-Id: 20260530T131737Z