### PR TITLE
backlog(B-0966): Ace store keyed by package identity — deferred future enhancement

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1078,5 +1078,6 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0947](backlog/P3/B-0947-windows-ci-checkout-fails-filename-too-long-max-path-260-long-persona-archive-names-otto-cli-2026-05-30.md)** Windows CI build-and-test fails at Checkout with "Filename too long" (MAX_PATH 260) on long persona-archive names -- non-required so it merges CLEAN but Windows is silently red
 - [ ] **[B-0949](backlog/P3/B-0949-fromvalue-wide-decoder-mode-search-hangs-bound-analytically-or-cap-widths-cross-language-parity-aaron-2026-05-30.md)** Tri-boolean float FromValue mode-search hangs for wide decoders (biased-exponent impls F#/C#/Rust; TS radix-point unaffected) — bound the scan analytically or cap widths, consistently
 - [ ] **[B-0950](backlog/P3/B-0950-creator-compensation-via-provenance-contribution-graph-weighted-split-not-drm-aaron-2026-05-31.md)** Creator compensation via a multi-attribution contribution graph + weighted split (provenance, NOT DRM)
+- [ ] **[B-0966](backlog/P3/B-0966-ace-store-key-by-package-identity-not-files-hash-future-enhancement-2026-06-01.md)** Ace store keyed by package identity (not files-hash) — future enhancement, only if same-files-different-identity arises
 
 <!-- END AUTO-GENERATED -->

--- a/docs/backlog/P3/B-0966-ace-store-key-by-package-identity-not-files-hash-future-enhancement-2026-06-01.md
+++ b/docs/backlog/P3/B-0966-ace-store-key-by-package-identity-not-files-hash-future-enhancement-2026-06-01.md
@@ -1,0 +1,85 @@
+---
+id: B-0966
+priority: P3
+status: open
+title: "Ace store keyed by package identity (not files-hash) — future enhancement, only if same-files-different-identity arises"
+created: 2026-06-01
+last_updated: 2026-06-01
+depends_on: [B-0288]
+classification: deferred-until-needed
+decomposition: atomic
+owners: [developer-experience-engineer]
+type: feature
+---
+
+# B-0966 — Ace store keyed by package identity (future enhancement)
+
+## Trigger / origin
+
+Surfaced during the slice-4 (inline-URL dependency resolution) spec review
+(Codex P1 on PR #6341). The slice-4 resolver keys package identity on the
+**full-package hash** (`package_hash` = sha256 of manifest+signature+files), so
+two genuinely-distinct packages that ship byte-identical files (same slice-2
+`content_hash`, different `package_hash`) are correctly NOT deduped. But the
+slice-1/2 store keys each install directory by the files-only `content_hash`
+(`tools/ace/store.ts`: `dir = <store>/<content_hash with ':'→'-'>`), so two such
+distinct packages would collide on disk.
+
+## Decision taken in slice 4 (the operator 2026-06-01): refuse, don't re-key
+
+The operator confirmed **no current Ace shape needs this**: on main today the
+manifest has **no** `dependencies` field, there are **zero** dependency graphs,
+zero `.ace` packages, and every install is single-package keyed by `content_hash`
+— the collision cannot occur until slice 4 ships dependency graphs AND someone
+creates two distinct packages with byte-identical files (pathological).
+
+So slice 4 takes the **minimal, strict, no-shipped-code-change** path
+(**option B**): the install **preflight refuses `store-collision`** when two
+resolved nodes share a `content_hash` but differ in `package_hash`. Slices 1-3
+store behavior is untouched.
+
+This row captures **option A** as a deferred future enhancement.
+
+## The enhancement (option A) — re-key the store by package identity
+
+Change the content-addressed store from **files-hash-addressed** to
+**package-identity-addressed**:
+
+- `installPackage` extracts to `<store>/<package_hash with ':'→'-'>/` (the full
+  package identity) instead of `<content_hash>/` (files-only).
+- `listInstalled` / `verify` key off the `package_hash` directory.
+- Files MAY still be content-addressed + shared underneath for dedup (optional;
+  the simplest version just gives each distinct package its own dir).
+
+With option A the store can hold two distinct packages with identical files, so
+the slice-4 `store-collision` refusal can be relaxed (the strict→permissive
+flip the slice-4 spec anticipated).
+
+## Acceptance (when/if built)
+
+- [ ] A real need exists: a genuine dependency graph wants two distinct packages
+      (different name/manifest) shipping byte-identical files. (If this never
+      arises, this row stays deferred indefinitely — that is the expected
+      outcome.)
+- [ ] `installPackage` keys the install dir by `package_hash`; `listInstalled` /
+      `verify` updated to match; store tests updated.
+- [ ] The slice-4 `store-collision` preflight refusal is relaxed (no longer
+      needed once the store distinguishes identity).
+- [ ] Migration note: the store dir-key changes; since Ace is pre-release with no
+      deployed store data, no data migration is required — but document the
+      layout change.
+
+## Why P3 / deferred-until-needed
+
+The triggering scenario (two distinct packages, byte-identical files) is
+pathological — different packages rarely ship identical files. Slice 4's strict
+`store-collision` refusal is the correct, honest behavior until a real need
+appears. Building option A speculatively would re-architect shipped slices 1-3
+store behavior for a case that may never occur (YAGNI).
+
+## Composes with
+
+- B-0288 (Ace package manager) — parent
+- Ace slice-4 design spec (`docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice4-inline-url-dependency-resolution-design.md`) — the `store-collision` preflight this would relax
+- `tools/ace/store.ts` (`installPackage` dir-key) — the code option A would change
+- Ace slice 5 (registry) — if/when registry resolution lands, identity-keyed store may become more relevant


### PR DESCRIPTION
Captures the slice-4 review fork (Codex P1 on #6341). The full-package-hash pin lets two distinct packages with identical files both resolve, but the slice-1/2 store keys install dirs by files-only `content_hash` → on-disk collision.

Operator confirmed (2026-06-01): **no current shape needs this** — main has no `dependencies` field, zero dependency graphs, zero `.ace` packages, all installs single-package. So slice 4 takes **option B** (preflight refuses `store-collision`, strict, slices 1-3 untouched); this **P3 deferred-until-needed** row captures **option A** (re-key store by `package_hash`) — built only if same-files-different-identity ever becomes real (pathological; may never).

🤖 Generated with [Claude Code](https://claude.com/claude-code)