### PR TITLE
Record observe-act outcome evidence

### DIFF
--- a/agentic-organization/apps/agent-cli/src/agent-cli-main.ts
+++ b/agentic-organization/apps/agent-cli/src/agent-cli-main.ts
@@ -355,11 +355,19 @@ function observeActEvidenceRefs(evidence: AgentCliCycleEvidence): readonly strin
     `observe-act:selected_slot:${evidence.selectedIndex}`,
     `observe-act:veto_count:${evidence.vetoCount}`,
     `observe-act:true_slot_count:${evidence.trueSlotCount}`,
+    ...selectedSemanticEvidenceRefs(evidence),
     ...evidence.selectorRejections.flatMap(selectorRejectionEvidenceRefs),
     ...statusEvidenceRefs(evidence),
     ...actionRejectionEvidenceRefs(evidence),
     ...evidence.promptFlowIds.map((id) => `observe-act:prompt_flow:${id}`),
     ...evidence.metricBlockIds.map((id) => `observe-act:metric:${id}`),
+  ];
+}
+
+function selectedSemanticEvidenceRefs(evidence: AgentCliCycleEvidence): readonly string[] {
+  return [
+    ...(evidence.selectedImplKind === undefined ? [] : [`observe-act:selected_impl:${evidence.selectedImplKind}`]),
+    ...(evidence.actionOutcome === undefined ? [] : [`observe-act:action_outcome:${evidence.actionOutcome}`]),
   ];
 }
 

--- a/agentic-organization/apps/agent-cli/src/agent-cli.ts
+++ b/agentic-organization/apps/agent-cli/src/agent-cli.ts
@@ -173,6 +173,8 @@ export type AgentCliCycleResult = {
 export type AgentCliCycleEvidence = {
   menuHash: string;
   selectedIndex: number;
+  selectedImplKind?: string | undefined;
+  actionOutcome?: ActResult["outcome"] | undefined;
   vetoCount: number;
   trueSlotCount: number;
   statusSignalKind?: GlassHaloStatusSignal["kind"] | undefined;
@@ -674,6 +676,8 @@ function createAgentCliCycleEvidence(
   return {
     menuHash: hashMenu(menu),
     selectedIndex: selection.index,
+    ...selectedImplKindEvidence(menu, selection.index),
+    ...(actionResult === undefined ? {} : { actionOutcome: actionResult.outcome }),
     vetoCount: menu.slots.filter((slot) => slot.availability === TriAvailability.False).length,
     trueSlotCount: menu.slots.filter((slot) => slot.availability === TriAvailability.True).length,
     ...selectedStatusEvidence(actionResult),
@@ -798,6 +802,14 @@ function selectedCommandEvidence(
 ): { selectedCommandType?: string } {
   const selected = menu.slots.find((slot) => slot.index === selectedIndex);
   return selected?.impl?.kind === "command" ? { selectedCommandType: selected.impl.commandType } : {};
+}
+
+function selectedImplKindEvidence(
+  menu: Menu16,
+  selectedIndex: number,
+): { selectedImplKind?: string } {
+  const selected = menu.slots.find((slot) => slot.index === selectedIndex);
+  return selected?.impl?.kind === undefined ? {} : { selectedImplKind: selected.impl.kind };
 }
 
 function createOptionalEvidenceNumber<K extends string>(

--- a/agentic-organization/apps/agent-cli/test/agent-cli-main.test.ts
+++ b/agentic-organization/apps/agent-cli/test/agent-cli-main.test.ts
@@ -95,6 +95,8 @@ test("runAgentCliMain routes selected command slots through supplied production 
   equal(events[0]?.kind, OrgEventKind.ObserveActTick);
   ok(events[0]?.evidenceRefs.some((ref) => ref.startsWith("observe-act:menu_hash:")));
   ok(events[0]?.evidenceRefs.includes("observe-act:selected_slot:4"));
+  ok(events[0]?.evidenceRefs.includes("observe-act:selected_impl:command"));
+  ok(events[0]?.evidenceRefs.includes("observe-act:action_outcome:dispatched"));
 });
 
 test("runAgentCliMain reports malformed env JSON as typed setup feedback instead of throwing", async () => {

--- a/agentic-organization/apps/workers/src/org-cadence-lanes.ts
+++ b/agentic-organization/apps/workers/src/org-cadence-lanes.ts
@@ -309,6 +309,7 @@ function observeActEvidenceRefs(
     `observe-act:selected_slot:${evidence.selectedIndex}`,
     `observe-act:veto_count:${evidence.vetoCount}`,
     `observe-act:true_slot_count:${evidence.trueSlotCount}`,
+    ...selectedSemanticEvidenceRefs(evidence),
     ...selectedCommandEvidenceRefs(evidence),
     ...promptFlowPageEvidenceRefs(evidence),
     ...evidence.selectorRejections.flatMap(selectorRejectionEvidenceRefs),
@@ -316,6 +317,15 @@ function observeActEvidenceRefs(
     ...actionRejectionEvidenceRefs(evidence),
     ...evidence.promptFlowIds.map((id) => `observe-act:prompt_flow:${id}`),
     ...evidence.metricBlockIds.map((id) => `observe-act:metric:${id}`),
+  ];
+}
+
+function selectedSemanticEvidenceRefs(
+  evidence: NonNullable<Awaited<ReturnType<typeof runAgentCliCycle>>["evidence"]>,
+): readonly string[] {
+  return [
+    ...(evidence.selectedImplKind === undefined ? [] : [`observe-act:selected_impl:${evidence.selectedImplKind}`]),
+    ...(evidence.actionOutcome === undefined ? [] : [`observe-act:action_outcome:${evidence.actionOutcome}`]),
   ];
 }
 

--- a/agentic-organization/apps/workers/test/org-cadence-lanes.test.ts
+++ b/agentic-organization/apps/workers/test/org-cadence-lanes.test.ts
@@ -161,6 +161,8 @@ test("observe-act work-item lane runs one tick through observe -> act -> org eve
   ]);
   ok(observeEvents[0]?.evidenceRefs.some((ref) => ref.startsWith("observe-act:menu_hash:")));
   ok(observeEvents[0]?.evidenceRefs.includes("observe-act:selected_slot:4"));
+  ok(observeEvents[0]?.evidenceRefs.includes("observe-act:selected_impl:command"));
+  ok(observeEvents[0]?.evidenceRefs.includes("observe-act:action_outcome:dispatched"));
 });
 
 test("observe-act work-item lane persists selector rejection evidence on fallback-selected ticks", async () => {

--- a/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
+++ b/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
@@ -407,6 +407,15 @@ agent intent visible in tick evidence while keeping the stronger retraction
 ledger, replay proof, and compensating-transaction machinery as the next
 implementation layer rather than implying undo/redo side effects already exist.
 
+**Checkpoint 2026-06-01: selected implementation and outcome evidence**
+
+Observe-act tick events now record both the stable selected slot and the semantic
+result of executing that selection. CLI and worker-lane events include
+`observe-act:selected_impl:<kind>` and `observe-act:action_outcome:<outcome>`
+evidence refs, so no-op/request choices such as rest, grammar-branch, history
+retract, and history redo are auditable from durable org events without scraping
+stdout.
+
 **Algorithms:**
 
 - **menu stability hash:** hash slot directions, labels, availability, reasons,


### PR DESCRIPTION
## Summary
- adds selected implementation kind and action outcome to AgentCliCycleEvidence
- persists `observe-act:selected_impl:*` and `observe-act:action_outcome:*` evidence refs from CLI main and worker lanes
- covers both persistence paths with tests and records the Phase 2 checkpoint

## Verification
- node --experimental-strip-types --test apps/agent-cli/test/agent-cli-main.test.ts apps/workers/test/org-cadence-lanes.test.ts apps/agent-cli/test/agent-cli.test.ts
- npm run typecheck
- npm test
- git diff --check
- KIND proof: production `agent:observe` selected slot 10 and persisted `observe-act:selected_impl:history_retract` plus `observe-act:action_outcome:history_retract_requested`
- dotnet build -c Release is blocked locally by existing SDK pin: global.json requests 10.0.203; installed SDKs are 9.0.100, 9.0.200, 10.0.101

## Review note
- Requested subagent review could not be spawned because the agent thread limit is currently reached.
