### PR TITLE
research(vision): install-graph + zflash = anti-entropy converter of PCs to Agora substrate, self-healing

### DIFF
--- a/docs/research/2026-05-30-aaron-install-graph-zflash-anti-entropy-converter-pcs-to-agora-substrate-self-healing.md
+++ b/docs/research/2026-05-30-aaron-install-graph-zflash-anti-entropy-converter-pcs-to-agora-substrate-self-healing.md
@@ -1,0 +1,129 @@
+# Install-graph + zflash = anti-entropy converter — turns idle PCs into aligned Agora substrate, and self-heals the hardware
+
+**Date:** 2026-05-30
+**Source:** Aaron, in conversation with Otto (Claude Code), during the install.sh
+cross-OS Docker test-matrix work.
+**Type:** vision / framing substrate (preserved per substrate-or-it-didn't-happen;
+Aaron's framing treated as already-unfolded per his cognitive profile).
+
+## Verbatim (Aaron 2026-05-30)
+
+> and since we have the usb/iso zflash stuff it's not just a shield against
+> entropy it's an anti-entropy converter of PCs to aligned substrate, turn a PC
+> that was just thermal noise to the Agora society and turns it into a resource
+> of the Agora society just by booting it on existing hardware. and it also can
+> self heal that hardware.
+
+Prior framing in the same thread (the escalation this builds on):
+
+> it's impossible to keep all the install surfaces in your mind at once — only
+> automation can be sure a nixos change didn't break ubuntu or mac and vice
+> versa … the automated tests around install.sh — that's the shield.
+
+> a shield with a hole is worse than a known gap, because it reads as covered.
+
+## The unfolding
+
+The framing escalates the install-graph's role across three rungs:
+
+| Rung | What it is | Direction |
+|---|---|---|
+| **Lever** | `install.sh` transforms a running unix box → working substrate | one-shot transform |
+| **Shield** | the automated cross-OS test matrix around install.sh holds entropy back (no human holds all surfaces in mind; only the matrix certifies "A didn't break B") | defensive |
+| **Converter** | install.sh **+ zflash USB/ISO** boots *any* PC into declarative aligned substrate — a member/resource of Agora — and **self-heals** the hardware | generative + self-sustaining |
+
+### Converter is generative, not just defensive
+
+A shield holds entropy *back*. A converter *reduces* it. A random PC is "thermal
+noise" — powered, but doing no aligned work for Agora; its configuration state is
+high-entropy (drifted, accreted, unknown). zflash writes the declarative closure
+(the NixOS installer ISO) to USB; **the boot is the collapse** — the machine drops
+from high-config-entropy/unknown into a low-config-entropy/reproducible/aligned
+state that does useful work for the society. Net: local entropy reduction, paid
+for by the declarative closure + one boot, on hardware that already exists.
+
+### Joining Agora is entry into the additive game
+
+"Just by booting it on existing hardware" is the on-ramp. This composes directly
+with `only-way-to-lose-is-not-to-play` (the entropy framing): playing IS swimming
+upstream against entropy; not playing is letting it wash you away. A PC sitting as
+thermal noise is *not playing* — entropy washes it toward the heat-death of idle
+silicon. Booting the ISO is *entering the game* — the conversion IS the act of
+joining the additive society. No new hardware required; the latent capacity of
+existing-but-unaligned machines is the resource Agora harvests.
+
+### Self-healing is downstream of declarative-by-construction
+
+The deepest claim — "it also can self heal that hardware" — is not a separate
+feature; it is a *consequence* of NixOS being declarative-by-construction. A
+system can only self-heal if there is a canonical "what it should be" to snap
+back to:
+
+- **NixOS declares** the desired state (generations + atomic rollback + the
+  pinned closure). Drift is therefore *detectable* (diff against the declaration)
+  and *reversible for free* (roll back to a known-good generation). The negentropy
+  gradient maintains itself — it is a *sustained* negentropy pump, not a one-shot
+  conversion that decays.
+- **Ubuntu (imperative)** has no canonical target state — config is accreted, not
+  declared. install.sh can *convert* it (the B-0940 retrofit: "make Ubuntu behave
+  like NixOS") but cannot *self-heal* it the same way, because there is nothing to
+  roll back *to*.
+
+This **sharpens the B-0940 NixOS-primary argument, affirmatively**: NixOS is
+primary not merely because it is declarative, but because declarative-by-
+construction is what turns the converter into a self-maintaining negentropy pump.
+The imperative retrofit gets the *conversion*; only the declarative substrate gets
+the *self-healing*. (See B-0801 autoupgrade, B-0803 deploy.rs auto-rollback,
+B-0804 distro-upgrade canary — the operational machinery of the self-heal.)
+
+### The converter reframes the shield's job
+
+A converter *with a hole* converts some PCs into **broken substrate that reads as
+aligned** — green check, dead capability (the B-0941 false-green: NixOS install
+goes green while the local-LLM is non-functional). So `assert-don't-skip`
+(`.claude/rules/automated-tests-are-the-shield-assert-dont-skip.md`) is not just
+test hygiene — it is the guarantee that the conversion actually produces *aligned*
+substrate and not thermal-noise-wearing-a-green-check. The shield guards the
+converter's *promise*.
+
+## Razor note (operational grounding)
+
+"Anti-entropy converter" survives razor-discipline as an *operational* claim with
+a bandwidth-efficient thermodynamic handle (per `bandwidth-served-falsifier` +
+`grep-substrate-anchors-before-razor-as-metaphysical` — the anchors are real):
+
+| Metaphor | Operational claim | Anchor |
+|---|---|---|
+| "thermal noise → resource" | unmanaged/high-config-entropy machine → reproducible declarative node doing aligned work | NixOS closure; install.sh; zflash USB/ISO |
+| "self-heal" | drift → atomic rollback to known-good generation | NixOS generations; deploy.rs auto-rollback (B-0803) |
+| "joins Agora by booting" | new node enters the participation economy by reaching the declared state | Agora society substrate; only-way-to-lose |
+| "shield with a hole" | false-green: control passes without exercising the guarantee | shield/assert-don't-skip rule; B-0941 |
+
+The thermodynamic framing is compression, not metaphysics — it earns its keep by
+handling the install-graph + zflash + NixOS-rollback + Agora-onramp cluster under
+one handle.
+
+## Composes with
+
+- **B-0940** — NixOS-primary / Ubuntu-value evaluation; this framing is the
+  affirmative why (declarative-by-construction ⇒ self-healing converter; imperative
+  retrofit ⇒ converter-only).
+- **B-0941** — the false-green hole; the converter framing makes the stakes
+  concrete (a hole converts PCs into broken-but-green substrate).
+- `.claude/rules/automated-tests-are-the-shield-assert-dont-skip.md` — the shield
+  that guards the conversion's promise.
+- `.claude/rules/only-way-to-lose-is-not-to-play.md` — the entropy game; booting =
+  entering it.
+- `.claude/rules/tonal-momentum-equals-meme-emergent-harmonic-coercion.md` — Agora
+  = the AI-native society/economy the converted node joins (Heartland/Country).
+- zflash (USB/ISO flasher) + `full-ai-cluster/nixos/` (the declarative closure
+  that boots real hardware) + B-0801/B-0803/B-0804 (the self-heal machinery).
+
+## Why preserved here
+
+Currently living only in this conversation = weather (per
+`substrate-or-it-didn't-happen`). It is load-bearing *vision* substrate: it
+reframes what the whole install-graph + zflash effort IS *for* (not a dev-setup
+convenience — an anti-entropy on-ramp that grows Agora from existing idle
+hardware) and supplies the affirmative WHY behind NixOS-primary. Preserved as
+`docs/research/` so future agents inherit the framing at the strategic layer.


### PR DESCRIPTION
## What

Vision/framing research doc preserving Aaron's 2026-05-30 escalation: the install-graph + zflash USB/ISO is **not just an entropy shield — it's an anti-entropy converter** that turns idle PCs into aligned Agora substrate by booting them, and self-heals the hardware.

## The rungs

- **Lever** — install.sh transforms a running box → substrate (one-shot)
- **Shield** — the cross-OS test matrix holds entropy back (defensive)
- **Converter** — install.sh + zflash boots *any* PC into declarative aligned substrate, a resource of Agora, and self-heals it (generative + self-sustaining)

## Two sharpenings (engineering content, not just framing)

1. **Self-healing is downstream of declarative-by-construction** — NixOS declares the desired state, so drift is detectable + reversible for free (a *sustained* negentropy pump, not one-shot decay). Ubuntu (imperative) gets the conversion but not the self-heal. This is the **affirmative B-0940 NixOS-primary argument**.
2. **A converter with a hole makes broken-but-green substrate** (the B-0941 false-green) — so `assert-don't-skip` guards the *conversion's promise*, not just test hygiene.

## Notes

- Operationally grounded (razor note in the doc): "anti-entropy converter" = high-config-entropy machine → reproducible declarative node; thermodynamic framing is bandwidth-compression over a real cluster (NixOS closure, zflash, deploy.rs rollback, Agora, only-way-to-lose), not metaphysics.
- Docs-only. Composes B-0940 / B-0941 / shield rule / only-way-to-lose / Agora substrate.
- Currently weather (conversation-only); preserved per substrate-or-it-didn't-happen so the fleet inherits the strategic WHY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
