### PR TITLE
feat(B-0976 slice 1): Bonsai-subset serializer — TS reference oracle (cross-language)

### DIFF
--- a/docs/backlog/P1/B-0976-self-evolving-saga-build-serialized-deferred-execution-bonsai-closure-resume-not-replay-temporal-grade-interface-rides-zset-ladder-aaron-2026-06-01.md
+++ b/docs/backlog/P1/B-0976-self-evolving-saga-build-serialized-deferred-execution-bonsai-closure-resume-not-replay-temporal-grade-interface-rides-zset-ladder-aaron-2026-06-01.md
@@ -115,8 +115,12 @@ stream = carrier; ℤ retraction = evolution + compensation.
 
 ## Acceptance / decomposition (slices)
 
-- [ ] Cross-language **Bonsai-subset serializer** (`{Context, Expression}`) +
+- 🚧 Cross-language **Bonsai-subset serializer** (`{Context, Expression}`) +
       golden-vector cross-verify (TS/F#/C#/Rust oracles), Nuqleon as .NET oracle.
+      **TS reference oracle ✅** (`src/Core.TypeScript/bonsai/` — weakly-typed /
+      reflection-omitted subset: const/param/lambda/binary/call/cond; canonical
+      byte-exact serialize + parse round-trip + `golden-vectors.json`; 30 tests).
+      **F#/C#/Rust oracles pending** (replay the shared golden vectors).
 - [ ] **Resume engine** — serialize closure + expr-tree; restore-not-replay;
       no-handles discipline enforced; non-determinism allowed.
 - [ ] **Context propagation** = OTel/IntrCtx — C#/TS AsyncLocal adapter + **F#

--- a/src/Core.TypeScript/bonsai/bonsai.test.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.test.ts
@@ -135,4 +135,19 @@ describe("Bonsai-subset — strict validation (the parse/construct conformance s
   it("parse rejects a bool literal carrying a non-boolean value", () => {
     expect(() => parse('{"v":1,"expr":{"kind":"const","value":{"t":"bool","v":1}}}')).toThrow();
   });
+
+  // Canonical-only: parse accepts the canonical byte form ONLY, so the advertised
+  // serialize∘parse fixed point holds and a non-canonical saga vector can't pass
+  // this oracle yet disagree on a peer oracle's byte-diff.
+  it("parse rejects a non-canonical vector carrying an unknown extra field", () => {
+    expect(() => parse('{"v":1,"expr":{"kind":"param","name":"x","extra":0}}')).toThrow();
+  });
+
+  it("parse rejects non-canonical whitespace (canonical form is whitespace-free)", () => {
+    expect(() => parse('{"v":1, "expr":{"kind":"param","name":"x"}}')).toThrow();
+  });
+
+  it("parse rejects non-canonical key order (canonical fixes kind/v first)", () => {
+    expect(() => parse('{"expr":{"kind":"param","name":"x"},"v":1}')).toThrow();
+  });
 });

--- a/src/Core.TypeScript/bonsai/bonsai.test.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.test.ts
@@ -1,0 +1,91 @@
+/**
+ * bonsai.test.ts — TS reference (oracle #1) for the Bonsai-subset serializer
+ * (B-0976 slice 1).
+ *
+ * Three duties (mirroring the algebra-ladder oracles):
+ *   1. **Canonical serialize is byte-exact** — `serialize(expr) === canonical`
+ *      for every shared golden vector (the cross-language parity lock the
+ *      F#/C#/Rust twins will also cast: same compact JSON, same fixed key order).
+ *   2. **`parse` round-trips** — `equals(parse(canonical), expr)` and
+ *      `serialize(parse(canonical)) === canonical` (the canonical string is the
+ *      fixed point).
+ *   3. **Structural laws** — `equals` is reflexive; `serialize ∘ parse ∘
+ *      serialize == serialize`; unknown kinds are rejected (no silent accept).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join as pathJoin } from "node:path";
+import { equals, type Expr, parse, serialize } from "./bonsai";
+
+interface GoldenCase {
+  readonly name: string;
+  readonly note: string;
+  readonly expr: Expr;
+  readonly canonical: string;
+}
+interface Golden {
+  readonly description: string;
+  readonly version: number;
+  readonly cases: readonly GoldenCase[];
+}
+
+const golden: Golden = JSON.parse(
+  readFileSync(pathJoin(import.meta.dir, "golden-vectors.json"), "utf8"),
+) as Golden;
+
+describe("Bonsai-subset — golden vectors (oracle #1 / parity lock)", () => {
+  it("the fixture is non-empty and version 1", () => {
+    expect(golden.version).toBe(1);
+    expect(golden.cases.length).toBeGreaterThan(0);
+  });
+
+  for (const c of golden.cases) {
+    it(`${c.name}: serialize(expr) is byte-exact canonical`, () => {
+      expect(serialize(c.expr)).toBe(c.canonical);
+    });
+
+    it(`${c.name}: parse(canonical) structurally equals expr`, () => {
+      expect(equals(parse(c.canonical), c.expr)).toBe(true);
+    });
+
+    it(`${c.name}: canonical is the serialize fixed point`, () => {
+      expect(serialize(parse(c.canonical))).toBe(c.canonical);
+    });
+  }
+});
+
+describe("Bonsai-subset — round-trip + structural laws", () => {
+  it("serialize ∘ parse ∘ serialize == serialize (every case)", () => {
+    for (const c of golden.cases) {
+      const once = serialize(c.expr);
+      expect(serialize(parse(once))).toBe(once);
+    }
+  });
+
+  it("equals is reflexive (every case)", () => {
+    for (const c of golden.cases) {
+      expect(equals(c.expr, c.expr)).toBe(true);
+    }
+  });
+
+  it("distinct cases are not equal (no false collisions)", () => {
+    const exprs = golden.cases.map((c) => c.expr);
+    for (let i = 0; i < exprs.length; i++) {
+      for (let j = i + 1; j < exprs.length; j++) {
+        // distinct canonical strings ⇒ must not be structurally equal
+        if (serialize(exprs[i]!) !== serialize(exprs[j]!)) {
+          expect(equals(exprs[i]!, exprs[j]!)).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("parse rejects an unknown node kind (no silent accept)", () => {
+    expect(() => parse('{"v":1,"expr":{"kind":"bogus"}}')).toThrow();
+  });
+
+  it("parse rejects an unsupported version", () => {
+    expect(() => parse('{"v":2,"expr":{"kind":"param","name":"x"}}')).toThrow();
+  });
+});

--- a/src/Core.TypeScript/bonsai/bonsai.test.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.test.ts
@@ -16,7 +16,7 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join as pathJoin } from "node:path";
-import { equals, type Expr, parse, serialize } from "./bonsai";
+import { cint, equals, type Expr, parse, serialize } from "./bonsai";
 
 interface GoldenCase {
   readonly name: string;
@@ -87,5 +87,52 @@ describe("Bonsai-subset — round-trip + structural laws", () => {
 
   it("parse rejects an unsupported version", () => {
     expect(() => parse('{"v":2,"expr":{"kind":"param","name":"x"}}')).toThrow();
+  });
+});
+
+describe("Bonsai-subset — strict validation (the parse/construct conformance surface)", () => {
+  it("cint rejects non-integer / NaN / Infinity (no silent truncation)", () => {
+    expect(() => cint(1.9)).toThrow();
+    expect(() => cint(Number.NaN)).toThrow();
+    expect(() => cint(Number.POSITIVE_INFINITY)).toThrow();
+  });
+
+  it("cint rejects integers outside the JS safe-integer range (no silent rounding)", () => {
+    expect(() => cint(2 ** 53)).toThrow(); // 2^53 is NOT a safe integer (MAX is 2^53 - 1)
+  });
+
+  it("parse rejects a non-integer int literal", () => {
+    expect(() => parse('{"v":1,"expr":{"kind":"const","value":{"t":"int","v":1.5}}}')).toThrow();
+  });
+
+  it("parse rejects an int beyond the safe-integer range (e.g. an int64 from another oracle)", () => {
+    expect(() => parse('{"v":1,"expr":{"kind":"const","value":{"t":"int","v":99999999999999999}}}')).toThrow();
+  });
+
+  it("parse rejects an unknown binary operator (e.g. div)", () => {
+    expect(() =>
+      parse('{"v":1,"expr":{"kind":"binary","op":"div","left":{"kind":"param","name":"a"},"right":{"kind":"param","name":"b"}}}'),
+    ).toThrow();
+  });
+
+  it("parse rejects non-array call args", () => {
+    expect(() => parse('{"v":1,"expr":{"kind":"call","fn":"f","args":"nope"}}')).toThrow();
+  });
+
+  it("parse rejects a null expr (deterministic Bonsai error, not a generic TypeError)", () => {
+    expect(() => parse('{"v":1,"expr":null}')).toThrow();
+  });
+
+  it("parse rejects a null const value", () => {
+    expect(() => parse('{"v":1,"expr":{"kind":"const","value":null}}')).toThrow();
+  });
+
+  it("parse rejects a non-object document", () => {
+    expect(() => parse("null")).toThrow();
+    expect(() => parse("42")).toThrow();
+  });
+
+  it("parse rejects a bool literal carrying a non-boolean value", () => {
+    expect(() => parse('{"v":1,"expr":{"kind":"const","value":{"t":"bool","v":1}}}')).toThrow();
   });
 });

--- a/src/Core.TypeScript/bonsai/bonsai.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.ts
@@ -1,0 +1,197 @@
+/**
+ * bonsai.ts — TS reference (oracle #1) for the **Bonsai-subset** expression-tree
+ * serializer (B-0976 slice 1), the cross-language serialization primitive the
+ * self-evolving-saga build needs ("serialize the deferred computation's
+ * expression tree").
+ *
+ * Named after Nuqleon **Bonsai** (Reaqtor's compact serializer for .NET
+ * expression trees). This is the **weakly-typed / reflection-info-omitted**
+ * mode — the cross-language-portable form (the same mode Bonsai uses when its
+ * trees are deserialized in native C++ or eval'd in JavaScript): kind-tagged
+ * nodes, no .NET type/assembly/member table. The full Nuqleon Bonsai stays the
+ * conformance oracle for the .NET-typed mode; this subset is what the
+ * TS/F#/C#/Rust oracles agree on byte-for-byte.
+ *
+ * The node set (the subset): `const` · `param` · `lambda` · `binary` · `call` ·
+ * `cond`. Enough to express a real deferred computation (e.g. a recursive
+ * factorial), small enough to cross-verify exactly.
+ *
+ * Canonical form (the cross-oracle byte-diff contract): `serialize` emits
+ * **compact JSON** (no whitespace) with a **fixed key order per node-kind**
+ * (`kind` first, then fields in declared order) and **integer-only** numeric
+ * literals (no floats — float formatting diverges across languages). Two oracles
+ * agree iff their `serialize` outputs are byte-identical, and `parse` round-trips
+ * (`serialize(parse(s)) === s`, `equals(parse(serialize(e)), e)`). String values
+ * use standard JSON escaping. Document wrapper: `{"v":1,"expr":<node>}`.
+ */
+
+/** A literal value — tagged so every oracle round-trips the type exactly. */
+export type ConstValue =
+  | { readonly t: "int"; readonly v: number } // integer only (no floats in the subset)
+  | { readonly t: "str"; readonly v: string }
+  | { readonly t: "bool"; readonly v: boolean }
+  | { readonly t: "null" };
+
+/** The language-agnostic binary operators in the subset. */
+export type BinOp = "add" | "sub" | "mul" | "eq" | "lt" | "and" | "or";
+
+/** A Bonsai-subset expression node (kind-tagged discriminated union). */
+export type Expr =
+  | { readonly kind: "const"; readonly value: ConstValue }
+  | { readonly kind: "param"; readonly name: string }
+  | { readonly kind: "lambda"; readonly params: readonly string[]; readonly body: Expr }
+  | { readonly kind: "binary"; readonly op: BinOp; readonly left: Expr; readonly right: Expr }
+  | { readonly kind: "call"; readonly fn: string; readonly args: readonly Expr[] }
+  | { readonly kind: "cond"; readonly test: Expr; readonly then: Expr; readonly else: Expr };
+
+/** The serialization format version (the `v` field of the document wrapper). */
+export const BONSAI_VERSION = 1;
+
+// ---- constructors (ergonomic builders; optional) ---------------------------
+
+/** A literal-int constant. */
+export const cint = (v: number): Expr => ({ kind: "const", value: { t: "int", v: Math.trunc(v) } });
+/** A literal-string constant. */
+export const cstr = (v: string): Expr => ({ kind: "const", value: { t: "str", v } });
+/** A literal-bool constant. */
+export const cbool = (v: boolean): Expr => ({ kind: "const", value: { t: "bool", v } });
+/** The null constant. */
+export const cnull = (): Expr => ({ kind: "const", value: { t: "null" } });
+/** A parameter (variable) reference. */
+export const param = (name: string): Expr => ({ kind: "param", name });
+/** A lambda abstraction. */
+export const lambda = (params: readonly string[], body: Expr): Expr => ({ kind: "lambda", params, body });
+/** A binary operation. */
+export const binary = (op: BinOp, left: Expr, right: Expr): Expr => ({ kind: "binary", op, left, right });
+/** A named function application. */
+export const call = (fn: string, args: readonly Expr[]): Expr => ({ kind: "call", fn, args });
+/** A conditional (`if test then then else else`). */
+export const cond = (test: Expr, then: Expr, els: Expr): Expr => ({ kind: "cond", test, then, else: els });
+
+// ---- serialize (canonical, byte-exact) ------------------------------------
+
+/** Emit a constant value in canonical compact form (`t` first, then `v`). */
+function emitConst(c: ConstValue): string {
+  switch (c.t) {
+    case "int":
+      return `{"t":"int","v":${Math.trunc(c.v)}}`;
+    case "str":
+      return `{"t":"str","v":${JSON.stringify(c.v)}}`;
+    case "bool":
+      return `{"t":"bool","v":${c.v ? "true" : "false"}}`;
+    case "null":
+      return `{"t":"null"}`;
+  }
+}
+
+/** Emit a node in canonical compact form (fixed key order per kind). */
+function emit(e: Expr): string {
+  switch (e.kind) {
+    case "const":
+      return `{"kind":"const","value":${emitConst(e.value)}}`;
+    case "param":
+      return `{"kind":"param","name":${JSON.stringify(e.name)}}`;
+    case "lambda":
+      return `{"kind":"lambda","params":[${e.params.map((p) => JSON.stringify(p)).join(",")}],"body":${emit(e.body)}}`;
+    case "binary":
+      return `{"kind":"binary","op":${JSON.stringify(e.op)},"left":${emit(e.left)},"right":${emit(e.right)}}`;
+    case "call":
+      return `{"kind":"call","fn":${JSON.stringify(e.fn)},"args":[${e.args.map(emit).join(",")}]}`;
+    case "cond":
+      return `{"kind":"cond","test":${emit(e.test)},"then":${emit(e.then)},"else":${emit(e.else)}}`;
+  }
+}
+
+/** Serialize an expression to the canonical Bonsai-subset string. */
+export function serialize(e: Expr): string {
+  return `{"v":${BONSAI_VERSION},"expr":${emit(e)}}`;
+}
+
+// ---- parse (canonical string -> Expr) -------------------------------------
+
+/** Rebuild a `ConstValue` from parsed JSON (validating the tag). */
+function parseConst(n: unknown): ConstValue {
+  const o = n as Record<string, unknown>;
+  switch (o.t) {
+    case "int":
+      return { t: "int", v: Math.trunc(o.v as number) };
+    case "str":
+      return { t: "str", v: o.v as string };
+    case "bool":
+      return { t: "bool", v: o.v as boolean };
+    case "null":
+      return { t: "null" };
+    default:
+      throw new Error(`bonsai: unknown const tag: ${String(o.t)}`);
+  }
+}
+
+/** Rebuild an `Expr` from parsed JSON (validating the kind). */
+function parseNode(n: unknown): Expr {
+  const o = n as Record<string, unknown>;
+  switch (o.kind) {
+    case "const":
+      return { kind: "const", value: parseConst(o.value) };
+    case "param":
+      return { kind: "param", name: o.name as string };
+    case "lambda":
+      return { kind: "lambda", params: o.params as string[], body: parseNode(o.body) };
+    case "binary":
+      return { kind: "binary", op: o.op as BinOp, left: parseNode(o.left), right: parseNode(o.right) };
+    case "call":
+      return { kind: "call", fn: o.fn as string, args: (o.args as unknown[]).map(parseNode) };
+    case "cond":
+      return { kind: "cond", test: parseNode(o.test), then: parseNode(o.then), else: parseNode(o.else) };
+    default:
+      throw new Error(`bonsai: unknown node kind: ${String(o.kind)}`);
+  }
+}
+
+/** Parse a canonical Bonsai-subset string back to an `Expr`. */
+export function parse(s: string): Expr {
+  const doc = JSON.parse(s) as { v?: number; expr?: unknown };
+  if (doc.v !== BONSAI_VERSION) {
+    throw new Error(`bonsai: unsupported version ${String(doc.v)} (expected ${BONSAI_VERSION})`);
+  }
+  return parseNode(doc.expr);
+}
+
+// ---- structural equality --------------------------------------------------
+
+function constEquals(a: ConstValue, b: ConstValue): boolean {
+  if (a.t !== b.t) return false;
+  if (a.t === "null") return true;
+  // a.t === b.t and not null ⇒ both carry a `v`
+  return (a as { v: unknown }).v === (b as { v: unknown }).v;
+}
+
+/** Structural equality of two expressions (the canonical-form equality). */
+export function equals(a: Expr, b: Expr): boolean {
+  if (a.kind !== b.kind) return false;
+  switch (a.kind) {
+    case "const":
+      return constEquals(a.value, (b as Extract<Expr, { kind: "const" }>).value);
+    case "param":
+      return a.name === (b as Extract<Expr, { kind: "param" }>).name;
+    case "lambda": {
+      const bb = b as Extract<Expr, { kind: "lambda" }>;
+      return (
+        a.params.length === bb.params.length &&
+        a.params.every((p, i) => p === bb.params[i]) &&
+        equals(a.body, bb.body)
+      );
+    }
+    case "binary": {
+      const bb = b as Extract<Expr, { kind: "binary" }>;
+      return a.op === bb.op && equals(a.left, bb.left) && equals(a.right, bb.right);
+    }
+    case "call": {
+      const bb = b as Extract<Expr, { kind: "call" }>;
+      return a.fn === bb.fn && a.args.length === bb.args.length && a.args.every((x, i) => equals(x, bb.args[i]!));
+    }
+    case "cond": {
+      const bb = b as Extract<Expr, { kind: "cond" }>;
+      return equals(a.test, bb.test) && equals(a.then, bb.then) && equals(a.else, bb.else);
+    }
+  }
+}

--- a/src/Core.TypeScript/bonsai/bonsai.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.ts
@@ -205,13 +205,28 @@ function parseNode(n: unknown): Expr {
   }
 }
 
-/** Parse a canonical Bonsai-subset string back to an `Expr` — strict. */
+/**
+ * Parse a canonical Bonsai-subset string back to an `Expr` — strict and
+ * **canonical-only**. Accepts the canonical byte form ONLY: a structurally-valid
+ * but non-canonical vector (extra fields, whitespace, reordered keys) is rejected
+ * rather than silently canonicalized. This enforces the advertised `serialize ∘
+ * parse` fixed point as a precondition — without it, `serialize(parse(s)) !== s`
+ * for such `s`, and a non-canonical saga vector could pass this oracle yet fail a
+ * peer oracle's byte-diff (the very invariant the cross-language oracles exist to
+ * guarantee).
+ */
 export function parse(s: string): Expr {
   const doc = asObject(JSON.parse(s), "document");
   if (doc.v !== BONSAI_VERSION) {
     throw new Error(`bonsai: unsupported version ${String(doc.v)} (expected ${BONSAI_VERSION})`);
   }
-  return parseNode(doc.expr);
+  const result = parseNode(doc.expr);
+  // Canonical-only guard: the round-trip must reproduce the input byte-for-byte.
+  const round = serialize(result);
+  if (round !== s) {
+    throw new Error(`bonsai: input is not in canonical form (serialize(parse(s)) !== s)`);
+  }
+  return result;
 }
 
 // ---- structural equality --------------------------------------------------

--- a/src/Core.TypeScript/bonsai/bonsai.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.ts
@@ -47,10 +47,58 @@ export type Expr =
 /** The serialization format version (the `v` field of the document wrapper). */
 export const BONSAI_VERSION = 1;
 
+// ---- validation helpers (construct + parse are strict conformance surfaces) -
+
+/** The valid binary operators, as a set for O(1) membership validation. */
+const BIN_OPS: ReadonlySet<string> = new Set<BinOp>(["add", "sub", "mul", "eq", "lt", "and", "or"]);
+
+/**
+ * Validate a value is a finite, JS-**safe** integer — the v1 `int` domain. An
+ * int64 from a C#/Rust oracle beyond 2^53 is REJECTED, not silently rounded,
+ * and a fractional / NaN / Infinity / non-number is rejected, not truncated —
+ * keeping the cross-language byte contract exact (a value TS cannot represent
+ * exactly must not be silently rewritten). A future v2 could widen ints to
+ * bigint/string; v1 is the safe-integer range.
+ */
+function asSafeInt(v: unknown, where: string): number {
+  if (typeof v !== "number" || !Number.isSafeInteger(v)) {
+    throw new Error(`bonsai: ${where} expects a safe integer, got ${typeof v === "number" ? String(v) : typeof v}`);
+  }
+  return v;
+}
+
+/** Validate a value is a non-null, non-array object. */
+function asObject(v: unknown, where: string): Record<string, unknown> {
+  if (typeof v !== "object" || v === null || Array.isArray(v)) {
+    const got = v === null ? "null" : Array.isArray(v) ? "array" : typeof v;
+    throw new Error(`bonsai: ${where} expects an object, got ${got}`);
+  }
+  return v as Record<string, unknown>;
+}
+
+/** Validate a value is a string. */
+function asString(v: unknown, where: string): string {
+  if (typeof v !== "string") throw new Error(`bonsai: ${where} expects a string, got ${typeof v}`);
+  return v;
+}
+
+/** Validate a value is an array. */
+function asArray(v: unknown, where: string): unknown[] {
+  if (!Array.isArray(v)) throw new Error(`bonsai: ${where} expects an array, got ${typeof v}`);
+  return v;
+}
+
+/** Validate a value is one of the known binary operators. */
+function asBinOp(v: unknown, where: string): BinOp {
+  const s = asString(v, where);
+  if (!BIN_OPS.has(s)) throw new Error(`bonsai: ${where} unknown binary operator: ${s}`);
+  return s as BinOp;
+}
+
 // ---- constructors (ergonomic builders; optional) ---------------------------
 
-/** A literal-int constant. */
-export const cint = (v: number): Expr => ({ kind: "const", value: { t: "int", v: Math.trunc(v) } });
+/** A literal-int constant. Rejects non-safe-integer / fractional / NaN / Infinity. */
+export const cint = (v: number): Expr => ({ kind: "const", value: { t: "int", v: asSafeInt(v, "cint") } });
 /** A literal-string constant. */
 export const cstr = (v: string): Expr => ({ kind: "const", value: { t: "str", v } });
 /** A literal-bool constant. */
@@ -74,7 +122,9 @@ export const cond = (test: Expr, then: Expr, els: Expr): Expr => ({ kind: "cond"
 function emitConst(c: ConstValue): string {
   switch (c.t) {
     case "int":
-      return `{"t":"int","v":${Math.trunc(c.v)}}`;
+      // Safe integers always stringify to plain digits (no exponent), so the
+      // emitted bytes are reproducible across oracles; reject anything else.
+      return `{"t":"int","v":${asSafeInt(c.v, "emit int")}}`;
     case "str":
       return `{"t":"str","v":${JSON.stringify(c.v)}}`;
     case "bool":
@@ -109,16 +159,19 @@ export function serialize(e: Expr): string {
 
 // ---- parse (canonical string -> Expr) -------------------------------------
 
-/** Rebuild a `ConstValue` from parsed JSON (validating the tag). */
+/** Rebuild a `ConstValue` from parsed JSON — strict (validates tag + value type). */
 function parseConst(n: unknown): ConstValue {
-  const o = n as Record<string, unknown>;
+  const o = asObject(n, "const value");
   switch (o.t) {
     case "int":
-      return { t: "int", v: Math.trunc(o.v as number) };
+      return { t: "int", v: asSafeInt(o.v, "const int value") };
     case "str":
-      return { t: "str", v: o.v as string };
+      return { t: "str", v: asString(o.v, "const str value") };
     case "bool":
-      return { t: "bool", v: o.v as boolean };
+      if (typeof o.v !== "boolean") {
+        throw new Error(`bonsai: const bool value expects a boolean, got ${typeof o.v}`);
+      }
+      return { t: "bool", v: o.v };
     case "null":
       return { t: "null" };
     default:
@@ -126,30 +179,35 @@ function parseConst(n: unknown): ConstValue {
   }
 }
 
-/** Rebuild an `Expr` from parsed JSON (validating the kind). */
+/** Rebuild an `Expr` from parsed JSON — strict (validates shape, kind, fields). */
 function parseNode(n: unknown): Expr {
-  const o = n as Record<string, unknown>;
-  switch (o.kind) {
+  const o = asObject(n, "node");
+  const kind = asString(o.kind, "node.kind");
+  switch (kind) {
     case "const":
       return { kind: "const", value: parseConst(o.value) };
     case "param":
-      return { kind: "param", name: o.name as string };
+      return { kind: "param", name: asString(o.name, "param.name") };
     case "lambda":
-      return { kind: "lambda", params: o.params as string[], body: parseNode(o.body) };
+      return {
+        kind: "lambda",
+        params: asArray(o.params, "lambda.params").map((p) => asString(p, "lambda.params[]")),
+        body: parseNode(o.body),
+      };
     case "binary":
-      return { kind: "binary", op: o.op as BinOp, left: parseNode(o.left), right: parseNode(o.right) };
+      return { kind: "binary", op: asBinOp(o.op, "binary.op"), left: parseNode(o.left), right: parseNode(o.right) };
     case "call":
-      return { kind: "call", fn: o.fn as string, args: (o.args as unknown[]).map(parseNode) };
+      return { kind: "call", fn: asString(o.fn, "call.fn"), args: asArray(o.args, "call.args").map(parseNode) };
     case "cond":
       return { kind: "cond", test: parseNode(o.test), then: parseNode(o.then), else: parseNode(o.else) };
     default:
-      throw new Error(`bonsai: unknown node kind: ${String(o.kind)}`);
+      throw new Error(`bonsai: unknown node kind: ${kind}`);
   }
 }
 
-/** Parse a canonical Bonsai-subset string back to an `Expr`. */
+/** Parse a canonical Bonsai-subset string back to an `Expr` — strict. */
 export function parse(s: string): Expr {
-  const doc = JSON.parse(s) as { v?: number; expr?: unknown };
+  const doc = asObject(JSON.parse(s), "document");
   if (doc.v !== BONSAI_VERSION) {
     throw new Error(`bonsai: unsupported version ${String(doc.v)} (expected ${BONSAI_VERSION})`);
   }

--- a/src/Core.TypeScript/bonsai/golden-vectors.json
+++ b/src/Core.TypeScript/bonsai/golden-vectors.json
@@ -1,0 +1,172 @@
+{
+  "description": "Bonsai-subset expression-tree serializer — cross-language conformance (B-0976 slice 1). The weakly-typed / reflection-info-omitted mode of Nuqleon Bonsai: kind-tagged nodes (const/param/lambda/binary/call/cond), no .NET type table — the cross-language-portable form. Canonical form (the cross-oracle byte-diff contract): serialize emits COMPACT JSON (no whitespace) with a FIXED key order per node-kind (kind first, then fields in declared order), integer-only numeric literals (no floats), standard JSON string escaping, document wrapper {\"v\":1,\"expr\":<node>}. Each oracle (TS reference here; F#/C#/Rust replay) must: (1) serialize(expr) === canonical (byte-identical), and (2) equals(parse(canonical), expr) (round-trip). Mirrors the algebra-ladder meet-in-the-middle discipline — the compilers do not lie; agreement IS the verification.",
+  "version": 1,
+  "cases": [
+    {
+      "name": "const_int",
+      "note": "integer literal",
+      "expr": {
+        "kind": "const",
+        "value": {
+          "t": "int",
+          "v": 42
+        }
+      },
+      "canonical": "{\"v\":1,\"expr\":{\"kind\":\"const\",\"value\":{\"t\":\"int\",\"v\":42}}}"
+    },
+    {
+      "name": "const_str",
+      "note": "string literal (JSON-escaped value)",
+      "expr": {
+        "kind": "const",
+        "value": {
+          "t": "str",
+          "v": "hi"
+        }
+      },
+      "canonical": "{\"v\":1,\"expr\":{\"kind\":\"const\",\"value\":{\"t\":\"str\",\"v\":\"hi\"}}}"
+    },
+    {
+      "name": "const_bool",
+      "note": "bool literal",
+      "expr": {
+        "kind": "const",
+        "value": {
+          "t": "bool",
+          "v": true
+        }
+      },
+      "canonical": "{\"v\":1,\"expr\":{\"kind\":\"const\",\"value\":{\"t\":\"bool\",\"v\":true}}}"
+    },
+    {
+      "name": "const_null",
+      "note": "null literal (no v field — canonical)",
+      "expr": {
+        "kind": "const",
+        "value": {
+          "t": "null"
+        }
+      },
+      "canonical": "{\"v\":1,\"expr\":{\"kind\":\"const\",\"value\":{\"t\":\"null\"}}}"
+    },
+    {
+      "name": "param",
+      "note": "a bare parameter reference",
+      "expr": {
+        "kind": "param",
+        "name": "x"
+      },
+      "canonical": "{\"v\":1,\"expr\":{\"kind\":\"param\",\"name\":\"x\"}}"
+    },
+    {
+      "name": "lambda_add",
+      "note": "(x, y) => x + y",
+      "expr": {
+        "kind": "lambda",
+        "params": [
+          "x",
+          "y"
+        ],
+        "body": {
+          "kind": "binary",
+          "op": "add",
+          "left": {
+            "kind": "param",
+            "name": "x"
+          },
+          "right": {
+            "kind": "param",
+            "name": "y"
+          }
+        }
+      },
+      "canonical": "{\"v\":1,\"expr\":{\"kind\":\"lambda\",\"params\":[\"x\",\"y\"],\"body\":{\"kind\":\"binary\",\"op\":\"add\",\"left\":{\"kind\":\"param\",\"name\":\"x\"},\"right\":{\"kind\":\"param\",\"name\":\"y\"}}}}"
+    },
+    {
+      "name": "call_empty_args",
+      "note": "true && p() — call with zero args",
+      "expr": {
+        "kind": "binary",
+        "op": "and",
+        "left": {
+          "kind": "const",
+          "value": {
+            "t": "bool",
+            "v": true
+          }
+        },
+        "right": {
+          "kind": "call",
+          "fn": "p",
+          "args": []
+        }
+      },
+      "canonical": "{\"v\":1,\"expr\":{\"kind\":\"binary\",\"op\":\"and\",\"left\":{\"kind\":\"const\",\"value\":{\"t\":\"bool\",\"v\":true}},\"right\":{\"kind\":\"call\",\"fn\":\"p\",\"args\":[]}}}"
+    },
+    {
+      "name": "factorial",
+      "note": "(n) => if n < 2 then 1 else n * fact(n-1) — cond + recursive call",
+      "expr": {
+        "kind": "lambda",
+        "params": [
+          "n"
+        ],
+        "body": {
+          "kind": "cond",
+          "test": {
+            "kind": "binary",
+            "op": "lt",
+            "left": {
+              "kind": "param",
+              "name": "n"
+            },
+            "right": {
+              "kind": "const",
+              "value": {
+                "t": "int",
+                "v": 2
+              }
+            }
+          },
+          "then": {
+            "kind": "const",
+            "value": {
+              "t": "int",
+              "v": 1
+            }
+          },
+          "else": {
+            "kind": "binary",
+            "op": "mul",
+            "left": {
+              "kind": "param",
+              "name": "n"
+            },
+            "right": {
+              "kind": "call",
+              "fn": "fact",
+              "args": [
+                {
+                  "kind": "binary",
+                  "op": "sub",
+                  "left": {
+                    "kind": "param",
+                    "name": "n"
+                  },
+                  "right": {
+                    "kind": "const",
+                    "value": {
+                      "t": "int",
+                      "v": 1
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "canonical": "{\"v\":1,\"expr\":{\"kind\":\"lambda\",\"params\":[\"n\"],\"body\":{\"kind\":\"cond\",\"test\":{\"kind\":\"binary\",\"op\":\"lt\",\"left\":{\"kind\":\"param\",\"name\":\"n\"},\"right\":{\"kind\":\"const\",\"value\":{\"t\":\"int\",\"v\":2}}},\"then\":{\"kind\":\"const\",\"value\":{\"t\":\"int\",\"v\":1}},\"else\":{\"kind\":\"binary\",\"op\":\"mul\",\"left\":{\"kind\":\"param\",\"name\":\"n\"},\"right\":{\"kind\":\"call\",\"fn\":\"fact\",\"args\":[{\"kind\":\"binary\",\"op\":\"sub\",\"left\":{\"kind\":\"param\",\"name\":\"n\"},\"right\":{\"kind\":\"const\",\"value\":{\"t\":\"int\",\"v\":1}}}]}}}}}"
+    }
+  ]
+}

--- a/src/Core.TypeScript/bonsai/index.ts
+++ b/src/Core.TypeScript/bonsai/index.ts
@@ -1,0 +1,1 @@
+export * from "./bonsai";


### PR DESCRIPTION
First slice of the self-evolving-saga build (**B-0976**): the cross-language **Bonsai-subset expression-tree serializer** the saga primitive needs. TS reference oracle (#1 of TS/F#/C#/Rust) — the algebra-ladder meet-in-the-middle discipline: TS authors the shared golden vectors; F#/C#/Rust replay later.

## What

The **weakly-typed / reflection-info-omitted** Bonsai mode (the cross-language-portable form Nuqleon uses for C++/JS targets) — kind-tagged node set `const · param · lambda · binary · call · cond`, no .NET type table. Nuqleon Bonsai stays the .NET-typed-mode conformance oracle.

- **Canonical byte-exact serializer** — compact JSON, fixed key order per node-kind (`kind` first), integer-only literals (no float-format divergence), standard JSON string escaping, `{"v":1,"expr":<node>}` wrapper. *The* cross-oracle byte-diff contract.
- **`parse` round-trip** — `equals(parse(canonical), expr)` and `serialize(parse(s)) === s` (canonical = fixed point).
- **Structural `equals`** + ergonomic constructors.

## Verification

`src/Core.TypeScript/bonsai/` — `bonsai.ts` + `golden-vectors.json` (8 cases incl. a recursive factorial: cond + recursive `call`) + `bonsai.test.ts` + `index.ts`.

- `bun test bonsai/` → **30 pass / 0 fail** (serialize byte-exact · parse round-trip · canonical fixed point · equals laws · unknown-kind + unsupported-version rejection).
- strict `bun --bun tsc --noEmit -p tsconfig.json` → **0 errors**.

Per `m-acc-multi-oracle`: the compilers don't lie; agreement IS the verification. F#/C#/Rust oracles replay the same `golden-vectors.json` in following slices.

B-0976 acceptance slice 1: **TS oracle ✅**; F#/C#/Rust pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)