### PR TITLE
feat(agentic-org): feed telemetry optimizer outcomes into reputation

### DIFF
--- a/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
+++ b/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
@@ -874,6 +874,33 @@ ChangeSets.
 - post-change regression produces rollback proposal;
 - optimizer proposal carries simulation evidence from Phase 2.7.
 
+**Checkpoint 2026-06-01: telemetry optimizer learning loop**
+
+Phase 2.9 now has a closed proposal-and-learning kernel. The telemetry
+improvement optimizer already turns queryable DORA/LGTM regressions into
+`ImprovementHypothesis` records and drafted ChangeSets with telemetry and
+simulation evidence. It rejects degraded telemetry, empty telemetry, noise below
+the change threshold, missing causal log/trace evidence, missing simulation
+evidence, rejected simulation decisions, and rollback proposals without an
+explicit rolled-out ChangeSet target. The KIND proof at
+`deploy/run-telemetry-improvement-optimizer.ts` persists the proposal and
+`decision_optimization_proposed` event through live Cockroach.
+
+The missing production-learning edge is now explicit: post-rollout metric
+movement is evaluated against the hypothesis' expected metric movement, and the
+result becomes a durable `reputation_outcome_observed` event for the proposing
+optimizer agent/hat. This means optimizer reputation can learn from realized
+metric outcomes instead of gaining credit merely for drafting plausible
+ChangeSets. A successful review-p95 improvement emits a positive quality
+observation; missed movement emits the same substrate with a failed binary
+signal, allowing the existing Bayesian reputation read model to reward or
+penalize optimizer hats.
+
+Subagent review for this checkpoint was attempted but blocked by the platform
+agent-thread limit (`collab spawn failed: agent thread limit reached`); local
+review covered the telemetry improvement optimizer, reputation event substrate,
+export surface, and focused regression tests.
+
 **Exit criteria:**
 
 - telemetry is not passive dashboard data;

--- a/agentic-organization/packages/application/src/index.ts
+++ b/agentic-organization/packages/application/src/index.ts
@@ -18,10 +18,13 @@ export {
 export {
   TelemetryImprovementMetricKind,
   TelemetryImprovementProposalMode,
+  evaluateTelemetryImprovementOutcome,
   runTelemetryImprovementOptimizer,
+  type EvaluateTelemetryImprovementOutcomeInput,
   type ImprovementHypothesis,
   type RunTelemetryImprovementOptimizerInput,
   type TelemetryImprovementExpectedMetricMovement,
+  type TelemetryImprovementOutcomeEvaluation,
   type TelemetryImprovementOptimizerResult,
   type TelemetryImprovementProposedChange,
   type TelemetryImprovementTrigger,

--- a/agentic-organization/packages/application/src/telemetry-improvement-optimizer.ts
+++ b/agentic-organization/packages/application/src/telemetry-improvement-optimizer.ts
@@ -14,6 +14,11 @@ import type {
 } from "../../observability/src/index.ts";
 import { contentAddressedChangeSetId } from "./change-control-id.ts";
 import { isContentAddressedEvidenceRef } from "./content-addressed-evidence.ts";
+import {
+  ReputationOutcomeClass,
+  createReputationOutcomeOrgEvent,
+  type ReputationObservation,
+} from "./reputation.ts";
 
 export const TelemetryImprovementMetricKind = {
   ReviewP95Ms: "review_p95_ms",
@@ -125,6 +130,32 @@ export type TelemetryImprovementOptimizerResult =
     readonly observedRelativeChange?: number | undefined;
   };
 
+export type EvaluateTelemetryImprovementOutcomeInput = {
+  readonly organizationId: string;
+  readonly optimizerAgentId: string;
+  readonly optimizerHatId: string;
+  readonly hypothesis: ImprovementHypothesis;
+  readonly postRolloutMetricValue: number;
+  readonly evaluatedAt: string;
+  readonly evidenceRef: string;
+  readonly eventId: string;
+  readonly correlationId: string;
+  readonly traceId: string;
+};
+
+export type TelemetryImprovementOutcomeEvaluation =
+  | {
+    readonly kind: "reputation_observed";
+    readonly expectedMovementMet: boolean;
+    readonly observedRelativeMovement: number;
+    readonly observation: ReputationObservation;
+    readonly event: OrgEvent;
+  }
+  | {
+    readonly kind: "no_reputation_observation";
+    readonly reason: "missing_evidence" | "zero_reference_metric";
+  };
+
 export async function runTelemetryImprovementOptimizer(
   input: RunTelemetryImprovementOptimizerInput,
 ): Promise<TelemetryImprovementOptimizerResult> {
@@ -219,6 +250,51 @@ export async function runTelemetryImprovementOptimizer(
     hypothesis,
     changeSet,
     event: improvementEvent(input, hypothesis, changeSet.changeSetId, evidenceRefs),
+  };
+}
+
+export function evaluateTelemetryImprovementOutcome(
+  input: EvaluateTelemetryImprovementOutcomeInput,
+): TelemetryImprovementOutcomeEvaluation {
+  if (!isContentAddressedEvidenceRef(input.evidenceRef)) {
+    return { kind: "no_reputation_observation", reason: "missing_evidence" };
+  }
+  const referenceValue = input.hypothesis.symptom.observedValue;
+  if (referenceValue === 0) {
+    return { kind: "no_reputation_observation", reason: "zero_reference_metric" };
+  }
+
+  const observedRelativeMovement = metricMovement(
+    input.hypothesis.expectedMetricMovement.direction,
+    referenceValue,
+    input.postRolloutMetricValue,
+  );
+  const expectedMovementMet = observedRelativeMovement >= input.hypothesis.expectedMetricMovement.minimumRelativeChange;
+  const observation: ReputationObservation = {
+    organizationId: input.organizationId,
+    agentId: input.optimizerAgentId,
+    hatId: input.optimizerHatId,
+    workType: "telemetry_improvement_optimizer",
+    outcomeClass: ReputationOutcomeClass.Quality,
+    observedAt: input.evaluatedAt,
+    signal: { kind: "binary", success: expectedMovementMet, weight: 1 },
+    evidenceRef: input.evidenceRef,
+  };
+
+  return {
+    kind: "reputation_observed",
+    expectedMovementMet,
+    observedRelativeMovement: round(observedRelativeMovement),
+    observation,
+    event: createReputationOutcomeOrgEvent({
+      eventId: input.eventId,
+      observedAt: input.evaluatedAt,
+      organizationId: input.organizationId,
+      observation,
+      correlationId: input.correlationId,
+      causationId: input.hypothesis.hypothesisId,
+      traceId: input.traceId,
+    }),
   };
 }
 
@@ -361,6 +437,17 @@ function rollbackChange(input: RunTelemetryImprovementOptimizerInput): Telemetry
     rolledOutChangeSetId,
     summary: `rollback ${rolledOutChangeSetId} because post-change telemetry breached rollback condition`,
   };
+}
+
+function metricMovement(
+  direction: TelemetryImprovementExpectedMetricMovement["direction"],
+  referenceValue: number,
+  postRolloutValue: number,
+): number {
+  const denominator = Math.abs(referenceValue);
+  return direction === "decrease"
+    ? (referenceValue - postRolloutValue) / denominator
+    : (postRolloutValue - referenceValue) / denominator;
 }
 
 function degradedSource(result: TelemetryQueryDegraded): string {

--- a/agentic-organization/packages/application/test/telemetry-improvement-optimizer.test.ts
+++ b/agentic-organization/packages/application/test/telemetry-improvement-optimizer.test.ts
@@ -4,9 +4,11 @@ import { test } from "node:test";
 import { ChangeArtifactKind, ChangeSetPhase } from "../../domain/src/index.ts";
 import { RecordingTelemetryQueryPort, type TelemetryQueryPort } from "../../observability/src/index.ts";
 import {
+  ReputationOutcomeClass,
   TelemetryImprovementMetricKind,
   TelemetryImprovementProposalMode,
   createContentAddressedEvidenceRef,
+  evaluateTelemetryImprovementOutcome,
   runTelemetryImprovementOptimizer,
 } from "../src/index.ts";
 
@@ -331,6 +333,60 @@ test("multiple telemetry proposals for one work target get distinct durable ids"
   if (first.kind !== "proposed" || second.kind !== "proposed") throw new Error("expected proposals");
   ok(first.changeSet.changeSetId !== second.changeSet.changeSetId);
   ok(first.event.id !== second.event.id);
+});
+
+test("post-rollout metric improvement emits optimizer reputation evidence", async () => {
+  const queryPort = new RecordingTelemetryQueryPort({
+    metrics: [{
+      labels: { hat: "code_reviewer", metric: "review_p95_ms" },
+      points: [
+        { timestamp: "2026-05-31T17:45:00.000Z", value: 100 },
+        { timestamp: "2026-05-31T18:00:00.000Z", value: 100 },
+        { timestamp: "2026-05-31T18:30:00.000Z", value: 300 },
+        { timestamp: "2026-05-31T18:45:00.000Z", value: 300 },
+      ],
+    }],
+    logs: [{ timestamp: NOW, line: "review p95 doubled", labels: { hat: "code_reviewer" } }],
+  });
+  const proposal = await runTelemetryImprovementOptimizer({
+    organizationId: "org-lfg",
+    workItemId: "work-improve-review-p95",
+    proposerHatId: "decision_optimizer",
+    targetRef: "tenant-config/org-lfg.json",
+    now: NOW,
+    queryPort,
+    range: RANGE,
+    telemetryEvidenceRef: TelemetryEvidenceRef,
+    simulationEvidenceRef: SimulationEvidenceRef,
+    simulationDecision: { status: "accepted", reason: "candidate_beats_baseline" },
+    trigger: { ...defaultTrigger(), logQuery: "{app=\"agentic-org-worker\"} |= \"review p95\"" },
+  });
+  equal(proposal.kind, "proposed");
+  if (proposal.kind !== "proposed") throw new Error("expected telemetry improvement proposal");
+
+  const outcome = evaluateTelemetryImprovementOutcome({
+    organizationId: "org-lfg",
+    optimizerAgentId: "agent-decision-optimizer-a",
+    optimizerHatId: "decision_optimizer",
+    hypothesis: proposal.hypothesis,
+    postRolloutMetricValue: 200,
+    evaluatedAt: "2026-05-31T20:45:00.000Z",
+    evidenceRef: createContentAddressedEvidenceRef("telemetry-post-rollout", { metric: "review_p95", window: "after" }),
+    eventId: "evt-optimizer-reputation-review-p95",
+    correlationId: proposal.changeSet.changeSetId,
+    traceId: "trace-optimizer-reputation-review-p95",
+  });
+
+  equal(outcome.kind, "reputation_observed");
+  if (outcome.kind !== "reputation_observed") throw new Error("expected optimizer reputation observation");
+  equal(outcome.expectedMovementMet, true);
+  equal(outcome.observedRelativeMovement, 0.333);
+  equal(outcome.observation.outcomeClass, ReputationOutcomeClass.Quality);
+  deepEqual(outcome.observation.signal, { kind: "binary", success: true, weight: 1 });
+  equal(outcome.event.kind, "reputation_outcome_observed");
+  equal(outcome.event.actorAgentId, "agent-decision-optimizer-a");
+  equal(outcome.event.actorHatId, "decision_optimizer");
+  ok(outcome.event.evidenceRefs.includes(outcome.observation.evidenceRef));
 });
 
 function defaultTrigger() {


### PR DESCRIPTION
## Summary
- add post-rollout telemetry improvement outcome evaluation
- emit durable reputation_outcome_observed evidence for the proposing optimizer agent/hat
- record the Phase 2.9 telemetry optimizer learning-loop checkpoint in the production autonomy CA

## Review
- Subagent review attempted but blocked by platform thread limit: `collab spawn failed: agent thread limit reached`.
- Local review covered the telemetry improvement optimizer, reputation event substrate, export surface, and focused regression tests.

## Verification
- `node --experimental-strip-types --test packages/application/test/telemetry-improvement-optimizer.test.ts packages/application/test/reputation-posterior.test.ts`
- `npm run typecheck`
- `npm test`
- `git diff --check`
- `dotnet build -c Release` attempted, blocked locally: global.json requires SDK 10.0.203; installed SDKs are 10.0.101, 9.0.200, 9.0.100
- `dotnet test Zeta.sln -c Release` attempted, blocked by same SDK mismatch
- `dotnet format --verify-no-changes` attempted, blocked by same SDK mismatch