### PR TITLE
feat(resume): byte-lock resume STATE wire — expectedStateAtSuspension golden (TS foundation)

### DIFF
--- a/src/Core.TypeScript/bonsai/resume-golden.json
+++ b/src/Core.TypeScript/bonsai/resume-golden.json
@@ -1,5 +1,5 @@
 {
-  "description": "Resume-engine cross-language conformance (B-0976 resume slice). The TS reference oracle authors these saga traces; F#/C#/Rust replay them. A trace is a Bonsai-subset program whose `call` nodes are activities (suspension points). Each oracle runs start -> (assert suspension fn+args; resume with the next activityResult)* -> done, and must produce the SAME ordered suspension sequence AND the SAME final value. Restore-not-replay: persisting the state at any suspension (serializeState) and resuming from the re-parsed state must give the identical continuation (prior activities are never re-invoked). The compilers do not lie; agreement IS the verification.",
+  "description": "Resume-engine cross-language conformance (B-0976 resume slice). The TS reference oracle authors these saga traces; F#/C#/Rust replay them. A trace is a Bonsai-subset program whose `call` nodes are activities (suspension points). Each oracle runs start -> (assert suspension fn+args; resume with the next activityResult)* -> done, and must produce the SAME ordered suspension sequence AND the SAME final value. Restore-not-replay: persisting the state at any suspension (serializeState) and resuming from the re-parsed state must give the identical continuation (prior activities are never re-invoked). `expectedStateAtSuspension` is the cross-oracle STATE-BYTE lock: the exact canonical serializeState() bytes the TS reference emits at each suspension (in order), so every oracle's persisted continuation is byte-identical, not merely behaviorally equivalent — the kont MUST serialize top-last (innermost frame first in the array; F# cons-lists serialize reversed and must be aligned to this order). The compilers do not lie; agreement IS the verification.",
   "version": 1,
   "traces": [
     {
@@ -20,7 +20,11 @@
         { "fn": "a", "args": [] },
         { "fn": "b", "args": [] }
       ],
-      "expectedFinal": { "t": "int", "v": 30 }
+      "expectedFinal": { "t": "int", "v": 30 },
+      "expectedStateAtSuspension": [
+        "{\"v\":1,\"kont\":[{\"k\":\"evalRight\",\"op\":\"add\",\"right\":{\"v\":1,\"expr\":{\"kind\":\"call\",\"fn\":\"b\",\"args\":[]}},\"env\":{}}],\"awaiting\":{\"fn\":\"a\",\"args\":[]}}",
+        "{\"v\":1,\"kont\":[{\"k\":\"applyOp\",\"op\":\"add\",\"left\":{\"t\":\"int\",\"v\":10}}],\"awaiting\":{\"fn\":\"b\",\"args\":[]}}"
+      ]
     },
     {
       "name": "cond_branch_on_activity",
@@ -39,7 +43,10 @@
       "bindings": {},
       "activityResults": [{ "t": "int", "v": 3 }],
       "expectedSuspensions": [{ "fn": "roll", "args": [] }],
-      "expectedFinal": { "t": "str", "v": "low" }
+      "expectedFinal": { "t": "str", "v": "low" },
+      "expectedStateAtSuspension": [
+        "{\"v\":1,\"kont\":[{\"k\":\"branch\",\"then\":{\"v\":1,\"expr\":{\"kind\":\"const\",\"value\":{\"t\":\"str\",\"v\":\"low\"}}},\"els\":{\"v\":1,\"expr\":{\"kind\":\"const\",\"value\":{\"t\":\"str\",\"v\":\"high\"}}},\"env\":{}},{\"k\":\"evalRight\",\"op\":\"lt\",\"right\":{\"v\":1,\"expr\":{\"kind\":\"const\",\"value\":{\"t\":\"int\",\"v\":5}}},\"env\":{}}],\"awaiting\":{\"fn\":\"roll\",\"args\":[]}}"
+      ]
     },
     {
       "name": "activity_with_computed_args",
@@ -62,7 +69,10 @@
       "expectedSuspensions": [
         { "fn": "act", "args": [{ "t": "int", "v": 3 }, { "t": "int", "v": 7 }] }
       ],
-      "expectedFinal": { "t": "int", "v": 42 }
+      "expectedFinal": { "t": "int", "v": 42 },
+      "expectedStateAtSuspension": [
+        "{\"v\":1,\"kont\":[],\"awaiting\":{\"fn\":\"act\",\"args\":[{\"t\":\"int\",\"v\":3},{\"t\":\"int\",\"v\":7}]}}"
+      ]
     },
     {
       "name": "pure_no_suspension",
@@ -81,7 +91,8 @@
       "bindings": {},
       "activityResults": [],
       "expectedSuspensions": [],
-      "expectedFinal": { "t": "int", "v": 14 }
+      "expectedFinal": { "t": "int", "v": 14 },
+      "expectedStateAtSuspension": []
     },
     {
       "name": "param_binding_plus_activity",
@@ -97,7 +108,10 @@
       "expectedSuspensions": [
         { "fn": "dbl", "args": [{ "t": "int", "v": 5 }] }
       ],
-      "expectedFinal": { "t": "int", "v": 15 }
+      "expectedFinal": { "t": "int", "v": 15 },
+      "expectedStateAtSuspension": [
+        "{\"v\":1,\"kont\":[{\"k\":\"applyOp\",\"op\":\"add\",\"left\":{\"t\":\"int\",\"v\":5}}],\"awaiting\":{\"fn\":\"dbl\",\"args\":[{\"t\":\"int\",\"v\":5}]}}"
+      ]
     }
   ]
 }

--- a/src/Core.TypeScript/bonsai/resume.test.ts
+++ b/src/Core.TypeScript/bonsai/resume.test.ts
@@ -31,6 +31,11 @@ function stepOk(r: Result<SagaStep, ResumeFeedback>): SagaStep {
 // activities are never re-invoked) AND the cross-language suspension/final contract.
 for (const tr of golden.traces) {
   test(`resume golden: ${tr.name}`, () => {
+    // fixture schema: exactly one expected state-byte string and one activity result per
+    // suspension — assert up front so a malformed golden fails as a clear schema mismatch,
+    // not a confusing undefined compare inside the loop
+    expect(tr.expectedStateAtSuspension.length).toBe(tr.expectedSuspensions.length);
+    expect(tr.activityResults.length).toBe(tr.expectedSuspensions.length);
     let step = stepOk(start(tr.program, tr.bindings));
     for (let i = 0; i < tr.expectedSuspensions.length; i++) {
       expect(step.kind).toBe("suspended");

--- a/src/Core.TypeScript/bonsai/resume.test.ts
+++ b/src/Core.TypeScript/bonsai/resume.test.ts
@@ -13,6 +13,9 @@ interface Trace {
   readonly activityResults: readonly ConstValue[];
   readonly expectedSuspensions: readonly { readonly fn: string; readonly args: readonly ConstValue[] }[];
   readonly expectedFinal: ConstValue;
+  // the canonical serializeState() bytes the TS reference emits at each suspension, in order —
+  // the cross-oracle STATE-BYTE lock every ferry (F#/C#/Rust) must reproduce verbatim
+  readonly expectedStateAtSuspension: readonly string[];
 }
 
 const goldenPath = join(dirname(fileURLToPath(import.meta.url)), "resume-golden.json");
@@ -38,6 +41,9 @@ for (const tr of golden.traces) {
       const ser = serializeState(step.state);
       expect(ser.ok).toBe(true);
       if (!ser.ok) return;
+      // STATE-BYTE LOCK: the persisted continuation must equal the canonical bytes the TS
+      // reference authored — the exact wire every ferry replays (kont serializes top-last)
+      expect(ser.value).toBe(tr.expectedStateAtSuspension[i]!);
       const restored = parseState(ser.value);
       expect(restored.ok).toBe(true);
       if (!restored.ok) return;


### PR DESCRIPTION
## What

Byte-locks the resume STATE wire across the four oracles. The resume slice (B-0976) was
byte-locked on suspension `fn`+`args` + final value, but the persisted `SagaState` bytes
were only behaviorally verified (per-oracle round-trip). This adds **`expectedStateAtSuspension`**
to `resume-golden.json` — the exact canonical `serializeState()` bytes the TS reference emits
at each suspension, in order — and asserts them in the TS oracle.

## Why this matters (the gap it closes)

State serialization was NOT byte-locked across oracles. The F# `kont` cons-list (top-first)
serializes **reversed** vs the TS array (top-last) on multi-frame konts. C#/Rust match TS by
construction (`Vec`/`IReadOnlyList` top-last). Behavioral tests passed anyway because each
oracle round-trips its own bytes — so the divergence was invisible until a saga is persisted
in one oracle and resumed in another.

The high-value golden case is **`cond_branch_on_activity`**: its 2-frame kont
(`branch` + `evalRight`) is exactly where the order diverges. The golden now pins **top-last**
(innermost frame first in the array), making it the single cross-oracle wire reference.

## Scope (foundation slice)

- `resume-golden.json`: `expectedStateAtSuspension` added to all 5 traces (canonical bytes
  authored by the TS reference engine) + description documents the byte-lock contract.
- `resume.test.ts`: `Trace.expectedStateAtSuspension` field + `expect(ser.value).toBe(...)`
  assertion at every suspension.

## Follow-ups (separate PRs)

1. Add the byte-equality assertion to the F#/C#/Rust resume cross-verify tests.
2. Align F# `Resume.fs` kont serialization order to the array reference (the actual fix).

## Verification

- `bun test bonsai/resume.test.ts` → **16 pass / 0 fail** (86 expect calls)
- root `tsc --noEmit` → **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
