### PR TITLE
feat(gset-fsharp): generic-math additive-monoid surface (Zero + (+)) on F# GSet

### DIFF
--- a/src/Core/GSet.fs
+++ b/src/Core/GSet.fs
@@ -38,6 +38,39 @@ type GSet<'T when 'T : comparison> =
 
     static member Empty : GSet<'T> = GSet(ImmutableArray<'T>.Empty)
 
+    /// The additive-monoid identity (generic-math `Zero`) — an alias for `Empty`,
+    /// recognized by F# SRTP / `LanguagePrimitives.GenericZero` + generic numeric
+    /// code. G-Set is an additive, **commutative + idempotent** monoid (identity +
+    /// associative `union`, **no inverse**), so it surfaces `Zero` + `(+)` only —
+    /// never `INumber` (no negation / order / multiplication). `(+)` IS `union`.
+    static member Zero : GSet<'T> = GSet<'T>.Empty
+
+    /// The additive operator (generic-math `(+)`): the CRDT `union` merge of two
+    /// sorted-unique runs, kept sorted-unique. Idempotent + commutative +
+    /// associative. The canonical home of the merge; `GSet.union` delegates here.
+    static member (+) (a: GSet<'T>, b: GSet<'T>) : GSet<'T> =
+        let xa = if a.items.IsDefault then ImmutableArray<'T>.Empty else a.items
+        let xb = if b.items.IsDefault then ImmutableArray<'T>.Empty else b.items
+        if xa.IsEmpty then GSet<'T>(xb)
+        elif xb.IsEmpty then GSet<'T>(xa)
+        else
+            let out = ImmutableArray.CreateBuilder<'T>(xa.Length + xb.Length)
+            let mutable i = 0
+            let mutable j = 0
+            while i < xa.Length && j < xb.Length do
+                let c = Comparer<'T>.Default.Compare(xa.[i], xb.[j])
+                if c < 0 then
+                    out.Add(xa.[i]); i <- i + 1
+                elif c > 0 then
+                    out.Add(xb.[j]); j <- j + 1
+                else
+                    out.Add(xa.[i]); i <- i + 1; j <- j + 1 // duplicate → keep one
+            while i < xa.Length do
+                out.Add(xa.[i]); i <- i + 1
+            while j < xb.Length do
+                out.Add(xb.[j]); j <- j + 1
+            GSet<'T>(out.ToImmutable())
+
     member this.Count =
         if this.items.IsDefault then 0 else this.items.Length
 
@@ -128,29 +161,9 @@ module GSet =
     /// The CRDT merge: the union of two sorted-unique runs, kept sorted-unique.
     /// Idempotent (`union a a = a`), commutative (`union a b = union b a`), and
     /// associative — verified by the law tests + the cross-language golden
-    /// vector.
-    let union (a: GSet<'T>) (b: GSet<'T>) : GSet<'T> =
-        let xa = if a.items.IsDefault then ImmutableArray<'T>.Empty else a.items
-        let xb = if b.items.IsDefault then ImmutableArray<'T>.Empty else b.items
-        if xa.IsEmpty then GSet<'T>(xb)
-        elif xb.IsEmpty then GSet<'T>(xa)
-        else
-            let out = ImmutableArray.CreateBuilder<'T>(xa.Length + xb.Length)
-            let mutable i = 0
-            let mutable j = 0
-            while i < xa.Length && j < xb.Length do
-                let c = Comparer<'T>.Default.Compare(xa.[i], xb.[j])
-                if c < 0 then
-                    out.Add(xa.[i]); i <- i + 1
-                elif c > 0 then
-                    out.Add(xb.[j]); j <- j + 1
-                else
-                    out.Add(xa.[i]); i <- i + 1; j <- j + 1 // duplicate → keep one
-            while i < xa.Length do
-                out.Add(xa.[i]); i <- i + 1
-            while j < xb.Length do
-                out.Add(xb.[j]); j <- j + 1
-            GSet<'T>(out.ToImmutable())
+    /// vector. Delegates to the type's generic-math `(+)` operator: same merge,
+    /// one canonical implementation (so `union` and `(+)` can never drift).
+    let union (a: GSet<'T>) (b: GSet<'T>) : GSet<'T> = a + b
 
     /// Add one element (`union` with a singleton). Idempotent: adding a present
     /// element returns an equal set.

--- a/tests/Tests.FSharp/Algebra/GSet.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/GSet.Tests.fs
@@ -72,10 +72,12 @@ let ``custom equality: order-independent inputs are equal + hash-stable`` () =
 // numeric code (`GenericZero`, SRTP-constrained folds) can aggregate a G-Set.
 
 [<Fact>]
-let ``(+) equals union`` () =
+let ``(+) merges to the explicit union result (semantics, not just delegation)`` () =
+    // assert the actual merged content, not `(+) = union` (which is tautological now that
+    // `union` delegates to `(+)`) — proves `(+)` produces the correct sorted-unique merge
     let a = GSet.ofSeq [ "a"; "b" ]
     let b = GSet.ofSeq [ "b"; "c" ]
-    (a + b) |> should equal (GSet.union a b)
+    (a + b) |> GSet.toList |> should equal [ "a"; "b"; "c" ]
 
 [<Fact>]
 let ``Zero is the additive identity: Zero + a = a and a + Zero = a`` () =

--- a/tests/Tests.FSharp/Algebra/GSet.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/GSet.Tests.fs
@@ -65,6 +65,38 @@ let ``custom equality: order-independent inputs are equal + hash-stable`` () =
     a.GetHashCode() |> should equal (b.GetHashCode())
     (a = GSet.ofSeq [ "a"; "b" ]) |> should equal false
 
+// ─── generic-math additive-monoid surface (Zero + (+)) ─────────────────────
+// G-Set is an additive, commutative + idempotent monoid, so it surfaces the
+// native F# generic-math idiom `Zero` + `(+)` (NOT `INumber` — no inverse /
+// order / product). These lock `(+)` to `union` and `Zero` to `empty` so generic
+// numeric code (`GenericZero`, SRTP-constrained folds) can aggregate a G-Set.
+
+[<Fact>]
+let ``(+) equals union`` () =
+    let a = GSet.ofSeq [ "a"; "b" ]
+    let b = GSet.ofSeq [ "b"; "c" ]
+    (a + b) |> should equal (GSet.union a b)
+
+[<Fact>]
+let ``Zero is the additive identity: Zero + a = a and a + Zero = a`` () =
+    let a = GSet.ofSeq [ "a"; "b" ]
+    (GSet<string>.Zero + a) |> should equal a
+    (a + GSet<string>.Zero) |> should equal a
+
+[<Fact>]
+let ``Zero equals empty and is recognized by GenericZero`` () =
+    GSet<string>.Zero |> should equal GSet.empty<string>
+    LanguagePrimitives.GenericZero<GSet<string>> |> should equal GSet.empty<string>
+
+[<Fact>]
+let ``(+) monoid laws: idempotent + commutative + associative`` () =
+    let a = GSet.ofSeq [ "a"; "b" ]
+    let b = GSet.ofSeq [ "b"; "c" ]
+    let c = GSet.ofSeq [ "c"; "d" ]
+    (a + a) |> should equal a // idempotent
+    (a + b) |> should equal (b + a) // commutative
+    ((a + b) + c) |> should equal (a + (b + c)) // associative
+
 // ─── Shared golden vector (cross-language parity lock) ─────────────────────
 
 /// Walk up from the test assembly to the repo root (Zeta.sln sentinel) — same


### PR DESCRIPTION
## What

First slice of the **numerics-ladder → generic-math interfaces** retrofit (registry directive: *"zset and gset can be System.Numerics since they're algebra — yes"*). Adds the native F# generic-math surface to `GSet`.

G-Set is an **additive, commutative + idempotent monoid** (identity + associative `union`, **no inverse**) — so per [`numerical-algebra-shaped-into-the-generic-math-interface`](.claude/rules/numerical-algebra-shaped-into-the-generic-math-interface-per-language-idiom.md) it surfaces **`Zero` + `(+)` only**, never `INumber` (no negation / order / multiplication). F#-first per B-0969.

## Changes

- **`static member Zero`** (= `Empty`) — recognized by SRTP / `LanguagePrimitives.GenericZero`, so generic numeric code can fold a G-Set.
- **`static member (+)`** — the CRDT `union` merge, moved onto the type as its canonical home; module `GSet.union` now **delegates** to it (same merge, one implementation, can't drift). The operator lives on the type (not a post-module augmentation) so SRTP `(+)` resolves it — matching existing F# precedent (`NovelMath` TropicalWeight, `Semiring`).
- **Laws**: `(+)` ≡ `union`; `Zero` is the additive identity; `Zero` = `empty` + `GenericZero` recognition; `(+)` idempotent + commutative + associative.

Public API unchanged (`GSet.union`/`add`/etc. all intact; `union` just delegates).

## Verification

- `dotnet build -c Release` → **0 warnings / 0 errors** (TreatWarningsAsErrors)
- `dotnet test --filter GSet` → **13 pass / 0 fail** (9 original + 4 new generic-math)

## Next slices (separate PRs)

C# (`IAdditiveIdentity` + `IAdditionOperators` IWSAM) · Rust (`Add` + a `Zero`) · TS (`Monoid` record) for G-Set — then the same for Bag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)