### PR TITLE
feat(observe): loadWorld — wire the real World snapshot (closes the observe→execute→observe loop)

### DIFF
--- a/tools/observe/load-world.test.ts
+++ b/tools/observe/load-world.test.ts
@@ -1,0 +1,94 @@
+/**
+ * tools/observe/load-world.test.ts — the real World snapshot (read side of the loop).
+ *
+ * Backlog channel is injected (so no real repo backlog needed); mode channel reads
+ * real event JSON from a temp dir (the schema-on-read fold). Closes-the-loop test:
+ * loadWorld → observe returns the persisted mode.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadWorld, readEventActions } from "./load-world";
+import { observe, type BacklogItem, type NextAction } from "./observe";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "loadworld-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const ID = (c: string): string => c.repeat(32);
+function writeEvent(id: string, at: string, action: NextAction): void {
+  writeFileSync(join(dir, `${id}.json`), `${JSON.stringify({ id, at, by: "otto-cli", action }, null, 2)}\n`);
+}
+const item: BacklogItem = { id: "B-1", title: "x", ready: true, ambiguous: false };
+
+describe("readEventActions — schema-on-read, deterministic order", () => {
+  it("returns [] for a missing dir", () => {
+    expect(readEventActions(join(dir, "nope"))).toEqual([]);
+  });
+
+  it("orders events by at then id (replayable)", () => {
+    writeEvent(ID("b"), "2026-05-31T00:00:02.000Z", { kind: "self_reflect", reason: "later" });
+    writeEvent(ID("a"), "2026-05-31T00:00:01.000Z", { kind: "free_time", reason: "earlier" });
+    expect(readEventActions(dir).map((a) => a.kind)).toEqual(["free_time", "self_reflect"]);
+  });
+
+  it("skips malformed files, non-canonical ids, and unknown kinds", () => {
+    writeFileSync(join(dir, "bad.json"), "{not json");
+    writeFileSync(join(dir, `${ID("c")}.json`), JSON.stringify({ id: "short", at: "t", action: { kind: "free_time" } }));
+    writeFileSync(join(dir, `${ID("d")}.json`), JSON.stringify({ id: ID("d"), at: "t", action: { kind: "bogus_kind" } }));
+    writeEvent(ID("e"), "2026-05-31T00:00:01.000Z", { kind: "free_time", reason: "ok" });
+    expect(readEventActions(dir).map((a) => a.kind)).toEqual(["free_time"]);
+  });
+});
+
+describe("loadWorld — backlog channel (selector) + mode channel (fold)", () => {
+  it("do_item selection → backlog = [that item]; empty log → mode unset", () => {
+    const w = loadWorld({ eventDir: dir, nextAction: () => ({ kind: "do_item", item }) });
+    expect(w.backlog).toEqual([item]);
+    expect(w.mode).toBeUndefined();
+    expect(w.operator).toBeUndefined();
+  });
+
+  it("free_time selection (empty/blocked backlog) → empty backlog", () => {
+    const w = loadWorld({ eventDir: dir, nextAction: () => ({ kind: "free_time", reason: "nothing ready" }) });
+    expect(w.backlog).toEqual([]);
+  });
+
+  it("mode = the last (by at) mode-setting event in the log", () => {
+    writeEvent(ID("a"), "2026-05-31T00:00:01.000Z", { kind: "free_time", reason: "rest" });
+    writeEvent(ID("b"), "2026-05-31T00:00:02.000Z", { kind: "self_reflect", reason: "journal" });
+    const w = loadWorld({ eventDir: dir, nextAction: () => ({ kind: "do_item", item }) });
+    expect(w.mode).toBe("self_reflect");
+  });
+
+  it("wires the operator channel when provided", () => {
+    const w = loadWorld({
+      eventDir: dir,
+      nextAction: () => ({ kind: "free_time", reason: "x" }),
+      operator: { pendingMessage: true, pendingFerry: false },
+    });
+    expect(w.operator?.pendingMessage).toBe(true);
+  });
+});
+
+describe("closes the loop: loadWorld → observe honors the persisted mode", () => {
+  it("a self_reflect event in the log → observe returns self_reflect (work offered, not forced)", () => {
+    writeEvent(ID("a"), "2026-05-31T00:00:01.000Z", { kind: "self_reflect", reason: "thinking" });
+    // even with ready work available from the backlog channel, the persisted free mode wins
+    const w = loadWorld({ eventDir: dir, nextAction: () => ({ kind: "do_item", item }) });
+    expect(observe(w).kind).toBe("self_reflect");
+  });
+
+  it("empty log + ready work → observe returns the backlog pick (mode unset)", () => {
+    const w = loadWorld({ eventDir: dir, nextAction: () => ({ kind: "do_item", item }) });
+    const a = observe(w);
+    expect(a.kind).toBe("do_item");
+    if (a.kind === "do_item") expect(a.item.id).toBe("B-1");
+  });
+});

--- a/tools/observe/load-world.test.ts
+++ b/tools/observe/load-world.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadWorld, readEventActions } from "./load-world";
@@ -38,12 +38,31 @@ describe("readEventActions — schema-on-read, deterministic order", () => {
     expect(readEventActions(dir).map((a) => a.kind)).toEqual(["free_time", "self_reflect"]);
   });
 
-  it("skips malformed files, non-canonical ids, and unknown kinds", () => {
+  it("skips malformed files, non-canonical ids, unknown kinds, and ill-shaped payloads", () => {
     writeFileSync(join(dir, "bad.json"), "{not json");
-    writeFileSync(join(dir, `${ID("c")}.json`), JSON.stringify({ id: "short", at: "t", action: { kind: "free_time" } }));
+    writeFileSync(join(dir, `${ID("c")}.json`), JSON.stringify({ id: "short", at: "t", action: { kind: "free_time", reason: "x" } }));
     writeFileSync(join(dir, `${ID("d")}.json`), JSON.stringify({ id: ID("d"), at: "t", action: { kind: "bogus_kind" } }));
+    // canonical id + known kind but NO item — would throw in simulate; must be skipped
+    writeFileSync(join(dir, `${ID("9")}.json`), JSON.stringify({ id: ID("9"), at: "t", action: { kind: "do_item" } }));
+    // known reason-kind but no reason — skipped
+    writeFileSync(join(dir, `${ID("8")}.json`), JSON.stringify({ id: ID("8"), at: "t", action: { kind: "free_time" } }));
     writeEvent(ID("e"), "2026-05-31T00:00:01.000Z", { kind: "free_time", reason: "ok" });
     expect(readEventActions(dir).map((a) => a.kind)).toEqual(["free_time"]);
+  });
+
+  it("recurses into date-partitioned subdirs (YYYY/MM/DD/{id}.json)", () => {
+    const day = join(dir, "2026", "05", "31");
+    mkdirSync(day, { recursive: true });
+    writeFileSync(join(day, `${ID("a")}.json`), JSON.stringify({ id: ID("a"), at: "2026-05-31T00:00:01.000Z", by: "otto-cli", action: { kind: "self_reflect", reason: "deep" } }));
+    expect(readEventActions(dir).map((a) => a.kind)).toEqual(["self_reflect"]);
+  });
+
+  it("folds a do_item event over empty backlog without throwing (payload validated upstream)", () => {
+    writeEvent(ID("a"), "2026-05-31T00:00:01.000Z", { kind: "do_item", item });
+    // do_item is a valid payload (has item.id) → fold(do_item) sets mode "work", no throw
+    expect(() => readEventActions(dir)).not.toThrow();
+    const w = loadWorld({ eventDir: dir, nextAction: () => ({ kind: "free_time", reason: "x" }) });
+    expect(w.mode).toBe("work");
   });
 });
 

--- a/tools/observe/load-world.ts
+++ b/tools/observe/load-world.ts
@@ -65,34 +65,55 @@ interface ParsedEvent {
 }
 
 /**
+ * The action payload must match its kind, or `fold → simulate` can throw (e.g. a
+ * `{ kind: "do_item" }` with no `item` derefs `action.item.id`). Tolerant reader
+ * rejects ill-shaped payloads.
+ */
+function hasValidPayload(kind: string, a: Record<string, unknown>): boolean {
+  if (kind === "do_item" || kind === "decompose") {
+    const it = a.item;
+    return typeof it === "object" && it !== null && typeof (it as Record<string, unknown>).id === "string";
+  }
+  return typeof a.reason === "string"; // the reason-carrying kinds
+}
+
+/** Parse one event file → a ParsedEvent, or null if anything is missing/malformed (never throws). */
+function parseEventFile(eventDir: string, name: string): ParsedEvent | null {
+  if (!name.endsWith(".json")) return null;
+  try {
+    const raw: unknown = JSON.parse(readFileSync(join(eventDir, name), "utf-8"));
+    if (typeof raw !== "object" || raw === null) return null;
+    const env = raw as Record<string, unknown>;
+    const action = env.action;
+    if (!isCanonicalEventId(env.id) || typeof env.at !== "string") return null;
+    if (typeof action !== "object" || action === null) return null;
+    const a = action as Record<string, unknown>;
+    const kind = a.kind;
+    if (typeof kind !== "string" || !KNOWN_KINDS.has(kind) || !hasValidPayload(kind, a)) return null;
+    return { id: env.id, at: env.at, action: action as NextAction };
+  } catch {
+    return null; // malformed file → skip
+  }
+}
+
+/**
  * Read + deterministically order the event log → the recorded actions. Tolerant:
- * a missing dir, a non-JSON file, a malformed envelope, a non-canonical id, or an
- * unknown action kind is skipped (never throws). Ordered by `at` then `id` so the
- * fold is replayable (DST).
+ * a missing dir, a non-JSON file, a malformed envelope, a non-canonical id, an
+ * unknown action kind, or an ill-shaped payload is skipped (never throws). Recurses
+ * date-partitioned dirs (YYYY/MM/DD/{id}.json, B-0867.2 / bus shape). Ordered by
+ * `at` then `id` so the fold is replayable (DST).
  */
 export function readEventActions(eventDir: string): readonly NextAction[] {
   let names: readonly string[];
   try {
-    names = readdirSync(eventDir);
+    names = readdirSync(eventDir, { recursive: true, encoding: "utf-8" });
   } catch {
     return []; // no event dir yet → empty log
   }
   const parsed: ParsedEvent[] = [];
   for (const name of names) {
-    if (!name.endsWith(".json")) continue;
-    try {
-      const raw: unknown = JSON.parse(readFileSync(join(eventDir, name), "utf-8"));
-      if (typeof raw !== "object" || raw === null) continue;
-      const env = raw as Record<string, unknown>;
-      const action = env.action;
-      if (!isCanonicalEventId(env.id) || typeof env.at !== "string") continue;
-      if (typeof action !== "object" || action === null) continue;
-      const kind = (action as Record<string, unknown>).kind;
-      if (typeof kind !== "string" || !KNOWN_KINDS.has(kind)) continue;
-      parsed.push({ id: env.id, at: env.at, action: action as NextAction });
-    } catch {
-      continue; // malformed file → skip
-    }
+    const p = parseEventFile(eventDir, name);
+    if (p !== null) parsed.push(p);
   }
   parsed.sort((a, b) => {
     if (a.at !== b.at) return a.at < b.at ? -1 : 1;

--- a/tools/observe/load-world.ts
+++ b/tools/observe/load-world.ts
@@ -1,0 +1,140 @@
+/**
+ * tools/observe/load-world.ts — wire the real World snapshot (closes the loop).
+ *
+ * observe.ts's roadmap was "wire the real World snapshot + execute the pick." The
+ * execute side landed (execute.ts + event-sink-folder.ts). `loadWorld` is the
+ * read side: it builds a `World` from the real channels so the loop runs for real:
+ *
+ *   loadWorld()  →  observe / observeWithLlm  →  execute (append event)  →  loadWorld()  →  …
+ *
+ * Two channels, each its own source of truth:
+ *
+ *   - BACKLOG  ← the existing selector (the oracle). Per backlog-reader.ts we do
+ *     NOT reimplement selection: `nextActionFromBacklog` runs the priority-ranked
+ *     `selectNextBacklogItem`, and the chosen item (if any) IS the world's backlog
+ *     for this tick. A free_time selection (empty/blocked) → empty backlog.
+ *   - MODE     ← a FOLD of the event log (per observe.ts v5: state is a projection
+ *     of the event log). The events `execute` appended (via the folder sink) carry
+ *     the chosen mode; folding them yields the persisted mode (operator: "i love
+ *     mode persistance"). This is the read side of what the folder sink writes —
+ *     the loop closing on itself.
+ *
+ * Schema-on-read (decoupled reader): `loadWorld` tolerantly parses the event JSON
+ * for just `{ id, at, action }` — the reader doesn't depend on the writer's type,
+ * skips anything malformed, and validates the action kind before trusting it. The
+ * folder + the canonical-id shape are the only contract.
+ *
+ * operator is OPTIONAL: absent = a background agent (no operator wired); a
+ * foreground caller injects the live channel. Same World DU, fewer channels.
+ *
+ * Pure-shaped + sync (reads files); the `nextAction` channel is injectable so the
+ * whole thing is testable without the real backlog.
+ *
+ * Composes with:
+ *   - tools/observe/observe.ts (World / BacklogItem / Mode / NextAction / fold)
+ *   - tools/observe/backlog-reader.ts (the backlog channel; selector = oracle)
+ *   - tools/observe/execute.ts + event-sink-folder.ts (the write side this reads back)
+ *   - docs/DECISIONS/2026-05-31-observe-act-16-direction-universal-action-grammar-local-no-cloud-llm.md
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { nextActionFromBacklog, type Priority } from "./backlog-reader";
+import { fold, type BacklogItem, type Mode, type NextAction, type OperatorChannel, type World } from "./observe";
+
+/** The NextAction kinds a folded event log may legitimately contain. */
+const KNOWN_KINDS: ReadonlySet<string> = new Set([
+  "preserve_ferry",
+  "respond_to_operator",
+  "do_item",
+  "decompose",
+  "explore",
+  "play",
+  "self_reflect",
+  "free_time",
+  "edit_grammar",
+]);
+
+const isCanonicalEventId = (id: unknown): id is string => typeof id === "string" && /^[0-9a-f]{32}$/.test(id);
+
+/** What the reader extracts from one event file (schema-on-read; ignores extra fields). */
+interface ParsedEvent {
+  readonly id: string;
+  readonly at: string;
+  readonly action: NextAction;
+}
+
+/**
+ * Read + deterministically order the event log → the recorded actions. Tolerant:
+ * a missing dir, a non-JSON file, a malformed envelope, a non-canonical id, or an
+ * unknown action kind is skipped (never throws). Ordered by `at` then `id` so the
+ * fold is replayable (DST).
+ */
+export function readEventActions(eventDir: string): readonly NextAction[] {
+  let names: readonly string[];
+  try {
+    names = readdirSync(eventDir);
+  } catch {
+    return []; // no event dir yet → empty log
+  }
+  const parsed: ParsedEvent[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    try {
+      const raw: unknown = JSON.parse(readFileSync(join(eventDir, name), "utf-8"));
+      if (typeof raw !== "object" || raw === null) continue;
+      const env = raw as Record<string, unknown>;
+      const action = env.action;
+      if (!isCanonicalEventId(env.id) || typeof env.at !== "string") continue;
+      if (typeof action !== "object" || action === null) continue;
+      const kind = (action as Record<string, unknown>).kind;
+      if (typeof kind !== "string" || !KNOWN_KINDS.has(kind)) continue;
+      parsed.push({ id: env.id, at: env.at, action: action as NextAction });
+    } catch {
+      continue; // malformed file → skip
+    }
+  }
+  parsed.sort((a, b) => {
+    if (a.at !== b.at) return a.at < b.at ? -1 : 1;
+    if (a.id !== b.id) return a.id < b.id ? -1 : 1;
+    return 0;
+  });
+  return parsed.map((p) => p.action);
+}
+
+export interface LoadWorldOptions {
+  /** The git folder the folder sink appended events to (the mode channel). */
+  readonly eventDir: string;
+  /** Backlog channel (default: the real selector). Inject in tests. */
+  readonly nextAction?: () => NextAction;
+  /** Repo root for the default backlog channel (default: process.cwd()). */
+  readonly repoRoot?: string;
+  readonly activeClaims?: readonly string[];
+  readonly maxPriority?: Priority;
+  /** Live operator channel; omit for a background agent. */
+  readonly operator?: OperatorChannel;
+}
+
+/**
+ * Build the real `World`: backlog from the selector (oracle), mode from folding
+ * the event log, operator if wired. The snapshot `observe()` reads — now sourced
+ * from real channels, closing the observe → execute → observe loop.
+ */
+export function loadWorld(opts: LoadWorldOptions): World {
+  const next = opts.nextAction
+    ? opts.nextAction()
+    : nextActionFromBacklog(opts.repoRoot ?? process.cwd(), opts.activeClaims ?? [], opts.maxPriority ?? "P2");
+  // Selector = oracle: the chosen item IS the backlog for this tick (no re-selection).
+  const backlog: readonly BacklogItem[] =
+    next.kind === "do_item" || next.kind === "decompose" ? [next.item] : [];
+
+  // Mode = projection of the event log (v5). Fold over an EMPTY backlog: mode
+  // transitions don't depend on backlog contents, so this isolates the persisted mode.
+  const mode: Mode | undefined = fold({ backlog: [] }, readEventActions(opts.eventDir)).mode;
+
+  return {
+    backlog,
+    ...(mode !== undefined ? { mode } : {}),
+    ...(opts.operator !== undefined ? { operator: opts.operator } : {}),
+  };
+}


### PR DESCRIPTION
## loadWorld — wire the real World snapshot (closes the loop)

operator: *"build loadWorld to close the real loop next."* The read side of observe.ts's roadmap (execute side already landed in #6310/#6312). Closes:

`loadWorld() → observe/observeWithLlm → execute (append event) → loadWorld() → …`

**Two channels, each its own source of truth:**
- **BACKLOG** ← the existing selector (the oracle) via `nextActionFromBacklog` — *not* reimplemented (per backlog-reader's "selector is the oracle"). The chosen item IS the world's backlog for the tick; a free_time selection (empty/blocked) → empty backlog.
- **MODE** ← a **fold of the event log** (v5: state is a projection of the log). The events `execute` appended via the folder sink carry the chosen mode; folding yields the persisted mode — **the read side of what the sink writes, the loop closing on itself.**

**Schema-on-read:** `readEventActions` tolerantly parses event JSON for `{id, at, action}`, validates canonical id + known action kind, orders by `(at, id)` for a replayable fold, skips malformed/missing (never throws). Decoupled reader — no dependency on the writer's type.

`operator` optional (absent = background agent); `nextAction` injectable → testable without the real backlog. **Closes-the-loop test:** a `self_reflect` event in the log → `observe` returns `self_reflect` even with ready work available (mode persisted; work offered, not forced).

Verified: tsc 0, eslint clean, **9/9 tests**. Additive (new file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
