### PR TITLE
feat(codec): hexagonal value-codec port + Bonsai adapter (F#)

### DIFF
--- a/src/Core/Bonsai.fs
+++ b/src/Core/Bonsai.fs
@@ -547,3 +547,14 @@ module Bonsai =
                         | true, v -> Error [ { Path = "$.v"; Feedback = UnsupportedVersion(v, Version) } ]
                         | false, _ -> Error [ { Path = "$.v"; Feedback = MalformedJson "document v is not an int32" } ]
                     | _ -> Error [ { Path = "$.v"; Feedback = MalformedJson "document v is missing or not a number" } ]
+
+    /// The Bonsai canonical-JSON serializer exposed as a value codec (the hexagonal port) —
+    /// callers can depend on `Codec.ICodec<Expr, string, BonsaiFeedback>` rather than the
+    /// concrete serialize/parse, so the canonical-JSON mechanism is swappable behind the port.
+    /// The byte-exact canonical contract + the accumulate-mode (parseAll/ProblemDetails) remain
+    /// Bonsai-specific extensions on top of the port's serialize/deserialize.
+    let codec: Codec.ICodec<Expr, string, BonsaiFeedback> =
+        { new Codec.ICodec<Expr, string, BonsaiFeedback> with
+            member _.Serialize(value) = serialize value
+            member _.Deserialize(wire) = parse wire
+            member _.Name = "bonsai/canonical-json-v1" }

--- a/src/Core/Codec.fs
+++ b/src/Core/Codec.fs
@@ -1,0 +1,24 @@
+namespace Zeta.Core
+
+/// A **value codec** port — own-our-interface (hexagonal) for serializing a single value `'T`
+/// to/from a wire representation `'Wire`, Result over throw (`'Feedback` is the typed decline
+/// channel). Per the BCL-interface-boundary rule: callers depend on this port, the concrete
+/// format is a swappable adapter behind it.
+///
+/// Distinct from the Z-set `ISerializer<'T>` in `Serializer.fs` (which is `ZSet<'T> -> bytes`,
+/// the incremental-view wire codec) — that one is shape-locked to a Z-set over a byte buffer.
+/// This is the **arbitrary-value** seam: the serializer roster plugs in here. The Bonsai
+/// canonical-JSON serializer (`Expr -> string`) is the first adapter; a binary Bonsai or other
+/// value formats can follow without changing callers. (If a bridge between this port and the
+/// Z-set `ISerializer` is ever needed, that's a separate adapter written on demand.)
+module Codec =
+
+    /// A value codec: encode `'T` to its `'Wire` form and decode it back, both Result-typed
+    /// over the codec's `'Feedback` channel (no exception crosses the boundary).
+    type ICodec<'T, 'Wire, 'Feedback> =
+        /// Encode a value to its wire form.
+        abstract member Serialize: value: 'T -> Result<'Wire, 'Feedback>
+        /// Decode a value from its wire form.
+        abstract member Deserialize: wire: 'Wire -> Result<'T, 'Feedback>
+        /// A stable identifier for this codec (e.g. "bonsai/canonical-json-v1").
+        abstract member Name: string

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="ZSet.fs" />
     <Compile Include="ToffoliGate.fs" />
     <Compile Include="IndexedZSet.fs" />
+    <Compile Include="Codec.fs" />
     <Compile Include="Bonsai.fs" />
     <Compile Include="Circuit.fs" />
     <Compile Include="PluginApi.fs" />

--- a/tests/Tests.FSharp/Bonsai/Bonsai.Tests.fs
+++ b/tests/Tests.FSharp/Bonsai/Bonsai.Tests.fs
@@ -367,3 +367,26 @@ let ``parseAll declines NonCanonical (single) for structurally-valid but non-can
             | Bonsai.NonCanonical -> true
             | _ -> false
         )
+
+// ---- hexagonal value-codec port (Codec.ICodec adapter) ----
+
+[<Fact>]
+let ``Bonsai.codec is the value-codec port: round-trips every golden + agrees with serialize/parse`` () =
+    let codec = Bonsai.codec
+    Assert.Equal("bonsai/canonical-json-v1", codec.Name)
+    let cases = goldenCanonicals ()
+    Assert.True(cases.Length > 0, "no golden cases loaded")
+
+    for (name, canonical) in cases do
+        // the codec round-trips byte-exact through the port
+        let node = codec.Deserialize canonical |> ok
+        Assert.Equal(canonical, codec.Serialize node |> ok)
+        // and the port agrees with the concrete serialize/parse it adapts
+        Assert.Equal<Bonsai.Expr>((Bonsai.parse canonical |> ok), node)
+        Assert.Equal((Bonsai.serialize node), (codec.Serialize node))
+        ignore name
+
+[<Fact>]
+let ``Bonsai.codec surfaces the typed feedback channel (no exception crosses the port)`` () =
+    let codec = Bonsai.codec
+    Assert.True(codec.Deserialize "not json" |> isErr (fun _ -> true))


### PR DESCRIPTION
Makes Bonsai serialization hexagonal via a **parallel value-serializer port** (per Aaron: agreed not to overload the Z-set `ISerializer`; a bridge between the two is a later on-demand adapter).

- **`src/Core/Codec.fs` (`module Codec`)**: `ICodec<'T,'Wire,'Feedback>` — own-our-interface value codec (`Serialize`/`Deserialize` Result-typed + `Name`). Distinct from the Z-set `ISerializer<'T>` (`ZSet<'T> -> bytes`); this is the **arbitrary-value seam** the serializer roster plugs into as swappable adapters.
- **`Bonsai.codec : Codec.ICodec<Expr, string, BonsaiFeedback>`**: the canonical-JSON adapter (`Name = "bonsai/canonical-json-v1"`). Callers depend on the port; the JSON mechanism is swappable behind it. The byte-exact canonical contract + accumulate-mode (ProblemDetails) stay Bonsai-specific extensions on top.

The *dependency* side was already hexagonal (we own `serialize`/`parse`; backend is BCL `System.Text.Json` / hand-rolled readers; no vendor serializer interface in the core). This adds the **port** so Bonsai composes with the roster.

**+2 tests** (codec round-trips every golden byte-exact + agrees with concrete serialize/parse + Name + typed feedback on bad input); 32 Bonsai tests, Core 0 warnings. F#-first — TS/C#/Rust `ICodec` ports + Bonsai adapters ferry next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)