### PR TITLE
Harden all-vetoed observe-act menus

### DIFF
--- a/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
+++ b/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
@@ -356,7 +356,8 @@ test("runAgentCliCycle passes schedule blocks into observe so execution can fail
   equal(result.exitCode, 1);
   equal(result.actionResult?.outcome, "rejected");
   if (result.actionResult?.outcome !== "rejected") return;
-  equal(result.actionResult.reason, ActRejectionReason.NoSelectableSlot);
+  equal(result.actionResult.reason, ActRejectionReason.SlotNotSelectable);
+  ok(result.actionResult.message.includes("requires a current schedule block"));
   equal(dispatched, false);
   ok(stdout.join("\n").includes("[04] F commit.a execute"));
   ok(stdout.join("\n").includes("requires a current schedule block"));
@@ -562,7 +563,7 @@ test("runAgentCliCycle status evidence includes hierarchy priority scope when hi
   equal(result.evidence?.statusHierarchyPriorityScope, "department_initiatives");
 });
 
-test("runAgentCliCycle returns typed no_selectable_slot feedback for all-vetoed menus", async () => {
+test("runAgentCliCycle rejects vetoed work slots while keeping all-vetoed meta controls visible", async () => {
   let dispatched = false;
   const stdout: string[] = [];
   const result = await runAgentCliCycle({
@@ -598,14 +599,16 @@ test("runAgentCliCycle returns typed no_selectable_slot feedback for all-vetoed 
   equal(result.exitCode, 1);
   equal(result.actionResult?.outcome, "rejected");
   if (result.actionResult?.outcome !== "rejected") return;
-  equal(result.actionResult.reason, "no_selectable_slot");
-  equal(result.actionResult.message, "no TriAvailability.True slots in rendered menu");
+  equal(result.actionResult.reason, "slot_not_selectable");
+  equal(result.actionResult.message, "tenant freeze blocks compose");
   equal(result.evidence?.selectedIndex, 4);
-  equal(result.evidence?.vetoCount, 2);
-  equal(result.evidence?.trueSlotCount, 0);
+  equal(result.evidence?.vetoCount, 4);
+  equal(result.evidence?.trueSlotCount, 2);
   equal(dispatched, false);
   ok(stdout.join("\n").includes("[04] F commit.a compose (tenant freeze blocks compose)"));
   ok(stdout.join("\n").includes("[05] F commit.b block (tenant freeze blocks block)"));
+  ok(stdout.join("\n").includes("[12] T meta.refresh refresh"));
+  ok(stdout.join("\n").includes("[13] T meta.status status / glass-halo"));
 });
 
 test("runAgentCliCycle renders prompt-flow tasks and loads selected context", async () => {

--- a/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
+++ b/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
@@ -81,8 +81,9 @@ The production gap is therefore in continuous closed-loop operation:
 - the current 16-slot menu is a usable projection, but not yet the ADR's full
   controller grammar with navigation, overflow paging, scope controls,
   retract/redo, and meta/escalation semantics;
-- zero-survivor observe cases still need a rendered all-vetoed menu so the agent
-  can see dark slots and reasons instead of only a feedback object;
+- zero-survivor observe cases now render all-vetoed work slots with reasons and
+  keep safe meta controls visible; remaining work is constrained local-model
+  selection and broader primary-lane rollout;
 - local model selection validates an index after free-form output; it is not yet
   constrained 1-of-16 decoding;
 - CLI and parsing failures still throw in several user-visible paths and must be
@@ -315,7 +316,8 @@ worker path.
   not-wired stubs;
 - the CLI lacks package/bin readiness as an executable production surface;
 - the current slot layout is not yet the full ADR controller grammar;
-- all-vetoed observe cases return feedback instead of a rendered disabled menu;
+- all-vetoed work menus now render disabled commit slots with reasons and keep
+  safe meta controls reachable for refresh/status/escalation;
 - local model selection is prompt-and-regex validation, not constrained decode;
 - several CLI/env/parser paths throw instead of returning typed feedback.
 
@@ -339,6 +341,17 @@ worker path.
 - replace prompt-and-regex local selection with a constrained selection contract
   that returns only an integer slot index and a reason string;
 - make illegal model output a normal feedback path, not a thrown worker crash.
+
+**Checkpoint 2026-06-01: all-work-vetoed menu liveness**
+
+`renderMenu16` now treats the work/commit bank and the controller/meta bank as
+separate safety domains. When every work option is vetoed, commit slots remain
+`False` with their veto reasons, prompt-flow work stays hidden, and
+`meta.refresh` / `meta.status` stay selectable so the agent can reobserve or
+emit glass-halo status instead of being stranded in a dead menu. Disabled
+controller actions such as pause or escalation without supervisor context remain
+`False`. CLI evidence now records this as `slot_not_selectable` when an agent
+chooses a vetoed work slot, while retaining visible meta recovery slots.
 
 **Algorithms:**
 

--- a/agentic-organization/packages/application/src/observe.ts
+++ b/agentic-organization/packages/application/src/observe.ts
@@ -844,9 +844,11 @@ export function renderMenu16(readout: RunStateReadout, options: RenderMenu16Opti
   }
   if (readout.options.length > 0) {
     renderScopeSlots(rendered, readout.scope);
-    renderMetaSlots(rendered, readout, options.status, options.escalation, options.escalationDisabledReason);
     const promptFlowPage = renderPromptFlowSlots(rendered, readout, options.promptFlows, options.hatAssignmentId, options.promptFlowPage);
     page = promptFlowPage === undefined ? undefined : { promptFlows: promptFlowPage };
+  }
+  if (readout.options.length > 0 || readout.vetoedOptions.length > 0) {
+    renderMetaSlots(rendered, readout, options.status, options.escalation, options.escalationDisabledReason);
   }
   return {
     slots: rendered,

--- a/agentic-organization/packages/application/test/observe.test.ts
+++ b/agentic-organization/packages/application/test/observe.test.ts
@@ -681,6 +681,65 @@ test("observe returns an all-vetoed readout so renderMenu16 can show dark slots 
   equal(menu.slots[5]?.action?.actionType, "block");
 });
 
+test("renderMenu16 keeps meta controls reachable when every work option is vetoed", async () => {
+  const blocked = observe(snapshot({
+    scope: RunScope.Project,
+    phase: RunLifecyclePhase.Observing,
+  }), {
+    clock: deps.clock,
+    deterministicRules: [
+      {
+        name: "maintenance-freeze",
+        veto: (option) => `maintenance freeze blocks ${option.actionType}`,
+      },
+    ],
+  });
+
+  equal(blocked.outcome, ObserveOutcome.Readout);
+  if (blocked.outcome !== ObserveOutcome.Readout) return;
+
+  const menu = renderMenu16(blocked.readout, {
+    status: {
+      metricBlockIds: ["queue.pressure"],
+      promptFlowIds: [],
+      promptFlowTaskCount: 0,
+      vetoedPromptFlowTaskCount: 0,
+    },
+  });
+
+  equal(menu.slots[4]?.availability, "F");
+  equal(menu.slots[5]?.availability, "F");
+  equal(menu.slots[12]?.direction, "meta.refresh");
+  equal(menu.slots[12]?.availability, "T");
+  deepEqual(menu.slots[12]?.impl, { kind: "observe", toScope: RunScope.Project });
+  equal(menu.slots[13]?.direction, "meta.status");
+  equal(menu.slots[13]?.availability, "T");
+  equal(menu.slots[14]?.direction, "meta.pause");
+  equal(menu.slots[14]?.availability, "F");
+  equal(menu.slots[15]?.direction, "meta.escalate");
+  equal(menu.slots[15]?.availability, "F");
+
+  const refreshResult = await act(12, menu, {
+    runCommand: async () => {
+      throw new Error("refresh must not dispatch command side effects");
+    },
+    dispatchTool: async () => {
+      throw new Error("refresh must not dispatch MCP side effects");
+    },
+  });
+  deepEqual(refreshResult, { outcome: "reobserve", scope: RunScope.Project });
+
+  const statusResult = await act(13, menu, {
+    runCommand: async () => {
+      throw new Error("status must not dispatch command side effects");
+    },
+    dispatchTool: async () => {
+      throw new Error("status must not dispatch MCP side effects");
+    },
+  });
+  equal(statusResult.outcome, "status_report");
+});
+
 test("renderMenu16 keeps all-vetoed menus dark even when prompt-flow tasks exist", () => {
   const blocked = observe(snapshot({ phase: RunLifecyclePhase.Observing }), {
     clock: deps.clock,


### PR DESCRIPTION
## Summary

- Keep `meta.refresh` and `meta.status` reachable when every work/commit option is vetoed.
- Preserve vetoed commit slots as `False` with deterministic reasons, while keeping prompt-flow work hidden under all-work-veto.
- Update CLI evidence expectations and the Phase 2 CA checkpoint to reflect the controller-bank liveness behavior.

## Verification

- `npm run typecheck`
- `npm test` — 1204 tests / 1197 pass / 0 fail / 7 skipped
- `git diff --check HEAD~2..HEAD`
- KIND smoke: production `agent:observe` status selection ran against in-cluster Cockroach via `kubectl port-forward svc/cockroach 26261:26257`, selecting slot 13 and returning `status glass_halo_status work_item awaiting_gate`.

## Review Notes

- Subagent review was attempted before and after implementation, but both attempts failed with `collab spawn failed: agent thread limit reached`.
- Repo-wide `.NET` gate could not run on this machine because `global.json` requires SDK `10.0.203`; installed SDKs are `9.0.100`, `9.0.200`, and `10.0.101`.
- Existing PR #6292 remains open and unmerged as of this PR creation.
