### PR TITLE
chore(mise): bump node 22 → 24 (current Active LTS) — keep bun, node everywhere

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -65,8 +65,10 @@ shellcheck = "0.11.0"
 # Node runtime must be installed first. Pinned here so dev
 # laptops + CI runners + devcontainers all get the same Node
 # version through the install script — no separate
-# actions/setup-node step in gate.yml. 22 LTS as of 2026-04.
-node = "22"
+# actions/setup-node step in gate.yml. 24 = current Active LTS
+# as of 2026-06 (Node 22 -> Maintenance Oct 2025); supported by
+# all agent CLIs we target (Claude Code >=22.5, Gemini CLI 18+).
+node = "24"
 # markdownlint-cli2: markdown linter. Declarative pin per the
 # human maintainer's "update declaratively everywhere" directive
 # (2026-04-24). Moves the version off a hardcoded


### PR DESCRIPTION
## What

Bumps `node` from **22 → 24** in `.mise.toml`. Keeps `bun = "1.3"` unchanged.

Per Aaron 2026-06-01: keep bun, but make sure every OS + shield has node, on the **latest version we can support everywhere** — "don't want to be on old node."

## Why node was already "everywhere" — and why 22 was stale

`.mise.toml` is the **single node pin** (its own comment notes there's no separate `actions/setup-node` in gate.yml). So every dev laptop, CI runner, devcontainer, and **install shield** already gets node via `mise install`. The problem was the *version*: as of June 2026, **Node 22 is in Maintenance** (since Oct 2025); **Node 24 is the current Active LTS** (Oct 2025 → Oct 2026). Node 26 exists but is "Current" (released 2026-04-22, not LTS until 2026-10-28) — too bleeding-edge to standardize an install graph on.

## Latest-supported-everywhere check (the harnesses from the bun-hypothesis research)

| Harness | Node requirement | Node 24? |
|---|---|---|
| Claude Code | ≥22.5 (bun accepted as alt) | ✓ |
| Gemini CLI | 18+ | ✓ |
| Cursor | bundles Node | ✓ |
| OpenAI Codex CLI | Rust binary, no JS runtime | n/a (unaffected) |

## Blast radius / validation

One-line value bump; mise propagates node 24 to all surfaces. `.mise.toml` is in every install shield's paths-filter **and** gate's `build-and-test` runs `mise install`, so CI self-validates node 24 across macOS / Ubuntu (x64+arm) / NixOS / WSL / Windows + the npm-backed mise tools (markdownlint-cli2 etc.). TOML parse verified locally.

Refs: [Node.js previous releases](https://nodejs.org/en/about/previous-releases) · [endoflife.date/nodejs](https://endoflife.date/nodejs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
