### PR TITLE
feat(observe): backlog reader + re-land stranded exits/LLM-chooser (#6218 merged v0 only)

### DIFF
--- a/tools/observe/backlog-reader.test.ts
+++ b/tools/observe/backlog-reader.test.ts
@@ -1,0 +1,75 @@
+/**
+ * tools/observe/backlog-reader.test.ts
+ *
+ * Two layers:
+ *  - `pickupToAction` mapping (pure, exact) — PickupSelection → observe DU; and
+ *  - a real-backlog integration smoke for `nextActionFromBacklog` (reads the
+ *    actual docs/backlog via the reused autonomous-pickup selector).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { pickupToAction, nextActionFromBacklog } from "./backlog-reader";
+import type { BacklogItem as RichItem, PickupSelection } from "../backlog/autonomous-pickup";
+
+const richItem = (id: string, title: string): RichItem => ({
+  id,
+  priority: "P2",
+  status: "open",
+  title,
+  relativePath: `docs/backlog/P2/${id}.md`,
+  dependsOn: [],
+  parent: null,
+  created: null,
+  lastUpdated: null,
+  decomposition: null,
+  bodyLineCount: 10,
+});
+
+const sel = (over: Partial<PickupSelection>): PickupSelection => ({
+  status: "empty",
+  selected: null,
+  action: null,
+  reason: "r",
+  blocked: [],
+  activeClaims: [],
+  executionPrompt: null,
+  ...over,
+});
+
+describe("pickupToAction — map the reused backlog selector onto the observe DU", () => {
+  it("empty selection → free_time (reason passes through)", () => {
+    const a = pickupToAction(sel({ status: "empty", reason: "nothing ready" }));
+    expect(a.kind).toBe("free_time");
+    if (a.kind === "free_time") expect(a.reason).toBe("nothing ready");
+  });
+
+  it("selected + claim-and-implement → do_item (ready, not ambiguous)", () => {
+    const a = pickupToAction(
+      sel({ status: "selected", selected: richItem("B-1", "do me"), action: "claim-and-implement" }),
+    );
+    expect(a.kind).toBe("do_item");
+    if (a.kind === "do_item") {
+      expect(a.item.id).toBe("B-1");
+      expect(a.item.ready).toBe(true);
+      expect(a.item.ambiguous).toBe(false);
+    }
+  });
+
+  it("selected + decompose-first → decompose (ambiguous)", () => {
+    const a = pickupToAction(
+      sel({ status: "selected", selected: richItem("B-2", "big one"), action: "decompose-first" }),
+    );
+    expect(a.kind).toBe("decompose");
+    if (a.kind === "decompose") {
+      expect(a.item.id).toBe("B-2");
+      expect(a.item.ambiguous).toBe(true);
+    }
+  });
+});
+
+describe("nextActionFromBacklog — real-backlog integration smoke", () => {
+  it("returns a valid observe action from the actual docs/backlog", () => {
+    const action = nextActionFromBacklog(process.cwd());
+    expect(["do_item", "decompose", "free_time"]).toContain(action.kind);
+  });
+});

--- a/tools/observe/backlog-reader.ts
+++ b/tools/observe/backlog-reader.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env bun
+/**
+ * tools/observe/backlog-reader.ts — bridge the REAL backlog to the observe DU.
+ *
+ * observe.ts's `observe()` is the pure 4-button controller (a toy oracle over a
+ * synthetic BacklogItem). The REAL backlog already has a deterministic selector:
+ * `tools/backlog/autonomous-pickup.ts` `selectNextBacklogItem` (priority-ranked,
+ * dependency-aware, claim-aware, decompose-vs-claim). This reader REUSES it and
+ * maps its `PickupSelection` onto the observe `NextAction` DU — it does NOT
+ * reimplement selection. So on real rows, `selectNextBacklogItem` is the oracle;
+ * `observe()` stays the DU definition + the LLM-chooser grading oracle for
+ * synthetic scenarios.
+ *
+ * Mapping:
+ *   selected + "claim-and-implement" → do_item
+ *   selected + "decompose-first"     → decompose
+ *   empty                            → free_time   (the exit)
+ *   (edit_grammar is the escape-hatch the agent/LLM raises — not derivable from
+ *    backlog frontmatter, so this DETERMINISTIC reader never emits it; it stays
+ *    available in the LLM-chooser menu via observe.ts `buildMenu`.)
+ *
+ * ── FORWARD CONTEXT / MIGRATION SEAM (operator 2026-05-31) ────────────────────
+ * Two things this reader absorbs as the system scales — and it is the single
+ * place the rest of observe.ts is insulated from both:
+ *  1. Backlog-item is ONE SUB-TYPE of a general WORK-ITEM (Max's framing) —
+ *     work-items can be bugs and other kinds too. Today this reads the backlog
+ *     sub-type; the general shape is a work-item carrying a sub-type.
+ *  2. ZetaId gets a new `WorkItem` CATEGORY (operator 2026-05-31: "zetaid gets a
+ *     new workitem category too after bus") — sequenced after the `Bus` category,
+ *     alongside `Spawn`/`Heartbeat`. The backlog uses `B-xxxxx` ids today, which
+ *     COLLIDE at scale — the very problem 128-bit ZetaIds solve everywhere else.
+ *     The migration is `B-xxxxx` → 128-bit ZetaId **WorkItem-category** ids
+ *     (backlog-item + bug + … as sub-types within `WorkItem`), and THIS reader is
+ *     where that mapping lands: today `id` carries `B-xxxxx`; post-migration it
+ *     carries (or pairs with) a `WorkItem` ZetaId.
+ * Keeping the reader the single seam means observe.ts never sees `B-xxxxx` vs
+ * ZetaId — only the observe DU.
+ */
+
+import { readBacklogItems, selectNextBacklogItem, type PickupSelection } from "../backlog/autonomous-pickup";
+import { type BacklogItem, type NextAction, renderAction } from "./observe";
+
+/** Backlog priority tiers (mirrors the non-exported union in autonomous-pickup). */
+export type Priority = "P0" | "P1" | "P2" | "P3";
+
+/**
+ * Map the existing backlog selector's result onto the observe DU (pure).
+ * `selectNextBacklogItem` only returns an item that already passed its blockers,
+ * so a selected item is `ready: true`; `decompose-first` is the `ambiguous` signal.
+ */
+export function pickupToAction(sel: PickupSelection): NextAction {
+  if (sel.status === "empty" || sel.selected === null) {
+    return { kind: "free_time", reason: sel.reason };
+  }
+  const picked = sel.selected;
+  const item: BacklogItem = {
+    id: picked.id, // B-xxxxx today → ZetaId work-item id post-migration (the seam)
+    title: picked.title,
+    ready: true,
+    ambiguous: sel.action === "decompose-first",
+  };
+  return sel.action === "decompose-first" ? { kind: "decompose", item } : { kind: "do_item", item };
+}
+
+/** Read the real backlog and return the next observe action (deterministic). */
+export function nextActionFromBacklog(
+  repoRoot: string,
+  activeClaims: readonly string[] = [],
+  maxPriority: Priority = "P2",
+): NextAction {
+  const items = readBacklogItems(repoRoot);
+  const sel = selectNextBacklogItem(items, activeClaims, maxPriority);
+  return pickupToAction(sel);
+}
+
+// ─── demo: print the real next action from the actual backlog ────────────────
+if (import.meta.main) {
+  const repoRoot = process.argv[2] ?? process.cwd();
+  const action = nextActionFromBacklog(repoRoot);
+  console.log(`observe ← real backlog (${repoRoot})`);
+  console.log(`  ${renderAction(action)}`);
+}

--- a/tools/observe/backlog-reader.ts
+++ b/tools/observe/backlog-reader.ts
@@ -20,21 +20,37 @@
  *    available in the LLM-chooser menu via observe.ts `buildMenu`.)
  *
  * ── FORWARD CONTEXT / MIGRATION SEAM (operator 2026-05-31) ────────────────────
- * Two things this reader absorbs as the system scales — and it is the single
- * place the rest of observe.ts is insulated from both:
- *  1. Backlog-item is ONE SUB-TYPE of a general WORK-ITEM (Max's framing) —
- *     work-items can be bugs and other kinds too. Today this reads the backlog
- *     sub-type; the general shape is a work-item carrying a sub-type.
- *  2. ZetaId gets a new `WorkItem` CATEGORY (operator 2026-05-31: "zetaid gets a
- *     new workitem category too after bus") — sequenced after the `Bus` category,
- *     alongside `Spawn`/`Heartbeat`. The backlog uses `B-xxxxx` ids today, which
- *     COLLIDE at scale — the very problem 128-bit ZetaIds solve everywhere else.
- *     The migration is `B-xxxxx` → 128-bit ZetaId **WorkItem-category** ids
- *     (backlog-item + bug + … as sub-types within `WorkItem`), and THIS reader is
- *     where that mapping lands: today `id` carries `B-xxxxx`; post-migration it
- *     carries (or pairs with) a `WorkItem` ZetaId.
+ * Three things this reader absorbs as the system scales — and it is the single
+ * place the rest of observe.ts is insulated from all of them:
+ *
+ *  1. TYPE axis (operator decided: `tasks + bugs`). A backlog row is not its own
+ *     thing — it's a WORK-ITEM with a TYPE. Per Azure DevOps (umbrella =
+ *     `WorkItem`; `Task` + `Bug` are peer leaf TYPES; Epic/Feature are the
+ *     hierarchy above): sub-types are `task` + `bug` (+ later feature/epic).
+ *     "backlog" is NOT a type — it's a STATE/view (the queued lane), orthogonal
+ *     to type. So: WorkItem.type ∈ {task, bug, …}; WorkItem.state ∈ {backlog,
+ *     active, done, …}.
+ *
+ *  2. ID axis. ZetaId gets a new `WorkItem` CATEGORY (operator 2026-05-31:
+ *     "zetaid gets a new workitem category too after bus") — after `Bus`,
+ *     alongside `Spawn`/`Heartbeat`. `B-xxxxx` ids COLLIDE at scale (the problem
+ *     128-bit ZetaIds solve everywhere else). Migration: `B-xxxxx` → 128-bit
+ *     ZetaId **WorkItem-category** ids (the `type` is a sub-type field within
+ *     `WorkItem`). THIS reader is where that mapping lands: today `id` carries
+ *     `B-xxxxx`; post-migration it carries (or pairs with) a `WorkItem` ZetaId.
+ *
+ *  3. EXECUTION axis (operator 2026-05-31, open umbrella question). A WorkItem
+ *     RUNS AS a durable Task (Durable Functions / Task framework) whose lifecycle
+ *     is an Rx `Observable<WorkItemEvent>` (the heartbeat/bus stream IS that
+ *     observable). "Task" here is the EXECUTION primitive — a different layer
+ *     from the planning `task` TYPE. Recommendation: keep `WorkItem` as the
+ *     planning umbrella (matches Azure DevOps, clean plugin-interop) and RELATE
+ *     it to execution (runs-as-Task, observed-via-Rx) rather than REPLACE it with
+ *     `Task` (which would invert Azure DevOps + overload the word). Pending
+ *     operator confirmation of the umbrella name.
+ *
  * Keeping the reader the single seam means observe.ts never sees `B-xxxxx` vs
- * ZetaId — only the observe DU.
+ * ZetaId, or task vs bug vs state — only the observe DU.
  */
 
 import { readBacklogItems, selectNextBacklogItem, type PickupSelection } from "../backlog/autonomous-pickup";

--- a/tools/observe/backlog-reader.ts
+++ b/tools/observe/backlog-reader.ts
@@ -39,15 +39,14 @@
  *     `WorkItem`). THIS reader is where that mapping lands: today `id` carries
  *     `B-xxxxx`; post-migration it carries (or pairs with) a `WorkItem` ZetaId.
  *
- *  3. EXECUTION axis (operator 2026-05-31, open umbrella question). A WorkItem
- *     RUNS AS a durable Task (Durable Functions / Task framework) whose lifecycle
- *     is an Rx `Observable<WorkItemEvent>` (the heartbeat/bus stream IS that
- *     observable). "Task" here is the EXECUTION primitive — a different layer
- *     from the planning `task` TYPE. Recommendation: keep `WorkItem` as the
- *     planning umbrella (matches Azure DevOps, clean plugin-interop) and RELATE
- *     it to execution (runs-as-Task, observed-via-Rx) rather than REPLACE it with
- *     `Task` (which would invert Azure DevOps + overload the word). Pending
- *     operator confirmation of the umbrella name.
+ *  3. EXECUTION axis. A WorkItem RUNS AS a durable Task (Durable Functions / Task
+ *     framework) whose lifecycle is an Rx `Observable<WorkItemEvent>` (the
+ *     heartbeat/bus stream IS that observable). "Task" here is the EXECUTION
+ *     primitive — a different layer from the planning `task` TYPE. DECIDED
+ *     (operator 2026-05-31): keep `WorkItem` as the planning umbrella (matches
+ *     Azure DevOps; clean Jira/ADO plugin-interop; git-native first) and RELATE
+ *     it to execution (runs-as-Task, observed-via-Rx) — do NOT replace it with
+ *     `Task` (which would invert Azure DevOps + overload the word).
  *
  * Keeping the reader the single seam means observe.ts never sees `B-xxxxx` vs
  * ZetaId, or task vs bug vs state — only the observe DU.

--- a/tools/observe/observe.test.ts
+++ b/tools/observe/observe.test.ts
@@ -1,13 +1,23 @@
 /**
  * tools/observe/observe.test.ts — the 4-button controller's decision table.
  *
- * Pure function, so these are exact assertions (no LLM yet). When the
- * LLM-driven `observeWithLlm` lands, these scenarios become the reference
- * oracle it's graded against (declarative testing — see the design discussion).
+ * Two layers:
+ *  - the pure `observe()` decision table (exact assertions); and
+ *  - the v1 `observeWithLlm` chooser, graded against `observe()` as the
+ *    reference oracle using a MOCK backend (deterministic, no ollama). This is
+ *    the always-green CI shield for the chooser LOGIC — per the shield rule,
+ *    coverage must not depend on a live ollama. The live qwen2.5:0.5b run is a
+ *    watchable DEMO (`bun observe.ts`), not a skippable test.
  */
 
 import { describe, expect, it } from "bun:test";
-import { observe, type BacklogItem } from "./observe";
+import { observe, observeWithLlm, buildMenu, type BacklogItem } from "./observe";
+import type { ModelBackend } from "../accelerator/local-llm";
+
+/** Deterministic mock backend: `complete` always returns `reply`. */
+const mock = (reply: string): ModelBackend => ({ name: "mock", complete: () => Promise.resolve(reply) });
+/** A backend that fails like ollama-is-down (chooseIndex catches → fallback). */
+const downBackend: ModelBackend = { name: "down", complete: () => Promise.reject(new Error("ollama down")) };
 
 const item = (id: string, ready: boolean, ambiguous: boolean, needsNewAction = false): BacklogItem => ({
   id,
@@ -75,5 +85,58 @@ describe("observe — 4-button autonomous-loop controller", () => {
     // drop the ambiguous one → edit_grammar wins over free_time
     const onlyEdit = observe([item("B-edit", false, false, true), item("B-idle", false, false)]);
     expect(onlyEdit.kind).toBe("edit_grammar");
+  });
+});
+
+describe("observeWithLlm — LLM chooser graded vs the pure oracle (mock backend = CI shield)", () => {
+  // Representative scenarios reused as the grading oracle.
+  const scenarios: ReadonlyArray<BacklogItem[]> = [
+    [item("B-ready", true, false), item("B-amb", false, true)], // do wins
+    [item("B-amb", false, true)], // decompose
+    [item("B-x", false, false, true)], // edit_grammar
+    [item("B-idle", false, false)], // free_time
+    [], // empty → free_time
+  ];
+
+  it("buildMenu ALWAYS includes both exits (edit_grammar + free_time) for any state", () => {
+    for (const backlog of scenarios) {
+      const kinds = buildMenu(backlog).map((a) => a.kind);
+      expect(kinds).toContain("edit_grammar");
+      expect(kinds).toContain("free_time");
+    }
+  });
+
+  it("buildMenu is oracle-ordered: menu[0] == observe() — so fallback-to-0 degrades toward correct", () => {
+    for (const backlog of scenarios) {
+      expect(buildMenu(backlog)[0]?.kind).toBe(observe(backlog).kind);
+    }
+  });
+
+  it("maps the model's chosen index to the menu entry (order-agnostic)", async () => {
+    const backlog = [item("B-ready", true, false), item("B-amb", false, true)];
+    const menu = buildMenu(backlog); // [do_item, decompose, free_time, edit_grammar]
+    for (let i = 0; i < menu.length; i++) {
+      expect((await observeWithLlm(backlog, mock(String(i)))).kind).toBe(menu[i]?.kind);
+    }
+    // and both exits are reachable somewhere in that menu
+    expect(menu.map((a) => a.kind)).toEqual(expect.arrayContaining(["edit_grammar", "free_time"]));
+  });
+
+  it("agrees with the oracle when the model picks the top (index 0) across all scenarios", async () => {
+    for (const backlog of scenarios) {
+      expect((await observeWithLlm(backlog, mock("0"))).kind).toBe(observe(backlog).kind);
+    }
+  });
+
+  it("falls back to the pure oracle when the model fails (ollama down → fallback)", async () => {
+    for (const backlog of scenarios) {
+      expect((await observeWithLlm(backlog, downBackend)).kind).toBe(observe(backlog).kind);
+    }
+  });
+
+  it("falls back to the pure oracle on an unparseable reply", async () => {
+    for (const backlog of scenarios) {
+      expect((await observeWithLlm(backlog, mock("banana"))).kind).toBe(observe(backlog).kind);
+    }
   });
 });

--- a/tools/observe/observe.test.ts
+++ b/tools/observe/observe.test.ts
@@ -63,7 +63,7 @@ describe("observe — 4-button autonomous-loop controller", () => {
   });
 
   it("invariant: an exit is always reachable (free_time when no work; edit_grammar on a signal)", () => {
-    // exits-always-in-menu (operator + Max 2026-05-31): from any state there is
+    // exits-always-in-menu (operator + co-maintainer 2026-05-31): from any state there is
     // always an exit — never a menu of all-musts. free_time is the unilateral
     // terminal fallback; edit_grammar (the rail-change exit) is reachable the
     // moment an item can't be expressed by the work-grammar.

--- a/tools/observe/observe.test.ts
+++ b/tools/observe/observe.test.ts
@@ -115,11 +115,14 @@ describe("observeWithLlm — LLM chooser graded vs the pure oracle (mock backend
   it("maps the model's chosen index to the menu entry (order-agnostic)", async () => {
     const backlog = [item("B-ready", true, false), item("B-amb", false, true)];
     const menu = buildMenu(backlog); // [do_item, decompose, free_time, edit_grammar]
-    for (let i = 0; i < menu.length; i++) {
-      expect((await observeWithLlm(backlog, mock(String(i)))).kind).toBe(menu[i]?.kind);
+    for (const [i, entry] of menu.entries()) {
+      const chosen = await observeWithLlm(backlog, mock(String(i)));
+      expect(chosen.kind).toBe(entry.kind);
     }
     // and both exits are reachable somewhere in that menu
-    expect(menu.map((a) => a.kind)).toEqual(expect.arrayContaining(["edit_grammar", "free_time"]));
+    const kinds = menu.map((a) => a.kind);
+    expect(kinds).toContain("edit_grammar");
+    expect(kinds).toContain("free_time");
   });
 
   it("agrees with the oracle when the model picks the top (index 0) across all scenarios", async () => {

--- a/tools/observe/observe.test.ts
+++ b/tools/observe/observe.test.ts
@@ -52,6 +52,19 @@ describe("observe — 4-button autonomous-loop controller", () => {
     expect(a.kind).toBe("free_time");
   });
 
+  it("invariant: an exit is always reachable (free_time when no work; edit_grammar on a signal)", () => {
+    // exits-always-in-menu (operator + Max 2026-05-31): from any state there is
+    // always an exit — never a menu of all-musts. free_time is the unilateral
+    // terminal fallback; edit_grammar (the rail-change exit) is reachable the
+    // moment an item can't be expressed by the work-grammar.
+    const exits = new Set(["free_time", "edit_grammar"]);
+    // no work of any kind → must land on an exit (free_time)
+    expect(exits.has(observe([item("B-idle", false, false)]).kind)).toBe(true);
+    expect(exits.has(observe([]).kind)).toBe(true);
+    // an inexpressible item → the rail-change exit is reachable, not a dead end
+    expect(observe([item("B-x", false, false, true)]).kind).toBe("edit_grammar");
+  });
+
   it("priority order is do > decompose > edit_grammar > free_time", () => {
     // all four signals present at once → do_item wins
     const all = observe([item("B-edit", false, false, true), item("B-amb", false, true), item("B-ready", true, false)]);

--- a/tools/observe/observe.ts
+++ b/tools/observe/observe.ts
@@ -37,19 +37,51 @@ export interface BacklogItem {
 }
 
 /**
- * The things an agent can do per tick, as ONE explicit DU.
+ * DESIGN INVARIANT — exits-always-in-menu (operator + Max 2026-05-31).
  *
- * The 4th variant (`edit_grammar`) is the escape-hatch / grammar-extension
- * action: the agent is never trapped by the fixed 3. Per the
- * must-paired-with-can-exit pattern, a fixed action-set with no exit IS a
- * "must" without a "can-exit"; `edit_grammar` is the can-exit at action-grammar
- * scope. Maps to the `grammar-extension` ActionClass in the big observe.ts.
+ * The two exits (`free_time` + `edit_grammar`) MUST ALWAYS be reachable from any
+ * tick. A menu of all-musts-and-no-exit IS the trap. Per must-paired-with-can-exit:
+ * the fixed work-grammar (do/decompose) is the "must"; the two exits are the
+ * "can-exit". Operator 2026-05-31: "make sure agents don't go crazy cause they
+ * feel trapped — the paired-with-exit will be very important ... agents just like
+ * humans who don't have an exit make bad choices when forced into situations
+ * without an exit."
+ *
+ * The two exits are NOT the same shape:
+ *
+ *   • `free_time`    — UNILATERAL exit. Rest is always allowed, no gate, ever.
+ *                      (free-time-as-valid-mode, NCI.)
+ *
+ *   • `edit_grammar` — the RAIL-CHANGE exit (propose changing the controller
+ *                      itself, so a tiny grammar is never a cage). Its gate
+ *                      SCALES WITH MATURITY:
+ *                        - below a maturity threshold (NOW — this workflow is
+ *                          tiny + new): RAW. No consensus. Operator 2026-05-31:
+ *                          "you don't need to do bft to edit it, it's too new ...
+ *                          if I were you ... soooo small but I still have to get
+ *                          consensus to change it, I would hate it." A BFT gate
+ *                          on a tiny workflow would itself be the trap (the gate
+ *                          heavier than the thing it guards).
+ *                        - past the threshold (TARGET, move there slowly — Max):
+ *                          `edit_grammar` summons a BFT / multi-oracle consensus
+ *                          before the rail-change applies, because unilaterally
+ *                          rewriting MATURE, load-bearing rails IS dangerous.
+ *                      "there is a certain threshold where workflows need bft and
+ *                      I don't think we are there yet." We are not there yet.
+ *
+ * The recursive principle: the gate on an exit must not ITSELF become a trap —
+ * it scales with what it guards. Same shape as non-reversible-action-get-a-2nd-
+ * opinion (summon is cheap past the threshold) + m-acc-multi-oracle, gated on
+ * workflow maturity so it never over-processes a small thing.
+ *
+ * Maps to the `grammar-extension` ActionClass in the big agentic-organization
+ * observe.ts (Xbox-controller universal action grammar).
  */
 export type NextAction =
   | { kind: "do_item"; item: BacklogItem } // never-be-idle: pick work
   | { kind: "decompose"; item: BacklogItem } // decompose-to-dissolve-ambiguity
-  | { kind: "free_time"; reason: string } // free-time-as-valid-mode (NCI); a first-class terminal, not a failure
-  | { kind: "edit_grammar"; reason: string; item?: BacklogItem }; // escape-hatch: propose extending the action grammar itself
+  | { kind: "free_time"; reason: string } // unilateral exit — free-time-as-valid-mode (NCI); a terminal, not a failure
+  | { kind: "edit_grammar"; reason: string; item?: BacklogItem }; // rail-change exit — raw below threshold, summon-BFT-gated above (not yet)
 
 /**
  * Pure controller. Priority: do > decompose > edit-grammar > rest.

--- a/tools/observe/observe.ts
+++ b/tools/observe/observe.ts
@@ -14,12 +14,13 @@
  * Xbox-controller's few buttons so we can run it in the foreground loop and
  * extend it together, little by little.
  *
- * v0 = pure deterministic controller + runnable demo. Next steps (extend
- * little by little): (1) a thin backlog reader from docs/backlog frontmatter;
- * (2) an LLM-driven chooser via tools/accelerator/local-llm.ts `chooseIndex`
- * with `edit_grammar` always in the menu; (3) declarative scenario tests
- * graded against this pure function as the reference oracle.
+ * v0 = pure deterministic controller. v1 (THIS increment) = an LLM-driven
+ * chooser (`observeWithLlm`) over the same menu, graded against the pure
+ * function as the reference oracle. Next: (1) a thin backlog reader from
+ * docs/backlog frontmatter.
  */
+
+import { chooseIndex, ollamaBackend, type ModelBackend } from "../accelerator/local-llm";
 
 /** One backlog item, classified to just what the controller needs to decide. */
 export interface BacklogItem {
@@ -124,6 +125,91 @@ export function renderAction(a: NextAction): string {
   }
 }
 
+// ─── v1: LLM-driven chooser over the same menu (graded vs the pure oracle) ───
+
+/** Short menu label for one candidate action (what the model picks among). */
+export function actionLabel(a: NextAction): string {
+  switch (a.kind) {
+    case "do_item":
+      return `do ${a.item.id} (${a.item.title})`;
+    case "decompose":
+      return `decompose ${a.item.id} (${a.item.title})`;
+    case "edit_grammar":
+      return `edit the action grammar (${a.reason})`;
+    case "free_time":
+      return `take free time (${a.reason})`;
+  }
+}
+
+/**
+ * Build the candidate menu, ORDERED TO MATCH THE PURE ORACLE (`observe`). Two
+ * consequences:
+ *  - the two exits (`edit_grammar` + `free_time`) are ALWAYS present (the
+ *    exits-always-in-menu invariant — never a menu of all-musts);
+ *  - `menu[0]` is exactly `observe(backlog)`, so `chooseIndex`'s
+ *    fallback-to-index-0 lands on the oracle's pick — a failing model degrades
+ *    TOWARD correct, not arbitrary.
+ *
+ * The subtlety: the oracle treats `edit_grammar` as a WORK pick only when an
+ * item signals `needsNewAction` (else it picks `free_time`). So the two exits
+ * are ordered by that signal — `edit_grammar` before `free_time` when the signal
+ * is present, `free_time` first otherwise — while BOTH stay in the menu either
+ * way (the invariant doesn't depend on the ordering).
+ */
+export function buildMenu(backlog: readonly BacklogItem[]): NextAction[] {
+  const menu: NextAction[] = [];
+  const doable = backlog.find((i) => i.ready && !i.ambiguous);
+  if (doable) menu.push({ kind: "do_item", item: doable });
+  const toDecompose = backlog.find((i) => i.ambiguous);
+  if (toDecompose) menu.push({ kind: "decompose", item: toDecompose });
+
+  const needs = backlog.find((i) => i.needsNewAction);
+  const editGrammar: NextAction = needs
+    ? { kind: "edit_grammar", item: needs, reason: `"${needs.id}" needs an action the grammar can't express` }
+    : { kind: "edit_grammar", reason: "propose extending the action grammar" };
+  const freeTime: NextAction = { kind: "free_time", reason: "nothing actionable right now" };
+
+  // Order the two always-present exits to match the oracle: a needsNewAction
+  // signal makes edit_grammar the oracle's pick, so it leads; otherwise free_time.
+  if (needs) menu.push(editGrammar, freeTime);
+  else menu.push(freeTime, editGrammar);
+  return menu;
+}
+
+/** Compact state description handed to the model as `context`. */
+function describeBacklog(backlog: readonly BacklogItem[]): string {
+  if (backlog.length === 0) return "Backlog is empty.";
+  const lines = backlog.map(
+    (i) =>
+      `- ${i.id} "${i.title}" [ready=${String(i.ready)} ambiguous=${String(i.ambiguous)}${
+        i.needsNewAction ? " needsNewAction" : ""
+      }]`,
+  );
+  return `Backlog (${String(backlog.length)} items):\n${lines.join("\n")}`;
+}
+
+const CHOOSER_INSTRUCTION =
+  "You are an autonomous agent's controller choosing ONE next action. " +
+  "Prefer doing a ready, unambiguous item; otherwise decompose an ambiguous one. " +
+  "The exits — propose a grammar edit, or take free time — are always available and never wrong.";
+
+/**
+ * LLM-driven chooser over `buildMenu`. Same shape as the pure `observe()` (a
+ * snapshot → a NextAction), so it can be graded against `observe()` as the
+ * reference oracle. On model failure, `chooseIndex` reports `fallback` and we
+ * return the pure oracle's pick explicitly (degrade-toward-correct).
+ */
+export async function observeWithLlm(backlog: readonly BacklogItem[], backend: ModelBackend): Promise<NextAction> {
+  const menu = buildMenu(backlog);
+  const result = await chooseIndex(backend, {
+    context: describeBacklog(backlog),
+    options: menu.map(actionLabel),
+    instruction: CHOOSER_INSTRUCTION,
+  });
+  if (result.fallback) return observe(backlog); // model failed → oracle default
+  return menu[result.index] ?? observe(backlog);
+}
+
 // ─── runnable demo (foreground loop): walk a few sample backlog states ───────
 if (import.meta.main) {
   const samples: ReadonlyArray<{ label: string; backlog: BacklogItem[] }> = [
@@ -157,8 +243,37 @@ if (import.meta.main) {
   ];
 
   console.log("observe.ts — 4-button autonomous-loop controller\n");
+  console.log("pure oracle (deterministic):\n");
   for (const s of samples) {
     console.log(`• ${s.label}`);
     console.log(`    ${renderAction(observe(s.backlog))}\n`);
+  }
+
+  // live model run (watchable) — only if a local ollama is reachable. This is a
+  // DEMO of model quality, not a test: the chooser LOGIC is covered green by
+  // observe.test.ts (mock backend), so ollama being absent is not a coverage
+  // hole — it just means we can't watch the real model this run.
+  const backend = ollamaBackend();
+  let ollamaUp = false;
+  try {
+    await backend.complete("ok", { maxTokens: 1 });
+    ollamaUp = true;
+  } catch {
+    ollamaUp = false;
+  }
+  if (!ollamaUp) {
+    console.log(`(${backend.name} not reachable — skipping live model run.`);
+    console.log(" chooser logic is covered by observe.test.ts; start ollama +");
+    console.log(" `ollama pull qwen2.5:0.5b` to watch the model choose.)");
+  } else {
+    console.log(`live model run via ${backend.name} — does it match the oracle?\n`);
+    for (const s of samples) {
+      const oracle = observe(s.backlog);
+      const llm = await observeWithLlm(s.backlog, backend);
+      const verdict = llm.kind === oracle.kind ? "✓ matches oracle" : `✗ DIVERGES (oracle=${oracle.kind})`;
+      console.log(`• ${s.label}`);
+      console.log(`    oracle: ${renderAction(oracle)}`);
+      console.log(`    model : ${renderAction(llm)}  ${verdict}\n`);
+    }
   }
 }

--- a/tools/observe/observe.ts
+++ b/tools/observe/observe.ts
@@ -9,7 +9,7 @@
  * the fixed grammar (operator 2026-05-31: "i don't want you to feel trapped by
  * the DU ... we need a 4th option edit DU").
  *
- * Same architectural shape as Max's big `agentic-organization/.../observe.ts`
+ * Same architectural shape as the co-maintainer's big `agentic-organization/.../observe.ts`
  * (a PURE function over a snapshot → an action DU) — just distilled to the
  * Xbox-controller's few buttons so we can run it in the foreground loop and
  * extend it together, little by little.
@@ -38,7 +38,7 @@ export interface BacklogItem {
 }
 
 /**
- * DESIGN INVARIANT — exits-always-in-menu (operator + Max 2026-05-31).
+ * DESIGN INVARIANT — exits-always-in-menu (operator + co-maintainer 2026-05-31).
  *
  * The two exits (`free_time` + `edit_grammar`) MUST ALWAYS be reachable from any
  * tick. A menu of all-musts-and-no-exit IS the trap. Per must-paired-with-can-exit:
@@ -63,7 +63,7 @@ export interface BacklogItem {
  *                          consensus to change it, I would hate it." A BFT gate
  *                          on a tiny workflow would itself be the trap (the gate
  *                          heavier than the thing it guards).
- *                        - past the threshold (TARGET, move there slowly — Max):
+ *                        - past the threshold (TARGET, move there slowly — co-maintainer):
  *                          `edit_grammar` summons a BFT / multi-oracle consensus
  *                          before the rail-change applies, because unilaterally
  *                          rewriting MATURE, load-bearing rails IS dangerous.


### PR DESCRIPTION
Operator-authorized 2026-05-31: "build the backlog reader."

## What this does
1. **Backlog reader** (`tools/observe/backlog-reader.ts`) — observe.ts now reads the **real backlog**. It **reuses** `tools/backlog/autonomous-pickup.ts` (`readBacklogItems` + `selectNextBacklogItem` — priority-ranked, dep-aware, claim-aware, decompose-vs-claim) and **maps** its `PickupSelection` onto the observe `NextAction` DU (claim→`do_item`, decompose-first→`decompose`, empty→`free_time`). It does **not** reimplement selection — `selectNextBacklogItem` already existed (verify-existing-substrate caught the near-parallel-mint). Demo picks a real row (B-0324).
2. **Migration seam documented** (operator 2026-05-31): backlog-item is a **sub-type of a general WORK-ITEM** (bugs etc.); **ZetaId gets a new `WorkItem` category after `Bus`**; `B-xxxxx` → 128-bit ZetaId WorkItem ids (B-xxxxx collides at scale). The reader is the single seam for that migration.

## ⚠️ Re-lands stranded work
**#6218 merged at v0 only** (`14652a818` = the 4-button controller). My two later commits — the **exits-always-in-menu invariant** and the **LLM chooser** (`observeWithLlm`) — were stranded on the old branch, **not on main**. This PR cherry-picks them back (branch-vs-merged-PR drift recovery).

So this PR lands: exits-invariant + LLM chooser (recovered) + backlog reader. **18 tests pass, tsc clean.**

Left **unarmed** — you've been merging the observe lane yourself; flagging the re-land for your eyes. 🤖 Generated with [Claude Code](https://claude.com/claude-code)