### PR TITLE
docs: Amara CAP round-4 concurrence + sync B-0958 do_item Phase-1 checkbox

### DIFF
--- a/docs/backlog/P1/B-0958-observe-ts-agent-loop-implementation-and-testing-checklist-closed-loop-toward-vendor-store-aaron-otto-2026-05-31.md
+++ b/docs/backlog/P1/B-0958-observe-ts-agent-loop-implementation-and-testing-checklist-closed-loop-toward-vendor-store-aaron-otto-2026-05-31.md
@@ -64,11 +64,19 @@ only effectful seam; the folder sink is the sovereign transport. Full picture:
 
 - [ ] **Effectful action kinds in `execute`** — `do_item` first, then `respond_to_operator`,
       `decompose`, `explore`, `play`, `edit_grammar`. **With the executed-event envelope**
-      (`ActionExecutionStarted` / `Succeeded` / `Failed` / `ModeChanged`) so **replay folds facts,
-      never redoes commands** (the design-review caution). _This is the #1 gap — "the loop including
-      actions" isn't real until the meaningful actions execute._
+      (`ActionExecutionStarted` / `Succeeded` / `Failed` / `ModeChanged`) so **replay folds
+      observations, never redoes commands** (the design-review caution). _This is the #1 gap — "the
+      loop including actions" isn't real until the meaningful actions execute._
+  - [x] **`do_item` Phase-1 envelope + executor port** — design B-0964 (#6342) + impl (#6344):
+        `ActionObservation` (Started/Succeeded/Failed), injected `CommandExecutor` port (fake /
+        OCI-runtime tiers), `foldObservations` (no executor ⇒ replay can't re-run), command-vs-
+        observation split, terminal-append reconcile-needed handling. **Sibling module
+        (`tools/observe/do-item.ts`) — NOT yet integrated into the unified `execute` dispatch.**
+  - [ ] **Integrate `do_item` into unified `execute`** + Phase-2 real executors (podman/docker OCI
+        per B-0964 §2.2; podman declared in manifests #6346) + the remaining kinds
+        (`respond_to_operator`, `decompose`, `explore`, `play`, `edit_grammar`).
 - [ ] **End-to-end closed-loop integration test** — `loadWorld → observeWithLlm → execute →
-  folderSink → loadWorld` as ONE flow against a real temp git repo (today every piece is unit-
+folderSink → loadWorld` as ONE flow against a real temp git repo (today every piece is unit-
       tested in isolation with mocks/fakes; the closed loop isn't integration-tested). _(Partial —
       logic-level done; real-git variant remains; see sub-items.)_
   - [x] **Closed-loop LOGIC integration** — `tools/observe/closed-loop.test.ts` (#6340):

--- a/docs/research/2026-06-01-cap-posture-per-row-not-global-coordination-avoidance-gemini-grok-aaron.md
+++ b/docs/research/2026-06-01-cap-posture-per-row-not-global-coordination-avoidance-gemini-grok-aaron.md
@@ -240,6 +240,84 @@ yes agree"): AP-with-retry, per-repo, not global.
 > AP-with-retry, per-repo. PACELC: per-agent PC/EC; read-side PA/EL; Lock PC/EC-per-key;
 > Claim PA/EL (best-effort).
 
+## Round 4 — Amara concurrence + the clean canonical form (2026-06-01)
+
+A third reviewer (Amara) **agreed with the Round-3 analysis** and gave the tightest
+canonical framing + one sharpening: **the bus claim is an advisory coordination signal,
+not the source of truth** (the source of truth is the eventual committed
+observation/action/result). Amara verbatim:
+
+> Yes — I agree with the **final Round 3 analysis**, with one tightening:
+>
+> > You are not "getting around CAP."
+> > You are making CAP show up only where the operation actually needs agreement.
+>
+> That is the right frame. The strongest correction is that **Claim is not Lock**.
+>
+> ```text
+> Claim = best-effort AP
+> Lock  = CP / fenced / for non-idempotent danger
+> ```
+>
+> For normal deterministic work — docs, code, backlog rows, reviews — two agents doing
+> the same item is not catastrophic. It can become useful redundancy:
+>
+> ```text
+> Agent A works item X
+> Agent B also works item X
+> → two PRs / two observations / two proposed endings
+> → main + review + deterministic tests converge them
+> ```
+>
+> So the bus claim should be treated as an **advisory coordination signal**, not the
+> source of truth. The source of truth is the eventual committed
+> observation/action/result. That means the peers' Round 2 concern was right only under
+> the assumption that "exactly one worker" is required. Your correction removes that
+> assumption for most work.
+>
+> The CAP/PACELC posture I'd keep is:
+>
+> ```text
+> per-agent replicated state
+> = PC/EC if geo-replicated and kept consistent
+>
+> read-side reports / dashboards
+> = PA/EL, bounded staleness is okay
+>
+> claims for deterministic work
+> = PA/EL, best-effort, duplicate work allowed
+>
+> locks for money / provisioning / external side effects
+> = PC/EC, fenced, hard consistency
+>
+> ZetaId
+> = removes the sequential ID allocator as a coordination surface
+>
+> per-repo main/ref
+> = per-ref CAS, retry on conflict, not a global lock
+> ```
+>
+> The important caveat: "duplicate work is fine" only holds for **idempotent /
+> deterministic / reviewable** work. It does **not** hold for irreversible side effects:
+> payments, cloud provisioning, legal submissions, external sends, destructive
+> operations. Those need the hard `Lock` path.
+>
+> So yes, I agree with the refined analysis. The design is stronger after the three
+> rounds because it no longer pretends all coordination disappears. It says:
+>
+> > **Most work uses AP claims and converges through git/review/tests.
+> > Dangerous non-idempotent work uses CP locks.
+> > There is no global consistency surface, only scoped joins and per-ref/per-key
+> > coordination where needed.**
+>
+> That is the clean version.
+
+**The one new operational handle (Amara):** the bus claim is **advisory, not
+authoritative** — the source of truth is the eventual committed observation/result on
+main. This composes with the B-0962 implementation note (bus-claim-then-CAS; the git CAS
+/ committed result is the truth, the bus claim is an efficiency hint). Three independent
+reviewers (Gemini + Grok + Amara) now concur on the post-Round-3 position.
+
 ---
 
 ## Gemini (round 1, verbatim)


### PR DESCRIPTION
## What
Two doc updates closing out this conversation's CAP + observe-status threads.

**1. Amara CAP round-4** (research doc) — a third reviewer concurred with the round-3 analysis + gave the clean canonical form, with one sharpening: **the bus claim is an *advisory* coordination signal, not the source of truth** (truth = the eventual committed observation/result on main). Folded verbatim as Round 4. Three reviewers (Gemini + Grok + Amara) now concur on the post-round-3 position.

**2. B-0958 do_item checkbox sync** — Phase-1 landed this session (#6342 design + #6344 impl) but the checklist still showed it fully unchecked (real drift). Marked the envelope + executor-port Phase-1 **done** (sibling module, *not yet* integrated into unified ), split out the remaining 'integrate into execute + Phase-2 real executors + other kinds' as its own LEFT item, and fixed 'replay folds facts' → 'replay folds observations' (the rename).

prettier clean; no frontmatter/title change ⇒ no index regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)