### PR TITLE
feat(B-0976 slice 1): TS Bonsai oracle → Result<_, BonsaiFeedback> (match F#)

### DIFF
--- a/src/Core.TypeScript/bonsai/bonsai.test.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.test.ts
@@ -201,4 +201,15 @@ describe("Bonsai-subset — nesting-depth contract (shared MaxDepth, bounded)", 
   it("serialize declines an expression past the shared MaxDepth with TooDeep", () => {
     expect(errKind(serialize(buildDeepChain(BONSAI_MAX_DEPTH + 50)))).toBe("TooDeep");
   });
+
+  it("parse declines a deeply-nested document with TooDeep during parsing (bounded recursion)", () => {
+    // Build an over-MaxDepth JSON document by hand (can't via serialize — it
+    // declines first); parse must decline TooDeep via the parseNode depth counter,
+    // not recurse to a stack-overflow before the serialize guard.
+    let node = '{"kind":"const","value":{"t":"int","v":1}}';
+    for (let i = 0; i < BONSAI_MAX_DEPTH + 50; i++) {
+      node = `{"kind":"binary","op":"add","left":${node},"right":{"kind":"const","value":{"t":"int","v":0}}}`;
+    }
+    expect(errKind(parse(`{"v":1,"expr":${node}}`))).toBe("TooDeep");
+  });
 });

--- a/src/Core.TypeScript/bonsai/bonsai.test.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.test.ts
@@ -184,6 +184,16 @@ describe("Bonsai-subset — total contract (no exception escapes, even on null)"
   it("parse declines null input with MalformedJson (no throw)", () => {
     expect(errKind(parse(null as unknown as string))).toBe("MalformedJson");
   });
+
+  it("serialize declines an invalid binary operator with UnknownOp (boundary symmetry with parse)", () => {
+    const bad: Expr = { kind: "binary", op: "div" as unknown as "add", left: cint(1), right: cint(2) };
+    expect(errKind(serialize(bad))).toBe("UnknownOp");
+  });
+
+  it("serialize declines a non-boolean bool constant with ExpectedBool (boundary symmetry with parse)", () => {
+    const bad: Expr = { kind: "const", value: { t: "bool", v: 1 as unknown as boolean } };
+    expect(errKind(serialize(bad))).toBe("ExpectedBool");
+  });
 });
 
 describe("Bonsai-subset — nesting-depth contract (shared MaxDepth, bounded)", () => {

--- a/src/Core.TypeScript/bonsai/bonsai.test.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.test.ts
@@ -2,21 +2,31 @@
  * bonsai.test.ts — TS reference (oracle #1) for the Bonsai-subset serializer
  * (B-0976 slice 1).
  *
- * Three duties (mirroring the algebra-ladder oracles):
- *   1. **Canonical serialize is byte-exact** — `serialize(expr) === canonical`
- *      for every shared golden vector (the cross-language parity lock the
- *      F#/C#/Rust twins will also cast: same compact JSON, same fixed key order).
+ * `serialize`/`parse` return `Result<_, BonsaiFeedback>` (result over throw, matching
+ * the F# oracle). Duties:
+ *   1. **Canonical serialize is byte-exact** — `serialize(expr)` is `Ok canonical`
+ *      for every shared golden vector (the cross-language parity lock).
  *   2. **`parse` round-trips** — `equals(parse(canonical), expr)` and
- *      `serialize(parse(canonical)) === canonical` (the canonical string is the
- *      fixed point).
- *   3. **Structural laws** — `equals` is reflexive; `serialize ∘ parse ∘
- *      serialize == serialize`; unknown kinds are rejected (no silent accept).
+ *      `serialize(parse(canonical))` is `Ok canonical` (canonical is the fixed point).
+ *   3. **Rejection contract** — bad input declines the **specific** `BonsaiFeedback`
+ *      variant (the cross-oracle rejection-vector contract), and no exception ever
+ *      crosses the boundary (even on `null`).
  */
 
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join as pathJoin } from "node:path";
-import { cint, equals, type Expr, parse, serialize } from "./bonsai";
+import {
+  BONSAI_MAX_DEPTH,
+  type BonsaiFeedback,
+  cint,
+  equals,
+  type Expr,
+  param,
+  parse,
+  type Result,
+  serialize,
+} from "./bonsai";
 
 interface GoldenCase {
   readonly name: string;
@@ -34,6 +44,16 @@ const golden: Golden = JSON.parse(
   readFileSync(pathJoin(import.meta.dir, "golden-vectors.json"), "utf8"),
 ) as Golden;
 
+// Unwrap an Ok, or fail the test with the feedback.
+function expectOk<T>(r: Result<T, BonsaiFeedback>): T {
+  if (!r.ok) throw new Error(`expected Ok, got Error ${JSON.stringify(r.error)}`);
+  return r.value;
+}
+// The feedback variant of an Error result, or null when Ok.
+function errKind(r: Result<unknown, BonsaiFeedback>): string | null {
+  return r.ok ? null : r.error.kind;
+}
+
 describe("Bonsai-subset — golden vectors (oracle #1 / parity lock)", () => {
   it("the fixture is non-empty and version 1", () => {
     expect(golden.version).toBe(1);
@@ -41,16 +61,16 @@ describe("Bonsai-subset — golden vectors (oracle #1 / parity lock)", () => {
   });
 
   for (const c of golden.cases) {
-    it(`${c.name}: serialize(expr) is byte-exact canonical`, () => {
-      expect(serialize(c.expr)).toBe(c.canonical);
+    it(`${c.name}: serialize(expr) is Ok byte-exact canonical`, () => {
+      expect(expectOk(serialize(c.expr))).toBe(c.canonical);
     });
 
     it(`${c.name}: parse(canonical) structurally equals expr`, () => {
-      expect(equals(parse(c.canonical), c.expr)).toBe(true);
+      expect(equals(expectOk(parse(c.canonical)), c.expr)).toBe(true);
     });
 
     it(`${c.name}: canonical is the serialize fixed point`, () => {
-      expect(serialize(parse(c.canonical))).toBe(c.canonical);
+      expect(expectOk(serialize(expectOk(parse(c.canonical))))).toBe(c.canonical);
     });
   }
 });
@@ -58,8 +78,8 @@ describe("Bonsai-subset — golden vectors (oracle #1 / parity lock)", () => {
 describe("Bonsai-subset — round-trip + structural laws", () => {
   it("serialize ∘ parse ∘ serialize == serialize (every case)", () => {
     for (const c of golden.cases) {
-      const once = serialize(c.expr);
-      expect(serialize(parse(once))).toBe(once);
+      const once = expectOk(serialize(c.expr));
+      expect(expectOk(serialize(expectOk(parse(once))))).toBe(once);
     }
   });
 
@@ -73,81 +93,112 @@ describe("Bonsai-subset — round-trip + structural laws", () => {
     const exprs = golden.cases.map((c) => c.expr);
     for (let i = 0; i < exprs.length; i++) {
       for (let j = i + 1; j < exprs.length; j++) {
-        // distinct canonical strings ⇒ must not be structurally equal
-        if (serialize(exprs[i]!) !== serialize(exprs[j]!)) {
+        if (expectOk(serialize(exprs[i]!)) !== expectOk(serialize(exprs[j]!))) {
           expect(equals(exprs[i]!, exprs[j]!)).toBe(false);
         }
       }
     }
   });
+});
 
-  it("parse rejects an unknown node kind (no silent accept)", () => {
-    expect(() => parse('{"v":1,"expr":{"kind":"bogus"}}')).toThrow();
+describe("Bonsai-subset — rejection contract (declines the specific variant)", () => {
+  it("parse declines an unknown node kind with UnknownKind", () => {
+    expect(errKind(parse('{"v":1,"expr":{"kind":"bogus"}}'))).toBe("UnknownKind");
   });
 
-  it("parse rejects an unsupported version", () => {
-    expect(() => parse('{"v":2,"expr":{"kind":"param","name":"x"}}')).toThrow();
+  it("parse declines an unsupported version with UnsupportedVersion", () => {
+    expect(errKind(parse('{"v":2,"expr":{"kind":"param","name":"x"}}'))).toBe("UnsupportedVersion");
+  });
+
+  it("parse declines an unknown binary operator with UnknownOp", () => {
+    expect(
+      errKind(parse('{"v":1,"expr":{"kind":"binary","op":"div","left":{"kind":"param","name":"a"},"right":{"kind":"param","name":"b"}}}')),
+    ).toBe("UnknownOp");
+  });
+
+  it("parse declines an unknown const tag with UnknownConstTag", () => {
+    expect(errKind(parse('{"v":1,"expr":{"kind":"const","value":{"t":"bogus"}}}'))).toBe("UnknownConstTag");
+  });
+
+  it("parse declines a fractional int literal with ExpectedInt", () => {
+    expect(errKind(parse('{"v":1,"expr":{"kind":"const","value":{"t":"int","v":1.5}}}'))).toBe("ExpectedInt");
+  });
+
+  it("parse declines an int beyond the safe-integer range with NonSafeInt", () => {
+    expect(errKind(parse('{"v":1,"expr":{"kind":"const","value":{"t":"int","v":99999999999999999}}}'))).toBe("NonSafeInt");
+  });
+
+  it("parse declines a null const string value with ExpectedString", () => {
+    expect(errKind(parse('{"v":1,"expr":{"kind":"const","value":{"t":"str","v":null}}}'))).toBe("ExpectedString");
+  });
+
+  it("parse declines a non-boolean bool literal with ExpectedBool", () => {
+    expect(errKind(parse('{"v":1,"expr":{"kind":"const","value":{"t":"bool","v":1}}}'))).toBe("ExpectedBool");
+  });
+
+  it("parse declines non-array call args with MalformedJson", () => {
+    expect(errKind(parse('{"v":1,"expr":{"kind":"call","fn":"f","args":"nope"}}'))).toBe("MalformedJson");
+  });
+
+  it("parse declines a null expr with MalformedJson", () => {
+    expect(errKind(parse('{"v":1,"expr":null}'))).toBe("MalformedJson");
+  });
+
+  it("parse declines malformed JSON with MalformedJson", () => {
+    expect(errKind(parse("not json at all"))).toBe("MalformedJson");
   });
 });
 
-describe("Bonsai-subset — strict validation (the parse/construct conformance surface)", () => {
-  it("cint rejects non-integer / NaN / Infinity (no silent truncation)", () => {
-    expect(() => cint(1.9)).toThrow();
-    expect(() => cint(Number.NaN)).toThrow();
-    expect(() => cint(Number.POSITIVE_INFINITY)).toThrow();
+describe("Bonsai-subset — canonical-only (the serialize∘parse fixed point)", () => {
+  it("declines an unknown extra field with NonCanonical", () => {
+    expect(errKind(parse('{"v":1,"expr":{"kind":"param","name":"x","extra":0}}'))).toBe("NonCanonical");
   });
 
-  it("cint rejects integers outside the JS safe-integer range (no silent rounding)", () => {
-    expect(() => cint(2 ** 53)).toThrow(); // 2^53 is NOT a safe integer (MAX is 2^53 - 1)
+  it("declines non-canonical whitespace with NonCanonical", () => {
+    expect(errKind(parse('{"v":1, "expr":{"kind":"param","name":"x"}}'))).toBe("NonCanonical");
   });
 
-  it("parse rejects a non-integer int literal", () => {
-    expect(() => parse('{"v":1,"expr":{"kind":"const","value":{"t":"int","v":1.5}}}')).toThrow();
+  it("declines non-canonical key order with NonCanonical", () => {
+    expect(errKind(parse('{"expr":{"kind":"param","name":"x"},"v":1}'))).toBe("NonCanonical");
+  });
+});
+
+describe("Bonsai-subset — total contract (no exception escapes, even on null)", () => {
+  it("serialize declines an unsafe-integer constant with NonSafeInt (cint is total)", () => {
+    expect(errKind(serialize(cint(2 ** 53)))).toBe("NonSafeInt"); // 2^53 is NOT safe (MAX is 2^53 - 1)
   });
 
-  it("parse rejects an int beyond the safe-integer range (e.g. an int64 from another oracle)", () => {
-    expect(() => parse('{"v":1,"expr":{"kind":"const","value":{"t":"int","v":99999999999999999}}}')).toThrow();
+  it("serialize declines a fractional constant with ExpectedInt", () => {
+    expect(errKind(serialize(cint(1.5)))).toBe("ExpectedInt");
   });
 
-  it("parse rejects an unknown binary operator (e.g. div)", () => {
-    expect(() =>
-      parse('{"v":1,"expr":{"kind":"binary","op":"div","left":{"kind":"param","name":"a"},"right":{"kind":"param","name":"b"}}}'),
-    ).toThrow();
+  it("serialize accepts the safe-integer boundary (2^53 - 1)", () => {
+    expect(expectOk(serialize(cint(2 ** 53 - 1)))).toBe('{"v":1,"expr":{"kind":"const","value":{"t":"int","v":9007199254740991}}}');
   });
 
-  it("parse rejects non-array call args", () => {
-    expect(() => parse('{"v":1,"expr":{"kind":"call","fn":"f","args":"nope"}}')).toThrow();
+  it("serialize declines a null string field with ExpectedString (no NRE)", () => {
+    // A JS caller (no TS types) can pass null through param(); decline cleanly.
+    expect(errKind(serialize(param(null as unknown as string)))).toBe("ExpectedString");
   });
 
-  it("parse rejects a null expr (deterministic Bonsai error, not a generic TypeError)", () => {
-    expect(() => parse('{"v":1,"expr":null}')).toThrow();
+  it("parse declines null input with MalformedJson (no throw)", () => {
+    expect(errKind(parse(null as unknown as string))).toBe("MalformedJson");
+  });
+});
+
+describe("Bonsai-subset — nesting-depth contract (shared MaxDepth, bounded)", () => {
+  const buildDeepChain = (n: number): Expr => {
+    let e: Expr = cint(1);
+    for (let i = 0; i < n; i++) e = { kind: "binary", op: "add", left: e, right: cint(0) };
+    return e;
+  };
+
+  it("a deep-but-valid expression round-trips (past JSON's typical default depth)", () => {
+    const deep = buildDeepChain(100);
+    expect(equals(expectOk(parse(expectOk(serialize(deep)))), deep)).toBe(true);
   });
 
-  it("parse rejects a null const value", () => {
-    expect(() => parse('{"v":1,"expr":{"kind":"const","value":null}}')).toThrow();
-  });
-
-  it("parse rejects a non-object document", () => {
-    expect(() => parse("null")).toThrow();
-    expect(() => parse("42")).toThrow();
-  });
-
-  it("parse rejects a bool literal carrying a non-boolean value", () => {
-    expect(() => parse('{"v":1,"expr":{"kind":"const","value":{"t":"bool","v":1}}}')).toThrow();
-  });
-
-  // Canonical-only: parse accepts the canonical byte form ONLY, so the advertised
-  // serialize∘parse fixed point holds and a non-canonical saga vector can't pass
-  // this oracle yet disagree on a peer oracle's byte-diff.
-  it("parse rejects a non-canonical vector carrying an unknown extra field", () => {
-    expect(() => parse('{"v":1,"expr":{"kind":"param","name":"x","extra":0}}')).toThrow();
-  });
-
-  it("parse rejects non-canonical whitespace (canonical form is whitespace-free)", () => {
-    expect(() => parse('{"v":1, "expr":{"kind":"param","name":"x"}}')).toThrow();
-  });
-
-  it("parse rejects non-canonical key order (canonical fixes kind/v first)", () => {
-    expect(() => parse('{"expr":{"kind":"param","name":"x"},"v":1}')).toThrow();
+  it("serialize declines an expression past the shared MaxDepth with TooDeep", () => {
+    expect(errKind(serialize(buildDeepChain(BONSAI_MAX_DEPTH + 50)))).toBe("TooDeep");
   });
 });

--- a/src/Core.TypeScript/bonsai/bonsai.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.ts
@@ -194,6 +194,9 @@ function emitConst(c: ConstValue): string {
     case "str":
       return `{"t":"str","v":${jstr(c.v, "const str value")}}`;
     case "bool":
+      // Validate the runtime type (an untyped JS caller could pass a truthy
+      // non-boolean); decline ExpectedBool so serialize agrees with parse.
+      if (typeof c.v !== "boolean") throw new BonsaiFail({ kind: "ExpectedBool", where: "const bool value" });
       return `{"t":"bool","v":${c.v ? "true" : "false"}}`;
     case "null":
       return `{"t":"null"}`;
@@ -212,8 +215,13 @@ function emitAt(depth: number, e: Expr): string {
       return `{"kind":"param","name":${jstr(e.name, "param.name")}}`;
     case "lambda":
       return `{"kind":"lambda","params":[${e.params.map((p) => jstr(p, "lambda.params[]")).join(",")}],"body":${emitAt(depth + 1, e.body)}}`;
-    case "binary":
+    case "binary": {
+      // Validate the operator at the boundary the same way parse does (an untyped
+      // JS caller could cast an invalid op); decline UnknownOp rather than emit
+      // bytes a peer oracle would reject.
+      if (!BIN_OPS.has(e.op)) throw new BonsaiFail({ kind: "UnknownOp", op: String(e.op) });
       return `{"kind":"binary","op":${JSON.stringify(e.op)},"left":${emitAt(depth + 1, e.left)},"right":${emitAt(depth + 1, e.right)}}`;
+    }
     case "call":
       return `{"kind":"call","fn":${jstr(e.fn, "call.fn")},"args":[${e.args.map((a) => emitAt(depth + 1, a)).join(",")}]}`;
     case "cond":

--- a/src/Core.TypeScript/bonsai/bonsai.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.ts
@@ -19,10 +19,20 @@
  * Canonical form (the cross-oracle byte-diff contract): `serialize` emits
  * **compact JSON** (no whitespace) with a **fixed key order per node-kind**
  * (`kind` first, then fields in declared order) and **integer-only** numeric
- * literals (no floats — float formatting diverges across languages). Two oracles
- * agree iff their `serialize` outputs are byte-identical, and `parse` round-trips
- * (`serialize(parse(s)) === s`, `equals(parse(serialize(e)), e)`). String values
- * use standard JSON escaping. Document wrapper: `{"v":1,"expr":<node>}`.
+ * literals in the shared JS-safe-integer range (no floats — float formatting
+ * diverges across languages). Two oracles agree iff their `serialize` outputs are
+ * byte-identical, and `parse` round-trips (`serialize(parse(s))` is `Ok s`). String
+ * values use standard JSON escaping. Document wrapper: `{"v":1,"expr":<node>}`.
+ *
+ * Error channel (matches the F# oracle): `serialize`/`parse` return
+ * `Result<_, BonsaiFeedback>` — no exceptions cross the boundary (result over
+ * throw). TS owns a minimal zero-dep `Result` port (no BCL Result in JS); a
+ * consumer wanting the ecosystem shape can adapt it to neverthrow at the seam.
+ * `BonsaiFeedback` is the shared cross-oracle payload (the `'TError`/`E` in the
+ * F#/Rust native `Result`). Per the contract-vs-mechanism split, the internals use
+ * an internal typed signal adapted to `Result` at the two boundaries. Fail-fast
+ * (monadic); the accumulate-mode (RFC-9457 ProblemDetails) is the complementary
+ * primitive for batch/validation, per B-0976.
  */
 
 /** A literal value — tagged so every oracle round-trips the type exactly. */
@@ -47,23 +57,72 @@ export type Expr =
 /** The serialization format version (the `v` field of the document wrapper). */
 export const BONSAI_VERSION = 1;
 
-// ---- validation helpers (construct + parse are strict conformance surfaces) -
+/**
+ * The shared v1 maximum expression nesting depth. Bounds the recursive
+ * serializer/parser (a stack-overflow / DoS guard) and is the cross-oracle depth
+ * contract, so a tree that round-trips in one oracle round-trips in every oracle.
+ */
+export const BONSAI_MAX_DEPTH = 1024;
+
+// ---- Result port + feedback contract ---------------------------------------
+
+/**
+ * Minimal Result port (zero-dep; JS has no BCL Result). `serialize`/`parse`
+ * return this; a consumer can adapt it to the ecosystem lib (neverthrow) at the
+ * seam — own-our-interface, tie in at the boundary.
+ */
+export type Result<T, E> = { readonly ok: true; readonly value: T } | { readonly ok: false; readonly error: E };
+
+/**
+ * The bonsai-domain feedback channel — the typed reasons serialize/parse decline,
+ * the shared cross-oracle payload contract (mirrors the F# `BonsaiFeedback` DU).
+ * The `where` fields are JSON-pointer-ish keys so a `BonsaiFeedback[]` maps onto an
+ * RFC-9457 ProblemDetails `errors` map when the accumulate mode is wanted.
+ */
+export type BonsaiFeedback =
+  | { readonly kind: "UnsupportedVersion"; readonly found: number; readonly expected: number }
+  | { readonly kind: "MalformedJson"; readonly message: string }
+  | { readonly kind: "UnknownKind"; readonly nodeKind: string }
+  | { readonly kind: "UnknownConstTag"; readonly tag: string }
+  | { readonly kind: "UnknownOp"; readonly op: string }
+  | { readonly kind: "ExpectedString"; readonly where: string }
+  | { readonly kind: "ExpectedBool"; readonly where: string }
+  | { readonly kind: "ExpectedInt"; readonly where: string }
+  | { readonly kind: "NonSafeInt"; readonly value: number }
+  | { readonly kind: "TooDeep"; readonly limit: number }
+  | { readonly kind: "NonCanonical" };
+
+const ok = <T>(value: T): Result<T, never> => ({ ok: true, value });
+const err = (error: BonsaiFeedback): Result<never, BonsaiFeedback> => ({ ok: false, error });
+
+/**
+ * Internal typed signal — the validation helpers throw this on a decline;
+ * serialize/parse catch it at the boundary and return `Error`. The wire contract
+ * stays `Result` (the TS internal mechanism; contract-vs-mechanism split).
+ */
+class BonsaiFail extends Error {
+  readonly feedback: BonsaiFeedback;
+  constructor(feedback: BonsaiFeedback) {
+    super(feedback.kind);
+    this.name = "BonsaiFail";
+    this.feedback = feedback;
+  }
+}
+
+// ---- validation helpers (parse + emit are the conformance surfaces) ---------
 
 /** The valid binary operators, as a set for O(1) membership validation. */
 const BIN_OPS: ReadonlySet<string> = new Set<BinOp>(["add", "sub", "mul", "eq", "lt", "and", "or"]);
 
 /**
- * Validate a value is a finite, JS-**safe** integer — the v1 `int` domain. An
- * int64 from a C#/Rust oracle beyond 2^53 is REJECTED, not silently rounded,
- * and a fractional / NaN / Infinity / non-number is rejected, not truncated —
- * keeping the cross-language byte contract exact (a value TS cannot represent
- * exactly must not be silently rewritten). A future v2 could widen ints to
- * bigint/string; v1 is the safe-integer range.
+ * Validate a value is a JS-**safe** integer — the v1 `int` domain. A fractional /
+ * NaN / Infinity / non-number declines `ExpectedInt`; an integer beyond 2^53-1
+ * declines `NonSafeInt` (a value a peer oracle could not preserve) — never
+ * silently rounded or truncated.
  */
 function asSafeInt(v: unknown, where: string): number {
-  if (typeof v !== "number" || !Number.isSafeInteger(v)) {
-    throw new Error(`bonsai: ${where} expects a safe integer, got ${typeof v === "number" ? String(v) : typeof v}`);
-  }
+  if (typeof v !== "number" || !Number.isInteger(v)) throw new BonsaiFail({ kind: "ExpectedInt", where });
+  if (!Number.isSafeInteger(v)) throw new BonsaiFail({ kind: "NonSafeInt", value: v });
   return v;
 }
 
@@ -71,34 +130,34 @@ function asSafeInt(v: unknown, where: string): number {
 function asObject(v: unknown, where: string): Record<string, unknown> {
   if (typeof v !== "object" || v === null || Array.isArray(v)) {
     const got = v === null ? "null" : Array.isArray(v) ? "array" : typeof v;
-    throw new Error(`bonsai: ${where} expects an object, got ${got}`);
+    throw new BonsaiFail({ kind: "MalformedJson", message: `${where} expects an object, got ${got}` });
   }
   return v as Record<string, unknown>;
 }
 
 /** Validate a value is a string. */
 function asString(v: unknown, where: string): string {
-  if (typeof v !== "string") throw new Error(`bonsai: ${where} expects a string, got ${typeof v}`);
+  if (typeof v !== "string") throw new BonsaiFail({ kind: "ExpectedString", where });
   return v;
 }
 
 /** Validate a value is an array. */
 function asArray(v: unknown, where: string): unknown[] {
-  if (!Array.isArray(v)) throw new Error(`bonsai: ${where} expects an array, got ${typeof v}`);
+  if (!Array.isArray(v)) throw new BonsaiFail({ kind: "MalformedJson", message: `${where} expects an array, got ${typeof v}` });
   return v;
 }
 
 /** Validate a value is one of the known binary operators. */
 function asBinOp(v: unknown, where: string): BinOp {
   const s = asString(v, where);
-  if (!BIN_OPS.has(s)) throw new Error(`bonsai: ${where} unknown binary operator: ${s}`);
+  if (!BIN_OPS.has(s)) throw new BonsaiFail({ kind: "UnknownOp", op: s });
   return s as BinOp;
 }
 
-// ---- constructors (ergonomic builders; optional) ---------------------------
+// ---- constructors (ergonomic builders; total — validation is at the boundary)
 
-/** A literal-int constant. Rejects non-safe-integer / fractional / NaN / Infinity. */
-export const cint = (v: number): Expr => ({ kind: "const", value: { t: "int", v: asSafeInt(v, "cint") } });
+/** A literal-int constant. (Total; an unsafe/fractional int declines at `serialize`.) */
+export const cint = (v: number): Expr => ({ kind: "const", value: { t: "int", v } });
 /** A literal-string constant. */
 export const cstr = (v: string): Expr => ({ kind: "const", value: { t: "str", v } });
 /** A literal-bool constant. */
@@ -118,15 +177,22 @@ export const cond = (test: Expr, then: Expr, els: Expr): Expr => ({ kind: "cond"
 
 // ---- serialize (canonical, byte-exact) ------------------------------------
 
+/** JSON-escape a string field, declining `ExpectedString` on a non-string (e.g.
+ * a CLR/JS `null` slipped past the types) so serialize stays total. */
+function jstr(v: string, where: string): string {
+  if (typeof v !== "string") throw new BonsaiFail({ kind: "ExpectedString", where });
+  return JSON.stringify(v);
+}
+
 /** Emit a constant value in canonical compact form (`t` first, then `v`). */
 function emitConst(c: ConstValue): string {
   switch (c.t) {
     case "int":
       // Safe integers always stringify to plain digits (no exponent), so the
-      // emitted bytes are reproducible across oracles; reject anything else.
-      return `{"t":"int","v":${asSafeInt(c.v, "emit int")}}`;
+      // emitted bytes are reproducible across oracles; decline anything else.
+      return `{"t":"int","v":${asSafeInt(c.v, "const int value")}}`;
     case "str":
-      return `{"t":"str","v":${JSON.stringify(c.v)}}`;
+      return `{"t":"str","v":${jstr(c.v, "const str value")}}`;
     case "bool":
       return `{"t":"bool","v":${c.v ? "true" : "false"}}`;
     case "null":
@@ -134,27 +200,36 @@ function emitConst(c: ConstValue): string {
   }
 }
 
-/** Emit a node in canonical compact form (fixed key order per kind). */
-function emit(e: Expr): string {
+/** Emit a node in canonical compact form (fixed key order per kind); declines
+ * `TooDeep` past the shared MaxDepth so serialize never emits a tree the parser
+ * could not read back, and recursion is bounded. */
+function emitAt(depth: number, e: Expr): string {
+  if (depth > BONSAI_MAX_DEPTH) throw new BonsaiFail({ kind: "TooDeep", limit: BONSAI_MAX_DEPTH });
   switch (e.kind) {
     case "const":
       return `{"kind":"const","value":${emitConst(e.value)}}`;
     case "param":
-      return `{"kind":"param","name":${JSON.stringify(e.name)}}`;
+      return `{"kind":"param","name":${jstr(e.name, "param.name")}}`;
     case "lambda":
-      return `{"kind":"lambda","params":[${e.params.map((p) => JSON.stringify(p)).join(",")}],"body":${emit(e.body)}}`;
+      return `{"kind":"lambda","params":[${e.params.map((p) => jstr(p, "lambda.params[]")).join(",")}],"body":${emitAt(depth + 1, e.body)}}`;
     case "binary":
-      return `{"kind":"binary","op":${JSON.stringify(e.op)},"left":${emit(e.left)},"right":${emit(e.right)}}`;
+      return `{"kind":"binary","op":${JSON.stringify(e.op)},"left":${emitAt(depth + 1, e.left)},"right":${emitAt(depth + 1, e.right)}}`;
     case "call":
-      return `{"kind":"call","fn":${JSON.stringify(e.fn)},"args":[${e.args.map(emit).join(",")}]}`;
+      return `{"kind":"call","fn":${jstr(e.fn, "call.fn")},"args":[${e.args.map((a) => emitAt(depth + 1, a)).join(",")}]}`;
     case "cond":
-      return `{"kind":"cond","test":${emit(e.test)},"then":${emit(e.then)},"else":${emit(e.else)}}`;
+      return `{"kind":"cond","test":${emitAt(depth + 1, e.test)},"then":${emitAt(depth + 1, e.then)},"else":${emitAt(depth + 1, e.else)}}`;
   }
 }
 
-/** Serialize an expression to the canonical Bonsai-subset string. */
-export function serialize(e: Expr): string {
-  return `{"v":${BONSAI_VERSION},"expr":${emit(e)}}`;
+/** Serialize an expression to the canonical Bonsai-subset string. Declines on an
+ * unsafe/fractional integer literal, a null string field, or nesting past MaxDepth. */
+export function serialize(e: Expr): Result<string, BonsaiFeedback> {
+  try {
+    return ok(`{"v":${BONSAI_VERSION},"expr":${emitAt(1, e)}}`);
+  } catch (ex) {
+    if (ex instanceof BonsaiFail) return err(ex.feedback);
+    throw ex;
+  }
 }
 
 // ---- parse (canonical string -> Expr) -------------------------------------
@@ -168,14 +243,12 @@ function parseConst(n: unknown): ConstValue {
     case "str":
       return { t: "str", v: asString(o.v, "const str value") };
     case "bool":
-      if (typeof o.v !== "boolean") {
-        throw new Error(`bonsai: const bool value expects a boolean, got ${typeof o.v}`);
-      }
+      if (typeof o.v !== "boolean") throw new BonsaiFail({ kind: "ExpectedBool", where: "const bool value" });
       return { t: "bool", v: o.v };
     case "null":
       return { t: "null" };
     default:
-      throw new Error(`bonsai: unknown const tag: ${String(o.t)}`);
+      throw new BonsaiFail({ kind: "UnknownConstTag", tag: String(o.t) });
   }
 }
 
@@ -201,32 +274,42 @@ function parseNode(n: unknown): Expr {
     case "cond":
       return { kind: "cond", test: parseNode(o.test), then: parseNode(o.then), else: parseNode(o.else) };
     default:
-      throw new Error(`bonsai: unknown node kind: ${kind}`);
+      throw new BonsaiFail({ kind: "UnknownKind", nodeKind: kind });
   }
 }
 
 /**
  * Parse a canonical Bonsai-subset string back to an `Expr` — strict and
  * **canonical-only**. Accepts the canonical byte form ONLY: a structurally-valid
- * but non-canonical vector (extra fields, whitespace, reordered keys) is rejected
- * rather than silently canonicalized. This enforces the advertised `serialize ∘
- * parse` fixed point as a precondition — without it, `serialize(parse(s)) !== s`
- * for such `s`, and a non-canonical saga vector could pass this oracle yet fail a
- * peer oracle's byte-diff (the very invariant the cross-language oracles exist to
- * guarantee).
+ * but non-canonical vector (extra fields, whitespace, reordered keys) declines
+ * `NonCanonical` rather than silently canonicalizing — enforcing the
+ * `serialize(parse(s)) === Ok s` fixed point so the oracles agree on which input is
+ * valid. Returns `Result` — no exception crosses the boundary, even on `null` input
+ * or malformed JSON.
  */
-export function parse(s: string): Expr {
-  const doc = asObject(JSON.parse(s), "document");
-  if (doc.v !== BONSAI_VERSION) {
-    throw new Error(`bonsai: unsupported version ${String(doc.v)} (expected ${BONSAI_VERSION})`);
+export function parse(s: string): Result<Expr, BonsaiFeedback> {
+  if (typeof s !== "string") return err({ kind: "MalformedJson", message: "input was not a string" });
+  let doc: unknown;
+  try {
+    doc = JSON.parse(s);
+  } catch (ex) {
+    return err({ kind: "MalformedJson", message: ex instanceof Error ? ex.message : String(ex) });
   }
-  const result = parseNode(doc.expr);
-  // Canonical-only guard: the round-trip must reproduce the input byte-for-byte.
-  const round = serialize(result);
-  if (round !== s) {
-    throw new Error(`bonsai: input is not in canonical form (serialize(parse(s)) !== s)`);
+  try {
+    const d = asObject(doc, "document");
+    if (typeof d.v !== "number") return err({ kind: "MalformedJson", message: "document v is not a number" });
+    if (d.v !== BONSAI_VERSION) return err({ kind: "UnsupportedVersion", found: d.v, expected: BONSAI_VERSION });
+    const result = parseNode(d.expr);
+    // Canonical-only guard: the round-trip must reproduce the input byte-for-byte
+    // (serialize also re-checks depth + safe-int, so an over-deep input declines here).
+    const round = serialize(result);
+    if (!round.ok) return round;
+    if (round.value !== s) return err({ kind: "NonCanonical" });
+    return ok(result);
+  } catch (ex) {
+    if (ex instanceof BonsaiFail) return err(ex.feedback);
+    throw ex;
   }
-  return result;
 }
 
 // ---- structural equality --------------------------------------------------

--- a/src/Core.TypeScript/bonsai/bonsai.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.ts
@@ -252,8 +252,14 @@ function parseConst(n: unknown): ConstValue {
   }
 }
 
-/** Rebuild an `Expr` from parsed JSON — strict (validates shape, kind, fields). */
-function parseNode(n: unknown): Expr {
+/** Rebuild an `Expr` from parsed JSON — strict (validates shape, kind, fields).
+ * Carries a depth counter so a deeply-nested input declines `TooDeep` *during*
+ * parsing — bounding recursion (no stack-overflow / RangeError escaping the
+ * Result) rather than relying only on the after-the-fact serialize guard.
+ * (F#'s parseNode is bounded by its JsonDocument MaxDepth; JS's JSON.parse has no
+ * such bound, so the counter must be explicit here.) */
+function parseNode(depth: number, n: unknown): Expr {
+  if (depth > BONSAI_MAX_DEPTH) throw new BonsaiFail({ kind: "TooDeep", limit: BONSAI_MAX_DEPTH });
   const o = asObject(n, "node");
   const kind = asString(o.kind, "node.kind");
   switch (kind) {
@@ -265,14 +271,24 @@ function parseNode(n: unknown): Expr {
       return {
         kind: "lambda",
         params: asArray(o.params, "lambda.params").map((p) => asString(p, "lambda.params[]")),
-        body: parseNode(o.body),
+        body: parseNode(depth + 1, o.body),
       };
     case "binary":
-      return { kind: "binary", op: asBinOp(o.op, "binary.op"), left: parseNode(o.left), right: parseNode(o.right) };
+      return {
+        kind: "binary",
+        op: asBinOp(o.op, "binary.op"),
+        left: parseNode(depth + 1, o.left),
+        right: parseNode(depth + 1, o.right),
+      };
     case "call":
-      return { kind: "call", fn: asString(o.fn, "call.fn"), args: asArray(o.args, "call.args").map(parseNode) };
+      return { kind: "call", fn: asString(o.fn, "call.fn"), args: asArray(o.args, "call.args").map((a) => parseNode(depth + 1, a)) };
     case "cond":
-      return { kind: "cond", test: parseNode(o.test), then: parseNode(o.then), else: parseNode(o.else) };
+      return {
+        kind: "cond",
+        test: parseNode(depth + 1, o.test),
+        then: parseNode(depth + 1, o.then),
+        else: parseNode(depth + 1, o.else),
+      };
     default:
       throw new BonsaiFail({ kind: "UnknownKind", nodeKind: kind });
   }
@@ -299,7 +315,7 @@ export function parse(s: string): Result<Expr, BonsaiFeedback> {
     const d = asObject(doc, "document");
     if (typeof d.v !== "number") return err({ kind: "MalformedJson", message: "document v is not a number" });
     if (d.v !== BONSAI_VERSION) return err({ kind: "UnsupportedVersion", found: d.v, expected: BONSAI_VERSION });
-    const result = parseNode(d.expr);
+    const result = parseNode(1, d.expr);
     // Canonical-only guard: the round-trip must reproduce the input byte-for-byte
     // (serialize also re-checks depth + safe-int, so an over-deep input declines here).
     const round = serialize(result);


### PR DESCRIPTION
Converts the TS reference Bonsai oracle from throw to a pure-`Result` contract, **matching the F# oracle (#6429)** — "make them match." Same node-set, same canonical bytes, same `BonsaiFeedback` variant set, same error channel.

## What changed
- `serialize`/`parse` return `Result<_, BonsaiFeedback>` — no exception crosses the boundary (result over throw). TS owns a **minimal zero-dep `Result` port** (no BCL Result in JS; a consumer can adapt to neverthrow at the seam — hexagonal).
- `BonsaiFeedback` **mirrors the F# DU exactly** (the shared cross-oracle payload): `UnsupportedVersion / MalformedJson / UnknownKind / UnknownConstTag / UnknownOp / ExpectedString / ExpectedBool / ExpectedInt / NonSafeInt / TooDeep / NonCanonical`. `where` fields are JSON-pointer keys (ProblemDetails-ready for the accumulate-mode).
- Adopts the shared **`BONSAI_MAX_DEPTH = 1024`** cap (TS lacked one → now matches F#'s `TooDeep` + the cross-oracle depth contract).
- Constructors total (validation at the boundary, matching F#'s raw DU); `serialize`/`parse` **total even on `null`** (null string field → `ExpectedString`; null input → `MalformedJson`).
- Rejections asserted by **specific variant** (cross-oracle rejection-vector contract); canonical-only parse + byte-exact golden parity preserved.

**49 tests, `tsc --noEmit` 0 errors.** No external consumers of the slice-1 module, so the signature change breaks nothing.

Internal mechanism: a private `BonsaiFail` adapted to `Result` at the two boundaries (contract-vs-mechanism split; matches F#). Fail-fast (monadic); the **accumulate-mode (RFC-9457 ProblemDetails)** is the additive next slice per B-0976 (the `where`-keyed payload is already designed for it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)