### PR TITLE
fix(shield): authenticate mise in the windows-ps1 install shield (MISE_GITHUB_TOKEN build-arg)

### DIFF
--- a/.github/workflows/docker-windows-install-ps1-test.yml
+++ b/.github/workflows/docker-windows-install-ps1-test.yml
@@ -122,10 +122,19 @@ jobs:
           Write-Host "DockerRootDir = $root"
           if ($root -notlike 'D:*') { Write-Host "::warning::data-root did not relocate to D: (got '$root') — build may still hit C: disk" }
 
+      # GITHUB_TOKEN forwards into the build (as MISE_GITHUB_TOKEN --build-arg) so mise install
+      # authenticates to the GitHub API (5000/hr) instead of hitting the unauthenticated 60/hr -> 403.
+      # Sibling fix to the 4 Unix shields (#6273). The legacy Windows builder has no BuildKit secret
+      # mounts, so the driver uses --build-arg + redacts the value in its logged command; the image is
+      # rmi'd in cleanup() so its history is discarded same-job. ZETA_INSTALL_FULL is NOT set here:
+      # that var gates the Unix one-liner-tools registry, which install.ps1 does not use. The top-level
+      # `permissions: contents: read` is sufficient — mise only READS public release metadata; the
+      # token just raises the rate limit.
       - name: Run Server-Core Docker install.ps1 test
         env:
           DOCKER_LOG_OUT_PATH: docker-windows-install-ps1-test.log
           DOCKER_BUILD_TIMEOUT_SEC: '2400'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun tools/ci/docker-windows-install-ps1-test.ts
 
       - name: Upload Docker test log (always)

--- a/tools/ci/docker-windows-install-ps1-test.ts
+++ b/tools/ci/docker-windows-install-ps1-test.ts
@@ -18,6 +18,14 @@
  *   DOCKER_BUILD_TIMEOUT_SEC   override timeout (default 2400 — servercore pull + scoop + mise
  *                              install of .mise.toml runtimes is heavy on a cold runner)
  *   DOCKER_LOG_OUT_PATH        override log path (default .tools/docker-windows-install-ps1-test.log)
+ *   GITHUB_TOKEN               (optional) GitHub API token forwarded to mise INSIDE the build as
+ *                              MISE_GITHUB_TOKEN (--build-arg) so `mise install` authenticates
+ *                              (5000 req/hr) instead of hitting the unauthenticated 60/hr -> 403.
+ *                              See the Dockerfile's ARG MISE_GITHUB_TOKEN block for the full
+ *                              rationale + leak mitigations (legacy Windows builder has no BuildKit
+ *                              secret mounts, so --build-arg is the channel; the value is redacted
+ *                              in the logged command below + the image is rmi'd in cleanup()).
+ *                              Unset -> mise stays unauthenticated (identical to prior behavior).
  *
  * Exit codes: 0 build ok | 1 build failed | 2 usage/prereq | 124 timeout.
  */
@@ -52,6 +60,7 @@ function usage(): never {
   console.error("env:");
   console.error("  DOCKER_BUILD_TIMEOUT_SEC  override timeout (default 2400)");
   console.error("  DOCKER_LOG_OUT_PATH       override log path");
+  console.error("  GITHUB_TOKEN              (optional) forwarded to mise as MISE_GITHUB_TOKEN (build-arg)");
   process.exit(2);
 }
 
@@ -71,10 +80,28 @@ function checkPrereqs(): void {
 
 function runBuild(timeoutSec: number, logPath: string): BuildResult {
   const startMs = Date.now();
-  // NOTE: no --progress=plain — the windows-2022 runner uses the LEGACY docker builder (not
+  // NOTE: no --progress=plain — the windows-2025 runner uses the LEGACY docker builder (not
   // BuildKit/buildx), which rejects --progress. Output still streams to stdout/stderr (captured).
-  const buildArgs = ["build", "--file", DOCKERFILE_PATH, "--tag", IMAGE_TAG, "."];
-  console.log(`[Slice 2c] docker build ${buildArgs.join(" ")}`);
+  //
+  // mise GitHub-API token (rate-limit fix; sibling to the 4 Unix shields in #6273): forward the
+  // ambient GITHUB_TOKEN into the build as MISE_GITHUB_TOKEN so `mise install` authenticates
+  // (5000/hr) instead of hitting the unauthenticated 60/hr -> 403. The legacy Windows builder has
+  // NO BuildKit `--mount=type=secret`, so --build-arg is the only build-time channel; the Dockerfile's
+  // `ARG MISE_GITHUB_TOKEN` exposes it to the install RUN as an env var that mise inherits. See the
+  // Dockerfile block for the full leak-mitigation reasoning (ephemeral token + image rmi'd in
+  // cleanup() + the redaction below). Empty when unset -> mise stays unauthenticated (prior behavior).
+  const miseGithubToken = process.env.GITHUB_TOKEN ?? "";
+  const buildArgs = [
+    "build",
+    "--file", DOCKERFILE_PATH,
+    "--build-arg", `MISE_GITHUB_TOKEN=${miseGithubToken}`,
+    "--tag", IMAGE_TAG,
+    ".",
+  ];
+  // REDACT the token value in the logged command — NEVER print the secret to CI logs. (GHA also
+  // auto-masks GITHUB_TOKEN, but that's the backup; this explicit redaction is the primary defense.)
+  const loggedArgs = buildArgs.map((a) => (a.startsWith("MISE_GITHUB_TOKEN=") ? "MISE_GITHUB_TOKEN=***" : a));
+  console.log(`[Slice 2c] docker ${loggedArgs.join(" ")}`);
   console.log(`[Slice 2c] timeout: ${timeoutSec}s; log: ${logPath}`);
 
   const result = spawnDocker(buildArgs, { timeoutMs: timeoutSec * 1000 });

--- a/tools/ci/docker-windows-install-ps1-test.ts
+++ b/tools/ci/docker-windows-install-ps1-test.ts
@@ -8,7 +8,7 @@
  * tools/ci/dockerfiles/windows-install-ps1-test/Dockerfile with exit-code mapping, log capture
  * (CI artifact), and timeout enforcement.
  *
- * REQUIRES a Windows host with Docker in Windows-container mode (the windows-2022 GitHub runner).
+ * REQUIRES a Windows host with Docker in Windows-container mode (the windows-2025 GitHub runner).
  * Windows containers cannot run on Linux hosts.
  *
  * Usage:
@@ -25,7 +25,11 @@
  *                              rationale + leak mitigations (legacy Windows builder has no BuildKit
  *                              secret mounts, so --build-arg is the channel; the value is redacted
  *                              in the logged command below + the image is rmi'd in cleanup()).
- *                              Unset -> mise stays unauthenticated (identical to prior behavior).
+ *                              DELIBERATELY OMITTED when --keep-image is set: a retained image's
+ *                              `docker history` would carry the build-arg value, so a kept image must
+ *                              never have the token baked in (mise then runs unauthenticated for that
+ *                              run — a tolerable local-debug degradation). Unset -> mise stays
+ *                              unauthenticated (identical to prior behavior).
  *
  * Exit codes: 0 build ok | 1 build failed | 2 usage/prereq | 124 timeout.
  */
@@ -60,7 +64,8 @@ function usage(): never {
   console.error("env:");
   console.error("  DOCKER_BUILD_TIMEOUT_SEC  override timeout (default 2400)");
   console.error("  DOCKER_LOG_OUT_PATH       override log path");
-  console.error("  GITHUB_TOKEN              (optional) forwarded to mise as MISE_GITHUB_TOKEN (build-arg)");
+  console.error("  GITHUB_TOKEN              (optional) forwarded to mise as MISE_GITHUB_TOKEN (build-arg);");
+  console.error("                           omitted when --keep-image is set (no token in a retained image)");
   process.exit(2);
 }
 
@@ -78,7 +83,7 @@ function checkPrereqs(): void {
   }
 }
 
-function runBuild(timeoutSec: number, logPath: string): BuildResult {
+function runBuild(timeoutSec: number, logPath: string, keepImage: boolean): BuildResult {
   const startMs = Date.now();
   // NOTE: no --progress=plain — the windows-2025 runner uses the LEGACY docker builder (not
   // BuildKit/buildx), which rejects --progress. Output still streams to stdout/stderr (captured).
@@ -89,8 +94,17 @@ function runBuild(timeoutSec: number, logPath: string): BuildResult {
   // NO BuildKit `--mount=type=secret`, so --build-arg is the only build-time channel; the Dockerfile's
   // `ARG MISE_GITHUB_TOKEN` exposes it to the install RUN as an env var that mise inherits. See the
   // Dockerfile block for the full leak-mitigation reasoning (ephemeral token + image rmi'd in
-  // cleanup() + the redaction below). Empty when unset -> mise stays unauthenticated (prior behavior).
-  const miseGithubToken = process.env.GITHUB_TOKEN ?? "";
+  // cleanup() + the redaction below).
+  //
+  // --keep-image OMITS the token: cleanup() skips the `docker rmi -f` for a kept image, so its
+  // `docker history` (where ARG values surface) would persist the token — bypassing the discard
+  // mitigation. A retained image must therefore never carry it; mise runs unauthenticated for that
+  // run (a tolerable local-debug degradation). Empty when unset -> unauthenticated (prior behavior).
+  const ambientToken = process.env.GITHUB_TOKEN ?? "";
+  const miseGithubToken = keepImage ? "" : ambientToken;
+  if (keepImage && ambientToken !== "") {
+    console.log("[Slice 2c] --keep-image set: OMITTING MISE_GITHUB_TOKEN so the retained image's history carries no token (mise runs unauthenticated for this run; GitHub rate-limit possible).");
+  }
   const buildArgs = [
     "build",
     "--file", DOCKERFILE_PATH,
@@ -156,7 +170,7 @@ function main(): void {
   if (logDir && !existsSync(logDir)) mkdirSync(logDir, { recursive: true });
 
   checkPrereqs();
-  const result = runBuild(timeoutSec, logPath);
+  const result = runBuild(timeoutSec, logPath, keepImage);
   console.log("");
   console.log(`[Slice 2c] result: ${result.reason}`);
   console.log(`[Slice 2c] log: ${logPath}`);

--- a/tools/ci/dockerfiles/windows-install-ps1-test/Dockerfile
+++ b/tools/ci/dockerfiles/windows-install-ps1-test/Dockerfile
@@ -51,6 +51,28 @@ COPY tools/persistence/windows C:/workspace/tools/persistence/windows
 COPY .mise.toml C:/workspace/.mise.toml
 COPY package.json C:/workspace/package.json
 
+# mise's GitHub-API token (the shield's rate-limit fix; sibling to the 4 Unix shields in #6273).
+# install.ps1 runs `mise install`, which calls the GitHub API to resolve .mise.toml runtime versions
+# from GitHub releases. UNAUTHENTICATED that API is 60 req/hr -> a cold cluster build exhausts it and
+# mise gets HTTP 403 (the exact failure the Unix macOS shield hit). AUTHENTICATED it's 5000 req/hr.
+#
+# WHY MISE_GITHUB_TOKEN (not GITHUB_TOKEN): mise's auth precedence is MISE_GITHUB_TOKEN >
+# GITHUB_API_TOKEN > GITHUB_TOKEN. Unix mise.sh auto-PROMOTES GITHUB_TOKEN -> MISE_GITHUB_TOKEN;
+# install.ps1 has NO such promotion, so the shield sets the highest-precedence var DIRECTLY.
+#
+# WHY --build-arg (not BuildKit --mount=type=secret like the Unix shields): the windows-2025 runner
+# uses the LEGACY docker builder (see the driver's NOTE), which has no BuildKit secret mounts. ARG
+# is the only build-time channel on the classic builder; declared here it is exposed to the install
+# RUN below as the $env:MISE_GITHUB_TOKEN build env var (core ARG-to-RUN-env behavior, cross-platform),
+# which `mise install` (a child of the RUN's powershell) inherits. It is NOT promoted to a persistent
+# ENV (that would bake it into every layer + `docker inspect` Config.Env) — ARG scope keeps it to the
+# build only. LEAK MITIGATION: (1) the value is the per-run ephemeral GitHub Actions GITHUB_TOKEN
+# (dead the moment the job ends); (2) the driver `docker rmi -f`s this image in cleanup() — its
+# `docker history` (where ARG values surface) is discarded in the same job, never pushed; (3) the
+# driver REDACTS the value to *** in the build command it logs, and GHA auto-masks GITHUB_TOKEN.
+# Empty (local runs without the env var) -> mise stays unauthenticated, identical to prior behavior.
+ARG MISE_GITHUB_TOKEN
+
 # Install graph + assert in ONE RUN so install.ps1's in-process PATH additions (scoop + mise
 # shims) carry to the smoke. -SkipLoopRegister: no interactive session in a container -> the
 # user-mode scheduled task isn't registered (desktop loop-smoke covers it). install.ps1 detects


### PR DESCRIPTION
## What

Authenticates `mise` inside the **windows-ps1 install shield** (`docker-windows-install-ps1-test`) so it stops hitting the GitHub API rate-limit. This is the sibling of the 4 Unix shields fixed in #6273 — the windows-ps1 follow-up that #6273's body flagged as deferred ("Windows container secrets differ + install.ps1's token-handling needs verifying first"). That verification is done; this lands the fix.

## Why it 403s

The shield runs `install.ps1` → `mise install`, which calls the GitHub API to resolve `.mise.toml` runtimes from GitHub releases. **Unauthenticated** that API is 60 req/hr; a cold Server-Core build exhausts it and mise gets HTTP 403 (the exact failure the macOS shield hit). **Authenticated** it's 5000 req/hr.

## Why the Windows delivery differs from the Unix shields

| Concern | Unix shields (#6273) | Windows shield (this PR) |
|---|---|---|
| Token var | `GITHUB_TOKEN` (Unix `mise.sh` auto-promotes → `MISE_GITHUB_TOKEN`) | **`MISE_GITHUB_TOKEN` set directly** — `install.ps1` has **no** promotion logic, so we set mise's highest-precedence var (`MISE_GITHUB_TOKEN > GITHUB_API_TOKEN > GITHUB_TOKEN`) |
| Build-time channel | BuildKit `--mount=type=secret` (token never enters layers) | **`--build-arg`** — the `windows-2025` runner uses the **legacy docker builder** (no BuildKit secret mounts; documented in the driver's NOTE). ARG is the only build-time channel; it reaches the install RUN as `$env:MISE_GITHUB_TOKEN`, which mise inherits |
| `ZETA_INSTALL_FULL` | set (exercises the Unix one-liner-tools registry) | **not set** — that registry is Unix-only; `install.ps1` doesn't use it |

## Leak mitigations for the `--build-arg`

A build-arg secret has two leak surfaces; both are mitigated:

1. **`docker history`** (where ARG values surface) — the driver already `docker rmi -f`s the image in `cleanup()`, so the history is discarded in the **same job, never pushed**. The token is the **per-run ephemeral `GITHUB_TOKEN`** (dead the moment the job ends).
2. **The driver logs the build command** — the value is **redacted to `***`** before logging (GHA's auto-mask of `GITHUB_TOKEN` is the backup, not the primary defense).

It's declared `ARG` (not `ENV`), so ARG scope keeps it out of image layers + `docker inspect Config.Env`. Unset `GITHUB_TOKEN` → mise stays unauthenticated (prior behavior).

## Files

- `tools/ci/dockerfiles/windows-install-ps1-test/Dockerfile` — `ARG MISE_GITHUB_TOKEN` before the `install.ps1` RUN
- `tools/ci/docker-windows-install-ps1-test.ts` — `--build-arg MISE_GITHUB_TOKEN` from `process.env.GITHUB_TOKEN`; value redacted in the logged command
- `.github/workflows/docker-windows-install-ps1-test.yml` — forward `GITHUB_TOKEN` to the driver step

## Validation

- `tsc` clean on the driver
- `actionlint` exit 0 on the workflow
- The shield's paths-filter matches all three changed files, so **this PR self-tests the fix** — a green ~15-min Windows-container build means mise no longer 403s.

## Follow-up (not bundled)

Optional parity item: `install.ps1` could gain a `GITHUB_TOKEN → MISE_GITHUB_TOKEN` promotion (mirroring Unix `mise.sh`) so Windows *devs* who only set `GITHUB_TOKEN` get auto-auth too. Kept out of this PR to keep it scoped to the shield (the literal ask); it touches the production install path so it's a separate, reviewable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
