### PR TITLE
feat(DynamicValue): TS canonical-JSON DECODE oracle — precision-safe + strict-canonical

### DIFF
--- a/src/Core.TypeScript/dynamic-value/golden-vectors-json-decode.test.ts
+++ b/src/Core.TypeScript/dynamic-value/golden-vectors-json-decode.test.ts
@@ -45,6 +45,12 @@ test("json decode rejects malformed input", () => {
   expect(decodeErr("[1,")).toBe("UnexpectedEnd"); // unterminated array
   expect(decodeErr('{"a"')).toBe("UnexpectedEnd"); // object missing colon+value
   expect(decodeErr('"unterminated')).toBe("UnexpectedEnd"); // unterminated string
+  expect(decodeErr('"\\u00gg"')).toBe("UnexpectedEnd"); // \uXXXX with non-hex digits
+  expect(decodeErr('"\\q"')).toBe("UnexpectedEnd"); // invalid escape
+  expect(decodeErr("1.")).toBe("UnexpectedEnd"); // no digit after '.'
+  expect(decodeErr("1e")).toBe("UnexpectedEnd"); // no exponent digits
+  expect(decodeErr("1e+")).toBe("UnexpectedEnd"); // exponent sign without digits
+  expect(decodeErr("-")).toBe("UnexpectedEnd"); // sign without digits
   expect(decodeErr("null x")).toBe("TrailingData"); // value + trailing token
   expect(decodeErr("nullnull")).toBe("TrailingData"); // two values
 });

--- a/src/Core.TypeScript/dynamic-value/golden-vectors-json-decode.test.ts
+++ b/src/Core.TypeScript/dynamic-value/golden-vectors-json-decode.test.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "bun:test";
+import vectors from "./golden-vectors.json";
+import { type Tagged, type DecodeError, fromCanonicalJson } from "./json";
+
+// DynamicValue canonical-JSON DECODE byte-lock — fromCanonicalJson is the inverse of
+// canonicalJson, completing the text<->value round-trip for the 6 locked shapes (Float +
+// Bytes are DEFERRED in JSON — they lock under CBOR, see cbor.ts). The decoder is strictly
+// canonical (lenient parse → fixed-point check canonicalJson(parsed) === input →
+// "NonCanonical"), so a successful decode of a seed vector is guaranteed to round-trip;
+// int64 precision is preserved by parsing the number token as text (BigInt). This asserts
+// decode succeeds + structurally matches the seed value, and that malformed / deferred /
+// oversized / non-canonical inputs are rejected with the right DecodeError. The codec lives
+// in ./json.ts (shared with encode). "The compilers don't lie."
+
+interface Vector {
+  name: string;
+  value: Tagged;
+  json: string;
+}
+
+const decodeErr = (s: string): DecodeError => {
+  const r = fromCanonicalJson(s);
+  if (r.ok) throw new Error("expected decode failure");
+  return r.error;
+};
+
+const seed = vectors as unknown as { vectors: Vector[] };
+
+for (const v of seed.vectors) {
+  test(`json decode round-trip: ${v.name}`, () => {
+    const r = fromCanonicalJson(v.json);
+    // ok ⟹ the fixed-point check passed (canonicalJson(parsed) === input), i.e. the
+    // round-trip holds against the already-verified encoder.
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      // structural: decoded tagged value equals the seed value (incl. object key order)
+      expect(JSON.stringify(r.value)).toBe(JSON.stringify(v.value));
+    }
+  });
+}
+
+test("json decode rejects malformed input", () => {
+  expect(decodeErr("")).toBe("UnexpectedEnd"); // empty
+  expect(decodeErr("tru")).toBe("UnexpectedEnd"); // truncated literal
+  expect(decodeErr("[1,")).toBe("UnexpectedEnd"); // unterminated array
+  expect(decodeErr('{"a"')).toBe("UnexpectedEnd"); // object missing colon+value
+  expect(decodeErr('"unterminated')).toBe("UnexpectedEnd"); // unterminated string
+  expect(decodeErr("null x")).toBe("TrailingData"); // value + trailing token
+  expect(decodeErr("nullnull")).toBe("TrailingData"); // two values
+});
+
+test("json decode rejects DEFERRED float-shaped numbers as Unsupported", () => {
+  expect(decodeErr("1.5")).toBe("Unsupported"); // decimal point
+  expect(decodeErr("1e10")).toBe("Unsupported"); // exponent
+  expect(decodeErr("-0.0")).toBe("Unsupported"); // negative float
+});
+
+test("json decode rejects oversized integers", () => {
+  expect(decodeErr("9223372036854775808")).toBe("IntegerOverflow"); // i64::MAX + 1
+  expect(decodeErr("-9223372036854775809")).toBe("IntegerOverflow"); // i64::MIN - 1
+});
+
+test("json decode rejects non-canonical input", () => {
+  expect(decodeErr(" null")).toBe("NonCanonical"); // leading whitespace
+  expect(decodeErr("[1, 2]")).toBe("NonCanonical"); // space after comma
+  expect(decodeErr("01")).toBe("NonCanonical"); // leading zero (BigInt("01")=1 → "1")
+  expect(decodeErr('"\\u0041"')).toBe("NonCanonical"); // A = "A"; canonical emits raw "A"
+  expect(decodeErr('{ "a":1}')).toBe("NonCanonical"); // whitespace inside object
+});

--- a/src/Core.TypeScript/dynamic-value/golden-vectors.test.ts
+++ b/src/Core.TypeScript/dynamic-value/golden-vectors.test.ts
@@ -1,87 +1,18 @@
 import { test, expect } from "bun:test";
 import vectors from "./golden-vectors.json";
+import { type Tagged, canonicalJson } from "./json";
 
 // DynamicValue TS oracle — grown FROM the seed (seed-first / grow-code-from-the-seed,
 // Aaron 2026-06-01). This is the canonical-encode side of the byte-lock: the seed
 // (golden-vectors.json) is the canonical DATA; this code AGREES on the JSON structure.
 // v1 locks null/bool/int/string/array/object; Float + Bytes are DEFERRED (see the
-// seed's `deferred` block). The decode side (precision-safe JSON tokenizer that keeps
-// int64 as a string) is the next slice; this slice locks ENCODE + canonical-JSON validity.
-
-type Tagged =
-  | { t: "null" }
-  | { t: "bool"; v: boolean }
-  | { t: "int"; v: string }
-  | { t: "str"; v: string }
-  | { t: "arr"; v: Tagged[] }
-  | { t: "obj"; v: [string, Tagged][] };
+// seed's `deferred` block — they lock under CBOR, see cbor.ts). The codec lives in
+// ./json.ts (shared with the decode test).
 
 interface Vector {
   name: string;
   value: Tagged;
   json: string;
-}
-
-// Canonical JSON encoding, per the seed's `canonicalJson` rules:
-// minified; object keys in INSERTION order (NOT sorted — Object is order-significant);
-// int = bare exact decimal; string = RFC 8259 minimal escaping ("/" NOT escaped,
-// control U+0000..001F as short-form or lowercase \u00XX, all else raw UTF-8).
-function encodeString(s: string): string {
-  let out = '"';
-  for (const ch of s) {
-    // iterate by code point (string iterator combines surrogate pairs)
-    switch (ch) {
-      case '"':
-        out += '\\"';
-        break;
-      case "\\":
-        out += "\\\\";
-        break;
-      case "\b":
-        out += "\\b";
-        break;
-      case "\f":
-        out += "\\f";
-        break;
-      case "\n":
-        out += "\\n";
-        break;
-      case "\r":
-        out += "\\r";
-        break;
-      case "\t":
-        out += "\\t";
-        break;
-      default: {
-        const code = ch.codePointAt(0)!;
-        if (code <= 0x1f) {
-          out += "\\u" + code.toString(16).padStart(4, "0");
-        } else {
-          out += ch; // raw UTF-8 (incl. non-ASCII / astral)
-        }
-      }
-    }
-  }
-  return out + '"';
-}
-
-function canonicalEncode(n: Tagged): string {
-  switch (n.t) {
-    case "null":
-      return "null";
-    case "bool":
-      return n.v ? "true" : "false";
-    case "int":
-      // re-canonicalize via BigInt: validates the seed's int text is canonical
-      // (no leading zeros, no '+', '-' only for negatives) and arbitrary-precision-exact
-      return BigInt(n.v).toString();
-    case "str":
-      return encodeString(n.v);
-    case "arr":
-      return "[" + n.v.map(canonicalEncode).join(",") + "]";
-    case "obj":
-      return "{" + n.v.map(([k, val]) => encodeString(k) + ":" + canonicalEncode(val)).join(",") + "}";
-  }
 }
 
 const seed = vectors as unknown as { primitive: string; version: number; vectors: Vector[] };
@@ -95,8 +26,10 @@ test("seed identifies as DynamicValue v1", () => {
 for (const v of seed.vectors) {
   test(`byte-lock encode: ${v.name}`, () => {
     // encode(value) === canonical json (the byte-lock target)
-    expect(canonicalEncode(v.value)).toBe(v.json);
-    // the canonical json is itself valid JSON
-    expect(() => JSON.parse(v.json)).not.toThrow();
+    expect(canonicalJson(v.value)).toBe(v.json);
+    // the canonical json is itself valid JSON (block body — don't return JSON.parse's `any`)
+    expect(() => {
+      JSON.parse(v.json);
+    }).not.toThrow();
   });
 }

--- a/src/Core.TypeScript/dynamic-value/json.ts
+++ b/src/Core.TypeScript/dynamic-value/json.ts
@@ -154,11 +154,11 @@ export function fromCanonicalJson(json: string): DecodeResult {
     const e = json.charAt(pos);
     if (e === "u") {
       const hex = json.slice(pos + 1, pos + 5);
-      if (hex.length < 4) fail("UnexpectedEnd");
-      const code = parseInt(hex, 16);
-      if (Number.isNaN(code)) fail("UnexpectedEnd");
+      // require exactly 4 hex digits — parseInt would PARTIALLY parse (e.g. "00gg" → 0),
+      // silently accepting malformed \uXXXX; reject as UnexpectedEnd instead.
+      if (!/^[0-9a-fA-F]{4}$/.test(hex)) fail("UnexpectedEnd");
       pos += 5; // 'u' + 4 hex digits
-      return String.fromCharCode(code);
+      return String.fromCharCode(parseInt(hex, 16));
     }
     const rep = JSON_ESCAPES[e];
     if (rep === undefined) fail("UnexpectedEnd"); // invalid escape / EOF after backslash
@@ -185,15 +185,23 @@ export function fromCanonicalJson(json: string): DecodeResult {
     return fail("UnexpectedEnd"); // unterminated string
   };
 
+  // consumes one or more digits at pos; fails UnexpectedEnd if none (enforces the JSON
+  // grammar's "at least one digit" for the integer part, fraction, and exponent).
+  const consumeDigits = (): void => {
+    const d0 = pos;
+    while (isDigit(json.charAt(pos))) pos += 1;
+    if (pos === d0) fail("UnexpectedEnd");
+  };
+
   const parseNumber = (): Tagged => {
     const start = pos;
     if (json.charAt(pos) === "-") pos += 1;
-    while (isDigit(json.charAt(pos))) pos += 1;
+    consumeDigits(); // integer part — required (rejects "-", "-.5")
     let isFloat = false;
     if (json.charAt(pos) === ".") {
       isFloat = true;
       pos += 1;
-      while (isDigit(json.charAt(pos))) pos += 1;
+      consumeDigits(); // fraction — required after '.' (rejects "1.")
     }
     const ec = json.charAt(pos);
     if (ec === "e" || ec === "E") {
@@ -201,12 +209,10 @@ export function fromCanonicalJson(json: string): DecodeResult {
       pos += 1;
       const sign = json.charAt(pos);
       if (sign === "+" || sign === "-") pos += 1;
-      while (isDigit(json.charAt(pos))) pos += 1;
+      consumeDigits(); // exponent — required (rejects "1e", "1e+")
     }
-    const tok = json.slice(start, pos);
-    if (tok === "" || tok === "-") return fail("UnexpectedEnd");
     if (isFloat) return fail("Unsupported"); // Float deferred in v1 JSON
-    const big = BigInt(tok);
+    const big = BigInt(json.slice(start, pos));
     if (big > I64_MAX || big < I64_MIN) return fail("IntegerOverflow");
     return { t: "int", v: big.toString() };
   };

--- a/src/Core.TypeScript/dynamic-value/json.ts
+++ b/src/Core.TypeScript/dynamic-value/json.ts
@@ -1,0 +1,308 @@
+// DynamicValue canonical JSON codec — the TS oracle, shared by the encode + decode
+// byte-lock tests. Canonical JSON is the PARTIAL form (6/8 shapes): Float + Bytes are
+// DEFERRED per the seed's `deferred` block (a JSON number is ambiguous Int-vs-Float on
+// decode, and JSON has no native byte type) and lock under CBOR instead (see cbor.ts).
+// Canonical rules (seed's `canonicalJson`): minified; object keys in INSERTION order
+// (NOT sorted — Object is order-significant); int = bare exact decimal; string = RFC 8259
+// minimal escaping ('/' NOT escaped; control U+0000..001F short-form or lowercase \u00XX;
+// all else raw UTF-8).
+//
+// `Tagged` is the language-neutral seed value form: int v = exact decimal string (so
+// int64 precision is never lost through a JS number). The decoder is the inverse of
+// `canonicalJson`: a lenient recursive-descent parse, then one fixed-point check
+// (`canonicalJson(parsed) === input`) rejects every non-canonical form (insignificant
+// whitespace, non-minimal escapes, leading zeros / '+' signs) as `NonCanonical`.
+// "The compilers don't lie."
+
+export type Tagged =
+  | { t: "null" }
+  | { t: "bool"; v: boolean }
+  | { t: "int"; v: string }
+  | { t: "str"; v: string }
+  | { t: "arr"; v: Tagged[] }
+  | { t: "obj"; v: [string, Tagged][] };
+
+// Why canonical JSON bytes could not be decoded into a v1 DynamicValue. (No `NonTextKey`:
+// JSON object keys are syntactically always strings, unlike CBOR map keys.)
+export type DecodeError = "UnexpectedEnd" | "TrailingData" | "Unsupported" | "IntegerOverflow" | "NonCanonical";
+
+export type DecodeResult = { ok: true; value: Tagged } | { ok: false; error: DecodeError };
+
+const I64_MAX = 9223372036854775807n;
+const I64_MIN = -9223372036854775808n;
+
+// --- canonical JSON encode (the byte-lock target; shared with the decoder's fixed-point check) ---
+
+// Canonical string per the seed's rules: minimal RFC 8259 escaping, '/' not escaped,
+// control chars as short-form or lowercase \u00XX, all else raw UTF-8.
+function encodeString(s: string): string {
+  let out = '"';
+  for (const ch of s) {
+    // iterate by code point (string iterator combines surrogate pairs)
+    switch (ch) {
+      case '"':
+        out += '\\"';
+        break;
+      case "\\":
+        out += "\\\\";
+        break;
+      case "\b":
+        out += "\\b";
+        break;
+      case "\f":
+        out += "\\f";
+        break;
+      case "\n":
+        out += "\\n";
+        break;
+      case "\r":
+        out += "\\r";
+        break;
+      case "\t":
+        out += "\\t";
+        break;
+      default: {
+        const code = ch.codePointAt(0) ?? 0;
+        if (code <= 0x1f) {
+          out += "\\u" + code.toString(16).padStart(4, "0");
+        } else {
+          out += ch; // raw UTF-8 (incl. non-ASCII / astral)
+        }
+      }
+    }
+  }
+  return out + '"';
+}
+
+export function canonicalJson(n: Tagged): string {
+  switch (n.t) {
+    case "null":
+      return "null";
+    case "bool":
+      return n.v ? "true" : "false";
+    case "int":
+      // re-canonicalize via BigInt: validates the int text is canonical (no leading
+      // zeros, no '+', '-' only for negatives) and arbitrary-precision-exact
+      return BigInt(n.v).toString();
+    case "str":
+      return encodeString(n.v);
+    case "arr":
+      return "[" + n.v.map(canonicalJson).join(",") + "]";
+    case "obj":
+      return "{" + n.v.map(([k, val]) => encodeString(k) + ":" + canonicalJson(val)).join(",") + "}";
+  }
+}
+
+// --- canonical JSON decode (inverse of canonicalJson) ---
+
+// Internal control-flow carrier: a decode failure throws this and is caught at the
+// fromCanonicalJson boundary, so the public API returns a DecodeResult, never throws.
+class JsonDecodeError extends Error {
+  readonly error: DecodeError;
+  constructor(error: DecodeError) {
+    super(error);
+    this.error = error;
+  }
+}
+
+const isDigit = (c: string): boolean => c >= "0" && c <= "9";
+
+// JSON simple (non-\u) escapes → their decoded character.
+const JSON_ESCAPES: Record<string, string> = {
+  '"': '"',
+  "\\": "\\",
+  "/": "/",
+  b: "\b",
+  f: "\f",
+  n: "\n",
+  r: "\r",
+  t: "\t",
+};
+
+/**
+ * Decode canonical JSON text into a {@link Tagged} value — the inverse of {@link canonicalJson}.
+ * Strictly canonical: a lenient recursive-descent parse, then one fixed-point check
+ * (`canonicalJson(parsed)` must equal the input) rejects every non-canonical form
+ * (insignificant whitespace, non-minimal escapes, leading zeros / '+' signs) as
+ * `NonCanonical`. int64 precision is preserved by reading the number token as text
+ * (`BigInt`), never via a JS number. A JSON number with a decimal point or exponent is a
+ * Float, which is DEFERRED in v1 → `Unsupported`. Never throws for malformed input.
+ */
+export function fromCanonicalJson(json: string): DecodeResult {
+  let pos = 0;
+  const fail = (e: DecodeError): never => {
+    throw new JsonDecodeError(e);
+  };
+
+  const skipWs = (): void => {
+    while (pos < json.length) {
+      const c = json.charAt(pos);
+      if (c === " " || c === "\t" || c === "\n" || c === "\r") pos += 1;
+      else break;
+    }
+  };
+
+  const expectLiteral = (lit: string): void => {
+    if (json.slice(pos, pos + lit.length) !== lit) fail("UnexpectedEnd");
+    pos += lit.length;
+  };
+
+  // reads one escape sequence (pos is at the backslash), advances pos past it, returns
+  // the decoded character. \uXXXX → the code unit; simple escapes via JSON_ESCAPES.
+  const readEscape = (): string => {
+    pos += 1; // past backslash
+    const e = json.charAt(pos);
+    if (e === "u") {
+      const hex = json.slice(pos + 1, pos + 5);
+      if (hex.length < 4) fail("UnexpectedEnd");
+      const code = parseInt(hex, 16);
+      if (Number.isNaN(code)) fail("UnexpectedEnd");
+      pos += 5; // 'u' + 4 hex digits
+      return String.fromCharCode(code);
+    }
+    const rep = JSON_ESCAPES[e];
+    if (rep === undefined) fail("UnexpectedEnd"); // invalid escape / EOF after backslash
+    pos += 1;
+    return rep ?? ""; // rep is defined here (fail threw); ?? satisfies the type narrowing
+  };
+
+  const parseString = (): string => {
+    pos += 1; // opening quote
+    let out = "";
+    while (pos < json.length) {
+      const c = json.charAt(pos);
+      if (c === '"') {
+        pos += 1;
+        return out;
+      }
+      if (c === "\\") {
+        out += readEscape();
+      } else {
+        out += c;
+        pos += 1;
+      }
+    }
+    return fail("UnexpectedEnd"); // unterminated string
+  };
+
+  const parseNumber = (): Tagged => {
+    const start = pos;
+    if (json.charAt(pos) === "-") pos += 1;
+    while (isDigit(json.charAt(pos))) pos += 1;
+    let isFloat = false;
+    if (json.charAt(pos) === ".") {
+      isFloat = true;
+      pos += 1;
+      while (isDigit(json.charAt(pos))) pos += 1;
+    }
+    const ec = json.charAt(pos);
+    if (ec === "e" || ec === "E") {
+      isFloat = true;
+      pos += 1;
+      const sign = json.charAt(pos);
+      if (sign === "+" || sign === "-") pos += 1;
+      while (isDigit(json.charAt(pos))) pos += 1;
+    }
+    const tok = json.slice(start, pos);
+    if (tok === "" || tok === "-") return fail("UnexpectedEnd");
+    if (isFloat) return fail("Unsupported"); // Float deferred in v1 JSON
+    const big = BigInt(tok);
+    if (big > I64_MAX || big < I64_MIN) return fail("IntegerOverflow");
+    return { t: "int", v: big.toString() };
+  };
+
+  const parseArray = (): Tagged => {
+    pos += 1; // past the opening bracket
+    const items: Tagged[] = [];
+    skipWs();
+    if (json.charAt(pos) === "]") {
+      pos += 1;
+      return { t: "arr", v: items };
+    }
+    while (pos < json.length) {
+      items.push(parseValue());
+      skipWs();
+      const c = json.charAt(pos);
+      if (c === ",") {
+        pos += 1;
+        continue;
+      }
+      if (c === "]") {
+        pos += 1;
+        return { t: "arr", v: items };
+      }
+      fail("UnexpectedEnd");
+    }
+    return fail("UnexpectedEnd");
+  };
+
+  const parseObject = (): Tagged => {
+    pos += 1; // past the opening brace
+    const pairs: [string, Tagged][] = [];
+    skipWs();
+    if (json.charAt(pos) === "}") {
+      pos += 1;
+      return { t: "obj", v: pairs };
+    }
+    while (pos < json.length) {
+      skipWs();
+      if (json.charAt(pos) !== '"') return fail("UnexpectedEnd"); // key must be a string
+      const key = parseString();
+      skipWs();
+      if (json.charAt(pos) !== ":") return fail("UnexpectedEnd");
+      pos += 1;
+      pairs.push([key, parseValue()]);
+      skipWs();
+      const c = json.charAt(pos);
+      if (c === ",") {
+        pos += 1;
+        continue;
+      }
+      if (c === "}") {
+        pos += 1;
+        return { t: "obj", v: pairs };
+      }
+      fail("UnexpectedEnd");
+    }
+    return fail("UnexpectedEnd");
+  };
+
+  function parseValue(): Tagged {
+    skipWs();
+    const c = json.charAt(pos);
+    if (c === "") fail("UnexpectedEnd");
+    switch (c) {
+      case "n":
+        expectLiteral("null");
+        return { t: "null" };
+      case "t":
+        expectLiteral("true");
+        return { t: "bool", v: true };
+      case "f":
+        expectLiteral("false");
+        return { t: "bool", v: false };
+      case '"':
+        return { t: "str", v: parseString() };
+      case "[":
+        return parseArray();
+      case "{":
+        return parseObject();
+      default:
+        if (c === "-" || isDigit(c)) return parseNumber();
+        return fail("UnexpectedEnd");
+    }
+  }
+
+  try {
+    const value = parseValue();
+    skipWs();
+    if (pos !== json.length) return { ok: false, error: "TrailingData" };
+    // canonical fixed-point: a canonical string re-encodes to itself; anything else (extra
+    // whitespace, non-minimal escapes, leading zeros) is well-formed but not canonical
+    if (canonicalJson(value) !== json) return { ok: false, error: "NonCanonical" };
+    return { ok: true, value };
+  } catch (e) {
+    if (e instanceof JsonDecodeError) return { ok: false, error: e.error };
+    throw e;
+  }
+}


### PR DESCRIPTION
Starts the **JSON decode set** (Aaron's "Both, CBOR then JSON"), mirroring the just-landed CBOR decode pattern. First of the four oracles (TS); C#/F#/Rust follow.

## What
- Extracts shared **`src/Core.TypeScript/dynamic-value/json.ts`** — encoder moved **verbatim** from `golden-vectors.test.ts` (encode byte-lock unchanged) + new **`fromCanonicalJson`** decoder + `DecodeError`/`DecodeResult` types.
- Repoints the encode test at the module; adds the decode test.

## Precision-safe + strict-canonical
- **int64 precision**: number tokens are read as **text** and parsed via `BigInt` (never a lossy JS `number`), with an i64 range check → `IntegerOverflow`. This is the whole reason a hand-rolled parser is needed (`JSON.parse` rounds `9223372036854775807`).
- **strict-canonical via fixed-point**: lenient recursive-descent parse, then one check — `canonicalJson(parsed) === input` → else `NonCanonical`. Rejects insignificant whitespace, non-minimal escapes (`\u0041` vs raw `A`), leading zeros, etc.
- **deferred shapes**: a number with `.`/`e`/`E` is a Float → `Unsupported` (Float + Bytes lock under CBOR, not JSON).
- never-throws: public API returns `DecodeResult`; internal `JsonDecodeError` caught at the boundary.

## Tests
Every seed vector decodes `ok` (fixed-point round-trip) + structural match incl. object key order; plus malformed (`UnexpectedEnd`/`TrailingData`), deferred-float (`Unsupported`), oversized (`IntegerOverflow`), and non-canonical rejections. **67 TS tests pass; tsc/eslint/prettier clean.**

`DecodeError`: `UnexpectedEnd | TrailingData | Unsupported | IntegerOverflow | NonCanonical` (no `NonTextKey` — JSON keys are syntactically strings). The compilers don't lie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)