### PR TITLE
feat(B-0347.6): CI-wire the skill-description audit gate (enforced, not just checkable)

### DIFF
--- a/.github/workflows/skill-description-lint.yml
+++ b/.github/workflows/skill-description-lint.yml
@@ -1,0 +1,69 @@
+# .github/workflows/skill-description-lint.yml
+#
+# CI-wire the skill-description audit gate (B-0347.6) so the routing-budget
+# cap is *enforced*, not just manually checkable.
+#
+# B-0347.4 (PR #6029) shipped tools/hygiene/audit-skill-description-length.ts —
+# a deterministic Rule-0 gate that fails on any over-cap (>150 char), multiline,
+# or boilerplate skill description. But nothing ran it automatically, so a
+# description could silently regrow past the budget and only be caught on a
+# manual invocation. This workflow makes the structural fix DURABLE rather than
+# checkable, per .claude/rules/automated-tests-are-the-shield-assert-dont-skip.md
+# (a gate that isn't wired reads as covered while not actually guarding).
+#
+# The tool exits non-zero on ERRORS (over-cap / multiline / boilerplate) and
+# exits 0 on WARNINGS (the <=120-char preferred band is advisory, not fatal —
+# promoting those to errors is B-0347.7's scope, out of scope here). So running
+# the tool directly yields exactly the intended gating: fail on errors, pass on
+# warnings.
+#
+# Safe-pattern compliance (FACTORY-HYGIENE), mirroring
+# .github/workflows/role-ref-current-state-surfaces-lint.yml:
+#   - SHA-pinned actions (actions/checkout v6.0.2, oven-sh/setup-bun v2.2.0)
+#   - Explicit minimum permissions: contents: read
+#   - No user-authored context (no github.event.* refs in run:)
+#   - Concurrency group + cancel-in-progress: false
+#   - runs-on ubuntu-24.04 pinned (not -latest)
+#
+# See:
+#   - tools/hygiene/audit-skill-description-length.ts (the gate this invokes)
+#   - docs/backlog/P2/B-0347.6-ci-wire-skill-description-audit-gate.md
+#   - .github/workflows/role-ref-current-state-surfaces-lint.yml (the precedent)
+
+on:
+  pull_request:
+    paths:
+      - .claude/skills/**
+      - tools/hygiene/audit-skill-description-length.ts
+      - .github/workflows/skill-description-lint.yml
+  push:
+    branches: [main]
+    paths:
+      - .claude/skills/**
+      - tools/hygiene/audit-skill-description-length.ts
+      - .github/workflows/skill-description-lint.yml
+  workflow_dispatch: {}
+
+name: skill-description-lint
+
+permissions:
+  contents: read
+
+concurrency:
+  group: skill-description-lint-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  lint:
+    name: lint skill descriptions for routing-budget cap
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: run skill-description audit (fails on over-cap / multiline / boilerplate)
+        shell: bash
+        run: bun tools/hygiene/audit-skill-description-length.ts


### PR DESCRIPTION
## Summary

Closes **B-0347.6** — CI-wires the skill-description audit so the routing-budget cap is **enforced**, not just manually checkable.

B-0347.4 ([#6029](https://github.com/Lucent-Financial-Group/Zeta/pull/6029)) shipped `tools/hygiene/audit-skill-description-length.ts` (fails on over-cap `>150` / multiline / boilerplate descriptions), but **nothing ran it** — a description could silently regrow past budget and only be caught on a manual invocation. An unwired gate *reads as covered while guarding nothing*, per `.claude/rules/automated-tests-are-the-shield-assert-dont-skip.md`.

## Change (1 file, new workflow)

- **`.github/workflows/skill-description-lint.yml`** — modeled on the `role-ref-current-state-surfaces-lint.yml` precedent. Triggers on `pull_request` + `push:main` with a `paths:` filter on `.claude/skills/**` + the audit tool + the workflow file; runs `bun tools/hygiene/audit-skill-description-length.ts`.

The tool exits **1 on errors, 0 on warnings** (verified at `audit-skill-description-length.ts:147`), so the job **fails** on over-cap/multiline/boilerplate and **passes** on the advisory `≤120` band. Promoting those warnings to errors is B-0347.7's scope — explicitly out of scope here.

**Strict from day one** (no soft-launch flag, unlike the role-ref precedent): the skills tree is already clean (`0 errors, 0 warnings`), so there's no migration debt to stage.

## Verification (local, on the install.sh-provisioned toolchain)

| Check | Result |
|---|---|
| `actionlint .github/workflows/skill-description-lint.yml` | ✅ clean |
| audit command on current tree | ✅ `0 errors, 0 warnings`, **EXIT=0** (job passes) |
| exit-1-on-errors (gate genuinely fails) | ✅ confirmed in tool source (`:147`) |
| SHA pins match prevailing repo pins | ✅ checkout `v6.0.2`, setup-bun `v2.2.0` |

## Security

Mirrors the precedent: SHA-pinned actions; `permissions: contents: read`; concurrency group; `runs-on: ubuntu-24.04` (not `-latest`); no `github.event.*` in `run:`.

Per backlog row [B-0347.6](docs/backlog/P2/B-0347.6-ci-wire-skill-description-audit-gate.md).

https://claude.ai/code/session_01Xy4V3eMD9pfEdEobg7ndEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xy4V3eMD9pfEdEobg7ndEA)_