### PR TITLE
feat(DynamicValue): lock Float + Bytes under canonical CBOR (seed + C# oracle)

### DIFF
--- a/src/Core.CSharp.DynamicValue/DynamicValues.cs
+++ b/src/Core.CSharp.DynamicValue/DynamicValues.cs
@@ -346,4 +346,178 @@ public static class DynamicValues
 
         sb.Append('"');
     }
+
+    /// <summary>Canonical CBOR encoding (RFC 8949) — the TOTAL byte-lock target for all eight shapes
+    /// (the shared seed is <c>src/Core.TypeScript/dynamic-value/golden-vectors-cbor.json</c>). Where
+    /// <see cref="ToCanonicalJson"/> is a partial projection (6/8 shapes; Float/Bytes deferred), CBOR
+    /// is total: <see cref="DynamicValue.Float"/> uses the RFC 8949 §4.2.2 shortest-float rule
+    /// (float16 if it round-trips exactly, else float32, else float64; NaN canonicalizes to
+    /// <c>0xf97e00</c>) and <see cref="DynamicValue.Bytes"/> uses a native major-type-2 byte string —
+    /// so no <see cref="Result{T, TError}"/> is needed (CBOR has a canonical form for every shape).
+    /// <para>One deliberate deviation from RFC 8949 §4.2.1 deterministic encoding:
+    /// <see cref="DynamicValue.Object"/> map keys stay in INSERTION order, NOT bytewise-sorted,
+    /// because Object is order-significant — the §4.2.1 key-sort would be lossy / non-bijective (the
+    /// same call v1 made for canonical JSON). Integers and string/array/map lengths use preferred
+    /// (shortest) serialization per §4.2.1.</para></summary>
+    /// <param name="value">the value to encode.</param>
+    /// <returns>the canonical CBOR bytes.</returns>
+    public static byte[] ToCanonicalCbor(DynamicValue value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        var buf = new List<byte>();
+        WriteCbor(buf, value);
+        return buf.ToArray();
+    }
+
+    private static void WriteCbor(List<byte> buf, DynamicValue value)
+    {
+        switch (value)
+        {
+            case DynamicValue.Null:
+                buf.Add(0xf6);
+                break;
+            case DynamicValue.Bool b:
+                buf.Add(b.Value ? (byte)0xf5 : (byte)0xf4);
+                break;
+            case DynamicValue.Int i:
+                WriteCborInt(buf, i.Value);
+                break;
+            case DynamicValue.Float f:
+                WriteCborFloat(buf, f.Value);
+                break;
+            case DynamicValue.String s:
+                WriteCborText(buf, s.Value);
+                break;
+            case DynamicValue.Bytes by:
+                WriteCborHead(buf, 2, (ulong)by.Value.Length);
+                buf.AddRange(by.Value);
+                break;
+            case DynamicValue.Array a:
+                WriteCborHead(buf, 4, (ulong)a.Items.Length);
+                foreach (DynamicValue item in a.Items)
+                {
+                    WriteCbor(buf, item);
+                }
+
+                break;
+            case DynamicValue.Object o:
+                WriteCborHead(buf, 5, (ulong)o.Pairs.Length);
+                foreach (KeyValuePair<string, DynamicValue> pair in o.Pairs)
+                {
+                    WriteCborText(buf, pair.Key);
+                    WriteCbor(buf, pair.Value);
+                }
+
+                break;
+            default:
+                // Unreachable: the DynamicValue hierarchy is closed (sealed record cases).
+                throw new InvalidOperationException(
+                    $"WriteCbor reached an unknown variant ({value.Type}); the DynamicValue hierarchy is closed");
+        }
+    }
+
+    // CBOR initial byte (major type in top 3 bits) + preferred/shortest argument (RFC 8949 §3, §4.2.1).
+    private static void WriteCborHead(List<byte> buf, int major, ulong arg)
+    {
+        byte mt = (byte)(major << 5);
+        if (arg <= 23UL)
+        {
+            buf.Add((byte)(mt | (byte)arg));
+        }
+        else if (arg <= 0xffUL)
+        {
+            buf.Add((byte)(mt | 24));
+            buf.Add((byte)arg);
+        }
+        else if (arg <= 0xffffUL)
+        {
+            buf.Add((byte)(mt | 25));
+            buf.Add((byte)(arg >> 8));
+            buf.Add((byte)arg);
+        }
+        else if (arg <= 0xffffffffUL)
+        {
+            buf.Add((byte)(mt | 26));
+            buf.Add((byte)(arg >> 24));
+            buf.Add((byte)(arg >> 16));
+            buf.Add((byte)(arg >> 8));
+            buf.Add((byte)arg);
+        }
+        else
+        {
+            buf.Add((byte)(mt | 27));
+            for (int shift = 56; shift >= 0; shift -= 8)
+            {
+                buf.Add((byte)(arg >> shift));
+            }
+        }
+    }
+
+    // Major 0 for v >= 0; major 1 for v < 0 (which encodes -1 - v). `~v` yields -1 - v without the
+    // long.MinValue overflow that `-1 - v` / `-v` would hit.
+    private static void WriteCborInt(List<byte> buf, long value)
+    {
+        if (value >= 0)
+        {
+            WriteCborHead(buf, 0, (ulong)value);
+        }
+        else
+        {
+            WriteCborHead(buf, 1, (ulong)(~value));
+        }
+    }
+
+    // Major 3 text string: raw UTF-8, no escaping (unlike JSON). A String holding a lone surrogate
+    // is not a valid Unicode scalar sequence; .NET UTF-8 encodes it as U+FFFD (encoder-defined) — the
+    // seed's string vectors are all valid UTF-8.
+    private static void WriteCborText(List<byte> buf, string? value)
+    {
+        byte[] utf8 = Encoding.UTF8.GetBytes(value ?? string.Empty);
+        WriteCborHead(buf, 3, (ulong)utf8.Length);
+        buf.AddRange(utf8);
+    }
+
+    // RFC 8949 §4.2.2 shortest float: NaN -> 0xf97e00; otherwise the shortest of float16 / float32 /
+    // float64 that decodes back to the exact same value (±0 and ±Inf round-trip through float16). The
+    // `(double)narrowed == value` test also rejects a width that overflowed to Inf (e.g. 1e300 as
+    // float32), correctly falling through to the wider form.
+    private static void WriteCborFloat(List<byte> buf, double value)
+    {
+        if (double.IsNaN(value))
+        {
+            buf.Add(0xf9);
+            buf.Add(0x7e);
+            buf.Add(0x00);
+            return;
+        }
+
+        float f32 = (float)value;
+        if ((double)f32 == value)
+        {
+            var f16 = (Half)f32;
+            if ((float)f16 == f32)
+            {
+                ushort bits16 = BitConverter.HalfToUInt16Bits(f16);
+                buf.Add(0xf9);
+                buf.Add((byte)(bits16 >> 8));
+                buf.Add((byte)bits16);
+                return;
+            }
+
+            uint bits32 = BitConverter.SingleToUInt32Bits(f32);
+            buf.Add(0xfa);
+            buf.Add((byte)(bits32 >> 24));
+            buf.Add((byte)(bits32 >> 16));
+            buf.Add((byte)(bits32 >> 8));
+            buf.Add((byte)bits32);
+            return;
+        }
+
+        ulong bits64 = BitConverter.DoubleToUInt64Bits(value);
+        buf.Add(0xfb);
+        for (int shift = 56; shift >= 0; shift -= 8)
+        {
+            buf.Add((byte)(bits64 >> shift));
+        }
+    }
 }

--- a/src/Core.TypeScript/dynamic-value/golden-vectors-cbor.json
+++ b/src/Core.TypeScript/dynamic-value/golden-vectors-cbor.json
@@ -1,0 +1,474 @@
+{
+  "primitive": "DynamicValue",
+  "format": "canonical-cbor",
+  "spec": "RFC 8949 (CBOR), preferred/shortest int+length (§4.2.1) and shortest-float (§4.2.2)",
+  "note": "Canonical CBOR byte-lock for all eight DynamicValue shapes (CBOR is TOTAL where canonical JSON is partial: it locks Float via shortest-float and Bytes via major-type-2). DELIBERATE deviation from RFC 8949 §4.2.1 deterministic encoding: Object map keys stay in INSERTION order, NOT bytewise-sorted, because Object is order-significant (sorting would be lossy/non-bijective) -- the same call v1 made for canonical JSON. value.v for float is the IEEE-754 f64 bit pattern (16 hex, big-endian) for exactness; for int a decimal string; for bytes a hex string. Generated + RFC-8949-Appendix-A-anchored by tools-side python; each language oracle replays.",
+  "vectors": [
+    {
+      "name": "null",
+      "value": {
+        "t": "null"
+      },
+      "cbor": "f6"
+    },
+    {
+      "name": "bool-false",
+      "value": {
+        "t": "bool",
+        "v": false
+      },
+      "cbor": "f4"
+    },
+    {
+      "name": "bool-true",
+      "value": {
+        "t": "bool",
+        "v": true
+      },
+      "cbor": "f5"
+    },
+    {
+      "name": "int-zero",
+      "value": {
+        "t": "int",
+        "v": "0"
+      },
+      "cbor": "00"
+    },
+    {
+      "name": "int-23-max-inline",
+      "value": {
+        "t": "int",
+        "v": "23"
+      },
+      "cbor": "17"
+    },
+    {
+      "name": "int-24-one-byte",
+      "value": {
+        "t": "int",
+        "v": "24"
+      },
+      "cbor": "1818"
+    },
+    {
+      "name": "int-1000",
+      "value": {
+        "t": "int",
+        "v": "1000"
+      },
+      "cbor": "1903e8"
+    },
+    {
+      "name": "int-1000000",
+      "value": {
+        "t": "int",
+        "v": "1000000"
+      },
+      "cbor": "1a000f4240"
+    },
+    {
+      "name": "int-i64-max",
+      "value": {
+        "t": "int",
+        "v": "9223372036854775807"
+      },
+      "cbor": "1b7fffffffffffffff"
+    },
+    {
+      "name": "int-neg-1",
+      "value": {
+        "t": "int",
+        "v": "-1"
+      },
+      "cbor": "20"
+    },
+    {
+      "name": "int-neg-1000",
+      "value": {
+        "t": "int",
+        "v": "-1000"
+      },
+      "cbor": "3903e7"
+    },
+    {
+      "name": "int-i64-min",
+      "value": {
+        "t": "int",
+        "v": "-9223372036854775808"
+      },
+      "cbor": "3b7fffffffffffffff"
+    },
+    {
+      "name": "str-empty",
+      "value": {
+        "t": "str",
+        "v": ""
+      },
+      "cbor": "60"
+    },
+    {
+      "name": "str-a",
+      "value": {
+        "t": "str",
+        "v": "a"
+      },
+      "cbor": "6161"
+    },
+    {
+      "name": "str-ietf",
+      "value": {
+        "t": "str",
+        "v": "IETF"
+      },
+      "cbor": "6449455446"
+    },
+    {
+      "name": "str-unicode",
+      "value": {
+        "t": "str",
+        "v": "a水b"
+      },
+      "cbor": "6561e6b0b462",
+      "note": "raw UTF-8, no escaping"
+    },
+    {
+      "name": "float-zero",
+      "value": {
+        "t": "float",
+        "v": "0000000000000000"
+      },
+      "cbor": "f90000",
+      "note": "0.0 -> f90000"
+    },
+    {
+      "name": "float-neg-zero",
+      "value": {
+        "t": "float",
+        "v": "8000000000000000"
+      },
+      "cbor": "f98000",
+      "note": "-0.0 -> f98000 (sign preserved)"
+    },
+    {
+      "name": "float-one",
+      "value": {
+        "t": "float",
+        "v": "3ff0000000000000"
+      },
+      "cbor": "f93c00",
+      "note": "1.0 -> f93c00"
+    },
+    {
+      "name": "float-one-point-five",
+      "value": {
+        "t": "float",
+        "v": "3ff8000000000000"
+      },
+      "cbor": "f93e00",
+      "note": "1.5 -> f93e00"
+    },
+    {
+      "name": "float-f16-max",
+      "value": {
+        "t": "float",
+        "v": "40effc0000000000"
+      },
+      "cbor": "f97bff",
+      "note": "largest float16 -> f97bff"
+    },
+    {
+      "name": "float-f32-only",
+      "value": {
+        "t": "float",
+        "v": "40f86a0000000000"
+      },
+      "cbor": "fa47c35000",
+      "note": "f16 overflow -> float32 fa47c35000"
+    },
+    {
+      "name": "float-f32-max",
+      "value": {
+        "t": "float",
+        "v": "47efffffe0000000"
+      },
+      "cbor": "fa7f7fffff",
+      "note": "float32 max -> fa7f7fffff"
+    },
+    {
+      "name": "float-f64-only",
+      "value": {
+        "t": "float",
+        "v": "7e37e43c8800759c"
+      },
+      "cbor": "fb7e37e43c8800759c",
+      "note": "f32 overflow -> float64 fb7e37e43c8800759c"
+    },
+    {
+      "name": "float-f16-subnormal",
+      "value": {
+        "t": "float",
+        "v": "3e70000000000000"
+      },
+      "cbor": "f90001",
+      "note": "smallest f16 subnormal -> f90001"
+    },
+    {
+      "name": "float-f16-min-normal",
+      "value": {
+        "t": "float",
+        "v": "3f10000000000000"
+      },
+      "cbor": "f90400",
+      "note": "2^-14 smallest f16 normal -> f90400"
+    },
+    {
+      "name": "float-neg-four",
+      "value": {
+        "t": "float",
+        "v": "c010000000000000"
+      },
+      "cbor": "f9c400",
+      "note": "-4.0 -> f9c400"
+    },
+    {
+      "name": "float-neg-four-point-one",
+      "value": {
+        "t": "float",
+        "v": "c010666666666666"
+      },
+      "cbor": "fbc010666666666666",
+      "note": "not f32-exact -> float64 fbc010666666666666"
+    },
+    {
+      "name": "float-pos-inf",
+      "value": {
+        "t": "float",
+        "v": "7ff0000000000000"
+      },
+      "cbor": "f97c00",
+      "note": "Infinity -> f97c00"
+    },
+    {
+      "name": "float-neg-inf",
+      "value": {
+        "t": "float",
+        "v": "fff0000000000000"
+      },
+      "cbor": "f9fc00",
+      "note": "-Infinity -> f9fc00"
+    },
+    {
+      "name": "float-nan",
+      "value": {
+        "t": "float",
+        "v": "7ff8000000000000"
+      },
+      "cbor": "f97e00",
+      "note": "canonical quiet NaN -> f97e00"
+    },
+    {
+      "name": "bytes-empty",
+      "value": {
+        "t": "bytes",
+        "v": ""
+      },
+      "cbor": "40",
+      "note": "major-type-2 empty -> 40"
+    },
+    {
+      "name": "bytes-1234",
+      "value": {
+        "t": "bytes",
+        "v": "01020304"
+      },
+      "cbor": "4401020304",
+      "note": "h'01020304' -> 4401020304"
+    },
+    {
+      "name": "array-empty",
+      "value": {
+        "t": "arr",
+        "v": []
+      },
+      "cbor": "80"
+    },
+    {
+      "name": "array-ints",
+      "value": {
+        "t": "arr",
+        "v": [
+          {
+            "t": "int",
+            "v": "1"
+          },
+          {
+            "t": "int",
+            "v": "2"
+          },
+          {
+            "t": "int",
+            "v": "3"
+          }
+        ]
+      },
+      "cbor": "83010203"
+    },
+    {
+      "name": "array-mixed",
+      "value": {
+        "t": "arr",
+        "v": [
+          {
+            "t": "int",
+            "v": "1"
+          },
+          {
+            "t": "float",
+            "v": "3ff8000000000000"
+          },
+          {
+            "t": "bytes",
+            "v": "ff"
+          },
+          {
+            "t": "null"
+          }
+        ]
+      },
+      "cbor": "8401f93e0041fff6",
+      "note": "float+bytes nested in array"
+    },
+    {
+      "name": "array-nested",
+      "value": {
+        "t": "arr",
+        "v": [
+          {
+            "t": "int",
+            "v": "1"
+          },
+          {
+            "t": "arr",
+            "v": [
+              {
+                "t": "int",
+                "v": "2"
+              },
+              {
+                "t": "int",
+                "v": "3"
+              }
+            ]
+          }
+        ]
+      },
+      "cbor": "8201820203"
+    },
+    {
+      "name": "object-empty",
+      "value": {
+        "t": "obj",
+        "v": []
+      },
+      "cbor": "a0"
+    },
+    {
+      "name": "object-single",
+      "value": {
+        "t": "obj",
+        "v": [
+          [
+            "a",
+            {
+              "t": "int",
+              "v": "1"
+            }
+          ]
+        ]
+      },
+      "cbor": "a1616101"
+    },
+    {
+      "name": "object-rfc-ordered",
+      "value": {
+        "t": "obj",
+        "v": [
+          [
+            "a",
+            {
+              "t": "int",
+              "v": "1"
+            }
+          ],
+          [
+            "b",
+            {
+              "t": "arr",
+              "v": [
+                {
+                  "t": "int",
+                  "v": "2"
+                },
+                {
+                  "t": "int",
+                  "v": "3"
+                }
+              ]
+            }
+          ]
+        ]
+      },
+      "cbor": "a26161016162820203",
+      "note": "RFC A: a26161016162820203"
+    },
+    {
+      "name": "object-order-significant",
+      "value": {
+        "t": "obj",
+        "v": [
+          [
+            "b",
+            {
+              "t": "int",
+              "v": "1"
+            }
+          ],
+          [
+            "a",
+            {
+              "t": "int",
+              "v": "2"
+            }
+          ]
+        ]
+      },
+      "cbor": "a2616201616102",
+      "note": "insertion order b,a NOT sorted"
+    },
+    {
+      "name": "object-float-bytes-values",
+      "value": {
+        "t": "obj",
+        "v": [
+          [
+            "pi",
+            {
+              "t": "float",
+              "v": "400c000000000000"
+            }
+          ],
+          [
+            "raw",
+            {
+              "t": "bytes",
+              "v": "dead"
+            }
+          ]
+        ]
+      },
+      "cbor": "a2627069f943006372617742dead",
+      "note": "float+bytes as object values"
+    }
+  ]
+}

--- a/tests/Tests.CSharp/DynamicValueCborCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/DynamicValueCborCrossVerifyTests.cs
@@ -1,0 +1,144 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+using Zeta.Core.CSharp;
+
+namespace Zeta.Tests.CSharp;
+
+/// <summary>
+/// DynamicValue canonical-CBOR byte-lock — the C# oracle agrees on the shared seed
+/// (<c>src/Core.TypeScript/dynamic-value/golden-vectors-cbor.json</c>). CBOR is the TOTAL form
+/// (all 8 shapes), so this is where Float (RFC 8949 §4.2.2 shortest-float) and Bytes
+/// (major-type-2) finally lock — the two cases canonical JSON deferred. The seed was generated +
+/// RFC-8949-Appendix-A-anchored independently (tools-side); <see cref="FloatMatchesRfc8949AppendixA"/>
+/// re-anchors the float logic against the RFC directly so the lock is not circular.
+/// "The compilers don't lie."
+/// </summary>
+public class DynamicValueCborCrossVerifyTests
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(Path.GetDirectoryName(typeof(DynamicValueCborCrossVerifyTests).Assembly.Location)!);
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "Zeta.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName
+            ?? throw new InvalidOperationException("Could not locate repo root (Zeta.sln) from test assembly location.");
+    }
+
+    private static string Str(JsonElement el, string prop) =>
+        el.GetProperty(prop).GetString()
+            ?? throw new InvalidOperationException($"fixture property '{prop}' is not a string: {el.GetRawText()}");
+
+    private static string Hex(byte[] bytes) => Convert.ToHexString(bytes).ToLowerInvariant();
+
+    /// <summary>Build a DynamicValue from the seed's language-neutral tagged form { t, v }. Float v is
+    /// the IEEE-754 f64 bit pattern (16 hex, big-endian) for exactness; bytes v is a hex string; int v
+    /// is a decimal string.</summary>
+    private static DynamicValue BuildValue(JsonElement el)
+    {
+        string tag = Str(el, "t");
+        switch (tag)
+        {
+            case "null":
+                return new DynamicValue.Null();
+            case "bool":
+                return new DynamicValue.Bool(el.GetProperty("v").GetBoolean());
+            case "int":
+                return new DynamicValue.Int(long.Parse(Str(el, "v"), CultureInfo.InvariantCulture));
+            case "float":
+                return new DynamicValue.Float(
+                    BitConverter.UInt64BitsToDouble(
+                        ulong.Parse(Str(el, "v"), NumberStyles.HexNumber, CultureInfo.InvariantCulture)));
+            case "str":
+                return new DynamicValue.String(Str(el, "v"));
+            case "bytes":
+                return new DynamicValue.Bytes(Convert.FromHexString(Str(el, "v")).ToImmutableArray());
+            case "arr":
+                return new DynamicValue.Array(
+                    el.GetProperty("v").EnumerateArray().Select(BuildValue).ToImmutableArray());
+            case "obj":
+                return new DynamicValue.Object(
+                    el.GetProperty("v").EnumerateArray()
+                        .Select(pair =>
+                        {
+                            JsonElement[] parts = pair.EnumerateArray().ToArray();
+                            if (parts.Length != 2)
+                            {
+                                throw new InvalidOperationException(
+                                    $"seed object pair must have exactly 2 elements [key, value], got {parts.Length}");
+                            }
+
+                            string key = parts[0].GetString()
+                                ?? throw new InvalidOperationException("object key is not a string");
+                            return new KeyValuePair<string, DynamicValue>(key, BuildValue(parts[1]));
+                        })
+                        .ToImmutableArray());
+            default:
+                throw new InvalidOperationException($"unsupported tag in CBOR seed: {tag}");
+        }
+    }
+
+    [Fact]
+    public void CSharpCborEncoderAgreesWithSeed()
+    {
+        string path = Path.Join(RepoRoot(), "src", "Core.TypeScript", "dynamic-value", "golden-vectors-cbor.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        JsonElement[] vectors = doc.RootElement.GetProperty("vectors").EnumerateArray().ToArray();
+        Assert.NotEmpty(vectors);
+
+        var failures = new List<string>();
+        foreach (JsonElement v in vectors)
+        {
+            string name = Str(v, "name");
+            DynamicValue value = BuildValue(v.GetProperty("value"));
+            string expected = Str(v, "cbor");
+            string actual = Hex(DynamicValues.ToCanonicalCbor(value));
+            if (!string.Equals(actual, expected, StringComparison.Ordinal))
+            {
+                failures.Add($"{name}: expected {expected} but got {actual}");
+            }
+        }
+
+        Assert.Empty(failures);
+    }
+
+    // Independent RFC 8949 Appendix A anchor (anti-circularity): these canonical bytes come straight
+    // from the RFC, not from our encoder or the seed. double.{Positive,Negative}Infinity / NaN / -0.0
+    // are not compile-time constants (or need sign care), so they are separate facts below.
+    [Theory]
+    [InlineData(0.0, "f90000")]
+    [InlineData(1.0, "f93c00")]
+    [InlineData(1.5, "f93e00")]
+    [InlineData(65504.0, "f97bff")]
+    [InlineData(100000.0, "fa47c35000")]
+    [InlineData(3.4028234663852886e38, "fa7f7fffff")]
+    [InlineData(1.0e300, "fb7e37e43c8800759c")]
+    [InlineData(5.960464477539063e-8, "f90001")]
+    [InlineData(0.00006103515625, "f90400")]
+    [InlineData(-4.0, "f9c400")]
+    [InlineData(-4.1, "fbc010666666666666")]
+    public void FloatMatchesRfc8949AppendixA(double value, string expectedHex) =>
+        Assert.Equal(expectedHex, Hex(DynamicValues.ToCanonicalCbor(new DynamicValue.Float(value))));
+
+    [Fact]
+    public void PositiveInfinityIsHalf() =>
+        Assert.Equal("f97c00", Hex(DynamicValues.ToCanonicalCbor(new DynamicValue.Float(double.PositiveInfinity))));
+
+    [Fact]
+    public void NegativeInfinityIsHalf() =>
+        Assert.Equal("f9fc00", Hex(DynamicValues.ToCanonicalCbor(new DynamicValue.Float(double.NegativeInfinity))));
+
+    [Fact]
+    public void NanCanonicalizesToQuietHalf() =>
+        Assert.Equal("f97e00", Hex(DynamicValues.ToCanonicalCbor(new DynamicValue.Float(double.NaN))));
+
+    [Fact]
+    public void NegativeZeroPreservesSign() =>
+        Assert.Equal("f98000", Hex(DynamicValues.ToCanonicalCbor(new DynamicValue.Float(-0.0))));
+}


### PR DESCRIPTION
Locks the two cases canonical JSON deferred — **Float** and **Bytes** — under canonical **CBOR (RFC 8949)**, per Aaron's direction. CBOR is the *total* canonical form for all 8 `DynamicValue` shapes (JSON was partial, 6/8).

## What
- **Seed**: `src/Core.TypeScript/dynamic-value/golden-vectors-cbor.json` — 42 vectors, all 8 shapes. `value.v` for float is the IEEE-754 f64 bit pattern (exact); int a decimal string; bytes a hex string. Generated by an **independent** tools-side encoder and **self-checked against RFC 8949 Appendix A** (anti-circularity).
- **C# oracle**: `DynamicValues.ToCanonicalCbor(DynamicValue) -> byte[]` (total — no `Result`/`EncodeError`, because CBOR has a canonical form for every shape).
- **Tests** (16 green): `FloatMatchesRfc8949AppendixA` re-anchors the float logic against the RFC directly; `CSharpCborEncoderAgreesWithSeed` replays all 42 vectors; Inf/-Inf/NaN/-0.0 facts.

## Float (RFC 8949 §4.2.2 shortest-float)
float16 if it round-trips exactly → else float32 → else float64. `NaN → 0xf97e00`; ±0 and ±Inf sign-preserved. Verified against Appendix A: `100000.0→fa47c35000`, `1e300→fb7e37e43c8800759c`, `-4.1→fbc010666666666666`, subnormal `f90001`, etc.

## Deliberate deviation from RFC §4.2.1
`Object` map keys stay in **insertion order, NOT bytewise-sorted** — `Object` is order-significant, so the §4.2.1 key-sort would be lossy / non-bijective (the same call v1 made for canonical JSON).

## Sequencing
First of the four CBOR oracles (one authors, others replay): **C# here; F#/Rust/TS replay the same seed next.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)