### PR TITLE
Wire observe-act slot 14 rest

### DIFF
--- a/agentic-organization/apps/agent-cli/src/agent-cli.ts
+++ b/agentic-organization/apps/agent-cli/src/agent-cli.ts
@@ -733,6 +733,11 @@ function stableSlotImpl(slot: Menu16Slot): unknown {
         promptFlowIds: slot.impl.status.promptFlowIds,
         hierarchy: slot.impl.status.hierarchy ?? null,
       };
+    case "rest":
+      return {
+        kind: slot.impl.kind,
+        reason: slot.impl.reason,
+      };
     case "command":
       return {
         kind: slot.impl.kind,
@@ -1155,6 +1160,8 @@ function formatActResult(result: ActResult): string {
       return `loaded context ${result.context.taskId}`;
     case "status_report":
       return `status ${result.status.kind} ${result.status.scope} ${result.status.phase}`;
+    case "rested":
+      return `rested ${result.reason}`;
     case "reobserve":
       return `reobserve ${result.scope}${result.menuPage?.promptFlows === undefined ? "" : ` prompt-flow-page ${result.menuPage.promptFlows + 1}`}`;
     case "rejected":

--- a/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
+++ b/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
@@ -292,8 +292,8 @@ test("runAgentCliCycle renders observe output and routes the selected slot throu
   ok(stdout.join("\n").includes("[04] T commit.a execute"));
   ok(stdout.join("\n").includes("action: dispatched command"));
   equal(result.evidence?.selectedIndex, 4);
-  equal(result.evidence?.vetoCount, 4);
-  equal(result.evidence?.trueSlotCount, 6);
+  equal(result.evidence?.vetoCount, 3);
+  equal(result.evidence?.trueSlotCount, 7);
   equal(result.evidence?.metricBlockIds[0], "queue");
   ok(result.evidence?.menuHash.match(/^[0-9a-f]{64}$/));
   deepEqual(commands, [
@@ -601,6 +601,48 @@ test("runAgentCliCycle status evidence includes hierarchy priority scope when hi
   equal(result.evidence?.statusHierarchyPriorityScope, "department_initiatives");
 });
 
+test("runAgentCliCycle can select free-time/rest without dispatching side effects", async () => {
+  const stdout: string[] = [];
+  const result = await runAgentCliCycle({
+    argv: [
+      "observe",
+      "--hat",
+      "release_operator",
+      "--hat-assignment",
+      "99",
+      "--agent",
+      "agent-release-1",
+      "--organization",
+      "org-1",
+      "--project",
+      "project-1",
+      "--work-item",
+      "work-1",
+      "--scope",
+      "work_item",
+      "--phase",
+      "awaiting_gate",
+      "--gate-approved",
+      "--select-index",
+      "14",
+    ],
+    now: () => "2026-05-31T12:00:00.000Z",
+    writeStdout: (text) => stdout.push(text),
+    runCommand: async () => {
+      throw new Error("rest must not dispatch command side effects");
+    },
+    dispatchTool: async () => {
+      throw new Error("rest must not dispatch MCP side effects");
+    },
+  });
+
+  equal(result.exitCode, 0);
+  equal(result.actionResult?.outcome, "rested");
+  ok(stdout.join("\n").includes("[14] T meta.pause free-time / rest"));
+  ok(stdout.join("\n").includes("action: rested free-time/rest selected; no side effects for this tick"));
+  equal(result.evidence?.selectedIndex, 14);
+});
+
 test("runAgentCliCycle rejects vetoed work slots while keeping all-vetoed meta controls visible", async () => {
   let dispatched = false;
   const stdout: string[] = [];
@@ -640,13 +682,14 @@ test("runAgentCliCycle rejects vetoed work slots while keeping all-vetoed meta c
   equal(result.actionResult.reason, "slot_not_selectable");
   equal(result.actionResult.message, "tenant freeze blocks compose");
   equal(result.evidence?.selectedIndex, 4);
-  equal(result.evidence?.vetoCount, 4);
-  equal(result.evidence?.trueSlotCount, 2);
+  equal(result.evidence?.vetoCount, 3);
+  equal(result.evidence?.trueSlotCount, 3);
   equal(dispatched, false);
   ok(stdout.join("\n").includes("[04] F commit.a compose (tenant freeze blocks compose)"));
   ok(stdout.join("\n").includes("[05] F commit.b block (tenant freeze blocks block)"));
   ok(stdout.join("\n").includes("[12] T meta.refresh refresh"));
   ok(stdout.join("\n").includes("[13] T meta.status status / glass-halo"));
+  ok(stdout.join("\n").includes("[14] T meta.pause free-time / rest"));
 });
 
 test("runAgentCliCycle renders prompt-flow tasks and loads selected context", async () => {

--- a/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
+++ b/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
@@ -317,7 +317,7 @@ worker path.
 - the CLI lacks package/bin readiness as an executable production surface;
 - the current slot layout is not yet the full ADR controller grammar;
 - all-vetoed work menus now render disabled commit slots with reasons and keep
-  safe meta controls reachable for refresh/status/escalation;
+  safe meta controls reachable for refresh/status/rest/escalation;
 - local model selection now uses a constrained JSON-schema `{ slot, reason }`
   contract, but broader primary-lane rollout still needs proof windows;
 - several CLI/env/parser paths throw instead of returning typed feedback.
@@ -375,6 +375,16 @@ commit slots through the real command pipeline while management hats that lack
 delivery authority remain denied. This closes a production wiring gap where the
 CLI could render and dispatch a command slot but the durable policy layer still
 treated the observe-act foreground command as unsupported.
+
+**Checkpoint 2026-06-01: slot 14 free-time/rest**
+
+Slot 14 is now wired as the ADR's always-reachable `free-time / rest` control
+instead of a disabled pause placeholder. `renderMenu16` exposes it as
+`TriAvailability.True` even when every work option is vetoed, and `act(14)`
+returns a typed `rested` result without invoking command dispatch or MCP/tool
+side effects. The agent CLI includes the selected slot and menu hash in durable
+tick evidence and prints an explicit rested action result, which gives the
+foreground loop a bounded no-op action that is visible, auditable, and legal.
 
 **Algorithms:**
 

--- a/agentic-organization/packages/application/src/observe.ts
+++ b/agentic-organization/packages/application/src/observe.ts
@@ -347,7 +347,8 @@ export type SlotImpl =
   | { kind: "mcp"; tool: string; args?: unknown; requiredSecretScopes?: readonly string[] | undefined }
   | { kind: "observe"; toScope: RunScope; menuPage?: MenuPageTarget | undefined }
   | { kind: "status"; status: GlassHaloStatusSignal }
-  | { kind: "prompt_flow"; request: PromptFlowContextRequest };
+  | { kind: "prompt_flow"; request: PromptFlowContextRequest }
+  | { kind: "rest"; reason: string };
 
 export const ObserveCommandType = {
   LifecycleTransition: "observe.lifecycle_transition",
@@ -479,6 +480,7 @@ export type ActResult =
   | { outcome: "dispatched"; kind: "command" | "mcp"; result: unknown }
   | { outcome: "loaded_context"; context: PromptFlowContext }
   | { outcome: "status_report"; status: GlassHaloStatusSignal }
+  | { outcome: "rested"; reason: string }
   | { outcome: "reobserve"; scope: RunScope; menuPage?: MenuPageTarget | undefined }
   | { outcome: "rejected"; reason: ActRejectionReason; message: string };
 
@@ -923,8 +925,21 @@ function renderMetaSlots(
   const currentScope = readout.scope;
   rendered[12] = createObserveSlot(12, MENU16_DIRECTIONS[12]!, "refresh", currentScope);
   rendered[13] = createStatusSlot(13, MENU16_DIRECTIONS[13]!, readout, statusContext);
-  rendered[14] = createDisabledGrammarSlot(14, MENU16_DIRECTIONS[14]!, "pause", "pause mode is not wired for this run state");
+  rendered[14] = createRestSlot(14, MENU16_DIRECTIONS[14]!);
   rendered[15] = createEscalationSlot(15, MENU16_DIRECTIONS[15]!, readout, escalationContext, escalationDisabledReason);
+}
+
+function createRestSlot(index: number, direction: string): Menu16Slot {
+  return {
+    index,
+    direction,
+    label: "free-time / rest",
+    availability: TriAvailability.True,
+    impl: {
+      kind: "rest",
+      reason: "free-time/rest selected; no side effects for this tick",
+    },
+  };
 }
 
 function createEscalationSlot(
@@ -1273,6 +1288,11 @@ export async function act(index: number, menu: Menu16, deps: ActDependencies): P
       return {
         outcome: "status_report",
         status: slot.impl.status,
+      };
+    case "rest":
+      return {
+        outcome: "rested",
+        reason: slot.impl.reason,
       };
     case "prompt_flow":
       if (deps.loadPromptFlowContext === undefined) {

--- a/agentic-organization/packages/application/test/observe.test.ts
+++ b/agentic-organization/packages/application/test/observe.test.ts
@@ -460,7 +460,12 @@ test("renderMenu16 exposes ADR scope, history, and meta controller slots", async
   equal(menu.slots[13]?.direction, "meta.status");
   equal(menu.slots[13]?.label, "status / glass-halo");
   equal(menu.slots[14]?.direction, "meta.pause");
-  equal(menu.slots[14]?.label, "pause");
+  equal(menu.slots[14]?.label, "free-time / rest");
+  equal(menu.slots[14]?.availability, "T");
+  deepEqual(menu.slots[14]?.impl, {
+    kind: "rest",
+    reason: "free-time/rest selected; no side effects for this tick",
+  });
   equal(menu.slots[15]?.direction, "meta.escalate");
   equal(menu.slots[15]?.label, "escalate");
 
@@ -481,6 +486,19 @@ test("renderMenu16 exposes ADR scope, history, and meta controller slots", async
     dispatchTool: async () => ({ ok: true }),
   });
   deepEqual(refreshResult, { outcome: "reobserve", scope: RunScope.WorkItem });
+
+  const restResult = await act(14, menu, {
+    runCommand: async () => {
+      throw new Error("rest must not dispatch command side effects");
+    },
+    dispatchTool: async () => {
+      throw new Error("rest must not dispatch MCP side effects");
+    },
+  });
+  deepEqual(restResult, {
+    outcome: "rested",
+    reason: "free-time/rest selected; no side effects for this tick",
+  });
 });
 
 test("renderMenu16 makes meta.status emit a glass-halo status signal", async () => {
@@ -715,7 +733,12 @@ test("renderMenu16 keeps meta controls reachable when every work option is vetoe
   equal(menu.slots[13]?.direction, "meta.status");
   equal(menu.slots[13]?.availability, "T");
   equal(menu.slots[14]?.direction, "meta.pause");
-  equal(menu.slots[14]?.availability, "F");
+  equal(menu.slots[14]?.label, "free-time / rest");
+  equal(menu.slots[14]?.availability, "T");
+  deepEqual(menu.slots[14]?.impl, {
+    kind: "rest",
+    reason: "free-time/rest selected; no side effects for this tick",
+  });
   equal(menu.slots[15]?.direction, "meta.escalate");
   equal(menu.slots[15]?.availability, "F");
 
@@ -738,6 +761,19 @@ test("renderMenu16 keeps meta controls reachable when every work option is vetoe
     },
   });
   equal(statusResult.outcome, "status_report");
+
+  const restResult = await act(14, menu, {
+    runCommand: async () => {
+      throw new Error("rest must not dispatch command side effects");
+    },
+    dispatchTool: async () => {
+      throw new Error("rest must not dispatch MCP side effects");
+    },
+  });
+  deepEqual(restResult, {
+    outcome: "rested",
+    reason: "free-time/rest selected; no side effects for this tick",
+  });
 });
 
 test("renderMenu16 keeps all-vetoed menus dark even when prompt-flow tasks exist", () => {


### PR DESCRIPTION
## Summary
- wires ADR slot 14 as an always-selectable free-time/rest Menu16 control
- returns a typed rested action without command or MCP side effects
- updates agent CLI rendering/evidence counts and documents the checkpoint in the Phase 2 CA plan

## Verification
- npm run typecheck
- npm test
- git diff --check HEAD~2..HEAD
- KIND proof: production agent:observe against Cockroach via kind-agentic-org selected slot 14 and persisted observe-act:selected_slot:14
- dotnet build -c Release is blocked by existing SDK pin: global.json requests 10.0.203; installed SDKs are 9.0.100, 9.0.200, 10.0.101

## Review note
- Requested subagent spec/code-quality reviews could not be spawned because the agent thread limit is currently reached.