### PR TITLE
feat(B-0976): accumulate-mode for TS Bonsai oracle (parseAll + RFC-9457 ProblemDetails)

### DIFF
--- a/src/Core.TypeScript/bonsai/bonsai.test.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.test.ts
@@ -24,8 +24,10 @@ import {
   type Expr,
   param,
   parse,
+  parseAll,
   type Result,
   serialize,
+  toProblemDetails,
 } from "./bonsai";
 
 interface GoldenCase {
@@ -221,5 +223,59 @@ describe("Bonsai-subset — nesting-depth contract (shared MaxDepth, bounded)", 
       node = `{"kind":"binary","op":"add","left":${node},"right":{"kind":"const","value":{"t":"int","v":0}}}`;
     }
     expect(errKind(parse(`{"v":1,"expr":${node}}`))).toBe("TooDeep");
+  });
+});
+
+describe("Bonsai-subset — accumulate-mode (parseAll + ProblemDetails)", () => {
+  it("parseAll returns Ok(Expr) for every valid canonical golden vector", () => {
+    for (const c of golden.cases) {
+      const r = parseAll(c.canonical);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(equals(r.value, c.expr)).toBe(true);
+    }
+  });
+
+  it("parseAll collects EVERY independent decline with its JSON-path (not just the first)", () => {
+    // op="div" (UnknownOp @ $.expr.op) + left name=null (ExpectedString @ $.expr.left.name)
+    // + right bool v=1 (ExpectedBool @ $.expr.right.value) — three independent errors.
+    const doc =
+      '{"v":1,"expr":{"kind":"binary","op":"div","left":{"kind":"param","name":null},"right":{"kind":"const","value":{"t":"bool","v":1}}}}';
+    const r = parseAll(doc);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.map((e) => e.feedback.kind).sort()).toEqual(["ExpectedBool", "ExpectedString", "UnknownOp"]);
+      expect(r.error.map((e) => e.path).sort()).toEqual(["$.expr.left.name", "$.expr.op", "$.expr.right.value"]);
+    }
+  });
+
+  it("toProblemDetails groups the declines into an RFC-9457 errors map keyed by path", () => {
+    const doc =
+      '{"v":1,"expr":{"kind":"binary","op":"div","left":{"kind":"param","name":null},"right":{"kind":"const","value":{"t":"int","v":1.5}}}}';
+    const r = parseAll(doc);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      const pd = toProblemDetails(r.error);
+      expect(pd.title).toBe("Bonsai validation failed");
+      expect(Object.keys(pd.errors).sort()).toEqual(["$.expr.left.name", "$.expr.op", "$.expr.right.value"]);
+      expect(pd.errors["$.expr.op"]?.length).toBe(1);
+    }
+  });
+
+  it("parseAll returns a single decline for fatal-structural input (malformed JSON)", () => {
+    const r = parseAll("not json");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toHaveLength(1);
+      expect(r.error[0]!.feedback.kind).toBe("MalformedJson");
+    }
+  });
+
+  it("parseAll declines NonCanonical (single) for structurally-valid but non-canonical input", () => {
+    const r = parseAll('{"v":1,"expr":{"kind":"param","name":"x","extra":0}}');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toHaveLength(1);
+      expect(r.error[0]!.feedback.kind).toBe("NonCanonical");
+    }
   });
 });

--- a/src/Core.TypeScript/bonsai/bonsai.ts
+++ b/src/Core.TypeScript/bonsai/bonsai.ts
@@ -375,3 +375,179 @@ export function equals(a: Expr, b: Expr): boolean {
     }
   }
 }
+
+// ---- accumulate-mode (RFC-9457 ProblemDetails) ----------------------------
+//
+// The applicative complement to the fail-fast `parse`: instead of declining at the
+// first error, `parseAll` collects EVERY per-node decline keyed by its JSON-path —
+// "see all the things that went wrong," for debugging a malformed tree / batch /
+// model-validation. Additive over the same `BonsaiFeedback` payload; `toProblemDetails`
+// adapts the collected list to the RFC-9457 shape (.NET `ValidationProblemDetails`'s
+// `errors: {field: messages[]}`). Independent sub-trees accumulate; a fatal-structural
+// node (unknown kind, not-an-object, missing kind) is single for that node (can't
+// recurse what it doesn't understand) but siblings still accumulate.
+
+/** A decline tagged with the JSON-path where it occurred (the ProblemDetails key). */
+export interface PathedFeedback {
+  readonly path: string;
+  readonly feedback: BonsaiFeedback;
+}
+
+/** RFC-9457 "Problem Details" — the field-keyed multi-error document (the shape
+ * .NET ships as `ValidationProblemDetails`; useful well outside HTTP). */
+export interface ProblemDetails {
+  readonly type: string;
+  readonly title: string;
+  readonly errors: Record<string, string[]>;
+}
+
+/** A human-readable message for a feedback variant (the ProblemDetails value). */
+function feedbackMessage(f: BonsaiFeedback): string {
+  switch (f.kind) {
+    case "UnsupportedVersion":
+      return `unsupported version ${f.found} (expected ${f.expected})`;
+    case "MalformedJson":
+      return f.message;
+    case "UnknownKind":
+      return `unknown node kind "${f.nodeKind}"`;
+    case "UnknownConstTag":
+      return `unknown const tag "${f.tag}"`;
+    case "UnknownOp":
+      return `unknown binary operator "${f.op}"`;
+    case "ExpectedString":
+      return "expected a string";
+    case "ExpectedBool":
+      return "expected a boolean";
+    case "ExpectedInt":
+      return "expected a safe integer";
+    case "NonSafeInt":
+      return `integer ${f.value} is outside the safe-integer range`;
+    case "TooDeep":
+      return `nesting exceeds the maximum depth of ${f.limit}`;
+    case "NonCanonical":
+      return "input is not in canonical form";
+  }
+}
+
+/** Adapt the collected declines to an RFC-9457 ProblemDetails document: group by
+ * JSON-path into the `errors` map (each path → its messages). */
+export function toProblemDetails(feedbacks: readonly PathedFeedback[]): ProblemDetails {
+  const errors: Record<string, string[]> = {};
+  for (const { path, feedback } of feedbacks) {
+    (errors[path] ??= []).push(feedbackMessage(feedback));
+  }
+  return { type: "about:blank", title: "Bonsai validation failed", errors };
+}
+
+/** Collect declines for a const value into `out` (non-throwing; mirrors parseConst). */
+function pushConst(path: string, n: unknown, out: PathedFeedback[]): void {
+  if (typeof n !== "object" || n === null || Array.isArray(n)) {
+    out.push({ path, feedback: { kind: "MalformedJson", message: `${path} is not an object` } });
+    return;
+  }
+  const o = n as Record<string, unknown>;
+  switch (o.t) {
+    case "int":
+      if (typeof o.v !== "number" || !Number.isInteger(o.v)) out.push({ path, feedback: { kind: "ExpectedInt", where: path } });
+      else if (!Number.isSafeInteger(o.v)) out.push({ path, feedback: { kind: "NonSafeInt", value: o.v } });
+      return;
+    case "str":
+      if (typeof o.v !== "string") out.push({ path, feedback: { kind: "ExpectedString", where: path } });
+      return;
+    case "bool":
+      if (typeof o.v !== "boolean") out.push({ path, feedback: { kind: "ExpectedBool", where: path } });
+      return;
+    case "null":
+      return;
+    default:
+      out.push({ path, feedback: { kind: "UnknownConstTag", tag: String(o.t) } });
+  }
+}
+
+/** Collect declines for a node into `out`, recursing all independent children
+ * (non-throwing; the accumulate counterpart of parseNode). A fatal-structural node
+ * (not-object / missing-or-unknown kind / too deep) is single for that node; its
+ * siblings still accumulate. */
+function pushNode(path: string, depth: number, n: unknown, out: PathedFeedback[]): void {
+  if (depth > BONSAI_MAX_DEPTH) {
+    out.push({ path, feedback: { kind: "TooDeep", limit: BONSAI_MAX_DEPTH } });
+    return;
+  }
+  if (typeof n !== "object" || n === null || Array.isArray(n)) {
+    out.push({ path, feedback: { kind: "MalformedJson", message: `${path} is not an object` } });
+    return;
+  }
+  const o = n as Record<string, unknown>;
+  if (typeof o.kind !== "string") {
+    out.push({ path, feedback: { kind: "MalformedJson", message: `${path}.kind is missing or not a string` } });
+    return;
+  }
+  switch (o.kind) {
+    case "const":
+      pushConst(`${path}.value`, o.value, out);
+      return;
+    case "param":
+      if (typeof o.name !== "string") out.push({ path: `${path}.name`, feedback: { kind: "ExpectedString", where: `${path}.name` } });
+      return;
+    case "lambda":
+      if (Array.isArray(o.params)) {
+        o.params.forEach((p, i) => {
+          if (typeof p !== "string") out.push({ path: `${path}.params[${i}]`, feedback: { kind: "ExpectedString", where: `${path}.params[${i}]` } });
+        });
+      } else {
+        out.push({ path: `${path}.params`, feedback: { kind: "MalformedJson", message: `${path}.params is not an array` } });
+      }
+      pushNode(`${path}.body`, depth + 1, o.body, out);
+      return;
+    case "binary":
+      if (typeof o.op !== "string" || !BIN_OPS.has(o.op)) out.push({ path: `${path}.op`, feedback: { kind: "UnknownOp", op: String(o.op) } });
+      pushNode(`${path}.left`, depth + 1, o.left, out);
+      pushNode(`${path}.right`, depth + 1, o.right, out);
+      return;
+    case "call":
+      if (typeof o.fn !== "string") out.push({ path: `${path}.fn`, feedback: { kind: "ExpectedString", where: `${path}.fn` } });
+      if (Array.isArray(o.args)) o.args.forEach((a, i) => pushNode(`${path}.args[${i}]`, depth + 1, a, out));
+      else out.push({ path: `${path}.args`, feedback: { kind: "MalformedJson", message: `${path}.args is not an array` } });
+      return;
+    case "cond":
+      pushNode(`${path}.test`, depth + 1, o.test, out);
+      pushNode(`${path}.then`, depth + 1, o.then, out);
+      pushNode(`${path}.else`, depth + 1, o.else, out);
+      return;
+    default:
+      out.push({ path, feedback: { kind: "UnknownKind", nodeKind: o.kind } });
+  }
+}
+
+/**
+ * Accumulate-mode parse: like `parse`, but on failure returns **every** per-node
+ * decline (each with its JSON-path) instead of just the first — the applicative
+ * complement for batch / model-validation / debugging a malformed tree. On success
+ * returns the same `Expr` as `parse` (the canonical-only contract still applies; a
+ * structurally-valid-but-non-canonical input declines `NonCanonical` at `$`).
+ */
+export function parseAll(s: string): Result<Expr, PathedFeedback[]> {
+  if (typeof s !== "string") return { ok: false, error: [{ path: "$", feedback: { kind: "MalformedJson", message: "input was not a string" } }] };
+  let doc: unknown;
+  try {
+    doc = JSON.parse(s);
+  } catch (ex) {
+    return { ok: false, error: [{ path: "$", feedback: { kind: "MalformedJson", message: ex instanceof Error ? ex.message : String(ex) } }] };
+  }
+  if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
+    return { ok: false, error: [{ path: "$", feedback: { kind: "MalformedJson", message: "document is not an object" } }] };
+  }
+  const d = doc as Record<string, unknown>;
+  if (typeof d.v !== "number") return { ok: false, error: [{ path: "$.v", feedback: { kind: "MalformedJson", message: "document v is not a number" } }] };
+  if (d.v !== BONSAI_VERSION) return { ok: false, error: [{ path: "$.v", feedback: { kind: "UnsupportedVersion", found: d.v, expected: BONSAI_VERSION } }] };
+
+  const errs: PathedFeedback[] = [];
+  pushNode("$.expr", 1, d.expr, errs);
+  if (errs.length > 0) return { ok: false, error: errs };
+
+  // Structurally valid → reuse the fail-fast parse for the Expr + canonical guard.
+  // The only decline reachable here is NonCanonical (structure already validated).
+  const r = parse(s);
+  if (r.ok) return ok(r.value);
+  return { ok: false, error: [{ path: "$", feedback: r.error }] };
+}


### PR DESCRIPTION
The accumulate-mode slice (TS reference first), the applicative complement to the fail-fast `parse` — "see all the things that went wrong" for debugging a malformed tree / batch / model-validation.

## What it adds (additive over the same `BonsaiFeedback` payload)
- **`parseAll : string -> Result<Expr, PathedFeedback[]>`** — collects **every** per-node decline keyed by its JSON-path instead of short-circuiting. Independent sub-trees accumulate (binary left+right, call args, lambda params, cond branches, each bad const); a fatal-structural node (not-object / missing-or-unknown kind / too-deep) is single for that node, but its siblings still accumulate.
- **`PathedFeedback = { path, feedback }`** — each decline tagged with its JSON-path (the ProblemDetails key).
- **`ProblemDetails` (RFC-9457) + `toProblemDetails`** — groups declines into the `errors: {path: messages[]}` map (the shape .NET ships as `ValidationProblemDetails`; useful well outside HTTP).
- Reuses the fail-fast `parse` for the valid path (the only decline reachable after structural validation is `NonCanonical`) → minimal duplication; same canonical-only contract.

**+5 tests** (Ok on every golden; collects **3 independent declines with paths**; `toProblemDetails` errors-map; single fatal-structural; single `NonCanonical`) → **57 tests**, `tsc` 0.

Per "one at a time": TS reference now; **F# ferry next**. B-0976's accumulate slice flips to ✅ once F# lands too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)