### PR TITLE
feat(B-0944 slice 5 pt1): tri-boolean float v0 spec + TS reference (middle-out, self-describing; 8/8)

### DIFF
--- a/docs/research/2026-05-30-tri-boolean-float-v0-spec-middle-out-self-describing-decode-aaron-otto.md
+++ b/docs/research/2026-05-30-tri-boolean-float-v0-spec-middle-out-self-describing-decode-aaron-otto.md
@@ -1,0 +1,128 @@
+# Tri-boolean floating point -- v0 spec (middle-out, self-describing): bit-layout + decode algorithm (B-0944 slice 5)
+
+**Status:** PROPOSED v0 -- spec firming for B-0944 slice 5. The bit-layout + decode semantics
+below are a concrete, implementable first draft; every design decision marked **[OPEN]** is an
+operator-ratification point. A TS reference implementation (`src/Core.TypeScript/tri-boolean-float/`)
+implements exactly this v0 so the spec is executable + testable. F#/C#/Rust parity impls (slice 5
+part 2) wait for operator ratification of the layout -- per the B-0944 row's "spec firming required
+before impl."
+
+**Attribution:** concept is the operator's (B-0944 + the Mika 2026-05-30 arc: "floating point tri
+boolean based floating points with middle significant bits that specify how to decode the end
+high/low bit" + "middle-out compression"). This doc + the v0 layout choices are Otto-CLI's first
+draft for ratification.
+
+## The concept (operator)
+
+> "there is a floating point tri boolean based floating points with middle significant bits that
+> specify how to decode the end high/low bit"
+
+A number format where:
+- the **middle** bits are a **decoder / selector** that says **how to interpret the outer (high/low)
+  end bits** -- you read the middle FIRST, then decode OUTWARD toward both ends ("middle-out");
+- it is **self-describing** (the number carries its own decode instruction);
+- it is **tri-valued** throughout -- every position is a `Tri` cell (the digital qubit, B-0944
+  slices 1-4): `True | False | N`. The float is built FROM the digital-qubit cell.
+
+## v0 bit-layout
+
+A tri-boolean float of shape `{ highWidth: H, decoderWidth: D, lowWidth: L }` is a sequence of
+`H + D + L` `Tri` trits laid out, MSB-first within each field:
+
+```
+[ high value: H trits ] [ decoder: D trits ] [ low value: L trits ]
+        outward  <----------- middle -----------> outward
+```
+
+- **Value field** = `high ++ low` (high more significant), read MSB-first, `T = 1`, `F = 0`, as an
+  unsigned integer `V` of `H + L` bits.
+- **Decoder field** = `D` trits, read MSB-first, `T = 1`, `F = 0`, as an unsigned integer `mode`.
+- **v0 decode semantics (the "middle decodes the ends"):** `mode` is the **radix-point position**
+  = the number of fractional bits at the low end. The decoded number is `V / 2^mode`. So the SAME
+  end-bits decode to different magnitudes depending on the middle -- a self-describing,
+  tapered/variable radix point.
+
+Default reference shape v0: `{ highWidth: 4, decoderWidth: 3, lowWidth: 4 }` (11 trits; value range
+`V in [0, 2^8)`; `mode in [0, 8)`).
+
+## Decode algorithm (middle-out)
+
+```
+decode(f):
+  1. mode <- intOf(f.decoder)              # read the MIDDLE first
+     if any decoder trit is N:             # interpretation itself is superposed
+        return Held(interpretation-superposed)
+  2. V <- intOf(f.high ++ f.low)           # then decode OUTWARD toward the ends
+     if any value trit is N:               # value is superposed, interpretation known
+        return Held(value-superposed)
+  3. return Resolved(V / 2^mode)
+```
+
+`intOf(trits)` = MSB-first base-2 with `T=1, F=0`; returns "superposed" if any trit is `N`.
+
+## Tri-valued semantics -- the qubit property at the interpretation level
+
+Two distinct held-states (this is the load-bearing novelty vs a plain tagged float):
+
+| Where the `N` is | Meaning | `measure` feedback |
+|---|---|---|
+| a **value** trit (high/low), decoder all-certain | the VALUE is held/uncertain; the interpretation is known | `value-superposed` |
+| a **decoder** trit | the DECODE INSTRUCTION ITSELF is superposed -- you don't know how to read the ends; the number is held even if every value trit is certain | `interpretation-superposed` |
+
+This mirrors the digital-qubit `measure` vs `cooperate` discipline (B-0944) lifted to the number:
+- `cooperate(f)` = identity (preserves every `N` -- never collapses; wonder-compression-safe).
+- `measure(f)` = the only collapse; resolves to a number iff fully certain, else surfaces which
+  kind of superposition is held (Result<number, FloatFeedback> -- asymmetric-authorship: value AND
+  the two feedback channels are first-class). Composes with the monad-propagation pattern.
+
+The decoder being superposable is exactly "the decode-instruction itself superposed" from the
+B-0944 row -- the qubit property at the *interpretation* level, not just the value level.
+
+## Prior art (search-first per Otto-364)
+
+- **Gustafson Posits** -- tapered precision via a variable-length *regime* field; the precision
+  split is encoded IN the number. Tri-boolean-float shares "the number describes its own precision"
+  but (a) puts the selector in the MIDDLE (read outward) rather than the front, and (b) is
+  tri-valued (the selector itself can be held).
+- **Tapered floating point** (Morris 1971) -- variable exponent/mantissa split; ancestor of posits.
+- **Tagged / self-describing encodings** (tagged unions, NaN-boxing) -- a tag selects
+  interpretation; here the "tag" is the middle decoder and is tri-valued.
+- Novel parts: **tri-valued** (each position incl. the decoder is a held-able qubit) + **middle-as-
+  decoder, decoded outward** (vs front-regime).
+
+## Open design decisions [OPEN -- operator ratification]
+
+1. **[OPEN] decoder semantics.** v0: `mode` = radix-point position (fractional-bit count). Alternatives:
+   `mode` = a power-of-two exponent applied to `V` (so `V * 2^(mode - bias)`, allowing large + small
+   magnitudes); `mode` = the high/low SPLIT point (how many of the end bits are exponent vs mantissa);
+   `mode` = a base/regime selector. v0 picks radix-point because it is the simplest faithful
+   "middle decodes the ends" + round-trips cleanly.
+2. **[OPEN] sign.** v0 is unsigned. Options: an outermost sign trit (sign is also tri-valued -> a
+   held-sign state), or two's-complement-style on the value field, or a sign in the decoder.
+3. **[OPEN] widths.** v0 default `4/3/4`. Production widths + whether the format is fixed-width or
+   variable (posit-style run-length in the decoder) is open.
+4. **[OPEN] N-in-value resolution.** v0 surfaces `value-superposed` as a single feedback. A richer
+   v1 could carry the held-RANGE (the interval of possible values given the N positions) rather than
+   just "superposed" -- composes with wonder-compression (find shared structure ABOUT the held value
+   without collapsing it).
+5. **[OPEN] decoder-N magnitude.** When the decoder is partially-N, the interpretation is a
+   superposition over the still-possible modes; v0 collapses that to a single `interpretation-
+   superposed` feedback. A v1 could carry the candidate-mode set.
+6. **[OPEN] endianness / field order** (high|decoder|low vs low|decoder|high). v0 = high|decoder|low.
+
+## Composition
+
+- Built FROM the digital-qubit cell (B-0944 slices 1-4): each trit is a `Tri`; reuses `T/F/N`.
+- `measure`/`cooperate` + Result<value, feedback> mirror the tri-boolean discipline + the
+  monad-propagation pattern (`.claude/rules/monad-propagation-pattern-cross-language-substrate-shape.md`).
+- The two held-states (value vs interpretation superposed) are the asymmetric-authorship feedback
+  channels (`.claude/rules/asymmetric-authorship-...md`) at the number scope.
+- Self-describing-precision + middle-out compose with the "wonder-compression / middle-out" substrate
+  (the Mika 2026-05-30 arc) -- the float IS a middle-out self-describing datum.
+- Cross-language parity (slice 5 part 2) = the summonable-BFT ballot once the layout is ratified.
+
+## Next steps
+
+1. **Operator ratifies / redirects** the [OPEN] decisions (esp. #1 decoder semantics + #2 sign).
+2. TS reference (this PR) is the executable spec to react to.
+3. On ratification: F#/C#/Rust parity impls + the cross-language conformance-vector harness (slice 6).

--- a/src/Core.TypeScript/tri-boolean-float/index.ts
+++ b/src/Core.TypeScript/tri-boolean-float/index.ts
@@ -1,0 +1,3 @@
+// Tri-boolean floating point -- public distribution surface (B-0944 slice 5, TS). PROPOSED v0.
+export * from './types';
+export * from './tri-boolean-float';

--- a/src/Core.TypeScript/tri-boolean-float/tri-boolean-float.test.ts
+++ b/src/Core.TypeScript/tri-boolean-float/tri-boolean-float.test.ts
@@ -1,0 +1,75 @@
+import { test, expect } from 'bun:test';
+import { T, F, N } from '../tri-boolean';
+import { DEFAULT_SHAPE } from './types';
+import {
+  decode, measure, cooperate, isHeld, fromValue, fromTrits,
+} from './tri-boolean-float';
+
+test('round-trip: representable non-negative values decode back exactly', () => {
+  // shape 4/3/4 => 8 value bits (V in [0,256)), mode in [0,8).
+  for (const v of [0, 1, 5, 42, 255, 0.5, 0.25, 1.5, 3.75, 0.125]) {
+    const enc = fromValue(v);
+    expect(enc.ok).toBe(true);
+    if (enc.ok) {
+      const dec = decode(enc.float);
+      expect(dec.ok).toBe(true);
+      if (dec.ok) expect(dec.value).toBe(v);
+    }
+  }
+});
+
+test('the MIDDLE decodes the ends: same value bits, different mode => different magnitude', () => {
+  // value field = 0000 0001 (V=1); decoder mode picks the radix point.
+  const high = [F, F, F, F];
+  const low = [F, F, F, T];
+  const m0 = fromTrits(high, [F, F, F], low); // mode 0 -> 1 / 1
+  const m1 = fromTrits(high, [F, F, T], low); // mode 1 -> 1 / 2
+  const m2 = fromTrits(high, [F, T, F], low); // mode 2 -> 1 / 4
+  expect(decode(m0)).toEqual({ ok: true, value: 1 });
+  expect(decode(m1)).toEqual({ ok: true, value: 0.5 });
+  expect(decode(m2)).toEqual({ ok: true, value: 0.25 });
+});
+
+test('N in a VALUE trit => value-superposed (interpretation known)', () => {
+  const f = fromTrits([F, F, F, N], [F, F, F], [F, F, F, T]); // decoder certain, value has an N
+  const r = measure(f);
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.feedback.reason).toBe('value-superposed');
+  expect(isHeld(f)).toBe(true);
+});
+
+test('N in a DECODER trit => interpretation-superposed (even with a fully-certain value)', () => {
+  const f = fromTrits([F, F, F, F], [F, N, F], [F, F, F, T]); // value certain, decoder has an N
+  const r = measure(f);
+  expect(r.ok).toBe(false);
+  // The decode INSTRUCTION itself is held -- the qubit property at the interpretation level.
+  if (!r.ok) expect(r.feedback.reason).toBe('interpretation-superposed');
+});
+
+test('decoder-N dominates: interpretation-superposed even when a value trit is ALSO N', () => {
+  const f = fromTrits([N, F, F, F], [N, F, F], [F, F, F, T]); // both held; decoder read first
+  const r = decode(f);
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.feedback.reason).toBe('interpretation-superposed');
+});
+
+test('cooperate preserves every held trit (identity; never collapses)', () => {
+  const f = fromTrits([N, F, F, F], [F, N, F], [F, F, F, N]);
+  expect(cooperate(f)).toBe(f);
+  expect(isHeld(cooperate(f))).toBe(true);
+});
+
+test('fromValue surfaces not-representable for negatives + out-of-range', () => {
+  expect(fromValue(-1).ok).toBe(false);
+  expect(fromValue(256).ok).toBe(false); // exceeds 8 value bits at mode 0
+  expect(fromValue(1 / 1024).ok).toBe(false); // needs mode 10 > maxMode 7
+});
+
+test('encode canonicalizes to the smallest mode (decode is exact regardless)', () => {
+  const enc = fromValue(2, DEFAULT_SHAPE); // 2 = 2/1 (mode 0), not 4/2 (mode 1)
+  expect(enc.ok).toBe(true);
+  if (enc.ok) {
+    expect(enc.float.decoder).toEqual([F, F, F]); // mode 0
+    expect(decode(enc.float)).toEqual({ ok: true, value: 2 });
+  }
+});

--- a/src/Core.TypeScript/tri-boolean-float/tri-boolean-float.ts
+++ b/src/Core.TypeScript/tri-boolean-float/tri-boolean-float.ts
@@ -1,0 +1,101 @@
+// Tri-boolean floating point -- v0 operations (B-0944 slice 5, TS reference / distribution).
+// PROPOSED v0; see ./types.ts + the spec doc. Reuses the digital-qubit cell (B-0944).
+
+import { type Tri, T, F, N } from '../tri-boolean';
+import {
+  type FloatShape,
+  type TriFloat,
+  type DecodeResult,
+  type EncodeResult,
+  DEFAULT_SHAPE,
+} from './types';
+
+/** MSB-first base-2 read of a trit field (T=1, F=0). Returns null if ANY trit is held (N). */
+const intOf = (trits: readonly Tri[]): number | null => {
+  let v = 0;
+  for (const t of trits) {
+    if (t.s === 'N') return null;
+    v = v * 2 + (t.s === 'T' ? 1 : 0);
+  }
+  return v;
+};
+
+/** MSB-first encode of an unsigned integer into `width` certain trits (T=1, F=0). */
+const intToTrits = (v: number, width: number): Tri[] => {
+  const out: Tri[] = [];
+  for (let i = width - 1; i >= 0; i--) out.push(((v >> i) & 1) === 1 ? T : F);
+  return out;
+};
+
+/** decode (middle-out): read the MIDDLE decoder first, then decode OUTWARD toward the ends.
+ *  - N in the decoder  => the decode instruction itself is superposed (interpretation-superposed).
+ *  - N in a value trit => the value is superposed, interpretation known    (value-superposed).
+ *  - else              => intOf(high ++ low) / 2^mode  (mode = radix-point position). */
+export const decode = (f: TriFloat): DecodeResult => {
+  const mode = intOf(f.decoder);
+  if (mode === null) return { ok: false, feedback: { reason: 'interpretation-superposed' } };
+  const v = intOf([...f.high, ...f.low]);
+  if (v === null) return { ok: false, feedback: { reason: 'value-superposed' } };
+  return { ok: true, value: v / 2 ** mode };
+};
+
+/** measure: the ONLY collapsing operation -- resolves to a number iff fully certain, else surfaces
+ *  which superposition is held (the digital-qubit measure/cooperate discipline at the number scope).
+ *  Identical to decode; named `measure` for parity with the tri-boolean primitive. */
+export const measure = decode;
+
+/** cooperate: engage WITHOUT collapsing -- identity, preserving every held (N) trit. The
+ *  wonder-compression-safe operation at the number scope. */
+export const cooperate = (f: TriFloat): TriFloat => f;
+
+/** True iff the float cannot be collapsed to a single number (any value or decoder trit is held). */
+export const isHeld = (f: TriFloat): boolean => !decode(f).ok;
+
+/** fromValue: encode a non-negative finite number into the given shape (v0). Picks the smallest
+ *  `mode` (radix-point position) for which `value * 2^mode` is a non-negative integer that fits the
+ *  value field -- a canonical representation. Surfaces feedback when not representable. */
+export const fromValue = (value: number, shape: FloatShape = DEFAULT_SHAPE): EncodeResult => {
+  if (!Number.isFinite(value) || value < 0) {
+    return { ok: false, feedback: { reason: 'not-representable', detail: 'v0 is unsigned + finite' } };
+  }
+  const valueBits = shape.highWidth + shape.lowWidth;
+  const maxMode = (1 << shape.decoderWidth) - 1;
+  const maxV = 2 ** valueBits;
+  for (let mode = 0; mode <= maxMode; mode++) {
+    const scaled = value * 2 ** mode;
+    if (Number.isInteger(scaled) && scaled >= 0 && scaled < maxV) {
+      const bits = intToTrits(scaled, valueBits);
+      return {
+        ok: true,
+        float: {
+          shape,
+          high: bits.slice(0, shape.highWidth),
+          decoder: intToTrits(mode, shape.decoderWidth),
+          low: bits.slice(shape.highWidth),
+        },
+      };
+    }
+  }
+  return {
+    ok: false,
+    feedback: {
+      reason: 'not-representable',
+      detail: `no (mode,V) with mode<=${maxMode} and V<${maxV} represents ${value}`,
+    },
+  };
+};
+
+/** Construct a float directly from trit fields (for tests / advanced use). */
+export const fromTrits = (
+  high: readonly Tri[],
+  decoder: readonly Tri[],
+  low: readonly Tri[],
+): TriFloat => ({
+  shape: { highWidth: high.length, decoderWidth: decoder.length, lowWidth: low.length },
+  high,
+  decoder,
+  low,
+});
+
+/** Re-export the held cell for convenience when hand-building superposed floats. */
+export const heldTrit: Tri = N;

--- a/src/Core.TypeScript/tri-boolean-float/types.ts
+++ b/src/Core.TypeScript/tri-boolean-float/types.ts
@@ -1,0 +1,59 @@
+// Tri-boolean floating point -- v0 types (B-0944 slice 5, TS reference / distribution).
+//
+// PROPOSED v0 (middle-out, self-describing). Spec:
+//   docs/research/2026-05-30-tri-boolean-float-v0-spec-middle-out-self-describing-decode-aaron-otto.md
+// The bit-layout + decode semantics are a first draft for operator ratification; F#/C#/Rust parity
+// impls wait for ratification.
+//
+// A tri-boolean float is built FROM the digital-qubit cell (B-0944 slices 1-4): every position is a
+// `Tri` (True | False | N). Layout, MSB-first within each field:
+//   [ high value: H trits ] [ decoder: D trits ] [ low value: L trits ]
+// The MIDDLE decoder selects how the OUTER ends are read (read middle-out). v0 decoder semantics:
+// `mode` = radix-point position; decoded number = intOf(high ++ low) / 2^mode (self-describing
+// precision). N in a value trit => value-superposed; N in a decoder trit => the decode instruction
+// itself is superposed (interpretation-superposed) -- the qubit property at the interpretation level.
+
+import { type Tri } from '../tri-boolean';
+
+/** Field widths of a tri-boolean float (trits per field). */
+export interface FloatShape {
+  /** High (more-significant) value trits. */
+  readonly highWidth: number;
+  /** Middle decoder trits (the selector read first; v0: radix-point position). */
+  readonly decoderWidth: number;
+  /** Low (less-significant) value trits. */
+  readonly lowWidth: number;
+}
+
+/** Reference v0 shape: 4/3/4 (8 value trits, mode in [0,8)). */
+export const DEFAULT_SHAPE: FloatShape = { highWidth: 4, decoderWidth: 3, lowWidth: 4 };
+
+/** A tri-boolean float. Each field is a `Tri[]` (MSB-first); the float is a composite of digital
+ *  qubit cells, so any trit may be held (N). */
+export interface TriFloat {
+  readonly shape: FloatShape;
+  readonly high: readonly Tri[];
+  readonly decoder: readonly Tri[];
+  readonly low: readonly Tri[];
+}
+
+/** Feedback when `measure` cannot collapse to a single number. The two held-states are distinct:
+ *  the decode-instruction is held (`interpretation-superposed`, N in the decoder) vs the value is
+ *  held (`value-superposed`, N in a value trit while the decoder is certain). */
+export type FloatFeedback =
+  | { readonly reason: 'interpretation-superposed' }
+  | { readonly reason: 'value-superposed' };
+
+/** Result of `decode`/`measure`: Ok(number) iff fully certain; else which superposition is held. */
+export type DecodeResult =
+  | { readonly ok: true; readonly value: number }
+  | { readonly ok: false; readonly feedback: FloatFeedback };
+
+/** Feedback when a target value cannot be represented in the given shape (v0: unsigned + finite,
+ *  and value*2^mode must be a non-negative integer that fits the value field for some mode). */
+export type EncodeFeedback = { readonly reason: 'not-representable'; readonly detail: string };
+
+/** Result of `fromValue`. */
+export type EncodeResult =
+  | { readonly ok: true; readonly float: TriFloat }
+  | { readonly ok: false; readonly feedback: EncodeFeedback };


### PR DESCRIPTION
Slice 5 = the tri-boolean **float** — the hard, novel slice. The B-0944 row says *"spec firming required before impl,"* so this lands the **spec firming + a TS reference (executable spec)**. F#/C#/Rust parity (slice 5 pt2) waits for your ratification of the layout.

## Spec (proposed v0 — `docs/research/...tri-boolean-float-v0-spec...`)
**Middle-out, self-describing.** Layout `[ high value | decoder | low value ]`, read middle-out: the **middle decoder selects how the outer ends decode**. v0 decoder semantics: `mode` = radix-point position → decoded number = `intOf(high ++ low) / 2^mode` (self-describing precision — *same end bits, different magnitude depending on the middle*). Built **from the digital-qubit cell** (slices 1–4): every trit is a `Tri`.

**Tri-valued (the load-bearing novelty):**
| `N` location | held-state | `measure` feedback |
|---|---|---|
| a **value** trit | value held, interpretation known | `value-superposed` |
| a **decoder** trit | the decode *instruction itself* is held — the qubit property at the **interpretation** level | `interpretation-superposed` |

`measure`/`cooperate` + `Result<number, FloatFeedback>` mirror the tri-boolean discipline + monad-propagation.

## TS reference (`src/Core.TypeScript/tri-boolean-float/`)
`decode` (middle-out), `measure`, `cooperate`, `isHeld`, `fromValue` (canonical smallest-mode encode), `fromTrits`. **Verified: `bun test` 8/8** (round-trip; middle-decodes-ends; value-superposed; interpretation-superposed; decoder-N-dominates; cooperate-preserves; not-representable; canonical-mode).

## 6 OPEN decisions surfaced for your ratification
1. **decoder semantics** (v0: radix-point; alts: power-of-two exponent / high-low split / regime)
2. **sign** (v0 unsigned; a tri-valued sign trit is an option → held-sign)
3. **widths** (v0 4/3/4; fixed vs posit-style variable)
4. **N-in-value** → carry the held *range* (v1, composes with wonder-compression)
5. **decoder-N** → carry the candidate-mode set (v1)
6. **field order**

Prior art: Gustafson posits / tapered precision / tagged encodings; novel = **tri-valued + middle-as-decoder-read-outward**.

> On ratification → F#/C#/Rust parity + the cross-language conformance harness (slice 6 = the BFT ballot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
