### PR TITLE
feat(bag-fsharp): generic-math additive-monoid surface (Zero + (+)) on F# Bag

### DIFF
--- a/src/Core/Bag.fs
+++ b/src/Core/Bag.fs
@@ -49,6 +49,43 @@ type Bag<'T when 'T : comparison> =
 
     static member Empty : Bag<'T> = Bag(ImmutableArray<BagEntry<'T>>.Empty)
 
+    /// The additive-monoid identity (generic-math `Zero`) — an alias for `Empty`,
+    /// recognized by F# SRTP / `LanguagePrimitives.GenericZero` + generic numeric code.
+    /// Bag is an additive, **commutative** monoid (identity + associative per-key-sum
+    /// `union`, **no inverse**, and — unlike G-Set — **NOT idempotent**: `a + a` doubles
+    /// every count), so it surfaces `Zero` + `(+)` only — never `INumber` (no negation /
+    /// order / multiplication). The Z-set completes this monoid into an abelian group
+    /// (signed ℤ weights, where retraction is the inverse). `(+)` IS `union`.
+    static member Zero : Bag<'T> = Bag<'T>.Empty
+
+    /// The additive operator (generic-math `(+)`): the per-key SUM of two sorted bags,
+    /// kept sorted + count-positive (overflow-checked via `Checked.(+)`). The canonical
+    /// home of the merge; `Bag.union` delegates here.
+    static member (+) (a: Bag<'T>, b: Bag<'T>) : Bag<'T> =
+        let xa = if a.items.IsDefault then ImmutableArray<BagEntry<'T>>.Empty else a.items
+        let xb = if b.items.IsDefault then ImmutableArray<BagEntry<'T>>.Empty else b.items
+        if xa.IsEmpty then Bag<'T>(xb)
+        elif xb.IsEmpty then Bag<'T>(xa)
+        else
+            let out = ImmutableArray.CreateBuilder<BagEntry<'T>>(xa.Length + xb.Length)
+            let mutable i = 0
+            let mutable j = 0
+            while i < xa.Length && j < xb.Length do
+                let c = compare xa.[i].Key xb.[j].Key
+                if c < 0 then
+                    out.Add(xa.[i]); i <- i + 1
+                elif c > 0 then
+                    out.Add(xb.[j]); j <- j + 1
+                else
+                    out.Add({ Key = xa.[i].Key; Count = Checked.(+) xa.[i].Count xb.[j].Count })
+                    i <- i + 1
+                    j <- j + 1
+            while i < xa.Length do
+                out.Add(xa.[i]); i <- i + 1
+            while j < xb.Length do
+                out.Add(xb.[j]); j <- j + 1
+            Bag<'T>(out.ToImmutable())
+
     /// The number of DISTINCT keys (the support size).
     member this.Count =
         if this.items.IsDefault then 0 else this.items.Length
@@ -187,31 +224,9 @@ module Bag =
     /// count-positive. Commutative, associative, and the empty bag is the
     /// identity — but NOT idempotent: `union a a` doubles every count. This
     /// commutative monoid is the step the Z-set completes into an abelian group
-    /// (signed ℤ weights, where retraction is the inverse).
-    let union (a: Bag<'T>) (b: Bag<'T>) : Bag<'T> =
-        let xa = if a.items.IsDefault then ImmutableArray<BagEntry<'T>>.Empty else a.items
-        let xb = if b.items.IsDefault then ImmutableArray<BagEntry<'T>>.Empty else b.items
-        if xa.IsEmpty then Bag<'T>(xb)
-        elif xb.IsEmpty then Bag<'T>(xa)
-        else
-            let out = ImmutableArray.CreateBuilder<BagEntry<'T>>(xa.Length + xb.Length)
-            let mutable i = 0
-            let mutable j = 0
-            while i < xa.Length && j < xb.Length do
-                let c = compare xa.[i].Key xb.[j].Key
-                if c < 0 then
-                    out.Add(xa.[i]); i <- i + 1
-                elif c > 0 then
-                    out.Add(xb.[j]); j <- j + 1
-                else
-                    out.Add({ Key = xa.[i].Key; Count = addCounts xa.[i].Count xb.[j].Count })
-                    i <- i + 1
-                    j <- j + 1
-            while i < xa.Length do
-                out.Add(xa.[i]); i <- i + 1
-            while j < xb.Length do
-                out.Add(xb.[j]); j <- j + 1
-            Bag<'T>(out.ToImmutable())
+    /// (signed ℤ weights, where retraction is the inverse). Delegates to the type's
+    /// generic-math `(+)` operator: same merge, one canonical implementation.
+    let union (a: Bag<'T>) (b: Bag<'T>) : Bag<'T> = a + b
 
     /// Increment `x`'s count by 1 (`union` with a singleton). NOT idempotent.
     let add (x: 'T) (g: Bag<'T>) : Bag<'T> = union g (singleton x 1L)

--- a/tests/Tests.FSharp/Algebra/Bag.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/Bag.Tests.fs
@@ -53,6 +53,38 @@ let ``union identity: union a empty = a and union empty a = a`` () =
     Bag.union a Bag.empty<string> |> Bag.toList |> should equal (Bag.toList a)
     Bag.union Bag.empty<string> a |> Bag.toList |> should equal (Bag.toList a)
 
+// ─── generic-math additive-monoid surface (Zero + (+)) ─────────────────────
+// Bag surfaces the native F# generic-math idiom `Zero` + `(+)` (NOT `INumber` — no
+// inverse / order / product). Like G-Set it's an additive commutative monoid, but —
+// unlike G-Set — NOT idempotent (`a + a` doubles counts). These lock `(+)` to `union`
+// + `Zero` to `empty` so generic numeric code can aggregate a Bag.
+
+[<Fact>]
+let ``(+) merges to the explicit per-key sum (semantics, not just delegation)`` () =
+    let a = Bag.ofEntries [ ("a", 1L); ("b", 2L) ]
+    let b = Bag.ofEntries [ ("b", 1L); ("c", 3L) ]
+    (a + b) |> Bag.toList |> should equal [ ("a", 1L); ("b", 3L); ("c", 3L) ]
+
+[<Fact>]
+let ``Zero is the additive identity: Zero + a = a and a + Zero = a`` () =
+    let a = Bag.ofEntries [ ("a", 1L); ("b", 2L) ]
+    (Bag<string>.Zero + a) |> should equal a
+    (a + Bag<string>.Zero) |> should equal a
+
+[<Fact>]
+let ``Zero equals empty and is recognized by GenericZero`` () =
+    Bag<string>.Zero |> should equal Bag.empty<string>
+    LanguagePrimitives.GenericZero<Bag<string>> |> should equal Bag.empty<string>
+
+[<Fact>]
+let ``(+) commutative + associative but NOT idempotent (the Bag distinction)`` () =
+    let a = Bag.ofEntries [ ("a", 1L); ("b", 2L) ]
+    let b = Bag.ofEntries [ ("b", 1L); ("c", 3L) ]
+    let c = Bag.ofEntries [ ("c", 5L) ]
+    (a + b) |> should equal (b + a) // commutative
+    ((a + b) + c) |> should equal (a + (b + c)) // associative
+    (a + a) |> Bag.toList |> should equal [ ("a", 2L); ("b", 4L) ] // NOT idempotent — doubles
+
 [<Fact>]
 let ``multiplicity + contains via binary search`` () =
     let a = Bag.ofEntries [ ("a", 3L); ("c", 1L) ]


### PR DESCRIPTION
## What

First **Bag** slice of the numerics-ladder → generic-math retrofit (G-Set is now 4/4: #6467/#6468/#6469/#6470). Adds the native F# generic-math surface to `Bag`.

Bag is an additive, **commutative** monoid (identity + associative per-key-sum `union`, **no inverse**) — but **unlike G-Set it is NOT idempotent** (`a + a` doubles every count). So per the rule it surfaces `Zero` + `(+)` **only**, never `INumber` (that abelian-group step is the Z-set, where retraction is the inverse).

## Changes

- **`static member Zero`** (= `Empty`) — recognized by SRTP / `LanguagePrimitives.GenericZero`.
- **`static member (+)`** — the per-key SUM merge (overflow-checked via `Checked.(+)`), moved onto the type as its canonical home; module `Bag.union` now delegates. Operator on the type so SRTP `(+)` resolves it (mirrors the F# GSet slice #6467).
- **Laws**: `(+)` explicit per-key-sum result; `Zero` identity; `Zero` = `empty` + `GenericZero`; commutative + associative + **NOT idempotent** (the Bag/G-Set distinction).

## Verification

- `dotnet build -c Release` → **0 warnings / 0 errors**
- `dotnet test --filter Bag` → **15 pass / 0 fail** (11 original + 4 new)

## Next

C# (`IAdditiveIdentity`+`IAdditionOperators`) · Rust (`Add`+`Default`) · TS (`Monoid`) for Bag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)