### PR TITLE
feat(bag-csharp): generic-math additive-monoid surface (IAdditiveIdentity + IAdditionOperators)

### DIFF
--- a/src/Core.CSharp/Bag.cs
+++ b/src/Core.CSharp/Bag.cs
@@ -6,7 +6,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Numerics;
 
 namespace Zeta.Core.CSharp;
 
@@ -132,7 +134,10 @@ public static class Bag
 /// ordinal) needs <see cref="StringComparer.Ordinal"/>. Pass it explicitly for cross-language parity.
 /// </remarks>
 /// <typeparam name="T">The key type.</typeparam>
-public sealed class Bag<T> : IEquatable<Bag<T>>
+public sealed class Bag<T> :
+    IEquatable<Bag<T>>,
+    IAdditiveIdentity<Bag<T>, Bag<T>>,
+    IAdditionOperators<Bag<T>, Bag<T>, Bag<T>>
 {
     private readonly ImmutableArray<BagEntry<T>> _items;
     private readonly IComparer<T> _comparer;
@@ -259,6 +264,52 @@ public sealed class Bag<T> : IEquatable<Bag<T>>
         }
 
         return new Bag<T>(builder.ToImmutable(), _comparer);
+    }
+
+    /// <summary>
+    /// The additive-monoid identity (generic-math <see cref="IAdditiveIdentity{TSelf, TResult}"/>):
+    /// the empty bag (default comparer), cached so it allocates once per closed generic type (the
+    /// empty bag is immutable). Bag is an additive, commutative monoid (identity + associative
+    /// per-key-sum <see cref="Union"/>, NO inverse) — and, unlike a G-Set, NOT idempotent
+    /// (<c>a + a</c> doubles counts) — so it surfaces only
+    /// <see cref="IAdditiveIdentity{TSelf, TResult}"/> + <see cref="IAdditionOperators{TSelf, TOther, TResult}"/>,
+    /// never <c>INumber</c> (the abelian-group step is the Z-set, where retraction is the inverse).
+    /// </summary>
+    [SuppressMessage(
+        "Design",
+        "CA1000:Do not declare static members on generic types",
+        Justification = "IAdditiveIdentity<TSelf,TResult> requires a static AdditiveIdentity member on the generic type; CA1000 predates static-abstract interface members (IWSAM) and does not apply to generic-math interface implementations.")]
+    public static Bag<T> AdditiveIdentity { get; } = Bag.Empty<T>();
+
+    /// <summary>
+    /// The additive operator (generic-math <c>+</c>): the per-key SUM <see cref="Union"/> merge.
+    /// The empty bag acts as a comparer-agnostic identity (<c>empty + x = x</c>, <c>x + empty = x</c>)
+    /// so <see cref="AdditiveIdentity"/> composes with a bag under any comparer; two NON-empty
+    /// operands still delegate to <see cref="Union"/>, which enforces the comparer-identity match.
+    /// </summary>
+    /// <param name="left">The left bag.</param>
+    /// <param name="right">The right bag.</param>
+    /// <returns>The per-key sum, in canonical order.</returns>
+    public static Bag<T> operator +(Bag<T> left, Bag<T> right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+
+        // The additive identity is the empty bag; it must absorb under ANY comparer for the
+        // monoid identity law to hold (AdditiveIdentity uses the default comparer, but a bag
+        // may carry a custom one). Empty has no entries, so its ordering is irrelevant —
+        // short-circuit before Union's deliberate same-comparer check (guards non-empty merges).
+        if (left.IsEmpty)
+        {
+            return right;
+        }
+
+        if (right.IsEmpty)
+        {
+            return left;
+        }
+
+        return left.Union(right);
     }
 
     /// <summary>Increment <paramref name="x"/>'s count by 1 (<see cref="Union"/> with a singleton). NOT idempotent.</summary>

--- a/tests/Tests.CSharp/Algebra/BagCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/BagCrossVerifyTests.cs
@@ -133,4 +133,41 @@ public class BagCrossVerifyTests
         // diff comparer ⇒ not equal
         Assert.False(Bag.OfEntries([("a", 1L)], ordinal).Equals(Bag.OfEntries([("a", 1L)], reverse)));
     }
+
+    [Fact]
+    public void GenericMathAdditiveMonoidSurface()
+    {
+        // Bag surfaces the generic-math IAdditiveIdentity + IAdditionOperators (NOT INumber —
+        // no inverse / order / product). (+) == Union for same-comparer operands; AdditiveIdentity
+        // is empty. Like G-Set it's an additive commutative monoid, but — unlike G-Set — NOT idempotent.
+        var cmp = StringComparer.Ordinal;
+        static Bag<string> B(StringComparer cmp, params (string, long)[] xs) => Bag.OfEntries(xs, cmp);
+
+        var a = B(cmp, ("a", 1L), ("b", 2L));
+        var b = B(cmp, ("b", 1L), ("c", 3L));
+        var c = B(cmp, ("c", 5L));
+
+        Assert.Equal(a.Union(b), a + b); // (+) equals Union
+        Assert.True(Bag<string>.AdditiveIdentity.IsEmpty); // identity is the empty bag
+        Assert.Equal(a, Bag<string>.AdditiveIdentity + a); // identity law
+        Assert.Equal(a, a + Bag<string>.AdditiveIdentity);
+        Assert.Equal(a + b, b + a); // commutative
+        Assert.Equal((a + b) + c, a + (b + c)); // associative
+        Assert.Equal(B(cmp, ("a", 2L), ("b", 4L)), a + a); // NOT idempotent — doubles counts
+    }
+
+    [Fact]
+    public void GenericMathIdentityIsComparerAgnosticButNonEmptyMismatchStillThrows()
+    {
+        // The additive identity (empty) absorbs under ANY comparer (so the monoid identity law
+        // holds for custom-comparer bags), but two NON-empty operands with different comparers
+        // still delegate to Union → throw (the comparer-identity guard for real merges is kept).
+        var reverse = Comparer<string>.Create((x, y) => string.CompareOrdinal(y, x));
+        var custom = Bag.OfEntries([("x", 1L), ("y", 2L)], reverse);
+        Assert.Equal(custom, custom + Bag<string>.AdditiveIdentity); // no throw
+        Assert.Equal(custom, Bag<string>.AdditiveIdentity + custom);
+
+        var ordinal = Bag.OfEntries([("a", 1L), ("b", 1L)], StringComparer.Ordinal);
+        Assert.Throws<ArgumentException>(() => ordinal + custom);
+    }
 }


### PR DESCRIPTION
## What

C# **Bag** slice of the numerics-ladder → generic-math retrofit (after F# Bag #6472; G-Set is 4/4). Bag is an additive, commutative monoid (identity + associative per-key-sum `Union`, **no inverse**) — but, unlike G-Set, **NOT idempotent** (`a + a` doubles counts). Implements the C# IWSAM surface `IAdditiveIdentity` + `IAdditionOperators` **only**, never `INumber` (the abelian-group step is the Z-set).

## Same pattern as the C# GSet slice (#6468)

- `AdditiveIdentity` **cached** (`{ get; } = Bag.Empty<T>()`) — allocates once per closed generic type.
- `operator +` treats the empty bag as a **comparer-agnostic identity** (so `AdditiveIdentity` composes with any-comparer bags), while two non-empty operands delegate to `Union` (same-comparer guard preserved).
- CA1000 suppressed on `AdditiveIdentity` (IWSAM requires the static member).

## Verification

- `dotnet build -c Release` → **0 warnings / 0 errors**
- `dotnet test --filter Bag` → **7 pass / 0 fail** (5 original + 2 new, incl. not-idempotent + comparer-agnostic-identity)

## Next

Rust (`Add`+`Default`) · TS (`Monoid`) for Bag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)