### PR TITLE
feat(range-set): RangeSet TS reference (oracle #1) — sparse-int-set in compact range notation

### DIFF
--- a/src/Core.TypeScript/range-set/golden-vectors.json
+++ b/src/Core.TypeScript/range-set/golden-vectors.json
@@ -1,0 +1,26 @@
+{
+  "description": "RangeSet cross-language conformance. The TS reference oracle authors these vectors; F#/C#/Rust replay them. For each case: parse(input) -> Ok, render(parsed) == canonical (the cross-language byte lock), and contains(parsed, n) matches each [n, expected] probe. For each rejection: parse(input) -> Err with the named feedback variant (the cross-language rejection-vector contract). Non-negative JS-safe integers; canonical = sorted, disjoint, non-adjacent (overlapping AND touching ranges coalesce), single values as `n`, joined by `,` with no spaces, empty set as ``.",
+  "version": 1,
+  "cases": [
+    { "name": "empty", "input": "", "canonical": "", "contains": [[0, false], [1, false]] },
+    { "name": "single", "input": "8", "canonical": "8", "contains": [[7, false], [8, true], [9, false]] },
+    { "name": "simple_range", "input": "1-5", "canonical": "1-5", "contains": [[0, false], [1, true], [3, true], [5, true], [6, false]] },
+    { "name": "mixed", "input": "1-5,8,10-17", "canonical": "1-5,8,10-17", "contains": [[5, true], [6, false], [8, true], [9, false], [10, true], [17, true], [18, false]] },
+    { "name": "unsorted_normalizes", "input": "8,10-17,1-5", "canonical": "1-5,8,10-17", "contains": [[8, true], [12, true]] },
+    { "name": "overlap_merges", "input": "1-3,2-5", "canonical": "1-5", "contains": [[4, true], [5, true], [6, false]] },
+    { "name": "adjacent_ranges_merge", "input": "1-3,4-6", "canonical": "1-6", "contains": [[3, true], [4, true], [7, false]] },
+    { "name": "adjacent_singles_merge", "input": "1,2,3", "canonical": "1-3", "contains": [[1, true], [2, true], [3, true], [4, false]] },
+    { "name": "duplicate_collapses", "input": "5,5,5", "canonical": "5", "contains": [[5, true]] },
+    { "name": "single_then_overlapping_range", "input": "10-17,3,1-5", "canonical": "1-5,10-17", "contains": [[3, true], [6, false], [10, true]] },
+    { "name": "zero_boundary", "input": "0-2", "canonical": "0-2", "contains": [[0, true], [2, true], [3, false]] }
+  ],
+  "rejections": [
+    { "name": "not_integer", "input": "a-b", "feedback": "NotInteger" },
+    { "name": "not_integer_single", "input": "x", "feedback": "NotInteger" },
+    { "name": "inverted_range", "input": "5-1", "feedback": "InvertedRange" },
+    { "name": "empty_token", "input": "1,,3", "feedback": "Malformed" },
+    { "name": "trailing_comma", "input": "1-5,", "feedback": "Malformed" },
+    { "name": "too_many_dashes", "input": "1-2-3", "feedback": "Malformed" },
+    { "name": "negative_unsupported", "input": "-3", "feedback": "Malformed" }
+  ]
+}

--- a/src/Core.TypeScript/range-set/index.ts
+++ b/src/Core.TypeScript/range-set/index.ts
@@ -1,0 +1,2 @@
+/** RangeSet — compact sparse-integer-set primitive (the TS reference oracle). */
+export * from "./range-set";

--- a/src/Core.TypeScript/range-set/range-set.test.ts
+++ b/src/Core.TypeScript/range-set/range-set.test.ts
@@ -1,0 +1,93 @@
+/**
+ * range-set.test.ts — TS reference (oracle #1) for RangeSet. Two duties:
+ *   1. The shared golden vectors replay: parse(input) -> Ok, render == canonical (the
+ *      cross-language byte lock the F#/C#/Rust twins also cast), and contains agrees; the
+ *      rejection vectors decline the SPECIFIC feedback variant (rejection-vector contract).
+ *   2. Structural laws: render(parse(canonical)) is a fixed point; union/add re-normalize;
+ *      contains/size are consistent.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { add, contains, parse, type RangeSet, render, size, union } from "./range-set";
+
+interface GoldenCase {
+  readonly name: string;
+  readonly input: string;
+  readonly canonical: string;
+  readonly contains: ReadonlyArray<readonly [number, boolean]>;
+}
+
+interface GoldenRejection {
+  readonly name: string;
+  readonly input: string;
+  readonly feedback: string;
+}
+
+interface Golden {
+  readonly cases: readonly GoldenCase[];
+  readonly rejections: readonly GoldenRejection[];
+}
+
+const golden: Golden = JSON.parse(readFileSync(join(import.meta.dir, "golden-vectors.json"), "utf8")) as Golden;
+
+function parseOk(input: string): RangeSet {
+  const r = parse(input);
+  if (!r.ok) throw new Error(`expected Ok for ${JSON.stringify(input)}, got ${r.error.kind}`);
+  return r.value;
+}
+
+describe("RangeSet — shared golden vectors", () => {
+  it("has cases + rejections", () => {
+    expect(golden.cases.length).toBeGreaterThan(0);
+    expect(golden.rejections.length).toBeGreaterThan(0);
+  });
+
+  for (const c of golden.cases) {
+    it(`case ${c.name}: render(parse(input)) == canonical + contains agrees`, () => {
+      const rs = parseOk(c.input);
+      expect(render(rs)).toBe(c.canonical);
+      // the canonical form is a fixed point of parse->render
+      expect(render(parseOk(c.canonical))).toBe(c.canonical);
+      for (const [n, expected] of c.contains) {
+        expect(contains(rs, n)).toBe(expected);
+      }
+    });
+  }
+
+  for (const r of golden.rejections) {
+    it(`rejection ${r.name}: parse declines ${r.feedback}`, () => {
+      const res = parse(r.input);
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error.kind as string).toBe(r.feedback);
+    });
+  }
+});
+
+describe("RangeSet — structural laws", () => {
+  it("union re-normalizes (coalesces across the two sets)", () => {
+    expect(render(union(parseOk("1-3"), parseOk("4-6")))).toBe("1-6");
+    expect(render(union(parseOk("1-5,10-12"), parseOk("6,13-14")))).toBe("1-6,10-14");
+    expect(render(union(parseOk(""), parseOk("8")))).toBe("8");
+  });
+
+  it("add inserts + coalesces", () => {
+    expect(render(add(parseOk("1-3,5-7"), 4))).toBe("1-7");
+    expect(render(add(parseOk("1-3"), 10))).toBe("1-3,10");
+    expect(render(add(parseOk("1-3"), 2))).toBe("1-3"); // already present
+  });
+
+  it("size counts covered integers", () => {
+    expect(size(parseOk(""))).toBe(0);
+    expect(size(parseOk("1-5,8,10-17"))).toBe(5 + 1 + 8);
+  });
+
+  it("contains is consistent with size for a dense range", () => {
+    const rs = parseOk("3-9");
+    let counted = 0;
+    for (let n = 0; n <= 12; n++) if (contains(rs, n)) counted++;
+    expect(counted).toBe(size(rs));
+  });
+});

--- a/src/Core.TypeScript/range-set/range-set.ts
+++ b/src/Core.TypeScript/range-set/range-set.ts
@@ -1,0 +1,124 @@
+/**
+ * range-set.ts — TS reference (oracle #1) for **RangeSet**: a sparse integer set in
+ * compact range notation (`"1-5,8,10-17"`). The TS oracle authors the shared golden vectors
+ * (`golden-vectors.json`); F#/C#/Rust ferry and replay them byte-for-byte: `render(parse(input))`
+ * equals the **canonical** form, and `contains` agrees. "The compilers don't lie."
+ *
+ * Canonical form (the cross-oracle byte-diff contract): ranges **sorted**, **disjoint**, and
+ * **non-adjacent** (auto-merged: overlapping AND touching ranges coalesce, `1-3,4-6 → 1-6`),
+ * each emitted as `n` when start==end else `start-end`, joined by `,` with no spaces; the empty
+ * set renders `""`. Non-negative JS-safe integers only.
+ *
+ * Result over throw: `parse` returns `Result<RangeSet, RangeSetFeedback>` (the rejection-vector
+ * contract — a malformed token declines the SPECIFIC variant, matching across oracles).
+ */
+
+/** A success/failure result — the value channel AND the feedback channel both first-class. */
+export type Result<T, E> = { readonly ok: true; readonly value: T } | { readonly ok: false; readonly error: E };
+
+/** An inclusive integer range `[start, end]` with `start <= end`. */
+export type Range = readonly [number, number];
+
+/** A normalized set of ranges: sorted, disjoint, non-adjacent (the canonical invariant). */
+export type RangeSet = readonly Range[];
+
+/** The typed reasons `parse` declines — the shared cross-oracle rejection-vector contract. */
+export type RangeSetFeedback =
+  // a token (or sub-token) was not a non-negative safe integer
+  | { readonly kind: "NotInteger"; readonly token: string }
+  // a range `lo-hi` had `lo > hi`
+  | { readonly kind: "InvertedRange"; readonly lo: number; readonly hi: number }
+  // a structurally bad token (empty between commas, trailing comma, too many dashes)
+  | { readonly kind: "Malformed"; readonly token: string };
+
+const ok = <T>(value: T): Result<T, never> => ({ ok: true, value });
+const err = (error: RangeSetFeedback): Result<never, RangeSetFeedback> => ({ ok: false, error });
+
+const MAX_SAFE = 9007199254740991; // 2^53 - 1 — the shared safe-int ceiling (matches the other primitives)
+
+/** Parse a non-negative integer token strictly: digits only, within the safe-int range. */
+function parseNat(token: string): number | null {
+  if (!/^[0-9]+$/.test(token)) return null;
+  const n = Number(token);
+  return Number.isSafeInteger(n) && n <= MAX_SAFE ? n : null;
+}
+
+/** Normalize raw ranges into the canonical invariant: sort, then coalesce overlapping/adjacent. */
+function normalize(ranges: ReadonlyArray<Range>): RangeSet {
+  if (ranges.length === 0) return [];
+  const sorted = [...ranges].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const merged: Array<[number, number]> = [];
+  for (const [lo, hi] of sorted) {
+    const last = merged[merged.length - 1];
+    // coalesce when the next range overlaps OR touches the previous (lo <= last.hi + 1)
+    if (last && lo <= last[1] + 1) {
+      last[1] = Math.max(last[1], hi);
+    } else {
+      merged.push([lo, hi]);
+    }
+  }
+  return merged;
+}
+
+/** Parse compact range notation into a canonical {@link RangeSet}. Empty string → empty set. */
+export function parse(s: string): Result<RangeSet, RangeSetFeedback> {
+  const trimmed = s.trim();
+  if (trimmed === "") return ok([]);
+
+  const ranges: Array<Range> = [];
+  for (const raw of trimmed.split(",")) {
+    const token = raw.trim();
+    if (token === "") return err({ kind: "Malformed", token: raw });
+
+    const parts = token.split("-");
+    if (parts.length === 1) {
+      const n = parseNat(parts[0]!);
+      if (n === null) return err({ kind: "NotInteger", token });
+      ranges.push([n, n]);
+    } else if (parts.length === 2) {
+      // an empty sub-token ("-3", "5-") is structurally missing, not a bad number
+      if (parts[0] === "" || parts[1] === "") return err({ kind: "Malformed", token });
+      const lo = parseNat(parts[0]!);
+      const hi = parseNat(parts[1]!);
+      if (lo === null) return err({ kind: "NotInteger", token: parts[0]! });
+      if (hi === null) return err({ kind: "NotInteger", token: parts[1]! });
+      if (lo > hi) return err({ kind: "InvertedRange", lo, hi });
+      ranges.push([lo, hi]);
+    } else {
+      // more than one dash (e.g. "1-2-3") — structurally malformed
+      return err({ kind: "Malformed", token });
+    }
+  }
+  return ok(normalize(ranges));
+}
+
+/** Render a {@link RangeSet} to its canonical compact string. */
+export function render(rs: RangeSet): string {
+  return rs.map(([lo, hi]) => (lo === hi ? `${lo}` : `${lo}-${hi}`)).join(",");
+}
+
+/** Whether `n` is a member of the set (ranges are sorted, so the scan early-exits). */
+export function contains(rs: RangeSet, n: number): boolean {
+  for (const [lo, hi] of rs) {
+    if (n < lo) return false;
+    if (n <= hi) return true;
+  }
+  return false;
+}
+
+/** The union of two range sets, re-normalized to canonical form. */
+export function union(a: RangeSet, b: RangeSet): RangeSet {
+  return normalize([...a, ...b]);
+}
+
+/** Add a single integer to the set (returns a new canonical set). */
+export function add(rs: RangeSet, n: number): RangeSet {
+  return normalize([...rs, [n, n]]);
+}
+
+/** The total count of integers covered by the set. */
+export function size(rs: RangeSet): number {
+  let total = 0;
+  for (const [lo, hi] of rs) total += hi - lo + 1;
+  return total;
+}


### PR DESCRIPTION
## What

New cross-language primitive from the registry wish list (Codec/IO line — `RangeSet`, ⬜): a **sparse integer set** in compact range notation (`"1-5,8,10-17"`). TS reference (oracle #1); F#/C#/Rust ferry next, per the standard TS-authors-the-golden pattern (matching bag/z-set/zeta-id).

- `parse(s) → Result<RangeSet, RangeSetFeedback>` — lenient input (unsorted/overlapping tokens accepted + normalized), strict **rejection-vector contract** (`NotInteger` / `InvertedRange` / `Malformed`). Non-negative JS-safe integers.
- `render(rs)` — **canonical** form: sorted, disjoint, **non-adjacent** (overlapping AND touching ranges coalesce: `1-3,4-6 → 1-6`), single values as `n`, joined by `,`, empty set as `""`.
- `contains` / `union` / `add` / `size`, all preserving the canonical invariant.

## Golden

`golden-vectors.json`: **11 cases** (`render(parse(input)) == canonical` byte-lock + `contains` probes + canonical fixed-point) + **7 rejection vectors** (specific feedback variant). The shared fixture the F#/C#/Rust oracles replay.

## Verified

`bun test` → **23 pass** (83 assertions); `tsc --noEmit` → **clean** (0 errors).

Start-gated: no prior-art (empty `git grep`), no open-PR collision, registry ⬜. The registry's Codec/IO `RangeSet` line already exists; this lands oracle #1 (I'll bump it to 🚧 1/4 once this merges, then ferry F#/C#/Rust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)