### PR TITLE
feat(algebra): Z-set TS generic-math — AbelianGroup record (monoid + invert/subtract) + concatAll

### DIFF
--- a/src/Core.TypeScript/z-set/z-set.test.ts
+++ b/src/Core.TypeScript/z-set/z-set.test.ts
@@ -16,13 +16,16 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+  abelianGroup,
   add,
   addW,
+  concatAll,
   contains,
   distinctCount,
   empty,
   equals,
   isEmpty,
+  monoid,
   negate,
   ofArray,
   ofEntries,
@@ -32,6 +35,7 @@ import {
   total,
   union,
   weight,
+  type AbelianGroup,
   type ZEntry,
   type ZSet,
 } from "./z-set";
@@ -172,5 +176,48 @@ describe("Z-set — shared golden vector (cross-language parity lock)", () => {
     }
     expect(states).toEqual(gv.expectedReplayStates.map((s) => s.map((x) => ({ e: x.e, w: x.w }))));
     expect(plain(state)).toEqual(gv.expectedFinalState.map((x) => ({ e: x.e, w: x.w })));
+  });
+});
+
+describe("Z-set — generic-math abelian-group surface (monoid / abelianGroup / concatAll)", () => {
+  // TS has no operator overloading, so the dotnet-numerics interface is a record of
+  // the operations: a Monoid (empty + concat) extended to an AbelianGroup with
+  // invert + subtract. The twins are F# Zero/(+)/(~-)/(-), C# IWSAM, Rust std::ops.
+  const a = zset(entry("a", 1), entry("b", 2));
+  const b = zset(entry("b", 1), entry("c", 3));
+
+  it("monoid: concat == union, empty is the identity", () => {
+    const m = monoid(cmp);
+    expect(m.concat(a, b)).toEqual(union(cmp, a, b));
+    expect(m.concat(m.empty, a)).toEqual(a);
+    expect(m.concat(a, m.empty)).toEqual(a);
+    expect(m.empty).toEqual(empty<string>());
+  });
+
+  it("abelianGroup: invert == negate, subtract == union(negate), and is a Monoid", () => {
+    const g: AbelianGroup<ZSet<string>> = abelianGroup(cmp);
+    expect(g.invert(a)).toEqual(negate(a));
+    expect(g.subtract(a, b)).toEqual(union(cmp, a, negate(b)));
+    expect(g.concat(a, b)).toEqual(union(cmp, a, b)); // extends Monoid
+    expect(g.empty).toEqual(empty<string>());
+  });
+
+  it("inverse law: concat(a, invert(a)) == empty and subtract(a, a) == empty", () => {
+    const g = abelianGroup(cmp);
+    const z = zset(entry("a", 1), entry("b", -2), entry("c", 3));
+    expect(g.concat(z, g.invert(z))).toEqual(empty<string>()); // the law a Bag cannot satisfy
+    expect(g.subtract(z, z)).toEqual(empty<string>());
+  });
+
+  it("concat is NOT idempotent: concat(a, a) doubles every weight (Z-set, not G-Set)", () => {
+    const g = abelianGroup(cmp);
+    const z = zset(entry("a", 1), entry("b", -3));
+    expect(g.concat(z, z)).toEqual(zset(entry("a", 2), entry("b", -6)));
+  });
+
+  it("concatAll folds a collection through the monoid (retraction-to-0 drops)", () => {
+    const parts = [zset(entry("a", 1)), zset(entry("a", 1), entry("b", 2)), zset(entry("b", -2), entry("c", 5))];
+    expect(concatAll(cmp, parts)).toEqual(zset(entry("a", 2), entry("c", 5)));
+    expect(concatAll(cmp, [])).toEqual(empty<string>());
   });
 });

--- a/src/Core.TypeScript/z-set/z-set.ts
+++ b/src/Core.TypeScript/z-set/z-set.ts
@@ -35,6 +35,8 @@
  * analog of F#'s `'K : comparison` constraint.
  */
 
+import type { Monoid } from "../g-set/g-set";
+
 /** A total order on `T` (`< 0`, `0`, `> 0`), e.g. {@link stringCompare}. */
 export type Compare<T> = (a: T, b: T) => number;
 
@@ -257,4 +259,63 @@ export function equals<T>(compare: Compare<T>, a: ZSet<T>, b: ZSet<T>): boolean 
     if (compare(ea.e, eb.e) !== 0 || ea.w !== eb.w) return false;
   }
   return true;
+}
+
+// ── generic-math abelian-group surface (record idiom — TS has no operators) ──
+// "numerics like dotnet as our interface, push to other langs if they don't
+// have" (Aaron 2026-06-01). TS has no operator overloading / generic-math, so
+// the port is a record of the operations (the analog of F# `Zero`/`(+)`/`(~-)`/
+// `(-)`, C# IWSAM, Rust `std::ops`). Z-set is an abelian GROUP, so it extends the
+// shared `Monoid` (empty + concat) with `invert` (negate) + `subtract`. Like the
+// G-Set/Bag twins these are comparator-specific, so they're factories over
+// `compare` (the F#/C#/Rust twins bake the comparer into the type / use a default).
+
+/**
+ * The abelian-group surface: a {@link Monoid} (identity + associative `concat`)
+ * PLUS the inverse `invert` (so `concat(a, invert(a)) === empty` — the law a Bag
+ * cannot satisfy) and `subtract` (`concat(a, invert(b))`). NOT `INumber` — no
+ * ordering; the ring scalar is per-element, not a numeric product.
+ */
+export interface AbelianGroup<T> extends Monoid<T> {
+  /** The additive inverse: `concat(a, invert(a)) === empty`. */
+  readonly invert: (a: T) => T;
+  /** `subtract(a, b) === concat(a, invert(b))` — retraction expressed directly. */
+  readonly subtract: (a: T, b: T) => T;
+}
+
+/**
+ * The additive-monoid view of a Z-set under `compare`: `empty` (identity) +
+ * `concat` (= {@link union}). The Z-set's full surface is {@link abelianGroup};
+ * this matches the G-Set/Bag `monoid` factories so generic monoid code can fold a
+ * collection of Z-sets uniformly (see {@link concatAll}).
+ */
+export function monoid<T>(compare: Compare<T>): Monoid<ZSet<T>> {
+  return {
+    empty: empty<T>(),
+    concat: (a, b) => union(compare, a, b),
+  };
+}
+
+/**
+ * The abelian-group surface of a Z-set under `compare`: `empty` + `concat`
+ * (= {@link union}) + `invert` (= {@link negate}) + `subtract`. The Z-set's
+ * distinguishing surface over the Bag (which has no inverse).
+ */
+export function abelianGroup<T>(compare: Compare<T>): AbelianGroup<ZSet<T>> {
+  return {
+    empty: empty<T>(),
+    concat: (a, b) => union(compare, a, b),
+    invert: (a) => negate(a),
+    subtract: (a, b) => union(compare, a, negate(b)),
+  };
+}
+
+/**
+ * Fold a collection of Z-sets through the monoid (identity + `concat`) — the
+ * "generic code folds it for free" payoff (the TS analog of Rust's `Sum` /
+ * F#'s `Seq.sum`). Retraction-to-0 keys drop as the fold proceeds.
+ */
+export function concatAll<T>(compare: Compare<T>, zs: readonly ZSet<T>[]): ZSet<T> {
+  const m = monoid(compare);
+  return zs.reduce(m.concat, m.empty);
 }


### PR DESCRIPTION
TS has no operator overloading / generic-math, so we **push our own port as a record** of the operations ("numerics like dotnet as our interface, push to other langs if they don't have", Aaron 2026-06-01). The **last rung** after F# (#6480), C# (#6481), Rust (#6482) — completes the Z-set ladder **4/4**.

### What
Z-set is an abelian **group**, so it extends the shared `Monoid` (from `g-set.ts`: `empty` + `concat`) with `invert` (= `negate`) + `subtract` (= `union∘negate`) as an `AbelianGroup<T>` interface. **NOT `INumber`** — no ordering; the ring scalar is per-element. Factories are comparator-specific (the F#/C#/Rust twins bake the comparer into the type / use a default):
- `monoid(compare): Monoid<ZSet<T>>` — additive-monoid view (parity with G-Set/Bag)
- `abelianGroup(compare): AbelianGroup<ZSet<T>>` — the distinguishing surface (invert + subtract)
- `concatAll(compare, zs)` — fold a collection (the `Sum` / `Seq.sum` analog)

### Verification (from repo root, matching CI gates)
`tsc --noEmit -p tsconfig.json` **clean** · `eslint` **clean** · `prettier --check` **clean** (both files) · `bun test` **21/21** (16 original + 5 new).

### Tests (+5)
`monoid`: concat == union + empty identity · `abelianGroup`: invert == negate, subtract == union(negate), IS-A Monoid · inverse law: `concat(a, invert(a)) == empty` and `subtract(a, a) == empty` · concat **NOT** idempotent (doubles) · `concatAll` folds with retraction-to-0 drop (+ empty-collection ⇒ empty).

### Ladder — Z-set generic-math 4/4 ✅
F# #6480 · C# #6481 · Rust #6482 · **TS (this)**. Registry status bump to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)