### PR TITLE
feat(algebra): IndexedZSet TS generic-math — AbelianGroup record (completes the ladder 4/4)

### DIFF
--- a/src/Core.TypeScript/indexed-z-set/indexed-z-set.test.ts
+++ b/src/Core.TypeScript/indexed-z-set/indexed-z-set.test.ts
@@ -20,12 +20,15 @@ import {
   equals as zEquals,
   ofEntries as zOfEntries,
   stringCompare,
+  type AbelianGroup,
   type Compare,
   type ZEntry,
   type ZSet,
 } from "../z-set/z-set";
 import {
+  abelianGroup,
   add,
+  concatAll,
   empty,
   equals,
   get,
@@ -34,6 +37,7 @@ import {
   type IndexedZSet,
   join,
   keyCount,
+  monoid,
   neg,
   ofGroups,
   sub,
@@ -177,5 +181,89 @@ describe("IndexedZSet — construction + lookup", () => {
       src,
     );
     expect(isEmpty(idx)).toBe(true);
+  });
+});
+
+describe("IndexedZSet — generic-math abelian-group surface (monoid / abelianGroup / concatAll)", () => {
+  // TS has no operator overloading, so the dotnet-numerics interface is a record:
+  // a Monoid (empty + concat) extended to an AbelianGroup with invert + subtract
+  // (reusing the shared interfaces from g-set/z-set). Twins: F# Zero/(+)/(~-)/(-),
+  // C# IWSAM, Rust std::ops. The last ladder rung.
+  const ixz = (triples: readonly [string, string, number][]): IndexedZSet<string, string> =>
+    indexWith<Pair, string, string>(
+      cmp,
+      cmp,
+      (p) => p.k,
+      (p) => p.v,
+      zOfEntries(
+        pairCompare,
+        triples.map(([k, v, w]) => ({ e: { k, v }, w })),
+      ),
+    );
+
+  const a = ixz([
+    ["k1", "a", 1],
+    ["k2", "b", 2],
+  ]);
+  const b = ixz([
+    ["k2", "b", 1],
+    ["k3", "c", 3],
+  ]);
+
+  it("monoid: concat == add, empty is the identity", () => {
+    const m = monoid<string, string>(cmp, cmp);
+    expect(eqI(m.concat(a, b), add(cmp, cmp, a, b))).toBe(true);
+    expect(eqI(m.concat(m.empty, a), a)).toBe(true);
+    expect(eqI(m.concat(a, m.empty), a)).toBe(true);
+    expect(isEmpty(m.empty)).toBe(true);
+  });
+
+  it("abelianGroup: invert == neg, subtract == sub, and is a Monoid", () => {
+    const g: AbelianGroup<IndexedZSet<string, string>> = abelianGroup<string, string>(cmp, cmp);
+    expect(eqI(g.invert(a), neg(a))).toBe(true);
+    expect(eqI(g.subtract(a, b), sub(cmp, cmp, a, b))).toBe(true);
+    expect(eqI(g.concat(a, b), add(cmp, cmp, a, b))).toBe(true); // extends Monoid
+    expect(isEmpty(g.empty)).toBe(true);
+  });
+
+  it("inverse law: concat(a, invert(a)) == empty and subtract(a, a) == empty", () => {
+    const g = abelianGroup<string, string>(cmp, cmp);
+    const z = ixz([
+      ["k1", "a", 1],
+      ["k2", "b", -2],
+      ["k2", "c", 3],
+    ]);
+    expect(isEmpty(g.concat(z, g.invert(z)))).toBe(true); // the law a Bag cannot satisfy
+    expect(isEmpty(g.subtract(z, z))).toBe(true);
+  });
+
+  it("concat is NOT idempotent: concat(a, a) doubles every value-weight", () => {
+    const g = abelianGroup<string, string>(cmp, cmp);
+    const z = ixz([
+      ["k", "a", 1],
+      ["k", "b", -3],
+    ]);
+    expect(
+      eqI(
+        g.concat(z, z),
+        ixz([
+          ["k", "a", 2],
+          ["k", "b", -6],
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it("concatAll folds a collection (key empties out and drops; [] => empty)", () => {
+    const parts = [
+      ixz([["k1", "a", 1]]),
+      ixz([
+        ["k1", "a", 1],
+        ["k2", "b", 2],
+      ]),
+      ixz([["k2", "b", -2]]),
+    ];
+    expect(eqI(concatAll(cmp, cmp, parts), ixz([["k1", "a", 2]]))).toBe(true);
+    expect(isEmpty(concatAll(cmp, cmp, []))).toBe(true);
   });
 });

--- a/src/Core.TypeScript/indexed-z-set/indexed-z-set.ts
+++ b/src/Core.TypeScript/indexed-z-set/indexed-z-set.ts
@@ -283,7 +283,8 @@ export function equals<K, V>(
 // abelian GROUP — same surface as the Z-set rung (#6483): reuse the shared
 // `Monoid` (g-set) + `AbelianGroup` (z-set) interfaces. NOT INumber — the ring
 // product is the bilinear `join`, surfaced separately, not a numeric multiply.
-// Factories are comparator-specific (key comparer) like the Z-set/Bag twins.
+// Factories are comparator-specific in BOTH key and value comparers (the per-key
+// value-Z-set merge needs the value comparer), like the Z-set/Bag twins.
 
 /**
  * The additive-monoid view of an IndexedZSet under `compareK` / `compareV`:

--- a/src/Core.TypeScript/indexed-z-set/indexed-z-set.ts
+++ b/src/Core.TypeScript/indexed-z-set/indexed-z-set.ts
@@ -20,6 +20,7 @@
  * matching keys' value-Z-sets with weight-multiply + consolidate.
  */
 
+import type { Monoid } from "../g-set/g-set";
 import {
   empty as zEmpty,
   isEmpty as zIsEmpty,
@@ -27,6 +28,7 @@ import {
   ofEntries as zOfEntries,
   toEntries as zToEntries,
   union as zUnion,
+  type AbelianGroup,
   type Compare,
   type ZEntry,
   type ZSet,
@@ -273,4 +275,54 @@ export function equals<K, V>(
     }
   }
   return true;
+}
+
+// ── generic-math abelian-group surface (record idiom — TS has no operators) ──
+// "numerics like dotnet as our interface, push to other langs if they don't
+// have" (Aaron 2026-06-01). The last ladder rung. IndexedZSet (Z[K×V]) is an
+// abelian GROUP — same surface as the Z-set rung (#6483): reuse the shared
+// `Monoid` (g-set) + `AbelianGroup` (z-set) interfaces. NOT INumber — the ring
+// product is the bilinear `join`, surfaced separately, not a numeric multiply.
+// Factories are comparator-specific (key comparer) like the Z-set/Bag twins.
+
+/**
+ * The additive-monoid view of an IndexedZSet under `compareK` / `compareV`:
+ * `empty` (identity) + `concat` (= group-wise {@link add}; the per-key value-Z-set
+ * merge needs the value comparer). Matches the G-Set/Bag/Z-set `monoid` factories
+ * so generic monoid code can fold a collection (see {@link concatAll}).
+ */
+export function monoid<K, V>(compareK: Compare<K>, compareV: Compare<V>): Monoid<IndexedZSet<K, V>> {
+  return {
+    empty: empty<K, V>(),
+    concat: (a, b) => add(compareK, compareV, a, b),
+  };
+}
+
+/**
+ * The abelian-group surface of an IndexedZSet under `compareK` / `compareV`:
+ * `empty` + `concat` (= {@link add}) + `invert` (= {@link neg}) + `subtract`
+ * (= {@link sub}). The distinguishing surface over the Bag (no inverse);
+ * `concat(a, invert(a))` is empty.
+ */
+export function abelianGroup<K, V>(compareK: Compare<K>, compareV: Compare<V>): AbelianGroup<IndexedZSet<K, V>> {
+  return {
+    empty: empty<K, V>(),
+    concat: (a, b) => add(compareK, compareV, a, b),
+    invert: (a) => neg(a),
+    subtract: (a, b) => sub(compareK, compareV, a, b),
+  };
+}
+
+/**
+ * Fold a collection of IndexedZSets through the monoid (identity + `concat`) — the
+ * "generic code folds it for free" payoff (the TS analog of Rust's `Sum` / F#'s
+ * `Seq.sum`). Keys whose value-Z-sets empty out (retraction-to-0) drop as it folds.
+ */
+export function concatAll<K, V>(
+  compareK: Compare<K>,
+  compareV: Compare<V>,
+  is: readonly IndexedZSet<K, V>[],
+): IndexedZSet<K, V> {
+  const m = monoid<K, V>(compareK, compareV);
+  return is.reduce(m.concat, m.empty);
 }


### PR DESCRIPTION
The **last ladder rung**. TS has no operator overloading, so the dotnet-numerics interface is a **record**: a `Monoid` (empty + concat) extended to an `AbelianGroup` with `invert` + `subtract` — **reusing** the shared `Monoid` (g-set) + `AbelianGroup` (z-set #6483) interfaces (DRY). Completes generic-math across the **whole algebra ladder** in all four languages.

### What
- `monoid(compareK, compareV)` · `abelianGroup(compareK, compareV)` · `concatAll(compareK, compareV, is)` — factories take **both** comparers (the per-key value-`ZSet` merge needs `compareV`). **NOT `INumber`** — the ring product is the bilinear `join`, surfaced separately.

### Verification (CI gates)
`tsc --noEmit -p tsconfig.json` **clean** · `prettier --check` **clean** (both) · `bun test` **18/18** (13 original + 5 new). *(Repo-wide `eslint .` from a fresh worktree floods on config-resolution and isn't CI-representative; the added factories + tests have zero non-null assertions and mirror the merged file's style.)*

### Tests (+5)
`monoid` concat == add + empty identity · `abelianGroup` invert == neg, subtract == sub, IS-A Monoid · inverse `concat(a, invert(a)) == empty` and `subtract(a, a) == empty` · concat **NOT** idempotent (doubles) · `concatAll` folds with key-empties-out drop (`[]` ⇒ empty).

### 🏁 Completes the algebra-ladder generic-math sweep
IndexedZSet: F# #6485 · C# #6486 · Rust #6489 · **TS (this)**. With Z-set (#6480–#6483) done, **every rung (G-Set · Bag · Z-set · IndexedZSet) now carries the dotnet-shaped generic-math interface in all four languages.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)