### PR TITLE
feat(B-0959): C# G-Set oracle — algebra-ladder bottom rung now 4/4 (Tier-1)

### DIFF
--- a/src/Core.CSharp/GSet.cs
+++ b/src/Core.CSharp/GSet.cs
@@ -135,14 +135,11 @@ public sealed class GSet<T> : IEquatable<GSet<T>>
     {
         ArgumentNullException.ThrowIfNull(other);
 
-        // If `other` was built with a different comparer, its run is not sorted under
-        // THIS set's comparer — recanonicalize before the linear merge (which assumes
-        // both runs are sorted under _comparer, else it can emit a non-canonical run
-        // and break later binary-search Contains). Fast path: same comparer instance.
-        if (!ReferenceEquals(_comparer, other._comparer))
-        {
-            other = new GSet<T>(GSet.Canonicalize(other._items, _comparer), _comparer);
-        }
+        // The comparer is part of a set's identity: two sets with different comparers are
+        // not union-compatible. Silently recanonicalizing would break commutativity
+        // (a∪b under a's order ≠ b∪a under b's order), so fail fast on mismatch
+        // (PR review 2026-06-01). Same comparer ⇒ both runs are sorted alike ⇒ linear merge.
+        RequireSameComparer(other);
 
         if (_items.IsEmpty)
         {
@@ -200,6 +197,18 @@ public sealed class GSet<T> : IEquatable<GSet<T>>
     public GSet<T> Add(T x) =>
         Contains(x) ? this : Union(new GSet<T>(ImmutableArray.Create(x), _comparer));
 
+    /// <summary>Throw if <paramref name="other"/> uses a different comparer (the comparer is part of the set's identity).</summary>
+    /// <param name="other">The set being combined.</param>
+    private void RequireSameComparer(GSet<T> other)
+    {
+        if (!_comparer.Equals(other._comparer))
+        {
+            throw new ArgumentException(
+                "GSet.Union requires both sets to use the same comparer (the comparer is part of the set's identity).",
+                nameof(other));
+        }
+    }
+
     /// <summary>The canonical (ascending) elements as an immutable array.</summary>
     /// <returns>The canonical run.</returns>
     public ImmutableArray<T> ToImmutableArray() => _items;
@@ -226,6 +235,14 @@ public sealed class GSet<T> : IEquatable<GSet<T>>
             return true;
         }
 
+        // The comparer is part of the set's identity: sets with different comparers are
+        // not equal. Keeps Equals symmetric (a.Equals(b) == b.Equals(a)) and keeps
+        // GetHashCode consistent. (PR review 2026-06-01.)
+        if (!_comparer.Equals(other._comparer))
+        {
+            return false;
+        }
+
         if (_items.Length != other._items.Length)
         {
             return false;
@@ -248,12 +265,13 @@ public sealed class GSet<T> : IEquatable<GSet<T>>
     /// <inheritdoc/>
     public override int GetHashCode()
     {
-        // The hash must follow the SAME equivalence relation as Equals (which compares
-        // under _comparer). When the comparer is also an equality comparer (e.g.
-        // StringComparer.Ordinal), hash each element through it; otherwise fall back to
-        // the count alone — weaker spread, but still consistent with comparer-based
-        // equality (equal sets share a count), so GSet stays a valid dictionary key.
+        // Consistent with Equals (which includes the comparer in identity): hash the
+        // comparer + the elements. When the comparer is also an equality comparer (e.g.
+        // StringComparer.Ordinal) hash each element through it so Compare==0 values hash
+        // alike; otherwise count-only for the element part (still consistent with the
+        // comparer-based Equals). (PR review 2026-06-01.)
         var hash = default(HashCode);
+        hash.Add(_comparer);
         hash.Add(_items.Length);
         if (_comparer is IEqualityComparer<T> eq)
         {

--- a/src/Core.CSharp/GSet.cs
+++ b/src/Core.CSharp/GSet.cs
@@ -39,6 +39,16 @@ public static class GSet
     public static GSet<T> OfSeq<T>(IEnumerable<T> xs, IComparer<T>? comparer = null)
     {
         var cmp = comparer ?? Comparer<T>.Default;
+        return new GSet<T>(Canonicalize(xs, cmp), cmp);
+    }
+
+    /// <summary>Sort ascending + drop duplicates under <paramref name="cmp"/> (the canonical run).</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="xs">The elements.</param>
+    /// <param name="cmp">The order.</param>
+    /// <returns>The canonical ascending, duplicate-free run.</returns>
+    internal static ImmutableArray<T> Canonicalize<T>(IEnumerable<T> xs, IComparer<T> cmp)
+    {
         var sorted = new List<T>(xs);
         sorted.Sort(cmp);
         var builder = ImmutableArray.CreateBuilder<T>(sorted.Count);
@@ -50,7 +60,7 @@ public static class GSet
             }
         }
 
-        return new GSet<T>(builder.ToImmutable(), cmp);
+        return builder.ToImmutable();
     }
 }
 
@@ -124,6 +134,16 @@ public sealed class GSet<T> : IEquatable<GSet<T>>
     public GSet<T> Union(GSet<T> other)
     {
         ArgumentNullException.ThrowIfNull(other);
+
+        // If `other` was built with a different comparer, its run is not sorted under
+        // THIS set's comparer — recanonicalize before the linear merge (which assumes
+        // both runs are sorted under _comparer, else it can emit a non-canonical run
+        // and break later binary-search Contains). Fast path: same comparer instance.
+        if (!ReferenceEquals(_comparer, other._comparer))
+        {
+            other = new GSet<T>(GSet.Canonicalize(other._items, _comparer), _comparer);
+        }
+
         if (_items.IsEmpty)
         {
             return other;
@@ -228,10 +248,19 @@ public sealed class GSet<T> : IEquatable<GSet<T>>
     /// <inheritdoc/>
     public override int GetHashCode()
     {
+        // The hash must follow the SAME equivalence relation as Equals (which compares
+        // under _comparer). When the comparer is also an equality comparer (e.g.
+        // StringComparer.Ordinal), hash each element through it; otherwise fall back to
+        // the count alone — weaker spread, but still consistent with comparer-based
+        // equality (equal sets share a count), so GSet stays a valid dictionary key.
         var hash = default(HashCode);
-        foreach (var x in _items)
+        hash.Add(_items.Length);
+        if (_comparer is IEqualityComparer<T> eq)
         {
-            hash.Add(x);
+            foreach (var x in _items)
+            {
+                hash.Add(x, eq);
+            }
         }
 
         return hash.ToHashCode();

--- a/src/Core.CSharp/GSet.cs
+++ b/src/Core.CSharp/GSet.cs
@@ -1,0 +1,239 @@
+// G-Set — grow-only set CRDT (bottom rung of the algebra ladder: G-Set ⊂ Bag ⊂ Z-set).
+// C# parity oracle; mirrors src/Core/GSet.fs, src/Core.TypeScript/g-set, and
+// src/Core.Rust.Algebra/src/gset.rs. Lives in the C# core next to the Z-set binding
+// (ZetaCircuitBuilder), mirroring how F# keeps GSet.fs in src/Core/.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Zeta.Core.CSharp;
+
+/// <summary>
+/// Factory methods for <see cref="GSet{T}"/>. A non-generic companion class (the .NET
+/// convention, e.g. <see cref="ImmutableArray"/> vs <see cref="ImmutableArray{T}"/>) so
+/// the constructors stay static-member-free on the generic type (CA1000).
+/// </summary>
+public static class GSet
+{
+    /// <summary>The empty G-Set (the <see cref="GSet{T}.Union"/> identity).</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <returns>An empty set.</returns>
+    public static GSet<T> Empty<T>(IComparer<T>? comparer = null) =>
+        new(ImmutableArray<T>.Empty, comparer ?? Comparer<T>.Default);
+
+    /// <summary>A one-element G-Set.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="x">The single element.</param>
+    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <returns>A set containing exactly <paramref name="x"/>.</returns>
+    public static GSet<T> Singleton<T>(T x, IComparer<T>? comparer = null) =>
+        new(ImmutableArray.Create(x), comparer ?? Comparer<T>.Default);
+
+    /// <summary>Canonicalize arbitrary input: sort ascending + drop duplicates.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="xs">The elements.</param>
+    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <returns>The canonical G-Set of the distinct elements.</returns>
+    public static GSet<T> OfSeq<T>(IEnumerable<T> xs, IComparer<T>? comparer = null)
+    {
+        var cmp = comparer ?? Comparer<T>.Default;
+        var sorted = new List<T>(xs);
+        sorted.Sort(cmp);
+        var builder = ImmutableArray.CreateBuilder<T>(sorted.Count);
+        for (var k = 0; k < sorted.Count; k++)
+        {
+            if (k == 0 || cmp.Compare(sorted[k - 1], sorted[k]) != 0)
+            {
+                builder.Add(sorted[k]);
+            }
+        }
+
+        return new GSet<T>(builder.ToImmutable(), cmp);
+    }
+}
+
+/// <summary>
+/// A grow-only set (G-Set CRDT): a canonical ascending-sorted, duplicate-free run under
+/// an <see cref="IComparer{T}"/>. <see cref="Union"/> is the only combiner and is
+/// idempotent, commutative, and associative (the three CRDT convergence laws), so
+/// replicas that have seen the same elements — in any order — converge with no
+/// coordination. Parity with <c>src/Core/GSet.fs</c>, <c>src/Core.TypeScript/g-set</c>,
+/// and <c>src/Core.Rust.Algebra/src/gset.rs</c>. Construct via <see cref="GSet"/>.
+/// </summary>
+/// <remarks>
+/// The comparer is explicit (like the TS <c>compare</c> parameter) rather than baked to
+/// <see cref="Comparer{T}.Default"/>: for <see cref="string"/> the default is
+/// culture-sensitive, but the cross-language wire (TS UTF-16 code-unit order, Rust UTF-8
+/// byte order) needs <see cref="StringComparer.Ordinal"/>. Pass it explicitly for
+/// cross-language parity.
+/// </remarks>
+/// <typeparam name="T">The element type.</typeparam>
+public sealed class GSet<T> : IEquatable<GSet<T>>
+{
+    private readonly ImmutableArray<T> _items;
+    private readonly IComparer<T> _comparer;
+
+    internal GSet(ImmutableArray<T> items, IComparer<T> comparer)
+    {
+        _items = items.IsDefault ? ImmutableArray<T>.Empty : items;
+        _comparer = comparer;
+    }
+
+    /// <summary>The number of elements.</summary>
+    public int Count => _items.Length;
+
+    /// <summary>Whether the set is empty.</summary>
+    public bool IsEmpty => _items.IsEmpty;
+
+    /// <summary>Membership via binary search on the sorted run. O(log n).</summary>
+    /// <param name="x">The element to test.</param>
+    /// <returns><see langword="true"/> iff <paramref name="x"/> is present.</returns>
+    public bool Contains(T x)
+    {
+        int lo = 0, hi = _items.Length - 1;
+        while (lo <= hi)
+        {
+            var mid = lo + ((hi - lo) >> 1);
+            var c = _comparer.Compare(_items[mid], x);
+            if (c == 0)
+            {
+                return true;
+            }
+
+            if (c < 0)
+            {
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The CRDT merge: the union of two sorted-unique runs, kept sorted-unique.
+    /// Idempotent, commutative, associative. Uses this set's comparer.
+    /// </summary>
+    /// <param name="other">The set to merge with.</param>
+    /// <returns>The union, in canonical order.</returns>
+    public GSet<T> Union(GSet<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        if (_items.IsEmpty)
+        {
+            return other;
+        }
+
+        if (other._items.IsEmpty)
+        {
+            return this;
+        }
+
+        var a = _items;
+        var b = other._items;
+        var builder = ImmutableArray.CreateBuilder<T>(a.Length + b.Length);
+        int i = 0, j = 0;
+        while (i < a.Length && j < b.Length)
+        {
+            var c = _comparer.Compare(a[i], b[j]);
+            if (c < 0)
+            {
+                builder.Add(a[i]);
+                i++;
+            }
+            else if (c > 0)
+            {
+                builder.Add(b[j]);
+                j++;
+            }
+            else
+            {
+                builder.Add(a[i]); // duplicate → keep one
+                i++;
+                j++;
+            }
+        }
+
+        while (i < a.Length)
+        {
+            builder.Add(a[i]);
+            i++;
+        }
+
+        while (j < b.Length)
+        {
+            builder.Add(b[j]);
+            j++;
+        }
+
+        return new GSet<T>(builder.ToImmutable(), _comparer);
+    }
+
+    /// <summary>Add one element (<see cref="Union"/> with a singleton); idempotent if already present.</summary>
+    /// <param name="x">The element to add.</param>
+    /// <returns>The set with <paramref name="x"/> present.</returns>
+    public GSet<T> Add(T x) =>
+        Contains(x) ? this : Union(new GSet<T>(ImmutableArray.Create(x), _comparer));
+
+    /// <summary>The canonical (ascending) elements as an immutable array.</summary>
+    /// <returns>The canonical run.</returns>
+    public ImmutableArray<T> ToImmutableArray() => _items;
+
+    /// <summary>The canonical (ascending) elements as a new array.</summary>
+    /// <returns>A fresh array of the elements in canonical order.</returns>
+    public T[] ToArray() => _items.AsSpan().ToArray();
+
+    /// <summary>
+    /// Value equality: same elements in canonical order (element-wise under the
+    /// comparer). Because both sets are canonical, this is set equality.
+    /// </summary>
+    /// <param name="other">The set to compare.</param>
+    /// <returns><see langword="true"/> iff the sets hold the same elements.</returns>
+    public bool Equals(GSet<T>? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        if (_items.Length != other._items.Length)
+        {
+            return false;
+        }
+
+        for (var k = 0; k < _items.Length; k++)
+        {
+            if (_comparer.Compare(_items[k], other._items[k]) != 0)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => Equals(obj as GSet<T>);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = default(HashCode);
+        foreach (var x in _items)
+        {
+            hash.Add(x);
+        }
+
+        return hash.ToHashCode();
+    }
+}

--- a/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -83,5 +84,27 @@ public class GSetCrossVerifyTests
         Assert.Equal(a, a.Union(GSet.Empty<string>(cmp))); // identity
         Assert.Equal(a, G(cmp, "a", "c").Add("c")); // add idempotent
         Assert.Equal(G(cmp, "a", "b", "c"), G(cmp, "a", "b").Add("c"));
+    }
+
+    [Fact]
+    public void UnionRecanonicalizesAMismatchedComparer()
+    {
+        // `other` built with a REVERSE comparer is stored descending; union under the
+        // ordinal set must recanonicalize it (PR review 2026-06-01) so the result stays
+        // canonical-ascending and binary-search Contains stays correct.
+        var ordinal = StringComparer.Ordinal;
+        var reverse = Comparer<string>.Create((x, y) => string.CompareOrdinal(y, x));
+
+        string[] aItems = ["a", "b"];
+        string[] otherItems = ["c", "a"]; // stored descending under the reverse comparer
+        string[] expected = ["a", "b", "c"];
+
+        var a = GSet.OfSeq(aItems, ordinal);
+        var other = GSet.OfSeq(otherItems, reverse);
+
+        var merged = a.Union(other);
+        Assert.Equal(expected, merged.ToArray()); // canonical ascending
+        Assert.True(merged.Contains("a")); // binary search works on the canonical run
+        Assert.True(merged.Contains("c"));
     }
 }

--- a/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
@@ -35,7 +35,10 @@ public class GSetCrossVerifyTests
     }
 
     private static string[] Strings(JsonElement array) =>
-        array.EnumerateArray().Select(e => e.GetString()!).ToArray();
+        array.EnumerateArray()
+            .Select(e => e.GetString()
+                ?? throw new InvalidOperationException($"fixture element is not a string: {e.GetRawText()}"))
+            .ToArray();
 
     [Fact]
     public void GSetReplayMatchesGoldenVectors()
@@ -87,24 +90,25 @@ public class GSetCrossVerifyTests
     }
 
     [Fact]
-    public void UnionRecanonicalizesAMismatchedComparer()
+    public void UnionThrowsOnMismatchedComparer()
     {
-        // `other` built with a REVERSE comparer is stored descending; union under the
-        // ordinal set must recanonicalize it (PR review 2026-06-01) so the result stays
-        // canonical-ascending and binary-search Contains stays correct.
+        // The comparer is part of a set's identity; unioning across different comparers is
+        // a programming error (it would break commutativity), surfaced loudly rather than
+        // silently recanonicalized (PR review 2026-06-01).
         var ordinal = StringComparer.Ordinal;
         var reverse = Comparer<string>.Create((x, y) => string.CompareOrdinal(y, x));
 
         string[] aItems = ["a", "b"];
-        string[] otherItems = ["c", "a"]; // stored descending under the reverse comparer
+        string[] otherItems = ["c", "a"];
         string[] expected = ["a", "b", "c"];
 
         var a = GSet.OfSeq(aItems, ordinal);
-        var other = GSet.OfSeq(otherItems, reverse);
+        var otherReverse = GSet.OfSeq(otherItems, reverse);
+        Assert.Throws<ArgumentException>(() => a.Union(otherReverse));
 
-        var merged = a.Union(other);
-        Assert.Equal(expected, merged.ToArray()); // canonical ascending
-        Assert.True(merged.Contains("a")); // binary search works on the canonical run
-        Assert.True(merged.Contains("c"));
+        // Same comparer still unions cleanly + symmetric Equals holds.
+        var otherOrdinal = GSet.OfSeq(otherItems, ordinal);
+        Assert.Equal(GSet.OfSeq(expected, ordinal), a.Union(otherOrdinal));
+        Assert.False(GSet.OfSeq(aItems, ordinal).Equals(GSet.OfSeq(aItems, reverse))); // diff comparer ⇒ not equal
     }
 }

--- a/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+using Zeta.Core.CSharp;
+
+namespace Zeta.Tests.CSharp.Algebra;
+
+/// <summary>
+/// G-Set cross-language conformance (C# oracle joining "meet-in-the-middle" per the
+/// fixture header). Replays the SHARED, self-describing golden vectors —
+/// <c>src/Core.TypeScript/g-set/golden-vectors.json</c> — and must value-match every
+/// <c>expectedReplayStates[i]</c> (after op i) AND <c>expectedFinalState</c>. The
+/// fixture embeds the canonical expected states (no per-language output file), so
+/// passing == agreeing with the TS/F#/Rust oracles. Read with
+/// <see cref="StringComparer.Ordinal"/> to match the fixture's stated ordinal/code-point
+/// order (not culture-sensitive <see cref="System.Collections.Generic.Comparer{T}.Default"/>).
+/// </summary>
+public class GSetCrossVerifyTests
+{
+    private static string RepoRoot()
+    {
+        // Walk up from the test assembly to the Zeta.sln sentinel (a git worktree's
+        // .git is a file, not a dir, so Zeta.sln is the reliable repo-root marker).
+        var dir = new DirectoryInfo(Path.GetDirectoryName(typeof(GSetCrossVerifyTests).Assembly.Location)!);
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "Zeta.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName
+            ?? throw new InvalidOperationException("Could not locate repo root (Zeta.sln) from test assembly location.");
+    }
+
+    private static string[] Strings(JsonElement array) =>
+        array.EnumerateArray().Select(e => e.GetString()!).ToArray();
+
+    [Fact]
+    public void GSetReplayMatchesGoldenVectors()
+    {
+        var root = RepoRoot();
+        var path = Path.Join(root, "src", "Core.TypeScript", "g-set", "golden-vectors.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        var r = doc.RootElement;
+        var cmp = StringComparer.Ordinal;
+
+        var state = GSet.OfSeq(Strings(r.GetProperty("initialSet")), cmp);
+        var ops = r.GetProperty("ops");
+        var expectedReplay = r.GetProperty("expectedReplayStates");
+        Assert.Equal(ops.GetArrayLength(), expectedReplay.GetArrayLength());
+
+        var i = 0;
+        foreach (var op in ops.EnumerateArray())
+        {
+            var kind = op.GetProperty("op").GetString();
+            state = kind switch
+            {
+                "add" => state.Add(op.GetProperty("arg").GetString()!),
+                "union" => state.Union(GSet.OfSeq(Strings(op.GetProperty("arg")), cmp)),
+                _ => throw new InvalidOperationException($"unknown op {kind}"),
+            };
+            Assert.Equal(Strings(expectedReplay[i]), state.ToArray());
+            i++;
+        }
+
+        Assert.Equal(Strings(r.GetProperty("expectedFinalState")), state.ToArray());
+    }
+
+    [Fact]
+    public void UnionObeysCrdtLaws()
+    {
+        var cmp = StringComparer.Ordinal;
+        static GSet<string> G(StringComparer cmp, params string[] xs) => GSet.OfSeq(xs, cmp);
+
+        var a = G(cmp, "a", "c");
+        var b = G(cmp, "b", "c", "d");
+        var c = G(cmp, "c", "e");
+
+        Assert.Equal(a, a.Union(a)); // idempotent
+        Assert.Equal(a.Union(b), b.Union(a)); // commutative
+        Assert.Equal(a.Union(b).Union(c), a.Union(b.Union(c))); // associative
+        Assert.Equal(a, a.Union(GSet.Empty<string>(cmp))); // identity
+        Assert.Equal(a, G(cmp, "a", "c").Add("c")); // add idempotent
+        Assert.Equal(G(cmp, "a", "b", "c"), G(cmp, "a", "b").Add("c"));
+    }
+}

--- a/tests/Tests.CSharp/Tests.CSharp.csproj
+++ b/tests/Tests.CSharp/Tests.CSharp.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\Core.fsproj" />
+    <ProjectReference Include="..\..\src\Core.CSharp\Core.CSharp.csproj" />
     <ProjectReference Include="..\..\src\Core.CSharp.ZetaId\Zeta.Core.CSharp.ZetaId.csproj" />
     <ProjectReference Include="..\..\src\Core.CSharp.TriBoolean\Zeta.Core.CSharp.TriBoolean.csproj" />
     <ProjectReference Include="..\..\src\Core.CSharp.Observe\Zeta.Core.CSharp.Observe.csproj" />


### PR DESCRIPTION
Completes the **G-Set** rung across all four oracles → **4/4 (TS/F#/C#/Rust)**, Tier-1 (shared golden-vector fixture). The directive: "go ahead with C# G-Set." Tracked by B-0959.

## What

- `src/Core.CSharp/GSet.cs` — in the C# core next to the Z-set binding (`ZetaCircuitBuilder`), mirroring F#'s `src/Core/GSet.fs` placement (F# has no separate algebra project; neither does the C# core).
  - **Non-generic companion-class** factory pattern (`GSet.Empty`/`Singleton`/`OfSeq`) + sealed generic `GSet<T>` instance methods — the .NET-idiomatic shape (`ImmutableArray`/`ImmutableArray<T>`) that satisfies **CA1000** (no statics on generic types).
  - **Explicit `IComparer<T>`** (like the TS `compare` param) so the cross-verify passes `StringComparer.Ordinal` — `Comparer<string>.Default` is culture-sensitive and would diverge from TS code-unit / Rust byte order beyond ASCII.
- `tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs` — reads the shared self-describing `src/Core.TypeScript/g-set/golden-vectors.json` (via `System.Text.Json`, BCL) and asserts every `expectedReplayStates[i]` + `expectedFinalState` (no per-lang output file). Plus the CRDT law tests.

## Proof

```
dotnet build src/Core.CSharp -c Release  → 0 warnings, 0 errors
dotnet test (--filter Algebra)           → Passed! 2/2 (cross-verify + CRDT laws)
```

**G-Set: 4/4** — the algebra ladder's bottom rung is complete across all oracles. Registry flip to Tier-1 follows once #6361 lands. Next: **Bag** (the missing middle) → **Z-set** (TS/Rust) → **bus**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)