### PR TITLE
feat(algebra): Z-set (signed multiset) TS reference — top rung of the ladder

### DIFF
--- a/src/Core.TypeScript/z-set/golden-vectors.json
+++ b/src/Core.TypeScript/z-set/golden-vectors.json
@@ -1,0 +1,93 @@
+{
+  "description": "Z-set (signed multiset) cross-language conformance — the TOP rung of the algebra ladder (G-Set ⊂ Bag ⊂ Z-set; B-0954 bus / B-0867.27 observe-algebra). A Z-set widens the Bag from ℕ to ℤ (weight codomain signed): every key carries a NONZERO integer weight w (positive OR negative), and the combiner is per-key SUM (per the database-design ADR 2026-05-31 — Z-set = ℤ/sum). Two load-bearing contrasts pin it down: (1) vs the Bag — a Bag drops any key summed to <= 0, a Z-set drops ONLY == 0, so NEGATIVE weights persist (a retraction in flight); that single change of the drop rule (>0 → !=0) is the entire ℕ→ℤ widening, and it makes the monoid an abelian GROUP with an inverse `negate` (flip every sign), giving union(a, negate(a)) == empty — the law a Bag cannot satisfy and the reason the Z-set is the substrate for retraction / undo / DBSP incremental views. (2) vs the G-Set — like the Bag, union is NOT idempotent: union(a, a) doubles every weight. Every impl starts from `initialZSet`, replays `ops` in order under the canonical key comparator, and must value-match `expectedReplayStates[i]` after op i AND `expectedFinalState`. Z-sets serialize as ascending-key-sorted { e, w } entries (w != 0, no key twice), so equality is array-equality. Oracle #1 = TS reference; the F# `src/Core/ZSet.fs` engine (ascending (key, weight) run, consolidate duplicates, drop zero-weighted) plus C#/Rust twins join later per the meet-in-the-middle 4-oracle.",
+  "elementType": "string",
+  "comparator": "ascending ordinal / UTF-16 code-unit order on the key `e` (TS `<` / C# StringComparer.Ordinal / byte-ordered Rust `Ord`). NOTE: the F# Z-set engine sorts via `Comparer<'K>.Default`, which for string is culture-sensitive (not ordinal); it coincides with ordinal for these ASCII `z-XXX` keys — where ordinal also equals Unicode code-point order — so all four oracles agree on these vectors. Moving F# to ordinal for true non-ASCII parity is the same known gap noted for the G-Set / Bag oracles. Astral-plane keys (UTF-16 code-unit vs code-point divergence) are out of scope for the v1 contract.",
+  "combiner": "sum over ℤ (per-key weights add; a shared key whose weights cancel to 0 is DROPPED = retraction; NOT idempotent)",
+  "initialZSet": [
+    { "e": "z-002", "w": 1 },
+    { "e": "z-005", "w": 2 }
+  ],
+  "ops": [
+    { "op": "add", "arg": "z-001", "note": "grow: new key at weight 1" },
+    {
+      "op": "addW",
+      "arg": "z-005",
+      "w": -1,
+      "note": "signed reduction: existing key, weight 2 → 1 (a Bag's addN cannot take a negative)"
+    },
+    {
+      "op": "addW",
+      "arg": "z-005",
+      "w": -1,
+      "note": "RETRACTION to zero: weight 1 → 0 → key DROPPED (the abelian-group inverse in action)"
+    },
+    {
+      "op": "addW",
+      "arg": "z-003",
+      "w": -3,
+      "note": "NEGATIVE weight persists: new key at -3 (a Bag would drop this; the Z-set keeps it)"
+    },
+    {
+      "op": "union",
+      "arg": [
+        { "e": "z-001", "w": 2 },
+        { "e": "z-003", "w": 3 },
+        { "e": "z-006", "w": -1 }
+      ],
+      "note": "mixed-sign sum over unsorted input: z-001 1→3, z-003 -3+3=0 → DROPPED (retraction), z-006 new -1 (negative persists)"
+    },
+    { "op": "union", "arg": [], "note": "identity: union with the empty Z-set is a no-op" },
+    { "op": "addW", "arg": "z-000", "w": 5, "note": "addW: new key at weight 5, sorted to the front" }
+  ],
+  "expectedReplayStates": [
+    [
+      { "e": "z-001", "w": 1 },
+      { "e": "z-002", "w": 1 },
+      { "e": "z-005", "w": 2 }
+    ],
+    [
+      { "e": "z-001", "w": 1 },
+      { "e": "z-002", "w": 1 },
+      { "e": "z-005", "w": 1 }
+    ],
+    [
+      { "e": "z-001", "w": 1 },
+      { "e": "z-002", "w": 1 }
+    ],
+    [
+      { "e": "z-001", "w": 1 },
+      { "e": "z-002", "w": 1 },
+      { "e": "z-003", "w": -3 }
+    ],
+    [
+      { "e": "z-001", "w": 3 },
+      { "e": "z-002", "w": 1 },
+      { "e": "z-006", "w": -1 }
+    ],
+    [
+      { "e": "z-001", "w": 3 },
+      { "e": "z-002", "w": 1 },
+      { "e": "z-006", "w": -1 }
+    ],
+    [
+      { "e": "z-000", "w": 5 },
+      { "e": "z-001", "w": 3 },
+      { "e": "z-002", "w": 1 },
+      { "e": "z-006", "w": -1 }
+    ]
+  ],
+  "expectedFinalState": [
+    { "e": "z-000", "w": 5 },
+    { "e": "z-001", "w": 3 },
+    { "e": "z-002", "w": 1 },
+    { "e": "z-006", "w": -1 }
+  ],
+  "laws": {
+    "commutative": "union(a, b) == union(b, a)",
+    "associative": "union(union(a, b), c) == union(a, union(b, c))",
+    "identity": "union(a, empty) == a",
+    "inverse": "union(a, negate(a)) == empty — the abelian-group inverse the Bag cannot satisfy (retraction)",
+    "notIdempotent": "union(a, a) doubles every weight (== scale a by 2) — the non-idempotence shared with the Bag, distinct from the G-Set",
+    "negativesPersist": "a key with a net-negative weight is kept (drop rule is == 0, not <= 0) — the ℕ→ℤ widening from the Bag"
+  }
+}

--- a/src/Core.TypeScript/z-set/index.ts
+++ b/src/Core.TypeScript/z-set/index.ts
@@ -1,0 +1,1 @@
+export * from "./z-set";

--- a/src/Core.TypeScript/z-set/z-set.test.ts
+++ b/src/Core.TypeScript/z-set/z-set.test.ts
@@ -1,0 +1,176 @@
+/**
+ * z-set.test.ts — TS reference (oracle #1) for the Z-set (signed multiset) — the
+ * TOP rung of the algebra ladder (G-Set ⊂ Bag ⊂ Z-set).
+ *
+ * Three duties:
+ *   1. The abelian-GROUP laws hold (commutative, associative, identity, AND the
+ *      inverse: union(a, negate(a)) == empty) — plus union is NOT idempotent
+ *      (union(a, a) doubles weights, shared with the Bag) and NEGATIVE weights
+ *      persist (drop rule is == 0, not <= 0 — the ℕ→ℤ widening from the Bag).
+ *   2. Construction canonicalizes (sum per key, drop weight == 0, sort).
+ *   3. The shared golden vector replays to the expected states — the
+ *      cross-language parity lock the F#/C#/Rust twins also cast.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  add,
+  addW,
+  contains,
+  distinctCount,
+  empty,
+  equals,
+  isEmpty,
+  negate,
+  ofArray,
+  ofEntries,
+  singleton,
+  stringCompare,
+  toEntries,
+  total,
+  union,
+  weight,
+  type ZEntry,
+  type ZSet,
+} from "./z-set";
+
+const cmp = stringCompare;
+const entry = (e: string, w: number): ZEntry<string> => ({ e, w });
+const zset = (...es: readonly ZEntry<string>[]): ZSet<string> => ofEntries(cmp, es);
+
+describe("Z-set — canonicalization", () => {
+  it("ofArray counts occurrences, sorts ascending", () => {
+    expect(toEntries(ofArray(cmp, ["c", "a", "b", "a", "c", "c"]))).toEqual([
+      entry("a", 2),
+      entry("b", 1),
+      entry("c", 3),
+    ]);
+  });
+  it("ofEntries sums per-key weights, drops weight == 0, KEEPS negatives", () => {
+    // a: 1+2=3 ; b: 1+(-1)=0 → dropped ; c: -1 kept (the Bag would drop c)
+    expect(toEntries(zset(entry("a", 1), entry("a", 2), entry("b", 1), entry("b", -1), entry("c", -1)))).toEqual([
+      entry("a", 3),
+      entry("c", -1),
+    ]);
+  });
+  it("empty is empty; singleton has one key; singleton(_, 0) is empty; singleton accepts negatives", () => {
+    expect(toEntries(empty<string>())).toEqual([]);
+    expect(toEntries(singleton("x", 4))).toEqual([entry("x", 4)]);
+    expect(toEntries(singleton("x", -4))).toEqual([entry("x", -4)]);
+    expect(toEntries(singleton("x", 0))).toEqual([]);
+  });
+  it("weight / contains agree (binary search; contains is weight != 0)", () => {
+    const z = zset(entry("a", 2), entry("c", -5), entry("e", 1));
+    expect(weight(cmp, z, "c")).toBe(-5);
+    expect(weight(cmp, z, "d")).toBe(0);
+    expect(contains(cmp, z, "c")).toBe(true); // negative weight still "contained"
+    expect(contains(cmp, z, "z")).toBe(false);
+  });
+  it("distinctCount counts keys; total sums weights (may be negative)", () => {
+    const z = zset(entry("a", 2), entry("b", -3));
+    expect(distinctCount(z)).toBe(2);
+    expect(total(z)).toBe(-1);
+  });
+  it("rejects non-integer / non-finite weights (weights are ℤ; integer F#/C#/Rust parity)", () => {
+    expect(() => singleton("x", 0.5)).toThrow(RangeError);
+    expect(() => addW(cmp, "x", 1.5, empty<string>())).toThrow(RangeError);
+    expect(() => ofEntries(cmp, [entry("x", Number.NaN)])).toThrow(RangeError);
+    expect(() => ofEntries(cmp, [entry("x", Number.NEGATIVE_INFINITY)])).toThrow(RangeError);
+    // safe integers (including 0, handled by the drop/no-op logic) are admitted
+    expect(toEntries(singleton("x", 0))).toEqual([]);
+    expect(equals(cmp, addW(cmp, "z", 0, zset(entry("a", 1))), zset(entry("a", 1)))).toBe(true);
+  });
+  it("guards SUMMED weights against safe-integer overflow (union + ofEntries dedup; both signs)", () => {
+    const big = singleton("x", Number.MAX_SAFE_INTEGER);
+    expect(() => union(cmp, big, singleton("x", 2))).toThrow(RangeError); // past MAX
+    const negBig = singleton("x", Number.MIN_SAFE_INTEGER);
+    expect(() => union(cmp, negBig, singleton("x", -2))).toThrow(RangeError); // below MIN
+    expect(() => ofEntries(cmp, [entry("x", Number.MAX_SAFE_INTEGER), entry("x", 2)])).toThrow(RangeError);
+    expect(toEntries(union(cmp, singleton("x", 2), singleton("x", 3)))).toEqual([entry("x", 5)]); // safe sum is fine
+  });
+  it("total throws if the aggregate sum overflows safe-integer range", () => {
+    const z = zset(entry("a", Number.MAX_SAFE_INTEGER), entry("b", 1));
+    expect(() => total(z)).toThrow(RangeError);
+    expect(total(zset(entry("a", 2), entry("b", -3)))).toBe(-1);
+  });
+});
+
+describe("Z-set — abelian-group laws (inverse + NON-idempotence + negatives persist)", () => {
+  // Named off the `union(compare, a, b)` parameter names so the commutativity
+  // test isn't misread as a swapped-argument bug by static analysis — the swap
+  // IS the property.
+  const zsetA = zset(entry("a", 1), entry("b", 2));
+  const zsetB = zset(entry("b", -1), entry("c", 3));
+  const zsetC = zset(entry("c", 1), entry("d", -4));
+
+  it("commutative: union(a, b) == union(b, a)", () => {
+    expect(equals(cmp, union(cmp, zsetA, zsetB), union(cmp, zsetB, zsetA))).toBe(true);
+  });
+  it("associative: union(union(a, b), c) == union(a, union(b, c))", () => {
+    const left = union(cmp, union(cmp, zsetA, zsetB), zsetC);
+    const right = union(cmp, zsetA, union(cmp, zsetB, zsetC));
+    expect(equals(cmp, left, right)).toBe(true);
+  });
+  it("identity: union(a, empty) == a and union(empty, a) == a", () => {
+    expect(equals(cmp, union(cmp, zsetA, empty<string>()), zsetA)).toBe(true);
+    expect(equals(cmp, union(cmp, empty<string>(), zsetA), zsetA)).toBe(true);
+  });
+  it("inverse: union(a, negate(a)) == empty (the law the Bag cannot satisfy)", () => {
+    expect(isEmpty(union(cmp, zsetA, negate(zsetA)))).toBe(true);
+    // negate flips every sign and preserves the canonical invariant
+    expect(toEntries(negate(zsetA))).toEqual([entry("a", -1), entry("b", -2)]);
+    expect(toEntries(negate(negate(zsetA)))).toEqual(toEntries(zsetA)); // involution
+  });
+  it("NOT idempotent: union(a, a) doubles every weight (shared with the Bag, distinct from the G-Set)", () => {
+    const doubled = union(cmp, zsetA, zsetA);
+    expect(toEntries(doubled)).toEqual([entry("a", 2), entry("b", 4)]);
+    expect(equals(cmp, doubled, zsetA)).toBe(false);
+  });
+  it("union sums overlapping keys, drops cancellations to 0, keeps surviving negatives", () => {
+    // a: 1 (disjoint) ; b: 2+(-1)=1 ; c: 3 (disjoint) → none cancel here
+    expect(toEntries(union(cmp, zsetA, zsetB))).toEqual([entry("a", 1), entry("b", 1), entry("c", 3)]);
+    // explicit cancellation: b 2 + (-2) = 0 → dropped
+    expect(toEntries(union(cmp, zsetA, zset(entry("b", -2))))).toEqual([entry("a", 1)]);
+  });
+  it("add increments by 1; addW adds signed weight; addW(_, 0) is a no-op; addW can retract to 0", () => {
+    expect(toEntries(add(cmp, "a", zsetA))).toEqual([entry("a", 2), entry("b", 2)]);
+    expect(toEntries(addW(cmp, "z", -3, zsetA))).toEqual([entry("a", 1), entry("b", 2), entry("z", -3)]);
+    expect(equals(cmp, addW(cmp, "z", 0, zsetA), zsetA)).toBe(true);
+    expect(toEntries(addW(cmp, "a", -1, zsetA))).toEqual([entry("b", 2)]); // a 1 + (-1) = 0 → retracted
+  });
+});
+
+interface GoldenZEntry {
+  e: string;
+  w: number;
+}
+type GoldenOp =
+  | { op: "add"; arg: string }
+  | { op: "addW"; arg: string; w: number }
+  | { op: "union"; arg: readonly GoldenZEntry[] };
+interface GoldenVector {
+  readonly initialZSet: readonly GoldenZEntry[];
+  readonly ops: readonly GoldenOp[];
+  readonly expectedReplayStates: readonly (readonly GoldenZEntry[])[];
+  readonly expectedFinalState: readonly GoldenZEntry[];
+}
+
+describe("Z-set — shared golden vector (cross-language parity lock)", () => {
+  const gv = JSON.parse(readFileSync(join(import.meta.dir, "golden-vectors.json"), "utf-8")) as GoldenVector;
+  const plain = (z: ZSet<string>): GoldenZEntry[] => toEntries(z).map((x) => ({ e: x.e, w: x.w }));
+
+  it("replays the vector to expectedReplayStates + expectedFinalState", () => {
+    let state = ofEntries(cmp, gv.initialZSet);
+    const states: GoldenZEntry[][] = [];
+    for (const op of gv.ops) {
+      if (op.op === "add") state = add(cmp, op.arg, state);
+      else if (op.op === "addW") state = addW(cmp, op.arg, op.w, state);
+      else state = union(cmp, state, ofEntries(cmp, op.arg));
+      states.push(plain(state));
+    }
+    expect(states).toEqual(gv.expectedReplayStates.map((s) => s.map((x) => ({ e: x.e, w: x.w }))));
+    expect(plain(state)).toEqual(gv.expectedFinalState.map((x) => ({ e: x.e, w: x.w })));
+  });
+});

--- a/src/Core.TypeScript/z-set/z-set.ts
+++ b/src/Core.TypeScript/z-set/z-set.ts
@@ -1,0 +1,260 @@
+/**
+ * z-set.ts — a Z-set (signed multiset), the TOP rung of the Zeta algebra ladder
+ * (**G-Set → Bag → Z-set**) made first-class.
+ *
+ * A Z-set widens the Bag from ℕ to **ℤ**: every key carries a NONZERO integer
+ * `w` (the weight; absent key ⇒ weight 0), positive OR negative, and the only
+ * combiner is `union` = per-key **sum**. Two axes of contrast pin it down:
+ *
+ *   - vs the **Bag** (ℕ / sum, commutative monoid): a Bag drops any key whose
+ *     summed count is `<= 0`; a Z-set drops ONLY `== 0` — a negative weight is a
+ *     valid stored value (a *retraction in flight*). That single change of the
+ *     drop rule (`> 0` → `!= 0`) is the entire ℕ→ℤ widening, and it makes the
+ *     monoid an abelian **group**: every Z-set has an inverse, {@link negate}
+ *     (flip every sign), with `union(a, negate(a)) == empty`. That inverse is
+ *     the law a Bag literally cannot have, and it is why the Z-set — not the
+ *     Bag — is the substrate for retraction / undo / DBSP incremental views.
+ *   - vs the **G-Set** (idempotent set-union semilattice): like the Bag, the
+ *     Z-set's union is NOT idempotent — `union(a, a)` doubles every weight.
+ *
+ * Per the database-design ADR (2026-05-31): Z-set = ℤ / sum
+ * (`docs/DECISIONS/2026-05-31-zeta-database-design-event-sourced-gset-bag-zset-rx-fold-materialized-views-two-backends.md`).
+ *
+ * This is the same comms/counting substrate as the lower rungs: it matches the
+ * existing F# `src/Core/ZSet.fs` engine semantics (an ascending-`(key, weight)`
+ * run that consolidates duplicates and drops zero-weighted entries), so the
+ * F#/C#/Rust twins join the shared `golden-vectors.json` per the
+ * meet-in-the-middle 4-oracle — every impl produces the identical canonical
+ * entry array, so the fixture is byte-stable across languages.
+ *
+ * Canonical representation: an **ascending-key-sorted** `readonly` array of
+ * `{ e, w }` entries, every `w != 0`, no key appearing twice. The canonical
+ * order makes `equals` a plain element-wise comparison and keeps the
+ * cross-language golden vector stable. The required `compare` is a total order
+ * on the KEY only (the weight never participates in ordering); it is the TS
+ * analog of F#'s `'K : comparison` constraint.
+ */
+
+/** A total order on `T` (`< 0`, `0`, `> 0`), e.g. {@link stringCompare}. */
+export type Compare<T> = (a: T, b: T) => number;
+
+/** One Z-set entry: a key `e` with a strictly-nonzero signed weight `w` (`w != 0`). */
+export interface ZEntry<T> {
+  readonly e: T;
+  readonly w: number;
+}
+
+/**
+ * A signed multiset: an ascending-key-sorted, weight-nonzero run under some
+ * `compare`. The invariant (sorted, every `w != 0`, no key twice) is held by
+ * every constructor here — never build one by hand from raw entries; use
+ * {@link ofEntries} or {@link ofArray}.
+ */
+export type ZSet<T> = readonly ZEntry<T>[];
+
+/**
+ * Index a run whose bound is guaranteed by the surrounding loop. The cast
+ * targets the bare element type parameter `E` — the same assertion-free-at-the-
+ * call-site idiom the G-Set / Bag twins use — because `noUncheckedIndexedAccess`
+ * would otherwise widen every `arr[i]` to `E | undefined`.
+ */
+function at<E>(arr: readonly E[], i: number): E {
+  return arr[i] as E;
+}
+
+/**
+ * A weight must be a safe integer — weights are ℤ, so a fraction / NaN /
+ * Infinity / unsafe-magnitude value is not an integer weight and cannot be
+ * represented by the int64 F#/C#/Rust oracles. Zero IS accepted as input (the
+ * constructors drop it — a `0` weight is never stored), and NEGATIVE integers
+ * are accepted AND stored (the Bag→Z-set widening), so a canonical Z-set always
+ * holds nonzero integer weights. `Number.isSafeInteger` bounds both signs
+ * (`|w| <= 2^53 - 1`).
+ */
+function assertWeight(w: number): void {
+  if (!Number.isSafeInteger(w)) {
+    throw new RangeError(`Z-set weight must be a safe integer (got ${String(w)})`);
+  }
+}
+
+/**
+ * Add two weights and re-assert the sum is still a safe integer before it is
+ * stored. Two valid (safe-integer) weights can sum past `Number.MAX_SAFE_INTEGER`
+ * (or below `Number.MIN_SAFE_INTEGER`) — which would silently lose precision
+ * where the int64 oracles would not — so every summed weight (the `union` /
+ * `ofEntries` merge of a shared key, and the `total` aggregate) is guarded.
+ */
+function addWeights(a: number, b: number): number {
+  const sum = a + b;
+  assertWeight(sum);
+  return sum;
+}
+
+/**
+ * Ascending ordinal (UTF-16 code-unit) order — JS `<` on strings — matching
+ * C# `StringComparer.Ordinal` and a byte-ordered Rust `Ord`. (Same ordinal note
+ * as the Bag/G-Set twins: the F# oracle's `Comparer<'K>.Default` is
+ * culture-sensitive for `string` but coincides with ordinal for the ASCII
+ * `z-XXX` fixture keys; astral-plane keys are out of scope for the v1 contract.)
+ */
+export const stringCompare: Compare<string> = (a, b) => {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+};
+
+/** The empty Z-set (the `union` identity, and `negate(empty) == empty`). */
+export function empty<T>(): ZSet<T> {
+  return [];
+}
+
+/** A one-key Z-set at weight `w` (default 1, must be a safe integer); `w == 0` yields the empty Z-set. `w` may be negative. */
+export function singleton<T>(x: T, w = 1): ZSet<T> {
+  assertWeight(w);
+  return w !== 0 ? [{ e: x, w }] : [];
+}
+
+/**
+ * Canonicalize arbitrary entries: sum weights per key, drop any whose summed
+ * weight is `== 0`, and sort ascending by key. This is the constructor that
+ * re-establishes the invariant from unordered, possibly-duplicated,
+ * possibly-negative input. (Contrast the Bag, which drops `<= 0`; the Z-set
+ * keeps negatives.)
+ */
+export function ofEntries<T>(compare: Compare<T>, entries: readonly ZEntry<T>[]): ZSet<T> {
+  const sorted = [...entries].sort((a, b) => compare(a.e, b.e));
+  const out: ZEntry<T>[] = [];
+  for (const entry of sorted) {
+    assertWeight(entry.w);
+    const last = out.length - 1;
+    if (last >= 0 && compare(at(out, last).e, entry.e) === 0) {
+      const prev = at(out, last);
+      out[last] = { e: prev.e, w: addWeights(prev.w, entry.w) };
+    } else {
+      out.push({ e: entry.e, w: entry.w });
+    }
+  }
+  return out.filter((entry) => entry.w !== 0);
+}
+
+/** Build a Z-set by counting occurrences in a list — each occurrence adds weight 1. */
+export function ofArray<T>(compare: Compare<T>, xs: readonly T[]): ZSet<T> {
+  return ofEntries(
+    compare,
+    xs.map((x) => ({ e: x, w: 1 })),
+  );
+}
+
+/** The weight of `x` (0 if absent — including a key that retracted to 0). Binary search on the sorted keys. O(log n). */
+export function weight<T>(compare: Compare<T>, z: ZSet<T>, x: T): number {
+  let lo = 0;
+  let hi = z.length - 1;
+  while (lo <= hi) {
+    const mid = lo + ((hi - lo) >> 1);
+    const e = at(z, mid);
+    const c = compare(e.e, x);
+    if (c === 0) return e.w;
+    if (c < 0) lo = mid + 1;
+    else hi = mid - 1;
+  }
+  return 0;
+}
+
+/** Membership: whether `x` has a NONZERO weight (positive or negative). */
+export function contains<T>(compare: Compare<T>, z: ZSet<T>, x: T): boolean {
+  return weight(compare, z, x) !== 0;
+}
+
+/**
+ * The combiner: the per-key SUM of two sorted Z-sets, kept sorted and
+ * weight-nonzero (a shared key whose weights cancel to 0 is DROPPED — that drop
+ * is retraction). Commutative, associative, with the empty Z-set as identity,
+ * and — unlike the Bag — every Z-set has an inverse {@link negate}, so this is
+ * an abelian GROUP. It is NOT idempotent: `union(a, a)` doubles every weight.
+ */
+export function union<T>(compare: Compare<T>, a: ZSet<T>, b: ZSet<T>): ZSet<T> {
+  if (a.length === 0) return b;
+  if (b.length === 0) return a;
+  const out: ZEntry<T>[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    const ea = at(a, i);
+    const eb = at(b, j);
+    const c = compare(ea.e, eb.e);
+    if (c < 0) {
+      out.push(ea);
+      i += 1;
+    } else if (c > 0) {
+      out.push(eb);
+      j += 1;
+    } else {
+      const sum = addWeights(ea.w, eb.w); // same key → weights add (guarded against overflow)
+      if (sum !== 0) out.push({ e: ea.e, w: sum }); // == 0 ⇒ retracted, dropped
+      i += 1;
+      j += 1;
+    }
+  }
+  while (i < a.length) {
+    out.push(at(a, i));
+    i += 1;
+  }
+  while (j < b.length) {
+    out.push(at(b, j));
+    j += 1;
+  }
+  return out;
+}
+
+/**
+ * The abelian-group inverse: flip the sign of every weight. `union(a, negate(a))
+ * == empty` (the law a Bag cannot satisfy). Preserves the canonical invariant —
+ * a nonzero weight negates to a nonzero weight, and key order is unchanged.
+ */
+export function negate<T>(z: ZSet<T>): ZSet<T> {
+  return z.map((entry) => ({ e: entry.e, w: -entry.w }));
+}
+
+/** Increment `x`'s weight by 1 (`union` with a singleton). NOT idempotent. */
+export function add<T>(compare: Compare<T>, x: T, z: ZSet<T>): ZSet<T> {
+  return union(compare, z, [{ e: x, w: 1 }]);
+}
+
+/** Add signed weight `w` to `x` (a safe integer, may be negative; `w == 0` is a no-op). A key driven to 0 is retracted. */
+export function addW<T>(compare: Compare<T>, x: T, w: number, z: ZSet<T>): ZSet<T> {
+  assertWeight(w);
+  return w !== 0 ? union(compare, z, [{ e: x, w }]) : z;
+}
+
+/** The entries in canonical (ascending-key) order — a defensive copy. */
+export function toEntries<T>(z: ZSet<T>): ZEntry<T>[] {
+  return z.map((entry) => ({ e: entry.e, w: entry.w }));
+}
+
+/** The number of DISTINCT keys with nonzero weight (the support size). */
+export function distinctCount<T>(z: ZSet<T>): number {
+  return z.length;
+}
+
+/** The sum of all weights (may be negative or zero); throws if the running sum overflows safe-integer range. */
+export function total<T>(z: ZSet<T>): number {
+  let s = 0;
+  for (const entry of z) s = addWeights(s, entry.w); // guarded: the running sum stays a safe integer
+  return s;
+}
+
+/** Whether the Z-set has no keys. */
+export function isEmpty<T>(z: ZSet<T>): boolean {
+  return z.length === 0;
+}
+
+/** Equality of two canonical Z-sets — element-wise key + weight comparison. */
+export function equals<T>(compare: Compare<T>, a: ZSet<T>, b: ZSet<T>): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    const ea = at(a, i);
+    const eb = at(b, i);
+    if (compare(ea.e, eb.e) !== 0 || ea.w !== eb.w) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Z-set (signed multiset) — TS reference oracle, top rung of the algebra ladder

Adds **oracle #1** for the Z-set, completing the design of the algebra ladder **G-Set ⊂ Bag ⊂ Z-set** (G-Set 4/4, Bag landing, Z-set starting here). Per the four-oracle / conformance-by-agreement model, this is the TS reference + the shared treaty fixture the F#/C#/Rust twins will replay.

### What the Z-set adds over the Bag (the ℕ→ℤ widening)
- **Signed weights.** Each key carries a nonzero integer weight, positive *or* negative; combiner is per-key sum.
- **Drop rule is `== 0`, not `<= 0`** → **negative weights persist** (a retraction in flight). One operator change is the entire widening.
- **`negate()` = abelian-group inverse** → `union(a, negate(a)) == empty` — the law the Bag's commutative monoid cannot satisfy, and the reason the Z-set (not the Bag) is the substrate for retraction / undo / DBSP incremental views.
- Like the Bag (unlike the G-Set), `union` is **not idempotent**.

### Matches the existing F# engine
Targets the semantics of the existing `src/Core/ZSet.fs` (ascending `(key, weight)` run, consolidate duplicates, drop zero-weighted), so the F# twin joins the shared `golden-vectors.json` directly; C#/Rust follow.

### Files
- `z-set.ts` — reference impl
- `golden-vectors.json` — the cross-language treaty (replay exercises signed reduction, retraction-to-zero, and a negative weight that persists into the final state)
- `z-set.test.ts` — abelian-group laws incl. inverse, non-idempotence, negatives-persist, canonicalization, golden replay
- `index.ts` — barrel

16/16 tests pass; tsc + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
