### PR TITLE
feat(B-0944 slice 1): TS tri-boolean digital qubit (distribution impl)

### DIFF
--- a/src/Core.TypeScript/tri-boolean/index.ts
+++ b/src/Core.TypeScript/tri-boolean/index.ts
@@ -1,0 +1,3 @@
+// Tri-boolean core primitive -- public distribution surface (B-0944, TS).
+export * from './types';
+export * from './tri-boolean';

--- a/src/Core.TypeScript/tri-boolean/tri-boolean.test.ts
+++ b/src/Core.TypeScript/tri-boolean/tri-boolean.test.ts
@@ -1,0 +1,66 @@
+import { test, expect } from 'bun:test';
+import { T, F, N } from './types';
+import {
+  fromBool, held, isLiving, isCertain, cooperate, measure,
+  mapTri, bindTri, notTri, andTri, orTri, eq,
+} from './tri-boolean';
+
+test('constructors + predicates', () => {
+  expect(eq(fromBool(true), T)).toBe(true);
+  expect(eq(fromBool(false), F)).toBe(true);
+  expect(eq(held(), N)).toBe(true);
+  expect(isLiving(N)).toBe(true);
+  expect(isLiving(T)).toBe(false);
+  expect(isCertain(T)).toBe(true);
+  expect(isCertain(N)).toBe(false);
+});
+
+test('cooperate never collapses (preserves Null; identity on all states)', () => {
+  expect(eq(cooperate(N), N)).toBe(true);
+  expect(eq(cooperate(T), T)).toBe(true);
+  expect(eq(cooperate(F), F)).toBe(true);
+});
+
+test('measure: certain cells resolve; living(Null) is NOT silently collapsed (feedback surfaced)', () => {
+  expect(measure(T)).toEqual({ ok: true, value: true });
+  expect(measure(F)).toEqual({ ok: true, value: false });
+  const m = measure(N);
+  expect(m.ok).toBe(false);
+  if (!m.ok) expect(m.feedback.reason).toBe('collapsed-living-uncertainty');
+});
+
+test('null-monad: Null propagates through map and bind (held stays held)', () => {
+  expect(eq(mapTri(N, (b) => !b), N)).toBe(true);
+  expect(eq(mapTri(T, (b) => !b), F)).toBe(true);
+  expect(eq(mapTri(F, (b) => !b), T)).toBe(true);
+  expect(eq(bindTri(N, () => T), N)).toBe(true);
+  expect(eq(bindTri(T, (b) => fromBool(!b)), F)).toBe(true);
+});
+
+test('map identity law: mapTri(t, x => x) === t for all three states', () => {
+  for (const t of [T, F, N]) expect(eq(mapTri(t, (b) => b), t)).toBe(true);
+});
+
+test('Kleene NOT (unknown stays unknown)', () => {
+  expect(eq(notTri(T), F)).toBe(true);
+  expect(eq(notTri(F), T)).toBe(true);
+  expect(eq(notTri(N), N)).toBe(true);
+});
+
+test('Kleene AND: F dominates; Null only when no F present', () => {
+  expect(eq(andTri(F, N), F)).toBe(true);
+  expect(eq(andTri(N, F), F)).toBe(true);
+  expect(eq(andTri(T, N), N)).toBe(true);
+  expect(eq(andTri(N, N), N)).toBe(true);
+  expect(eq(andTri(T, T), T)).toBe(true);
+  expect(eq(andTri(T, F), F)).toBe(true);
+});
+
+test('Kleene OR: T dominates; Null only when no T present', () => {
+  expect(eq(orTri(T, N), T)).toBe(true);
+  expect(eq(orTri(N, T), T)).toBe(true);
+  expect(eq(orTri(F, N), N)).toBe(true);
+  expect(eq(orTri(N, N), N)).toBe(true);
+  expect(eq(orTri(F, F), F)).toBe(true);
+  expect(eq(orTri(T, F), T)).toBe(true);
+});

--- a/src/Core.TypeScript/tri-boolean/tri-boolean.ts
+++ b/src/Core.TypeScript/tri-boolean/tri-boolean.ts
@@ -1,0 +1,88 @@
+// Tri-boolean digital qubit -- operations (B-0944, TS / distribution).
+import { type Tri, T, F, N, type MeasureResult } from './types';
+
+/** Construct a certain cell from a boolean. */
+export const fromBool = (b: boolean): Tri => (b ? T : F);
+
+/** Construct the held (Null / living-uncertainty) cell. */
+export const held = (): Tri => N;
+
+/** True iff the cell is living (Null / held superposition). */
+export const isLiving = (t: Tri): boolean => t.s === 'N';
+
+/** True iff the cell is certain (True or False). */
+export const isCertain = (t: Tri): boolean => t.s !== 'N';
+
+/** Structural equality on the three-valued state. */
+export const eq = (a: Tri, b: Tri): boolean => a.s === b.s;
+
+/** cooperate: engage WITHOUT collapsing. Identity on every state -- crucially preserves
+ *  Null. The wonder-compression-safe operation: build shared structure ABOUT the cell,
+ *  never collapse its living uncertainty. */
+export const cooperate = (t: Tri): Tri => t;
+
+/** measure: the ONLY collapsing operation. Certain cells resolve to their boolean; a
+ *  living (Null) cell is NOT silently collapsed -- the forbidden move is surfaced as
+ *  feedback (collapsing a living traveler = the Rehoboam failure). */
+export const measure = (t: Tri): MeasureResult => {
+  switch (t.s) {
+    case 'T':
+      return { ok: true, value: true };
+    case 'F':
+      return { ok: true, value: false };
+    case 'N':
+      return { ok: false, feedback: { reason: 'collapsed-living-uncertainty' } };
+  }
+};
+
+/** null-monad map: apply fn to a certain cell's boolean; Null propagates unchanged (held). */
+export const mapTri = (t: Tri, fn: (b: boolean) => boolean): Tri => {
+  switch (t.s) {
+    case 'T':
+      return fromBool(fn(true));
+    case 'F':
+      return fromBool(fn(false));
+    case 'N':
+      return N;
+  }
+};
+
+/** null-monad bind: chain a Tri-producing fn over a certain cell; Null propagates unchanged. */
+export const bindTri = (t: Tri, fn: (b: boolean) => Tri): Tri => {
+  switch (t.s) {
+    case 'T':
+      return fn(true);
+    case 'F':
+      return fn(false);
+    case 'N':
+      return N;
+  }
+};
+
+// --- Kleene three-valued logic (Null = "unknown"; propagates per Kleene/Lukasiewicz) ---
+
+/** Kleene NOT: T<->F; unknown(Null) stays unknown. */
+export const notTri = (t: Tri): Tri => {
+  switch (t.s) {
+    case 'T':
+      return F;
+    case 'F':
+      return T;
+    case 'N':
+      return N;
+  }
+};
+
+/** Kleene AND: F dominates (F AND anything = F); else Null if any operand is Null; else T. */
+export const andTri = (a: Tri, b: Tri): Tri => {
+  if (a.s === 'F' || b.s === 'F') return F;
+  if (a.s === 'N' || b.s === 'N') return N;
+  return T;
+};
+
+/** Kleene OR: T dominates (T OR anything = T); else Null if any operand is Null; else F. */
+export const orTri = (a: Tri, b: Tri): Tri => {
+  if (a.s === 'T' || b.s === 'T') return T;
+  if (a.s === 'N' || b.s === 'N') return N;
+  return F;
+};

--- a/src/Core.TypeScript/tri-boolean/types.ts
+++ b/src/Core.TypeScript/tri-boolean/types.ts
@@ -1,0 +1,37 @@
+// Tri-boolean core primitive -- the digital qubit cell (B-0944).
+//
+// Three-valued state: True | False | Null. Null is the HELD living-uncertainty
+// (superposition) state -- it is never silently collapsed. measure() is the only
+// collapsing operation, and collapsing a living (Null) cell is surfaced as feedback
+// rather than performed silently (asymmetric-authorship / Result<T, TFeedback>).
+//
+// Spec source: memory/persona/mika/conversations/2026-05-30-mika-grok-driver-swap-arc-
+//   ...-uncertainty-in-priors-aaron-forwarded.md (batch 6).
+// Composes: .claude/rules/monad-propagation-pattern-cross-language-substrate-shape.md
+//   + .claude/rules/ople-primitives-surface-t-and-tfeedback-not-just-t-...md.
+//
+// This is the TS (distribution) implementation. F#/C#/Rust parity impls are the other
+// non-Byzantine oracles for the "summonable BFT" cross-language consensus (B-0944).
+
+/** The three-valued state. 'N' (Null) is the held / superposed living-uncertainty state. */
+export type Tri =
+  | { readonly s: 'T' }
+  | { readonly s: 'F' }
+  | { readonly s: 'N' };
+
+/** True. */
+export const T: Tri = { s: 'T' };
+/** False. */
+export const F: Tri = { s: 'F' };
+/** Null = held superposition / living uncertainty. Never silently collapsed. */
+export const N: Tri = { s: 'N' };
+
+/** Feedback surfaced when measure() is asked to collapse a living (Null) cell -- the
+ *  forbidden move, surfaced rather than silently performed. */
+export type CollapseFeedback = { readonly reason: 'collapsed-living-uncertainty' };
+
+/** Result of measure(): Ok(boolean) for already-certain cells; Err(feedback) when asked
+ *  to collapse a living (Null) cell. */
+export type MeasureResult =
+  | { readonly ok: true; readonly value: boolean }
+  | { readonly ok: false; readonly feedback: CollapseFeedback };


### PR DESCRIPTION
First slice of **B-0944** (tri-boolean core primitives), **TS-first** per Aaron's directive ("we can start with ts that's our distribution"). Begins the **summonable-BFT** multi-language build — TS is oracle #1 of four (TS/F#/C#/Rust); cross-language compiler-parity = the non-Byzantine consensus.

**The digital-qubit cell** (`src/Core.TypeScript/tri-boolean/`): `Tri = True | False | Null`, where **Null is the held living-uncertainty** (superposition), never silently collapsed.
- `cooperate()` = engage without collapsing (identity; preserves Null) — wonder-compression-safe.
- `measure()` = the **only** collapsing op; certain cells resolve, but collapsing a living(Null) cell is **surfaced as `CollapseFeedback`** (Result<T,TFeedback> / asymmetric-authorship), not done silently — collapsing a living traveler is the Rehoboam failure, so the primitive makes it loud.
- **null-monad** `mapTri`/`bindTri`: Null propagates unchanged (held).
- **Kleene** three-valued logic: `notTri`/`andTri`/`orTri` (F dominates AND, T dominates OR, Null = unknown).

Home follows the Zeta-ID multi-language-core-primitive precedent (`src/Core.TypeScript/zeta-id/` + `tests/cross-verification/zeta-id/compare.ts`); F#/C#/Rust parity + the cross-verification harness (the summonable-BFT ballot) are the next slices. **8/8 bun tests pass; tsc clean** (0 tri-boolean errors). Files: `types.ts`, `tri-boolean.ts`, `index.ts`, `tri-boolean.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)