### PR TITLE
feat(ace): slice 6.1 — ace registry publish (signed index producer + round-trip self-verify)

### DIFF
--- a/.claude/skills/ace/SKILL.md
+++ b/.claude/skills/ace/SKILL.md
@@ -224,3 +224,64 @@ injecting a future-dated index. The per-package **content-hash pin** and
 **Ed25519 signature gate** (slice 2–3) are unchanged and still enforced on every
 downloaded package. Remote registry support is additive security — the two layers
 cover different attack surfaces and both must pass.
+
+## Publishing a registry (slice 6.1)
+
+Slice 6.1 adds the producer side: `ace registry publish` scans a directory of
+package manifests, builds a signed index, and writes the file a registry serves.
+
+### Command
+
+```bash
+ace registry publish --packages <dir> --base-url <url> --key <pem-path> [--out index.json]
+```
+
+- **`--packages <dir>`** — directory to scan. Every `*.json` file is attempted
+  as a package manifest; files that do not parse as a valid package manifest are
+  skipped with a warning.
+- **`--base-url <url>`** — base URL of the registry. Each package's consumer
+  `url` is derived as `<base-url>/<name>-<version>.json` and its `package_hash`
+  is computed from the manifest file.
+- **`--key <pem-path>`** — path to the Ed25519 **private** key (PEM format, mode
+  0600). The index is signed with this key.
+- **`--out <file>`** — path to write the signed index JSON (default: `./index.json`).
+
+### Sequence auto-bump
+
+If `--out` already exists, `publish` reads the previous index and sets the new
+index's `sequence` to `prior_sequence + 1`. A sequence that is not strictly
+increasing is refused (exit 1). This is the producer-side mirror of the
+consumer's anti-rollback gate: the published sequence always advances.
+
+### Round-trip self-verify
+
+Before writing, `publish` re-parses the produced index through the same
+`parseIndex` path and signature check that `ace install` uses (verifying against
+the signing key's own public key). A published `index.json` is therefore
+guaranteed to satisfy `ace install` when a consumer has registered the registry
+with the matching key ID.
+
+To find the key ID to pin, run:
+
+```bash
+ace trust <pub-file>   # prints the key ID
+```
+
+Then on the consumer side:
+
+```bash
+ace registry remote add <url> --key <keyId>
+```
+
+### The published index
+
+The `index.json` written by `publish` is the file a registry serves at the URL
+consumers configure. It contains the package list, `sequence`, `issued_at`,
+and the Ed25519 signature over the canonical payload.
+
+### Deferred
+
+- Per-package URL override (custom artifact hosting).
+- ETag / Last-Modified sidecar for conditional-GET cache validation.
+- Multi-directory publish and incremental (append-only) publish.
+- Multi-signer publish (multiple signing keys on one index).

--- a/.claude/skills/ace/SKILL.md
+++ b/.claude/skills/ace/SKILL.md
@@ -242,8 +242,10 @@ ace registry publish --packages <dir> --base-url <url> --key <pem-path> [--out i
 - **`--base-url <url>`** — base URL of the registry. Each package's consumer
   `url` is derived as `<base-url>/<name>-<version>.json` and its `package_hash`
   is the `packageHash` of the canonical whole package (`{ manifest, files }`) — the same hash the consumer pins.
-- **`--key <pem-path>`** — path to the Ed25519 **private** key (PEM format, mode
-  0600). The index is signed with this key.
+- **`--key <pem-path>`** — path to the Ed25519 **private** key (PEM format). The index is signed
+  with this key. Recommended: restrict the key file so only you can read it
+  (e.g. `chmod 600` on POSIX); `publish` reads the key but does not enforce
+  its file permissions.
 - **`--out <file>`** — path to write the signed index JSON (default: `./index.json`).
 
 ### Sequence auto-bump

--- a/.claude/skills/ace/SKILL.md
+++ b/.claude/skills/ace/SKILL.md
@@ -241,7 +241,7 @@ ace registry publish --packages <dir> --base-url <url> --key <pem-path> [--out i
   skipped with a warning.
 - **`--base-url <url>`** — base URL of the registry. Each package's consumer
   `url` is derived as `<base-url>/<name>-<version>.json` and its `package_hash`
-  is computed from the manifest file.
+  is the `packageHash` of the canonical whole package (`{ manifest, files }`) — the same hash the consumer pins.
 - **`--key <pem-path>`** — path to the Ed25519 **private** key (PEM format, mode
   0600). The index is signed with this key.
 - **`--out <file>`** — path to write the signed index JSON (default: `./index.json`).
@@ -261,11 +261,7 @@ the signing key's own public key). A published `index.json` is therefore
 guaranteed to satisfy `ace install` when a consumer has registered the registry
 with the matching key ID.
 
-To find the key ID to pin, run:
-
-```bash
-ace trust <pub-file>   # prints the key ID
-```
+To find the `<keyId>` to pin, the `<keyId>` is shown by `ace trust list` (or printed by `ace trust add <pub>` when the key is added).
 
 Then on the consumer side:
 

--- a/.claude/skills/ace/SKILL.md
+++ b/.claude/skills/ace/SKILL.md
@@ -258,10 +258,15 @@ consumer's anti-rollback gate: the published sequence always advances.
 ### Round-trip self-verify
 
 Before writing, `publish` re-parses the produced index through the same
-`parseIndex` path and signature check that `ace install` uses (verifying against
-the signing key's own public key). A published `index.json` is therefore
-guaranteed to satisfy `ace install` when a consumer has registered the registry
-with the matching key ID.
+`parseIndex` path and signature check the consumer uses, verifying against the
+signing key's own public key. This guarantees the published `index.json` loads
+and verifies as a signed index for a consumer who pinned the matching registry
+key ID. It does **not** by itself guarantee `ace install` succeeds: install
+additionally verifies each package's own manifest signature against the
+consumer's package trust store, which may use a different key than the registry
+index. Consumers must trust both the registry key (for the index) and each
+package's signing key (for install), or pass `--allow-no-signature` for unsigned
+packages.
 
 To find the `<keyId>` to pin, the `<keyId>` is shown by `ace trust list` (or printed by `ace trust add <pub>` when the key is added).
 

--- a/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice6.1-implementation-plan.md
+++ b/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice6.1-implementation-plan.md
@@ -1,0 +1,460 @@
+# Ace CLI slice 6.1 — `ace registry publish` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `ace registry publish --packages <dir> --base-url <url> --key <pem> [--out index.json]`
+— scan a dir of package files, derive each consumer `url` + `package_hash`, assemble + sign
+the registry index, auto-bump `sequence` from `--out`, and round-trip self-verify the
+produced index through the consumer's `parseIndex` + `verifyIndexSignature` before writing.
+
+**Architecture:** A pure helper module `tools/ace/registry-publish.ts` (assemble/sign/bump/
+url-join) + a tiny additive `publicKeyInfoFromPrivatePem` in `signing.ts` (for the
+self-verify trust store) + a `registry publish` sub-verb in `ace.ts` (dir scan, file I/O,
+self-verify). Reuses `packageHash` (resolve.ts), `signIndex`/`IndexSignableContent`
+(signing.ts), `IndexDoc`/`parseIndex`/`verifyIndexSignature` (registry-remote.ts + signing.ts).
+
+**Tech Stack:** TypeScript on Bun; `node:crypto` ed25519; `bun test`; strict `tsc`.
+
+**Spec:** `docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice6.1-registry-publish-design.md`.
+
+**Harness constraints (every task):** Otto-343 hook blocks the Edit tool even after
+Read/Write — use **Write** for brand-new files, **bun patch-scripts** for edits to existing
+files (write `tools/ace/_patch_<x>.ts` → `readFileSync` → `split().length-1`
+assert-exactly-1 → `split().join()` → `writeFileSync` → `bun run` → `rm` — and **`rm` it
+before committing; never commit a `_patch_*.ts`**). Commit canary `git ls-tree HEAD | wc -l`
+must stay **67**. Commit trailer last line: `Co-Authored-By: Claude Opus 4.8
+<noreply@anthropic.com>`. Tests: `bun test tools/ace/`. Strict gate:
+`bun --bun tsc --noEmit -p tsconfig.json` (exit 0; repo uses `exactOptionalPropertyTypes` +
+`noUnusedLocals` — never assign `undefined` to an optional prop; import only what you use).
+markdownlint on SKILL.md (Task 4): blank lines around headings/lists/fences; no spaces
+inside `code spans`; don't start a wrapped line with `#` or `+`.
+
+**Existing-code facts to reuse (do not re-derive):**
+
+- `signing.ts`: `keyId(spkiB64)`, `generateKeypair()`, `signIndex(content, privatePem)`,
+  `IndexSignableContent`, `AceSignature`, `TrustEntry`, `VerifyResult`. Top imports already
+  include `createPrivateKey, createPublicKey` from `node:crypto`.
+- `store.ts`: `AcePackage { manifest: { name, version, content_hash, ... }, files }`,
+  `RegistryEntry { url, package_hash }`.
+- `resolve.ts`: `packageHash(pkg: AcePackage): string`.
+- `registry-remote.ts`: `IndexDoc = IndexSignableContent & { signature: AceSignature }`
+  (exported), `parseIndex(json): IndexDoc | { error }`.
+- `ace.ts`: `interface RegistryArgs { command: "registry"; sub: "list"|"add"|"remote-add"|
+  "remote-list"|"remote-rm"; ... }` + the `if (command === "registry")` parse block (handles
+  `remote` sub-verb) + the `if (parsed.command === "registry")` handler. `verifyIndexSignature`
+  imported from `./signing.ts`; `parseIndex` from `./registry-remote.ts` (already imported
+  for the install/update paths). `node:fs` `readFileSync`/`writeFileSync`/`readdirSync`/
+  `existsSync` available.
+- `ace.test.ts`: per-test temp-HOME (`tempHome`, `beforeEach`/`afterEach`); `generateKeypair`,
+  `signManifest`, `contentHash`, `packageHash`, `listInstalled`, `parseLockfile` imported;
+  `signIndex`/`generateKeypair` available; global-`fetch` save/restore pattern from slice 6.
+
+---
+
+## File structure
+
+| File | Responsibility | Task |
+| --- | --- | --- |
+| `tools/ace/signing.ts` | + `publicKeyInfoFromPrivatePem` (pubkey + keyId from a private PEM) | 1 |
+| `tools/ace/signing.test.ts` | test for the above | 1 |
+| `tools/ace/registry-publish.ts` (**new**) | `joinUrl`, `nextSequence`, `buildIndexDoc` (pure) | 2 |
+| `tools/ace/registry-publish.test.ts` (**new**) | unit tests | 2 |
+| `tools/ace/ace.ts` | `registry publish` parse + handler + usage | 3 |
+| `tools/ace/ace.test.ts` | end-to-end producer→consumer test | 3 |
+| `.claude/skills/ace/SKILL.md` | document `ace registry publish` | 4 |
+
+---
+
+## Task 1: signing.ts — `publicKeyInfoFromPrivatePem`
+
+**Files:** Modify `tools/ace/signing.ts`; Modify `tools/ace/signing.test.ts`.
+
+- [ ] **Step 1: Write the failing test** (append to `tools/ace/signing.test.ts` via patch-script)
+
+```ts
+import { publicKeyInfoFromPrivatePem } from "./signing.ts";
+
+describe("publicKeyInfoFromPrivatePem", () => {
+  test("derives the same keyId + public_key as generateKeypair for the same key", () => {
+    const kp = generateKeypair();
+    const info = publicKeyInfoFromPrivatePem(kp.privatePem);
+    expect(info.keyId).toBe(kp.keyId);
+    expect(info.public_key).toBe(kp.publicSpkiB64);
+  });
+  test("the derived public_key verifies an index this key signed", () => {
+    const kp = generateKeypair();
+    const content = { format_version: 1 as const, sequence: 1, issued_at: "2026-06-01T12:00:00Z",
+      packages: { leaf: { "1.0.0": { url: "https://x/l.json", package_hash: "sha256:aa" } } } };
+    const sig = signIndex(content, kp.privatePem);
+    const info = publicKeyInfoFromPrivatePem(kp.privatePem);
+    const trust = new Map([[info.keyId, { public_key: info.public_key }]]);
+    expect(verifyIndexSignature(content, sig, trust).ok).toBe(true);
+  });
+});
+```
+(`generateKeypair`, `signIndex`, `verifyIndexSignature` are already imported at the top of
+signing.test.ts from Task-1-of-slice-6; if not, add them to the `./signing.ts` import.)
+
+- [ ] **Step 2: Run → confirm RED** (`publicKeyInfoFromPrivatePem` not exported).
+  Run: `bun test tools/ace/signing.test.ts`
+
+- [ ] **Step 3: Implement** (patch-script append to `signing.ts`)
+
+```ts
+/** Derive the SPKI-DER base64 public key + its keyId from a private PEM (for a self-verify
+ *  trust store). Sibling of signIndex's internal signer-id derivation. */
+export function publicKeyInfoFromPrivatePem(privatePem: string): { keyId: string; public_key: string } {
+  const priv = createPrivateKey(privatePem);
+  const public_key = (createPublicKey(priv).export({ type: "spki", format: "der" }) as Buffer).toString("base64");
+  return { keyId: keyId(public_key), public_key };
+}
+```
+(`createPrivateKey`, `createPublicKey`, `keyId` are already in scope in signing.ts.)
+
+- [ ] **Step 4: Run → GREEN; `bun --bun tsc --noEmit -p tsconfig.json` exit 0.** False-green
+  check: break the `public_key` derivation (e.g. wrong export type) → the verify test goes
+  red → restore.
+
+- [ ] **Step 5: Commit** (canary 67 first)
+
+```bash
+git add tools/ace/signing.ts tools/ace/signing.test.ts
+git commit -m "feat(ace): publicKeyInfoFromPrivatePem for publish self-verify (slice 6.1 task 1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: registry-publish.ts — `joinUrl` / `nextSequence` / `buildIndexDoc` (pure)
+
+**Files:** Create `tools/ace/registry-publish.ts`; Create `tools/ace/registry-publish.test.ts`.
+
+- [ ] **Step 1: Write the failing test** (`tools/ace/registry-publish.test.ts`)
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { joinUrl, nextSequence, buildIndexDoc } from "./registry-publish.ts";
+import { generateKeypair, verifyIndexSignature, publicKeyInfoFromPrivatePem } from "./signing.ts";
+import { parseIndex } from "./registry-remote.ts";
+import { packageHash } from "./resolve.ts";
+import { contentHash } from "./store.ts";
+
+// helper: a minimal well-formed AcePackage with a correct content_hash
+function pkg(name: string, version: string, files: Record<string, string> = { "a.txt": "x" }) {
+  const content_hash = contentHash(new TextEncoder().encode(JSON.stringify(files)));
+  return { manifest: { format_version: 1, name, version, content_hash }, files };
+}
+
+describe("joinUrl", () => {
+  test("single separator regardless of trailing slash", () => {
+    expect(joinUrl("https://pkgs", "leaf-1.0.0.json")).toBe("https://pkgs/leaf-1.0.0.json");
+    expect(joinUrl("https://pkgs/", "leaf-1.0.0.json")).toBe("https://pkgs/leaf-1.0.0.json");
+    expect(joinUrl("https://pkgs///", "leaf-1.0.0.json")).toBe("https://pkgs/leaf-1.0.0.json");
+  });
+});
+
+describe("nextSequence", () => {
+  test("null → 1", () => { expect(nextSequence(null)).toBe(1); });
+  test("prev → prev+1", () => {
+    const prev = { format_version: 1 as const, sequence: 6, issued_at: "2026-06-01T12:00:00Z", packages: {}, signature: { algo: "ed25519" as const, key_id: "k", sig: "s" } };
+    expect(nextSequence(prev)).toBe(7);
+  });
+});
+
+describe("buildIndexDoc", () => {
+  const kp = generateKeypair();
+  const issuedAt = "2026-06-01T12:00:00Z";
+  test("assembles url + package_hash per package, signs, self-verifies", () => {
+    const p = pkg("leaf", "1.0.0");
+    const doc = buildIndexDoc({ packages: [p as never], baseUrl: "https://pkgs", sequence: 3, issuedAt, privatePem: kp.privatePem });
+    expect("error" in doc).toBe(false);
+    if ("error" in doc) return;
+    expect(doc.sequence).toBe(3);
+    expect(doc.issued_at).toBe(issuedAt);
+    expect(doc.packages.leaf!["1.0.0"]!.url).toBe("https://pkgs/leaf-1.0.0.json");
+    expect(doc.packages.leaf!["1.0.0"]!.package_hash).toBe(packageHash(p as never));
+    // round-trip through the consumer gates
+    const reparsed = parseIndex(JSON.stringify(doc));
+    expect("error" in reparsed).toBe(false);
+    const info = publicKeyInfoFromPrivatePem(kp.privatePem);
+    const { signature, ...content } = doc;
+    expect(verifyIndexSignature(content, signature, new Map([[info.keyId, { public_key: info.public_key }]])).ok).toBe(true);
+  });
+  test("duplicate name@version → error", () => {
+    const doc = buildIndexDoc({ packages: [pkg("leaf", "1.0.0") as never, pkg("leaf", "1.0.0") as never], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    expect("error" in doc).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run → RED** (module not found).
+
+- [ ] **Step 3: Implement** (`tools/ace/registry-publish.ts`)
+
+```ts
+// registry-publish.ts -- Ace slice 6.1: pure producer-side index assembly + signing.
+// Inverts the consumer: build the signed IndexSignableContent a slice-6 consumer accepts.
+// No I/O — the caller (ace.ts) reads the package files + sequence + pem and writes the output.
+import type { AcePackage, RegistryEntry } from "./store.ts";
+import { packageHash } from "./resolve.ts";
+import type { IndexSignableContent } from "./signing.ts";
+import { signIndex } from "./signing.ts";
+import type { IndexDoc } from "./registry-remote.ts";
+
+/** Join a base url + filename with exactly one separator (trailing slashes normalized). */
+export function joinUrl(base: string, file: string): string {
+  return base.replace(/\/+$/, "") + "/" + file;
+}
+
+/** Monotonic next sequence: bump the prior index's sequence, or start at 1. */
+export function nextSequence(prev: IndexDoc | null): number {
+  return prev ? prev.sequence + 1 : 1;
+}
+
+/** Assemble + sign an index doc from already-read packages. Duplicate name@version → error. */
+export function buildIndexDoc(args: {
+  packages: AcePackage[]; baseUrl: string; sequence: number; issuedAt: string; privatePem: string;
+}): IndexDoc | { error: string } {
+  // Null-prototype map: a package name like "__proto__" cannot pollute via bracket-assign.
+  const packages: Record<string, Record<string, RegistryEntry>> = Object.create(null);
+  for (const pkg of args.packages) {
+    const name = pkg.manifest.name;
+    const version = pkg.manifest.version;
+    const versions = packages[name] ?? (Object.create(null) as Record<string, RegistryEntry>);
+    if (versions[version] !== undefined) return { error: `duplicate package ${name}@${version}` };
+    versions[version] = { url: joinUrl(args.baseUrl, `${name}-${version}.json`), package_hash: packageHash(pkg) };
+    packages[name] = versions;
+  }
+  const content: IndexSignableContent = { format_version: 1, sequence: args.sequence, issued_at: args.issuedAt, packages };
+  const signature = signIndex(content, args.privatePem);
+  return { ...content, signature };
+}
+```
+
+- [ ] **Step 4: Run → GREEN; `tsc` exit 0.** False-green: break `joinUrl` (drop the
+  separator) → the url test goes red → restore.
+
+- [ ] **Step 5: Commit** (canary 67)
+
+```bash
+git add tools/ace/registry-publish.ts tools/ace/registry-publish.test.ts
+git commit -m "feat(ace): registry-publish buildIndexDoc/nextSequence/joinUrl (slice 6.1 task 2)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: ace.ts — `registry publish` CLI + handler + end-to-end test
+
+**Files:** Modify `tools/ace/ace.ts`; Modify `tools/ace/ace.test.ts`.
+
+- [ ] **Step 1: Write the failing test** (append to `tools/ace/ace.test.ts` via patch-script)
+
+```ts
+describe("ace registry publish (slice 6.1)", () => {
+  function writeSignedPkg(dir: string, name: string, version: string) {
+    const files = { [`${name}.txt`]: "hi" };
+    const ch = contentHash(new TextEncoder().encode(JSON.stringify(files)));
+    const kp = generateKeypair();
+    const m = { format_version: 1, name, version, content_hash: ch };
+    const pkg = { manifest: { ...m, signature: signManifest(m, kp.privatePem) }, files };
+    writeFileSync(join(dir, `${name}-${version}.json`), JSON.stringify(pkg));
+    return { kp, pkg };
+  }
+
+  test("publish a dir → signed index; sequence auto-bumps; non-package skipped", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-"));   // mkdtempSync creates the dir
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    writeFileSync(join(pkgDir, "not-a-package.json"), JSON.stringify({ hello: "world" })); // skipped
+    const keyPath = join(tempHome, "registry.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "index.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    expect("error" in doc).toBe(false);
+    if (!("error" in doc)) {
+      expect(doc.sequence).toBe(1);
+      expect(doc.packages.leaf!["1.0.0"]!.url).toBe("https://pkgs/leaf-1.0.0.json");
+    }
+    // re-publish bumps sequence 1 → 2
+    const code2 = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code2).toBe(0);
+    const doc2 = parseIndex(readFileSync(outPath, "utf8"));
+    if (!("error" in doc2)) expect(doc2.sequence).toBe(2);
+  });
+
+  test("publish without --key is a parse error", () => {
+    expect("error" in parseArgs(["registry", "publish", "--packages", "d", "--base-url", "https://x"])).toBe(true);
+  });
+});
+```
+> **Implementer note:** adapt to the real `ace.test.ts` imports — `mkdtempSync`, `join`,
+> `tmpdir`, `readFileSync`, `writeFileSync`, `contentHash`, `generateKeypair`, `signManifest`,
+> `parseArgs`, `main`, `tempHome` are already imported/available there; do not duplicate
+> imports. The test's intent: publish a dir → exit 0 → `parseIndex(out)` shows the expected
+> node + sequence 1; re-publish bumps the sequence to 2; a non-package json is skipped;
+> missing `--key` is a parse error.
+
+- [ ] **Step 2: Run → RED.**
+
+- [ ] **Step 3: Implement** (patch-scripts on `ace.ts`)
+
+(a) Extend `RegistryArgs`:
+
+```ts
+interface RegistryArgs {
+  readonly command: "registry";
+  readonly sub: "list" | "add" | "remote-add" | "remote-list" | "remote-rm" | "publish";
+  readonly regName?: string;
+  readonly regVersion?: string;
+  readonly regUrl?: string;
+  readonly regHash?: string;
+  readonly remoteUrl?: string;
+  readonly remoteKey?: string;
+  readonly remoteMaxStaleness?: number;
+  readonly pubPackagesDir?: string;
+  readonly pubBaseUrl?: string;
+  readonly pubKeyPath?: string;
+  readonly pubOut?: string;
+}
+```
+
+(b) In the `if (command === "registry")` parse block, add a `publish` branch (sibling of the
+`remote` branch, BEFORE the final `return { error: "registry requires ..." }`):
+
+```ts
+    if (sub === "publish") {
+      let dir: string | undefined, base: string | undefined, key: string | undefined, out: string | undefined;
+      for (let i = 2; i < argv.length; i++) {
+        if (argv[i] === "--packages") { dir = argv[++i]; if (!dir || dir.startsWith("-")) return { error: "--packages requires a value" }; }
+        else if (argv[i] === "--base-url") { base = argv[++i]; if (!base || base.startsWith("-")) return { error: "--base-url requires a value" }; }
+        else if (argv[i] === "--key") { key = argv[++i]; if (!key || key.startsWith("-")) return { error: "--key requires a value" }; }
+        else if (argv[i] === "--out") { out = argv[++i]; if (!out || out.startsWith("-")) return { error: "--out requires a value" }; }
+        else return { error: `Unknown option for registry publish: ${argv[i]}` };
+      }
+      if (!dir) return { error: "registry publish requires --packages <dir>" };
+      if (!base) return { error: "registry publish requires --base-url <url>" };
+      if (!key) return { error: "registry publish requires --key <pem-path>" };
+      const r: RegistryArgs = { command: "registry", sub: "publish", pubPackagesDir: dir, pubBaseUrl: base, pubKeyPath: key };
+      return out !== undefined ? { ...r, pubOut: out } : r;
+    }
+```
+
+(c) Add imports: `import { buildIndexDoc, nextSequence } from "./registry-publish.ts";` and
+extend the `./signing.ts` import to include `publicKeyInfoFromPrivatePem`. (`parseIndex` +
+`verifyIndexSignature` are already imported; `readdirSync` may need adding to the `node:fs`
+import.)
+
+(d) In the `if (parsed.command === "registry")` handler, add a `publish` branch (before the
+local-`add` logic):
+
+```ts
+    if (parsed.sub === "publish") {
+      let pem: string;
+      try { pem = readFileSync(parsed.pubKeyPath!, "utf8"); }
+      catch (e) { console.error(`ace: publish: cannot read key ${parsed.pubKeyPath}: ${(e as Error).message}`); return 1; }
+      let entries: string[];
+      try { entries = readdirSync(parsed.pubPackagesDir!).filter((f) => f.endsWith(".json")); }
+      catch (e) { console.error(`ace: publish: cannot read dir ${parsed.pubPackagesDir}: ${(e as Error).message}`); return 1; }
+      const packages: AcePackage[] = [];
+      for (const f of entries) {
+        const full = join(parsed.pubPackagesDir!, f);
+        let raw: string;
+        try { raw = readFileSync(full, "utf8"); } catch { console.error(`ace: publish: skip unreadable ${f}`); continue; }
+        let obj: unknown;
+        try { obj = JSON.parse(raw); } catch { console.error(`ace: publish: skip non-JSON ${f}`); continue; }
+        if (typeof obj !== "object" || obj === null || typeof (obj as AcePackage).manifest !== "object" || (obj as AcePackage).manifest === null
+          || typeof (obj as AcePackage).manifest.name !== "string" || typeof (obj as AcePackage).manifest.version !== "string"
+          || typeof (obj as AcePackage).files !== "object" || (obj as AcePackage).files === null) {
+          console.error(`ace: publish: skip non-package ${f}`); continue;
+        }
+        packages.push(obj as AcePackage);
+      }
+      if (packages.length === 0) { console.error(`ace: publish refused: no valid packages in ${parsed.pubPackagesDir}`); return 1; }
+      const outPath = parsed.pubOut ?? "index.json";
+      let prev: import("./registry-remote.ts").IndexDoc | null = null;
+      if (existsSync(outPath)) {
+        try { const p = parseIndex(readFileSync(outPath, "utf8")); if (!("error" in p)) prev = p; } catch { /* no prev */ }
+      }
+      const seq = nextSequence(prev);
+      if (prev && seq <= prev.sequence) { console.error(`ace: publish refused: sequence ${seq} <= prev ${prev.sequence}`); return 1; }
+      const doc = buildIndexDoc({ packages, baseUrl: parsed.pubBaseUrl!, sequence: seq, issuedAt: new Date().toISOString(), privatePem: pem });
+      if ("error" in doc) { console.error(`ace: publish refused: ${doc.error}`); return 1; }
+      // Round-trip self-verify: never write an index the consumer would reject.
+      const serialized = JSON.stringify(doc, null, 2);
+      const reparsed = parseIndex(serialized);
+      if ("error" in reparsed) { console.error(`ace: publish refused: self-verify parse failed: ${reparsed.error}`); return 1; }
+      const info = publicKeyInfoFromPrivatePem(pem);
+      const { signature, ...content } = doc;
+      const sv = verifyIndexSignature(content, signature, new Map([[info.keyId, { public_key: info.public_key }]]));
+      if (!sv.ok) { console.error(`ace: publish refused: self-verify signature failed: ${sv.reason}`); return 1; }
+      try { writeFileSync(outPath, serialized); }
+      catch (e) { console.error(`ace: publish failed: cannot write ${outPath}: ${(e as Error).message}`); return 1; }
+      console.log(`ace: published ${packages.length} package(s) at sequence ${seq} → ${outPath}`);
+      return 0;
+    }
+```
+> **Implementer note:** match the file's actual import style. `AcePackage` is already
+> imported in ace.ts (used by install/update). If `readdirSync`/`existsSync` aren't imported,
+> add them to the `node:fs` import. The `import("./registry-remote.ts").IndexDoc` inline type
+> can instead be a top `import type { IndexDoc } from "./registry-remote.ts";` if cleaner.
+
+(e) Usage text: add `ace registry publish --packages <dir> --base-url <url> --key <pem> [--out <path>]`.
+
+- [ ] **Step 4: Run → `bun test tools/ace/` all green; `tsc` exit 0.** False-green: corrupt
+  the signing key passed to publish (write a non-PEM) → the publish test fails (key read /
+  self-verify) → restore.
+
+- [ ] **Step 5: Commit** (canary 67)
+
+```bash
+git add tools/ace/ace.ts tools/ace/ace.test.ts
+git commit -m "feat(ace): registry publish CLI + handler with round-trip self-verify (slice 6.1 task 3)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: SKILL.md — document `ace registry publish`
+
+**Files:** Modify `.claude/skills/ace/SKILL.md`.
+
+- [ ] **Step 1: Implement** (patch-script append a "Publishing a registry (slice 6.1)" section)
+
+Document: `ace registry publish --packages <dir> --base-url <url> --key <pem-path>
+[--out index.json]`; that it scans the dir for package `*.json` (non-packages skipped),
+derives each `url` as `<base-url>/<name>-<version>.json` + the `package_hash`, signs the
+index with the ed25519 private key, auto-bumps `sequence` from the existing `--out` (refusing
+a non-increasing sequence), and **round-trip self-verifies** the produced index through the
+consumer's own parse + signature check before writing (so a published index always satisfies
+`ace install` against `ace registry remote add <url> --key <keyId>`). Note the deferred
+items (per-package url, ETag sidecar, multi-dir, incremental/multi-signer).
+
+- [ ] **Step 2: Verify** → `bunx markdownlint-cli2 ".claude/skills/ace/SKILL.md"` exit 0.
+- [ ] **Step 3: Commit** (canary 67)
+
+```bash
+git add .claude/skills/ace/SKILL.md
+git commit -m "docs(ace): document ace registry publish (slice 6.1 task 4)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## After all tasks
+
+- [ ] Whole suite: `bun test tools/ace/` → all pass.
+- [ ] Strict: `bun --bun tsc --noEmit -p tsconfig.json` → exit 0.
+- [ ] Canary: `git ls-tree HEAD | wc -l` → 67; no stray `tools/ace/_patch_*.ts`.
+- [ ] Final holistic code-review subagent over `git diff origin/main..HEAD -- tools/ace/ .claude/skills/ace/SKILL.md`.
+- [ ] Open the impl PR; arm auto-merge; run the PR-gate loop.
+- [ ] Post-merge: annotate B-0980 (mark `ace registry publish` core shipped; per-package url
+  + ETag sidecar + multi-dir + incremental/multi-signer stay deferred).

--- a/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice6.1-implementation-plan.md
+++ b/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice6.1-implementation-plan.md
@@ -24,8 +24,7 @@ Read/Write — use **Write** for brand-new files, **bun patch-scripts** for edit
 files (write `tools/ace/_patch_<x>.ts` → `readFileSync` → `split().length-1`
 assert-exactly-1 → `split().join()` → `writeFileSync` → `bun run` → `rm` — and **`rm` it
 before committing; never commit a `_patch_*.ts`**). Commit canary `git ls-tree HEAD | wc -l`
-must stay **67**. Commit trailer last line: `Co-Authored-By: Claude Opus 4.8
-<noreply@anthropic.com>`. Tests: `bun test tools/ace/`. Strict gate:
+must stay **67**. Commit trailer last line: the project's standard `Co-Authored-By:` agent trailer (see `CLAUDE.md`). Tests: `bun test tools/ace/`. Strict gate:
 `bun --bun tsc --noEmit -p tsconfig.json` (exit 0; repo uses `exactOptionalPropertyTypes` +
 `noUnusedLocals` — never assign `undefined` to an optional prop; import only what you use).
 markdownlint on SKILL.md (Task 4): blank lines around headings/lists/fences; no spaces

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -1530,4 +1530,31 @@ describe("ace registry publish (slice 6.1)", () => {
     expect(code).toBe(1);
     expect(existsSyncLocal(outPath)).toBe(false);
   });
+
+  test("package with non-array dependencies is skipped; well-formed sibling is indexed", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-baddeps-"));
+    // Good package
+    writeSignedPkg(pkgDir, "good", "1.0.0");
+    // Bad package: dependencies is a string, not an array
+    const badFiles = { "bad.txt": "x" };
+    const badCh = contentHash(new TextEncoder().encode(JSON.stringify(badFiles)));
+    const badKp = generateKeypair();
+    const badM = { format_version: 1 as const, name: "bad", version: "1.0.0", content_hash: badCh };
+    const badSig = signManifest(badM, badKp.privatePem);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const badPkg = { manifest: { ...badM, dependencies: "not-an-array" as any, signature: badSig }, files: badFiles };
+    writeFileSync(join(pkgDir, "bad-1.0.0.json"), JSON.stringify(badPkg));
+    const keyPath = join(tempHome, "bd.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "baddeps-index.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    expect("error" in doc).toBe(false);
+    if (!("error" in doc)) {
+      expect(doc.packages.good).toBeDefined();
+      expect(doc.packages.bad).toBeUndefined();
+    }
+  });
 });

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -1386,6 +1386,31 @@ describe("ace registry publish (slice 6.1)", () => {
     if (!("error" in doc2)) expect(doc2.sequence).toBe(2);
   });
 
+  test("package with a non-string file value is skipped", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-fv-"));
+    writeSignedPkg(pkgDir, "good", "1.0.0");
+    // files value is a number, not a string: content_hash matches its JSON, so it clears the
+    // content gate, but installPackage would throw at writeFileSync. Must be skipped at publish.
+    const badFiles = { "a.txt": 123 };
+    const bch = contentHash(new TextEncoder().encode(JSON.stringify(badFiles)));
+    const bm = { format_version: 1, name: "bad", version: "1.0.0", content_hash: bch };
+    const bkp = generateKeypair();
+    const badPkg = { manifest: { ...bm, signature: signManifest(bm, bkp.privatePem) }, files: badFiles };
+    writeFileSync(join(pkgDir, "bad-1.0.0.json"), JSON.stringify(badPkg));
+    const keyPath = join(tempHome, "registry-fv.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "index-fv.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    expect("error" in doc).toBe(false);
+    if (!("error" in doc)) {
+      expect(doc.packages.good).toBeDefined();
+      expect(doc.packages.bad).toBeUndefined();
+    }
+  });
+
   test("publish without --key is a parse error", () => {
     expect("error" in parseArgs(["registry", "publish", "--packages", "d", "--base-url", "https://x"])).toBe(true);
   });

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -1419,4 +1419,44 @@ describe("ace registry publish (slice 6.1)", () => {
     expect(code).toBe(1);
     expect(existsSyncLocal(outPath)).toBe(false);
   });
+
+  test("non-ed25519 key → publish refused (exit 1, no index)", async () => {
+    const { existsSync: existsLocal } = await import("node:fs");
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-rsa-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    const rsa = generateKeyPairSync("rsa", { modulusLength: 2048 }).privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+    const keyPath = join(tempHome, "rsa.pem"); writeFileSync(keyPath, rsa);
+    const outPath = join(tempHome, "rsa-index.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(1);
+    expect(existsLocal(outPath)).toBe(false);
+  });
+
+  test("existing unparseable --out → publish refused (no rollback reset)", async () => {
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-corrupt-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    const keyPath = join(tempHome, "ck.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "corrupt-index.json"); writeFileSync(outPath, "{ truncated");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(1);
+  });
+
+  test("package with mismatched content_hash is skipped (not indexed)", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-badhash-"));
+    writeSignedPkg(pkgDir, "good", "1.0.0");
+    // a package whose content_hash does NOT match files
+    const kp = generateKeypair();
+    const m = { format_version: 1, name: "bad", version: "1.0.0", content_hash: "sha256:deadbeef" };
+    const bad = { manifest: { ...m, signature: signManifest(m, kp.privatePem) }, files: { "bad.txt": "x" } };
+    writeFileSync(join(pkgDir, "bad-1.0.0.json"), JSON.stringify(bad));
+    const keyPath = join(tempHome, "bh.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "badhash-index.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    if (!("error" in doc)) { expect(doc.packages.good).toBeDefined(); expect(doc.packages.bad).toBeUndefined(); }
+  });
 });

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -1390,12 +1390,14 @@ describe("ace registry publish (slice 6.1)", () => {
     expect("error" in parseArgs(["registry", "publish", "--packages", "d", "--base-url", "https://x"])).toBe(true);
   });
 
-  test("duplicate name@version in the dir → publish refused (exit 1, no index written)", async () => {
-    const { existsSync: existsSyncLocal } = await import("node:fs");
+  test("second SAME-identity file with a mismatched basename is skipped (basename filter precedes dup check); dup-detection itself covered at buildIndexDoc unit level", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
     const idxKp = generateKeypair();
     const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-dup-"));
     writeSignedPkg(pkgDir, "leaf", "1.0.0");
-    // a second file, different filename, SAME name@version
+    // a second file, SAME name@version, but its basename != leaf-1.0.0.json so Fix 2 skips it
+    // BEFORE it can reach buildIndexDoc's duplicate check. (Two files cannot share the canonical
+    // basename leaf-1.0.0.json in one dir, so the CLI scan can no longer surface a duplicate.)
     const dupFiles = { "leaf.txt": "other" };
     const dupCh = contentHash(new TextEncoder().encode(JSON.stringify(dupFiles)));
     const dupKp = generateKeypair();
@@ -1405,8 +1407,12 @@ describe("ace registry publish (slice 6.1)", () => {
     const keyPath = join(tempHome, "dup.pem"); writeFileSync(keyPath, idxKp.privatePem);
     const outPath = join(tempHome, "dup-index.json");
     const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
-    expect(code).toBe(1);
-    expect(existsSyncLocal(outPath)).toBe(false);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    if (!("error" in doc)) {
+      // only the canonically-named leaf-1.0.0.json was indexed; the mismatched dup was skipped
+      expect(doc.packages.leaf!["1.0.0"]!.url).toBe("https://pkgs/leaf-1.0.0.json");
+    }
   });
 
   test("malformed (non-PEM) key → publish refused (exit 1, no index written)", async () => {
@@ -1458,5 +1464,70 @@ describe("ace registry publish (slice 6.1)", () => {
     expect(code).toBe(0);
     const doc = parseIndex(readFileSync(outPath, "utf8"));
     if (!("error" in doc)) { expect(doc.packages.good).toBeDefined(); expect(doc.packages.bad).toBeUndefined(); }
+  });
+
+  test("tampered existing --out (signature flipped) → publish refused; index unchanged", async () => {
+    const { existsSync: existsSyncLocal } = await import("node:fs");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-tamper-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    const keyPath = join(tempHome, "tk.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "tamper-index.json");
+    // publish a valid index once
+    const code1 = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code1).toBe(0);
+    // tamper: lower sequence (still parseable, but sequence is signed so signature no longer verifies)
+    const tampered = JSON.parse(readFileSync(outPath, "utf8")) as { sequence: number };
+    tampered.sequence = 0;
+    const tamperedBytes = JSON.stringify(tampered, null, 2);
+    writeFileSync(outPath, tamperedBytes);
+    // republish with same key + packages → refused (signature does not verify under --key)
+    const code2 = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code2).toBe(1);
+    // on-disk index unchanged (publish must not overwrite on refusal)
+    expect(existsSyncLocal(outPath)).toBe(true);
+    expect(readFileSync(outPath, "utf8")).toBe(tamperedBytes);
+  });
+
+  test("package file whose basename != name-version.json is skipped", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-mismatch-"));
+    // correctly-named package
+    writeSignedPkg(pkgDir, "good", "1.0.0");
+    // mismatched filename: manifest other@2.0.0 written as mypkg.json (valid content_hash)
+    const oFiles = { "other.txt": "x" };
+    const oCh = contentHash(new TextEncoder().encode(JSON.stringify(oFiles)));
+    const oKp = generateKeypair();
+    const oM = { format_version: 1, name: "other", version: "2.0.0", content_hash: oCh };
+    const oPkg = { manifest: { ...oM, signature: signManifest(oM, oKp.privatePem) }, files: oFiles };
+    writeFileSync(join(pkgDir, "mypkg.json"), JSON.stringify(oPkg));
+    const keyPath = join(tempHome, "mm.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "mismatch-index.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    if (!("error" in doc)) {
+      expect(doc.packages.good!["1.0.0"]).toBeDefined();
+      expect(doc.packages.other).toBeUndefined();
+    }
+  });
+
+  test("all package files have mismatched basenames → no valid packages (exit 1)", async () => {
+    const { existsSync: existsSyncLocal } = await import("node:fs");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-allmismatch-"));
+    // only one file, manifest foo@1.0.0 but named mypkg.json
+    const fFiles = { "foo.txt": "x" };
+    const fCh = contentHash(new TextEncoder().encode(JSON.stringify(fFiles)));
+    const fKp = generateKeypair();
+    const fM = { format_version: 1, name: "foo", version: "1.0.0", content_hash: fCh };
+    const fPkg = { manifest: { ...fM, signature: signManifest(fM, fKp.privatePem) }, files: fFiles };
+    writeFileSync(join(pkgDir, "mypkg.json"), JSON.stringify(fPkg));
+    const keyPath = join(tempHome, "am.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "allmismatch-index.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(1);
+    expect(existsSyncLocal(outPath)).toBe(false);
   });
 });

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -1352,3 +1352,41 @@ describe("ace install via remote registry (slice 6)", () => {
     }
   });
 });
+
+describe("ace registry publish (slice 6.1)", () => {
+  function writeSignedPkg(dir: string, name: string, version: string) {
+    const files = { [`${name}.txt`]: "hi" };
+    const ch = contentHash(new TextEncoder().encode(JSON.stringify(files)));
+    const kp = generateKeypair();
+    const m = { format_version: 1, name, version, content_hash: ch };
+    const pkg = { manifest: { ...m, signature: signManifest(m, kp.privatePem) }, files };
+    writeFileSync(join(dir, `${name}-${version}.json`), JSON.stringify(pkg));
+    return { kp, pkg };
+  }
+
+  test("publish a dir → signed index; sequence auto-bumps; non-package skipped", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    writeFileSync(join(pkgDir, "not-a-package.json"), JSON.stringify({ hello: "world" }));
+    const keyPath = join(tempHome, "registry.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "index.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    expect("error" in doc).toBe(false);
+    if (!("error" in doc)) {
+      expect(doc.sequence).toBe(1);
+      expect(doc.packages.leaf!["1.0.0"]!.url).toBe("https://pkgs/leaf-1.0.0.json");
+    }
+    const code2 = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code2).toBe(0);
+    const doc2 = parseIndex(readFileSync(outPath, "utf8"));
+    if (!("error" in doc2)) expect(doc2.sequence).toBe(2);
+  });
+
+  test("publish without --key is a parse error", () => {
+    expect("error" in parseArgs(["registry", "publish", "--packages", "d", "--base-url", "https://x"])).toBe(true);
+  });
+});

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -1582,4 +1582,79 @@ describe("ace registry publish (slice 6.1)", () => {
       expect(doc.packages.bad).toBeUndefined();
     }
   });
+
+  test("URL-unsafe name is skipped; well-formed sibling is indexed", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-urlbad-"));
+    writeSignedPkg(pkgDir, "good", "1.0.0");
+    // bad: name contains '#', which is URL-unsafe
+    const badName = "bad#x";
+    const badFiles = { "bad.txt": "x" };
+    const badCh = contentHash(new TextEncoder().encode(JSON.stringify(badFiles)));
+    const badKp = generateKeypair();
+    const badM = { format_version: 1, name: badName, version: "1.0.0", content_hash: badCh };
+    const badPkg = { manifest: { ...badM, signature: signManifest(badM, badKp.privatePem) }, files: badFiles };
+    // filename matches <name>-<version>.json so it clears the basename guard, but name is URL-unsafe
+    writeFileSync(join(pkgDir, `${badName}-1.0.0.json`), JSON.stringify(badPkg));
+    const keyPath = join(tempHome, "urlbad.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "urlbad-index.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    expect("error" in doc).toBe(false);
+    if (!("error" in doc)) {
+      expect(doc.packages.good).toBeDefined();
+      expect(doc.packages[badName]).toBeUndefined();
+    }
+  });
+
+  test("malformed dep edge (missing version) is skipped; well-formed sibling is indexed", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-baddep-"));
+    writeSignedPkg(pkgDir, "good", "1.0.0");
+    // bad: dep edge missing version field
+    const badFiles = { "bad.txt": "x" };
+    const badCh = contentHash(new TextEncoder().encode(JSON.stringify(badFiles)));
+    const badKp = generateKeypair();
+    const badM = { format_version: 1, name: "bad", version: "1.0.0", content_hash: badCh };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const badPkg = { manifest: { ...badM, dependencies: [{ kind: "registry", name: "dep" }] as any, signature: signManifest(badM, badKp.privatePem) }, files: badFiles };
+    writeFileSync(join(pkgDir, "bad-1.0.0.json"), JSON.stringify(badPkg));
+    const keyPath = join(tempHome, "baddep.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "baddep-index.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    expect("error" in doc).toBe(false);
+    if (!("error" in doc)) {
+      expect(doc.packages.good).toBeDefined();
+      expect(doc.packages.bad).toBeUndefined();
+    }
+  });
+
+  test("unsafe file path is skipped; well-formed sibling is indexed", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-unsafe-"));
+    writeSignedPkg(pkgDir, "good", "1.0.0");
+    // bad: files key is a path-traversal path
+    const badFiles = { "../escape.txt": "x" };
+    const badCh = contentHash(new TextEncoder().encode(JSON.stringify(badFiles)));
+    const badKp = generateKeypair();
+    const badM = { format_version: 1, name: "bad", version: "1.0.0", content_hash: badCh };
+    const badPkg = { manifest: { ...badM, signature: signManifest(badM, badKp.privatePem) }, files: badFiles };
+    writeFileSync(join(pkgDir, "bad-1.0.0.json"), JSON.stringify(badPkg));
+    const keyPath = join(tempHome, "unsafe.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "unsafe-index.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    expect("error" in doc).toBe(false);
+    if (!("error" in doc)) {
+      expect(doc.packages.good).toBeDefined();
+      expect(doc.packages.bad).toBeUndefined();
+    }
+  });
 });

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -1389,4 +1389,34 @@ describe("ace registry publish (slice 6.1)", () => {
   test("publish without --key is a parse error", () => {
     expect("error" in parseArgs(["registry", "publish", "--packages", "d", "--base-url", "https://x"])).toBe(true);
   });
+
+  test("duplicate name@version in the dir → publish refused (exit 1, no index written)", async () => {
+    const { existsSync: existsSyncLocal } = await import("node:fs");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-dup-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    // a second file, different filename, SAME name@version
+    const dupFiles = { "leaf.txt": "other" };
+    const dupCh = contentHash(new TextEncoder().encode(JSON.stringify(dupFiles)));
+    const dupKp = generateKeypair();
+    const dupM = { format_version: 1, name: "leaf", version: "1.0.0", content_hash: dupCh };
+    const dupPkg = { manifest: { ...dupM, signature: signManifest(dupM, dupKp.privatePem) }, files: dupFiles };
+    writeFileSync(join(pkgDir, "leaf-dup.json"), JSON.stringify(dupPkg));
+    const keyPath = join(tempHome, "dup.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "dup-index.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(1);
+    expect(existsSyncLocal(outPath)).toBe(false);
+  });
+
+  test("malformed (non-PEM) key → publish refused (exit 1, no index written)", async () => {
+    const { existsSync: existsSyncLocal } = await import("node:fs");
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-badkey-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    const keyPath = join(tempHome, "bad.pem"); writeFileSync(keyPath, "not a pem at all");
+    const outPath = join(tempHome, "badkey-index.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(1);
+    expect(existsSyncLocal(outPath)).toBe(false);
+  });
 });

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -255,7 +255,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
       const r: RegistryArgs = { command: "registry", sub: "publish", pubPackagesDir: dir, pubBaseUrl: base, pubKeyPath: key };
       return out !== undefined ? { ...r, pubOut: out } : r;
     }
-    return { error: "registry requires 'add' or 'list'" };
+    return { error: "registry requires 'add', 'list', 'remote', or 'publish'" };
   }
 
   if (command === "update") {

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -15,7 +15,7 @@
 //
 // Future commands (not yet implemented): remove, inspect.
 
-import { chmodSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createPublicKey } from "node:crypto";
 import {
   defaultStorePath, listInstalled, installPackage, contentHash,
@@ -24,12 +24,14 @@ import {
   writeRegistryRemote, removeRegistryRemote, readRegistriesConfig,
   type AcePackage,
 } from "./store";
-import { generateKeypair, signManifest, verifySignature, keyId } from "./signing";
+import { generateKeypair, signManifest, verifySignature, keyId, publicKeyInfoFromPrivatePem, verifyIndexSignature } from "./signing";
 import { resolve, packageHash } from "./resolve.ts";
 import { buildLockfile, serializeLockfile, parseLockfile, verifyRootMatchesLock, lockfilesEqual, buildLeafLockfile } from "./lockfile.ts";
 import { solve } from "./solver.ts";
-import { loadRegistries } from "./registry-remote.ts";
-import { resolve as toAbsolutePath } from "node:path";
+import { buildIndexDoc, nextSequence } from "./registry-publish.ts";
+import { loadRegistries, parseIndex } from "./registry-remote.ts";
+import type { IndexDoc } from "./registry-remote.ts";
+import { resolve as toAbsolutePath, join } from "node:path";
 
 interface ListArgs {
   readonly command: "list";
@@ -88,7 +90,7 @@ interface UpdateArgs {
 
 interface RegistryArgs {
   readonly command: "registry";
-  readonly sub: "list" | "add" | "remote-add" | "remote-list" | "remote-rm";
+  readonly sub: "list" | "add" | "remote-add" | "remote-list" | "remote-rm" | "publish";
   readonly regName?: string;
   readonly regVersion?: string;
   readonly regUrl?: string;
@@ -96,6 +98,10 @@ interface RegistryArgs {
   readonly remoteUrl?: string;
   readonly remoteKey?: string;
   readonly remoteMaxStaleness?: number;
+  readonly pubPackagesDir?: string;
+  readonly pubBaseUrl?: string;
+  readonly pubKeyPath?: string;
+  readonly pubOut?: string;
 }
 
 type ParsedArgs = ListArgs | HelpArgs | InstallArgs | VerifyArgs | KeygenArgs | SignArgs | TrustArgs | RegistryArgs | UpdateArgs;
@@ -234,6 +240,21 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
       }
       return { error: "registry remote requires 'add', 'list', or 'rm'" };
     }
+    if (sub === "publish") {
+      let dir: string | undefined, base: string | undefined, key: string | undefined, out: string | undefined;
+      for (let i = 2; i < argv.length; i++) {
+        if (argv[i] === "--packages") { dir = argv[++i]; if (!dir || dir.startsWith("-")) return { error: "--packages requires a value" }; }
+        else if (argv[i] === "--base-url") { base = argv[++i]; if (!base || base.startsWith("-")) return { error: "--base-url requires a value" }; }
+        else if (argv[i] === "--key") { key = argv[++i]; if (!key || key.startsWith("-")) return { error: "--key requires a value" }; }
+        else if (argv[i] === "--out") { out = argv[++i]; if (!out || out.startsWith("-")) return { error: "--out requires a value" }; }
+        else return { error: `Unknown option for registry publish: ${argv[i]}` };
+      }
+      if (!dir) return { error: "registry publish requires --packages <dir>" };
+      if (!base) return { error: "registry publish requires --base-url <url>" };
+      if (!key) return { error: "registry publish requires --key <pem-path>" };
+      const r: RegistryArgs = { command: "registry", sub: "publish", pubPackagesDir: dir, pubBaseUrl: base, pubKeyPath: key };
+      return out !== undefined ? { ...r, pubOut: out } : r;
+    }
     return { error: "registry requires 'add' or 'list'" };
   }
 
@@ -358,6 +379,7 @@ Usage:
   ace trust list                                 List all trusted keys
   ace registry add <name> <version> <url> [--hash <h>] Register a package in the local registry
   ace registry list                              List all registry entries
+  ace registry publish --packages <dir> --base-url <url> --key <pem> [--out <path>] Build + sign an index from a dir of packages
   ace registry remote add <url> --key <keyid> [--max-staleness-days <n>] Add a signed remote registry
   ace registry remote list                       List configured remote registries
   ace registry remote rm <url>                   Remove a configured remote registry
@@ -509,6 +531,52 @@ export async function main(argv: readonly string[]): Promise<number> {
       const rows = listRegistry();
       if (rows.length === 0) { console.log("No registry entries. (add one: ace registry add <name> <version> <url>)"); return 0; }
       for (const r of rows) console.log(`  ${r.name}@${r.version}  ${r.url}  [${r.source}]`);
+      return 0;
+    }
+    if (parsed.sub === "publish") {
+      let pem: string;
+      try { pem = readFileSync(parsed.pubKeyPath!, "utf8"); }
+      catch (e) { console.error(`ace: publish: cannot read key ${parsed.pubKeyPath}: ${(e as Error).message}`); return 1; }
+      let entries: string[];
+      try { entries = readdirSync(parsed.pubPackagesDir!).filter((f) => f.endsWith(".json")); }
+      catch (e) { console.error(`ace: publish: cannot read dir ${parsed.pubPackagesDir}: ${(e as Error).message}`); return 1; }
+      const packages: AcePackage[] = [];
+      for (const f of entries) {
+        const full = join(parsed.pubPackagesDir!, f);
+        let raw: string;
+        try { raw = readFileSync(full, "utf8"); } catch { console.error(`ace: publish: skip unreadable ${f}`); continue; }
+        let obj: unknown;
+        try { obj = JSON.parse(raw); } catch { console.error(`ace: publish: skip non-JSON ${f}`); continue; }
+        if (typeof obj !== "object" || obj === null || typeof (obj as AcePackage).manifest !== "object" || (obj as AcePackage).manifest === null
+          || typeof (obj as AcePackage).manifest.name !== "string" || typeof (obj as AcePackage).manifest.version !== "string"
+          || typeof (obj as AcePackage).files !== "object" || (obj as AcePackage).files === null) {
+          console.error(`ace: publish: skip non-package ${f}`); continue;
+        }
+        packages.push(obj as AcePackage);
+      }
+      if (packages.length === 0) { console.error(`ace: publish refused: no valid packages in ${parsed.pubPackagesDir}`); return 1; }
+      const outPath = parsed.pubOut ?? "index.json";
+      let prev: IndexDoc | null = null;
+      if (existsSync(outPath)) {
+        try { const p = parseIndex(readFileSync(outPath, "utf8")); if (!("error" in p)) prev = p; } catch { /* no prev */ }
+      }
+      const seq = nextSequence(prev);
+      if (prev && seq <= prev.sequence) { console.error(`ace: publish refused: sequence ${seq} <= prev ${prev.sequence}`); return 1; }
+      let serialized: string;
+      try {
+        const doc = buildIndexDoc({ packages, baseUrl: parsed.pubBaseUrl!, sequence: seq, issuedAt: new Date().toISOString(), privatePem: pem });
+        if ("error" in doc) { console.error(`ace: publish refused: ${doc.error}`); return 1; }
+        serialized = JSON.stringify(doc, null, 2);
+        const reparsed = parseIndex(serialized);
+        if ("error" in reparsed) { console.error(`ace: publish refused: self-verify parse failed: ${reparsed.error}`); return 1; }
+        const info = publicKeyInfoFromPrivatePem(pem);
+        const { signature, ...content } = doc;
+        const sv = verifyIndexSignature(content, signature, new Map([[info.keyId, { public_key: info.public_key }]]));
+        if (!sv.ok) { console.error(`ace: publish refused: self-verify signature failed: ${sv.reason}`); return 1; }
+      } catch (e) { console.error(`ace: publish refused: signing failed (check --key is a valid Ed25519 PEM): ${(e as Error).message}`); return 1; }
+      try { writeFileSync(outPath, serialized); }
+      catch (e) { console.error(`ace: publish failed: cannot write ${outPath}: ${(e as Error).message}`); return 1; }
+      console.log(`ace: published ${packages.length} package(s) at sequence ${seq} → ${outPath}`);
       return 0;
     }
     // sub === "add"

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -561,6 +561,8 @@ export async function main(argv: readonly string[]): Promise<number> {
         try { const p = parseIndex(readFileSync(outPath, "utf8")); if (!("error" in p)) prev = p; } catch { /* no prev */ }
       }
       const seq = nextSequence(prev);
+      // Anti-rollback guard (defense-in-depth): unreachable while sequence is auto-bumped (+1),
+      // but protects the deferred explicit --sequence flag from emitting a non-increasing index.
       if (prev && seq <= prev.sequence) { console.error(`ace: publish refused: sequence ${seq} <= prev ${prev.sequence}`); return 1; }
       let serialized: string;
       try {

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -576,6 +576,13 @@ export async function main(argv: readonly string[]): Promise<number> {
         if (deps !== undefined && !Array.isArray(deps)) {
           console.error(`ace: publish: skip ${f} — manifest.dependencies must be an array`); continue;
         }
+        // P2: every files value must be a string — installPackage's writeFileSync(dest, contents)
+        // throws on non-string values, so a self-verified index could point at an un-installable
+        // package. Skip + warn (consistent with the other scan skips).
+        const fileVals = Object.values((obj as AcePackage).files as Record<string, unknown>);
+        if (fileVals.some((v) => typeof v !== "string")) {
+          console.error(`ace: publish: skip ${f} — every file value must be a string`); continue;
+        }
         packages.push(obj as AcePackage);
       }
       if (packages.length === 0) { console.error(`ace: publish refused: no valid packages in ${parsed.pubPackagesDir}`); return 1; }

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -572,6 +572,10 @@ export async function main(argv: readonly string[]): Promise<number> {
         if (f !== expectedFile) {
           console.error(`ace: publish: skip ${f} — filename must be ${expectedFile} to match its derived consumer URL`); continue;
         }
+        const deps = (obj as AcePackage).manifest.dependencies;
+        if (deps !== undefined && !Array.isArray(deps)) {
+          console.error(`ace: publish: skip ${f} — manifest.dependencies must be an array`); continue;
+        }
         packages.push(obj as AcePackage);
       }
       if (packages.length === 0) { console.error(`ace: publish refused: no valid packages in ${parsed.pubPackagesDir}`); return 1; }

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -16,7 +16,7 @@
 // Future commands (not yet implemented): remove, inspect.
 
 import { chmodSync, existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { createPublicKey } from "node:crypto";
+import { createPublicKey, createPrivateKey } from "node:crypto";
 import {
   defaultStorePath, listInstalled, installPackage, contentHash,
   loadTrustStore, addTrustedKey, listTrustedKeys, validatePackagePaths,
@@ -537,6 +537,13 @@ export async function main(argv: readonly string[]): Promise<number> {
       let pem: string;
       try { pem = readFileSync(parsed.pubKeyPath!, "utf8"); }
       catch (e) { console.error(`ace: publish: cannot read key ${parsed.pubKeyPath}: ${(e as Error).message}`); return 1; }
+      // P2-A: a non-Ed25519 key (RSA/EC) would sign + self-verify but the index claims algo:"ed25519",
+      // so consumers reject it. Refuse non-ed25519 (and malformed) keys here, before building the index.
+      try {
+        if (createPrivateKey(pem).asymmetricKeyType !== "ed25519") {
+          console.error("ace: publish refused: --key must be an ed25519 private key"); return 1;
+        }
+      } catch (e) { console.error(`ace: publish refused: invalid private key: ${(e as Error).message}`); return 1; }
       let entries: string[];
       try { entries = readdirSync(parsed.pubPackagesDir!).filter((f) => f.endsWith(".json")); }
       catch (e) { console.error(`ace: publish: cannot read dir ${parsed.pubPackagesDir}: ${(e as Error).message}`); return 1; }
@@ -552,13 +559,27 @@ export async function main(argv: readonly string[]): Promise<number> {
           || typeof (obj as AcePackage).files !== "object" || (obj as AcePackage).files === null) {
           console.error(`ace: publish: skip non-package ${f}`); continue;
         }
+        // P2-C: a package whose content_hash is missing or does not match its files would be indexed
+        // but fail the consumer's content-hash gate. Skip + warn (consistent with the non-package skip).
+        if (typeof (obj as AcePackage).manifest.content_hash !== "string") {
+          console.error(`ace: publish: skip ${f} — missing manifest.content_hash`); continue;
+        }
+        const fh = contentHash(new TextEncoder().encode(JSON.stringify((obj as AcePackage).files)));
+        if (fh !== (obj as AcePackage).manifest.content_hash) {
+          console.error(`ace: publish: skip ${f} — content_hash does not match files`); continue;
+        }
         packages.push(obj as AcePackage);
       }
       if (packages.length === 0) { console.error(`ace: publish refused: no valid packages in ${parsed.pubPackagesDir}`); return 1; }
       const outPath = parsed.pubOut ?? "index.json";
       let prev: IndexDoc | null = null;
       if (existsSync(outPath)) {
-        try { const p = parseIndex(readFileSync(outPath, "utf8")); if (!("error" in p)) prev = p; } catch { /* no prev */ }
+        let prevRaw: string;
+        try { prevRaw = readFileSync(outPath, "utf8"); }
+        catch (e) { console.error(`ace: publish refused: cannot read existing ${outPath}: ${(e as Error).message}`); return 1; }
+        const p = parseIndex(prevRaw);
+        if ("error" in p) { console.error(`ace: publish refused: existing ${outPath} is not a valid index (${p.error}) — refusing to reset sequence (would look like a rollback to consumers); remove or fix it`); return 1; }
+        prev = p;
       }
       const seq = nextSequence(prev);
       // Anti-rollback guard (defense-in-depth): unreachable while sequence is auto-bumped (+1),

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -568,6 +568,10 @@ export async function main(argv: readonly string[]): Promise<number> {
         if (fh !== (obj as AcePackage).manifest.content_hash) {
           console.error(`ace: publish: skip ${f} — content_hash does not match files`); continue;
         }
+        const expectedFile = `${(obj as AcePackage).manifest.name}-${(obj as AcePackage).manifest.version}.json`;
+        if (f !== expectedFile) {
+          console.error(`ace: publish: skip ${f} — filename must be ${expectedFile} to match its derived consumer URL`); continue;
+        }
         packages.push(obj as AcePackage);
       }
       if (packages.length === 0) { console.error(`ace: publish refused: no valid packages in ${parsed.pubPackagesDir}`); return 1; }
@@ -579,6 +583,10 @@ export async function main(argv: readonly string[]): Promise<number> {
         catch (e) { console.error(`ace: publish refused: cannot read existing ${outPath}: ${(e as Error).message}`); return 1; }
         const p = parseIndex(prevRaw);
         if ("error" in p) { console.error(`ace: publish refused: existing ${outPath} is not a valid index (${p.error}) — refusing to reset sequence (would look like a rollback to consumers); remove or fix it`); return 1; }
+        const prevInfo = publicKeyInfoFromPrivatePem(pem);
+        const { signature: prevSig, ...prevContent } = p;
+        const prevVerify = verifyIndexSignature(prevContent, prevSig, new Map([[prevInfo.keyId, { public_key: prevInfo.public_key }]]));
+        if (!prevVerify.ok) { console.error(`ace: publish refused: existing ${outPath} signature does not verify under --key (${prevVerify.reason}) — refusing to auto-bump from an untrusted index; fix or remove it`); return 1; }
         prev = p;
       }
       const seq = nextSequence(prev);

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -28,6 +28,15 @@ import { generateKeypair, signManifest, verifySignature, keyId, publicKeyInfoFro
 import { resolve, packageHash } from "./resolve.ts";
 import { buildLockfile, serializeLockfile, parseLockfile, verifyRootMatchesLock, lockfilesEqual, buildLeafLockfile } from "./lockfile.ts";
 import { solve } from "./solver.ts";
+
+function isValidDepEdge(e: unknown): boolean {
+  if (typeof e !== "object" || e === null) return false;
+  const d = e as Record<string, unknown>;
+  if (typeof d.name !== "string" || typeof d.version !== "string") return false;
+  if (d.kind === "registry") return true;
+  if (d.kind === "inline") return typeof d.url === "string" && typeof d.package_hash === "string";
+  return false;
+}
 import { buildIndexDoc, nextSequence } from "./registry-publish.ts";
 import { loadRegistries, parseIndex } from "./registry-remote.ts";
 import type { IndexDoc } from "./registry-remote.ts";
@@ -537,8 +546,8 @@ export async function main(argv: readonly string[]): Promise<number> {
       let pem: string;
       try { pem = readFileSync(parsed.pubKeyPath!, "utf8"); }
       catch (e) { console.error(`ace: publish: cannot read key ${parsed.pubKeyPath}: ${(e as Error).message}`); return 1; }
-      // P2-A: a non-Ed25519 key (RSA/EC) would sign + self-verify but the index claims algo:"ed25519",
-      // so consumers reject it. Refuse non-ed25519 (and malformed) keys here, before building the index.
+      // P2-A: signIndex uses crypto.sign(null, ...) which only supports Ed25519/Ed448 — an RSA/EC key
+      // THROWS rather than signing. Pre-check here to fail fast with a clear error before building the index.
       try {
         if (createPrivateKey(pem).asymmetricKeyType !== "ed25519") {
           console.error("ace: publish refused: --key must be an ed25519 private key"); return 1;
@@ -582,6 +591,25 @@ export async function main(argv: readonly string[]): Promise<number> {
         const fileVals = Object.values((obj as AcePackage).files as Record<string, unknown>);
         if (fileVals.some((v) => typeof v !== "string")) {
           console.error(`ace: publish: skip ${f} — every file value must be a string`); continue;
+        }
+        // P2: package name/version must be URL-safe — the consumer URL is <base>/<name>-<version>.json,
+        // so a '#' or '?' (or path sep / control char) would break or redirect the fetched URL.
+        const nm = (obj as AcePackage).manifest.name;
+        const ver = (obj as AcePackage).manifest.version;
+        if (/[\x00-\x20#?%/\\]/.test(nm) || /[\x00-\x20#?%/\\]/.test(ver)) {
+          console.error(`ace: publish: skip ${f} — name/version has a URL-unsafe character`); continue;
+        }
+        // P2: dependency edges must be well-formed (matching the consumer's AceDependency shape),
+        // else a consumer resolve would break on a self-verified index.
+        const depEdges = (obj as AcePackage).manifest.dependencies;
+        if (Array.isArray(depEdges) && !depEdges.every(isValidDepEdge)) {
+          console.error(`ace: publish: skip ${f} — malformed dependency edge`); continue;
+        }
+        // P2: reuse the consumer's path guard — a package with an unsafe files key (../ or absolute)
+        // would index but be rejected/unsafe at install. Skip + warn.
+        const unsafePath = validatePackagePaths(obj as AcePackage);
+        if (unsafePath !== null) {
+          console.error(`ace: publish: skip ${f} — unsafe file path: ${unsafePath}`); continue;
         }
         packages.push(obj as AcePackage);
       }

--- a/tools/ace/registry-publish.test.ts
+++ b/tools/ace/registry-publish.test.ts
@@ -45,6 +45,16 @@ describe("buildIndexDoc", () => {
     const { signature, ...content } = doc;
     expect(verifyIndexSignature(content, signature, new Map([[info.keyId, { public_key: info.public_key }]])).ok).toBe(true);
   });
+
+  test.each(["__proto__", "constructor", "prototype"])("rejects reserved package name %s", (bad) => {
+    const doc = buildIndexDoc({ packages: [pkg(bad, "1.0.0") as never], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    expect("error" in doc).toBe(true);
+  });
+  test("rejects reserved package version", () => {
+    const doc = buildIndexDoc({ packages: [pkg("ok", "__proto__") as never], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    expect("error" in doc).toBe(true);
+  });
+
   test("duplicate name@version → error", () => {
     const doc = buildIndexDoc({ packages: [pkg("leaf", "1.0.0") as never, pkg("leaf", "1.0.0") as never], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
     expect("error" in doc).toBe(true);

--- a/tools/ace/registry-publish.test.ts
+++ b/tools/ace/registry-publish.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { joinUrl, nextSequence, buildIndexDoc } from "./registry-publish.ts";
+import { generateKeypair, verifyIndexSignature, publicKeyInfoFromPrivatePem } from "./signing.ts";
+import { parseIndex } from "./registry-remote.ts";
+import { packageHash } from "./resolve.ts";
+import { contentHash } from "./store.ts";
+
+// helper: a minimal well-formed AcePackage with a correct content_hash
+function pkg(name: string, version: string, files: Record<string, string> = { "a.txt": "x" }) {
+  const content_hash = contentHash(new TextEncoder().encode(JSON.stringify(files)));
+  return { manifest: { format_version: 1, name, version, content_hash }, files };
+}
+
+describe("joinUrl", () => {
+  test("single separator regardless of trailing slash", () => {
+    expect(joinUrl("https://pkgs", "leaf-1.0.0.json")).toBe("https://pkgs/leaf-1.0.0.json");
+    expect(joinUrl("https://pkgs/", "leaf-1.0.0.json")).toBe("https://pkgs/leaf-1.0.0.json");
+    expect(joinUrl("https://pkgs///", "leaf-1.0.0.json")).toBe("https://pkgs/leaf-1.0.0.json");
+  });
+});
+
+describe("nextSequence", () => {
+  test("null → 1", () => { expect(nextSequence(null)).toBe(1); });
+  test("prev → prev+1", () => {
+    const prev = { format_version: 1 as const, sequence: 6, issued_at: "2026-06-01T12:00:00Z", packages: {}, signature: { algo: "ed25519" as const, key_id: "k", sig: "s" } };
+    expect(nextSequence(prev)).toBe(7);
+  });
+});
+
+describe("buildIndexDoc", () => {
+  const kp = generateKeypair();
+  const issuedAt = "2026-06-01T12:00:00Z";
+  test("assembles url + package_hash per package, signs, self-verifies", () => {
+    const p = pkg("leaf", "1.0.0");
+    const doc = buildIndexDoc({ packages: [p as never], baseUrl: "https://pkgs", sequence: 3, issuedAt, privatePem: kp.privatePem });
+    expect("error" in doc).toBe(false);
+    if ("error" in doc) return;
+    expect(doc.sequence).toBe(3);
+    expect(doc.issued_at).toBe(issuedAt);
+    expect(doc.packages.leaf!["1.0.0"]!.url).toBe("https://pkgs/leaf-1.0.0.json");
+    expect(doc.packages.leaf!["1.0.0"]!.package_hash).toBe(packageHash(p as never));
+    const reparsed = parseIndex(JSON.stringify(doc));
+    expect("error" in reparsed).toBe(false);
+    const info = publicKeyInfoFromPrivatePem(kp.privatePem);
+    const { signature, ...content } = doc;
+    expect(verifyIndexSignature(content, signature, new Map([[info.keyId, { public_key: info.public_key }]])).ok).toBe(true);
+  });
+  test("duplicate name@version → error", () => {
+    const doc = buildIndexDoc({ packages: [pkg("leaf", "1.0.0") as never, pkg("leaf", "1.0.0") as never], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    expect("error" in doc).toBe(true);
+  });
+});

--- a/tools/ace/registry-publish.test.ts
+++ b/tools/ace/registry-publish.test.ts
@@ -59,4 +59,11 @@ describe("buildIndexDoc", () => {
     const doc = buildIndexDoc({ packages: [pkg("leaf", "1.0.0"), pkg("leaf", "1.0.0")], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
     expect("error" in doc).toBe(true);
   });
+
+  test("packages sorted by name then version regardless of input order", () => {
+    const doc = buildIndexDoc({ packages: [pkg("zeta", "1.0.0"), pkg("alpha", "1.0.0")], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    expect("error" in doc).toBe(false);
+    if ("error" in doc) return;
+    expect(Object.keys(doc.packages)).toEqual(["alpha", "zeta"]);
+  });
 });

--- a/tools/ace/registry-publish.test.ts
+++ b/tools/ace/registry-publish.test.ts
@@ -32,13 +32,13 @@ describe("buildIndexDoc", () => {
   const issuedAt = "2026-06-01T12:00:00Z";
   test("assembles url + package_hash per package, signs, self-verifies", () => {
     const p = pkg("leaf", "1.0.0");
-    const doc = buildIndexDoc({ packages: [p as never], baseUrl: "https://pkgs", sequence: 3, issuedAt, privatePem: kp.privatePem });
+    const doc = buildIndexDoc({ packages: [p], baseUrl: "https://pkgs", sequence: 3, issuedAt, privatePem: kp.privatePem });
     expect("error" in doc).toBe(false);
     if ("error" in doc) return;
     expect(doc.sequence).toBe(3);
     expect(doc.issued_at).toBe(issuedAt);
     expect(doc.packages.leaf!["1.0.0"]!.url).toBe("https://pkgs/leaf-1.0.0.json");
-    expect(doc.packages.leaf!["1.0.0"]!.package_hash).toBe(packageHash(p as never));
+    expect(doc.packages.leaf!["1.0.0"]!.package_hash).toBe(packageHash(p));
     const reparsed = parseIndex(JSON.stringify(doc));
     expect("error" in reparsed).toBe(false);
     const info = publicKeyInfoFromPrivatePem(kp.privatePem);
@@ -47,16 +47,16 @@ describe("buildIndexDoc", () => {
   });
 
   test.each(["__proto__", "constructor", "prototype"])("rejects reserved package name %s", (bad) => {
-    const doc = buildIndexDoc({ packages: [pkg(bad, "1.0.0") as never], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    const doc = buildIndexDoc({ packages: [pkg(bad, "1.0.0")], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
     expect("error" in doc).toBe(true);
   });
   test("rejects reserved package version", () => {
-    const doc = buildIndexDoc({ packages: [pkg("ok", "__proto__") as never], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    const doc = buildIndexDoc({ packages: [pkg("ok", "__proto__")], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
     expect("error" in doc).toBe(true);
   });
 
   test("duplicate name@version → error", () => {
-    const doc = buildIndexDoc({ packages: [pkg("leaf", "1.0.0") as never, pkg("leaf", "1.0.0") as never], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    const doc = buildIndexDoc({ packages: [pkg("leaf", "1.0.0"), pkg("leaf", "1.0.0")], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
     expect("error" in doc).toBe(true);
   });
 });

--- a/tools/ace/registry-publish.ts
+++ b/tools/ace/registry-publish.ts
@@ -17,6 +17,9 @@ export function nextSequence(prev: IndexDoc | null): number {
   return prev ? prev.sequence + 1 : 1;
 }
 
+
+/** Package names/versions that would mutate Object prototypes; rejected at ingest. */
+const RESERVED_IDENTITY_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 /** Assemble + sign an index doc from already-read packages. Duplicate name@version → error. */
 export function buildIndexDoc(args: {
   packages: AcePackage[]; baseUrl: string; sequence: number; issuedAt: string; privatePem: string;
@@ -27,6 +30,9 @@ export function buildIndexDoc(args: {
     const name = pkg.manifest.name;
     const version = pkg.manifest.version;
     const versions = packages[name] ?? (Object.create(null) as Record<string, RegistryEntry>);
+    if (RESERVED_IDENTITY_KEYS.has(name) || RESERVED_IDENTITY_KEYS.has(version)) {
+      return { error: `reserved package identity not allowed: ${name}@${version}` };
+    }
     if (versions[version] !== undefined) return { error: `duplicate package ${name}@${version}` };
     versions[version] = { url: joinUrl(args.baseUrl, `${name}-${version}.json`), package_hash: packageHash(pkg) };
     packages[name] = versions;

--- a/tools/ace/registry-publish.ts
+++ b/tools/ace/registry-publish.ts
@@ -1,0 +1,37 @@
+// registry-publish.ts -- Ace slice 6.1: pure producer-side index assembly + signing.
+// Inverts the consumer: build the signed IndexSignableContent a slice-6 consumer accepts.
+// No I/O — the caller (ace.ts) reads the package files + sequence + pem and writes the output.
+import type { AcePackage, RegistryEntry } from "./store.ts";
+import { packageHash } from "./resolve.ts";
+import type { IndexSignableContent } from "./signing.ts";
+import { signIndex } from "./signing.ts";
+import type { IndexDoc } from "./registry-remote.ts";
+
+/** Join a base url + filename with exactly one separator (trailing slashes normalized). */
+export function joinUrl(base: string, file: string): string {
+  return base.replace(/\/+$/, "") + "/" + file;
+}
+
+/** Monotonic next sequence: bump the prior index's sequence, or start at 1. */
+export function nextSequence(prev: IndexDoc | null): number {
+  return prev ? prev.sequence + 1 : 1;
+}
+
+/** Assemble + sign an index doc from already-read packages. Duplicate name@version → error. */
+export function buildIndexDoc(args: {
+  packages: AcePackage[]; baseUrl: string; sequence: number; issuedAt: string; privatePem: string;
+}): IndexDoc | { error: string } {
+  // Null-prototype map: a package name like "__proto__" cannot pollute via bracket-assign.
+  const packages: Record<string, Record<string, RegistryEntry>> = Object.create(null);
+  for (const pkg of args.packages) {
+    const name = pkg.manifest.name;
+    const version = pkg.manifest.version;
+    const versions = packages[name] ?? (Object.create(null) as Record<string, RegistryEntry>);
+    if (versions[version] !== undefined) return { error: `duplicate package ${name}@${version}` };
+    versions[version] = { url: joinUrl(args.baseUrl, `${name}-${version}.json`), package_hash: packageHash(pkg) };
+    packages[name] = versions;
+  }
+  const content: IndexSignableContent = { format_version: 1, sequence: args.sequence, issued_at: args.issuedAt, packages };
+  const signature = signIndex(content, args.privatePem);
+  return { ...content, signature };
+}

--- a/tools/ace/registry-publish.ts
+++ b/tools/ace/registry-publish.ts
@@ -26,7 +26,9 @@ export function buildIndexDoc(args: {
 }): IndexDoc | { error: string } {
   // Null-prototype map: a package name like "__proto__" cannot pollute via bracket-assign.
   const packages: Record<string, Record<string, RegistryEntry>> = Object.create(null);
-  for (const pkg of args.packages) {
+  const sorted = [...args.packages].sort((a, b) =>
+    a.manifest.name.localeCompare(b.manifest.name) || a.manifest.version.localeCompare(b.manifest.version));
+  for (const pkg of sorted) {
     const name = pkg.manifest.name;
     const version = pkg.manifest.version;
     const versions = packages[name] ?? (Object.create(null) as Record<string, RegistryEntry>);

--- a/tools/ace/signing.test.ts
+++ b/tools/ace/signing.test.ts
@@ -3,9 +3,10 @@ import { generateKeyPairSync } from "node:crypto";
 import {
   generateKeypair, keyId, canonicalManifestBytes, signManifest, verifySignature,
   type TrustEntry,
+  signIndex, verifyIndexSignature, type IndexSignableContent,
+  publicKeyInfoFromPrivatePem,
 } from "./signing.ts";
 import type { AceManifest } from "./store.ts";
-import { signIndex, verifyIndexSignature, type IndexSignableContent } from "./signing.ts";
 
 function baseManifest(overrides: Partial<AceManifest> = {}): AceManifest {
   return { format_version: 1, name: "demo", version: "1.0.0", content_hash: "sha256:abc", ...overrides };
@@ -130,7 +131,6 @@ describe("index signing", () => {
   });
 });
 
-import { publicKeyInfoFromPrivatePem } from "./signing.ts";
 
 describe("publicKeyInfoFromPrivatePem", () => {
   test("derives the same keyId + public_key as generateKeypair for the same key", () => {

--- a/tools/ace/signing.test.ts
+++ b/tools/ace/signing.test.ts
@@ -128,3 +128,23 @@ describe("index signing", () => {
     if (!r.ok) expect(r.reason).toBe("unsupported-algo");
   });
 });
+
+import { publicKeyInfoFromPrivatePem } from "./signing.ts";
+
+describe("publicKeyInfoFromPrivatePem", () => {
+  test("derives the same keyId + public_key as generateKeypair for the same key", () => {
+    const kp = generateKeypair();
+    const info = publicKeyInfoFromPrivatePem(kp.privatePem);
+    expect(info.keyId).toBe(kp.keyId);
+    expect(info.public_key).toBe(kp.publicSpkiB64);
+  });
+  test("the derived public_key verifies an index this key signed", () => {
+    const kp = generateKeypair();
+    const content = { format_version: 1 as const, sequence: 1, issued_at: "2026-06-01T12:00:00Z",
+      packages: { leaf: { "1.0.0": { url: "https://x/l.json", package_hash: "sha256:aa" } } } };
+    const sig = signIndex(content, kp.privatePem);
+    const info = publicKeyInfoFromPrivatePem(kp.privatePem);
+    const trust = new Map([[info.keyId, { public_key: info.public_key }]]);
+    expect(verifyIndexSignature(content, sig, trust).ok).toBe(true);
+  });
+});

--- a/tools/ace/signing.test.ts
+++ b/tools/ace/signing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
 import {
   generateKeypair, keyId, canonicalManifestBytes, signManifest, verifySignature,
   type TrustEntry,
@@ -146,5 +147,10 @@ describe("publicKeyInfoFromPrivatePem", () => {
     const info = publicKeyInfoFromPrivatePem(kp.privatePem);
     const trust = new Map([[info.keyId, { public_key: info.public_key }]]);
     expect(verifyIndexSignature(content, sig, trust).ok).toBe(true);
+  });
+  test("throws for a non-ed25519 key", () => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const rsaPem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+    expect(() => publicKeyInfoFromPrivatePem(rsaPem)).toThrow(/ed25519/);
   });
 });

--- a/tools/ace/signing.ts
+++ b/tools/ace/signing.ts
@@ -114,3 +114,12 @@ export function verifyIndexSignature(
   if (entry.label !== undefined) (result as { ok: true; key_id: string; label?: string }).label = entry.label;
   return result;
 }
+
+
+/** Derive the SPKI-DER base64 public key + its keyId from a private PEM (for a self-verify
+ *  trust store). Sibling of signIndex's internal signer-id derivation. */
+export function publicKeyInfoFromPrivatePem(privatePem: string): { keyId: string; public_key: string } {
+  const priv = createPrivateKey(privatePem);
+  const public_key = (createPublicKey(priv).export({ type: "spki", format: "der" }) as Buffer).toString("base64");
+  return { keyId: keyId(public_key), public_key };
+}

--- a/tools/ace/signing.ts
+++ b/tools/ace/signing.ts
@@ -120,6 +120,9 @@ export function verifyIndexSignature(
  *  trust store). Sibling of signIndex's internal signer-id derivation. */
 export function publicKeyInfoFromPrivatePem(privatePem: string): { keyId: string; public_key: string } {
   const priv = createPrivateKey(privatePem);
+  if (priv.asymmetricKeyType !== "ed25519") {
+    throw new Error(`publicKeyInfoFromPrivatePem: expected an ed25519 key, got ${priv.asymmetricKeyType ?? "unknown"}`);
+  }
   const public_key = (createPublicKey(priv).export({ type: "spki", format: "der" }) as Buffer).toString("base64");
   return { keyId: keyId(public_key), public_key };
 }


### PR DESCRIPTION
Slice 6.1 — **`ace registry publish`** (B-0980), the producer-side counterpart to slice 6's consumer trust gates. Spec #6434; plan in this PR.

`ace registry publish --packages <dir> --base-url <url> --key <pem-path> [--out index.json]`: scan a dir of package files → derive each consumer `url` (`<base>/<name>-<version>.json`) + `package_hash` → assemble + sign the `IndexSignableContent` → auto-bump `sequence` from `--out` → **round-trip self-verify** the produced index through the consumer's own `parseIndex` + `verifyIndexSignature` before writing.

### What ships
- **`tools/ace/registry-publish.ts`** (new, pure): `buildIndexDoc` (assemble + sign; duplicate `name@version` → error; null-proto maps), `nextSequence` (null→1, prev→+1), `joinUrl` (trailing-slash normalized).
- **`tools/ace/signing.ts`** (+`publicKeyInfoFromPrivatePem`): derive pubkey+keyId from a private PEM for the self-verify trust store.
- **`tools/ace/ace.ts`**: `registry publish` parse + handler — dir scan (non-packages skipped + warned), prev-from-`--out` sequence bump, build, **round-trip self-verify (parse + signature; hard error + no write on failure)**, pretty-print write. Malformed-PEM throw caught → clean exit 1.

### Verification
- **266 pass / 0 fail**, tsc 0, markdownlint clean, canary 67. Built subagent-driven (4 TDD tasks), each false-green-checked.
- Final holistic review: zero P0; self-verify confirmed genuine + never-writes-on-failure; producer/consumer coherent (published index satisfies the slice-6 consumer). Review fixes: duplicate + malformed-key e2e coverage added; dead anti-rollback guard clarified (defense-in-depth for the deferred `--sequence` flag).

### Deferred (B-0980 stays open for these)
Per-package url override, ETag/Last-Modified sidecar, multi-dir, incremental/multi-signer publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)