### PR TITLE
docs(B-0959): git-native TEXT durability is the universal durability; binary is the optimization

### DIFF
--- a/docs/backlog/P1/B-0959-zeta-sovereign-distributed-db-and-agent-loop-master-checklist-one-git-native-zset-substrate-aaron-otto-2026-05-31.md
+++ b/docs/backlog/P1/B-0959-zeta-sovereign-distributed-db-and-agent-loop-master-checklist-one-git-native-zset-substrate-aaron-otto-2026-05-31.md
@@ -363,6 +363,31 @@ FoundationDB-style: all nodes on one deterministic thread.
 - Research anchors: `docs/research/2026-05-26-kestrel-...-time-as-generator-foundationdb-anchor.md`,
   `docs/research/2026-05-26-mika-...-self-derived-iScheduler-recursive-injection.md`.
 
+### Git-native TEXT durability is the UNIVERSAL durability — binary is the optimization (Aaron 2026-06-01)
+
+Refinement of the B-0958 dual-track ("git-native + filesystem-binary-efficient"): the two
+are **not parallel-equal backends.** The aim is **git-native _text_ durability for ALL fs
+stuff, not just the binary filesystem** — human-readable, diffable, retraction-native text
+files (the agent-bus JSON envelopes, the observe folderSink, heartbeats are the existing
+instances) as the **universal durable truth**; the F# binary-efficient frontier
+(`Spine.fs` / LSM, §4/§6) is an **optimization / cache / index over** that text truth, not
+a separate source of record. Operator 2026-06-01: _"we want to have a git native text
+durability eventually for all our fs stuff not just binary file system."_
+
+- [ ] **Git-native text durability as the universal storage interface** — extend B-0951's
+      git-native-text storage interface so the binary track is a derived cache over the
+      git-native-text durable form (every fs artifact has a diffable text representation;
+      binary is regenerable from it). Eventually, not now — directional aim. Composes
+      [B-0951](../P2/B-0951-git-native-eventually-consistent-text-indexes-sorted-inverted-graph-plus-git-native-hindsight-storage-interface-aaron-2026-05-31.md) + the B-0958 dual-track.
+
+- **DST harness = local bare repos (real git binary), confirmed (Aaron 2026-06-01:
+  "bare … will work with fs ts and rust too").** Multi-agent multi-repo DST runs against
+  `git init --bare` remotes + working clones with pinned `GIT_AUTHOR_DATE` /
+  `GIT_COMMITTER_DATE` — the **real git binary is language-agnostic**, so F#/TS/Rust/C#
+  all drive the same fixtures (the 4-oracle shares one harness); `isomorphic-git` is
+  TS-only and reserved for optional zero-FS determinism; `git-http-mock-server` / Gitea
+  for HTTP integration only (they reintroduce nondeterminism that fights DST).
+
 ### The reporting / insights view — a columnar materialized view over everything (Aaron 2026-06-01)
 
 The same F# single-thread FoundationDB-DST DB — multi-node / multi-cluster,


### PR DESCRIPTION
Captures Aaron 2026-06-01 (substrate-or-it-didn't-happen):

> we want to have a git native text durability eventually for all our fs stuff not just binary file system.

## What

Adds a §4 subsection to the B-0959 master checklist: **git-native TEXT durability is the universal durable TRUTH; the binary track is an optimization/cache over it — NOT a parallel-equal backend.**

- git-native TEXT (diffable, human-readable, retraction-native) is the durability floor for ALL fs substrate. The existing `docs/agent-bus/`, `docs/agent-heartbeats/`, observe-loop event files are the instances already in this shape.
- The F# binary frontier (`Spine.fs` / LSM, §4/§6) is a derived cache over the text truth — speed optimization, not a separate source of truth.
- Refines the B-0958 dual-track so the two tracks are ordered (text = truth, binary = optimization), not co-equal.

Also records the **bare-repos DST harness** confirmation (Aaron: *"bare … will work with fs ts and rust too"*) — local `git init --bare` remotes + working clones + pinned `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE` give a deterministic, real-git-binary, language-agnostic (fs/ts/rust/cs) multi-agent/multi-repo test harness — one 4-oracle harness rather than per-language mocks.

## Why

A directional aim Aaron stated that otherwise lived only in chat (weather). Lands it as a `[ ]` acceptance item composing B-0951 (git-native-text storage) so the binary track is explicitly a derived cache.

Tracker row; docs-only; no code. `last_updated` → 2026-06-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)