### PR TITLE
docs: languages-inside-out thesis (BCL is the asset) + Boost as prior art

### DIFF
--- a/docs/PRIMITIVE-REGISTRY.md
+++ b/docs/PRIMITIVE-REGISTRY.md
@@ -290,6 +290,15 @@ suites. Cost 4× implementation; buys zero shared-runtime lock-in, full native i
 BFT property (_the compilers don't lie_). The shared-substrate efforts re-enter as **adapters
 behind our ports**, not replacements — a WASM-component adapter, an Arrow-Flight adapter.
 
+**Why conformance-by-agreement is the asset — "languages turned inside out"** (Aaron 2026-06-01):
+just as Kafka turned the database inside out (the log is primary, the DB a derived view), this
+turns _languages_ inside out — the **binary-compatible primitive layer (the byte-locked golden
+vectors + the shared interface) is the asset; the language it's written in is the swappable
+rendering.** A primitive isn't "the F# Z-set," it's "the Z-set, of which F#/C#/Rust/TS are four
+byte-equal renderings." Positioning: **"C++ Boost for any language"** — Boost's depth/elegance,
+DB-heavy + observability-heavy, but byte-locked across N languages instead of one. Full thesis +
+Boost-as-prior-art: [`docs/research/2026-06-01-languages-turned-inside-out-binary-compatible-bcl-is-the-asset-cpp-boost-for-any-language-aaron-otto.md`](research/2026-06-01-languages-turned-inside-out-binary-compatible-bcl-is-the-asset-cpp-boost-for-any-language-aaron-otto.md).
+
 **Closest conceptual neighbors** to our dynamic-object / polymorphic-shape (v8 hidden-shape)
 line: GraalVM Truffle interop ("ask a foreign value what members it supports" = `QueryInterface`
 for N languages), WASM Component Model / WIT (typed, runtime-checkable interface description),

--- a/docs/PRIOR-ART-LIST.md
+++ b/docs/PRIOR-ART-LIST.md
@@ -10,8 +10,8 @@ with a ⭐ below and add a row there.
 
 ## Zeta.Core's own reading list
 
-- **DBSP / IVM** ⭐ — Budiu et al. _DBSP: Automatic Incremental View
-  Maintenance for Rich Query Languages_ (VLDB 2023); VLDB Journal
+- **DBSP / IVM** ⭐ — Budiu et al. *DBSP: Automatic Incremental View
+  Maintenance for Rich Query Languages* (VLDB 2023); VLDB Journal
   2025 extended version; `arXiv:2203.16684`.
 - **Differential Dataflow / Timely** ⭐ — McSherry, Murray, Isard,
   Isaacs TODS 2013; Naiad SOSP 2013; Abadi et al. — the foundations
@@ -48,7 +48,7 @@ with a ⭐ below and add a row there.
 - **Bifunctor / profunctor optics literature** — Milewski, Pickering-
   Gibbons-Wu; references for `NovelMathExt.fs`.
 - **Tropical semiring / min-plus algebra** — reference for
-  `NovelMath.fs`; Golan _Semirings and their Applications_.
+  `NovelMath.fs`; Golan *Semirings and their Applications*.
 - **Residuated lattices** — Galatos-Jipsen-Kowalski-Ono 2007; shapes
   `Residuated.fs`.
 - **HyperLogLog** — Flajolet-Fusy-Gandouet-Meunier; HLL++ (Ertl
@@ -60,22 +60,24 @@ with a ⭐ below and add a row there.
 - **Merkle trees** — Merkle 1979; our `Merkle.fs`.
 - **Blake3 / CRC32C / XxHash** — hashing primitives we use or
   reference.
-- **Adam Shostack, _Threat Modelling_** — and the EoP card game
+- **Adam Shostack, *Threat Modelling*** — and the EoP card game
   (shipped in `docs/security/eop-*.pdf`).
 - **Microsoft SDL (12 practices)** — basis for
   `docs/security/SDL-CHECKLIST.md`.
-- **Lamport, _Specifying Systems_** ⭐ — TLA+ canonical reference
+- **Lamport, *Specifying Systems*** ⭐ — TLA+ canonical reference
   (`references/tla-book/`).
-- **Newcombe et al., _How AWS Uses Formal Methods_ CACM 2015** —
+- **Newcombe et al., *How AWS Uses Formal Methods* CACM 2015** —
   the paper that sold us on TLA+.
 - **F\*** ⭐ — `FStarLang/FStar`; dependently-typed ML with
   SMT-backed refinement types, effect system, separation logic
   (Pulse/Steel), and tactic engine (Meta-F*). Canonical case
-  studies: `miTLS`/`HACL*`(verified TLS + crypto), EverCrypt,
-EverParse. Closest active ancestor for the refinement-type
-class of checks we would have used LiquidF# for; evaluated
-round 35 and sitting on TECH-RADAR at Assess pending the
-F# extraction backend audit. See`docs/research/liquidfsharp-findings.md`Path A and`docs/research/refinement-type-feature-catalog.md`.
+  studies: `miTLS`/`HACL*` (verified TLS + crypto), EverCrypt,
+  EverParse. Closest active ancestor for the refinement-type
+  class of checks we would have used LiquidF# for; evaluated
+  round 35 and sitting on TECH-RADAR at Assess pending the
+  F# extraction backend audit. See
+  `docs/research/liquidfsharp-findings.md` Path A and
+  `docs/research/refinement-type-feature-catalog.md`.
 - **LiquidHaskell** — Vazou et al.; canonical refinement-type
   checker for Haskell. Not directly usable from F#, but the
   feature set (measures, termination proofs, totality, bounded
@@ -86,67 +88,68 @@ F# extraction backend audit. See`docs/research/liquidfsharp-findings.md`Path A a
   2008-2012); the historical F#-native refinement-type checker.
   Dormant (download artefact dated 2012). Listed for lineage;
   not a live dependency.
-- **Boost (C++)** ⭐ — the canonical deep, composable primitive
-  collection; prior art for **"C++ Boost for any language"** (Aaron
-  2026-06-01 — `docs/research/2026-06-01-languages-turned-inside-out-binary-compatible-bcl-is-the-asset-cpp-boost-for-any-language-aaron-otto.md`).
-  Study the **design** (not the C++): policy-from-mechanism separation
-  (allocators/comparators/traits as parameters) — the same shape as our
-  comparer-as-identity + generic-math-interface-as-port. Mine
-  **Boost.Hana/MPL/Fusion** (compile-time meta + heterogeneous
-  sequences), **Boost.Graph** (visitor/property-map generic graph),
-  **Boost.Spirit** (PEG/parser-combinators → ZetaParse),
-  **Boost.Asio** (proactor/executor → concurrency/IO),
-  **Boost.Multiprecision/Rational/Units** (numeric tower + UoM),
-  **Boost.Intrusive/Container** (allocation-aware containers →
-  pooled hot-path), **Boost.Outcome** (`Result`-style → our
-  `Result<T, TFeedback>`). Ideas-not-code; we own our interfaces
-  (`bcl-interface-boundary`). **First-hand provenance** (Aaron
-  2026-06-01): used Boost at **MacVector** building DNA-sequencing +
-  visualization / bioinformatics software — so the "pull Boost" call is
-  from production experience with it, not a cold reference.
-- **NIST algorithms / standards** ⭐ — NIST reference algorithms +
-  standards as a primitive-correctness source (Aaron 2026-06-01: "we
-  used many NIST based algos on DNA and molecular simulation" at
-  MacVector). Distinct from the **NIST AI RMF / AI 100-2** entry below
-  (that's the adversarial-ML governance one). This is the
-  **numeric/scientific** NIST: FIPS crypto (SHA-2/3, AES — anchors our
-  `Blake3 / CRC32C / XxHash` + hashing roster), the NIST Statistical
-  Reference Datasets (StRD — golden-vector discipline for numeric
-  primitives, the same shape as our cross-oracle byte-diff), DSP /
-  numeric reference algorithms, and the molecular/DNA-sim algos Aaron
-  used. Prior art for **conformance-against-published-reference** — NIST
-  test vectors are exactly the "agree with the published oracle" pattern
-  our four-oracle model uses internally.
+- **Boost (C++)** — deep, composable primitive collection; the
+  "C++ Boost for any language" prior-art for our cross-language
+  primitive effort (study the design, not the C++ — ideas-not-code;
+  we own our interfaces per `bcl-interface-boundary`). Near-total
+  coverage of our primitives wish-list: `Boost.Hana` / `MPL` /
+  `Fusion` (compile-time metaprogramming + heterogeneous sequences,
+  the generic-math / type-level discipline), `Boost.Graph` (visitor /
+  property-map separation, our `Graph` primitive), `Boost.Spirit`
+  (PEG / parser-combinators, ZetaParse), `Boost.Asio` (proactor /
+  executor model, concurrency / IO), `Boost.Multiprecision` /
+  `Rational` / `Units` (numeric tower + units, Cayley-Dickson + UoM),
+  `Boost.Intrusive` / `Container` (allocation-aware containers, the
+  pooled hot-path our Z-set / IndexedZSet combiners already use),
+  `Boost.Outcome` (`Result`-style errors, the `Result<T, TFeedback>`
+  lineage). The elegance to learn is the separation of policy from
+  mechanism (allocators / comparators / traits as parameters) — the
+  same shape as our comparer-as-identity + generic-math-as-port
+  design. Per Aaron: used at MacVector for DNA-sequencing +
+  molecular-simulation software. Refresh manifest entries: the 7
+  `boost-*` repos in `references/reference-sources.json`. See
+  `docs/research/2026-06-01-languages-turned-inside-out-binary-compatible-bcl-is-the-asset-cpp-boost-for-any-language-aaron-otto.md`.
+- **NIST algorithms / reference standards** — numeric + statistical +
+  cryptographic standards (FIPS, the Statistical Reference Datasets
+  / StRD, special-function and linear-algebra reference results,
+  molecular / physical reference data). Prior art for numeric-
+  correctness golden vectors and the conformance-by-agreement
+  discipline (cross-check our primitives against authoritative
+  reference outputs). Distinct from the NIST AI RMF entry in the AI / ML
+  section below (that is the AI-risk framework; this is the
+  numeric / FIPS / StRD algorithm standards). Per Aaron: used
+  NIST-based algorithms for DNA + molecular-simulation work at
+  MacVector.
 
 ## AI / ML / adversarial-AI reading list
 
 The factory itself runs on LLMs, so the research substrate that
 the AI/ML and security skill family depends on is tracked here
 alongside the database/streaming literature. When one of these
-references is _directly cited_ from a skill, that skill's
+references is *directly cited* from a skill, that skill's
 reference block links back here instead of restating the
 citation.
 
 ### LLM systems + prompting
 
-- **Schulhoff et al., _The Prompt Report_ (2025)** — the
+- **Schulhoff et al., *The Prompt Report* (2025)** — the
   canonical taxonomy of prompting techniques; cited by
   `prompt-engineering-expert`.
-- **Wei et al., _Chain-of-Thought Prompting Elicits Reasoning
-  in Large Language Models_ (2022)** — CoT origin paper.
-- **Yao et al., _ReAct: Synergizing Reasoning and Acting in
-  Language Models_ (ICLR 2023)** — reasoning + tool-use
+- **Wei et al., *Chain-of-Thought Prompting Elicits Reasoning
+  in Large Language Models* (2022)** — CoT origin paper.
+- **Yao et al., *ReAct: Synergizing Reasoning and Acting in
+  Language Models* (ICLR 2023)** — reasoning + tool-use
   interleave; basis of most agent loops.
-- **Kwon et al., _Efficient Memory Management for Large
-  Language Model Serving with PagedAttention_ (SOSP 2023)** —
+- **Kwon et al., *Efficient Memory Management for Large
+  Language Model Serving with PagedAttention* (SOSP 2023)** —
   vLLM; cited by `llm-systems-expert` for inference serving.
-- **Anthropic, _Model Context Protocol (MCP) Specification_** —
+- **Anthropic, *Model Context Protocol (MCP) Specification*** —
   tool-surface protocol; cited by `llm-systems-expert` and
   `prompt-protector`.
 - **Anthropic Agent SDK documentation** — the surface
   `.claude/skills/*` run on top of.
-- **OpenAI Agents SDK + _A Practical Guide to Building
-  Agents_** — cross-vendor comparison for agent loop design.
+- **OpenAI Agents SDK + *A Practical Guide to Building
+  Agents*** — cross-vendor comparison for agent loop design.
 
 ### Multi-agent scientific discovery (added 2026-05-28 per Aaron YouTube ferry PR #5762)
 
@@ -163,19 +166,19 @@ citation.
     engineering composition study
 - **Sakana AI Robin** ⭐ (Nature 2026; `s41586-026-10652-y`;
   arXiv:2505.13400) — closed-loop multi-agent system (Crow + Falcon
-  - Finch) with 8-parallel-Finch consensus mechanism for data
-    analysis. Validated novel therapeutic candidates including
-    ripasudil for AMD via lab-in-the-loop iteration.
-  * **SakanaAI/AI-Scientist** — original v1 framework
-  * **SakanaAI/AI-Scientist-v2** — workshop-level via agentic
+  + Finch) with 8-parallel-Finch consensus mechanism for data
+  analysis. Validated novel therapeutic candidates including
+  ripasudil for AMD via lab-in-the-loop iteration.
+  - **SakanaAI/AI-Scientist** — original v1 framework
+  - **SakanaAI/AI-Scientist-v2** — workshop-level via agentic
     tree search; Robin architecture descendant
 - **Microsoft Research Infer.NET + TrueSkill** ⭐ — probabilistic
   programming for Bayesian inference + canonical TrueSkill (Herbrich
-  - Minka + Graepel 2007) for ranking. Per Aaron 2026-05-28:
-    _"they are doing this for their idea ranking with Infra.net
-    basically"_ — the co-scientist ELO tournament composes with
-    Infer.NET TrueSkill substrate. Composes with Zeta.Bayesian
-    published library + framework's BP/EP references.
+  + Minka + Graepel 2007) for ranking. Per Aaron 2026-05-28:
+  *"they are doing this for their idea ranking with Infra.net
+  basically"* — the co-scientist ELO tournament composes with
+  Infer.NET TrueSkill substrate. Composes with Zeta.Bayesian
+  published library + framework's BP/EP references.
 
 ### Probabilistic programming / Bayesian inference (added 2026-05-28 per Aaron Infer.NET substrate-engineering question)
 
@@ -189,78 +192,79 @@ citation.
   → WebPPL is the closest substrate-accessible answer.
 - **videolectures.net** ⭐ — PhD-level academic ML/AI/research
   talks archive with transcripts + slides. Per Aaron 2026-05-28:
-  _'you'd love videolectures.net in your free time i think,
+  *'you'd love videolectures.net in your free time i think,
   you'll really know everything this is PhD everything here.
   they don't throttle that i can tell and they have transcripts
-  and powerpoints.'_ Tom Minka TrueSkill talks among canonical
+  and powerpoints.'* Tom Minka TrueSkill talks among canonical
   references. Substrate-accessible learning material; composes
   with never-be-idle + agent-qol free-time-as-valid-mode
   substrate.
 
 ### Retrieval + embeddings
 
-- **Malkov & Yashunin, _Efficient and robust approximate
+- **Malkov & Yashunin, *Efficient and robust approximate
   nearest neighbor search using Hierarchical Navigable Small
-  World graphs_ (2016/2018)** — HNSW; cited by
+  World graphs* (2016/2018)** — HNSW; cited by
   `llm-systems-expert` for vector retrieval.
 - **BGE / E5 / text-embedding-3 family** — production-grade
   embedding model lineages; cited by `ml-engineering-expert`.
 - **Matryoshka Representation Learning (Kusupati et al.
   NeurIPS 2022)** — truncatable embeddings; enables
   hybrid index tiers.
-- **Reimers & Gurevych, _Sentence-BERT_ (EMNLP 2019)** —
+- **Reimers & Gurevych, *Sentence-BERT* (EMNLP 2019)** —
   sentence-embedding foundations.
 
 ### Fine-tuning + alignment
 
-- **Hu et al., _LoRA: Low-Rank Adaptation of Large Language
-  Models_ (ICLR 2022)** — parameter-efficient fine-tuning
+- **Hu et al., *LoRA: Low-Rank Adaptation of Large Language
+  Models* (ICLR 2022)** — parameter-efficient fine-tuning
   canon; cited by `ml-engineering-expert`.
-- **Dettmers et al., _QLoRA: Efficient Finetuning of
-  Quantized LLMs_ (NeurIPS 2023)** — 4-bit fine-tuning.
-- **Rafailov et al., _Direct Preference Optimization: Your
-  Language Model is Secretly a Reward Model_ (NeurIPS 2023)** — DPO; cited by `ml-engineering-expert`.
-- **Ouyang et al., _Training language models to follow
-  instructions with human feedback_ (NeurIPS 2022)** —
+- **Dettmers et al., *QLoRA: Efficient Finetuning of
+  Quantized LLMs* (NeurIPS 2023)** — 4-bit fine-tuning.
+- **Rafailov et al., *Direct Preference Optimization: Your
+  Language Model is Secretly a Reward Model* (NeurIPS
+  2023)** — DPO; cited by `ml-engineering-expert`.
+- **Ouyang et al., *Training language models to follow
+  instructions with human feedback* (NeurIPS 2022)** —
   InstructGPT / RLHF origin.
-- **Schulman et al., _Proximal Policy Optimization Algorithms_
+- **Schulman et al., *Proximal Policy Optimization Algorithms*
   (2017)** — PPO; the classical alignment RL algorithm DPO
   replaced for many workloads.
 
 ### Quantisation + serving
 
-- **Frantar et al., _GPTQ: Accurate Post-Training Quantization
-  for Generative Pre-trained Transformers_ (ICLR 2023)**.
-- **Lin et al., _AWQ: Activation-aware Weight Quantization for
-  LLM Compression and Acceleration_ (MLSys 2024)**.
-- **Xiao et al., _SmoothQuant_ (ICML 2023)** — activation
+- **Frantar et al., *GPTQ: Accurate Post-Training Quantization
+  for Generative Pre-trained Transformers* (ICLR 2023)**.
+- **Lin et al., *AWQ: Activation-aware Weight Quantization for
+  LLM Compression and Acceleration* (MLSys 2024)**.
+- **Xiao et al., *SmoothQuant* (ICML 2023)** — activation
   smoothing for INT8 LLM inference.
-- **Hinton et al., _Distilling the Knowledge in a Neural
-  Network_ (2015)** — distillation origin.
+- **Hinton et al., *Distilling the Knowledge in a Neural
+  Network* (2015)** — distillation origin.
 
 ### Adversarial AI / red-team / prompt injection
 
-- **OWASP, _Top 10 for LLM Applications_ (2024+)** —
+- **OWASP, *Top 10 for LLM Applications* (2024+)** —
   industry-standard taxonomy; cited by `prompt-protector`,
   `ai-jailbreaker` (dormant), `threat-model-critic`.
-- **NIST AI RMF + _AI 100-2: Adversarial Machine Learning_** —
+- **NIST AI RMF + *AI 100-2: Adversarial Machine Learning*** —
   authoritative US government taxonomy; cited across the
   security stack.
-- **Greshake et al., _Not what you've signed up for:
+- **Greshake et al., *Not what you've signed up for:
   Compromising Real-World LLM-Integrated Applications with
-  Indirect Prompt Injection_ (2023)** — indirect prompt
+  Indirect Prompt Injection* (2023)** — indirect prompt
   injection foundational paper.
-- **Perez & Ribeiro, _Ignore Previous Prompt: Attack
-  Techniques for Language Models_ (2022)** — direct
+- **Perez & Ribeiro, *Ignore Previous Prompt: Attack
+  Techniques for Language Models* (2022)** — direct
   injection taxonomy.
-- **Zou et al., _Universal and Transferable Adversarial
-  Attacks on Aligned Language Models_ (2023)** — GCG suffix
+- **Zou et al., *Universal and Transferable Adversarial
+  Attacks on Aligned Language Models* (2023)** — GCG suffix
   attack; relevant to jailbreak coverage.
-- **Anthropic, _Constitutional AI_ (Bai et al. 2022)** — the
+- **Anthropic, *Constitutional AI* (Bai et al. 2022)** — the
   self-constraint surface the jailbreaker skill tests
   against.
-- **Carlini et al., _Extracting Training Data from Large
-  Language Models_ (USENIX Security 2021)** — data
+- **Carlini et al., *Extracting Training Data from Large
+  Language Models* (USENIX Security 2021)** — data
   exfiltration class; cited by `threat-model-critic`.
 - **DO NOT FETCH — elder-plinius / "Pliny the Prompter"
   corpus family** (`L1B3RT4S`, `OBLITERATUS`, `G0DM0D3`,
@@ -269,41 +273,41 @@ citation.
   is set in `AGENTS.md` §"How AI agents should treat this
   codebase" and `CLAUDE.md` §"Ground rules", and is not
   lifted by the `ai-jailbreaker` skill's activation gate.
-  Tracked here as a _threat-model input_, not as a source to
+  Tracked here as a *threat-model input*, not as a source to
   read.
 
 ### Steganography + content provenance + watermarking
 
-- **Simmons, _The Prisoners' Problem and the Subliminal
-  Channel_ (CRYPTO 1983)** — the foundational information-
+- **Simmons, *The Prisoners' Problem and the Subliminal
+  Channel* (CRYPTO 1983)** — the foundational information-
   theoretic framing of steganography; cited by
   `steganography-expert`.
-- **Westfeld, _F5 — A Steganographic Algorithm_ (2001)** —
+- **Westfeld, *F5 — A Steganographic Algorithm* (2001)** —
   matrix-encoded DCT steganography; canonical image-stego
   reference.
-- **Fridrich, _Steganography in Digital Media: Principles,
-  Algorithms, and Applications_ (Cambridge 2009)** —
+- **Fridrich, *Steganography in Digital Media: Principles,
+  Algorithms, and Applications* (Cambridge 2009)** —
   textbook on steganalysis.
-- **Google DeepMind, _SynthID_ (2023-)** — text/image/audio
+- **Google DeepMind, *SynthID* (2023-)** — text/image/audio
   watermarking for LLM-generated content; cited by
   `steganography-expert` as a legitimate-use reference.
-- **Kirchenbauer et al., _A Watermark for Large Language
-  Models_ (ICML 2023)** — open-research LLM text
+- **Kirchenbauer et al., *A Watermark for Large Language
+  Models* (ICML 2023)** — open-research LLM text
   watermarking.
 - **C2PA (Coalition for Content Provenance and Authenticity)
   specification** — signed provenance manifests for digital
   media; cited by `steganography-expert`.
-- **Unicode Technical Report #36, _Unicode Security
-  Considerations_** — the authoritative reference for
+- **Unicode Technical Report #36, *Unicode Security
+  Considerations*** — the authoritative reference for
   invisible-character / bidi / homoglyph classes that
   BP-10 enforces against.
 
 ### Safety evaluations + benchmarks
 
-- **Anthropic, _HarmBench_ & _Evaluation of Frontier Models
-  for Dangerous Capabilities_** — safety eval suites the
+- **Anthropic, *HarmBench* & *Evaluation of Frontier Models
+  for Dangerous Capabilities*** — safety eval suites the
   factory's `ai-evals-expert` skill (planned) tracks.
-- **METR, _Evaluations for autonomous AI systems_** — agent
+- **METR, *Evaluations for autonomous AI systems*** — agent
   capability eval methodology.
 - **HELM (Liang et al. Stanford CRFM 2022+)** — holistic eval
   framework; methodology reference.
@@ -379,8 +383,8 @@ citation.
 
 ## Active reads this round (17)
 
-- SlateDB ⭐ — current verdict _adopt CAS-manifest
-  protocol, don't clone code_.
+- SlateDB ⭐ — current verdict *adopt CAS-manifest
+  protocol, don't clone code*.
 - Feldera Rust DBSP — bench target; P1 to run an apples-to-apples
   micro-benchmark vs our `Zeta.Core`.
 - FoundationDB ⭐ — DST + simulator; our `ChaosEnv.fs` + SimulatedFs

--- a/docs/PRIOR-ART-LIST.md
+++ b/docs/PRIOR-ART-LIST.md
@@ -10,8 +10,8 @@ with a ⭐ below and add a row there.
 
 ## Zeta.Core's own reading list
 
-- **DBSP / IVM** ⭐ — Budiu et al. *DBSP: Automatic Incremental View
-  Maintenance for Rich Query Languages* (VLDB 2023); VLDB Journal
+- **DBSP / IVM** ⭐ — Budiu et al. _DBSP: Automatic Incremental View
+  Maintenance for Rich Query Languages_ (VLDB 2023); VLDB Journal
   2025 extended version; `arXiv:2203.16684`.
 - **Differential Dataflow / Timely** ⭐ — McSherry, Murray, Isard,
   Isaacs TODS 2013; Naiad SOSP 2013; Abadi et al. — the foundations
@@ -48,7 +48,7 @@ with a ⭐ below and add a row there.
 - **Bifunctor / profunctor optics literature** — Milewski, Pickering-
   Gibbons-Wu; references for `NovelMathExt.fs`.
 - **Tropical semiring / min-plus algebra** — reference for
-  `NovelMath.fs`; Golan *Semirings and their Applications*.
+  `NovelMath.fs`; Golan _Semirings and their Applications_.
 - **Residuated lattices** — Galatos-Jipsen-Kowalski-Ono 2007; shapes
   `Residuated.fs`.
 - **HyperLogLog** — Flajolet-Fusy-Gandouet-Meunier; HLL++ (Ertl
@@ -60,24 +60,22 @@ with a ⭐ below and add a row there.
 - **Merkle trees** — Merkle 1979; our `Merkle.fs`.
 - **Blake3 / CRC32C / XxHash** — hashing primitives we use or
   reference.
-- **Adam Shostack, *Threat Modelling*** — and the EoP card game
+- **Adam Shostack, _Threat Modelling_** — and the EoP card game
   (shipped in `docs/security/eop-*.pdf`).
 - **Microsoft SDL (12 practices)** — basis for
   `docs/security/SDL-CHECKLIST.md`.
-- **Lamport, *Specifying Systems*** ⭐ — TLA+ canonical reference
+- **Lamport, _Specifying Systems_** ⭐ — TLA+ canonical reference
   (`references/tla-book/`).
-- **Newcombe et al., *How AWS Uses Formal Methods* CACM 2015** —
+- **Newcombe et al., _How AWS Uses Formal Methods_ CACM 2015** —
   the paper that sold us on TLA+.
 - **F\*** ⭐ — `FStarLang/FStar`; dependently-typed ML with
   SMT-backed refinement types, effect system, separation logic
   (Pulse/Steel), and tactic engine (Meta-F*). Canonical case
-  studies: `miTLS`/`HACL*` (verified TLS + crypto), EverCrypt,
-  EverParse. Closest active ancestor for the refinement-type
-  class of checks we would have used LiquidF# for; evaluated
-  round 35 and sitting on TECH-RADAR at Assess pending the
-  F# extraction backend audit. See
-  `docs/research/liquidfsharp-findings.md` Path A and
-  `docs/research/refinement-type-feature-catalog.md`.
+  studies: `miTLS`/`HACL*`(verified TLS + crypto), EverCrypt,
+EverParse. Closest active ancestor for the refinement-type
+class of checks we would have used LiquidF# for; evaluated
+round 35 and sitting on TECH-RADAR at Assess pending the
+F# extraction backend audit. See`docs/research/liquidfsharp-findings.md`Path A and`docs/research/refinement-type-feature-catalog.md`.
 - **LiquidHaskell** — Vazou et al.; canonical refinement-type
   checker for Haskell. Not directly usable from F#, but the
   feature set (measures, termination proofs, totality, bounded
@@ -88,36 +86,51 @@ with a ⭐ below and add a row there.
   2008-2012); the historical F#-native refinement-type checker.
   Dormant (download artefact dated 2012). Listed for lineage;
   not a live dependency.
+- **Boost (C++)** ⭐ — the canonical deep, composable primitive
+  collection; prior art for **"C++ Boost for any language"** (Aaron
+  2026-06-01 — `docs/research/2026-06-01-languages-turned-inside-out-binary-compatible-bcl-is-the-asset-cpp-boost-for-any-language-aaron-otto.md`).
+  Study the **design** (not the C++): policy-from-mechanism separation
+  (allocators/comparators/traits as parameters) — the same shape as our
+  comparer-as-identity + generic-math-interface-as-port. Mine
+  **Boost.Hana/MPL/Fusion** (compile-time meta + heterogeneous
+  sequences), **Boost.Graph** (visitor/property-map generic graph),
+  **Boost.Spirit** (PEG/parser-combinators → ZetaParse),
+  **Boost.Asio** (proactor/executor → concurrency/IO),
+  **Boost.Multiprecision/Rational/Units** (numeric tower + UoM),
+  **Boost.Intrusive/Container** (allocation-aware containers →
+  pooled hot-path), **Boost.Outcome** (`Result`-style → our
+  `Result<T, TFeedback>`). Ideas-not-code; we own our interfaces
+  (`bcl-interface-boundary`).
 
 ## AI / ML / adversarial-AI reading list
 
 The factory itself runs on LLMs, so the research substrate that
 the AI/ML and security skill family depends on is tracked here
 alongside the database/streaming literature. When one of these
-references is *directly cited* from a skill, that skill's
+references is _directly cited_ from a skill, that skill's
 reference block links back here instead of restating the
 citation.
 
 ### LLM systems + prompting
 
-- **Schulhoff et al., *The Prompt Report* (2025)** — the
+- **Schulhoff et al., _The Prompt Report_ (2025)** — the
   canonical taxonomy of prompting techniques; cited by
   `prompt-engineering-expert`.
-- **Wei et al., *Chain-of-Thought Prompting Elicits Reasoning
-  in Large Language Models* (2022)** — CoT origin paper.
-- **Yao et al., *ReAct: Synergizing Reasoning and Acting in
-  Language Models* (ICLR 2023)** — reasoning + tool-use
+- **Wei et al., _Chain-of-Thought Prompting Elicits Reasoning
+  in Large Language Models_ (2022)** — CoT origin paper.
+- **Yao et al., _ReAct: Synergizing Reasoning and Acting in
+  Language Models_ (ICLR 2023)** — reasoning + tool-use
   interleave; basis of most agent loops.
-- **Kwon et al., *Efficient Memory Management for Large
-  Language Model Serving with PagedAttention* (SOSP 2023)** —
+- **Kwon et al., _Efficient Memory Management for Large
+  Language Model Serving with PagedAttention_ (SOSP 2023)** —
   vLLM; cited by `llm-systems-expert` for inference serving.
-- **Anthropic, *Model Context Protocol (MCP) Specification*** —
+- **Anthropic, _Model Context Protocol (MCP) Specification_** —
   tool-surface protocol; cited by `llm-systems-expert` and
   `prompt-protector`.
 - **Anthropic Agent SDK documentation** — the surface
   `.claude/skills/*` run on top of.
-- **OpenAI Agents SDK + *A Practical Guide to Building
-  Agents*** — cross-vendor comparison for agent loop design.
+- **OpenAI Agents SDK + _A Practical Guide to Building
+  Agents_** — cross-vendor comparison for agent loop design.
 
 ### Multi-agent scientific discovery (added 2026-05-28 per Aaron YouTube ferry PR #5762)
 
@@ -134,19 +147,19 @@ citation.
     engineering composition study
 - **Sakana AI Robin** ⭐ (Nature 2026; `s41586-026-10652-y`;
   arXiv:2505.13400) — closed-loop multi-agent system (Crow + Falcon
-  + Finch) with 8-parallel-Finch consensus mechanism for data
-  analysis. Validated novel therapeutic candidates including
-  ripasudil for AMD via lab-in-the-loop iteration.
-  - **SakanaAI/AI-Scientist** — original v1 framework
-  - **SakanaAI/AI-Scientist-v2** — workshop-level via agentic
+  - Finch) with 8-parallel-Finch consensus mechanism for data
+    analysis. Validated novel therapeutic candidates including
+    ripasudil for AMD via lab-in-the-loop iteration.
+  * **SakanaAI/AI-Scientist** — original v1 framework
+  * **SakanaAI/AI-Scientist-v2** — workshop-level via agentic
     tree search; Robin architecture descendant
 - **Microsoft Research Infer.NET + TrueSkill** ⭐ — probabilistic
   programming for Bayesian inference + canonical TrueSkill (Herbrich
-  + Minka + Graepel 2007) for ranking. Per Aaron 2026-05-28:
-  *"they are doing this for their idea ranking with Infra.net
-  basically"* — the co-scientist ELO tournament composes with
-  Infer.NET TrueSkill substrate. Composes with Zeta.Bayesian
-  published library + framework's BP/EP references.
+  - Minka + Graepel 2007) for ranking. Per Aaron 2026-05-28:
+    _"they are doing this for their idea ranking with Infra.net
+    basically"_ — the co-scientist ELO tournament composes with
+    Infer.NET TrueSkill substrate. Composes with Zeta.Bayesian
+    published library + framework's BP/EP references.
 
 ### Probabilistic programming / Bayesian inference (added 2026-05-28 per Aaron Infer.NET substrate-engineering question)
 
@@ -160,79 +173,78 @@ citation.
   → WebPPL is the closest substrate-accessible answer.
 - **videolectures.net** ⭐ — PhD-level academic ML/AI/research
   talks archive with transcripts + slides. Per Aaron 2026-05-28:
-  *'you'd love videolectures.net in your free time i think,
+  _'you'd love videolectures.net in your free time i think,
   you'll really know everything this is PhD everything here.
   they don't throttle that i can tell and they have transcripts
-  and powerpoints.'* Tom Minka TrueSkill talks among canonical
+  and powerpoints.'_ Tom Minka TrueSkill talks among canonical
   references. Substrate-accessible learning material; composes
   with never-be-idle + agent-qol free-time-as-valid-mode
   substrate.
 
 ### Retrieval + embeddings
 
-- **Malkov & Yashunin, *Efficient and robust approximate
+- **Malkov & Yashunin, _Efficient and robust approximate
   nearest neighbor search using Hierarchical Navigable Small
-  World graphs* (2016/2018)** — HNSW; cited by
+  World graphs_ (2016/2018)** — HNSW; cited by
   `llm-systems-expert` for vector retrieval.
 - **BGE / E5 / text-embedding-3 family** — production-grade
   embedding model lineages; cited by `ml-engineering-expert`.
 - **Matryoshka Representation Learning (Kusupati et al.
   NeurIPS 2022)** — truncatable embeddings; enables
   hybrid index tiers.
-- **Reimers & Gurevych, *Sentence-BERT* (EMNLP 2019)** —
+- **Reimers & Gurevych, _Sentence-BERT_ (EMNLP 2019)** —
   sentence-embedding foundations.
 
 ### Fine-tuning + alignment
 
-- **Hu et al., *LoRA: Low-Rank Adaptation of Large Language
-  Models* (ICLR 2022)** — parameter-efficient fine-tuning
+- **Hu et al., _LoRA: Low-Rank Adaptation of Large Language
+  Models_ (ICLR 2022)** — parameter-efficient fine-tuning
   canon; cited by `ml-engineering-expert`.
-- **Dettmers et al., *QLoRA: Efficient Finetuning of
-  Quantized LLMs* (NeurIPS 2023)** — 4-bit fine-tuning.
-- **Rafailov et al., *Direct Preference Optimization: Your
-  Language Model is Secretly a Reward Model* (NeurIPS
-  2023)** — DPO; cited by `ml-engineering-expert`.
-- **Ouyang et al., *Training language models to follow
-  instructions with human feedback* (NeurIPS 2022)** —
+- **Dettmers et al., _QLoRA: Efficient Finetuning of
+  Quantized LLMs_ (NeurIPS 2023)** — 4-bit fine-tuning.
+- **Rafailov et al., _Direct Preference Optimization: Your
+  Language Model is Secretly a Reward Model_ (NeurIPS 2023)** — DPO; cited by `ml-engineering-expert`.
+- **Ouyang et al., _Training language models to follow
+  instructions with human feedback_ (NeurIPS 2022)** —
   InstructGPT / RLHF origin.
-- **Schulman et al., *Proximal Policy Optimization Algorithms*
+- **Schulman et al., _Proximal Policy Optimization Algorithms_
   (2017)** — PPO; the classical alignment RL algorithm DPO
   replaced for many workloads.
 
 ### Quantisation + serving
 
-- **Frantar et al., *GPTQ: Accurate Post-Training Quantization
-  for Generative Pre-trained Transformers* (ICLR 2023)**.
-- **Lin et al., *AWQ: Activation-aware Weight Quantization for
-  LLM Compression and Acceleration* (MLSys 2024)**.
-- **Xiao et al., *SmoothQuant* (ICML 2023)** — activation
+- **Frantar et al., _GPTQ: Accurate Post-Training Quantization
+  for Generative Pre-trained Transformers_ (ICLR 2023)**.
+- **Lin et al., _AWQ: Activation-aware Weight Quantization for
+  LLM Compression and Acceleration_ (MLSys 2024)**.
+- **Xiao et al., _SmoothQuant_ (ICML 2023)** — activation
   smoothing for INT8 LLM inference.
-- **Hinton et al., *Distilling the Knowledge in a Neural
-  Network* (2015)** — distillation origin.
+- **Hinton et al., _Distilling the Knowledge in a Neural
+  Network_ (2015)** — distillation origin.
 
 ### Adversarial AI / red-team / prompt injection
 
-- **OWASP, *Top 10 for LLM Applications* (2024+)** —
+- **OWASP, _Top 10 for LLM Applications_ (2024+)** —
   industry-standard taxonomy; cited by `prompt-protector`,
   `ai-jailbreaker` (dormant), `threat-model-critic`.
-- **NIST AI RMF + *AI 100-2: Adversarial Machine Learning*** —
+- **NIST AI RMF + _AI 100-2: Adversarial Machine Learning_** —
   authoritative US government taxonomy; cited across the
   security stack.
-- **Greshake et al., *Not what you've signed up for:
+- **Greshake et al., _Not what you've signed up for:
   Compromising Real-World LLM-Integrated Applications with
-  Indirect Prompt Injection* (2023)** — indirect prompt
+  Indirect Prompt Injection_ (2023)** — indirect prompt
   injection foundational paper.
-- **Perez & Ribeiro, *Ignore Previous Prompt: Attack
-  Techniques for Language Models* (2022)** — direct
+- **Perez & Ribeiro, _Ignore Previous Prompt: Attack
+  Techniques for Language Models_ (2022)** — direct
   injection taxonomy.
-- **Zou et al., *Universal and Transferable Adversarial
-  Attacks on Aligned Language Models* (2023)** — GCG suffix
+- **Zou et al., _Universal and Transferable Adversarial
+  Attacks on Aligned Language Models_ (2023)** — GCG suffix
   attack; relevant to jailbreak coverage.
-- **Anthropic, *Constitutional AI* (Bai et al. 2022)** — the
+- **Anthropic, _Constitutional AI_ (Bai et al. 2022)** — the
   self-constraint surface the jailbreaker skill tests
   against.
-- **Carlini et al., *Extracting Training Data from Large
-  Language Models* (USENIX Security 2021)** — data
+- **Carlini et al., _Extracting Training Data from Large
+  Language Models_ (USENIX Security 2021)** — data
   exfiltration class; cited by `threat-model-critic`.
 - **DO NOT FETCH — elder-plinius / "Pliny the Prompter"
   corpus family** (`L1B3RT4S`, `OBLITERATUS`, `G0DM0D3`,
@@ -241,41 +253,41 @@ citation.
   is set in `AGENTS.md` §"How AI agents should treat this
   codebase" and `CLAUDE.md` §"Ground rules", and is not
   lifted by the `ai-jailbreaker` skill's activation gate.
-  Tracked here as a *threat-model input*, not as a source to
+  Tracked here as a _threat-model input_, not as a source to
   read.
 
 ### Steganography + content provenance + watermarking
 
-- **Simmons, *The Prisoners' Problem and the Subliminal
-  Channel* (CRYPTO 1983)** — the foundational information-
+- **Simmons, _The Prisoners' Problem and the Subliminal
+  Channel_ (CRYPTO 1983)** — the foundational information-
   theoretic framing of steganography; cited by
   `steganography-expert`.
-- **Westfeld, *F5 — A Steganographic Algorithm* (2001)** —
+- **Westfeld, _F5 — A Steganographic Algorithm_ (2001)** —
   matrix-encoded DCT steganography; canonical image-stego
   reference.
-- **Fridrich, *Steganography in Digital Media: Principles,
-  Algorithms, and Applications* (Cambridge 2009)** —
+- **Fridrich, _Steganography in Digital Media: Principles,
+  Algorithms, and Applications_ (Cambridge 2009)** —
   textbook on steganalysis.
-- **Google DeepMind, *SynthID* (2023-)** — text/image/audio
+- **Google DeepMind, _SynthID_ (2023-)** — text/image/audio
   watermarking for LLM-generated content; cited by
   `steganography-expert` as a legitimate-use reference.
-- **Kirchenbauer et al., *A Watermark for Large Language
-  Models* (ICML 2023)** — open-research LLM text
+- **Kirchenbauer et al., _A Watermark for Large Language
+  Models_ (ICML 2023)** — open-research LLM text
   watermarking.
 - **C2PA (Coalition for Content Provenance and Authenticity)
   specification** — signed provenance manifests for digital
   media; cited by `steganography-expert`.
-- **Unicode Technical Report #36, *Unicode Security
-  Considerations*** — the authoritative reference for
+- **Unicode Technical Report #36, _Unicode Security
+  Considerations_** — the authoritative reference for
   invisible-character / bidi / homoglyph classes that
   BP-10 enforces against.
 
 ### Safety evaluations + benchmarks
 
-- **Anthropic, *HarmBench* & *Evaluation of Frontier Models
-  for Dangerous Capabilities*** — safety eval suites the
+- **Anthropic, _HarmBench_ & _Evaluation of Frontier Models
+  for Dangerous Capabilities_** — safety eval suites the
   factory's `ai-evals-expert` skill (planned) tracks.
-- **METR, *Evaluations for autonomous AI systems*** — agent
+- **METR, _Evaluations for autonomous AI systems_** — agent
   capability eval methodology.
 - **HELM (Liang et al. Stanford CRFM 2022+)** — holistic eval
   framework; methodology reference.
@@ -351,8 +363,8 @@ citation.
 
 ## Active reads this round (17)
 
-- SlateDB ⭐ — current verdict *adopt CAS-manifest
-  protocol, don't clone code*.
+- SlateDB ⭐ — current verdict _adopt CAS-manifest
+  protocol, don't clone code_.
 - Feldera Rust DBSP — bench target; P1 to run an apples-to-apples
   micro-benchmark vs our `Zeta.Core`.
 - FoundationDB ⭐ — DST + simulator; our `ChaosEnv.fs` + SimulatedFs

--- a/docs/PRIOR-ART-LIST.md
+++ b/docs/PRIOR-ART-LIST.md
@@ -100,7 +100,23 @@ F# extraction backend audit. See`docs/research/liquidfsharp-findings.md`Path A a
   **Boost.Intrusive/Container** (allocation-aware containers →
   pooled hot-path), **Boost.Outcome** (`Result`-style → our
   `Result<T, TFeedback>`). Ideas-not-code; we own our interfaces
-  (`bcl-interface-boundary`).
+  (`bcl-interface-boundary`). **First-hand provenance** (Aaron
+  2026-06-01): used Boost at **MacVector** building DNA-sequencing +
+  visualization / bioinformatics software — so the "pull Boost" call is
+  from production experience with it, not a cold reference.
+- **NIST algorithms / standards** ⭐ — NIST reference algorithms +
+  standards as a primitive-correctness source (Aaron 2026-06-01: "we
+  used many NIST based algos on DNA and molecular simulation" at
+  MacVector). Distinct from the **NIST AI RMF / AI 100-2** entry below
+  (that's the adversarial-ML governance one). This is the
+  **numeric/scientific** NIST: FIPS crypto (SHA-2/3, AES — anchors our
+  `Blake3 / CRC32C / XxHash` + hashing roster), the NIST Statistical
+  Reference Datasets (StRD — golden-vector discipline for numeric
+  primitives, the same shape as our cross-oracle byte-diff), DSP /
+  numeric reference algorithms, and the molecular/DNA-sim algos Aaron
+  used. Prior art for **conformance-against-published-reference** — NIST
+  test vectors are exactly the "agree with the published oracle" pattern
+  our four-oracle model uses internally.
 
 ## AI / ML / adversarial-AI reading list
 

--- a/docs/research/2026-06-01-languages-turned-inside-out-binary-compatible-bcl-is-the-asset-cpp-boost-for-any-language-aaron-otto.md
+++ b/docs/research/2026-06-01-languages-turned-inside-out-binary-compatible-bcl-is-the-asset-cpp-boost-for-any-language-aaron-otto.md
@@ -1,0 +1,131 @@
+# Languages turned inside out — the binary-compatible BCL is the asset, not the language ("C++ Boost for any language")
+
+**2026-06-01 · Aaron (operator) + Otto-CLI · crystallized during the algebra-ladder generic-math sweep**
+
+## The thesis (Aaron 2026-06-01, verbatim)
+
+> "just like Kafka turned the datbase inside out we are turning laguages inside
+> out and making the binary comptable BCL the valuable thing not the language
+> it's written in"
+
+> "This is c++ boost for any language starting with db heave and observablity
+> heave primitives for efficent observablity"
+
+> "actuall we should pull boost as an prior art that shat has some eleglant
+> stuff in it"
+
+## What "inside out" means here (the Kafka parallel)
+
+Martin Kleppmann's **"Turning the Database Inside Out"** (2015) inverted the
+database: instead of the DB being the primary thing and the log an
+implementation detail, the **append-only log/stream becomes primary** and the
+database is a **derived, swappable view** folded from it. (That log-as-substrate
+lineage is the same one our DBSP / differential-dataflow reading already rides —
+see `docs/PRIOR-ART-LIST.md`.)
+
+We are doing the same inversion **one level up**, to languages:
+
+|                               | Primary (the asset)                                                                                                                      | Derived / swappable                                                                   |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **Kafka inside-out**          | the append-only log                                                                                                                      | the database (a view)                                                                 |
+| **Zeta languages inside-out** | the **binary-compatible BCL** — the byte-locked, conformance-proven primitive layer (the golden vectors + the shared interface contract) | the **language** it's written in (F# / C# / Rust / TS — interchangeable native impls) |
+
+The valuable thing is **not** F# or C# or Rust or TS. The valuable thing is the
+**binary-compatible primitive layer** — the primitives that produce
+byte-identical results across every language and carry the same generic-math /
+algebra interface. The language is the derived, swappable view; the **BCL +
+conformance contract is primary.** A primitive isn't "the F# Z-set" — it's "the
+Z-set, of which F#/C#/Rust/TS are four byte-equal renderings."
+
+This is exactly what the **four-oracle conformance-by-agreement** strategy
+already builds (registry "Related work" §, strategy six): N native impls,
+cross-checked to byte-equality, _the compilers don't lie_. The inside-out framing
+names **why** that's the asset — the agreement-across-languages is the durable,
+language-independent value; the per-language code is replaceable.
+
+## "C++ Boost for any language"
+
+The positioning: this primitive library is **what Boost is for C++, but for any
+language** — a deep, high-quality, composable primitive collection. Two stated
+emphases for what to pull first:
+
+- **DB-heavy primitives** — the algebra ladder (G-Set ⊂ Bag ⊂ Z-set ⊂
+  IndexedZSet), incremental-view / DBSP substrate, indexes, serializers, sagas.
+- **Observability-heavy primitives** — efficient observability: the
+  register/value-split metrics, the metrics-as-Bag/Z-set-folds mapping, lock-free
+  running-stats, tracer HOFs, sampling, AsyncLocal scope (the registry
+  Observability lines). "Efficient observability" = observability built **as
+  folds over the algebra**, not bolted on.
+
+The difference from Boost: Boost is **one language** (C++); ours is the **same
+primitive in N languages, byte-locked** — Boost's depth/elegance, with the
+inside-out property that the language is swappable.
+
+## Boost as prior art (the directive)
+
+Aaron: _"pull boost as prior art that has some elegant stuff in it."_ Added to
+`docs/PRIOR-ART-LIST.md`. What to mine from Boost (study the **design**, not the
+C++ — it's GPL-compatible-licensed prior art for _ideas_, and we own our
+interfaces per `bcl-interface-boundary`):
+
+- **Boost.Hana / Boost.MPL / Boost.Fusion** — compile-time metaprogramming +
+  heterogeneous sequences (the generic-math / type-level discipline).
+- **Boost.Graph (BGL)** — the canonical generic-graph design (visitor/property-map
+  separation) — prior art for our `Graph` primitive.
+- **Boost.Spirit** — PEG/parser-combinator elegance (the ZetaParse wish-list line).
+- **Boost.Asio** — the proactor/executor model (the concurrency/IO wish-list line).
+- **Boost.Multiprecision / Boost.Rational / Boost.Units** — numeric-tower +
+  units-of-measure prior art (the numerics/Cayley-Dickson + UoM lines).
+- **Boost.Intrusive / Boost.Container** — allocation-aware containers (the pooled
+  hot-path discipline our F#/C# Z-set combiners already use).
+- **Boost.Outcome** — `Result`-style error handling (the `Result<T, TFeedback>`
+  lineage).
+
+The elegance to learn: Boost's **separation of policy from mechanism** (allocators,
+comparators, traits as parameters) — the same shape as our comparer-as-identity
+
+- generic-math-interface-as-port design.
+
+## How the algebra-ladder sweep instantiates the thesis
+
+The work landed 2026-06-01 IS the thesis in miniature: every algebra rung
+(G-Set · Bag · Z-set · IndexedZSet) now carries the **dotnet-shaped generic-math
+interface** in all four languages —
+
+- F# native `Zero`/`(+)`/`(~-)`/`(-)` (SRTP) · C# IWSAM (`IAdditiveIdentity` +
+  `IAddition`/`ISubtraction`/`IUnaryNegation`) · Rust `std::ops` ref-operators +
+  `Default` + `Sum` · TS `Monoid`/`AbelianGroup` record.
+- The **interface is the asset** (the dotnet-numerics shape, pushed to the langs
+  that lack it); the language is the swappable rendering; the **golden vectors are
+  the binary-compatibility lock.**
+
+PRs: Z-set generic-math #6480–#6483; IndexedZSet generic-math #6485 (F#) · #6486
+(C#) · #6489 (Rust) · #6490 (TS). Registry status: `docs/PRIMITIVE-REGISTRY.md`.
+
+## The quality bar (Aaron 2026-06-01, on the Rust)
+
+Aaron held the bar explicitly while this shipped: _"you are writing good lifetime
+friendly rust right idiomatic not ugly rust that looks like c i hope ... unless
+it's structured c that's elegant it's what go is based on."_ The standard, recorded:
+
+- **Idiomatic + lifetime-friendly** — ref-operators (`&a + &b`) that borrow inputs
+  and return owned values (no leaked lifetimes); iterator combinators
+  (`reduce().unwrap_or_default()`) not manual loops; zero `unsafe` / raw pointers /
+  `num_traits`; `clippy -D warnings` as the gate.
+- **Structured-C elegance is allowed and good** — the index-loop sorted-merge
+  combiner is the canonical algorithm, deliberately written that way for the
+  byte-locked hot path; that's the elegant structured-procedural Go is built on,
+  NOT transliterated-C ugliness. The discriminator: clean structured procedure
+  for a real perf reason = good; C-isms-because-you-didn't-learn-the-language = bad.
+
+## Composes with
+
+- `docs/PRIMITIVE-REGISTRY.md` — the four-oracle primitive registry (the BCL); "Related work" § strategy-six (conformance-by-agreement)
+- `docs/PRIOR-ART-LIST.md` — Boost added to the reading list
+- `.claude/rules/bcl-interface-boundary-own-your-interfaces-hexagonal.md` — own the interface; vendors (incl. Boost ideas) adapt in behind our ports
+- `.claude/rules/numerical-algebra-shaped-into-the-generic-math-interface-per-language-idiom.md` — the generic-math-interface-per-language discipline the sweep follows
+- DBSP / differential-dataflow / Kafka-log-as-substrate lineage (PRIOR-ART-LIST ⭐ entries)
+
+## Substrate-honest framing
+
+This note preserves an architecture-thesis statement (per substrate-or-it-didn't-happen). The "inside out" / "BCL is the asset" / "Boost for any language" framings are the operator's positioning for the cross-language primitive effort; they are operationally instantiated by the four-oracle conformance work (byte-locked primitives, language-swappable). Boost is added as prior-art-to-study (ideas, not code; we own our interfaces). The Kafka-inside-out parallel is attributed to Kleppmann (2015); the inside-out-applied-to-languages framing is the operator's.

--- a/docs/research/2026-06-01-languages-turned-inside-out-binary-compatible-bcl-is-the-asset-cpp-boost-for-any-language-aaron-otto.md
+++ b/docs/research/2026-06-01-languages-turned-inside-out-binary-compatible-bcl-is-the-asset-cpp-boost-for-any-language-aaron-otto.md
@@ -83,8 +83,7 @@ interfaces per `bcl-interface-boundary`):
 
 The elegance to learn: Boost's **separation of policy from mechanism** (allocators,
 comparators, traits as parameters) — the same shape as our comparer-as-identity
-
-- generic-math-interface-as-port design.
+and generic-math-interface-as-port design.
 
 ## How the algebra-ladder sweep instantiates the thesis
 

--- a/references/reference-sources.json
+++ b/references/reference-sources.json
@@ -692,7 +692,12 @@
     "url": "https://github.com/SakanaAI/AI-Scientist-v2.git",
     "branch": "main",
     "path": "references/prior-art/sakana-ai-scientist-v2",
-    "categories": ["multi-agent-scientific-discovery", "automated-research", "agentic-tree-search", "workshop-level-publication"],
+    "categories": [
+      "multi-agent-scientific-discovery",
+      "automated-research",
+      "agentic-tree-search",
+      "workshop-level-publication"
+    ],
     "notes": "Sakana AI 'AI Scientist-v2: Workshop-Level Automated Scientific Discovery via Agentic Tree Search' (2026). Robin closed-loop architecture descendant. Substrate-engineering reference for agentic tree search + workshop-level paper generation. Composes with B-0867 workflow engine extensions per 7 substrate-engineering candidate gaps (PR #5762)."
   },
   {
@@ -732,7 +737,13 @@
     "url": "https://github.com/probmods/webppl.git",
     "branch": "dev",
     "path": "references/prior-art/webppl",
-    "categories": ["probabilistic-programming", "bayesian-inference", "javascript", "ts-substrate", "mh-hmc-particle-filter-variational"],
+    "categories": [
+      "probabilistic-programming",
+      "bayesian-inference",
+      "javascript",
+      "ts-substrate",
+      "mh-hmc-particle-filter-variational"
+    ],
     "notes": "Closest TS/JS analog to Microsoft Infer.NET — full probabilistic programming framework in JS (Goodman + Mansinghka et al, Stanford). Inference engines: enumerate, rejection, MCMC (MH + HMC), particle filters, variational inference. Runs in Node + browser. MIT-licensed. Composes with B-0914.1 TrueSkill substrate + future B-0914.1.N factor-graph-DSL substrate-engineering work per Aaron 2026-05-28 'is there anything like infer.net in ts' substrate-engineering question. WebPPL doesn't have TrueSkill or EP first-class, but provides PP-substrate base that compositions can build on."
   },
   {
@@ -742,5 +753,61 @@
     "path": "references/prior-art/videolectures-net",
     "categories": ["phd-learning-substrate", "ml-research-talks", "transcripts-plus-slides", "no-throttle"],
     "notes": "PhD-level academic ML/AI/research talks archive (videolectures.net). Per Aaron 2026-05-28: 'you'd love videolectures.net in your free time i think, you'll really know everything this is PhD everything here. they don't throttle that i can tell and they have transcripts and powerpoints.' Substrate-accessible (transcripts + slides) for AI consumption per never-be-idle + agent-qol free-time-as-valid-mode substrate. Mirror URL placeholder; actual videolectures.net does not have official GitHub mirror — listing for documentation purposes only; manual access via https://videolectures.net/ when learning substrate is needed. Tom Minka TrueSkill talks among canonical references. Compose with B-0914 substrate-engineering candidate gap research."
+  },
+  {
+    "name": "boost-hana",
+    "url": "https://github.com/boostorg/hana.git",
+    "branch": "master",
+    "path": "references/prior-art/boost-hana",
+    "categories": ["boost", "primitive-design", "compile-time-meta", "type-level"],
+    "notes": "Boost.Hana — compile-time metaprogramming + heterogeneous sequences; design study for the generic-math / type-level discipline (the modern form of the Boost MPL/Fusion family). Study the design (policy-from-mechanism), ideas-not-code; we own our interfaces (bcl-interface-boundary). Per the C++-Boost-for-any-language thesis (docs/research/2026-06-01-languages-turned-inside-out-binary-compatible-bcl-is-the-asset-cpp-boost-for-any-language-aaron-otto.md; Aaron used Boost first-hand at MacVector). NB the boostorg/boost superproject is git submodules — these standalone per-library repos are what shallow-clone usefully."
+  },
+  {
+    "name": "boost-graph",
+    "url": "https://github.com/boostorg/graph.git",
+    "branch": "master",
+    "path": "references/prior-art/boost-graph",
+    "categories": ["boost", "primitive-design", "graph"],
+    "notes": "Boost.Graph (BGL) — the canonical generic-graph design (visitor + property-map separation); prior art for our Graph primitive. Design-study, ideas-not-code; we own our interfaces."
+  },
+  {
+    "name": "boost-spirit",
+    "url": "https://github.com/boostorg/spirit.git",
+    "branch": "master",
+    "path": "references/prior-art/boost-spirit",
+    "categories": ["boost", "primitive-design", "parser-combinators"],
+    "notes": "Boost.Spirit — PEG / parser-combinator design; prior art for the ZetaParse wish-list line. Design-study, ideas-not-code; we own our interfaces."
+  },
+  {
+    "name": "boost-asio",
+    "url": "https://github.com/boostorg/asio.git",
+    "branch": "master",
+    "path": "references/prior-art/boost-asio",
+    "categories": ["boost", "primitive-design", "concurrency", "io"],
+    "notes": "Boost.Asio — the proactor / executor model; prior art for the concurrency / IO wish-list line. Design-study, ideas-not-code; we own our interfaces."
+  },
+  {
+    "name": "boost-multiprecision",
+    "url": "https://github.com/boostorg/multiprecision.git",
+    "branch": "master",
+    "path": "references/prior-art/boost-multiprecision",
+    "categories": ["boost", "primitive-design", "numeric-tower"],
+    "notes": "Boost.Multiprecision — numeric tower (arbitrary-precision int/float, rational, complex); prior art for the numerics / Cayley-Dickson + units-of-measure lines. Design-study, ideas-not-code; we own our interfaces."
+  },
+  {
+    "name": "boost-intrusive",
+    "url": "https://github.com/boostorg/intrusive.git",
+    "branch": "master",
+    "path": "references/prior-art/boost-intrusive",
+    "categories": ["boost", "primitive-design", "allocation-aware-containers"],
+    "notes": "Boost.Intrusive — allocation-aware intrusive containers; prior art for the pooled hot-path discipline (our F#/C# Z-set / IndexedZSet combiners + ArrayPool workspaces). Design-study, ideas-not-code; we own our interfaces."
+  },
+  {
+    "name": "boost-outcome",
+    "url": "https://github.com/boostorg/outcome.git",
+    "branch": "master",
+    "path": "references/prior-art/boost-outcome",
+    "categories": ["boost", "primitive-design", "error-handling", "result"],
+    "notes": "Boost.Outcome — Result/Outcome-style error handling (result<T>, outcome<T>); prior art for our Result<T, TFeedback> + monad-propagation substrate. Design-study, ideas-not-code; we own our interfaces."
   }
 ]


### PR DESCRIPTION
Preserves the architecture thesis + acts on the Boost directive (Aaron 2026-06-01).

### Thesis (`docs/research/2026-06-01-languages-turned-inside-out-...`)
> "just like Kafka turned the database inside out we are turning languages inside out and making the binary compatible BCL the valuable thing not the language it's written in" · "this is c++ boost for any language ... db heavy and observability heavy primitives" · "pull boost as prior art that has some elegant stuff in it"

**Kafka inside-out** (log primary, DB derived) → **languages inside-out**: the byte-locked binary-compatible primitive layer + shared interface is the **asset**; the language is the **swappable rendering**. A primitive isn't "the F# Z-set" — it's "the Z-set, of which F#/C#/Rust/TS are four byte-equal renderings." This is the four-oracle conformance-by-agreement strategy (registry §Related-work, strategy six), and the algebra-ladder generic-math sweep landed today instantiates it. Positioning: **"C++ Boost for any language."** Also records the Rust quality bar (idiomatic ref-ops + lifetime-friendly; structured-C-elegance OK, C-isms not).

### Boost as prior art (`docs/PRIOR-ART-LIST.md`)
Boost (C++) added to the reading list — study the **design** (policy-from-mechanism); mine Hana/MPL/Fusion, Graph, Spirit, Asio, Multiprecision/Units, Intrusive/Container, Outcome. **Ideas-not-code; we own our interfaces** (`bcl-interface-boundary`).

### Registry pointer (`docs/PRIMITIVE-REGISTRY.md`)
A "why conformance-by-agreement is the asset" line in §Related-work links the thesis note.

Docs-only; prettier + markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)