### PR TITLE
feat(DynamicValue): F# canonical-JSON DECODE oracle — precision-safe + strict-canonical

### DIFF
--- a/src/Core/DynamicValue.fs
+++ b/src/Core/DynamicValue.fs
@@ -709,3 +709,246 @@ module DynamicValue =
                 Error DecodeError.NonCanonical
             else
                 Ok value
+
+    /// Decodes canonical JSON text into a `DynamicValue` — the inverse of `toCanonicalJson`,
+    /// completing the text↔value round-trip for the six locked shapes (Float + Bytes are DEFERRED
+    /// in JSON and lock under CBOR; a number with a decimal point or exponent is a Float ->
+    /// `DecodeError.Unsupported`). Strictly canonical: a lenient recursive-descent parse, then one
+    /// fixed-point check (`toCanonicalJson decoded = input`) rejects every non-canonical form
+    /// (insignificant whitespace, non-minimal escapes, leading zeros / '+' signs) as
+    /// `DecodeError.NonCanonical`. int64 precision is preserved by parsing the number token as text,
+    /// never via a float. Surfaced as data via `Result`, never thrown. Mirrors the TS/C#/Rust decoder.
+    let fromCanonicalJson (json: string) : Result<DynamicValue, DecodeError> =
+        let mutable pos = 0
+        let len = json.Length
+
+        let skipWs () =
+            while pos < len
+                  && (json.[pos] = ' ' || json.[pos] = '\t' || json.[pos] = '\n' || json.[pos] = '\r') do
+                pos <- pos + 1
+
+        let isDigit c = c >= '0' && c <= '9'
+
+        // consumes one or more digits at pos; UnexpectedEnd if none (the JSON grammar's
+        // "at least one digit" for the integer part, fraction, and exponent)
+        let consumeDigits () : Result<unit, DecodeError> =
+            let d0 = pos
+
+            while pos < len && isDigit json.[pos] do
+                pos <- pos + 1
+
+            if pos = d0 then Error DecodeError.UnexpectedEnd else Ok()
+
+        // reads one escape (pos at the backslash), returns the decoded char, advances pos
+        let readEscape () : Result<char, DecodeError> =
+            pos <- pos + 1 // past backslash
+
+            if pos >= len then
+                Error DecodeError.UnexpectedEnd
+            elif json.[pos] = 'u' then
+                if pos + 5 > len then
+                    Error DecodeError.UnexpectedEnd // 'u' + 4 hex digits
+                else
+                    // require exactly 4 hex digits — a partial parse would silently accept malformed \uXXXX
+                    match
+                        System.UInt16.TryParse(
+                            json.Substring(pos + 1, 4),
+                            System.Globalization.NumberStyles.HexNumber,
+                            System.Globalization.CultureInfo.InvariantCulture
+                        )
+                    with
+                    | true, code ->
+                        pos <- pos + 5 // 'u' + 4 hex
+                        Ok(char code)
+                    | false, _ -> Error DecodeError.UnexpectedEnd
+            else
+                let rep =
+                    match json.[pos] with
+                    | '"' -> Some '"'
+                    | '\\' -> Some '\\'
+                    | '/' -> Some '/'
+                    | 'b' -> Some '\b'
+                    | 'f' -> Some '\f'
+                    | 'n' -> Some '\n'
+                    | 'r' -> Some '\r'
+                    | 't' -> Some '\t'
+                    | _ -> None
+
+                match rep with
+                | Some c ->
+                    pos <- pos + 1
+                    Ok c
+                | None -> Error DecodeError.UnexpectedEnd // invalid escape
+
+        let readString () : Result<string, DecodeError> =
+            pos <- pos + 1 // opening quote
+            let sb = System.Text.StringBuilder()
+
+            let rec loop () : Result<string, DecodeError> =
+                if pos >= len then
+                    Error DecodeError.UnexpectedEnd // unterminated
+                else
+                    let c = json.[pos]
+
+                    if c = '"' then
+                        pos <- pos + 1
+                        Ok(sb.ToString())
+                    elif c = '\\' then
+                        match readEscape () with
+                        | Error e -> Error e
+                        | Ok ch ->
+                            sb.Append(ch) |> ignore
+                            loop ()
+                    else
+                        sb.Append(c) |> ignore
+                        pos <- pos + 1
+                        loop ()
+
+            loop ()
+
+        let readNumber () : Result<DynamicValue, DecodeError> =
+            let start = pos
+
+            if pos < len && json.[pos] = '-' then
+                pos <- pos + 1
+
+            let readFrac () =
+                if pos < len && json.[pos] = '.' then
+                    pos <- pos + 1
+                    consumeDigits () |> Result.map (fun () -> true) // fraction required after '.'
+                else
+                    Ok false
+
+            let readExp () =
+                if pos < len && (json.[pos] = 'e' || json.[pos] = 'E') then
+                    pos <- pos + 1
+
+                    if pos < len && (json.[pos] = '+' || json.[pos] = '-') then
+                        pos <- pos + 1
+
+                    consumeDigits () |> Result.map (fun () -> true) // exponent digits required
+                else
+                    Ok false
+
+            consumeDigits () // integer part — required (rejects "-", "-.5")
+            |> Result.bind readFrac
+            |> Result.bind (fun hasFrac -> readExp () |> Result.map (fun hasExp -> hasFrac || hasExp))
+            |> Result.bind (fun isFloat ->
+                if isFloat then
+                    Error DecodeError.Unsupported // Float deferred in v1 JSON
+                else
+                    match
+                        System.Int64.TryParse(
+                            json.Substring(start, pos - start),
+                            System.Globalization.NumberStyles.AllowLeadingSign,
+                            System.Globalization.CultureInfo.InvariantCulture
+                        )
+                    with
+                    | true, n -> Ok(DynamicValue.Int n)
+                    | false, _ -> Error DecodeError.IntegerOverflow) // token is -?[0-9]+, so only overflow fails
+
+        let rec readValue () : Result<DynamicValue, DecodeError> =
+            skipWs ()
+
+            if pos >= len then
+                Error DecodeError.UnexpectedEnd
+            else
+                match json.[pos] with
+                | 'n' -> readLiteral "null" DynamicValue.Null
+                | 't' -> readLiteral "true" (DynamicValue.Bool true)
+                | 'f' -> readLiteral "false" (DynamicValue.Bool false)
+                | '"' -> readString () |> Result.map DynamicValue.String
+                | '[' -> readArray ()
+                | '{' -> readObject ()
+                | c when c = '-' || isDigit c -> readNumber ()
+                | _ -> Error DecodeError.UnexpectedEnd
+
+        and readLiteral (lit: string) (lifted: DynamicValue) : Result<DynamicValue, DecodeError> =
+            if pos + lit.Length > len || System.String.CompareOrdinal(json, pos, lit, 0, lit.Length) <> 0 then
+                Error DecodeError.UnexpectedEnd
+            else
+                pos <- pos + lit.Length
+                Ok lifted
+
+        and readArray () : Result<DynamicValue, DecodeError> =
+            pos <- pos + 1 // past the opening bracket
+            skipWs ()
+
+            if pos < len && json.[pos] = ']' then
+                pos <- pos + 1
+                Ok(DynamicValue.Array [])
+            else
+                let rec loop acc =
+                    match readValue () with
+                    | Error e -> Error e
+                    | Ok item ->
+                        skipWs ()
+
+                        if pos >= len then
+                            Error DecodeError.UnexpectedEnd
+                        elif json.[pos] = ',' then
+                            pos <- pos + 1
+                            loop (item :: acc)
+                        elif json.[pos] = ']' then
+                            pos <- pos + 1
+                            Ok(DynamicValue.Array(List.rev (item :: acc)))
+                        else
+                            Error DecodeError.UnexpectedEnd
+
+                loop []
+
+        and readObject () : Result<DynamicValue, DecodeError> =
+            pos <- pos + 1 // past the opening brace
+            skipWs ()
+
+            if pos < len && json.[pos] = '}' then
+                pos <- pos + 1
+                Ok(DynamicValue.Object [])
+            else
+                let rec loop acc =
+                    skipWs ()
+
+                    if pos >= len || json.[pos] <> '"' then
+                        Error DecodeError.UnexpectedEnd // key must be a string
+                    else
+                        match readString () with
+                        | Error e -> Error e
+                        | Ok key ->
+                            skipWs ()
+
+                            if pos >= len || json.[pos] <> ':' then
+                                Error DecodeError.UnexpectedEnd
+                            else
+                                pos <- pos + 1
+
+                                match readValue () with
+                                | Error e -> Error e
+                                | Ok v ->
+                                    skipWs ()
+
+                                    if pos >= len then
+                                        Error DecodeError.UnexpectedEnd
+                                    elif json.[pos] = ',' then
+                                        pos <- pos + 1
+                                        loop ((key, v) :: acc)
+                                    elif json.[pos] = '}' then
+                                        pos <- pos + 1
+                                        Ok(DynamicValue.Object(List.rev ((key, v) :: acc)))
+                                    else
+                                        Error DecodeError.UnexpectedEnd
+
+                loop []
+
+        match readValue () with
+        | Error e -> Error e
+        | Ok value ->
+            skipWs ()
+
+            if pos <> len then
+                Error DecodeError.TrailingData
+            else
+                // canonical fixed-point: a canonical string re-encodes to itself; the decoder only
+                // produces the six locked shapes, so toCanonicalJson is always Ok here
+                match toCanonicalJson value with
+                | Ok s when System.String.Equals(s, json, System.StringComparison.Ordinal) -> Ok value
+                | _ -> Error DecodeError.NonCanonical

--- a/src/Core/DynamicValue.fs
+++ b/src/Core/DynamicValue.fs
@@ -749,11 +749,12 @@ module DynamicValue =
                 if pos + 5 > len then
                     Error DecodeError.UnexpectedEnd // 'u' + 4 hex digits
                 else
-                    // require exactly 4 hex digits — a partial parse would silently accept malformed \uXXXX
+                    // require exactly 4 hex digits — AllowHexSpecifier (NOT HexNumber, which also
+                    // permits leading/trailing whitespace) so a "\u 001"-style escape is rejected
                     match
                         System.UInt16.TryParse(
                             json.Substring(pos + 1, 4),
-                            System.Globalization.NumberStyles.HexNumber,
+                            System.Globalization.NumberStyles.AllowHexSpecifier,
                             System.Globalization.CultureInfo.InvariantCulture
                         )
                     with

--- a/src/Core/DynamicValue.fs
+++ b/src/Core/DynamicValue.fs
@@ -715,8 +715,9 @@ module DynamicValue =
     /// in JSON and lock under CBOR; a number with a decimal point or exponent is a Float ->
     /// `DecodeError.Unsupported`). Strictly canonical: a lenient recursive-descent parse, then one
     /// fixed-point check (`toCanonicalJson decoded = input`) rejects every non-canonical form
-    /// (insignificant whitespace, non-minimal escapes, leading zeros / '+' signs) as
-    /// `DecodeError.NonCanonical`. int64 precision is preserved by parsing the number token as text,
+    /// (insignificant whitespace, non-minimal escapes, leading zeros) as
+    /// `DecodeError.NonCanonical` (a leading '+' is invalid JSON → `UnexpectedEnd`, not non-canonical).
+    /// int64 precision is preserved by parsing the number token as text,
     /// never via a float. Surfaced as data via `Result`, never thrown. Mirrors the TS/C#/Rust decoder.
     let fromCanonicalJson (json: string) : Result<DynamicValue, DecodeError> =
         let mutable pos = 0
@@ -753,7 +754,7 @@ module DynamicValue =
                     // permits leading/trailing whitespace) so a "\u 001"-style escape is rejected
                     match
                         System.UInt16.TryParse(
-                            json.Substring(pos + 1, 4),
+                            System.MemoryExtensions.AsSpan(json, pos + 1, 4),
                             System.Globalization.NumberStyles.AllowHexSpecifier,
                             System.Globalization.CultureInfo.InvariantCulture
                         )
@@ -840,7 +841,7 @@ module DynamicValue =
                 else
                     match
                         System.Int64.TryParse(
-                            json.Substring(start, pos - start),
+                            System.MemoryExtensions.AsSpan(json, start, pos - start),
                             System.Globalization.NumberStyles.AllowLeadingSign,
                             System.Globalization.CultureInfo.InvariantCulture
                         )

--- a/tests/Tests.FSharp/DynamicValue.JsonDecode.Tests.fs
+++ b/tests/Tests.FSharp/DynamicValue.JsonDecode.Tests.fs
@@ -1,0 +1,104 @@
+module Zeta.Tests.DynamicValueJsonDecodeTests
+
+open System.IO
+open System.Reflection
+open System.Globalization
+open System.Text.Json
+open global.Xunit
+open Zeta.Core
+
+// DynamicValue canonical-JSON DECODE byte-lock — DynamicValue.fromCanonicalJson is the inverse of
+// toCanonicalJson for the six locked shapes (Float + Bytes are DEFERRED in JSON — they lock under
+// CBOR). Strictly canonical (fixed-point check toCanonicalJson(decode s) = s → DecodeError.NonCanonical);
+// int64 precision is preserved by parsing the number token as text. Asserts decode round-trips the
+// seed structurally + malformed / deferred-float / oversized / non-canonical inputs are rejected with
+// the right DecodeError. "The compilers don't lie."
+
+let private repoRoot () : string =
+    let mutable dir = DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))
+
+    while not (isNull dir) && not (File.Exists(Path.Join(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+
+    if isNull dir then
+        failwith "Could not locate repo root (Zeta.sln) from test assembly location."
+
+    dir.FullName
+
+let private children (el: JsonElement) : JsonElement[] =
+    [| for child in el.EnumerateArray() -> child |]
+
+let rec private buildValue (el: JsonElement) : DynamicValue =
+    match el.GetProperty("t").GetString() with
+    | "null" -> DynamicValue.Null
+    | "bool" -> DynamicValue.Bool(el.GetProperty("v").GetBoolean())
+    | "int" -> DynamicValue.Int(System.Int64.Parse(el.GetProperty("v").GetString(), CultureInfo.InvariantCulture))
+    | "str" -> DynamicValue.String(el.GetProperty("v").GetString())
+    | "arr" -> DynamicValue.Array(children (el.GetProperty "v") |> Array.map buildValue |> Array.toList)
+    | "obj" ->
+        DynamicValue.Object(
+            children (el.GetProperty "v")
+            |> Array.map (fun pair ->
+                let parts = children pair
+                (parts.[0].GetString(), buildValue parts.[1]))
+            |> Array.toList)
+    | other -> failwithf "unsupported tag in JSON seed: %s" other
+
+[<Fact>]
+let ``F# JSON decode round-trips the seed`` () =
+    let path =
+        Path.Join(repoRoot (), "src", "Core.TypeScript", "dynamic-value", "golden-vectors.json")
+
+    use doc = JsonDocument.Parse(File.ReadAllText path)
+    let vectors = children (doc.RootElement.GetProperty "vectors")
+    Assert.NotEmpty vectors
+
+    let failures =
+        vectors
+        |> Array.choose (fun v ->
+            let name = v.GetProperty("name").GetString()
+            let json = v.GetProperty("json").GetString()
+            let expected = buildValue (v.GetProperty "value")
+
+            match DynamicValue.fromCanonicalJson json with
+            | Ok decoded when decoded = expected -> None
+            | Ok _ -> Some(sprintf "%s: decoded value != expected" name)
+            | Error e -> Some(sprintf "%s: decode failed with %A" name e))
+
+    Assert.True(Array.isEmpty failures, System.String.Join("\n", failures))
+
+[<Fact>]
+let ``F# JSON decode rejects malformed, deferred, oversized, and non-canonical`` () =
+    let err (s: string) =
+        match DynamicValue.fromCanonicalJson s with
+        | Error e -> e
+        | Ok _ -> failwith "expected Error"
+
+    // malformed
+    Assert.Equal(DecodeError.UnexpectedEnd, err "") // empty
+    Assert.Equal(DecodeError.UnexpectedEnd, err "tru") // truncated literal
+    Assert.Equal(DecodeError.UnexpectedEnd, err "[1,") // unterminated array
+    Assert.Equal(DecodeError.UnexpectedEnd, err "{\"a\"") // object missing colon+value
+    Assert.Equal(DecodeError.UnexpectedEnd, err "\"unterminated") // unterminated string
+    Assert.Equal(DecodeError.UnexpectedEnd, err "\"\\u00gg\"") // \uXXXX with non-hex digits
+    Assert.Equal(DecodeError.UnexpectedEnd, err "\"\\q\"") // invalid escape
+    Assert.Equal(DecodeError.UnexpectedEnd, err "1.") // no digit after '.'
+    Assert.Equal(DecodeError.UnexpectedEnd, err "1e") // no exponent digits
+    Assert.Equal(DecodeError.UnexpectedEnd, err "1e+") // exponent sign without digits
+    Assert.Equal(DecodeError.UnexpectedEnd, err "-") // sign without digits
+    // trailing
+    Assert.Equal(DecodeError.TrailingData, err "null x") // value + trailing token
+    Assert.Equal(DecodeError.TrailingData, err "nullnull") // two values
+    // deferred float
+    Assert.Equal(DecodeError.Unsupported, err "1.5")
+    Assert.Equal(DecodeError.Unsupported, err "1e10")
+    Assert.Equal(DecodeError.Unsupported, err "-0.0")
+    // oversized
+    Assert.Equal(DecodeError.IntegerOverflow, err "9223372036854775808") // i64::MAX + 1
+    Assert.Equal(DecodeError.IntegerOverflow, err "-9223372036854775809") // i64::MIN - 1
+    // non-canonical
+    Assert.Equal(DecodeError.NonCanonical, err " null") // leading whitespace
+    Assert.Equal(DecodeError.NonCanonical, err "[1, 2]") // space after comma
+    Assert.Equal(DecodeError.NonCanonical, err "01") // leading zero (parses to 1 → "1")
+    Assert.Equal(DecodeError.NonCanonical, err "\"\\u0041\"") // A; canonical emits raw "A"
+    Assert.Equal(DecodeError.NonCanonical, err "{ \"a\":1}") // whitespace inside object

--- a/tests/Tests.FSharp/DynamicValue.JsonDecode.Tests.fs
+++ b/tests/Tests.FSharp/DynamicValue.JsonDecode.Tests.fs
@@ -81,6 +81,8 @@ let ``F# JSON decode rejects malformed, deferred, oversized, and non-canonical``
     Assert.Equal(DecodeError.UnexpectedEnd, err "{\"a\"") // object missing colon+value
     Assert.Equal(DecodeError.UnexpectedEnd, err "\"unterminated") // unterminated string
     Assert.Equal(DecodeError.UnexpectedEnd, err "\"\\u00gg\"") // \uXXXX with non-hex digits
+    Assert.Equal(DecodeError.UnexpectedEnd, err "\"\\u 001\"") // \uXXXX leading whitespace (HexNumber would trim)
+    Assert.Equal(DecodeError.UnexpectedEnd, err "\"\\u001 \"") // \uXXXX trailing whitespace
     Assert.Equal(DecodeError.UnexpectedEnd, err "\"\\q\"") // invalid escape
     Assert.Equal(DecodeError.UnexpectedEnd, err "1.") // no digit after '.'
     Assert.Equal(DecodeError.UnexpectedEnd, err "1e") // no exponent digits

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -42,6 +42,7 @@
     <Compile Include="DynamicValue.GoldenVectors.Tests.fs" />
     <Compile Include="DynamicValue.CborGoldenVectors.Tests.fs" />
     <Compile Include="DynamicValue.CborDecode.Tests.fs" />
+    <Compile Include="DynamicValue.JsonDecode.Tests.fs" />
     <Compile Include="Observe/GoldenVectors.Tests.fs" />
     <Compile Include="Observe/EventLog.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />


### PR DESCRIPTION
Third of the four JSON-decode oracles (TS #6518, C# #6519 landed/landing; Rust follows). `fromCanonicalJson` is the inverse of `toCanonicalJson` for the 6 locked shapes (Float + Bytes DEFERRED in JSON — they lock under CBOR).

## What
- Adds `fromCanonicalJson` to `DynamicValue.fs`, mirroring the CBOR-decode functional style (mutable `pos` + `let rec readValue () … and …`) + the **shared `DecodeError` DU** + the fixed-point canonical check.
- `DynamicValue.JsonDecode.Tests.fs`: round-trip over the seed (structural) + 23 rejection assertions.

## Precision-safe + strict-canonical
- **int64 precision**: number token parsed as **text** via `System.Int64.TryParse` (never via a float); on a `-?[0-9]+` token the only failure is overflow → `IntegerOverflow`.
- **fixed-point**: `toCanonicalJson decoded = input` → else `NonCanonical` (rejects whitespace, non-minimal escapes, leading zeros).
- **deferred**: a number with `.`/`e`/`E` → `Unsupported`.
- **carries the TS/C# malformed-input lessons**: `\uXXXX` requires exactly 4 hex digits (`UInt16.TryParse` HexNumber); `.`/exponent require digits (`consumeDigits`) — so `1.`/`1e`/`1e+` → `UnexpectedEnd`, not `Unsupported`.
- never thrown: `Result<DynamicValue, DecodeError>`.

**2 facts pass (round-trip + 23-case rejection batch); Release build 0-warnings.** The compilers don't lie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)