### PR TITLE
docs(B-0171): mark OpenSpec parent decomposed

### DIFF
--- a/docs/backlog/P1/B-0171-openspec-catch-up-canonical-source-of-truth-aaron-2026-05-03.md
+++ b/docs/backlog/P1/B-0171-openspec-catch-up-canonical-source-of-truth-aaron-2026-05-03.md
@@ -9,6 +9,7 @@ ask: Aaron 2026-05-03 verbatim *"openspec which we are way behind on, that's sup
 created: 2026-05-03
 last_updated: 2026-05-31
 depends_on: []
+decomposition: decomposed
 composes_with: [B-0058, B-0169, B-0170, B-0172, B-0173, B-0190]
 tags:
   [
@@ -62,6 +63,10 @@ The current child-row sequence is:
 - `B-0171.2` - author the Tick-History Schema spec.
 - `B-0171.3` - author the Retraction-Native Semantics spec.
 - `B-0171.4` - author the Backlog Row Schema spec.
+
+The parent row is marked `decomposition: decomposed` so autonomous pickup can
+descend into the open atomic child rows instead of repeatedly selecting the
+parent for another decomposition pass.
 
 ## Why P1 (foundation)
 

--- a/docs/claims/task-b0171-mark-decomposed-20260531.md
+++ b/docs/claims/task-b0171-mark-decomposed-20260531.md
@@ -1,0 +1,18 @@
+# Claim - task-b0171-mark-decomposed-20260531
+
+- **Session ID:** codex/20260531T132207Z-task-b0171-mark-decomposed
+- **Harness:** codex
+- **Claimed at:** 2026-05-31T13:22:07Z
+- **ETA:** 2026-05-31T14:07:07Z
+- **Scope:** Mark B-0171 decomposed now that atomic child rows exist.
+- **Durable target:** docs/backlog/P1/B-0171-openspec-catch-up-canonical-source-of-truth-aaron-2026-05-03.md
+- **Platform mirror:** GitHub PR pending
+
+## Notes
+
+Branch: `claim/task-b0171-mark-decomposed-20260531`
+
+Initial intended path set:
+
+- `docs/backlog/P1/B-0171-openspec-catch-up-canonical-source-of-truth-aaron-2026-05-03.md`
+

--- a/docs/claims/task-b0171-mark-decomposed-20260531.md
+++ b/docs/claims/task-b0171-mark-decomposed-20260531.md
@@ -15,4 +15,3 @@ Branch: `claim/task-b0171-mark-decomposed-20260531`
 Initial intended path set:
 
 - `docs/backlog/P1/B-0171-openspec-catch-up-canonical-source-of-truth-aaron-2026-05-03.md`
-


### PR DESCRIPTION
## What

- Marks B-0171 with `decomposition: decomposed` now that it has atomic child rows.
- Adds the checkpoint rationale so autonomous pickup descends into child rows instead of repeatedly selecting the parent.
- Includes a git-native claim file for the scoped branch.

## Why

After #6209 merged, `tools/backlog/empty-queue-pickup.ts --json --dry-run` still selected B-0171 with `decompose-first`. The parent row had a child sequence but no decomposed marker, so the selector treated the parent as still requiring decomposition.

## Validation

- `bun tools/backlog/lint-frontmatter.ts --file docs/backlog/P1/B-0171-openspec-catch-up-canonical-source-of-truth-aaron-2026-05-03.md --strict`
- `bun tools/backlog/autonomous-pickup.ts --json` selects `B-0164.1` with `claim-and-implement` instead of B-0171 `decompose-first`
- `bun tools/backlog/generate-index.ts --check`
- `git diff --check`
- `bunx prettier --check docs/backlog/P1/B-0171-openspec-catch-up-canonical-source-of-truth-aaron-2026-05-03.md docs/claims/task-b0171-mark-decomposed-20260531.md`
- `bunx markdownlint-cli2 docs/backlog/P1/B-0171-openspec-catch-up-canonical-source-of-truth-aaron-2026-05-03.md docs/claims/task-b0171-mark-decomposed-20260531.md`
