### PR TITLE
feat(agentic-org): model mission trajectory pressure

### DIFF
--- a/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
+++ b/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
@@ -654,6 +654,20 @@ when capacity, reliability, or mission pressure changes.
   supervisor/RMO reassignment;
 - expose schedule pressure in director, TPM, manager, and agent readouts.
 
+**Checkpoint 2026-06-01: mission trajectory kernel**
+
+The scheduling kernel now includes `evaluateMissionTrajectory`, a pure
+expected-vs-actual mission slope model. It takes mission timeframe, target
+progress, actual progress, and tolerance, then returns `on_track`, `at_risk`,
+or `off_track` with expected progress, lag, remaining time, evidence refs, and
+legal schedule corrective actions. Management observe readouts now derive their
+mission progress slope from this shared kernel instead of a separate ad hoc
+timeframe calculation, so director/TPM/manager surfaces and supervisor
+reassignment policy use the same trajectory semantics. Subagent review for this
+checkpoint was attempted but blocked by the platform agent-thread limit
+(`collab spawn failed: agent thread limit reached`); the local TDD review
+covered scheduler and observe tests instead.
+
 **Algorithms:**
 
 - **mission trajectory model:** compare target milestone slope to actual progress

--- a/agentic-organization/packages/application/src/index.ts
+++ b/agentic-organization/packages/application/src/index.ts
@@ -199,10 +199,14 @@ export {
   type ScheduleAuthorityCommandRule,
 } from "./schedule-authority.ts";
 export {
+  MissionTrajectoryStatus,
   ScheduleCorrectiveActionKind,
   SchedulePressureLevel,
   SchedulePressureSignalKind,
   computeSchedulePressure,
+  evaluateMissionTrajectory,
+  type MissionTrajectory,
+  type MissionTrajectoryInput,
   schedulePressureReadoutForHat,
   type ScheduleCorrectiveAction,
   type SchedulePressure,

--- a/agentic-organization/packages/application/src/observe.ts
+++ b/agentic-organization/packages/application/src/observe.ts
@@ -48,6 +48,11 @@ import type {
   PromptFlowRollbackPolicy,
   PromptFlowRunState,
 } from "./prompt-flow.ts";
+import {
+  MissionTrajectoryStatus,
+  evaluateMissionTrajectory,
+  type MissionTrajectory,
+} from "./schedule-optimizer.ts";
 
 /**
  * ZetaId rendered as a base-10 string — the canonical index for git-as-db
@@ -1961,12 +1966,13 @@ function hierarchyMissionReadoutForHat(
   const mission = mostSpecificMissionForHat(hat, missions, projects, initiatives);
   if (mission === undefined) return undefined;
 
-  const expectedProgressPercent = expectedMissionProgressPercent(mission.timeframe, observedAt);
-  const actualProgressPercent = clampPercent(mission.progressPercent);
+  const trajectory = missionTrajectoryForReadout(mission, hat, observedAt);
+  const expectedProgressPercent = Math.floor(trajectory.expectedProgress * 100);
+  const actualProgressPercent = Math.floor(trajectory.actualProgress * 100);
   const variancePercent = actualProgressPercent - expectedProgressPercent;
   const daysRemaining = missionDaysRemaining(mission.timeframe, observedAt);
   const lagSignals = missionLagSignals(mission, expectedProgressPercent, actualProgressPercent, daysRemaining);
-  const status = missionStatus(mission.status, lagSignals);
+  const status = missionStatus(mission.status, lagSignals, trajectory.status);
   const corrective = missionCorrectiveActions(status, actions, vetoedActions);
 
   return {
@@ -2038,13 +2044,22 @@ function missionSpecificityScore(
   return score;
 }
 
-function expectedMissionProgressPercent(timeframe: HierarchyMissionTimeframe, observedAt: string): number {
-  const start = Date.parse(timeframe.startsAt);
-  const target = Date.parse(timeframe.targetAt);
-  const observed = Date.parse(observedAt);
-  if (!Number.isFinite(start) || !Number.isFinite(target) || !Number.isFinite(observed)) return 0;
-  if (target <= start) return observed >= target ? 100 : 0;
-  return Math.floor(clampPercent(((observed - start) / (target - start)) * 100));
+function missionTrajectoryForReadout(
+  mission: HierarchyMission,
+  hat: HatDefinition,
+  observedAt: string,
+): MissionTrajectory {
+  return evaluateMissionTrajectory({
+    organizationId: "observe",
+    missionId: mission.missionId,
+    now: observedAt,
+    startsAt: mission.timeframe.startsAt,
+    targetAt: mission.timeframe.targetAt,
+    targetProgress: 1,
+    actualProgress: clampPercent(mission.progressPercent) / 100,
+    tolerance: 0.1,
+    correctiveActionHatId: mission.assignedHatId ?? hat.id,
+  });
 }
 
 function missionDaysRemaining(timeframe: HierarchyMissionTimeframe, observedAt: string): number {
@@ -2122,11 +2137,13 @@ function missionLagSignals(
 function missionStatus(
   declared: HierarchyMissionStatus,
   lagSignals: readonly HierarchyMissionLagSignal[],
+  trajectoryStatus: MissionTrajectoryStatus,
 ): HierarchyMissionStatus {
   if (declared === "complete") return "complete";
   if (lagSignals.some((signal) => signal.severity === "blocked")) return "blocked";
   if (lagSignals.some((signal) => signal.severity === "behind")) return "behind";
-  if (lagSignals.some((signal) => signal.severity === "at_risk")) return "at_risk";
+  if (trajectoryStatus === MissionTrajectoryStatus.OffTrack) return "behind";
+  if (lagSignals.some((signal) => signal.severity === "at_risk") || trajectoryStatus === MissionTrajectoryStatus.AtRisk) return "at_risk";
   return declared;
 }
 

--- a/agentic-organization/packages/application/src/schedule-optimizer.ts
+++ b/agentic-organization/packages/application/src/schedule-optimizer.ts
@@ -107,6 +107,77 @@ export type SchedulePressureReadout = {
   readonly correctiveActions: readonly ScheduleCorrectiveAction[];
 };
 
+export const MissionTrajectoryStatus = {
+  OnTrack: "on_track",
+  AtRisk: "at_risk",
+  OffTrack: "off_track",
+} as const;
+
+export type MissionTrajectoryStatus =
+  (typeof MissionTrajectoryStatus)[keyof typeof MissionTrajectoryStatus];
+
+export type MissionTrajectoryInput = {
+  readonly organizationId: string;
+  readonly missionId: string;
+  readonly now: string;
+  readonly startsAt: string;
+  readonly targetAt: string;
+  readonly targetProgress: number;
+  readonly actualProgress: number;
+  readonly tolerance?: number;
+  readonly correctiveActionHatId?: string;
+};
+
+export type MissionTrajectory = {
+  readonly organizationId: string;
+  readonly missionId: string;
+  readonly status: MissionTrajectoryStatus;
+  readonly expectedProgress: number;
+  readonly actualProgress: number;
+  readonly lag: number;
+  readonly elapsedRatio: number;
+  readonly remainingRatio: number;
+  readonly correctiveActions: readonly ScheduleCorrectiveAction[];
+  readonly evidenceRefs: readonly string[];
+};
+
+export function evaluateMissionTrajectory(input: MissionTrajectoryInput): MissionTrajectory {
+  const elapsedRatio = elapsedRatioForDates(input.startsAt, input.targetAt, input.now);
+  const remainingRatio = round3(1 - elapsedRatio);
+  const targetProgress = clamp01(input.targetProgress);
+  const expectedProgress = round3(targetProgress * elapsedRatio);
+  const actualProgress = round3(clamp01(input.actualProgress));
+  const lag = round3(Math.max(0, expectedProgress - actualProgress));
+  const tolerance = Math.max(0, input.tolerance ?? 0.1);
+  const missedTarget = elapsedRatio >= 1 && actualProgress < round3(targetProgress - tolerance);
+  const status =
+    missedTarget || lag > tolerance * 2
+      ? MissionTrajectoryStatus.OffTrack
+      : lag > tolerance
+        ? MissionTrajectoryStatus.AtRisk
+        : MissionTrajectoryStatus.OnTrack;
+  const correctiveActions = correctiveActionsForTrajectory(status, input.correctiveActionHatId ?? input.missionId);
+
+  return {
+    organizationId: input.organizationId,
+    missionId: input.missionId,
+    status,
+    expectedProgress,
+    actualProgress,
+    lag,
+    elapsedRatio: round3(elapsedRatio),
+    remainingRatio,
+    correctiveActions,
+    evidenceRefs: [
+      `mission:${input.missionId}`,
+      `trajectory:${status}`,
+      `expected:${expectedProgress}`,
+      `actual:${actualProgress}`,
+      `lag:${lag}`,
+    ],
+  };
+}
+
 export function computeSchedulePressure(input: SchedulePressureInput): SchedulePressure {
   const workMarket = workMarketReadoutForHat(input.workQueues, {
     organizationId: input.organizationId,
@@ -291,6 +362,24 @@ function correctiveActionsForPressure(pressure: SchedulePressure): readonly Sche
   return dedupeActions(actions);
 }
 
+function correctiveActionsForTrajectory(
+  status: MissionTrajectoryStatus,
+  hatId: string,
+): readonly ScheduleCorrectiveAction[] {
+  if (status === MissionTrajectoryStatus.OnTrack) return [];
+  if (status === MissionTrajectoryStatus.AtRisk) {
+    return dedupeActions([
+      action(ScheduleCorrectiveActionKind.ExtendFocusBlock, hatId, "Extend focus block", "mission trajectory is behind expected progress but still recoverable inside tolerance bounds"),
+      action(ScheduleCorrectiveActionKind.OpenOfficeHours, hatId, "Open office hours", "mission trajectory needs coordination before adding capacity"),
+    ]);
+  }
+  return dedupeActions([
+    action(ScheduleCorrectiveActionKind.RebalanceHatCapacity, hatId, "Rebalance hat capacity", "mission trajectory is off track against target slope"),
+    action(ScheduleCorrectiveActionKind.RequestRmoExpand, hatId, "Request RMO expansion", "mission trajectory may require more legal hat capacity"),
+    action(ScheduleCorrectiveActionKind.PauseLowPriorityWork, hatId, "Pause low-priority work", "off-track mission should protect the highest-priority trajectory"),
+  ]);
+}
+
 function action(
   kind: ScheduleCorrectiveActionKind,
   hatId: string,
@@ -335,6 +424,15 @@ function activeAt(block: WorkScheduleBlock, now: string): boolean {
   const startsAt = Date.parse(block.startsAt);
   const endsAt = Date.parse(block.endsAt);
   return block.state === ScheduleBlockState.Active && Number.isFinite(nowMs) && startsAt <= nowMs && nowMs < endsAt;
+}
+
+function elapsedRatioForDates(startsAt: string, targetAt: string, now: string): number {
+  const startsAtMs = Date.parse(startsAt);
+  const targetAtMs = Date.parse(targetAt);
+  const nowMs = Date.parse(now);
+  if (!Number.isFinite(startsAtMs) || !Number.isFinite(targetAtMs) || !Number.isFinite(nowMs)) return 0;
+  if (targetAtMs <= startsAtMs) return nowMs >= targetAtMs ? 1 : 0;
+  return clamp01((nowMs - startsAtMs) / (targetAtMs - startsAtMs));
 }
 
 function blockBelongsToHat(

--- a/agentic-organization/packages/application/test/schedule-optimizer.test.ts
+++ b/agentic-organization/packages/application/test/schedule-optimizer.test.ts
@@ -9,15 +9,82 @@ import {
   type WorkScheduleBlock,
 } from "../../domain/src/index.ts";
 import {
+  MissionTrajectoryStatus,
   ScheduleCorrectiveActionKind,
   SchedulePressureLevel,
   computeSchedulePressure,
+  evaluateMissionTrajectory,
   schedulePressureReadoutForHat,
 } from "../src/index.ts";
 import { buildHatDefinitions } from "../src/org-seed.ts";
 import { WorkClaimState, WorkShardState, type HatWorkQueue } from "../src/work-market.ts";
 
 const NOW = "2026-05-31T12:30:00.000Z";
+
+test("mission trajectory marks late missions off track and emits capacity corrective actions", () => {
+  const trajectory = evaluateMissionTrajectory({
+    organizationId: "org-lfg",
+    missionId: "mission-observe-act",
+    now: "2026-05-31T12:00:00.000Z",
+    startsAt: "2026-05-01T00:00:00.000Z",
+    targetAt: "2026-06-30T00:00:00.000Z",
+    targetProgress: 1,
+    actualProgress: 0.18,
+    tolerance: 0.08,
+    correctiveActionHatId: "engineering_director",
+  });
+
+  equal(trajectory.status, MissionTrajectoryStatus.OffTrack);
+  equal(trajectory.expectedProgress, 0.508);
+  equal(trajectory.actualProgress, 0.18);
+  equal(trajectory.lag, 0.328);
+  deepEqual(
+    trajectory.correctiveActions.map((action) => action.kind),
+    [
+      ScheduleCorrectiveActionKind.PauseLowPriorityWork,
+      ScheduleCorrectiveActionKind.RebalanceHatCapacity,
+      ScheduleCorrectiveActionKind.RequestRmoExpand,
+    ],
+  );
+  ok(trajectory.evidenceRefs.includes("mission:mission-observe-act"));
+  ok(trajectory.evidenceRefs.includes("trajectory:off_track"));
+});
+
+test("mission trajectory distinguishes at-risk and on-track schedules by tolerance", () => {
+  const atRisk = evaluateMissionTrajectory({
+    organizationId: "org-lfg",
+    missionId: "mission-work-market",
+    now: "2026-05-31T12:00:00.000Z",
+    startsAt: "2026-05-01T00:00:00.000Z",
+    targetAt: "2026-06-30T00:00:00.000Z",
+    targetProgress: 1,
+    actualProgress: 0.45,
+    tolerance: 0.04,
+    correctiveActionHatId: "technical_program_manager",
+  });
+  const onTrack = evaluateMissionTrajectory({
+    organizationId: "org-lfg",
+    missionId: "mission-work-market",
+    now: "2026-05-31T12:00:00.000Z",
+    startsAt: "2026-05-01T00:00:00.000Z",
+    targetAt: "2026-06-30T00:00:00.000Z",
+    targetProgress: 1,
+    actualProgress: 0.49,
+    tolerance: 0.04,
+    correctiveActionHatId: "technical_program_manager",
+  });
+
+  equal(atRisk.status, MissionTrajectoryStatus.AtRisk);
+  deepEqual(
+    atRisk.correctiveActions.map((action) => action.kind),
+    [
+      ScheduleCorrectiveActionKind.ExtendFocusBlock,
+      ScheduleCorrectiveActionKind.OpenOfficeHours,
+    ],
+  );
+  equal(onTrack.status, MissionTrajectoryStatus.OnTrack);
+  deepEqual(onTrack.correctiveActions, []);
+});
 
 test("schedule pressure combines queue depth, stale claims, review lag, failure rate, and reliability", () => {
   const pressure = computeSchedulePressure({


### PR DESCRIPTION
## Summary

- add `evaluateMissionTrajectory` as the Phase 2.6 mission slope kernel for `on_track`, `at_risk`, and `off_track` schedule pressure
- emit legal schedule corrective actions and evidence refs from trajectory status
- wire management observe mission readouts through the shared trajectory kernel
- document the Phase 2.6 checkpoint in `PHASE_2_PRODUCTION_AUTONOMY_CA.md`

## Verification

- `node --experimental-strip-types --test packages/application/test/schedule-optimizer.test.ts`
- `node --experimental-strip-types --test packages/application/test/schedule-optimizer.test.ts packages/application/test/observe.test.ts`
- `node --experimental-strip-types --test packages/application/test/schedule-optimizer.test.ts packages/application/test/observe.test.ts packages/application/test/observe-for-hat.test.ts`
- `npm run typecheck`
- `npm test` (1223 total, 1216 pass, 7 skipped)
- `git diff --check`

## Local .NET gate

- `dotnet build -c Release` blocked locally because `global.json` requires SDK `10.0.203`; installed SDKs are `10.0.101`, `9.0.200`, and `9.0.100`
- `dotnet test Zeta.sln -c Release` blocked for the same SDK mismatch
- `dotnet format --verify-no-changes` blocked for the same SDK mismatch

## Subagent Review

Attempted to spawn a subagent reviewer for this checkpoint, but the platform returned `collab spawn failed: agent thread limit reached`. Local review covered scheduler and observe tests; PR review should treat the missing subagent pass as a process constraint, not a completed external review.
