### PR TITLE
feat(ace): slice 5.2 — semver ranges + version solver (B-0288)

### DIFF
--- a/.claude/skills/ace/SKILL.md
+++ b/.claude/skills/ace/SKILL.md
@@ -30,7 +30,7 @@ Publisher verbs: `keygen`, `sign`. Consumer verbs: `install`, `verify`, `trust a
 | `keygen` | `bun tools/ace/ace.ts keygen [--out <prefix>]` | Generate an Ed25519 keypair (writes `<prefix>.key` 0600 + `<prefix>.pub`) |
 | `sign` | `bun tools/ace/ace.ts sign <pkg> --key <priv.key> [--out <file>]` | Sign a package manifest with an Ed25519 private key |
 | `list` | `bun tools/ace/ace.ts list [--store <path>] [--json]` | List installed packages from `~/.ace/store` |
-| `install` | `bun tools/ace/ace.ts install <url-or-path> [--allow-no-signature]` | Resolve the transitive dependency graph, verify integrity + authenticity of every node, install leaves-first (atomic) |
+| `install` | `bun tools/ace/ace.ts install <url-or-path> [--allow-no-signature] [--print-resolution]` | Resolve the transitive dependency graph, verify integrity + authenticity of every node, install leaves-first (atomic) |
 | `verify` | `bun tools/ace/ace.ts verify <hash>` | Confirm an installed package is present |
 | `trust add` | `bun tools/ace/ace.ts trust add <pub-file-or-b64> [--label <name>]` | Add an Ed25519 public key to the user trust store (`~/.ace/trusted-keys.json`) |
 | `trust list` | `bun tools/ace/ace.ts trust list` | List all trusted keys (bundled + user) |
@@ -49,10 +49,43 @@ per node, identity-pinned by `package_hash`) and preflights path-safety + store-
 uniqueness BEFORE extracting anything — any failure installs nothing. Refusal reasons:
 `version-skew`, `tamper`, `pin-mismatch`, `bad-content-hash`, `bad-signature`,
 `untrusted-key`, `unsupported-algo`, `no-signature`, `cycle`, `fetch-failed`,
-`invalid-package`, `store-collision`. `--allow-no-signature` applies graph-wide
+`invalid-package`, `store-collision`, `registry-miss`, `registry-unsatisfiable`.
+`--allow-no-signature` applies graph-wide
 (permits only genuinely-unsigned nodes; a bad/untrusted signature on any node always refuses).
 
-A dependency edge is one of two kinds: `inline` (`{kind:"inline", name, version, url, package_hash}` — self-pinned) or `registry` (`{kind:"registry", name, version}` — resolved via the registry). Registry deps are looked up **exact-version** in the bundled (`tools/ace/registry.json`) ∪ user (`~/.ace/registry.json`) registry; a miss is the `registry-miss` refusal. After lookup, a registry dep runs the identical verify path (hash + pin + identity + signature) as an inline dep. Semver ranges + a solver are slice 5.2; a lockfile is 5.3.
+A dependency edge is one of two kinds: `inline` (`{kind:"inline", name, version, url, package_hash}` — self-pinned) or `registry` (`{kind:"registry", name, version}` — resolved via the registry). Registry deps are resolved against the bundled (`tools/ace/registry.json`) ∪ user (`~/.ace/registry.json`) registry. After lookup, a registry dep runs the identical verify path (hash + pin + identity + signature) as an inline dep.
+
+## Semver ranges (slice 5.2)
+
+Registry dependency `version` fields may be semver ranges. `ace install` runs a solver
+that picks the newest registry version satisfying each range across the transitive graph,
+then runs the same verify + atomic-install path.
+
+Supported range subset:
+
+- Caret `^1.2.0` — compatible with the major version
+- Tilde `~1.2.0` — compatible with the minor version
+- Comparators `>=1.0.0`, `<=2.0.0`, `>1.0.0`, `<2.0.0`, `=1.0.0`
+- Exact `1.2.3`
+- Wildcard `*` or `x`
+- Space-AND ranges `>=1.0.0 <2.0.0`
+
+Deferred to B-0970: `||` (OR ranges), hyphen ranges (`1.0.0 - 2.0.0`), pre-release tags.
+
+Inline edges stay exact-pinned by `package_hash` and are never registry-routed. An
+unsatisfiable range (no registry version matches any constraint) refuses with exit 1 and
+installs nothing (`registry-unsatisfiable` reason).
+
+### `--print-resolution`
+
+Pass `--print-resolution` to print the solved graph before installing:
+
+```bash
+ace install <pkg> --allow-no-signature --print-resolution
+```
+
+Each printed line has the format `name@version`, sorted lexicographically. Useful for
+auditing which versions the solver selected before committing to the install.
 
 ## Invocation
 
@@ -60,7 +93,7 @@ A dependency edge is one of two kinds: `inline` (`{kind:"inline", name, version,
 bun tools/ace/ace.ts list --json
 ```
 
-Exit codes: `0` ok · `64` usage error · `65` invalid package JSON · `1` refused (bad signature / untrusted key / integrity fail).
+Exit codes: `0` ok · `64` usage error · `65` invalid package JSON · `1` refused (bad signature / untrusted key / integrity fail / unsatisfiable range).
 
 ## Where the deep substrate lives (one Read away)
 

--- a/.claude/skills/ace/SKILL.md
+++ b/.claude/skills/ace/SKILL.md
@@ -49,7 +49,7 @@ per node, identity-pinned by `package_hash`) and preflights path-safety + store-
 uniqueness BEFORE extracting anything — any failure installs nothing. Refusal reasons:
 `version-skew`, `tamper`, `pin-mismatch`, `bad-content-hash`, `bad-signature`,
 `untrusted-key`, `unsupported-algo`, `no-signature`, `cycle`, `fetch-failed`,
-`invalid-package`, `store-collision`, `registry-miss`, `registry-unsatisfiable`.
+`invalid-package`, `store-collision`, `registry-miss`, `unsatisfiable`.
 `--allow-no-signature` applies graph-wide
 (permits only genuinely-unsigned nodes; a bad/untrusted signature on any node always refuses).
 
@@ -74,7 +74,7 @@ Deferred to B-0970: `||` (OR ranges), hyphen ranges (`1.0.0 - 2.0.0`), pre-relea
 
 Inline edges stay exact-pinned by `package_hash` and are never registry-routed. An
 unsatisfiable range (no registry version matches any constraint) refuses with exit 1 and
-installs nothing (`registry-unsatisfiable` reason).
+installs nothing (`unsatisfiable` reason).
 
 ### `--print-resolution`
 

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "semver": "7.8.1",
         "typescript": "6.0.3",
         "typescript-eslint": "8.59.0",
+        "z3-solver": "4.16.0",
       },
     },
   },
@@ -139,6 +140,8 @@
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "async-mutex": ["async-mutex@0.3.2", "", { "dependencies": { "tslib": "^2.3.1" } }, "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -430,6 +433,8 @@
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
@@ -453,6 +458,8 @@
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "z3-solver": ["z3-solver@4.16.0", "", { "dependencies": { "async-mutex": "^0.3.2" } }, "sha512-vWT+I5Yz0dXtseLVZsnkwAIrRmbxw0rCX5a6Xglc6n1CyPESNMnHB3iAWh7XTQQHZRlpWYnKJXTJ0ahTTNHZEg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "@types/bun": "1.3.12",
+        "@types/semver": "7.7.1",
         "eslint": "10.2.1",
         "eslint-plugin-sonarjs": "4.0.3",
         "globals": "17.5.0",
@@ -23,6 +24,7 @@
         "markdownlint-cli2": "0.22.1",
         "prettier": "3.8.3",
         "prettier-plugin-toml": "2.0.6",
+        "semver": "7.8.1",
         "typescript": "6.0.3",
         "typescript-eslint": "8.59.0",
       },
@@ -103,6 +105,8 @@
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
     "@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
@@ -404,7 +408,7 @@
 
     "scslre": ["scslre@0.3.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.0", "regexp-ast-analysis": "^0.7.0" } }, "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ=="],
 
-    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -453,6 +457,10 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "eslint-plugin-sonarjs/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice5.2-implementation-plan.md
+++ b/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice5.2-implementation-plan.md
@@ -1,0 +1,392 @@
+# Ace slice 5.2 — semver ranges + version solver: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A registry dependency can name a package by name + semver range; `ace install` solves the range constraints across the transitive graph to one concrete version per package, then feeds the solved graph into slice-5.1's unchanged verify + atomic-install engine.
+
+**Architecture:** Two new pure modules — `semver.ts` (subset range parser + `satisfies`/`compare`/`maxSatisfying`) and `solver.ts` (deterministic newest-first backtracking `solve()` that classifies edges by source: inline = pre-decided, registry = range-solved). `resolve()` gains a `solved: Map<string,string>` param + a `satisfies` defense-in-depth re-check. `ace install` runs solve→resolve.
+
+**Tech Stack:** TypeScript on Bun; `bun:test`. Test-only devDeps (differential oracles, never on the install path): `semver@7.8.1` + `@types/semver@7.7.1` (range-primitive oracle) and `z3-solver@4.16.0` (end-to-end SAT oracle). Versions WebSearch-pinned at authoring time 2026-06-01 per `.claude/rules/dep-pin-search-first-authority.md` (sources: npmjs.com/package/semver, /@types/semver, /z3-solver).
+
+**Spec:** `docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice5.2-semver-solver-design.md`.
+
+**Conventions (every commit):** `git ls-tree HEAD | wc -l` must stay **67**; branch = `otto-windows/ace-slice5.2-impl-2026-06-01`; trailer `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. Otto-343 hook blocks `Edit` on unread files → Read-first or `Write`/patch-script. Full suite: `bun test tools/ace/`. Strict tsc gate: `bunx tsc --noEmit` must be clean for `tools/ace/**` (Bun's transpiler is lenient — run tsc before the PR). markdownlint MD032 on any docs (blank line around lists).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `tools/ace/semver.ts` | new — pure subset: `parseVersion`, `compareVersions`, `parseRange`, `satisfies`, `maxSatisfying` |
+| `tools/ace/solver.ts` | new — `solve(root, fetchPackage, registry)` → `Map<name,version>` or failure |
+| `tools/ace/resolve.ts` | minimal — `solved` map param; registry edge concrete-from-map + `satisfies` re-check; `unsatisfiable`/`bad-range` reasons |
+| `tools/ace/ace.ts` | install runs solve→resolve; optional `--print-resolution` |
+| `tools/ace/semver.test.ts` | new — unit + node-semver differential |
+| `tools/ace/solver.test.ts` | new — unit + Z3 differential |
+| `tools/ace/resolve.test.ts`, `ace.test.ts` | range / unsatisfiable / inline-back-compat / e2e |
+| `package.json` | test-only devDeps `semver` 7.8.1, `@types/semver` 7.7.1, `z3-solver` 4.16.0 |
+| `.claude/skills/ace/SKILL.md` | range deps + solver docs |
+
+---
+
+## Task 1: `semver.ts` core — versions + exact/comparator/wildcard ranges + `satisfies`
+
+**Files:** Create `tools/ace/semver.ts`, `tools/ace/semver.test.ts`
+
+- [ ] **Step 1: Write failing tests** (`semver.test.ts`):
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { parseVersion, compareVersions, parseRange, satisfies } from "./semver.ts";
+
+describe("parseVersion + compareVersions", () => {
+  test("parses x.y.z", () => { expect(parseVersion("1.2.3")).toEqual({ major: 1, minor: 2, patch: 3 }); });
+  test("rejects junk", () => { expect(parseVersion("1.2")).toBeNull(); expect(parseVersion("v1.2.3")).toBeNull(); expect(parseVersion("1.2.x")).toBeNull(); });
+  test("orders numerically (not lexically)", () => {
+    expect(compareVersions("1.2.3", "1.2.10")).toBe(-1);
+    expect(compareVersions("2.0.0", "1.9.9")).toBe(1);
+    expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
+  });
+});
+
+describe("satisfies — exact / comparator / wildcard", () => {
+  test("exact", () => { expect(satisfies("1.2.3", "1.2.3")).toBe(true); expect(satisfies("1.2.4", "1.2.3")).toBe(false); expect(satisfies("1.2.3", "=1.2.3")).toBe(true); });
+  test("comparators", () => {
+    expect(satisfies("1.5.0", ">=1.2.0")).toBe(true);
+    expect(satisfies("1.1.0", ">=1.2.0")).toBe(false);
+    expect(satisfies("1.2.0", "<2.0.0")).toBe(true);
+    expect(satisfies("2.0.0", "<2.0.0")).toBe(false);
+    expect(satisfies("1.2.0", ">1.2.0")).toBe(false);
+    expect(satisfies("1.2.0", "<=1.2.0")).toBe(true);
+  });
+  test("wildcard * and x match any valid version", () => { expect(satisfies("9.9.9", "*")).toBe(true); expect(satisfies("0.0.1", "x")).toBe(true); });
+  test("malformed range surfaces via parseRange error", () => { expect("error" in (parseRange("@@@") as object)).toBe(true); });
+});
+```
+
+- [ ] **Step 2: Run** `bun test tools/ace/semver.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Implement `tools/ace/semver.ts`:**
+
+```ts
+// Pure semver subset for Ace slice 5.2 (no pre-release / build-metadata / unions / hyphen — see B-0970).
+export interface Version { readonly major: number; readonly minor: number; readonly patch: number }
+export type Comparator = { readonly op: ">=" | "<=" | ">" | "<" | "="; readonly v: Version };
+// A Range is a conjunction (AND) of comparators. `*` / `x` → empty conjunction (matches all).
+export type Range = { readonly comparators: ReadonlyArray<Comparator> };
+export type RangeOrError = Range | { readonly error: string };
+
+const VER = /^(\d+)\.(\d+)\.(\d+)$/;
+export function parseVersion(s: string): Version | null {
+  const m = VER.exec(s.trim());
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+export function compareVersions(a: string | Version, b: string | Version): -1 | 0 | 1 {
+  const pa = typeof a === "string" ? parseVersion(a) : a;
+  const pb = typeof b === "string" ? parseVersion(b) : b;
+  if (pa === null || pb === null) throw new Error("compareVersions: invalid version");
+  for (const k of ["major", "minor", "patch"] as const) {
+    if (pa[k] < pb[k]) return -1;
+    if (pa[k] > pb[k]) return 1;
+  }
+  return 0;
+}
+function cmp(a: Version, op: Comparator["op"], b: Version): boolean {
+  const c = compareVersions(a, b);
+  switch (op) {
+    case "=": return c === 0;
+    case ">": return c === 1;
+    case "<": return c === -1;
+    case ">=": return c >= 0;
+    case "<=": return c <= 0;
+  }
+}
+
+export function parseRange(s: string): RangeOrError {
+  const trimmed = s.trim();
+  if (trimmed === "" || trimmed === "*" || trimmed === "x" || trimmed === "X") return { comparators: [] };
+  const out: Comparator[] = [];
+  for (const tokenRaw of trimmed.split(/\s+/)) {
+    const sub = parseComparatorToken(tokenRaw);
+    if ("error" in sub) return sub;
+    out.push(...sub.comparators);
+  }
+  return { comparators: out };
+}
+
+// Task-2 will extend this with ^ / ~. Task 1: exact, comparators, wildcard token.
+function parseComparatorToken(token: string): RangeOrError {
+  if (token === "*" || token === "x" || token === "X") return { comparators: [] };
+  const m = /^(>=|<=|>|<|=)?(.+)$/.exec(token);
+  if (!m) return { error: `bad comparator: ${token}` };
+  const op = (m[1] ?? "=") as Comparator["op"];
+  const v = parseVersion(m[2]!);
+  if (v === null) return { error: `bad version in comparator: ${token}` };
+  return { comparators: [{ op, v }] };
+}
+
+export function satisfies(version: string, range: string | Range): boolean {
+  const v = parseVersion(version);
+  if (v === null) return false;
+  const r = typeof range === "string" ? parseRange(range) : range;
+  if ("error" in r) return false;
+  return r.comparators.every((c) => cmp(v, c.op, c.v));
+}
+```
+
+- [ ] **Step 4: Run** `bun test tools/ace/semver.test.ts` → PASS.
+- [ ] **Step 5: Commit** `feat(ace): semver subset — versions + exact/comparator/wildcard ranges + satisfies (slice 5.2 task 1)`
+
+---
+
+## Task 2: `semver.ts` — `^`/`~` desugar + AND-ranges + `maxSatisfying` + node-semver differential
+
+**Files:** Modify `tools/ace/semver.ts`, `tools/ace/semver.test.ts`, `package.json`
+
+- [ ] **Step 1: Add devDeps** to `package.json` `devDependencies` (exact-pinned, alphabetical near existing): `"@types/semver": "7.7.1"`, `"semver": "7.8.1"`. Run `bun install` so the lockfile updates. (WebSearch-pinned 2026-06-01 per dep-pin rule; cite in commit.)
+
+- [ ] **Step 2: Write failing tests** (append to `semver.test.ts`):
+
+```ts
+import { maxSatisfying } from "./semver.ts";
+import semverLib from "semver";
+
+describe("caret / tilde desugaring", () => {
+  test("^1.2.3 => >=1.2.3 <2.0.0", () => { expect(satisfies("1.9.0", "^1.2.3")).toBe(true); expect(satisfies("2.0.0", "^1.2.3")).toBe(false); expect(satisfies("1.2.2", "^1.2.3")).toBe(false); });
+  test("^0.2.3 => >=0.2.3 <0.3.0", () => { expect(satisfies("0.2.9", "^0.2.3")).toBe(true); expect(satisfies("0.3.0", "^0.2.3")).toBe(false); });
+  test("^0.0.3 => >=0.0.3 <0.0.4", () => { expect(satisfies("0.0.3", "^0.0.3")).toBe(true); expect(satisfies("0.0.4", "^0.0.3")).toBe(false); });
+  test("~1.2.3 => >=1.2.3 <1.3.0", () => { expect(satisfies("1.2.9", "~1.2.3")).toBe(true); expect(satisfies("1.3.0", "~1.2.3")).toBe(false); });
+});
+describe("AND ranges + maxSatisfying", () => {
+  test("space-AND", () => { expect(satisfies("1.5.0", ">=1.2.0 <2.0.0")).toBe(true); expect(satisfies("2.1.0", ">=1.2.0 <2.0.0")).toBe(false); });
+  test("maxSatisfying picks newest in range", () => {
+    expect(maxSatisfying(["1.0.0", "1.2.0", "1.9.0", "2.0.0"], "^1.0.0")).toBe("1.9.0");
+    expect(maxSatisfying(["1.0.0", "2.0.0"], "^3.0.0")).toBeNull();
+  });
+});
+describe("node-semver differential (oracle)", () => {
+  const versions = ["0.0.1", "0.2.3", "0.2.9", "1.0.0", "1.2.3", "1.2.10", "1.9.0", "2.0.0", "2.3.4"];
+  const ranges = ["1.2.3", "=1.2.3", ">=1.2.0", "<2.0.0", ">1.0.0 <2.0.0", "^1.2.3", "~1.2.3", "^0.2.3", "*"];
+  test("our satisfies matches semver.satisfies for the corpus", () => {
+    for (const v of versions) for (const r of ranges) expect(satisfies(v, r)).toBe(semverLib.satisfies(v, r));
+  });
+  test("our maxSatisfying matches semver.maxSatisfying for the corpus", () => {
+    for (const r of ranges) expect(maxSatisfying(versions, r)).toBe(semverLib.maxSatisfying(versions, r));
+  });
+});
+```
+
+- [ ] **Step 3: Implement** in `tools/ace/semver.ts`: (a) extend `parseComparatorToken` to handle `^` and `~`:
+
+```ts
+  if (token.startsWith("^") || token.startsWith("~")) {
+    const v = parseVersion(token.slice(1));
+    if (v === null) return { error: `bad version in range: ${token}` };
+    const lower: Comparator = { op: ">=", v };
+    let upper: Version;
+    if (token.startsWith("~")) upper = { major: v.major, minor: v.minor + 1, patch: 0 };
+    else if (v.major > 0) upper = { major: v.major + 1, minor: 0, patch: 0 };
+    else if (v.minor > 0) upper = { major: 0, minor: v.minor + 1, patch: 0 };
+    else upper = { major: 0, minor: 0, patch: v.patch + 1 };
+    return { comparators: [lower, { op: "<", v: upper }] };
+  }
+```
+
+(b) add `maxSatisfying`:
+
+```ts
+export function maxSatisfying(versions: ReadonlyArray<string>, range: string | Range): string | null {
+  let best: string | null = null;
+  for (const ver of versions) {
+    if (!satisfies(ver, range)) continue;
+    if (best === null || compareVersions(ver, best) === 1) best = ver;
+  }
+  return best;
+}
+```
+
+- [ ] **Step 4: Run** `bun test tools/ace/semver.test.ts` → PASS (incl. differential). Run `bunx tsc --noEmit 2>&1 | grep tools/ace` → clean.
+- [ ] **Step 5: Commit** `feat(ace): semver ^/~ desugar + AND ranges + maxSatisfying; node-semver differential (slice 5.2 task 2)`
+
+---
+
+## Task 3: `solver.ts` — source-classified newest-first backtracking `solve()` + unit tests
+
+**Files:** Create `tools/ace/solver.ts`, `tools/ace/solver.test.ts`
+
+The solver classifies each package name by **source** (spec §Solver): an **inline** edge fixes version + url/hash (pre-decided, never registry-looked-up); a **registry** edge contributes a range solved against registry versions. It re-validates already-assigned packages on **every** new constraint and backtracks on conflict.
+
+- [ ] **Step 1: Write failing tests** (`solver.test.ts`). Use a `fetchOf` map + `regOf` helper mirroring resolve.test.ts. Cover: inline-only graph (empty registry, no `registry-miss`); registry range resolves newest; transitive-dep narrows already-assigned pkg → backtrack to satisfying version; unsatisfiable; mixed inline+registry (inline authoritative); `bad-range`; determinism (same input → same map).
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { solve } from "./solver.ts";
+import { packageHash } from "./resolve.ts";
+import type { AcePackage, RegistryEntry } from "./store.ts";
+
+const enc = (f: Record<string, string>) => "sha256:" + Bun.hash(JSON.stringify(f)).toString(); // placeholder; use real content_hash helper from resolve.test.ts pattern
+// NOTE: implementer — reuse the exact pkgOf/fetchOf/regOf/content_hash helpers used in resolve.test.ts for consistency.
+
+// (Implementer writes the full helper block mirroring resolve.test.ts, then:)
+// - inline-only: root has one inline edge A@1.0.0 (url+hash), empty registry → solve ok, no registry-miss; map has no registry entry for A (inline-sourced).
+// - registry: registry has A {1.0.0,1.5.0,1.9.0}; root edge {kind:registry,name:A,version:"^1.0.0"} → solved A=1.9.0.
+// - backtrack: root → A ">=1.0.0" (newest 1.9.0) and B "*"; B@<newest> deps A "<1.6.0"; registry A has 1.0.0..1.9.0 → solver backtracks A to highest <1.6.0 (e.g. 1.5.0).
+// - unsatisfiable: A ">=2.0.0" but registry A only has 1.x → reason "unsatisfiable".
+// - bad-range: edge version "@@@" → reason "bad-range".
+// - determinism: two solve() runs on same (root,registry) return equal maps.
+```
+
+- [ ] **Step 2: Run** `bun test tools/ace/solver.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement `tools/ace/solver.ts`:**
+
+```ts
+import { parseRange, satisfies, maxSatisfying, compareVersions } from "./semver.ts";
+import { packageHash } from "./resolve.ts";
+import type { AcePackage, AceDependency, Registry } from "./store.ts";
+import type { FetchPackage } from "./resolve.ts";
+
+export type SolveResult =
+  | { ok: true; versions: Map<string, string> }
+  | { ok: false; reason: "unsatisfiable" | "bad-range" | "registry-miss" | "fetch-failed" | "invalid-package"; detail: string; path: string[] };
+
+interface Constraint { readonly range: string; readonly via: string[] }
+
+export async function solve(root: AcePackage, fetchPackage: FetchPackage, registry: Registry): Promise<SolveResult> {
+  // edges(): typed accessor over untrusted manifest.dependencies
+  const edgesOf = (p: AcePackage): AceDependency[] => Array.isArray(p.manifest.dependencies) ? [...p.manifest.dependencies] : [];
+  // inline source map: name -> {version, pkg} discovered from inline edges (pre-decided)
+  // registry constraint map: name -> Constraint[] (ranges to intersect)
+  // assignment: name -> version
+  // fetched cache: "name@version" -> AcePackage (solve-run scoped)
+  const fetched = new Map<string, AcePackage>();
+  const fetchByUrl = async (url: string, here: string[]): Promise<AcePackage | SolveResult> => {
+    try { return JSON.parse(await fetchPackage(url)) as AcePackage; }
+    catch (e) { return { ok: false, reason: "fetch-failed", detail: `${url}: ${(e as Error).message}`, path: here }; }
+  };
+
+  // Backtracking search. Implementer: a recursive/iterative explorer that
+  //  (1) seeds constraints from root edges (classify inline vs registry),
+  //  (2) for registry names, intersect ranges + maxSatisfying over registry.get(name) keys, newest-first,
+  //  (3) on adding any constraint to an already-assigned name, RE-VALIDATE (satisfies(assigned, newRange)); if violated, backtrack to the decision that introduced the narrowing and try its next-lower candidate,
+  //  (4) inline names: record version from the inline edge (NO registry lookup); fetch via inline url to recurse into its deps; if a registry range for the same name is not satisfied by the inline version → unsatisfiable,
+  //  (5) registry name with no candidate in intersected range → backtrack; exhausted → unsatisfiable,
+  //  (6) validate ranges with parseRange first; "error" in parseRange → bad-range,
+  //  (7) deterministic: candidate versions sorted desc via compareVersions; package visitation sorted by name.
+  // Returns { ok:true, versions } where `versions` contains an entry for every REGISTRY-sourced name
+  // (inline-sourced names install via their inline edge in resolve(), so a map entry is optional but
+  //  harmless; include inline-fixed versions too for completeness).
+  // ... full implementation by the implementer ...
+}
+```
+
+Implementer: write the full backtracking search per the 7 numbered rules above + the spec §Solver. Keep it pure aside from `fetchPackage`. Prefer an explicit decision-stack over deep recursion so backtracking is clean. The registry's available versions for a name are `[...registry.get(name)?.keys() ?? []]`.
+
+- [ ] **Step 4: Run** `bun test tools/ace/solver.test.ts` → PASS. `bunx tsc --noEmit 2>&1 | grep tools/ace` → clean.
+- [ ] **Step 5: Commit** `feat(ace): version solver — source-classified newest-first backtracking solve() (slice 5.2 task 3)`
+
+---
+
+## Task 4: solver Z3 differential test
+
+**Files:** Modify `package.json`, create `tools/ace/solver.z3.test.ts`
+
+- [ ] **Step 1: Add devDep** `"z3-solver": "4.16.0"` to `package.json` `devDependencies`; `bun install`. (WebSearch-pinned 2026-06-01; cite in commit.)
+
+- [ ] **Step 2: Write the Z3 differential test** (`solver.z3.test.ts`). z3-solver is WASM + async-init; init once. Scope: Z3 as a **satisfiability oracle** — generate a corpus of (packages → available int versions, edges → ranges as int constraints), ask Z3 "does an assignment satisfying all comparator constraints exist?", and assert our `solve()` verdict agrees (ok ⇔ Z3 SAT, unsatisfiable ⇔ Z3 UNSAT). For SAT cases also assert our returned assignment actually satisfies every range (self-consistency). Do NOT require Z3 to reproduce our newest-first tie-break (that is validated against node-semver in Task 2).
+
+```ts
+import { describe, expect, test, beforeAll } from "bun:test";
+import { init } from "z3-solver";
+// map each x.y.z to an int major*1_000_000 + minor*1_000 + patch for Z3 integer constraints;
+// encode each comparator (>= <= > < =) as an int (in)equality; AND them per package; ask check().
+// Compare to solve() over the same registry+edges. z3-solver is a WASM devDep present in CI →
+// this test ASSERTS (no skip) per automated-tests-are-the-shield.
+```
+
+Implementer: keep the corpus small but adversarial (include at least one UNSAT graph + one backtrack-needed graph). If `init()` is slow, guard with a generous test timeout, NOT a skip.
+
+- [ ] **Step 3: Run** `bun test tools/ace/solver.z3.test.ts` → PASS. `bunx tsc --noEmit 2>&1 | grep tools/ace` → clean.
+- [ ] **Step 4: Commit** `test(ace): Z3 differential — SAT-oracle cross-check of the TS solver (slice 5.2 task 4)`
+
+---
+
+## Task 5: `resolve.ts` integration — solved-map param + `satisfies` re-check + new reasons
+
+**Files:** Modify `tools/ace/resolve.ts`, `tools/ace/resolve.test.ts`
+
+- [ ] **Step 1: Update resolve.test.ts** — add `solved` arg (a `Map<string,string>`) to EVERY existing `resolve(...)` call (4th-after-trustStore is already `registry`; `solved` is the new 5th, before `opts` → search `new Map(), {` and insert another map, OR pass the solved map explicitly). Then add tests: a registry range edge whose concrete version comes from the `solved` map resolves+verifies; a `solved` map entry that violates the edge's range → `unsatisfiable` (defense-in-depth `satisfies` re-check); a registry name absent from the map → `unsatisfiable`; inline edges still resolve unchanged.
+
+- [ ] **Step 2: Run** `bun test tools/ace/resolve.test.ts` → FAIL (signature).
+
+- [ ] **Step 3: Implement** in `tools/ace/resolve.ts`: (a) `import { satisfies } from "./semver.ts";` (b) add `"unsatisfiable" | "bad-range"` to `ResolveReason`. (c) add `solved: Map<string, string>` param after `registry`, before `opts`. (d) in the registry-edge branch, derive concrete from the map + re-check:
+
+```ts
+      if (edge.kind === "registry") {
+        const concrete = solved.get(edge.name);
+        if (concrete === undefined) return { ok: false, reason: "unsatisfiable", detail: `${edge.name}: no solved version`, path: here };
+        if (!satisfies(concrete, edge.version)) return { ok: false, reason: "unsatisfiable", detail: `${edge.name}: solved ${concrete} violates ${edge.version}`, path: here };
+        const entry = registry.get(edge.name)?.get(concrete);
+        if (entry === undefined) return { ok: false, reason: "registry-miss", detail: `${edge.name}@${concrete} not in registry`, path: here };
+        url = entry.url; package_hash = entry.package_hash;
+        // downstream byName/version-skew/tamper use `concrete` — bind a local and use it for those checks
+      }
+```
+
+Implementer: ensure the registry-edge concrete version (not the range string) is what flows into the `visiting`/`byName`/`seen.version` bookkeeping below (replace the prior `edge.version` usages on the registry path with `concrete`; inline path keeps `edge.version`). Keep all verify steps intact.
+
+- [ ] **Step 4: Run** `bun test tools/ace/resolve.test.ts` + full `bun test tools/ace/` → PASS. `bunx tsc --noEmit 2>&1 | grep tools/ace` → clean.
+- [ ] **Step 5: Commit** `feat(ace): resolver solved-map param + satisfies defense-in-depth re-check (slice 5.2 task 5)`
+
+---
+
+## Task 6: `ace.ts` install solve→resolve wiring + e2e + SKILL.md
+
+**Files:** Modify `tools/ace/ace.ts`, `tools/ace/ace.test.ts`, `.claude/skills/ace/SKILL.md`
+
+- [ ] **Step 1: Update ace.test.ts** — every existing `resolve(...)` call gets the `solved` arg; add e2e tests via `main(["install", …])`: (a) install a root with a ranged registry dep resolving across a multi-version registry → exit 0, both installed; (b) unsatisfiable graph (range no registry version satisfies) → exit 1, store empty; (c) inline-only graph (empty registry) → exit 0 (back-compat, no `registry-miss`).
+
+- [ ] **Step 2: Run** `bun test tools/ace/ace.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement** in `tools/ace/ace.ts`: import `solve` from `./solver.ts`. In the install handler, before the graph `resolve` call, run the solver and thread its map:
+
+```ts
+      const sv = await solve(pkg, fetchPackage, loadRegistry());
+      if (!sv.ok) { console.error(`ace: install: ${sv.reason}: ${sv.detail} (at ${sv.path.join(" → ")})`); return 1; }
+      if (parsed.printResolution) for (const [n, v] of [...sv.versions].sort()) console.log(`  ${n}@${v}`);
+      const r = await resolve(pkg, fetchPackage, loadTrustStore(), loadRegistry(), sv.versions, { allowNoSignature: parsed.allowNoSignature });
+```
+
+Add an optional `--print-resolution` flag to the install parse (mirror `--allow-no-signature`); carry `printResolution?: boolean` on the parsed install args. Confirm `solve` import + `loadRegistry` (already imported from slice 5.1).
+
+- [ ] **Step 4: SKILL.md** — add to `.claude/skills/ace/SKILL.md`: registry deps may use a semver range (`{kind:"registry", name, version:"^1.2.0"}`); `ace install` solves ranges → concrete versions over the registry (pragmatic subset: `^ ~ >= <= > < =`, exact, `*`, AND-ranges; advanced semver is B-0970); inline edges stay exact-pinned + are never registry-routed; `--print-resolution` prints the solved graph; an unsatisfiable graph refuses (exit 1, nothing installed). Watch MD032 (blank line around any list).
+
+- [ ] **Step 5: Run** full `bun test tools/ace/` → PASS. `bunx tsc --noEmit 2>&1 | grep tools/ace` → clean. `bunx markdownlint-cli2 ".claude/skills/ace/SKILL.md"` → clean. `git ls-tree HEAD | wc -l` → 67.
+- [ ] **Step 6: Commit** `feat(ace): install runs solve→resolve; --print-resolution; SKILL docs (slice 5.2 task 6)`
+
+---
+
+## Final: open the PR
+
+After all 6 tasks + a final code-review subagent + a full `bunx tsc --noEmit` + `bun test tools/ace/` pass:
+
+```bash
+git push -u origin otto-windows/ace-slice5.2-impl-2026-06-01
+gh pr create --head otto-windows/ace-slice5.2-impl-2026-06-01 --base main \
+  --title "feat(ace): slice 5.2 — semver ranges + version solver (B-0288)" --body "<summary>"
+gh pr merge <N> --auto --squash
+```
+
+Then the standard PR-gate loop (`bun tools/github/poll-pr-gate.ts <N>`): verify-before-fix on review threads, keep canary 67, resolve threads, land on green.
+
+---
+
+## Self-Review
+
+**Spec coverage:** semver subset (Task 1-2) · ^/~/AND/wildcard (Task 1-2) · maxSatisfying (Task 2) · node-semver oracle (Task 2) · solver source-classification inline-vs-registry (Task 3) · newest-first + re-validation + backtracking (Task 3) · unsatisfiable/bad-range (Task 3+5) · Z3 SAT oracle (Task 4) · resolve solved-map + satisfies re-check (Task 5) · install solve→resolve + --print-resolution (Task 6) · inline back-compat regression guard (Task 3 + 6) · SKILL docs (Task 6) · devDeps pinned (Task 2+4). All spec test cases mapped.
+
+**Placeholder scan:** Tasks 1-2-5-6 have full code; Tasks 3-4 give exact signatures + numbered algorithm rules + the test corpus (the backtracking body + Z3 encoding are the implementer's to write from the rules — flagged explicitly, not hidden). The `enc` helper in Task 3 Step 1 is marked placeholder → implementer reuses resolve.test.ts's real content_hash helper.
+
+**Type consistency:** `SolveResult.versions: Map<string,string>` consistent across solver (Task 3) + resolve param (Task 5) + ace wiring (Task 6). `Range`/`Comparator`/`Version` consistent (Task 1-2). `satisfies`/`maxSatisfying`/`compareVersions` signatures consistent. `resolve(root, fetchPackage, trustStore, registry, solved, opts)` consistent across def (Task 5) + all call-sites (Task 5 tests + Task 6 ace + ace.test).

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@eslint/js": "10.0.1",
     "@types/bun": "1.3.12",
     "@types/semver": "7.7.1",
-    "semver": "7.8.1",
     "eslint": "10.2.1",
     "eslint-plugin-sonarjs": "4.0.3",
     "globals": "17.5.0",
@@ -34,8 +33,10 @@
     "markdownlint-cli2": "0.22.1",
     "prettier": "3.8.3",
     "prettier-plugin-toml": "2.0.6",
+    "semver": "7.8.1",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.59.0"
+    "typescript-eslint": "8.59.0",
+    "z3-solver": "4.16.0"
   },
   "overrides": {
     "smol-toml": "1.6.1"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@types/bun": "1.3.12",
+    "@types/semver": "7.7.1",
+    "semver": "7.8.1",
     "eslint": "10.2.1",
     "eslint-plugin-sonarjs": "4.0.3",
     "globals": "17.5.0",

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -689,3 +689,56 @@ describe("registry commands", () => {
     expect(listInstalled(store).length).toBe(0);
   });
 });
+
+// ---- semver ranges + solver (slice 5.2) ----
+
+describe("install — semver ranges (slice 5.2)", () => {
+  test("e2e: ranged registry dep resolves to newest satisfying version", async () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-graph-"));
+    const dir = mkdtempSync(join(tmpdir(), "ace-pkgs-"));
+    const h = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+    const mkA = (v: string) => ({ manifest: { format_version:1, name:"A", version:v, content_hash: h({ "a.txt":v }) }, files: { "a.txt":v } });
+    for (const v of ["1.0.0","1.5.0","1.9.0"]) { const p = join(dir, `A-${v}.json`); writeFileSync(p, JSON.stringify(mkA(v))); await main(["registry","add","A",v,p]); }
+    const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: h({ "r.txt":"r" }), dependencies:[{ kind:"registry" as const, name:"A", version:"^1.0.0" }] }, files: { "r.txt":"r" } };
+    const rootPath = join(dir, "root.json"); writeFileSync(rootPath, JSON.stringify(root));
+    expect(await main(["install", rootPath, "--store", store, "--allow-no-signature"])).toBe(0);
+    const names = listInstalled(store).map((p)=>`${p.manifest.name}@${p.manifest.version}`).sort();
+    expect(names).toEqual(["A@1.9.0", "root@1.0.0"]);
+  });
+
+  test("e2e: unsatisfiable range → exit 1, store empty", async () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-graph-"));
+    const dir = mkdtempSync(join(tmpdir(), "ace-pkgs-"));
+    const h = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+    const A = { manifest: { format_version:1, name:"A", version:"1.0.0", content_hash: h({ "a.txt":"a" }) }, files: { "a.txt":"a" } };
+    const ap = join(dir, "A.json"); writeFileSync(ap, JSON.stringify(A)); await main(["registry","add","A","1.0.0",ap]);
+    const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: h({ "r.txt":"r" }), dependencies:[{ kind:"registry" as const, name:"A", version:">=2.0.0" }] }, files: { "r.txt":"r" } };
+    const rootPath = join(dir, "root.json"); writeFileSync(rootPath, JSON.stringify(root));
+    expect(await main(["install", rootPath, "--store", store, "--allow-no-signature"])).toBe(1);
+    expect(listInstalled(store).length).toBe(0);
+  });
+
+  test("e2e: inline-only graph still installs (empty registry, no registry-miss)", async () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-graph-"));
+    const dir = mkdtempSync(join(tmpdir(), "ace-pkgs-"));
+    const h = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+    const A = { manifest: { format_version:1, name:"A", version:"1.0.0", content_hash: h({ "a.txt":"a" }) }, files: { "a.txt":"a" } };
+    const ap = join(dir, "A.json"); writeFileSync(ap, JSON.stringify(A));
+    const aHash = packageHash(A as any);
+    const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: h({ "r.txt":"r" }), dependencies:[{ kind:"inline" as const, name:"A", version:"1.0.0", url: ap, package_hash: aHash }] }, files: { "r.txt":"r" } };
+    const rootPath = join(dir, "root.json"); writeFileSync(rootPath, JSON.stringify(root));
+    expect(await main(["install", rootPath, "--store", store, "--allow-no-signature"])).toBe(0);
+    expect(listInstalled(store).map((p)=>p.manifest.name).sort()).toEqual(["A","root"]);
+  });
+
+  test("e2e: --print-resolution prints the solved graph", async () => {
+    const store = mkdtempSync(join(tmpdir(), "ace-graph-"));
+    const dir = mkdtempSync(join(tmpdir(), "ace-pkgs-"));
+    const h = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+    const A = { manifest: { format_version:1, name:"A", version:"1.2.0", content_hash: h({ "a.txt":"a" }) }, files: { "a.txt":"a" } };
+    const ap = join(dir, "A.json"); writeFileSync(ap, JSON.stringify(A)); await main(["registry","add","A","1.2.0",ap]);
+    const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: h({ "r.txt":"r" }), dependencies:[{ kind:"registry" as const, name:"A", version:"^1.0.0" }] }, files: { "r.txt":"r" } };
+    const rootPath = join(dir, "root.json"); writeFileSync(rootPath, JSON.stringify(root));
+    expect(await main(["install", rootPath, "--store", store, "--allow-no-signature", "--print-resolution"])).toBe(0);
+  });
+});

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -24,6 +24,7 @@ import {
 } from "./store";
 import { generateKeypair, signManifest, verifySignature, keyId } from "./signing";
 import { resolve, packageHash } from "./resolve.ts";
+import { solve } from "./solver.ts";
 import { resolve as toAbsolutePath } from "node:path";
 
 interface ListArgs {
@@ -488,7 +489,12 @@ export async function main(argv: readonly string[]): Promise<number> {
       }
       const fetchPackage = async (u: string): Promise<string> =>
         (u.startsWith("http://") || u.startsWith("https://")) ? await (await fetch(u)).text() : readFileSync(u, "utf8");
-      const res = await resolve(pkg, fetchPackage, loadTrustStore(), loadRegistry(), { allowNoSignature: parsed.allowNoSignature });
+      const solveResult = await solve(pkg, fetchPackage, loadRegistry());
+      if (!solveResult.ok) {
+        console.error(`ace: install refused: ${solveResult.reason} — ${solveResult.detail} (path: ${solveResult.path.join(" → ")})`);
+        return 1;
+      }
+      const res = await resolve(pkg, fetchPackage, loadTrustStore(), loadRegistry(), solveResult.versions, { allowNoSignature: parsed.allowNoSignature });
       if (!res.ok) {
         console.error(`ace: install refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`);
         return 1;

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -3,7 +3,7 @@
 //
 // Usage:
 //   bun tools/ace/ace.ts list [--store <path>] [--json]
-//   bun tools/ace/ace.ts install <url-or-path> [--allow-no-signature]
+//   bun tools/ace/ace.ts install <url-or-path> [--allow-no-signature] [--print-resolution]
 //   bun tools/ace/ace.ts verify <hash>
 //   bun tools/ace/ace.ts keygen [--out <prefix>]
 //   bun tools/ace/ace.ts sign <pkg> --key <priv.key> [--out <file>]
@@ -42,6 +42,7 @@ interface InstallArgs {
   readonly source: string;
   readonly storePath: string;
   readonly allowNoSignature: boolean;
+  readonly printResolution?: boolean;
 }
 
 interface VerifyArgs {
@@ -181,6 +182,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
     if (!source || source.startsWith("-")) return { error: "install requires a <url-or-path> argument" };
     let storePath = defaultStorePath();
     let allowNoSignature = false;
+    let printResolution = false;
     for (let i = 2; i < argv.length; i++) {
       if (argv[i] === "--store" || argv[i] === "-s") {
         const next = argv[i + 1];
@@ -189,11 +191,15 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
         i++;
       } else if (argv[i] === "--allow-no-signature") {
         allowNoSignature = true;
+      } else if (argv[i] === "--print-resolution") {
+        printResolution = true;
       } else {
         return { error: `Unknown option for install: ${argv[i]}` };
       }
     }
-    return { command: "install", source, storePath, allowNoSignature };
+    const baseResult: InstallArgs = { command: "install", source, storePath, allowNoSignature };
+    if (printResolution) return { ...baseResult, printResolution: true };
+    return baseResult;
   }
 
   if (command === "verify") {
@@ -238,8 +244,10 @@ function printUsage(): void {
 
 Usage:
   ace list [--store <path>] [--json]             List installed DLC packages
-  ace install <url-or-path> [--allow-no-signature]   Download/read a package, verify integrity+authenticity, install
+  ace install <url-or-path> [--allow-no-signature] [--print-resolution]
+                                                   Download/read a package, verify integrity+authenticity, install
                                                    --allow-no-signature only installs packages with NO signature; it never bypasses a present (bad or untrusted) signature
+                                                   --print-resolution prints the solved name@version graph before installing
   ace verify <hash>                              Confirm an installed package is present
   ace keygen [--out <prefix>]                    Generate an Ed25519 keypair (writes <prefix>.key + <prefix>.pub)
   ace sign <pkg> --key <priv.key> [--out <file>] Sign a package manifest with an Ed25519 private key
@@ -493,6 +501,12 @@ export async function main(argv: readonly string[]): Promise<number> {
       if (!solveResult.ok) {
         console.error(`ace: install refused: ${solveResult.reason} — ${solveResult.detail} (path: ${solveResult.path.join(" → ")})`);
         return 1;
+      }
+      // Print the solved graph if --print-resolution was requested.
+      if (parsed.printResolution) {
+        for (const [n, v] of [...solveResult.versions].sort()) {
+          console.log(`  ${n}@${v}`);
+        }
       }
       const res = await resolve(pkg, fetchPackage, loadTrustStore(), loadRegistry(), solveResult.versions, { allowNoSignature: parsed.allowNoSignature });
       if (!res.ok) {

--- a/tools/ace/resolve.test.ts
+++ b/tools/ace/resolve.test.ts
@@ -49,7 +49,7 @@ const NO_TRUST = new Map(); // empty trust store; basic tests pass allowNoSignat
 describe("resolve — basic", () => {
   test("leaf package (no deps) resolves to [root]", async () => {
     const root = pkgOf("root", { "r.txt": "x" });
-    const r = await resolve(root, fetchOf({}), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({}), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.order.map((p) => p.manifest.name)).toEqual(["root"]);
   });
@@ -57,7 +57,7 @@ describe("resolve — basic", () => {
     const B = pkgOf("B", { "b.txt": "b" });
     const A = pkgOf("A", { "a.txt": "a" }, [{ pkg: B, url: "http://e/B" }]);
     const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: A, url: "http://e/A" }]);
-    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B }), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.order.map((p) => p.manifest.name)).toEqual(["B", "A", "root"]);
   });
@@ -69,7 +69,7 @@ describe("resolve — dedup", () => {
     const A = pkgOf("A", { "a.txt": "a" }, [{ pkg: D, url: "http://e/D" }]);
     const B = pkgOf("B", { "b.txt": "b" }, [{ pkg: D, url: "http://e/D" }]);
     const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: A, url: "http://e/A" }, { pkg: B, url: "http://e/B" }]);
-    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B, "http://e/D": D }), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B, "http://e/D": D }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.order.filter((p) => p.manifest.name === "D").length).toBe(1);
   });
@@ -78,7 +78,7 @@ describe("resolve — dedup", () => {
     const X = pkgOf("X", files);
     const Y = pkgOf("Y", files); // same files, different name => different package_hash
     const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: X, url: "http://e/X" }, { pkg: Y, url: "http://e/Y" }]);
-    const r = await resolve(root, fetchOf({ "http://e/X": X, "http://e/Y": Y }), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/X": X, "http://e/Y": Y }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.order.map((p) => p.manifest.name).sort()).toEqual(["X", "Y", "root"]);
   });
@@ -91,7 +91,7 @@ describe("resolve — conflicts", () => {
     const A = pkgOf("A", { "a.txt": "a" }, [{ pkg: D1, url: "http://e/D1" }]);
     const B: AcePackage = { manifest: { ...pkgOf("B", { "b.txt": "b" }).manifest, dependencies: [{ kind: "inline" as const, name: "D", version: "2.0.0", url: "http://e/D2", package_hash: packageHash(D2) }] }, files: { "b.txt": "b" } };
     const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: A, url: "http://e/A" }, { pkg: B, url: "http://e/B" }]);
-    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B, "http://e/D1": D1, "http://e/D2": D2 }), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B, "http://e/D1": D1, "http://e/D2": D2 }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("version-skew");
   });
@@ -99,7 +99,7 @@ describe("resolve — conflicts", () => {
     const root2: AcePackage = { manifest: { format_version: 1, name: "root", version: "2.0.0", content_hash: "sha256:zzz" }, files: { "r.txt": "two" } };
     const A: AcePackage = { manifest: { ...pkgOf("A", { "a.txt": "a" }).manifest, dependencies: [{ kind: "inline" as const, name: "root", version: "2.0.0", url: "http://e/root2", package_hash: packageHash(root2) }] }, files: { "a.txt": "a" } };
     const root = pkgOf("root", { "r.txt": "one" }, [{ pkg: A, url: "http://e/A" }]);
-    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/root2": root2 }), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/root2": root2 }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(["version-skew", "cycle"]).toContain(r.reason);
   });
@@ -108,7 +108,7 @@ describe("resolve — conflicts", () => {
     const rootPlaceholder = pkgOf("root", root1Files);
     const A: AcePackage = { manifest: { ...pkgOf("A", { "a.txt": "a" }).manifest, dependencies: [{ kind: "inline" as const, name: "root", version: "1.0.0", url: "http://e/root", package_hash: packageHash(rootPlaceholder) }] }, files: { "a.txt": "a" } };
     const root = pkgOf("root", root1Files, [{ pkg: A, url: "http://e/A" }]);
-    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/root": root }), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/root": root }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("cycle");
   });
@@ -118,7 +118,7 @@ describe("resolve — conflicts", () => {
     const B: AcePackage = { manifest: { ...pkgOf("B", bFiles).manifest, dependencies: [{ kind: "inline" as const, name: "A", version: "1.0.0", url: "http://e/A", package_hash: packageHash(aPlaceholder) }] }, files: bFiles };
     const A: AcePackage = { manifest: { ...pkgOf("A", aFiles).manifest, dependencies: [{ kind: "inline" as const, name: "B", version: "1.0.0", url: "http://e/B", package_hash: packageHash(B) }] }, files: aFiles };
     const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: A, url: "http://e/A" }]);
-    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B }), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/B": B }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) { expect(r.reason).toBe("cycle"); expect(r.path).toContain("A"); }
   });
@@ -129,7 +129,7 @@ describe("resolve — verification", () => {
     const D = pkgOf("D", { "d.txt": "d" });
     const tampered: AcePackage = { manifest: D.manifest, files: { "d.txt": "TAMPERED" } };
     const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: D, url: "http://e/D" }]); // edge pins original D
-    const r = await resolve(root, fetchOf({ "http://e/D": tampered }), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/D": tampered }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("bad-content-hash");
   });
@@ -137,7 +137,7 @@ describe("resolve — verification", () => {
     const D = pkgOf("D", { "d.txt": "d" });
     const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: D, url: "http://e/D" }]);
     (root.manifest.dependencies as any)[0] = { kind: "inline" as const, ...root.manifest.dependencies![0], package_hash: "sha256:wrongwrong" };
-    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("pin-mismatch");
   });
@@ -145,24 +145,24 @@ describe("resolve — verification", () => {
     const D = pkgOf("D", { "d.txt": "d" });
     const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: D, url: "http://e/D" }]);
     (root.manifest.dependencies as any)[0] = { kind: "inline" as const, ...root.manifest.dependencies![0], name: "NOT_D" };
-    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("pin-mismatch");
   });
   test("unsigned node refuses without allowNoSignature, resolves with it", async () => {
     const D = pkgOf("D", { "d.txt": "d" });
     const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: D, url: "http://e/D" }]);
-    const strict = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, new Map(), { allowNoSignature: false });
+    const strict = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, new Map(), new Map(), { allowNoSignature: false });
     expect(strict.ok).toBe(false);
     if (!strict.ok) expect(strict.reason).toBe("no-signature");
-    const lax = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, new Map(), { allowNoSignature: true });
+    const lax = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(lax.ok).toBe(true);
   });
   test("untrusted/bad signature refuses even with allowNoSignature:true", async () => {
     const D = pkgOf("D", { "d.txt": "d" });
     const signed: AcePackage = { manifest: { ...D.manifest, signature: { algo: "ed25519", key_id: "ed25519:unknownkey", sig: "AAAA" } }, files: D.files };
     const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: signed, url: "http://e/D" }]);
-    const r = await resolve(root, fetchOf({ "http://e/D": signed }), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/D": signed }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(["untrusted-key", "bad-signature"]).toContain(r.reason);
   });
@@ -172,7 +172,7 @@ describe("resolve — invalid package", () => {
   test("dep JSON that is parseable but not an AcePackage refuses invalid-package (no throw)", async () => {
     const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: pkgOf("D", { "d.txt": "d" }), url: "http://e/D" }]);
     const badFetch: FetchPackage = async () => JSON.stringify({ foo: 1 }); // valid JSON, not an AcePackage
-    const r = await resolve(root, badFetch, NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, badFetch, NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("invalid-package");
   });
@@ -182,7 +182,7 @@ describe("resolve — invalid package", () => {
     const badDep: any = { manifest: { ...D.manifest, dependencies: {} }, files: D.files }; // dependencies present but not an array
     // point the root edge's package_hash at badDep so it passes the pin check and reaches the dependencies access
     (root.manifest.dependencies as any)[0] = { kind: "inline" as const, name: "D", version: "1.0.0", url: "http://e/D", package_hash: packageHash(badDep) };
-    const r = await resolve(root, fetchOf({ "http://e/D": badDep }), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/D": badDep }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("invalid-package");
   });
@@ -200,14 +200,15 @@ describe("resolve — registry deps", () => {
     const D = pkgOf("D", { "d.txt": "d" });
     const root: AcePackage = { manifest: { ...pkgOf("root", { "r.txt": "r" }).manifest, dependencies: [regEdge("D", "1.0.0")] }, files: { "r.txt": "r" } };
     const reg = regOf({ D: { "1.0.0": { url: "http://e/D", package_hash: packageHash(D) } } });
-    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, reg, { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, reg, new Map([["D", "1.0.0"]]), { allowNoSignature: true });
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.order.map((p) => p.manifest.name)).toEqual(["D", "root"]);
   });
   test("registry-miss (name/version absent) refuses", async () => {
     const root: AcePackage = { manifest: { ...pkgOf("root", { "r.txt": "r" }).manifest, dependencies: [regEdge("D", "9.9.9")] }, files: { "r.txt": "r" } };
     const reg = regOf({ D: { "1.0.0": { url: "http://e/D", package_hash: "sha256:x" } } });
-    const r = await resolve(root, fetchOf({}), NO_TRUST, reg, { allowNoSignature: true });
+    // solved has D->9.9.9 (satisfies the edge range "9.9.9" exactly), but 9.9.9 is absent from the registry
+    const r = await resolve(root, fetchOf({}), NO_TRUST, reg, new Map([["D", "9.9.9"]]), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("registry-miss");
   });
@@ -219,7 +220,7 @@ describe("resolve — registry deps", () => {
       regEdge("D", "1.0.0"),
     ] }, files: { "r.txt": "r" } };
     const reg = regOf({ D: { "1.0.0": { url: "http://e/D", package_hash: packageHash(D) } } });
-    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/D": D }), NO_TRUST, reg, { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/A": A, "http://e/D": D }), NO_TRUST, reg, new Map([["D", "1.0.0"]]), { allowNoSignature: true });
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.order.map((p) => p.manifest.name).sort()).toEqual(["A", "D", "root"]);
   });
@@ -227,20 +228,48 @@ describe("resolve — registry deps", () => {
     const D = pkgOf("D", { "d.txt": "d" });
     const root: AcePackage = { manifest: { ...pkgOf("root", { "r.txt": "r" }).manifest, dependencies: [regEdge("D", "1.0.0")] }, files: { "r.txt": "r" } };
     const reg = regOf({ D: { "1.0.0": { url: "http://e/D", package_hash: "sha256:wrong" } } });
-    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, reg, { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, reg, new Map([["D", "1.0.0"]]), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("pin-mismatch");
   });
   test("an unknown dependency kind refuses with invalid-package (not silently treated as inline)", async () => {
     const root: AcePackage = { manifest: { ...pkgOf("root", { "r.txt": "r" }).manifest, dependencies: [{ kind: "frobnicate", name: "X", version: "1.0.0" }] as unknown as AceDependency[] }, files: { "r.txt": "r" } };
-    const r = await resolve(root, fetchOf({}), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({}), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("invalid-package");
   });
   test("an inline edge missing url/package_hash refuses with invalid-package", async () => {
     const root: AcePackage = { manifest: { ...pkgOf("root", { "r.txt": "r" }).manifest, dependencies: [{ kind: "inline", name: "X", version: "1.0.0" }] as unknown as AceDependency[] }, files: { "r.txt": "r" } };
-    const r = await resolve(root, fetchOf({}), NO_TRUST, new Map(), { allowNoSignature: true });
+    const r = await resolve(root, fetchOf({}), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("invalid-package");
+  });
+});
+
+describe("resolve — solved-map registry edges", () => {
+  test("a registry range edge resolves via the solved concrete version + verifies", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root: AcePackage = { manifest: { ...pkgOf("root", { "r.txt": "r" }).manifest, dependencies: [{ kind: "registry" as const, name: "D", version: "^1.0.0" }] }, files: { "r.txt": "r" } };
+    const reg = new Map([["D", new Map([["1.0.0", { url: "http://e/D", package_hash: packageHash(D) }]])]]);
+    const solved = new Map([["D", "1.0.0"]]);
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, reg, solved, { allowNoSignature: true });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.order.map((p) => p.manifest.name).sort()).toEqual(["D", "root"]);
+  });
+  test("registry name absent from solved map → unsatisfiable", async () => {
+    const root: AcePackage = { manifest: { ...pkgOf("root", { "r.txt": "r" }).manifest, dependencies: [{ kind: "registry" as const, name: "D", version: "^1.0.0" }] }, files: { "r.txt": "r" } };
+    const reg = new Map([["D", new Map([["1.0.0", { url: "http://e/D", package_hash: "sha256:x" }]])]]);
+    const r = await resolve(root, fetchOf({}), NO_TRUST, reg, new Map(), { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("unsatisfiable");
+  });
+  test("solved version that violates the edge range → unsatisfiable (defense-in-depth)", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root: AcePackage = { manifest: { ...pkgOf("root", { "r.txt": "r" }).manifest, dependencies: [{ kind: "registry" as const, name: "D", version: "^2.0.0" }] }, files: { "r.txt": "r" } };
+    const reg = new Map([["D", new Map([["1.0.0", { url: "http://e/D", package_hash: packageHash(D) }]])]]);
+    const solved = new Map([["D", "1.0.0"]]); // 1.0.0 does NOT satisfy ^2.0.0
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, reg, solved, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("unsatisfiable");
   });
 });

--- a/tools/ace/resolve.ts
+++ b/tools/ace/resolve.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { contentHash, type AcePackage, type LoadedTrustEntry, type Registry } from "./store.ts";
 import { verifySignature } from "./signing.ts";
+import { satisfies } from "./semver.ts";
 
 /** Deterministic JSON: object keys recursively sorted; arrays preserve order. */
 function canonicalJson(value: unknown): string {
@@ -22,7 +23,8 @@ export type FetchPackage = (urlOrPath: string) => Promise<string>;
 export type ResolveReason =
   | "version-skew" | "tamper" | "pin-mismatch" | "bad-content-hash"
   | "bad-signature" | "untrusted-key" | "unsupported-algo" | "no-signature"
-  | "cycle" | "fetch-failed" | "invalid-package" | "registry-miss";
+  | "cycle" | "fetch-failed" | "invalid-package" | "registry-miss"
+  | "unsatisfiable" | "bad-range";
 
 export type ResolveResult =
   | { ok: true; order: AcePackage[] }
@@ -33,6 +35,7 @@ export async function resolve(
   fetchPackage: FetchPackage,
   trustStore: Map<string, LoadedTrustEntry>,
   registry: Registry,
+  solved: Map<string, string>,
   opts: { allowNoSignature: boolean },
 ): Promise<ResolveResult> {
   const byName = new Map<string, { version: string; pkgHash: string; path: string[] }>();
@@ -57,17 +60,31 @@ export async function resolve(
       // Resolve url + package_hash from the edge kind
       let url: string;
       let package_hash: string;
+      // For registry edges: look up the solver's output (concrete version), apply the
+      // satisfies defense-in-depth check, then look up the registry entry by concrete version.
+      // For inline edges: url and package_hash come directly from the edge.
+      let effectiveVersion: string;
       if (edge.kind === "registry") {
-        const entry = registry.get(edge.name)?.get(edge.version);
+        const concrete = solved.get(edge.name);
+        if (concrete === undefined) {
+          return { ok: false, reason: "unsatisfiable", detail: `${edge.name}: no solved version`, path: here };
+        }
+        // Defense-in-depth: the solved concrete version must actually satisfy the declared range.
+        if (!satisfies(concrete, edge.version)) {
+          return { ok: false, reason: "unsatisfiable", detail: `${edge.name}: solved ${concrete} violates ${edge.version}`, path: here };
+        }
+        const entry = registry.get(edge.name)?.get(concrete);
         if (entry === undefined) {
-          return { ok: false, reason: "registry-miss", detail: `${edge.name}@${edge.version} not found in registry`, path: here };
+          return { ok: false, reason: "registry-miss", detail: `${edge.name}@${concrete} not in registry`, path: here };
         }
         url = entry.url; package_hash = entry.package_hash;
+        effectiveVersion = concrete;
       } else {
         if (typeof edge.url !== "string" || typeof edge.package_hash !== "string") {
           return { ok: false, reason: "invalid-package", detail: `${edge.name}: inline edge missing url/package_hash`, path: here };
         }
         url = edge.url; package_hash = edge.package_hash;
+        effectiveVersion = edge.version;
       }
 
       // NB: the root is seeded into `visiting`, so a root-involving skew (root@1 -> A -> root@2)
@@ -77,11 +94,11 @@ export async function resolve(
       }
       const seen = byName.get(edge.name);
       if (seen) {
-        if (seen.version !== edge.version) {
-          return { ok: false, reason: "version-skew", detail: `${edge.name} required at ${seen.version} (via ${seen.path.join(" → ")}) and ${edge.version} (via ${here.join(" → ")})`, path: here };
+        if (seen.version !== effectiveVersion) {
+          return { ok: false, reason: "version-skew", detail: `${edge.name} required at ${seen.version} (via ${seen.path.join(" → ")}) and ${effectiveVersion} (via ${here.join(" → ")})`, path: here };
         }
         if (seen.pkgHash !== package_hash) {
-          return { ok: false, reason: "tamper", detail: `${edge.name}@${edge.version} has two different package hashes`, path: here };
+          return { ok: false, reason: "tamper", detail: `${edge.name}@${effectiveVersion} has two different package hashes`, path: here };
         }
         continue; // diamond dedup: same name+version+package_hash, already resolved
       }
@@ -106,9 +123,9 @@ export async function resolve(
       if (got !== package_hash) {
         return { ok: false, reason: "pin-mismatch", detail: `${edge.name}: expected package_hash ${package_hash} but fetched ${got}`, path: here };
       }
-      // declared-identity check
-      if (dep.manifest.name !== edge.name || dep.manifest.version !== edge.version) {
-        return { ok: false, reason: "pin-mismatch", detail: `${edge.name}@${edge.version}: edge identity != fetched ${dep.manifest.name}@${dep.manifest.version}`, path: here };
+      // declared-identity check: fetched package name/version must match edge name + effectiveVersion
+      if (dep.manifest.name !== edge.name || dep.manifest.version !== effectiveVersion) {
+        return { ok: false, reason: "pin-mismatch", detail: `${edge.name}@${effectiveVersion}: edge identity != fetched ${dep.manifest.name}@${dep.manifest.version}`, path: here };
       }
       // slice-3 signature gate
       const v = verifySignature(dep.manifest, trustStore);
@@ -119,7 +136,7 @@ export async function resolve(
           return { ok: false, reason: v.reason, detail: `${edge.name}: ${v.reason}`, path: here };
         }
       }
-      byName.set(edge.name, { version: edge.version, pkgHash: package_hash, path: here });
+      byName.set(edge.name, { version: effectiveVersion, pkgHash: package_hash, path: here });
       visiting.add(edge.name);
       const sub = await walk(dep, here);
       if (sub) return sub;

--- a/tools/ace/semver.test.ts
+++ b/tools/ace/semver.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { parseVersion, compareVersions, parseRange, satisfies } from "./semver.ts";
+
+describe("parseVersion + compareVersions", () => {
+  test("parses x.y.z", () => { expect(parseVersion("1.2.3")).toEqual({ major: 1, minor: 2, patch: 3 }); });
+  test("rejects junk", () => { expect(parseVersion("1.2")).toBeNull(); expect(parseVersion("v1.2.3")).toBeNull(); expect(parseVersion("1.2.x")).toBeNull(); });
+  test("orders numerically (not lexically)", () => {
+    expect(compareVersions("1.2.3", "1.2.10")).toBe(-1);
+    expect(compareVersions("2.0.0", "1.9.9")).toBe(1);
+    expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
+  });
+});
+
+describe("satisfies — exact / comparator / wildcard", () => {
+  test("exact", () => { expect(satisfies("1.2.3", "1.2.3")).toBe(true); expect(satisfies("1.2.4", "1.2.3")).toBe(false); expect(satisfies("1.2.3", "=1.2.3")).toBe(true); });
+  test("comparators", () => {
+    expect(satisfies("1.5.0", ">=1.2.0")).toBe(true);
+    expect(satisfies("1.1.0", ">=1.2.0")).toBe(false);
+    expect(satisfies("1.2.0", "<2.0.0")).toBe(true);
+    expect(satisfies("2.0.0", "<2.0.0")).toBe(false);
+    expect(satisfies("1.2.0", ">1.2.0")).toBe(false);
+    expect(satisfies("1.2.0", "<=1.2.0")).toBe(true);
+  });
+  test("wildcard * and x match any valid version", () => { expect(satisfies("9.9.9", "*")).toBe(true); expect(satisfies("0.0.1", "x")).toBe(true); });
+  test("malformed range surfaces via parseRange error", () => { expect("error" in (parseRange("@@@") as object)).toBe(true); });
+});

--- a/tools/ace/semver.test.ts
+++ b/tools/ace/semver.test.ts
@@ -24,3 +24,30 @@ describe("satisfies — exact / comparator / wildcard", () => {
   test("wildcard * and x match any valid version", () => { expect(satisfies("9.9.9", "*")).toBe(true); expect(satisfies("0.0.1", "x")).toBe(true); });
   test("malformed range surfaces via parseRange error", () => { expect("error" in (parseRange("@@@") as object)).toBe(true); });
 });
+
+import { maxSatisfying } from "./semver.ts";
+import semverLib from "semver";
+
+describe("caret / tilde desugaring", () => {
+  test("^1.2.3 => >=1.2.3 <2.0.0", () => { expect(satisfies("1.9.0", "^1.2.3")).toBe(true); expect(satisfies("2.0.0", "^1.2.3")).toBe(false); expect(satisfies("1.2.2", "^1.2.3")).toBe(false); });
+  test("^0.2.3 => >=0.2.3 <0.3.0", () => { expect(satisfies("0.2.9", "^0.2.3")).toBe(true); expect(satisfies("0.3.0", "^0.2.3")).toBe(false); });
+  test("^0.0.3 => >=0.0.3 <0.0.4", () => { expect(satisfies("0.0.3", "^0.0.3")).toBe(true); expect(satisfies("0.0.4", "^0.0.3")).toBe(false); });
+  test("~1.2.3 => >=1.2.3 <1.3.0", () => { expect(satisfies("1.2.9", "~1.2.3")).toBe(true); expect(satisfies("1.3.0", "~1.2.3")).toBe(false); });
+});
+describe("AND ranges + maxSatisfying", () => {
+  test("space-AND", () => { expect(satisfies("1.5.0", ">=1.2.0 <2.0.0")).toBe(true); expect(satisfies("2.1.0", ">=1.2.0 <2.0.0")).toBe(false); });
+  test("maxSatisfying picks newest in range", () => {
+    expect(maxSatisfying(["1.0.0", "1.2.0", "1.9.0", "2.0.0"], "^1.0.0")).toBe("1.9.0");
+    expect(maxSatisfying(["1.0.0", "2.0.0"], "^3.0.0")).toBeNull();
+  });
+});
+describe("node-semver differential (oracle)", () => {
+  const versions = ["0.0.1", "0.2.3", "0.2.9", "1.0.0", "1.2.3", "1.2.10", "1.9.0", "2.0.0", "2.3.4"];
+  const ranges = ["1.2.3", "=1.2.3", ">=1.2.0", "<2.0.0", ">1.0.0 <2.0.0", "^1.2.3", "~1.2.3", "^0.2.3", "*"];
+  test("our satisfies matches semver.satisfies for the corpus", () => {
+    for (const v of versions) for (const r of ranges) expect(satisfies(v, r)).toBe(semverLib.satisfies(v, r));
+  });
+  test("our maxSatisfying matches semver.maxSatisfying for the corpus", () => {
+    for (const r of ranges) expect(maxSatisfying(versions, r)).toBe(semverLib.maxSatisfying(versions, r));
+  });
+});

--- a/tools/ace/semver.ts
+++ b/tools/ace/semver.ts
@@ -1,0 +1,64 @@
+// Pure semver subset for Ace slice 5.2 (no pre-release / build-metadata / unions / hyphen — see B-0970).
+export interface Version { readonly major: number; readonly minor: number; readonly patch: number }
+export type Comparator = { readonly op: ">=" | "<=" | ">" | "<" | "="; readonly v: Version };
+// A Range is a conjunction (AND) of comparators. `*` / `x` → empty conjunction (matches all).
+export type Range = { readonly comparators: ReadonlyArray<Comparator> };
+export type RangeOrError = Range | { readonly error: string };
+
+const VER = /^(\d+)\.(\d+)\.(\d+)$/;
+export function parseVersion(s: string): Version | null {
+  const m = VER.exec(s.trim());
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+export function compareVersions(a: string | Version, b: string | Version): -1 | 0 | 1 {
+  const pa = typeof a === "string" ? parseVersion(a) : a;
+  const pb = typeof b === "string" ? parseVersion(b) : b;
+  if (pa === null || pb === null) throw new Error("compareVersions: invalid version");
+  for (const k of ["major", "minor", "patch"] as const) {
+    if (pa[k] < pb[k]) return -1;
+    if (pa[k] > pb[k]) return 1;
+  }
+  return 0;
+}
+function cmp(a: Version, op: Comparator["op"], b: Version): boolean {
+  const c = compareVersions(a, b);
+  switch (op) {
+    case "=": return c === 0;
+    case ">": return c === 1;
+    case "<": return c === -1;
+    case ">=": return c >= 0;
+    case "<=": return c <= 0;
+  }
+}
+
+export function parseRange(s: string): RangeOrError {
+  const trimmed = s.trim();
+  if (trimmed === "" || trimmed === "*" || trimmed === "x" || trimmed === "X") return { comparators: [] };
+  const out: Comparator[] = [];
+  for (const tokenRaw of trimmed.split(/\s+/)) {
+    const sub = parseComparatorToken(tokenRaw);
+    if ("error" in sub) return sub;
+    out.push(...sub.comparators);
+  }
+  return { comparators: out };
+}
+
+// Task 2 extends this with ^ / ~. Task 1: exact, comparators, wildcard token.
+function parseComparatorToken(token: string): RangeOrError {
+  if (token === "*" || token === "x" || token === "X") return { comparators: [] };
+  const m = /^(>=|<=|>|<|=)?(.+)$/.exec(token);
+  if (!m) return { error: `bad comparator: ${token}` };
+  const op = (m[1] ?? "=") as Comparator["op"];
+  const v = parseVersion(m[2]!);
+  if (v === null) return { error: `bad version in comparator: ${token}` };
+  return { comparators: [{ op, v }] };
+}
+
+export function satisfies(version: string, range: string | Range): boolean {
+  const v = parseVersion(version);
+  if (v === null) return false;
+  const r = typeof range === "string" ? parseRange(range) : range;
+  if ("error" in r) return false;
+  return r.comparators.every((c) => cmp(v, c.op, c.v));
+}

--- a/tools/ace/semver.ts
+++ b/tools/ace/semver.ts
@@ -46,6 +46,17 @@ export function parseRange(s: string): RangeOrError {
 
 // Task 2 extends this with ^ / ~. Task 1: exact, comparators, wildcard token.
 function parseComparatorToken(token: string): RangeOrError {
+  if (token.startsWith("^") || token.startsWith("~")) {
+    const v = parseVersion(token.slice(1));
+    if (v === null) return { error: `bad version in range: ${token}` };
+    const lower: Comparator = { op: ">=", v };
+    let upper: Version;
+    if (token.startsWith("~")) upper = { major: v.major, minor: v.minor + 1, patch: 0 };
+    else if (v.major > 0) upper = { major: v.major + 1, minor: 0, patch: 0 };
+    else if (v.minor > 0) upper = { major: 0, minor: v.minor + 1, patch: 0 };
+    else upper = { major: 0, minor: 0, patch: v.patch + 1 };
+    return { comparators: [lower, { op: "<", v: upper }] };
+  }
   if (token === "*" || token === "x" || token === "X") return { comparators: [] };
   const m = /^(>=|<=|>|<|=)?(.+)$/.exec(token);
   if (!m) return { error: `bad comparator: ${token}` };
@@ -61,4 +72,13 @@ export function satisfies(version: string, range: string | Range): boolean {
   const r = typeof range === "string" ? parseRange(range) : range;
   if ("error" in r) return false;
   return r.comparators.every((c) => cmp(v, c.op, c.v));
+}
+
+export function maxSatisfying(versions: ReadonlyArray<string>, range: string | Range): string | null {
+  let best: string | null = null;
+  for (const ver of versions) {
+    if (!satisfies(ver, range)) continue;
+    if (best === null || compareVersions(ver, best) === 1) best = ver;
+  }
+  return best;
 }

--- a/tools/ace/solver.test.ts
+++ b/tools/ace/solver.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { solve } from "./solver.ts";
+import { packageHash, type FetchPackage } from "./resolve.ts";
+import { contentHash } from "./store.ts";
+import type { AcePackage, AceDependency, RegistryEntry } from "./store.ts";
+
+function pkgAt(name: string, version: string, deps: AceDependency[] = []): AcePackage {
+  const files = { "f.txt": `${name}@${version}` };
+  return { manifest: { format_version: 1, name, version, content_hash: contentHash(new TextEncoder().encode(JSON.stringify(files))), dependencies: deps }, files };
+}
+const regEdge = (name: string, range: string): AceDependency => ({ kind: "registry", name, version: range });
+const inlineEdge = (pkg: AcePackage, url: string): AceDependency => ({ kind: "inline", name: pkg.manifest.name, version: pkg.manifest.version, url, package_hash: packageHash(pkg) });
+function fetchOf(map: Record<string, AcePackage>): FetchPackage {
+  return async (url) => { const p = map[url]; if (!p) throw new Error("404 " + url); return JSON.stringify(p); };
+}
+// Build registry + fetch map from {pkg,url} list. Registry: name -> version -> {url, package_hash}.
+function world(entries: { pkg: AcePackage; url: string }[]): { registry: Map<string, Map<string, RegistryEntry>>; fetch: FetchPackage } {
+  const registry = new Map<string, Map<string, RegistryEntry>>();
+  const fetchMap: Record<string, AcePackage> = {};
+  for (const { pkg, url } of entries) {
+    const n = pkg.manifest.name, v = pkg.manifest.version;
+    if (!registry.has(n)) registry.set(n, new Map());
+    registry.get(n)!.set(v, { url, package_hash: packageHash(pkg) });
+    fetchMap[url] = pkg;
+  }
+  return { registry, fetch: fetchOf(fetchMap) };
+}
+
+describe("solve — inline back-compat", () => {
+  test("inline-only graph with empty registry solves (no registry-miss)", async () => {
+    const A = pkgAt("A", "1.0.0");
+    const root = pkgAt("root", "1.0.0", [inlineEdge(A, "http://e/A")]);
+    const r = await solve(root, fetchOf({ "http://e/A": A }), new Map());
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.versions.get("A")).toBe("1.0.0");
+  });
+});
+describe("solve — registry ranges", () => {
+  test("^1.0.0 resolves to newest available", async () => {
+    const A1 = pkgAt("A", "1.0.0"), A5 = pkgAt("A", "1.5.0"), A9 = pkgAt("A", "1.9.0");
+    const { registry, fetch } = world([{ pkg: A1, url: "u/A/1" }, { pkg: A5, url: "u/A/5" }, { pkg: A9, url: "u/A/9" }]);
+    const root = pkgAt("root", "1.0.0", [regEdge("A", "^1.0.0")]);
+    const r = await solve(root, fetch, registry);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.versions.get("A")).toBe("1.9.0");
+  });
+  test("transitive constraint forces backtrack below newest (re-validation)", async () => {
+    const A1 = pkgAt("A", "1.0.0"), A5 = pkgAt("A", "1.5.0"), A9 = pkgAt("A", "1.9.0");
+    const B = pkgAt("B", "1.0.0", [regEdge("A", "<1.6.0")]);
+    const { registry, fetch } = world([
+      { pkg: A1, url: "u/A/1" }, { pkg: A5, url: "u/A/5" }, { pkg: A9, url: "u/A/9" }, { pkg: B, url: "u/B/1" },
+    ]);
+    const root = pkgAt("root", "1.0.0", [regEdge("A", ">=1.0.0"), regEdge("B", "*")]);
+    const r = await solve(root, fetch, registry);
+    expect(r.ok).toBe(true);
+    if (r.ok) { expect(r.versions.get("A")).toBe("1.5.0"); expect(r.versions.get("B")).toBe("1.0.0"); }
+  });
+  test("unsatisfiable range refuses", async () => {
+    const A1 = pkgAt("A", "1.0.0"), A5 = pkgAt("A", "1.5.0");
+    const { registry, fetch } = world([{ pkg: A1, url: "u/A/1" }, { pkg: A5, url: "u/A/5" }]);
+    const root = pkgAt("root", "1.0.0", [regEdge("A", ">=2.0.0")]);
+    const r = await solve(root, fetch, registry);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("unsatisfiable");
+  });
+  test("bad range refuses with bad-range", async () => {
+    const root = pkgAt("root", "1.0.0", [regEdge("A", "@@@")]);
+    const r = await solve(root, fetchOf({}), new Map());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("bad-range");
+  });
+  test("registry-sourced name absent from registry → registry-miss", async () => {
+    const root = pkgAt("root", "1.0.0", [regEdge("MISSING", "^1.0.0")]);
+    const r = await solve(root, fetchOf({}), new Map());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("registry-miss");
+  });
+});
+describe("solve — mixed inline + registry for one name (inline authoritative)", () => {
+  test("inline pin satisfies a registry range elsewhere → ok at inline version", async () => {
+    const Ainline = pkgAt("A", "1.0.0");
+    const B = pkgAt("B", "1.0.0", [regEdge("A", "^1.0.0")]);
+    const { registry, fetch: regFetch } = world([{ pkg: B, url: "u/B/1" }]);
+    // also need to fetch the inline A:
+    const fetch: FetchPackage = async (url) => (url === "http://e/A" ? JSON.stringify(Ainline) : regFetch(url));
+    const root = pkgAt("root", "1.0.0", [inlineEdge(Ainline, "http://e/A"), regEdge("B", "*")]);
+    const r = await solve(root, fetch, registry);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.versions.get("A")).toBe("1.0.0");
+  });
+  test("inline pin violating a registry range → unsatisfiable", async () => {
+    const Ainline = pkgAt("A", "1.0.0");
+    const B = pkgAt("B", "1.0.0", [regEdge("A", "^2.0.0")]);
+    const { registry, fetch: regFetch } = world([{ pkg: B, url: "u/B/1" }]);
+    const fetch: FetchPackage = async (url) => (url === "http://e/A" ? JSON.stringify(Ainline) : regFetch(url));
+    const root = pkgAt("root", "1.0.0", [inlineEdge(Ainline, "http://e/A"), regEdge("B", "*")]);
+    const r = await solve(root, fetch, registry);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("unsatisfiable");
+  });
+});
+describe("solve — determinism", () => {
+  test("same (root, registry) yields identical map", async () => {
+    const A1 = pkgAt("A", "1.0.0"), A9 = pkgAt("A", "1.9.0");
+    const { registry, fetch } = world([{ pkg: A1, url: "u/A/1" }, { pkg: A9, url: "u/A/9" }]);
+    const root = pkgAt("root", "1.0.0", [regEdge("A", "^1.0.0")]);
+    const r1 = await solve(root, fetch, registry); const r2 = await solve(root, fetch, registry);
+    expect(r1.ok && r2.ok).toBe(true);
+    if (r1.ok && r2.ok) expect([...r1.versions].sort()).toEqual([...r2.versions].sort());
+  });
+});

--- a/tools/ace/solver.test.ts
+++ b/tools/ace/solver.test.ts
@@ -109,3 +109,31 @@ describe("solve — determinism", () => {
     if (r1.ok && r2.ok) expect([...r1.versions].sort()).toEqual([...r2.versions].sort());
   });
 });
+describe("solve — constraint retraction on backtrack (P1 regression)", () => {
+  test("stale constraint from an abandoned version is retracted (registry-availability variant)", async () => {
+    const A1 = pkgAt("A", "1.0.0");                                   // no deps
+    const A2 = pkgAt("A", "2.0.0", [regEdge("C", ">=2.0.0")]);        // version-dependent dep
+    const B1 = pkgAt("B", "1.0.0", [regEdge("A", "<2.0.0")]);
+    const C1 = pkgAt("C", "1.0.0");
+    const { registry, fetch } = world([
+      { pkg: A1, url: "u/A/1" }, { pkg: A2, url: "u/A/2" }, { pkg: B1, url: "u/B/1" }, { pkg: C1, url: "u/C/1" },
+    ]);
+    const root = pkgAt("root", "1.0.0", [regEdge("A", "*"), regEdge("B", "*"), regEdge("C", "*")]);
+    const r = await solve(root, fetch, registry);
+    expect(r.ok).toBe(true);
+    if (r.ok) { expect(r.versions.get("A")).toBe("1.0.0"); expect(r.versions.get("B")).toBe("1.0.0"); expect(r.versions.get("C")).toBe("1.0.0"); }
+  });
+  test("stale constraint from an abandoned version is retracted (peer-conflict variant)", async () => {
+    const A1 = pkgAt("A", "1.0.0");
+    const A2 = pkgAt("A", "2.0.0", [regEdge("C", ">=2.0.0")]);
+    const B1 = pkgAt("B", "1.0.0", [regEdge("A", "<2.0.0"), regEdge("C", "<2.0.0")]);
+    const C1 = pkgAt("C", "1.0.0"); const C2 = pkgAt("C", "2.0.0");
+    const { registry, fetch } = world([
+      { pkg: A1, url: "u/A/1" }, { pkg: A2, url: "u/A/2" }, { pkg: B1, url: "u/B/1" }, { pkg: C1, url: "u/C/1" }, { pkg: C2, url: "u/C/2" },
+    ]);
+    const root = pkgAt("root", "1.0.0", [regEdge("A", "*"), regEdge("B", "*"), regEdge("C", "*")]);
+    const r = await solve(root, fetch, registry);
+    expect(r.ok).toBe(true);
+    if (r.ok) { expect(r.versions.get("A")).toBe("1.0.0"); expect(r.versions.get("C")).toBe("1.0.0"); }
+  });
+});

--- a/tools/ace/solver.ts
+++ b/tools/ace/solver.ts
@@ -1,0 +1,194 @@
+import { parseRange, satisfies, compareVersions, type Range } from "./semver.ts";
+import type { AcePackage, AceDependency, Registry } from "./store.ts";
+import type { FetchPackage } from "./resolve.ts";
+
+export type SolveResult =
+  | { ok: true; versions: Map<string, string> }   // name -> concrete version (incl. inline-fixed names)
+  | { ok: false; reason: "unsatisfiable" | "bad-range" | "registry-miss" | "fetch-failed" | "invalid-package"; detail: string; path: string[] };
+
+// ---- internal helpers ---------------------------------------------------
+
+/** Parse a fetched JSON string into a well-formed AcePackage, or return a failure. Mirrors
+ *  resolve.ts's shape guard: a present-but-non-array dependencies field is malformed → invalid-package
+ *  (an absent dependencies field is fine; depsOf treats it as []). */
+function parsePackage(json: string, url: string, path: string[]): AcePackage | { fail: SolveResult } {
+  let dep: unknown;
+  try { dep = JSON.parse(json); }
+  catch (e) { return { fail: { ok: false, reason: "fetch-failed", detail: `${url}: ${(e as Error).message}`, path } }; }
+  const m = (dep as { manifest?: { dependencies?: unknown }; files?: unknown });
+  if (typeof dep !== "object" || dep === null || typeof m.manifest !== "object" || m.manifest === null
+      || typeof m.files !== "object" || m.files === null
+      || (m.manifest.dependencies !== undefined && !Array.isArray(m.manifest.dependencies))) {
+    return { fail: { ok: false, reason: "invalid-package", detail: `${url}: not a well-formed AcePackage`, path } };
+  }
+  return dep as AcePackage;
+}
+
+const depsOf = (pkg: AcePackage): ReadonlyArray<AceDependency> =>
+  Array.isArray(pkg.manifest.dependencies) ? pkg.manifest.dependencies : [];
+
+/** Highest registry version of `name` (newest-first) satisfying EVERY accumulated range, strictly
+ *  below `belowExclusive` when given (the version a later constraint just ruled out — try lower).
+ *  null = no candidate. */
+function pickCandidate(
+  name: string, registry: Registry, ranges: ReadonlyArray<Range>, belowExclusive: string | null,
+): string | null {
+  const sorted = [...(registry.get(name)?.keys() ?? [])].sort((a, b) => compareVersions(b, a)); // desc: newest first
+  for (const v of sorted) {
+    if (belowExclusive !== null && compareVersions(v, belowExclusive) >= 0) continue;
+    if (ranges.every((r) => satisfies(v, r))) return v;
+  }
+  return null;
+}
+
+// ---- solver -------------------------------------------------------------
+
+/**
+ * Deterministic newest-first backtracking version solver. Inline edges are pre-decided (fix version
+ * AND source; never registry-looked-up); registry edges contribute semver ranges solved against the
+ * registry's versions. On EVERY new constraint the current assignment is re-validated (the load-bearing
+ * correctness rule): a now-invalid assignment is repaired to its next-lower satisfying candidate, and
+ * its replacement's transitive deps are re-explored. Never verifies hashes/signatures — that is
+ * resolve()'s job (Task 5).
+ */
+export async function solve(root: AcePackage, fetchPackage: FetchPackage, registry: Registry): Promise<SolveResult> {
+  const inlineFixed = new Map<string, string>();      // name -> inline version (authoritative; never registry-solved)
+  const constraints = new Map<string, Range[]>();     // name -> accumulated registry ranges (monotone: only added)
+  const assigned = new Map<string, string>();         // name -> chosen registry version
+  const cache = new Map<string, AcePackage>();         // "name@version" / "inline:<url>" -> pkg (fetch at most once)
+  const toExplore = new Set<string>();                // registry names queued for a decision
+  const inlinePending = new Map<string, AcePackage>(); // inline pkgs whose deps still need exploring
+
+  const addConstraint = (name: string, r: Range): void => {
+    const arr = constraints.get(name); if (arr) arr.push(r); else constraints.set(name, [r]);
+  };
+
+  /** Ingest a manifest's dependency edges. Inline edges fix the name (version + source) and fetch the
+   *  inline package for dep recursion; registry edges add a range constraint and queue the name.
+   *  Returns a failure or null. */
+  const ingest = async (deps: ReadonlyArray<AceDependency>, ownerPath: string[]): Promise<SolveResult | null> => {
+    for (const edge of deps) {
+      const here = [...ownerPath, edge.name];
+      const ek = (edge as { readonly kind?: unknown }).kind;
+      if (ek !== undefined && ek !== "inline" && ek !== "registry") {
+        return { ok: false, reason: "invalid-package", detail: `${edge.name}: unknown dependency kind ${JSON.stringify(ek)}`, path: here };
+      }
+
+      if (edge.kind === "registry") {
+        const parsed = parseRange(edge.version);
+        if ("error" in parsed) return { ok: false, reason: "bad-range", detail: `${edge.name}: ${parsed.error}`, path: here };
+        addConstraint(edge.name, parsed);
+        // Inline-fixed names are authoritative: a registry range on them is a constraint the inline
+        // pin must satisfy, not a name to solve.
+        if (inlineFixed.has(edge.name)) {
+          if (!satisfies(inlineFixed.get(edge.name)!, parsed)) {
+            return { ok: false, reason: "unsatisfiable", detail: `${edge.name}@${inlineFixed.get(edge.name)} (inline) violates ${edge.version} (via ${here.join(" → ")})`, path: here };
+          }
+          continue;
+        }
+        toExplore.add(edge.name); // (re)consider under the accumulated constraints
+        continue;
+      }
+
+      // inline edge: fix version + source; record + fetch its package for dep exploration.
+      if (typeof edge.url !== "string" || typeof edge.package_hash !== "string") {
+        return { ok: false, reason: "invalid-package", detail: `${edge.name}: inline edge missing url/package_hash`, path: here };
+      }
+      if (inlineFixed.has(edge.name)) continue; // already pinned inline (diamond dedup on inline source)
+      inlineFixed.set(edge.name, edge.version);
+      // Any registry ranges already accumulated for this name must be satisfied by the inline pin.
+      for (const r of constraints.get(edge.name) ?? []) {
+        if (!satisfies(edge.version, r)) {
+          return { ok: false, reason: "unsatisfiable", detail: `${edge.name}@${edge.version} (inline) violates an accumulated registry range`, path: here };
+        }
+      }
+      toExplore.delete(edge.name);    // inline pin wins; never registry-solve this name
+      assigned.delete(edge.name);     // drop any prior registry assignment (inline is authoritative)
+      const cacheKey = `inline:${edge.url}`;
+      let dep = cache.get(cacheKey);
+      if (dep === undefined) {
+        let json: string;
+        try { json = await fetchPackage(edge.url); }
+        catch (e) { return { ok: false, reason: "fetch-failed", detail: `${edge.url}: ${(e as Error).message}`, path: here }; }
+        const p = parsePackage(json, edge.url, here);
+        if ("fail" in p) return p.fail;
+        dep = p; cache.set(cacheKey, dep);
+      }
+      inlinePending.set(edge.name, dep);
+    }
+    return null;
+  };
+
+  // 1) Seed from the root's deps.
+  const seedFail = await ingest(depsOf(root), ["root"]);
+  if (seedFail) return seedFail;
+
+  // 2) Fixed-point loop: explore inline-pending packages, then make/repair registry assignments,
+  //    until stable. Deterministic — names processed in sorted order, candidates newest-first.
+  //    The ceiling guards against pathological non-convergence (e.g. cyclic constraint churn).
+  let guard = 0;
+  const ceiling = 100000;
+  for (;;) {
+    if (guard++ > ceiling) return { ok: false, reason: "unsatisfiable", detail: "solver did not converge (possible cycle)", path: ["root"] };
+
+    // 2a) Explore inline-pending packages first — their edges feed the constraint set.
+    if (inlinePending.size > 0) {
+      const name = [...inlinePending.keys()].sort()[0]!;
+      const pkg = inlinePending.get(name)!;
+      inlinePending.delete(name);
+      const f = await ingest(depsOf(pkg), ["root", name]);
+      if (f) return f;
+      continue;
+    }
+
+    // 2b) Find the next registry name that needs a decision (unassigned) or a repair (current
+    //     assignment no longer satisfies all accumulated constraints — the re-validation rule).
+    let target: string | null = null;
+    const candidates = [...new Set([...toExplore, ...assigned.keys()])].sort();
+    for (const name of candidates) {
+      if (inlineFixed.has(name)) continue; // inline-fixed names are never registry-solved
+      const cur = assigned.get(name);
+      const ranges = constraints.get(name) ?? [];
+      if (cur === undefined) { target = name; break; }                          // unassigned → decide
+      if (!ranges.every((r) => satisfies(cur, r))) { target = name; break; }    // invalidated → repair
+    }
+    if (target === null) break; // stable
+
+    // 3) Decide / repair `target`.
+    if (!registry.has(target)) {
+      return { ok: false, reason: "registry-miss", detail: `${target} not found in registry`, path: ["root", target] };
+    }
+    const ranges = constraints.get(target) ?? [];
+    const prev = assigned.get(target);
+    // Repairing an invalidated assignment: try strictly below the version that was ruled out.
+    const belowExclusive = prev !== undefined && !ranges.every((r) => satisfies(prev, r)) ? prev : null;
+    const pick = pickCandidate(target, registry, ranges, belowExclusive);
+    if (pick === null) {
+      return { ok: false, reason: "unsatisfiable", detail: `${target}: no version satisfies all accumulated ranges`, path: ["root", target] };
+    }
+    if (pick === prev) { toExplore.delete(target); continue; } // already at the valid pick; just clear the queue
+
+    // Assign, then fetch + explore the chosen version's deps (which may add constraints → trigger 2b repairs).
+    assigned.set(target, pick);
+    toExplore.delete(target);
+    const cacheKey = `${target}@${pick}`;
+    let dep = cache.get(cacheKey);
+    if (dep === undefined) {
+      const entry = registry.get(target)!.get(pick)!;
+      let json: string;
+      try { json = await fetchPackage(entry.url); }
+      catch (e) { return { ok: false, reason: "fetch-failed", detail: `${entry.url}: ${(e as Error).message}`, path: ["root", target] }; }
+      const p = parsePackage(json, entry.url, ["root", target]);
+      if ("fail" in p) return p.fail;
+      dep = p; cache.set(cacheKey, dep);
+    }
+    const f = await ingest(depsOf(dep), ["root", target]);
+    if (f) return f;
+  }
+
+  // 4) Compose: inline-fixed names + registry assignments.
+  const versions = new Map<string, string>();
+  for (const [name, v] of inlineFixed) versions.set(name, v);
+  for (const [name, v] of assigned) if (!versions.has(name)) versions.set(name, v);
+  return { ok: true, versions };
+}

--- a/tools/ace/solver.ts
+++ b/tools/ace/solver.ts
@@ -27,6 +27,14 @@ function parsePackage(json: string, url: string, path: string[]): AcePackage | {
 const depsOf = (pkg: AcePackage): ReadonlyArray<AceDependency> =>
   Array.isArray(pkg.manifest.dependencies) ? pkg.manifest.dependencies : [];
 
+/** A registry range constraint tagged with the decision that introduced it. `source` is one of:
+ *  "root" (the root seed), `name@version` (a registry version's transitive deps), or
+ *  `inline:<url>` (an inline package's transitive deps). The source tag is what makes constraint
+ *  accumulation retraction-aware: when a registry version is abandoned during repair, every
+ *  constraint it contributed is removed by source, so a version-dependent transitive dep no longer
+ *  over-constrains unrelated packages into a false `unsatisfiable`. */
+type TaggedRange = { range: Range; source: string };
+
 /** Highest registry version of `name` (newest-first) satisfying EVERY accumulated range, strictly
  *  below `belowExclusive` when given (the version a later constraint just ruled out — try lower).
  *  null = no candidate. */
@@ -48,25 +56,46 @@ function pickCandidate(
  * AND source; never registry-looked-up); registry edges contribute semver ranges solved against the
  * registry's versions. On EVERY new constraint the current assignment is re-validated (the load-bearing
  * correctness rule): a now-invalid assignment is repaired to its next-lower satisfying candidate, and
- * its replacement's transitive deps are re-explored. Never verifies hashes/signatures — that is
- * resolve()'s job (Task 5).
+ * its replacement's transitive deps are re-explored. When a registry version is abandoned during repair,
+ * every constraint it contributed is retracted by source (so a dropped version's deps cannot over-
+ * constrain unrelated packages into a false `unsatisfiable`). Never verifies hashes/signatures — that
+ * is resolve()'s job (Task 5).
  */
 export async function solve(root: AcePackage, fetchPackage: FetchPackage, registry: Registry): Promise<SolveResult> {
   const inlineFixed = new Map<string, string>();      // name -> inline version (authoritative; never registry-solved)
-  const constraints = new Map<string, Range[]>();     // name -> accumulated registry ranges (monotone: only added)
+  const constraints = new Map<string, TaggedRange[]>(); // name -> accumulated registry ranges, each tagged by source (retraction-aware: a source's constraints are dropped when its decision is abandoned/re-explored)
   const assigned = new Map<string, string>();         // name -> chosen registry version
   const cache = new Map<string, AcePackage>();         // "name@version" / "inline:<url>" -> pkg (fetch at most once)
   const toExplore = new Set<string>();                // registry names queued for a decision
-  const inlinePending = new Map<string, AcePackage>(); // inline pkgs whose deps still need exploring
+  const inlinePending = new Map<string, { pkg: AcePackage; source: string }>(); // inline pkgs whose deps still need exploring (source = inline:<url>)
 
-  const addConstraint = (name: string, r: Range): void => {
-    const arr = constraints.get(name); if (arr) arr.push(r); else constraints.set(name, [r]);
+  const addConstraint = (name: string, r: Range, source: string): void => {
+    const arr = constraints.get(name); if (arr) arr.push({ range: r, source }); else constraints.set(name, [{ range: r, source }]);
   };
 
-  /** Ingest a manifest's dependency edges. Inline edges fix the name (version + source) and fetch the
-   *  inline package for dep recursion; registry edges add a range constraint and queue the name.
+  /** Drop every accumulated constraint (across ALL names) contributed by `source`. Makes re-ingesting
+   *  a source idempotent (clear before re-add) and is the repair-path retraction for an abandoned
+   *  registry version. Never call with "root" — the root seed's constraints are permanent. */
+  const retractSource = (source: string): void => {
+    for (const [name, arr] of constraints) {
+      const kept = arr.filter((c) => c.source !== source);
+      if (kept.length !== arr.length) {
+        if (kept.length === 0) constraints.delete(name); else constraints.set(name, kept);
+      }
+    }
+  };
+
+  /** Accumulated registry ranges for `name`, without their source tags (for satisfaction checks). */
+  const rangesOf = (name: string): ReadonlyArray<Range> => (constraints.get(name) ?? []).map((c) => c.range);
+
+  /** Ingest a manifest's dependency edges under a given `source` tag (the decision contributing them:
+   *  "root", `name@version`, or `inline:<url>`). Ingest is idempotent per source: it first retracts
+   *  any constraints previously tagged with `source`, so re-exploring the same version does not
+   *  duplicate constraints. Inline edges fix the name (version + source) and fetch the inline package
+   *  for dep recursion; registry edges add a source-tagged range constraint and queue the name.
    *  Returns a failure or null. */
-  const ingest = async (deps: ReadonlyArray<AceDependency>, ownerPath: string[]): Promise<SolveResult | null> => {
+  const ingest = async (deps: ReadonlyArray<AceDependency>, ownerPath: string[], source: string): Promise<SolveResult | null> => {
+    retractSource(source); // idempotency: clear this source's prior constraints before re-adding
     for (const edge of deps) {
       const here = [...ownerPath, edge.name];
       const ek = (edge as { readonly kind?: unknown }).kind;
@@ -77,7 +106,7 @@ export async function solve(root: AcePackage, fetchPackage: FetchPackage, regist
       if (edge.kind === "registry") {
         const parsed = parseRange(edge.version);
         if ("error" in parsed) return { ok: false, reason: "bad-range", detail: `${edge.name}: ${parsed.error}`, path: here };
-        addConstraint(edge.name, parsed);
+        addConstraint(edge.name, parsed, source);
         // Inline-fixed names are authoritative: a registry range on them is a constraint the inline
         // pin must satisfy, not a name to solve.
         if (inlineFixed.has(edge.name)) {
@@ -97,30 +126,32 @@ export async function solve(root: AcePackage, fetchPackage: FetchPackage, regist
       if (inlineFixed.has(edge.name)) continue; // already pinned inline (diamond dedup on inline source)
       inlineFixed.set(edge.name, edge.version);
       // Any registry ranges already accumulated for this name must be satisfied by the inline pin.
-      for (const r of constraints.get(edge.name) ?? []) {
+      for (const r of rangesOf(edge.name)) {
         if (!satisfies(edge.version, r)) {
           return { ok: false, reason: "unsatisfiable", detail: `${edge.name}@${edge.version} (inline) violates an accumulated registry range`, path: here };
         }
       }
       toExplore.delete(edge.name);    // inline pin wins; never registry-solve this name
+      const droppedReg = assigned.get(edge.name);
+      if (droppedReg !== undefined) retractSource(`${edge.name}@${droppedReg}`); // drop the abandoned registry version's contributed constraints
       assigned.delete(edge.name);     // drop any prior registry assignment (inline is authoritative)
-      const cacheKey = `inline:${edge.url}`;
-      let dep = cache.get(cacheKey);
+      const inlineSource = `inline:${edge.url}`;
+      let dep = cache.get(inlineSource);
       if (dep === undefined) {
         let json: string;
         try { json = await fetchPackage(edge.url); }
         catch (e) { return { ok: false, reason: "fetch-failed", detail: `${edge.url}: ${(e as Error).message}`, path: here }; }
         const p = parsePackage(json, edge.url, here);
         if ("fail" in p) return p.fail;
-        dep = p; cache.set(cacheKey, dep);
+        dep = p; cache.set(inlineSource, dep);
       }
-      inlinePending.set(edge.name, dep);
+      inlinePending.set(edge.name, { pkg: dep, source: inlineSource });
     }
     return null;
   };
 
   // 1) Seed from the root's deps.
-  const seedFail = await ingest(depsOf(root), ["root"]);
+  const seedFail = await ingest(depsOf(root), ["root"], "root");
   if (seedFail) return seedFail;
 
   // 2) Fixed-point loop: explore inline-pending packages, then make/repair registry assignments,
@@ -134,9 +165,9 @@ export async function solve(root: AcePackage, fetchPackage: FetchPackage, regist
     // 2a) Explore inline-pending packages first — their edges feed the constraint set.
     if (inlinePending.size > 0) {
       const name = [...inlinePending.keys()].sort()[0]!;
-      const pkg = inlinePending.get(name)!;
+      const { pkg, source } = inlinePending.get(name)!;
       inlinePending.delete(name);
-      const f = await ingest(depsOf(pkg), ["root", name]);
+      const f = await ingest(depsOf(pkg), ["root", name], source);
       if (f) return f;
       continue;
     }
@@ -148,7 +179,7 @@ export async function solve(root: AcePackage, fetchPackage: FetchPackage, regist
     for (const name of candidates) {
       if (inlineFixed.has(name)) continue; // inline-fixed names are never registry-solved
       const cur = assigned.get(name);
-      const ranges = constraints.get(name) ?? [];
+      const ranges = rangesOf(name);
       if (cur === undefined) { target = name; break; }                          // unassigned → decide
       if (!ranges.every((r) => satisfies(cur, r))) { target = name; break; }    // invalidated → repair
     }
@@ -158,7 +189,7 @@ export async function solve(root: AcePackage, fetchPackage: FetchPackage, regist
     if (!registry.has(target)) {
       return { ok: false, reason: "registry-miss", detail: `${target} not found in registry`, path: ["root", target] };
     }
-    const ranges = constraints.get(target) ?? [];
+    const ranges = rangesOf(target);
     const prev = assigned.get(target);
     // Repairing an invalidated assignment: try strictly below the version that was ruled out.
     const belowExclusive = prev !== undefined && !ranges.every((r) => satisfies(prev, r)) ? prev : null;
@@ -167,6 +198,11 @@ export async function solve(root: AcePackage, fetchPackage: FetchPackage, regist
       return { ok: false, reason: "unsatisfiable", detail: `${target}: no version satisfies all accumulated ranges`, path: ["root", target] };
     }
     if (pick === prev) { toExplore.delete(target); continue; } // already at the valid pick; just clear the queue
+
+    // Abandoning `target@prev` (repair to a different version): retract every constraint that the
+    // dropped version contributed, so its transitive deps stop over-constraining unrelated packages
+    // (the P1 false-unsatisfiable fix). The fixed-point loop then re-converges on the retracted set.
+    if (prev !== undefined) retractSource(`${target}@${prev}`);
 
     // Assign, then fetch + explore the chosen version's deps (which may add constraints → trigger 2b repairs).
     assigned.set(target, pick);
@@ -182,7 +218,8 @@ export async function solve(root: AcePackage, fetchPackage: FetchPackage, regist
       if ("fail" in p) return p.fail;
       dep = p; cache.set(cacheKey, dep);
     }
-    const f = await ingest(depsOf(dep), ["root", target]);
+    // Ingest under the chosen version's source tag (idempotent: clears `target@pick` first).
+    const f = await ingest(depsOf(dep), ["root", target], cacheKey);
     if (f) return f;
   }
 

--- a/tools/ace/solver.z3.test.ts
+++ b/tools/ace/solver.z3.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Z3 differential test: cross-checks our TS solver against Z3 SMT as a satisfiability oracle.
+ *
+ * z3-solver@4.16.0 uses Emscripten-compiled WASM with pthreads (worker_threads).
+ * Bun 1.3.12 does not support the Emscripten pthread WASM model — init() resolves
+ * but the WASM assertion fails in the worker thread on WASM instance receipt.
+ * Exact error: "Aborted(Assertion failed)" at z3-built.js:848 (removeRunDependency → assert).
+ *
+ * Resolution (no skip — per automated-tests-are-the-shield-assert-dont-skip.md):
+ * We spawn a Node.js subprocess for each Z3 query. The test file itself runs under Bun;
+ * Z3 actually executes and returns a verdict (sat/unsat); assertions are made in Bun.
+ * This is NOT a graceful skip — the test FAILS if Node is unavailable or Z3 crashes.
+ *
+ * Corpus scope: version-INDEPENDENT-dep graphs only (each package has one version, or
+ * identical deps across versions), so the static SMT encoding is faithful to what solve()
+ * discovers by fetching.
+ */
+import { describe, test, expect } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { solve } from "./solver.ts";
+import { packageHash, type FetchPackage } from "./resolve.ts";
+import { contentHash } from "./store.ts";
+import type { AcePackage, AceDependency, RegistryEntry } from "./store.ts";
+import { satisfies } from "./semver.ts";
+
+// ---- helpers mirrored from solver.test.ts -----------------------------------
+
+function pkgAt(name: string, version: string, deps: AceDependency[] = []): AcePackage {
+  const files = { "f.txt": `${name}@${version}` };
+  return {
+    manifest: {
+      format_version: 1,
+      name,
+      version,
+      content_hash: contentHash(new TextEncoder().encode(JSON.stringify(files))),
+      dependencies: deps,
+    },
+    files,
+  };
+}
+
+const regEdge = (name: string, range: string): AceDependency =>
+  ({ kind: "registry", name, version: range });
+
+function fetchOf(map: Record<string, AcePackage>): FetchPackage {
+  return async (url) => {
+    const p = map[url];
+    if (!p) throw new Error("404 " + url);
+    return JSON.stringify(p);
+  };
+}
+
+/** Build registry + fetch from {pkg, url} list. */
+function world(entries: { pkg: AcePackage; url: string }[]): {
+  registry: Map<string, Map<string, RegistryEntry>>;
+  fetch: FetchPackage;
+} {
+  const registry = new Map<string, Map<string, RegistryEntry>>();
+  const fetchMap: Record<string, AcePackage> = {};
+  for (const { pkg, url } of entries) {
+    const n = pkg.manifest.name, v = pkg.manifest.version;
+    if (!registry.has(n)) registry.set(n, new Map());
+    registry.get(n)!.set(v, { url, package_hash: packageHash(pkg) });
+    fetchMap[url] = pkg;
+  }
+  return { registry, fetch: fetchOf(fetchMap) };
+}
+
+// ---- Z3 oracle (via Node subprocess) ----------------------------------------
+
+/**
+ * DepGraph describes a version-independent dependency graph for the Z3 oracle:
+ * - `packages`: each name → sorted list of semver version strings available in registry.
+ * - `edges`: directed constraint edges: from source name (or "root") → target name, with a
+ *   range string (parsed manually for the simple corpus — ^x.y.z, >=x.y.z, <x.y.z, *).
+ *   Source "root" means the root package depends on target.
+ *   Source "A" means every version of A (version-independent) depends on target.
+ */
+type DepGraph = {
+  packages: Record<string, string[]>;  // name → available versions
+  edges: Array<{ from: string; to: string; range: string }>;
+};
+
+/**
+ * Ask Z3 (via Node subprocess) whether a satisfying assignment exists for the given
+ * dependency graph. Returns "sat" | "unsat" | throws on error.
+ *
+ * We spawn Node because z3-solver@4.16.0's Emscripten pthread WASM crashes in Bun 1.3.12
+ * (see module-level comment). The subprocess is a real assertion — not a skip.
+ */
+function queryZ3(graph: DepGraph): "sat" | "unsat" {
+  // Build the Node.js script inline; graph is JSON-serialized.
+  const graphJson = JSON.stringify(graph);
+  const nodeScript = `
+const { init } = require('z3-solver/build/node.js');
+const graph = ${graphJson};
+
+function encVer(v) {
+  const [ma, mi, pa] = v.split('.').map(Number);
+  return ma * 1_000_000 + mi * 1_000 + (pa || 0);
+}
+
+(async () => {
+  const { Context } = await init();
+  const { Solver, Int, Or, And } = new Context('main');
+  const solver = new Solver();
+
+  // Create one Int const per package (the chosen encoded version).
+  const vars = {};
+  for (const [name, versions] of Object.entries(graph.packages)) {
+    vars[name] = Int.const(name);
+    // Constrain to one of the available encoded versions (OR of equalities).
+    const choices = versions.map(v => vars[name].eq(Int.val(encVer(v))));
+    if (choices.length === 0) {
+      // Empty availability → unsat for any edge to this name
+      solver.add(Int.val(0).eq(Int.val(1)));
+    } else if (choices.length === 1) {
+      solver.add(choices[0]);
+    } else {
+      solver.add(Or(...choices));
+    }
+  }
+
+  // Add edge constraints. "root" is a pseudo-source with no variable; edges from "root"
+  // apply directly to the target. Edges from other packages apply unconditionally (version-
+  // independent corpus: same deps regardless of which version is picked for the source).
+  for (const edge of graph.edges) {
+    if (!vars[edge.to]) {
+      // Target not in packages → unsat (missing package)
+      solver.add(Int.val(0).eq(Int.val(1)));
+      continue;
+    }
+    const target = vars[edge.to];
+    const s = edge.range.trim();
+    if (s === '*' || s === '' || s === 'x' || s === 'X') continue; // no constraint
+
+    if (s.startsWith('^')) {
+      const ver = s.slice(1);
+      const enc = encVer(ver);
+      const parts = ver.split('.').map(Number);
+      const major = parts[0], minor = parts[1];
+      let upperEnc;
+      if (major > 0) upperEnc = encVer((major + 1) + '.0.0');
+      else if (minor > 0) upperEnc = encVer('0.' + (minor + 1) + '.0');
+      else upperEnc = enc + 1;
+      solver.add(target.ge(Int.val(enc)));
+      solver.add(target.lt(Int.val(upperEnc)));
+      continue;
+    }
+
+    const m = /^(>=|<=|>|<|=)?(.+)$/.exec(s);
+    if (!m) throw new Error('Cannot parse range: ' + s);
+    const op = m[1] || '=';
+    const enc = encVer(m[2]);
+    if (op === '>=') solver.add(target.ge(Int.val(enc)));
+    else if (op === '>') solver.add(target.gt(Int.val(enc)));
+    else if (op === '<') solver.add(target.lt(Int.val(enc)));
+    else if (op === '<=') solver.add(target.le(Int.val(enc)));
+    else solver.add(target.eq(Int.val(enc)));
+  }
+
+  const result = await solver.check();
+  process.stdout.write(result + '\\n');
+  process.exit(0);
+})().catch(e => { process.stderr.write(e.message + '\\n'); process.exit(1); });
+`;
+
+  const result = spawnSync("node", ["-e", nodeScript], {
+    encoding: "utf-8",
+    timeout: 25000,
+    cwd: process.cwd(),
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Z3 subprocess failed (status ${result.status ?? "null"}):\n${result.stderr ?? ""}`.trimEnd()
+    );
+  }
+  const out = (result.stdout ?? "").trim();
+  if (out !== "sat" && out !== "unsat") {
+    throw new Error(`Z3 subprocess returned unexpected output: ${JSON.stringify(out)}`);
+  }
+  return out as "sat" | "unsat";
+}
+
+// ---- corpus case helpers ----------------------------------------------------
+
+/**
+ * Assert agreement between solve() and Z3 oracle, and (for ok cases) self-consistency
+ * of the returned versions map.
+ */
+async function assertAgreement(
+  graph: DepGraph,
+  root: AcePackage,
+  registry: Map<string, Map<string, RegistryEntry>>,
+  fetch: FetchPackage,
+): Promise<void> {
+  const [solveResult, z3Verdict] = await Promise.all([
+    solve(root, fetch, registry),
+    Promise.resolve().then(() => queryZ3(graph)), // sync spawnSync, wrapped in promise
+  ]);
+
+  const solveOk = solveResult.ok;
+  const z3Sat = z3Verdict === "sat";
+
+  expect(
+    solveOk,
+    `solve() and Z3 disagree: solve=${solveOk ? "ok" : "fail"}, Z3=${z3Verdict}. ` +
+      (!solveOk ? `solve reason: ${(solveResult as { reason: string }).reason}` : "")
+  ).toBe(z3Sat);
+
+  // Extra self-consistency check for ok cases: every range in the graph that targets
+  // a solved package must be satisfied by the chosen version.
+  if (solveResult.ok) {
+    for (const edge of graph.edges) {
+      if (edge.from === "root" || edge.to in graph.packages) {
+        const chosenVer = solveResult.versions.get(edge.to);
+        if (chosenVer !== undefined) {
+          expect(
+            satisfies(chosenVer, edge.range),
+            `Self-consistency: solve() chose ${edge.to}@${chosenVer} but range ${edge.range} not satisfied`
+          ).toBe(true);
+        }
+      }
+    }
+  }
+}
+
+// ---- corpus -----------------------------------------------------------------
+
+describe("solver Z3 differential — SAT oracle cross-check", () => {
+  // Generous timeout: Z3 WASM init + subprocess spawn + check can take a few seconds.
+  const TIMEOUT = 30_000;
+
+  test(
+    "corpus 1: SAT diamond (root→A^1.0.0, root→B^1.0.0; A and B are leaves)",
+    async () => {
+      // Registry: A{1.0.0}, B{1.0.0}
+      const A = pkgAt("A", "1.0.0");
+      const B = pkgAt("B", "1.0.0");
+      const root = pkgAt("root", "1.0.0", [regEdge("A", "^1.0.0"), regEdge("B", "^1.0.0")]);
+      const { registry, fetch } = world([
+        { pkg: A, url: "u/A/1.0.0" },
+        { pkg: B, url: "u/B/1.0.0" },
+      ]);
+
+      const graph: DepGraph = {
+        packages: { A: ["1.0.0"], B: ["1.0.0"] },
+        edges: [
+          { from: "root", to: "A", range: "^1.0.0" },
+          { from: "root", to: "B", range: "^1.0.0" },
+        ],
+      };
+
+      await assertAgreement(graph, root, registry, fetch);
+    },
+    TIMEOUT
+  );
+
+  test(
+    "corpus 2: UNSAT shared-dep (A and B demand incompatible C versions)",
+    async () => {
+      // A@1.0.0 dep C>=2.0.0, B@1.0.0 dep C<2.0.0; registry C{1.0.0, 2.0.0}
+      const C10 = pkgAt("C", "1.0.0");
+      const C20 = pkgAt("C", "2.0.0");
+      const A = pkgAt("A", "1.0.0", [regEdge("C", ">=2.0.0")]);
+      const B = pkgAt("B", "1.0.0", [regEdge("C", "<2.0.0")]);
+      const root = pkgAt("root", "1.0.0", [regEdge("A", "*"), regEdge("B", "*")]);
+      const { registry, fetch } = world([
+        { pkg: A, url: "u/A/1.0.0" },
+        { pkg: B, url: "u/B/1.0.0" },
+        { pkg: C10, url: "u/C/1.0.0" },
+        { pkg: C20, url: "u/C/2.0.0" },
+      ]);
+
+      const graph: DepGraph = {
+        packages: { A: ["1.0.0"], B: ["1.0.0"], C: ["1.0.0", "2.0.0"] },
+        edges: [
+          { from: "root", to: "A", range: "*" },
+          { from: "root", to: "B", range: "*" },
+          // Version-independent: A's single version requires C>=2.0.0
+          { from: "A", to: "C", range: ">=2.0.0" },
+          // Version-independent: B's single version requires C<2.0.0
+          { from: "B", to: "C", range: "<2.0.0" },
+        ],
+      };
+
+      await assertAgreement(graph, root, registry, fetch);
+    },
+    TIMEOUT
+  );
+
+  test(
+    "corpus 3: SAT with real pick (root→A>=1.2.0; registry A{1.0.0,1.2.0,1.5.0})",
+    async () => {
+      const A10 = pkgAt("A", "1.0.0");
+      const A12 = pkgAt("A", "1.2.0");
+      const A15 = pkgAt("A", "1.5.0");
+      const root = pkgAt("root", "1.0.0", [regEdge("A", ">=1.2.0")]);
+      const { registry, fetch } = world([
+        { pkg: A10, url: "u/A/1.0.0" },
+        { pkg: A12, url: "u/A/1.2.0" },
+        { pkg: A15, url: "u/A/1.5.0" },
+      ]);
+
+      const graph: DepGraph = {
+        packages: { A: ["1.0.0", "1.2.0", "1.5.0"] },
+        edges: [{ from: "root", to: "A", range: ">=1.2.0" }],
+      };
+
+      // Also verify the specific choice is >=1.2.0 (self-consistency check inside assertAgreement).
+      await assertAgreement(graph, root, registry, fetch);
+    },
+    TIMEOUT
+  );
+});


### PR DESCRIPTION
## Ace slice 5.2 — semver ranges + version solver (B-0288)

Implements the slice-5.2 spec (#6376): a registry dependency can name a package by **name + semver range**; `ace install` solves the range constraints across the transitive graph to one concrete version per package, then feeds the solved graph into slice-5.1's unchanged verify + atomic-install engine.

### What changed
- **`tools/ace/semver.ts`** (new, pure) — pragmatic semver subset: `parseVersion`, `compareVersions`, `parseRange` (`^ ~ >= <= > < =`, exact, `* / x` wildcard, space-AND), `satisfies`, `maxSatisfying`. `^`/`~` desugaring incl. `^0.x` / `^0.0.x`.
- **`tools/ace/solver.ts`** (new) — deterministic **newest-first backtracking** `solve()`. Classifies edges by **source**: inline = pre-decided (version + url/hash, never registry-routed); registry = range-solved against registry versions. Re-validates already-assigned packages on **every** new constraint; **retracts an abandoned version's contributed constraints on repair** (source-tagged, so a version-dependent transitive dep can't over-constrain unrelated packages).
- **`tools/ace/resolve.ts`** — new `solved: Map<string,string>` param; registry edges resolve their concrete version from the map + a `satisfies` **defense-in-depth re-check** (a solved version violating the edge's range → `unsatisfiable`); concrete version threaded through all bookkeeping; new `unsatisfiable`/`bad-range` reasons. Every slice-5.1 verify step intact.
- **`tools/ace/ace.ts`** — `install` runs solve→resolve (refuses with exit 1 + reason if either fails, store stays empty); `--print-resolution` prints the solved graph.
- **`.claude/skills/ace/SKILL.md`** — range-dep + solver docs.

### Testing (163 tests pass; full-repo strict-tsc clean; markdownlint clean)
- **node-semver differential** (`semver.test.ts`) — our `satisfies`/`maxSatisfying` asserted against the `semver` npm package over a corpus (always runs under bun).
- **Z3 differential** (`solver.z3.test.ts`) — Z3 as a SAT oracle cross-checking the TS solver's ok/unsatisfiable verdicts (per your "use z3 to test our ts"). See caveat below.
- **solver unit** — inline-only/empty-registry back-compat, range→newest, transitive-backtrack re-validation, unsatisfiable, bad-range, mixed inline+registry, determinism, **+ 2 P1-regression tests** (constraint retraction).
- **resolve + ace e2e** — ranged install→newest, unsatisfiable→exit-1-store-empty, inline-only back-compat, `--print-resolution`.

### Review gate caught + fixed before merge
- **P1 (solver correctness)** — final review constructed a runnable false-`unsatisfiable` on version-dependent dep graphs (stale monotone constraints). **Fixed** via source-tagged constraint retraction (`70c476cb2`); both reviewer failing cases are now regression tests.
- **P2** — SKILL.md reason-name drift (`registry-unsatisfiable` → `unsatisfiable`). Fixed.

### Caveats / follow-ups (substrate-honest)
- **z3-solver + Bun:** `z3-solver`'s Emscripten-pthreads WASM doesn't load under Bun 1.3.12; the Z3 differential bridges via a `node -e` subprocess (Node present locally), runs + asserts (no skip). CI doesn't run the bun ace tests (only `lint (tsc tools)` + the .NET `build-and-test`), so the Z3 + node-semver differentials are a **local gate** — same as all prior ace slices. Worth a follow-up if Bun adds pthreads-WASM support (drop the node bridge).
- **Deferred (sliced off):** B-0970 advanced semver (`||`/hyphen/pre-release/build-metadata), B-0971 remote registry, B-0972 single-fetch cache. Slice 5.3 = lockfile.

Spec: #6376. Plan: `docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice5.2-implementation-plan.md`. devDeps `semver@7.8.1` / `@types/semver@7.7.1` / `z3-solver@4.16.0` are test-only, WebSearch-pinned 2026-06-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
