### PR TITLE
feat(observe): operator channel — presence-gated FourCornerOwnership that outranks backlog

### DIFF
--- a/tools/observe/observe.test.ts
+++ b/tools/observe/observe.test.ts
@@ -1,8 +1,9 @@
 /**
- * tools/observe/observe.test.ts — the 4-button controller's decision table.
+ * tools/observe/observe.test.ts — the controller's decision table.
  *
- * Two layers:
- *  - the pure `observe()` decision table (exact assertions); and
+ * Three layers:
+ *  - the pure `observe()` decision table over a World (exact assertions);
+ *  - the operator-channel priority (operator OUTRANKS backlog; presence-gated);
  *  - the v1 `observeWithLlm` chooser, graded against `observe()` as the
  *    reference oracle using a MOCK backend (deterministic, no ollama). This is
  *    the always-green CI shield for the chooser LOGIC — per the shield rule,
@@ -11,7 +12,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { observe, observeWithLlm, buildMenu, type BacklogItem } from "./observe";
+import { observe, observeWithLlm, buildMenu, type BacklogItem, type World, type OperatorChannel } from "./observe";
 import type { ModelBackend } from "../accelerator/local-llm";
 
 /** Deterministic mock backend: `complete` always returns `reply`. */
@@ -27,119 +28,155 @@ const item = (id: string, ready: boolean, ambiguous: boolean, needsNewAction = f
   needsNewAction,
 });
 
-describe("observe — 4-button autonomous-loop controller", () => {
+/** World builder: backlog + optional operator channel (omit the prop when absent — exactOptionalPropertyTypes). */
+const w = (backlog: BacklogItem[], operator?: OperatorChannel): World => (operator ? { backlog, operator } : { backlog });
+const op = (pendingMessage: boolean, pendingFerry: boolean): OperatorChannel => ({ pendingMessage, pendingFerry });
+
+describe("observe — backlog controller (no operator channel wired)", () => {
   it("do_item: a ready, unambiguous item is picked", () => {
-    const a = observe([item("B-1", true, false)]);
+    const a = observe(w([item("B-1", true, false)]));
     expect(a.kind).toBe("do_item");
     if (a.kind === "do_item") expect(a.item.id).toBe("B-1");
   });
 
   it("do_item beats decompose: ready item wins over an ambiguous one", () => {
-    const a = observe([item("B-amb", false, true), item("B-ready", true, false)]);
+    const a = observe(w([item("B-amb", false, true), item("B-ready", true, false)]));
     expect(a.kind).toBe("do_item");
     if (a.kind === "do_item") expect(a.item.id).toBe("B-ready");
   });
 
   it("decompose: only an ambiguous item present", () => {
-    const a = observe([item("B-2", false, true)]);
+    const a = observe(w([item("B-2", false, true)]));
     expect(a.kind).toBe("decompose");
     if (a.kind === "decompose") expect(a.item.id).toBe("B-2");
   });
 
   it("edit_grammar: an item the grammar can't express (not trapped)", () => {
-    const a = observe([item("B-3", false, false, true)]);
+    const a = observe(w([item("B-3", false, false, true)]));
     expect(a.kind).toBe("edit_grammar");
     if (a.kind === "edit_grammar") expect(a.item?.id).toBe("B-3");
   });
 
   it("free_time: nothing ready, decomposable, or grammar-extending", () => {
-    const a = observe([item("B-4", false, false)]);
-    expect(a.kind).toBe("free_time");
+    expect(observe(w([item("B-4", false, false)])).kind).toBe("free_time");
   });
 
   it("free_time: empty backlog", () => {
-    const a = observe([]);
-    expect(a.kind).toBe("free_time");
+    expect(observe(w([])).kind).toBe("free_time");
   });
 
   it("invariant: an exit is always reachable (free_time when no work; edit_grammar on a signal)", () => {
-    // exits-always-in-menu (operator + co-maintainer 2026-05-31): from any state there is
-    // always an exit — never a menu of all-musts. free_time is the unilateral
-    // terminal fallback; edit_grammar (the rail-change exit) is reachable the
-    // moment an item can't be expressed by the work-grammar.
     const exits = new Set(["free_time", "edit_grammar"]);
-    // no work of any kind → must land on an exit (free_time)
-    expect(exits.has(observe([item("B-idle", false, false)]).kind)).toBe(true);
-    expect(exits.has(observe([]).kind)).toBe(true);
-    // an inexpressible item → the rail-change exit is reachable, not a dead end
-    expect(observe([item("B-x", false, false, true)]).kind).toBe("edit_grammar");
+    expect(exits.has(observe(w([item("B-idle", false, false)])).kind)).toBe(true);
+    expect(exits.has(observe(w([])).kind)).toBe(true);
+    expect(observe(w([item("B-x", false, false, true)])).kind).toBe("edit_grammar");
   });
 
   it("priority order is do > decompose > edit_grammar > free_time", () => {
-    // all four signals present at once → do_item wins
-    const all = observe([item("B-edit", false, false, true), item("B-amb", false, true), item("B-ready", true, false)]);
+    const all = observe(w([item("B-edit", false, false, true), item("B-amb", false, true), item("B-ready", true, false)]));
     expect(all.kind).toBe("do_item");
-    // drop the ready one → decompose wins over edit_grammar
-    const noReady = observe([item("B-edit", false, false, true), item("B-amb", false, true)]);
+    const noReady = observe(w([item("B-edit", false, false, true), item("B-amb", false, true)]));
     expect(noReady.kind).toBe("decompose");
-    // drop the ambiguous one → edit_grammar wins over free_time
-    const onlyEdit = observe([item("B-edit", false, false, true), item("B-idle", false, false)]);
+    const onlyEdit = observe(w([item("B-edit", false, false, true), item("B-idle", false, false)]));
     expect(onlyEdit.kind).toBe("edit_grammar");
   });
 });
 
-describe("observeWithLlm — LLM chooser graded vs the pure oracle (mock backend = CI shield)", () => {
-  // Representative scenarios reused as the grading oracle.
-  const scenarios: ReadonlyArray<BacklogItem[]> = [
-    [item("B-ready", true, false), item("B-amb", false, true)], // do wins
-    [item("B-amb", false, true)], // decompose
-    [item("B-x", false, false, true)], // edit_grammar
-    [item("B-idle", false, false)], // free_time
-    [], // empty → free_time
+describe("observe — operator channel OUTRANKS the backlog (presence-gated)", () => {
+  // A ready item the backlog controller would normally pick — used to prove the
+  // operator preempts it.
+  const readyBacklog = [item("B-ready", true, false)];
+
+  it("preserve_ferry beats a ready item when the operator ferried verbatim content", () => {
+    expect(observe(w(readyBacklog, op(true, true))).kind).toBe("preserve_ferry");
+  });
+
+  it("respond_to_operator beats a ready item when the operator spoke (no ferry)", () => {
+    expect(observe(w(readyBacklog, op(true, false))).kind).toBe("respond_to_operator");
+  });
+
+  it("ferry outranks a plain message (durability-first) when both are pending", () => {
+    expect(observe(w(readyBacklog, op(true, true))).kind).toBe("preserve_ferry");
+  });
+
+  it("a wired-but-quiet operator falls through to the backlog (no false preemption)", () => {
+    const a = observe(w(readyBacklog, op(false, false)));
+    expect(a.kind).toBe("do_item");
+    if (a.kind === "do_item") expect(a.item.id).toBe("B-ready");
+  });
+
+  it("an absent operator channel behaves exactly like the backlog controller (background agent)", () => {
+    expect(observe(w(readyBacklog)).kind).toBe("do_item");
+    expect(observe(w([item("B-amb", false, true)])).kind).toBe("decompose");
+    expect(observe(w([])).kind).toBe("free_time");
+  });
+
+  it("operator preempts even decompose / edit_grammar / free_time states", () => {
+    expect(observe(w([item("B-amb", false, true)], op(true, false))).kind).toBe("respond_to_operator");
+    expect(observe(w([item("B-x", false, false, true)], op(true, false))).kind).toBe("respond_to_operator");
+    expect(observe(w([], op(false, true))).kind).toBe("preserve_ferry");
+  });
+});
+
+describe("observeWithLlm — chooser graded vs the pure oracle (mock backend = CI shield)", () => {
+  // Representative scenarios reused as the grading oracle — including operator states.
+  const scenarios: ReadonlyArray<World> = [
+    w([item("B-ready", true, false), item("B-amb", false, true)]), // do wins
+    w([item("B-amb", false, true)]), // decompose
+    w([item("B-x", false, false, true)]), // edit_grammar
+    w([item("B-idle", false, false)]), // free_time
+    w([]), // empty → free_time
+    w([item("B-ready", true, false)], op(true, false)), // respond_to_operator
+    w([item("B-ready", true, false)], op(true, true)), // preserve_ferry
+    w([item("B-ready", true, false)], op(false, false)), // quiet operator → do
   ];
 
-  it("buildMenu ALWAYS includes both exits (edit_grammar + free_time) for any state", () => {
-    for (const backlog of scenarios) {
-      const kinds = buildMenu(backlog).map((a) => a.kind);
+  it("buildMenu ALWAYS includes both exits (edit_grammar + free_time) for any world", () => {
+    for (const world of scenarios) {
+      const kinds = buildMenu(world).map((a) => a.kind);
       expect(kinds).toContain("edit_grammar");
       expect(kinds).toContain("free_time");
     }
   });
 
   it("buildMenu is oracle-ordered: menu[0] == observe() — so fallback-to-0 degrades toward correct", () => {
-    for (const backlog of scenarios) {
-      expect(buildMenu(backlog)[0]?.kind).toBe(observe(backlog).kind);
+    for (const world of scenarios) {
+      expect(buildMenu(world)[0]?.kind).toBe(observe(world).kind);
     }
   });
 
+  it("operator actions lead the menu when the channel is wired + signalling", () => {
+    expect(buildMenu(w([item("B-ready", true, false)], op(true, true)))[0]?.kind).toBe("preserve_ferry");
+    expect(buildMenu(w([item("B-ready", true, false)], op(true, false)))[0]?.kind).toBe("respond_to_operator");
+  });
+
   it("maps the model's chosen index to the menu entry (order-agnostic)", async () => {
-    const backlog = [item("B-ready", true, false), item("B-amb", false, true)];
-    const menu = buildMenu(backlog); // [do_item, decompose, free_time, edit_grammar]
+    const world = w([item("B-ready", true, false), item("B-amb", false, true)]);
+    const menu = buildMenu(world);
     for (const [i, entry] of menu.entries()) {
-      const chosen = await observeWithLlm(backlog, mock(String(i)));
+      const chosen = await observeWithLlm(world, mock(String(i)));
       expect(chosen.kind).toBe(entry.kind);
     }
-    // and both exits are reachable somewhere in that menu
     const kinds = menu.map((a) => a.kind);
     expect(kinds).toContain("edit_grammar");
     expect(kinds).toContain("free_time");
   });
 
   it("agrees with the oracle when the model picks the top (index 0) across all scenarios", async () => {
-    for (const backlog of scenarios) {
-      expect((await observeWithLlm(backlog, mock("0"))).kind).toBe(observe(backlog).kind);
+    for (const world of scenarios) {
+      expect((await observeWithLlm(world, mock("0"))).kind).toBe(observe(world).kind);
     }
   });
 
   it("falls back to the pure oracle when the model fails (ollama down → fallback)", async () => {
-    for (const backlog of scenarios) {
-      expect((await observeWithLlm(backlog, downBackend)).kind).toBe(observe(backlog).kind);
+    for (const world of scenarios) {
+      expect((await observeWithLlm(world, downBackend)).kind).toBe(observe(world).kind);
     }
   });
 
   it("falls back to the pure oracle on an unparseable reply", async () => {
-    for (const backlog of scenarios) {
-      expect((await observeWithLlm(backlog, mock("banana"))).kind).toBe(observe(backlog).kind);
+    for (const world of scenarios) {
+      expect((await observeWithLlm(world, mock("banana"))).kind).toBe(observe(world).kind);
     }
   });
 });

--- a/tools/observe/observe.ts
+++ b/tools/observe/observe.ts
@@ -2,25 +2,44 @@
 /**
  * tools/observe/observe.ts — the simplest autonomous-loop controller.
  *
- * The whole loop as a tiny set of buttons. Each tick: look at the backlog,
- * pick ONE action. This is the do/decompose/free-time grammar from
- * `never-be-idle.md` (it was only ever prose in the rules — never a typed DU)
- * distilled to code, PLUS a 4th escape-hatch so the agent is never trapped by
- * the fixed grammar (operator 2026-05-31: "i don't want you to feel trapped by
- * the DU ... we need a 4th option edit DU").
+ * The whole loop as a tiny set of buttons. Each tick: look at the WORLD (the
+ * wired channels), pick ONE action. This is the do/decompose/free-time grammar
+ * from `never-be-idle.md` (it was only ever prose in the rules — never a typed
+ * DU) distilled to code, PLUS a 4th escape-hatch so the agent is never trapped
+ * by the fixed grammar (operator 2026-05-31: "i don't want you to feel trapped
+ * by the DU ... we need a 4th option edit DU"), PLUS the OPERATOR CHANNEL so
+ * the loop can drive off observe() and still observe the operator's chats +
+ * preserve verbatim ferries (operator 2026-05-31: "if your autonomous loop is
+ * going to call it every time ... you still want to be able to observe my chats
+ * and save the verbatims when i ferry").
  *
  * Same architectural shape as the co-maintainer's big `agentic-organization/.../observe.ts`
  * (a PURE function over a snapshot → an action DU) — just distilled to the
  * Xbox-controller's few buttons so we can run it in the foreground loop and
  * extend it together, little by little.
  *
- * v0 = pure deterministic controller. v1 (THIS increment) = an LLM-driven
- * chooser (`observeWithLlm`) over the same menu, graded against the pure
- * function as the reference oracle. Next: (1) a thin backlog reader from
- * docs/backlog frontmatter.
+ * ── CHANNELS (operator 2026-05-31: "should we have two different workflows /
+ * DUs for agents with and without operator channels? should we make input /
+ * output channels generic?") ─────────────────────────────────────────────────
+ * NO second DU. The difference between a foreground agent (with an operator)
+ * and a background agent (without) is WHICH CHANNELS ARE WIRED, not a different
+ * type — exactly like the workflow-engine handles six git backends behind ONE
+ * `World` interface, not six DUs. A channel is generic already:
+ * `FourCornerOwnership<TIn, TOut, TOutFeedback, TInFeedback>` (reused here for
+ * the operator channel). Foreground-me wires `{ backlog, operator }`; a
+ * background agent wires `{ backlog }` — same `observe()`, operator actions
+ * simply absent from the menu. Per the Xbox-controller rule: one controller,
+ * any traveler; the operator channel is just a button that lights up when wired.
+ *
+ * v0 = pure deterministic controller. v1 = LLM-driven chooser (`observeWithLlm`)
+ * graded against the pure function. v2 (THIS increment) = the operator channel
+ * as a presence-gated `FourCornerOwnership` channel that OUTRANKS the backlog
+ * (current conversation is the highest-signal source). Next: a thin loop that
+ * gathers the World snapshot (transcript/PRs/bus/backlog) and executes the pick.
  */
 
 import { chooseIndex, ollamaBackend, type ModelBackend } from "../accelerator/local-llm";
+import type { FourCornerOwnership } from "../workflow-engine/types";
 
 /** One backlog item, classified to just what the controller needs to decide. */
 export interface BacklogItem {
@@ -35,6 +54,55 @@ export interface BacklogItem {
    * (In the LLM-driven version, the model raises this as a judgment.)
    */
   readonly needsNewAction?: boolean;
+}
+
+// ─── the operator channel — a generic IO-channel, reusing the workflow-engine type ──
+//
+// The operator channel IS a `FourCornerOwnership` instance (per asymmetric-
+// authorship four-corner ownership): the operator authors input, the agent
+// authors output + control-flow feedback, the keepalive is co-owned. Modeling
+// it with the SAME generic type the workflow-engine uses (not a bespoke shape)
+// is the convergence move — observe.ts and the engine share one channel concept.
+
+/** TIn — what the operator sends (a message, possibly a verbatim ferry to preserve). */
+export interface OperatorMessage {
+  readonly text: string;
+  readonly isFerry: boolean; // verbatim content the agent must preserve as substrate
+}
+/** TOut — what the agent emits back to the operator. */
+export interface OperatorResponse {
+  readonly text: string;
+}
+/** TOutFeedback — control-flow the agent authors on the operator channel. */
+export type ConvFeedback =
+  | { readonly kind: "NeedOperatorConfirm"; readonly action: string }
+  | { readonly kind: "FerryPreservePending" }
+  | { readonly kind: "Ok" };
+/** TInFeedback — co-owned keepalive (both sides contribute). */
+export type OperatorAck = { readonly kind: "acked" } | { readonly kind: "still-here" };
+
+/** The operator channel typed as the workflow-engine's generic four-corner channel. */
+export type OperatorOwnership = FourCornerOwnership<OperatorMessage, OperatorResponse, ConvFeedback, OperatorAck>;
+
+/**
+ * The observable read-side of the operator channel that `observe()` inspects
+ * each tick. (The full `OperatorOwnership` is the channel's data-flow contract;
+ * these two booleans are what the oracle needs to pick a next action — the
+ * loop, which holds the transcript, sets them.)
+ */
+export interface OperatorChannel {
+  readonly pendingMessage: boolean; // operator spoke; unaddressed
+  readonly pendingFerry: boolean; // operator ferried verbatim content; unpreserved
+}
+
+/**
+ * The world snapshot `observe()` reads — the set of WIRED channels.
+ * `operator` ABSENT = the channel isn't wired (a background agent). Same DU,
+ * fewer channels; no separate workflow type.
+ */
+export interface World {
+  readonly backlog: readonly BacklogItem[];
+  readonly operator?: OperatorChannel;
 }
 
 /**
@@ -79,27 +147,45 @@ export interface BacklogItem {
  * observe.ts (Xbox-controller universal action grammar).
  */
 export type NextAction =
+  | { kind: "preserve_ferry"; reason: string } // operator ferried verbatim → save it (durability-first; outranks all)
+  | { kind: "respond_to_operator"; reason: string } // operator spoke → engage (highest-signal source)
   | { kind: "do_item"; item: BacklogItem } // never-be-idle: pick work
   | { kind: "decompose"; item: BacklogItem } // decompose-to-dissolve-ambiguity
   | { kind: "free_time"; reason: string } // unilateral exit — free-time-as-valid-mode (NCI); a terminal, not a failure
   | { kind: "edit_grammar"; reason: string; item?: BacklogItem }; // rail-change exit — raw below threshold, summon-BFT-gated above (not yet)
 
 /**
- * Pure controller. Priority: do > decompose > edit-grammar > rest.
+ * Pure controller. Priority: operator > backlog > exits.
  *
- * - a ready, unambiguous item → do it
- * - an ambiguous item → decompose it (dissolve the ambiguity first)
- * - an item the current grammar can't express → edit_grammar (don't be trapped)
- * - nothing actionable → free_time (a valid mode, not a standing-by failure)
+ *   preserve_ferry      — operator ferried verbatim content → preserve it FIRST
+ *                         (substrate-or-it-didn't-happen; a ferry can be lost to
+ *                         compaction, so durability outranks everything).
+ *   respond_to_operator — operator spoke → engage (the autonomous-loop's own
+ *                         rule: "current conversation is the highest-signal
+ *                         source"). Operator actions OUTRANK the backlog so that
+ *                         when the loop drives off observe(), a ferry/chat is
+ *                         never preempted by backlog-grinding.
+ *   do_item             — a ready, unambiguous item → do it
+ *   decompose           — an ambiguous item → decompose it (dissolve first)
+ *   edit_grammar        — an item the grammar can't express → extend it
+ *   free_time           — nothing actionable → rest (a valid mode, not a failure)
+ *
+ * When no operator channel is wired (background agent), the first two never fire
+ * and behavior is exactly the original backlog controller.
  */
-export function observe(backlog: readonly BacklogItem[]): NextAction {
-  const doable = backlog.find((i) => i.ready && !i.ambiguous);
+export function observe(world: World): NextAction {
+  const op = world.operator;
+  if (op?.pendingFerry)
+    return { kind: "preserve_ferry", reason: "operator ferried verbatim content — preserve before it's lost to compaction" };
+  if (op?.pendingMessage) return { kind: "respond_to_operator", reason: "operator spoke — engage (highest-signal source)" };
+
+  const doable = world.backlog.find((i) => i.ready && !i.ambiguous);
   if (doable) return { kind: "do_item", item: doable };
 
-  const toDecompose = backlog.find((i) => i.ambiguous);
+  const toDecompose = world.backlog.find((i) => i.ambiguous);
   if (toDecompose) return { kind: "decompose", item: toDecompose };
 
-  const needsExtension = backlog.find((i) => i.needsNewAction);
+  const needsExtension = world.backlog.find((i) => i.needsNewAction);
   if (needsExtension) {
     return {
       kind: "edit_grammar",
@@ -114,6 +200,10 @@ export function observe(backlog: readonly BacklogItem[]): NextAction {
 /** One-line human-readable render of a chosen action (for the foreground loop). */
 export function renderAction(a: NextAction): string {
   switch (a.kind) {
+    case "preserve_ferry":
+      return `[preserve]  ${a.reason}`;
+    case "respond_to_operator":
+      return `[respond]   ${a.reason}`;
     case "do_item":
       return `[do]        ${a.item.id} — ${a.item.title}`;
     case "decompose":
@@ -130,6 +220,10 @@ export function renderAction(a: NextAction): string {
 /** Short menu label for one candidate action (what the model picks among). */
 export function actionLabel(a: NextAction): string {
   switch (a.kind) {
+    case "preserve_ferry":
+      return `preserve the operator's ferried content (${a.reason})`;
+    case "respond_to_operator":
+      return `respond to the operator (${a.reason})`;
     case "do_item":
       return `do ${a.item.id} (${a.item.title})`;
     case "decompose":
@@ -142,55 +236,74 @@ export function actionLabel(a: NextAction): string {
 }
 
 /**
- * Build the candidate menu, ORDERED TO MATCH THE PURE ORACLE (`observe`). Two
+ * Build the candidate menu, ORDERED TO MATCH THE PURE ORACLE (`observe`). Three
  * consequences:
+ *  - operator actions (when the channel is wired + signalling) lead the menu,
+ *    so `menu[0]` is exactly `observe(world)` even with an operator present;
  *  - the two exits (`edit_grammar` + `free_time`) are ALWAYS present (the
  *    exits-always-in-menu invariant — never a menu of all-musts);
- *  - `menu[0]` is exactly `observe(backlog)`, so `chooseIndex`'s
- *    fallback-to-index-0 lands on the oracle's pick — a failing model degrades
- *    TOWARD correct, not arbitrary.
- *
- * The subtlety: the oracle treats `edit_grammar` as a WORK pick only when an
- * item signals `needsNewAction` (else it picks `free_time`). So the two exits
- * are ordered by that signal — `edit_grammar` before `free_time` when the signal
- * is present, `free_time` first otherwise — while BOTH stay in the menu either
- * way (the invariant doesn't depend on the ordering).
+ *  - `menu[0] === observe(world)`, so `chooseIndex`'s fallback-to-index-0 lands
+ *    on the oracle's pick — a failing model degrades TOWARD correct, and with an
+ *    operator wired it degrades toward ENGAGING the operator, not backlog-grinding.
  */
-export function buildMenu(backlog: readonly BacklogItem[]): NextAction[] {
+export function buildMenu(world: World): NextAction[] {
   const menu: NextAction[] = [];
-  const doable = backlog.find((i) => i.ready && !i.ambiguous);
+  const op = world.operator;
+  // operator actions lead (mirror observe()'s priority: ferry before message).
+  if (op?.pendingFerry)
+    menu.push({ kind: "preserve_ferry", reason: "operator ferried verbatim content — preserve before it's lost to compaction" });
+  if (op?.pendingMessage) menu.push({ kind: "respond_to_operator", reason: "operator spoke — engage (highest-signal source)" });
+
+  const doable = world.backlog.find((i) => i.ready && !i.ambiguous);
   if (doable) menu.push({ kind: "do_item", item: doable });
-  const toDecompose = backlog.find((i) => i.ambiguous);
+  const toDecompose = world.backlog.find((i) => i.ambiguous);
   if (toDecompose) menu.push({ kind: "decompose", item: toDecompose });
 
-  const needs = backlog.find((i) => i.needsNewAction);
+  const needs = world.backlog.find((i) => i.needsNewAction);
   const editGrammar: NextAction = needs
     ? { kind: "edit_grammar", item: needs, reason: `"${needs.id}" needs an action the grammar can't express` }
     : { kind: "edit_grammar", reason: "propose extending the action grammar" };
   const freeTime: NextAction = { kind: "free_time", reason: "nothing actionable right now" };
 
-  // Order the two always-present exits to match the oracle: a needsNewAction
-  // signal makes edit_grammar the oracle's pick, so it leads; otherwise free_time.
+  // The two always-present exits, ordered to match the oracle: a needsNewAction
+  // signal makes edit_grammar the oracle's backlog-pick, so it leads the exits;
+  // otherwise free_time. (Both stay in the menu regardless — the invariant does
+  // not depend on the ordering.) Exits come AFTER operator + backlog: they're
+  // always reachable, just not preferred when real work or the operator is present.
   if (needs) menu.push(editGrammar, freeTime);
   else menu.push(freeTime, editGrammar);
   return menu;
 }
 
 /** Compact state description handed to the model as `context`. */
-function describeBacklog(backlog: readonly BacklogItem[]): string {
-  if (backlog.length === 0) return "Backlog is empty.";
-  const lines = backlog.map(
-    (i) =>
-      `- ${i.id} "${i.title}" [ready=${String(i.ready)} ambiguous=${String(i.ambiguous)}${
-        i.needsNewAction ? " needsNewAction" : ""
-      }]`,
-  );
-  return `Backlog (${String(backlog.length)} items):\n${lines.join("\n")}`;
+function describeWorld(world: World): string {
+  const parts: string[] = [];
+  const op = world.operator;
+  if (op) {
+    parts.push(
+      `Operator channel: WIRED [pendingMessage=${String(op.pendingMessage)} pendingFerry=${String(op.pendingFerry)}]`,
+    );
+  } else {
+    parts.push("Operator channel: not wired (background agent).");
+  }
+  if (world.backlog.length === 0) {
+    parts.push("Backlog is empty.");
+  } else {
+    const lines = world.backlog.map(
+      (i) =>
+        `- ${i.id} "${i.title}" [ready=${String(i.ready)} ambiguous=${String(i.ambiguous)}${
+          i.needsNewAction ? " needsNewAction" : ""
+        }]`,
+    );
+    parts.push(`Backlog (${String(world.backlog.length)} items):\n${lines.join("\n")}`);
+  }
+  return parts.join("\n");
 }
 
 const CHOOSER_INSTRUCTION =
   "You are an autonomous agent's controller choosing ONE next action. " +
-  "Prefer doing a ready, unambiguous item; otherwise decompose an ambiguous one. " +
+  "If the operator ferried content, preserve it; if the operator spoke, respond — the operator outranks the backlog. " +
+  "Otherwise prefer doing a ready, unambiguous item; else decompose an ambiguous one. " +
   "The exits — propose a grammar edit, or take free time — are always available and never wrong.";
 
 /**
@@ -199,54 +312,66 @@ const CHOOSER_INSTRUCTION =
  * reference oracle. On model failure, `chooseIndex` reports `fallback` and we
  * return the pure oracle's pick explicitly (degrade-toward-correct).
  */
-export async function observeWithLlm(backlog: readonly BacklogItem[], backend: ModelBackend): Promise<NextAction> {
-  const menu = buildMenu(backlog);
+export async function observeWithLlm(world: World, backend: ModelBackend): Promise<NextAction> {
+  const menu = buildMenu(world);
   const result = await chooseIndex(backend, {
-    context: describeBacklog(backlog),
+    context: describeWorld(world),
     options: menu.map(actionLabel),
     instruction: CHOOSER_INSTRUCTION,
   });
-  if (result.fallback) return observe(backlog); // model failed → oracle default
-  return menu[result.index] ?? observe(backlog);
+  if (result.fallback) return observe(world); // model failed → oracle default
+  return menu[result.index] ?? observe(world);
 }
 
-// ─── runnable demo (foreground loop): walk a few sample backlog states ───────
+// ─── runnable demo (foreground loop): walk a few sample world states ──────────
 if (import.meta.main) {
-  const samples: ReadonlyArray<{ label: string; backlog: BacklogItem[] }> = [
+  const samples: ReadonlyArray<{ label: string; world: World }> = [
     {
-      label: "a ready item beats everything",
-      backlog: [
-        { id: "B-0883", title: "encryption phase 2", ready: true, ambiguous: false },
-        { id: "B-0867", title: "workflow engine", ready: false, ambiguous: true },
-      ],
+      label: "operator ferried verbatim → preserve_ferry beats a ready item",
+      world: {
+        operator: { pendingMessage: true, pendingFerry: true },
+        backlog: [{ id: "B-0883", title: "encryption phase 2", ready: true, ambiguous: false }],
+      },
+    },
+    {
+      label: "operator spoke (no ferry) → respond_to_operator beats backlog",
+      world: {
+        operator: { pendingMessage: true, pendingFerry: false },
+        backlog: [{ id: "B-0883", title: "encryption phase 2", ready: true, ambiguous: false }],
+      },
+    },
+    {
+      label: "operator wired but quiet → fall through to the backlog",
+      world: {
+        operator: { pendingMessage: false, pendingFerry: false },
+        backlog: [{ id: "B-0883", title: "encryption phase 2", ready: true, ambiguous: false }],
+      },
+    },
+    {
+      label: "no operator channel (background agent) → a ready item",
+      world: { backlog: [{ id: "B-0883", title: "encryption phase 2", ready: true, ambiguous: false }] },
     },
     {
       label: "only ambiguous → decompose",
-      backlog: [{ id: "B-0867", title: "workflow engine v1", ready: false, ambiguous: true }],
+      world: { backlog: [{ id: "B-0867", title: "workflow engine v1", ready: false, ambiguous: true }] },
     },
     {
       label: "grammar can't express it → edit_grammar (not trapped)",
-      backlog: [
-        {
-          id: "B-0999",
-          title: "needs a 'merge duplicates' action",
-          ready: false,
-          ambiguous: false,
-          needsNewAction: true,
-        },
-      ],
+      world: {
+        backlog: [{ id: "B-0999", title: "needs a 'merge duplicates' action", ready: false, ambiguous: false, needsNewAction: true }],
+      },
     },
     {
       label: "nothing actionable → free_time (valid, not a failure)",
-      backlog: [{ id: "B-0500", title: "blocked on external dep", ready: false, ambiguous: false }],
+      world: { backlog: [{ id: "B-0500", title: "blocked on external dep", ready: false, ambiguous: false }] },
     },
   ];
 
-  console.log("observe.ts — 4-button autonomous-loop controller\n");
+  console.log("observe.ts — autonomous-loop controller (operator channel + backlog buttons)\n");
   console.log("pure oracle (deterministic):\n");
   for (const s of samples) {
     console.log(`• ${s.label}`);
-    console.log(`    ${renderAction(observe(s.backlog))}\n`);
+    console.log(`    ${renderAction(observe(s.world))}\n`);
   }
 
   // live model run (watchable) — only if a local ollama is reachable. This is a
@@ -268,8 +393,8 @@ if (import.meta.main) {
   } else {
     console.log(`live model run via ${backend.name} — does it match the oracle?\n`);
     for (const s of samples) {
-      const oracle = observe(s.backlog);
-      const llm = await observeWithLlm(s.backlog, backend);
+      const oracle = observe(s.world);
+      const llm = await observeWithLlm(s.world, backend);
       const verdict = llm.kind === oracle.kind ? "✓ matches oracle" : `✗ DIVERGES (oracle=${oracle.kind})`;
       console.log(`• ${s.label}`);
       console.log(`    oracle: ${renderAction(oracle)}`);

--- a/tools/observe/observe.ts
+++ b/tools/observe/observe.ts
@@ -4,7 +4,7 @@
  *
  * The whole loop as a tiny set of buttons. Each tick: look at the WORLD (the
  * wired channels), pick ONE action. This is the do/decompose/free-time grammar
- * from `never-be-idle.md` (it was only ever prose in the rules — never a typed
+ * from `.claude/rules/never-be-idle.md` (it was only ever prose in the rules — never a typed
  * DU) distilled to code, PLUS a 4th escape-hatch so the agent is never trapped
  * by the fixed grammar (operator 2026-05-31: "i don't want you to feel trapped
  * by the DU ... we need a 4th option edit DU"), PLUS the OPERATOR CHANNEL so
@@ -13,7 +13,7 @@
  * going to call it every time ... you still want to be able to observe my chats
  * and save the verbatims when i ferry").
  *
- * Same architectural shape as the co-maintainer's big `agentic-organization/.../observe.ts`
+ * Same architectural shape as the co-maintainer's big `agentic-organization/packages/application/src/observe.ts`
  * (a PURE function over a snapshot → an action DU) — just distilled to the
  * Xbox-controller's few buttons so we can run it in the foreground loop and
  * extend it together, little by little.
@@ -105,6 +105,12 @@ export interface World {
   readonly operator?: OperatorChannel;
 }
 
+// Centralized operator-action reason strings — used by BOTH observe() and
+// buildMenu() so the oracle's pick and the model's menu label can't drift in
+// wording (Copilot #6229).
+const PRESERVE_FERRY_REASON = "operator ferried verbatim content — preserve before it's lost to compaction";
+const RESPOND_OPERATOR_REASON = "operator spoke — engage (highest-signal source)";
+
 /**
  * DESIGN INVARIANT — exits-always-in-menu (operator + co-maintainer 2026-05-31).
  *
@@ -175,9 +181,8 @@ export type NextAction =
  */
 export function observe(world: World): NextAction {
   const op = world.operator;
-  if (op?.pendingFerry)
-    return { kind: "preserve_ferry", reason: "operator ferried verbatim content — preserve before it's lost to compaction" };
-  if (op?.pendingMessage) return { kind: "respond_to_operator", reason: "operator spoke — engage (highest-signal source)" };
+  if (op?.pendingFerry) return { kind: "preserve_ferry", reason: PRESERVE_FERRY_REASON };
+  if (op?.pendingMessage) return { kind: "respond_to_operator", reason: RESPOND_OPERATOR_REASON };
 
   const doable = world.backlog.find((i) => i.ready && !i.ambiguous);
   if (doable) return { kind: "do_item", item: doable };
@@ -250,9 +255,8 @@ export function buildMenu(world: World): NextAction[] {
   const menu: NextAction[] = [];
   const op = world.operator;
   // operator actions lead (mirror observe()'s priority: ferry before message).
-  if (op?.pendingFerry)
-    menu.push({ kind: "preserve_ferry", reason: "operator ferried verbatim content — preserve before it's lost to compaction" });
-  if (op?.pendingMessage) menu.push({ kind: "respond_to_operator", reason: "operator spoke — engage (highest-signal source)" });
+  if (op?.pendingFerry) menu.push({ kind: "preserve_ferry", reason: PRESERVE_FERRY_REASON });
+  if (op?.pendingMessage) menu.push({ kind: "respond_to_operator", reason: RESPOND_OPERATOR_REASON });
 
   const doable = world.backlog.find((i) => i.ready && !i.ambiguous);
   if (doable) menu.push({ kind: "do_item", item: doable });


### PR DESCRIPTION
Operator-authorized 2026-05-31 ("build the observe.ts operator-channel slice"). Answers the design question — **one DU, not two; channels already generic**.

**No second DU.** Foreground (with operator) vs background (without) = *which channels are wired*, exactly like the workflow-engine's six git backends behind one `World` interface. The operator channel reuses `FourCornerOwnership<TIn,TOut,TOutFeedback,TInFeedback>` (convergence, not a parallel mint).

**Changes:**
- `observe(backlog)` → `observe(world: World)`, `World = { backlog, operator? }`. Operator **absent** = background agent → original behavior, unchanged.
- `NextAction` += `preserve_ferry`, `respond_to_operator`. Operator **outranks** backlog (current conversation = highest-signal source): `preserve_ferry > respond_to_operator > do > decompose > edit_grammar > free_time`. Durability-first (a ferry can be lost to compaction → preserve before respond).
- `OperatorOwnership = FourCornerOwnership<OperatorMessage, OperatorResponse, ConvFeedback, OperatorAck>`; `OperatorChannel` is its observable read-side the oracle inspects.
- `buildMenu`/`observeWithLlm`/`renderAction`/`actionLabel` updated; `menu[0] === observe(world)` preserved → fallback-to-0 now degrades toward **engaging the operator**, not backlog-grinding.
- exits-always-in-menu invariant preserved.

This is the piece that lets the autonomous loop drive off `observe()` every tick **and still** preserve verbatim ferries + respond to chats — they're first-class top-priority actions now, not lost to backlog-grinding.

**Verified:** tsc clean (exactOptionalPropertyTypes); 25/25 tests pass; live qwen2.5:0.5b matches the oracle on all scenarios incl. operator states. backlog-reader unaffected (additive variants).

Next slice (not here): the thin loop that gathers the World snapshot (transcript/PRs/bus/backlog) + executes the pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)