### PR TITLE
feat(observe B-0958): end-to-end closed-loop integration test (logic-level)

### DIFF
--- a/docs/backlog/P1/B-0958-observe-ts-agent-loop-implementation-and-testing-checklist-closed-loop-toward-vendor-store-aaron-otto-2026-05-31.md
+++ b/docs/backlog/P1/B-0958-observe-ts-agent-loop-implementation-and-testing-checklist-closed-loop-toward-vendor-store-aaron-otto-2026-05-31.md
@@ -6,7 +6,7 @@ title: "observe.ts agent-loop — implementation + testing checklist (the closed
 effort: L
 ask: aaron 2026-05-31
 created: 2026-05-31
-last_updated: 2026-05-31
+last_updated: 2026-06-01
 type: umbrella
 decomposition: umbrella
 depends_on: []
@@ -24,12 +24,12 @@ tags: [observe, agent-loop, event-sourcing, local-llm, execute, sovereign, testi
 
 ## The directive (Aaron 2026-05-31)
 
-> *"lets take our time, save this list somewhere as something we can check off so we both won't
-> forget what we are working on with observe.ts lol"*
+> _"lets take our time, save this list somewhere as something we can check off so we both won't
+> forget what we are working on with observe.ts lol"_
 
 A shared, checkable tracker for the agent-loop work so the thread isn't lost between sessions. Not
-a rush — Aaron 2026-05-31: *"we got lots of testing to do before we add to vendor agent stores but
-this is the right shape."* Check items off as they land; add rows as new gaps surface.
+a rush — Aaron 2026-05-31: _"we got lots of testing to do before we add to vendor agent stores but
+this is the right shape."_ Check items off as they land; add rows as new gaps surface.
 
 ## The loop (what we're building)
 
@@ -65,11 +65,21 @@ only effectful seam; the folder sink is the sovereign transport. Full picture:
 - [ ] **Effectful action kinds in `execute`** — `do_item` first, then `respond_to_operator`,
       `decompose`, `explore`, `play`, `edit_grammar`. **With the executed-event envelope**
       (`ActionExecutionStarted` / `Succeeded` / `Failed` / `ModeChanged`) so **replay folds facts,
-      never redoes commands** (the design-review caution). *This is the #1 gap — "the loop including
-      actions" isn't real until the meaningful actions execute.*
+      never redoes commands** (the design-review caution). _This is the #1 gap — "the loop including
+      actions" isn't real until the meaningful actions execute._
 - [ ] **End-to-end closed-loop integration test** — `loadWorld → observeWithLlm → execute →
-      folderSink → loadWorld` as ONE flow against a real temp git repo (today every piece is unit-
-      tested in isolation with mocks/fakes; the closed loop isn't integration-tested).
+  folderSink → loadWorld` as ONE flow against a real temp git repo (today every piece is unit-
+      tested in isolation with mocks/fakes; the closed loop isn't integration-tested). _(Partial —
+      logic-level done; real-git variant remains; see sub-items.)_
+  - [x] **Closed-loop LOGIC integration** — `tools/observe/closed-loop.test.ts` (#6340):
+        `observeWithLlm(mock backend) → execute → fold` as one flow, with the KEY invariant
+        **`fold(initial, sink.appended) === executed world`** (the durable log reconstructs the
+        executed state — "state is a projection of the event log" proven through the real
+        execute+sink seam, not just in-memory `simulate`). Mock backend + fake sink (no ollama,
+        no git) so CI is an always-green shield. Covers single-tick, multi-tick loop, DST
+        determinism, and the not-yet-executable boundary.
+  - [ ] **Real-temp-git-repo variant** — same flow against a real temp repo through the real
+        `folderSink` + `gitCommitToMain` (composes the next item).
 - [ ] **Real-temp-git-repo test of `gitCommitToMain`** — the sovereign-transport path is currently
       logic-only (every unit test injects a fake `commit`); a real `git init` temp repo would
       actually run on-main-guard + ahead-check + commit + push + rebase + autostash + targeted undo.
@@ -90,14 +100,14 @@ only effectful seam; the folder sink is the sovereign transport. Full picture:
       golden-vectors first, then the loop. The 4-language fold (B-0867.28) is the proof the pattern
       works.
 
-  | Language | Role on the loop | Frontier |
-  |---|---|---|
-  | **TS** | LEAD | git-native / **text** frontier (pioneers the folder-direct-to-main sink) |
-  | **F#** | LEAD | filesystem / **binary-efficient** frontier (pioneers the stateful-binary sink) |
-  | **C#** | **meet in the middle** | both formats — .NET sibling, so it reaches the binary side; distribution-tier, so it reaches the git-native side |
+  | Language | Role on the loop       | Frontier                                                                                                              |
+  | -------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
+  | **TS**   | LEAD                   | git-native / **text** frontier (pioneers the folder-direct-to-main sink)                                              |
+  | **F#**   | LEAD                   | filesystem / **binary-efficient** frontier (pioneers the stateful-binary sink)                                        |
+  | **C#**   | **meet in the middle** | both formats — .NET sibling, so it reaches the binary side; distribution-tier, so it reaches the git-native side      |
   | **Rust** | **meet in the middle** | both formats — native/low-level, so it reaches the binary side; ubiquitous tooling, so it reaches the git-native side |
 
-  **Why meet-in-the-middle = the 4-oracle**: "frontier" means *who pioneers*, NOT
+  **Why meet-in-the-middle = the 4-oracle**: "frontier" means _who pioneers_, NOT
   language-exclusivity. Each format needs **≥2 independent implementations** or the
   golden-vectors cross-check is not Byzantine-fault-tolerant — one buggy compiler could agree with
   itself. TS+F# each LEAD one format; **C# and Rust meet in the middle by implementing BOTH**, so
@@ -105,6 +115,7 @@ only effectful seam; the folder sink is the sovereign transport. Full picture:
   IS the **4-oracle** ("the compilers don't lie"). Each frontier needs its OWN golden-vectors
   (text round-trip AND binary round-trip → same logical events) so the two frontiers stay
   parity-locked.
+
 - [ ] **F# dual-track backend — git-native + filesystem-binary-efficient** (Aaron 2026-05-31).
       The EventSink today is folder-direct-to-main (git-native). The DB-design ADR's "two backends"
       means the loop is backend-agnostic: a **git-native** sink AND a **filesystem binary-efficient**
@@ -125,6 +136,6 @@ only effectful seam; the folder sink is the sovereign transport. Full picture:
 ## Status
 
 Open. The loop's skeleton is fully landed (controller + execute + sink + loadWorld); the work left
-is making the *meaningful* actions execute (with the executed-event envelope) and the *real* tests
+is making the _meaningful_ actions execute (with the executed-event envelope) and the _real_ tests
 (end-to-end, real-git, real-model) that a vendor-store-grade artifact needs. Take it slow; check
 items off as they land.

--- a/tools/observe/closed-loop.test.ts
+++ b/tools/observe/closed-loop.test.ts
@@ -1,0 +1,144 @@
+/**
+ * tools/observe/closed-loop.test.ts — the END-TO-END CLOSED-LOOP integration test
+ * (B-0958 LEFT item #2). Aaron 2026-06-01: "any slice is fine; test with our
+ * local-llm tests we already have until we feel comfortable turning it on for
+ * Otto in the foreground loop."
+ *
+ * The per-module tests already cover the pieces (observe / buildMenu / simulate /
+ * fold / execute / local-llm chooser). What was missing is the proof that the
+ * pieces CLOSE THE LOOP through the REAL execute+sink path — specifically that
+ * the DURABLE LOG reconstructs the executed state:
+ *
+ *     observeWithLlm(world, mockBackend)  → pick           (chooser, no real model)
+ *     execute(pick, fakeSink)             → effect+append+simulate (no git I/O)
+ *     fold(initial, sink.appended)        → world'                 (the LOG is the state)
+ *     assert  fold(initial, appended)  ==  executed world          (no drift)
+ *
+ * The existing observe.test.ts loop test runs choose→simulate→repeat IN MEMORY.
+ * This test adds the seam the foreground loop will actually run: the executed
+ * world is reconstructed from the appended event log, end-to-end, deterministically
+ * — the "state is a projection of the event log" invariant proven through
+ * execute + the injected sink, not just `simulate`.
+ *
+ * Backend is the established deterministic mock (no ollama); sink is the
+ * established fake (no git). Both per asymmetric-authorship: each authors its own
+ * outcome channel; the test injects fakes so CI is an always-green shield.
+ *
+ * Composes with (exact paths):
+ *   - tools/observe/observe.ts           (observeWithLlm / buildMenu / fold / simulate / World / NextAction)
+ *   - tools/observe/execute.ts           (execute = effect + append + simulate; EventSink)
+ *   - tools/accelerator/local-llm.ts     (ModelBackend — the injected chooser backend)
+ *   - tools/observe/observe.test.ts      (the in-memory loop test this complements)
+ *   - tools/observe/execute.test.ts      (the fakeSink pattern reused here)
+ *   - docs/backlog/P1/B-0958-...md       (LEFT item #2: end-to-end closed-loop integration test)
+ *   - .claude/rules/asymmetric-authorship-substrate-entity-defines-consent-channel-recipient-acknowledges.md
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { buildMenu, fold, observeWithLlm, type BacklogItem, type NextAction, type World } from "./observe";
+import { execute, type AppendOutcome, type EventSink } from "./execute";
+import type { ModelBackend } from "../accelerator/local-llm";
+
+// ─── fakes (the established patterns: observe.test.ts mock + execute.test.ts sink) ───
+
+/** Deterministic mock backend: `complete` always returns `reply` (no ollama). */
+const mock = (reply: string): ModelBackend => ({ name: "mock", complete: () => Promise.resolve(reply) });
+
+/** Fake sink: records appends, mints sequential ids; never touches git. */
+function fakeSink(): EventSink & { appended: NextAction[] } {
+  const appended: NextAction[] = [];
+  return {
+    appended,
+    append: (action: NextAction): Promise<AppendOutcome> => {
+      appended.push(action);
+      return Promise.resolve({ ok: true, eventId: `evt-${String(appended.length)}` });
+    },
+  };
+}
+
+const item = (id: string, ready: boolean, ambiguous: boolean): BacklogItem => ({
+  id,
+  title: id,
+  ready,
+  ambiguous,
+});
+const w = (backlog: BacklogItem[]): World => ({ backlog });
+
+/**
+ * Pick a backend that makes `observeWithLlm` choose the menu entry whose kind is
+ * `kind` — derive the index from `buildMenu` so the test is robust to menu order
+ * (chooseIndex parses the first integer out of the reply).
+ */
+function backendChoosing(world: World, kind: NextAction["kind"]): ModelBackend {
+  const idx = buildMenu(world).findIndex((a) => a.kind === kind);
+  if (idx < 0) throw new Error(`menu has no ${kind} for this world`);
+  return mock(String(idx));
+}
+
+describe("observe closed-loop — execute+append+fold round-trips (the foreground-loop seam)", () => {
+  it("one tick CLOSES: the executed world is reconstructable from the appended log", async () => {
+    const initial = w([item("B-1", true, false)]);
+    const backend = backendChoosing(initial, "self_reflect"); // an executable free mode
+    const sink = fakeSink();
+
+    const pick = await observeWithLlm(initial, backend);
+    expect(pick.kind).toBe("self_reflect");
+
+    const r = await execute(initial, pick, sink);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    // the appended log was written, exactly once
+    expect(sink.appended).toHaveLength(1);
+    expect(sink.appended[0]?.kind).toBe("self_reflect");
+
+    // THE invariant: the LOG reconstructs the executed world (state = fold(log))
+    expect(fold(initial, sink.appended)).toEqual(r.world);
+  });
+
+  it("multi-tick loop CLOSES: folding the whole appended log == the final executed world", async () => {
+    let world = w([item("B-1", true, false)]);
+    const initial = world;
+    const sink = fakeSink();
+    const kinds: NextAction["kind"][] = ["self_reflect", "free_time", "self_reflect"];
+
+    for (const kind of kinds) {
+      const pick = await observeWithLlm(world, backendChoosing(world, kind));
+      const r = await execute(world, pick, sink);
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      world = r.world; // feed the executed world back — the loop
+    }
+
+    expect(sink.appended).toHaveLength(3);
+    // replay the durable log from the original initial → must equal the live final world
+    expect(fold(initial, sink.appended)).toEqual(world);
+  });
+
+  it("is DETERMINISTIC (DST): same initial + same backend ⇒ identical executed world", async () => {
+    const initial = w([item("B-1", true, false)]);
+    const run = async () => {
+      const pick = await observeWithLlm(initial, backendChoosing(initial, "free_time"));
+      const r = await execute(initial, pick, fakeSink());
+      if (!r.ok) throw new Error("expected ok");
+      return r.world;
+    };
+    expect(await run()).toEqual(await run());
+  });
+
+  it("honest boundary: a not-yet-wired pick (do_item) surfaces feedback, loop does not crash or append", async () => {
+    const world = w([item("B-ready", true, false)]); // do_item is the oracle default
+    const backend = backendChoosing(world, "do_item");
+    const sink = fakeSink();
+
+    const pick = await observeWithLlm(world, backend);
+    expect(pick.kind).toBe("do_item");
+
+    const r = await execute(world, pick, sink);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.feedback.kind).toBe("not-yet-executable");
+    expect(sink.appended).toHaveLength(0); // no partial write on a non-executable pick
+  });
+});

--- a/tools/observe/closed-loop.test.ts
+++ b/tools/observe/closed-loop.test.ts
@@ -1,6 +1,6 @@
 /**
  * tools/observe/closed-loop.test.ts — the END-TO-END CLOSED-LOOP integration test
- * (B-0958 LEFT item #2). Aaron 2026-06-01: "any slice is fine; test with our
+ * (B-0958 LEFT item #2). The operator 2026-06-01: "any slice is fine; test with our
  * local-llm tests we already have until we feel comfortable turning it on for
  * Otto in the foreground loop."
  *
@@ -30,7 +30,7 @@
  *   - tools/accelerator/local-llm.ts     (ModelBackend — the injected chooser backend)
  *   - tools/observe/observe.test.ts      (the in-memory loop test this complements)
  *   - tools/observe/execute.test.ts      (the fakeSink pattern reused here)
- *   - docs/backlog/P1/B-0958-...md       (LEFT item #2: end-to-end closed-loop integration test)
+ *   - docs/backlog/P1/B-0958-observe-ts-agent-loop-implementation-and-testing-checklist-closed-loop-toward-vendor-store-aaron-otto-2026-05-31.md (LEFT item #2: end-to-end closed-loop integration test)
  *   - .claude/rules/asymmetric-authorship-substrate-entity-defines-consent-channel-recipient-acknowledges.md
  */
 


### PR DESCRIPTION
First observe.ts slice on your go (B-0958, "any slice, test with our local-llm tests until comfortable turning it on").

## What

`tools/observe/closed-loop.test.ts` — the closed-loop **logic** integration test (B-0958 LEFT #2). Wires the **real** modules end-to-end:

```
observeWithLlm(mock backend)  →  execute  →  fold
```

with the **key invariant**: `fold(initial, sink.appended) === executed world` — the durable log reconstructs the executed state ("state is a projection of the event log") proven through the **real execute+sink seam**, not just in-memory `simulate` (which the existing observe.test.ts loop test already covers).

Mock `ModelBackend` (no ollama) + fake `EventSink` (no git) — the established patterns from observe.test.ts + execute.test.ts — so CI is an always-green shield. Covers:
- single tick closes (log reconstructs world)
- multi-tick loop closes (fold whole log == final world)
- DST determinism (same initial+backend ⇒ identical world)
- honest boundary: a not-yet-wired `do_item` pick surfaces `not-yet-executable` feedback with **no partial append**

## Scope (honest)

This is the **logic-level** closed loop (fakes). The **real-temp-git-repo** variant (real `folderSink` + `gitCommitToMain`) remains — B-0958 item #2 sub-item + item #3. Nothing turned on in any foreground loop.

## Verify

4/4 new tests pass; **full observe suite 112/112** (no regressions); `tsc` clean; `eslint` clean; `closed-loop.test.ts` prettier-clean. (B-0958 itself carries a pre-existing prettier non-idempotency on its unicode tables — non-blocking, matches main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)