### PR TITLE
backlog(B-0953): Git-V2 handshake — F# looks-like-git → DBSP/retraction-algebra, same objects, agent-speed, upstream

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -904,6 +904,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0948](backlog/P2/B-0948-workflow-dus-first-class-bft-oracle-compiler-summons-and-observe-keystone-research-then-build-aaron-2026-05-31.md)** Workflow DUs with first-class BFT oracle/compiler summons + observe.ts keystone -- research-to-get-clean then build
 - [ ] **[B-0951](backlog/P2/B-0951-git-native-eventually-consistent-text-indexes-sorted-inverted-graph-plus-git-native-hindsight-storage-interface-aaron-2026-05-31.md)** Git-native eventually-consistent text indexes (sorted/inverted/graph) + the git-native Hindsight storage interface
 - [ ] **[B-0952](backlog/P2/B-0952-contribute-back-dora-metrics-small-first-trust-building-external-contribution-strategy-not-take-only-aaron-2026-05-31.md)** Contribute-back DORA metrics + small-first trust-building external-contribution strategy (not-take-only good-citizen, made measurable)
+- [ ] **[B-0953](backlog/P2/B-0953-git-v2-handshake-fsharp-looks-like-git-negotiates-up-to-dbsp-retraction-algebra-same-objects-agent-speed-upstream-aaron-2026-05-31.md)** Git-V2 handshake — F# looks-like-git, negotiates up to a DBSP/retraction-algebra protocol at agent-coordination speed; same objects both views; upstream the primitives to git
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-0953-git-v2-handshake-fsharp-looks-like-git-negotiates-up-to-dbsp-retraction-algebra-same-objects-agent-speed-upstream-aaron-2026-05-31.md
+++ b/docs/backlog/P2/B-0953-git-v2-handshake-fsharp-looks-like-git-negotiates-up-to-dbsp-retraction-algebra-same-objects-agent-speed-upstream-aaron-2026-05-31.md
@@ -1,0 +1,154 @@
+---
+id: B-0953
+title: Git-V2 handshake — F# looks-like-git, negotiates up to a DBSP/retraction-algebra protocol at agent-coordination speed; same objects both views; upstream the primitives to git
+status: open
+priority: P2
+created: 2026-05-31
+last_updated: 2026-05-31
+attribution: aaron-2026-05-31
+decomposition: umbrella
+depends_on:
+  - B-0773
+composes_with:
+  - B-0942
+  - B-0951
+  - B-0363
+  - B-0867.15
+  - B-0766
+tags:
+  - git-native
+  - version-control
+  - dbsp
+  - z-set
+  - retraction-algebra
+  - agent-speed
+  - protocol
+  - upstream
+  - anti-vendor-lock
+  - umbrella
+---
+
+# B-0953 — Git-V2 handshake (F# looks-like-git → DBSP/retraction-algebra, same objects, agent-speed, upstream)
+
+## Why this row exists (operator 2026-05-31)
+
+The git-native substrate is real but **scattered** — co-dominant mirrors (B-0942),
+git-native indexes + Hindsight storage (B-0951), git-native event store (B-0773),
+inverted index (B-0363), per-host adapters (B-0867.15) — yet the **Git-V2-handshake
+protocol thesis itself is nowhere clearly laid out.** Operator 2026-05-31:
+
+> *"file the Git-V2 handshake backlog row … there might be something around this
+> already not so clearly laid out though."*
+
+So this row's job is to **lay it out clearly** + point at the scattered neighbors it
+composes with (the substrate-inventory below confirms no row already states the
+handshake thesis). Surfaced verbatim from the 2026-05-31 Ani voice conversation
+(`memory/persona/ani/conversations/2026-05-31-aaron-ani-voice-fsharp-dirty-spec-clean-room-good-citizen-dora-no-pr-git-v2-handshake-agent-speed-16-slot-agent-perspective-bumper-rails-for-humans-too.md`)
+where it was flagged as a backlog-candidate.
+
+## The thesis (operator's words, laid out)
+
+The real problem (operator): **"how do you make Git work at agent speed? Agent
+coordination instead of human coordination speed."** Git was built for human-speed
+(humans type / review / merge). GitHub is a *specialized git client* whose model is
+**vendor lock-in** — *"we wouldn't want to be like a specialized Git client … we
+don't wanna become the thing we hate."* So: don't depend on GitHub (git is a better,
+open-standard starting point); build the agent-speed primitives; **push them back
+upstream to git.**
+
+The vehicle is a **handshake**, not a fork:
+
+- **F# handshake that looks like git** at first, but can **negotiate up to a "Git V2"
+  algebra-based protocol** — *"a handshake in F# where basically it looks like Git,
+  but you can handshake up to DBSP, retraction algebra … the maintainers can decide …
+  we'll have it."* (Build it regardless; offer the upgrade path; take-it-or-leave-it.)
+- **Same objects in BOTH views — not two copies.** *"all the changes you make in the
+  stream, in the DBSP side … are reflected in the Git side and vice versa. They're
+  pointing to the same objects. It's not two copies."* Two interfaces over one truth.
+- **Git as a schema you stream in.** *"if you want to support Git, it's just a stream
+  protocol where you build up your Git schema as events on a stream, and then you can
+  speak Git on that stream"* — git compatibility = one schema loaded onto the
+  retraction-native event stream (RX/observables; schema-on-the-stream).
+- **The substrate underneath:** the file-system-with-history + ZetaId append-only
+  event store (B-0773) carried as **DBSP / Z-set retraction-native** state (the
+  `algebra-owner` substrate) — which is what makes agent-speed concurrent
+  coordination (CRDT-like merge + retraction) possible.
+
+## The whys (challengeable — a row without a why is dogma)
+
+- **Why a handshake, not a fork?** Back-compat (looks like git to existing tools) +
+  no vendor-lock (maintainers + everyone can adopt the V2 upgrade or not) + it forces
+  a response rather than asking permission. A fork fragments; a handshake offers an
+  upgrade path on the existing standard.
+- **Why DBSP / retraction-algebra for V2?** Agent-coordination speed needs
+  concurrent, mergeable, *retractable* state — CRDT-like (B-0942) + incremental
+  (DBSP/Z-sets). Human-git's merge model is built around human-paced review; the
+  algebra makes concurrent agent writes + retractions first-class.
+- **Why same-objects-not-two-copies?** Two copies need syncing (drift, conflict); one
+  object store with two *views* (git-view + DBSP-stream-view) has no sync surface —
+  the integration is the point.
+- **Why upstream the primitives?** Anti-vendor-lock (don't become GitHub); the core
+  improvements live in git itself, benefiting everyone — composes with the
+  contribute-back DORA discipline (B-0952).
+
+## Acceptance / decomposition (umbrella — sub-rows on pickup)
+
+1. **Object substrate** — file-system-with-history + ZetaId append-only event store
+   as the shared object store, carried as DBSP/Z-set retraction-native state
+   (composes B-0773 + B-0951 + `algebra-owner`).
+2. **Git-schema-as-stream layer** — build the git schema as events on the stream;
+   "speak git" on the stream (the back-compat / looks-like-git surface).
+3. **F# dual-protocol handshake** — negotiate `git` ↔ `git-v2` (DBSP/retraction-
+   algebra); graceful fallback to plain git when the peer doesn't speak V2.
+4. **Same-objects integration** — git-view ↔ DBSP-stream-view share one object store
+   (changes in either reflect in the other; no second copy).
+5. **Agent-speed coordination primitives** — concurrent mergeable retractable writes
+   (composes B-0942 co-dominant-mirrors / git-native CRDT).
+6. **Upstream-contribution path** — package the agent-speed primitives as proposals
+   to git itself (composes B-0952 contribute-back DORA; start small, earn inroads).
+
+Each sub-row carries its own start-gate (prior-art search incl. `references/upstreams/git/`,
+the git protocol v2 spec, jujutsu/jj + Pijul/Sapling as prior art for
+algebra/CRDT-shaped VCS, dependency check).
+
+## Composes with
+
+- **B-0942** (co-dominant git mirrors + git-native CRDT coordination — the
+  agent-speed coordination substrate this handshake exposes)
+- **B-0951** (git-native eventually-consistent indexes + Hindsight storage interface
+  — the index/query layer over the object store)
+- **B-0773** (cluster-as-digital-twin git-native event store — the object substrate)
+- **B-0363** (git-native full-text inverted index — a derived view over the store)
+- **B-0867.15** (per-host adapters: github/gitlab/gitea/bitbucket isomorphic — the
+  multi-host surface the looks-like-git layer presents)
+- **B-0766** (slow-replace-all-deps binary-compatible F#/C#/Rust — same
+  "rebuild-the-substrate, stay binary/protocol-compatible" thesis at the git layer)
+- **B-0952** (contribute-back DORA — the upstream-the-primitives discipline)
+- `docs/research/2026-05-31-formal-analysis-computational-omniscience-over-simulation-state-space-under-deterministic-simulator.md`
+  (the DBSP/Z-set retraction algebra + git-as-append-only-trajectory this builds on)
+- `.claude/rules/dont-ask-permission.md` (no-PR = workflow-is-branch-protection; the
+  agent-speed coordination this row enables) + the observe-act ADR (the no-PR transport)
+- `algebra-owner` skill (Z-sets / DBSP / the retraction algebra) + the planned Zeta
+  Infer.NET BP/EP substrate (per `.claude/rules/peer-call-infrastructure.md`)
+
+## Substrate-inventory pass (per `.claude/rules/verify-existing-substrate-before-authoring.md`)
+
+Topic: Git-V2 handshake / git-at-agent-speed / git-protocol-upgrade / DBSP-over-git /
+own-git-server / git-as-schema-on-stream
+
+Searched (origin/main):
+
+- `docs/backlog/` — `git.native|git.v2|handshake|agent.speed.*git|co.dominant|own git|git server|git protocol|dbsp.*git|retraction.*git`: neighbors found (B-0942, B-0951, B-0773, B-0363, B-0867.15, B-0155, B-0847) but **NONE states the handshake/upgrade-protocol thesis**; `git.*handshake|git v2|agent.coordination.speed|upgrade.*git.protocol` → **zero backlog rows**.
+- `docs/agendas/` — no git/version-control agenda.
+- `docs/research/` — no git-v2-handshake doc (the 2026-05-31 formal-analysis doc carries the DBSP/trajectory algebra this composes with).
+
+Conclusion: the substrate is **scattered, the thesis not clearly laid out** (operator-confirmed). Authoring action: **mint-new umbrella** that lays out the thesis + composes with the scattered neighbors (NOT a parallel-mint — it consolidates).
+
+## Substrate-honest framing
+
+This row does NOT claim the handshake is designed or feasible-as-stated — it lays out
+the **thesis + the why + the decomposition + the prior-art-to-check** so the work has
+a clear home instead of being scattered across the git-native rows. Sub-rows do the
+real design (incl. prior-art on git protocol v2, jujutsu/jj, Pijul, Sapling). P2:
+substantial, not urgent; the agent-speed-coordination value lands incrementally via
+the existing git-native rows (B-0942/B-0951) before the full V2 handshake.


### PR DESCRIPTION
Files the **Git-V2-handshake** thesis the operator asked for (*"file the Git-V2 handshake backlog row … there might be something around this already not so clearly laid out though"*).

**Your instinct was right** — the git-native substrate is **scattered** (B-0942 co-dominant-mirrors/CRDT · B-0951 indexes/Hindsight · B-0773 event-store · B-0363 inverted-index · B-0867.15 per-host-adapters) but the **handshake protocol thesis was nowhere stated**. Substrate-inventory: `git handshake / git v2 / agent-coordination-speed / git-protocol-upgrade` → **zero backlog rows**. So this row **lays it out + consolidates** (not a parallel-mint), composing with all the neighbors.

## The thesis (laid out)
- The problem: make git work at **agent-coordination speed**, not human-speed; don't become a vendor-lock specialized-git-client like GitHub.
- F# handshake that **looks like git** but **negotiates up to a DBSP/retraction-algebra "Git V2"** (take-it-or-leave-it for maintainers).
- **Same objects in both views** (git-view + DBSP-stream-view), not two copies.
- **Git-as-schema-on-the-stream** (stream the git schema → speak git on the stream).
- **Upstream the agent-speed primitives** to git (anti-vendor-lock; composes B-0952 contribute-back).

Whys-first (challengeable). Umbrella with 6 sub-targets + prior-art-to-check (git protocol v2, jujutsu/jj, Pijul, Sapling). P2 — substantial, not urgent; agent-speed value lands incrementally via B-0942/B-0951 before the full V2 handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)