### PR TITLE
fix(persistence/windows): windowless loop (conhost --headless) + install.ps1 plan

### DIFF
--- a/docs/plans/2026-05-30-windows-install-ps1-cross-edition-tests-plan.md
+++ b/docs/plans/2026-05-30-windows-install-ps1-cross-edition-tests-plan.md
@@ -1,0 +1,178 @@
+# Windows `install.ps1` + cross-edition test matrix — implementation plan
+
+> **For agentic workers:** implement task-by-task; steps use `- [ ]` checkboxes.
+> Discipline anchors: `.claude/rules/automated-tests-are-the-shield-assert-dont-skip.md`
+> (every test **asserts**, never skips-to-green), `.claude/rules/rule-0-no-sh-files.md`
+> (TS for tooling; `.ps1` is the Windows install-graph analog of the `.sh` install-graph,
+> which is the sanctioned exception), `.claude/rules/dep-pin-search-first-authority.md`
+> (pin base images + tool versions, cite the source).
+
+**Goal:** Give Zeta a user-mode, **declarative** Windows install entry (`install.ps1`) with
+parity to `tools/setup/install.sh` → `macos.sh`, and a cross-Windows-edition test matrix that
+**asserts** it works on **Windows Server** (free GitHub-hosted Docker) and **consumer desktop /
+Win 11** (this laptop, loop-driven now + restricted self-hosted runner later).
+
+**Architecture:** `install.ps1` mirrors `macos.sh`'s graph and stays **declarative + symmetric**
+with the Unix manifests (operator 2026-05-30): a `manifests/windows` package manifest drives a
+**scoop → winget → chocolatey** resolver (scoop primary: user-mode, no admin, AI-native;
+winget/choco fallback). Language/runtime tools stay identical to Unix — mise (`.mise.toml`),
+`manifests/dotnet-tools`, `manifests/uv-tools`, bun-global for claude — so the tool set is kept
+**in sync and symmetric** across OSes. Loop registration reuses the already-shipped
+`install-scheduled-task.ts` (schtasks ≈ launchd).
+
+**Tech stack:** PowerShell 5.1+ (`install.ps1`), scoop/winget/choco (system pkgs), mise
+(cross-platform runtimes), bun + TypeScript (test runners), Windows Server Core container
+(`mcr.microsoft.com/windows/servercore`), GitHub Actions `windows-2022` (hosted, ephemeral).
+
+---
+
+## Symmetry principle (operator 2026-05-30)
+
+> "declarative just like those systems … scoop, then winget, then chocolatey as the primary
+> package source outside of like npm and such; we will use mise and all that just the same;
+> keep the tools in sync and symmetric."
+
+| Layer | Unix (apt/brew) | Windows | Symmetric? |
+|---|---|---|---|
+| System CLI tools | `manifests/apt`, `manifests/brew` | `manifests/windows` (scoop→winget→choco) | same manifest concept, per-OS source |
+| Runtimes (dotnet/python/java/bun/uv) | `.mise.toml` via mise | `.mise.toml` via mise | **identical file** |
+| dotnet global tools | `manifests/dotnet-tools` | `manifests/dotnet-tools` | **identical file** |
+| uv Python tools | `manifests/uv-tools` | `manifests/uv-tools` | **identical file** |
+| claude-code | `bun install --global` | `bun install --global` | **identical** |
+| background loop | launchd LaunchAgent | schtasks (`install-scheduled-task.ts`) | parity, per-OS mechanism |
+
+**Package-source priority (operator 2026-05-30): cross-platform first.** Prefer **mise** (runtimes
++ CLI tools via its aqua / ubi / cargo / npm / pipx / go backends) and **npm / `bun --global`**
+(node-ecosystem CLIs) — these install *identically* on every OS, so they maximize symmetry. Drop to
+an OS-specific source (**scoop → winget → choco** on Windows; brew/apt on Unix) *only* for the
+irreducible remainder no cross-platform source provides. So `manifests/windows` should stay
+**minimal** — most tools belong in `.mise.toml` / a shared npm-global manifest (identical across
+OSes). The symmetry test (Slice 2a Step 6) asserts `manifests/windows` covers the same logical
+OS-specific tools as `manifests/brew`/`apt`, AND flags any tool that should have been promoted to
+the cross-platform (mise/npm) layer.
+
+---
+
+## Coverage matrix (the shield — what asserts what)
+
+| Surface | Editions | Covers | Does NOT cover | Where |
+|---|---|---|---|---|
+| Server-Core Docker | Windows Server | scoop/winget resolve, system tools, mise runtime pins, claude install | user-mode scheduled task (no interactive session in a container) | `windows-2022` hosted runner (free, ephemeral, fork-PR-safe) |
+| Desktop loop-smoke | Win 10/11 client | full graph **incl.** `ZetaOttoLoop` registration + per-minute auto-fire | nothing additional — complete check | this laptop, loop-driven, `origin/main`-only |
+| Restricted self-hosted runner (later) | Win 10/11 client | same as loop-smoke, PR-gated | n/a | this laptop, `workflow_dispatch`/main-push only, **never** fork `pull_request` |
+
+Neither surface pretends to cover the other (shield-honesty): the container's loop-task gap is a
+documented *printed* skip-with-reason, never a silent green.
+
+---
+
+## File structure
+
+- Create: `tools/setup/manifests/windows` — declarative system-tool manifest (scoop-primary, optional `winget=`/`choco=` ID overrides).
+- Create: `tools/setup/install.ps1` — Windows install-graph entry; parses `manifests/windows` + resolves scoop→winget→choco; then mise + dotnet-tools + uv-tools + claude + loop register. Idempotent.
+- Modify: `tools/setup/install.sh` — MINGW/MSYS detection in the `*)` arm → route to `install.ps1` (parity with the NixOS-live routing stub; `exit 2`).
+- Create: `tools/ci/windows-install-ps1-smoke.ts` (+ `.test.ts`) — assertion smoke reused by loop (desktop) + Docker (container).
+- Create: `tools/ci/manifest-symmetry.test.ts` — asserts `manifests/windows` covers the same logical tools as `manifests/brew`/`apt`.
+- Create: `tools/ci/dockerfiles/windows-install-ps1-test/Dockerfile`, `tools/ci/docker-windows-install-ps1-test.ts`, `.github/workflows/docker-windows-install-ps1-test.yml`.
+- Modify: `tools/persistence/windows/otto-loop-wrapper.ps1` — gated desktop-smoke step.
+- Modify: `tools/persistence/windows/README.md` — document `install.ps1` + coverage matrix.
+
+---
+
+## Slice 2a — declarative `install.ps1` + `manifests/windows` (build first)
+
+**Files:** Create `tools/setup/manifests/windows`, `tools/setup/install.ps1`; Modify `tools/setup/install.sh`.
+
+- [ ] **Step 1 — Manifest** `tools/setup/manifests/windows` (declarative, symmetric with `manifests/brew`):
+
+```
+# tools/setup/manifests/windows — declarative Windows system CLI tools.
+# Resolver priority: scoop -> winget -> chocolatey (operator 2026-05-30). scoop is
+# primary (user-mode, no admin). Format per line:  <scoop-id> [winget=<id>] [choco=<id>]
+# winget/choco overrides optional (default to <scoop-id>). `#` comments + blank lines ignored.
+# Runtimes/lang tools are NOT here — they live in .mise.toml / manifests/dotnet-tools /
+# manifests/uv-tools (identical to Unix). Keep this in sync with manifests/brew + manifests/apt.
+git    winget=Git.Git    choco=git
+```
+
+- [ ] **Step 2 — `install.ps1`** parses the manifest + resolves per priority (mirrors `macos.sh`'s brew-manifest loop; strips `#` comments + trims, like the awk in `macos.sh`):
+
+```powershell
+#Requires -Version 5.1
+# tools/setup/install.ps1 — Windows user-mode, DECLARATIVE install-graph entry (parity with
+# tools/setup/install.sh -> macos.sh). System pkgs: scoop -> winget -> choco (operator 2026-05-30).
+# Runtimes via mise/.mise.toml; dotnet/uv tools + claude identical to Unix. Idempotent.
+[CmdletBinding()] param([switch]$SkipLoopRegister)
+Set-StrictMode -Version Latest; $ErrorActionPreference = 'Stop'
+$RepoRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
+function Have($c) { [bool](Get-Command $c -ErrorAction SilentlyContinue) }
+
+# 1. scoop (user-mode; no admin)
+if (-not (Have scoop)) { Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression }
+
+# 2. system tools from manifests/windows (scoop -> winget -> choco)
+foreach ($raw in Get-Content "$RepoRoot\tools\setup\manifests\windows") {
+  $line = ($raw -replace '#.*$','').Trim(); if (-not $line) { continue }
+  $parts = $line -split '\s+'; $scoopId = $parts[0]
+  $winget = ($parts | Where-Object { $_ -like 'winget=*' }) -replace 'winget=',''
+  $choco  = ($parts | Where-Object { $_ -like 'choco=*'  }) -replace 'choco=',''
+  if     (Have scoop)  { scoop install $scoopId }
+  elseif (Have winget) { winget install --id ($winget ? $winget : $scoopId) --silent --accept-package-agreements --accept-source-agreements }
+  elseif (Have choco)  { choco install ($choco ? $choco : $scoopId) -y }
+  else   { throw "no package source (scoop/winget/choco) available for $scoopId" }
+}
+
+# 3. runtimes + lang tools — IDENTICAL to Unix (symmetric)
+& mise install                                              # .mise.toml: dotnet/python/java/bun/uv
+& bun install --global '@anthropic-ai/claude-code'          # claude-code
+# (dotnet-tools / uv-tools manifests applied here too, mirroring common/dotnet-tools.sh etc.)
+
+# 4. register the per-minute loop unless skipped
+if (-not $SkipLoopRegister) { & bun "$RepoRoot\tools\persistence\windows\install-scheduled-task.ts" --register }
+```
+
+- [ ] **Step 3 — Pin/verify** scoop install URL (`get.scoop.sh`) + winget/choco IDs per `dep-pin-search-first-authority.md`; cite in comments. (mise/bun/dotnet pins inherited from `.mise.toml` — no second pin.)
+- [ ] **Step 4 — `install.sh` Windows-routing stub**: `*)` arm detects `MINGW*`/`MSYS*`/`CYGWIN*` from `uname -s` → "run `pwsh tools/setup/install.ps1`" + `exit 2` (parity with NixOS-live guard). Non-Windows-unknown keeps `exit 1`.
+- [ ] **Step 5 — Manual run** on this laptop: `pwsh tools/setup/install.ps1 -SkipLoopRegister` twice → idempotent, exit 0 both times.
+- [ ] **Step 6 — Symmetry test** `tools/ci/manifest-symmetry.test.ts` (TDD): assert every logical tool in `manifests/brew`/`apt` has a counterpart in `manifests/windows` (allowlist OS-specific exceptions). Fails loud on drift — keeps the OSes "in sync and symmetric."
+- [ ] **Step 7 — Commit** `feat(setup): declarative install.ps1 + manifests/windows (scoop->winget->choco)`.
+
+## Slice 2b — desktop loop-smoke (the "smoke now" path)
+
+**Files:** Create `tools/ci/windows-install-ps1-smoke.ts` + `.test.ts`; Modify `otto-loop-wrapper.ps1`.
+
+- [ ] **Step 1 — TDD assertion helpers** (`.test.ts` first): `assertCommandOnPath(name)`, `assertMiseRuntime(name, semverPrefix)`, `assertLoopTaskHealthy(queryXml, verOutput)` (parses `schtasks /Query /XML` + `/V` → asserts `<Duration>` present AND `Next Run Time != N/A`). Run → fails (unimplemented).
+- [ ] **Step 2 — Implement** so tests pass. `--mode desktop` asserts full set incl. loop-task; `--mode container` asserts everything **except** loop-task (printed skip + reason — not silent). Exit non-zero on any failed assert.
+- [ ] **Step 3 — Wire the loop**: in `otto-loop-wrapper.ps1`, gated `if ($env:ZETA_RUN_DESKTOP_SMOKE)` runs `bun ...windows-install-ps1-smoke.ts --mode desktop`, writes `desktop-smoke.json`, folds pass/fail into the heartbeat disposition. Best-effort, never fails the tick, default off.
+- [ ] **Step 4 — Verify live**: enable env, one tick, confirm all-pass JSON + (break a check → asserts fail → restore).
+- [ ] **Step 5 — Commit** `feat(ci): windows install.ps1 desktop loop-smoke (asserts loop-task health)`.
+
+## Slice 2c — Server-Core Docker test (free hosted CI)
+
+**Files:** Dockerfile, `docker-windows-install-ps1-test.ts`, workflow.
+
+- [ ] **Step 1 — Dockerfile** mirroring the NixOS one: `FROM mcr.microsoft.com/windows/servercore:ltsc2022@sha256:<pinned>` (WebSearch + pin by digest); install bun; `COPY tools/setup tools/persistence tools/ci .mise.toml package.json`; `RUN pwsh install.ps1 -SkipLoopRegister`; assertion `RUN`s via `windows-install-ps1-smoke.ts --mode container`. Build fails on any miss.
+- [ ] **Step 2 — Orchestrator** `docker-windows-install-ps1-test.ts` (+ `.test.ts` for arg helpers), mirroring `docker-nixos-install-sh-test.ts`.
+- [ ] **Step 3 — Workflow** `runs-on: windows-2022`, `push`/`pull_request` (hosted = ephemeral = fork-PR-safe). Document the no-interactive-session/no-loop-task gap inline.
+- [ ] **Step 4 — Iterate** to green-by-assertion (break a check → build fails → restore).
+- [ ] **Step 5 — Commit** `feat(ci): Server-Core Docker test for install.ps1 (asserts tool-install graph)`.
+
+## Slice 2d — restricted self-hosted runner (LATER, your go)
+
+- [ ] **Step 1 — Doc** the registration + hard guard: runner labeled `windows-desktop`; desktop-CI workflow triggers **only** `workflow_dispatch` + main-repo `push`; **never** fork `pull_request` (GitHub's public-repo self-hosted footgun). Note: ServiceTitan is pro-OSS — this guard is about the GitHub fork-PR *mechanic*, not company stance; still respects the AV/EDR/NAC boundary.
+- [ ] **Step 2 — Hold** for explicit authorization before registering anything.
+
+---
+
+## Self-review
+
+- **Spec coverage:** declarative + scoop→winget→choco + symmetric (2a, symmetry principle) ✓; approach 1 / both mechanisms (2b now, 2d later) ✓; Server coverage (2c) ✓; install.ps1 exists before its tests (2a first) ✓.
+- **Shield rule:** every test asserts + fails loud; container loop-task gap is a documented printed skip ✓; symmetry test fails on tool drift ✓.
+- **Symmetry:** runtimes/dotnet/uv/claude use the *identical* Unix files; only `manifests/windows` is net-new; symmetry test guards drift ✓.
+- **Public-repo/corporate constraint:** Server on ephemeral hosted runner; desktop on `origin/main`-only loop; self-hosted gated + fork-PR-excluded ✓.
+- **Rule-0:** `.ps1` = sanctioned Windows install-graph analog; all tooling/tests `.ts` ✓.
+
+## Execution handoff
+
+Inline execution, slice by slice, checkpoint-commit after each slice (review 2a before 2b/2c
+build on it). Slice 2d holds for explicit go.

--- a/docs/plans/2026-05-30-windows-install-ps1-cross-edition-tests-plan.md
+++ b/docs/plans/2026-05-30-windows-install-ps1-cross-edition-tests-plan.md
@@ -107,8 +107,16 @@ Set-StrictMode -Version Latest; $ErrorActionPreference = 'Stop'
 $RepoRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
 function Have($c) { [bool](Get-Command $c -ErrorAction SilentlyContinue) }
 
-# 1. scoop (user-mode; no admin)
-if (-not (Have scoop)) { Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression }
+# 1. scoop (user-mode; no admin). Download-then-exec (NOT pipe-to-shell) — mirrors macos.sh's
+# Homebrew B-0063 pattern: fetch to a temp .ps1, verify non-empty, run the local file.
+if (-not (Have scoop)) {
+  $scoopTmp = Join-Path $env:TEMP "scoop-install-$([guid]::NewGuid()).ps1"
+  try {
+    Invoke-RestMethod -Uri https://get.scoop.sh -OutFile $scoopTmp
+    if (-not (Test-Path $scoopTmp) -or (Get-Item $scoopTmp).Length -eq 0) { throw "scoop installer empty; refusing to run" }
+    & $scoopTmp
+  } finally { Remove-Item $scoopTmp -Force -ErrorAction SilentlyContinue }
+}
 
 # 2. system tools from manifests/windows (scoop -> winget -> choco)
 foreach ($raw in Get-Content "$RepoRoot\tools\setup\manifests\windows") {
@@ -116,9 +124,11 @@ foreach ($raw in Get-Content "$RepoRoot\tools\setup\manifests\windows") {
   $parts = $line -split '\s+'; $scoopId = $parts[0]
   $winget = ($parts | Where-Object { $_ -like 'winget=*' }) -replace 'winget=',''
   $choco  = ($parts | Where-Object { $_ -like 'choco=*'  }) -replace 'choco=',''
+  $wid = if ($winget) { $winget } else { $scoopId }   # if/else (5.1-safe; NOT the 7+ ?: ternary)
+  $cid = if ($choco)  { $choco }  else { $scoopId }
   if     (Have scoop)  { scoop install $scoopId }
-  elseif (Have winget) { winget install --id ($winget ? $winget : $scoopId) --silent --accept-package-agreements --accept-source-agreements }
-  elseif (Have choco)  { choco install ($choco ? $choco : $scoopId) -y }
+  elseif (Have winget) { winget install --id $wid --silent --accept-package-agreements --accept-source-agreements }
+  elseif (Have choco)  { choco install $cid -y }
   else   { throw "no package source (scoop/winget/choco) available for $scoopId" }
 }
 

--- a/docs/plans/2026-05-30-windows-install-ps1-cross-edition-tests-plan.md
+++ b/docs/plans/2026-05-30-windows-install-ps1-cross-edition-tests-plan.md
@@ -42,7 +42,7 @@ winget/choco fallback). Language/runtime tools stay identical to Unix — mise (
 | background loop | launchd LaunchAgent | schtasks (`install-scheduled-task.ts`) | parity, per-OS mechanism |
 
 **Package-source priority (operator 2026-05-30): cross-platform first.** Prefer **mise** (runtimes
-+ CLI tools via its aqua / ubi / cargo / npm / pipx / go backends) and **npm / `bun --global`**
+and CLI tools via its aqua / ubi / cargo / npm / pipx / go backends) and **npm / `bun --global`**
 (node-ecosystem CLIs) — these install *identically* on every OS, so they maximize symmetry. Drop to
 an OS-specific source (**scoop → winget → choco** on Windows; brew/apt on Unix) *only* for the
 irreducible remainder no cross-platform source provides. So `manifests/windows` should stay

--- a/tools/persistence/windows/README.md
+++ b/tools/persistence/windows/README.md
@@ -102,6 +102,7 @@ Remove-Item -Recurse -Force "$env:LOCALAPPDATA\zeta-otto-loop"   # optional: clo
   git-state; cross-machine "is-it-alive" visibility doesn't need every minute), stamped to
   `last-heartbeat-push.txt`, and best-effort — a failed push warns to `wrapper.err` and never
   fails the tick.
+- **Windowless launch (`conhost --headless`):** the task action is `conhost.exe --headless pwsh.exe …`, not `pwsh.exe` directly. A Task Scheduler *interactive* task otherwise flashes a console window every fire (and the wrapper's git/bun children pop their own); the headless pseudoconsole is inherited by the whole process tree so nothing shows. Trade-off: `conhost --headless` swallows the child exit code, so the task's **Last Result is always 0** — the wrapper writes the real tick result to `last-tick-result.txt` (and the heartbeat reports health), so schtasks Last Result is *not* the health signal.
 - **Tests:** `bun test ./tools/persistence/windows/install-scheduled-task.test.ts` and
   `bun test ./tools/persistence/loop-subprocess-path.test.ts` (tests live under `tools/`
   because `bun test` does not discover dot-directories).

--- a/tools/persistence/windows/install-scheduled-task.test.ts
+++ b/tools/persistence/windows/install-scheduled-task.test.ts
@@ -12,6 +12,7 @@ test("substitutePlaceholders fills all keys and XML-escapes values", () => {
     WRAPPER_PATH: "C:\\w & x.ps1",
     TASK_NAME: "T",
     PWSH_PATH: "p",
+    CONHOST_PATH: "c",
     REPO_ROOT: "r",
   });
   expect(out).toBe("<U>S-1-5-21</U><W>C:\\w &amp; x.ps1</W>");
@@ -19,7 +20,7 @@ test("substitutePlaceholders fills all keys and XML-escapes values", () => {
 
 test("substitutePlaceholders throws on an unknown leftover placeholder", () => {
   expect(() =>
-    substitutePlaceholders("{{NOT_A_KEY}}", { USER_ID: "", WRAPPER_PATH: "", TASK_NAME: "", PWSH_PATH: "", REPO_ROOT: "" }),
+    substitutePlaceholders("{{NOT_A_KEY}}", { USER_ID: "", WRAPPER_PATH: "", TASK_NAME: "", PWSH_PATH: "", CONHOST_PATH: "", REPO_ROOT: "" }),
   ).toThrow(/NOT_A_KEY/);
 });
 

--- a/tools/persistence/windows/install-scheduled-task.test.ts
+++ b/tools/persistence/windows/install-scheduled-task.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "bun:test";
 import { xmlEscape, substitutePlaceholders, toUtf16WithBom, parseArgs, defaultCloneDir } from "./install-scheduled-task";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 test("xmlEscape escapes the five XML entities", () => {
   expect(xmlEscape(`a & b < c > d " e ' f`)).toBe("a &amp; b &lt; c &gt; d &quot; e &apos; f");
@@ -58,4 +60,19 @@ test("parseArgs throws on an unknown flag", () => {
 
 test("defaultCloneDir lands under a zeta-otto-loop\\Zeta path", () => {
   expect(defaultCloneDir().replace(/\\/g, "/")).toMatch(/zeta-otto-loop\/Zeta$/);
+});
+
+test("scheduled-task.xml: every placeholder substitutes, no leftovers, conhost shape preserved", () => {
+  const xml = readFileSync(join(import.meta.dir, "scheduled-task.xml"), "utf8");
+  const out = substitutePlaceholders(xml, {
+    TASK_NAME: "T",
+    USER_ID: "S-1-5-21",
+    CONHOST_PATH: "conhost.exe",
+    PWSH_PATH: "pwsh.exe",
+    WRAPPER_PATH: "wrap.ps1",
+    REPO_ROOT: "repo",
+  });
+  expect(out).not.toMatch(/\{\{[A-Z_]+\}\}/); // no leftover placeholders
+  expect(out).toContain("--headless");        // windowless launch shape preserved
+  expect(out).toContain("conhost.exe");       // conhost launcher present
 });

--- a/tools/persistence/windows/install-scheduled-task.ts
+++ b/tools/persistence/windows/install-scheduled-task.ts
@@ -34,7 +34,7 @@ export interface Args {
   register: boolean;
 }
 
-export type Placeholders = Record<"TASK_NAME" | "USER_ID" | "PWSH_PATH" | "WRAPPER_PATH" | "REPO_ROOT", string>;
+export type Placeholders = Record<"TASK_NAME" | "USER_ID" | "CONHOST_PATH" | "PWSH_PATH" | "WRAPPER_PATH" | "REPO_ROOT", string>;
 
 /** Escape the five XML predefined entities — substituted values land in element text. */
 export function xmlEscape(s: string): string {
@@ -115,6 +115,14 @@ function detectPwsh(): string {
   throw new Error("Neither pwsh.exe nor powershell.exe found on PATH");
 }
 
+// conhost.exe --headless runs pwsh with a headless pseudoconsole the whole process tree
+// inherits -> NO window for pwsh OR its git/bun children (Task Scheduler interactive tasks
+// otherwise flash a console each fire). Trade-off: conhost swallows the child exit code, so
+// the task's Last Result is always 0 -> the wrapper writes last-tick-result.txt for health.
+function detectConhost(): string {
+  return join(process.env.SystemRoot ?? "C:\\Windows", "System32", "conhost.exe");
+}
+
 export function defaultCloneDir(): string {
   const localAppData = process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local");
   return join(localAppData, "zeta-otto-loop", "Zeta");
@@ -141,6 +149,7 @@ export function renderXml(repoRoot: string, args: Args): string {
   return substitutePlaceholders(template, {
     TASK_NAME: args.taskName,
     USER_ID: detectUserSid(),
+    CONHOST_PATH: detectConhost(),
     PWSH_PATH: detectPwsh(),
     WRAPPER_PATH: join(here, "otto-loop-wrapper.ps1"),
     REPO_ROOT: repoRoot,

--- a/tools/persistence/windows/otto-loop-wrapper.ps1
+++ b/tools/persistence/windows/otto-loop-wrapper.ps1
@@ -71,4 +71,8 @@ if ($pushHb) {
     }
 }
 
+# The conhost --headless launcher (scheduled-task action) swallows this exit code, so the
+# task's Last Result always reads 0. Write the real tick result for health observability.
+"$(Get-Date -Format o) exit=$tickExit" | Out-File -Encoding utf8 (Join-Path $Base 'last-tick-result.txt')
+
 exit $tickExit

--- a/tools/persistence/windows/scheduled-task.xml
+++ b/tools/persistence/windows/scheduled-task.xml
@@ -54,8 +54,8 @@
   </Triggers>
   <Actions Context="Author">
     <Exec>
-      <Command>{{PWSH_PATH}}</Command>
-      <Arguments>-NoProfile -ExecutionPolicy Bypass -File "{{WRAPPER_PATH}}"</Arguments>
+      <Command>{{CONHOST_PATH}}</Command>
+      <Arguments>--headless "{{PWSH_PATH}}" -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "{{WRAPPER_PATH}}"</Arguments>
       <WorkingDirectory>{{REPO_ROOT}}</WorkingDirectory>
     </Exec>
   </Actions>


### PR DESCRIPTION
**Popup fix (you reported a console window every minute once the loop actually started ticking).**

Root cause: the Task Scheduler *interactive* task launched `pwsh.exe` directly, which flashes a console each fire — and the wrapper's `git`/`bun` children pop their own. `-WindowStyle Hidden` only hides *after* creation (still flashed; you confirmed). Fix: action is now `conhost.exe --headless pwsh.exe …` — a headless pseudoconsole the whole process tree inherits, so nothing shows. **Verified live on this Win11 laptop; you confirmed no window.**

- `scheduled-task.xml`: `Command` → conhost; `Arguments` → `--headless "<pwsh>" …`
- `install-scheduled-task.ts`: `detectConhost()` + `CONHOST_PATH` placeholder
- `otto-loop-wrapper.ps1`: writes `last-tick-result.txt` — conhost swallows the child exit code (verified `exit 7` → `0`), so the task's `Last Result` is always 0; this keeps tick health observable (heartbeat also reports it)
- README: windowless-launch note + the caveat
- 13 tests pass, tsc + markdownlint clean; installer re-register verified end-to-end (live task is installer-produced)

Also lands the **install.ps1 cross-edition test plan** (`docs/plans/…`): declarative install.ps1 (mise/npm cross-platform-first, scoop→winget→choco for the irreducible remainder), Server-Core Docker + desktop loop-smoke matrix, per the shield rule (assert, don't skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)