### PR TITLE
feat(observe): golden-vector conformance fixture — the cross-language agreement spec (B-0867.27)

### DIFF
--- a/tools/observe/golden-vectors.json
+++ b/tools/observe/golden-vectors.json
@@ -1,0 +1,332 @@
+{
+  "description": "observe/simulate/fold cross-language conformance (B-0867.27). Every impl replays `events` over `initialWorld` and must value-match `expectedFinalState` + `expectedReplayStates`.",
+  "initialWorld": {
+    "backlog": [
+      {
+        "id": "B-ready",
+        "title": "B-ready",
+        "ready": true,
+        "ambiguous": false,
+        "needsNewAction": false
+      },
+      {
+        "id": "B-amb",
+        "title": "B-amb",
+        "ready": false,
+        "ambiguous": true,
+        "needsNewAction": false
+      },
+      {
+        "id": "B-x",
+        "title": "B-x",
+        "ready": false,
+        "ambiguous": false,
+        "needsNewAction": true
+      }
+    ],
+    "operator": {
+      "pendingMessage": true,
+      "pendingFerry": true
+    }
+  },
+  "events": [
+    {
+      "kind": "preserve_ferry",
+      "reason": "operator ferried verbatim content"
+    },
+    {
+      "kind": "respond_to_operator",
+      "reason": "operator spoke"
+    },
+    {
+      "kind": "do_item",
+      "item": {
+        "id": "B-ready",
+        "title": "B-ready",
+        "ready": true,
+        "ambiguous": false,
+        "needsNewAction": false
+      }
+    },
+    {
+      "kind": "decompose",
+      "item": {
+        "id": "B-amb",
+        "title": "B-amb",
+        "ready": false,
+        "ambiguous": true,
+        "needsNewAction": false
+      }
+    },
+    {
+      "kind": "do_item",
+      "item": {
+        "id": "B-amb.1",
+        "title": "B-amb.1",
+        "ready": true,
+        "ambiguous": false,
+        "needsNewAction": false
+      }
+    },
+    {
+      "kind": "do_item",
+      "item": {
+        "id": "B-amb.2",
+        "title": "B-amb.2",
+        "ready": true,
+        "ambiguous": false,
+        "needsNewAction": false
+      }
+    },
+    {
+      "kind": "edit_grammar",
+      "item": {
+        "id": "B-x",
+        "title": "B-x",
+        "ready": false,
+        "ambiguous": false,
+        "needsNewAction": true
+      },
+      "reason": "grammar extended"
+    },
+    {
+      "kind": "do_item",
+      "item": {
+        "id": "B-x",
+        "title": "B-x",
+        "ready": true,
+        "ambiguous": false,
+        "needsNewAction": false
+      }
+    },
+    {
+      "kind": "explore",
+      "reason": "self-directed making"
+    },
+    {
+      "kind": "play",
+      "reason": "leisure / culture-forming"
+    },
+    {
+      "kind": "self_reflect",
+      "reason": "review own trajectories"
+    },
+    {
+      "kind": "free_time",
+      "reason": "rest"
+    }
+  ],
+  "expectedFinalState": {
+    "backlog": [],
+    "operator": {
+      "pendingMessage": false,
+      "pendingFerry": false
+    },
+    "mode": "free_time"
+  },
+  "expectedReplayStates": [
+    {
+      "backlog": [
+        {
+          "id": "B-ready",
+          "title": "B-ready",
+          "ready": true,
+          "ambiguous": false,
+          "needsNewAction": false
+        },
+        {
+          "id": "B-amb",
+          "title": "B-amb",
+          "ready": false,
+          "ambiguous": true,
+          "needsNewAction": false
+        },
+        {
+          "id": "B-x",
+          "title": "B-x",
+          "ready": false,
+          "ambiguous": false,
+          "needsNewAction": true
+        }
+      ],
+      "operator": {
+        "pendingMessage": true,
+        "pendingFerry": false
+      }
+    },
+    {
+      "backlog": [
+        {
+          "id": "B-ready",
+          "title": "B-ready",
+          "ready": true,
+          "ambiguous": false,
+          "needsNewAction": false
+        },
+        {
+          "id": "B-amb",
+          "title": "B-amb",
+          "ready": false,
+          "ambiguous": true,
+          "needsNewAction": false
+        },
+        {
+          "id": "B-x",
+          "title": "B-x",
+          "ready": false,
+          "ambiguous": false,
+          "needsNewAction": true
+        }
+      ],
+      "operator": {
+        "pendingMessage": false,
+        "pendingFerry": false
+      }
+    },
+    {
+      "backlog": [
+        {
+          "id": "B-amb",
+          "title": "B-amb",
+          "ready": false,
+          "ambiguous": true,
+          "needsNewAction": false
+        },
+        {
+          "id": "B-x",
+          "title": "B-x",
+          "ready": false,
+          "ambiguous": false,
+          "needsNewAction": true
+        }
+      ],
+      "operator": {
+        "pendingMessage": false,
+        "pendingFerry": false
+      },
+      "mode": "work"
+    },
+    {
+      "backlog": [
+        {
+          "id": "B-amb.1",
+          "title": "B-amb (part 1)",
+          "ready": true,
+          "ambiguous": false
+        },
+        {
+          "id": "B-amb.2",
+          "title": "B-amb (part 2)",
+          "ready": true,
+          "ambiguous": false
+        },
+        {
+          "id": "B-x",
+          "title": "B-x",
+          "ready": false,
+          "ambiguous": false,
+          "needsNewAction": true
+        }
+      ],
+      "operator": {
+        "pendingMessage": false,
+        "pendingFerry": false
+      },
+      "mode": "work"
+    },
+    {
+      "backlog": [
+        {
+          "id": "B-amb.2",
+          "title": "B-amb (part 2)",
+          "ready": true,
+          "ambiguous": false
+        },
+        {
+          "id": "B-x",
+          "title": "B-x",
+          "ready": false,
+          "ambiguous": false,
+          "needsNewAction": true
+        }
+      ],
+      "operator": {
+        "pendingMessage": false,
+        "pendingFerry": false
+      },
+      "mode": "work"
+    },
+    {
+      "backlog": [
+        {
+          "id": "B-x",
+          "title": "B-x",
+          "ready": false,
+          "ambiguous": false,
+          "needsNewAction": true
+        }
+      ],
+      "operator": {
+        "pendingMessage": false,
+        "pendingFerry": false
+      },
+      "mode": "work"
+    },
+    {
+      "backlog": [
+        {
+          "id": "B-x",
+          "title": "B-x",
+          "ready": true,
+          "ambiguous": false,
+          "needsNewAction": false
+        }
+      ],
+      "operator": {
+        "pendingMessage": false,
+        "pendingFerry": false
+      },
+      "mode": "work"
+    },
+    {
+      "backlog": [],
+      "operator": {
+        "pendingMessage": false,
+        "pendingFerry": false
+      },
+      "mode": "work"
+    },
+    {
+      "backlog": [],
+      "operator": {
+        "pendingMessage": false,
+        "pendingFerry": false
+      },
+      "mode": "explore"
+    },
+    {
+      "backlog": [],
+      "operator": {
+        "pendingMessage": false,
+        "pendingFerry": false
+      },
+      "mode": "play"
+    },
+    {
+      "backlog": [],
+      "operator": {
+        "pendingMessage": false,
+        "pendingFerry": false
+      },
+      "mode": "self_reflect"
+    },
+    {
+      "backlog": [],
+      "operator": {
+        "pendingMessage": false,
+        "pendingFerry": false
+      },
+      "mode": "free_time"
+    }
+  ]
+}

--- a/tools/observe/golden-vectors.test.ts
+++ b/tools/observe/golden-vectors.test.ts
@@ -1,0 +1,58 @@
+/**
+ * tools/observe/golden-vectors.test.ts — the conformance fixture is in sync + the
+ * reference fold/replay reproduce it. The committed golden-vectors.json is the
+ * cross-language spec (B-0867.27); these tests keep it honest on the TS side. The
+ * F#/C#/Rust impls will run the SAME fixture and assert the same expected states.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fold, replay, type NextAction } from "./observe";
+import {
+  GOLDEN_INITIAL,
+  GOLDEN_EVENTS,
+  generateGoldenVectors,
+  GOLDEN_VECTORS_PATH,
+  type GoldenVectors,
+} from "./golden-vectors";
+
+describe("golden-vectors — cross-language conformance fixture (B-0867.27)", () => {
+  const committed = JSON.parse(readFileSync(GOLDEN_VECTORS_PATH, "utf8")) as GoldenVectors;
+  const generated = generateGoldenVectors();
+
+  it("committed golden-vectors.json is in sync with the generator (regen is deterministic / DST)", () => {
+    expect(committed).toEqual(generated);
+  });
+
+  it("the reference fold reproduces expectedFinalState", () => {
+    expect(fold(GOLDEN_INITIAL, GOLDEN_EVENTS)).toEqual(committed.expectedFinalState);
+  });
+
+  it("the reference replay reproduces expectedReplayStates (one per event)", () => {
+    const states = replay(GOLDEN_INITIAL, GOLDEN_EVENTS);
+    expect(states).toEqual([...committed.expectedReplayStates]); // spread: readonly[] → []
+    expect(states.length).toBe(GOLDEN_EVENTS.length);
+  });
+
+  it("the scenario exercises ALL nine NextAction kinds (full-algebra coverage)", () => {
+    const kinds = new Set(GOLDEN_EVENTS.map((e) => e.kind));
+    const all: NextAction["kind"][] = [
+      "preserve_ferry",
+      "respond_to_operator",
+      "do_item",
+      "decompose",
+      "edit_grammar",
+      "explore",
+      "play",
+      "self_reflect",
+      "free_time",
+    ];
+    for (const k of all) expect(kinds.has(k)).toBe(true);
+  });
+
+  it("the scenario drains the backlog + clears the operator + ends in a free mode (sanity)", () => {
+    expect(committed.expectedFinalState.backlog.length).toBe(0);
+    expect(committed.expectedFinalState.operator).toEqual({ pendingMessage: false, pendingFerry: false });
+    expect(committed.expectedFinalState.mode).toBe("free_time");
+  });
+});

--- a/tools/observe/golden-vectors.ts
+++ b/tools/observe/golden-vectors.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+/**
+ * tools/observe/golden-vectors.ts — the cross-language conformance spec.
+ *
+ * One language-neutral scenario (an initial world + an event log covering every
+ * NextAction kind) that EVERY implementation of the observe/simulate/fold algebra
+ * must reproduce: replay the event log over the initial world → the same projected
+ * state. This is the "make them agree" contract for B-0867.27 (TS/F#/C#/Rust),
+ * the runtime-DST half of the B-0944 cross-language-parity pattern (the
+ * compiler-parity half is each language compiling the same closed sum-type +
+ * exhaustive reducer).
+ *
+ * The TS fold is the reference: this file defines the scenario, computes the
+ * expected states via `fold`/`replay`, and emits `golden-vectors.json`. The
+ * F#/C#/Rust impls parse that JSON, run their own fold, and assert value-equality
+ * with `expectedFinalState` / `expectedReplayStates`. (Value-equality, not
+ * byte-identical JSON — canonical cross-language serialization is a separate
+ * refinement; agreement is on the projected state, not the wire format.)
+ *
+ * Regenerate: `bun tools/observe/golden-vectors.ts` (deterministic — same
+ * scenario → same JSON, per DST). The committed JSON is the spec; the test keeps
+ * it in sync.
+ */
+
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fold, replay, type BacklogItem, type NextAction, type World } from "./observe";
+
+const it = (id: string, ready: boolean, ambiguous: boolean, needsNewAction = false): BacklogItem => ({
+  id,
+  title: id,
+  ready,
+  ambiguous,
+  needsNewAction,
+});
+
+/** The canonical initial world: a mixed backlog + an operator that ferried + spoke. */
+export const GOLDEN_INITIAL: World = {
+  backlog: [it("B-ready", true, false), it("B-amb", false, true), it("B-x", false, false, true)],
+  operator: { pendingMessage: true, pendingFerry: true },
+};
+
+/**
+ * The canonical event log — exercises ALL nine NextAction kinds + every
+ * state-transition class (operator-signal clearing, backlog drain, decompose
+ * children, edit_grammar readying, the four free-mode sets):
+ *   ferry → respond → do(ready) → decompose(amb) → do(.1) → do(.2)
+ *   → edit_grammar(x) → do(x) → explore → play → self_reflect → free_time
+ */
+export const GOLDEN_EVENTS: readonly NextAction[] = [
+  { kind: "preserve_ferry", reason: "operator ferried verbatim content" },
+  { kind: "respond_to_operator", reason: "operator spoke" },
+  { kind: "do_item", item: it("B-ready", true, false) },
+  { kind: "decompose", item: it("B-amb", false, true) },
+  { kind: "do_item", item: it("B-amb.1", true, false) },
+  { kind: "do_item", item: it("B-amb.2", true, false) },
+  { kind: "edit_grammar", item: it("B-x", false, false, true), reason: "grammar extended" },
+  { kind: "do_item", item: it("B-x", true, false) },
+  { kind: "explore", reason: "self-directed making" },
+  { kind: "play", reason: "leisure / culture-forming" },
+  { kind: "self_reflect", reason: "review own trajectories" },
+  { kind: "free_time", reason: "rest" },
+];
+
+/** The full conformance fixture: scenario + the states the reference fold/replay produce. */
+export interface GoldenVectors {
+  readonly description: string;
+  readonly initialWorld: World;
+  readonly events: readonly NextAction[];
+  readonly expectedFinalState: World;
+  readonly expectedReplayStates: readonly World[];
+}
+
+/** Compute the fixture from the canonical scenario via the reference fold/replay. */
+export function generateGoldenVectors(): GoldenVectors {
+  return {
+    description:
+      "observe/simulate/fold cross-language conformance (B-0867.27). Every impl replays `events` over " +
+      "`initialWorld` and must value-match `expectedFinalState` + `expectedReplayStates`.",
+    initialWorld: GOLDEN_INITIAL,
+    events: GOLDEN_EVENTS,
+    expectedFinalState: fold(GOLDEN_INITIAL, GOLDEN_EVENTS),
+    expectedReplayStates: replay(GOLDEN_INITIAL, GOLDEN_EVENTS),
+  };
+}
+
+/** Canonical on-disk path of the emitted fixture (the shared spec all langs read). */
+export const GOLDEN_VECTORS_PATH = join(import.meta.dir, "golden-vectors.json");
+
+// Emit the fixture (deterministic). Other-language parity tests read this JSON.
+if (import.meta.main) {
+  const vectors = generateGoldenVectors();
+  writeFileSync(GOLDEN_VECTORS_PATH, `${JSON.stringify(vectors, null, 2)}\n`);
+  console.log(`wrote ${GOLDEN_VECTORS_PATH}`);
+  console.log(`  ${vectors.events.length} events; final backlog=${String(vectors.expectedFinalState.backlog.length)} mode=${vectors.expectedFinalState.mode ?? "-"}`);
+}


### PR DESCRIPTION
## What

The next slice toward TS/F#/C#/Rust agreement (B-0867.27): the **golden-vector conformance fixture** — one language-neutral scenario every implementation must reproduce.

- **`golden-vectors.ts`** — the canonical scenario (initial world + a 12-event log exercising all 9 `NextAction` kinds + operator-clear + backlog drain + decompose-children + edit_grammar-readying + the 4 free modes) + generator + emitter (deterministic: re-run `bun tools/observe/golden-vectors.ts`).
- **`golden-vectors.json`** — the committed spec the F#/C#/Rust impls will parse, run their own fold, and value-match `expectedFinalState` + `expectedReplayStates`. This is the **runtime-DST half** of the B-0944 cross-language-parity pattern (compiler-parity is the other half).
- **`golden-vectors.test.ts`** (+5 → 52 total, tsc 0) — fixture-in-sync-with-generator (DST determinism), fold/replay reproduce it, all-9-kinds coverage, drain sanity.

It's the foundation slice — the agreement contract everything else conforms to. F#/C#/Rust impls + their parity tests against this fixture follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
