### PR TITLE
feat(algebra): native Rust Z-set (signed multiset) — top rung, oracle #4 (4/4)

### DIFF
--- a/src/Core.Rust.Algebra/src/lib.rs
+++ b/src/Core.Rust.Algebra/src/lib.rs
@@ -5,12 +5,13 @@
 //! weights {0,1}     weights ℕ            weights ℤ (retraction-native)
 //! ```
 //!
-//! Each rung is the next by widening the weight codomain. **G-Set** (bottom rung)
-//! and **Bag** (middle rung) are implemented here; **Z-set** lands in this same
-//! crate next — one crate, one ladder, mirroring how F# keeps `GSet.fs` +
-//! `ZSet.fs` together in `src/Core/`. Cross-verified against the shared golden
-//! vectors so the Rust rungs agree byte-for-byte with the TS/F#/C# oracles (per
-//! `m-acc-multi-oracle`: the compilers don't lie; agreement IS the verification).
+//! Each rung is the next by widening the weight codomain. All three —
+//! **G-Set** (bottom), **Bag** (middle), **Z-set** (top) — are implemented here:
+//! one crate, one ladder, mirroring how F# keeps `GSet.fs` + `ZSet.fs` together
+//! in `src/Core/`. Cross-verified against the shared golden vectors so the Rust
+//! rungs agree byte-for-byte with the TS/F#/C# oracles (per `m-acc-multi-oracle`:
+//! the compilers don't lie; agreement IS the verification).
 
 pub mod bag;
 pub mod gset;
+pub mod zset;

--- a/src/Core.Rust.Algebra/src/zset.rs
+++ b/src/Core.Rust.Algebra/src/zset.rs
@@ -1,0 +1,355 @@
+//! Z-set — signed multiset, the TOP rung of the algebra ladder (G-Set ⊂ Bag ⊂ Z-set).
+//! Mirrors `src/Core.TypeScript/z-set/z-set.ts` (the TS reference oracle) +
+//! `src/Core.TypeScript/z-set/golden-vectors.json`, and the F#/C# twins.
+//!
+//! A Z-set widens the Bag from ℕ to **ℤ**: every key carries a NONZERO `i64`
+//! weight `w` (positive OR negative; absent ⇒ weight 0), and the only combiner is
+//! `union` = per-key **sum**. Two contrasts pin it down:
+//!
+//! - vs the **Bag** (ℕ / sum): a Bag drops any key summed `<= 0`; a Z-set drops
+//!   ONLY `== 0` — a negative weight is a valid stored value (a retraction in
+//!   flight). That single change of the drop rule (`> 0` → `!= 0`) is the whole
+//!   ℕ→ℤ widening, and it makes the monoid an abelian **group**: every Z-set has
+//!   an inverse [`ZSet::negate`] (flip every sign), with `union(a, negate(a))`
+//!   empty — the law a Bag cannot satisfy, and why the Z-set (not the Bag) is the
+//!   substrate for retraction / undo / DBSP incremental views.
+//! - vs the **G-Set** (idempotent set-union): like the Bag, `union` is NOT
+//!   idempotent — `union(a, a)` doubles every weight.
+//!
+//! Per the database-design ADR (2026-05-31): Z-set = ℤ / sum. Weights are `i64`
+//! (matching the int64 F#/C# oracles); sums use `checked_add` and negation uses
+//! `checked_neg` (overflow panics rather than silently wrapping).
+//!
+//! Canonical representation: an **ascending-key-sorted** `Vec<ZEntry<T>>`, every
+//! `w != 0`, no key twice — so equality is plain entry-array equality and the
+//! cross-language golden vectors are byte-stable.
+
+use core::cmp::Ordering;
+
+/// One Z-set entry: a key `e` with a strictly-nonzero signed weight `w`
+/// (`!= 0` in a canonical Z-set; may be negative).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZEntry<T> {
+    /// The key.
+    pub e: T,
+    /// The signed weight (`!= 0` in a canonical Z-set; may be negative).
+    pub w: i64,
+}
+
+/// A signed multiset: a canonical ascending-key-sorted, weight-nonzero run under
+/// `T: Ord`. The invariant (sorted, every `w != 0`, no key twice) is held by
+/// every constructor here — never build one by hand; use [`ZSet::of_entries`] or
+/// [`ZSet::of_iter`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZSet<T> {
+    items: Vec<ZEntry<T>>,
+}
+
+/// Add two weights, re-checking the sum stays in `i64` range before it is stored.
+/// Mirrors the TS `addWeights` guard (both signs); panics on overflow rather than
+/// silently wrapping.
+fn add_weights(a: i64, b: i64) -> i64 {
+    a.checked_add(b).expect("Z-set weight overflow (i64)")
+}
+
+impl<T: Ord + Clone> ZSet<T> {
+    /// The empty Z-set (the `union` identity).
+    #[must_use]
+    pub const fn empty() -> Self {
+        ZSet { items: Vec::new() }
+    }
+
+    /// A one-key Z-set at weight `w`; `w == 0` yields the empty Z-set. `w` may be negative.
+    #[must_use]
+    pub fn singleton(x: T, w: i64) -> Self {
+        if w != 0 {
+            ZSet {
+                items: vec![ZEntry { e: x, w }],
+            }
+        } else {
+            ZSet::empty()
+        }
+    }
+
+    /// Canonicalize arbitrary entries: sum weights per key, drop any summed weight
+    /// `== 0` (retraction — KEEPS negatives), and sort ascending by key.
+    pub fn of_entries(entries: impl IntoIterator<Item = ZEntry<T>>) -> Self {
+        let mut v: Vec<ZEntry<T>> = entries.into_iter().collect();
+        v.sort_by(|a, b| a.e.cmp(&b.e));
+        let mut out: Vec<ZEntry<T>> = Vec::with_capacity(v.len());
+        for entry in v {
+            match out.last_mut() {
+                Some(last) if last.e == entry.e => last.w = add_weights(last.w, entry.w),
+                _ => out.push(entry),
+            }
+        }
+        // Drop keys that netted to 0 (retraction); KEEP negatives (drop rule != 0, not <= 0).
+        out.retain(|entry| entry.w != 0);
+        ZSet { items: out }
+    }
+
+    /// Build a Z-set by counting occurrences in an iterator — each occurrence adds weight 1.
+    pub fn of_iter(xs: impl IntoIterator<Item = T>) -> Self {
+        ZSet::of_entries(xs.into_iter().map(|x| ZEntry { e: x, w: 1 }))
+    }
+
+    /// The weight of `x` (0 if absent — including a key retracted to 0). Binary search. O(log n).
+    #[must_use]
+    pub fn weight(&self, x: &T) -> i64 {
+        match self.items.binary_search_by(|entry| entry.e.cmp(x)) {
+            Ok(i) => self.items[i].w,
+            Err(_) => 0,
+        }
+    }
+
+    /// Membership: whether `x` has a NONZERO weight (positive or negative).
+    #[must_use]
+    pub fn contains(&self, x: &T) -> bool {
+        self.weight(x) != 0
+    }
+
+    /// The combiner: the per-key SUM of two sorted Z-sets, kept sorted and
+    /// weight-nonzero (a shared key whose weights cancel to 0 is DROPPED —
+    /// retraction). Commutative, associative, identity, with [`ZSet::negate`] the
+    /// inverse (abelian group) — but NOT idempotent: `union(a, a)` doubles weights.
+    #[must_use]
+    pub fn union(&self, other: &Self) -> Self {
+        if self.items.is_empty() {
+            return other.clone();
+        }
+        if other.items.is_empty() {
+            return self.clone();
+        }
+        let (a, b) = (&self.items, &other.items);
+        let mut out: Vec<ZEntry<T>> = Vec::with_capacity(a.len() + b.len());
+        let (mut i, mut j) = (0usize, 0usize);
+        while i < a.len() && j < b.len() {
+            match a[i].e.cmp(&b[j].e) {
+                Ordering::Less => {
+                    out.push(a[i].clone());
+                    i += 1;
+                }
+                Ordering::Greater => {
+                    out.push(b[j].clone());
+                    j += 1;
+                }
+                Ordering::Equal => {
+                    let sum = add_weights(a[i].w, b[j].w); // same key → weights add (overflow-guarded)
+                    if sum != 0 {
+                        out.push(ZEntry {
+                            e: a[i].e.clone(),
+                            w: sum,
+                        }); // == 0 ⇒ retracted, dropped
+                    }
+                    i += 1;
+                    j += 1;
+                }
+            }
+        }
+        out.extend_from_slice(&a[i..]);
+        out.extend_from_slice(&b[j..]);
+        ZSet { items: out }
+    }
+
+    /// The abelian-group inverse: flip the sign of every weight. `union(a, negate(a))`
+    /// is empty (the law the Bag's monoid cannot satisfy). Preserves the canonical
+    /// invariant — a nonzero weight negates to a nonzero weight, order unchanged.
+    #[must_use]
+    pub fn negate(&self) -> Self {
+        ZSet {
+            items: self
+                .items
+                .iter()
+                .map(|entry| ZEntry {
+                    e: entry.e.clone(),
+                    w: entry
+                        .w
+                        .checked_neg()
+                        .expect("Z-set weight overflow on negate (i64)"),
+                })
+                .collect(),
+        }
+    }
+
+    /// Increment `x`'s weight by 1 (`union` with a singleton). NOT idempotent.
+    #[must_use]
+    pub fn add(&self, x: T) -> Self {
+        self.union(&ZSet {
+            items: vec![ZEntry { e: x, w: 1 }],
+        })
+    }
+
+    /// Add signed weight `w` to `x` (`w == 0` is a no-op; a key driven to net 0 is retracted).
+    #[must_use]
+    pub fn add_w(&self, x: T, w: i64) -> Self {
+        if w != 0 {
+            self.union(&ZSet {
+                items: vec![ZEntry { e: x, w }],
+            })
+        } else {
+            self.clone()
+        }
+    }
+
+    /// The entries in canonical (ascending-key) order — a defensive copy.
+    #[must_use]
+    pub fn to_entries(&self) -> Vec<ZEntry<T>> {
+        self.items.clone()
+    }
+
+    /// The canonical run as a slice (no copy).
+    #[must_use]
+    pub fn as_slice(&self) -> &[ZEntry<T>] {
+        &self.items
+    }
+
+    /// The number of DISTINCT keys with nonzero weight (the support size).
+    #[must_use]
+    pub fn distinct_count(&self) -> usize {
+        self.items.len()
+    }
+
+    /// The sum of all weights (may be negative or zero); panics on `i64` overflow.
+    #[must_use]
+    pub fn total(&self) -> i64 {
+        self.items
+            .iter()
+            .fold(0i64, |s, entry| add_weights(s, entry.w))
+    }
+
+    /// Whether the Z-set has no keys.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn e(key: &str, w: i64) -> ZEntry<String> {
+        ZEntry {
+            e: key.to_string(),
+            w,
+        }
+    }
+
+    fn zset(entries: &[(&str, i64)]) -> ZSet<String> {
+        ZSet::of_entries(entries.iter().map(|(k, w)| e(k, *w)))
+    }
+
+    #[test]
+    fn of_iter_counts_occurrences_sorted() {
+        assert_eq!(
+            ZSet::of_iter(
+                ["c", "a", "b", "a", "c", "c"]
+                    .iter()
+                    .map(|s| (*s).to_string())
+            )
+            .to_entries(),
+            vec![e("a", 2), e("b", 1), e("c", 3)],
+        );
+    }
+
+    #[test]
+    fn of_entries_sums_drops_zero_keeps_negatives() {
+        // c: 1+3=4; b nets to 0 → dropped; d: -1 KEPT (a Bag would drop it).
+        assert_eq!(
+            zset(&[("c", 1), ("a", 2), ("c", 3), ("b", 1), ("b", -1), ("d", -1)]).to_entries(),
+            vec![e("a", 2), e("c", 4), e("d", -1)],
+        );
+    }
+
+    #[test]
+    fn singleton_zero_is_empty_negatives_kept() {
+        assert!(ZSet::<String>::singleton("x".to_string(), 0).is_empty());
+        assert_eq!(
+            ZSet::singleton("x".to_string(), -4).to_entries(),
+            vec![e("x", -4)]
+        );
+    }
+
+    #[test]
+    fn weight_and_contains() {
+        let z = zset(&[("a", 2), ("c", -5), ("e", 1)]);
+        assert_eq!(z.weight(&"c".to_string()), -5);
+        assert_eq!(z.weight(&"d".to_string()), 0);
+        assert!(z.contains(&"c".to_string())); // negative still "contained"
+        assert!(!z.contains(&"z".to_string()));
+    }
+
+    #[test]
+    fn distinct_count_and_total() {
+        let z = zset(&[("a", 2), ("b", -3)]);
+        assert_eq!(z.distinct_count(), 2);
+        assert_eq!(z.total(), -1);
+    }
+
+    // Abelian-group laws (commutative, associative, identity, inverse) + NON-idempotence.
+    #[test]
+    fn law_commutative() {
+        let a = zset(&[("a", 1), ("b", 2)]);
+        let b = zset(&[("b", -1), ("c", 3)]);
+        assert_eq!(a.union(&b), b.union(&a));
+    }
+
+    #[test]
+    fn law_associative() {
+        let a = zset(&[("a", 1), ("b", 2)]);
+        let b = zset(&[("b", -1), ("c", 3)]);
+        let c = zset(&[("c", 1), ("d", -4)]);
+        assert_eq!(a.union(&b).union(&c), a.union(&b.union(&c)));
+    }
+
+    #[test]
+    fn law_identity() {
+        let a = zset(&[("a", 1), ("b", 2)]);
+        assert_eq!(a.union(&ZSet::empty()), a);
+        assert_eq!(ZSet::<String>::empty().union(&a), a);
+    }
+
+    #[test]
+    fn law_inverse_negate() {
+        // union(a, negate(a)) == empty — the law a Bag cannot satisfy.
+        let a = zset(&[("a", 1), ("b", 2)]);
+        assert!(a.union(&a.negate()).is_empty());
+        // negate flips signs + is an involution.
+        assert_eq!(a.negate().to_entries(), vec![e("a", -1), e("b", -2)]);
+        assert_eq!(a.negate().negate(), a);
+    }
+
+    #[test]
+    fn union_not_idempotent_doubles_weights() {
+        let a = zset(&[("a", 1), ("b", 2)]);
+        assert_eq!(a.union(&a).to_entries(), vec![e("a", 2), e("b", 4)]);
+        assert_ne!(a.union(&a), a);
+    }
+
+    #[test]
+    fn union_retraction_to_zero_drops_keeps_negative() {
+        let a = zset(&[("a", 1), ("b", 2)]);
+        // b: 2 + (-2) = 0 → dropped; a survives at 1.
+        assert_eq!(a.union(&zset(&[("b", -2)])).to_entries(), vec![e("a", 1)]);
+        // a: 1 + (-3) = -2 → negative kept.
+        assert_eq!(
+            a.union(&zset(&[("a", -3)])).to_entries(),
+            vec![e("a", -2), e("b", 2)]
+        );
+    }
+
+    #[test]
+    fn add_and_add_w() {
+        let a = zset(&[("a", 1), ("b", 2)]);
+        assert_eq!(
+            a.add("a".to_string()).to_entries(),
+            vec![e("a", 2), e("b", 2)]
+        );
+        assert_eq!(
+            a.add_w("z".to_string(), -3).to_entries(),
+            vec![e("a", 1), e("b", 2), e("z", -3)]
+        );
+        assert_eq!(a.add_w("z".to_string(), 0), a); // w == 0 no-op
+        assert_eq!(a.add_w("a".to_string(), -1).to_entries(), vec![e("b", 2)]); // retract a to 0
+    }
+}

--- a/src/Core.Rust.Algebra/tests/zset_cross_verify.rs
+++ b/src/Core.Rust.Algebra/tests/zset_cross_verify.rs
@@ -1,0 +1,87 @@
+//! Z-set cross-language conformance (the Rust oracle for the TOP rung). Replays
+//! the SHARED, self-describing golden vectors —
+//! `src/Core.TypeScript/z-set/golden-vectors.json` — and must value-match every
+//! `expectedReplayStates[i]` (after op i) AND `expectedFinalState`. Z-sets
+//! serialize as ascending-key-sorted `{e, w}` entries (w != 0, no key twice), so
+//! passing == agreeing with the TS/F#/C# oracles (entry-array equality).
+//!
+//! Dev-only `serde_json` reads the nested-JSON fixture; the production crate
+//! (`zeta_core_algebra`) has zero dependencies.
+
+use std::path::PathBuf;
+
+use serde_json::Value;
+use zeta_core_algebra::zset::{ZEntry, ZSet};
+
+/// Walk up from the crate dir to the repo root (`Zeta.sln` sentinel), matching the
+/// convention in the other Rust oracles.
+fn repo_root() -> PathBuf {
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        if dir.join("Zeta.sln").exists() {
+            return dir;
+        }
+        assert!(dir.pop(), "could not locate repo root (Zeta.sln)");
+    }
+}
+
+/// A JSON array of `{e, w}` objects → `Vec<ZEntry<String>>`.
+fn entries(v: &Value) -> Vec<ZEntry<String>> {
+    v.as_array()
+        .expect("expected a JSON array")
+        .iter()
+        .map(|x| ZEntry {
+            e: x["e"].as_str().expect("entry.e string").to_string(),
+            w: x["w"].as_i64().expect("entry.w integer"),
+        })
+        .collect()
+}
+
+#[test]
+fn zset_cross_verify_matches_golden_vectors() {
+    let path = repo_root().join("src/Core.TypeScript/z-set/golden-vectors.json");
+    let text = std::fs::read_to_string(&path).expect("read z-set golden-vectors.json");
+    let v: Value = serde_json::from_str(&text).expect("parse z-set golden-vectors.json");
+
+    let mut state = ZSet::of_entries(entries(&v["initialZSet"]));
+
+    let ops = v["ops"].as_array().expect("ops array");
+    let expected_replay = v["expectedReplayStates"]
+        .as_array()
+        .expect("expectedReplayStates array");
+    assert_eq!(
+        ops.len(),
+        expected_replay.len(),
+        "ops / expectedReplayStates length mismatch",
+    );
+
+    for (i, op) in ops.iter().enumerate() {
+        let kind = op["op"].as_str().expect("op.op string");
+        state = match kind {
+            "add" => state.add(op["arg"].as_str().expect("add arg string").to_string()),
+            "addW" => state.add_w(
+                op["arg"].as_str().expect("addW arg string").to_string(),
+                op["w"].as_i64().expect("addW w integer"),
+            ),
+            "union" => state.union(&ZSet::of_entries(entries(&op["arg"]))),
+            other => panic!("unknown op {other}"),
+        };
+        assert_eq!(
+            state.to_entries(),
+            entries(&expected_replay[i]),
+            "replay state mismatch after op {i} ({kind})",
+        );
+    }
+
+    assert_eq!(
+        state.to_entries(),
+        entries(&v["expectedFinalState"]),
+        "final state mismatch",
+    );
+
+    println!(
+        "Z-set cross-verify: {} ops replayed; all {} replay states + final state match.",
+        ops.len(),
+        expected_replay.len(),
+    );
+}


### PR DESCRIPTION
Completes the **algebra ladder G-Set ⊂ Bag ⊂ Z-set across all four oracles** (TS + F# + C# + Rust). Native Rust `ZSet<T>` mirrors `bag.rs`/`gset.rs`.

### Z-set semantics (the ℕ→ℤ widening)
- signed `i64` weights, per-key SUM combiner
- **drop-on-net-zero** (retraction) — KEEPS negatives (drop rule `!= 0`, not `<= 0`)
- `negate` = abelian-group inverse → `union(a, negate(a))` empty
- `add_w` (signed), `checked_add`/`checked_neg` overflow guards, **zero-dep** production crate

### Files
- `src/zset.rs` — native impl + 12 zset unit/law tests (inverse, drops-zero-keeps-negatives, retraction, not-idempotent)
- `tests/zset_cross_verify.rs` — replays the shared `z-set/golden-vectors.json` (dev-only `serde_json`), byte-matches every replay + final state
- `lib.rs` — `pub mod zset;`

**Z-set ladder COMPLETE: 4/4** (TS #6389 + F# #6392 + C# #6395 + Rust). `cargo test`: 12 zset unit + 3 cross-verify pass (the crate-wide "30 passed" includes gset+bag+zset units); clippy + fmt clean. Conformance by agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
