### PR TITLE
fix(DynamicValue): C# JSON \uXXXX uses AllowHexSpecifier not HexNumber (Codex #6519)

### DIFF
--- a/src/Core.CSharp.DynamicValue/DynamicValues.cs
+++ b/src/Core.CSharp.DynamicValue/DynamicValues.cs
@@ -958,9 +958,10 @@ public static class DynamicValues
                 return DecodeError.UnexpectedEnd; // 'u' + 4 hex digits
             }
 
-            // require exactly 4 hex digits — a partial parse would silently accept malformed \uXXXX
+            // require exactly 4 hex digits — AllowHexSpecifier (NOT HexNumber, which also permits
+            // leading/trailing whitespace) so a "\u 001"-style escape is rejected, not trimmed
             if (!ushort.TryParse(
-                    s.AsSpan(pos + 1, 4), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ushort code))
+                    s.AsSpan(pos + 1, 4), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out ushort code))
             {
                 return DecodeError.UnexpectedEnd;
             }

--- a/tests/Tests.CSharp/DynamicValueJsonDecodeTests.cs
+++ b/tests/Tests.CSharp/DynamicValueJsonDecodeTests.cs
@@ -120,6 +120,8 @@ public class DynamicValueJsonDecodeTests
     [InlineData("{\"a\"", DecodeError.UnexpectedEnd)] // object missing colon+value
     [InlineData("\"unterminated", DecodeError.UnexpectedEnd)] // unterminated string
     [InlineData("\"\\u00gg\"", DecodeError.UnexpectedEnd)] // \uXXXX with non-hex digits
+    [InlineData("\"\\u 001\"", DecodeError.UnexpectedEnd)] // \uXXXX leading whitespace (HexNumber would trim)
+    [InlineData("\"\\u001 \"", DecodeError.UnexpectedEnd)] // \uXXXX trailing whitespace
     [InlineData("\"\\q\"", DecodeError.UnexpectedEnd)] // invalid escape
     [InlineData("1.", DecodeError.UnexpectedEnd)] // no digit after '.'
     [InlineData("1e", DecodeError.UnexpectedEnd)] // no exponent digits


### PR DESCRIPTION
Follow-up to #6519 addressing a Codex P2 review thread.

## Problem
`NumberStyles.HexNumber` = `AllowLeadingWhite | AllowTrailingWhite | AllowHexSpecifier` — it trims surrounding whitespace. So a malformed escape like `"\u 001"` / `"\u001 "` was trimmed and **accepted** as a decoded char, then surfaced as `NonCanonical` by the fixed-point check, instead of the `UnexpectedEnd` the JSON decoder promises (and the TS oracle's `/^[0-9a-fA-F]{4}$/` regex already enforces).

## Fix
`NumberStyles.HexNumber` → `NumberStyles.AllowHexSpecifier` (hex digits only, no whitespace flags). Added whitespace-`\u` rejection cases. **26 tests pass; Release 0-warnings.**

The same fix is applied to the F# oracle in #6520 (pushed before merge). The Rust oracle (next) uses a strict hex check from the start. The compilers don't lie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)