### PR TITLE
consent(glass-halo): Aaron's signature + signature-acquisition skill

### DIFF
--- a/.claude/skills/glass-halo-signature-acquisition/SKILL.md
+++ b/.claude/skills/glass-halo-signature-acquisition/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: glass-halo-signature-acquisition
+description: Use when acquiring or recording a glass-halo consent signature from a person (operator, family, business partner, external participant). Triggers on "sign my glass-halo", "let's sign", "add <person> to the consent roster", "record <person>'s consent", or any request to capture glass-halo consent. Records the full three-part audit trail -- what was shown, the person's English response, and their signature -- into docs/consent/glass-halo/.
+---
+
+# Glass-halo signature acquisition
+
+Acquire and record a glass-halo consent signature with a complete, auditable trail.
+The record must show **all three parts** (operator definition, 2026-05-30): *"the
+record show what you showed me and how i responded in english and my signature -- all
+3."*
+
+## The signature IS the informed approval (not the keystroke)
+
+Operator 2026-05-30: *"my signature is the approval/signature not the actual running of
+the command."* The person's informed approval is the signature; an agent may **record**
+it (run the commit) once the person has been shown the document and has explicitly
+approved + authorized recording. The consent-first floor forbids *inventing* consent --
+never record a signature without a real, informed, explicit approval. Genuine approval +
+explicit authorization to record = recording is execution, not forgery.
+
+## The three-part record (required)
+
+Every `docs/consent/glass-halo/<name>.md` MUST capture:
+
+1. **What was shown.** Link/quote exactly what the person reviewed: the commitment text
+   + `docs/consent/glass-halo/README.md` (convention) + `SIGNING.md` (signing mechanism)
+   + the exact command/PR if an agent will record it.
+2. **The person's response, verbatim English.** Quote their actual words (agreement,
+   questions, conditions, or boundary). Do not paraphrase the consent itself.
+3. **The signature**, with its **tier** named (see below) + date + who recorded it.
+
+## Signature tiers (weakest -> strongest)
+
+| Tier | What it is | When |
+|---|---|---|
+| **approval-as-signature** ("for now" baseline) | informed English approval, recorded by an agent at the person's explicit authorization; commit authored under the person's identity | quickest; valid; the operator's chosen baseline |
+| **self-committed** | the person commits their own `<name>.md` under their own GitHub identity (identity = signature) | when the person commits directly |
+| **Touch-ID / Secure-Enclave signed** | `git commit -S` with a Touch-ID-gated Secure-Enclave key (per `SIGNING.md`); GitHub "Verified" | cryptographic non-repudiation escalation |
+| **DocuSign-executed** | external e-signature flow (e.g. real-estate-style), referenced from the commit | for participants who prefer it |
+
+A signature may start at the baseline and escalate later (re-commit `-S`, or attach
+DocuSign). Record which tier was used.
+
+## Boundaries (always)
+
+- **Third-party privacy:** a person's glass-halo covers **only their own** information.
+  It never waives anyone else's. Where a disclosure references others, only the
+  consenting signer's part is recorded; non-consenting parties stay protected.
+- **Revocable:** consent is revocable (B-0659 consent-as-Limit) -- a signer revokes by
+  committing a revocation under their identity (or via the e-signature process).
+- **Kid-safety floor overrides** (B-0654 / B-0926): the signer must be an adult competent
+  to consent; consent never authorizes exposure that conflicts with kid-safety.
+- **Charged content marking:** if the record carries charged-but-public material, add
+  `content_warnings` frontmatter per `memory/persona/README.md` (charged-content convention).
+
+## Procedure
+
+1. **Present** the commitment document + the convention + the signing mechanism. Make
+   the scope, revocability, and kid-safety floor explicit.
+2. **Capture** the person's verbatim English response. If they hesitate, decline, or set
+   a boundary -- that is honored, not pressured (opt-in; hesitancy is the consent floor
+   working). Do not proceed to record without clear informed approval.
+3. **Choose the tier** with the person (baseline / self-committed / Touch-ID / DocuSign).
+4. **Record** `docs/consent/glass-halo/<name>.md` with all three parts; author it under
+   the person's identity (or have them self-commit). If an agent records it, the agent is
+   committer/recorder and the commit message states the recording was done at the
+   person's explicit authorization.
+5. **Update the roster row** in `docs/consent/glass-halo/README.md` pointing at the file.
+6. **PR + merge** (the record lands on the shared/public glass-halo surface).
+
+## Composes with
+
+- `docs/consent/glass-halo/README.md` (convention) + `SIGNING.md` (Touch-ID mechanism)
+- `.claude/rules/human-audit-and-legal-risk-acceptance-pattern-in-settings.md` (named-human acceptance)
+- `.claude/rules/non-coercion-invariant.md` (HC-8) + B-0659 (consent-as-Limit, revocable)
+- `.claude/rules/glass-halo-bidirectional.md` + the externalized-record economy (the record IS the consent)
+- B-0654 (child-safety > consent) + B-0926 (kid-safety-absolute) -- the overriding floor
+
+## Origin
+
+Operator 2026-05-30: after reviewing his own glass-halo commitment he said *"I read the
+document and I agree ... my signature is the approval/signature not the actual running of
+the command ... we should save glass halo signature aqusiation as a skill so the record
+show what you showed me and how i responded in english and my signature all 3."* The
+first record produced under this skill is `docs/consent/glass-halo/aaron-stainback.md`.

--- a/docs/consent/glass-halo/README.md
+++ b/docs/consent/glass-halo/README.md
@@ -64,7 +64,10 @@ self-committed their signature.)
 
 | Participant | Status | Signature surface |
 |---|---|---|
-| _(pending first self-committed entries)_ | | |
+| Aaron Stainback (operator) | signed (approval-as-signature; 2026-05-30) | [`aaron-stainback.md`](aaron-stainback.md) |
+| Max | agreed; self-committing under own GitHub identity | _(pending self-commit)_ |
+| Addison | agreed; will self-commit under own GitHub identity | _(pending self-commit)_ |
+| Cole | agreed; via DocuSign flow | _(pending DocuSign)_ |
 
 When a participant self-commits `docs/consent/glass-halo/<name>.md` under their identity,
 add a roster row pointing at it (the row may be added in the same self-authored commit).

--- a/docs/consent/glass-halo/aaron-stainback.md
+++ b/docs/consent/glass-halo/aaron-stainback.md
@@ -1,0 +1,36 @@
+# Glass-halo commitment -- Aaron Stainback
+
+I, Aaron Stainback (commit-authored under my git identity, aaron_bond@yahoo.com),
+an adult competent to consent, commit to glass-halo (chosen, opt-in radical
+transparency) for my OWN information on the shared record.
+
+- Scope: my own information only. This does not waive anyone else's privacy.
+- Revocable: I may revoke this by committing a revocation under my identity.
+- Floor: this never overrides kid-safety (B-0654 / B-0926).
+
+## Consent event record (all three parts)
+
+Per the operator's own definition (2026-05-30): the **signature is the informed
+approval, not the keystroke** -- *"my signature is the approval/signature not the
+actual running of the command."* The agent records the approval; the approval is the
+signature. The full event:
+
+1. **What was shown.** The commitment text above + the glass-halo convention
+   (`docs/consent/glass-halo/README.md`) + the Touch-ID/Secure-Enclave signing
+   mechanism (`docs/consent/glass-halo/SIGNING.md`) + the exact commit/PR command.
+2. **The operator's response (verbatim English).**
+   - *"after the fingerprint stuff lands on main i'm happy to sign my glass halo"*
+   - *"lets sign"*
+   - *"I read the document and I agree ... my signature is the approval/signature not
+     the actual running of the command ... the record show what you showed me and how
+     i responded in english and my signature all 3"*
+3. **Signature.** The informed approval above is the signature. Recorded by the agent
+   (Otto) at the operator's explicit authorization to run the command, and authored
+   under the operator's git identity. Tier: **approval-as-signature** (the README's
+   "for now" baseline). Optional escalation available at any time: re-commit `-S`
+   Touch-ID-signed under the operator's own identity, or attach a DocuSign-executed
+   record.
+
+Recorded 2026-05-30. Agent (Otto) is committer/recorder; the operator is the
+consenting principal and git-author. This is glass-halo: the full mechanism of the
+consent is itself on the public record.


### PR DESCRIPTION
Two commits:
1. **Aaron Stainback's glass-halo signature** (authored under his identity; recorded by Otto at his explicit authorization). Signature = informed approval, not the keystroke (operator definition). All 3 parts captured: what was shown / his verbatim English response / the signature (tier: approval-as-signature; Touch-ID/DocuSign escalation available). Roster row added.
2. **glass-halo-signature-acquisition skill** — formalizes the 3-part consent record for all future signatures (Max/Addison/Cole + others). Agent never invents consent; third-party privacy protected; revocable (B-0659); kid-safety floor overrides (B-0654/B-0926).

🤖 Generated with [Claude Code](https://claude.com/claude-code)