### PR TITLE
fix(B-0944 slice 5 pt2): widen C# float to long — 4-oracle width parity (TS f64 / F# int64 / C# long / Rust u64)

### DIFF
--- a/src/Core.CSharp.TriBoolean/FloatOps.cs
+++ b/src/Core.CSharp.TriBoolean/FloatOps.cs
@@ -13,6 +13,12 @@ namespace Zeta.Core.CSharp.TriBoolean;
 /// (Tri.T=1, Tri.F=0). C# null is NOT the held Tri.N state; every operation rejects null loudly.
 /// Roslyn is the non-Byzantine oracle: the switches carry an explicit UnreachableException arm
 /// because the closed Tri hierarchy is not compiler-inferred exhaustive.
+///
+/// Width: field reads accumulate into <see cref="long"/> (matching the Rust u64 + F# int64 oracles;
+/// TS uses f64). This keeps all four oracles in agreement up to f64's 2^53 exact-integer range --
+/// the shared limit, since the decoded value is f64 in every oracle. A naive 32-bit int would wrap
+/// at 2^31, diverging from the other oracles before the f64 limit; long defers that to widths no
+/// realistic shape reaches.
 /// </summary>
 public static class FloatOps
 {
@@ -21,12 +27,13 @@ public static class FloatOps
 
     /// <summary>
     /// MSB-first base-2 read of a trit field (Tri.T=1, Tri.F=0). Returns null iff ANY trit is held
-    /// (Tri.N) -- the held signal. Rejects a null trit loudly (null is not Tri.N).
+    /// (Tri.N) -- the held signal. Rejects a null trit loudly (null is not Tri.N). Accumulates into
+    /// long (no wrap until 63 bits; see class doc for the f64-2^53 shared limit across oracles).
     /// </summary>
-    private static int? IntOf(IEnumerable<Tri> trits)
+    private static long? IntOf(IEnumerable<Tri> trits)
     {
         ArgumentNullException.ThrowIfNull(trits);
-        var v = 0;
+        var v = 0L;
         foreach (var t in trits)
         {
             switch (t)
@@ -50,13 +57,13 @@ public static class FloatOps
     }
 
     /// <summary>MSB-first encode of a non-negative integer into <paramref name="width"/> certain trits.</summary>
-    private static Tri[] IntToTrits(int v, int width)
+    private static Tri[] IntToTrits(long v, int width)
     {
         var trits = new Tri[width];
         for (var i = 0; i < width; i++)
         {
-            var bit = (v >> (width - 1 - i)) & 1;
-            trits[i] = bit == 1 ? Tri.T : Tri.F;
+            var bit = (v >> (width - 1 - i)) & 1L;
+            trits[i] = bit == 1L ? Tri.T : Tri.F;
         }
 
         return trits;
@@ -83,7 +90,7 @@ public static class FloatOps
             return new DecodeResult.Held(FloatFeedback.ValueSuperposed);
         }
 
-        var bias = 1 << (f.Decoder.Count - 1);
+        var bias = 1L << (f.Decoder.Count - 1);
         return new DecodeResult.Decoded(v.Value * Math.Pow(2, mode.Value - bias));
     }
 
@@ -113,7 +120,8 @@ public static class FloatOps
     /// fromValue (biased-exponent canonical encode): find a (mode, V) with V * 2^(mode-bias) = value,
     /// V a non-negative integer fitting the value field and mode in the decoder field. Picks the
     /// SMALLEST mode that works (a canonical representation; the biased-exponent decoder has redundant
-    /// representations). v0 is unsigned + finite. Round-trips with Decode.
+    /// representations). v0 is unsigned + finite. Round-trips with Decode. Bounds math uses long so
+    /// wide shapes return feedback rather than overflowing to negative/incorrect bounds.
     /// </summary>
     public static EncodeResult FromValue(double value, FloatShape shape)
     {
@@ -124,16 +132,16 @@ public static class FloatOps
         }
 
         var valueBits = shape.HighWidth + shape.LowWidth;
-        var maxMode = (1 << shape.DecoderWidth) - 1;
-        var maxV = 1 << valueBits;
-        var bias = 1 << (shape.DecoderWidth - 1);
+        var maxMode = (1L << shape.DecoderWidth) - 1;
+        var maxV = 1L << valueBits;
+        var bias = 1L << (shape.DecoderWidth - 1);
 
-        for (var mode = 0; mode <= maxMode; mode++)
+        for (long mode = 0; mode <= maxMode; mode++)
         {
             var scaled = value / Math.Pow(2, mode - bias); // = V
             if (double.IsInteger(scaled) && scaled >= 0.0 && scaled < maxV)
             {
-                var v = (int)scaled;
+                var v = (long)scaled;
                 var bits = IntToTrits(v, valueBits);
                 return new EncodeResult.Encoded(new TriFloat(
                     shape,

--- a/tests/Tests.CSharp/TriBoolean/FloatTests.cs
+++ b/tests/Tests.CSharp/TriBoolean/FloatTests.cs
@@ -117,4 +117,19 @@ public class FloatTests
         Assert.IsType<EncodeResult.NotRepresentable>(FromValue(-1.0, FloatShape.Default));
         Assert.IsType<EncodeResult.NotRepresentable>(FromValue(0.1, FloatShape.Default)); // not dyadic
     }
+
+    // Guards the long widening at the width where the previous 32-bit bug occurred (Copilot P1 on
+    // #6186): a regression to 32-bit accumulation/bounds would wrap and fail these. Wide VALUE field
+    // (52 bits > 31) with a small 3-trit decoder (no mode-search blowup — that wide-DECODER concern
+    // is the separate cross-language hardening row).
+    [Fact]
+    public void DecodeAndFromValueWorkPast32BitsOfValueWidth()
+    {
+        var wide = new FloatShape(26, 3, 26); // valueBits = 52, exact within f64's 2^53 range
+        foreach (var v in new[] { Math.Pow(2, 31), Math.Pow(2, 40), Math.Pow(2, 50), Math.Pow(2, 40) + 32.0 })
+        {
+            var encoded = Assert.IsType<EncodeResult.Encoded>(FromValue(v, wide));
+            Assert.Equal(new DecodeResult.Decoded(v), Decode(encoded.Value));
+        }
+    }
 }


### PR DESCRIPTION
## B-0944 slice 5 pt2 — C# float width parity (32-bit → `long`)

Follow-up to the F# fix ([#6183](https://github.com/Lucent-Financial-Group/Zeta/pull/6183) commit `160173c80`). The C# float had the **same latent 32-bit `int` width** Copilot flagged P1 on F#:
- `IntOf` accumulated into `int` (wraps past 31 bits → silent wrong mode/V)
- `FromValue` computed `maxV`/`maxMode`/`bias` with 32-bit `int` (widths 31+ → negative/incorrect bounds instead of `Result` feedback)

Latent at the default 4/3/4 shape (8 value bits) but `FromTrits` + public `Decode` accept arbitrary widths.

### Fix — widen to `long`
`IntOf` accumulator · `IntToTrits` param · `FromValue` bounds (`maxV`/`maxMode`/`bias`) · the mode loop var → `long`.

### Closes the 4-oracle width-parity gap
| Oracle | Width | Exact to |
|---|---|---|
| TS | f64 (`number`) | 2^53 |
| F# | `int64` | 2^53 (then →f64) |
| C# | **`long`** (this PR) | 2^53 (then →f64) |
| Rust | `u64` | 2^53 (then →f64) |

All four now agree up to f64's 2^53 exact-integer range — the shared limit, since the decoded value is f64 in every oracle.

### Verification
- `dotnet build -c Release`: **0 warnings, 0 errors**.
- Tests: **13/13** (unchanged vectors; default-shape behavior identical).

Composes-with: B-0944 (slice 5 pt2) · F# width fix (#6183) · C# float (#6184) · Rust float (#6185).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
