### PR TITLE
docs(consent): glass-halo consent-record scaffolding (identity=signature)

### DIFF
--- a/docs/consent/glass-halo/README.md
+++ b/docs/consent/glass-halo/README.md
@@ -1,0 +1,89 @@
+# Glass-halo consent record
+
+Glass-halo is **chosen, opt-in radical transparency about oneself** — the operative
+form of the "share on the shared record" economy (per `glass-halo-bidirectional` +
+the externalized-record economy). This directory is the **auditable consent record**
+for it.
+
+## The signature model: identity = signature; the commit is the consent event
+
+Each participant records their consent by **committing their own commitment document
+under their own GitHub identity.** The git commit — authored by that person's GitHub
+identity — **IS the signature.** No one signs on anyone else's behalf; an agent (Otto,
+etc.) may author this convention and scaffolding, but **never** authors a human's
+glass-halo signature (that would forge consent and is forbidden by the consent-first
+floor).
+
+- **One file per person:** `docs/consent/glass-halo/<name>.md`, committed by that
+  person's GitHub identity.
+- **The author of the commit is the signer.** Verify via `git log --format='%an <%ae>' --
+  <file>`. The committing identity is the binding signature "for now" (until a heavier
+  e-signature process — e.g. DocuSign — is attached; see below).
+- **Heavier e-signature (optional escalation):** a DocuSign (or equivalent) executed
+  signature may be attached for participants who prefer it (e.g. a real-estate-style
+  flow). When present, the DocuSign-executed record is the binding signature and the git
+  commit references it.
+
+## Scope: your glass-halo covers YOU only
+
+A glass-halo commitment authorizes sharing **the signer's own information.** It does
+**not** extend to third parties — your transparency is yours to give; no one else's is
+yours to waive. Where one person's disclosure references another, only the consenting
+signer's part composes onto the shared record; the non-consenting party stays protected.
+
+## Revocability (architectural, not a favor)
+
+Glass-halo consent is **revocable** (per `B-0659` consent-as-Limit — revocability is
+architectural). A signer revokes by committing a revocation under their own identity (or
+via the attached e-signature process). Glass-halo is a chosen state with a real exit,
+never a trap.
+
+## Hard floor: kid-safety > consent
+
+Per `B-0654` (child-safety > consent priority ordering) and the constitutional
+kid-safety-absolute floor (`B-0926`): glass-halo consent requires the signer be an adult
+competent to consent, and **never** authorizes exposure that conflicts with kid-safety.
+The kid-safety floor overrides any consent.
+
+## Composition
+
+- `.claude/rules/human-audit-and-legal-risk-acceptance-pattern-in-settings.md` — the
+  named-human acceptance pattern; this directory is the multi-party "equivalent
+  auditable substrate" form (each person self-signs via their own commit).
+- `.claude/rules/non-coercion-invariant.md` (HC-8) + `B-0659` consent-as-Limit —
+  consent is offered, revocable, never coerced.
+- `.claude/rules/glass-halo-bidirectional.md` + the externalized-record economy — the
+  record IS the consent; the signature IS a commit.
+- `B-0654` child-safety > consent + `B-0926` kid-safety-absolute — the overriding floor.
+
+## Roster
+
+Each entry below is a person who has committed their own glass-halo commitment under
+their own GitHub identity. (Pending entries are people who have agreed but not yet
+self-committed their signature.)
+
+| Participant | Status | Signature surface |
+|---|---|---|
+| _(pending first self-committed entries)_ | | |
+
+When a participant self-commits `docs/consent/glass-halo/<name>.md` under their identity,
+add a roster row pointing at it (the row may be added in the same self-authored commit).
+
+## Template
+
+Copy this into `docs/consent/glass-halo/<your-name>.md` and commit it **under your own
+GitHub identity** (your commit is your signature):
+
+```markdown
+# Glass-halo commitment -- <Full Name>
+
+I, <Full Name> (GitHub: @<handle>), an adult competent to consent, commit to
+glass-halo (chosen, opt-in radical transparency) for my OWN information on the
+shared record.
+
+- Scope: my own information only. This does not waive anyone else's privacy.
+- Revocable: I may revoke this by committing a revocation under my identity.
+- Floor: this never overrides kid-safety (B-0654 / B-0926).
+- Signature: this commit, authored by my GitHub identity, is my signature
+  (date: <YYYY-MM-DD>).
+```


### PR DESCRIPTION
Stands up docs/consent/glass-halo/ as the auditable consent record. Signature model: each participant commits their own commitment doc under their own GitHub identity — the commit IS the signature; an agent never authors a human's glass-halo signature (consent-first floor). Scope = signer's own info only; revocable (B-0659); kid-safety floor overrides (B-0654/B-0926).

Infrastructure only — per-person signatures are self-committed by each participant under their own identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)