### PR TITLE
backlog(B-0982): 4-oracle multi-format golden-vector seeds (CBOR/JSON/YAML/XML) — nothing is single source of truth

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -928,6 +928,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-0973](backlog/P2/B-0973-ace-update-re-solve-within-ranges-rewrite-lockfile-bump-deferred-from-slice5.3-2026-06-01.md)** Ace `ace update` — re-solve within ranges + rewrite the lockfile (bump; deferred from slice 5.3 lockfile)
 - [x] **[B-0974](backlog/P2/B-0974-ace-install-locked-mode-verify-lock-matches-fresh-solve-vs-frozen-replay-deferred-from-slice5.3-2026-06-01.md)** Ace `ace install --locked` — verify the lock matches a fresh solve (cargo --locked vs --frozen distinction; deferred from slice 5.3)
 - [ ] **[B-0975](backlog/P2/B-0975-ace-lockfile-ergonomics-partial-merge-alphabetical-ordering-leaf-lock-deferred-from-slice5.3-2026-06-01.md)** Ace lockfile ergonomics — partial-merge, alphabetical ordering, leaf-install lock (deferred from slice 5.3)
+- [ ] **[B-0982](backlog/P2/B-0982-four-oracle-multi-format-golden-vector-seeds-cbor-json-yaml-xml-nothing-is-single-source-of-truth-aaron-2026-06-01.md)** 4-oracle multi-format golden-vector seeds (CBOR/JSON/YAML/XML) — nothing is single source of truth, the seed itself must be cross-validated not trusted as one file
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-0982-four-oracle-multi-format-golden-vector-seeds-cbor-json-yaml-xml-nothing-is-single-source-of-truth-aaron-2026-06-01.md
+++ b/docs/backlog/P2/B-0982-four-oracle-multi-format-golden-vector-seeds-cbor-json-yaml-xml-nothing-is-single-source-of-truth-aaron-2026-06-01.md
@@ -1,0 +1,114 @@
+---
+id: B-0982
+title: 4-oracle multi-format golden-vector seeds (CBOR/JSON/YAML/XML) — nothing is single source of truth, the seed itself must be cross-validated not trusted as one file
+status: open
+priority: P2
+created: 2026-06-01
+attribution: aaron-2026-06-01
+last_updated: 2026-06-01
+decomposition: umbrella
+depends_on: []
+composes_with:
+  - B-0638
+tags:
+  - dynamicvalue
+  - golden-vectors
+  - seed
+  - no-single-source-of-truth
+  - four-oracle
+  - byte-lock
+  - cbor
+  - json
+  - yaml
+  - xml
+  - decode
+---
+
+# B-0982 — 4-oracle multi-format golden-vector seeds; nothing is single source of truth
+
+**Operator (Aaron 2026-06-01):**
+
+> "we really need 4 orcle data format eventaully for seeds too nothing is single source of truth"
+
+> "CBOR JSON YAML XML mybe"
+
+> "i'm pretty sure you can use the c# hkt trick to get uom like behaviors" *(separate
+> thread — see "Sibling: C# UoM via the CRTP/HKT trick" below; already substrate)*
+
+## The gap
+
+The DynamicValue byte-lock today makes the *code* 4-oracle (TS/F#/C#/Rust all agree),
+but the **seed itself is single source of truth**: `golden-vectors.json` (JSON) and
+`golden-vectors-cbor.json` (CBOR vectors carried *as JSON* hex) are each **one JSON
+file** that all four oracles trust. If that one file is wrong or drifts, all four
+oracles agree on the wrong data. The RFC-8949-Appendix-A anchor mitigates this for the
+float vectors (independent ground truth), but the seed *artifact* is still a single
+file in a single format.
+
+This cuts against the framework invariant **"nothing is single source of truth."** The
+four-oracle / "the compilers don't lie" discipline should apply to the **data** too,
+not just the code.
+
+## The shape
+
+Express + cross-validate the seed in **four data formats — CBOR, JSON, YAML, XML**
+(Aaron: "CBOR JSON YAML XML mybe") — so no single file is authoritative. The four
+representations mutually validate: decoding each must yield the *same* canonical
+`DynamicValue` set, and re-encoding must reproduce each format's canonical bytes.
+
+```
+decode_cbor(seed.cbor) == decode_json(seed.json)
+                       == decode_yaml(seed.yaml)
+                       == decode_xml(seed.xml)
+                       == the canonical value set
+```
+
+**The DynamicValue primitive + its format codecs ARE the mechanism.** DynamicValue is
+the format-agnostic value tree riding the `ISerializer<'T>` seam (JSON / CBOR / YAML /
+XML / …). Once each format has **both encode and decode**, the seed becomes a set of
+canonical `DynamicValue`s serialized into all four formats + cross-validated — no
+format privileged.
+
+## Enabler: the decode side (in progress)
+
+This requires the **decode side** (bytes/text → DynamicValue), currently being built
+(CBOR decode: C# #6512; F#/Rust/TS + JSON decode to follow). Cross-format seed
+validation needs decode in *each* format to compare. So the multi-format-seed work is
+**gated on the decode side landing across formats**, and is the natural capstone once
+it does.
+
+Plus YAML + XML codecs (encode+decode) as DynamicValue format adapters (the serializer
+roster already names YAML/XML as targets).
+
+## Sibling: C# UoM via the CRTP/HKT trick (already substrate — connect, don't duplicate)
+
+Aaron 2026-06-01: *"i'm pretty sure you can use the c# hkt trick to get uom like
+behaviors."* Correct, and **already covered** — captured here only so the thread is
+not lost:
+
+- `.claude/rules/numerical-algebra-shaped-into-the-generic-math-interface-per-language-idiom.md`
+  — C# `System.Numerics` IWSAM generic-math per-language-idiom.
+- `memory/feedback_fbounded_crtp_inumber_tself_is_the_csharp_hkt_monad_hack_*` — the
+  F-bounded `INumber<TSelf> where TSelf : INumber<TSelf>` CRTP = the C# HKT hack;
+  "fluent-over-it is coming."
+- `.claude/rules/attention-as-currency-...-fsharp-uom-...` — F# UOM as the economic
+  substrate; the **C# oracle** of that UOM would use the CRTP/phantom-unit trick
+  (C#'s analog of F# `[<Measure>]`).
+- B-0198 / B-0374 (F# UoM). The C#-specific UoM-via-CRTP is the C# oracle of these.
+
+No separate row minted (per verify-existing-substrate-before-authoring); the C# UoM
+angle belongs with the generic-math + attention-as-currency substrate above.
+
+## Acceptance (umbrella; decompose when the decode side lands)
+
+- [ ] Decode side complete across formats (CBOR ✅-in-progress, JSON, then YAML/XML codecs).
+- [ ] Seed expressed in CBOR + JSON + YAML + XML.
+- [ ] Cross-validation test: all four decode to the same canonical DynamicValue set; each re-encodes to its canonical bytes.
+- [ ] No single seed file is the source of truth — drift in any one is caught by the others.
+
+## Composes with
+
+- **B-0638** Eve Protocol / dynamic-shape primitive (DynamicValue is its instantiation).
+- DynamicValue byte-lock substrate (PRs #6506/#6508/#6509/#6510/#6511 encode; #6512+ decode) + the registry's "Dynamic runtime objects / polymorphic shape" clause.
+- The serializer roster (the format adapters — JSON/CBOR/YAML/XML/…).
+- The "nothing is single source of truth" / four-oracle / "the compilers don't lie" invariant.


### PR DESCRIPTION
Captures Aaron 2026-06-01: *"we really need 4 orcle data format eventaully for seeds too nothing is single source of truth"* + *"CBOR JSON YAML XML mybe"*.

The byte-lock makes the **code** 4-oracle, but the **seed is still single source of truth** — one JSON file all four oracles trust. This row captures the direction: express + cross-validate the seed across **CBOR/JSON/YAML/XML** so no file is authoritative (`decode_fmt(seed.fmt) ==` the same canonical DynamicValue set for all four; re-encode reproduces each formats canonical bytes). The DynamicValue 4-format codecs (encode + **decode**) are the mechanism — **gated on the decode side landing across formats** (CBOR decode in flight, #6512). P2 (Aaron: "eventually").

Also folds in the sibling *"C# HKT trick for UoM-like behaviors"* thread by **connecting it to existing substrate** (generic-math rule + `fbounded-crtp` memory + attention-as-currency F# UOM + B-0198/B-0374) rather than minting a parallel row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)