### PR TITLE
feat(B-0164.1): reconciliation-status reader (read half, dual-loop AC #4)

### DIFF
--- a/docs/backlog/P1/B-0164.1-pr-review-disagreement-preservation-protocol.md
+++ b/docs/backlog/P1/B-0164.1-pr-review-disagreement-preservation-protocol.md
@@ -123,3 +123,28 @@ controlled dual-review experiment → validate this protocol against the outcome
 - The detector compares two loop observations only when PR number and review-thread id match, normalizes machine conclusions, and returns a `DivergenceInput` for `writeDivergenceShard` when conclusions differ.
 - Focused tests cover same-thread disagreement, same-conclusion no-op, different-thread no-op, and blank-field rejection.
 - This remains below the blocked end-to-end GitHub review submission/reconciliation workflow: it provides testable tooling glue for dual-loop observations without auto-resolving comments or changing GitHub review submission behavior.
+
+## Reconciliation-reader slice (2026-05-30, Otto)
+
+- Added the **read half** of the protocol to `tools/hygiene/divergence-shard.ts`:
+  pure `parseReconciliationStatus(markdown)` + `ReconciliationDecision` /
+  `ReconciliationStatus` types + `RECONCILIATION_DECISIONS` const.
+- Directly serves **AC #4**: the schema README's morning workflow ("reads all
+  shards with empty `Reconciliation` sections") needs a primitive that tells an
+  empty (awaiting) section from a filled (decided) one. `parseReconciliationStatus`
+  is that primitive — it consumes exactly the placeholder `buildDivergenceShard`
+  writes (round-trip → `unreconciled`), and on a filled section extracts the
+  earliest-occurring decision keyword from the README's four-option vocabulary
+  (`accept-loop-a | accept-loop-b | accept-both | escalate`), case-insensitively.
+- Three explicit `ReconciliationStatus` variants per the IMPLICIT-NOT-EXPLICIT
+  discipline: `unreconciled`, `reconciled` (recognized keyword), and
+  `reconciled-freeform` (filled but no keyword — the morning tooling flags it for
+  the maintainer to canonicalize). Comment-stripping is load-bearing and tested:
+  the unreconciled placeholder itself lists the keywords, so HTML comments are
+  stripped before the empty-check + keyword scan.
+- Pure (no GitHub, no concurrent-loop harness) → stays below the blocked
+  end-to-end boundary. 11 focused tests (41 total in the file, 0 fail). Schema
+  unchanged (B-0164 AC #4 remains the source of truth; this slice only reads it).
+- Natural next slice (still below the boundary): an I/O scanner over
+  `docs/hygiene-history/divergences/**` that lists unreconciled shards by feeding
+  each through `parseReconciliationStatus`. NOT in this slice (one bounded step).

--- a/tools/hygiene/divergence-reconcile.ts
+++ b/tools/hygiene/divergence-reconcile.ts
@@ -109,8 +109,12 @@ export function isReconciliationPending(markdown: string): boolean {
  * so we re-run until the string stops shrinking. Termination is guaranteed —
  * each changing pass strictly deletes characters. (CodeQL js/incomplete-multi-
  * character-sanitization.)
+ *
+ * Exported as the single source of HTML-comment sanitization for the divergence
+ * protocol: divergence-shard.ts's read half (parseReconciliationStatus) reuses
+ * this exact fixpoint impl rather than carrying its own pass (Copilot PR #6130).
  */
-function stripHtmlComments(text: string): string {
+export function stripHtmlComments(text: string): string {
   let out = text;
   let prev: string;
   do {

--- a/tools/hygiene/divergence-shard.test.ts
+++ b/tools/hygiene/divergence-shard.test.ts
@@ -6,10 +6,12 @@ import { dirname, join } from "node:path";
 import {
   type DivergenceInput,
   type ReviewThreadDisagreementInput,
+  RECONCILIATION_DECISIONS,
   detectReviewThreadDisagreement,
   buildDivergenceShard,
   divergenceShardRelPath,
   fileReviewThreadDisagreement,
+  parseReconciliationStatus,
   shortContentHash,
   writeDivergenceShard,
   writeShardAtPath,
@@ -472,6 +474,86 @@ describe("fileReviewThreadDisagreement (detect → file glue, AC #2)", () => {
         }),
       ).toThrow(/loopB\.body/);
       expect(existsSync(join(root, DIVERGENCE_DIR))).toBe(false);
+    });
+  });
+
+  describe("parseReconciliationStatus (read half, AC #4)", () => {
+    /** Replace a built shard's Reconciliation section body with `body`. */
+    function withReconciliation(shard: string, body: string): string {
+      const idx = shard.indexOf("## Reconciliation");
+      if (idx < 0) throw new Error("test fixture: built shard had no Reconciliation header");
+      return `${shard.slice(0, idx)}## Reconciliation\n\n${body}\n`;
+    }
+
+    test("a freshly-built shard reads as unreconciled (round-trip with builder)", () => {
+      // The builder writes a placeholder whose HTML comments LIST the four
+      // decision keywords. Reading unreconciled here proves comment-stripping
+      // happens before the empty-check + keyword scan.
+      expect(parseReconciliationStatus(buildDivergenceShard(INPUT))).toEqual({ kind: "unreconciled" });
+    });
+
+    test("whitespace-only Reconciliation (no comments) reads as unreconciled", () => {
+      expect(parseReconciliationStatus(withReconciliation(buildDivergenceShard(INPUT), "   \n\t"))).toEqual({
+        kind: "unreconciled",
+      });
+    });
+
+    for (const decision of RECONCILIATION_DECISIONS) {
+      test(`reads a filled decision: ${decision}`, () => {
+        const md = withReconciliation(buildDivergenceShard(INPUT), `${decision} — maintainer chose this.`);
+        const status = parseReconciliationStatus(md);
+        expect(status.kind).toBe("reconciled");
+        if (status.kind !== "reconciled") throw new Error("expected reconciled");
+        expect(status.decision).toBe(decision);
+        expect(status.note).toContain("maintainer chose this");
+      });
+    }
+
+    test("matches decision keywords case-insensitively, preserving note case", () => {
+      const md = withReconciliation(buildDivergenceShard(INPUT), "Accept-Loop-B: Loop B reproduces it locally.");
+      const status = parseReconciliationStatus(md);
+      expect(status.kind).toBe("reconciled");
+      if (status.kind !== "reconciled") throw new Error("expected reconciled");
+      expect(status.decision).toBe("accept-loop-b");
+      // note preserves original casing
+      expect(status.note).toContain("Accept-Loop-B");
+    });
+
+    test("earliest-occurring keyword wins, not README list order", () => {
+      // "escalate" is LAST in RECONCILIATION_DECISIONS but appears FIRST in the
+      // prose; earliest-by-index must win over list order.
+      const md = withReconciliation(
+        buildDivergenceShard(INPUT),
+        "escalate for now; we considered accept-both but want more evidence.",
+      );
+      const status = parseReconciliationStatus(md);
+      expect(status.kind).toBe("reconciled");
+      if (status.kind !== "reconciled") throw new Error("expected reconciled");
+      expect(status.decision).toBe("escalate");
+    });
+
+    test("filled prose with no recognized keyword reads as reconciled-freeform", () => {
+      const md = withReconciliation(buildDivergenceShard(INPUT), "Talked it over; Loop A is right here.");
+      const status = parseReconciliationStatus(md);
+      expect(status.kind).toBe("reconciled-freeform");
+      if (status.kind !== "reconciled-freeform") throw new Error("expected reconciled-freeform");
+      expect(status.note).toBe("Talked it over; Loop A is right here.");
+    });
+
+    test("throws on a shard missing the Reconciliation section", () => {
+      expect(() => parseReconciliationStatus("---\ntype: divergence\n---\n\n## Loop A perspective\n\nx")).toThrow(
+        /missing "## Reconciliation" section/,
+      );
+    });
+
+    test("terminates the section at a following heading (does not bleed into later content)", () => {
+      const md = `${withReconciliation(buildDivergenceShard(INPUT), "accept-loop-a — done.")}\n## Notes\n\nescalate appears here but must be ignored.`;
+      const status = parseReconciliationStatus(md);
+      expect(status.kind).toBe("reconciled");
+      if (status.kind !== "reconciled") throw new Error("expected reconciled");
+      // "escalate" lives in the later ## Notes section, so it must NOT win.
+      expect(status.decision).toBe("accept-loop-a");
+      expect(status.note).not.toContain("ignored");
     });
   });
 });

--- a/tools/hygiene/divergence-shard.ts
+++ b/tools/hygiene/divergence-shard.ts
@@ -394,3 +394,106 @@ export function fileReviewThreadDisagreement(repoRoot: string, input: ReviewThre
     divergenceInput: detection.divergenceInput,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Read half of the protocol (AC #4): classify a filed shard's Reconciliation
+// section. The schema README's morning-reconciliation workflow ("reads all
+// shards with empty Reconciliation sections") needs a primitive that tells an
+// empty (awaiting) section from a filled (decided) one. This is the pure
+// counterpart to buildDivergenceShard: it consumes exactly the placeholder
+// that builder writes. Stays below the blocked end-to-end boundary -- parsing
+// an already-filed shard needs no GitHub call and no concurrent-loop harness.
+// ---------------------------------------------------------------------------
+
+/**
+ * The four canonical reconciliation decisions per the schema README
+ * ("Reconciliation outcomes"). Order is the README's listing order; matching
+ * is by earliest occurrence in the section, not by this order.
+ */
+export const RECONCILIATION_DECISIONS = ["accept-loop-a", "accept-loop-b", "accept-both", "escalate"] as const;
+
+export type ReconciliationDecision = (typeof RECONCILIATION_DECISIONS)[number];
+
+/**
+ * Status of a divergence shard's Reconciliation section.
+ *   - unreconciled: the section holds only the maintainer-fills-in placeholder
+ *     (the two HTML comments buildDivergenceShard writes) and/or whitespace;
+ *     this shard awaits morning reconciliation.
+ *   - reconciled: the section is filled and carries a recognized decision
+ *     keyword; `note` is the maintainer's trimmed, case-preserving prose.
+ *   - reconciled-freeform: the section is filled but carries no recognized
+ *     keyword. Distinct from `reconciled` because the morning tooling should
+ *     flag it for the maintainer to canonicalize rather than treat it as a
+ *     clean decision (IMPLICIT-NOT-EXPLICIT: a substantively-distinct state
+ *     earns its own variant).
+ */
+export type ReconciliationStatus =
+  | { readonly kind: "unreconciled" }
+  | { readonly kind: "reconciled"; readonly decision: ReconciliationDecision; readonly note: string }
+  | { readonly kind: "reconciled-freeform"; readonly note: string };
+
+const RECONCILIATION_HEADER = "## Reconciliation";
+
+/**
+ * Extract the Reconciliation section body: everything after the
+ * "## Reconciliation" header up to the next "## " heading or end-of-file. In
+ * the canonical shape Reconciliation is the last section, so EOF terminates
+ * it; the next-heading terminator is defensive for shards that append further
+ * sections. Throws on a shard missing the header (malformed per schema --
+ * eager rejection over silent acceptance, matching detectReviewThreadDisagreement).
+ */
+function extractReconciliationSection(markdown: string): string {
+  const headerIdx = markdown.indexOf(RECONCILIATION_HEADER);
+  if (headerIdx < 0) {
+    throw new Error(`malformed divergence shard: missing "${RECONCILIATION_HEADER}" section`);
+  }
+  const afterHeader = markdown.slice(headerIdx + RECONCILIATION_HEADER.length);
+  const nextHeading = afterHeader.search(/\n## /);
+  return nextHeading >= 0 ? afterHeader.slice(0, nextHeading) : afterHeader;
+}
+
+/** Remove HTML comments. Load-bearing: the unreconciled placeholder itself
+ *  lists the four decision keywords inside `<!-- ... -->`, so comments MUST be
+ *  stripped before the empty-check and before the keyword scan -- otherwise an
+ *  untouched placeholder would read as a filled "accept-loop-a..." decision. */
+function stripHtmlComments(text: string): string {
+  return text.replace(/<!--[\s\S]*?-->/g, "");
+}
+
+/** Earliest-occurring recognized decision keyword in `text` (already lowercased
+ *  by the caller), or null if none is present. Earliest-wins is deterministic
+ *  when a note mentions more than one keyword. */
+function findEarliestDecision(lowerText: string): ReconciliationDecision | null {
+  let earliest: { decision: ReconciliationDecision; idx: number } | null = null;
+  for (const decision of RECONCILIATION_DECISIONS) {
+    const idx = lowerText.indexOf(decision);
+    if (idx >= 0 && (earliest === null || idx < earliest.idx)) {
+      earliest = { decision, idx };
+    }
+  }
+  return earliest?.decision ?? null;
+}
+
+/**
+ * Classify a filed divergence shard's Reconciliation section. Pure: no I/O, no
+ * GitHub, no clock. Composes with buildDivergenceShard -- feeding that builder's
+ * output here returns `{ kind: "unreconciled" }`, which is the foundational read
+ * the schema README's "reads all shards with empty Reconciliation sections"
+ * morning workflow (and B-0164.1 AC #4) depends on.
+ *
+ * Decision keyword matching is case-insensitive (consistent with
+ * normalizedConclusion). The returned `note` preserves the maintainer's
+ * original case + content (trimmed) for human readability.
+ */
+export function parseReconciliationStatus(markdown: string): ReconciliationStatus {
+  const section = extractReconciliationSection(markdown);
+  const filled = stripHtmlComments(section).trim();
+  if (filled.length === 0) {
+    return { kind: "unreconciled" };
+  }
+  const decision = findEarliestDecision(filled.toLowerCase());
+  if (decision === null) {
+    return { kind: "reconciled-freeform", note: filled };
+  }
+  return { kind: "reconciled", decision, note: filled };
+}

--- a/tools/hygiene/divergence-shard.ts
+++ b/tools/hygiene/divergence-shard.ts
@@ -24,6 +24,20 @@ import { createHash } from "node:crypto";
 import { closeSync, mkdirSync, openSync, readFileSync, writeSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 
+import {
+  RECONCILIATION_DECISIONS,
+  type ReconciliationDecision,
+  reconciliationBody,
+  stripHtmlComments,
+} from "./divergence-reconcile.ts";
+
+// Re-export the canonical reconciliation vocabulary so existing importers of
+// divergence-shard (the test suite, downstream callers) keep a stable surface.
+// Single-sourced in divergence-reconcile.ts to stop the two modules drifting on
+// order/value/doc -- the read half here and the fill half there now share one
+// definition of the four decisions (Copilot PR #6130).
+export { RECONCILIATION_DECISIONS, type ReconciliationDecision };
+
 /** A single loop's identity for attribution in the shard frontmatter. */
 export interface LoopIdentity {
   /** Named agent identifier, e.g. "otto", "codex-loop", "vera". */
@@ -406,21 +420,14 @@ export function fileReviewThreadDisagreement(repoRoot: string, input: ReviewThre
 // ---------------------------------------------------------------------------
 
 /**
- * The four canonical reconciliation decisions per the schema README
- * ("Reconciliation outcomes"). Order is the README's listing order; matching
- * is by earliest occurrence in the section, not by this order.
- */
-export const RECONCILIATION_DECISIONS = ["accept-loop-a", "accept-loop-b", "accept-both", "escalate"] as const;
-
-export type ReconciliationDecision = (typeof RECONCILIATION_DECISIONS)[number];
-
-/**
  * Status of a divergence shard's Reconciliation section.
  *   - unreconciled: the section holds only the maintainer-fills-in placeholder
  *     (the two HTML comments buildDivergenceShard writes) and/or whitespace;
  *     this shard awaits morning reconciliation.
  *   - reconciled: the section is filled and carries a recognized decision
- *     keyword; `note` is the maintainer's trimmed, case-preserving prose.
+ *     keyword; `note` is the maintainer's prose, case-preserving and trimmed,
+ *     with the placeholder HTML comments removed (the same strip the empty-check
+ *     applies, so an `<!-- ... -->` block never leaks into the note).
  *   - reconciled-freeform: the section is filled but carries no recognized
  *     keyword. Distinct from `reconciled` because the morning tooling should
  *     flag it for the maintainer to canonicalize rather than treat it as a
@@ -432,8 +439,6 @@ export type ReconciliationStatus =
   | { readonly kind: "reconciled"; readonly decision: ReconciliationDecision; readonly note: string }
   | { readonly kind: "reconciled-freeform"; readonly note: string };
 
-const RECONCILIATION_HEADER = "## Reconciliation";
-
 /**
  * Extract the Reconciliation section body: everything after the
  * "## Reconciliation" header up to the next "## " heading or end-of-file. In
@@ -441,23 +446,20 @@ const RECONCILIATION_HEADER = "## Reconciliation";
  * it; the next-heading terminator is defensive for shards that append further
  * sections. Throws on a shard missing the header (malformed per schema --
  * eager rejection over silent acceptance, matching detectReviewThreadDisagreement).
+ *
+ * Delegates to divergence-reconcile.ts's `reconciliationBody`, which anchors on
+ * the heading as a full line (`/^## Reconciliation[ \t]*$/m`) instead of a bare
+ * `indexOf`. The anchored match is deterministic: an "## Reconciliation" mention
+ * inside prose or a fenced code block before the real heading can no longer
+ * slice the wrong region (Copilot PR #6130). `reconciliationBody` returns null
+ * when no heading line exists; we convert that to the eager-rejection throw.
  */
 function extractReconciliationSection(markdown: string): string {
-  const headerIdx = markdown.indexOf(RECONCILIATION_HEADER);
-  if (headerIdx < 0) {
-    throw new Error(`malformed divergence shard: missing "${RECONCILIATION_HEADER}" section`);
+  const body = reconciliationBody(markdown);
+  if (body === null) {
+    throw new Error('malformed divergence shard: missing "## Reconciliation" section');
   }
-  const afterHeader = markdown.slice(headerIdx + RECONCILIATION_HEADER.length);
-  const nextHeading = afterHeader.search(/\n## /);
-  return nextHeading >= 0 ? afterHeader.slice(0, nextHeading) : afterHeader;
-}
-
-/** Remove HTML comments. Load-bearing: the unreconciled placeholder itself
- *  lists the four decision keywords inside `<!-- ... -->`, so comments MUST be
- *  stripped before the empty-check and before the keyword scan -- otherwise an
- *  untouched placeholder would read as a filled "accept-loop-a..." decision. */
-function stripHtmlComments(text: string): string {
-  return text.replace(/<!--[\s\S]*?-->/g, "");
+  return body;
 }
 
 /** Earliest-occurring recognized decision keyword in `text` (already lowercased
@@ -482,8 +484,10 @@ function findEarliestDecision(lowerText: string): ReconciliationDecision | null 
  * morning workflow (and B-0164.1 AC #4) depends on.
  *
  * Decision keyword matching is case-insensitive (consistent with
- * normalizedConclusion). The returned `note` preserves the maintainer's
- * original case + content (trimmed) for human readability.
+ * normalizedConclusion). The returned `note` is the section's text after the
+ * placeholder HTML comments are stripped (same fixpoint strip as the empty-
+ * check) then trimmed; case is preserved for human readability. It is the
+ * maintainer's prose, not a byte-for-byte copy of the raw section.
  */
 export function parseReconciliationStatus(markdown: string): ReconciliationStatus {
   const section = extractReconciliationSection(markdown);


### PR DESCRIPTION
## What

Adds the **read half** of the B-0164.1 PR-review disagreement-preservation
protocol (dual-loop **AC #4**) to `tools/hygiene/divergence-shard.ts`.

The module already had the *write* half (detector -> builder -> fail-closed
writer -> `fileReviewThreadDisagreement` composer). The schema README's morning
workflow — *"Morning reconciliation reads all shards with empty `Reconciliation`
sections"* — and AC #4 (*"resolve the thread in one read + one action"*) both
depend on a primitive that distinguishes an **empty (awaiting)** Reconciliation
section from a **filled (decided)** one. None existed. This PR adds it.

New exports (pure, no I/O):

- `parseReconciliationStatus(markdown)` — classifies a filed shard's
  Reconciliation section. Round-trips with `buildDivergenceShard` (its
  placeholder output reads back as `unreconciled`).
- `ReconciliationStatus` — three explicit variants per the IMPLICIT-NOT-EXPLICIT
  discipline: `unreconciled` / `reconciled` (recognized keyword) /
  `reconciled-freeform` (filled but no keyword; morning tooling flags it to
  canonicalize).
- `RECONCILIATION_DECISIONS` + `ReconciliationDecision` — the README's
  four-option vocabulary (`accept-loop-a | accept-loop-b | accept-both |
  escalate`).

## Why this is the smallest safe slice

- **Below the blocked boundary.** Parsing an already-filed shard needs no GitHub
  call and no concurrent-loop harness (the B-0160 blocker), so it is fully
  testable in isolation — same posture as the Codex detector slice (2026-05-30).
- **Schema unchanged.** B-0164 AC #4 remains the source of truth; this slice only
  *reads* the schema (out-of-scope changes — GitHub submission, schema edits —
  untouched).
- **Load-bearing correctness detail:** the unreconciled placeholder itself lists
  the four decision keywords inside HTML comments, so comment-stripping is
  ordered *before* the empty-check + keyword scan. A test asserts the freshly
  built placeholder reads as `unreconciled` (not a spurious `accept-loop-a`).
- Matching is case-insensitive (consistent with `normalizedConclusion`);
  earliest-by-index wins when multiple keywords appear; `note` preserves original
  case. Section extraction terminates at the next `## ` heading or EOF (a later
  heading's `escalate` does not bleed in — tested). Malformed shard (missing
  `## Reconciliation`) throws, matching the eager-rejection discipline of
  `detectReviewThreadDisagreement`.

## Re-decomposition note

Per the build-time re-decompose discipline: Riven's 2026-05-11 "no substrate
mutation" framing is superseded by the Codex 2026-05-30 precedent of landing
real below-the-boundary tooling. The genuine remaining gap was the *read* half;
this PR lands exactly that and nothing more (one bounded step). Natural next
slice (still below the boundary, NOT here): an I/O scanner over
`docs/hygiene-history/divergences/**` that lists unreconciled shards by feeding
each through `parseReconciliationStatus`.

## Focused checks

- `bun test tools/hygiene/divergence-shard.test.ts` -> **41 pass / 0 fail**
  (11 new; baseline was 30).
- `bunx tsc --noEmit -p tsconfig.json` -> **clean** on the touched files (no
  `error TS` lines).
- Commit-canary: tree-size 66 == parent 66 (no commit-tree corruption).
- TS + docs only — no `.fs`/`.cs`/`.fsproj` touched, so the `dotnet build -c
  Release` gate is unaffected (determined entirely by `origin/main` state).

operative-authorization: aaron 2026-05-14: "- **Devil-pole** (edge-runner drive): keep pushing, discover, go hard, never-be-idle"

Closes a slice of B-0164.1 (`docs/backlog/P1/B-0164.1-pr-review-disagreement-preservation-protocol.md`). Parent B-0164; depends_on B-0160 (impl child remains blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
