### PR TITLE
fix(DynamicValue): TS fromCanonicalCbor honors never-throws for non-byte number[] (Codex #6516)

### DIFF
--- a/src/Core.TypeScript/dynamic-value/cbor.ts
+++ b/src/Core.TypeScript/dynamic-value/cbor.ts
@@ -247,8 +247,17 @@ function bytesEqual(a: number[], b: number[]): boolean {
  * (`canonicalCbor(decoded)` must equal the input) rejects every non-canonical form
  * (non-shortest int/length width, non-shortest float / non-canonical NaN, invalid UTF-8
  * repaired to U+FFFD) as `NonCanonical`. Never throws for malformed input.
+ *
+ * The input is typed `number[]` (the C#/F#/Rust oracles take `byte[]`/`Vec<u8>`, which
+ * enforce 0..255 at the type level; JS cannot). Any element that is not an integer in
+ * 0..255 is not a valid CBOR byte, so the input cannot be canonical CBOR → `NonCanonical`.
+ * This boundary check also preserves the never-throws contract: without it a non-integer
+ * element (e.g. `1.5`, `NaN`, `Infinity`) would reach `BigInt(...)` and throw `RangeError`.
  */
 export function fromCanonicalCbor(bytes: number[]): DecodeResult {
+  for (const b of bytes) {
+    if (!Number.isInteger(b) || b < 0 || b > 255) return { ok: false, error: "NonCanonical" };
+  }
   let pos = 0;
   const fail = (e: DecodeError): never => {
     throw new CborDecodeError(e);

--- a/src/Core.TypeScript/dynamic-value/golden-vectors-cbor-decode.test.ts
+++ b/src/Core.TypeScript/dynamic-value/golden-vectors-cbor-decode.test.ts
@@ -63,3 +63,14 @@ test("cbor decode rejects non-canonical input", () => {
   expect(decodeErr([0xfa, 0x3f, 0x80, 0x00, 0x00])).toBe("NonCanonical"); // 1.0 as float32
   expect(decodeErr([0xfb, 0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])).toBe("NonCanonical"); // 1.0 as float64
 });
+
+// number[] cannot enforce 0..255 bytes at the type level (the C#/F#/Rust oracles take
+// byte[]/Vec<u8>); a non-byte element is not valid CBOR and must NOT throw (never-throws
+// contract) — it returns NonCanonical, not a RangeError from BigInt(non-integer).
+test("cbor decode rejects non-byte input without throwing", () => {
+  expect(decodeErr([0x18, 1.5])).toBe("NonCanonical"); // non-integer byte (would throw BigInt(1.5))
+  expect(decodeErr([0x18, NaN])).toBe("NonCanonical"); // NaN byte
+  expect(decodeErr([0x18, Infinity])).toBe("NonCanonical"); // Infinity byte
+  expect(decodeErr([0x18, 256])).toBe("NonCanonical"); // out-of-range high
+  expect(decodeErr([0x18, -1])).toBe("NonCanonical"); // out-of-range low
+});


### PR DESCRIPTION
Follow-up to #6516 addressing a Codex P2 review thread.

## Problem
The TS decoder's input is `number[]` — the C#/F#/Rust oracles take `byte[]`/`Vec<u8>` which enforce 0..255 at the type level, but JS can't. A caller passing a non-integer/out-of-range element (e.g. `[0x18, 1.5]`) reached `BigInt(1.5)` and threw a `RangeError`, escaping the documented **never-throws** contract.

## Fix
Validate every element is an integer in 0..255 at the `fromCanonicalCbor` boundary; a non-byte element cannot be canonical CBOR → `NonCanonical`, returned as a `DecodeResult` (not thrown). **No new `DecodeError` variant** — the cross-oracle error set stays identical (this is a TS-only boundary concern the type-safe oracles don't have).

## Test
Rejects `[0x18, 1.5]` / `NaN` / `Infinity` / `256` / `-1` as `NonCanonical` without throwing. **90 TS tests pass; tsc/eslint/prettier clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)