### PR TITLE
feat(B-0883): better-git-crypt Phase 2 — real post-quantum crypto (XWing + ML-DSA-65 + ChaCha20-Poly1305 + CBOR)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,10 @@
       "dependencies": {
         "@nats-io/jetstream": "3.4.0",
         "@nats-io/transport-node": "3.4.0",
+        "@noble/ciphers": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@noble/post-quantum": "0.6.1",
+        "cborg": "5.1.1",
         "pg": "8.21.0",
       },
       "devDependencies": {
@@ -63,6 +67,14 @@
     "@nats-io/nuid": ["@nats-io/nuid@3.0.0", "", {}, "sha512-QbXZDrxmYlrn5AD06gYcUTmEHwxn96HBQMIk7XTjDlEcx6FPzVBBPjp4AMRh1lEv6B4iJ6Xb/Uz61JugPXFRQg=="],
 
     "@nats-io/transport-node": ["@nats-io/transport-node@3.4.0", "", { "dependencies": { "@nats-io/nats-core": "3.4.0", "@nats-io/nkeys": "2.0.3", "@nats-io/nuid": "3.0.0" } }, "sha512-hH7u7ejIBTFEJIZ8rIcMrHJI6wl+HhpO5sVFs1+ppmXa8RuB2+Lh1+UwTzZ5xTNNm1TKcRkYy+2qCV56qp8RxA=="],
+
+    "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
+
+    "@noble/curves": ["@noble/curves@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0" } }, "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ=="],
+
+    "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+
+    "@noble/post-quantum": ["@noble/post-quantum@0.6.1", "", { "dependencies": { "@noble/ciphers": "~2.2.0", "@noble/curves": "~2.2.0", "@noble/hashes": "~2.2.0" } }, "sha512-+pormrDZwjRw05U8ADK4JpHejo87+gBd+muRBB/ozztH5yhDLMDF4jHQWN3NQQAsu1zBNPWTG0ZwVI0CR29H0A=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -135,6 +147,8 @@
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "cborg": ["cborg@5.1.1", "", { "bin": { "cborg": "lib/bin.js" } }, "sha512-BDbSRIp6XrQXkTc7g+DN0RB9RrDPTUfals2ecWUlt3juPLjbAvy/V72mJcXY0Ehu0Dq/3WpNCOCT68HUTbW+lw=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
@@ -360,8 +374,6 @@
 
     "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
-
     "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 
     "postgres-bytea": ["postgres-bytea@1.0.0", "", {}, "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="],
@@ -369,6 +381,8 @@
     "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
   "dependencies": {
     "@nats-io/jetstream": "3.4.0",
     "@nats-io/transport-node": "3.4.0",
+    "@noble/ciphers": "2.2.0",
+    "@noble/hashes": "2.2.0",
+    "@noble/post-quantum": "0.6.1",
+    "cborg": "5.1.1",
     "pg": "8.21.0"
   }
 }

--- a/tools/crypto/better-git-crypt/README.md
+++ b/tools/crypto/better-git-crypt/README.md
@@ -78,24 +78,32 @@ bun test tools/crypto/better-git-crypt/
 
 Invariants checked: unique alg ids; ships-v1 presence for each class (kem/signature/kdf/aead); registry catches duplicate ids + missing ships-v1; envelope catches wrong version + context mismatch + unknown algs + wrong-class-references + empty recipient set + empty signerIdentity; encryption context catches empty recipient set + sender-not-in-recipients + unsupported algs + invalid keys.
 
-## Phase 2 integration protocol
+## Phase 2 — as implemented
 
-When operator authorizes Phase 2:
+Phase 2 landed as a single `crypto.ts` against the real primitives (NOT the
+split-module / `cbor-x` sketch this section originally proposed — that plan is
+superseded by what actually shipped):
 
-1. Add `@noble/post-quantum`, `@noble/ciphers`, `@noble/hashes`, and a CBOR library (e.g. `cbor-x`) to `package.json`
-2. Implement `ciphers/registry.ts` dispatch:
-   - `mlKem768Encapsulate(pk: Uint8Array): { ct: Uint8Array; ss: Uint8Array }`
-   - `mlKem768Decapsulate(sk: Uint8Array, ct: Uint8Array): Uint8Array`
-   - `xwingHybrid` wrapper composing ML-KEM-768 + X25519
-   - `mlDsa65Sign(sk: Uint8Array, msg: Uint8Array): Uint8Array`
-   - `mlDsa65Verify(pk: Uint8Array, msg: Uint8Array, sig: Uint8Array): boolean`
-3. Implement `envelope.ts` CBOR encode/decode
-4. Implement `files/encrypt.ts` + `files/decrypt.ts` round-trip
-5. Implement `recipients/manage.ts` + `recipients/storage.ts`
-6. Implement `seed/sources.ts` with random-bytes ships-v1; Adinkra-derived per B-0623 future
-7. Add round-trip integration tests + KAT (Known-Answer Tests) per Noble's KAT vectors
-8. Wire `files/textconv.ts` for `git textconv` filter (diff-readable ciphertext)
-9. Optional: ship as standalone npm package OR keep internal to tools/
+- **Deps** (pinned): `@noble/post-quantum` (XWing KEM + `ml_dsa65`),
+  `@noble/ciphers` (`chacha20poly1305`), `@noble/hashes` (`hkdf`/`sha256`),
+  `cborg` (canonical CBOR). See "On-disk wire format" above for the authoritative
+  envelope shape (flat camelCase — supersedes the earlier snake_case sketch).
+- **`crypto.ts`** (single module, not split): `generateRecipientKeyPair`,
+  `encrypt` / `decrypt` (Result-shaped: `Result<_, EncryptionFeedback>` /
+  `Result<_, DecryptionFeedback>`), `encodeEnvelope` / `decodeEnvelope` (canonical
+  CBOR with a non-canonical / unknown-field reject), and the signed-view encoder.
+- **`crypto.test.ts`**: wiring + tamper-detection suite (round-trip,
+  multi-recipient, every typed failure mode). Scope-honest — see that file's
+  header: a green run proves the API composes, NOT cryptographic correctness.
+
+Still future (NOT done in this PR): `git textconv` filter wiring, a recipients
+registry / storage layer, alternate seed sources (Adinkra-derived per B-0623,
+HSM-derived), and optional standalone-npm packaging.
+
+**Before it holds anything real**, the crypto-don't-rush gate below still
+applies — KATs against Noble's vectors + formal verification + security-ops
+review of the envelope and key-handling. A green wiring suite is necessary, not
+sufficient.
 
 ## Phase 2 operator decisions (2026-05-29)
 

--- a/tools/crypto/better-git-crypt/README.md
+++ b/tools/crypto/better-git-crypt/README.md
@@ -1,10 +1,10 @@
-# `tools/crypto/better-git-crypt/` — B-0883 v1 PoC scaffold
+# `tools/crypto/better-git-crypt/` — B-0883 v1 (Phase 2: real crypto)
 
-PoC scaffold for the better-git-crypt v1 spec — post-quantum (Noble + XWing + ML-DSA-65 + CBOR envelope) replacement for legacy git-crypt, per [B-0883](../../../docs/backlog/P1/B-0883-better-gitcrypt-post-quantum-lattice-based-retraction-native-diff-readable-bouncy-castle-patterns-aaron-2026-05-28.md) + [v1 design memo](../../../docs/research/2026-05-28-b-0883-v1-design-memo-noble-xwing-mldsa65-cbor-envelope-with-locked-decisions.md).
+Post-quantum (Noble + XWing + ML-DSA-65 + CBOR envelope) replacement for legacy git-crypt, per [B-0883](../../../docs/backlog/P1/B-0883-better-gitcrypt-post-quantum-lattice-based-retraction-native-diff-readable-bouncy-castle-patterns-aaron-2026-05-28.md) + [v1 design memo](../../../docs/research/2026-05-28-b-0883-v1-design-memo-noble-xwing-mldsa65-cbor-envelope-with-locked-decisions.md).
 
 ## Scope
 
-**PoC**: declarative TS type substrate + CLI dispatcher + invariant tests. Implements:
+**Phase 1 (scaffold)**: declarative TS type substrate + CLI dispatcher + invariant tests.
 
 - Algorithm registry (`ALG_REGISTRY`) typed per `AlgSpec` with `class` + `status` discriminator
 - File envelope (`FileEnvelope`) typed per the v1 design memo's CBOR shape
@@ -12,29 +12,38 @@ PoC scaffold for the better-git-crypt v1 spec — post-quantum (Noble + XWing + 
 - Validation invariants (`validateAlgRegistry` + `validateEnvelopeStructure` + `validateEncryptionContext`) enforced at runtime + by unit tests
 - CLI scaffold with `--list-algs` / `--validate` / `--dry-run-envelope` modes
 
-**NOT in PoC** (deferred to Phase 2 operator-authorized work):
+**Phase 2 (real crypto — IMPLEMENTED, operator-authorized 2026-05-31, `crypto.ts`)**:
 
-- Real `@noble/post-quantum` integration (KEM + signature operations)
-- Real CBOR encoding (cbor-x or similar)
-- Real ChaCha20-Poly1305 content encryption via `@noble/ciphers`
-- HKDF-SHA256 key derivation via `@noble/hashes`
+- ✅ Real `@noble/post-quantum` integration — XWing KEM encapsulate/decapsulate + ML-DSA-65 sign/verify
+- ✅ Real CBOR envelope encode/decode via `cborg` (canonical/deterministic — the signature is computed over the encoded bytes, so deterministic encoding makes sign/verify agree)
+- ✅ Real ChaCha20-Poly1305 content + CEK-wrap AEAD via `@noble/ciphers`
+- ✅ HKDF-SHA256 key derivation via `@noble/hashes`
+- ✅ `generateRecipientKeyPair` / `encrypt` / `decrypt` / `encodeEnvelope` / `decodeEnvelope` — full round-trip, signature-first fail-closed verification, FIPS-203 implicit-rejection handling
+- API shapes empirically verified against installed packages (`crypto.test.ts` — 23 tests: keygen, multi-recipient round-trip, tamper-detection, wrong-recipient, on-disk CBOR codec)
+
+**Still deferred (post-Phase-2)**:
+
 - `git textconv` filter integration for diff-readable ciphertext
 - Recipient management (`.zeta-crypt/recipients.json` + rotation per B-0883.3)
-- Multi-cipher hedge implementations (Saber / NTRU-Prime / FrodoKEM per B-0883.2) — deferred until TS-native impls mature
+- Multi-cipher hedge implementations (Saber / NTRU-Prime / FrodoKEM per B-0883.2) — until TS-native impls mature
 - Metadata encryption (filenames / commit messages per B-0883.5) — v1 content-only
+
+## Dependencies (pinned current-latest per dep-pin-search-first-authority, verified 2026-05-31)
+
+`@noble/post-quantum@0.6.1` · `@noble/ciphers@2.2.0` · `@noble/hashes@2.2.0` · `cborg@5.1.1`
 
 ## v1 algorithms (per design memo + B-0883.1 library landscape audit)
 
-| Class | Algorithm | Status | Noble module |
-|---|---|---|---|
-| KEM | ML-KEM-768 + X25519 (XWing hybrid) | ships-v1 | `@noble/post-quantum/ml-kem` |
-| KEM | Saber | deferred-alternate (B-0883.2) | — |
-| KEM | NTRU-Prime | deferred-alternate (B-0883.2) | — |
-| KEM | FrodoKEM | deferred-alternate (B-0883.2) | — |
-| Signature | ML-DSA-65 | ships-v1 | `@noble/post-quantum/ml-dsa` |
-| Signature | SLH-DSA (SPHINCS+) | ships-v1 | `@noble/post-quantum/slh-dsa` |
-| KDF | HKDF-SHA256 | ships-v1 | `@noble/hashes/hkdf` |
-| AEAD | ChaCha20-Poly1305 | ships-v1 | `@noble/ciphers/chacha` |
+| Class     | Algorithm                          | Status                        | Noble module                  |
+| --------- | ---------------------------------- | ----------------------------- | ----------------------------- |
+| KEM       | ML-KEM-768 + X25519 (XWing hybrid) | ships-v1                      | `@noble/post-quantum/ml-kem`  |
+| KEM       | Saber                              | deferred-alternate (B-0883.2) | —                             |
+| KEM       | NTRU-Prime                         | deferred-alternate (B-0883.2) | —                             |
+| KEM       | FrodoKEM                           | deferred-alternate (B-0883.2) | —                             |
+| Signature | ML-DSA-65                          | ships-v1                      | `@noble/post-quantum/ml-dsa`  |
+| Signature | SLH-DSA (SPHINCS+)                 | ships-v1                      | `@noble/post-quantum/slh-dsa` |
+| KDF       | HKDF-SHA256                        | ships-v1                      | `@noble/hashes/hkdf`          |
+| AEAD      | ChaCha20-Poly1305                  | ships-v1                      | `@noble/ciphers/chacha`       |
 
 ## CLI
 
@@ -85,17 +94,17 @@ When operator authorizes Phase 2:
 ## Phase 2 operator decisions (2026-05-29)
 
 Operator-authorized Phase 2, with four decisions settled + a sequencing directive
-(*"do what's easy first and expand; all those other opens should be backlogged and
-picked up based on our audience"*). Process gate alongside: **KATs against Noble's
+(_"do what's easy first and expand; all those other opens should be backlogged and
+picked up based on our audience"_). Process gate alongside: **KATs against Noble's
 vectors, plus formal-verification and security-ops review of the
 envelope and key-handling, BEFORE it holds anything real** (crypto-don't-rush).
 
-| Decision | Choice | Notes |
-|---|---|---|
-| **Key custody** | OS keychain | Per-machine secure store (macOS Keychain etc.); per-agent keypairs the same way; private keys never touch the repo. |
-| **Key-loss / recovery** | N-of-M social recovery | Any N of M trusted holders jointly recover; composes B-0634 + the distributed-Guardian; preserve-forever survives a lost key. |
-| **Tiers** | Tiered lane; weapon-face uncreated | Tiers for agent-private + charged-personal; the working-bystander-harm-payload tier stays **uncreated**, not merely encrypted (don't-rush-something-that-can-hurt-bystanders). |
-| **v1 scope** | Crypto-only first | Encrypt/decrypt + KATs + peer-review first; Agora-V6 budget-gating (B-0646 / B-0883.16) deferred to a later step. |
+| Decision                | Choice                             | Notes                                                                                                                                                                          |
+| ----------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Key custody**         | OS keychain                        | Per-machine secure store (macOS Keychain etc.); per-agent keypairs the same way; private keys never touch the repo.                                                            |
+| **Key-loss / recovery** | N-of-M social recovery             | Any N of M trusted holders jointly recover; composes B-0634 + the distributed-Guardian; preserve-forever survives a lost key.                                                  |
+| **Tiers**               | Tiered lane; weapon-face uncreated | Tiers for agent-private + charged-personal; the working-bystander-harm-payload tier stays **uncreated**, not merely encrypted (don't-rush-something-that-can-hurt-bystanders). |
+| **v1 scope**            | Crypto-only first                  | Encrypt/decrypt + KATs + peer-review first; Agora-V6 budget-gating (B-0646 / B-0883.16) deferred to a later step.                                                              |
 
 ### Easy-first slice (do now)
 
@@ -109,15 +118,15 @@ minimal verifiable lane; it does NOT yet hold real material (peer-review gate fi
 
 Most deferred opens are **already backlogged** as B-0883 sub-rows — verify before minting:
 
-| Deferred open | Existing row | Audience |
-|---|---|---|
-| Multi-cipher hedge | B-0883.2 | crypto-resilience |
-| Recipient rotation / revocation | B-0883.3 | multi-agent |
-| Metadata (filename / commit-msg) encryption | B-0883.5 | privacy-completeness |
-| Budget-gating (encryption-as-earned) | B-0883.16 / B-0646 | Agora economy |
-| Readable-ciphertext format / textconv | B-0883.17 | reviewers / glass-halo |
-| Agent-private encrypted state | B-0885 | factory agents first, then co-maintainer ASAP |
-| Encryption thermal-cost | B-0906 | thermodynamic substrate |
+| Deferred open                               | Existing row       | Audience                                      |
+| ------------------------------------------- | ------------------ | --------------------------------------------- |
+| Multi-cipher hedge                          | B-0883.2           | crypto-resilience                             |
+| Recipient rotation / revocation             | B-0883.3           | multi-agent                                   |
+| Metadata (filename / commit-msg) encryption | B-0883.5           | privacy-completeness                          |
+| Budget-gating (encryption-as-earned)        | B-0883.16 / B-0646 | Agora economy                                 |
+| Readable-ciphertext format / textconv       | B-0883.17          | reviewers / glass-halo                        |
+| Agent-private encrypted state               | B-0885             | factory agents first, then co-maintainer ASAP |
+| Encryption thermal-cost                     | B-0906             | thermodynamic substrate                       |
 
 **Gaps to file** (the two decisions that lack a dedicated row): **N-of-M social recovery
 infra** (audience: operator / preserve-forever) and **tier-tagging + weapon-face-uncreated

--- a/tools/crypto/better-git-crypt/README.md
+++ b/tools/crypto/better-git-crypt/README.md
@@ -34,16 +34,22 @@ Post-quantum (Noble + XWing + ML-DSA-65 + CBOR envelope) replacement for legacy 
 
 ## v1 algorithms (per design memo + B-0883.1 library landscape audit)
 
-| Class     | Algorithm                          | Status                        | Noble module                  |
-| --------- | ---------------------------------- | ----------------------------- | ----------------------------- |
-| KEM       | ML-KEM-768 + X25519 (XWing hybrid) | ships-v1                      | `@noble/post-quantum/ml-kem`  |
-| KEM       | Saber                              | deferred-alternate (B-0883.2) | —                             |
-| KEM       | NTRU-Prime                         | deferred-alternate (B-0883.2) | —                             |
-| KEM       | FrodoKEM                           | deferred-alternate (B-0883.2) | —                             |
-| Signature | ML-DSA-65                          | ships-v1                      | `@noble/post-quantum/ml-dsa`  |
-| Signature | SLH-DSA (SPHINCS+)                 | ships-v1                      | `@noble/post-quantum/slh-dsa` |
-| KDF       | HKDF-SHA256                        | ships-v1                      | `@noble/hashes/hkdf`          |
-| AEAD      | ChaCha20-Poly1305                  | ships-v1                      | `@noble/ciphers/chacha`       |
+| Class     | Algorithm                          | Status                        | Noble module                                                                         |
+| --------- | ---------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------ |
+| KEM       | ML-KEM-768 + X25519 (XWing hybrid) | ships-v1                      | `@noble/post-quantum/ml-kem`                                                         |
+| KEM       | Saber                              | deferred-alternate (B-0883.2) | —                                                                                    |
+| KEM       | NTRU-Prime                         | deferred-alternate (B-0883.2) | —                                                                                    |
+| KEM       | FrodoKEM                           | deferred-alternate (B-0883.2) | —                                                                                    |
+| Signature | ML-DSA-65                          | ships-v1                      | `@noble/post-quantum/ml-dsa`                                                         |
+| Signature | SLH-DSA (SPHINCS+)                 | deferred-alternate            | `@noble/post-quantum/slh-dsa` (Noble has it; crypto.ts v1 dispatches ML-DSA-65 only) |
+| KDF       | HKDF-SHA256                        | ships-v1                      | `@noble/hashes/hkdf`                                                                 |
+| AEAD      | ChaCha20-Poly1305                  | ships-v1                      | `@noble/ciphers/chacha`                                                              |
+
+## On-disk wire format (canonical — authoritative as implemented)
+
+The signed on-disk envelope is **canonical CBOR** (cborg) of a **flat, camelCase** object. This is the authoritative schema — it supersedes the v1 design memo's pre-implementation sketch (which used a nested/snake_case shape). `decodeEnvelope` enforces canonical bytes: it re-encodes the reconstructed envelope and rejects any input that isn't byte-identical (so non-canonical encodings AND unknown fields fail closed — the bytes are bit-locked to the signed content).
+
+Fields: `version` (1), `context` (`"zeta.git-crypt.file.v1"`), `algKem`, `algKdf`, `algWrap`, `algContent`, `algSig`, `recipients[]` (`{ identity, kemCt, wrappedCek, kdfInfo }`), `ciphertext`, `contentNonce` (12 bytes), `signerIdentity`, `signature`. The ML-DSA-65 signature covers every field **except** `signature` itself (the "signed view"), with `context` inside the signed bytes for domain separation.
 
 ## CLI
 

--- a/tools/crypto/better-git-crypt/cli/main.ts
+++ b/tools/crypto/better-git-crypt/cli/main.ts
@@ -31,12 +31,7 @@
  * points for Phase 2.
  */
 
-import {
-  ALG_REGISTRY,
-  validateAlgRegistry,
-  validateEnvelopeStructure,
-  type FileEnvelope,
-} from "../types";
+import { ALG_REGISTRY, validateAlgRegistry, validateEnvelopeStructure, type FileEnvelope } from "../types";
 
 type Mode = "list-algs" | "validate" | "dry-run-envelope";
 
@@ -135,6 +130,7 @@ function modeDryRunEnvelope(): number {
       },
     ],
     ciphertext: new Uint8Array(0),
+    contentNonce: new Uint8Array(12),
     signerIdentity: "otto-cli@zeta",
     signature: new Uint8Array(0),
   };
@@ -159,8 +155,7 @@ function modeDryRunEnvelope(): number {
         signerIdentity: synthetic.signerIdentity,
       },
       integrationPending: {
-        nobleKemImpl:
-          "Phase 2 — @noble/post-quantum/ml-kem XWing implementation; KEM encapsulate/decapsulate",
+        nobleKemImpl: "Phase 2 — @noble/post-quantum/ml-kem XWing implementation; KEM encapsulate/decapsulate",
         nobleSigImpl: "Phase 2 — @noble/post-quantum/ml-dsa signature gen/verify",
         cborEncoding: "Phase 2 — CBOR envelope encode/decode (cbor-x or similar)",
         contentAead: "Phase 2 — @noble/ciphers ChaCha20-Poly1305 encrypt/decrypt",

--- a/tools/crypto/better-git-crypt/cli/main.ts
+++ b/tools/crypto/better-git-crypt/cli/main.ts
@@ -39,7 +39,7 @@ interface ParsedArgs {
   readonly mode: Mode;
 }
 
-function parseArgs(argv: ReadonlyArray<string>): ParsedArgs | { error: string } {
+function parseArgs(argv: readonly string[]): ParsedArgs | { error: string } {
   const args = argv.slice(2);
   if (args.length === 0) {
     return { error: "no mode specified — use --list-algs, --validate, or --dry-run-envelope" };
@@ -154,19 +154,22 @@ function modeDryRunEnvelope(): number {
         recipientCount: synthetic.recipients.length,
         signerIdentity: synthetic.signerIdentity,
       },
-      integrationPending: {
-        nobleKemImpl: "Phase 2 — @noble/post-quantum/ml-kem XWing implementation; KEM encapsulate/decapsulate",
-        nobleSigImpl: "Phase 2 — @noble/post-quantum/ml-dsa signature gen/verify",
-        cborEncoding: "Phase 2 — CBOR envelope encode/decode (cbor-x or similar)",
-        contentAead: "Phase 2 — @noble/ciphers ChaCha20-Poly1305 encrypt/decrypt",
-        kdfDerivation: "Phase 2 — @noble/hashes HKDF-SHA256 derive",
-        seedSource:
-          "Phase 2 — SeedSource dispatch (random-bytes ships v1; adinkra-derived per B-0623 future; hsm-derived future)",
-        gitTextconv: "Phase 2 — git textconv filter integration for diff-readable ciphertext",
-        recipientManagement: "Phase 2 — .zeta-crypt/recipients.json read/write + rotation",
-        multiCipherHedge:
-          "B-0883.2 deferred — Saber / NTRU-Prime / FrodoKEM ship as alternates when TS-native impls mature",
+      phase2Implemented: {
+        crypto: "../crypto.ts — generateRecipientKeyPair / encrypt / decrypt / encodeEnvelope / decodeEnvelope",
+        kem: "XWing (ML-KEM-768 + X25519) via @noble/post-quantum/hybrid",
+        signature: "ML-DSA-65 via @noble/post-quantum/ml-dsa (sign + self-verify)",
+        kdf: "HKDF-SHA256 via @noble/hashes",
+        aead: "ChaCha20-Poly1305 via @noble/ciphers (content + CEK-wrap)",
+        cbor: "canonical/deterministic envelope via cborg",
       },
+      stillDeferred: {
+        gitTextconv: "git textconv filter integration for diff-readable ciphertext",
+        recipientManagement: ".zeta-crypt/recipients.json read/write + rotation",
+        multiCipherHedge: "B-0883.2 — Saber / NTRU-Prime / FrodoKEM ship as alternates when TS-native impls mature",
+        metadataEncryption: "B-0883.5 — filenames / commit messages (v1 is content-only)",
+        seedSourcesBeyondRandom: "adinkra-derived (B-0623) + hsm-derived seed sources",
+      },
+      beforeRealUse: "KATs vs Noble vectors + formal-verification + security-ops review (crypto-don't-rush gate)",
     });
     return 0;
   } catch (e) {
@@ -182,7 +185,7 @@ function modeDryRunEnvelope(): number {
   }
 }
 
-function main(argv: ReadonlyArray<string>): number {
+function main(argv: readonly string[]): number {
   const parsed = parseArgs(argv);
   if ("error" in parsed) {
     console.error(`usage error: ${parsed.error}`);

--- a/tools/crypto/better-git-crypt/crypto.test.ts
+++ b/tools/crypto/better-git-crypt/crypto.test.ts
@@ -37,13 +37,13 @@ function ctxFor(plaintext: Uint8Array, sender: GeneratedKeyPair, recipients: Gen
 
 describe("B-0883 v1 Phase 2 — keygen", () => {
   it("generates XWing + ML-DSA-65 keypair with expected public-key sizes", () => {
-    const kp = generateRecipientKeyPair("otto-cli@zeta");
-    expect(kp.publicKey.identity).toBe("otto-cli@zeta");
+    const kp = generateRecipientKeyPair("sender@zeta");
+    expect(kp.publicKey.identity).toBe("sender@zeta");
     expect(kp.publicKey.kemAlgId).toBe("ML-KEM-768+X25519");
     expect(kp.publicKey.sigAlgId).toBe("ML-DSA-65");
     expect(kp.publicKey.publicKemKey.length).toBe(1216); // XWing public key
     expect(kp.publicKey.publicSigKey.length).toBeGreaterThan(0); // ML-DSA-65 public key
-    expect(kp.secretKeys.identity).toBe("otto-cli@zeta");
+    expect(kp.secretKeys.identity).toBe("sender@zeta");
     expect(kp.secretKeys.kemSecretKey.length).toBeGreaterThan(0);
     expect(kp.secretKeys.sigSecretKey.length).toBeGreaterThan(0);
   });
@@ -61,53 +61,53 @@ describe("B-0883 v1 Phase 2 — keygen", () => {
 
 describe("B-0883 v1 Phase 2 — encrypt/decrypt round-trip", () => {
   it("single recipient (sender == recipient) round-trips", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const sender = generateRecipientKeyPair("sender@zeta");
     const pt = utf8("the secret is in the wavefunction");
-    const enc = encrypt(ctxFor(pt, otto, [otto]), otto.secretKeys);
+    const enc = encrypt(ctxFor(pt, sender, [sender]), sender.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
-    const dec = decrypt(enc.envelope, otto.secretKeys, otto.publicKey.publicSigKey);
+    const dec = decrypt(enc.envelope, sender.secretKeys, sender.publicKey.publicSigKey);
     expect(dec.ok).toBe(true);
     if (!dec.ok) return;
     expect(str(dec.plaintext)).toBe("the secret is in the wavefunction");
   });
 
   it("multi-recipient: every recipient (and the sender) can decrypt", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
-    const addison = generateRecipientKeyPair("addison@zeta");
-    const max = generateRecipientKeyPair("max@zeta");
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const recipientA = generateRecipientKeyPair("recipient-a@zeta");
+    const recipientB = generateRecipientKeyPair("recipient-b@zeta");
     const pt = utf8("three-party shared secret");
-    // sender (otto) must be in the recipient set for round-trip recovery
-    const enc = encrypt(ctxFor(pt, otto, [otto, addison, max]), otto.secretKeys);
+    // sender (sender) must be in the recipient set for round-trip recovery
+    const enc = encrypt(ctxFor(pt, sender, [sender, recipientA, recipientB]), sender.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
     expect(enc.envelope.recipients.length).toBe(3);
 
-    for (const who of [otto, addison, max]) {
-      const dec = decrypt(enc.envelope, who.secretKeys, otto.publicKey.publicSigKey);
+    for (const who of [sender, recipientA, recipientB]) {
+      const dec = decrypt(enc.envelope, who.secretKeys, sender.publicKey.publicSigKey);
       expect(dec.ok).toBe(true);
       if (dec.ok) expect(str(dec.plaintext)).toBe("three-party shared secret");
     }
   });
 
   it("empty plaintext round-trips", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
-    const enc = encrypt(ctxFor(new Uint8Array(0), otto, [otto]), otto.secretKeys);
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const enc = encrypt(ctxFor(new Uint8Array(0), sender, [sender]), sender.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
-    const dec = decrypt(enc.envelope, otto.secretKeys, otto.publicKey.publicSigKey);
+    const dec = decrypt(enc.envelope, sender.secretKeys, sender.publicKey.publicSigKey);
     expect(dec.ok).toBe(true);
     if (dec.ok) expect(dec.plaintext.length).toBe(0);
   });
 
   it("larger binary payload round-trips byte-for-byte", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const sender = generateRecipientKeyPair("sender@zeta");
     const pt = new Uint8Array(8192);
     for (let i = 0; i < pt.length; i++) pt[i] = (i * 37 + 11) & 0xff;
-    const enc = encrypt(ctxFor(pt, otto, [otto]), otto.secretKeys);
+    const enc = encrypt(ctxFor(pt, sender, [sender]), sender.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
-    const dec = decrypt(enc.envelope, otto.secretKeys, otto.publicKey.publicSigKey);
+    const dec = decrypt(enc.envelope, sender.secretKeys, sender.publicKey.publicSigKey);
     expect(dec.ok).toBe(true);
     if (dec.ok) expect(Buffer.from(dec.plaintext).equals(Buffer.from(pt))).toBe(true);
   });
@@ -115,32 +115,32 @@ describe("B-0883 v1 Phase 2 — encrypt/decrypt round-trip", () => {
 
 describe("B-0883 v1 Phase 2 — encrypt failure modes (authored TFeedback)", () => {
   it("EmptyRecipientSet", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
-    const enc = encrypt(ctxFor(utf8("x"), otto, []), otto.secretKeys);
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const enc = encrypt(ctxFor(utf8("x"), sender, []), sender.secretKeys);
     expect(enc.ok).toBe(false);
     if (!enc.ok) expect(enc.feedback.kind).toBe("EmptyRecipientSet");
   });
 
   it("SenderNotInRecipientSet", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
-    const addison = generateRecipientKeyPair("addison@zeta");
-    const enc = encrypt(ctxFor(utf8("x"), otto, [addison]), otto.secretKeys);
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const recipientA = generateRecipientKeyPair("recipient-a@zeta");
+    const enc = encrypt(ctxFor(utf8("x"), sender, [recipientA]), sender.secretKeys);
     expect(enc.ok).toBe(false);
     if (!enc.ok) expect(enc.feedback.kind).toBe("SenderNotInRecipientSet");
   });
 
   it("RecipientKeyInvalid when sender secret-key identity mismatches", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const sender = generateRecipientKeyPair("sender@zeta");
     const imposter = generateRecipientKeyPair("imposter@zeta");
-    // context sender = otto, but pass imposter's secret keys
-    const enc = encrypt(ctxFor(utf8("x"), otto, [otto]), imposter.secretKeys);
+    // context sender = sender, but pass imposter's secret keys
+    const enc = encrypt(ctxFor(utf8("x"), sender, [sender]), imposter.secretKeys);
     expect(enc.ok).toBe(false);
     if (!enc.ok) expect(enc.feedback.kind).toBe("RecipientKeyInvalid");
   });
 
   it("SeedSourceNotAvailable for non-random-bytes", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
-    const enc = encrypt({ ...ctxFor(utf8("x"), otto, [otto]), seedSource: "hsm-derived" }, otto.secretKeys);
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const enc = encrypt({ ...ctxFor(utf8("x"), sender, [sender]), seedSource: "hsm-derived" }, sender.secretKeys);
     expect(enc.ok).toBe(false);
     if (!enc.ok) expect(enc.feedback.kind).toBe("SeedSourceNotAvailable");
   });
@@ -150,7 +150,7 @@ describe("B-0883 v1 Phase 2 — encrypt failure modes (authored TFeedback)", () 
     // only dispatches ml_dsa65 — encrypt must reject it rather than write an
     // envelope whose algSig label disagrees with the actual signature bytes.
     // (Codex P2 finding on PR #6217.)
-    const base = generateRecipientKeyPair("otto-cli@zeta");
+    const base = generateRecipientKeyPair("sender@zeta");
     const slhSender = { ...base.publicKey, sigAlgId: "SLH-DSA" };
     const ctx: EncryptionContext = {
       plaintext: utf8("x"),
@@ -170,91 +170,114 @@ describe("B-0883 v1 Phase 2 — encrypt failure modes (authored TFeedback)", () 
     // Right identity, WRONG sig key — encrypt self-verifies after signing and
     // must catch this at encrypt time rather than mint an undecryptable envelope.
     // (Copilot P1 finding on PR #6217.)
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const sender = generateRecipientKeyPair("sender@zeta");
     const other = generateRecipientKeyPair("other@zeta");
     const wrongKeys = {
-      identity: otto.publicKey.identity, // same identity as the declared sender
-      kemSecretKey: otto.secretKeys.kemSecretKey,
-      sigSecretKey: other.secretKeys.sigSecretKey, // but a sig key that doesn't match otto's public sig key
+      identity: sender.publicKey.identity, // same identity as the declared sender
+      kemSecretKey: sender.secretKeys.kemSecretKey,
+      sigSecretKey: other.secretKeys.sigSecretKey, // but a sig key that doesn't match sender's public sig key
     };
-    const enc = encrypt(ctxFor(utf8("x"), otto, [otto]), wrongKeys);
+    const enc = encrypt(ctxFor(utf8("x"), sender, [sender]), wrongKeys);
     expect(enc.ok).toBe(false);
     if (!enc.ok) expect(enc.feedback.kind).toBe("RecipientKeyInvalid");
+  });
+
+  it("RecipientKeyInvalid (not a throw) on a malformed sender publicSigKey", () => {
+    // Noble's verify decoder throws on a truncated key — encrypt's self-verify
+    // must catch it and return a Result, not throw. (Codex P2 on PR #6217.)
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const malformedSender = { ...sender.publicKey, publicSigKey: new Uint8Array([1, 2, 3]) };
+    const ctx: EncryptionContext = {
+      plaintext: utf8("x"),
+      recipients: [malformedSender],
+      sender: malformedSender,
+      seedSource: "random-bytes",
+    };
+    let threw = false;
+    let result: ReturnType<typeof encrypt> | undefined;
+    try {
+      result = encrypt(ctx, sender.secretKeys);
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+    expect(result?.ok).toBe(false);
+    if (result && !result.ok) expect(result.feedback.kind).toBe("RecipientKeyInvalid");
   });
 });
 
 describe("B-0883 v1 Phase 2 — decrypt failure modes (tamper detection)", () => {
   it("wrong recipient (not in envelope) -> RecipientNotInEnvelope", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const sender = generateRecipientKeyPair("sender@zeta");
     const stranger = generateRecipientKeyPair("stranger@zeta");
-    const enc = encrypt(ctxFor(utf8("secret"), otto, [otto]), otto.secretKeys);
+    const enc = encrypt(ctxFor(utf8("secret"), sender, [sender]), sender.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
-    const dec = decrypt(enc.envelope, stranger.secretKeys, otto.publicKey.publicSigKey);
+    const dec = decrypt(enc.envelope, stranger.secretKeys, sender.publicKey.publicSigKey);
     expect(dec.ok).toBe(false);
     if (!dec.ok) expect(dec.feedback.kind).toBe("RecipientNotInEnvelope");
   });
 
   it("tampered ciphertext -> SignatureInvalid (signature covers content)", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
-    const enc = encrypt(ctxFor(utf8("secret"), otto, [otto]), otto.secretKeys);
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const enc = encrypt(ctxFor(utf8("secret"), sender, [sender]), sender.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
     const tampered = new Uint8Array(enc.envelope.ciphertext);
     tampered[0] = (tampered[0] ?? 0) ^ 0xff;
-    const dec = decrypt({ ...enc.envelope, ciphertext: tampered }, otto.secretKeys, otto.publicKey.publicSigKey);
+    const dec = decrypt({ ...enc.envelope, ciphertext: tampered }, sender.secretKeys, sender.publicKey.publicSigKey);
     expect(dec.ok).toBe(false);
     if (!dec.ok) expect(dec.feedback.kind).toBe("SignatureInvalid");
   });
 
   it("tampered signature -> SignatureInvalid", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
-    const enc = encrypt(ctxFor(utf8("secret"), otto, [otto]), otto.secretKeys);
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const enc = encrypt(ctxFor(utf8("secret"), sender, [sender]), sender.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
     const sig = new Uint8Array(enc.envelope.signature);
     sig[0] = (sig[0] ?? 0) ^ 0xff;
-    const dec = decrypt({ ...enc.envelope, signature: sig }, otto.secretKeys, otto.publicKey.publicSigKey);
+    const dec = decrypt({ ...enc.envelope, signature: sig }, sender.secretKeys, sender.publicKey.publicSigKey);
     expect(dec.ok).toBe(false);
     if (!dec.ok) expect(dec.feedback.kind).toBe("SignatureInvalid");
   });
 
   it("wrong sender public sig key -> SignatureInvalid", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const sender = generateRecipientKeyPair("sender@zeta");
     const other = generateRecipientKeyPair("other@zeta");
-    const enc = encrypt(ctxFor(utf8("secret"), otto, [otto]), otto.secretKeys);
+    const enc = encrypt(ctxFor(utf8("secret"), sender, [sender]), sender.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
-    const dec = decrypt(enc.envelope, otto.secretKeys, other.publicKey.publicSigKey);
+    const dec = decrypt(enc.envelope, sender.secretKeys, other.publicKey.publicSigKey);
     expect(dec.ok).toBe(false);
     if (!dec.ok) expect(dec.feedback.kind).toBe("SignatureInvalid");
   });
 
   it("recipient present but holding wrong KEM secret key -> KemFailure", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
-    const addison = generateRecipientKeyPair("addison@zeta");
-    const enc = encrypt(ctxFor(utf8("secret"), otto, [otto, addison]), otto.secretKeys);
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const recipientA = generateRecipientKeyPair("recipient-a@zeta");
+    const enc = encrypt(ctxFor(utf8("secret"), sender, [sender, recipientA]), sender.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
-    // addison's slot exists, but supply a mismatched KEM secret key (otto's)
+    // recipientA's slot exists, but supply a mismatched KEM secret key (sender's)
     const wrongKeys = {
-      identity: "addison@zeta",
-      kemSecretKey: otto.secretKeys.kemSecretKey,
-      sigSecretKey: addison.secretKeys.sigSecretKey,
+      identity: "recipient-a@zeta",
+      kemSecretKey: sender.secretKeys.kemSecretKey,
+      sigSecretKey: recipientA.secretKeys.sigSecretKey,
     };
-    const dec = decrypt(enc.envelope, wrongKeys, otto.publicKey.publicSigKey);
+    const dec = decrypt(enc.envelope, wrongKeys, sender.publicKey.publicSigKey);
     expect(dec.ok).toBe(false);
     if (!dec.ok) expect(dec.feedback.kind).toBe("KemFailure");
   });
 
   it("context mismatch -> ContextMismatch", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
-    const enc = encrypt(ctxFor(utf8("secret"), otto, [otto]), otto.secretKeys);
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const enc = encrypt(ctxFor(utf8("secret"), sender, [sender]), sender.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
     // decrypt checks context BEFORE structural validation + signature verify,
     // so a wrong context must surface the precise ContextMismatch feedback.
-    const dec = decrypt({ ...enc.envelope, context: "wrong.ctx.v1" }, otto.secretKeys, otto.publicKey.publicSigKey);
+    const dec = decrypt({ ...enc.envelope, context: "wrong.ctx.v1" }, sender.secretKeys, sender.publicKey.publicSigKey);
     expect(dec.ok).toBe(false);
     if (!dec.ok) expect(dec.feedback.kind).toBe("ContextMismatch");
   });
@@ -262,9 +285,9 @@ describe("B-0883 v1 Phase 2 — decrypt failure modes (tamper detection)", () =>
 
 describe("B-0883 v1 Phase 2 — on-disk envelope CBOR codec", () => {
   it("encode/decode round-trips and the decoded envelope still decrypts", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
-    const addison = generateRecipientKeyPair("addison@zeta");
-    const enc = encrypt(ctxFor(utf8("persisted to git, read later"), otto, [otto, addison]), otto.secretKeys);
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const recipientA = generateRecipientKeyPair("recipient-a@zeta");
+    const enc = encrypt(ctxFor(utf8("persisted to git, read later"), sender, [sender, recipientA]), sender.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
 
@@ -281,7 +304,7 @@ describe("B-0883 v1 Phase 2 — on-disk envelope CBOR codec", () => {
     expect(decoded.envelope.contentNonce.length).toBe(12);
 
     // The decoded envelope must still decrypt (proves the persist->observe bridge)
-    const dec = decrypt(decoded.envelope, addison.secretKeys, otto.publicKey.publicSigKey);
+    const dec = decrypt(decoded.envelope, recipientA.secretKeys, sender.publicKey.publicSigKey);
     expect(dec.ok).toBe(true);
     if (dec.ok) expect(str(dec.plaintext)).toBe("persisted to git, read later");
   });
@@ -295,8 +318,8 @@ describe("B-0883 v1 Phase 2 — on-disk envelope CBOR codec", () => {
   it("decodeEnvelope rejects a wrong-length contentNonce with EnvelopeMalformed", () => {
     // A signed-but-malformed nonce must fail structurally at decode, not later
     // as a content decrypt error. (Copilot finding on PR #6217.)
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
-    const enc = encrypt(ctxFor(utf8("x"), otto, [otto]), otto.secretKeys);
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const enc = encrypt(ctxFor(utf8("x"), sender, [sender]), sender.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
     const bytes = encodeEnvelope({ ...enc.envelope, contentNonce: new Uint8Array(8) }); // wrong length
@@ -305,9 +328,25 @@ describe("B-0883 v1 Phase 2 — on-disk envelope CBOR codec", () => {
     if (!decoded.ok) expect(decoded.feedback.kind).toBe("EnvelopeMalformed");
   });
 
+  it("decodeEnvelope reports VersionUnsupported for a well-formed future version", () => {
+    // A well-formed envelope of an unsupported version must get the precise
+    // VersionUnsupported feedback, not generic EnvelopeMalformed. (Copilot P1.)
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const enc = encrypt(ctxFor(utf8("x"), sender, [sender]), sender.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    const bytes = encodeEnvelope({ ...enc.envelope, version: 2 as unknown as 1 });
+    const decoded = decodeEnvelope(bytes);
+    expect(decoded.ok).toBe(false);
+    if (!decoded.ok) {
+      expect(decoded.feedback.kind).toBe("VersionUnsupported");
+      if (decoded.feedback.kind === "VersionUnsupported") expect(decoded.feedback.version).toBe(2);
+    }
+  });
+
   it("encodeEnvelope is deterministic (same envelope -> same bytes)", () => {
-    const otto = generateRecipientKeyPair("otto-cli@zeta");
-    const enc = encrypt(ctxFor(utf8("determinism"), otto, [otto]), otto.secretKeys);
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const enc = encrypt(ctxFor(utf8("determinism"), sender, [sender]), sender.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
     const a = encodeEnvelope(enc.envelope);

--- a/tools/crypto/better-git-crypt/crypto.test.ts
+++ b/tools/crypto/better-git-crypt/crypto.test.ts
@@ -204,6 +204,22 @@ describe("B-0883 v1 Phase 2 — encrypt failure modes (authored TFeedback)", () 
     expect(result?.ok).toBe(false);
     if (result && !result.ok) expect(result.feedback.kind).toBe("RecipientKeyInvalid");
   });
+
+  it("RecipientKeyInvalid: rejects duplicate recipient identities", () => {
+    // Two slots for one identity would make decrypt's first-match resolution
+    // skip a valid later slot -> spurious KemFailure. (Codex P2 on PR #6217.)
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const dupeStale = { ...generateRecipientKeyPair("sender@zeta").publicKey }; // same identity, different keys
+    const ctx: EncryptionContext = {
+      plaintext: utf8("x"),
+      recipients: [sender.publicKey, dupeStale],
+      sender: sender.publicKey,
+      seedSource: "random-bytes",
+    };
+    const enc = encrypt(ctx, sender.secretKeys);
+    expect(enc.ok).toBe(false);
+    if (!enc.ok) expect(enc.feedback.kind).toBe("RecipientKeyInvalid");
+  });
 });
 
 describe("B-0883 v1 Phase 2 — decrypt failure modes (tamper detection)", () => {

--- a/tools/crypto/better-git-crypt/crypto.test.ts
+++ b/tools/crypto/better-git-crypt/crypto.test.ts
@@ -165,6 +165,22 @@ describe("B-0883 v1 Phase 2 — encrypt failure modes (authored TFeedback)", () 
       if (enc.feedback.kind === "AlgUnsupported") expect(enc.feedback.algId).toBe("SLH-DSA");
     }
   });
+
+  it("RecipientKeyInvalid: sender secret key doesn't match declared public sig key", () => {
+    // Right identity, WRONG sig key — encrypt self-verifies after signing and
+    // must catch this at encrypt time rather than mint an undecryptable envelope.
+    // (Copilot P1 finding on PR #6217.)
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const other = generateRecipientKeyPair("other@zeta");
+    const wrongKeys = {
+      identity: otto.publicKey.identity, // same identity as the declared sender
+      kemSecretKey: otto.secretKeys.kemSecretKey,
+      sigSecretKey: other.secretKeys.sigSecretKey, // but a sig key that doesn't match otto's public sig key
+    };
+    const enc = encrypt(ctxFor(utf8("x"), otto, [otto]), wrongKeys);
+    expect(enc.ok).toBe(false);
+    if (!enc.ok) expect(enc.feedback.kind).toBe("RecipientKeyInvalid");
+  });
 });
 
 describe("B-0883 v1 Phase 2 — decrypt failure modes (tamper detection)", () => {
@@ -236,12 +252,11 @@ describe("B-0883 v1 Phase 2 — decrypt failure modes (tamper detection)", () =>
     const enc = encrypt(ctxFor(utf8("secret"), otto, [otto]), otto.secretKeys);
     expect(enc.ok).toBe(true);
     if (!enc.ok) return;
-    // Mutating context breaks the signature first; verify it fails closed.
+    // decrypt checks context BEFORE structural validation + signature verify,
+    // so a wrong context must surface the precise ContextMismatch feedback.
     const dec = decrypt({ ...enc.envelope, context: "wrong.ctx.v1" }, otto.secretKeys, otto.publicKey.publicSigKey);
     expect(dec.ok).toBe(false);
-    // EnvelopeMalformed (structural validator rejects bad context) is the
-    // first gate; either that or SignatureInvalid is acceptable fail-closed.
-    if (!dec.ok) expect(["EnvelopeMalformed", "ContextMismatch", "SignatureInvalid"]).toContain(dec.feedback.kind);
+    if (!dec.ok) expect(dec.feedback.kind).toBe("ContextMismatch");
   });
 });
 
@@ -273,6 +288,19 @@ describe("B-0883 v1 Phase 2 — on-disk envelope CBOR codec", () => {
 
   it("decodeEnvelope rejects garbage bytes with EnvelopeMalformed", () => {
     const decoded = decodeEnvelope(new Uint8Array([0xff, 0x00, 0x13, 0x37]));
+    expect(decoded.ok).toBe(false);
+    if (!decoded.ok) expect(decoded.feedback.kind).toBe("EnvelopeMalformed");
+  });
+
+  it("decodeEnvelope rejects a wrong-length contentNonce with EnvelopeMalformed", () => {
+    // A signed-but-malformed nonce must fail structurally at decode, not later
+    // as a content decrypt error. (Copilot finding on PR #6217.)
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const enc = encrypt(ctxFor(utf8("x"), otto, [otto]), otto.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    const bytes = encodeEnvelope({ ...enc.envelope, contentNonce: new Uint8Array(8) }); // wrong length
+    const decoded = decodeEnvelope(bytes);
     expect(decoded.ok).toBe(false);
     if (!decoded.ok) expect(decoded.feedback.kind).toBe("EnvelopeMalformed");
   });

--- a/tools/crypto/better-git-crypt/crypto.test.ts
+++ b/tools/crypto/better-git-crypt/crypto.test.ts
@@ -1,0 +1,268 @@
+/**
+ * tools/crypto/better-git-crypt/crypto.test.ts
+ *
+ * B-0883 v1 Phase 2 — real-crypto round-trip + tamper-detection tests.
+ *
+ * These tests ARE the no-human-intervention oracle: they exercise the actual
+ * @noble post-quantum primitives end-to-end. A green run proves the wiring
+ * (XWing KEM + ML-DSA-65 sig + HKDF + ChaCha20-Poly1305 + CBOR envelope) is
+ * correct against the installed package versions.
+ *
+ * Run via: bun test tools/crypto/better-git-crypt/crypto.test.ts
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  generateRecipientKeyPair,
+  encrypt,
+  decrypt,
+  encodeEnvelope,
+  decodeEnvelope,
+  type GeneratedKeyPair,
+} from "./crypto";
+import type { EncryptionContext } from "./types";
+
+const utf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
+const str = (b: Uint8Array): string => new TextDecoder().decode(b);
+
+/** Build an EncryptionContext from generated keypairs. */
+function ctxFor(plaintext: Uint8Array, sender: GeneratedKeyPair, recipients: GeneratedKeyPair[]): EncryptionContext {
+  return {
+    plaintext,
+    recipients: recipients.map((r) => r.publicKey),
+    sender: sender.publicKey,
+    seedSource: "random-bytes",
+  };
+}
+
+describe("B-0883 v1 Phase 2 — keygen", () => {
+  it("generates XWing + ML-DSA-65 keypair with expected public-key sizes", () => {
+    const kp = generateRecipientKeyPair("otto-cli@zeta");
+    expect(kp.publicKey.identity).toBe("otto-cli@zeta");
+    expect(kp.publicKey.kemAlgId).toBe("ML-KEM-768+X25519");
+    expect(kp.publicKey.sigAlgId).toBe("ML-DSA-65");
+    expect(kp.publicKey.publicKemKey.length).toBe(1216); // XWing public key
+    expect(kp.publicKey.publicSigKey.length).toBeGreaterThan(0); // ML-DSA-65 public key
+    expect(kp.secretKeys.identity).toBe("otto-cli@zeta");
+    expect(kp.secretKeys.kemSecretKey.length).toBeGreaterThan(0);
+    expect(kp.secretKeys.sigSecretKey.length).toBeGreaterThan(0);
+  });
+
+  it("two keypairs differ (fresh randomness)", () => {
+    const a = generateRecipientKeyPair("a@zeta");
+    const b = generateRecipientKeyPair("b@zeta");
+    expect(Buffer.from(a.publicKey.publicKemKey).equals(Buffer.from(b.publicKey.publicKemKey))).toBe(false);
+  });
+
+  it("rejects non-random-bytes seed source in v1", () => {
+    expect(() => generateRecipientKeyPair("x@zeta", "adinkra-derived")).toThrow(/not available in v1/);
+  });
+});
+
+describe("B-0883 v1 Phase 2 — encrypt/decrypt round-trip", () => {
+  it("single recipient (sender == recipient) round-trips", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const pt = utf8("the secret is in the wavefunction");
+    const enc = encrypt(ctxFor(pt, otto, [otto]), otto.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    const dec = decrypt(enc.envelope, otto.secretKeys, otto.publicKey.publicSigKey);
+    expect(dec.ok).toBe(true);
+    if (!dec.ok) return;
+    expect(str(dec.plaintext)).toBe("the secret is in the wavefunction");
+  });
+
+  it("multi-recipient: every recipient (and the sender) can decrypt", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const addison = generateRecipientKeyPair("addison@zeta");
+    const max = generateRecipientKeyPair("max@zeta");
+    const pt = utf8("three-party shared secret");
+    // sender (otto) must be in the recipient set for round-trip recovery
+    const enc = encrypt(ctxFor(pt, otto, [otto, addison, max]), otto.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    expect(enc.envelope.recipients.length).toBe(3);
+
+    for (const who of [otto, addison, max]) {
+      const dec = decrypt(enc.envelope, who.secretKeys, otto.publicKey.publicSigKey);
+      expect(dec.ok).toBe(true);
+      if (dec.ok) expect(str(dec.plaintext)).toBe("three-party shared secret");
+    }
+  });
+
+  it("empty plaintext round-trips", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const enc = encrypt(ctxFor(new Uint8Array(0), otto, [otto]), otto.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    const dec = decrypt(enc.envelope, otto.secretKeys, otto.publicKey.publicSigKey);
+    expect(dec.ok).toBe(true);
+    if (dec.ok) expect(dec.plaintext.length).toBe(0);
+  });
+
+  it("larger binary payload round-trips byte-for-byte", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const pt = new Uint8Array(8192);
+    for (let i = 0; i < pt.length; i++) pt[i] = (i * 37 + 11) & 0xff;
+    const enc = encrypt(ctxFor(pt, otto, [otto]), otto.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    const dec = decrypt(enc.envelope, otto.secretKeys, otto.publicKey.publicSigKey);
+    expect(dec.ok).toBe(true);
+    if (dec.ok) expect(Buffer.from(dec.plaintext).equals(Buffer.from(pt))).toBe(true);
+  });
+});
+
+describe("B-0883 v1 Phase 2 — encrypt failure modes (authored TFeedback)", () => {
+  it("EmptyRecipientSet", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const enc = encrypt(ctxFor(utf8("x"), otto, []), otto.secretKeys);
+    expect(enc.ok).toBe(false);
+    if (!enc.ok) expect(enc.feedback.kind).toBe("EmptyRecipientSet");
+  });
+
+  it("SenderNotInRecipientSet", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const addison = generateRecipientKeyPair("addison@zeta");
+    const enc = encrypt(ctxFor(utf8("x"), otto, [addison]), otto.secretKeys);
+    expect(enc.ok).toBe(false);
+    if (!enc.ok) expect(enc.feedback.kind).toBe("SenderNotInRecipientSet");
+  });
+
+  it("RecipientKeyInvalid when sender secret-key identity mismatches", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const imposter = generateRecipientKeyPair("imposter@zeta");
+    // context sender = otto, but pass imposter's secret keys
+    const enc = encrypt(ctxFor(utf8("x"), otto, [otto]), imposter.secretKeys);
+    expect(enc.ok).toBe(false);
+    if (!enc.ok) expect(enc.feedback.kind).toBe("RecipientKeyInvalid");
+  });
+
+  it("SeedSourceNotAvailable for non-random-bytes", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const enc = encrypt({ ...ctxFor(utf8("x"), otto, [otto]), seedSource: "hsm-derived" }, otto.secretKeys);
+    expect(enc.ok).toBe(false);
+    if (!enc.ok) expect(enc.feedback.kind).toBe("SeedSourceNotAvailable");
+  });
+});
+
+describe("B-0883 v1 Phase 2 — decrypt failure modes (tamper detection)", () => {
+  it("wrong recipient (not in envelope) -> RecipientNotInEnvelope", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const stranger = generateRecipientKeyPair("stranger@zeta");
+    const enc = encrypt(ctxFor(utf8("secret"), otto, [otto]), otto.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    const dec = decrypt(enc.envelope, stranger.secretKeys, otto.publicKey.publicSigKey);
+    expect(dec.ok).toBe(false);
+    if (!dec.ok) expect(dec.feedback.kind).toBe("RecipientNotInEnvelope");
+  });
+
+  it("tampered ciphertext -> SignatureInvalid (signature covers content)", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const enc = encrypt(ctxFor(utf8("secret"), otto, [otto]), otto.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    const tampered = new Uint8Array(enc.envelope.ciphertext);
+    tampered[0] = (tampered[0] ?? 0) ^ 0xff;
+    const dec = decrypt({ ...enc.envelope, ciphertext: tampered }, otto.secretKeys, otto.publicKey.publicSigKey);
+    expect(dec.ok).toBe(false);
+    if (!dec.ok) expect(dec.feedback.kind).toBe("SignatureInvalid");
+  });
+
+  it("tampered signature -> SignatureInvalid", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const enc = encrypt(ctxFor(utf8("secret"), otto, [otto]), otto.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    const sig = new Uint8Array(enc.envelope.signature);
+    sig[0] = (sig[0] ?? 0) ^ 0xff;
+    const dec = decrypt({ ...enc.envelope, signature: sig }, otto.secretKeys, otto.publicKey.publicSigKey);
+    expect(dec.ok).toBe(false);
+    if (!dec.ok) expect(dec.feedback.kind).toBe("SignatureInvalid");
+  });
+
+  it("wrong sender public sig key -> SignatureInvalid", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const other = generateRecipientKeyPair("other@zeta");
+    const enc = encrypt(ctxFor(utf8("secret"), otto, [otto]), otto.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    const dec = decrypt(enc.envelope, otto.secretKeys, other.publicKey.publicSigKey);
+    expect(dec.ok).toBe(false);
+    if (!dec.ok) expect(dec.feedback.kind).toBe("SignatureInvalid");
+  });
+
+  it("recipient present but holding wrong KEM secret key -> KemFailure", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const addison = generateRecipientKeyPair("addison@zeta");
+    const enc = encrypt(ctxFor(utf8("secret"), otto, [otto, addison]), otto.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    // addison's slot exists, but supply a mismatched KEM secret key (otto's)
+    const wrongKeys = {
+      identity: "addison@zeta",
+      kemSecretKey: otto.secretKeys.kemSecretKey,
+      sigSecretKey: addison.secretKeys.sigSecretKey,
+    };
+    const dec = decrypt(enc.envelope, wrongKeys, otto.publicKey.publicSigKey);
+    expect(dec.ok).toBe(false);
+    if (!dec.ok) expect(dec.feedback.kind).toBe("KemFailure");
+  });
+
+  it("context mismatch -> ContextMismatch", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const enc = encrypt(ctxFor(utf8("secret"), otto, [otto]), otto.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    // Mutating context breaks the signature first; verify it fails closed.
+    const dec = decrypt({ ...enc.envelope, context: "wrong.ctx.v1" }, otto.secretKeys, otto.publicKey.publicSigKey);
+    expect(dec.ok).toBe(false);
+    // EnvelopeMalformed (structural validator rejects bad context) is the
+    // first gate; either that or SignatureInvalid is acceptable fail-closed.
+    if (!dec.ok) expect(["EnvelopeMalformed", "ContextMismatch", "SignatureInvalid"]).toContain(dec.feedback.kind);
+  });
+});
+
+describe("B-0883 v1 Phase 2 — on-disk envelope CBOR codec", () => {
+  it("encode/decode round-trips and the decoded envelope still decrypts", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const addison = generateRecipientKeyPair("addison@zeta");
+    const enc = encrypt(ctxFor(utf8("persisted to git, read later"), otto, [otto, addison]), otto.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+
+    const bytes = encodeEnvelope(enc.envelope);
+    expect(bytes.length).toBeGreaterThan(0);
+
+    const decoded = decodeEnvelope(bytes);
+    expect(decoded.ok).toBe(true);
+    if (!decoded.ok) return;
+
+    // Field-level fidelity
+    expect(decoded.envelope.context).toBe("zeta.git-crypt.file.v1");
+    expect(decoded.envelope.recipients.length).toBe(2);
+    expect(decoded.envelope.contentNonce.length).toBe(12);
+
+    // The decoded envelope must still decrypt (proves the persist->observe bridge)
+    const dec = decrypt(decoded.envelope, addison.secretKeys, otto.publicKey.publicSigKey);
+    expect(dec.ok).toBe(true);
+    if (dec.ok) expect(str(dec.plaintext)).toBe("persisted to git, read later");
+  });
+
+  it("decodeEnvelope rejects garbage bytes with EnvelopeMalformed", () => {
+    const decoded = decodeEnvelope(new Uint8Array([0xff, 0x00, 0x13, 0x37]));
+    expect(decoded.ok).toBe(false);
+    if (!decoded.ok) expect(decoded.feedback.kind).toBe("EnvelopeMalformed");
+  });
+
+  it("encodeEnvelope is deterministic (same envelope -> same bytes)", () => {
+    const otto = generateRecipientKeyPair("otto-cli@zeta");
+    const enc = encrypt(ctxFor(utf8("determinism"), otto, [otto]), otto.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    const a = encodeEnvelope(enc.envelope);
+    const b = encodeEnvelope(enc.envelope);
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+  });
+});

--- a/tools/crypto/better-git-crypt/crypto.test.ts
+++ b/tools/crypto/better-git-crypt/crypto.test.ts
@@ -144,6 +144,27 @@ describe("B-0883 v1 Phase 2 — encrypt failure modes (authored TFeedback)", () 
     expect(enc.ok).toBe(false);
     if (!enc.ok) expect(enc.feedback.kind).toBe("SeedSourceNotAvailable");
   });
+
+  it("AlgUnsupported: rejects a non-ML-DSA-65 signature alg (no lying metadata)", () => {
+    // SLH-DSA is ships-v1 in the registry + accepted by the planner, but crypto.ts
+    // only dispatches ml_dsa65 — encrypt must reject it rather than write an
+    // envelope whose algSig label disagrees with the actual signature bytes.
+    // (Codex P2 finding on PR #6217.)
+    const base = generateRecipientKeyPair("otto-cli@zeta");
+    const slhSender = { ...base.publicKey, sigAlgId: "SLH-DSA" };
+    const ctx: EncryptionContext = {
+      plaintext: utf8("x"),
+      recipients: [slhSender],
+      sender: slhSender,
+      seedSource: "random-bytes",
+    };
+    const enc = encrypt(ctx, base.secretKeys);
+    expect(enc.ok).toBe(false);
+    if (!enc.ok) {
+      expect(enc.feedback.kind).toBe("AlgUnsupported");
+      if (enc.feedback.kind === "AlgUnsupported") expect(enc.feedback.algId).toBe("SLH-DSA");
+    }
+  });
 });
 
 describe("B-0883 v1 Phase 2 — decrypt failure modes (tamper detection)", () => {

--- a/tools/crypto/better-git-crypt/crypto.test.ts
+++ b/tools/crypto/better-git-crypt/crypto.test.ts
@@ -221,6 +221,28 @@ describe("B-0883 v1 Phase 2 — encrypt failure modes (authored TFeedback)", () 
     expect(enc.ok).toBe(false);
     if (!enc.ok) expect(enc.feedback.kind).toBe("RecipientKeyInvalid");
   });
+
+  it("RecipientKeyInvalid: rejects empty sender/recipient identity", () => {
+    // generateRecipientKeyPair("") yields identity:"". Encrypting with it would
+    // mint an envelope whose signerIdentity/slot id is "" — decrypt can't
+    // resolve it later, so the artifact is undecryptable. Reject up front.
+    // (Codex P2 on PR #6217.)
+    const empty = generateRecipientKeyPair("");
+    const ctx: EncryptionContext = {
+      plaintext: utf8("x"),
+      recipients: [empty.publicKey],
+      sender: empty.publicKey,
+      seedSource: "random-bytes",
+    };
+    const enc = encrypt(ctx, empty.secretKeys);
+    expect(enc.ok).toBe(false);
+    if (!enc.ok) {
+      expect(enc.feedback.kind).toBe("RecipientKeyInvalid");
+      if (enc.feedback.kind === "RecipientKeyInvalid") {
+        expect(enc.feedback.reason).toBe("empty recipient identity");
+      }
+    }
+  });
 });
 
 describe("B-0883 v1 Phase 2 — decrypt failure modes (tamper detection)", () => {

--- a/tools/crypto/better-git-crypt/crypto.test.ts
+++ b/tools/crypto/better-git-crypt/crypto.test.ts
@@ -1,12 +1,17 @@
 /**
  * tools/crypto/better-git-crypt/crypto.test.ts
  *
- * B-0883 v1 Phase 2 — real-crypto round-trip + tamper-detection tests.
+ * B-0883 v1 Phase 2 — WIRING + tamper-detection tests.
  *
- * These tests ARE the no-human-intervention oracle: they exercise the actual
- * @noble post-quantum primitives end-to-end. A green run proves the wiring
- * (XWing KEM + ML-DSA-65 sig + HKDF + ChaCha20-Poly1305 + CBOR envelope) is
- * correct against the installed package versions.
+ * SCOPE (do not overstate): these exercise the actual @noble post-quantum
+ * primitives end-to-end and prove the API COMPOSES — encrypt→decrypt round
+ * trips, multi-recipient, empty/large payloads — and that every typed failure
+ * mode surfaces as Result feedback (tamper, wrong key, bad CBOR, version, etc).
+ * They do NOT prove cryptographic CORRECTNESS: no Known-Answer-Tests against
+ * Noble's published vectors, no formal verification of the envelope/key-handling
+ * design, no security-ops review. Those are still REQUIRED before this holds
+ * anything real — the crypto-don't-rush gate (README "Phase 2 operator
+ * decisions"). A green wiring suite is necessary, not sufficient.
  *
  * Run via: bun test tools/crypto/better-git-crypt/crypto.test.ts
  */
@@ -55,8 +60,16 @@ describe("B-0883 v1 Phase 2 — keygen", () => {
     expect(Buffer.from(a.publicKey.publicKemKey).equals(Buffer.from(b.publicKey.publicKemKey))).toBe(false);
   });
 
-  it("rejects non-random-bytes seed source in v1", () => {
-    expect(() => generateRecipientKeyPair("x@zeta", "adinkra-derived")).toThrow(/not available in v1/);
+  it("seed source is type-narrowed: an unsupported source is a COMPILE error, not a runtime throw", () => {
+    // v1 narrows the param to the literal "random-bytes", so the unsupported
+    // case is unrepresentable at compile time (Result-boundary by construction)
+    // rather than a runtime exception. (Copilot P1 on PR #6217 — an exported
+    // surface must not throw on a user-selectable option.) The @ts-expect-error
+    // IS the assertion: if the param is ever widened, this line stops erroring
+    // and the test fails, forcing a Result-shaped return at that point.
+    // @ts-expect-error "adinkra-derived" is not assignable to "random-bytes"
+    const kp = generateRecipientKeyPair("x@zeta", "adinkra-derived");
+    expect(kp.publicKey.identity).toBe("x@zeta"); // no throw — keygen just proceeds
   });
 });
 
@@ -240,6 +253,30 @@ describe("B-0883 v1 Phase 2 — encrypt failure modes (authored TFeedback)", () 
       expect(enc.feedback.kind).toBe("RecipientKeyInvalid");
       if (enc.feedback.kind === "RecipientKeyInvalid") {
         expect(enc.feedback.reason).toBe("empty recipient identity");
+      }
+    }
+  });
+
+  it("RecipientKeyInvalid: rejects a sender KEM secret that can't unwrap its own slot", () => {
+    // Right sender identity + right public keys + right SIG secret, but a
+    // stale/mismatched KEM SECRET. Signature self-verify passes; without the
+    // KEM-side self-check encrypt would mint an envelope the sender (a required
+    // self-recipient) can't decrypt. (Codex P2 on PR #6217.)
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const other = generateRecipientKeyPair("sender@zeta"); // different keys, same identity
+    const mismatchedSecrets = { ...sender.secretKeys, kemSecretKey: other.secretKeys.kemSecretKey };
+    const ctx: EncryptionContext = {
+      plaintext: utf8("x"),
+      recipients: [sender.publicKey],
+      sender: sender.publicKey,
+      seedSource: "random-bytes",
+    };
+    const enc = encrypt(ctx, mismatchedSecrets);
+    expect(enc.ok).toBe(false);
+    if (!enc.ok) {
+      expect(enc.feedback.kind).toBe("RecipientKeyInvalid");
+      if (enc.feedback.kind === "RecipientKeyInvalid") {
+        expect(enc.feedback.reason).toContain("KEM secret");
       }
     }
   });

--- a/tools/crypto/better-git-crypt/crypto.test.ts
+++ b/tools/crypto/better-git-crypt/crypto.test.ts
@@ -21,6 +21,7 @@ import {
   type GeneratedKeyPair,
 } from "./crypto";
 import type { EncryptionContext } from "./types";
+import { encode as cborEncode } from "cborg";
 
 const utf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
 const str = (b: Uint8Array): string => new TextDecoder().decode(b);
@@ -146,10 +147,10 @@ describe("B-0883 v1 Phase 2 — encrypt failure modes (authored TFeedback)", () 
   });
 
   it("AlgUnsupported: rejects a non-ML-DSA-65 signature alg (no lying metadata)", () => {
-    // SLH-DSA is ships-v1 in the registry + accepted by the planner, but crypto.ts
-    // only dispatches ml_dsa65 — encrypt must reject it rather than write an
-    // envelope whose algSig label disagrees with the actual signature bytes.
-    // (Codex P2 finding on PR #6217.)
+    // SLH-DSA is deferred-alternate in the registry (not ships-v1), so the
+    // planner rejects it; even if it weren't, crypto.ts only dispatches ml_dsa65,
+    // so encrypt must reject rather than write an envelope whose algSig label
+    // disagrees with the actual signature bytes. (Codex P2 finding on PR #6217.)
     const base = generateRecipientKeyPair("sender@zeta");
     const slhSender = { ...base.publicKey, sigAlgId: "SLH-DSA" };
     const ctx: EncryptionContext = {
@@ -340,6 +341,20 @@ describe("B-0883 v1 Phase 2 — on-disk envelope CBOR codec", () => {
     if (!enc.ok) return;
     const bytes = encodeEnvelope({ ...enc.envelope, contentNonce: new Uint8Array(8) }); // wrong length
     const decoded = decodeEnvelope(bytes);
+    expect(decoded.ok).toBe(false);
+    if (!decoded.ok) expect(decoded.feedback.kind).toBe("EnvelopeMalformed");
+  });
+
+  it("decodeEnvelope rejects unknown top-level fields (canonical-bytes enforcement)", () => {
+    // Extra unauthenticated fields would otherwise ride along in a valid envelope.
+    // The canonical re-encode-and-compare check fails closed. (Codex P2 + Copilot P1.)
+    const sender = generateRecipientKeyPair("sender@zeta");
+    const enc = encrypt(ctxFor(utf8("x"), sender, [sender]), sender.secretKeys);
+    expect(enc.ok).toBe(true);
+    if (!enc.ok) return;
+    expect(decodeEnvelope(encodeEnvelope(enc.envelope)).ok).toBe(true); // canonical round-trips
+    const withRogue = cborEncode({ ...enc.envelope, rogue: new Uint8Array([1, 2, 3]) });
+    const decoded = decodeEnvelope(withRogue);
     expect(decoded.ok).toBe(false);
     if (!decoded.ok) expect(decoded.feedback.kind).toBe("EnvelopeMalformed");
   });

--- a/tools/crypto/better-git-crypt/crypto.ts
+++ b/tools/crypto/better-git-crypt/crypto.ts
@@ -214,6 +214,22 @@ export function encrypt(context: EncryptionContext, senderSecretKeys: RecipientS
     return { ok: false, feedback: { kind: "AlgUnsupported", algId: plan.path.algSig } };
   }
 
+  // 2b. Reject duplicate recipient identities. decrypt resolves a recipient by
+  //     identity via first-match, so two slots for the same identity (e.g. a
+  //     stale registry entry kept before the current key) would make a valid
+  //     later slot unreachable and surface a spurious KemFailure. Keep the
+  //     recipient set identity-unique.
+  const seenIdentities = new Set<string>();
+  for (const r of context.recipients) {
+    if (seenIdentities.has(r.identity)) {
+      return {
+        ok: false,
+        feedback: { kind: "RecipientKeyInvalid", identity: r.identity, reason: "duplicate recipient identity" },
+      };
+    }
+    seenIdentities.add(r.identity);
+  }
+
   // 3. v1 supports random-bytes seed source only.
   if (context.seedSource !== "random-bytes") {
     return {

--- a/tools/crypto/better-git-crypt/crypto.ts
+++ b/tools/crypto/better-git-crypt/crypto.ts
@@ -1,0 +1,448 @@
+/**
+ * tools/crypto/better-git-crypt/crypto.ts
+ *
+ * B-0883 v1 — Phase 2 REAL crypto implementation (operator-authorized
+ * 2026-05-31). Wires the type substrate in `types.ts` to actual
+ * post-quantum primitives:
+ *
+ *   - KEM:       XWing (ML-KEM-768 + X25519 hybrid) — @noble/post-quantum/hybrid.js
+ *   - Signature: ML-DSA-65 (Dilithium)             — @noble/post-quantum/ml-dsa.js
+ *   - KDF:       HKDF-SHA256                        — @noble/hashes/hkdf.js + sha2.js
+ *   - AEAD:      ChaCha20-Poly1305                  — @noble/ciphers/chacha.js
+ *   - Envelope:  CBOR (canonical/deterministic)     — cborg
+ *
+ * Dependency versions (pinned current-latest per dep-pin-search-first-authority,
+ * verified empirically against the installed packages 2026-05-31):
+ *   @noble/post-quantum@0.6.1  @noble/ciphers@2.2.0  @noble/hashes@2.2.0  cborg@5.1.1
+ *
+ * API shapes EMPIRICALLY VERIFIED against the installed packages (the runtime
+ * is the oracle — the v1 design memo's pseudocode used a different chacha
+ * call-shape + a 3-arg ml_dsa sign that do NOT exist in these versions):
+ *   - chacha20poly1305(key, nonce).encrypt(pt) / .decrypt(ct)   [NOT (key).encrypt(nonce,pt)]
+ *   - ml_dsa65.sign(msg, sk) / verify(sig, msg, pk)             [2-arg; no context positional]
+ *   - XWing.keygen() -> {publicKey, secretKey}; encapsulate(pk) -> {cipherText, sharedSecret};
+ *     decapsulate(ct, sk) -> sharedSecret
+ *   - hkdf(sha256, ikm, salt?, info, len)
+ *
+ * Domain separation: the signature is computed over the CBOR encoding of the
+ * envelope's signed view, which INCLUDES the `context` field
+ * ("zeta.git-crypt.file.v1"). That puts the domain-separation tag inside the
+ * signed bytes — so the (unavailable) ml_dsa context positional is not needed.
+ *
+ * Scope (v1):
+ *   - content-only encryption (B-0883.5); metadata (filenames / commit msgs) deferred
+ *   - git-at-rest threat model (B-0883.4)
+ *   - single envelope KEM column (all recipients share one KEM) per memo
+ *   - forward-only revocation (B-0883.3 future)
+ *
+ * Composes with: types.ts (determineEncryptionPath planner + validation),
+ * B-0883 design memo, B-0885 (agent private encrypted state consumer),
+ * asymmetric-authorship + monad-propagation rules (Result<T, TFeedback>).
+ */
+
+import { sha256 } from "@noble/hashes/sha2.js";
+import { hkdf } from "@noble/hashes/hkdf.js";
+import { randomBytes } from "@noble/hashes/utils.js";
+import { chacha20poly1305 } from "@noble/ciphers/chacha.js";
+import { XWing } from "@noble/post-quantum/hybrid.js";
+import { ml_dsa65 } from "@noble/post-quantum/ml-dsa.js";
+import { encode as cborEncode, decode as cborDecode } from "cborg";
+
+import {
+  type EncryptionContext,
+  type EncryptionFeedback,
+  type DecryptionFeedback,
+  type FileEnvelope,
+  type RecipientKey,
+  type RecipientSlot,
+  type SeedSource,
+  determineEncryptionPath,
+  validateEnvelopeStructure,
+} from "./types";
+
+/** v1 algorithm ids — the only ships-v1 set this implementation wires. */
+export const V1_KEM_ALG = "ML-KEM-768+X25519";
+export const V1_SIG_ALG = "ML-DSA-65";
+export const V1_CONTEXT = "zeta.git-crypt.file.v1";
+
+/** ChaCha20-Poly1305 nonce length (bytes). */
+const NONCE_LEN = 12;
+/** Content encryption key length (bytes) — ChaCha20 key size. */
+const CEK_LEN = 32;
+/**
+ * Zero nonce used for the per-recipient CEK wrap.
+ *
+ * SAFETY INVARIANT (per design memo): the wrap key is single-use. It is
+ * `HKDF(sha256, sharedSecret, info=cek-wrap.v1:<identity>)` where
+ * `sharedSecret` is freshly produced by `XWing.encapsulate` on every
+ * encryption (XWing draws fresh randomness per call). A given wrapKey
+ * therefore encrypts exactly one CEK, ever — so a fixed (zero) nonce can
+ * never be reused under the same key, which is the only condition
+ * ChaCha20-Poly1305 nonce-uniqueness requires. The content nonce, by
+ * contrast, IS random (the CEK is reused across recipients within one file,
+ * though still single-file-scoped).
+ */
+const WRAP_ZERO_NONCE = new Uint8Array(NONCE_LEN);
+
+/**
+ * A recipient's PRIVATE key material — the secret counterpart to the public
+ * `RecipientKey` in types.ts. Held only by the identity itself; never
+ * serialized into an envelope.
+ */
+export interface RecipientSecretKeys {
+  readonly identity: string;
+  readonly kemSecretKey: Uint8Array; // XWing secret key
+  readonly sigSecretKey: Uint8Array; // ML-DSA-65 secret key
+}
+
+/** A freshly generated keypair: the publishable public half + the private half. */
+export interface GeneratedKeyPair {
+  readonly publicKey: RecipientKey;
+  readonly secretKeys: RecipientSecretKeys;
+}
+
+/** Result of `encrypt` — Result<FileEnvelope, EncryptionFeedback>. */
+export type EncryptResult = { ok: true; envelope: FileEnvelope } | { ok: false; feedback: EncryptionFeedback };
+
+/** Result of `decrypt` — Result<plaintext, DecryptionFeedback>. */
+export type DecryptResult = { ok: true; plaintext: Uint8Array } | { ok: false; feedback: DecryptionFeedback };
+
+const utf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+/**
+ * Generate a v1 recipient keypair (XWing KEM + ML-DSA-65 signature).
+ *
+ * v1 supports `seedSource: "random-bytes"` only; `adinkra-derived` (B-0623)
+ * and `hsm-derived` are future substrate. Throws on unsupported seed source —
+ * keygen is a setup operation, not a hot-path Result surface.
+ */
+export function generateRecipientKeyPair(identity: string, seedSource: SeedSource = "random-bytes"): GeneratedKeyPair {
+  if (seedSource !== "random-bytes") {
+    throw new Error(`generateRecipientKeyPair: seedSource "${seedSource}" not available in v1 (random-bytes only)`);
+  }
+  const kem = XWing.keygen();
+  const sig = ml_dsa65.keygen();
+  return {
+    publicKey: {
+      identity,
+      kemAlgId: V1_KEM_ALG,
+      sigAlgId: V1_SIG_ALG,
+      publicKemKey: kem.publicKey,
+      publicSigKey: sig.publicKey,
+      seedSource,
+      composesWith: ["B-0883", "B-0883.1"],
+    },
+    secretKeys: {
+      identity,
+      kemSecretKey: kem.secretKey,
+      sigSecretKey: sig.secretKey,
+    },
+  };
+}
+
+/**
+ * Canonical CBOR encoding of the envelope's SIGNED VIEW — every field except
+ * `signature`. Both encrypt (to produce the signature) and decrypt (to verify
+ * it) call this with the same field set; cborg's canonical/deterministic
+ * encoding then guarantees byte-identical input to sign/verify.
+ *
+ * The recipient slots are mapped to a fixed shape so no extraneous field can
+ * leak into (or fall out of) the signed bytes.
+ */
+function encodeSignedView(env: {
+  version: number;
+  context: string;
+  algKem: string;
+  algKdf: string;
+  algWrap: string;
+  algContent: string;
+  algSig: string;
+  recipients: readonly RecipientSlot[];
+  ciphertext: Uint8Array;
+  contentNonce: Uint8Array;
+  signerIdentity: string;
+}): Uint8Array {
+  return cborEncode({
+    version: env.version,
+    context: env.context,
+    algKem: env.algKem,
+    algKdf: env.algKdf,
+    algWrap: env.algWrap,
+    algContent: env.algContent,
+    algSig: env.algSig,
+    recipients: env.recipients.map((r) => ({
+      identity: r.identity,
+      kemCt: r.kemCt,
+      wrappedCek: r.wrappedCek,
+      kdfInfo: r.kdfInfo,
+    })),
+    ciphertext: env.ciphertext,
+    contentNonce: env.contentNonce,
+    signerIdentity: env.signerIdentity,
+  });
+}
+
+/**
+ * Encrypt `context.plaintext` to all `context.recipients`, signed by
+ * `context.sender` (whose private keys are supplied separately — the public
+ * `RecipientKey` in the context carries no secret).
+ *
+ * Returns Result<FileEnvelope, EncryptionFeedback>. All failure modes are the
+ * function's own authored TFeedback variants (asymmetric-authorship rule).
+ */
+export function encrypt(context: EncryptionContext, senderSecretKeys: RecipientSecretKeys): EncryptResult {
+  // 1. Plan the algorithm path (reuses the validated planner from types.ts).
+  const plan = determineEncryptionPath(context);
+  if (!plan.ok) {
+    return { ok: false, feedback: plan.feedback };
+  }
+
+  // 2. v1 supports random-bytes seed source only.
+  if (context.seedSource !== "random-bytes") {
+    return {
+      ok: false,
+      feedback: { kind: "SeedSourceNotAvailable", seedSource: context.seedSource },
+    };
+  }
+
+  // 3. The sender's secret keys must belong to the sender identity in context.
+  if (senderSecretKeys.identity !== context.sender.identity) {
+    return {
+      ok: false,
+      feedback: {
+        kind: "RecipientKeyInvalid",
+        identity: senderSecretKeys.identity,
+        reason: `sender secret key identity "${senderSecretKeys.identity}" != context sender "${context.sender.identity}"`,
+      },
+    };
+  }
+
+  // 4. Content encryption key + content nonce.
+  const cek = randomBytes(CEK_LEN);
+  const contentNonce = randomBytes(NONCE_LEN);
+
+  // 5. Per-recipient KEM encapsulation + CEK wrap.
+  const slots: RecipientSlot[] = [];
+  for (const r of context.recipients) {
+    let cipherText: Uint8Array;
+    let sharedSecret: Uint8Array;
+    try {
+      const enc = XWing.encapsulate(r.publicKemKey);
+      cipherText = enc.cipherText;
+      sharedSecret = enc.sharedSecret;
+    } catch {
+      return { ok: false, feedback: { kind: "KemFailure", recipientIdentity: r.identity } };
+    }
+    const kdfInfo = utf8(`zeta.git-crypt.cek-wrap.v1:${r.identity}`);
+    const wrapKey = hkdf(sha256, sharedSecret, undefined, kdfInfo, CEK_LEN);
+    // Zero nonce is safe here — see WRAP_ZERO_NONCE invariant (single-use wrapKey).
+    const wrappedCek = chacha20poly1305(wrapKey, WRAP_ZERO_NONCE).encrypt(cek);
+    slots.push({ identity: r.identity, kemCt: cipherText, wrappedCek, kdfInfo });
+  }
+
+  // 6. Encrypt the content once with the CEK.
+  const ciphertext = chacha20poly1305(cek, contentNonce).encrypt(context.plaintext);
+
+  // 7. Sign the signed view (everything except the signature). The signed
+  //    bytes include `context` for domain separation.
+  const signedView = {
+    version: 1 as const,
+    context: V1_CONTEXT,
+    algKem: plan.path.algKem,
+    algKdf: plan.path.algKdf,
+    algWrap: plan.path.algWrap,
+    algContent: plan.path.algContent,
+    algSig: plan.path.algSig,
+    recipients: slots,
+    ciphertext,
+    contentNonce,
+    signerIdentity: context.sender.identity,
+  };
+  let signature: Uint8Array;
+  try {
+    signature = ml_dsa65.sign(encodeSignedView(signedView), senderSecretKeys.sigSecretKey);
+  } catch {
+    return { ok: false, feedback: { kind: "SignatureFailure" } };
+  }
+
+  return { ok: true, envelope: { ...signedView, signature } };
+}
+
+/**
+ * Decrypt an envelope as `recipientSecretKeys`, verifying it was signed by the
+ * holder of `senderPublicSigKey` (the caller resolves the envelope's
+ * `signerIdentity` to a known public sig key, e.g. via a recipients registry).
+ *
+ * Signature is verified FIRST (fail-closed on tampering before touching the
+ * KEM). Returns Result<plaintext, DecryptionFeedback>.
+ */
+export function decrypt(
+  envelope: FileEnvelope,
+  recipientSecretKeys: RecipientSecretKeys,
+  senderPublicSigKey: Uint8Array,
+): DecryptResult {
+  // 1. Version + context checks FIRST, so the precise typed feedback is
+  //    reachable. The `version` literal type says `1`, but decrypt may be
+  //    handed UNTRUSTED decoded input (e.g. a hand-built or future-version
+  //    envelope) where it isn't — hence the runtime guard the type can't see.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard on untrusted decoded input; the compile-time literal type does not hold for arbitrary runtime envelopes
+  if (envelope.version !== 1) {
+    return { ok: false, feedback: { kind: "VersionUnsupported", version: envelope.version } };
+  }
+  if (envelope.context !== V1_CONTEXT) {
+    return {
+      ok: false,
+      feedback: { kind: "ContextMismatch", expected: V1_CONTEXT, actual: envelope.context },
+    };
+  }
+
+  // 2. Structural validation (alg classes / non-empty shape).
+  try {
+    validateEnvelopeStructure(envelope);
+  } catch (e) {
+    return {
+      ok: false,
+      feedback: { kind: "EnvelopeMalformed", reason: e instanceof Error ? e.message : String(e) },
+    };
+  }
+
+  // 3. Verify the signature over the signed view (fail-closed on tampering).
+  let sigValid: boolean;
+  try {
+    sigValid = ml_dsa65.verify(envelope.signature, encodeSignedView(envelope), senderPublicSigKey);
+  } catch {
+    sigValid = false;
+  }
+  if (!sigValid) {
+    return { ok: false, feedback: { kind: "SignatureInvalid", signerIdentity: envelope.signerIdentity } };
+  }
+
+  // 4. Locate this recipient's slot.
+  const slot = envelope.recipients.find((r) => r.identity === recipientSecretKeys.identity);
+  if (!slot) {
+    return { ok: false, feedback: { kind: "RecipientNotInEnvelope", identity: recipientSecretKeys.identity } };
+  }
+
+  // 5. KEM decapsulate -> shared secret -> unwrap CEK.
+  //    Per FIPS-203 implicit rejection, decapsulate never throws on a bad
+  //    ciphertext; it returns a (wrong) shared secret, and the CEK-unwrap
+  //    AEAD tag check below is what fails -> KemFailure.
+  let cek: Uint8Array;
+  try {
+    const sharedSecret = XWing.decapsulate(slot.kemCt, recipientSecretKeys.kemSecretKey);
+    const wrapKey = hkdf(sha256, sharedSecret, undefined, slot.kdfInfo, CEK_LEN);
+    cek = chacha20poly1305(wrapKey, WRAP_ZERO_NONCE).decrypt(slot.wrappedCek);
+  } catch {
+    return { ok: false, feedback: { kind: "KemFailure" } };
+  }
+
+  // 6. Decrypt content under the CEK.
+  try {
+    const plaintext = chacha20poly1305(cek, envelope.contentNonce).decrypt(envelope.ciphertext);
+    return { ok: true, plaintext };
+  } catch {
+    return { ok: false, feedback: { kind: "ContentDecryptFailure" } };
+  }
+}
+
+/**
+ * Encode a full envelope (including signature) to canonical CBOR bytes — the
+ * on-disk / in-git file format.
+ */
+export function encodeEnvelope(envelope: FileEnvelope): Uint8Array {
+  return cborEncode({
+    version: envelope.version,
+    context: envelope.context,
+    algKem: envelope.algKem,
+    algKdf: envelope.algKdf,
+    algWrap: envelope.algWrap,
+    algContent: envelope.algContent,
+    algSig: envelope.algSig,
+    recipients: envelope.recipients.map((r) => ({
+      identity: r.identity,
+      kemCt: r.kemCt,
+      wrappedCek: r.wrappedCek,
+      kdfInfo: r.kdfInfo,
+    })),
+    ciphertext: envelope.ciphertext,
+    contentNonce: envelope.contentNonce,
+    signerIdentity: envelope.signerIdentity,
+    signature: envelope.signature,
+  });
+}
+
+/** Result of `decodeEnvelope` — Result<FileEnvelope, DecryptionFeedback>. */
+export type DecodeEnvelopeResult = { ok: true; envelope: FileEnvelope } | { ok: false; feedback: DecryptionFeedback };
+
+/**
+ * Decode on-disk CBOR bytes back into a `FileEnvelope`, structurally validated.
+ * Returns `EnvelopeMalformed` feedback on any decode / shape failure rather
+ * than throwing (Result-shaped per monad-propagation rule).
+ */
+export function decodeEnvelope(bytes: Uint8Array): DecodeEnvelopeResult {
+  let raw: unknown;
+  try {
+    raw = cborDecode(bytes);
+  } catch (e) {
+    return {
+      ok: false,
+      feedback: {
+        kind: "EnvelopeMalformed",
+        reason: `cbor decode failed: ${e instanceof Error ? e.message : String(e)}`,
+      },
+    };
+  }
+  if (typeof raw !== "object" || raw === null) {
+    return { ok: false, feedback: { kind: "EnvelopeMalformed", reason: "decoded value is not an object" } };
+  }
+  const o = raw as Record<string, unknown>;
+  const isBytes = (v: unknown): v is Uint8Array => v instanceof Uint8Array;
+  const isStr = (v: unknown): v is string => typeof v === "string";
+  if (
+    o.version !== 1 ||
+    !isStr(o.context) ||
+    !isStr(o.algKem) ||
+    !isStr(o.algKdf) ||
+    !isStr(o.algWrap) ||
+    !isStr(o.algContent) ||
+    !isStr(o.algSig) ||
+    !Array.isArray(o.recipients) ||
+    !isBytes(o.ciphertext) ||
+    !isBytes(o.contentNonce) ||
+    !isStr(o.signerIdentity) ||
+    !isBytes(o.signature)
+  ) {
+    return { ok: false, feedback: { kind: "EnvelopeMalformed", reason: "envelope field shape mismatch" } };
+  }
+  const recipients: RecipientSlot[] = [];
+  for (const r of o.recipients as unknown[]) {
+    if (typeof r !== "object" || r === null) {
+      return { ok: false, feedback: { kind: "EnvelopeMalformed", reason: "recipient slot is not an object" } };
+    }
+    const rr = r as Record<string, unknown>;
+    if (!isStr(rr.identity) || !isBytes(rr.kemCt) || !isBytes(rr.wrappedCek) || !isBytes(rr.kdfInfo)) {
+      return { ok: false, feedback: { kind: "EnvelopeMalformed", reason: "recipient slot field shape mismatch" } };
+    }
+    recipients.push({ identity: rr.identity, kemCt: rr.kemCt, wrappedCek: rr.wrappedCek, kdfInfo: rr.kdfInfo });
+  }
+  const envelope: FileEnvelope = {
+    version: 1,
+    context: o.context,
+    algKem: o.algKem,
+    algKdf: o.algKdf,
+    algWrap: o.algWrap,
+    algContent: o.algContent,
+    algSig: o.algSig,
+    recipients,
+    ciphertext: o.ciphertext,
+    contentNonce: o.contentNonce,
+    signerIdentity: o.signerIdentity,
+    signature: o.signature,
+  };
+  try {
+    validateEnvelopeStructure(envelope);
+  } catch (e) {
+    return { ok: false, feedback: { kind: "EnvelopeMalformed", reason: e instanceof Error ? e.message : String(e) } };
+  }
+  return { ok: true, envelope };
+}

--- a/tools/crypto/better-git-crypt/crypto.ts
+++ b/tools/crypto/better-git-crypt/crypto.ts
@@ -114,11 +114,17 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
   return Buffer.from(a).equals(Buffer.from(b));
 }
 
-/** First duplicated identity in a recipient list, or null if all unique. */
-function firstDuplicateIdentity(recipients: readonly RecipientKey[]): string | null {
+/**
+ * First invalid recipient identity (empty or duplicated), or null if all are
+ * non-empty + unique. Empty identities would mint an envelope with an empty
+ * `signerIdentity`/slot id that decrypt can't resolve (undecryptable); dupes
+ * make a valid later slot unreachable via first-match.
+ */
+function firstInvalidIdentity(recipients: readonly RecipientKey[]): { identity: string; reason: string } | null {
   const seen = new Set<string>();
   for (const r of recipients) {
-    if (seen.has(r.identity)) return r.identity;
+    if (r.identity.length === 0) return { identity: r.identity, reason: "empty recipient identity" };
+    if (seen.has(r.identity)) return { identity: r.identity, reason: "duplicate recipient identity" };
     seen.add(r.identity);
   }
   return null;
@@ -224,16 +230,20 @@ export function encrypt(context: EncryptionContext, senderSecretKeys: RecipientS
     return { ok: false, feedback: { kind: "AlgUnsupported", algId: plan.path.algSig } };
   }
 
-  // 2b. Reject duplicate recipient identities. decrypt resolves a recipient by
-  //     identity via first-match, so two slots for the same identity (e.g. a
-  //     stale registry entry kept before the current key) would make a valid
-  //     later slot unreachable and surface a spurious KemFailure. Keep the
-  //     recipient set identity-unique.
-  const dupId = firstDuplicateIdentity(context.recipients);
-  if (dupId !== null) {
+  // 2b. Reject empty + duplicate recipient identities. decrypt resolves a
+  //     recipient by identity via first-match: an empty identity would mint a
+  //     slot keyed by "" that decrypt can't resolve (undecryptable artifact),
+  //     and two slots for the same identity (e.g. a stale registry entry kept
+  //     before the current key) would make a valid later slot unreachable and
+  //     surface a spurious KemFailure. Since the sender MUST be in the recipient
+  //     set (checked next), this also rejects an empty sender identity before it
+  //     can sign an envelope with signerIdentity:"". Keep identities non-empty +
+  //     unique.
+  const invalidId = firstInvalidIdentity(context.recipients);
+  if (invalidId !== null) {
     return {
       ok: false,
-      feedback: { kind: "RecipientKeyInvalid", identity: dupId, reason: "duplicate recipient identity" },
+      feedback: { kind: "RecipientKeyInvalid", identity: invalidId.identity, reason: invalidId.reason },
     };
   }
 

--- a/tools/crypto/better-git-crypt/crypto.ts
+++ b/tools/crypto/better-git-crypt/crypto.ts
@@ -197,7 +197,19 @@ export function encrypt(context: EncryptionContext, senderSecretKeys: RecipientS
     return { ok: false, feedback: plan.feedback };
   }
 
-  // 2. v1 supports random-bytes seed source only.
+  // 2. This implementation only DISPATCHES XWing KEM + ML-DSA-65 signatures.
+  //    The planner accepts any ships-v1 alg from the registry (e.g. SLH-DSA),
+  //    but signing with ml_dsa65 while recording a different `algSig` would
+  //    write LYING metadata (bytes are ML-DSA, label says otherwise). Reject
+  //    anything we don't actually dispatch so the envelope never lies.
+  if (plan.path.algKem !== V1_KEM_ALG) {
+    return { ok: false, feedback: { kind: "AlgUnsupported", algId: plan.path.algKem } };
+  }
+  if (plan.path.algSig !== V1_SIG_ALG) {
+    return { ok: false, feedback: { kind: "AlgUnsupported", algId: plan.path.algSig } };
+  }
+
+  // 3. v1 supports random-bytes seed source only.
   if (context.seedSource !== "random-bytes") {
     return {
       ok: false,
@@ -205,7 +217,7 @@ export function encrypt(context: EncryptionContext, senderSecretKeys: RecipientS
     };
   }
 
-  // 3. The sender's secret keys must belong to the sender identity in context.
+  // 4. The sender's secret keys must belong to the sender identity in context.
   if (senderSecretKeys.identity !== context.sender.identity) {
     return {
       ok: false,
@@ -217,11 +229,11 @@ export function encrypt(context: EncryptionContext, senderSecretKeys: RecipientS
     };
   }
 
-  // 4. Content encryption key + content nonce.
+  // 5. Content encryption key + content nonce.
   const cek = randomBytes(CEK_LEN);
   const contentNonce = randomBytes(NONCE_LEN);
 
-  // 5. Per-recipient KEM encapsulation + CEK wrap.
+  // 6. Per-recipient KEM encapsulation + CEK wrap.
   const slots: RecipientSlot[] = [];
   for (const r of context.recipients) {
     let cipherText: Uint8Array;
@@ -240,10 +252,10 @@ export function encrypt(context: EncryptionContext, senderSecretKeys: RecipientS
     slots.push({ identity: r.identity, kemCt: cipherText, wrappedCek, kdfInfo });
   }
 
-  // 6. Encrypt the content once with the CEK.
+  // 7. Encrypt the content once with the CEK.
   const ciphertext = chacha20poly1305(cek, contentNonce).encrypt(context.plaintext);
 
-  // 7. Sign the signed view (everything except the signature). The signed
+  // 8. Sign the signed view (everything except the signature). The signed
   //    bytes include `context` for domain separation.
   const signedView = {
     version: 1 as const,
@@ -296,7 +308,18 @@ export function decrypt(
     };
   }
 
-  // 2. Structural validation (alg classes / non-empty shape).
+  // 2. This implementation only dispatches XWing KEM + ML-DSA-65. Reject any
+  //    envelope whose declared algorithms we don't actually verify with — an
+  //    envelope labelled e.g. algSig "SLH-DSA" must NOT be verified with
+  //    ml_dsa65 (that would treat lying metadata as valid).
+  if (envelope.algKem !== V1_KEM_ALG) {
+    return { ok: false, feedback: { kind: "AlgUnsupported", algId: envelope.algKem } };
+  }
+  if (envelope.algSig !== V1_SIG_ALG) {
+    return { ok: false, feedback: { kind: "AlgUnsupported", algId: envelope.algSig } };
+  }
+
+  // 3. Structural validation (alg classes / non-empty shape).
   try {
     validateEnvelopeStructure(envelope);
   } catch (e) {
@@ -306,7 +329,7 @@ export function decrypt(
     };
   }
 
-  // 3. Verify the signature over the signed view (fail-closed on tampering).
+  // 4. Verify the signature over the signed view (fail-closed on tampering).
   let sigValid: boolean;
   try {
     sigValid = ml_dsa65.verify(envelope.signature, encodeSignedView(envelope), senderPublicSigKey);
@@ -317,13 +340,13 @@ export function decrypt(
     return { ok: false, feedback: { kind: "SignatureInvalid", signerIdentity: envelope.signerIdentity } };
   }
 
-  // 4. Locate this recipient's slot.
+  // 5. Locate this recipient's slot.
   const slot = envelope.recipients.find((r) => r.identity === recipientSecretKeys.identity);
   if (!slot) {
     return { ok: false, feedback: { kind: "RecipientNotInEnvelope", identity: recipientSecretKeys.identity } };
   }
 
-  // 5. KEM decapsulate -> shared secret -> unwrap CEK.
+  // 6. KEM decapsulate -> shared secret -> unwrap CEK.
   //    Per FIPS-203 implicit rejection, decapsulate never throws on a bad
   //    ciphertext; it returns a (wrong) shared secret, and the CEK-unwrap
   //    AEAD tag check below is what fails -> KemFailure.
@@ -336,7 +359,7 @@ export function decrypt(
     return { ok: false, feedback: { kind: "KemFailure" } };
   }
 
-  // 6. Decrypt content under the CEK.
+  // 7. Decrypt content under the CEK.
   try {
     const plaintext = chacha20poly1305(cek, envelope.contentNonce).decrypt(envelope.ciphertext);
     return { ok: true, plaintext };

--- a/tools/crypto/better-git-crypt/crypto.ts
+++ b/tools/crypto/better-git-crypt/crypto.ts
@@ -565,5 +565,20 @@ export function decodeEnvelope(bytes: Uint8Array): DecodeEnvelopeResult {
   } catch (e) {
     return { ok: false, feedback: { kind: "EnvelopeMalformed", reason: e instanceof Error ? e.message : String(e) } };
   }
+  // Canonical-bytes enforcement (closes two findings at once):
+  //  - non-canonical CBOR malleability: a byte-level rewrite to another valid
+  //    encoding of the same fields would otherwise decode + re-encode-for-verify
+  //    and still pass. (Codex P2)
+  //  - unknown top-level fields: extra unauthenticated data dropped from the
+  //    reconstructed signed view would otherwise ride along in a valid envelope. (Copilot P1)
+  // Re-encoding the reconstructed envelope canonically and requiring it to equal
+  // the input bytes rejects BOTH: the only valid on-disk form is the canonical
+  // encodeEnvelope output, so the bytes are bit-locked to the signed content.
+  if (!bytesEqual(encodeEnvelope(envelope), bytes)) {
+    return {
+      ok: false,
+      feedback: { kind: "EnvelopeMalformed", reason: "non-canonical CBOR encoding or unknown fields present" },
+    };
+  }
   return { ok: true, envelope };
 }

--- a/tools/crypto/better-git-crypt/crypto.ts
+++ b/tools/crypto/better-git-crypt/crypto.ts
@@ -55,7 +55,6 @@ import {
   type FileEnvelope,
   type RecipientKey,
   type RecipientSlot,
-  type SeedSource,
   determineEncryptionPath,
   validateEnvelopeStructure,
 } from "./types";
@@ -134,13 +133,20 @@ function firstInvalidIdentity(recipients: readonly RecipientKey[]): { identity: 
  * Generate a v1 recipient keypair (XWing KEM + ML-DSA-65 signature).
  *
  * v1 supports `seedSource: "random-bytes"` only; `adinkra-derived` (B-0623)
- * and `hsm-derived` are future substrate. Throws on unsupported seed source —
- * keygen is a setup operation, not a hot-path Result surface.
+ * and `hsm-derived` are future substrate. The parameter is NARROWED to the
+ * literal `"random-bytes"` (not the full `SeedSource` union) so an unsupported
+ * source is a COMPILE error, not a runtime throw — the strongest form of the
+ * Result-shaped boundary `encrypt`/`decrypt` use: the unsupported case is made
+ * unrepresentable rather than handled. When `adinkra-derived`/`hsm-derived`
+ * land, widen the parameter to the union AND return `Result<GeneratedKeyPair,
+ * { kind: "SeedSourceNotAvailable"; seedSource }>` to keep the boundary typed.
+ * (Codex/Copilot P1 on PR #6217 — exported surface must not throw on a
+ * user-selectable option.)
  */
-export function generateRecipientKeyPair(identity: string, seedSource: SeedSource = "random-bytes"): GeneratedKeyPair {
-  if (seedSource !== "random-bytes") {
-    throw new Error(`generateRecipientKeyPair: seedSource "${seedSource}" not available in v1 (random-bytes only)`);
-  }
+export function generateRecipientKeyPair(
+  identity: string,
+  seedSource: "random-bytes" = "random-bytes",
+): GeneratedKeyPair {
   const kem = XWing.keygen();
   const sig = ml_dsa65.keygen();
   return {
@@ -159,6 +165,25 @@ export function generateRecipientKeyPair(identity: string, seedSource: SeedSourc
       sigSecretKey: sig.secretKey,
     },
   };
+}
+
+/**
+ * Prove a KEM SECRET key actually unwraps a given slot to the expected CEK.
+ * encrypt uses this on the SENDER's own slot: the guards above only compare
+ * sender PUBLIC KEM keys + self-verify the signature key, so a stale/mismatched
+ * KEM secret (right public key, wrong secret) would still mint an envelope the
+ * sender — a required self-recipient — can't decrypt. This is the KEM-side
+ * analogue of the signature self-verify. (Codex P2 on PR #6217.)
+ */
+function kemSecretUnwrapsSlot(slot: RecipientSlot, kemSecretKey: Uint8Array, expectedCek: Uint8Array): boolean {
+  try {
+    const sharedSecret = XWing.decapsulate(slot.kemCt, kemSecretKey);
+    const wrapKey = hkdf(sha256, sharedSecret, undefined, slot.kdfInfo, CEK_LEN);
+    const unwrapped = chacha20poly1305(wrapKey, WRAP_ZERO_NONCE).decrypt(slot.wrappedCek);
+    return bytesEqual(unwrapped, expectedCek);
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -351,6 +376,21 @@ export function encrypt(context: EncryptionContext, senderSecretKeys: RecipientS
         kind: "RecipientKeyInvalid",
         identity: context.sender.identity,
         reason: "sender secret key does not match (or sender publicSigKey is malformed)",
+      },
+    };
+  }
+
+  // KEM-side self-check: prove the sender's own KEM SECRET unwraps the sender's
+  // slot back to the CEK. Without this, a stale/mismatched KEM secret (right
+  // public key, wrong secret) mints an envelope the sender can't decrypt.
+  const senderSlot = slots.find((s) => s.identity === context.sender.identity);
+  if (!senderSlot || !kemSecretUnwrapsSlot(senderSlot, senderSecretKeys.kemSecretKey, cek)) {
+    return {
+      ok: false,
+      feedback: {
+        kind: "RecipientKeyInvalid",
+        identity: context.sender.identity,
+        reason: "sender KEM secret key does not unwrap the sender slot (stale/mismatched KEM secret)",
       },
     };
   }

--- a/tools/crypto/better-git-crypt/crypto.ts
+++ b/tools/crypto/better-git-crypt/crypto.ts
@@ -114,6 +114,16 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
   return Buffer.from(a).equals(Buffer.from(b));
 }
 
+/** First duplicated identity in a recipient list, or null if all unique. */
+function firstDuplicateIdentity(recipients: readonly RecipientKey[]): string | null {
+  const seen = new Set<string>();
+  for (const r of recipients) {
+    if (seen.has(r.identity)) return r.identity;
+    seen.add(r.identity);
+  }
+  return null;
+}
+
 /**
  * Generate a v1 recipient keypair (XWing KEM + ML-DSA-65 signature).
  *
@@ -219,15 +229,12 @@ export function encrypt(context: EncryptionContext, senderSecretKeys: RecipientS
   //     stale registry entry kept before the current key) would make a valid
   //     later slot unreachable and surface a spurious KemFailure. Keep the
   //     recipient set identity-unique.
-  const seenIdentities = new Set<string>();
-  for (const r of context.recipients) {
-    if (seenIdentities.has(r.identity)) {
-      return {
-        ok: false,
-        feedback: { kind: "RecipientKeyInvalid", identity: r.identity, reason: "duplicate recipient identity" },
-      };
-    }
-    seenIdentities.add(r.identity);
+  const dupId = firstDuplicateIdentity(context.recipients);
+  if (dupId !== null) {
+    return {
+      ok: false,
+      feedback: { kind: "RecipientKeyInvalid", identity: dupId, reason: "duplicate recipient identity" },
+    };
   }
 
   // 3. v1 supports random-bytes seed source only.

--- a/tools/crypto/better-git-crypt/crypto.ts
+++ b/tools/crypto/better-git-crypt/crypto.ts
@@ -109,6 +109,11 @@ export type DecryptResult = { ok: true; plaintext: Uint8Array } | { ok: false; f
 
 const utf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
 
+/** Byte equality for public-key comparison (constant-time not required — keys are public). */
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  return Buffer.from(a).equals(Buffer.from(b));
+}
+
 /**
  * Generate a v1 recipient keypair (XWing KEM + ML-DSA-65 signature).
  *
@@ -229,6 +234,22 @@ export function encrypt(context: EncryptionContext, senderSecretKeys: RecipientS
     };
   }
 
+  // 4b. The sender's entry in `recipients` must carry the SAME public KEM key as
+  //     `context.sender`. Otherwise the CEK gets wrapped to a stale/rotated key
+  //     and the sender can't decrypt their own envelope (key-rotation / registry
+  //     staleness footgun). Compare the entry that will actually be encrypted to.
+  const senderRecipientEntry = context.recipients.find((r) => r.identity === context.sender.identity);
+  if (senderRecipientEntry && !bytesEqual(senderRecipientEntry.publicKemKey, context.sender.publicKemKey)) {
+    return {
+      ok: false,
+      feedback: {
+        kind: "RecipientKeyInvalid",
+        identity: context.sender.identity,
+        reason: "sender's recipients entry has a different publicKemKey than context.sender (stale/rotated key)",
+      },
+    };
+  }
+
   // 5. Content encryption key + content nonce.
   const cek = randomBytes(CEK_LEN);
   const contentNonce = randomBytes(NONCE_LEN);
@@ -281,14 +302,22 @@ export function encrypt(context: EncryptionContext, senderSecretKeys: RecipientS
   // Self-verify against the sender's DECLARED public sig key. If the supplied
   // secret key doesn't match (right identity, wrong/stale key), this catches it
   // at encrypt time — otherwise we'd mint an envelope that no one can verify
-  // (an undecryptable artifact). Surface it as RecipientKeyInvalid now.
-  if (!ml_dsa65.verify(signature, toSign, context.sender.publicSigKey)) {
+  // (an undecryptable artifact). Surface it as RecipientKeyInvalid now. The
+  // verify is wrapped because Noble's key decoder THROWS on a malformed/truncated
+  // publicSigKey — a throw here would break the EncryptResult contract.
+  let selfVerified: boolean;
+  try {
+    selfVerified = ml_dsa65.verify(signature, toSign, context.sender.publicSigKey);
+  } catch {
+    selfVerified = false;
+  }
+  if (!selfVerified) {
     return {
       ok: false,
       feedback: {
         kind: "RecipientKeyInvalid",
         identity: context.sender.identity,
-        reason: "sender secret key does not match the declared public sig key",
+        reason: "sender secret key does not match (or sender publicSigKey is malformed)",
       },
     };
   }
@@ -413,6 +442,22 @@ export function encodeEnvelope(envelope: FileEnvelope): Uint8Array {
 /** Result of `decodeEnvelope` — Result<FileEnvelope, DecryptionFeedback>. */
 export type DecodeEnvelopeResult = { ok: true; envelope: FileEnvelope } | { ok: false; feedback: DecryptionFeedback };
 
+/** Decode + shape-validate the recipient-slot array (extracted to keep decodeEnvelope simple). */
+function decodeRecipientSlots(arr: readonly unknown[]): { slots: RecipientSlot[] } | { error: string } {
+  const isBytes = (v: unknown): v is Uint8Array => v instanceof Uint8Array;
+  const isStr = (v: unknown): v is string => typeof v === "string";
+  const slots: RecipientSlot[] = [];
+  for (const r of arr) {
+    if (typeof r !== "object" || r === null) return { error: "recipient slot is not an object" };
+    const rr = r as Record<string, unknown>;
+    if (!isStr(rr.identity) || !isBytes(rr.kemCt) || !isBytes(rr.wrappedCek) || !isBytes(rr.kdfInfo)) {
+      return { error: "recipient slot field shape mismatch" };
+    }
+    slots.push({ identity: rr.identity, kemCt: rr.kemCt, wrappedCek: rr.wrappedCek, kdfInfo: rr.kdfInfo });
+  }
+  return { slots };
+}
+
 /**
  * Decode on-disk CBOR bytes back into a `FileEnvelope`, structurally validated.
  * Returns `EnvelopeMalformed` feedback on any decode / shape failure rather
@@ -437,8 +482,16 @@ export function decodeEnvelope(bytes: Uint8Array): DecodeEnvelopeResult {
   const o = raw as Record<string, unknown>;
   const isBytes = (v: unknown): v is Uint8Array => v instanceof Uint8Array;
   const isStr = (v: unknown): v is string => typeof v === "string";
+  // Split the version check from the shape check so a well-formed envelope of an
+  // UNSUPPORTED version gets the precise VersionUnsupported feedback (the same
+  // condition decrypt exposes), not a generic EnvelopeMalformed.
+  if (typeof o.version !== "number") {
+    return { ok: false, feedback: { kind: "EnvelopeMalformed", reason: "version is not a number" } };
+  }
+  if (o.version !== 1) {
+    return { ok: false, feedback: { kind: "VersionUnsupported", version: o.version } };
+  }
   if (
-    o.version !== 1 ||
     !isStr(o.context) ||
     !isStr(o.algKem) ||
     !isStr(o.algKdf) ||
@@ -465,17 +518,11 @@ export function decodeEnvelope(bytes: Uint8Array): DecodeEnvelopeResult {
       },
     };
   }
-  const recipients: RecipientSlot[] = [];
-  for (const r of o.recipients as unknown[]) {
-    if (typeof r !== "object" || r === null) {
-      return { ok: false, feedback: { kind: "EnvelopeMalformed", reason: "recipient slot is not an object" } };
-    }
-    const rr = r as Record<string, unknown>;
-    if (!isStr(rr.identity) || !isBytes(rr.kemCt) || !isBytes(rr.wrappedCek) || !isBytes(rr.kdfInfo)) {
-      return { ok: false, feedback: { kind: "EnvelopeMalformed", reason: "recipient slot field shape mismatch" } };
-    }
-    recipients.push({ identity: rr.identity, kemCt: rr.kemCt, wrappedCek: rr.wrappedCek, kdfInfo: rr.kdfInfo });
+  const recipientsResult = decodeRecipientSlots(o.recipients as readonly unknown[]);
+  if ("error" in recipientsResult) {
+    return { ok: false, feedback: { kind: "EnvelopeMalformed", reason: recipientsResult.error } };
   }
+  const recipients = recipientsResult.slots;
   const envelope: FileEnvelope = {
     version: 1,
     context: o.context,

--- a/tools/crypto/better-git-crypt/crypto.ts
+++ b/tools/crypto/better-git-crypt/crypto.ts
@@ -270,11 +270,27 @@ export function encrypt(context: EncryptionContext, senderSecretKeys: RecipientS
     contentNonce,
     signerIdentity: context.sender.identity,
   };
+  const toSign = encodeSignedView(signedView);
   let signature: Uint8Array;
   try {
-    signature = ml_dsa65.sign(encodeSignedView(signedView), senderSecretKeys.sigSecretKey);
+    signature = ml_dsa65.sign(toSign, senderSecretKeys.sigSecretKey);
   } catch {
     return { ok: false, feedback: { kind: "SignatureFailure" } };
+  }
+
+  // Self-verify against the sender's DECLARED public sig key. If the supplied
+  // secret key doesn't match (right identity, wrong/stale key), this catches it
+  // at encrypt time — otherwise we'd mint an envelope that no one can verify
+  // (an undecryptable artifact). Surface it as RecipientKeyInvalid now.
+  if (!ml_dsa65.verify(signature, toSign, context.sender.publicSigKey)) {
+    return {
+      ok: false,
+      feedback: {
+        kind: "RecipientKeyInvalid",
+        identity: context.sender.identity,
+        reason: "sender secret key does not match the declared public sig key",
+      },
+    };
   }
 
   return { ok: true, envelope: { ...signedView, signature } };
@@ -436,6 +452,18 @@ export function decodeEnvelope(bytes: Uint8Array): DecodeEnvelopeResult {
     !isBytes(o.signature)
   ) {
     return { ok: false, feedback: { kind: "EnvelopeMalformed", reason: "envelope field shape mismatch" } };
+  }
+  // contentNonce is a fixed-size ChaCha20-Poly1305 nonce — reject a wrong-length
+  // one here (a signed-but-malformed nonce would otherwise only surface as a
+  // late ContentDecryptFailure rather than a structural EnvelopeMalformed).
+  if (o.contentNonce.length !== NONCE_LEN) {
+    return {
+      ok: false,
+      feedback: {
+        kind: "EnvelopeMalformed",
+        reason: `contentNonce must be ${NONCE_LEN} bytes, got ${o.contentNonce.length}`,
+      },
+    };
   }
   const recipients: RecipientSlot[] = [];
   for (const r of o.recipients as unknown[]) {

--- a/tools/crypto/better-git-crypt/crypto.ts
+++ b/tools/crypto/better-git-crypt/crypto.ts
@@ -461,7 +461,7 @@ export function decodeEnvelope(bytes: Uint8Array): DecodeEnvelopeResult {
       ok: false,
       feedback: {
         kind: "EnvelopeMalformed",
-        reason: `contentNonce must be ${NONCE_LEN} bytes, got ${o.contentNonce.length}`,
+        reason: `contentNonce must be ${String(NONCE_LEN)} bytes, got ${String(o.contentNonce.length)}`,
       },
     };
   }

--- a/tools/crypto/better-git-crypt/types.test.ts
+++ b/tools/crypto/better-git-crypt/types.test.ts
@@ -98,6 +98,7 @@ describe("B-0883 v1 envelope structure invariants", () => {
       },
     ],
     ciphertext: new Uint8Array(0),
+    contentNonce: new Uint8Array(12),
     signerIdentity: "test@zeta",
     signature: new Uint8Array(0),
   });

--- a/tools/crypto/better-git-crypt/types.ts
+++ b/tools/crypto/better-git-crypt/types.ts
@@ -224,8 +224,13 @@ export const ALG_REGISTRY: readonly AlgSpec[] = [
   {
     id: "SLH-DSA",
     class: "signature",
-    status: "ships-v1",
-    description: "SPHINCS+ — hash-based signature alternate; Noble-native",
+    // deferred-alternate, NOT ships-v1: Noble has it, but crypto.ts v1 only
+    // dispatches ML-DSA-65. Marking it ships-v1 would let determineEncryptionPath
+    // advertise a signature the crypto layer can't actually produce (registry/
+    // planner inconsistency — Copilot P1 on PR #6217). Promote when real
+    // SLH-DSA dispatch lands.
+    status: "deferred-alternate",
+    description: "SPHINCS+ — hash-based signature alternate; Noble-native; deferred until crypto.ts dispatch added",
     nobleModule: "@noble/post-quantum/slh-dsa",
     composesWith: ["B-0883.1"],
   },

--- a/tools/crypto/better-git-crypt/types.ts
+++ b/tools/crypto/better-git-crypt/types.ts
@@ -61,19 +61,19 @@ export type CipherClass = "kem" | "signature" | "kdf" | "aead";
  * Cipher implementation status — tracks Phase 1 ship vs deferred.
  */
 export type CipherStatus =
-  | "ships-v1"                    // Noble-native; ready for Phase 2 impl
-  | "deferred-alternate"          // multi-cipher hedge per B-0883.2
-  | "future-substrate";           // requires substrate that doesn't yet exist
+  | "ships-v1" // Noble-native; ready for Phase 2 impl
+  | "deferred-alternate" // multi-cipher hedge per B-0883.2
+  | "future-substrate"; // requires substrate that doesn't yet exist
 
 /**
  * Algorithm spec — registry entry per cipher.
  */
 export interface AlgSpec {
-  readonly id: string;            // e.g. "ML-KEM-768+X25519" (XWing identifier)
+  readonly id: string; // e.g. "ML-KEM-768+X25519" (XWing identifier)
   readonly class: CipherClass;
   readonly status: CipherStatus;
   readonly description: string;
-  readonly nobleModule?: string;  // @noble/post-quantum module path when ships-v1
+  readonly nobleModule?: string; // @noble/post-quantum module path when ships-v1
   readonly composesWith: ReadonlyArray<string>; // backlog/rule references
 }
 
@@ -81,17 +81,17 @@ export interface AlgSpec {
  * Seed source — parameterized per B-0623 (Adinkras-derived seeds swap in later).
  */
 export type SeedSource =
-  | "random-bytes"        // v1 default; CSPRNG
-  | "adinkra-derived"     // B-0623 future; SUSY-ECC private state
-  | "hsm-derived";        // future; HSM-backed seed source
+  | "random-bytes" // v1 default; CSPRNG
+  | "adinkra-derived" // B-0623 future; SUSY-ECC private state
+  | "hsm-derived"; // future; HSM-backed seed source
 
 /**
  * Recipient key — identity + public key material.
  */
 export interface RecipientKey {
-  readonly identity: string;      // e.g. "otto-cli@zeta"
-  readonly kemAlgId: string;      // must reference AlgSpec.id of CipherClass "kem"
-  readonly sigAlgId: string;      // must reference AlgSpec.id of CipherClass "signature"
+  readonly identity: string; // e.g. "otto-cli@zeta"
+  readonly kemAlgId: string; // must reference AlgSpec.id of CipherClass "kem"
+  readonly sigAlgId: string; // must reference AlgSpec.id of CipherClass "signature"
   readonly publicKemKey: Uint8Array;
   readonly publicSigKey: Uint8Array;
   readonly seedSource: SeedSource;
@@ -103,9 +103,9 @@ export interface RecipientKey {
  */
 export interface RecipientSlot {
   readonly identity: string;
-  readonly kemCt: Uint8Array;       // XWing ciphertext (per-recipient)
-  readonly wrappedCek: Uint8Array;  // CEK encrypted under KDF(shared_secret)
-  readonly kdfInfo: Uint8Array;     // domain-separation tag for HKDF
+  readonly kemCt: Uint8Array; // XWing ciphertext (per-recipient)
+  readonly wrappedCek: Uint8Array; // CEK encrypted under KDF(shared_secret)
+  readonly kdfInfo: Uint8Array; // domain-separation tag for HKDF
 }
 
 /**
@@ -119,15 +119,16 @@ export interface RecipientSlot {
  */
 export interface FileEnvelope {
   readonly version: EnvelopeVersion;
-  readonly context: string;          // domain-separation; must equal "zeta.git-crypt.file.v1"
-  readonly algKem: string;           // AlgSpec.id of CipherClass "kem"
-  readonly algKdf: string;           // AlgSpec.id of CipherClass "kdf"
-  readonly algWrap: string;          // AlgSpec.id of CipherClass "aead"
-  readonly algContent: string;       // AlgSpec.id of CipherClass "aead"
-  readonly algSig: string;           // AlgSpec.id of CipherClass "signature"
+  readonly context: string; // domain-separation; must equal "zeta.git-crypt.file.v1"
+  readonly algKem: string; // AlgSpec.id of CipherClass "kem"
+  readonly algKdf: string; // AlgSpec.id of CipherClass "kdf"
+  readonly algWrap: string; // AlgSpec.id of CipherClass "aead"
+  readonly algContent: string; // AlgSpec.id of CipherClass "aead"
+  readonly algSig: string; // AlgSpec.id of CipherClass "signature"
   readonly recipients: ReadonlyArray<RecipientSlot>;
   readonly ciphertext: Uint8Array;
-  readonly signerIdentity: string;   // matches RecipientKey.identity of sender
+  readonly contentNonce: Uint8Array; // 12-byte ChaCha20-Poly1305 nonce for the content AEAD (memo schema "content_nonce"); covered by the signature
+  readonly signerIdentity: string; // matches RecipientKey.identity of sender
   readonly signature: Uint8Array;
 }
 
@@ -297,11 +298,11 @@ export function findAlg(id: string): AlgSpec | undefined {
  * exist in ALG_REGISTRY and have CipherClass matching the slot.
  */
 export interface PlannedEncryptionPath {
-  readonly algKem: string;       // CipherClass: kem
-  readonly algKdf: string;       // CipherClass: kdf
-  readonly algWrap: string;      // CipherClass: aead (for CEK wrap)
-  readonly algContent: string;   // CipherClass: aead (for plaintext)
-  readonly algSig: string;       // CipherClass: signature
+  readonly algKem: string; // CipherClass: kem
+  readonly algKdf: string; // CipherClass: kdf
+  readonly algWrap: string; // CipherClass: aead (for CEK wrap)
+  readonly algContent: string; // CipherClass: aead (for plaintext)
+  readonly algSig: string; // CipherClass: signature
   readonly recipientCount: number;
   readonly senderIdentity: string;
   readonly composesWith: ReadonlyArray<string>;
@@ -314,9 +315,7 @@ export interface PlannedEncryptionPath {
  * so the path-planner composes cleanly with downstream encrypt operations
  * via Result.bind chains.
  */
-export type PlanResult =
-  | { ok: true; path: PlannedEncryptionPath }
-  | { ok: false; feedback: EncryptionFeedback };
+export type PlanResult = { ok: true; path: PlannedEncryptionPath } | { ok: false; feedback: EncryptionFeedback };
 
 /**
  * `determineEncryptionPath` — discriminator that maps an EncryptionContext
@@ -339,9 +338,7 @@ export type PlanResult =
  * extensions to EncryptionFeedback union must update this function (TS
  * strict mode enforces).
  */
-export function determineEncryptionPath(
-  context: EncryptionContext,
-): PlanResult {
+export function determineEncryptionPath(context: EncryptionContext): PlanResult {
   // Empty recipient set:
   if (context.recipients.length === 0) {
     return { ok: false, feedback: { kind: "EmptyRecipientSet" } };
@@ -349,9 +346,7 @@ export function determineEncryptionPath(
 
   // Sender must be in recipient set (sender encrypts to self too for
   // round-trip recovery, per design memo):
-  const senderInRecipients = context.recipients.some(
-    (r) => r.identity === context.sender.identity,
-  );
+  const senderInRecipients = context.recipients.some((r) => r.identity === context.sender.identity);
   if (!senderInRecipients) {
     return {
       ok: false,
@@ -367,18 +362,14 @@ export function determineEncryptionPath(
   if (!firstKemId) {
     return { ok: false, feedback: { kind: "EmptyRecipientSet" } };
   }
-  const allSameKem = context.recipients.every(
-    (r) => r.kemAlgId === firstKemId,
-  );
+  const allSameKem = context.recipients.every((r) => r.kemAlgId === firstKemId);
   if (!allSameKem) {
     // Use RecipientKeyInvalid (not AlgUnsupported) — the per-recipient
     // KEM is itself well-formed and supported; the failure is that v1's
     // single-envelope-KEM-column constraint requires all recipients use
     // the SAME KEM. RecipientKeyInvalid surfaces the specific mismatched
     // identity + the v1 constraint reason for the caller's handler.
-    const mismatched = context.recipients.find(
-      (r) => r.kemAlgId !== firstKemId,
-    );
+    const mismatched = context.recipients.find((r) => r.kemAlgId !== firstKemId);
     return {
       ok: false,
       feedback: {
@@ -512,9 +503,7 @@ export function validateEncryptionContext(
   if (ctx.recipients.length === 0) {
     return { kind: "EmptyRecipientSet" };
   }
-  const senderInRecipients = ctx.recipients.some(
-    (r) => r.identity === ctx.sender.identity,
-  );
+  const senderInRecipients = ctx.recipients.some((r) => r.identity === ctx.sender.identity);
   if (!senderInRecipients) {
     return { kind: "SenderNotInRecipientSet", senderIdentity: ctx.sender.identity };
   }

--- a/tools/crypto/better-git-crypt/types.ts
+++ b/tools/crypto/better-git-crypt/types.ts
@@ -74,7 +74,7 @@ export interface AlgSpec {
   readonly status: CipherStatus;
   readonly description: string;
   readonly nobleModule?: string; // @noble/post-quantum module path when ships-v1
-  readonly composesWith: ReadonlyArray<string>; // backlog/rule references
+  readonly composesWith: readonly string[]; // backlog/rule references
 }
 
 /**
@@ -95,7 +95,7 @@ export interface RecipientKey {
   readonly publicKemKey: Uint8Array;
   readonly publicSigKey: Uint8Array;
   readonly seedSource: SeedSource;
-  readonly composesWith: ReadonlyArray<string>;
+  readonly composesWith: readonly string[];
 }
 
 /**
@@ -125,7 +125,7 @@ export interface FileEnvelope {
   readonly algWrap: string; // AlgSpec.id of CipherClass "aead"
   readonly algContent: string; // AlgSpec.id of CipherClass "aead"
   readonly algSig: string; // AlgSpec.id of CipherClass "signature"
-  readonly recipients: ReadonlyArray<RecipientSlot>;
+  readonly recipients: readonly RecipientSlot[];
   readonly ciphertext: Uint8Array;
   readonly contentNonce: Uint8Array; // 12-byte ChaCha20-Poly1305 nonce for the content AEAD (memo schema "content_nonce"); covered by the signature
   readonly signerIdentity: string; // matches RecipientKey.identity of sender
@@ -137,7 +137,7 @@ export interface FileEnvelope {
  */
 export interface EncryptionContext {
   readonly plaintext: Uint8Array;
-  readonly recipients: ReadonlyArray<RecipientKey>;
+  readonly recipients: readonly RecipientKey[];
   readonly sender: RecipientKey;
   readonly seedSource: SeedSource;
 }
@@ -181,7 +181,7 @@ export type DecryptionFeedback =
 /**
  * Seed v1 algorithm registry per design memo.
  */
-export const ALG_REGISTRY: ReadonlyArray<AlgSpec> = [
+export const ALG_REGISTRY: readonly AlgSpec[] = [
   // KEM
   {
     id: "ML-KEM-768+X25519",
@@ -305,7 +305,7 @@ export interface PlannedEncryptionPath {
   readonly algSig: string; // CipherClass: signature
   readonly recipientCount: number;
   readonly senderIdentity: string;
-  readonly composesWith: ReadonlyArray<string>;
+  readonly composesWith: readonly string[];
 }
 
 /**
@@ -382,7 +382,7 @@ export function determineEncryptionPath(context: EncryptionContext): PlanResult 
 
   // KEM alg must be ships-v1:
   const kemAlg = findAlg(firstKemId);
-  if (!kemAlg || kemAlg.class !== "kem" || kemAlg.status !== "ships-v1") {
+  if (kemAlg?.class !== "kem" || kemAlg.status !== "ships-v1") {
     return {
       ok: false,
       feedback: { kind: "AlgUnsupported", algId: firstKemId },
@@ -392,7 +392,7 @@ export function determineEncryptionPath(context: EncryptionContext): PlanResult 
   // Signature alg must be ships-v1:
   const sigAlgId = context.sender.sigAlgId;
   const sigAlg = findAlg(sigAlgId);
-  if (!sigAlg || sigAlg.class !== "signature" || sigAlg.status !== "ships-v1") {
+  if (sigAlg?.class !== "signature" || sigAlg.status !== "ships-v1") {
     return {
       ok: false,
       feedback: { kind: "AlgUnsupported", algId: sigAlgId },
@@ -407,7 +407,7 @@ export function determineEncryptionPath(context: EncryptionContext): PlanResult 
   // Sanity-check the defaults exist (should always hold given seed registry):
   for (const id of [algKdf, algWrap, algContent]) {
     const alg = findAlg(id);
-    if (!alg || alg.status !== "ships-v1") {
+    if (alg?.status !== "ships-v1") {
       return { ok: false, feedback: { kind: "AlgUnsupported", algId: id } };
     }
   }
@@ -437,7 +437,7 @@ export function determineEncryptionPath(context: EncryptionContext): PlanResult 
  *   - at least one ships-v1 KDF
  *   - at least one ships-v1 AEAD
  */
-export function validateAlgRegistry(reg: ReadonlyArray<AlgSpec>): void {
+export function validateAlgRegistry(reg: readonly AlgSpec[]): void {
   const ids = new Set<string>();
   for (const a of reg) {
     if (ids.has(a.id)) {
@@ -489,6 +489,13 @@ export function validateEnvelopeStructure(env: FileEnvelope): void {
   if (env.signerIdentity.length === 0) {
     throw new Error("envelope has empty signerIdentity");
   }
+  // contentNonce is a fixed 12-byte ChaCha20-Poly1305 nonce. Enforce it in the
+  // SHARED validator so callers that validate/decrypt without going through
+  // decodeEnvelope still reject a malformed nonce structurally (not as a late
+  // crypto failure).
+  if (env.contentNonce.length !== 12) {
+    throw new Error(`envelope contentNonce must be 12 bytes, got ${env.contentNonce.length}`);
+  }
 }
 
 /**
@@ -498,7 +505,7 @@ export function validateEnvelopeStructure(env: FileEnvelope): void {
  */
 export function validateEncryptionContext(
   ctx: EncryptionContext,
-  reg: ReadonlyArray<AlgSpec>,
+  reg: readonly AlgSpec[],
 ): EncryptionFeedback | undefined {
   if (ctx.recipients.length === 0) {
     return { kind: "EmptyRecipientSet" };


### PR DESCRIPTION
## B-0883 Phase 2 — real crypto (operator-authorized 2026-05-31)

Wires the v1 type scaffold (`types.ts`) to actual post-quantum primitives in new `crypto.ts`: `generateRecipientKeyPair` / `encrypt` / `decrypt` / `encodeEnvelope` / `decodeEnvelope`.

### What's implemented
- **XWing** (ML-KEM-768 + X25519 hybrid) KEM + **ML-DSA-65** signatures — `@noble/post-quantum`
- **HKDF-SHA256** — `@noble/hashes`; **ChaCha20-Poly1305** content + CEK-wrap AEAD — `@noble/ciphers`
- **canonical CBOR** envelope — `cborg` (deterministic, so sign-over-encoded-bytes / verify agree)
- signature-first **fail-closed** verify; FIPS-203 implicit-rejection → `KemFailure`
- per-recipient KEM encapsulation + single shared CEK for content; zero-nonce CEK-wrap with the single-use-wrapKey safety invariant documented inline
- `contentNonce` added to `FileEnvelope` (memo schema `content_nonce`)

### Empirical API correction (runtime = the oracle)
A probe against the **installed** packages caught two errors in the v1 design memo's pseudocode before they reached code:
- memo's `chacha20poly1305(key).encrypt(nonce, pt)` **fails** on `@noble/ciphers@2.2.0` → corrected to `chacha20poly1305(key, nonce).encrypt(pt)`
- memo's 3-arg `ml_dsa65.sign(msg, sk, context)` **fails** → 2-arg `sign(msg, sk)`; domain-separation `ctx` lives inside the signed CBOR instead

### Tests — 51 pass / 0 fail
23 new `crypto.test.ts`: keygen sizes, single + multi-recipient round-trip, empty + 8 KiB binary payloads, all encrypt/decrypt `TFeedback` failure modes (EmptyRecipientSet, SenderNotInRecipientSet, RecipientKeyInvalid, SeedSourceNotAvailable, RecipientNotInEnvelope, KemFailure, SignatureInvalid on tampered ciphertext/signature/wrong-key), and on-disk CBOR encode/decode round-trip + determinism.

typecheck clean (CI gate); eslint clean; prettier clean.

### Deps (pinned current-latest per dep-pin-search-first-authority, verified 2026-05-31)
`@noble/post-quantum@0.6.1` · `@noble/ciphers@2.2.0` · `@noble/hashes@2.2.0` · `cborg@5.1.1`

### ⚠️ crypto-don't-rush gate (operator decision, README §"Phase 2 operator decisions")
This lands the **library + round-trip tests only** — it is **not wired to any real secret** (no recipients.json, no git textconv, no real-data flow). Per the operator's gate, **KATs against Noble's published vectors + formal-verification + security-ops review of the envelope & key-handling are REQUIRED before this holds anything real.** Those are tracked follow-ups; do not use for real secrets until they're done.

### Still deferred (post-Phase-2)
git textconv filter · recipient management (`.zeta-crypt/recipients.json` + rotation) · multi-cipher hedge (B-0883.2) · metadata encryption (B-0883.5)

Unblocks **B-0884** (zflash USB-bound crypto integration) + **B-0885** (agent private encrypted state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)