### PR TITLE
feat(algebra): IndexedZSet C# generic-math — IWSAM abelian-group

### DIFF
--- a/src/Core.CSharp/IndexedZSet.cs
+++ b/src/Core.CSharp/IndexedZSet.cs
@@ -14,7 +14,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Numerics;
 
 namespace Zeta.Core.CSharp;
 
@@ -156,7 +158,12 @@ public static class IndexedZSet
 /// </summary>
 /// <typeparam name="TKey">The key type.</typeparam>
 /// <typeparam name="TValue">The value type.</typeparam>
-public sealed class IndexedZSet<TKey, TValue> : IEquatable<IndexedZSet<TKey, TValue>>
+public sealed class IndexedZSet<TKey, TValue> :
+    IEquatable<IndexedZSet<TKey, TValue>>,
+    IAdditiveIdentity<IndexedZSet<TKey, TValue>, IndexedZSet<TKey, TValue>>,
+    IAdditionOperators<IndexedZSet<TKey, TValue>, IndexedZSet<TKey, TValue>, IndexedZSet<TKey, TValue>>,
+    ISubtractionOperators<IndexedZSet<TKey, TValue>, IndexedZSet<TKey, TValue>, IndexedZSet<TKey, TValue>>,
+    IUnaryNegationOperators<IndexedZSet<TKey, TValue>, IndexedZSet<TKey, TValue>>
 {
     private readonly ImmutableArray<KeyGroup<TKey, TValue>> _groups;
     private readonly IComparer<TKey> _compareK;
@@ -328,6 +335,88 @@ public sealed class IndexedZSet<TKey, TValue> : IEquatable<IndexedZSet<TKey, TVa
     {
         ArgumentNullException.ThrowIfNull(other);
         return Add(other.Negate());
+    }
+
+    // ─── generic-math abelian-group surface (System.Numerics IWSAM) ──────────
+    // "numerics like dotnet as our interface, push to other langs if they don't
+    // have" (Aaron 2026-06-01). IndexedZSet IS-A IAdditiveIdentity +
+    // IAdditionOperators (monoid) + ISubtractionOperators + IUnaryNegationOperators
+    // (the abelian-group inverse). Mirrors the Z-set rung (#6481) and the F#
+    // Zero/(+)/(~-)/(-) twin. NOT INumber — the ring product is the bilinear Join,
+    // surfaced separately, not a numeric multiply.
+
+    /// <summary>
+    /// The additive identity (empty indexed Z-set): <c>a + AdditiveIdentity == a</c>. Cached,
+    /// comparer-agnostic (default comparers); the <c>operator +</c>/<c>operator -</c> empty
+    /// short-circuits keep the identity law holding for indexed Z-sets built with any comparers.
+    /// </summary>
+    [SuppressMessage(
+        "Design",
+        "CA1000:Do not declare static members on generic types",
+        Justification = "IWSAM (IAdditiveIdentity) requires the static member on the generic type itself; CA1000 predates static abstract interface members.")]
+    public static IndexedZSet<TKey, TValue> AdditiveIdentity { get; } = IndexedZSet.Empty<TKey, TValue>();
+
+    /// <summary>
+    /// <c>a + b</c> — per-key value-Z-set sum (the abelian-group operation; delegates to <see cref="Add"/>).
+    /// Empty is short-circuited as a comparer-agnostic identity BEFORE <see cref="Add"/>'s same-comparer
+    /// check, so <c>a + Zero == a</c> and <c>Zero + a == a</c> hold for any comparers; two NON-empty
+    /// operands with mismatched comparers still fail fast. NOT idempotent — <c>a + a</c> doubles weights.
+    /// </summary>
+    /// <param name="left">The left indexed Z-set.</param>
+    /// <param name="right">The right indexed Z-set.</param>
+    /// <returns>The per-key sum.</returns>
+    public static IndexedZSet<TKey, TValue> operator +(IndexedZSet<TKey, TValue> left, IndexedZSet<TKey, TValue> right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+        if (left.IsEmpty)
+        {
+            return right;
+        }
+
+        if (right.IsEmpty)
+        {
+            return left;
+        }
+
+        return left.Add(right);
+    }
+
+    /// <summary>
+    /// <c>-a</c> — the abelian-group inverse (delegates to <see cref="Negate"/>), so
+    /// <c>a + (-a) == AdditiveIdentity</c> (the law a Bag cannot satisfy).
+    /// </summary>
+    /// <param name="value">The indexed Z-set to negate.</param>
+    /// <returns>The indexed Z-set with every weight sign-flipped.</returns>
+    public static IndexedZSet<TKey, TValue> operator -(IndexedZSet<TKey, TValue> value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return value.Negate();
+    }
+
+    /// <summary>
+    /// <c>a - b == a + (-b)</c> (delegates to <see cref="Sub"/>). Empty is short-circuited as a
+    /// comparer-agnostic identity (<c>a - Zero == a</c>, <c>Zero - b == -b</c>) before the same-comparer
+    /// check, matching <c>operator +</c>.
+    /// </summary>
+    /// <param name="left">The minuend.</param>
+    /// <param name="right">The subtrahend.</param>
+    /// <returns><c>left + (-right)</c>.</returns>
+    public static IndexedZSet<TKey, TValue> operator -(IndexedZSet<TKey, TValue> left, IndexedZSet<TKey, TValue> right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+        if (right.IsEmpty)
+        {
+            return left;
+        }
+
+        if (left.IsEmpty)
+        {
+            return right.Negate();
+        }
+
+        return left.Sub(right);
     }
 
     /// <summary>

--- a/tests/Tests.CSharp/Algebra/IndexedZSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/IndexedZSetCrossVerifyTests.cs
@@ -143,4 +143,76 @@ public class IndexedZSetCrossVerifyTests
         var a = BuildA(r);
         Assert.True(a.Add(a.Negate()).IsEmpty); // add(a, neg(a)) == empty (every group cancels + drops)
     }
+
+    // ─── generic-math abelian-group surface (System.Numerics IWSAM) ──────────
+
+    private static IndexedZSet<string, string> BuildIxz(
+        IComparer<string> kc,
+        IComparer<string> vc,
+        params (string K, string V, long W)[] triples)
+    {
+        var pairCmp = Comparer<(string, string)>.Create((x, y) =>
+        {
+            var c = kc.Compare(x.Item1, y.Item1);
+            return c != 0 ? c : vc.Compare(x.Item2, y.Item2);
+        });
+        var source = ZSet.OfEntries(triples.Select(t => ((t.K, t.V), t.W)), pairCmp);
+        return IndexedZSet.IndexWith(source, p => p.Item1, p => p.Item2, kc, vc);
+    }
+
+    private static IndexedZSet<string, string> Ixz(params (string K, string V, long W)[] triples) =>
+        BuildIxz(Ord, Ord, triples);
+
+    [Fact]
+    public void GenericMathAbelianGroupSurface()
+    {
+        // dotnet IWSAM: IAdditiveIdentity + IAdditionOperators (monoid) PLUS
+        // ISubtractionOperators + IUnaryNegationOperators (the abelian-group inverse).
+        // (+) == Add, (-a) == Negate, (a-b) == Sub; AdditiveIdentity is empty. NOT INumber.
+        var a = Ixz(("k1", "a", 1L), ("k2", "b", 2L));
+        var b = Ixz(("k2", "b", 1L), ("k3", "c", 3L));
+        var c = Ixz(("k3", "c", -1L), ("k4", "d", 4L));
+
+        Assert.Equal(a.Add(b), a + b);  // (+) == Add
+        Assert.Equal(a.Negate(), -a);   // unary (-) == Negate
+        Assert.Equal(a.Sub(b), a - b);  // (-) == Sub
+        Assert.True(IndexedZSet<string, string>.AdditiveIdentity.IsEmpty);
+        Assert.Equal(a, IndexedZSet<string, string>.AdditiveIdentity + a); // identity law
+        Assert.Equal(a, a + IndexedZSet<string, string>.AdditiveIdentity);
+
+        Assert.Equal(a + b, b + a);             // commutative
+        Assert.Equal((a + b) + c, a + (b + c)); // associative
+        Assert.True((a + (-a)).IsEmpty);        // inverse: a + (-a) == empty
+        Assert.True((a - a).IsEmpty);           // a - a == empty
+    }
+
+    [Fact]
+    public void GenericMathAdditionIsNotIdempotentAndSubtractionRetracts()
+    {
+        // (+) is SUM, not set-union: a + a doubles every value-weight.
+        var a = Ixz(("k", "a", 1L), ("k", "b", -3L));
+        Assert.Equal(Ixz(("k", "a", 2L), ("k", "b", -6L)), a + a);
+
+        // subtraction drives a shared (key,value) to net 0 → retracted (group empties + drops)
+        var x = Ixz(("k", "a", 5L), ("k", "b", 2L));
+        var y = Ixz(("k", "a", 5L));
+        Assert.Equal(Ixz(("k", "b", 2L)), x - y);
+    }
+
+    [Fact]
+    public void GenericMathIdentityIsComparerAgnosticButNonEmptyMismatchThrows()
+    {
+        // empty must absorb under ANY comparers (the identity law); (+)/(-) short-circuit empty
+        // BEFORE Add's RequireSameComparers. Two NON-empty operands with mismatched comparers throw.
+        var rev = Comparer<string>.Create((x, y) => string.CompareOrdinal(y, x));
+        var custom = BuildIxz(rev, rev, ("x", "p", 1L));
+        var id = IndexedZSet<string, string>.AdditiveIdentity;
+        Assert.Equal(custom, custom + id); // a + empty = a (no throw)
+        Assert.Equal(custom, id + custom); // empty + a = a (no throw)
+        Assert.Equal(custom, custom - id); // a - empty = a (no throw)
+
+        var ordinal = Ixz(("a", "p", 1L));
+        Assert.Throws<ArgumentException>(() => ordinal + custom);
+        Assert.Throws<ArgumentException>(() => ordinal - custom);
+    }
 }


### PR DESCRIPTION
The C# rung of the last ladder primitive (after F# #6485). IndexedZSet (`Z[K×V]`) IS-A `IAdditiveIdentity` + `IAdditionOperators` (monoid) **plus** `ISubtractionOperators` + `IUnaryNegationOperators` (the abelian-group inverse). Mirrors the Z-set IWSAM twin (#6481). **NOT `INumber`** — the ring product is the bilinear `Join`, surfaced separately.

### What
- `operator +`/binary `-` short-circuit empty as a **comparer-agnostic identity** before `Add`'s `RequireSameComparers` guard (`a + Zero = a` / `Zero + a = a` / `a - Zero = a` for any K/V comparers); two **non-empty** mismatched-comparer operands still throw.
- unary `-` → `Negate`; `+`/binary `-` → `Add`/`Sub`. **Hot path unchanged.**
- `AdditiveIdentity` cached + `[SuppressMessage CA1000]`.

### Tests (+3, **9/9** IndexedZSet pass; Core 0 warn / 0 err)
`(+)`==`Add`, `(-a)`==`Negate`, `(a-b)`==`Sub` · identity + commutative + associative · `a + (-a) = empty`, `a - a = empty` · `(+)` **NOT** idempotent (doubles) · subtraction retracts a shared `(key,value)` to 0 · comparer-agnostic identity, non-empty mismatch throws.

### Ladder
Z-set 4/4 done. IndexedZSet: F# #6485 · **C# (this)** · Rust · TS to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)