### PR TITLE
feat(gset-csharp): generic-math additive-monoid surface (IAdditiveIdentity + IAdditionOperators)

### DIFF
--- a/src/Core.CSharp/GSet.cs
+++ b/src/Core.CSharp/GSet.cs
@@ -207,7 +207,7 @@ public sealed class GSet<T> :
         "Design",
         "CA1000:Do not declare static members on generic types",
         Justification = "IAdditiveIdentity<TSelf,TResult> requires a static AdditiveIdentity member on the generic type; CA1000 predates static-abstract interface members (IWSAM) and does not apply to generic-math interface implementations.")]
-    public static GSet<T> AdditiveIdentity => GSet.Empty<T>();
+    public static GSet<T> AdditiveIdentity { get; } = GSet.Empty<T>();
 
     /// <summary>
     /// The additive operator (generic-math <c>+</c>): the CRDT <see cref="Union"/> merge.
@@ -225,8 +225,8 @@ public sealed class GSet<T> :
 
         // The additive identity is the empty set; it must absorb under ANY comparer for the
         // monoid identity law to hold (AdditiveIdentity uses the default comparer, but a set
-        // may carry a custom one). Empty has no elements, so its ordering is irrelevant — short
-        // -circuit before Union's deliberate same-comparer check (which guards non-empty merges).
+        // may carry a custom one). Empty has no elements, so its ordering is irrelevant —
+        // short-circuit before Union's deliberate same-comparer check (guards non-empty merges).
         if (left.IsEmpty)
         {
             return right;

--- a/src/Core.CSharp/GSet.cs
+++ b/src/Core.CSharp/GSet.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 
 namespace Zeta.Core.CSharp;
 
@@ -80,7 +82,10 @@ public static class GSet
 /// cross-language parity.
 /// </remarks>
 /// <typeparam name="T">The element type.</typeparam>
-public sealed class GSet<T> : IEquatable<GSet<T>>
+public sealed class GSet<T> :
+    IEquatable<GSet<T>>,
+    IAdditiveIdentity<GSet<T>, GSet<T>>,
+    IAdditionOperators<GSet<T>, GSet<T>, GSet<T>>
 {
     private readonly ImmutableArray<T> _items;
     private readonly IComparer<T> _comparer;
@@ -189,6 +194,50 @@ public sealed class GSet<T> : IEquatable<GSet<T>>
         }
 
         return new GSet<T>(builder.ToImmutable(), _comparer);
+    }
+
+    /// <summary>
+    /// The additive-monoid identity (generic-math <see cref="IAdditiveIdentity{TSelf, TResult}"/>):
+    /// the empty set (default comparer). G-Set is an additive, commutative + idempotent monoid
+    /// (identity + associative <see cref="Union"/>, NO inverse), so it surfaces only
+    /// <see cref="IAdditiveIdentity{TSelf, TResult}"/> + <see cref="IAdditionOperators{TSelf, TOther, TResult}"/>
+    /// — never <c>INumber</c> (no negation / order / multiplication).
+    /// </summary>
+    [SuppressMessage(
+        "Design",
+        "CA1000:Do not declare static members on generic types",
+        Justification = "IAdditiveIdentity<TSelf,TResult> requires a static AdditiveIdentity member on the generic type; CA1000 predates static-abstract interface members (IWSAM) and does not apply to generic-math interface implementations.")]
+    public static GSet<T> AdditiveIdentity => GSet.Empty<T>();
+
+    /// <summary>
+    /// The additive operator (generic-math <c>+</c>): the CRDT <see cref="Union"/> merge.
+    /// The empty set acts as a comparer-agnostic identity (<c>empty + x = x</c>, <c>x + empty = x</c>)
+    /// so <see cref="AdditiveIdentity"/> composes with a set under any comparer; two NON-empty
+    /// operands still delegate to <see cref="Union"/>, which enforces the comparer-identity match.
+    /// </summary>
+    /// <param name="left">The left set.</param>
+    /// <param name="right">The right set.</param>
+    /// <returns>The union, in canonical order.</returns>
+    public static GSet<T> operator +(GSet<T> left, GSet<T> right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+
+        // The additive identity is the empty set; it must absorb under ANY comparer for the
+        // monoid identity law to hold (AdditiveIdentity uses the default comparer, but a set
+        // may carry a custom one). Empty has no elements, so its ordering is irrelevant — short
+        // -circuit before Union's deliberate same-comparer check (which guards non-empty merges).
+        if (left.IsEmpty)
+        {
+            return right;
+        }
+
+        if (right.IsEmpty)
+        {
+            return left;
+        }
+
+        return left.Union(right);
     }
 
     /// <summary>Add one element (<see cref="Union"/> with a singleton); idempotent if already present.</summary>

--- a/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
@@ -111,4 +111,43 @@ public class GSetCrossVerifyTests
         Assert.Equal(GSet.OfSeq(expected, ordinal), a.Union(otherOrdinal));
         Assert.False(GSet.OfSeq(aItems, ordinal).Equals(GSet.OfSeq(aItems, reverse))); // diff comparer ⇒ not equal
     }
+
+    [Fact]
+    public void GenericMathAdditiveMonoidSurface()
+    {
+        // G-Set is an additive, commutative + idempotent monoid, so it surfaces the
+        // generic-math IAdditiveIdentity + IAdditionOperators (NOT INumber — no inverse /
+        // order / product). (+) == Union for same-comparer operands; AdditiveIdentity is empty.
+        var cmp = StringComparer.Ordinal;
+        static GSet<string> G(StringComparer cmp, params string[] xs) => GSet.OfSeq(xs, cmp);
+
+        var a = G(cmp, "a", "c");
+        var b = G(cmp, "b", "c", "d");
+        var c = G(cmp, "c", "e");
+
+        Assert.Equal(a.Union(b), a + b); // (+) equals Union
+        Assert.True(GSet<string>.AdditiveIdentity.IsEmpty); // identity is the empty set
+        Assert.Equal(a, GSet<string>.AdditiveIdentity + a); // identity law
+        Assert.Equal(a, a + GSet<string>.AdditiveIdentity);
+        Assert.Equal(a, a + a); // idempotent
+        Assert.Equal(a + b, b + a); // commutative
+        Assert.Equal((a + b) + c, a + (b + c)); // associative
+    }
+
+    [Fact]
+    public void GenericMathIdentityIsComparerAgnosticButNonEmptyMismatchStillThrows()
+    {
+        // The additive identity (empty) must absorb under ANY comparer for the monoid identity
+        // law to hold — AdditiveIdentity carries the default comparer, but a set may carry a
+        // custom one. Empty has no elements, so its ordering is irrelevant: (+) short-circuits.
+        var reverse = Comparer<string>.Create((x, y) => string.CompareOrdinal(y, x));
+        var custom = GSet.OfSeq(["x", "y"], reverse);
+        Assert.Equal(custom, custom + GSet<string>.AdditiveIdentity); // no throw
+        Assert.Equal(custom, GSet<string>.AdditiveIdentity + custom);
+
+        // But two NON-empty operands with different comparers still delegate to Union → throw
+        // (the comparer-identity guard for real merges is preserved).
+        var ordinal = GSet.OfSeq(["a", "b"], StringComparer.Ordinal);
+        Assert.Throws<ArgumentException>(() => ordinal + custom);
+    }
 }


### PR DESCRIPTION
## What

C# slice of the **numerics-ladder → generic-math** retrofit (after F# #6467). Implements the C# IWSAM generic-math surface on `GSet<T>`: `IAdditiveIdentity<GSet<T>,GSet<T>>` + `IAdditionOperators<GSet<T>,GSet<T>,GSet<T>>` — additive-monoid **only**, never `INumber` (no negation / order / multiplication). Establishes the actual IWSAM pattern that `IndexedZSet.cs`'s header only *planned* in a comment.

## Changes

- **`AdditiveIdentity`** => `GSet.Empty<T>()` (default comparer).
- **`operator +`** delegates to `Union`, **but** treats the empty set as a **comparer-agnostic identity** (`empty + x = x`, `x + empty = x`). This is necessary: `AdditiveIdentity` carries the default comparer, but a set may carry a custom one — and `Union` runs `RequireSameComparer` *before* its empty short-circuit, so a raw `Union` against a default-comparer empty would throw. The operator's pre-check makes the **monoid identity law hold for custom-comparer sets**. Two NON-empty operands still delegate to `Union`, preserving its deliberate same-comparer guard.
- **CA1000 suppressed** on `AdditiveIdentity` with justification — `IAdditiveIdentity` *requires* the static member; CA1000 predates IWSAM. (`operator +` is already CA1000-exempt.)

## Verification

- `dotnet build -c Release` → **0 warnings / 0 errors** (Meziantou + analyzers + TreatWarningsAsErrors)
- `dotnet test --filter GSet` → **5 pass / 0 fail** (3 original + 2 new: monoid laws + comparer-agnostic-identity-vs-nonempty-mismatch-throws)

## Next slices

Rust (`Add` + a `Zero`) + TS (`Monoid` record) for G-Set; then Bag across all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)