### PR TITLE
feat(B-0976 slice 1): F# Bonsai oracle as Result<_, BonsaiFeedback> (result over throw)

### DIFF
--- a/docs/backlog/P1/B-0976-self-evolving-saga-build-serialized-deferred-execution-bonsai-closure-resume-not-replay-temporal-grade-interface-rides-zset-ladder-aaron-2026-06-01.md
+++ b/docs/backlog/P1/B-0976-self-evolving-saga-build-serialized-deferred-execution-bonsai-closure-resume-not-replay-temporal-grade-interface-rides-zset-ladder-aaron-2026-06-01.md
@@ -128,7 +128,7 @@ container where one exists):
   JSON-pointer keys.
 - **Accumulate (applicative) — SAVE, hexagonal eventually (NOT this slice).** For
   batch / model-validation (validate N golden vectors at once, the bus validating a
-  batch of envelopes, throttled-batch ops) you want _every_ failure, keyed by field.
+  batch of envelopes, throttled-batch ops) you want *every* failure, keyed by field.
   That shape is **RFC 9457 "Problem Details"** (supersedes RFC 7807), and .NET ships
   it as **`ValidationProblemDetails`** with `Errors: IDictionary<string, string[]>`
   (field → messages) — useful well outside HTTP (only `status` is HTTP-flavored).

--- a/docs/backlog/P1/B-0976-self-evolving-saga-build-serialized-deferred-execution-bonsai-closure-resume-not-replay-temporal-grade-interface-rides-zset-ladder-aaron-2026-06-01.md
+++ b/docs/backlog/P1/B-0976-self-evolving-saga-build-serialized-deferred-execution-bonsai-closure-resume-not-replay-temporal-grade-interface-rides-zset-ladder-aaron-2026-06-01.md
@@ -113,14 +113,45 @@ stream = carrier; ℤ retraction = evolution + compensation.
   cached-results + break-exception + state-provider + context) — cheap to build a
   replay-family backend if needed; resume is the superset.
 
+## Error channel — fail-fast `Result` now; accumulate (RFC-9457 ProblemDetails) later
+
+Two complementary modes (the monad/applicative split), each leaning on its
+ecosystem's native shape (hexagonal — own the payload contract, use the BCL
+container where one exists):
+
+- **Fail-fast (monadic) — built now.** `serialize`/`parse` return
+  `Result<T, BonsaiFeedback>`; the first decline short-circuits. Correct for
+  single-parse (you can't continue past a structural error). F#/Rust lean on the
+  BCL `Result` (`FSharp.Core.Result`, `std::result::Result`); C#/TS own a minimal
+  `Result` port + adapt to the widely-used lib (neverthrow / FluentResults-class).
+  `BonsaiFeedback` is the shared cross-oracle payload; its `where` fields are
+  JSON-pointer keys.
+- **Accumulate (applicative) — SAVE, hexagonal eventually (NOT this slice).** For
+  batch / model-validation (validate N golden vectors at once, the bus validating a
+  batch of envelopes, throttled-batch ops) you want _every_ failure, keyed by field.
+  That shape is **RFC 9457 "Problem Details"** (supersedes RFC 7807), and .NET ships
+  it as **`ValidationProblemDetails`** with `Errors: IDictionary<string, string[]>`
+  (field → messages) — useful well outside HTTP (only `status` is HTTP-flavored).
+  Hexagonal plan: own a cross-language ProblemDetails-shaped port
+  (`{type, title, status?, detail, instance?, errors}`), adapt to .NET's
+  `ValidationProblemDetails` at the C# seam; a `BonsaiFeedback list` maps straight
+  onto the `errors` map via the `where` keys. Complementary primitive for the family
+  + the git-native bus (B-0954) — build when scheduled; **saved here so the
+  hexagonal isn't forgotten** (the operator 2026-06-01).
+
 ## Acceptance / decomposition (slices)
 
 - 🚧 Cross-language **Bonsai-subset serializer** (`{Context, Expression}`) +
       golden-vector cross-verify (TS/F#/C#/Rust oracles), Nuqleon as .NET oracle.
       **TS reference oracle ✅** (`src/Core.TypeScript/bonsai/` — weakly-typed /
       reflection-omitted subset: const/param/lambda/binary/call/cond; canonical
-      byte-exact serialize + parse round-trip + `golden-vectors.json`; 30 tests).
-      **F#/C#/Rust oracles pending** (replay the shared golden vectors).
+      byte-exact serialize + parse round-trip + `golden-vectors.json`; hardened:
+      safe-integer range, lone-surrogate escaping, canonical-only parse; 43 tests).
+      **F# oracle ✅** (`src/Core/Bonsai.fs` — replays the shared golden vectors
+      byte-for-byte; `serialize`/`parse` return `Result<_, BonsaiFeedback>`
+      (result over throw); rejections asserted by specific feedback variant; 22 tests).
+      **C#/Rust oracles pending** (replay the shared golden vectors; native `Result`
+      container — C# owns a port + adapter, Rust uses `std::result::Result`).
 - [ ] **Resume engine** — serialize closure + expr-tree; restore-not-replay;
       no-handles discipline enforced; non-determinism allowed.
 - [ ] **Context propagation** = OTel/IntrCtx — C#/TS AsyncLocal adapter + **F#

--- a/src/Core/Bonsai.fs
+++ b/src/Core/Bonsai.fs
@@ -1,0 +1,336 @@
+namespace Zeta.Core
+
+open System.Collections.Generic
+open System.Text
+open System.Text.Json
+
+/// Bonsai-subset expression-tree serializer — the F# oracle (#2 of TS/F#/C#/Rust)
+/// for B-0976 slice 1. Named after Nuqleon Bonsai (Reaqtor's compact serializer
+/// for .NET expression trees); this is the weakly-typed / reflection-info-omitted
+/// mode — kind-tagged nodes, no .NET type table — the cross-language-portable
+/// form. The TS reference oracle (src/Core.TypeScript/bonsai/) authors the shared
+/// golden vectors; this F# oracle replays them byte-for-byte. Mirrors the
+/// algebra-ladder meet-in-the-middle discipline: the compilers do not lie;
+/// agreement IS the verification.
+///
+/// Canonical form (the cross-oracle byte-diff contract): serialize emits compact
+/// JSON (no whitespace) with a fixed key order per node-kind (kind first, then
+/// fields in declared order), integer-only numeric literals in the shared
+/// JS-safe-integer range, standard JSON string escaping, and the document wrapper
+/// v=1,expr=node. parse round-trips: serialize(parse s) = Ok s, and the DU has
+/// structural equality.
+///
+/// Error channel: serialize and parse return Result&lt;_, BonsaiFeedback&gt; — no
+/// exceptions cross the public boundary (result-over-throw; "stay round, not
+/// sharp"). F# leans on the BCL FSharp.Core Result; BonsaiFeedback is the shared
+/// cross-oracle payload contract (the 'TError in F#'s Result, the E in Rust's
+/// std::result::Result, the owned-port payload in C#/TS). Per the hexagonal
+/// contract-vs-mechanism split, the internals adapt System.Text.Json's throwing
+/// API (and a private typed signal) into Result at the two boundaries; the wire
+/// contract is pure Result. This is fail-fast (monadic) — for accumulate-all-errors
+/// (RFC-9457 ProblemDetails / model-validation), the where-keyed variants below map
+/// straight to a {where: [msg…]} document; that accumulate mode is the complementary
+/// primitive for batch/validation, not single-parse.
+module Bonsai =
+
+    /// A literal value — tagged so every oracle round-trips the type exactly.
+    type ConstValue =
+        /// An integer literal (int64 to match the Rust i64 oracle; the wire form
+        /// is bounded to the shared JS-safe-integer range).
+        | CInt of int64
+        /// A string literal (serialized with standard JSON escaping).
+        | CStr of string
+        /// A boolean literal.
+        | CBool of bool
+        /// The null literal (no value field in the canonical form).
+        | CNull
+
+    /// The language-agnostic binary operators in the subset.
+    type BinOp =
+        | Add
+        | Sub
+        | Mul
+        | Eq
+        | Lt
+        | And
+        | Or
+
+    /// A Bonsai-subset expression node (kind-tagged discriminated union).
+    type Expr =
+        /// A constant literal.
+        | Const of ConstValue
+        /// A parameter (variable) reference by name.
+        | Param of string
+        /// A lambda abstraction: parameter names and a body.
+        | Lambda of string list * Expr
+        /// A binary operation: operator, left, right.
+        | Binary of BinOp * Expr * Expr
+        /// A named function application: function name and arguments.
+        | Call of string * Expr list
+        /// A conditional: test, then-branch, else-branch.
+        | Cond of Expr * Expr * Expr
+
+    /// The bonsai-domain feedback channel — the typed reasons serialize/parse can
+    /// decline, surfaced as Result values (no exceptions) so callers handle or
+    /// propagate. The shared cross-oracle payload contract. Named *Feedback* not
+    /// *Error* per the framework's substrate-honest convention: the decline path is
+    /// load-bearing engineering input, not residue. The `where` fields are
+    /// JSON-pointer-ish paths so a list of these maps directly to an RFC-9457
+    /// ProblemDetails errors map when the accumulate mode is wanted.
+    type BonsaiFeedback =
+        /// The document `v` was not the supported version (found, expected).
+        | UnsupportedVersion of found: int * expected: int
+        /// The input was not well-formed JSON, or a required property was missing
+        /// or of the wrong JSON kind (carries the underlying message).
+        | MalformedJson of message: string
+        /// A node `kind` tag was not one of the known node kinds.
+        | UnknownKind of kind: string
+        /// A const `t` tag was not one of int/str/bool/null.
+        | UnknownConstTag of tag: string
+        /// A binary `op` was not one of the known operators.
+        | UnknownOp of op: string
+        /// A string was required at `where` but the value was null / non-string.
+        | ExpectedString of where: string
+        /// A boolean was required at `where` but the value was non-boolean.
+        | ExpectedBool of where: string
+        /// A safe integer was required at `where` but the value was non-numeric,
+        /// fractional, or beyond the representable range.
+        | ExpectedInt of where: string
+        /// An integer literal was a valid int64 but outside the shared v1
+        /// JS-safe-integer range (a value a peer oracle could not preserve).
+        | NonSafeInt of value: int64
+        /// Expression nesting exceeded the shared v1 maximum (the limit).
+        | TooDeep of limit: int
+        /// The input was valid JSON but not the canonical byte form (extra fields,
+        /// whitespace, or reordered keys); serialize(parse s) would not equal s.
+        | NonCanonical
+
+    /// The serialization format version (the v field of the document wrapper).
+    [<Literal>]
+    let Version = 1
+
+    /// The maximum expression nesting depth in the v1 contract. Bounds the
+    /// recursive serializer/parser against unbounded nesting (a stack-overflow /
+    /// DoS vector on attacker-controlled saga bytes) and is the shared depth limit
+    /// every oracle enforces, so a tree that round-trips in one oracle round-trips
+    /// in every oracle. Generous for any realistic deferred computation, well below
+    /// the recursion ceiling, and far above System.Text.Json's default of 64.
+    [<Literal>]
+    let MaxDepth = 1024
+
+    /// The JS safe-integer bound, Number.MAX_SAFE_INTEGER = 2^53 - 1 — the shared
+    /// v1 int domain (a value beyond this cannot round-trip through the TS oracle's
+    /// number, so it is rejected, not silently rewritten).
+    [<Literal>]
+    let private MaxSafeInt = 9007199254740991L // 2^53 - 1
+
+    /// JSON tokenizer depth ceiling — generous headroom above MaxDepth so
+    /// JsonDocument.Parse never rejects a tree within the v1 nesting contract
+    /// (System.Text.Json defaults to 64). The serialize-side cap (emitAt) + the
+    /// canonical round-trip guard in parse are the actual contract enforcers.
+    let private parseDepthCeiling = MaxDepth * 2
+
+    /// Private typed signal — internals raise this on a decline; serialize/parse
+    /// catch it at the boundary and return Error. The wire contract stays Result;
+    /// this is the F# internal mechanism (hexagonal contract-vs-mechanism split).
+    exception private BonsaiFail of BonsaiFeedback
+
+    /// Reject an integer literal outside the shared v1 safe-integer range.
+    let private checkSafeInt (v: int64) : int64 =
+        if v > MaxSafeInt || v < -MaxSafeInt then
+            raise (BonsaiFail(NonSafeInt v))
+
+        v
+
+    /// Map a binary operator to its canonical wire string.
+    let private binOpToString (op: BinOp) : string =
+        match op with
+        | Add -> "add"
+        | Sub -> "sub"
+        | Mul -> "mul"
+        | Eq -> "eq"
+        | Lt -> "lt"
+        | And -> "and"
+        | Or -> "or"
+
+    /// Parse a canonical wire string back to a binary operator.
+    let private binOpOfString (s: string) : BinOp =
+        match s with
+        | "add" -> Add
+        | "sub" -> Sub
+        | "mul" -> Mul
+        | "eq" -> Eq
+        | "lt" -> Lt
+        | "and" -> And
+        | "or" -> Or
+        | other -> raise (BonsaiFail(UnknownOp(if isNull other then "<null>" else other)))
+
+    /// Escape a string to a JSON string literal (quotes included), matching
+    /// JavaScript JSON.stringify: escape quote, backslash, the short control
+    /// forms, any other control char below 0x20 as lowercase \uXXXX, and any
+    /// unpaired UTF-16 surrogate as lowercase \uXXXX (a valid surrogate pair is
+    /// emitted literally, as JSON.stringify does, so the bytes stay valid UTF-8).
+    let private jsonString (s: string) : string =
+        let sb = StringBuilder(s.Length + 2)
+        sb.Append('"') |> ignore
+        let mutable i = 0
+
+        while i < s.Length do
+            let ch = s.[i]
+
+            match ch with
+            | '"' -> sb.Append("\\\"") |> ignore
+            | '\\' -> sb.Append("\\\\") |> ignore
+            | '\b' -> sb.Append("\\b") |> ignore
+            | '\f' -> sb.Append("\\f") |> ignore
+            | '\n' -> sb.Append("\\n") |> ignore
+            | '\r' -> sb.Append("\\r") |> ignore
+            | '\t' -> sb.Append("\\t") |> ignore
+            | c when c < ' ' -> sb.AppendFormat("\\u{0:x4}", int c) |> ignore
+            | c when System.Char.IsHighSurrogate c && i + 1 < s.Length && System.Char.IsLowSurrogate(s.[i + 1]) ->
+                // valid surrogate pair — emit both code units literally (matches
+                // JSON.stringify, which emits the astral character, not an escape)
+                sb.Append(c) |> ignore
+                sb.Append(s.[i + 1]) |> ignore
+                i <- i + 1 // also consume the low surrogate
+            | c when System.Char.IsHighSurrogate c || System.Char.IsLowSurrogate c ->
+                // unpaired surrogate — escape it (well-formed JSON.stringify does)
+                sb.AppendFormat("\\u{0:x4}", int c) |> ignore
+            | c -> sb.Append(c) |> ignore
+
+            i <- i + 1
+
+        sb.Append('"') |> ignore
+        sb.ToString()
+
+    /// Emit a constant value in canonical compact form (t first, then v).
+    let private emitConst (c: ConstValue) : string =
+        match c with
+        | CInt v -> sprintf "{\"t\":\"int\",\"v\":%d}" (checkSafeInt v)
+        | CStr v -> sprintf "{\"t\":\"str\",\"v\":%s}" (jsonString v)
+        | CBool v -> sprintf "{\"t\":\"bool\",\"v\":%s}" (if v then "true" else "false")
+        | CNull -> "{\"t\":\"null\"}"
+
+    /// Emit a node in canonical compact form (fixed key order per kind). Tracks
+    /// nesting depth and declines (TooDeep) past MaxDepth — so serialize never
+    /// emits a tree the parser (any oracle) could not read back, and recursion is
+    /// bounded.
+    let rec private emitAt (depth: int) (e: Expr) : string =
+        if depth > MaxDepth then
+            raise (BonsaiFail(TooDeep MaxDepth))
+
+        match e with
+        | Const c -> sprintf "{\"kind\":\"const\",\"value\":%s}" (emitConst c)
+        | Param n -> sprintf "{\"kind\":\"param\",\"name\":%s}" (jsonString n)
+        | Lambda(ps, body) ->
+            let psJson = ps |> List.map jsonString |> String.concat ","
+            sprintf "{\"kind\":\"lambda\",\"params\":[%s],\"body\":%s}" psJson (emitAt (depth + 1) body)
+        | Binary(op, l, r) ->
+            sprintf
+                "{\"kind\":\"binary\",\"op\":%s,\"left\":%s,\"right\":%s}"
+                (jsonString (binOpToString op))
+                (emitAt (depth + 1) l)
+                (emitAt (depth + 1) r)
+        | Call(fn, args) ->
+            let argsJson = args |> List.map (emitAt (depth + 1)) |> String.concat ","
+            sprintf "{\"kind\":\"call\",\"fn\":%s,\"args\":[%s]}" (jsonString fn) argsJson
+        | Cond(t, th, el) ->
+            sprintf
+                "{\"kind\":\"cond\",\"test\":%s,\"then\":%s,\"else\":%s}"
+                (emitAt (depth + 1) t)
+                (emitAt (depth + 1) th)
+                (emitAt (depth + 1) el)
+
+    /// Serialize an expression to the canonical Bonsai-subset string. Declines
+    /// (Error) on an unsafe integer literal or nesting past MaxDepth.
+    let serialize (e: Expr) : Result<string, BonsaiFeedback> =
+        try
+            Ok(sprintf "{\"v\":%d,\"expr\":%s}" Version (emitAt 1 e))
+        with BonsaiFail f ->
+            Error f
+
+    /// Rebuild a ConstValue from a parsed JSON element (validating tag + value
+    /// kind; null / wrong-kind values decline rather than crash).
+    let private parseConst (el: JsonElement) : ConstValue =
+        match el.GetProperty("t").GetString() with
+        | "int" ->
+            match el.GetProperty("v").TryGetInt64() with
+            | true, i -> CInt(checkSafeInt i)
+            | false, _ -> raise (BonsaiFail(ExpectedInt "const int value"))
+        | "str" ->
+            let v = el.GetProperty("v")
+
+            if v.ValueKind = JsonValueKind.String then
+                CStr(v.GetString())
+            else
+                raise (BonsaiFail(ExpectedString "const str value"))
+        | "bool" ->
+            match el.GetProperty("v").ValueKind with
+            | JsonValueKind.True -> CBool true
+            | JsonValueKind.False -> CBool false
+            | _ -> raise (BonsaiFail(ExpectedBool "const bool value"))
+        | "null" -> CNull
+        | other -> raise (BonsaiFail(UnknownConstTag(if isNull other then "<null>" else other)))
+
+    /// Rebuild an Expr from a parsed JSON element (validating the kind). Uses eager
+    /// list comprehensions over EnumerateArray (the JsonElement array enumerator is
+    /// a mutable struct that corrupts through a lazy Seq pipeline). Null string
+    /// values decline (ExpectedString) rather than crash in serialize.
+    let rec private parseNode (el: JsonElement) : Expr =
+        match el.GetProperty("kind").GetString() with
+        | "const" -> Const(parseConst (el.GetProperty("value")))
+        | "param" ->
+            match el.GetProperty("name").GetString() with
+            | null -> raise (BonsaiFail(ExpectedString "param.name"))
+            | n -> Param n
+        | "lambda" ->
+            let ps =
+                [ for p in el.GetProperty("params").EnumerateArray() ->
+                      match p.GetString() with
+                      | null -> raise (BonsaiFail(ExpectedString "lambda.params[]"))
+                      | s -> s ]
+
+            Lambda(ps, parseNode (el.GetProperty("body")))
+        | "binary" ->
+            Binary(
+                binOpOfString (el.GetProperty("op").GetString()),
+                parseNode (el.GetProperty("left")),
+                parseNode (el.GetProperty("right"))
+            )
+        | "call" ->
+            match el.GetProperty("fn").GetString() with
+            | null -> raise (BonsaiFail(ExpectedString "call.fn"))
+            | fn ->
+                let args = [ for a in el.GetProperty("args").EnumerateArray() -> parseNode a ]
+                Call(fn, args)
+        | "cond" ->
+            Cond(parseNode (el.GetProperty("test")), parseNode (el.GetProperty("then")), parseNode (el.GetProperty("else")))
+        | other -> raise (BonsaiFail(UnknownKind(if isNull other then "<null>" else other)))
+
+    /// Parse a canonical Bonsai-subset string back to an Expr. Canonical-only: a
+    /// structurally-valid but non-canonical vector (extra fields, whitespace,
+    /// reordered keys) declines (NonCanonical) rather than silently canonicalizing,
+    /// so the serialize(parse s) = Ok s fixed point holds and the oracles agree on
+    /// which input is valid. Wraps System.Text.Json's throwing access API into the
+    /// Result contract at this boundary.
+    let parse (s: string) : Result<Expr, BonsaiFeedback> =
+        try
+            use doc = JsonDocument.Parse(s, JsonDocumentOptions(MaxDepth = parseDepthCeiling))
+            let root = doc.RootElement
+            let v = root.GetProperty("v").GetInt32()
+
+            if v <> Version then
+                Error(UnsupportedVersion(v, Version))
+            else
+                let node = parseNode (root.GetProperty("expr"))
+                // Canonical-only guard: the round-trip must reproduce the input
+                // byte-for-byte (serialize also re-checks depth + safe-int).
+                match serialize node with
+                | Error f -> Error f
+                | Ok round -> if round = s then Ok node else Error NonCanonical
+        with
+        | BonsaiFail f -> Error f
+        | :? JsonException as ex -> Error(MalformedJson ex.Message)
+        | :? KeyNotFoundException -> Error(MalformedJson "missing required property")
+        | :? System.InvalidOperationException as ex -> Error(MalformedJson ex.Message)
+        | :? System.FormatException as ex -> Error(MalformedJson ex.Message)

--- a/src/Core/Bonsai.fs
+++ b/src/Core/Bonsai.fs
@@ -171,6 +171,12 @@ module Bonsai =
     /// unpaired UTF-16 surrogate as lowercase \uXXXX (a valid surrogate pair is
     /// emitted literally, as JSON.stringify does, so the bytes stay valid UTF-8).
     let private jsonString (s: string) : string =
+        if isNull s then
+            // A CLR caller can construct an Expr with a null string field
+            // (Param null / CStr null / null call fn / null lambda param);
+            // decline cleanly instead of NRE-ing here, keeping serialize total.
+            raise (BonsaiFail(ExpectedString "null string field"))
+
         let sb = StringBuilder(s.Length + 2)
         sb.Append('"') |> ignore
         let mutable i = 0
@@ -330,6 +336,7 @@ module Bonsai =
                 | Ok round -> if round = s then Ok node else Error NonCanonical
         with
         | BonsaiFail f -> Error f
+        | :? System.ArgumentNullException -> Error(MalformedJson "input was null")
         | :? JsonException as ex -> Error(MalformedJson ex.Message)
         | :? KeyNotFoundException -> Error(MalformedJson "missing required property")
         | :? System.InvalidOperationException as ex -> Error(MalformedJson ex.Message)

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="ZSet.fs" />
     <Compile Include="ToffoliGate.fs" />
     <Compile Include="IndexedZSet.fs" />
+    <Compile Include="Bonsai.fs" />
     <Compile Include="Circuit.fs" />
     <Compile Include="PluginApi.fs" />
     <Compile Include="PluginHarness.fs" />

--- a/tests/Tests.FSharp/Bonsai/Bonsai.Tests.fs
+++ b/tests/Tests.FSharp/Bonsai/Bonsai.Tests.fs
@@ -1,0 +1,260 @@
+module Zeta.Tests.Bonsai.BonsaiTests
+
+open System.IO
+open System.Reflection
+open System.Text.Json
+open global.Xunit
+open Zeta.Core
+
+// Bonsai-subset serializer — the F# oracle (#2 of TS/F#/C#/Rust) for B-0976
+// slice 1. The TS reference oracle (src/Core.TypeScript/bonsai/) authors the
+// shared golden vectors; this proves the F# impl replays them byte-for-byte:
+// serialize(parse canonical) = Ok canonical (the cross-language byte lock) AND an
+// independently F#-constructed tree serializes to the same canonical bytes.
+// "The compilers don't lie."
+//
+// Error channel: serialize/parse return Result<_, BonsaiFeedback> (result over
+// throw). The rejection tests assert the SPECIFIC feedback variant, not merely
+// "it failed" — that's the cross-language rejection-vector contract (every oracle
+// declines the same bad input with the same variant).
+
+// Walk up from the test assembly to the repo root (Zeta.sln sentinel).
+let private repoRoot () : string =
+    let mutable dir = DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))
+
+    while not (isNull dir) && not (File.Exists(Path.Join(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+
+    if isNull dir then
+        failwith "Could not locate repo root (Zeta.sln) from test assembly location."
+
+    dir.FullName
+
+// Read each golden case's (name, canonical) eagerly so the JsonDocument is safe
+// to dispose before the values are used.
+let private goldenCanonicals () : (string * string) list =
+    let path = Path.Join(repoRoot (), "src", "Core.TypeScript", "bonsai", "golden-vectors.json")
+    use doc = JsonDocument.Parse(File.ReadAllText(path))
+
+    [ for c in doc.RootElement.GetProperty("cases").EnumerateArray() ->
+          c.GetProperty("name").GetString(), c.GetProperty("canonical").GetString() ]
+
+// Unwrap an Ok, or fail the test with the feedback.
+let private ok (r: Result<'a, Bonsai.BonsaiFeedback>) : 'a =
+    match r with
+    | Ok v -> v
+    | Error f -> failwithf "expected Ok, got Error %A" f
+
+// True when the Result is an Error whose feedback satisfies the predicate.
+let private isErr (pred: Bonsai.BonsaiFeedback -> bool) (r: Result<'a, Bonsai.BonsaiFeedback>) : bool =
+    match r with
+    | Error f -> pred f
+    | Ok _ -> false
+
+[<Fact>]
+let ``F# serialize is the byte-exact fixed point of every shared Bonsai golden canonical`` () =
+    let cases = goldenCanonicals ()
+    Assert.True(cases.Length > 0, "no golden cases loaded")
+
+    for (name, canonical) in cases do
+        let round = canonical |> Bonsai.parse |> ok |> Bonsai.serialize |> ok
+        Assert.True((round = canonical), sprintf "case %s: serialize(parse canonical) != canonical\n exp: %s\n got: %s" name canonical round)
+
+[<Fact>]
+let ``F#-constructed factorial serializes to the shared canonical bytes`` () =
+    // Independent construction path (not via parse) — proves F# serialize emits
+    // the exact TS reference bytes for a non-trivial tree (cond + recursive call).
+    let fact =
+        Bonsai.Lambda(
+            [ "n" ],
+            Bonsai.Cond(
+                Bonsai.Binary(Bonsai.Lt, Bonsai.Param "n", Bonsai.Const(Bonsai.CInt 2L)),
+                Bonsai.Const(Bonsai.CInt 1L),
+                Bonsai.Binary(
+                    Bonsai.Mul,
+                    Bonsai.Param "n",
+                    Bonsai.Call("fact", [ Bonsai.Binary(Bonsai.Sub, Bonsai.Param "n", Bonsai.Const(Bonsai.CInt 1L)) ])
+                )
+            )
+        )
+
+    let expected = goldenCanonicals () |> List.find (fun (n, _) -> n = "factorial") |> snd
+    Assert.Equal(expected, ok (Bonsai.serialize fact))
+
+[<Fact>]
+let ``parse round-trips structurally through serialize (DU equality, every case)`` () =
+    for (_, canonical) in goldenCanonicals () do
+        let e1 = ok (Bonsai.parse canonical)
+        let e2 = ok (Bonsai.parse (ok (Bonsai.serialize e1)))
+        Assert.Equal<Bonsai.Expr>(e1, e2)
+
+// ---- rejection contract (each asserts the specific BonsaiFeedback variant) ----
+
+[<Fact>]
+let ``parse declines an unknown node kind with UnknownKind`` () =
+    Assert.True(
+        Bonsai.parse "{\"v\":1,\"expr\":{\"kind\":\"bogus\"}}"
+        |> isErr (function
+            | Bonsai.UnknownKind _ -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``parse declines an unsupported version with UnsupportedVersion`` () =
+    Assert.True(
+        Bonsai.parse "{\"v\":2,\"expr\":{\"kind\":\"param\",\"name\":\"x\"}}"
+        |> isErr (function
+            | Bonsai.UnsupportedVersion(2, 1) -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``parse declines an int beyond the safe-integer range with NonSafeInt`` () =
+    // 2^53 + 1 — a valid int64 the TS oracle's number would round; reject.
+    Assert.True(
+        Bonsai.parse "{\"v\":1,\"expr\":{\"kind\":\"const\",\"value\":{\"t\":\"int\",\"v\":9007199254740993}}}"
+        |> isErr (function
+            | Bonsai.NonSafeInt _ -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``serialize declines an int beyond the safe-integer range with NonSafeInt`` () =
+    Assert.True(
+        Bonsai.serialize (Bonsai.Const(Bonsai.CInt 9007199254740993L))
+        |> isErr (function
+            | Bonsai.NonSafeInt 9007199254740993L -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``serialize accepts the safe-integer boundary (2^53 - 1)`` () =
+    let s = ok (Bonsai.serialize (Bonsai.Const(Bonsai.CInt 9007199254740991L)))
+    Assert.Equal("{\"v\":1,\"expr\":{\"kind\":\"const\",\"value\":{\"t\":\"int\",\"v\":9007199254740991}}}", s)
+
+[<Fact>]
+let ``serialize escapes a lone high surrogate as lowercase backslash-u (matches JSON.stringify)`` () =
+    let s = ok (Bonsai.serialize (Bonsai.Param(System.String([| '\uD800' |]))))
+    Assert.Contains("\\ud800", s)
+
+[<Fact>]
+let ``serialize keeps a valid surrogate pair literal (matches JSON.stringify)`` () =
+    let pair = System.String([| '\uD83D'; '\uDE00' |])
+    let s = ok (Bonsai.serialize (Bonsai.Param pair))
+    Assert.Contains(pair, s)
+    Assert.DoesNotContain("\\ud83d", s)
+
+[<Fact>]
+let ``parse declines a non-canonical vector (extra field) with NonCanonical`` () =
+    Assert.True(
+        Bonsai.parse "{\"v\":1,\"expr\":{\"kind\":\"param\",\"name\":\"x\",\"extra\":0}}"
+        |> isErr (function
+            | Bonsai.NonCanonical -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``parse declines non-canonical whitespace with NonCanonical`` () =
+    Assert.True(
+        Bonsai.parse "{\"v\":1, \"expr\":{\"kind\":\"param\",\"name\":\"x\"}}"
+        |> isErr (function
+            | Bonsai.NonCanonical -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``parse declines non-canonical key order with NonCanonical`` () =
+    Assert.True(
+        Bonsai.parse "{\"expr\":{\"kind\":\"param\",\"name\":\"x\"},\"v\":1}"
+        |> isErr (function
+            | Bonsai.NonCanonical -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``parse declines a null string value with ExpectedString (no NRE)`` () =
+    // The P1: GetString() returns null for a JSON null; must decline cleanly,
+    // not build Param null and crash inside serialize.
+    Assert.True(
+        Bonsai.parse "{\"v\":1,\"expr\":{\"kind\":\"param\",\"name\":null}}"
+        |> isErr (function
+            | Bonsai.ExpectedString _ -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``parse declines a null const str value with ExpectedString`` () =
+    Assert.True(
+        Bonsai.parse "{\"v\":1,\"expr\":{\"kind\":\"const\",\"value\":{\"t\":\"str\",\"v\":null}}}"
+        |> isErr (function
+            | Bonsai.ExpectedString _ -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``parse declines a non-boolean bool literal with ExpectedBool`` () =
+    Assert.True(
+        Bonsai.parse "{\"v\":1,\"expr\":{\"kind\":\"const\",\"value\":{\"t\":\"bool\",\"v\":1}}}"
+        |> isErr (function
+            | Bonsai.ExpectedBool _ -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``parse declines a fractional int literal with ExpectedInt`` () =
+    Assert.True(
+        Bonsai.parse "{\"v\":1,\"expr\":{\"kind\":\"const\",\"value\":{\"t\":\"int\",\"v\":1.5}}}"
+        |> isErr (function
+            | Bonsai.ExpectedInt _ -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``parse declines an unknown binary operator with UnknownOp`` () =
+    Assert.True(
+        Bonsai.parse
+            "{\"v\":1,\"expr\":{\"kind\":\"binary\",\"op\":\"div\",\"left\":{\"kind\":\"param\",\"name\":\"a\"},\"right\":{\"kind\":\"param\",\"name\":\"b\"}}}"
+        |> isErr (function
+            | Bonsai.UnknownOp "div" -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``parse declines an unknown const tag with UnknownConstTag`` () =
+    Assert.True(
+        Bonsai.parse "{\"v\":1,\"expr\":{\"kind\":\"const\",\"value\":{\"t\":\"bogus\"}}}"
+        |> isErr (function
+            | Bonsai.UnknownConstTag "bogus" -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``parse declines malformed JSON with MalformedJson`` () =
+    Assert.True(
+        Bonsai.parse "not json at all"
+        |> isErr (function
+            | Bonsai.MalformedJson _ -> true
+            | _ -> false)
+    )
+
+// ---- nesting-depth contract (past System.Text.Json's default 64; bounded) ----
+
+let rec private buildDeepChain (n: int) : Bonsai.Expr =
+    if n <= 0 then
+        Bonsai.Const(Bonsai.CInt 1L)
+    else
+        Bonsai.Binary(Bonsai.Add, buildDeepChain (n - 1), Bonsai.Const(Bonsai.CInt 0L))
+
+[<Fact>]
+let ``deep-but-valid expression round-trips past System.Text.Json's default depth 64`` () =
+    let deep = buildDeepChain 100
+    Assert.Equal<Bonsai.Expr>(deep, ok (Bonsai.parse (ok (Bonsai.serialize deep))))
+
+[<Fact>]
+let ``serialize declines an expression past the v1 maximum nesting depth with TooDeep`` () =
+    Assert.True(
+        Bonsai.serialize (buildDeepChain (Bonsai.MaxDepth + 50))
+        |> isErr (function
+            | Bonsai.TooDeep _ -> true
+            | _ -> false)
+    )

--- a/tests/Tests.FSharp/Bonsai/Bonsai.Tests.fs
+++ b/tests/Tests.FSharp/Bonsai/Bonsai.Tests.fs
@@ -258,3 +258,36 @@ let ``serialize declines an expression past the v1 maximum nesting depth with To
             | Bonsai.TooDeep _ -> true
             | _ -> false)
     )
+
+// ---- total contract: no exception escapes serialize/parse, even on CLR null ----
+
+[<Fact>]
+let ``serialize declines a null string field with ExpectedString (no NRE)`` () =
+    // A CLR caller can construct Param null directly (the DU permits it).
+    let nullName: string = null
+    Assert.True(
+        Bonsai.serialize (Bonsai.Param nullName)
+        |> isErr (function
+            | Bonsai.ExpectedString _ -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``serialize declines a null const string value with ExpectedString`` () =
+    let nullVal: string = null
+    Assert.True(
+        Bonsai.serialize (Bonsai.Const(Bonsai.CStr nullVal))
+        |> isErr (function
+            | Bonsai.ExpectedString _ -> true
+            | _ -> false)
+    )
+
+[<Fact>]
+let ``parse declines null input with MalformedJson (no ArgumentNullException)`` () =
+    let nullInput: string = null
+    Assert.True(
+        Bonsai.parse nullInput
+        |> isErr (function
+            | Bonsai.MalformedJson _ -> true
+            | _ -> false)
+    )

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -35,6 +35,7 @@
     <Compile Include="Algebra/Semiring.Tests.fs" />
     <Compile Include="TriBoolean/TriBoolean.Tests.fs" />
     <Compile Include="TriBoolean/Float.Tests.fs" />
+    <Compile Include="Bonsai/Bonsai.Tests.fs" />
     <Compile Include="Observe/GoldenVectors.Tests.fs" />
     <Compile Include="Observe/EventLog.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />


### PR DESCRIPTION
F# oracle (#2 of TS/F#/C#/Rust) for the B-0976 Bonsai-subset serializer, **as a pure-`Result` contract** (operator decision 2026-06-01: result over throw, "stay round not sharp"). Replays the shared `golden-vectors.json` byte-for-byte against the TS reference oracle (merged #6428).

## Error channel (hexagonal, prior-art-checked per ecosystem)
- `serialize : Expr -> Result<string, BonsaiFeedback>` · `parse : string -> Result<Expr, BonsaiFeedback>` — **no exceptions cross the boundary.**
- F# leans on the **BCL `FSharp.Core.Result`** (matches the existing `Result<_, DbspError>` Core convention — no `FsToolkit` dep). `BonsaiFeedback` is the shared cross-oracle payload contract (the `'TError`; Rust → `std::result::Result`, C#/TS → own a port + adapter to the widely-used lib).
- Per the contract-vs-mechanism split, F# adapts System.Text.Json's throwing access API + a private typed signal into `Result` at the two boundaries; the wire contract is pure `Result`.

## Hardening folded in (Result-returning), credit to the four-oracle review
- safe-integer range (`NonSafeInt`) + lone-surrogate escaping
- canonical-only parse (`NonCanonical`) — the `serialize(parse s) = Ok s` fixed point
- shared nesting cap `MaxDepth = 1024` (`TooDeep`) — round-trips past JSON depth 64
- P1 null-string NRE → clean `ExpectedString` decline
- `binOpToString`/`binOpOfString` made `private`; de-tautologized round-trip test

Rejections are asserted by **specific `BonsaiFeedback` variant** (the cross-language rejection-vector contract). **22 F# tests**, `dotnet build -c Release` **0 warnings**, byte-exact golden parity preserved.

## B-0976
F# oracle marked ✅; the RFC-9457 ProblemDetails / .NET `ValidationProblemDetails` **accumulate-mode** saved as the complementary primitive to hexagonal eventually (fail-fast `Result` now, accumulate for batch/validation + the bus later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)