### PR TITLE
ci(shields): mise token (no 403) + exercise one-liner installers across Unix shields

### DIFF
--- a/.github/workflows/docker-nixos-install-sh-test.yml
+++ b/.github/workflows/docker-nixos-install-sh-test.yml
@@ -103,6 +103,10 @@ jobs:
           # (mise install + bun install + claude-code download + gh
           # nix-shell + ~50 mise-tool installs); bump to 900s.
           DOCKER_BUILD_TIMEOUT_SEC: '900'
+          # mise.sh promotes GITHUB_TOKEN -> MISE_GITHUB_TOKEN (authenticated GitHub API,
+          # no 403); the driver passes it into the build as a BuildKit secret. BuildKit on.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_BUILDKIT: '1'
         run: bun tools/ci/docker-nixos-install-sh-test.ts
 
       - name: Upload Docker test log (always)

--- a/.github/workflows/docker-ubuntu-install-sh-test.yml
+++ b/.github/workflows/docker-ubuntu-install-sh-test.yml
@@ -66,8 +66,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: docker build (the test — install.sh + local-LLM validation inside)
+        env:
+          # mise.sh promotes GITHUB_TOKEN -> MISE_GITHUB_TOKEN (authenticated GitHub API,
+          # no 403); passed into the build as a BuildKit secret below (not a build-arg).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker build \
+          DOCKER_BUILDKIT=1 docker build \
+            --secret id=github_token,env=GITHUB_TOKEN \
             -f tools/ci/dockerfiles/ubuntu-install-sh-test/Dockerfile \
             -t zeta-ubuntu-install-sh-test \
             .

--- a/.github/workflows/macos-install-sh-test.yml
+++ b/.github/workflows/macos-install-sh-test.yml
@@ -71,6 +71,15 @@ jobs:
     # jars + ~398MB model pull. Matches the other shields' 40-min bound, +5 slack.
     timeout-minutes: 45
 
+    env:
+      # mise.sh auto-promotes GITHUB_TOKEN -> MISE_GITHUB_TOKEN so mise's aqua/pipx GitHub
+      # release lookups are authenticated (5000/hr) instead of the unauthenticated 60/hr
+      # limit this shield was hitting 403s on.
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Exercise the one-liner dev-CLI installers here (they default-skip in non-interactive
+      # CI; the shields are where we test everything).
+      ZETA_INSTALL_FULL: "1"
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/wsl-install-sh-test.yml
+++ b/.github/workflows/wsl-install-sh-test.yml
@@ -85,7 +85,11 @@ jobs:
         env:
           # Pass the Windows-host checkout path into WSL, /p = translate to the /mnt form.
           HOST_WORKSPACE: ${{ github.workspace }}
-          WSLENV: HOST_WORKSPACE/p
+          # mise.sh promotes GITHUB_TOKEN -> MISE_GITHUB_TOKEN (authenticated GitHub API,
+          # no 403 rate-limit); ZETA_INSTALL_FULL exercises the one-liner installers.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZETA_INSTALL_FULL: "1"
+          WSLENV: HOST_WORKSPACE/p:GITHUB_TOKEN:ZETA_INSTALL_FULL
         run: |
           set -euo pipefail
           echo "=== WSL install.sh test ==="

--- a/tools/ci/docker-nixos-install-sh-test.ts
+++ b/tools/ci/docker-nixos-install-sh-test.ts
@@ -127,6 +127,11 @@ function runBuild(timeoutSec: number, logPath: string): BuildResult {
   const startMs = Date.now();
   const buildArgs = [
     "build",
+    // Authenticate mise GitHub API lookups via a BuildKit secret (no 403 rate-limit);
+    // mounted as a file for the install.sh RUN only, never baked into a layer (vs
+    // --build-arg). DOCKER_BUILDKIT=1 (workflow env, inherited by spawnSync) enables it.
+    "--secret",
+    "id=github_token,env=GITHUB_TOKEN",
     "--file",
     DOCKERFILE_PATH,
     "--tag",

--- a/tools/ci/dockerfiles/nixos-install-sh-test/Dockerfile
+++ b/tools/ci/dockerfiles/nixos-install-sh-test/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # tools/ci/dockerfiles/nixos-install-sh-test/Dockerfile
 #
 # B-0849 Phase 1 — fast-iteration test harness for tools/setup/install.sh
@@ -130,7 +132,14 @@ COPY tools/accelerator /workspace/tools/accelerator
 #      verifiers, shellenv)
 # Exits non-zero if any step fails — the docker build itself fails,
 # which CI surfaces as a build failure.
-RUN tools/setup/install.sh
+# Exercise the one-liner dev-CLI installers (default-skip in non-interactive CI; the shields
+# are where we test everything) + authenticate mise GitHub API lookups via a BuildKit secret
+# (no 403). Token mounted as a file for THIS RUN only — never baked into an image layer (vs
+# --build-arg). Both env vars scoped to this RUN. || true keeps local builds (no --secret) ok.
+RUN --mount=type=secret,id=github_token \
+    ZETA_INSTALL_FULL=1 \
+    GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
+    tools/setup/install.sh
 
 # Validation step 1: bun installed via mise AND matches .mise.toml pin
 # `bun = "1.3"` exactly (per Copilot review on PR #5393 — earlier check

--- a/tools/ci/dockerfiles/ubuntu-install-sh-test/Dockerfile
+++ b/tools/ci/dockerfiles/ubuntu-install-sh-test/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # tools/ci/dockerfiles/ubuntu-install-sh-test/Dockerfile
 #
 # Docker-based install.sh test on Ubuntu userspace — sibling to
@@ -38,7 +40,15 @@ WORKDIR /zeta
 COPY . /zeta
 
 # The entropy lever: bare ubuntu -> working substrate (incl. the local-LLM core).
-RUN ./tools/setup/install.sh
+# Exercise the one-liner dev-CLI installers (default-skip in non-interactive CI; the shields
+# are where we test everything) + authenticate mise GitHub API lookups via a BuildKit secret
+# (no 403 rate-limit). The token is mounted as a file for THIS RUN only — never baked into an
+# image layer (the reason for --mount=type=secret over --build-arg). Both env vars are scoped
+# to this RUN. || true keeps a local build (no --secret) working (empty token = unauth, as before).
+RUN --mount=type=secret,id=github_token \
+    ZETA_INSTALL_FULL=1 \
+    GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
+    ./tools/setup/install.sh
 
 # Validate the local-LLM primitive end-to-end. The MODEL persists on disk
 # (install.sh pulled it into a layer); the DAEMON does not persist across RUN


### PR DESCRIPTION
## Why

Per operator: **shields should test everything as often as possible, throttle only if truly forced.** Two gaps stopped that:

1. **403 rate-limit** — the install-shields never pass mise a GitHub token, so mise's aqua/pipx release lookups (uv/shellcheck/actionlint/semgrep) hit the unauthenticated GitHub API (60/hr) and **403 under CI load**. The macOS shield was failing on exactly this.
2. **one-liner installers skipped** — they default-skip in non-interactive CI (the TTY-skip from #6252), so the shields weren't exercising grok/cursor/kiro/hermes/forge at all.

## What

For all **4 Unix install-shields** (macos, wsl, docker-ubuntu, docker-nixos):

- **`GITHUB_TOKEN`** → `mise.sh` auto-promotes it to `MISE_GITHUB_TOKEN` (authenticated 5000/hr; no 403). Same mechanism gate.yml already uses (line 72).
- **`ZETA_INSTALL_FULL=1`** → exercise the one-liner installers. The throttle (TTY-skip) stays only on the gate lint jobs that just need `bun`.

Delivery differs by how each shield runs install.sh:

| Shield | Mechanism |
|---|---|
| macos | job-level `env` (install.sh on the runner) |
| wsl | step `env` + `WSLENV` extended to carry both vars into the WSL shell |
| docker-ubuntu | `GITHUB_TOKEN` via BuildKit `--secret` (mounted as a file for the install.sh RUN only — **never** baked into a layer, vs `--build-arg`) + `ZETA_INSTALL_FULL` scoped to that RUN; `# syntax=docker/dockerfile:1` added |
| docker-nixos | same Dockerfile pattern; TS driver passes `--secret` in buildArgs with `DOCKER_BUILDKIT=1` |

## Verification

- `actionlint` CLEAN on all 4 workflows
- `tsc` clean on the nixos driver
- BuildKit-secret uses file-mount + `|| true` so local builds (no `--secret`) still work (empty token = unauth, as before)

## Follow-up (not in this PR)

The Windows Server-Core ps1 shield (`docker-windows-install-ps1-test`) also runs mise and needs a token, but Windows container secrets differ from Linux BuildKit and `install.ps1`'s token-handling needs verifying first — deferred to a separate careful change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)