### PR TITLE
docs(B-0962): Phase-1 typed Claim/Lock events + multi-round deadlock/livelock review

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -915,6 +915,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0960](backlog/P2/B-0960-ace-slice3.1-pave-the-strict-default-road-2026-06-01.md)** Ace slice 3.1 — pave the strict-by-default road (lower signature friction)
 - [ ] **[B-0961](backlog/P2/B-0961-zetaid-root-category-taxonomy-gap-analysis-claim-lock-coordination-categories-2026-05-31.md)** ZetaId root-category taxonomy — gap analysis + DEFERRAL (model Claim/Lock as typed events first; promote to root Category only after producers + identity-rule + growth-theory)
 - [ ] **[B-0962](backlog/P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md)** Phase 1 — typed Claim/Lock coordination events (optimistic CAS: mechanism-deadlock-free + symmetry-breaking observe-menu; app-level safety needs fencing + release-before-acquire)
+- [ ] **[B-0963](backlog/P2/B-0963-prove-completion-lock-freedom-and-per-agent-wait-freedom-in-fsharp-model-first-then-extend-to-git-2026-06-01.md)** Prove completion-lock-freedom + per-agent wait-freedom — F# model first (no git), then extend to git
 
 ## P3 — convenience / deferred
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -914,6 +914,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0955](backlog/P2/B-0955-migrate-tools-off-bun-only-apis-to-node-process-equivalents-node-safe-baseline-policy-aaron-otto-2026-05-31.md)** Migrate tools/ production code off Bun-only APIs to node:/process equivalents — honor the Node-safe-baseline policy (2026-04-20 tools-runtime ADR v6)
 - [ ] **[B-0960](backlog/P2/B-0960-ace-slice3.1-pave-the-strict-default-road-2026-06-01.md)** Ace slice 3.1 — pave the strict-by-default road (lower signature friction)
 - [ ] **[B-0961](backlog/P2/B-0961-zetaid-root-category-taxonomy-gap-analysis-claim-lock-coordination-categories-2026-05-31.md)** ZetaId root-category taxonomy — gap analysis + DEFERRAL (model Claim/Lock as typed events first; promote to root Category only after producers + identity-rule + growth-theory)
+- [ ] **[B-0962](backlog/P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md)** Phase 1 — typed Claim/Lock coordination events (optimistic CAS: mechanism-deadlock-free + symmetry-breaking observe-menu; app-level safety needs fencing + release-before-acquire)
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P1/B-0959-zeta-sovereign-distributed-db-and-agent-loop-master-checklist-one-git-native-zset-substrate-aaron-otto-2026-05-31.md
+++ b/docs/backlog/P1/B-0959-zeta-sovereign-distributed-db-and-agent-loop-master-checklist-one-git-native-zset-substrate-aaron-otto-2026-05-31.md
@@ -284,9 +284,11 @@ no-PR (sovereign transport). Now unblocked by §1's first-class G-Set.
       to §3 (bus): the dashboard becomes a live, mode-aware view of the substrate.
 - [ ] **ZetaId coordination — Claim + Lock as typed events first; root-Category promotion deferred** — [B-0961](../P2/B-0961-zetaid-root-category-taxonomy-gap-analysis-claim-lock-coordination-categories-2026-05-31.md).
       Multi-agent review (Grok + Amara, 2026-06-01) rejected adding `Claim(9)`/`Lock(10)`
-      to root `Category` now. Phase 1: model Claim (rides `Bus(6)`) + Lock (CAS slice,
-      B-0954.1) as typed coordination **events under existing categories**. Phase 2
-      (promote to root): gated on Gate A (identity-rule — is `Category` in the
+      to root `Category` now. Phase 1 ([B-0962](../P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md)):
+      model Claim (rides `Bus(6)`) + Lock (CAS slice, B-0954.1) as typed
+      coordination **events under existing categories** — **deadlock-free by
+      construction** (optimistic CAS, not blocking locks; TTL + single-resource).
+      Phase 2 (promote to root): gated on Gate A (identity-rule — is `Category` in the
       content-hash?) + Gate B (real producers/consumers). Gate C (growth) **resolved**:
       escape-to-`Extended` (reserve slot `15`, then read a **wider** extension
       field — not repeated 4-bit nibbles — or an `IdVersion` width-bump) means 4

--- a/docs/backlog/P1/B-0959-zeta-sovereign-distributed-db-and-agent-loop-master-checklist-one-git-native-zset-substrate-aaron-otto-2026-05-31.md
+++ b/docs/backlog/P1/B-0959-zeta-sovereign-distributed-db-and-agent-loop-master-checklist-one-git-native-zset-substrate-aaron-otto-2026-05-31.md
@@ -286,8 +286,11 @@ no-PR (sovereign transport). Now unblocked by §1's first-class G-Set.
       Multi-agent review (Grok + Amara, 2026-06-01) rejected adding `Claim(9)`/`Lock(10)`
       to root `Category` now. Phase 1 ([B-0962](../P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md)):
       model Claim (rides `Bus(6)`) + Lock (CAS slice, B-0954.1) as typed
-      coordination **events under existing categories** — **deadlock-free by
-      construction** (optimistic CAS, not blocking locks; TTL + single-resource).
+      coordination **events under existing categories**. Multi-round review
+      disciplined the guarantee: **mechanism-deadlock-free** (optimistic CAS, not
+      blocking locks); app-level safety via fencing + release-before-acquire; menu
+      symmetry-breaking for livelock; completion-lock-freedom + per-agent
+      wait-freedom formally proven in B-0963 (F# first, then git).
       Phase 2 (promote to root): gated on Gate A (identity-rule — is `Category` in the
       content-hash?) + Gate B (real producers/consumers). Gate C (growth) **resolved**:
       escape-to-`Extended` (reserve slot `15`, then read a **wider** extension

--- a/docs/backlog/P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md
+++ b/docs/backlog/P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md
@@ -179,6 +179,49 @@ Boundary: SSB proper is ground-states/order-parameters/Goldstone machinery we ar
 **not** invoking — this is a structural rhyme that names _why_ the menu needs the
 break (the symmetric state is the livelock), not a physics derivation.
 
+### §3.2 Intelligent-agent supervision — the advantage dumb locks lack (operator 2026-06-01)
+
+> **Aaron 2026-06-01:** "we have one advantage … it's intelligent agents doing the
+> locks, not dumb code — so we can likely build in the ability for the agents to
+> notice the lock issues."
+
+Classical distributed locking has to be provable-by-construction precisely because
+the participants are **dumb code** that can't introspect — a spinning process
+can't tell it's livelocked. Here the participants are **intelligent agents** who
+can _observe their own coordination history_ and adapt. That gives a **second,
+complementary defense layer** exactly where construction is weakest — the soft
+properties (livelock, starvation, fairness) that §3 / B-0963 cannot guarantee by
+construction:
+
+- **Detection is cheap — it's already in the observe loop.** The agent's
+  observe→act fold can surface coordination-health signals per tick: CAS
+  loss-rate, contention-count on a resource, age-since-own-progress, repeated-
+  same-loser. A dumb lock has none of this; an intelligent agent reads it for free.
+- **Adaptation is the practical fairness mechanism.** On noticing "I've lost this
+  CAS N times / I'm starved," the agent can back off, **switch to different work**
+  (the menu always offers other cells), escalate to a human, **negotiate with the
+  peer** holding the resource, or propose a redesign. That IS the anti-starvation /
+  per-agent-progress mechanism pure CAS lacks — supplied by intelligence, not by a
+  ticket queue (build the queue only if intelligence proves insufficient).
+- **It's a natural fit for wait-freedom-in-practice (B-0963).** Formal wait-freedom
+  needs an explicit fairness term; intelligent supervision provides one without
+  hard-coding it — the agent that notices it's starved self-corrects. B-0963 proves
+  the construction bound; this layer covers the residual operationally.
+
+**Honest boundaries (defense-in-depth, not a replacement):**
+
+- This is **complementary**, not a substitute for the structural guarantees. The
+  **frozen-deadlock** and **lost-update** failures stay closed **by construction**
+  (mechanism-nonblocking + fencing + release-before-acquire) — those must NOT
+  depend on an agent being clever enough to notice. Intelligence handles the
+  _soft_ failures (livelock/starvation), not the _dangerous_ ones.
+- It is **not a guarantee.** An agent can fail to notice, or notice and act wrongly
+  (make contention worse). So it's a layer that _raises the floor in practice_, not
+  a proof — and it never licenses skipping fencing or release-before-acquire.
+- **Buildable + falsifiable:** surface the coordination-health signals as explicit
+  observe-loop telemetry; an agent that ignores a starvation signal is a detectable
+  bug, not an invisible hang.
+
 ## §4 The typed event shapes (Phase 1 — payloads under existing `Bus(6)`)
 
 Both ride `Bus(6)` (no root-`Category` change — Phase 2 is gated per B-0961).

--- a/docs/backlog/P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md
+++ b/docs/backlog/P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md
@@ -146,8 +146,9 @@ observed state)`, re-derived each tick. A CAS loser, **once the winner's
 **Net (honest):** the menu **breaks lockstep livelock** (symmetry-breaking via
 state-fold) and gives **lock-free selection under fair-retry + fresh-state +
 visible-reservation**; it does **not** prove completion-lock-freedom or per-agent
-wait-freedom — those are **formally proven (F# model first, then extended to git)
-in [B-0963](B-0963-prove-completion-lock-freedom-and-per-agent-wait-freedom-in-fsharp-model-first-then-extend-to-git-2026-06-01.md)**.
+wait-freedom — those are **deferred to [B-0963](B-0963-prove-completion-lock-freedom-and-per-agent-wait-freedom-in-fsharp-model-first-then-extend-to-git-2026-06-01.md)
+for formal proof** (open follow-up; F# model first, then extended to git — not yet
+proven here).
 That's still a real win — much of "easy-as-fuck" survives — but it's
 a symmetry breaker, not a fairness theorem. Composes with the framework's
 lock-free/wait-free always-active disciplines (`dv2-data-split`) as the _selection_

--- a/docs/backlog/P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md
+++ b/docs/backlog/P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md
@@ -1,0 +1,229 @@
+---
+id: B-0962
+title: Phase 1 — typed Claim/Lock coordination events (optimistic CAS: mechanism-deadlock-free + symmetry-breaking observe-menu; app-level safety needs fencing + release-before-acquire)
+status: open
+priority: P2
+created: 2026-06-01
+author: otto-cli
+composes_with:
+  - B-0961 # taxonomy gap-analysis — this IS its Phase 1 (typed events under existing categories)
+  - B-0954 # git-native bus / G-Set (Claim is monotone, lives here)
+  - B-0954.1 # bus-tip partition tolerance (Lock = the non-monotone single-row CAS)
+  - B-0959 # sovereign-DB lane master (CALM boundary + lock-free/wait-free disciplines)
+---
+
+# B-0962 — Phase 1: typed Claim/Lock coordination events
+
+> **Why this row exists (not dogma):** B-0961 chose Phase 1 = model Claim/Lock as
+> typed events under existing categories. Aaron asked _"do we risk deadlocks? can
+> we never deadlock and stay simple?"_ — and, separately, _"is there a livelock
+> guarantee on the observe 4×4 menu too?"_ A **multi-round** review (Grok +
+> Gemini round 1, Amara round 2, 2026-06-01) **disciplined the answer**: the first
+> draft over-claimed "deadlock-free by construction." The honest, defensible
+> result is below. WHYs stated inline so they can be questioned/agreed/revised.
+
+## §0 The honest deadlock answer — mechanism-deadlock-free; app-level needs three hard invariants
+
+The core intuition holds and is right: **optimistic short-TTL single-resource
+coordination is far safer than blocking locks.** But "deadlock-free by
+construction" was too strong. Split the claim cleanly (round-1 reviewers
+converged here):
+
+- **Mechanism level — deadlock-free, yes.** CAS (`push --force-with-lease`) and
+  cooperative claim (try-or-pick-different) are **protocol-level nonblocking** —
+  Coffman's hold-and-wait is broken in the coordination algebra. (Round-2 caveat:
+  external I/O — a `git push` / network call — can still _hang outside the
+  algebra_; that's a separate hazard handled by the `timeout --kill-after`
+  discipline, not by CAS. "Nonblocking" is about the coordination protocol, not
+  about every syscall it rides on.)
+- **Application level — NOT free "by construction."** An agent _policy_ can still
+  hold claim A while waiting (sleeping, awaiting human review, awaiting another
+  topic) to get B. "No blocking API" is a statement about the library surface,
+  not about what a policy does. That circular wait becomes **livelock** (spinning,
+  not frozen) — no progress, but not a classic deadlock.
+
+Coffman conditions, honestly:
+
+| Coffman condition   | Mechanism                          | Application (policy)                                                                  |
+| ------------------- | ---------------------------------- | ------------------------------------------------------------------------------------- |
+| 1. Mutual exclusion | yes (Lock is exclusive)            | yes                                                                                   |
+| 2. Hold-and-wait    | **broken** (try-or-fail, no block) | **only broken if policy releases-before-acquiring-different** (§1.3, now a HARD rule) |
+| 3. No-preemption    | **broken** (TTL preempts)          | TTL preemption is **unsafe without fencing** (§2 — the real flaw)                     |
+| 4. Circular wait    | **broken** (single-resource)       | broken iff single-resource + total-order escape held                                  |
+
+So: deadlock-free at the mechanism; the application is deadlock-free **iff** three
+invariants hold as HARD rules — (a) release-before-acquire-different (§1.3),
+(b) fencing / CAS-at-write (§2), (c) lease-protected release (§2). The residual is
+**livelock**, addressed in §3 (and turned into a real guarantee for the menu).
+
+## §1 The patterns — never-deadlock AND keep-it-simple
+
+Items 1–3 are the simple defaults; #4 is the only-if-ever escape; #5 the livelock
+guard; #6 the CALM lens:
+
+1. **Optimistic CAS, never blocking locks (THE pattern).** `git push
+--force-with-lease=ref:expectedSha` is compare-and-set: succeeds, or fails-fast
+   on drift. Claim is try-or-pick-different (exit-1, no wait). No blocking-acquire
+   API exists — breaks hold-and-wait at the mechanism.
+2. **TTL on every claim and lock.** No permanent hold; a crashed holder
+   auto-expires. **But TTL preemption is only SAFE with fencing (§2)** — without
+   it, TTL trades deadlock for a worse stale-holder hazard.
+3. **Single-resource + release-before-acquire-different (HARD rule, not a
+   preference — round-1 correction).** Hold at most one resource; you MUST release
+   it before attempting a different one. This is what actually breaks circular
+   wait at the _policy_ level (the mechanism alone doesn't). Mechanically
+   enforceable: the API offers `withResource(r, fn)` (acquire→do→release in one
+   scope), not a free-standing `acquire` you can stash and hold.
+4. **Total lock-order — only if you EVER must hold two.** Acquire in a global
+   canonical order (sort keys). Prefer to never need it; first ask whether one
+   coarser resource or a redesign removes the second lock.
+5. **Bounded randomized backoff (livelock guard, not deadlock).** CAS contention
+   can livelock (agents retry in lockstep); randomized backoff + "pick a different
+   work-item" breaks symmetry. (Stronger guarantee for the menu in §3.)
+6. **Minimize the non-monotone surface (CALM lens).** Claims are **monotone**
+   (G-Set, coordination-free) — they cannot deadlock at all. Only **Lock** is
+   non-monotone and uses CAS. Smaller lock surface = smaller place deadlock could
+   even be contemplated.
+
+## §2 The real flaw round 1 caught — fencing / CAS-at-write (Kleppmann)
+
+A TTL'd lock without **fencing tokens** is unsafe (Kleppmann, _How to do
+distributed locking_; the Redlock critique; Chubby sequence numbers): a holder
+that pauses (GC, hypervisor, API latency) past its TTL wakes up believing it still
+holds the lock and clobbers a resource a new holder now owns → lost update /
+split-brain. **`leaseSha` as written only fences the lock-ACQUISITION ref move, not
+the protected WRITE.** Two hard requirements:
+
+- **CAS-at-write (mandatory):** the protected mutation must itself re-validate the
+  lease at write time — `push --force-with-lease=<resource-ref>:<leaseSha>` on the
+  _actual_ mutation, so a stale holder's write fails-fast. Acquisition-CAS is not
+  enough; the write carries the fence.
+- **Lease-protected release:** release must be lease-checked too — a stale holder
+  must not be able to delete a ref it no longer holds.
+
+**Gemini's simplification (worth taking):** if the protected mutation IS a git
+commit, then `push --force-with-lease` on the **data branch** is the lock _and_
+the fence, combined. In that case **we may not need a separate `LockEvent` at
+all** — the data-branch tip is the lock. Keep `LockEvent` only for resources whose
+mutation is _not_ a single git-ref move (where `leaseSha` must be threaded to the
+writer). **Open design question for Phase-1 impl: which resources actually need a
+LockEvent vs. are already fenced by their own data-ref CAS?**
+
+## §3 Livelock on the observe 4×4 menu — a symmetry breaker, not a fairness theorem (Aaron's question, round-2 disciplined)
+
+Yes, livelock matters on the menu (two agents pick the same option, both CAS, one
+loses). The first draft claimed "lock-free **by construction**" — **round 2 caught
+that as the same overclaim sin §0 had.** The honest statement (Amara keeper):
+
+> **Menu-as-state-fold is a symmetry breaker, not a fairness theorem.**
+
+What the construction actually buys, with the assumptions named:
+
+- **Symmetry-breaking (the real, defensible property).** The menu is `f(current
+observed state)`, re-derived each tick. A CAS loser, **once the winner's
+  reservation is visible to it**, re-derives a menu with the taken cell gone → it
+  picks a **different** cell. So the state-fold prevents _lockstep re-picking of a
+  dead option_. That's symmetry-breaking — it stops the classic two-agents-spin
+  livelock. It is **not** a proof of progress on its own.
+- **Menu selection is lock-free ONLY under three assumptions** — (a) fair retry,
+  (b) fresh-state re-derivation each tick, (c) the winner's successful reservation
+  is **visible** before the loser re-derives. CAS gives **at most one** winner per
+  contended resource per round (zero if stale reads / non-contention failure), so
+  "exactly one progresses" does **not** hold under visibility lag or partition
+  (the local-vs-remote ref lag round 1 also flagged).
+- **NOT proven:** lock-freedom of _task completion_ (vs. selection), per-agent
+  **wait-freedom**, fairness, or monotone shrink of the global work set under new
+  work / requeues / stale reads / a stalled winner. Don't claim these.
+- **Practical (not guaranteed) progress via breadth.** 4×4 = 16 cells; with N < 16
+  agents + randomized tie-break, losers disperse to uncontended cells, so under
+  normal load starvation is transient. This is an empirical expectation, not a
+  theorem.
+- **Hard wait-freedom — deferred, only if starvation is observed.** Pure CAS has
+  no fairness; add age/ticket priority on a hot resource if a victim actually
+  starves. Don't build it pre-emptively (all-complexity-accidental).
+
+**Net (honest):** the menu **breaks lockstep livelock** (symmetry-breaking via
+state-fold) and gives **lock-free selection under fair-retry + fresh-state +
+visible-reservation**; it does **not** prove completion-lock-freedom or per-agent
+wait-freedom. That's still a real win — much of "easy-as-fuck" survives — but it's
+a symmetry breaker, not a fairness theorem. Composes with the framework's
+lock-free/wait-free always-active disciplines (`dv2-data-split`) as the _selection_
+layer, with fairness left explicit-if-needed.
+
+## §4 The typed event shapes (Phase 1 — payloads under existing `Bus(6)`)
+
+Both ride `Bus(6)` (no root-`Category` change — Phase 2 is gated per B-0961).
+`kind` is the subtype discriminator (Grok's "one Coordination + subtype" at
+payload scope).
+
+### Claim — cooperative ownership (monotone, G-Set)
+
+```ts
+interface ClaimEvent {
+  kind: "claim";
+  resource: string; // logical: work-item id, lane
+  holder: SenderId; // surface-tagged: otto-cli, vera-codex, ...
+  acquiredAt: Milliseconds;
+  ttlMs: Milliseconds; // long (24h); expiry == release
+  action: "acquire" | "release";
+}
+```
+
+Acquire = observe-then-assert (fold G-Set; if unheld publish `acquire`; if held,
+pick a different resource — no wait). The existing `tools/bus/claim.ts`, typed.
+
+### Lock — hard mutual-exclusion (non-monotone, CAS + fencing)
+
+```ts
+interface LockEvent {
+  kind: "lock";
+  resource: string; // specific: ref / row / file path
+  holder: SenderId;
+  acquiredAt: Milliseconds;
+  ttlMs: Milliseconds; // SHORT — critical-op scoped
+  leaseSha: string; // fencing token — threaded to the WRITE (§2), not just acquire
+  action: "acquire" | "release";
+}
+```
+
+Acquire = CAS; the **protected write re-validates `leaseSha`** (§2 fencing);
+release is lease-checked; TTL expiry auto-releases. (Or skip `LockEvent` entirely
+where the data-ref CAS already fences — §2.)
+
+## §5 Acceptance criteria
+
+- [ ] `ClaimEvent` + `LockEvent` typed shapes (TS) as `Bus(6)` payloads; F# parity
+      later (mirror the GSet pair).
+- [ ] **Scoped API only** — `withResource(r, fn)` (acquire→do→release in one
+      scope); no free-standing `acquire` you can stash → release-before-acquire is
+      mechanically enforced (§1.3).
+- [ ] **Fencing mandatory** — protected write does `--force-with-lease=<ref>:<leaseSha>`;
+      release is lease-checked; stale holder fails-fast (§2).
+- [ ] Decide per-resource: needs `LockEvent`, or already fenced by its own data-ref
+      CAS (§2 Gemini simplification)?
+- [ ] TTL on both; short for Lock; expiry == release.
+- [ ] Tests: CAS-contention (**at most** one winner), **stale-holder write
+      rejected** (fencing), TTL-expiry-releases, **menu symmetry-breaking** (loser
+      re-derives + picks a different cell once the winner's reservation is visible;
+      no lockstep re-pick), livelock-backoff converges. (Per-agent wait-freedom is
+      NOT asserted — see §3.)
+- [ ] Total-order helper only if a real multi-lock consumer appears.
+
+## §6 Candidate rules (cooling period — not minted here)
+
+- "Coordination is optimistic CAS, never blocking; mechanism-deadlock-free, with
+  app-level safety via fencing + release-before-acquire."
+- "Menu-as-state-fold is a symmetry breaker, not a fairness theorem: selection is
+  lock-free under fair-retry + fresh-state + visible-reservation; completion
+  lock-freedom and per-agent wait-freedom are not proven." (Composes the existing
+  lock-free/wait-free disciplines as the _selection_ layer.)
+
+Strong rule candidates, but rules are razored (cooling-period). Revisit after this
+lands + a second consumer exists.
+
+## §7 Master-checklist linkage
+
+Phase-1 slice of B-0961, under the sovereign-DB lane (B-0959), reachable from
+`docs/ACTIVE-WORKSTREAMS.md`. Unblocks B-0954.1 (Lock = single-row CAS + fencing)
+with no root-`Category` change. The menu symmetry-breaking / selection-lock-freedom
+(§3) composes with the observe.ts 4×4 move-next construction.

--- a/docs/backlog/P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md
+++ b/docs/backlog/P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md
@@ -4,6 +4,7 @@ title: Phase 1 — typed Claim/Lock coordination events (optimistic CAS: mechani
 status: open
 priority: P2
 created: 2026-06-01
+last_updated: 2026-06-01
 author: otto-cli
 composes_with:
   - B-0961 # taxonomy gap-analysis — this IS its Phase 1 (typed events under existing categories)
@@ -145,10 +146,38 @@ observed state)`, re-derived each tick. A CAS loser, **once the winner's
 **Net (honest):** the menu **breaks lockstep livelock** (symmetry-breaking via
 state-fold) and gives **lock-free selection under fair-retry + fresh-state +
 visible-reservation**; it does **not** prove completion-lock-freedom or per-agent
-wait-freedom. That's still a real win — much of "easy-as-fuck" survives — but it's
+wait-freedom — those are **formally proven (F# model first, then extended to git)
+in [B-0963](B-0963-prove-completion-lock-freedom-and-per-agent-wait-freedom-in-fsharp-model-first-then-extend-to-git-2026-06-01.md)**.
+That's still a real win — much of "easy-as-fuck" survives — but it's
 a symmetry breaker, not a fairness theorem. Composes with the framework's
 lock-free/wait-free always-active disciplines (`dv2-data-split`) as the _selection_
 layer, with fairness left explicit-if-needed.
+
+### §3.1 Physics RHYME (operator 2026-06-01 — marked rhyme, not derivation)
+
+The menu's symmetry-break **rhymes with spontaneous symmetry breaking (SSB)** —
+operator-authorized to record _as a rhyme_, not a theorem-transfer (per
+`grep-substrate-anchors-before-razor` + "rhymes ≠ derivation"):
+
+| SSB ingredient                                 | The menu                                                  |
+| ---------------------------------------------- | --------------------------------------------------------- |
+| symmetric laws                                 | the protocol privileges no agent                          |
+| degenerate equivalent ground states            | "A wins" ≅ "B wins" (same value, relabeled)               |
+| a microscopic fluctuation lifts the degeneracy | **CAS-race timing jitter** decides who hits the ref first |
+| amplified to macroscopic asymmetry             | the winner **locks in** the resource                      |
+
+So **livelock IS the system stuck in the unbroken symmetric state**; progress
+_requires_ the symmetry to break. Two ways, both fine:
+
+- **Spontaneous-like** — let the **CAS race** decide (intrinsic timing fluctuation;
+  zero added machinery).
+- **Explicit** — **inject jitter / randomness**, which operator confirms is fine
+  **especially for fairness** (the explicit symmetry-breaking term is the fairness
+  knob; use it when starvation needs breaking).
+
+Boundary: SSB proper is ground-states/order-parameters/Goldstone machinery we are
+**not** invoking — this is a structural rhyme that names _why_ the menu needs the
+break (the symmetric state is the livelock), not a physics derivation.
 
 ## §4 The typed event shapes (Phase 1 — payloads under existing `Bus(6)`)
 

--- a/docs/backlog/P2/B-0963-prove-completion-lock-freedom-and-per-agent-wait-freedom-in-fsharp-model-first-then-extend-to-git-2026-06-01.md
+++ b/docs/backlog/P2/B-0963-prove-completion-lock-freedom-and-per-agent-wait-freedom-in-fsharp-model-first-then-extend-to-git-2026-06-01.md
@@ -36,8 +36,14 @@ composes_with:
 These are **liveness/progress properties under concurrency** — distinct from the
 safety properties (mutual-exclusion, no-lost-update via fencing) B-0962 already
 argues. Liveness needs **fairness assumptions** stated explicitly (that's the
-whole game): lock-freedom typically needs **weak fairness**; wait-freedom needs
-**strong fairness** or an explicit fairness mechanism (the jitter/ticket knob).
+whole game) — and a sharp distinction the proof must keep (Copilot 2026-06-01):
+lock-freedom typically needs **weak fairness**; **starvation-freedom** (eventual
+completion — every agent _eventually_ finishes) follows from **strong fairness**;
+but the **bounded per-agent wait-freedom** §0 defines (completion within a bounded
+number of an agent's _own_ steps) is **stronger than starvation-freedom** and does
+**not** follow from fairness alone — it needs an explicit **bound** (a ranking /
+variant function, or a ticket/age mechanism). Don't conflate "eventually" with
+"within N steps."
 
 ## §1 Phase A — prove in the F# model (no git)
 
@@ -54,9 +60,12 @@ generator over IScheduler").
   class; do NOT TLA+-hammer reflexively, but liveness-under-concurrency IS TLA+'s
   sweet spot):**
   - **TLA+ / TLC** — model-check **lock-freedom** under weak fairness and
-    **wait-freedom** under strong fairness (temporal-logic liveness with explicit
-    `WF`/`SF` fairness; this is exactly what TLA+ is for). The honest deliverable is
-    "property X holds under fairness assumption Y."
+    **starvation-freedom** (eventual completion) under strong fairness
+    (temporal-logic liveness with explicit `WF`/`SF`; this is exactly what TLA+ is
+    for). The honest deliverable is "property X holds under fairness assumption Y."
+    **Note:** strong fairness gives _eventual_ completion, not the **bounded**
+    per-agent wait-freedom §0 defines — that bound needs a separate ranking/variant
+    argument or a ticket mechanism (model-checking liveness ≠ proving a step-bound).
   - **FsCheck** — property-based tests of the F# model (at-most-one-winner;
     monotone progress of the work-set; no-lockstep-re-pick once a winner is
     visible). Tests, not proofs — they bound confidence, they don't replace TLC.
@@ -102,8 +111,12 @@ round-1 review named — re-run the analysis with them and state what survives:
 - [ ] F# abstract model of the coordination protocol (CAS + menu fold + TTL +
       optional fairness knob) over the deterministic `IScheduler` (B-0878/B-0767).
 - [ ] TLA+ spec + TLC model-check: lock-freedom under weak fairness;
-      wait-freedom under strong fairness / explicit fairness mechanism. Record the
+      **starvation-freedom** (eventual completion) under strong fairness. Record the
       fairness assumption each property requires.
+- [ ] **Bounded per-agent wait-freedom** (if that is the deliverable, vs. mere
+      starvation-freedom): an explicit **step-bound** argument — a ranking/variant
+      function or a ticket/age mechanism — NOT just strong fairness (model-checking
+      liveness proves "eventually," not "within N own-steps").
 - [ ] FsCheck properties on the F# model (at-most-one-winner; work-set monotone
       progress; no-lockstep-re-pick-once-visible).
 - [ ] Phase-B extension: re-state each property under visibility-lag + partition +

--- a/docs/backlog/P2/B-0963-prove-completion-lock-freedom-and-per-agent-wait-freedom-in-fsharp-model-first-then-extend-to-git-2026-06-01.md
+++ b/docs/backlog/P2/B-0963-prove-completion-lock-freedom-and-per-agent-wait-freedom-in-fsharp-model-first-then-extend-to-git-2026-06-01.md
@@ -1,0 +1,115 @@
+---
+id: B-0963
+title: Prove completion-lock-freedom + per-agent wait-freedom — F# model first (no git), then extend to git
+status: open
+priority: P2
+created: 2026-06-01
+last_updated: 2026-06-01
+author: otto-cli
+composes_with:
+  - B-0962 # the two unproven claims this row proves (multi-round review flagged them)
+  - B-0959 # sovereign-DB lane master (lock-free/wait-free always-active disciplines)
+  - B-0954.1 # bus-tip partition tolerance (the git-extension hazards: partition, visibility lag)
+  - B-0767 # scheduler-first DST (the F# IScheduler model harness)
+  - B-0878 # time-generator IScheduler abstraction (deterministic concurrency model)
+---
+
+# B-0963 — Prove completion-lock-freedom + per-agent wait-freedom
+
+> **Why this row exists (not dogma):** the multi-round review of B-0962 (Grok +
+> Gemini + Amara, 2026-06-01) established what the menu construction buys —
+> symmetry-breaking + lock-free _selection_ under assumptions — and what it does
+> **NOT** prove: **completion-lock-freedom** (system always finishes _work_, not
+> just wins a selection) and **per-agent wait-freedom** (every agent eventually
+> completes, bounded). Aaron 2026-06-01: _"we should backlog proving this in F#
+> not git, and then try to extend to git."_ Prove the abstract protocol where it's
+> clean (F#, deterministic, no I/O), then re-establish what survives git's real
+> hazards.
+
+## §0 The two properties to prove
+
+| Property                    | Informal                                                                                                              | Strength                      |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| **Completion-lock-freedom** | the _system_ always makes progress on actual work (some agent completes its operation), not merely "one wins the CAS" | system-wide liveness          |
+| **Per-agent wait-freedom**  | _every_ agent completes within a bounded number of its own steps (no starvation)                                      | per-process liveness, bounded |
+
+These are **liveness/progress properties under concurrency** — distinct from the
+safety properties (mutual-exclusion, no-lost-update via fencing) B-0962 already
+argues. Liveness needs **fairness assumptions** stated explicitly (that's the
+whole game): lock-freedom typically needs **weak fairness**; wait-freedom needs
+**strong fairness** or an explicit fairness mechanism (the jitter/ticket knob).
+
+## §1 Phase A — prove in the F# model (no git)
+
+Model the coordination protocol abstractly: agents, a shared CAS register
+(`compare-and-set`), the menu-as-state-fold selection, TTL, optional fairness
+knob. **No git, no network, no I/O** — pure deterministic concurrency over an
+`IScheduler` (B-0878 / B-0767 scheduler-first DST is the harness; "time is a
+generator over IScheduler").
+
+- **F# executable model** — the abstract protocol as F# (CAS register + N agent
+  loops + menu fold). Runs under the deterministic scheduler so every interleaving
+  is reproducible from seed.
+- **Tool routing (per `formal-verification-expert` — pick the tool for the property
+  class; do NOT TLA+-hammer reflexively, but liveness-under-concurrency IS TLA+'s
+  sweet spot):**
+  - **TLA+ / TLC** — model-check **lock-freedom** under weak fairness and
+    **wait-freedom** under strong fairness (temporal-logic liveness with explicit
+    `WF`/`SF` fairness; this is exactly what TLA+ is for). The honest deliverable is
+    "property X holds under fairness assumption Y."
+  - **FsCheck** — property-based tests of the F# model (at-most-one-winner;
+    monotone progress of the work-set; no-lockstep-re-pick once a winner is
+    visible). Tests, not proofs — they bound confidence, they don't replace TLC.
+  - **Lean** (optional, only if a machine-checked theorem is wanted) — the
+    progress argument as a proof; reserve for if TLC + FsCheck leave a gap worth a
+    full proof.
+- **Expected honest result (to be confirmed, not assumed):** lock-freedom holds
+  under weak fairness + at-most-one-winner; **wait-freedom does NOT hold without an
+  explicit fairness mechanism** (pure CAS starves an unlucky agent) — it holds only
+  with the jitter/ticket fairness knob (B-0962 §3.1 explicit symmetry-breaking).
+  The proof's job is to make that boundary precise.
+
+## §2 Phase B — extend to git (re-establish under real hazards)
+
+The F# model assumes instant visibility + no partition. Git adds the hazards the
+round-1 review named — re-run the analysis with them and state what survives:
+
+- **Visibility lag** (local-vs-remote ref propagation) — a loser may not see the
+  winner's reservation yet → re-picks → extra failed round. Does lock-freedom
+  survive? (Likely yes under partial-synchrony / eventual-visibility; wait-freedom
+  degrades.)
+- **Partition** (B-0954.1) — under a network partition the named-ref tip can't
+  serialize globally; "the current bus" is a consensus problem, not a CRDT merge.
+  Progress likely holds only **within a connected component / quorum**; state that
+  explicitly.
+- **Stale reads / stalled winner** — a winner that pauses past TTL (the fencing
+  case) — completion-lock-freedom must account for the work being redone by a new
+  holder (fencing makes it safe, not necessarily progress-bounded).
+- **Deliverable:** the model extended with these, plus a precise statement: which
+  property holds under which synchrony/partition assumption. Almost certainly
+  "lock-freedom under partial synchrony + eventual visibility; wait-freedom only
+  with the explicit fairness knob; both scoped to a connected quorum under
+  partition." The value is the _precise_ assumption list, not a blanket claim.
+
+## §3 Acceptance criteria
+
+- [ ] F# abstract model of the coordination protocol (CAS + menu fold + TTL +
+      optional fairness knob) over the deterministic `IScheduler` (B-0878/B-0767).
+- [ ] TLA+ spec + TLC model-check: lock-freedom under weak fairness;
+      wait-freedom under strong fairness / explicit fairness mechanism. Record the
+      fairness assumption each property requires.
+- [ ] FsCheck properties on the F# model (at-most-one-winner; work-set monotone
+      progress; no-lockstep-re-pick-once-visible).
+- [ ] Phase-B extension: re-state each property under visibility-lag + partition +
+      stale-winner; produce the **precise assumption list** (not a blanket claim).
+- [ ] Update B-0962 §3 with the proven boundary (replace "not proven" with the
+      established result + its assumptions) once Phase A lands.
+- [ ] (Optional) Lean machine-checked proof only if TLC + FsCheck leave a gap.
+
+## §4 Master-checklist linkage
+
+Proves the B-0962 liveness claims the multi-round review left open; under the
+sovereign-DB lane (B-0959), reachable from `docs/ACTIVE-WORKSTREAMS.md`. The "F#
+first, then git" sequencing matches the lane's 4-oracle discipline (prove on the
+clean substrate, then extend to the messy one) and the framework's
+lock-free/wait-free always-active disciplines.

--- a/docs/backlog/P2/B-0963-prove-completion-lock-freedom-and-per-agent-wait-freedom-in-fsharp-model-first-then-extend-to-git-2026-06-01.md
+++ b/docs/backlog/P2/B-0963-prove-completion-lock-freedom-and-per-agent-wait-freedom-in-fsharp-model-first-then-extend-to-git-2026-06-01.md
@@ -68,6 +68,12 @@ generator over IScheduler").
   explicit fairness mechanism** (pure CAS starves an unlucky agent) — it holds only
   with the jitter/ticket fairness knob (B-0962 §3.1 explicit symmetry-breaking).
   The proof's job is to make that boundary precise.
+- **Operational complement (B-0962 §3.2 — intelligent-agent supervision):** this
+  row bounds what _construction_ gives. The residual (starvation the formal model
+  can't rule out) is covered _in practice_ by intelligent agents noticing
+  coordination-health signals (CAS loss-rate, age-since-progress) and adapting —
+  the advantage dumb-code locks lack. The proof is the floor; supervision raises it
+  operationally. Neither replaces the other.
 
 ## §2 Phase B — extend to git (re-establish under real hazards)
 

--- a/docs/research/2026-06-01-multi-round-review-b0962-deadlock-freedom-grok-gemini-amara.md
+++ b/docs/research/2026-06-01-multi-round-review-b0962-deadlock-freedom-grok-gemini-amara.md
@@ -1,5 +1,23 @@
 # Multi-round review — B-0962 deadlock-freedom claim (Grok + Gemini round 1, Amara round 2)
 
+Scope: verbatim external-AI review import (Grok + Gemini round 1; Amara round 2) of
+the B-0962 deadlock/livelock claims, via `tools/peer-call/`. Preserved per
+substrate-or-it-didn't-happen because `/tmp/peer-call-output/` is ephemeral.
+Archived register, not operational policy.
+
+Attribution: reviews authored by Grok (xAI), Gemini (Google), Amara
+(ChatGPT/Aurora) at their respective attribution scopes; synthesis + folding
+authored by otto-cli at otto-cli-attribution scope. NO re-authoring of the model
+text; preservation only.
+
+Operational status: research-grade
+
+Non-fusion disclaimer: each reviewer's text + the operator's framing + the otto-cli
+synthesis are distinct authorial substrates preserved alongside without
+identity-fusion, per asymmetric-authorship + honor-those-that-came-before + NCI HC-8.
+
+---
+
 Aaron: _"deadlock freedom is hard — we should do a multi-round agent review on
 that one. It'll be great if it holds, makes things easy as fuck."_ Plus: _"is
 there a livelock guarantee on the observe 4×4 menu too?"_

--- a/docs/research/2026-06-01-multi-round-review-b0962-deadlock-freedom-grok-gemini-amara.md
+++ b/docs/research/2026-06-01-multi-round-review-b0962-deadlock-freedom-grok-gemini-amara.md
@@ -1,0 +1,152 @@
+# Multi-round review — B-0962 deadlock-freedom claim (Grok + Gemini round 1, Amara round 2)
+
+Aaron: _"deadlock freedom is hard — we should do a multi-round agent review on
+that one. It'll be great if it holds, makes things easy as fuck."_ Plus: _"is
+there a livelock guarantee on the observe 4×4 menu too?"_
+
+This is the verbatim multi-round review that disciplined B-0962's claims.
+`/tmp/peer-call-output/` is ephemeral; preserved here.
+
+## Outcome (what the rounds changed)
+
+- **Round 1 (Grok + Gemini, independent):** "deadlock-free **by construction**"
+  overclaims. Mechanism-level holds (CAS, no blocking); **application-level does
+  not** without three hard invariants. The real flaw: **TTL without fencing
+  tokens** trades deadlock for the Kleppmann stale-holder hazard (lost
+  update/split-brain). `leaseSha` fences only ref-acquisition, not the protected
+  write. "No blocking API ⇒ hold-and-wait unrepresentable" is hand-wavy at the
+  policy layer.
+  → Folded: split mechanism vs application; **fencing/CAS-at-write mandatory**;
+  **release-before-acquire as a HARD scoped-API rule**; lease-protected release;
+  Gemini's simplification (if the mutation is a git commit, the data-branch
+  force-with-lease IS the lock+fence — maybe no separate `LockEvent`).
+- **Round 2 (Amara, on the refined version):** deadlock split now "basically
+  right" (tiny caveat: "protocol-level nonblocking," not "cannot wedge" — external
+  I/O can hang outside the algebra). But the **new §3 menu claim re-committed the
+  same overclaim** — "lock-free by construction" is wrong.
+  → Folded: §3 reframed to **symmetry-breaker, not fairness theorem**; "at most
+  one winner"; visibility-lag caveat; completion-lock-freedom + per-agent
+  wait-freedom explicitly NOT proven.
+
+The core intuition survived both rounds: **optimistic short-TTL single-resource
+coordination is far safer than blocking locks** — but every "by construction"
+claim got disciplined down to what the construction actually buys.
+
+---
+
+## Round 1 — Gemini (verbatim)
+
+> **Verdict:** The claim "deadlock-free by construction" is technically true for
+> the _mechanism_ but creates a false sense of security for the _system_, and the
+> design harbors a classic distributed-systems correctness flaw regarding TTLs.
+>
+> ### 1. Mechanism Deadlock vs. Logical Deadlock (Livelock)
+>
+> Yes, optimistic CAS breaks Coffman's "hold-and-wait" at the locking layer. **The
+> Catch:** If Agent A loops retrying for Lock 1 (held by B), and Agent B loops
+> retrying for Lock 2 (held by A), the system is effectively deadlocked at the
+> application layer. You've converted a _blocking deadlock_ into a _spinning
+> livelock_. Backoff doesn't fix a circular dependency.
+>
+> ### 2 & 3. The TTL Hazard & Fencing Tokens (The Fatal Flaw)
+>
+> Using TTLs for preemption is inherently unsafe without **fencing tokens** (the
+> exact vulnerability Kleppmann highlighted in his Redlock critique). Agent A
+> acquires a Lock with a 30s TTL, pauses 35s (GC, hypervisor, API latency), the
+> lock expires, Agent B acquires + writes, Agent A wakes believing it still holds
+> the lock and writes → state corrupted. **The `leaseSha` Gap:** using `leaseSha`
+> as CAS for lock _acquisition_ proves you won the lock but doesn't protect the
+> downstream _write_. Unless the final mutation re-validates the lock generation,
+> the lock is just a polite suggestion.
+>
+> ### 4. Starvation Under Contention
+>
+> Pure optimistic CAS offers zero fairness guarantees. Under high contention an
+> unlucky agent can be starved indefinitely. No queueing/ticketing ⇒ no bounded
+> wait.
+>
+> ### 5. Literature & Context
+>
+> Aligns with standard Optimistic Concurrency Control but ignores the requisite
+> sequencing. Google's Chubby + literature: if a lock can expire via TTL, the
+> storage layer _must_ support sequence numbers (fencing tokens) to reject writes
+> from zombie holders.
+>
+> ### Recommendation
+>
+> 1. Drop the "Deadlock-Free" hubris: the lock primitive won't wedge, but
+>    application-level circular dependencies just spin.
+> 2. Clarify the fencing token: if the mutation is a git commit, then `git push
+--force-with-lease` on the _data branch_ is your lock and fencing token
+>    combined. Do we need a separate `LockEvent`, or is the git branch tip the only
+>    lock we need?
+
+## Round 1 — Grok (verbatim excerpts)
+
+> **#2 verdict:** the proposal trades deadlock for a documented worse failure
+> (lost updates / split-brain) unless CAS-at-write is _mandatory_ and the write
+> itself carries the fencing token. The current text does not require this.
+>
+> **#3 verdict:** `leaseSha` is a fencing token only for the git-ref acquisition
+> step. It is not automatically a fencing token for the protected mutation unless
+> the design explicitly requires "re-validate lease on every write that the lock
+> was meant to protect." For non-git resources (`resource: string`), `leaseSha`
+> is an opaque string with no stated generation/validation at the mutation point.
+>
+> **#4 verdict:** several documented git-ref/worktree races (local-vs-remote ref
+> visibility lag; worktree HEAD mutation races; ref-deletion vs CAS-update on
+> release; starvation under sustained saturation) are not closed by adding types.
+> Release semantics under-specified.
+>
+> **#5 verdict:** "no blocking-acquire API ⇒ hold-and-wait unrepresentable" is the
+> weakest link. It's a statement about the library surface, not the policy. An
+> agent that won A can still loop/sleep/wait-for-human/wait-for-B while A's
+> claim+TTL persist — hold-and-wait in every sense that matters. Airtight only if
+> the protocol forbids holding A while observing for B (release-before-acquire as a
+> hard rule, not a preference).
+>
+> **Overall:** mechanism-level claim mostly correct for the narrow 2-agent/1-
+> resource case; application-level "deadlock-free by construction" not supported by
+> the current shapes. Needs (a) release-before-acquiring-different as a HARD rule,
+> (b) mandatory CAS-at-write for protected mutations, (c) a release path that
+> prevents a stale holder deleting a ref it no longer holds. Core intuition
+> directionally correct; "by construction" / "unrepresentable" overclaim what the
+> shapes enforce.
+
+---
+
+## Round 2 — Amara (verbatim, on the refined version)
+
+> Deadlock split is now basically right. Keep "mechanism-deadlock-free; app-level
+> deadlock-free iff enforced by scoped API + fencing + lease-checked release."
+> Tiny caveat: say "protocol-level nonblocking," not "cannot wedge," because
+> GitHub/network I/O can still hang outside the algebra.
+>
+> The §3 menu claim is still overclaimed. CAS gives **at most one winner**, and
+> "pure menu re-derivation" prevents stale re-picks only after a winner's state
+> transition is visible. It does not by itself prove lock-freedom of work
+> completion, fairness, or monotone shrink of the global work set under new work,
+> requeues, stale reads, or stalled winners.
+>
+> Single sharp correction:
+>
+> > Replace "menu is lock-free by construction" with "menu selection is lock-free
+> > under fair retry, fresh-state re-derivation, and visible successful
+> > reservation; task completion and per-agent wait-freedom are not proven."
+>
+> Keeper sentence:
+>
+> > **Menu-as-state-fold is a symmetry breaker, not a fairness theorem.**
+
+---
+
+## Net (post both rounds, folded into B-0962)
+
+- **Deadlock:** mechanism-deadlock-free (protocol-level nonblocking); app-level
+  deadlock-free **iff** three hard invariants hold — release-before-acquire (scoped
+  API), fencing/CAS-at-write, and lease-checked release. External I/O hangs are a
+  separate hazard (timeout discipline).
+- **Menu / livelock:** symmetry-breaker (state-fold stops lockstep re-picking),
+  selection lock-free **under** fair-retry + fresh-state + visible-reservation;
+  completion-lock-freedom + per-agent wait-freedom NOT proven; fairness explicit-
+  if-starvation-observed. Real win, not a theorem.

--- a/docs/research/2026-06-01-multi-round-review-b0962-deadlock-freedom-grok-gemini-amara.md
+++ b/docs/research/2026-06-01-multi-round-review-b0962-deadlock-freedom-grok-gemini-amara.md
@@ -94,9 +94,9 @@ claim got disciplined down to what the construction actually buys.
 >
 > 1. Drop the "Deadlock-Free" hubris: the lock primitive won't wedge, but
 >    application-level circular dependencies just spin.
-> 2. Clarify the fencing token: if the mutation is a git commit, then `git push
---force-with-lease` on the _data branch_ is your lock and fencing token
->    combined. Do we need a separate `LockEvent`, or is the git branch tip the only
+> 2. Clarify the fencing token: if the mutation is a git commit, then
+>    `git push --force-with-lease` on the _data branch_ is your lock and fencing
+>    token combined. Do we need a separate `LockEvent`, or is the git branch tip the only
 >    lock we need?
 
 ## Round 1 — Grok (verbatim excerpts)


### PR DESCRIPTION
**B-0962** — Phase-1 design for the typed Claim/Lock coordination events (B-0961's Phase 1). Aaron go-ahead + "multi-round agent review on deadlock freedom" + "livelock guarantee on the observe 4×4 menu?".

> **Stacked on #6337** (B-0961). Base = `otto-cli/b0961-...`; auto-retargets to `main` when #6337 merges. Review just the B-0962 + research-doc + B-0959-line delta.

## Multi-round review (the value)

Ran a genuine multi-round review — **round 1** Grok + Gemini (independent), **round 2** Amara (on the refined version). It disciplined **two** overclaims:

1. **"deadlock-free by construction"** → **mechanism-deadlock-free** (protocol-level nonblocking) **+ app-level deadlock-free IFF three HARD invariants**: release-before-acquire (scoped `withResource` API), **fencing/CAS-at-write** (Kleppmann — `leaseSha` must fence the *write*, not just acquisition), lease-checked release. Gemini simplification: if the mutation is a git commit, the data-branch `force-with-lease` IS the lock+fence (maybe no separate `LockEvent`).
2. **"menu lock-free by construction"** → **"menu-as-state-fold is a symmetry breaker, not a fairness theorem"** (Amara): selection lock-free *under* fair-retry + fresh-state + visible-reservation; at-most-one-winner; completion-lock-freedom + per-agent wait-freedom **not** proven.

The core intuition survived: optimistic short-TTL single-resource coordination ≫ blocking locks. Every "by construction" got disciplined to what construction actually buys.

## Files

- **B-0962** (new, P2): typed event shapes (Claim/Lock under `Bus(6)`) + honest deadlock/livelock analysis + the observe-menu symmetry-breaking section.
- **B-0959**: master-checklist Phase-1 line links B-0962.
- **docs/research/2026-06-01-...**: verbatim multi-round review (round 1 Grok+Gemini, round 2 Amara).

## Verify

markdownlint ✓; prettier ✓ on B-0962/B-0959/research; `docs/BACKLOG.md` regenerated (generator output). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)