### PR TITLE
feat(ace): slice 7 revocation / quarantine

### DIFF
--- a/.claude/skills/ace/SKILL.md
+++ b/.claude/skills/ace/SKILL.md
@@ -334,3 +334,63 @@ while all other packages derive their URL from `--base-url`.
 
 - ETag / Last-Modified sidecar for conditional-GET cache validation.
 - Multi-signer publish (multiple signing keys on one index).
+
+## Revocation and quarantine (slice 7)
+
+Slice 7 adds two mark states to the signed registry index. Marks live inside
+`IndexSignableContent` (inherited by the Ed25519 signature, anti-rollback
+sequence, and freshness gates). An index carrying any mark has `format_version`
+set to `2`; a plain publish with no marks stays `format_version` `1`.
+
+### Mark semantics
+
+- **`revoked`** — permanent hard-refuse. A revoked version is refused at resolve
+  and install regardless of the lockfile. There is no `unrevoke`; revocation is
+  terminal.
+- **`quarantined`** — soft-refuse, override-able with `--allow-quarantined`.
+
+Revoke supersedes quarantine: revoking a quarantined version removes the
+quarantine mark and adds the revocation mark. Quarantining an already-revoked
+version is an error.
+
+### Producer subcommands
+
+Each mutate-command reads the existing `--out` index, verifies its signature
+under `--key`, applies the mark, bumps the sequence by one, refreshes
+`issued_at`, re-signs, self-verifies, and writes the result. `--out` must
+already exist (these commands mutate an existing index; use `ace registry
+publish` to create one first).
+
+| Subcommand | Effect |
+|---|---|
+| `ace registry revoke <name>@<version> [--reason "..."] --key <pem> [--out <path>]` | Permanently revokes the version; also clears any quarantine on it |
+| `ace registry quarantine <name>@<version> [--reason "..."] --key <pem> [--out <path>]` | Soft-refuses the version; errors if already revoked |
+| `ace registry unquarantine <name>@<version> --key <pem> [--out <path>]` | Releases the quarantine after review; errors if not quarantined |
+
+### publish carries marks forward
+
+`ace registry publish` preserves existing `revoked` and `quarantined` maps from
+a prior index when `--out` already exists, so marks are not silently dropped on
+republish.
+
+### Consumer behaviour
+
+`ace install` (and the resolver) refuses marked versions:
+
+- **Revoked** — always refused, even when the version is pinned in the lockfile.
+  Revocation overrides the lockfile: if a locked version is subsequently revoked,
+  `ace install` refuses and the lockfile must be updated.
+- **Quarantined** — refused by default; pass `--allow-quarantined` to opt in.
+
+```bash
+# Producer: revoke a bad version
+ace registry revoke my-pkg@1.2.3 --reason "supply-chain compromise" \
+    --key registry.pem --out index.json
+
+# Consumer: plain install now refuses my-pkg@1.2.3
+ace install my-pkg.json
+# Error: my-pkg@1.2.3 is revoked: supply-chain compromise
+
+# Consumer: opt into a quarantined (but not revoked) version
+ace install my-pkg.json --allow-quarantined
+```

--- a/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice7-implementation-plan.md
+++ b/docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice7-implementation-plan.md
@@ -1,0 +1,280 @@
+# Ace CLI slice 7 — revocation / quarantine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. Full behavior is in
+> `2026-06-01-ace-cli-slice7-revocation-quarantine-design.md` — read it.
+
+**Goal:** Add revocation + quarantine to the Ace registry: a `format_version`-2 signed index
+carries `revoked` / `quarantined` maps; `ace registry revoke|quarantine|unquarantine` mark
+versions; `publish` carries marks forward; consumers refuse marked versions at resolve +
+install; revocation overrides the lockfile; `--allow-quarantined` opts in.
+
+**Architecture:** marks are two sibling maps in the already-signed `IndexSignableContent`
+(inherit signature + anti-rollback + freshness). Producer mutate-commands reuse the slice-6.1
+read-verify-edit-bump-sign-selfverify-write pattern via new pure `apply*` functions. Consumer
+threads union-merged marks into resolve + the install lockfile re-check.
+
+**Tech stack:** TypeScript on Bun. `bun test tools/ace/`; strict
+`bun --bun tsc --noEmit -p tsconfig.json` (exactOptionalPropertyTypes + noUnusedLocals);
+markdownlint on `SKILL.md`. Harness: NO Edit tool — new files via Write, edits via Python
+patch-scripts (exact-occurrence asserts; `rm` before commit; never commit `_patch_*`). Pure
+LF — verify CR=0 with Python `open(f,'rb').read().count(b'\r')` (Git-Bash `grep $'\r'` is
+unreliable here). Canary `git ls-tree HEAD | wc -l` = 67 (new files go under existing
+top-level dirs, so the count is unchanged). Commit trailer
+`Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+**Tasks (sequential; A before B before C):** A = signing types + producer pure logic
+(`signing.ts`, `registry-revoke.ts` new, `registry-publish.ts` carry-forward); B = consumer
+parse + resolve (`registry-remote.ts`, `resolve.ts`); C = `ace.ts` integration + e2e; D =
+`SKILL.md`.
+
+---
+
+## Task A: signing types + `registry-revoke.ts` (new) + `buildIndexDoc` carry-forward
+
+**Files:** Modify `tools/ace/signing.ts`, `tools/ace/registry-publish.ts`,
+`tools/ace/registry-publish.test.ts`; create `tools/ace/registry-revoke.ts`,
+`tools/ace/registry-revoke.test.ts`.
+
+- [ ] **Step A1: signing.ts types (additive)**
+
+Add to `tools/ace/signing.ts` near `IndexSignableContent`:
+
+```ts
+export interface RevocationEntry { reason?: string; at: string }
+export type RevocationMap = Record<string, Record<string, RevocationEntry>>;
+```
+
+Extend `IndexSignableContent` with two optional fields (additive; `canonicalIndexBytes` /
+`signIndex` / `verifyIndexSignature` unchanged — they canonicalize the whole content):
+
+```ts
+export interface IndexSignableContent {
+  format_version: number;
+  sequence: number;
+  issued_at: string;
+  packages: Record<string, Record<string, RegistryEntry>>;
+  revoked?: RevocationMap;
+  quarantined?: RevocationMap;
+}
+```
+
+- [ ] **Step A2: `registry-revoke.ts` pure apply functions + tests (TDD)**
+
+Create `tools/ace/registry-revoke.test.ts` FIRST (RED). Then `tools/ace/registry-revoke.ts`.
+Functions (all pure; return new content or `{ error }`):
+
+```ts
+import type { IndexSignableContent, RevocationMap, RevocationEntry } from "./signing.ts";
+
+// format_version is 2 iff a mark remains, else 1.
+function withFmt(c: IndexSignableContent): IndexSignableContent {
+  const hasMarks = (m?: RevocationMap) => !!m && Object.keys(m).length > 0;
+  return { ...c, format_version: (hasMarks(c.revoked) || hasMarks(c.quarantined)) ? 2 : 1 };
+}
+function clone(m: RevocationMap | undefined): RevocationMap {
+  // deep-ish clone (own keys only; null-proto to avoid prototype pollution)
+  const out: RevocationMap = Object.create(null);
+  for (const n of Object.keys(m ?? {})) { out[n] = Object.create(null); for (const v of Object.keys(m![n]!)) out[n]![v] = { ...m![n]![v]! }; }
+  return out;
+}
+function has(m: RevocationMap | undefined, name: string, version: string): boolean {
+  return !!m && !!m[name] && m[name]![version] !== undefined;
+}
+function add(m: RevocationMap, name: string, version: string, entry: RevocationEntry): void {
+  (m[name] ?? (m[name] = Object.create(null)))[version] = entry;
+}
+function remove(m: RevocationMap, name: string, version: string): void {
+  if (m[name]) { delete m[name]![version]; if (Object.keys(m[name]!).length === 0) delete m[name]; }
+}
+
+export function applyRevoke(prev: IndexSignableContent, name: string, version: string, reason: string | undefined, at: string): IndexSignableContent {
+  const revoked = clone(prev.revoked); const quarantined = clone(prev.quarantined);
+  remove(quarantined, name, version);                 // revoke supersedes quarantine
+  add(revoked, name, version, reason !== undefined ? { reason, at } : { at });
+  return withFmt({ ...prev, revoked, quarantined });
+}
+export function applyQuarantine(prev: IndexSignableContent, name: string, version: string, reason: string | undefined, at: string): IndexSignableContent | { error: string } {
+  if (has(prev.revoked, name, version)) return { error: `${name}@${version} is revoked (terminal); cannot quarantine` };
+  const quarantined = clone(prev.quarantined);
+  add(quarantined, name, version, reason !== undefined ? { reason, at } : { at });
+  return withFmt({ ...prev, quarantined });
+}
+export function applyUnquarantine(prev: IndexSignableContent, name: string, version: string): IndexSignableContent | { error: string } {
+  if (!has(prev.quarantined, name, version)) return { error: `${name}@${version} is not quarantined` };
+  const quarantined = clone(prev.quarantined);
+  remove(quarantined, name, version);
+  return withFmt({ ...prev, quarantined });
+}
+```
+
+Tests (RED→GREEN): applyRevoke adds to `revoked`, sets `format_version` 2, clears a matching
+`quarantined`; re-revoke is idempotent (no error); applyQuarantine errors on an
+already-revoked version, else adds; applyUnquarantine removes (and reverts `format_version`
+to 1 when it was the last mark), errors when not quarantined. Note exactOptionalPropertyTypes:
+build the entry as `reason !== undefined ? { reason, at } : { at }` (never `{ reason: undefined }`).
+
+- [ ] **Step A3: `buildIndexDoc` carry-forward (registry-publish.ts)**
+
+Extend `buildIndexDoc`'s args with optional `revoked?: RevocationMap; quarantined?: RevocationMap;`.
+After building `content`, attach them when non-empty and set `format_version` accordingly:
+
+```ts
+  const hasMarks = (m?: RevocationMap) => !!m && Object.keys(m).length > 0;
+  const fmt = (hasMarks(args.revoked) || hasMarks(args.quarantined)) ? 2 : 1;
+  const content: IndexSignableContent = { format_version: fmt, sequence: args.sequence, issued_at: args.issuedAt, packages };
+  if (hasMarks(args.revoked)) content.revoked = args.revoked;
+  if (hasMarks(args.quarantined)) content.quarantined = args.quarantined;
+```
+
+(Import `RevocationMap`. Existing `format_version: 1` literal is replaced by `fmt`.) Extend
+`registry-publish.test.ts`: passing `revoked`/`quarantined` yields a v2 doc carrying them;
+omitting them yields v1 as before.
+
+- [ ] **Step A4: verify + commit** — `bun test tools/ace/registry-revoke.test.ts tools/ace/registry-publish.test.ts`
+  pass; `bun --bun tsc --noEmit` exit 0; Python CR=0 on the 4 touched/new files; canary 67.
+  Commit `tools/ace/signing.ts tools/ace/registry-revoke.ts tools/ace/registry-revoke.test.ts tools/ace/registry-publish.ts tools/ace/registry-publish.test.ts`.
+
+---
+
+## Task B: consumer parse (v2) + resolve gates
+
+**Files:** Modify `tools/ace/registry-remote.ts`, `tools/ace/resolve.ts`, and their tests.
+
+- [ ] **Step B1: `parseIndex` accept v2 + mark shape-guard (registry-remote.ts)**
+
+Change the `format_version` gate from `!== 1` to accept `1` or `2`. When marks are present,
+shape-validate; reject marks on a v1 index. Add a helper:
+
+```ts
+function validMarkMap(m: unknown): boolean {
+  if (typeof m !== "object" || m === null) return false;
+  for (const name of Object.keys(m as object)) {
+    const vs = (m as Record<string, unknown>)[name];
+    if (typeof vs !== "object" || vs === null) return false;
+    for (const v of Object.keys(vs as object)) {
+      const e = (vs as Record<string, unknown>)[v];
+      if (typeof e !== "object" || e === null) return false;
+      const ee = e as Record<string, unknown>;
+      if (typeof ee.at !== "string") return false;
+      if (ee.reason !== undefined && typeof ee.reason !== "string") return false;
+    }
+  }
+  return true;
+}
+```
+
+In `parseIndex`: `if (o.format_version !== 1 && o.format_version !== 2) return { error: "unsupported index format_version" };`
+Then: if `o.revoked !== undefined` → must be `format_version === 2` and `validMarkMap` (else
+error); same for `o.quarantined`. Carry them onto the returned `IndexDoc`.
+
+- [ ] **Step B2: `loadRegistries` union-merge marks (registry-remote.ts)**
+
+Wherever `loadRegistries` merges `packages` into the loaded result, also union-merge `revoked`
+and `quarantined` across all sources (a version marked by any source is marked). Expose
+`revoked` / `quarantined` (each a `RevocationMap`) on the loaded-registry result type. Read the
+current `loadRegistries` return shape first and extend it minimally.
+
+- [ ] **Step B3: resolve gates (resolve.ts)**
+
+Add `"revoked"` and `"quarantined"` to the `ResolveReason` union. Add an
+`allowQuarantined?: boolean` to the resolve options, and pass the merged marks in (extend the
+resolve entry-point signature/opts to receive `revoked?: RevocationMap; quarantined?: RevocationMap`).
+After a registry edge resolves to a concrete `name@concrete`, before/with the existing
+registry-entry + signature gates:
+
+```ts
+        if (revoked && revoked[edge.name]?.[concrete] !== undefined) {
+          const r = revoked[edge.name]![concrete]!;
+          return { ok: false, reason: "revoked", detail: `${edge.name}@${concrete} is revoked${r.reason ? ": " + r.reason : ""}`, path: here };
+        }
+        if (!opts.allowQuarantined && quarantined && quarantined[edge.name]?.[concrete] !== undefined) {
+          const q = quarantined[edge.name]![concrete]!;
+          return { ok: false, reason: "quarantined", detail: `${edge.name}@${concrete} is quarantined${q.reason ? ": " + q.reason : ""} (use --allow-quarantined)`, path: here };
+        }
+```
+
+(Match the exact local names already used at the resolve site — read resolve.ts for `concrete`,
+`edge`, `here`, the opts object, and how the registry is threaded; adapt accordingly.)
+
+- [ ] **Step B4: tests + verify + commit** — extend `registry-remote.test.ts` (v2 parse;
+  v1-with-marks rejected; bad-mark shape rejected; union-merge) + `resolve.test.ts` (revoked →
+  `"revoked"`; quarantined → `"quarantined"` without `allowQuarantined`, resolves with it).
+  `bun test tools/ace/` green; tsc 0; CR=0; canary 67. Commit the two files + tests.
+
+---
+
+## Task C: `ace.ts` — subcommands + install enforcement + publish wiring + e2e
+
+**Files:** Modify `tools/ace/ace.ts`, `tools/ace/ace.test.ts`.
+
+Read first: the `registry` parse block + `RegistryArgs` type; the `publish` handler (prev read, then the `buildIndexDoc` call); the `install` handler (lockfile path + the resolve call); the existing
+`registry remote`/`publish` subcommand dispatch.
+
+- [ ] **Step C1: e2e tests (RED)** — add to `ace.test.ts` (reuse `writeSignedPkg`, `main`,
+  `parseIndex`, `generateKeypair`, temp dirs). Cover, per the spec's Testing section: publish →
+  `revoke` makes the index v2 + marks + bumps sequence + self-verifies; consumer resolve of a
+  revoked version refuses; `quarantine` refuses without `--allow-quarantined`, installs with
+  it; `unquarantine` restores; `revoke` on a quarantined version moves it (out of quarantined,
+  into revoked); `publish` after a revoke preserves the mark; `revoke`/`quarantine` against an
+  index signed by a different key → refused; `quarantine` of an already-revoked version →
+  error; `unquarantine` of a non-quarantined → error; lockfile-pinned-then-revoked →
+  `ace install` refuses.
+
+- [ ] **Step C2: parse — three subcommands + `--allow-quarantined`**
+
+Extend `RegistryArgs.sub` with `"revoke" | "quarantine" | "unquarantine"` and fields for the
+parsed `name`/`version`/`reason`. Parse `<name>@<version>` by splitting on the LAST `@` (both
+parts non-empty, else parse error); `--key` required; `--reason` optional (not for
+unquarantine); `--out` optional. Add `--allow-quarantined` (boolean) to the `install` parse.
+Use the spread-conditional form for optionals (exactOptionalPropertyTypes).
+
+- [ ] **Step C3: handlers — revoke/quarantine/unquarantine**
+
+Shared shape (mirror the publish mutate path): read `--key` PEM (validate ed25519); read
+`--out` (required; missing/unparseable → hard error); `parseIndex(prevRaw)` → prev; verify
+prev signature under the key (`publicKeyInfoFromPrivatePem` + `verifyIndexSignature`) else hard
+error; call the matching `apply*` (registry-revoke.ts) with `at = new Date().toISOString()`; on
+`{ error }` → hard error; `sequence = prev.sequence + 1`; `signIndex` the new content;
+round-trip self-verify (`parseIndex` + `verifyIndexSignature`); `writeFileSync` pretty; print
+`ace: <verb> <name>@<version> → <out> (sequence n)`.
+
+- [ ] **Step C4: publish carry-forward wiring** — in the `publish` handler, pass
+  `revoked: prev?.revoked, quarantined: prev?.quarantined` into `buildIndexDoc` (only when
+  prev exists). (`buildIndexDoc` already handles non-empty → v2 from Task A.)
+
+- [ ] **Step C5: install enforcement** — thread the loaded registry's merged
+  `revoked`/`quarantined` + `allowQuarantined` into the resolve call. Add the **lockfile
+  re-check**: before installing from a lockfile, for each pinned `name@version`, refuse if
+  revoked (always) or quarantined (unless `--allow-quarantined`; warn when allowed). Match the
+  existing install/lockfile code structure.
+
+- [ ] **Step C6: usage text** — add the three subcommands + `--allow-quarantined` to the help.
+
+- [ ] **Step C7: verify + commit** — `bun test tools/ace/` ALL green; tsc 0; CR=0 on ace.ts +
+  ace.test.ts; canary 67; no `_patch_*`. Commit.
+
+---
+
+## Task D: `SKILL.md`
+
+**Files:** Modify `.claude/skills/ace/SKILL.md`.
+
+- [ ] **Step D1** — document the marks (two-state, in the signed v2 index), the three
+  subcommands (`revoke`/`quarantine`/`unquarantine`), consumer refusal at resolve+install,
+  revocation-overrides-lockfile, and `--allow-quarantined`. Keep existing content. Watch
+  markdownlint: no nested backticks in inline code spans; blank lines around lists + fenced
+  blocks.
+- [ ] **Step D2** — `bunx markdownlint-cli2 .claude/skills/ace/SKILL.md` exit 0; CR=0; canary 67. Commit.
+
+---
+
+## Final holistic review
+
+Dispatch a reviewer over `git diff origin/main..HEAD -- tools/ace/ .claude/skills/ace/SKILL.md`
+checking: marks are in the signed content (covered by signature); `format_version` 2 iff marks
+present (and reverts to 1 when the last mark is removed); revoke supersedes quarantine +
+quarantine errors on revoked + no unrevoke; parseIndex rejects v1-with-marks; union-merge;
+resolve + install + lockfile enforcement; `--allow-quarantined` path; producer mutate-guard
+(verify-before-edit) on all three subcommands; `bun test tools/ace/` + strict tsc +
+markdownlint green; CR=0; canary 67. Then open the impl PR + run the PR-gate loop.

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -10,6 +10,14 @@ import { generateKeypair, signManifest } from "./signing.ts";
 import { generateKeypair as gkpA, signIndex as sidxA } from "./signing.ts";
 import { packageHash } from "./resolve.ts";
 import { parseLockfile } from "./lockfile.ts";
+import { parseIndex } from "./registry-remote.ts";
+
+/** Read an index file + parseIndex it, throwing on a parse error (test ergonomics). */
+function readIndexFile(path: string) {
+  const doc = parseIndex(readFileSync(path, "utf8"));
+  if ("error" in doc) throw new Error(`readIndexFile: ${doc.error}`);
+  return doc;
+}
 
 // ---- Trust-path isolation: redirect ~/.ace to a temp dir in every test ----
 let savedHome: string | undefined;
@@ -1765,5 +1773,202 @@ describe("ace registry publish (slice 6.1)", () => {
     // bad values → parse error
     expect("error" in parseArgs(["registry", "publish", "--packages", "d", "--base-url", "https://x", "--key", "k", "--sequence", "0"])).toBe(true);
     expect("error" in parseArgs(["registry", "publish", "--packages", "d", "--base-url", "https://x", "--key", "k", "--sequence", "abc"])).toBe(true);
+  });
+});
+
+describe("ace registry revoke/quarantine/unquarantine (slice 7)", () => {
+  let savedFetch: typeof globalThis.fetch;
+  beforeEach(() => { savedFetch = globalThis.fetch; });
+  afterEach(() => { globalThis.fetch = savedFetch; });
+
+  // Producer helper: write a signed package file named <name>-<version>.json in dir.
+  function writeSignedPkg(dir: string, name: string, version: string) {
+    const files = { [`${name}.txt`]: "hi" };
+    const ch = contentHash(new TextEncoder().encode(JSON.stringify(files)));
+    const kp = generateKeypair();
+    const m = { format_version: 1, name, version, content_hash: ch };
+    const pkg = { manifest: { ...m, signature: signManifest(m, kp.privatePem) }, files };
+    writeFileSync(join(dir, `${name}-${version}.json`), JSON.stringify(pkg));
+    return { kp, pkg };
+  }
+
+  // ---- Producer-side: marks land in a v2 signed index, sequence bumps ----
+
+  test("revoke makes the index format_version 2, adds revoked mark, bumps sequence, self-verifies", async () => {
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-rev-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    const keyPath = join(tempHome, "r-rev.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "rev-index.json");
+    expect(await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath])).toBe(0);
+    const before = readIndexFile(outPath); expect(before.sequence).toBe(1); expect(before.format_version).toBe(1);
+    const code = await main(["registry", "revoke", "leaf@1.0.0", "--reason", "key compromise", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(0);
+    const after = readIndexFile(outPath);
+    expect(after.format_version).toBe(2);
+    expect(after.sequence).toBe(2);
+    expect(after.revoked?.leaf?.["1.0.0"]).toBeDefined();
+    expect(after.revoked!.leaf!["1.0.0"]!.reason).toBe("key compromise");
+  });
+
+  test("revoke against an index signed by a DIFFERENT key is refused (sig verify fails)", async () => {
+    const idxKp = generateKeypair();
+    const otherKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-rev-otherkey-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    const keyPath = join(tempHome, "r-own.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "rev-otherkey-index.json");
+    expect(await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath])).toBe(0);
+    const otherPath = join(tempHome, "r-other.pem"); writeFileSync(otherPath, otherKp.privatePem);
+    const code = await main(["registry", "revoke", "leaf@1.0.0", "--key", otherPath, "--out", outPath]);
+    expect(code).toBe(1);
+    const after = readIndexFile(outPath);
+    expect(after.sequence).toBe(1);
+    expect(after.format_version).toBe(1);
+  });
+
+  test("revoke with a missing --out (no existing index) is refused", async () => {
+    const idxKp = generateKeypair();
+    const keyPath = join(tempHome, "r-noidx.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const code = await main(["registry", "revoke", "leaf@1.0.0", "--key", keyPath, "--out", join(tempHome, "does-not-exist.json")]);
+    expect(code).toBe(1);
+  });
+
+  test("quarantine an already-revoked version is an error (exit 1)", async () => {
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-q-on-rev-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    const keyPath = join(tempHome, "r-qrev.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "qrev-index.json");
+    expect(await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath])).toBe(0);
+    expect(await main(["registry", "revoke", "leaf@1.0.0", "--key", keyPath, "--out", outPath])).toBe(0);
+    const code = await main(["registry", "quarantine", "leaf@1.0.0", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(1);
+  });
+
+  test("unquarantine a non-quarantined version is an error (exit 1)", async () => {
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-unq-non-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    const keyPath = join(tempHome, "r-unqnon.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "unqnon-index.json");
+    expect(await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath])).toBe(0);
+    const code = await main(["registry", "unquarantine", "leaf@1.0.0", "--key", keyPath, "--out", outPath]);
+    expect(code).toBe(1);
+  });
+
+  test("revoke on a quarantined version moves it (out of quarantined, into revoked)", async () => {
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-q-then-rev-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    const keyPath = join(tempHome, "r-qmove.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "qmove-index.json");
+    expect(await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath])).toBe(0);
+    expect(await main(["registry", "quarantine", "leaf@1.0.0", "--reason", "review", "--key", keyPath, "--out", outPath])).toBe(0);
+    let doc = readIndexFile(outPath);
+    expect(doc.quarantined?.leaf?.["1.0.0"]).toBeDefined();
+    expect(doc.revoked?.leaf?.["1.0.0"]).toBeUndefined();
+    expect(await main(["registry", "revoke", "leaf@1.0.0", "--key", keyPath, "--out", outPath])).toBe(0);
+    doc = readIndexFile(outPath);
+    expect(doc.revoked?.leaf?.["1.0.0"]).toBeDefined();
+    expect(doc.quarantined?.leaf?.["1.0.0"]).toBeUndefined();
+  });
+
+  test("publish after a revoke preserves the mark (carry-forward)", async () => {
+    const idxKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-pub-after-rev-"));
+    writeSignedPkg(pkgDir, "leaf", "1.0.0");
+    const keyPath = join(tempHome, "r-cf.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const outPath = join(tempHome, "cf-index.json");
+    expect(await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath])).toBe(0);
+    expect(await main(["registry", "revoke", "leaf@0.9.0", "--reason", "old", "--key", keyPath, "--out", outPath])).toBe(0);
+    expect(await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", outPath])).toBe(0);
+    const doc = readIndexFile(outPath);
+    expect(doc.format_version).toBe(2);
+    expect(doc.revoked?.leaf?.["0.9.0"]).toBeDefined();
+  });
+
+  // ---- Consumer-side: resolve/install refuses revoked + quarantined; --allow-quarantined opts in ----
+  // Mirrors the slice-6 install-via-remote harness (fetch mock serving index + package by URL).
+
+  const PKG_URL = "https://pkgs/leaf-1.0.0.json";
+  const IDX_URL = "https://x/index.json";
+
+  /** Build a signed package + a published+optionally-marked index; serve both via a fetch mock;
+   *  register the remote + trust both keys; write a root that depends on leaf@^1.0.0. */
+  async function setupConsumer(opts: { mark?: "revoke" | "quarantine"; reason?: string }) {
+    const idxKp = generateKeypair();
+    const pkgKp = generateKeypair();
+    const pkgDir = mkdtempSync(join(tmpdir(), "ace-cons-pkgs-"));
+    const files = { "leaf.txt": "hi" };
+    const ch = contentHash(new TextEncoder().encode(JSON.stringify(files)));
+    const m = { format_version: 1, name: "leaf", version: "1.0.0", content_hash: ch };
+    const pkg = { manifest: { ...m, signature: signManifest(m, pkgKp.privatePem) }, files };
+    const pkgJson = JSON.stringify(pkg);
+    writeFileSync(join(pkgDir, "leaf-1.0.0.json"), pkgJson);
+    const keyPath = join(tempHome, "r-cons.pem"); writeFileSync(keyPath, idxKp.privatePem);
+    const idxPath = join(tempHome, "cons-index.json");
+    expect(await main(["registry", "publish", "--packages", pkgDir, "--base-url", "https://pkgs", "--key", keyPath, "--out", idxPath])).toBe(0);
+    if (opts.mark === "revoke") {
+      expect(await main(["registry", "revoke", "leaf@1.0.0", ...(opts.reason ? ["--reason", opts.reason] : []), "--key", keyPath, "--out", idxPath])).toBe(0);
+    } else if (opts.mark === "quarantine") {
+      expect(await main(["registry", "quarantine", "leaf@1.0.0", ...(opts.reason ? ["--reason", opts.reason] : []), "--key", keyPath, "--out", idxPath])).toBe(0);
+    }
+    const serve = (u: string) => new Response(u === PKG_URL ? pkgJson : readFileSync(idxPath, "utf8"), { status: 200 });
+    globalThis.fetch = (async (u: string) => serve(u)) as unknown as typeof fetch;
+    await main(["trust", "add", idxKp.publicSpkiB64]);
+    await main(["trust", "add", pkgKp.publicSpkiB64]);
+    await main(["registry", "remote", "add", IDX_URL, "--key", idxKp.keyId]);
+    const root = { manifest: { format_version: 1, name: "root", version: "1.0.0",
+      content_hash: contentHash(new TextEncoder().encode(JSON.stringify({ "r.txt": "r" }))),
+      dependencies: [{ kind: "registry", name: "leaf", version: "^1.0.0" }] }, files: { "r.txt": "r" } };
+    const rootPath = join(tempHome, "root.json"); writeFileSync(rootPath, JSON.stringify(root));
+    return { rootPath, idxPath, keyPath, pkgJson, serve, store: () => join(tempHome, ".ace", "store") };
+  }
+
+  async function freshFetchAfterCacheWipe(serve: (u: string) => Response) {
+    const { rmSync } = await import("node:fs");
+    const { registryCacheDir } = await import("./store.ts");
+    rmSync(registryCacheDir(), { recursive: true, force: true });
+    globalThis.fetch = (async (u: string) => serve(u)) as unknown as typeof fetch;
+  }
+
+  test("install of a revoked registry version refuses (resolve)", async () => {
+    const c = await setupConsumer({ mark: "revoke", reason: "compromise" });
+    const code = await main(["install", c.rootPath, "--allow-no-signature"]);
+    expect(code).toBe(1);
+    expect(listInstalled(c.store()).some((p) => p.manifest.name === "leaf")).toBe(false);
+  });
+
+  test("install of a quarantined version refuses without --allow-quarantined, installs with it", async () => {
+    const c = await setupConsumer({ mark: "quarantine", reason: "review" });
+    const refused = await main(["install", c.rootPath, "--allow-no-signature"]);
+    expect(refused).toBe(1);
+    expect(listInstalled(c.store()).some((p) => p.manifest.name === "leaf")).toBe(false);
+    const allowed = await main(["install", c.rootPath, "--allow-no-signature", "--allow-quarantined"]);
+    expect(allowed).toBe(0);
+    expect(listInstalled(c.store()).some((p) => p.manifest.name === "leaf")).toBe(true);
+  });
+
+  test("unquarantine restores normal install", async () => {
+    const c = await setupConsumer({ mark: "quarantine", reason: "review" });
+    expect(await main(["install", c.rootPath, "--allow-no-signature"])).toBe(1);
+    expect(await main(["registry", "unquarantine", "leaf@1.0.0", "--key", c.keyPath, "--out", c.idxPath])).toBe(0);
+    await freshFetchAfterCacheWipe(c.serve);
+    const code = await main(["install", c.rootPath, "--allow-no-signature"]);
+    expect(code).toBe(0);
+    expect(listInstalled(c.store()).some((p) => p.manifest.name === "leaf")).toBe(true);
+  });
+
+  test("lockfile pins leaf@1.0.0; then revoke; ace install --frozen refuses (revocation overrides lockfile)", async () => {
+    const c = await setupConsumer({});
+    const lockPath = join(tempHome, "ace.lock");
+    expect(await main(["install", c.rootPath, "--allow-no-signature", "--lockfile", lockPath])).toBe(0);
+    expect(existsSync(lockPath)).toBe(true);
+    expect(await main(["registry", "revoke", "leaf@1.0.0", "--reason", "compromise", "--key", c.keyPath, "--out", c.idxPath])).toBe(0);
+    await freshFetchAfterCacheWipe(c.serve);
+    const store = mkdtempSync(join(tmpdir(), "ace-lock-rev-store-"));
+    const code = await main(["install", c.rootPath, "--store", store, "--allow-no-signature", "--lockfile", lockPath, "--frozen"]);
+    expect(code).toBe(1);
   });
 });

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -24,7 +24,9 @@ import {
   writeRegistryRemote, removeRegistryRemote, readRegistriesConfig,
   type AcePackage,
 } from "./store";
-import { generateKeypair, signManifest, verifySignature, keyId, publicKeyInfoFromPrivatePem, verifyIndexSignature } from "./signing";
+import { generateKeypair, signManifest, verifySignature, keyId, publicKeyInfoFromPrivatePem, verifyIndexSignature, signIndex } from "./signing";
+import type { IndexSignableContent, RevocationMap } from "./signing";
+import { applyRevoke, applyQuarantine, applyUnquarantine } from "./registry-revoke.ts";
 import { resolve, packageHash } from "./resolve.ts";
 import { buildLockfile, serializeLockfile, parseLockfile, verifyRootMatchesLock, lockfilesEqual, buildLeafLockfile } from "./lockfile.ts";
 import { solve } from "./solver.ts";
@@ -57,6 +59,7 @@ interface InstallArgs {
   readonly source: string;
   readonly storePath: string;
   readonly allowNoSignature: boolean;
+  readonly allowQuarantined?: boolean;
   readonly printResolution?: boolean;
   readonly frozen: boolean;
   readonly locked: boolean;
@@ -99,7 +102,7 @@ interface UpdateArgs {
 
 interface RegistryArgs {
   readonly command: "registry";
-  readonly sub: "list" | "add" | "remote-add" | "remote-list" | "remote-rm" | "publish";
+  readonly sub: "list" | "add" | "remote-add" | "remote-list" | "remote-rm" | "publish" | "revoke" | "quarantine" | "unquarantine";
   readonly regName?: string;
   readonly regVersion?: string;
   readonly regUrl?: string;
@@ -112,6 +115,9 @@ interface RegistryArgs {
   readonly pubKeyPath?: string;
   readonly pubOut?: string;
   readonly pubSequence?: number;
+  readonly revName?: string;
+  readonly revVersion?: string;
+  readonly revReason?: string;
 }
 
 type ParsedArgs = ListArgs | HelpArgs | InstallArgs | VerifyArgs | KeygenArgs | SignArgs | TrustArgs | RegistryArgs | UpdateArgs;
@@ -274,7 +280,30 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
       if (seq !== undefined) r = { ...r, pubSequence: seq };
       return r;
     }
-    return { error: "registry requires 'add', 'list', 'remote', or 'publish'" };
+    if (sub === "revoke" || sub === "quarantine" || sub === "unquarantine") {
+      const spec = argv[2];
+      if (!spec || spec.startsWith("-")) return { error: `registry ${sub} requires <name>@<version>` };
+      // split on the LAST '@' so scoped names (rare) survive; both parts must be non-empty.
+      const at = spec.lastIndexOf("@");
+      if (at <= 0 || at === spec.length - 1) return { error: `registry ${sub}: <name>@<version> must have a non-empty name and version` };
+      const name = spec.slice(0, at), version = spec.slice(at + 1);
+      let key: string | undefined, out: string | undefined, reason: string | undefined;
+      for (let i = 3; i < argv.length; i++) {
+        if (argv[i] === "--key") { key = argv[++i]; if (!key || key.startsWith("-")) return { error: "--key requires a value" }; }
+        else if (argv[i] === "--out") { out = argv[++i]; if (!out || out.startsWith("-")) return { error: "--out requires a value" }; }
+        else if (argv[i] === "--reason") {
+          if (sub === "unquarantine") return { error: "registry unquarantine does not take --reason" };
+          reason = argv[++i]; if (reason === undefined || reason.startsWith("-")) return { error: "--reason requires a value" };
+        }
+        else return { error: `Unknown option for registry ${sub}: ${argv[i]}` };
+      }
+      if (!key) return { error: `registry ${sub} requires --key <pem-path>` };
+      let r: RegistryArgs = { command: "registry", sub, revName: name, revVersion: version, pubKeyPath: key };
+      if (out !== undefined) r = { ...r, pubOut: out };
+      if (reason !== undefined) r = { ...r, revReason: reason };
+      return r;
+    }
+    return { error: "registry requires 'add', 'list', 'remote', 'publish', 'revoke', 'quarantine', or 'unquarantine'" };
   }
 
   if (command === "update") {
@@ -306,6 +335,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
     let storePath = defaultStorePath();
     let allowNoSignature = false;
     let printResolution = false;
+    let allowQuarantined = false;
     let frozen = false;
     let locked = false;
     let offline = false;
@@ -318,6 +348,8 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
         i++;
       } else if (argv[i] === "--allow-no-signature") {
         allowNoSignature = true;
+      } else if (argv[i] === "--allow-quarantined") {
+        allowQuarantined = true;
       } else if (argv[i] === "--print-resolution") {
         printResolution = true;
       } else if (argv[i] === "--frozen") {
@@ -335,7 +367,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
       }
     }
     if (locked && frozen) return { error: "--locked and --frozen are mutually exclusive" };
-    const baseResult: InstallArgs = { command: "install", source, storePath, allowNoSignature, frozen, locked, lockfile: lockfilePath, ...(offline ? { offline: true } : {}) };
+    const baseResult: InstallArgs = { command: "install", source, storePath, allowNoSignature, frozen, locked, lockfile: lockfilePath, ...(allowQuarantined ? { allowQuarantined: true } : {}), ...(offline ? { offline: true } : {}) };
     if (printResolution) return { ...baseResult, printResolution: true };
     return baseResult;
   }
@@ -382,7 +414,7 @@ function printUsage(): void {
 
 Usage:
   ace list [--store <path>] [--json]             List installed DLC packages
-  ace install <url-or-path> [--allow-no-signature] [--print-resolution] [--frozen|--locked] [--lockfile <path>] [--offline]
+  ace install <url-or-path> [--allow-no-signature] [--allow-quarantined] [--print-resolution] [--frozen|--locked] [--lockfile <path>] [--offline]
                                                    Download/read a package, verify integrity+authenticity, install
                                                    --allow-no-signature only installs packages with NO signature; it never bypasses a present (bad or untrusted) signature
                                                    --print-resolution prints the solved name@version graph before installing
@@ -399,6 +431,9 @@ Usage:
   ace registry add <name> <version> <url> [--hash <h>] Register a package in the local registry
   ace registry list                              List all registry entries
   ace registry publish --packages <dir>[,<dir>...] --base-url <url> --key <pem> [--out <path>] [--sequence <n>] Build + sign an index from one or more dirs of packages
+  ace registry revoke <name>@<version> [--reason <s>] --key <pem> [--out <path>] Mark a version revoked (permanent hard-refuse) in the signed index
+  ace registry quarantine <name>@<version> [--reason <s>] --key <pem> [--out <path>] Mark a version quarantined (soft-refuse; --allow-quarantined overrides)
+  ace registry unquarantine <name>@<version> --key <pem> [--out <path>] Release a quarantined version
   ace registry remote add <url> --key <keyid> [--max-staleness-days <n>] Add a signed remote registry
   ace registry remote list                       List configured remote registries
   ace registry remote rm <url>                   Remove a configured remote registry
@@ -408,6 +443,36 @@ Future commands (not yet implemented):
   ace remove <hash>                              Uninstall a DLC
   ace inspect <hash>                             Show manifest without installing`;
   console.log(text);
+}
+
+/** SLICE 7 lockfile re-check: best-effort load the registry marks and refuse any pinned
+ *  name@version that is revoked (always) or quarantined (unless allowQuarantined; warn when
+ *  allowed). Best-effort means an unreachable/empty registry yields no marks and no refusal —
+ *  the --frozen install stays registry-independent (it only gains a security veto when a
+ *  reachable trusted registry has marked a locked pin). Returns an error string or null. */
+async function checkLockedMarks(
+  pins: ReadonlyArray<{ name: string; version: string }>,
+  allowQuarantined: boolean, offline: boolean,
+): Promise<string | null> {
+  let revoked: RevocationMap; let quarantined: RevocationMap;
+  try {
+    const loaded = await loadRegistries({ trustStore: loadTrustStore(), offline });
+    revoked = loaded.revoked; quarantined = loaded.quarantined;
+  } catch { return null; } // marks unavailable → no veto (preserve frozen registry-independence)
+  for (const pin of pins) {
+    if (revoked[pin.name]?.[pin.version] !== undefined) {
+      const r = revoked[pin.name]![pin.version]!;
+      return `${pin.name}@${pin.version} is revoked${r.reason ? ": " + r.reason : ""} (revocation overrides the lockfile)`;
+    }
+    if (quarantined[pin.name]?.[pin.version] !== undefined) {
+      if (!allowQuarantined) {
+        const q = quarantined[pin.name]![pin.version]!;
+        return `${pin.name}@${pin.version} is quarantined${q.reason ? ": " + q.reason : ""} (use --allow-quarantined)`;
+      }
+      console.error(`ace: WARNING: installing quarantined ${pin.name}@${pin.version} (--allow-quarantined).`);
+    }
+  }
+  return null;
 }
 
 export async function main(argv: readonly string[]): Promise<number> {
@@ -662,7 +727,7 @@ export async function main(argv: readonly string[]): Promise<number> {
       if (prev && seq <= prev.sequence) { console.error(`ace: publish refused: sequence ${seq} <= prev ${prev.sequence}`); return 1; }
       let serialized: string;
       try {
-        const doc = buildIndexDoc({ packages, baseUrl: parsed.pubBaseUrl!, sequence: seq, issuedAt: new Date().toISOString(), privatePem: pem });
+        const doc = buildIndexDoc({ packages, baseUrl: parsed.pubBaseUrl!, sequence: seq, issuedAt: new Date().toISOString(), privatePem: pem, ...(prev?.revoked ? { revoked: prev.revoked } : {}), ...(prev?.quarantined ? { quarantined: prev.quarantined } : {}) });
         if ("error" in doc) { console.error(`ace: publish refused: ${doc.error}`); return 1; }
         serialized = JSON.stringify(doc, null, 2);
         const reparsed = parseIndex(serialized);
@@ -675,6 +740,55 @@ export async function main(argv: readonly string[]): Promise<number> {
       try { writeFileSync(outPath, serialized); }
       catch (e) { console.error(`ace: publish failed: cannot write ${outPath}: ${(e as Error).message}`); return 1; }
       console.log(`ace: published ${packages.length} package(s) at sequence ${seq} → ${outPath}`);
+      return 0;
+    }
+    if (parsed.sub === "revoke" || parsed.sub === "quarantine" || parsed.sub === "unquarantine") {
+      const verb = parsed.sub;
+      let pem: string;
+      try { pem = readFileSync(parsed.pubKeyPath!, "utf8"); }
+      catch (e) { console.error(`ace: ${verb}: cannot read key ${parsed.pubKeyPath}: ${(e as Error).message}`); return 1; }
+      try {
+        if (createPrivateKey(pem).asymmetricKeyType !== "ed25519") { console.error(`ace: ${verb} refused: --key must be an ed25519 private key`); return 1; }
+      } catch (e) { console.error(`ace: ${verb} refused: invalid private key: ${(e as Error).message}`); return 1; }
+      const outPath = parsed.pubOut ?? "index.json";
+      if (!existsSync(outPath)) { console.error(`ace: ${verb} refused: ${outPath} does not exist — cannot mark a version in a nonexistent index`); return 1; }
+      let prevRaw: string;
+      try { prevRaw = readFileSync(outPath, "utf8"); }
+      catch (e) { console.error(`ace: ${verb} refused: cannot read ${outPath}: ${(e as Error).message}`); return 1; }
+      const p = parseIndex(prevRaw);
+      if ("error" in p) { console.error(`ace: ${verb} refused: ${outPath} is not a valid index (${p.error}) — no silent reset`); return 1; }
+      const prevInfo = publicKeyInfoFromPrivatePem(pem);
+      const { signature: prevSig, ...prevContent } = p;
+      const prevVerify = verifyIndexSignature(prevContent, prevSig, new Map([[prevInfo.keyId, { public_key: prevInfo.public_key }]]));
+      if (!prevVerify.ok) { console.error(`ace: ${verb} refused: ${outPath} signature does not verify under --key (${prevVerify.reason}) — not your index`); return 1; }
+      const name = parsed.revName!, version = parsed.revVersion!;
+      const at = new Date().toISOString();
+      let next: IndexSignableContent | { error: string };
+      if (verb === "revoke") next = applyRevoke(prevContent, name, version, parsed.revReason, at);
+      else if (verb === "quarantine") next = applyQuarantine(prevContent, name, version, parsed.revReason, at);
+      else next = applyUnquarantine(prevContent, name, version);
+      if ("error" in next) { console.error(`ace: ${verb} refused: ${next.error}`); return 1; }
+      const seq = p.sequence + 1;
+      // Drop any now-empty mark map so a format_version-1 index never carries an empty
+      // `revoked`/`quarantined` key (parseIndex rejects a v1 index that carries either map).
+      const isEmpty = (m?: RevocationMap) => !m || Object.keys(m).length === 0;
+      const content: IndexSignableContent = { ...next, sequence: seq };
+      if (isEmpty(content.revoked)) delete content.revoked;
+      if (isEmpty(content.quarantined)) delete content.quarantined;
+      let serialized: string;
+      try {
+        const sig = signIndex(content, pem);
+        const doc = { ...content, signature: sig };
+        serialized = JSON.stringify(doc, null, 2);
+        const reparsed = parseIndex(serialized);
+        if ("error" in reparsed) { console.error(`ace: ${verb} refused: self-verify parse failed: ${reparsed.error}`); return 1; }
+        const sv = verifyIndexSignature(content, sig, new Map([[prevInfo.keyId, { public_key: prevInfo.public_key }]]));
+        if (!sv.ok) { console.error(`ace: ${verb} refused: self-verify signature failed: ${sv.reason}`); return 1; }
+      } catch (e) { console.error(`ace: ${verb} refused: signing failed: ${(e as Error).message}`); return 1; }
+      try { writeFileSync(outPath, serialized); }
+      catch (e) { console.error(`ace: ${verb} failed: cannot write ${outPath}: ${(e as Error).message}`); return 1; }
+      const verbed = verb === "revoke" ? "revoked" : verb === "quarantine" ? "quarantined" : "unquarantined";
+      console.log(`ace: ${verbed} ${name}@${version} → ${outPath} (sequence ${seq})`);
       return 0;
     }
     // sub === "add"
@@ -850,6 +964,12 @@ export async function main(argv: readonly string[]): Promise<number> {
           console.error(`ace: install refused: lockfile out of date for ${pkg.manifest.name} — re-run without --frozen to regenerate`);
           return 1;
         }
+        // SLICE 7: revocation overrides the lockfile. Best-effort load the registry marks
+        // (offline/unreachable → empty marks, frozen stays registry-independent) and re-check
+        // every locked pin: a revoked pin hard-refuses; a quarantined pin refuses unless
+        // --allow-quarantined (warn when allowed).
+        const fr = await checkLockedMarks(lf.nodes, parsed.allowQuarantined === true, parsed.offline === true);
+        if (fr !== null) { console.error(`ace: install refused: ${fr}`); return 1; }
         const trust = loadTrustStore();
         // PASS 1 (verify-all, install NOTHING) — mirrors the default-path preflight: fetch → parse →
         // verify pin + content_hash + signature + path-safety + store-key collision across the WHOLE
@@ -900,7 +1020,7 @@ export async function main(argv: readonly string[]): Promise<number> {
       }
       const fetchPackage = async (u: string): Promise<string> =>
         (u.startsWith("http://") || u.startsWith("https://")) ? await (await fetch(u)).text() : readFileSync(u, "utf8");
-      const { registry, warnings, errors } = await loadRegistries({
+      const { registry, revoked, quarantined, warnings, errors } = await loadRegistries({
         trustStore: loadTrustStore(), offline: parsed.offline === true,
       });
       for (const w of warnings) console.error(`ace: ${w}`);
@@ -916,7 +1036,7 @@ export async function main(argv: readonly string[]): Promise<number> {
           console.log(`  ${n}@${v}`);
         }
       }
-      const res = await resolve(pkg, fetchPackage, loadTrustStore(), registry, solveResult.versions, { allowNoSignature: parsed.allowNoSignature });
+      const res = await resolve(pkg, fetchPackage, loadTrustStore(), registry, solveResult.versions, { allowNoSignature: parsed.allowNoSignature, allowQuarantined: parsed.allowQuarantined === true, revoked, quarantined });
       if (!res.ok) {
         console.error(`ace: install refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`);
         return 1;
@@ -968,6 +1088,8 @@ export async function main(argv: readonly string[]): Promise<number> {
       const lf = parseLockfile(lockRaw);
       if ("error" in lf) { console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${lf.error}`); return 1; }
       if (!verifyRootMatchesLock(pkg, lf)) { console.error(`ace: install refused: lockfile out of date for ${pkg.manifest.name} — re-run without --frozen to regenerate`); return 1; }
+      const lr = await checkLockedMarks([{ name: pkg.manifest.name, version: pkg.manifest.version }, ...lf.nodes], parsed.allowQuarantined === true, parsed.offline === true);
+      if (lr !== null) { console.error(`ace: install refused: ${lr}`); return 1; }
     } else if (parsed.locked) {
       let lockRaw: string;
       try { lockRaw = readFileSync(parsed.lockfile, "utf8"); }

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -766,15 +766,10 @@ export async function main(argv: readonly string[]): Promise<number> {
       let next: IndexSignableContent | { error: string };
       if (verb === "revoke") next = applyRevoke(prevContent, name, version, parsed.revReason, at);
       else if (verb === "quarantine") next = applyQuarantine(prevContent, name, version, parsed.revReason, at);
-      else next = applyUnquarantine(prevContent, name, version);
+      else next = applyUnquarantine(prevContent, name, version, at);
       if ("error" in next) { console.error(`ace: ${verb} refused: ${next.error}`); return 1; }
       const seq = p.sequence + 1;
-      // Drop any now-empty mark map so a format_version-1 index never carries an empty
-      // `revoked`/`quarantined` key (parseIndex rejects a v1 index that carries either map).
-      const isEmpty = (m?: RevocationMap) => !m || Object.keys(m).length === 0;
       const content: IndexSignableContent = { ...next, sequence: seq };
-      if (isEmpty(content.revoked)) delete content.revoked;
-      if (isEmpty(content.quarantined)) delete content.quarantined;
       let serialized: string;
       try {
         const sig = signIndex(content, pem);

--- a/tools/ace/registry-publish.test.ts
+++ b/tools/ace/registry-publish.test.ts
@@ -88,3 +88,65 @@ describe("buildIndexDoc", () => {
     expect(withUrl.packages.alpha!["1.0.0"]!.package_hash).toBe(without.packages.alpha!["1.0.0"]!.package_hash);
   });
 });
+
+describe("buildIndexDoc with revoked/quarantined marks", () => {
+  const kp2 = generateKeypair();
+  const issuedAt2 = "2026-06-01T12:00:00Z";
+  const leafPkg = pkg("leaf", "1.0.0");
+
+  test("passing revoked yields v2 doc with marks", () => {
+    const revoked = Object.create(null) as import("./signing.ts").RevocationMap;
+    revoked["leaf"] = Object.create(null);
+    revoked["leaf"]!["1.0.0"] = { at: "2026-06-01T00:00:00Z" };
+    const doc = buildIndexDoc({
+      packages: [{ pkg: leafPkg }],
+      baseUrl: "https://pkgs", sequence: 1, issuedAt: issuedAt2, privatePem: kp2.privatePem,
+      revoked,
+    });
+    expect("error" in doc).toBe(false);
+    if ("error" in doc) return;
+    expect(doc.format_version).toBe(2);
+    expect(doc.revoked?.["leaf"]?.["1.0.0"]?.at).toBe("2026-06-01T00:00:00Z");
+    expect(doc.quarantined).toBeUndefined();
+  });
+
+  test("passing quarantined yields v2 doc with marks", () => {
+    const quarantined = Object.create(null) as import("./signing.ts").RevocationMap;
+    quarantined["leaf"] = Object.create(null);
+    quarantined["leaf"]!["1.0.0"] = { reason: "suspicious", at: "2026-06-01T00:00:00Z" };
+    const doc = buildIndexDoc({
+      packages: [{ pkg: leafPkg }],
+      baseUrl: "https://pkgs", sequence: 1, issuedAt: issuedAt2, privatePem: kp2.privatePem,
+      quarantined,
+    });
+    expect("error" in doc).toBe(false);
+    if ("error" in doc) return;
+    expect(doc.format_version).toBe(2);
+    expect(doc.quarantined?.["leaf"]?.["1.0.0"]?.reason).toBe("suspicious");
+    expect(doc.revoked).toBeUndefined();
+  });
+
+  test("omitting marks yields v1 doc (regression)", () => {
+    const doc = buildIndexDoc({
+      packages: [{ pkg: leafPkg }],
+      baseUrl: "https://pkgs", sequence: 1, issuedAt: issuedAt2, privatePem: kp2.privatePem,
+    });
+    expect("error" in doc).toBe(false);
+    if ("error" in doc) return;
+    expect(doc.format_version).toBe(1);
+    expect(doc.revoked).toBeUndefined();
+    expect(doc.quarantined).toBeUndefined();
+  });
+
+  test("empty revoked/quarantined maps yield v1", () => {
+    const doc = buildIndexDoc({
+      packages: [{ pkg: leafPkg }],
+      baseUrl: "https://pkgs", sequence: 1, issuedAt: issuedAt2, privatePem: kp2.privatePem,
+      revoked: Object.create(null) as import("./signing.ts").RevocationMap,
+      quarantined: Object.create(null) as import("./signing.ts").RevocationMap,
+    });
+    expect("error" in doc).toBe(false);
+    if ("error" in doc) return;
+    expect(doc.format_version).toBe(1);
+  });
+});

--- a/tools/ace/registry-publish.ts
+++ b/tools/ace/registry-publish.ts
@@ -3,7 +3,7 @@
 // No I/O — the caller (ace.ts) reads the package files + sequence + pem and writes the output.
 import type { AcePackage, RegistryEntry } from "./store.ts";
 import { packageHash } from "./resolve.ts";
-import type { IndexSignableContent } from "./signing.ts";
+import type { IndexSignableContent, RevocationMap } from "./signing.ts";
 import { signIndex } from "./signing.ts";
 import type { IndexDoc } from "./registry-remote.ts";
 
@@ -22,7 +22,7 @@ export function nextSequence(prev: IndexDoc | null): number {
 const RESERVED_IDENTITY_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 /** Assemble + sign an index doc from already-read packages. Duplicate name@version → error. */
 export function buildIndexDoc(args: {
-  packages: ReadonlyArray<{ pkg: AcePackage; url?: string }>; baseUrl: string; sequence: number; issuedAt: string; privatePem: string;
+  packages: ReadonlyArray<{ pkg: AcePackage; url?: string }>; baseUrl: string; sequence: number; issuedAt: string; privatePem: string; revoked?: RevocationMap; quarantined?: RevocationMap;
 }): IndexDoc | { error: string } {
   // Null-prototype map: a package name like "__proto__" cannot pollute via bracket-assign.
   const packages: Record<string, Record<string, RegistryEntry>> = Object.create(null);
@@ -41,7 +41,11 @@ export function buildIndexDoc(args: {
     versions[version] = { url, package_hash: packageHash(pkg) };
     packages[name] = versions;
   }
-  const content: IndexSignableContent = { format_version: 1, sequence: args.sequence, issued_at: args.issuedAt, packages };
+  const hasMarks = (m?: RevocationMap) => !!m && Object.keys(m).length > 0;
+  const fmt = (hasMarks(args.revoked) || hasMarks(args.quarantined)) ? 2 : 1;
+  const content: IndexSignableContent = { format_version: fmt, sequence: args.sequence, issued_at: args.issuedAt, packages };
+  if (hasMarks(args.revoked)) content.revoked = args.revoked!;
+  if (hasMarks(args.quarantined)) content.quarantined = args.quarantined!;
   const signature = signIndex(content, args.privatePem);
   return { ...content, signature };
 }

--- a/tools/ace/registry-remote.test.ts
+++ b/tools/ace/registry-remote.test.ts
@@ -18,7 +18,7 @@ describe("parseIndex", () => {
   });
   test.each([
     ["not json", "{"],
-    ["bad format_version", JSON.stringify({ format_version: 2, sequence: 1, issued_at: "2026-06-01T12:00:00Z", packages: {}, signature: { algo: "ed25519", key_id: "k", sig: "s" } })],
+    ["bad format_version", JSON.stringify({ format_version: 99, sequence: 1, issued_at: "2026-06-01T12:00:00Z", packages: {}, signature: { algo: "ed25519", key_id: "k", sig: "s" } })],
     ["negative sequence", JSON.stringify({ format_version: 1, sequence: -1, issued_at: "2026-06-01T12:00:00Z", packages: {}, signature: { algo: "ed25519", key_id: "k", sig: "s" } })],
     ["unparseable issued_at", JSON.stringify({ format_version: 1, sequence: 1, issued_at: "nope", packages: {}, signature: { algo: "ed25519", key_id: "k", sig: "s" } })],
     ["missing signature", JSON.stringify({ format_version: 1, sequence: 1, issued_at: "2026-06-01T12:00:00Z", packages: {} })],
@@ -214,5 +214,155 @@ describe("loadRegistries merge precedence", () => {
     const r = await loadRegistries({ trustStore: trust, now });
     expect(r.errors).toEqual([]);
     expect(r.registry.get("leaf")!.get("1.0.0")!.url).toBe("https://R0/l.json");
+  });
+});
+
+// ─── Task B: parseIndex v2 + marks + loadRegistries union-merge ─────────────
+
+import { signIndex as si2, generateKeypair as gk2 } from "./signing.ts";
+import type { RevocationMap } from "./signing.ts";
+
+function mkV2Index(kp: { privatePem: string; keyId: string }, seq: number, issuedAtMs: number, extra: Record<string, unknown> = {}) {
+  const content = {
+    format_version: 2 as const, sequence: seq, issued_at: new Date(issuedAtMs).toISOString(),
+    packages: { leaf: { "1.0.0": { url: "https://x/l.json", package_hash: "sha256:aa" } } },
+    ...extra,
+  };
+  return JSON.stringify({ ...content, signature: si2(content, kp.privatePem) });
+}
+
+describe("parseIndex — v2 + marks (Task B)", () => {
+  test("accepts a v2 index with no marks", () => {
+    const kp = gk2(); const now = Date.parse("2026-06-01T12:00:00Z");
+    const json = mkV2Index(kp, 1, now);
+    const r = parseIndex(json);
+    expect("error" in r).toBe(false);
+    if (!("error" in r)) { expect(r.format_version).toBe(2); }
+  });
+
+  test("accepts a v2 index with valid revoked + quarantined maps", () => {
+    const kp = gk2(); const now = Date.parse("2026-06-01T12:00:00Z");
+    const revoked: RevocationMap = { leaf: { "0.9.0": { at: "2026-05-01T00:00:00Z", reason: "CVE-xxx" } } };
+    const quarantined: RevocationMap = { leaf: { "0.8.0": { at: "2026-04-01T00:00:00Z" } } };
+    const json = mkV2Index(kp, 2, now, { revoked, quarantined });
+    const r = parseIndex(json);
+    expect("error" in r).toBe(false);
+    if (!("error" in r)) {
+      expect(r.revoked!["leaf"]!["0.9.0"]!.reason).toBe("CVE-xxx");
+      expect(r.quarantined!["leaf"]!["0.8.0"]!.at).toBe("2026-04-01T00:00:00Z");
+    }
+  });
+
+  test("rejects a v1 index carrying a revoked map", () => {
+    const revoked = { leaf: { "0.9.0": { at: "2026-05-01T00:00:00Z" } } };
+    const json = JSON.stringify({
+      format_version: 1, sequence: 1, issued_at: "2026-06-01T12:00:00Z",
+      packages: {}, revoked,
+      signature: { algo: "ed25519", key_id: "ed25519:k", sig: "BASE64" },
+    });
+    const r = parseIndex(json);
+    expect("error" in r).toBe(true);
+    if ("error" in r) expect(r.error).toContain("format_version 2");
+  });
+
+  test("rejects a v1 index carrying a quarantined map", () => {
+    const quarantined = { leaf: { "0.8.0": { at: "2026-04-01T00:00:00Z" } } };
+    const json = JSON.stringify({
+      format_version: 1, sequence: 1, issued_at: "2026-06-01T12:00:00Z",
+      packages: {}, quarantined,
+      signature: { algo: "ed25519", key_id: "ed25519:k", sig: "BASE64" },
+    });
+    const r = parseIndex(json);
+    expect("error" in r).toBe(true);
+    if ("error" in r) expect(r.error).toContain("format_version 2");
+  });
+
+  test("rejects a malformed revoked map (entry missing at)", () => {
+    const revoked = { leaf: { "0.9.0": { reason: "missing-at" } } };
+    const json = JSON.stringify({
+      format_version: 2, sequence: 1, issued_at: "2026-06-01T12:00:00Z",
+      packages: {}, revoked,
+      signature: { algo: "ed25519", key_id: "ed25519:k", sig: "BASE64" },
+    });
+    const r = parseIndex(json);
+    expect("error" in r).toBe(true);
+    if ("error" in r) expect(r.error).toContain("revoked");
+  });
+
+  test("rejects a malformed quarantined map (versions entry is not an object)", () => {
+    const quarantined = { leaf: "bad" };
+    const json = JSON.stringify({
+      format_version: 2, sequence: 1, issued_at: "2026-06-01T12:00:00Z",
+      packages: {}, quarantined,
+      signature: { algo: "ed25519", key_id: "ed25519:k", sig: "BASE64" },
+    });
+    const r = parseIndex(json);
+    expect("error" in r).toBe(true);
+    if ("error" in r) expect(r.error).toContain("quarantined");
+  });
+});
+
+import { loadRegistries as lr2 } from "./registry-remote.ts";
+import { mkdtempSync as mktmp2 } from "node:fs";
+import { tmpdir as td2 } from "node:os";
+import { join as pj2 } from "node:path";
+
+describe("loadRegistries — union-merge marks (Task B)", () => {
+  let savedFetch2: typeof globalThis.fetch, savedHome2: string | undefined, savedUP2: string | undefined;
+  beforeEach(() => {
+    savedFetch2 = globalThis.fetch; savedHome2 = process.env.HOME; savedUP2 = process.env.USERPROFILE;
+    const h = mktmp2(pj2(td2(), "ace-marks-"));
+    process.env.HOME = h; process.env.USERPROFILE = h;
+  });
+  afterEach(() => {
+    globalThis.fetch = savedFetch2;
+    if (savedHome2 !== undefined) process.env.HOME = savedHome2; else delete process.env.HOME;
+    if (savedUP2 !== undefined) process.env.USERPROFILE = savedUP2; else delete process.env.USERPROFILE;
+  });
+
+  test("union-merges revoked marks from two remote sources", async () => {
+    const kp0 = gk2(), kp1 = gk2();
+    const now = Date.parse("2026-06-01T12:00:00Z");
+
+    const mkBody = (kp: typeof kp0, revoked: RevocationMap) => {
+      const content = {
+        format_version: 2 as const, sequence: 1, issued_at: new Date(now).toISOString(),
+        packages: {}, revoked,
+      };
+      return JSON.stringify({ ...content, signature: si2(content, kp.privatePem) });
+    };
+
+    const body0 = mkBody(kp0, { pkgA: { "1.0.0": { at: "2026-01-01T00:00:00Z", reason: "from-r0" } } });
+    const body1 = mkBody(kp1, { pkgB: { "2.0.0": { at: "2026-02-01T00:00:00Z" } } });
+
+    globalThis.fetch = (async (u: string) =>
+      new Response(u === "https://r0/index.json" ? body0 : body1, { status: 200 })
+    ) as unknown as typeof fetch;
+
+    const { writeRegistryRemote: wrr2 } = await import("./store.ts");
+    wrr2({ url: "https://r0/index.json", key_id: kp0.keyId });
+    wrr2({ url: "https://r1/index.json", key_id: kp1.keyId });
+
+    const trust = new Map([[kp0.keyId, { public_key: kp0.publicSpkiB64 }], [kp1.keyId, { public_key: kp1.publicSpkiB64 }]]);
+    const result = await lr2({ trustStore: trust, now });
+
+    expect(result.errors).toEqual([]);
+    expect(result.revoked["pkgA"]?.["1.0.0"]?.reason).toBe("from-r0");
+    expect(result.revoked["pkgB"]?.["2.0.0"]?.at).toBe("2026-02-01T00:00:00Z");
+    expect(Object.keys(result.quarantined)).toHaveLength(0);
+  });
+
+  test("loadRegistries exposes empty revoked/quarantined when no marks in any source", async () => {
+    const kp = gk2(); const now = Date.parse("2026-06-01T12:00:00Z");
+    const content = { format_version: 1 as const, sequence: 1, issued_at: new Date(now).toISOString(), packages: {} };
+    const body = JSON.stringify({ ...content, signature: si2(content, kp.privatePem) });
+    globalThis.fetch = (async () => new Response(body, { status: 200 })) as unknown as typeof fetch;
+    const { writeRegistryRemote: wrr3 } = await import("./store.ts");
+    wrr3({ url: "https://x/index.json", key_id: kp.keyId });
+    const trust = new Map([[kp.keyId, { public_key: kp.publicSpkiB64 }]]);
+    const result = await lr2({ trustStore: trust, now });
+    expect(result.errors).toEqual([]);
+    expect(Object.keys(result.revoked)).toHaveLength(0);
+    expect(Object.keys(result.quarantined)).toHaveLength(0);
   });
 });

--- a/tools/ace/registry-remote.ts
+++ b/tools/ace/registry-remote.ts
@@ -2,7 +2,7 @@
 // signed remote registry index. Untrusted-input discipline throughout (never throw on bad
 // input; return { error } / { skipped }). The package bytes the index points at are still
 // hash-pinned + signature-gated downstream (unchanged) — index trust is additive.
-import type { AceSignature, IndexSignableContent, TrustEntry } from "./signing.ts";
+import type { AceSignature, IndexSignableContent, RevocationMap, TrustEntry } from "./signing.ts";
 import { verifyIndexSignature } from "./signing.ts";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
@@ -24,12 +24,28 @@ function isSig(s: unknown): s is AceSignature {
     && typeof (s as AceSignature).sig === "string";
 }
 
+function validMarkMap(m: unknown): boolean {
+  if (typeof m !== "object" || m === null) return false;
+  for (const name of Object.keys(m as object)) {
+    const vs = (m as Record<string, unknown>)[name];
+    if (typeof vs !== "object" || vs === null) return false;
+    for (const v of Object.keys(vs as object)) {
+      const e = (vs as Record<string, unknown>)[v];
+      if (typeof e !== "object" || e === null) return false;
+      const ee = e as Record<string, unknown>;
+      if (typeof ee.at !== "string") return false;
+      if (ee.reason !== undefined && typeof ee.reason !== "string") return false;
+    }
+  }
+  return true;
+}
+
 export function parseIndex(json: string): IndexDoc | { error: string } {
   let raw: unknown;
   try { raw = JSON.parse(json); } catch { return { error: "index is not valid JSON" }; }
   if (!raw || typeof raw !== "object") return { error: "index is not an object" };
   const o = raw as Record<string, unknown>;
-  if (o.format_version !== 1) return { error: "unsupported index format_version" };
+  if (o.format_version !== 1 && o.format_version !== 2) return { error: "unsupported index format_version" };
   if (typeof o.sequence !== "number" || !Number.isInteger(o.sequence) || o.sequence < 0) return { error: "index sequence must be a non-negative integer" };
   if (typeof o.issued_at !== "string" || Number.isNaN(Date.parse(o.issued_at))) return { error: "index issued_at must be RFC3339" };
   if (!o.packages || typeof o.packages !== "object") return { error: "index packages must be an object" };
@@ -43,8 +59,19 @@ export function parseIndex(json: string): IndexDoc | { error: string } {
     }
     packages[name] = vm;
   }
+  if (o.revoked !== undefined) {
+    if (o.format_version !== 2) return { error: "index revoked map requires format_version 2" };
+    if (!validMarkMap(o.revoked)) return { error: "index revoked map is malformed" };
+  }
+  if (o.quarantined !== undefined) {
+    if (o.format_version !== 2) return { error: "index quarantined map requires format_version 2" };
+    if (!validMarkMap(o.quarantined)) return { error: "index quarantined map is malformed" };
+  }
   if (!isSig(o.signature)) return { error: "index signature is malformed" };
-  return { format_version: 1, sequence: o.sequence, issued_at: o.issued_at, packages, signature: o.signature };
+  const doc: IndexDoc = { format_version: o.format_version as number, sequence: o.sequence, issued_at: o.issued_at, packages, signature: o.signature };
+  if (o.revoked !== undefined) doc.revoked = o.revoked as RevocationMap;
+  if (o.quarantined !== undefined) doc.quarantined = o.quarantined as RevocationMap;
+  return doc;
 }
 
 export const DEFAULT_MAX_STALENESS_DAYS = 30;
@@ -126,18 +153,21 @@ function toRegistryFragment(doc: IndexDoc): Registry {
 
 export async function fetchRemoteIndex(
   remote: RemoteRegistryConfig, trustStore: Map<string, TrustEntry>, opts: FetchOpts = {},
-): Promise<{ entries: Registry } | { error: string } | { skipped: string }> {
+): Promise<{ entries: Registry; marks: { revoked?: RevocationMap; quarantined?: RevocationMap } } | { error: string } | { skipped: string }> {
   const now = opts.now ?? Date.now();
   const cached = readCache(remote.url);
   const cacheMeta: CacheMeta = cached?.meta ?? { url: remote.url, sequence_high_water: 0, index_content_hash: "", fetched_at: "" };
 
   // Validate a CACHED body through the three gates; never writes (the fresh-200 path writes its own cache).
-  const useCachedBody = (body: string): { entries: Registry } | { error: string } => {
+  const useCachedBody = (body: string): { entries: Registry; marks: { revoked?: RevocationMap; quarantined?: RevocationMap } } | { error: string } => {
     const parsed = parseIndex(body);
     if ("error" in parsed) return { error: `${remote.url}: ${parsed.error}` };
     const v = verifyIndex(parsed, remote, trustStore, cacheMeta, now, { offline: opts.offline === true });
     if (!v.ok) return { error: `${remote.url}: ${v.reason}` };
-    return { entries: toRegistryFragment(parsed) };
+    const marks: { revoked?: RevocationMap; quarantined?: RevocationMap } = {};
+    if (parsed.revoked !== undefined) marks.revoked = parsed.revoked;
+    if (parsed.quarantined !== undefined) marks.quarantined = parsed.quarantined;
+    return { entries: toRegistryFragment(parsed), marks };
   };
 
   if (opts.offline) {
@@ -176,23 +206,35 @@ export async function fetchRemoteIndex(
     ...(etag !== undefined ? { etag } : {}),
     ...(last_modified !== undefined ? { last_modified } : {}),
   });
-  return { entries: toRegistryFragment(parsed) };
+  const freshMarks: { revoked?: RevocationMap; quarantined?: RevocationMap } = {};
+  if (parsed.revoked !== undefined) freshMarks.revoked = parsed.revoked;
+  if (parsed.quarantined !== undefined) freshMarks.quarantined = parsed.quarantined;
+  return { entries: toRegistryFragment(parsed), marks: freshMarks };
 }
 
 export interface LoadRegistriesOpts { trustStore: Map<string, TrustEntry>; offline?: boolean; now?: number }
 
+export interface LoadedRegistries {
+  registry: Registry;
+  revoked: RevocationMap;
+  quarantined: RevocationMap;
+  warnings: string[];
+  errors: string[];
+}
+
 /** Merge: remotes (reverse listed order) ∪ bundled ∪ user → user > bundled > remote[0] > … */
 export async function loadRegistries(
   opts: LoadRegistriesOpts,
-): Promise<{ registry: Registry; warnings: string[]; errors: string[] }> {
+): Promise<LoadedRegistries> {
   const warnings: string[] = []; const errors: string[] = [];
   const remotes = readRegistriesConfig().remotes;
   const fragments: Registry[] = [];
+  const markFragments: { revoked?: RevocationMap; quarantined?: RevocationMap }[] = [];
   for (const remote of remotes) {
     const r = await fetchRemoteIndex(remote, opts.trustStore, { offline: opts.offline === true, ...(opts.now !== undefined ? { now: opts.now } : {}) });
     if ("error" in r) errors.push(r.error);
     else if ("skipped" in r) warnings.push(r.skipped);
-    else fragments.push(r.entries);
+    else { fragments.push(r.entries); markFragments.push(r.marks); }
   }
   const registry: Registry = new Map();
   const merge = (frag: Registry): void => {
@@ -204,5 +246,16 @@ export async function loadRegistries(
   };
   for (let i = fragments.length - 1; i >= 0; i--) merge(fragments[i]!);
   merge(loadRegistry());
-  return { registry, warnings, errors };
+  const mergedRevoked: RevocationMap = Object.create(null);
+  const mergedQuarantined: RevocationMap = Object.create(null);
+  const unionMerge = (target: RevocationMap, src: RevocationMap | undefined): void => {
+    if (!src) return;
+    for (const name of Object.keys(src)) {
+      const vs = src[name]!;
+      if (!target[name]) target[name] = Object.create(null);
+      for (const v of Object.keys(vs)) { target[name]![v] = vs[v]!; }
+    }
+  };
+  for (const mf of markFragments) { unionMerge(mergedRevoked, mf.revoked); unionMerge(mergedQuarantined, mf.quarantined); }
+  return { registry, revoked: mergedRevoked, quarantined: mergedQuarantined, warnings, errors };
 }

--- a/tools/ace/registry-revoke.test.ts
+++ b/tools/ace/registry-revoke.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import { applyRevoke, applyQuarantine, applyUnquarantine } from "./registry-revoke.ts";
+import type { IndexSignableContent } from "./signing.ts";
+
+function baseContent(): IndexSignableContent {
+  return {
+    format_version: 1,
+    sequence: 1,
+    issued_at: "2026-06-01T00:00:00Z",
+    packages: Object.create(null) as Record<string, Record<string, import("./store.ts").RegistryEntry>>,
+  };
+}
+
+describe("applyRevoke", () => {
+  test("adds entry to revoked + sets format_version 2", () => {
+    const prev = baseContent();
+    const next = applyRevoke(prev, "leaf", "1.0.0", "critical bug", "2026-06-01T00:00:00Z");
+    expect(next.format_version).toBe(2);
+    expect(next.revoked?.["leaf"]?.["1.0.0"]?.reason).toBe("critical bug");
+    expect(next.revoked?.["leaf"]?.["1.0.0"]?.at).toBe("2026-06-01T00:00:00Z");
+  });
+
+  test("without reason — entry has no reason field (exactOptionalPropertyTypes)", () => {
+    const prev = baseContent();
+    const next = applyRevoke(prev, "leaf", "1.0.0", undefined, "2026-06-01T00:00:00Z");
+    const entry = next.revoked?.["leaf"]?.["1.0.0"];
+    expect(entry).toBeDefined();
+    expect("reason" in (entry ?? {})).toBe(false);
+    expect(entry?.at).toBe("2026-06-01T00:00:00Z");
+  });
+
+  test("re-revoke is idempotent (no error, still revoked)", () => {
+    const prev = baseContent();
+    const once = applyRevoke(prev, "leaf", "1.0.0", "v1", "2026-06-01T00:00:00Z");
+    const twice = applyRevoke(once, "leaf", "1.0.0", "v2", "2026-06-01T01:00:00Z");
+    expect("error" in twice).toBe(false);
+    // latest call wins
+    expect(twice.revoked?.["leaf"]?.["1.0.0"]?.reason).toBe("v2");
+    expect(twice.format_version).toBe(2);
+  });
+
+  test("revoke clears matching quarantined entry", () => {
+    let prev = baseContent();
+    prev = applyQuarantine(prev, "leaf", "1.0.0", "maybe bad", "2026-06-01T00:00:00Z") as IndexSignableContent;
+    expect(prev.quarantined?.["leaf"]?.["1.0.0"]).toBeDefined();
+    const next = applyRevoke(prev, "leaf", "1.0.0", "definitely bad", "2026-06-01T01:00:00Z");
+    expect(next.revoked?.["leaf"]?.["1.0.0"]).toBeDefined();
+    expect(next.quarantined?.["leaf"]?.["1.0.0"]).toBeUndefined();
+  });
+
+  test("does not mutate prev", () => {
+    const prev = baseContent();
+    applyRevoke(prev, "leaf", "1.0.0", "bug", "2026-06-01T00:00:00Z");
+    expect(prev.revoked).toBeUndefined();
+    expect(prev.format_version).toBe(1);
+  });
+});
+
+describe("applyQuarantine", () => {
+  test("adds entry to quarantined + sets format_version 2", () => {
+    const prev = baseContent();
+    const next = applyQuarantine(prev, "leaf", "1.0.0", "suspicious", "2026-06-01T00:00:00Z");
+    expect("error" in next).toBe(false);
+    if ("error" in next) return;
+    expect(next.format_version).toBe(2);
+    expect(next.quarantined?.["leaf"]?.["1.0.0"]?.reason).toBe("suspicious");
+    expect(next.quarantined?.["leaf"]?.["1.0.0"]?.at).toBe("2026-06-01T00:00:00Z");
+  });
+
+  test("without reason — no reason field", () => {
+    const prev = baseContent();
+    const next = applyQuarantine(prev, "leaf", "1.0.0", undefined, "2026-06-01T00:00:00Z");
+    if ("error" in next) return;
+    const entry = next.quarantined?.["leaf"]?.["1.0.0"];
+    expect(entry).toBeDefined();
+    expect("reason" in (entry ?? {})).toBe(false);
+  });
+
+  test("errors when already revoked", () => {
+    const prev = applyRevoke(baseContent(), "leaf", "1.0.0", undefined, "2026-06-01T00:00:00Z");
+    const result = applyQuarantine(prev, "leaf", "1.0.0", "too late", "2026-06-01T01:00:00Z");
+    expect("error" in result).toBe(true);
+    if ("error" in result) expect(result.error).toMatch(/revoked/);
+  });
+
+  test("does not mutate prev", () => {
+    const prev = baseContent();
+    applyQuarantine(prev, "leaf", "1.0.0", "q", "2026-06-01T00:00:00Z");
+    expect(prev.quarantined).toBeUndefined();
+    expect(prev.format_version).toBe(1);
+  });
+});
+
+describe("applyUnquarantine", () => {
+  test("removes quarantine entry", () => {
+    let prev = baseContent();
+    const q = applyQuarantine(prev, "leaf", "1.0.0", "q", "2026-06-01T00:00:00Z");
+    if ("error" in q) throw new Error("unexpected error");
+    prev = q;
+    const next = applyUnquarantine(prev, "leaf", "1.0.0");
+    expect("error" in next).toBe(false);
+    if ("error" in next) return;
+    expect(next.quarantined?.["leaf"]?.["1.0.0"]).toBeUndefined();
+  });
+
+  test("reverts format_version to 1 when it was the last mark", () => {
+    const q = applyQuarantine(baseContent(), "leaf", "1.0.0", "q", "2026-06-01T00:00:00Z");
+    if ("error" in q) throw new Error("unexpected");
+    const next = applyUnquarantine(q, "leaf", "1.0.0");
+    if ("error" in next) throw new Error("unexpected");
+    expect(next.format_version).toBe(1);
+  });
+
+  test("keeps format_version 2 when other marks remain", () => {
+    let prev = baseContent();
+    const q1 = applyQuarantine(prev, "alpha", "1.0.0", "q1", "2026-06-01T00:00:00Z");
+    if ("error" in q1) throw new Error("unexpected");
+    prev = q1;
+    const q2 = applyQuarantine(prev, "beta", "2.0.0", "q2", "2026-06-01T00:00:00Z");
+    if ("error" in q2) throw new Error("unexpected");
+    prev = q2;
+    const next = applyUnquarantine(prev, "alpha", "1.0.0");
+    if ("error" in next) throw new Error("unexpected");
+    expect(next.format_version).toBe(2);
+    expect(next.quarantined?.["beta"]?.["2.0.0"]).toBeDefined();
+  });
+
+  test("errors when not quarantined", () => {
+    const result = applyUnquarantine(baseContent(), "leaf", "1.0.0");
+    expect("error" in result).toBe(true);
+    if ("error" in result) expect(result.error).toMatch(/not quarantined/);
+  });
+
+  test("does not mutate prev", () => {
+    const q = applyQuarantine(baseContent(), "leaf", "1.0.0", "q", "2026-06-01T00:00:00Z");
+    if ("error" in q) throw new Error("unexpected");
+    const snap = JSON.stringify(q);
+    applyUnquarantine(q, "leaf", "1.0.0");
+    expect(JSON.stringify(q)).toBe(snap);
+  });
+});

--- a/tools/ace/registry-revoke.test.ts
+++ b/tools/ace/registry-revoke.test.ts
@@ -97,7 +97,7 @@ describe("applyUnquarantine", () => {
     const q = applyQuarantine(prev, "leaf", "1.0.0", "q", "2026-06-01T00:00:00Z");
     if ("error" in q) throw new Error("unexpected error");
     prev = q;
-    const next = applyUnquarantine(prev, "leaf", "1.0.0");
+    const next = applyUnquarantine(prev, "leaf", "1.0.0", "2026-06-01T01:00:00Z");
     expect("error" in next).toBe(false);
     if ("error" in next) return;
     expect(next.quarantined?.["leaf"]?.["1.0.0"]).toBeUndefined();
@@ -106,7 +106,7 @@ describe("applyUnquarantine", () => {
   test("reverts format_version to 1 when it was the last mark", () => {
     const q = applyQuarantine(baseContent(), "leaf", "1.0.0", "q", "2026-06-01T00:00:00Z");
     if ("error" in q) throw new Error("unexpected");
-    const next = applyUnquarantine(q, "leaf", "1.0.0");
+    const next = applyUnquarantine(q, "leaf", "1.0.0", "2026-06-01T01:00:00Z");
     if ("error" in next) throw new Error("unexpected");
     expect(next.format_version).toBe(1);
   });
@@ -119,14 +119,14 @@ describe("applyUnquarantine", () => {
     const q2 = applyQuarantine(prev, "beta", "2.0.0", "q2", "2026-06-01T00:00:00Z");
     if ("error" in q2) throw new Error("unexpected");
     prev = q2;
-    const next = applyUnquarantine(prev, "alpha", "1.0.0");
+    const next = applyUnquarantine(prev, "alpha", "1.0.0", "2026-06-01T01:00:00Z");
     if ("error" in next) throw new Error("unexpected");
     expect(next.format_version).toBe(2);
     expect(next.quarantined?.["beta"]?.["2.0.0"]).toBeDefined();
   });
 
   test("errors when not quarantined", () => {
-    const result = applyUnquarantine(baseContent(), "leaf", "1.0.0");
+    const result = applyUnquarantine(baseContent(), "leaf", "1.0.0", "2026-06-01T01:00:00Z");
     expect("error" in result).toBe(true);
     if ("error" in result) expect(result.error).toMatch(/not quarantined/);
   });
@@ -135,7 +135,57 @@ describe("applyUnquarantine", () => {
     const q = applyQuarantine(baseContent(), "leaf", "1.0.0", "q", "2026-06-01T00:00:00Z");
     if ("error" in q) throw new Error("unexpected");
     const snap = JSON.stringify(q);
-    applyUnquarantine(q, "leaf", "1.0.0");
+    applyUnquarantine(q, "leaf", "1.0.0", "2026-06-01T01:00:00Z");
     expect(JSON.stringify(q)).toBe(snap);
+  });
+});
+
+describe("issued_at refresh", () => {
+  test("applyRevoke sets issued_at to the `at` param", () => {
+    const prev = baseContent(); // issued_at "2026-06-01T00:00:00Z"
+    const at = "2026-06-01T12:00:00Z";
+    const next = applyRevoke(prev, "leaf", "1.0.0", "bug", at);
+    expect(next.issued_at).toBe(at);
+    expect(next.issued_at).not.toBe(prev.issued_at);
+  });
+
+  test("applyQuarantine sets issued_at to the `at` param", () => {
+    const prev = baseContent();
+    const at = "2026-06-01T12:00:00Z";
+    const next = applyQuarantine(prev, "leaf", "1.0.0", "suspicious", at);
+    if ("error" in next) throw new Error("unexpected error");
+    expect(next.issued_at).toBe(at);
+    expect(next.issued_at).not.toBe(prev.issued_at);
+  });
+
+  test("applyUnquarantine sets issued_at to the `at` param", () => {
+    const q = applyQuarantine(baseContent(), "leaf", "1.0.0", "q", "2026-06-01T00:00:00Z");
+    if ("error" in q) throw new Error("unexpected");
+    const at = "2026-06-01T12:00:00Z";
+    const next = applyUnquarantine(q, "leaf", "1.0.0", at);
+    if ("error" in next) throw new Error("unexpected");
+    expect(next.issued_at).toBe(at);
+    expect(next.issued_at).not.toBe(q.issued_at);
+  });
+});
+
+describe("empty mark map stripping (pure layer)", () => {
+  test("applyUnquarantine of last quarantined mark leaves no quarantined key", () => {
+    const q = applyQuarantine(baseContent(), "leaf", "1.0.0", "q", "2026-06-01T00:00:00Z");
+    if ("error" in q) throw new Error("unexpected");
+    const next = applyUnquarantine(q, "leaf", "1.0.0", "2026-06-01T01:00:00Z");
+    if ("error" in next) throw new Error("unexpected");
+    expect("quarantined" in next).toBe(false);
+    expect(next.format_version).toBe(1);
+  });
+
+  test("applyRevoke of only quarantined version clears quarantined key, keeps revoked", () => {
+    const q = applyQuarantine(baseContent(), "leaf", "1.0.0", "q", "2026-06-01T00:00:00Z");
+    if ("error" in q) throw new Error("unexpected");
+    // revoke supersedes quarantine: quarantined becomes empty
+    const next = applyRevoke(q, "leaf", "1.0.0", "bad", "2026-06-01T01:00:00Z");
+    expect("quarantined" in next).toBe(false);
+    expect(next.revoked?.["leaf"]?.["1.0.0"]).toBeDefined();
+    expect(next.format_version).toBe(2);
   });
 });

--- a/tools/ace/registry-revoke.ts
+++ b/tools/ace/registry-revoke.ts
@@ -1,0 +1,43 @@
+// registry-revoke.ts -- Ace slice 7: pure apply functions for revocation + quarantine marks.
+// All functions are pure (no I/O). Returns new content or { error: string }.
+import type { IndexSignableContent, RevocationMap, RevocationEntry } from "./signing.ts";
+
+// format_version is 2 iff a mark remains, else 1.
+function withFmt(c: IndexSignableContent): IndexSignableContent {
+  const hasMarks = (m?: RevocationMap) => !!m && Object.keys(m).length > 0;
+  return { ...c, format_version: (hasMarks(c.revoked) || hasMarks(c.quarantined)) ? 2 : 1 };
+}
+function clone(m: RevocationMap | undefined): RevocationMap {
+  // deep-ish clone (own keys only; null-proto to avoid prototype pollution)
+  const out: RevocationMap = Object.create(null);
+  for (const n of Object.keys(m ?? {})) { out[n] = Object.create(null); for (const v of Object.keys(m![n]!)) out[n]![v] = { ...m![n]![v]! }; }
+  return out;
+}
+function has(m: RevocationMap | undefined, name: string, version: string): boolean {
+  return !!m && !!m[name] && m[name]![version] !== undefined;
+}
+function add(m: RevocationMap, name: string, version: string, entry: RevocationEntry): void {
+  (m[name] ?? (m[name] = Object.create(null)))[version] = entry;
+}
+function remove(m: RevocationMap, name: string, version: string): void {
+  if (m[name]) { delete m[name]![version]; if (Object.keys(m[name]!).length === 0) delete m[name]; }
+}
+
+export function applyRevoke(prev: IndexSignableContent, name: string, version: string, reason: string | undefined, at: string): IndexSignableContent {
+  const revoked = clone(prev.revoked); const quarantined = clone(prev.quarantined);
+  remove(quarantined, name, version);                 // revoke supersedes quarantine
+  add(revoked, name, version, reason !== undefined ? { reason, at } : { at });
+  return withFmt({ ...prev, revoked, quarantined });
+}
+export function applyQuarantine(prev: IndexSignableContent, name: string, version: string, reason: string | undefined, at: string): IndexSignableContent | { error: string } {
+  if (has(prev.revoked, name, version)) return { error: `${name}@${version} is revoked (terminal); cannot quarantine` };
+  const quarantined = clone(prev.quarantined);
+  add(quarantined, name, version, reason !== undefined ? { reason, at } : { at });
+  return withFmt({ ...prev, quarantined });
+}
+export function applyUnquarantine(prev: IndexSignableContent, name: string, version: string): IndexSignableContent | { error: string } {
+  if (!has(prev.quarantined, name, version)) return { error: `${name}@${version} is not quarantined` };
+  const quarantined = clone(prev.quarantined);
+  remove(quarantined, name, version);
+  return withFmt({ ...prev, quarantined });
+}

--- a/tools/ace/registry-revoke.ts
+++ b/tools/ace/registry-revoke.ts
@@ -2,10 +2,15 @@
 // All functions are pure (no I/O). Returns new content or { error: string }.
 import type { IndexSignableContent, RevocationMap, RevocationEntry } from "./signing.ts";
 
-// format_version is 2 iff a mark remains, else 1.
-function withFmt(c: IndexSignableContent): IndexSignableContent {
+// format_version is 2 iff a mark remains, else 1.  Also strips empty mark maps
+// so a v1 result never carries revoked:{} or quarantined:{}, which parseIndex rejects.
+function withFmt(c: IndexSignableContent, issuedAt: string): IndexSignableContent {
   const hasMarks = (m?: RevocationMap) => !!m && Object.keys(m).length > 0;
-  return { ...c, format_version: (hasMarks(c.revoked) || hasMarks(c.quarantined)) ? 2 : 1 };
+  const out: IndexSignableContent = { ...c, issued_at: issuedAt };
+  if (!hasMarks(out.revoked)) delete out.revoked;
+  if (!hasMarks(out.quarantined)) delete out.quarantined;
+  out.format_version = (hasMarks(c.revoked) || hasMarks(c.quarantined)) ? 2 : 1;
+  return out;
 }
 function clone(m: RevocationMap | undefined): RevocationMap {
   // deep-ish clone (own keys only; null-proto to avoid prototype pollution)
@@ -27,17 +32,17 @@ export function applyRevoke(prev: IndexSignableContent, name: string, version: s
   const revoked = clone(prev.revoked); const quarantined = clone(prev.quarantined);
   remove(quarantined, name, version);                 // revoke supersedes quarantine
   add(revoked, name, version, reason !== undefined ? { reason, at } : { at });
-  return withFmt({ ...prev, revoked, quarantined });
+  return withFmt({ ...prev, revoked, quarantined }, at);
 }
 export function applyQuarantine(prev: IndexSignableContent, name: string, version: string, reason: string | undefined, at: string): IndexSignableContent | { error: string } {
   if (has(prev.revoked, name, version)) return { error: `${name}@${version} is revoked (terminal); cannot quarantine` };
   const quarantined = clone(prev.quarantined);
   add(quarantined, name, version, reason !== undefined ? { reason, at } : { at });
-  return withFmt({ ...prev, quarantined });
+  return withFmt({ ...prev, quarantined }, at);
 }
-export function applyUnquarantine(prev: IndexSignableContent, name: string, version: string): IndexSignableContent | { error: string } {
+export function applyUnquarantine(prev: IndexSignableContent, name: string, version: string, at: string): IndexSignableContent | { error: string } {
   if (!has(prev.quarantined, name, version)) return { error: `${name}@${version} is not quarantined` };
   const quarantined = clone(prev.quarantined);
   remove(quarantined, name, version);
-  return withFmt({ ...prev, quarantined });
+  return withFmt({ ...prev, quarantined }, at);
 }

--- a/tools/ace/resolve.test.ts
+++ b/tools/ace/resolve.test.ts
@@ -301,3 +301,92 @@ describe("resolve — untrusted registry edge version (regression / bad-range)",
     if (!r.ok) expect(r.reason).toBe("invalid-package");
   });
 });
+
+// ─── Task B: revoked / quarantined gates ─────────────────────────────────────
+
+import type { RevocationMap as RM } from "./signing.ts";
+
+describe("resolve — revoked / quarantined gates (Task B)", () => {
+  function mkRegRoot(): AcePackage {
+    return {
+      manifest: {
+        ...pkgOf("root", { "r.txt": "r" }).manifest,
+        dependencies: [{ kind: "registry" as const, name: "D", version: "1.0.0" }],
+      },
+      files: { "r.txt": "r" },
+    };
+  }
+
+  test("revoked concrete version → ok:false reason:revoked", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root = mkRegRoot();
+    const reg = regOf({ D: { "1.0.0": { url: "http://e/D", package_hash: packageHash(D) } } });
+    const revokedMap: RM = { D: { "1.0.0": { at: "2026-05-01T00:00:00Z", reason: "CVE-test" } } };
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, reg, new Map([["D", "1.0.0"]]), {
+      allowNoSignature: true,
+      revoked: revokedMap,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe("revoked");
+      expect(r.detail).toContain("CVE-test");
+    }
+  });
+
+  test("quarantined version refuses without allowQuarantined", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root = mkRegRoot();
+    const reg = regOf({ D: { "1.0.0": { url: "http://e/D", package_hash: packageHash(D) } } });
+    const quarantinedMap: RM = { D: { "1.0.0": { at: "2026-05-01T00:00:00Z", reason: "suspect" } } };
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, reg, new Map([["D", "1.0.0"]]), {
+      allowNoSignature: true,
+      quarantined: quarantinedMap,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe("quarantined");
+      expect(r.detail).toContain("suspect");
+      expect(r.detail).toContain("--allow-quarantined");
+    }
+  });
+
+  test("quarantined version resolves with allowQuarantined:true", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root = mkRegRoot();
+    const reg = regOf({ D: { "1.0.0": { url: "http://e/D", package_hash: packageHash(D) } } });
+    const quarantinedMap: RM = { D: { "1.0.0": { at: "2026-05-01T00:00:00Z" } } };
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, reg, new Map([["D", "1.0.0"]]), {
+      allowNoSignature: true,
+      quarantined: quarantinedMap,
+      allowQuarantined: true,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  test("revoked with no reason in detail still refuses cleanly", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root = mkRegRoot();
+    const reg = regOf({ D: { "1.0.0": { url: "http://e/D", package_hash: packageHash(D) } } });
+    const revokedMap: RM = { D: { "1.0.0": { at: "2026-05-01T00:00:00Z" } } };
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, reg, new Map([["D", "1.0.0"]]), {
+      allowNoSignature: true,
+      revoked: revokedMap,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("revoked");
+  });
+
+  test("non-revoked/quarantined version resolves normally (no false positive)", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    const root = mkRegRoot();
+    const reg = regOf({ D: { "1.0.0": { url: "http://e/D", package_hash: packageHash(D) } } });
+    const revokedMap: RM = { D: { "9.9.9": { at: "2026-05-01T00:00:00Z" } } };
+    const quarantinedMap: RM = { OTHER: { "1.0.0": { at: "2026-05-01T00:00:00Z" } } };
+    const r = await resolve(root, fetchOf({ "http://e/D": D }), NO_TRUST, reg, new Map([["D", "1.0.0"]]), {
+      allowNoSignature: true,
+      revoked: revokedMap,
+      quarantined: quarantinedMap,
+    });
+    expect(r.ok).toBe(true);
+  });
+});

--- a/tools/ace/resolve.ts
+++ b/tools/ace/resolve.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import type { RevocationMap } from "./signing.ts";
 import { contentHash, type AcePackage, type LoadedTrustEntry, type Registry } from "./store.ts";
 import { verifySignature } from "./signing.ts";
 import { parseRange, satisfies } from "./semver.ts";
@@ -24,7 +25,7 @@ export type ResolveReason =
   | "version-skew" | "tamper" | "pin-mismatch" | "bad-content-hash"
   | "bad-signature" | "untrusted-key" | "unsupported-algo" | "no-signature"
   | "cycle" | "fetch-failed" | "invalid-package" | "registry-miss"
-  | "unsatisfiable" | "bad-range";
+  | "unsatisfiable" | "bad-range" | "revoked" | "quarantined";
 
 export type ResolveResult =
   | { ok: true; order: AcePackage[] }
@@ -36,7 +37,7 @@ export async function resolve(
   trustStore: Map<string, LoadedTrustEntry>,
   registry: Registry,
   solved: Map<string, string>,
-  opts: { allowNoSignature: boolean },
+  opts: { allowNoSignature: boolean; allowQuarantined?: boolean; revoked?: RevocationMap; quarantined?: RevocationMap },
 ): Promise<ResolveResult> {
   const byName = new Map<string, { version: string; pkgHash: string; path: string[] }>();
   const visiting = new Set<string>();
@@ -87,6 +88,14 @@ export async function resolve(
           return { ok: false, reason: "registry-miss", detail: `${edge.name}@${concrete} not in registry`, path: here };
         }
         url = entry.url; package_hash = entry.package_hash;
+        if (opts.revoked && opts.revoked[edge.name]?.[concrete] !== undefined) {
+          const r = opts.revoked[edge.name]![concrete]!;
+          return { ok: false, reason: "revoked", detail: `${edge.name}@${concrete} is revoked${r.reason ? ": " + r.reason : ""}`, path: here };
+        }
+        if (!opts.allowQuarantined && opts.quarantined && opts.quarantined[edge.name]?.[concrete] !== undefined) {
+          const q = opts.quarantined[edge.name]![concrete]!;
+          return { ok: false, reason: "quarantined", detail: `${edge.name}@${concrete} is quarantined${q.reason ? ": " + q.reason : ""} (use --allow-quarantined)`, path: here };
+        }
         effectiveVersion = concrete;
       } else {
         if (typeof edge.url !== "string" || typeof edge.package_hash !== "string" || typeof edge.version !== "string") {

--- a/tools/ace/signing.ts
+++ b/tools/ace/signing.ts
@@ -78,11 +78,16 @@ export function verifySignature(
   return result;
 }
 
+export interface RevocationEntry { reason?: string; at: string }
+export type RevocationMap = Record<string, Record<string, RevocationEntry>>;
+
 export interface IndexSignableContent {
   format_version: number;
   sequence: number;
   issued_at: string;
   packages: Record<string, Record<string, RegistryEntry>>;
+  revoked?: RevocationMap;
+  quarantined?: RevocationMap;
 }
 
 /** Index content (no `signature`), recursively key-sorted, compact JSON. Sibling of canonicalManifestBytes. */


### PR DESCRIPTION
Implements **slice 7** (revocation/quarantine; B-0288, lifecycle stage 12). Spec: #6466. Built subagent-driven per `docs/agendas/ace-package-manager/2026-06-01-ace-cli-slice7-implementation-plan.md` (Tasks A→D + a pure-layer fix).

## What it does
- **Two marks in the signed index (format_version 2):** `revoked` (permanent hard-refuse) + `quarantined` (soft-refuse, override-able), as sibling maps in `IndexSignableContent` — covered by the existing signature + monotonic-sequence anti-rollback + freshness gates (a revocation can't be un-seen by serving an older index). Plain publish stays format_version 1.
- **Producer:** `ace registry revoke|quarantine|unquarantine <name>@<version> --key <pem> [--reason] [--out]` — read-verify-mark-bump-refresh-sign-selfverify-write (reuses 6.1's mutate-guard: refuses to edit an index this key didn't sign). revoke supersedes quarantine; quarantine errors on already-revoked; no `unrevoke` (permanent). `publish` carries marks forward.
- **Consumer:** resolve + install refuse marked versions (new `revoked`/`quarantined` ResolveReasons; union-merged across registries). **Revocation overrides the lockfile** (`--frozen` replay re-checks pins; default path re-resolves). `ace install --allow-quarantined` opts in.

## Mechanics
- `registry-revoke.ts` (new, pure) `applyRevoke`/`applyQuarantine`/`applyUnquarantine` — refresh `issued_at`, strip empty mark maps (format_version reverts to 1 when the last mark clears). `buildIndexDoc` carry-forward. `parseIndex` accepts v1|v2 (v1-with-marks rejected; fail-closed for a v1-only consumer on v2). `loadRegistries` union-merges marks.

## Verification
- `bun test tools/ace/` 338 pass / 0 fail (47 net-new across registry-revoke/publish/remote/resolve/ace tests); RED→GREEN + 3 false-green checks (resolve gate, lockfile re-check, issued_at).
- strict `tsc --noEmit` exit 0; markdownlint clean; pure LF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)