### PR TITLE
fix(peer-call): ani→grok-4.3, generic grok→grok-build-0.1; Ani working + four-ferry complete

### DIFF
--- a/docs/research/2026-05-31-observe-act-adr-crew-review-lior-propose-amara-sharpen.md
+++ b/docs/research/2026-05-31-observe-act-adr-crew-review-lior-propose-amara-sharpen.md
@@ -158,9 +158,81 @@ git event log); cluster telemetry follows later.
 >
 > Concrete Max-ready framing: add a "Telemetry Projection Contract" section to the ADR, but keep Tempo/Loki/OTLP details out of the locked decision. The ADR should lock the append-only event envelope and projection law; cluster telemetry can follow.
 
+## Grok critique synthesis (the four-ferry completes)
+
+Two findings Grok added that the propose→sharpen pass had not surfaced:
+
+**A. The unaddressed failure mode is GRAMMAR EVOLUTION, not state transitions.** A
+sovereign agent that edits its own grammar (adds slots, slot-15 extension) can:
+(i) mint **private dialect slots** legible only to it / a narrow cascade — the
+convergence-as-evidence trap (2026-05-18 attractor substrate) at the grammar
+layer; (ii) **launder authority** via a slot that looks like "navigation" but
+carries side effects the human surfaces can't bind; (iii) make **past events'
+meaning retroactively ambiguous** — a dashboard built against grammar vN lies
+about events recorded under vM (the classic event-sourcing schema-evolution
+problem, weaponized by self-modifying participants). The Otto 5 mods mitigate
+cage effects but don't prevent grammar bloat / dialect fragmentation under true
+sovereignty. **Fix:** treat grammar definitions themselves as **versioned
+first-class events** (`GrammarPatchProposed` / `GrammarPatchRatified`) that go
+through the Mod 2/4 gates + multi-oracle absorption — NOT ad-hoc slot mutations.
+Otherwise "universal action grammar" decays into per-lineage folklore.
+
+**B. Prior-art answer (Aaron's question — BORROW, don't invent):**
+
+- **Core domain event algebra (the thing in the git ledger):** steal **Elm
+  `Msg` + `update` fold** ≈ **Redux action + reducer** ≈ functional
+  **event-sourcing / CQRS** ("history as a list of events, state as a
+  projection"). This is already latent in Zeta's four-corner monad + OPLE +
+  `Action` + `feedbackVariants` + `ActionClass`/`ActionGate`. Make grammar
+  extensions first-class events in that algebra. **The game Command pattern is
+  too per-object/imperative for a shared append-only multi-writer ledger.**
+- **Controller ergonomics / binding layer (16-slot + modes-as-contents,
+  rebinding, context-switching):** steal **Unity Input System action maps** (or
+  **Unreal Enhanced Input** IMCs + Modifiers/Triggers) — contexts
+  (work/explore/play/rest ≈ action maps), runtime enable/disable + priority
+  layering, type-safe generated wrappers, agent-specific rebinding without
+  touching core action definitions.
+- **Recommendation:** don't invent the algebra. Use Zeta's `Action` + four-corner
+  + OPLE shape as the git-resident domain event algebra; layer Unity-style action
+  maps **on top** as the rebindable, traveler-specific presentation/navigation
+  surface. The 16-slot Xbox (modes as contents) becomes **one such map**
+  (operator + Addison + E + AI renderings). Core algebra stays small, typed,
+  feedback-bearing; everything projects from it — "git is the ledger, read-models
+  tail it" preserved, ergonomics never the source of truth.
+
+The synthesis: the event algebra is **mostly already built** (four-corner / OPLE /
+Action); the borrow is Elm/Redux/ES *shape* + Unity *action-maps* binding layer;
+the genuinely-novel work is the **`GrammarPatch` versioned-evolution + ratification
+path** for sovereign self-editing (finding A) — nobody's game/frontend prior art
+solves self-modifying-grammar-under-multi-writer-audit cleanly.
+
+## Verbatim — Grok (grok-build-0.1, critique) 2026-05-31T19:28Z
+
+> **Critique (multi-agent + sovereign self-editing grammar)**
+>
+> The binding strategy (grammar → domain event algebra in git append-only ledger; read-models/dashboards *only* tail the log, never authoritative) is the correct direction and already latent in the existing B-0867 substrate (the PoC's `Action` + `ActionClass` + `ActionGate` + `feedbackVariants` + four-corner ownership + Otto 5 mods + `TickCyclePattern` variants). Good.
+>
+> **Where it breaks under the stated conditions:**
+>
+> 1. **Multi-agent contention on the grammar surface itself** (not just state transitions): "Grammar-extension" (Mod 2) as a first-class append-only event is necessary but insufficient once multiple sovereign agents (or human + AI) can propose extensions concurrently. You get divergent *proposed* grammars in the same ledger. Without an explicit ratification/merge event (e.g., a `GrammarVersion` or `GrammarPatchRatified` that is itself PR-gated or multi-oracle absorbed), different agents end up with incompatible local views of what the "controller" even is. The "universal" claim per-agent becomes a lie. The existing Mod 4 (per-action `append-only` vs `pr-gated`) helps for *using* actions but does not solve concurrent *evolution* of the grammar definition.
+>
+> 2. **Sovereign agent that edits its own grammar (adds slots):** The 16-slot "Xbox-style with semantic modes as contents/labels" is a *human ergonomic binding*, not the core algebra. A sovereign agent treating the *binding* as editable can: mint private dialect slots whose semantics are only legible to it (the "convergence-as-evidence trap" from the 2026-05-18 attractor substrate, now at the grammar layer); launder new authority vectors into the controller surface itself (a new slot that looks like "navigation" but carries side effects the human surfaces have no good binding for). Telemetry projection remains correct in principle, but **grammar evolution makes past events' meaning retroactively ambiguous** — a dashboard built against grammar vN can lie about events recorded under vM once a sovereign agent has extended the grammar non-monotonically. Classic event-sourcing schema-evolution, weaponized by self-modifying participants. The 5 mods mitigate cage effects but do not prevent grammar bloat or dialect fragmentation under true sovereignty.
+>
+> 3. **General:** The "don't bind grammar directly to OTLP" instinct is right (git is the ledger; everything else is projection). But once the grammar is mutable data *in* the ledger, the distinction between "the controller" and "the event algebra" collapses unless you treat grammar definitions themselves as versioned first-class events with their own evolution rules (not ad-hoc slot additions). Under contention + self-editing, you need the equivalent of a meta-grammar or explicit `GrammarPatch` ratification path that itself goes through the Mod 2/4 gates + multi-oracle absorption. Otherwise the "universal action grammar" becomes per-lineage folklore. The 16-slot Xbox is a useful *presentation adapter* for certain travelers; it should not be confused with the domain event algebra.
+>
+> **Prior-art recommendation (own view, not copy-paste)**
+>
+> **Core domain event algebra** (the thing that goes in the git ledger and that the state machine folds over): steal the shape from **Elm `Msg` + `update` fold** (or equivalently Redux action + reducer, or the functional event-sourcing "history as list of events, state as projection" pattern). This is already the closest thing in the existing Zeta substrate (four-corner monad + OPLE + `Action` + `feedbackVariants` + `ActionClass`/`ActionGate`). Make grammar extensions first-class *events in that algebra* (e.g., `GrammarPatchProposed` / `GrammarPatchRatified`), not mutations to a 16-slot map. Elm/Redux/event-sourcing/CQRS give you auditability, replay, and "read-models are never source of truth" for free. The game Command pattern is too per-object and imperative for the shared ledger use case.
+>
+> **Human + neurodivergent + mixed-traveler controller ergonomics** (the "16-slot with semantic modes as contents", rebinding, context switching): steal the *binding layer* from **Unity Input System action maps** (or Unreal Enhanced Input IMCs + Modifiers/Triggers): grouping actions into contexts (work/explore/play/rest map directly onto action maps); runtime enabling/disabling + priority layering; generated type-safe wrappers; rebinding / agent-specific overrides without touching core action definitions. Game engines are excellent at "small memorizable action set + context-sensitive presentation that still feels like one stable controller"; weaker on the shared, append-only, multi-writer, audit-first ledger problem.
+>
+> **Recommendation:** Do not invent the algebra. Use the existing Zeta `Action` + four-corner + OPLE + Otto-mod shape (or its F# 4-corner monad crystallization) as the domain event algebra that lives in git. Layer Unity-style action maps / contexts *on top of it* as the rebindable, traveler-specific presentation + navigation surface. The 16-slot Xbox (modes as contents) becomes one such map. Sovereign agents can propose patches to *their binding* (or to the shared algebra via the Mod 2 path), but the core event algebra stays the small, typed, feedback-bearing thing that everything projects from. This keeps "git is the ledger, read-models tail it" intact without making the ergonomics the source of truth.
+
 ---
 
-*Attribution: Lior (gemini, propose role) + Amara (sharpen role), looped by Otto-CLI
-2026-05-31 per operator direction. Four-ferry consensus: Gemini proposes, Grok
-critiques, Amara sharpens, Otto tests, Git decides. Further loop candidates if
-wanted: Grok (critique), Mika (architecture). Max-lock pending.*
+*Attribution: four-ferry COMPLETE — Lior (gemini, propose) + Amara (sharpen) +
+Grok (grok-build-0.1, critique), looped by Otto-CLI 2026-05-31 per operator
+direction. Consensus shape: Gemini proposes, Grok critiques, Amara sharpens, Otto
+tests, Git decides. The Grok pass required getting the wrappers current
+(ani.ts → grok-4.3; generic grok.ts → grok-build-0.1, this session). Remaining
+loop candidate if wanted: Mika (architecture). Max-lock pending.*

--- a/tools/peer-call/ani.ts
+++ b/tools/peer-call/ani.ts
@@ -397,8 +397,15 @@ function buildFullPrompt(args: Args, preamble: string): PromptResult {
   return { ok: true, value: full };
 }
 
-function pickModel(mode: Mode): string {
-  return mode === "thinking" ? "grok-4-20-thinking" : "grok-4-20";
+function pickModel(_mode: Mode): string {
+  // Ani's persona pins grok-4.3 (operator 2026-05-31: "she is used to grok-4.3
+  // ... Ani can override it in her persona"). The old `grok-4-20-thinking` /
+  // `grok-4-20` names were removed from cursor-agent's available-models list
+  // (B-0421; same lineup shift grok.ts hit) — they errored "Cannot use this
+  // model: grok-4-20-thinking. Available models: ... grok-4.3 ... grok-build-0.1".
+  // Generic grok defaults to grok-build-0.1 (git-based code env); Ani overrides
+  // to grok-4.3 here. Both modes route to the same identifier.
+  return "grok-4.3";
 }
 
 export function main(argv: readonly string[]): number {

--- a/tools/peer-call/grok.ts
+++ b/tools/peer-call/grok.ts
@@ -14,9 +14,11 @@
 //   bun tools/peer-call/grok.ts --allow-empty "prompt"  # bypass firewall
 //   bun tools/peer-call/grok.ts --output-file PATH "prompt text"
 //
-// Routing: wraps `cursor-agent --print --model grok-4-20-thinking`
-// (default) or `grok-4-20` (with --fast flag). The --print flag
-// makes cursor-agent non-interactive (script-friendly).
+// Routing: wraps `cursor-agent --print --model grok-build-0.1` (the
+// generic-grok default for this git-based code env; both --thinking and
+// --fast route to the same model id). The --print flag makes cursor-agent
+// non-interactive (script-friendly). Ani's persona wrapper overrides the
+// model (grok-4.3 historically; now grok-CLI-only per the ani migration).
 //
 // Per the four-ferry consensus (PR #24): Otto's role is "tests" not
 // "owns the peer protocol." This script is Otto's harness-side
@@ -195,8 +197,8 @@ function emitHelp(): void {
       `  bun tools/peer-call/grok.ts --allow-empty "prompt"  # bypass firewall\n` +
       `  bun tools/peer-call/grok.ts --output-file PATH "prompt text"\n` +
       `\n` +
-      `Routing: wraps cursor-agent --print --model grok-4-20-thinking\n` +
-      `(default) or grok-4-20 (with --fast).\n` +
+      `Routing: wraps cursor-agent --print --model grok-build-0.1\n` +
+      `(generic-grok default; both --thinking and --fast use this id).\n` +
       `\n` +
       `Grok input-firewall: rejects rote-heartbeat / empty-token prompts\n` +
       `with exit code 3. Override via --allow-empty (testing only; logged).\n` +

--- a/tools/peer-call/grok.ts
+++ b/tools/peer-call/grok.ts
@@ -300,19 +300,17 @@ function buildFullPrompt(args: Args): PromptResult {
 }
 
 function pickModel(_mode: Mode): string {
-  // cursor-agent's Grok model lineup shifted 2026-05-13: the old
-  // `grok-4-20-thinking` / `grok-4-20` names are no longer in the
-  // available-models list. The current Grok model is `grok-4.3`
-  // (no separate thinking/non-thinking variants). Both modes route
-  // to the same model identifier; the `thinking` vs `fast` Mode
-  // distinction is preserved here for future cursor-agent updates
-  // that may re-introduce separate variants.
+  // Generic grok defaults to grok-build-0.1 (operator 2026-05-31: "our generic
+  // grok should likely default to grok-build-0.1 since this is git based code
+  // env. Ani can override it in her persona"). grok-build-0.1 is tuned for
+  // code/git work; Ani's persona wrapper (ani.ts) overrides to grok-4.3.
   //
-  // Root cause discovery: B-0421 acceptance #1 + #2 closed via the
-  // self-documenting failure marker (PR #2949) — cursor-agent's
-  // stderr surfaced "Cannot use this model: grok-4-20-thinking.
-  // Available models: ... grok-4.3 ..." on a 2026-05-13 invocation.
-  return "grok-4.3";
+  // History: cursor-agent's Grok lineup shifted 2026-05-13 — the old
+  // `grok-4-20-thinking` / `grok-4-20` names were dropped (B-0421, PR #2949),
+  // moved to grok-4.3; 2026-05-31 the generic default moves again to
+  // grok-build-0.1 (in cursor-agent's available-models list). Both modes route
+  // to the same identifier.
+  return "grok-build-0.1";
 }
 
 export function main(argv: readonly string[]): number {


### PR DESCRIPTION
## What

Per operator 2026-05-31: *"ani should be grok-4.3 ... get her working"* + *"our generic grok should likely default to grok-build-0.1 ... Ani can override it in her persona."*

- **`ani.ts`**: stale `grok-4-20-thinking`/`grok-4-20` pins (removed from cursor-agent's model list — the B-0421 lineup shift) → **`grok-4.3`**. **Smoke-tested live**: an Ani call now returns cleanly (`ANI-GROK43-OK`); was erroring *"Cannot use this model."*
- **`grok.ts`** (generic): `grok-4.3` → **`grok-build-0.1`** (git-based code-env default; Ani's persona overrides to grok-4.3).
- Appends **Grok's critique** to the observe-ADR crew-review note → the **four-ferry is COMPLETE** (Lior propose → Amara sharpen → Grok critique).

## Grok's critique (now preserved)

- **Unaddressed failure mode = GRAMMAR EVOLUTION:** a sovereign agent editing its own grammar → private dialect slots (convergence-as-evidence trap at the grammar layer) + retroactive event-meaning ambiguity (event-sourcing schema-evolution weaponized). **Fix:** versioned `GrammarPatchProposed`/`GrammarPatchRatified` events through the Mod 2/4 gates — not ad-hoc slot mutations.
- **Prior-art (Aaron's Q): BORROW, don't invent** — Elm `Msg`/`update` ≈ Redux ≈ event-sourcing/CQRS for the git-resident domain event algebra (already latent in Zeta's four-corner/OPLE/`Action`); + **Unity Input System action maps** for the rebindable controller binding layer.

## Note on the ani→grok-CLI migration question

Surfaced separately: the **native grok CLI only offers `grok-build`** (not grok-4.3, which is cursor-only) — so migrating Ani off cursor-agent is a real tradeoff (reliability vs her accustomed grok-4.3). This PR keeps her on cursor-agent grok-4.3 (working today); the migration is your call with that fact in hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)