### PR TITLE
feat(windows+tooling): git-bash exec->install.ps1 (b2) + safe-search grep wrapper

### DIFF
--- a/tools/search/grep.test.ts
+++ b/tools/search/grep.test.ts
@@ -10,6 +10,7 @@ import { grepTree, isExcludedDir, parseArgs, EXCLUDE_BASENAMES } from "./grep.ts
 //   references/upstreams/noise.ts  -> "needle" (MUST be excluded — the whole point)
 //   node_modules/dep/index.ts      -> "needle" (MUST be excluded)
 //   bin/output.ts                  -> "needle" (MUST be excluded)
+//   src/case.ts                    -> "NeEdLe" (only matched with -i)
 let root: string;
 
 beforeAll(() => {
@@ -24,40 +25,48 @@ beforeAll(() => {
   write("references/upstreams/noise.ts", "// needle in vendored upstream — MUST NOT surface\n");
   write("node_modules/dep/index.ts", "// needle in a dep — MUST NOT surface\n");
   write("bin/output.ts", "// needle in build output — MUST NOT surface\n");
+  write("src/case.ts", "// NeEdLe mixed case\n");
 });
 
 afterAll(() => {
   if (root) rmSync(root, { recursive: true, force: true });
 });
 
-test("finds matches in normal source files", () => {
-  const m = grepTree({ root, pattern: /needle/ });
+test("finds literal substring in normal source files", () => {
+  const m = grepTree({ root, needle: "needle" });
   const files = m.map((x) => x.file).sort();
   expect(files).toContain("src/hit.ts");
   expect(files).toContain("src/nested/also.md");
 });
 
 test("EXCLUDES references/upstreams (the load-bearing guarantee)", () => {
-  const m = grepTree({ root, pattern: /needle/ });
+  const m = grepTree({ root, needle: "needle" });
   const files = m.map((x) => x.file);
   expect(files.some((f) => f.includes("references/upstreams"))).toBe(false);
 });
 
 test("EXCLUDES node_modules and build-output dirs", () => {
-  const m = grepTree({ root, pattern: /needle/ });
+  const m = grepTree({ root, needle: "needle" });
   const files = m.map((x) => x.file);
   expect(files.some((f) => f.startsWith("node_modules/"))).toBe(false);
   expect(files.some((f) => f.startsWith("bin/"))).toBe(false);
 });
 
+test("case-sensitive by default; -i matches mixed case", () => {
+  const sensitive = grepTree({ root, needle: "needle" }).map((x) => x.file);
+  expect(sensitive).not.toContain("src/case.ts");
+  const insensitive = grepTree({ root, needle: "needle", ignoreCase: true }).map((x) => x.file);
+  expect(insensitive).toContain("src/case.ts");
+});
+
 test("reports correct 1-based line numbers", () => {
-  const m = grepTree({ root, pattern: /needle/ });
+  const m = grepTree({ root, needle: "needle" });
   const hit = m.find((x) => x.file === "src/hit.ts");
   expect(hit?.line).toBe(2);
 });
 
 test("--ext filter restricts to given extensions", () => {
-  const m = grepTree({ root, pattern: /needle/, exts: new Set(["md"]) });
+  const m = grepTree({ root, needle: "needle", exts: new Set(["md"]) });
   const files = m.map((x) => x.file);
   expect(files).toEqual(["src/nested/also.md"]);
 });
@@ -77,7 +86,7 @@ test("EXCLUDE_BASENAMES carries the known noise dirs", () => {
   }
 });
 
-test("parseArgs: pattern required", () => {
+test("parseArgs: needle required", () => {
   const r = parseArgs([]);
   expect("error" in r).toBe(true);
 });
@@ -86,7 +95,7 @@ test("parseArgs: flags parsed", () => {
   const r = parseArgs(["foo", "bar", "-i", "--ext", "ts,md", "--files"]);
   expect("error" in r).toBe(false);
   if (!("error" in r)) {
-    expect(r.pattern).toBe("foo bar");
+    expect(r.needle).toBe("foo bar");
     expect(r.ignoreCase).toBe(true);
     expect(r.filesOnly).toBe(true);
     expect([...(r.exts ?? [])].sort()).toEqual(["md", "ts"]);

--- a/tools/search/grep.test.ts
+++ b/tools/search/grep.test.ts
@@ -1,0 +1,99 @@
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { grepTree, isExcludedDir, parseArgs, EXCLUDE_BASENAMES } from "./grep.ts";
+
+// Fixture tree:
+//   src/hit.ts                     -> "needle" (MUST be found)
+//   src/nested/also.md             -> "needle" (MUST be found)
+//   references/upstreams/noise.ts  -> "needle" (MUST be excluded — the whole point)
+//   node_modules/dep/index.ts      -> "needle" (MUST be excluded)
+//   bin/output.ts                  -> "needle" (MUST be excluded)
+let root: string;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "zeta-grep-test-"));
+  const write = (rel: string, body: string) => {
+    const abs = join(root, rel);
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, body, "utf8");
+  };
+  write("src/hit.ts", "const x = 1;\n// needle here\n");
+  write("src/nested/also.md", "# doc\nneedle in markdown\n");
+  write("references/upstreams/noise.ts", "// needle in vendored upstream — MUST NOT surface\n");
+  write("node_modules/dep/index.ts", "// needle in a dep — MUST NOT surface\n");
+  write("bin/output.ts", "// needle in build output — MUST NOT surface\n");
+});
+
+afterAll(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+test("finds matches in normal source files", () => {
+  const m = grepTree({ root, pattern: /needle/ });
+  const files = m.map((x) => x.file).sort();
+  expect(files).toContain("src/hit.ts");
+  expect(files).toContain("src/nested/also.md");
+});
+
+test("EXCLUDES references/upstreams (the load-bearing guarantee)", () => {
+  const m = grepTree({ root, pattern: /needle/ });
+  const files = m.map((x) => x.file);
+  expect(files.some((f) => f.includes("references/upstreams"))).toBe(false);
+});
+
+test("EXCLUDES node_modules and build-output dirs", () => {
+  const m = grepTree({ root, pattern: /needle/ });
+  const files = m.map((x) => x.file);
+  expect(files.some((f) => f.startsWith("node_modules/"))).toBe(false);
+  expect(files.some((f) => f.startsWith("bin/"))).toBe(false);
+});
+
+test("reports correct 1-based line numbers", () => {
+  const m = grepTree({ root, pattern: /needle/ });
+  const hit = m.find((x) => x.file === "src/hit.ts");
+  expect(hit?.line).toBe(2);
+});
+
+test("--ext filter restricts to given extensions", () => {
+  const m = grepTree({ root, pattern: /needle/, exts: new Set(["md"]) });
+  const files = m.map((x) => x.file);
+  expect(files).toEqual(["src/nested/also.md"]);
+});
+
+test("isExcludedDir: upstreams + node_modules excluded, src kept", () => {
+  expect(isExcludedDir(root, join(root, "references", "upstreams"))).toBe(true);
+  expect(isExcludedDir(root, join(root, "references", "upstreams", "deep"))).toBe(true);
+  expect(isExcludedDir(root, join(root, "node_modules"))).toBe(true);
+  expect(isExcludedDir(root, join(root, "src"))).toBe(false);
+  // a dir literally named "upstreams" but NOT under references/ is kept
+  expect(isExcludedDir(root, join(root, "upstreams"))).toBe(false);
+});
+
+test("EXCLUDE_BASENAMES carries the known noise dirs", () => {
+  for (const d of [".git", "node_modules", "bin", "obj", "target"]) {
+    expect(EXCLUDE_BASENAMES.has(d)).toBe(true);
+  }
+});
+
+test("parseArgs: pattern required", () => {
+  const r = parseArgs([]);
+  expect("error" in r).toBe(true);
+});
+
+test("parseArgs: flags parsed", () => {
+  const r = parseArgs(["foo", "bar", "-i", "--ext", "ts,md", "--files"]);
+  expect("error" in r).toBe(false);
+  if (!("error" in r)) {
+    expect(r.pattern).toBe("foo bar");
+    expect(r.ignoreCase).toBe(true);
+    expect(r.filesOnly).toBe(true);
+    expect([...(r.exts ?? [])].sort()).toEqual(["md", "ts"]);
+  }
+});
+
+test("parseArgs: unknown flag errors", () => {
+  const r = parseArgs(["x", "--bogus"]);
+  expect("error" in r).toBe(true);
+});

--- a/tools/search/grep.test.ts
+++ b/tools/search/grep.test.ts
@@ -10,6 +10,7 @@ import { grepTree, isExcludedDir, parseArgs, EXCLUDE_BASENAMES } from "./grep.ts
 //   references/upstreams/noise.ts  -> "needle" (MUST be excluded — the whole point)
 //   node_modules/dep/index.ts      -> "needle" (MUST be excluded)
 //   bin/output.ts                  -> "needle" (MUST be excluded)
+//   artifacts/built.ts             -> "needle" (MUST be excluded)
 //   src/case.ts                    -> "NeEdLe" (only matched with -i)
 let root: string;
 
@@ -25,6 +26,7 @@ beforeAll(() => {
   write("references/upstreams/noise.ts", "// needle in vendored upstream — MUST NOT surface\n");
   write("node_modules/dep/index.ts", "// needle in a dep — MUST NOT surface\n");
   write("bin/output.ts", "// needle in build output — MUST NOT surface\n");
+  write("artifacts/built.ts", "// needle in artifacts — MUST NOT surface\n");
   write("src/case.ts", "// NeEdLe mixed case\n");
 });
 
@@ -45,11 +47,12 @@ test("EXCLUDES references/upstreams (the load-bearing guarantee)", () => {
   expect(files.some((f) => f.includes("references/upstreams"))).toBe(false);
 });
 
-test("EXCLUDES node_modules and build-output dirs", () => {
+test("EXCLUDES node_modules + build-output dirs (bin, artifacts)", () => {
   const m = grepTree({ root, needle: "needle" });
   const files = m.map((x) => x.file);
   expect(files.some((f) => f.startsWith("node_modules/"))).toBe(false);
   expect(files.some((f) => f.startsWith("bin/"))).toBe(false);
+  expect(files.some((f) => f.startsWith("artifacts/"))).toBe(false);
 });
 
 test("case-sensitive by default; -i matches mixed case", () => {
@@ -80,8 +83,18 @@ test("isExcludedDir: upstreams + node_modules excluded, src kept", () => {
   expect(isExcludedDir(root, join(root, "upstreams"))).toBe(false);
 });
 
-test("EXCLUDE_BASENAMES carries the known noise dirs", () => {
-  for (const d of [".git", "node_modules", "bin", "obj", "target"]) {
+test("EXCLUDE_BASENAMES carries the known noise dirs (incl. .NET/Lean/bench outputs)", () => {
+  for (const d of [
+    ".git",
+    "node_modules",
+    "bin",
+    "obj",
+    "target",
+    "artifacts",
+    "TestResults",
+    "BenchmarkDotNet.Artifacts",
+    ".lake",
+  ]) {
     expect(EXCLUDE_BASENAMES.has(d)).toBe(true);
   }
 });
@@ -91,7 +104,7 @@ test("parseArgs: needle required", () => {
   expect("error" in r).toBe(true);
 });
 
-test("parseArgs: flags parsed", () => {
+test("parseArgs: flags parsed (default repo = cwd, valid)", () => {
   const r = parseArgs(["foo", "bar", "-i", "--ext", "ts,md", "--files"]);
   expect("error" in r).toBe(false);
   if (!("error" in r)) {
@@ -105,4 +118,16 @@ test("parseArgs: flags parsed", () => {
 test("parseArgs: unknown flag errors", () => {
   const r = parseArgs(["x", "--bogus"]);
   expect("error" in r).toBe(true);
+});
+
+test("parseArgs: bad --repo errors (no silent 0-hits false-negative)", () => {
+  const missing = parseArgs(["x", "--repo", join(root, "does-not-exist-xyz")]);
+  expect("error" in missing).toBe(true);
+  // a file (non-directory) is also rejected
+  const filePath = join(root, "src", "hit.ts");
+  const notDir = parseArgs(["x", "--repo", filePath]);
+  expect("error" in notDir).toBe(true);
+  // a real directory is accepted
+  const ok = parseArgs(["x", "--repo", root]);
+  expect("error" in ok).toBe(false);
 });

--- a/tools/search/grep.ts
+++ b/tools/search/grep.ts
@@ -1,0 +1,214 @@
+#!/usr/bin/env bun
+// tools/search/grep.ts — safe content-search wrapper with noise-dir excludes
+// baked in. Distinct from concept-index.ts (a curated semantic index); this is
+// the raw ad-hoc content grep an agent reaches for, made correct-by-construction.
+//
+// WHY (operator 2026-05-31): agents doing ad-hoc content search via raw
+// recursive file-walks — PowerShell `Get-ChildItem -Recurse | Select-String`,
+// bash `find | xargs grep` — do NOT honor .gitignore, so they walk into
+// `references/upstreams/` (gigabytes of mirrored OTHER-repo code) + node_modules
+// + build outputs: slow + noisy. Per
+// `.claude/rules/references-upstreams-not-our-code-search-excludes.md` +
+// `.claude/rules/architecture-is-safety-mechanism-not-discipline-...` the fix is
+// STRUCTURAL not behavioral — bake the excludes into a `.ts` so "call the tool"
+// can't hit the noise even with a sloppy invocation. Operator's framing: "the
+// .ts files have the excludes built in or they should at least."
+//
+// Cross-repo aware: `--repo ../SQLSharp` searches a sibling repo, still skipping
+// THAT repo's references/upstreams (every repo mirrors the same convention).
+//
+//   bun tools/search/grep.ts <pattern> [--repo <dir>] [--ext ts,md] [-i] [--files]
+//
+// Options:
+//   --repo <dir>   root to search (default: cwd)
+//   --ext a,b      only files with these extensions (no dot); default: all text
+//   -i             case-insensitive
+//   --files        print matching file paths only (not lines)
+//
+// v1 is a zero-dep Bun-native walk so the excludes hold EVERYWHERE — including
+// this Windows laptop, which has no `rg` on PATH (verified 2026-05-31). A
+// ripgrep fast-path (rg already honors .gitignore) is a future optimization;
+// correctness + zero-dep beats speed for v1.
+
+import { resolve, relative, join, sep } from "node:path";
+import { readdirSync, statSync, readFileSync, type Dirent } from "node:fs";
+
+/** Directory basenames never worth searching (build outputs / vendored deps). */
+export const EXCLUDE_BASENAMES = new Set([
+  ".git",
+  "node_modules",
+  "bin",
+  "obj",
+  "target",
+  ".playwright-mcp",
+  "drop",
+]);
+
+/** Repo-relative POSIX paths to skip wholesale. references/upstreams is the
+ *  load-bearing one — gigabytes of mirrored upstream repos (NOT our code). */
+export const EXCLUDE_RELPATHS = ["references/upstreams"];
+
+/** Files larger than this are skipped (likely data/binary, not source). */
+const MAX_FILE_BYTES = 2 * 1024 * 1024;
+
+export interface GrepMatch {
+  file: string; // repo-relative POSIX path
+  line: number; // 1-based
+  text: string;
+}
+
+export interface GrepOptions {
+  root: string;
+  pattern: RegExp;
+  exts?: Set<string>; // extensions without the dot; undefined = all text files
+}
+
+function relPosix(root: string, abs: string): string {
+  return relative(root, abs).split(sep).join("/");
+}
+
+/** True if this directory should be pruned from the walk. */
+export function isExcludedDir(root: string, absDir: string): boolean {
+  const base = absDir.split(sep).pop() ?? "";
+  if (EXCLUDE_BASENAMES.has(base)) return true;
+  const rp = relPosix(root, absDir);
+  return EXCLUDE_RELPATHS.some((e) => rp === e || rp.startsWith(e + "/"));
+}
+
+/** A NUL byte in the first 1KB → treat as binary, skip. (Char-code check so
+ *  there's no NUL literal in this source file.) */
+function looksBinary(buf: string): boolean {
+  const n = Math.min(buf.length, 1024);
+  for (let i = 0; i < n; i++) {
+    if (buf.charCodeAt(i) === 0) return true;
+  }
+  return false;
+}
+
+/** Pure, testable core: walk `root`, skipping excluded dirs, return matches. */
+export function grepTree(opts: GrepOptions): GrepMatch[] {
+  const { root, pattern, exts } = opts;
+  const out: GrepMatch[] = [];
+
+  const walk = (absDir: string): void => {
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(absDir, { withFileTypes: true });
+    } catch {
+      return; // unreadable dir — skip rather than throw
+    }
+    for (const ent of entries) {
+      const abs = join(absDir, ent.name);
+      if (ent.isDirectory()) {
+        if (!isExcludedDir(root, abs)) walk(abs);
+        continue;
+      }
+      if (!ent.isFile()) continue;
+      if (exts) {
+        const dot = ent.name.lastIndexOf(".");
+        const ext = dot >= 0 ? ent.name.slice(dot + 1) : "";
+        if (!exts.has(ext)) continue;
+      }
+      let size: number;
+      try {
+        size = statSync(abs).size;
+      } catch {
+        continue;
+      }
+      if (size > MAX_FILE_BYTES) continue;
+      let content: string;
+      try {
+        content = readFileSync(abs, "utf8");
+      } catch {
+        continue;
+      }
+      if (looksBinary(content)) continue;
+      const lines = content.split(/\r?\n/);
+      for (let i = 0; i < lines.length; i++) {
+        // Reset lastIndex defensively in case a global flag was passed.
+        pattern.lastIndex = 0;
+        if (pattern.test(lines[i]!)) {
+          out.push({ file: relPosix(root, abs), line: i + 1, text: lines[i]! });
+        }
+      }
+    }
+  };
+
+  walk(root);
+  return out;
+}
+
+interface ParsedArgs {
+  pattern: string;
+  repo: string;
+  exts?: Set<string>;
+  ignoreCase: boolean;
+  filesOnly: boolean;
+}
+
+export function parseArgs(argv: string[]): ParsedArgs | { error: string } {
+  let repo = process.cwd();
+  let exts: Set<string> | undefined;
+  let ignoreCase = false;
+  let filesOnly = false;
+  const positionals: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a === "--repo") {
+      const v = argv[++i];
+      if (!v) return { error: "--repo requires a directory" };
+      repo = resolve(v);
+    } else if (a === "--ext") {
+      const v = argv[++i];
+      if (!v) return { error: "--ext requires a comma-separated list" };
+      exts = new Set(v.split(",").map((s) => s.trim().replace(/^\./, "")).filter(Boolean));
+    } else if (a === "-i") {
+      ignoreCase = true;
+    } else if (a === "--files") {
+      filesOnly = true;
+    } else if (a.startsWith("--")) {
+      return { error: `unknown flag: ${a}` };
+    } else {
+      positionals.push(a);
+    }
+  }
+
+  const pattern = positionals.join(" ").trim();
+  if (!pattern) {
+    return { error: "usage: bun tools/search/grep.ts <pattern> [--repo <dir>] [--ext ts,md] [-i] [--files]" };
+  }
+  return { pattern, repo, exts, ignoreCase, filesOnly };
+}
+
+export function main(argv: string[]): number {
+  const parsed = parseArgs(argv);
+  if ("error" in parsed) {
+    console.error(parsed.error);
+    return 1;
+  }
+  let pattern: RegExp;
+  try {
+    pattern = new RegExp(parsed.pattern, parsed.ignoreCase ? "i" : "");
+  } catch (e) {
+    console.error(`invalid regex: ${(e as Error).message}`);
+    return 1;
+  }
+  const matches = grepTree({ root: parsed.repo, pattern, exts: parsed.exts });
+  if (parsed.filesOnly) {
+    const seen = new Set<string>();
+    for (const m of matches) {
+      if (!seen.has(m.file)) {
+        seen.add(m.file);
+        console.log(m.file);
+      }
+    }
+  } else {
+    for (const m of matches) console.log(`${m.file}:${m.line}:${m.text}`);
+  }
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/tools/search/grep.ts
+++ b/tools/search/grep.ts
@@ -35,9 +35,10 @@
 // EVERYWHERE — including this Windows laptop, which has no `rg` on PATH (2026-05-31).
 
 import { resolve, relative, join, sep } from "node:path";
-import { readdirSync, fstatSync, readFileSync, openSync, closeSync, type Dirent } from "node:fs";
+import { readdirSync, fstatSync, statSync, readFileSync, openSync, closeSync, type Dirent } from "node:fs";
 
-/** Directory basenames never worth searching (build outputs / vendored deps). */
+/** Directory basenames never worth searching (build outputs / vendored deps).
+ *  Mirrors the repo's established ignore set (gitignore / tsconfig / tooling). */
 export const EXCLUDE_BASENAMES = new Set([
   ".git",
   "node_modules",
@@ -46,6 +47,11 @@ export const EXCLUDE_BASENAMES = new Set([
   "target",
   ".playwright-mcp",
   "drop",
+  // .NET / Lean / benchmark build outputs (regeneratable; not source).
+  "artifacts",
+  "TestResults",
+  "BenchmarkDotNet.Artifacts",
+  ".lake",
 ]);
 
 /** Repo-relative POSIX paths to skip wholesale. references/upstreams is the
@@ -194,6 +200,20 @@ export function parseArgs(argv: string[]): ParsedArgs | { error: string } {
   if (!needle) {
     return { error: "usage: bun tools/search/grep.ts <substring> [--repo <dir>] [--ext ts,md] [-i] [--files]" };
   }
+
+  // Fail loud on a bad search root: a missing/non-directory --repo would otherwise
+  // walk nothing, return 0 matches, and exit 0 — indistinguishable from a genuine
+  // "no hits" (a silent false-negative). Validate so main() can exit non-zero.
+  let repoStat;
+  try {
+    repoStat = statSync(repo);
+  } catch {
+    return { error: `--repo path does not exist: ${repo}` };
+  }
+  if (!repoStat.isDirectory()) {
+    return { error: `--repo is not a directory: ${repo}` };
+  }
+
   return { needle, repo, exts, ignoreCase, filesOnly };
 }
 

--- a/tools/search/grep.ts
+++ b/tools/search/grep.ts
@@ -60,7 +60,9 @@ export interface GrepMatch {
 export interface GrepOptions {
   root: string;
   pattern: RegExp;
-  exts?: Set<string>; // extensions without the dot; undefined = all text files
+  // extensions without the dot; undefined = all text files. Explicit `| undefined`
+  // so it composes under tsconfig `exactOptionalPropertyTypes: true`.
+  exts?: Set<string> | undefined;
 }
 
 function relPosix(root: string, abs: string): string {
@@ -141,7 +143,7 @@ export function grepTree(opts: GrepOptions): GrepMatch[] {
 interface ParsedArgs {
   pattern: string;
   repo: string;
-  exts?: Set<string>;
+  exts?: Set<string> | undefined;
   ignoreCase: boolean;
   filesOnly: boolean;
 }

--- a/tools/search/grep.ts
+++ b/tools/search/grep.ts
@@ -17,7 +17,7 @@
 // Cross-repo aware: `--repo ../SQLSharp` searches a sibling repo, still skipping
 // THAT repo's references/upstreams (every repo mirrors the same convention).
 //
-//   bun tools/search/grep.ts <pattern> [--repo <dir>] [--ext ts,md] [-i] [--files]
+//   bun tools/search/grep.ts <substring> [--repo <dir>] [--ext ts,md] [-i] [--files]
 //
 // Options:
 //   --repo <dir>   root to search (default: cwd)
@@ -25,13 +25,16 @@
 //   -i             case-insensitive
 //   --files        print matching file paths only (not lines)
 //
-// v1 is a zero-dep Bun-native walk so the excludes hold EVERYWHERE — including
-// this Windows laptop, which has no `rg` on PATH (verified 2026-05-31). A
-// ripgrep fast-path (rg already honors .gitignore) is a future optimization;
-// correctness + zero-dep beats speed for v1.
+// MATCH SEMANTICS: literal substring (fixed-string, like `grep -F`), NOT regex —
+// deliberately. This is the "safe quick search excluding noise" tool; literal is
+// the common case, faster, and avoids constructing a regex from CLI input (no
+// ReDoS / regex-injection surface). When you genuinely need a regex, the harness
+// Grep tool (ripgrep) serves that AND honors .gitignore (so it also skips
+// references/upstreams). This tool stays literal + zero-dep so the excludes hold
+// EVERYWHERE — including this Windows laptop, which has no `rg` on PATH (2026-05-31).
 
 import { resolve, relative, join, sep } from "node:path";
-import { readdirSync, statSync, readFileSync, type Dirent } from "node:fs";
+import { readdirSync, fstatSync, readFileSync, openSync, closeSync, type Dirent } from "node:fs";
 
 /** Directory basenames never worth searching (build outputs / vendored deps). */
 export const EXCLUDE_BASENAMES = new Set([
@@ -59,7 +62,8 @@ export interface GrepMatch {
 
 export interface GrepOptions {
   root: string;
-  pattern: RegExp;
+  needle: string; // literal substring to find
+  ignoreCase?: boolean | undefined;
   // extensions without the dot; undefined = all text files. Explicit `| undefined`
   // so it composes under tsconfig `exactOptionalPropertyTypes: true`.
   exts?: Set<string> | undefined;
@@ -87,9 +91,31 @@ function looksBinary(buf: string): boolean {
   return false;
 }
 
+/** Read a file via a single fd — fstat the OPEN handle (not a second path stat)
+ *  so there's no time-of-check/time-of-use race between size-check and read.
+ *  Returns null if too big, binary, or unreadable. */
+function readTextCapped(abs: string): string | null {
+  let fd: number;
+  try {
+    fd = openSync(abs, "r");
+  } catch {
+    return null;
+  }
+  try {
+    if (fstatSync(fd).size > MAX_FILE_BYTES) return null;
+    const content = readFileSync(fd, "utf8");
+    return looksBinary(content) ? null : content;
+  } catch {
+    return null;
+  } finally {
+    closeSync(fd);
+  }
+}
+
 /** Pure, testable core: walk `root`, skipping excluded dirs, return matches. */
 export function grepTree(opts: GrepOptions): GrepMatch[] {
-  const { root, pattern, exts } = opts;
+  const { root, needle, ignoreCase, exts } = opts;
+  const cmpNeedle = ignoreCase ? needle.toLowerCase() : needle;
   const out: GrepMatch[] = [];
 
   const walk = (absDir: string): void => {
@@ -111,25 +137,12 @@ export function grepTree(opts: GrepOptions): GrepMatch[] {
         const ext = dot >= 0 ? ent.name.slice(dot + 1) : "";
         if (!exts.has(ext)) continue;
       }
-      let size: number;
-      try {
-        size = statSync(abs).size;
-      } catch {
-        continue;
-      }
-      if (size > MAX_FILE_BYTES) continue;
-      let content: string;
-      try {
-        content = readFileSync(abs, "utf8");
-      } catch {
-        continue;
-      }
-      if (looksBinary(content)) continue;
+      const content = readTextCapped(abs);
+      if (content === null) continue;
       const lines = content.split(/\r?\n/);
       for (let i = 0; i < lines.length; i++) {
-        // Reset lastIndex defensively in case a global flag was passed.
-        pattern.lastIndex = 0;
-        if (pattern.test(lines[i]!)) {
+        const hay = ignoreCase ? lines[i]!.toLowerCase() : lines[i]!;
+        if (hay.includes(cmpNeedle)) {
           out.push({ file: relPosix(root, abs), line: i + 1, text: lines[i]! });
         }
       }
@@ -141,7 +154,7 @@ export function grepTree(opts: GrepOptions): GrepMatch[] {
 }
 
 interface ParsedArgs {
-  pattern: string;
+  needle: string;
   repo: string;
   exts?: Set<string> | undefined;
   ignoreCase: boolean;
@@ -176,11 +189,11 @@ export function parseArgs(argv: string[]): ParsedArgs | { error: string } {
     }
   }
 
-  const pattern = positionals.join(" ").trim();
-  if (!pattern) {
-    return { error: "usage: bun tools/search/grep.ts <pattern> [--repo <dir>] [--ext ts,md] [-i] [--files]" };
+  const needle = positionals.join(" ").trim();
+  if (!needle) {
+    return { error: "usage: bun tools/search/grep.ts <substring> [--repo <dir>] [--ext ts,md] [-i] [--files]" };
   }
-  return { pattern, repo, exts, ignoreCase, filesOnly };
+  return { needle, repo, exts, ignoreCase, filesOnly };
 }
 
 export function main(argv: string[]): number {
@@ -189,14 +202,12 @@ export function main(argv: string[]): number {
     console.error(parsed.error);
     return 1;
   }
-  let pattern: RegExp;
-  try {
-    pattern = new RegExp(parsed.pattern, parsed.ignoreCase ? "i" : "");
-  } catch (e) {
-    console.error(`invalid regex: ${(e as Error).message}`);
-    return 1;
-  }
-  const matches = grepTree({ root: parsed.repo, pattern, exts: parsed.exts });
+  const matches = grepTree({
+    root: parsed.repo,
+    needle: parsed.needle,
+    ignoreCase: parsed.ignoreCase,
+    exts: parsed.exts,
+  });
   if (parsed.filesOnly) {
     const seen = new Set<string>();
     for (const m of matches) {

--- a/tools/search/grep.ts
+++ b/tools/search/grep.ts
@@ -8,8 +8,9 @@
 // bash `find | xargs grep` — do NOT honor .gitignore, so they walk into
 // `references/upstreams/` (gigabytes of mirrored OTHER-repo code) + node_modules
 // + build outputs: slow + noisy. Per
-// `.claude/rules/references-upstreams-not-our-code-search-excludes.md` +
-// `.claude/rules/architecture-is-safety-mechanism-not-discipline-...` the fix is
+// `.claude/rules/references-upstreams-not-our-code-search-excludes.md` + the rule
+// `architecture-is-safety-mechanism-not-discipline-structural-protections-vs-runtime-virtue-historical-innovation-parallel.md`
+// (full filename, no ellipsis — keep it greppable) the fix is
 // STRUCTURAL not behavioral — bake the excludes into a `.ts` so "call the tool"
 // can't hit the noise even with a sloppy invocation. Operator's framing: "the
 // .ts files have the excludes built in or they should at least."

--- a/tools/setup/install.sh
+++ b/tools/setup/install.sh
@@ -40,6 +40,9 @@
 #     /run/initramfs canonical installer-       (B-0857.3 will factor that body into
 #     ISO markers)                              a callable nixos-install-from-usb.sh;
 #                                                this routing stub lands first)
+#   - Windows (Git Bash MINGW/MSYS/CYGWIN)   -> exec setup/install.ps1 via PowerShell
+#                                                (b2; the PowerShell graph is the
+#                                                Windows install path)
 #
 # Per B-0857 operator framing (2026-05-27): install.sh is the universal
 # Unix-like-OS install + self-update entry — "there is no distinction
@@ -157,19 +160,36 @@ EOF
     ;;
   MINGW*|MSYS*|CYGWIN*)
     # Windows under Git Bash / MSYS. install.sh is the Unix-like entry; on Windows the install
-    # graph is PowerShell (user-mode, scoop-primary, no admin). Route to install.ps1. exit 2 =
-    # intentional routing guard (NOT a failure), matching the NixOS-live branch above.
-    cat >&2 <<WINEOF
+    # graph is PowerShell (user-mode, scoop-primary, no admin). b2 (operator 2026-05-31): rather
+    # than just print instructions, DRIVE the Windows install directly — exec install.ps1 via pwsh
+    # (PowerShell 7+) or fall back to Windows PowerShell (powershell.exe). `bash install.sh` from
+    # Git Bash then installs Zeta on Windows in one shot — parity with the Unix one-liner. exec
+    # replaces this shell so install.ps1's exit code propagates. Only if NO PowerShell is found do
+    # we emit the routing message + exit 2 (the intentional guard, matching the NixOS-live branch).
+    echo "OS: Windows ($os) — dispatching to the PowerShell install graph (install.ps1)"
+    ps1_path="$REPO_ROOT/tools/setup/install.ps1"
+    # Git Bash paths are MSYS-style (/c/Users/...); convert to a native Windows path so PowerShell
+    # -File resolves it. cygpath ships with Git Bash/MSYS; fall back to the raw path if absent.
+    if command -v cygpath >/dev/null 2>&1; then
+      ps1_path="$(cygpath -w "$ps1_path")"
+    fi
+    if command -v pwsh >/dev/null 2>&1; then
+      exec pwsh -NoProfile -ExecutionPolicy Bypass -File "$ps1_path" "$@"
+    elif command -v powershell.exe >/dev/null 2>&1; then
+      exec powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$ps1_path" "$@"
+    else
+      cat >&2 <<WINEOF
 OS: Windows ($os)
 
-This is a Windows shell. install.sh is the Unix-like entry; on Windows run the
-PowerShell install graph instead (user-mode, scoop-primary, no admin):
+No PowerShell found on PATH (looked for pwsh + powershell.exe). Install
+PowerShell 7+ (https://aka.ms/powershell), then run:
 
   pwsh "$REPO_ROOT/tools/setup/install.ps1"
 
 Exit 2 is the intentional routing guard (see exit-code documentation in the header).
 WINEOF
-    exit 2
+      exit 2
+    fi
     ;;
   *)
     echo "error: unsupported OS '$os' (macOS + Linux + Windows supported; others unsupported)"

--- a/tools/setup/install.sh
+++ b/tools/setup/install.sh
@@ -40,7 +40,7 @@
 #     /run/initramfs canonical installer-       (B-0857.3 will factor that body into
 #     ISO markers)                              a callable nixos-install-from-usb.sh;
 #                                                this routing stub lands first)
-#   - Windows (Git Bash MINGW/MSYS/CYGWIN)   -> exec setup/install.ps1 via PowerShell
+#   - Windows (Git Bash MINGW/MSYS/CYGWIN)   -> exec tools/setup/install.ps1 via PowerShell
 #                                                (b2; the PowerShell graph is the
 #                                                Windows install path)
 #


### PR DESCRIPTION
## Two operator-authorized items (2026-05-31)

### b2 — `install.sh` git-bash arm DRIVES the Windows install
Previously the `MINGW*|MSYS*|CYGWIN*` arm just printed "run `pwsh install.ps1`" and exited 2. Now it **execs `install.ps1`** via `pwsh` (or falls back to `powershell.exe`), with `cygpath` path conversion and a no-PowerShell fallback (message + exit 2). So `bash tools/setup/install.sh` from Git Bash installs Zeta on Windows in one shot — **parity with the Unix one-liner**.
- `exec` replaces the shell so `install.ps1`'s exit code propagates.
- Linux/macOS/NixOS routing unchanged; the Server-Core `install.ps1` CI test is unaffected (it runs `install.ps1` directly, not via the git-bash arm).
- `bash -n` clean.

### Safe-search grep wrapper — `tools/search/grep.ts`
Content-search wrapper with `references/upstreams` + `node_modules` + build-output excludes **baked in** — structural, not behavioral (per `architecture-is-safety-mechanism-not-discipline` + `references-upstreams-not-our-code-search-excludes`). Came from an operator catch: agents doing raw `Get-ChildItem -Recurse | Select-String` / `find | xargs grep` don't honor `.gitignore` and walk into the gigabytes of mirrored upstream repos.
- **Zero-dep Bun-native walk** so the excludes hold even where `rg` isn't on PATH (this laptop has none).
- Cross-repo aware (`--repo ../SQLSharp` still skips that repo's upstreams).
- Distinct from the concept-index (`tools/search/concept-index.ts`); this is the raw ad-hoc grep made correct-by-construction.
- **10 tests pass** (asserts the upstreams/node_modules/bin exclusion + match correctness + arg parsing).

## Note on diff
Branch is behind a fast-moving `main`; the 3-dot (real PR) diff is the focused 3-file set (grep.ts, grep.test.ts, install.sh). The `install.sh` change triggers the NixOS + Windows Docker install tests (paths-gated) — both expected green (b2 only touches the git-bash arm neither test exercises).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
