### PR TITLE
fix(setup): make Windows ollama install best-effort (optional) — unbreaks docker-windows shield (B-0857)

### DIFF
--- a/tools/setup/install.ps1
+++ b/tools/setup/install.ps1
@@ -51,8 +51,8 @@ function Invoke-Tool {
   if ($LASTEXITCODE -ne 0) { throw "$What failed (exit $LASTEXITCODE)" }
 }
 # Best-effort native call: surface merged output, return the exit code, NEVER throw -- for GRACEFUL
-# steps that must not brick install (e.g. the local-LLM pull). Mirrors common/local-llm.sh's
-# warn-and-continue discipline (exceptions-as-signals: the model is best-effort substrate).
+# steps that must not brick install (e.g. the local-LLM pull + `optional` manifest tools). Mirrors
+# common/local-llm.sh's warn-and-continue discipline (exceptions-as-signals: best-effort substrate).
 function Invoke-ToolSoft {
   param([Parameter(Mandatory)][scriptblock]$Cmd)
   $prev = $ErrorActionPreference
@@ -138,6 +138,15 @@ if (Have choco) { Write-Host "choco: $(Get-ToolVersion { choco --version })" }
 #    trims (parity with the awk in macos.sh's brew-manifest loop). Each `scoop install` /
 #    `winget install` / `choco install` is itself detect-first (no-op when already present), so a
 #    re-run only fetches what's missing/stale -- the idempotent-update property.
+#
+#    A line may carry the `optional` token => BEST-EFFORT install (warn + continue on failure,
+#    NEVER throw). This mirrors Linux's common/local-llm.sh, which installs the ollama BINARY
+#    gracefully (a download/extract/disk failure warns + continues -- the local-LLM model is
+#    best-effort substrate, not a hard dep). ollama is `optional` so a disk-constrained CI
+#    container (e.g. the Server Core docker-windows shield, where the ~1GB ollama download can
+#    exhaust the sandbox disk -- run 86a365916) does NOT brick the whole install: a real desktop
+#    has room and installs it; the constrained container warns + the toolchain still provisions.
+#    Required tools (e.g. git, no `optional` token) still throw on failure.
 $manifest = Join-Path $RepoRoot 'tools\setup\manifests\windows'
 foreach ($raw in Get-Content $manifest) {
   $line = ($raw -replace '#.*$', '').Trim(); if (-not $line) { continue }
@@ -145,13 +154,25 @@ foreach ($raw in Get-Content $manifest) {
   $scoopId = $parts[0]
   $winget = ($parts | Where-Object { $_ -like 'winget=*' }) -replace 'winget=', ''
   $choco = ($parts | Where-Object { $_ -like 'choco=*' }) -replace 'choco=', ''
+  $optional = $parts -contains 'optional'             # best-effort: warn, never throw
   $wid = if ($winget) { $winget } else { $scoopId }   # if/else (5.1-safe; NOT the 7+ ?: ternary)
   $cid = if ($choco) { $choco } else { $scoopId }
-  Write-Host "down $scoopId (scoop -> winget -> choco)"
-  if ($(Have scoop)) { Invoke-Tool { scoop install $scoopId } "scoop install $scoopId" }
-  elseif ($(Have winget)) { Invoke-Tool { winget install --id $wid --silent --accept-package-agreements --accept-source-agreements } "winget install $wid" }
-  elseif ($(Have choco)) { Invoke-Tool { choco install $cid -y } "choco install $cid" }
-  else { throw "no package source (scoop/winget/choco) available for $scoopId" }
+  # Pick the first available source's command + label (scoop -> winget -> choco).
+  $cmd = $null; $what = $null
+  if     ($(Have scoop))  { $cmd = { scoop install $scoopId }; $what = "scoop install $scoopId" }
+  elseif ($(Have winget)) { $cmd = { winget install --id $wid --silent --accept-package-agreements --accept-source-agreements }; $what = "winget install $wid" }
+  elseif ($(Have choco))  { $cmd = { choco install $cid -y }; $what = "choco install $cid" }
+  Write-Host "down $scoopId (scoop -> winget -> choco)$(if ($optional) { ' [optional/best-effort]' } else { '' })"
+  if ($null -eq $cmd) {
+    if ($optional) { Write-Host "warn: no package source (scoop/winget/choco) for optional '$scoopId'; skipping (best-effort)"; continue }
+    throw "no package source (scoop/winget/choco) available for $scoopId"
+  }
+  if ($optional) {
+    $code = Invoke-ToolSoft $cmd
+    if ($code -ne 0) { Write-Host "warn: optional '$scoopId' install failed (exit $code); continuing (best-effort substrate -- e.g. disk-constrained CI; real desktops have room)" }
+  } else {
+    Invoke-Tool $cmd $what
+  }
 }
 
 # 3. mise (runtime manager) via scoop -- mirrors macos.sh step 4 (brew install mise).
@@ -168,9 +189,10 @@ try {
 # 5. claude-code via bun --global (bun provided by mise) -- identical to Unix.
 Invoke-Tool { mise exec -- bun install --global '@anthropic-ai/claude-code' } 'bun install -g claude-code'
 
-# 6. local-LLM core primitive -- pull the pinned model (the ollama BINARY was installed by the
-#    manifest loop in step 2, since `ollama` is now in manifests/windows). Mirrors
-#    common/local-llm.sh: idempotent (skip when the model is already present) + GRACEFUL (a
+# 6. local-LLM core primitive -- pull the pinned model (the ollama BINARY is installed by the
+#    manifest loop in step 2; ollama is `optional` there, so on a disk-constrained container it may
+#    be ABSENT -- this step already handles that gracefully via the `-not (Have ollama)` branch).
+#    Mirrors common/local-llm.sh: idempotent (skip when the model is already present) + GRACEFUL (a
 #    registry/network/daemon failure WARNS and continues -- it must NEVER brick install; the
 #    primitive's tests skip-if-absent -> mock-only, per exceptions-as-signals). Reads model/host
 #    from manifests/local-llm (the OS-agnostic shared contract Unix reads too).
@@ -191,7 +213,7 @@ if (Test-Path $llmManifest) {
   if (-not $model) {
     Write-Host "warn: local-llm manifest has no 'model'; skipping local-LLM pull"
   } elseif (-not (Have ollama)) {
-    Write-Host "warn: ollama not on PATH after the manifest step; skipping local-LLM (tests fall back to mock)"
+    Write-Host "warn: ollama not on PATH after the manifest step (optional; may be disk-skipped in CI); skipping local-LLM (tests fall back to mock)"
   } else {
     if (-not (Test-OllamaUp -Base $llmHost)) {
       Write-Host "down starting ollama serve (background)..."

--- a/tools/setup/manifests/windows
+++ b/tools/setup/manifests/windows
@@ -1,7 +1,10 @@
 # tools/setup/manifests/windows — declarative Windows system CLI tools.
 # Resolver priority (operator 2026-05-30): scoop -> winget -> chocolatey. scoop is primary
-# (user-mode, no admin, AI-native). Format per line:  <scoop-id> [winget=<id>] [choco=<id>]
-# winget/choco overrides are optional (default to <scoop-id>). `#` comments + blank lines ignored.
+# (user-mode, no admin, AI-native). Format per line:  <scoop-id> [winget=<id>] [choco=<id>] [optional]
+# winget/choco overrides are optional (default to <scoop-id>). The bare `optional` token marks a
+# BEST-EFFORT tool: install.ps1 warns + continues on failure instead of throwing (for substrate
+# that must never brick the whole install — mirrors Linux's graceful common/local-llm.sh). `#`
+# comments + blank lines ignored.
 #
 # KEEP MINIMAL + symmetric with manifests/apt + manifests/brew. Cross-platform tools belong in
 # .mise.toml (mise) or install via bun/dotnet/uv — NOT here. Only tools that no cross-platform
@@ -20,4 +23,11 @@ git    winget=Git.Git    choco=git
 # classifier + DST fixtures. The pinned MODEL (manifests/local-llm) is pulled by install.ps1's
 # local-LLM step, mirroring common/local-llm.sh. Pins per dep-pin-search-first (verified
 # 2026-05-31): scoop main bucket `ollama` 0.20.7 | winget `Ollama.Ollama` 0.24.0 | choco `ollama`.
-ollama    winget=Ollama.Ollama    choco=ollama
+#
+# `optional` (BEST-EFFORT): the ~1GB ollama download can exhaust a disk-constrained CI container's
+# sandbox (the Server Core docker-windows shield — run 86a365916 died on "not enough space on
+# disk"). Marking it optional means install.ps1 warns + continues there (the toolchain still
+# provisions; the local-LLM step then no-ops gracefully), while a real desktop with disk installs
+# it normally. This matches Linux: common/local-llm.sh installs the ollama binary gracefully too
+# (the local-LLM model is best-effort substrate, never a hard dep).
+ollama    winget=Ollama.Ollama    choco=ollama    optional


### PR DESCRIPTION
## Why (fix-forward — option A)

The docker-windows shield went **red on the #6239 merge** (`86a365916`): `scoop install ollama` died with **"not enough space on disk"** — the ~1 GB ollama download exhausts the Server Core CI container's sandbox disk. Pre-#6239 baseline was green.

**Root cause = a cross-OS inconsistency #6239 introduced:** Linux's `common/local-llm.sh` installs the ollama **binary gracefully** (download/extract/disk failure → warn + continue; the local-LLM model is best-effort substrate). But #6239 put ollama in the **hard Windows manifest loop** (`Invoke-Tool` throws), making it a hard dep that bricks the whole install in a constrained container.

## What

Operator-picked **option A**: add an `optional` manifest token = **best-effort** install (warn + continue, never throw), and mark `ollama optional`.

- **install.ps1** — manifest loop parses `optional`; optional tools use `Invoke-ToolSoft` (warn on non-zero) instead of `Invoke-Tool` (throw). **Required tools (git) still throw.** Refactored to pick the source command once (scoop→winget→choco), then branch optional-vs-required.
- **manifests/windows** — `ollama … optional` + documented the token and the disk rationale; updated the format-doc line.
- **step 6 (model pull)** already no-ops gracefully when ollama is absent (`-not (Have ollama)` branch) — composes cleanly.

Now **consistent cross-OS**: ollama is best-effort *everywhere*. Real desktops install it; disk-constrained CI containers warn + still provision the toolchain. The docker-windows shield validates the **toolchain**; ollama-on-Windows is validated on the real desktop.

## Verification

- PS language-parser parse OK (0 errors); `manifest-symmetry` test 3 pass.
- Parse sim on the actual manifest: `git` → required (throws), `ollama` → optional (warns), winget/choco overrides clean.

## Follow-up (option B, separate)

If we want ollama **asserted** on Windows-CI specifically, engineer container disk headroom (repoint Docker `data-root` to a larger runner drive / free space — *local* disk, not an external mount). Exploring feasibility separately; not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)