### PR TITLE
docs(B-0964): effectful do_item design — fact-event envelope + injected executor + just-bash sandbox surface

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -461,7 +461,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0957](backlog/P1/B-0957-first-class-labels-tags-scopes-on-every-gset-zset-entity-deferred-to-human-state-label-otel-baggage-di-scope-propagation-aaron-otto-2026-05-31.md)** First-class labels/tags + scopes on every G-Set/Z-set entity — deferred-to-human state-label; OTel-baggage / DI-scope propagation; the metadata layer policies + decentralized identity build on
 - [ ] **[B-0958](backlog/P1/B-0958-observe-ts-agent-loop-implementation-and-testing-checklist-closed-loop-toward-vendor-store-aaron-otto-2026-05-31.md)** observe.ts agent-loop — implementation + testing checklist (the closed observe→execute→loadWorld loop; toward vendor-store distribution)
 - [ ] **[B-0959](backlog/P1/B-0959-zeta-sovereign-distributed-db-and-agent-loop-master-checklist-one-git-native-zset-substrate-aaron-otto-2026-05-31.md)** Zeta sovereign distributed-DB + agent-loop MASTER checklist — one git-native ZetaId Z-set substrate (algebra ladder · observe loop · git-native bus · distributed time · 4-oracle)
-- [ ] **[B-0964](backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md)** Effectful do_item — command-vs-fact-event envelope + injected executor port + just-bash sandboxed bash surface
+- [ ] **[B-0964](backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md)** Effectful do_item — command-vs-fact-event envelope + injected executor port + item-class-routed bash surface (just-bash text / local docker real-work / CF cloud-burst)
 
 ## P2 — research-grade
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -461,6 +461,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0957](backlog/P1/B-0957-first-class-labels-tags-scopes-on-every-gset-zset-entity-deferred-to-human-state-label-otel-baggage-di-scope-propagation-aaron-otto-2026-05-31.md)** First-class labels/tags + scopes on every G-Set/Z-set entity — deferred-to-human state-label; OTel-baggage / DI-scope propagation; the metadata layer policies + decentralized identity build on
 - [ ] **[B-0958](backlog/P1/B-0958-observe-ts-agent-loop-implementation-and-testing-checklist-closed-loop-toward-vendor-store-aaron-otto-2026-05-31.md)** observe.ts agent-loop — implementation + testing checklist (the closed observe→execute→loadWorld loop; toward vendor-store distribution)
 - [ ] **[B-0959](backlog/P1/B-0959-zeta-sovereign-distributed-db-and-agent-loop-master-checklist-one-git-native-zset-substrate-aaron-otto-2026-05-31.md)** Zeta sovereign distributed-DB + agent-loop MASTER checklist — one git-native ZetaId Z-set substrate (algebra ladder · observe loop · git-native bus · distributed time · 4-oracle)
+- [ ] **[B-0964](backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md)** Effectful do_item — command-vs-fact-event envelope + injected executor port + just-bash sandboxed bash surface
 
 ## P2 — research-grade
 

--- a/docs/backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md
+++ b/docs/backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md
@@ -1,6 +1,6 @@
 ---
 id: B-0964
-title: Effectful do_item — command-vs-fact-event envelope + injected executor port + just-bash sandboxed bash surface
+title: Effectful do_item — command-vs-fact-event envelope + injected executor port + item-class-routed bash surface (just-bash text / local docker real-work / CF cloud-burst)
 status: open
 priority: P1
 created: 2026-06-01
@@ -77,47 +77,51 @@ append `ActionSucceeded|ActionFailed` → `simulate` **only on success**. Tests
 inject a fake executor (deterministic ok/fail, no shell). Production injects the
 real one (§2).
 
-## §2 The bash surface (Aaron's question) — RESOLVED: just-bash sandbox by default
+## §2 The bash surface (Aaron's question) — RESOLVED (post multi-AI review): item-class-routed, NOT just-bash-everywhere
 
 > **Aaron 2026-06-01:** "can we use justbash or anything like that to give the
 > local llm a real simulated bash surface without a ton of work or some sort of
-> docker container if not?"
+> docker container if not? … maybe see if the peers think it's overkill."
 
-**Yes — [`just-bash`](https://github.com/vercel-labs/just-bash) (vercel-labs;
-[justbash.dev](https://justbash.dev/)).** A full **bash environment reimplemented
-in TypeScript, in-process, that never touches the real filesystem** — 70+ commands
-(cat/grep/sed/jq, pipes, redirects, `&&`/`||`, for/while, functions, globs,
-heredocs, var-expansion), filesystem-isolated, **no VM/container**
-([writeup](https://www.codeline.co/thoughts/repo-review/2026/just-bash-virtual-shell-for-ai-agents)).
-Exactly "a real simulated bash surface without docker or a ton of work" — and it's
-TS, so it drops straight into the Bun-hosted observe loop (Rule 0: TS is the
-substrate).
+First draft answered "just-bash as the default." **The review (Gemini + Amara,
+2026-06-01) demoted that** — and the reasoning is load-bearing. Amara's keeper:
 
-The three-tier surface (default safe → escalate only when needed):
+> **`just-bash` proves the envelope; local Docker proves the work. Persist facts
+> across both, and never let replay reissue commands.**
 
-| Tier            | Surface                                                                                               | When                                                             | Safety                                                                                                       |
-| --------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **Default**     | just-bash **in the IN-MEMORY config, network DISABLED**                                               | the LLM's do_item work — real shell semantics, no real-FS reach  | sandboxed **only in this config** — the in-memory FS can't escape to disk; network off                       |
-| **Constrained** | [`just`](https://github.com/casey/just) recipes via [just-mcp](https://docs.rs/crate/just-mcp/latest) | pre-vetted named tasks (build/test) — an allowlist               | safest: the LLM picks a recipe index, not free-form bash (composes the 16-action constrained-choice grammar) |
-| **Escalation**  | just-bash **OverlayFS / ReadWriteFs / network-allowlist** configs · Bun `$` · real shell · docker     | only when the item genuinely needs real-FS / real-system effects | **GATED** — see §3 security floor; not the default                                                           |
+[`just-bash`](https://github.com/vercel-labs/just-bash) (vercel-labs;
+[justbash.dev](https://justbash.dev/)) is real: a bash environment reimplemented in
+TypeScript, in-process, in-memory FS, no container — "a real bash surface without
+docker." But it is a **simulator**: it hits a wall the moment an item needs **real
+tools** (git/npm/compilers), and re-implementing POSIX chases a long tail forever
+vs. a real kernel's correctness + namespaces/cgroups (Gemini). And it is **TS-only**
+— the 4-oracle (Rust/C#/F#) would each need a re-impl, whereas a **container
+boundary is language-agnostic** (one local docker, all four drive it). So the
+routing is **by item-class**, not a single default:
+
+| Tier                       | Surface                                                                                                                                                       | When                                                                                        | Safety                                                                                                                     |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Tests**                  | **fake executor** (deterministic, no shell)                                                                                                                   | CI / envelope-shakedown                                                                     | always-green shield                                                                                                        |
+| **Text / no-FS items**     | **just-bash** (in-memory FS, network OFF)                                                                                                                     | pure-text work that never needs real tools — zero-ops, in-process                           | sandboxed **only in this config** (in-memory FS can't reach disk; net off)                                                 |
+| **Real effectful work**    | **local docker** (real kernel, real tools)                                                                                                                    | "the first time the item needs real tools, **stop simulating**" (Amara) — git/npm/compilers | real namespaces/cgroups; **language-agnostic boundary** — the 4-oracle's shared executor                                   |
+| **Constrained**            | [`just`](https://github.com/casey/just) recipes via [just-mcp](https://docs.rs/crate/just-mcp/latest)                                                         | pre-vetted named tasks — an allowlist                                                       | safest: pick a recipe index, not free-form bash (composes the 16-action grammar)                                           |
+| **Cloud-burst escalation** | [Cloudflare Sandbox SDK](https://github.com/cloudflare/sandbox-sdk) (edge containers + fork-sessions) · just-bash OverlayFS/ReadWriteFs/net · real host shell | massive parallel / explicit need                                                            | **GATED** (§3). CF is a **dependency trap for a LOCAL sovereign agent** (Gemini) — escalation only, never the loop default |
 
 > **The tool is NOT the gate — the CONFIG is (Codex review, 2026-06-01).** just-bash
-> ([justbash.dev](https://justbash.dev/)) ships more than the in-memory `Bash`:
-> it also documents **CLI / OverlayFS / ReadWriteFs mounting** that reads the real
-> project root, and **network access with URL allowlists**. So "we use just-bash"
-> does NOT by itself mean sandboxed — choosing the OverlayFS/ReadWriteFs path or
-> enabling network silently crosses into the real-FS/network tier. The default
-> executor MUST pin the **in-memory filesystem + network-disabled** config; those
-> other just-bash configs sit in the **Escalation** tier and require the §3 gate.
+> also ships CLI/OverlayFS/ReadWriteFs mounting (reads the real project root) +
+> network-allowlist configs. "We use just-bash" ≠ sandboxed — the text-tier MUST pin
+> **in-memory FS + network-disabled**; its other configs are cloud-burst/escalation
+> tier, gated.
 
-**Recommendation:** **just-bash (in-memory FS, network disabled) as the default
-`CommandExecutor` impl** (real bash surface, no docker, can't reach disk);
-**fake executor for tests** (the always-green shield, per "test with our local-llm
-tests until comfortable"); **`just`-recipe allowlist** where the work is a known
-task; **any real-FS/network config (just-bash OverlayFS/ReadWriteFs/curl, Bun `$`,
-docker) only behind the §3 gate.** Adding just-bash is a new dep — implementation
-PR runs the dep-pin-search-first WebSearch for the current version + confirms the
-exact in-memory/network-off config flags.
+**Recommendation (folded):** **fake for tests; just-bash (in-memory, net-off) only
+for pure-text/no-FS items; LOCAL DOCKER as the default for real effectful work**
+(real kernel, language-agnostic boundary — the 4-oracle drives the same container,
+no 4× bash re-impl); **`just`-recipe allowlist** for known tasks; **CF Sandbox =
+cloud-burst escalation only** (sovereignty trap as a default); **reject
+bash-on-our-own-FUSE-fs** ("we're building an AI factory, not rewriting GNU
+userland" — Gemini). The `CommandExecutor` port (§1) is the invariant Rust/C#/F#
+inherit; the impl is swappable behind it. Each impl is a new dep — implementation
+PR runs dep-pin-search-first for versions + confirms sandbox/config flags.
 
 ## §2.1 Cross-language + alternatives — the port is the seam (operator 2026-06-01)
 
@@ -206,13 +210,19 @@ LLM sub-loop over just-bash) as Phase 2.
 - [ ] Tests: fake executor success path, failure path (item stays, mode unchanged
       or work), replay-folds-facts-without-executor, closed-loop.test.ts extended.
 
-**Phase 2 — real bash surface (just-bash):**
+**Phase 2 — real surfaces (review-folded routing):**
 
-- [ ] just-bash `CommandExecutor` impl (dep-pin WebSearch for current version);
-      sandboxed FS-isolation verified; fake stays the CI default.
+- [ ] **local docker `CommandExecutor`** — the DEFAULT for real effectful work
+      (real kernel, language-agnostic boundary the 4-oracle shares). Real
+      namespaces/cgroups; gate per §3.
+- [ ] **just-bash `CommandExecutor`** — for pure-text / no-FS items only. Package:
+      **[`@archildata/just-bash`](https://www.npmjs.com/package/@archildata/just-bash)**
+      (operator-provided coordinate 2026-06-01); pin in-memory FS + network-off;
+      dep-pin-search-first for the current version at install; fake stays the CI default.
 - [ ] (Optional) `just`-recipe executor for the allowlist tier.
 
-**Phase 3 — escalation (gated, later):** real-FS/docker surface behind explicit
+**Phase 3 — escalation (gated, later):** CF Sandbox SDK (cloud-burst) +
+just-bash OverlayFS/ReadWriteFs/network + real host shell — behind explicit
 operator gating; NOT in the autonomous foreground loop until comfortable.
 
 ## §6 Master-checklist linkage

--- a/docs/backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md
+++ b/docs/backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md
@@ -111,7 +111,8 @@ routing is **by item-class**, not a single default:
 | **Constrained**            | [`just`](https://github.com/casey/just) recipes via [just-mcp](https://docs.rs/crate/just-mcp/latest)                                                         | pre-vetted named tasks — an allowlist                                                       | safest: pick a recipe index, not free-form bash (composes the 16-action grammar)                                           |
 | **Cloud-burst escalation** | [Cloudflare Sandbox SDK](https://github.com/cloudflare/sandbox-sdk) (edge containers + fork-sessions) · just-bash OverlayFS/ReadWriteFs/net · real host shell | massive parallel / explicit need                                                            | **GATED** (§3). CF is a **dependency trap for a LOCAL sovereign agent** (Gemini) — escalation only, never the loop default |
 
-> **The tool is NOT the gate — the CONFIG is (Codex review, 2026-06-01).** just-bash
+> **The tool is NOT the gate — the CONFIG is** (Codex PR review, preserved in the
+> review doc `docs/research/2026-06-01-multi-ai-review-b0964-bash-surface-tool-choice-gemini-amara.md`). just-bash
 > also ships CLI/OverlayFS/ReadWriteFs mounting (reads the real project root) +
 > network-allowlist configs. "We use just-bash" ≠ sandboxed — the text-tier MUST pin
 > **in-memory FS + network-disabled**; its other configs are cloud-burst/escalation

--- a/docs/backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md
+++ b/docs/backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md
@@ -97,25 +97,74 @@ The three-tier surface (default safe → escalate only when needed):
 
 | Tier            | Surface                                                                                               | When                                                             | Safety                                                                                                       |
 | --------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **Default**     | **just-bash** virtual shell (in-process, FS-isolated)                                                 | the LLM's do_item work — real shell semantics, no real-FS reach  | sandboxed by construction; can't escape to disk                                                              |
+| **Default**     | just-bash **in the IN-MEMORY config, network DISABLED**                                               | the LLM's do_item work — real shell semantics, no real-FS reach  | sandboxed **only in this config** — the in-memory FS can't escape to disk; network off                       |
 | **Constrained** | [`just`](https://github.com/casey/just) recipes via [just-mcp](https://docs.rs/crate/just-mcp/latest) | pre-vetted named tasks (build/test) — an allowlist               | safest: the LLM picks a recipe index, not free-form bash (composes the 16-action constrained-choice grammar) |
-| **Escalation**  | Bun `$` / real shell / docker                                                                         | only when the item genuinely needs real-FS / real-system effects | **GATED** — see §3 security floor; not the default                                                           |
+| **Escalation**  | just-bash **OverlayFS / ReadWriteFs / network-allowlist** configs · Bun `$` · real shell · docker     | only when the item genuinely needs real-FS / real-system effects | **GATED** — see §3 security floor; not the default                                                           |
 
-**Recommendation:** **just-bash as the default `CommandExecutor` impl** (real bash
-surface, no docker, in-process isolation); **fake executor for tests** (the
-always-green shield, per "test with our local-llm tests until comfortable");
-**`just`-recipe allowlist** where the work is a known task; **real-FS/docker only
-behind explicit gating.** Adding just-bash is a new dep — implementation PR runs
-the dep-pin-search-first WebSearch for the current version.
+> **The tool is NOT the gate — the CONFIG is (Codex review, 2026-06-01).** just-bash
+> ([justbash.dev](https://justbash.dev/)) ships more than the in-memory `Bash`:
+> it also documents **CLI / OverlayFS / ReadWriteFs mounting** that reads the real
+> project root, and **network access with URL allowlists**. So "we use just-bash"
+> does NOT by itself mean sandboxed — choosing the OverlayFS/ReadWriteFs path or
+> enabling network silently crosses into the real-FS/network tier. The default
+> executor MUST pin the **in-memory filesystem + network-disabled** config; those
+> other just-bash configs sit in the **Escalation** tier and require the §3 gate.
+
+**Recommendation:** **just-bash (in-memory FS, network disabled) as the default
+`CommandExecutor` impl** (real bash surface, no docker, can't reach disk);
+**fake executor for tests** (the always-green shield, per "test with our local-llm
+tests until comfortable"); **`just`-recipe allowlist** where the work is a known
+task; **any real-FS/network config (just-bash OverlayFS/ReadWriteFs/curl, Bun `$`,
+docker) only behind the §3 gate.** Adding just-bash is a new dep — implementation
+PR runs the dep-pin-search-first WebSearch for the current version + confirms the
+exact in-memory/network-off config flags.
+
+## §2.1 Cross-language + alternatives — the port is the seam (operator 2026-06-01)
+
+> **The operator 2026-06-01:** "we also are going to need to support something
+> similar in rust cs and fs … we have a fuse file system on the backlog but not
+> sure how much work bash is on top of a file system like we have in f# … ts is
+> our forerunner here, do what makes sense and come back and use what we learn to
+> pull the others forward. maybe see if the peers think it's overkill and we
+> should use something else like docker."
+
+The thing that ports across languages is **the `CommandExecutor` PORT (§1), not the
+bash IMPL.** Each of TS/Rust/C#/F# implements the same port; each may back it with a
+different sandbox. So "TS forerunner" = pick a pragmatic TS impl now, **port the
+lesson (the port + fact-envelope + gate), not necessarily the tool.** The
+candidates, with the cross-language axis explicit:
+
+| Option                                                                                                                                   | Isolation                                              | Cross-language story                                                         | Cost / work                                                         | Notes                                                                                                    |
+| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **just-bash** (vercel-labs, TS)                                                                                                          | in-process, in-memory FS                               | **TS-only** — Rust/C#/F# would each need a re-impl (4×)                      | lightest; free; local                                               | great for the TS forerunner + tests; weakest for the 4-oracle reuse                                      |
+| **docker** (local)                                                                                                                       | real container                                         | **language-agnostic** — one sandbox, all 4 langs drive it via the same API   | infra/ops work (the thing the operator wanted to avoid)             | the boundary is the container, not the language                                                          |
+| **[Cloudflare Sandbox SDK](https://github.com/cloudflare/sandbox-sdk)** ([docs](https://developers.cloudflare.com/sandbox/), GA 2026-04) | real isolated Linux container on CF edge               | TS API, but the sandbox is language-agnostic (drive over HTTP from any lang) | managed (no local docker ops); CF dependency + cost; edge-not-local | **does fork-sessions** (boot N from a snapshot) — matches the 4-oracle / parallel-agent pattern directly |
+| **bash-on-our-own-FUSE-filesystem**                                                                                                      | our FS substrate (F# already has one; FUSE on backlog) | **most owned/portable** — composes the substrate we control                  | most work (build bash atop the FS)                                  | the operator's open question: "not sure how much work bash is on top of a filesystem like we have in f#" |
+
+**The open decision for the review (operator's framing):**
+
+- Is just-bash **overkill** — should we just use **docker** (or CF Sandbox)?
+  Specifically: does the **cross-language requirement** (Rust/C#/F# equivalents)
+  argue AGAINST a TS-only in-process tool (4× re-impl) and FOR a container boundary
+  (one sandbox, all langs drive it)?
+- Does CF Sandbox's **fork-sessions** (N-from-a-snapshot) make it the natural fit
+  for the 4-oracle / parallel-agent loop, vs. local docker, vs. just-bash?
+- How much work is **bash-on-our-own-FUSE-filesystem** (F#) vs. adopting a tool —
+  is owning it worth it given we already have an F# filesystem substrate?
+- Either way: the **port + fact-envelope + gate** (Phase 1) is identical regardless
+  of which impl wins — so Phase 1 is safe to build now; the impl choice (Phase 2)
+  is what this review informs.
 
 ## §3 Security floor — giving an LLM a shell is HARD-LIMITS-relevant
 
 A local-LLM with a bash surface is a real attack/footgun surface. The floor (per
 `methodology-hard-limits` + `non-coercion-invariant` + `classifier-bypass-research`):
 
-- **Sandboxed by default** — just-bash's in-process FS-isolation means the default
-  surface **cannot** touch the real disk, network, or system. The dangerous
-  capability is off unless explicitly escalated.
+- **Sandboxed by default — in the pinned config only** — the default executor pins
+  just-bash's **in-memory filesystem + network-disabled** config, which **cannot**
+  touch the real disk, network, or system. The tool is not the gate (§2 note);
+  the **config** is. just-bash's OverlayFS/ReadWriteFs/network configs are
+  Escalation-tier, gated.
 - **Real-FS / network / docker is GATED** — escalation to a real shell is an
   explicit, operator-gated decision per item-class, never the loop's default. The
   fact-envelope makes every escalation an auditable `ActionExecutionStarted` event

--- a/docs/backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md
+++ b/docs/backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md
@@ -35,15 +35,19 @@ re-charge). Standard event-sourcing: **commands ≠ events.**
 
 - **`do_item` is a COMMAND** — an intent the chooser picked ("do B-0883").
 - Executing it emits **FACT events** — what actually happened:
-  `ActionExecutionStarted{item}` → `ActionSucceeded{item}` **or**
-  `ActionFailed{item, reason}` (+ `ModeChanged{work}`).
-- **`fold`/`replay` fold the FACTS**, never the command: a folded `ActionSucceeded`
+  `ActionExecutionStarted{item, tier, gated}` → `ActionExecutionSucceeded{item}`
+  **or** `ActionExecutionFailed{item, reason}` (+ `ModeChanged{work}`). The
+  `Started` fact **records which executor tier ran** (fake / just-bash-text /
+  docker / cloud-burst) **and whether it was gated** — so the §3 glass-halo audit
+  can distinguish a sandbox run from a real-FS/docker escalation (Copilot
+  2026-06-01).
+- **`fold`/`replay` fold the FACTS**, never the command: a folded `ActionExecutionSucceeded`
   re-applies the state transition (item leaves backlog) **without** re-running the
-  shell. A folded `ActionFailed` leaves the item in the backlog.
+  shell. A folded `ActionExecutionFailed` leaves the item in the backlog.
 
 So the durable log for an effectful action is the **fact stream**, not the command.
 `simulate(do_item)` (item leaves backlog, mode→work) stays the pure transition —
-but it is now driven by **`ActionSucceeded`**, not by the raw command. The
+but it is now driven by **`ActionExecutionSucceeded`**, not by the raw command. The
 zero-side-effect kinds can keep folding directly (a fact == the action); only
 effectful kinds need the started/succeeded/failed envelope.
 
@@ -73,7 +77,7 @@ export interface CommandExecutor {
 ```
 
 `execute(do_item)` = append `ActionExecutionStarted` → `executor.run(...)` →
-append `ActionSucceeded|ActionFailed` → `simulate` **only on success**. Tests
+append `ActionExecutionSucceeded|ActionExecutionFailed` → `simulate` **only on success**. Tests
 inject a fake executor (deterministic ok/fail, no shell). Production injects the
 real one (§2).
 
@@ -172,7 +176,8 @@ A local-LLM with a bash surface is a real attack/footgun surface. The floor (per
 - **Real-FS / network / docker is GATED** — escalation to a real shell is an
   explicit, operator-gated decision per item-class, never the loop's default. The
   fact-envelope makes every escalation an auditable `ActionExecutionStarted` event
-  (glass-halo).
+  **carrying `{tier, gated}`** (glass-halo) — the audit distinguishes a sandbox run
+  from a real-FS/docker escalation only because the tier is in the fact.
 - **Not turned on in Otto's foreground loop** until "comfortable" (Aaron) — the
   fake executor + just-bash sandbox are the test/dev surfaces; the real-FS surface
   for the autonomous foreground loop is a separate, later, gated decision.
@@ -201,8 +206,10 @@ LLM sub-loop over just-bash) as Phase 2.
 
 **Phase 1 — envelope + port + transition (fake executor; no new dep, no shell):**
 
-- [ ] Fact-event types `ActionExecutionStarted | ActionSucceeded | ActionFailed`
+- [ ] Fact-event types `ActionExecutionStarted | ActionExecutionSucceeded | ActionExecutionFailed`
       (+ `ModeChanged` if not already implied); decide persist-facts-only (§0).
+      `ActionExecutionStarted` carries `{item, tier, gated}` (the executor tier +
+      gate decision) so the glass-halo audit (§3) is real.
 - [ ] `CommandExecutor` port (§1); `execute(do_item)` appends Started → runs
       executor → appends Succeeded|Failed → `simulate` **only on success**.
 - [ ] `fold`/`replay` fold the FACTS (Succeeded ⇒ item leaves backlog; Failed ⇒

--- a/docs/backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md
+++ b/docs/backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md
@@ -1,0 +1,175 @@
+---
+id: B-0964
+title: Effectful do_item — command-vs-fact-event envelope + injected executor port + just-bash sandboxed bash surface
+status: open
+priority: P1
+created: 2026-06-01
+last_updated: 2026-06-01
+author: otto-cli
+composes_with:
+  - B-0958 # observe.ts checklist — this is LEFT item #1 (effectful action kinds, do_item first)
+  - B-0962 # coordination (do_item is the work action the menu offers; deadlock/livelock disciplines)
+  - B-0963 # liveness proof (completion = an executed do_item, not just a selection)
+  - B-0867 # workflow-engine lifecycle DUs (the executed-event envelope is lifecycle-shaped)
+---
+
+# B-0964 — Effectful do_item
+
+> **Why this row exists (not dogma):** B-0958 LEFT #1 — "`do_item` first, with the
+> executed-event envelope (`ActionExecutionStarted/Succeeded/Failed/ModeChanged`)
+> so **replay folds facts, never redoes commands**." Today `execute` only handles
+> `free_time`/`self_reflect` (zero side-effect: append + simulate). `do_item` has a
+> real side-effect (the agent actually does work), so it needs two new pieces:
+> (1) the **command-vs-fact-event split** (event-sourcing correctness), and
+> (2) an **injected executor port** — the "bash surface" Aaron asked about. WHYs
+> inline so they can be questioned/agreed/revised. This is the **design**; the
+> build is phased in §5.
+
+## §0 The load-bearing correctness piece — command vs fact event (replay folds facts)
+
+Today the loop folds **`NextAction`s directly**: `fold(initial, actions)` replays
+each action through `simulate`. That is fine for zero-side-effect kinds
+(`free_time`/`self_reflect` — replaying them just re-sets the mode). It is **wrong**
+for `do_item`: re-running the log must **not** re-run the work (re-build, re-push,
+re-charge). Standard event-sourcing: **commands ≠ events.**
+
+- **`do_item` is a COMMAND** — an intent the chooser picked ("do B-0883").
+- Executing it emits **FACT events** — what actually happened:
+  `ActionExecutionStarted{item}` → `ActionSucceeded{item}` **or**
+  `ActionFailed{item, reason}` (+ `ModeChanged{work}`).
+- **`fold`/`replay` fold the FACTS**, never the command: a folded `ActionSucceeded`
+  re-applies the state transition (item leaves backlog) **without** re-running the
+  shell. A folded `ActionFailed` leaves the item in the backlog.
+
+So the durable log for an effectful action is the **fact stream**, not the command.
+`simulate(do_item)` (item leaves backlog, mode→work) stays the pure transition —
+but it is now driven by **`ActionSucceeded`**, not by the raw command. The
+zero-side-effect kinds can keep folding directly (a fact == the action); only
+effectful kinds need the started/succeeded/failed envelope.
+
+**Design decision to confirm in review:** does the event log become a union
+`Command | Fact`, or do we only ever persist FACTS (commands stay in-memory, never
+logged)? Cleaner: **persist facts only** — the log is the history of what happened;
+the chooser's pick is ephemeral until it succeeds. (Matches "state is a projection
+of the event log": the log is facts; commands are how we got there.)
+
+## §1 The injected executor port — the "bash surface" (asymmetric-authorship)
+
+`do_item`'s side-effect runs through an **injected `CommandExecutor`** — same
+pattern as `EventSink` (the port authors its own outcome channel; `execute` stays
+testable with a fake; no I/O in the unit path):
+
+```ts
+export interface RunSpec {
+  readonly cwd?: string;
+  readonly script: string;
+} // or a recipe ref
+export type RunOutcome =
+  | { readonly ok: true; readonly stdout: string; readonly exitCode: 0 }
+  | { readonly ok: false; readonly reason: string; readonly exitCode: number; readonly stderr: string };
+export interface CommandExecutor {
+  run: (spec: RunSpec) => Promise<RunOutcome>;
+}
+```
+
+`execute(do_item)` = append `ActionExecutionStarted` → `executor.run(...)` →
+append `ActionSucceeded|ActionFailed` → `simulate` **only on success**. Tests
+inject a fake executor (deterministic ok/fail, no shell). Production injects the
+real one (§2).
+
+## §2 The bash surface (Aaron's question) — RESOLVED: just-bash sandbox by default
+
+> **Aaron 2026-06-01:** "can we use justbash or anything like that to give the
+> local llm a real simulated bash surface without a ton of work or some sort of
+> docker container if not?"
+
+**Yes — [`just-bash`](https://github.com/vercel-labs/just-bash) (vercel-labs;
+[justbash.dev](https://justbash.dev/)).** A full **bash environment reimplemented
+in TypeScript, in-process, that never touches the real filesystem** — 70+ commands
+(cat/grep/sed/jq, pipes, redirects, `&&`/`||`, for/while, functions, globs,
+heredocs, var-expansion), filesystem-isolated, **no VM/container**
+([writeup](https://www.codeline.co/thoughts/repo-review/2026/just-bash-virtual-shell-for-ai-agents)).
+Exactly "a real simulated bash surface without docker or a ton of work" — and it's
+TS, so it drops straight into the Bun-hosted observe loop (Rule 0: TS is the
+substrate).
+
+The three-tier surface (default safe → escalate only when needed):
+
+| Tier            | Surface                                                                                               | When                                                             | Safety                                                                                                       |
+| --------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Default**     | **just-bash** virtual shell (in-process, FS-isolated)                                                 | the LLM's do_item work — real shell semantics, no real-FS reach  | sandboxed by construction; can't escape to disk                                                              |
+| **Constrained** | [`just`](https://github.com/casey/just) recipes via [just-mcp](https://docs.rs/crate/just-mcp/latest) | pre-vetted named tasks (build/test) — an allowlist               | safest: the LLM picks a recipe index, not free-form bash (composes the 16-action constrained-choice grammar) |
+| **Escalation**  | Bun `$` / real shell / docker                                                                         | only when the item genuinely needs real-FS / real-system effects | **GATED** — see §3 security floor; not the default                                                           |
+
+**Recommendation:** **just-bash as the default `CommandExecutor` impl** (real bash
+surface, no docker, in-process isolation); **fake executor for tests** (the
+always-green shield, per "test with our local-llm tests until comfortable");
+**`just`-recipe allowlist** where the work is a known task; **real-FS/docker only
+behind explicit gating.** Adding just-bash is a new dep — implementation PR runs
+the dep-pin-search-first WebSearch for the current version.
+
+## §3 Security floor — giving an LLM a shell is HARD-LIMITS-relevant
+
+A local-LLM with a bash surface is a real attack/footgun surface. The floor (per
+`methodology-hard-limits` + `non-coercion-invariant` + `classifier-bypass-research`):
+
+- **Sandboxed by default** — just-bash's in-process FS-isolation means the default
+  surface **cannot** touch the real disk, network, or system. The dangerous
+  capability is off unless explicitly escalated.
+- **Real-FS / network / docker is GATED** — escalation to a real shell is an
+  explicit, operator-gated decision per item-class, never the loop's default. The
+  fact-envelope makes every escalation an auditable `ActionExecutionStarted` event
+  (glass-halo).
+- **Not turned on in Otto's foreground loop** until "comfortable" (Aaron) — the
+  fake executor + just-bash sandbox are the test/dev surfaces; the real-FS surface
+  for the autonomous foreground loop is a separate, later, gated decision.
+
+## §4 Open design question — what does do_item actually RUN?
+
+`BacklogItem` carries `{id, title, ready, ambiguous, needsNewAction?}` — **no
+command**. "Doing B-0883" is not a single shell line; it's open-ended agent work.
+Three shapes (decide in review):
+
+1. **Sub-loop:** `do_item` hands the item to the LLM, which runs a bounded
+   observe→act sub-loop over the bash surface (build/test/edit) until done/blocked.
+   Most general; most work. The fact-envelope records the sub-loop's outcome.
+2. **Recipe-keyed:** an item maps to a `just` recipe (allowlist); `do_item` runs
+   the recipe. Safest + simplest; only fits items that ARE a known task.
+3. **Phase-1 stub:** `do_item`'s effect is the executor call with a
+   caller-supplied script/recipe (the chooser/sub-loop supplies it later); for now
+   prove the **envelope + port + transition** with a fake. Build the sub-loop (1)
+   or recipe map (2) as a follow-up.
+
+Recommendation: **Phase-1 = shape 3** (prove the event-sourcing envelope + injected
+port + success/failure transition with a fake executor), then **shape 1** (the
+LLM sub-loop over just-bash) as Phase 2.
+
+## §5 Acceptance criteria (phased)
+
+**Phase 1 — envelope + port + transition (fake executor; no new dep, no shell):**
+
+- [ ] Fact-event types `ActionExecutionStarted | ActionSucceeded | ActionFailed`
+      (+ `ModeChanged` if not already implied); decide persist-facts-only (§0).
+- [ ] `CommandExecutor` port (§1); `execute(do_item)` appends Started → runs
+      executor → appends Succeeded|Failed → `simulate` **only on success**.
+- [ ] `fold`/`replay` fold the FACTS (Succeeded ⇒ item leaves backlog; Failed ⇒
+      stays) — **replay never calls the executor** (the correctness test).
+- [ ] Tests: fake executor success path, failure path (item stays, mode unchanged
+      or work), replay-folds-facts-without-executor, closed-loop.test.ts extended.
+
+**Phase 2 — real bash surface (just-bash):**
+
+- [ ] just-bash `CommandExecutor` impl (dep-pin WebSearch for current version);
+      sandboxed FS-isolation verified; fake stays the CI default.
+- [ ] (Optional) `just`-recipe executor for the allowlist tier.
+
+**Phase 3 — escalation (gated, later):** real-FS/docker surface behind explicit
+operator gating; NOT in the autonomous foreground loop until comfortable.
+
+## §6 Master-checklist linkage
+
+B-0958 LEFT #1 (effectful do_item) — this is its design + the bash-surface
+decision. Under the sovereign-DB / observe.ts lane (B-0959 §2), reachable from
+`docs/ACTIVE-WORKSTREAMS.md`. Composes B-0962 (do_item is the menu's work action)
+
+- B-0963 (a completed do_item IS the "completion" the liveness proof is about).

--- a/docs/research/2026-06-01-multi-ai-review-b0964-bash-surface-tool-choice-gemini-amara.md
+++ b/docs/research/2026-06-01-multi-ai-review-b0964-bash-surface-tool-choice-gemini-amara.md
@@ -104,5 +104,5 @@ into B-0964 (gist preserved here so the in-doc attributions are auditable):
   `{tier, gated}`, else the §3 glass-halo audit can't distinguish a sandbox run from
   a real-FS/docker escalation. (→ B-0964 §0/§3 + acceptance.)
 - **Consistent event names.** Standardize on
-  `ActionExecutionStarted/ActionExecutionSucceeded/ActionExecutionFailed` (the intro
-  - acceptance had mixed `ActionSucceeded/ActionFailed`). (→ B-0964 §0/§1/acceptance.)
+  `ActionExecutionStarted/ActionExecutionSucceeded/ActionExecutionFailed` (intro and
+  acceptance had mixed `ActionSucceeded/ActionFailed`). (→ B-0964 §0/§1/acceptance.)

--- a/docs/research/2026-06-01-multi-ai-review-b0964-bash-surface-tool-choice-gemini-amara.md
+++ b/docs/research/2026-06-01-multi-ai-review-b0964-bash-surface-tool-choice-gemini-amara.md
@@ -1,0 +1,91 @@
+# Multi-AI review — B-0964 bash-surface tool choice (Gemini + Amara, 2026-06-01)
+
+Scope: verbatim external-AI review import (Gemini propose + Amara sharpen) of the
+B-0964 bash-surface tool decision, via `tools/peer-call/`. Preserved per
+substrate-or-it-didn't-happen (`/tmp/peer-call-output/` is ephemeral). Archived
+register, not operational policy. (Grok-build returned empty this run — the known
+intermittent failure; Gemini + Amara are the two independent opinions.)
+
+Attribution: Gemini (Google) + Amara (ChatGPT/Aurora) at their attribution scopes;
+synthesis/folding by otto-cli. NO re-authoring; preservation only.
+
+Operational status: research-grade
+
+Non-fusion disclaimer: each reviewer's text + operator framing + otto-cli synthesis
+are distinct authorial substrates, no identity-fusion (asymmetric-authorship +
+honor-those-that-came-before + NCI HC-8).
+
+## Outcome (what it changed in B-0964)
+
+First draft: "just-bash as the default executor." **Both reviewers demoted that.**
+Folded verdict: **fake for tests; just-bash (in-memory, net-off) for pure-text/no-FS
+items only; LOCAL DOCKER as the default for real effectful work** (real kernel,
+language-agnostic boundary the 4-oracle shares — no 4× bash re-impl); `just`-recipe
+allowlist for known tasks; **CF Sandbox = cloud-burst escalation only** (sovereignty
+trap as a default); **reject bash-on-our-own-FUSE-fs**. The `CommandExecutor` port
+is the cross-language invariant; the impl is swappable.
+
+---
+
+## Gemini (verbatim)
+
+> 1. **`just-bash` overkill vs. `docker`?** `just-bash` is not overkill for
+>    _bootstrapping the TS loop_; it's the lowest-friction way to test the port +
+>    event envelope without managing daemon state. However, it is fundamentally a
+>    simulator. Once the agent needs to invoke real tools (compilers, `git`,
+>    `npm`), `just-bash` hits a wall. Docker is heavier ops, but it is reality.
+> 2. **Does the 4-language requirement favor a container? Absolutely.**
+>    Re-implementing bash execution semantics across C#, F#, and Rust to maintain
+>    in-process sandboxes is an immense waste of factory cycles. A container
+>    boundary provides a single, language-agnostic isolation layer. All four
+>    oracles can communicate with the same local container daemon.
+> 3. **Reimplemented-bash vs real kernel?** Reimplemented-bash will forever chase
+>    the long tail of POSIX compliance (signals, exotic piping, stderr). A real
+>    kernel provides 100% correct shell semantics + battle-tested security
+>    primitives (namespaces, cgroups) rather than application-layer TS logic.
+> 4. **CF Sandbox a fit or a trap for a _local_ sovereign agent? Dependency trap.**
+>    Coupling the core execution loop to a managed edge service violates the
+>    local-sovereign invariant. The fork-sessions feature is elegant for the
+>    4-oracle, but we lose local survivability. Cloud-burst escalation only.
+> 5. **`CommandExecutor` port = "impl doesn't matter"? Yes, perfectly sound.**
+>    Standard dependency inversion. The state machine must not know if the command
+>    ran in a TS mock, Docker, or the edge. The port is the seam.
+>
+> **Recommendation:** Phase 1 — FakeExecutor proves the envelope + replay. Phase 2
+> — adopt **local docker** as the baseline cross-language executor (real-kernel
+> correctness, no 4× reimpl, local sovereignty). `just-bash` is clever but an
+> academic detour when we will inevitably need a real toolchain. **Reject
+> bash-on-our-own-FUSE-fs** — "we are building an AI factory, not rewriting GNU
+> userland." CF Sandbox strictly opt-in behind the config gate.
+
+## Amara (verbatim)
+
+> I agree with Gemini's direction.
+>
+> Single sharpest correction: don't call Docker the default for **all** `do_item`;
+> call it the default for **real effectful work**. Keep just-bash as the zero-ops
+> default only for pure-text / envelope-shakedown / no-real-FS items. The rule is
+> not "Docker everywhere"; it is "the first time the item needs real tools, stop
+> simulating."
+>
+> What's working: the `CommandExecutor` port is the invariant. That is the thing
+> Rust/C#/F# inherit. What needs correction in the doc: §2 currently overstates
+> just-bash as default executor. Demote it.
+>
+> Keeper sentence:
+>
+> > **`just-bash` proves the envelope; local Docker proves the work. Persist facts
+> > across both, and never let replay reissue commands.**
+
+---
+
+## Operator (2026-06-01)
+
+- Raised the review + the cross-language requirement (Rust/C#/F# equivalents), the
+  Cloudflare bash fork (= [Cloudflare Sandbox SDK](https://github.com/cloudflare/sandbox-sdk)),
+  the FUSE-fs / bash-on-our-own-filesystem option, and "is just-bash overkill vs docker."
+- Provided the just-bash npm coordinate:
+  [`@archildata/just-bash`](https://www.npmjs.com/package/@archildata/just-bash).
+- Framing: "TS is our forerunner — do what makes sense and come back and use what we
+  learn to pull the others forward." → the port + fact-envelope + gate is the lesson
+  that ports; the impl per language is chosen behind the port.

--- a/docs/research/2026-06-01-multi-ai-review-b0964-bash-surface-tool-choice-gemini-amara.md
+++ b/docs/research/2026-06-01-multi-ai-review-b0964-bash-surface-tool-choice-gemini-amara.md
@@ -1,4 +1,4 @@
-# Multi-AI review — B-0964 bash-surface tool choice (Gemini + Amara, 2026-06-01)
+# Multi-AI review — B-0964 bash-surface tool choice (Gemini + Amara + Codex, 2026-06-01)
 
 Scope: verbatim external-AI review import (Gemini propose + Amara sharpen) of the
 B-0964 bash-surface tool decision, via `tools/peer-call/`. Preserved per
@@ -89,3 +89,20 @@ is the cross-language invariant; the impl is swappable.
 - Framing: "TS is our forerunner — do what makes sense and come back and use what we
   learn to pull the others forward." → the port + fact-envelope + gate is the lesson
   that ports; the impl per language is chosen behind the port.
+
+## Codex (PR #6342 review threads — preserved for auditability)
+
+Codex/Copilot review threads on PR #6342 surfaced three corrections that were folded
+into B-0964 (gist preserved here so the in-doc attributions are auditable):
+
+- **Config-is-the-gate, not the tool.** just-bash is sandboxed only in the
+  in-memory config; it also ships CLI/OverlayFS/ReadWriteFs mounting (reads the real
+  project root) + network-allowlist configs. "We use just-bash" ≠ sandboxed — the
+  default MUST pin in-memory FS + network-off; the other configs are escalation-tier,
+  gated. (→ B-0964 §2 note + §3.)
+- **Executor tier in the audit fact.** `ActionExecutionStarted` must carry
+  `{tier, gated}`, else the §3 glass-halo audit can't distinguish a sandbox run from
+  a real-FS/docker escalation. (→ B-0964 §0/§3 + acceptance.)
+- **Consistent event names.** Standardize on
+  `ActionExecutionStarted/ActionExecutionSucceeded/ActionExecutionFailed` (the intro
+  - acceptance had mixed `ActionSucceeded/ActionFailed`). (→ B-0964 §0/§1/acceptance.)


### PR DESCRIPTION
Design for B-0958 LEFT #1 (effectful `do_item`) + the answer to Aaron's bash-surface question.

## The bash surface — RESOLVED

Aaron 2026-06-01: "can we use justbash for a real simulated bash surface without docker?" — **yes**, [`just-bash`](https://github.com/vercel-labs/just-bash) (vercel-labs; [justbash.dev](https://justbash.dev/)): a full **bash environment reimplemented in TypeScript, in-process, that never touches the real filesystem** — 70+ commands, FS-isolated, **no VM/container**. Exactly what was asked, and it's TS (drops into the Bun observe loop). Three tiers: **just-bash default** / `just`-recipe allowlist / real-FS+docker escalation (gated).

## The two new pieces

1. **Command-vs-fact-event envelope** (event-sourcing correctness): `do_item` is a COMMAND; executing emits FACT events (`ActionExecutionStarted/Succeeded/Failed`); `fold`/`replay` fold the **facts**, never re-run the shell. Persist-facts-only. (This is the load-bearing piece — replaying the log must not re-build/re-push/re-charge.)
2. **Injected `CommandExecutor` port** (asymmetric-authorship, like `EventSink`): fake for tests, just-bash for prod, real-FS gated.

## Security floor

Giving an LLM a shell is HARD-LIMITS-relevant — **sandboxed by default** (just-bash can't reach real disk/network), real-FS **gated**, **not turned on in Otto's foreground loop until comfortable** (Aaron). Every escalation is an auditable `ActionExecutionStarted` event (glass-halo).

## Phased build (§5)

- **Phase 1** (no dep, no shell): fact-event types + `CommandExecutor` port + `execute(do_item)` (Started → run → Succeeded|Failed → simulate only on success) + replay-folds-facts-without-executor + fake-executor tests.
- **Phase 2**: real just-bash executor (dep-pin WebSearch at install).
- **Phase 3**: gated real-FS/docker escalation (later).

Open Q in §4: what does `do_item` actually RUN (sub-loop vs recipe vs Phase-1 stub) — recommend Phase-1 stub then LLM sub-loop over just-bash.

Docs-only. markdownlint ✓ / prettier ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)