### PR TITLE
feat(B-0164.1): add review-thread observation batch recorder

### DIFF
--- a/tools/hygiene/review-thread-observations.test.ts
+++ b/tools/hygiene/review-thread-observations.test.ts
@@ -9,6 +9,7 @@ import {
   loadObservationStore,
   parseArgs,
   recordReviewThreadObservation,
+  recordReviewThreadObservationBatch,
   writeObservationStore,
 } from "./review-thread-observations.ts";
 import type { ReviewThreadObservation } from "./divergence-shard.ts";
@@ -278,6 +279,35 @@ describe("recordReviewThreadObservation", () => {
       expect(result.compared).toBe(0);
       expect(result.filed).toEqual([]);
       expect(loadObservationStore(root).observations).toHaveLength(2);
+    });
+  });
+
+  test("records a batch and files disagreements against earlier batch items", () => {
+    withTempRoot((root) => {
+      const results = recordReviewThreadObservationBatch({
+        repoRoot: root,
+        observations: [
+          {
+            observedAt: TICK,
+            tick: TICK,
+            operativeAuthorization: AUTH,
+            observation: observation("otto", "resolve"),
+          },
+          {
+            observedAt: "2026-06-01T11:10:00Z",
+            tick: "2026-06-01T11:10:00Z",
+            operativeAuthorization: AUTH,
+            observation: observation("codex-loop", "needs-fix"),
+          },
+        ],
+      });
+
+      expect(results).toHaveLength(2);
+      expect(results[0]!.compared).toBe(0);
+      expect(results[1]!.compared).toBe(1);
+      expect(results[1]!.filed).toHaveLength(1);
+      expect(loadObservationStore(root).observations).toHaveLength(2);
+      expect(divergenceFiles(root)).toHaveLength(1);
     });
   });
 

--- a/tools/hygiene/review-thread-observations.ts
+++ b/tools/hygiene/review-thread-observations.ts
@@ -65,6 +65,20 @@ export interface RecordReviewThreadObservationInput {
   readonly fileDisagreement?: ReviewThreadDisagreementWriter;
 }
 
+export interface RecordReviewThreadObservationBatchItem {
+  readonly observedAt: string;
+  readonly tick: string;
+  readonly operativeAuthorization: string;
+  readonly observation: ReviewThreadObservation;
+}
+
+export interface RecordReviewThreadObservationBatchInput {
+  readonly repoRoot: string;
+  readonly storeRelPath?: string;
+  readonly fileDisagreement?: ReviewThreadDisagreementWriter;
+  readonly observations: ReadonlyArray<RecordReviewThreadObservationBatchItem>;
+}
+
 export interface FiledReviewThreadDisagreement {
   readonly prior: StoredReviewThreadObservation;
   readonly outcome: Extract<ReviewThreadShardOutcome, { readonly kind: "filed" }>;
@@ -453,6 +467,19 @@ export function recordReviewThreadObservation(
       noDisagreements,
     };
   });
+}
+
+export function recordReviewThreadObservationBatch(
+  input: RecordReviewThreadObservationBatchInput,
+): ReadonlyArray<RecordReviewThreadObservationResult> {
+  return input.observations.map((observationInput) =>
+    recordReviewThreadObservation({
+      repoRoot: input.repoRoot,
+      storeRelPath: input.storeRelPath,
+      fileDisagreement: input.fileDisagreement,
+      ...observationInput,
+    }),
+  );
 }
 
 function hasFlagValue(value: string | undefined): value is string {

--- a/tools/hygiene/review-thread-observations.ts
+++ b/tools/hygiene/review-thread-observations.ts
@@ -474,10 +474,10 @@ export function recordReviewThreadObservationBatch(
 ): ReadonlyArray<RecordReviewThreadObservationResult> {
   return input.observations.map((observationInput) =>
     recordReviewThreadObservation({
-      repoRoot: input.repoRoot,
-      ...(input.storeRelPath === undefined ? {} : { storeRelPath: input.storeRelPath }),
-      ...(input.fileDisagreement === undefined ? {} : { fileDisagreement: input.fileDisagreement }),
       ...observationInput,
+      repoRoot: input.repoRoot,
+      storeRelPath: input.storeRelPath ?? DEFAULT_OBSERVATION_STORE_REL_PATH,
+      fileDisagreement: input.fileDisagreement ?? fileReviewThreadDisagreement,
     }),
   );
 }

--- a/tools/hygiene/review-thread-observations.ts
+++ b/tools/hygiene/review-thread-observations.ts
@@ -475,8 +475,8 @@ export function recordReviewThreadObservationBatch(
   return input.observations.map((observationInput) =>
     recordReviewThreadObservation({
       repoRoot: input.repoRoot,
-      storeRelPath: input.storeRelPath,
-      fileDisagreement: input.fileDisagreement,
+      ...(input.storeRelPath === undefined ? {} : { storeRelPath: input.storeRelPath }),
+      ...(input.fileDisagreement === undefined ? {} : { fileDisagreement: input.fileDisagreement }),
       ...observationInput,
     }),
   );


### PR DESCRIPTION
## Summary
- add a batch wrapper around the B-0164.1 review-thread observation live caller
- let later observations in the same batch compare against earlier observations and file a divergence when conclusions differ
- cover the batch path with a focused Bun test

## Test
- bun test tools/hygiene/review-thread-observations.test.ts