### PR TITLE
feat(install.ps1): enable Windows long paths (git core.longpaths + OS LongPathsEnabled)

### DIFF
--- a/tools/setup/install.ps1
+++ b/tools/setup/install.ps1
@@ -175,6 +175,34 @@ foreach ($raw in Get-Content $manifest) {
   }
 }
 
+# 2b. Windows long-path enablement (B-0947 / MAX_PATH 260). Zeta's persona-archive filenames exceed
+#     260 chars; without long-path support git refuses to create them ("Filename too long") + some
+#     tools choke. Two layers (WebSearch 2026-05-31:
+#     https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation):
+#       Layer 1 (NO admin, load-bearing): git core.longpaths -- git prepends the Windows extended-length
+#         prefix + bypasses MAX_PATH ITSELF (no registry, no reboot). Fixes the actual problem (git
+#         creating Zeta's long files). Set --global for this user; always-safe, best-effort.
+#       Layer 2 (admin-only, broader bonus): the OS-wide LongPathsEnabled registry DWORD (Win10 1607+;
+#         helps all longPathAware apps; takes effect after a RESTART). Admin-gated + GRACEFUL like the
+#         choco step -- set only when elevated, else print how to enable it. NEVER force elevation.
+if (Have git) {
+  $lpCode = Invoke-ToolSoft { git config --global core.longpaths true }
+  if ($lpCode -eq 0) { Write-Host "ok git core.longpaths=true (user-global; git bypasses MAX_PATH via the Windows extended-length path mechanism -- no admin/reboot)" }
+  else { Write-Host "warn: 'git config --global core.longpaths true' failed (exit $lpCode); continuing (best-effort)" }
+} else {
+  Write-Host "warn: git not on PATH yet; skipping git core.longpaths (re-run after git installs)"
+}
+if (Test-IsAdmin) {
+  try {
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1 -Type DWord
+    Write-Host "ok OS LongPathsEnabled=1 (HKLM FileSystem) -- effective for longPathAware apps after a RESTART"
+  } catch {
+    Write-Host "warn: could not set OS LongPathsEnabled ($($_.Exception.Message)); git core.longpaths above already fixes git -- continuing"
+  }
+} else {
+  Write-Host "OS-wide LongPathsEnabled needs admin -- skipped (git core.longpaths above covers git). To enable OS-wide: run elevated, or set HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled=1 (DWORD) + restart."
+}
+
 # 3. mise (runtime manager) via scoop -- mirrors macos.sh step 4 (brew install mise).
 if (-not (Have mise)) { Invoke-Tool { scoop install mise } 'scoop install mise' }
 Write-Host "mise: $(Get-ToolVersion { mise --version })"


### PR DESCRIPTION
## What

`install.ps1` now enables Windows long paths, so any machine that runs the installer stops worrying about the 260-char MAX_PATH limit on Zeta's long persona-archive filenames (the B-0947 "Filename too long" class). Aaron-requested 2026-05-31.

## Two layers (matching install.ps1's existing conditional-on-admin pattern)

| Layer | Admin? | What | Effect |
|---|---|---|---|
| **1 — `git config --global core.longpaths true`** | **No** | Git prepends the Windows extended-length path prefix + bypasses MAX_PATH **itself** (no registry, no reboot) | **Fixes the actual problem** — git creating Zeta's long files. Always-set, best-effort (`Invoke-ToolSoft`, never bricks install). |
| **2 — `HKLM\…\FileSystem\LongPathsEnabled = 1`** | Yes | OS-wide DWORD (Win10 1607+; all longPathAware apps) | Broader bonus; **needs a restart**. Admin-gated + graceful (set only when `Test-IsAdmin`, else print how-to). Never forces elevation. |

Runs as a new step 2b (after the manifest step installs git, before mise). Mirrors the existing scoop `-RunAsAdmin` / choco-only-when-elevated / graceful-skip discipline.

## Scope (important — complementary to B-0947, not redundant)

This is the **dev-machine + post-install-git-ops** prong. It does **not** replace the B-0947 *CI* fix: in CI, `actions/checkout` runs *before* `install.ps1`, so the gate's windows legs still need `git config core.longpaths` pre-checkout (B-0947 option 1). Together they cover both surfaces — your machines (this PR) and CI (B-0947).

## Validation

- PowerShell AST parser: **0 parse errors**.
- The install shields' paths-filter matches `tools/setup/**`, so `docker-windows-install-ps1-test` **self-exercises** this — the container runs as admin, so both layers execute (git config + the registry DWORD).

Refs: [Maximum Path Length Limitation — Win32 (Microsoft Learn)](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
