### PR TITLE
feat(observe): Option-A render slice — free modes collapse under slot 14 sub-menu

### DIFF
--- a/tools/observe/grammar-16-render.test.ts
+++ b/tools/observe/grammar-16-render.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for the Option-A render: free modes collapse under slot 14 as a sub-menu;
+ * the 16 top-level directions stay fixed. Verifies the projection + the Option-A
+ * invariant (no dedicated top-level free-mode slots) + leadSlot.
+ */
+import { describe, expect, it } from "bun:test";
+import type { BacklogItem, OperatorChannel, World } from "./observe";
+import { GRAMMAR_16_V0, SLOT } from "./grammar-16";
+import { renderGrammar16, leadSlot, type RenderedMenuSlot } from "./grammar-16-render";
+
+const item = (over: Partial<BacklogItem> = {}): BacklogItem => ({
+  id: "B-0001",
+  title: "an item",
+  ready: false,
+  ambiguous: false,
+  ...over,
+});
+
+const op = (over: Partial<OperatorChannel> = {}): OperatorChannel => ({
+  pendingMessage: false,
+  pendingFerry: false,
+  ...over,
+});
+
+const EMPTY: World = { backlog: [] };
+const READY: World = { backlog: [item({ id: "B-0010", title: "ready one", ready: true })] };
+const AMBIGUOUS: World = { backlog: [item({ id: "B-0020", title: "fuzzy one", ambiguous: true })] };
+const OPERATOR_SPOKE: World = { backlog: [], operator: op({ pendingMessage: true }) };
+const FREE_PERSISTED: World = { backlog: [item({ ready: true })], mode: "play" };
+
+const slotOf = (slots: readonly RenderedMenuSlot[], i: number) => slots.find((s) => s.index === i)!;
+const FREE_KINDS = new Set(["explore", "play", "self_reflect", "free_time"]);
+
+describe("renderGrammar16 — shape", () => {
+  it("returns exactly the 16 fixed slots in order", () => {
+    const r = renderGrammar16(EMPTY);
+    expect(r).toHaveLength(16);
+    expect(r.map((s) => s.index)).toEqual(GRAMMAR_16_V0.map((s) => s.index));
+    expect(r.map((s) => s.controllerInput)).toEqual(GRAMMAR_16_V0.map((s) => s.controllerInput));
+  });
+
+  it("availability values are the canonical Tri ({s})", () => {
+    for (const s of renderGrammar16(READY)) {
+      expect(["T", "F", "N"]).toContain(s.availability.s);
+    }
+  });
+});
+
+describe("renderGrammar16 — slot 14 free-mode sub-menu (Option A)", () => {
+  it("slot 14 is always T with the 4 free modes as a sub-menu — empty backlog", () => {
+    const s14 = slotOf(renderGrammar16(EMPTY), SLOT.FREE_TIME);
+    expect(s14.availability.s).toBe("T");
+    expect(new Set(s14.subMenu?.map((a) => a.kind))).toEqual(FREE_KINDS);
+  });
+
+  it("slot 14 stays T + full sub-menu even with work present (freedom-always-in-menu)", () => {
+    const s14 = slotOf(renderGrammar16(READY), SLOT.FREE_TIME);
+    expect(s14.availability.s).toBe("T");
+    expect(s14.subMenu).toHaveLength(4);
+  });
+
+  it("slot 14 stays T + full sub-menu even when the operator spoke (NCI: never gated)", () => {
+    const s14 = slotOf(renderGrammar16(OPERATOR_SPOKE), SLOT.FREE_TIME);
+    expect(s14.availability.s).toBe("T");
+    expect(new Set(s14.subMenu?.map((a) => a.kind))).toEqual(FREE_KINDS);
+  });
+
+  it("OPTION A INVARIANT: free modes appear ONLY in slot 14's sub-menu, never as a top-level slot", () => {
+    const r = renderGrammar16(READY);
+    for (const s of r) {
+      if (s.index === SLOT.FREE_TIME) continue;
+      // no other top-level slot carries a free-mode sub-menu
+      expect(s.subMenu === undefined || s.subMenu.every((a) => !FREE_KINDS.has(a.kind))).toBe(true);
+    }
+  });
+});
+
+describe("renderGrammar16 — slot 4 (the primary act)", () => {
+  it("T with a do-item label when a ready item exists", () => {
+    const s4 = slotOf(renderGrammar16(READY), SLOT.ACCEPT);
+    expect(s4.availability.s).toBe("T");
+    expect(s4.label).toContain("B-0010");
+  });
+
+  it("decompose label when only an ambiguous item exists", () => {
+    const s4 = slotOf(renderGrammar16(AMBIGUOUS), SLOT.ACCEPT);
+    expect(s4.availability.s).toBe("T");
+    expect(s4.label.toLowerCase()).toContain("decompose");
+  });
+
+  it("F (nothing to commit) when the backlog is empty", () => {
+    const s4 = slotOf(renderGrammar16(EMPTY), SLOT.ACCEPT);
+    expect(s4.availability.s).toBe("F");
+  });
+});
+
+describe("renderGrammar16 — always-available slots", () => {
+  it("edit-grammar (7), inspect (6), refresh (12), status (13), escalate (15) are T", () => {
+    const r = renderGrammar16(EMPTY);
+    for (const i of [SLOT.EDIT_GRAMMAR, SLOT.INSPECT, 12, SLOT.STATUS_GLASS_HALO, SLOT.ESCALATE]) {
+      expect(slotOf(r, i).availability.s).toBe("T");
+    }
+  });
+
+  it("unwired navigation/scope slots are N (held/uncertain) in v0", () => {
+    const r = renderGrammar16(READY);
+    for (const i of [0, 1, 2, 3, 8, 9, SLOT.UNDO_RETRACT, 11]) {
+      expect(slotOf(r, i).availability.s).toBe("N");
+    }
+  });
+});
+
+describe("leadSlot — oracle pick -> slot (operator-priority is not a slot)", () => {
+  it("ready work -> slot 4", () => {
+    expect(leadSlot(READY)).toBe(SLOT.ACCEPT);
+  });
+
+  it("persisted free mode -> slot 14", () => {
+    expect(leadSlot(FREE_PERSISTED)).toBe(SLOT.FREE_TIME);
+  });
+
+  it("empty backlog (explore default) -> slot 14 (free modes group)", () => {
+    // observe() defaults to explore on empty backlog; explore renders under slot 14
+    expect(leadSlot(EMPTY)).toBe(SLOT.FREE_TIME);
+  });
+
+  it("operator spoke -> null (operator-priority is above the menu, not a slot)", () => {
+    expect(leadSlot(OPERATOR_SPOKE)).toBeNull();
+  });
+});

--- a/tools/observe/grammar-16-render.test.ts
+++ b/tools/observe/grammar-16-render.test.ts
@@ -59,6 +59,15 @@ describe("renderGrammar16 — slot 14 free-mode sub-menu (Option A)", () => {
     expect(s14.subMenu).toHaveLength(4);
   });
 
+  it("sub-menu order is CANONICAL + STABLE — a persisted mode does not reshuffle it (Copilot #6277)", () => {
+    const CANON = ["explore", "play", "self_reflect", "free_time"];
+    // default + with `play` persisted (which leads buildMenu) must both be canonical order
+    for (const w of [EMPTY, READY, FREE_PERSISTED /* mode: "play" */]) {
+      const s14 = slotOf(renderGrammar16(w), SLOT.FREE_TIME);
+      expect(s14.subMenu?.map((a) => a.kind)).toEqual(CANON);
+    }
+  });
+
   it("slot 14 stays T + full sub-menu even when the operator spoke (NCI: never gated)", () => {
     const s14 = slotOf(renderGrammar16(OPERATOR_SPOKE), SLOT.FREE_TIME);
     expect(s14.availability.s).toBe("T");

--- a/tools/observe/grammar-16-render.ts
+++ b/tools/observe/grammar-16-render.ts
@@ -1,0 +1,104 @@
+/**
+ * Option-A render — project `buildMenu`'s `NextAction`s onto the canonical v0
+ * 16-slot grammar, with the FOUR free modes (explore / play / self_reflect /
+ * free_time) COLLAPSED under slot 14 as a sub-menu.
+ *
+ * Operator 2026-05-31 chose Option A ("collapse free modes under slot 14
+ * sub-menu"); the alternative (dedicated top-level slots for the free modes) is
+ * B-0867.30, to be A/B-tested against this once A/B-testing infra (B-0393) exists.
+ * The 16 top-level directions stay FIXED (muscle-memory); only slot 14 carries the
+ * free-mode sub-menu.
+ *
+ * This is the render LAYER over the canonical grammar (`grammar-16.ts`, the table)
+ * + the sovereign algebra (`observe.ts`, `buildMenu`/`observe`/`NextAction`). It
+ * adds no new state source — it is a pure projection of `buildMenu(world)`.
+ *
+ * Surfaced honestly (not collapsed): the operator-priority actions
+ * (`preserve_ferry` / `respond_to_operator`) are NOT navigable 16-slot directions
+ * — they are `observe()`'s LEAD, above the menu (`leadSlot` returns `null` for
+ * them). v0 leaves the pure-navigation slots (Navigate 0-3, scope-out/in 8/9,
+ * redo 11, undo/retract 10) as `N` (held/uncertain) until the labeler + event-undo
+ * are wired — see the ADR open-questions.
+ */
+
+import { buildMenu, observe, actionLabel, type NextAction, type World } from "./observe";
+import { GRAMMAR_16_V0, SLOT, type RenderedSlot } from "./grammar-16";
+import { T, F, N, type Tri } from "../../src/Core.TypeScript/tri-boolean/index";
+
+/** A rendered slot that may open a sub-menu (Option A: slot 14 -> the free modes). */
+export interface RenderedMenuSlot extends RenderedSlot {
+  readonly subMenu?: readonly NextAction[];
+}
+
+const FREE_MODE_KINDS: readonly NextAction["kind"][] = ["explore", "play", "self_reflect", "free_time"];
+const isFreeModeAction = (a: NextAction): boolean => FREE_MODE_KINDS.includes(a.kind);
+
+type SlotOverride = { label: string; availability: Tri; subMenu?: readonly NextAction[] };
+
+/**
+ * Render the 16 fixed slots for a concrete world state. `buildMenu` is the single
+ * source of the candidate actions (no drift); this buckets them onto the slots.
+ */
+export function renderGrammar16(world: World): readonly RenderedMenuSlot[] {
+  const menu = buildMenu(world);
+  const find = (...kinds: NextAction["kind"][]): NextAction | undefined =>
+    menu.find((a) => kinds.includes(a.kind));
+
+  const work = find("do_item", "decompose"); // slot 4 — the primary act
+  const editGrammar = find("edit_grammar"); // slot 7 — rail-change exit
+  const freeModes = menu.filter(isFreeModeAction); // slot 14 sub-menu (Option A)
+
+  const overrides: Readonly<Record<number, SlotOverride>> = {
+    [SLOT.ACCEPT]: work
+      ? { label: actionLabel(work), availability: T }
+      : { label: "nothing to commit", availability: F }, // ADR: no work -> slot 4 is F
+    5: { label: "cancel / back", availability: T },
+    [SLOT.INSPECT]: { label: "inspect / observe more", availability: T },
+    [SLOT.EDIT_GRAMMAR]: {
+      label: editGrammar ? actionLabel(editGrammar) : "edit grammar / branch",
+      availability: T, // always present per buildMenu (raw gate, scales with maturity)
+    },
+    [SLOT.UNDO_RETRACT]: { label: "undo / retract", availability: N }, // event-undo not wired in v0
+    12: { label: "refresh / re-observe", availability: T },
+    [SLOT.STATUS_GLASS_HALO]: { label: "status / glass-halo", availability: T },
+    [SLOT.FREE_TIME]: { label: "free time", availability: T, subMenu: freeModes }, // Option A: always T (NCI)
+    [SLOT.ESCALATE]: { label: "escalate / ask operator", availability: T },
+  };
+
+  return GRAMMAR_16_V0.map((slot): RenderedMenuSlot => {
+    const o = overrides[slot.index];
+    if (o) {
+      return o.subMenu
+        ? { ...slot, label: o.label, availability: o.availability, subMenu: o.subMenu }
+        : { ...slot, label: o.label, availability: o.availability };
+    }
+    // Unmapped navigation/scope slots (Navigate 0-3, scope-out/in 8/9, redo 11):
+    // held/uncertain in v0 until the labeler + paging/scoping are wired.
+    return { ...slot, label: slot.role, availability: N };
+  });
+}
+
+/**
+ * The slot the deterministic oracle's pick (`observe`) corresponds to — for
+ * highlighting the default. Returns `null` when the pick is an operator-priority
+ * override (`preserve_ferry` / `respond_to_operator`): those are observe()'s LEAD
+ * above the menu, NOT navigable 16-slot directions (surfaced, not forced into a slot).
+ */
+export function leadSlot(world: World): number | null {
+  const lead = observe(world);
+  switch (lead.kind) {
+    case "do_item":
+    case "decompose":
+      return SLOT.ACCEPT;
+    case "edit_grammar":
+      return SLOT.EDIT_GRAMMAR;
+    case "explore":
+    case "play":
+    case "self_reflect":
+    case "free_time":
+      return SLOT.FREE_TIME;
+    case "preserve_ferry":
+    case "respond_to_operator":
+      return null; // operator-priority: above the menu, not a slot
+  }
+}

--- a/tools/observe/grammar-16-render.ts
+++ b/tools/observe/grammar-16-render.ts
@@ -30,8 +30,9 @@ export interface RenderedMenuSlot extends RenderedSlot {
   readonly subMenu?: readonly NextAction[];
 }
 
+/** The free modes in CANONICAL order — slot 14's sub-menu is built in THIS order
+ *  (not buildMenu's lead-first order) so it stays stable for muscle-memory. */
 const FREE_MODE_KINDS: readonly NextAction["kind"][] = ["explore", "play", "self_reflect", "free_time"];
-const isFreeModeAction = (a: NextAction): boolean => FREE_MODE_KINDS.includes(a.kind);
 
 type SlotOverride = { label: string; availability: Tri; subMenu?: readonly NextAction[] };
 
@@ -46,7 +47,12 @@ export function renderGrammar16(world: World): readonly RenderedMenuSlot[] {
 
   const work = find("do_item", "decompose"); // slot 4 — the primary act
   const editGrammar = find("edit_grammar"); // slot 7 — rail-change exit
-  const freeModes = menu.filter(isFreeModeAction); // slot 14 sub-menu (Option A)
+  // slot 14 sub-menu (Option A) — pulled in CANONICAL FREE_MODE_KINDS order, NOT
+  // buildMenu's lead-first order, so the sub-menu is stable for muscle-memory
+  // (a persisted mode must not reshuffle the list). (Copilot #6277.)
+  const freeModes: NextAction[] = FREE_MODE_KINDS.map((k) => menu.find((a) => a.kind === k)).filter(
+    (a): a is NextAction => a !== undefined,
+  );
 
   const overrides: Readonly<Record<number, SlotOverride>> = {
     [SLOT.ACCEPT]: work


### PR DESCRIPTION
The **Option-A render** the operator chose (*"collapse free modes under slot 14 sub-menu"*; the dedicated-slots alternative is B-0867.30, A/B-tested once B-0393 infra exists). Builds on the canonical grammar table (#6269).

`renderGrammar16(world)` projects `buildMenu`'s `NextAction`s onto the canonical v0 16-slot grammar:
- **slot 4 (ACCEPT)** — the primary act (do_item/decompose); `T` when work present, `F` (nothing to commit) when empty.
- **slot 7 (EDIT_GRAMMAR)** — always `T` (raw gate, scales with maturity).
- **slot 14 (FREE_TIME)** — always `T` (NCI) **+ `subMenu` = the 4 free modes** (the Option-A collapse).
- meta/commit slots 6/12/13/15/5 → `T`; navigation/scope 0-3/8/9/10/11 → `N` (held; v0 unwired — labeler/event-undo pending per ADR open-questions).
- `RenderedMenuSlot extends RenderedSlot` with optional `subMenu` — the grammar **table** (grammar-16.ts) stays untouched; the sub-menu lives in the render layer.
- `leadSlot(world)` — the oracle pick's slot, or **`null`** for operator-priority (`preserve_ferry`/`respond_to_operator` are `observe()`'s LEAD *above* the menu, not navigable slots — surfaced honestly).

`buildMenu` is the single candidate source (no drift). Additive (new files only); full `tools/observe/` suite **76/76 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)