### PR TITLE
test(setup): assert install.sh idempotency — 2nd run must not re-pull the model (ubuntu shield)

### DIFF
--- a/tools/ci/dockerfiles/ubuntu-install-sh-test/Dockerfile
+++ b/tools/ci/dockerfiles/ubuntu-install-sh-test/Dockerfile
@@ -59,3 +59,27 @@ RUN set -eu; \
     ollama list | awk 'NR>1 {print $1}' | grep -qx "$MODEL"; \
     bun test tools/accelerator/local-llm.test.ts; \
     bun tools/accelerator/validate-local-llm.ts --root "$PWD"
+
+# Idempotency / 2nd-run assert (operator 2026-05-31: "like our mac installs
+# homebrew ... the windows should be the same indepotent install/update everything
+# ... a 2nd run should not redo everything, it should efficiently just update
+# what's needed and no more"). A re-run on an already-provisioned machine must NOT
+# redo work — in particular it must NOT re-pull the 398MB model (the exact caching
+# issue named). Run install.sh a SECOND time on the state the 1st RUN left (tools
+# installed + model on disk), then ASSERT the idempotency signals. Per
+# automated-tests-are-the-shield-assert-dont-skip.md the test ASSERTS the positive
+# (model already-present + zero re-pull), it does not merely tolerate a no-op.
+# The DAEMON doesn't persist across layers, so install.sh's local-LLM step starts
+# its own `ollama serve` and reads the model from the persisted disk layer.
+RUN set -eu; \
+    export PATH="/root/.local/bin:$PATH"; \
+    MODEL="$(grep -E '^model' tools/setup/manifests/local-llm | awk '{print $2}')"; \
+    echo "=== 2nd install.sh run (idempotency) ==="; \
+    ./tools/setup/install.sh 2>&1 | tee /tmp/install-2nd.log; \
+    echo "=== idempotency asserts ==="; \
+    grep -qF "local-llm model ${MODEL} already present" /tmp/install-2nd.log \
+      || { echo "FAIL: 2nd run did not report '${MODEL} already present' — idempotency hole (the local-LLM step should detect-first-skip)"; exit 1; }; \
+    if grep -qF "pulling ${MODEL}" /tmp/install-2nd.log || grep -qF "pulling manifest" /tmp/install-2nd.log; then \
+      echo "FAIL: 2nd run RE-PULLED the model — caching/idempotency regression (a re-run must reuse the on-disk model)"; exit 1; \
+    fi; \
+    echo "OK: 2nd run idempotent — ${MODEL} already present, zero re-pull"

--- a/tools/ci/dockerfiles/ubuntu-install-sh-test/Dockerfile
+++ b/tools/ci/dockerfiles/ubuntu-install-sh-test/Dockerfile
@@ -61,7 +61,7 @@ RUN set -eu; \
     bun tools/accelerator/validate-local-llm.ts --root "$PWD"
 
 # Idempotency / 2nd-run assert (operator 2026-05-31: "like our mac installs
-# homebrew ... the windows should be the same indepotent install/update everything
+# homebrew ... the windows should be the same idempotent install/update everything
 # ... a 2nd run should not redo everything, it should efficiently just update
 # what's needed and no more"). A re-run on an already-provisioned machine must NOT
 # redo work — in particular it must NOT re-pull the 398MB model (the exact caching
@@ -71,11 +71,22 @@ RUN set -eu; \
 # (model already-present + zero re-pull), it does not merely tolerate a no-op.
 # The DAEMON doesn't persist across layers, so install.sh's local-LLM step starts
 # its own `ollama serve` and reads the model from the persisted disk layer.
+#
+# Capture install.sh's exit status EXPLICITLY (Copilot review on PR #6240): a
+# `install.sh | tee log` pipeline would take `tee`'s exit code, so a non-zero
+# install.sh after the expected strings would still read green (a false-green hole
+# in this very shield). ubuntu's /bin/sh is dash (no `set -o pipefail`), so don't
+# pipe — redirect to the log, gate on `install.sh`'s own status via `if !`, then
+# `cat` the log for CI visibility + the asserts.
 RUN set -eu; \
     export PATH="/root/.local/bin:$PATH"; \
     MODEL="$(grep -E '^model' tools/setup/manifests/local-llm | awk '{print $2}')"; \
     echo "=== 2nd install.sh run (idempotency) ==="; \
-    ./tools/setup/install.sh 2>&1 | tee /tmp/install-2nd.log; \
+    if ! ./tools/setup/install.sh > /tmp/install-2nd.log 2>&1; then \
+      cat /tmp/install-2nd.log; \
+      echo "FAIL: 2nd install.sh run exited non-zero (a re-run must succeed cleanly)"; exit 1; \
+    fi; \
+    cat /tmp/install-2nd.log; \
     echo "=== idempotency asserts ==="; \
     grep -qF "local-llm model ${MODEL} already present" /tmp/install-2nd.log \
       || { echo "FAIL: 2nd run did not report '${MODEL} already present' — idempotency hole (the local-LLM step should detect-first-skip)"; exit 1; }; \


### PR DESCRIPTION
## Why

Operator 2026-05-31: *"like our mac installs homebrew package manager … the windows should be the same indepotent install/update everything even from fresh machine state. … we want to test initial install AND 2nd run to look for issues with 2nd run / idempotent updates and caching issues — it should not redo everything, it should efficiently just update what's needed and no more."*

## Finding

**None of the 4 install shields run install twice.** `docker-ubuntu`, `docker-nixos`, `docker-windows`, and `wsl` each prove a *fresh* machine provisions — none prove a *re-run* is efficient. (Checked `../SQLSharp` too, per Aaron's pointer — no dedicated idempotency test there either; the only hits were `references/upstreams/` mirror noise. Aaron's memory was approximate.)

## What

Proof-of-pattern on the **ubuntu shield** — the cleanest "build IS the test" vehicle, already asserting the local-LLM primitive. Adds a **second `install.sh` run** on the state the 1st `RUN` left (tools installed + model on disk), then **asserts the idempotency signals**:

- the local-LLM step reports **`<model> already present`** (detect-first-skip), **and**
- it does **NOT** re-pull — no `pulling <model>` / `pulling manifest` — the exact **398MB caching regression** the operator named.

Per `automated-tests-are-the-shield-assert-dont-skip.md`: the test **asserts the positive** (already-present + zero re-pull), it does not merely tolerate a no-op. A 2nd run that silently re-pulled 400MB would **fail the build**.

## Verification

- Assert logic validated locally against 4 synthetic logs: idempotent → PASS; missing-signal / re-pulled / ollama-internal-pull → FAIL.
- The 40-min docker build runs in CI — this PR triggers the `docker-ubuntu-install-sh-test` shield via the `tools/ci/dockerfiles/**` path-gate. **This is the high-information run**: if `install.sh` isn't actually idempotent somewhere, the 2nd run surfaces it here (which is the point).

## Follow-up (offered, not in this PR)

Replicate the pattern to the other 3 shields once this template is validated green:
- **wsl** — direct 2nd `install.sh` invocation + same grep assert (easy).
- **nixos** — via its TS driver (different mechanics).
- **windows** — 2nd `install.ps1` run; pairs with #6239's now-idempotent ollama step (`ollama list` skip + no re-pull).

🤖 Generated with [Claude Code](https://claude.com/claude-code)