### PR TITLE
feat(ci): Slice 2c — Server-Core Docker test for install.ps1 (dispatch-only, iterating)

### DIFF
--- a/.github/workflows/docker-windows-install-ps1-test.yml
+++ b/.github/workflows/docker-windows-install-ps1-test.yml
@@ -1,0 +1,58 @@
+# .github/workflows/docker-windows-install-ps1-test.yml
+#
+# Slice 2c — CI for the Server-Core Docker test of tools/setup/install.ps1 (B-0857 Windows
+# parity). Mirrors docker-nixos-install-sh-test.yml but runs on windows-2022: Windows containers
+# need a Windows host, and windows-latest = Server 2025 which REMOVED servercore:ltsc2022 — so
+# pin -2022 (WebSearch 2026-05-30: actions/runner-images).
+#
+# FIRST LANDING: workflow_dispatch ONLY, while the Windows-container specifics (scoop's admin
+# behavior, mise install of runtimes, cross-layer PATH) are iterated to green via manual dispatch
+# (gh workflow run). Once green, a follow-up flips the triggers to pull_request + push (the
+# gating config, matching the NixOS workflow's paths-filtered triggers). Keeping it dispatch-only
+# first avoids a red check on every install-substrate PR while the harness is being stabilized.
+name: docker-windows-install-ps1-test
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  docker-test:
+    name: docker-windows-install-ps1-test
+    runs-on: windows-2022
+    # servercore pull (~1-2 GB cold) + scoop bootstrap + mise install of .mise.toml runtimes
+    # (dotnet/python/java/bun/uv) is heavy on a cold runner; 45-min ceiling gives headroom.
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup bun (matches .mise.toml pin)
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3
+
+      - name: Install bun dependencies (for the TS wrapper)
+        run: bun install --frozen-lockfile
+
+      - name: Run Server-Core Docker install.ps1 test
+        env:
+          DOCKER_LOG_OUT_PATH: docker-windows-install-ps1-test.log
+          DOCKER_BUILD_TIMEOUT_SEC: '2400'
+        run: bun tools/ci/docker-windows-install-ps1-test.ts
+
+      - name: Upload Docker test log (always)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docker-windows-install-ps1-test-log
+          path: docker-windows-install-ps1-test.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/tools/ci/docker-windows-install-ps1-test.ts
+++ b/tools/ci/docker-windows-install-ps1-test.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env bun
+/**
+ * tools/ci/docker-windows-install-ps1-test.ts
+ *
+ * Slice 2c — TS wrapper for the Server-Core Docker test of tools/setup/install.ps1 (B-0857
+ * Windows parity). Mirrors tools/ci/docker-nixos-install-sh-test.ts (per
+ * .claude/rules/rule-0-no-sh-files.md: TS-over-bash). Wraps `docker build` of
+ * tools/ci/dockerfiles/windows-install-ps1-test/Dockerfile with exit-code mapping, log capture
+ * (CI artifact), and timeout enforcement.
+ *
+ * REQUIRES a Windows host with Docker in Windows-container mode (the windows-2022 GitHub runner).
+ * Windows containers cannot run on Linux hosts.
+ *
+ * Usage:
+ *   bun tools/ci/docker-windows-install-ps1-test.ts [--keep-image]
+ *
+ * Env:
+ *   DOCKER_BUILD_TIMEOUT_SEC   override timeout (default 2400 — servercore pull + scoop + mise
+ *                              install of .mise.toml runtimes is heavy on a cold runner)
+ *   DOCKER_LOG_OUT_PATH        override log path (default .tools/docker-windows-install-ps1-test.log)
+ *
+ * Exit codes: 0 build ok | 1 build failed | 2 usage/prereq | 124 timeout.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+function spawnDocker(args: string[], opts: { timeoutMs?: number } = {}): ReturnType<typeof spawnSync> {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  return spawnSync("docker", args, {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024, // docker build output is verbose
+    timeout: opts.timeoutMs,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+const DOCKERFILE_PATH = "tools/ci/dockerfiles/windows-install-ps1-test/Dockerfile";
+const IMAGE_TAG = "zeta-windows-install-ps1-test:local";
+const DEFAULT_TIMEOUT_SEC = 2400;
+const DEFAULT_LOG_PATH = ".tools/docker-windows-install-ps1-test.log";
+
+interface BuildResult {
+  exitCode: 0 | 1 | 2 | 124;
+  reason: string;
+  logTail?: string;
+}
+
+function usage(): never {
+  console.error("usage: bun tools/ci/docker-windows-install-ps1-test.ts [--keep-image]");
+  console.error("");
+  console.error("env:");
+  console.error("  DOCKER_BUILD_TIMEOUT_SEC  override timeout (default 2400)");
+  console.error("  DOCKER_LOG_OUT_PATH       override log path");
+  process.exit(2);
+}
+
+function checkPrereqs(): void {
+  const docker = spawnDocker(["--version"]);
+  if (docker.status !== 0) {
+    console.error("error: docker not installed or not on PATH");
+    process.exit(2);
+  }
+  for (const p of [DOCKERFILE_PATH, ".mise.toml", "tools/ci/windows-install-ps1-smoke.ts"]) {
+    if (!existsSync(p)) {
+      console.error(`error: ${p} not found (run from repo root)`);
+      process.exit(2);
+    }
+  }
+}
+
+function runBuild(timeoutSec: number, logPath: string): BuildResult {
+  const startMs = Date.now();
+  const buildArgs = ["build", "--file", DOCKERFILE_PATH, "--tag", IMAGE_TAG, "--progress=plain", "."];
+  console.log(`[Slice 2c] docker build ${buildArgs.join(" ")}`);
+  console.log(`[Slice 2c] timeout: ${timeoutSec}s; log: ${logPath}`);
+
+  const result = spawnDocker(buildArgs, { timeoutMs: timeoutSec * 1000 });
+  const elapsedSec = Math.floor((Date.now() - startMs) / 1000);
+
+  const stdout = (result.stdout ?? "").toString();
+  const stderr = (result.stderr ?? "").toString();
+  const fullLog = stdout + stderr;
+  writeFileSync(logPath, fullLog, "utf8");
+  const logTail = fullLog.split("\n").slice(-25).join("\n");
+
+  const errCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
+  if (result.signal === "SIGTERM" || errCode === "ETIMEDOUT") {
+    return { exitCode: 124, reason: `docker build timed out after ${timeoutSec}s (actual: ${elapsedSec}s)`, logTail };
+  }
+  if (result.status === 0) {
+    console.log(`[Slice 2c] SUCCESS — docker build completed in ${elapsedSec}s`);
+    return { exitCode: 0, reason: `docker build succeeded in ${elapsedSec}s`, logTail };
+  }
+  return { exitCode: 1, reason: `docker build failed (exit ${result.status}) after ${elapsedSec}s`, logTail };
+}
+
+function cleanup(keepImage: boolean): void {
+  if (keepImage) {
+    console.log(`[Slice 2c] --keep-image set; image ${IMAGE_TAG} retained`);
+    return;
+  }
+  const rm = spawnDocker(["rmi", "-f", IMAGE_TAG]);
+  if (rm.status === 0) console.log(`[Slice 2c] cleaned up image ${IMAGE_TAG}`);
+  else console.error(`[Slice 2c] warning: docker rmi ${IMAGE_TAG} failed (non-fatal)`);
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  let keepImage = false;
+  for (const arg of args) {
+    if (arg === "--keep-image") keepImage = true;
+    else if (arg === "--help" || arg === "-h") usage();
+    else {
+      console.error(`error: unknown arg: ${arg}`);
+      usage();
+    }
+  }
+
+  const timeoutSec = parseInt(process.env.DOCKER_BUILD_TIMEOUT_SEC ?? String(DEFAULT_TIMEOUT_SEC), 10);
+  if (!Number.isFinite(timeoutSec) || timeoutSec <= 0) {
+    console.error(`error: DOCKER_BUILD_TIMEOUT_SEC must be a positive integer (got: ${process.env.DOCKER_BUILD_TIMEOUT_SEC})`);
+    process.exit(2);
+  }
+  const logPath = resolve(process.env.DOCKER_LOG_OUT_PATH ?? DEFAULT_LOG_PATH);
+  const logDir = dirname(logPath);
+  if (logDir && !existsSync(logDir)) mkdirSync(logDir, { recursive: true });
+
+  checkPrereqs();
+  const result = runBuild(timeoutSec, logPath);
+  console.log("");
+  console.log(`[Slice 2c] result: ${result.reason}`);
+  console.log(`[Slice 2c] log: ${logPath}`);
+  if (result.exitCode !== 0) {
+    console.log("[Slice 2c] tail of build log:");
+    console.log("--- BEGIN TAIL ---");
+    console.log(result.logTail);
+    console.log("--- END TAIL ---");
+  }
+  cleanup(keepImage);
+  process.exit(result.exitCode);
+}
+
+main();

--- a/tools/ci/dockerfiles/windows-install-ps1-test/Dockerfile
+++ b/tools/ci/dockerfiles/windows-install-ps1-test/Dockerfile
@@ -1,0 +1,43 @@
+# escape=`
+# tools/ci/dockerfiles/windows-install-ps1-test/Dockerfile
+#
+# Slice 2c — Server-Core Docker test for tools/setup/install.ps1 (B-0857 Windows parity).
+# Validates install.ps1's TOOL-INSTALL GRAPH (scoop -> git/mise -> .mise.toml runtimes -> claude)
+# on a clean Windows Server Core userspace, then asserts via tools/ci/windows-install-ps1-smoke.ts
+# --mode container. The user-mode scheduled task is NOT covered here — a Windows container has no
+# interactive session; the desktop loop-smoke covers it. The smoke PRINTS that skip (not silent)
+# per .claude/rules/automated-tests-are-the-shield-assert-dont-skip.md.
+#
+# Runs on the windows-2022 GitHub runner (process isolation; container OS must match the host).
+# windows-latest moved to Server 2025, which REMOVED servercore:ltsc2022 — so the workflow pins
+# runs-on: windows-2022. (WebSearch 2026-05-30: actions/runner-images + scoop.sh.)
+#
+# Base image pin per dep-pin-search-first-authority (WebSearch 2026-05-30 — https://scoop.sh/ +
+# https://learn.microsoft.com/windows/package-manager/ + actions/runner-images). TODO(dep-pin):
+# pin by sha256 digest at next maintenance (capture the resolved digest from a green CI run);
+# the :ltsc2022 tag receives monthly servicing, so a digest gives content-addressed reproducibility.
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+# Server Core ships Windows PowerShell 5.1 (NOT pwsh 7). install.ps1 is #Requires 5.1 + 5.1-safe.
+SHELL ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "$ErrorActionPreference='Stop'; $ProgressPreference='SilentlyContinue';"]
+
+WORKDIR C:\workspace
+
+# COPY only the install-relevant subset (forward-slash dests are fine on Windows containers;
+# avoids invalidating the build cache on unrelated repo changes).
+COPY tools/setup C:/workspace/tools/setup
+COPY tools/ci/windows-install-ps1-smoke.ts C:/workspace/tools/ci/windows-install-ps1-smoke.ts
+COPY tools/persistence/windows C:/workspace/tools/persistence/windows
+COPY .mise.toml C:/workspace/.mise.toml
+COPY package.json C:/workspace/package.json
+
+# Install graph + assert in ONE RUN so install.ps1's in-process PATH additions (scoop + mise
+# shims) carry to the smoke. -SkipLoopRegister: no interactive session in a container -> the
+# user-mode scheduled task isn't registered (desktop loop-smoke covers it). install.ps1 detects
+# the admin context (ContainerAdministrator) + passes -RunAsAdmin to the scoop bootstrap.
+# install.ps1 uses $ErrorActionPreference='Stop', so any install failure throws -> the build fails.
+RUN & 'C:\workspace\tools\setup\install.ps1' -SkipLoopRegister; `
+    mise exec -- bun 'C:\workspace\tools\ci\windows-install-ps1-smoke.ts' --mode container; `
+    if ($LASTEXITCODE -ne 0) { throw "windows-install-ps1-smoke (container mode) failed (exit $LASTEXITCODE)" }
+
+RUN Write-Host "Slice 2c — install.ps1 Server-Core Docker validation COMPLETE"

--- a/tools/setup/install.ps1
+++ b/tools/setup/install.ps1
@@ -40,7 +40,11 @@ if (-not (Have scoop)) {
   try {
     Invoke-RestMethod -Uri https://get.scoop.sh -OutFile $scoopTmp
     if (-not (Test-Path $scoopTmp) -or (Get-Item $scoopTmp).Length -eq 0) { throw "scoop installer empty; refusing to run" }
-    & $scoopTmp
+    # scoop refuses admin by default (desktop = non-admin). In an admin context (CI / a Windows
+    # container runs as ContainerAdministrator) pass -RunAsAdmin so the bootstrap proceeds; on a
+    # normal user desktop this branch is skipped.
+    $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    if ($isAdmin) { & $scoopTmp -RunAsAdmin } else { & $scoopTmp }
   } finally { Remove-Item $scoopTmp -Force -ErrorAction SilentlyContinue }
 }
 # scoop shims on PATH for the rest of this process (scoop adds them to the user PATH for new


### PR DESCRIPTION
**Slice 2c** — the Server-Core Docker test for `install.ps1`, the Windows-Server coverage surface (B-0857 parity). Consumes Slice 2b's smoke in `--mode container`.

- **`install.ps1`**: detects the admin context → passes `-RunAsAdmin` to the scoop bootstrap (a Windows container runs as ContainerAdministrator; scoop refuses admin by default). Real cross-context improvement — the non-admin desktop path is unchanged.
- **Dockerfile** (`servercore:ltsc2022`, `# escape=` backtick, one chained RUN so install.ps1's in-process PATH carries to the smoke assertion).
- **`docker-windows-install-ps1-test.ts`** — orchestrator mirroring the NixOS one.
- **workflow** — `runs-on: windows-2022` (NOT `-latest`, which is Server 2025 and *removed* `servercore:ltsc2022`); SHA-pinned actions.

**Honest about runtime:** Windows containers can't run on Linux or this laptop, so the only runtime surface is CI. I shipped the workflow as **`workflow_dispatch`-only** so it doesn't run red on every install PR while I iterate the genuinely-thorny Windows-container specifics (scoop's admin behavior, `mise install` of runtimes, cross-layer PATH) to green via manual dispatch. A follow-up flips it to `pull_request`+`push` once green.

**Static validation:** tsc clean, install.ps1 syntax OK, **actionlint clean**, 18 windows tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)