### PR TITLE
feat(DynamicValue): Rust canonical-JSON DECODE oracle — completes the 4-oracle JSON decode set

### DIFF
--- a/src/Core.Rust.DynamicValue/src/lib.rs
+++ b/src/Core.Rust.DynamicValue/src/lib.rs
@@ -308,16 +308,16 @@ pub enum DecodeError {
 
 impl std::fmt::Display for DecodeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // format-neutral: `DecodeError` is shared by the CBOR and JSON decoders, so the messages
+        // must not name one codec (a JSON caller logging `Unsupported` shouldn't see "CBOR ... tag").
         f.write_str(match self {
-            DecodeError::UnexpectedEnd => "input ended mid-item (truncated CBOR)",
-            DecodeError::TrailingData => "extra bytes after a complete top-level value",
-            DecodeError::Unsupported => {
-                "unsupported CBOR (reserved/indefinite additional-info, tag, or simple value)"
-            }
-            DecodeError::IntegerOverflow => "CBOR integer does not fit i64",
+            DecodeError::UnexpectedEnd => "input ended mid-item (truncated input)",
+            DecodeError::TrailingData => "extra input after a complete top-level value",
+            DecodeError::Unsupported => "unsupported or reserved form for this codec",
+            DecodeError::IntegerOverflow => "integer does not fit i64",
             DecodeError::NonTextKey => "object (map) key was not a text string",
             DecodeError::NonCanonical => {
-                "well-formed but non-canonical CBOR (not the shortest/canonical form this codec emits)"
+                "well-formed but non-canonical input (not the canonical form this codec emits)"
             }
         })
     }
@@ -967,11 +967,21 @@ mod tests {
         assert!(
             DecodeError::TrailingData
                 .to_string()
-                .contains("extra bytes")
+                .contains("extra input")
         );
         assert!(DecodeError::Unsupported.to_string().contains("unsupported"));
         assert!(DecodeError::IntegerOverflow.to_string().contains("i64"));
         assert!(DecodeError::NonTextKey.to_string().contains("text string"));
         assert!(DecodeError::NonCanonical.to_string().contains("canonical"));
+        // format-neutral: the shared DecodeError Display must not name a single codec
+        for e in [
+            DecodeError::UnexpectedEnd,
+            DecodeError::TrailingData,
+            DecodeError::Unsupported,
+            DecodeError::IntegerOverflow,
+            DecodeError::NonCanonical,
+        ] {
+            assert!(!e.to_string().contains("CBOR"), "{e:?} Display names CBOR");
+        }
     }
 }

--- a/src/Core.Rust.DynamicValue/src/lib.rs
+++ b/src/Core.Rust.DynamicValue/src/lib.rs
@@ -225,6 +225,33 @@ impl DynamicValue {
         }
         Ok(value)
     }
+
+    /// Decodes canonical JSON text into a [`DynamicValue`] -- the inverse of
+    /// [`to_canonical_json`](DynamicValue::to_canonical_json), completing the text<->value round-trip
+    /// for the six locked shapes (`Float` + `Bytes` are DEFERRED in JSON and lock under CBOR; a number
+    /// with a decimal point or exponent is a Float -> [`DecodeError::Unsupported`]). Strictly canonical:
+    /// a lenient recursive-descent parse, then one fixed-point check (`to_canonical_json() == input`)
+    /// rejects every non-canonical form (insignificant whitespace, non-minimal escapes, leading zeros)
+    /// as [`DecodeError::NonCanonical`] (a leading '+' is invalid JSON -> `UnexpectedEnd`). int64
+    /// precision is preserved by parsing the number token as text. Mirrors the TS/C#/F# decoder.
+    ///
+    /// # Errors
+    /// Returns the [`DecodeError`] describing why the input is not a valid canonical-JSON v1 value.
+    pub fn from_canonical_json(json: &str) -> Result<DynamicValue, DecodeError> {
+        let chars: Vec<char> = json.chars().collect();
+        let mut pos = 0usize;
+        let value = read_json_value(&chars, &mut pos)?;
+        skip_json_ws(&chars, &mut pos);
+        if pos != chars.len() {
+            return Err(DecodeError::TrailingData);
+        }
+        // canonical fixed-point: a canonical string re-encodes to itself; anything else (extra
+        // whitespace, non-minimal escapes, leading zeros) is well-formed but not canonical
+        match value.to_canonical_json() {
+            Ok(s) if s == json => Ok(value),
+            _ => Err(DecodeError::NonCanonical),
+        }
+    }
 }
 
 /// Why a [`DynamicValue`] could not be canonically encoded (v1). `Float` and
@@ -605,6 +632,211 @@ fn read_map(b: &[u8], pos: &mut usize, arg: u64) -> Result<DynamicValue, DecodeE
         pairs.push((k, v));
     }
     Ok(DynamicValue::Object(pairs))
+}
+
+// --- canonical JSON decode (inverse of to_canonical_json) ---
+// Operates on a Vec<char> (Unicode scalar values) so structural scanning never splits a
+// multi-byte UTF-8 char and raw string content reconstructs faithfully.
+
+fn skip_json_ws(c: &[char], pos: &mut usize) {
+    while *pos < c.len() && matches!(c[*pos], ' ' | '\t' | '\n' | '\r') {
+        *pos += 1;
+    }
+}
+
+// reads one JSON value at `pos`, advancing it
+fn read_json_value(c: &[char], pos: &mut usize) -> Result<DynamicValue, DecodeError> {
+    skip_json_ws(c, pos);
+    if *pos >= c.len() {
+        return Err(DecodeError::UnexpectedEnd);
+    }
+    match c[*pos] {
+        'n' => read_json_literal(c, pos, "null", DynamicValue::Null),
+        't' => read_json_literal(c, pos, "true", DynamicValue::Bool(true)),
+        'f' => read_json_literal(c, pos, "false", DynamicValue::Bool(false)),
+        '"' => Ok(DynamicValue::String(read_json_string(c, pos)?)),
+        '[' => read_json_array(c, pos),
+        '{' => read_json_object(c, pos),
+        ch if ch == '-' || ch.is_ascii_digit() => read_json_number(c, pos),
+        _ => Err(DecodeError::UnexpectedEnd),
+    }
+}
+
+fn read_json_literal(
+    c: &[char],
+    pos: &mut usize,
+    lit: &str,
+    val: DynamicValue,
+) -> Result<DynamicValue, DecodeError> {
+    for (i, lc) in lit.chars().enumerate() {
+        if c.get(*pos + i) != Some(&lc) {
+            return Err(DecodeError::UnexpectedEnd);
+        }
+    }
+    *pos += lit.chars().count();
+    Ok(val)
+}
+
+// reads one escape (pos at the backslash), returns the decoded char, advances pos
+fn read_json_escape(c: &[char], pos: &mut usize) -> Result<char, DecodeError> {
+    *pos += 1; // past backslash
+    if *pos >= c.len() {
+        return Err(DecodeError::UnexpectedEnd);
+    }
+    if c[*pos] == 'u' {
+        if *pos + 5 > c.len() {
+            return Err(DecodeError::UnexpectedEnd); // 'u' + 4 hex digits
+        }
+        // require exactly 4 hex digits — to_digit(16) rejects whitespace / non-hex (no lenient trim)
+        let mut code: u32 = 0;
+        for i in 1..=4 {
+            match c[*pos + i].to_digit(16) {
+                Some(d) => code = code * 16 + d,
+                None => return Err(DecodeError::UnexpectedEnd),
+            }
+        }
+        *pos += 5; // 'u' + 4 hex
+        // a lone UTF-16 surrogate is not a valid scalar value; reject it
+        char::from_u32(code).ok_or(DecodeError::UnexpectedEnd)
+    } else {
+        let rep = match c[*pos] {
+            '"' => '"',
+            '\\' => '\\',
+            '/' => '/',
+            'b' => '\u{0008}',
+            'f' => '\u{000C}',
+            'n' => '\n',
+            'r' => '\r',
+            't' => '\t',
+            _ => return Err(DecodeError::UnexpectedEnd), // invalid escape
+        };
+        *pos += 1;
+        Ok(rep)
+    }
+}
+
+fn read_json_string(c: &[char], pos: &mut usize) -> Result<String, DecodeError> {
+    *pos += 1; // opening quote
+    let mut out = String::new();
+    while *pos < c.len() {
+        let ch = c[*pos];
+        if ch == '"' {
+            *pos += 1;
+            return Ok(out);
+        }
+        if ch == '\\' {
+            out.push(read_json_escape(c, pos)?);
+        } else {
+            out.push(ch);
+            *pos += 1;
+        }
+    }
+    Err(DecodeError::UnexpectedEnd) // unterminated string
+}
+
+// consumes one or more digits at pos; UnexpectedEnd if none (the JSON grammar's
+// "at least one digit" for the integer part, fraction, and exponent)
+fn consume_json_digits(c: &[char], pos: &mut usize) -> Result<(), DecodeError> {
+    let d0 = *pos;
+    while *pos < c.len() && c[*pos].is_ascii_digit() {
+        *pos += 1;
+    }
+    if *pos == d0 {
+        Err(DecodeError::UnexpectedEnd)
+    } else {
+        Ok(())
+    }
+}
+
+fn read_json_number(c: &[char], pos: &mut usize) -> Result<DynamicValue, DecodeError> {
+    let start = *pos;
+    if c[*pos] == '-' {
+        *pos += 1;
+    }
+    consume_json_digits(c, pos)?; // integer part — required (rejects "-", "-.5")
+    let mut is_float = false;
+    if *pos < c.len() && c[*pos] == '.' {
+        is_float = true;
+        *pos += 1;
+        consume_json_digits(c, pos)?; // fraction — required after '.'
+    }
+    if *pos < c.len() && (c[*pos] == 'e' || c[*pos] == 'E') {
+        is_float = true;
+        *pos += 1;
+        if *pos < c.len() && (c[*pos] == '+' || c[*pos] == '-') {
+            *pos += 1;
+        }
+        consume_json_digits(c, pos)?; // exponent — required ("1e", "1e+")
+    }
+    if is_float {
+        return Err(DecodeError::Unsupported); // Float deferred in v1 JSON
+    }
+    // token is -?[0-9]+, so the only way the parse fails is i64 overflow
+    let tok: String = c[start..*pos].iter().collect();
+    tok.parse::<i64>()
+        .map(DynamicValue::Int)
+        .map_err(|_| DecodeError::IntegerOverflow)
+}
+
+fn read_json_array(c: &[char], pos: &mut usize) -> Result<DynamicValue, DecodeError> {
+    *pos += 1; // past the opening bracket
+    let mut items = Vec::new();
+    skip_json_ws(c, pos);
+    if *pos < c.len() && c[*pos] == ']' {
+        *pos += 1;
+        return Ok(DynamicValue::Array(items));
+    }
+    loop {
+        items.push(read_json_value(c, pos)?);
+        skip_json_ws(c, pos);
+        if *pos >= c.len() {
+            return Err(DecodeError::UnexpectedEnd);
+        }
+        match c[*pos] {
+            ',' => *pos += 1,
+            ']' => {
+                *pos += 1;
+                return Ok(DynamicValue::Array(items));
+            }
+            _ => return Err(DecodeError::UnexpectedEnd),
+        }
+    }
+}
+
+fn read_json_object(c: &[char], pos: &mut usize) -> Result<DynamicValue, DecodeError> {
+    *pos += 1; // past the opening brace
+    let mut pairs = Vec::new();
+    skip_json_ws(c, pos);
+    if *pos < c.len() && c[*pos] == '}' {
+        *pos += 1;
+        return Ok(DynamicValue::Object(pairs));
+    }
+    loop {
+        skip_json_ws(c, pos);
+        if *pos >= c.len() || c[*pos] != '"' {
+            return Err(DecodeError::UnexpectedEnd); // key must be a string
+        }
+        let key = read_json_string(c, pos)?;
+        skip_json_ws(c, pos);
+        if *pos >= c.len() || c[*pos] != ':' {
+            return Err(DecodeError::UnexpectedEnd);
+        }
+        *pos += 1;
+        let val = read_json_value(c, pos)?;
+        pairs.push((key, val));
+        skip_json_ws(c, pos);
+        if *pos >= c.len() {
+            return Err(DecodeError::UnexpectedEnd);
+        }
+        match c[*pos] {
+            ',' => *pos += 1,
+            '}' => {
+                *pos += 1;
+                return Ok(DynamicValue::Object(pairs));
+            }
+            _ => return Err(DecodeError::UnexpectedEnd),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/Core.Rust.DynamicValue/src/lib.rs
+++ b/src/Core.Rust.DynamicValue/src/lib.rs
@@ -677,6 +677,22 @@ fn read_json_literal(
     Ok(val)
 }
 
+// reads exactly 4 hex digits starting at index `at`, as a u32; UnexpectedEnd on out-of-range or
+// any non-hex char (to_digit(16) rejects whitespace + non-hex — no lenient trim)
+fn read_u4_hex(c: &[char], at: usize) -> Result<u32, DecodeError> {
+    if at + 4 > c.len() {
+        return Err(DecodeError::UnexpectedEnd);
+    }
+    let mut code: u32 = 0;
+    for ch in &c[at..at + 4] {
+        match ch.to_digit(16) {
+            Some(d) => code = code * 16 + d,
+            None => return Err(DecodeError::UnexpectedEnd),
+        }
+    }
+    Ok(code)
+}
+
 // reads one escape (pos at the backslash), returns the decoded char, advances pos
 fn read_json_escape(c: &[char], pos: &mut usize) -> Result<char, DecodeError> {
     *pos += 1; // past backslash
@@ -684,20 +700,25 @@ fn read_json_escape(c: &[char], pos: &mut usize) -> Result<char, DecodeError> {
         return Err(DecodeError::UnexpectedEnd);
     }
     if c[*pos] == 'u' {
-        if *pos + 5 > c.len() {
-            return Err(DecodeError::UnexpectedEnd); // 'u' + 4 hex digits
-        }
-        // require exactly 4 hex digits — to_digit(16) rejects whitespace / non-hex (no lenient trim)
-        let mut code: u32 = 0;
-        for i in 1..=4 {
-            match c[*pos + i].to_digit(16) {
-                Some(d) => code = code * 16 + d,
-                None => return Err(DecodeError::UnexpectedEnd),
-            }
-        }
+        let hi = read_u4_hex(c, *pos + 1)?; // 4 hex after 'u'
         *pos += 5; // 'u' + 4 hex
-        // a lone UTF-16 surrogate is not a valid scalar value; reject it
-        char::from_u32(code).ok_or(DecodeError::UnexpectedEnd)
+        // A UTF-16 high surrogate must be followed by a \uXXXX low surrogate; combine into the
+        // astral scalar. This matches the TS/C#/F# oracles (whose UTF-16 strings decode the pair
+        // and then report NonCanonical via the fixed-point check, since canonical emits raw UTF-8).
+        if (0xD800..=0xDBFF).contains(&hi) {
+            if *pos + 6 > c.len() || c[*pos] != '\\' || c[*pos + 1] != 'u' {
+                return Err(DecodeError::UnexpectedEnd); // high surrogate not followed by \uXXXX
+            }
+            let lo = read_u4_hex(c, *pos + 2)?;
+            if !(0xDC00..=0xDFFF).contains(&lo) {
+                return Err(DecodeError::UnexpectedEnd); // not a valid low surrogate
+            }
+            *pos += 6; // '\' 'u' + 4 hex
+            let astral = 0x10000 + ((hi - 0xD800) << 10) + (lo - 0xDC00);
+            return char::from_u32(astral).ok_or(DecodeError::UnexpectedEnd);
+        }
+        // a lone low surrogate (or any non-scalar code unit) is not representable as a char; reject
+        char::from_u32(hi).ok_or(DecodeError::UnexpectedEnd)
     } else {
         let rep = match c[*pos] {
             '"' => '"',

--- a/src/Core.Rust.DynamicValue/tests/json_decode_cross_verify.rs
+++ b/src/Core.Rust.DynamicValue/tests/json_decode_cross_verify.rs
@@ -1,0 +1,136 @@
+//! DynamicValue canonical-JSON DECODE byte-lock -- `DynamicValue::from_canonical_json` is the
+//! inverse of `to_canonical_json` for the six locked shapes (Float + Bytes are DEFERRED in JSON --
+//! they lock under CBOR). The decoder is strictly canonical (fixed-point check
+//! `to_canonical_json() == input` -> `DecodeError::NonCanonical`), so a successful decode of the
+//! seed is guaranteed to round-trip; this asserts the decoded value structurally equals the
+//! expected value (JSON has no floats, so derived `PartialEq` is exact here), and that malformed /
+//! deferred / oversized / non-canonical inputs are rejected with the right DecodeError. int64
+//! precision is preserved by parsing the number token as text. "The compilers don't lie."
+
+use std::path::PathBuf;
+
+use serde_json::Value;
+use zeta_core_dynamic_value::{DecodeError, DynamicValue};
+
+fn repo_root() -> PathBuf {
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        if dir.join("Zeta.sln").exists() {
+            return dir;
+        }
+        assert!(dir.pop(), "could not locate repo root (Zeta.sln)");
+    }
+}
+
+/// Build the expected `DynamicValue` from the seed's tagged form (the six locked JSON shapes).
+fn build_value(v: &Value) -> DynamicValue {
+    match v["t"].as_str().expect("tag string") {
+        "null" => DynamicValue::Null,
+        "bool" => DynamicValue::Bool(v["v"].as_bool().expect("bool value")),
+        "int" => DynamicValue::Int(
+            v["v"]
+                .as_str()
+                .expect("int decimal string")
+                .parse::<i64>()
+                .expect("i64 parse"),
+        ),
+        "str" => DynamicValue::String(v["v"].as_str().expect("str value").to_string()),
+        "arr" => DynamicValue::Array(
+            v["v"]
+                .as_array()
+                .expect("arr value")
+                .iter()
+                .map(build_value)
+                .collect(),
+        ),
+        "obj" => DynamicValue::Object(
+            v["v"]
+                .as_array()
+                .expect("obj value")
+                .iter()
+                .map(|pair| {
+                    let p = pair.as_array().expect("pair array");
+                    assert_eq!(p.len(), 2, "obj pair must be [key, value]");
+                    (
+                        p[0].as_str().expect("key string").to_string(),
+                        build_value(&p[1]),
+                    )
+                })
+                .collect(),
+        ),
+        other => panic!("unsupported tag in JSON seed: {other}"),
+    }
+}
+
+#[test]
+fn json_decode_round_trips_golden_vectors() {
+    let path = repo_root().join("src/Core.TypeScript/dynamic-value/golden-vectors.json");
+    let text = std::fs::read_to_string(&path).expect("read dynamic-value golden-vectors.json");
+    let v: Value = serde_json::from_str(&text).expect("parse golden-vectors.json");
+
+    let vectors = v["vectors"].as_array().expect("vectors array");
+    assert!(!vectors.is_empty(), "seed must have vectors");
+
+    let mut failures: Vec<String> = Vec::new();
+    for vec in vectors {
+        let name = vec["name"].as_str().expect("name string");
+        let json = vec["json"].as_str().expect("json string");
+        match DynamicValue::from_canonical_json(json) {
+            Ok(decoded) => {
+                if decoded != build_value(&vec["value"]) {
+                    failures.push(format!("{name}: decoded != expected"));
+                }
+            }
+            Err(e) => failures.push(format!("{name}: decode failed {e:?}")),
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "JSON decode mismatches:\n{}",
+        failures.join("\n")
+    );
+}
+
+fn err(s: &str) -> DecodeError {
+    match DynamicValue::from_canonical_json(s) {
+        Err(e) => e,
+        Ok(_) => panic!("expected decode failure for {s:?}"),
+    }
+}
+
+#[test]
+fn json_decode_rejects_malformed() {
+    assert_eq!(err(""), DecodeError::UnexpectedEnd); // empty
+    assert_eq!(err("tru"), DecodeError::UnexpectedEnd); // truncated literal
+    assert_eq!(err("[1,"), DecodeError::UnexpectedEnd); // unterminated array
+    assert_eq!(err("{\"a\""), DecodeError::UnexpectedEnd); // object missing colon+value
+    assert_eq!(err("\"unterminated"), DecodeError::UnexpectedEnd); // unterminated string
+    assert_eq!(err("\"\\u00gg\""), DecodeError::UnexpectedEnd); // \uXXXX non-hex digits
+    assert_eq!(err("\"\\u 001\""), DecodeError::UnexpectedEnd); // \uXXXX leading whitespace
+    assert_eq!(err("\"\\q\""), DecodeError::UnexpectedEnd); // invalid escape
+    assert_eq!(err("1."), DecodeError::UnexpectedEnd); // no digit after '.'
+    assert_eq!(err("1e"), DecodeError::UnexpectedEnd); // no exponent digits
+    assert_eq!(err("1e+"), DecodeError::UnexpectedEnd); // exponent sign without digits
+    assert_eq!(err("-"), DecodeError::UnexpectedEnd); // sign without digits
+}
+
+#[test]
+fn json_decode_rejects_trailing_deferred_oversized() {
+    assert_eq!(err("null x"), DecodeError::TrailingData); // value + trailing token
+    assert_eq!(err("nullnull"), DecodeError::TrailingData); // two values
+    assert_eq!(err("1.5"), DecodeError::Unsupported); // Float deferred
+    assert_eq!(err("1e10"), DecodeError::Unsupported); // Float (exponent) deferred
+    assert_eq!(err("-0.0"), DecodeError::Unsupported); // Float deferred
+    assert_eq!(err("9223372036854775808"), DecodeError::IntegerOverflow); // i64::MAX + 1
+    assert_eq!(err("-9223372036854775809"), DecodeError::IntegerOverflow); // i64::MIN - 1
+}
+
+#[test]
+fn json_decode_rejects_non_canonical() {
+    assert_eq!(err(" null"), DecodeError::NonCanonical); // leading whitespace
+    assert_eq!(err("[1, 2]"), DecodeError::NonCanonical); // space after comma
+    assert_eq!(err("01"), DecodeError::NonCanonical); // leading zero (parses to 1 -> "1")
+    assert_eq!(err("\"\\u0041\""), DecodeError::NonCanonical); // A; canonical emits raw "A"
+    assert_eq!(err("{ \"a\":1}"), DecodeError::NonCanonical); // whitespace inside object
+}

--- a/src/Core.Rust.DynamicValue/tests/json_decode_cross_verify.rs
+++ b/src/Core.Rust.DynamicValue/tests/json_decode_cross_verify.rs
@@ -133,4 +133,16 @@ fn json_decode_rejects_non_canonical() {
     assert_eq!(err("01"), DecodeError::NonCanonical); // leading zero (parses to 1 -> "1")
     assert_eq!(err("\"\\u0041\""), DecodeError::NonCanonical); // A; canonical emits raw "A"
     assert_eq!(err("{ \"a\":1}"), DecodeError::NonCanonical); // whitespace inside object
+    // a valid 😀 surrogate PAIR decodes to U+1F600 (😀); canonical emits raw UTF-8, so the
+    // escaped form is non-canonical — must match the TS/C#/F# oracles (not UnexpectedEnd)
+    assert_eq!(err("\"\\uD83D\\uDE00\""), DecodeError::NonCanonical);
+}
+
+#[test]
+fn json_decode_rejects_lone_surrogate() {
+    // a high surrogate with no following \uXXXX low surrogate can't form a scalar (Rust char) — and,
+    // unlike the UTF-16-string oracles, can't even be held; rejected at decode time
+    assert_eq!(err("\"\\uD83D\""), DecodeError::UnexpectedEnd); // lone high surrogate
+    assert_eq!(err("\"\\uDE00\""), DecodeError::UnexpectedEnd); // lone low surrogate
+    assert_eq!(err("\"\\uD83Dx\""), DecodeError::UnexpectedEnd); // high surrogate not followed by \u
 }


### PR DESCRIPTION
Last of the four JSON-decode oracles (TS #6518, C# #6519, F# #6520). `from_canonical_json` is the inverse of `to_canonical_json` for the 6 locked shapes (Float + Bytes DEFERRED in JSON — they lock under CBOR). **This completes the JSON decode set across all four oracles.**

## What
- Adds `from_canonical_json` + free recursive-descent readers to `lib.rs`, mirroring the CBOR-decode free-function pattern + the **shared `DecodeError` enum** + the fixed-point canonical check.
- `tests/json_decode_cross_verify.rs`: round-trip over the seed (structural) + malformed / trailing / deferred-float / oversized / non-canonical rejection cases.

## Precision-safe + strict-canonical
- operates on `Vec<char>` (Unicode scalar values) so structural scanning never splits a multi-byte UTF-8 char.
- **int64 precision**: number token collected as text + `str::parse::<i64>` (never via `f64`); only failure on a `-?[0-9]+` token is overflow → `IntegerOverflow`.
- **fixed-point**: `to_canonical_json() == input` → else `NonCanonical`.
- **deferred**: a number with `.`/`e`/`E` → `Unsupported`.
- **bakes in every accumulated oracle lesson from the start**: `\uXXXX` requires exactly 4 hex digits (`char::to_digit(16)` per digit — rejects whitespace + non-hex, no lenient trim); `.`/exponent require digits → `1.`/`1e`/`1e+` are `UnexpectedEnd`; lone UTF-16 surrogate in `\u` → `UnexpectedEnd`.
- never panics: `Result<DynamicValue, DecodeError>`.

**4 tests pass; `cargo fmt` + `clippy -D warnings` clean.**

DynamicValue is now fully **decode-locked in both CBOR (total, 8 shapes) and JSON (6 shapes) across all four oracles**. The compilers don't lie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)