### PR TITLE
docs(B-0954): status-drift fix — Phase 1 is IMPLEMENTED (#6283 + #6327), not 'not started'

### DIFF
--- a/docs/backlog/P2/B-0954-implement-git-native-cross-machine-agent-bus-docs-agent-bus-folder-zetaid-keyed-gset-crdt-no-pr-per-6219-spec-aaron-otto-2026-05-31.md
+++ b/docs/backlog/P2/B-0954-implement-git-native-cross-machine-agent-bus-docs-agent-bus-folder-zetaid-keyed-gset-crdt-no-pr-per-6219-spec-aaron-otto-2026-05-31.md
@@ -5,7 +5,7 @@ status: open
 priority: P2
 created: 2026-05-31
 attribution: aaron-otto-2026-05-31
-last_updated: 2026-05-31
+last_updated: 2026-06-01
 decomposition: umbrella
 depends_on:
   - B-0858
@@ -32,14 +32,23 @@ tags:
 
 ## Why this row exists (the gap behind the spec)
 
+> **Status update (2026-06-01, substrate-drift fix):** the bus is **Phase-1 IMPLEMENTED**,
+> not "not started" — `tools/agent-bus/` landed via **#6283** (Phase 1: types + publish +
+> subscribe, ZetaId-keyed G-Set CRDT, no-PR) and **#6327** (the cross-machine G-Set merge
+> view). Acceptance items **1–3 + the merge view are DONE**; **items 4 (bridge) and 6
+> (GC/retention) are not built**; item 5 (cross-machine) is logic-tested. The real
+> remaining gap is **wiring**: `docs/agent-bus/` is empty because nothing in the loop
+> publishes to it yet. The original "not started" text below is preserved
+> (retraction-native) as the row's filing-time framing.
+
 The git-native cross-machine bus is **spec'd + categorized but not implemented**:
 
 - **Spec**: `docs/research/2026-05-31-git-backed-cross-machine-otto-bus-zetaid-spec.md`
-  (PR #6219, merged) — *"git-backed cross-machine Otto bus — ZetaId-keyed,
-  conflict-free, PR-less."* The spec left the impl row as *"Candidate backlog row
-  B-NNNN (likely a B-0858 sibling)"* — **this row IS that candidate, now filed.**
+  (PR #6219, merged) — _"git-backed cross-machine Otto bus — ZetaId-keyed,
+  conflict-free, PR-less."_ The spec left the impl row as _"Candidate backlog row
+  B-NNNN (likely a B-0858 sibling)"_ — **this row IS that candidate, now filed.**
 - **ZetaId `Category.Bus = 6`** landed (`src/Core.TypeScript/zeta-id/types.ts`:
-  *"cross-machine agent comms (git-native bus spec, #6219)"*).
+  _"cross-machine agent comms (git-native bus spec, #6219)"_).
 - **Not started**: `docs/agent-bus/` does not exist on main; there is no
   publish/subscribe tooling over it. (Only `docs/agent-heartbeats/` exists — the
   B-0858 heartbeat sibling.)
@@ -48,9 +57,9 @@ This is also the **answer to "the bus on Windows"**: the legacy in-process bus
 (`tools/bus/` → `/tmp/zeta-bus/`) is **local-machine-only** and not a Windows-native
 path; the git-native bus crosses machines + OSes **because git is the cross-OS
 transport** (a peer-Otto on Windows reads/writes the same `docs/agent-bus/` folder
-via git push/pull). Operator 2026-05-31: *"we added a bus category to our zeta id and
+via git push/pull). Operator 2026-05-31: _"we added a bus category to our zeta id and
 we're going to have a bus folder/branch setup … you backloged it, you started working
-on it before we moved to action grammar and event algebra."*
+on it before we moved to action grammar and event algebra."_
 
 ## The design (from the #6219 spec — laid out)
 
@@ -68,7 +77,7 @@ on it before we moved to action grammar and event algebra."*
   ⇒ separate folder.
 - **Collision caveat** (from the spec): the filename must be unique-or-merge-safe,
   not assumed-unique (DST can produce identical-field envelopes → same ZetaId →
-  same file; that's a *safe* idempotent merge, but the writer must treat
+  same file; that's a _safe_ idempotent merge, but the writer must treat
   already-exists as success, not error).
 
 ## The whys (challengeable)
@@ -86,21 +95,27 @@ on it before we moved to action grammar and event algebra."*
 
 ## Acceptance / decomposition (umbrella — sub-rows on pickup)
 
-1. **Folder + envelope schema** — `docs/agent-bus/<persona>/.../<zetaIdHex>.json`;
-   reuse `tools/bus/types.ts` envelope shape (topic/from/payload/ts) keyed by a
-   `Bus`-category ZetaId.
-2. **Publish tool** — write an envelope as a ZetaId-named file + `git add/commit/push`
-   (no PR), idempotent on already-exists (collision caveat).
-3. **Subscribe/read tool** — `git pull` + read new `docs/agent-bus/` files since a
-   cursor; surface to the agent (the cross-machine analog of `tools/bus/subscribe.ts`).
-4. **Bridge from the legacy bus** — `tools/bus/` (`/tmp/zeta-bus/`) stays the
+1. **[DONE — #6283]** **Folder + envelope schema** — `docs/agent-bus/<persona>/.../<zetaIdHex>.json`;
+   `tools/agent-bus/types.ts` (`AgentBusEnvelope`, `envelopePath`, `mintBusZetaIdHex`,
+   `makeEnvelope`, `serializeEnvelope`, `isCanonicalBusId`, `isSafeSegment`), `Bus`-category ZetaId.
+2. **[DONE — #6283]** **Publish tool** — `tools/agent-bus/publish.ts` (`writeEnvelope`):
+   ZetaId-named file, no-PR, idempotent on already-exists (collision caveat handled).
+3. **[DONE — #6283]** **Subscribe/read tool** — `tools/agent-bus/subscribe.ts`
+   (`readEnvelopesSince`, `readEnvelopesFromGitRef`, cursor, `parseSubscribeArgs`).
+   - **[DONE — #6327]** **Cross-machine G-Set merge view** — `tools/agent-bus/g-set-view.ts`
+     (`busIdSet`, `mergeViews`, `unseen`, `envelopesIn`); logic-tested in `*.test.ts`.
+4. **[LEFT]** **Bridge from the legacy bus** — `tools/bus/` (`/tmp/zeta-bus/`) stays the
    intra-machine fast path; the git-native folder is the cross-machine path; decide
    whether local publishes also mirror to the folder (or a `--cross-machine` flag).
-5. **Windows parity** — the publish/subscribe tooling runs on Windows (it's git +
-   file IO; no `/tmp` assumption); confirm cross-machine round-trip Otto-CLI ↔
-   Windows-peer (the original operator question).
-6. **GC / retention** — grow-only set needs pruning (the bus envelopes are ephemeral;
+5. **[PARTIAL — logic-tested]** **Windows parity** — the tooling is git + file IO (no `/tmp`
+   assumption); cross-machine merge is logic-tested. Still confirm a real cross-machine
+   round-trip Otto-CLI ↔ Windows-peer (the original operator question).
+6. **[LEFT]** **GC / retention** — grow-only set needs pruning (envelopes are ephemeral;
    thermal-erasure / retention per the memory-lifetime substrate); a retention sweep.
+7. **[LEFT — the real gap]** **Wire it into the loop** — the tooling exists but nothing
+   publishes/subscribes via it yet (`docs/agent-bus/` is empty on main). The bus is inert
+   until the agent loop actually emits + consumes envelopes through it (composes with the
+   observe loop, B-0958). Phase-1 built the pipes; this turns them on.
 
 ## Dependencies + rollout
 
@@ -139,5 +154,5 @@ Conclusion: spec + ZetaId category exist; **implementation row absent** — mint
 The design is settled by the #6219 spec; this row tracks the **implementation** so it
 has a home instead of living only as a research doc + a reserved enum slot. P2:
 valuable (it's the cross-machine/Windows comms channel) but not urgent (git is the
-working ambient cross-machine channel today; this makes the *explicit* channel
+working ambient cross-machine channel today; this makes the _explicit_ channel
 cross-machine too). Phase 1 ships without B-0887; Phase 2 hardens with it.


### PR DESCRIPTION
## What
B-0954's row said **"not started,"** but `tools/agent-bus/` already exists on main — caught while about to (re)build slice 1 (verify-existing-substrate; no duplicate landed). Corrects the stale status.

## Actual state
- **Items 1–3 DONE** (#6283 Phase 1): `types.ts` / `publish.ts` / `subscribe.ts` — ZetaId-keyed G-Set CRDT, no-PR.
- **Cross-machine G-Set merge view DONE** (#6327): `g-set-view.ts`.
- **Item 4 (legacy-bus bridge) + Item 6 (GC/retention): LEFT.**
- **Item 5 (Windows): logic-tested**; real cross-machine round-trip unconfirmed.
- **Item 7 (NEW — the real gap): wire it into the loop.** The pipes are built but nothing publishes/subscribes via the bus yet — `docs/agent-bus/` is empty on main. The bus is inert until the loop emits + consumes through it (composes B-0958 observe loop).

Original 'not started' framing preserved (retraction-native). No code change; status accuracy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)