### PR TITLE
test(resume): assert STATE-BYTE lock in C# + Rust oracles (completes 4-oracle byte-lock)

### DIFF
--- a/src/Core.Rust.Resume/tests/resume_cross_verify.rs
+++ b/src/Core.Rust.Resume/tests/resume_cross_verify.rs
@@ -101,6 +101,14 @@ fn rust_resume_replays_every_shared_golden_trace_restore_not_replay() {
         }
         let activity_results: Vec<ConstValue> = tr["activityResults"].as_array().expect("activityResults").iter().map(const_of_json).collect();
         let expected_suspensions: Vec<Activity> = tr["expectedSuspensions"].as_array().expect("expectedSuspensions").iter().map(activity_of_json).collect();
+        // the canonical serialize_state bytes the TS reference emits at each suspension, in order —
+        // the cross-oracle STATE-BYTE lock this Rust oracle must reproduce verbatim (kont top-last)
+        let expected_state_at_suspension: Vec<&str> = tr["expectedStateAtSuspension"]
+            .as_array()
+            .expect("expectedStateAtSuspension")
+            .iter()
+            .map(|s| s.as_str().expect("expectedStateAtSuspension entry"))
+            .collect();
         let expected_final = const_of_json(&tr["expectedFinal"]);
 
         let mut step = start(&program, &bindings).unwrap_or_else(|f| panic!("{name}: start: {f:?}"));
@@ -111,6 +119,9 @@ fn rust_resume_replays_every_shared_golden_trace_restore_not_replay() {
                     assert_eq!(*exp, activity, "{name}: suspension {i}");
                     // persist -> re-parse -> resume from the RESTORED state (not a replay)
                     let ser = serialize_state(&state).unwrap_or_else(|f| panic!("{name}: serialize: {f:?}"));
+                    // STATE-BYTE LOCK: the persisted continuation must equal the TS reference bytes
+                    // (the kont serializes top-last — innermost frame last in the array)
+                    assert_eq!(expected_state_at_suspension[i], ser.as_str(), "{name}: state byte-lock at suspension {i}");
                     let restored = parse_state(&ser).unwrap_or_else(|f| panic!("{name}: parse: {f:?}"));
                     assert_eq!(ser, serialize_state(&restored).expect("re-serialize"), "{name}: round-trip byte-stable");
                     step = resume(restored, activity_results[i].clone()).unwrap_or_else(|f| panic!("{name}: resume: {f:?}"));

--- a/tests/Tests.CSharp/Resume/ResumeTests.cs
+++ b/tests/Tests.CSharp/Resume/ResumeTests.cs
@@ -131,6 +131,9 @@ public class ResumeTests
 
             var activityResults = tr.GetProperty("activityResults").EnumerateArray().Select(ConstOfJson).ToList();
             var expectedSuspensions = tr.GetProperty("expectedSuspensions").EnumerateArray().Select(ActivityOfJson).ToList();
+            // the canonical serializeState bytes the TS reference emits at each suspension, in order —
+            // the cross-oracle STATE-BYTE lock this C# oracle must reproduce verbatim (kont top-last)
+            var expectedStateAtSuspension = tr.GetProperty("expectedStateAtSuspension").EnumerateArray().Select(e => e.GetString()!).ToList();
             var expectedFinal = ConstOfJson(tr.GetProperty("expectedFinal"));
 
             var step = StepOk(ResumeEngine.Start(program, bindings));
@@ -142,6 +145,9 @@ public class ResumeTests
 
                 // persist -> re-parse -> resume from the RESTORED state (not a replay)
                 var ser = StrOk(ResumeEngine.SerializeState(suspended.State));
+                // STATE-BYTE LOCK: the persisted continuation must equal the TS reference bytes
+                // (the kont serializes top-last — innermost frame last in the array)
+                Assert.Equal(expectedStateAtSuspension[i], ser);
                 var restored = StateOk(ResumeEngine.ParseState(ser));
                 Assert.Equal(ser, StrOk(ResumeEngine.SerializeState(restored))); // round-trip byte-stable
                 step = StepOk(ResumeEngine.Resume(restored, activityResults[i]));


### PR DESCRIPTION
## What

Completes the cross-oracle resume **STATE byte-lock** by wiring the byte-equality assertion into the C# and Rust resume cross-verify replays:
`serializeState(state) === expectedStateAtSuspension[i]` at every suspension.

The arc:
- **TS** authored the canonical `expectedStateAtSuspension` bytes — #6459
- **F#** fixed to serialize the kont top-last (cons-list needed `List.rev`) — #6463
- **C# + Rust** assert the same bytes — this PR

## No production change

C# (`IReadOnlyList`) and Rust (`Vec`) already serialize the kont **top-last by construction**, so the assertion *confirms parity* rather than fixing a divergence (unlike F#). The 2-frame `cond_branch_on_activity` kont is the discriminating case; both reproduce the TS reference bytes verbatim.

## Verification

- `dotnet test --filter Resume` → **9 pass / 0 fail** (0 warnings, TreatWarningsAsErrors)
- `cargo test` → **9 pass / 0 fail**
- `cargo clippy --all-targets -- -D warnings` → clean

With this, all four resume oracles (TS/F#/C#/Rust) are byte-locked on the persisted `SagaState`, not merely behaviorally equivalent — a saga persisted by any oracle restores byte-identically in every other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)