### PR TITLE
feat(algebra): native C# Z-set (signed multiset) — top rung, oracle #3 (3/4)

### DIFF
--- a/src/Core.CSharp/Variance.cs
+++ b/src/Core.CSharp/Variance.cs
@@ -82,7 +82,7 @@ public static class StreamExtensions
     /// <typeparam name="T">Element type.</typeparam>
     /// <param name="handle">Output handle to snapshot.</param>
     /// <returns>A newly-allocated array of Z-entries.</returns>
-    public static ZEntry<T>[] Snapshot<T>(this OutputHandle<ZSet<T>> handle)
+    public static ZEntry<T>[] Snapshot<T>(this OutputHandle<global::Zeta.Core.ZSet<T>> handle)
         where T : IComparable<T>
     {
         var zs = handle.Current;

--- a/src/Core.CSharp/ZSet.cs
+++ b/src/Core.CSharp/ZSet.cs
@@ -1,0 +1,388 @@
+// ZSet — signed-weight multiset (TOP rung of the algebra ladder: G-Set ⊂ Bag ⊂ Z-set).
+// C# native parity oracle; mirrors src/Core.TypeScript/z-set, the F# engine src/Core/ZSet.fs, and
+// the Rust twin (src/Core.Rust.Algebra/src/zset.rs). Native ladder oracle next to GSet.cs / Bag.cs;
+// distinct from the DBSP Z-set binding (ZetaCircuitBuilder) — this is the cross-language treaty impl.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Zeta.Core.CSharp;
+
+/// <summary>
+/// Factory methods for <see cref="ZSet{T}"/>. A non-generic companion class (the .NET convention,
+/// e.g. <see cref="ImmutableArray"/> vs <see cref="ImmutableArray{T}"/>) so the constructors stay
+/// static-member-free on the generic type (CA1000).
+/// </summary>
+public static class ZSet
+{
+    /// <summary>The empty Z-set (the <see cref="ZSet{T}.Union"/> identity).</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <returns>An empty Z-set.</returns>
+    public static ZSet<T> Empty<T>(IComparer<T>? comparer = null) =>
+        new(ImmutableArray<ZSetEntry<T>>.Empty, comparer ?? Comparer<T>.Default);
+
+    /// <summary>A one-key Z-set at weight <paramref name="w"/>; <paramref name="w"/> == 0 yields the empty Z-set. <paramref name="w"/> may be negative.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="x">The single key.</param>
+    /// <param name="w">The signed weight (a no-op if 0).</param>
+    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <returns>A Z-set containing exactly <paramref name="x"/> at weight <paramref name="w"/> (or empty).</returns>
+    public static ZSet<T> Singleton<T>(T x, long w = 1, IComparer<T>? comparer = null)
+    {
+        var cmp = comparer ?? Comparer<T>.Default;
+        return w != 0
+            ? new ZSet<T>(ImmutableArray.Create(new ZSetEntry<T>(x, w)), cmp)
+            : new ZSet<T>(ImmutableArray<ZSetEntry<T>>.Empty, cmp);
+    }
+
+    /// <summary>
+    /// Canonicalize arbitrary <c>(key, weight)</c> entries: sum weights per key, drop any whose
+    /// summed weight is == 0 (retraction), sort ascending by key. Unlike the Bag (which drops
+    /// &lt;= 0), the Z-set KEEPS negatives — the ℕ→ℤ widening.
+    /// </summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="entries">The entries.</param>
+    /// <param name="comparer">Order on the key; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <returns>The canonical Z-set.</returns>
+    public static ZSet<T> OfEntries<T>(IEnumerable<(T Key, long Weight)> entries, IComparer<T>? comparer = null)
+    {
+        var cmp = comparer ?? Comparer<T>.Default;
+        return new ZSet<T>(Canonicalize(entries, cmp), cmp);
+    }
+
+    /// <summary>
+    /// Build a Z-set by counting occurrences in a sequence — each occurrence adds weight 1. The
+    /// ladder sibling of <see cref="GSet.OfSeq"/> / <see cref="Bag.OfSeq"/>.
+    /// </summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="xs">The keys.</param>
+    /// <param name="comparer">Order on the key; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <returns>The canonical Z-set of occurrence weights.</returns>
+    public static ZSet<T> OfSeq<T>(IEnumerable<T> xs, IComparer<T>? comparer = null)
+    {
+        ArgumentNullException.ThrowIfNull(xs);
+        var cmp = comparer ?? Comparer<T>.Default;
+        var entries = new List<(T, long)>();
+        foreach (var x in xs)
+        {
+            entries.Add((x, 1L));
+        }
+
+        return new ZSet<T>(Canonicalize(entries, cmp), cmp);
+    }
+
+    /// <summary>
+    /// Build a Z-set by counting occurrences in an array — the C# parity twin of the TypeScript
+    /// oracle's <c>ofArray(compare, readonly T[])</c>. Takes a concrete <c>T[]</c> to match the TS
+    /// golden-source shape; forwards to <see cref="OfSeq{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="xs">The keys.</param>
+    /// <param name="comparer">Order on the key; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <returns>The canonical Z-set of occurrence weights.</returns>
+    public static ZSet<T> OfArray<T>(T[] xs, IComparer<T>? comparer = null) => OfSeq(xs, comparer);
+
+    /// <summary>
+    /// Sum per key, drop keys whose summed weight is == 0 (retraction — KEEP negatives), sort
+    /// ascending under <paramref name="cmp"/>. The summed weight is <c>checked</c> so an int64
+    /// overflow throws rather than silently wrapping (the C# analog of the TS safe-integer guard /
+    /// Rust <c>checked_add</c>; both signs guarded).
+    /// </summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="entries">The entries.</param>
+    /// <param name="cmp">The key order.</param>
+    /// <returns>The canonical ascending, key-unique, weight-nonzero run.</returns>
+    internal static ImmutableArray<ZSetEntry<T>> Canonicalize<T>(IEnumerable<(T Key, long Weight)> entries, IComparer<T> cmp)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        var sorted = new List<(T Key, long Weight)>(entries);
+        sorted.Sort((a, b) => cmp.Compare(a.Key, b.Key));
+        var merged = ImmutableArray.CreateBuilder<ZSetEntry<T>>(sorted.Count);
+        for (var k = 0; k < sorted.Count; k++)
+        {
+            if (merged.Count > 0 && cmp.Compare(merged[^1].Key, sorted[k].Key) == 0)
+            {
+                merged[^1] = merged[^1] with { Weight = checked(merged[^1].Weight + sorted[k].Weight) };
+            }
+            else
+            {
+                merged.Add(new ZSetEntry<T>(sorted[k].Key, sorted[k].Weight));
+            }
+        }
+
+        // Drop keys that netted to weight 0 (retraction, e.g. +1 then -1), keeping negatives and
+        // the rest in canonical order — drop rule is == 0, not <= 0 (the Bag/Z-set distinction).
+        return merged.Where(e => e.Weight != 0).ToImmutableArray();
+    }
+}
+
+/// <summary>
+/// A Z-set (signed multiset): a canonical ascending-key-sorted, weight-nonzero, key-unique run
+/// under an <see cref="IComparer{T}"/>. <see cref="Union"/> is the per-key SUM — commutative,
+/// associative, with the empty Z-set as identity, and (unlike the Bag) every Z-set has an inverse
+/// <see cref="Negate"/>, so this is an abelian GROUP: <c>Union(a, a.Negate())</c> is empty. It is
+/// NOT idempotent (<c>Union(a, a)</c> doubles every weight). Parity with
+/// <c>src/Core.TypeScript/z-set</c>, the F# engine <c>src/Core/ZSet.fs</c>, and
+/// <c>src/Core.Rust.Algebra/src/zset.rs</c>. Construct via <see cref="ZSet"/>.
+/// </summary>
+/// <remarks>
+/// The comparer is explicit (like the TS <c>compare</c> parameter) rather than baked to
+/// <see cref="Comparer{T}.Default"/>: for <see cref="string"/> the default is culture-sensitive,
+/// but the cross-language wire (TS UTF-16 code-unit order, Rust UTF-8 byte order, F# structural
+/// ordinal) needs <see cref="StringComparer.Ordinal"/>. Pass it explicitly for cross-language parity.
+/// </remarks>
+/// <typeparam name="T">The key type.</typeparam>
+public sealed class ZSet<T> : IEquatable<ZSet<T>>
+{
+    private readonly ImmutableArray<ZSetEntry<T>> _items;
+    private readonly IComparer<T> _comparer;
+
+    internal ZSet(ImmutableArray<ZSetEntry<T>> items, IComparer<T> comparer)
+    {
+        _items = items.IsDefault ? ImmutableArray<ZSetEntry<T>>.Empty : items;
+        _comparer = comparer;
+    }
+
+    /// <summary>The number of DISTINCT keys with nonzero weight (the support size).</summary>
+    public int Count => _items.Length;
+
+    /// <summary>Whether the Z-set has no keys.</summary>
+    public bool IsEmpty => _items.IsEmpty;
+
+    /// <summary>The weight of <paramref name="x"/> (0 if absent — including a key retracted to 0). Binary search. O(log n).</summary>
+    /// <param name="x">The key to look up.</param>
+    /// <returns>The signed weight of <paramref name="x"/>, or 0 if absent.</returns>
+    public long Weight(T x)
+    {
+        int lo = 0, hi = _items.Length - 1;
+        while (lo <= hi)
+        {
+            var mid = lo + ((hi - lo) >> 1);
+            var c = _comparer.Compare(_items[mid].Key, x);
+            if (c == 0)
+            {
+                return _items[mid].Weight;
+            }
+
+            if (c < 0)
+            {
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>Membership: whether <paramref name="x"/> has a NONZERO weight (positive or negative).</summary>
+    /// <param name="x">The key to test.</param>
+    /// <returns><see langword="true"/> iff <paramref name="x"/> has nonzero weight.</returns>
+    public bool Contains(T x) => Weight(x) != 0;
+
+    /// <summary>The sum of all weights (may be negative or zero); throws on int64 overflow.</summary>
+    /// <returns>The total weight.</returns>
+    public long Total()
+    {
+        var s = 0L;
+        foreach (var e in _items)
+        {
+            s = checked(s + e.Weight);
+        }
+
+        return s;
+    }
+
+    /// <summary>
+    /// The combiner: the per-key SUM of two sorted Z-sets, kept sorted and weight-nonzero (a shared
+    /// key whose weights cancel to 0 is DROPPED — that drop is retraction). Commutative,
+    /// associative, empty-Z-set identity, with <see cref="Negate"/> the inverse (abelian group); NOT
+    /// idempotent. Uses this Z-set's comparer; the summed weight is <c>checked</c> against overflow.
+    /// </summary>
+    /// <param name="other">The Z-set to merge with.</param>
+    /// <returns>The per-key sum, in canonical order.</returns>
+    public ZSet<T> Union(ZSet<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        // Comparer is part of identity (mirrors GSet/Bag): same ⇒ linear merge; mismatched ⇒ fail fast.
+        RequireSameComparer(other);
+        if (_items.IsEmpty)
+        {
+            return other;
+        }
+
+        if (other._items.IsEmpty)
+        {
+            return this;
+        }
+
+        var a = _items;
+        var b = other._items;
+        var builder = ImmutableArray.CreateBuilder<ZSetEntry<T>>(a.Length + b.Length);
+        int i = 0, j = 0;
+        while (i < a.Length && j < b.Length)
+        {
+            var c = _comparer.Compare(a[i].Key, b[j].Key);
+            if (c < 0)
+            {
+                builder.Add(a[i]);
+                i++;
+            }
+            else if (c > 0)
+            {
+                builder.Add(b[j]);
+                j++;
+            }
+            else
+            {
+                var sum = checked(a[i].Weight + b[j].Weight); // same key → weights add
+                if (sum != 0)
+                {
+                    builder.Add(new ZSetEntry<T>(a[i].Key, sum)); // == 0 ⇒ retracted, dropped
+                }
+
+                i++;
+                j++;
+            }
+        }
+
+        while (i < a.Length)
+        {
+            builder.Add(a[i]);
+            i++;
+        }
+
+        while (j < b.Length)
+        {
+            builder.Add(b[j]);
+            j++;
+        }
+
+        return new ZSet<T>(builder.ToImmutable(), _comparer);
+    }
+
+    /// <summary>Increment <paramref name="x"/>'s weight by 1 (<see cref="Union"/> with a singleton). NOT idempotent.</summary>
+    /// <param name="x">The key to increment.</param>
+    /// <returns>The Z-set with <paramref name="x"/>'s weight raised by 1.</returns>
+    public ZSet<T> Add(T x) =>
+        Union(new ZSet<T>(ImmutableArray.Create(new ZSetEntry<T>(x, 1L)), _comparer));
+
+    /// <summary>Add signed weight <paramref name="w"/> to <paramref name="x"/>; <paramref name="w"/> == 0 is a no-op, and a key driven to net 0 is retracted.</summary>
+    /// <param name="x">The key to adjust.</param>
+    /// <param name="w">The signed weight to add (may be negative; no-op if 0).</param>
+    /// <returns>The Z-set with <paramref name="x"/>'s weight adjusted by <paramref name="w"/>.</returns>
+    public ZSet<T> AddW(T x, long w) =>
+        w != 0 ? Union(new ZSet<T>(ImmutableArray.Create(new ZSetEntry<T>(x, w)), _comparer)) : this;
+
+    /// <summary>
+    /// The abelian-group inverse: flip the sign of every weight. <c>Union(a, a.Negate())</c> is
+    /// empty (the law the Bag's monoid cannot satisfy). Preserves the canonical invariant — a
+    /// nonzero weight negates to a nonzero weight, key order unchanged. Weight negation is
+    /// <c>checked</c> (mirrors the F# <c>ZSet.neg</c> <c>Checked.(-) 0L w</c>).
+    /// </summary>
+    /// <returns>The Z-set with every weight sign-flipped.</returns>
+    public ZSet<T> Negate()
+    {
+        var builder = ImmutableArray.CreateBuilder<ZSetEntry<T>>(_items.Length);
+        foreach (var e in _items)
+        {
+            builder.Add(new ZSetEntry<T>(e.Key, checked(0L - e.Weight)));
+        }
+
+        return new ZSet<T>(builder.ToImmutable(), _comparer);
+    }
+
+    /// <summary>Throw if <paramref name="other"/> uses a different comparer (the comparer is part of the Z-set's identity).</summary>
+    /// <param name="other">The Z-set being combined.</param>
+    private void RequireSameComparer(ZSet<T> other)
+    {
+        if (!_comparer.Equals(other._comparer))
+        {
+            throw new ArgumentException(
+                "ZSet.Union requires both Z-sets to use the same comparer (the comparer is part of the Z-set's identity).",
+                nameof(other));
+        }
+    }
+
+    /// <summary>The canonical (ascending-key) entries as an immutable array.</summary>
+    /// <returns>The canonical run.</returns>
+    public ImmutableArray<ZSetEntry<T>> ToImmutableArray() => _items;
+
+    /// <summary>The canonical (ascending-key) entries as a new array.</summary>
+    /// <returns>A fresh array of the entries in canonical order.</returns>
+    public ZSetEntry<T>[] ToArray() => _items.AsSpan().ToArray();
+
+    /// <summary>
+    /// Value equality: same entries (key + weight) in canonical order, with keys compared under the
+    /// comparer. Because both Z-sets are canonical, this is Z-set equality.
+    /// </summary>
+    /// <param name="other">The Z-set to compare.</param>
+    /// <returns><see langword="true"/> iff the Z-sets hold the same keys at the same weights.</returns>
+    public bool Equals(ZSet<T>? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        // The comparer is part of the Z-set's identity (keeps Equals symmetric + GetHashCode
+        // consistent — mirrors GSet/Bag, PR review 2026-06-01).
+        if (!_comparer.Equals(other._comparer))
+        {
+            return false;
+        }
+
+        if (_items.Length != other._items.Length)
+        {
+            return false;
+        }
+
+        for (var k = 0; k < _items.Length; k++)
+        {
+            if (_comparer.Compare(_items[k].Key, other._items[k].Key) != 0
+                || _items[k].Weight != other._items[k].Weight)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => Equals(obj as ZSet<T>);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        // Consistent with Equals (comparer is part of identity): hash the comparer + the entries.
+        // When the comparer is also an equality comparer (e.g. StringComparer.Ordinal) hash each
+        // key through it so Compare==0 keys hash alike; always fold the weight. (Mirrors GSet/Bag.)
+        var hash = default(HashCode);
+        hash.Add(_comparer);
+        hash.Add(_items.Length);
+        var eq = _comparer as IEqualityComparer<T>;
+        foreach (var e in _items)
+        {
+            if (eq is not null)
+            {
+                hash.Add(e.Key, eq);
+            }
+
+            hash.Add(e.Weight);
+        }
+
+        return hash.ToHashCode();
+    }
+}

--- a/src/Core.CSharp/ZSetEntry.cs
+++ b/src/Core.CSharp/ZSetEntry.cs
@@ -1,0 +1,17 @@
+// ZSetEntry — one entry of a Z-set (signed multiset): a key + its strictly-nonzero signed weight.
+// Companion to ZSet.cs; the C# parity oracle for the TS `{ e, w }`, the F# engine's
+// `ZEntry { Key; Weight }`, and the Rust `BagEntry`-shaped `{ e, w: i64 }`.
+
+namespace Zeta.Core.CSharp;
+
+/// <summary>
+/// One Z-set entry: a key <see cref="Key"/> with a strictly-nonzero signed weight
+/// <see cref="Weight"/> (!= 0 in a canonical Z-set; may be negative). Mirrors the TS twin's
+/// <c>{ e, w }</c>, the F# engine's <c>ZEntry { Key; Weight }</c> (<c>src/Core/ZSet.fs</c>), and the
+/// Rust twin's <c>{ e, w: i64 }</c>; <see cref="Weight"/> is <see cref="long"/> to match the int64
+/// oracles and keep the cross-language golden vector exact.
+/// </summary>
+/// <typeparam name="T">The key type.</typeparam>
+/// <param name="Key">The key.</param>
+/// <param name="Weight">The signed weight (!= 0 in a canonical Z-set; may be negative).</param>
+public readonly record struct ZSetEntry<T>(T Key, long Weight);

--- a/src/Core.CSharp/ZetaCircuitBuilder.cs
+++ b/src/Core.CSharp/ZetaCircuitBuilder.cs
@@ -13,7 +13,7 @@ namespace Zeta.Core.CSharp;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Enter the chain with <see cref="CircuitBuilderExtensions.From{T}(Circuit,Stream{ZSet{T}})"/>
+/// Enter the chain with <see cref="CircuitBuilderExtensions.From{T}(Circuit,Stream{Zeta.Core.ZSet{T}})"/>
 /// and terminate with <see cref="Build"/> to obtain an <see cref="OutputHandle{T}"/>.
 /// </para>
 /// <para>
@@ -27,9 +27,9 @@ namespace Zeta.Core.CSharp;
 public sealed class ZetaCircuitBuilder<T>
 {
     private readonly Circuit _circuit;
-    private readonly Stream<ZSet<T>> _stream;
+    private readonly Stream<global::Zeta.Core.ZSet<T>> _stream;
 
-    internal ZetaCircuitBuilder(Circuit circuit, Stream<ZSet<T>> stream)
+    internal ZetaCircuitBuilder(Circuit circuit, Stream<global::Zeta.Core.ZSet<T>> stream)
     {
         _circuit = circuit;
         _stream = stream;
@@ -44,7 +44,7 @@ public sealed class ZetaCircuitBuilder<T>
         => new(_circuit, _circuit.Filter(_stream, predicate));
 
     /// <summary>Flattens each element to a Z-set of <typeparamref name="TResult"/> values.</summary>
-    public ZetaCircuitBuilder<TResult> FlatMap<TResult>(Func<T, ZSet<TResult>> selector)
+    public ZetaCircuitBuilder<TResult> FlatMap<TResult>(Func<T, global::Zeta.Core.ZSet<TResult>> selector)
         => new(_circuit, _circuit.FlatMap(_stream, selector));
 
     /// <summary>
@@ -98,14 +98,14 @@ public sealed class ZetaCircuitBuilder<T>
     /// Returns the underlying <see cref="Stream{T}"/> for use with Circuit APIs
     /// not exposed on this builder (e.g. <c>SpeculativeWindow</c> for temporal windowing).
     /// </summary>
-    public Stream<ZSet<T>> ToStream() => _stream;
+    public Stream<global::Zeta.Core.ZSet<T>> ToStream() => _stream;
 
     /// <summary>
     /// Registers an output handle for the current stream.
     /// After each <see cref="Circuit.StepAsync()"/>, read results from
     /// <see cref="OutputHandle{T}.Current"/>.
     /// </summary>
-    public OutputHandle<ZSet<T>> Build() => _circuit.Output(_stream);
+    public OutputHandle<global::Zeta.Core.ZSet<T>> Build() => _circuit.Output(_stream);
 }
 
 /// <summary>Entry-point extension that begins a <see cref="ZetaCircuitBuilder{T}"/> chain.</summary>
@@ -127,6 +127,6 @@ public static class CircuitBuilderExtensions
     ///     .Build();
     /// </code>
     /// </example>
-    public static ZetaCircuitBuilder<T> From<T>(this Circuit circuit, Stream<ZSet<T>> stream)
+    public static ZetaCircuitBuilder<T> From<T>(this Circuit circuit, Stream<global::Zeta.Core.ZSet<T>> stream)
         => new(circuit, stream);
 }

--- a/tests/Tests.CSharp/Algebra/ZSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/ZSetCrossVerifyTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+using Zeta.Core.CSharp;
+
+namespace Zeta.Tests.CSharp.Algebra;
+
+/// <summary>
+/// Z-set (signed multiset) cross-language conformance — the C# native oracle for the TOP rung of
+/// the algebra ladder (G-Set ⊂ Bag ⊂ Z-set). Replays the SHARED, self-describing golden vectors —
+/// <c>src/Core.TypeScript/z-set/golden-vectors.json</c> — and must value-match every
+/// <c>expectedReplayStates[i]</c> (after op i) AND <c>expectedFinalState</c>. Passing == agreeing
+/// with the TS/F#/Rust oracles. Read with <see cref="StringComparer.Ordinal"/> to match the
+/// fixture's stated ordinal/code-point key order (not culture-sensitive
+/// <see cref="Comparer{T}.Default"/>).
+/// </summary>
+public class ZSetCrossVerifyTests
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(Path.GetDirectoryName(typeof(ZSetCrossVerifyTests).Assembly.Location)!);
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "Zeta.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName
+            ?? throw new InvalidOperationException("Could not locate repo root (Zeta.sln) from test assembly location.");
+    }
+
+    private static (string Key, long Weight)[] Entries(JsonElement array) =>
+        array.EnumerateArray()
+            .Select(e => (
+                e.GetProperty("e").GetString()
+                    ?? throw new InvalidOperationException($"fixture entry key is not a string: {e.GetRawText()}"),
+                e.GetProperty("w").GetInt64()))
+            .ToArray();
+
+    /// <summary>The canonical entries as <c>(key, weight)</c> tuples — the shape the fixture compares against.</summary>
+    private static (string Key, long Weight)[] AsTuples(ZSet<string> z) =>
+        z.ToArray().Select(e => (e.Key, e.Weight)).ToArray();
+
+    [Fact]
+    public void ZSetReplayMatchesGoldenVectors()
+    {
+        var root = RepoRoot();
+        var path = Path.Join(root, "src", "Core.TypeScript", "z-set", "golden-vectors.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        var r = doc.RootElement;
+        var cmp = StringComparer.Ordinal;
+
+        var state = ZSet.OfEntries(Entries(r.GetProperty("initialZSet")), cmp);
+        var ops = r.GetProperty("ops");
+        var expectedReplay = r.GetProperty("expectedReplayStates");
+        Assert.Equal(ops.GetArrayLength(), expectedReplay.GetArrayLength());
+
+        var i = 0;
+        foreach (var op in ops.EnumerateArray())
+        {
+            var kind = op.GetProperty("op").GetString();
+            state = kind switch
+            {
+                "add" => state.Add(op.GetProperty("arg").GetString()!),
+                "addW" => state.AddW(op.GetProperty("arg").GetString()!, op.GetProperty("w").GetInt64()),
+                "union" => state.Union(ZSet.OfEntries(Entries(op.GetProperty("arg")), cmp)),
+                _ => throw new InvalidOperationException($"unknown op {kind}"),
+            };
+            Assert.Equal(Entries(expectedReplay[i]), AsTuples(state));
+            i++;
+        }
+
+        Assert.Equal(Entries(r.GetProperty("expectedFinalState")), AsTuples(state));
+    }
+
+    [Fact]
+    public void UnionIsAbelianGroupButNotIdempotent()
+    {
+        var cmp = StringComparer.Ordinal;
+        static ZSet<string> Z(StringComparer cmp, params (string, long)[] xs) => ZSet.OfEntries(xs, cmp);
+
+        var a = Z(cmp, ("a", 1L), ("b", 2L));
+        var b = Z(cmp, ("b", -1L), ("c", 3L));
+        var c = Z(cmp, ("c", 1L), ("d", -4L));
+
+        // NOT idempotent: union(a, a) doubles every weight (shared with Bag, distinct from G-Set).
+        Assert.Equal(Z(cmp, ("a", 2L), ("b", 4L)), a.Union(a));
+        Assert.Equal(a.Union(b), b.Union(a)); // commutative
+        Assert.Equal(a.Union(b).Union(c), a.Union(b.Union(c))); // associative
+        Assert.Equal(a, a.Union(ZSet.Empty<string>(cmp))); // identity
+        // inverse: union(a, negate(a)) == empty (the law a Bag's monoid cannot satisfy)
+        Assert.True(a.Union(a.Negate()).IsEmpty);
+    }
+
+    [Fact]
+    public void OfEntriesSumsSortsDropsZeroKeepsNegatives()
+    {
+        var cmp = StringComparer.Ordinal;
+        // c: 1+3=4; b nets to 0 → dropped; d: -1 KEPT (a Bag would drop it); sorted ascending.
+        var z = ZSet.OfEntries([("c", 1L), ("a", 2L), ("c", 3L), ("b", 1L), ("b", -1L), ("d", -1L)], cmp);
+        Assert.Equal([("a", 2L), ("c", 4L), ("d", -1L)], AsTuples(z));
+    }
+
+    [Fact]
+    public void WeightAddWNegateAndTotal()
+    {
+        var cmp = StringComparer.Ordinal;
+        var a = ZSet.OfEntries([("a", 3L), ("c", -1L)], cmp);
+
+        Assert.Equal(3L, a.Weight("a"));
+        Assert.Equal(-1L, a.Weight("c")); // negative weight stored
+        Assert.Equal(0L, a.Weight("b"));
+        Assert.True(a.Contains("c")); // negative still "contained" (weight != 0)
+        Assert.False(a.Contains("z"));
+
+        Assert.Equal(a, a.AddW("a", 0L)); // w == 0 is a no-op
+        Assert.Equal(ZSet.OfEntries([("a", 4L), ("c", -1L)], cmp), a.Add("a"));
+        Assert.Equal(ZSet.OfEntries([("c", -1L)], cmp), a.AddW("a", -3L)); // a: 3 + (-3) = 0 → retracted
+        Assert.Equal(2L, a.Total()); // 3 + (-1)
+        Assert.Equal(2, a.Count); // distinct keys
+
+        // negate is an involution
+        Assert.Equal(a, a.Negate().Negate());
+    }
+
+    [Fact]
+    public void UnionThrowsOnMismatchedComparer()
+    {
+        // The comparer is part of a Z-set's identity (mirrors GSet/Bag, PR review 2026-06-01).
+        var ordinal = StringComparer.Ordinal;
+        var reverse = Comparer<string>.Create((x, y) => string.CompareOrdinal(y, x));
+
+        var a = ZSet.OfEntries([("a", 1L), ("b", 2L)], ordinal);
+        var otherReverse = ZSet.OfEntries([("c", 1L), ("a", 1L)], reverse);
+        Assert.Throws<ArgumentException>(() => a.Union(otherReverse));
+
+        // diff comparer ⇒ not equal
+        Assert.False(ZSet.OfEntries([("a", 1L)], ordinal).Equals(ZSet.OfEntries([("a", 1L)], reverse)));
+    }
+}


### PR DESCRIPTION
Native C# `ZSet<T>` ladder oracle (mirrors `GSet.cs`/`Bag.cs`), distinct from the DBSP F#-Z-set binding (`ZetaCircuitBuilder`). Takes **Z-set to 3/4** (TS #6389 + F# #6392 + C#).

### Z-set semantics (the ℕ→ℤ widening over Bag)
- signed ℤ weights, per-key SUM combiner
- **drop-on-net-zero** (retraction) — KEEPS negatives (drop rule `!= 0`, not `<= 0`)
- `Negate` = abelian-group inverse → `Union(a, a.Negate()) == empty` (the law a Bag's monoid can't satisfy)
- `AddW` (signed), comparer-as-identity, `checked` int64 overflow

### Files
- `ZSet.cs` + `ZSetEntry.cs` — native impl
- `ZSetCrossVerifyTests.cs` — replays the shared `z-set/golden-vectors.json` (`StringComparer.Ordinal`) + abelian-group laws (incl. inverse), drops-zero-keeps-negatives, retraction, not-idempotent, mismatched-comparer-throws

### Disambiguation (behavior-preserving)
`ZetaCircuitBuilder.cs` + `Variance.cs` consumed the F# `Zeta.Core.ZSet` unqualified; the new `Zeta.Core.CSharp.ZSet` shadowed it, so those refs are now `global::Zeta.Core.ZSet<...>`. The two Z-sets coexist: the native one is the ladder oracle; the F# one stays the DBSP circuit binding.

Build 0/0; 9/9 ZSet tests pass (5 new cross-verify + 4 existing binding). Native Rust `zset.rs` is the remaining oracle (→ 4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)