### PR TITLE
feat(algebra): Z-set F# generic-math — Zero/(+)/(~-)/(-) on the type (abelian group)

### DIFF
--- a/src/Core/ZSet.fs
+++ b/src/Core/ZSet.fs
@@ -41,6 +41,70 @@ type ZSet<'K when 'K : comparison> =
 
     static member Empty : ZSet<'K> = ZSet(ImmutableArray<ZEntry<'K>>.Empty)
 
+    /// Generic-math additive identity (`System.Numerics`-shaped). F# SRTP —
+    /// `LanguagePrimitives.GenericZero`, `Seq.sum`/`List.sum` — resolves the
+    /// zero through this member; the empty Z-set is the `+` identity
+    /// (`a + Zero = a`, `Zero + a = a`). The `ZSet.empty` module value and the
+    /// C# `IAdditiveIdentity` twin carry the same meaning per-language.
+    static member Zero : ZSet<'K> = ZSet<'K>.Empty
+
+    /// `a + b` — per-key **signed sum**, the abelian-group operation. Linear
+    /// sorted-merge over the two spans: one pool workspace + one final array.
+    /// This is the generic-math addition rung (C#'s `IAdditionOperators` twin);
+    /// the `ZSet.add` module function delegates here so SRTP can resolve `(+)`
+    /// on the type itself rather than the (later-defined) module. Combiner is
+    /// SUM, NOT idempotent — `a + a` doubles every weight (the Bag/Z-set step
+    /// away from G-Set's idempotent union).
+    static member (+) (a: ZSet<'K>, b: ZSet<'K>) : ZSet<'K> =
+        if a.IsEmpty then b
+        elif b.IsEmpty then a
+        else
+            let sa = a.AsSpan()
+            let sb = b.AsSpan()
+            let cap = sa.Length + sb.Length
+            let rented = Pool.Rent<ZEntry<'K>> cap
+            try
+                let cmp = Comparer<'K>.Default
+                let mutable i = 0
+                let mutable j = 0
+                let mutable k = 0
+                while i < sa.Length && j < sb.Length do
+                    let c = cmp.Compare(sa.[i].Key, sb.[j].Key)
+                    if c < 0 then rented.[k] <- sa.[i]; i <- i + 1; k <- k + 1
+                    elif c > 0 then rented.[k] <- sb.[j]; j <- j + 1; k <- k + 1
+                    else
+                        // `Checked.(+)` — Z-set weights are int64 but nothing
+                        // stops a stream from running forever; silent wraparound
+                        // on overflow would turn a +2^63 multiset into a -2^63
+                        // multiset and corrupt every downstream query.
+                        let s = Checked.(+) sa.[i].Weight sb.[j].Weight
+                        if s <> 0L then rented.[k] <- ZEntry(sa.[i].Key, s); k <- k + 1
+                        i <- i + 1; j <- j + 1
+                while i < sa.Length do rented.[k] <- sa.[i]; i <- i + 1; k <- k + 1
+                while j < sb.Length do rented.[k] <- sb.[j]; j <- j + 1; k <- k + 1
+                if k = 0 then ZSet<'K>.Empty else ZSet(Pool.FreezeSlice(rented, k))
+            finally
+                Pool.Return rented
+
+    /// `-a` — the abelian-group **inverse**: flip every sign, so
+    /// `a + (-a) = Zero` (the law a Bag cannot satisfy, and why the Z-set — not
+    /// the Bag — is the substrate for retraction / undo / DBSP). Exact-size
+    /// allocation, no workspace. C#'s `IUnaryNegationOperators` twin.
+    static member (~-) (a: ZSet<'K>) : ZSet<'K> =
+        let span = a.AsSpan()
+        if span.IsEmpty then a
+        else
+            let arr = Pool.AllocateExact<ZEntry<'K>> span.Length
+            for i in 0 .. span.Length - 1 do
+                // Checked negation — `-Int64.MinValue` overflows.
+                arr.[i] <- ZEntry(span.[i].Key, Checked.(-) 0L span.[i].Weight)
+            ZSet(Pool.Freeze arr)
+
+    /// `a - b = a + (-b)`. The generic-math subtraction rung (C#'s
+    /// `ISubtractionOperators` twin); retraction expressed directly.
+    static member (-) (a: ZSet<'K>, b: ZSet<'K>) : ZSet<'K> =
+        a + (-b)
+
     member this.Count =
         if this.entries.IsDefault then 0 else this.entries.Length
 
@@ -205,50 +269,17 @@ module ZSet =
     let ofSet (keys: 'K seq) : ZSet<'K> =
         keys |> Seq.distinct |> Seq.map (fun k -> k, 1L) |> ofSeq
 
-    /// `a + b`. Linear sorted-merge. One pool workspace + one final array.
-    let add (a: ZSet<'K>) (b: ZSet<'K>) : ZSet<'K> =
-        if a.IsEmpty then b
-        elif b.IsEmpty then a
-        else
-            let sa = a.AsSpan()
-            let sb = b.AsSpan()
-            let cap = sa.Length + sb.Length
-            let rented = Pool.Rent<ZEntry<'K>> cap
-            try
-                let cmp = Comparer<'K>.Default
-                let mutable i = 0
-                let mutable j = 0
-                let mutable k = 0
-                while i < sa.Length && j < sb.Length do
-                    let c = cmp.Compare(sa.[i].Key, sb.[j].Key)
-                    if c < 0 then rented.[k] <- sa.[i]; i <- i + 1; k <- k + 1
-                    elif c > 0 then rented.[k] <- sb.[j]; j <- j + 1; k <- k + 1
-                    else
-                        // `Checked.(+)` — Z-set weights are int64 but nothing
-                        // stops a stream from running forever; silent wraparound
-                        // on overflow would turn a +2^63 multiset into a -2^63
-                        // multiset and corrupt every downstream query.
-                        let s = Checked.(+) sa.[i].Weight sb.[j].Weight
-                        if s <> 0L then rented.[k] <- ZEntry(sa.[i].Key, s); k <- k + 1
-                        i <- i + 1; j <- j + 1
-                while i < sa.Length do rented.[k] <- sa.[i]; i <- i + 1; k <- k + 1
-                while j < sb.Length do rented.[k] <- sb.[j]; j <- j + 1; k <- k + 1
-                if k = 0 then ZSet.Empty else ZSet(Pool.FreezeSlice(rented, k))
-            finally
-                Pool.Return rented
+    /// `a + b` — per-key signed sum. Delegates to the type's generic-math `(+)`
+    /// operator, where the pooled sorted-merge combiner now lives so F# SRTP
+    /// (`Seq.sum`, `GenericZero`) and the `System.Numerics`-shaped interface can
+    /// resolve addition on the type itself rather than this (later) module.
+    let add (a: ZSet<'K>) (b: ZSet<'K>) : ZSet<'K> = a + b
 
-    /// `-a`. Exact-size allocation, no workspace needed.
-    let neg (a: ZSet<'K>) : ZSet<'K> =
-        let span = a.AsSpan()
-        if span.IsEmpty then a
-        else
-            let arr = Pool.AllocateExact<ZEntry<'K>> span.Length
-            for i in 0 .. span.Length - 1 do
-                // Checked negation — `-Int64.MinValue` overflows.
-                arr.[i] <- ZEntry(span.[i].Key, Checked.(-) 0L span.[i].Weight)
-            ZSet(Pool.Freeze arr)
+    /// `-a` — the abelian-group inverse. Delegates to the type's generic-math
+    /// `(~-)` operator (the unary-negation rung).
+    let neg (a: ZSet<'K>) : ZSet<'K> = -a
 
-    let inline sub (a: ZSet<'K>) (b: ZSet<'K>) : ZSet<'K> = add a (neg b)
+    let inline sub (a: ZSet<'K>) (b: ZSet<'K>) : ZSet<'K> = a - b
 
     let scale (n: Weight) (a: ZSet<'K>) : ZSet<'K> =
         if n = 0L || a.IsEmpty then ZSet.Empty

--- a/tests/Tests.FSharp/Algebra/ZSet.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/ZSet.Tests.fs
@@ -364,3 +364,56 @@ let ``Z-set distinctions: abelian-group inverse, negatives persist, retraction-t
     ZSet.add (ZSet.ofSeq [ ("a", 1L) ]) (ZSet.ofSeq [ ("a", -1L) ])
     |> ZSet.isEmpty
     |> should equal true
+
+
+// ─── generic-math abelian-group surface (Zero + (+) + (~-) + (-)) ───────────
+// Z-set surfaces the native F# generic-math idiom ON THE TYPE: `Zero` + `(+)`
+// (additive monoid) PLUS `(~-)` / `(-)` (the abelian-group inverse) — the
+// `System.Numerics`-shaped interface ("numerics like dotnet", pushed to the
+// other langs that lack generic-math). NOT `INumber` (no total order; the ring
+// scalar is `ZSet.scale`, not a numeric product). These lock the operators to
+// the pooled combiner (operator ≡ module fn) and let generic numeric code +
+// `Seq.sum` aggregate Z-sets through `GenericZero` + `(+)`.
+
+[<Fact>]
+let ``(+) equals ZSet.add — operator delegates to the same pooled combiner`` () =
+    let a = ZSet.ofSeq [ ("a", 1L); ("b", 2L) ]
+    let b = ZSet.ofSeq [ ("b", 1L); ("c", 3L) ]
+    (a + b) |> should equal (ZSet.add a b)
+    (a + b) |> zToList |> should equal [ ("a", 1L); ("b", 3L); ("c", 3L) ]
+
+[<Fact>]
+let ``(~-) equals ZSet.neg and (-) equals ZSet.sub`` () =
+    let a = ZSet.ofSeq [ ("a", 1L); ("b", 2L) ]
+    let b = ZSet.ofSeq [ ("b", 1L) ]
+    (-a) |> should equal (ZSet.neg a)
+    (a - b) |> should equal (ZSet.sub a b)
+    (a - b) |> zToList |> should equal [ ("a", 1L); ("b", 1L) ]
+
+[<Fact>]
+let ``Zero is the additive identity and equals empty / GenericZero`` () =
+    let a = ZSet.ofSeq [ ("a", 1L); ("b", 2L) ]
+    (ZSet<string>.Zero + a) |> should equal a
+    (a + ZSet<string>.Zero) |> should equal a
+    ZSet<string>.Zero |> should equal ZSet.empty<string>
+    LanguagePrimitives.GenericZero<ZSet<string>> |> should equal ZSet.empty<string>
+
+[<Fact>]
+let ``abelian-group inverse via operators: a + (-a) = Zero and a - a = Zero`` () =
+    let a = ZSet.ofSeq [ ("a", 1L); ("b", -2L); ("c", 3L) ]
+    (a + (-a)) |> should equal ZSet<string>.Zero
+    (a - a) |> should equal ZSet<string>.Zero
+
+[<Fact>]
+let ``Seq.sum aggregates Z-sets through GenericZero + (+) (retraction nets to 0)`` () =
+    let parts =
+        [ ZSet.ofSeq [ ("a", 1L) ]
+          ZSet.ofSeq [ ("a", 1L); ("b", 2L) ]
+          ZSet.ofSeq [ ("b", -2L); ("c", 5L) ] ]
+    // empty Seq.sum seed is GenericZero (= empty); b nets to 0 and drops
+    Seq.sum parts |> zToList |> should equal [ ("a", 2L); ("c", 5L) ]
+
+[<Fact>]
+let ``(+) is NOT idempotent: a + a doubles every weight (Z-set, not G-Set)`` () =
+    let a = ZSet.ofSeq [ ("a", 1L); ("b", -3L) ]
+    (a + a) |> zToList |> should equal [ ("a", 2L); ("b", -6L) ]


### PR DESCRIPTION
Retrofit the **System.Numerics-shaped generic-math interface** onto the F# Z-set — the next rung after G-Set (#6467) and Bag (#6472). Z-set is an abelian **group**, so it gets the inverse rungs `(~-)`/`(-)` on top of the monoid `Zero`/`(+)`.

### What
- `static member Zero` / `(+)` / `(~-)` / `(-)` on the `ZSet<'K>` type.
- The pooled sorted-merge combiner (`add`) and `negate` **relocate onto the type** as the `(+)` and `(~-)` operators — F# SRTP (`LanguagePrimitives.GenericZero`, `Seq.sum`, generic `+`/`-`/`~-`) resolves operators *on the type*, and the `ZSet` module is `ModuleSuffix` (defined after the type) so a type-member can't forward-delegate to it.
- Module `add`/`neg`/`sub` become thin delegators. **Hot path is perf-neutral** (same code, new home); `Checked.(+)`/`Checked.(-)` overflow guards preserved.

### Why
> "numerics like dotnet as our interface, push to other langs if they don't have" — Aaron 2026-06-01

F# has native generic-math; this is the F# idiom rung. Same shape as the G-Set/Bag ladder.

### Tests (+6, **58/58** ZSet pass; Core builds 0 warn / 0 err)
- operator `≡` module fn (delegation is real)
- `Zero` = `empty` = `LanguagePrimitives.GenericZero`
- abelian-group inverse via operators: `a + (-a) = Zero` and `a - a = Zero`
- `Seq.sum` aggregates Z-sets through `GenericZero` + `(+)` (retraction-to-0 drops)
- `(+)` is **NOT** idempotent: `a + a` doubles every weight (Z-set, not G-Set)

### Next rungs (one primitive at a time, hexagonal)
C# IWSAM (`ISubtractionOperators` + `IUnaryNegationOperators`) · Rust (`impl Sub`/`Neg`) · TS (`AbelianGroup` record). Registry status bump to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)