### PR TITLE
feat(B-0976): resume engine — TS reference (restore-not-replay CEK saga kernel)

### DIFF
--- a/src/Core.TypeScript/bonsai/resume-golden.json
+++ b/src/Core.TypeScript/bonsai/resume-golden.json
@@ -1,0 +1,103 @@
+{
+  "description": "Resume-engine cross-language conformance (B-0976 resume slice). The TS reference oracle authors these saga traces; F#/C#/Rust replay them. A trace is a Bonsai-subset program whose `call` nodes are activities (suspension points). Each oracle runs start -> (assert suspension fn+args; resume with the next activityResult)* -> done, and must produce the SAME ordered suspension sequence AND the SAME final value. Restore-not-replay: persisting the state at any suspension (serializeState) and resuming from the re-parsed state must give the identical continuation (prior activities are never re-invoked). The compilers do not lie; agreement IS the verification.",
+  "version": 1,
+  "traces": [
+    {
+      "name": "two_sequential_activities",
+      "note": "add(a(), b()) — suspends at a, then b; arithmetic on their results",
+      "program": {
+        "kind": "binary",
+        "op": "add",
+        "left": { "kind": "call", "fn": "a", "args": [] },
+        "right": { "kind": "call", "fn": "b", "args": [] }
+      },
+      "bindings": {},
+      "activityResults": [
+        { "t": "int", "v": 10 },
+        { "t": "int", "v": 20 }
+      ],
+      "expectedSuspensions": [
+        { "fn": "a", "args": [] },
+        { "fn": "b", "args": [] }
+      ],
+      "expectedFinal": { "t": "int", "v": 30 }
+    },
+    {
+      "name": "cond_branch_on_activity",
+      "note": "cond(lt(roll(), 5), 'low', 'high') — one activity, branch on its result",
+      "program": {
+        "kind": "cond",
+        "test": {
+          "kind": "binary",
+          "op": "lt",
+          "left": { "kind": "call", "fn": "roll", "args": [] },
+          "right": { "kind": "const", "value": { "t": "int", "v": 5 } }
+        },
+        "then": { "kind": "const", "value": { "t": "str", "v": "low" } },
+        "else": { "kind": "const", "value": { "t": "str", "v": "high" } }
+      },
+      "bindings": {},
+      "activityResults": [{ "t": "int", "v": 3 }],
+      "expectedSuspensions": [{ "fn": "roll", "args": [] }],
+      "expectedFinal": { "t": "str", "v": "low" }
+    },
+    {
+      "name": "activity_with_computed_args",
+      "note": "act(add(1,2), 7) — args evaluated before the activity suspends",
+      "program": {
+        "kind": "call",
+        "fn": "act",
+        "args": [
+          {
+            "kind": "binary",
+            "op": "add",
+            "left": { "kind": "const", "value": { "t": "int", "v": 1 } },
+            "right": { "kind": "const", "value": { "t": "int", "v": 2 } }
+          },
+          { "kind": "const", "value": { "t": "int", "v": 7 } }
+        ]
+      },
+      "bindings": {},
+      "activityResults": [{ "t": "int", "v": 42 }],
+      "expectedSuspensions": [
+        { "fn": "act", "args": [{ "t": "int", "v": 3 }, { "t": "int", "v": 7 }] }
+      ],
+      "expectedFinal": { "t": "int", "v": 42 }
+    },
+    {
+      "name": "pure_no_suspension",
+      "note": "add(2, mul(3,4)) — no activities; finishes without suspending",
+      "program": {
+        "kind": "binary",
+        "op": "add",
+        "left": { "kind": "const", "value": { "t": "int", "v": 2 } },
+        "right": {
+          "kind": "binary",
+          "op": "mul",
+          "left": { "kind": "const", "value": { "t": "int", "v": 3 } },
+          "right": { "kind": "const", "value": { "t": "int", "v": 4 } }
+        }
+      },
+      "bindings": {},
+      "activityResults": [],
+      "expectedSuspensions": [],
+      "expectedFinal": { "t": "int", "v": 14 }
+    },
+    {
+      "name": "param_binding_plus_activity",
+      "note": "add(n, dbl(n)) with n bound to 5 — param lookup + activity carrying a computed arg",
+      "program": {
+        "kind": "binary",
+        "op": "add",
+        "left": { "kind": "param", "name": "n" },
+        "right": { "kind": "call", "fn": "dbl", "args": [{ "kind": "param", "name": "n" }] }
+      },
+      "bindings": { "n": { "t": "int", "v": 5 } },
+      "activityResults": [{ "t": "int", "v": 10 }],
+      "expectedSuspensions": [
+        { "fn": "dbl", "args": [{ "t": "int", "v": 5 }] }
+      ],
+      "expectedFinal": { "t": "int", "v": 15 }
+    }
+  ]
+}

--- a/src/Core.TypeScript/bonsai/resume.test.ts
+++ b/src/Core.TypeScript/bonsai/resume.test.ts
@@ -127,3 +127,21 @@ test("parseState declines MalformedState on a tampered/unknown operator in a res
   expect(r.ok).toBe(false);
   if (!r.ok) expect(r.error.kind).toBe("MalformedState");
 });
+
+test("parseState declines MalformedState on an unsafe integer in a restored state", () => {
+  // a suspension carrying an int activity-arg: act(7) → awaiting {act, args:[{int,7}]}
+  const program = { kind: "call", fn: "act", args: [cint(7)] } as const;
+  const s0 = stepOk(start(program));
+  expect(s0.kind).toBe("suspended");
+  if (s0.kind !== "suspended") return;
+  const ser = serializeState(s0.state);
+  expect(ser.ok).toBe(true);
+  if (!ser.ok) return;
+  // tamper the persisted int beyond 2^53-1 — JSON.parse rounds it to an integer, but the
+  // safe-int wire contract must reject it rather than resume a corrupted value
+  const tampered = ser.value.replace('"v":7', '"v":9007199254740993');
+  expect(tampered).not.toBe(ser.value);
+  const r = parseState(tampered);
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error.kind).toBe("MalformedState");
+});

--- a/src/Core.TypeScript/bonsai/resume.test.ts
+++ b/src/Core.TypeScript/bonsai/resume.test.ts
@@ -109,3 +109,21 @@ test("parseState declines MalformedState on junk + on an unsupported version", (
   expect(b.ok).toBe(false);
   if (!b.ok) expect(b.error.kind).toBe("MalformedState");
 });
+
+test("parseState declines MalformedState on a tampered/unknown operator in a restored frame", () => {
+  // a real suspension whose kont carries an evalRight 'add' frame: add(a(), b()) at activity a
+  const program = binary("add", { kind: "call", fn: "a", args: [] }, { kind: "call", fn: "b", args: [] });
+  const s0 = stepOk(start(program));
+  expect(s0.kind).toBe("suspended");
+  if (s0.kind !== "suspended") return;
+  const ser = serializeState(s0.state);
+  expect(ser.ok).toBe(true);
+  if (!ser.ok) return;
+  // tamper the persisted op to an unknown one — must be rejected at the parse boundary,
+  // never cast through to applyBinOp (which would silently yield undefined)
+  const tampered = ser.value.replace('"op":"add"', '"op":"xor"');
+  expect(tampered).not.toBe(ser.value);
+  const r = parseState(tampered);
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error.kind).toBe("MalformedState");
+});

--- a/src/Core.TypeScript/bonsai/resume.test.ts
+++ b/src/Core.TypeScript/bonsai/resume.test.ts
@@ -79,6 +79,20 @@ test("lambda in eval position declines UnsupportedNode (slice-1)", () => {
   if (!r.ok) expect(r.error.kind).toBe("UnsupportedNode");
 });
 
+test("a param named like an Object.prototype member declines Unbound (own-property lookup)", () => {
+  for (const name of ["toString", "constructor", "hasOwnProperty", "__proto__"]) {
+    const r = start(param(name)); // default {} bindings — must NOT resolve an inherited member
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.kind).toBe("Unbound");
+  }
+});
+
+test("arithmetic past the safe-int range declines NonSafeInt", () => {
+  const r = start(binary("add", cint(Number.MAX_SAFE_INTEGER), cint(1)));
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error.kind).toBe("NonSafeInt");
+});
+
 // ---- state serialization round-trip ----
 
 test("serializeState / parseState round-trip + resume-from-restored equals resume-from-original", () => {

--- a/src/Core.TypeScript/bonsai/resume.test.ts
+++ b/src/Core.TypeScript/bonsai/resume.test.ts
@@ -93,6 +93,31 @@ test("arithmetic past the safe-int range declines NonSafeInt", () => {
   if (!r.ok) expect(r.error.kind).toBe("NonSafeInt");
 });
 
+test("a restored env preserves a __proto__ binding (no prototype-setter hole)", () => {
+  // "__proto__" is a legal Bonsai param name; a saga that captures it must round-trip through
+  // persist/restore and still resolve the binding (not invoke the legacy prototype setter)
+  const bindings = Object.create(null) as Record<string, ConstValue>;
+  bindings["__proto__"] = { t: "int", v: 5 };
+  const program = binary("add", { kind: "call", fn: "a", args: [] }, param("__proto__"));
+  const s0 = stepOk(start(program, bindings));
+  expect(s0.kind).toBe("suspended");
+  if (s0.kind !== "suspended") return;
+  const ser = serializeState(s0.state);
+  expect(ser.ok).toBe(true);
+  if (!ser.ok) return;
+  const restored = parseState(ser.value);
+  expect(restored.ok).toBe(true);
+  if (!restored.ok) return;
+  // resume from the RESTORED state: param("__proto__") must resolve to 5 → add(10,5)=15,
+  // not decline Unbound (which it would if readEnv had used the prototype setter)
+  const r = resume(restored.value, { t: "int", v: 10 });
+  expect(r.ok).toBe(true);
+  if (r.ok) {
+    expect(r.value.kind).toBe("done");
+    if (r.value.kind === "done") expect(r.value.value).toEqual({ t: "int", v: 15 });
+  }
+});
+
 // ---- state serialization round-trip ----
 
 test("serializeState / parseState round-trip + resume-from-restored equals resume-from-original", () => {

--- a/src/Core.TypeScript/bonsai/resume.test.ts
+++ b/src/Core.TypeScript/bonsai/resume.test.ts
@@ -1,0 +1,111 @@
+import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { binary, cbool, cint, lambda, param, type ConstValue, type Expr, type Result } from "./bonsai";
+import { parseState, resume, serializeState, start, type ResumeFeedback, type SagaStep } from "./resume";
+
+interface Trace {
+  readonly name: string;
+  readonly program: Expr;
+  readonly bindings: Record<string, ConstValue>;
+  readonly activityResults: readonly ConstValue[];
+  readonly expectedSuspensions: readonly { readonly fn: string; readonly args: readonly ConstValue[] }[];
+  readonly expectedFinal: ConstValue;
+}
+
+const goldenPath = join(dirname(fileURLToPath(import.meta.url)), "resume-golden.json");
+const golden = JSON.parse(readFileSync(goldenPath, "utf8")) as { readonly traces: readonly Trace[] };
+
+function stepOk(r: Result<SagaStep, ResumeFeedback>): SagaStep {
+  if (!r.ok) throw new Error(`expected Ok SagaStep, got Error ${JSON.stringify(r.error)}`);
+  return r.value;
+}
+
+// Replay each golden trace; at EVERY suspension persist the state and resume from the
+// re-parsed state — proving restore-not-replay (the continuation round-trips; prior
+// activities are never re-invoked) AND the cross-language suspension/final contract.
+for (const tr of golden.traces) {
+  test(`resume golden: ${tr.name}`, () => {
+    let step = stepOk(start(tr.program, tr.bindings));
+    for (let i = 0; i < tr.expectedSuspensions.length; i++) {
+      expect(step.kind).toBe("suspended");
+      if (step.kind !== "suspended") return;
+      expect(step.activity).toEqual(tr.expectedSuspensions[i]!);
+
+      // persist → re-parse → resume from the RESTORED state (not a replay from the top)
+      const ser = serializeState(step.state);
+      expect(ser.ok).toBe(true);
+      if (!ser.ok) return;
+      const restored = parseState(ser.value);
+      expect(restored.ok).toBe(true);
+      if (!restored.ok) return;
+      // canonical round-trip is byte-stable
+      const reser = serializeState(restored.value);
+      expect(reser.ok).toBe(true);
+      if (reser.ok) expect(reser.value).toBe(ser.value);
+
+      step = stepOk(resume(restored.value, tr.activityResults[i]!));
+    }
+    expect(step.kind).toBe("done");
+    if (step.kind !== "done") return;
+    expect(step.value).toEqual(tr.expectedFinal);
+  });
+}
+
+test("golden traces are loaded", () => {
+  expect(golden.traces.length).toBeGreaterThan(0);
+});
+
+// ---- feedback-variant rejections ----
+
+test("unbound param declines Unbound", () => {
+  const r = start(param("missing"));
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error.kind).toBe("Unbound");
+});
+
+test("type mismatch declines TypeMismatch", () => {
+  // add requires int operands; a bool operand is a type error
+  const r = start(binary("add", cint(1), cbool(true)));
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error.kind).toBe("TypeMismatch");
+});
+
+test("lambda in eval position declines UnsupportedNode (slice-1)", () => {
+  const r = start(lambda(["x"], cint(1)));
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error.kind).toBe("UnsupportedNode");
+});
+
+// ---- state serialization round-trip ----
+
+test("serializeState / parseState round-trip + resume-from-restored equals resume-from-original", () => {
+  // a 2-activity saga: suspend at the first, persist, restore, and resume both ways
+  const program = binary("add", { kind: "call", fn: "x", args: [] }, { kind: "call", fn: "y", args: [] });
+  const s0 = stepOk(start(program));
+  expect(s0.kind).toBe("suspended");
+  if (s0.kind !== "suspended") return;
+
+  const ser = serializeState(s0.state);
+  expect(ser.ok).toBe(true);
+  if (!ser.ok) return;
+  const restored = parseState(ser.value);
+  expect(restored.ok).toBe(true);
+  if (!restored.ok) return;
+
+  const fromOriginal = stepOk(resume(s0.state, { t: "int", v: 1 }));
+  const fromRestored = stepOk(resume(restored.value, { t: "int", v: 1 }));
+  expect(fromRestored).toEqual(fromOriginal);
+});
+
+test("parseState declines MalformedState on junk + on an unsupported version", () => {
+  const a = parseState("not json");
+  expect(a.ok).toBe(false);
+  if (!a.ok) expect(a.error.kind).toBe("MalformedState");
+
+  const b = parseState('{"v":2,"kont":[],"awaiting":{"fn":"a","args":[]}}');
+  expect(b.ok).toBe(false);
+  if (!b.ok) expect(b.error.kind).toBe("MalformedState");
+});

--- a/src/Core.TypeScript/bonsai/resume.ts
+++ b/src/Core.TypeScript/bonsai/resume.ts
@@ -283,6 +283,17 @@ function bad(message: string): never {
   throw new ResumeFail({ kind: "MalformedState", message });
 }
 
+/** The valid binary operators, for validating ops restored from a persisted state. */
+const BIN_OPS: ReadonlySet<string> = new Set<BinOp>(["add", "sub", "mul", "eq", "lt", "and", "or"]);
+
+/** Validate a restored operator against the known `BinOp` tags. A tampered / future-version
+ * state carrying an unknown op (e.g. "xor") declines `MalformedState` here, rather than
+ * casting through to `applyBinOp` (whose exhaustive switch would otherwise yield `undefined`). */
+function readBinOp(v: unknown, where: string): BinOp {
+  if (typeof v !== "string" || !BIN_OPS.has(v)) bad(`${where} unknown operator`);
+  return v as BinOp;
+}
+
 function readConstValue(n: unknown, where: string): ConstValue {
   if (typeof n !== "object" || n === null) bad(`${where} is not an object`);
   const o = n as Record<string, unknown>;
@@ -323,9 +334,9 @@ function readFrame(n: unknown): Frame {
   const o = n as Record<string, unknown>;
   switch (o.k) {
     case "evalRight":
-      return { k: "evalRight", op: o.op as BinOp, right: readExpr(o.right, "evalRight.right"), env: readEnv(o.env, "evalRight.env") };
+      return { k: "evalRight", op: readBinOp(o.op, "evalRight.op"), right: readExpr(o.right, "evalRight.right"), env: readEnv(o.env, "evalRight.env") };
     case "applyOp":
-      return { k: "applyOp", op: o.op as BinOp, left: readConstValue(o.left, "applyOp.left") };
+      return { k: "applyOp", op: readBinOp(o.op, "applyOp.op"), left: readConstValue(o.left, "applyOp.left") };
     case "branch":
       return { k: "branch", then: readExpr(o.then, "branch.then"), els: readExpr(o.els, "branch.els"), env: readEnv(o.env, "branch.env") };
     case "evalArgs": {

--- a/src/Core.TypeScript/bonsai/resume.ts
+++ b/src/Core.TypeScript/bonsai/resume.ts
@@ -335,7 +335,10 @@ function readConstValue(n: unknown, where: string): ConstValue {
 function readEnv(n: unknown, where: string): Env {
   if (typeof n !== "object" || n === null || Array.isArray(n)) bad(`${where} is not an object`);
   const o = n as Record<string, unknown>;
-  const out: Record<string, ConstValue> = {};
+  // null-prototype: assigning a binding named "__proto__" (a legal Bonsai param name) must
+  // create an own property, not invoke the legacy prototype setter — so a restored env
+  // preserves every binding (and the own-property param lookup then finds it).
+  const out: Record<string, ConstValue> = Object.create(null) as Record<string, ConstValue>;
   for (const k of Object.keys(o)) out[k] = readConstValue(o[k], `${where}.${k}`);
   return out;
 }

--- a/src/Core.TypeScript/bonsai/resume.ts
+++ b/src/Core.TypeScript/bonsai/resume.ts
@@ -299,7 +299,10 @@ function readConstValue(n: unknown, where: string): ConstValue {
   const o = n as Record<string, unknown>;
   switch (o.t) {
     case "int":
-      if (typeof o.v !== "number" || !Number.isInteger(o.v)) bad(`${where} int value`);
+      // match the Bonsai ConstValue wire contract: JS-safe integers only. A restored /
+      // tampered / cross-oracle int outside 2^53-1 (which JSON.parse silently rounds to an
+      // integer) declines MalformedState rather than resuming a corrupted numeric value.
+      if (typeof o.v !== "number" || !Number.isSafeInteger(o.v)) bad(`${where} int value`);
       return { t: "int", v: o.v as number };
     case "str":
       if (typeof o.v !== "string") bad(`${where} str value`);

--- a/src/Core.TypeScript/bonsai/resume.ts
+++ b/src/Core.TypeScript/bonsai/resume.ts
@@ -36,6 +36,8 @@ export type ResumeFeedback =
   | { readonly kind: "Unbound"; readonly name: string }
   | { readonly kind: "TypeMismatch"; readonly where: string; readonly expected: string }
   | { readonly kind: "UnsupportedNode"; readonly nodeKind: string }
+  // an int operation/value left the shared JS-safe-integer wire domain (the Bonsai contract)
+  | { readonly kind: "NonSafeInt"; readonly value: number }
   | { readonly kind: "MalformedState"; readonly message: string };
 
 /**
@@ -87,15 +89,23 @@ function constEq(a: ConstValue, b: ConstValue): boolean {
   return (a as { v: unknown }).v === (b as { v: unknown }).v;
 }
 
+/** Build an `int` ConstValue, declining if the (possibly arithmetic) result left the shared
+ * JS-safe-integer wire domain — so an overflowing add/sub/mul can't become a final value or
+ * activity arg that `serializeState` emits but `parseState` rejects (the Bonsai safe-int contract). */
+function intResult(v: number): ConstValue {
+  if (!Number.isSafeInteger(v)) throw new ResumeFail({ kind: "NonSafeInt", value: v });
+  return { t: "int", v };
+}
+
 /** Apply a binary operator to two evaluated operands (the inline, pure step). */
 function applyBinOp(op: BinOp, left: ConstValue, right: ConstValue): ConstValue {
   switch (op) {
     case "add":
-      return { t: "int", v: asInt(left, "add.left") + asInt(right, "add.right") };
+      return intResult(asInt(left, "add.left") + asInt(right, "add.right"));
     case "sub":
-      return { t: "int", v: asInt(left, "sub.left") - asInt(right, "sub.right") };
+      return intResult(asInt(left, "sub.left") - asInt(right, "sub.right"));
     case "mul":
-      return { t: "int", v: asInt(left, "mul.left") * asInt(right, "mul.right") };
+      return intResult(asInt(left, "mul.left") * asInt(right, "mul.right"));
     case "eq":
       return { t: "bool", v: constEq(left, right) };
     case "lt":
@@ -136,9 +146,10 @@ function run(control: Control, kont: readonly Frame[]): SagaStep {
           ctrl = { mode: "ret", value: e.value };
           break;
         case "param": {
-          const v = env[e.name];
-          if (v === undefined) throw new ResumeFail({ kind: "Unbound", name: e.name });
-          ctrl = { mode: "ret", value: v };
+          // own-property check: a name like "toString"/"constructor" must NOT resolve to an
+          // inherited Object.prototype member — an unbound param declines Unbound, always
+          if (!Object.prototype.hasOwnProperty.call(env, e.name)) throw new ResumeFail({ kind: "Unbound", name: e.name });
+          ctrl = { mode: "ret", value: env[e.name]! };
           break;
         }
         case "binary":
@@ -221,6 +232,10 @@ export function resume(state: SagaState, activityResult: ConstValue): Result<Sag
 function emitConstValue(c: ConstValue): string {
   switch (c.t) {
     case "int":
+      // symmetric with parseState (and Bonsai): never emit an int parseState would reject —
+      // so an unsafe int injected via a resume() activity-result declines rather than producing
+      // un-parseable durable bytes
+      if (!Number.isSafeInteger(c.v)) throw new ResumeFail({ kind: "NonSafeInt", value: c.v });
       return `{"t":"int","v":${c.v}}`;
     case "str":
       return `{"t":"str","v":${JSON.stringify(c.v)}}`;

--- a/src/Core.TypeScript/bonsai/resume.ts
+++ b/src/Core.TypeScript/bonsai/resume.ts
@@ -1,0 +1,373 @@
+/**
+ * resume.ts — TS reference (oracle #1) for the **resume engine** (B-0976 slice), the
+ * self-evolving-saga kernel that the serialized Bonsai expression-tree feeds. Where
+ * `bonsai.ts` is the *serializer* (the deferred computation's shape), this is the *evaluator*
+ * that runs that shape with **restore-not-replay** durable execution.
+ *
+ * The model is a small-step **CEK machine** (Control / Environment / Kontinuation). The
+ * Bonsai-subset `Expr` is the program; **`call` nodes are activities** — the suspension points
+ * (the saga's awaits). Evaluation runs the pure parts inline (`const`/`param`/`binary`/`cond`)
+ * until it needs an activity result, then **suspends**: the machine hands back a fully
+ * **serializable `SagaState`** — the remaining continuation (the `kont` stack) plus the pending
+ * activity call. `resume(state, result)` **restores** that continuation and feeds the activity
+ * result back as the call's value; it does **not** replay from the top, so prior activities are
+ * never re-invoked (the distinguishing property vs Temporal-style replay-with-memoization).
+ *
+ * The continuation IS the closure: a `kont` frame captures exactly the environment + sub-expr
+ * it still needs ("serialize closure + expr-tree" per the slice). The whole `SagaState`
+ * round-trips through `serializeState`/`parseState` so a saga can be persisted at a suspension
+ * and resumed later (or, once the F#/C#/Rust oracles ferry this, on another machine).
+ *
+ * Slice-1 scope: `const`/`param`/`binary`/`cond`/`call` (activity). `lambda` application is
+ * deferred (slice-2) — a `lambda` in evaluation position declines `UnsupportedNode`.
+ */
+
+import type { BinOp, ConstValue, Expr, Result } from "./bonsai";
+import { serialize, parse } from "./bonsai";
+
+/** The resume-state serialization version (the `v` field of the persisted wrapper). */
+export const RESUME_VERSION = 1;
+
+/** An environment: parameter name → bound value (the saga's captured bindings). */
+export type Env = Readonly<Record<string, ConstValue>>;
+
+/** The typed reasons the evaluator declines — the shared cross-oracle payload contract. */
+export type ResumeFeedback =
+  | { readonly kind: "Unbound"; readonly name: string }
+  | { readonly kind: "TypeMismatch"; readonly where: string; readonly expected: string }
+  | { readonly kind: "UnsupportedNode"; readonly nodeKind: string }
+  | { readonly kind: "MalformedState"; readonly message: string };
+
+/**
+ * A defunctionalized continuation frame — one pending operation waiting on a sub-result, with
+ * exactly the environment + expression it still needs (the serialized closure). The `kont`
+ * stack of these IS the suspended computation.
+ */
+export type Frame =
+  // computed the left operand; next evaluate the right (in `env`), then apply `op`
+  | { readonly k: "evalRight"; readonly op: BinOp; readonly right: Expr; readonly env: Env }
+  // computed both operands; apply `op` to (`left`, the returning value)
+  | { readonly k: "applyOp"; readonly op: BinOp; readonly left: ConstValue }
+  // computed the test; pick `then`/`els` (in `env`) by its truthiness
+  | { readonly k: "branch"; readonly then: Expr; readonly els: Expr; readonly env: Env }
+  // evaluating an activity's args left-to-right: `done` are computed, `pending` remain
+  | { readonly k: "evalArgs"; readonly fn: string; readonly pending: readonly Expr[]; readonly done: readonly ConstValue[]; readonly env: Env };
+
+/** The persisted, resumable state of a suspended saga: the continuation + the pending activity. */
+export interface SagaState {
+  /** The continuation (work stack), outermost first; resume restores this. */
+  readonly kont: readonly Frame[];
+  /** The activity the saga is awaiting — its result feeds back as the `call`'s value. */
+  readonly awaiting: { readonly fn: string; readonly args: readonly ConstValue[] };
+}
+
+/** The outcome of a step: either the saga finished, or it suspended awaiting an activity. */
+export type SagaStep =
+  | { readonly kind: "done"; readonly value: ConstValue }
+  | { readonly kind: "suspended"; readonly state: SagaState; readonly activity: { readonly fn: string; readonly args: readonly ConstValue[] } };
+
+const ok = <T>(value: T): Result<T, ResumeFeedback> => ({ ok: true, value });
+const err = (error: ResumeFeedback): Result<never, ResumeFeedback> => ({ ok: false, error });
+
+// ---- pure operators (the saga's inline semantics) -------------------------
+
+function asInt(v: ConstValue, where: string): number {
+  if (v.t !== "int") throw new ResumeFail({ kind: "TypeMismatch", where, expected: "int" });
+  return v.v;
+}
+
+function asBool(v: ConstValue, where: string): boolean {
+  if (v.t !== "bool") throw new ResumeFail({ kind: "TypeMismatch", where, expected: "bool" });
+  return v.v;
+}
+
+function constEq(a: ConstValue, b: ConstValue): boolean {
+  if (a.t !== b.t) return false;
+  if (a.t === "null") return true;
+  return (a as { v: unknown }).v === (b as { v: unknown }).v;
+}
+
+/** Apply a binary operator to two evaluated operands (the inline, pure step). */
+function applyBinOp(op: BinOp, left: ConstValue, right: ConstValue): ConstValue {
+  switch (op) {
+    case "add":
+      return { t: "int", v: asInt(left, "add.left") + asInt(right, "add.right") };
+    case "sub":
+      return { t: "int", v: asInt(left, "sub.left") - asInt(right, "sub.right") };
+    case "mul":
+      return { t: "int", v: asInt(left, "mul.left") * asInt(right, "mul.right") };
+    case "eq":
+      return { t: "bool", v: constEq(left, right) };
+    case "lt":
+      return { t: "bool", v: asInt(left, "lt.left") < asInt(right, "lt.right") };
+    case "and":
+      return { t: "bool", v: asBool(left, "and.left") && asBool(right, "and.right") };
+    case "or":
+      return { t: "bool", v: asBool(left, "or.left") || asBool(right, "or.right") };
+  }
+}
+
+/** Internal typed signal — the inline helpers throw this; the machine catches it at the
+ * boundary and returns `Error` (the wire contract stays `Result`). */
+class ResumeFail extends Error {
+  readonly feedback: ResumeFeedback;
+  constructor(feedback: ResumeFeedback) {
+    super(feedback.kind);
+    this.name = "ResumeFail";
+    this.feedback = feedback;
+  }
+}
+
+// ---- the CEK machine ------------------------------------------------------
+
+type Control = { readonly mode: "eval"; readonly expr: Expr; readonly env: Env } | { readonly mode: "ret"; readonly value: ConstValue };
+
+/** Drive the machine from `control` with continuation `kont` until it finishes or suspends. */
+function run(control: Control, kont: readonly Frame[]): SagaStep {
+  let ctrl = control;
+  let stack: readonly Frame[] = kont;
+
+  for (;;) {
+    if (ctrl.mode === "eval") {
+      const e = ctrl.expr;
+      const env = ctrl.env;
+      switch (e.kind) {
+        case "const":
+          ctrl = { mode: "ret", value: e.value };
+          break;
+        case "param": {
+          const v = env[e.name];
+          if (v === undefined) throw new ResumeFail({ kind: "Unbound", name: e.name });
+          ctrl = { mode: "ret", value: v };
+          break;
+        }
+        case "binary":
+          stack = [...stack, { k: "evalRight", op: e.op, right: e.right, env }];
+          ctrl = { mode: "eval", expr: e.left, env };
+          break;
+        case "cond":
+          stack = [...stack, { k: "branch", then: e.then, els: e.else, env }];
+          ctrl = { mode: "eval", expr: e.test, env };
+          break;
+        case "call":
+          if (e.args.length === 0) {
+            return { kind: "suspended", state: { kont: stack, awaiting: { fn: e.fn, args: [] } }, activity: { fn: e.fn, args: [] } };
+          }
+          stack = [...stack, { k: "evalArgs", fn: e.fn, pending: e.args.slice(1), done: [], env }];
+          ctrl = { mode: "eval", expr: e.args[0]!, env };
+          break;
+        case "lambda":
+          throw new ResumeFail({ kind: "UnsupportedNode", nodeKind: "lambda" });
+      }
+    } else {
+      // returning a value to the continuation
+      if (stack.length === 0) return { kind: "done", value: ctrl.value };
+      const top = stack[stack.length - 1]!;
+      const rest = stack.slice(0, -1);
+      const value = ctrl.value;
+      switch (top.k) {
+        case "evalRight":
+          stack = [...rest, { k: "applyOp", op: top.op, left: value }];
+          ctrl = { mode: "eval", expr: top.right, env: top.env };
+          break;
+        case "applyOp":
+          stack = rest;
+          ctrl = { mode: "ret", value: applyBinOp(top.op, top.left, value) };
+          break;
+        case "branch": {
+          const t = asBool(value, "cond.test");
+          stack = rest;
+          ctrl = { mode: "eval", expr: t ? top.then : top.els, env: top.env };
+          break;
+        }
+        case "evalArgs": {
+          const done = [...top.done, value];
+          if (top.pending.length === 0) {
+            // all args computed → this activity call suspends; `rest` is the continuation
+            return { kind: "suspended", state: { kont: rest, awaiting: { fn: top.fn, args: done } }, activity: { fn: top.fn, args: done } };
+          }
+          stack = [...rest, { k: "evalArgs", fn: top.fn, pending: top.pending.slice(1), done, env: top.env }];
+          ctrl = { mode: "eval", expr: top.pending[0]!, env: top.env };
+          break;
+        }
+      }
+    }
+  }
+}
+
+function trap(thunk: () => SagaStep): Result<SagaStep, ResumeFeedback> {
+  try {
+    return ok(thunk());
+  } catch (ex) {
+    if (ex instanceof ResumeFail) return err(ex.feedback);
+    throw ex;
+  }
+}
+
+/** Start a saga: evaluate `program` (with optional initial `bindings`) until it finishes or
+ * suspends at its first activity. */
+export function start(program: Expr, bindings: Env = {}): Result<SagaStep, ResumeFeedback> {
+  return trap(() => run({ mode: "eval", expr: program, env: bindings }, []));
+}
+
+/** Resume a suspended saga: feed `activityResult` back as the awaited `call`'s value and
+ * continue the restored continuation (no replay — prior activities are not re-invoked). */
+export function resume(state: SagaState, activityResult: ConstValue): Result<SagaStep, ResumeFeedback> {
+  return trap(() => run({ mode: "ret", value: activityResult }, state.kont));
+}
+
+// ---- state serialization (persist a suspension; round-trips) --------------
+
+function emitConstValue(c: ConstValue): string {
+  switch (c.t) {
+    case "int":
+      return `{"t":"int","v":${c.v}}`;
+    case "str":
+      return `{"t":"str","v":${JSON.stringify(c.v)}}`;
+    case "bool":
+      return `{"t":"bool","v":${c.v ? "true" : "false"}}`;
+    case "null":
+      return `{"t":"null"}`;
+  }
+}
+
+function emitEnv(env: Env): string {
+  // canonical: keys sorted, each value in the `{t,v}` shape
+  const keys = Object.keys(env).sort();
+  const parts = keys.map((k) => `${JSON.stringify(k)}:${emitConstValue(env[k]!)}`);
+  return `{${parts.join(",")}}`;
+}
+
+function emitFrame(f: Frame): string {
+  switch (f.k) {
+    case "evalRight": {
+      const r = serialize(f.right);
+      if (!r.ok) throw new ResumeFail({ kind: "MalformedState", message: `evalRight.right: ${r.error.kind}` });
+      return `{"k":"evalRight","op":${JSON.stringify(f.op)},"right":${r.value},"env":${emitEnv(f.env)}}`;
+    }
+    case "applyOp":
+      return `{"k":"applyOp","op":${JSON.stringify(f.op)},"left":${emitConstValue(f.left)}}`;
+    case "branch": {
+      const t = serialize(f.then);
+      const e = serialize(f.els);
+      if (!t.ok) throw new ResumeFail({ kind: "MalformedState", message: `branch.then: ${t.error.kind}` });
+      if (!e.ok) throw new ResumeFail({ kind: "MalformedState", message: `branch.els: ${e.error.kind}` });
+      return `{"k":"branch","then":${t.value},"els":${e.value},"env":${emitEnv(f.env)}}`;
+    }
+    case "evalArgs": {
+      const pend = f.pending.map((p) => {
+        const r = serialize(p);
+        if (!r.ok) throw new ResumeFail({ kind: "MalformedState", message: `evalArgs.pending: ${r.error.kind}` });
+        return r.value;
+      });
+      return `{"k":"evalArgs","fn":${JSON.stringify(f.fn)},"pending":[${pend.join(",")}],"done":[${f.done.map(emitConstValue).join(",")}],"env":${emitEnv(f.env)}}`;
+    }
+  }
+}
+
+/** Serialize a suspended `SagaState` to a canonical string for persistence. */
+export function serializeState(state: SagaState): Result<string, ResumeFeedback> {
+  try {
+    const kont = state.kont.map(emitFrame).join(",");
+    const args = state.awaiting.args.map(emitConstValue).join(",");
+    return ok(`{"v":${RESUME_VERSION},"kont":[${kont}],"awaiting":{"fn":${JSON.stringify(state.awaiting.fn)},"args":[${args}]}}`);
+  } catch (ex) {
+    if (ex instanceof ResumeFail) return err(ex.feedback);
+    throw ex;
+  }
+}
+
+// ---- state parsing (restore a persisted suspension) -----------------------
+
+function bad(message: string): never {
+  throw new ResumeFail({ kind: "MalformedState", message });
+}
+
+function readConstValue(n: unknown, where: string): ConstValue {
+  if (typeof n !== "object" || n === null) bad(`${where} is not an object`);
+  const o = n as Record<string, unknown>;
+  switch (o.t) {
+    case "int":
+      if (typeof o.v !== "number" || !Number.isInteger(o.v)) bad(`${where} int value`);
+      return { t: "int", v: o.v as number };
+    case "str":
+      if (typeof o.v !== "string") bad(`${where} str value`);
+      return { t: "str", v: o.v as string };
+    case "bool":
+      if (typeof o.v !== "boolean") bad(`${where} bool value`);
+      return { t: "bool", v: o.v as boolean };
+    case "null":
+      return { t: "null" };
+    default:
+      bad(`${where} unknown const tag`);
+  }
+}
+
+function readEnv(n: unknown, where: string): Env {
+  if (typeof n !== "object" || n === null || Array.isArray(n)) bad(`${where} is not an object`);
+  const o = n as Record<string, unknown>;
+  const out: Record<string, ConstValue> = {};
+  for (const k of Object.keys(o)) out[k] = readConstValue(o[k], `${where}.${k}`);
+  return out;
+}
+
+function readExpr(n: unknown, where: string): Expr {
+  // a frame's embedded Expr was emitted via bonsai serialize → re-parse via bonsai
+  const r = parse(JSON.stringify(n));
+  if (!r.ok) bad(`${where} expr: ${r.error.kind}`);
+  return r.value;
+}
+
+function readFrame(n: unknown): Frame {
+  if (typeof n !== "object" || n === null) bad("frame is not an object");
+  const o = n as Record<string, unknown>;
+  switch (o.k) {
+    case "evalRight":
+      return { k: "evalRight", op: o.op as BinOp, right: readExpr(o.right, "evalRight.right"), env: readEnv(o.env, "evalRight.env") };
+    case "applyOp":
+      return { k: "applyOp", op: o.op as BinOp, left: readConstValue(o.left, "applyOp.left") };
+    case "branch":
+      return { k: "branch", then: readExpr(o.then, "branch.then"), els: readExpr(o.els, "branch.els"), env: readEnv(o.env, "branch.env") };
+    case "evalArgs": {
+      if (!Array.isArray(o.pending)) bad("evalArgs.pending is not an array");
+      if (!Array.isArray(o.done)) bad("evalArgs.done is not an array");
+      return {
+        k: "evalArgs",
+        fn: typeof o.fn === "string" ? o.fn : bad("evalArgs.fn"),
+        pending: (o.pending as unknown[]).map((p, i) => readExpr(p, `evalArgs.pending[${i}]`)),
+        done: (o.done as unknown[]).map((d, i) => readConstValue(d, `evalArgs.done[${i}]`)),
+        env: readEnv(o.env, "evalArgs.env"),
+      };
+    }
+    default:
+      bad(`unknown frame kind`);
+  }
+}
+
+/** Parse a persisted state string back to a `SagaState` (the inverse of `serializeState`). */
+export function parseState(s: string): Result<SagaState, ResumeFeedback> {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(s);
+  } catch (ex) {
+    return err({ kind: "MalformedState", message: ex instanceof Error ? ex.message : String(ex) });
+  }
+  try {
+    if (typeof doc !== "object" || doc === null) bad("state is not an object");
+    const o = doc as Record<string, unknown>;
+    if (o.v !== RESUME_VERSION) bad(`unsupported state version ${String(o.v)}`);
+    if (!Array.isArray(o.kont)) bad("kont is not an array");
+    const aw = o.awaiting;
+    if (typeof aw !== "object" || aw === null) bad("awaiting is not an object");
+    const awo = aw as Record<string, unknown>;
+    if (typeof awo.fn !== "string") bad("awaiting.fn");
+    if (!Array.isArray(awo.args)) bad("awaiting.args is not an array");
+    return ok({
+      kont: (o.kont as unknown[]).map(readFrame),
+      awaiting: { fn: awo.fn, args: (awo.args as unknown[]).map((a, i) => readConstValue(a, `awaiting.args[${i}]`)) },
+    });
+  } catch (ex) {
+    if (ex instanceof ResumeFail) return err(ex.feedback);
+    throw ex;
+  }
+}


### PR DESCRIPTION
Starts the **resume-engine slice** — the self-evolving-saga kernel the serialized Bonsai expression-tree feeds (the `bonsai.ts` serializer is the *shape*; this is the *evaluator* that runs it durably). TS reference oracle (#1 of TS/F#/C#/Rust); the proven Bonsai pattern — TS authors the golden saga-traces, F#/C#/Rust ferry.

## Model — restore-not-replay (the row's distinguishing property)
A small-step **CEK machine** over the Bonsai-subset `Expr`. **`call` nodes are activities** (the suspension points). Pure parts (`const`/`param`/`binary`/`cond`) evaluate inline; at an activity the machine **suspends**, handing back a fully serializable **`SagaState`** = the remaining continuation (the `kont` stack) + the pending activity. `resume(state, result)` **restores** the continuation and feeds the result back as the call's value — it does **not** replay from the top, so prior activities are never re-invoked (vs Temporal's replay-with-memoization). Each `kont` frame **is the closure** — it captures exactly the env + sub-expr it still needs (the slice's "serialize closure + expr-tree").

## Shape (matches the Bonsai oracle conventions)
- **Result over throw**: `start`/`resume`/`serializeState`/`parseState` return `Result<_, ResumeFeedback>` (`Unbound` / `TypeMismatch` / `UnsupportedNode` / `MalformedState`); internal typed signal adapted at the boundary.
- **State round-trips canonically** — persist at a suspension, restore, resume (the durability property; sets up cross-machine resume once the other oracles ferry).
- Slice-1 scope: `const`/`param`/`binary`/`cond`/`call`. `lambda` application deferred to slice-2 (declines `UnsupportedNode`).

## Tests — 11 (68 bonsai-dir total), tsc clean
`resume-golden.json` has 5 saga-traces (sequential activities · cond-branch-on-activity · activity-with-computed-args · pure-no-suspension · param-binding + activity) — the cross-language behavioral lock (same suspension sequence + final value). Each trace **persists + restores at every suspension** (proves restore-not-replay) + feedback-variant + state round-trip.

Fills the `PRIMITIVE-REGISTRY` **"serializable deferred execution = self-evolving sagas"** line (Event/reactive) — the TS cell. F#/C#/Rust ferry next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)