### PR TITLE
feat(observe): execute the pick — impure twin of simulate (free_time + self_reflect slice)

### DIFF
--- a/tools/observe/execute.test.ts
+++ b/tools/observe/execute.test.ts
@@ -54,13 +54,19 @@ describe("execute — free_time + self_reflect slice", () => {
     if (r.ok) expect(r.world).toEqual(simulate(emptyWorld, freeTime));
   });
 
-  it("returns not-yet-executable for effectful kinds (no append attempted)", async () => {
+  it("returns not-yet-executable for EVERY non-executable kind (allowlist gate — no append attempted)", async () => {
+    // All 7 currently non-executable kinds (the 9 NextAction kinds minus the 2
+    // executable ones, free_time + self_reflect). Exhaustive so a future change
+    // can't make one append without an explicit test update.
+    const item = { id: "B-1", title: "x", ready: true, ambiguous: false };
     const effectful: NextAction[] = [
-      { kind: "do_item", item: { id: "B-1", title: "x", ready: true, ambiguous: false } },
-      { kind: "respond_to_operator", reason: "op spoke" },
       { kind: "preserve_ferry", reason: "ferry" },
+      { kind: "respond_to_operator", reason: "op spoke" },
+      { kind: "do_item", item },
+      { kind: "decompose", item },
       { kind: "explore", reason: "make" },
       { kind: "play", reason: "play" },
+      { kind: "edit_grammar", reason: "needs new action", item },
     ];
     for (const action of effectful) {
       const sink = fakeSink();

--- a/tools/observe/execute.test.ts
+++ b/tools/observe/execute.test.ts
@@ -1,0 +1,96 @@
+/**
+ * tools/observe/execute.test.ts — the impure twin (free_time + self_reflect slice).
+ *
+ * Verifies: execute appends FIRST then transitions via `simulate`; the executed
+ * world is identical to the pure `simulate` path; effectful kinds are
+ * `not-yet-executable`; append failure surfaces as feedback (never throws).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { simulate, type NextAction, type World } from "./observe";
+import { execute, type AppendOutcome, type EventSink } from "./execute";
+
+/** A fake sink that records appends and replies with a fixed outcome. */
+function fakeSink(outcome: AppendOutcome = { ok: true, eventId: "evt-1" }): EventSink & { appended: NextAction[] } {
+  const appended: NextAction[] = [];
+  return {
+    appended,
+    append: (action: NextAction): Promise<AppendOutcome> => {
+      appended.push(action);
+      return Promise.resolve(outcome);
+    },
+  };
+}
+
+const emptyWorld: World = { backlog: [] };
+const freeTime: NextAction = { kind: "free_time", reason: "rest" };
+const selfReflect: NextAction = { kind: "self_reflect", reason: "journal" };
+
+describe("execute — free_time + self_reflect slice", () => {
+  it("executes free_time: appends the event then sets mode via simulate", async () => {
+    const sink = fakeSink();
+    const r = await execute(emptyWorld, freeTime, sink);
+    expect(r.ok).toBe(true);
+    expect(sink.appended).toEqual([freeTime]); // appended FIRST
+    if (r.ok) {
+      expect(r.world.mode).toBe("free_time");
+      expect(r.appended).toBe(freeTime);
+      expect(r.eventId).toBe("evt-1");
+    }
+  });
+
+  it("executes self_reflect: appends + sets mode", async () => {
+    const sink = fakeSink();
+    const r = await execute(emptyWorld, selfReflect, sink);
+    expect(r.ok).toBe(true);
+    expect(sink.appended).toEqual([selfReflect]);
+    if (r.ok) expect(r.world.mode).toBe("self_reflect");
+  });
+
+  it("executed world is IDENTICAL to the pure simulate path (single reducer)", async () => {
+    const sink = fakeSink();
+    const r = await execute(emptyWorld, freeTime, sink);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.world).toEqual(simulate(emptyWorld, freeTime));
+  });
+
+  it("returns not-yet-executable for effectful kinds (no append attempted)", async () => {
+    const effectful: NextAction[] = [
+      { kind: "do_item", item: { id: "B-1", title: "x", ready: true, ambiguous: false } },
+      { kind: "respond_to_operator", reason: "op spoke" },
+      { kind: "preserve_ferry", reason: "ferry" },
+      { kind: "explore", reason: "make" },
+      { kind: "play", reason: "play" },
+    ];
+    for (const action of effectful) {
+      const sink = fakeSink();
+      const r = await execute(emptyWorld, action, sink);
+      expect(r.ok).toBe(false);
+      expect(sink.appended).toEqual([]); // not-yet-executable → nothing appended
+      if (!r.ok) {
+        expect(r.feedback.kind).toBe("not-yet-executable");
+        if (r.feedback.kind === "not-yet-executable") expect(r.feedback.actionKind).toBe(action.kind);
+      }
+    }
+  });
+
+  it("surfaces append failure as feedback (no transition, never throws)", async () => {
+    const sink = fakeSink({ ok: false, reason: "remote ahead" });
+    const r = await execute(emptyWorld, freeTime, sink);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.feedback.kind).toBe("append-failed");
+      if (r.feedback.kind === "append-failed") {
+        expect(r.feedback.actionKind).toBe("free_time");
+        expect(r.feedback.reason).toBe("remote ahead");
+      }
+    }
+  });
+
+  it("does NOT advance the world when the append fails", async () => {
+    const sink = fakeSink({ ok: false, reason: "sink down" });
+    const r = await execute(emptyWorld, selfReflect, sink);
+    // caller keeps the prior world; execute reports failure, no mode change leaked
+    expect(r.ok).toBe(false);
+  });
+});

--- a/tools/observe/execute.ts
+++ b/tools/observe/execute.ts
@@ -34,13 +34,14 @@
  * outcome channel) so this slice is testable with a fake sink and no git I/O;
  * the real folder-direct-to-main sink is a follow-up adapter.
  *
- * Composes with:
+ * Composes with (exact paths):
  *   - tools/observe/observe.ts (simulate = the pure reducer; World / NextAction)
- *   - docs/DECISIONS/2026-05-31-zeta-database-design-…-gset-bag-zset-rx-fold-…  (the event log + materialized views)
- *   - docs/DECISIONS/2026-05-31-observe-act-16-direction-…  (the observe→act loop this completes)
- *   - docs/backlog/P2/B-0951-… (eventually-consistent git-native indexes — the read side of the same log)
- *   - .claude/rules/monad-propagation-pattern + asymmetric-authorship (Result<T, TFeedback>; the sink authors its channel)
- *   - .claude/rules/non-coercion-invariant (free_time never gated)
+ *   - docs/DECISIONS/2026-05-31-zeta-database-design-event-sourced-gset-bag-zset-rx-fold-materialized-views-two-backends.md (the event log + materialized views)
+ *   - docs/DECISIONS/2026-05-31-observe-act-16-direction-universal-action-grammar-local-no-cloud-llm.md (the observe→act loop this completes)
+ *   - docs/backlog/P2/B-0951-git-native-eventually-consistent-text-indexes-sorted-inverted-graph-plus-git-native-hindsight-storage-interface-aaron-2026-05-31.md (eventually-consistent git-native indexes — the read side of the same log)
+ *   - .claude/rules/monad-propagation-pattern-cross-language-substrate-shape.md (Result<T, TFeedback>)
+ *   - .claude/rules/asymmetric-authorship-substrate-entity-defines-consent-channel-recipient-acknowledges.md (the sink authors its outcome channel)
+ *   - .claude/rules/non-coercion-invariant.md (free_time never gated)
  */
 
 import { simulate, type NextAction, type World } from "./observe";

--- a/tools/observe/execute.ts
+++ b/tools/observe/execute.ts
@@ -1,0 +1,107 @@
+/**
+ * tools/observe/execute.ts — "execute the pick": the impure twin of `simulate`.
+ *
+ * The controller (`observe.ts`) is pure all the way down: `observe` picks,
+ * `simulate` transitions in-memory, `fold`/`replay` project the log. None of it
+ * touches the world. `execute` is the ONE effectful seam — observe.ts's own
+ * roadmap: *"Next: wire the real World snapshot + execute the pick."*
+ *
+ * ── The command/effect split (why `simulate` stays the single reducer) ────────
+ * `simulate` remains the sole source of truth for the STATE TRANSITION, so
+ * `fold`/`replay`/DST keep working unchanged. `execute` adds only what `simulate`
+ * deliberately omits:
+ *   1. the real SIDE-EFFECT for the action kind, and
+ *   2. APPENDING the chosen NextAction to the durable event log (via an injected
+ *      `EventSink` — the transport: sovereign folder-direct-to-main, or corporate
+ *      batched; see the DB-design + keystone ADRs),
+ * then it DELEGATES the in-memory transition back to `simulate` so the executed
+ * world can never drift from the pure path. `execute = effect + append + simulate`.
+ *
+ * ── Why mode-persistence needs no separate store ──────────────────────────────
+ * Per observe.ts v5 (state is a PROJECTION of the event log): the persisted
+ * `mode` is just `fold(initial, events).mode`. So "persist the chosen mode" IS
+ * "append the mode-setting NextAction to the log." No mode table — the log is it.
+ *
+ * ── This slice: free_time + self_reflect ONLY (operator 2026-05-31) ───────────
+ * These two are the zero-risk first kinds: they have NO external side-effect —
+ * executing them is purely (a) append the event + (b) set the mode via simulate.
+ * free_time is unilateral/never-gated (NCI); self_reflect is review/journal/think.
+ * Every other kind (do_item, respond_to_operator, preserve_ferry, decompose,
+ * explore, play, edit_grammar) carries a real side-effect and is returned as
+ * `not-yet-executable` until its effect is wired in a follow-up slice.
+ *
+ * The `EventSink` is INJECTED (asymmetric-authorship: the sink AUTHORS its own
+ * outcome channel) so this slice is testable with a fake sink and no git I/O;
+ * the real folder-direct-to-main sink is a follow-up adapter.
+ *
+ * Composes with:
+ *   - tools/observe/observe.ts (simulate = the pure reducer; World / NextAction)
+ *   - docs/DECISIONS/2026-05-31-zeta-database-design-…-gset-bag-zset-rx-fold-…  (the event log + materialized views)
+ *   - docs/DECISIONS/2026-05-31-observe-act-16-direction-…  (the observe→act loop this completes)
+ *   - docs/backlog/P2/B-0951-… (eventually-consistent git-native indexes — the read side of the same log)
+ *   - .claude/rules/monad-propagation-pattern + asymmetric-authorship (Result<T, TFeedback>; the sink authors its channel)
+ *   - .claude/rules/non-coercion-invariant (free_time never gated)
+ */
+
+import { simulate, type NextAction, type World } from "./observe";
+
+/** The action kinds this slice can execute (zero external side-effect: mode-set + append). */
+const EXECUTABLE_KINDS = ["free_time", "self_reflect"] as const;
+type ExecutableKind = (typeof EXECUTABLE_KINDS)[number];
+
+function isExecutableKind(kind: NextAction["kind"]): kind is ExecutableKind {
+  return (EXECUTABLE_KINDS as readonly string[]).includes(kind);
+}
+
+/**
+ * The outcome an EventSink authors when asked to append (asymmetric-authorship:
+ * the sink owns this channel — success carries the minted event id; failure
+ * carries a reason the caller surfaces, never throws).
+ */
+export type AppendOutcome =
+  | { readonly ok: true; readonly eventId: string }
+  | { readonly ok: false; readonly reason: string };
+
+/**
+ * EventSink — the injected durability port. Appends one NextAction to the
+ * append-only, ZetaId-keyed event log via whichever transport is wired
+ * (sovereign folder-direct-to-main / corporate batched). Pure interface;
+ * implementations do the I/O. Tests inject a fake.
+ */
+export interface EventSink {
+  append: (action: NextAction) => Promise<AppendOutcome>;
+}
+
+/** The execute feedback channel (asymmetric-authorship). */
+export type ExecuteFeedback =
+  | { readonly kind: "not-yet-executable"; readonly actionKind: NextAction["kind"] }
+  | { readonly kind: "append-failed"; readonly actionKind: NextAction["kind"]; readonly reason: string };
+
+/** Result of executing a pick — `ok` carries the new world + the appended event id. */
+export type ExecuteResult =
+  | { readonly ok: true; readonly world: World; readonly appended: NextAction; readonly eventId: string }
+  | { readonly ok: false; readonly feedback: ExecuteFeedback };
+
+/**
+ * Execute a chosen action: append it to the durable log, then transition the
+ * world via `simulate` (the single reducer). This slice handles `free_time` +
+ * `self_reflect`; every other kind returns `not-yet-executable`.
+ *
+ * Order matters: APPEND FIRST, then project. If the append fails, no transition
+ * is reported (the durable log stays the source of truth — we don't advance the
+ * in-memory world past an event that didn't land). Idempotency + ordering of the
+ * log itself are the sink/transport's concern (G-Set dedup by event id).
+ */
+export async function execute(world: World, action: NextAction, sink: EventSink): Promise<ExecuteResult> {
+  if (!isExecutableKind(action.kind)) {
+    return { ok: false, feedback: { kind: "not-yet-executable", actionKind: action.kind } };
+  }
+
+  const outcome = await sink.append(action);
+  if (!outcome.ok) {
+    return { ok: false, feedback: { kind: "append-failed", actionKind: action.kind, reason: outcome.reason } };
+  }
+
+  // Durable event landed → project the in-memory transition via the pure reducer.
+  return { ok: true, world: simulate(world, action), appended: action, eventId: outcome.eventId };
+}


### PR DESCRIPTION
## execute the pick — the impure twin of `simulate` (free_time + self_reflect slice)

operator: *"build the execute slice for free_time and self_reflect first."* First piece of observe.ts's roadmap **"wire the real World snapshot + execute the pick."**

The controller is pure (`observe`/`simulate`/`fold`); **`execute` is the one effectful seam.** Command/effect split:
- `simulate` stays the **single reducer** → `fold`/`replay`/DST unchanged.
- `execute` adds what simulate omits: (1) the real side-effect, (2) **append the `NextAction` to the durable log** via an injected **`EventSink`** (the transport — sovereign folder-direct-to-main / corporate batched), then (3) delegates the transition back to `simulate` so the executed world can't drift from the pure path. **`execute = effect + append + simulate`.**
- **Mode-persistence needs no store:** per v5, `mode = fold(log).mode`, so "persist the mode" *is* "append the mode-setting event."

**This slice = `free_time` + `self_reflect` only** — the zero-external-side-effect kinds (just append + set mode; `free_time` never gated, NCI). Every other kind returns `not-yet-executable` until its effect is wired in a follow-up. `EventSink` is injected (asymmetric-authorship; testable with a fake, no git I/O) — the real folder-direct-to-main adapter is the next slice.

**Append-first ordering:** if the append fails, the world does NOT advance (durable log stays source of truth). `Result<T, TFeedback>`; never throws.

Composes with the eventually-consistent git-native indexes ([B-0951](https://github.com/Lucent-Financial-Group/Zeta/blob/main/docs/backlog/P2/B-0951-git-native-eventually-consistent-text-indexes-sorted-inverted-graph-plus-git-native-hindsight-storage-interface-aaron-2026-05-31.md)) — the read side of the same log this writes to.

Verified: eslint clean, tsc 0, **6/6 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
