### PR TITLE
backlog(B-0980): close — ace registry publish core shipped (slice 6.1)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1093,7 +1093,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0977](backlog/P3/B-0977-ace-registry-mirror-failover-multiple-urls-per-registry-deferred-from-slice6-2026-06-01.md)** Ace registry mirror/failover — multiple URLs per registry (deferred from slice 6)
 - [ ] **[B-0978](backlog/P3/B-0978-ace-registry-incremental-paginated-index-deferred-from-slice6-2026-06-01.md)** Ace registry incremental/paginated index — delta updates + range requests (deferred from slice 6)
 - [ ] **[B-0979](backlog/P3/B-0979-ace-registry-full-tuf-role-separation-deferred-from-slice6-2026-06-01.md)** Ace registry full TUF role separation — root/targets/snapshot/timestamp (deferred from slice 6)
-- [ ] **[B-0980](backlog/P3/B-0980-ace-registry-publish-index-generation-tooling-deferred-from-slice6-2026-06-01.md)** Ace `ace registry publish` — index-generation + signing tooling (deferred from slice 6)
+- [x] **[B-0980](backlog/P3/B-0980-ace-registry-publish-index-generation-tooling-deferred-from-slice6-2026-06-01.md)** Ace `ace registry publish` — index-generation + signing tooling (deferred from slice 6)
 - [ ] **[B-0981](backlog/P3/B-0981-ace-registry-key-rotation-multi-signer-thresholds-deferred-from-slice6-2026-06-01.md)** Ace registry per-registry key rotation + multi-signer thresholds (deferred from slice 6)
 
 <!-- END AUTO-GENERATED -->

--- a/docs/backlog/P3/B-0980-ace-registry-publish-index-generation-tooling-deferred-from-slice6-2026-06-01.md
+++ b/docs/backlog/P3/B-0980-ace-registry-publish-index-generation-tooling-deferred-from-slice6-2026-06-01.md
@@ -1,7 +1,7 @@
 ---
 id: B-0980
 priority: P3
-status: open
+status: closed
 title: Ace `ace registry publish` — index-generation + signing tooling (deferred from slice 6)
 effort: M
 ask: operator 2026-06-01
@@ -42,6 +42,44 @@ The consumer side is what slice 6 needed to resolve against a hosted catalog; an
 be hand-assembled + signed with the test helper for now. First-class publish tooling is
 ergonomics for registry operators, not a consumer capability gap. Operator: *"everything
 we skipped lets slice off for further enhancements."*
+
+## Resolution (2026-06-01 — slice 6.1 core shipped via PR #6439, merge `2d662dbb`)
+
+Core `ace registry publish` shipped. Spec: `docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice6.1-registry-publish-design.md` (spec PR #6434).
+
+**Shipped:**
+
+- `ace registry publish --packages <dir> --base-url <url> --key <pem> [--out index.json]` —
+  scans `<dir>` for `*.json` packages, derives each `url = <base-url>/<name>-<version>.json`
+  + `package_hash = packageHash(pkg)`, assembles + Ed25519-signs the index, sets `issued_at`,
+  auto-bumps `sequence` from an existing `--out` (read as prev), and **round-trip self-verifies**
+  (consumer `parseIndex` + `verifyIndexSignature` under the signing key's own public key)
+  before writing — never writes a non-self-verifying index.
+- **Publish-side anti-rollback:** refuses to auto-bump from an existing `--out` whose
+  signature does not verify under `--key`, and refuses an unparseable `--out` (no silent
+  sequence reset that would look like a rollback to consumers).
+- **Input-validation hardening** (skip+warn any package that would fail on a consumer, so a
+  self-verified index can't point at an un-installable package): non-Ed25519 `--key` refused;
+  `content_hash` required + must match `files`; basename must equal `<name>-<version>.json`;
+  reserved prototype-key identities (`__proto__`/`constructor`/`prototype`) rejected;
+  URL-unsafe name/version characters rejected; `dependencies` must be a well-formed array of
+  valid `AceDependency` edges; every `files` value must be a string; unsafe file paths
+  (`../`/absolute) rejected by reusing the consumer's `validatePackagePaths`.
+- **Deterministic output:** packages sorted by `(name, version)` so re-publishing yields a
+  byte-stable `index.json`.
+- Surfaces: `tools/ace/registry-publish.ts` (pure module) + `ace.ts` `registry publish`
+  handler + `signing.ts` `publicKeyInfoFromPrivatePem` + `.claude/skills/ace/SKILL.md`
+  publish section + unit + e2e tests.
+
+**Deferred (future enhancement candidates — not blocking; core is complete):**
+
+- Per-package `url` override (the "maybe 2" URL model — operator chose base-url-only for now).
+- ETag / Last-Modified sidecar emission for static hosting.
+- Multi-directory / `--packages` list input (currently one dir).
+- Explicit `--sequence` override flag (currently auto-bump only; the dead anti-rollback
+  guard already in the handler covers the future flag).
+- Incremental index → B-0978; full TUF role separation → B-0979; key rotation / multi-signer
+  → B-0981 (already rowed).
 
 ## Composes with
 


### PR DESCRIPTION
Post-merge bookkeeping for slice 6.1 (`ace registry publish`), shipped via #6439 (merge `2d662dbb`).

Closes **B-0980**: marks the core `ace registry publish` command shipped + records what's deferred (per-package url override, ETag sidecar, multi-dir, explicit `--sequence`; incremental/TUF/key-rotation already rowed as B-0978/B-0979/B-0981).

Regenerated `docs/BACKLOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)