### PR TITLE
Wire observe-act history request slots

### DIFF
--- a/agentic-organization/apps/agent-cli/src/agent-cli.ts
+++ b/agentic-organization/apps/agent-cli/src/agent-cli.ts
@@ -738,6 +738,16 @@ function stableSlotImpl(slot: Menu16Slot): unknown {
         kind: slot.impl.kind,
         reason: slot.impl.reason,
       };
+    case "history_retract":
+      return {
+        kind: slot.impl.kind,
+        reason: slot.impl.reason,
+      };
+    case "history_redo":
+      return {
+        kind: slot.impl.kind,
+        reason: slot.impl.reason,
+      };
     case "grammar_branch":
       return {
         kind: slot.impl.kind,
@@ -1165,6 +1175,10 @@ function formatActResult(result: ActResult): string {
       return `loaded context ${result.context.taskId}`;
     case "status_report":
       return `status ${result.status.kind} ${result.status.scope} ${result.status.phase}`;
+    case "history_retract_requested":
+      return `history-retract requested ${result.reason}`;
+    case "history_redo_requested":
+      return `history-redo requested ${result.reason}`;
     case "grammar_branch_requested":
       return `grammar-branch requested ${result.reason}`;
     case "rested":

--- a/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
+++ b/agentic-organization/apps/agent-cli/test/agent-cli.test.ts
@@ -292,8 +292,8 @@ test("runAgentCliCycle renders observe output and routes the selected slot throu
   ok(stdout.join("\n").includes("[04] T commit.a execute"));
   ok(stdout.join("\n").includes("action: dispatched command"));
   equal(result.evidence?.selectedIndex, 4);
-  equal(result.evidence?.vetoCount, 3);
-  equal(result.evidence?.trueSlotCount, 8);
+  equal(result.evidence?.vetoCount, 1);
+  equal(result.evidence?.trueSlotCount, 10);
   equal(result.evidence?.metricBlockIds[0], "queue");
   ok(result.evidence?.menuHash.match(/^[0-9a-f]{64}$/));
   deepEqual(commands, [
@@ -683,6 +683,53 @@ test("runAgentCliCycle can select edit-grammar/branch without dispatching side e
   ok(stdout.join("\n").includes("[07] T branch.fork edit-grammar / branch"));
   ok(stdout.join("\n").includes("action: grammar-branch requested edit-grammar/branch selected; no side effects for this tick"));
   equal(result.evidence?.selectedIndex, 7);
+});
+
+test("runAgentCliCycle can select history retract/redo without dispatching side effects", async () => {
+  for (const [slotIndex, label, outcome, actionLine] of [
+    [10, "history.retract retract", "history_retract_requested", "action: history-retract requested history.retract selected; no ledger mutation for this tick"],
+    [11, "history.redo redo", "history_redo_requested", "action: history-redo requested history.redo selected; no ledger mutation for this tick"],
+  ] as const) {
+    const stdout: string[] = [];
+    const result = await runAgentCliCycle({
+      argv: [
+        "observe",
+        "--hat",
+        "release_operator",
+        "--hat-assignment",
+        "99",
+        "--agent",
+        "agent-release-1",
+        "--organization",
+        "org-1",
+        "--project",
+        "project-1",
+        "--work-item",
+        "work-1",
+        "--scope",
+        "work_item",
+        "--phase",
+        "awaiting_gate",
+        "--gate-approved",
+        "--select-index",
+        String(slotIndex),
+      ],
+      now: () => "2026-05-31T12:00:00.000Z",
+      writeStdout: (text) => stdout.push(text),
+      runCommand: async () => {
+        throw new Error(`${label} must not dispatch command side effects`);
+      },
+      dispatchTool: async () => {
+        throw new Error(`${label} must not dispatch MCP side effects`);
+      },
+    });
+
+    equal(result.exitCode, 0);
+    equal(result.actionResult?.outcome, outcome);
+    ok(stdout.join("\n").includes(`[${String(slotIndex).padStart(2, "0")}] T ${label}`));
+    ok(stdout.join("\n").includes(actionLine));
+    equal(result.evidence?.selectedIndex, slotIndex);
+  }
 });
 
 test("runAgentCliCycle rejects vetoed work slots while keeping all-vetoed meta controls visible", async () => {

--- a/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
+++ b/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
@@ -397,6 +397,16 @@ now pages through slot 6 (`inspect.more`) only, preserving the fixed 16-slot
 controller grammar while still giving agents access to all scoped prompt-flow
 tasks through navigation.
 
+**Checkpoint 2026-06-01: slots 10/11 history request controls**
+
+Slots 10 and 11 are now selectable ADR grammar controls instead of disabled
+placeholders. `history.retract` and `history.redo` return typed
+`history_retract_requested` and `history_redo_requested` outcomes from `act()`
+without command dispatch, MCP/tool dispatch, or ledger mutation. This makes
+agent intent visible in tick evidence while keeping the stronger retraction
+ledger, replay proof, and compensating-transaction machinery as the next
+implementation layer rather than implying undo/redo side effects already exist.
+
 **Algorithms:**
 
 - **menu stability hash:** hash slot directions, labels, availability, reasons,

--- a/agentic-organization/packages/application/src/observe.ts
+++ b/agentic-organization/packages/application/src/observe.ts
@@ -348,6 +348,8 @@ export type SlotImpl =
   | { kind: "observe"; toScope: RunScope; menuPage?: MenuPageTarget | undefined }
   | { kind: "status"; status: GlassHaloStatusSignal }
   | { kind: "prompt_flow"; request: PromptFlowContextRequest }
+  | { kind: "history_retract"; reason: string }
+  | { kind: "history_redo"; reason: string }
   | { kind: "grammar_branch"; reason: string }
   | { kind: "rest"; reason: string };
 
@@ -481,6 +483,8 @@ export type ActResult =
   | { outcome: "dispatched"; kind: "command" | "mcp"; result: unknown }
   | { outcome: "loaded_context"; context: PromptFlowContext }
   | { outcome: "status_report"; status: GlassHaloStatusSignal }
+  | { outcome: "history_retract_requested"; reason: string }
+  | { outcome: "history_redo_requested"; reason: string }
   | { outcome: "grammar_branch_requested"; reason: string }
   | { outcome: "rested"; reason: string }
   | { outcome: "reobserve"; scope: RunScope; menuPage?: MenuPageTarget | undefined }
@@ -914,8 +918,8 @@ function renderScopeSlots(rendered: Menu16Slot[], currentScope: RunScope): void 
   rendered[9] = finerScope === undefined
     ? createDisabledGrammarSlot(9, MENU16_DIRECTIONS[9]!, "scope in", "already at run scope")
     : createObserveSlot(9, MENU16_DIRECTIONS[9]!, `scope in to ${finerScope}`, finerScope);
-  rendered[10] = createDisabledGrammarSlot(10, MENU16_DIRECTIONS[10]!, "retract", "retraction is not wired for this run state");
-  rendered[11] = createDisabledGrammarSlot(11, MENU16_DIRECTIONS[11]!, "redo", "redo is not wired for this run state");
+  rendered[10] = createHistoryRetractSlot(10, MENU16_DIRECTIONS[10]!);
+  rendered[11] = createHistoryRedoSlot(11, MENU16_DIRECTIONS[11]!);
 }
 
 function renderBranchSlot(rendered: Menu16Slot[]): void {
@@ -927,6 +931,32 @@ function renderBranchSlot(rendered: Menu16Slot[]): void {
     impl: {
       kind: "grammar_branch",
       reason: "edit-grammar/branch selected; no side effects for this tick",
+    },
+  };
+}
+
+function createHistoryRetractSlot(index: number, direction: string): Menu16Slot {
+  return {
+    index,
+    direction,
+    label: "retract",
+    availability: TriAvailability.True,
+    impl: {
+      kind: "history_retract",
+      reason: "history.retract selected; no ledger mutation for this tick",
+    },
+  };
+}
+
+function createHistoryRedoSlot(index: number, direction: string): Menu16Slot {
+  return {
+    index,
+    direction,
+    label: "redo",
+    availability: TriAvailability.True,
+    impl: {
+      kind: "history_redo",
+      reason: "history.redo selected; no ledger mutation for this tick",
     },
   };
 }
@@ -1304,6 +1334,16 @@ export async function act(index: number, menu: Menu16, deps: ActDependencies): P
       return {
         outcome: "status_report",
         status: slot.impl.status,
+      };
+    case "history_retract":
+      return {
+        outcome: "history_retract_requested",
+        reason: slot.impl.reason,
+      };
+    case "history_redo":
+      return {
+        outcome: "history_redo_requested",
+        reason: slot.impl.reason,
       };
     case "grammar_branch":
       return {

--- a/agentic-organization/packages/application/test/observe.test.ts
+++ b/agentic-organization/packages/application/test/observe.test.ts
@@ -461,12 +461,18 @@ test("renderMenu16 exposes ADR scope, history, and meta controller slots", async
   });
   equal(menu.slots[10]?.direction, "history.retract");
   equal(menu.slots[10]?.label, "retract");
-  equal(menu.slots[10]?.availability, "F");
-  ok(menu.slots[10]?.reason?.includes("retraction is not wired"));
+  equal(menu.slots[10]?.availability, "T");
+  deepEqual(menu.slots[10]?.impl, {
+    kind: "history_retract",
+    reason: "history.retract selected; no ledger mutation for this tick",
+  });
   equal(menu.slots[11]?.direction, "history.redo");
   equal(menu.slots[11]?.label, "redo");
-  equal(menu.slots[11]?.availability, "F");
-  ok(menu.slots[11]?.reason?.includes("redo is not wired"));
+  equal(menu.slots[11]?.availability, "T");
+  deepEqual(menu.slots[11]?.impl, {
+    kind: "history_redo",
+    reason: "history.redo selected; no ledger mutation for this tick",
+  });
   equal(menu.slots[12]?.direction, "meta.refresh");
   equal(menu.slots[12]?.label, "refresh");
   equal(menu.slots[12]?.availability, "T");
@@ -524,6 +530,32 @@ test("renderMenu16 exposes ADR scope, history, and meta controller slots", async
   deepEqual(branchResult, {
     outcome: "grammar_branch_requested",
     reason: "edit-grammar/branch selected; no side effects for this tick",
+  });
+
+  const retractResult = await act(10, menu, {
+    runCommand: async () => {
+      throw new Error("history.retract must not dispatch command side effects");
+    },
+    dispatchTool: async () => {
+      throw new Error("history.retract must not dispatch MCP side effects");
+    },
+  });
+  deepEqual(retractResult, {
+    outcome: "history_retract_requested",
+    reason: "history.retract selected; no ledger mutation for this tick",
+  });
+
+  const redoResult = await act(11, menu, {
+    runCommand: async () => {
+      throw new Error("history.redo must not dispatch command side effects");
+    },
+    dispatchTool: async () => {
+      throw new Error("history.redo must not dispatch MCP side effects");
+    },
+  });
+  deepEqual(redoResult, {
+    outcome: "history_redo_requested",
+    reason: "history.redo selected; no ledger mutation for this tick",
   });
 });
 


### PR DESCRIPTION
## Summary
- makes Menu16 slots 10/11 selectable `history.retract` and `history.redo` request controls
- returns typed no-side-effect `history_retract_requested` and `history_redo_requested` outcomes from `act()`
- updates CLI stable menu hashing, action formatting, and tests for history request selection
- records the checkpoint in the Phase 2 CA plan

## Verification
- node --experimental-strip-types --test packages/application/test/observe.test.ts apps/agent-cli/test/agent-cli.test.ts
- npm run typecheck
- npm test
- git diff --check
- KIND proof: production `agent:observe` against kind-agentic-org Cockroach selected slots 10 and 11 and persisted `observe-act:selected_slot:10` / `observe-act:selected_slot:11`
- dotnet build -c Release is blocked locally by existing SDK pin: global.json requests 10.0.203; installed SDKs are 9.0.100, 9.0.200, 10.0.101

## Review note
- Requested subagent review could not be spawned because the agent thread limit is currently reached.
