### PR TITLE
feat(gset-ts): additive-monoid surface (Monoid record) — completes G-Set generic-math 4/4

### DIFF
--- a/src/Core.TypeScript/g-set/g-set.test.ts
+++ b/src/Core.TypeScript/g-set/g-set.test.ts
@@ -12,7 +12,7 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { add, contains, empty, equals, ofArray, stringCompare, toArray, union, type GSet } from "./g-set";
+import { add, concatAll, contains, empty, equals, monoid, ofArray, stringCompare, toArray, union, type GSet } from "./g-set";
 
 const cmp = stringCompare;
 const g = (...xs: readonly string[]): GSet<string> => ofArray(cmp, xs);
@@ -59,6 +59,32 @@ describe("G-Set — CRDT convergence laws", () => {
   it("add is idempotent for a present element", () => {
     expect(equals(cmp, add(cmp, "a", setA), setA)).toBe(true);
     expect(toArray(add(cmp, "z", setA))).toEqual(["a", "b", "z"]);
+  });
+});
+
+describe("G-Set — additive-monoid surface (empty + concat)", () => {
+  const m = monoid(cmp);
+  const setA = g("a", "b");
+  const setB = g("b", "c");
+  const setC = g("c", "d");
+
+  it("concat produces the explicit union (not just delegation)", () => {
+    expect(toArray(m.concat(setA, setB))).toEqual(["a", "b", "c"]);
+  });
+  it("empty is the identity: concat(empty, a) == a and concat(a, empty) == a", () => {
+    expect(toArray(m.empty)).toEqual([]);
+    expect(equals(cmp, m.concat(m.empty, setA), setA)).toBe(true);
+    expect(equals(cmp, m.concat(setA, m.empty), setA)).toBe(true);
+  });
+  it("monoid laws: idempotent + commutative + associative via concat", () => {
+    expect(equals(cmp, m.concat(setA, setA), setA)).toBe(true);
+    expect(equals(cmp, m.concat(setA, setB), m.concat(setB, setA))).toBe(true);
+    const left = m.concat(m.concat(setA, setB), setC);
+    const right = m.concat(setA, m.concat(setB, setC));
+    expect(equals(cmp, left, right)).toBe(true);
+  });
+  it("concatAll folds a collection through the monoid", () => {
+    expect(toArray(concatAll(cmp, [g("a"), g("b", "a"), g("c")]))).toEqual(["a", "b", "c"]);
   });
 });
 

--- a/src/Core.TypeScript/g-set/g-set.ts
+++ b/src/Core.TypeScript/g-set/g-set.ts
@@ -144,8 +144,11 @@ export function equals<T>(compare: Compare<T>, a: GSet<T>, b: GSet<T>): boolean 
 // empty+concat, never subtraction/negation/product.
 
 /**
- * A monoid: an identity element (`empty`) + an associative binary combiner (`concat`),
- * with `concat(empty, x) === x === concat(x, empty)`.
+ * A monoid: an identity element (`empty`) + an associative binary combiner (`concat`).
+ * The identity law holds by VALUE/semantic equality (not reference `===`): combining with
+ * `empty` yields a value equal to the other operand — `concat(empty, x)` equals `x` equals
+ * `concat(x, empty)`. (For {@link GSet}, `concat` = `union` returns a fresh array except for
+ * the empty short-circuit, so compare with {@link equals}, never `===`.)
  */
 export interface Monoid<T> {
   /** The identity element. */

--- a/src/Core.TypeScript/g-set/g-set.ts
+++ b/src/Core.TypeScript/g-set/g-set.ts
@@ -135,3 +135,43 @@ export function equals<T>(compare: Compare<T>, a: GSet<T>, b: GSet<T>): boolean 
   }
   return true;
 }
+
+// ── generic-math additive-monoid surface (TS idiom: a Monoid record) ────────
+// G-Set is an additive, commutative + idempotent monoid (identity + associative
+// union, NO inverse). TS has no operator overloading or generic-math interfaces, so
+// the additive-monoid surface is a small `{ empty, concat }` record — the TS analog
+// of F#'s `Zero`+`(+)` / C#'s `IAdditiveIdentity`+`IAdditionOperators`. Exposes only
+// empty+concat, never subtraction/negation/product.
+
+/**
+ * A monoid: an identity element (`empty`) + an associative binary combiner (`concat`),
+ * with `concat(empty, x) === x === concat(x, empty)`.
+ */
+export interface Monoid<T> {
+  /** The identity element. */
+  readonly empty: T;
+  /** The associative combiner. */
+  readonly concat: (a: T, b: T) => T;
+}
+
+/**
+ * The additive-monoid surface of a G-Set under `compare`: `empty` (identity) + `concat`
+ * (= {@link union}). Lets generic monoid code fold a collection of G-Sets — see
+ * {@link concatAll}. G-Set's monoid is comparator-specific, so this is a factory over
+ * `compare` (the F#/C#/Rust twins bake the comparer into the type / use a default).
+ */
+export function monoid<T>(compare: Compare<T>): Monoid<GSet<T>> {
+  return {
+    empty: empty<T>(),
+    concat: (a, b) => union(compare, a, b),
+  };
+}
+
+/**
+ * Fold a collection of G-Sets through the monoid (identity + `concat`) — the
+ * "generic code folds it for free" payoff (the TS analog of Rust's `Sum`).
+ */
+export function concatAll<T>(compare: Compare<T>, gs: readonly GSet<T>[]): GSet<T> {
+  const m = monoid(compare);
+  return gs.reduce(m.concat, m.empty);
+}


### PR DESCRIPTION
## What

TS slice of the **numerics-ladder → generic-math** retrofit — **completes G-Set across all four oracles** (F# #6467 · C# #6468 · Rust #6469 · TS this).

TS has no operator overloading or generic-math interfaces, so per the rule the additive-monoid surface is a small **`Monoid<T>` record `{ empty, concat }`** — the TS analog of F# `Zero`+`(+)` / C# `IAdditiveIdentity`+`operator+` / Rust `Add`+`Default`. Exposes `empty`+`concat` only (no subtraction/negation/product).

- **`interface Monoid<T>`** `{ empty; concat }` — first monoid type in the TS core.
- **`monoid(compare): Monoid<GSet<T>>`** — factory (G-Set's monoid is comparator-specific: `empty = []`, `concat = union`).
- **`concatAll(compare, gs)`** — fold a collection through the monoid (the Rust-`Sum` analog).

## Verification

- `bun test` → **13 pass / 0 fail** (9 original + 4 new monoid laws)
- root `tsc --noEmit` → **0 errors**

## Status

**G-Set generic-math is now 4/4.** Next: **Bag** across all four oracles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)