### PR TITLE
docs(adr): Zeta DB design — event-sourced G-Set/Bag/Z-set + Rx-fold materialized views, two backends

### DIFF
--- a/docs/DECISIONS/2026-05-31-zeta-database-design-event-sourced-gset-bag-zset-rx-fold-materialized-views-two-backends.md
+++ b/docs/DECISIONS/2026-05-31-zeta-database-design-event-sourced-gset-bag-zset-rx-fold-materialized-views-two-backends.md
@@ -1,0 +1,109 @@
+# ADR: Zeta's database design — an event-sourced G-Set/Bag/Z-set log, folded by Rx-observables into incremental materialized views; one logical design, two physical backends
+
+**Date:** 2026-05-31
+**Status:** Proposed — names + ratifies the unified design that several already-built pieces
+share (the F# Z-set algebra, the multi-language observe algebra, the git-native bus). Routed
+through the product-team agreement before it becomes binding doctrine.
+**Owner:** operator (Aaron, shaping) + Otto (synthesis).
+**Decision confidence:** medium-high — the core pieces exist in code; this ADR is mostly
+*recognition + naming* of one design across them, plus the explicit two-backends equivalence.
+
+## Context & problem
+
+Over 2026-05-31 the same shape kept recurring across unrelated-looking features: the
+agent-bus (B-0954) is a **G-Set**; Ace deps + work-items (B-0824 / B-0956) are **Z-sets**;
+DORA/metrics/observability (#6289 git-native LGTM) are **Bag-folds**; the `observe`
+event-algebra (B-0867.27) is the **Rx-style fold**; and the F# core already ships a **Z-set
+algebra** (`src/Core/ZSet.fs`, `IndexedZSet.fs`, `Algebra.fs`). These are not separate
+systems — they are **one database design** seen from different angles. Without naming it,
+each new feature re-derives a slice of it and the cross-backend equivalence stays implicit.
+
+This ADR states the design once.
+
+## The design
+
+**One sentence:** the database is an *append-only event log* whose entries live in the
+**G-Set / Bag / Z-set** algebra, and every query/report/index is a **materialized view**
+produced by **folding** that log with **Rx-style observables that update incrementally**
+(DBSP / differential-dataflow IVM) — add and retract propagate as deltas, never full
+recompute.
+
+### 1. The log is the source of truth (event-sourced)
+
+Append-only, ZetaId-keyed events. Nothing is updated-in-place; state is *derived*. (Same
+principle as the event-sourced-observability ADR, 2026-05-29.)
+
+### 2. Entries live in the algebra ladder
+
+| Container | Element count | Merge | Use |
+|---|---|---|---|
+| **G-Set** | {0,1} | union (idempotent) | grow-only / comms / append-only facts (the bus) |
+| **Bag** | ℕ | sum | counts / metrics / DORA (the LGTM "M") |
+| **Z-set** | ℤ (retraction) | sum | sets with add+remove → resolved views (Ace deps, work-items, the open backlog) |
+
+(G-Set = Z-set restricted to non-negative multiplicity; Bag sits between. See the bus↔Ace
+synthesis doc.)
+
+### 3. Views = Rx-observable folds, incrementally maintained
+
+A query is a **standing fold** over the log → a **materialized view**. Built on Rx-style
+observables (`src/Core/*` + `Core.{CSharp,Rust}.Observe` `observe`/`fold` algebra; the
+durable-reactive lineage in B-0251 Reaqtor/Temporal/Bonsai, B-0250 Rx-join). The fold is
+**incremental (DBSP IVM)**: an inserted/retracted event propagates as a **delta** through
+the view graph; reads are O(view), writes are O(change), no full recompute. Retraction is
+first-class (Z-set −1), so "remove a dep / close a work-item / correct a metric" is a delta,
+not a rebuild.
+
+### 4. One logical design, two physical backends
+
+The logical model above is **identical** across two storage substrates; only the on-disk
+encoding + transport differ:
+
+| | **git-native backend** | **F# filesystem backend** |
+|---|---|---|
+| Encoding | ZetaId-keyed JSON files | **binary-efficient** on-disk format |
+| Transport / merge | git (replication log; CRDT/G-Set merge; no-PR folders-on-main) | local filesystem / the F# engine |
+| Algebra home | the `observe`/fold tools (TS) | `src/Core/ZSet.fs` · `IndexedZSet.fs` · `Algebra.fs` |
+| Strengths | conflict-free **multi-agent** (no ID consensus — ZetaId PKs), human-auditable, zero-infra, cross-machine/Windows-safe | **throughput + compactness**, hot-path, deterministic-simulation replay |
+| Used for | bus (B-0954), work-items (B-0956), Ace (B-0824), observability/LGTM (#6289) | the engine's high-volume state; binary-efficient storage over the same Z-set algebra |
+| **Same** | **event log + G-Set/Bag/Z-set algebra + Rx-fold→incremental materialized view** | **(identical)** |
+
+A fold/query/view written against the algebra **ports between backends** — write the view
+once, run it over git-native JSON *or* F# binary storage. git-native is the
+multi-agent/audit/zero-infra surface; the F# binary backend is the perf/compactness surface;
+both are the same database.
+
+## Why this design
+
+- **Multi-agent without consensus:** ZetaId-keyed append-only log = conflict-free across
+  shards (agents). Incrementing IDs are a hidden consensus point; ZetaId PKs remove it
+  (B-0956). git is the replication log for free.
+- **Queries are cheap + always-fresh:** materialized views are maintained incrementally
+  (DBSP), not recomputed; retraction-native, so corrections are deltas.
+- **One mental model, many features:** bus / Ace / work-items / observability / DORA are
+  all *folds over one log* — learn the algebra once.
+- **Right tool per surface, same logic:** git-native for collaboration/audit/zero-infra; F#
+  binary for throughput — without forking the design.
+
+## Consequences
+
+- **Positive:** unified storage/query model; portable views; conflict-free multi-agent;
+  incremental + retraction-native; zero-infra collaboration surface + a fast binary surface;
+  observability is just another fold (no separate metrics store).
+- **Costs / open questions (route through ratification):** keeping the two backends' algebra
+  semantics provably equivalent (a differential/property-test obligation — cf. the golden-
+  vectors BFT oracle, B-0944/B-0867.27); the binary-efficient on-disk format spec for the F#
+  backend; when a view should be git-native (auditable/shared) vs F#-binary (hot/large);
+  view-definition language shared across TS + F#.
+
+## Composes with
+
+- `src/Core/ZSet.fs` · `IndexedZSet.fs` · `Algebra.fs` — the built F# Z-set algebra (the F# backend's algebra home)
+- `Core.CSharp.Observe/Algebra.cs` · `Core.Rust.Observe/src/algebra.rs` + B-0867.27 — the multi-language `observe`/`fold` algebra (cross-language parity)
+- the event-sourced-observability ADR (2026-05-29) + its git-native LGTM addendum (#6289) — observability is the Bag-fold view of this design
+- the bus↔Ace synthesis (`docs/research/2026-05-31-bus-and-ace-…`) — the G-Set/Bag/Z-set ladder
+- B-0954 (agent-bus, G-Set) · B-0956 (work-items, Z-set + ZetaId PKs) · B-0824 (Ace, dependency Z-set)
+- B-0251 (durable-computation: Reaqtor/Temporal/Orleans/Bonsai) · B-0250 (Rx-join) — the durable-reactive fold lineage
+- B-0773 (cluster-as-git-native-event-store) · B-0890.1 (folders-on-main, no-PR) — the git-native substrate + transport
+- the `algebra-owner` skill (Z-set + Clifford + BP/EP) — the algebra steward
+- the 5 always-active disciplines (DST / lock-free / weight-free / scale-free / DV2.0) — the design satisfies them (deterministic replay over the log; conflict-free merge; change-rate partitioning)


### PR DESCRIPTION
Saves the unified design that recurred across today's whole thread as a foundational ADR — **"this is our DB design."**

**One sentence:** an append-only ZetaId-keyed **event log**, entries in the **G-Set / Bag / Z-set** algebra, where every query/index/report is a **materialized view** produced by **folding the log with Rx-style observables that update incrementally** (DBSP IVM — add/retract propagate as deltas, no full recompute, retraction first-class).

**One logical design, two physical backends** (only encoding + transport differ; folds/views port between them):
- **git-native** — ZetaId JSON files, git transport; conflict-free multi-agent (ZetaId PKs, no ID consensus), human-auditable, zero-infra. → bus (B-0954), work-items (B-0956), Ace (B-0824), LGTM observability (#6289).
- **F# filesystem** — binary-efficient storage over the existing `src/Core` Z-set algebra; throughput/hot-path/deterministic-simulation.

**Same log + same algebra + same Rx-fold→materialized-view; only the bytes + transport change.** Bus/Ace/work-items/observability/DORA are all folds over one log.

Composes the already-built pieces: `src/Core/ZSet.fs`/`IndexedZSet.fs`/`Algebra.fs`, the multi-language observe algebra (B-0867.27), B-0250/B-0251 (Rx-join / Reaqtor durable-reactive), the bus/Ace/work-items/observability rows. **Status: Proposed**, pending product-team ratification (the pieces exist; this names the architecture). Requested by Aaron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
