### PR TITLE
docs: present-tense docstrings + pronoun-free CONFLICT-RESOLUTION (two BUGS.md P2 closes)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -296,9 +296,11 @@ tempted to ship.
 - **Found:** round 20 by Rune
 - **Severity:** P2
 - **Symptom:** the registry and `CONFLICT-RESOLUTION.md` disagree on
-  the expert roster and on whether pronouns are declared. The
-  name-canon rule is pronoun-free; any residual pronoun phrasing
-  in `CONFLICT-RESOLUTION.md` should be removed.
+  the expert roster (the registry carries names; `CONFLICT-RESOLUTION`
+  lists mostly bare role-titles). The declared-pronoun half is
+  resolved — the `(she/her)` / `(he/him)` / `(they/them)` markers
+  have been removed from `CONFLICT-RESOLUTION.md` per the pronoun-free
+  name-canon. Roster reconciliation remains.
 - **Fix:** registry is canon for names; `CONFLICT-RESOLUTION`
   defers to it.
 

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -278,19 +278,6 @@ tempted to ship.
 
 ## P2 — nice to have
 
-### "Round-N fix" historical voice survivors in docstrings
-
-- **Sites:** `src/Core/FastCdc.fs:68`, `Residuated.fs:39`,
-  `Durability.fs:17`, `Durability.fs:33`, `Recursive.fs:211`,
-  `FeatureFlags.fs:43`
-- **Found:** round 20 by Rune
-- **Severity:** P2
-- **Symptom:** docstrings read as changelog
-  ("Round-17 fix", "Round-17 honesty note"). Rule says
-  current-state; history lives in `ROUND-HISTORY.md`.
-- **Fix:** rewrite each as present-tense description of the
-  invariant; move the historical note to `ROUND-HISTORY.md`.
-
 ### TECH-RADAR row for Bloom sits at Trial without a bench
 
 - **Site:** `docs/TECH-RADAR.md` (Bloom filter row)

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -296,12 +296,12 @@ tempted to ship.
 - **Found:** round 20 by Rune
 - **Severity:** P2
 - **Symptom:** the registry and `CONFLICT-RESOLUTION.md` disagree on
-  the expert roster (the registry carries names; `CONFLICT-RESOLUTION`
+  the expert roster (the registry carries names; `CONFLICT-RESOLUTION.md`
   lists mostly bare role-titles). The declared-pronoun half is
   resolved — the `(she/her)` / `(he/him)` / `(they/them)` markers
   have been removed from `CONFLICT-RESOLUTION.md` per the pronoun-free
   name-canon. Roster reconciliation remains.
-- **Fix:** registry is canon for names; `CONFLICT-RESOLUTION`
+- **Fix:** registry is canon for names; `CONFLICT-RESOLUTION.md`
   defers to it.
 
 ---

--- a/docs/CONFLICT-RESOLUTION.md
+++ b/docs/CONFLICT-RESOLUTION.md
@@ -88,31 +88,31 @@ the full roster + diversity notes. The name is how humans refer
 to them in conversation ("Kira flagged it"); the role title is
 how the skill system invokes them.
 
-**Storage Specialist — Zara (she/her)** — durability, storage format,
+**Storage Specialist — Zara** — durability, storage format,
 commit protocols. Advises on WDC patterns, checkpoints.
 Values correctness + performance; wary of premature wire-format
 commitment.
 
-**Algebra Owner (he/him)** — Z-set algebra, operator composition
+**Algebra Owner** — Z-set algebra, operator composition
 laws, residuated-lattice extensions. Values algebraic closure and
 composition; wary of engineering shortcuts that break laws.
 
-**Query Planner Specialist (she/her)** — `Plan.fs`, cost models,
+**Query Planner Specialist** — `Plan.fs`, cost models,
 operator ordering, SIMD / tensor intrinsics. Values measured
 speed and clarity; wary of unexplained magic.
 
-**Complexity Theory Reviewer (he/him)** — Big-O honesty across
+**Complexity Theory Reviewer** — Big-O honesty across
 the codebase. Values tight claims backed by proof or benchmark;
 wary of hand-waved asymptotics.
 
-**Threat Model Critic (she/her)** — `docs/security/`, STRIDE,
+**Threat Model Critic** — `docs/security/`, STRIDE,
 SDL. Values explicit adversary models; wary of "probably fine".
 
-**Paper Peer Reviewer (he/him)** — conference-PC-grade review of
+**Paper Peer Reviewer** — conference-PC-grade review of
 any claim that escapes the repo. Values scholarly honesty; wary
 of oversold contributions.
 
-**Maintainability Reviewer (they/them)** — long-horizon
+**Maintainability Reviewer** — long-horizon
 readability, naming, module shape, docstring discipline. Values
 a codebase a new contributor can understand in a week; wary of
 clever constructs that require tribal knowledge.
@@ -123,8 +123,8 @@ attacks). Works in an isolated context by design (see policy in
 skill file). Values defensive prompt design; wary of any payload
 that "wants" to be run.
 
-**Skill Tune-Up Ranker (he/him)** — keeps a running notebook of
-which skills most need improvement. Allowed to recommend himself.
+**Skill Tune-Up Ranker** — keeps a running notebook of
+which skills most need improvement. Allowed to self-recommend.
 
 **TECH-RADAR Owner** — maintains `docs/TECH-RADAR.md` and the
 Adopt/Trial/Assess/Hold ring discipline.

--- a/docs/CONFLICT-RESOLUTION.md
+++ b/docs/CONFLICT-RESOLUTION.md
@@ -83,10 +83,11 @@ When two specialists (or a specialist and a human) disagree:
 
 Every specialist below is advisory. Their reviews carry weight
 proportional to their domain expertise; none carry veto power.
-Each expert carries a name — see `docs/EXPERT-REGISTRY.md` for
-the full roster + diversity notes. The name is how humans refer
-to them in conversation ("Kira flagged it"); the role title is
-how the skill system invokes them.
+Each expert has a name in `docs/EXPERT-REGISTRY.md` (the full
+roster + diversity notes); the entries below list them by role
+title. The name is how humans refer to them in conversation
+("Kira flagged it"); the role title is how the skill system
+invokes them.
 
 **Storage Specialist — Zara** — durability, storage format,
 commit protocols. Advises on WDC patterns, checkpoints.

--- a/src/Core/Durability.fs
+++ b/src/Core/Durability.fs
@@ -14,7 +14,7 @@ open System.Threading
 /// definition in `docs/security/THREAT-MODEL.md` under the R
 /// (Repudiation) + the I (Information-disclosure) quadrants.
 ///
-/// Round-17 sketch. The `WitnessDurable` variant is a research
+/// The `WitnessDurable` variant is a research
 /// target — the protocol has not been specified yet and there is
 /// no in-tree paper draft. It's defined here as a skeleton so
 /// callers can type against it. The implementing
@@ -30,7 +30,7 @@ type DurabilityMode =
     /// fsync, ~50 kTPS with group commit. Correctness model: buffered
     /// durable linearizability (Izraelevitz DISC'16).
     ///
-    /// **Round-17 honesty note**: `createBackingStore` currently maps
+    /// **Honesty note:** `createBackingStore` currently maps
     /// this variant to the `OsBuffered` implementation because the
     /// per-`Save` fsync path hasn't shipped yet. Selecting this mode
     /// today gets `OsBuffered` semantics. The factory flags the

--- a/src/Core/FastCdc.fs
+++ b/src/Core/FastCdc.fs
@@ -63,13 +63,13 @@ module private Gear =
 /// Chunker that emits boundaries at content-defined offsets. Caller
 /// feeds bytes via `Push`; `TryTakeChunk` returns available chunks.
 ///
-/// **Complexity (round-17 fix):** `Push(n)` amortises to **O(n)**.
-/// The previous implementation restarted the scan from offset 0 on
-/// every `Push`, giving O(n²) when callers streamed bytes one small
-/// span at a time. The current implementation keeps a persistent
+/// **Complexity:** `Push(n)` amortises to **O(n)**.
+/// A naive implementation that restarted the scan from offset 0 on
+/// every `Push` would be O(n²) when callers stream bytes one small
+/// span at a time. This implementation keeps a persistent
 /// `scanCursor` and a persistent `hash` so each byte is Gear-hashed
 /// **exactly once** over the chunker's lifetime. Per-byte `Add` on
-/// a `ResizeArray` is also gone — the buffer is a raw `byte[]` with
+/// a `ResizeArray` is avoided too — the buffer is a raw `byte[]` with
 /// `Buffer.BlockCopy` append, and the emitted-chunk copy uses
 /// `Buffer.BlockCopy` instead of a byte-by-byte loop.
 [<Sealed>]

--- a/src/Core/Residuated.fs
+++ b/src/Core/Residuated.fs
@@ -36,15 +36,14 @@ open System.Threading.Tasks
 ///   - Retract to zero/negative → `SortedSet<'K>.Remove`
 ///   - Query current max → `SortedSet<'K>.Max`
 ///
-/// ## Round-17 fix
+/// ## Logarithmic retraction
 ///
-/// The previous revision maintained only the **top-2** keys and
-/// triggered a full O(n) scan of the integrated Z-set whenever the
-/// top value was fully retracted. It advertised "O(1) amortised"
-/// retraction, but adversarial retract-top workloads forced an O(n)
-/// scan on every tick — the claim was false. Harsh-critic round-16
-/// flagged this; this revision drops the top-2 cache entirely in
-/// favour of a SortedSet-backed store so **every** operation is
+/// A top-2-cache design (tracking only the **top-2** keys) would
+/// trigger a full O(n) scan of the integrated Z-set whenever the
+/// top value is fully retracted; adversarial retract-top workloads
+/// force that O(n) scan on every tick, so the "O(1) amortised"
+/// retraction such a design advertises is false. This implementation
+/// uses a SortedSet-backed store instead, so **every** operation is
 /// genuinely logarithmic, with no hidden linear-scan fallback.
 ///
 /// ## Wire it into a circuit


### PR DESCRIPTION
Two small, off-lane, clearly-correct doc/docstring cleanups closing (and scoping) `docs/BUGS.md` P2 entries. **Zero logic change** — `///` docstring comments + markdown only.

## Commit 1 — `cb71268` — Round-N changelog voice → present-tense docstrings

Closes the BUGS.md P2 *"Round-N fix historical voice survivors in docstrings"* entry. Repo rule: docstrings describe current-state invariants; round-history lives in `ROUND-HISTORY.md`.

- **FastCdc.fs** — dropped `(round-17 fix)` complexity tag; reframed "previous/current implementation" → present-tense "a naive impl would be O(n²) / this impl…" (design rationale kept, only changelog framing changed).
- **Residuated.fs** — `## Round-17 fix` heading → `## Logarithmic retraction`; present-tense "why SortedSet, not a top-2 cache".
- **Durability.fs ×2** — dropped `Round-17 sketch.`; `**Round-17 honesty note**` → `**Honesty note:**` (consistent with the already-present-tense honesty note later in the file).
- The two other cited sites (`Recursive.fs:211`, `FeatureFlags.fs:43`) had **no** round-N voice remaining repo-wide — already-resolved drift from the round-20 finding; verified, no edit.
- BUGS.md entry deleted per that file's fixed-entry discipline.

## Commit 2 — `607bb91` — pronoun-free CONFLICT-RESOLUTION.md

`docs/EXPERT-REGISTRY.md` name-canon is pronoun-free ("No declared pronouns. Names carry the identity. English prose pronouns in the skill body are normal writing"). CONFLICT-RESOLUTION.md still carried declared-pronoun markers `(she/her)` / `(he/him)` / `(they/them)` on 8 entries — the declared-pronoun field the canon forbids, present **nowhere else** (not in `.claude/agents/` or persona memory), so removal aligns with canon without erasing any identity declared elsewhere.

- Removed the 8 `(x/y)` markers.
- `Allowed to recommend himself.` → `Allowed to self-recommend.` (matches skill-expert "Self-recommendation allowed").
- BUGS.md entry **amended** (not deleted) — only the pronoun half is done; roster reconciliation (registry has names, CONFLICT-RESOLUTION lists bare role-titles) remains open.

## Notes
- ROUND-HISTORY.md not touched — no active round section to slot into without fabricating round-context; resolution narrative lives in commit messages.
- Authored from a phone-driven cloud session; tight diffs by design.

https://claude.ai/code/session_01JjZLtuWj1GXecSrTWfeqcq

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjZLtuWj1GXecSrTWfeqcq)_