### PR TITLE
feat(B-0959): G-Set first-class pair (F#+TS) + sovereign-DB master checklist

### DIFF
--- a/docs/backlog/P1/B-0958-observe-ts-agent-loop-implementation-and-testing-checklist-closed-loop-toward-vendor-store-aaron-otto-2026-05-31.md
+++ b/docs/backlog/P1/B-0958-observe-ts-agent-loop-implementation-and-testing-checklist-closed-loop-toward-vendor-store-aaron-otto-2026-05-31.md
@@ -55,10 +55,9 @@ only effectful seam; the folder sink is the sovereign transport. Full picture:
       kinds `not-yet-executable`). `tools/observe/execute.ts` (#6310).
 - [x] **`loadWorld`** — read side: backlog channel (selector = oracle) + mode from folding the event
       log; schema-on-read; closes the loop. `tools/observe/load-world.ts` (#6316).
-- [~] **`folderSink`** — real EventSink: ZetaId-named JSON, folder-direct-to-main, conflict
+- [x] **`folderSink`** — real EventSink: ZetaId-named JSON, folder-direct-to-main, conflict
       discipline (ahead-check + rebase --autostash + targeted undo), idempotency, path-traversal
-      guard, Result-only. **IN-FLIGHT — #6312 armed, not yet on `main`**; flip to [x] +
-      `tools/observe/event-sink-folder.ts` once it merges (Codex #6318).
+      guard, Result-only. `tools/observe/event-sink-folder.ts` (#6312, merged).
 - [x] **Synthesis + transport correction + key-custody design + hardware-to-buy** (#6304/#6306/#6307).
 
 ## LEFT (the testing + impl backlog — ordered)

--- a/docs/backlog/P1/B-0959-zeta-sovereign-distributed-db-and-agent-loop-master-checklist-one-git-native-zset-substrate-aaron-otto-2026-05-31.md
+++ b/docs/backlog/P1/B-0959-zeta-sovereign-distributed-db-and-agent-loop-master-checklist-one-git-native-zset-substrate-aaron-otto-2026-05-31.md
@@ -1,0 +1,167 @@
+---
+id: B-0959
+priority: P1
+status: open
+title: Zeta sovereign distributed-DB + agent-loop MASTER checklist — one git-native ZetaId Z-set substrate (algebra ladder · observe loop · git-native bus · distributed time · 4-oracle)
+effort: XL
+ask: aaron 2026-05-31
+created: 2026-05-31
+last_updated: 2026-05-31
+depends_on: []
+composes_with:
+  - B-0958
+  - B-0954
+  - B-0878
+  - B-0767
+  - B-0780
+  - B-0683
+  - B-0684
+  - B-0662
+  - B-0924
+  - B-0890.1
+  - B-0890
+  - B-0951
+  - B-0867
+  - B-0824
+  - B-0428
+tags:
+  - master-checklist
+  - one-substrate
+  - git-native
+  - zset
+  - gset
+  - algebra-ladder
+  - observe-loop
+  - distributed-time
+  - ischeduler
+  - 4-oracle
+  - dual-mode
+type: tracker
+---
+
+# Master checklist — the one substrate and everything built on it
+
+**Why this row exists** (Aaron 2026-05-31): the concrete deliverables are now
+real and scattered across ~15 rows + research docs + F# files; this is the
+single index so we stop re-forgetting pieces (the distributed-time primitive got
+forgotten once already). Each item links its detail row; check items off here as
+they land. This row tracks; the linked rows do.
+
+## 0. The recognition — it is ONE substrate
+
+Everything below is a view over **one git-native, ZetaId-keyed, append-entry
+store whose current state is a DBSP / Z-set fold over the entry stream**
+(`docs/research/2026-05-31-bus-and-ace-...-gset-comms-vs-dependency-zset.md`).
+The pieces differ in the _algebra of their entries_, not the substrate:
+
+| View                   | Algebra                                       | What it is                                |
+| ---------------------- | --------------------------------------------- | ----------------------------------------- |
+| Agent-bus comms        | **G-Set** (grow-only, no retraction)          | "what's been said" — append-only messages |
+| Ace dependency graph   | **Z-set** (retraction-native)                 | "the resolved dependency state"           |
+| Filesystem / hierarchy | **closure-table over Z-set** (`Hierarchy.fs`) | retraction-native subtree-delete          |
+| Observe loop state     | **fold over the event log**                   | `fold(initial, events).mode` etc.         |
+
+The Z-set is the general case; the G-Set is the Z-set restricted to non-negative
+multiplicity. **Build the ladder once; reuse it for all four views.**
+
+## 1. Algebra ladder first-class (G-Set → Bag → Z-set)
+
+- [x] **Z-set** — first-class: `src/Core/ZSet.fs` (+ `IndexedZSet.fs`, the `Spine`
+      LSM family). The retraction-native general case. Already shipped.
+- [x] **G-Set** — first-class **pair** (this row's first deliverable): `src/Core/GSet.fs` + `src/Core.TypeScript/g-set/` + shared `golden-vectors.json`; idempotent /
+      commutative / associative / identity laws proven in both langs; F# 9/9 + TS
+      9/9, parity-locked on the shared vector. The bottom rung, no longer implicit.
+- [ ] **Bag** (ℕ-multiplicity) — first-class `Bag.fs` + `bag.ts` + golden vector.
+      The middle rung (metrics / counting; git-native LGTM). Mirror the G-Set pair.
+
+## 2. Sovereign agent-loop (`tools/observe/`) — detail in [B-0958](B-0958-observe-ts-agent-loop-implementation-and-testing-checklist-closed-loop-toward-vendor-store-aaron-otto-2026-05-31.md)
+
+- [x] Pure controller (`observe` / `simulate` / `fold` / `replay`), 4×4 grammar,
+      golden-vectors, local-LLM chooser + real-model CI gate, `execute`,
+      `loadWorld`, `folderSink` (folder-direct-to-main). Loop skeleton closed.
+- [ ] Effectful action kinds with the executed-event envelope; end-to-end test;
+      real-temp-git-repo test of `gitCommitToMain`; real-model loop test;
+      `observe-loop` TS skill; vendor-store distribution. (All in B-0958.)
+
+## 3. Git-native cross-machine agent bus — [B-0954](../P2/B-0954-implement-git-native-cross-machine-agent-bus-docs-agent-bus-folder-zetaid-keyed-gset-crdt-no-pr-per-6219-spec-aaron-otto-2026-05-31.md)
+
+The bus IS a **G-Set CRDT** over a `docs/agent-bus/` folder, ZetaId-keyed,
+no-PR (sovereign transport). Now unblocked by §1's first-class G-Set.
+
+- [x] G-Set foundation (this row, §1).
+- [ ] `docs/agent-bus/` folder convention + ZetaId-keyed message envelope.
+- [ ] Append (= `GSet.union`, idempotent on re-observe) + per-topic TTL + receipts.
+- [ ] Cross-machine read (fold the folder → current G-Set) + the existing
+      `/tmp/zeta-bus/` ephemeral bus as the in-process fast path.
+- [ ] **Rx queries over the bus → observe dashboard** (Aaron 2026-05-31): agents
+      run live Rx queries over the bus G-Set (and, more generally, over _any_
+      stream) that render on their `observe.ts` dashboard; the queries are
+      **conditional on context + mode** (e.g. work-mode surfaces backlog-claims;
+      self-reflect surfaces own trajectory; play surfaces peer chatter). The bus
+      is just the first source — Rx-over-anything → dashboard. Wires §2 (observe)
+      to §3 (bus): the dashboard becomes a live, mode-aware view of the substrate.
+
+## 4. Distributed F# DB + the time primitive (the part we forgot)
+
+The primitive: **"in deterministic simulation, time is just a generator function
+over `IScheduler` (Rx)"** — pass the scheduler around → virtual time +
+injectable clock-uncertainty (CockroachDB-style) + retro-causality
+(generator-time; the three-clocks rule). Test multi-node/multi-cluster
+FoundationDB-style: all nodes on one deterministic thread.
+
+- [ ] **Time-generator `IScheduler` abstraction** — [B-0878](../P3/B-0878-time-generator-ischeduler-abstraction-for-clifford-space-agent-dynamics-aaron-2026-05-28.md)
+      (the buildable row; Rx `TestScheduler` lineage).
+- [ ] **Scheduler-first DST + AI-aware cluster management** — [B-0767](B-0767-zeta-native-scheduler-first-deterministic-simulation-and-ai-aware-cluster-management-aaron-2026-05-25.md);
+      single-thread "superorganism" green-thread multi-node sim.
+- [ ] **Local-loop DST of multi-node k8s** — [B-0780](B-0780-local-loop-deterministic-simulation-testing-of-kubernetes-deployments-lexisnexis-lineage-three-tier-testing-argocd-apps-as-packages-aaron-mika-2026-05-25.md).
+- [ ] **Tier-deferred causality (HLC / vector-clock / uncertainty)** — [B-0683](../P2/B-0683-tier-deferred-causality-worked-example-zsets-2026-05-21.md);
+      the CockroachDB-similar novel piece (3-layer mediation: Rx-joins-over-CRDTs
+      → CAS-per-function → BFT).
+- [ ] **Clock-protocol negotiation stack** — [B-0684](../P2/B-0684-clock-protocol-negotiation-stack-end-to-end-sequence-diagram-2026-05-21.md).
+- [ ] **Closed bidirectional causal loop ↔ F# ↔ C# ↔ Rust** — [B-0662](../P2/B-0662-closed-bidirectional-causal-loop-spec-fsharp-csharp-rust-chain-aaron-mika-2026-05-18.md)
+      (each layer regenerates the others; this IS the §6 4-oracle made concrete).
+- [x] **Deterministic chaos env seed** — `src/Core/ChaosEnv.fs` +
+      `tools/tla/specs/ChaosEnvDeterminism.cfg` (FoundationDB DST lineage, on main).
+- [x] **Closure-table-over-Z-set hierarchy** — `src/Core/Hierarchy.fs` (the binary
+      frontier's index; retraction-native subtree-delete). On main.
+- Research anchors: `docs/research/2026-05-26-kestrel-...-time-as-generator-foundationdb-anchor.md`,
+  `docs/research/2026-05-26-mika-...-self-derived-iScheduler-recursive-injection.md`.
+
+## 5. Eventually-consistent git-native indexes — [B-0951](../P2/B-0951-git-native-eventually-consistent-text-indexes-sorted-inverted-graph-plus-git-native-hindsight-storage-interface-aaron-2026-05-31.md)
+
+- [ ] Sorted / inverted / graph indexes over the same log (the graph index = the
+      closure table from §4). Read-amplification answer; eventually-consistent.
+
+## 6. 4-language meet-in-the-middle → the 4-oracle — detail in [B-0958](B-0958-observe-ts-agent-loop-implementation-and-testing-checklist-closed-loop-toward-vendor-store-aaron-otto-2026-05-31.md) §fan-out
+
+Golden-vectors are the locked safe ground; build on them, not on shaky ground.
+**TS leads the git-native/text frontier; F# leads the filesystem/binary frontier;
+C# and Rust meet in the middle (both formats) → every format has ≥2 impls so the
+cross-check is Byzantine-fault-tolerant.** "The compilers don't lie."
+
+- [x] Observe golden-vectors ×4 (TS/F#/C#/Rust) — locked.
+- [x] G-Set golden-vector — TS + F# (oracles #1, #2); C#/Rust join next.
+- [ ] G-Set + Bag golden-vectors ×4 (lowest-risk rungs first, bottom-up).
+- [ ] Observe loop in F#/C#/Rust on the locked oracle (after TS APIs stable).
+- [ ] F# dual-track: git-native AND filesystem-binary-efficient backend.
+
+## 7. Dual-mode transport
+
+- [x] Sovereign = folders-direct-to-main, no-PR — [B-0890.1](B-0890.1-fast-lane-as-folders-on-main-not-branches-supersedes-coordinator-complexity-per-operator-2026-05-28-zeta-native-branch-protection.md)
+      (the `folderSink` already writes this way).
+- [ ] Corporate = batch-to-main coordinator — [B-0890](B-0890-state-machine-fast-lane-batch-merge-to-main-composes-with-heartbeat-pattern-aaron-2026-05-28.md);
+      same event shape, PR-gated transport. The dial = `ActionGate "append-only" | "pr-gated"`.
+
+## Composes with
+
+- [B-0958](B-0958-observe-ts-agent-loop-implementation-and-testing-checklist-closed-loop-toward-vendor-store-aaron-otto-2026-05-31.md) — the observe-loop sub-tracker (this row is the umbrella over it)
+- [B-0954](../P2/B-0954-implement-git-native-cross-machine-agent-bus-docs-agent-bus-folder-zetaid-keyed-gset-crdt-no-pr-per-6219-spec-aaron-otto-2026-05-31.md) — git-native bus (G-Set CRDT)
+- [B-0824](B-0824-package-manager-of-package-managers-n-dimensional-dependency-space-holographic-projection-ai-rate-continuous-upstream-negotiation-aaron-2026-05-26.md) — Ace (the Z-set dependency view of the same substrate)
+- [B-0428](B-0428-dbpedia-direct-dotnetrdf-fsharp-ce-hkt-mdm-canonical-demo-aaron-2026-05-13.md) — F# fork (the binary-efficient frontier substrate)
+- the time-primitive cluster (§4) + the algebra ladder (§1)
+
+## Status
+
+Open — master tracker. First deliverable landed: the **G-Set first-class pair**
+(§1) which also unblocks the **git-native bus** (§3). Everything else is linked
+and checkbox-tracked above; pull from here so nothing gets re-forgotten.

--- a/src/Core.TypeScript/g-set/g-set.test.ts
+++ b/src/Core.TypeScript/g-set/g-set.test.ts
@@ -1,0 +1,86 @@
+/**
+ * g-set.test.ts — TS reference (oracle #1) for the G-Set CRDT.
+ *
+ * Two duties:
+ *   1. The three CRDT laws + identity hold (idempotent, commutative,
+ *      associative, identity) — the reason a G-Set converges without
+ *      coordination.
+ *   2. The shared golden vector replays to the expected states — the
+ *      cross-language parity lock the F# twin (oracle #2) also casts.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { add, contains, empty, equals, ofArray, stringCompare, toArray, union, type GSet } from "./g-set";
+
+const cmp = stringCompare;
+const g = (...xs: readonly string[]): GSet<string> => ofArray(cmp, xs);
+
+describe("G-Set — canonicalization", () => {
+  it("ofArray sorts ascending and drops duplicates", () => {
+    expect(toArray(g("c", "a", "b", "a", "c"))).toEqual(["a", "b", "c"]);
+  });
+  it("empty is empty; singleton-via-ofArray has one element", () => {
+    expect(toArray(empty<string>())).toEqual([]);
+    expect(toArray(g("x"))).toEqual(["x"]);
+  });
+  it("contains agrees with membership (binary search)", () => {
+    const s = g("a", "c", "e");
+    expect(contains(cmp, s, "c")).toBe(true);
+    expect(contains(cmp, s, "d")).toBe(false);
+    expect(contains(cmp, empty<string>(), "a")).toBe(false);
+  });
+});
+
+describe("G-Set — CRDT convergence laws", () => {
+  // Named off the `union(compare, a, b)` parameter names so the commutativity
+  // test (`union(setA, setB)` vs `union(setB, setA)`) isn't misread as a
+  // swapped-argument bug by static analysis — the swap IS the property.
+  const setA = g("a", "b");
+  const setB = g("b", "c");
+  const setC = g("c", "d");
+
+  it("idempotent: union(a, a) == a", () => {
+    expect(equals(cmp, union(cmp, setA, setA), setA)).toBe(true);
+  });
+  it("commutative: union(a, b) == union(b, a)", () => {
+    expect(equals(cmp, union(cmp, setA, setB), union(cmp, setB, setA))).toBe(true);
+  });
+  it("associative: union(union(a, b), c) == union(a, union(b, c))", () => {
+    const left = union(cmp, union(cmp, setA, setB), setC);
+    const right = union(cmp, setA, union(cmp, setB, setC));
+    expect(equals(cmp, left, right)).toBe(true);
+  });
+  it("identity: union(a, empty) == a and union(empty, a) == a", () => {
+    expect(equals(cmp, union(cmp, setA, empty<string>()), setA)).toBe(true);
+    expect(equals(cmp, union(cmp, empty<string>(), setA), setA)).toBe(true);
+  });
+  it("add is idempotent for a present element", () => {
+    expect(equals(cmp, add(cmp, "a", setA), setA)).toBe(true);
+    expect(toArray(add(cmp, "z", setA))).toEqual(["a", "b", "z"]);
+  });
+});
+
+type GoldenOp = { op: "add"; arg: string } | { op: "union"; arg: readonly string[] };
+interface GoldenVector {
+  readonly initialSet: readonly string[];
+  readonly ops: readonly GoldenOp[];
+  readonly expectedReplayStates: readonly (readonly string[])[];
+  readonly expectedFinalState: readonly string[];
+}
+
+describe("G-Set — shared golden vector (cross-language parity lock)", () => {
+  const gv = JSON.parse(readFileSync(join(import.meta.dir, "golden-vectors.json"), "utf-8")) as GoldenVector;
+
+  it("replays the vector to expectedReplayStates + expectedFinalState", () => {
+    let state = ofArray(cmp, gv.initialSet);
+    const states: string[][] = [];
+    for (const op of gv.ops) {
+      state = op.op === "add" ? add(cmp, op.arg, state) : union(cmp, state, ofArray(cmp, op.arg));
+      states.push(toArray(state));
+    }
+    expect(states).toEqual(gv.expectedReplayStates.map((s) => [...s]));
+    expect(toArray(state)).toEqual([...gv.expectedFinalState]);
+  });
+});

--- a/src/Core.TypeScript/g-set/g-set.ts
+++ b/src/Core.TypeScript/g-set/g-set.ts
@@ -1,0 +1,137 @@
+/**
+ * g-set.ts — a grow-only set (G-Set CRDT), the bottom rung of the Zeta algebra
+ * ladder (**G-Set → Bag → Z-set**) made first-class instead of implicit.
+ *
+ * A G-Set is the Z-set restricted to non-negative multiplicity with no
+ * retractions: every element is present exactly once, `union` is the only
+ * combiner, and `union` is **idempotent, commutative, and associative** — the
+ * three CRDT convergence laws (any two replicas that have seen the same
+ * elements, in any order, converge to the same set with no coordination).
+ *
+ * This is the comms substrate of the git-native agent-bus (B-0954): an
+ * append-only `docs/agent-bus/` folder of ZetaId-keyed messages IS a G-Set —
+ * re-observing the same message id is `union` and a no-op (the same reason the
+ * observe-loop's `folderSink` treats an EEXIST write as success). The F# twin
+ * lives in `src/Core/GSet.fs`; both produce the identical canonical array, so
+ * the shared `golden-vectors.json` is byte-stable across languages.
+ *
+ * Canonical representation: an **ascending-sorted, duplicate-free** `readonly`
+ * array under the provided `compare`. The canonical order makes `equals` a
+ * plain array comparison and keeps cross-language golden-vectors stable. The
+ * required `compare` is the TS analog of F#'s `'T : comparison` constraint.
+ */
+
+/** A total order on `T` (`< 0`, `0`, `> 0`), e.g. {@link stringCompare}. */
+export type Compare<T> = (a: T, b: T) => number;
+
+/**
+ * A grow-only set: an ascending-sorted, duplicate-free run under some
+ * `compare`. The invariant is held by every constructor here — never build one
+ * by hand from an unsorted array; use {@link ofArray}.
+ */
+export type GSet<T> = readonly T[];
+
+/** Ascending Unicode code-point order — the canonical comparator for the bus. */
+export const stringCompare: Compare<string> = (a, b) => {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+};
+
+/** The empty G-Set (the `union` identity). */
+export function empty<T>(): GSet<T> {
+  return [];
+}
+
+/** A one-element G-Set. */
+export function singleton<T>(x: T): GSet<T> {
+  return [x];
+}
+
+/** Canonicalize arbitrary input: sort ascending + drop duplicates. */
+export function ofArray<T>(compare: Compare<T>, xs: readonly T[]): GSet<T> {
+  const sorted = [...xs].sort(compare);
+  const out: T[] = [];
+  for (const x of sorted) {
+    const last = out.length - 1;
+    if (last < 0 || compare(out[last] as T, x) !== 0) out.push(x);
+  }
+  return out;
+}
+
+/** Membership via binary search on the sorted run. O(log n). */
+export function contains<T>(compare: Compare<T>, g: GSet<T>, x: T): boolean {
+  let lo = 0;
+  let hi = g.length - 1;
+  while (lo <= hi) {
+    const mid = lo + ((hi - lo) >> 1);
+    const c = compare(g[mid] as T, x);
+    if (c === 0) return true;
+    if (c < 0) lo = mid + 1;
+    else hi = mid - 1;
+  }
+  return false;
+}
+
+/**
+ * The CRDT merge: the union of two sorted-unique runs, kept sorted-unique.
+ * Idempotent, commutative, associative (verified by the law tests + the
+ * cross-language golden vector).
+ */
+export function union<T>(compare: Compare<T>, a: GSet<T>, b: GSet<T>): GSet<T> {
+  if (a.length === 0) return b;
+  if (b.length === 0) return a;
+  const out: T[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    const c = compare(a[i] as T, b[j] as T);
+    if (c < 0) {
+      out.push(a[i] as T);
+      i += 1;
+    } else if (c > 0) {
+      out.push(b[j] as T);
+      j += 1;
+    } else {
+      out.push(a[i] as T); // duplicate → keep one
+      i += 1;
+      j += 1;
+    }
+  }
+  while (i < a.length) {
+    out.push(a[i] as T);
+    i += 1;
+  }
+  while (j < b.length) {
+    out.push(b[j] as T);
+    j += 1;
+  }
+  return out;
+}
+
+/** Add one element (`union` with a singleton); idempotent if already present. */
+export function add<T>(compare: Compare<T>, x: T, g: GSet<T>): GSet<T> {
+  return contains(compare, g, x) ? g : union(compare, g, [x]);
+}
+
+/** The elements in canonical (ascending) order — a defensive copy. */
+export function toArray<T>(g: GSet<T>): T[] {
+  return [...g];
+}
+
+export function count<T>(g: GSet<T>): number {
+  return g.length;
+}
+
+export function isEmpty<T>(g: GSet<T>): boolean {
+  return g.length === 0;
+}
+
+/** Equality of two canonical runs — plain element-wise comparison. */
+export function equals<T>(compare: Compare<T>, a: GSet<T>, b: GSet<T>): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (compare(a[i] as T, b[i] as T) !== 0) return false;
+  }
+  return true;
+}

--- a/src/Core.TypeScript/g-set/golden-vectors.json
+++ b/src/Core.TypeScript/g-set/golden-vectors.json
@@ -1,0 +1,31 @@
+{
+  "description": "G-Set CRDT cross-language conformance (the bottom rung of the algebra ladder; B-0954 bus comms substrate). Every impl starts from `initialSet`, replays `ops` in order with the canonical string comparator, and must value-match `expectedReplayStates[i]` after op i AND `expectedFinalState` at the end. Sets are serialized in canonical ascending order, so equality is array-equality. Oracle #1 = TS reference; F# casts oracle #2; C#/Rust join later per the meet-in-the-middle 4-oracle.",
+  "elementType": "string",
+  "comparator": "ascending Unicode code-point (TS default string compare / F# Comparer<string>.Default / ordinal)",
+  "initialSet": ["b-002", "b-005"],
+  "ops": [
+    { "op": "add", "arg": "b-001", "note": "grow" },
+    { "op": "add", "arg": "b-005", "note": "idempotent: already present, no change" },
+    {
+      "op": "union",
+      "arg": ["b-003", "b-001", "b-009"],
+      "note": "commutative+associative: unsorted input, b-001 already present"
+    },
+    { "op": "union", "arg": [], "note": "identity: union with empty is a no-op" },
+    { "op": "add", "arg": "b-000", "note": "grow at the front" }
+  ],
+  "expectedReplayStates": [
+    ["b-001", "b-002", "b-005"],
+    ["b-001", "b-002", "b-005"],
+    ["b-001", "b-002", "b-003", "b-005", "b-009"],
+    ["b-001", "b-002", "b-003", "b-005", "b-009"],
+    ["b-000", "b-001", "b-002", "b-003", "b-005", "b-009"]
+  ],
+  "expectedFinalState": ["b-000", "b-001", "b-002", "b-003", "b-005", "b-009"],
+  "laws": {
+    "idempotent": "union(a, a) == a",
+    "commutative": "union(a, b) == union(b, a)",
+    "associative": "union(union(a, b), c) == union(a, union(b, c))",
+    "identity": "union(a, empty) == a"
+  }
+}

--- a/src/Core.TypeScript/g-set/index.ts
+++ b/src/Core.TypeScript/g-set/index.ts
@@ -1,0 +1,1 @@
+export * from "./g-set";

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="CayleyDickson.fs" />
     <Compile Include="Semiring.fs" />
     <Compile Include="Pool.fs" />
+    <Compile Include="GSet.fs" />
     <Compile Include="ZSet.fs" />
     <Compile Include="ToffoliGate.fs" />
     <Compile Include="IndexedZSet.fs" />

--- a/src/Core/GSet.fs
+++ b/src/Core/GSet.fs
@@ -1,0 +1,158 @@
+namespace Zeta.Core
+
+open System
+open System.Collections.Generic
+open System.Collections.Immutable
+open System.Runtime.CompilerServices
+
+/// A grow-only set `G[T]` — the bottom rung of the Zeta algebra ladder
+/// (**G-Set → Bag → Z-set**) made first-class instead of implicit.
+///
+/// G-Set is the `ZSet` (`ZSet.fs`) **restricted to non-negative multiplicity
+/// with no retractions**: every element is present exactly once, `union` is the
+/// only combiner, and `union` is **idempotent, commutative, and associative** —
+/// the three CRDT convergence laws. Those three laws are why a G-Set converges
+/// without coordination: any two replicas that have seen the same elements (in
+/// any order, with any duplication) compute the same set.
+///
+/// This is the comms substrate of the git-native agent-bus (B-0954): an
+/// append-only `docs/agent-bus/` folder of ZetaId-keyed messages *is* a G-Set —
+/// re-observing the same message id is `union` and a no-op (the same reason the
+/// observe-loop's `folderSink` treats an `EEXIST` write as success). Ace's
+/// dependency graph (B-0824) is the general `ZSet`, where add/remove nets via
+/// retraction; the bus never retracts, so the weaker G-Set is exactly right.
+///
+/// Represented as an immutable **ascending-sorted, de-duplicated** run. The
+/// canonical order makes `Equals` total, makes `toArray` deterministic, and
+/// makes cross-language golden-vectors byte-stable (the TS twin in
+/// `src/Core.TypeScript/g-set/` produces the identical sorted array). `'T`
+/// needs `comparison` to give the sort + the dedup — the F# analog of the TS
+/// twin's required `compare`.
+[<Struct; IsReadOnly; CustomEquality; NoComparison>]
+type GSet<'T when 'T : comparison> =
+    val internal items : ImmutableArray<'T>
+
+    /// Construct from an already sorted-ascending, duplicate-free run. Callers
+    /// own the invariant; use `GSet.ofSeq` for arbitrary input.
+    new(items: ImmutableArray<'T>) = { items = items }
+
+    static member Empty : GSet<'T> = GSet(ImmutableArray<'T>.Empty)
+
+    member this.Count =
+        if this.items.IsDefault then 0 else this.items.Length
+
+    member this.IsEmpty = this.items.IsDefaultOrEmpty
+
+    /// Membership via binary search on the sorted run. O(log n), zero-alloc.
+    member this.Contains(x: 'T) : bool =
+        if this.items.IsDefaultOrEmpty then
+            false
+        else
+            let mutable lo = 0
+            let mutable hi = this.items.Length - 1
+            let mutable found = false
+            while lo <= hi && not found do
+                let mid = lo + (hi - lo) / 2
+                let c = Comparer<'T>.Default.Compare(this.items.[mid], x)
+                if c = 0 then found <- true
+                elif c < 0 then lo <- mid + 1
+                else hi <- mid - 1
+            found
+
+    /// The elements in canonical (ascending) order.
+    member this.ToArray() : 'T[] =
+        if this.items.IsDefaultOrEmpty then
+            Array.empty
+        else
+            let arr = Array.zeroCreate this.items.Length
+            this.items.CopyTo(arr)
+            arr
+
+    override this.Equals(o: obj) : bool =
+        match o with
+        | :? GSet<'T> as other -> (this :> IEquatable<GSet<'T>>).Equals(other)
+        | _ -> false
+
+    override this.GetHashCode() : int =
+        // Order-independent only in principle; the run is canonical-sorted, so a
+        // simple positional combine over the canonical order is stable + total.
+        let mutable h = 17
+        if not this.items.IsDefaultOrEmpty then
+            for i in 0 .. this.items.Length - 1 do
+                h <- (h * 31) + EqualityComparer<'T>.Default.GetHashCode(this.items.[i])
+        h
+
+    interface IEquatable<GSet<'T>> with
+        member this.Equals(other: GSet<'T>) : bool =
+            let a = this.items
+            let b = other.items
+            let an = if a.IsDefault then 0 else a.Length
+            let bn = if b.IsDefault then 0 else b.Length
+            if an <> bn then
+                false
+            else
+                let mutable i = 0
+                let mutable eq = true
+                while i < an && eq do
+                    if Comparer<'T>.Default.Compare(a.[i], b.[i]) <> 0 then eq <- false
+                    i <- i + 1
+                eq
+
+/// Operations on `GSet<'T>`. The combiner `union` is the CRDT merge; `add` is
+/// `union` with a singleton; `ofSeq` canonicalizes arbitrary input.
+[<RequireQualifiedAccess>]
+module GSet =
+
+    /// The empty G-Set (the `union` identity).
+    let empty<'T when 'T : comparison> : GSet<'T> = GSet<'T>.Empty
+
+    /// Canonicalize arbitrary input: sort ascending + drop duplicates.
+    let ofSeq (xs: seq<'T>) : GSet<'T> =
+        let sorted =
+            xs
+            |> Seq.distinct
+            |> Seq.sortWith (fun a b -> Comparer<'T>.Default.Compare(a, b))
+            |> ImmutableArray.CreateRange
+        GSet<'T>(sorted)
+
+    /// A one-element G-Set.
+    let singleton (x: 'T) : GSet<'T> = GSet<'T>(ImmutableArray.Create(x))
+
+    let toArray (g: GSet<'T>) : 'T[] = g.ToArray()
+    let toList (g: GSet<'T>) : 'T list = g.ToArray() |> List.ofArray
+    let toSeq (g: GSet<'T>) : seq<'T> = g.ToArray() :> seq<'T>
+    let contains (x: 'T) (g: GSet<'T>) : bool = g.Contains(x)
+    let count (g: GSet<'T>) : int = g.Count
+    let isEmpty (g: GSet<'T>) : bool = g.IsEmpty
+
+    /// The CRDT merge: the union of two sorted-unique runs, kept sorted-unique.
+    /// Idempotent (`union a a = a`), commutative (`union a b = union b a`), and
+    /// associative — verified by the law tests + the cross-language golden
+    /// vector.
+    let union (a: GSet<'T>) (b: GSet<'T>) : GSet<'T> =
+        let xa = if a.items.IsDefault then ImmutableArray<'T>.Empty else a.items
+        let xb = if b.items.IsDefault then ImmutableArray<'T>.Empty else b.items
+        if xa.IsEmpty then GSet<'T>(xb)
+        elif xb.IsEmpty then GSet<'T>(xa)
+        else
+            let out = ImmutableArray.CreateBuilder<'T>(xa.Length + xb.Length)
+            let mutable i = 0
+            let mutable j = 0
+            while i < xa.Length && j < xb.Length do
+                let c = Comparer<'T>.Default.Compare(xa.[i], xb.[j])
+                if c < 0 then
+                    out.Add(xa.[i]); i <- i + 1
+                elif c > 0 then
+                    out.Add(xb.[j]); j <- j + 1
+                else
+                    out.Add(xa.[i]); i <- i + 1; j <- j + 1 // duplicate → keep one
+            while i < xa.Length do
+                out.Add(xa.[i]); i <- i + 1
+            while j < xb.Length do
+                out.Add(xb.[j]); j <- j + 1
+            GSet<'T>(out.ToImmutable())
+
+    /// Add one element (`union` with a singleton). Idempotent: adding a present
+    /// element returns an equal set.
+    let add (x: 'T) (g: GSet<'T>) : GSet<'T> =
+        if g.Contains(x) then g else union g (singleton x)

--- a/tests/Tests.FSharp/Algebra/GSet.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/GSet.Tests.fs
@@ -1,0 +1,120 @@
+module Zeta.Tests.Algebra.GSetTests
+
+open System.IO
+open System.Reflection
+open System.Text.Json
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+// G-Set is oracle #2 of the cross-language 4-oracle (TS = #1; C#/Rust join
+// later per the meet-in-the-middle fan-out). This file proves the three CRDT
+// convergence laws hold AND that the F# impl replays the SHARED golden vector
+// to the same states the TS reference emitted. "The compilers don't lie."
+
+// ─── CRDT convergence laws (why a G-Set converges without coordination) ────
+
+[<Fact>]
+let ``ofSeq sorts ascending and drops duplicates`` () =
+    GSet.ofSeq [ "c"; "a"; "b"; "a"; "c" ] |> GSet.toList |> should equal [ "a"; "b"; "c" ]
+
+[<Fact>]
+let ``contains agrees with membership via binary search`` () =
+    let s = GSet.ofSeq [ "a"; "c"; "e" ]
+    GSet.contains "c" s |> should equal true
+    GSet.contains "d" s |> should equal false
+    GSet.contains "a" GSet.empty<string> |> should equal false
+
+[<Fact>]
+let ``union is idempotent: union a a = a`` () =
+    let a = GSet.ofSeq [ "a"; "b" ]
+    GSet.union a a |> GSet.toList |> should equal (GSet.toList a)
+
+[<Fact>]
+let ``union is commutative: union a b = union b a`` () =
+    let a = GSet.ofSeq [ "a"; "b" ]
+    let b = GSet.ofSeq [ "b"; "c" ]
+    GSet.union a b |> GSet.toList |> should equal (GSet.union b a |> GSet.toList)
+
+[<Fact>]
+let ``union is associative: union (union a b) c = union a (union b c)`` () =
+    let a = GSet.ofSeq [ "a"; "b" ]
+    let b = GSet.ofSeq [ "b"; "c" ]
+    let c = GSet.ofSeq [ "c"; "d" ]
+    let left = GSet.union (GSet.union a b) c
+    let right = GSet.union a (GSet.union b c)
+    GSet.toList left |> should equal (GSet.toList right)
+
+[<Fact>]
+let ``union identity: union a empty = a and union empty a = a`` () =
+    let a = GSet.ofSeq [ "a"; "b" ]
+    GSet.union a GSet.empty<string> |> GSet.toList |> should equal (GSet.toList a)
+    GSet.union GSet.empty<string> a |> GSet.toList |> should equal (GSet.toList a)
+
+[<Fact>]
+let ``add is idempotent for a present element`` () =
+    let a = GSet.ofSeq [ "a"; "b" ]
+    GSet.add "a" a |> GSet.toList |> should equal (GSet.toList a)
+    GSet.add "z" a |> GSet.toList |> should equal [ "a"; "b"; "z" ]
+
+[<Fact>]
+let ``custom equality: order-independent inputs are equal + hash-stable`` () =
+    let a = GSet.ofSeq [ "a"; "b"; "c" ]
+    let b = GSet.ofSeq [ "c"; "a"; "b"; "a" ]
+    (a = b) |> should equal true
+    a.GetHashCode() |> should equal (b.GetHashCode())
+    (a = GSet.ofSeq [ "a"; "b" ]) |> should equal false
+
+// ─── Shared golden vector (cross-language parity lock) ─────────────────────
+
+/// Walk up from the test assembly to the repo root (Zeta.sln sentinel) — same
+/// pattern as the observe golden-vector test.
+let private repoRoot () : string =
+    let mutable dir = DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))
+    while not (isNull dir) && not (File.Exists(Path.Join(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+    if isNull dir then
+        failwith "Could not locate repo root (Zeta.sln) from test assembly location."
+    dir.FullName
+
+/// Eager list-comprehension over `EnumerateArray()` — NOT `Seq.map`. The
+/// `JsonElement.ArrayEnumerator` is a mutable struct that corrupts when boxed
+/// through a lazy Seq pipeline in Release (passes in fsi, fails compiled).
+let private strList (e: JsonElement) : string list =
+    [ for x in e.EnumerateArray() -> x.GetString() ]
+
+type private GsOp =
+    | Add of string
+    | Union of string list
+
+let private parseOp (e: JsonElement) : GsOp =
+    match e.GetProperty("op").GetString() with
+    | "add" -> Add(e.GetProperty("arg").GetString())
+    | "union" -> Union(strList (e.GetProperty("arg")))
+    | other -> failwithf "unknown g-set op in fixture: %s" other
+
+/// Read the fixture once; copy every primitive into F# values so the
+/// JsonDocument is safe to dispose before the values are used.
+let private loadVector () : string list * GsOp list * string list list * string list =
+    let path = Path.Join(repoRoot (), "src", "Core.TypeScript", "g-set", "golden-vectors.json")
+    use doc = JsonDocument.Parse(File.ReadAllText(path))
+    let root = doc.RootElement
+    let initial = strList (root.GetProperty("initialSet"))
+    let ops = [ for op in root.GetProperty("ops").EnumerateArray() -> parseOp op ]
+    let replay = [ for st in root.GetProperty("expectedReplayStates").EnumerateArray() -> strList st ]
+    let final = strList (root.GetProperty("expectedFinalState"))
+    initial, ops, replay, final
+
+[<Fact>]
+let ``F# replays the shared golden vector to expectedReplayStates + expectedFinalState`` () =
+    let initial, ops, expectedReplay, expectedFinal = loadVector ()
+    let mutable state = GSet.ofSeq initial
+    let actual =
+        [ for op in ops do
+              state <-
+                  match op with
+                  | Add x -> GSet.add x state
+                  | Union xs -> GSet.union state (GSet.ofSeq xs)
+              yield GSet.toList state ]
+    actual |> should equal expectedReplay
+    GSet.toList state |> should equal expectedFinal

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Algebra/Weight.Tests.fs" />
     <Compile Include="Algebra/CayleyDickson.Tests.fs" />
     <Compile Include="Algebra/Units.Tests.fs" />
+    <Compile Include="Algebra/GSet.Tests.fs" />
     <Compile Include="Algebra/ZSet.Tests.fs" />
     <Compile Include="Algebra/ZSet.Overflow.Tests.fs" />
     <Compile Include="Algebra/Residuated.Tests.fs" />


### PR DESCRIPTION
## What

The **G-Set first-class pair** (the bottom rung of the algebra ladder, made first-class instead of implicit) + **B-0959**, the master checklist that pulls the whole sovereign distributed-DB + agent-loop together so pieces stop getting re-forgotten.

## G-Set pair (parity-locked)

| File | What |
|---|---|
| `src/Core/GSet.fs` | grow-only set; idempotent / commutative / associative / identity union; the Z-set restricted to non-negative multiplicity (registered before `ZSet.fs`) |
| `src/Core.TypeScript/g-set/` | TS twin — same canonical sorted-unique repr; required `compare` is the analog of F# `'T : comparison` |
| `src/Core.TypeScript/g-set/golden-vectors.json` | shared cross-language oracle; TS (oracle 1) + F# (oracle 2) both replay it; structured for C#/Rust to join per the meet-in-the-middle 4-oracle |

**Verify:** F# 9/9 + TS 9/9 (laws + custom equality + golden-vector replay); Core builds 0 warnings / 0 errors; eslint + prettier clean.

**Why it matters:** the git-native agent-bus (B-0954) IS a G-Set CRDT — this unblocks it. Bus = grow-only comms, Ace = retraction-native Z-set, one substrate.

## B-0959 master checklist

One git-native ZetaId Z-set substrate, sections for: algebra ladder · observe loop (B-0958) · git-native bus (B-0954) · distributed-time primitive (IScheduler time-generator B-0878 + CockroachDB-similar 3-layer mediation + FoundationDB-style single-thread multi-node DST + closure-table-over-Z-set `Hierarchy.fs`) · the 4-oracle meet-in-the-middle · dual-mode transport. Captures the **Rx-queries-over-the-bus-onto-the-observe-dashboard** direction (conditional by context/mode).

Also flips B-0958 `folderSink` `[~]`→`[x]` (#6312 merged, now on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
