### PR TITLE
feat(B-0944 slice 5 pt2): F# tri-boolean float (biased-exponent) — oracle #2 parity

### DIFF
--- a/src/Core.FSharp.TriBoolean/Float.fs
+++ b/src/Core.FSharp.TriBoolean/Float.fs
@@ -17,6 +17,11 @@ namespace Zeta.Core.FSharp.TriBoolean
 /// `measure` is the only collapsing op; it surfaces which superposition is held rather than
 /// collapsing silently (the digital-qubit measure/cooperate discipline at the number scope).
 ///
+/// Width: field reads accumulate into int64 (matching the Rust u64 oracle; TS uses f64). This keeps
+/// all four oracles in agreement up to f64's 2^53 exact-integer range -- the shared limit, since the
+/// decoded value is f64 in every oracle. (A naive 32-bit int would wrap at 2^31, diverging from the
+/// other three oracles before the f64 limit; int64 defers that to widths no realistic shape reaches.)
+///
 /// F# is oracle #2 of four (TS/F#/C#/Rust) in the summonable-BFT cross-language consensus. The F#
 /// compiler is a non-Byzantine oracle: it cannot lie about whether the TS design type-composes, so
 /// four-of-four compiler-checked parity = BFT consensus with no human voters.
@@ -52,19 +57,21 @@ module Float =
         | ValueSuperposed
 
     /// MSB-first base-2 read of a trit field (Tri.T = 1, Tri.F = 0). None if ANY trit is held (Tri.N).
-    let private intOf (trits: Tri list) : int option =
+    /// Accumulates into int64 (see module doc): no wrap until 63 bits, well past any realistic shape
+    /// and past f64's 2^53 exact range that bounds the decoded value across all four oracles.
+    let private intOf (trits: Tri list) : int64 option =
         let rec go acc ts =
             match ts with
             | [] -> Some acc
             | Tri.N :: _ -> None
-            | Tri.T :: rest -> go (acc * 2 + 1) rest
-            | Tri.F :: rest -> go (acc * 2) rest
+            | Tri.T :: rest -> go (acc * 2L + 1L) rest
+            | Tri.F :: rest -> go (acc * 2L) rest
 
-        go 0 trits
+        go 0L trits
 
     /// MSB-first encode of a non-negative integer into `width` certain trits (Tri.T = 1, Tri.F = 0).
-    let private intToTrits (v: int) (width: int) : Tri list =
-        [ for i in (width - 1) .. -1 .. 0 -> if (v >>> i) &&& 1 = 1 then Tri.T else Tri.F ]
+    let private intToTrits (v: int64) (width: int) : Tri list =
+        [ for i in (width - 1) .. -1 .. 0 -> if (v >>> i) &&& 1L = 1L then Tri.T else Tri.F ]
 
     /// decode (middle-out, biased-exponent): read the MIDDLE decoder first, then decode OUTWARD.
     ///   * Tri.N in the decoder  => InterpretationSuperposed (the decode instruction is held).
@@ -78,7 +85,7 @@ module Float =
             match intOf (f.High @ f.Low) with
             | None -> Error FloatFeedback.ValueSuperposed
             | Some v ->
-                let bias = pown 2 (f.Decoder.Length - 1)
+                let bias = pown 2L (f.Decoder.Length - 1)
                 Ok(float v * (2.0 ** float (mode - bias)))
 
     /// measure: the ONLY collapsing operation (identical to decode; named for parity with the
@@ -111,17 +118,18 @@ module Float =
     /// in the decoder field. Picks the SMALLEST mode that works (a canonical representation; the
     /// biased-exponent decoder has redundant representations, so a canonical choice is required).
     /// Surfaces a reason string when not representable. v0 is unsigned + finite. Round-trips with
-    /// decode: `fromValue v shape |> Result.map decode` resolves back to Ok v.
+    /// decode: `fromValue v shape |> Result.map decode` resolves back to Ok v. Bounds math uses
+    /// int64 so wide shapes return feedback rather than overflowing to negative/incorrect bounds.
     let fromValue (value: float) (shape: FloatShape) : Result<TriFloat, string> =
         if System.Double.IsNaN value || System.Double.IsInfinity value || value < 0.0 then
             Error "v0 is unsigned + finite"
         else
             let valueBits = shape.HighWidth + shape.LowWidth
-            let maxMode = (1 <<< shape.DecoderWidth) - 1
-            let maxV = pown 2 valueBits
-            let bias = pown 2 (shape.DecoderWidth - 1)
+            let maxMode = (1L <<< shape.DecoderWidth) - 1L
+            let maxV = pown 2L valueBits
+            let bias = pown 2L (shape.DecoderWidth - 1)
 
-            let rec tryMode mode =
+            let rec tryMode (mode: int64) =
                 if mode > maxMode then
                     Error(sprintf "no (mode,V) with mode<=%d and V<%d represents %g" maxMode maxV value)
                 else
@@ -129,7 +137,7 @@ module Float =
                     let scaled = value / (2.0 ** float (mode - bias))
 
                     if System.Double.IsInteger scaled && scaled >= 0.0 && scaled < float maxV then
-                        let v = int scaled
+                        let v = int64 scaled
                         let bits = intToTrits v valueBits
 
                         Ok
@@ -138,6 +146,6 @@ module Float =
                               Decoder = intToTrits mode shape.DecoderWidth
                               Low = bits |> List.skip shape.HighWidth }
                     else
-                        tryMode (mode + 1)
+                        tryMode (mode + 1L)
 
-            tryMode 0
+            tryMode 0L

--- a/src/Core.FSharp.TriBoolean/Float.fs
+++ b/src/Core.FSharp.TriBoolean/Float.fs
@@ -1,0 +1,143 @@
+namespace Zeta.Core.FSharp.TriBoolean
+
+/// Tri-boolean floating point -- biased-exponent decoder (B-0944 slice 5 pt2, F# parity oracle).
+///
+/// Mirrors the TS distribution surface (src/Core.TypeScript/tri-boolean-float) with the RATIFIED
+/// biased-exponent decoder. The middle field decodes the ends (middle-out, self-describing):
+///
+///   decoded value = V * 2 ^ (mode - bias),   bias = 2 ^ (decoderWidth - 1)
+///
+/// where V    = MSB-first base-2 read of (high ++ low)   (Tri.T = 1, Tri.F = 0), and
+///       mode = MSB-first base-2 read of the middle decoder field.
+///
+/// Every field is a `Tri list` -- the float is a composite of digital-qubit cells (Types.fs), so
+/// any trit may be held (Tri.N):
+///   * Tri.N in a value trit   => the value is superposed       (ValueSuperposed)
+///   * Tri.N in a decoder trit => the decode instruction itself  (InterpretationSuperposed)
+/// `measure` is the only collapsing op; it surfaces which superposition is held rather than
+/// collapsing silently (the digital-qubit measure/cooperate discipline at the number scope).
+///
+/// F# is oracle #2 of four (TS/F#/C#/Rust) in the summonable-BFT cross-language consensus. The F#
+/// compiler is a non-Byzantine oracle: it cannot lie about whether the TS design type-composes, so
+/// four-of-four compiler-checked parity = BFT consensus with no human voters.
+module Float =
+
+    /// Field widths (trits per field), MSB-first within each field.
+    type FloatShape =
+        { HighWidth: int
+          DecoderWidth: int
+          LowWidth: int }
+
+    /// Reference v0 shape: 4/3/4 -- 8 value trits, mode in [0,8), bias = 4.
+    let defaultShape: FloatShape =
+        { HighWidth = 4
+          DecoderWidth = 3
+          LowWidth = 4 }
+
+    /// A tri-boolean float: a composite of digital-qubit cells. Each field is MSB-first; any trit
+    /// may be held (Tri.N).
+    type TriFloat =
+        { Shape: FloatShape
+          High: Tri list
+          Decoder: Tri list
+          Low: Tri list }
+
+    /// Which superposition is held when `measure` cannot collapse to a single number. The two
+    /// held-states are distinct (the decode instruction is held vs the value is held).
+    [<RequireQualifiedAccess>]
+    type FloatFeedback =
+        /// Tri.N in the decoder field -- the decode instruction itself is superposed.
+        | InterpretationSuperposed
+        /// Tri.N in a value trit while the decoder is certain -- the value is superposed.
+        | ValueSuperposed
+
+    /// MSB-first base-2 read of a trit field (Tri.T = 1, Tri.F = 0). None if ANY trit is held (Tri.N).
+    let private intOf (trits: Tri list) : int option =
+        let rec go acc ts =
+            match ts with
+            | [] -> Some acc
+            | Tri.N :: _ -> None
+            | Tri.T :: rest -> go (acc * 2 + 1) rest
+            | Tri.F :: rest -> go (acc * 2) rest
+
+        go 0 trits
+
+    /// MSB-first encode of a non-negative integer into `width` certain trits (Tri.T = 1, Tri.F = 0).
+    let private intToTrits (v: int) (width: int) : Tri list =
+        [ for i in (width - 1) .. -1 .. 0 -> if (v >>> i) &&& 1 = 1 then Tri.T else Tri.F ]
+
+    /// decode (middle-out, biased-exponent): read the MIDDLE decoder first, then decode OUTWARD.
+    ///   * Tri.N in the decoder  => InterpretationSuperposed (the decode instruction is held).
+    ///   * Tri.N in a value trit => ValueSuperposed (the value is held; interpretation known).
+    ///   * else                  => Ok (V * 2 ^ (mode - bias)),  bias = 2 ^ (decoderWidth - 1).
+    /// The decoder is read first, so InterpretationSuperposed dominates when both are held.
+    let decode (f: TriFloat) : Result<float, FloatFeedback> =
+        match intOf f.Decoder with
+        | None -> Error FloatFeedback.InterpretationSuperposed
+        | Some mode ->
+            match intOf (f.High @ f.Low) with
+            | None -> Error FloatFeedback.ValueSuperposed
+            | Some v ->
+                let bias = pown 2 (f.Decoder.Length - 1)
+                Ok(float v * (2.0 ** float (mode - bias)))
+
+    /// measure: the ONLY collapsing operation (identical to decode; named for parity with the
+    /// digital-qubit cell primitive's measure/cooperate pair).
+    let measure (f: TriFloat) : Result<float, FloatFeedback> = decode f
+
+    /// cooperate: engage WITHOUT collapsing -- identity, preserving every held (Tri.N) trit. The
+    /// wonder-compression-safe operation at the number scope.
+    let cooperate (f: TriFloat) : TriFloat = f
+
+    /// True iff the float cannot be collapsed to a single number (any value or decoder trit is held).
+    let isHeld (f: TriFloat) : bool =
+        match decode f with
+        | Ok _ -> false
+        | Error _ -> true
+
+    /// Construct a float directly from trit fields (tests / advanced use). The shape is inferred
+    /// from the field lengths.
+    let fromTrits (high: Tri list) (decoder: Tri list) (low: Tri list) : TriFloat =
+        { Shape =
+            { HighWidth = List.length high
+              DecoderWidth = List.length decoder
+              LowWidth = List.length low }
+          High = high
+          Decoder = decoder
+          Low = low }
+
+    /// fromValue (biased-exponent canonical encode): find a (mode, V) with
+    /// `V * 2 ^ (mode - bias) = value`, V a non-negative integer that fits the value field and mode
+    /// in the decoder field. Picks the SMALLEST mode that works (a canonical representation; the
+    /// biased-exponent decoder has redundant representations, so a canonical choice is required).
+    /// Surfaces a reason string when not representable. v0 is unsigned + finite. Round-trips with
+    /// decode: `fromValue v shape |> Result.map decode` resolves back to Ok v.
+    let fromValue (value: float) (shape: FloatShape) : Result<TriFloat, string> =
+        if System.Double.IsNaN value || System.Double.IsInfinity value || value < 0.0 then
+            Error "v0 is unsigned + finite"
+        else
+            let valueBits = shape.HighWidth + shape.LowWidth
+            let maxMode = (1 <<< shape.DecoderWidth) - 1
+            let maxV = pown 2 valueBits
+            let bias = pown 2 (shape.DecoderWidth - 1)
+
+            let rec tryMode mode =
+                if mode > maxMode then
+                    Error(sprintf "no (mode,V) with mode<=%d and V<%d represents %g" maxMode maxV value)
+                else
+                    // V = value / 2 ^ (mode - bias)
+                    let scaled = value / (2.0 ** float (mode - bias))
+
+                    if System.Double.IsInteger scaled && scaled >= 0.0 && scaled < float maxV then
+                        let v = int scaled
+                        let bits = intToTrits v valueBits
+
+                        Ok
+                            { Shape = shape
+                              High = bits |> List.take shape.HighWidth
+                              Decoder = intToTrits mode shape.DecoderWidth
+                              Low = bits |> List.skip shape.HighWidth }
+                    else
+                        tryMode (mode + 1)
+
+            tryMode 0

--- a/src/Core.FSharp.TriBoolean/Zeta.Core.FSharp.TriBoolean.fsproj
+++ b/src/Core.FSharp.TriBoolean/Zeta.Core.FSharp.TriBoolean.fsproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <Compile Include="Types.fs" />
     <Compile Include="TriBoolean.fs" />
+    <!-- Tri-boolean float (B-0944 slice 5 pt2): biased-exponent decoder, built from the Tri cell. -->
+    <Compile Include="Float.fs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -32,6 +32,7 @@
     <Compile Include="Algebra/SignalQuality.Tests.fs" />
     <Compile Include="Algebra/Semiring.Tests.fs" />
     <Compile Include="TriBoolean/TriBoolean.Tests.fs" />
+    <Compile Include="TriBoolean/Float.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->

--- a/tests/Tests.FSharp/TriBoolean/Float.Tests.fs
+++ b/tests/Tests.FSharp/TriBoolean/Float.Tests.fs
@@ -1,0 +1,88 @@
+module Zeta.Tests.TriBooleanFloatTests
+
+open global.Xunit
+open Zeta.Core.FSharp.TriBoolean
+open Zeta.Core.FSharp.TriBoolean.Float
+
+// Tri-boolean float -- biased-exponent parity tests (B-0944 slice 5 pt2, F# oracle #2).
+// Shape 4/3/4 throughout: decoderWidth = 3 -> bias = 2^(3-1) = 4; valueBits = 8 -> V in [0,256).
+// decoded value = V * 2^(mode - 4). The TS distribution (decoders.ts, 'biased-exponent') uses the
+// identical formula; these vectors decode to the same f64 the TS oracle produces (the BFT ballot).
+
+/// Build the 4/3/4 reference float from high/decoder/low trit lists.
+let private mk high decoder low : TriFloat = fromTrits high decoder low
+
+[<Fact>]
+let ``decode mode=bias (exp 0): value = V`` () =
+    // decoder 100 = mode 4 = bias -> exp 0; low 0101 -> V = 5 -> 5.0
+    let f = mk [ Tri.F; Tri.F; Tri.F; Tri.F ] [ Tri.T; Tri.F; Tri.F ] [ Tri.F; Tri.T; Tri.F; Tri.T ]
+    Assert.Equal(Ok 5.0, decode f)
+
+[<Fact>]
+let ``decode mode>bias (exp +1): value = V * 2`` () =
+    // decoder 101 = mode 5 -> exp 1; low 0011 -> V = 3 -> 6.0
+    let f = mk [ Tri.F; Tri.F; Tri.F; Tri.F ] [ Tri.T; Tri.F; Tri.T ] [ Tri.F; Tri.F; Tri.T; Tri.T ]
+    Assert.Equal(Ok 6.0, decode f)
+
+[<Fact>]
+let ``decode mode<bias (exp -1): value = V / 2`` () =
+    // decoder 011 = mode 3 -> exp -1; low 1000 -> V = 8 -> 4.0
+    let f = mk [ Tri.F; Tri.F; Tri.F; Tri.F ] [ Tri.F; Tri.T; Tri.T ] [ Tri.T; Tri.F; Tri.F; Tri.F ]
+    Assert.Equal(Ok 4.0, decode f)
+
+[<Fact>]
+let ``decode mode<bias (exp -2): value = V / 4`` () =
+    // decoder 010 = mode 2 -> exp -2; low 0100 -> V = 4 -> 1.0
+    let f = mk [ Tri.F; Tri.F; Tri.F; Tri.F ] [ Tri.F; Tri.T; Tri.F ] [ Tri.F; Tri.T; Tri.F; Tri.F ]
+    Assert.Equal(Ok 1.0, decode f)
+
+[<Fact>]
+let ``decode reads high ++ low MSB-first as one V`` () =
+    // high 0001, low 0000 -> V = 0b00010000 = 16; decoder 100 = mode 4 -> exp 0 -> 16.0
+    let f = mk [ Tri.F; Tri.F; Tri.F; Tri.T ] [ Tri.T; Tri.F; Tri.F ] [ Tri.F; Tri.F; Tri.F; Tri.F ]
+    Assert.Equal(Ok 16.0, decode f)
+
+[<Fact>]
+let ``N in a decoder trit => InterpretationSuperposed`` () =
+    let f = mk [ Tri.F; Tri.F; Tri.F; Tri.F ] [ Tri.T; Tri.N; Tri.F ] [ Tri.F; Tri.T; Tri.F; Tri.T ]
+    Assert.Equal(Error FloatFeedback.InterpretationSuperposed, decode f)
+
+[<Fact>]
+let ``N in a value trit (decoder certain) => ValueSuperposed`` () =
+    let f = mk [ Tri.F; Tri.F; Tri.F; Tri.N ] [ Tri.T; Tri.F; Tri.F ] [ Tri.F; Tri.F; Tri.F; Tri.F ]
+    Assert.Equal(Error FloatFeedback.ValueSuperposed, decode f)
+
+[<Fact>]
+let ``decoder is read first: both held => InterpretationSuperposed`` () =
+    // N in BOTH decoder and value -> InterpretationSuperposed dominates (decoder checked first).
+    let f = mk [ Tri.N; Tri.F; Tri.F; Tri.F ] [ Tri.N; Tri.F; Tri.F ] [ Tri.F; Tri.F; Tri.F; Tri.F ]
+    Assert.Equal(Error FloatFeedback.InterpretationSuperposed, decode f)
+
+[<Fact>]
+let ``measure equals decode`` () =
+    let f = mk [ Tri.F; Tri.F; Tri.F; Tri.F ] [ Tri.T; Tri.F; Tri.F ] [ Tri.F; Tri.T; Tri.F; Tri.T ]
+    Assert.Equal(decode f, measure f)
+
+[<Fact>]
+let ``cooperate is identity and preserves held trits`` () =
+    let held = mk [ Tri.F; Tri.F; Tri.F; Tri.N ] [ Tri.N; Tri.F; Tri.F ] [ Tri.F; Tri.F; Tri.F; Tri.F ]
+    Assert.Equal(held, cooperate held)
+
+[<Fact>]
+let ``isHeld is true iff any value or decoder trit is held`` () =
+    let certain = mk [ Tri.F; Tri.F; Tri.F; Tri.F ] [ Tri.T; Tri.F; Tri.F ] [ Tri.F; Tri.T; Tri.F; Tri.T ]
+    let held = mk [ Tri.F; Tri.F; Tri.F; Tri.N ] [ Tri.T; Tri.F; Tri.F ] [ Tri.F; Tri.F; Tri.F; Tri.F ]
+    Assert.False(isHeld certain)
+    Assert.True(isHeld held)
+
+[<Fact>]
+let ``fromValue round-trips through decode (biased-exponent)`` () =
+    for v in [ 0.0; 1.0; 5.0; 6.0; 0.5; 8.0; 16.0 ] do
+        match fromValue v defaultShape with
+        | Ok f -> Assert.Equal(Ok v, decode f)
+        | Error e -> Assert.True(false, sprintf "fromValue %g unexpectedly failed: %s" v e)
+
+[<Fact>]
+let ``fromValue surfaces feedback for negative + non-dyadic values`` () =
+    Assert.True(fromValue -1.0 defaultShape |> Result.isError)
+    Assert.True(fromValue 0.1 defaultShape |> Result.isError) // 0.1 is not a dyadic rational


### PR DESCRIPTION
## B-0944 slice 5 pt2 — F# tri-boolean float (biased-exponent), oracle #2

Ports the **ratified biased-exponent** tri-boolean-float decoder from the TS distribution to **F#**, the #2 non-Byzantine compiler oracle. Per the framing: *TS is the distribution; F#/C#/Rust check its design works without much human intervention* — the compiler gate (0 warnings) IS the no-human-intervention check.

### Decoder (middle-out, self-describing)
```
decoded value = V * 2^(mode - bias),   bias = 2^(decoderWidth - 1)
V    = MSB-first base-2 read of (high ++ low)   (Tri.T=1, Tri.F=0)
mode = MSB-first base-2 read of the middle decoder field
```
Held-state logic mirrors TS exactly: `Tri.N` in a value trit → `ValueSuperposed`; `Tri.N` in a decoder trit → `InterpretationSuperposed` (decoder read first → dominates when both held).

### Surface (mirrors TS as faithfully as F# allows)
`FloatShape` · `TriFloat` · `FloatFeedback` · `decode`/`measure` · `cooperate` (identity, preserves N) · `isHeld` · `fromTrits` · `fromValue` (biased-exponent canonical encode, smallest-mode, round-trips through `decode`). Lives as `Float.fs` in the existing `Zeta.Core.FSharp.TriBoolean` project (built from the `Tri` cell; same package/namespace).

### Verification (the non-Byzantine oracle check)
- `dotnet build -c Release`: **0 warnings, 0 errors** (`TreatWarningsAsErrors`).
- Tests: **13/13** — decode at mode `<`/`=`/`>` bias, MSB-first V across high++low, both held-states + decoder-first precedence, `measure`=`decode`, cooperate identity, `isHeld`, `fromValue` round-trip, negative + non-dyadic feedback.

### Surfaced (not silently done)
TS *canonical* `decode()` is still radix-point; biased-exponent is reachable via `decodeWith('biased-exponent')`. Flipping TS canonical to the ratified biased-exponent is a **merged-behavior change left for operator call**; the slice-6 ballot uses biased-exponent across all four regardless.

Composes-with: B-0944 (slice 5 pt2) · TS slice 5 (#6172/#6173) · `fsharp-anchor-dotnet-build-sanity-check` · `monad-propagation-pattern-cross-language-substrate-shape`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
