### PR TITLE
feat(B-0944 slice 5 pt2): C# tri-boolean float (biased-exponent) — oracle #3 parity

### DIFF
--- a/src/Core.CSharp.TriBoolean/DecodeResult.cs
+++ b/src/Core.CSharp.TriBoolean/DecodeResult.cs
@@ -1,0 +1,18 @@
+namespace Zeta.Core.CSharp.TriBoolean;
+
+/// <summary>
+/// Result of <see cref="FloatOps.Decode"/> / <see cref="FloatOps.Measure"/>: a decoded number, or
+/// feedback that the float is held (cannot collapse). Sealed-record hierarchy mirrors F#
+/// Result&lt;double, FloatFeedback&gt; and the TS DecodeResult discriminated union
+/// (asymmetric-authorship: the value channel AND the feedback channel are both first-class).
+/// </summary>
+public abstract record DecodeResult
+{
+    private DecodeResult() { }
+
+    /// <summary>The float was fully certain; it decoded to <paramref name="Value"/>.</summary>
+    public sealed record Decoded(double Value) : DecodeResult;
+
+    /// <summary>The float is held; collapsing it is surfaced as <paramref name="Feedback"/>.</summary>
+    public sealed record Held(FloatFeedback Feedback) : DecodeResult;
+}

--- a/src/Core.CSharp.TriBoolean/EncodeResult.cs
+++ b/src/Core.CSharp.TriBoolean/EncodeResult.cs
@@ -1,0 +1,18 @@
+namespace Zeta.Core.CSharp.TriBoolean;
+
+/// <summary>
+/// Result of <see cref="FloatOps.FromValue"/>: an encoded float, or feedback that the target value
+/// is not representable in the given shape (v0 is unsigned + finite, and the value must be a
+/// non-negative integer V times a power of two that fits the value field for some mode). Sealed-record
+/// hierarchy mirrors F# Result&lt;TriFloat, string&gt; and the TS EncodeResult discriminated union.
+/// </summary>
+public abstract record EncodeResult
+{
+    private EncodeResult() { }
+
+    /// <summary>The value was representable; <paramref name="Value"/> is a canonical encoding.</summary>
+    public sealed record Encoded(TriFloat Value) : EncodeResult;
+
+    /// <summary>The value is not representable in the shape; <paramref name="Detail"/> says why.</summary>
+    public sealed record NotRepresentable(string Detail) : EncodeResult;
+}

--- a/src/Core.CSharp.TriBoolean/FloatFeedback.cs
+++ b/src/Core.CSharp.TriBoolean/FloatFeedback.cs
@@ -1,0 +1,15 @@
+namespace Zeta.Core.CSharp.TriBoolean;
+
+/// <summary>
+/// Which superposition is held when <see cref="FloatOps.Measure"/> cannot collapse a tri-boolean
+/// float to a single number. The two held-states are distinct (the decode instruction is held vs
+/// the value is held). Parity with the F# Float.FloatFeedback DU and the TS FloatFeedback union.
+/// </summary>
+public enum FloatFeedback
+{
+    /// <summary>Tri.N in the decoder field -- the decode instruction itself is superposed.</summary>
+    InterpretationSuperposed,
+
+    /// <summary>Tri.N in a value trit while the decoder is certain -- the value is superposed.</summary>
+    ValueSuperposed,
+}

--- a/src/Core.CSharp.TriBoolean/FloatOps.cs
+++ b/src/Core.CSharp.TriBoolean/FloatOps.cs
@@ -1,0 +1,149 @@
+using System.Diagnostics;
+
+namespace Zeta.Core.CSharp.TriBoolean;
+
+/// <summary>
+/// Tri-boolean float -- operations (B-0944 slice 5 pt2, C# parity oracle #3). Static; the
+/// biased-exponent decoder ported from the TS distribution (decoders.ts 'biased-exponent') and the
+/// F# Float module. Named FloatOps (not TriFloat) because TriFloat is already the data type and the
+/// ops class must not collide with it.
+///
+/// Middle-out, self-describing: <c>decoded value = V * 2^(mode - bias)</c>, bias = 2^(decoderWidth - 1),
+/// where V = MSB-first read of (high ++ low) and mode = MSB-first read of the middle decoder
+/// (Tri.T=1, Tri.F=0). C# null is NOT the held Tri.N state; every operation rejects null loudly.
+/// Roslyn is the non-Byzantine oracle: the switches carry an explicit UnreachableException arm
+/// because the closed Tri hierarchy is not compiler-inferred exhaustive.
+/// </summary>
+public static class FloatOps
+{
+    private const string ClosedHierarchy =
+        "Tri is a closed hierarchy: TrueCell | FalseCell | NCell";
+
+    /// <summary>
+    /// MSB-first base-2 read of a trit field (Tri.T=1, Tri.F=0). Returns null iff ANY trit is held
+    /// (Tri.N) -- the held signal. Rejects a null trit loudly (null is not Tri.N).
+    /// </summary>
+    private static int? IntOf(IEnumerable<Tri> trits)
+    {
+        ArgumentNullException.ThrowIfNull(trits);
+        var v = 0;
+        foreach (var t in trits)
+        {
+            switch (t)
+            {
+                case null:
+                    throw new ArgumentException("A trit was null; null is not Tri.N.", nameof(trits));
+                case Tri.NCell:
+                    return null;
+                case Tri.TrueCell:
+                    v = (v * 2) + 1;
+                    break;
+                case Tri.FalseCell:
+                    v *= 2;
+                    break;
+                default:
+                    throw new UnreachableException(ClosedHierarchy);
+            }
+        }
+
+        return v;
+    }
+
+    /// <summary>MSB-first encode of a non-negative integer into <paramref name="width"/> certain trits.</summary>
+    private static Tri[] IntToTrits(int v, int width)
+    {
+        var trits = new Tri[width];
+        for (var i = 0; i < width; i++)
+        {
+            var bit = (v >> (width - 1 - i)) & 1;
+            trits[i] = bit == 1 ? Tri.T : Tri.F;
+        }
+
+        return trits;
+    }
+
+    /// <summary>
+    /// decode (middle-out, biased-exponent): read the MIDDLE decoder first, then decode OUTWARD.
+    /// Tri.N in the decoder => InterpretationSuperposed; Tri.N in a value trit => ValueSuperposed
+    /// (decoder read first, so InterpretationSuperposed dominates when both are held); else
+    /// Decoded(V * 2^(mode - bias)).
+    /// </summary>
+    public static DecodeResult Decode(TriFloat f)
+    {
+        ArgumentNullException.ThrowIfNull(f);
+        var mode = IntOf(f.Decoder);
+        if (mode is null)
+        {
+            return new DecodeResult.Held(FloatFeedback.InterpretationSuperposed);
+        }
+
+        var v = IntOf(f.High.Concat(f.Low));
+        if (v is null)
+        {
+            return new DecodeResult.Held(FloatFeedback.ValueSuperposed);
+        }
+
+        var bias = 1 << (f.Decoder.Count - 1);
+        return new DecodeResult.Decoded(v.Value * Math.Pow(2, mode.Value - bias));
+    }
+
+    /// <summary>measure: the only collapsing op (identical to Decode; named for parity with the cell).</summary>
+    public static DecodeResult Measure(TriFloat f) => Decode(f);
+
+    /// <summary>cooperate: engage WITHOUT collapsing -- identity, preserving every held (Tri.N) trit.</summary>
+    public static TriFloat Cooperate(TriFloat f)
+    {
+        ArgumentNullException.ThrowIfNull(f);
+        return f;
+    }
+
+    /// <summary>True iff the float cannot collapse to a single number (any value or decoder trit is held).</summary>
+    public static bool IsHeld(TriFloat f) => Decode(f) is DecodeResult.Held;
+
+    /// <summary>Construct a float directly from trit fields (tests / advanced use); shape is inferred.</summary>
+    public static TriFloat FromTrits(IReadOnlyList<Tri> high, IReadOnlyList<Tri> decoder, IReadOnlyList<Tri> low)
+    {
+        ArgumentNullException.ThrowIfNull(high);
+        ArgumentNullException.ThrowIfNull(decoder);
+        ArgumentNullException.ThrowIfNull(low);
+        return new TriFloat(new FloatShape(high.Count, decoder.Count, low.Count), high, decoder, low);
+    }
+
+    /// <summary>
+    /// fromValue (biased-exponent canonical encode): find a (mode, V) with V * 2^(mode-bias) = value,
+    /// V a non-negative integer fitting the value field and mode in the decoder field. Picks the
+    /// SMALLEST mode that works (a canonical representation; the biased-exponent decoder has redundant
+    /// representations). v0 is unsigned + finite. Round-trips with Decode.
+    /// </summary>
+    public static EncodeResult FromValue(double value, FloatShape shape)
+    {
+        ArgumentNullException.ThrowIfNull(shape);
+        if (double.IsNaN(value) || double.IsInfinity(value) || value < 0.0)
+        {
+            return new EncodeResult.NotRepresentable("v0 is unsigned + finite");
+        }
+
+        var valueBits = shape.HighWidth + shape.LowWidth;
+        var maxMode = (1 << shape.DecoderWidth) - 1;
+        var maxV = 1 << valueBits;
+        var bias = 1 << (shape.DecoderWidth - 1);
+
+        for (var mode = 0; mode <= maxMode; mode++)
+        {
+            var scaled = value / Math.Pow(2, mode - bias); // = V
+            if (double.IsInteger(scaled) && scaled >= 0.0 && scaled < maxV)
+            {
+                var v = (int)scaled;
+                var bits = IntToTrits(v, valueBits);
+                return new EncodeResult.Encoded(new TriFloat(
+                    shape,
+                    bits.Take(shape.HighWidth).ToList(),
+                    IntToTrits(mode, shape.DecoderWidth),
+                    bits.Skip(shape.HighWidth).ToList()));
+            }
+        }
+
+        return new EncodeResult.NotRepresentable(
+            $"no (mode,V) with mode<={maxMode} and V<{maxV} represents {value}");
+    }
+}

--- a/src/Core.CSharp.TriBoolean/FloatShape.cs
+++ b/src/Core.CSharp.TriBoolean/FloatShape.cs
@@ -1,0 +1,14 @@
+namespace Zeta.Core.CSharp.TriBoolean;
+
+/// <summary>
+/// Field widths of a tri-boolean float (trits per field), MSB-first within each field. Parity with
+/// the TS FloatShape (src/Core.TypeScript/tri-boolean-float/types.ts) and F# Float.FloatShape.
+/// </summary>
+/// <param name="HighWidth">High (more-significant) value trits.</param>
+/// <param name="DecoderWidth">Middle decoder trits (the selector read first; the biased-exponent mode).</param>
+/// <param name="LowWidth">Low (less-significant) value trits.</param>
+public sealed record FloatShape(int HighWidth, int DecoderWidth, int LowWidth)
+{
+    /// <summary>Reference v0 shape: 4/3/4 -- 8 value trits, mode in [0,8), bias = 4.</summary>
+    public static readonly FloatShape Default = new(HighWidth: 4, DecoderWidth: 3, LowWidth: 4);
+}

--- a/src/Core.CSharp.TriBoolean/TriFloat.cs
+++ b/src/Core.CSharp.TriBoolean/TriFloat.cs
@@ -1,0 +1,17 @@
+namespace Zeta.Core.CSharp.TriBoolean;
+
+/// <summary>
+/// A tri-boolean float: a composite of digital-qubit cells (<see cref="Tri"/>). Each field is a
+/// list of trits read MSB-first; because every position is a <see cref="Tri"/>, any trit may be
+/// held (Tri.N). Parity with the TS TriFloat and F# Float.TriFloat. Records give structural
+/// equality, so two floats with equal fields are value-equal.
+/// </summary>
+/// <param name="Shape">The field widths.</param>
+/// <param name="High">High value trits (MSB-first).</param>
+/// <param name="Decoder">Middle decoder trits (the biased-exponent mode, MSB-first).</param>
+/// <param name="Low">Low value trits (MSB-first).</param>
+public sealed record TriFloat(
+    FloatShape Shape,
+    IReadOnlyList<Tri> High,
+    IReadOnlyList<Tri> Decoder,
+    IReadOnlyList<Tri> Low);

--- a/tests/Tests.CSharp/TriBoolean/FloatTests.cs
+++ b/tests/Tests.CSharp/TriBoolean/FloatTests.cs
@@ -1,0 +1,120 @@
+using Xunit;
+using Zeta.Core.CSharp.TriBoolean;
+using static Zeta.Core.CSharp.TriBoolean.FloatOps;
+
+namespace Zeta.Tests.CSharp.TriBoolean;
+
+// C# parity oracle (#3 of four) for the biased-exponent tri-boolean float (B-0944 slice 5 pt2).
+// Vectors mirror tests/Tests.FSharp/TriBoolean/Float.Tests.fs so four-of-four parity across
+// TS/F#/C#/Rust IS the summonable-BFT ballot. Roslyn is the non-Byzantine oracle here.
+// Shape 4/3/4 throughout: decoderWidth 3 -> bias 2^(3-1) = 4; valueBits 8 -> V in [0,256).
+// decoded value = V * 2^(mode - 4).
+
+public class FloatTests
+{
+    private static readonly Tri[] Zero4 = [Tri.F, Tri.F, Tri.F, Tri.F];
+
+    private static TriFloat Mk(Tri[] high, Tri[] decoder, Tri[] low) => FromTrits(high, decoder, low);
+
+    [Fact]
+    public void DecodeModeEqualsBiasValueIsV()
+    {
+        // decoder 100 = mode 4 = bias -> exp 0; low 0101 -> V = 5 -> 5.0
+        var f = Mk(Zero4, [Tri.T, Tri.F, Tri.F], [Tri.F, Tri.T, Tri.F, Tri.T]);
+        Assert.Equal(new DecodeResult.Decoded(5.0), Decode(f));
+    }
+
+    [Fact]
+    public void DecodeModeGreaterThanBiasTimesTwo()
+    {
+        // decoder 101 = mode 5 -> exp +1; low 0011 -> V = 3 -> 6.0
+        var f = Mk(Zero4, [Tri.T, Tri.F, Tri.T], [Tri.F, Tri.F, Tri.T, Tri.T]);
+        Assert.Equal(new DecodeResult.Decoded(6.0), Decode(f));
+    }
+
+    [Fact]
+    public void DecodeModeLessThanBiasHalf()
+    {
+        // decoder 011 = mode 3 -> exp -1; low 1000 -> V = 8 -> 4.0
+        var f = Mk(Zero4, [Tri.F, Tri.T, Tri.T], [Tri.T, Tri.F, Tri.F, Tri.F]);
+        Assert.Equal(new DecodeResult.Decoded(4.0), Decode(f));
+    }
+
+    [Fact]
+    public void DecodeModeLessThanBiasQuarter()
+    {
+        // decoder 010 = mode 2 -> exp -2; low 0100 -> V = 4 -> 1.0
+        var f = Mk(Zero4, [Tri.F, Tri.T, Tri.F], [Tri.F, Tri.T, Tri.F, Tri.F]);
+        Assert.Equal(new DecodeResult.Decoded(1.0), Decode(f));
+    }
+
+    [Fact]
+    public void DecodeReadsHighThenLowAsOneV()
+    {
+        // high 0001, low 0000 -> V = 0b00010000 = 16; decoder 100 = mode 4 -> exp 0 -> 16.0
+        var f = Mk([Tri.F, Tri.F, Tri.F, Tri.T], [Tri.T, Tri.F, Tri.F], Zero4);
+        Assert.Equal(new DecodeResult.Decoded(16.0), Decode(f));
+    }
+
+    [Fact]
+    public void NInDecoderIsInterpretationSuperposed()
+    {
+        var f = Mk(Zero4, [Tri.T, Tri.N, Tri.F], [Tri.F, Tri.T, Tri.F, Tri.T]);
+        Assert.Equal(new DecodeResult.Held(FloatFeedback.InterpretationSuperposed), Decode(f));
+    }
+
+    [Fact]
+    public void NInValueDecoderCertainIsValueSuperposed()
+    {
+        var f = Mk([Tri.F, Tri.F, Tri.F, Tri.N], [Tri.T, Tri.F, Tri.F], Zero4);
+        Assert.Equal(new DecodeResult.Held(FloatFeedback.ValueSuperposed), Decode(f));
+    }
+
+    [Fact]
+    public void DecoderReadFirstBothHeldIsInterpretationSuperposed()
+    {
+        // N in BOTH decoder and value -> InterpretationSuperposed dominates (decoder checked first).
+        var f = Mk([Tri.N, Tri.F, Tri.F, Tri.F], [Tri.N, Tri.F, Tri.F], Zero4);
+        Assert.Equal(new DecodeResult.Held(FloatFeedback.InterpretationSuperposed), Decode(f));
+    }
+
+    [Fact]
+    public void MeasureEqualsDecode()
+    {
+        var f = Mk(Zero4, [Tri.T, Tri.F, Tri.F], [Tri.F, Tri.T, Tri.F, Tri.T]);
+        Assert.Equal(Decode(f), Measure(f));
+    }
+
+    [Fact]
+    public void CooperateIsIdentityAndPreservesHeldTrits()
+    {
+        var held = Mk([Tri.F, Tri.F, Tri.F, Tri.N], [Tri.N, Tri.F, Tri.F], Zero4);
+        Assert.Equal(held, Cooperate(held));
+    }
+
+    [Fact]
+    public void IsHeldTrueIffAnyValueOrDecoderTritIsHeld()
+    {
+        var certain = Mk(Zero4, [Tri.T, Tri.F, Tri.F], [Tri.F, Tri.T, Tri.F, Tri.T]);
+        var held = Mk([Tri.F, Tri.F, Tri.F, Tri.N], [Tri.T, Tri.F, Tri.F], Zero4);
+        Assert.False(IsHeld(certain));
+        Assert.True(IsHeld(held));
+    }
+
+    [Fact]
+    public void FromValueRoundTripsThroughDecode()
+    {
+        foreach (var v in new[] { 0.0, 1.0, 5.0, 6.0, 0.5, 8.0, 16.0 })
+        {
+            var encoded = Assert.IsType<EncodeResult.Encoded>(FromValue(v, FloatShape.Default));
+            Assert.Equal(new DecodeResult.Decoded(v), Decode(encoded.Value));
+        }
+    }
+
+    [Fact]
+    public void FromValueNotRepresentableForNegativeAndNonDyadic()
+    {
+        Assert.IsType<EncodeResult.NotRepresentable>(FromValue(-1.0, FloatShape.Default));
+        Assert.IsType<EncodeResult.NotRepresentable>(FromValue(0.1, FloatShape.Default)); // not dyadic
+    }
+}


### PR DESCRIPTION
## B-0944 slice 5 pt2 — C# tri-boolean float (biased-exponent), oracle #3

Ports the **ratified biased-exponent** decoder to **C#** (Roslyn = oracle #3). Same middle-out, self-describing decoder as TS/F#:
```
decoded value = V * 2^(mode - bias),   bias = 2^(decoderWidth - 1)
```

### Mirrors F# with C# digital-qubit patterns
- Closed **sealed-record** result hierarchies: `DecodeResult` (`Decoded`|`Held`), `EncodeResult` (`Encoded`|`NotRepresentable`) — asymmetric-authorship, value + feedback channels both first-class.
- C# `null` is **NOT** the held `Tri.N` state — every op rejects null loudly.
- Switches carry an explicit `UnreachableException` arm (the closed `Tri` hierarchy is not compiler-inferred exhaustive).
- One type per file (MA0048); `FloatOps` named so it doesn't collide with the `TriFloat` type.

### The oracle did its job (no-human-intervention check)
The Roslyn analyzers caught two design issues **before any human reviewer**: CA1720 (param `Float` shadowed a type name → `Value`) and CA1859 (private `IntToTrits` should return concrete `Tri[]`). Both fixed; final build 0 warnings. (Neither the TS nor F# oracle flags these — different analyzer slices, stronger union.)

### Verification
- `dotnet build -c Release`: **0 warnings, 0 errors**.
- Tests: **13/13** — the **same vectors** as the F# oracle (decode at mode `<`/`=`/`>` bias, MSB-first V across high++low, both held-states + decoder-first precedence, `measure`=`decode`, cooperate identity, `isHeld`, `fromValue` round-trip, negative + non-dyadic feedback).

Files (implicit SDK globbing — no csproj edits): `FloatShape` · `TriFloat` · `FloatFeedback` · `DecodeResult` · `EncodeResult` · `FloatOps` + `FloatTests`.

Composes-with: B-0944 (slice 5 pt2) · F# slice 5 pt2 (#6183) · TS slice 5 (#6172/#6173) · `fsharp-anchor-dotnet-build-sanity-check` · `monad-propagation-pattern-cross-language-substrate-shape`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
