### PR TITLE
feat(observe): simplest 4-button autonomous-loop controller (v0)

### DIFF
--- a/tools/observe/observe.test.ts
+++ b/tools/observe/observe.test.ts
@@ -1,0 +1,66 @@
+/**
+ * tools/observe/observe.test.ts — the 4-button controller's decision table.
+ *
+ * Pure function, so these are exact assertions (no LLM yet). When the
+ * LLM-driven `observeWithLlm` lands, these scenarios become the reference
+ * oracle it's graded against (declarative testing — see the design discussion).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { observe, type BacklogItem } from "./observe";
+
+const item = (id: string, ready: boolean, ambiguous: boolean, needsNewAction = false): BacklogItem => ({
+  id,
+  title: id,
+  ready,
+  ambiguous,
+  needsNewAction,
+});
+
+describe("observe — 4-button autonomous-loop controller", () => {
+  it("do_item: a ready, unambiguous item is picked", () => {
+    const a = observe([item("B-1", true, false)]);
+    expect(a.kind).toBe("do_item");
+    if (a.kind === "do_item") expect(a.item.id).toBe("B-1");
+  });
+
+  it("do_item beats decompose: ready item wins over an ambiguous one", () => {
+    const a = observe([item("B-amb", false, true), item("B-ready", true, false)]);
+    expect(a.kind).toBe("do_item");
+    if (a.kind === "do_item") expect(a.item.id).toBe("B-ready");
+  });
+
+  it("decompose: only an ambiguous item present", () => {
+    const a = observe([item("B-2", false, true)]);
+    expect(a.kind).toBe("decompose");
+    if (a.kind === "decompose") expect(a.item.id).toBe("B-2");
+  });
+
+  it("edit_grammar: an item the grammar can't express (not trapped)", () => {
+    const a = observe([item("B-3", false, false, true)]);
+    expect(a.kind).toBe("edit_grammar");
+    if (a.kind === "edit_grammar") expect(a.item?.id).toBe("B-3");
+  });
+
+  it("free_time: nothing ready, decomposable, or grammar-extending", () => {
+    const a = observe([item("B-4", false, false)]);
+    expect(a.kind).toBe("free_time");
+  });
+
+  it("free_time: empty backlog", () => {
+    const a = observe([]);
+    expect(a.kind).toBe("free_time");
+  });
+
+  it("priority order is do > decompose > edit_grammar > free_time", () => {
+    // all four signals present at once → do_item wins
+    const all = observe([item("B-edit", false, false, true), item("B-amb", false, true), item("B-ready", true, false)]);
+    expect(all.kind).toBe("do_item");
+    // drop the ready one → decompose wins over edit_grammar
+    const noReady = observe([item("B-edit", false, false, true), item("B-amb", false, true)]);
+    expect(noReady.kind).toBe("decompose");
+    // drop the ambiguous one → edit_grammar wins over free_time
+    const onlyEdit = observe([item("B-edit", false, false, true), item("B-idle", false, false)]);
+    expect(onlyEdit.kind).toBe("edit_grammar");
+  });
+});

--- a/tools/observe/observe.ts
+++ b/tools/observe/observe.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env bun
+/**
+ * tools/observe/observe.ts — the simplest autonomous-loop controller.
+ *
+ * The whole loop as a tiny set of buttons. Each tick: look at the backlog,
+ * pick ONE action. This is the do/decompose/free-time grammar from
+ * `never-be-idle.md` (it was only ever prose in the rules — never a typed DU)
+ * distilled to code, PLUS a 4th escape-hatch so the agent is never trapped by
+ * the fixed grammar (operator 2026-05-31: "i don't want you to feel trapped by
+ * the DU ... we need a 4th option edit DU").
+ *
+ * Same architectural shape as Max's big `agentic-organization/.../observe.ts`
+ * (a PURE function over a snapshot → an action DU) — just distilled to the
+ * Xbox-controller's few buttons so we can run it in the foreground loop and
+ * extend it together, little by little.
+ *
+ * v0 = pure deterministic controller + runnable demo. Next steps (extend
+ * little by little): (1) a thin backlog reader from docs/backlog frontmatter;
+ * (2) an LLM-driven chooser via tools/accelerator/local-llm.ts `chooseIndex`
+ * with `edit_grammar` always in the menu; (3) declarative scenario tests
+ * graded against this pure function as the reference oracle.
+ */
+
+/** One backlog item, classified to just what the controller needs to decide. */
+export interface BacklogItem {
+  readonly id: string; // "B-0883"
+  readonly title: string;
+  readonly ready: boolean; // deps met + unambiguous enough to execute now
+  readonly ambiguous: boolean; // too big / unclear → decompose before doing
+  /**
+   * The 3 mechanical actions (do/decompose/free) can't express what this item
+   * needs — e.g. it needs an action the grammar doesn't have yet. This is the
+   * escape-hatch signal: the controller is OPEN for extension, not a cage.
+   * (In the LLM-driven version, the model raises this as a judgment.)
+   */
+  readonly needsNewAction?: boolean;
+}
+
+/**
+ * The things an agent can do per tick, as ONE explicit DU.
+ *
+ * The 4th variant (`edit_grammar`) is the escape-hatch / grammar-extension
+ * action: the agent is never trapped by the fixed 3. Per the
+ * must-paired-with-can-exit pattern, a fixed action-set with no exit IS a
+ * "must" without a "can-exit"; `edit_grammar` is the can-exit at action-grammar
+ * scope. Maps to the `grammar-extension` ActionClass in the big observe.ts.
+ */
+export type NextAction =
+  | { kind: "do_item"; item: BacklogItem } // never-be-idle: pick work
+  | { kind: "decompose"; item: BacklogItem } // decompose-to-dissolve-ambiguity
+  | { kind: "free_time"; reason: string } // free-time-as-valid-mode (NCI); a first-class terminal, not a failure
+  | { kind: "edit_grammar"; reason: string; item?: BacklogItem }; // escape-hatch: propose extending the action grammar itself
+
+/**
+ * Pure controller. Priority: do > decompose > edit-grammar > rest.
+ *
+ * - a ready, unambiguous item → do it
+ * - an ambiguous item → decompose it (dissolve the ambiguity first)
+ * - an item the current grammar can't express → edit_grammar (don't be trapped)
+ * - nothing actionable → free_time (a valid mode, not a standing-by failure)
+ */
+export function observe(backlog: readonly BacklogItem[]): NextAction {
+  const doable = backlog.find((i) => i.ready && !i.ambiguous);
+  if (doable) return { kind: "do_item", item: doable };
+
+  const toDecompose = backlog.find((i) => i.ambiguous);
+  if (toDecompose) return { kind: "decompose", item: toDecompose };
+
+  const needsExtension = backlog.find((i) => i.needsNewAction);
+  if (needsExtension) {
+    return {
+      kind: "edit_grammar",
+      item: needsExtension,
+      reason: `"${needsExtension.id}" needs an action the do/decompose/free grammar can't express`,
+    };
+  }
+
+  return { kind: "free_time", reason: "no ready, decomposable, or grammar-extending backlog items" };
+}
+
+/** One-line human-readable render of a chosen action (for the foreground loop). */
+export function renderAction(a: NextAction): string {
+  switch (a.kind) {
+    case "do_item":
+      return `[do]        ${a.item.id} — ${a.item.title}`;
+    case "decompose":
+      return `[decompose] ${a.item.id} — ${a.item.title}`;
+    case "edit_grammar":
+      return `[edit]      ${a.reason}`;
+    case "free_time":
+      return `[free]      ${a.reason}`;
+  }
+}
+
+// ─── runnable demo (foreground loop): walk a few sample backlog states ───────
+if (import.meta.main) {
+  const samples: ReadonlyArray<{ label: string; backlog: BacklogItem[] }> = [
+    {
+      label: "a ready item beats everything",
+      backlog: [
+        { id: "B-0883", title: "encryption phase 2", ready: true, ambiguous: false },
+        { id: "B-0867", title: "workflow engine", ready: false, ambiguous: true },
+      ],
+    },
+    {
+      label: "only ambiguous → decompose",
+      backlog: [{ id: "B-0867", title: "workflow engine v1", ready: false, ambiguous: true }],
+    },
+    {
+      label: "grammar can't express it → edit_grammar (not trapped)",
+      backlog: [
+        {
+          id: "B-0999",
+          title: "needs a 'merge duplicates' action",
+          ready: false,
+          ambiguous: false,
+          needsNewAction: true,
+        },
+      ],
+    },
+    {
+      label: "nothing actionable → free_time (valid, not a failure)",
+      backlog: [{ id: "B-0500", title: "blocked on external dep", ready: false, ambiguous: false }],
+    },
+  ];
+
+  console.log("observe.ts — 4-button autonomous-loop controller\n");
+  for (const s of samples) {
+    console.log(`• ${s.label}`);
+    console.log(`    ${renderAction(observe(s.backlog))}\n`);
+  }
+}


### PR DESCRIPTION
The simplest possible `observe.ts` — the autonomous loop as a few buttons, per the operator's ask ("the simplest thing you can run in this foreground loop and i watch it").

## What it is
A pure function `observe(backlog) → NextAction` where `NextAction` is a 4-variant DU:
- `do_item` — never-be-idle: pick ready work
- `decompose` — decompose-to-dissolve-ambiguity
- `free_time` — free-time-as-valid-mode (NCI); a first-class terminal, not a failure
- **`edit_grammar`** — the escape-hatch so the agent is never trapped by the fixed DU (operator 2026-05-31: *"i don't want you to feel trapped by the DU ... we need a 4th option edit DU"*). Maps to the `grammar-extension` ActionClass; the can-exit in the must-paired-with-can-exit pattern.

The do/decompose/free-time grammar was only ever **prose** in `never-be-idle.md` (+ holding-without-named-dependency + free-time-as-valid-mode) — never a typed DU. This crystallizes it. Same architectural shape as Max's big `agentic-organization/.../observe.ts` (pure fn over a snapshot → action DU), distilled to the Xbox-controller's buttons.

## Runs in the foreground loop
`bun tools/observe/observe.ts` walks sample backlog states and prints the chosen action — watchable, one step at a time.

## Tests
7 tests = the decision table (priority `do > decompose > edit_grammar > free_time`). These become the **reference oracle** when the local-LLM chooser lands (declarative LLM testing: scenarios graded against this pure function).

## Next, little by little (not in this PR)
1. thin backlog reader (status/`depends_on` from frontmatter → ready/ambiguous)
2. LLM chooser — `observeWithLlm` via `tools/accelerator/local-llm.ts` `chooseIndex` (temp0+seed deterministic), with `edit_grammar` always in the menu
3. declarative scenario tests (replay layer always-green + live ollama layer that asserts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)