### PR TITLE
feat(agentic-org): gate production pilot readiness

### DIFF
--- a/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
+++ b/agentic-organization/docs/PHASE_2_PRODUCTION_AUTONOMY_CA.md
@@ -932,6 +932,29 @@ export surface, and focused regression tests.
 - production pilot report with all SLOs and incidents;
 - post-pilot ChangeSet backlog generated from measured gaps.
 
+**Checkpoint 2026-06-01: pilot readiness gate and measured backlog**
+
+Phase 2.10 now has a deterministic pilot-readiness kernel. The evaluator binds a
+single pilot to an organization, project, and department, then gates launch on
+the full production-drill bundle: at least seven replay days, zero illegal
+transitions, at least 24 soak hours, zero degraded soak ticks, ESTOP drill,
+restore drill, observe-act primary, reputation updates, work-market claims,
+schedule optimization, simulator-required policy changes, telemetry optimizer,
+and ESTOP capability. Pilot SLOs cover conformance pass ratio, lead time, review
+lag, QA bounce-back rate, cost per completed work item, stale-claim recovery,
+and operator intervention count.
+
+The readiness result carries a production pilot report with SLO observations,
+disaster-drill results, incidents, and stable evidence refs. Unsafe pilots are
+blocked with typed blocker codes, and measured gaps generate the post-pilot
+improvement backlog from SLO misses, failed disaster drills, and incidents. This
+keeps the pilot backlog telemetry/evidence-driven instead of opinion-driven.
+
+Subagent review for this checkpoint was attempted but blocked by the platform
+agent-thread limit (`collab spawn failed: agent thread limit reached`); local
+review covered the readiness gate, SLO/drill blockers, measured backlog
+generation, export surface, and focused regression tests.
+
 **Exit criteria:**
 
 - pilot completes without illegal transitions;

--- a/agentic-organization/packages/application/src/index.ts
+++ b/agentic-organization/packages/application/src/index.ts
@@ -30,6 +30,20 @@ export {
   type TelemetryImprovementTrigger,
 } from "./telemetry-improvement-optimizer.ts";
 export {
+  PilotDisasterDrillKind,
+  PilotSloKind,
+  evaluatePilotReadiness,
+  type PilotDisasterDrillResult,
+  type PilotImprovementBacklogItem,
+  type PilotIncidentSummary,
+  type PilotReadinessCapabilities,
+  type PilotReadinessEvaluation,
+  type PilotReadinessInput,
+  type PilotReadinessReport,
+  type PilotSloObservation,
+  type PilotSloReport,
+} from "./pilot-readiness.ts";
+export {
   TriageActionFeedbackReason,
   TriageActionResolution,
   resolveTriageAction,

--- a/agentic-organization/packages/application/src/pilot-readiness.ts
+++ b/agentic-organization/packages/application/src/pilot-readiness.ts
@@ -1,0 +1,222 @@
+export const PilotSloKind = {
+  ConformancePassRatio: "conformance_pass_ratio",
+  LeadTimeMs: "lead_time_ms",
+  ReviewLagMs: "review_lag_ms",
+  QaBounceBackRate: "qa_bounce_back_rate",
+  CostPerCompletedWorkItem: "cost_per_completed_work_item",
+  StaleClaimRecoveryMs: "stale_claim_recovery_ms",
+  OperatorInterventionCount: "operator_intervention_count",
+} as const;
+export type PilotSloKind = (typeof PilotSloKind)[keyof typeof PilotSloKind];
+
+export const PilotDisasterDrillKind = {
+  AgentSilence: "agent_silence",
+  BadModelSelector: "bad_model_selector",
+  QueueOverload: "queue_overload",
+  ConformanceBreach: "conformance_breach",
+  ProviderOutage: "provider_outage",
+  Rollback: "rollback",
+} as const;
+export type PilotDisasterDrillKind = (typeof PilotDisasterDrillKind)[keyof typeof PilotDisasterDrillKind];
+
+export type PilotSloObservation = {
+  readonly kind: PilotSloKind;
+  readonly observed: number;
+  readonly target: number;
+  readonly direction: "higher_or_equal" | "lower_or_equal";
+  readonly evidenceRef: string;
+};
+
+export type PilotDisasterDrillResult = {
+  readonly kind: PilotDisasterDrillKind;
+  readonly status: "passed" | "failed";
+  readonly finding: string;
+  readonly evidenceRef: string;
+};
+
+export type PilotIncidentSummary = {
+  readonly incidentId: string;
+  readonly severity: "low" | "medium" | "high" | "critical";
+  readonly summary: string;
+};
+
+export type PilotReadinessCapabilities = {
+  readonly observeActPrimary: boolean;
+  readonly reputationUpdates: boolean;
+  readonly workMarketClaims: boolean;
+  readonly scheduleOptimization: boolean;
+  readonly simulatorRequiredPolicyChanges: boolean;
+  readonly telemetryOptimizer: boolean;
+  readonly estop: boolean;
+};
+
+export type PilotReadinessInput = {
+  readonly organizationId: string;
+  readonly projectId: string;
+  readonly departmentId: string;
+  readonly evaluatedAt: string;
+  readonly replay: {
+    readonly days: number;
+    readonly illegalTransitionCount: number;
+  };
+  readonly soak: {
+    readonly hours: number;
+    readonly degradedTickCount: number;
+  };
+  readonly controls: {
+    readonly estopDrillPassed: boolean;
+    readonly restoreDrillPassed: boolean;
+  };
+  readonly capabilities: PilotReadinessCapabilities;
+  readonly slos: readonly PilotSloObservation[];
+  readonly disasterDrills: readonly PilotDisasterDrillResult[];
+  readonly incidents: readonly PilotIncidentSummary[];
+};
+
+export type PilotSloReport = PilotSloObservation & {
+  readonly status: "passed" | "failed";
+};
+
+export type PilotDisasterDrillReport = PilotDisasterDrillResult;
+
+export type PilotImprovementBacklogItem = {
+  readonly backlogItemId: string;
+  readonly source: "slo" | "disaster_drill" | "incident";
+  readonly sourceId: string;
+  readonly title: string;
+  readonly evidenceRefs: readonly string[];
+};
+
+export type PilotReadinessReport = {
+  readonly organizationId: string;
+  readonly projectId: string;
+  readonly departmentId: string;
+  readonly evaluatedAt: string;
+  readonly replay: PilotReadinessInput["replay"];
+  readonly soak: PilotReadinessInput["soak"];
+  readonly controls: PilotReadinessInput["controls"];
+  readonly capabilities: PilotReadinessCapabilities;
+  readonly slos: readonly PilotSloReport[];
+  readonly disasterDrills: readonly PilotDisasterDrillReport[];
+  readonly incidents: readonly PilotIncidentSummary[];
+  readonly evidenceRefs: readonly string[];
+};
+
+export type PilotReadinessEvaluation = {
+  readonly status: "ready" | "blocked";
+  readonly blockers: readonly string[];
+  readonly report: PilotReadinessReport;
+  readonly backlog: readonly PilotImprovementBacklogItem[];
+};
+
+const RequiredCapabilities: readonly (keyof PilotReadinessCapabilities)[] = [
+  "observeActPrimary",
+  "reputationUpdates",
+  "workMarketClaims",
+  "scheduleOptimization",
+  "simulatorRequiredPolicyChanges",
+  "telemetryOptimizer",
+  "estop",
+];
+
+export function evaluatePilotReadiness(input: PilotReadinessInput): PilotReadinessEvaluation {
+  const blockers: string[] = [];
+  if (input.replay.days < 7) blockers.push("seven_day_replay_missing");
+  if (input.replay.illegalTransitionCount > 0) blockers.push("illegal_transitions_present");
+  if (input.soak.hours < 24) blockers.push("twenty_four_hour_soak_missing");
+  if (input.soak.degradedTickCount > 0) blockers.push("degraded_soak_ticks_present");
+  if (!input.controls.estopDrillPassed) blockers.push("estop_drill_failed");
+  if (!input.controls.restoreDrillPassed) blockers.push("restore_drill_failed");
+
+  for (const capability of RequiredCapabilities) {
+    if (!input.capabilities[capability]) {
+      blockers.push(`capability_${capability}_disabled`);
+    }
+  }
+
+  const slos = input.slos.map((slo): PilotSloReport => {
+    const status = sloPasses(slo) ? "passed" : "failed";
+    if (status === "failed") blockers.push(`slo_${slo.kind}_failed`);
+    return { ...slo, status };
+  });
+
+  const disasterDrills = input.disasterDrills.map((drill) => {
+    if (drill.status === "failed") blockers.push(`disaster_drill_${drill.kind}_failed`);
+    return drill;
+  });
+
+  const evidenceRefs = uniqueSorted([
+    `pilot:replay:${input.replay.days}d`,
+    `pilot:soak:${input.soak.hours}h`,
+    `pilot:control:estop:${input.controls.estopDrillPassed ? "passed" : "failed"}`,
+    `pilot:control:restore:${input.controls.restoreDrillPassed ? "passed" : "failed"}`,
+    ...input.slos.map((slo) => slo.evidenceRef),
+    ...input.disasterDrills.map((drill) => drill.evidenceRef),
+    ...input.incidents.map((incident) => `pilot:incident:${incident.incidentId}`),
+  ]);
+  const report: PilotReadinessReport = {
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    departmentId: input.departmentId,
+    evaluatedAt: input.evaluatedAt,
+    replay: input.replay,
+    soak: input.soak,
+    controls: input.controls,
+    capabilities: input.capabilities,
+    slos,
+    disasterDrills,
+    incidents: input.incidents,
+    evidenceRefs,
+  };
+
+  return {
+    status: blockers.length === 0 ? "ready" : "blocked",
+    blockers: uniqueSorted(blockers),
+    report,
+    backlog: createBacklog(input, slos, disasterDrills),
+  };
+}
+
+function createBacklog(
+  input: PilotReadinessInput,
+  slos: readonly PilotSloReport[],
+  drills: readonly PilotDisasterDrillReport[],
+): readonly PilotImprovementBacklogItem[] {
+  return [
+    ...slos.filter((slo) => slo.status === "failed").map((slo) => ({
+      backlogItemId: backlogId(input.organizationId, "slo", slo.kind),
+      source: "slo" as const,
+      sourceId: slo.kind,
+      title: `Improve pilot SLO ${slo.kind}`,
+      evidenceRefs: [slo.evidenceRef],
+    })),
+    ...drills.filter((drill) => drill.status === "failed").map((drill) => ({
+      backlogItemId: backlogId(input.organizationId, "disaster_drill", drill.kind),
+      source: "disaster_drill" as const,
+      sourceId: drill.kind,
+      title: `Fix failed pilot disaster drill ${drill.kind}`,
+      evidenceRefs: [drill.evidenceRef],
+    })),
+    ...input.incidents.map((incident) => ({
+      backlogItemId: backlogId(input.organizationId, "incident", incident.incidentId),
+      source: "incident" as const,
+      sourceId: incident.incidentId,
+      title: `Address pilot incident ${incident.incidentId}: ${incident.summary}`,
+      evidenceRefs: [`pilot:incident:${incident.incidentId}`],
+    })),
+  ];
+}
+
+function sloPasses(slo: PilotSloObservation): boolean {
+  return slo.direction === "higher_or_equal"
+    ? slo.observed >= slo.target
+    : slo.observed <= slo.target;
+}
+
+function backlogId(organizationId: string, source: string, sourceId: string): string {
+  return `pilot-backlog:${organizationId}:${source}:${sourceId}`;
+}
+
+function uniqueSorted(values: readonly string[]): readonly string[] {
+  return [...new Set(values)].sort();
+}

--- a/agentic-organization/packages/application/test/pilot-readiness.test.ts
+++ b/agentic-organization/packages/application/test/pilot-readiness.test.ts
@@ -1,0 +1,116 @@
+import { deepEqual, equal, ok } from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  PilotDisasterDrillKind,
+  PilotSloKind,
+  evaluatePilotReadiness,
+} from "../src/index.ts";
+
+const NOW = "2026-06-01T00:00:00.000Z";
+
+test("pilot readiness passes only when replay, soak, SLOs, drills, controls, and capabilities clear", () => {
+  const report = evaluatePilotReadiness({
+    organizationId: "org-lfg",
+    projectId: "project-agentic-org",
+    departmentId: "engineering",
+    evaluatedAt: NOW,
+    replay: { days: 7, illegalTransitionCount: 0 },
+    soak: { hours: 24, degradedTickCount: 0 },
+    controls: { estopDrillPassed: true, restoreDrillPassed: true },
+    capabilities: {
+      observeActPrimary: true,
+      reputationUpdates: true,
+      workMarketClaims: true,
+      scheduleOptimization: true,
+      simulatorRequiredPolicyChanges: true,
+      telemetryOptimizer: true,
+      estop: true,
+    },
+    slos: [
+      slo(PilotSloKind.ConformancePassRatio, 1, 0.995, "higher_or_equal"),
+      slo(PilotSloKind.LeadTimeMs, 3_600_000, 7_200_000, "lower_or_equal"),
+      slo(PilotSloKind.ReviewLagMs, 900_000, 1_800_000, "lower_or_equal"),
+      slo(PilotSloKind.QaBounceBackRate, 0.02, 0.05, "lower_or_equal"),
+      slo(PilotSloKind.CostPerCompletedWorkItem, 1.2, 2, "lower_or_equal"),
+      slo(PilotSloKind.StaleClaimRecoveryMs, 300_000, 600_000, "lower_or_equal"),
+      slo(PilotSloKind.OperatorInterventionCount, 1, 3, "lower_or_equal"),
+    ],
+    disasterDrills: [
+      drill(PilotDisasterDrillKind.AgentSilence),
+      drill(PilotDisasterDrillKind.BadModelSelector),
+      drill(PilotDisasterDrillKind.QueueOverload),
+      drill(PilotDisasterDrillKind.ConformanceBreach),
+      drill(PilotDisasterDrillKind.ProviderOutage),
+      drill(PilotDisasterDrillKind.Rollback),
+    ],
+    incidents: [],
+  });
+
+  equal(report.status, "ready");
+  deepEqual(report.blockers, []);
+  deepEqual(report.backlog, []);
+  equal(report.report.slos.length, 7);
+  equal(report.report.disasterDrills.length, 6);
+  ok(report.report.evidenceRefs.includes("pilot:replay:7d"));
+  ok(report.report.evidenceRefs.includes("pilot:soak:24h"));
+});
+
+test("pilot readiness blocks unsafe pilots and creates backlog from measured gaps", () => {
+  const report = evaluatePilotReadiness({
+    organizationId: "org-lfg",
+    projectId: "project-agentic-org",
+    departmentId: "engineering",
+    evaluatedAt: NOW,
+    replay: { days: 6, illegalTransitionCount: 1 },
+    soak: { hours: 12, degradedTickCount: 2 },
+    controls: { estopDrillPassed: false, restoreDrillPassed: true },
+    capabilities: {
+      observeActPrimary: true,
+      reputationUpdates: true,
+      workMarketClaims: true,
+      scheduleOptimization: false,
+      simulatorRequiredPolicyChanges: true,
+      telemetryOptimizer: true,
+      estop: true,
+    },
+    slos: [
+      slo(PilotSloKind.ConformancePassRatio, 0.98, 0.995, "higher_or_equal"),
+      slo(PilotSloKind.ReviewLagMs, 2_700_000, 1_800_000, "lower_or_equal"),
+    ],
+    disasterDrills: [
+      drill(PilotDisasterDrillKind.AgentSilence),
+      drill(PilotDisasterDrillKind.ProviderOutage, "failed", "provider failover timed out"),
+    ],
+    incidents: [{ incidentId: "inc-1", severity: "high", summary: "provider failover timeout" }],
+  });
+
+  equal(report.status, "blocked");
+  ok(report.blockers.includes("seven_day_replay_missing"));
+  ok(report.blockers.includes("illegal_transitions_present"));
+  ok(report.blockers.includes("twenty_four_hour_soak_missing"));
+  ok(report.blockers.includes("estop_drill_failed"));
+  ok(report.blockers.includes("capability_scheduleOptimization_disabled"));
+  ok(report.blockers.includes("slo_conformance_pass_ratio_failed"));
+  ok(report.blockers.includes("disaster_drill_provider_outage_failed"));
+  ok(report.backlog.some((item) => item.source === "slo" && item.sourceId === PilotSloKind.ReviewLagMs));
+  ok(report.backlog.some((item) => item.source === "disaster_drill" && item.sourceId === PilotDisasterDrillKind.ProviderOutage));
+  ok(report.backlog.some((item) => item.source === "incident" && item.sourceId === "inc-1"));
+});
+
+function slo(
+  kind: PilotSloKind,
+  observed: number,
+  target: number,
+  direction: "higher_or_equal" | "lower_or_equal",
+) {
+  return { kind, observed, target, direction, evidenceRef: `pilot:slo:${kind}` };
+}
+
+function drill(
+  kind: PilotDisasterDrillKind,
+  status: "passed" | "failed" = "passed",
+  finding = "passed",
+) {
+  return { kind, status, finding, evidenceRef: `pilot:drill:${kind}` };
+}


### PR DESCRIPTION
## Summary
- add a deterministic Phase 2.10 pilot-readiness evaluator
- gate replay, soak, controls, capabilities, SLOs, disaster drills, and incidents before pilot launch
- generate measured improvement backlog items from SLO misses, failed drills, and pilot incidents
- record the Phase 2.10 checkpoint in the production autonomy CA

## Review
- Subagent review attempted but blocked by platform thread limit: `collab spawn failed: agent thread limit reached`.
- Local review covered the readiness gate, SLO/drill blockers, measured backlog generation, export surface, and focused regression tests.

## Verification
- `node --experimental-strip-types --test packages/application/test/pilot-readiness.test.ts packages/application/test/restore-drill.test.ts packages/application/test/telemetry-improvement-optimizer.test.ts`
- `npm run typecheck`
- `npm test`
- `git diff --check`
- `dotnet build -c Release` attempted, blocked locally: global.json requires SDK 10.0.203; installed SDKs are 10.0.101, 9.0.200, 9.0.100
- `dotnet test Zeta.sln -c Release` attempted, blocked by same SDK mismatch
- `dotnet format --verify-no-changes` attempted, blocked by same SDK mismatch