### PR TITLE
fix(persistence/windows): loop now ticks every minute (TimeTrigger + Repetition Duration)

### DIFF
--- a/tools/persistence/windows/README.md
+++ b/tools/persistence/windows/README.md
@@ -27,8 +27,8 @@ setup, which clones to `~/.local/share/zeta-claude-loop-*/Zeta`.)
 | LaunchAgent in `~/Library/LaunchAgents` | per-user task, no admin |
 | `gui/$uid` domain | `<LogonType>InteractiveToken</LogonType>` |
 | (user agent, never elevated) | **omit `<RunLevel>`** → `Limited` (no UAC) |
-| `StartInterval` 60 | `<LogonTrigger>` + `<Repetition><Interval>PT1M</Interval>` |
-| `RunAtLoad` true | logon trigger fires at sign-in |
+| `StartInterval` 60 | `<TimeTrigger>` (past `<StartBoundary>` + `StartWhenAvailable`) + `<Repetition>` `PT1M`/`P3650D` — wall-clock timer, ticks while logged on |
+| `RunAtLoad` true | `TimeTrigger` past-boundary starts immediately on register; `LogonTrigger` also restarts at sign-in |
 | `KeepAlive` + `ThrottleInterval` | `<RestartOnFailure>` + `<MultipleInstancesPolicy>IgnoreNew` |
 | `StandardOutPath`/`ErrorPath` | wrapper redirects to `%LOCALAPPDATA%\zeta-otto-loop\*.log` |
 | plist UTF-8 | task XML **UTF-16** (`schtasks /Create /XML` requirement) |
@@ -89,9 +89,12 @@ Remove-Item -Recurse -Force "$env:LOCALAPPDATA\zeta-otto-loop"   # optional: clo
   ```
 
   The default `--ref main` needs no flip — this only applies when you tracked a feature branch.
-- **Repetition fallback:** if `schtasks /Create /XML` rejects the `<Repetition>` without a
-  `<Duration>`, add `<Duration>P3650D</Duration>` inside `<Repetition>` in
-  `scheduled-task.xml` and re-register.
+- **Triggers (why both `TimeTrigger` and `LogonTrigger`):** the XML uses a `TimeTrigger`
+  with a past `<StartBoundary>` + `StartWhenAvailable` so the loop starts immediately on
+  register and ticks every minute while logged on (true `StartInterval` parity), plus a
+  `LogonTrigger` so it also restarts at sign-in. Both repetitions carry an explicit
+  `<Duration>P3650D</Duration>` — without it, `schtasks /Create /XML` registers a degenerate
+  `<Repetition>` that never fires (symptom: `Next Run Time: N/A`, runs once at logon then stops).
 - **Cross-machine heartbeat (slice-1b — landed):** after each tick the wrapper pushes a
   ZetaID-keyed heartbeat to the shared `agent-heartbeats` branch (append-only, no PR, via the
   REST git-data API) using `tools/agent-heartbeats/write-heartbeat.ts --push --persona-name

--- a/tools/persistence/windows/scheduled-task.xml
+++ b/tools/persistence/windows/scheduled-task.xml
@@ -33,11 +33,21 @@
     </RestartOnFailure>
   </Settings>
   <Triggers>
+    <TimeTrigger>
+      <StartBoundary>2024-01-01T00:00:00</StartBoundary>
+      <Enabled>true</Enabled>
+      <Repetition>
+        <Interval>PT1M</Interval>
+        <Duration>P3650D</Duration>
+        <StopAtDurationEnd>false</StopAtDurationEnd>
+      </Repetition>
+    </TimeTrigger>
     <LogonTrigger>
       <Enabled>true</Enabled>
       <UserId>{{USER_ID}}</UserId>
       <Repetition>
         <Interval>PT1M</Interval>
+        <Duration>P3650D</Duration>
         <StopAtDurationEnd>false</StopAtDurationEnd>
       </Repetition>
     </LogonTrigger>


### PR DESCRIPTION
The slice-1 `ZetaOttoLoop` task fired once at logon then went silent. Diagnosed live this autonomous tick (Last Run frozen ~36 min, `Next Run Time: N/A`, no hung instance — `IgnoreNew` ruled out). Two compounding defects:

1. **`<Repetition>` had no `<Duration>`** → `schtasks /Create /XML` registered a degenerate repetition that never repeats (the README's documented "Repetition fallback" case). The *live* registered XML showed `<Repetition><Interval>PT1M</Interval></Repetition>` — `schtasks` had stripped `<StopAtDurationEnd>` on import, leaving a no-op. Added `<Duration>P3650D</Duration>`.
2. **A bare `<LogonTrigger>` only starts its repetition at a logon *event*** → while already logged on (normal dev case) the loop never starts. That's not parity with launchd `RunAtLoad`+`StartInterval` (start-now + free-running timer). Added a `<TimeTrigger>` with a past `<StartBoundary>` + `StartWhenAvailable` so it starts immediately on register and ticks every minute while logged on; kept `<LogonTrigger>` for sign-in start.

**Verified live** (re-registered on this Win11 laptop): `Next Run Time` populated (10:05); after 75s with no manual run, `Last Run` advanced to 10:05:01 (`Result 0`) and `Next Run` rolled to 10:06 — genuine per-minute auto-fire.

Tests: 13 pass, tsc + markdownlint clean. README parity map + Notes updated to the as-built trigger model.

Found + fixed autonomously while you were away — flagging the trigger-model adjustment (LogonTrigger-only → TimeTrigger+LogonTrigger) for your review; it's reversible and delivers the approved per-minute intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)