### PR TITLE
Harden agent CLI ZetaId feedback

### DIFF
--- a/agentic-organization/apps/agent-cli/src/agent-cli.ts
+++ b/agentic-organization/apps/agent-cli/src/agent-cli.ts
@@ -77,6 +77,12 @@ export type ParseAgentCliArgsResult =
   | { ok: true; value: ParsedAgentCliArgs }
   | { ok: false; message: string };
 
+type AgentCliZetaIdDecimal = ReturnType<typeof asZetaIdDecimal>;
+
+type ParseAgentCliZetaIdResult =
+  | { ok: true; value: AgentCliZetaIdDecimal }
+  | { ok: false; message: string };
+
 export type AgentCliScreen = {
   scope: RunScope;
   phase: RunLifecyclePhase;
@@ -448,8 +454,20 @@ export async function runAgentCliCycle(input: AgentCliCycleInput): Promise<Agent
     return { exitCode: 2 };
   }
 
+  const runId = parseAgentCliZetaId(parsed.value.runId, "--run-id");
+  if (!runId.ok) {
+    input.writeStderr?.(`${runId.message}\n`);
+    return { exitCode: 2 };
+  }
+
+  const hatAssignmentId = parseAgentCliZetaId(parsed.value.hatAssignmentId, "--hat-assignment");
+  if (!hatAssignmentId.ok) {
+    input.writeStderr?.(`${hatAssignmentId.message}\n`);
+    return { exitCode: 2 };
+  }
+
   const snapshot: AgentObserveSnapshot = {
-    runId: asZetaIdDecimal(parsed.value.runId),
+    runId: runId.value,
     scope: parsed.value.scope,
     phase: parsed.value.phase,
     trace: {
@@ -459,7 +477,7 @@ export async function runAgentCliCycle(input: AgentCliCycleInput): Promise<Agent
     },
     hasGateApproval: parsed.value.gateApproved,
     hasEvidence: parsed.value.evidence,
-    hatAssignmentId: asZetaIdDecimal(parsed.value.hatAssignmentId),
+    hatAssignmentId: hatAssignmentId.value,
     hat,
     agentId: parsed.value.agentId,
     organizationId: parsed.value.organizationId,
@@ -1763,6 +1781,14 @@ function parseOptionalMetricUnit(value: unknown): { unit?: string } {
     throw new Error("prompt-flow task metric unit must be a string");
   }
   return { unit: value };
+}
+
+function parseAgentCliZetaId(value: string, flagName: string): ParseAgentCliZetaIdResult {
+  try {
+    return { ok: true, value: asZetaIdDecimal(value) };
+  } catch {
+    return { ok: false, message: `${flagName} must be a base-10 ZetaId, got '${value}'` };
+  }
 }
 
 function parseJsonEnv(raw: string, envName: string): unknown {

--- a/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
+++ b/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
@@ -1059,6 +1059,34 @@ test("runAgentCliCycle rejects an unknown hat before rendering authority", async
   ok(stderr.join("\n").includes("unknown hat"));
 });
 
+test("runAgentCliCycle rejects malformed run ids before rendering authority", async () => {
+  const stderr: string[] = [];
+  const result = await runAgentCliCycle({
+    argv: ["observe", "--hat", "release_operator", "--scope", "work_item", "--run-id", "0x2a"],
+    now: () => "2026-05-31T12:00:00.000Z",
+    writeStderr: (text) => stderr.push(text),
+    runCommand: async () => ({ ok: true }),
+    dispatchTool: async () => ({ ok: true }),
+  });
+
+  equal(result.exitCode, 2);
+  ok(stderr.join("\n").includes("--run-id must be a base-10 ZetaId"));
+});
+
+test("runAgentCliCycle rejects malformed hat assignment ids before rendering authority", async () => {
+  const stderr: string[] = [];
+  const result = await runAgentCliCycle({
+    argv: ["observe", "--hat", "release_operator", "--scope", "work_item", "--hat-assignment", "hat-99"],
+    now: () => "2026-05-31T12:00:00.000Z",
+    writeStderr: (text) => stderr.push(text),
+    runCommand: async () => ({ ok: true }),
+    dispatchTool: async () => ({ ok: true }),
+  });
+
+  equal(result.exitCode, 2);
+  ok(stderr.join("\n").includes("--hat-assignment must be a base-10 ZetaId"));
+});
+
 test("createAgentCliMetricAgentsFromEnv wires live LGTM telemetry when all endpoints are configured", () => {
   const fetchCalls: string[] = [];
   const agents = createAgentCliMetricAgentsFromEnv({

--- a/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
+++ b/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
@@ -11,6 +11,32 @@ status: design
 Current checkpoint after the first executable TypeScript slices and
 subagent review.
 
+## Update 2026-06-01 — Phase 2.2 CLI ZetaId parser feedback closed
+
+The observe-act foreground CLI no longer lets malformed decimal Zeta IDs throw
+while constructing the observe snapshot. `runAgentCliCycle` now validates
+`--run-id` and `--hat-assignment` at the CLI boundary, returns exit code 2, and
+prints a flag-specific setup message before rendering authority or calling
+`observeAgentSurface`.
+
+This closes one remaining Phase 2.2 parser hardening path from
+`PHASE_2_PRODUCTION_AUTONOMY_CA.md`: the domain guard `asZetaIdDecimal` remains
+strict, while the CLI translates that guard into operator-readable typed
+feedback.
+
+Verification:
+
+```text
+npm test -- apps/agent-cli/test/agent-cli.test.ts
+  1205 tests / 1198 pass / 0 fail / 7 skipped
+
+KIND
+  Not rerun for this slice. The change is a pre-observe CLI input-validation
+  boundary; existing observe-act worker/KIND proofs exercise the successful
+  `runAgentCliMain` path, while this slice is covered by direct CLI regression
+  tests for both malformed ID flags.
+```
+
 ## Update 2026-05-30 — M1/M4 conformance checker + clamp properties built and proven in kind
 
 The first orchestration-moat phase is shipped: the org can now replay the

--- a/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
+++ b/agentic-organization/docs/NORTH_STAR_ALIGNMENT_CHECKPOINT.md
@@ -13,7 +13,7 @@ subagent review.
 
 ## Update 2026-06-01 — Phase 2.2 CLI ZetaId parser feedback closed
 
-The observe-act foreground CLI no longer lets malformed decimal Zeta IDs throw
+The observe-act foreground CLI no longer lets non-base-10 Zeta ID inputs throw
 while constructing the observe snapshot. `runAgentCliCycle` now validates
 `--run-id` and `--hat-assignment` at the CLI boundary, returns exit code 2, and
 prints a flag-specific setup message before rendering authority or calling


### PR DESCRIPTION
## Summary
- convert malformed observe-act CLI run IDs into flag-specific setup feedback instead of thrown snapshot construction errors
- convert malformed hat-assignment IDs through the same CLI feedback boundary
- record the Phase 2.2 parser-hardening checkpoint and KIND boundary

## Verification
- npm test -- apps/agent-cli/test/agent-cli.test.ts (1205 tests / 1198 pass / 0 fail / 7 skipped)
- npm run typecheck
- git diff --check

## Review Notes
- Subagent review was attempted but the runner returned agent thread limit reached. This PR is intentionally scoped to the CLI boundary and has direct regression tests for the previously throwing paths.
- KIND was not rerun because this is pre-observe CLI input validation; existing observe-act KIND coverage exercises the successful runAgentCliMain path.