### PR TITLE
feat(ci): Slice 2b — install.ps1 desktop loop-smoke (asserts; shared with Docker)

### DIFF
--- a/tools/ci/windows-install-ps1-smoke.test.ts
+++ b/tools/ci/windows-install-ps1-smoke.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "bun:test";
+import {
+  taskHasDurationAndNextRun,
+  miseProvidesTool,
+  SHARED_COMMANDS,
+  CONTAINER_SKIPS,
+} from "./windows-install-ps1-smoke";
+
+test("taskHasDurationAndNextRun: healthy task (Repetition Duration + populated Next Run)", () => {
+  const xml = "<Repetition><Interval>PT1M</Interval><Duration>P3650D</Duration></Repetition>";
+  const v = "Next Run Time:                        5/30/2026 11:00:00 AM";
+  expect(taskHasDurationAndNextRun(xml, v)).toEqual({ durationPresent: true, nextRunPopulated: true });
+});
+
+test("taskHasDurationAndNextRun: degenerate repetition (no Duration) + N/A next run", () => {
+  // This is exactly the broken state the conhost/repetition fixes addressed.
+  const xml = "<Repetition><Interval>PT1M</Interval></Repetition>";
+  const v = "Next Run Time:                        N/A";
+  expect(taskHasDurationAndNextRun(xml, v)).toEqual({ durationPresent: false, nextRunPopulated: false });
+});
+
+test("miseProvidesTool: token match, no substring false-positives", () => {
+  const out = "bun       1.3.0   ~/.mise.toml\ndotnet    10.0.0  ~/.mise.toml";
+  expect(miseProvidesTool(out, "bun")).toBe(true);
+  expect(miseProvidesTool(out, "dotnet")).toBe(true);
+  expect(miseProvidesTool(out, "python")).toBe(false);
+  expect(miseProvidesTool(out, "do")).toBe(false); // not a substring of "dotnet"
+});
+
+test("container mode documents its skip (loop-task) — never silent", () => {
+  expect(Object.keys(CONTAINER_SKIPS)).toContain("loop-task");
+  expect(CONTAINER_SKIPS["loop-task"]).toMatch(/interactive session/);
+});
+
+test("shared commands are scoop, git, mise", () => {
+  expect([...SHARED_COMMANDS]).toEqual(["scoop", "git", "mise"]);
+});

--- a/tools/ci/windows-install-ps1-smoke.ts
+++ b/tools/ci/windows-install-ps1-smoke.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env bun
+// tools/ci/windows-install-ps1-smoke.ts
+//
+// Asserts the outcomes of tools/setup/install.ps1 on a Windows machine. Shared by two surfaces:
+//   --mode desktop   : full graph INCL. the ZetaOttoLoop scheduled task (the loop runs this on a
+//                      real Win 10/11 desktop via otto-loop-wrapper.ps1)
+//   --mode container : tool-install graph ONLY. A Windows container has no interactive session,
+//                      so the user-mode scheduled task can't run there — that check is a PRINTED
+//                      skip-with-reason, NEVER a silent green
+//                      (per .claude/rules/automated-tests-are-the-shield-assert-dont-skip.md).
+//
+//   bun tools/ci/windows-install-ps1-smoke.ts --mode desktop
+//   bun tools/ci/windows-install-ps1-smoke.ts --mode container
+//
+// Exit 0 = all checks passed; 1 = one or more FAILED; 2 = bad usage.
+import { execFileSync } from "node:child_process";
+
+export type Mode = "desktop" | "container";
+
+/** Pure: does `schtasks /Query /XML` show a <Repetition><Duration> AND a populated Next Run? */
+export function taskHasDurationAndNextRun(
+  taskXml: string,
+  verboseList: string,
+): { durationPresent: boolean; nextRunPopulated: boolean } {
+  const durationPresent = /<Duration>\s*P/.test(taskXml);
+  const m = verboseList.match(/Next Run Time:\s*(.+)/);
+  const nextRun = (m?.[1] ?? "").trim();
+  const nextRunPopulated = nextRun.length > 0 && !/^N\/A$/i.test(nextRun);
+  return { durationPresent, nextRunPopulated };
+}
+
+/** Pure: does `mise ls`-style output list the given tool (token match, not substring)? */
+export function miseProvidesTool(miseListOutput: string, tool: string): boolean {
+  return miseListOutput
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .some((l) => new RegExp(`(^|\\s)${tool}(\\s|@|$)`).test(l));
+}
+
+/** Pure: system-command checks that run in BOTH modes. */
+export const SHARED_COMMANDS = ["scoop", "git", "mise"] as const;
+
+/** Pure: checks skipped in container mode — each with the reason printed (not silently dropped). */
+export const CONTAINER_SKIPS: Record<string, string> = {
+  "loop-task":
+    "a Windows container has no interactive session; the user-mode scheduled task can't run there (the desktop-smoke covers it)",
+};
+
+function have(cmd: string): boolean {
+  try {
+    execFileSync("where.exe", [cmd], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const idx = argv.indexOf("--mode");
+  const mode = (idx >= 0 ? argv[idx + 1] : undefined) as Mode | undefined;
+  if (mode !== "desktop" && mode !== "container") {
+    console.error("usage: windows-install-ps1-smoke.ts --mode desktop|container");
+    process.exit(2);
+  }
+
+  const failures: string[] = [];
+  const pass = (m: string): void => console.log(`  PASS  ${m}`);
+  const fail = (m: string): void => {
+    failures.push(m);
+    console.error(`  FAIL  ${m}`);
+  };
+
+  for (const cmd of SHARED_COMMANDS) {
+    if (have(cmd)) pass(`${cmd} on PATH`);
+    else fail(`${cmd} not on PATH`);
+  }
+
+  try {
+    const ls = execFileSync("mise", ["ls", "--installed"], { encoding: "utf8" });
+    if (miseProvidesTool(ls, "bun")) pass("mise provides bun (.mise.toml)");
+    else fail("mise does not list bun");
+  } catch {
+    fail("could not run `mise ls --installed`");
+  }
+
+  try {
+    const g = execFileSync("mise", ["exec", "--", "bun", "pm", "ls", "-g"], { encoding: "utf8" });
+    if (g.includes("claude-code")) pass("claude-code installed (bun --global)");
+    else fail("claude-code not in bun global packages");
+  } catch {
+    fail("could not check bun global packages");
+  }
+
+  if (mode === "desktop") {
+    try {
+      const xml = execFileSync("schtasks", ["/Query", "/TN", "ZetaOttoLoop", "/XML"], { encoding: "utf8" });
+      const v = execFileSync("schtasks", ["/Query", "/TN", "ZetaOttoLoop", "/V", "/FO", "LIST"], { encoding: "utf8" });
+      const h = taskHasDurationAndNextRun(xml, v);
+      if (h.durationPresent && h.nextRunPopulated) pass("ZetaOttoLoop healthy (Repetition Duration + Next Run populated)");
+      else fail(`ZetaOttoLoop unhealthy (durationPresent=${h.durationPresent}, nextRunPopulated=${h.nextRunPopulated})`);
+    } catch {
+      fail("could not query the ZetaOttoLoop task");
+    }
+  } else {
+    for (const [k, reason] of Object.entries(CONTAINER_SKIPS)) console.log(`  SKIP  ${k} — ${reason}`);
+  }
+
+  if (failures.length > 0) {
+    console.error(`\nwindows-install-ps1-smoke (${mode}): ${failures.length} FAILED`);
+    process.exit(1);
+  }
+  console.log(`\nwindows-install-ps1-smoke (${mode}): all checks passed`);
+}
+
+if (import.meta.main) main();

--- a/tools/persistence/windows/otto-loop-wrapper.ps1
+++ b/tools/persistence/windows/otto-loop-wrapper.ps1
@@ -71,6 +71,16 @@ if ($pushHb) {
     }
 }
 
+# slice-2b — optional desktop install.ps1 smoke (gated, best-effort, never fails the tick).
+# Asserts install.ps1's outcomes on this real Win desktop (scoop/git/mise/bun/claude +
+# ZetaOttoLoop health). Default OFF — opt in by setting ZETA_RUN_DESKTOP_SMOKE on the task.
+if ($env:ZETA_RUN_DESKTOP_SMOKE) {
+    $smoke = Join-Path $Clone 'tools\ci\windows-install-ps1-smoke.ts'
+    if (Test-Path $smoke) {
+        & $bun $smoke --mode desktop *>> (Join-Path $LogDir 'desktop-smoke.log')
+        "$(Get-Date -Format o) exit=$LASTEXITCODE" | Out-File -Encoding utf8 (Join-Path $Base 'desktop-smoke-result.txt')
+    }
+}
 # The conhost --headless launcher (scheduled-task action) swallows this exit code, so the
 # task's Last Result always reads 0. Write the real tick result for health observability.
 "$(Get-Date -Format o) exit=$tickExit" | Out-File -Encoding utf8 (Join-Path $Base 'last-tick-result.txt')


### PR DESCRIPTION
**Slice 2b** — the desktop loop-smoke for `install.ps1`, and the shared assertion engine Slice 2c (Docker) will consume.

`tools/ci/windows-install-ps1-smoke.ts` asserts `install.ps1`'s outcomes on a Windows box:
- `--mode desktop` — full graph **incl.** `ZetaOttoLoop` health (Repetition `Duration` + `Next Run` populated)
- `--mode container` — tool-install graph only; the user-mode scheduled task is a **printed skip-with-reason** (a container has no interactive session), never a silent green (shield rule)

Pure parse helpers (`taskHasDurationAndNextRun`, `miseProvidesTool`) are unit-tested (5 tests, run in CI). `otto-loop-wrapper.ps1` gains a **gated** (`ZETA_RUN_DESKTOP_SMOKE`), best-effort desktop-smoke step that never fails the tick (default OFF).

**Validated live on this Win11 laptop:** the smoke correctly **PASSed** scoop/git/`ZetaOttoLoop`-health and **FAILed** the mise checks (mise isn't installed here yet) — proving the assertions fire (not a false-green). The loop-task-health check validated against the real conhost-fixed live task. tsc + wrapper-syntax clean.

Slice 2c (Server-Core Docker, `--mode container`) lands next — it needs this smoke on main first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)