### PR TITLE
research(B-0623 #3): Adinkra [8,4,4] code-based-crypto constructive proof prototype (code → ECC → key)

### DIFF
--- a/tools/research/adinkra-ecc/adinkra-ecc-prototype.test.ts
+++ b/tools/research/adinkra-ecc/adinkra-ecc-prototype.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   EXTENDED_HAMMING_8_4_4_GENERATOR, enumerateCodewords, isDoublyEven, isSelfDual,
-  weight, dotMod2, canonicalCodeMaterial, deriveKeySeed, adinkraEccProof,
+  weight, dotMod2, deriveKeySeed, adinkraEccProof,
 } from "./adinkra-ecc-prototype";
 
 describe("Adinkra [8,4,4] ECC — B-0623 acceptance #3 constructive proof path", () => {
@@ -17,14 +17,14 @@ describe("Adinkra [8,4,4] ECC — B-0623 acceptance #3 constructive proof path",
     expect(isSelfDual(cw)).toBe(true);
     cw.forEach((a) => cw.forEach((b) => expect(dotMod2(a, b)).toBe(0)));
   });
-  test("key-seed is deterministic (same code → same seed)", async () => {
-    const a = await deriveKeySeed(cw);
-    const b = await deriveKeySeed(enumerateCodewords([...EXTENDED_HAMMING_8_4_4_GENERATOR].reverse()));
+  test("key-seed is deterministic (same code → same seed)", () => {
+    const a = deriveKeySeed(cw);
+    const b = deriveKeySeed(enumerateCodewords([...EXTENDED_HAMMING_8_4_4_GENERATOR].reverse()));
     expect(a).toBe(b); // order-independent (canonical material)
     expect(a).toHaveLength(64); // SHA-256 hex
   });
-  test("full proof path holds", async () => {
-    const p = await adinkraEccProof();
+  test("full proof path holds", () => {
+    const p = adinkraEccProof();
     expect(p.doublyEven && p.selfDual).toBe(true);
     expect(p.dimension).toBe(4);
   });

--- a/tools/research/adinkra-ecc/adinkra-ecc-prototype.test.ts
+++ b/tools/research/adinkra-ecc/adinkra-ecc-prototype.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import {
+  EXTENDED_HAMMING_8_4_4_GENERATOR, enumerateCodewords, isDoublyEven, isSelfDual,
+  weight, dotMod2, canonicalCodeMaterial, deriveKeySeed, adinkraEccProof,
+} from "./adinkra-ecc-prototype";
+
+describe("Adinkra [8,4,4] ECC — B-0623 acceptance #3 constructive proof path", () => {
+  const cw = enumerateCodewords(EXTENDED_HAMMING_8_4_4_GENERATOR);
+  test("16 codewords (dim 4)", () => expect(cw.length).toBe(16));
+  test("generator rows are weight 4 (doubly-even generators)", () =>
+    EXTENDED_HAMMING_8_4_4_GENERATOR.forEach((r) => expect(weight(r)).toBe(4)));
+  test("DOUBLY-EVEN: all codeword weights divisible by 4", () => {
+    expect(isDoublyEven(cw)).toBe(true);
+    cw.forEach((c) => expect(weight(c) % 4).toBe(0));
+  });
+  test("SELF-DUAL: self-orthogonal + dim n/2", () => {
+    expect(isSelfDual(cw)).toBe(true);
+    cw.forEach((a) => cw.forEach((b) => expect(dotMod2(a, b)).toBe(0)));
+  });
+  test("key-seed is deterministic (same code → same seed)", async () => {
+    const a = await deriveKeySeed(cw);
+    const b = await deriveKeySeed(enumerateCodewords([...EXTENDED_HAMMING_8_4_4_GENERATOR].reverse()));
+    expect(a).toBe(b); // order-independent (canonical material)
+    expect(a).toHaveLength(64); // SHA-256 hex
+  });
+  test("full proof path holds", async () => {
+    const p = await adinkraEccProof();
+    expect(p.doublyEven && p.selfDual).toBe(true);
+    expect(p.dimension).toBe(4);
+  });
+});

--- a/tools/research/adinkra-ecc/adinkra-ecc-prototype.ts
+++ b/tools/research/adinkra-ecc/adinkra-ecc-prototype.ts
@@ -21,6 +21,8 @@
 // the primer (indistinguishability / forward-secrecy / non-compromise of the ECC)
 // are NOT answered here. This is the proof-of-construction, not a security claim.
 
+import { createHash } from "node:crypto";
+
 /** A length-8 binary codeword as a tuple of 8 bits (0|1). */
 export type Bits8 = readonly [number, number, number, number, number, number, number, number];
 
@@ -40,7 +42,13 @@ export const EXTENDED_HAMMING_8_4_4_GENERATOR: readonly Bits8[] = [
 
 /** XOR two length-8 bit vectors (GF(2) addition). */
 export function xor8(a: Bits8, b: Bits8): Bits8 {
-  return a.map((bit, i) => bit ^ b[i]) as unknown as Bits8;
+  // Construct the 8-tuple explicitly: literal indices on a Bits8 tuple are
+  // exact `number` (not `number | undefined`), so the return type is honest
+  // without an `as unknown as Bits8` cast.
+  return [
+    a[0] ^ b[0], a[1] ^ b[1], a[2] ^ b[2], a[3] ^ b[3],
+    a[4] ^ b[4], a[5] ^ b[5], a[6] ^ b[6], a[7] ^ b[7],
+  ];
 }
 
 /** Hamming weight (number of 1-bits). */
@@ -50,23 +58,39 @@ export function weight(c: Bits8): number {
 
 /** Standard inner product mod 2 (used for self-duality / orthogonality). */
 export function dotMod2(a: Bits8, b: Bits8): number {
-  return a.reduce((acc, bit, i) => acc ^ (bit & b[i]), 0);
+  // Literal indices keep each `&` operand exact `number` (honest under
+  // noUncheckedIndexedAccess); the chained XOR is the GF(2) inner product.
+  return (
+    (a[0] & b[0]) ^ (a[1] & b[1]) ^ (a[2] & b[2]) ^ (a[3] & b[3]) ^
+    (a[4] & b[4]) ^ (a[5] & b[5]) ^ (a[6] & b[6]) ^ (a[7] & b[7])
+  );
 }
 
 /**
- * Enumerate all 2^k codewords of the linear code spanned by `generators`
- * (k = generators.length). Each codeword is the GF(2) sum of a subset of rows.
+ * Enumerate the linear code spanned by `generators` — the SET of distinct
+ * codewords, each the GF(2) sum of a subset of rows. For k linearly-independent
+ * generators (the [8,4,4] case, whose I_4 block guarantees independence) this is
+ * exactly 2^k words. If the rows are NOT independent the code is smaller than
+ * 2^k, so duplicate sums are de-duplicated here rather than over-counted — this
+ * keeps `isSelfDual`'s `|C| = 2^(n/2)` dimension check honest (a dependent
+ * generator set would otherwise inflate `codewords.length` and false-positive).
  */
 export function enumerateCodewords(generators: readonly Bits8[]): Bits8[] {
   const k = generators.length;
   const zero: Bits8 = [0, 0, 0, 0, 0, 0, 0, 0];
+  const seen = new Set<string>();
   const out: Bits8[] = [];
   for (let mask = 0; mask < 1 << k; mask++) {
     let cw: Bits8 = zero;
     for (let i = 0; i < k; i++) {
-      if (mask & (1 << i)) cw = xor8(cw, generators[i]);
+      const row = generators[i];
+      if (row !== undefined && (mask & (1 << i))) cw = xor8(cw, row);
     }
-    out.push(cw);
+    const key = cw.join("");
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(cw);
+    }
   }
   return out;
 }
@@ -104,29 +128,30 @@ export function canonicalCodeMaterial(codewords: readonly Bits8[]): string {
  * The "code → key" proof path: the SAME code always yields the SAME seed; a
  * production KDF would substitute blake3 (Lucent-KSK substrate) + add the
  * security properties the primer flags as open research.
+ *
+ * Uses `node:crypto` `createHash` — the repo-uniform hashing pattern (vs the
+ * WebCrypto `crypto.subtle` async path) — so the call is synchronous and
+ * consistent with the rest of `tools/`.
  */
-export async function deriveKeySeed(codewords: readonly Bits8[]): Promise<string> {
+export function deriveKeySeed(codewords: readonly Bits8[]): string {
   const material = canonicalCodeMaterial(codewords);
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(material));
-  return Array.from(new Uint8Array(digest))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+  return createHash("sha256").update(material, "utf8").digest("hex");
 }
 
 /** The full constructive proof path, as one object (code → properties → key). */
-export async function adinkraEccProof(): Promise<{
+export function adinkraEccProof(): {
   codewords: Bits8[];
   doublyEven: boolean;
   selfDual: boolean;
   dimension: number;
   keySeed: string;
-}> {
+} {
   const codewords = enumerateCodewords(EXTENDED_HAMMING_8_4_4_GENERATOR);
   return {
     codewords,
     doublyEven: isDoublyEven(codewords),
     selfDual: isSelfDual(codewords),
     dimension: EXTENDED_HAMMING_8_4_4_GENERATOR.length,
-    keySeed: await deriveKeySeed(codewords),
+    keySeed: deriveKeySeed(codewords),
   };
 }

--- a/tools/research/adinkra-ecc/adinkra-ecc-prototype.ts
+++ b/tools/research/adinkra-ecc/adinkra-ecc-prototype.ts
@@ -1,0 +1,132 @@
+// tools/research/adinkra-ecc/adinkra-ecc-prototype.ts
+//
+// B-0623 acceptance #3 — "one constructive proof path: small Adinkra → ECC code →
+// cryptographic primitive." Toy scale, test-guarded.
+//
+// The primer (docs/research/2026-05-21-adinkra-primer-for-non-physicists-zeta-substrate-context.md)
+// established: an Adinkra's chromotopology IS a hypercube H_n quotiented by a
+// doubly-even self-dual binary code C. The smallest interesting case is the
+// [8,4,4] extended Hamming code (the unique doubly-even self-dual code of length 8).
+//
+// This module CONSTRUCTS that code, VERIFIES the two load-bearing properties
+// (doubly-even + self-dual — the structural requirements that make it an Adinkra
+// code AND give it ECC error-resistance), and derives a deterministic key-seed
+// from it (the "code → key" path). The point is the constructive proof that ONE
+// structure yields both the ECC (protect-from-errors) and key material
+// (protect-from-being-seen) — B-0623's dual-use claim, at toy scale.
+//
+// SUBSTRATE-HONESTY (per the primer's razor note): deriving key MATERIAL from the
+// code is a deterministic construction; turning it into a production key needs a
+// real KDF (blake3 per the Lucent-KSK substrate) + the open security questions in
+// the primer (indistinguishability / forward-secrecy / non-compromise of the ECC)
+// are NOT answered here. This is the proof-of-construction, not a security claim.
+
+/** A length-8 binary codeword as a tuple of 8 bits (0|1). */
+export type Bits8 = readonly [number, number, number, number, number, number, number, number];
+
+/**
+ * Generator matrix G = [I_4 | A] for the [8,4,4] extended Hamming code, where
+ * A = J + I (mod 2) = the 4×4 all-ones-off-diagonal matrix. Each generator row
+ * has weight 4 (1 from I + 3 from A) ⇒ doubly-even generators. A·Aᵀ = I (mod 2)
+ * ⇒ G·Gᵀ = I + A·Aᵀ = 0 (mod 2) ⇒ self-orthogonal; with dim = n/2 = 4 ⇒ self-dual.
+ * (Derivation verified in the module doc / the test below.)
+ */
+export const EXTENDED_HAMMING_8_4_4_GENERATOR: readonly Bits8[] = [
+  [1, 0, 0, 0, 0, 1, 1, 1],
+  [0, 1, 0, 0, 1, 0, 1, 1],
+  [0, 0, 1, 0, 1, 1, 0, 1],
+  [0, 0, 0, 1, 1, 1, 1, 0],
+];
+
+/** XOR two length-8 bit vectors (GF(2) addition). */
+export function xor8(a: Bits8, b: Bits8): Bits8 {
+  return a.map((bit, i) => bit ^ b[i]) as unknown as Bits8;
+}
+
+/** Hamming weight (number of 1-bits). */
+export function weight(c: Bits8): number {
+  return c.reduce((acc, bit) => acc + bit, 0);
+}
+
+/** Standard inner product mod 2 (used for self-duality / orthogonality). */
+export function dotMod2(a: Bits8, b: Bits8): number {
+  return a.reduce((acc, bit, i) => acc ^ (bit & b[i]), 0);
+}
+
+/**
+ * Enumerate all 2^k codewords of the linear code spanned by `generators`
+ * (k = generators.length). Each codeword is the GF(2) sum of a subset of rows.
+ */
+export function enumerateCodewords(generators: readonly Bits8[]): Bits8[] {
+  const k = generators.length;
+  const zero: Bits8 = [0, 0, 0, 0, 0, 0, 0, 0];
+  const out: Bits8[] = [];
+  for (let mask = 0; mask < 1 << k; mask++) {
+    let cw: Bits8 = zero;
+    for (let i = 0; i < k; i++) {
+      if (mask & (1 << i)) cw = xor8(cw, generators[i]);
+    }
+    out.push(cw);
+  }
+  return out;
+}
+
+/** Doubly-even: EVERY codeword has Hamming weight divisible by 4. */
+export function isDoublyEven(codewords: readonly Bits8[]): boolean {
+  return codewords.every((c) => weight(c) % 4 === 0);
+}
+
+/**
+ * Self-dual: C = C⊥. For a length-n code we check (a) self-orthogonal — every
+ * pair of codewords is orthogonal under the mod-2 inner product — and (b) the
+ * dimension is n/2 (|C| = 2^(n/2)). Self-orthogonal + dim n/2 ⟹ C = C⊥.
+ */
+export function isSelfDual(codewords: readonly Bits8[], n = 8): boolean {
+  const selfOrthogonal = codewords.every((a) => codewords.every((b) => dotMod2(a, b) === 0));
+  const correctDimension = codewords.length === 2 ** (n / 2);
+  return selfOrthogonal && correctDimension;
+}
+
+/**
+ * Canonical, order-independent serialization of the code (the set of codewords,
+ * sorted) — deterministic key MATERIAL. Same code ⇒ same string, regardless of
+ * generator-row order or enumeration order.
+ */
+export function canonicalCodeMaterial(codewords: readonly Bits8[]): string {
+  return codewords
+    .map((c) => c.join(""))
+    .sort()
+    .join("|");
+}
+
+/**
+ * Derive a deterministic key-seed (hex) from the code material via SHA-256.
+ * The "code → key" proof path: the SAME code always yields the SAME seed; a
+ * production KDF would substitute blake3 (Lucent-KSK substrate) + add the
+ * security properties the primer flags as open research.
+ */
+export async function deriveKeySeed(codewords: readonly Bits8[]): Promise<string> {
+  const material = canonicalCodeMaterial(codewords);
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(material));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** The full constructive proof path, as one object (code → properties → key). */
+export async function adinkraEccProof(): Promise<{
+  codewords: Bits8[];
+  doublyEven: boolean;
+  selfDual: boolean;
+  dimension: number;
+  keySeed: string;
+}> {
+  const codewords = enumerateCodewords(EXTENDED_HAMMING_8_4_4_GENERATOR);
+  return {
+    codewords,
+    doublyEven: isDoublyEven(codewords),
+    selfDual: isSelfDual(codewords),
+    dimension: EXTENDED_HAMMING_8_4_4_GENERATOR.length,
+    keySeed: await deriveKeySeed(codewords),
+  };
+}


### PR DESCRIPTION
## What

B-0623 acceptance #3 — the **constructive proof prototype** for code-based (Adinkra) crypto. Toy scale, test-guarded (6 tests / 283 assertions, passing locally).

`tools/research/adinkra-ecc/adinkra-ecc-prototype.ts` constructs the **[8,4,4] extended Hamming code** (the unique doubly-even self-dual code of length 8 — the smallest interesting Adinkra code per the existing 2026-05-21 primer), verifies:
- **doubly-even** — all 16 codeword weights ≡ 0 mod 4
- **self-dual** — self-orthogonal under mod-2 inner product + dimension n/2

and derives a **deterministic key-seed** (SHA-256 of canonical code material). The dual-use claim made concrete: *one structure yields both the ECC (protect-from-errors) and key material (protect-from-being-seen)*.

## Grounding (this session)

verify-existing-substrate confirmed the primer (acceptance #1+#2) already exists — so this adds only the open slice (#3, the code), no duplicate. The broader crypto substrate this composes with:
- **B-0906** — encryption thermal-cost / two-axis: Adinkra = the thermal/physical axis
- **B-0883.2** — multi-cipher PQ, hedge against NIST monoculture: Adinkra is **code-based** PQC, a *different family* from NIST lattices ⇒ a hedge family (Aaron: "don't lock to nist lattices, they are sus")
- **B-0883** — minimal/lattice gitcrypt (Noble / X-Wing / ML-DSA-65)

## Substrate-honest

Proof-OF-CONSTRUCTION, not a security claim. Production KDF needs blake3 (Lucent-KSK); the open security questions (indistinguishability / forward-secrecy / non-compromise of the ECC) remain B-0623 #3 research scope. Research code; reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
