### PR TITLE
feat(ace): slice 6.2 publish enhancements (per-package url + multi-dir + --sequence)

### DIFF
--- a/.claude/skills/ace/SKILL.md
+++ b/.claude/skills/ace/SKILL.md
@@ -233,27 +233,35 @@ package manifests, builds a signed index, and writes the file a registry serves.
 ### Command
 
 ```bash
-ace registry publish --packages <dir> --base-url <url> --key <pem-path> [--out index.json]
+ace registry publish --packages <dir>[,<dir>...] --base-url <url> --key <pem-path> [--out <path>] [--sequence <n>]
 ```
 
-- **`--packages <dir>`** — directory to scan. Every `*.json` file is attempted
-  as a package manifest; files that do not parse as a valid package manifest are
-  skipped with a warning.
+- **`--packages <dir>[,<dir>...]`** — one or more directories to scan (comma-separated).
+  Every `*.json` file in each directory is attempted as a package manifest; files
+  that do not parse as a valid package manifest are skipped with a warning. Each
+  listed directory must be readable (an unreadable directory is a hard error).
+  A duplicate `name@version` across directories is also a hard error.
 - **`--base-url <url>`** — base URL of the registry. Each package's consumer
-  `url` is derived as `<base-url>/<name>-<version>.json` and its `package_hash`
-  is the `packageHash` of the canonical whole package (`{ manifest, files }`) — the same hash the consumer pins.
+  `url` is derived as `<base-url>/<name>-<version>.json` (unless overridden — see
+  Per-package `url` below) and its `package_hash` is the `packageHash` of the
+  canonical whole package (`{ manifest, files }`) — the same hash the consumer pins.
 - **`--key <pem-path>`** — path to the Ed25519 **private** key (PEM format). The index is signed
   with this key. Recommended: restrict the key file so only you can read it
   (e.g. `chmod 600` on POSIX); `publish` reads the key but does not enforce
   its file permissions.
-- **`--out <file>`** — path to write the signed index JSON (default: `./index.json`).
+- **`--out <path>`** — path to write the signed index JSON (default: `./index.json`).
+- **`--sequence <n>`** — explicit positive integer to use as the index sequence number,
+  overriding the auto-bump. Still anti-rollback-gated: if `--out` holds a prior index
+  and `n <= prior_sequence`, publish refuses (exit 1). Absent → auto-bump as before.
 
 ### Sequence auto-bump
 
 If `--out` already exists, `publish` reads the previous index and sets the new
 index's `sequence` to `prior_sequence + 1`. A sequence that is not strictly
 increasing is refused (exit 1). This is the producer-side mirror of the
-consumer's anti-rollback gate: the published sequence always advances.
+consumer's anti-rollback gate: the published sequence always advances. Pass
+`--sequence <n>` to supply an explicit positive integer instead of auto-bumping;
+the anti-rollback gate still applies.
 
 ### Round-trip self-verify
 
@@ -282,9 +290,47 @@ The `index.json` written by `publish` is the file a registry serves at the URL
 consumers configure. It contains the package list, `sequence`, `issued_at`,
 and the Ed25519 signature over the canonical payload.
 
+### Per-package `url` field (slice 6.2)
+
+A package file may carry an optional top-level `url` key — a sibling of `manifest`
+and `files`, outside the signed manifest:
+
+```text
+{
+  "manifest": { ... },
+  "files": { ... },
+  "url": "https://cdn.example/my-pkg-v1.json"
+}
+```
+
+When present, `url` overrides the derived `<base-url>/<name>-<version>.json` for
+that package in the published index. Key properties:
+
+- **Publish-only:** the `url` field is excluded from `package_hash`, which hashes
+  only `manifest` and `files`. The content/signature gates are unaffected.
+- **Filename exemption:** a package WITH a `url` is exempt from the
+  `<name>-<version>.json` filename requirement (the on-disk file may be named
+  anything, e.g. a CDN-style path). A package WITHOUT a `url` still must be named
+  `<name>-<version>.json`.
+- **Validation:** `url` must be a non-empty string that is a valid absolute URL.
+  An invalid or empty `url` causes `publish` to skip that package with a warning.
+
+Example — two directories, one package with a CDN url:
+
+```bash
+ace registry publish   --packages /srv/pkgs/tier1,/srv/pkgs/tier2   --base-url https://registry.example   --key registry.pem   --out index.json   --sequence 7
+```
+
+In `tier1/leaf.json`:
+
+```text
+{ "manifest": { ... }, "files": { ... }, "url": "https://cdn.example/leaf-v2.json" }
+```
+
+The published index entry for `leaf` uses `https://cdn.example/leaf-v2.json`
+while all other packages derive their URL from `--base-url`.
+
 ### Deferred
 
-- Per-package URL override (custom artifact hosting).
 - ETag / Last-Modified sidecar for conditional-GET cache validation.
-- Multi-directory publish and incremental (append-only) publish.
 - Multi-signer publish (multiple signing keys on one index).

--- a/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice6.2-implementation-plan.md
+++ b/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice6.2-implementation-plan.md
@@ -1,0 +1,382 @@
+# Ace CLI slice 6.2 — publish enhancements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three deferred `ace registry publish` enhancements — per-package `url` override,
+comma-separated multi-directory `--packages`, and explicit `--sequence` — per
+`2026-06-01-ace-cli-slice6.2-publish-enhancements-design.md`.
+
+**Architecture:** `buildIndexDoc` (pure, `registry-publish.ts`) changes its input shape to
+carry an optional per-package url; `ace.ts` parse gains comma-split `--packages` + `--sequence`;
+the `ace.ts` publish handler scans multiple dirs, reads+validates a top-level `url` per package
+(skipping the filename guard when present), and threads the sequence override. ETag sidecar
+dropped.
+
+**Tech stack:** TypeScript on Bun. Tests `bun test tools/ace/`. Strict
+`bun --bun tsc --noEmit -p tsconfig.json` (exactOptionalPropertyTypes + noUnusedLocals).
+Markdownlint on `SKILL.md`. Harness: NO Edit tool — new files via Write, edits via
+Python/bun patch-scripts with exact-occurrence asserts (rm before commit, never commit
+`_patch_*`). LF only — verify CR=0 with Python `open(f,'rb').read().count(b'\r')` (Git-Bash
+`grep $'\r'` is unreliable on this box). Canary `git ls-tree HEAD | wc -l` = 67 (no
+added/removed tracked files; the plan + spec docs already exist or land via their own PR).
+Commit trailer `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+**File-boundary task groups (sequential):** T1 = `registry-publish.ts` (+test); T2 = `ace.ts`
+(parse + handler) + `ace.test.ts`; T3 = `SKILL.md`. T1 before T2 (T2's handler calls the new
+`buildIndexDoc` shape).
+
+---
+
+## Task 1: `buildIndexDoc` per-entry `{ pkg, url? }` input
+
+**Files:**
+
+- Modify: `tools/ace/registry-publish.ts` (`buildIndexDoc`)
+- Test: `tools/ace/registry-publish.test.ts`
+
+Current `buildIndexDoc` takes `packages: AcePackage[]`, sorts by `(name, version)`, and per
+package sets each entry's `url` to the joined base-url + name-version filename and its
+`package_hash` to `packageHash(pkg)`. Change the input to
+`ReadonlyArray<{ pkg: AcePackage; url?: string }>` and use `entry.url` when present.
+
+- [ ] **Step 1: Update existing tests to the new input shape + add url tests (RED)**
+
+In `tools/ace/registry-publish.test.ts`, every `buildIndexDoc({ packages: [X], ... })` call
+becomes `buildIndexDoc({ packages: [{ pkg: X }], ... })` (wrap each `AcePackage` as `{ pkg }`).
+Then add to the `describe("buildIndexDoc", ...)` block (reuse `pkg`/`kp`/`issuedAt`):
+
+```ts
+  test("per-package url override is used; absent falls back to base-url", () => {
+    const a = pkg("alpha", "1.0.0");
+    const b = pkg("beta", "1.0.0");
+    const doc = buildIndexDoc({
+      packages: [{ pkg: a, url: "https://cdn.example/alpha-v1.json" }, { pkg: b }],
+      baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem,
+    });
+    expect("error" in doc).toBe(false);
+    if ("error" in doc) return;
+    expect(doc.packages.alpha!["1.0.0"]!.url).toBe("https://cdn.example/alpha-v1.json");
+    expect(doc.packages.beta!["1.0.0"]!.url).toBe("https://pkgs/beta-1.0.0.json");
+  });
+
+  test("url override does not change package_hash", () => {
+    const a = pkg("alpha", "1.0.0");
+    const withUrl = buildIndexDoc({ packages: [{ pkg: a, url: "https://cdn/x.json" }], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    const without = buildIndexDoc({ packages: [{ pkg: a }], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    if ("error" in withUrl || "error" in without) throw new Error("unexpected");
+    expect(withUrl.packages.alpha!["1.0.0"]!.package_hash).toBe(without.packages.alpha!["1.0.0"]!.package_hash);
+  });
+```
+
+Run `bun test tools/ace/registry-publish.test.ts` → FAILS to compile/run (old call sites + new
+shape mismatch).
+
+- [ ] **Step 2: Change `buildIndexDoc` input shape (GREEN)**
+
+Patch `buildIndexDoc` in `tools/ace/registry-publish.ts`:
+
+```ts
+export function buildIndexDoc(args: {
+  packages: ReadonlyArray<{ pkg: AcePackage; url?: string }>; baseUrl: string; sequence: number; issuedAt: string; privatePem: string;
+}): IndexDoc | { error: string } {
+  const packages: Record<string, Record<string, RegistryEntry>> = Object.create(null);
+  const sorted = [...args.packages].sort((a, b) =>
+    a.pkg.manifest.name.localeCompare(b.pkg.manifest.name) || a.pkg.manifest.version.localeCompare(b.pkg.manifest.version));
+  for (const entry of sorted) {
+    const pkg = entry.pkg;
+    const name = pkg.manifest.name;
+    const version = pkg.manifest.version;
+    const versions = packages[name] ?? (Object.create(null) as Record<string, RegistryEntry>);
+    if (RESERVED_IDENTITY_KEYS.has(name) || RESERVED_IDENTITY_KEYS.has(version)) {
+      return { error: `reserved package identity not allowed: ${name}@${version}` };
+    }
+    if (versions[version] !== undefined) return { error: `duplicate package ${name}@${version}` };
+    const url = entry.url ?? joinUrl(args.baseUrl, `${name}-${version}.json`);
+    versions[version] = { url, package_hash: packageHash(pkg) };
+    packages[name] = versions;
+  }
+  const content: IndexSignableContent = { format_version: 1, sequence: args.sequence, issued_at: args.issuedAt, packages };
+  const signature = signIndex(content, args.privatePem);
+  return { ...content, signature };
+}
+```
+
+(Module-level `RESERVED_IDENTITY_KEYS`, `nextSequence`, `joinUrl` unchanged.)
+
+- [ ] **Step 3: Verify (GREEN)** — `bun test tools/ace/registry-publish.test.ts` all pass;
+  `bun --bun tsc --noEmit -p tsconfig.json` exit 0. (ace.ts's existing call site will be
+  red until T2 — that's expected; T1's own file + test must be green, but the full `tsc` may
+  show ace.ts's old call site mismatch. Note it; T2 fixes it. If the controller wants a green
+  tsc after T1, T1 may stub the ace.ts call site to the new shape minimally — but cleaner to
+  do ace.ts fully in T2. Mark tsc "green except the ace.ts call site addressed in T2".)
+
+- [ ] **Step 4: Commit** — `git add tools/ace/registry-publish.ts tools/ace/registry-publish.test.ts`
+
+---
+
+## Task 2: `ace.ts` parse (`--packages` comma-split + `--sequence`) + handler (multi-dir, url, sequence) + e2e
+
+**Files:**
+
+- Modify: `tools/ace/ace.ts` (RegistryArgs type, parse, publish handler, usage text)
+- Test: `tools/ace/ace.test.ts`
+
+Read first: `RegistryArgs` type (~line 110), the `registry publish` parse branch (~255-265),
+the publish handler (~547-603), the slice-6.1 publish e2e block in `ace.test.ts`
+(`describe("ace registry publish (slice 6.1)"` ~1356, helper `writeSignedPkg`).
+
+- [ ] **Step 1: e2e tests for the three enhancements (RED)**
+
+Add to the publish describe block in `tools/ace/ace.test.ts` (reuse `writeSignedPkg`,
+`main`, `parseIndex`, `parseArgs`, `mkdtempSync`, `tmpdir`, `join`, `writeFileSync`,
+`readFileSync`, `contentHash`, `signManifest`, `generateKeypair`, `tempHome`). Helper for a
+url-bearing package written under an arbitrary basename:
+
+```ts
+  function writeUrlPkg(dir: string, file: string, name: string, version: string, url: unknown) {
+    const files = { [`${name}.txt`]: "hi" };
+    const ch = contentHash(new TextEncoder().encode(JSON.stringify(files)));
+    const kp = generateKeypair();
+    const m = { format_version: 1, name, version, content_hash: ch };
+    const pkg = { manifest: { ...m, signature: signManifest(m, kp.privatePem) }, files, url };
+    writeFileSync(join(dir, file), JSON.stringify(pkg));
+  }
+```
+
+Tests:
+
+```ts
+  test("per-package url override is honored; absent derives from base-url", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-url-"));
+    writeUrlPkg(pkgDir, "leaf.json", "leaf", "1.0.0", "https://cdn/leaf-v1.json"); // NOT canonical basename
+    writeSignedPkg(pkgDir, "other", "2.0.0");                                       // canonical, no url
+    const keyPath = join(tempHome, "r-url.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "i-url.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    if ("error" in doc) throw new Error(doc.error);
+    expect(doc.packages.leaf!["1.0.0"]!.url).toBe("https://cdn/leaf-v1.json");
+    expect(doc.packages.other!["2.0.0"]!.url).toBe("https://pkgs/other-2.0.0.json");
+  });
+
+  test("non-canonical filename WITHOUT url is skipped; WITH url is indexed", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-fn-"));
+    // bad: leaf.json, no url → filename guard skips it
+    const files = { "leaf.txt": "hi" }; const ch = contentHash(new TextEncoder().encode(JSON.stringify(files)));
+    const kp = generateKeypair(); const m = { format_version: 1, name: "leaf", version: "1.0.0", content_hash: ch };
+    writeFileSync(join(pkgDir, "leaf.json"), JSON.stringify({ manifest: { ...m, signature: signManifest(m, kp.privatePem) }, files }));
+    const keyPath = join(tempHome, "r-fn.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const out1 = join(tempHome, "i-fn1.json");
+    const c1 = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", out1]);
+    expect(c1).toBe(1); // no valid packages (leaf.json skipped by filename guard)
+    // now add url → indexed
+    writeUrlPkg(pkgDir, "leaf.json", "leaf", "1.0.0", "https://cdn/leaf.json");
+    const out2 = join(tempHome, "i-fn2.json");
+    const c2 = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", out2]);
+    expect(c2).toBe(0);
+    const doc = parseIndex(readFileSync(out2, "utf8"));
+    if ("error" in doc) throw new Error(doc.error);
+    expect(doc.packages.leaf!["1.0.0"]!.url).toBe("https://cdn/leaf.json");
+  });
+
+  test("invalid url (not an absolute URL) is skipped", async () => {
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-badurl-"));
+    writeUrlPkg(pkgDir, "leaf-1.0.0.json", "leaf", "1.0.0", "leaf#x"); // not absolute
+    const keyPath = join(tempHome, "r-bu.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "i-bu.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(1); // only package skipped → no valid packages
+  });
+
+  test("comma-separated --packages indexes both dirs; cross-dir duplicate errors", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const dirA = mkdtempSync(join(tmpdir(), "ace-pub-a-"));
+    const dirB = mkdtempSync(join(tmpdir(), "ace-pub-b-"));
+    writeSignedPkg(dirA, "aa", "1.0.0");
+    writeSignedPkg(dirB, "bb", "1.0.0");
+    const keyPath = join(tempHome, "r-md.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "i-md.json");
+    const code = await main(["registry", "publish", "--packages", `${dirA},${dirB}`, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    if ("error" in doc) throw new Error(doc.error);
+    expect(doc.packages.aa).toBeDefined();
+    expect(doc.packages.bb).toBeDefined();
+    // cross-dir duplicate
+    writeSignedPkg(dirB, "aa", "1.0.0");
+    const out2 = join(tempHome, "i-md2.json");
+    const dup = await main(["registry", "publish", "--packages", `${dirA},${dirB}`, "--base-url", "https://pkgs", "--key", keyPath, "--out", out2]);
+    expect(dup).toBe(1);
+  });
+
+  test("unreadable listed dir is a hard error", async () => {
+    const idxKp = generateKeypair();
+    const dirA = mkdtempSync(join(tmpdir(), "ace-pub-ok-"));
+    writeSignedPkg(dirA, "aa", "1.0.0");
+    const keyPath = join(tempHome, "r-ud.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "i-ud.json");
+    const code = await main(["registry", "publish", "--packages", `${dirA},/no/such/dir/xyz`, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(1);
+  });
+
+  test("--sequence sets the sequence; rollback is refused; bad value is a parse error", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-seq-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    const keyPath = join(tempHome, "r-seq.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "i-seq.json");
+    const c1 = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath, "--sequence", "5"]);
+    expect(c1).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    if ("error" in doc) throw new Error(doc.error);
+    expect(doc.sequence).toBe(5);
+    // rollback against prev (5)
+    const c2 = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath, "--sequence", "3"]);
+    expect(c2).toBe(1);
+    // bad values → parse error
+    expect("error" in parseArgs(["registry", "publish", "--packages", "d", "--base-url", "https://x", "--key", "k", "--sequence", "0"])).toBe(true);
+    expect("error" in parseArgs(["registry", "publish", "--packages", "d", "--base-url", "https://x", "--key", "k", "--sequence", "abc"])).toBe(true);
+  });
+```
+
+Run `bun test tools/ace/ace.test.ts` → these FAIL on current code.
+
+- [ ] **Step 2: Parse — `RegistryArgs.pubSequence` + `--sequence` + keep `--packages` raw (GREEN)**
+
+In `tools/ace/ace.ts`: add `readonly pubSequence?: number;` to the `RegistryArgs` interface
+(near `pubOut`). In the `registry publish` parse branch, add a `seq` local + a `--sequence`
+arm; reject non-positive-integer:
+
+```ts
+        else if (argv[i] === "--sequence") {
+          const sv = argv[++i];
+          const n = Number(sv);
+          if (!sv || !Number.isInteger(n) || n <= 0) return { error: "--sequence requires a positive integer" };
+          seq = n;
+        }
+```
+
+Declare `let seq: number | undefined;` alongside the existing `dir`/`base`/`key`/`out` locals.
+Build the result carrying `pubSequence` when set:
+
+```ts
+      let r: RegistryArgs = { command: "registry", sub: "publish", pubPackagesDir: dir, pubBaseUrl: base, pubKeyPath: key };
+      if (out !== undefined) r = { ...r, pubOut: out };
+      if (seq !== undefined) r = { ...r, pubSequence: seq };
+      return r;
+```
+
+(`pubPackagesDir` keeps the raw comma value; the handler splits. Do NOT assign `undefined` to
+optional props — exactOptionalPropertyTypes. Use the spread-conditional form above.)
+
+- [ ] **Step 3: Handler — multi-dir scan, url read+validate, filename-guard skip, sequence override (GREEN)**
+
+In the publish handler:
+
+- Split dirs (replace the single `readdirSync(parsed.pubPackagesDir!)`):
+
+```ts
+      const dirs = parsed.pubPackagesDir!.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+      if (dirs.length === 0) { console.error("ace: publish refused: --packages requires at least one directory"); return 1; }
+      const packages: { pkg: AcePackage; url?: string }[] = [];
+      for (const d of dirs) {
+        let entries: string[];
+        try { entries = readdirSync(d).filter((f) => f.endsWith(".json")); }
+        catch (e) { console.error(`ace: publish: cannot read dir ${d}: ${(e as Error).message}`); return 1; }
+        for (const f of entries) {
+          const full = join(d, f);
+          // ... existing per-file scan body, with the two changes below ...
+        }
+      }
+```
+
+(The per-file scan body — JSON parse, shape guard, content_hash checks, deps/file-value/path
+guards, URL-unsafe identity guard — is unchanged EXCEPT the two changes below. `full` uses `d`
+not the old single dir.)
+
+- Read + validate the optional `url`, and make the filename guard conditional. After the
+content_hash-match check and before/around the filename guard:
+
+```ts
+          let urlOverride: string | undefined;
+          const rawUrl = (obj as { url?: unknown }).url;
+          if (rawUrl !== undefined) {
+            if (typeof rawUrl !== "string" || rawUrl.length === 0) { console.error(`ace: publish: skip ${f} — url must be a non-empty string`); continue; }
+            try { new URL(rawUrl); } catch { console.error(`ace: publish: skip ${f} — url is not an absolute URL: ${rawUrl}`); continue; }
+            urlOverride = rawUrl;
+          }
+          // filename guard applies ONLY when there is no url override
+          if (urlOverride === undefined) {
+            const expectedFile = `${(obj as AcePackage).manifest.name}-${(obj as AcePackage).manifest.version}.json`;
+            if (f !== expectedFile) { console.error(`ace: publish: skip ${f} — filename must be ${expectedFile} to match its derived consumer URL`); continue; }
+          }
+```
+
+(Remove the old unconditional filename-guard block; the URL-unsafe-identity, deps, file-value,
+and `validatePackagePaths` guards stay, applied to both cases.)
+
+- Push the entry:
+
+```ts
+          packages.push(urlOverride !== undefined ? { pkg: obj as AcePackage, url: urlOverride } : { pkg: obj as AcePackage });
+```
+
+- Generalize the empty + sequence:
+
+```ts
+      if (packages.length === 0) { console.error(`ace: publish refused: no valid packages in ${dirs.join(", ")}`); return 1; }
+      // ... outPath + prev read (unchanged) ...
+      const seq = parsed.pubSequence ?? nextSequence(prev);
+      if (prev && seq <= prev.sequence) { console.error(`ace: publish refused: sequence ${seq} <= prev ${prev.sequence}`); return 1; }
+```
+
+- `buildIndexDoc({ packages, baseUrl: parsed.pubBaseUrl!, sequence: seq, ... })` — `packages`
+   is now `{ pkg, url? }[]`, matching the T1 signature.
+
+- [ ] **Step 4: Usage text** — update the `registry publish` usage line to
+  `--packages <dir>[,<dir>...] ... [--sequence <n>]`.
+
+- [ ] **Step 5: Verify (GREEN)** — `bun test tools/ace/` all pass; `bun --bun tsc --noEmit -p tsconfig.json`
+  exit 0; Python CR=0 on `ace.ts` + `ace.test.ts`; canary 67; no `_patch_*`.
+
+- [ ] **Step 6: Commit** — `git add tools/ace/ace.ts tools/ace/ace.test.ts`
+
+---
+
+## Task 3: `SKILL.md` — document the three enhancements
+
+**Files:**
+
+- Modify: `.claude/skills/ace/SKILL.md` (publish section)
+
+- [ ] **Step 1: Document** — in the `ace registry publish` section, add: the optional
+  top-level `url` field (publish-only; sibling of manifest/files; outside the signed manifest;
+  overrides the derived URL; excluded from `package_hash`; relaxes the `<name>-<version>.json`
+  filename requirement for that package; must be an absolute URL); comma-separated
+  `--packages a,b,c` (scan + merge multiple dirs); and `--sequence <n>` (explicit positive
+  integer, anti-rollback-gated). Keep the existing slice-6.1 content.
+
+- [ ] **Step 2: Verify** — `bunx markdownlint-cli2 .claude/skills/ace/SKILL.md` exit 0;
+  Python CR=0; canary 67.
+
+- [ ] **Step 3: Commit** — `git add .claude/skills/ace/SKILL.md`
+
+---
+
+## Final holistic review
+
+After T1-T3, dispatch a final reviewer over `git diff origin/main..HEAD -- tools/ace/
+.claude/skills/ace/SKILL.md` checking: buildIndexDoc shape change is consistent at all call
+sites; url override correctly bypasses the filename guard but NOT the other guards;
+package_hash excludes the url; sequence override is anti-rollback-gated; multi-dir per-dir
+error handling; `bun test tools/ace/` + strict tsc + markdownlint all green; CR=0; canary 67.
+Then the controller opens the impl PR + runs the PR-gate loop.

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -1657,4 +1657,113 @@ describe("ace registry publish (slice 6.1)", () => {
       expect(doc.packages.bad).toBeUndefined();
     }
   });
+
+  function writeUrlPkg(dir: string, file: string, name: string, version: string, url: unknown) {
+    const files = { [`${name}.txt`]: "hi" };
+    const ch = contentHash(new TextEncoder().encode(JSON.stringify(files)));
+    const kp = generateKeypair();
+    const m = { format_version: 1, name, version, content_hash: ch };
+    const pkg = { manifest: { ...m, signature: signManifest(m, kp.privatePem) }, files, url };
+    writeFileSync(join(dir, file), JSON.stringify(pkg));
+  }
+
+  test("per-package url override is honored; absent derives from base-url", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-url-"));
+    writeUrlPkg(pkgDir, "leaf.json", "leaf", "1.0.0", "https://cdn/leaf-v1.json"); // NOT canonical basename
+    writeSignedPkg(pkgDir, "other", "2.0.0");                                       // canonical, no url
+    const keyPath = join(tempHome, "r-url.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "i-url.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    if ("error" in doc) throw new Error(doc.error);
+    expect(doc.packages.leaf!["1.0.0"]!.url).toBe("https://cdn/leaf-v1.json");
+    expect(doc.packages.other!["2.0.0"]!.url).toBe("https://pkgs/other-2.0.0.json");
+  });
+
+  test("non-canonical filename WITHOUT url is skipped; WITH url is indexed", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-fn-"));
+    // bad: leaf.json, no url → filename guard skips it
+    const files = { "leaf.txt": "hi" }; const ch = contentHash(new TextEncoder().encode(JSON.stringify(files)));
+    const kp = generateKeypair(); const m = { format_version: 1, name: "leaf", version: "1.0.0", content_hash: ch };
+    writeFileSync(join(pkgDir, "leaf.json"), JSON.stringify({ manifest: { ...m, signature: signManifest(m, kp.privatePem) }, files }));
+    const keyPath = join(tempHome, "r-fn.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const out1 = join(tempHome, "i-fn1.json");
+    const c1 = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", out1]);
+    expect(c1).toBe(1); // no valid packages (leaf.json skipped by filename guard)
+    // now add url → indexed
+    writeUrlPkg(pkgDir, "leaf.json", "leaf", "1.0.0", "https://cdn/leaf.json");
+    const out2 = join(tempHome, "i-fn2.json");
+    const c2 = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", out2]);
+    expect(c2).toBe(0);
+    const doc = parseIndex(readFileSync(out2, "utf8"));
+    if ("error" in doc) throw new Error(doc.error);
+    expect(doc.packages.leaf!["1.0.0"]!.url).toBe("https://cdn/leaf.json");
+  });
+
+  test("invalid url (not an absolute URL) is skipped", async () => {
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-badurl-"));
+    writeUrlPkg(pkgDir, "leaf-1.0.0.json", "leaf", "1.0.0", "leaf#x"); // not absolute
+    const keyPath = join(tempHome, "r-bu.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "i-bu.json");
+    const code = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(1); // only package skipped → no valid packages
+  });
+
+  test("comma-separated --packages indexes both dirs; cross-dir duplicate errors", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const dirA = mkdtempSync(join(tmpdir(), "ace-pub-a-"));
+    const dirB = mkdtempSync(join(tmpdir(), "ace-pub-b-"));
+    writeSignedPkg(dirA, "aa", "1.0.0");
+    writeSignedPkg(dirB, "bb", "1.0.0");
+    const keyPath = join(tempHome, "r-md.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "i-md.json");
+    const code = await main(["registry", "publish", "--packages", `${dirA},${dirB}`, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    if ("error" in doc) throw new Error(doc.error);
+    expect(doc.packages.aa).toBeDefined();
+    expect(doc.packages.bb).toBeDefined();
+    // cross-dir duplicate
+    writeSignedPkg(dirB, "aa", "1.0.0");
+    const out2 = join(tempHome, "i-md2.json");
+    const dup = await main(["registry", "publish", "--packages", `${dirA},${dirB}`, "--base-url", "https://pkgs", "--key", keyPath, "--out", out2]);
+    expect(dup).toBe(1);
+  });
+
+  test("unreadable listed dir is a hard error", async () => {
+    const idxKp = generateKeypair();
+    const dirA = mkdtempSync(join(tmpdir(), "ace-pub-ok-"));
+    writeSignedPkg(dirA, "aa", "1.0.0");
+    const keyPath = join(tempHome, "r-ud.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "i-ud.json");
+    const code = await main(["registry", "publish", "--packages", `${dirA},/no/such/dir/xyz`, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(1);
+  });
+
+  test("--sequence sets the sequence; rollback is refused; bad value is a parse error", async () => {
+    const { parseIndex } = await import("./registry-remote.ts");
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-seq-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    const keyPath = join(tempHome, "r-seq.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "i-seq.json");
+    const c1 = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath, "--sequence", "5"]);
+    expect(c1).toBe(0);
+    const doc = parseIndex(readFileSync(outPath, "utf8"));
+    if ("error" in doc) throw new Error(doc.error);
+    expect(doc.sequence).toBe(5);
+    // rollback against prev (5)
+    const c2 = await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath, "--sequence", "3"]);
+    expect(c2).toBe(1);
+    // bad values → parse error
+    expect("error" in parseArgs(["registry", "publish", "--packages", "d", "--base-url", "https://x", "--key", "k", "--sequence", "0"])).toBe(true);
+    expect("error" in parseArgs(["registry", "publish", "--packages", "d", "--base-url", "https://x", "--key", "k", "--sequence", "abc"])).toBe(true);
+  });
 });

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -111,6 +111,7 @@ interface RegistryArgs {
   readonly pubBaseUrl?: string;
   readonly pubKeyPath?: string;
   readonly pubOut?: string;
+  readonly pubSequence?: number;
 }
 
 type ParsedArgs = ListArgs | HelpArgs | InstallArgs | VerifyArgs | KeygenArgs | SignArgs | TrustArgs | RegistryArgs | UpdateArgs;
@@ -251,18 +252,27 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
     }
     if (sub === "publish") {
       let dir: string | undefined, base: string | undefined, key: string | undefined, out: string | undefined;
+      let seq: number | undefined;
       for (let i = 2; i < argv.length; i++) {
         if (argv[i] === "--packages") { dir = argv[++i]; if (!dir || dir.startsWith("-")) return { error: "--packages requires a value" }; }
         else if (argv[i] === "--base-url") { base = argv[++i]; if (!base || base.startsWith("-")) return { error: "--base-url requires a value" }; }
         else if (argv[i] === "--key") { key = argv[++i]; if (!key || key.startsWith("-")) return { error: "--key requires a value" }; }
         else if (argv[i] === "--out") { out = argv[++i]; if (!out || out.startsWith("-")) return { error: "--out requires a value" }; }
+        else if (argv[i] === "--sequence") {
+          const sv = argv[++i];
+          const n = Number(sv);
+          if (!sv || !Number.isInteger(n) || n <= 0) return { error: "--sequence requires a positive integer" };
+          seq = n;
+        }
         else return { error: `Unknown option for registry publish: ${argv[i]}` };
       }
       if (!dir) return { error: "registry publish requires --packages <dir>" };
       if (!base) return { error: "registry publish requires --base-url <url>" };
       if (!key) return { error: "registry publish requires --key <pem-path>" };
-      const r: RegistryArgs = { command: "registry", sub: "publish", pubPackagesDir: dir, pubBaseUrl: base, pubKeyPath: key };
-      return out !== undefined ? { ...r, pubOut: out } : r;
+      let r: RegistryArgs = { command: "registry", sub: "publish", pubPackagesDir: dir, pubBaseUrl: base, pubKeyPath: key };
+      if (out !== undefined) r = { ...r, pubOut: out };
+      if (seq !== undefined) r = { ...r, pubSequence: seq };
+      return r;
     }
     return { error: "registry requires 'add', 'list', 'remote', or 'publish'" };
   }
@@ -388,7 +398,7 @@ Usage:
   ace trust list                                 List all trusted keys
   ace registry add <name> <version> <url> [--hash <h>] Register a package in the local registry
   ace registry list                              List all registry entries
-  ace registry publish --packages <dir> --base-url <url> --key <pem> [--out <path>] Build + sign an index from a dir of packages
+  ace registry publish --packages <dir>[,<dir>...] --base-url <url> --key <pem> [--out <path>] [--sequence <n>] Build + sign an index from one or more dirs of packages
   ace registry remote add <url> --key <keyid> [--max-staleness-days <n>] Add a signed remote registry
   ace registry remote list                       List configured remote registries
   ace registry remote rm <url>                   Remove a configured remote registry
@@ -553,67 +563,85 @@ export async function main(argv: readonly string[]): Promise<number> {
           console.error("ace: publish refused: --key must be an ed25519 private key"); return 1;
         }
       } catch (e) { console.error(`ace: publish refused: invalid private key: ${(e as Error).message}`); return 1; }
-      let entries: string[];
-      try { entries = readdirSync(parsed.pubPackagesDir!).filter((f) => f.endsWith(".json")); }
-      catch (e) { console.error(`ace: publish: cannot read dir ${parsed.pubPackagesDir}: ${(e as Error).message}`); return 1; }
-      const packages: AcePackage[] = [];
-      for (const f of entries) {
-        const full = join(parsed.pubPackagesDir!, f);
-        let raw: string;
-        try { raw = readFileSync(full, "utf8"); } catch { console.error(`ace: publish: skip unreadable ${f}`); continue; }
-        let obj: unknown;
-        try { obj = JSON.parse(raw); } catch { console.error(`ace: publish: skip non-JSON ${f}`); continue; }
-        if (typeof obj !== "object" || obj === null || typeof (obj as AcePackage).manifest !== "object" || (obj as AcePackage).manifest === null
-          || typeof (obj as AcePackage).manifest.name !== "string" || typeof (obj as AcePackage).manifest.version !== "string"
-          || typeof (obj as AcePackage).files !== "object" || (obj as AcePackage).files === null) {
-          console.error(`ace: publish: skip non-package ${f}`); continue;
+      const dirs = parsed.pubPackagesDir!.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+      if (dirs.length === 0) { console.error("ace: publish refused: --packages requires at least one directory"); return 1; }
+      const packages: { pkg: AcePackage; url?: string }[] = [];
+      for (const d of dirs) {
+        let entries: string[];
+        try { entries = readdirSync(d).filter((f) => f.endsWith(".json")); }
+        catch (e) { console.error(`ace: publish: cannot read dir ${d}: ${(e as Error).message}`); return 1; }
+        for (const f of entries) {
+          const full = join(d, f);
+          let raw: string;
+          try { raw = readFileSync(full, "utf8"); } catch { console.error(`ace: publish: skip unreadable ${f}`); continue; }
+          let obj: unknown;
+          try { obj = JSON.parse(raw); } catch { console.error(`ace: publish: skip non-JSON ${f}`); continue; }
+          if (typeof obj !== "object" || obj === null || typeof (obj as AcePackage).manifest !== "object" || (obj as AcePackage).manifest === null
+            || typeof (obj as AcePackage).manifest.name !== "string" || typeof (obj as AcePackage).manifest.version !== "string"
+            || typeof (obj as AcePackage).files !== "object" || (obj as AcePackage).files === null) {
+            console.error(`ace: publish: skip non-package ${f}`); continue;
+          }
+          // P2-C: a package whose content_hash is missing or does not match its files would be indexed
+          // but fail the consumer's content-hash gate. Skip + warn (consistent with the non-package skip).
+          if (typeof (obj as AcePackage).manifest.content_hash !== "string") {
+            console.error(`ace: publish: skip ${f} — missing manifest.content_hash`); continue;
+          }
+          const fh = contentHash(new TextEncoder().encode(JSON.stringify((obj as AcePackage).files)));
+          if (fh !== (obj as AcePackage).manifest.content_hash) {
+            console.error(`ace: publish: skip ${f} — content_hash does not match files`); continue;
+          }
+          // Optional top-level url override (publish-only, outside the signed manifest). When present
+          // it sets the consumer URL directly and relaxes the <name>-<version>.json filename guard for
+          // this package. Must be a non-empty, absolute URL or the package is skipped.
+          let urlOverride: string | undefined;
+          const rawUrl = (obj as { url?: unknown }).url;
+          if (rawUrl !== undefined) {
+            if (typeof rawUrl !== "string" || rawUrl.length === 0) { console.error(`ace: publish: skip ${f} — url must be a non-empty string`); continue; }
+            try { new URL(rawUrl); } catch { console.error(`ace: publish: skip ${f} — url is not an absolute URL: ${rawUrl}`); continue; }
+            urlOverride = rawUrl;
+          }
+          // filename guard applies ONLY when there is no url override (the derived URL depends on the basename)
+          if (urlOverride === undefined) {
+            const expectedFile = `${(obj as AcePackage).manifest.name}-${(obj as AcePackage).manifest.version}.json`;
+            if (f !== expectedFile) {
+              console.error(`ace: publish: skip ${f} — filename must be ${expectedFile} to match its derived consumer URL`); continue;
+            }
+          }
+          const deps = (obj as AcePackage).manifest.dependencies;
+          if (deps !== undefined && !Array.isArray(deps)) {
+            console.error(`ace: publish: skip ${f} — manifest.dependencies must be an array`); continue;
+          }
+          // P2: every files value must be a string — installPackage's writeFileSync(dest, contents)
+          // throws on non-string values, so a self-verified index could point at an un-installable
+          // package. Skip + warn (consistent with the other scan skips).
+          const fileVals = Object.values((obj as AcePackage).files as Record<string, unknown>);
+          if (fileVals.some((v) => typeof v !== "string")) {
+            console.error(`ace: publish: skip ${f} — every file value must be a string`); continue;
+          }
+          // P2: package name/version must be URL-safe — the derived consumer URL is
+          // <base>/<name>-<version>.json, so a '#' or '?' (or path sep / control char) would break or
+          // redirect the fetched URL. Applies in both cases (the package_hash store key is name-keyed).
+          const nm = (obj as AcePackage).manifest.name;
+          const ver = (obj as AcePackage).manifest.version;
+          if (/[\x00-\x20#?%/\\]/.test(nm) || /[\x00-\x20#?%/\\]/.test(ver)) {
+            console.error(`ace: publish: skip ${f} — name/version has a URL-unsafe character`); continue;
+          }
+          // P2: dependency edges must be well-formed (matching the consumer's AceDependency shape),
+          // else a consumer resolve would break on a self-verified index.
+          const depEdges = (obj as AcePackage).manifest.dependencies;
+          if (Array.isArray(depEdges) && !depEdges.every(isValidDepEdge)) {
+            console.error(`ace: publish: skip ${f} — malformed dependency edge`); continue;
+          }
+          // P2: reuse the consumer's path guard — a package with an unsafe files key (../ or absolute)
+          // would index but be rejected/unsafe at install. Skip + warn.
+          const unsafePath = validatePackagePaths(obj as AcePackage);
+          if (unsafePath !== null) {
+            console.error(`ace: publish: skip ${f} — unsafe file path: ${unsafePath}`); continue;
+          }
+          packages.push(urlOverride !== undefined ? { pkg: obj as AcePackage, url: urlOverride } : { pkg: obj as AcePackage });
         }
-        // P2-C: a package whose content_hash is missing or does not match its files would be indexed
-        // but fail the consumer's content-hash gate. Skip + warn (consistent with the non-package skip).
-        if (typeof (obj as AcePackage).manifest.content_hash !== "string") {
-          console.error(`ace: publish: skip ${f} — missing manifest.content_hash`); continue;
-        }
-        const fh = contentHash(new TextEncoder().encode(JSON.stringify((obj as AcePackage).files)));
-        if (fh !== (obj as AcePackage).manifest.content_hash) {
-          console.error(`ace: publish: skip ${f} — content_hash does not match files`); continue;
-        }
-        const expectedFile = `${(obj as AcePackage).manifest.name}-${(obj as AcePackage).manifest.version}.json`;
-        if (f !== expectedFile) {
-          console.error(`ace: publish: skip ${f} — filename must be ${expectedFile} to match its derived consumer URL`); continue;
-        }
-        const deps = (obj as AcePackage).manifest.dependencies;
-        if (deps !== undefined && !Array.isArray(deps)) {
-          console.error(`ace: publish: skip ${f} — manifest.dependencies must be an array`); continue;
-        }
-        // P2: every files value must be a string — installPackage's writeFileSync(dest, contents)
-        // throws on non-string values, so a self-verified index could point at an un-installable
-        // package. Skip + warn (consistent with the other scan skips).
-        const fileVals = Object.values((obj as AcePackage).files as Record<string, unknown>);
-        if (fileVals.some((v) => typeof v !== "string")) {
-          console.error(`ace: publish: skip ${f} — every file value must be a string`); continue;
-        }
-        // P2: package name/version must be URL-safe — the consumer URL is <base>/<name>-<version>.json,
-        // so a '#' or '?' (or path sep / control char) would break or redirect the fetched URL.
-        const nm = (obj as AcePackage).manifest.name;
-        const ver = (obj as AcePackage).manifest.version;
-        if (/[\x00-\x20#?%/\\]/.test(nm) || /[\x00-\x20#?%/\\]/.test(ver)) {
-          console.error(`ace: publish: skip ${f} — name/version has a URL-unsafe character`); continue;
-        }
-        // P2: dependency edges must be well-formed (matching the consumer's AceDependency shape),
-        // else a consumer resolve would break on a self-verified index.
-        const depEdges = (obj as AcePackage).manifest.dependencies;
-        if (Array.isArray(depEdges) && !depEdges.every(isValidDepEdge)) {
-          console.error(`ace: publish: skip ${f} — malformed dependency edge`); continue;
-        }
-        // P2: reuse the consumer's path guard — a package with an unsafe files key (../ or absolute)
-        // would index but be rejected/unsafe at install. Skip + warn.
-        const unsafePath = validatePackagePaths(obj as AcePackage);
-        if (unsafePath !== null) {
-          console.error(`ace: publish: skip ${f} — unsafe file path: ${unsafePath}`); continue;
-        }
-        packages.push(obj as AcePackage);
       }
-      if (packages.length === 0) { console.error(`ace: publish refused: no valid packages in ${parsed.pubPackagesDir}`); return 1; }
+      if (packages.length === 0) { console.error(`ace: publish refused: no valid packages in ${dirs.join(", ")}`); return 1; }
       const outPath = parsed.pubOut ?? "index.json";
       let prev: IndexDoc | null = null;
       if (existsSync(outPath)) {
@@ -628,7 +656,7 @@ export async function main(argv: readonly string[]): Promise<number> {
         if (!prevVerify.ok) { console.error(`ace: publish refused: existing ${outPath} signature does not verify under --key (${prevVerify.reason}) — refusing to auto-bump from an untrusted index; fix or remove it`); return 1; }
         prev = p;
       }
-      const seq = nextSequence(prev);
+      const seq = parsed.pubSequence ?? nextSequence(prev);
       // Anti-rollback guard (defense-in-depth): unreachable while sequence is auto-bumped (+1),
       // but protects the deferred explicit --sequence flag from emitting a non-increasing index.
       if (prev && seq <= prev.sequence) { console.error(`ace: publish refused: sequence ${seq} <= prev ${prev.sequence}`); return 1; }

--- a/tools/ace/registry-publish.test.ts
+++ b/tools/ace/registry-publish.test.ts
@@ -32,7 +32,7 @@ describe("buildIndexDoc", () => {
   const issuedAt = "2026-06-01T12:00:00Z";
   test("assembles url + package_hash per package, signs, self-verifies", () => {
     const p = pkg("leaf", "1.0.0");
-    const doc = buildIndexDoc({ packages: [p], baseUrl: "https://pkgs", sequence: 3, issuedAt, privatePem: kp.privatePem });
+    const doc = buildIndexDoc({ packages: [{ pkg: p }], baseUrl: "https://pkgs", sequence: 3, issuedAt, privatePem: kp.privatePem });
     expect("error" in doc).toBe(false);
     if ("error" in doc) return;
     expect(doc.sequence).toBe(3);
@@ -47,23 +47,44 @@ describe("buildIndexDoc", () => {
   });
 
   test.each(["__proto__", "constructor", "prototype"])("rejects reserved package name %s", (bad) => {
-    const doc = buildIndexDoc({ packages: [pkg(bad, "1.0.0")], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    const doc = buildIndexDoc({ packages: [{ pkg: pkg(bad, "1.0.0") }], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
     expect("error" in doc).toBe(true);
   });
   test("rejects reserved package version", () => {
-    const doc = buildIndexDoc({ packages: [pkg("ok", "__proto__")], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    const doc = buildIndexDoc({ packages: [{ pkg: pkg("ok", "__proto__") }], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
     expect("error" in doc).toBe(true);
   });
 
   test("duplicate name@version → error", () => {
-    const doc = buildIndexDoc({ packages: [pkg("leaf", "1.0.0"), pkg("leaf", "1.0.0")], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    const doc = buildIndexDoc({ packages: [{ pkg: pkg("leaf", "1.0.0") }, { pkg: pkg("leaf", "1.0.0") }], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
     expect("error" in doc).toBe(true);
   });
 
   test("packages sorted by name then version regardless of input order", () => {
-    const doc = buildIndexDoc({ packages: [pkg("zeta", "1.0.0"), pkg("alpha", "1.0.0")], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    const doc = buildIndexDoc({ packages: [{ pkg: pkg("zeta", "1.0.0") }, { pkg: pkg("alpha", "1.0.0") }], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
     expect("error" in doc).toBe(false);
     if ("error" in doc) return;
     expect(Object.keys(doc.packages)).toEqual(["alpha", "zeta"]);
+  });
+
+  test("per-package url override is used; absent falls back to base-url", () => {
+    const a = pkg("alpha", "1.0.0");
+    const b = pkg("beta", "1.0.0");
+    const doc = buildIndexDoc({
+      packages: [{ pkg: a, url: "https://cdn.example/alpha-v1.json" }, { pkg: b }],
+      baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem,
+    });
+    expect("error" in doc).toBe(false);
+    if ("error" in doc) return;
+    expect(doc.packages.alpha!["1.0.0"]!.url).toBe("https://cdn.example/alpha-v1.json");
+    expect(doc.packages.beta!["1.0.0"]!.url).toBe("https://pkgs/beta-1.0.0.json");
+  });
+
+  test("url override does not change package_hash", () => {
+    const a = pkg("alpha", "1.0.0");
+    const withUrl = buildIndexDoc({ packages: [{ pkg: a, url: "https://cdn/x.json" }], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    const without = buildIndexDoc({ packages: [{ pkg: a }], baseUrl: "https://pkgs", sequence: 1, issuedAt, privatePem: kp.privatePem });
+    if ("error" in withUrl || "error" in without) throw new Error("unexpected");
+    expect(withUrl.packages.alpha!["1.0.0"]!.package_hash).toBe(without.packages.alpha!["1.0.0"]!.package_hash);
   });
 });

--- a/tools/ace/registry-publish.ts
+++ b/tools/ace/registry-publish.ts
@@ -22,13 +22,14 @@ export function nextSequence(prev: IndexDoc | null): number {
 const RESERVED_IDENTITY_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 /** Assemble + sign an index doc from already-read packages. Duplicate name@version → error. */
 export function buildIndexDoc(args: {
-  packages: AcePackage[]; baseUrl: string; sequence: number; issuedAt: string; privatePem: string;
+  packages: ReadonlyArray<{ pkg: AcePackage; url?: string }>; baseUrl: string; sequence: number; issuedAt: string; privatePem: string;
 }): IndexDoc | { error: string } {
   // Null-prototype map: a package name like "__proto__" cannot pollute via bracket-assign.
   const packages: Record<string, Record<string, RegistryEntry>> = Object.create(null);
   const sorted = [...args.packages].sort((a, b) =>
-    a.manifest.name.localeCompare(b.manifest.name) || a.manifest.version.localeCompare(b.manifest.version));
-  for (const pkg of sorted) {
+    a.pkg.manifest.name.localeCompare(b.pkg.manifest.name) || a.pkg.manifest.version.localeCompare(b.pkg.manifest.version));
+  for (const entry of sorted) {
+    const pkg = entry.pkg;
     const name = pkg.manifest.name;
     const version = pkg.manifest.version;
     const versions = packages[name] ?? (Object.create(null) as Record<string, RegistryEntry>);
@@ -36,7 +37,8 @@ export function buildIndexDoc(args: {
       return { error: `reserved package identity not allowed: ${name}@${version}` };
     }
     if (versions[version] !== undefined) return { error: `duplicate package ${name}@${version}` };
-    versions[version] = { url: joinUrl(args.baseUrl, `${name}-${version}.json`), package_hash: packageHash(pkg) };
+    const url = entry.url ?? joinUrl(args.baseUrl, `${name}-${version}.json`);
+    versions[version] = { url, package_hash: packageHash(pkg) };
     packages[name] = versions;
   }
   const content: IndexSignableContent = { format_version: 1, sequence: args.sequence, issued_at: args.issuedAt, packages };


### PR DESCRIPTION
Implements **slice 6.2** of `ace registry publish` (B-0980 deferred enhancements). Spec: #6456. Built subagent-driven per `docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice6.2-implementation-plan.md`.

## Three enhancements
- **Per-package `url` field** — optional top-level `url` (sibling of `manifest`/`files`, outside the signed manifest) overrides the derived `<base>/<name>-<version>.json`. Excluded from `package_hash` (hashes manifest+files only — verified), ignored by signature/content_hash gates, validated as an absolute URL (invalid → skip+warn). A package WITH a `url` is exempt from the `<name>-<version>.json` filename guard (the override decouples URL from filename); WITHOUT a `url` the filename guard still applies. All other scan guards (reserved-key, URL-unsafe identity, deps-array, dep-edge, file-values, `validatePackagePaths`) apply in both cases.
- **Comma-separated `--packages a,b,c`** — multi-directory scan + merge; each dir must be readable (else hard error); cross-dir duplicate `name@version` → existing duplicate guard. Single dir unchanged.
- **Explicit `--sequence <n>`** — overrides auto-bump; positive integer (else parse error); the anti-rollback guard goes live (`n <= prev.sequence` → refuse).

**ETag/Last-Modified sidecar: dropped** (consumer conditional-GET + 6.1 deterministic output already cover it).

## Mechanics
- `buildIndexDoc` input shape: `AcePackage[]` → `ReadonlyArray<{ pkg: AcePackage; url? }>` (per-entry url; `package_hash` unchanged).
- ace.ts: parse (`--packages` comma-split + `--sequence` positive-int), handler (multi-dir loop, read+validate top-level `url`, conditional filename guard, sequence override).

## Verification
- `bun test tools/ace/` 291 pass / 0 fail (8 net-new: 2 unit url + 6 e2e); RED-before/GREEN-after + false-green confirmed on the url path.
- strict `tsc --noEmit` exit 0; markdownlint clean; pure LF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)