### PR TITLE
docs(B-0250): calibrate queue-drain coincidence window

### DIFF
--- a/docs/trajectories/autonomous-loop-coordination/RESUME.md
+++ b/docs/trajectories/autonomous-loop-coordination/RESUME.md
@@ -249,16 +249,25 @@ It selects one clean local-only worktree,
 later bounded cleanup packet. The selection is based on clean status, absent
 remote branch, absent PR, and a head already reachable from `origin/main`.
 
+Current B-0250 queue-drain window calibration:
+`docs/trajectories/autonomous-loop-coordination/b0250-queue-drain-window-calibration-2026-05-30.md`
+
+It re-runs the live monitor after the merge-burst clustering and author-label
+patches. The monitor still reports 15 coincidence windows, but the top windows
+are prior-day pure Codex/Otto merged-PR adjacency. The #6113/#6115 burst did
+not become a top current incident window, so pure merged-PR adjacency remains a
+warning/debug signal until joined by a stronger source.
+
 ## Recommended Next Action
 
-Inspect the remaining live B-0250 Codex/Otto adjacency windows and decide
-whether the five-minute event window is too wide for queue-drain bursts, or
-whether the coincidence source needs a stronger source set before escalation.
+Keep the five-minute queue-drain window as a warning/debug surface, but require
+a stronger joined source before treating Codex/Otto merged-PR adjacency as an
+incident-grade signal.
 
 ## Next Child Packets
 
-- B-0250 live calibration after merge-burst clustering
-- B-0250 queue-drain window calibration for remaining Codex/Otto adjacency
+- B-0250 stronger-source escalation gate for Codex/Otto adjacency
+- B-0250 claim/PR blocker source join calibration
 
 ## Evidence Links
 

--- a/docs/trajectories/autonomous-loop-coordination/b0250-queue-drain-window-calibration-2026-05-30.md
+++ b/docs/trajectories/autonomous-loop-coordination/b0250-queue-drain-window-calibration-2026-05-30.md
@@ -1,0 +1,52 @@
+# B-0250 Queue-Drain Window Calibration - 2026-05-30
+
+## Status
+
+This packet inspects the remaining live B-0250 Codex/Otto adjacency windows
+after merge-burst clustering and merged-PR author labels landed.
+
+## Live Observation
+
+Command:
+
+```bash
+bun tools/health/factory-health-monitor.ts --json
+```
+
+At `2026-05-30T14:17:30.528Z`, the monitor reported:
+
+```text
+15 event-window coincidence(s) detected
+```
+
+The top debug windows were:
+
+| Window start | Trajectories | Events |
+| --- | --- | --- |
+| `2026-05-29T18:04:13Z` | codex+otto | `otto:merged-pr-6023`, `codex:merged-pr-6025` |
+| `2026-05-29T18:08:42Z` | codex+otto | `codex:merged-pr-6025`, `otto:merged-pr-6026` |
+| `2026-05-29T19:06:34Z` | codex+otto | `codex:merged-pr-6032`, `otto:merged-pr-6031` |
+
+The recent 2026-05-30 Otto merge burst for #6113/#6115 did not become a top
+coincidence window after the author-label and merge-burst clustering patches.
+
+## Calibration Verdict
+
+The remaining top B-0250 warning is a queue-drain adjacency pattern, not
+evidence of a current shared-upstream incident.
+
+The five-minute window is still broad enough to connect adjacent Codex/Otto
+merged PRs during rapid queue drain. Those windows can be useful runway
+pressure evidence, but they should not page as incident-grade correlation
+unless another independent source joins the same window.
+
+## Recommended Next Slice
+
+Keep the five-minute window for now, but raise incident confidence only when a
+Codex/Otto merged-PR adjacency also includes a stronger source such as a claim
+mutation, PR review blocker, failed gate, or explicit broadcast blocker. Pure
+merged-PR adjacency should remain a warning/debug surface.
+
+## Verification
+
+- `bun tools/health/factory-health-monitor.ts --json`


### PR DESCRIPTION
## Summary

- Add a B-0250 queue-drain calibration receipt from the live factory-health monitor.
- Update the autonomous-loop coordination resume so pure Codex/Otto merged-PR adjacency remains warning/debug signal until joined by a stronger source.

## Verification

- `bun run lint:markdown docs/trajectories/autonomous-loop-coordination/b0250-queue-drain-window-calibration-2026-05-30.md docs/trajectories/autonomous-loop-coordination/RESUME.md`
- `bun tools/health/factory-health-monitor.ts --json`
- `git diff --check origin/main...HEAD`

---
Headless-Origin: codex-launchd-loop
Headless-Surface: codex-background-service
Codex-Loop-Run-Id: 20260530T141835Z