### PR TITLE
feat(observe): real EventSink — folder-direct-to-main adapter (sovereign transport)

### DIFF
--- a/tools/observe/event-sink-folder.test.ts
+++ b/tools/observe/event-sink-folder.test.ts
@@ -35,28 +35,35 @@ afterEach(() => {
 
 const freeTime: NextAction = { kind: "free_time", reason: "rest" };
 
+// Canonical 32-lowercase-hex ids (the only shape the sink accepts as a path segment).
+const ID_A = "a".repeat(32);
+const ID_DUP = "d".repeat(32);
+const ID_CLASH = "c".repeat(32);
+const ID_FAILC = "e".repeat(32);
+const ID_WRITEF = "f".repeat(32);
+
 describe("folderSink — write the fact envelope + commit", () => {
   it("writes <eventDir>/<id>.json and commits it; returns ok + eventId", async () => {
-    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => "abc123", now: () => FIXED, commit: okCommit });
+    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => ID_A, now: () => FIXED, commit: okCommit });
     const r = await sink.append(freeTime);
     expect(r.ok).toBe(true);
-    if (r.ok) expect(r.eventId).toBe("abc123");
+    if (r.ok) expect(r.eventId).toBe(ID_A);
     expect(committed).toHaveLength(1);
-    expect(committed[0]?.path).toBe(join(dir, "abc123.json"));
+    expect(committed[0]?.path).toBe(join(dir, `${ID_A}.json`));
 
-    const env = JSON.parse(readFileSync(join(dir, "abc123.json"), "utf-8")) as EventEnvelope;
-    expect(env).toEqual({ id: "abc123", at: "2026-05-31T12:00:00.000Z", by: "otto-cli", action: freeTime });
+    const env = JSON.parse(readFileSync(join(dir, `${ID_A}.json`), "utf-8")) as EventEnvelope;
+    expect(env).toEqual({ id: ID_A, at: "2026-05-31T12:00:00.000Z", by: "otto-cli", action: freeTime });
   });
 
   it("is idempotent: same id + same content appended twice → both ok (EEXIST no-op, G-Set)", async () => {
-    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => "dup", now: () => FIXED, commit: okCommit });
+    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => ID_DUP, now: () => FIXED, commit: okCommit });
     const a = await sink.append(freeTime);
     const b = await sink.append(freeTime);
     expect(a.ok && b.ok).toBe(true);
   });
 
   it("rejects a same-id collision with DIFFERENT content (not a silent no-op)", async () => {
-    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => "clash", now: () => FIXED, commit: okCommit });
+    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => ID_CLASH, now: () => FIXED, commit: okCommit });
     const first = await sink.append(freeTime);
     const second = await sink.append({ kind: "self_reflect", reason: "different action, same id" });
     expect(first.ok).toBe(true);
@@ -64,16 +71,25 @@ describe("folderSink — write the fact envelope + commit", () => {
     if (!second.ok) expect(second.reason).toContain("collision");
   });
 
+  it("rejects a non-canonical id (path-traversal / reserved-name guard; never writes outside)", async () => {
+    for (const evil of ["../outside", "con", "not-hex", "AAAA", "a".repeat(31)]) {
+      const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => evil, now: () => FIXED, commit: okCommit });
+      const r = await sink.append(freeTime);
+      expect(r.ok).toBe(false);
+      expect(committed).toHaveLength(0); // never wrote, never committed
+    }
+  });
+
   it("surfaces a commit failure as ok:false (never throws)", async () => {
     const failCommit = (): CommitOutcome => ({ ok: false, reason: "not on main" });
-    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => "x", now: () => FIXED, commit: failCommit });
+    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => ID_FAILC, now: () => FIXED, commit: failCommit });
     const r = await sink.append(freeTime);
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("not on main");
   });
 
   it("surfaces a write failure as ok:false (unwritable dir, never throws)", async () => {
-    const sink = folderSink({ eventDir: "/dev/null/cannot-create", by: "otto-cli", mint: () => "y", now: () => FIXED, commit: okCommit });
+    const sink = folderSink({ eventDir: "/dev/null/cannot-create", by: "otto-cli", mint: () => ID_WRITEF, now: () => FIXED, commit: okCommit });
     const r = await sink.append(freeTime);
     expect(r.ok).toBe(false);
     expect(committed).toHaveLength(0); // never reached commit
@@ -95,16 +111,17 @@ describe("mintObserveEventIdHex — stable WorkItem-category identity", () => {
 describe("folderSink composes with execute (the real adapter end-to-end)", () => {
   it("execute(free_time, folderSink) appends the event + transitions mode", async () => {
     const world: World = { backlog: [] };
-    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => "evt", now: () => FIXED, commit: okCommit });
+    const ID_EXEC = "b".repeat(32);
+    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => ID_EXEC, now: () => FIXED, commit: okCommit });
     const r = await execute(world, freeTime, sink);
     expect(r.ok).toBe(true);
     if (r.ok) {
       expect(r.world.mode).toBe("free_time");
-      expect(r.eventId).toBe("evt");
+      expect(r.eventId).toBe(ID_EXEC);
     }
     // the durable event landed (one file, one commit)
     expect(committed).toHaveLength(1);
-    const env = JSON.parse(readFileSync(join(dir, "evt.json"), "utf-8")) as EventEnvelope;
+    const env = JSON.parse(readFileSync(join(dir, `${ID_EXEC}.json`), "utf-8")) as EventEnvelope;
     expect(env.action).toEqual(freeTime);
   });
 });

--- a/tools/observe/event-sink-folder.test.ts
+++ b/tools/observe/event-sink-folder.test.ts
@@ -94,6 +94,13 @@ describe("folderSink — write the fact envelope + commit", () => {
     expect(r.ok).toBe(false);
     expect(committed).toHaveLength(0); // never reached commit
   });
+
+  it("converts an injected throw (now()=NaN) to ok:false, never throws (Result-only contract)", async () => {
+    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => ID_A, now: () => Number.NaN, commit: okCommit });
+    const r = await sink.append(freeTime); // new Date(NaN).toISOString() throws inside append
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain("append failed");
+  });
 });
 
 describe("mintObserveEventIdHex — stable WorkItem-category identity", () => {
@@ -134,6 +141,9 @@ describe("coauthorFor — harness-specific trailer from the acting agent (shared
     expect(coauthorFor("vera-codex")).toBe("Co-Authored-By: Codex <noreply@openai.com>");
     expect(coauthorFor("lior-antigravity")).toBe("Co-Authored-By: Gemini <noreply@google.com>");
     expect(coauthorFor("addison")).toBe("Co-Authored-By: addison <noreply@zeta.local>");
+    // bare-prefix near-misses must NOT be mis-stamped (exact-or-hyphen only)
+    expect(coauthorFor("ottobot")).toBe("Co-Authored-By: ottobot <noreply@zeta.local>");
+    expect(coauthorFor("liorx")).toBe("Co-Authored-By: liorx <noreply@zeta.local>");
   });
 });
 

--- a/tools/observe/event-sink-folder.test.ts
+++ b/tools/observe/event-sink-folder.test.ts
@@ -97,6 +97,29 @@ describe("folderSink — write the fact envelope + commit", () => {
     expect(committed).toHaveLength(0); // never reached commit
   });
 
+  it("does NOT delete a pre-existing durable event when a later append's commit fails (G-Set P0)", async () => {
+    const ID_DUR = "1".repeat(32);
+    // 1) land the event durably (commit ok)
+    await folderSink({ eventDir: dir, by: "otto-cli", mint: () => ID_DUR, now: () => FIXED, commit: okCommit }).append(freeTime);
+    expect(existsSync(join(dir, `${ID_DUR}.json`))).toBe(true);
+    // 2) a second append of the SAME id whose commit fails must NOT delete the pre-existing file
+    const failCommit = (): CommitOutcome => ({ ok: false, reason: "not on main" });
+    const r = await folderSink({ eventDir: dir, by: "otto-cli", mint: () => ID_DUR, now: () => FIXED, commit: failCommit }).append(freeTime);
+    expect(r.ok).toBe(false);
+    expect(existsSync(join(dir, `${ID_DUR}.json`))).toBe(true); // durable event preserved
+  });
+
+  it("a THROWING injected commit → ok:false AND removes the file we created (P1)", async () => {
+    const ID_THROW = "2".repeat(32);
+    const throwCommit = (): CommitOutcome => {
+      throw new Error("boom");
+    };
+    const r = await folderSink({ eventDir: dir, by: "otto-cli", mint: () => ID_THROW, now: () => FIXED, commit: throwCommit }).append(freeTime);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain("append failed");
+    expect(existsSync(join(dir, `${ID_THROW}.json`))).toBe(false); // our half-written file cleaned up
+  });
+
   it("converts an injected throw (now()=NaN) to ok:false, never throws (Result-only contract)", async () => {
     const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => ID_A, now: () => Number.NaN, commit: okCommit });
     const r = await sink.append(freeTime); // new Date(NaN).toISOString() throws inside append

--- a/tools/observe/event-sink-folder.test.ts
+++ b/tools/observe/event-sink-folder.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { unpack } from "../../src/Core.TypeScript/zeta-id/zeta-id";
@@ -86,6 +86,8 @@ describe("folderSink — write the fact envelope + commit", () => {
     const r = await sink.append(freeTime);
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("not on main");
+    // the event did NOT land → the written file is removed (not left for loadWorld to half-read)
+    expect(existsSync(join(dir, `${ID_FAILC}.json`))).toBe(false);
   });
 
   it("surfaces a write failure as ok:false (unwritable dir, never throws)", async () => {

--- a/tools/observe/event-sink-folder.test.ts
+++ b/tools/observe/event-sink-folder.test.ts
@@ -1,0 +1,107 @@
+/**
+ * tools/observe/event-sink-folder.test.ts — the real folder-direct-to-main sink.
+ *
+ * No real git: `commit` is injected with a fake. Writes go to a real temp dir.
+ * Verifies the fact envelope shape + ZetaId identity (Category.WorkItem) +
+ * idempotency (EEXIST = ok, G-Set) + Result discipline (write/commit failure →
+ * ok:false, never throws) + composition with `execute`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { unpack } from "../../src/Core.TypeScript/zeta-id/zeta-id";
+import { Category, type ZetaId } from "../../src/Core.TypeScript/zeta-id/types";
+import { execute } from "./execute";
+import { folderSink, gitCommitToMain, mintObserveEventIdHex, type CommitOutcome, type EventEnvelope } from "./event-sink-folder";
+import type { NextAction, World } from "./observe";
+
+let dir: string;
+let committed: { path: string; envelope: EventEnvelope }[];
+const okCommit = (path: string, envelope: EventEnvelope): CommitOutcome => {
+  committed.push({ path, envelope });
+  return { ok: true };
+};
+const FIXED = Date.UTC(2026, 4, 31, 12, 0, 0); // 2026-05-31T12:00:00.000Z
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "observe-events-"));
+  committed = [];
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const freeTime: NextAction = { kind: "free_time", reason: "rest" };
+
+describe("folderSink — write the fact envelope + commit", () => {
+  it("writes <eventDir>/<id>.json and commits it; returns ok + eventId", async () => {
+    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => "abc123", now: () => FIXED, commit: okCommit });
+    const r = await sink.append(freeTime);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.eventId).toBe("abc123");
+    expect(committed).toHaveLength(1);
+    expect(committed[0]?.path).toBe(join(dir, "abc123.json"));
+
+    const env = JSON.parse(readFileSync(join(dir, "abc123.json"), "utf-8")) as EventEnvelope;
+    expect(env).toEqual({ id: "abc123", at: "2026-05-31T12:00:00.000Z", by: "otto-cli", action: freeTime });
+  });
+
+  it("is idempotent: same id appended twice → both ok (EEXIST is a no-op, G-Set)", async () => {
+    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => "dup", now: () => FIXED, commit: okCommit });
+    const a = await sink.append(freeTime);
+    const b = await sink.append(freeTime);
+    expect(a.ok && b.ok).toBe(true);
+  });
+
+  it("surfaces a commit failure as ok:false (never throws)", async () => {
+    const failCommit = (): CommitOutcome => ({ ok: false, reason: "not on main" });
+    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => "x", now: () => FIXED, commit: failCommit });
+    const r = await sink.append(freeTime);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("not on main");
+  });
+
+  it("surfaces a write failure as ok:false (unwritable dir, never throws)", async () => {
+    const sink = folderSink({ eventDir: "/dev/null/cannot-create", by: "otto-cli", mint: () => "y", now: () => FIXED, commit: okCommit });
+    const r = await sink.append(freeTime);
+    expect(r.ok).toBe(false);
+    expect(committed).toHaveLength(0); // never reached commit
+  });
+});
+
+describe("mintObserveEventIdHex — stable WorkItem-category identity", () => {
+  it("mints a 32-hex id tagged Category.WorkItem", () => {
+    const id = mintObserveEventIdHex();
+    expect(id).toMatch(/^[0-9a-f]{32}$/);
+    expect(unpack(BigInt(`0x${id}`) as ZetaId).category).toBe(Category.WorkItem);
+  });
+
+  it("two mints are distinct (crypto env)", () => {
+    expect(mintObserveEventIdHex()).not.toBe(mintObserveEventIdHex());
+  });
+});
+
+describe("folderSink composes with execute (the real adapter end-to-end)", () => {
+  it("execute(free_time, folderSink) appends the event + transitions mode", async () => {
+    const world: World = { backlog: [] };
+    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => "evt", now: () => FIXED, commit: okCommit });
+    const r = await execute(world, freeTime, sink);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.world.mode).toBe("free_time");
+      expect(r.eventId).toBe("evt");
+    }
+    // the durable event landed (one file, one commit)
+    expect(committed).toHaveLength(1);
+    const env = JSON.parse(readFileSync(join(dir, "evt.json"), "utf-8")) as EventEnvelope;
+    expect(env.action).toEqual(freeTime);
+  });
+});
+
+describe("gitCommitToMain — exported (real default; not run here)", () => {
+  it("is a function (real git path is exercised by the runtime, not unit tests)", () => {
+    expect(typeof gitCommitToMain).toBe("function");
+  });
+});

--- a/tools/observe/event-sink-folder.test.ts
+++ b/tools/observe/event-sink-folder.test.ts
@@ -14,7 +14,7 @@ import { join } from "node:path";
 import { unpack } from "../../src/Core.TypeScript/zeta-id/zeta-id";
 import { Category, type ZetaId } from "../../src/Core.TypeScript/zeta-id/types";
 import { execute } from "./execute";
-import { folderSink, gitCommitToMain, mintObserveEventIdHex, type CommitOutcome, type EventEnvelope } from "./event-sink-folder";
+import { coauthorFor, folderSink, gitCommitToMain, mintObserveEventIdHex, type CommitOutcome, type EventEnvelope } from "./event-sink-folder";
 import type { NextAction, World } from "./observe";
 
 let dir: string;
@@ -48,11 +48,20 @@ describe("folderSink — write the fact envelope + commit", () => {
     expect(env).toEqual({ id: "abc123", at: "2026-05-31T12:00:00.000Z", by: "otto-cli", action: freeTime });
   });
 
-  it("is idempotent: same id appended twice → both ok (EEXIST is a no-op, G-Set)", async () => {
+  it("is idempotent: same id + same content appended twice → both ok (EEXIST no-op, G-Set)", async () => {
     const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => "dup", now: () => FIXED, commit: okCommit });
     const a = await sink.append(freeTime);
     const b = await sink.append(freeTime);
     expect(a.ok && b.ok).toBe(true);
+  });
+
+  it("rejects a same-id collision with DIFFERENT content (not a silent no-op)", async () => {
+    const sink = folderSink({ eventDir: dir, by: "otto-cli", mint: () => "clash", now: () => FIXED, commit: okCommit });
+    const first = await sink.append(freeTime);
+    const second = await sink.append({ kind: "self_reflect", reason: "different action, same id" });
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.reason).toContain("collision");
   });
 
   it("surfaces a commit failure as ok:false (never throws)", async () => {
@@ -97,6 +106,17 @@ describe("folderSink composes with execute (the real adapter end-to-end)", () =>
     expect(committed).toHaveLength(1);
     const env = JSON.parse(readFileSync(join(dir, "evt.json"), "utf-8")) as EventEnvelope;
     expect(env.action).toEqual(freeTime);
+  });
+});
+
+describe("coauthorFor — harness-specific trailer from the acting agent (shared sink)", () => {
+  it("maps each surface to its trailer; falls back to naming the sender", () => {
+    expect(coauthorFor("otto-cli")).toBe("Co-Authored-By: Claude <noreply@anthropic.com>");
+    expect(coauthorFor("alexa-kiro")).toBe("Co-Authored-By: Kiro <noreply@kiro.dev>");
+    expect(coauthorFor("riven-cursor")).toBe("Co-Authored-By: Grok <noreply@x.ai>");
+    expect(coauthorFor("vera-codex")).toBe("Co-Authored-By: Codex <noreply@openai.com>");
+    expect(coauthorFor("lior-antigravity")).toBe("Co-Authored-By: Gemini <noreply@google.com>");
+    expect(coauthorFor("addison")).toBe("Co-Authored-By: addison <noreply@zeta.local>");
   });
 });
 

--- a/tools/observe/event-sink-folder.ts
+++ b/tools/observe/event-sink-folder.ts
@@ -178,8 +178,39 @@ export function coauthorFor(by: string): string {
  * DATA not code), push `HEAD:main` with rebase-retry (disjoint ZetaId files →
  * G-Set union, never a real conflict). Returns a CommitOutcome; never throws.
  */
+type GitRun = (args: readonly string[]) => string;
+
+/**
+ * Push HEAD:main with rebase-retry. A concurrent peer advancing main rejects the push
+ * non-fast-forward, but disjoint ZetaId files (G-Set CRDT) never conflict → `pull --rebase
+ * --autostash` (tolerates a dirty checkout) + retry. On exhausted/failed rebase, `undoLocalCommit`
+ * leaves no local residue. Extracted from gitCommitToMain to keep each function's complexity bounded.
+ */
+function pushWithRebaseRetry(run: GitRun, undoLocalCommit: () => void): CommitOutcome {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      run(["push", "origin", "HEAD:main"]);
+      return { ok: true };
+    } catch {
+      try {
+        run(["pull", "--rebase", "--autostash", "origin", "main"]);
+      } catch {
+        try {
+          run(["rebase", "--abort"]);
+        } catch {
+          /* no rebase in progress to abort — fine */
+        }
+        undoLocalCommit();
+        return { ok: false, reason: "push rejected and rebase failed (peer contention); local commit undone" };
+      }
+    }
+  }
+  undoLocalCommit();
+  return { ok: false, reason: "push failed after 3 rebase-retry attempts; local commit undone" };
+}
+
 export function gitCommitToMain(filePath: string, envelope: EventEnvelope): CommitOutcome {
-  const run = (args: readonly string[]): string =>
+  const run: GitRun = (args) =>
     // eslint-disable-next-line sonarjs/no-os-command-from-path
     execFileSync("git", [...args], { encoding: "utf-8" }).trim();
   const gitPath = filePath.replaceAll("\\", "/");
@@ -228,33 +259,7 @@ export function gitCommitToMain(filePath: string, envelope: EventEnvelope): Comm
         /* nothing to undo — fine */
       }
     };
-    for (let attempt = 0; attempt < 3; attempt++) {
-      try {
-        run(["push", "origin", "HEAD:main"]);
-        return { ok: true };
-      } catch {
-        try {
-          // --autostash: an agent may have unrelated unstaged tracked edits in the shared main
-          // checkout; without it the rebase refuses on a dirty tree. autostash stashes them, replays
-          // our disjoint event, and pops them back — peer contention resolves even on a dirty checkout
-          // (Codex #6312). Our event is a disjoint ZetaId file, so the pop never conflicts with it.
-          run(["pull", "--rebase", "--autostash", "origin", "main"]);
-        } catch {
-          // Leave the checkout clean: abort the in-progress rebase + undo our local commit
-          // (best-effort) so neither a dangling rebase nor an ahead local main blocks the next
-          // append. Result-only contract: a failed append leaves no local residue (Codex #6312 P2).
-          try {
-            run(["rebase", "--abort"]);
-          } catch {
-            /* no rebase in progress to abort — fine */
-          }
-          undoLocalCommit();
-          return { ok: false, reason: "push rejected and rebase failed (peer contention); local commit undone" };
-        }
-      }
-    }
-    undoLocalCommit();
-    return { ok: false, reason: "push failed after 3 rebase-retry attempts; local commit undone" };
+    return pushWithRebaseRetry(run, undoLocalCommit);
   } catch (err) {
     // If `git commit` itself failed AFTER `git add` (e.g. missing git identity, a commit hook),
     // our path is left STAGED; append's rmSync would then remove the worktree file but leave a

--- a/tools/observe/event-sink-folder.ts
+++ b/tools/observe/event-sink-folder.ts
@@ -116,12 +116,18 @@ export interface FolderSinkOptions {
  * file exists — but for a G-Set the same id means the same event already landed,
  * so EEXIST is idempotent SUCCESS, not an error.
  */
-function writeEventFile(envelope: EventEnvelope, eventDir: string): { ok: true; path: string } | { ok: false; reason: string } {
+// `created` distinguishes a file WE wrote this append (safe to clean up on failure) from a
+// pre-existing durable event found via EEXIST-replay (must NEVER be deleted — that would drop a
+// landed G-Set event, Copilot #6312 P0).
+function writeEventFile(
+  envelope: EventEnvelope,
+  eventDir: string,
+): { ok: true; path: string; created: boolean } | { ok: false; reason: string } {
   const path = join(eventDir, `${envelope.id}.json`);
   try {
     mkdirSync(eventDir, { recursive: true });
     writeFileSync(path, `${JSON.stringify(envelope, null, 2)}\n`, { flag: "wx" });
-    return { ok: true, path };
+    return { ok: true, path, created: true }; // WE created it → ours to clean up on failure
   } catch (err) {
     const e = err as NodeJS.ErrnoException;
     if (e.code === "EEXIST") {
@@ -130,7 +136,7 @@ function writeEventFile(envelope: EventEnvelope, eventDir: string): { ok: true; 
       // real collision — surface it, never silently accept stale (Codex #6312 P2).
       try {
         const existing = readFileSync(path, "utf-8");
-        if (existing === `${JSON.stringify(envelope, null, 2)}\n`) return { ok: true, path };
+        if (existing === `${JSON.stringify(envelope, null, 2)}\n`) return { ok: true, path, created: false }; // pre-existing → do NOT delete
         return { ok: false, reason: `id collision: ${envelope.id} already exists with different content` };
       } catch (readErr) {
         return { ok: false, reason: `EEXIST but re-read failed: ${(readErr as Error).message}` };
@@ -254,6 +260,16 @@ export function gitCommitToMain(filePath: string, envelope: EventEnvelope): Comm
   }
 }
 
+/** Best-effort remove a file WE created this append (null = we created nothing → nothing to remove). */
+function removeOurFile(path: string | null): void {
+  if (path === null) return;
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    /* already gone (e.g. undo removed it) — fine */
+  }
+}
+
 /**
  * The real folder-direct-to-main EventSink. `append` mints a ZetaId, builds the
  * fact envelope, atomically writes `<eventDir>/<id>.json`, and commits it to main.
@@ -265,9 +281,12 @@ export function folderSink(opts: FolderSinkOptions): EventSink {
   const commit = opts.commit ?? gitCommitToMain;
   return {
     append: (action: NextAction): Promise<AppendOutcome> => {
-      // Wrap the whole body: the injected `mint` / `now` / `commit` could throw (e.g. a now()
-      // returning NaN makes toISOString() throw), but the documented contract is Result-only —
-      // convert ANY throw to { ok: false } like the rest of the adapter (Copilot #6312 P1).
+      // `ourFile` is set ONLY to a file WE created this append — so failure-cleanup removes our own
+      // residue but NEVER a pre-existing durable event found via EEXIST-replay (Copilot #6312 P0).
+      let ourFile: string | null = null;
+      // Wrap the whole body: the injected `mint` / `now` / `commit` could throw (e.g. now()=NaN
+      // makes toISOString() throw, or commit() throws). The documented contract is Result-only —
+      // ANY throw converts to { ok: false } AND still cleans up our own file (Copilot #6312 P1).
       try {
         const id = mint();
         // `mint` is injectable + FolderSinkOptions is exported, so a caller could return a
@@ -281,20 +300,17 @@ export function folderSink(opts: FolderSinkOptions): EventSink {
         const envelope: EventEnvelope = { id, at, by: opts.by, action };
         const written = writeEventFile(envelope, opts.eventDir);
         if (!written.ok) return Promise.resolve({ ok: false, reason: written.reason });
+        if (written.created) ourFile = written.path; // only OUR new file is ours to clean up
         const committed = commit(written.path, envelope);
         if (!committed.ok) {
-          // The append failed → the event did NOT land. Remove the written file so it can't be
-          // half-read by loadWorld (which reads the folder), regardless of whether the failure was
-          // pre-commit (file written, never committed) or post-commit (commit undone) (Codex #6312).
-          try {
-            rmSync(written.path, { force: true });
-          } catch {
-            /* file already gone (e.g. undo removed it) — fine */
-          }
+          removeOurFile(ourFile); // pre-existing durable events are NOT touched (created === false)
           return Promise.resolve({ ok: false, reason: committed.reason });
         }
         return Promise.resolve({ ok: true, eventId: id });
       } catch (err) {
+        // A throw (e.g. from an injected commit) must route through the SAME cleanup, so a failed
+        // append never leaves a half-written file we created (Copilot #6312 P1).
+        removeOurFile(ourFile);
         return Promise.resolve({ ok: false, reason: `append failed: ${(err as Error).message}` });
       }
     },

--- a/tools/observe/event-sink-folder.ts
+++ b/tools/observe/event-sink-folder.ts
@@ -9,16 +9,16 @@
  * B-0954). Corporate batch-to-main (B-0890) is the same event shape behind a
  * different commit fn — swap `commit`, not the envelope.
  *
- * ── Fact, not command (Amara 2026-05-31) ─────────────────────────────────────
+ * ── Fact, not command (per the design review) ────────────────────────────────
  * Replay must fold FACTS, not redo COMMANDS. So the durable record is an
  * `EventEnvelope` — `{ id, at, by, action }` — a fact ("at t, actor X recorded
- * this action"), carrying a **stable ZetaId identity** (Amara caution #2) so the
+ * this action"), carrying a **stable ZetaId identity** (design-review caution #2) so the
  * log is idempotent (the filename IS the id; re-appending the same id is a
  * no-op — the G-Set CRDT property). The richer executed-event envelope
  * (ActionExecutionStarted/Succeeded/Failed/ModeChanged) is the next refinement;
  * this slice logs the chosen action as the fact, with identity + actor + time.
  *
- * ── Conflict discipline (Amara cautions #5/#6) ───────────────────────────────
+ * ── Conflict discipline (design-review cautions #5/#6) ───────────────────────
  * Direct-to-main is safe here for the same reason the bus is: events are
  * **disjoint ZetaId files** — two agents appending never touch the same path, so
  * a concurrent peer advancing `main` only causes a non-fast-forward push, which
@@ -80,6 +80,11 @@ export function mintObserveEventIdHex(env: SimulationEnvironment = DEFAULT_ENV, 
     location: LocationHint.EastUS_VA1,
   };
   return pack(obs, env).toString(16).padStart(32, "0");
+}
+
+/** A canonical observe-event id is 32 lowercase hex chars (mintObserveEventIdHex output). */
+export function isCanonicalEventId(id: string): boolean {
+  return /^[0-9a-f]{32}$/.test(id);
 }
 
 /** The durable FACT: a recorded action with stable identity + actor + time. */
@@ -175,6 +180,17 @@ export function gitCommitToMain(filePath: string, envelope: EventEnvelope): Comm
       return { ok: false, reason: `local main is ${ahead} commit(s) ahead of origin/main; reconcile before appending events` };
     }
     run(["add", gitPath]);
+    // Idempotent re-append: if the file is already committed + unchanged, `git add` stages
+    // nothing, so `git commit` would fail ("nothing to commit"). That's a no-op, not an error —
+    // return ok (the event already landed durably). `git diff --cached --quiet` exits 0 when
+    // nothing is staged (Copilot #6312 — re-append of an already-landed event must be idempotent ok).
+    let staged = false;
+    try {
+      run(["diff", "--cached", "--quiet", "--", gitPath]);
+    } catch {
+      staged = true; // non-zero exit = staged changes present
+    }
+    if (!staged) return { ok: true };
     const msg = [
       `observe(${envelope.by}): ${envelope.action.kind} ${gitPath}`,
       "",
@@ -221,6 +237,13 @@ export function folderSink(opts: FolderSinkOptions): EventSink {
   return {
     append: (action: NextAction): Promise<AppendOutcome> => {
       const id = mint();
+      // `mint` is injectable + FolderSinkOptions is exported, so a caller could return a
+      // path-traversal segment ("../outside") or a Windows-reserved name. The id is used as a
+      // path segment — reject anything but a canonical 32-hex ZetaId before joining a path
+      // (the bus guards its segments the same way). Security-relevant (Copilot #6312 P1).
+      if (!isCanonicalEventId(id)) {
+        return Promise.resolve({ ok: false, reason: `non-canonical event id (expected 32 lowercase hex): '${id}'` });
+      }
       const envelope: EventEnvelope = { id, at: new Date(now()).toISOString(), by: opts.by, action };
       const written = writeEventFile(envelope, opts.eventDir);
       if (!written.ok) return Promise.resolve({ ok: false, reason: written.reason });

--- a/tools/observe/event-sink-folder.ts
+++ b/tools/observe/event-sink-folder.ts
@@ -228,7 +228,11 @@ export function gitCommitToMain(filePath: string, envelope: EventEnvelope): Comm
         return { ok: true };
       } catch {
         try {
-          run(["pull", "--rebase", "origin", "main"]);
+          // --autostash: an agent may have unrelated unstaged tracked edits in the shared main
+          // checkout; without it the rebase refuses on a dirty tree. autostash stashes them, replays
+          // our disjoint event, and pops them back — peer contention resolves even on a dirty checkout
+          // (Codex #6312). Our event is a disjoint ZetaId file, so the pop never conflicts with it.
+          run(["pull", "--rebase", "--autostash", "origin", "main"]);
         } catch {
           // Leave the checkout clean: abort the in-progress rebase + undo our local commit
           // (best-effort) so neither a dangling rebase nor an ahead local main blocks the next

--- a/tools/observe/event-sink-folder.ts
+++ b/tools/observe/event-sink-folder.ts
@@ -1,0 +1,196 @@
+/**
+ * tools/observe/event-sink-folder.ts — the real EventSink: folder-direct-to-main.
+ *
+ * The sovereign transport for `execute` (per the observe-act + DB-design + keystone
+ * ADRs). Where `execute.ts` defines the `EventSink` port (append a chosen action to
+ * the durable log), THIS is the production adapter: it writes the event as a
+ * ZetaId-named JSON file into a git folder and commits it **direct to `main`,
+ * no-PR** (B-0890.1 folders-on-main; same mechanism as the agent-bus G-Set,
+ * B-0954). Corporate batch-to-main (B-0890) is the same event shape behind a
+ * different commit fn — swap `commit`, not the envelope.
+ *
+ * ── Fact, not command (Amara 2026-05-31) ─────────────────────────────────────
+ * Replay must fold FACTS, not redo COMMANDS. So the durable record is an
+ * `EventEnvelope` — `{ id, at, by, action }` — a fact ("at t, actor X recorded
+ * this action"), carrying a **stable ZetaId identity** (Amara caution #2) so the
+ * log is idempotent (the filename IS the id; re-appending the same id is a
+ * no-op — the G-Set CRDT property). The richer executed-event envelope
+ * (ActionExecutionStarted/Succeeded/Failed/ModeChanged) is the next refinement;
+ * this slice logs the chosen action as the fact, with identity + actor + time.
+ *
+ * ── Conflict discipline (Amara cautions #5/#6) ───────────────────────────────
+ * Direct-to-main is safe here for the same reason the bus is: events are
+ * **disjoint ZetaId files** — two agents appending never touch the same path, so
+ * a concurrent peer advancing `main` only causes a non-fast-forward push, which
+ * `git pull --rebase` + retry resolves cleanly (G-Set merge = set union). The
+ * on-main guard + ahead-check (mirrored from the bus) prevent shoving unrelated
+ * local commits to main.
+ *
+ * ── Never throws (Result discipline) ─────────────────────────────────────────
+ * Every failure (not-on-main, local-ahead, write error, push failure) becomes an
+ * `AppendOutcome { ok: false; reason }` — the sink AUTHORS its outcome channel
+ * (asymmetric-authorship); the caller (`execute`) surfaces it as feedback.
+ *
+ * I/O is injectable (`mint` / `now` / `commit`) so the whole adapter is testable
+ * with no real git and a temp dir.
+ *
+ * Composes with:
+ *   - tools/observe/execute.ts (the EventSink port this implements)
+ *   - tools/observe/observe.ts (NextAction — the action recorded)
+ *   - tools/agent-bus/publish.ts (the proven atomic-write + git-direct-to-main pattern this mirrors)
+ *   - src/Core.TypeScript/zeta-id (the ZetaId codec — Category.WorkItem ids)
+ *   - docs/DECISIONS/2026-05-31-observe-act-16-direction-universal-action-grammar-local-no-cloud-llm.md
+ *   - docs/backlog/P1/B-0890.1-fast-lane-as-folders-on-main-not-branches-supersedes-coordinator-complexity-per-operator-2026-05-28-zeta-native-branch-protection.md
+ *   - docs/backlog/P2/B-0951-git-native-eventually-consistent-text-indexes-sorted-inverted-graph-plus-git-native-hindsight-storage-interface-aaron-2026-05-31.md (the read side: indexes over this log)
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pack, DEFAULT_ENV, type SimulationEnvironment } from "../../src/Core.TypeScript/zeta-id/zeta-id";
+import {
+  Category,
+  IdVersion,
+  Chromosome,
+  Firefly,
+  Persona,
+  LocationHint,
+  type ZetaObservation,
+  type Milliseconds,
+} from "../../src/Core.TypeScript/zeta-id/types";
+import type { AppendOutcome, EventSink } from "./execute";
+import type { NextAction } from "./observe";
+
+/**
+ * Mint a WorkItem-category ZetaId as 32-hex — the observe-event identity.
+ * `DEFAULT_ENV` (crypto randomness) makes each call unique; pass a deterministic
+ * env in tests for reproducible ids. Mirrors the bus minter but tags the id
+ * `Category.WorkItem` (planning/workflow), not `Category.Bus`.
+ */
+export function mintObserveEventIdHex(env: SimulationEnvironment = DEFAULT_ENV, atMs: number = Date.now()): string {
+  const obs: ZetaObservation = {
+    version: IdVersion.V1,
+    timestamp: atMs as Milliseconds,
+    chromosome: Chromosome.MetaCoherence,
+    category: Category.WorkItem,
+    firefly: Firefly.NoDirective,
+    authority: { type: "TrustedAgent" },
+    persona: Persona.FireflyCoherence,
+    momentum: { type: "Normal" },
+    location: LocationHint.EastUS_VA1,
+  };
+  return pack(obs, env).toString(16).padStart(32, "0");
+}
+
+/** The durable FACT: a recorded action with stable identity + actor + time. */
+export interface EventEnvelope {
+  readonly id: string; // ZetaId hex — stable identity; the filename; G-Set dedup key
+  readonly at: string; // canonical ISO-8601 ms timestamp
+  readonly by: string; // acting agent id (the actor trail)
+  readonly action: NextAction; // the chosen action this event records
+}
+
+/** Outcome of committing the event file (sync; mirrors the bus's git pattern). */
+export type CommitOutcome = { readonly ok: true } | { readonly ok: false; readonly reason: string };
+
+export interface FolderSinkOptions {
+  /** The git folder events land in (folders-not-branches, on a main checkout). */
+  readonly eventDir: string;
+  /** Acting agent id, stamped into every envelope. */
+  readonly by: string;
+  /** Id minter (default: WorkItem ZetaId). Inject a deterministic one in tests. */
+  readonly mint?: () => string;
+  /** Clock (default: Date.now). Inject in tests. */
+  readonly now?: () => number;
+  /** Commit the written file (default: gitCommitToMain). Inject a fake in tests. */
+  readonly commit?: (filePath: string, envelope: EventEnvelope) => CommitOutcome;
+}
+
+/**
+ * Write the envelope as an atomic, ZetaId-named file. `flag: "wx"` fails if the
+ * file exists — but for a G-Set the same id means the same event already landed,
+ * so EEXIST is idempotent SUCCESS, not an error.
+ */
+function writeEventFile(envelope: EventEnvelope, eventDir: string): { ok: true; path: string } | { ok: false; reason: string } {
+  const path = join(eventDir, `${envelope.id}.json`);
+  try {
+    mkdirSync(eventDir, { recursive: true });
+    writeFileSync(path, `${JSON.stringify(envelope, null, 2)}\n`, { flag: "wx" });
+    return { ok: true, path };
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === "EEXIST") return { ok: true, path }; // idempotent: this event id already landed (G-Set)
+    return { ok: false, reason: `write failed: ${e.message}` };
+  }
+}
+
+/**
+ * Default commit: folder-direct-to-`main`, no-PR. Mirrors the agent-bus
+ * `gitPushEnvelope` (B-0954): on-main guard, fetch + 0-ahead check (never shove
+ * unrelated local commits to main), add ONLY this file, `--no-verify` (events are
+ * DATA not code), push `HEAD:main` with rebase-retry (disjoint ZetaId files →
+ * G-Set union, never a real conflict). Returns a CommitOutcome; never throws.
+ */
+export function gitCommitToMain(filePath: string, envelope: EventEnvelope): CommitOutcome {
+  const run = (args: readonly string[]): string =>
+    // eslint-disable-next-line sonarjs/no-os-command-from-path
+    execFileSync("git", [...args], { encoding: "utf-8" }).trim();
+  const gitPath = filePath.replaceAll("\\", "/");
+  try {
+    const branch = run(["rev-parse", "--abbrev-ref", "HEAD"]);
+    if (branch !== "main") {
+      return { ok: false, reason: `observe event sink must run on a main checkout (on '${branch}')` };
+    }
+    run(["fetch", "origin", "main"]);
+    const ahead = run(["rev-list", "--count", "origin/main..HEAD"]);
+    if (ahead !== "0") {
+      return { ok: false, reason: `local main is ${ahead} commit(s) ahead of origin/main; reconcile before appending events` };
+    }
+    run(["add", gitPath]);
+    const msg = [
+      `observe(${envelope.by}): ${envelope.action.kind} ${gitPath}`,
+      "",
+      `Observe event ${envelope.id} appended folder-direct-to-main (sovereign transport, B-0890.1).`,
+      "",
+      "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>",
+    ].join("\n");
+    run(["commit", "--no-verify", "-q", "-m", msg, "--", gitPath]);
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        run(["push", "origin", "HEAD:main"]);
+        return { ok: true };
+      } catch {
+        try {
+          run(["pull", "--rebase", "origin", "main"]);
+        } catch {
+          return { ok: false, reason: "push rejected and rebase failed (peer contention)" };
+        }
+      }
+    }
+    return { ok: false, reason: "push failed after 3 rebase-retry attempts" };
+  } catch (err) {
+    return { ok: false, reason: `git commit failed: ${(err as Error).message}` };
+  }
+}
+
+/**
+ * The real folder-direct-to-main EventSink. `append` mints a ZetaId, builds the
+ * fact envelope, atomically writes `<eventDir>/<id>.json`, and commits it to main.
+ * Pure-shaped (Result; never throws); I/O injected for tests.
+ */
+export function folderSink(opts: FolderSinkOptions): EventSink {
+  const mint = opts.mint ?? (() => mintObserveEventIdHex());
+  const now = opts.now ?? (() => Date.now());
+  const commit = opts.commit ?? gitCommitToMain;
+  return {
+    append: (action: NextAction): Promise<AppendOutcome> => {
+      const id = mint();
+      const envelope: EventEnvelope = { id, at: new Date(now()).toISOString(), by: opts.by, action };
+      const written = writeEventFile(envelope, opts.eventDir);
+      if (!written.ok) return Promise.resolve({ ok: false, reason: written.reason });
+      const committed = commit(written.path, envelope);
+      if (!committed.ok) return Promise.resolve({ ok: false, reason: committed.reason });
+      return Promise.resolve({ ok: true, eventId: id });
+    },
+  };
+}

--- a/tools/observe/event-sink-folder.ts
+++ b/tools/observe/event-sink-folder.ts
@@ -256,6 +256,15 @@ export function gitCommitToMain(filePath: string, envelope: EventEnvelope): Comm
     undoLocalCommit();
     return { ok: false, reason: "push failed after 3 rebase-retry attempts; local commit undone" };
   } catch (err) {
+    // If `git commit` itself failed AFTER `git add` (e.g. missing git identity, a commit hook),
+    // our path is left STAGED; append's rmSync would then remove the worktree file but leave a
+    // staged-add of a now-deleted file = dirty index that blocks the next rebase. Unstage our path
+    // (best-effort; no-op if nothing was staged) so the index is clean too (Codex #6312 P2).
+    try {
+      run(["restore", "--staged", "--", gitPath]);
+    } catch {
+      /* nothing staged for our path — fine */
+    }
     return { ok: false, reason: `git commit failed: ${(err as Error).message}` };
   }
 }

--- a/tools/observe/event-sink-folder.ts
+++ b/tools/observe/event-sink-folder.ts
@@ -45,7 +45,7 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { pack, DEFAULT_ENV, type SimulationEnvironment } from "../../src/Core.TypeScript/zeta-id/zeta-id";
 import {
@@ -119,9 +119,37 @@ function writeEventFile(envelope: EventEnvelope, eventDir: string): { ok: true; 
     return { ok: true, path };
   } catch (err) {
     const e = err as NodeJS.ErrnoException;
-    if (e.code === "EEXIST") return { ok: true, path }; // idempotent: this event id already landed (G-Set)
+    if (e.code === "EEXIST") {
+      // Same id already on disk. Idempotent SUCCESS only if the content matches
+      // (the true G-Set property). A reused id with a different action/by/at is a
+      // real collision — surface it, never silently accept stale (Codex #6312 P2).
+      try {
+        const existing = readFileSync(path, "utf-8");
+        if (existing === `${JSON.stringify(envelope, null, 2)}\n`) return { ok: true, path };
+        return { ok: false, reason: `id collision: ${envelope.id} already exists with different content` };
+      } catch (readErr) {
+        return { ok: false, reason: `EEXIST but re-read failed: ${(readErr as Error).message}` };
+      }
+    }
     return { ok: false, reason: `write failed: ${e.message}` };
   }
+}
+
+/**
+ * Harness-specific `Co-Authored-By` trailer derived from the acting agent id.
+ * The sink is SHARED — Vera/Riven/Alexa/Lior all use it — and the repo requires
+ * per-surface trailers (agent-roster-reference-card), so a hardcoded Claude
+ * trailer mis-attributes every non-Otto surface's events (Codex #6312 P2).
+ * Mirrors the agent-bus `coauthorFor` map; falls back to naming the sender.
+ */
+export function coauthorFor(by: string): string {
+  const id = by.toLowerCase();
+  if (id.startsWith("otto")) return "Co-Authored-By: Claude <noreply@anthropic.com>";
+  if (id.startsWith("alexa")) return "Co-Authored-By: Kiro <noreply@kiro.dev>";
+  if (id.startsWith("riven")) return "Co-Authored-By: Grok <noreply@x.ai>";
+  if (id.startsWith("vera")) return "Co-Authored-By: Codex <noreply@openai.com>";
+  if (id.startsWith("lior")) return "Co-Authored-By: Gemini <noreply@google.com>";
+  return `Co-Authored-By: ${by} <noreply@zeta.local>`;
 }
 
 /**
@@ -152,7 +180,7 @@ export function gitCommitToMain(filePath: string, envelope: EventEnvelope): Comm
       "",
       `Observe event ${envelope.id} appended folder-direct-to-main (sovereign transport, B-0890.1).`,
       "",
-      "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>",
+      coauthorFor(envelope.by),
     ].join("\n");
     run(["commit", "--no-verify", "-q", "-m", msg, "--", gitPath]);
     for (let attempt = 0; attempt < 3; attempt++) {
@@ -163,7 +191,15 @@ export function gitCommitToMain(filePath: string, envelope: EventEnvelope): Comm
         try {
           run(["pull", "--rebase", "origin", "main"]);
         } catch {
-          return { ok: false, reason: "push rejected and rebase failed (peer contention)" };
+          // Leave the checkout clean: abort the in-progress rebase (best-effort) so the
+          // next append / any unrelated git op isn't blocked. Result-only contract
+          // means we never leave a dangling rebase behind (Codex #6312 P2).
+          try {
+            run(["rebase", "--abort"]);
+          } catch {
+            /* no rebase in progress to abort — fine */
+          }
+          return { ok: false, reason: "push rejected and rebase failed (peer contention); rebase aborted" };
         }
       }
     }

--- a/tools/observe/event-sink-folder.ts
+++ b/tools/observe/event-sink-folder.ts
@@ -45,7 +45,7 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { pack, DEFAULT_ENV, type SimulationEnvironment } from "../../src/Core.TypeScript/zeta-id/zeta-id";
 import {
@@ -207,15 +207,17 @@ export function gitCommitToMain(filePath: string, envelope: EventEnvelope): Comm
       coauthorFor(envelope.by),
     ].join("\n");
     run(["commit", "--no-verify", "-q", "-m", msg, "--", gitPath]);
-    // After this point the commit exists on local main. If the push never lands we MUST fully undo
-    // it — commit AND the event file — leaving the checkout exactly at origin/main. A soft reset
-    // would leave the file STAGED, which then makes the next append's `git pull --rebase` refuse on
-    // a dirty index (Codex #6312). A hard reset of our own pathspec-scoped commit on the sink's
-    // clean-main checkout leaves zero residue; the failed append didn't land, and the loop re-appends
-    // a fresh event next tick (so nothing is lost). (Codex #6312 P2: ahead-check wedge + dirty-index.)
+    // After this point the commit exists on local main. If the push never lands we MUST undo it
+    // WITHOUT clobbering unrelated edits: a `reset --hard` would wipe an agent's concurrent
+    // uncommitted work in other files (Codex #6312 P1). Targeted undo instead: `reset --soft`
+    // (move HEAD back; stages ONLY our commit's diff = our event file; other files untouched) then
+    // `restore --staged -- <our path>` (unstage ONLY our file → untracked; nothing else touched).
+    // The orphaned event file itself is removed by `append` on the ok:false return (so it can't be
+    // half-read by loadWorld). Net: commit gone, our file gone, every other file exactly as it was.
     const undoLocalCommit = (): void => {
       try {
-        run(["reset", "--hard", "HEAD~1"]); // drop our commit + the event file → clean at origin/main
+        run(["reset", "--soft", "HEAD~1"]);
+        run(["restore", "--staged", "--", gitPath]);
       } catch {
         /* nothing to undo — fine */
       }
@@ -276,7 +278,17 @@ export function folderSink(opts: FolderSinkOptions): EventSink {
         const written = writeEventFile(envelope, opts.eventDir);
         if (!written.ok) return Promise.resolve({ ok: false, reason: written.reason });
         const committed = commit(written.path, envelope);
-        if (!committed.ok) return Promise.resolve({ ok: false, reason: committed.reason });
+        if (!committed.ok) {
+          // The append failed → the event did NOT land. Remove the written file so it can't be
+          // half-read by loadWorld (which reads the folder), regardless of whether the failure was
+          // pre-commit (file written, never committed) or post-commit (commit undone) (Codex #6312).
+          try {
+            rmSync(written.path, { force: true });
+          } catch {
+            /* file already gone (e.g. undo removed it) — fine */
+          }
+          return Promise.resolve({ ok: false, reason: committed.reason });
+        }
         return Promise.resolve({ ok: true, eventId: id });
       } catch (err) {
         return Promise.resolve({ ok: false, reason: `append failed: ${(err as Error).message}` });

--- a/tools/observe/event-sink-folder.ts
+++ b/tools/observe/event-sink-folder.ts
@@ -199,6 +199,16 @@ export function gitCommitToMain(filePath: string, envelope: EventEnvelope): Comm
       coauthorFor(envelope.by),
     ].join("\n");
     run(["commit", "--no-verify", "-q", "-m", msg, "--", gitPath]);
+    // After this point the commit exists on local main. If the push never lands we MUST undo it
+    // (soft, so the event file is preserved for a later retry) — otherwise local main is left
+    // ahead of origin/main and the ahead-check wedges every future append (Codex #6312 P2).
+    const undoLocalCommit = (): void => {
+      try {
+        run(["reset", "--soft", "HEAD~1"]); // un-commit; keep the event file staged for retry
+      } catch {
+        /* nothing to undo — fine */
+      }
+    };
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
         run(["push", "origin", "HEAD:main"]);
@@ -207,19 +217,21 @@ export function gitCommitToMain(filePath: string, envelope: EventEnvelope): Comm
         try {
           run(["pull", "--rebase", "origin", "main"]);
         } catch {
-          // Leave the checkout clean: abort the in-progress rebase (best-effort) so the
-          // next append / any unrelated git op isn't blocked. Result-only contract
-          // means we never leave a dangling rebase behind (Codex #6312 P2).
+          // Leave the checkout clean: abort the in-progress rebase + undo our local commit
+          // (best-effort) so neither a dangling rebase nor an ahead local main blocks the next
+          // append. Result-only contract: a failed append leaves no local residue (Codex #6312 P2).
           try {
             run(["rebase", "--abort"]);
           } catch {
             /* no rebase in progress to abort — fine */
           }
-          return { ok: false, reason: "push rejected and rebase failed (peer contention); rebase aborted" };
+          undoLocalCommit();
+          return { ok: false, reason: "push rejected and rebase failed (peer contention); local commit undone" };
         }
       }
     }
-    return { ok: false, reason: "push failed after 3 rebase-retry attempts" };
+    undoLocalCommit();
+    return { ok: false, reason: "push failed after 3 rebase-retry attempts; local commit undone" };
   } catch (err) {
     return { ok: false, reason: `git commit failed: ${(err as Error).message}` };
   }

--- a/tools/observe/event-sink-folder.ts
+++ b/tools/observe/event-sink-folder.ts
@@ -149,11 +149,19 @@ function writeEventFile(envelope: EventEnvelope, eventDir: string): { ok: true; 
  */
 export function coauthorFor(by: string): string {
   const id = by.toLowerCase();
-  if (id.startsWith("otto")) return "Co-Authored-By: Claude <noreply@anthropic.com>";
-  if (id.startsWith("alexa")) return "Co-Authored-By: Kiro <noreply@kiro.dev>";
-  if (id.startsWith("riven")) return "Co-Authored-By: Grok <noreply@x.ai>";
-  if (id.startsWith("vera")) return "Co-Authored-By: Codex <noreply@openai.com>";
-  if (id.startsWith("lior")) return "Co-Authored-By: Gemini <noreply@google.com>";
+  // Match the EXACT surface id or a hyphen-delimited variant (otto, otto-cli, otto-desktop) —
+  // NOT a bare prefix, so "ottobot" / "liorx" fall back to the sender trailer instead of being
+  // mis-stamped (Codex #6312: mirror the agent-bus exact-or-hyphen matching, not startsWith).
+  const TRAILERS: readonly (readonly [string, string])[] = [
+    ["otto", "Co-Authored-By: Claude <noreply@anthropic.com>"],
+    ["alexa", "Co-Authored-By: Kiro <noreply@kiro.dev>"],
+    ["riven", "Co-Authored-By: Grok <noreply@x.ai>"],
+    ["vera", "Co-Authored-By: Codex <noreply@openai.com>"],
+    ["lior", "Co-Authored-By: Gemini <noreply@google.com>"],
+  ];
+  for (const [surface, trailer] of TRAILERS) {
+    if (id === surface || id.startsWith(`${surface}-`)) return trailer;
+  }
   return `Co-Authored-By: ${by} <noreply@zeta.local>`;
 }
 
@@ -199,12 +207,15 @@ export function gitCommitToMain(filePath: string, envelope: EventEnvelope): Comm
       coauthorFor(envelope.by),
     ].join("\n");
     run(["commit", "--no-verify", "-q", "-m", msg, "--", gitPath]);
-    // After this point the commit exists on local main. If the push never lands we MUST undo it
-    // (soft, so the event file is preserved for a later retry) — otherwise local main is left
-    // ahead of origin/main and the ahead-check wedges every future append (Codex #6312 P2).
+    // After this point the commit exists on local main. If the push never lands we MUST fully undo
+    // it — commit AND the event file — leaving the checkout exactly at origin/main. A soft reset
+    // would leave the file STAGED, which then makes the next append's `git pull --rebase` refuse on
+    // a dirty index (Codex #6312). A hard reset of our own pathspec-scoped commit on the sink's
+    // clean-main checkout leaves zero residue; the failed append didn't land, and the loop re-appends
+    // a fresh event next tick (so nothing is lost). (Codex #6312 P2: ahead-check wedge + dirty-index.)
     const undoLocalCommit = (): void => {
       try {
-        run(["reset", "--soft", "HEAD~1"]); // un-commit; keep the event file staged for retry
+        run(["reset", "--hard", "HEAD~1"]); // drop our commit + the event file → clean at origin/main
       } catch {
         /* nothing to undo — fine */
       }
@@ -248,20 +259,28 @@ export function folderSink(opts: FolderSinkOptions): EventSink {
   const commit = opts.commit ?? gitCommitToMain;
   return {
     append: (action: NextAction): Promise<AppendOutcome> => {
-      const id = mint();
-      // `mint` is injectable + FolderSinkOptions is exported, so a caller could return a
-      // path-traversal segment ("../outside") or a Windows-reserved name. The id is used as a
-      // path segment — reject anything but a canonical 32-hex ZetaId before joining a path
-      // (the bus guards its segments the same way). Security-relevant (Copilot #6312 P1).
-      if (!isCanonicalEventId(id)) {
-        return Promise.resolve({ ok: false, reason: `non-canonical event id (expected 32 lowercase hex): '${id}'` });
+      // Wrap the whole body: the injected `mint` / `now` / `commit` could throw (e.g. a now()
+      // returning NaN makes toISOString() throw), but the documented contract is Result-only —
+      // convert ANY throw to { ok: false } like the rest of the adapter (Copilot #6312 P1).
+      try {
+        const id = mint();
+        // `mint` is injectable + FolderSinkOptions is exported, so a caller could return a
+        // path-traversal segment ("../outside") or a Windows-reserved name. The id is used as a
+        // path segment — reject anything but a canonical 32-hex ZetaId before joining a path
+        // (the bus guards its segments the same way). Security-relevant (Copilot #6312 P1).
+        if (!isCanonicalEventId(id)) {
+          return Promise.resolve({ ok: false, reason: `non-canonical event id (expected 32 lowercase hex): '${id}'` });
+        }
+        const at = new Date(now()).toISOString();
+        const envelope: EventEnvelope = { id, at, by: opts.by, action };
+        const written = writeEventFile(envelope, opts.eventDir);
+        if (!written.ok) return Promise.resolve({ ok: false, reason: written.reason });
+        const committed = commit(written.path, envelope);
+        if (!committed.ok) return Promise.resolve({ ok: false, reason: committed.reason });
+        return Promise.resolve({ ok: true, eventId: id });
+      } catch (err) {
+        return Promise.resolve({ ok: false, reason: `append failed: ${(err as Error).message}` });
       }
-      const envelope: EventEnvelope = { id, at: new Date(now()).toISOString(), by: opts.by, action };
-      const written = writeEventFile(envelope, opts.eventDir);
-      if (!written.ok) return Promise.resolve({ ok: false, reason: written.reason });
-      const committed = commit(written.path, envelope);
-      if (!committed.ok) return Promise.resolve({ ok: false, reason: committed.reason });
-      return Promise.resolve({ ok: true, eventId: id });
     },
   };
 }


### PR DESCRIPTION
## Real EventSink — folder-direct-to-main adapter (the sovereign transport)

operator: *"build the real EventSink folder-direct-to-main adapter next."* The production impl of the `EventSink` port (`execute.ts`).

`folderSink(opts)` writes the chosen action as a **ZetaId-named JSON file** into a git folder and commits it **direct to `main`, no-PR** (B-0890.1 folders-on-main; same mechanism as the agent-bus G-Set, B-0954). **Corporate batch-to-main (B-0890) = same envelope, different `commit` fn.**

**Honors Amara's review:**
- **#2 stable identity + idempotency** — `EventEnvelope = { id, at, by, action }` is the durable **fact** ("at t, actor X recorded this action"); `id` = `mintObserveEventIdHex` → **`Category.WorkItem`** ZetaId; the filename IS the id, so EEXIST is a no-op (G-Set CRDT).
- **#1 fact, not command** — logs the action as a fact with identity+actor+time (toward the richer executed-event envelope, the next refinement).
- **#5/#6 conflict discipline** — mirrors the bus `gitPushEnvelope`: on-main guard + fetch + 0-ahead check + add only this file + `--no-verify` + `push HEAD:main` with rebase-retry (disjoint ZetaId files → G-Set union, never a real conflict).
- **never throws** — every failure → `AppendOutcome { ok:false; reason }` (the sink authors its outcome channel); `execute` surfaces it as feedback.

I/O injectable (`mint`/`now`/`commit`) → fully testable, no real git, temp dir. **Composes with `execute()` end-to-end** (tested). The read side over this log = the eventually-consistent indexes ([B-0951](https://github.com/Lucent-Financial-Group/Zeta/blob/main/docs/backlog/P2/B-0951-git-native-eventually-consistent-text-indexes-sorted-inverted-graph-plus-git-native-hindsight-storage-interface-aaron-2026-05-31.md)).

Verified: tsc 0, eslint clean, **8/8 tests pass**. Additive (new file; no change to `observe.ts`/`execute.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
