### PR TITLE
feat(DynamicValue): Rust CBOR oracle replays the seed (Float + Bytes locked)

### DIFF
--- a/src/Core.Rust.DynamicValue/src/lib.rs
+++ b/src/Core.Rust.DynamicValue/src/lib.rs
@@ -130,6 +130,71 @@ impl DynamicValue {
 
         Ok(())
     }
+
+    /// Canonical CBOR encoding (RFC 8949) -- the TOTAL byte-lock target for all
+    /// eight shapes (the shared seed is
+    /// `src/Core.TypeScript/dynamic-value/golden-vectors-cbor.json`). Where
+    /// [`to_canonical_json`](DynamicValue::to_canonical_json) is a partial
+    /// projection (6/8 shapes; Float/Bytes deferred), CBOR is total: `Float` uses
+    /// the RFC 8949 §4.2.2 shortest-float rule (float16 if it round-trips exactly,
+    /// else float32, else float64; NaN canonicalizes to `0xf97e00`) and `Bytes`
+    /// uses a native major-type-2 byte string -- so the result is `Vec<u8>`, not
+    /// `Result` (CBOR has a canonical form for every shape). Mirrors the C#/F#
+    /// `toCanonicalCbor`.
+    ///
+    /// One deliberate deviation from RFC 8949 §4.2.1 deterministic encoding:
+    /// `Object` map keys stay in INSERTION order, NOT bytewise-sorted, because
+    /// `Object` is order-significant -- the §4.2.1 key-sort would be lossy /
+    /// non-bijective (the same call v1 made for canonical JSON). Integers and
+    /// string/array/map lengths use preferred (shortest) serialization per §4.2.1.
+    #[must_use]
+    pub fn to_canonical_cbor(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.write_cbor(&mut out);
+        out
+    }
+
+    fn write_cbor(&self, out: &mut Vec<u8>) {
+        match self {
+            DynamicValue::Null => out.push(0xf6),
+            DynamicValue::Bool(b) => out.push(if *b { 0xf5 } else { 0xf4 }),
+            DynamicValue::Int(i) => {
+                // major 0 for >= 0; major 1 for < 0 (encodes -1 - n). `(!i) as u64`
+                // (bitwise NOT) yields -1 - i without the i64::MIN overflow of `-1 - i`.
+                if *i >= 0 {
+                    cbor_head(out, 0, *i as u64);
+                } else {
+                    cbor_head(out, 1, (!*i) as u64);
+                }
+            }
+            DynamicValue::Float(f) => cbor_float(out, *f),
+            DynamicValue::String(s) => {
+                // CBOR text string: raw UTF-8, no escaping (unlike JSON).
+                let bytes = s.as_bytes();
+                cbor_head(out, 3, bytes.len() as u64);
+                out.extend_from_slice(bytes);
+            }
+            DynamicValue::Bytes(b) => {
+                cbor_head(out, 2, b.len() as u64);
+                out.extend_from_slice(b);
+            }
+            DynamicValue::Array(items) => {
+                cbor_head(out, 4, items.len() as u64);
+                for item in items {
+                    item.write_cbor(out);
+                }
+            }
+            DynamicValue::Object(pairs) => {
+                cbor_head(out, 5, pairs.len() as u64);
+                for (key, val) in pairs {
+                    let kb = key.as_bytes();
+                    cbor_head(out, 3, kb.len() as u64);
+                    out.extend_from_slice(kb);
+                    val.write_cbor(out);
+                }
+            }
+        }
+    }
 }
 
 /// Why a [`DynamicValue`] could not be canonically encoded (v1). `Float` and
@@ -189,6 +254,141 @@ fn escape_json_string(s: &str, out: &mut String) {
     out.push('"');
 }
 
+// CBOR initial byte (major type in the top 3 bits) + preferred/shortest argument
+// (RFC 8949 §3, §4.2.1).
+fn cbor_head(out: &mut Vec<u8>, major: u8, arg: u64) {
+    let mt = major << 5;
+    if arg <= 23 {
+        out.push(mt | arg as u8);
+    } else if arg <= 0xff {
+        out.push(mt | 24);
+        out.push(arg as u8);
+    } else if arg <= 0xffff {
+        out.push(mt | 25);
+        out.extend_from_slice(&(arg as u16).to_be_bytes());
+    } else if arg <= 0xffff_ffff {
+        out.push(mt | 26);
+        out.extend_from_slice(&(arg as u32).to_be_bytes());
+    } else {
+        out.push(mt | 27);
+        out.extend_from_slice(&arg.to_be_bytes());
+    }
+}
+
+// RFC 8949 §4.2.2 shortest float: NaN -> 0xf97e00; else the shortest of
+// float16 / float32 / float64 that decodes back to the exact same value (±0 and
+// ±Inf round-trip through float16). float16 is hand-rolled (no stable `f16` in
+// Rust, and the core is zero-dep) and gated on an EXACT round-trip, so it is only
+// ever emitted for genuinely f16-exact values. `f32v as f64 == v` also rejects a
+// width that overflowed to Inf (e.g. 1e300 as float32), falling through correctly.
+fn cbor_float(out: &mut Vec<u8>, v: f64) {
+    if v.is_nan() {
+        out.extend_from_slice(&[0xf9, 0x7e, 0x00]);
+        return;
+    }
+    let f32v = v as f32;
+    if f32v as f64 == v {
+        if let Some(bits16) = f16_bits_if_exact(f32v) {
+            out.push(0xf9);
+            out.extend_from_slice(&bits16.to_be_bytes());
+            return;
+        }
+        out.push(0xfa);
+        out.extend_from_slice(&f32v.to_bits().to_be_bytes());
+        return;
+    }
+    out.push(0xfb);
+    out.extend_from_slice(&v.to_bits().to_be_bytes());
+}
+
+// Some(bits) iff `value` is EXACTLY representable in float16 (the round-trip is
+// bit-identical, including sign of zero); None otherwise. The exact gate means a
+// rounding imperfection can never emit a non-canonical f16 -- non-exact values are
+// always rejected here and fall through to float32.
+fn f16_bits_if_exact(value: f32) -> Option<u16> {
+    let bits = f32_to_f16_round(value);
+    if f16_to_f32(bits).to_bits() == value.to_bits() {
+        Some(bits)
+    } else {
+        None
+    }
+}
+
+// f32 -> float16 bits, round-to-nearest-even. Only the exact path (no rounding)
+// affects canonical output, since non-exact results are rejected by the round-trip
+// gate in `f16_bits_if_exact`.
+fn f32_to_f16_round(value: f32) -> u16 {
+    let x = value.to_bits();
+    let sign = ((x >> 16) & 0x8000) as u16;
+    let exp_field = ((x >> 23) & 0xff) as i32;
+    let mant = x & 0x007f_ffff;
+
+    if exp_field == 0xff {
+        // Inf (mant 0) or NaN (mant != 0; NaN is handled before this in cbor_float).
+        return if mant != 0 {
+            sign | 0x7e00
+        } else {
+            sign | 0x7c00
+        };
+    }
+
+    let exp = exp_field - 127 + 15; // rebias to float16
+    if exp >= 0x1f {
+        return sign | 0x7c00; // overflow -> Inf
+    }
+    if exp <= 0 {
+        if exp < -10 {
+            return sign; // underflow -> ±0
+        }
+        let m = mant | 0x0080_0000; // 24-bit significand with the implicit leading 1
+        let result = round_shift(m, (14 - exp) as u32);
+        return sign | result as u16;
+    }
+
+    // normal
+    let m10 = round_shift(mant, 13);
+    if m10 == 0x400 {
+        // mantissa rounding carried into the exponent
+        let e = exp + 1;
+        if e >= 0x1f {
+            return sign | 0x7c00;
+        }
+        return sign | ((e as u16) << 10);
+    }
+    sign | ((exp as u16) << 10) | m10 as u16
+}
+
+// Right shift with round-to-nearest-even.
+fn round_shift(value: u32, shift: u32) -> u32 {
+    if shift == 0 {
+        return value;
+    }
+    let result = value >> shift;
+    let round_bit = 1u32 << (shift - 1);
+    let rem = value & ((1u32 << shift) - 1);
+    if rem > round_bit || (rem == round_bit && (result & 1) == 1) {
+        result + 1
+    } else {
+        result
+    }
+}
+
+// float16 bits -> f32, exact (every float16 value is exactly representable in f32;
+// no rounding occurs).
+fn f16_to_f32(bits: u16) -> f32 {
+    let sign = if bits & 0x8000 != 0 { -1.0f32 } else { 1.0f32 };
+    let exp = ((bits >> 10) & 0x1f) as i32;
+    let mant = (bits & 0x3ff) as f32;
+    let val = if exp == 0 {
+        mant * 2.0f32.powi(-24) // subnormal: mant * 2^-24
+    } else if exp == 0x1f {
+        if mant == 0.0 { f32::INFINITY } else { f32::NAN }
+    } else {
+        (1.0 + mant / 1024.0) * 2.0f32.powi(exp - 15) // normal
+    };
+    sign * val
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -219,5 +419,44 @@ mod tests {
     fn encode_error_display_is_human_readable() {
         assert!(EncodeError::FloatDeferred.to_string().contains("Float"));
         assert!(EncodeError::BytesDeferred.to_string().contains("Bytes"));
+    }
+
+    fn float_hex(v: f64) -> String {
+        DynamicValue::Float(v)
+            .to_canonical_cbor()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect()
+    }
+
+    // Independent RFC 8949 Appendix A anchor (anti-circularity): these canonical
+    // bytes come straight from the RFC, not from our encoder or the seed.
+    #[test]
+    fn cbor_float_matches_rfc_8949_appendix_a() {
+        assert_eq!(float_hex(0.0), "f90000");
+        assert_eq!(float_hex(1.0), "f93c00");
+        assert_eq!(float_hex(1.5), "f93e00");
+        assert_eq!(float_hex(65504.0), "f97bff");
+        assert_eq!(float_hex(100000.0), "fa47c35000");
+        assert_eq!(float_hex(3.4028234663852886e38), "fa7f7fffff");
+        assert_eq!(float_hex(1.0e300), "fb7e37e43c8800759c");
+        assert_eq!(float_hex(5.960464477539063e-8), "f90001");
+        assert_eq!(float_hex(0.00006103515625), "f90400");
+        assert_eq!(float_hex(-4.0), "f9c400");
+        assert_eq!(float_hex(-4.1), "fbc010666666666666");
+        assert_eq!(float_hex(f64::INFINITY), "f97c00");
+        assert_eq!(float_hex(f64::NEG_INFINITY), "f9fc00");
+        assert_eq!(float_hex(f64::NAN), "f97e00");
+        assert_eq!(float_hex(-0.0), "f98000");
+    }
+
+    // Shortest-float tier selection (robust, no hard-coded f64 bit patterns): the
+    // encoder picks the narrowest exact width.
+    #[test]
+    fn cbor_shortest_float_tier_selection() {
+        assert!(float_hex(1.5).starts_with("f9")); // float16 (exact)
+        assert!(float_hex(100000.0).starts_with("fa")); // float32 (float16 overflow)
+        assert!(float_hex(1.1).starts_with("fb")); // float64 (not float32-exact)
+        assert!(float_hex(1.0e300).starts_with("fb")); // float64 (float32 overflow)
     }
 }

--- a/src/Core.Rust.DynamicValue/tests/cbor_cross_verify.rs
+++ b/src/Core.Rust.DynamicValue/tests/cbor_cross_verify.rs
@@ -1,0 +1,119 @@
+//! DynamicValue canonical-CBOR byte-lock -- the Rust oracle replays the shared
+//! seed (`src/Core.TypeScript/dynamic-value/golden-vectors-cbor.json`). CBOR is the
+//! TOTAL form (all 8 shapes), so this is where Float (RFC 8949 §4.2.2
+//! shortest-float) and Bytes (major-type-2) lock -- the two cases canonical JSON
+//! deferred. Passing == agreeing with the C#/F#/seed oracles on the bytes. The seed
+//! was generated + RFC-8949-Appendix-A-anchored independently; the in-crate unit
+//! tests (`cbor_float_matches_rfc_8949_appendix_a`) re-anchor the float logic
+//! against the RFC directly, so this lock is not circular. "The compilers don't lie."
+//!
+//! Dev-only `serde_json` reads the seed; the production crate has zero dependencies.
+
+use std::path::PathBuf;
+
+use serde_json::Value;
+use zeta_core_dynamic_value::DynamicValue;
+
+/// Walk up from the crate dir to the repo root (`Zeta.sln` sentinel).
+fn repo_root() -> PathBuf {
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        if dir.join("Zeta.sln").exists() {
+            return dir;
+        }
+        assert!(dir.pop(), "could not locate repo root (Zeta.sln)");
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+fn decode_hex(s: &str) -> Vec<u8> {
+    assert!(
+        s.len().is_multiple_of(2),
+        "byte hex must have even length: {s}"
+    );
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).expect("hex byte"))
+        .collect()
+}
+
+/// Build a `DynamicValue` from the seed's language-neutral tagged form `{ t, v }`.
+/// Float v is the IEEE-754 f64 bit pattern (16 hex, big-endian) for exactness;
+/// bytes v is a hex string; int v is a decimal string.
+fn build_value(v: &Value) -> DynamicValue {
+    match v["t"].as_str().expect("tag string") {
+        "null" => DynamicValue::Null,
+        "bool" => DynamicValue::Bool(v["v"].as_bool().expect("bool value")),
+        "int" => DynamicValue::Int(
+            v["v"]
+                .as_str()
+                .expect("int decimal string")
+                .parse::<i64>()
+                .expect("i64 parse"),
+        ),
+        "float" => DynamicValue::Float(f64::from_bits(
+            u64::from_str_radix(v["v"].as_str().expect("float bits hex"), 16)
+                .expect("u64 hex parse"),
+        )),
+        "str" => DynamicValue::String(v["v"].as_str().expect("str value").to_string()),
+        "bytes" => DynamicValue::Bytes(decode_hex(v["v"].as_str().expect("bytes hex"))),
+        "arr" => DynamicValue::Array(
+            v["v"]
+                .as_array()
+                .expect("arr value")
+                .iter()
+                .map(build_value)
+                .collect(),
+        ),
+        "obj" => DynamicValue::Object(
+            v["v"]
+                .as_array()
+                .expect("obj value")
+                .iter()
+                .map(|pair| {
+                    let p = pair.as_array().expect("pair array");
+                    assert_eq!(p.len(), 2, "object pair must be [key, value]");
+                    (
+                        p[0].as_str().expect("key string").to_string(),
+                        build_value(&p[1]),
+                    )
+                })
+                .collect(),
+        ),
+        other => panic!("unsupported tag in CBOR seed: {other}"),
+    }
+}
+
+#[test]
+fn cbor_cross_verify_matches_golden_vectors() {
+    let path = repo_root().join("src/Core.TypeScript/dynamic-value/golden-vectors-cbor.json");
+    let text = std::fs::read_to_string(&path).expect("read dynamic-value golden-vectors-cbor.json");
+    let v: Value = serde_json::from_str(&text).expect("parse golden-vectors-cbor.json");
+
+    let vectors = v["vectors"].as_array().expect("vectors array");
+    assert!(!vectors.is_empty(), "seed must have vectors");
+
+    let mut failures: Vec<String> = Vec::new();
+    for vec in vectors {
+        let name = vec["name"].as_str().expect("name string");
+        let value = build_value(&vec["value"]);
+        let expected = vec["cbor"].as_str().expect("cbor string");
+        let actual = hex(&value.to_canonical_cbor());
+        if actual != expected {
+            failures.push(format!("{name}: expected {expected} but got {actual}"));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "byte-lock mismatches:\n{}",
+        failures.join("\n")
+    );
+}


### PR DESCRIPTION
Third of the four CBOR oracles (one authors, others replay) — the **Rust oracle** agrees on the canonical-CBOR seed (`golden-vectors-cbor.json`). Float + Bytes locked in Rust too.

## What
- `DynamicValue::to_canonical_cbor(&self) -> Vec<u8>` — **total** (no `Result`): CBOR has a canonical form for every shape.
- **Float**: RFC 8949 §4.2.2 shortest-float. Rust has no stable `f16` and the core is **zero-dep** (no `half` crate), so f64→f16 is hand-rolled and **gated on an exact round-trip** (`f16_to_f32(bits).to_bits() == f32.to_bits()`) — f16 is emitted *only* for genuinely f16-exact values, so a rounding imperfection can never produce non-canonical output (non-exact → float32). `NaN → 0xf97e00`; ±0/±Inf sign-preserved.
- **Bytes**: native major-type-2 byte string.
- **Object** map keys stay in **insertion order**, NOT §4.2.1 bytewise-sorted.

## Tests (cargo-verified; Rust is not in the CI matrix)
`cbor_float_matches_rfc_8949_appendix_a` re-anchors against the RFC directly (anti-circular) + shortest-float tier-selection + the 42-vector seed replay. `cargo test` / `clippy` / `fmt` all green.

## Sequencing
C# (#6506) ✅ → F# (#6508, in flight) → **Rust here** → TS replay → registry flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)