### PR TITLE
Test observe-act CLI entrypoint readiness

### DIFF
--- a/agentic-organization/apps/agent-cli/test/agent-cli-main.test.ts
+++ b/agentic-organization/apps/agent-cli/test/agent-cli-main.test.ts
@@ -1,5 +1,7 @@
 import { deepEqual, equal, ok } from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   ActRejectionReason,
@@ -21,6 +23,22 @@ import {
   runAgentCliMain,
   type AgentCliMainRuntime,
 } from "../src/agent-cli-main.ts";
+
+test("package metadata exposes observe-act as the production CLI entrypoint", async () => {
+  const packageJsonUrl = new URL("../../../package.json", import.meta.url);
+  const packageJson = JSON.parse(await readFile(fileURLToPath(packageJsonUrl), "utf8")) as {
+    scripts?: Record<string, string>;
+    bin?: Record<string, string>;
+    engines?: Record<string, string>;
+  };
+  const mainEntrypointUrl = new URL("../src/main.ts", import.meta.url);
+  const mainEntrypoint = await readFile(fileURLToPath(mainEntrypointUrl), "utf8");
+
+  equal(packageJson.scripts?.["agent:observe"], "node --experimental-strip-types apps/agent-cli/src/main.ts");
+  equal(packageJson.bin?.["agentic-org-observe"], "./apps/agent-cli/src/main.ts");
+  equal(packageJson.engines?.node, ">=22.12.0");
+  ok(mainEntrypoint.startsWith("#!/usr/bin/env -S node --experimental-strip-types\n"));
+});
 
 test("resolveAgentCliProductionRuntime fails closed without COCKROACH_DATABASE_URL", async () => {
   const resolved = await resolveAgentCliProductionRuntime({

--- a/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
+++ b/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
@@ -312,9 +312,6 @@ worker path.
 
 **Current production blockers:**
 
-- `apps/agent-cli/src/main.ts` still wires `runCommand` and `dispatchTool` to
-  not-wired stubs;
-- the CLI lacks package/bin readiness as an executable production surface;
 - the current slot layout is not yet the full ADR controller grammar;
 - all-vetoed work menus now render disabled commit slots with reasons and keep
   safe meta controls reachable for refresh/status/rest/escalation;
@@ -415,6 +412,17 @@ result of executing that selection. CLI and worker-lane events include
 evidence refs, so no-op/request choices such as rest, grammar-branch, history
 retract, and history redo are auditable from durable org events without scraping
 stdout.
+
+**Checkpoint 2026-06-01: production CLI entrypoint readiness**
+
+The observe-act foreground loop now has a tested executable surface. The root
+`agentic-organization/package.json` exposes `npm run agent:observe` and the
+`agentic-org-observe` bin entry, while `apps/agent-cli/src/main.ts` has the
+`node --experimental-strip-types` shebang expected by that bin. The package
+metadata test also anchors the Node engine floor used by the executable path.
+This moves package/bin readiness out of the blocker list; remaining production
+work is primary-lane rollout, controller-grammar completion, and deeper typed
+feedback coverage.
 
 **Algorithms:**
 


### PR DESCRIPTION
## Summary
- adds a package metadata test for the observe-act CLI script, bin entry, Node engine floor, and shebang
- updates the Phase 2 CA to mark package/bin readiness as a completed checkpoint instead of a blocker

## Verification
- node --experimental-strip-types --test apps/agent-cli/test/agent-cli-main.test.ts
- npm run typecheck
- npm test
- git diff --check
- dotnet build -c Release is blocked locally because global.json requests SDK 10.0.203; installed SDKs are 9.0.100, 9.0.200, and 10.0.101

## Review note
- Requested subagent review could not be spawned because the agent thread limit is currently reached.