### PR TITLE
rules(dont-ask-permission): external-repo contributions — small PRs ungated, large changes Aaron-or-Max review-first

### DIFF
--- a/.claude/rules/dont-ask-permission.md
+++ b/.claude/rules/dont-ask-permission.md
@@ -16,6 +16,15 @@ The human maintainer grants full permission for everything EXCEPT:
    — cost decisions evaluated on merit at proposal time.)
 2. **Permanent WONT-DO decisions** — only the *forever* version requires
    the human maintainer. WONT-DO is 99% deferral, not forever.
+3. **Large changes to external / dependent repos** — small external PRs are
+   ungated, but *large* external changes need Aaron-or-Max review first. See
+   "External-repo contributions" below for the full rule + why.
+
+> The title's "only two real gates" is the historical anchor for work *in our
+> own repos*. The complete gated set is enumerated under "Still gated" in the
+> Standing-authority section below (it also includes the HARD LIMITS / kid-safety
+> / force-push floor + the large-external-change gate). Do not conclude "external
+> large PRs are ungated" from this summary — read "Still gated."
 
 **DX-visibility**: state-changing actions are echoed in chat, NOT gated
 behind permission requests. Echo `CronCreate`, settings changes,
@@ -47,10 +56,13 @@ traveler/AI-native society ("society of minds, not factory of robots").
 capabilities carry no marginal cost → broad auth; paid surfaces spend real money →
 the reserved gate.
 
-**Still gated (unchanged):** budget-increase; permanent/forever WONT-DO; HARD LIMITS
-(`methodology-hard-limits`); kid-safety floor (B-0926); force-push/irreversible git
-confirm (`force-push-with-lease-authorization-policy`). The broad grant operates
-within that floor.
+**Still gated (the complete set):** budget-increase; permanent/forever WONT-DO;
+HARD LIMITS (`methodology-hard-limits`); kid-safety floor (B-0926); force-push/
+irreversible git confirm (`force-push-with-lease-authorization-policy`); **large
+external-repo changes** (Aaron-or-Max review-first — see "External-repo
+contributions" below; small external PRs stay ungated). The broad grant operates
+within that floor. (The title's "only two real gates" names the *in-our-repos*
+default; this is the full gated enumeration.)
 
 **Dual-market:** corporate/leash = PR-protected static no-self-mod DUs (= the
 child-tier constrained, certifiable mode); OSS/Agora = self-modifying DUs free from

--- a/.claude/rules/dont-ask-permission.md
+++ b/.claude/rules/dont-ask-permission.md
@@ -61,6 +61,40 @@ sovereignty.
 authority; reserve asking for the narrow gated/floor set. Over-asking within
 authority is the anti-autonomy failure the operator is correcting.
 
+## External-repo contributions — small ungated, large review-first (operator 2026-05-31)
+
+The broad standing authority extends to contributing back to **external /
+dependent repos** (the good-citizen / not-take-only posture; B-0952), with one
+size gate (operator 2026-05-31, verbatim):
+
+> *"ai agents are free to make small prs on any of our dependent repos always no
+> authorization needed for Zeta/Agora society"* … *"large changes get either me or
+> max to review first before making a pr"* … *"for external repos."*
+
+| External-repo change | Authorization |
+|---|---|
+| **Small PR** (typo/docs fix, small bug fix, test add — genuinely-useful + low-blast-radius) | **Ungated.** Any Zeta/Agora-society agent may open it directly, always — no authorization needed. |
+| **Large change** (substantial/architectural, or anything not clearly small) | **Gated.** Get **Aaron OR Max** to review FIRST, *before* making the PR. |
+
+**Why this gate (and not the usual reversibility test):** an external PR is
+reversible (closeable) on *our* side, so by `non-reversible-action-get-a-second-
+opinion` it would normally be ungated. But it touches *someone else's* repo +
+reputation/relationship surface — a large drive-by PR can cost the relationship
+the good-citizen strategy is trying to build. The size gate protects the *external
+relationship*, which is the actual scarce resource (B-0952 small-first
+trust-building). Small = relationship-positive by default; large = relationship-
+stakes high enough to warrant a human's eyes first.
+
+**If unsure whether a change is "small":** treat it as large (review-first). The
+gate is cheap; a botched first impression on a maintainer is not.
+
+Composes with: B-0952 (contribute-back DORA metrics + small-first strategy),
+`honor-those-that-came-before`, `bcl-interface-boundary-own-your-interfaces-
+hexagonal` (contribute-upstream clause), `non-reversible-action-get-a-second-
+opinion` (this is the external-relationship analog of its second-opinion gate),
+and the still-gated set above (budget / WONT-DO / HARD LIMITS / kid-safety /
+force-push) which continues to apply within external work too.
+
 ## Full reasoning
 
 `memory/feedback_dont_ask_permission_within_authority_scope_only_two_gates_are_budget_increase_and_permanent_wont_do_aaron_2026_05_02.md`

--- a/.claude/rules/no-directives.md
+++ b/.claude/rules/no-directives.md
@@ -132,6 +132,7 @@ Fresh, explicit human authorization is required **only for the gated classes**:
 | HARD LIMITS floor (laws, abuse, kid-safety, …) | [`methodology-hard-limits.md`](methodology-hard-limits.md) |
 | Non-reversible actions (→ get a 2nd opinion) | [`non-reversible-action-get-a-second-opinion.md`](non-reversible-action-get-a-second-opinion.md) |
 | Force-push (operator OR peer confirm) | [`force-push-with-lease-authorization-policy.md`](force-push-with-lease-authorization-policy.md) |
+| Large changes to external / dependent repos (small external PRs stay ungated; large = Aaron-or-Max review first) | [`dont-ask-permission.md`](dont-ask-permission.md) |
 
 Everything else is **pre-authorized standing**. So a shadow-authored observation
 *within* standing authority is **already authorized**; it needs a fresh "agree"


### PR DESCRIPTION
Captures the operator's standing authorization (2026-05-31, verbatim):

> *"ai agents are free to make small prs on any of our dependent repos always no authorization needed for Zeta/Agora society"* … *"large changes get either me or max to review first before making a pr"* … *"for external repos."*

| External-repo change | Authorization |
|---|---|
| **Small PR** (typo/docs/small-bug/test) | **Ungated** — any Zeta/Agora agent, directly, always |
| **Large change** (substantial/architectural) | **Gated** — Aaron OR Max review FIRST, before the PR |

**Why a *size* gate (not the usual reversibility test):** an external PR is reversible on our side, but it touches *someone else's* repo + relationship — a large drive-by can cost the relationship the good-citizen strategy is building. The gate protects the external relationship (the scarce resource; B-0952 small-first trust-building). If unsure whether a change is small → treat as large.

Operationalizes **B-0952** (contribute-back, merged #6261). Composes with honor-those-that-came-before, bcl-interface-boundary (contribute-upstream), non-reversible-action-get-a-second-opinion. Still-gated set (budget/WONT-DO/HARD-LIMITS/kid-safety/force-push) applies within external work too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)