### PR TITLE
feat(agentic-org): gate incident runbooks with human approval

### DIFF
--- a/agentic-organization/apps/agent-cli/src/agent-cli.ts
+++ b/agentic-organization/apps/agent-cli/src/agent-cli.ts
@@ -1604,6 +1604,10 @@ function parsePromptFlowGate(value: unknown): PromptFlowPhaseGate {
     kind: gate.kind as PromptFlowGateKind,
     requiredEvidenceRefs: parseStringArray(gate.requiredEvidenceRefs, "gate.requiredEvidenceRefs"),
     ...(gate.reviewerHatIds === undefined ? {} : { reviewerHatIds: parseStringArray(gate.reviewerHatIds, "gate.reviewerHatIds") }),
+    ...(gate.approverHatIds === undefined ? {} : { approverHatIds: parseStringArray(gate.approverHatIds, "gate.approverHatIds") }),
+    ...(gate.requiredHumanApprovalCount === undefined
+      ? {}
+      : { requiredHumanApprovalCount: parsePositiveInteger(gate.requiredHumanApprovalCount, "gate.requiredHumanApprovalCount") }),
   };
 }
 
@@ -1615,7 +1619,7 @@ function parseOptionalPositiveInteger(value: unknown, property: "timeoutSeconds"
   return { [property]: parsed } as Partial<Pick<PromptFlowTask, "timeoutSeconds" | "retryLimit">>;
 }
 
-function parsePositiveInteger(value: unknown, property: "timeoutSeconds"): number {
+function parsePositiveInteger(value: unknown, property: "timeoutSeconds" | "gate.requiredHumanApprovalCount"): number {
   if (!Number.isInteger(value) || (value as number) <= 0) {
     throw new Error(`prompt-flow task ${property} must be a positive integer when present`);
   }

--- a/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
+++ b/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
@@ -1082,7 +1082,12 @@ test("createAgentCliPromptFlowTasksFromEnv reads current tasks from JSON", () =>
           phaseId: "execute",
           runState: PromptFlowRunState.RunningPhase,
           requiredEvidenceRefs: ["tests.green"],
-          gate: { kind: PromptFlowGateKind.Evidence, requiredEvidenceRefs: ["tests.green"] },
+          gate: {
+            kind: PromptFlowGateKind.HumanApproval,
+            requiredEvidenceRefs: ["tests.green"],
+            approverHatIds: ["operations_director"],
+            requiredHumanApprovalCount: 1,
+          },
           reviewerHatIds: ["code_reviewer"],
           timeoutSeconds: 900,
           retryLimit: 2,
@@ -1100,7 +1105,9 @@ test("createAgentCliPromptFlowTasksFromEnv reads current tasks from JSON", () =>
   equal(tasks[0]?.phaseId, "execute");
   equal(tasks[0]?.runState, PromptFlowRunState.RunningPhase);
   deepEqual(tasks[0]?.requiredEvidenceRefs, ["tests.green"]);
-  equal(tasks[0]?.gate?.kind, PromptFlowGateKind.Evidence);
+  equal(tasks[0]?.gate?.kind, PromptFlowGateKind.HumanApproval);
+  deepEqual(tasks[0]?.gate?.approverHatIds, ["operations_director"]);
+  equal(tasks[0]?.gate?.requiredHumanApprovalCount, 1);
   deepEqual(tasks[0]?.reviewerHatIds, ["code_reviewer"]);
   equal(tasks[0]?.timeoutSeconds, 900);
   equal(tasks[0]?.retryLimit, 2);

--- a/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
+++ b/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
@@ -2024,3 +2024,33 @@ expected cadence lanes with zero `worker run failed` or structured error matches
 ### Verification
 
 `npm run typecheck` passed. `npm test` passed: **1199 tests, 1192 pass, 0 fail, 7 skipped**.
+
+---
+
+## Update 2026-05-31 — Phase 2.8 incident runbook prompt flows gain human approval gates
+
+Production incident runbooks are now represented as typed prompt-flow definitions instead of
+free-form operational text. The first shipped registry entry is the provider-outage incident
+runbook for the `incident_commander` hat. It walks the agent through impact assessment, an
+operator approval packet, and guarded recovery/closure, while keeping the production freeze or
+failover step behind an explicit human-approval gate.
+
+### What shipped
+
+- `PromptFlowPhaseGate` now carries human approver hats and a required approval count for
+  `human_approval` gates.
+- `advancePromptFlowRun` now accepts structured human approvals in addition to evidence refs.
+  A human-approval gate blocks when approval is missing, when the approver hat is not allowed,
+  or when the approval evidence ref is not content-addressed.
+- `lintPromptFlowDefinition` rejects human-approval gates that do not name approver hats or
+  declare an invalid approval count.
+- `buildProductionIncidentRunbookPromptFlowDefinitions` returns the first production runbook
+  registry entry: `incident.provider-outage`.
+- The runbook uses the existing prompt-flow compiler/readout path, so incident work appears in
+  observe as a hat-scoped prompt-flow task rather than a separate control surface.
+- The agent CLI parser preserves `approverHatIds` and `requiredHumanApprovalCount` from durable
+  prompt-flow JSON, so runbook gates survive JSON ingestion.
+
+### Verification
+
+`npm run typecheck` passed. `npm test` passed: **1201 tests, 1194 pass, 0 fail, 7 skipped**.

--- a/agentic-organization/packages/application/src/incident-runbook-prompt-flows.ts
+++ b/agentic-organization/packages/application/src/incident-runbook-prompt-flows.ts
@@ -1,0 +1,146 @@
+import { ToolBundle } from "../../domain/src/index.ts";
+import { createContentAddressedEvidenceRef } from "./content-addressed-evidence.ts";
+import { ActionClass } from "./hat-guardrails.ts";
+import {
+  PromptFlowGateKind,
+  type PromptFlowDefinition,
+  type PromptFlowPhaseDefinition,
+} from "./prompt-flow.ts";
+import { RunScope } from "./observe.ts";
+
+export const IncidentRunbookPromptFlowId = {
+  ProviderOutage: "incident.provider-outage",
+} as const;
+export type IncidentRunbookPromptFlowId = (typeof IncidentRunbookPromptFlowId)[keyof typeof IncidentRunbookPromptFlowId];
+
+export type BuildProductionIncidentRunbookPromptFlowDefinitionsInput = {
+  ownerDepartmentId?: string | undefined;
+  incidentCommanderHatId?: string | undefined;
+  approverHatIds?: readonly string[] | undefined;
+  reviewerHatIds?: readonly string[] | undefined;
+};
+
+export function buildProductionIncidentRunbookPromptFlowDefinitions(
+  input: BuildProductionIncidentRunbookPromptFlowDefinitionsInput = {},
+): readonly PromptFlowDefinition[] {
+  const ownerDepartmentId = input.ownerDepartmentId ?? "operations_and_infrastructure";
+  const incidentCommanderHatId = input.incidentCommanderHatId ?? "incident_commander";
+  const approverHatIds = input.approverHatIds ?? ["operations_director"];
+  const reviewerHatIds = input.reviewerHatIds ?? ["runbook_maintainer", "operations_director"];
+
+  return [
+    {
+      promptFlowId: IncidentRunbookPromptFlowId.ProviderOutage,
+      version: "1.0.0",
+      name: "Provider outage incident runbook",
+      ownerDepartmentId,
+      allowedHatIds: [incidentCommanderHatId],
+      requiredScope: RunScope.WorkItem,
+      reviewerHatIds,
+      rollbackPolicy: {
+        kind: "compensating_action",
+        description: "clear temporary freezes, close incident work, and attach post-incident evidence",
+      },
+      phases: [
+        providerOutageAssessmentPhase(),
+        providerOutageHumanApprovalPhase(approverHatIds),
+        providerOutageRecoveryPhase(reviewerHatIds),
+      ],
+    },
+  ];
+}
+
+function providerOutageAssessmentPhase(): PromptFlowPhaseDefinition {
+  const evidenceRef = runbookEvidenceRef("provider-outage", "impact-assessment");
+  return {
+    phaseId: "assess-impact",
+    label: "Assess provider outage impact",
+    actionClass: ActionClass.Prioritize,
+    permittedUniversalActions: ["load_context", "query_metrics", "send_status_update"],
+    directions: [
+      "Load active control-plane flags, affected tenants, queue pressure, and provider error telemetry.",
+      "Classify blast radius and identify which non-control actions would keep failing.",
+      "Prepare the operator approval packet before any freeze or failover action.",
+    ],
+    requiredToolBundles: [ToolBundle.Observability, ToolBundle.Status, ToolBundle.ArtifactAndEvidence],
+    toolInjections: [
+      { tool: "lgtm.query_provider_errors", args: { providerId: "provider-from-incident" } },
+      { tool: "org.list_control_plane_flags", args: { scope: "incident-work-item" } },
+    ],
+    contextArtifactRefs: ["incident:work-item", "runbook:provider-outage", "control-plane:active-flags"],
+    requiredEvidenceRefs: [evidenceRef],
+    gate: { kind: PromptFlowGateKind.Evidence, requiredEvidenceRefs: [evidenceRef] },
+    timeoutSeconds: 600,
+    retryLimit: 1,
+    metrics: [
+      { id: "incident.provider_error_rate", label: "provider error rate", value: 0, unit: "errors/min" },
+      { id: "incident.affected_tenants", label: "affected tenants", value: 0, unit: "count" },
+    ],
+  };
+}
+
+function providerOutageHumanApprovalPhase(approverHatIds: readonly string[]): PromptFlowPhaseDefinition {
+  const evidenceRef = runbookEvidenceRef("provider-outage", "operator-approval-packet");
+  return {
+    phaseId: "operator-approval",
+    label: "Request human approval for production control action",
+    actionClass: ActionClass.Prioritize,
+    permittedUniversalActions: ["request_human_approval", "set_control_plane_flag", "reobserve"],
+    directions: [
+      "Present blast radius, proposed freeze or failover, expected customer impact, rollback path, and approval deadline.",
+      "Do not execute provider freeze, tenant freeze, budget freeze, or failover until a human approval artifact is attached.",
+      "After approval, set only the narrowest control-plane flag needed for the incident scope.",
+    ],
+    requiredToolBundles: [ToolBundle.HumanOverride, ToolBundle.AlwaysOnRuntime, ToolBundle.ArtifactAndEvidence],
+    toolInjections: [
+      { tool: "ops.request_human_approval", args: { approverHatIds } },
+      { tool: "org.set_control_plane_flag", args: { flag: "provider_freeze", scope: "provider-from-incident" } },
+    ],
+    contextArtifactRefs: ["incident:impact-assessment", "control-plane:freeze-policy"],
+    requiredEvidenceRefs: [evidenceRef],
+    gate: {
+      kind: PromptFlowGateKind.HumanApproval,
+      requiredEvidenceRefs: [evidenceRef],
+      approverHatIds,
+      requiredHumanApprovalCount: 1,
+    },
+    timeoutSeconds: 900,
+    retryLimit: 0,
+    metrics: [
+      { id: "incident.operator_approval_age", label: "operator approval age", value: 0, unit: "minutes" },
+    ],
+  };
+}
+
+function providerOutageRecoveryPhase(reviewerHatIds: readonly string[]): PromptFlowPhaseDefinition {
+  const evidenceRef = runbookEvidenceRef("provider-outage", "recovery-verified");
+  return {
+    phaseId: "recover-and-close",
+    label: "Recover service and close incident",
+    actionClass: ActionClass.Prioritize,
+    permittedUniversalActions: ["execute_recovery", "submit_evidence", "request_review"],
+    directions: [
+      "Coordinate the approved recovery or failover action through the control-plane guarded dispatch path.",
+      "Verify provider error rate, queue pressure, and stale claim rate return below incident thresholds.",
+      "Attach recovery evidence and route the incident for post-incident runbook review.",
+    ],
+    requiredToolBundles: [ToolBundle.AlwaysOnRuntime, ToolBundle.Observability, ToolBundle.ArtifactAndEvidence],
+    toolInjections: [
+      { tool: "ops.coordinate_approved_recovery", args: { incidentScope: "incident-work-item" } },
+      { tool: "lgtm.query_incident_recovery", args: { incidentScope: "incident-work-item" } },
+    ],
+    contextArtifactRefs: ["incident:operator-approval", "incident:recovery-plan"],
+    requiredEvidenceRefs: [evidenceRef],
+    gate: { kind: PromptFlowGateKind.Reviewer, requiredEvidenceRefs: [evidenceRef], reviewerHatIds },
+    timeoutSeconds: 1200,
+    retryLimit: 1,
+    metrics: [
+      { id: "incident.recovery_error_rate", label: "recovery error rate", value: 0, unit: "errors/min" },
+      { id: "incident.queue_pressure", label: "queue pressure", value: 0, unit: "index" },
+    ],
+  };
+}
+
+function runbookEvidenceRef(runbook: string, artifact: string): string {
+  return createContentAddressedEvidenceRef("incident-runbook-evidence-contract", { runbook, artifact });
+}

--- a/agentic-organization/packages/application/src/index.ts
+++ b/agentic-organization/packages/application/src/index.ts
@@ -386,14 +386,21 @@ export {
   compilePromptFlowTasks,
   lintPromptFlowDefinition,
   type CompilePromptFlowTasksInput,
+  type PromptFlowAdvanceEvidence,
   type PromptFlowAdvanceResult,
   type PromptFlowDefinition,
+  type PromptFlowHumanApproval,
   type PromptFlowLintDiagnostic,
   type PromptFlowPhaseDefinition,
   type PromptFlowPhaseGate,
   type PromptFlowRollbackPolicy,
   type PromptFlowRun,
 } from "./prompt-flow.ts";
+export {
+  IncidentRunbookPromptFlowId,
+  buildProductionIncidentRunbookPromptFlowDefinitions,
+  type BuildProductionIncidentRunbookPromptFlowDefinitionsInput,
+} from "./incident-runbook-prompt-flows.ts";
 export {
   DEPARTMENTS,
   OrgGraphValidation,

--- a/agentic-organization/packages/application/src/prompt-flow.ts
+++ b/agentic-organization/packages/application/src/prompt-flow.ts
@@ -31,7 +31,24 @@ export type PromptFlowPhaseGate = {
   kind: PromptFlowGateKind;
   requiredEvidenceRefs: readonly string[];
   reviewerHatIds?: readonly string[] | undefined;
+  approverHatIds?: readonly string[] | undefined;
+  requiredHumanApprovalCount?: number | undefined;
 };
+
+export type PromptFlowHumanApproval = {
+  approverId: string;
+  approverHatId: string;
+  approved: boolean;
+  approvedAt: string;
+  evidenceRef: string;
+};
+
+export type PromptFlowAdvanceEvidence =
+  | readonly string[]
+  | {
+      evidenceRefs?: readonly string[] | undefined;
+      humanApprovals?: readonly PromptFlowHumanApproval[] | undefined;
+    };
 
 export type PromptFlowRollbackPolicy = {
   kind: "compensating_action" | "revert_artifact" | "cancel_only";
@@ -89,6 +106,8 @@ export type PromptFlowLintDiagnostic = {
     | "missing_directions"
     | "missing_required_evidence"
     | "missing_gate"
+    | "missing_human_approvers"
+    | "invalid_human_approval_count"
     | "invalid_timeout"
     | "missing_rollback"
     | "evidence_gate_mismatch";
@@ -105,9 +124,10 @@ export type PromptFlowAdvanceResult =
   | { outcome: "advanced"; run: PromptFlowRun }
   | {
       outcome: "blocked";
-      reason: "missing_evidence" | "invalid_evidence";
+      reason: "missing_evidence" | "missing_human_approval" | "invalid_evidence";
       missingEvidenceRefs: readonly string[];
       invalidEvidenceRefs: readonly string[];
+      missingHumanApprovalCount?: number | undefined;
     }
   | { outcome: "rejected"; reason: "unknown_phase" | "terminal_state" | "definition_mismatch"; message: string };
 
@@ -168,15 +188,15 @@ export function compilePromptFlowTasks(input: CompilePromptFlowTasksInput): read
 export function canAdvancePromptFlowRun(
   definition: PromptFlowDefinition,
   run: PromptFlowRun,
-  evidenceRefs: readonly string[] = [],
+  evidence: PromptFlowAdvanceEvidence = [],
 ): PromptFlowAdvanceResult {
-  return advancePromptFlowRun(definition, run, evidenceRefs);
+  return advancePromptFlowRun(definition, run, evidence);
 }
 
 export function advancePromptFlowRun(
   definition: PromptFlowDefinition,
   run: PromptFlowRun,
-  evidenceRefs: readonly string[] = [],
+  evidence: PromptFlowAdvanceEvidence = [],
 ): PromptFlowAdvanceResult {
   if (definition.promptFlowId !== run.promptFlowId || definition.version !== run.definitionVersion) {
     return {
@@ -206,7 +226,8 @@ export function advancePromptFlowRun(
   }
 
   const phase = definition.phases[phaseIndex]!;
-  const evidenceCheck = checkGateEvidence(phase, evidenceRefs);
+  const normalizedEvidence = normalizePromptFlowAdvanceEvidence(evidence);
+  const evidenceCheck = checkGateEvidence(phase, normalizedEvidence);
   if (evidenceCheck.outcome === "blocked") {
     return evidenceCheck;
   }
@@ -268,6 +289,25 @@ function lintPromptFlowPhase(phase: PromptFlowPhaseDefinition): readonly PromptF
   if (phase.gate.requiredEvidenceRefs.length === 0) {
     diagnostics.push({ code: "missing_gate", message: "prompt flow phase gate must declare evidence requirements", phaseId });
   }
+  if (phase.gate.kind === PromptFlowGateKind.HumanApproval) {
+    if (phase.gate.approverHatIds === undefined || phase.gate.approverHatIds.length === 0) {
+      diagnostics.push({
+        code: "missing_human_approvers",
+        message: "human-approval gate must name at least one approver hat",
+        phaseId,
+      });
+    }
+    if (
+      phase.gate.requiredHumanApprovalCount !== undefined &&
+      (!Number.isInteger(phase.gate.requiredHumanApprovalCount) || phase.gate.requiredHumanApprovalCount <= 0)
+    ) {
+      diagnostics.push({
+        code: "invalid_human_approval_count",
+        message: "human-approval gate approval count must be a positive integer",
+        phaseId,
+      });
+    }
+  }
   if (!sameStringSet(phase.requiredEvidenceRefs, phase.gate.requiredEvidenceRefs)) {
     diagnostics.push({
       code: "evidence_gate_mismatch",
@@ -283,8 +323,9 @@ function lintPromptFlowPhase(phase: PromptFlowPhaseDefinition): readonly PromptF
 
 function checkGateEvidence(
   phase: PromptFlowPhaseDefinition,
-  evidenceRefs: readonly string[],
+  evidence: NormalizedPromptFlowAdvanceEvidence,
 ): GateEvidenceCheck {
+  const { evidenceRefs, humanApprovals } = evidence;
   const invalidEvidenceRefs = evidenceRefs.filter((ref) => !isContentAddressedEvidenceRef(ref));
   if (invalidEvidenceRefs.length > 0) {
     return {
@@ -304,7 +345,57 @@ function checkGateEvidence(
       invalidEvidenceRefs: [],
     };
   }
+  if (phase.gate.kind === PromptFlowGateKind.HumanApproval) {
+    const invalidApprovalEvidenceRefs = humanApprovals
+      .map((approval) => approval.evidenceRef)
+      .filter((ref) => !isContentAddressedEvidenceRef(ref));
+    if (invalidApprovalEvidenceRefs.length > 0) {
+      return {
+        outcome: "blocked",
+        reason: "invalid_evidence",
+        missingEvidenceRefs: [],
+        invalidEvidenceRefs: invalidApprovalEvidenceRefs,
+      };
+    }
+    const approverHatIds = new Set(phase.gate.approverHatIds ?? []);
+    const approvedCount = humanApprovals.filter((approval) =>
+      approval.approved &&
+      isContentAddressedEvidenceRef(approval.evidenceRef) &&
+      (approverHatIds.size === 0 || approverHatIds.has(approval.approverHatId))
+    ).length;
+    const requiredHumanApprovalCount = phase.gate.requiredHumanApprovalCount ?? 1;
+    if (approvedCount < requiredHumanApprovalCount) {
+      return {
+        outcome: "blocked",
+        reason: "missing_human_approval",
+        missingEvidenceRefs: [],
+        invalidEvidenceRefs: [],
+        missingHumanApprovalCount: requiredHumanApprovalCount - approvedCount,
+      };
+    }
+  }
   return { outcome: "satisfied" };
+}
+
+type NormalizedPromptFlowAdvanceEvidence = {
+  evidenceRefs: readonly string[];
+  humanApprovals: readonly PromptFlowHumanApproval[];
+};
+
+function normalizePromptFlowAdvanceEvidence(
+  evidence: PromptFlowAdvanceEvidence,
+): NormalizedPromptFlowAdvanceEvidence {
+  if (isEvidenceRefList(evidence)) {
+    return { evidenceRefs: evidence, humanApprovals: [] };
+  }
+  return {
+    evidenceRefs: evidence.evidenceRefs ?? [],
+    humanApprovals: evidence.humanApprovals ?? [],
+  };
+}
+
+function isEvidenceRefList(evidence: PromptFlowAdvanceEvidence): evidence is readonly string[] {
+  return Array.isArray(evidence);
 }
 
 function sameStringSet(left: readonly string[], right: readonly string[]): boolean {

--- a/agentic-organization/packages/application/test/prompt-flow-compiler.test.ts
+++ b/agentic-organization/packages/application/test/prompt-flow-compiler.test.ts
@@ -8,6 +8,7 @@ import {
   PromptFlowRunState,
   RunScope,
   advancePromptFlowRun,
+  buildProductionIncidentRunbookPromptFlowDefinitions,
   compilePromptFlowTasks,
   createContentAddressedEvidenceRef,
   lintPromptFlowDefinition,
@@ -168,6 +169,131 @@ test("advancePromptFlowRun blocks awaiting gate until content-addressed evidence
   equal(advanced.outcome, "advanced");
   if (advanced.outcome === "advanced") {
     equal(advanced.run.state, PromptFlowRunState.Completed);
+  }
+});
+
+test("advancePromptFlowRun requires explicit human approval for human-approval gates", () => {
+  const approvalEvidence = createContentAddressedEvidenceRef("human-approval", {
+    run: "pfr-incident-1",
+    approver: "human-ops-1",
+  });
+  const runbookEvidence = createContentAddressedEvidenceRef("incident-runbook-phase", {
+    run: "pfr-incident-1",
+    phase: "operator-approval",
+  });
+  const flow = definition({
+    promptFlowId: "flow-incident-runbook",
+    allowedHatIds: ["incident_commander"],
+    reviewerHatIds: ["director_engineering"],
+    phases: [
+      {
+        ...definition().phases[0]!,
+        phaseId: "operator-approval",
+        requiredEvidenceRefs: [runbookEvidence],
+        gate: {
+          kind: PromptFlowGateKind.HumanApproval,
+          requiredEvidenceRefs: [runbookEvidence],
+          approverHatIds: ["director_engineering"],
+          requiredHumanApprovalCount: 1,
+        },
+      },
+    ],
+  });
+  const run = {
+    runId: "pfr-incident-1",
+    promptFlowId: "flow-incident-runbook",
+    definitionVersion: "1.0.0",
+    workItemId: "incident-1",
+    scope: RunScope.WorkItem,
+    currentPhaseId: "operator-approval",
+    state: PromptFlowRunState.AwaitingGate,
+    priority: 100,
+  };
+
+  const missingApproval = advancePromptFlowRun(flow, run, { evidenceRefs: [runbookEvidence] });
+  equal(missingApproval.outcome, "blocked");
+  if (missingApproval.outcome === "blocked") {
+    equal(missingApproval.reason, "missing_human_approval");
+    equal(missingApproval.missingHumanApprovalCount, 1);
+  }
+
+  const forgedApproval = advancePromptFlowRun(flow, run, {
+    evidenceRefs: [runbookEvidence],
+    humanApprovals: [
+      {
+        approverId: "human-ops-1",
+        approverHatId: "director_engineering",
+        approved: true,
+        approvedAt: "2026-05-31T00:00:00.000Z",
+        evidenceRef: "plain-approval-note",
+      },
+    ],
+  });
+  equal(forgedApproval.outcome, "blocked");
+  if (forgedApproval.outcome === "blocked") {
+    equal(forgedApproval.reason, "invalid_evidence");
+    deepEqual(forgedApproval.invalidEvidenceRefs, ["plain-approval-note"]);
+  }
+
+  const wrongHatApproval = advancePromptFlowRun(flow, run, {
+    evidenceRefs: [runbookEvidence],
+    humanApprovals: [
+      {
+        approverId: "human-ops-1",
+        approverHatId: "backend_implementer",
+        approved: true,
+        approvedAt: "2026-05-31T00:00:00.000Z",
+        evidenceRef: approvalEvidence,
+      },
+    ],
+  });
+  equal(wrongHatApproval.outcome, "blocked");
+  if (wrongHatApproval.outcome === "blocked") {
+    equal(wrongHatApproval.reason, "missing_human_approval");
+  }
+
+  const approved = advancePromptFlowRun(flow, run, {
+    evidenceRefs: [runbookEvidence],
+    humanApprovals: [
+      {
+        approverId: "human-ops-1",
+        approverHatId: "director_engineering",
+        approved: true,
+        approvedAt: "2026-05-31T00:00:00.000Z",
+        evidenceRef: approvalEvidence,
+      },
+    ],
+  });
+  equal(approved.outcome, "advanced");
+  if (approved.outcome === "advanced") {
+    equal(approved.run.state, PromptFlowRunState.Completed);
+  }
+});
+
+test("production incident runbook prompt flows are lint-clean and expose human approval gates", () => {
+  const runbooks = buildProductionIncidentRunbookPromptFlowDefinitions();
+  const incidentCommander = buildHatDefinitions().find((hat) => hat.id === "incident_commander")!;
+  ok(runbooks.length >= 1);
+  for (const runbook of runbooks) {
+    deepEqual(lintPromptFlowDefinition(runbook), []);
+    ok(runbook.allowedHatIds.includes("incident_commander"));
+    ok(runbook.phases.some((phase) => phase.gate.kind === PromptFlowGateKind.HumanApproval));
+    const tasks = compilePromptFlowTasks({
+      definitions: [runbook],
+      runs: runbook.phases.map((phase, index) => ({
+        runId: `pfr-incident-${index}`,
+        promptFlowId: runbook.promptFlowId,
+        definitionVersion: runbook.version,
+        workItemId: "incident-1",
+        scope: runbook.requiredScope,
+        currentPhaseId: phase.phaseId,
+        state: PromptFlowRunState.RunningPhase,
+        priority: 100 - index,
+      })),
+    });
+    const readout = promptFlowReadoutForHat(incidentCommander, tasks);
+    equal(readout.tasks.length, runbook.phases.length);
+    deepEqual(readout.vetoedTasks, []);
   }
 });
 


### PR DESCRIPTION
## Summary
- adds typed human-approval evidence to prompt-flow advancement
- preserves human-approval gate metadata through agent CLI prompt-flow JSON parsing
- seeds the first production incident runbook prompt-flow registry entry for provider outages
- updates the north-star checkpoint with the Phase 2.8 runbook slice

## Verification
- npm run typecheck
- npm test (1201 tests, 1194 pass, 0 fail, 7 skipped)

Note: PR #6279 was already merged, so this PR is opened from a fresh branch based on current origin/main and contains only the new incident-runbook slice.