### PR TITLE
feat(B-0976): resume engine — F# ferry (restore-not-replay CEK saga kernel)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="ToffoliGate.fs" />
     <Compile Include="IndexedZSet.fs" />
     <Compile Include="Bonsai.fs" />
+    <Compile Include="Resume.fs" />
     <Compile Include="Circuit.fs" />
     <Compile Include="PluginApi.fs" />
     <Compile Include="PluginHarness.fs" />

--- a/src/Core/Resume.fs
+++ b/src/Core/Resume.fs
@@ -92,20 +92,34 @@ module Resume =
         | CBool b -> b
         | _ -> raise (ResumeFail(TypeMismatch(where, "bool")))
 
-    /// Build an int ConstValue, declining if the (possibly arithmetic) result left the shared
-    /// JS-safe-integer domain — an overflowing add/sub/mul can't become a value the peer
-    /// oracles' parse would reject (the Bonsai safe-int wire contract).
-    let private intResult (v: int64) : ConstValue =
-        if v > MaxSafeInt || v < MinSafeInt then
-            raise (ResumeFail(NonSafeInt v))
+    /// Build an int ConstValue from a wide (overflow-free) result, declining if it left the
+    /// shared JS-safe-integer domain — an overflowing add/sub/mul can't become a value the peer
+    /// oracles' parse would reject (the Bonsai safe-int wire contract). The arithmetic is done
+    /// in `bigint` FIRST: F# `int64` silently WRAPS on overflow (unlike JS floats, which lose
+    /// precision and are still caught by `Number.isSafeInteger` — so the TS reference is immune),
+    /// meaning a safe-int × safe-int multiply (≤ ~8.1e31) overflows int64 and could wrap to a
+    /// wrong *in-range* value before any bounds check. The bigint never overflows; we range-check
+    /// then narrow. (Add/Sub of two safe-ints can't overflow int64, but routing them through the
+    /// same path keeps the semantics uniform and obviously correct.)
+    let private toSafe (p: bigint) : ConstValue =
+        if p >= bigint MinSafeInt && p <= bigint MaxSafeInt then
+            // within the safe domain ⊂ int64 — narrowing is total
+            CInt(int64 p)
+        else
+            // out of the safe domain; report the exact value when it still fits int64, else a
+            // sign sentinel (the value was never a usable result — NonSafeInt is the signal)
+            let v =
+                if p > bigint System.Int64.MaxValue then System.Int64.MaxValue
+                elif p < bigint System.Int64.MinValue then System.Int64.MinValue
+                else int64 p
 
-        CInt v
+            raise (ResumeFail(NonSafeInt v))
 
     let private applyBinOp (op: BinOp) (left: ConstValue) (right: ConstValue) : ConstValue =
         match op with
-        | Add -> intResult (asInt left "add.left" + asInt right "add.right")
-        | Sub -> intResult (asInt left "sub.left" - asInt right "sub.right")
-        | Mul -> intResult (asInt left "mul.left" * asInt right "mul.right")
+        | Add -> toSafe (bigint (asInt left "add.left") + bigint (asInt right "add.right"))
+        | Sub -> toSafe (bigint (asInt left "sub.left") - bigint (asInt right "sub.right"))
+        | Mul -> toSafe (bigint (asInt left "mul.left") * bigint (asInt right "mul.right"))
         | Eq -> CBool(left = right)
         | Lt -> CBool(asInt left "lt.left" < asInt right "lt.right")
         | And -> CBool(asBool left "and.left" && asBool right "and.right")
@@ -219,7 +233,48 @@ module Resume =
 
     // ---- state serialization (persist a suspension; round-trips) ----------
 
-    let private jstr (s: string) : string = JsonSerializer.Serialize s
+    /// Escape a string to canonical JSON — byte-identical to JS `JSON.stringify` (and to
+    /// `Bonsai`'s embedded-expr escaper), NOT `JsonSerializer.Serialize` (which escapes more
+    /// chars, e.g. astral as `\uXXXX\uXXXX` and `<`/`>`/`&`). State strings (fn names, env keys,
+    /// CStr values) must match the reference so a TS-persisted state restores byte-for-byte on
+    /// F#/C#/Rust — the whole point of the cross-oracle resume ferry.
+    let private jstr (s: string) : string =
+        if isNull s then
+            // a CLR caller can hand us a null fn / param key / CStr — decline cleanly so
+            // serializeState stays total (it catches ResumeFail)
+            raise (ResumeFail(MalformedState "null string field"))
+
+        let sb = System.Text.StringBuilder(s.Length + 2)
+        sb.Append('"') |> ignore
+        let mutable i = 0
+
+        while i < s.Length do
+            let ch = s.[i]
+
+            match ch with
+            | '"' -> sb.Append("\\\"") |> ignore
+            | '\\' -> sb.Append("\\\\") |> ignore
+            | '\b' -> sb.Append("\\b") |> ignore
+            | '\f' -> sb.Append("\\f") |> ignore
+            | '\n' -> sb.Append("\\n") |> ignore
+            | '\r' -> sb.Append("\\r") |> ignore
+            | '\t' -> sb.Append("\\t") |> ignore
+            | c when c < ' ' -> sb.AppendFormat("\\u{0:x4}", int c) |> ignore
+            | c when System.Char.IsHighSurrogate c && i + 1 < s.Length && System.Char.IsLowSurrogate(s.[i + 1]) ->
+                // valid surrogate pair — emit both code units literally (JSON.stringify emits
+                // the astral character, not an escape)
+                sb.Append(c) |> ignore
+                sb.Append(s.[i + 1]) |> ignore
+                i <- i + 1 // also consume the low surrogate
+            | c when System.Char.IsHighSurrogate c || System.Char.IsLowSurrogate c ->
+                // unpaired surrogate — escape it (well-formed JSON.stringify does)
+                sb.AppendFormat("\\u{0:x4}", int c) |> ignore
+            | c -> sb.Append(c) |> ignore
+
+            i <- i + 1
+
+        sb.Append('"') |> ignore
+        sb.ToString()
 
     let private emitConstValue (c: ConstValue) : string =
         match c with
@@ -395,11 +450,18 @@ module Resume =
             EvalArgs(fn, pending, doneArgs, readEnv (prop el "env") "evalArgs.env")
         | _ -> bad "unknown frame kind"
 
+    /// JSON tokenizer depth ceiling for restore. A persisted state embeds Bonsai-serialized
+    /// Exprs INLINE (nested objects, up to `Bonsai.MaxDepth` = 1024 deep) wrapped in a few state
+    /// levels (state → kont → frame → "right"/"then"/… → bonsai doc → "expr" → node…). The
+    /// default `JsonDocument` MaxDepth is 64, which would reject a perfectly valid deep program;
+    /// allow generous headroom above the worst case (embedded-expr depth + state wrapping).
+    let private stateDepthCeiling = Bonsai.MaxDepth * 4
+
     /// Parse a persisted state string back to a `SagaState` (the inverse of `serializeState`).
     let parseState (s: string) : Result<SagaState, ResumeFeedback> =
         let parsed =
             try
-                Ok(JsonDocument.Parse s)
+                Ok(JsonDocument.Parse(s, JsonDocumentOptions(MaxDepth = stateDepthCeiling)))
             with ex ->
                 Error(MalformedState ex.Message)
 

--- a/src/Core/Resume.fs
+++ b/src/Core/Resume.fs
@@ -1,0 +1,442 @@
+namespace Zeta.Core
+
+/// Resume engine — the F# oracle (#2 of TS/F#/C#/Rust) for the **resume-engine slice**
+/// (B-0976), the self-evolving-saga kernel the serialized Bonsai expression-tree feeds. Where
+/// `Bonsai` is the *serializer* (the deferred computation's shape), this is the *evaluator*
+/// that runs it with **restore-not-replay** durable execution. Ferry of the TS reference
+/// (`src/Core.TypeScript/bonsai/resume.ts`); replays the shared `resume-golden.json` saga
+/// traces — same suspension sequence + final value across oracles. "The compilers don't lie."
+///
+/// Model: a small-step **CEK machine** over the Bonsai-subset `Expr`. `Call` nodes are
+/// activities — the suspension points. Pure parts (Const/Param/Binary/Cond) evaluate inline;
+/// at an activity the machine **suspends**, handing back a serializable `SagaState` = the
+/// remaining continuation (the `Kont` list) + the pending activity. `resume state result`
+/// **restores** that continuation and feeds the result back as the call's value — it does NOT
+/// replay from the top, so prior activities are never re-invoked. Each `Kont` frame captures
+/// exactly the environment + sub-expr it still needs (the slice's "serialize closure +
+/// expr-tree"). `serialize`/`parse` of the state round-trip (persist a suspension, restore).
+///
+/// Slice-1 scope: Const/Param/Binary/Cond/Call. `Lambda` application is deferred (slice-2) —
+/// a `Lambda` in evaluation position declines `UnsupportedNode`.
+module Resume =
+
+    open System.Text.Json
+    open Zeta.Core.Bonsai
+
+    /// The resume-state serialization version (the `v` field of the persisted wrapper).
+    [<Literal>]
+    let Version = 1
+
+    // The shared JS-safe-integer bounds (2^53 - 1): the `int` wire domain (matches Bonsai).
+    [<Literal>]
+    let private MaxSafeInt = 9007199254740991L
+
+    [<Literal>]
+    let private MinSafeInt = -9007199254740991L
+
+    /// The typed reasons the evaluator declines — the shared cross-oracle payload contract.
+    type ResumeFeedback =
+        /// A parameter reference had no binding in the environment.
+        | Unbound of name: string
+        /// A value had the wrong type for an operation (the field + expected type).
+        | TypeMismatch of where: string * expected: string
+        /// A node kind unsupported in slice-1 (a `Lambda` in evaluation position).
+        | UnsupportedNode of nodeKind: string
+        /// An int operation/value left the shared JS-safe-integer wire domain.
+        | NonSafeInt of value: int64
+        /// A persisted state string was malformed / could not be restored.
+        | MalformedState of message: string
+
+    /// An environment: parameter name → bound value (the saga's captured bindings).
+    type Env = Map<string, ConstValue>
+
+    /// A defunctionalized continuation frame — one pending operation with exactly the
+    /// environment + expression it still needs (the serialized closure). The `Kont` list of
+    /// these IS the suspended computation (head = top of stack).
+    type Frame =
+        /// Computed the left operand; next evaluate the right (in env), then apply the op.
+        | EvalRight of BinOp * Expr * Env
+        /// Computed both operands; apply the op to (left, the returning value).
+        | ApplyOp of BinOp * ConstValue
+        /// Computed the test; pick then/else (in env) by its truthiness.
+        | Branch of Expr * Expr * Env
+        /// Evaluating an activity's args left-to-right: fn, pending, done, env.
+        | EvalArgs of string * Expr list * ConstValue list * Env
+
+    /// The activity a suspended saga is awaiting — its result feeds back as the call's value.
+    type Activity = { Fn: string; Args: ConstValue list }
+
+    /// The persisted, resumable state of a suspended saga: the continuation + the pending activity.
+    type SagaState = { Kont: Frame list; Awaiting: Activity }
+
+    /// The outcome of a step: either the saga finished, or it suspended awaiting an activity.
+    type SagaStep =
+        /// The saga finished with a value.
+        | Done of ConstValue
+        /// The saga suspended; resume with the activity's result.
+        | Suspended of SagaState * Activity
+
+    /// Private typed signal — internals raise this on a decline; start/resume catch it at the
+    /// boundary and return Error (the wire contract stays Result).
+    exception private ResumeFail of ResumeFeedback
+
+    // ---- pure operators (the saga's inline semantics) ---------------------
+
+    let private asInt (v: ConstValue) (where: string) : int64 =
+        match v with
+        | CInt i -> i
+        | _ -> raise (ResumeFail(TypeMismatch(where, "int")))
+
+    let private asBool (v: ConstValue) (where: string) : bool =
+        match v with
+        | CBool b -> b
+        | _ -> raise (ResumeFail(TypeMismatch(where, "bool")))
+
+    /// Build an int ConstValue, declining if the (possibly arithmetic) result left the shared
+    /// JS-safe-integer domain — an overflowing add/sub/mul can't become a value the peer
+    /// oracles' parse would reject (the Bonsai safe-int wire contract).
+    let private intResult (v: int64) : ConstValue =
+        if v > MaxSafeInt || v < MinSafeInt then
+            raise (ResumeFail(NonSafeInt v))
+
+        CInt v
+
+    let private applyBinOp (op: BinOp) (left: ConstValue) (right: ConstValue) : ConstValue =
+        match op with
+        | Add -> intResult (asInt left "add.left" + asInt right "add.right")
+        | Sub -> intResult (asInt left "sub.left" - asInt right "sub.right")
+        | Mul -> intResult (asInt left "mul.left" * asInt right "mul.right")
+        | Eq -> CBool(left = right)
+        | Lt -> CBool(asInt left "lt.left" < asInt right "lt.right")
+        | And -> CBool(asBool left "and.left" && asBool right "and.right")
+        | Or -> CBool(asBool left "or.left" || asBool right "or.right")
+
+    let private binOpToString (op: BinOp) : string =
+        match op with
+        | Add -> "add"
+        | Sub -> "sub"
+        | Mul -> "mul"
+        | Eq -> "eq"
+        | Lt -> "lt"
+        | And -> "and"
+        | Or -> "or"
+
+    let private binOpOfString (s: string) : BinOp option =
+        match s with
+        | "add" -> Some Add
+        | "sub" -> Some Sub
+        | "mul" -> Some Mul
+        | "eq" -> Some Eq
+        | "lt" -> Some Lt
+        | "and" -> Some And
+        | "or" -> Some Or
+        | _ -> None
+
+    // ---- the CEK machine --------------------------------------------------
+
+    type private Control =
+        | Eval of Expr * Env
+        | Ret of ConstValue
+
+    /// Drive the machine from `control` with continuation `kont` until it finishes or suspends.
+    let private run (control: Control) (kont: Frame list) : SagaStep =
+        let mutable ctrl = control
+        let mutable stack = kont
+        let mutable outcome = Unchecked.defaultof<SagaStep>
+        let mutable running = true
+
+        while running do
+            match ctrl with
+            | Eval(e, env) ->
+                match e with
+                | Const v -> ctrl <- Ret v
+                | Param name ->
+                    // Map.tryFind is an own-key lookup — no inherited-member leakage
+                    match Map.tryFind name env with
+                    | Some v -> ctrl <- Ret v
+                    | None -> raise (ResumeFail(Unbound name))
+                | Binary(op, l, r) ->
+                    stack <- EvalRight(op, r, env) :: stack
+                    ctrl <- Eval(l, env)
+                | Cond(test, thenE, elseE) ->
+                    stack <- Branch(thenE, elseE, env) :: stack
+                    ctrl <- Eval(test, env)
+                | Call(fn, args) ->
+                    match args with
+                    | [] ->
+                        let act = { Fn = fn; Args = [] }
+                        outcome <- Suspended({ Kont = stack; Awaiting = act }, act)
+                        running <- false
+                    | a0 :: rest ->
+                        stack <- EvalArgs(fn, rest, [], env) :: stack
+                        ctrl <- Eval(a0, env)
+                | Lambda _ -> raise (ResumeFail(UnsupportedNode "lambda"))
+            | Ret value ->
+                match stack with
+                | [] ->
+                    outcome <- Done value
+                    running <- false
+                | top :: rest ->
+                    match top with
+                    | EvalRight(op, r, env) ->
+                        stack <- ApplyOp(op, value) :: rest
+                        ctrl <- Eval(r, env)
+                    | ApplyOp(op, left) ->
+                        stack <- rest
+                        ctrl <- Ret(applyBinOp op left value)
+                    | Branch(thenE, elseE, env) ->
+                        let t = asBool value "cond.test"
+                        stack <- rest
+                        ctrl <- Eval((if t then thenE else elseE), env)
+                    | EvalArgs(fn, pending, doneArgs, env) ->
+                        let doneArgs2 = doneArgs @ [ value ]
+
+                        match pending with
+                        | [] ->
+                            let act = { Fn = fn; Args = doneArgs2 }
+                            outcome <- Suspended({ Kont = rest; Awaiting = act }, act)
+                            running <- false
+                        | p0 :: pRest ->
+                            stack <- EvalArgs(fn, pRest, doneArgs2, env) :: rest
+                            ctrl <- Eval(p0, env)
+
+        outcome
+
+    let private trap (thunk: unit -> SagaStep) : Result<SagaStep, ResumeFeedback> =
+        try
+            Ok(thunk ())
+        with ResumeFail f ->
+            Error f
+
+    /// Start a saga: evaluate `program` (with initial `bindings`) until it finishes or suspends.
+    let start (program: Expr) (bindings: Env) : Result<SagaStep, ResumeFeedback> =
+        trap (fun () -> run (Eval(program, bindings)) [])
+
+    /// Resume a suspended saga: feed `activityResult` back as the awaited call's value and
+    /// continue the restored continuation (no replay — prior activities are not re-invoked).
+    let resume (state: SagaState) (activityResult: ConstValue) : Result<SagaStep, ResumeFeedback> =
+        trap (fun () -> run (Ret activityResult) state.Kont)
+
+    // ---- state serialization (persist a suspension; round-trips) ----------
+
+    let private jstr (s: string) : string = JsonSerializer.Serialize s
+
+    let private emitConstValue (c: ConstValue) : string =
+        match c with
+        | CInt v ->
+            // symmetric with parse (and Bonsai): never emit an int parse would reject
+            if v > MaxSafeInt || v < MinSafeInt then
+                raise (ResumeFail(NonSafeInt v))
+
+            sprintf "{\"t\":\"int\",\"v\":%d}" v
+        | CStr s -> sprintf "{\"t\":\"str\",\"v\":%s}" (jstr s)
+        | CBool b -> sprintf "{\"t\":\"bool\",\"v\":%s}" (if b then "true" else "false")
+        | CNull -> "{\"t\":\"null\"}"
+
+    let private emitEnv (env: Env) : string =
+        let parts =
+            env
+            |> Map.toList
+            |> List.sortBy fst
+            |> List.map (fun (k, v) -> sprintf "%s:%s" (jstr k) (emitConstValue v))
+
+        "{" + String.concat "," parts + "}"
+
+    let private okExpr (e: Expr) (where: string) : string =
+        match Bonsai.serialize e with
+        | Ok s -> s
+        | Error f -> raise (ResumeFail(MalformedState(sprintf "%s: %A" where f)))
+
+    let private emitFrame (f: Frame) : string =
+        match f with
+        | EvalRight(op, r, env) ->
+            sprintf
+                "{\"k\":\"evalRight\",\"op\":%s,\"right\":%s,\"env\":%s}"
+                (jstr (binOpToString op))
+                (okExpr r "evalRight.right")
+                (emitEnv env)
+        | ApplyOp(op, left) ->
+            sprintf "{\"k\":\"applyOp\",\"op\":%s,\"left\":%s}" (jstr (binOpToString op)) (emitConstValue left)
+        | Branch(thenE, elseE, env) ->
+            sprintf
+                "{\"k\":\"branch\",\"then\":%s,\"els\":%s,\"env\":%s}"
+                (okExpr thenE "branch.then")
+                (okExpr elseE "branch.els")
+                (emitEnv env)
+        | EvalArgs(fn, pending, doneArgs, env) ->
+            let pend = pending |> List.map (fun p -> okExpr p "evalArgs.pending") |> String.concat ","
+            let dn = doneArgs |> List.map emitConstValue |> String.concat ","
+            sprintf "{\"k\":\"evalArgs\",\"fn\":%s,\"pending\":[%s],\"done\":[%s],\"env\":%s}" (jstr fn) pend dn (emitEnv env)
+
+    /// Serialize a suspended `SagaState` to a canonical string for persistence.
+    let serializeState (state: SagaState) : Result<string, ResumeFeedback> =
+        try
+            let kont = state.Kont |> List.map emitFrame |> String.concat ","
+            let args = state.Awaiting.Args |> List.map emitConstValue |> String.concat ","
+
+            Ok(
+                sprintf
+                    "{\"v\":%d,\"kont\":[%s],\"awaiting\":{\"fn\":%s,\"args\":[%s]}}"
+                    Version
+                    kont
+                    (jstr state.Awaiting.Fn)
+                    args
+            )
+        with ResumeFail f ->
+            Error f
+
+    // ---- state parsing (restore a persisted suspension) -------------------
+
+    let private bad (msg: string) : 'a = raise (ResumeFail(MalformedState msg))
+
+    let private prop (el: JsonElement) (name: string) : JsonElement =
+        match el.TryGetProperty name with
+        | true, v -> v
+        | _ -> bad (sprintf "missing %s" name)
+
+    let private readConstValue (el: JsonElement) (where: string) : ConstValue =
+        if el.ValueKind <> JsonValueKind.Object then
+            bad (where + " is not an object")
+
+        let tag =
+            match el.TryGetProperty "t" with
+            | true, te when te.ValueKind = JsonValueKind.String -> te.GetString()
+            | _ -> null
+
+        match tag with
+        | "int" ->
+            match el.TryGetProperty "v" with
+            | true, v when v.ValueKind = JsonValueKind.Number ->
+                match v.TryGetInt64() with
+                // safe-int only (matches the Bonsai wire contract); a rounded/out-of-range
+                // int from a tampered or cross-oracle state declines rather than restoring corrupt
+                | true, n when n <= MaxSafeInt && n >= MinSafeInt -> CInt n
+                | _ -> bad (where + " int value")
+            | _ -> bad (where + " int value")
+        | "str" ->
+            match el.TryGetProperty "v" with
+            | true, v when v.ValueKind = JsonValueKind.String -> CStr(v.GetString())
+            | _ -> bad (where + " str value")
+        | "bool" ->
+            match el.TryGetProperty "v" with
+            | true, v when v.ValueKind = JsonValueKind.True || v.ValueKind = JsonValueKind.False ->
+                CBool(v.ValueKind = JsonValueKind.True)
+            | _ -> bad (where + " bool value")
+        | "null" -> CNull
+        | _ -> bad (where + " unknown const tag")
+
+    let private readEnv (el: JsonElement) (where: string) : Env =
+        if el.ValueKind <> JsonValueKind.Object then
+            bad (where + " is not an object")
+
+        el.EnumerateObject()
+        |> Seq.map (fun p -> p.Name, readConstValue p.Value (where + "." + p.Name))
+        |> Map.ofSeq
+
+    let private readExpr (el: JsonElement) (where: string) : Expr =
+        match Bonsai.parse (el.GetRawText()) with
+        | Ok e -> e
+        | Error f -> bad (sprintf "%s expr: %A" where f)
+
+    let private readBinOp (el: JsonElement) (where: string) : BinOp =
+        let v =
+            if el.ValueKind = JsonValueKind.String then
+                binOpOfString (el.GetString())
+            else
+                None
+
+        match v with
+        | Some op -> op
+        | None -> bad (where + " unknown operator")
+
+    let private readArray (el: JsonElement) (where: string) : JsonElement list =
+        if el.ValueKind <> JsonValueKind.Array then
+            bad (where + " is not an array")
+
+        [ for x in el.EnumerateArray() -> x ]
+
+    let private readFrame (el: JsonElement) : Frame =
+        if el.ValueKind <> JsonValueKind.Object then
+            bad "frame is not an object"
+
+        let k =
+            match el.TryGetProperty "k" with
+            | true, ke when ke.ValueKind = JsonValueKind.String -> ke.GetString()
+            | _ -> bad "frame.k is missing or not a string"
+
+        match k with
+        | "evalRight" ->
+            EvalRight(
+                readBinOp (prop el "op") "evalRight.op",
+                readExpr (prop el "right") "evalRight.right",
+                readEnv (prop el "env") "evalRight.env"
+            )
+        | "applyOp" -> ApplyOp(readBinOp (prop el "op") "applyOp.op", readConstValue (prop el "left") "applyOp.left")
+        | "branch" ->
+            Branch(
+                readExpr (prop el "then") "branch.then",
+                readExpr (prop el "els") "branch.els",
+                readEnv (prop el "env") "branch.env"
+            )
+        | "evalArgs" ->
+            let fn =
+                match prop el "fn" with
+                | v when v.ValueKind = JsonValueKind.String -> v.GetString()
+                | _ -> bad "evalArgs.fn"
+
+            let pending =
+                readArray (prop el "pending") "evalArgs.pending"
+                |> List.map (fun p -> readExpr p "evalArgs.pending")
+
+            let doneArgs =
+                readArray (prop el "done") "evalArgs.done"
+                |> List.map (fun d -> readConstValue d "evalArgs.done")
+
+            EvalArgs(fn, pending, doneArgs, readEnv (prop el "env") "evalArgs.env")
+        | _ -> bad "unknown frame kind"
+
+    /// Parse a persisted state string back to a `SagaState` (the inverse of `serializeState`).
+    let parseState (s: string) : Result<SagaState, ResumeFeedback> =
+        let parsed =
+            try
+                Ok(JsonDocument.Parse s)
+            with ex ->
+                Error(MalformedState ex.Message)
+
+        match parsed with
+        | Error f -> Error f
+        | Ok doc ->
+            use doc = doc
+
+            try
+                let root = doc.RootElement
+
+                if root.ValueKind <> JsonValueKind.Object then
+                    bad "state is not an object"
+
+                match root.TryGetProperty "v" with
+                | true, v when v.ValueKind = JsonValueKind.Number ->
+                    match v.TryGetInt32() with
+                    | true, n when n = Version -> ()
+                    | _ -> bad "unsupported state version"
+                | _ -> bad "state version is missing or not a number"
+
+                let kont = readArray (prop root "kont") "kont" |> List.map readFrame
+
+                let aw =
+                    match root.TryGetProperty "awaiting" with
+                    | true, a when a.ValueKind = JsonValueKind.Object -> a
+                    | _ -> bad "awaiting is missing or not an object"
+
+                let fn =
+                    match aw.TryGetProperty "fn" with
+                    | true, v when v.ValueKind = JsonValueKind.String -> v.GetString()
+                    | _ -> bad "awaiting.fn"
+
+                let args =
+                    readArray (prop aw "args") "awaiting.args"
+                    |> List.map (fun a -> readConstValue a "awaiting.args")
+
+                Ok { Kont = kont; Awaiting = { Fn = fn; Args = args } }
+            with ResumeFail f ->
+                Error f

--- a/tests/Tests.FSharp/Bonsai/Resume.Tests.fs
+++ b/tests/Tests.FSharp/Bonsai/Resume.Tests.fs
@@ -1,0 +1,214 @@
+module Zeta.Tests.Bonsai.ResumeTests
+
+open System.IO
+open System.Reflection
+open System.Text.Json
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.Bonsai
+open Zeta.Core.Resume
+
+// Resume engine — the F# oracle (#2 of TS/F#/C#/Rust) for the B-0976 resume slice. The TS
+// reference (src/Core.TypeScript/bonsai/resume.ts) authors the shared saga traces
+// (resume-golden.json); this proves the F# impl replays them: same ordered suspension
+// sequence + same final value (the cross-language behavioral lock), and restore-not-replay
+// (persist + re-parse the state at every suspension; prior activities are never re-invoked).
+// "The compilers don't lie."
+
+// Walk up from the test assembly to the repo root (Zeta.sln sentinel).
+let private repoRoot () : string =
+    let mutable dir = DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))
+
+    while not (isNull dir) && not (File.Exists(Path.Join(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+
+    if isNull dir then
+        failwith "Could not locate repo root (Zeta.sln) from test assembly location."
+
+    dir.FullName
+
+// ---- golden JSON -> F# DU converters (the golden stores programs as expr-node objects) ----
+
+let private binOpOfJson (s: string) : BinOp =
+    match s with
+    | "add" -> Add
+    | "sub" -> Sub
+    | "mul" -> Mul
+    | "eq" -> Eq
+    | "lt" -> Lt
+    | "and" -> And
+    | "or" -> Or
+    | other -> failwithf "unknown op %s" other
+
+let rec private exprOfJson (el: JsonElement) : Expr =
+    match el.GetProperty("kind").GetString() with
+    | "const" -> Const(constValueOfJson (el.GetProperty "value"))
+    | "param" -> Param(el.GetProperty("name").GetString())
+    | "lambda" ->
+        Lambda([ for p in el.GetProperty("params").EnumerateArray() -> p.GetString() ], exprOfJson (el.GetProperty "body"))
+    | "binary" ->
+        Binary(
+            binOpOfJson (el.GetProperty("op").GetString()),
+            exprOfJson (el.GetProperty "left"),
+            exprOfJson (el.GetProperty "right")
+        )
+    | "call" -> Call(el.GetProperty("fn").GetString(), [ for a in el.GetProperty("args").EnumerateArray() -> exprOfJson a ])
+    | "cond" ->
+        Cond(exprOfJson (el.GetProperty "test"), exprOfJson (el.GetProperty "then"), exprOfJson (el.GetProperty "else"))
+    | other -> failwithf "unknown kind %s" other
+
+and private constValueOfJson (el: JsonElement) : ConstValue =
+    match el.GetProperty("t").GetString() with
+    | "int" -> CInt(el.GetProperty("v").GetInt64())
+    | "str" -> CStr(el.GetProperty("v").GetString())
+    | "bool" -> CBool(el.GetProperty("v").GetBoolean())
+    | "null" -> CNull
+    | other -> failwithf "unknown const tag %s" other
+
+let private activityOfJson (el: JsonElement) : Activity =
+    { Fn = el.GetProperty("fn").GetString()
+      Args = [ for a in el.GetProperty("args").EnumerateArray() -> constValueOfJson a ] }
+
+// ---- golden loader ----
+
+type private Trace =
+    { Name: string
+      Program: Expr
+      Bindings: Env
+      ActivityResults: ConstValue list
+      ExpectedSuspensions: Activity list
+      ExpectedFinal: ConstValue }
+
+let private goldenTraces () : Trace list =
+    let path = Path.Join(repoRoot (), "src", "Core.TypeScript", "bonsai", "resume-golden.json")
+    use doc = JsonDocument.Parse(File.ReadAllText(path))
+
+    [ for c in doc.RootElement.GetProperty("traces").EnumerateArray() ->
+          let bindings =
+              c.GetProperty("bindings").EnumerateObject()
+              |> Seq.map (fun p -> p.Name, constValueOfJson p.Value)
+              |> Map.ofSeq
+
+          { Name = c.GetProperty("name").GetString()
+            Program = exprOfJson (c.GetProperty "program")
+            Bindings = bindings
+            ActivityResults = [ for a in c.GetProperty("activityResults").EnumerateArray() -> constValueOfJson a ]
+            ExpectedSuspensions = [ for s in c.GetProperty("expectedSuspensions").EnumerateArray() -> activityOfJson s ]
+            ExpectedFinal = constValueOfJson (c.GetProperty "expectedFinal") } ]
+
+let private stepOk (r: Result<SagaStep, ResumeFeedback>) : SagaStep =
+    match r with
+    | Ok s -> s
+    | Error f -> failwithf "expected Ok SagaStep, got Error %A" f
+
+let private stateOk (r: Result<SagaState, ResumeFeedback>) : SagaState =
+    match r with
+    | Ok s -> s
+    | Error f -> failwithf "expected Ok SagaState, got Error %A" f
+
+let private strOk (r: Result<string, ResumeFeedback>) : string =
+    match r with
+    | Ok s -> s
+    | Error f -> failwithf "expected Ok string, got Error %A" f
+
+[<Fact>]
+let ``F# resume replays every shared golden saga-trace (restore-not-replay at each suspension)`` () =
+    let traces = goldenTraces ()
+    Assert.True(traces.Length > 0, "no golden traces loaded")
+
+    for tr in traces do
+        let mutable step = stepOk (start tr.Program tr.Bindings)
+
+        for i in 0 .. tr.ExpectedSuspensions.Length - 1 do
+            match step with
+            | Done v -> failwithf "%s: expected suspension %d, got Done %A" tr.Name i v
+            | Suspended(state, activity) ->
+                Assert.Equal(tr.ExpectedSuspensions.[i], activity)
+                // persist -> re-parse -> resume from the RESTORED state (not a replay)
+                let ser = strOk (serializeState state)
+                let restored = stateOk (parseState ser)
+                // canonical round-trip is byte-stable
+                Assert.Equal(ser, strOk (serializeState restored))
+                step <- stepOk (resume restored tr.ActivityResults.[i])
+
+        match step with
+        | Done v -> Assert.Equal(tr.ExpectedFinal, v)
+        | Suspended(_, a) -> failwithf "%s: expected Done, still suspended on %A" tr.Name a
+
+[<Fact>]
+let ``F# resume: unbound param declines Unbound (incl. names that are not Map keys)`` () =
+    for name in [ "missing"; "toString"; "constructor" ] do
+        match start (Param name) Map.empty with
+        | Error(Unbound _) -> ()
+        | other -> failwithf "expected Error Unbound for %s, got %A" name other
+
+[<Fact>]
+let ``F# resume: type mismatch declines TypeMismatch`` () =
+    match start (Binary(Add, Const(CInt 1L), Const(CBool true))) Map.empty with
+    | Error(TypeMismatch _) -> ()
+    | other -> failwithf "expected Error TypeMismatch, got %A" other
+
+[<Fact>]
+let ``F# resume: lambda in eval position declines UnsupportedNode (slice-1)`` () =
+    match start (Lambda([ "x" ], Const(CInt 1L))) Map.empty with
+    | Error(UnsupportedNode _) -> ()
+    | other -> failwithf "expected Error UnsupportedNode, got %A" other
+
+[<Fact>]
+let ``F# resume: arithmetic past the safe-int range declines NonSafeInt`` () =
+    // 2^53-1 (the shared max safe int) + 1 overflows the wire domain
+    match start (Binary(Add, Const(CInt 9007199254740991L), Const(CInt 1L))) Map.empty with
+    | Error(NonSafeInt _) -> ()
+    | other -> failwithf "expected Error NonSafeInt, got %A" other
+
+[<Fact>]
+let ``F# resume: serializeState/parseState round-trip + restored resume equals original`` () =
+    let program = Binary(Add, Call("x", []), Call("y", []))
+
+    match stepOk (start program Map.empty) with
+    | Done v -> failwithf "expected suspension, got Done %A" v
+    | Suspended(state, _) ->
+        let ser = strOk (serializeState state)
+        let restored = stateOk (parseState ser)
+        let fromOriginal = resume state (CInt 1L)
+        let fromRestored = resume restored (CInt 1L)
+        Assert.Equal(fromOriginal, fromRestored)
+
+[<Fact>]
+let ``F# resume: parseState declines MalformedState on junk + bad version + tampered op + unsafe int`` () =
+    Assert.True(
+        (match parseState "not json" with
+         | Error(MalformedState _) -> true
+         | _ -> false)
+    )
+
+    Assert.True(
+        (match parseState "{\"v\":2,\"kont\":[],\"awaiting\":{\"fn\":\"a\",\"args\":[]}}" with
+         | Error(MalformedState _) -> true
+         | _ -> false)
+    )
+
+    // a real suspension's persisted state with a tampered op / unsafe int must be rejected
+    let program = Binary(Add, Call("a", [ Const(CInt 7L) ]), Call("b", []))
+
+    match stepOk (start program Map.empty) with
+    | Suspended(state, _) ->
+        let ser = strOk (serializeState state)
+        let tamperedOp = ser.Replace("\"op\":\"add\"", "\"op\":\"xor\"")
+        Assert.NotEqual<string>(ser, tamperedOp)
+
+        Assert.True(
+            (match parseState tamperedOp with
+             | Error(MalformedState _) -> true
+             | _ -> false)
+        )
+
+        let tamperedInt = ser.Replace("\"v\":7", "\"v\":9007199254740993")
+        Assert.NotEqual<string>(ser, tamperedInt)
+
+        Assert.True(
+            (match parseState tamperedInt with
+             | Error(MalformedState _) -> true
+             | _ -> false)
+        )
+    | Done v -> failwithf "expected suspension, got Done %A" v

--- a/tests/Tests.FSharp/Bonsai/Resume.Tests.fs
+++ b/tests/Tests.FSharp/Bonsai/Resume.Tests.fs
@@ -175,6 +175,51 @@ let ``F# resume: serializeState/parseState round-trip + restored resume equals o
         Assert.Equal(fromOriginal, fromRestored)
 
 [<Fact>]
+let ``F# resume: multiply that overflows int64 but wraps back into safe range declines NonSafeInt (not silent-wrong)`` () =
+    // 4294967296 (= 2^32) is a valid safe int (≈4.3e9 ≪ 2^53-1); its square is 2^64, which wraps
+    // to *exactly 0* in signed int64. A naive `int64 a * int64 b` then `0 in-range -> CInt 0`
+    // returns a silently-wrong result. The bigint-first path must catch the true product as
+    // out-of-safe-range. (TS is immune: JS floats lose precision but Number.isSafeInteger catches it.)
+    match start (Binary(Mul, Const(CInt 4294967296L), Const(CInt 4294967296L))) Map.empty with
+    | Error(NonSafeInt _) -> ()
+    | Ok(Done v) -> failwithf "int64-wrap silent-wrong leak: expected NonSafeInt, got Done %A" v
+    | other -> failwithf "expected Error NonSafeInt, got %A" other
+
+[<Fact>]
+let ``F# resume: a deep-but-valid embedded program restores (parseState depth ceiling > default 64)`` () =
+    // The persisted state embeds the Bonsai-serialized right operand INLINE; a default
+    // JsonDocument MaxDepth (64) would reject a valid program nested deeper than that.
+    let rec deepNest n =
+        if n <= 0 then Const(CInt 0L) else Binary(Add, Const(CInt 1L), deepNest (n - 1))
+
+    // left is a no-arg Call -> suspends immediately, leaving the deep right operand in the
+    // EvalRight frame (≈200 JSON levels once serialized — well past 64, well under MaxDepth=1024).
+    let program = Binary(Add, Call("a", []), deepNest 100)
+
+    match stepOk (start program Map.empty) with
+    | Done v -> failwithf "expected suspension, got Done %A" v
+    | Suspended(state, _) ->
+        let ser = strOk (serializeState state)
+        let restored = stateOk (parseState ser) // would be MalformedState under the default depth
+        Assert.Equal(ser, strOk (serializeState restored)) // round-trip is byte-stable
+
+[<Fact>]
+let ``F# resume: state strings escape like JSON.stringify (literal '<', not JsonSerializer's <)`` () =
+    // Cross-machine durability: F#/C#/Rust state bytes must match the TS reference. JsonSerializer
+    // escapes '<' as < (and astral as surrogate \u escapes); JSON.stringify emits '<' literally.
+    let program = Call("act", [ Const(CStr "x<y\"z\n") ])
+
+    match stepOk (start program Map.empty) with
+    | Suspended(state, _) ->
+        let ser = strOk (serializeState state)
+        Assert.Contains("<", ser) // literal '<' — JsonSerializer would have written <
+        Assert.DoesNotContain("\\u003", ser) // no < / > style escaping of '<'
+        Assert.Contains("\\n", ser) // newline as the canonical short escape
+        let restored = stateOk (parseState ser)
+        Assert.Equal(ser, strOk (serializeState restored)) // round-trips byte-stable
+    | Done v -> failwithf "expected suspension, got Done %A" v
+
+[<Fact>]
 let ``F# resume: parseState declines MalformedState on junk + bad version + tampered op + unsafe int`` () =
     Assert.True(
         (match parseState "not json" with

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -36,6 +36,7 @@
     <Compile Include="TriBoolean/TriBoolean.Tests.fs" />
     <Compile Include="TriBoolean/Float.Tests.fs" />
     <Compile Include="Bonsai/Bonsai.Tests.fs" />
+    <Compile Include="Bonsai/Resume.Tests.fs" />
     <Compile Include="Observe/GoldenVectors.Tests.fs" />
     <Compile Include="Observe/EventLog.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />


### PR DESCRIPTION
F# oracle (#2 of TS/F#/C#/Rust) for the resume-engine slice — ferry of the TS reference (#6446). `src/Core/Resume.fs` is a small-step **CEK machine** over the Bonsai-subset `Expr`: `Call` = activity suspension point; the serializable `SagaState` = continuation + pending activity; `resume` **restores** the continuation (prior activities never re-invoked). Replays the shared `resume-golden.json` — same suspension sequence + final value, restore-not-replay at each suspension.

Carries the #6446 review hardening by construction: `Map.tryFind` own-key param lookup (no prototype leak), safe-int guard on arithmetic + restore, op validated on restore. **7 tests** (golden-trace replay across all 5 traces + Unbound / TypeMismatch / UnsupportedNode / NonSafeInt / round-trip / MalformedState), Core builds 0 warnings.

⚠️ **Stacked on #6446** (which adds `resume-golden.json` + the TS reference). The diff shows #6446's commits until it merges; **not armed** so the TS work can't merge under this PR — I'll rebase clean off `main` + arm once #6446 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)