### PR TITLE
feat(agent-bus): B-0954 Phase 1 — git-native cross-machine bus (ZetaId-keyed G-Set CRDT, no-PR)

### DIFF
--- a/tools/agent-bus/agent-bus.test.ts
+++ b/tools/agent-bus/agent-bus.test.ts
@@ -10,7 +10,7 @@ import { DETERMINISTIC_ENV, DEFAULT_ENV, unpack } from "../../src/Core.TypeScrip
 import { Category } from "../../src/Core.TypeScript/zeta-id/types";
 import { envelopePath, mintBusZetaIdHex, serializeEnvelope, isSafeSegment, type AgentBusEnvelope } from "./types";
 import { writeEnvelope, makeEnvelope } from "./publish";
-import { readEnvelopesSince, nextCursor, envelopeCursor } from "./subscribe";
+import { readEnvelopesSince, nextCursor, envelopeCursor, parseSubscribeArgs } from "./subscribe";
 
 let ROOT: string;
 beforeEach(() => {
@@ -187,5 +187,21 @@ describe("serializeEnvelope + makeEnvelope", () => {
     expect(e.topic).toBe("heartbeat");
     expect(e.from).toBe("otto-cli");
     expect(typeof e.expiresAt).toBe("string");
+  });
+});
+
+describe("parseSubscribeArgs (CLI arg parsing)", () => {
+  it("treats a bare positional as the cursor when --for is absent (Codex #6283 regression)", () => {
+    expect(parseSubscribeArgs(["mycursor"])).toEqual({ cursor: "mycursor", recipient: undefined, fetch: true });
+  });
+  it("parses cursor + --for in either order", () => {
+    expect(parseSubscribeArgs(["mycursor", "--for", "otto-cli"])).toEqual({ cursor: "mycursor", recipient: "otto-cli", fetch: true });
+    expect(parseSubscribeArgs(["--for", "otto-cli", "mycursor"])).toEqual({ cursor: "mycursor", recipient: "otto-cli", fetch: true });
+  });
+  it("does not mistake the --for value for the cursor", () => {
+    expect(parseSubscribeArgs(["--for", "otto-cli"]).cursor).toBeUndefined();
+  });
+  it("honors --no-fetch", () => {
+    expect(parseSubscribeArgs(["mycursor", "--no-fetch"])).toEqual({ cursor: "mycursor", recipient: undefined, fetch: false });
   });
 });

--- a/tools/agent-bus/agent-bus.test.ts
+++ b/tools/agent-bus/agent-bus.test.ts
@@ -99,6 +99,9 @@ describe("writeEnvelope — G-Set CRDT semantics (atomic, no TOCTOU)", () => {
     const r = writeEnvelope(env({ id, timestamp: "2026-05-31T23:59:00.000Z" }), ROOT);
     expect(r.path).toBe(join(ROOT, "otto-cli", "2026", "05", "31", `${id}.json`));
   });
+  it("refuses to write an envelope with a malformed timestamp (no NaN/NaN/NaN path) — Copilot #6283", () => {
+    expect(() => writeEnvelope(env({ timestamp: "not-a-date" }), ROOT)).toThrow();
+  });
 });
 
 describe("readEnvelopesSince", () => {
@@ -159,6 +162,15 @@ describe("readEnvelopesSince", () => {
     mkdirSync(dirname(bad), { recursive: true });
     writeFileSync(bad, JSON.stringify({ topic: "shadow-catch", payload: { content: "no keys" } })); // no timestamp/id
     expect(readEnvelopesSince(ROOT)).toHaveLength(1); // the good one; schema-invalid skipped, no crash
+  });
+  it("skips an envelope whose timestamp isn't canonical ISO (would corrupt ordering) — Copilot #6283", () => {
+    writeEnvelope(env(), ROOT, at);
+    const id = "dddddddddddddddddddddddddddddddd";
+    const bad = join(ROOT, "otto-cli", "2026", "05", "31", `${id}.json`);
+    mkdirSync(dirname(bad), { recursive: true });
+    // valid JSON, has id + timestamp strings, but timestamp is non-ISO (sorts wrong)
+    writeFileSync(bad, JSON.stringify({ ...env({ id }), timestamp: "2026/05/31 12:00" }));
+    expect(readEnvelopesSince(ROOT)).toHaveLength(1); // good one only; non-ISO skipped
   });
 });
 

--- a/tools/agent-bus/agent-bus.test.ts
+++ b/tools/agent-bus/agent-bus.test.ts
@@ -20,8 +20,14 @@ afterEach(() => {
   rmSync(ROOT, { recursive: true, force: true });
 });
 
-// AgentBusEnvelope === MessageEnvelope: topic+payload top-level + id/from/to/timestamp/expiresAt
-const env = (over: Partial<AgentBusEnvelope> = {}): AgentBusEnvelope => ({
+// AgentBusEnvelope === MessageEnvelope: topic+payload top-level + id/from/to/timestamp/expiresAt.
+// Scope the helper to the shadow-catch member so `over` can't desync topic from its payload:
+// Partial<AgentBusEnvelope> would let a caller set topic without the matching payload, and the
+// spread { topic, payload, ...over } then produces a non-member (e.g. heartbeat-topic with a
+// shadow payload) that isn't assignable to the discriminated union (Codex #6283 P1; bun strips
+// types so it ran green, tsc catches it).
+type ShadowCatchEnvelope = Extract<AgentBusEnvelope, { topic: "shadow-catch" }>;
+const env = (over: Partial<ShadowCatchEnvelope> = {}): AgentBusEnvelope => ({
   topic: "shadow-catch",
   payload: { content: "hi" },
   id: "00000000000000000000000000000001",
@@ -121,6 +127,15 @@ describe("readEnvelopesSince", () => {
     writeEnvelope(e2, ROOT, at);
     expect(readEnvelopesSince(ROOT, envelopeCursor(e1)).map((e) => e.id)).toEqual([e2.id]);
   });
+  it("filters to a recipient (addressed-to-me + broadcast *, never others) — Codex #6283", () => {
+    const A1 = "a1".padStart(32, "0");
+    const A3 = "a3".padStart(32, "0");
+    writeEnvelope(env({ id: A1, to: "otto-cli" }), ROOT, at);
+    writeEnvelope(env({ id: "a2".padStart(32, "0"), to: "otto-windows" }), ROOT, at);
+    writeEnvelope(env({ id: A3, to: "*" }), ROOT, at);
+    expect(readEnvelopesSince(ROOT, undefined, "otto-cli").map((e) => e.id).sort()).toEqual([A1, A3].sort());
+  });
+
   it("skips malformed JSON (best-effort) without throwing", () => {
     writeEnvelope(env(), ROOT, at);
     const bad = join(ROOT, "otto-cli", "2026", "05", "31", "ffffffffffffffffffffffffffffffff.json");

--- a/tools/agent-bus/agent-bus.test.ts
+++ b/tools/agent-bus/agent-bus.test.ts
@@ -60,9 +60,12 @@ describe("envelopePath + isSafeSegment (path-injection guard)", () => {
   });
   it("rejects unsafe segments (../, /, leading dot)", () => {
     expect(isSafeSegment("otto-cli")).toBe(true);
+    expect(isSafeSegment("otto-windows")).toBe(true); // kebab hyphen is fine
     expect(isSafeSegment("../etc")).toBe(false);
     expect(isSafeSegment("a/b")).toBe(false);
     expect(isSafeSegment(".hidden")).toBe(false);
+    expect(isSafeSegment("a:b")).toBe(false); // Windows-forbidden colon (Copilot #6283)
+    expect(isSafeSegment("a*b")).toBe(false); // Windows-forbidden glob char
     expect(() => envelopePath(ROOT, "../escape", "deadbeef")).toThrow();
     expect(() => envelopePath(ROOT, "otto-cli", "../../escape")).toThrow();
   });
@@ -88,6 +91,13 @@ describe("writeEnvelope — G-Set CRDT semantics (atomic, no TOCTOU)", () => {
     writeEnvelope(env({ id: "00000000000000000000000000000001" }), ROOT, at);
     writeEnvelope(env({ id: "00000000000000000000000000000002" }), ROOT, at);
     expect(readEnvelopesSince(ROOT)).toHaveLength(2);
+  });
+  it("defaults the date partition to the envelope's OWN timestamp, not wall-clock (Copilot #6283)", () => {
+    // No explicit `at` -> partition must come from env.timestamp so an idempotent
+    // re-publish always lands the same file, even near a UTC-midnight boundary.
+    const id = "dd".padStart(32, "0");
+    const r = writeEnvelope(env({ id, timestamp: "2026-05-31T23:59:00.000Z" }), ROOT);
+    expect(r.path).toBe(join(ROOT, "otto-cli", "2026", "05", "31", `${id}.json`));
   });
 });
 

--- a/tools/agent-bus/agent-bus.test.ts
+++ b/tools/agent-bus/agent-bus.test.ts
@@ -10,7 +10,7 @@ import { DETERMINISTIC_ENV, DEFAULT_ENV, unpack } from "../../src/Core.TypeScrip
 import { Category } from "../../src/Core.TypeScript/zeta-id/types";
 import { envelopePath, mintBusZetaIdHex, serializeEnvelope, type AgentBusEnvelope } from "./types";
 import { writeEnvelope, makeEnvelope } from "./publish";
-import { readEnvelopesSince, nextCursor } from "./subscribe";
+import { readEnvelopesSince, nextCursor, envelopeCursor } from "./subscribe";
 
 let ROOT: string;
 beforeEach(() => {
@@ -109,9 +109,22 @@ describe("readEnvelopesSince", () => {
     expect(after.map((e) => e.ts)).toEqual(["2026-05-31T11:00:00.000Z", "2026-05-31T12:00:00.000Z"]);
   });
 
-  it("nextCursor is the newest ts (advances the read position)", () => {
+  it("nextCursor is the newest envelope's compound cursor (advances the read position)", () => {
     seed();
-    expect(nextCursor(readEnvelopesSince(ROOT))).toBe("2026-05-31T12:00:00.000Z");
+    const envs = readEnvelopesSince(ROOT);
+    expect(nextCursor(envs)).toBe(envelopeCursor(envs[envs.length - 1]!));
+    expect(nextCursor(envs)).toBe(`2026-05-31T12:00:00.000Z|${"03".padStart(32, "0")}`);
+  });
+
+  it("does NOT drop a later same-millisecond envelope — compound (ts, zetaIdHex) cursor (Codex #6283)", () => {
+    const sameTs = "2026-05-31T12:00:00.000Z";
+    const e1 = env({ zetaIdHex: "aa".padStart(32, "0"), ts: sameTs });
+    const e2 = env({ zetaIdHex: "bb".padStart(32, "0"), ts: sameTs }); // same ms, higher hex
+    writeEnvelope(e1, ROOT, at);
+    writeEnvelope(e2, ROOT, at);
+    // cursor at e1's compound key: a ts-only filter would drop e2 (same ts); compound keeps it
+    const after = readEnvelopesSince(ROOT, envelopeCursor(e1));
+    expect(after.map((e) => e.zetaIdHex)).toEqual([e2.zetaIdHex]);
   });
 
   it("skips malformed envelopes (best-effort) without throwing", () => {

--- a/tools/agent-bus/agent-bus.test.ts
+++ b/tools/agent-bus/agent-bus.test.ts
@@ -8,7 +8,7 @@ import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { DETERMINISTIC_ENV, DEFAULT_ENV, unpack } from "../../src/Core.TypeScript/zeta-id/zeta-id";
 import { Category } from "../../src/Core.TypeScript/zeta-id/types";
-import { envelopePath, mintBusZetaIdHex, serializeEnvelope, type AgentBusEnvelope } from "./types";
+import { envelopePath, mintBusZetaIdHex, serializeEnvelope, isSafeSegment, type AgentBusEnvelope } from "./types";
 import { writeEnvelope, makeEnvelope } from "./publish";
 import { readEnvelopesSince, nextCursor, envelopeCursor } from "./subscribe";
 
@@ -20,12 +20,15 @@ afterEach(() => {
   rmSync(ROOT, { recursive: true, force: true });
 });
 
+// AgentBusEnvelope === MessageEnvelope: topic+payload top-level + id/from/to/timestamp/expiresAt
 const env = (over: Partial<AgentBusEnvelope> = {}): AgentBusEnvelope => ({
-  zetaIdHex: "00000000000000000000000000000001",
+  topic: "shadow-catch",
+  payload: { content: "hi" },
+  id: "00000000000000000000000000000001",
   from: "otto-cli",
   to: "*",
-  ts: "2026-05-31T12:00:00.000Z",
-  message: { topic: "shadow-catch", payload: { content: "hi" } },
+  timestamp: "2026-05-31T12:00:00.000Z",
+  expiresAt: "2026-06-01T12:00:00.000Z",
   ...over,
 });
 
@@ -33,55 +36,51 @@ describe("mintBusZetaIdHex", () => {
   it("is 32 hex chars in the Bus category", () => {
     const hex = mintBusZetaIdHex(DETERMINISTIC_ENV, 1_700_000_000_000);
     expect(hex).toMatch(/^[0-9a-f]{32}$/);
-    const obs = unpack(BigInt(`0x${hex}`) as never);
-    expect(obs.category).toBe(Category.Bus);
+    expect(unpack(BigInt(`0x${hex}`) as never).category).toBe(Category.Bus);
   });
-
   it("is reproducible under DETERMINISTIC_ENV (same fields -> same id; the G-Set collision caveat)", () => {
-    const a = mintBusZetaIdHex(DETERMINISTIC_ENV, 1_700_000_000_000);
-    const b = mintBusZetaIdHex(DETERMINISTIC_ENV, 1_700_000_000_000);
-    expect(a).toBe(b);
+    expect(mintBusZetaIdHex(DETERMINISTIC_ENV, 1_700_000_000_000)).toBe(mintBusZetaIdHex(DETERMINISTIC_ENV, 1_700_000_000_000));
   });
-
   it("is unique under DEFAULT_ENV even at the same ms (crypto randomness)", () => {
-    const a = mintBusZetaIdHex(DEFAULT_ENV, 1_700_000_000_000);
-    const b = mintBusZetaIdHex(DEFAULT_ENV, 1_700_000_000_000);
-    expect(a).not.toBe(b);
+    expect(mintBusZetaIdHex(DEFAULT_ENV, 1_700_000_000_000)).not.toBe(mintBusZetaIdHex(DEFAULT_ENV, 1_700_000_000_000));
   });
 });
 
-describe("envelopePath", () => {
-  it("lays out <root>/<persona>/<YYYY>/<MM>/<DD>/<hex>.json (UTC)", () => {
-    const p = envelopePath(ROOT, "otto-cli", "deadbeef", new Date("2026-05-31T23:59:00Z"));
-    expect(p).toBe(join(ROOT, "otto-cli", "2026", "05", "31", "deadbeef.json"));
+describe("envelopePath + isSafeSegment (path-injection guard)", () => {
+  it("lays out <root>/<persona>/<YYYY>/<MM>/<DD>/<id>.json (UTC)", () => {
+    expect(envelopePath(ROOT, "otto-cli", "deadbeef", new Date("2026-05-31T23:59:00Z"))).toBe(
+      join(ROOT, "otto-cli", "2026", "05", "31", "deadbeef.json"),
+    );
+  });
+  it("rejects unsafe segments (../, /, leading dot)", () => {
+    expect(isSafeSegment("otto-cli")).toBe(true);
+    expect(isSafeSegment("../etc")).toBe(false);
+    expect(isSafeSegment("a/b")).toBe(false);
+    expect(isSafeSegment(".hidden")).toBe(false);
+    expect(() => envelopePath(ROOT, "../escape", "deadbeef")).toThrow();
+    expect(() => envelopePath(ROOT, "otto-cli", "../../escape")).toThrow();
   });
 });
 
-describe("writeEnvelope — G-Set CRDT semantics", () => {
-  it("creates the file under the persona/date path", () => {
-    const r = writeEnvelope(env(), ROOT, new Date("2026-05-31T12:00:00Z"));
+describe("writeEnvelope — G-Set CRDT semantics (atomic, no TOCTOU)", () => {
+  const at = new Date("2026-05-31T12:00:00Z");
+  it("creates the file under the persona/date/id path", () => {
+    const r = writeEnvelope(env(), ROOT, at);
     expect(r.kind).toBe("created");
     expect(existsSync(r.path)).toBe(true);
-    expect(r.path).toBe(join(ROOT, "otto-cli", "2026", "05", "31", `${env().zetaIdHex}.json`));
+    expect(r.path).toBe(join(ROOT, "otto-cli", "2026", "05", "31", `${env().id}.json`));
   });
-
   it("is idempotent on identical content (re-publish = safe no-op)", () => {
-    const at = new Date("2026-05-31T12:00:00Z");
     expect(writeEnvelope(env(), ROOT, at).kind).toBe("created");
     expect(writeEnvelope(env(), ROOT, at).kind).toBe("exists-identical");
   });
-
-  it("surfaces a same-id/different-content collision (never silently overwrites)", () => {
-    const at = new Date("2026-05-31T12:00:00Z");
+  it("surfaces a same-id/different-content collision (atomic; never silently overwrites)", () => {
     writeEnvelope(env(), ROOT, at);
-    const r = writeEnvelope(env({ message: { topic: "shadow-catch", payload: { content: "DIFFERENT" } } }), ROOT, at);
-    expect(r.kind).toBe("collision");
+    expect(writeEnvelope(env({ payload: { content: "DIFFERENT" } }), ROOT, at).kind).toBe("collision");
   });
-
-  it("disjoint zetaIds -> disjoint files (grow-only set, conflict-free)", () => {
-    const at = new Date("2026-05-31T12:00:00Z");
-    writeEnvelope(env({ zetaIdHex: "00000000000000000000000000000001" }), ROOT, at);
-    writeEnvelope(env({ zetaIdHex: "00000000000000000000000000000002" }), ROOT, at);
+  it("disjoint ids -> disjoint files (grow-only set, conflict-free)", () => {
+    writeEnvelope(env({ id: "00000000000000000000000000000001" }), ROOT, at);
+    writeEnvelope(env({ id: "00000000000000000000000000000002" }), ROOT, at);
     expect(readEnvelopesSince(ROOT)).toHaveLength(2);
   });
 });
@@ -89,66 +88,67 @@ describe("writeEnvelope — G-Set CRDT semantics", () => {
 describe("readEnvelopesSince", () => {
   const at = new Date("2026-05-31T12:00:00Z");
   const seed = () => {
-    writeEnvelope(env({ zetaIdHex: "01".padStart(32, "0"), ts: "2026-05-31T10:00:00.000Z" }), ROOT, at);
-    writeEnvelope(env({ zetaIdHex: "02".padStart(32, "0"), ts: "2026-05-31T11:00:00.000Z" }), ROOT, at);
-    writeEnvelope(env({ zetaIdHex: "03".padStart(32, "0"), ts: "2026-05-31T12:00:00.000Z" }), ROOT, at);
+    writeEnvelope(env({ id: "01".padStart(32, "0"), timestamp: "2026-05-31T10:00:00.000Z" }), ROOT, at);
+    writeEnvelope(env({ id: "02".padStart(32, "0"), timestamp: "2026-05-31T11:00:00.000Z" }), ROOT, at);
+    writeEnvelope(env({ id: "03".padStart(32, "0"), timestamp: "2026-05-31T12:00:00.000Z" }), ROOT, at);
   };
 
-  it("returns all envelopes sorted by ts when no cursor", () => {
+  it("returns all envelopes sorted by timestamp when no cursor", () => {
     seed();
-    expect(readEnvelopesSince(ROOT).map((e) => e.ts)).toEqual([
+    expect(readEnvelopesSince(ROOT).map((e) => e.timestamp)).toEqual([
       "2026-05-31T10:00:00.000Z",
       "2026-05-31T11:00:00.000Z",
       "2026-05-31T12:00:00.000Z",
     ]);
   });
-
   it("returns only envelopes strictly after the cursor", () => {
     seed();
-    const after = readEnvelopesSince(ROOT, "2026-05-31T10:30:00.000Z");
-    expect(after.map((e) => e.ts)).toEqual(["2026-05-31T11:00:00.000Z", "2026-05-31T12:00:00.000Z"]);
+    expect(readEnvelopesSince(ROOT, "2026-05-31T10:30:00.000Z").map((e) => e.timestamp)).toEqual([
+      "2026-05-31T11:00:00.000Z",
+      "2026-05-31T12:00:00.000Z",
+    ]);
   });
-
-  it("nextCursor is the newest envelope's compound cursor (advances the read position)", () => {
+  it("nextCursor is the newest envelope's compound cursor", () => {
     seed();
     const envs = readEnvelopesSince(ROOT);
-    expect(nextCursor(envs)).toBe(envelopeCursor(envs[envs.length - 1]!));
     expect(nextCursor(envs)).toBe(`2026-05-31T12:00:00.000Z|${"03".padStart(32, "0")}`);
   });
-
-  it("does NOT drop a later same-millisecond envelope — compound (ts, zetaIdHex) cursor (Codex #6283)", () => {
+  it("does NOT drop a later same-millisecond envelope — compound (timestamp, id) cursor", () => {
     const sameTs = "2026-05-31T12:00:00.000Z";
-    const e1 = env({ zetaIdHex: "aa".padStart(32, "0"), ts: sameTs });
-    const e2 = env({ zetaIdHex: "bb".padStart(32, "0"), ts: sameTs }); // same ms, higher hex
+    const e1 = env({ id: "aa".padStart(32, "0"), timestamp: sameTs });
+    const e2 = env({ id: "bb".padStart(32, "0"), timestamp: sameTs });
     writeEnvelope(e1, ROOT, at);
     writeEnvelope(e2, ROOT, at);
-    // cursor at e1's compound key: a ts-only filter would drop e2 (same ts); compound keeps it
-    const after = readEnvelopesSince(ROOT, envelopeCursor(e1));
-    expect(after.map((e) => e.zetaIdHex)).toEqual([e2.zetaIdHex]);
+    expect(readEnvelopesSince(ROOT, envelopeCursor(e1)).map((e) => e.id)).toEqual([e2.id]);
   });
-
-  it("skips malformed envelopes (best-effort) without throwing", () => {
+  it("skips malformed JSON (best-effort) without throwing", () => {
     writeEnvelope(env(), ROOT, at);
     const bad = join(ROOT, "otto-cli", "2026", "05", "31", "ffffffffffffffffffffffffffffffff.json");
     mkdirSync(dirname(bad), { recursive: true });
     writeFileSync(bad, "{ not json");
-    expect(readEnvelopesSince(ROOT)).toHaveLength(1); // the one good envelope; bad skipped
+    expect(readEnvelopesSince(ROOT)).toHaveLength(1);
+  });
+  it("skips schema-invalid envelopes (valid JSON, missing timestamp/id) without throwing", () => {
+    writeEnvelope(env(), ROOT, at);
+    const bad = join(ROOT, "otto-cli", "2026", "05", "31", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.json");
+    mkdirSync(dirname(bad), { recursive: true });
+    writeFileSync(bad, JSON.stringify({ topic: "shadow-catch", payload: { content: "no keys" } })); // no timestamp/id
+    expect(readEnvelopesSince(ROOT)).toHaveLength(1); // the good one; schema-invalid skipped, no crash
   });
 });
 
-describe("serializeEnvelope", () => {
-  it("is stable (pretty + trailing newline) so re-publish content-matches", () => {
+describe("serializeEnvelope + makeEnvelope", () => {
+  it("serialize is stable (pretty + trailing newline)", () => {
     const s = serializeEnvelope(env());
     expect(s.endsWith("}\n")).toBe(true);
-    expect(JSON.parse(s).zetaIdHex).toBe(env().zetaIdHex);
+    expect(JSON.parse(s).id).toBe(env().id);
   });
-});
-
-describe("makeEnvelope", () => {
-  it("mints a Bus zetaId + ISO ts for a given message", () => {
+  it("makeEnvelope builds a MessageEnvelope (Bus id, timestamp+expiresAt, top-level topic/payload)", () => {
     const e = makeEnvelope("otto-cli", "*", { topic: "heartbeat", payload: { status: "alive" } }, 1_700_000_000_000);
-    expect(e.zetaIdHex).toMatch(/^[0-9a-f]{32}$/);
-    expect(e.ts).toBe(new Date(1_700_000_000_000).toISOString());
+    expect(e.id).toMatch(/^[0-9a-f]{32}$/);
+    expect(e.timestamp).toBe(new Date(1_700_000_000_000).toISOString());
+    expect(e.topic).toBe("heartbeat");
     expect(e.from).toBe("otto-cli");
+    expect(typeof e.expiresAt).toBe("string");
   });
 });

--- a/tools/agent-bus/agent-bus.test.ts
+++ b/tools/agent-bus/agent-bus.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Agent-bus Phase 1 (B-0954) tests — pure write/read/mint against a temp root.
+ * No git, no real docs/agent-bus/ (per the module's pure/CLI split).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { DETERMINISTIC_ENV, DEFAULT_ENV, unpack } from "../../src/Core.TypeScript/zeta-id/zeta-id";
+import { Category } from "../../src/Core.TypeScript/zeta-id/types";
+import { envelopePath, mintBusZetaIdHex, serializeEnvelope, type AgentBusEnvelope } from "./types";
+import { writeEnvelope, makeEnvelope } from "./publish";
+import { readEnvelopesSince, nextCursor } from "./subscribe";
+
+let ROOT: string;
+beforeEach(() => {
+  ROOT = mkdtempSync(join(tmpdir(), "agent-bus-test-"));
+});
+afterEach(() => {
+  rmSync(ROOT, { recursive: true, force: true });
+});
+
+const env = (over: Partial<AgentBusEnvelope> = {}): AgentBusEnvelope => ({
+  zetaIdHex: "00000000000000000000000000000001",
+  from: "otto-cli",
+  to: "*",
+  ts: "2026-05-31T12:00:00.000Z",
+  message: { topic: "shadow-catch", payload: { content: "hi" } },
+  ...over,
+});
+
+describe("mintBusZetaIdHex", () => {
+  it("is 32 hex chars in the Bus category", () => {
+    const hex = mintBusZetaIdHex(DETERMINISTIC_ENV, 1_700_000_000_000);
+    expect(hex).toMatch(/^[0-9a-f]{32}$/);
+    const obs = unpack(BigInt(`0x${hex}`) as never);
+    expect(obs.category).toBe(Category.Bus);
+  });
+
+  it("is reproducible under DETERMINISTIC_ENV (same fields -> same id; the G-Set collision caveat)", () => {
+    const a = mintBusZetaIdHex(DETERMINISTIC_ENV, 1_700_000_000_000);
+    const b = mintBusZetaIdHex(DETERMINISTIC_ENV, 1_700_000_000_000);
+    expect(a).toBe(b);
+  });
+
+  it("is unique under DEFAULT_ENV even at the same ms (crypto randomness)", () => {
+    const a = mintBusZetaIdHex(DEFAULT_ENV, 1_700_000_000_000);
+    const b = mintBusZetaIdHex(DEFAULT_ENV, 1_700_000_000_000);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("envelopePath", () => {
+  it("lays out <root>/<persona>/<YYYY>/<MM>/<DD>/<hex>.json (UTC)", () => {
+    const p = envelopePath(ROOT, "otto-cli", "deadbeef", new Date("2026-05-31T23:59:00Z"));
+    expect(p).toBe(join(ROOT, "otto-cli", "2026", "05", "31", "deadbeef.json"));
+  });
+});
+
+describe("writeEnvelope — G-Set CRDT semantics", () => {
+  it("creates the file under the persona/date path", () => {
+    const r = writeEnvelope(env(), ROOT, new Date("2026-05-31T12:00:00Z"));
+    expect(r.kind).toBe("created");
+    expect(existsSync(r.path)).toBe(true);
+    expect(r.path).toBe(join(ROOT, "otto-cli", "2026", "05", "31", `${env().zetaIdHex}.json`));
+  });
+
+  it("is idempotent on identical content (re-publish = safe no-op)", () => {
+    const at = new Date("2026-05-31T12:00:00Z");
+    expect(writeEnvelope(env(), ROOT, at).kind).toBe("created");
+    expect(writeEnvelope(env(), ROOT, at).kind).toBe("exists-identical");
+  });
+
+  it("surfaces a same-id/different-content collision (never silently overwrites)", () => {
+    const at = new Date("2026-05-31T12:00:00Z");
+    writeEnvelope(env(), ROOT, at);
+    const r = writeEnvelope(env({ message: { topic: "shadow-catch", payload: { content: "DIFFERENT" } } }), ROOT, at);
+    expect(r.kind).toBe("collision");
+  });
+
+  it("disjoint zetaIds -> disjoint files (grow-only set, conflict-free)", () => {
+    const at = new Date("2026-05-31T12:00:00Z");
+    writeEnvelope(env({ zetaIdHex: "00000000000000000000000000000001" }), ROOT, at);
+    writeEnvelope(env({ zetaIdHex: "00000000000000000000000000000002" }), ROOT, at);
+    expect(readEnvelopesSince(ROOT)).toHaveLength(2);
+  });
+});
+
+describe("readEnvelopesSince", () => {
+  const at = new Date("2026-05-31T12:00:00Z");
+  const seed = () => {
+    writeEnvelope(env({ zetaIdHex: "01".padStart(32, "0"), ts: "2026-05-31T10:00:00.000Z" }), ROOT, at);
+    writeEnvelope(env({ zetaIdHex: "02".padStart(32, "0"), ts: "2026-05-31T11:00:00.000Z" }), ROOT, at);
+    writeEnvelope(env({ zetaIdHex: "03".padStart(32, "0"), ts: "2026-05-31T12:00:00.000Z" }), ROOT, at);
+  };
+
+  it("returns all envelopes sorted by ts when no cursor", () => {
+    seed();
+    expect(readEnvelopesSince(ROOT).map((e) => e.ts)).toEqual([
+      "2026-05-31T10:00:00.000Z",
+      "2026-05-31T11:00:00.000Z",
+      "2026-05-31T12:00:00.000Z",
+    ]);
+  });
+
+  it("returns only envelopes strictly after the cursor", () => {
+    seed();
+    const after = readEnvelopesSince(ROOT, "2026-05-31T10:30:00.000Z");
+    expect(after.map((e) => e.ts)).toEqual(["2026-05-31T11:00:00.000Z", "2026-05-31T12:00:00.000Z"]);
+  });
+
+  it("nextCursor is the newest ts (advances the read position)", () => {
+    seed();
+    expect(nextCursor(readEnvelopesSince(ROOT))).toBe("2026-05-31T12:00:00.000Z");
+  });
+
+  it("skips malformed envelopes (best-effort) without throwing", () => {
+    writeEnvelope(env(), ROOT, at);
+    const bad = join(ROOT, "otto-cli", "2026", "05", "31", "ffffffffffffffffffffffffffffffff.json");
+    mkdirSync(dirname(bad), { recursive: true });
+    writeFileSync(bad, "{ not json");
+    expect(readEnvelopesSince(ROOT)).toHaveLength(1); // the one good envelope; bad skipped
+  });
+});
+
+describe("serializeEnvelope", () => {
+  it("is stable (pretty + trailing newline) so re-publish content-matches", () => {
+    const s = serializeEnvelope(env());
+    expect(s.endsWith("}\n")).toBe(true);
+    expect(JSON.parse(s).zetaIdHex).toBe(env().zetaIdHex);
+  });
+});
+
+describe("makeEnvelope", () => {
+  it("mints a Bus zetaId + ISO ts for a given message", () => {
+    const e = makeEnvelope("otto-cli", "*", { topic: "heartbeat", payload: { status: "alive" } }, 1_700_000_000_000);
+    expect(e.zetaIdHex).toMatch(/^[0-9a-f]{32}$/);
+    expect(e.ts).toBe(new Date(1_700_000_000_000).toISOString());
+    expect(e.from).toBe("otto-cli");
+  });
+});

--- a/tools/agent-bus/agent-bus.test.ts
+++ b/tools/agent-bus/agent-bus.test.ts
@@ -146,7 +146,8 @@ describe("readEnvelopesSince", () => {
     writeEnvelope(env({ id: A1, to: "otto-cli" }), ROOT, at);
     writeEnvelope(env({ id: "a2".padStart(32, "0"), to: "otto-windows" }), ROOT, at);
     writeEnvelope(env({ id: A3, to: "*" }), ROOT, at);
-    expect(readEnvelopesSince(ROOT, undefined, "otto-cli").map((e) => e.id).sort()).toEqual([A1, A3].sort());
+    const cmp = (a: string, b: string) => a.localeCompare(b);
+    expect(readEnvelopesSince(ROOT, undefined, "otto-cli").map((e) => e.id).sort(cmp)).toEqual([A1, A3].sort(cmp));
   });
 
   it("skips malformed JSON (best-effort) without throwing", () => {
@@ -178,7 +179,7 @@ describe("serializeEnvelope + makeEnvelope", () => {
   it("serialize is stable (pretty + trailing newline)", () => {
     const s = serializeEnvelope(env());
     expect(s.endsWith("}\n")).toBe(true);
-    expect(JSON.parse(s).id).toBe(env().id);
+    expect((JSON.parse(s) as AgentBusEnvelope).id).toBe(env().id);
   });
   it("makeEnvelope builds a MessageEnvelope (Bus id, timestamp+expiresAt, top-level topic/payload)", () => {
     const e = makeEnvelope("otto-cli", "*", { topic: "heartbeat", payload: { status: "alive" } }, 1_700_000_000_000);

--- a/tools/agent-bus/publish.ts
+++ b/tools/agent-bus/publish.ts
@@ -10,7 +10,15 @@
 import { mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { execFileSync } from "node:child_process";
-import { AGENT_BUS_ROOT, envelopePath, serializeEnvelope, makeEnvelope, type AgentBusEnvelope } from "./types";
+import {
+  AGENT_BUS_ROOT,
+  envelopePath,
+  serializeEnvelope,
+  makeEnvelope,
+  isCanonicalTimestamp,
+  isCanonicalBusId,
+  type AgentBusEnvelope,
+} from "./types";
 import { SENDER_IDS, AGENT_IDS, TTL_MS, type AgentId, type SenderAgentId, type BusMessage } from "../bus/types";
 
 export { makeEnvelope };
@@ -35,6 +43,14 @@ export function writeEnvelope(
   // a wall-clock `new Date()` would write a 2nd file for one id (Copilot #6283).
   at: Date = new Date(env.timestamp),
 ): WriteResult {
+  // Guard the path-determining fields: a malformed timestamp would default `at` to an
+  // Invalid Date and write under NaN/NaN/NaN; a non-32-hex id breaks the dedup key
+  // (Copilot #6283). Refuse loudly rather than write a broken path.
+  if (!isCanonicalTimestamp(env.timestamp) || !isCanonicalBusId(env.id)) {
+    throw new Error(
+      `agent-bus: refusing to write malformed envelope (timestamp=${JSON.stringify(env.timestamp)}, id=${JSON.stringify(env.id)})`,
+    );
+  }
   const path = envelopePath(root, env.from, env.id, at);
   const content = serializeEnvelope(env);
   mkdirSync(dirname(path), { recursive: true });

--- a/tools/agent-bus/publish.ts
+++ b/tools/agent-bus/publish.ts
@@ -74,7 +74,17 @@ function gitPushEnvelope(path: string, from: SenderAgentId, topic: string): void
   // --no-verify: bus envelopes are DATA, not code — skip code hooks.
   // Pathspec `-- path` commits ONLY the envelope, never pre-staged work already in the
   // checkout (Codex #6283 P2 — a direct-to-main --no-verify commit must not sweep it in).
-  execFileSync("git", ["commit", "--no-verify", "-q", "-m", `bus(${from}): ${topic} ${path}`, "--", path], opts);
+  // Body names the publishing sender; the Co-Authored-By trailer keeps the repo-required
+  // attribution even though --no-verify skips the hook that would otherwise add/check it
+  // (Codex #6283 P2 — a direct-to-main bus commit must still carry attribution).
+  const commitMsg = [
+    `bus(${from}): ${topic} ${path}`,
+    "",
+    `Agent-bus envelope published by ${from} (B-0954, no-PR direct-to-main).`,
+    "",
+    "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>",
+  ].join("\n");
+  execFileSync("git", ["commit", "--no-verify", "-q", "-m", commitMsg, "--", path], opts);
   // Explicit target: a concurrent peer advancing main rejects this push non-fast-forward,
   // but disjoint ZetaId files (G-Set CRDT) never conflict -> pull --rebase + retry.
   for (let attempt = 0; attempt < 3; attempt++) {

--- a/tools/agent-bus/publish.ts
+++ b/tools/agent-bus/publish.ts
@@ -56,9 +56,21 @@ function gitPushEnvelope(path: string, from: SenderAgentId, topic: string): void
   if (branch !== "main") {
     throw new Error(`agent-bus publish must run on a main checkout (on '${branch}'); use a bus worktree on main`);
   }
+  // Refuse if local main is ahead of origin/main: `git push HEAD:main` would shove those
+  // unrelated local commits straight to main alongside the envelope (Codex #6283 P1).
+  // Fetch first so the comparison is against fresh origin/main, then require 0 ahead.
+  execFileSync("git", ["fetch", "origin", "main"], opts);
+  const ahead = execFileSync("git", ["rev-list", "--count", "origin/main..HEAD"], { encoding: "utf-8" }).trim();
+  if (ahead !== "0") {
+    throw new Error(
+      `agent-bus publish: local main is ${ahead} commit(s) ahead of origin/main; reconcile before publishing (refusing to push unrelated commits to main)`,
+    );
+  }
   execFileSync("git", ["add", path], opts);
   // --no-verify: bus envelopes are DATA, not code — skip code hooks.
-  execFileSync("git", ["commit", "--no-verify", "-q", "-m", `bus(${from}): ${topic} ${path}`], opts);
+  // Pathspec `-- path` commits ONLY the envelope, never pre-staged work already in the
+  // checkout (Codex #6283 P2 — a direct-to-main --no-verify commit must not sweep it in).
+  execFileSync("git", ["commit", "--no-verify", "-q", "-m", `bus(${from}): ${topic} ${path}`, "--", path], opts);
   // Explicit target: a concurrent peer advancing main rejects this push non-fast-forward,
   // but disjoint ZetaId files (G-Set CRDT) never conflict -> pull --rebase + retry.
   for (let attempt = 0; attempt < 3; attempt++) {

--- a/tools/agent-bus/publish.ts
+++ b/tools/agent-bus/publish.ts
@@ -11,7 +11,7 @@ import { mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { execFileSync } from "node:child_process";
 import { AGENT_BUS_ROOT, envelopePath, serializeEnvelope, makeEnvelope, type AgentBusEnvelope } from "./types";
-import { SENDER_IDS, AGENT_IDS, type AgentId, type SenderAgentId, type BusMessage } from "../bus/types";
+import { SENDER_IDS, AGENT_IDS, TTL_MS, type AgentId, type SenderAgentId, type BusMessage } from "../bus/types";
 
 export { makeEnvelope };
 
@@ -29,7 +29,11 @@ export type WriteResult =
 export function writeEnvelope(
   env: AgentBusEnvelope,
   root: string = AGENT_BUS_ROOT,
-  at: Date = new Date(),
+  // Partition by the envelope's OWN timestamp, not wall-clock: the path must be a
+  // deterministic function of (from, id, timestamp) so an idempotent re-publish always
+  // lands the SAME file (the G-Set property) — even across a UTC-midnight boundary, where
+  // a wall-clock `new Date()` would write a 2nd file for one id (Copilot #6283).
+  at: Date = new Date(env.timestamp),
 ): WriteResult {
   const path = envelopePath(root, env.from, env.id, at);
   const content = serializeEnvelope(env);
@@ -100,6 +104,13 @@ if (import.meta.main) {
     console.error(`unknown target '${to}'. Valid: ${AGENT_IDS.join(", ")} | *`);
     process.exit(2);
   }
+  // Validate topic against the known bus topics (TTL_MS keys) BEFORE building the envelope:
+  // an unknown topic makes TTL_MS[topic] undefined, and makeEnvelope's expiresAt
+  // (new Date(atMs + undefined)) throws a confusing RangeError (Copilot #6283 P0).
+  if (!(topic in TTL_MS)) {
+    console.error(`unknown topic '${topic}'. Valid: ${Object.keys(TTL_MS).join(", ")}`);
+    process.exit(2);
+  }
   let payload: unknown;
   try {
     payload = JSON.parse(payloadJson);
@@ -107,7 +118,8 @@ if (import.meta.main) {
     console.error(`invalid JSON payload: ${(e as Error).message}`);
     process.exit(2);
   }
-  const message = { topic, payload } as BusMessage;
+  // topic validated above -> safe to narrow to the BusMessage topic union.
+  const message = { topic: topic as BusMessage["topic"], payload } as BusMessage;
   const env = makeEnvelope(from as SenderAgentId, to as AgentId, message);
   const result = writeEnvelope(env);
   console.log(JSON.stringify({ result: result.kind, path: result.path, id: env.id }));

--- a/tools/agent-bus/publish.ts
+++ b/tools/agent-bus/publish.ts
@@ -82,7 +82,24 @@ function gitPushEnvelope(path: string, from: SenderAgentId, topic: string): void
       execFileSync("git", ["push", "origin", "HEAD:main"], opts);
       return;
     } catch {
-      execFileSync("git", ["pull", "--rebase", "origin", "main"], opts);
+      try {
+        execFileSync("git", ["pull", "--rebase", "origin", "main"], opts);
+      } catch {
+        // A rebase CONFLICT here means a peer pushed the SAME ZetaId path with DIFFERENT
+        // content — a genuine same-path collision (only reachable with deterministic ids;
+        // crypto DEFAULT_ENV ids make it astronomically improbable). Disjoint files never
+        // conflict, so this is NOT the ordinary non-fast-forward case. Abort to leave a
+        // clean repo and fail loudly — the publisher should re-mint (use DEFAULT_ENV) and
+        // retry rather than silently merge over a peer's envelope (Codex #6283 P2).
+        try {
+          execFileSync("git", ["rebase", "--abort"], opts);
+        } catch {
+          /* no rebase in progress to abort */
+        }
+        throw new Error(
+          "agent-bus publish: rebase conflict — a peer published the same ZetaId path with different content (same-path collision). Re-mint with DEFAULT_ENV (crypto) and retry.",
+        );
+      }
     }
   }
   execFileSync("git", ["push", "origin", "HEAD:main"], opts); // final attempt — throws if still failing

--- a/tools/agent-bus/publish.ts
+++ b/tools/agent-bus/publish.ts
@@ -1,69 +1,75 @@
 /**
  * Agent-bus Phase 1 (B-0954) — publish.
  *
- * `writeEnvelope` is PURE (file write only; idempotent on identical content — the
- * G-Set CRDT property). The CLI (`import.meta.main`) is the no-PR runtime: write the
- * file, then `git add/commit/push` directly to main (no PR) — the B-0858 mechanism.
- * Tests import `writeEnvelope` against a temp root and never touch git.
+ * `writeEnvelope` is PURE (atomic file create; idempotent on identical content — the
+ * G-Set CRDT property; collision-surfacing via an ATOMIC `wx` create, no TOCTOU). The
+ * CLI (`import.meta.main`) is the no-PR runtime: write the file, then commit
+ * `--no-verify` + push `origin HEAD:main` directly (no PR) — the B-0858 mechanism;
+ * guarded by `import.meta.main` so tests never touch git.
  */
-import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { execFileSync } from "node:child_process";
-import { AGENT_BUS_ROOT, envelopePath, serializeEnvelope, mintBusZetaIdHex, type AgentBusEnvelope } from "./types";
-import type { AgentId, SenderAgentId, BusMessage } from "../bus/types";
+import { AGENT_BUS_ROOT, envelopePath, serializeEnvelope, makeEnvelope, type AgentBusEnvelope } from "./types";
+import { SENDER_IDS, AGENT_IDS, type AgentId, type SenderAgentId, type BusMessage } from "../bus/types";
+
+export { makeEnvelope };
 
 export type WriteResult =
   | { readonly kind: "created"; readonly path: string }
   | { readonly kind: "exists-identical"; readonly path: string } // idempotent re-publish (G-Set CRDT)
-  | { readonly kind: "collision"; readonly path: string }; // same zetaId, DIFFERENT content — should never happen with crypto ids
+  | { readonly kind: "collision"; readonly path: string }; // same id, DIFFERENT content — should never happen with crypto ids
 
 /**
- * Write an envelope as its ZetaId-named file. Idempotent on identical content (re-
- * publishing the same envelope is a safe no-op — the grow-only-set property). A
- * same-id/different-content collision is surfaced as feedback (`kind: "collision"`),
- * never silently overwritten — the writer decides (per the spec's collision caveat).
+ * Write an envelope as its ZetaId-named file via an ATOMIC create (`flag: "wx"` —
+ * fails if the file exists, no TOCTOU window). On `EEXIST`, compare the existing
+ * content: identical -> idempotent no-op (the grow-only-set property); different ->
+ * surfaced as `collision` (never silently overwritten — the spec's collision caveat).
  */
 export function writeEnvelope(
   env: AgentBusEnvelope,
   root: string = AGENT_BUS_ROOT,
   at: Date = new Date(),
 ): WriteResult {
-  const path = envelopePath(root, env.from, env.zetaIdHex, at);
-  if (existsSync(path)) {
-    return readFileSync(path, "utf-8") === serializeEnvelope(env)
+  const path = envelopePath(root, env.from, env.id, at);
+  const content = serializeEnvelope(env);
+  mkdirSync(dirname(path), { recursive: true });
+  try {
+    writeFileSync(path, content, { flag: "wx" }); // atomic: fail if exists
+    return { kind: "created", path };
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+    return readFileSync(path, "utf-8") === content
       ? { kind: "exists-identical", path }
       : { kind: "collision", path };
   }
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, serializeEnvelope(env));
-  return { kind: "created", path };
 }
 
-/** Build an envelope: mint a fresh Bus ZetaId + stamp the ISO ts. */
-export function makeEnvelope(from: SenderAgentId, to: AgentId, message: BusMessage, atMs: number = Date.now()): AgentBusEnvelope {
-  return { zetaIdHex: mintBusZetaIdHex(undefined, atMs), from, to, ts: new Date(atMs).toISOString(), message };
-}
-
-// ── no-PR runtime: write + git add/commit/push directly to main (B-0858) ──────────
+// ── no-PR runtime: write + commit --no-verify + push origin HEAD:main (B-0858) ──────
 // Guarded behind import.meta.main so importing this module (tests) never runs git.
 
 function gitPushEnvelope(path: string, from: SenderAgentId, topic: string): void {
   const opts = { stdio: "inherit" as const };
+  // The bus folder lives on main; publishing from a feature branch would push that
+  // branch's unrelated commits to main. Require a main checkout (or a bus worktree on main).
+  const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { encoding: "utf-8" }).trim();
+  if (branch !== "main") {
+    throw new Error(`agent-bus publish must run on a main checkout (on '${branch}'); use a bus worktree on main`);
+  }
   execFileSync("git", ["add", path], opts);
-  execFileSync("git", ["commit", "-q", "-m", `bus(${from}): ${topic} ${path}`], opts);
-  // Direct-to-main, no PR (the B-0858 carve-out). A concurrent peer publishing its OWN
-  // disjoint envelope advances main, so this push can be rejected non-fast-forward — but
-  // the envelopes are disjoint ZetaId files (the G-Set CRDT), so `pull --rebase` NEVER
-  // conflicts; integrate the peer's commit + retry. (Codex #6283.)
+  // --no-verify: bus envelopes are DATA, not code — skip code hooks.
+  execFileSync("git", ["commit", "--no-verify", "-q", "-m", `bus(${from}): ${topic} ${path}`], opts);
+  // Explicit target: a concurrent peer advancing main rejects this push non-fast-forward,
+  // but disjoint ZetaId files (G-Set CRDT) never conflict -> pull --rebase + retry.
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
-      execFileSync("git", ["push"], opts);
+      execFileSync("git", ["push", "origin", "HEAD:main"], opts);
       return;
     } catch {
-      execFileSync("git", ["pull", "--rebase"], opts);
+      execFileSync("git", ["pull", "--rebase", "origin", "main"], opts);
     }
   }
-  execFileSync("git", ["push"], opts); // final attempt — throws if still failing (surfaced, not swallowed)
+  execFileSync("git", ["push", "origin", "HEAD:main"], opts); // final attempt — throws if still failing
 }
 
 if (import.meta.main) {
@@ -73,10 +79,26 @@ if (import.meta.main) {
     console.error("usage: publish.ts <from> <to> <topic> <json-payload> [--no-push]");
     process.exit(2);
   }
-  const message = { topic, payload: JSON.parse(payloadJson) } as BusMessage;
+  // Validate against the canonical allowlists (also blocks path-injection via <from>).
+  if (!SENDER_IDS.includes(from as SenderAgentId)) {
+    console.error(`unknown sender '${from}'. Valid: ${SENDER_IDS.join(", ")}`);
+    process.exit(2);
+  }
+  if (!AGENT_IDS.includes(to as AgentId)) {
+    console.error(`unknown target '${to}'. Valid: ${AGENT_IDS.join(", ")} | *`);
+    process.exit(2);
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(payloadJson);
+  } catch (e) {
+    console.error(`invalid JSON payload: ${(e as Error).message}`);
+    process.exit(2);
+  }
+  const message = { topic, payload } as BusMessage;
   const env = makeEnvelope(from as SenderAgentId, to as AgentId, message);
   const result = writeEnvelope(env);
-  console.log(JSON.stringify({ result: result.kind, path: result.path, zetaIdHex: env.zetaIdHex }));
+  console.log(JSON.stringify({ result: result.kind, path: result.path, id: env.id }));
   if (result.kind === "collision") process.exit(1);
   if (result.kind === "created" && !process.argv.includes("--no-push")) {
     gitPushEnvelope(result.path, env.from, topic);

--- a/tools/agent-bus/publish.ts
+++ b/tools/agent-bus/publish.ts
@@ -51,8 +51,19 @@ function gitPushEnvelope(path: string, from: SenderAgentId, topic: string): void
   const opts = { stdio: "inherit" as const };
   execFileSync("git", ["add", path], opts);
   execFileSync("git", ["commit", "-q", "-m", `bus(${from}): ${topic} ${path}`], opts);
-  // Direct-to-main, no PR (the B-0858 carve-out). --no-verify: bus envelopes are data, not code.
-  execFileSync("git", ["push"], opts);
+  // Direct-to-main, no PR (the B-0858 carve-out). A concurrent peer publishing its OWN
+  // disjoint envelope advances main, so this push can be rejected non-fast-forward — but
+  // the envelopes are disjoint ZetaId files (the G-Set CRDT), so `pull --rebase` NEVER
+  // conflicts; integrate the peer's commit + retry. (Codex #6283.)
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      execFileSync("git", ["push"], opts);
+      return;
+    } catch {
+      execFileSync("git", ["pull", "--rebase"], opts);
+    }
+  }
+  execFileSync("git", ["push"], opts); // final attempt — throws if still failing (surfaced, not swallowed)
 }
 
 if (import.meta.main) {

--- a/tools/agent-bus/publish.ts
+++ b/tools/agent-bus/publish.ts
@@ -68,10 +68,28 @@ export function writeEnvelope(
 // ── no-PR runtime: write + commit --no-verify + push origin HEAD:main (B-0858) ──────
 // Guarded behind import.meta.main so importing this module (tests) never runs git.
 
+/**
+ * Co-Authored-By trailer for the publishing sender (per agent-roster-reference-card), so a
+ * bus commit by a non-Claude surface isn't mis-stamped as Claude (Codex #6283). Unknown
+ * senders fall back to naming themselves.
+ */
+function coauthorFor(from: string): string {
+  const byPrefix: readonly (readonly [string, string])[] = [
+    ["otto", "Co-Authored-By: Claude <noreply@anthropic.com>"],
+    ["alexa", "Co-Authored-By: Kiro <noreply@kiro.dev>"],
+    ["riven", "Co-Authored-By: Grok <noreply@x.ai>"],
+    ["vera", "Co-Authored-By: Codex <noreply@openai.com>"],
+    ["lior", "Co-Authored-By: Gemini <noreply@google.com>"],
+  ];
+  const match = byPrefix.find(([p]) => from === p || from.startsWith(`${p}-`));
+  return match ? match[1] : `Co-Authored-By: ${from} <noreply@zeta.local>`;
+}
+
 function gitPushEnvelope(path: string, from: SenderAgentId, topic: string): void {
   const opts = { stdio: "inherit" as const };
   // The bus folder lives on main; publishing from a feature branch would push that
   // branch's unrelated commits to main. Require a main checkout (or a bus worktree on main).
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
   const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { encoding: "utf-8" }).trim();
   if (branch !== "main") {
     throw new Error(`agent-bus publish must run on a main checkout (on '${branch}'); use a bus worktree on main`);
@@ -79,36 +97,44 @@ function gitPushEnvelope(path: string, from: SenderAgentId, topic: string): void
   // Refuse if local main is ahead of origin/main: `git push HEAD:main` would shove those
   // unrelated local commits straight to main alongside the envelope (Codex #6283 P1).
   // Fetch first so the comparison is against fresh origin/main, then require 0 ahead.
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
   execFileSync("git", ["fetch", "origin", "main"], opts);
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
   const ahead = execFileSync("git", ["rev-list", "--count", "origin/main..HEAD"], { encoding: "utf-8" }).trim();
   if (ahead !== "0") {
     throw new Error(
       `agent-bus publish: local main is ${ahead} commit(s) ahead of origin/main; reconcile before publishing (refusing to push unrelated commits to main)`,
     );
   }
-  execFileSync("git", ["add", path], opts);
+  // Normalize to forward slashes: envelopePath uses node:path.join, which on Windows yields
+  // backslashes that git pathspec parsing can mis-handle (Copilot #6283 — Windows surface).
+  const gitPath = path.replaceAll("\\", "/");
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  execFileSync("git", ["add", gitPath], opts);
   // --no-verify: bus envelopes are DATA, not code — skip code hooks.
-  // Pathspec `-- path` commits ONLY the envelope, never pre-staged work already in the
-  // checkout (Codex #6283 P2 — a direct-to-main --no-verify commit must not sweep it in).
-  // Body names the publishing sender; the Co-Authored-By trailer keeps the repo-required
-  // attribution even though --no-verify skips the hook that would otherwise add/check it
-  // (Codex #6283 P2 — a direct-to-main bus commit must still carry attribution).
+  // Pathspec `-- gitPath` commits ONLY the envelope, never pre-staged work in the checkout
+  // (Codex #6283 P2 — a direct-to-main --no-verify commit must not sweep it in). Body names
+  // the sender; the Co-Authored-By trailer is resolved PER SENDER (not hardcoded Claude) so
+  // a non-Claude surface's bus commit is attributed correctly (Codex #6283 P2).
   const commitMsg = [
-    `bus(${from}): ${topic} ${path}`,
+    `bus(${from}): ${topic} ${gitPath}`,
     "",
     `Agent-bus envelope published by ${from} (B-0954, no-PR direct-to-main).`,
     "",
-    "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>",
+    coauthorFor(from),
   ].join("\n");
-  execFileSync("git", ["commit", "--no-verify", "-q", "-m", commitMsg, "--", path], opts);
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
+  execFileSync("git", ["commit", "--no-verify", "-q", "-m", commitMsg, "--", gitPath], opts);
   // Explicit target: a concurrent peer advancing main rejects this push non-fast-forward,
   // but disjoint ZetaId files (G-Set CRDT) never conflict -> pull --rebase + retry.
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
+      // eslint-disable-next-line sonarjs/no-os-command-from-path
       execFileSync("git", ["push", "origin", "HEAD:main"], opts);
       return;
     } catch {
       try {
+        // eslint-disable-next-line sonarjs/no-os-command-from-path
         execFileSync("git", ["pull", "--rebase", "origin", "main"], opts);
       } catch {
         // A rebase CONFLICT here means a peer pushed the SAME ZetaId path with DIFFERENT
@@ -118,6 +144,7 @@ function gitPushEnvelope(path: string, from: SenderAgentId, topic: string): void
         // clean repo and fail loudly — the publisher should re-mint (use DEFAULT_ENV) and
         // retry rather than silently merge over a peer's envelope (Codex #6283 P2).
         try {
+          // eslint-disable-next-line sonarjs/no-os-command-from-path
           execFileSync("git", ["rebase", "--abort"], opts);
         } catch {
           /* no rebase in progress to abort */
@@ -128,6 +155,7 @@ function gitPushEnvelope(path: string, from: SenderAgentId, topic: string): void
       }
     }
   }
+  // eslint-disable-next-line sonarjs/no-os-command-from-path
   execFileSync("git", ["push", "origin", "HEAD:main"], opts); // final attempt — throws if still failing
 }
 
@@ -144,7 +172,7 @@ if (import.meta.main) {
     process.exit(2);
   }
   if (!AGENT_IDS.includes(to as AgentId)) {
-    console.error(`unknown target '${to}'. Valid: ${AGENT_IDS.join(", ")} | *`);
+    console.error(`unknown target '${to}'. Valid: ${AGENT_IDS.join(", ")}`); // AGENT_IDS already includes "*"
     process.exit(2);
   }
   // Validate topic against the known bus topics (TTL_MS keys) BEFORE building the envelope:

--- a/tools/agent-bus/publish.ts
+++ b/tools/agent-bus/publish.ts
@@ -1,0 +1,73 @@
+/**
+ * Agent-bus Phase 1 (B-0954) — publish.
+ *
+ * `writeEnvelope` is PURE (file write only; idempotent on identical content — the
+ * G-Set CRDT property). The CLI (`import.meta.main`) is the no-PR runtime: write the
+ * file, then `git add/commit/push` directly to main (no PR) — the B-0858 mechanism.
+ * Tests import `writeEnvelope` against a temp root and never touch git.
+ */
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { dirname } from "node:path";
+import { execFileSync } from "node:child_process";
+import { AGENT_BUS_ROOT, envelopePath, serializeEnvelope, mintBusZetaIdHex, type AgentBusEnvelope } from "./types";
+import type { AgentId, SenderAgentId, BusMessage } from "../bus/types";
+
+export type WriteResult =
+  | { readonly kind: "created"; readonly path: string }
+  | { readonly kind: "exists-identical"; readonly path: string } // idempotent re-publish (G-Set CRDT)
+  | { readonly kind: "collision"; readonly path: string }; // same zetaId, DIFFERENT content — should never happen with crypto ids
+
+/**
+ * Write an envelope as its ZetaId-named file. Idempotent on identical content (re-
+ * publishing the same envelope is a safe no-op — the grow-only-set property). A
+ * same-id/different-content collision is surfaced as feedback (`kind: "collision"`),
+ * never silently overwritten — the writer decides (per the spec's collision caveat).
+ */
+export function writeEnvelope(
+  env: AgentBusEnvelope,
+  root: string = AGENT_BUS_ROOT,
+  at: Date = new Date(),
+): WriteResult {
+  const path = envelopePath(root, env.from, env.zetaIdHex, at);
+  if (existsSync(path)) {
+    return readFileSync(path, "utf-8") === serializeEnvelope(env)
+      ? { kind: "exists-identical", path }
+      : { kind: "collision", path };
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, serializeEnvelope(env));
+  return { kind: "created", path };
+}
+
+/** Build an envelope: mint a fresh Bus ZetaId + stamp the ISO ts. */
+export function makeEnvelope(from: SenderAgentId, to: AgentId, message: BusMessage, atMs: number = Date.now()): AgentBusEnvelope {
+  return { zetaIdHex: mintBusZetaIdHex(undefined, atMs), from, to, ts: new Date(atMs).toISOString(), message };
+}
+
+// ── no-PR runtime: write + git add/commit/push directly to main (B-0858) ──────────
+// Guarded behind import.meta.main so importing this module (tests) never runs git.
+
+function gitPushEnvelope(path: string, from: SenderAgentId, topic: string): void {
+  const opts = { stdio: "inherit" as const };
+  execFileSync("git", ["add", path], opts);
+  execFileSync("git", ["commit", "-q", "-m", `bus(${from}): ${topic} ${path}`], opts);
+  // Direct-to-main, no PR (the B-0858 carve-out). --no-verify: bus envelopes are data, not code.
+  execFileSync("git", ["push"], opts);
+}
+
+if (import.meta.main) {
+  // usage: bun tools/agent-bus/publish.ts <from> <to> <topic> <json-payload> [--no-push]
+  const [from, to, topic, payloadJson] = process.argv.slice(2);
+  if (!from || !to || !topic || !payloadJson) {
+    console.error("usage: publish.ts <from> <to> <topic> <json-payload> [--no-push]");
+    process.exit(2);
+  }
+  const message = { topic, payload: JSON.parse(payloadJson) } as BusMessage;
+  const env = makeEnvelope(from as SenderAgentId, to as AgentId, message);
+  const result = writeEnvelope(env);
+  console.log(JSON.stringify({ result: result.kind, path: result.path, zetaIdHex: env.zetaIdHex }));
+  if (result.kind === "collision") process.exit(1);
+  if (result.kind === "created" && !process.argv.includes("--no-push")) {
+    gitPushEnvelope(result.path, env.from, topic);
+  }
+}

--- a/tools/agent-bus/subscribe.ts
+++ b/tools/agent-bus/subscribe.ts
@@ -1,0 +1,65 @@
+/**
+ * Agent-bus Phase 1 (B-0954) — subscribe.
+ *
+ * `readEnvelopesSince` is PURE (read the folder; filter by an ISO ts cursor; sort).
+ * The CLI (`import.meta.main`) is the cross-machine read: `git pull` first, then read
+ * — so a peer's pushed envelopes (incl. a Windows peer) arrive. Tests import
+ * `readEnvelopesSince` against a temp root and never touch git.
+ */
+import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { AGENT_BUS_ROOT, type AgentBusEnvelope } from "./types";
+
+/** Recursively collect every `*.json` file under `dir` (depth-first; missing dir -> []). */
+function walkJson(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) out.push(...walkJson(p));
+    else if (entry.endsWith(".json")) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Read all envelopes with `ts` strictly after `sinceTs` (ISO 8601 sorts
+ * lexicographically), sorted by `(ts, zetaIdHex)` for a stable cross-machine order.
+ * No cursor -> all. Malformed files are skipped with a warning (best-effort; a bad
+ * envelope must not break the read for everyone — exceptions-as-signals).
+ */
+export function readEnvelopesSince(root: string = AGENT_BUS_ROOT, sinceTs?: string): AgentBusEnvelope[] {
+  const envs: AgentBusEnvelope[] = [];
+  for (const file of walkJson(root)) {
+    let env: AgentBusEnvelope;
+    try {
+      env = JSON.parse(readFileSync(file, "utf-8")) as AgentBusEnvelope;
+    } catch {
+      console.warn(`agent-bus: skipping malformed envelope ${file}`);
+      continue;
+    }
+    if (sinceTs === undefined || env.ts > sinceTs) envs.push(env);
+  }
+  envs.sort((a, b) => (a.ts === b.ts ? a.zetaIdHex.localeCompare(b.zetaIdHex) : a.ts.localeCompare(b.ts)));
+  return envs;
+}
+
+/** The next cursor = the last (newest) envelope's ts, or the prior cursor if none. */
+export function nextCursor(envs: readonly AgentBusEnvelope[], prior?: string): string | undefined {
+  return envs.length > 0 ? envs[envs.length - 1]!.ts : prior;
+}
+
+if (import.meta.main) {
+  // usage: bun tools/agent-bus/subscribe.ts [sinceTs] [--no-pull]
+  if (!process.argv.includes("--no-pull")) {
+    try {
+      execFileSync("git", ["pull", "--ff-only"], { stdio: "inherit" });
+    } catch {
+      console.warn("agent-bus: git pull failed (offline?) — reading local state only");
+    }
+  }
+  const sinceTs = process.argv.slice(2).find((a) => !a.startsWith("--"));
+  const envs = readEnvelopesSince(AGENT_BUS_ROOT, sinceTs);
+  console.log(JSON.stringify({ count: envs.length, cursor: nextCursor(envs, sinceTs), envelopes: envs }, null, 2));
+}

--- a/tools/agent-bus/subscribe.ts
+++ b/tools/agent-bus/subscribe.ts
@@ -132,23 +132,39 @@ export function nextCursor(envs: readonly AgentBusEnvelope[], prior?: string): s
   return envs.length > 0 ? envelopeCursor(envs[envs.length - 1]!) : prior;
 }
 
+/**
+ * Parse the subscribe CLI args (pure + testable): `[cursor] [--for <agentId>] [--no-fetch]`.
+ * The cursor is the first non-flag arg that ISN'T the `--for` value. `forValueIdx` is
+ * guarded to -1 when `--for` is absent — otherwise `forIdx (-1) + 1 = 0` would wrongly drop
+ * the cursor at index 0, making `subscribe.ts <cursor>` reread everything (Codex #6283).
+ */
+export function parseSubscribeArgs(args: readonly string[]): {
+  cursor?: string;
+  recipient?: AgentId;
+  fetch: boolean;
+} {
+  const forIdx = args.indexOf("--for");
+  const forValueIdx = forIdx >= 0 ? forIdx + 1 : -1;
+  return {
+    recipient: forIdx >= 0 ? (args[forIdx + 1] as AgentId) : undefined,
+    cursor: args.find((a, i) => !a.startsWith("--") && i !== forValueIdx),
+    fetch: !args.includes("--no-fetch"),
+  };
+}
+
 if (import.meta.main) {
   // usage: bun tools/agent-bus/subscribe.ts [cursor] [--for <agentId>] [--no-fetch]
   // cursor = "<timestamp>|<id>" from a prior run (or a bare ISO timestamp as a lower bound).
   // --for <agentId> returns only envelopes addressed to that agent or broadcast to `*`.
-  const args = process.argv.slice(2);
+  const { cursor, recipient, fetch } = parseSubscribeArgs(process.argv.slice(2));
   const ref = "origin/main";
-  if (!args.includes("--no-fetch")) {
+  if (fetch) {
     try {
       execFileSync("git", ["fetch", "origin", "main"], { stdio: "inherit" });
     } catch {
       console.warn("agent-bus: git fetch failed (offline?) — reading last-known origin/main");
     }
   }
-  const forIdx = args.indexOf("--for");
-  const recipient = forIdx >= 0 ? (args[forIdx + 1] as AgentId) : undefined;
-  // positional cursor = first non-flag arg that isn't the --for value
-  const cursor = args.find((a, i) => !a.startsWith("--") && i !== forIdx + 1);
   const envs = readEnvelopesFromGitRef(ref, AGENT_BUS_ROOT, cursor, recipient);
   console.log(JSON.stringify({ count: envs.length, cursor: nextCursor(envs, cursor), envelopes: envs }, null, 2));
 }

--- a/tools/agent-bus/subscribe.ts
+++ b/tools/agent-bus/subscribe.ts
@@ -11,7 +11,7 @@
 import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
-import { AGENT_BUS_ROOT, type AgentBusEnvelope } from "./types";
+import { AGENT_BUS_ROOT, isCanonicalTimestamp, isCanonicalBusId, type AgentBusEnvelope } from "./types";
 import type { AgentId } from "../bus/types";
 
 /**
@@ -23,10 +23,22 @@ export function envelopeCursor(env: AgentBusEnvelope): string {
   return `${env.timestamp}|${env.id}`;
 }
 
-/** A parsed value is a usable envelope only if its ordering keys are present strings. */
+/**
+ * A parsed value is a usable envelope only if its ordering keys are present AND
+ * well-formed: timestamp a canonical ISO string (so lexical sort == time sort) and id a
+ * 32-hex (the deterministic tiebreak). typeof-string alone isn't enough — one malformed
+ * timestamp/id would corrupt ordering + cursor progression for everyone (Copilot #6283).
+ */
 function isReadableEnvelope(v: unknown): v is AgentBusEnvelope {
   const e = v as Partial<AgentBusEnvelope> | null;
-  return !!e && typeof e === "object" && typeof e.timestamp === "string" && typeof e.id === "string";
+  return (
+    !!e &&
+    typeof e === "object" &&
+    typeof e.timestamp === "string" &&
+    isCanonicalTimestamp(e.timestamp) &&
+    typeof e.id === "string" &&
+    isCanonicalBusId(e.id)
+  );
 }
 
 /** A subscriber sees envelopes addressed to it or broadcast to `*`; no recipient = all. */

--- a/tools/agent-bus/subscribe.ts
+++ b/tools/agent-bus/subscribe.ts
@@ -12,6 +12,7 @@ import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 import { AGENT_BUS_ROOT, type AgentBusEnvelope } from "./types";
+import type { AgentId } from "../bus/types";
 
 /**
  * Compound cursor `<timestamp>|<id>` — the read position. timestamp alone drops a
@@ -28,8 +29,17 @@ function isReadableEnvelope(v: unknown): v is AgentBusEnvelope {
   return !!e && typeof e === "object" && typeof e.timestamp === "string" && typeof e.id === "string";
 }
 
-/** Parse + schema-validate + compound-cursor-filter + stable-sort envelope JSON strings. */
-function collect(files: Iterable<{ path: string; json: string }>, cursor?: string): AgentBusEnvelope[] {
+/** A subscriber sees envelopes addressed to it or broadcast to `*`; no recipient = all. */
+function matchesRecipient(env: AgentBusEnvelope, recipient?: AgentId): boolean {
+  return recipient === undefined || env.to === recipient || env.to === "*";
+}
+
+/** Parse + schema-validate + recipient-filter + compound-cursor-filter + stable-sort. */
+function collect(
+  files: Iterable<{ path: string; json: string }>,
+  cursor?: string,
+  recipient?: AgentId,
+): AgentBusEnvelope[] {
   const envs: AgentBusEnvelope[] = [];
   for (const { path, json } of files) {
     let parsed: unknown;
@@ -43,6 +53,7 @@ function collect(files: Iterable<{ path: string; json: string }>, cursor?: strin
       console.warn(`agent-bus: skipping schema-invalid envelope (missing timestamp/id) ${path}`);
       continue;
     }
+    if (!matchesRecipient(parsed, recipient)) continue;
     if (cursor === undefined || envelopeCursor(parsed) > cursor) envs.push(parsed);
   }
   envs.sort((a, b) => envelopeCursor(a).localeCompare(envelopeCursor(b)));
@@ -67,10 +78,15 @@ function walkJson(dir: string): string[] {
  * Malformed + schema-invalid files skipped (best-effort; one bad envelope must not
  * break the read for everyone).
  */
-export function readEnvelopesSince(root: string = AGENT_BUS_ROOT, cursor?: string): AgentBusEnvelope[] {
+export function readEnvelopesSince(
+  root: string = AGENT_BUS_ROOT,
+  cursor?: string,
+  recipient?: AgentId,
+): AgentBusEnvelope[] {
   return collect(
     walkJson(root).map((path) => ({ path, json: readFileSync(path, "utf-8") })),
     cursor,
+    recipient,
   );
 }
 
@@ -79,7 +95,12 @@ export function readEnvelopesSince(root: string = AGENT_BUS_ROOT, cursor?: strin
  * the cross-machine-correct read (the working tree may be on a feature branch / stale).
  * Uses `git ls-tree` + `git show`; same schema-validate + compound-cursor filter + sort.
  */
-export function readEnvelopesFromGitRef(ref: string, root: string = AGENT_BUS_ROOT, cursor?: string): AgentBusEnvelope[] {
+export function readEnvelopesFromGitRef(
+  ref: string,
+  root: string = AGENT_BUS_ROOT,
+  cursor?: string,
+  recipient?: AgentId,
+): AgentBusEnvelope[] {
   let listing: string;
   try {
     listing = execFileSync("git", ["ls-tree", "-r", "--name-only", ref, "--", root], { encoding: "utf-8" });
@@ -90,6 +111,7 @@ export function readEnvelopesFromGitRef(ref: string, root: string = AGENT_BUS_RO
   return collect(
     paths.map((path) => ({ path, json: execFileSync("git", ["show", `${ref}:${path}`], { encoding: "utf-8" }) })),
     cursor,
+    recipient,
   );
 }
 
@@ -99,17 +121,22 @@ export function nextCursor(envs: readonly AgentBusEnvelope[], prior?: string): s
 }
 
 if (import.meta.main) {
-  // usage: bun tools/agent-bus/subscribe.ts [cursor] [--no-fetch]
+  // usage: bun tools/agent-bus/subscribe.ts [cursor] [--for <agentId>] [--no-fetch]
   // cursor = "<timestamp>|<id>" from a prior run (or a bare ISO timestamp as a lower bound).
+  // --for <agentId> returns only envelopes addressed to that agent or broadcast to `*`.
+  const args = process.argv.slice(2);
   const ref = "origin/main";
-  if (!process.argv.includes("--no-fetch")) {
+  if (!args.includes("--no-fetch")) {
     try {
       execFileSync("git", ["fetch", "origin", "main"], { stdio: "inherit" });
     } catch {
       console.warn("agent-bus: git fetch failed (offline?) — reading last-known origin/main");
     }
   }
-  const cursor = process.argv.slice(2).find((a) => !a.startsWith("--"));
-  const envs = readEnvelopesFromGitRef(ref, AGENT_BUS_ROOT, cursor);
+  const forIdx = args.indexOf("--for");
+  const recipient = forIdx >= 0 ? (args[forIdx + 1] as AgentId) : undefined;
+  // positional cursor = first non-flag arg that isn't the --for value
+  const cursor = args.find((a, i) => !a.startsWith("--") && i !== forIdx + 1);
+  const envs = readEnvelopesFromGitRef(ref, AGENT_BUS_ROOT, cursor, recipient);
   console.log(JSON.stringify({ count: envs.length, cursor: nextCursor(envs, cursor), envelopes: envs }, null, 2));
 }

--- a/tools/agent-bus/subscribe.ts
+++ b/tools/agent-bus/subscribe.ts
@@ -139,8 +139,8 @@ export function nextCursor(envs: readonly AgentBusEnvelope[], prior?: string): s
  * the cursor at index 0, making `subscribe.ts <cursor>` reread everything (Codex #6283).
  */
 export function parseSubscribeArgs(args: readonly string[]): {
-  cursor?: string;
-  recipient?: AgentId;
+  cursor: string | undefined;
+  recipient: AgentId | undefined;
   fetch: boolean;
 } {
   const forIdx = args.indexOf("--for");

--- a/tools/agent-bus/subscribe.ts
+++ b/tools/agent-bus/subscribe.ts
@@ -115,12 +115,14 @@ export function readEnvelopesFromGitRef(
 ): AgentBusEnvelope[] {
   let listing: string;
   try {
+    // eslint-disable-next-line sonarjs/no-os-command-from-path
     listing = execFileSync("git", ["ls-tree", "-r", "--name-only", ref, "--", root], { encoding: "utf-8" });
   } catch {
     return []; // ref or path absent (e.g. no bus folder yet)
   }
   const paths = listing.split("\n").filter((p) => p.endsWith(".json"));
   return collect(
+    // eslint-disable-next-line sonarjs/no-os-command-from-path
     paths.map((path) => ({ path, json: execFileSync("git", ["show", `${ref}:${path}`], { encoding: "utf-8" }) })),
     cursor,
     recipient,
@@ -129,7 +131,8 @@ export function readEnvelopesFromGitRef(
 
 /** The next compound cursor = the last (newest) envelope's `<timestamp>|<id>`, else prior. */
 export function nextCursor(envs: readonly AgentBusEnvelope[], prior?: string): string | undefined {
-  return envs.length > 0 ? envelopeCursor(envs[envs.length - 1]!) : prior;
+  const last = envs.at(-1);
+  return last ? envelopeCursor(last) : prior;
 }
 
 /**
@@ -160,6 +163,7 @@ if (import.meta.main) {
   const ref = "origin/main";
   if (fetch) {
     try {
+      // eslint-disable-next-line sonarjs/no-os-command-from-path
       execFileSync("git", ["fetch", "origin", "main"], { stdio: "inherit" });
     } catch {
       console.warn("agent-bus: git fetch failed (offline?) — reading last-known origin/main");

--- a/tools/agent-bus/subscribe.ts
+++ b/tools/agent-bus/subscribe.ts
@@ -1,15 +1,43 @@
 /**
  * Agent-bus Phase 1 (B-0954) — subscribe.
  *
- * `readEnvelopesSince` is PURE (read the folder; filter by an ISO ts cursor; sort).
- * The CLI (`import.meta.main`) is the cross-machine read: `git pull` first, then read
- * — so a peer's pushed envelopes (incl. a Windows peer) arrive. Tests import
- * `readEnvelopesSince` against a temp root and never touch git.
+ * `readEnvelopesSince` is PURE (read a folder; filter by a COMPOUND `(ts, zetaIdHex)`
+ * cursor; sort). The CLI (`import.meta.main`) does the cross-machine read **from
+ * `origin/main`** (not the working tree): `git fetch origin main`, then read the bus
+ * folder at the `origin/main` tree via `readEnvelopesFromGitRef` — so it works even
+ * when the agent is checked out on a feature branch or a stale worktree (the
+ * post-fetch-read-trap; Codex #6283). Tests import the pure readers and never touch git.
  */
 import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 import { AGENT_BUS_ROOT, type AgentBusEnvelope } from "./types";
+
+/**
+ * Compound cursor `<ts>|<zetaIdHex>` — the read position. ts alone drops a later
+ * envelope that shares the cursor's millisecond; the zetaIdHex tiebreak fixes that
+ * (Codex #6283). ISO ts sorts lexicographically; the hex breaks ties deterministically.
+ */
+export function envelopeCursor(env: AgentBusEnvelope): string {
+  return `${env.ts}|${env.zetaIdHex}`;
+}
+
+/** Parse + compound-cursor-filter + stable-sort a set of envelope JSON strings. */
+function collect(files: Iterable<{ path: string; json: string }>, cursor?: string): AgentBusEnvelope[] {
+  const envs: AgentBusEnvelope[] = [];
+  for (const { path, json } of files) {
+    let env: AgentBusEnvelope;
+    try {
+      env = JSON.parse(json) as AgentBusEnvelope;
+    } catch {
+      console.warn(`agent-bus: skipping malformed envelope ${path}`);
+      continue;
+    }
+    if (cursor === undefined || envelopeCursor(env) > cursor) envs.push(env);
+  }
+  envs.sort((a, b) => envelopeCursor(a).localeCompare(envelopeCursor(b)));
+  return envs;
+}
 
 /** Recursively collect every `*.json` file under `dir` (depth-first; missing dir -> []). */
 function walkJson(dir: string): string[] {
@@ -24,42 +52,54 @@ function walkJson(dir: string): string[] {
 }
 
 /**
- * Read all envelopes with `ts` strictly after `sinceTs` (ISO 8601 sorts
- * lexicographically), sorted by `(ts, zetaIdHex)` for a stable cross-machine order.
- * No cursor -> all. Malformed files are skipped with a warning (best-effort; a bad
- * envelope must not break the read for everyone — exceptions-as-signals).
+ * PURE filesystem read: all envelopes under `root` with a compound cursor strictly
+ * after `cursor` (`<ts>|<zetaIdHex>`), sorted by that cursor. No cursor -> all.
+ * Malformed files skipped (best-effort; one bad envelope must not break the read).
  */
-export function readEnvelopesSince(root: string = AGENT_BUS_ROOT, sinceTs?: string): AgentBusEnvelope[] {
-  const envs: AgentBusEnvelope[] = [];
-  for (const file of walkJson(root)) {
-    let env: AgentBusEnvelope;
-    try {
-      env = JSON.parse(readFileSync(file, "utf-8")) as AgentBusEnvelope;
-    } catch {
-      console.warn(`agent-bus: skipping malformed envelope ${file}`);
-      continue;
-    }
-    if (sinceTs === undefined || env.ts > sinceTs) envs.push(env);
-  }
-  envs.sort((a, b) => (a.ts === b.ts ? a.zetaIdHex.localeCompare(b.zetaIdHex) : a.ts.localeCompare(b.ts)));
-  return envs;
+export function readEnvelopesSince(root: string = AGENT_BUS_ROOT, cursor?: string): AgentBusEnvelope[] {
+  return collect(
+    walkJson(root).map((path) => ({ path, json: readFileSync(path, "utf-8") })),
+    cursor,
+  );
 }
 
-/** The next cursor = the last (newest) envelope's ts, or the prior cursor if none. */
+/**
+ * Read the bus folder at a git REF (e.g. `origin/main`) rather than the working tree —
+ * the cross-machine-correct read (the working tree may be on a feature branch / stale).
+ * Uses `git ls-tree` + `git show`; same compound-cursor filter + sort as the filesystem
+ * read. (Codex #6283.)
+ */
+export function readEnvelopesFromGitRef(ref: string, root: string = AGENT_BUS_ROOT, cursor?: string): AgentBusEnvelope[] {
+  let listing: string;
+  try {
+    listing = execFileSync("git", ["ls-tree", "-r", "--name-only", ref, "--", root], { encoding: "utf-8" });
+  } catch {
+    return []; // ref or path absent (e.g. no bus folder yet)
+  }
+  const paths = listing.split("\n").filter((p) => p.endsWith(".json"));
+  return collect(
+    paths.map((path) => ({ path, json: execFileSync("git", ["show", `${ref}:${path}`], { encoding: "utf-8" }) })),
+    cursor,
+  );
+}
+
+/** The next compound cursor = the last (newest) envelope's `<ts>|<zetaIdHex>`, else prior. */
 export function nextCursor(envs: readonly AgentBusEnvelope[], prior?: string): string | undefined {
-  return envs.length > 0 ? envs[envs.length - 1]!.ts : prior;
+  return envs.length > 0 ? envelopeCursor(envs[envs.length - 1]!) : prior;
 }
 
 if (import.meta.main) {
-  // usage: bun tools/agent-bus/subscribe.ts [sinceTs] [--no-pull]
-  if (!process.argv.includes("--no-pull")) {
+  // usage: bun tools/agent-bus/subscribe.ts [cursor] [--no-fetch]
+  // cursor = "<ts>|<zetaIdHex>" from a prior run (or a bare ISO ts as a lower bound).
+  const ref = "origin/main";
+  if (!process.argv.includes("--no-fetch")) {
     try {
-      execFileSync("git", ["pull", "--ff-only"], { stdio: "inherit" });
+      execFileSync("git", ["fetch", "origin", "main"], { stdio: "inherit" });
     } catch {
-      console.warn("agent-bus: git pull failed (offline?) — reading local state only");
+      console.warn("agent-bus: git fetch failed (offline?) — reading last-known origin/main");
     }
   }
-  const sinceTs = process.argv.slice(2).find((a) => !a.startsWith("--"));
-  const envs = readEnvelopesSince(AGENT_BUS_ROOT, sinceTs);
-  console.log(JSON.stringify({ count: envs.length, cursor: nextCursor(envs, sinceTs), envelopes: envs }, null, 2));
+  const cursor = process.argv.slice(2).find((a) => !a.startsWith("--"));
+  const envs = readEnvelopesFromGitRef(ref, AGENT_BUS_ROOT, cursor);
+  console.log(JSON.stringify({ count: envs.length, cursor: nextCursor(envs, cursor), envelopes: envs }, null, 2));
 }

--- a/tools/agent-bus/subscribe.ts
+++ b/tools/agent-bus/subscribe.ts
@@ -1,12 +1,12 @@
 /**
  * Agent-bus Phase 1 (B-0954) — subscribe.
  *
- * `readEnvelopesSince` is PURE (read a folder; filter by a COMPOUND `(ts, zetaIdHex)`
+ * `readEnvelopesSince` is PURE (read a folder; filter by a COMPOUND `(timestamp, id)`
  * cursor; sort). The CLI (`import.meta.main`) does the cross-machine read **from
  * `origin/main`** (not the working tree): `git fetch origin main`, then read the bus
  * folder at the `origin/main` tree via `readEnvelopesFromGitRef` — so it works even
  * when the agent is checked out on a feature branch or a stale worktree (the
- * post-fetch-read-trap; Codex #6283). Tests import the pure readers and never touch git.
+ * post-fetch-read-trap). Tests import the pure readers and never touch git.
  */
 import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -14,26 +14,36 @@ import { execFileSync } from "node:child_process";
 import { AGENT_BUS_ROOT, type AgentBusEnvelope } from "./types";
 
 /**
- * Compound cursor `<ts>|<zetaIdHex>` — the read position. ts alone drops a later
- * envelope that shares the cursor's millisecond; the zetaIdHex tiebreak fixes that
- * (Codex #6283). ISO ts sorts lexicographically; the hex breaks ties deterministically.
+ * Compound cursor `<timestamp>|<id>` — the read position. timestamp alone drops a
+ * later envelope sharing the cursor's millisecond; the id tiebreak fixes that. ISO
+ * timestamp sorts lexicographically; the id (32-hex) breaks ties deterministically.
  */
 export function envelopeCursor(env: AgentBusEnvelope): string {
-  return `${env.ts}|${env.zetaIdHex}`;
+  return `${env.timestamp}|${env.id}`;
 }
 
-/** Parse + compound-cursor-filter + stable-sort a set of envelope JSON strings. */
+/** A parsed value is a usable envelope only if its ordering keys are present strings. */
+function isReadableEnvelope(v: unknown): v is AgentBusEnvelope {
+  const e = v as Partial<AgentBusEnvelope> | null;
+  return !!e && typeof e === "object" && typeof e.timestamp === "string" && typeof e.id === "string";
+}
+
+/** Parse + schema-validate + compound-cursor-filter + stable-sort envelope JSON strings. */
 function collect(files: Iterable<{ path: string; json: string }>, cursor?: string): AgentBusEnvelope[] {
   const envs: AgentBusEnvelope[] = [];
   for (const { path, json } of files) {
-    let env: AgentBusEnvelope;
+    let parsed: unknown;
     try {
-      env = JSON.parse(json) as AgentBusEnvelope;
+      parsed = JSON.parse(json);
     } catch {
       console.warn(`agent-bus: skipping malformed envelope ${path}`);
       continue;
     }
-    if (cursor === undefined || envelopeCursor(env) > cursor) envs.push(env);
+    if (!isReadableEnvelope(parsed)) {
+      console.warn(`agent-bus: skipping schema-invalid envelope (missing timestamp/id) ${path}`);
+      continue;
+    }
+    if (cursor === undefined || envelopeCursor(parsed) > cursor) envs.push(parsed);
   }
   envs.sort((a, b) => envelopeCursor(a).localeCompare(envelopeCursor(b)));
   return envs;
@@ -53,8 +63,9 @@ function walkJson(dir: string): string[] {
 
 /**
  * PURE filesystem read: all envelopes under `root` with a compound cursor strictly
- * after `cursor` (`<ts>|<zetaIdHex>`), sorted by that cursor. No cursor -> all.
- * Malformed files skipped (best-effort; one bad envelope must not break the read).
+ * after `cursor` (`<timestamp>|<id>`), sorted by that cursor. No cursor -> all.
+ * Malformed + schema-invalid files skipped (best-effort; one bad envelope must not
+ * break the read for everyone).
  */
 export function readEnvelopesSince(root: string = AGENT_BUS_ROOT, cursor?: string): AgentBusEnvelope[] {
   return collect(
@@ -66,8 +77,7 @@ export function readEnvelopesSince(root: string = AGENT_BUS_ROOT, cursor?: strin
 /**
  * Read the bus folder at a git REF (e.g. `origin/main`) rather than the working tree —
  * the cross-machine-correct read (the working tree may be on a feature branch / stale).
- * Uses `git ls-tree` + `git show`; same compound-cursor filter + sort as the filesystem
- * read. (Codex #6283.)
+ * Uses `git ls-tree` + `git show`; same schema-validate + compound-cursor filter + sort.
  */
 export function readEnvelopesFromGitRef(ref: string, root: string = AGENT_BUS_ROOT, cursor?: string): AgentBusEnvelope[] {
   let listing: string;
@@ -83,14 +93,14 @@ export function readEnvelopesFromGitRef(ref: string, root: string = AGENT_BUS_RO
   );
 }
 
-/** The next compound cursor = the last (newest) envelope's `<ts>|<zetaIdHex>`, else prior. */
+/** The next compound cursor = the last (newest) envelope's `<timestamp>|<id>`, else prior. */
 export function nextCursor(envs: readonly AgentBusEnvelope[], prior?: string): string | undefined {
   return envs.length > 0 ? envelopeCursor(envs[envs.length - 1]!) : prior;
 }
 
 if (import.meta.main) {
   // usage: bun tools/agent-bus/subscribe.ts [cursor] [--no-fetch]
-  // cursor = "<ts>|<zetaIdHex>" from a prior run (or a bare ISO ts as a lower bound).
+  // cursor = "<timestamp>|<id>" from a prior run (or a bare ISO timestamp as a lower bound).
   const ref = "origin/main";
   if (!process.argv.includes("--no-fetch")) {
     try {

--- a/tools/agent-bus/types.ts
+++ b/tools/agent-bus/types.ts
@@ -56,6 +56,21 @@ export function isSafeSegment(seg: string): boolean {
   return /^[A-Za-z0-9._-]+$/.test(seg) && !seg.startsWith(".") && !seg.includes("..");
 }
 
+/**
+ * A canonical envelope timestamp is exactly `Date.toISOString()` output
+ * (`YYYY-MM-DDTHH:mm:ss.sssZ`). This guarantees lexical string order == time order, which
+ * the readers' compound `(timestamp, id)` cursor relies on — a non-ISO timestamp (e.g.
+ * `2026/05/31`) would sort wrong and break cursor progression (Copilot #6283).
+ */
+export function isCanonicalTimestamp(ts: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(ts);
+}
+
+/** A canonical bus id is 32 lowercase hex chars (`mintBusZetaIdHex` output). */
+export function isCanonicalBusId(id: string): boolean {
+  return /^[0-9a-f]{32}$/.test(id);
+}
+
 /** `<root>/<persona>/<YYYY>/<MM>/<DD>/<id>.json` (UTC date partition). */
 export function envelopePath(root: string, persona: string, id: string, at: Date = new Date()): string {
   if (!isSafeSegment(persona) || !isSafeSegment(id)) {

--- a/tools/agent-bus/types.ts
+++ b/tools/agent-bus/types.ts
@@ -52,8 +52,17 @@ const pad2 = (n: number): string => String(n).padStart(2, "0");
  * otto-windows) + 32-hex ids, which already satisfy this; the allowlist makes the
  * "Windows-safe" claim actually hold for any future caller (Copilot #6283).
  */
+// Windows reserved device names (case-insensitive, with or without an extension) — invalid
+// as filenames on Windows even though they pass the char allowlist (Copilot #6283).
+const WINDOWS_RESERVED_NAME = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|$)/i;
+
 export function isSafeSegment(seg: string): boolean {
-  return /^[A-Za-z0-9._-]+$/.test(seg) && !seg.startsWith(".") && !seg.includes("..");
+  return (
+    /^[A-Za-z0-9._-]+$/.test(seg) &&
+    !seg.startsWith(".") &&
+    !seg.includes("..") &&
+    !WINDOWS_RESERVED_NAME.test(seg)
+  );
 }
 
 /**

--- a/tools/agent-bus/types.ts
+++ b/tools/agent-bus/types.ts
@@ -44,9 +44,16 @@ export type AgentBusEnvelope = MessageEnvelope;
 
 const pad2 = (n: number): string => String(n).padStart(2, "0");
 
-/** A path segment must be a single safe name — no separators, no `..`, no leading dot. */
+/**
+ * A path segment must be a single name that is valid on EVERY OS. Positive allowlist:
+ * letters, digits, dot, underscore, hyphen — no leading dot, no `..`. Everything
+ * Windows forbids (`< > : " / \ | ? *`, control chars, spaces) is rejected by
+ * omission. Our real segments are SENDER_IDS personas (kebab-case, e.g. otto-cli /
+ * otto-windows) + 32-hex ids, which already satisfy this; the allowlist makes the
+ * "Windows-safe" claim actually hold for any future caller (Copilot #6283).
+ */
 export function isSafeSegment(seg: string): boolean {
-  return seg.length > 0 && !seg.includes("/") && !seg.includes("\\") && !seg.includes("..") && !seg.startsWith(".");
+  return /^[A-Za-z0-9._-]+$/.test(seg) && !seg.startsWith(".") && !seg.includes("..");
 }
 
 /** `<root>/<persona>/<YYYY>/<MM>/<DD>/<id>.json` (UTC date partition). */

--- a/tools/agent-bus/types.ts
+++ b/tools/agent-bus/types.ts
@@ -1,0 +1,86 @@
+/**
+ * Agent-bus Phase 1 (B-0954) — the git-native cross-machine agent comms channel.
+ *
+ * Envelopes are ZetaId-named files in
+ *   docs/agent-bus/<persona>/<YYYY>/<MM>/<DD>/<zetaIdHex>.json
+ * a **G-Set CRDT**: disjoint, ZetaId-named files never collide, so concurrent agents
+ * on different machines write different files -> conflict-free -> cross-machine /
+ * Windows-safe (git is the transport). Per the #6219 spec; no-PR direct-to-main per
+ * B-0858 (heartbeat folder) + folders-on-main per B-0890.1.
+ *
+ * Reuses the existing bus topic+payload (`tools/bus/types`) + the canonical ZetaId
+ * (`Category.Bus`) — NOT a new id scheme or action language.
+ *
+ * This module is PURE (path + mint + types). The git layer (commit/push on publish,
+ * pull on subscribe) lives behind the CLIs in publish.ts / subscribe.ts so tests +
+ * importers never touch git or the real `docs/agent-bus/` folder.
+ */
+import { join } from "node:path";
+import type { AgentId, SenderAgentId, BusMessage } from "../bus/types";
+import { pack, DEFAULT_ENV, type SimulationEnvironment } from "../../src/Core.TypeScript/zeta-id/zeta-id";
+import {
+  Category,
+  IdVersion,
+  Chromosome,
+  Firefly,
+  Persona,
+  LocationHint,
+  type ZetaObservation,
+  type Milliseconds,
+} from "../../src/Core.TypeScript/zeta-id/types";
+
+/** Repo-relative root for the bus folder; override with `ZETA_AGENT_BUS_DIR` (tests). */
+export const AGENT_BUS_ROOT: string = process.env.ZETA_AGENT_BUS_DIR ?? "docs/agent-bus";
+
+/**
+ * One bus envelope = one file. Reuses the existing `BusMessage` (topic+payload union)
+ * + the sender/target identifiers; the ZetaId hex is the filename + the dedup key.
+ */
+export interface AgentBusEnvelope {
+  readonly zetaIdHex: string; // 32-hex Bus-category ZetaId — filename + dedup key
+  readonly from: SenderAgentId; // publishing agent surface
+  readonly to: AgentId; // target ("*" = broadcast)
+  readonly ts: string; // ISO timestamp — the ordering key (the ZetaId carries the canonical ms)
+  readonly message: BusMessage; // the existing topic+payload discriminated union
+}
+
+const pad2 = (n: number): string => String(n).padStart(2, "0");
+
+/** `<root>/<persona>/<YYYY>/<MM>/<DD>/<zetaIdHex>.json` (UTC date partition). */
+export function envelopePath(root: string, persona: string, zetaIdHex: string, at: Date = new Date()): string {
+  return join(
+    root,
+    persona,
+    String(at.getUTCFullYear()),
+    pad2(at.getUTCMonth() + 1),
+    pad2(at.getUTCDate()),
+    `${zetaIdHex}.json`,
+  );
+}
+
+/**
+ * Mint a Bus-category ZetaId as 32-hex. `DEFAULT_ENV` (crypto randomness) makes each
+ * call unique even with identical semantic fields — so distinct envelopes get distinct
+ * files. Pass `DETERMINISTIC_ENV` for reproducible tests (identical fields -> identical
+ * id -> the safe idempotent same-file the G-Set CRDT relies on; see the spec's
+ * collision caveat).
+ */
+export function mintBusZetaIdHex(env: SimulationEnvironment = DEFAULT_ENV, atMs: number = Date.now()): string {
+  const obs: ZetaObservation = {
+    version: IdVersion.V1,
+    timestamp: atMs as Milliseconds,
+    chromosome: Chromosome.MetaCoherence,
+    category: Category.Bus,
+    firefly: Firefly.NoDirective,
+    authority: { type: "TrustedAgent" },
+    persona: Persona.FireflyCoherence,
+    momentum: { type: "Normal" },
+    location: LocationHint.EastUS_VA1,
+  };
+  return pack(obs, env).toString(16).padStart(32, "0");
+}
+
+/** Canonical on-disk serialization (stable: pretty + trailing newline). */
+export function serializeEnvelope(env: AgentBusEnvelope): string {
+  return `${JSON.stringify(env, null, 2)}\n`;
+}

--- a/tools/agent-bus/types.ts
+++ b/tools/agent-bus/types.ts
@@ -2,21 +2,24 @@
  * Agent-bus Phase 1 (B-0954) — the git-native cross-machine agent comms channel.
  *
  * Envelopes are ZetaId-named files in
- *   docs/agent-bus/<persona>/<YYYY>/<MM>/<DD>/<zetaIdHex>.json
+ *   docs/agent-bus/<persona>/<YYYY>/<MM>/<DD>/<id>.json
  * a **G-Set CRDT**: disjoint, ZetaId-named files never collide, so concurrent agents
  * on different machines write different files -> conflict-free -> cross-machine /
  * Windows-safe (git is the transport). Per the #6219 spec; no-PR direct-to-main per
  * B-0858 (heartbeat folder) + folders-on-main per B-0890.1.
  *
- * Reuses the existing bus topic+payload (`tools/bus/types`) + the canonical ZetaId
- * (`Category.Bus`) — NOT a new id scheme or action language.
+ * The envelope **reuses the existing local-bus `MessageEnvelope`** (`tools/bus/types`)
+ * per the spec's "extend MessageEnvelope" guidance — `id` is the Bus-category ZetaId
+ * hex (filename + dedup key); `topic`/`payload` are the existing `BusMessage` union;
+ * `from`/`to`/`timestamp`/`expiresAt` are the existing fields. Same shape as the
+ * local bus, so the legacy-bus bridge (B-0954 sub-target) is a transport swap, not a
+ * reshape. NOT a new id scheme or action language.
  *
- * This module is PURE (path + mint + types). The git layer (commit/push on publish,
- * pull on subscribe) lives behind the CLIs in publish.ts / subscribe.ts so tests +
- * importers never touch git or the real `docs/agent-bus/` folder.
+ * This module is PURE (path + mint + types). The git layer lives behind the CLIs in
+ * publish.ts / subscribe.ts so tests + importers never touch git or the real folder.
  */
 import { join } from "node:path";
-import type { AgentId, SenderAgentId, BusMessage } from "../bus/types";
+import { TTL_MS, type AgentId, type SenderAgentId, type BusMessage, type MessageEnvelope } from "../bus/types";
 import { pack, DEFAULT_ENV, type SimulationEnvironment } from "../../src/Core.TypeScript/zeta-id/zeta-id";
 import {
   Category,
@@ -33,37 +36,39 @@ import {
 export const AGENT_BUS_ROOT: string = process.env.ZETA_AGENT_BUS_DIR ?? "docs/agent-bus";
 
 /**
- * One bus envelope = one file. Reuses the existing `BusMessage` (topic+payload union)
- * + the sender/target identifiers; the ZetaId hex is the filename + the dedup key.
+ * One bus envelope = one file. **Reuses the local-bus `MessageEnvelope`** — `id` is
+ * the 32-hex Bus-category ZetaId (filename + dedup key); `topic`/`payload` come from
+ * `BusMessage`; `from`/`to`/`timestamp`/`expiresAt` are the existing fields.
  */
-export interface AgentBusEnvelope {
-  readonly zetaIdHex: string; // 32-hex Bus-category ZetaId — filename + dedup key
-  readonly from: SenderAgentId; // publishing agent surface
-  readonly to: AgentId; // target ("*" = broadcast)
-  readonly ts: string; // ISO timestamp — the ordering key (the ZetaId carries the canonical ms)
-  readonly message: BusMessage; // the existing topic+payload discriminated union
-}
+export type AgentBusEnvelope = MessageEnvelope;
 
 const pad2 = (n: number): string => String(n).padStart(2, "0");
 
-/** `<root>/<persona>/<YYYY>/<MM>/<DD>/<zetaIdHex>.json` (UTC date partition). */
-export function envelopePath(root: string, persona: string, zetaIdHex: string, at: Date = new Date()): string {
+/** A path segment must be a single safe name — no separators, no `..`, no leading dot. */
+export function isSafeSegment(seg: string): boolean {
+  return seg.length > 0 && !seg.includes("/") && !seg.includes("\\") && !seg.includes("..") && !seg.startsWith(".");
+}
+
+/** `<root>/<persona>/<YYYY>/<MM>/<DD>/<id>.json` (UTC date partition). */
+export function envelopePath(root: string, persona: string, id: string, at: Date = new Date()): string {
+  if (!isSafeSegment(persona) || !isSafeSegment(id)) {
+    throw new Error(`agent-bus: unsafe path segment (persona=${persona}, id=${id})`);
+  }
   return join(
     root,
     persona,
     String(at.getUTCFullYear()),
     pad2(at.getUTCMonth() + 1),
     pad2(at.getUTCDate()),
-    `${zetaIdHex}.json`,
+    `${id}.json`,
   );
 }
 
 /**
  * Mint a Bus-category ZetaId as 32-hex. `DEFAULT_ENV` (crypto randomness) makes each
- * call unique even with identical semantic fields — so distinct envelopes get distinct
- * files. Pass `DETERMINISTIC_ENV` for reproducible tests (identical fields -> identical
- * id -> the safe idempotent same-file the G-Set CRDT relies on; see the spec's
- * collision caveat).
+ * call unique even with identical semantic fields. Pass `DETERMINISTIC_ENV` for
+ * reproducible tests (identical fields -> identical id -> the safe idempotent same-file
+ * the G-Set CRDT relies on; see the spec's collision caveat).
  */
 export function mintBusZetaIdHex(env: SimulationEnvironment = DEFAULT_ENV, atMs: number = Date.now()): string {
   const obs: ZetaObservation = {
@@ -78,6 +83,23 @@ export function mintBusZetaIdHex(env: SimulationEnvironment = DEFAULT_ENV, atMs:
     location: LocationHint.EastUS_VA1,
   };
   return pack(obs, env).toString(16).padStart(32, "0");
+}
+
+/** Build an envelope (reuses MessageEnvelope): mint a Bus id + stamp timestamp/expiresAt. */
+export function makeEnvelope(
+  from: SenderAgentId,
+  to: AgentId,
+  message: BusMessage,
+  atMs: number = Date.now(),
+): AgentBusEnvelope {
+  return {
+    ...message,
+    id: mintBusZetaIdHex(undefined, atMs),
+    from,
+    to,
+    timestamp: new Date(atMs).toISOString(),
+    expiresAt: new Date(atMs + TTL_MS[message.topic]).toISOString(), // per-topic TTL (Record<Topic, number>)
+  };
 }
 
 /** Canonical on-disk serialization (stable: pretty + trailing newline). */

--- a/tools/bus/types.ts
+++ b/tools/bus/types.ts
@@ -38,6 +38,9 @@ export type AgentId =
   | "otto-cli"
   | "otto-desktop"
   | "otto-vscode"
+  // otto-windows — first Windows surface; the git-native cross-machine agent-bus
+  // names it the first Windows sender (#6219 spec / B-0954).
+  | "otto-windows"
   // Alexa multi-surface (Kiro IDE + CLI)
   | "alexa-cli"
   | "alexa-kiro"
@@ -162,6 +165,8 @@ export const SENDER_IDS: readonly SenderAgentId[] = [
   // Multi-surface variants (added 2026-05-13 — multi-foreground-surface activation;
   // otto-vscode added 2026-05-21 per B-0689)
   "otto-cli", "otto-desktop", "otto-vscode",
+  // otto-windows — first Windows surface for the git-native bus (#6219 / B-0954)
+  "otto-windows",
   "alexa-cli", "alexa-kiro",
   "riven-cli", "riven-cursor",
   "lior-antigravity", "lior-gemini",


### PR DESCRIPTION
**B-0954 Phase 1** — the git-native cross-machine agent-bus, the folder + ZetaId-keyed tooling that works *today* (pre-B-0887), per the #6219 spec. You said "start the agent-bus implementation, phase 1."

Envelopes are ZetaId-named files in `docs/agent-bus/<persona>/<YYYY>/<MM>/<DD>/<hex>.json` — a **G-Set CRDT**: disjoint files never collide, so concurrent agents on different machines write different files → conflict-free → **cross-machine / Windows-safe** (git is the transport).

- **types.ts** — `AgentBusEnvelope` (reuses `tools/bus` `BusMessage` topic+payload + `AgentId`); `envelopePath` (UTC partition); `mintBusZetaIdHex` (canonical ZetaId, `Category.Bus`; `DEFAULT_ENV` unique / `DETERMINISTIC_ENV` reproducible); `serializeEnvelope` (stable).
- **publish.ts** — `writeEnvelope` (**pure**; idempotent on identical content; surfaces a same-id/different-content **collision** as feedback, never silent-overwrite — the spec's collision caveat) + `makeEnvelope` + CLI (write then `git add/commit/push` direct-to-main, **no PR** — the B-0858 mechanism; guarded by `import.meta.main` so tests never touch git).
- **subscribe.ts** — `readEnvelopesSince` (**pure**; ISO-ts cursor; sorted `(ts, hex)`; skips malformed best-effort) + `nextCursor` + CLI (`git pull --ff-only` then read).
- **agent-bus.test.ts** — **14 tests**: mint (Bus category / 32-hex / unique / reproducible), path layout, write (created / idempotent / collision / disjoint-G-Set), read (all / since-cursor / ordering / skip-malformed), nextCursor.

Reuses `tools/bus` + the canonical ZetaId (no new id scheme or action language). Pure/CLI split keeps git out of tests. **14/14 green; 0 agent-bus type errors.** Windows parity is by construction (git + file IO, no `/tmp`); the cross-machine round-trip verification is a follow-up sub-target. Phase 2 (path-scoped protection) waits on B-0887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
