### PR TITLE
feat(B-0867.28): observe-fold as an additive monoid (C# System.Numerics + F# native Zero/(+)) — additive-monoidal only

### DIFF
--- a/docs/backlog/P2/B-0867.28-observe-algebra-trifloat-system-numerics-generic-math-fsharp-uom-interface-gate-before-building-on-top-aaron-2026-05-31.md
+++ b/docs/backlog/P2/B-0867.28-observe-algebra-trifloat-system-numerics-generic-math-fsharp-uom-interface-gate-before-building-on-top-aaron-2026-05-31.md
@@ -87,17 +87,50 @@ deterministic), lock-free (pure ops), weight-free (explicit), DV2.0, idempotency
 idempotency/replay-safety substrate), alignment floor. UoM adds compile-time
 unit-safety (operational, checkable — not ceremony).
 
+## Decision (operator 2026-05-31): additive-monoidal ONLY, not `INumber<T>`
+
+Reading the code surfaced the real fork (it wasn't guessable from the spec):
+TriFloat is a tri-state, *held-capable*, shape-parameterized composite with a
+*partial* encode (`FromValue → EncodeResult`) and idempotent-`Cooperate` /
+non-idempotent-`Measure` ops. Full `System.Numerics` `INumber<T>` assumes total,
+deterministic, field-like arithmetic (`+`, `*`, `0`, `1`, total order) — a
+square-peg on a tri-boolean number. **Decision: implement only the additive-monoid
+interfaces (`IAdditiveIdentity` + `IAdditionOperators`), the exact structure the
+log/number has.** No multiplication, no ordering, no negatives invented.
+
 ## Acceptance
 
-- [ ] Target 1: TriFloat implements the chosen System.Numerics generic-math
-      interfaces + carries `[<Measure>]` units; dotnet build clean (0 warnings).
-- [ ] Target 2: observe-fold exposed as a monoid via generic-math additive
-      interfaces (identity = empty log; compose = associative event-append) + UoM
-      on the measurable quantities; the algebra interface is settled here.
-- [ ] Cross-language parity (B-0867.27 golden vectors) still green after the
-      interface change — the numerics+UoM shape did not break agreement.
-- [ ] Decision recorded: how much the interface changed (so B-0867.26 + the
-      build-on-top slices build on the final shape).
+- [ ] Target 1: TriFloat carries the additive-monoid interfaces (`IAdditiveIdentity`
+      + `IAdditionOperators`) — NOT full `INumber<T>` (decision above). Open.
+- [x] Target 2 (C#): observe-fold exposed as a monoid via `System.Numerics`
+      additive interfaces — `EventLog : IAdditiveIdentity<EventLog,EventLog>,
+      IAdditionOperators<EventLog,EventLog,EventLog>` (identity = empty log;
+      compose = associative append); `FoldOnto` is the monoid action /
+      homomorphism. `dotnet build -c Release` clean (0 warnings). **UoM: N/A for
+      the observe algebra** — the observe `World` carries no measurable numeric
+      quantity (only ids, flags, a mode), so `[<Measure>]` here would be ceremony,
+      not safety (load-bearing razor). UoM lives where measurable quantities do
+      (TriFloat values, the attention/tick/dora domain); the substrate already
+      exists in `src/Core/Units.fs`.
+- [x] Cross-language parity (B-0867.27 golden vectors) still green — 42/42 C# tests
+      pass incl. `GoldenVectorsTests`; the additive-monoid layer did not break
+      agreement.
+- [x] Decision recorded: **the interface did NOT change.** The monoid is a NEW
+      additive type (`EventLog`); `World` / `Algebra` / `NextAction` are untouched.
+      So the gate's worry ("may change the interface significantly") resolves
+      favorably — additive-monoid is a non-breaking *addition*; B-0867.26 +
+      build-on-top slices build on the unchanged algebra plus the new monoid layer.
+
+## Remaining
+
+- [ ] **F# observe-fold monoid**: F# lists are already the free monoid (`[]` / `@`),
+      so a generic-math-interface wrapper would be near-ceremony (and F# static-
+      abstract generic-math interop is awkward); decide whether the recognized-as-
+      monoid interface earns its keep in F# or the native free-monoid suffices.
+- [ ] **Target 1 (TriFloat additive-monoid)**: apply the additive-monoid decision
+      to TriFloat in C#/F# (define the additive identity + associative compose for
+      tri-floats — note `Cooperate`'s idempotence is the natural identity-leaning op
+      to reconcile).
 
 ## Why this is its own row (not folded into B-0867.27)
 

--- a/docs/backlog/P2/B-0867.28-observe-algebra-trifloat-system-numerics-generic-math-fsharp-uom-interface-gate-before-building-on-top-aaron-2026-05-31.md
+++ b/docs/backlog/P2/B-0867.28-observe-algebra-trifloat-system-numerics-generic-math-fsharp-uom-interface-gate-before-building-on-top-aaron-2026-05-31.md
@@ -123,10 +123,16 @@ log/number has.** No multiplication, no ordering, no negatives invented.
 
 ## Remaining
 
-- [ ] **F# observe-fold monoid**: F# lists are already the free monoid (`[]` / `@`),
-      so a generic-math-interface wrapper would be near-ceremony (and F# static-
-      abstract generic-math interop is awkward); decide whether the recognized-as-
-      monoid interface earns its keep in F# or the native free-monoid suffices.
+- [x] **F# observe-fold monoid** (operator 2026-05-31: "do the F# monoid too"):
+      `EventLog = { Events: NextAction list }` with `static member Zero` +
+      `static member (+)` + `FoldOnto` — expressed via F#'s **native** generic-math
+      convention (`Zero`/`(+)`, recognized by SRTP / `List.sum`), the F# parallel
+      to C#'s `System.Numerics` additive interfaces. Each language owns the
+      interface in its own idiom (transplanting C#'s IWSAM into F# would fight the
+      language + risk the FS3535 advisory under TreatWarningsAsErrors). 9/9 F#
+      Observe tests pass (6 monoid laws incl. homomorphism + 3 golden-vector
+      parity). F# records give structural equality natively, so no element-wise
+      compare needed.
 - [ ] **Target 1 (TriFloat additive-monoid)**: apply the additive-monoid decision
       to TriFloat in C#/F# (define the additive identity + associative compose for
       tri-floats — note `Cooperate`'s idempotence is the natural identity-leaning op

--- a/src/Core.CSharp.Observe/EventLog.cs
+++ b/src/Core.CSharp.Observe/EventLog.cs
@@ -33,11 +33,24 @@ namespace Zeta.Core.CSharp.Observe;
 /// safety; UoM lives where measurable quantities do (TriFloat values, the
 /// attention/tick/dora domain).</para>
 /// </summary>
-/// <param name="Events">The append-only event log (MSB-of-history first).</param>
-public sealed record EventLog(IReadOnlyList<NextAction> Events)
+public sealed record EventLog
     : IAdditiveIdentity<EventLog, EventLog>,
       IAdditionOperators<EventLog, EventLog, EventLog>
 {
+    /// <summary>The append-only event log (MSB-of-history first). Defensively
+    /// COPIED on construction (see the constructor) so a caller's later mutation of
+    /// a passed-in mutable list cannot change what <see cref="FoldOnto"/> replays
+    /// or what <c>+</c> appends — the free-monoid stability this type exists to
+    /// guarantee. (Record equality still compares this by reference; value
+    /// comparison uses <c>SequenceEqual</c>, per the tests.)</summary>
+    public IReadOnlyList<NextAction> Events { get; }
+
+    /// <summary>Construct a log, defensively copying <paramref name="events"/> into
+    /// a private read-only backing array — so the log is genuinely append-only and
+    /// immutable regardless of what the caller does with its argument afterward.</summary>
+    /// <param name="events">The events to copy into this log.</param>
+    public EventLog(IReadOnlyList<NextAction> events) => Events = events.ToArray();
+
     /// <summary>The empty log — the monoid identity. <c>empty + x == x == x + empty</c>.</summary>
     public static EventLog AdditiveIdentity { get; } = new(Array.Empty<NextAction>());
 

--- a/src/Core.CSharp.Observe/EventLog.cs
+++ b/src/Core.CSharp.Observe/EventLog.cs
@@ -41,8 +41,9 @@ public sealed record EventLog
     /// COPIED on construction (see the constructor) so a caller's later mutation of
     /// a passed-in mutable list cannot change what <see cref="FoldOnto"/> replays
     /// or what <c>+</c> appends — the free-monoid stability this type exists to
-    /// guarantee. (Record equality still compares this by reference; value
-    /// comparison uses <c>SequenceEqual</c>, per the tests.)</summary>
+    /// guarantee. Compared STRUCTURALLY (element-wise — see <see cref="Equals(EventLog?)"/>
+    /// + <see cref="GetHashCode"/>), so the advertised monoid laws hold through
+    /// <c>==</c> and hash-based collections.</summary>
     public IReadOnlyList<NextAction> Events { get; }
 
     /// <summary>Construct a log, defensively copying <paramref name="events"/> into
@@ -63,4 +64,27 @@ public sealed record EventLog
     /// <c>Algebra.Fold(initial, Events)</c>; satisfies
     /// <c>(a + b).FoldOnto(w0) == b.FoldOnto(a.FoldOnto(w0))</c>.</summary>
     public World FoldOnto(World initial) => Algebra.Fold(initial, Events);
+
+    /// <summary>Structural equality — element-wise over <see cref="Events"/> — so the
+    /// advertised monoid laws actually hold through <c>==</c>, <see cref="object.Equals(object)"/>,
+    /// and hash-based collections (<c>AdditiveIdentity + x == x</c>; associativity).
+    /// The compiler-generated record equality would compare <see cref="Events"/> by
+    /// REFERENCE (C# records do reference equality on list-typed properties), which
+    /// breaks those laws — so it is overridden here. (The F# observe-fold EventLog is
+    /// structural by construction; this brings C# to parity.)</summary>
+    public bool Equals(EventLog? other) =>
+        other is not null && Events.SequenceEqual(other.Events);
+
+    /// <summary>Hash consistent with the structural <see cref="Equals(EventLog?)"/>:
+    /// combined over the event sequence (order-sensitive — the log is ordered).</summary>
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var ev in Events)
+        {
+            hash.Add(ev);
+        }
+
+        return hash.ToHashCode();
+    }
 }

--- a/src/Core.CSharp.Observe/EventLog.cs
+++ b/src/Core.CSharp.Observe/EventLog.cs
@@ -1,0 +1,53 @@
+using System.Numerics;
+
+namespace Zeta.Core.CSharp.Observe;
+
+/// <summary>
+/// The observe event log as a <em>monoid</em>, made machine-recognized via
+/// <c>System.Numerics</c> generic-math additive interfaces (B-0867.28 — the
+/// interface-gate before building on top of the algebra). It wraps the
+/// append-only list of <see cref="NextAction"/> events.
+///
+/// <para><b>Why additive-monoid (not <c>INumber&lt;T&gt;</c>)</b>: the event log is
+/// the <em>free monoid</em> — identity = the empty log, operation = associative
+/// append — and nothing more. It is not a field-like number (no multiplication,
+/// no ordering, no negatives), so it implements only
+/// <see cref="IAdditiveIdentity{TSelf, TResult}"/> +
+/// <see cref="IAdditionOperators{TSelf, TOther, TResult}"/>, the exact algebraic
+/// structure it has. (Decision: additive-monoidal only — operator 2026-05-31.)</para>
+///
+/// <para><b>The load-bearing law</b> is the homomorphism
+/// <see cref="FoldOnto"/>: folding a concatenated log equals folding the second
+/// onto the result of folding the first —
+/// <c>(a + b).FoldOnto(w0) == b.FoldOnto(a.FoldOnto(w0))</c>. That is exactly the
+/// append-only-replay-soundness / DST-replay property: re-folding a joined log
+/// reproduces the same state as incremental folding. <c>Fold</c> is the monoid
+/// action of (<see cref="EventLog"/>, +, empty) on <see cref="World"/>.</para>
+///
+/// <para>NOTE (consistent with <see cref="World"/>): the record's generated
+/// equality compares <see cref="Events"/> by reference, not element-wise — value
+/// comparison of two logs must compare <see cref="Events"/> with
+/// <c>SequenceEqual</c>. UoM (<c>[&lt;Measure&gt;]</c>) is intentionally absent:
+/// the observe <see cref="World"/> carries no measurable numeric quantity to
+/// protect (only ids, flags, and a mode), so units here would be ceremony, not
+/// safety; UoM lives where measurable quantities do (TriFloat values, the
+/// attention/tick/dora domain).</para>
+/// </summary>
+/// <param name="Events">The append-only event log (MSB-of-history first).</param>
+public sealed record EventLog(IReadOnlyList<NextAction> Events)
+    : IAdditiveIdentity<EventLog, EventLog>,
+      IAdditionOperators<EventLog, EventLog, EventLog>
+{
+    /// <summary>The empty log — the monoid identity. <c>empty + x == x == x + empty</c>.</summary>
+    public static EventLog AdditiveIdentity { get; } = new(Array.Empty<NextAction>());
+
+    /// <summary>Associative append — the free-monoid operation.</summary>
+    public static EventLog operator +(EventLog left, EventLog right) =>
+        new(left.Events.Concat(right.Events).ToList());
+
+    /// <summary>Project this log onto an initial world: the monoid action /
+    /// homomorphism to <see cref="World"/>. Equivalent to
+    /// <c>Algebra.Fold(initial, Events)</c>; satisfies
+    /// <c>(a + b).FoldOnto(w0) == b.FoldOnto(a.FoldOnto(w0))</c>.</summary>
+    public World FoldOnto(World initial) => Algebra.Fold(initial, Events);
+}

--- a/src/Core.CSharp.Observe/EventLog.cs
+++ b/src/Core.CSharp.Observe/EventLog.cs
@@ -46,11 +46,15 @@ public sealed record EventLog
     /// <c>==</c> and hash-based collections.</summary>
     public IReadOnlyList<NextAction> Events { get; }
 
-    /// <summary>Construct a log, defensively copying <paramref name="events"/> into
-    /// a private read-only backing array — so the log is genuinely append-only and
-    /// immutable regardless of what the caller does with its argument afterward.</summary>
+    /// <summary>Construct a log, defensively copying <paramref name="events"/> into a
+    /// <see cref="System.Collections.ObjectModel.ReadOnlyCollection{T}"/> wrapper over a
+    /// private array — so the log is genuinely append-only and immutable regardless of
+    /// what the caller does with its argument afterward, AND the exposed
+    /// <see cref="Events"/> cannot be downcast to a mutable array and rewritten
+    /// (assigning a bare <c>T[]</c> to the <see cref="IReadOnlyList{T}"/> property would
+    /// leave that hole; the read-only wrapper closes it).</summary>
     /// <param name="events">The events to copy into this log.</param>
-    public EventLog(IReadOnlyList<NextAction> events) => Events = events.ToArray();
+    public EventLog(IReadOnlyList<NextAction> events) => Events = Array.AsReadOnly(events.ToArray());
 
     /// <summary>The empty log — the monoid identity. <c>empty + x == x == x + empty</c>.</summary>
     public static EventLog AdditiveIdentity { get; } = new(Array.Empty<NextAction>());

--- a/src/Core.FSharp.Observe/EventLog.fs
+++ b/src/Core.FSharp.Observe/EventLog.fs
@@ -1,0 +1,39 @@
+namespace Zeta.Core.FSharp.Observe
+
+/// The observe event log as an additive MONOID (B-0867.28, Target 2 — F# slice),
+/// expressed via F#'s native generic-math convention: `Zero` (identity) + `(+)`
+/// (associative op). This is the F# parallel to the C# `EventLog`'s
+/// `System.Numerics` `IAdditiveIdentity` + `IAdditionOperators` — each language
+/// owns the interface in its OWN idiom. F#'s generic numeric machinery (SRTP,
+/// `List.sum`, `LanguagePrimitives.GenericZero`) recognizes `Zero`/`(+)`, so this
+/// is the genuine F# generic-math surface, not a transplant of the C# IWSAM
+/// interfaces (which would fight the language).
+///
+/// Additive-monoidal ONLY (operator 2026-05-31): the log is the FREE monoid —
+/// identity = empty log, op = associative append — not a field-like number
+/// (no multiplication, ordering, or negatives to invent).
+///
+/// Load-bearing law: `FoldOnto` is the monoid action / homomorphism onto `World`
+/// — folding a concatenated log equals incremental folding:
+///   `(a + b).FoldOnto w0  =  b.FoldOnto (a.FoldOnto w0)`
+/// i.e. append-only / DST-replay soundness.
+///
+/// UoM (`[<Measure>]`) is intentionally absent: the observe `World` carries no
+/// measurable numeric quantity (only ids, flags, a mode), so units here would be
+/// ceremony, not safety; UoM lives at the TriFloat / attention value domain
+/// (`src/Core/Units.fs`). F# records give structural equality (incl. the
+/// `NextAction list`), so two logs with equal events are value-equal natively.
+type EventLog =
+    { Events: NextAction list }
+
+    /// The empty log — the monoid identity (F# generic-math `Zero`).
+    static member Zero: EventLog = { Events = [] }
+
+    /// Associative append — the free-monoid operation.
+    static member (+)(left: EventLog, right: EventLog) : EventLog =
+        { Events = left.Events @ right.Events }
+
+    /// Project this log onto an initial world: the monoid action / homomorphism
+    /// to `World`. Equivalent to `Algebra.fold initial this.Events`; satisfies
+    /// `(a + b).FoldOnto w0 = b.FoldOnto (a.FoldOnto w0)`.
+    member this.FoldOnto(initial: World) : World = Algebra.fold initial this.Events

--- a/src/Core.FSharp.Observe/Zeta.Core.FSharp.Observe.fsproj
+++ b/src/Core.FSharp.Observe/Zeta.Core.FSharp.Observe.fsproj
@@ -10,10 +10,12 @@
 
   <!-- Zero external dependencies (B-0944 supply-chain doctrine: the algebra is a
        pure event-fold; it needs nothing but FSharp.Core). Compile order matters in
-       F#: Types.fs before Observe.fs. -->
+       F#: Types.fs before Observe.fs before EventLog.fs (the monoid uses
+       Algebra.fold). -->
   <ItemGroup>
     <Compile Include="Types.fs" />
     <Compile Include="Observe.fs" />
+    <Compile Include="EventLog.fs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Tests.CSharp/Observe/EventLogTests.cs
+++ b/tests/Tests.CSharp/Observe/EventLogTests.cs
@@ -87,4 +87,19 @@ public sealed class EventLogTests
         AssertWorldEqual((a + b).FoldOnto(w0), b.FoldOnto(a.FoldOnto(w0)));
         AssertWorldEqual(((a + b) + c).FoldOnto(w0), c.FoldOnto(b.FoldOnto(a.FoldOnto(w0))));
     }
+
+    // The log must be genuinely append-only: constructing from a mutable list and
+    // mutating that list afterward MUST NOT change the log (the free-monoid
+    // stability this type guarantees). The constructor defensively copies.
+    [Fact]
+    public void ConstructorDefensivelyCopiesTheInput()
+    {
+        var mutable = new List<NextAction> { new NextAction.Explore("e") };
+        var log = new EventLog(mutable);
+
+        mutable.Add(new NextAction.Play("p")); // mutate the source AFTER construction
+
+        Assert.Single(log.Events);
+        Assert.IsType<NextAction.Explore>(log.Events[0]);
+    }
 }

--- a/tests/Tests.CSharp/Observe/EventLogTests.cs
+++ b/tests/Tests.CSharp/Observe/EventLogTests.cs
@@ -120,4 +120,15 @@ public sealed class EventLogTests
         EventLog a = LogA(), b = LogB(), c = LogC();
         Assert.Equal((a + b) + c, a + (b + c));  // associativity at ==/Equals
     }
+
+    // Codex P2: assigning a bare T[] to the IReadOnlyList property would let a caller
+    // downcast (log.Events is NextAction[] arr) and rewrite the backing array. The
+    // constructor wraps the copy in a read-only collection, so Events is NOT a raw
+    // array and cannot be downcast-and-mutated.
+    [Fact]
+    public void EventsCannotBeDowncastToAMutableArray()
+    {
+        var log = new EventLog([new NextAction.Explore("e")]);
+        Assert.False(log.Events is NextAction[]);
+    }
 }

--- a/tests/Tests.CSharp/Observe/EventLogTests.cs
+++ b/tests/Tests.CSharp/Observe/EventLogTests.cs
@@ -1,0 +1,90 @@
+namespace Zeta.Tests.CSharp.Observe;
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Zeta.Core.CSharp.Observe;
+
+// B-0867.28 (the numerics interface-gate): the observe event log is an additive
+// MONOID via System.Numerics generic-math interfaces. These tests pin the monoid
+// laws (identity, associativity) AND the load-bearing homomorphism — folding a
+// concatenated log equals incremental folding — which is the append-only /
+// DST-replay soundness property. Additive-monoidal only (operator 2026-05-31): no
+// INumber<T>, because the log is the free monoid and nothing more.
+public sealed class EventLogTests
+{
+    private static readonly BacklogItem Alpha = new("a", "Alpha", Ready: true, Ambiguous: false, NeedsNewAction: false);
+    private static readonly BacklogItem Beta = new("b", "Beta", Ready: false, Ambiguous: true, NeedsNewAction: false);
+
+    private static World InitialWorld() =>
+        new([Alpha, Beta], new OperatorChannel(PendingMessage: true, PendingFerry: true), Mode: null);
+
+    // Three non-trivial logs that touch backlog (DoItem/Decompose), mode (Explore/
+    // SelfReflect) and the operator channel (RespondToOperator) — so the
+    // homomorphism law exercises real state transitions, not a no-op.
+    private static EventLog LogA() =>
+        new([new NextAction.Explore("e"), new NextAction.DoItem(Alpha)]);
+
+    private static EventLog LogB() =>
+        new([new NextAction.Decompose(Beta), new NextAction.RespondToOperator("r")]);
+
+    private static EventLog LogC() =>
+        new([new NextAction.SelfReflect("s")]);
+
+    /// Element-wise world equality: C# records compare the Backlog list by
+    /// reference, so compare it with SequenceEqual (BacklogItem is a record →
+    /// structural). Operator + Mode use record/enum value equality. Mirrors
+    /// GoldenVectorsTests.AssertWorldEqual.
+    private static void AssertWorldEqual(World expected, World actual)
+    {
+        Assert.Equal(expected.Operator, actual.Operator);
+        Assert.Equal(expected.Mode, actual.Mode);
+        Assert.True(
+            expected.Backlog.SequenceEqual(actual.Backlog),
+            $"backlog mismatch: expected [{string.Join(", ", expected.Backlog.Select(b => b.Id))}] " +
+            $"vs actual [{string.Join(", ", actual.Backlog.Select(b => b.Id))}]");
+    }
+
+    [Fact]
+    public void AdditiveIdentityIsTheEmptyLog() =>
+        Assert.Empty(EventLog.AdditiveIdentity.Events);
+
+    [Fact]
+    public void LeftIdentityHolds()
+    {
+        var x = LogA();
+        Assert.True((EventLog.AdditiveIdentity + x).Events.SequenceEqual(x.Events));
+    }
+
+    [Fact]
+    public void RightIdentityHolds()
+    {
+        var x = LogA();
+        Assert.True((x + EventLog.AdditiveIdentity).Events.SequenceEqual(x.Events));
+    }
+
+    [Fact]
+    public void AppendIsAssociative()
+    {
+        EventLog a = LogA(), b = LogB(), c = LogC();
+        Assert.True(((a + b) + c).Events.SequenceEqual((a + (b + c)).Events));
+    }
+
+    [Fact]
+    public void FoldOntoEmptyLogIsTheInitialWorld() =>
+        AssertWorldEqual(InitialWorld(), EventLog.AdditiveIdentity.FoldOnto(InitialWorld()));
+
+    // The load-bearing law: Fold is the monoid action — folding a joined log =
+    // folding the second onto the result of folding the first. This is exactly
+    // append-only-replay soundness (re-folding a concatenated log reproduces the
+    // incremental state). Checked across three logs (associatively) too.
+    [Fact]
+    public void FoldOntoIsAMonoidHomomorphism()
+    {
+        var w0 = InitialWorld();
+        EventLog a = LogA(), b = LogB(), c = LogC();
+
+        AssertWorldEqual((a + b).FoldOnto(w0), b.FoldOnto(a.FoldOnto(w0)));
+        AssertWorldEqual(((a + b) + c).FoldOnto(w0), c.FoldOnto(b.FoldOnto(a.FoldOnto(w0))));
+    }
+}

--- a/tests/Tests.CSharp/Observe/EventLogTests.cs
+++ b/tests/Tests.CSharp/Observe/EventLogTests.cs
@@ -102,4 +102,22 @@ public sealed class EventLogTests
         Assert.Single(log.Events);
         Assert.IsType<NextAction.Explore>(log.Events[0]);
     }
+
+    // Codex P2: a record that advertises value equality must actually obey the
+    // monoid laws through == / Equals / hash — not only via .Events.SequenceEqual.
+    // Equality is overridden structurally so AdditiveIdentity + x == x really holds
+    // (the generated record equality would compare Events by reference and fail it).
+    [Fact]
+    public void RecordEqualityObeysMonoidLawsThroughEqualsAndHash()
+    {
+        var x = LogA();
+        Assert.Equal(x, EventLog.AdditiveIdentity + x);  // left identity at ==/Equals
+        Assert.Equal(x, x + EventLog.AdditiveIdentity);  // right identity at ==/Equals
+        Assert.Equal(
+            x.GetHashCode(),
+            (EventLog.AdditiveIdentity + x).GetHashCode());  // hash consistent with Equals
+
+        EventLog a = LogA(), b = LogB(), c = LogC();
+        Assert.Equal((a + b) + c, a + (b + c));  // associativity at ==/Equals
+    }
 }

--- a/tests/Tests.FSharp/Observe/EventLog.Tests.fs
+++ b/tests/Tests.FSharp/Observe/EventLog.Tests.fs
@@ -1,0 +1,62 @@
+module Zeta.Tests.FSharp.Observe.EventLogTests
+
+open global.Xunit
+open Zeta.Core.FSharp.Observe
+
+// B-0867.28 (numerics interface-gate), F# slice: the observe event log is an
+// additive MONOID via F#'s native `Zero` + `(+)` convention. Pins the monoid laws
+// (identity, associativity) AND the load-bearing homomorphism — folding a
+// concatenated log == incremental folding — i.e. append-only / DST-replay
+// soundness. Additive-monoidal only (operator 2026-05-31). F# records are
+// structurally equal, so `Assert.Equal<_>` compares logs/worlds element-wise.
+
+let private alpha: BacklogItem =
+    { Id = "a"; Title = "Alpha"; Ready = true; Ambiguous = false; NeedsNewAction = false }
+
+let private beta: BacklogItem =
+    { Id = "b"; Title = "Beta"; Ready = false; Ambiguous = true; NeedsNewAction = false }
+
+let private initialWorld () : World =
+    { Backlog = [ alpha; beta ]
+      Operator = Some { PendingMessage = true; PendingFerry = true }
+      Mode = None }
+
+// Three non-trivial logs touching backlog (DoItem/Decompose), mode (Explore/
+// SelfReflect) and the operator channel (RespondToOperator), so the homomorphism
+// law exercises real transitions, not a no-op.
+let private logA () : EventLog = { Events = [ Explore "e"; DoItem alpha ] }
+let private logB () : EventLog = { Events = [ Decompose beta; RespondToOperator "r" ] }
+let private logC () : EventLog = { Events = [ SelfReflect "s" ] }
+
+[<Fact>]
+let ``additive identity is the empty log`` () = Assert.Empty(EventLog.Zero.Events)
+
+[<Fact>]
+let ``left identity holds`` () =
+    let x = logA ()
+    Assert.Equal<EventLog>(x, EventLog.Zero + x)
+
+[<Fact>]
+let ``right identity holds`` () =
+    let x = logA ()
+    Assert.Equal<EventLog>(x, x + EventLog.Zero)
+
+[<Fact>]
+let ``append is associative`` () =
+    let a, b, c = logA (), logB (), logC ()
+    Assert.Equal<EventLog>((a + b) + c, a + (b + c))
+
+[<Fact>]
+let ``foldOnto empty log is the initial world`` () =
+    let w0 = initialWorld ()
+    Assert.Equal<World>(w0, EventLog.Zero.FoldOnto w0)
+
+// The load-bearing law: Fold is the monoid action — folding a joined log = folding
+// the second onto the result of folding the first (append-only / DST-replay
+// soundness). Checked across three logs (associatively) too.
+[<Fact>]
+let ``foldOnto is a monoid homomorphism`` () =
+    let w0 = initialWorld ()
+    let a, b, c = logA (), logB (), logC ()
+    Assert.Equal<World>((a + b).FoldOnto w0, b.FoldOnto(a.FoldOnto w0))
+    Assert.Equal<World>(((a + b) + c).FoldOnto w0, c.FoldOnto(b.FoldOnto(a.FoldOnto w0)))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -34,6 +34,7 @@
     <Compile Include="TriBoolean/TriBoolean.Tests.fs" />
     <Compile Include="TriBoolean/Float.Tests.fs" />
     <Compile Include="Observe/GoldenVectors.Tests.fs" />
+    <Compile Include="Observe/EventLog.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
## What

Target 2 of the numerics interface-gate (B-0867.28), C# slice. The observe event log is the **free monoid**; this exposes it via `System.Numerics` generic-math additive interfaces:

```csharp
EventLog : IAdditiveIdentity<EventLog, EventLog>, IAdditionOperators<EventLog, EventLog, EventLog>
```

- **identity** = empty log · **+** = associative append · **FoldOnto** = the monoid action / homomorphism onto `World`.
- **Load-bearing law (tested):** folding a concatenated log == incremental folding — `(a + b).FoldOnto(w0) == b.FoldOnto(a.FoldOnto(w0))` — i.e. append-only / DST-replay soundness.

## Decisions (operator 2026-05-31)

- **Additive-monoidal ONLY, not `INumber<T>`.** Reading the code surfaced the fork: TriFloat (and the log) is the free monoid, not a field-like number — tri-state, held-capable, shape-parameterized, partial encode. Full `INumber<T>` (×, ordering, negatives) would be a square peg. Implement only the additive-monoid interfaces — the exact structure present.
- **UoM: N/A here.** The observe `World` has no measurable numeric quantity (ids, flags, a mode) — `[<Measure>]` would be ceremony, not safety (load-bearing razor). UoM lives at the TriFloat/attention value domain (`src/Core/Units.fs`).

## Interface-gate result: NON-BREAKING

`EventLog` is a **new** additive type; `World` / `Algebra` / `NextAction` are **unchanged**. The gate's 'may change the interface significantly' worry resolves favorably — build-on-top (B-0867.26) builds on the unchanged algebra + the new monoid layer.

## Tests

6 monoid-law tests (identity ×2, associativity, fold-empty, homomorphism ×2). **42/42 C# tests pass** incl. `GoldenVectorsTests` — cross-language BFT parity intact after the interface addition.

## Remaining (tracked in the row, not this PR)

- F# observe-fold monoid (F# lists already ARE the free monoid → decide if a generic-math wrapper earns its keep).
- Target 1: apply the additive-monoid decision to TriFloat itself (C#/F#).

🤖 Generated with [Claude Code](https://claude.com/claude-code)