### PR TITLE
Constrain observe-act model selector output

### DIFF
--- a/agentic-organization/apps/agent-cli/src/agent-cli.ts
+++ b/agentic-organization/apps/agent-cli/src/agent-cli.ts
@@ -384,8 +384,9 @@ export function createModelBackedMenuSelector(input: CreateModelBackedMenuSelect
     try {
       completion = await input.chat.complete({
         system:
-          "You are selecting from a deterministic 16-slot agent controller. Reply with only one selectable integer slot index and no prose.",
+          "You are selecting from a deterministic 16-slot agent controller. Return JSON only. The `slot` value must be one selectable slot index, and `reason` must briefly explain the choice.",
         user: buildMenuSelectorPrompt(selectable),
+        format: buildMenuSelectionSchema(selectable),
       });
     } catch {
       const fallback = normalizeMenuSelectionResult(await input.fallback(menu), "fallback_after_model_error");
@@ -776,8 +777,28 @@ function buildMenuSelectorPrompt(selectable: readonly Menu16Slot[]): string {
   return [
     "Selectable slots:",
     ...selectable.map((slot) => `[${String(slot.index).padStart(2, "0")}] ${slot.direction} ${slot.label}`),
-    "Reply with one slot index from the list above. Do not explain.",
+    "Return exactly this JSON shape: {\"slot\": <one listed integer>, \"reason\": \"short reason\"}.",
   ].join("\n");
+}
+
+function buildMenuSelectionSchema(selectable: readonly Menu16Slot[]): {
+  type: "object";
+  additionalProperties: false;
+  required: readonly ["slot", "reason"];
+  properties: {
+    slot: { type: "integer"; enum: readonly number[] };
+    reason: { type: "string"; minLength: 1 };
+  };
+} {
+  return {
+    type: "object",
+    additionalProperties: false,
+    required: ["slot", "reason"],
+    properties: {
+      slot: { type: "integer", enum: selectable.map((slot) => slot.index) },
+      reason: { type: "string", minLength: 1 },
+    },
+  };
 }
 
 function completionContent(completion: ChatCompletionResult): string {
@@ -788,17 +809,26 @@ function parseModelSelectedIndex(
   raw: string,
   menu: Menu16,
 ): { ok: true; index: number } | { ok: false; reason: SelectorRejectionReason; rejectedIndex?: number | undefined } {
-  const normalized = raw.trim();
-  const match = /^(?:\[(\d{1,2})\]|(\d{1,2}))$/.exec(normalized);
-  if (match === null) {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
     return { ok: false, reason: SelectorRejectionReason.ParseFailure };
   }
-  const index = Number.parseInt((match[1] ?? match[2])!, 10);
+  if (typeof decoded !== "object" || decoded === null || Array.isArray(decoded)) {
+    return { ok: false, reason: SelectorRejectionReason.ParseFailure };
+  }
+  const slot = (decoded as { slot?: unknown }).slot;
+  const reason = (decoded as { reason?: unknown }).reason;
+  if (!Number.isInteger(slot) || typeof reason !== "string" || reason.trim().length === 0) {
+    return { ok: false, reason: SelectorRejectionReason.ParseFailure };
+  }
+  const index = slot as number;
   if (index < 0 || index >= 16) {
     return { ok: false, reason: SelectorRejectionReason.SlotOutOfRange, rejectedIndex: index };
   }
-  const slot = menu.slots.find((candidate) => candidate.index === index);
-  if (slot?.availability !== TriAvailability.True) {
+  const renderedSlot = menu.slots.find((candidate) => candidate.index === index);
+  if (renderedSlot?.availability !== TriAvailability.True) {
     return { ok: false, reason: SelectorRejectionReason.NonSelectableSlot, rejectedIndex: index };
   }
   return { ok: true, index };

--- a/agentic-organization/apps/agent-cli/test/agent-cli-main.test.ts
+++ b/agentic-organization/apps/agent-cli/test/agent-cli-main.test.ts
@@ -614,7 +614,7 @@ test("runAgentCliMain persists selector rejection evidence from local model fall
       AGENTIC_ORG_LLM_MODEL: "llama3.1",
     },
     fetchImpl: (async () =>
-      new Response(JSON.stringify({ message: { content: "15" }, model: "llama3.1" }))) as typeof fetch,
+      new Response(JSON.stringify({ message: { content: JSON.stringify({ slot: 15, reason: "try escalation" }) }, model: "llama3.1" }))) as typeof fetch,
     now: () => "2026-05-31T00:00:00.000Z",
     writeStdout: () => undefined,
     writeStderr: () => undefined,

--- a/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
+++ b/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
@@ -9,6 +9,7 @@ import {
   RunLifecyclePhase,
   RunScope,
   type PromptFlowDefinition,
+  type ChatCompletionRequest,
   type HierarchySnapshot,
   type HierarchyMission,
   type PromptFlowTask,
@@ -109,12 +110,12 @@ test("selectFirstTrueSlot prefers executable work over page navigation", () => {
 });
 
 test("createModelBackedMenuSelector accepts only rendered T slot indexes from the local model", async () => {
-  const prompts: { system: string; user: string }[] = [];
+  const prompts: ChatCompletionRequest[] = [];
   const selector = createModelBackedMenuSelector({
     chat: {
       complete: async (request) => {
         prompts.push(request);
-        return { content: "[04]", model: "llama3.1" };
+        return { content: JSON.stringify({ slot: 4, reason: "execute the available work item" }), model: "llama3.1" };
       },
     },
     fallback: selectFirstTrueSlot,
@@ -123,14 +124,42 @@ test("createModelBackedMenuSelector accepts only rendered T slot indexes from th
   const selected = await selector(menuForSelection());
 
   equal(selected, 4);
+  deepEqual(prompts[0]?.format, {
+    type: "object",
+    additionalProperties: false,
+    required: ["slot", "reason"],
+    properties: {
+      slot: { type: "integer", enum: [4] },
+      reason: { type: "string", minLength: 1 },
+    },
+  });
   ok(prompts[0]?.user.includes("[04] commit.a execute"));
   ok(!prompts[0]?.user.includes("[05] commit.b blocked"));
+});
+
+test("createModelBackedMenuSelector rejects free-form slot text instead of regex-parsing it", async () => {
+  const selector = createModelBackedMenuSelector({
+    chat: {
+      complete: async () => "[04]",
+    },
+    fallback: () => 4,
+  });
+
+  deepEqual(await selector(menuForSelection()), {
+    index: 4,
+    reason: "fallback_after_selector_rejection",
+    selectorRejection: {
+      reason: "parse_failure",
+      rawOutput: "[04]",
+      fallbackIndex: 4,
+    },
+  });
 });
 
 test("createModelBackedMenuSelector records selector rejection evidence when the model chooses a non-selectable slot", async () => {
   const selector = createModelBackedMenuSelector({
     chat: {
-      complete: async () => "5",
+      complete: async () => JSON.stringify({ slot: 5, reason: "try blocked slot" }),
     },
     fallback: () => 4,
   });
@@ -140,7 +169,7 @@ test("createModelBackedMenuSelector records selector rejection evidence when the
     reason: "fallback_after_selector_rejection",
     selectorRejection: {
       reason: "non_selectable_slot",
-      rawOutput: "5",
+      rawOutput: "{\"slot\":5,\"reason\":\"try blocked slot\"}",
       rejectedIndex: 5,
       fallbackIndex: 4,
     },
@@ -172,7 +201,7 @@ test("runAgentCliCycle carries selector rejection evidence into observe-act tick
     now: () => "2026-05-31T12:00:00.000Z",
     selectSlot: createModelBackedMenuSelector({
       chat: {
-        complete: async () => "15",
+        complete: async () => JSON.stringify({ slot: 15, reason: "escalate instead" }),
       },
       fallback: () => 4,
     }),
@@ -184,7 +213,7 @@ test("runAgentCliCycle carries selector rejection evidence into observe-act tick
   equal(result.evidence?.selectedIndex, 4);
   deepEqual(result.evidence?.selectorRejections, [{
     reason: "non_selectable_slot",
-    rawOutput: "15",
+    rawOutput: "{\"slot\":15,\"reason\":\"escalate instead\"}",
     rejectedIndex: 15,
     fallbackIndex: 4,
   }]);
@@ -199,12 +228,21 @@ test("createAgentCliSelectorFromEnv wires a local Ollama selector when configure
     },
     fetchImpl: (async (url, init) => {
       calls.push({ url: String(url), body: JSON.parse(String(init?.body)) });
-      return new Response(JSON.stringify({ message: { content: "4" }, model: "llama3.1" }));
+      return new Response(JSON.stringify({ message: { content: JSON.stringify({ slot: 4, reason: "execute" }) }, model: "llama3.1" }));
     }) as typeof fetch,
   });
 
   equal(await selector(menuForSelection()), 4);
   equal(calls[0]?.url, "http://ollama:11434/api/chat");
+  deepEqual((calls[0]?.body as { format?: unknown } | undefined)?.format, {
+    type: "object",
+    additionalProperties: false,
+    required: ["slot", "reason"],
+    properties: {
+      slot: { type: "integer", enum: [4] },
+      reason: { type: "string", minLength: 1 },
+    },
+  });
 });
 
 test("runAgentCliCycle renders observe output and routes the selected slot through act", async () => {

--- a/agentic-organization/apps/workers/src/adapters/ollama-chat-port.ts
+++ b/agentic-organization/apps/workers/src/adapters/ollama-chat-port.ts
@@ -46,6 +46,7 @@ export function createOllamaChatPort(input: CreateOllamaChatPortInput): ChatComp
           body: JSON.stringify({
             model: input.model,
             stream: false,
+            ...createOptionalFormat(request.format),
             options: { temperature: 0 },
             messages: [
               { role: "system", content: request.system },
@@ -72,6 +73,10 @@ export function createOllamaChatPort(input: CreateOllamaChatPortInput): ChatComp
       }
     },
   };
+}
+
+function createOptionalFormat(format: ChatCompletionRequest["format"]): { format?: ChatCompletionRequest["format"] } {
+  return format === undefined ? {} : { format };
 }
 
 function createOptionalTokenUsage(body: OllamaChatResponse): {

--- a/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
+++ b/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
@@ -82,10 +82,10 @@ The production gap is therefore in continuous closed-loop operation:
   controller grammar with navigation, overflow paging, scope controls,
   retract/redo, and meta/escalation semantics;
 - zero-survivor observe cases now render all-vetoed work slots with reasons and
-  keep safe meta controls visible; remaining work is constrained local-model
-  selection and broader primary-lane rollout;
-- local model selection validates an index after free-form output; it is not yet
-  constrained 1-of-16 decoding;
+  keep safe meta controls visible; remaining work is broader primary-lane rollout;
+- local model selection now requests structured JSON-schema output for the
+  selectable slot set, then still clamps the returned slot against the rendered
+  `TriAvailability.True` menu;
 - CLI and parsing failures still throw in several user-visible paths and must be
   converted to typed feedback for production loops;
 - telemetry primitives exist, but every live cadence lane must be proven to emit
@@ -318,7 +318,8 @@ worker path.
 - the current slot layout is not yet the full ADR controller grammar;
 - all-vetoed work menus now render disabled commit slots with reasons and keep
   safe meta controls reachable for refresh/status/escalation;
-- local model selection is prompt-and-regex validation, not constrained decode;
+- local model selection now uses a constrained JSON-schema `{ slot, reason }`
+  contract, but broader primary-lane rollout still needs proof windows;
 - several CLI/env/parser paths throw instead of returning typed feedback.
 
 **Implementation:**
@@ -352,6 +353,17 @@ emit glass-halo status instead of being stranded in a dead menu. Disabled
 controller actions such as pause or escalation without supervisor context remain
 `False`. CLI evidence now records this as `slot_not_selectable` when an agent
 chooses a vetoed work slot, while retaining visible meta recovery slots.
+
+**Checkpoint 2026-06-01: constrained local-model selector**
+
+The agent CLI selector now requests structured model output with a JSON schema:
+`{ "slot": <selectable integer>, "reason": <non-empty string> }`. The schema
+enumerates only the currently rendered `TriAvailability.True` slots and is sent
+through the Ollama chat adapter as the request `format` field. The post-model
+clamp still validates the returned `slot` against the full rendered menu, so
+schema failure, bracketed/free-form text, out-of-range slots, and non-selectable
+slots remain typed selector rejections with fallback evidence instead of worker
+crashes.
 
 **Algorithms:**
 

--- a/agentic-organization/packages/application/src/model-backed-composer.ts
+++ b/agentic-organization/packages/application/src/model-backed-composer.ts
@@ -29,7 +29,30 @@ import {
 export type ChatCompletionRequest = {
   system: string;
   user: string;
+  format?: ChatCompletionFormat | undefined;
 };
+
+export type ChatCompletionFormat = "json" | JsonSchemaObject;
+
+export type JsonSchemaObject = {
+  type: "object";
+  properties: Record<string, JsonSchemaValue>;
+  required?: readonly string[] | undefined;
+  additionalProperties?: boolean | undefined;
+};
+
+export type JsonSchemaValue =
+  | {
+      type: "integer";
+      enum?: readonly number[] | undefined;
+      minimum?: number | undefined;
+      maximum?: number | undefined;
+    }
+  | {
+      type: "string";
+      enum?: readonly string[] | undefined;
+      minLength?: number | undefined;
+    };
 
 export type ChatCompletionUsage = {
   promptTokens?: number;


### PR DESCRIPTION
## Summary

- Replaces free-form/regex local model slot parsing with a constrained JSON-schema `{ slot, reason }` selector contract.
- Sends the schema through the Ollama chat adapter using the request `format` field.
- Keeps the existing deterministic clamp: bracketed/free-form text, malformed JSON, out-of-range slots, and non-selectable slots become typed selector rejection evidence with fallback selection.
- Updates the Phase 2 CA checkpoint to record the constrained selector slice.

## TDD Evidence

Red tests first failed because JSON selector responses were treated as parse failures and bracketed `[04]` text still selected a slot.

Green verification:

- `npm run typecheck`
- `npm test -- apps/agent-cli/test/agent-cli.test.ts apps/agent-cli/test/agent-cli-main.test.ts`
- `npm test` — 1205 tests / 1198 pass / 0 fail / 7 skipped
- `git diff --check`

## KIND Proof

- Confirmed KIND services running in namespace `agentic-org`.
- Pulled `qwen2:0.5b` into the in-cluster Ollama service because `/api/tags` initially returned no models.
- Port-forwarded in-cluster Ollama and Cockroach.
- Ran production CLI with `AGENTIC_ORG_LLM_BASE_URL=http://127.0.0.1:11434`, `AGENTIC_ORG_LLM_MODEL=qwen2:0.5b`, and `COCKROACH_DATABASE_URL=postgresql://root@localhost:26261/defaultdb?sslmode=disable`.
- CLI rendered the observe-act menu, accepted structured model selection, and returned `action: reobserve initiative`.
- Queried in-cluster `agentic_org_org_events` and verified an `observe_act_tick` for `work-kind-constrained-selector-20260601` with `observe-act:selected_slot:8` evidence.

## Review Notes

- Subagent review was attempted before and after implementation, but both attempts failed with `collab spawn failed: agent thread limit reached`.
- Repo-wide `.NET` gate could not run locally because `global.json` requires SDK `10.0.203`; installed SDKs are `9.0.100`, `9.0.200`, and `10.0.101`.
- The Ollama `format` behavior follows the official Ollama API structured-output field: https://github.com/ollama/ollama/blob/main/docs/api.md#request-structured-outputs
