### PR TITLE
ci(windows): Slice 2c — Server-Core Docker test of install.ps1, green on windows-2025 (B-0857)

### DIFF
--- a/.github/workflows/docker-windows-install-ps1-test.yml
+++ b/.github/workflows/docker-windows-install-ps1-test.yml
@@ -31,6 +31,11 @@ jobs:
     timeout-minutes: 45
 
     steps:
+      # Zeta has >260-char filenames (dense persona/research naming); a fresh windows-2022
+      # runner's git fails checkout with "Filename too long" without long-path support.
+      - name: Enable git long paths (Windows MAX_PATH)
+        run: git config --global core.longpaths true
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/docker-windows-install-ps1-test.yml
+++ b/.github/workflows/docker-windows-install-ps1-test.yml
@@ -6,14 +6,53 @@
 # Server 2025, the current LTSC). WebSearch 2026-05-31: actions/runner-images#11742 (windows-2025
 # GA 2025-04-08; windows-latest already migrated to Server 2025) — see the Dockerfile for full pins.
 #
-# FIRST LANDING: workflow_dispatch ONLY, while the Windows-container specifics (scoop's admin
-# behavior, mise install of runtimes, cross-layer PATH) are iterated to green via manual dispatch
-# (gh workflow run). Once green, a follow-up flips the triggers to pull_request + push (the
-# gating config, matching the NixOS workflow's paths-filtered triggers). Keeping it dispatch-only
-# first avoids a red check on every install-substrate PR while the harness is being stabilized.
+# GATED (2026-05-31): harness reached green on windows-2025 (CI run #6, 15 min) + locally (Docker
+# Desktop, Hyper-V isolation) — so triggers flip from dispatch-only to pull_request + push, matching
+# the NixOS sibling's paths-filtered gating (explicit duplicated lists, NO YAML anchors — GitHub
+# Actions is finicky with anchors). Paths mirror the Dockerfile COPY set (tools/setup, the windows
+# smoke + persistence, .mise.toml, package.json) + the harness (orchestrator + Dockerfile dir) +
+# build-context inputs (.dockerignore, bun.lock) + this workflow file. install-substrate PRs that
+# touch none of these skip the heavy (~15-min) Windows-container build entirely. workflow_dispatch
+# stays for manual reruns.
 name: docker-windows-install-ps1-test
 
 on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      # Install dispatcher + per-OS scripts + shared library + the windows package manifest
+      - 'tools/setup/**'
+      # Pinned runtime versions read by mise — the IDENTICAL file Unix uses (symmetric)
+      - '.mise.toml'
+      # bun --frozen-lockfile inputs for the TS wrapper
+      - 'package.json'
+      - 'bun.lock'
+      # Windows background-loop scheduled-task installer (COPYed into the image)
+      - 'tools/persistence/windows/**'
+      # The Docker harness itself (orchestrator + Dockerfile dir + container smoke)
+      - 'tools/ci/docker-windows-install-ps1-test.ts'
+      - 'tools/ci/dockerfiles/windows-install-ps1-test/**'
+      - 'tools/ci/windows-install-ps1-smoke.ts'
+      # .dockerignore affects build context for ALL docker builds
+      - '.dockerignore'
+      # This workflow file itself
+      - '.github/workflows/docker-windows-install-ps1-test.yml'
+
+  push:
+    branches:
+      - main
+    paths:
+      - 'tools/setup/**'
+      - '.mise.toml'
+      - 'package.json'
+      - 'bun.lock'
+      - 'tools/persistence/windows/**'
+      - 'tools/ci/docker-windows-install-ps1-test.ts'
+      - 'tools/ci/dockerfiles/windows-install-ps1-test/**'
+      - 'tools/ci/windows-install-ps1-smoke.ts'
+      - '.dockerignore'
+      - '.github/workflows/docker-windows-install-ps1-test.yml'
+
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docker-windows-install-ps1-test.yml
+++ b/.github/workflows/docker-windows-install-ps1-test.yml
@@ -1,9 +1,10 @@
 # .github/workflows/docker-windows-install-ps1-test.yml
 #
 # Slice 2c — CI for the Server-Core Docker test of tools/setup/install.ps1 (B-0857 Windows
-# parity). Mirrors docker-nixos-install-sh-test.yml but runs on windows-2022: Windows containers
-# need a Windows host, and windows-latest = Server 2025 which REMOVED servercore:ltsc2022 — so
-# pin -2022 (WebSearch 2026-05-30: actions/runner-images).
+# parity). Mirrors docker-nixos-install-sh-test.yml but on a Windows host (Windows containers need
+# one). Base + runner are a MATCHED PAIR: servercore:ltsc2025 on runs-on: windows-2025 (Windows
+# Server 2025, the current LTSC). WebSearch 2026-05-31: actions/runner-images#11742 (windows-2025
+# GA 2025-04-08; windows-latest already migrated to Server 2025) — see the Dockerfile for full pins.
 #
 # FIRST LANDING: workflow_dispatch ONLY, while the Windows-container specifics (scoop's admin
 # behavior, mise install of runtimes, cross-layer PATH) are iterated to green via manual dispatch
@@ -25,14 +26,14 @@ concurrency:
 jobs:
   docker-test:
     name: docker-windows-install-ps1-test
-    runs-on: windows-2022
-    # servercore pull (~1-2 GB cold) + scoop bootstrap + mise install of .mise.toml runtimes
+    runs-on: windows-2025
+    # servercore pull (cold) + scoop bootstrap + mise install of .mise.toml runtimes
     # (dotnet/python/java/bun/uv) is heavy on a cold runner; 45-min ceiling gives headroom.
     timeout-minutes: 45
 
     steps:
-      # Zeta has >260-char filenames (dense persona/research naming); a fresh windows-2022
-      # runner's git fails checkout with "Filename too long" without long-path support.
+      # Zeta has >260-char filenames (dense persona/research naming); a fresh runner's git fails
+      # checkout with "Filename too long" without long-path support.
       - name: Enable git long paths (Windows MAX_PATH)
         run: git config --global core.longpaths true
 

--- a/tools/ci/docker-windows-install-ps1-test.ts
+++ b/tools/ci/docker-windows-install-ps1-test.ts
@@ -71,7 +71,9 @@ function checkPrereqs(): void {
 
 function runBuild(timeoutSec: number, logPath: string): BuildResult {
   const startMs = Date.now();
-  const buildArgs = ["build", "--file", DOCKERFILE_PATH, "--tag", IMAGE_TAG, "--progress=plain", "."];
+  // NOTE: no --progress=plain — the windows-2022 runner uses the LEGACY docker builder (not
+  // BuildKit/buildx), which rejects --progress. Output still streams to stdout/stderr (captured).
+  const buildArgs = ["build", "--file", DOCKERFILE_PATH, "--tag", IMAGE_TAG, "."];
   console.log(`[Slice 2c] docker build ${buildArgs.join(" ")}`);
   console.log(`[Slice 2c] timeout: ${timeoutSec}s; log: ${logPath}`);
 

--- a/tools/ci/dockerfiles/windows-install-ps1-test/Dockerfile
+++ b/tools/ci/dockerfiles/windows-install-ps1-test/Dockerfile
@@ -8,18 +8,38 @@
 # interactive session; the desktop loop-smoke covers it. The smoke PRINTS that skip (not silent)
 # per .claude/rules/automated-tests-are-the-shield-assert-dont-skip.md.
 #
-# Runs on the windows-2022 GitHub runner (process isolation; container OS must match the host).
-# windows-latest moved to Server 2025, which REMOVED servercore:ltsc2022 — so the workflow pins
-# runs-on: windows-2022. (WebSearch 2026-05-30: actions/runner-images + scoop.sh.)
+# Runs on the windows-2025 GitHub runner (process isolation; container OS must match the host).
+# Base + runner are a MATCHED PAIR and move together: a newer base on an older runner can't run
+# under process isolation. ltsc2025 (Windows Server 2025) pairs with runs-on: windows-2025.
 #
-# Base image pin per dep-pin-search-first-authority (WebSearch 2026-05-30 — https://scoop.sh/ +
-# https://learn.microsoft.com/windows/package-manager/ + actions/runner-images). TODO(dep-pin):
-# pin by sha256 digest at next maintenance (capture the resolved digest from a green CI run);
-# the :ltsc2022 tag receives monthly servicing, so a digest gives content-addressed reproducibility.
-FROM mcr.microsoft.com/windows/servercore:ltsc2022
+# Pins per dep-pin-search-first-authority (WebSearch 2026-05-31):
+#   base   — mcr.microsoft.com/windows/servercore:ltsc2025 (current LTSC; there is no 2026 LTSC,
+#            and the repo publishes no `latest` tag). Refs:
+#            https://hub.docker.com/r/microsoft/windows-servercore +
+#            https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+#   runner — windows-2025 (GA 2025-04-08; windows-latest already migrated to Server 2025).
+#            Ref: https://github.com/actions/runner-images/issues/11742
+# TODO(dep-pin): pin base by sha256 digest at next maintenance (capture from a green CI run);
+# the :ltsc2025 tag receives monthly servicing, so a digest gives content-addressed reproducibility.
+FROM mcr.microsoft.com/windows/servercore:ltsc2025
 
 # Server Core ships Windows PowerShell 5.1 (NOT pwsh 7). install.ps1 is #Requires 5.1 + 5.1-safe.
 SHELL ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "$ErrorActionPreference='Stop'; $ProgressPreference='SilentlyContinue';"]
+
+# Server Core deliberately OMITS the MSVC runtime (vcruntime140.dll etc.) that real Win10/11
+# desktops ship. bun.exe needs it — without it `mise exec -- bun` dies with STATUS_DLL_NOT_FOUND
+# (0xC0000135 / exit 3221225781), and install.ps1's own `bun install -g claude-code` step fails
+# silently (PS 5.1 doesn't fault on a native non-zero exit). This is a SYSTEM runtime that a real
+# desktop already has, so it's provisioned in the container harness here — NOT in install.ps1,
+# which is deliberately user-mode/no-admin. Single quotes only (the SHELL -Command wrapper collides
+# with double-quoted strings in a RUN). Pin: aka.ms/vs/17/release/vc_redist.x64.exe = Microsoft's
+# evergreen latest VC++ 2015-2022 x64 redist (WebSearch 2026-05-31;
+# https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist). Exit 1638/3010 = already-
+# present / reboot-deferred, both success.
+RUN Invoke-WebRequest -UseBasicParsing https://aka.ms/vs/17/release/vc_redist.x64.exe -OutFile C:\vc_redist.x64.exe; `
+    $p = Start-Process C:\vc_redist.x64.exe -ArgumentList '/install','/quiet','/norestart' -Wait -PassThru; `
+    if ($p.ExitCode -notin 0,1638,3010) { throw ('vc_redist failed with exit ' + $p.ExitCode) }; `
+    Remove-Item C:\vc_redist.x64.exe
 
 WORKDIR C:\workspace
 
@@ -36,8 +56,15 @@ COPY package.json C:/workspace/package.json
 # user-mode scheduled task isn't registered (desktop loop-smoke covers it). install.ps1 detects
 # the admin context (ContainerAdministrator) + passes -RunAsAdmin to the scoop bootstrap.
 # install.ps1 uses $ErrorActionPreference='Stop', so any install failure throws -> the build fails.
+#
+# Propagate the smoke's exit code with `exit $LASTEXITCODE` (NOT a `throw "..."`): the SHELL above
+# wraps this whole RUN in powershell -Command "...", and a double-quoted throw message collides
+# with that outer quoting (PS then mis-parses the message as commands). exit-code propagation is
+# quote-free and the smoke already prints its own FAIL diagnostics. (Server-Core local build
+# 2026-05-31: install.ps1 succeeded end-to-end; the quoting bug + missing VC++ runtime were the
+# last blockers.)
 RUN & 'C:\workspace\tools\setup\install.ps1' -SkipLoopRegister; `
     mise exec -- bun 'C:\workspace\tools\ci\windows-install-ps1-smoke.ts' --mode container; `
-    if ($LASTEXITCODE -ne 0) { throw "windows-install-ps1-smoke (container mode) failed (exit $LASTEXITCODE)" }
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 RUN Write-Host "Slice 2c — install.ps1 Server-Core Docker validation COMPLETE"

--- a/tools/ci/windows-install-ps1-smoke.test.ts
+++ b/tools/ci/windows-install-ps1-smoke.test.ts
@@ -1,4 +1,6 @@
 import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   taskHasDurationAndNextRun,
   miseProvidesTool,
@@ -34,4 +36,28 @@ test("container mode documents its skip (loop-task) — never silent", () => {
 
 test("shared commands are scoop, git, mise", () => {
   expect([...SHARED_COMMANDS]).toEqual(["scoop", "git", "mise"]);
+});
+
+// Empirical anchor (Server-Core Docker run #3, 2026-05-30): install.ps1 had an em-dash (—) and
+// died with "Missing argument in parameter list" because the container invokes it via Windows
+// PowerShell 5.1 (shipped in-box on Server Core + every Win10/11), which reads a BOM-less .ps1 as
+// the system ANSI codepage — NOT UTF-8. Any non-ASCII char then corrupts and the parser chokes.
+// pwsh 7 (Aaron's laptop) defaults to UTF-8 so it never hit this. The Docker test catches the bug
+// slowly (~15-min build); this assertion catches it fast in the `bun test` lane. Keep the .ps1
+// entrypoints ASCII-clean (decorative em-dashes -> '--') so they run on 5.1 AND 7, BOM or no BOM.
+// Per .claude/rules/automated-tests-are-the-shield-assert-dont-skip.md: this asserts the positive.
+test("Windows .ps1 entrypoints are ASCII-only (PS 5.1 reads BOM-less .ps1 as ANSI, not UTF-8)", () => {
+  const repoRoot = join(import.meta.dir, "..", "..");
+  const files = [
+    join(repoRoot, "tools", "setup", "install.ps1"),
+    join(repoRoot, "tools", "persistence", "windows", "otto-loop-wrapper.ps1"),
+  ];
+  for (const f of files) {
+    const text = readFileSync(f, "utf8");
+    const offenders = [...text]
+      .map((ch, i) => ({ ch, i, code: ch.charCodeAt(0) }))
+      .filter((c) => c.code > 0x7f)
+      .map((c) => `${f}@char${c.i}: U+${c.code.toString(16).toUpperCase().padStart(4, "0")} '${c.ch}'`);
+    expect(offenders).toEqual([]);
+  }
 });

--- a/tools/persistence/windows/otto-loop-wrapper.ps1
+++ b/tools/persistence/windows/otto-loop-wrapper.ps1
@@ -1,9 +1,9 @@
 #Requires -Version 5.1
-# otto-loop-wrapper.ps1 — per-tick entry point for the Zeta autonomous loop on Windows.
+# otto-loop-wrapper.ps1 -- per-tick entry point for the Zeta autonomous loop on Windows.
 # Task Scheduler runs this each minute (at-logon trigger + PT1M repetition, user-mode).
 #
 # Parity with tools/kiro/kiro-loop-wrapper.sh. Runs the loop tick against a DEDICATED
-# CLONE under %LOCALAPPDATA%\zeta-otto-loop\Zeta — NEVER the operator checkout, because
+# CLONE under %LOCALAPPDATA%\zeta-otto-loop\Zeta -- NEVER the operator checkout, because
 # the tick does `git reset --hard origin/<ref>` which would wipe a working checkout.
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
@@ -35,7 +35,7 @@ $env:ZETA_CLAUDE_LOOP_WORKTREE  = $Clone
 $env:ZETA_CLAUDE_LOOP_STATE_DIR = Join-Path $Base 'state'
 $env:ZETA_CLAUDE_LOOP_LOG_DIR   = $LogDir
 $env:ZETA_CLAUDE_LOOP_REF       = $ref
-# Heartbeat-only by default (slice 1 — proves the mechanism). Uncomment for harness-launch:
+# Heartbeat-only by default (slice 1 -- proves the mechanism). Uncomment for harness-launch:
 # $env:ZETA_CLAUDE_LOOP_RUN_CLAUDE = '1'
 # $env:ZETA_CLAUDE_LOOP_MODEL      = 'sonnet'
 
@@ -44,10 +44,10 @@ $tick = Join-Path $Clone '.claude\bin\claude-loop-tick.ts'
 & $bun $tick *>> (Join-Path $LogDir 'wrapper.log')
 $tickExit = $LASTEXITCODE
 
-# slice-1b — cross-machine heartbeat-push to the shared agent-heartbeats branch (PR-free,
+# slice-1b -- cross-machine heartbeat-push to the shared agent-heartbeats branch (PR-free,
 # REST, ZetaID-keyed via tools/agent-heartbeats/write-heartbeat.ts). Gated to ~10 min to be
 # host-considerate: the per-minute tick covers local git-state; cross-machine "is-it-alive"
-# visibility doesn't need every minute. Best-effort — never fails the tick.
+# visibility doesn't need every minute. Best-effort -- never fails the tick.
 $hbStamp = Join-Path $Base 'last-heartbeat-push.txt'
 $pushHb = $true
 if (Test-Path $hbStamp) {
@@ -60,7 +60,7 @@ if ($pushHb) {
     # NOTE: PowerShell try/catch does NOT trap non-zero exits from native exes
     # (bun.exe here); $ErrorActionPreference='Stop' only governs cmdlets, and
     # $PSNativeCommandUseErrorActionPreference is PS 7.3+ (this script floors at
-    # 5.1). So check $LASTEXITCODE explicitly and only stamp $hbStamp on success —
+    # 5.1). So check $LASTEXITCODE explicitly and only stamp $hbStamp on success --
     # stamping on failure would suppress retries for ~10 min (see gate above).
     & $bun (Join-Path $Clone 'tools\agent-heartbeats\write-heartbeat.ts') `
         --push --persona-name otto-windows --disposition loop-tick *>> (Join-Path $LogDir 'wrapper.log')
@@ -71,9 +71,9 @@ if ($pushHb) {
     }
 }
 
-# slice-2b — optional desktop install.ps1 smoke (gated, best-effort, never fails the tick).
+# slice-2b -- optional desktop install.ps1 smoke (gated, best-effort, never fails the tick).
 # Asserts install.ps1's outcomes on this real Win desktop (scoop/git/mise/bun/claude +
-# ZetaOttoLoop health). Default OFF — opt in by setting ZETA_RUN_DESKTOP_SMOKE on the task.
+# ZetaOttoLoop health). Default OFF -- opt in by setting ZETA_RUN_DESKTOP_SMOKE on the task.
 if ($env:ZETA_RUN_DESKTOP_SMOKE) {
     $smoke = Join-Path $Clone 'tools\ci\windows-install-ps1-smoke.ts'
     if (Test-Path $smoke) {

--- a/tools/setup/install.ps1
+++ b/tools/setup/install.ps1
@@ -17,7 +17,12 @@
 #           https://scoop.sh/  https://github.com/ScoopInstaller/scoop
 #   git   -- scoop: git | winget: Git.Git | choco: git
 [CmdletBinding()] param([switch]$SkipLoopRegister)
-Set-StrictMode -Version Latest
+# Deliberately NO `Set-StrictMode -Version Latest`: this installer shells out (via the call
+# operator) to third-party bootstrap scripts -- scoop's get.scoop.sh + the scoop shim -- which run
+# in child scopes that INHERIT strict mode. scoop reads $LASTEXITCODE before any native command has
+# set it, which throws under StrictMode (Server-Core Docker run #5, 2026-05-30). Keep this script
+# lenient so third-party bootstraps run cleanly; $ErrorActionPreference=Stop still catches our own
+# cmdlet failures.
 $ErrorActionPreference = 'Stop'
 $RepoRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
 function Have($c) { [bool](Get-Command $c -ErrorAction SilentlyContinue) }

--- a/tools/setup/install.ps1
+++ b/tools/setup/install.ps1
@@ -27,6 +27,29 @@ $ErrorActionPreference = 'Stop'
 $RepoRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
 function Have($c) { [bool](Get-Command $c -ErrorAction SilentlyContinue) }
 
+# Native-tool invocation helper. Native tools (scoop/mise/bun) write progress + benign notes to
+# STDERR; PS 5.1 promotes native stderr to a fatal NativeCommandError under
+# $ErrorActionPreference='Stop' the moment the tool emits ANY stderr line -- even with 2>$null or
+# 2>&1 (Server-Core build 2026-05-31: `mise trust` printing "mise trusted ..." to stderr crashed
+# install). Conversely, Stop does NOT catch a native non-zero EXIT in 5.1, so real failures went
+# silent (e.g. a failed `bun install -g claude-code`). So route native calls through here: run
+# stderr-tolerant (ErrorActionPreference=Continue so merged stderr is just text), surface output,
+# then fault ONLY on a real non-zero exit code.
+function Invoke-Tool {
+  param([Parameter(Mandatory)][scriptblock]$Cmd, [string]$What = 'native command')
+  $prev = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try { & $Cmd 2>&1 | ForEach-Object { Write-Host "$_" } } finally { $ErrorActionPreference = $prev }
+  if ($LASTEXITCODE -ne 0) { throw "$What failed (exit $LASTEXITCODE)" }
+}
+# Cosmetic version probe -- best-effort, never fatal (stderr-tolerant, ignores exit code).
+function Get-ToolVersion {
+  param([Parameter(Mandatory)][scriptblock]$Cmd)
+  $prev = $ErrorActionPreference
+  $ErrorActionPreference = 'SilentlyContinue'
+  try { (& $Cmd 2>&1 | Select-Object -First 1) } finally { $ErrorActionPreference = $prev }
+}
+
 Write-Host "=== Zeta install -- Windows user-mode entry (scoop-primary, declarative) ==="
 Write-Host "Repo root: $RepoRoot"
 
@@ -63,7 +86,7 @@ if (-not (Have scoop)) {
 # shells, but this process needs them now -- mirrors macos.sh's brew/mise shim PATH export).
 $scoopShims = Join-Path $env:USERPROFILE 'scoop\shims'
 if ((Test-Path $scoopShims) -and ($env:PATH -notlike "*$scoopShims*")) { $env:PATH = "$scoopShims;$env:PATH" }
-Write-Host "scoop: $((scoop --version 2>$null | Select-Object -First 1))"
+Write-Host "scoop: $(Get-ToolVersion { scoop --version })"
 
 # 2. system CLI tools from manifests/windows (scoop -> winget -> choco). Strips `#` comments +
 #    trims (parity with the awk in macos.sh's brew-manifest loop).
@@ -77,29 +100,29 @@ foreach ($raw in Get-Content $manifest) {
   $wid = if ($winget) { $winget } else { $scoopId }   # if/else (5.1-safe; NOT the 7+ ?: ternary)
   $cid = if ($choco) { $choco } else { $scoopId }
   Write-Host "down $scoopId (scoop -> winget -> choco)"
-  if ($(Have scoop)) { scoop install $scoopId }
-  elseif ($(Have winget)) { winget install --id $wid --silent --accept-package-agreements --accept-source-agreements }
-  elseif ($(Have choco)) { choco install $cid -y }
+  if ($(Have scoop)) { Invoke-Tool { scoop install $scoopId } "scoop install $scoopId" }
+  elseif ($(Have winget)) { Invoke-Tool { winget install --id $wid --silent --accept-package-agreements --accept-source-agreements } "winget install $wid" }
+  elseif ($(Have choco)) { Invoke-Tool { choco install $cid -y } "choco install $cid" }
   else { throw "no package source (scoop/winget/choco) available for $scoopId" }
 }
 
 # 3. mise (runtime manager) via scoop -- mirrors macos.sh step 4 (brew install mise).
-if (-not (Have mise)) { scoop install mise }
-Write-Host "mise: $((mise --version 2>$null))"
+if (-not (Have mise)) { Invoke-Tool { scoop install mise } 'scoop install mise' }
+Write-Host "mise: $(Get-ToolVersion { mise --version })"
 
 # 4. runtimes from .mise.toml (dotnet/python/java/bun/uv) -- IDENTICAL file to Unix (symmetric).
 Push-Location $RepoRoot
 try {
-  mise trust 2>$null | Out-Null
-  mise install
+  Invoke-Tool { mise trust } 'mise trust'
+  Invoke-Tool { mise install } 'mise install'
 } finally { Pop-Location }
 
 # 5. claude-code via bun --global (bun provided by mise) -- identical to Unix.
-mise exec -- bun install --global '@anthropic-ai/claude-code'
+Invoke-Tool { mise exec -- bun install --global '@anthropic-ai/claude-code' } 'bun install -g claude-code'
 
 # 6. register the per-minute (windowless, conhost --headless) loop unless skipped.
 if (-not $SkipLoopRegister) {
-  mise exec -- bun "$RepoRoot\tools\persistence\windows\install-scheduled-task.ts" --register
+  Invoke-Tool { mise exec -- bun "$RepoRoot\tools\persistence\windows\install-scheduled-task.ts" --register } 'register loop task'
 }
 
 Write-Host ""

--- a/tools/setup/install.ps1
+++ b/tools/setup/install.ps1
@@ -25,11 +25,18 @@ function Have($c) { [bool](Get-Command $c -ErrorAction SilentlyContinue) }
 Write-Host "=== Zeta install -- Windows user-mode entry (scoop-primary, declarative) ==="
 Write-Host "Repo root: $RepoRoot"
 
-# Allow running local scripts for THIS user (no admin) -- scoop + mise need it.
-$cur = Get-ExecutionPolicy -Scope CurrentUser
-if ($cur -notin @('RemoteSigned', 'Unrestricted', 'Bypass')) {
-  Write-Host "setting CurrentUser ExecutionPolicy -> RemoteSigned (no admin)"
-  Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+# Allow running local scripts for THIS user (no admin) -- scoop + mise need it. Check the
+# EFFECTIVE policy (most-specific scope wins): if the process can already run scripts
+# (RemoteSigned/Unrestricted/Bypass -- e.g. a container launched with -ExecutionPolicy Bypass, or
+# pwsh's default), leave it alone. Only attempt a CurrentUser set when the effective policy is
+# restrictive, and TOLERATE a more-specific override (e.g. a corporate GPO scope on a managed
+# laptop) rather than dying: Set-ExecutionPolicy emits a non-terminating "overridden by a more
+# specific scope" error that this script's $ErrorActionPreference='Stop' would promote to fatal.
+$eff = Get-ExecutionPolicy
+if ($eff -notin @('RemoteSigned', 'Unrestricted', 'Bypass')) {
+  Write-Host "effective ExecutionPolicy is '$eff'; setting CurrentUser -> RemoteSigned (no admin)"
+  try { Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force }
+  catch { Write-Host "could not set CurrentUser policy ($($_.Exception.Message)); effective policy '$eff' may be GPO-pinned -- continuing" }
 }
 
 # 1. scoop (user-mode; no admin). Download-then-exec (NOT pipe-to-shell) -- mirrors macos.sh's

--- a/tools/setup/install.ps1
+++ b/tools/setup/install.ps1
@@ -1,38 +1,38 @@
 #Requires -Version 5.1
-# tools/setup/install.ps1 — Windows user-mode, DECLARATIVE install-graph entry.
+# tools/setup/install.ps1 -- Windows user-mode, DECLARATIVE install-graph entry.
 #
 # Parity with tools/setup/install.sh -> macos.sh (B-0857 Windows parity). System CLI tools
 # resolve scoop -> winget -> chocolatey (operator 2026-05-30; scoop primary = user-mode, no
-# admin, AI-native). Runtimes via mise/.mise.toml; claude via bun --global — the IDENTICAL files
+# admin, AI-native). Runtimes via mise/.mise.toml; claude via bun --global -- the IDENTICAL files
 # Unix uses, so the tool set stays in sync + symmetric across OSes. Background loop registered via
 # tools/persistence/windows/install-scheduled-task.ts (schtasks ~= launchd). No admin required.
 #
-# Idempotent (detect-first-install-else-update) — safe to run repeatedly to keep tools fresh.
+# Idempotent (detect-first-install-else-update) -- safe to run repeatedly to keep tools fresh.
 #
 #   pwsh tools/setup/install.ps1                    # full install + register the per-minute loop
 #   pwsh tools/setup/install.ps1 -SkipLoopRegister  # skip the scheduled-task registration (dev)
 #
 # Package-source pins per dep-pin-search-first-authority (WebSearch 2026-05-30):
-#   scoop — https://get.scoop.sh (canonical; download-then-exec, NOT pipe-to-shell). Refs:
+#   scoop -- https://get.scoop.sh (canonical; download-then-exec, NOT pipe-to-shell). Refs:
 #           https://scoop.sh/  https://github.com/ScoopInstaller/scoop
-#   git   — scoop: git | winget: Git.Git | choco: git
+#   git   -- scoop: git | winget: Git.Git | choco: git
 [CmdletBinding()] param([switch]$SkipLoopRegister)
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $RepoRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
 function Have($c) { [bool](Get-Command $c -ErrorAction SilentlyContinue) }
 
-Write-Host "=== Zeta install — Windows user-mode entry (scoop-primary, declarative) ==="
+Write-Host "=== Zeta install -- Windows user-mode entry (scoop-primary, declarative) ==="
 Write-Host "Repo root: $RepoRoot"
 
-# Allow running local scripts for THIS user (no admin) — scoop + mise need it.
+# Allow running local scripts for THIS user (no admin) -- scoop + mise need it.
 $cur = Get-ExecutionPolicy -Scope CurrentUser
 if ($cur -notin @('RemoteSigned', 'Unrestricted', 'Bypass')) {
   Write-Host "setting CurrentUser ExecutionPolicy -> RemoteSigned (no admin)"
   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
 }
 
-# 1. scoop (user-mode; no admin). Download-then-exec (NOT pipe-to-shell) — mirrors macos.sh's
+# 1. scoop (user-mode; no admin). Download-then-exec (NOT pipe-to-shell) -- mirrors macos.sh's
 #    Homebrew B-0063 pattern: fetch to a temp .ps1, verify non-empty, run the local file.
 if (-not (Have scoop)) {
   Write-Host "downloading scoop (user-mode)..."
@@ -48,7 +48,7 @@ if (-not (Have scoop)) {
   } finally { Remove-Item $scoopTmp -Force -ErrorAction SilentlyContinue }
 }
 # scoop shims on PATH for the rest of this process (scoop adds them to the user PATH for new
-# shells, but this process needs them now — mirrors macos.sh's brew/mise shim PATH export).
+# shells, but this process needs them now -- mirrors macos.sh's brew/mise shim PATH export).
 $scoopShims = Join-Path $env:USERPROFILE 'scoop\shims'
 if ((Test-Path $scoopShims) -and ($env:PATH -notlike "*$scoopShims*")) { $env:PATH = "$scoopShims;$env:PATH" }
 Write-Host "scoop: $((scoop --version 2>$null | Select-Object -First 1))"
@@ -71,18 +71,18 @@ foreach ($raw in Get-Content $manifest) {
   else { throw "no package source (scoop/winget/choco) available for $scoopId" }
 }
 
-# 3. mise (runtime manager) via scoop — mirrors macos.sh step 4 (brew install mise).
+# 3. mise (runtime manager) via scoop -- mirrors macos.sh step 4 (brew install mise).
 if (-not (Have mise)) { scoop install mise }
 Write-Host "mise: $((mise --version 2>$null))"
 
-# 4. runtimes from .mise.toml (dotnet/python/java/bun/uv) — IDENTICAL file to Unix (symmetric).
+# 4. runtimes from .mise.toml (dotnet/python/java/bun/uv) -- IDENTICAL file to Unix (symmetric).
 Push-Location $RepoRoot
 try {
   mise trust 2>$null | Out-Null
   mise install
 } finally { Pop-Location }
 
-# 5. claude-code via bun --global (bun provided by mise) — identical to Unix.
+# 5. claude-code via bun --global (bun provided by mise) -- identical to Unix.
 mise exec -- bun install --global '@anthropic-ai/claude-code'
 
 # 6. register the per-minute (windowless, conhost --headless) loop unless skipped.


### PR DESCRIPTION
## Slice 2c — Server-Core Docker test of `tools/setup/install.ps1` (B-0857 Windows parity)

Brings the Windows half of the install-graph under the same CI shield the NixOS `install.sh` test gives the Linux half. Proves `install.ps1` (scoop → git/mise → dotnet/python/java/bun/uv → claude-code) runs clean on a **bare Windows Server-Core container**.

### Status: GREEN ✅
- **CI run #6** on `windows-2025` — SUCCESS in 15 min (process isolation, exact base/runner match).
- **Local** (this laptop, Docker Desktop, Hyper-V isolation) — SUCCESS, confirming the laptop needs no new installs for Windows-container builds.

### The shield caught 7 real cross-platform / cross-PowerShell-version bugs
1. `git config core.longpaths true` before checkout — Zeta's >260-char filenames break a fresh runner's checkout.
2. Dropped BuildKit `--progress=plain` — the Windows **legacy** docker builder rejects it (exit 125).
3. ASCII-cleaned the `.ps1` entrypoints — PS 5.1 reads BOM-less scripts as ANSI codepage; an em-dash became mojibake and broke a command. Added a unit-test guard.
4. Effective-`ExecutionPolicy` check + GPO/scope-override tolerance — the "overridden by a more specific scope" non-terminating error was promoted to fatal under `Stop`.
5. Dropped `Set-StrictMode -Version Latest` — it leaked into scoop's shim child-scope, which reads `$LASTEXITCODE` before any native command sets it → crash.
6. Dockerfile `exit $LASTEXITCODE` instead of `throw "..."` — `SHELL ["powershell",...,"-Command",...]` double-quotes the RUN, colliding with the nested `throw` string.
7. VC++ runtime provisioning (`vc_redist.x64.exe`, MS evergreen) — Server Core omits `vcruntime140.dll`; bun needs it (without → `STATUS_DLL_NOT_FOUND`). Container-harness concern, not user-mode `install.ps1`.

Plus the native-stderr-under-`Stop` trap: PS 5.1 promotes a native tool's **stderr** to a fatal `NativeCommandError` even with `2>&1`, yet does **not** catch a native non-zero **exit** — so `mise trust`/`mise install` printing benign notes crashed install while real failures went silent. Routed all native calls through `Invoke-Tool` (stderr-tolerant, faults on exit code) / `Get-ToolVersion` (best-effort).

### This PR also flips the trigger (step "1")
`workflow_dispatch`-only → paths-filtered `pull_request` + `push` (gated to `main`), mirroring the NixOS sibling (explicit duplicated path lists, no YAML anchors). PRs touching none of the Dockerfile COPY-set / harness paths skip the heavy (~15-min) Windows build. **This PR touches `install.ps1` + the workflow → run #7 fires on it automatically, validating the gating end-to-end.**

### Merge note
Branch is 94 commits behind a fast-moving `main`, but the 3-dot (real PR) diff is the **focused 6-file set** below — and **none of the 6 files were touched on main since the fork** (verified via `git diff --name-only merge-base origin/main` + `git merge-tree`), so the squash-merge is conflict-free.

### Pins (per dep-pin-search-first, WebSearch 2026-05-31)
`servercore:ltsc2025` ↔ `windows-2025` (matched pair; current LTSC; no 2026 tag exists). `vc_redist` via `aka.ms/vs/17/release/...` (MS evergreen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
