### PR TITLE
feat(DynamicValue): C# canonical-JSON DECODE oracle — precision-safe + strict-canonical

### DIFF
--- a/src/Core.CSharp.DynamicValue/DynamicValues.cs
+++ b/src/Core.CSharp.DynamicValue/DynamicValues.cs
@@ -807,4 +807,400 @@ public static class DynamicValues
         arg = v;
         return null;
     }
+
+    /// <summary>Decodes canonical JSON text into a <see cref="DynamicValue"/> — the inverse of
+    /// <see cref="ToCanonicalJson"/>, completing the text↔value round-trip for the six locked shapes
+    /// (Float + Bytes are DEFERRED in JSON and lock under CBOR instead; a number with a decimal point
+    /// or exponent is a Float → <see cref="DecodeError.Unsupported"/>).
+    /// <para>Strictly canonical: a lenient recursive-descent parse, then one fixed-point check
+    /// (<c>ToCanonicalJson(decoded) == input</c>) rejects every non-canonical form (insignificant
+    /// whitespace, non-minimal escapes, leading zeros / '+' signs) as <see cref="DecodeError.NonCanonical"/>.
+    /// int64 precision is preserved by parsing the number token as text (<see cref="long"/>), never via a
+    /// double. Surfaced as data via <see cref="Result{T, TError}"/>, never thrown. Mirrors the TS/F#/Rust
+    /// decoder.</para></summary>
+    /// <param name="json">canonical JSON text.</param>
+    /// <returns><see cref="Result{T, TError}.Ok"/> with the decoded value, or
+    /// <see cref="Result{T, TError}.Err"/> carrying the <see cref="DecodeError"/>.</returns>
+    public static Result<DynamicValue, DecodeError> FromCanonicalJson(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+        int pos = 0;
+        DecodeError? err = TryReadJsonValue(json, ref pos, out DynamicValue value);
+        if (err is DecodeError e)
+        {
+            return new Result<DynamicValue, DecodeError>.Err(e);
+        }
+
+        SkipJsonWs(json, ref pos);
+        if (pos != json.Length)
+        {
+            return new Result<DynamicValue, DecodeError>.Err(DecodeError.TrailingData);
+        }
+
+        // Canonical-form fixed-point: a canonical string re-encodes to itself. The decoder only
+        // produces the six locked shapes, so ToCanonicalJson is always Ok here; anything else (extra
+        // whitespace, non-minimal escapes, leading zeros) is well-formed but not canonical.
+        if (ToCanonicalJson(value) is not Result<string, EncodeError>.Ok reEnc
+            || !string.Equals(reEnc.Value, json, StringComparison.Ordinal))
+        {
+            return new Result<DynamicValue, DecodeError>.Err(DecodeError.NonCanonical);
+        }
+
+        return new Result<DynamicValue, DecodeError>.Ok(value);
+    }
+
+    private static void SkipJsonWs(string s, ref int pos)
+    {
+        while (pos < s.Length && (s[pos] == ' ' || s[pos] == '\t' || s[pos] == '\n' || s[pos] == '\r'))
+        {
+            pos++;
+        }
+    }
+
+    // Reads one JSON value at `pos`, advancing it. Returns null on success (value set), else the error.
+    private static DecodeError? TryReadJsonValue(string s, ref int pos, out DynamicValue value)
+    {
+        value = new DynamicValue.Null();
+        SkipJsonWs(s, ref pos);
+        if (pos >= s.Length)
+        {
+            return DecodeError.UnexpectedEnd;
+        }
+
+        char c = s[pos];
+        switch (c)
+        {
+            case 'n':
+                return TryReadJsonLiteral(s, ref pos, "null", new DynamicValue.Null(), out value);
+            case 't':
+                return TryReadJsonLiteral(s, ref pos, "true", new DynamicValue.Bool(true), out value);
+            case 'f':
+                return TryReadJsonLiteral(s, ref pos, "false", new DynamicValue.Bool(false), out value);
+            case '"':
+                return TryReadJsonString(s, ref pos, out value);
+            case '[':
+                return TryReadJsonArray(s, ref pos, out value);
+            case '{':
+                return TryReadJsonObject(s, ref pos, out value);
+            default:
+                if (c == '-' || (c >= '0' && c <= '9'))
+                {
+                    return TryReadJsonNumber(s, ref pos, out value);
+                }
+
+                return DecodeError.UnexpectedEnd;
+        }
+    }
+
+    private static DecodeError? TryReadJsonLiteral(
+        string s, ref int pos, string lit, DynamicValue lifted, out DynamicValue value)
+    {
+        value = new DynamicValue.Null();
+        if (pos + lit.Length > s.Length || !s.AsSpan(pos, lit.Length).SequenceEqual(lit))
+        {
+            return DecodeError.UnexpectedEnd;
+        }
+
+        pos += lit.Length;
+        value = lifted;
+        return null;
+    }
+
+    // Reads a JSON string body into `result` (pos is at the opening quote). Lenient on escapes;
+    // the fixed-point check rejects non-canonical escapes (e.g. A for raw "A") as NonCanonical.
+    private static DecodeError? TryReadJsonStringRaw(string s, ref int pos, out string result)
+    {
+        result = string.Empty;
+        var sb = new StringBuilder();
+        pos++; // opening quote
+        while (pos < s.Length)
+        {
+            char c = s[pos];
+            if (c == '"')
+            {
+                pos++;
+                result = sb.ToString();
+                return null;
+            }
+
+            if (c == '\\')
+            {
+                DecodeError? escErr = ReadJsonEscape(s, ref pos, sb);
+                if (escErr is DecodeError ee)
+                {
+                    return ee;
+                }
+            }
+            else
+            {
+                sb.Append(c);
+                pos++;
+            }
+        }
+
+        return DecodeError.UnexpectedEnd; // unterminated string
+    }
+
+    // Reads one escape sequence (pos at the backslash), appends the decoded char, advances pos.
+    private static DecodeError? ReadJsonEscape(string s, ref int pos, StringBuilder sb)
+    {
+        pos++; // past backslash
+        if (pos >= s.Length)
+        {
+            return DecodeError.UnexpectedEnd;
+        }
+
+        char e = s[pos];
+        if (e == 'u')
+        {
+            if (pos + 5 > s.Length)
+            {
+                return DecodeError.UnexpectedEnd; // 'u' + 4 hex digits
+            }
+
+            // require exactly 4 hex digits — a partial parse would silently accept malformed \uXXXX
+            if (!ushort.TryParse(
+                    s.AsSpan(pos + 1, 4), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ushort code))
+            {
+                return DecodeError.UnexpectedEnd;
+            }
+
+            sb.Append((char)code);
+            pos += 5; // 'u' + 4 hex
+            return null;
+        }
+
+        char? rep = e switch
+        {
+            '"' => '"',
+            '\\' => '\\',
+            '/' => '/',
+            'b' => '\b',
+            'f' => '\f',
+            'n' => '\n',
+            'r' => '\r',
+            't' => '\t',
+            _ => (char?)null,
+        };
+        if (rep is not char rc)
+        {
+            return DecodeError.UnexpectedEnd; // invalid escape
+        }
+
+        sb.Append(rc);
+        pos++; // past escape char
+        return null;
+    }
+
+    private static DecodeError? TryReadJsonString(string s, ref int pos, out DynamicValue value)
+    {
+        value = new DynamicValue.Null();
+        DecodeError? err = TryReadJsonStringRaw(s, ref pos, out string str);
+        if (err is DecodeError e)
+        {
+            return e;
+        }
+
+        value = new DynamicValue.String(str);
+        return null;
+    }
+
+    // Consumes one or more digits at pos; UnexpectedEnd if none (enforces the JSON grammar's
+    // "at least one digit" for the integer part, fraction, and exponent).
+    private static DecodeError? ConsumeJsonDigits(string s, ref int pos)
+    {
+        int d0 = pos;
+        while (pos < s.Length && s[pos] >= '0' && s[pos] <= '9')
+        {
+            pos++;
+        }
+
+        return pos == d0 ? DecodeError.UnexpectedEnd : null;
+    }
+
+    private static DecodeError? TryReadJsonNumber(string s, ref int pos, out DynamicValue value)
+    {
+        value = new DynamicValue.Null();
+        int start = pos;
+        if (s[pos] == '-')
+        {
+            pos++;
+        }
+
+        if (ConsumeJsonDigits(s, ref pos) is DecodeError intErr) // integer part — required ("-", "-.5")
+        {
+            return intErr;
+        }
+
+        bool isFloat = false;
+        if (pos < s.Length && s[pos] == '.')
+        {
+            isFloat = true;
+            pos++;
+            if (ConsumeJsonDigits(s, ref pos) is DecodeError fracErr) // fraction — required after '.'
+            {
+                return fracErr;
+            }
+        }
+
+        if (pos < s.Length && (s[pos] == 'e' || s[pos] == 'E'))
+        {
+            isFloat = true;
+            pos++;
+            if (pos < s.Length && (s[pos] == '+' || s[pos] == '-'))
+            {
+                pos++;
+            }
+
+            if (ConsumeJsonDigits(s, ref pos) is DecodeError expErr) // exponent — required ("1e", "1e+")
+            {
+                return expErr;
+            }
+        }
+
+        if (isFloat)
+        {
+            return DecodeError.Unsupported; // Float deferred in v1 JSON
+        }
+
+        // token is `-?[0-9]+`, so the only way long.TryParse fails is int64 overflow
+        if (!long.TryParse(
+                s.AsSpan(start, pos - start), NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out long n))
+        {
+            return DecodeError.IntegerOverflow;
+        }
+
+        value = new DynamicValue.Int(n);
+        return null;
+    }
+
+    private static DecodeError? TryReadJsonArray(string s, ref int pos, out DynamicValue value)
+    {
+        value = new DynamicValue.Null();
+        pos++; // past the opening bracket
+        var items = ImmutableArray.CreateBuilder<DynamicValue>();
+        SkipJsonWs(s, ref pos);
+        if (pos < s.Length && s[pos] == ']')
+        {
+            pos++;
+            value = new DynamicValue.Array(items.ToImmutable());
+            return null;
+        }
+
+        while (pos < s.Length)
+        {
+            DecodeError? itemErr = TryReadJsonValue(s, ref pos, out DynamicValue item);
+            if (itemErr is DecodeError ie)
+            {
+                return ie;
+            }
+
+            items.Add(item);
+            SkipJsonWs(s, ref pos);
+            if (pos >= s.Length)
+            {
+                break;
+            }
+
+            char c = s[pos];
+            if (c == ',')
+            {
+                pos++;
+                continue;
+            }
+
+            if (c == ']')
+            {
+                pos++;
+                value = new DynamicValue.Array(items.ToImmutable());
+                return null;
+            }
+
+            return DecodeError.UnexpectedEnd;
+        }
+
+        return DecodeError.UnexpectedEnd;
+    }
+
+    // Reads one "key": value pair (pos at the opening quote of the key), advancing pos.
+    private static DecodeError? TryReadJsonPair(
+        string s, ref int pos, out KeyValuePair<string, DynamicValue> pair)
+    {
+        pair = default;
+        DecodeError? keyErr = TryReadJsonStringRaw(s, ref pos, out string key);
+        if (keyErr is DecodeError ke)
+        {
+            return ke;
+        }
+
+        SkipJsonWs(s, ref pos);
+        if (pos >= s.Length || s[pos] != ':')
+        {
+            return DecodeError.UnexpectedEnd;
+        }
+
+        pos++;
+        DecodeError? valErr = TryReadJsonValue(s, ref pos, out DynamicValue val);
+        if (valErr is DecodeError ve)
+        {
+            return ve;
+        }
+
+        pair = new KeyValuePair<string, DynamicValue>(key, val);
+        return null;
+    }
+
+    private static DecodeError? TryReadJsonObject(string s, ref int pos, out DynamicValue value)
+    {
+        value = new DynamicValue.Null();
+        pos++; // past the opening brace
+        var pairs = ImmutableArray.CreateBuilder<KeyValuePair<string, DynamicValue>>();
+        SkipJsonWs(s, ref pos);
+        if (pos < s.Length && s[pos] == '}')
+        {
+            pos++;
+            value = new DynamicValue.Object(pairs.ToImmutable());
+            return null;
+        }
+
+        while (pos < s.Length)
+        {
+            SkipJsonWs(s, ref pos);
+            if (pos >= s.Length || s[pos] != '"')
+            {
+                return DecodeError.UnexpectedEnd; // key must be a string
+            }
+
+            DecodeError? pairErr = TryReadJsonPair(s, ref pos, out KeyValuePair<string, DynamicValue> pair);
+            if (pairErr is DecodeError pe)
+            {
+                return pe;
+            }
+
+            pairs.Add(pair);
+            SkipJsonWs(s, ref pos);
+            if (pos >= s.Length)
+            {
+                break;
+            }
+
+            char c = s[pos];
+            if (c == ',')
+            {
+                pos++;
+                continue;
+            }
+
+            if (c == '}')
+            {
+                pos++;
+                value = new DynamicValue.Object(pairs.ToImmutable());
+                return null;
+            }
+
+            return DecodeError.UnexpectedEnd;
+        }
+
+        return DecodeError.UnexpectedEnd;
+    }
 }

--- a/tests/Tests.CSharp/DynamicValueJsonDecodeTests.cs
+++ b/tests/Tests.CSharp/DynamicValueJsonDecodeTests.cs
@@ -1,0 +1,146 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+using Zeta.Core.CSharp;
+
+namespace Zeta.Tests.CSharp;
+
+/// <summary>
+/// DynamicValue canonical-JSON DECODE byte-lock — <see cref="DynamicValues.FromCanonicalJson"/> is
+/// the inverse of <see cref="DynamicValues.ToCanonicalJson"/>, completing the text↔value round-trip
+/// for the six locked shapes (Float + Bytes are DEFERRED in JSON — they lock under CBOR). Primary
+/// check is the round-trip <c>ToCanonicalJson(FromCanonicalJson(s)) == s</c> over the shared seed
+/// (sound because canonical encode is bijective). A direct structural <c>decode == value</c> check
+/// runs too (C# DynamicValue has structural equality). int64 precision is preserved by parsing the
+/// number token as text. "The compilers don't lie."
+/// </summary>
+public class DynamicValueJsonDecodeTests
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(Path.GetDirectoryName(typeof(DynamicValueJsonDecodeTests).Assembly.Location)!);
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "Zeta.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName
+            ?? throw new InvalidOperationException("Could not locate repo root (Zeta.sln) from test assembly location.");
+    }
+
+    private static string Str(JsonElement el, string prop) =>
+        el.GetProperty(prop).GetString()
+            ?? throw new InvalidOperationException($"fixture property '{prop}' is not a string: {el.GetRawText()}");
+
+    private static DynamicValue BuildValue(JsonElement el)
+    {
+        string tag = Str(el, "t");
+        switch (tag)
+        {
+            case "null":
+                return new DynamicValue.Null();
+            case "bool":
+                return new DynamicValue.Bool(el.GetProperty("v").GetBoolean());
+            case "int":
+                return new DynamicValue.Int(long.Parse(Str(el, "v"), CultureInfo.InvariantCulture));
+            case "str":
+                return new DynamicValue.String(Str(el, "v"));
+            case "arr":
+                return new DynamicValue.Array(
+                    el.GetProperty("v").EnumerateArray().Select(BuildValue).ToImmutableArray());
+            case "obj":
+                return new DynamicValue.Object(
+                    el.GetProperty("v").EnumerateArray()
+                        .Select(pair =>
+                        {
+                            JsonElement[] parts = pair.EnumerateArray().ToArray();
+                            string key = parts[0].GetString()
+                                ?? throw new InvalidOperationException("object key is not a string");
+                            return new KeyValuePair<string, DynamicValue>(key, BuildValue(parts[1]));
+                        })
+                        .ToImmutableArray());
+            default:
+                throw new InvalidOperationException($"unsupported tag in JSON seed: {tag}");
+        }
+    }
+
+    [Fact]
+    public void CSharpJsonDecodeRoundTripsSeed()
+    {
+        string path = Path.Join(RepoRoot(), "src", "Core.TypeScript", "dynamic-value", "golden-vectors.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        JsonElement[] vectors = doc.RootElement.GetProperty("vectors").EnumerateArray().ToArray();
+        Assert.NotEmpty(vectors);
+
+        var failures = new List<string>();
+        foreach (JsonElement v in vectors)
+        {
+            string name = Str(v, "name");
+            string json = Str(v, "json");
+
+            switch (DynamicValues.FromCanonicalJson(json))
+            {
+                case Result<DynamicValue, DecodeError>.Ok ok:
+                    // (a) round-trip: re-encoding the decoded value reproduces the canonical JSON
+                    string reEncoded = DynamicValues.ToCanonicalJson(ok.Value) is Result<string, EncodeError>.Ok e
+                        ? e.Value
+                        : "<encode-error>";
+                    if (!string.Equals(reEncoded, json, StringComparison.Ordinal))
+                    {
+                        failures.Add($"{name}: re-encode {reEncoded} != {json}");
+                    }
+
+                    // (b) structural: the decoded value equals the expected value
+                    DynamicValue expected = BuildValue(v.GetProperty("value"));
+                    if (!ok.Value.Equals(expected))
+                    {
+                        failures.Add($"{name}: decoded value != expected");
+                    }
+
+                    break;
+                case Result<DynamicValue, DecodeError>.Err err:
+                    failures.Add($"{name}: decode failed with {err.Error}");
+                    break;
+                default:
+                    failures.Add($"{name}: unexpected Result shape");
+                    break;
+            }
+        }
+
+        Assert.Empty(failures);
+    }
+
+    [Theory]
+    [InlineData("", DecodeError.UnexpectedEnd)] // empty
+    [InlineData("tru", DecodeError.UnexpectedEnd)] // truncated literal
+    [InlineData("[1,", DecodeError.UnexpectedEnd)] // unterminated array
+    [InlineData("{\"a\"", DecodeError.UnexpectedEnd)] // object missing colon+value
+    [InlineData("\"unterminated", DecodeError.UnexpectedEnd)] // unterminated string
+    [InlineData("\"\\u00gg\"", DecodeError.UnexpectedEnd)] // \uXXXX with non-hex digits
+    [InlineData("\"\\q\"", DecodeError.UnexpectedEnd)] // invalid escape
+    [InlineData("1.", DecodeError.UnexpectedEnd)] // no digit after '.'
+    [InlineData("1e", DecodeError.UnexpectedEnd)] // no exponent digits
+    [InlineData("1e+", DecodeError.UnexpectedEnd)] // exponent sign without digits
+    [InlineData("-", DecodeError.UnexpectedEnd)] // sign without digits
+    [InlineData("null x", DecodeError.TrailingData)] // value + trailing token
+    [InlineData("nullnull", DecodeError.TrailingData)] // two values
+    [InlineData("1.5", DecodeError.Unsupported)] // Float deferred
+    [InlineData("1e10", DecodeError.Unsupported)] // Float (exponent) deferred
+    [InlineData("-0.0", DecodeError.Unsupported)] // Float deferred
+    [InlineData("9223372036854775808", DecodeError.IntegerOverflow)] // i64::MAX + 1
+    [InlineData("-9223372036854775809", DecodeError.IntegerOverflow)] // i64::MIN - 1
+    [InlineData(" null", DecodeError.NonCanonical)] // leading whitespace
+    [InlineData("[1, 2]", DecodeError.NonCanonical)] // space after comma
+    [InlineData("01", DecodeError.NonCanonical)] // leading zero (parses to 1 → "1")
+    [InlineData("\"\\u0041\"", DecodeError.NonCanonical)] // A; canonical emits raw "A"
+    [InlineData("{ \"a\":1}", DecodeError.NonCanonical)] // whitespace inside object
+    public void JsonDecodeRejects(string json, DecodeError expected)
+    {
+        var result = DynamicValues.FromCanonicalJson(json);
+        var err = Assert.IsType<Result<DynamicValue, DecodeError>.Err>(result);
+        Assert.Equal(expected, err.Error);
+    }
+}


### PR DESCRIPTION
Second of the four JSON-decode oracles (TS #6518 landed; F#/Rust follow). `FromCanonicalJson` is the inverse of `ToCanonicalJson` for the 6 locked shapes (Float + Bytes DEFERRED in JSON — they lock under CBOR).

## What
- Adds `FromCanonicalJson` + private recursive-descent readers to `DynamicValues.cs`, mirroring the CBOR `TryReadX(ref pos): DecodeError?` pattern + the **shared `DecodeError` enum** + the fixed-point canonical check.
- `DynamicValueJsonDecodeTests.cs`: round-trip over the seed (re-encode + structural equality) + 23 rejection cases.

## Precision-safe + strict-canonical
- **int64 precision**: number token parsed as **text** via `long.TryParse` (never a lossy `double`); on a `-?[0-9]+` token the only failure is overflow → `IntegerOverflow`.
- **fixed-point**: `ToCanonicalJson(decoded) == input` → else `NonCanonical` (rejects whitespace, non-minimal escapes, leading zeros).
- **deferred**: a number with `.`/`e`/`E` is a Float → `Unsupported`.
- **carries the TS oracle's malformed-input lessons in from the start**: `\uXXXX` requires exactly 4 hex digits (`ushort.TryParse` on the 4-char span); `.`/exponent require digits (`ConsumeJsonDigits`) — so `1.`/`1e`/`1e+` → `UnexpectedEnd`, not `Unsupported`.
- never thrown: `Result<DynamicValue, DecodeError>` per the Result-over-exception rule.

**24 tests pass; Release build 0-warnings** (split `TryReadJsonPair` out of `TryReadJsonObject` for MA0051). The compilers don't lie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)