### PR TITLE
feat(ace): slice 5.4 — lockfile ergonomics (ace update + --locked + leaf-lock)

### DIFF
--- a/.claude/skills/ace/SKILL.md
+++ b/.claude/skills/ace/SKILL.md
@@ -30,7 +30,8 @@ Publisher verbs: `keygen`, `sign`. Consumer verbs: `install`, `verify`, `trust a
 | `keygen` | `bun tools/ace/ace.ts keygen [--out <prefix>]` | Generate an Ed25519 keypair (writes `<prefix>.key` 0600 + `<prefix>.pub`) |
 | `sign` | `bun tools/ace/ace.ts sign <pkg> --key <priv.key> [--out <file>]` | Sign a package manifest with an Ed25519 private key |
 | `list` | `bun tools/ace/ace.ts list [--store <path>] [--json]` | List installed packages from `~/.ace/store` |
-| `install` | `bun tools/ace/ace.ts install <url-or-path> [--allow-no-signature] [--print-resolution] [--frozen] [--lockfile <path>]` | Resolve the transitive dependency graph, verify integrity + authenticity of every node, install leaves-first (atomic) |
+| `install` | `bun tools/ace/ace.ts install <url-or-path> [--allow-no-signature] [--print-resolution] [--frozen\|--locked] [--lockfile <path>]` | Resolve the transitive dependency graph, verify integrity + authenticity of every node, install leaves-first (atomic) |
+| `update` | `bun tools/ace/ace.ts update <url-or-path> [--lockfile <path>] [--allow-no-signature]` | Re-solve the graph and rewrite the lockfile; installs nothing (lock-only) |
 | `verify` | `bun tools/ace/ace.ts verify <hash>` | Confirm an installed package is present |
 | `trust add` | `bun tools/ace/ace.ts trust add <pub-file-or-b64> [--label <name>]` | Add an Ed25519 public key to the user trust store (`~/.ace/trusted-keys.json`) |
 | `trust list` | `bun tools/ace/ace.ts trust list` | List all trusted keys (bundled + user) |
@@ -87,22 +88,40 @@ ace install <pkg> --allow-no-signature --print-resolution
 Each printed line has the format `name@version`, sorted lexicographically. Useful for
 auditing which versions the solver selected before committing to the install.
 
-## Lockfile (slice 5.3)
+## Lockfile (slices 5.3 + 5.4)
 
-A normal `ace install` on a package with dependencies writes `./ace.lock` after a
-successful graph install. The lockfile pins every resolved dependency by name, version,
-URL, and `package_hash`.
+A normal `ace install` writes `./ace.lock` after a successful install — for a
+dependency graph (pins every resolved dep by name, version, URL, `package_hash`) AND
+for a leaf (no-dependency) package (an empty-`nodes` lock pinning just the root identity,
+slice 5.4).
 
 **`--frozen`** replays the locked graph: skips solving and registry access entirely,
 fetches each node from the locked URL, and byte-verifies the result against the locked
-`package_hash` and `content_hash`. Refused if the lockfile is missing or if the root
-package has drifted from its locked state ("lockfile out of date — re-run without
-`--frozen` to regenerate").
+`package_hash` and `content_hash`. On a leaf it just drift-gates the root against the
+lock. Refused if the lockfile is missing or if the root package has drifted from its
+locked state ("lockfile out of date — re-run without `--frozen` to regenerate").
 
-**`--lockfile <path>`** overrides the default lockfile path (`ace.lock`).
+**`--locked`** (slice 5.4) is the CI guard: it re-solves, then asserts the committed
+lock equals a fresh solve, and refuses (installing nothing) if they differ — "lockfile
+out of date (--locked) — run 'ace update' to regenerate". Unlike `--frozen` (which
+replays the lock registry-independently), `--locked` consults the registry to detect a
+stale lock. `--locked` and `--frozen` are mutually exclusive (a usage error together).
 
-Errors during lockfile *write* are warnings (install still succeeds). All `--frozen`
-refusals (missing lock, drift, hash mismatch, bad signature) are hard exits (code `1`).
+**`ace update`** (slice 5.4) refreshes the lock by re-solving the dependency graph and
+rewriting the lockfile — it installs nothing (lock-only). It runs the same signature gate,
+root `content_hash` check, solve, resolve, and integrity preflight as `install`, but
+preflights the freshly-solved graph BEFORE writing: it never writes a lock for a graph
+`install` would reject. A failed solve/resolve/preflight refuses with exit `1` and writes
+no lock; a write failure is a hard error (exit `1`). On a leaf it writes the empty-`nodes`
+lock. Typical loop: `ace update` (regenerate) → commit `ace.lock` → `ace install --locked`
+(CI asserts it is current) or `ace install --frozen` (reproducible replay).
+
+**`--lockfile <path>`** overrides the default lockfile path (`ace.lock`) for `install`
+and `update`.
+
+Errors during a normal `install` lockfile *write* are warnings (install still succeeds).
+All `--frozen`/`--locked` refusals (missing lock, drift, stale, hash mismatch, bad
+signature) and an `ace update` write failure are hard exits (code `1`).
 
 ## Invocation
 

--- a/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice5.4-implementation-plan.md
+++ b/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice5.4-implementation-plan.md
@@ -1,0 +1,531 @@
+# Ace CLI slice 5.4 — lockfile ergonomics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `ace update` (re-solve + rewrite the lock), `ace install --locked` (assert the committed lock is up to date, else refuse), and leaf-install lockfiles — all additive, with the lock format (`format_version: 1`) unchanged.
+
+**Architecture:** Two small pure helpers in `tools/ace/lockfile.ts` (`lockfilesEqual`, `buildLeafLockfile`); a new `update` command + a `--locked` install flag + leaf-path lock handling in `tools/ace/ace.ts`; the existing graph integrity preflight is extracted into a shared `preflightGraph` helper reused by install AND update. No solver changes; no lock-format changes.
+
+**Tech Stack:** TypeScript on Bun. Tests `bun test tools/ace/`. Strict gate `bun --bun tsc --noEmit -p tsconfig.json`. Docs gate `bunx markdownlint-cli2`.
+
+**Spec:** `docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice5.4-lockfile-ergonomics-design.md` (the `ace update` preflight-before-write correction is landing via PR #6414 and is reflected below).
+
+**Harness notes (every task):**
+
+- The Otto-343 hook blocks the `Edit` tool even after `Read`/`Write`. NEW files → `Write`. EDITS to existing files → a throwaway `tools/ace/_patch_<x>.ts` doing `readFileSync` → `String.split(find).join(repl)` (assert exactly 1 occurrence) → `writeFileSync`, run `bun run`, then `rm`. Never commit a patch script.
+- Commit canary: `git ls-tree HEAD | wc -l` MUST stay **67** after every commit. If not, STOP (tree corruption).
+- Commit trailer (last line of every message): `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- Branch is already `otto-windows/ace-slice5.4-impl-2026-06-01` off `origin/main`. Do NOT switch branches.
+
+**Existing-code facts (verified against `origin/main` — read the file before editing):**
+
+- `tools/ace/resolve.ts`: `export function packageHash(pkg: AcePackage): string`; `resolve(root, fetchPackage, trustStore, registry, solved, opts) → { ok: true; order: AcePackage[] } | { ok: false; ... }`; `order` is deps-first, **root LAST**; `export function canonicalJson`.
+- `tools/ace/lockfile.ts` exports: `type LockNode`, `type Lockfile` (`{format_version:1; root:{name;version;package_hash}; nodes: LockNode[]}`), `buildLockfile(root, order, registry)`, `serializeLockfile(lf)`, `parseLockfile(json) → Lockfile | {error}`, `verifyRootMatchesLock(root, lf) → boolean`.
+- `tools/ace/store.ts`: `contentHash`, `validatePackagePaths`, `installPackage`, `loadRegistry`, `loadTrustStore`, `defaultStorePath`, `type Registry`, `type AcePackage`, `type AceManifest`.
+- `tools/ace/signing.ts`: `verifySignature(manifest, trustStore)`.
+- `tools/ace/ace.ts`: `InstallArgs` already has `frozen: boolean; lockfile: string`. `parseArgs` install loop (~line 183) parses `--frozen`/`--lockfile`/`--allow-no-signature`/`--store`/`--print-resolution`, returns `InstallArgs` (~line 211). `ParsedArgs` union (~line 85). The install handler (~line 462) graph path: signature gate → root content_hash → `solve` → `--print-resolution` → `resolve` → **PREFLIGHT loop** over `res.order` (per node: content_hash, `validatePackagePaths`, `byStoreKey` content_hash→package_hash collision) → **EXTRACT loop** (`installPackage`) → `buildLockfile`+write. `--frozen` branch is at the top of the graph path. The leaf (no-deps) path falls through to the single-package install below (~line 617). Usage text ~line 258.
+
+---
+
+## Tasks
+
+### Task 1: `lockfile.ts` — `lockfilesEqual` + `buildLeafLockfile`
+
+**Files:**
+
+- Modify: `tools/ace/lockfile.ts`
+- Test: `tools/ace/lockfile.test.ts`
+
+- [ ] **Step 1: Write the failing tests** (append to `tools/ace/lockfile.test.ts`)
+
+```ts
+import { lockfilesEqual, buildLeafLockfile, type Lockfile } from "./lockfile.ts";
+
+describe("lockfilesEqual", () => {
+  const base: Lockfile = {
+    format_version: 1,
+    root: { name: "root", version: "1.0.0", package_hash: "sha256:r" },
+    nodes: [{ name: "A", version: "1.2.0", url: "u/A", package_hash: "sha256:a" }],
+  };
+  test("true for identical (incl. key-order-insensitive via canonical)", () => {
+    const clone: Lockfile = JSON.parse(JSON.stringify(base));
+    expect(lockfilesEqual(base, clone)).toBe(true);
+  });
+  test("false when a node version differs", () => {
+    const diff: Lockfile = { ...base, nodes: [{ ...base.nodes[0]!, version: "1.3.0" }] };
+    expect(lockfilesEqual(base, diff)).toBe(false);
+  });
+  test("false when root differs", () => {
+    const diff: Lockfile = { ...base, root: { ...base.root, package_hash: "sha256:other" } };
+    expect(lockfilesEqual(base, diff)).toBe(false);
+  });
+});
+
+describe("buildLeafLockfile", () => {
+  test("produces {format_version:1, root, nodes:[]} with the root package_hash", () => {
+    const files = { "f.txt": "leaf@1.0.0" };
+    const root = { manifest: { format_version: 1, name: "leaf", version: "1.0.0", content_hash: contentHash(new TextEncoder().encode(JSON.stringify(files))) }, files };
+    const lf = buildLeafLockfile(root);
+    expect(lf.format_version).toBe(1);
+    expect(lf.nodes).toEqual([]);
+    expect(lf.root).toEqual({ name: "leaf", version: "1.0.0", package_hash: packageHash(root) });
+  });
+});
+```
+
+(`contentHash`/`packageHash` are already imported at the top of `lockfile.test.ts` from prior tasks — if not, add `import { contentHash } from "./store.ts"` and `import { packageHash } from "./resolve.ts"`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tools/ace/lockfile.test.ts`
+Expected: FAIL — `lockfilesEqual` / `buildLeafLockfile` not exported.
+
+- [ ] **Step 3: Implement** (append to `tools/ace/lockfile.ts`)
+
+```ts
+/** True iff two lockfiles serialize identically (canonical JSON — key-order-insensitive). */
+export function lockfilesEqual(a: Lockfile, b: Lockfile): boolean {
+  return serializeLockfile(a) === serializeLockfile(b);
+}
+
+/** Lockfile for a no-dependency (leaf) root: the root identity + empty nodes. */
+export function buildLeafLockfile(root: AcePackage): Lockfile {
+  return {
+    format_version: 1,
+    root: { name: root.manifest.name, version: root.manifest.version, package_hash: packageHash(root) },
+    nodes: [],
+  };
+}
+```
+
+- [ ] **Step 4: Run tests + strict tsc**
+
+Run: `bun test tools/ace/lockfile.test.ts` → PASS. Run: `bun --bun tsc --noEmit -p tsconfig.json` → exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/lockfile.ts tools/ace/lockfile.test.ts
+git commit -m "$(printf 'feat(ace): lockfilesEqual + buildLeafLockfile (slice 5.4 task 1)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+git ls-tree HEAD | wc -l   # 67
+```
+
+---
+
+### Task 2: extract `preflightGraph` helper (shared by install + update)
+
+**Files:**
+
+- Modify: `tools/ace/ace.ts` (extract the existing preflight loop into a function; route the install graph path through it)
+
+- [ ] **Step 1: Read** the install graph path's preflight loop in `tools/ace/ace.ts` (the `const byStoreKey = new Map...` block over `res.order`, before the extract loop).
+
+- [ ] **Step 2: Implement** (patch-script) — add a module-level helper near the other top-level helpers in `ace.ts` (after imports / before `parseArgs`, wherever module-scope functions live):
+
+```ts
+/** Integrity preflight over a resolved graph: per-node content_hash, path-safety, and
+ *  store-key (content_hash → package_hash) collision. Returns null on success, or an
+ *  error message. Shared by `install` (before extract) and `update` (before lock write). */
+function preflightGraph(order: AcePackage[]): string | null {
+  const byStoreKey = new Map<string, string>(); // content_hash -> package_hash
+  for (const node of order) {
+    const fh = contentHash(new TextEncoder().encode(JSON.stringify(node.files)));
+    if (fh !== node.manifest.content_hash) return `bad-content-hash in ${node.manifest.name}`;
+    const unsafe = validatePackagePaths(node);
+    if (unsafe !== null) return `unsafe file path in ${node.manifest.name}: ${unsafe}`;
+    const ph = packageHash(node);
+    const prior = byStoreKey.get(node.manifest.content_hash);
+    if (prior !== undefined && prior !== ph) return `store-collision — ${node.manifest.name} shares a content_hash store key with a different package`;
+    byStoreKey.set(node.manifest.content_hash, ph);
+  }
+  return null;
+}
+```
+
+Confirm `packageHash` is imported in ace.ts (it is — used by the existing preflight). Then replace the inline preflight loop in the install graph path with:
+
+```ts
+      const pf = preflightGraph(res.order);
+      if (pf !== null) { console.error(`ace: install refused: ${pf}`); return 1; }
+```
+
+(Match the existing refusal message style; the extract loop immediately after is unchanged.)
+
+- [ ] **Step 3: Run tests + strict tsc**
+
+Run: `bun test tools/ace/` → all PASS (behavior identical — pure extraction). Run: `bun --bun tsc --noEmit -p tsconfig.json` → exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/ace/ace.ts
+git commit -m "$(printf 'refactor(ace): extract preflightGraph helper (slice 5.4 task 2)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+git ls-tree HEAD | wc -l   # 67
+```
+
+---
+
+### Task 3: `--locked` flag (parse + mutual-exclusion with `--frozen`)
+
+**Files:**
+
+- Modify: `tools/ace/ace.ts` (`InstallArgs` + parseArgs)
+- Test: `tools/ace/ace.test.ts`
+
+- [ ] **Step 1: Write the failing tests** (append to the parseArgs describe in `tools/ace/ace.test.ts`)
+
+```ts
+describe("parseArgs — install --locked", () => {
+  test("--locked defaults off", () => {
+    const a = parseArgs(["install", "pkg.json"]);
+    if ("command" in a && a.command === "install") expect(a.locked).toBe(false);
+  });
+  test("--locked sets locked true", () => {
+    const a = parseArgs(["install", "pkg.json", "--locked"]);
+    if ("command" in a && a.command === "install") expect(a.locked).toBe(true);
+  });
+  test("--locked + --frozen is an error (mutually exclusive)", () => {
+    const a = parseArgs(["install", "pkg.json", "--locked", "--frozen"]);
+    expect("error" in a).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tools/ace/ace.test.ts`
+Expected: FAIL — `locked` not on InstallArgs / not parsed / no mutual-exclusion error.
+
+- [ ] **Step 3a: Add `locked` to `InstallArgs`** (patch-script): add `readonly locked: boolean;` to the interface (next to `frozen`).
+
+- [ ] **Step 3b: Parse `--locked` + mutual-exclusion** (patch-script): add `let locked = false;` next to `let frozen = false;`; add a parse case `} else if (argv[i] === "--locked") { locked = true;`; after the install arg loop (before building the return object) add `if (locked && frozen) return { error: "--locked and --frozen are mutually exclusive" };`; thread `locked` into the returned `InstallArgs` object (next to `frozen, lockfile: lockfilePath`).
+
+- [ ] **Step 4: Run tests + strict tsc**
+
+Run: `bun test tools/ace/ace.test.ts` → PASS. Run: `bun --bun tsc --noEmit -p tsconfig.json` → exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/ace.ts tools/ace/ace.test.ts
+git commit -m "$(printf 'feat(ace): --locked flag + --frozen mutual-exclusion (slice 5.4 task 3)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+git ls-tree HEAD | wc -l   # 67
+```
+
+---
+
+### Task 4: `--locked` graph-path compare-before-extract
+
+**Files:**
+
+- Modify: `tools/ace/ace.ts` (install graph path)
+- Test: `tools/ace/ace.test.ts`
+
+- [ ] **Step 1: Write the failing tests** (`tools/ace/ace.test.ts`, reuse the existing graph-install integration harness — temp store, temp cwd, fetch map, registry)
+
+```ts
+// 1. --locked passes (installs) when the on-disk lock matches a fresh solve:
+//    do a normal install (writes ./ace.lock), then install --locked again with the
+//    SAME registry → exit 0, graph installed.
+// 2. --locked refuses + installs nothing when the lock is stale:
+//    normal install (locks A@1.0.0), then add A@1.1.0 to the registry (in-range), then
+//    install --locked → exit non-zero, store unchanged (A@1.1.0 NOT installed).
+// 3. --locked with NO lockfile → refused (exit non-zero).
+```
+
+Match the existing harness's return-code capture + store-assertion idiom (read a current graph-install test first).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tools/ace/ace.test.ts`
+Expected: FAIL — `--locked` not handled (installs regardless).
+
+- [ ] **Step 3: Implement** (patch-script) — in the install graph path, AFTER `resolve()` succeeds and BEFORE the `preflightGraph`/extract, insert the `--locked` gate:
+
+```ts
+      if (parsed.locked) {
+        let lockRaw: string;
+        try { lockRaw = readFileSync(parsed.lockfile, "utf8"); }
+        catch { console.error(`ace: install refused: --locked but no lockfile at ${parsed.lockfile} — run 'ace update' or install without --locked`); return 1; }
+        const onDisk = parseLockfile(lockRaw);
+        if ("error" in onDisk) { console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${onDisk.error}`); return 1; }
+        const fresh = buildLockfile(pkg, res.order, registry);
+        if ("error" in fresh) { console.error(`ace: install refused: could not build lockfile: ${fresh.error}`); return 1; }
+        if (!lockfilesEqual(onDisk, fresh)) {
+          console.error(`ace: install refused: lockfile out of date (--locked) — run 'ace update' to regenerate`);
+          return 1;
+        }
+      }
+```
+
+Add `lockfilesEqual` to the `./lockfile.ts` import line (alongside `buildLockfile, serializeLockfile, parseLockfile, verifyRootMatchesLock`). When `--locked` passes, control falls through to the existing `preflightGraph` + extract + (lock already matches; the existing buildLockfile+write rewrites an identical file — acceptable).
+
+- [ ] **Step 4: Run tests + strict tsc + full suite**
+
+Run: `bun test tools/ace/ace.test.ts` → PASS. Run: `bun --bun tsc --noEmit -p tsconfig.json` → exit 0. Run: `bun test tools/ace/` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/ace.ts tools/ace/ace.test.ts
+git commit -m "$(printf 'feat(ace): install --locked compare-before-extract (slice 5.4 task 4)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+git ls-tree HEAD | wc -l   # 67
+```
+
+---
+
+### Task 5: leaf-install lockfiles (default write + `--frozen` + `--locked` on leaf)
+
+**Files:**
+
+- Modify: `tools/ace/ace.ts` (the leaf / single-package install path)
+- Test: `tools/ace/ace.test.ts`
+
+- [ ] **Step 1: Write the failing tests** (`tools/ace/ace.test.ts`)
+
+```ts
+// 1. Leaf install writes an empty-nodes lock:
+//    install a no-dep package with --lockfile <tmp> → ./lock parses to {root, nodes:[]}.
+// 2. --frozen on a leaf installs the root when the lock matches:
+//    after (1), install --frozen the same leaf → exit 0, installed.
+// 3. --frozen leaf with a drifted root → refused:
+//    build a leaf lock for root@1.0.0, then --frozen install a DIFFERENT root (changed files) → refused.
+// 4. --locked leaf passes when lock matches / refuses when no lock.
+```
+
+Match the existing leaf-install test idiom.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tools/ace/ace.test.ts`
+Expected: FAIL — leaf path writes no lock; `--frozen`/`--locked` are no-ops on leaf.
+
+- [ ] **Step 3: Implement** (patch-script) — find the leaf / single-package install path (the fall-through below the graph path, ~line 617 `const result = installPackage(parsed.storePath, pkg);`). Wrap it with frozen/locked handling + a default lock write. Replace the bare single-package install with:
+
+```ts
+    // SLICE 5.4: leaf (no-dependency) install — uniform lockfile handling.
+    if (parsed.frozen) {
+      let lockRaw: string;
+      try { lockRaw = readFileSync(parsed.lockfile, "utf8"); }
+      catch { console.error(`ace: install refused: no lockfile at ${parsed.lockfile} — run install without --frozen first`); return 1; }
+      const lf = parseLockfile(lockRaw);
+      if ("error" in lf) { console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${lf.error}`); return 1; }
+      if (!verifyRootMatchesLock(pkg, lf)) { console.error(`ace: install refused: lockfile out of date for ${pkg.manifest.name} — re-run without --frozen to regenerate`); return 1; }
+    } else if (parsed.locked) {
+      let lockRaw: string;
+      try { lockRaw = readFileSync(parsed.lockfile, "utf8"); }
+      catch { console.error(`ace: install refused: --locked but no lockfile at ${parsed.lockfile} — run 'ace update' or install without --locked`); return 1; }
+      const onDisk = parseLockfile(lockRaw);
+      if ("error" in onDisk) { console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${onDisk.error}`); return 1; }
+      if (!lockfilesEqual(onDisk, buildLeafLockfile(pkg))) { console.error(`ace: install refused: lockfile out of date (--locked) — run 'ace update' to regenerate`); return 1; }
+    }
+    const result = installPackage(parsed.storePath, pkg);
+    if (!result.ok) { /* existing failure handling unchanged */ }
+    // existing success logging ... then, for the default (non-frozen) path, write the leaf lock:
+    if (!parsed.frozen) {
+      try { writeFileSync(parsed.lockfile, serializeLockfile(buildLeafLockfile(pkg))); }
+      catch (e) { console.error(`ace: WARNING: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`); }
+    }
+```
+
+Add `buildLeafLockfile` to the `./lockfile.ts` import line. IMPORTANT: read the exact existing leaf-path code first — preserve its existing success/failure handling + return values; only WRAP it with the frozen/locked guards above and ADD the post-install leaf-lock write. Do not duplicate or drop the existing single-package verification that already runs before this point (signature gate + content_hash happen earlier in the handler, shared with the graph path).
+
+- [ ] **Step 4: Run tests + strict tsc + full suite**
+
+Run: `bun test tools/ace/ace.test.ts` → PASS. Run: `bun --bun tsc --noEmit -p tsconfig.json` → exit 0. Run: `bun test tools/ace/` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/ace.ts tools/ace/ace.test.ts
+git commit -m "$(printf 'feat(ace): leaf-install lockfiles + --frozen/--locked leaf handling (slice 5.4 task 5)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+git ls-tree HEAD | wc -l   # 67
+```
+
+---
+
+### Task 6: `ace update` command
+
+**Files:**
+
+- Modify: `tools/ace/ace.ts` (`UpdateArgs` + `ParsedArgs` + parseArgs branch + handler)
+- Test: `tools/ace/ace.test.ts`
+
+- [ ] **Step 1: Write the failing tests** (`tools/ace/ace.test.ts`)
+
+```ts
+describe("parseArgs — update", () => {
+  test("update requires a source", () => {
+    expect("error" in parseArgs(["update"])).toBe(true);
+  });
+  test("update parses source + default lockfile", () => {
+    const a = parseArgs(["update", "pkg.json"]);
+    if ("command" in a && a.command === "update") { expect(a.source).toBe("pkg.json"); expect(a.lockfile).toBe("ace.lock"); }
+  });
+  test("update --lockfile override", () => {
+    const a = parseArgs(["update", "pkg.json", "--lockfile", "x.lock"]);
+    if ("command" in a && a.command === "update") expect(a.lockfile).toBe("x.lock");
+  });
+});
+// Integration:
+// 1. ace update rewrites ./ace.lock to the freshly-solved graph, installs NOTHING:
+//    seed registry A@1.0.0; install (locks A@1.0.0); add A@1.1.0 in-range; ace update →
+//    ./ace.lock now pins A@1.1.0; store still has only the original install (update didn't extract).
+// 2. ace update on a leaf writes an empty-nodes lock.
+// 3. ace update refuses (no lock written) when a freshly-solved node fails preflight
+//    (e.g. an unsafe file path in a dep) — the preflight-before-write guard.
+```
+
+Match the existing harness.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tools/ace/ace.test.ts`
+Expected: FAIL — no `update` command.
+
+- [ ] **Step 3a: `UpdateArgs` + union + parseArgs branch** (patch-script):
+
+Add the interface (near `InstallArgs`):
+
+```ts
+interface UpdateArgs {
+  readonly command: "update";
+  readonly source: string;
+  readonly lockfile: string;
+  readonly allowNoSignature: boolean;
+}
+```
+
+Add `| UpdateArgs` to the `ParsedArgs` union. Add a parseArgs branch (mirror the install arg loop, minus `--frozen`/`--locked`/`--print-resolution`/`--store`-if-not-needed; `update` needs `source`, `--lockfile` default `"ace.lock"`, `--allow-no-signature`):
+
+```ts
+  if (command === "update") {
+    const source = argv[1];
+    if (!source || source.startsWith("-")) return { error: "update requires a <url-or-path> argument" };
+    let lockfilePath = "ace.lock";
+    let allowNoSignature = false;
+    for (let i = 2; i < argv.length; i++) {
+      if (argv[i] === "--lockfile") {
+        const next = argv[++i];
+        if (!next || next.startsWith("-")) return { error: "--lockfile requires a path argument" };
+        lockfilePath = next;
+      } else if (argv[i] === "--allow-no-signature") {
+        allowNoSignature = true;
+      } else {
+        return { error: `Unknown option for update: ${argv[i]}` };
+      }
+    }
+    return { command: "update", source, lockfile: lockfilePath, allowNoSignature };
+  }
+```
+
+- [ ] **Step 3b: `update` handler** (patch-script) — add a handler block (near the install handler). It reuses the install front-half verification (read root → signature gate → root content_hash), then solves+resolves+preflights and writes the lock WITHOUT extracting:
+
+```ts
+  if (parsed.command === "update") {
+    let raw: string;
+    try {
+      raw = parsed.source.startsWith("http://") || parsed.source.startsWith("https://")
+        ? await (await fetch(parsed.source)).text() : readFileSync(parsed.source, "utf8");
+    } catch (e) { console.error(`ace: download/read failed: ${(e as Error).message}`); return 1; }
+    let pkg: AcePackage;
+    try { pkg = JSON.parse(raw) as AcePackage; } catch { console.error("ace: package is not valid JSON"); return 65; }
+    if (typeof pkg !== "object" || pkg === null || typeof pkg.manifest !== "object" || pkg.manifest === null || typeof pkg.files !== "object" || pkg.files === null) {
+      console.error("ace: update refused: not a well-formed AcePackage"); return 1;
+    }
+    // Signature gate (same policy as install).
+    const v = verifySignature(pkg.manifest, loadTrustStore());
+    if (!v.ok && v.reason !== "no-signature") { console.error(`ace: update refused: ${v.reason}`); return 1; }
+    if (!v.ok && v.reason === "no-signature" && !parsed.allowNoSignature) { console.error("ace: update refused: unsigned package (use --allow-no-signature)"); return 1; }
+    // Root content_hash.
+    const rootFilesHash = contentHash(new TextEncoder().encode(JSON.stringify(pkg.files)));
+    if (rootFilesHash !== pkg.manifest.content_hash) { console.error(`ace: update refused: bad-content-hash in ${pkg.manifest.name} (root)`); return 1; }
+
+    if (pkg.manifest.dependencies && pkg.manifest.dependencies.length > 0) {
+      const fetchPackage = async (u: string): Promise<string> =>
+        (u.startsWith("http://") || u.startsWith("https://")) ? await (await fetch(u)).text() : readFileSync(u, "utf8");
+      const registry = loadRegistry();
+      const solveResult = await solve(pkg, fetchPackage, registry);
+      if (!solveResult.ok) { console.error(`ace: update refused: ${solveResult.reason} — ${solveResult.detail} (path: ${solveResult.path.join(" → ")})`); return 1; }
+      const res = await resolve(pkg, fetchPackage, loadTrustStore(), registry, solveResult.versions, { allowNoSignature: parsed.allowNoSignature });
+      if (!res.ok) { console.error(`ace: update refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`); return 1; }
+      // Preflight BEFORE writing — never write a lock for a graph install would reject (Codex #6412).
+      const pf = preflightGraph(res.order);
+      if (pf !== null) { console.error(`ace: update refused: ${pf}`); return 1; }
+      const lf = buildLockfile(pkg, res.order, registry);
+      if ("error" in lf) { console.error(`ace: update refused: could not build lockfile: ${lf.error}`); return 1; }
+      try { writeFileSync(parsed.lockfile, serializeLockfile(lf)); }
+      catch (e) { console.error(`ace: update failed: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`); return 1; }
+      console.log(`ace: wrote lockfile ${parsed.lockfile} (${lf.nodes.length} deps)`);
+      return 0;
+    }
+    // Leaf: trivial lock.
+    try { writeFileSync(parsed.lockfile, serializeLockfile(buildLeafLockfile(pkg))); }
+    catch (e) { console.error(`ace: update failed: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`); return 1; }
+    console.log(`ace: wrote lockfile ${parsed.lockfile} (0 deps)`);
+    return 0;
+  }
+```
+
+Confirm imports: `solve` (from `./solver.ts`), `resolve`, `packageHash` (from `./resolve.ts`), `buildLockfile`/`serializeLockfile`/`buildLeafLockfile` (from `./lockfile.ts`), `loadRegistry`/`loadTrustStore`/`contentHash` (from `./store.ts`), `verifySignature` (from `./signing.ts`) — all already imported for install; add any missing.
+
+- [ ] **Step 4: Run tests + strict tsc + full suite**
+
+Run: `bun test tools/ace/ace.test.ts` → PASS. Run: `bun --bun tsc --noEmit -p tsconfig.json` → exit 0. Run: `bun test tools/ace/` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/ace.ts tools/ace/ace.test.ts
+git commit -m "$(printf 'feat(ace): ace update command — re-solve + rewrite lock, preflight before write (slice 5.4 task 6)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+git ls-tree HEAD | wc -l   # 67
+```
+
+---
+
+### Task 7: usage text + SKILL.md docs
+
+**Files:**
+
+- Modify: `tools/ace/ace.ts` (usage/help string)
+- Modify: `.claude/skills/ace/SKILL.md`
+
+- [ ] **Step 1: Update usage text** (patch-script) — add an `ace update <url-or-path> [--lockfile <path>] [--allow-no-signature]` line (re-solve + rewrite the lockfile, installs nothing) and add `[--locked]` to the `install` line with a one-line note (assert the committed lock is up to date, else refuse; mutually exclusive with `--frozen`). Match the existing usage style.
+
+- [ ] **Step 2: Update SKILL.md** (patch-script or Write) — extend the lockfile section: `ace update` (refresh the lock by re-solving; lock-only), `install --locked` (CI guard: assert lock current vs `--frozen` replay), and that leaf installs now write a lock too. Terse; match the existing voice.
+
+- [ ] **Step 3: Lint** — `bunx markdownlint-cli2 ".claude/skills/ace/SKILL.md"` → clean.
+
+- [ ] **Step 4: Final verify** — `bun test tools/ace/` → all PASS; `bun --bun tsc --noEmit -p tsconfig.json` → exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/ace.ts .claude/skills/ace/SKILL.md
+git commit -m "$(printf 'docs(ace): document ace update + --locked + leaf-lock (slice 5.4 task 7)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+git ls-tree HEAD | wc -l   # 67
+```
+
+---
+
+## Final verification (after all tasks)
+
+```bash
+bun test tools/ace/                              # all green
+bun --bun tsc --noEmit -p tsconfig.json          # exit 0
+bunx markdownlint-cli2 ".claude/skills/ace/SKILL.md"
+git ls-tree HEAD | wc -l                         # 67
+```
+
+Then open the PR against `main`, arm auto-merge, run the PR-gate loop (Copilot/Codex threads, keep canary 67), land on green.
+
+## Self-review (plan vs spec)
+
+- **Spec Feature 1 (`ace update`, lock-only, preflight-before-write)** → Task 6 (+ Task 2 extracts the shared `preflightGraph`). ✓
+- **Spec Feature 2 (`ace install --locked`, compare, `--frozen` mutual-exclusion)** → Tasks 3 (parse + exclusion) + 4 (graph compare) + 5 (leaf compare). ✓
+- **Spec Feature 3 (leaf-install lockfiles + `--frozen`/`--locked` on leaf)** → Task 5. ✓
+- **Spec Components (`lockfilesEqual`, `buildLeafLockfile`)** → Task 1. ✓
+- **Lock format unchanged (`format_version: 1`)** — no task touches the format; ✓.
+- **Deferred (alpha-ordering, partial-merge, `--package`)** — no task implements them; ✓.
+- **Error-handling table** — update solve/resolve/preflight refusals (Task 6), update write-fail hard error (Task 6), `--locked` no-lock/stale refusals (Tasks 4/5), `--locked`+`--frozen` error (Task 3), `--frozen` leaf no-lock/drift (Task 5), leaf default write warning (Task 5). ✓
+- **Type consistency:** `lockfilesEqual(a,b)` / `buildLeafLockfile(root)` / `UpdateArgs` / `InstallArgs.locked` / `preflightGraph(order)` names + signatures consistent across Tasks 1–7. ✓

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -1200,4 +1200,17 @@ describe("ace update (slice 5.4)", () => {
     expect(code).toBe(1);
     expect(existsSync(lockPath)).toBe(false);
   });
+
+  test("update refuses (no lock written) when a LEAF package fails preflight (unsafe path)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ace-update-leaf-bad-"));
+    // A leaf (no deps) with an unsafe file path → validatePackagePaths fails → no lock written.
+    // Parity with the graph path; otherwise update could commit an unreplayable leaf lock that
+    // installPackage/--frozen would reject (Codex #6416).
+    const bad = { manifest: { format_version:1, name:"BADLEAF", version:"1.0.0", content_hash: h({ "../escape":"x" }) }, files: { "../escape":"x" } };
+    const badPath = join(dir, "BADLEAF.json"); writeFileSync(badPath, JSON.stringify(bad));
+    const lockPath = join(dir, "ace.lock");
+    const code = await main(["update", badPath, "--lockfile", lockPath, "--allow-no-signature"]);
+    expect(code).toBe(1);
+    expect(existsSync(lockPath)).toBe(false);
+  });
 });

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -999,3 +999,55 @@ describe("install — semver ranges (slice 5.2)", () => {
     expect(await main(["install", rootPath, "--store", store, "--allow-no-signature", "--print-resolution"])).toBe(0);
   });
 });
+
+describe("install --locked graph (slice 5.4)", () => {
+  const h = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+
+  test("--locked installs when the on-disk lock matches a fresh solve", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ace-locked-pkgs-"));
+    const A = { manifest: { format_version:1, name:"A", version:"1.0.0", content_hash: h({ "a.txt":"a" }) }, files: { "a.txt":"a" } };
+    const aPath = join(dir, "A.json"); writeFileSync(aPath, JSON.stringify(A)); await main(["registry","add","A","1.0.0",aPath]);
+    const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: h({ "r.txt":"r" }), dependencies:[{ kind:"registry" as const, name:"A", version:"^1.0.0" }] }, files: { "r.txt":"r" } };
+    const rootPath = join(dir, "root.json"); writeFileSync(rootPath, JSON.stringify(root));
+    const lockPath = join(dir, "ace.lock");
+    // 1. Normal install writes the lock.
+    expect(await main(["install", rootPath, "--store", mkdtempSync(join(tmpdir(),"ace-locked-gen-")), "--allow-no-signature", "--lockfile", lockPath])).toBe(0);
+    expect(existsSync(lockPath)).toBe(true);
+    // 2. --locked with the SAME registry + matching lock → installs.
+    const store = mkdtempSync(join(tmpdir(), "ace-locked-ok-"));
+    const code = await main(["install", rootPath, "--store", store, "--allow-no-signature", "--lockfile", lockPath, "--locked"]);
+    expect(code).toBe(0);
+    expect(listInstalled(store).map((p)=>p.manifest.name).sort()).toEqual(["A","root"]);
+  });
+
+  test("--locked refuses + installs nothing when the lock is stale", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ace-locked-stale-"));
+    const A1 = { manifest: { format_version:1, name:"A", version:"1.0.0", content_hash: h({ "a.txt":"a1" }) }, files: { "a.txt":"a1" } };
+    const a1Path = join(dir, "A-1.0.0.json"); writeFileSync(a1Path, JSON.stringify(A1)); await main(["registry","add","A","1.0.0",a1Path]);
+    const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: h({ "r.txt":"r" }), dependencies:[{ kind:"registry" as const, name:"A", version:"^1.0.0" }] }, files: { "r.txt":"r" } };
+    const rootPath = join(dir, "root.json"); writeFileSync(rootPath, JSON.stringify(root));
+    const lockPath = join(dir, "ace.lock");
+    // 1. Normal install locks A@1.0.0.
+    expect(await main(["install", rootPath, "--store", mkdtempSync(join(tmpdir(),"ace-locked-stale-gen-")), "--allow-no-signature", "--lockfile", lockPath])).toBe(0);
+    // 2. Add A@1.1.0 (in-range) — the fresh solve now picks A@1.1.0, so the lock is stale.
+    const A11 = { manifest: { format_version:1, name:"A", version:"1.1.0", content_hash: h({ "a.txt":"a11" }) }, files: { "a.txt":"a11" } };
+    const a11Path = join(dir, "A-1.1.0.json"); writeFileSync(a11Path, JSON.stringify(A11)); await main(["registry","add","A","1.1.0",a11Path]);
+    // 3. --locked → refuse, store unchanged.
+    const store = mkdtempSync(join(tmpdir(), "ace-locked-stale-store-"));
+    const code = await main(["install", rootPath, "--store", store, "--allow-no-signature", "--lockfile", lockPath, "--locked"]);
+    expect(code).toBe(1);
+    expect(listInstalled(store).length).toBe(0);
+  });
+
+  test("--locked with NO lockfile → refused", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ace-locked-nolock-"));
+    const A = { manifest: { format_version:1, name:"A", version:"1.0.0", content_hash: h({ "a.txt":"a" }) }, files: { "a.txt":"a" } };
+    const aPath = join(dir, "A.json"); writeFileSync(aPath, JSON.stringify(A)); await main(["registry","add","A","1.0.0",aPath]);
+    const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: h({ "r.txt":"r" }), dependencies:[{ kind:"registry" as const, name:"A", version:"^1.0.0" }] }, files: { "r.txt":"r" } };
+    const rootPath = join(dir, "root.json"); writeFileSync(rootPath, JSON.stringify(root));
+    const store = mkdtempSync(join(tmpdir(), "ace-locked-nolock-store-"));
+    const code = await main(["install", rootPath, "--store", store, "--allow-no-signature", "--lockfile", join(dir, "missing.lock"), "--locked"]);
+    expect(code).toBe(1);
+    expect(listInstalled(store).length).toBe(0);
+  });
+});

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -1051,3 +1051,76 @@ describe("install --locked graph (slice 5.4)", () => {
     expect(listInstalled(store).length).toBe(0);
   });
 });
+
+describe("leaf-install lockfiles (slice 5.4)", () => {
+  const h = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+
+  // Builds a no-dependency (leaf) package file in a temp dir; returns { dir, pkg, pkgPath }.
+  function leafFixture(files: Record<string,string> = { "leaf.txt": "v1" }) {
+    const dir = mkdtempSync(join(tmpdir(), "ace-leaf-pkgs-"));
+    const pkg = { manifest: { format_version:1, name:"leaf", version:"1.0.0", content_hash: h(files) }, files };
+    const pkgPath = join(dir, "leaf.json"); writeFileSync(pkgPath, JSON.stringify(pkg));
+    return { dir, pkg, pkgPath };
+  }
+
+  test("leaf install writes an empty-nodes lock", async () => {
+    const { dir, pkg, pkgPath } = leafFixture();
+    const store = mkdtempSync(join(tmpdir(), "ace-leaf-store-"));
+    const lockPath = join(dir, "ace.lock");
+    const code = await main(["install", pkgPath, "--store", store, "--allow-no-signature", "--lockfile", lockPath]);
+    expect(code).toBe(0);
+    expect(listInstalled(store).map((p)=>p.manifest.name)).toEqual(["leaf"]);
+    expect(existsSync(lockPath)).toBe(true);
+    const lf = parseLockfile(readFileSync(lockPath, "utf8"));
+    expect("error" in lf).toBe(false);
+    if (!("error" in lf)) {
+      expect(lf.root.name).toBe("leaf");
+      expect(lf.root.package_hash).toBe(packageHash(pkg as any));
+      expect(lf.nodes).toEqual([]);
+    }
+  });
+
+  test("--frozen on a leaf installs the root when the lock matches", async () => {
+    const { dir, pkgPath } = leafFixture();
+    const lockPath = join(dir, "ace.lock");
+    // 1. Normal leaf install writes the lock.
+    expect(await main(["install", pkgPath, "--store", mkdtempSync(join(tmpdir(),"ace-leaf-gen-")), "--allow-no-signature", "--lockfile", lockPath])).toBe(0);
+    // 2. --frozen leaf with the matching lock → installs.
+    const store = mkdtempSync(join(tmpdir(), "ace-leaf-frozen-"));
+    const code = await main(["install", pkgPath, "--store", store, "--allow-no-signature", "--lockfile", lockPath, "--frozen"]);
+    expect(code).toBe(0);
+    expect(listInstalled(store).map((p)=>p.manifest.name)).toEqual(["leaf"]);
+  });
+
+  test("--frozen leaf with a drifted root → refused, installs nothing", async () => {
+    const { dir, pkgPath } = leafFixture({ "leaf.txt": "v1" });
+    const lockPath = join(dir, "ace.lock");
+    // 1. Lock leaf@1.0.0 with the original files.
+    expect(await main(["install", pkgPath, "--store", mkdtempSync(join(tmpdir(),"ace-leaf-drift-gen-")), "--allow-no-signature", "--lockfile", lockPath])).toBe(0);
+    // 2. A DIFFERENT root (same name/version, changed files → different packageHash) under --frozen → refused.
+    const drifted = { manifest: { format_version:1, name:"leaf", version:"1.0.0", content_hash: h({ "leaf.txt": "v2-CHANGED" }) }, files: { "leaf.txt": "v2-CHANGED" } };
+    const driftedPath = join(dir, "leaf-drift.json"); writeFileSync(driftedPath, JSON.stringify(drifted));
+    const store = mkdtempSync(join(tmpdir(), "ace-leaf-drift-store-"));
+    const code = await main(["install", driftedPath, "--store", store, "--allow-no-signature", "--lockfile", lockPath, "--frozen"]);
+    expect(code).toBe(1);
+    expect(listInstalled(store).length).toBe(0);
+  });
+
+  test("--locked leaf passes when the lock matches", async () => {
+    const { dir, pkgPath } = leafFixture();
+    const lockPath = join(dir, "ace.lock");
+    expect(await main(["install", pkgPath, "--store", mkdtempSync(join(tmpdir(),"ace-leaf-locked-gen-")), "--allow-no-signature", "--lockfile", lockPath])).toBe(0);
+    const store = mkdtempSync(join(tmpdir(), "ace-leaf-locked-ok-"));
+    const code = await main(["install", pkgPath, "--store", store, "--allow-no-signature", "--lockfile", lockPath, "--locked"]);
+    expect(code).toBe(0);
+    expect(listInstalled(store).map((p)=>p.manifest.name)).toEqual(["leaf"]);
+  });
+
+  test("--locked leaf with NO lockfile → refused", async () => {
+    const { dir, pkgPath } = leafFixture();
+    const store = mkdtempSync(join(tmpdir(), "ace-leaf-locked-nolock-"));
+    const code = await main(["install", pkgPath, "--store", store, "--allow-no-signature", "--lockfile", join(dir, "missing.lock"), "--locked"]);
+    expect(code).toBe(1);
+    expect(listInstalled(store).length).toBe(0);
+  });
+});

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -1213,4 +1213,18 @@ describe("ace update (slice 5.4)", () => {
     expect(code).toBe(1);
     expect(existsSync(lockPath)).toBe(false);
   });
+
+  test("update treats non-array dependencies as a leaf (untrusted-JSON Array.isArray guard)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ace-update-nonarr-"));
+    // dependencies as a string must NOT route through solve (would iterate chars / crash);
+    // the Array.isArray guard routes it to the leaf path instead.
+    const pkg = { manifest: { format_version:1, name:"weird", version:"1.0.0", content_hash: h({ "f.txt":"v" }), dependencies: "notanarray" }, files: { "f.txt":"v" } };
+    const pkgPath = join(dir, "weird.json"); writeFileSync(pkgPath, JSON.stringify(pkg));
+    const lockPath = join(dir, "ace.lock");
+    const code = await main(["update", pkgPath, "--lockfile", lockPath, "--allow-no-signature"]);
+    expect(code).toBe(0);
+    const lf = parseLockfile(readFileSync(lockPath, "utf8"));
+    expect("error" in lf).toBe(false);
+    if (!("error" in lf)) expect(lf.nodes).toEqual([]);
+  });
 });

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -1124,3 +1124,80 @@ describe("leaf-install lockfiles (slice 5.4)", () => {
     expect(listInstalled(store).length).toBe(0);
   });
 });
+
+describe("parseArgs — update", () => {
+  test("update requires a source", () => {
+    expect("error" in parseArgs(["update"])).toBe(true);
+  });
+  test("update parses source + default lockfile", () => {
+    const a = parseArgs(["update", "pkg.json"]);
+    if ("command" in a && a.command === "update") { expect(a.source).toBe("pkg.json"); expect(a.lockfile).toBe("ace.lock"); }
+  });
+  test("update --lockfile override", () => {
+    const a = parseArgs(["update", "pkg.json", "--lockfile", "x.lock"]);
+    if ("command" in a && a.command === "update") expect(a.lockfile).toBe("x.lock");
+  });
+});
+
+describe("ace update (slice 5.4)", () => {
+  const h = (files: Record<string,string>) => "sha256:" + createHash("sha256").update(new TextEncoder().encode(JSON.stringify(files))).digest("hex");
+
+  test("update rewrites ./ace.lock to the freshly-solved graph + installs NOTHING", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ace-update-pkgs-"));
+    const A1 = { manifest: { format_version:1, name:"A", version:"1.0.0", content_hash: h({ "a.txt":"a1" }) }, files: { "a.txt":"a1" } };
+    const a1Path = join(dir, "A-1.0.0.json"); writeFileSync(a1Path, JSON.stringify(A1)); await main(["registry","add","A","1.0.0",a1Path]);
+    const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: h({ "r.txt":"r" }), dependencies:[{ kind:"registry" as const, name:"A", version:"^1.0.0" }] }, files: { "r.txt":"r" } };
+    const rootPath = join(dir, "root.json"); writeFileSync(rootPath, JSON.stringify(root));
+    const lockPath = join(dir, "ace.lock");
+    const genStore = mkdtempSync(join(tmpdir(), "ace-update-gen-"));
+    // 1. Normal install locks A@1.0.0.
+    expect(await main(["install", rootPath, "--store", genStore, "--allow-no-signature", "--lockfile", lockPath])).toBe(0);
+    const before = parseLockfile(readFileSync(lockPath, "utf8"));
+    expect("error" in before).toBe(false);
+    if (!("error" in before)) expect(before.nodes.map((n)=>`${n.name}@${n.version}`)).toEqual(["A@1.0.0"]);
+    const installedBefore = listInstalled(genStore).map((p)=>p.manifest.name).sort();
+    // 2. Add A@1.1.0 (in-range) → a fresh solve now picks A@1.1.0.
+    const A11 = { manifest: { format_version:1, name:"A", version:"1.1.0", content_hash: h({ "a.txt":"a11" }) }, files: { "a.txt":"a11" } };
+    const a11Path = join(dir, "A-1.1.0.json"); writeFileSync(a11Path, JSON.stringify(A11)); await main(["registry","add","A","1.1.0",a11Path]);
+    // 3. ace update → rewrites the lock to A@1.1.0, extracts NOTHING (no --store; gen-store unchanged).
+    const code = await main(["update", rootPath, "--lockfile", lockPath, "--allow-no-signature"]);
+    expect(code).toBe(0);
+    const after = parseLockfile(readFileSync(lockPath, "utf8"));
+    expect("error" in after).toBe(false);
+    if (!("error" in after)) {
+      expect(after.nodes.map((n)=>`${n.name}@${n.version}`)).toEqual(["A@1.1.0"]);
+      expect(after.nodes[0]!.package_hash).toBe(packageHash(A11 as any));
+    }
+    // The gen-store is unchanged — update never extracted A@1.1.0.
+    expect(listInstalled(genStore).map((p)=>p.manifest.name).sort()).toEqual(installedBefore);
+  });
+
+  test("update on a leaf writes an empty-nodes lock", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ace-update-leaf-"));
+    const pkg = { manifest: { format_version:1, name:"leaf", version:"1.0.0", content_hash: h({ "leaf.txt":"v1" }) }, files: { "leaf.txt":"v1" } };
+    const pkgPath = join(dir, "leaf.json"); writeFileSync(pkgPath, JSON.stringify(pkg));
+    const lockPath = join(dir, "ace.lock");
+    const code = await main(["update", pkgPath, "--lockfile", lockPath, "--allow-no-signature"]);
+    expect(code).toBe(0);
+    const lf = parseLockfile(readFileSync(lockPath, "utf8"));
+    expect("error" in lf).toBe(false);
+    if (!("error" in lf)) {
+      expect(lf.root.name).toBe("leaf");
+      expect(lf.root.package_hash).toBe(packageHash(pkg as any));
+      expect(lf.nodes).toEqual([]);
+    }
+  });
+
+  test("update refuses (no lock written) when a freshly-solved node fails preflight", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ace-update-bad-"));
+    // A dep with an unsafe file path → preflightGraph fails → no lock written (preflight-before-write).
+    const bad = { manifest: { format_version:1, name:"BAD", version:"1.0.0", content_hash: h({ "../escape":"x" }) }, files: { "../escape":"x" } };
+    const badPath = join(dir, "BAD.json"); writeFileSync(badPath, JSON.stringify(bad)); await main(["registry","add","BAD","1.0.0",badPath]);
+    const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: h({ "r.txt":"r" }), dependencies:[{ kind:"registry" as const, name:"BAD", version:"^1.0.0" }] }, files: { "r.txt":"r" } };
+    const rootPath = join(dir, "root.json"); writeFileSync(rootPath, JSON.stringify(root));
+    const lockPath = join(dir, "ace.lock");
+    const code = await main(["update", rootPath, "--lockfile", lockPath, "--allow-no-signature"]);
+    expect(code).toBe(1);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+});

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -202,6 +202,21 @@ describe("parseArgs — install lockfile flags", () => {
   });
 });
 
+describe("parseArgs — install --locked", () => {
+  test("--locked defaults off", () => {
+    const a = parseArgs(["install", "pkg.json"]);
+    if ("command" in a && a.command === "install") expect(a.locked).toBe(false);
+  });
+  test("--locked sets locked true", () => {
+    const a = parseArgs(["install", "pkg.json", "--locked"]);
+    if ("command" in a && a.command === "install") expect(a.locked).toBe(true);
+  });
+  test("--locked + --frozen is an error (mutually exclusive)", () => {
+    const a = parseArgs(["install", "pkg.json", "--locked", "--frozen"]);
+    expect("error" in a).toBe(true);
+  });
+});
+
 // ---- listInstalled ----
 
 describe("listInstalled", () => {

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -24,7 +24,7 @@ import {
 } from "./store";
 import { generateKeypair, signManifest, verifySignature, keyId } from "./signing";
 import { resolve, packageHash } from "./resolve.ts";
-import { buildLockfile, serializeLockfile, parseLockfile, verifyRootMatchesLock, lockfilesEqual } from "./lockfile.ts";
+import { buildLockfile, serializeLockfile, parseLockfile, verifyRootMatchesLock, lockfilesEqual, buildLeafLockfile } from "./lockfile.ts";
 import { solve } from "./solver.ts";
 import { resolve as toAbsolutePath } from "node:path";
 
@@ -645,6 +645,25 @@ export async function main(argv: readonly string[]): Promise<number> {
       return 0;
     }
 
+    // SLICE 5.4: leaf (no-dependency) install — uniform lockfile handling.
+    // --frozen: require an on-disk lock + a matching root before installing (drift gate).
+    // --locked: require the on-disk lock to equal a fresh leaf lock (CI guard).
+    // default: install, then write the trivial leaf lock (empty nodes).
+    if (parsed.frozen) {
+      let lockRaw: string;
+      try { lockRaw = readFileSync(parsed.lockfile, "utf8"); }
+      catch { console.error(`ace: install refused: no lockfile at ${parsed.lockfile} — run install without --frozen first`); return 1; }
+      const lf = parseLockfile(lockRaw);
+      if ("error" in lf) { console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${lf.error}`); return 1; }
+      if (!verifyRootMatchesLock(pkg, lf)) { console.error(`ace: install refused: lockfile out of date for ${pkg.manifest.name} — re-run without --frozen to regenerate`); return 1; }
+    } else if (parsed.locked) {
+      let lockRaw: string;
+      try { lockRaw = readFileSync(parsed.lockfile, "utf8"); }
+      catch { console.error(`ace: install refused: --locked but no lockfile at ${parsed.lockfile} — run 'ace update' or install without --locked`); return 1; }
+      const onDisk = parseLockfile(lockRaw);
+      if ("error" in onDisk) { console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${onDisk.error}`); return 1; }
+      if (!lockfilesEqual(onDisk, buildLeafLockfile(pkg))) { console.error(`ace: install refused: lockfile out of date (--locked) — run 'ace update' to regenerate`); return 1; }
+    }
     // INTEGRITY + extract (slice 2, unchanged)
     const result = installPackage(parsed.storePath, pkg);
     if (!result.ok) { console.error(`ace: install refused: ${result.error}`); return 1; }
@@ -653,6 +672,11 @@ export async function main(argv: readonly string[]): Promise<number> {
     } else {
       console.log(`ace: installed ${pkg.manifest.name}@${pkg.manifest.version} -> ${result.dir}`);
       console.log("ace: integrity-verified (content hash). NOT authenticity-verified (--allow-no-signature).");
+    }
+    // SLICE 5.4: default (non-frozen) path writes the trivial leaf lock; write failure is a warning.
+    if (!parsed.frozen) {
+      try { writeFileSync(parsed.lockfile, serializeLockfile(buildLeafLockfile(pkg))); }
+      catch (e) { console.error(`ace: WARNING: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`); }
     }
     return 0;
   }

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -45,6 +45,7 @@ interface InstallArgs {
   readonly allowNoSignature: boolean;
   readonly printResolution?: boolean;
   readonly frozen: boolean;
+  readonly locked: boolean;
   readonly lockfile: string;
 }
 
@@ -205,6 +206,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
     let allowNoSignature = false;
     let printResolution = false;
     let frozen = false;
+    let locked = false;
     let lockfilePath = "ace.lock";
     for (let i = 2; i < argv.length; i++) {
       if (argv[i] === "--store" || argv[i] === "-s") {
@@ -218,6 +220,8 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
         printResolution = true;
       } else if (argv[i] === "--frozen") {
         frozen = true;
+      } else if (argv[i] === "--locked") {
+        locked = true;
       } else if (argv[i] === "--lockfile") {
         const next = argv[++i];
         if (!next || next.startsWith("-")) return { error: "--lockfile requires a path argument" };
@@ -226,7 +230,8 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
         return { error: `Unknown option for install: ${argv[i]}` };
       }
     }
-    const baseResult: InstallArgs = { command: "install", source, storePath, allowNoSignature, frozen, lockfile: lockfilePath };
+    if (locked && frozen) return { error: "--locked and --frozen are mutually exclusive" };
+    const baseResult: InstallArgs = { command: "install", source, storePath, allowNoSignature, frozen, locked, lockfile: lockfilePath };
     if (printResolution) return { ...baseResult, printResolution: true };
     return baseResult;
   }

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -550,7 +550,11 @@ export async function main(argv: readonly string[]): Promise<number> {
       console.log(`ace: wrote lockfile ${parsed.lockfile} (${lf.nodes.length} deps)`);
       return 0;
     }
-    // Leaf: trivial lock.
+    // Leaf: trivial lock — preflight the single package before writing, so update never
+    // commits a lock for a package installPackage/--frozen would reject (parity with the
+    // graph path's preflightGraph; Codex #6416).
+    const leafUnsafe = validatePackagePaths(pkg);
+    if (leafUnsafe !== null) { console.error(`ace: update refused: unsafe file path in ${pkg.manifest.name}: ${leafUnsafe}`); return 1; }
     try { writeFileSync(parsed.lockfile, serializeLockfile(buildLeafLockfile(pkg))); }
     catch (e) { console.error(`ace: update failed: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`); return 1; }
     console.log(`ace: wrote lockfile ${parsed.lockfile} (0 deps)`);

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -3,7 +3,8 @@
 //
 // Usage:
 //   bun tools/ace/ace.ts list [--store <path>] [--json]
-//   bun tools/ace/ace.ts install <url-or-path> [--allow-no-signature] [--print-resolution]
+//   bun tools/ace/ace.ts install <url-or-path> [--allow-no-signature] [--print-resolution] [--frozen|--locked] [--lockfile <path>]
+//   bun tools/ace/ace.ts update <url-or-path> [--lockfile <path>] [--allow-no-signature]
 //   bun tools/ace/ace.ts verify <hash>
 //   bun tools/ace/ace.ts keygen [--out <prefix>]
 //   bun tools/ace/ace.ts sign <pkg> --key <priv.key> [--out <file>]
@@ -304,12 +305,15 @@ function printUsage(): void {
 
 Usage:
   ace list [--store <path>] [--json]             List installed DLC packages
-  ace install <url-or-path> [--allow-no-signature] [--print-resolution] [--frozen] [--lockfile <path>]
+  ace install <url-or-path> [--allow-no-signature] [--print-resolution] [--frozen|--locked] [--lockfile <path>]
                                                    Download/read a package, verify integrity+authenticity, install
                                                    --allow-no-signature only installs packages with NO signature; it never bypasses a present (bad or untrusted) signature
                                                    --print-resolution prints the solved name@version graph before installing
                                                    writes ./ace.lock on a normal install; --frozen installs exactly the locked graph (registry-independent)
+                                                   --locked asserts the committed lock is up to date vs a fresh solve, else refuses (CI guard; mutually exclusive with --frozen)
                                                    --lockfile <path> overrides the default lockfile path (default: ace.lock)
+  ace update <url-or-path> [--lockfile <path>] [--allow-no-signature]
+                                                   Re-solve the dependency graph and rewrite the lockfile; installs nothing (lock-only)
   ace verify <hash>                              Confirm an installed package is present
   ace keygen [--out <prefix>]                    Generate an Ed25519 keypair (writes <prefix>.key + <prefix>.pub)
   ace sign <pkg> --key <priv.key> [--out <file>] Sign a package manifest with an Ed25519 private key

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -88,6 +88,24 @@ interface ArgError {
   readonly error: string;
 }
 
+/** Integrity preflight over a resolved graph: per-node content_hash, path-safety, and
+ *  store-key (content_hash -> package_hash) collision. Returns null on success, or an
+ *  error message. Shared by `install` (before extract) and `update` (before lock write). */
+function preflightGraph(order: AcePackage[]): string | null {
+  const byStoreKey = new Map<string, string>(); // content_hash -> package_hash
+  for (const node of order) {
+    const fh = contentHash(new TextEncoder().encode(JSON.stringify(node.files)));
+    if (fh !== node.manifest.content_hash) return `bad-content-hash in ${node.manifest.name}`;
+    const unsafe = validatePackagePaths(node);
+    if (unsafe !== null) return `unsafe file path in ${node.manifest.name}: ${unsafe}`;
+    const ph = packageHash(node);
+    const prior = byStoreKey.get(node.manifest.content_hash);
+    if (prior !== undefined && prior !== ph) return `store-collision — ${node.manifest.name} shares a content_hash store key with a different package`;
+    byStoreKey.set(node.manifest.content_hash, ph);
+  }
+  return null;
+}
+
 export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
   const command = argv[0];
   if (!command || command === "help" || command === "--help" || command === "-h") {
@@ -587,21 +605,9 @@ export async function main(argv: readonly string[]): Promise<number> {
         return 1;
       }
       // PREFLIGHT (atomic): integrity + path-safety + store-key collision across the whole
-      // graph BEFORE any extract. content_hash is verified first (including the root, which
-      // the resolver does not re-check) so a tampered root cannot orphan already-extracted
-      // leaves.
-      const byStoreKey = new Map<string, string>(); // content_hash -> package_hash
-      for (const node of res.order) {
-        // D6 atomicity: verify every node's content_hash before any extraction (incl. root).
-        const fh = contentHash(new TextEncoder().encode(JSON.stringify(node.files)));
-        if (fh !== node.manifest.content_hash) { console.error(`ace: install refused: bad-content-hash in ${node.manifest.name}`); return 1; }
-        const unsafe = validatePackagePaths(node);
-        if (unsafe !== null) { console.error(`ace: install refused: unsafe file path in ${node.manifest.name}: ${unsafe}`); return 1; }
-        const ph = packageHash(node);
-        const prior = byStoreKey.get(node.manifest.content_hash);
-        if (prior !== undefined && prior !== ph) { console.error(`ace: install refused: store-collision — ${node.manifest.name} shares a content_hash store key with a different package`); return 1; }
-        byStoreKey.set(node.manifest.content_hash, ph);
-      }
+      // graph BEFORE any extract (shared with `update`'s before-write guard via preflightGraph).
+      const pf = preflightGraph(res.order);
+      if (pf !== null) { console.error(`ace: install refused: ${pf}`); return 1; }
       // EXTRACT all, leaves first.
       for (const node of res.order) {
         const out = installPackage(parsed.storePath, node);

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -74,6 +74,13 @@ interface TrustArgs {
   readonly label?: string;
 }
 
+interface UpdateArgs {
+  readonly command: "update";
+  readonly source: string;
+  readonly lockfile: string;
+  readonly allowNoSignature: boolean;
+}
+
 interface RegistryArgs {
   readonly command: "registry";
   readonly sub: "list" | "add";
@@ -83,7 +90,7 @@ interface RegistryArgs {
   readonly regHash?: string;
 }
 
-type ParsedArgs = ListArgs | HelpArgs | InstallArgs | VerifyArgs | KeygenArgs | SignArgs | TrustArgs | RegistryArgs;
+type ParsedArgs = ListArgs | HelpArgs | InstallArgs | VerifyArgs | KeygenArgs | SignArgs | TrustArgs | RegistryArgs | UpdateArgs;
 
 interface ArgError {
   readonly error: string;
@@ -197,6 +204,25 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
       return result;
     }
     return { error: "registry requires 'add' or 'list'" };
+  }
+
+  if (command === "update") {
+    const source = argv[1];
+    if (!source || source.startsWith("-")) return { error: "update requires a <url-or-path> argument" };
+    let lockfilePath = "ace.lock";
+    let allowNoSignature = false;
+    for (let i = 2; i < argv.length; i++) {
+      if (argv[i] === "--lockfile") {
+        const next = argv[++i];
+        if (!next || next.startsWith("-")) return { error: "--lockfile requires a path argument" };
+        lockfilePath = next;
+      } else if (argv[i] === "--allow-no-signature") {
+        allowNoSignature = true;
+      } else {
+        return { error: `Unknown option for update: ${argv[i]}` };
+      }
+    }
+    return { command: "update", source, lockfile: lockfilePath, allowNoSignature };
   }
 
   if (command === "install") {
@@ -479,6 +505,51 @@ export async function main(argv: readonly string[]): Promise<number> {
       console.log(`  ${pkg.manifest.name}@${pkg.manifest.version}${desc}`);
       console.log(`    hash: ${pkg.hash}`);
     }
+    return 0;
+  }
+
+  if (parsed.command === "update") {
+    let raw: string;
+    try {
+      raw = parsed.source.startsWith("http://") || parsed.source.startsWith("https://")
+        ? await (await fetch(parsed.source)).text() : readFileSync(parsed.source, "utf8");
+    } catch (e) { console.error(`ace: download/read failed: ${(e as Error).message}`); return 1; }
+    let pkg: AcePackage;
+    try { pkg = JSON.parse(raw) as AcePackage; } catch { console.error("ace: package is not valid JSON"); return 65; }
+    if (typeof pkg !== "object" || pkg === null || typeof pkg.manifest !== "object" || pkg.manifest === null || typeof pkg.files !== "object" || pkg.files === null) {
+      console.error("ace: update refused: not a well-formed AcePackage"); return 1;
+    }
+    // Signature gate (same policy as install): hard-refuse a present-but-invalid signature;
+    // no-signature is only overridable with --allow-no-signature.
+    const v = verifySignature(pkg.manifest, loadTrustStore());
+    if (!v.ok && v.reason !== "no-signature") { console.error(`ace: update refused: ${v.reason}`); return 1; }
+    if (!v.ok && v.reason === "no-signature" && !parsed.allowNoSignature) { console.error("ace: update refused: unsigned package (use --allow-no-signature)"); return 1; }
+    // Root content_hash.
+    const rootFilesHash = contentHash(new TextEncoder().encode(JSON.stringify(pkg.files)));
+    if (rootFilesHash !== pkg.manifest.content_hash) { console.error(`ace: update refused: bad-content-hash in ${pkg.manifest.name} (root)`); return 1; }
+
+    if (pkg.manifest.dependencies && pkg.manifest.dependencies.length > 0) {
+      const fetchPackage = async (u: string): Promise<string> =>
+        (u.startsWith("http://") || u.startsWith("https://")) ? await (await fetch(u)).text() : readFileSync(u, "utf8");
+      const registry = loadRegistry();
+      const solveResult = await solve(pkg, fetchPackage, registry);
+      if (!solveResult.ok) { console.error(`ace: update refused: ${solveResult.reason} — ${solveResult.detail} (path: ${solveResult.path.join(" → ")})`); return 1; }
+      const res = await resolve(pkg, fetchPackage, loadTrustStore(), registry, solveResult.versions, { allowNoSignature: parsed.allowNoSignature });
+      if (!res.ok) { console.error(`ace: update refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`); return 1; }
+      // Preflight BEFORE writing — never write a lock for a graph install would reject (Codex #6412).
+      const pf = preflightGraph(res.order);
+      if (pf !== null) { console.error(`ace: update refused: ${pf}`); return 1; }
+      const lf = buildLockfile(pkg, res.order, registry);
+      if ("error" in lf) { console.error(`ace: update refused: could not build lockfile: ${lf.error}`); return 1; }
+      try { writeFileSync(parsed.lockfile, serializeLockfile(lf)); }
+      catch (e) { console.error(`ace: update failed: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`); return 1; }
+      console.log(`ace: wrote lockfile ${parsed.lockfile} (${lf.nodes.length} deps)`);
+      return 0;
+    }
+    // Leaf: trivial lock.
+    try { writeFileSync(parsed.lockfile, serializeLockfile(buildLeafLockfile(pkg))); }
+    catch (e) { console.error(`ace: update failed: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`); return 1; }
+    console.log(`ace: wrote lockfile ${parsed.lockfile} (0 deps)`);
     return 0;
   }
 

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -24,7 +24,7 @@ import {
 } from "./store";
 import { generateKeypair, signManifest, verifySignature, keyId } from "./signing";
 import { resolve, packageHash } from "./resolve.ts";
-import { buildLockfile, serializeLockfile, parseLockfile, verifyRootMatchesLock } from "./lockfile.ts";
+import { buildLockfile, serializeLockfile, parseLockfile, verifyRootMatchesLock, lockfilesEqual } from "./lockfile.ts";
 import { solve } from "./solver.ts";
 import { resolve as toAbsolutePath } from "node:path";
 
@@ -608,6 +608,21 @@ export async function main(argv: readonly string[]): Promise<number> {
       if (!res.ok) {
         console.error(`ace: install refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`);
         return 1;
+      }
+      // SLICE 5.4: --locked — assert the committed lock equals a fresh solve, else refuse
+      // (CI guard; installs nothing). Falls through to the normal preflight+extract when it matches.
+      if (parsed.locked) {
+        let lockRaw: string;
+        try { lockRaw = readFileSync(parsed.lockfile, "utf8"); }
+        catch { console.error(`ace: install refused: --locked but no lockfile at ${parsed.lockfile} — run 'ace update' or install without --locked`); return 1; }
+        const onDisk = parseLockfile(lockRaw);
+        if ("error" in onDisk) { console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${onDisk.error}`); return 1; }
+        const fresh = buildLockfile(pkg, res.order, registry);
+        if ("error" in fresh) { console.error(`ace: install refused: could not build lockfile: ${fresh.error}`); return 1; }
+        if (!lockfilesEqual(onDisk, fresh)) {
+          console.error(`ace: install refused: lockfile out of date (--locked) — run 'ace update' to regenerate`);
+          return 1;
+        }
       }
       // PREFLIGHT (atomic): integrity + path-safety + store-key collision across the whole
       // graph BEFORE any extract (shared with `update`'s before-write guard via preflightGraph).

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -532,7 +532,7 @@ export async function main(argv: readonly string[]): Promise<number> {
     const rootFilesHash = contentHash(new TextEncoder().encode(JSON.stringify(pkg.files)));
     if (rootFilesHash !== pkg.manifest.content_hash) { console.error(`ace: update refused: bad-content-hash in ${pkg.manifest.name} (root)`); return 1; }
 
-    if (pkg.manifest.dependencies && pkg.manifest.dependencies.length > 0) {
+    if (Array.isArray(pkg.manifest.dependencies) && pkg.manifest.dependencies.length > 0) {
       const fetchPackage = async (u: string): Promise<string> =>
         (u.startsWith("http://") || u.startsWith("https://")) ? await (await fetch(u)).text() : readFileSync(u, "utf8");
       const registry = loadRegistry();
@@ -540,7 +540,7 @@ export async function main(argv: readonly string[]): Promise<number> {
       if (!solveResult.ok) { console.error(`ace: update refused: ${solveResult.reason} — ${solveResult.detail} (path: ${solveResult.path.join(" → ")})`); return 1; }
       const res = await resolve(pkg, fetchPackage, loadTrustStore(), registry, solveResult.versions, { allowNoSignature: parsed.allowNoSignature });
       if (!res.ok) { console.error(`ace: update refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`); return 1; }
-      // Preflight BEFORE writing — never write a lock for a graph install would reject (Codex #6412).
+      // Preflight BEFORE writing — never write a lock the graph install would reject (preflight-before-write per spec #6412, fix-forward #6414).
       const pf = preflightGraph(res.order);
       if (pf !== null) { console.error(`ace: update refused: ${pf}`); return 1; }
       const lf = buildLockfile(pkg, res.order, registry);
@@ -552,7 +552,7 @@ export async function main(argv: readonly string[]): Promise<number> {
     }
     // Leaf: trivial lock — preflight the single package before writing, so update never
     // commits a lock for a package installPackage/--frozen would reject (parity with the
-    // graph path's preflightGraph; Codex #6416).
+    // graph path's preflightGraph).
     const leafUnsafe = validatePackagePaths(pkg);
     if (leafUnsafe !== null) { console.error(`ace: update refused: unsafe file path in ${pkg.manifest.name}: ${leafUnsafe}`); return 1; }
     try { writeFileSync(parsed.lockfile, serializeLockfile(buildLeafLockfile(pkg))); }
@@ -603,7 +603,7 @@ export async function main(argv: readonly string[]): Promise<number> {
     }
 
     // SLICE 4: transitive graph. Leaf (no deps) falls through to the single-package path below (unchanged).
-    if (pkg.manifest.dependencies && pkg.manifest.dependencies.length > 0) {
+    if (Array.isArray(pkg.manifest.dependencies) && pkg.manifest.dependencies.length > 0) {
       // Verify root content_hash BEFORE resolving (no wasted graph fetch on a bad root).
       const rootFilesHash = contentHash(new TextEncoder().encode(JSON.stringify(pkg.files)));
       if (rootFilesHash !== pkg.manifest.content_hash) {

--- a/tools/ace/lockfile.test.ts
+++ b/tools/ace/lockfile.test.ts
@@ -98,3 +98,36 @@ describe("verifyRootMatchesLock", () => {
     expect(verifyRootMatchesLock(changed, lf)).toBe(false);
   });
 });
+
+import { lockfilesEqual, buildLeafLockfile } from "./lockfile.ts";
+
+describe("lockfilesEqual", () => {
+  const base: Lockfile = {
+    format_version: 1,
+    root: { name: "root", version: "1.0.0", package_hash: "sha256:r" },
+    nodes: [{ name: "A", version: "1.2.0", url: "u/A", package_hash: "sha256:a" }],
+  };
+  test("true for identical (incl. key-order-insensitive via canonical)", () => {
+    const clone: Lockfile = JSON.parse(JSON.stringify(base));
+    expect(lockfilesEqual(base, clone)).toBe(true);
+  });
+  test("false when a node version differs", () => {
+    const diff: Lockfile = { ...base, nodes: [{ ...base.nodes[0]!, version: "1.3.0" }] };
+    expect(lockfilesEqual(base, diff)).toBe(false);
+  });
+  test("false when root differs", () => {
+    const diff: Lockfile = { ...base, root: { ...base.root, package_hash: "sha256:other" } };
+    expect(lockfilesEqual(base, diff)).toBe(false);
+  });
+});
+
+describe("buildLeafLockfile", () => {
+  test("produces {format_version:1, root, nodes:[]} with the root package_hash", () => {
+    const files = { "f.txt": "leaf@1.0.0" };
+    const root = { manifest: { format_version: 1, name: "leaf", version: "1.0.0", content_hash: contentHash(new TextEncoder().encode(JSON.stringify(files))) }, files };
+    const lf = buildLeafLockfile(root);
+    expect(lf.format_version).toBe(1);
+    expect(lf.nodes).toEqual([]);
+    expect(lf.root).toEqual({ name: "leaf", version: "1.0.0", package_hash: packageHash(root) });
+  });
+});

--- a/tools/ace/lockfile.ts
+++ b/tools/ace/lockfile.ts
@@ -79,7 +79,7 @@ export function verifyRootMatchesLock(root: AcePackage, lf: Lockfile): boolean {
   return packageHash(root) === lf.root.package_hash;
 }
 
-/** True iff two lockfiles serialize identically (canonical JSON — key-order-insensitive). */
+/** True iff two lockfiles serialize identically. Canonical JSON normalizes object key order, but node array order IS significant — the same nodes in a different order are NOT equal. */
 export function lockfilesEqual(a: Lockfile, b: Lockfile): boolean {
   return serializeLockfile(a) === serializeLockfile(b);
 }

--- a/tools/ace/lockfile.ts
+++ b/tools/ace/lockfile.ts
@@ -78,3 +78,17 @@ export function parseLockfile(json: string): Lockfile | { error: string } {
 export function verifyRootMatchesLock(root: AcePackage, lf: Lockfile): boolean {
   return packageHash(root) === lf.root.package_hash;
 }
+
+/** True iff two lockfiles serialize identically (canonical JSON — key-order-insensitive). */
+export function lockfilesEqual(a: Lockfile, b: Lockfile): boolean {
+  return serializeLockfile(a) === serializeLockfile(b);
+}
+
+/** Lockfile for a no-dependency (leaf) root: the root identity + empty nodes. */
+export function buildLeafLockfile(root: AcePackage): Lockfile {
+  return {
+    format_version: 1,
+    root: { name: root.manifest.name, version: root.manifest.version, package_hash: packageHash(root) },
+    nodes: [],
+  };
+}


### PR DESCRIPTION
## Ace slice 5.4 — lockfile ergonomics (B-0973 / B-0974 / B-0975)

Builds on slice 5.3 (lockfile `--frozen`/`--lockfile`, merged #6410). All
**additive** — no solver change, no lock-format change (`format_version`
stays `1`). Spec #6412 (+ preflight fix-forward #6414, merged); plan
`0f2b0cff7`.

### What ships

1. **`ace update <root>`** (B-0973 core) — re-solve within ranges + rewrite
   `./ace.lock`, **lock-only** (never extracts / `installPackage`). Runs the
   **same integrity preflight as install** (content_hash + store-key
   collision + `validatePackagePaths` over the resolved graph) **before**
   writing the lock; lock write failure is a **hard error** (the whole point
   of `update` is the lock). Leaf root → writes a leaf lock.

2. **`ace install --locked`** (B-0974) — solve fresh, build the lockfile,
   compare against the on-disk lock via `lockfilesEqual`; **drift → refuse
   installing nothing** (`run ace update`); match → proceed through the
   existing preflight + extract. Mutually exclusive with `--frozen`
   (parse-time error). Distinct from `--frozen`: `--locked` *verifies the
   lock matches a fresh solve*; `--frozen` *replays the lock
   registry-independently*.

3. **Leaf-install lockfiles** (B-0975 leaf piece) — leaf (no-dep) installs
   now write a `buildLeafLockfile` (`nodes: []`); `--frozen` leaf reads +
   drift-gates the root; `--locked` leaf compares. Default leaf write is a
   warning (install already succeeded), matching the graph path.

### Preflight-before-write (per #6414)

`resolve()` succeeding ≠ safe to materialize — unsafe-path / store-collision
graphs can solve. So `ace update` preflights the resolved graph **before**
writing the lock, refusing to hand `--frozen` a lock that replays into an
unsafe state. This is the corrected design from Codex's #6412 review,
shipped to the spec on main via **#6414**.

### Verification

- `bun test tools/ace/` → **210 pass / 0 fail** (17 new: 11 lockfile helper
  + 6 ace integration), `bun --bun tsc --noEmit` → **0**, markdownlint clean,
  commit canary `git ls-tree HEAD | wc -l` = **67** throughout.
- Subagent-driven build (7 TDD tasks); each group spec- + quality-reviewed;
  final holistic review clean on correctness + scope (format unchanged,
  update never extracts, `--locked` refuses-without-installing,
  mutual-exclusion enforced at parse).

### Deferred (backlog)

B-0973 `--package <name>` single-bump · B-0975 alphabetical node ordering +
partial-merge · B-0971 remote registry (slice 6) · B-0972 single-fetch cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
