### PR TITLE
feat(setup): Slice 2a — declarative install.ps1 + manifests/windows + symmetry test

### DIFF
--- a/tools/ci/manifest-symmetry.test.ts
+++ b/tools/ci/manifest-symmetry.test.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Keep the Windows install graph in sync + symmetric with Unix (operator 2026-05-30): every
+// system tool in manifests/apt + manifests/brew must EITHER appear in manifests/windows OR be an
+// allowlisted exception with a documented reason (Windows built-in / prebuilt / scoop-bundled).
+// A new apt/brew tool with no Windows disposition fails this test — so the OSes can't drift apart
+// silently. (Per .claude/rules/automated-tests-are-the-shield-assert-dont-skip.md: this asserts.)
+
+const setupDir = join(import.meta.dir, "..", "setup");
+
+function parseManifest(name: string): string[] {
+  let raw: string;
+  try {
+    raw = readFileSync(join(setupDir, "manifests", name), "utf8");
+  } catch {
+    return [];
+  }
+  return raw
+    .split(/\r?\n/)
+    .map((l) => l.replace(/#.*$/, "").trim())
+    .filter((l) => l.length > 0)
+    .map((l) => l.split(/\s+/)[0]!); // first token = the package id
+}
+
+// Windows disposition for Unix system tools NOT carried in manifests/windows.
+// Each entry needs a reason (why it doesn't need a scoop/winget/choco line).
+const WINDOWS_EXCEPTIONS: Record<string, string> = {
+  "build-essential": "Linux compilers; Zeta's toolchain is prebuilt on Windows (mise/bun/dotnet)",
+  curl: "built into Windows 10+ (curl.exe ships in-box)",
+  "ca-certificates": "Windows manages the trust store via the OS cert store",
+  "p7zip-full": "scoop bundles 7zip for archive extraction; tar/curl are Windows built-ins",
+  p7zip: "scoop bundles 7zip (brew's 7zip formula; sibling of apt's p7zip-full)",
+  "hermes-agent":
+    "NousResearch agent; upstream install is a Linux/macOS curl script (WebSearch 2026-05-30); Windows + cross-platform (uv/npm?) install TBD — deferred from manifests/windows pending an install-graph decision",
+};
+
+test("manifests/windows covers every apt/brew system tool (or an allowlisted exception)", () => {
+  const unixTools = new Set([...parseManifest("apt"), ...parseManifest("brew")]);
+  const windowsTools = new Set(parseManifest("windows"));
+  const undealt = [...unixTools].filter((t) => !windowsTools.has(t) && !(t in WINDOWS_EXCEPTIONS));
+  // Each Unix system tool must be in manifests/windows OR WINDOWS_EXCEPTIONS — no silent drift.
+  expect(undealt).toEqual([]);
+});
+
+test("git is present in manifests/windows (loop clone + repo-ops prerequisite)", () => {
+  expect(parseManifest("windows")).toContain("git");
+});
+
+test("no stale WINDOWS_EXCEPTIONS (each must still be a real apt/brew tool)", () => {
+  const unixTools = new Set([...parseManifest("apt"), ...parseManifest("brew")]);
+  const stale = Object.keys(WINDOWS_EXCEPTIONS).filter((t) => !unixTools.has(t));
+  expect(stale).toEqual([]);
+});

--- a/tools/setup/install.ps1
+++ b/tools/setup/install.ps1
@@ -1,0 +1,91 @@
+#Requires -Version 5.1
+# tools/setup/install.ps1 — Windows user-mode, DECLARATIVE install-graph entry.
+#
+# Parity with tools/setup/install.sh -> macos.sh (B-0857 Windows parity). System CLI tools
+# resolve scoop -> winget -> chocolatey (operator 2026-05-30; scoop primary = user-mode, no
+# admin, AI-native). Runtimes via mise/.mise.toml; claude via bun --global — the IDENTICAL files
+# Unix uses, so the tool set stays in sync + symmetric across OSes. Background loop registered via
+# tools/persistence/windows/install-scheduled-task.ts (schtasks ~= launchd). No admin required.
+#
+# Idempotent (detect-first-install-else-update) — safe to run repeatedly to keep tools fresh.
+#
+#   pwsh tools/setup/install.ps1                    # full install + register the per-minute loop
+#   pwsh tools/setup/install.ps1 -SkipLoopRegister  # skip the scheduled-task registration (dev)
+#
+# Package-source pins per dep-pin-search-first-authority (WebSearch 2026-05-30):
+#   scoop — https://get.scoop.sh (canonical; download-then-exec, NOT pipe-to-shell). Refs:
+#           https://scoop.sh/  https://github.com/ScoopInstaller/scoop
+#   git   — scoop: git | winget: Git.Git | choco: git
+[CmdletBinding()] param([switch]$SkipLoopRegister)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$RepoRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
+function Have($c) { [bool](Get-Command $c -ErrorAction SilentlyContinue) }
+
+Write-Host "=== Zeta install — Windows user-mode entry (scoop-primary, declarative) ==="
+Write-Host "Repo root: $RepoRoot"
+
+# Allow running local scripts for THIS user (no admin) — scoop + mise need it.
+$cur = Get-ExecutionPolicy -Scope CurrentUser
+if ($cur -notin @('RemoteSigned', 'Unrestricted', 'Bypass')) {
+  Write-Host "setting CurrentUser ExecutionPolicy -> RemoteSigned (no admin)"
+  Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+}
+
+# 1. scoop (user-mode; no admin). Download-then-exec (NOT pipe-to-shell) — mirrors macos.sh's
+#    Homebrew B-0063 pattern: fetch to a temp .ps1, verify non-empty, run the local file.
+if (-not (Have scoop)) {
+  Write-Host "downloading scoop (user-mode)..."
+  $scoopTmp = Join-Path $env:TEMP "scoop-install-$([guid]::NewGuid()).ps1"
+  try {
+    Invoke-RestMethod -Uri https://get.scoop.sh -OutFile $scoopTmp
+    if (-not (Test-Path $scoopTmp) -or (Get-Item $scoopTmp).Length -eq 0) { throw "scoop installer empty; refusing to run" }
+    & $scoopTmp
+  } finally { Remove-Item $scoopTmp -Force -ErrorAction SilentlyContinue }
+}
+# scoop shims on PATH for the rest of this process (scoop adds them to the user PATH for new
+# shells, but this process needs them now — mirrors macos.sh's brew/mise shim PATH export).
+$scoopShims = Join-Path $env:USERPROFILE 'scoop\shims'
+if ((Test-Path $scoopShims) -and ($env:PATH -notlike "*$scoopShims*")) { $env:PATH = "$scoopShims;$env:PATH" }
+Write-Host "scoop: $((scoop --version 2>$null | Select-Object -First 1))"
+
+# 2. system CLI tools from manifests/windows (scoop -> winget -> choco). Strips `#` comments +
+#    trims (parity with the awk in macos.sh's brew-manifest loop).
+$manifest = Join-Path $RepoRoot 'tools\setup\manifests\windows'
+foreach ($raw in Get-Content $manifest) {
+  $line = ($raw -replace '#.*$', '').Trim(); if (-not $line) { continue }
+  $parts = $line -split '\s+'
+  $scoopId = $parts[0]
+  $winget = ($parts | Where-Object { $_ -like 'winget=*' }) -replace 'winget=', ''
+  $choco = ($parts | Where-Object { $_ -like 'choco=*' }) -replace 'choco=', ''
+  $wid = if ($winget) { $winget } else { $scoopId }   # if/else (5.1-safe; NOT the 7+ ?: ternary)
+  $cid = if ($choco) { $choco } else { $scoopId }
+  Write-Host "down $scoopId (scoop -> winget -> choco)"
+  if ($(Have scoop)) { scoop install $scoopId }
+  elseif ($(Have winget)) { winget install --id $wid --silent --accept-package-agreements --accept-source-agreements }
+  elseif ($(Have choco)) { choco install $cid -y }
+  else { throw "no package source (scoop/winget/choco) available for $scoopId" }
+}
+
+# 3. mise (runtime manager) via scoop — mirrors macos.sh step 4 (brew install mise).
+if (-not (Have mise)) { scoop install mise }
+Write-Host "mise: $((mise --version 2>$null))"
+
+# 4. runtimes from .mise.toml (dotnet/python/java/bun/uv) — IDENTICAL file to Unix (symmetric).
+Push-Location $RepoRoot
+try {
+  mise trust 2>$null | Out-Null
+  mise install
+} finally { Pop-Location }
+
+# 5. claude-code via bun --global (bun provided by mise) — identical to Unix.
+mise exec -- bun install --global '@anthropic-ai/claude-code'
+
+# 6. register the per-minute (windowless, conhost --headless) loop unless skipped.
+if (-not $SkipLoopRegister) {
+  mise exec -- bun "$RepoRoot\tools\persistence\windows\install-scheduled-task.ts" --register
+}
+
+Write-Host ""
+Write-Host "=== Install complete ==="
+Write-Host "Open a new shell to pick up scoop + mise shims on PATH."

--- a/tools/setup/install.sh
+++ b/tools/setup/install.sh
@@ -155,8 +155,24 @@ EOF
         ;;
     esac
     ;;
+  MINGW*|MSYS*|CYGWIN*)
+    # Windows under Git Bash / MSYS. install.sh is the Unix-like entry; on Windows the install
+    # graph is PowerShell (user-mode, scoop-primary, no admin). Route to install.ps1. exit 2 =
+    # intentional routing guard (NOT a failure), matching the NixOS-live branch above.
+    cat >&2 <<WINEOF
+OS: Windows ($os)
+
+This is a Windows shell. install.sh is the Unix-like entry; on Windows run the
+PowerShell install graph instead (user-mode, scoop-primary, no admin):
+
+  pwsh "$REPO_ROOT/tools/setup/install.ps1"
+
+Exit 2 is the intentional routing guard (see exit-code documentation in the header).
+WINEOF
+    exit 2
+    ;;
   *)
-    echo "error: unsupported OS '$os' (macOS + Linux only this round; Windows backlogged)"
+    echo "error: unsupported OS '$os' (macOS + Linux + Windows supported; others unsupported)"
     exit 1
     ;;
 esac

--- a/tools/setup/manifests/windows
+++ b/tools/setup/manifests/windows
@@ -1,0 +1,16 @@
+# tools/setup/manifests/windows — declarative Windows system CLI tools.
+# Resolver priority (operator 2026-05-30): scoop -> winget -> chocolatey. scoop is primary
+# (user-mode, no admin, AI-native). Format per line:  <scoop-id> [winget=<id>] [choco=<id>]
+# winget/choco overrides are optional (default to <scoop-id>). `#` comments + blank lines ignored.
+#
+# KEEP MINIMAL + symmetric with manifests/apt + manifests/brew. Cross-platform tools belong in
+# .mise.toml (mise) or install via bun/dotnet/uv — NOT here. Only tools that no cross-platform
+# source provides on Windows AND that aren't Windows built-ins go here. The manifest-symmetry
+# test (tools/ci/manifest-symmetry.test.ts) enforces this: every apt/brew system tool must be
+# here OR an allowlisted exception (curl/ca-certificates = Windows built-ins; build-essential =
+# prebuilt toolchain; p7zip-full = scoop-bundled 7zip).
+#
+# Pins per dep-pin-search-first-authority (WebSearch 2026-05-30 — https://scoop.sh/ +
+# https://github.com/ScoopInstaller/scoop + https://learn.microsoft.com/windows/package-manager/):
+#   git — scoop: git | winget: Git.Git | choco: git
+git    winget=Git.Git    choco=git


### PR DESCRIPTION
**Slice 2a** of the Windows install-graph parity (B-0857), per the merged plan. Declarative, user-mode, scoop-primary `install.ps1` mirroring `macos.sh`.

**Files**
- `tools/setup/manifests/windows` — declarative system-tool manifest (`scoop → winget → choco` resolver; minimal — just `git`, since mise/npm cover the cross-platform tools). Pins per dep-pin WebSearch 2026-05-30.
- `tools/setup/install.ps1` — ExecutionPolicy CurrentUser RemoteSigned (no admin); scoop **download-then-exec** (NOT pipe-to-shell — mirrors `macos.sh` Homebrew B-0063); manifest resolver (5.1-safe `if/else`, no PS7 ternary); `scoop install mise`; `mise install` (`.mise.toml` runtimes, identical to Unix); claude via `mise exec -- bun --global`; loop register (conhost --headless) unless `-SkipLoopRegister`.
- `tools/setup/install.sh` — `MINGW*/MSYS*/CYGWIN*` routing arm → points to `install.ps1` (`exit 2` routing guard, parity with the NixOS-live branch).
- `tools/ci/manifest-symmetry.test.ts` — asserts every apt/brew system tool has a Windows disposition (manifest or allowlisted exception w/ reason) + `git` present + no stale exceptions. **It caught real drift** (`p7zip` + `hermes-agent`) on first run.

**`hermes-agent` finding:** it's a real NousResearch agent (WebSearch 2026-05-30, post my Jan-2026 cutoff) but upstream install is a Linux/macOS curl script with no verified Windows method → **deferred exception** (not a fabricated scoop package). Its cross-platform/Windows install treatment is an open install-graph question (it's brew-only, not in apt, and curl-script upstream rather than a real homebrew formula) — flagging for an owner decision.

**Validation:** install.ps1 syntax-parse OK, symmetry test 3/3, tsc clean. **Runtime** validation is Slice 2c (Server-Core Docker, clean-box) + 2b (desktop loop-smoke) — deliberately NOT run on the corporate laptop unprompted (a full run `mise install`s ~GBs of runtimes; mise is currently missing here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)