### PR TITLE
fix(install): graceful apt-get update on unreachable third-party sources + resilience test

### DIFF
--- a/.github/workflows/docker-ubuntu-install-sh-test.yml
+++ b/.github/workflows/docker-ubuntu-install-sh-test.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-24.04
     # Cold build: full install.sh (mise toolchain + lean + jars) + ollama 1.2GB +
     # 398MB model pull. Generous bound for the first uncached run.
-    timeout-minutes: 40
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/tools/ci/dockerfiles/ubuntu-install-sh-test/Dockerfile
+++ b/tools/ci/dockerfiles/ubuntu-install-sh-test/Dockerfile
@@ -104,3 +104,32 @@ RUN set -eu; \
       echo "FAIL: 2nd run RE-PULLED the model — caching/idempotency regression (a re-run must reuse the on-disk model)"; exit 1; \
     fi; \
     echo "OK: 2nd run idempotent — ${MODEL} already present, zero re-pull"
+
+
+# Apt-source resilience assert (operator 2026-06-01: "as long as it's not silent
+# failure and the test catches the warning if it happens"). A third-party apt source
+# the host image shipped that we don't control must NOT abort the whole install —
+# linux.sh's `apt-get update` is graceful (warn + continue) while `apt-get install`
+# stays strict. Inject an unreachable source (`.invalid` TLD, RFC-2606 reserved →
+# guaranteed non-resolving, no real-network dependency), run install.sh, and ASSERT
+# BOTH per automated-tests-are-the-shield-assert-dont-skip.md: (a) it still exits 0
+# (graceful — pipefail did not abort), AND (b) the warning WAS emitted (NOT silent —
+# a graceful path that warned about nothing would be a false-green hole). The strict
+# half (a genuinely-missing NEEDED package still fails loudly) is preserved by the
+# unchanged `apt-get install` — its packages come from the reachable archive, so the
+# build's success also asserts the bogus source didn't poison real installs.
+RUN set -eu; \
+    SRC=/etc/apt/sources.list.d/zeta-unreachable-test.list; \
+    echo "deb [trusted=yes] https://zeta-unreachable.invalid/ubuntu noble main" > "$SRC"; \
+    echo "=== 3rd install.sh run (unreachable apt-source resilience) ==="; \
+    if ! ZETA_INSTALL_FULL=1 ./tools/setup/install.sh > /tmp/install-resilience.log 2>&1; then \
+      cat /tmp/install-resilience.log; \
+      rm -f "$SRC"; \
+      echo "FAIL: install.sh aborted on an unreachable third-party apt source (it must warn + continue)"; exit 1; \
+    fi; \
+    rm -f "$SRC"; \
+    cat /tmp/install-resilience.log; \
+    echo "=== resilience asserts ==="; \
+    grep -qF "apt-get update reported errors" /tmp/install-resilience.log \
+      || { echo "FAIL: graceful path took but emitted NO warning — silent failure is a shield hole"; exit 1; }; \
+    echo "OK: unreachable apt source warned + continued (graceful, not silent)"

--- a/tools/setup/linux.sh
+++ b/tools/setup/linux.sh
@@ -108,8 +108,16 @@ elif [ -f "$APT_MANIFEST" ]; then
     apt_update_rc=0
     apt_update_out="$($SUDO apt-get update -y 2>&1)" || apt_update_rc=$?
     printf '%s\n' "$apt_update_out"
+    # Use a here-string, NOT `printf ... | grep -q`: under `set -o pipefail`,
+    # `grep -q` exits on the first match → `printf` gets SIGPIPE (exit 141) →
+    # pipefail makes the whole pipeline return 141, so the `||` reads it as
+    # false and the warning is SUPPRESSED even though grep matched — a silent
+    # hole in exactly the exit-0 partial-source case this guard exists to
+    # surface (Codex P2 on PR #6419, discussion_r3334414817). A here-string has
+    # no upstream producer to receive SIGPIPE, so pipefail never trips it, and
+    # grep stays line-oriented so `^Err:` still anchors per-line.
     if [ "$apt_update_rc" -ne 0 ] \
-       || printf '%s' "$apt_update_out" | grep -qiE 'Failed to fetch|Some index files failed to download|^Err:'; then
+       || grep -qiE 'Failed to fetch|Some index files failed to download|^Err:' <<<"$apt_update_out"; then
       echo "⚠ apt-get update reported errors — likely an unreachable third-party" >&2
       echo "  source the host image shipped (not a Zeta manifest source). Continuing;" >&2
       echo "  the apt-get install below still asserts the packages we need are present." >&2

--- a/tools/setup/linux.sh
+++ b/tools/setup/linux.sh
@@ -105,23 +105,23 @@ elif [ -f "$APT_MANIFEST" ]; then
     # (warn + continue) while the install below stays STRICT — `apt-get install`
     # still fails loudly if a package we actually need is unavailable, so the
     # assert is preserved at install time rather than skipped to a false-green.
+    # STREAM the output live (a slow/retry-heavy mirror must not look hung —
+    # Copilot P1 on PR #6419) WHILE capturing it to a temp file for the
+    # partial-failure probe. `tee` consumes ALL of apt's output, so the
+    # SIGPIPE/pipefail hazard that ruled out `printf | grep -q` (Codex P2) does
+    # not apply here — the probe greps the FILE, not a pipe. Take apt's OWN exit
+    # from PIPESTATUS[0]; the pipeline's own status would be `tee`'s, masking
+    # apt. grep on the file stays line-oriented so `^Err:` still anchors per-line.
+    apt_log="$(mktemp)"
     apt_update_rc=0
-    apt_update_out="$($SUDO apt-get update -y 2>&1)" || apt_update_rc=$?
-    printf '%s\n' "$apt_update_out"
-    # Use a here-string, NOT `printf ... | grep -q`: under `set -o pipefail`,
-    # `grep -q` exits on the first match → `printf` gets SIGPIPE (exit 141) →
-    # pipefail makes the whole pipeline return 141, so the `||` reads it as
-    # false and the warning is SUPPRESSED even though grep matched — a silent
-    # hole in exactly the exit-0 partial-source case this guard exists to
-    # surface (Codex P2 on PR #6419, discussion_r3334414817). A here-string has
-    # no upstream producer to receive SIGPIPE, so pipefail never trips it, and
-    # grep stays line-oriented so `^Err:` still anchors per-line.
+    if $SUDO apt-get update -y 2>&1 | tee "$apt_log"; then :; else apt_update_rc="${PIPESTATUS[0]}"; fi
     if [ "$apt_update_rc" -ne 0 ] \
-       || grep -qiE 'Failed to fetch|Some index files failed to download|^Err:' <<<"$apt_update_out"; then
+       || grep -qiE 'Failed to fetch|Some index files failed to download|^Err:' "$apt_log"; then
       echo "⚠ apt-get update reported errors — likely an unreachable third-party" >&2
       echo "  source the host image shipped (not a Zeta manifest source). Continuing;" >&2
       echo "  the apt-get install below still asserts the packages we need are present." >&2
     fi
+    rm -f "$apt_log"
     # shellcheck disable=SC2086
     $SUDO apt-get install -y --no-install-recommends $PKGS
   else

--- a/tools/setup/linux.sh
+++ b/tools/setup/linux.sh
@@ -87,7 +87,22 @@ elif [ -f "$APT_MANIFEST" ]; then
     # Use sudo only when not already root (CI containers often run as root).
     SUDO=""
     if [ "$(id -u)" -ne 0 ]; then SUDO="sudo"; fi
-    $SUDO apt-get update -y
+    # `apt-get update` refreshes EVERY configured source, including any
+    # third-party PPAs the host image shipped that we don't control. Under
+    # `set -euo pipefail` a single unreachable source (e.g. a launchpad PPA
+    # returning 403 behind a restricted-network policy) aborts the whole
+    # install before any runtime tooling is set up. Per
+    # `.claude/rules/automated-tests-are-the-shield-assert-dont-skip.md`
+    # ("grace in the artifact, assert in the test"): keep the update GRACEFUL
+    # (warn + continue on partial-source failure) while the install below stays
+    # STRICT — `apt-get install` still fails loudly if a package we actually
+    # need is unavailable, so the assert is preserved at install time rather
+    # than skipped to a false-green.
+    if ! $SUDO apt-get update -y; then
+      echo "⚠ apt-get update reported errors — likely an unreachable third-party" >&2
+      echo "  source the host image shipped (not a Zeta manifest source). Continuing;" >&2
+      echo "  the apt-get install below still asserts the packages we need are present." >&2
+    fi
     # shellcheck disable=SC2086
     $SUDO apt-get install -y --no-install-recommends $PKGS
   else

--- a/tools/setup/linux.sh
+++ b/tools/setup/linux.sh
@@ -91,14 +91,25 @@ elif [ -f "$APT_MANIFEST" ]; then
     # third-party PPAs the host image shipped that we don't control. Under
     # `set -euo pipefail` a single unreachable source (e.g. a launchpad PPA
     # returning 403 behind a restricted-network policy) aborts the whole
-    # install before any runtime tooling is set up. Per
+    # install before any runtime tooling is set up.
+    #
+    # apt's EXIT CODE is an unreliable partial-failure signal: a signature/403
+    # error exits non-zero, but a DNS/connection failure on one source can exit
+    # 0 with only `W: Some index files failed to download` (Codex review on
+    # PR #6419, confirmed by docker-ubuntu-install-sh-test). So detect partial
+    # failure from BOTH the exit code AND the output, and warn in either case —
+    # otherwise a real third-party-source outage stays silent, which is the very
+    # failure this guard exists to surface. Per
     # `.claude/rules/automated-tests-are-the-shield-assert-dont-skip.md`
-    # ("grace in the artifact, assert in the test"): keep the update GRACEFUL
-    # (warn + continue on partial-source failure) while the install below stays
-    # STRICT — `apt-get install` still fails loudly if a package we actually
-    # need is unavailable, so the assert is preserved at install time rather
-    # than skipped to a false-green.
-    if ! $SUDO apt-get update -y; then
+    # ("grace in the artifact, assert in the test"): the update is GRACEFUL
+    # (warn + continue) while the install below stays STRICT — `apt-get install`
+    # still fails loudly if a package we actually need is unavailable, so the
+    # assert is preserved at install time rather than skipped to a false-green.
+    apt_update_rc=0
+    apt_update_out="$($SUDO apt-get update -y 2>&1)" || apt_update_rc=$?
+    printf '%s\n' "$apt_update_out"
+    if [ "$apt_update_rc" -ne 0 ] \
+       || printf '%s' "$apt_update_out" | grep -qiE 'Failed to fetch|Some index files failed to download|^Err:'; then
       echo "⚠ apt-get update reported errors — likely an unreachable third-party" >&2
       echo "  source the host image shipped (not a Zeta manifest source). Continuing;" >&2
       echo "  the apt-get install below still asserts the packages we need are present." >&2


### PR DESCRIPTION
## What

`tools/setup/linux.sh` ran `apt-get update -y` under `set -euo pipefail`, so **any single unreachable apt source aborts the entire install** before runtime tooling (mise/dotnet/bun) is set up — even when the failing source isn't ours.

## Why (empirical)

Surfaced live from a restricted-network cloud session: the host image shipped third-party PPAs (`deadsnakes`, `ondrej/php`) that nobody added, and the egress policy `403`s those PPA hosts. `apt-get update` → non-zero → `pipefail` → whole install dead. Zeta's own apt manifest is clean; the brittleness is that a non-essential, non-Zeta source failure is treated as fatal.

## Fix — *grace in the artifact, assert in the test*

Per [`automated-tests-are-the-shield-assert-dont-skip.md`](../blob/main/.claude/rules/automated-tests-are-the-shield-assert-dont-skip.md):

- **`apt-get update` is now graceful** — a partial-source failure prints a visible `⚠` warning to stderr (**not silent**) and continues.
- **`apt-get install` stays strict** — it still fails loudly if a package we actually need is unavailable, so the assert is preserved at install time, **not** skipped to a false-green.

## Test — the shield must cover the graceful path

`tools/ci/dockerfiles/ubuntu-install-sh-test/Dockerfile` gets a resilience-assert RUN (sibling to the existing idempotency assert):

- Injects an unreachable apt source (`.invalid` TLD — RFC-2606 reserved, deterministic non-resolve, **no real-network dependency**), runs `install.sh`, and asserts **BOTH**: (a) exit 0 (graceful — pipefail didn't abort), and (b) the `⚠` warning **was emitted** (not silent — a graceful path that warned about nothing would be a false-green hole).
- Workflow `timeout-minutes` 40→45 for the extra idempotent run.

## Verification

Locally, against the live 403 condition: guarded update fires the warning + continues (exit 0); the unchanged `apt-get install` still pulls needed packages from the reachable archive. (`dotnet` itself still can't install in *that* env — the egress policy also 403s the dotnet/github runtime endpoints — but that's the env, not this fix; this fix stops a non-essential source from bricking the whole graph.)

Doc/script only; `tools/setup/*.sh` is Rule-0-allowed (install-graph).

https://claude.ai/code/session_01JjZLtuWj1GXecSrTWfeqcq

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjZLtuWj1GXecSrTWfeqcq)_