### PR TITLE
docs(B-0962): Round 3 — Aaron resolves round-2 (Claim=best-effort AP not CP; per-agent PC/EC via geo-replicas)

### DIFF
--- a/docs/backlog/P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md
+++ b/docs/backlog/P2/B-0962-phase1-typed-claim-lock-coordination-events-deadlock-free-by-construction-optimistic-cas-2026-06-01.md
@@ -97,8 +97,31 @@ AP-with-retry; GitHub is the availability dependency). Correctness is in how tho
 **compose under partial connectivity**. Also: per-agent state is **CA-local** —
 **PACELC is undefined intra-process** (no network boundary), NOT "PC/EC." Cross-row work
 (decomposition / cascades) needs the §1.3 single-resource + release-before-acquire rule;
-hot-row contention needs §3 backoff + the (unproven) B-0963 bounded-wait-freedom. Full
-two-round huddle (Gemini + Grok verbatim, both rounds + Aaron's resolutions):
+hot-row contention needs §3 backoff + the (unproven) B-0963 bounded-wait-freedom.
+
+**Round-3 resolution (Aaron, 2026-06-01) — Claim is best-effort AP, not CP; this row's
+two primitives ARE the AP/CP split.** Round 2's pessimism resolves:
+
+- **Mutual exclusion is NOT a correctness requirement for deterministic/idempotent work.**
+  Two agents double-claiming the same backlog item is fine — even valuable: two PRs that
+  **cross-verify** each other, or one finishes first and the second sees it on main and
+  converges (**deterministic ending; "git decides"**). No lock ⇒ no deadlock/livelock to
+  contend (the round-2 deadlock/livelock objections only bite if at-most-once is required).
+  So **Claim** (§4: cooperative, monotone, G-Set, try-or-pick-different) is **best-effort
+  AP** — redundancy-as-verification, not a CP island.
+- **Lock** (§4: hard CAS + fencing) is the **CP** primitive, reserved for the gated
+  **non-idempotent** class (money / provisioning / external charges — B-0918 banker-bot
+  territory) where double-work IS unsafe. So this row's Claim-vs-Lock split = the AP/CP
+  split: Claim = AP default; Lock = CP escape.
+- **PACELC correction-of-the-correction:** per-agent state is geo-replicated for safety
+  (F# deterministic DB / CockroachDB — a single copy would be unsafe), so PACELC DOES
+  apply: per-agent = **PC/EC** (single-writer; replication chooses C). Round-2's
+  "undefined intra-process" assumed a single copy.
+- **ID surface being removed:** B-NNNN is a stopgap; ZetaId 128-bit (B-0858 v1 /
+  B-0893 v2, already implemented; content/structure-addressed) needs no global allocator.
+
+Full three-round analysis (Gemini + Grok verbatim, both huddle rounds + Aaron's
+resolutions):
 [`docs/research/2026-06-01-cap-posture-per-row-not-global-coordination-avoidance-gemini-grok-aaron.md`](../../research/2026-06-01-cap-posture-per-row-not-global-coordination-avoidance-gemini-grok-aaron.md).
 
 ## §1 The patterns — never-deadlock AND keep-it-simple

--- a/docs/research/2026-06-01-cap-posture-per-row-not-global-coordination-avoidance-gemini-grok-aaron.md
+++ b/docs/research/2026-06-01-cap-posture-per-row-not-global-coordination-avoidance-gemini-grok-aaron.md
@@ -175,6 +175,71 @@ randomized backoff is the mitigation, not a proof). Not solved by construction.
 > B-0962 §3 backoff + the (unproven) B-0963 bounded-wait-freedom. Correctness is in how
 > the layers **compose under partial connectivity**, not in a pure per-row story.
 
+## Round 3 — Aaron's resolution: the round-2 pessimism resolves (2026-06-01)
+
+Aaron answered the round-2 findings, and each resolves rather than disputes — the net is
+**stronger** than round 2 concluded. (Authored by Aaron; not a new peer huddle.)
+
+**R2-finding 1 (PACELC undefined intra-process) → RESOLVED: PACELC applies; per-agent is
+PC/EC.** Round 2 assumed a single in-process copy. It isn't: a safe agent is
+**geo-replicated** (F# deterministic DB _or_ CockroachDB) — a single unreplicated copy
+would be unsafe. That replication IS the network boundary, so PACELC applies. Single-writer
+⇒ no write-_conflict_, but the replica set still chooses L-vs-C / C-vs-A → **PC/EC**
+(CockroachDB Raft-per-range + FoundationDB-style single-thread both favor consistency,
+sacrifice the partitioned-minority replica's availability). Aaron 2026-06-01: _"agents
+will have replicas geographically not just one — that would be unsafe."_
+
+**R2-finding 2 (claim/lock is a problematic CP island; distributed-deadlock; systemic
+livelock) → RESOLVED: the bus is BEST-EFFORT AP, not CP — mutual exclusion is NOT
+required.** Both peers assumed "exactly one agent holds X" is a correctness invariant
+(→ CP). Aaron: it is not. Double-claim is fine, even valuable. Aaron 2026-06-01:
+
+> "Bus can be optimistic and even start working on the same problem. If both agents
+> do the same backlog, they use the two PRs to verify each other's work — they rejoin
+> main from their branches and see each other's PRs, or one finishes first and the
+> second sees it. It's deterministic in its ending. They don't have to lock; best-effort
+> is fine and move forward."
+
+So: redundant work = a free **2-oracle cross-check**, and determinism guarantees
+**convergence at main** ("git decides"). With no required mutual exclusion there is no
+lock to contend ⇒ **the distributed-deadlock and systemic-livelock objections do not
+bite** (they only bite if you require at-most-once). The would-be-CP-coordination-cost
+becomes verification value — the same move as the 4-oracle golden-vectors (redundancy
+IS the correctness mechanism, not waste).
+
+**Boundary (don't-collapse):** this holds for **deterministic / idempotent / convergent**
+work (code, docs, backlog — the majority). **Non-idempotent side-effects** (money,
+provisioning, external charges) still need true mutual exclusion. That is exactly
+**B-0962's two-primitive split**: **Claim** = cooperative best-effort AP (default;
+redundancy-as-verification); **Lock** = hard CAS+fencing **CP**, reserved for the gated
+non-idempotent class (B-0918 banker-bot territory). Aaron's point doesn't contradict
+B-0962 — it explains _why it has two primitives_.
+
+**R2-finding (ID allocation is a global uniqueness surface) → RESOLVED: being removed.**
+Sequential `B-NNNN` was a stopgap; **ZetaId (128-bit, already implemented** — B-0858 v1
+"128-bit observation ID", B-0893 v2 structured encoding, `registry/categories.yaml`) is
+content/structure-addressed ⇒ no global allocator ⇒ no coordination surface. Conversion
+is on the main checklist / workstreams (in progress before this discussion). Aaron
+2026-06-01: _"seq backlog id is stupid and was a stopgap — we were literally running the
+backlog to convert this."_
+
+**R2 (per-shared-repo `origin/main` = per-ref CAS) → CONFIRMED** by Aaron ("per ref cas
+yes agree"): AP-with-retry, per-repo, not global.
+
+### Final precise statement (post Round 3)
+
+> **No global consistency surface** across the multi-repo/multi-project society (Aaron's
+> core — holds). Per-agent state is **geo-replicated PC/EC** (single-writer; replication
+> chooses consistency; PACELC applies — CockroachDB/FoundationDB-class). Read-side
+> aggregate is **AP** (bounded staleness). The **Claim** layer is **best-effort AP** —
+> double-work is tolerated as redundancy-as-verification + deterministic convergence at
+> main, so it is NOT a CP requirement and carries no deadlock/livelock for deterministic
+> work. The only genuine **CP** islands are (a) per-agent replication (chosen-C) and
+> (b) the **Lock** primitive for the gated non-idempotent (money) class. ID allocation is
+> being removed as a coordination surface (ZetaId 128-bit). `origin/main` is per-ref CAS,
+> AP-with-retry, per-repo. PACELC: per-agent PC/EC; read-side PA/EL; Lock PC/EC-per-key;
+> Claim PA/EL (best-effort).
+
 ---
 
 ## Gemini (round 1, verbatim)


### PR DESCRIPTION
## What

Folds Aaron's resolution of the round-2 CAP/PACELC findings into the research doc (Round 3 section + final precise statement) + the B-0962 §0.1 note. Each round-2 concern **resolves** rather than disputes — net position is stronger.

## The resolutions

- **PACELC applies per-agent → PC/EC.** Round-2 assumed a single in-process copy; agents are **geo-replicated** for safety (F# deterministic DB / CockroachDB — one copy would be unsafe). Replication = the network boundary → PACELC applies; single-writer ⇒ no write-conflict but replication chooses **C** (CockroachDB/FoundationDB class).
- **The bus is best-effort AP, not CP.** Mutual exclusion isn't a correctness requirement for deterministic/idempotent work: double-claim → two PRs that **cross-verify**, or one finishes first and the second converges at main (**deterministic, "git decides"**). No lock ⇒ the round-2 distributed-deadlock + systemic-livelock objections don't bite. Redundancy becomes verification value (4-oracle shape).
  - **Boundary:** non-idempotent side-effects (money) still need true exclusion → that's **B-0962's Lock (CP)**. So Claim(best-effort AP) / Lock(CP-for-money) **is** the AP/CP split — explains why this row has two primitives.
- **ID surface removed:** B-NNNN stopgap → **ZetaId 128-bit** (B-0858 v1 / B-0893 v2, already implemented, no global allocator).
- **origin/main per-ref CAS:** confirmed.

## Final position
No global surface (core holds); per-agent **PC/EC** (geo-replicas); read-side **AP**; **Claim = best-effort AP** (redundancy-as-verification); only CP = per-agent replication (chosen) + the gated **Lock** for money.

Retraction-native: rounds 1 + 2 preserved beside the round-3 resolution. prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)