### PR TITLE
feat(DynamicValue): C# CBOR DECODE oracle (FromCanonicalCbor) — completes the bijection

### DIFF
--- a/src/Core.CSharp.DynamicValue/DecodeError.cs
+++ b/src/Core.CSharp.DynamicValue/DecodeError.cs
@@ -22,4 +22,10 @@ public enum DecodeError
 
     /// <summary>An object (map) key was not a text string (<see cref="DynamicValue.Object"/> keys are strings).</summary>
     NonTextKey,
+
+    /// <summary>Well-formed CBOR that is NOT the canonical form this codec emits — e.g. a non-shortest
+    /// integer/length width (<c>18 00</c> vs <c>00</c>), a non-shortest float / non-canonical NaN, or
+    /// invalid UTF-8 silently repaired to U+FFFD. Detected by the fixed-point check
+    /// <c>ToCanonicalCbor(decoded) == input</c>; canonical bytes are exactly those fixed points.</summary>
+    NonCanonical,
 }

--- a/src/Core.CSharp.DynamicValue/DecodeError.cs
+++ b/src/Core.CSharp.DynamicValue/DecodeError.cs
@@ -1,0 +1,25 @@
+namespace Zeta.Core.CSharp;
+
+/// <summary>
+/// Why canonical CBOR bytes could not be decoded into a <see cref="DynamicValue"/>. Surfaced as data
+/// via <see cref="Result{T, TError}"/> per the Result-over-exception hard rule (AGENTS.md), never
+/// thrown. Mirrors the F#/Rust <c>DecodeError</c>.
+/// </summary>
+public enum DecodeError
+{
+    /// <summary>Input ended mid-item (a head or payload was truncated).</summary>
+    UnexpectedEnd,
+
+    /// <summary>Extra bytes remained after a complete top-level value.</summary>
+    TrailingData,
+
+    /// <summary>An additional-info or major-7 simple value this canonical decoder does not accept
+    /// (reserved 28–30, indefinite-length 31, CBOR tags (major 6), or an unsupported simple value).</summary>
+    Unsupported,
+
+    /// <summary>A CBOR integer does not fit <see cref="long"/> (<see cref="DynamicValue.Int"/> is int64).</summary>
+    IntegerOverflow,
+
+    /// <summary>An object (map) key was not a text string (<see cref="DynamicValue.Object"/> keys are strings).</summary>
+    NonTextKey,
+}

--- a/src/Core.CSharp.DynamicValue/DynamicValues.cs
+++ b/src/Core.CSharp.DynamicValue/DynamicValues.cs
@@ -547,6 +547,16 @@ public static class DynamicValues
             return new Result<DynamicValue, DecodeError>.Err(DecodeError.TrailingData);
         }
 
+        // Canonical-form fixed-point check: the canonical bytes are exactly those `b` with
+        // ToCanonicalCbor(decode(b)) == b. This rejects well-formed-but-non-canonical input —
+        // non-shortest int/length widths (18 00 vs 00), non-shortest floats / non-canonical NaN,
+        // and invalid UTF-8 silently repaired to U+FFFD (which re-encodes to different bytes) — in
+        // one uniform check, instead of scattering per-form strictness through the reader.
+        if (!ToCanonicalCbor(value).AsSpan().SequenceEqual(bytes))
+        {
+            return new Result<DynamicValue, DecodeError>.Err(DecodeError.NonCanonical);
+        }
+
         return new Result<DynamicValue, DecodeError>.Ok(value);
     }
 

--- a/src/Core.CSharp.DynamicValue/DynamicValues.cs
+++ b/src/Core.CSharp.DynamicValue/DynamicValues.cs
@@ -520,4 +520,281 @@ public static class DynamicValues
             buf.Add((byte)(bits64 >> shift));
         }
     }
+
+    /// <summary>Decode canonical CBOR (RFC 8949) bytes back into a <see cref="DynamicValue"/> — the
+    /// inverse of <see cref="ToCanonicalCbor"/>, completing the byte↔value bijection for all eight
+    /// shapes. Decode is partial (truncation, reserved/indefinite forms, CBOR tags, oversized
+    /// integers, non-text map keys), so it returns <see cref="Result{T, TError}"/> per the
+    /// Result-over-exception hard rule (AGENTS.md) — never throws for malformed input.
+    /// <para>Round-trip is the byte-lock: <c>ToCanonicalCbor(FromCanonicalCbor(b)) == b</c> for every
+    /// canonical <c>b</c> in the shared seed. float16 payloads decode via <see cref="Half"/>.</para>
+    /// </summary>
+    /// <param name="bytes">canonical CBOR bytes.</param>
+    /// <returns><see cref="Result{T, TError}.Ok"/> with the decoded value, or
+    /// <see cref="Result{T, TError}.Err"/> carrying the <see cref="DecodeError"/>.</returns>
+    public static Result<DynamicValue, DecodeError> FromCanonicalCbor(byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+        int pos = 0;
+        DecodeError? err = TryReadCbor(bytes, ref pos, out DynamicValue value);
+        if (err is DecodeError e)
+        {
+            return new Result<DynamicValue, DecodeError>.Err(e);
+        }
+
+        if (pos != bytes.Length)
+        {
+            return new Result<DynamicValue, DecodeError>.Err(DecodeError.TrailingData);
+        }
+
+        return new Result<DynamicValue, DecodeError>.Ok(value);
+    }
+
+    // Reads one CBOR item starting at `pos`, advancing it. Returns null on success (value set), or
+    // the DecodeError on failure.
+    private static DecodeError? TryReadCbor(byte[] b, ref int pos, out DynamicValue value)
+    {
+        value = new DynamicValue.Null();
+        if (pos >= b.Length)
+        {
+            return DecodeError.UnexpectedEnd;
+        }
+
+        byte initial = b[pos++];
+        int major = initial >> 5;
+        int ai = initial & 0x1f;
+
+        // Major 7: simple values (false/true/null) + IEEE floats.
+        if (major == 7)
+        {
+            return TryReadSimpleOrFloat(b, ref pos, ai, out value);
+        }
+
+        DecodeError? argErr = TryReadCborArg(b, ref pos, ai, out ulong arg);
+        if (argErr is DecodeError ae)
+        {
+            return ae;
+        }
+
+        switch (major)
+        {
+            case 0: // unsigned integer
+                if (arg > long.MaxValue)
+                {
+                    return DecodeError.IntegerOverflow;
+                }
+
+                value = new DynamicValue.Int((long)arg);
+                return null;
+            case 1: // negative integer = -1 - arg
+                if (arg > long.MaxValue)
+                {
+                    return DecodeError.IntegerOverflow;
+                }
+
+                value = new DynamicValue.Int(-1L - (long)arg);
+                return null;
+            case 2:
+                return TryReadByteString(b, ref pos, arg, out value);
+            case 3:
+                return TryReadTextString(b, ref pos, arg, out value);
+            case 4:
+                return TryReadArray(b, ref pos, arg, out value);
+            case 5:
+                return TryReadMap(b, ref pos, arg, out value);
+            default:
+                return DecodeError.Unsupported; // major 6 = tags, not used by our canonical form
+        }
+    }
+
+    // Major 7: simple values (false/true/null) + IEEE floats (float16/32/64). NaN/Inf/±0 ride the
+    // float payloads; float16 decodes via System.Half.
+    private static DecodeError? TryReadSimpleOrFloat(byte[] b, ref int pos, int ai, out DynamicValue value)
+    {
+        value = new DynamicValue.Null();
+        switch (ai)
+        {
+            case 20:
+                value = new DynamicValue.Bool(false);
+                return null;
+            case 21:
+                value = new DynamicValue.Bool(true);
+                return null;
+            case 22:
+                return null; // value already Null
+            case 25:
+            {
+                if (pos + 2 > b.Length)
+                {
+                    return DecodeError.UnexpectedEnd;
+                }
+
+                ushort bits16 = (ushort)((b[pos] << 8) | b[pos + 1]);
+                pos += 2;
+                value = new DynamicValue.Float((double)BitConverter.UInt16BitsToHalf(bits16));
+                return null;
+            }
+            case 26:
+            {
+                if (pos + 4 > b.Length)
+                {
+                    return DecodeError.UnexpectedEnd;
+                }
+
+                uint bits32 = ((uint)b[pos] << 24) | ((uint)b[pos + 1] << 16) | ((uint)b[pos + 2] << 8) | b[pos + 3];
+                pos += 4;
+                value = new DynamicValue.Float(BitConverter.UInt32BitsToSingle(bits32));
+                return null;
+            }
+            case 27:
+            {
+                if (pos + 8 > b.Length)
+                {
+                    return DecodeError.UnexpectedEnd;
+                }
+
+                ulong bits64 = 0;
+                for (int i = 0; i < 8; i++)
+                {
+                    bits64 = (bits64 << 8) | b[pos + i];
+                }
+
+                pos += 8;
+                value = new DynamicValue.Float(BitConverter.UInt64BitsToDouble(bits64));
+                return null;
+            }
+            default:
+                return DecodeError.Unsupported; // undefined / 1-byte simple value / reserved
+        }
+    }
+
+    private static DecodeError? TryReadByteString(byte[] b, ref int pos, ulong arg, out DynamicValue value)
+    {
+        value = new DynamicValue.Null();
+        if (arg > (ulong)(b.Length - pos))
+        {
+            return DecodeError.UnexpectedEnd;
+        }
+
+        int n = (int)arg;
+        var slice = new byte[n];
+        Array.Copy(b, pos, slice, 0, n);
+        pos += n;
+        value = new DynamicValue.Bytes(slice.ToImmutableArray());
+        return null;
+    }
+
+    private static DecodeError? TryReadTextString(byte[] b, ref int pos, ulong arg, out DynamicValue value)
+    {
+        value = new DynamicValue.Null();
+        if (arg > (ulong)(b.Length - pos))
+        {
+            return DecodeError.UnexpectedEnd;
+        }
+
+        int n = (int)arg;
+        value = new DynamicValue.String(Encoding.UTF8.GetString(b, pos, n));
+        pos += n;
+        return null;
+    }
+
+    private static DecodeError? TryReadArray(byte[] b, ref int pos, ulong arg, out DynamicValue value)
+    {
+        value = new DynamicValue.Null();
+        // each item is ≥ 1 byte, so a count beyond the remaining bytes is truncated
+        if (arg > (ulong)(b.Length - pos))
+        {
+            return DecodeError.UnexpectedEnd;
+        }
+
+        var items = ImmutableArray.CreateBuilder<DynamicValue>((int)arg);
+        for (ulong i = 0; i < arg; i++)
+        {
+            DecodeError? itemErr = TryReadCbor(b, ref pos, out DynamicValue item);
+            if (itemErr is DecodeError ie)
+            {
+                return ie;
+            }
+
+            items.Add(item);
+        }
+
+        value = new DynamicValue.Array(items.ToImmutable());
+        return null;
+    }
+
+    private static DecodeError? TryReadMap(byte[] b, ref int pos, ulong arg, out DynamicValue value)
+    {
+        value = new DynamicValue.Null();
+        if (arg > (ulong)(b.Length - pos))
+        {
+            return DecodeError.UnexpectedEnd;
+        }
+
+        var pairs = ImmutableArray.CreateBuilder<KeyValuePair<string, DynamicValue>>((int)arg);
+        for (ulong i = 0; i < arg; i++)
+        {
+            DecodeError? keyErr = TryReadCbor(b, ref pos, out DynamicValue key);
+            if (keyErr is DecodeError ke)
+            {
+                return ke;
+            }
+
+            if (key is not DynamicValue.String ks)
+            {
+                return DecodeError.NonTextKey;
+            }
+
+            DecodeError? valErr = TryReadCbor(b, ref pos, out DynamicValue val);
+            if (valErr is DecodeError ve)
+            {
+                return ve;
+            }
+
+            pairs.Add(new KeyValuePair<string, DynamicValue>(ks.Value, val));
+        }
+
+        value = new DynamicValue.Object(pairs.ToImmutable());
+        return null;
+    }
+
+    // Reads a CBOR argument (the value after the initial byte) for additional-info `ai`: inline for
+    // 0–23, else 1/2/4/8 big-endian bytes for 24/25/26/27. 28–31 are reserved/indefinite (Unsupported).
+    private static DecodeError? TryReadCborArg(byte[] b, ref int pos, int ai, out ulong arg)
+    {
+        arg = 0;
+        if (ai < 24)
+        {
+            arg = (ulong)ai;
+            return null;
+        }
+
+        int n = ai switch
+        {
+            24 => 1,
+            25 => 2,
+            26 => 4,
+            27 => 8,
+            _ => -1,
+        };
+        if (n < 0)
+        {
+            return DecodeError.Unsupported;
+        }
+
+        if (pos + n > b.Length)
+        {
+            return DecodeError.UnexpectedEnd;
+        }
+
+        ulong v = 0;
+        for (int i = 0; i < n; i++)
+        {
+            v = (v << 8) | b[pos + i];
+        }
+
+        pos += n;
+        arg = v;
+        return null;
+    }
 }

--- a/tests/Tests.CSharp/DynamicValueCborDecodeTests.cs
+++ b/tests/Tests.CSharp/DynamicValueCborDecodeTests.cs
@@ -131,6 +131,10 @@ public class DynamicValueCborDecodeTests
     [InlineData(new byte[] { 0x61, 0xff }, DecodeError.NonCanonical)] // text string with invalid UTF-8 (silent U+FFFD repair)
     [InlineData(new byte[] { 0xfb, 0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, DecodeError.NonCanonical)] // 1.0 as float64 (non-shortest float)
     [InlineData(new byte[] { 0x81, 0x18, 0x00 }, DecodeError.NonCanonical)] // non-canonical nested in an array
+    [InlineData(new byte[] { 0x18, 0x17 }, DecodeError.NonCanonical)] // 23 as uint8 (non-shortest arg width)
+    [InlineData(new byte[] { 0xf9, 0x7e, 0x01 }, DecodeError.NonCanonical)] // float16 NaN, non-canonical payload (≠ 0x7e00)
+    [InlineData(new byte[] { 0xfa, 0x7f, 0xc0, 0x00, 0x00 }, DecodeError.NonCanonical)] // float32 NaN (canonicalizes to f97e00)
+    [InlineData(new byte[] { 0xfa, 0x3f, 0x80, 0x00, 0x00 }, DecodeError.NonCanonical)] // 1.0 as float32 (fits float16)
     public void DecodeRejectsMalformed(byte[] bytes, DecodeError expected)
     {
         var result = DynamicValues.FromCanonicalCbor(bytes);

--- a/tests/Tests.CSharp/DynamicValueCborDecodeTests.cs
+++ b/tests/Tests.CSharp/DynamicValueCborDecodeTests.cs
@@ -1,0 +1,145 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+using Zeta.Core.CSharp;
+
+namespace Zeta.Tests.CSharp;
+
+/// <summary>
+/// DynamicValue canonical-CBOR DECODE byte-lock — <see cref="DynamicValues.FromCanonicalCbor"/> is
+/// the inverse of <see cref="DynamicValues.ToCanonicalCbor"/>, completing the byte↔value bijection.
+/// Primary check is the round-trip <c>ToCanonicalCbor(FromCanonicalCbor(b)) == b</c> over the shared
+/// seed (sound because canonical encode is bijective, and it sidesteps NaN/-0.0 value-equality
+/// traps — NaN re-encodes to f97e00 regardless of bit pattern). A direct structural
+/// <c>decode == value</c> check runs too (C# DynamicValue has structural equality). "The compilers
+/// don't lie."
+/// </summary>
+public class DynamicValueCborDecodeTests
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(Path.GetDirectoryName(typeof(DynamicValueCborDecodeTests).Assembly.Location)!);
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "Zeta.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName
+            ?? throw new InvalidOperationException("Could not locate repo root (Zeta.sln) from test assembly location.");
+    }
+
+    private static string Str(JsonElement el, string prop) =>
+        el.GetProperty(prop).GetString()
+            ?? throw new InvalidOperationException($"fixture property '{prop}' is not a string: {el.GetRawText()}");
+
+    private static string Hex(byte[] bytes) => Convert.ToHexString(bytes).ToLowerInvariant();
+
+    private static DynamicValue BuildValue(JsonElement el)
+    {
+        string tag = Str(el, "t");
+        switch (tag)
+        {
+            case "null":
+                return new DynamicValue.Null();
+            case "bool":
+                return new DynamicValue.Bool(el.GetProperty("v").GetBoolean());
+            case "int":
+                return new DynamicValue.Int(long.Parse(Str(el, "v"), CultureInfo.InvariantCulture));
+            case "float":
+                return new DynamicValue.Float(
+                    BitConverter.UInt64BitsToDouble(
+                        ulong.Parse(Str(el, "v"), NumberStyles.HexNumber, CultureInfo.InvariantCulture)));
+            case "str":
+                return new DynamicValue.String(Str(el, "v"));
+            case "bytes":
+                return new DynamicValue.Bytes(Convert.FromHexString(Str(el, "v")).ToImmutableArray());
+            case "arr":
+                return new DynamicValue.Array(
+                    el.GetProperty("v").EnumerateArray().Select(BuildValue).ToImmutableArray());
+            case "obj":
+                return new DynamicValue.Object(
+                    el.GetProperty("v").EnumerateArray()
+                        .Select(pair =>
+                        {
+                            JsonElement[] parts = pair.EnumerateArray().ToArray();
+                            string key = parts[0].GetString()
+                                ?? throw new InvalidOperationException("object key is not a string");
+                            return new KeyValuePair<string, DynamicValue>(key, BuildValue(parts[1]));
+                        })
+                        .ToImmutableArray());
+            default:
+                throw new InvalidOperationException($"unsupported tag in CBOR seed: {tag}");
+        }
+    }
+
+    [Fact]
+    public void CSharpDecodeRoundTripsSeed()
+    {
+        string path = Path.Join(RepoRoot(), "src", "Core.TypeScript", "dynamic-value", "golden-vectors-cbor.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        JsonElement[] vectors = doc.RootElement.GetProperty("vectors").EnumerateArray().ToArray();
+        Assert.NotEmpty(vectors);
+
+        var failures = new List<string>();
+        foreach (JsonElement v in vectors)
+        {
+            string name = Str(v, "name");
+            byte[] cbor = Convert.FromHexString(Str(v, "cbor"));
+
+            switch (DynamicValues.FromCanonicalCbor(cbor))
+            {
+                case Result<DynamicValue, DecodeError>.Ok ok:
+                    // (a) byte round-trip: re-encoding the decoded value reproduces the canonical bytes
+                    string reEncoded = Hex(DynamicValues.ToCanonicalCbor(ok.Value));
+                    if (!string.Equals(reEncoded, Str(v, "cbor"), StringComparison.Ordinal))
+                    {
+                        failures.Add($"{name}: re-encode {reEncoded} != {Str(v, "cbor")}");
+                    }
+
+                    // (b) structural: the decoded value equals the expected value
+                    DynamicValue expected = BuildValue(v.GetProperty("value"));
+                    if (!ok.Value.Equals(expected))
+                    {
+                        failures.Add($"{name}: decoded value != expected");
+                    }
+
+                    break;
+                case Result<DynamicValue, DecodeError>.Err err:
+                    failures.Add($"{name}: decode failed with {err.Error}");
+                    break;
+                default:
+                    failures.Add($"{name}: unexpected Result shape");
+                    break;
+            }
+        }
+
+        Assert.Empty(failures);
+    }
+
+    [Theory]
+    [InlineData(new byte[] { }, DecodeError.UnexpectedEnd)] // empty
+    [InlineData(new byte[] { 0x18 }, DecodeError.UnexpectedEnd)] // uint8 head, payload truncated
+    [InlineData(new byte[] { 0x43, 0x01, 0x02 }, DecodeError.UnexpectedEnd)] // 3-byte bstr, only 2 present
+    [InlineData(new byte[] { 0xf6, 0x00 }, DecodeError.TrailingData)] // null + extra byte
+    [InlineData(new byte[] { 0xc0, 0x00 }, DecodeError.Unsupported)] // tag (major 6)
+    [InlineData(new byte[] { 0xf7 }, DecodeError.Unsupported)] // undefined (major 7, ai 23)
+    [InlineData(new byte[] { 0x9f }, DecodeError.Unsupported)] // indefinite-length array (ai 31)
+    public void DecodeRejectsMalformed(byte[] bytes, DecodeError expected)
+    {
+        var result = DynamicValues.FromCanonicalCbor(bytes);
+        var err = Assert.IsType<Result<DynamicValue, DecodeError>.Err>(result);
+        Assert.Equal(expected, err.Error);
+    }
+
+    [Fact]
+    public void DecodeRejectsNonTextMapKey()
+    {
+        // a1 (map, 1 pair) 00 (int key 0) 00 (int value 0) — our objects require text keys
+        var result = DynamicValues.FromCanonicalCbor([0xa1, 0x00, 0x00]);
+        var err = Assert.IsType<Result<DynamicValue, DecodeError>.Err>(result);
+        Assert.Equal(DecodeError.NonTextKey, err.Error);
+    }
+}

--- a/tests/Tests.CSharp/DynamicValueCborDecodeTests.cs
+++ b/tests/Tests.CSharp/DynamicValueCborDecodeTests.cs
@@ -127,6 +127,10 @@ public class DynamicValueCborDecodeTests
     [InlineData(new byte[] { 0xc0, 0x00 }, DecodeError.Unsupported)] // tag (major 6)
     [InlineData(new byte[] { 0xf7 }, DecodeError.Unsupported)] // undefined (major 7, ai 23)
     [InlineData(new byte[] { 0x9f }, DecodeError.Unsupported)] // indefinite-length array (ai 31)
+    [InlineData(new byte[] { 0x18, 0x00 }, DecodeError.NonCanonical)] // non-shortest int (0 as uint8)
+    [InlineData(new byte[] { 0x61, 0xff }, DecodeError.NonCanonical)] // text string with invalid UTF-8 (silent U+FFFD repair)
+    [InlineData(new byte[] { 0xfb, 0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, DecodeError.NonCanonical)] // 1.0 as float64 (non-shortest float)
+    [InlineData(new byte[] { 0x81, 0x18, 0x00 }, DecodeError.NonCanonical)] // non-canonical nested in an array
     public void DecodeRejectsMalformed(byte[] bytes, DecodeError expected)
     {
         var result = DynamicValues.FromCanonicalCbor(bytes);


### PR DESCRIPTION
Starts **the decode side** (per Aaron: both, **CBOR then JSON**). `DynamicValues.FromCanonicalCbor(byte[]) -> Result<DynamicValue, DecodeError>` is the inverse of `ToCanonicalCbor`, completing the byte↔value bijection for all 8 shapes.

- **Result-shaped** (decode is partial): new `DecodeError` enum — `UnexpectedEnd / TrailingData / Unsupported / IntegerOverflow / NonTextKey`. Never throws for malformed input.
- **float16** payloads decode via `System.Half`.
- **Byte-lock = round-trip**: `ToCanonicalCbor(FromCanonicalCbor(b)) == b` over the shared seed — sound (canonical encode is bijective) and it sidesteps NaN/-0.0 value-equality traps (NaN re-encodes to `f97e00`). Plus direct structural `decode == value` (C# `DynamicValue` has structural equality) + 7 malformed-input rejections + non-text-key. **9 tests green.**

First decode oracle (one authors, others replay): **C# here; F#/Rust/TS CBOR decode next, then JSON decode ×4.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)