### PR TITLE
docs(ace): slice 5.3 lockfile design spec + deferred-enhancement rows

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -924,6 +924,9 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0970](backlog/P2/B-0970-ace-advanced-semver-union-hyphen-prerelease-build-metadata-deferred-from-slice5.2-pragmatic-subset-2026-06-01.md)** Ace advanced semver — `||` unions, hyphen ranges, pre-release precedence, build metadata (deferred from slice 5.2 pragmatic subset)
 - [ ] **[B-0971](backlog/P2/B-0971-ace-remote-registry-http-fetched-index-deferred-from-slice5.x-local-only-2026-06-01.md)** Ace remote registry — HTTP-fetched registry index (deferred from slice 5.x local-only registry)
 - [ ] **[B-0972](backlog/P2/B-0972-ace-solver-installer-single-fetch-cache-deferred-from-slice5.2-two-phase-2026-06-01.md)** Ace solver↔installer single-fetch cache — fetch each package once (deferred from slice 5.2 clean two-phase split)
+- [ ] **[B-0973](backlog/P2/B-0973-ace-update-re-solve-within-ranges-rewrite-lockfile-bump-deferred-from-slice5.3-2026-06-01.md)** Ace `ace update` — re-solve within ranges + rewrite the lockfile (bump; deferred from slice 5.3 lockfile)
+- [ ] **[B-0974](backlog/P2/B-0974-ace-install-locked-mode-verify-lock-matches-fresh-solve-vs-frozen-replay-deferred-from-slice5.3-2026-06-01.md)** Ace `ace install --locked` — verify the lock matches a fresh solve (cargo --locked vs --frozen distinction; deferred from slice 5.3)
+- [ ] **[B-0975](backlog/P2/B-0975-ace-lockfile-ergonomics-partial-merge-alphabetical-ordering-leaf-lock-deferred-from-slice5.3-2026-06-01.md)** Ace lockfile ergonomics — partial-merge, alphabetical ordering, leaf-install lock (deferred from slice 5.3)
 
 ## P3 — convenience / deferred
 

--- a/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice5.3-lockfile-design.md
+++ b/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice5.3-lockfile-design.md
@@ -1,0 +1,201 @@
+# Ace CLI slice 5.3 — lockfile (design)
+
+> Spec for slice 5.3 of the Ace DLC package manager (B-0288). Builds directly on
+> slice 5.1 (registry data layer, merged PR #6369) and slice 5.2 (semver ranges +
+> version solver, merged PRs #6388 + #6391). Brainstormed + decided with the
+> operator 2026-06-01.
+
+## Goal
+
+Persist the **solved + pinned** dependency graph to a lockfile so a subsequent
+install is **deterministic, registry-independent, and byte-reproducible**. A normal
+`ace install` solves fresh and writes the lock; an `ace install --frozen` reads the
+lock, skips solving entirely, and installs exactly the locked graph — verifying every
+node against the locked hashes — without ever consulting the registry.
+
+## Decomposition of slice 5 (recap)
+
+- **5.1** (done, #6369): registry data layer + exact-version lookup.
+- **5.2** (done, #6388 + #6391): semver ranges + solver → concrete versions → 5.1 engine.
+- **5.3** (this spec): lockfile — persist the solved+pinned graph; replay it under `--frozen`.
+
+## Decisions (this spec locks them; operator 2026-06-01)
+
+1. **Workflow = cargo-style write + opt-in frozen-read.** A normal `ace install`
+   **always solves fresh** and writes/refreshes the lockfile after a successful
+   install. `--frozen` instead **reads** the lock, **skips solving**, installs
+   exactly the locked graph, and **fails on drift**. Default behavior is unchanged;
+   reproducibility is opt-in.
+2. **Location = `./ace.lock` in CWD, `--lockfile <path>` override.** cargo-consistent
+   (Cargo.lock sits in the project dir). No global state. Write and `--frozen`-read
+   both resolve the same path.
+3. **Content = full pin (`name` + `version` + `url` + `package_hash`) per node.**
+   `--frozen` fetches the locked `url`, verifies bytes against the locked
+   `package_hash` (+ `content_hash` + signature), and does **not** consult the
+   registry. Registry-independent, byte-reproducible, tamper-evident — the actual
+   lockfile guarantee (cargo/npm pin url + integrity).
+
+## Lockfile format
+
+JSON, written through the existing canonical-JSON discipline (deterministic key
+ordering — `canonicalJson` in `resolve.ts`, **exported** by this slice for reuse;
+see Components). Nodes are emitted in **install order** (deps-first), which is
+deterministic because slice-5.2 solve + slice-5.1 resolve are deterministic
+(newest-first, sorted) — so re-locking the same input yields a byte-identical file.
+
+```json
+{
+  "format_version": 1,
+  "root": { "name": "myapp", "version": "1.0.0", "package_hash": "sha256:…" },
+  "nodes": [
+    { "name": "leaf",  "version": "1.0.0", "url": "https://…/leaf-1.0.0.json",  "package_hash": "sha256:…" },
+    { "name": "mid",   "version": "2.3.0", "url": "https://…/mid-2.3.0.json",   "package_hash": "sha256:…" }
+  ]
+}
+```
+
+- `format_version`: `1`. A lock with any other value is a hard refusal under `--frozen`
+  (forward-compat guard; no silent migration this slice).
+- `root`: identity of the root artifact the lock was generated from — the **drift gate**
+  for `--frozen` (see §Frozen). `package_hash` = `packageHash(root)`.
+- `nodes`: every resolved **dependency** node (root excluded — it is the input, not a
+  locked dependency), each fully pinned. Covers both registry-solved and inline nodes
+  (an inline node's `url` + `package_hash` come from its edge).
+
+## Components
+
+### `tools/ace/lockfile.ts` (new — pure, no I/O)
+
+- `type LockNode = { name: string; version: string; url: string; package_hash: string }`
+- `type Lockfile = { format_version: 1; root: { name: string; version: string; package_hash: string }; nodes: LockNode[] }`
+- `buildLockfile(root: AcePackage, order: AcePackage[], registry: Registry): Lockfile | { error: string }`
+  — `order` is resolve's output (deps-first, **root last**). Split root off the tail;
+  for each dependency node compute `package_hash = packageHash(node)`,
+  `version = node.manifest.version`, and resolve `url`:
+  - registry node (`registry.get(name)?.get(version)` present) → that entry's `url`;
+  - else inline node → look up the `url` from a **prescan** of every inline edge in
+    the graph (`order.flatMap(p => p.manifest.dependencies).filter(kind==="inline")`,
+    map `name@version → url`);
+  - neither found → `{ error }` (should not happen for a graph resolve produced; the
+    error path keeps `buildLockfile` total + testable).
+- `serializeLockfile(lf): string` — canonical JSON + trailing newline.
+- `parseLockfile(json: string): Lockfile | { error: string }` — JSON-parse + shape
+  guard (every field present + correct type; `nodes` an array of well-formed
+  `LockNode`; `format_version === 1`). Untrusted-input discipline per slice-5.2
+  (non-string fields → `{ error }`, never a throw).
+- `verifyRootMatchesLock(root: AcePackage, lf: Lockfile): boolean` —
+  `packageHash(root) === lf.root.package_hash` (the drift gate). The frozen replay
+  iterates `lf.nodes` directly (already in install order); no extra accessor.
+
+### `tools/ace/resolve.ts` (one additive export)
+
+- Export the existing private `canonicalJson` so `lockfile.ts` reuses it (no second
+  canonical-JSON implementation). Pure rename of `function` → `export function`;
+  no behavior change, no call-site change.
+
+### `tools/ace/ace.ts` (install handler — additive)
+
+- **`parseArgs`**: add `--frozen` (boolean) and `--lockfile <path>` (string, default
+  `./ace.lock`) to `InstallArgs`. Unknown-option + missing-arg handling matches the
+  existing `--store` / `--allow-no-signature` pattern.
+- **Default path (graph install)**: after the existing successful `resolve()` +
+  install, call `buildLockfile(pkg, res.order, registry)` → `serializeLockfile` →
+  `writeFileSync(lockfilePath, …)`. A lockfile **write failure is a warning**
+  (`ace: WARNING: could not write lockfile: …`), not a failed install — the install
+  already succeeded. `--print-resolution` is unchanged.
+- **Frozen path (`--frozen`)** — taken *instead of* solve+resolve when the root has
+  dependencies:
+  1. Read `--lockfile` (missing file → hard error: `ace: install refused: no
+     lockfile at <path> — run install without --frozen first`).
+  2. `parseLockfile` (parse / shape / `format_version` failure → hard error).
+  3. Verify the provided root normally (signature gate + `content_hash`) — unchanged
+     from the default path.
+  4. **Drift gate**: `verifyRootMatchesLock(pkg, lf)` false → hard error
+     (`ace: install refused: lockfile out of date for <name> — re-run without
+     --frozen to regenerate`). Any change to the root manifest/files changes its
+     `packageHash`, so this catches added/removed/changed deps + changed root files.
+  5. **Replay** (registry untouched): for each `LockNode` in install order →
+     `fetch(url)` → `JSON.parse` → verify `packageHash(node) === lockNode.package_hash`
+     (pin) + `content_hash` + signature gate (`verifySignature` + `--allow-no-signature`
+     semantics, identical to the default path) + `validatePackagePaths` →
+     `installPackage`. Then install the root. Any fetch / parse / hash-mismatch /
+     bad-or-untrusted-signature / unsafe-path → hard refusal with the offending node
+     named.
+  6. `--frozen` does **not** call `solve()`, does **not** `loadRegistry()`, and does
+     **not** write the lock.
+
+- **Leaf (no-dependency) install**: unchanged. No lock is written (nothing to
+  reproduce beyond the single artifact the operator already supplied); `--frozen` on
+  a leaf install is a no-op flag (documented; the leaf still installs normally).
+
+## Data flow
+
+```text
+default:  read root → verify → solve → resolve → install → buildLockfile → write ./ace.lock
+--frozen: read root → verify → read+parse ./ace.lock → root-drift gate
+          → for each locked node: fetch+verify+install → install root   (registry never touched)
+```
+
+## Error handling
+
+| Situation | Mode | Behavior |
+| --- | --- | --- |
+| Lock write fails (disk, perms) | default | **Warning**, exit 0 (install already succeeded) |
+| `--frozen`, lock file missing | frozen | Hard refusal, exit non-zero |
+| `--frozen`, lock parse / shape / `format_version` bad | frozen | Hard refusal |
+| `--frozen`, root drift (packageHash ≠ lock.root) | frozen | Hard refusal — "re-run without --frozen" |
+| `--frozen`, locked url unreachable | frozen | Hard refusal (registry-independent ⇒ the lock's urls are authoritative) |
+| `--frozen`, fetched bytes ≠ locked package_hash | frozen | Hard refusal (tamper) |
+| `--frozen`, bad / untrusted signature on a node | frozen | Hard refusal (same gate as default; `--allow-no-signature` only waives *no*-signature) |
+
+## Testing
+
+- **`tools/ace/lockfile.test.ts`** (new, pure unit):
+  - `buildLockfile` resolves `url` correctly for registry nodes (from the registry)
+    and inline nodes (from the inline-edge prescan); excludes root from `nodes`;
+    records root identity.
+  - `serializeLockfile` → `parseLockfile` round-trips; output is canonical
+    (key-order-stable) + ends in a newline.
+  - `parseLockfile` rejects malformed input (missing field, wrong type, non-string
+    `url`/`version`, `format_version ≠ 1`) with `{ error }` (no throw) — slice-5.2
+    untrusted-input discipline.
+  - `verifyRootMatchesLock` true on match, false on any root change.
+- **Frozen integration (in `tools/ace/ace.test.ts`)**, reusing the existing
+  build-packages + `fetchOf` map + registry helpers:
+  - default install **writes** `./ace.lock` with the expected pinned nodes;
+  - `--frozen` with a matching lock installs the graph using an **empty registry**
+    (proves registry-independence) and the lock's urls;
+  - `--frozen` with a **drifted root** (added/changed dep) → refused;
+  - `--frozen` with **no lockfile** → refused;
+  - `--frozen` with a **tampered** locked node (bytes whose `packageHash` ≠ the lock)
+    → refused;
+  - `--lockfile <path>` override is honored for both write and read.
+- All gated by the existing local `bun test tools/ace/` suite (new lockfile +
+  frozen tests added) + strict whole-repo `tsc` (the `lint (tsc tools)` CI gate)
+  + markdownlint on this doc.
+
+## Scope / YAGNI — deferred (future slices / backlog rows)
+
+- **`ace update`** — re-solve within ranges + rewrite the lock (bump). → backlog.
+- **Partial-lock / lock-merge** — add one dep without a full re-solve. → backlog.
+- **Alphabetical lock ordering + re-derived install order** — current design stores
+  deterministic install order; an alpha-sorted file with a separately-derived order
+  is a later readability nicety. → backlog.
+- **Lock for leaf (no-dep) installs** — skipped this slice (nothing to reproduce). → backlog.
+- **Separate `--locked` mode** (verify the lock matches a fresh solve *without*
+  registry-independent replay, cargo's `--locked` vs `--frozen` distinction) — one
+  flag (`--frozen`) this slice. → backlog.
+- **Single-fetch cache across solve+resolve** — already filed B-0972 in slice 5.2;
+  composes here (frozen replay re-fetches each node) but stays deferred.
+
+## Files touched
+
+- `tools/ace/lockfile.ts` — **new** (pure module).
+- `tools/ace/lockfile.test.ts` — **new** (unit tests).
+- `tools/ace/resolve.ts` — export `canonicalJson` (one-keyword additive change).
+- `tools/ace/ace.ts` — `--frozen` / `--lockfile` flags; default-path lock write;
+  frozen replay path; usage text.
+- `tools/ace/ace.test.ts` — frozen integration tests.
+- `.claude/skills/ace/SKILL.md` — document `--frozen` / `--lockfile` + the lockfile.
+- Deferred-enhancement backlog rows filed alongside the PR (matching slice 5.2's
+  B-0970/0971/0972 pattern).

--- a/docs/backlog/P2/B-0973-ace-update-re-solve-within-ranges-rewrite-lockfile-bump-deferred-from-slice5.3-2026-06-01.md
+++ b/docs/backlog/P2/B-0973-ace-update-re-solve-within-ranges-rewrite-lockfile-bump-deferred-from-slice5.3-2026-06-01.md
@@ -1,0 +1,44 @@
+---
+id: B-0973
+priority: P2
+status: open
+title: Ace `ace update` — re-solve within ranges + rewrite the lockfile (bump; deferred from slice 5.3 lockfile)
+effort: S
+ask: operator 2026-06-01
+created: 2026-06-01
+last_updated: 2026-06-01
+depends_on:
+  - B-0288
+composes_with: []
+tags: [ace, package-manager, lockfile, update, deferred-enhancement, slice-5.3]
+---
+
+## What this row proposes
+
+Slice 5.3 writes a lockfile on a normal `ace install` (solve fresh → write) and replays
+it under `--frozen`. There is no explicit "bump within the declared ranges" command:
+today re-locking just means running a normal `ace install` (which always solves fresh and
+rewrites the lock). This row tracks a dedicated **`ace update`** verb that re-solves the
+root's ranges against the current registry and rewrites `./ace.lock` — the cargo
+`cargo update` analog — with optional `--package <name>` to bump a single dependency.
+
+## Why deferred (operator 2026-06-01)
+
+Slice 5.3's normal `ace install` already regenerates the lock (solve-fresh-then-write), so
+a separate `update` verb is pure ergonomics, not a capability gap. Keep slice 5.3 to
+write + `--frozen`-replay. Operator: *"everything we skipped lets slice off for further
+enhancements."*
+
+## Scope sketch
+
+- `ace update [--package <name>] [--lockfile <path>]`: read the root, solve fresh (or
+  solve with all-but-`<name>` pinned to the existing lock when `--package` is given),
+  write the lock. No install side effect required (lock-only), or `--install` to also
+  install.
+- Single-package bump uses the existing lock as a partial pin set (composes with B-0975).
+
+## Composes with
+
+- Slice 5.3 spec: `docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice5.3-lockfile-design.md`
+- B-0975 (lockfile ergonomics — partial-merge is the single-package-bump primitive)
+- B-0288 (Ace DLC package manager CLI)

--- a/docs/backlog/P2/B-0974-ace-install-locked-mode-verify-lock-matches-fresh-solve-vs-frozen-replay-deferred-from-slice5.3-2026-06-01.md
+++ b/docs/backlog/P2/B-0974-ace-install-locked-mode-verify-lock-matches-fresh-solve-vs-frozen-replay-deferred-from-slice5.3-2026-06-01.md
@@ -1,0 +1,42 @@
+---
+id: B-0974
+priority: P2
+status: open
+title: Ace `ace install --locked` — verify the lock matches a fresh solve (cargo --locked vs --frozen distinction; deferred from slice 5.3)
+effort: S
+ask: operator 2026-06-01
+created: 2026-06-01
+last_updated: 2026-06-01
+depends_on:
+  - B-0288
+composes_with: []
+tags: [ace, package-manager, lockfile, frozen, locked, ci, deferred-enhancement, slice-5.3]
+---
+
+## What this row proposes
+
+Slice 5.3 ships **one** flag, `--frozen`: read the lock, skip solving, install exactly the
+locked graph from the locked urls/hashes (registry-independent replay). Cargo distinguishes
+two modes: `--locked` (solve normally but **fail if the lock would change** — i.e. assert
+the committed lock is already up to date) and `--frozen` (`--locked` + `--offline`). This
+row tracks adding the **`--locked` assert-up-to-date** mode: run a fresh solve, then refuse
+if the resulting graph differs from `./ace.lock` (instead of replaying the lock blind).
+
+## Why deferred (operator 2026-06-01)
+
+`--frozen` (registry-independent replay) is the stronger reproducibility guarantee and the
+one slice 5.3 needs first. `--locked` (solve-then-compare) is a CI convenience that catches
+"someone forgot to commit the updated lock"; it can land once `--frozen` is proven. One
+flag this slice. Operator: *"everything we skipped lets slice off for further enhancements."*
+
+## Scope sketch
+
+- `ace install --locked`: normal solve + resolve, then `buildLockfile(...)` and compare
+  (canonical-JSON equality) against the on-disk lock; mismatch → hard refusal naming the
+  drift. On match, install proceeds (lock unchanged).
+- Clarify the `--locked` vs `--frozen` semantics in the usage text + SKILL.md.
+
+## Composes with
+
+- Slice 5.3 spec: `docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice5.3-lockfile-design.md`
+- B-0288 (Ace DLC package manager CLI)

--- a/docs/backlog/P2/B-0975-ace-lockfile-ergonomics-partial-merge-alphabetical-ordering-leaf-lock-deferred-from-slice5.3-2026-06-01.md
+++ b/docs/backlog/P2/B-0975-ace-lockfile-ergonomics-partial-merge-alphabetical-ordering-leaf-lock-deferred-from-slice5.3-2026-06-01.md
@@ -1,0 +1,50 @@
+---
+id: B-0975
+priority: P2
+status: open
+title: Ace lockfile ergonomics — partial-merge, alphabetical ordering, leaf-install lock (deferred from slice 5.3)
+effort: S
+ask: operator 2026-06-01
+created: 2026-06-01
+last_updated: 2026-06-01
+depends_on:
+  - B-0288
+composes_with: []
+tags: [ace, package-manager, lockfile, ergonomics, deferred-enhancement, slice-5.3]
+---
+
+## What this row proposes
+
+Three small lockfile ergonomics deferred from slice 5.3 (which keeps the lock minimal:
+full-graph, install-ordered, written only for dependency installs):
+
+1. **Partial-merge** — add/bump one dependency without a full re-solve, holding the rest of
+   the lock pinned (the primitive `ace update --package <name>` (B-0973) builds on).
+2. **Alphabetical ordering** — emit `nodes` sorted by name with the install order
+   re-derived at `--frozen` time (cleaner diffs), instead of slice-5.3's
+   deterministic-install-order serialization.
+3. **Leaf-install lock** — write a trivial lock (root + empty `nodes`) for no-dependency
+   installs too, so `--frozen` works uniformly on leaf artifacts.
+
+## Why deferred (operator 2026-06-01)
+
+Slice 5.3's serialization is already deterministic (install order is stable because
+solve+resolve are deterministic), so alphabetical ordering is a diff-readability nicety,
+not correctness. Partial-merge is an optimization over solve-fresh-then-write. Leaf-lock
+adds a uniform-but-empty artifact. None are needed for the core write + `--frozen`-replay
+guarantee. Operator: *"everything we skipped lets slice off for further enhancements."*
+
+## Scope sketch
+
+- Partial-merge: `buildLockfile` variant that takes an existing lock + a single changed
+  node and re-pins only the affected subtree.
+- Alphabetical: sort `nodes` by `name` on serialize; re-derive install order from the dep
+  graph at `--frozen` time (requires the lock to also carry edges, or a topo re-derivation
+  from the installed manifests).
+- Leaf-lock: extend the leaf (no-dep) install path to write `{ format_version, root, nodes: [] }`.
+
+## Composes with
+
+- Slice 5.3 spec: `docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice5.3-lockfile-design.md`
+- B-0973 (`ace update` — consumes the partial-merge primitive)
+- B-0288 (Ace DLC package manager CLI)


### PR DESCRIPTION
Slice 5.3 of the Ace DLC package manager (B-0288), building on 5.1 (#6369) + 5.2 (#6388/#6391). Brainstormed + decided with the operator 2026-06-01.

**Spec:** `docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice5.3-lockfile-design.md`

Three locked decisions:
- **Workflow = cargo-style:** `ace install` always solves fresh + writes `./ace.lock`; `--frozen` reads the lock, skips solving, installs exactly the locked graph, fails on drift. Default behavior unchanged; reproducibility opt-in.
- **Location = `./ace.lock`** in CWD, `--lockfile <path>` override.
- **Content = full pin** (name + version + url + package_hash per node) → `--frozen` is registry-independent, byte-reproducible, tamper-evident.

**Design:** new pure `tools/ace/lockfile.ts` (build / serialize / parse / drift-gate); `resolve.ts` exports `canonicalJson` for reuse; `ace.ts` gains `--frozen`/`--lockfile` + default-path lock write + frozen replay (fetch+verify+install each locked node, registry untouched). The slice-5.1/5.2 verify pipeline is reused, not rewritten.

**Deferred-enhancement rows** (everything sliced off per operator 2026-06-01):
- **B-0973** `ace update` (re-solve within ranges + rewrite lock)
- **B-0974** `ace install --locked` (assert-up-to-date vs `--frozen` replay)
- **B-0975** lockfile ergonomics (partial-merge, alphabetical ordering, leaf-lock)

Spec-only PR (no code yet) — mirrors the 5.1/5.2 flow: spec → review → writing-plans → subagent-driven build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)