### PR TITLE
Reserve observe-act slot 7 for grammar branch

### DIFF
--- a/agentic-organization/apps/agent-cli/src/agent-cli.ts
+++ b/agentic-organization/apps/agent-cli/src/agent-cli.ts
@@ -738,6 +738,11 @@ function stableSlotImpl(slot: Menu16Slot): unknown {
         kind: slot.impl.kind,
         reason: slot.impl.reason,
       };
+    case "grammar_branch":
+      return {
+        kind: slot.impl.kind,
+        reason: slot.impl.reason,
+      };
     case "command":
       return {
         kind: slot.impl.kind,
@@ -1160,6 +1165,8 @@ function formatActResult(result: ActResult): string {
       return `loaded context ${result.context.taskId}`;
     case "status_report":
       return `status ${result.status.kind} ${result.status.scope} ${result.status.phase}`;
+    case "grammar_branch_requested":
+      return `grammar-branch requested ${result.reason}`;
     case "rested":
       return `rested ${result.reason}`;
     case "reobserve":

--- a/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
+++ b/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
@@ -293,7 +293,7 @@ test("runAgentCliCycle renders observe output and routes the selected slot throu
   ok(stdout.join("\n").includes("action: dispatched command"));
   equal(result.evidence?.selectedIndex, 4);
   equal(result.evidence?.vetoCount, 3);
-  equal(result.evidence?.trueSlotCount, 7);
+  equal(result.evidence?.trueSlotCount, 8);
   equal(result.evidence?.metricBlockIds[0], "queue");
   ok(result.evidence?.menuHash.match(/^[0-9a-f]{64}$/));
   deepEqual(commands, [
@@ -643,6 +643,48 @@ test("runAgentCliCycle can select free-time/rest without dispatching side effect
   equal(result.evidence?.selectedIndex, 14);
 });
 
+test("runAgentCliCycle can select edit-grammar/branch without dispatching side effects", async () => {
+  const stdout: string[] = [];
+  const result = await runAgentCliCycle({
+    argv: [
+      "observe",
+      "--hat",
+      "release_operator",
+      "--hat-assignment",
+      "99",
+      "--agent",
+      "agent-release-1",
+      "--organization",
+      "org-1",
+      "--project",
+      "project-1",
+      "--work-item",
+      "work-1",
+      "--scope",
+      "work_item",
+      "--phase",
+      "awaiting_gate",
+      "--gate-approved",
+      "--select-index",
+      "7",
+    ],
+    now: () => "2026-05-31T12:00:00.000Z",
+    writeStdout: (text) => stdout.push(text),
+    runCommand: async () => {
+      throw new Error("edit-grammar/branch must not dispatch command side effects");
+    },
+    dispatchTool: async () => {
+      throw new Error("edit-grammar/branch must not dispatch MCP side effects");
+    },
+  });
+
+  equal(result.exitCode, 0);
+  equal(result.actionResult?.outcome, "grammar_branch_requested");
+  ok(stdout.join("\n").includes("[07] T branch.fork edit-grammar / branch"));
+  ok(stdout.join("\n").includes("action: grammar-branch requested edit-grammar/branch selected; no side effects for this tick"));
+  equal(result.evidence?.selectedIndex, 7);
+});
+
 test("runAgentCliCycle rejects vetoed work slots while keeping all-vetoed meta controls visible", async () => {
   let dispatched = false;
   const stdout: string[] = [];
@@ -683,10 +725,11 @@ test("runAgentCliCycle rejects vetoed work slots while keeping all-vetoed meta c
   equal(result.actionResult.message, "tenant freeze blocks compose");
   equal(result.evidence?.selectedIndex, 4);
   equal(result.evidence?.vetoCount, 3);
-  equal(result.evidence?.trueSlotCount, 3);
+  equal(result.evidence?.trueSlotCount, 4);
   equal(dispatched, false);
   ok(stdout.join("\n").includes("[04] F commit.a compose (tenant freeze blocks compose)"));
   ok(stdout.join("\n").includes("[05] F commit.b block (tenant freeze blocks block)"));
+  ok(stdout.join("\n").includes("[07] T branch.fork edit-grammar / branch"));
   ok(stdout.join("\n").includes("[12] T meta.refresh refresh"));
   ok(stdout.join("\n").includes("[13] T meta.status status / glass-halo"));
   ok(stdout.join("\n").includes("[14] T meta.pause free-time / rest"));
@@ -810,8 +853,9 @@ test("runAgentCliCycle renders prompt-flow overflow pages and reobserve page nav
     menuPage: { promptFlows: 0 },
   });
   const rendered = stdout.join("\n");
-  ok(rendered.includes("prompt-flow page: 2/2"));
-  ok(rendered.includes("[06] T inspect.more Task 3"));
+  ok(rendered.includes("prompt-flow page: 2/3"));
+  ok(rendered.includes("[06] T inspect.more Task 2"));
+  ok(rendered.includes("[07] T branch.fork edit-grammar / branch"));
   ok(rendered.includes("[00] T navigate.previous previous prompt-flow page"));
   ok(rendered.includes("action: reobserve work_item prompt-flow-page 1"));
   equal(result.evidence?.promptFlowPage, 1);
@@ -861,8 +905,8 @@ test("runAgentCliCycle binds selected prompt-flow task identity into evidence", 
 
   equal(result.exitCode, 0);
   equal(result.evidence?.promptFlowPage, 1);
-  equal(result.evidence?.selectedPromptFlowTaskId, "task-3");
-  equal(result.evidence?.selectedPromptFlowId, "flow-3");
+  equal(result.evidence?.selectedPromptFlowTaskId, "task-2");
+  equal(result.evidence?.selectedPromptFlowId, "flow-2");
 });
 
 test("runAgentCliCycle default prompt-flow loader preserves compiled phase metadata", async () => {

--- a/agentic-organization/apps/workers/test/org-cadence-lanes.test.ts
+++ b/agentic-organization/apps/workers/test/org-cadence-lanes.test.ts
@@ -582,14 +582,14 @@ test("observe-act work-item lane carries prompt-flow overflow page navigation in
   equal(first.failures.length, 0);
   equal(first.status, "observe-act:reobserve:work_item:prompt_flow_page:1");
   equal(second.failures.length, 0);
-  equal(second.status, "observe-act:context:task-3");
-  ok(stdout.join("\n").includes("prompt-flow page: 2/2"));
-  deepEqual(loaded, ["task-3"]);
+  equal(second.status, "observe-act:context:task-2");
+  ok(stdout.join("\n").includes("prompt-flow page: 2/3"));
+  deepEqual(loaded, ["task-2"]);
   ok(observeEvents[0]?.evidenceRefs.includes("observe-act:prompt_flow_page:0"));
   ok(observeEvents[0]?.evidenceRefs.includes("observe-act:reobserve_prompt_flow_page:1"));
   ok(observeEvents[1]?.evidenceRefs.includes("observe-act:prompt_flow_page:1"));
-  ok(observeEvents[1]?.evidenceRefs.includes("observe-act:selected_prompt_flow_task:task-3"));
-  ok(observeEvents[1]?.evidenceRefs.includes("observe-act:selected_prompt_flow:flow-3"));
+  ok(observeEvents[1]?.evidenceRefs.includes("observe-act:selected_prompt_flow_task:task-2"));
+  ok(observeEvents[1]?.evidenceRefs.includes("observe-act:selected_prompt_flow:flow-2"));
 });
 
 test("observe-act work-item lane passes hierarchy readouts through to the agent observe surface", async () => {

--- a/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
+++ b/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
@@ -386,6 +386,17 @@ side effects. The agent CLI includes the selected slot and menu hash in durable
 tick evidence and prints an explicit rested action result, which gives the
 foreground loop a bounded no-op action that is visible, auditable, and legal.
 
+**Checkpoint 2026-06-01: slot 7 edit-grammar/branch**
+
+Slot 7 is now reserved for the ADR's always-reachable `edit-grammar / branch`
+generative exit instead of being reused as prompt-flow overflow capacity.
+`renderMenu16` exposes it as `TriAvailability.True` in normal and all-work-vetoed
+menus, and `act(7)` returns a typed `grammar_branch_requested` result without
+invoking command dispatch or MCP/tool side effects. Prompt-flow context loading
+now pages through slot 6 (`inspect.more`) only, preserving the fixed 16-slot
+controller grammar while still giving agents access to all scoped prompt-flow
+tasks through navigation.
+
 **Algorithms:**
 
 - **menu stability hash:** hash slot directions, labels, availability, reasons,

--- a/agentic-organization/packages/application/src/observe.ts
+++ b/agentic-organization/packages/application/src/observe.ts
@@ -348,6 +348,7 @@ export type SlotImpl =
   | { kind: "observe"; toScope: RunScope; menuPage?: MenuPageTarget | undefined }
   | { kind: "status"; status: GlassHaloStatusSignal }
   | { kind: "prompt_flow"; request: PromptFlowContextRequest }
+  | { kind: "grammar_branch"; reason: string }
   | { kind: "rest"; reason: string };
 
 export const ObserveCommandType = {
@@ -480,6 +481,7 @@ export type ActResult =
   | { outcome: "dispatched"; kind: "command" | "mcp"; result: unknown }
   | { outcome: "loaded_context"; context: PromptFlowContext }
   | { outcome: "status_report"; status: GlassHaloStatusSignal }
+  | { outcome: "grammar_branch_requested"; reason: string }
   | { outcome: "rested"; reason: string }
   | { outcome: "reobserve"; scope: RunScope; menuPage?: MenuPageTarget | undefined }
   | { outcome: "rejected"; reason: ActRejectionReason; message: string };
@@ -815,7 +817,7 @@ const MENU16_DIRECTIONS: readonly string[] = [
   "meta.escalate",
 ];
 const COMMIT_SLOT_INDICES: readonly number[] = [4, 5];
-const PROMPT_FLOW_SLOT_INDICES: readonly number[] = [6, 7];
+const PROMPT_FLOW_SLOT_INDICES: readonly number[] = [6];
 const PROMPT_FLOW_PAGE_SIZE = PROMPT_FLOW_SLOT_INDICES.length;
 const MENU16_SLOT_COUNT = 16;
 const RUN_SCOPE_LADDER: readonly RunScope[] = [
@@ -850,6 +852,7 @@ export function renderMenu16(readout: RunStateReadout, options: RenderMenu16Opti
     page = promptFlowPage === undefined ? undefined : { promptFlows: promptFlowPage };
   }
   if (readout.options.length > 0 || readout.vetoedOptions.length > 0) {
+    renderBranchSlot(rendered);
     renderMetaSlots(rendered, readout, options.status, options.escalation, options.escalationDisabledReason);
   }
   return {
@@ -913,6 +916,19 @@ function renderScopeSlots(rendered: Menu16Slot[], currentScope: RunScope): void 
     : createObserveSlot(9, MENU16_DIRECTIONS[9]!, `scope in to ${finerScope}`, finerScope);
   rendered[10] = createDisabledGrammarSlot(10, MENU16_DIRECTIONS[10]!, "retract", "retraction is not wired for this run state");
   rendered[11] = createDisabledGrammarSlot(11, MENU16_DIRECTIONS[11]!, "redo", "redo is not wired for this run state");
+}
+
+function renderBranchSlot(rendered: Menu16Slot[]): void {
+  rendered[7] = {
+    index: 7,
+    direction: MENU16_DIRECTIONS[7]!,
+    label: "edit-grammar / branch",
+    availability: TriAvailability.True,
+    impl: {
+      kind: "grammar_branch",
+      reason: "edit-grammar/branch selected; no side effects for this tick",
+    },
+  };
 }
 
 function renderMetaSlots(
@@ -1288,6 +1304,11 @@ export async function act(index: number, menu: Menu16, deps: ActDependencies): P
       return {
         outcome: "status_report",
         status: slot.impl.status,
+      };
+    case "grammar_branch":
+      return {
+        outcome: "grammar_branch_requested",
+        reason: slot.impl.reason,
       };
     case "rest":
       return {

--- a/agentic-organization/packages/application/test/observe.test.ts
+++ b/agentic-organization/packages/application/test/observe.test.ts
@@ -325,8 +325,12 @@ test("renderMenu16 prompt-flow overflow prefers executable tasks over vetoed tas
 
   equal(menu.slots[6]?.label, "Allowed task");
   equal(menu.slots[6]?.availability, "T");
-  equal(menu.slots[7]?.label, "Vetoed high task");
-  equal(menu.slots[7]?.availability, "F");
+  equal(menu.slots[7]?.label, "edit-grammar / branch");
+  equal(menu.slots[7]?.availability, "T");
+  deepEqual(menu.slots[7]?.impl, {
+    kind: "grammar_branch",
+    reason: "edit-grammar/branch selected; no side effects for this tick",
+  });
 });
 
 test("renderMenu16 pages prompt-flow overflow through fixed navigation slots", async () => {
@@ -349,7 +353,7 @@ test("renderMenu16 pages prompt-flow overflow through fixed navigation slots", a
     promptFlows: { tasks, vetoedTasks: [] },
   });
 
-  deepEqual(firstPage.page?.promptFlows, { page: 0, pageSize: 2, pageCount: 3, total: 5 });
+  deepEqual(firstPage.page?.promptFlows, { page: 0, pageSize: 1, pageCount: 5, total: 5 });
   equal(firstPage.slots[0]?.direction, "navigate.previous");
   equal(firstPage.slots[0]?.availability, "F");
   ok(firstPage.slots[0]?.reason?.includes("already at first prompt-flow page"));
@@ -360,7 +364,8 @@ test("renderMenu16 pages prompt-flow overflow through fixed navigation slots", a
     toScope: RunScope.WorkItem,
     menuPage: { promptFlows: 1 },
   });
-  deepEqual(firstPage.slots.slice(6, 8).map((slot) => slot.label), ["Task 1", "Task 2"]);
+  equal(firstPage.slots[6]?.label, "Task 1");
+  equal(firstPage.slots[7]?.label, "edit-grammar / branch");
 
   const nextResult = await act(1, firstPage, {
     runCommand: async () => ({ ok: true }),
@@ -396,7 +401,7 @@ test("renderMenu16 renders later prompt-flow overflow pages without changing slo
   });
 
   equal(middlePage.slots.length, 16);
-  deepEqual(middlePage.page?.promptFlows, { page: 1, pageSize: 2, pageCount: 3, total: 5 });
+  deepEqual(middlePage.page?.promptFlows, { page: 1, pageSize: 1, pageCount: 5, total: 5 });
   equal(middlePage.slots[0]?.availability, "T");
   deepEqual(middlePage.slots[0]?.impl, {
     kind: "observe",
@@ -409,22 +414,23 @@ test("renderMenu16 renders later prompt-flow overflow pages without changing slo
     toScope: RunScope.WorkItem,
     menuPage: { promptFlows: 2 },
   });
-  deepEqual(middlePage.slots.slice(6, 8).map((slot) => slot.label), ["Task 3", "Task 4"]);
+  equal(middlePage.slots[6]?.label, "Task 2");
+  equal(middlePage.slots[7]?.label, "edit-grammar / branch");
 
   const lastPage = renderMenu16(approved.readout, {
     hatAssignmentId: asZetaIdDecimal("99"),
-    promptFlowPage: 2,
+    promptFlowPage: 4,
     promptFlows: { tasks, vetoedTasks: [] },
   });
 
-  deepEqual(lastPage.page?.promptFlows, { page: 2, pageSize: 2, pageCount: 3, total: 5 });
+  deepEqual(lastPage.page?.promptFlows, { page: 4, pageSize: 1, pageCount: 5, total: 5 });
   equal(lastPage.slots[0]?.availability, "T");
   equal(lastPage.slots[1]?.availability, "F");
   ok(lastPage.slots[1]?.reason?.includes("already at last prompt-flow page"));
   equal(lastPage.slots[6]?.label, "Task 5");
   equal(lastPage.slots[6]?.availability, "T");
-  equal(lastPage.slots[7]?.label, "empty");
-  equal(lastPage.slots[7]?.availability, "N");
+  equal(lastPage.slots[7]?.label, "edit-grammar / branch");
+  equal(lastPage.slots[7]?.availability, "T");
 });
 
 test("renderMenu16 exposes ADR scope, history, and meta controller slots", async () => {
@@ -446,6 +452,13 @@ test("renderMenu16 exposes ADR scope, history, and meta controller slots", async
   equal(menu.slots[9]?.label, "scope in to run");
   equal(menu.slots[9]?.availability, "T");
   deepEqual(menu.slots[9]?.impl, { kind: "observe", toScope: RunScope.Run });
+  equal(menu.slots[7]?.direction, "branch.fork");
+  equal(menu.slots[7]?.label, "edit-grammar / branch");
+  equal(menu.slots[7]?.availability, "T");
+  deepEqual(menu.slots[7]?.impl, {
+    kind: "grammar_branch",
+    reason: "edit-grammar/branch selected; no side effects for this tick",
+  });
   equal(menu.slots[10]?.direction, "history.retract");
   equal(menu.slots[10]?.label, "retract");
   equal(menu.slots[10]?.availability, "F");
@@ -498,6 +511,19 @@ test("renderMenu16 exposes ADR scope, history, and meta controller slots", async
   deepEqual(restResult, {
     outcome: "rested",
     reason: "free-time/rest selected; no side effects for this tick",
+  });
+
+  const branchResult = await act(7, menu, {
+    runCommand: async () => {
+      throw new Error("edit-grammar/branch must not dispatch command side effects");
+    },
+    dispatchTool: async () => {
+      throw new Error("edit-grammar/branch must not dispatch MCP side effects");
+    },
+  });
+  deepEqual(branchResult, {
+    outcome: "grammar_branch_requested",
+    reason: "edit-grammar/branch selected; no side effects for this tick",
   });
 });
 
@@ -804,7 +830,8 @@ test("renderMenu16 keeps all-vetoed menus dark even when prompt-flow tasks exist
   equal(menu.slots[6]?.availability, "N");
   equal(menu.slots[6]?.label, "empty");
   equal(menu.slots[7]?.direction, "branch.fork");
-  equal(menu.slots[7]?.availability, "N");
+  equal(menu.slots[7]?.label, "edit-grammar / branch");
+  equal(menu.slots[7]?.availability, "T");
   equal(menu.slots[8]?.availability, "N");
 });
 
@@ -1189,8 +1216,9 @@ test("observeAgentSurface renders current hat-allowed prompt-flow tasks as conte
   equal(surface.actions.slots[6]?.availability, "T");
   equal(surface.actions.slots[6]?.label, "Implement work item");
   equal(surface.actions.slots[6]?.impl?.kind, "prompt_flow");
-  equal(surface.actions.slots[7]?.availability, "F");
-  equal(surface.actions.slots[7]?.label, "Approve review");
+  deepEqual(surface.actions.page?.promptFlows, { page: 0, pageSize: 1, pageCount: 2, total: 2 });
+  equal(surface.actions.slots[7]?.availability, "T");
+  equal(surface.actions.slots[7]?.label, "edit-grammar / branch");
 });
 
 test("observeAgentSurface shows C-suite projects with trajectories and policy violations", async () => {


### PR DESCRIPTION
## Summary
- reserves ADR slot 7 as an always-selectable edit-grammar/branch Menu16 control
- returns a typed grammar_branch_requested action without command or MCP side effects
- moves prompt-flow task overflow to slot 6 paging and updates CLI/lane evidence tests
- records the checkpoint in the Phase 2 CA plan

## Verification
- node --experimental-strip-types --test packages/application/test/observe.test.ts apps/agent-cli/test/agent-cli.test.ts
- node --experimental-strip-types --test apps/workers/test/org-cadence-lanes.test.ts
- npm run typecheck
- npm test
- git diff --check / git diff --check HEAD~2..HEAD
- KIND proof: production agent:observe against kind-agentic-org Cockroach selected slot 7 and persisted observe-act:selected_slot:7
- dotnet build -c Release is blocked locally by existing SDK pin: global.json requests 10.0.203; installed SDKs are 9.0.100, 9.0.200, 10.0.101

## Review note
- Requested subagent spec/code-quality reviews could not be spawned because the agent thread limit is currently reached.
