### PR TITLE
fix(DynamicValue): Rust oracle returns Result (converge with F#/C#) — no panic on deferred variants

### DIFF
--- a/src/Core.Rust.DynamicValue/src/lib.rs
+++ b/src/Core.Rust.DynamicValue/src/lib.rs
@@ -85,35 +85,32 @@ impl DynamicValue {
     /// `\u00XX` lowercase; all else raw UTF-8). v1 locks
     /// null/bool/int/string/array/object.
     ///
-    /// # Panics
-    /// Panics on `Float` or `Bytes` -- both are DEFERRED (no canonical JSON form
-    /// yet; they lock under CBOR or a tagged-JSON convention).
-    #[must_use]
-    pub fn to_canonical_json(&self) -> String {
+    /// # Errors
+    /// Returns [`EncodeError`] for `Float` or `Bytes` -- both are DEFERRED (no
+    /// canonical JSON form yet; they lock under CBOR or a tagged-JSON
+    /// convention), surfaced as data per the Result-over-exception rule (AGENTS.md),
+    /// never panicked. Mirrors the F#/C# `Result<string, EncodeError>` oracles.
+    pub fn to_canonical_json(&self) -> Result<String, EncodeError> {
         let mut out = String::new();
-        self.write_canonical(&mut out);
-        out
+        self.write_canonical(&mut out)?;
+        Ok(out)
     }
 
-    fn write_canonical(&self, out: &mut String) {
+    fn write_canonical(&self, out: &mut String) -> Result<(), EncodeError> {
         match self {
             DynamicValue::Null => out.push_str("null"),
             DynamicValue::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
             DynamicValue::Int(i) => out.push_str(&i.to_string()),
-            DynamicValue::Float(_) => panic!(
-                "DynamicValue::Float canonical JSON is DEFERRED (no canonical shortest-float in plain JSON); locks under CBOR or a tagged-JSON convention"
-            ),
+            DynamicValue::Float(_) => return Err(EncodeError::FloatDeferred),
             DynamicValue::String(s) => escape_json_string(s, out),
-            DynamicValue::Bytes(_) => panic!(
-                "DynamicValue::Bytes canonical JSON is DEFERRED (no native JSON byte type); locks under CBOR or a tagged-JSON convention"
-            ),
+            DynamicValue::Bytes(_) => return Err(EncodeError::BytesDeferred),
             DynamicValue::Array(items) => {
                 out.push('[');
                 for (k, item) in items.iter().enumerate() {
                     if k > 0 {
                         out.push(',');
                     }
-                    item.write_canonical(out);
+                    item.write_canonical(out)?;
                 }
                 out.push(']');
             }
@@ -125,12 +122,26 @@ impl DynamicValue {
                     }
                     escape_json_string(key, out);
                     out.push(':');
-                    val.write_canonical(out);
+                    val.write_canonical(out)?;
                 }
                 out.push('}');
             }
         }
+
+        Ok(())
     }
+}
+
+/// Why a [`DynamicValue`] could not be canonically encoded (v1). `Float` and
+/// `Bytes` have no canonical JSON form yet (they lock under CBOR or a tagged-JSON
+/// convention); surfaced as `Err` data per the Result-over-exception rule
+/// (AGENTS.md), never panicked. Mirrors the F#/C# `EncodeError`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncodeError {
+    /// `DynamicValue::Float` has no canonical shortest-float form in plain JSON.
+    FloatDeferred,
+    /// `DynamicValue::Bytes` has no native JSON byte type.
+    BytesDeferred,
 }
 
 // Append `s` as a JSON string literal (including the surrounding quotes), RFC 8259

--- a/src/Core.Rust.DynamicValue/src/lib.rs
+++ b/src/Core.Rust.DynamicValue/src/lib.rs
@@ -144,6 +144,24 @@ pub enum EncodeError {
     BytesDeferred,
 }
 
+// `EncodeError` is public API (returned from `to_canonical_json`), so it carries
+// a stable human-readable `Display` and is a real `std::error::Error` -- callers
+// surface it without leaning on `Debug`.
+impl std::fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            EncodeError::FloatDeferred => {
+                "DynamicValue::Float has no canonical JSON form yet (deferred to CBOR or a tagged-JSON convention)"
+            }
+            EncodeError::BytesDeferred => {
+                "DynamicValue::Bytes has no native JSON byte type yet (deferred to CBOR or a tagged-JSON convention)"
+            }
+        })
+    }
+}
+
+impl std::error::Error for EncodeError {}
+
 // Append `s` as a JSON string literal (including the surrounding quotes), RFC 8259
 // minimal escaping: '"' and '\' and control chars U+0000..U+001F (short forms
 // where they exist, else \u00XX lowercase-hex); '/' is NOT escaped; all other
@@ -169,4 +187,37 @@ fn escape_json_string(s: &str, out: &mut String) {
         }
     }
     out.push('"');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Lock the Result contract this oracle introduced: the deferred variants
+    // surface as `Err` and NEVER panic, per the Result-over-exception rule
+    // (AGENTS.md). The seed has no Float/Bytes vectors, so the cross-verify
+    // oracle can't catch a regression here -- these assert the contract directly
+    // (assert-don't-skip: a contract with no test is a hole in the shield).
+    #[test]
+    fn float_is_deferred_error_not_panic() {
+        assert_eq!(
+            DynamicValue::Float(1.5).to_canonical_json(),
+            Err(EncodeError::FloatDeferred)
+        );
+    }
+
+    #[test]
+    fn bytes_is_deferred_error_not_panic() {
+        assert_eq!(
+            DynamicValue::Bytes(vec![0u8, 1, 2]).to_canonical_json(),
+            Err(EncodeError::BytesDeferred)
+        );
+    }
+
+    // `EncodeError` is public API; Display must be stable + human-readable.
+    #[test]
+    fn encode_error_display_is_human_readable() {
+        assert!(EncodeError::FloatDeferred.to_string().contains("Float"));
+        assert!(EncodeError::BytesDeferred.to_string().contains("Bytes"));
+    }
 }

--- a/src/Core.Rust.DynamicValue/tests/cross_verify.rs
+++ b/src/Core.Rust.DynamicValue/tests/cross_verify.rs
@@ -79,9 +79,10 @@ fn dynamic_value_cross_verify_matches_golden_vectors() {
         let name = vec["name"].as_str().expect("name string");
         let value = build_value(&vec["value"]);
         let expected = vec["json"].as_str().expect("json string");
-        let actual = value.to_canonical_json();
-        if actual != expected {
-            failures.push(format!("{name}: expected {expected} but got {actual}"));
+        match value.to_canonical_json() {
+            Ok(actual) if actual == expected => {}
+            Ok(actual) => failures.push(format!("{name}: expected {expected} but got {actual}")),
+            Err(e) => failures.push(format!("{name}: expected {expected} but got Err {e:?}")),
         }
     }
 


### PR DESCRIPTION
Converges the merged Rust oracle (#6503) with the F# (#6500) + C# (#6502) reground, per AGENTS.md's **Result-over-exception hard rule**. The Rust `to_canonical_json` *panicked* on a legal `DynamicValue::Float`/`::Bytes` — the same exception-for-a-legal-value-path violation fixed in F#/C#. Now returns `Result<String, EncodeError>` (FloatDeferred | BytesDeferred), surfacing deferred variants as **Err data** via `?` propagation.

All four oracles now agree on the byte-lock bytes; the three with a production encoder (F#/C#/Rust) share the `Result` error-wrapper. (TS needs no change — its only encoder is the test's inline one over the six locked cases, no production deferred path.)

Verified **locally**: `cargo test` green + `RUSTFLAGS=-D warnings` clean. Rust is not in the CI build-and-test matrix (`gate.yml` is dotnet-only) — locally cargo-verified, like every `Core.Rust.*` oracle.

This completes the DynamicValue v1 byte-lock + Result-convergence across all oracles. Next (separate): Float/Bytes lock under CBOR (or tagged-JSON) if called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)