### PR TITLE
fix(ace): harden slice-5.2 solver/resolve from Copilot review of #6388

### DIFF
--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -497,7 +497,8 @@ export async function main(argv: readonly string[]): Promise<number> {
       }
       const fetchPackage = async (u: string): Promise<string> =>
         (u.startsWith("http://") || u.startsWith("https://")) ? await (await fetch(u)).text() : readFileSync(u, "utf8");
-      const solveResult = await solve(pkg, fetchPackage, loadRegistry());
+      const registry = loadRegistry();
+      const solveResult = await solve(pkg, fetchPackage, registry);
       if (!solveResult.ok) {
         console.error(`ace: install refused: ${solveResult.reason} — ${solveResult.detail} (path: ${solveResult.path.join(" → ")})`);
         return 1;
@@ -508,7 +509,7 @@ export async function main(argv: readonly string[]): Promise<number> {
           console.log(`  ${n}@${v}`);
         }
       }
-      const res = await resolve(pkg, fetchPackage, loadTrustStore(), loadRegistry(), solveResult.versions, { allowNoSignature: parsed.allowNoSignature });
+      const res = await resolve(pkg, fetchPackage, loadTrustStore(), registry, solveResult.versions, { allowNoSignature: parsed.allowNoSignature });
       if (!res.ok) {
         console.error(`ace: install refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`);
         return 1;

--- a/tools/ace/resolve.test.ts
+++ b/tools/ace/resolve.test.ts
@@ -273,3 +273,31 @@ describe("resolve — solved-map registry edges", () => {
     if (!r.ok) expect(r.reason).toBe("unsatisfiable");
   });
 });
+
+describe("resolve — untrusted registry edge version (regression / bad-range)", () => {
+  test("non-string registry version → bad-range (no satisfies crash)", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root: AcePackage = { manifest: { ...pkgOf("root", { "r.txt": "r" }).manifest, dependencies: [{ kind: "registry", name: "D", version: 123 } as unknown as AceDependency] }, files: { "r.txt": "r" } };
+    const reg = new Map([["D", new Map([["1.0.0", { url: "http://e/D", package_hash: packageHash(D) }]])]]);
+    const solved = new Map([["D", "1.0.0"]]);
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, reg, solved, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("bad-range");
+  });
+  test("malformed registry range string → bad-range (defense-in-depth; resolve does not assume solve ran)", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root: AcePackage = { manifest: { ...pkgOf("root", { "r.txt": "r" }).manifest, dependencies: [{ kind: "registry" as const, name: "D", version: "@@@" }] }, files: { "r.txt": "r" } };
+    const reg = new Map([["D", new Map([["1.0.0", { url: "http://e/D", package_hash: packageHash(D) }]])]]);
+    const solved = new Map([["D", "1.0.0"]]);
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, reg, solved, { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("bad-range");
+  });
+  test("inline edge with non-string version → invalid-package", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root: AcePackage = { manifest: { ...pkgOf("root", { "r.txt": "r" }).manifest, dependencies: [{ kind: "inline", name: "D", version: 123, url: "http://e/D", package_hash: packageHash(D) } as unknown as AceDependency] }, files: { "r.txt": "r" } };
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("invalid-package");
+  });
+});

--- a/tools/ace/resolve.ts
+++ b/tools/ace/resolve.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { contentHash, type AcePackage, type LoadedTrustEntry, type Registry } from "./store.ts";
 import { verifySignature } from "./signing.ts";
-import { satisfies } from "./semver.ts";
+import { parseRange, satisfies } from "./semver.ts";
 
 /** Deterministic JSON: object keys recursively sorted; arrays preserve order. */
 function canonicalJson(value: unknown): string {
@@ -69,8 +69,17 @@ export async function resolve(
         if (concrete === undefined) {
           return { ok: false, reason: "unsatisfiable", detail: `${edge.name}: no solved version`, path: here };
         }
-        // Defense-in-depth: the solved concrete version must actually satisfy the declared range.
-        if (!satisfies(concrete, edge.version)) {
+        // Defense-in-depth: edge.version is untrusted JSON. resolve() must not assume solve() ran,
+        // so parse the declared range here (non-string OR malformed → bad-range) before confirming
+        // the solved concrete version satisfies it.
+        if (typeof edge.version !== "string") {
+          return { ok: false, reason: "bad-range", detail: `${edge.name}: registry edge version must be a string`, path: here };
+        }
+        const range = parseRange(edge.version);
+        if ("error" in range) {
+          return { ok: false, reason: "bad-range", detail: `${edge.name}: ${range.error}`, path: here };
+        }
+        if (!satisfies(concrete, range)) {
           return { ok: false, reason: "unsatisfiable", detail: `${edge.name}: solved ${concrete} violates ${edge.version}`, path: here };
         }
         const entry = registry.get(edge.name)?.get(concrete);
@@ -80,8 +89,8 @@ export async function resolve(
         url = entry.url; package_hash = entry.package_hash;
         effectiveVersion = concrete;
       } else {
-        if (typeof edge.url !== "string" || typeof edge.package_hash !== "string") {
-          return { ok: false, reason: "invalid-package", detail: `${edge.name}: inline edge missing url/package_hash`, path: here };
+        if (typeof edge.url !== "string" || typeof edge.package_hash !== "string" || typeof edge.version !== "string") {
+          return { ok: false, reason: "invalid-package", detail: `${edge.name}: inline edge missing/invalid url/package_hash/version`, path: here };
         }
         url = edge.url; package_hash = edge.package_hash;
         effectiveVersion = edge.version;

--- a/tools/ace/semver.ts
+++ b/tools/ace/semver.ts
@@ -44,7 +44,7 @@ export function parseRange(s: string): RangeOrError {
   return { comparators: out };
 }
 
-// Task 2 extends this with ^ / ~. Task 1: exact, comparators, wildcard token.
+// Parse one comparator token: ^/~ (caret/tilde desugar to a >= / < pair), an exact x.y.z, an op-prefixed (>= <= > < =) version, or a * / x wildcard.
 function parseComparatorToken(token: string): RangeOrError {
   if (token.startsWith("^") || token.startsWith("~")) {
     const v = parseVersion(token.slice(1));

--- a/tools/ace/solver.test.ts
+++ b/tools/ace/solver.test.ts
@@ -137,3 +137,21 @@ describe("solve — constraint retraction on backtrack (P1 regression)", () => {
     if (r.ok) { expect(r.versions.get("A")).toBe("1.0.0"); expect(r.versions.get("C")).toBe("1.0.0"); }
   });
 });
+
+describe("solve — untrusted edge shape (regression)", () => {
+  test("registry edge with non-string version → invalid-package (no parseRange crash)", async () => {
+    const bad = { kind: "registry", name: "A", version: 123 } as unknown as AceDependency;
+    const root = pkgAt("root", "1.0.0", [bad]);
+    const r = await solve(root, fetchOf({}), new Map());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("invalid-package");
+  });
+  test("inline edge with non-string version → invalid-package (no satisfies/pin crash)", async () => {
+    const A = pkgAt("A", "1.0.0");
+    const bad = { kind: "inline", name: "A", version: 123, url: "http://e/A", package_hash: packageHash(A) } as unknown as AceDependency;
+    const root = pkgAt("root", "1.0.0", [bad]);
+    const r = await solve(root, fetchOf({ "http://e/A": A }), new Map());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("invalid-package");
+  });
+});

--- a/tools/ace/solver.test.ts
+++ b/tools/ace/solver.test.ts
@@ -155,3 +155,13 @@ describe("solve — untrusted edge shape (regression)", () => {
     if (!r.ok) expect(r.reason).toBe("invalid-package");
   });
 });
+
+describe("solve — malformed edge name path fidelity (regression)", () => {
+  test("non-string name → invalid-package, path preserves the stringified bad name", async () => {
+    const bad = { kind: "registry", name: 99, version: "^1.0.0" } as unknown as AceDependency;
+    const root = pkgAt("root", "1.0.0", [bad]);
+    const r = await solve(root, fetchOf({}), new Map());
+    expect(r.ok).toBe(false);
+    if (!r.ok) { expect(r.reason).toBe("invalid-package"); expect(r.path).toEqual(["root", "99"]); }
+  });
+});

--- a/tools/ace/solver.ts
+++ b/tools/ace/solver.ts
@@ -97,7 +97,7 @@ export async function solve(root: AcePackage, fetchPackage: FetchPackage, regist
   const ingest = async (deps: ReadonlyArray<AceDependency>, ownerPath: string[], source: string): Promise<SolveResult | null> => {
     if (source !== "root") retractSource(source); // idempotency: clear this source's prior constraints before re-adding (root is seeded once; its constraints are permanent — honors retractSource's "never call with root" invariant)
     for (const edge of deps) {
-      const here = [...ownerPath, edge.name];
+      const here = [...ownerPath, String((edge as { name?: unknown }).name)];
       const ek = (edge as { readonly kind?: unknown }).kind;
       if (ek !== undefined && ek !== "inline" && ek !== "registry") {
         return { ok: false, reason: "invalid-package", detail: `${edge.name}: unknown dependency kind ${JSON.stringify(ek)}`, path: here };

--- a/tools/ace/solver.ts
+++ b/tools/ace/solver.ts
@@ -95,12 +95,18 @@ export async function solve(root: AcePackage, fetchPackage: FetchPackage, regist
    *  for dep recursion; registry edges add a source-tagged range constraint and queue the name.
    *  Returns a failure or null. */
   const ingest = async (deps: ReadonlyArray<AceDependency>, ownerPath: string[], source: string): Promise<SolveResult | null> => {
-    retractSource(source); // idempotency: clear this source's prior constraints before re-adding
+    if (source !== "root") retractSource(source); // idempotency: clear this source's prior constraints before re-adding (root is seeded once; its constraints are permanent — honors retractSource's "never call with root" invariant)
     for (const edge of deps) {
       const here = [...ownerPath, edge.name];
       const ek = (edge as { readonly kind?: unknown }).kind;
       if (ek !== undefined && ek !== "inline" && ek !== "registry") {
         return { ok: false, reason: "invalid-package", detail: `${edge.name}: unknown dependency kind ${JSON.stringify(ek)}`, path: here };
+      }
+      // Edge name + version are untrusted JSON; both kinds read edge.version (registry → parseRange,
+      // inline → satisfies/pin). A non-string crashes those — refuse with a precise invalid-package.
+      const en = edge as { name?: unknown; version?: unknown };
+      if (typeof en.name !== "string" || typeof en.version !== "string") {
+        return { ok: false, reason: "invalid-package", detail: `${String(en.name)}: edge name and version must be strings`, path: here };
       }
 
       if (edge.kind === "registry") {

--- a/tools/ace/solver.z3.test.ts
+++ b/tools/ace/solver.z3.test.ts
@@ -6,7 +6,7 @@
  * but the WASM assertion fails in the worker thread on WASM instance receipt.
  * Exact error: "Aborted(Assertion failed)" at z3-built.js:848 (removeRunDependency → assert).
  *
- * Resolution (no skip — per automated-tests-are-the-shield-assert-dont-skip.md):
+ * Resolution (no skip — per .claude/rules/automated-tests-are-the-shield-assert-dont-skip.md):
  * We spawn a Node.js subprocess for each Z3 query. The test file itself runs under Bun;
  * Z3 actually executes and returns a verdict (sat/unsat); assertions are made in Bun.
  * This is NOT a graceful skip — the test FAILS if Node is unavailable or Z3 crashes.
@@ -165,6 +165,7 @@ function encVer(v) {
 })().catch(e => { process.stderr.write(e.message + '\\n'); process.exit(1); });
 `;
 
+  // eslint-disable-next-line sonarjs/no-os-command-from-path -- "node" is a trusted PATH runtime lookup; Z3's Emscripten-pthread WASM can't init under Bun (see file header), so each query shells to Node. argv carries only a fixed nodeScript template — no untrusted input.
   const result = spawnSync("node", ["-e", nodeScript], {
     encoding: "utf-8",
     timeout: 25000,


### PR DESCRIPTION
Follow-up to #6388 (slice 5.2 — semver + solver, merged `a7263f2d2`). Auto-merge fired on the 7 required checks **before** Copilot's async review completed, so 8 review threads landed on the already-merged PR. This addresses all 8 on the now-merged code. **TS-only; no .NET touched.**

### P0 robustness — untrusted-JSON crash → clean refusal
Dependency edges are untrusted JSON. Both edge kinds read `edge.version` (`registry` → `parseRange`, `inline` → `satisfies`/pin), so a non-string `version` (number/null) threw instead of refusing.
- **solver.ts** — `typeof edge.name/edge.version === "string"` guard right after the kind-check → `invalid-package`.
- **resolve.ts** — registry branch now parses `edge.version` with `parseRange` (guards non-string **and** malformed-string range) before the `satisfies` re-check; inline branch adds the `edge.version` string guard.

### P1 — dead reason
`resolve()`'s `ResolveReason` listed `"bad-range"` but never emitted it. The `parseRange` path above now emits it legitimately (non-string / malformed registry range) — defense-in-depth, since `resolve()` must not assume `solve()` ran.

### P0 lint + P2 cleanups
- **solver.z3.test.ts** — `eslint-disable sonarjs/no-os-command-from-path` on the `spawnSync("node",…)` with rationale (matches the `tools/agent-bus/publish.ts` idiom); full `.claude/rules/…` path on the assert-dont-skip xref.
- **solver.ts `ingest`** — skip `retractSource` for `"root"` (honors the documented "never call with root" invariant; root is seeded once → behavior-identical).
- **semver.ts** — replace the stale "Task 2 extends this" comment (`^`/`~` already handled).
- **ace.ts** — load the registry once and reuse for both `solve()` and `resolve()` (was `loadRegistry()` twice → the two phases could observe different registries).

### Tests
+5 regression tests (2 solver, 3 resolve): non-string version → `invalid-package` (solver) / `bad-range` (resolve registry), malformed range string → `bad-range`, inline non-string version → `invalid-package`. Full ace suite **168 pass / 0 fail**; strict whole-repo `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)