### PR TITLE
feat(range-set): RangeSet F# ferry (oracle #2 of 4)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="Codec.fs" />
     <Compile Include="Bonsai.fs" />
     <Compile Include="Resume.fs" />
+    <Compile Include="RangeSet.fs" />
     <Compile Include="Circuit.fs" />
     <Compile Include="PluginApi.fs" />
     <Compile Include="PluginHarness.fs" />

--- a/src/Core/RangeSet.fs
+++ b/src/Core/RangeSet.fs
@@ -1,0 +1,120 @@
+namespace Zeta.Core
+
+/// RangeSet — the F# ferry (oracle #2 of TS/F#/C#/Rust) for the **RangeSet** primitive: a sparse
+/// integer set in compact range notation (`"1-5,8,10-17"`). The TS reference
+/// (`src/Core.TypeScript/range-set/`) authors the shared `golden-vectors.json`; this replays it:
+/// `render (parse input)` equals the **canonical** form, and `contains` agrees. "The compilers
+/// don't lie."
+///
+/// Canonical form (the cross-oracle byte-diff contract): ranges sorted, disjoint, NON-ADJACENT
+/// (overlapping AND touching ranges coalesce, `1-3,4-6` → `1-6`), each emitted as `n` when
+/// `lo = hi` else `lo-hi`, joined by `,` with no spaces; the empty set renders `""`. Non-negative
+/// JS-safe integers (matching the shared int wire domain).
+///
+/// Result over throw: `parse` returns `Result<RangeSet, RangeSetFeedback>` (the rejection-vector
+/// contract — a malformed token declines the SPECIFIC variant, matching across oracles).
+module RangeSet =
+
+    /// The shared JS-safe-integer ceiling (2^53 - 1) — the int wire domain (matches Bonsai).
+    [<Literal>]
+    let private MaxSafeInt = 9007199254740991L
+
+    /// An inclusive integer range `(lo, hi)` with `lo <= hi`.
+    type Range = int64 * int64
+
+    /// A normalized set of ranges: sorted, disjoint, non-adjacent (the canonical invariant).
+    type RangeSet = Range list
+
+    /// The typed reasons `parse` declines — the shared cross-oracle rejection-vector contract.
+    type RangeSetFeedback =
+        /// A token (or sub-token) was not a non-negative safe integer.
+        | NotInteger of token: string
+        /// A range `lo-hi` had `lo > hi`.
+        | InvertedRange of lo: int64 * hi: int64
+        /// A structurally bad token (empty between commas, trailing comma, empty sub-token, too many dashes).
+        | Malformed of token: string
+
+    /// Parse a non-negative integer token strictly: digits only, within the safe-int range.
+    let private parseNat (token: string) : int64 option =
+        if token.Length > 0 && token |> Seq.forall (fun c -> c >= '0' && c <= '9') then
+            match System.Int64.TryParse token with
+            | true, n when n >= 0L && n <= MaxSafeInt -> Some n
+            | _ -> None
+        else
+            None
+
+    /// Normalize raw ranges into the canonical invariant: sort, then coalesce overlapping/adjacent.
+    let private normalize (ranges: Range list) : RangeSet =
+        ranges
+        |> List.sortWith (fun (a0, a1) (b0, b1) -> if a0 <> b0 then compare a0 b0 else compare a1 b1)
+        |> List.fold
+            (fun acc (lo, hi) ->
+                match acc with
+                // coalesce when the next range overlaps OR touches the previous (lo <= phi + 1)
+                | (plo, phi) :: rest when lo <= phi + 1L -> (plo, max phi hi) :: rest
+                | _ -> (lo, hi) :: acc)
+            []
+        |> List.rev
+
+    /// Parse compact range notation into a canonical `RangeSet`. Empty string → empty set.
+    let parse (s: string) : Result<RangeSet, RangeSetFeedback> =
+        let trimmed = s.Trim()
+
+        if trimmed = "" then
+            Ok []
+        else
+            let tokens = trimmed.Split(',')
+
+            let rec loop i acc =
+                if i >= Array.length tokens then
+                    Ok(normalize (List.rev acc))
+                else
+                    let raw = tokens.[i]
+                    let token = raw.Trim()
+
+                    if token = "" then
+                        Error(Malformed raw)
+                    else
+                        let parts = token.Split('-')
+
+                        match parts.Length with
+                        | 1 ->
+                            match parseNat parts.[0] with
+                            | Some n -> loop (i + 1) ((n, n) :: acc)
+                            | None -> Error(NotInteger token)
+                        | 2 ->
+                            // an empty sub-token ("-3", "5-") is structurally missing, not a bad number
+                            if parts.[0] = "" || parts.[1] = "" then
+                                Error(Malformed token)
+                            else
+                                match parseNat parts.[0], parseNat parts.[1] with
+                                | Some lo, Some hi -> if lo > hi then Error(InvertedRange(lo, hi)) else loop (i + 1) ((lo, hi) :: acc)
+                                | None, _ -> Error(NotInteger parts.[0])
+                                | _, None -> Error(NotInteger parts.[1])
+                        | _ -> Error(Malformed token)
+
+            loop 0 []
+
+    /// Render a `RangeSet` to its canonical compact string.
+    let render (rs: RangeSet) : string =
+        rs
+        |> List.map (fun (lo, hi) -> if lo = hi then string lo else sprintf "%d-%d" lo hi)
+        |> String.concat ","
+
+    /// Whether `n` is a member of the set (ranges are sorted, so the scan early-exits).
+    let rec contains (rs: RangeSet) (n: int64) : bool =
+        match rs with
+        | [] -> false
+        | (lo, hi) :: rest ->
+            if n < lo then false
+            elif n <= hi then true
+            else contains rest n
+
+    /// The union of two range sets, re-normalized to canonical form.
+    let union (a: RangeSet) (b: RangeSet) : RangeSet = normalize (a @ b)
+
+    /// Add a single integer to the set (returns a new canonical set).
+    let add (rs: RangeSet) (n: int64) : RangeSet = normalize ((n, n) :: rs)
+
+    /// The total count of integers covered by the set.
+    let size (rs: RangeSet) : int64 = rs |> List.sumBy (fun (lo, hi) -> hi - lo + 1L)

--- a/tests/Tests.FSharp/RangeSet.Tests.fs
+++ b/tests/Tests.FSharp/RangeSet.Tests.fs
@@ -1,0 +1,81 @@
+module Zeta.Tests.RangeSetTests
+
+open System.IO
+open System.Reflection
+open System.Text.Json
+open global.Xunit
+open Zeta.Core
+
+// RangeSet — the F# oracle (#2 of TS/F#/C#/Rust). The TS reference
+// (src/Core.TypeScript/range-set/) authors the shared golden vectors; this proves the F# impl
+// replays them: render(parse input) == canonical (the cross-language byte lock) + contains agrees,
+// and the rejection vectors decline the SPECIFIC feedback variant. "The compilers don't lie."
+
+let private repoRoot () : string =
+    let mutable dir = DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))
+
+    while not (isNull dir) && not (File.Exists(Path.Join(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+
+    if isNull dir then
+        failwith "Could not locate repo root (Zeta.sln) from test assembly location."
+
+    dir.FullName
+
+let private golden () : JsonDocument =
+    let path = Path.Join(repoRoot (), "src", "Core.TypeScript", "range-set", "golden-vectors.json")
+    JsonDocument.Parse(File.ReadAllText path)
+
+let private feedbackName (f: RangeSet.RangeSetFeedback) : string =
+    match f with
+    | RangeSet.NotInteger _ -> "NotInteger"
+    | RangeSet.InvertedRange _ -> "InvertedRange"
+    | RangeSet.Malformed _ -> "Malformed"
+
+let private parseOk (input: string) : RangeSet.RangeSet =
+    match RangeSet.parse input with
+    | Ok rs -> rs
+    | Error f -> failwithf "expected Ok for %A, got Error %A" input f
+
+[<Fact>]
+let ``F# RangeSet replays the shared golden cases (render(parse) == canonical + contains agrees)`` () =
+    use doc = golden ()
+    let cases = doc.RootElement.GetProperty("cases").EnumerateArray() |> Seq.toList
+    Assert.True(cases.Length > 0, "no golden cases")
+
+    for c in cases do
+        let name = c.GetProperty("name").GetString()
+        let input = c.GetProperty("input").GetString()
+        let canonical = c.GetProperty("canonical").GetString()
+        let rs = parseOk input
+        Assert.Equal(canonical, RangeSet.render rs) // ($"{name}")
+        // canonical is a fixed point of parse->render
+        Assert.Equal(canonical, RangeSet.render (parseOk canonical))
+
+        for probe in c.GetProperty("contains").EnumerateArray() do
+            let arr = probe.EnumerateArray() |> Seq.toArray
+            let n = arr.[0].GetInt64()
+            let expected = arr.[1].GetBoolean()
+            Assert.True((RangeSet.contains rs n) = expected, sprintf "%s: contains %d expected %b" name n expected)
+
+[<Fact>]
+let ``F# RangeSet rejection vectors decline the specific feedback variant`` () =
+    use doc = golden ()
+
+    for r in doc.RootElement.GetProperty("rejections").EnumerateArray() do
+        let name = r.GetProperty("name").GetString()
+        let input = r.GetProperty("input").GetString()
+        let expected = r.GetProperty("feedback").GetString()
+
+        match RangeSet.parse input with
+        | Error f -> Assert.Equal(expected, feedbackName f)
+        | Ok rs -> failwithf "%s: expected Error %s, got Ok %A" name expected rs
+
+[<Fact>]
+let ``F# RangeSet structural laws — union/add/size coalesce + count`` () =
+    Assert.Equal("1-6", RangeSet.render (RangeSet.union (parseOk "1-3") (parseOk "4-6")))
+    Assert.Equal("1-6,10-14", RangeSet.render (RangeSet.union (parseOk "1-5,10-12") (parseOk "6,13-14")))
+    Assert.Equal("1-7", RangeSet.render (RangeSet.add (parseOk "1-3,5-7") 4L))
+    Assert.Equal("1-3,10", RangeSet.render (RangeSet.add (parseOk "1-3") 10L))
+    Assert.Equal(0L, RangeSet.size (parseOk ""))
+    Assert.Equal(14L, RangeSet.size (parseOk "1-5,8,10-17"))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -37,6 +37,7 @@
     <Compile Include="TriBoolean/Float.Tests.fs" />
     <Compile Include="Bonsai/Bonsai.Tests.fs" />
     <Compile Include="Bonsai/Resume.Tests.fs" />
+    <Compile Include="RangeSet.Tests.fs" />
     <Compile Include="Observe/GoldenVectors.Tests.fs" />
     <Compile Include="Observe/EventLog.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />


### PR DESCRIPTION
Ferries the RangeSet TS reference (#6454, merged) to **F# — oracle #2 of 4** (TS/F#/C#/Rust). `src/Core/RangeSet.fs` (module `RangeSet`) mirrors the TS logic with `int64` + F# `Result`: `parse` (lenient input, strict `NotInteger`/`InvertedRange`/`Malformed` rejection vectors) / `render` (canonical: sorted, disjoint, non-adjacent — overlapping AND touching coalesce) / `contains` / `union` / `add` / `size`. Non-negative JS-safe integers.

Replays `src/Core.TypeScript/range-set/golden-vectors.json`: `render(parse input) == canonical` + contains probes + canonical fixed-point (11 cases) + the 7 rejection vectors decline the specific feedback variant. **3 tests pass; Core builds 0/0.**

Rebased onto main after #6454 landed (clean F#-only diff). Placement follows the most-recent 4-oracle precedent (`Resume.fs`/`Bonsai.fs` in `Core.fsproj`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)