### PR TITLE
backlog(B-0960): Ace slice 3.1 — pave the strict-by-default road (DX/security follow-on)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -460,6 +460,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0956](backlog/P1/B-0956-migrate-backlog-sequential-b-nnnn-ids-to-zetaid-workitem-keys-conflict-free-no-cross-agent-id-consensus-aaron-otto-2026-05-31.md)** Migrate work-items to ZetaId WorkItem keys (conflict-free, no cross-agent ID consensus) — type ∈ {task, bug}; backlog is a STATE, not a type
 - [ ] **[B-0957](backlog/P1/B-0957-first-class-labels-tags-scopes-on-every-gset-zset-entity-deferred-to-human-state-label-otel-baggage-di-scope-propagation-aaron-otto-2026-05-31.md)** First-class labels/tags + scopes on every G-Set/Z-set entity — deferred-to-human state-label; OTel-baggage / DI-scope propagation; the metadata layer policies + decentralized identity build on
 - [ ] **[B-0958](backlog/P1/B-0958-observe-ts-agent-loop-implementation-and-testing-checklist-closed-loop-toward-vendor-store-aaron-otto-2026-05-31.md)** observe.ts agent-loop — implementation + testing checklist (the closed observe→execute→loadWorld loop; toward vendor-store distribution)
+- [ ] **[B-0959](backlog/P1/B-0959-zeta-sovereign-distributed-db-and-agent-loop-master-checklist-one-git-native-zset-substrate-aaron-otto-2026-05-31.md)** Zeta sovereign distributed-DB + agent-loop MASTER checklist — one git-native ZetaId Z-set substrate (algebra ladder · observe loop · git-native bus · distributed time · 4-oracle)
 
 ## P2 — research-grade
 
@@ -910,6 +911,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0953](backlog/P2/B-0953-git-v2-handshake-fsharp-looks-like-git-negotiates-up-to-dbsp-retraction-algebra-same-objects-agent-speed-upstream-aaron-2026-05-31.md)** Git-V2 handshake — F# looks-like-git, negotiates up to a DBSP/retraction-algebra protocol at agent-coordination speed; same objects both views; upstream the primitives to git
 - [ ] **[B-0954](backlog/P2/B-0954-implement-git-native-cross-machine-agent-bus-docs-agent-bus-folder-zetaid-keyed-gset-crdt-no-pr-per-6219-spec-aaron-otto-2026-05-31.md)** Implement the git-native cross-machine agent-bus — docs/agent-bus/ folder, ZetaId-Bus-keyed G-Set CRDT, no-PR (per the #6219 spec); the cross-machine/Windows comms channel
 - [ ] **[B-0955](backlog/P2/B-0955-migrate-tools-off-bun-only-apis-to-node-process-equivalents-node-safe-baseline-policy-aaron-otto-2026-05-31.md)** Migrate tools/ production code off Bun-only APIs to node:/process equivalents — honor the Node-safe-baseline policy (2026-04-20 tools-runtime ADR v6)
+- [ ] **[B-0960](backlog/P2/B-0960-ace-slice3.1-pave-the-strict-default-road-2026-06-01.md)** Ace slice 3.1 — pave the strict-by-default road (lower signature friction)
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-0960-ace-slice3.1-pave-the-strict-default-road-2026-06-01.md
+++ b/docs/backlog/P2/B-0960-ace-slice3.1-pave-the-strict-default-road-2026-06-01.md
@@ -1,0 +1,88 @@
+---
+id: B-0960
+priority: P2
+status: open
+title: "Ace slice 3.1 — pave the strict-by-default road (lower signature friction)"
+created: 2026-06-01
+last_updated: 2026-06-01
+parent: B-0288
+depends_on: [B-0288]
+classification: buildable-now
+decomposition: atomic
+owners: [developer-experience-engineer, security-researcher]
+type: feature
+---
+
+# B-0960 — Ace slice 3.1: pave the strict-by-default road
+
+Follow-on to Ace slice 3 (Ed25519 authenticity; signed-enforced install gate,
+`--allow-unsigned` opt-out). Operator-authorized deferred follow-on
+(the operator 2026-06-01): *"you can push it through it can be a later follow on …
+it's better to build strict first in my mind and back off later cause of friction
+instead of the other way around."*
+
+## Decision context — the default is CONFIRMED strict; this row is the paving
+
+The operator reopened the cost-benefit on the default enforcement posture
+(strict-by-default + `--allow-unsigned` switch vs loose-default + opt-in `--strict`).
+Ran it by the team + web research; **all lenses converged on KEEP strict-by-default**:
+
+- **Security (security-researcher):** "Pick A. Do not change the default." Loose-default
+  on an untrusted distribution surface = unauthenticated write-then-install (the exact
+  attack); fail-closed is correct; the empty-bundled-trust bootstrap *strengthens* the
+  argument (the first experience sets the mental model). Loose-default flagged Important
+  (teaches the wrong reflex), not a shipped P0 (bundled trust is empty today).
+- **DX (developer-experience-engineer):** strict is the correct posture; the risk is
+  *friction*, not the default — a strict path that's too painful makes `--allow-unsigned`
+  the reflexive de-facto mode (strictness becomes theater). Verdict: keep strict, **pave
+  the road**.
+- **Web research (search-first):** secure-defaults UX — users stick with defaults;
+  "disabling a security feature should require justification" (opt-out > opt-in);
+  BUT "when security is difficult/noisy, people bypass the controls" (paved-road) —
+  so reduce the friction of strict, don't abandon it.
+  Sources: [NCSC Secure by Default](https://www.ncsc.gov.uk/information/secure-default),
+  [ReversingLabs secure-by-default](https://www.reversinglabs.com/blog/secure-by-default-a-painless-way-to-harden-your-appsec),
+  [Semgrep — security as path of least resistance](https://semgrep.dev/blog/2026/security-should-be-the-path-of-least-resistance/).
+
+The default stays strict (shipped in the slice-3 build PR). This row tracks the
+"make strict the easy path" work so the escape hatch doesn't become the norm.
+
+## Acceptance criteria (paving items, ranked by leverage)
+
+1. **Golden-path refusal messages** — the unsigned-install refusal should name the
+   remediation FIRST (`ace trust add <pub>` / where to get the publisher `.pub`),
+   not lead with `--allow-unsigned`. (Slice 3 already enriched the *untrusted-key*
+   refusal + trust-list-empty hint; extend the same to the *unsigned* refusal +
+   make the `--allow-unsigned` WARNING nudge toward `ace trust add`.)
+2. **Root-key custody ceremony (the big one)** — bundled `tools/ace/trusted-keys.json`
+   ships empty, so out-of-box every install needs `trust add`/`--allow-unsigned`.
+   Until the real Zeta root key is provisioned (per the
+   [agent-native key-custody design](../../research/2026-05-31-agent-native-key-custody-design-otto-holds-key-aaron-cant-access-wont-lose-threshold-attestation-honest-debug-dump-limit.md)),
+   strict-default is theater for Zeta-store packages. This is the highest-impact
+   paving step — once a real key is in the bundled anchor, the typical signed
+   install just works. (Operator custody ceremony — gated on the operator.)
+3. **`ace trust add` ergonomics** — a convenience path (e.g. `--from-url`) so trusting
+   a well-known publisher key is one command, not a key-retrieval-and-pipe dance.
+4. **`ace sign` CI ergonomics** — signing a package in a CI pipeline should be a single
+   obvious command, so publishers sign by default rather than skip.
+5. **`--allow-unsigned` telemetry** — a counter in the store log of `--allow-unsigned`
+   installs, as a signal if the escape hatch is becoming the de-facto default
+   (the degradation-without-policy-change risk both reviewers named).
+6. **Quickstart** — a two-command golden path in `CONTRIBUTING.md`/SKILL so a dev
+   doesn't have to read the design doc to learn the trust→install flow.
+
+## Out of scope (further-out)
+
+Key rotation/revocation/expiry; order-independent `content_hash`; guardian-AI
+oversight; minisign/sigstore interop (all per slice-3 design §10). Also the open
+operator question on whether to RENAME `--allow-unsigned` (e.g. `--allow-no-signature`)
+— a CLI-contract decision deferred to the operator; the slice-3 build applied only
+the help-text gloss.
+
+## Composes with
+
+- B-0288 (Ace CLI parent) · slice 3 build (Ed25519 authenticity) · the slice-3 design
+  `docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice3-authenticity-signature-verify-design.md`
+  §6 (gate) + §8 (threat model) + §10 (follow-ons).
+- `.claude/rules/automated-tests-are-the-shield-assert-dont-skip.md` (the false-green
+  discipline that frames "strict path must be paved, not just present").


### PR DESCRIPTION
Operator-authorized deferred follow-on to Ace slice 3 (#6320, Ed25519 strict-by-default authenticity).

The operator reopened the cost-benefit on the default (strict-by-default vs loose+opt-in-strict). Ran it by the team + web research; **all lenses converged on keep strict-by-default** — security (fail-closed on an untrusted distribution surface; loose = unauthenticated write-then-install), DX (strict is the right posture; the risk is friction, not the default), and the secure-defaults literature (opt-out > opt-in; but pave the road so the escape hatch doesn't become the norm). Operator's call: *"build strict first, back off later for friction, not the other way around."*

The default stays strict (shipped in #6320). **This row captures the deferred paving plan** so the research + verdict don't evaporate: golden-path refusal messages, the root-key custody ceremony (highest-impact — bundled trust ships empty today), `ace trust add`/`ace sign` ergonomics, `--allow-unsigned` telemetry, a quickstart. Also records the open operator question (whether to rename `--allow-unsigned`).

Docs-only (new P2 row + regenerated BACKLOG.md index). Does not touch #6320.

> ID note: B-0958/B-0959 were peer-created on main between my ID-check and write (multi-agent ID race per the otto-channels rule); renumbered to B-0960, dup-id audit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)