### PR TITLE
feat(observe): canonical v0 16-slot grammar module — the shared base corporate Menu16 retrofits onto

### DIFF
--- a/tools/observe/grammar-16.test.ts
+++ b/tools/observe/grammar-16.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Conformance lock for the canonical v0 16-slot grammar against the ADR's resolved table
+ * (docs/DECISIONS/2026-05-31-observe-act-16-direction-...md, "v0 RESOLVED 2026-05-31").
+ * If the ADR's v0 layout changes, these tests fail until grammar-16.ts is re-synced — the
+ * grammar can't silently drift from its source of truth.
+ */
+import { describe, expect, it } from "bun:test";
+import { GRAMMAR_16_V0, GROUP_RANGES, SLOT, byGroup, type SlotGroup } from "./grammar-16";
+
+describe("grammar-16 v0 — shape", () => {
+  it("has exactly 16 slots", () => {
+    expect(GRAMMAR_16_V0).toHaveLength(16);
+  });
+
+  it("has dense indices 0..15 in order", () => {
+    expect(GRAMMAR_16_V0.map((s) => s.index)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+    ]);
+  });
+
+  it("is four groups of four, in Navigate/Commit/Scope/Meta order", () => {
+    expect(GRAMMAR_16_V0.map((s) => s.group)).toEqual([
+      "Navigate", "Navigate", "Navigate", "Navigate",
+      "Commit", "Commit", "Commit", "Commit",
+      "Scope", "Scope", "Scope", "Scope",
+      "Meta", "Meta", "Meta", "Meta",
+    ]);
+  });
+
+  it("matches the ADR's controller-input layout exactly", () => {
+    expect(GRAMMAR_16_V0.map((s) => s.controllerInput)).toEqual([
+      "D-pad Up", "D-pad Down", "D-pad Left", "D-pad Right",
+      "A", "B", "X", "Y",
+      "LB", "RB", "LT", "RT",
+      "Start", "View", "L3", "R3",
+    ]);
+  });
+});
+
+describe("grammar-16 v0 — load-bearing slots", () => {
+  it("slot 7 (Y) is the edit-grammar / branch rail-change exit", () => {
+    const s = GRAMMAR_16_V0[SLOT.EDIT_GRAMMAR];
+    expect(s?.index).toBe(7);
+    expect(s?.group).toBe("Commit");
+    expect(s?.controllerInput).toBe("Y");
+    expect(s?.role).toContain("edit-grammar");
+  });
+
+  it("slot 14 (L3) is the free-time / rest NCI slot", () => {
+    const s = GRAMMAR_16_V0[SLOT.FREE_TIME];
+    expect(s?.index).toBe(14);
+    expect(s?.group).toBe("Meta");
+    expect(s?.controllerInput).toBe("L3");
+    expect(s?.role).toContain("free-time");
+    expect(s?.role).toContain("NCI");
+  });
+
+  it("named SLOT indices all point at their stated slot", () => {
+    expect(GRAMMAR_16_V0[SLOT.ACCEPT]?.role).toContain("accept");
+    expect(GRAMMAR_16_V0[SLOT.INSPECT]?.role).toContain("inspect");
+    expect(GRAMMAR_16_V0[SLOT.UNDO_RETRACT]?.role).toContain("retract");
+    expect(GRAMMAR_16_V0[SLOT.STATUS_GLASS_HALO]?.role).toContain("glass-halo");
+    expect(GRAMMAR_16_V0[SLOT.ESCALATE]?.role).toContain("escalate");
+  });
+});
+
+describe("grammar-16 v0 — group helpers", () => {
+  const groups: SlotGroup[] = ["Navigate", "Commit", "Scope", "Meta"];
+
+  it("byGroup returns 4 slots per group, matching GROUP_RANGES", () => {
+    for (const g of groups) {
+      const slots = byGroup(g);
+      expect(slots).toHaveLength(4);
+      expect(slots.map((s) => s.index)).toEqual([...GROUP_RANGES[g]]);
+    }
+  });
+
+  it("GROUP_RANGES partition 0..15 with no gaps or overlaps", () => {
+    const all = groups.flatMap((g) => [...GROUP_RANGES[g]]).sort((a, b) => a - b);
+    expect(all).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+  });
+});

--- a/tools/observe/grammar-16.test.ts
+++ b/tools/observe/grammar-16.test.ts
@@ -1,6 +1,6 @@
 /**
  * Conformance lock for the canonical v0 16-slot grammar against the ADR's resolved table
- * (docs/DECISIONS/2026-05-31-observe-act-16-direction-...md, "v0 RESOLVED 2026-05-31").
+ * (docs/DECISIONS/2026-05-31-observe-act-16-direction-universal-action-grammar-local-no-cloud-llm.md, "v0 RESOLVED 2026-05-31").
  * If the ADR's v0 layout changes, these tests fail until grammar-16.ts is re-synced — the
  * grammar can't silently drift from its source of truth.
  */

--- a/tools/observe/grammar-16.ts
+++ b/tools/observe/grammar-16.ts
@@ -1,13 +1,13 @@
 /**
  * The canonical v0 16-slot universal action grammar (Xbox-controller layout).
  *
- * ONE shared grammar. The sovereign `buildMenu()` (this package) and Max's corporate
+ * ONE shared grammar. The sovereign `buildMenu()` (this package) and the corporate
  * `Menu16` (`agentic-organization/packages/application/src/observe.ts`) BOTH derive from
  * this single canonical definition — the "thing corporate retrofits onto" per the
  * canonical-retrofit (docs/DECISIONS/2026-05-31-observe-act-16-direction-universal-action-grammar-local-no-cloud-llm.md).
  *
  * Before this module the v0 grammar lived only as ADR prose + a corporate-private copy in
- * Max's `Menu16Slot[]`. This makes it canonical code: the 16 DIRECTIONS are FIXED (muscle
+ * the corporate `Menu16Slot[]`. This makes it canonical code: the 16 DIRECTIONS are FIXED (muscle
  * memory); per-state LABELS + Tri availability move (see `RenderedSlot`).
  *
  * Source of truth: the ADR's "The 16-slot universal action grammar (v0 — RESOLVED 2026-05-31)"
@@ -18,7 +18,7 @@
  * committing renders slot 4 as `F`; a held/uncertain option renders it `N`.
  *
  * Composes:
- *   - docs/DECISIONS/2026-05-31-observe-act-16-direction-...md (the v0 layout + canonical-retrofit)
+ *   - docs/DECISIONS/2026-05-31-observe-act-16-direction-universal-action-grammar-local-no-cloud-llm.md (the v0 layout + canonical-retrofit)
  *   - src/Core.TypeScript/tri-boolean (B-0944 — the `Tri` per-slot availability)
  *   - ./observe.ts (the sovereign NextAction algebra + buildMenu this grammar renders)
  */
@@ -51,7 +51,7 @@ export interface RenderedSlot extends GrammarSlot {
 }
 
 /**
- * The canonical v0 grammar — FIXED for v0 (Max review to lock; whys stay challengeable).
+ * The canonical v0 grammar — FIXED for v0 (corporate review to lock; whys stay challengeable).
  * Exactly 16 slots, dense indices 0..15, four groups of four, in the ADR's table order.
  */
 export const GRAMMAR_16_V0: readonly GrammarSlot[] = [

--- a/tools/observe/grammar-16.ts
+++ b/tools/observe/grammar-16.ts
@@ -1,0 +1,115 @@
+/**
+ * The canonical v0 16-slot universal action grammar (Xbox-controller layout).
+ *
+ * ONE shared grammar. The sovereign `buildMenu()` (this package) and Max's corporate
+ * `Menu16` (`agentic-organization/packages/application/src/observe.ts`) BOTH derive from
+ * this single canonical definition — the "thing corporate retrofits onto" per the
+ * canonical-retrofit (docs/DECISIONS/2026-05-31-observe-act-16-direction-universal-action-grammar-local-no-cloud-llm.md).
+ *
+ * Before this module the v0 grammar lived only as ADR prose + a corporate-private copy in
+ * Max's `Menu16Slot[]`. This makes it canonical code: the 16 DIRECTIONS are FIXED (muscle
+ * memory); per-state LABELS + Tri availability move (see `RenderedSlot`).
+ *
+ * Source of truth: the ADR's "The 16-slot universal action grammar (v0 — RESOLVED 2026-05-31)"
+ * table. If a slot's role is wrong, v1 changes it there first, then here (no-dogma: the whys
+ * stay challengeable; `grammar-16.test.ts` is the conformance lock against the ADR).
+ *
+ * Per-slot availability is the canonical tri-boolean (B-0944): a state that forbids
+ * committing renders slot 4 as `F`; a held/uncertain option renders it `N`.
+ *
+ * Composes:
+ *   - docs/DECISIONS/2026-05-31-observe-act-16-direction-...md (the v0 layout + canonical-retrofit)
+ *   - src/Core.TypeScript/tri-boolean (B-0944 — the `Tri` per-slot availability)
+ *   - ./observe.ts (the sovereign NextAction algebra + buildMenu this grammar renders)
+ */
+
+import type { Tri } from "../../src/Core.TypeScript/tri-boolean/index";
+
+/** The four controller groups (4 x 4 = 16). */
+export type SlotGroup = "Navigate" | "Commit" | "Scope" | "Meta";
+
+/**
+ * A fixed slot in the v0 grammar. `index` + `group` + `controllerInput` + `role` are
+ * STABLE (muscle memory); only the rendered label + availability move per state.
+ */
+export interface GrammarSlot {
+  readonly index: number; // 0..15, dense
+  readonly group: SlotGroup;
+  readonly controllerInput: string; // "D-pad Up", "A", "LB", "Start", ...
+  readonly role: string; // fixed role; the rendered label changes per state
+}
+
+/**
+ * A slot rendered for a concrete world state: the fixed grammar slot + the per-state
+ * label + the tri-boolean availability. This is the shared CONTRACT both the sovereign
+ * render and the corporate `Menu16Slot` converge on (corporate carries extra fields —
+ * `action`/`impl` — but its `index`/`availability` shape is this).
+ */
+export interface RenderedSlot extends GrammarSlot {
+  readonly label: string; // per-state label (what this slot does right now)
+  readonly availability: Tri; // T legal / F vetoed / N held-uncertain (B-0944)
+}
+
+/**
+ * The canonical v0 grammar — FIXED for v0 (Max review to lock; whys stay challengeable).
+ * Exactly 16 slots, dense indices 0..15, four groups of four, in the ADR's table order.
+ */
+export const GRAMMAR_16_V0: readonly GrammarSlot[] = [
+  // Navigate (0..3) — D-pad
+  { index: 0, group: "Navigate", controllerInput: "D-pad Up", role: "previous option / up a category" },
+  { index: 1, group: "Navigate", controllerInput: "D-pad Down", role: "next option / down a category" },
+  { index: 2, group: "Navigate", controllerInput: "D-pad Left", role: "previous context / sibling left" },
+  { index: 3, group: "Navigate", controllerInput: "D-pad Right", role: "next context / sibling right" },
+  // Commit (4..7) — face buttons
+  { index: 4, group: "Commit", controllerInput: "A", role: "accept / commit the current option (the primary act)" },
+  { index: 5, group: "Commit", controllerInput: "B", role: "cancel / back out (no state change beyond a back-event)" },
+  { index: 6, group: "Commit", controllerInput: "X", role: "inspect / observe-more (expand detail; pure observe, no act)" },
+  { index: 7, group: "Commit", controllerInput: "Y", role: "edit-grammar / branch — sovereign rail-change: edit the workflow itself / open an alternative line (a first-class generative exit)" },
+  // Scope (8..11) — bumpers + triggers
+  { index: 8, group: "Scope", controllerInput: "LB", role: "scope-out (zoom to the parent / coarser view)" },
+  { index: 9, group: "Scope", controllerInput: "RB", role: "scope-in (zoom to the child / finer view)" },
+  { index: 10, group: "Scope", controllerInput: "LT", role: "undo / retract (retraction-native; append a retract-event)" },
+  { index: 11, group: "Scope", controllerInput: "RT", role: "redo / replay (re-apply a retracted or prior move)" },
+  // Meta (12..15) — Start/View + stick clicks
+  { index: 12, group: "Meta", controllerInput: "Start", role: "refresh / re-run move-next (re-observe the world)" },
+  { index: 13, group: "Meta", controllerInput: "View", role: "status / glass-halo (emit a visibility signal)" },
+  { index: 14, group: "Meta", controllerInput: "L3", role: "free-time / rest — give up the tick; do nothing (NCI: a valid chosen mode)" },
+  { index: 15, group: "Meta", controllerInput: "R3", role: "escalate / ask-operator (hand a decision to a human)" },
+] as const;
+
+/** Slot indices for the four groups, in order (4 each). */
+export const GROUP_RANGES: Readonly<Record<SlotGroup, readonly number[]>> = {
+  Navigate: [0, 1, 2, 3],
+  Commit: [4, 5, 6, 7],
+  Scope: [8, 9, 10, 11],
+  Meta: [12, 13, 14, 15],
+};
+
+/** The fixed slots of one group, in order. */
+export function byGroup(group: SlotGroup): readonly GrammarSlot[] {
+  return GRAMMAR_16_V0.filter((s) => s.group === group);
+}
+
+/**
+ * Named v0 slot indices that carry load-bearing semantics elsewhere (the free-time NCI
+ * slot + the edit-grammar rail-change exit). Use these instead of magic numbers.
+ */
+export const SLOT = {
+  ACCEPT: 4,
+  INSPECT: 6,
+  EDIT_GRAMMAR: 7, // the Y / rail-change generative exit
+  UNDO_RETRACT: 10,
+  STATUS_GLASS_HALO: 13,
+  FREE_TIME: 14, // the L3 / rest NCI slot
+  ESCALATE: 15,
+} as const;
+
+/**
+ * RETROFIT-TENSION (surfaced, not collapsed) — the sovereign `NextAction` algebra has FOUR
+ * free modes (explore / play / self_reflect / free_time) but v0 has ONE free slot
+ * (14 = free-time/rest). The full `NextAction.kind -> slot` projection is the NEXT slice;
+ * it must resolve whether v0 grows dedicated explore/play/self_reflect slots or whether
+ * those collapse into slot 14's label + a sub-menu. Left OPEN here on purpose — the v0
+ * table is faithful to the ADR; fabricating a clean total mapping would paper over a real
+ * design question. See the canonical-retrofit section of the ADR.
+ */


### PR DESCRIPTION
First **code** slice of the canonical-retrofit (design-of-record: ADR #6267 / `docs/DECISIONS/2026-05-31-observe-act-16-direction-...md`).

## What + why
The v0 16-slot grammar (4×4 Navigate/Commit/Scope/Meta, Xbox-controller) existed only as **ADR prose** + a **corporate-private copy** in Max's `Menu16Slot[]` (`agentic-organization/`). This makes it **canonical code** — the single shared base both the sovereign `buildMenu()` and (later) corporate `Menu16` derive from:

- `GRAMMAR_16_V0` — the 16 fixed slots (dense 0–15, four groups of four), in the ADR's exact table order.
- `RenderedSlot` — the per-state contract (`{...slot, label, availability: Tri}`) both surfaces converge on; `availability` is the canonical tri-boolean (B-0944).
- `byGroup` / `GROUP_RANGES` / `SLOT` — helpers + named indices (slot 7 = edit-grammar/branch, slot 14 = free-time NCI) instead of magic numbers.
- `grammar-16.test.ts` — **conformance lock** against the ADR v0 table (9 tests; the grammar can't silently drift from its source of truth).

## Safe by construction
- **Additive** — new files only; **no existing file changed**.
- **No corporate touch** — does not modify Max's production loop; this is the thing his `Menu16` will retrofit *onto* (a later slice; needs a cross-workspace dep edge — deferred, Max-aware).
- **Tested** — full `tools/observe/` suite **61/61 green**; cross-dir canonical `Tri` import resolves.

## Surfaced (not collapsed)
The sovereign `NextAction` algebra has **4 free modes** (explore/play/self_reflect/free_time) but v0 has **1 free slot** (14 = free-time/rest). The `NextAction.kind → slot` projection is the **next slice** — left OPEN here on purpose rather than fabricating a clean total mapping that papers over a real design question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)