### PR TITLE
feat(agentic-org): type CLI env-load failures

### DIFF
--- a/agentic-organization/apps/agent-cli/src/agent-cli-main.ts
+++ b/agentic-organization/apps/agent-cli/src/agent-cli-main.ts
@@ -51,12 +51,12 @@ import {
   type PgCockroachWorkerPool,
 } from "../../workers/src/adapters/pg-cockroach-worker-pool.ts";
 import {
-  createAgentCliHierarchyFromEnv,
   createAgentCliMetricAgentsFromEnv,
-  createAgentCliPromptFlowTasksFromEnv,
   createAgentCliSelectorFromEnv,
   parseAgentCliArgs,
   runAgentCliCycle,
+  tryCreateAgentCliHierarchyFromEnv,
+  tryCreateAgentCliPromptFlowTasksFromEnv,
   type AgentCliCycleEvidence,
   type ParsedAgentCliArgs,
 } from "./agent-cli.ts";
@@ -109,8 +109,12 @@ export async function runAgentCliMain(input: RunAgentCliMainInput): Promise<numb
 
   try {
     const cycleInput = createRunAgentCliCycleInput(input, runtime);
+    if (!cycleInput.ok) {
+      input.writeStderr(`agent CLI setup failed: ${cycleInput.message}\n`);
+      return 2;
+    }
     const result = await runAgentCliCycle({
-      ...cycleInput,
+      ...cycleInput.value,
     });
     const evidenceExitCode = await appendObserveActEvidenceIfPresent(input, runtime, result.evidence);
     if (evidenceExitCode !== undefined) return evidenceExitCode;
@@ -183,36 +187,45 @@ function createAgentCliProductionRuntime(input: {
 function createRunAgentCliCycleInput(
   input: RunAgentCliMainInput,
   runtime: AgentCliMainRuntime,
-): Parameters<typeof runAgentCliCycle>[0] {
+): { ok: true; value: Parameters<typeof runAgentCliCycle>[0] } | { ok: false; message: string } {
   const parsed = parseAgentCliArgs(input.argv);
   const authorizeSlot = runtime.authorizeSlot ?? (
     parsed.ok ? createAgentCliControlPlaneSlotAuthorizer(runtime, parsed.value, input.now) : undefined
   );
+  const promptFlowTasks = tryCreateAgentCliPromptFlowTasksFromEnv({
+    env: input.env,
+  });
+  if (!promptFlowTasks.ok) return { ok: false, message: promptFlowTasks.message };
+
+  const hierarchy = tryCreateAgentCliHierarchyFromEnv({
+    env: input.env,
+  });
+  if (!hierarchy.ok) return { ok: false, message: hierarchy.message };
+
   return {
-    argv: input.argv,
-    now: input.now,
-    writeStdout: input.writeStdout,
-    writeStderr: input.writeStderr,
-    metricAgents: createAgentCliMetricAgentsFromEnv({
-      env: input.env,
+    ok: true,
+    value: {
+      argv: input.argv,
       now: input.now,
-      ...createOptionalFetchImpl(input.fetchImpl),
-    }),
-    promptFlowTasks: createAgentCliPromptFlowTasksFromEnv({
-      env: input.env,
-    }),
-    hierarchy: createAgentCliHierarchyFromEnv({
-      env: input.env,
-    }),
-    selectSlot: createAgentCliSelectorFromEnv({
-      env: input.env,
-      ...createOptionalFetchImpl(input.fetchImpl),
-    }),
-    runCommand: runtime.runCommand,
-    dispatchTool: runtime.dispatchTool,
-    ...createOptionalAuthorizeSlot(authorizeSlot),
-    ...createOptionalLoadPromptFlowContext(runtime.loadPromptFlowContext),
-    ...createOptionalAvailableSecretScopes(runtime.availableSecretScopes),
+      writeStdout: input.writeStdout,
+      writeStderr: input.writeStderr,
+      metricAgents: createAgentCliMetricAgentsFromEnv({
+        env: input.env,
+        now: input.now,
+        ...createOptionalFetchImpl(input.fetchImpl),
+      }),
+      promptFlowTasks: promptFlowTasks.value,
+      hierarchy: hierarchy.value,
+      selectSlot: createAgentCliSelectorFromEnv({
+        env: input.env,
+        ...createOptionalFetchImpl(input.fetchImpl),
+      }),
+      runCommand: runtime.runCommand,
+      dispatchTool: runtime.dispatchTool,
+      ...createOptionalAuthorizeSlot(authorizeSlot),
+      ...createOptionalLoadPromptFlowContext(runtime.loadPromptFlowContext),
+      ...createOptionalAvailableSecretScopes(runtime.availableSecretScopes),
+    },
   };
 }
 

--- a/agentic-organization/apps/agent-cli/src/agent-cli.ts
+++ b/agentic-organization/apps/agent-cli/src/agent-cli.ts
@@ -116,6 +116,12 @@ export type CreateAgentCliHierarchyFromEnvInput = {
   env: Readonly<Record<string, string | undefined>>;
 };
 
+export type AgentCliEnvLoadErrorSource = "prompt_flow_tasks" | "hierarchy";
+
+export type AgentCliEnvLoadResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; source: AgentCliEnvLoadErrorSource; message: string };
+
 export const SelectorRejectionReason = {
   ModelError: "model_error",
   ParseFailure: "parse_failure",
@@ -308,7 +314,7 @@ export function createAgentCliPromptFlowTasksFromEnv(
   if (raw === undefined || raw.trim().length === 0) {
     return compiled;
   }
-  const parsed: unknown = JSON.parse(raw);
+  const parsed = parseJsonEnv(raw, "AGENTIC_ORG_PROMPT_FLOW_TASKS_JSON");
   if (!Array.isArray(parsed)) {
     throw new Error("AGENTIC_ORG_PROMPT_FLOW_TASKS_JSON must be a JSON array");
   }
@@ -318,6 +324,20 @@ export function createAgentCliPromptFlowTasksFromEnv(
   ];
 }
 
+export function tryCreateAgentCliPromptFlowTasksFromEnv(
+  input: CreateAgentCliPromptFlowTasksFromEnvInput,
+): AgentCliEnvLoadResult<readonly PromptFlowTask[]> {
+  try {
+    return { ok: true, value: createAgentCliPromptFlowTasksFromEnv(input) };
+  } catch (error) {
+    return {
+      ok: false,
+      source: "prompt_flow_tasks",
+      message: extractErrorMessage(error),
+    };
+  }
+}
+
 export function createAgentCliHierarchyFromEnv(
   input: CreateAgentCliHierarchyFromEnvInput,
 ): HierarchySnapshot {
@@ -325,7 +345,7 @@ export function createAgentCliHierarchyFromEnv(
   if (raw === undefined || raw.trim().length === 0) {
     return { projects: [], initiatives: [] };
   }
-  const parsed: unknown = JSON.parse(raw);
+  const parsed = parseJsonEnv(raw, "AGENTIC_ORG_HIERARCHY_JSON");
   if (typeof parsed !== "object" || parsed === null) {
     throw new Error("AGENTIC_ORG_HIERARCHY_JSON must be a JSON object");
   }
@@ -337,6 +357,20 @@ export function createAgentCliHierarchyFromEnv(
     workItems: parseOptionalHierarchyWorkItems(candidate.workItems),
     missions: parseOptionalHierarchyMissions(candidate.missions),
   };
+}
+
+export function tryCreateAgentCliHierarchyFromEnv(
+  input: CreateAgentCliHierarchyFromEnvInput,
+): AgentCliEnvLoadResult<HierarchySnapshot> {
+  try {
+    return { ok: true, value: createAgentCliHierarchyFromEnv(input) };
+  } catch (error) {
+    return {
+      ok: false,
+      source: "hierarchy",
+      message: extractErrorMessage(error),
+    };
+  }
 }
 
 export function createModelBackedMenuSelector(input: CreateModelBackedMenuSelectorInput): MenuSelector {
@@ -1110,7 +1144,7 @@ function compileAgentCliPromptFlowTasksFromEnv(
 }
 
 function parsePromptFlowDefinitionsJson(raw: string): readonly PromptFlowDefinition[] {
-  const parsed: unknown = JSON.parse(raw);
+  const parsed = parseJsonEnv(raw, "AGENTIC_ORG_PROMPT_FLOW_DEFINITIONS_JSON");
   if (!Array.isArray(parsed)) {
     throw new Error("AGENTIC_ORG_PROMPT_FLOW_DEFINITIONS_JSON must be a JSON array");
   }
@@ -1123,7 +1157,7 @@ function parsePromptFlowDefinitionsJson(raw: string): readonly PromptFlowDefinit
 }
 
 function parsePromptFlowRunsJson(raw: string): readonly PromptFlowRun[] {
-  const parsed: unknown = JSON.parse(raw);
+  const parsed = parseJsonEnv(raw, "AGENTIC_ORG_PROMPT_FLOW_RUNS_JSON");
   if (!Array.isArray(parsed)) {
     throw new Error("AGENTIC_ORG_PROMPT_FLOW_RUNS_JSON must be a JSON array");
   }
@@ -1729,4 +1763,16 @@ function parseOptionalMetricUnit(value: unknown): { unit?: string } {
     throw new Error("prompt-flow task metric unit must be a string");
   }
   return { unit: value };
+}
+
+function parseJsonEnv(raw: string, envName: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${envName} invalid JSON: ${extractErrorMessage(error)}`);
+  }
+}
+
+function extractErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
+++ b/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
@@ -23,6 +23,8 @@ import {
   parseAgentCliArgs,
   runAgentCliCycle,
   selectFirstTrueSlot,
+  tryCreateAgentCliHierarchyFromEnv,
+  tryCreateAgentCliPromptFlowTasksFromEnv,
 } from "../src/agent-cli.ts";
 import {
   CommandType,
@@ -888,6 +890,19 @@ test("createAgentCliHierarchyFromEnv reads hierarchy projects and initiatives fr
   equal(hierarchy.workItems?.[0]?.workItemId, "work-ready");
 });
 
+test("tryCreateAgentCliHierarchyFromEnv returns typed feedback for malformed hierarchy JSON", () => {
+  const result = tryCreateAgentCliHierarchyFromEnv({
+    env: {
+      AGENTIC_ORG_HIERARCHY_JSON: "{",
+    },
+  });
+
+  equal(result.ok, false);
+  if (result.ok) throw new Error("expected typed hierarchy parse failure");
+  equal(result.source, "hierarchy");
+  ok(result.message.includes("AGENTIC_ORG_HIERARCHY_JSON"));
+});
+
 test("runAgentCliCycle renders TPM operating readout for work batches and meetings", async () => {
   const stdout: string[] = [];
   const result = await runAgentCliCycle({
@@ -1112,6 +1127,19 @@ test("createAgentCliPromptFlowTasksFromEnv reads current tasks from JSON", () =>
   equal(tasks[0]?.timeoutSeconds, 900);
   equal(tasks[0]?.retryLimit, 2);
   equal(tasks[0]?.rollbackPolicy?.kind, "compensating_action");
+});
+
+test("tryCreateAgentCliPromptFlowTasksFromEnv returns typed feedback for malformed prompt-flow JSON", () => {
+  const result = tryCreateAgentCliPromptFlowTasksFromEnv({
+    env: {
+      AGENTIC_ORG_PROMPT_FLOW_TASKS_JSON: "{",
+    },
+  });
+
+  equal(result.ok, false);
+  if (result.ok) throw new Error("expected typed prompt-flow parse failure");
+  equal(result.source, "prompt_flow_tasks");
+  ok(result.message.includes("AGENTIC_ORG_PROMPT_FLOW_TASKS_JSON"));
 });
 
 test("createAgentCliPromptFlowTasksFromEnv compiles durable definitions and runs into current tasks", () => {

--- a/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
+++ b/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
@@ -2054,3 +2054,36 @@ failover step behind an explicit human-approval gate.
 ### Verification
 
 `npm run typecheck` passed. `npm test` passed: **1201 tests, 1194 pass, 0 fail, 7 skipped**.
+
+---
+
+## Update 2026-05-31 — Phase 2.2 CLI setup failures become typed env-load feedback
+
+The observe-act agent CLI now has typed env-load result surfaces for the production-visible
+prompt-flow and hierarchy JSON inputs. The previous production main path relied on catching parser
+throws after constructing the cycle input. The CLI still keeps the throwing helpers for existing
+internal call sites and tests, but the executable `runAgentCliMain` path consumes the typed
+`tryCreate...FromEnv` loaders and exits with setup feedback before invoking the observe-act cycle.
+
+### What shipped
+
+- `tryCreateAgentCliPromptFlowTasksFromEnv` returns `{ ok: false, source: "prompt_flow_tasks",
+  message }` for malformed prompt-flow task/definition/run JSON.
+- `tryCreateAgentCliHierarchyFromEnv` returns `{ ok: false, source: "hierarchy", message }` for
+  malformed hierarchy JSON.
+- JSON parse failures now name the exact env variable (`AGENTIC_ORG_PROMPT_FLOW_TASKS_JSON`,
+  `AGENTIC_ORG_PROMPT_FLOW_DEFINITIONS_JSON`, `AGENTIC_ORG_PROMPT_FLOW_RUNS_JSON`, or
+  `AGENTIC_ORG_HIERARCHY_JSON`) before the parser detail.
+- `runAgentCliMain` uses the typed loaders while preserving shutdown behavior and the existing
+  `agent CLI setup failed:` user-visible feedback line.
+
+### Proof boundary
+
+This is a CLI setup-contract hardening slice, not a new in-cluster state transition. No new KIND
+runner was added because the behavior is pure env parsing and cycle-input construction; the
+production KIND proofs that execute the CLI still exercise the same `runAgentCliMain` boundary.
+
+### Verification
+
+Focused tests passed with the full agentic-org test harness: **1203 tests, 1196 pass, 0 fail,
+7 skipped**. `npm run typecheck` passed.


### PR DESCRIPTION
## Summary
- add typed result-returning env loaders for observe-act prompt-flow and hierarchy JSON inputs
- route runAgentCliMain through those typed loaders before invoking the observe-act cycle
- keep the existing throwing helpers for internal call sites while naming malformed JSON env variables in setup feedback
- record the Phase 2.2 checkpoint and proof boundary in NORTH_STAR_ALIGNMENT_CHECKPOINT.md

## Verification
- npm run typecheck
- npm test
- git diff --check

## KIND
No new KIND runner was added for this slice because the behavior is pure CLI env parsing and cycle-input construction. Existing production KIND proofs still exercise the runAgentCliMain boundary; this PR hardens the setup contract feeding that boundary.

## Subagent Review
Attempted twice, but the platform returned: collab spawn failed: agent thread limit reached. Local review found no issues in the bounded patch.