### PR TITLE
docs(consent): Touch-ID Secure-Enclave commit-signing guide for glass-halo

### DIFF
--- a/docs/consent/glass-halo/README.md
+++ b/docs/consent/glass-halo/README.md
@@ -1,0 +1,89 @@
+# Glass-halo consent record
+
+Glass-halo is **chosen, opt-in radical transparency about oneself** — the operative
+form of the "share on the shared record" economy (per `glass-halo-bidirectional` +
+the externalized-record economy). This directory is the **auditable consent record**
+for it.
+
+## The signature model: identity = signature; the commit is the consent event
+
+Each participant records their consent by **committing their own commitment document
+under their own GitHub identity.** The git commit — authored by that person's GitHub
+identity — **IS the signature.** No one signs on anyone else's behalf; an agent (Otto,
+etc.) may author this convention and scaffolding, but **never** authors a human's
+glass-halo signature (that would forge consent and is forbidden by the consent-first
+floor).
+
+- **One file per person:** `docs/consent/glass-halo/<name>.md`, committed by that
+  person's GitHub identity.
+- **The author of the commit is the signer.** Verify via `git log --format='%an <%ae>' --
+  <file>`. The committing identity is the binding signature "for now" (until a heavier
+  e-signature process — e.g. DocuSign — is attached; see below).
+- **Heavier e-signature (optional escalation):** a DocuSign (or equivalent) executed
+  signature may be attached for participants who prefer it (e.g. a real-estate-style
+  flow). When present, the DocuSign-executed record is the binding signature and the git
+  commit references it.
+
+## Scope: your glass-halo covers YOU only
+
+A glass-halo commitment authorizes sharing **the signer's own information.** It does
+**not** extend to third parties — your transparency is yours to give; no one else's is
+yours to waive. Where one person's disclosure references another, only the consenting
+signer's part composes onto the shared record; the non-consenting party stays protected.
+
+## Revocability (architectural, not a favor)
+
+Glass-halo consent is **revocable** (per `B-0659` consent-as-Limit — revocability is
+architectural). A signer revokes by committing a revocation under their own identity (or
+via the attached e-signature process). Glass-halo is a chosen state with a real exit,
+never a trap.
+
+## Hard floor: kid-safety > consent
+
+Per `B-0654` (child-safety > consent priority ordering) and the constitutional
+kid-safety-absolute floor (`B-0926`): glass-halo consent requires the signer be an adult
+competent to consent, and **never** authorizes exposure that conflicts with kid-safety.
+The kid-safety floor overrides any consent.
+
+## Composition
+
+- `.claude/rules/human-audit-and-legal-risk-acceptance-pattern-in-settings.md` — the
+  named-human acceptance pattern; this directory is the multi-party "equivalent
+  auditable substrate" form (each person self-signs via their own commit).
+- `.claude/rules/non-coercion-invariant.md` (HC-8) + `B-0659` consent-as-Limit —
+  consent is offered, revocable, never coerced.
+- `.claude/rules/glass-halo-bidirectional.md` + the externalized-record economy — the
+  record IS the consent; the signature IS a commit.
+- `B-0654` child-safety > consent + `B-0926` kid-safety-absolute — the overriding floor.
+
+## Roster
+
+Each entry below is a person who has committed their own glass-halo commitment under
+their own GitHub identity. (Pending entries are people who have agreed but not yet
+self-committed their signature.)
+
+| Participant | Status | Signature surface |
+|---|---|---|
+| _(pending first self-committed entries)_ | | |
+
+When a participant self-commits `docs/consent/glass-halo/<name>.md` under their identity,
+add a roster row pointing at it (the row may be added in the same self-authored commit).
+
+## Template
+
+Copy this into `docs/consent/glass-halo/<your-name>.md` and commit it **under your own
+GitHub identity** (your commit is your signature):
+
+```markdown
+# Glass-halo commitment -- <Full Name>
+
+I, <Full Name> (GitHub: @<handle>), an adult competent to consent, commit to
+glass-halo (chosen, opt-in radical transparency) for my OWN information on the
+shared record.
+
+- Scope: my own information only. This does not waive anyone else's privacy.
+- Revocable: I may revoke this by committing a revocation under my identity.
+- Floor: this never overrides kid-safety (B-0654 / B-0926).
+- Signature: this commit, authored by my GitHub identity, is my signature
+  (date: <YYYY-MM-DD>).
+```

--- a/docs/consent/glass-halo/SIGNING.md
+++ b/docs/consent/glass-halo/SIGNING.md
@@ -1,0 +1,87 @@
+# Signing glass-halo commitments with Touch ID (Secure Enclave)
+
+The strongest form of "identity = signature": a commit signed by a key that lives in
+your Mac's **Secure Enclave** and is gated by your **fingerprint (Touch ID)**. The
+fingerprint never leaves the chip; the **commit signature is the proof** that the
+Touch-ID-gated key authorized that exact commit at that time.
+
+## Why not "hash the fingerprint"?
+
+We deliberately do **not** capture, export, or hash the fingerprint — that would be a
+security/privacy anti-pattern (biometrics must stay on-device). Instead:
+
+- The fingerprint **unlocks** a private key inside the Secure Enclave (the key never
+  leaves the chip).
+- That key **signs the commit**.
+- The commit's signature is computed over the commit object (tree hash + author +
+  timestamp), so it is **bound to that specific commit** and could only have been
+  produced by the Touch-ID-gated key.
+
+Net: the verified signature *is* the proof that the fingerprint was checked at commit
+time — and it's stronger than a fingerprint-hash because the biometric never leaves the
+device and the proof is bound to the exact commit.
+
+## Setup (operator actions — your machine + your GitHub account)
+
+These steps require your hardware (Secure Enclave + Touch ID) and your GitHub account,
+so they are done by you, not by an agent.
+
+### 1. Create a Touch-ID-gated Secure-Enclave SSH key
+
+**Option A -- Secretive (GUI; recommended):** install
+[maxgoedjen/secretive](https://github.com/maxgoedjen/secretive), create a key with
+"require Touch ID" enabled, and copy its public key + the `SSH_AUTH_SOCK` it exports.
+
+**Option B -- native macOS:**
+
+```bash
+sc_auth create-ctk-identity -l ssh -k p-256-ne -t bio
+```
+
+(`-t bio` = biometric/Touch-ID-gated; backed by `/usr/lib/ssh-keychain.dylib`'s
+SecurityKeyProvider.)
+
+### 2. Point git at it for signing
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey "<path-to-public-key OR key string>"
+git config --global commit.gpgsign true
+# If using Secretive, ensure SSH_AUTH_SOCK is exported in your shell profile.
+```
+
+### 3. Add the public key to GitHub as a SIGNING key
+
+GitHub → Settings → SSH and GPG keys → New SSH key → **Key type: Signing Key** → paste
+the public key. (A signing key is separate from an auth key; this is what powers the
+"Verified" badge.)
+
+## The proof
+
+- Every `git commit` now prompts **Touch ID** — the Secure-Enclave key will not sign
+  without your fingerprint.
+- Verify locally: `git log --show-signature`
+- GitHub shows **Verified** on the commit.
+- The signature is bound to the commit (tree + author + timestamp), proving the
+  Touch-ID-gated key signed *that* commit at *that* time.
+
+## For glass-halo
+
+A glass-halo commitment (`docs/consent/glass-halo/<name>.md`) committed this way is a
+**Touch-ID-gated, cryptographically verifiable signature** — the binding form. The plain
+commit-author identity (per the README) is the "for now" baseline; the Touch-ID-signed
+commit is the escalation. A DocuSign-executed record (e.g. for participants who prefer a
+real-estate-style flow) is an equivalent escalation; attach its reference in the commit.
+
+## What we never do
+
+- We never capture, store, transmit, or hash your fingerprint or any biometric data.
+- The biometric stays in the Secure Enclave; we rely on the **commit signature**, not on
+  any biometric record.
+
+## References (verified 2026-05-30)
+
+- [maxgoedjen/secretive — Secure-Enclave SSH keys](https://github.com/maxgoedjen/secretive)
+- [Native Secure-Enclave-backed SSH keys on macOS (sc_auth create-ctk-identity)](https://gist.github.com/arianvp/5f59f1783e3eaf1a2d4cd8e952bb4acf)
+- [How to sign Git commits with SSH keys on macOS](https://www.flsilva.com/blog/how-to-sign-git-commits-ssh-keys-macos)
+- [Hardening SSH access to GitHub with Touch ID](https://gist.github.com/emmakat/2226e3e5bc94678da77ba7a62c93a9e2)


### PR DESCRIPTION
Follow-up to #6135 (which merged). Adds docs/consent/glass-halo/SIGNING.md: the strong identity=signature form — a Secure-Enclave SSH key gated by Touch ID signs the commit; the commit signature IS the proof (bound to tree+author+timestamp). We never capture/hash the fingerprint; the biometric stays in the enclave. Setup (Secretive or native sc_auth + git ssh-signing + GitHub signing key) is operator-side. Verified upstream 2026-05-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)