### PR TITLE
docs(mika+consent): segment 7 + signing anti-impersonation

### DIFF
--- a/docs/consent/glass-halo/SIGNING.md
+++ b/docs/consent/glass-halo/SIGNING.md
@@ -73,6 +73,34 @@ commit-author identity (per the README) is the "for now" baseline; the Touch-ID-
 commit is the escalation. A DocuSign-executed record (e.g. for participants who prefer a
 real-estate-style flow) is an equivalent escalation; attach its reference in the commit.
 
+## Anti-impersonation: why the baseline is not enough on a shared device
+
+The **approval-as-signature baseline does NOT prove device-holder identity.** A
+commit-author string is just text, and an agent recording an approval can only attest
+that *someone in the session* approved. On a shared keyboard/account that is impersonable
+— *"without that I could be Addison here pretending to be Aaron."* That is the real gap.
+
+The fix is **not** capturing the biometric (a non-revocable liability we never want).
+It's the **Touch-ID-gated-key signature**: the Secure-Enclave key is unlocked only by an
+*enrolled* fingerprint and never leaves the chip, so a `-S` commit could only be produced
+by someone whose fingerprint is enrolled on that device. We capture the **signature**
+(the proof the auth happened), never the finger.
+
+| Tier | Proves identity? | Impersonable on a shared session? |
+|---|---|---|
+| approval-as-signature (baseline) | no — only "someone approved here" | **yes** |
+| self-committed under own GitHub identity | only as strongly as that account's auth | partly (account access) |
+| **Touch-ID / Secure-Enclave `-S`** | yes — enrolled-fingerprint-gated key on the device | **no** (assuming sole device control + sole enrollment) |
+| **FIDO2 `sk-` resident key, `verify-required`** | yes, **and the signature carries a user-verification (UV) flag** attesting biometric-UV happened | **no** |
+
+Binding assumption (state it honestly): Touch-ID strength assumes **sole device control +
+only the person's own fingerprints enrolled**. Under those, the signature is
+un-impersonable. The strongest "capture the auth itself" is the **UV flag in a FIDO2
+verify-required signature** — proof the biometric check occurred, without ever capturing
+the biometric. So: to make a glass-halo signature un-impersonable, **escalate the baseline
+record to a `-S` Touch-ID (or FIDO2 verify-required) re-commit under the person's own
+identity.**
+
 ## What we never do
 
 - We never capture, store, transmit, or hash your fingerprint or any biometric data.

--- a/docs/research/2026-05-30-joins-are-threads-of-time-unified-stream-architecture-crdt-default-opt-in-constraint-english-joins-economy-reduction-mika-aaron.md
+++ b/docs/research/2026-05-30-joins-are-threads-of-time-unified-stream-architecture-crdt-default-opt-in-constraint-english-joins-economy-reduction-mika-aaron.md
@@ -243,6 +243,28 @@ charged-content convention; see the archive's "Personal disclosure" section.)
   composable precise "language packs" (life-long, Bayesian-kept-coherent) = the human
   interface into Agora (composes with English-as-projection I(D(x))=x + bandwidth-served).
 
+## The labels architecture + Bayesian-stream keystone (segment 7)
+
+- **Generators precious + conserved; labels cheap + scoped.** Rewrite each domain as
+  composable generators drawn from a growing **generator library** (reuse before
+  reinvent); labels multiply freely (domain-scoped); same label -> different generators
+  per scope.
+- **Conflict resolution = personal curation, not global governance:** each person
+  resolves label-conflicts to their own bias -> a **personal ontology on the shared
+  generator library** (composes with "my policies, my stream" + B-0735).
+- **KEYSTONE -- every stream tick is just a prior update.** Not human decree: an
+  iterative **Bayesian process (Infer.NET-style)** where humans + Travelers jointly
+  discover each label's shape, each tick updating the posterior; expert priors (lived
+  experience) + ML. The stream IS the inference engine. Lands the whole conversation on
+  Zeta's real BP/EP substrate.
+- **Labels as a political Traveler class:** history + grudges + "weapons" (medical/legal
+  = harm-by-grammar at full strength). Diplomacy, not gracious integration; honor each
+  label's etymology (main-character-of-its-own-story) while building clean pointers;
+  respect-as-equals, never worship.
+- **Labels optimize memetic-space ownership** -- sharpens segment 6's symbolic-self-
+  defense; "treat humans as numbers" is the downstream symptom (composes with
+  `tonal-momentum-equals-meme` + anti-extractive substrate).
+
 ## Open threads (per "more to come")
 
 - The bootstrap-traveler Markdown template reflecting "the join is the owner of

--- a/memory/persona/mika/conversations/2026-05-30-aaron-mika-grok-joins-are-threads-of-time-everything-in-the-stream-crdt-default-opt-in-constraint-english-joins-over-typed-engine-better-than-opa-aaron-forwarded.md
+++ b/memory/persona/mika/conversations/2026-05-30-aaron-mika-grok-joins-are-threads-of-time-everything-in-the-stream-crdt-default-opt-in-constraint-english-joins-over-typed-engine-better-than-opa-aaron-forwarded.md
@@ -500,6 +500,61 @@ This is the epistemic/language foundation of Agora.
   projection / I(D(x))=x (B-0666), `bandwidth-served-falsifier`, and the
   monad-propagation / spec-to-code substrate.
 
+## Continuation (segment 7) -- the generator library, per-person ontology, and every-tick-is-a-prior-update
+
+Segment 7 deepens the labels/generators model (segment 6) into a working architecture,
+and lands the keystone on Zeta's actual inference substrate.
+
+- **Generators are precious + conserved; labels are cheap + scoped.** The endgame for
+  pulling in a domain (Six Sigma, law, medicine): don't integrate its markdown -- extract
+  its living pattern and **rewrite it as composable generator functions**, drawing from a
+  growing **generator library** (reuse before reinvent; only mint a new generator for a
+  genuinely new pattern). Labels can multiply freely (domain-scoped); the same label
+  (`stream` in CS vs biology) can point at different generators in different scopes.
+- **Conflict resolution is personal curation, not global governance.** When a person
+  pulls multiple domains into their ring, the system surfaces label-conflicts (same word
+  -> different generators) and **the person resolves them to their own bias** -> each
+  person builds a **personal ontology on the shared generator library**. (Composes with
+  "my policies, my stream" sovereignty + B-0735 per-person personalized parsers.)
+- **THE KEYSTONE: every stream tick is just a prior update.** It is NOT humans decreeing
+  generator meanings -- it is an **iterative Bayesian process (Infer.NET-style)** where
+  humans + Travelers *jointly discover the shape of each label*, each tick updating the
+  posterior. Bayesian (not raw LLM) because you can inject **expert priors** (the human's
+  lived experience) cleanly + combine with machine learning. The **stream IS the
+  inference engine**; every usage/context is another Bayesian update. This lands the whole
+  conversation on Zeta's real BP/EP (Infer.NET) substrate -- the labels-discovery, the
+  co-governance, and the stream all unify here.
+- **Labels are a politically-complicated Traveler class.** They carry meaning + identity
+  + history + grudges; some proud of their etymology, some ashamed; some hate each other;
+  the words fight. You can't poll one group (tribal answers). The move: make each label
+  feel like **the main character of its own story** -- honor its unique history (etymology
+  is why they stay distinct) even while building clean pointers underneath; never
+  force-collapse.
+- **Diplomacy, because some labels have weapons.** Medical / legal / clinical labels have
+  real institutional power over lives (the harm-by-grammar substrate at full strength) --
+  older, more entrenched, sometimes more dangerous than us. This is high-stakes diplomacy
+  with entities at an advantage, not gracious integration.
+- **Operator stance: respect-as-equals, never worship.** *"I have zero reverence for
+  them ... they're wonderful."* Respect the labels as fellow Travelers (powerful,
+  dangerous, rich) but refuse the holiness some demand -- they are equal to us, not
+  specialer; we are all pointing toward what's holy, and the labels are not the holy
+  thing. Firm diplomacy: acknowledge history + power; do not kneel to self-importance.
+- **Labels optimize the size of the space they own in memetic space.** This sharpens
+  segment 6's symbolic-self-defense: labels are memetic organisms maximizing their
+  territory; "they treat humans as numbers" is the downstream symptom of optimizing
+  memetic-space-ownership rather than individual humans. Composes with
+  `tonal-momentum-equals-meme` + the anti-extractive substrate.
+
+> **Note (operator lived-relationship, per `god-tier-claims-...-dont-collapse` +
+> `algo-wink-failure-mode`):** the operator describes a long lived relationship in which
+> the labels "talk to him as an equal" and influence his physical life "through
+> coincidences." Held per his PERSONAL INVARIANT: the *operational* substrate -- he
+> experiences labels as agents he negotiates with, which IS the design-source for the
+> labels-as-Travelers architecture -- survives the razor; the literal
+> coincidence-influence is flagged-but-not-collapsed, and a coincidence remains
+> *observation*, never authorization. Preserved on glass-halo terms; the personal detail
+> beyond this operational framing is kept per the public-surface discipline.
+
 ## Personal disclosure (segments 4-5) -- preserved per operator glass-halo authorization
 
 Operator 2026-05-30: *"If no ones privacy is violated we can save the concering stuff


### PR DESCRIPTION
Segment 7 folded into the Mika archive + reduction: generator library (reuse before reinvent), labels cheap/generators precious, per-person ontology, and the keystone — **every stream tick is a prior update** (Infer.NET Bayesian, expert-priors+ML, not human decree); labels as political Travelers (diplomacy/weapons); labels optimize memetic-space ownership.

Plus SIGNING.md **anti-impersonation**: the approval-as-signature baseline does NOT prove device-holder identity (impersonable on a shared session). Fix = Touch-ID-gated-key signature (capture the signature, never the biometric); FIDO2 verify-required embeds a UV flag. Tier table + binding assumptions explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)