### PR TITLE
feat(bag-ts): additive-monoid surface (Monoid record) — completes Bag generic-math 4/4

### DIFF
--- a/src/Core.TypeScript/bag/bag.test.ts
+++ b/src/Core.TypeScript/bag/bag.test.ts
@@ -20,10 +20,12 @@ import {
   addN,
   type Bag,
   type BagEntry,
+  concatAll,
   contains,
   distinctCount,
   empty,
   equals,
+  monoid,
   multiplicity,
   ofArray,
   ofEntries,
@@ -123,6 +125,33 @@ describe("Bag — commutative-monoid laws (and NON-idempotence)", () => {
     expect(toEntries(add(cmp, "a", bagA))).toEqual([entry("a", 2), entry("b", 2)]);
     expect(toEntries(addN(cmp, "z", 3, bagA))).toEqual([entry("a", 1), entry("b", 2), entry("z", 3)]);
     expect(equals(cmp, addN(cmp, "z", 0, bagA), bagA)).toBe(true);
+  });
+});
+
+describe("Bag — additive-monoid surface (empty + concat)", () => {
+  const m = monoid(cmp);
+  const a = bag(entry("a", 1), entry("b", 2));
+  const b = bag(entry("b", 1), entry("c", 3));
+  const c = bag(entry("c", 5));
+
+  it("concat is the explicit per-key sum (not just delegation)", () => {
+    expect(toEntries(m.concat(a, b))).toEqual([entry("a", 1), entry("b", 3), entry("c", 3)]);
+  });
+  it("empty is the identity: concat(empty, a) == a and concat(a, empty) == a", () => {
+    expect(toEntries(m.empty)).toEqual([]);
+    expect(equals(cmp, m.concat(m.empty, a), a)).toBe(true);
+    expect(equals(cmp, m.concat(a, m.empty), a)).toBe(true);
+  });
+  it("monoid laws: commutative + associative but NOT idempotent (the Bag distinction)", () => {
+    expect(equals(cmp, m.concat(a, b), m.concat(b, a))).toBe(true);
+    expect(equals(cmp, m.concat(m.concat(a, b), c), m.concat(a, m.concat(b, c)))).toBe(true);
+    expect(toEntries(m.concat(a, a))).toEqual([entry("a", 2), entry("b", 4)]); // doubles
+  });
+  it("concatAll folds a collection through the monoid (per-key sums)", () => {
+    expect(toEntries(concatAll(cmp, [bag(entry("a", 1)), bag(entry("a", 2), entry("b", 1)), bag(entry("b", 3))]))).toEqual([
+      entry("a", 3),
+      entry("b", 4),
+    ]);
   });
 });
 

--- a/src/Core.TypeScript/bag/bag.ts
+++ b/src/Core.TypeScript/bag/bag.ts
@@ -28,6 +28,10 @@
  * analog of F#'s `'T : comparison` constraint.
  */
 
+// The Monoid record type is the lower rung's (G-Set's) — reused, not redeclared, so the
+// additive-monoid surface is one shape across the ladder.
+import type { Monoid } from "../g-set/g-set";
+
 /** A total order on `T` (`< 0`, `0`, `> 0`), e.g. {@link stringCompare}. */
 export type Compare<T> = (a: T, b: T) => number;
 
@@ -244,4 +248,33 @@ export function equals<T>(compare: Compare<T>, a: Bag<T>, b: Bag<T>): boolean {
     if (compare(ea.e, eb.e) !== 0 || ea.n !== eb.n) return false;
   }
   return true;
+}
+
+// ── generic-math additive-monoid surface (TS idiom: a Monoid record) ────────
+// Bag is an additive, commutative monoid (identity + associative per-key-sum union, NO
+// inverse) — but, unlike a G-Set, NOT idempotent (concat(a, a) doubles every count). The
+// TS additive-monoid surface is a `{ empty, concat }` record (the analog of F# Zero+(+) /
+// C# IAdditiveIdentity+operator+ / Rust Add+Default). Exposes empty+concat only — never
+// subtraction/negation (the abelian-group step is the Z-set, where retraction is the inverse).
+
+/**
+ * The additive-monoid surface of a Bag under `compare`: `empty` (identity) + `concat`
+ * (= {@link union}, the per-key sum). Lets generic monoid code fold a collection of Bags —
+ * see {@link concatAll}. Bag's monoid is comparator-specific, so this is a factory over
+ * `compare`. Identity holds by VALUE equality (compare with {@link equals}, not `===`).
+ */
+export function monoid<T>(compare: Compare<T>): Monoid<Bag<T>> {
+  return {
+    empty: empty<T>(),
+    concat: (a, b) => union(compare, a, b),
+  };
+}
+
+/**
+ * Fold a collection of Bags through the monoid (identity + `concat`, the per-key sum) — the
+ * "generic code folds it for free" payoff (the TS analog of Rust's `Sum`).
+ */
+export function concatAll<T>(compare: Compare<T>, bs: readonly Bag<T>[]): Bag<T> {
+  const m = monoid(compare);
+  return bs.reduce(m.concat, m.empty);
 }


### PR DESCRIPTION
## What

TS **Bag** slice — **completes Bag generic-math across all four oracles** (F# #6472 · C# #6473 · Rust #6474 · TS this). Bag is an additive, commutative monoid (identity + associative per-key-sum `union`, **no inverse**) — but, unlike a G-Set, **NOT idempotent** (`concat(a, a)` doubles counts). Surfaces a `{ empty, concat }` `Monoid` record (no operator overloading in TS); the abelian-group step is the Z-set.

- **Reuses** the `Monoid<T>` type from the lower rung (g-set) — not redeclared, one shape across the ladder (type-only import).
- `monoid(compare): Monoid<Bag<T>>` factory (empty = `[]`, concat = per-key-sum union).
- `concatAll(compare, bs)` — fold a collection through the monoid (Rust-`Sum` analog).

## Verification

- `bun test` → **19 pass / 0 fail** (15 original + 4 new monoid laws, incl. not-idempotent)
- root `tsc --noEmit` → **0 errors**

## Status

**G-Set 4/4 ✅ and Bag 4/4 ✅** (the two additive-monoid rungs). Next: the **Z-set** rung — the abelian **group**, which adds the `negate` inverse (C# `ISubtractionOperators` + `IUnaryNegationOperators` / F# `(-)` + `(~-)` / Rust `Sub` + `Neg`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)