### PR TITLE
feat(DynamicValue): F# CBOR oracle replays the seed (Float + Bytes locked)

### DIFF
--- a/src/Core/DynamicValue.fs
+++ b/src/Core/DynamicValue.fs
@@ -417,6 +417,17 @@ module DynamicValue =
     /// `Object` is order-significant — the §4.2.1 key-sort would be lossy /
     /// non-bijective (the same call v1 made for canonical JSON). Integers and
     /// string/array/map lengths use preferred (shortest) serialization per §4.2.1.
+    ///
+    /// Domain: "total" is over the eight SHAPES (each has a canonical CBOR form,
+    /// unlike JSON which defers Float/Bytes), for valid-Unicode values. A `String`
+    /// (or object key) holding a LONE UTF-16 surrogate is malformed content,
+    /// reachable only via C#/F# interop: it is not a valid Unicode scalar sequence,
+    /// so it is unrepresentable in a CBOR text string (RFC 8949 §3.1 = UTF-8) AND
+    /// unrepresentable in the Rust oracle (Rust `String` is guaranteed valid UTF-8)
+    /// AND in the seed — i.e. outside the cross-language byte-lock domain. .NET's
+    /// `Encoding.UTF8.GetBytes` emits U+FFFD for it (encoder-defined). Unlike the
+    /// JSON encoder, CBOR text cannot `\u`-escape it back to bijectivity; that
+    /// asymmetry is inherent to CBOR's UTF-8 text requirement, not an encoder choice.
     let toCanonicalCbor (value: DynamicValue) : byte[] =
         let buf = System.Collections.Generic.List<byte>()
 

--- a/src/Core/DynamicValue.fs
+++ b/src/Core/DynamicValue.fs
@@ -401,3 +401,120 @@ module DynamicValue =
                     |> Result.bind (fun parts -> toCanonicalJson v |> Result.map (fun s -> (escapeJsonString k + ":" + s) :: parts)))
                 (Ok [])
             |> Result.map (fun parts -> "{" + String.concat "," (List.rev parts) + "}")
+
+    /// Canonical CBOR encoding (RFC 8949) — the TOTAL byte-lock target for all
+    /// eight shapes (the shared seed is
+    /// `src/Core.TypeScript/dynamic-value/golden-vectors-cbor.json`). Where
+    /// `toCanonicalJson` is a partial projection (6/8 shapes; Float/Bytes
+    /// deferred), CBOR is total: `Float` uses the RFC 8949 §4.2.2 shortest-float
+    /// rule (float16 if it round-trips exactly, else float32, else float64; NaN
+    /// canonicalizes to `0xf97e00`) and `Bytes` uses a native major-type-2 byte
+    /// string — so the result is `byte[]`, not `Result` (CBOR has a canonical form
+    /// for every shape).
+    ///
+    /// One deliberate deviation from RFC 8949 §4.2.1 deterministic encoding:
+    /// `Object` map keys stay in INSERTION order, NOT bytewise-sorted, because
+    /// `Object` is order-significant — the §4.2.1 key-sort would be lossy /
+    /// non-bijective (the same call v1 made for canonical JSON). Integers and
+    /// string/array/map lengths use preferred (shortest) serialization per §4.2.1.
+    let toCanonicalCbor (value: DynamicValue) : byte[] =
+        let buf = System.Collections.Generic.List<byte>()
+
+        // CBOR initial byte (major type in the top 3 bits) + preferred/shortest argument.
+        let writeHead (major: int) (arg: uint64) =
+            let mt = byte (major <<< 5)
+
+            if arg <= 23UL then
+                buf.Add(mt ||| byte arg)
+            elif arg <= 0xffUL then
+                buf.Add(mt ||| 24uy)
+                buf.Add(byte arg)
+            elif arg <= 0xffffUL then
+                buf.Add(mt ||| 25uy)
+                buf.Add(byte (arg >>> 8))
+                buf.Add(byte arg)
+            elif arg <= 0xffffffffUL then
+                buf.Add(mt ||| 26uy)
+                buf.Add(byte (arg >>> 24))
+                buf.Add(byte (arg >>> 16))
+                buf.Add(byte (arg >>> 8))
+                buf.Add(byte arg)
+            else
+                buf.Add(mt ||| 27uy)
+
+                for shift in [ 56; 48; 40; 32; 24; 16; 8; 0 ] do
+                    buf.Add(byte (arg >>> shift))
+
+        // Major 0 for v >= 0; major 1 for v < 0 (which encodes -1 - v). `~~~v` yields
+        // -1 - v without the Int64.MinValue overflow that `-1L - v` / `-v` would hit.
+        let writeInt (v: int64) =
+            if v >= 0L then writeHead 0 (uint64 v) else writeHead 1 (uint64 (~~~v))
+
+        // Major 3 text string: raw UTF-8, no escaping. A lone surrogate is not a valid Unicode
+        // scalar; .NET UTF-8 encodes it as U+FFFD (encoder-defined) — the seed's strings are valid.
+        let writeText (s: string) =
+            let utf8 =
+                System.Text.Encoding.UTF8.GetBytes(if System.Object.ReferenceEquals(s, null) then "" else s)
+
+            writeHead 3 (uint64 utf8.Length)
+            buf.AddRange(utf8)
+
+        // RFC 8949 §4.2.2 shortest float: NaN -> 0xf97e00; else the shortest of float16 / float32 /
+        // float64 that decodes back to the exact same value (±0 and ±Inf round-trip through float16).
+        // `float f32 = v` also rejects a width that overflowed to Inf (e.g. 1e300 as float32),
+        // correctly falling through to the wider form.
+        let writeFloat (v: float) =
+            if System.Double.IsNaN v then
+                buf.Add 0xf9uy
+                buf.Add 0x7euy
+                buf.Add 0x00uy
+            else
+                let f32 = float32 v
+
+                if float f32 = v then
+                    let h: System.Half = System.Half.op_Explicit f32
+
+                    if (System.Half.op_Explicit h: float32) = f32 then
+                        let bits16 = System.BitConverter.HalfToUInt16Bits h
+                        buf.Add 0xf9uy
+                        buf.Add(byte (bits16 >>> 8))
+                        buf.Add(byte bits16)
+                    else
+                        let bits32 = System.BitConverter.SingleToUInt32Bits f32
+                        buf.Add 0xfauy
+                        buf.Add(byte (bits32 >>> 24))
+                        buf.Add(byte (bits32 >>> 16))
+                        buf.Add(byte (bits32 >>> 8))
+                        buf.Add(byte bits32)
+                else
+                    let bits64 = System.BitConverter.DoubleToUInt64Bits v
+                    buf.Add 0xfbuy
+
+                    for shift in [ 56; 48; 40; 32; 24; 16; 8; 0 ] do
+                        buf.Add(byte (bits64 >>> shift))
+
+        let rec write (v: DynamicValue) =
+            match v with
+            | DynamicValue.Null -> buf.Add 0xf6uy
+            | DynamicValue.Bool b -> buf.Add(if b then 0xf5uy else 0xf4uy)
+            | DynamicValue.Int i -> writeInt i
+            | DynamicValue.Float f -> writeFloat f
+            | DynamicValue.String s -> writeText s
+            | DynamicValue.Bytes bytes ->
+                let b = if bytes.IsDefault then ImmutableArray<byte>.Empty else bytes
+                writeHead 2 (uint64 b.Length)
+                buf.AddRange(b)
+            | DynamicValue.Array items ->
+                writeHead 4 (uint64 (List.length items))
+
+                for item in items do
+                    write item
+            | DynamicValue.Object pairs ->
+                writeHead 5 (uint64 (List.length pairs))
+
+                for (k, value) in pairs do
+                    writeText k
+                    write value
+
+        write value
+        buf.ToArray()

--- a/tests/Tests.FSharp/DynamicValue.CborGoldenVectors.Tests.fs
+++ b/tests/Tests.FSharp/DynamicValue.CborGoldenVectors.Tests.fs
@@ -1,0 +1,116 @@
+module Zeta.Tests.DynamicValueCborGoldenVectorsTests
+
+open System.IO
+open System.Reflection
+open System.Globalization
+open System.Collections.Immutable
+open System.Text.Json
+open global.Xunit
+open Zeta.Core
+
+// DynamicValue canonical-CBOR byte-lock — the F# oracle agrees on the shared seed
+// (src/Core.TypeScript/dynamic-value/golden-vectors-cbor.json). CBOR is the TOTAL
+// form (all 8 shapes), so this is where Float (RFC 8949 §4.2.2 shortest-float) and
+// Bytes (major-type-2) lock — the two cases canonical JSON deferred. The seed was
+// generated + RFC-8949-Appendix-A-anchored independently; `float matches RFC 8949
+// Appendix A` re-anchors the float logic against the RFC directly so the lock is
+// not circular, then the seed-replay proves agreement. "The compilers don't lie."
+
+/// Walk up from the test assembly to the repo root (Zeta.sln sentinel).
+let private repoRoot () : string =
+    let mutable dir = DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))
+
+    while not (isNull dir) && not (File.Exists(Path.Join(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+
+    if isNull dir then
+        failwith "Could not locate repo root (Zeta.sln) from test assembly location."
+
+    dir.FullName
+
+// Eager array of a JsonElement's children via a direct enumerator loop, NOT a lazy
+// Seq pipeline: JsonElement.ArrayEnumerator is a mutable struct and boxing it
+// through Seq corrupts its state in compiled F# (works in fsi, fails in Release)
+// — see tests/Tests.FSharp/Observe/GoldenVectors.Tests.fs.
+let private children (el: JsonElement) : JsonElement[] =
+    [| for child in el.EnumerateArray() -> child |]
+
+let private hex (bytes: byte[]) : string =
+    System.Convert.ToHexString(bytes).ToLowerInvariant()
+
+/// Build a DynamicValue from the seed's language-neutral tagged form `{ t, v }`.
+/// Float v is the IEEE-754 f64 bit pattern (16 hex, big-endian) for exactness;
+/// bytes v is a hex string; int v is a decimal string.
+let rec private buildValue (el: JsonElement) : DynamicValue =
+    match el.GetProperty("t").GetString() with
+    | "null" -> DynamicValue.Null
+    | "bool" -> DynamicValue.Bool(el.GetProperty("v").GetBoolean())
+    | "int" -> DynamicValue.Int(System.Int64.Parse(el.GetProperty("v").GetString(), CultureInfo.InvariantCulture))
+    | "float" ->
+        DynamicValue.Float(
+            System.BitConverter.UInt64BitsToDouble(
+                System.UInt64.Parse(el.GetProperty("v").GetString(), NumberStyles.HexNumber, CultureInfo.InvariantCulture)))
+    | "str" -> DynamicValue.String(el.GetProperty("v").GetString())
+    | "bytes" -> DynamicValue.Bytes(ImmutableArray.Create<byte>(System.Convert.FromHexString(el.GetProperty("v").GetString())))
+    | "arr" -> DynamicValue.Array(children (el.GetProperty "v") |> Array.map buildValue |> Array.toList)
+    | "obj" ->
+        DynamicValue.Object(
+            children (el.GetProperty "v")
+            |> Array.map (fun pair ->
+                let parts = children pair
+
+                if parts.Length <> 2 then
+                    failwithf "seed object pair must have exactly 2 elements [key, value], got %d" parts.Length
+
+                (parts.[0].GetString(), buildValue parts.[1]))
+            |> Array.toList)
+    | other -> failwithf "unsupported tag in CBOR seed: %s" other
+
+[<Fact>]
+let ``F# CBOR encoder agrees with seed`` () =
+    let path =
+        Path.Join(repoRoot (), "src", "Core.TypeScript", "dynamic-value", "golden-vectors-cbor.json")
+
+    use doc = JsonDocument.Parse(File.ReadAllText path)
+    let vectors = children (doc.RootElement.GetProperty "vectors")
+    Assert.NotEmpty vectors
+
+    let failures =
+        vectors
+        |> Array.choose (fun v ->
+            let name = v.GetProperty("name").GetString()
+            let value = buildValue (v.GetProperty "value")
+            let expected = v.GetProperty("cbor").GetString()
+            let actual = hex (DynamicValue.toCanonicalCbor value)
+
+            if actual = expected then
+                None
+            else
+                Some(sprintf "%s: expected %s but got %s" name expected actual))
+
+    Assert.True(Array.isEmpty failures, System.String.Join("\n", failures))
+
+// Independent RFC 8949 Appendix A anchor (anti-circularity): these canonical bytes
+// come straight from the RFC, not from our encoder or the seed. ±Inf / NaN / -0.0
+// are not finite literals (or need sign care), so they are a separate fact below.
+[<Theory>]
+[<InlineData(0.0, "f90000")>]
+[<InlineData(1.0, "f93c00")>]
+[<InlineData(1.5, "f93e00")>]
+[<InlineData(65504.0, "f97bff")>]
+[<InlineData(100000.0, "fa47c35000")>]
+[<InlineData(3.4028234663852886e38, "fa7f7fffff")>]
+[<InlineData(1.0e300, "fb7e37e43c8800759c")>]
+[<InlineData(5.960464477539063e-8, "f90001")>]
+[<InlineData(0.00006103515625, "f90400")>]
+[<InlineData(-4.0, "f9c400")>]
+[<InlineData(-4.1, "fbc010666666666666")>]
+let ``float matches RFC 8949 Appendix A`` (value: float) (expected: string) =
+    Assert.Equal(expected, hex (DynamicValue.toCanonicalCbor (DynamicValue.Float value)))
+
+[<Fact>]
+let ``infinities, NaN, and negative zero canonicalize`` () =
+    Assert.Equal("f97c00", hex (DynamicValue.toCanonicalCbor (DynamicValue.Float System.Double.PositiveInfinity)))
+    Assert.Equal("f9fc00", hex (DynamicValue.toCanonicalCbor (DynamicValue.Float System.Double.NegativeInfinity)))
+    Assert.Equal("f97e00", hex (DynamicValue.toCanonicalCbor (DynamicValue.Float System.Double.NaN)))
+    Assert.Equal("f98000", hex (DynamicValue.toCanonicalCbor (DynamicValue.Float -0.0)))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -40,6 +40,7 @@
     <Compile Include="RangeSet.Tests.fs" />
     <Compile Include="DynamicValue.Tests.fs" />
     <Compile Include="DynamicValue.GoldenVectors.Tests.fs" />
+    <Compile Include="DynamicValue.CborGoldenVectors.Tests.fs" />
     <Compile Include="Observe/GoldenVectors.Tests.fs" />
     <Compile Include="Observe/EventLog.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />


### PR DESCRIPTION
Second of the four CBOR oracles (one authors, others replay) — the **F# oracle** agrees on the canonical-CBOR seed (`golden-vectors-cbor.json`, landed in #6506). Float + Bytes now locked in F# too.

## What
- `DynamicValue.toCanonicalCbor : DynamicValue -> byte[]` — **total** (no `Result`/`EncodeError`): CBOR has a canonical form for every shape, where canonical JSON deferred Float + Bytes.
- **Float**: RFC 8949 §4.2.2 shortest-float via `System.Half` (float16 if it round-trips exactly → float32 → float64; `NaN → 0xf97e00`; ±0/±Inf sign-preserved).
- **Bytes**: native major-type-2 byte string.
- **Object** map keys stay in **insertion order**, NOT §4.2.1 bytewise-sorted (order-significant — same call v1 made for JSON).

## Tests (13 green)
`float matches RFC 8949 Appendix A` re-anchors the float logic against the RFC directly (anti-circular) + the 42-vector seed replay + Inf/-Inf/NaN/-0.0.

## Sequencing
C# (#6506) ✅ → **F# here** → Rust replay → TS replay → registry flips to "Float/Bytes locked under CBOR".

🤖 Generated with [Claude Code](https://claude.com/claude-code)