### PR TITLE
feat(B-0954): agent-bus on the G-Set foundation — cross-machine merge view

### DIFF
--- a/tools/agent-bus/g-set-view.test.ts
+++ b/tools/agent-bus/g-set-view.test.ts
@@ -1,0 +1,85 @@
+/**
+ * g-set-view.test.ts — the bus AS a first-class G-Set (B-0954 on the G-Set foundation).
+ *
+ * Proves the cross-machine read-model: folding a clone's envelopes into a G-Set of
+ * ids, merging N clones by G-Set union (commutative + idempotent — the CRDT laws
+ * that make it coordination-free), the unseen-since-merge difference, and the
+ * re-hydration back to envelopes.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { ofArray, stringCompare, toArray } from "../../src/Core.TypeScript/g-set/g-set";
+import type { AgentBusEnvelope } from "./types";
+import { busIdSet, envelopesIn, mergeViews, unseen } from "./g-set-view";
+
+/** A minimal valid envelope for a given id (the view only reads `.id`). */
+const env = (id: string): AgentBusEnvelope => ({
+  topic: "shadow-catch",
+  payload: { content: `msg ${id}` },
+  id,
+  from: "otto-cli",
+  to: "*",
+  timestamp: "2026-06-01T00:00:00.000Z",
+  expiresAt: "2026-06-01T01:00:00.000Z",
+});
+
+const A = "a".repeat(32);
+const B = "b".repeat(32);
+const C = "c".repeat(32);
+const D = "d".repeat(32);
+
+describe("busIdSet — the bus AS a grow-only set of ids", () => {
+  it("folds envelopes to a sorted-unique id set", () => {
+    expect(toArray(busIdSet([env(C), env(A), env(B)]))).toEqual([A, B, C]);
+  });
+  it("is idempotent: duplicate-id envelopes collapse to one", () => {
+    expect(toArray(busIdSet([env(A), env(A), env(B)]))).toEqual([A, B]);
+  });
+  it("empty clone → empty set", () => {
+    expect(toArray(busIdSet([]))).toEqual([]);
+  });
+});
+
+describe("mergeViews — cross-machine union (the whole cross-machine story)", () => {
+  const cli = busIdSet([env(A), env(B)]);
+  const windows = busIdSet([env(B), env(C)]);
+
+  it("unions two machines' clones", () => {
+    expect(toArray(mergeViews([cli, windows]))).toEqual([A, B, C]);
+  });
+  it("is commutative — merge order does not matter", () => {
+    expect(toArray(mergeViews([cli, windows]))).toEqual(toArray(mergeViews([windows, cli])));
+  });
+  it("is idempotent — re-merging an included view changes nothing", () => {
+    const once = mergeViews([cli, windows]);
+    expect(toArray(mergeViews([once, cli, windows]))).toEqual(toArray(once));
+  });
+  it("empty merge → empty set", () => {
+    expect(toArray(mergeViews([]))).toEqual([]);
+  });
+});
+
+describe("unseen — what a peer's clone has that mine lacks", () => {
+  it("returns the set difference theirs − mine", () => {
+    const mine = ofArray(stringCompare, [A, B]);
+    const theirs = ofArray(stringCompare, [B, C, D]);
+    expect(unseen(mine, theirs)).toEqual([C, D]);
+  });
+  it("nothing new when theirs ⊆ mine", () => {
+    const mine = ofArray(stringCompare, [A, B, C]);
+    const theirs = ofArray(stringCompare, [A, B]);
+    expect(unseen(mine, theirs)).toEqual([]);
+  });
+});
+
+describe("envelopesIn — re-hydrate a merged id-set back to envelopes", () => {
+  it("maps ids to envelopes via the lookup, dropping unknown ids", () => {
+    const byId = new Map<string, AgentBusEnvelope>([
+      [A, env(A)],
+      [C, env(C)],
+    ]);
+    const merged = ofArray(stringCompare, [A, B, C]); // B has no envelope in byId
+    const got = envelopesIn(merged, byId).map((e) => e.id);
+    expect(got).toEqual([A, C]);
+  });
+});

--- a/tools/agent-bus/g-set-view.ts
+++ b/tools/agent-bus/g-set-view.ts
@@ -1,0 +1,69 @@
+/**
+ * tools/agent-bus/g-set-view.ts — the agent-bus AS a first-class G-Set
+ * (B-0954 on the G-Set foundation; the read-model the §3 math note describes).
+ *
+ * The existing `subscribe.ts` reads ONE `origin/main` tree via an ordered
+ * `(timestamp, id)` cursor — exactly right for "stream me what's new in MY clone."
+ * But the **cross-machine** bus state is the UNION of every machine's clone, and
+ * the union of disjoint ZetaId-named envelope files IS a **G-Set** (grow-only,
+ * idempotent / commutative / associative — the three CRDT convergence laws). This
+ * module models that union explicitly, on the first-class `GSet` (`src/Core.TypeScript/g-set/`).
+ *
+ * This is the B-0959 §0 agent-partition recognition applied to the bus: each clone
+ * is a shard; the global bus = the CRDT **merge** of shards; no coordinator is
+ * needed because the merge is a pure G-Set union. It is monotone, so per CALM it is
+ * coordination-free: reading + merging bus views across machines never needs to
+ * agree on an order — union is commutative + idempotent.
+ *
+ * PURE: no git, no IO. Callers feed it the envelopes that `subscribe.ts`'
+ * `readEnvelopesFromGitRef` / `readEnvelopesSince` already produced (per machine),
+ * and this folds + merges them. Composes the read side onto the algebra.
+ */
+
+import { contains, ofArray, stringCompare, toArray, union, type GSet } from "../../src/Core.TypeScript/g-set/g-set";
+import type { AgentBusEnvelope } from "./types";
+
+/**
+ * The bus AS a G-Set: the grow-only set of envelope ids. Idempotent — re-reading
+ * the same clone (or duplicate envelopes sharing an id) yields the same set.
+ */
+export function busIdSet(envelopes: readonly AgentBusEnvelope[]): GSet<string> {
+  return ofArray(
+    stringCompare,
+    envelopes.map((e) => e.id),
+  );
+}
+
+/**
+ * Cross-machine merge: union the id-sets of N machines' clones. This is the whole
+ * cross-machine story in one line — disjoint ZetaId files mean the union is exact
+ * and conflict-free (G-Set CRDT). Commutative + idempotent: merge order does not
+ * matter and re-merging a view already included changes nothing.
+ */
+export function mergeViews(views: readonly GSet<string>[]): GSet<string> {
+  let acc: GSet<string> = [];
+  for (const v of views) acc = union(stringCompare, acc, v);
+  return acc;
+}
+
+/**
+ * Ids a peer's clone has that mine does not — "what's new to me after a merge."
+ * (A set difference: present-in-`theirs`, absent-from-`mine`.)
+ */
+export function unseen(mine: GSet<string>, theirs: GSet<string>): string[] {
+  return toArray(theirs).filter((id) => !contains(stringCompare, mine, id));
+}
+
+/**
+ * Re-hydrate the merged id-set back to envelopes, given a per-id lookup built from
+ * the machines' reads. Ids with no envelope in `byId` are dropped (best-effort,
+ * schema-on-read already filtered malformed envelopes upstream).
+ */
+export function envelopesIn(ids: GSet<string>, byId: ReadonlyMap<string, AgentBusEnvelope>): AgentBusEnvelope[] {
+  const out: AgentBusEnvelope[] = [];
+  for (const id of toArray(ids)) {
+    const env = byId.get(id);
+    if (env !== undefined) out.push(env);
+  }
+  return out;
+}


### PR DESCRIPTION
## What

Wires the git-native agent-bus (B-0954) onto the **G-Set foundation** (the `src/Core.TypeScript/g-set/` module from #6322) — the genuine missing piece, added additively.

### Substrate-honest note

The bus **publish / subscribe / types / tests already existed on main** (built after B-0954 was filed; the row text still said "not started"). I did **not** rebuild them — `verify-existing-substrate` caught it before I wrote a duplicate. What was missing was the G-Set foundation: the existing `subscribe.ts` reads **one** `origin/main` tree via an ordered `(timestamp, id)` cursor, but the **cross-machine** bus state is the **union of every machine's clone**, and union of disjoint ZetaId files **is a G-Set** (B-0954 acceptance items 4/5).

### Added (no rewrite of publish/subscribe)

`tools/agent-bus/g-set-view.ts` — the bus AS a first-class `GSet<id>`:

- `busIdSet(envelopes) → GSet<id>` — the grow-only set; idempotent re-read
- `mergeViews([...clones]) → GSet` — cross-machine **union** (commutative + idempotent → coordination-free per CALM; the whole cross-machine story in one fold)
- `unseen(mine, theirs) → string[]` — ids a peer's clone has that mine lacks
- `envelopesIn(ids, byId) → envelopes` — re-hydrate the merged set

`g-set-view.test.ts` — 10 tests (fold, union laws, set-difference, re-hydrate). Pure (no git/IO); composes the existing readers' output onto the algebra.

This is the B-0959 §0 **agent-partition** recognition applied to the bus: each clone is a shard; the global bus = the CRDT merge of shards; no coordinator.

**Verify:** bun test 10/10; tsc + eslint + prettier clean.

**Remaining B-0954 items** (not this PR): legacy-bus bridge, cross-machine round-trip test (Otto-CLI ↔ Windows), GC/retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
