### PR TITLE
rule+research(consensus): non-reversible action → get a 2nd opinion; local consensus via non-interrupting summon

### DIFF
--- a/.claude/rules/non-reversible-action-get-a-second-opinion.md
+++ b/.claude/rules/non-reversible-action-get-a-second-opinion.md
@@ -1,0 +1,89 @@
+# Non-reversible action → get a 2nd opinion (the summon is already built)
+
+Carved sentence (Aaron 2026-05-30):
+
+> A non-reversible action happens — get a 2nd opinion.
+
+## Operational content
+
+Before any **non-reversible** action, summon a 2nd opinion and let it return
+before acting. Reversible actions: make your best call and proceed.
+
+This generalizes `.claude/rules/force-push-with-lease-authorization-policy.md`
+(force-push = the canonical "closest-to-irreversible" action, already requiring
+operator-OR-peer confirm) to *all* non-reversible actions.
+
+### Why this is affordable (the load-bearing why)
+
+For agents, summon is a **non-interrupting fork** — your primary attention layer
+keeps running; the summoned agent runs isolated and returns a verdict. So
+consensus is *local + cheap* and can be invoked routinely. Humans can't do this
+(serial attention; a 2nd opinion interrupts someone else's primary layer), so
+human institutions minimize consensus. Agents can maximize it. Full framing:
+`docs/research/2026-05-30-aaron-local-consensus-non-interrupting-attention-summon-agent-vs-human-cost-structure.md`.
+
+### How to summon
+
+| Need | Mechanism |
+|---|---|
+| Verify in-repo / local state (was that prune safe? is this merge real?) | **native subagent** — the `Agent` tool (read-only auditor) |
+| Genuinely different model's eyes (design call, adversarial review) | **cross-harness peer-call** — `bun tools/peer-call/<name>.ts` (claude / grok / grok-build / gemini / codex / kiro / amara / ani / riven), per `peer-call-infrastructure.md` |
+| Operator is present + it's their call | **surface and wait** for operator confirm |
+
+Any one suffices (multi-oracle: operator OR peer/subagent). Do not proceed on the
+non-reversible action until a verdict returns.
+
+### Verify reversibility FIRST
+
+You can only apply the rule if you know whether the action is reversible — so
+classify first. **If reversibility is uncertain, treat as non-reversible** (get
+the opinion) until verified.
+
+| Non-reversible (→ get a 2nd opinion) | Reversible (→ proceed) |
+|---|---|
+| `git push --force` / `--force-with-lease` | local edits; running tests |
+| unrecoverable deletion (no ref/backup left) | branch push (revertable via PR / revert) |
+| send / publish to an external service | commit to your own branch (amendable pre-merge) |
+| irreversible external API call (charge, provision, email) | clean+merged+mine worktree `remove` (branch ref preserved, content on main — **reversible**; reconstruct via `git worktree add`) |
+| anything where undo is not trivial | anything trivially undoable |
+
+Note the worktree-prune case: a clean (`git status --short` = 0, no modified
+*and* no untracked) + merged + own-identity worktree `remove` is **reversible** —
+`git worktree remove` deletes only the checkout dir, not the branch ref or
+commits, and merged content is on `origin/main`. It does not require a fresh 2nd
+opinion *once classified clean+merged*. The classification check IS the insurance
+for that class.
+
+## Empirical anchor
+
+2026-05-30: Otto pruned worktrees solo; Aaron: *"are you sure its safe to prune?
+I usually get a 2nd opinion you can easily spin up other agents and ask."* Otto
+summoned a native-subagent auditor — it ran without interrupting Otto's primary
+attention, confirmed the prune safe+reversible, AND corrected a peer-vs-mine
+misclassification. Aaron then set the class boundary: *"a non-reversible action
+happens, get a 2nd opinion."* The prune turned out reversible (so not strictly
+required), but the value of the opinion (the correction) shows why summoning even
+on the margin is cheap enough to be worth it.
+
+## Composes with
+
+- `.claude/rules/force-push-with-lease-authorization-policy.md` — the canonical
+  non-reversible action + multi-oracle authorization path this generalizes.
+- `.claude/rules/peer-call-infrastructure.md` — the 9 cross-harness summon
+  wrappers; the `Agent` tool is the native-subagent summon.
+- `.claude/rules/m-acc-multi-oracle-end-user-moral-invariants.md` — multi-oracle
+  by design (standing-governance form; this is the local-transient form).
+- `.claude/rules/agent-worktree-hygiene-never-hold-main-never-step-on-operator-cleanup-on-pr-merge.md`
+  — worktree-prune is the empirical anchor; this rule sets when prune needs a 2nd
+  opinion (uncertain) vs not (verified clean+merged+mine).
+- `docs/research/2026-05-30-aaron-local-consensus-non-interrupting-attention-summon-agent-vs-human-cost-structure.md`
+  — the WHY (non-interrupting summon → local cheap consensus).
+- `.claude/rules/substrate-or-it-didn't-happen.md` — non-reversible actions are
+  exactly the ones where a wrong call can't be quietly undone.
+
+## Why this auto-loads
+
+Per `.claude/rules/wake-time-substrate.md`: the discipline fires at action-time —
+the moment before a non-reversible operation. Cold-boot landing makes "classify
+reversibility → if non-reversible/uncertain, summon a 2nd opinion before acting"
+the default for every agent, using infrastructure that already exists.

--- a/.claude/rules/non-reversible-action-get-a-second-opinion.md
+++ b/.claude/rules/non-reversible-action-get-a-second-opinion.md
@@ -39,10 +39,28 @@ You can only apply the rule if you know whether the action is reversible — so
 classify first. **If reversibility is uncertain, treat as non-reversible** (get
 the opinion) until verified.
 
+**Git-presence IS the reversibility boundary** (Aaron 2026-05-30): the
+discriminator under the table is *is the thing in git — committed AND pushed to a
+durable remote?* Git is the recovery substrate (ref / reflog / remote / revert).
+
+- **In git** → reversible (recover from git).
+- **Dark** (NOT in git — untracked files, an unpushed local branch, a stash,
+  `drop/` & `.playwright-mcp/` artifacts, a worktree's untracked content, anything
+  only on one developer's machine) → **irreversible to delete**: there is no
+  recovery substrate to restore from.
+
+Aaron 2026-05-30: *"deleting anything in the missing-files md file is also
+irreversible cause it's all happening on dark areas not in git yet only on the
+dark developer's machine."* `tools/hygiene/LOST-FILES-LOCATIONS.md` is the
+**catalog of dark areas** (15 location-classes outside git); deleting an entry
+there loses the *map* to recovery, not just one dark file — meta-irreversible.
+This is also *why* the worktree clean-check works (note below): `git status
+--short == 0` confirms there is nothing dark to lose.
+
 | Non-reversible (→ get a 2nd opinion) | Reversible (→ proceed) |
 |---|---|
 | `git push --force` / `--force-with-lease` | local edits; running tests |
-| unrecoverable deletion (no ref/backup left) | branch push (revertable via PR / revert) |
+| delete of DARK content — untracked / unpushed branch / stash / `drop/` artifact (only on one machine, no git copy) | branch push (revertable via PR / revert) |
 | send / publish to an external service | commit to your own branch (amendable pre-merge) |
 | irreversible external API call (charge, provision, email) | clean+merged+mine worktree `remove` (branch ref preserved, content on main — **reversible**; reconstruct via `git worktree add`) |
 | anything where undo is not trivial | anything trivially undoable |

--- a/docs/research/2026-05-30-aaron-local-consensus-non-interrupting-attention-summon-agent-vs-human-cost-structure.md
+++ b/docs/research/2026-05-30-aaron-local-consensus-non-interrupting-attention-summon-agent-vs-human-cost-structure.md
@@ -1,0 +1,117 @@
+# Local consensus via non-interrupting attention-summon — agent consensus has a different cost structure than human consensus
+
+**Date:** 2026-05-30
+**Source:** Aaron, in conversation with Otto (Claude Code), extending the
+2nd-opinion / multi-oracle thread that arose over a worktree-prune.
+**Type:** architecture / framing substrate (Aaron's framing treated as
+already-unfolded per his cognitive profile; preserved per
+substrate-or-it-didn't-happen).
+
+## Verbatim (Aaron 2026-05-30, in order)
+
+> are you sure its safe to prune? I usually get a 2nd opinion you can easily
+> spin up other agents and ask
+
+> all agents have the ability to summon the other agents on demand in their
+> native harness we already built that.
+
+> this way consensus can be a local thing cause agent attention can be summoned
+> without interrupts on it's primary attention layer, humans don't work this way
+
+> a non-reversible action happens, get a 2nd opinion
+
+## The keystone
+
+**Non-interrupting attention-summon changes the *cost structure* of consensus —
+which is why "consensus can be local" is true for agents and false for humans.**
+
+| | Humans | Agents |
+|---|---|---|
+| Attention | serial, singular | forkable (summon ≠ interrupt) |
+| Getting a 2nd opinion | interrupts someone else's primary layer (meeting / async wait / context-switch both ends) | non-interrupting fork: primary layer keeps running; summoned agent runs isolated, returns a verdict |
+| Consensus cost | `O(interrupt-everyone)`, serialized, expensive | `O(local-fork)`, parallel-isolated, cheap |
+| Rational response | **minimize** consensus — decide solo, escalate rarely, batch into meetings | **maximize** consensus — run a local quorum before every uncertain/non-reversible action, routinely |
+| Consensus is | a heavyweight protocol invoked sparingly | a lightweight primitive invoked by default |
+
+The 2nd-opinion-before-non-reversible-action discipline is **only viable because
+the fork is non-interrupting.** If summoning interrupted the primary attention
+layer (human-style), the discipline would be too expensive to apply routinely;
+because it doesn't, it is cheap enough to be the default.
+
+## Two edges
+
+### It changes the *topology* of consensus, not just the cost
+
+Multi-oracle / BFT consensus is usually pictured as distributed long-lived agents
+voting over a bus (B-0703, m-acc — the **standing-governance** form). The keystone
+adds the **local-transient** form: a single agent convenes a quorum *in its own
+decision context*, on demand, then dissolves it. Both are valid:
+
+- **Distributed / standing** — for governance that must persist (moral invariants,
+  cross-fork ratification, Knights-Guild-class decisions).
+- **Local / transient** — for routine per-action checks before acting.
+
+The local form only exists because the summon is non-interrupting. Humans have
+only ever had the distributed-and-expensive form, so human institutions minimize
+consensus; agent societies can afford it per-action.
+
+### Local-consensus-before-acting is the reconciler pattern applied to decisions
+
+Composes straight back into "declarative + self-healing = anti-entropy" (the
+2026-05-30 anti-entropy-converter doc): before `emit` (the action), summon a local
+quorum to reconcile "is this safe/correct?" against the desired invariant, *then*
+emit. It is a **self-healing check on the agent's own decisions** — catch the bad
+action before it lands. The reconciler pattern runs OS → cluster → agent → and now
+→ the agent's *decision loop itself*.
+
+## The rule it justifies
+
+Aaron's class boundary — **"a non-reversible action happens, get a 2nd opinion"** —
+lands as `.claude/rules/non-reversible-action-get-a-second-opinion.md`. It
+generalizes the force-push-with-lease policy (force-push = the canonical
+"closest-to-irreversible" action, already requiring operator-or-peer confirm) to
+*all* non-reversible actions. The summon mechanism is already built (native
+subagents via the `Agent` tool; cross-harness via the 9 `tools/peer-call/`
+wrappers) — the discipline is *using* it, not building it.
+
+## Empirical anchor (this session)
+
+A worktree-prune surfaced the whole thread. Otto pruned 4 clean+merged worktrees
+solo; Aaron asked "are you sure it's safe?"; Otto summoned an independent native
+subagent to audit. The audit ran **without interrupting Otto's primary attention**
+(Otto kept composing the response while it ran ~44s), returned a verdict
+(prune was safe + reversible), AND **corrected** a misclassification (a detached
+worktree Otto had marked "uncertain" was a *peer* commit — leave it). That is the
+keystone in action: a local, cheap, non-interrupting consensus that improved the
+decision. Note the prune itself was *reversible* (branch refs preserved, content
+on main), so under Aaron's class boundary it did not strictly require the opinion —
+but the value of getting it (the correction) shows why agents can afford to summon
+even on the margin.
+
+## Razor note
+
+Operational, not metaphysical: "non-interrupting summon" is a real mechanism (the
+`Agent` tool / peer-call wrappers fork a separate context; the primary loop's
+state is untouched); the cost-structure difference is measurable (human consensus
+serializes attention + incurs interrupt cost; agent consensus forks). "Consensus
+is local" = a single agent can instantiate + collect + dissolve a quorum within
+one decision flow. The human-vs-agent contrast is the load-bearing claim.
+
+## Composes with
+
+- `.claude/rules/non-reversible-action-get-a-second-opinion.md` (the rule this
+  doc is the WHY for) — lands alongside.
+- `.claude/rules/force-push-with-lease-authorization-policy.md` — the canonical
+  non-reversible action + the multi-oracle (operator OR peer-agent) authorization
+  path this generalizes.
+- `.claude/rules/peer-call-infrastructure.md` — the 9 cross-harness summon
+  wrappers; the `Agent` tool is the native-subagent summon.
+- `.claude/rules/m-acc-multi-oracle-end-user-moral-invariants.md` — multi-oracle
+  by design (the standing-governance form; this is the local-transient form).
+- B-0703 (multi-oracle BFT) — distributed/standing consensus; complemented by the
+  local/transient form here.
+- `docs/research/2026-05-30-aaron-install-graph-zflash-anti-entropy-converter-...md`
+  — the reconciler/anti-entropy framing local-consensus-before-acting extends to
+  decisions.
+- `.claude/rules/substrate-or-it-didn't-happen.md` — why this conversation-only
+  framing is preserved here.


### PR DESCRIPTION
## What

Two files, one thread (the consensus-architecture arc from this session):

1. **Rule** `.claude/rules/non-reversible-action-get-a-second-opinion.md` — fleet cold-boot behavioral discipline.
2. **Research doc** `docs/research/2026-05-30-…-local-consensus-non-interrupting-attention-summon-…md` — the WHY.

## Rule (Aaron's class boundary)

**"A non-reversible action happens — get a 2nd opinion."** Before any non-reversible action, summon a 2nd opinion (native subagent / peer-call / operator) and let it return before acting. Generalizes the force-push-with-lease policy (force-push = canonical closest-to-irreversible) to *all* non-reversible actions. Includes verify-reversibility-first (uncertain → treat as non-reversible) + a reversible/non-reversible table (clean+merged+mine worktree-prune = reversible; force-push / unrecoverable-delete / external-send = not).

## Research doc (the WHY)

**Non-interrupting attention-summon changes the cost structure of consensus.** Humans: serial attention; a 2nd opinion interrupts someone's primary layer → `O(interrupt)`, expensive → minimize consensus. Agents: summon is a non-interrupting fork → `O(local-fork)`, cheap → *can* run a local quorum before every non-reversible action. "Consensus can be local" is true for agents, false for humans. Adds local-transient consensus alongside distributed-standing BFT (B-0703); local-consensus-before-acting = the reconciler pattern applied to decisions (composes the anti-entropy-converter framing).

## Empirical anchor

This session's worktree-prune → "are you sure?" → summoned audit (ran non-interrupting, corrected a peer-classification) → Aaron set the class boundary. The summon mechanism is already built (Agent tool + 9 `tools/peer-call/` wrappers); the discipline is *using* it.

Authorized: operator "yes we can land it." Docs/rule-only; reversible via revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
