### PR TITLE
feat(ace): slice 4 — inline-URL transitive dependency resolution (B-0288)

### DIFF
--- a/.claude/skills/ace/SKILL.md
+++ b/.claude/skills/ace/SKILL.md
@@ -30,7 +30,7 @@ Publisher verbs: `keygen`, `sign`. Consumer verbs: `install`, `verify`, `trust a
 | `keygen` | `bun tools/ace/ace.ts keygen [--out <prefix>]` | Generate an Ed25519 keypair (writes `<prefix>.key` 0600 + `<prefix>.pub`) |
 | `sign` | `bun tools/ace/ace.ts sign <pkg> --key <priv.key> [--out <file>]` | Sign a package manifest with an Ed25519 private key |
 | `list` | `bun tools/ace/ace.ts list [--store <path>] [--json]` | List installed packages from `~/.ace/store` |
-| `install` | `bun tools/ace/ace.ts install <url-or-path> [--allow-no-signature]` | Download/read a package, verify integrity + authenticity, install |
+| `install` | `bun tools/ace/ace.ts install <url-or-path> [--allow-no-signature]` | Resolve the transitive dependency graph, verify integrity + authenticity of every node, install leaves-first (atomic) |
 | `verify` | `bun tools/ace/ace.ts verify <hash>` | Confirm an installed package is present |
 | `trust add` | `bun tools/ace/ace.ts trust add <pub-file-or-b64> [--label <name>]` | Add an Ed25519 public key to the user trust store (`~/.ace/trusted-keys.json`) |
 | `trust list` | `bun tools/ace/ace.ts trust list` | List all trusted keys (bundled + user) |
@@ -39,6 +39,16 @@ Publisher verbs: `keygen`, `sign`. Consumer verbs: `install`, `verify`, `trust a
 `install` verifies **integrity** (content hash) AND **authenticity** (Ed25519 signature
 against the trust store). Unsigned packages need `--allow-no-signature`; a present-but-untrusted
 signature is always refused (`ace trust add` the key).
+
+For a manifest with `dependencies` (inline-URL: `{name, version, url, package_hash}`),
+`install` resolves the full transitive graph and installs every node leaves-first.
+Resolution is atomic: it verifies the whole graph (slice-2 hash + slice-3 signature
+per node, identity-pinned by `package_hash`) and preflights path-safety + store-key
+uniqueness BEFORE extracting anything — any failure installs nothing. Refusal reasons:
+`version-skew`, `tamper`, `pin-mismatch`, `bad-content-hash`, `bad-signature`,
+`untrusted-key`, `unsupported-algo`, `no-signature`, `cycle`, `fetch-failed`,
+`invalid-package`, `store-collision`. `--allow-no-signature` applies graph-wide
+(permits only genuinely-unsigned nodes; a bad/untrusted signature on any node always refuses).
 
 ## Invocation
 

--- a/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice4-implementation-plan.md
+++ b/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice4-implementation-plan.md
@@ -28,6 +28,7 @@
 ## Task 1: Manifest gains `dependencies?` (back-compat)
 
 **Files:**
+
 - Modify: `tools/ace/store.ts` (the `AceManifest` interface + a new `AceDependency` interface, near lines 7-14)
 - Test: `tools/ace/store.test.ts`
 
@@ -93,6 +94,7 @@ git commit -m "feat(ace): AceManifest.dependencies? + AceDependency (slice 4 tas
 ## Task 2: Factor `validatePackagePaths` out of `installPackage`
 
 **Files:**
+
 - Modify: `tools/ace/store.ts` (`installPackage`, the path-safety loop ~lines 115-119)
 - Test: `tools/ace/store.test.ts`
 
@@ -161,6 +163,7 @@ git commit -m "refactor(ace): factor validatePackagePaths out of installPackage 
 ## Task 3: `packageHash` (full-package identity)
 
 **Files:**
+
 - Create: `tools/ace/resolve.ts`
 - Test: `tools/ace/resolve.test.ts`
 
@@ -237,6 +240,7 @@ git commit -m "feat(ace): packageHash full-package identity helper (slice 4 task
 ## Task 4: `resolve` — leaf + linear chain (topo order)
 
 **Files:**
+
 - Modify: `tools/ace/resolve.ts`, `tools/ace/resolve.test.ts`
 
 **Shared test helper** (add near the top of `resolve.test.ts`, after imports): builds a package + a fetch map keyed by URL, with edges carrying the correct `package_hash`.

--- a/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice4-implementation-plan.md
+++ b/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice4-implementation-plan.md
@@ -1,0 +1,817 @@
+# Ace slice 4 — inline-URL dependency resolution: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `ace install` resolves a manifest's full transitive inline-URL dependency graph, verifies every node (slice-2 hash + slice-3 signature), and installs leaves-first — atomically.
+
+**Architecture:** A new pure `resolve.ts` (fetch boundary injected → fully in-memory testable) does identity-keyed graph resolution; `store.ts` gains the `dependencies?` manifest field + a factored-out `validatePackagePaths`; `ace.ts` wires the resolver into `install` with a graph preflight (path-safety + store-collision) before extracting anything.
+
+**Tech Stack:** TypeScript on Bun; `bun:test`; `node:crypto` (sha256). Spec: `docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice4-inline-url-dependency-resolution-design.md`.
+
+**Conventions (every commit):** run `git ls-tree HEAD | wc -l` — must stay **67** root entries (commit canary); confirm `git branch --show-current` = `otto-windows/ace-slice4-impl-2026-06-01` before committing; commit trailer `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. The Otto-343 hook blocks `Edit` on files not Read this session — prefer `Write` (full file) when it blocks. Run the full ace suite with `bun test tools/ace/` (currently 76 tests, all green).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `tools/ace/store.ts` | (modify) `AceManifest.dependencies?` + `AceDependency` export; factor `validatePackagePaths(pkg)` out of `installPackage` |
+| `tools/ace/resolve.ts` | (create) pure resolver: `packageHash`, `resolve` (identity-keyed DFS, verify per node, topo order) |
+| `tools/ace/resolve.test.ts` | (create) resolver unit tests, injected in-memory fetch |
+| `tools/ace/ace.ts` | (modify) wire `resolve` into `install`; graph preflight; graph-wide `--allow-no-signature`; resolved-set output |
+| `tools/ace/ace.test.ts` | (modify) e2e graph-install + atomic-refuse tests |
+| `.claude/skills/ace/SKILL.md` | (modify) document transitive install + refusal reasons |
+
+---
+
+## Task 1: Manifest gains `dependencies?` (back-compat)
+
+**Files:**
+- Modify: `tools/ace/store.ts` (the `AceManifest` interface + a new `AceDependency` interface, near lines 7-14)
+- Test: `tools/ace/store.test.ts`
+
+- [ ] **Step 1: Write the failing test** (append to `store.test.ts`, inside the `installPackage` describe)
+
+```ts
+test("installPackage ignores a manifest's dependencies field (leaf back-compat)", () => {
+  const store = mkdtempSync(join(tmpdir(), "ace-store-"));
+  const files = { "r.txt": "hi" };
+  const content_hash = "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+  const pkg = {
+    manifest: {
+      format_version: 1, name: "demo", version: "1.0.0", content_hash,
+      dependencies: [{ name: "x", version: "1.0.0", url: "http://e/x.json", package_hash: "sha256:deadbeef" }],
+    },
+    files,
+  };
+  const result = installPackage(store, pkg);
+  expect(result.ok).toBe(true); // store layer ignores dependencies; still installs the single package
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `bun test tools/ace/store.test.ts`
+Expected: FAIL — TypeScript rejects `dependencies` (not on `AceManifest`).
+
+- [ ] **Step 3: Add the field + interface** (in `tools/ace/store.ts`, replace the `AceManifest` interface block, lines 7-14)
+
+```ts
+export interface AceDependency {
+  readonly name: string;
+  readonly version: string;
+  readonly url: string;
+  readonly package_hash: string; // sha256 of the canonical FULL package (manifest incl. signature + files)
+}
+
+export interface AceManifest {
+  readonly format_version: number;
+  readonly name: string;
+  readonly version: string;
+  readonly content_hash: string; // slice-2: sha256(files)
+  readonly description?: string;
+  readonly signature?: { readonly algo: string; readonly key_id: string; readonly sig: string };
+  readonly dependencies?: ReadonlyArray<AceDependency>;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tools/ace/store.test.ts`
+Expected: PASS (all existing store tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/store.ts tools/ace/store.test.ts
+git commit -m "feat(ace): AceManifest.dependencies? + AceDependency (slice 4 task 1)"
+```
+
+---
+
+## Task 2: Factor `validatePackagePaths` out of `installPackage`
+
+**Files:**
+- Modify: `tools/ace/store.ts` (`installPackage`, the path-safety loop ~lines 115-119)
+- Test: `tools/ace/store.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { validatePackagePaths } from "./store.ts"; // add to the existing import line
+
+describe("validatePackagePaths", () => {
+  test("returns null for safe paths", () => {
+    expect(validatePackagePaths({ manifest: { format_version: 1, name: "a", version: "1", content_hash: "x" }, files: { "ok.txt": "y" } })).toBeNull();
+  });
+  test("returns the offending path for '..' traversal", () => {
+    expect(validatePackagePaths({ manifest: { format_version: 1, name: "a", version: "1", content_hash: "x" }, files: { "../escape": "y" } })).toBe("../escape");
+  });
+  test("returns the offending path for an absolute path", () => {
+    expect(validatePackagePaths({ manifest: { format_version: 1, name: "a", version: "1", content_hash: "x" }, files: { "/etc/passwd": "y" } })).toBe("/etc/passwd");
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `bun test tools/ace/store.test.ts`
+Expected: FAIL — `validatePackagePaths` is not exported.
+
+- [ ] **Step 3: Add the helper + use it in `installPackage`** (in `tools/ace/store.ts`)
+
+Add the exported helper just above `installPackage`:
+
+```ts
+/** Returns the first unsafe file path in the package, or null if all paths are safe.
+ *  Unsafe = contains '..', or is absolute (leading '/' or '\\'). Shared by installPackage
+ *  AND the slice-4 graph install preflight so the two never drift. */
+export function validatePackagePaths(pkg: AcePackage): string | null {
+  for (const rel of Object.keys(pkg.files)) {
+    if (rel.includes("..") || rel.startsWith("/") || rel.startsWith("\\")) return rel;
+  }
+  return null;
+}
+```
+
+Then replace the inline loop in `installPackage` (the `for (const rel of Object.keys(pkg.files)) { if (...) return {ok:false,...}}` block) with:
+
+```ts
+  const unsafe = validatePackagePaths(pkg);
+  if (unsafe !== null) {
+    return { ok: false, error: `unsafe file path in package: ${unsafe}` };
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tools/ace/store.test.ts`
+Expected: PASS (the existing traversal/absolute-path installPackage tests still pass — behavior unchanged, just refactored).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/store.ts tools/ace/store.test.ts
+git commit -m "refactor(ace): factor validatePackagePaths out of installPackage (slice 4 task 2)"
+```
+
+---
+
+## Task 3: `packageHash` (full-package identity)
+
+**Files:**
+- Create: `tools/ace/resolve.ts`
+- Test: `tools/ace/resolve.test.ts`
+
+- [ ] **Step 1: Write the failing test** (create `tools/ace/resolve.test.ts`)
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { packageHash } from "./resolve.ts";
+import type { AcePackage } from "./store.ts";
+
+const mk = (name: string, deps?: unknown): AcePackage => ({
+  manifest: { format_version: 1, name, version: "1.0.0", content_hash: "sha256:aaa", ...(deps ? { dependencies: deps } : {}) } as AcePackage["manifest"],
+  files: { "a.txt": "x" },
+});
+
+describe("packageHash", () => {
+  test("stable under key reordering (canonical)", () => {
+    const a: AcePackage = { manifest: { format_version: 1, name: "n", version: "1", content_hash: "h" }, files: { a: "1", b: "2" } };
+    const b: AcePackage = { manifest: { content_hash: "h", version: "1", name: "n", format_version: 1 }, files: { b: "2", a: "1" } } as AcePackage;
+    expect(packageHash(a)).toBe(packageHash(b));
+  });
+  test("differs when manifest differs even if files identical", () => {
+    expect(packageHash(mk("A"))).not.toBe(packageHash(mk("B"))); // same files, different name
+  });
+  test("differs when files differ", () => {
+    const base = mk("A");
+    const other: AcePackage = { manifest: base.manifest, files: { "a.txt": "DIFFERENT" } };
+    expect(packageHash(base)).not.toBe(packageHash(other));
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `bun test tools/ace/resolve.test.ts`
+Expected: FAIL — `resolve.ts` does not exist.
+
+- [ ] **Step 3: Create `tools/ace/resolve.ts` with `packageHash`**
+
+```ts
+import { createHash } from "node:crypto";
+import type { AcePackage } from "./store.ts";
+
+/** Deterministic JSON: object keys recursively sorted; arrays preserve order. */
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return "[" + value.map(canonicalJson).join(",") + "]";
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return "{" + keys.map((k) => JSON.stringify(k) + ":" + canonicalJson(obj[k])).join(",") + "}";
+}
+
+/** sha256 of the canonical whole package ({manifest incl. signature, files}). The parent's
+ *  pin / identity for a dependency. Two edges sharing a packageHash are byte-identical. */
+export function packageHash(pkg: AcePackage): string {
+  return "sha256:" + createHash("sha256").update(canonicalJson({ manifest: pkg.manifest, files: pkg.files })).digest("hex");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tools/ace/resolve.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/resolve.ts tools/ace/resolve.test.ts
+git commit -m "feat(ace): packageHash full-package identity helper (slice 4 task 3)"
+```
+
+---
+
+## Task 4: `resolve` — leaf + linear chain (topo order)
+
+**Files:**
+- Modify: `tools/ace/resolve.ts`, `tools/ace/resolve.test.ts`
+
+**Shared test helper** (add near the top of `resolve.test.ts`, after imports): builds a package + a fetch map keyed by URL, with edges carrying the correct `package_hash`.
+
+```ts
+import { resolve, packageHash, type FetchPackage } from "./resolve.ts";
+import { contentHash, type AcePackage } from "./store.ts";
+
+// Build a package; deps is an array of { pkg, url } children already built.
+function pkgOf(name: string, files: Record<string, string>, children: { pkg: AcePackage; url: string }[] = []): AcePackage {
+  const ch = "sha256:" + // slice-2 files hash
+    require("node:crypto").createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+  return {
+    manifest: {
+      format_version: 1, name, version: "1.0.0", content_hash: ch,
+      dependencies: children.map((c) => ({ name: c.pkg.manifest.name, version: c.pkg.manifest.version, url: c.url, package_hash: packageHash(c.pkg) })),
+    },
+    files,
+  };
+}
+// An injected fetch over a {url: package} map.
+function fetchOf(map: Record<string, AcePackage>): FetchPackage {
+  return async (url: string) => { const p = map[url]; if (!p) throw new Error("404 " + url); return JSON.stringify(p); };
+}
+const NO_TRUST = new Map(); // empty trust store; tests use allowNoSignature:true unless testing signatures
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("resolve — basic", () => {
+  test("leaf package (no deps) resolves to [root]", async () => {
+    const root = pkgOf("root", { "r.txt": "x" });
+    const r = await resolve(root, fetchOf({}), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.order.map((p) => p.manifest.name)).toEqual(["root"]);
+  });
+  test("linear chain root->A->B installs leaves-first [B, A, root]", async () => {
+    const B = pkgOf("B", { "b.txt": "b" });
+    const A = pkgOf("A", { "a.txt": "a" }, [{ pkg: B, url: "http://e/B" }]);
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: A, url: "http://e/A" }]);
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.order.map((p) => p.manifest.name)).toEqual(["B", "A", "root"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test tools/ace/resolve.test.ts`
+Expected: FAIL — `resolve` not exported.
+
+- [ ] **Step 3: Implement `resolve` (basic DFS, no conflict checks yet)** — append to `tools/ace/resolve.ts`
+
+```ts
+import { contentHash, verifyHelpersPlaceholder } from "./store.ts"; // NOTE: see Task 8 for the real imports
+import type { AceManifest, LoadedTrustEntry } from "./store.ts";
+
+export type FetchPackage = (urlOrPath: string) => Promise<string>;
+
+export type ResolveReason =
+  | "version-skew" | "tamper" | "pin-mismatch" | "bad-content-hash"
+  | "bad-signature" | "untrusted-key" | "unsupported-algo" | "no-signature"
+  | "cycle" | "fetch-failed" | "invalid-package";
+
+export type ResolveResult =
+  | { ok: true; order: AcePackage[] }
+  | { ok: false; reason: ResolveReason; detail: string; path: string[] };
+
+export async function resolve(
+  root: AcePackage,
+  fetchPackage: FetchPackage,
+  _trustStore: Map<string, LoadedTrustEntry>,
+  _opts: { allowNoSignature: boolean },
+): Promise<ResolveResult> {
+  const byName = new Map<string, { version: string; pkgHash: string; path: string[] }>();
+  const visiting = new Set<string>();
+  const order: AcePackage[] = [];
+
+  byName.set(root.manifest.name, { version: root.manifest.version, pkgHash: packageHash(root), path: ["root"] });
+  visiting.add(root.manifest.name);
+
+  const walk = async (node: AcePackage, path: string[]): Promise<ResolveResult | null> => {
+    for (const edge of node.manifest.dependencies ?? []) {
+      const here = [...path, edge.name];
+      let dep: AcePackage;
+      try { dep = JSON.parse(await fetchPackage(edge.url)) as AcePackage; }
+      catch (e) { return { ok: false, reason: "fetch-failed", detail: `${edge.url}: ${(e as Error).message}`, path: here }; }
+      byName.set(edge.name, { version: edge.version, pkgHash: edge.package_hash, path: here });
+      visiting.add(edge.name);
+      const sub = await walk(dep, here);
+      if (sub) return sub;
+      visiting.delete(edge.name);
+      order.push(dep);
+    }
+    return null;
+  };
+
+  const failure = await walk(root, ["root"]);
+  if (failure) return failure;
+  order.push(root);
+  return { ok: true, order };
+}
+```
+
+> NOTE: the `verifyHelpersPlaceholder` import line above is a deliberate stand-in — delete it; the real imports (`contentHash`, `verifySignature`) are added in Task 8. For Task 4, the only imports needed are `packageHash` (same file) and the types.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test tools/ace/resolve.test.ts`
+Expected: PASS (basic + packageHash tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/resolve.ts tools/ace/resolve.test.ts
+git commit -m "feat(ace): resolve leaf + linear-chain topo order (slice 4 task 4)"
+```
+
+---
+
+## Task 5: Diamond dedup + distinct-identical-files
+
+**Files:** `tools/ace/resolve.ts`, `tools/ace/resolve.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("resolve — dedup", () => {
+  test("diamond (root->A->D, root->B->D, same D) installs D once", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const A = pkgOf("A", { "a.txt": "a" }, [{ pkg: D, url: "http://e/D" }]);
+    const B = pkgOf("B", { "b.txt": "b" }, [{ pkg: D, url: "http://e/D" }]);
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: A, url: "http://e/A" }, { pkg: B, url: "http://e/B" }]);
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B, "http://e/D": D }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.order.filter((p) => p.manifest.name === "D").length).toBe(1);
+  });
+  test("distinct packages with identical files (different names) both resolve", async () => {
+    const files = { "same.txt": "identical" };
+    const X = pkgOf("X", files); // same files...
+    const Y = pkgOf("Y", files); // ...different name => different package_hash
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: X, url: "http://e/X" }, { pkg: Y, url: "http://e/Y" }]);
+    const r = await resolve(root, fetchOf({ "http://e/X": X, "http://e/Y": Y }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.order.map((p) => p.manifest.name).sort()).toEqual(["X", "Y", "root"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test tools/ace/resolve.test.ts`
+Expected: FAIL — diamond installs D twice (no dedup yet).
+
+- [ ] **Step 3: Add dedup/cycle/skew/tamper branch** — in `walk`, replace the top of the loop body (before the fetch) with the identity checks:
+
+```ts
+    for (const edge of node.manifest.dependencies ?? []) {
+      const here = [...path, edge.name];
+      if (visiting.has(edge.name)) {
+        return { ok: false, reason: "cycle", detail: here.join(" → "), path: here };
+      }
+      const seen = byName.get(edge.name);
+      if (seen) {
+        if (seen.version !== edge.version) {
+          return { ok: false, reason: "version-skew", detail: `${edge.name} required at ${seen.version} (via ${seen.path.join(" → ")}) and ${edge.version} (via ${here.join(" → ")})`, path: here };
+        }
+        if (seen.pkgHash !== edge.package_hash) {
+          return { ok: false, reason: "tamper", detail: `${edge.name}@${edge.version} has two different package hashes`, path: here };
+        }
+        continue; // diamond dedup: same name+version+package_hash, already resolved
+      }
+      let dep: AcePackage;
+      try { dep = JSON.parse(await fetchPackage(edge.url)) as AcePackage; }
+      catch (e) { return { ok: false, reason: "fetch-failed", detail: `${edge.url}: ${(e as Error).message}`, path: here }; }
+      byName.set(edge.name, { version: edge.version, pkgHash: edge.package_hash, path: here });
+      visiting.add(edge.name);
+      const sub = await walk(dep, here);
+      if (sub) return sub;
+      visiting.delete(edge.name);
+      order.push(dep);
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test tools/ace/resolve.test.ts`
+Expected: PASS (diamond D once; X+Y both resolve).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/resolve.ts tools/ace/resolve.test.ts
+git commit -m "feat(ace): resolve diamond dedup + identity-keyed (slice 4 task 5)"
+```
+
+---
+
+## Task 6: Version-skew + tamper + root-seeded skew/cycle
+
+**Files:** `tools/ace/resolve.test.ts` (logic already added in Task 5; this task proves skew/tamper + root-seeding)
+
+- [ ] **Step 1: Write the failing/confirming tests**
+
+```ts
+describe("resolve — conflicts", () => {
+  test("version-skew (A->D@1.0, B->D@2.0) refuses", async () => {
+    const D1 = pkgOf("D", { "d.txt": "d1" });
+    const D2: AcePackage = { manifest: { ...D1.manifest, version: "2.0.0" }, files: { "d.txt": "d2" } };
+    const A = pkgOf("A", { "a.txt": "a" }, [{ pkg: D1, url: "http://e/D1" }]);
+    const B: AcePackage = { manifest: { ...pkgOf("B", { "b.txt": "b" }).manifest, dependencies: [{ name: "D", version: "2.0.0", url: "http://e/D2", package_hash: packageHash(D2) }] }, files: { "b.txt": "b" } };
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: A, url: "http://e/A" }, { pkg: B, url: "http://e/B" }]);
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B, "http://e/D1": D1, "http://e/D2": D2 }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("version-skew");
+  });
+  test("root-involving skew (root@1 -> A -> root@2) refuses (root is seeded)", async () => {
+    const root2: AcePackage = { manifest: { format_version: 1, name: "root", version: "2.0.0", content_hash: "sha256:zzz" }, files: { "r.txt": "two" } };
+    const A: AcePackage = { manifest: { ...pkgOf("A", { "a.txt": "a" }).manifest, dependencies: [{ name: "root", version: "2.0.0", url: "http://e/root2", package_hash: packageHash(root2) }] }, files: { "a.txt": "a" } };
+    const root = pkgOf("root", { "r.txt": "one" }, [{ pkg: A, url: "http://e/A" }]);
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/root2": root2 }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(["version-skew", "cycle"]).toContain(r.reason); // root is on the stack -> cycle takes precedence
+  });
+  test("root cycle (root@1 -> A -> root@1) refuses as cycle", async () => {
+    const root1Files = { "r.txt": "one" };
+    const rootPlaceholder = pkgOf("root", root1Files); // for hash only
+    const A: AcePackage = { manifest: { ...pkgOf("A", { "a.txt": "a" }).manifest, dependencies: [{ name: "root", version: "1.0.0", url: "http://e/root", package_hash: packageHash(rootPlaceholder) }] }, files: { "a.txt": "a" } };
+    const root = pkgOf("root", root1Files, [{ pkg: A, url: "http://e/A" }]);
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/root": root }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("cycle");
+  });
+});
+```
+
+- [ ] **Step 2: Run** — Run: `bun test tools/ace/resolve.test.ts`
+
+Expected: the cycle/skew logic from Task 5 + root seeding from Task 4 make these PASS. If root-skew/cycle fail, confirm Task 4 seeded `byName`+`visiting` with the root (it does).
+
+- [ ] **Step 3: (only if a test fails)** — no new code expected; the Task-4 seeding + Task-5 checks cover this. If `version-skew` detail doesn't name both requirers, confirm `byName` stores `path` (it does, Task 4).
+
+- [ ] **Step 4: Run to verify pass** — Run: `bun test tools/ace/resolve.test.ts` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/resolve.test.ts
+git commit -m "test(ace): resolve version-skew + root-seeded skew/cycle (slice 4 task 6)"
+```
+
+---
+
+## Task 7: Cycle (A->B->A)
+
+**Files:** `tools/ace/resolve.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```ts
+test("cycle A->B->A refuses with the loop in path", async () => {
+  // Build B that depends on A, and A that depends on B (mutual). Use placeholders for hashes.
+  const aFiles = { "a.txt": "a" }, bFiles = { "b.txt": "b" };
+  const aPlaceholder = pkgOf("A", aFiles);
+  const B: AcePackage = { manifest: { ...pkgOf("B", bFiles).manifest, dependencies: [{ name: "A", version: "1.0.0", url: "http://e/A", package_hash: packageHash(aPlaceholder) }] }, files: bFiles };
+  const A: AcePackage = { manifest: { ...pkgOf("A", aFiles).manifest, dependencies: [{ name: "B", version: "1.0.0", url: "http://e/B", package_hash: packageHash(B) }] }, files: aFiles };
+  const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: A, url: "http://e/A" }]);
+  const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B }), NO_TRUST, { allowNoSignature: true });
+  expect(r.ok).toBe(false);
+  if (!r.ok) { expect(r.reason).toBe("cycle"); expect(r.path).toContain("A"); }
+});
+```
+
+- [ ] **Step 2: Run** → Run: `bun test tools/ace/resolve.test.ts` → expect PASS (Task-5 cycle logic covers it).
+
+- [ ] **Step 3:** no new code expected.
+
+- [ ] **Step 4: Run** → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/resolve.test.ts
+git commit -m "test(ace): resolve A->B->A cycle (slice 4 task 7)"
+```
+
+---
+
+## Task 8: Per-node verification (slice-2 hash, pin, identity, slice-3 signature)
+
+**Files:** `tools/ace/resolve.ts` (add the verification block in `walk`, after fetch), `tools/ace/resolve.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("resolve — verification", () => {
+  test("bad-content-hash (files don't hash to manifest.content_hash) refuses", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const tampered: AcePackage = { manifest: D.manifest, files: { "d.txt": "TAMPERED" } }; // hash no longer matches
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: D, url: "http://e/D" }]); // edge pins original D
+    const r = await resolve(root, fetchOf({ "http://e/D": tampered }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("bad-content-hash");
+  });
+  test("pin-mismatch (edge package_hash != fetched) refuses", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: D, url: "http://e/D" }]);
+    // mutate the edge's package_hash to a wrong value
+    (root.manifest.dependencies as any)[0] = { ...root.manifest.dependencies![0], package_hash: "sha256:wrongwrong" };
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("pin-mismatch");
+  });
+  test("declared-identity mismatch (edge name != fetched manifest name) refuses pin-mismatch", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: D, url: "http://e/D" }]);
+    (root.manifest.dependencies as any)[0] = { ...root.manifest.dependencies![0], name: "NOT_D" }; // edge claims a different name
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("pin-mismatch");
+  });
+  test("unsigned node refuses without allowNoSignature, resolves with it", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: D, url: "http://e/D" }]);
+    const strict = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, { allowNoSignature: false });
+    expect(strict.ok).toBe(false);
+    if (!strict.ok) expect(strict.reason).toBe("no-signature");
+    const lax = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, { allowNoSignature: true });
+    expect(lax.ok).toBe(true);
+  });
+});
+```
+
+> Note on the identity-mismatch test: after changing the edge `name`, that edge no longer matches a `byName` seed, so it fetches D, whose manifest.name ("D") ≠ edge.name ("NOT_D") → `pin-mismatch` at the identity check.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test tools/ace/resolve.test.ts`
+Expected: FAIL — no verification yet (e.g. bad-content-hash resolves OK).
+
+- [ ] **Step 3: Add verification** — fix the imports at the top of `resolve.ts` (replace the placeholder import line from Task 4):
+
+```ts
+import { contentHash, type AcePackage, type LoadedTrustEntry } from "./store.ts";
+import { verifySignature } from "./signing.ts";
+```
+
+Then in `walk`, immediately AFTER the successful `JSON.parse` of `dep` and BEFORE `byName.set(...)`, insert:
+
+```ts
+      // slice-2 self-check
+      const filesHash = contentHash(new TextEncoder().encode(JSON.stringify(dep.files)));
+      if (filesHash !== dep.manifest.content_hash) {
+        return { ok: false, reason: "bad-content-hash", detail: `${edge.name}: files hash ${filesHash} != manifest ${dep.manifest.content_hash}`, path: here };
+      }
+      // pin check (whole-package identity)
+      const got = packageHash(dep);
+      if (got !== edge.package_hash) {
+        return { ok: false, reason: "pin-mismatch", detail: `${edge.name}: expected package_hash ${edge.package_hash} but fetched ${got}`, path: here };
+      }
+      // declared-identity check
+      if (dep.manifest.name !== edge.name || dep.manifest.version !== edge.version) {
+        return { ok: false, reason: "pin-mismatch", detail: `${edge.name}@${edge.version}: edge identity != fetched ${dep.manifest.name}@${dep.manifest.version}`, path: here };
+      }
+      // slice-3 signature gate
+      const v = verifySignature(dep.manifest, _trustStore);
+      if (!v.ok) {
+        if (v.reason === "no-signature") {
+          if (!_opts.allowNoSignature) return { ok: false, reason: "no-signature", detail: `${edge.name}: unsigned (use --allow-no-signature)`, path: here };
+        } else {
+          return { ok: false, reason: v.reason, detail: `${edge.name}: ${v.reason}`, path: here };
+        }
+      }
+```
+
+Rename `_trustStore`/`_opts` params to `trustStore`/`opts` (drop the underscores) now that they're used.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test tools/ace/resolve.test.ts`
+Expected: PASS (all resolver tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/resolve.ts tools/ace/resolve.test.ts
+git commit -m "feat(ace): resolve per-node hash/pin/identity/signature gates (slice 4 task 8)"
+```
+
+---
+
+## Task 9: Wire `resolve` into `ace install` (graph preflight + atomic)
+
+**Files:** `tools/ace/ace.ts` (the `install` command, ~lines 358-410), `tools/ace/ace.test.ts`
+
+- [ ] **Step 1: Write the failing tests** (append to `ace.test.ts`; it already has the temp-HOME beforeEach/afterEach + helpers — reuse them; build packages with the resolve.test helper pattern, writing each dep package to a temp file and pointing edges at `file://`-less local paths via the install `<path>` form)
+
+```ts
+import { resolve as _r, packageHash } from "./resolve.ts"; // packageHash for building edges
+
+test("e2e: install a small graph (root->A->B) installs all three, leaves first", async () => {
+  const store = mkdtempSync(join(tmpdir(), "ace-graph-"));
+  const dir = mkdtempSync(join(tmpdir(), "ace-pkgs-"));
+  const hash = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+  const B = { manifest: { format_version:1, name:"B", version:"1.0.0", content_hash: hash({ "b.txt":"b" }) }, files: { "b.txt":"b" } };
+  writeFileSync(join(dir,"B.json"), JSON.stringify(B));
+  const A = { manifest: { format_version:1, name:"A", version:"1.0.0", content_hash: hash({ "a.txt":"a" }), dependencies:[{ name:"B", version:"1.0.0", url: join(dir,"B.json"), package_hash: packageHash(B) }] }, files: { "a.txt":"a" } };
+  writeFileSync(join(dir,"A.json"), JSON.stringify(A));
+  const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: hash({ "r.txt":"r" }), dependencies:[{ name:"A", version:"1.0.0", url: join(dir,"A.json"), package_hash: packageHash(A) }] }, files: { "r.txt":"r" } };
+  writeFileSync(join(dir,"root.json"), JSON.stringify(root));
+  const code = await main(["install", join(dir,"root.json"), "--store", store, "--allow-no-signature"]);
+  expect(code).toBe(0);
+  expect(listInstalled(store).map((p)=>p.manifest.name).sort()).toEqual(["A","B","root"]);
+});
+
+test("atomic: a graph with an unsafe-path node installs NOTHING (preflight)", async () => {
+  const store = mkdtempSync(join(tmpdir(), "ace-graph-"));
+  const dir = mkdtempSync(join(tmpdir(), "ace-pkgs-"));
+  const hash = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+  const bad = { manifest: { format_version:1, name:"BAD", version:"1.0.0", content_hash: hash({ "../escape":"x" }) }, files: { "../escape":"x" } };
+  writeFileSync(join(dir,"BAD.json"), JSON.stringify(bad));
+  const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: hash({ "r.txt":"r" }), dependencies:[{ name:"BAD", version:"1.0.0", url: join(dir,"BAD.json"), package_hash: packageHash(bad) }] }, files: { "r.txt":"r" } };
+  writeFileSync(join(dir,"root.json"), JSON.stringify(root));
+  const code = await main(["install", join(dir,"root.json"), "--store", store, "--allow-no-signature"]);
+  expect(code).toBe(1);
+  expect(listInstalled(store).length).toBe(0); // nothing extracted
+});
+```
+
+> Ensure `ace.test.ts` imports `writeFileSync`, `mkdtempSync`, `createHash`, `join`, `tmpdir`, `listInstalled`, `main` (most already imported — add any missing).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test tools/ace/ace.test.ts`
+Expected: FAIL — `install` doesn't resolve graphs yet (root with deps installs only root; listInstalled has 1, not 3).
+
+- [ ] **Step 3: Wire the resolver into `install`** — in `tools/ace/ace.ts`, add imports at top:
+
+```ts
+import { resolve, packageHash } from "./resolve.ts";
+import { validatePackagePaths } from "./store.ts"; // add to the existing store import
+```
+
+In the `install` block, AFTER the root authenticity gate succeeds and BEFORE the `installPackage(parsed.storePath, pkg)` line, branch on dependencies:
+
+```ts
+    // SLICE 4: transitive graph. Leaf (no deps) falls through to the single-package path below (unchanged).
+    if (pkg.manifest.dependencies && pkg.manifest.dependencies.length > 0) {
+      const fetchPackage = async (u: string): Promise<string> =>
+        u.startsWith("http") ? await (await fetch(u)).text() : readFileSync(u, "utf8");
+      const res = await resolve(pkg, fetchPackage, loadTrustStore(), { allowNoSignature: parsed.allowNoSignature });
+      if (!res.ok) {
+        console.error(`ace: install refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`);
+        return 1;
+      }
+      // PREFLIGHT (atomic): path-safety + store-key collision across the whole graph BEFORE any extract.
+      const byStoreKey = new Map<string, string>(); // content_hash -> package_hash
+      for (const node of res.order) {
+        const unsafe = validatePackagePaths(node);
+        if (unsafe !== null) { console.error(`ace: install refused: unsafe file path in ${node.manifest.name}: ${unsafe}`); return 1; }
+        const ph = packageHash(node);
+        const prior = byStoreKey.get(node.manifest.content_hash);
+        if (prior !== undefined && prior !== ph) { console.error(`ace: install refused: store-collision — ${node.manifest.name} shares a content_hash store key with a different package`); return 1; }
+        byStoreKey.set(node.manifest.content_hash, ph);
+      }
+      // EXTRACT all, leaves first.
+      for (const node of res.order) {
+        const out = installPackage(parsed.storePath, node);
+        if (!out.ok) { console.error(`ace: install failed mid-graph: ${out.error}`); return 1; }
+      }
+      console.log(`ace: installed ${res.order.length}: ${res.order.map((p) => `${p.manifest.name}@${p.manifest.version}`).join(", ")}`);
+      return 0;
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test tools/ace/ace.test.ts`
+Expected: PASS (graph install installs 3; unsafe-path graph installs 0).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/ace.ts tools/ace/ace.test.ts
+git commit -m "feat(ace): wire resolver into install — graph preflight + atomic (slice 4 task 9)"
+```
+
+---
+
+## Task 10: store-collision e2e test + SKILL.md docs
+
+**Files:** `tools/ace/ace.test.ts`, `.claude/skills/ace/SKILL.md`
+
+- [ ] **Step 1: Write the store-collision test**
+
+```ts
+test("store-collision: two distinct packages with identical files install NOTHING", async () => {
+  const store = mkdtempSync(join(tmpdir(), "ace-graph-"));
+  const dir = mkdtempSync(join(tmpdir(), "ace-pkgs-"));
+  const hash = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+  const sharedFiles = { "same.txt": "identical" };
+  const X = { manifest: { format_version:1, name:"X", version:"1.0.0", content_hash: hash(sharedFiles) }, files: sharedFiles };
+  const Y = { manifest: { format_version:1, name:"Y", version:"1.0.0", content_hash: hash(sharedFiles) }, files: sharedFiles }; // same content_hash, diff name => diff package_hash
+  writeFileSync(join(dir,"X.json"), JSON.stringify(X));
+  writeFileSync(join(dir,"Y.json"), JSON.stringify(Y));
+  const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: hash({ "r.txt":"r" }), dependencies:[
+    { name:"X", version:"1.0.0", url: join(dir,"X.json"), package_hash: packageHash(X) },
+    { name:"Y", version:"1.0.0", url: join(dir,"Y.json"), package_hash: packageHash(Y) },
+  ] }, files: { "r.txt":"r" } };
+  writeFileSync(join(dir,"root.json"), JSON.stringify(root));
+  const code = await main(["install", join(dir,"root.json"), "--store", store, "--allow-no-signature"]);
+  expect(code).toBe(1);
+  expect(listInstalled(store).length).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run** → Run: `bun test tools/ace/ace.test.ts` → expect PASS (Task-9 preflight store-collision check covers it).
+
+- [ ] **Step 3: Update `.claude/skills/ace/SKILL.md`** — in the `install` row + the paragraph below the verb table, document transitive resolution. Replace the install-row description and add a sentence:
+
+In the verb table, the `install` row becomes:
+
+```
+| `install` | `bun tools/ace/ace.ts install <url-or-path> [--allow-no-signature]` | Resolve the transitive dependency graph, verify integrity + authenticity of every node, install leaves-first (atomic) |
+```
+
+Add after the existing "install verifies integrity AND authenticity" paragraph:
+
+```markdown
+For a manifest with `dependencies` (inline-URL: `{name, version, url, package_hash}`),
+`install` resolves the full transitive graph and installs every node leaves-first.
+Resolution is atomic: it verifies the whole graph (slice-2 hash + slice-3 signature
+per node, identity-pinned by `package_hash`) and preflights path-safety + store-key
+uniqueness BEFORE extracting anything — any failure installs nothing. Refusal reasons:
+`version-skew`, `tamper`, `pin-mismatch`, `bad-content-hash`, `bad-signature`,
+`untrusted-key`, `unsupported-algo`, `no-signature`, `cycle`, `fetch-failed`,
+`invalid-package`, `store-collision`. `--allow-no-signature` applies graph-wide
+(permits only genuinely-unsigned nodes; a bad/untrusted signature on any node always refuses).
+```
+
+- [ ] **Step 4: Run the full suite + build**
+
+Run: `bun test tools/ace/` (expect all green — 76 prior + the new slice-4 tests)
+Run: `git ls-tree HEAD | wc -l` (expect 67)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/ace.test.ts .claude/skills/ace/SKILL.md
+git commit -m "feat(ace): store-collision e2e test + SKILL transitive-install docs (slice 4 task 10)"
+```
+
+---
+
+## Final: open the PR
+
+After all tasks pass + the plan doc is committed:
+
+```bash
+git push -u origin otto-windows/ace-slice4-impl-2026-06-01
+gh pr create --head otto-windows/ace-slice4-impl-2026-06-01 --base main \
+  --title "feat(ace): slice 4 — inline-URL transitive dependency resolution (B-0288)" --body "<summary>"
+gh pr merge <N> --auto --squash
+```
+
+Then run the standard PR-gate loop (`bun tools/github/poll-pr-gate.ts <N>`): address review threads (verify-before-fix), keep the canary at 67, resolve threads, land on green.
+
+---
+
+## Self-Review
+
+**Spec coverage:** D1 inline-URL (Task 1 manifest field) · D2 transitive (Task 4 recursion) · D3 version-skew (Task 6) · D4 tamper (Task 5/6) · D5 diamond dedup (Task 5) · D6 atomic + preflight (Task 9) · D7 no lockfile (nothing to build) · D8 signature policy graph-wide (Task 8 + Task 9 `allowNoSignature` threaded through) · packageHash (Task 3) · validatePackagePaths factor (Task 2) · store-collision (Task 9/10) · resolved-set output (Task 9) · all 16 resolver test cases + 4 ace.test cases (Tasks 4-10) · SKILL docs (Task 10). No gaps.
+
+**Placeholder scan:** the only intentional stand-in is the Task-4 `verifyHelpersPlaceholder` import line, explicitly flagged to delete + replaced with real imports in Task 8. No other TBD/TODO.
+
+**Type consistency:** `resolve(root, fetchPackage, trustStore, {allowNoSignature})` signature consistent across Tasks 4/8/9. `packageHash(pkg)` consistent (Tasks 3/5/8/9/10). `validatePackagePaths(pkg): string|null` consistent (Tasks 2/9). `ResolveReason` union matches the per-node returns in Task 8 + the spec. `byName` value `{version, pkgHash, path}` consistent (Tasks 4/5/6/8). `verifySignature(manifest, trustStore)` matches the existing `ace.ts` call signature.

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -591,6 +591,19 @@ describe("main", () => {
     expect(listInstalled(store).length).toBe(0);
   });
 
+  test("atomic: a graph whose ROOT has a bad content_hash installs NOTHING", async () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-graph-"));
+    const dir = mkdtempSync(join(tmpdir(), "ace-pkgs-"));
+    const h = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+    const B = { manifest: { format_version:1, name:"B", version:"1.0.0", content_hash: h({ "b.txt":"b" }) }, files: { "b.txt":"b" } };
+    writeFileSync(join(dir,"B.json"), JSON.stringify(B));
+    const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: "sha256:deadbeef", dependencies:[{ name:"B", version:"1.0.0", url: join(dir,"B.json"), package_hash: packageHash(B as any) }] }, files: { "r.txt":"r" } };
+    writeFileSync(join(dir,"root.json"), JSON.stringify(root));
+    const code = await main(["install", join(dir,"root.json"), "--store", store, "--allow-no-signature"]);
+    expect(code).toBe(1);
+    expect(listInstalled(store).length).toBe(0);
+  });
+
   test("store-collision: two distinct packages with identical files install NOTHING", async () => {
     const store = mkdtempSync(join(tmpdir(), "ace-graph-"));
     const dir = mkdtempSync(join(tmpdir(), "ace-pkgs-"));

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -6,6 +6,7 @@ import { generateKeyPairSync, createHash } from "node:crypto";
 import { parseArgs, main } from "./ace.ts";
 import { listInstalled, contentHash, listTrustedKeys } from "./store.ts";
 import { generateKeypair, signManifest } from "./signing.ts";
+import { packageHash } from "./resolve.ts";
 
 // ---- Trust-path isolation: redirect ~/.ace to a temp dir in every test ----
 let savedHome: string | undefined;
@@ -558,5 +559,35 @@ describe("main", () => {
     // --allow-no-signature must NOT override algorithm-confusion
     const code = await main(["install", tamperedPath, "--allow-no-signature", "--store", store]);
     expect(code).toBe(1);
+  });
+
+  // ---- slice 4: graph install ----
+
+  test("e2e: install a small graph (root->A->B) installs all three", async () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-graph-"));
+    const dir = mkdtempSync(join(tmpdir(), "ace-pkgs-"));
+    const h = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+    const B = { manifest: { format_version:1, name:"B", version:"1.0.0", content_hash: h({ "b.txt":"b" }) }, files: { "b.txt":"b" } };
+    writeFileSync(join(dir,"B.json"), JSON.stringify(B));
+    const A = { manifest: { format_version:1, name:"A", version:"1.0.0", content_hash: h({ "a.txt":"a" }), dependencies:[{ name:"B", version:"1.0.0", url: join(dir,"B.json"), package_hash: packageHash(B as any) }] }, files: { "a.txt":"a" } };
+    writeFileSync(join(dir,"A.json"), JSON.stringify(A));
+    const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: h({ "r.txt":"r" }), dependencies:[{ name:"A", version:"1.0.0", url: join(dir,"A.json"), package_hash: packageHash(A as any) }] }, files: { "r.txt":"r" } };
+    writeFileSync(join(dir,"root.json"), JSON.stringify(root));
+    const code = await main(["install", join(dir,"root.json"), "--store", store, "--allow-no-signature"]);
+    expect(code).toBe(0);
+    expect(listInstalled(store).map((p)=>p.manifest.name).sort()).toEqual(["A","B","root"]);
+  });
+
+  test("atomic: a graph with an unsafe-path node installs NOTHING (preflight)", async () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-graph-"));
+    const dir = mkdtempSync(join(tmpdir(), "ace-pkgs-"));
+    const h = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+    const bad = { manifest: { format_version:1, name:"BAD", version:"1.0.0", content_hash: h({ "../escape":"x" }) }, files: { "../escape":"x" } };
+    writeFileSync(join(dir,"BAD.json"), JSON.stringify(bad));
+    const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: h({ "r.txt":"r" }), dependencies:[{ name:"BAD", version:"1.0.0", url: join(dir,"BAD.json"), package_hash: packageHash(bad as any) }] }, files: { "r.txt":"r" } };
+    writeFileSync(join(dir,"root.json"), JSON.stringify(root));
+    const code = await main(["install", join(dir,"root.json"), "--store", store, "--allow-no-signature"]);
+    expect(code).toBe(1);
+    expect(listInstalled(store).length).toBe(0);
   });
 });

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -590,4 +590,23 @@ describe("main", () => {
     expect(code).toBe(1);
     expect(listInstalled(store).length).toBe(0);
   });
+
+  test("store-collision: two distinct packages with identical files install NOTHING", async () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-graph-"));
+    const dir = mkdtempSync(join(tmpdir(), "ace-pkgs-"));
+    const h = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+    const sharedFiles = { "same.txt": "identical" };
+    const X = { manifest: { format_version:1, name:"X", version:"1.0.0", content_hash: h(sharedFiles) }, files: sharedFiles };
+    const Y = { manifest: { format_version:1, name:"Y", version:"1.0.0", content_hash: h(sharedFiles) }, files: sharedFiles };
+    writeFileSync(join(dir,"X.json"), JSON.stringify(X));
+    writeFileSync(join(dir,"Y.json"), JSON.stringify(Y));
+    const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: h({ "r.txt":"r" }), dependencies:[
+      { name:"X", version:"1.0.0", url: join(dir,"X.json"), package_hash: packageHash(X as any) },
+      { name:"Y", version:"1.0.0", url: join(dir,"Y.json"), package_hash: packageHash(Y as any) },
+    ] }, files: { "r.txt":"r" } };
+    writeFileSync(join(dir,"root.json"), JSON.stringify(root));
+    const code = await main(["install", join(dir,"root.json"), "--store", store, "--allow-no-signature"]);
+    expect(code).toBe(1);
+    expect(listInstalled(store).length).toBe(0);
+  });
 });

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -16,10 +16,11 @@ import { chmodSync, readFileSync, writeFileSync } from "node:fs";
 import { createPublicKey } from "node:crypto";
 import {
   defaultStorePath, listInstalled, installPackage, contentHash,
-  loadTrustStore, addTrustedKey, listTrustedKeys,
+  loadTrustStore, addTrustedKey, listTrustedKeys, validatePackagePaths,
   type AcePackage,
 } from "./store";
 import { generateKeypair, signManifest, verifySignature, keyId } from "./signing";
+import { resolve, packageHash } from "./resolve.ts";
 
 interface ListArgs {
   readonly command: "list";
@@ -394,6 +395,34 @@ export async function main(argv: readonly string[]): Promise<number> {
         return 1;
       }
       console.error("ace: WARNING: installing UNSIGNED package (--allow-no-signature).");
+    }
+
+    // SLICE 4: transitive graph. Leaf (no deps) falls through to the single-package path below (unchanged).
+    if (pkg.manifest.dependencies && pkg.manifest.dependencies.length > 0) {
+      const fetchPackage = async (u: string): Promise<string> =>
+        u.startsWith("http") ? await (await fetch(u)).text() : readFileSync(u, "utf8");
+      const res = await resolve(pkg, fetchPackage, loadTrustStore(), { allowNoSignature: parsed.allowNoSignature });
+      if (!res.ok) {
+        console.error(`ace: install refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`);
+        return 1;
+      }
+      // PREFLIGHT (atomic): path-safety + store-key collision across the whole graph BEFORE any extract.
+      const byStoreKey = new Map<string, string>(); // content_hash -> package_hash
+      for (const node of res.order) {
+        const unsafe = validatePackagePaths(node);
+        if (unsafe !== null) { console.error(`ace: install refused: unsafe file path in ${node.manifest.name}: ${unsafe}`); return 1; }
+        const ph = packageHash(node);
+        const prior = byStoreKey.get(node.manifest.content_hash);
+        if (prior !== undefined && prior !== ph) { console.error(`ace: install refused: store-collision — ${node.manifest.name} shares a content_hash store key with a different package`); return 1; }
+        byStoreKey.set(node.manifest.content_hash, ph);
+      }
+      // EXTRACT all, leaves first.
+      for (const node of res.order) {
+        const out = installPackage(parsed.storePath, node);
+        if (!out.ok) { console.error(`ace: install failed mid-graph: ${out.error}`); return 1; }
+      }
+      console.log(`ace: installed ${res.order.length}: ${res.order.map((p) => `${p.manifest.name}@${p.manifest.version}`).join(", ")}`);
+      return 0;
     }
 
     // INTEGRITY + extract (slice 2, unchanged)

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -406,9 +406,15 @@ export async function main(argv: readonly string[]): Promise<number> {
         console.error(`ace: install refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`);
         return 1;
       }
-      // PREFLIGHT (atomic): path-safety + store-key collision across the whole graph BEFORE any extract.
+      // PREFLIGHT (atomic): integrity + path-safety + store-key collision across the whole
+      // graph BEFORE any extract. content_hash is verified first (including the root, which
+      // the resolver does not re-check) so a tampered root cannot orphan already-extracted
+      // leaves.
       const byStoreKey = new Map<string, string>(); // content_hash -> package_hash
       for (const node of res.order) {
+        // D6 atomicity: verify every node's content_hash before any extraction (incl. root).
+        const fh = contentHash(new TextEncoder().encode(JSON.stringify(node.files)));
+        if (fh !== node.manifest.content_hash) { console.error(`ace: install refused: bad-content-hash in ${node.manifest.name}`); return 1; }
         const unsafe = validatePackagePaths(node);
         if (unsafe !== null) { console.error(`ace: install refused: unsafe file path in ${node.manifest.name}: ${unsafe}`); return 1; }
         const ph = packageHash(node);

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -359,7 +359,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   if (parsed.command === "install") {
     let raw: string;
     try {
-      raw = parsed.source.startsWith("http")
+      raw = parsed.source.startsWith("http://") || parsed.source.startsWith("https://")
         ? await (await fetch(parsed.source)).text()
         : readFileSync(parsed.source, "utf8");
     } catch (e) {
@@ -399,8 +399,14 @@ export async function main(argv: readonly string[]): Promise<number> {
 
     // SLICE 4: transitive graph. Leaf (no deps) falls through to the single-package path below (unchanged).
     if (pkg.manifest.dependencies && pkg.manifest.dependencies.length > 0) {
+      // Verify root content_hash BEFORE resolving (no wasted graph fetch on a bad root).
+      const rootFilesHash = contentHash(new TextEncoder().encode(JSON.stringify(pkg.files)));
+      if (rootFilesHash !== pkg.manifest.content_hash) {
+        console.error(`ace: install refused: bad-content-hash in ${pkg.manifest.name} (root)`);
+        return 1;
+      }
       const fetchPackage = async (u: string): Promise<string> =>
-        u.startsWith("http") ? await (await fetch(u)).text() : readFileSync(u, "utf8");
+        (u.startsWith("http://") || u.startsWith("https://")) ? await (await fetch(u)).text() : readFileSync(u, "utf8");
       const res = await resolve(pkg, fetchPackage, loadTrustStore(), { allowNoSignature: parsed.allowNoSignature });
       if (!res.ok) {
         console.error(`ace: install refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`);
@@ -456,7 +462,7 @@ export async function main(argv: readonly string[]): Promise<number> {
 
 if (import.meta.main) {
   // .catch() closes the unhandled-promise surface from the async main(): an unexpected throw
-  // inside an await exits 1 with a diagnostic instead of an UnhandledPromiseRejection.
+  // inside an async main() exits 1 with a diagnostic instead of an UnhandledPromiseRejection.
   main(process.argv.slice(2))
     .then((c) => process.exit(c))
     .catch((e) => {

--- a/tools/ace/resolve.test.ts
+++ b/tools/ace/resolve.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { packageHash } from "./resolve.ts";
+import type { AcePackage } from "./store.ts";
+
+const mk = (name: string): AcePackage => ({
+  manifest: { format_version: 1, name, version: "1.0.0", content_hash: "sha256:aaa" },
+  files: { "a.txt": "x" },
+});
+
+describe("packageHash", () => {
+  test("stable under key reordering (canonical)", () => {
+    const a: AcePackage = { manifest: { format_version: 1, name: "n", version: "1", content_hash: "h" }, files: { a: "1", b: "2" } };
+    const b: AcePackage = { manifest: { content_hash: "h", version: "1", name: "n", format_version: 1 }, files: { b: "2", a: "1" } } as AcePackage;
+    expect(packageHash(a)).toBe(packageHash(b));
+  });
+  test("differs when manifest differs even if files identical", () => {
+    expect(packageHash(mk("A"))).not.toBe(packageHash(mk("B")));
+  });
+  test("differs when files differ", () => {
+    const base = mk("A");
+    const other: AcePackage = { manifest: base.manifest, files: { "a.txt": "DIFFERENT" } };
+    expect(packageHash(base)).not.toBe(packageHash(other));
+  });
+});

--- a/tools/ace/resolve.test.ts
+++ b/tools/ace/resolve.test.ts
@@ -156,4 +156,22 @@ describe("resolve — verification", () => {
     const lax = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, { allowNoSignature: true });
     expect(lax.ok).toBe(true);
   });
+  test("untrusted/bad signature refuses even with allowNoSignature:true", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const signed: AcePackage = { manifest: { ...D.manifest, signature: { algo: "ed25519", key_id: "ed25519:unknownkey", sig: "AAAA" } }, files: D.files };
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: signed, url: "http://e/D" }]);
+    const r = await resolve(root, fetchOf({ "http://e/D": signed }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(["untrusted-key", "bad-signature"]).toContain(r.reason);
+  });
+});
+
+describe("resolve — invalid package", () => {
+  test("dep JSON that is parseable but not an AcePackage refuses invalid-package (no throw)", async () => {
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: pkgOf("D", { "d.txt": "d" }), url: "http://e/D" }]);
+    const badFetch: FetchPackage = async () => JSON.stringify({ foo: 1 }); // valid JSON, not an AcePackage
+    const r = await resolve(root, badFetch, NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("invalid-package");
+  });
 });

--- a/tools/ace/resolve.test.ts
+++ b/tools/ace/resolve.test.ts
@@ -60,3 +60,24 @@ describe("resolve — basic", () => {
     if (r.ok) expect(r.order.map((p) => p.manifest.name)).toEqual(["B", "A", "root"]);
   });
 });
+
+describe("resolve — dedup", () => {
+  test("diamond (root->A->D, root->B->D, same D) installs D once", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const A = pkgOf("A", { "a.txt": "a" }, [{ pkg: D, url: "http://e/D" }]);
+    const B = pkgOf("B", { "b.txt": "b" }, [{ pkg: D, url: "http://e/D" }]);
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: A, url: "http://e/A" }, { pkg: B, url: "http://e/B" }]);
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B, "http://e/D": D }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.order.filter((p) => p.manifest.name === "D").length).toBe(1);
+  });
+  test("distinct packages with identical files (different names) both resolve", async () => {
+    const files = { "same.txt": "identical" };
+    const X = pkgOf("X", files);
+    const Y = pkgOf("Y", files); // same files, different name => different package_hash
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: X, url: "http://e/X" }, { pkg: Y, url: "http://e/Y" }]);
+    const r = await resolve(root, fetchOf({ "http://e/X": X, "http://e/Y": Y }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.order.map((p) => p.manifest.name).sort()).toEqual(["X", "Y", "root"]);
+  });
+});

--- a/tools/ace/resolve.test.ts
+++ b/tools/ace/resolve.test.ts
@@ -110,4 +110,14 @@ describe("resolve — conflicts", () => {
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("cycle");
   });
+  test("cycle A->B->A refuses with the loop in path", async () => {
+    const aFiles = { "a.txt": "a" }, bFiles = { "b.txt": "b" };
+    const aPlaceholder = pkgOf("A", aFiles);
+    const B: AcePackage = { manifest: { ...pkgOf("B", bFiles).manifest, dependencies: [{ name: "A", version: "1.0.0", url: "http://e/A", package_hash: packageHash(aPlaceholder) }] }, files: bFiles };
+    const A: AcePackage = { manifest: { ...pkgOf("A", aFiles).manifest, dependencies: [{ name: "B", version: "1.0.0", url: "http://e/B", package_hash: packageHash(B) }] }, files: aFiles };
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: A, url: "http://e/A" }]);
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) { expect(r.reason).toBe("cycle"); expect(r.path).toContain("A"); }
+  });
 });

--- a/tools/ace/resolve.test.ts
+++ b/tools/ace/resolve.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { packageHash } from "./resolve.ts";
+import { packageHash, resolve, type FetchPackage } from "./resolve.ts";
 import type { AcePackage } from "./store.ts";
+import { contentHash } from "./store.ts";
 
 const mk = (name: string): AcePackage => ({
   manifest: { format_version: 1, name, version: "1.0.0", content_hash: "sha256:aaa" },
@@ -20,5 +21,42 @@ describe("packageHash", () => {
     const base = mk("A");
     const other: AcePackage = { manifest: base.manifest, files: { "a.txt": "DIFFERENT" } };
     expect(packageHash(base)).not.toBe(packageHash(other));
+  });
+});
+
+// --- slice-4 resolve test helpers ---
+// Build a package; children are already-built {pkg, url} whose edges this package will declare.
+function pkgOf(name: string, files: Record<string, string>, children: { pkg: AcePackage; url: string }[] = []): AcePackage {
+  return {
+    manifest: {
+      format_version: 1, name, version: "1.0.0",
+      content_hash: contentHash(new TextEncoder().encode(JSON.stringify(files))),
+      dependencies: children.map((c) => ({
+        name: c.pkg.manifest.name, version: c.pkg.manifest.version, url: c.url, package_hash: packageHash(c.pkg),
+      })),
+    },
+    files,
+  };
+}
+// Injected fetch over a {url: package} map.
+function fetchOf(map: Record<string, AcePackage>): FetchPackage {
+  return async (url: string) => { const p = map[url]; if (!p) throw new Error("404 " + url); return JSON.stringify(p); };
+}
+const NO_TRUST = new Map(); // empty trust store; basic tests pass allowNoSignature:true
+
+describe("resolve — basic", () => {
+  test("leaf package (no deps) resolves to [root]", async () => {
+    const root = pkgOf("root", { "r.txt": "x" });
+    const r = await resolve(root, fetchOf({}), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.order.map((p) => p.manifest.name)).toEqual(["root"]);
+  });
+  test("linear chain root->A->B installs leaves-first [B, A, root]", async () => {
+    const B = pkgOf("B", { "b.txt": "b" });
+    const A = pkgOf("A", { "a.txt": "a" }, [{ pkg: B, url: "http://e/B" }]);
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: A, url: "http://e/A" }]);
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.order.map((p) => p.manifest.name)).toEqual(["B", "A", "root"]);
   });
 });

--- a/tools/ace/resolve.test.ts
+++ b/tools/ace/resolve.test.ts
@@ -174,4 +174,14 @@ describe("resolve — invalid package", () => {
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("invalid-package");
   });
+  test("dep with non-array dependencies refuses invalid-package (no throw)", async () => {
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: pkgOf("D", { "d.txt": "d" }), url: "http://e/D" }]);
+    const D = pkgOf("D", { "d.txt": "d" });
+    const badDep: any = { manifest: { ...D.manifest, dependencies: {} }, files: D.files }; // dependencies present but not an array
+    // point the root edge's package_hash at badDep so it passes the pin check and reaches the dependencies access
+    (root.manifest.dependencies as any)[0] = { name: "D", version: "1.0.0", url: "http://e/D", package_hash: packageHash(badDep) };
+    const r = await resolve(root, fetchOf({ "http://e/D": badDep }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("invalid-package");
+  });
 });

--- a/tools/ace/resolve.test.ts
+++ b/tools/ace/resolve.test.ts
@@ -81,3 +81,33 @@ describe("resolve — dedup", () => {
     if (r.ok) expect(r.order.map((p) => p.manifest.name).sort()).toEqual(["X", "Y", "root"]);
   });
 });
+
+describe("resolve — conflicts", () => {
+  test("version-skew (A->D@1.0, B->D@2.0) refuses", async () => {
+    const D1 = pkgOf("D", { "d.txt": "d1" });
+    const D2: AcePackage = { manifest: { ...D1.manifest, version: "2.0.0" }, files: { "d.txt": "d2" } };
+    const A = pkgOf("A", { "a.txt": "a" }, [{ pkg: D1, url: "http://e/D1" }]);
+    const B: AcePackage = { manifest: { ...pkgOf("B", { "b.txt": "b" }).manifest, dependencies: [{ name: "D", version: "2.0.0", url: "http://e/D2", package_hash: packageHash(D2) }] }, files: { "b.txt": "b" } };
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: A, url: "http://e/A" }, { pkg: B, url: "http://e/B" }]);
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B, "http://e/D1": D1, "http://e/D2": D2 }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("version-skew");
+  });
+  test("root-involving skew (root@1 -> A -> root@2) refuses (root seeded)", async () => {
+    const root2: AcePackage = { manifest: { format_version: 1, name: "root", version: "2.0.0", content_hash: "sha256:zzz" }, files: { "r.txt": "two" } };
+    const A: AcePackage = { manifest: { ...pkgOf("A", { "a.txt": "a" }).manifest, dependencies: [{ name: "root", version: "2.0.0", url: "http://e/root2", package_hash: packageHash(root2) }] }, files: { "a.txt": "a" } };
+    const root = pkgOf("root", { "r.txt": "one" }, [{ pkg: A, url: "http://e/A" }]);
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/root2": root2 }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(["version-skew", "cycle"]).toContain(r.reason);
+  });
+  test("root cycle (root@1 -> A -> root@1) refuses as cycle", async () => {
+    const root1Files = { "r.txt": "one" };
+    const rootPlaceholder = pkgOf("root", root1Files);
+    const A: AcePackage = { manifest: { ...pkgOf("A", { "a.txt": "a" }).manifest, dependencies: [{ name: "root", version: "1.0.0", url: "http://e/root", package_hash: packageHash(rootPlaceholder) }] }, files: { "a.txt": "a" } };
+    const root = pkgOf("root", root1Files, [{ pkg: A, url: "http://e/A" }]);
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/root": root }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("cycle");
+  });
+});

--- a/tools/ace/resolve.test.ts
+++ b/tools/ace/resolve.test.ts
@@ -121,3 +121,39 @@ describe("resolve — conflicts", () => {
     if (!r.ok) { expect(r.reason).toBe("cycle"); expect(r.path).toContain("A"); }
   });
 });
+
+describe("resolve — verification", () => {
+  test("bad-content-hash (files don't hash to manifest.content_hash) refuses", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const tampered: AcePackage = { manifest: D.manifest, files: { "d.txt": "TAMPERED" } };
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: D, url: "http://e/D" }]); // edge pins original D
+    const r = await resolve(root, fetchOf({ "http://e/D": tampered }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("bad-content-hash");
+  });
+  test("pin-mismatch (edge package_hash != fetched) refuses", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: D, url: "http://e/D" }]);
+    (root.manifest.dependencies as any)[0] = { ...root.manifest.dependencies![0], package_hash: "sha256:wrongwrong" };
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("pin-mismatch");
+  });
+  test("declared-identity mismatch (edge name != fetched manifest name) refuses pin-mismatch", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: D, url: "http://e/D" }]);
+    (root.manifest.dependencies as any)[0] = { ...root.manifest.dependencies![0], name: "NOT_D" };
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("pin-mismatch");
+  });
+  test("unsigned node refuses without allowNoSignature, resolves with it", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: D, url: "http://e/D" }]);
+    const strict = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, { allowNoSignature: false });
+    expect(strict.ok).toBe(false);
+    if (!strict.ok) expect(strict.reason).toBe("no-signature");
+    const lax = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, { allowNoSignature: true });
+    expect(lax.ok).toBe(true);
+  });
+});

--- a/tools/ace/resolve.ts
+++ b/tools/ace/resolve.ts
@@ -44,6 +44,8 @@ export async function resolve(
   const walk = async (node: AcePackage, path: string[]): Promise<ResolveResult | null> => {
     for (const edge of node.manifest.dependencies ?? []) {
       const here = [...path, edge.name];
+      // NB: the root is seeded into `visiting`, so a root-involving skew (root@1 -> A -> root@2)
+      // trips this cycle check before the version-skew check below — both refuse + install nothing.
       if (visiting.has(edge.name)) {
         return { ok: false, reason: "cycle", detail: here.join(" → "), path: here };
       }
@@ -60,6 +62,11 @@ export async function resolve(
       let dep: AcePackage;
       try { dep = JSON.parse(await fetchPackage(edge.url)) as AcePackage; }
       catch (e) { return { ok: false, reason: "fetch-failed", detail: `${edge.url}: ${(e as Error).message}`, path: here }; }
+      // Shape guard: verify the parsed JSON is a well-formed AcePackage before any field access.
+      const m = (dep as { manifest?: unknown; files?: unknown });
+      if (typeof dep !== "object" || dep === null || typeof m.manifest !== "object" || m.manifest === null || typeof m.files !== "object" || m.files === null) {
+        return { ok: false, reason: "invalid-package", detail: `${edge.url}: not a well-formed AcePackage`, path: here };
+      }
       // slice-2 self-check
       const filesHash = contentHash(new TextEncoder().encode(JSON.stringify(dep.files)));
       if (filesHash !== dep.manifest.content_hash) {

--- a/tools/ace/resolve.ts
+++ b/tools/ace/resolve.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import type { AcePackage } from "./store.ts";
+import type { AcePackage, LoadedTrustEntry } from "./store.ts";
 
 /** Deterministic JSON: object keys recursively sorted; arrays preserve order. */
 function canonicalJson(value: unknown): string {
@@ -14,4 +14,50 @@ function canonicalJson(value: unknown): string {
  *  pin / identity for a dependency. Two edges sharing a packageHash are byte-identical. */
 export function packageHash(pkg: AcePackage): string {
   return "sha256:" + createHash("sha256").update(canonicalJson({ manifest: pkg.manifest, files: pkg.files })).digest("hex");
+}
+
+export type FetchPackage = (urlOrPath: string) => Promise<string>;
+
+export type ResolveReason =
+  | "version-skew" | "tamper" | "pin-mismatch" | "bad-content-hash"
+  | "bad-signature" | "untrusted-key" | "unsupported-algo" | "no-signature"
+  | "cycle" | "fetch-failed" | "invalid-package";
+
+export type ResolveResult =
+  | { ok: true; order: AcePackage[] }
+  | { ok: false; reason: ResolveReason; detail: string; path: string[] };
+
+export async function resolve(
+  root: AcePackage,
+  fetchPackage: FetchPackage,
+  _trustStore: Map<string, LoadedTrustEntry>,
+  _opts: { allowNoSignature: boolean },
+): Promise<ResolveResult> {
+  const byName = new Map<string, { version: string; pkgHash: string; path: string[] }>();
+  const visiting = new Set<string>();
+  const order: AcePackage[] = [];
+
+  byName.set(root.manifest.name, { version: root.manifest.version, pkgHash: packageHash(root), path: ["root"] });
+  visiting.add(root.manifest.name);
+
+  const walk = async (node: AcePackage, path: string[]): Promise<ResolveResult | null> => {
+    for (const edge of node.manifest.dependencies ?? []) {
+      const here = [...path, edge.name];
+      let dep: AcePackage;
+      try { dep = JSON.parse(await fetchPackage(edge.url)) as AcePackage; }
+      catch (e) { return { ok: false, reason: "fetch-failed", detail: `${edge.url}: ${(e as Error).message}`, path: here }; }
+      byName.set(edge.name, { version: edge.version, pkgHash: edge.package_hash, path: here });
+      visiting.add(edge.name);
+      const sub = await walk(dep, here);
+      if (sub) return sub;
+      visiting.delete(edge.name);
+      order.push(dep);
+    }
+    return null;
+  };
+
+  const failure = await walk(root, ["root"]);
+  if (failure) return failure;
+  order.push(root);
+  return { ok: true, order };
 }

--- a/tools/ace/resolve.ts
+++ b/tools/ace/resolve.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import type { AcePackage, LoadedTrustEntry } from "./store.ts";
+import { contentHash, type AcePackage, type LoadedTrustEntry } from "./store.ts";
+import { verifySignature } from "./signing.ts";
 
 /** Deterministic JSON: object keys recursively sorted; arrays preserve order. */
 function canonicalJson(value: unknown): string {
@@ -30,8 +31,8 @@ export type ResolveResult =
 export async function resolve(
   root: AcePackage,
   fetchPackage: FetchPackage,
-  _trustStore: Map<string, LoadedTrustEntry>,
-  _opts: { allowNoSignature: boolean },
+  trustStore: Map<string, LoadedTrustEntry>,
+  opts: { allowNoSignature: boolean },
 ): Promise<ResolveResult> {
   const byName = new Map<string, { version: string; pkgHash: string; path: string[] }>();
   const visiting = new Set<string>();
@@ -59,6 +60,29 @@ export async function resolve(
       let dep: AcePackage;
       try { dep = JSON.parse(await fetchPackage(edge.url)) as AcePackage; }
       catch (e) { return { ok: false, reason: "fetch-failed", detail: `${edge.url}: ${(e as Error).message}`, path: here }; }
+      // slice-2 self-check
+      const filesHash = contentHash(new TextEncoder().encode(JSON.stringify(dep.files)));
+      if (filesHash !== dep.manifest.content_hash) {
+        return { ok: false, reason: "bad-content-hash", detail: `${edge.name}: files hash ${filesHash} != manifest ${dep.manifest.content_hash}`, path: here };
+      }
+      // pin check (whole-package identity)
+      const got = packageHash(dep);
+      if (got !== edge.package_hash) {
+        return { ok: false, reason: "pin-mismatch", detail: `${edge.name}: expected package_hash ${edge.package_hash} but fetched ${got}`, path: here };
+      }
+      // declared-identity check
+      if (dep.manifest.name !== edge.name || dep.manifest.version !== edge.version) {
+        return { ok: false, reason: "pin-mismatch", detail: `${edge.name}@${edge.version}: edge identity != fetched ${dep.manifest.name}@${dep.manifest.version}`, path: here };
+      }
+      // slice-3 signature gate
+      const v = verifySignature(dep.manifest, trustStore);
+      if (!v.ok) {
+        if (v.reason === "no-signature") {
+          if (!opts.allowNoSignature) return { ok: false, reason: "no-signature", detail: `${edge.name}: unsigned (use --allow-no-signature)`, path: here };
+        } else {
+          return { ok: false, reason: v.reason, detail: `${edge.name}: ${v.reason}`, path: here };
+        }
+      }
       byName.set(edge.name, { version: edge.version, pkgHash: edge.package_hash, path: here });
       visiting.add(edge.name);
       const sub = await walk(dep, here);

--- a/tools/ace/resolve.ts
+++ b/tools/ace/resolve.ts
@@ -43,6 +43,19 @@ export async function resolve(
   const walk = async (node: AcePackage, path: string[]): Promise<ResolveResult | null> => {
     for (const edge of node.manifest.dependencies ?? []) {
       const here = [...path, edge.name];
+      if (visiting.has(edge.name)) {
+        return { ok: false, reason: "cycle", detail: here.join(" → "), path: here };
+      }
+      const seen = byName.get(edge.name);
+      if (seen) {
+        if (seen.version !== edge.version) {
+          return { ok: false, reason: "version-skew", detail: `${edge.name} required at ${seen.version} (via ${seen.path.join(" → ")}) and ${edge.version} (via ${here.join(" → ")})`, path: here };
+        }
+        if (seen.pkgHash !== edge.package_hash) {
+          return { ok: false, reason: "tamper", detail: `${edge.name}@${edge.version} has two different package hashes`, path: here };
+        }
+        continue; // diamond dedup: same name+version+package_hash, already resolved
+      }
       let dep: AcePackage;
       try { dep = JSON.parse(await fetchPackage(edge.url)) as AcePackage; }
       catch (e) { return { ok: false, reason: "fetch-failed", detail: `${edge.url}: ${(e as Error).message}`, path: here }; }

--- a/tools/ace/resolve.ts
+++ b/tools/ace/resolve.ts
@@ -42,7 +42,7 @@ export async function resolve(
   visiting.add(root.manifest.name);
 
   const walk = async (node: AcePackage, path: string[]): Promise<ResolveResult | null> => {
-    for (const edge of node.manifest.dependencies ?? []) {
+    for (const edge of (Array.isArray(node.manifest.dependencies) ? node.manifest.dependencies : [])) {
       const here = [...path, edge.name];
       // NB: the root is seeded into `visiting`, so a root-involving skew (root@1 -> A -> root@2)
       // trips this cycle check before the version-skew check below — both refuse + install nothing.
@@ -63,8 +63,11 @@ export async function resolve(
       try { dep = JSON.parse(await fetchPackage(edge.url)) as AcePackage; }
       catch (e) { return { ok: false, reason: "fetch-failed", detail: `${edge.url}: ${(e as Error).message}`, path: here }; }
       // Shape guard: verify the parsed JSON is a well-formed AcePackage before any field access.
-      const m = (dep as { manifest?: unknown; files?: unknown });
-      if (typeof dep !== "object" || dep === null || typeof m.manifest !== "object" || m.manifest === null || typeof m.files !== "object" || m.files === null) {
+      // Also reject non-array dependencies: a dependencies field that is present but not an array
+      // is malformed and would throw in the for-of loop, so we refuse it here as invalid-package.
+      const m = (dep as { manifest?: { dependencies?: unknown }; files?: unknown });
+      if (typeof dep !== "object" || dep === null || typeof m.manifest !== "object" || m.manifest === null || typeof m.files !== "object" || m.files === null
+          || (m.manifest.dependencies !== undefined && !Array.isArray(m.manifest.dependencies))) {
         return { ok: false, reason: "invalid-package", detail: `${edge.url}: not a well-formed AcePackage`, path: here };
       }
       // slice-2 self-check

--- a/tools/ace/resolve.ts
+++ b/tools/ace/resolve.ts
@@ -1,0 +1,17 @@
+import { createHash } from "node:crypto";
+import type { AcePackage } from "./store.ts";
+
+/** Deterministic JSON: object keys recursively sorted; arrays preserve order. */
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return "[" + value.map(canonicalJson).join(",") + "]";
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return "{" + keys.map((k) => JSON.stringify(k) + ":" + canonicalJson(obj[k])).join(",") + "}";
+}
+
+/** sha256 of the canonical whole package ({manifest incl. signature, files}). The parent's
+ *  pin / identity for a dependency. Two edges sharing a packageHash are byte-identical. */
+export function packageHash(pkg: AcePackage): string {
+  return "sha256:" + createHash("sha256").update(canonicalJson({ manifest: pkg.manifest, files: pkg.files })).digest("hex");
+}

--- a/tools/ace/store.test.ts
+++ b/tools/ace/store.test.ts
@@ -96,6 +96,21 @@ describe("installPackage", () => {
     const dir = join(store, content_hash.replace(":", "-"));
     expect(existsSync(dir)).toBe(false);
   });
+
+  test("installPackage ignores a manifest's dependencies field (leaf back-compat)", () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-store-"));
+    const files = { "r.txt": "hi" };
+    const content_hash = "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+    const pkg = {
+      manifest: {
+        format_version: 1, name: "demo", version: "1.0.0", content_hash,
+        dependencies: [{ name: "x", version: "1.0.0", url: "http://e/x.json", package_hash: "sha256:deadbeef" }],
+      },
+      files,
+    };
+    const result = installPackage(store, pkg);
+    expect(result.ok).toBe(true);
+  });
 });
 
 describe("trust store", () => {

--- a/tools/ace/store.test.ts
+++ b/tools/ace/store.test.ts
@@ -123,6 +123,12 @@ describe("validatePackagePaths", () => {
   test("returns the offending path for an absolute path", () => {
     expect(validatePackagePaths({ manifest: { format_version: 1, name: "a", version: "1", content_hash: "x" }, files: { "/etc/passwd": "y" } })).toBe("/etc/passwd");
   });
+  test("returns the offending path for a Windows drive-absolute path", () => {
+    expect(validatePackagePaths({ manifest: { format_version: 1, name: "a", version: "1", content_hash: "x" }, files: { "C:\\Windows\\system.ini": "y" } })).toBe("C:\\Windows\\system.ini");
+  });
+  test("returns the offending path for a Windows drive-relative path", () => {
+    expect(validatePackagePaths({ manifest: { format_version: 1, name: "a", version: "1", content_hash: "x" }, files: { "C:evil": "y" } })).toBe("C:evil");
+  });
 });
 
 describe("trust store", () => {

--- a/tools/ace/store.test.ts
+++ b/tools/ace/store.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, existsSync, readFileSync, statSync, writeFileSync, chmodSy
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createHash } from "node:crypto";
-import { contentHash, installPackage, loadTrustStore, addTrustedKey, listTrustedKeys, trustStorePath } from "./store.ts";
+import { contentHash, installPackage, validatePackagePaths, loadTrustStore, addTrustedKey, listTrustedKeys, trustStorePath } from "./store.ts";
 
 describe("contentHash", () => {
   test("sha256 of known bytes matches the sha256:<hex> form", () => {
@@ -110,6 +110,18 @@ describe("installPackage", () => {
     };
     const result = installPackage(store, pkg);
     expect(result.ok).toBe(true);
+  });
+});
+
+describe("validatePackagePaths", () => {
+  test("returns null for safe paths", () => {
+    expect(validatePackagePaths({ manifest: { format_version: 1, name: "a", version: "1", content_hash: "x" }, files: { "ok.txt": "y" } })).toBeNull();
+  });
+  test("returns the offending path for '..' traversal", () => {
+    expect(validatePackagePaths({ manifest: { format_version: 1, name: "a", version: "1", content_hash: "x" }, files: { "../escape": "y" } })).toBe("../escape");
+  });
+  test("returns the offending path for an absolute path", () => {
+    expect(validatePackagePaths({ manifest: { format_version: 1, name: "a", version: "1", content_hash: "x" }, files: { "/etc/passwd": "y" } })).toBe("/etc/passwd");
   });
 });
 

--- a/tools/ace/store.ts
+++ b/tools/ace/store.ts
@@ -90,11 +90,12 @@ export interface AcePackage {
 export type InstallResult = { ok: true; dir: string } | { ok: false; error: string };
 
 /** Returns the first unsafe file path in the package, or null if all paths are safe.
- *  Unsafe = contains '..', or is absolute (leading '/' or '\\'). Shared by installPackage
- *  AND the slice-4 graph install preflight so the two never drift. */
+ *  Unsafe = contains '..', or is absolute (leading '/' or '\\'), or is a Windows drive
+ *  path (drive-absolute like 'C:\...' or drive-relative like 'C:foo'). Shared by
+ *  installPackage AND the slice-4 graph install preflight so the two never drift. */
 export function validatePackagePaths(pkg: AcePackage): string | null {
   for (const rel of Object.keys(pkg.files)) {
-    if (rel.includes("..") || rel.startsWith("/") || rel.startsWith("\\")) return rel;
+    if (rel.includes("..") || rel.startsWith("/") || rel.startsWith("\\") || /^[A-Za-z]:/.test(rel)) return rel;
   }
   return null;
 }
@@ -115,13 +116,14 @@ export function installPackage(storePath: string, pkg: AcePackage): InstallResul
   // traversal-blocked install refuses ATOMICALLY (extracts nothing) — the same guarantee a
   // hash mismatch gives. (Validating inside the write loop would leave a partial dir on disk
   // when a bad path is not the first entry.) Reject any '..' component (POSIX `../` or Windows
-  // `..\`) or absolute path (leading '/' or '\').
+  // `..\`) or absolute path (leading '/' or '\') or Windows drive path ('C:\...' or 'C:foo').
+  //
+  // NOTE (slice-4 hardening):
+  //   Windows drive paths (C:\Windows\... and C:foo) are now rejected here. On Windows,
+  //   path.join(store, "C:\\x") discards the store prefix, enabling an escape from the store
+  //   directory. The /^[A-Za-z]:/ regex catches both drive-absolute and drive-relative forms.
   //
   // NOTE (slice-3 hardening):
-  //   (a) PATH: Windows device names (CON/NUL/PRN/AUX/COM1…) and drive-relative paths
-  //       (`C:foo`) are NOT rejected here. They cannot escape `<storePath>/<hash>/` —
-  //       `path.join` embeds them as subpaths — but a malicious package could still target a
-  //       Windows device sink.
   //   (b) CONTENT/SOURCE: the `install <url>` verb fetches package bytes over HTTP and writes
   //       them here (CodeQL js/http-to-file-access, accepted). The write is confined to
   //       `<storePath>/<hash>/` (path guard above) and the bytes are integrity-checked against

--- a/tools/ace/store.ts
+++ b/tools/ace/store.ts
@@ -89,6 +89,16 @@ export interface AcePackage {
 
 export type InstallResult = { ok: true; dir: string } | { ok: false; error: string };
 
+/** Returns the first unsafe file path in the package, or null if all paths are safe.
+ *  Unsafe = contains '..', or is absolute (leading '/' or '\\'). Shared by installPackage
+ *  AND the slice-4 graph install preflight so the two never drift. */
+export function validatePackagePaths(pkg: AcePackage): string | null {
+  for (const rel of Object.keys(pkg.files)) {
+    if (rel.includes("..") || rel.startsWith("/") || rel.startsWith("\\")) return rel;
+  }
+  return null;
+}
+
 /**
  * Verify-before-extract: recompute the content hash of `pkg.files` and refuse to
  * extract unless it matches `pkg.manifest.content_hash` (integrity). Extracts to
@@ -120,10 +130,9 @@ export function installPackage(storePath: string, pkg: AcePackage): InstallResul
   //       the signed+trusted path is authenticity-verified, and `--allow-no-signature` is required to
   //       install an unsigned one. The CodeQL js/http-to-file-access alert remains a true
   //       intended-flow observation (the http→file write is the package manager's function).
-  for (const rel of Object.keys(pkg.files)) {
-    if (rel.includes("..") || rel.startsWith("/") || rel.startsWith("\\")) {
-      return { ok: false, error: `unsafe file path in package: ${rel}` };
-    }
+  const unsafe = validatePackagePaths(pkg);
+  if (unsafe !== null) {
+    return { ok: false, error: `unsafe file path in package: ${unsafe}` };
   }
   const dir = join(storePath, pkg.manifest.content_hash.replace(":", "-"));
   try {

--- a/tools/ace/store.ts
+++ b/tools/ace/store.ts
@@ -4,13 +4,21 @@ import { join, dirname } from "node:path";
 import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
 
+export interface AceDependency {
+  readonly name: string;
+  readonly version: string;
+  readonly url: string;
+  readonly package_hash: string; // sha256 of the canonical FULL package (manifest incl. signature + files)
+}
+
 export interface AceManifest {
   readonly format_version: number;
   readonly name: string;
   readonly version: string;
-  readonly content_hash: string;
+  readonly content_hash: string; // slice-2: sha256(files)
   readonly description?: string;
   readonly signature?: { readonly algo: string; readonly key_id: string; readonly sig: string };
+  readonly dependencies?: ReadonlyArray<AceDependency>;
 }
 
 export interface InstalledPackage {


### PR DESCRIPTION
Implements Ace slice 4 per the merged spec (`docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice4-inline-url-dependency-resolution-design.md`) and plan (`...-slice4-implementation-plan.md`), TDD, 12 commits.

## What lands
- **`tools/ace/resolve.ts`** (new, pure, injected fetch): `packageHash` (full-package identity) + `resolve()` — identity-keyed DFS, root-seeded, diamond dedup, cycle/version-skew/tamper detection, per-node verification (slice-2 files hash + `package_hash` pin + declared-identity + slice-3 signature gate, graph-wide `--allow-no-signature`), topo order (leaves-first, root-last).
- **`tools/ace/store.ts`**: `AceManifest.dependencies?` + `AceDependency`; `validatePackagePaths` factored out of `installPackage` (shared with the install preflight).
- **`tools/ace/ace.ts`**: resolver wired into `install` — resolve → **atomic preflight** (content_hash + path-safety + store-collision across the whole graph) → extract leaves-first → resolved-set output. Leaf packages unchanged (back-compat).
- **`.claude/skills/ace/SKILL.md`**: transitive-install docs + the 12 refusal reasons.

## Verification
- **101 tests pass, 0 fail** (`bun test tools/ace/`).
- Final opus code-review pass: 2 P1s found + fixed (root content_hash preflight closing the D6 atomicity gap; `invalid-package` shape-guard so malformed dep JSON refuses cleanly instead of throwing) + a P2 test + a nit comment.

## Scope
Inline-URL only. Registry + semver = slice 5. Store-collision is **refused** (strict); re-keying the store by identity is deferred to **B-0966** (only if same-files-different-identity ever arises). Commit canary 67 throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)