### PR TITLE
feat(algebra): Z-set C# generic-math — IWSAM abelian-group (IAdditiveIdentity + IAddition/ISubtraction/IUnaryNegation)

### DIFF
--- a/src/Core.CSharp/ZSet.cs
+++ b/src/Core.CSharp/ZSet.cs
@@ -6,7 +6,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Numerics;
 
 namespace Zeta.Core.CSharp;
 
@@ -135,7 +137,12 @@ public static class ZSet
 /// ordinal) needs <see cref="StringComparer.Ordinal"/>. Pass it explicitly for cross-language parity.
 /// </remarks>
 /// <typeparam name="T">The key type.</typeparam>
-public sealed class ZSet<T> : IEquatable<ZSet<T>>
+public sealed class ZSet<T> :
+    IEquatable<ZSet<T>>,
+    IAdditiveIdentity<ZSet<T>, ZSet<T>>,
+    IAdditionOperators<ZSet<T>, ZSet<T>, ZSet<T>>,
+    ISubtractionOperators<ZSet<T>, ZSet<T>, ZSet<T>>,
+    IUnaryNegationOperators<ZSet<T>, ZSet<T>>
 {
     private readonly ImmutableArray<ZSetEntry<T>> _items;
     private readonly IComparer<T> _comparer;
@@ -296,6 +303,89 @@ public sealed class ZSet<T> : IEquatable<ZSet<T>>
         }
 
         return new ZSet<T>(builder.ToImmutable(), _comparer);
+    }
+
+    // ─── generic-math abelian-group surface (System.Numerics IWSAM) ──────────
+    // "numerics like dotnet as our interface, push to other langs if they don't
+    // have" (Aaron 2026-06-01). The dotnet-native form: Z-set IS-A
+    // IAdditiveIdentity + IAdditionOperators (monoid) + ISubtractionOperators +
+    // IUnaryNegationOperators (the abelian-group inverse). NOT INumber (no total
+    // order; the ring scalar is per-element, not a numeric product). Mirrors the
+    // F# `Zero`/`(+)`/`(~-)`/`(-)` rung and the GSet/Bag IWSAM twins.
+
+    /// <summary>
+    /// The additive identity (empty Z-set): <c>a + AdditiveIdentity == a</c>. Cached, comparer-agnostic
+    /// (built with <see cref="Comparer{T}.Default"/>); the <c>operator +</c>/<c>operator -</c> empty
+    /// short-circuits keep the identity law holding for Z-sets built with any comparer.
+    /// </summary>
+    [SuppressMessage(
+        "Design",
+        "CA1000:Do not declare static members on generic types",
+        Justification = "IWSAM (IAdditiveIdentity) requires the static member on the generic type itself; CA1000 predates static abstract interface members.")]
+    public static ZSet<T> AdditiveIdentity { get; } = ZSet.Empty<T>();
+
+    /// <summary>
+    /// <c>a + b</c> — per-key signed sum (the abelian-group operation; delegates to <see cref="Union"/>).
+    /// Empty is short-circuited as a comparer-agnostic identity BEFORE <see cref="Union"/>'s
+    /// same-comparer check, so <c>a + Zero == a</c> and <c>Zero + a == a</c> hold for any comparer; two
+    /// NON-empty Z-sets with mismatched comparers still fail fast (the comparer is part of identity).
+    /// NOT idempotent — <c>a + a</c> doubles every weight.
+    /// </summary>
+    /// <param name="left">The left Z-set.</param>
+    /// <param name="right">The right Z-set.</param>
+    /// <returns>The per-key sum.</returns>
+    public static ZSet<T> operator +(ZSet<T> left, ZSet<T> right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+        if (left.IsEmpty)
+        {
+            return right;
+        }
+
+        if (right.IsEmpty)
+        {
+            return left;
+        }
+
+        return left.Union(right);
+    }
+
+    /// <summary>
+    /// <c>-a</c> — the abelian-group inverse (flip every sign; delegates to <see cref="Negate"/>), so
+    /// <c>a + (-a) == AdditiveIdentity</c> (the law a Bag cannot satisfy).
+    /// </summary>
+    /// <param name="value">The Z-set to negate.</param>
+    /// <returns>The Z-set with every weight sign-flipped.</returns>
+    public static ZSet<T> operator -(ZSet<T> value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return value.Negate();
+    }
+
+    /// <summary>
+    /// <c>a - b == a + (-b)</c> — retraction expressed directly. Empty is short-circuited as a
+    /// comparer-agnostic identity (<c>a - Zero == a</c>, <c>Zero - b == -b</c>) before the same-comparer
+    /// check, matching <c>operator +</c>.
+    /// </summary>
+    /// <param name="left">The minuend.</param>
+    /// <param name="right">The subtrahend.</param>
+    /// <returns><c>left + (-right)</c>.</returns>
+    public static ZSet<T> operator -(ZSet<T> left, ZSet<T> right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+        if (right.IsEmpty)
+        {
+            return left;
+        }
+
+        if (left.IsEmpty)
+        {
+            return right.Negate();
+        }
+
+        return left.Union(right.Negate());
     }
 
     /// <summary>Throw if <paramref name="other"/> uses a different comparer (the comparer is part of the Z-set's identity).</summary>

--- a/tests/Tests.CSharp/Algebra/ZSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/ZSetCrossVerifyTests.cs
@@ -139,4 +139,63 @@ public class ZSetCrossVerifyTests
         // diff comparer ⇒ not equal
         Assert.False(ZSet.OfEntries([("a", 1L)], ordinal).Equals(ZSet.OfEntries([("a", 1L)], reverse)));
     }
+
+    [Fact]
+    public void GenericMathAbelianGroupSurface()
+    {
+        // dotnet-native generic-math IWSAM: IAdditiveIdentity + IAdditionOperators (monoid) PLUS
+        // ISubtractionOperators + IUnaryNegationOperators (the abelian-group inverse). NOT INumber
+        // (no total order; the ring scalar is per-element). (+) == Union, (-a) == Negate,
+        // (a - b) == Union(Negate); AdditiveIdentity is empty. Mirrors the F# Zero/(+)/(~-)/(-) rung.
+        var cmp = StringComparer.Ordinal;
+        static ZSet<string> Z(StringComparer cmp, params (string, long)[] xs) => ZSet.OfEntries(xs, cmp);
+
+        var a = Z(cmp, ("a", 1L), ("b", 2L));
+        var b = Z(cmp, ("b", 1L), ("c", 3L));
+        var c = Z(cmp, ("c", -1L), ("d", 4L));
+
+        Assert.Equal(a.Union(b), a + b);                    // (+) equals Union
+        Assert.Equal(a.Negate(), -a);                       // unary (-) equals Negate
+        Assert.Equal(a.Union(b.Negate()), a - b);           // (-) equals Union(Negate)
+        Assert.True(ZSet<string>.AdditiveIdentity.IsEmpty); // identity is empty
+        Assert.Equal(a, ZSet<string>.AdditiveIdentity + a); // identity law
+        Assert.Equal(a, a + ZSet<string>.AdditiveIdentity);
+
+        Assert.Equal(a + b, b + a);             // commutative
+        Assert.Equal((a + b) + c, a + (b + c)); // associative
+
+        // abelian-group inverse: a + (-a) == empty and a - a == empty (the law a Bag cannot satisfy)
+        Assert.True((a + (-a)).IsEmpty);
+        Assert.True((a - a).IsEmpty);
+    }
+
+    [Fact]
+    public void GenericMathAdditionIsNotIdempotentAndSubtractionRetracts()
+    {
+        // (+) is SUM, not set-union: a + a doubles every weight (the Bag/Z-set step away from G-Set).
+        var cmp = StringComparer.Ordinal;
+        var a = ZSet.OfEntries([("a", 1L), ("b", -3L)], cmp);
+        Assert.Equal(ZSet.OfEntries([("a", 2L), ("b", -6L)], cmp), a + a);
+
+        // subtraction drives a shared key to net 0 → retracted (dropped)
+        var x = ZSet.OfEntries([("a", 5L), ("b", 2L)], cmp);
+        var y = ZSet.OfEntries([("a", 5L)], cmp);
+        Assert.Equal(ZSet.OfEntries([("b", 2L)], cmp), x - y);
+    }
+
+    [Fact]
+    public void GenericMathIdentityIsComparerAgnosticButNonEmptyMismatchStillThrows()
+    {
+        // empty must absorb under ANY comparer (the identity law); (+)/(-) short-circuit empty BEFORE
+        // Union's same-comparer guard. Two NON-empty operands with mismatched comparers still throw.
+        var reverse = Comparer<string>.Create((x, y) => string.CompareOrdinal(y, x));
+        var custom = ZSet.OfEntries([("x", 1L), ("y", 2L)], reverse);
+        Assert.Equal(custom, custom + ZSet<string>.AdditiveIdentity); // no throw (a + empty = a)
+        Assert.Equal(custom, ZSet<string>.AdditiveIdentity + custom); // no throw (empty + a = a)
+        Assert.Equal(custom, custom - ZSet<string>.AdditiveIdentity); // no throw (a - empty = a)
+
+        var ordinal = ZSet.OfEntries([("a", 1L)], StringComparer.Ordinal);
+        Assert.Throws<ArgumentException>(() => ordinal + custom);
+        Assert.Throws<ArgumentException>(() => ordinal - custom);
+    }
 }


### PR DESCRIPTION
The **dotnet-native** form of "numerics like dotnet as our interface" (Aaron 2026-06-01) — the C# Z-set rung after F# (#6480). C# Z-set IS-A `IAdditiveIdentity` + `IAdditionOperators` (monoid) **plus** `ISubtractionOperators` + `IUnaryNegationOperators` (the abelian-group inverse). Same shape as the G-Set (#6468) / Bag (#6473) IWSAM twins. **NOT `INumber`** — no total order; the ring scalar is per-element, not a numeric product.

### What
- `operator +` / binary `operator -` short-circuit empty as a **comparer-agnostic identity** *before* `Union`'s `RequireSameComparer` guard — so `a + Zero = a` / `Zero + a = a` / `a - Zero = a` hold for Z-sets built with *any* comparer (the G-Set #6468 wrinkle: `Union` runs `RequireSameComparer` before its own empty short-circuit). Two **non-empty** operands with mismatched comparers still fail fast.
- unary `operator -` → `Negate`; `operator +` / binary `-` → `Union` / `Union(Negate)`. **Hot path unchanged.**
- `AdditiveIdentity` cached + `[SuppressMessage CA1000]` (IWSAM requires the static member on the generic type; CA1000 predates static abstract interface members).

### Tests (+3, **18/18** ZSet pass; Core builds 0 warn / 0 err)
- `(+)` == `Union`, `(-a)` == `Negate`, `(a - b)` == `Union(Negate)`
- identity + commutative + associative
- abelian-group inverse: `a + (-a) = empty`, `a - a = empty`
- `(+)` **NOT** idempotent (`a + a` doubles); subtraction retracts a shared key to 0
- comparer-agnostic identity, but non-empty mismatch still throws (`+` and `-`)

### Ladder
F# #6480 ✅ · **C# (this)** · Rust (`impl Sub`/`Neg`) next · TS (`AbelianGroup` record) next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)