### PR TITLE
feat(algebra): IndexedZSet F# generic-math — Zero/(+)/(~-)/(-) on the type (abelian group)

### DIFF
--- a/src/Core/IndexedZSet.fs
+++ b/src/Core/IndexedZSet.fs
@@ -35,6 +35,66 @@ type IndexedZSet<'K, 'V when 'K : comparison and 'V : comparison> =
     static member Empty : IndexedZSet<'K, 'V> =
         IndexedZSet(ImmutableArray<KeyGroup<'K, 'V>>.Empty)
 
+    /// Generic-math additive identity (`System.Numerics`-shaped). F# SRTP —
+    /// `LanguagePrimitives.GenericZero`, `Seq.sum` — resolves the zero through
+    /// this member; the empty IndexedZSet is the `+` identity. Mirrors the Z-set
+    /// (#6480) rung and the C# `IAdditiveIdentity` twin.
+    static member Zero : IndexedZSet<'K, 'V> = IndexedZSet<'K, 'V>.Empty
+
+    /// `a + b` — per-key merge, each shared key's value-`ZSet` summed (the
+    /// abelian-group operation; a key whose values cancel to empty is dropped).
+    /// Linear sorted-merge over the key-groups: one pool workspace + one final
+    /// array. This is the generic-math addition rung (C#'s `IAdditionOperators`
+    /// twin); the `IndexedZSet.add` module function delegates here so SRTP can
+    /// resolve `(+)` on the type itself rather than the (later) module. NOT
+    /// idempotent — `a + a` doubles every value-weight.
+    static member (+) (a: IndexedZSet<'K, 'V>, b: IndexedZSet<'K, 'V>) : IndexedZSet<'K, 'V> =
+        if a.IsEmpty then b
+        elif b.IsEmpty then a
+        else
+            let ga = a.AsSpan()
+            let gb = b.AsSpan()
+            let cap = ga.Length + gb.Length
+            let rented = Pool.Rent<KeyGroup<'K, 'V>> cap
+            try
+                let cmp = Comparer<'K>.Default
+                let mutable i = 0
+                let mutable j = 0
+                let mutable k = 0
+                while i < ga.Length && j < gb.Length do
+                    let c = cmp.Compare(ga.[i].Key, gb.[j].Key)
+                    if c < 0 then rented.[k] <- ga.[i]; i <- i + 1; k <- k + 1
+                    elif c > 0 then rented.[k] <- gb.[j]; j <- j + 1; k <- k + 1
+                    else
+                        let merged = ZSet.add ga.[i].Values gb.[j].Values
+                        if not merged.IsEmpty then
+                            rented.[k] <- KeyGroup(ga.[i].Key, merged)
+                            k <- k + 1
+                        i <- i + 1; j <- j + 1
+                while i < ga.Length do rented.[k] <- ga.[i]; i <- i + 1; k <- k + 1
+                while j < gb.Length do rented.[k] <- gb.[j]; j <- j + 1; k <- k + 1
+                if k = 0 then IndexedZSet<'K, 'V>.Empty
+                else IndexedZSet(Pool.FreezeSlice(rented, k))
+            finally
+                Pool.Return rented
+
+    /// `-a` — the abelian-group inverse (negate every key's value-`ZSet`), so
+    /// `a + (-a) = Zero`. Exact-size allocation, no workspace. C#'s
+    /// `IUnaryNegationOperators` twin.
+    static member (~-) (a: IndexedZSet<'K, 'V>) : IndexedZSet<'K, 'V> =
+        let span = a.AsSpan()
+        if span.IsEmpty then a
+        else
+            let arr = Pool.AllocateExact<KeyGroup<'K, 'V>> span.Length
+            for i in 0 .. span.Length - 1 do
+                arr.[i] <- KeyGroup(span.[i].Key, ZSet.neg span.[i].Values)
+            IndexedZSet(Pool.Freeze arr)
+
+    /// `a - b = a + (-b)`. The generic-math subtraction rung (C#'s
+    /// `ISubtractionOperators` twin); retraction expressed directly.
+    static member (-) (a: IndexedZSet<'K, 'V>, b: IndexedZSet<'K, 'V>) : IndexedZSet<'K, 'V> =
+        a + (-b)
+
     member this.KeyCount =
         if this.groups.IsDefault then 0 else this.groups.Length
 
@@ -204,47 +264,17 @@ module IndexedZSet =
             finally
                 Pool.Return rented
 
-    let add (a: IndexedZSet<'K, 'V>) (b: IndexedZSet<'K, 'V>) : IndexedZSet<'K, 'V> =
-        if a.IsEmpty then b
-        elif b.IsEmpty then a
-        else
-            let ga = a.AsSpan()
-            let gb = b.AsSpan()
-            let cap = ga.Length + gb.Length
-            let rented = Pool.Rent<KeyGroup<'K, 'V>> cap
-            try
-                let cmp = Comparer<'K>.Default
-                let mutable i = 0
-                let mutable j = 0
-                let mutable k = 0
-                while i < ga.Length && j < gb.Length do
-                    let c = cmp.Compare(ga.[i].Key, gb.[j].Key)
-                    if c < 0 then rented.[k] <- ga.[i]; i <- i + 1; k <- k + 1
-                    elif c > 0 then rented.[k] <- gb.[j]; j <- j + 1; k <- k + 1
-                    else
-                        let merged = ZSet.add ga.[i].Values gb.[j].Values
-                        if not merged.IsEmpty then
-                            rented.[k] <- KeyGroup(ga.[i].Key, merged)
-                            k <- k + 1
-                        i <- i + 1; j <- j + 1
-                while i < ga.Length do rented.[k] <- ga.[i]; i <- i + 1; k <- k + 1
-                while j < gb.Length do rented.[k] <- gb.[j]; j <- j + 1; k <- k + 1
-                if k = 0 then IndexedZSet<'K, 'V>.Empty
-                else IndexedZSet(Pool.FreezeSlice(rented, k))
-            finally
-                Pool.Return rented
+    /// `a + b` — per-key value-`ZSet` sum. Delegates to the type's generic-math
+    /// `(+)` operator, where the pooled sorted-merge combiner now lives so F#
+    /// SRTP (`Seq.sum`, `GenericZero`) and the `System.Numerics`-shaped interface
+    /// resolve addition on the type itself rather than this (later) module.
+    let add (a: IndexedZSet<'K, 'V>) (b: IndexedZSet<'K, 'V>) : IndexedZSet<'K, 'V> = a + b
 
-    let neg (a: IndexedZSet<'K, 'V>) : IndexedZSet<'K, 'V> =
-        let span = a.AsSpan()
-        if span.IsEmpty then a
-        else
-            let arr = Pool.AllocateExact<KeyGroup<'K, 'V>> span.Length
-            for i in 0 .. span.Length - 1 do
-                arr.[i] <- KeyGroup(span.[i].Key, ZSet.neg span.[i].Values)
-            IndexedZSet(Pool.Freeze arr)
+    /// `-a` — the abelian-group inverse. Delegates to the type's generic-math
+    /// `(~-)` operator (the unary-negation rung).
+    let neg (a: IndexedZSet<'K, 'V>) : IndexedZSet<'K, 'V> = -a
 
-    let inline sub (a: IndexedZSet<'K, 'V>) (b: IndexedZSet<'K, 'V>) : IndexedZSet<'K, 'V> =
-        add a (neg b)
+    let inline sub (a: IndexedZSet<'K, 'V>) (b: IndexedZSet<'K, 'V>) : IndexedZSet<'K, 'V> = a - b
 
     let inline join
         ([<InlineIfLambda>] combine: 'K -> 'VA -> 'VB -> 'C)

--- a/tests/Tests.FSharp/Algebra/IndexedZSet.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/IndexedZSet.Tests.fs
@@ -99,3 +99,50 @@ let ``IndexedZSet empty is empty`` () =
     let e = IndexedZSet.empty<int, string>
     IndexedZSet.isEmpty e |> should be True
     IndexedZSet.keyCount e |> should equal 0
+
+
+// ─── generic-math abelian-group surface (Zero + (+) + (~-) + (-)) ───────────
+// IndexedZSet (Z[K×V]) is an abelian group — same surface as the Z-set rung
+// (#6480): Zero + (+) (additive monoid) PLUS (~-)/(-) (the inverse). The pooled
+// key-group merge combiner lives ON THE TYPE so F# SRTP / Seq.sum / GenericZero
+// resolve it; the module add/neg/sub delegate. NOT INumber — the ring product is
+// the bilinear `join`, surfaced separately, not a numeric multiply.
+
+let private ixz (pairs: ((int * string) * int64) list) : IndexedZSet<int, string> =
+    IndexedZSet.indexWith fst snd (ZSet.ofSeq pairs)
+
+[<Fact>]
+let ``(+) equals IndexedZSet.add; (~-) equals neg; (-) equals sub`` () =
+    let a = ixz [ (1, "a"), 1L; (2, "b"), 2L ]
+    let b = ixz [ (2, "b"), 1L; (3, "c"), 3L ]
+    (a + b) |> should equal (IndexedZSet.add a b)
+    (-a) |> should equal (IndexedZSet.neg a)
+    (a - b) |> should equal (IndexedZSet.sub a b)
+
+[<Fact>]
+let ``Zero is the additive identity and equals empty / GenericZero`` () =
+    let a = ixz [ (1, "a"), 1L ]
+    (IndexedZSet<int, string>.Zero + a) |> should equal a
+    (a + IndexedZSet<int, string>.Zero) |> should equal a
+    IndexedZSet<int, string>.Zero |> should equal IndexedZSet.empty<int, string>
+    LanguagePrimitives.GenericZero<IndexedZSet<int, string>> |> should equal IndexedZSet.empty<int, string>
+
+[<Fact>]
+let ``abelian-group inverse via operators: a + (-a) = Zero and a - a = Zero`` () =
+    let a = ixz [ (1, "a"), 1L; (2, "b"), -2L; (2, "c"), 3L ]
+    (a + (-a)) |> IndexedZSet.isEmpty |> should be True
+    (a - a) |> IndexedZSet.isEmpty |> should be True
+
+[<Fact>]
+let ``Seq.sum aggregates through GenericZero + (+) (key empties out and drops)`` () =
+    let parts =
+        [ ixz [ (1, "a"), 1L ]
+          ixz [ (1, "a"), 1L; (2, "b"), 2L ]
+          ixz [ (2, "b"), -2L ] ]
+    // key 1 → a:2 ; key 2 → b nets 0 → value-ZSet empties → key dropped
+    IndexedZSet.toZSet (Seq.sum parts) |> should equal (ZSet.ofSeq [ (1, "a"), 2L ])
+
+[<Fact>]
+let ``(+) is NOT idempotent: a + a doubles every value-weight`` () =
+    let a = ixz [ (1, "a"), 1L; (1, "b"), -3L ]
+    IndexedZSet.toZSet (a + a) |> should equal (ZSet.ofSeq [ (1, "a"), 2L; (1, "b"), -6L ])


### PR DESCRIPTION
The **last algebra-ladder rung**. IndexedZSet (`Z[K×V]`, the join/aggregation rung) is an abelian **group** — same surface as the Z-set rung (#6480): `Zero` + `(+)` (additive monoid) **plus** `(~-)`/`(-)` (the inverse). Completes generic-math across the whole ladder (G-Set + Bag + Z-set + IndexedZSet).

### What
- `static member Zero` / `(+)` / `(~-)` / `(-)` on `IndexedZSet<'K,'V>`.
- The pooled key-group sorted-merge combiner (`add`, per-key delegating to `ZSet.add` on the value-`ZSet`s) and `negate` **relocate onto the type** so F# SRTP (`GenericZero`, `Seq.sum`, generic `+`/`-`/`~-`) resolves them (module is `ModuleSuffix`, defined after the type). Module `add`/`neg`/`sub` become thin delegators. **Hot path perf-neutral.**
- The bilinear **`join`** (the DBSP product) is **not** the group op and is left untouched — the ring multiply is surfaced separately, not as a numeric default.

### Tests (+5, **16/16** IndexedZSet pass; Core 0 warn / 0 err)
operator `≡` module fn (`+`/`~-`/`-`) · `Zero` = `empty` = `GenericZero` · `a + (-a) = Zero` and `a - a = Zero` · `Seq.sum` aggregates with key-empties-out drop · `(+)` **NOT** idempotent (doubles value-weights).

### Ladder
Z-set 4/4 done (#6480–#6483). IndexedZSet: **F# (this)** · C# IWSAM · Rust · TS to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)