### PR TITLE
Authorize observe-act lifecycle commands

### DIFF
--- a/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
+++ b/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
@@ -365,6 +365,17 @@ schema failure, bracketed/free-form text, out-of-range slots, and non-selectable
 slots remain typed selector rejections with fallback evidence instead of worker
 crashes.
 
+**Checkpoint 2026-06-01: observe lifecycle command authority**
+
+Production observe-act command dispatch now reaches the same durable hat
+authority policy as every other command without being rejected as an unknown
+command class. `observe.lifecycle_transition` is classified as a delivery
+`write_code` authority action, so delivery hats can advance selected lifecycle
+commit slots through the real command pipeline while management hats that lack
+delivery authority remain denied. This closes a production wiring gap where the
+CLI could render and dispatch a command slot but the durable policy layer still
+treated the observe-act foreground command as unsupported.
+
 **Algorithms:**
 
 - **menu stability hash:** hash slot directions, labels, availability, reasons,

--- a/agentic-organization/packages/application/src/hat-authority-port.ts
+++ b/agentic-organization/packages/application/src/hat-authority-port.ts
@@ -10,6 +10,7 @@ import {
   type HatAuthorityRequest,
 } from "../../policy/src/index.ts";
 import { ActionClass, preflightHatAction } from "./hat-guardrails.ts";
+import { ObserveCommandType } from "./observe.ts";
 import type { HatAssignmentAuthorityReaderPort } from "./ports.ts";
 
 export const HatAuthorityPolicyVersion = "hat-authority-v1" as const;
@@ -21,7 +22,7 @@ export type CreateHatAuthorityPortInput = {
   policyVersion?: string | undefined;
 };
 
-const CommandActionClass: Readonly<Partial<Record<CommandType, ActionClass>>> = {
+const CommandActionClass: Readonly<Partial<Record<string, ActionClass>>> = {
   [CommandType.CreateWorkItem]: ActionClass.Prioritize,
   [CommandType.CreateDiscussionAnchor]: ActionClass.WriteDoc,
   [CommandType.RecordQualityGateEvaluation]: ActionClass.ApproveReview,
@@ -29,6 +30,7 @@ const CommandActionClass: Readonly<Partial<Record<CommandType, ActionClass>>> = 
   [CommandType.ScheduleWorkBlock]: ActionClass.Prioritize,
   [CommandType.SendSupervisorSignal]: ActionClass.Prioritize,
   [CommandType.TriageSupervisorSignal]: ActionClass.Prioritize,
+  [ObserveCommandType.LifecycleTransition]: ActionClass.WriteCode,
 };
 
 const ToolActionClass: Readonly<Record<ActionClass, ActionClass>> = {

--- a/agentic-organization/packages/application/test/hat-authority-port.test.ts
+++ b/agentic-organization/packages/application/test/hat-authority-port.test.ts
@@ -12,6 +12,7 @@ import {
   type HatAuthorityRequest,
 } from "../../policy/src/index.ts";
 import {
+  ObserveCommandType,
   buildHatDefinitions,
   createHatAuthorityPort,
   type HatAssignmentAuthorityReaderPort,
@@ -57,6 +58,34 @@ describe("real hat authority port", () => {
     }));
 
     equal(decision.status, HatAuthorityDecisionStatus.Active);
+  });
+
+  test("allows observe-act lifecycle transition commands through durable hat authority", async () => {
+    const port = createHatAuthorityPort({
+      hatAssignmentAuthorityReader: readerFor(authority({ hatId: "release_operator" })),
+      hatDefinitions: buildHatDefinitions(),
+      createId,
+    });
+
+    const decision = await port.evaluateHatAuthority(request({
+      commandType: ObserveCommandType.LifecycleTransition,
+    }));
+
+    equal(decision.status, HatAuthorityDecisionStatus.Active);
+  });
+
+  test("denies observe-act lifecycle transition commands for hats without delivery authority", async () => {
+    const port = createHatAuthorityPort({
+      hatAssignmentAuthorityReader: readerFor(authority({ hatId: "program_director" })),
+      hatDefinitions: buildHatDefinitions(),
+      createId,
+    });
+
+    const decision = await port.evaluateHatAuthority(request({
+      commandType: ObserveCommandType.LifecycleTransition,
+    }));
+
+    equal(decision.status, HatAuthorityDecisionStatus.ToolDenied);
   });
 
   test("denies missing hat assignments", async () => {


### PR DESCRIPTION
## Summary

- classifies `observe.lifecycle_transition` as a delivery `write_code` authority command in the durable hat-authority policy
- adds positive/negative coverage so delivery hats can run observe-act lifecycle commands while non-delivery management hats remain denied
- records the Phase 2.2 checkpoint in `PHASE_2_PRODUCTION_AUTONOMY_CA.md`

## Why

The observe-act CLI now dispatches selected commit slots through the real command pipeline. Without a hat-authority mapping for `observe.lifecycle_transition`, production dispatch can render and select a legal command slot but still fail at the durable authority layer as an unknown command class.

## Verification

- RED: `node --experimental-strip-types --test packages/application/test/hat-authority-port.test.ts` failed with `hat_tool_denied` for `observe.lifecycle_transition`
- GREEN: `node --experimental-strip-types --test packages/application/test/hat-authority-port.test.ts` passed, 9/9
- `npm run typecheck` passed
- `npm test` passed, 1209 tests, 1202 passed, 0 failed, 7 skipped
- `git diff --check` passed
- KIND proof: `COCKROACH_DATABASE_URL='postgresql://root@localhost:26257/defaultdb?sslmode=disable' node --experimental-strip-types deploy/run-org-cadence.ts` passed against the `agentic-org` KIND cluster; proof output included `observe-act:command:accepted_primary_promotion`, `observe-act:selected_slot:4`, and `observe-act:command_type:observe.lifecycle_transition`

## Limitations

- Subagent review was attempted before and after implementation, but the environment returned `collab spawn failed: agent thread limit reached` both times.
- Local `.NET` gate remains blocked because `global.json` requires SDK `10.0.203`; this machine has `9.0.100`, `9.0.200`, and `10.0.101`.
