### PR TITLE
feat(observe B-0964): Phase-1 effectful do_item — fact envelope + executor port + replay-folds-facts

### DIFF
--- a/tools/observe/do-item.test.ts
+++ b/tools/observe/do-item.test.ts
@@ -1,0 +1,139 @@
+/**
+ * tools/observe/do-item.test.ts — Phase-1 acceptance for effectful do_item (B-0964).
+ *
+ * Proves: the fact envelope (Started→Succeeded|Failed), the injected executor port
+ * (fake — no shell), the success/failure transitions, the audit tier in the
+ * Started fact, applyFact-delegates-to-simulate (single reducer), and the
+ * load-bearing correctness guarantee — **replay folds facts without an executor**
+ * (foldFacts has no executor param, so re-running the log cannot re-run the work).
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { simulate, type BacklogItem, type World } from "./observe";
+import type { ActionFact, RunOutcome } from "./do-item";
+import { applyFact, executeDoItem, fakeExecutor, foldFacts, type CommandExecutor } from "./do-item";
+import type { AppendOutcome, EventSink } from "./execute";
+
+const item = (id: string): BacklogItem => ({ id, title: id, ready: true, ambiguous: false });
+const w = (backlog: BacklogItem[]): World => ({ backlog });
+
+/** Fake fact-sink: records appends; never touches git. */
+function fakeFactSink(): EventSink<ActionFact> & { appended: ActionFact[] } {
+  const appended: ActionFact[] = [];
+  return {
+    appended,
+    append: (event: ActionFact): Promise<AppendOutcome> => {
+      appended.push(event);
+      return Promise.resolve({ ok: true, eventId: `evt-${String(appended.length)}` });
+    },
+  };
+}
+/** Fact-sink that fails the Nth append (1-based) — for durability-failure tests. */
+function failingFactSink(failOn: number): EventSink<ActionFact> & { appended: ActionFact[]; calls: number } {
+  const appended: ActionFact[] = [];
+  const sink = {
+    appended,
+    calls: 0,
+    append: (event: ActionFact): Promise<AppendOutcome> => {
+      sink.calls += 1;
+      if (sink.calls === failOn) return Promise.resolve({ ok: false, reason: "remote ahead" });
+      appended.push(event);
+      return Promise.resolve({ ok: true, eventId: `evt-${String(sink.calls)}` });
+    },
+  };
+  return sink;
+}
+
+const okRun: RunOutcome = { ok: true, stdout: "built", exitCode: 0 };
+const failRun: RunOutcome = { ok: false, reason: "build failed", exitCode: 1, stderr: "error" };
+const opts = { spec: { script: "noop" }, gated: false };
+
+describe("executeDoItem — the fact envelope", () => {
+  it("success: Started→Succeeded logged, item leaves backlog, completed=true", async () => {
+    const world = w([item("B-1"), item("B-2")]);
+    const sink = fakeFactSink();
+    const r = await executeDoItem(world, item("B-1"), sink, fakeExecutor(okRun), opts);
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.completed).toBe(true);
+    expect(r.world.backlog.map((i) => i.id)).toEqual(["B-2"]); // B-1 done, gone
+    expect(r.world.mode).toBe("work");
+    expect(sink.appended.map((f) => f.kind)).toEqual(["ActionExecutionStarted", "ActionExecutionSucceeded"]);
+  });
+
+  it("failure: Started→Failed logged, item STAYS, completed=false, reason carried", async () => {
+    const world = w([item("B-1")]);
+    const sink = fakeFactSink();
+    const r = await executeDoItem(world, item("B-1"), sink, fakeExecutor(failRun), opts);
+
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.completed) return;
+    expect(r.world.backlog.map((i) => i.id)).toEqual(["B-1"]); // still there — work failed
+    expect(r.reason).toBe("build failed");
+    expect(sink.appended.map((f) => f.kind)).toEqual(["ActionExecutionStarted", "ActionExecutionFailed"]);
+  });
+
+  it("the Started fact records the executor TIER + gated (the §3 glass-halo audit)", async () => {
+    const sink = fakeFactSink();
+    const dockerish: CommandExecutor = { tier: "docker", run: () => Promise.resolve(okRun) };
+    await executeDoItem(w([item("B-1")]), item("B-1"), sink, dockerish, { spec: { script: "x" }, gated: true });
+
+    const started = sink.appended[0];
+    expect(started?.kind).toBe("ActionExecutionStarted");
+    if (started?.kind !== "ActionExecutionStarted") return;
+    expect(started.tier).toBe("docker");
+    expect(started.gated).toBe(true);
+  });
+
+  it("durability failure on Started: no executor run, no transition, ok=false", async () => {
+    const world = w([item("B-1")]);
+    const sink = failingFactSink(1); // first append (Started) fails
+    let ran = false;
+    const watchExecutor: CommandExecutor = {
+      tier: "fake",
+      run: () => {
+        ran = true;
+        return Promise.resolve(okRun);
+      },
+    };
+
+    const r = await executeDoItem(world, item("B-1"), sink, watchExecutor, opts);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.feedback.kind).toBe("append-failed");
+    expect(ran).toBe(false); // executor never ran — append-first
+    expect(sink.appended).toHaveLength(0);
+  });
+});
+
+describe("foldFacts — replay folds FACTS, never re-runs (B-0964 §0 correctness)", () => {
+  it("replaying [Started, Succeeded] reconstructs the executed world — with NO executor", async () => {
+    const world = w([item("B-1"), item("B-2")]);
+    const sink = fakeFactSink();
+    const r = await executeDoItem(world, item("B-1"), sink, fakeExecutor(okRun), opts);
+    if (!r.ok) throw new Error("expected ok");
+
+    // foldFacts takes only (initial, facts) — structurally cannot call an executor.
+    const replayed = foldFacts(world, sink.appended);
+    expect(replayed).toEqual(r.world); // the log reconstructs the executed state
+    expect(replayed.backlog.map((i) => i.id)).toEqual(["B-2"]);
+  });
+
+  it("replaying a failed run leaves the item in the backlog", () => {
+    const world = w([item("B-1")]);
+    const facts: ActionFact[] = [
+      { kind: "ActionExecutionStarted", item: item("B-1"), tier: "fake", gated: false },
+      { kind: "ActionExecutionFailed", item: item("B-1"), reason: "x" },
+    ];
+    expect(foldFacts(world, facts).backlog.map((i) => i.id)).toEqual(["B-1"]);
+  });
+
+  it("applyFact(Succeeded) is IDENTICAL to simulate(do_item) — the single reducer, no drift", () => {
+    const world = w([item("B-1"), item("B-2")]);
+    const viaFact = applyFact(world, { kind: "ActionExecutionSucceeded", item: item("B-1") });
+    const viaSimulate = simulate(world, { kind: "do_item", item: item("B-1") });
+    expect(viaFact).toEqual(viaSimulate);
+  });
+});

--- a/tools/observe/do-item.test.ts
+++ b/tools/observe/do-item.test.ts
@@ -106,6 +106,28 @@ describe("executeDoItem — the fact envelope", () => {
     expect(ran).toBe(false); // executor never ran — append-first
     expect(sink.appended).toHaveLength(0);
   });
+
+  it("terminal-append failure (executor RAN): reconcile-needed feedback, not blind-retryable (Copilot 2026-06-01)", async () => {
+    const world = w([item("B-1")]);
+    const sink = failingFactSink(2); // Started lands; the terminal Succeeded append fails
+    let ran = false;
+    const watchExecutor: CommandExecutor = {
+      tier: "fake",
+      run: () => {
+        ran = true;
+        return Promise.resolve(okRun);
+      },
+    };
+
+    const r = await executeDoItem(world, item("B-1"), sink, watchExecutor, opts);
+    expect(ran).toBe(true); // the side-effect DID happen
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.feedback.kind).toBe("terminal-append-failed"); // distinct from append-failed — do NOT blind-retry
+    if (r.feedback.kind !== "terminal-append-failed") return;
+    expect(r.feedback.ranOutcome).toBe("succeeded");
+    expect(r.feedback.durableFacts.map((f) => f.kind)).toEqual(["ActionExecutionStarted"]); // only Started is durable
+  });
 });
 
 describe("foldFacts — replay folds FACTS, never re-runs (B-0964 §0 correctness)", () => {

--- a/tools/observe/do-item.test.ts
+++ b/tools/observe/do-item.test.ts
@@ -107,7 +107,7 @@ describe("executeDoItem — the fact envelope", () => {
     expect(sink.appended).toHaveLength(0);
   });
 
-  it("terminal-append failure (executor RAN): reconcile-needed feedback, not blind-retryable (Copilot 2026-06-01)", async () => {
+  it("terminal-append failure (executor RAN): reconcile-needed feedback, not blind-retryable (PR review 2026-06-01)", async () => {
     const world = w([item("B-1")]);
     const sink = failingFactSink(2); // Started lands; the terminal Succeeded append fails
     let ran = false;
@@ -127,6 +127,41 @@ describe("executeDoItem — the fact envelope", () => {
     if (r.feedback.kind !== "terminal-append-failed") return;
     expect(r.feedback.ranOutcome).toBe("succeeded");
     expect(r.feedback.durableFacts.map((f) => f.kind)).toEqual(["ActionExecutionStarted"]); // only Started is durable
+  });
+
+  it("executor THROWS/rejects: converted to ActionExecutionFailed, never an unhandled rejection (PR review 2026-06-01)", async () => {
+    const world = w([item("B-1")]);
+    const sink = fakeFactSink();
+    const throwingExecutor: CommandExecutor = {
+      tier: "fake",
+      run: () => Promise.reject(new Error("spawn ENOENT")),
+    };
+
+    const r = await executeDoItem(world, item("B-1"), sink, throwingExecutor, opts);
+    // a throw must still produce a clean terminal fact (Started→Failed), not crash
+    expect(r.ok).toBe(true); // machinery worked: both facts landed
+    if (!r.ok) return;
+    expect(r.completed).toBe(false); // the WORK failed
+    expect(sink.appended.map((f) => f.kind)).toEqual(["ActionExecutionStarted", "ActionExecutionFailed"]);
+    const failed = sink.appended[1];
+    if (failed?.kind !== "ActionExecutionFailed") return;
+    expect(failed.reason).toContain("executor threw"); // the throw is captured in the fact's reason
+    expect(failed.reason).toContain("spawn ENOENT");
+    expect(world.backlog.some((b) => b.id === "B-1")).toBe(true); // failed work leaves the item in the backlog
+  });
+
+  it("terminal-append failure on a FAILED run preserves the executor reason via ranReason (PR review 2026-06-01)", async () => {
+    const world = w([item("B-1")]);
+    const sink = failingFactSink(2); // Started lands; the terminal Failed append fails
+    const r = await executeDoItem(world, item("B-1"), sink, fakeExecutor(failRun), opts);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.feedback.kind).toBe("terminal-append-failed");
+    if (r.feedback.kind !== "terminal-append-failed") return;
+    expect(r.feedback.ranOutcome).toBe("failed");
+    expect(r.feedback.reason).toBe("remote ahead"); // the APPEND failure (why we're reconcile-needed)
+    expect(r.feedback.ranReason).toBe("build failed"); // the EXECUTOR failure preserved (why the work failed)
+    expect(r.feedback.durableFacts.map((f) => f.kind)).toEqual(["ActionExecutionStarted"]);
   });
 });
 

--- a/tools/observe/do-item.ts
+++ b/tools/observe/do-item.ts
@@ -29,7 +29,7 @@
  * Integrating `executeDoItem` into the unified `execute`/log/sink is a follow-up
  * (Phase 1 keeps it a sibling so the existing `execute` + its tests stay green).
  *
- * At-least-once corner (Copilot 2026-06-01): if the executor RUNS but the terminal
+ * At-least-once corner (PR review 2026-06-01): if the executor RUNS but the terminal
  * fact append fails, the side-effect happened yet only `Started` is durable. That
  * surfaces as `terminal-append-failed` (NOT `append-failed`) so the caller does not
  * blind-retry (which would duplicate the side-effect). A `Started`-only log is a
@@ -124,7 +124,7 @@ export interface DoItemOptions {
 
 /**
  * Machinery feedback (durability failure) — distinct from work-failure. Two cases,
- * because they have OPPOSITE retry-safety (Copilot 2026-06-01):
+ * because they have OPPOSITE retry-safety (PR review 2026-06-01):
  *   - `append-failed`: the `Started` append failed → the executor NEVER ran (no
  *     side-effect). Safe to retry the whole do_item.
  *   - `terminal-append-failed`: the executor ALREADY RAN (side-effect happened) but
@@ -133,7 +133,10 @@ export interface DoItemOptions {
  *     would duplicate the side-effect under at-least-once). The caller must reconcile
  *     (re-append the known terminal fact, or check the world + decide). Re-execution
  *     is only safe if the item's work is idempotent (the always-active idempotency
- *     discipline — `dv2-data-split`). `durableFacts` carries what DID land.
+ *     discipline — `dv2-data-split`). `durableFacts` carries what DID land; `reason`
+ *     is the APPEND failure; `ranReason` preserves the executor's own failure reason
+ *     when `ranOutcome === "failed"` (so reconciliation doesn't lose WHY the work
+ *     failed, only that the terminal fact didn't land) (PR review 2026-06-01).
  */
 export type DoItemFeedback =
   | { readonly kind: "append-failed"; readonly reason: string }
@@ -141,6 +144,7 @@ export type DoItemFeedback =
       readonly kind: "terminal-append-failed";
       readonly ranOutcome: "succeeded" | "failed";
       readonly reason: string;
+      readonly ranReason?: string;
       readonly durableFacts: readonly ActionFact[];
     };
 
@@ -185,7 +189,22 @@ export async function executeDoItem(
     return { ok: false, feedback: { kind: "append-failed", reason: startedAppend.reason } };
   }
 
-  const outcome = await executor.run(opts.spec);
+  // The port contract is `Promise<RunOutcome>`, but a real impl (spawn / timeout
+  // wrapper / container start) can REJECT instead of returning a failed outcome.
+  // Convert a throw into a failed outcome so an effectful run ALWAYS produces a
+  // terminal fact — never an unhandled rejection that leaves a dangling `Started`
+  // (PR review 2026-06-01).
+  let outcome: RunOutcome;
+  try {
+    outcome = await executor.run(opts.spec);
+  } catch (err) {
+    outcome = {
+      ok: false,
+      reason: `executor threw: ${err instanceof Error ? err.message : String(err)}`,
+      exitCode: -1,
+      stderr: "",
+    };
+  }
 
   if (outcome.ok) {
     const succeeded: ActionFact = { kind: "ActionExecutionSucceeded", item };
@@ -209,12 +228,15 @@ export async function executeDoItem(
   const append: AppendOutcome = await sink.append(failed);
   if (!append.ok) {
     // executor RAN (and failed); the terminal fact didn't land → reconcile-needed.
+    // Preserve the executor's own failure reason (`outcome.reason`) so reconciliation
+    // doesn't lose WHY the work failed — only that the Failed fact didn't land.
     return {
       ok: false,
       feedback: {
         kind: "terminal-append-failed",
         ranOutcome: "failed",
         reason: append.reason,
+        ranReason: outcome.reason,
         durableFacts: [started],
       },
     };

--- a/tools/observe/do-item.ts
+++ b/tools/observe/do-item.ts
@@ -29,6 +29,15 @@
  * Integrating `executeDoItem` into the unified `execute`/log/sink is a follow-up
  * (Phase 1 keeps it a sibling so the existing `execute` + its tests stay green).
  *
+ * At-least-once corner (Copilot 2026-06-01): if the executor RUNS but the terminal
+ * fact append fails, the side-effect happened yet only `Started` is durable. That
+ * surfaces as `terminal-append-failed` (NOT `append-failed`) so the caller does not
+ * blind-retry (which would duplicate the side-effect). A `Started`-only log is a
+ * **reconcile-needed** state; safe re-execution requires idempotent item-work (the
+ * always-active idempotency discipline). FOLLOW-UP: project a `Started` with no
+ * matching terminal into an explicit in-flight state that BLOCKS auto-re-execution
+ * until reconciled (needs a World in-flight field — beyond Phase-1's envelope scope).
+ *
  * Composes with (exact paths):
  *   - tools/observe/observe.ts (simulate = the single reducer; World / BacklogItem)
  *   - tools/observe/execute.ts (EventSink<E> = the durability port reused here for facts; AppendOutcome)
@@ -113,11 +122,27 @@ export interface DoItemOptions {
   readonly gated: boolean; // was this run gate-approved (real-FS/escalation)?
 }
 
-/** Machinery feedback (append/durability failure) — distinct from work-failure. */
-export interface DoItemFeedback {
-  readonly kind: "append-failed";
-  readonly reason: string;
-}
+/**
+ * Machinery feedback (durability failure) — distinct from work-failure. Two cases,
+ * because they have OPPOSITE retry-safety (Copilot 2026-06-01):
+ *   - `append-failed`: the `Started` append failed → the executor NEVER ran (no
+ *     side-effect). Safe to retry the whole do_item.
+ *   - `terminal-append-failed`: the executor ALREADY RAN (side-effect happened) but
+ *     the TERMINAL fact (Succeeded/Failed) didn't land — only `Started` is durable.
+ *     A `Started`-only log is a **reconcile-needed** state: do NOT blind-retry (that
+ *     would duplicate the side-effect under at-least-once). The caller must reconcile
+ *     (re-append the known terminal fact, or check the world + decide). Re-execution
+ *     is only safe if the item's work is idempotent (the always-active idempotency
+ *     discipline — `dv2-data-split`). `durableFacts` carries what DID land.
+ */
+export type DoItemFeedback =
+  | { readonly kind: "append-failed"; readonly reason: string }
+  | {
+      readonly kind: "terminal-append-failed";
+      readonly ranOutcome: "succeeded" | "failed";
+      readonly reason: string;
+      readonly durableFacts: readonly ActionFact[];
+    };
 
 /**
  * `ok` means the MACHINERY worked (facts landed); `completed` means the WORK
@@ -166,7 +191,16 @@ export async function executeDoItem(
     const succeeded: ActionFact = { kind: "ActionExecutionSucceeded", item };
     const append: AppendOutcome = await sink.append(succeeded);
     if (!append.ok) {
-      return { ok: false, feedback: { kind: "append-failed", reason: append.reason } };
+      // executor RAN; the terminal fact didn't land → reconcile-needed, NOT retry.
+      return {
+        ok: false,
+        feedback: {
+          kind: "terminal-append-failed",
+          ranOutcome: "succeeded",
+          reason: append.reason,
+          durableFacts: [started],
+        },
+      };
     }
     return { ok: true, completed: true, world: foldFacts(world, [started, succeeded]), facts: [started, succeeded] };
   }
@@ -174,7 +208,16 @@ export async function executeDoItem(
   const failed: ActionFact = { kind: "ActionExecutionFailed", item, reason: outcome.reason };
   const append: AppendOutcome = await sink.append(failed);
   if (!append.ok) {
-    return { ok: false, feedback: { kind: "append-failed", reason: append.reason } };
+    // executor RAN (and failed); the terminal fact didn't land → reconcile-needed.
+    return {
+      ok: false,
+      feedback: {
+        kind: "terminal-append-failed",
+        ranOutcome: "failed",
+        reason: append.reason,
+        durableFacts: [started],
+      },
+    };
   }
   return {
     ok: true,

--- a/tools/observe/do-item.ts
+++ b/tools/observe/do-item.ts
@@ -1,0 +1,186 @@
+/**
+ * tools/observe/do-item.ts — effectful `do_item`, Phase 1 (B-0964).
+ *
+ * `do_item` is the first action kind with a REAL side-effect (the agent actually
+ * does work). The other kinds `execute` handles (`free_time`/`self_reflect`) have
+ * no side-effect, so logging the action itself == logging the fact. `do_item` does
+ * not: re-running the log must NOT re-run the work (re-build, re-push, re-charge).
+ * So we apply the **command-vs-fact-event split** (standard event-sourcing):
+ *
+ *   `do_item` is a COMMAND (the chooser's pick) — NOT logged.
+ *   Executing it emits FACT events — what actually happened — and THOSE are logged:
+ *     ActionExecutionStarted{item, tier, gated} → ActionExecutionSucceeded{item}
+ *                                                or ActionExecutionFailed{item, reason}
+ *
+ * `foldFacts` replays the FACTS: a folded `succeeded` re-applies the transition
+ * (item leaves backlog) by DELEGATING to `simulate(do_item)` — the single pure
+ * reducer, so the replayed world can't drift from the executed one — and a folded
+ * `failed` leaves the item in place. **`foldFacts` takes no executor: replay
+ * structurally cannot re-run the command.** That is the correctness guarantee.
+ *
+ * The `CommandExecutor` is INJECTED (asymmetric-authorship: the port authors its
+ * own outcome channel; `executeDoItem` stays testable with a fake; no shell in the
+ * unit path). The `Started` fact records the executor `tier` + `gated` so the
+ * §3 glass-halo audit can tell a sandbox run from a real-FS/docker escalation.
+ *
+ * Phase 1 (this file): the envelope + port + transition, fake executor, no dep,
+ * no shell. Phase 2 wires real impls behind `CommandExecutor` (local docker for
+ * real work; just-bash in-memory for text; per B-0964 §2 review-folded routing).
+ * Integrating `executeDoItem` into the unified `execute`/log/sink is a follow-up
+ * (Phase 1 keeps it a sibling so the existing `execute` + its tests stay green).
+ *
+ * Composes with (exact paths):
+ *   - tools/observe/observe.ts (simulate = the single reducer; World / BacklogItem)
+ *   - tools/observe/execute.ts (EventSink<E> = the durability port reused here for facts; AppendOutcome)
+ *   - docs/backlog/P1/B-0964-effectful-do-item-command-vs-fact-event-envelope-injected-executor-just-bash-sandbox-surface-2026-06-01.md
+ *   - .claude/rules/asymmetric-authorship-substrate-entity-defines-consent-channel-recipient-acknowledges.md
+ *   - .claude/rules/monad-propagation-pattern-cross-language-substrate-shape.md (Result<T, TFeedback>)
+ */
+
+import { simulate, type BacklogItem, type World } from "./observe";
+import type { AppendOutcome, EventSink } from "./execute";
+
+// ─── the executor port (the "bash surface") ──────────────────────────────────
+
+/** Which surface ran the command — recorded in the Started fact for the audit. */
+export type ExecutorTier = "fake" | "just-bash" | "docker" | "cloud-burst";
+
+/** What to run. Phase 1: the caller supplies it (B-0964 §4: the sub-loop / recipe map decides later). */
+export interface RunSpec {
+  readonly script: string;
+  readonly cwd?: string;
+}
+
+/** The executor's outcome channel (asymmetric-authorship — never throws; failure is data). */
+export type RunOutcome =
+  | { readonly ok: true; readonly stdout: string; readonly exitCode: 0 }
+  | { readonly ok: false; readonly reason: string; readonly exitCode: number; readonly stderr: string };
+
+/** The injected bash surface. Fake in tests; docker / just-bash in prod (B-0964 §2). */
+export interface CommandExecutor {
+  readonly tier: ExecutorTier;
+  run: (spec: RunSpec) => Promise<RunOutcome>;
+}
+
+/** A deterministic fake executor (no shell) — the always-green test surface. */
+export function fakeExecutor(outcome: RunOutcome): CommandExecutor {
+  return { tier: "fake", run: () => Promise.resolve(outcome) };
+}
+
+// ─── the fact events (what's logged; the command is not) ──────────────────────
+
+export type ActionFact =
+  | {
+      readonly kind: "ActionExecutionStarted";
+      readonly item: BacklogItem;
+      readonly tier: ExecutorTier;
+      readonly gated: boolean;
+    }
+  | { readonly kind: "ActionExecutionSucceeded"; readonly item: BacklogItem }
+  | { readonly kind: "ActionExecutionFailed"; readonly item: BacklogItem; readonly reason: string };
+
+/**
+ * Apply ONE fact to the world (the fact reducer). `Succeeded` DELEGATES to
+ * `simulate(do_item)` so the transition can't drift from the pure path; `Started`
+ * and `Failed` only move the mode (the item stays until it actually succeeds).
+ * No executor — applying a fact never runs anything.
+ */
+export function applyFact(world: World, fact: ActionFact): World {
+  switch (fact.kind) {
+    case "ActionExecutionStarted":
+      return { ...world, mode: "work" };
+    case "ActionExecutionSucceeded":
+      // the single reducer: item leaves the backlog, mode → work.
+      return simulate(world, { kind: "do_item", item: fact.item });
+    case "ActionExecutionFailed":
+      // work attempted but failed → item stays; mode reflects the attempt.
+      return { ...world, mode: "work" };
+  }
+}
+
+/**
+ * Replay the fact log. Pure fold — **no executor parameter**, so replay cannot
+ * re-run the command (the B-0964 §0 correctness guarantee, enforced by the type).
+ */
+export function foldFacts(initial: World, facts: readonly ActionFact[]): World {
+  return facts.reduce(applyFact, initial);
+}
+
+// ─── execute do_item: append Started → run → append Succeeded|Failed ───────────
+
+export interface DoItemOptions {
+  readonly spec: RunSpec; // what to run (Phase 1: caller-supplied)
+  readonly gated: boolean; // was this run gate-approved (real-FS/escalation)?
+}
+
+/** Machinery feedback (append/durability failure) — distinct from work-failure. */
+export interface DoItemFeedback {
+  readonly kind: "append-failed";
+  readonly reason: string;
+}
+
+/**
+ * `ok` means the MACHINERY worked (facts landed); `completed` means the WORK
+ * succeeded (item gone). A failed run is still `ok: true` (facts logged) with
+ * `completed: false` (item stays). `ok: false` only on durability failure.
+ */
+export type DoItemResult =
+  | { readonly ok: true; readonly completed: true; readonly world: World; readonly facts: readonly ActionFact[] }
+  | {
+      readonly ok: true;
+      readonly completed: false;
+      readonly world: World;
+      readonly facts: readonly ActionFact[];
+      readonly reason: string;
+    }
+  | { readonly ok: false; readonly feedback: DoItemFeedback };
+
+/**
+ * Execute a `do_item`: append `Started` (with tier+gated for the audit) → run the
+ * injected executor → append `Succeeded` or `Failed` → project via `applyFact`.
+ * Append-first: if the `Started` append fails, nothing runs (durability is the
+ * source of truth). The executor never throws (RunOutcome is data); the Succeeded
+ * transition leaves the item out of the backlog, the Failed transition keeps it.
+ */
+export async function executeDoItem(
+  world: World,
+  item: BacklogItem,
+  sink: EventSink<ActionFact>,
+  executor: CommandExecutor,
+  opts: DoItemOptions,
+): Promise<DoItemResult> {
+  const started: ActionFact = {
+    kind: "ActionExecutionStarted",
+    item,
+    tier: executor.tier,
+    gated: opts.gated,
+  };
+  const startedAppend: AppendOutcome = await sink.append(started);
+  if (!startedAppend.ok) {
+    return { ok: false, feedback: { kind: "append-failed", reason: startedAppend.reason } };
+  }
+
+  const outcome = await executor.run(opts.spec);
+
+  if (outcome.ok) {
+    const succeeded: ActionFact = { kind: "ActionExecutionSucceeded", item };
+    const append: AppendOutcome = await sink.append(succeeded);
+    if (!append.ok) {
+      return { ok: false, feedback: { kind: "append-failed", reason: append.reason } };
+    }
+    return { ok: true, completed: true, world: foldFacts(world, [started, succeeded]), facts: [started, succeeded] };
+  }
+
+  const failed: ActionFact = { kind: "ActionExecutionFailed", item, reason: outcome.reason };
+  const append: AppendOutcome = await sink.append(failed);
+  if (!append.ok) {
+    return { ok: false, feedback: { kind: "append-failed", reason: append.reason } };
+  }
+  return {
+    ok: true,
+    completed: false,
+    world: foldFacts(world, [started, failed]),
+    facts: [started, failed],
+    reason: outcome.reason,
+  };
+}

--- a/tools/observe/execute.ts
+++ b/tools/observe/execute.ts
@@ -64,13 +64,19 @@ export type AppendOutcome =
   | { readonly ok: false; readonly reason: string };
 
 /**
- * EventSink — the injected durability port. Appends one NextAction to the
+ * EventSink — the injected durability port. Appends one event to the
  * append-only, ZetaId-keyed event log via whichever transport is wired
  * (sovereign folder-direct-to-main / corporate batched). Pure interface;
  * implementations do the I/O. Tests inject a fake.
+ *
+ * Generic over the event type `E` (default `NextAction`, backward-compatible:
+ * `EventSink` ≡ `EventSink<NextAction>`). Effectful actions log **fact** events
+ * instead of the command (B-0964: replay folds facts, never re-runs commands) —
+ * e.g. `EventSink<ActionFact>` for the do_item envelope. One durability-port
+ * shape, parameterized by what gets logged.
  */
-export interface EventSink {
-  append: (action: NextAction) => Promise<AppendOutcome>;
+export interface EventSink<E = NextAction> {
+  append: (event: E) => Promise<AppendOutcome>;
 }
 
 /** The execute feedback channel (asymmetric-authorship). */


### PR DESCRIPTION
B-0964 §5 **Phase 1** (fake executor; no dep, no shell) — built on your go.

## What

The **command-vs-fact-event split** for effectful `do_item`:
- `do_item` is a COMMAND (not logged). Executing it emits **FACT events** that ARE logged: `ActionExecutionStarted{item, tier, gated}` → `ActionExecutionSucceeded{item}` | `ActionExecutionFailed{item, reason}`.
- `foldFacts(initial, facts)` replays the facts, **delegating the success transition to `simulate(do_item)`** (single reducer — no drift). It takes **no executor**, so replay *structurally cannot re-run the work* — the §0 correctness guarantee, enforced by the type.
- `CommandExecutor` port (the bash surface) is injected; `fakeExecutor` for tests. The `Started` fact records `tier` + `gated` so the §3 glass-halo audit can tell a sandbox run from a docker/real-FS escalation.

## Files

- `tools/observe/do-item.ts` — port + `fakeExecutor` + `ActionFact` + `applyFact` + `foldFacts` + `executeDoItem` (append-first; `ok` = machinery worked, `completed` = work succeeded).
- `tools/observe/execute.ts` — `EventSink` → generic `EventSink<E = NextAction>` (backward-compatible; `EventSink` ≡ `EventSink<NextAction>`) so the fact stream reuses the one durability-port shape.
- `tools/observe/do-item.test.ts` — success/failure transitions, tier-in-fact, append-first (executor never runs on durability failure), **replay-folds-facts-without-executor**, `applyFact == simulate`.

## Verify

7/7 new pass; **full observe suite 119/119** (no regressions from the `EventSink` generic); tsc ✓; eslint ✓; prettier ✓.

## Scope

Sibling to `execute()` for Phase 1 (keeps existing `execute` + tests green); unified-`execute` integration + Phase-2 real executors (local docker / just-bash) are follow-ups. Box-checking B-0964/B-0958 follows once B-0964 (#6342) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)