### PR TITLE
refactor(observe B-0964): ExecutorTier 'docker' → 'oci' (runtime-agnostic; match merged §2.2 verdict)

### DIFF
--- a/tools/observe/do-item.test.ts
+++ b/tools/observe/do-item.test.ts
@@ -79,13 +79,13 @@ describe("executeDoItem — the observation envelope", () => {
 
   it("the Started observation records the executor TIER + gated (the §3 glass-halo audit)", async () => {
     const sink = fakeObservationSink();
-    const dockerish: CommandExecutor = { tier: "docker", run: () => Promise.resolve(okRun) };
-    await executeDoItem(w([item("B-1")]), item("B-1"), sink, dockerish, { spec: { script: "x" }, gated: true });
+    const ociExec: CommandExecutor = { tier: "oci", run: () => Promise.resolve(okRun) };
+    await executeDoItem(w([item("B-1")]), item("B-1"), sink, ociExec, { spec: { script: "x" }, gated: true });
 
     const started = sink.appended[0];
     expect(started?.kind).toBe("ActionExecutionStarted");
     if (started?.kind !== "ActionExecutionStarted") return;
-    expect(started.tier).toBe("docker");
+    expect(started.tier).toBe("oci");
     expect(started.gated).toBe(true);
   });
 

--- a/tools/observe/do-item.ts
+++ b/tools/observe/do-item.ts
@@ -21,7 +21,7 @@
  * The `CommandExecutor` is INJECTED (asymmetric-authorship: the port authors its
  * own outcome channel; `executeDoItem` stays testable with a fake; no shell in the
  * unit path). The `Started` observation records the executor `tier` + `gated` so the
- * §3 glass-halo audit can tell a sandbox run from a real-FS/docker escalation.
+ * §3 glass-halo audit can tell a sandbox run from a real-FS/OCI escalation.
  *
  * Phase 1 (this file): the envelope + port + transition, fake executor, no dep,
  * no shell. Phase 2 wires real impls behind `CommandExecutor` (local OCI runtime —
@@ -71,7 +71,7 @@ export type RunOutcome =
   | { readonly ok: true; readonly stdout: string; readonly exitCode: 0 }
   | { readonly ok: false; readonly reason: string; readonly exitCode: number; readonly stderr: string };
 
-/** The injected bash surface. Fake in tests; docker / just-bash in prod (B-0964 §2). */
+/** The injected bash surface. Fake in tests; oci / just-bash in prod (B-0964 §2). */
 export interface CommandExecutor {
   readonly tier: ExecutorTier;
   run: (spec: RunSpec) => Promise<RunOutcome>;

--- a/tools/observe/do-item.ts
+++ b/tools/observe/do-item.ts
@@ -24,8 +24,9 @@
  * §3 glass-halo audit can tell a sandbox run from a real-FS/docker escalation.
  *
  * Phase 1 (this file): the envelope + port + transition, fake executor, no dep,
- * no shell. Phase 2 wires real impls behind `CommandExecutor` (local docker for
- * real work; just-bash in-memory for text; per B-0964 §2 review-folded routing).
+ * no shell. Phase 2 wires real impls behind `CommandExecutor` (local OCI runtime —
+ * podman default, swappable — for real work; just-bash in-memory for text; per
+ * B-0964 §2 / §2.2 review-folded routing).
  * Integrating `executeDoItem` into the unified `execute`/log/sink is a follow-up
  * (Phase 1 keeps it a sibling so the existing `execute` + its tests stay green).
  *
@@ -51,8 +52,13 @@ import type { AppendOutcome, EventSink } from "./execute";
 
 // ─── the executor port (the "bash surface") ──────────────────────────────────
 
-/** Which surface ran the command — recorded in the Started observation for the audit. */
-export type ExecutorTier = "fake" | "just-bash" | "docker" | "cloud-burst";
+/**
+ * Which surface ran the command — recorded in the Started observation for the audit.
+ * `oci` = the runtime-agnostic local OCI runtime (podman default, swappable to
+ * docker/nerdctl/finch via `ZETA_CONTAINER_RUNTIME`; B-0964 §2.2). The tier names the
+ * boundary CLASS, not a specific vendor — so the audit doesn't lie about which engine ran.
+ */
+export type ExecutorTier = "fake" | "just-bash" | "oci" | "cloud-burst";
 
 /** What to run. Phase 1: the caller supplies it (B-0964 §4: the sub-loop / recipe map decides later). */
 export interface RunSpec {


### PR DESCRIPTION
## What
Renames the do_item `ExecutorTier` member **`"docker"` → `"oci"`** so the code matches the merged B-0964 §2.2 OCI-runtime verdict (#6347): the real-work tier is a **runtime-agnostic** local OCI runtime (podman default, swappable to docker/nerdctl/finch via `ZETA_CONTAINER_RUNTIME`), not a docker-specific tier. The Started-observation audit now names the boundary **class**, not a vendor — so it doesn't lie about which engine ran.

## Why now
Code↔decided-design consistency: §2.2 landed the OCI verdict but the enum still said `docker`. Small, safe substrate-honesty fix on the do_item/observe lane (B-0958 checklist push).

## Verification
Pure rename + comment. 122 pass; tsc / eslint (pinned) / prettier clean; no residual `tier: "docker"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)