### PR TITLE
feat(ace): MVP slice 2 — content-hash-integrity install/verify (B-0288)

### DIFF
--- a/.claude/skills/ace/SKILL.md
+++ b/.claude/skills/ace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ace
-description: Ace DLC package manager — list/install/verify content-addressed packages from the local ~/.ace store. install verifies content-hash integrity (authenticity/signatures are slice 3). Run via bun; Node-floor portable.
+description: Ace DLC package manager — list/install/verify content-addressed packages in ~/.ace store. Run via bun.
 record_source: "B-0288 + ace-package-manager agenda; distribution per 2026-06-01 design"
 load_datetime: "2026-06-01"
 last_updated: "2026-06-01"

--- a/.claude/skills/ace/SKILL.md
+++ b/.claude/skills/ace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ace
-description: Ace DLC package manager — list (and, when built, install/verify) content-addressed packages from the local ~/.ace store. Run via bun; Node-floor portable.
+description: Ace DLC package manager — list/install/verify content-addressed packages from the local ~/.ace store. install verifies content-hash integrity (authenticity/signatures are slice 3). Run via bun; Node-floor portable.
 record_source: "B-0288 + ace-package-manager agenda; distribution per 2026-06-01 design"
 load_datetime: "2026-06-01"
 last_updated: "2026-06-01"

--- a/.claude/skills/ace/SKILL.md
+++ b/.claude/skills/ace/SKILL.md
@@ -23,14 +23,14 @@ without one.
 
 ## Verb grammar
 
-Today (`list`-only slice):
-
 | Verb | Form | What |
 |---|---|---|
 | `list` | `bun tools/ace/ace.ts list [--store <path>] [--json]` | List installed packages from `~/.ace/store` |
+| `install` | `bun tools/ace/ace.ts install <url-or-path>` | Download/read a package, verify content-hash integrity, install to `~/.ace/store` |
+| `verify` | `bun tools/ace/ace.ts verify <hash>` | Confirm an installed package is present |
 | `help` | `bun tools/ace/ace.ts help` | Usage |
 
-(Coming in slice 2: `install <url>` + `verify <hash>` — integrity-verified.)
+`install` verifies **integrity** (content hash). Authenticity (signatures) is not yet checked — slice 3.
 
 ## Invocation
 

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -44,10 +44,27 @@ describe("parseArgs", () => {
     expect("error" in result).toBe(true);
   });
 
-  test("unimplemented commands return error", () => {
-    for (const cmd of ["install", "verify", "remove", "inspect"]) {
-      const result = parseArgs([cmd]);
-      expect("error" in result).toBe(true);
+  test("install requires a url/path argument", () => {
+    const result = parseArgs(["install"]);
+    expect("error" in result).toBe(true);
+  });
+
+  test("install <url> parses", () => {
+    const result = parseArgs(["install", "https://example.com/p.json"]);
+    expect("error" in result).toBe(false);
+    if (!("error" in result) && result.command === "install") {
+      expect(result.source).toBe("https://example.com/p.json");
+    }
+  });
+
+  test("verify requires a hash argument", () => {
+    const result = parseArgs(["verify"]);
+    expect("error" in result).toBe(true);
+  });
+
+  test("remove + inspect are still unimplemented", () => {
+    for (const cmd of ["remove", "inspect"]) {
+      expect("error" in parseArgs([cmd])).toBe(true);
     }
   });
 
@@ -179,25 +196,25 @@ describe("listInstalled", () => {
 });
 
 describe("main", () => {
-  test("help returns 0", () => {
-    expect(main(["help"])).toBe(0);
+  test("help returns 0", async () => {
+    expect(await main(["help"])).toBe(0);
   });
 
-  test("list on empty store returns 0", () => {
+  test("list on empty store returns 0", async () => {
     const dir = mkdtempSync(join(tmpdir(), "ace-test-"));
-    expect(main(["list", "--store", dir])).toBe(0);
+    expect(await main(["list", "--store", dir])).toBe(0);
   });
 
-  test("list --json on empty store returns 0", () => {
+  test("list --json on empty store returns 0", async () => {
     const dir = mkdtempSync(join(tmpdir(), "ace-test-"));
-    expect(main(["list", "--store", dir, "--json"])).toBe(0);
+    expect(await main(["list", "--store", dir, "--json"])).toBe(0);
   });
 
-  test("unknown command returns 64", () => {
-    expect(main(["bogus"])).toBe(64);
+  test("unknown command returns 64", async () => {
+    expect(await main(["bogus"])).toBe(64);
   });
 
-  test("list with populated store returns 0", () => {
+  test("list with populated store returns 0", async () => {
     const dir = mkdtempSync(join(tmpdir(), "ace-test-"));
     const pkgDir = join(dir, "sha256-test");
     mkdirSync(pkgDir);
@@ -211,6 +228,6 @@ describe("main", () => {
         description: "Demo package",
       }),
     );
-    expect(main(["list", "--store", dir])).toBe(0);
+    expect(await main(["list", "--store", dir])).toBe(0);
   });
 });

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -3,10 +3,13 @@
 //
 // Usage:
 //   bun tools/ace/ace.ts list [--store <path>] [--json]
+//   bun tools/ace/ace.ts install <url-or-path>
+//   bun tools/ace/ace.ts verify <hash>
 //
-// Future commands (not yet implemented): install, verify, remove, inspect.
+// Future commands (not yet implemented): remove, inspect.
 
-import { defaultStorePath, listInstalled } from "./store";
+import { readFileSync } from "node:fs";
+import { defaultStorePath, listInstalled, installPackage, type AcePackage } from "./store";
 
 interface ListArgs {
   readonly command: "list";
@@ -18,7 +21,19 @@ interface HelpArgs {
   readonly command: "help";
 }
 
-type ParsedArgs = ListArgs | HelpArgs;
+interface InstallArgs {
+  readonly command: "install";
+  readonly source: string;
+  readonly storePath: string;
+}
+
+interface VerifyArgs {
+  readonly command: "verify";
+  readonly hash: string;
+  readonly storePath: string;
+}
+
+type ParsedArgs = ListArgs | HelpArgs | InstallArgs | VerifyArgs;
 
 interface ArgError {
   readonly error: string;
@@ -28,6 +43,18 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
   const command = argv[0];
   if (!command || command === "help" || command === "--help" || command === "-h") {
     return { command: "help" };
+  }
+
+  if (command === "install") {
+    const source = argv[1];
+    if (!source || source.startsWith("-")) return { error: "install requires a <url-or-path> argument" };
+    return { command: "install", source, storePath: defaultStorePath() };
+  }
+
+  if (command === "verify") {
+    const hash = argv[1];
+    if (!hash || hash.startsWith("-")) return { error: "verify requires a <hash> argument" };
+    return { command: "verify", hash, storePath: defaultStorePath() };
   }
 
   if (command === "list") {
@@ -53,9 +80,9 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
     return { command: "list", storePath, json };
   }
 
-  const known = ["install", "verify", "remove", "inspect"];
+  const known = ["remove", "inspect"];
   if (known.includes(command)) {
-    return { error: `'${command}' is not yet implemented (smallest safe slice: list only)` };
+    return { error: `'${command}' is not yet implemented` };
   }
 
   return { error: `Unknown command: ${command}` };
@@ -65,18 +92,18 @@ function printUsage(): void {
   const text = `Ace DLC Package Manager
 
 Usage:
-  ace list [--store <path>] [--json]    List installed DLC packages
-  ace help                              Show this help
+  ace list [--store <path>] [--json]             List installed DLC packages
+  ace install <url-or-path>                      Download/read a package, verify integrity, install
+  ace verify <hash>                              Confirm an installed package is present
+  ace help                                       Show this help
 
 Future commands (not yet implemented):
-  ace install <hash-or-url>             Download, verify, and extract a DLC
-  ace verify <hash>                     Check signature and integrity
-  ace remove <hash>                     Uninstall a DLC
-  ace inspect <hash>                    Show manifest without installing`;
+  ace remove <hash>                              Uninstall a DLC
+  ace inspect <hash>                             Show manifest without installing`;
   console.log(text);
 }
 
-export function main(argv: readonly string[]): number {
+export async function main(argv: readonly string[]): Promise<number> {
   const parsed = parseArgs(argv);
 
   if ("error" in parsed) {
@@ -111,9 +138,37 @@ export function main(argv: readonly string[]): number {
     return 0;
   }
 
+  if (parsed.command === "install") {
+    let raw: string;
+    try {
+      raw = parsed.source.startsWith("http")
+        ? await (await fetch(parsed.source)).text()
+        : readFileSync(parsed.source, "utf8");
+    } catch (e) {
+      console.error(`ace: download/read failed: ${(e as Error).message}`);
+      return 1;
+    }
+    let pkg: AcePackage;
+    try { pkg = JSON.parse(raw) as AcePackage; }
+    catch { console.error("ace: package is not valid JSON"); return 65; }
+    const result = installPackage(parsed.storePath, pkg);
+    if (!result.ok) { console.error(`ace: install refused: ${result.error}`); return 1; }
+    console.log(`ace: installed ${pkg.manifest.name}@${pkg.manifest.version} -> ${result.dir}`);
+    console.log("ace: integrity-verified (content hash). NOT authenticity-verified (no signature check yet).");
+    return 0;
+  }
+
+  if (parsed.command === "verify") {
+    const pkgs = listInstalled(parsed.storePath);
+    const found = pkgs.find((p) => p.hash === parsed.hash || p.manifest.content_hash === parsed.hash);
+    if (!found) { console.error(`ace: no installed package with hash ${parsed.hash}`); return 1; }
+    console.log(`ace: ${found.manifest.name}@${found.manifest.version} present (manifest hash ${found.manifest.content_hash})`);
+    return 0;
+  }
+
   return 1;
 }
 
 if (import.meta.main) {
-  process.exit(main(process.argv.slice(2)));
+  main(process.argv.slice(2)).then((c) => process.exit(c));
 }

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -170,5 +170,12 @@ export async function main(argv: readonly string[]): Promise<number> {
 }
 
 if (import.meta.main) {
-  main(process.argv.slice(2)).then((c) => process.exit(c));
+  // .catch() closes the unhandled-promise surface from the async main(): an unexpected throw
+  // inside an await exits 1 with a diagnostic instead of an UnhandledPromiseRejection.
+  main(process.argv.slice(2))
+    .then((c) => process.exit(c))
+    .catch((e) => {
+      console.error(`ace: fatal: ${(e as Error).message}`);
+      process.exit(1);
+    });
 }

--- a/tools/ace/store.test.ts
+++ b/tools/ace/store.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { contentHash } from "./store.ts";
+
+describe("contentHash", () => {
+  test("sha256 of known bytes matches the sha256:<hex> form", () => {
+    // sha256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+    const h = contentHash(new TextEncoder().encode("hello"));
+    expect(h).toBe("sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+  });
+
+  test("empty input has the known empty-sha256", () => {
+    const h = contentHash(new Uint8Array(0));
+    expect(h).toBe("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  });
+});

--- a/tools/ace/store.test.ts
+++ b/tools/ace/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { mkdtempSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { contentHash, installPackage } from "./store.ts";

--- a/tools/ace/store.test.ts
+++ b/tools/ace/store.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
 import { contentHash, installPackage } from "./store.ts";
 
 describe("contentHash", () => {
@@ -23,8 +24,7 @@ describe("installPackage", () => {
   function makePkg(files: Record<string, string>, name = "demo") {
     const filesJson = JSON.stringify(files);
     const content_hash =
-      "sha256:" +
-      require("node:crypto").createHash("sha256").update(new TextEncoder().encode(filesJson)).digest("hex");
+      "sha256:" + createHash("sha256").update(new TextEncoder().encode(filesJson)).digest("hex");
     return {
       pkg: { manifest: { format_version: 1, name, version: "1.0.0", content_hash }, files },
       content_hash,
@@ -52,11 +52,48 @@ describe("installPackage", () => {
     if (!result.ok) expect(result.error).toContain("content hash mismatch");
   });
 
-  test("rejects a package with a path-traversal file path", () => {
+  test("rejects a package with a '../' path-traversal file path", () => {
     const store = mkdtempSync(join(tmpdir(), "ace-store-"));
     const { pkg } = makePkg({ "../escape.txt": "x" });
     const result = installPackage(store, pkg);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toContain("unsafe file path");
+  });
+
+  test("rejects a Windows-style '..\\' path-traversal file path", () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-store-"));
+    const { pkg } = makePkg({ "..\\escape.txt": "x" });
+    const result = installPackage(store, pkg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("unsafe file path");
+  });
+
+  test("rejects an absolute POSIX path", () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-store-"));
+    const { pkg } = makePkg({ "/etc/passwd": "x" });
+    const result = installPackage(store, pkg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("unsafe file path");
+  });
+
+  test("rejects an absolute Windows/UNC backslash path", () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-store-"));
+    const { pkg } = makePkg({ "\\\\server\\share": "x" });
+    const result = installPackage(store, pkg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("unsafe file path");
+  });
+
+  test("traversal refusal is ATOMIC — a non-first bad path extracts NOTHING (store stays clean)", () => {
+    // The bad path is not first: validate-all-before-extract must reject before the legit
+    // file is written, so the hash dir must not exist at all after a refused install.
+    const store = mkdtempSync(join(tmpdir(), "ace-store-"));
+    const { pkg, content_hash } = makePkg({ "legit.txt": "ok", "../escape.txt": "x" });
+    const result = installPackage(store, pkg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("unsafe file path");
+    // Nothing extracted: the hash dir was never created (no partial write of legit.txt).
+    const dir = join(store, content_hash.replace(":", "-"));
+    expect(existsSync(dir)).toBe(false);
   });
 });

--- a/tools/ace/store.test.ts
+++ b/tools/ace/store.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { contentHash } from "./store.ts";
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { contentHash, installPackage } from "./store.ts";
 
 describe("contentHash", () => {
   test("sha256 of known bytes matches the sha256:<hex> form", () => {
@@ -11,5 +14,49 @@ describe("contentHash", () => {
   test("empty input has the known empty-sha256", () => {
     const h = contentHash(new Uint8Array(0));
     expect(h).toBe("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  });
+});
+
+describe("installPackage", () => {
+  // A package is a JSON file: { manifest: AceManifest, files: {relpath: contents} }.
+  // content_hash is the sha256 of the canonical JSON of `files`.
+  function makePkg(files: Record<string, string>, name = "demo") {
+    const filesJson = JSON.stringify(files);
+    const content_hash =
+      "sha256:" +
+      require("node:crypto").createHash("sha256").update(new TextEncoder().encode(filesJson)).digest("hex");
+    return {
+      pkg: { manifest: { format_version: 1, name, version: "1.0.0", content_hash }, files },
+      content_hash,
+    };
+  }
+
+  test("installs a package whose content_hash matches, extracting files under <store>/<hash>", () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-store-"));
+    const { pkg, content_hash } = makePkg({ "readme.txt": "hi" });
+    const result = installPackage(store, pkg);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const dir = join(store, content_hash.replace(":", "-"));
+      expect(existsSync(join(dir, "manifest.json"))).toBe(true);
+      expect(readFileSync(join(dir, "readme.txt"), "utf8")).toBe("hi");
+    }
+  });
+
+  test("rejects a package whose content_hash does NOT match the files (no extraction)", () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-store-"));
+    const { pkg } = makePkg({ "a.txt": "x" });
+    const tampered = { ...pkg, files: { "a.txt": "TAMPERED" } }; // hash no longer matches
+    const result = installPackage(store, tampered);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("content hash mismatch");
+  });
+
+  test("rejects a package with a path-traversal file path", () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-store-"));
+    const { pkg } = makePkg({ "../escape.txt": "x" });
+    const result = installPackage(store, pkg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("unsafe file path");
   });
 });

--- a/tools/ace/store.ts
+++ b/tools/ace/store.ts
@@ -91,14 +91,26 @@ export function installPackage(storePath: string, pkg: AcePackage): InstallResul
   if (actual !== pkg.manifest.content_hash) {
     return { ok: false, error: `content hash mismatch: manifest says ${pkg.manifest.content_hash}, computed ${actual}` };
   }
+  // Validate ALL file paths BEFORE creating any directory or writing any file, so a
+  // traversal-blocked install refuses ATOMICALLY (extracts nothing) — the same guarantee a
+  // hash mismatch gives. (Validating inside the write loop would leave a partial dir on disk
+  // when a bad path is not the first entry.) Reject any '..' component (POSIX `../` or Windows
+  // `..\`) or absolute path (leading '/' or '\').
+  //
+  // NOTE (slice-3 hardening — on the map per the shield rule, not silently skipped): Windows
+  // device names (CON/NUL/PRN/AUX/COM1…) and drive-relative paths (`C:foo`) are NOT rejected
+  // here. They cannot escape `<storePath>/<hash>/` — `path.join` embeds them as subpaths — but
+  // a malicious package could still target a Windows device sink. Out of scope for this
+  // integrity-only MVP; tracked for the authenticity/robustness slice.
+  for (const rel of Object.keys(pkg.files)) {
+    if (rel.includes("..") || rel.startsWith("/") || rel.startsWith("\\")) {
+      return { ok: false, error: `unsafe file path in package: ${rel}` };
+    }
+  }
   const dir = join(storePath, pkg.manifest.content_hash.replace(":", "-"));
   try {
     mkdirSync(dir, { recursive: true });
     for (const [rel, contents] of Object.entries(pkg.files)) {
-      // Guard against path traversal: reject any '..' or absolute path component.
-      if (rel.includes("..") || rel.startsWith("/") || rel.startsWith("\\")) {
-        return { ok: false, error: `unsafe file path in package: ${rel}` };
-      }
       const dest = join(dir, rel);
       mkdirSync(join(dest, ".."), { recursive: true });
       writeFileSync(dest, contents);

--- a/tools/ace/store.ts
+++ b/tools/ace/store.ts
@@ -1,6 +1,7 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import type { Dirent } from "node:fs";
 import { join } from "node:path";
+import { createHash } from "node:crypto";
 
 export interface AceManifest {
   readonly format_version: number;
@@ -18,6 +19,11 @@ export interface InstalledPackage {
 export function defaultStorePath(): string {
   const home = process.env.HOME ?? process.env.USERPROFILE ?? ".";
   return join(home, ".ace", "store");
+}
+
+/** Content hash of raw bytes, in the `sha256:<hex>` form Ace manifests use. */
+export function contentHash(bytes: Uint8Array): string {
+  return "sha256:" + createHash("sha256").update(bytes).digest("hex");
 }
 
 export function listInstalled(storePath: string): InstalledPackage[] {
@@ -64,4 +70,42 @@ export function listInstalled(storePath: string): InstalledPackage[] {
   }
 
   return packages.sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
+}
+
+export interface AcePackage {
+  readonly manifest: AceManifest;
+  readonly files: Readonly<Record<string, string>>;
+}
+
+export type InstallResult = { ok: true; dir: string } | { ok: false; error: string };
+
+/**
+ * Verify-before-extract: recompute the content hash of `pkg.files` and refuse to
+ * extract unless it matches `pkg.manifest.content_hash` (integrity). Extracts to
+ * `<storePath>/<hash-with-':'-as-'-'>/` with a `manifest.json`. INTEGRITY ONLY —
+ * authenticity (signatures) is a separate concern (slice 3).
+ */
+export function installPackage(storePath: string, pkg: AcePackage): InstallResult {
+  const filesJson = JSON.stringify(pkg.files);
+  const actual = contentHash(new TextEncoder().encode(filesJson));
+  if (actual !== pkg.manifest.content_hash) {
+    return { ok: false, error: `content hash mismatch: manifest says ${pkg.manifest.content_hash}, computed ${actual}` };
+  }
+  const dir = join(storePath, pkg.manifest.content_hash.replace(":", "-"));
+  try {
+    mkdirSync(dir, { recursive: true });
+    for (const [rel, contents] of Object.entries(pkg.files)) {
+      // Guard against path traversal: reject any '..' or absolute path component.
+      if (rel.includes("..") || rel.startsWith("/") || rel.startsWith("\\")) {
+        return { ok: false, error: `unsafe file path in package: ${rel}` };
+      }
+      const dest = join(dir, rel);
+      mkdirSync(join(dest, ".."), { recursive: true });
+      writeFileSync(dest, contents);
+    }
+    writeFileSync(join(dir, "manifest.json"), JSON.stringify(pkg.manifest, null, 2));
+    return { ok: true, dir };
+  } catch (e) {
+    return { ok: false, error: `extract failed: ${(e as Error).message}` };
+  }
 }

--- a/tools/ace/store.ts
+++ b/tools/ace/store.ts
@@ -97,11 +97,18 @@ export function installPackage(storePath: string, pkg: AcePackage): InstallResul
   // when a bad path is not the first entry.) Reject any '..' component (POSIX `../` or Windows
   // `..\`) or absolute path (leading '/' or '\').
   //
-  // NOTE (slice-3 hardening — on the map per the shield rule, not silently skipped): Windows
-  // device names (CON/NUL/PRN/AUX/COM1…) and drive-relative paths (`C:foo`) are NOT rejected
-  // here. They cannot escape `<storePath>/<hash>/` — `path.join` embeds them as subpaths — but
-  // a malicious package could still target a Windows device sink. Out of scope for this
-  // integrity-only MVP; tracked for the authenticity/robustness slice.
+  // NOTE (slice-3 hardening — on the map per the shield rule, NOT silenced):
+  //   (a) PATH: Windows device names (CON/NUL/PRN/AUX/COM1…) and drive-relative paths
+  //       (`C:foo`) are NOT rejected here. They cannot escape `<storePath>/<hash>/` —
+  //       `path.join` embeds them as subpaths — but a malicious package could still target a
+  //       Windows device sink.
+  //   (b) CONTENT/SOURCE: the `install <url>` verb fetches package bytes over HTTP and writes
+  //       them here (CodeQL js/http-to-file-access, accepted). The write is confined to
+  //       `<storePath>/<hash>/` (path guard above) and the bytes are integrity-checked against
+  //       the manifest hash — but the manifest ships WITH the download, so integrity alone does
+  //       not defend against a malicious *source*. Authenticity (signature over a trusted key)
+  //       is the defense, and is explicitly the authenticity/robustness slice (slice 3). The
+  //       alert stays open until then rather than being suppressed.
   for (const rel of Object.keys(pkg.files)) {
     if (rel.includes("..") || rel.startsWith("/") || rel.startsWith("\\")) {
       return { ok: false, error: `unsafe file path in package: ${rel}` };


### PR DESCRIPTION
## What

Ace MVP **slice 2** — the content-hash-**integrity** `install`/`verify` build (slice 1 = `bun link` distribution + skill surface, merged #6301; the plan: `docs/agendas/ace-package-manager/2026-06-01-ace-cli-mvp-implementation-plan.md` SLICE 2 / Tasks 5–8).

- **`contentHash(bytes) → sha256:<hex>`** in `store.ts` (Task 5).
- **`installPackage()` verify-before-extract** (Task 6): recompute the content hash of `pkg.files`, refuse on mismatch, extract to `~/.ace/store/<hash>/` with a `manifest.json`. Path-traversal guard rejects `..` / absolute / UNC-backslash paths. Validation is a **pre-pass over all paths before any mkdir/write**, so a traversal-blocked install refuses **atomically** (extracts nothing) — same guarantee as a hash mismatch.
- **`install <url-or-path>` + `verify <hash>` verbs** wired into `ace.ts` (Task 7); `main` is now async with a `.catch()` entry-point guard. `install` prints an **unconditional** "integrity-verified (content hash). NOT authenticity-verified" line — no green-by-skip.
- **`.claude/skills/ace/SKILL.md`** verb table + frontmatter updated; install/verify live, integrity-only noted (Task 8).

**Integrity only** — authenticity/signatures are explicitly **slice 3**. On the map (not silently skipped): Windows device names (CON/NUL/PRN) + drive-relative paths are not rejected by the guard (they can't escape `<store>/<hash>/`); tracked for the authenticity/robustness slice.

## Process

Built subagent-driven (implementer → independent review → fix loop → independent re-review). First review returned CHANGES_REQUIRED (atomic-refusal partial-write, untested absolute/backslash guard branches, entry-point unhandled-promise, `require()` idiom, stale router description); fix commit `dbfcef7d0` closed all; re-review **APPROVED**, all findings CLOSED, no regressions.

## Gates (verified)

- `bun test tools/ace/` → **35 pass / 0 fail**
- `tsc --noEmit` → clean on `tools/ace`
- `ace help` / `ace list --json` → exit 0 · `ace verify nonexistent` → exit 1
- `markdownlint-cli2 SKILL.md` → exit 0
- commit canary `git ls-tree HEAD | wc -l` → 67

🤖 Generated with [Claude Code](https://claude.com/claude-code)