### PR TITLE
fix(ADR): mark F# WorkflowEngine as planned future-work, not existing (Codex P2 on #6175)

### DIFF
--- a/docs/DECISIONS/2026-05-31-observe-act-16-direction-universal-action-grammar-local-no-cloud-llm.md
+++ b/docs/DECISIONS/2026-05-31-observe-act-16-direction-universal-action-grammar-local-no-cloud-llm.md
@@ -118,9 +118,9 @@ committing renders slot 4 as `F`; a state with a held/uncertain option renders i
 
 ### Layering (clean separation)
 
-- **Deterministic script** (`tools/agent-loop/` TS + the canonical F# DU in
-  `src/Core.FSharp/WorkflowEngine/`): owns the state machine + `move-next(state) -> 16-slot menu`.
-  No LLM here. Replayable / DST-able.
+- **Deterministic script** (`tools/agent-loop/` TS today; the canonical F# DU in
+  `src/Core.FSharp/WorkflowEngine/` is PLANNED future-work, B-0867.1 — does not exist yet): owns the
+  state machine + `move-next(state) -> 16-slot menu`. No LLM here. Replayable / DST-able.
 - **LLM selector** (local, no cloud): a pure function `menu -> index 0..15` over only-`T` slots.
   Holds no state. Swappable model.
 - **Git** (append-only, 128-bit IDs): the only state store. Each act appends one event.


### PR DESCRIPTION
Small accuracy fix to the observe->act ADR (merged #6175). It pointed implementers at `src/Core.FSharp/WorkflowEngine/` as the canonical F# DU layer, but that doesn't exist yet (future-work, B-0867.1; `tools/agent-loop/` TS is what's real today). Reworded so you + Max coding from the ADR don't expect a directory that isn't there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)