### PR TITLE
feat(setup): graduate Windows-native ollama + bootstrap choco; idempotent local-LLM pull (B-0857)

### DIFF
--- a/tools/ci/manifest-symmetry.test.ts
+++ b/tools/ci/manifest-symmetry.test.ts
@@ -34,15 +34,15 @@ const WINDOWS_EXCEPTIONS: Record<string, string> = {
   p7zip: "scoop bundles 7zip (brew's 7zip formula; sibling of apt's p7zip-full)",
   "hermes-agent":
     "NousResearch agent; upstream install is a Linux/macOS curl script (WebSearch 2026-05-30); Windows + cross-platform (uv/npm?) install TBD — deferred from manifests/windows pending an install-graph decision",
-  // #6123 local-LLM substrate deps (added to apt/brew). The Linux runtime libs are provided
-  // natively by Windows; ollama is cross-platform but its Windows rollout is a local-LLM-substrate
-  // decision (deferred, like hermes-agent).
+  // #6123 local-LLM substrate deps (added to apt/brew). The Linux runtime libs below are provided
+  // natively by Windows; zstd's extraction need is covered by Windows tar / scoop. (ollama itself
+  // GRADUATED to manifests/windows on 2026-05-31 — Windows-native local-LLM parity; it is no longer
+  // an exception.)
   zstd: "compression lib (Linux runtime dep for the local-LLM substrate); Windows tar supports zstd in-box + scoop has zstd if needed",
   libicu74: "Linux ICU runtime lib for the dotnet/local-LLM stack; Windows provides ICU natively",
   libssl3t64: "Linux OpenSSL runtime lib; Windows uses Schannel / native TLS",
   "libgssapi-krb5-2": "Linux Kerberos/GSSAPI runtime lib; Windows uses SSPI natively",
   tzdata: "Linux timezone database; Windows ships its own timezone data",
-  ollama: "cross-platform incl. Windows (scoop / winget Ollama.Ollama); inclusion in the Windows install graph is a local-LLM-substrate Windows-parity decision — deferred, like hermes-agent",
 };
 
 test("manifests/windows covers every apt/brew system tool (or an allowlisted exception)", () => {

--- a/tools/setup/install.ps1
+++ b/tools/setup/install.ps1
@@ -8,6 +8,9 @@
 # tools/persistence/windows/install-scheduled-task.ts (schtasks ~= launchd). No admin required.
 #
 # Idempotent (detect-first-install-else-update) -- safe to run repeatedly to keep tools fresh.
+# Mirrors the macOS Homebrew flow: a fresh machine gets the full install; a re-run efficiently
+# updates only what changed (scoop/mise/ollama all detect-first; the model pull checks `ollama
+# list` and skips when present), so a 2nd run does NOT redo everything (operator 2026-05-31).
 #
 #   pwsh tools/setup/install.ps1                    # full install + register the per-minute loop
 #   pwsh tools/setup/install.ps1 -SkipLoopRegister  # skip the scheduled-task registration (dev)
@@ -15,6 +18,8 @@
 # Package-source pins per dep-pin-search-first-authority (WebSearch 2026-05-30):
 #   scoop -- https://get.scoop.sh (canonical; download-then-exec, NOT pipe-to-shell). Refs:
 #           https://scoop.sh/  https://github.com/ScoopInstaller/scoop
+#   choco -- https://community.chocolatey.org/install.ps1 (canonical; download-then-exec). Ref:
+#           https://docs.chocolatey.org/en-us/choco/setup/  (admin-only bootstrap)
 #   git   -- scoop: git | winget: Git.Git | choco: git
 [CmdletBinding()] param([switch]$SkipLoopRegister)
 # Deliberately NO `Set-StrictMode -Version Latest`: this installer shells out (via the call
@@ -26,6 +31,9 @@
 $ErrorActionPreference = 'Stop'
 $RepoRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
 function Have($c) { [bool](Get-Command $c -ErrorAction SilentlyContinue) }
+function Test-IsAdmin {
+  ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
 
 # Native-tool invocation helper. Native tools (scoop/mise/bun) write progress + benign notes to
 # STDERR; PS 5.1 promotes native stderr to a fatal NativeCommandError under
@@ -41,6 +49,16 @@ function Invoke-Tool {
   $ErrorActionPreference = 'Continue'
   try { & $Cmd 2>&1 | ForEach-Object { Write-Host "$_" } } finally { $ErrorActionPreference = $prev }
   if ($LASTEXITCODE -ne 0) { throw "$What failed (exit $LASTEXITCODE)" }
+}
+# Best-effort native call: surface merged output, return the exit code, NEVER throw -- for GRACEFUL
+# steps that must not brick install (e.g. the local-LLM pull). Mirrors common/local-llm.sh's
+# warn-and-continue discipline (exceptions-as-signals: the model is best-effort substrate).
+function Invoke-ToolSoft {
+  param([Parameter(Mandatory)][scriptblock]$Cmd)
+  $prev = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try { & $Cmd 2>&1 | ForEach-Object { Write-Host "$_" } } finally { $ErrorActionPreference = $prev }
+  return $LASTEXITCODE
 }
 # Cosmetic version probe -- best-effort, never fatal (stderr-tolerant, ignores exit code).
 function Get-ToolVersion {
@@ -78,8 +96,7 @@ if (-not (Have scoop)) {
     # scoop refuses admin by default (desktop = non-admin). In an admin context (CI / a Windows
     # container runs as ContainerAdministrator) pass -RunAsAdmin so the bootstrap proceeds; on a
     # normal user desktop this branch is skipped.
-    $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-    if ($isAdmin) { & $scoopTmp -RunAsAdmin } else { & $scoopTmp }
+    if (Test-IsAdmin) { & $scoopTmp -RunAsAdmin } else { & $scoopTmp }
   } finally { Remove-Item $scoopTmp -Force -ErrorAction SilentlyContinue }
 }
 # scoop shims on PATH for the rest of this process (scoop adds them to the user PATH for new
@@ -88,8 +105,39 @@ $scoopShims = Join-Path $env:USERPROFILE 'scoop\shims'
 if ((Test-Path $scoopShims) -and ($env:PATH -notlike "*$scoopShims*")) { $env:PATH = "$scoopShims;$env:PATH" }
 Write-Host "scoop: $(Get-ToolVersion { scoop --version })"
 
+# 1b. chocolatey -- the THIRD resolver source (scoop -> winget -> choco), bootstrapped as part of
+#     setup per operator 2026-05-31. choco's installer REQUIRES admin, and scoop (above) is the
+#     non-elevated PRIMARY the operator prefers ("scoop ... all non-elevated user scope"), so this
+#     is admin-gated + GRACEFUL: install choco ONLY when this process is already elevated AND choco
+#     is missing; otherwise warn + skip cleanly (scoop+winget fully cover the non-admin desktop
+#     flow -- NEVER force elevation). Download-then-exec (B-0063 pattern, like scoop above).
+if (-not (Have choco)) {
+  if (Test-IsAdmin) {
+    Write-Host "downloading chocolatey (admin fallback source)..."
+    $chocoTmp = Join-Path $env:TEMP "choco-install-$([guid]::NewGuid()).ps1"
+    try {
+      # choco's bootstrap wants TLS 1.2 on older .NET; set it for THIS process only (harmless on
+      # modern Windows where it's already the default).
+      try { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12 } catch {}
+      Invoke-RestMethod -Uri https://community.chocolatey.org/install.ps1 -OutFile $chocoTmp
+      if (-not (Test-Path $chocoTmp) -or (Get-Item $chocoTmp).Length -eq 0) { throw "chocolatey installer empty; refusing to run" }
+      & $chocoTmp
+      # choco installs to $env:ProgramData\chocolatey\bin; surface it on PATH for this process.
+      $chocoBin = Join-Path $env:ProgramData 'chocolatey\bin'
+      if ((Test-Path $chocoBin) -and ($env:PATH -notlike "*$chocoBin*")) { $env:PATH = "$chocoBin;$env:PATH" }
+    } catch {
+      Write-Host "could not bootstrap chocolatey ($($_.Exception.Message)); continuing (scoop/winget cover the resolver chain)"
+    } finally { Remove-Item $chocoTmp -Force -ErrorAction SilentlyContinue }
+  } else {
+    Write-Host "chocolatey absent + not elevated -> skipping choco bootstrap (scoop is the non-elevated primary; re-run from an elevated shell to add choco as a fallback source)"
+  }
+}
+if (Have choco) { Write-Host "choco: $(Get-ToolVersion { choco --version })" }
+
 # 2. system CLI tools from manifests/windows (scoop -> winget -> choco). Strips `#` comments +
-#    trims (parity with the awk in macos.sh's brew-manifest loop).
+#    trims (parity with the awk in macos.sh's brew-manifest loop). Each `scoop install` /
+#    `winget install` / `choco install` is itself detect-first (no-op when already present), so a
+#    re-run only fetches what's missing/stale -- the idempotent-update property.
 $manifest = Join-Path $RepoRoot 'tools\setup\manifests\windows'
 foreach ($raw in Get-Content $manifest) {
   $line = ($raw -replace '#.*$', '').Trim(); if (-not $line) { continue }
@@ -120,7 +168,58 @@ try {
 # 5. claude-code via bun --global (bun provided by mise) -- identical to Unix.
 Invoke-Tool { mise exec -- bun install --global '@anthropic-ai/claude-code' } 'bun install -g claude-code'
 
-# 6. register the per-minute (windowless, conhost --headless) loop unless skipped.
+# 6. local-LLM core primitive -- pull the pinned model (the ollama BINARY was installed by the
+#    manifest loop in step 2, since `ollama` is now in manifests/windows). Mirrors
+#    common/local-llm.sh: idempotent (skip when the model is already present) + GRACEFUL (a
+#    registry/network/daemon failure WARNS and continues -- it must NEVER brick install; the
+#    primitive's tests skip-if-absent -> mock-only, per exceptions-as-signals). Reads model/host
+#    from manifests/local-llm (the OS-agnostic shared contract Unix reads too).
+$llmManifest = Join-Path $RepoRoot 'tools\setup\manifests\local-llm'
+if (Test-Path $llmManifest) {
+  $llm = @{}
+  foreach ($raw in Get-Content $llmManifest) {
+    $line = ($raw -replace '#.*$', '').Trim(); if (-not $line) { continue }
+    $kv = $line -split '\s+', 2
+    if ($kv.Count -eq 2) { $llm[$kv[0]] = $kv[1] }
+  }
+  $model = $llm['model']
+  $llmHost = if ($llm['host']) { $llm['host'] } else { 'http://127.0.0.1:11434' }
+  function Test-OllamaUp {
+    param([string]$Base)
+    try { Invoke-WebRequest -UseBasicParsing -Uri "$Base/api/version" -TimeoutSec 3 | Out-Null; return $true } catch { return $false }
+  }
+  if (-not $model) {
+    Write-Host "warn: local-llm manifest has no 'model'; skipping local-LLM pull"
+  } elseif (-not (Have ollama)) {
+    Write-Host "warn: ollama not on PATH after the manifest step; skipping local-LLM (tests fall back to mock)"
+  } else {
+    if (-not (Test-OllamaUp -Base $llmHost)) {
+      Write-Host "down starting ollama serve (background)..."
+      Start-Process -FilePath ollama -ArgumentList 'serve' -WindowStyle Hidden -ErrorAction SilentlyContinue
+      for ($i = 0; $i -lt 30; $i++) { if (Test-OllamaUp -Base $llmHost) { break }; Start-Sleep -Seconds 1 }
+    }
+    if (-not (Test-OllamaUp -Base $llmHost)) {
+      Write-Host "warn: ollama daemon not reachable at $llmHost; skipping model pull (tests fall back to mock)"
+    } else {
+      # idempotent: only pull if the pinned model is absent (`ollama list` first column).
+      $present = $false
+      try {
+        $listed = & ollama list 2>$null | Select-Object -Skip 1
+        $present = [bool]($listed -match "^$([regex]::Escape($model))\s")
+      } catch { $present = $false }
+      if ($present) {
+        Write-Host "ok local-LLM model $model already present"
+      } else {
+        Write-Host "down pulling $model (~400MB, one-time)..."
+        $code = Invoke-ToolSoft { ollama pull $model }
+        if ($code -ne 0) { Write-Host "warn: 'ollama pull $model' failed (exit $code); skipping (tests fall back to mock)" }
+        else { Write-Host "ok local-LLM primitive ready: $model" }
+      }
+    }
+  }
+}
+
+# 7. register the per-minute (windowless, conhost --headless) loop unless skipped.
 if (-not $SkipLoopRegister) {
   Invoke-Tool { mise exec -- bun "$RepoRoot\tools\persistence\windows\install-scheduled-task.ts" --register } 'register loop task'
 }

--- a/tools/setup/manifests/windows
+++ b/tools/setup/manifests/windows
@@ -14,3 +14,10 @@
 # https://github.com/ScoopInstaller/scoop + https://learn.microsoft.com/windows/package-manager/):
 #   git — scoop: git | winget: Git.Git | choco: git
 git    winget=Git.Git    choco=git
+
+# Local-LLM core primitive (operator 2026-05-31 — graduated from deferred to Windows-native parity;
+# symmetric with manifests/brew's `ollama`). Provides the local move-next selector + observe.ts
+# classifier + DST fixtures. The pinned MODEL (manifests/local-llm) is pulled by install.ps1's
+# local-LLM step, mirroring common/local-llm.sh. Pins per dep-pin-search-first (verified
+# 2026-05-31): scoop main bucket `ollama` 0.20.7 | winget `Ollama.Ollama` 0.24.0 | choco `ollama`.
+ollama    winget=Ollama.Ollama    choco=ollama


### PR DESCRIPTION
## What

Windows install-graph parity with mac/linux for the **local-LLM core primitive**, plus completing the package-manager bootstrap (**scoop + choco**) — keeping the whole graph **detect-first idempotent** like the macOS Homebrew flow.

Per operator 2026-05-31: *"do (a) — graduate windows-native ollama"* + *"we should make our windows install scoope and chocolaty as part of setup"* + *"I like scoop the best cause it's all non elevated user scope"* + *"like our mac installs homebrew package manager … the windows should be the same indepotent install/update everything even from fresh machine state."*

## Changes

- **`manifests/windows`** — graduate `ollama` from deferred → Windows-native parity (`scoop` main `ollama` 0.20.7 | `winget` `Ollama.Ollama` 0.24.0 | `choco` `ollama`). Symmetric with `manifests/brew`'s `ollama`. The existing manifest loop installs it via `scoop → winget → choco`.
- **`manifest-symmetry.test.ts`** — drop the `ollama` `WINDOWS_EXCEPTION` (it's now carried in `manifests/windows`); keep the no-stale-exception assert.
- **`install.ps1`**
  - **step 1b** — admin-gated **graceful chocolatey bootstrap** (the 3rd resolver source). `scoop` stays the **non-elevated PRIMARY** (operator preference); `choco` only bootstraps when the process is **already elevated**, else warns + skips cleanly — **never forces elevation**. Download-then-exec (B-0063), TLS 1.2 for older .NET, PATH-surface `chocolatey\bin`.
  - **step 6** — **local-LLM model pull** mirroring `common/local-llm.sh`: **idempotent** (skip when `ollama list` already has the pinned model) + **graceful** (daemon/network failure warns + continues; tests fall back to mock). Reads `model`/`host` from `manifests/local-llm` (OS-agnostic shared contract Unix reads too).
  - **header** — document the idempotent-update property explicitly (fresh machine → full install; re-run → updates only what changed, no redo).

## Verification

- PS language-parser parse OK (0 errors).
- `bun test tools/ci/manifest-symmetry.test.ts` → 3 pass.
- CI will trigger all 4 install shields via the `tools/setup/**` path-gate (docker-ubuntu, docker-nixos, docker-windows, wsl).

## Shield discipline

Per `automated-tests-are-the-shield-assert-dont-skip.md`: the **installer** is graceful so it never bricks a machine; the **docker-windows shield** should ASSERT ollama actually works in the Windows container — that's the **B-0941-windows** follow-up (same "skip-as-green hole" the nixos B-0941 named).

🤖 Generated with [Claude Code](https://claude.com/claude-code)