### PR TITLE
chore(setup): declare podman as default OCI container runtime (brew/apt/windows)

### DIFF
--- a/tools/ci/manifest-symmetry.test.ts
+++ b/tools/ci/manifest-symmetry.test.ts
@@ -43,6 +43,13 @@ const WINDOWS_EXCEPTIONS: Record<string, string> = {
   libssl3t64: "Linux OpenSSL runtime lib; Windows uses Schannel / native TLS",
   "libgssapi-krb5-2": "Linux Kerberos/GSSAPI runtime lib; Windows uses SSPI natively",
   tzdata: "Linux timezone database; Windows ships its own timezone data",
+  // Rootless-podman helpers (added to apt with podman; B-0964 §2). Linux-only: on
+  // Windows podman runs its Linux VM via WSL2, which provides user-namespace mapping,
+  // networking, and overlay storage inside the VM — these host packages have no
+  // Windows-native equivalent (the WSL2 distro carries them).
+  uidmap: "Linux rootless user-namespace mapping (newuidmap/newgidmap); Windows podman uses WSL2's VM",
+  slirp4netns: "Linux rootless container networking; Windows podman uses WSL2's VM networking",
+  "fuse-overlayfs": "Linux rootless overlay storage driver; Windows podman uses WSL2's VM storage",
 };
 
 test("manifests/windows covers every apt/brew system tool (or an allowlisted exception)", () => {

--- a/tools/setup/manifests/apt
+++ b/tools/setup/manifests/apt
@@ -31,3 +31,12 @@ libicu74          # ICU — .NET globalization (the classic "dotnet exited" caus
 libssl3t64        # OpenSSL 3 runtime (Noble t64 name)
 libgssapi-krb5-2  # Kerberos/GSSAPI — .NET networking
 tzdata            # timezone data — .NET DateTime
+
+# Container runtime for the effectful do_item executor (B-0964 §2; OCI-standard,
+# runtime-swappable via ZETA_CONTAINER_RUNTIME). podman = default (Apache-2.0,
+# rootless, daemonless). On Linux no VM is needed (native namespaces/cgroups). On
+# the GPU cluster, NVIDIA access is runtime-NEUTRAL via the NVIDIA Container Toolkit
+# + CDI — same `--device nvidia.com/gpu=all` works on podman AND docker (CDI ≥
+# podman 4.1 / docker via nvidia-container-toolkit), so the executor stays runtime-
+# agnostic even with GPUs. Docker (if installed) coexists; the executor picks via env.
+podman

--- a/tools/setup/manifests/apt
+++ b/tools/setup/manifests/apt
@@ -32,11 +32,15 @@ libssl3t64        # OpenSSL 3 runtime (Noble t64 name)
 libgssapi-krb5-2  # Kerberos/GSSAPI — .NET networking
 tzdata            # timezone data — .NET DateTime
 
-# Container runtime for the effectful do_item executor (B-0964 §2; OCI-standard,
-# runtime-swappable via ZETA_CONTAINER_RUNTIME). podman = default (Apache-2.0,
-# rootless, daemonless). On Linux no VM is needed (native namespaces/cgroups). On
-# the GPU cluster, NVIDIA access is runtime-NEUTRAL via the NVIDIA Container Toolkit
-# + CDI — same `--device nvidia.com/gpu=all` works on podman AND docker (CDI ≥
-# podman 4.1 / docker via nvidia-container-toolkit), so the executor stays runtime-
-# agnostic even with GPUs. Docker (if installed) coexists; the executor picks via env.
+# Container runtime for the effectful do_item executor (rationale: B-0964 §2). podman
+# is the default OCI runtime: Apache-2.0, rootless, daemonless; native on Linux (no
+# VM). Version unpinned (fast-mover CLI) per dep-pin-search-first-authority.
 podman
+# Rootless-podman helpers: linux.sh runs `apt install --no-install-recommends`, which
+# skips podman's Recommends — so a minimal Ubuntu needs these explicitly or rootless
+# podman silently breaks. Per automated-tests-are-the-shield-assert-dont-skip: declare
+# them so podman actually RUNS rootless, not just installs (a green install that can't
+# run a container is a hole in the shield).
+uidmap          # newuidmap/newgidmap — rootless user-namespace ID mapping
+slirp4netns     # rootless container networking
+fuse-overlayfs  # rootless overlay storage driver

--- a/tools/setup/manifests/brew
+++ b/tools/setup/manifests/brew
@@ -31,14 +31,10 @@ hermes-agent  # "Self-improving AI agent that creates skills from
 ollama  # CPU-served tiny model for the move-next selector + observe.ts
         # classifier + DST fixtures. Idempotent: brew install skips if present.
 
-# Container runtime for the effectful do_item executor (B-0964 §2; the OCI-standard
-# boundary where real CLI work runs — "the first time the item needs real tools,
-# stop simulating"). podman is the DEFAULT (huddle 2026-06-01: gemini+grok+amara):
-# Apache-2.0, $0, rootless, daemonless. Runtime-SWAPPABLE — the executor reads
-# ZETA_CONTAINER_RUNTIME (podman|docker|nerdctl|finch), so Docker Desktop (if a
-# maintainer already has it) coexists fine: separate VM, separate socket, no
-# conflict — do NOT install `podman-mac-helper`/`podman-docker` (they'd shadow the
-# real docker CLI). macOS one-time bootstrap after install: `podman machine init &&
-# podman machine start` (creates the Linux VM the CLI talks to; Phase-2 executor
-# starts it lazily). Idempotent: brew skips if present.
+# Container runtime for the effectful do_item executor (rationale: B-0964 §2). podman
+# is the default OCI runtime: Apache-2.0, rootless, daemonless. Coexists with an
+# existing Docker Desktop (separate VM + socket); do NOT install `podman-mac-helper`
+# /`podman-docker` (they shadow the real docker CLI). macOS one-time bootstrap:
+# `podman machine init && podman machine start`. Version unpinned (fast-mover CLI;
+# brew default) per dep-pin-search-first-authority. Idempotent: brew skips if present.
 podman

--- a/tools/setup/manifests/brew
+++ b/tools/setup/manifests/brew
@@ -30,3 +30,15 @@ hermes-agent  # "Self-improving AI agent that creates skills from
 # model is the reproducible/pinned artifact; brew tracks latest ollama binary).
 ollama  # CPU-served tiny model for the move-next selector + observe.ts
         # classifier + DST fixtures. Idempotent: brew install skips if present.
+
+# Container runtime for the effectful do_item executor (B-0964 §2; the OCI-standard
+# boundary where real CLI work runs — "the first time the item needs real tools,
+# stop simulating"). podman is the DEFAULT (huddle 2026-06-01: gemini+grok+amara):
+# Apache-2.0, $0, rootless, daemonless. Runtime-SWAPPABLE — the executor reads
+# ZETA_CONTAINER_RUNTIME (podman|docker|nerdctl|finch), so Docker Desktop (if a
+# maintainer already has it) coexists fine: separate VM, separate socket, no
+# conflict — do NOT install `podman-mac-helper`/`podman-docker` (they'd shadow the
+# real docker CLI). macOS one-time bootstrap after install: `podman machine init &&
+# podman machine start` (creates the Linux VM the CLI talks to; Phase-2 executor
+# starts it lazily). Idempotent: brew skips if present.
+podman

--- a/tools/setup/manifests/windows
+++ b/tools/setup/manifests/windows
@@ -36,6 +36,7 @@ ollama    winget=Ollama.Ollama    choco=ollama    optional
 # manifests/apt; rationale: B-0964 §2). podman = the default OCI runtime (Apache-2.0); on
 # Windows it runs its Linux VM via WSL2 (`podman machine init` on first use). Coexists with
 # Docker Desktop. Pins per dep-pin-search-first-authority (WebSearch 2026-06-01 —
-# https://winget.run/pkg/RedHat/Podman + https://scoop.sh/): scoop `podman` | winget
-# `RedHat.Podman` | choco defaults to `podman` (scoop is the primary resolver).
-podman    winget=RedHat.Podman
+# https://winget.run/pkg/RedHat/Podman + https://community.chocolatey.org/packages/podman-cli):
+# scoop `podman` | winget `RedHat.Podman` | choco `podman-cli` (the CLI package — NOT
+# `podman`, which would 404 on a choco-only host; `podman-desktop` is the separate GUI).
+podman    winget=RedHat.Podman    choco=podman-cli

--- a/tools/setup/manifests/windows
+++ b/tools/setup/manifests/windows
@@ -31,3 +31,11 @@ git    winget=Git.Git    choco=git
 # it normally. This matches Linux: common/local-llm.sh installs the ollama binary gracefully too
 # (the local-LLM model is best-effort substrate, never a hard dep).
 ollama    winget=Ollama.Ollama    choco=ollama    optional
+
+# Container runtime for the effectful do_item executor (symmetric with manifests/brew +
+# manifests/apt; B-0964 §2). podman = the default OCI runtime (Apache-2.0); on Windows it
+# runs its Linux VM via WSL2 (`podman machine init` on first use). Coexists with Docker
+# Desktop (also WSL2; separate machine). Pins per dep-pin-search-first (WebSearch 2026-06-01
+# — https://winget.run/pkg/RedHat/Podman + https://scoop.sh/): scoop `podman` | winget
+# `RedHat.Podman` | choco defaults to `podman` (last-resort; scoop is primary resolver).
+podman    winget=RedHat.Podman

--- a/tools/setup/manifests/windows
+++ b/tools/setup/manifests/windows
@@ -33,9 +33,9 @@ git    winget=Git.Git    choco=git
 ollama    winget=Ollama.Ollama    choco=ollama    optional
 
 # Container runtime for the effectful do_item executor (symmetric with manifests/brew +
-# manifests/apt; B-0964 §2). podman = the default OCI runtime (Apache-2.0); on Windows it
-# runs its Linux VM via WSL2 (`podman machine init` on first use). Coexists with Docker
-# Desktop (also WSL2; separate machine). Pins per dep-pin-search-first (WebSearch 2026-06-01
-# — https://winget.run/pkg/RedHat/Podman + https://scoop.sh/): scoop `podman` | winget
-# `RedHat.Podman` | choco defaults to `podman` (last-resort; scoop is primary resolver).
+# manifests/apt; rationale: B-0964 §2). podman = the default OCI runtime (Apache-2.0); on
+# Windows it runs its Linux VM via WSL2 (`podman machine init` on first use). Coexists with
+# Docker Desktop. Pins per dep-pin-search-first-authority (WebSearch 2026-06-01 —
+# https://winget.run/pkg/RedHat/Podman + https://scoop.sh/): scoop `podman` | winget
+# `RedHat.Podman` | choco defaults to `podman` (scoop is the primary resolver).
 podman    winget=RedHat.Podman


### PR DESCRIPTION
## What

Declares **podman** as the default OCI container runtime across all three platform manifests, for the effectful `do_item` executor's real-work tier (B-0964 §2 — "the first time the item needs real tools, stop simulating").

| Manifest | Line |
|---|---|
| `tools/setup/manifests/brew` | `podman` (macOS; one-time `podman machine init && start` Linux-VM bootstrap) |
| `tools/setup/manifests/apt` | `podman` (Linux; native, no VM) |
| `tools/setup/manifests/windows` | `podman  winget=RedHat.Podman` (WSL2 machine; scoop primary) |

## Why podman (huddle 2026-06-01: gemini + grok + amara)

OCI-standard, **Apache-2.0, $0, rootless, daemonless**. The executor reads `ZETA_CONTAINER_RUNTIME` (podman|docker|nerdctl|finch) — **runtime-swappable**, so Docker Desktop coexists for maintainers who already run it (separate VM, separate socket, no conflict; don't install `podman-mac-helper`/`podman-docker` which would shadow the docker CLI).

- NVIDIA GPU on the cluster is **runtime-neutral** via the NVIDIA Container Toolkit + CDI — same `--device nvidia.com/gpu=all` on podman and docker (no docker lock-in for GPUs).
- Version **unpinned** (fast-mover CLI; brew/scoop default) per pin-only-slow-movers.
- Compose stays at the infra layer (Compose Spec), not the executor — a follow-up note.

## Verification

- `manifest-symmetry.test.ts` 3/3 ✓ (brew/apt tool ⇒ present in windows)
- Installed + smoke-tested on the maintainer's Mac: podman 5.8.2, `podman machine` up, ran a real alpine container (`uname=Linux aarch64`), coexisting with the pre-existing Docker 29.4.3 — no conflict.

## Follow-up (same session)

Fold the OCI-abstraction + compose-at-infra into B-0964 §2 + preserve the docker/podman huddle verbatim in a review doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)