### PR TITLE
feat(observe): event-sourcing fold/replay — the algebra foundation (v5)

### DIFF
--- a/tools/observe/observe.test.ts
+++ b/tools/observe/observe.test.ts
@@ -18,6 +18,8 @@ import {
   buildMenu,
   simulate,
   runLoop,
+  fold,
+  replay,
   type BacklogItem,
   type World,
   type OperatorChannel,
@@ -356,5 +358,60 @@ describe("the loop — real local LLM (ollama) when reachable; the mock loop abo
     expect(Array.isArray(finalWorld.backlog)).toBe(true); // simulate produced well-formed worlds
     // termination-to-fixed-point is NOT asserted: a free agent may legitimately
     // oscillate among free modes — freedom is the point, not forced draining.
+  });
+});
+
+describe("fold — event-sourcing projection (state is a projection of the event log)", () => {
+  it("empty log → the initial world unchanged", () => {
+    const initial = w([item("B-1", true, false)]);
+    expect(fold(initial, [])).toEqual(initial);
+  });
+
+  it("fold == nested simulate (left-fold over the reducer)", () => {
+    const initial = w([item("B-ready", true, false)], op(true, false));
+    const events: NextAction[] = [
+      { kind: "respond_to_operator", reason: "x" },
+      { kind: "play", reason: "x" },
+    ];
+    expect(fold(initial, events)).toEqual(simulate(simulate(initial, events[0]!), events[1]!));
+  });
+
+  it("THE event-sourcing property: the loop's event log folds back to the loop's final state", async () => {
+    // the event log (trace) is the source of truth; the World is its projection.
+    const initial = w(
+      [item("B-ready", true, false), item("B-amb", false, true), item("B-x", false, false, true)],
+      op(true, true),
+    );
+    const { trace, finalWorld } = await runLoop(initial, mock("0"), 30);
+    expect(fold(initial, trace)).toEqual(finalWorld); // replaying the log reconstructs the state
+  });
+
+  it("fold is deterministic — same log over same initial → same state (DST/replay)", () => {
+    const initial = w([item("B-amb", false, true)]);
+    const events: NextAction[] = [
+      { kind: "decompose", item: item("B-amb", false, true) },
+      { kind: "play", reason: "x" },
+    ];
+    expect(fold(initial, events)).toEqual(fold(initial, events));
+  });
+
+  it("fold does not mutate the initial world (pure projection)", () => {
+    const initial = w([item("B-1", true, false)]);
+    const snapshot = JSON.stringify(initial);
+    fold(initial, [{ kind: "do_item", item: item("B-1", true, false) }, { kind: "explore", reason: "x" }]);
+    expect(JSON.stringify(initial)).toBe(snapshot);
+  });
+
+  it("replay returns the projected state after each event; last == fold", () => {
+    const initial = w([item("B-1", true, false)]);
+    const events: NextAction[] = [
+      { kind: "play", reason: "x" },
+      { kind: "free_time", reason: "x" },
+    ];
+    const states = replay(initial, events);
+    expect(states.length).toBe(events.length);
+    expect(states[0]?.mode).toBe("play"); // projection after event 1
+    expect(states[1]?.mode).toBe("free_time"); // projection after event 2
+    expect(states[states.length - 1]).toEqual(fold(initial, events)); // last replay state == fold
   });
 });

--- a/tools/observe/observe.ts
+++ b/tools/observe/observe.ts
@@ -511,6 +511,38 @@ export async function runLoop(
   return { trace, finalWorld: current, steadyState: false };
 }
 
+// ─── v5: event-sourcing fold — state is a PROJECTION of the event log ──────────
+//
+// The algebra foundation (operator 2026-05-31: "the algebra foundation will be
+// very good to ground everything else"). The borrow, per the four-ferry critique
+// (Elm `Msg`/`update` ≈ Redux action+reducer ≈ event-sourcing/CQRS): a
+// `NextAction[]` IS the event log; `simulate` IS the reducer; the `World` is the
+// DERIVED state. `fold` replays the log → the state projection. "History is a
+// list of events; state is a projection of that log." Deterministic (DST): the
+// same log over the same initial world yields the same state, replayable. This is
+// the ledger/projection split (git-native events = ledger; everything else tails
+// it) at the in-memory layer — and the substrate GrammarPatch events (B-0867.26)
+// will live in.
+
+/** Project state from an event log: left-fold the actions over `simulate`.
+ *  `fold(w0, [])` === `w0`; `fold(w0, [a,b]) === simulate(simulate(w0, a), b)`. Pure. */
+export function fold(initial: World, events: readonly NextAction[]): World {
+  return events.reduce((world, action) => simulate(world, action), initial);
+}
+
+/** The trajectory: the projected state AFTER each event (initial excluded). One
+ *  entry per event — the projection at each point in the log (time-travel /
+ *  Redux-DevTools-style). The last entry equals `fold(initial, events)`. */
+export function replay(initial: World, events: readonly NextAction[]): World[] {
+  const states: World[] = [];
+  let world = initial;
+  for (const action of events) {
+    world = simulate(world, action);
+    states.push(world);
+  }
+  return states;
+}
+
 // ─── runnable demo (foreground loop): walk a few sample world states ──────────
 if (import.meta.main) {
   const samples: ReadonlyArray<{ label: string; world: World }> = [


### PR DESCRIPTION
## What

First build slice toward the full actions (operator 2026-05-31: *"the algebra foundation will be very good to ground everything else"*) — in the `tools/observe` prototype (proves the borrowed shape; folds into Max's keystone later).

**The borrow** (Grok four-ferry critique; Elm `Msg`/`update` ≈ Redux action+reducer ≈ event-sourcing/CQRS): a `NextAction[]` IS the event log; `simulate` IS the reducer; `World` is the **derived** state.

- **`fold(initial, events)`** — left-fold the actions over `simulate` → the state projection. *"History is a list of events; state is a projection of that log."*
- **`replay(initial, events)`** — the projected state after each event (time-travel / Redux-DevTools-style); last == `fold`.

This is the ledger/projection split (git-native events = ledger, everything tails it) at the in-memory layer — and the substrate the **GrammarPatch** events (B-0867.26) will live in.

## Tests (+6 → 47 total, 0 fail, tsc 0)

- empty-log identity; `fold` == nested `simulate`
- **THE event-sourcing property:** the loop's event log folds back to its final state (the log is the source of truth)
- DST replay-determinism (same log → same state)
- purity (no mutation of initial)
- `replay` per-event projections

Pure addition (no behavior change to observe/simulate/runLoop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)