### PR TITLE
fix(resume-fsharp): serialize kont top-last to byte-lock with the TS reference

### DIFF
--- a/src/Core/Resume.fs
+++ b/src/Core/Resume.fs
@@ -326,7 +326,10 @@ module Resume =
     /// Serialize a suspended `SagaState` to a canonical string for persistence.
     let serializeState (state: SagaState) : Result<string, ResumeFeedback> =
         try
-            let kont = state.Kont |> List.map emitFrame |> String.concat ","
+            // The in-memory Kont is a cons-stack (head = top = innermost / next-to-run); the
+            // cross-oracle wire (TS reference) serializes the kont TOP-LAST (outermost frame
+            // first, innermost last), so reverse before emitting to match the byte contract.
+            let kont = state.Kont |> List.rev |> List.map emitFrame |> String.concat ","
             let args = state.Awaiting.Args |> List.map emitConstValue |> String.concat ","
 
             Ok(
@@ -483,7 +486,9 @@ module Resume =
                     | _ -> bad "unsupported state version"
                 | _ -> bad "state version is missing or not a number"
 
-                let kont = readArray (prop root "kont") "kont" |> List.map readFrame
+                // The wire stores the kont TOP-LAST (see serializeState); reverse after reading
+                // to restore the in-memory cons-stack orientation (head = top = innermost).
+                let kont = readArray (prop root "kont") "kont" |> List.map readFrame |> List.rev
 
                 let aw =
                     match root.TryGetProperty "awaiting" with

--- a/tests/Tests.FSharp/Bonsai/Resume.Tests.fs
+++ b/tests/Tests.FSharp/Bonsai/Resume.Tests.fs
@@ -77,6 +77,9 @@ type private Trace =
       Bindings: Env
       ActivityResults: ConstValue list
       ExpectedSuspensions: Activity list
+      // the canonical serializeState bytes the TS reference emits at each suspension, in order —
+      // the cross-oracle STATE-BYTE lock this F# ferry must reproduce verbatim (kont top-last)
+      ExpectedStateAtSuspension: string list
       ExpectedFinal: ConstValue }
 
 let private goldenTraces () : Trace list =
@@ -94,6 +97,8 @@ let private goldenTraces () : Trace list =
             Bindings = bindings
             ActivityResults = [ for a in c.GetProperty("activityResults").EnumerateArray() -> constValueOfJson a ]
             ExpectedSuspensions = [ for s in c.GetProperty("expectedSuspensions").EnumerateArray() -> activityOfJson s ]
+            ExpectedStateAtSuspension =
+              [ for s in c.GetProperty("expectedStateAtSuspension").EnumerateArray() -> s.GetString() ]
             ExpectedFinal = constValueOfJson (c.GetProperty "expectedFinal") } ]
 
 let private stepOk (r: Result<SagaStep, ResumeFeedback>) : SagaStep =
@@ -126,6 +131,9 @@ let ``F# resume replays every shared golden saga-trace (restore-not-replay at ea
                 Assert.Equal(tr.ExpectedSuspensions.[i], activity)
                 // persist -> re-parse -> resume from the RESTORED state (not a replay)
                 let ser = strOk (serializeState state)
+                // STATE-BYTE LOCK: the persisted continuation must equal the TS reference bytes
+                // (the kont serializes top-last — innermost frame last in the array)
+                Assert.Equal(tr.ExpectedStateAtSuspension.[i], ser)
                 let restored = stateOk (parseState ser)
                 // canonical round-trip is byte-stable
                 Assert.Equal(ser, strOk (serializeState restored))


### PR DESCRIPTION
## What

Makes the **F# resume STATE wire byte-identical** to the TS reference on multi-frame konts, and wires the byte-lock assertion (landed #6459) into the F# golden replay.

## The bug

The in-memory `Kont` is a cons-stack — **head = top = innermost / next-to-run** (`run` pushes with `:: stack`, pops `top :: rest`). `serializeState` emitted it in raw list order (**top-first**), but the cross-oracle wire is **top-last** (outermost frame first, innermost last): TS array, C# `IReadOnlyList`, Rust `Vec` all serialize top-last. So an F#-persisted saga byte-compared against — or resumed by — another oracle silently disagreed.

Only **multi-frame** konts diverged; single-frame konts are order-invariant, so the per-oracle round-trip + behavioral tests passed and masked it. The discriminating trace is `cond_branch_on_activity` (2-frame kont: `branch` + `evalRight`).

## The fix (symmetric — round-trip preserved)

- `serializeState`: `state.Kont |> List.rev |> List.map emitFrame` (emit top-last)
- `parseState`: `... |> List.map readFrame |> List.rev` (restore in-memory head = top)

In-memory orientation is unchanged; only the wire order flips. Serialize-then-parse still round-trips byte-stable.

## Verification (TDD — the assertion has teeth)

The F# golden replay now loads `expectedStateAtSuspension` and asserts `serializeState(state) === expectedStateAtSuspension[i]` at every suspension.

- **Pre-fix:** failed on `cond_branch_on_activity` — Expected `{"kont":[{"k":"branch",...` vs Actual `{"kont":[{"k":"evalRight",...` (9 pass / 1 fail).
- **Post-fix:** all **10** F# resume tests pass, **0 warnings** (TreatWarningsAsErrors).

## Follow-up (separate PR)

Add the same byte-equality assertion to the C#/Rust resume cross-verify tests — both already serialize top-last by construction (`IReadOnlyList`/`Vec`), so that's assertion-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
