### PR TITLE
feat(B-0982): unified canonical value manifest + cross-format projection harness (slice 1)

### DIFF
--- a/src/Core.TypeScript/dynamic-value/cbor.ts
+++ b/src/Core.TypeScript/dynamic-value/cbor.ts
@@ -221,6 +221,13 @@ export function canonicalCbor(n: Tagged): number[] {
 
 export const toHex = (bytes: number[]): string => bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
 
+// inverse of toHex — the seed carries CBOR bytes as a hex string; shared by the decode + manifest tests
+export const fromHex = (hex: string): number[] => {
+  const out: number[] = [];
+  for (let i = 0; i < hex.length; i += 2) out.push(parseInt(hex.slice(i, i + 2), 16));
+  return out;
+};
+
 // --- CBOR decode (inverse of canonicalCbor) ---
 
 // Internal control-flow carrier: a decode failure throws this and is caught at the

--- a/src/Core.TypeScript/dynamic-value/golden-vectors-cbor-decode.test.ts
+++ b/src/Core.TypeScript/dynamic-value/golden-vectors-cbor-decode.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "bun:test";
 import vectors from "./golden-vectors-cbor.json";
-import { type Tagged, type DecodeError, fromCanonicalCbor } from "./cbor";
+import { type Tagged, type DecodeError, fromCanonicalCbor, fromHex } from "./cbor";
 
 // DynamicValue canonical-CBOR DECODE byte-lock — fromCanonicalCbor is the inverse of
 // canonicalCbor, completing the byte↔value bijection. The decoder is strictly canonical
@@ -17,12 +17,6 @@ interface Vector {
   note?: string;
 }
 
-const hexToBytes = (hex: string): number[] => {
-  const out: number[] = [];
-  for (let i = 0; i < hex.length; i += 2) out.push(parseInt(hex.slice(i, i + 2), 16));
-  return out;
-};
-
 const decodeErr = (bytes: number[]): DecodeError => {
   const r = fromCanonicalCbor(bytes);
   if (r.ok) throw new Error("expected decode failure");
@@ -33,7 +27,7 @@ const seed = vectors as unknown as { vectors: Vector[] };
 
 for (const v of seed.vectors) {
   test(`cbor decode round-trip: ${v.name}`, () => {
-    const r = fromCanonicalCbor(hexToBytes(v.cbor));
+    const r = fromCanonicalCbor(fromHex(v.cbor));
     // ok ⟹ the decoder's internal fixed-point check passed (canonicalCbor(decoded) == input),
     // i.e. the byte-lock holds against the already-verified encoder.
     expect(r.ok).toBe(true);

--- a/src/Core.TypeScript/dynamic-value/golden-vectors-manifest.test.ts
+++ b/src/Core.TypeScript/dynamic-value/golden-vectors-manifest.test.ts
@@ -3,7 +3,7 @@ import manifest from "./golden-vectors-values.json";
 import jsonSeed from "./golden-vectors.json";
 import cborSeed from "./golden-vectors-cbor.json";
 import { type Tagged as JsonTagged, fromCanonicalJson } from "./json";
-import { type Tagged as CborTagged, fromCanonicalCbor } from "./cbor";
+import { type Tagged as CborTagged, fromCanonicalCbor, fromHex } from "./cbor";
 
 // B-0982 (slice 1) — the unified value manifest (golden-vectors-values.json) is the single source
 // for WHICH canonical DynamicValues exist; the per-format seeds are PROJECTIONS of it. This proves
@@ -32,12 +32,6 @@ interface CborVec {
 
 const key = (v: AnyTagged): string => JSON.stringify(v);
 
-const hexToBytes = (hex: string): number[] => {
-  const out: number[] = [];
-  for (let i = 0; i < hex.length; i += 2) out.push(parseInt(hex.slice(i, i + 2), 16));
-  return out;
-};
-
 const entries = (manifest as unknown as { values: ManifestEntry[] }).values;
 const jsonVectors = (jsonSeed as unknown as { vectors: JsonVec[] }).vectors;
 const cborVectors = (cborSeed as unknown as { vectors: CborVec[] }).vectors;
@@ -64,7 +58,7 @@ test("CBOR seed is a faithful projection of the manifest", () => {
     const fmts = manifestByValue.get(key(v.value));
     expect(fmts).toBeDefined();
     expect(fmts).toContain("cbor");
-    const r = fromCanonicalCbor(hexToBytes(v.cbor));
+    const r = fromCanonicalCbor(fromHex(v.cbor));
     expect(r.ok).toBe(true);
     if (r.ok) expect(key(r.value)).toBe(key(v.value));
   }
@@ -92,7 +86,7 @@ test("CBOR and JSON agree on every value both express (nothing is single source 
     if (!jv || !cv) continue;
     shared += 1;
     const fj = fromCanonicalJson(jv.json);
-    const fc = fromCanonicalCbor(hexToBytes(cv.cbor));
+    const fc = fromCanonicalCbor(fromHex(cv.cbor));
     expect(fj.ok && fc.ok).toBe(true);
     if (fj.ok && fc.ok) expect(key(fj.value)).toBe(key(fc.value));
   }

--- a/src/Core.TypeScript/dynamic-value/golden-vectors-manifest.test.ts
+++ b/src/Core.TypeScript/dynamic-value/golden-vectors-manifest.test.ts
@@ -1,0 +1,100 @@
+import { test, expect } from "bun:test";
+import manifest from "./golden-vectors-values.json";
+import jsonSeed from "./golden-vectors.json";
+import cborSeed from "./golden-vectors-cbor.json";
+import { type Tagged as JsonTagged, fromCanonicalJson } from "./json";
+import { type Tagged as CborTagged, fromCanonicalCbor } from "./cbor";
+
+// B-0982 (slice 1) — the unified value manifest (golden-vectors-values.json) is the single source
+// for WHICH canonical DynamicValues exist; the per-format seeds are PROJECTIONS of it. This proves
+// the existing CBOR + JSON seeds are faithful projections: (1) no seed value drifts from the manifest
+// (every seed value is listed, with that format flagged) + each encoding decodes back to it; (2) each
+// format's projection is complete (every manifest value flagged for a format appears in that seed);
+// (3) the two formats AGREE on every value they both express. YAML + XML join the manifest as their
+// codecs land. Nothing is single source of truth for ENCODINGS (each is cross-checked by decode
+// round-trip + the RFC-8949 Appendix-A anchor); the manifest is the single source for VALUES.
+
+type AnyTagged = JsonTagged | CborTagged;
+interface ManifestEntry {
+  value: AnyTagged;
+  formats: string[];
+}
+interface JsonVec {
+  name: string;
+  value: JsonTagged;
+  json: string;
+}
+interface CborVec {
+  name: string;
+  value: CborTagged;
+  cbor: string;
+}
+
+const key = (v: AnyTagged): string => JSON.stringify(v);
+
+const hexToBytes = (hex: string): number[] => {
+  const out: number[] = [];
+  for (let i = 0; i < hex.length; i += 2) out.push(parseInt(hex.slice(i, i + 2), 16));
+  return out;
+};
+
+const entries = (manifest as unknown as { values: ManifestEntry[] }).values;
+const jsonVectors = (jsonSeed as unknown as { vectors: JsonVec[] }).vectors;
+const cborVectors = (cborSeed as unknown as { vectors: CborVec[] }).vectors;
+const manifestByValue = new Map(entries.map((e) => [key(e.value), e.formats]));
+
+test("manifest is non-empty and every value lists at least one format", () => {
+  expect(entries.length).toBeGreaterThan(0);
+  for (const e of entries) expect(e.formats.length).toBeGreaterThan(0);
+});
+
+test("JSON seed is a faithful projection of the manifest", () => {
+  for (const v of jsonVectors) {
+    const fmts = manifestByValue.get(key(v.value));
+    expect(fmts).toBeDefined();
+    expect(fmts).toContain("json");
+    const r = fromCanonicalJson(v.json);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(key(r.value)).toBe(key(v.value)); // encoding decodes back to the manifest value
+  }
+});
+
+test("CBOR seed is a faithful projection of the manifest", () => {
+  for (const v of cborVectors) {
+    const fmts = manifestByValue.get(key(v.value));
+    expect(fmts).toBeDefined();
+    expect(fmts).toContain("cbor");
+    const r = fromCanonicalCbor(hexToBytes(v.cbor));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(key(r.value)).toBe(key(v.value));
+  }
+});
+
+test("each format projection is complete (every flagged manifest value is in that seed)", () => {
+  const jsonValues = new Set(jsonVectors.map((v) => key(v.value)));
+  const cborValues = new Set(cborVectors.map((v) => key(v.value)));
+  for (const e of entries) {
+    if (e.formats.includes("json")) expect(jsonValues.has(key(e.value))).toBe(true);
+    if (e.formats.includes("cbor")) expect(cborValues.has(key(e.value))).toBe(true);
+  }
+});
+
+test("CBOR and JSON agree on every value both express (nothing is single source of truth)", () => {
+  const jsonByValue = new Map(jsonVectors.map((v) => [key(v.value), v]));
+  const cborByValue = new Map(cborVectors.map((v) => [key(v.value), v]));
+  let shared = 0;
+  for (const e of entries) {
+    if (!(e.formats.includes("json") && e.formats.includes("cbor"))) continue;
+    const jv = jsonByValue.get(key(e.value));
+    const cv = cborByValue.get(key(e.value));
+    expect(jv).toBeDefined();
+    expect(cv).toBeDefined();
+    if (!jv || !cv) continue;
+    shared += 1;
+    const fj = fromCanonicalJson(jv.json);
+    const fc = fromCanonicalCbor(hexToBytes(cv.cbor));
+    expect(fj.ok && fc.ok).toBe(true);
+    if (fj.ok && fc.ok) expect(key(fj.value)).toBe(key(fc.value));
+  }
+  expect(shared).toBeGreaterThan(0); // there ARE values both formats express
+});

--- a/src/Core.TypeScript/dynamic-value/golden-vectors-values.json
+++ b/src/Core.TypeScript/dynamic-value/golden-vectors-values.json
@@ -1,0 +1,661 @@
+{
+  "primitive": "DynamicValue",
+  "description": "Unified canonical value manifest (B-0982): the single source for WHICH canonical DynamicValues exist. The per-format seeds (golden-vectors.json, golden-vectors-cbor.json, + future yaml/xml) are PROJECTIONS — each expresses the subset its format can carry. golden-vectors-manifest.test.ts cross-validates that no per-format seed drifts from this set (every seed value is here) and that each format projection is complete + decodes back to the listed value. Nothing is single source of truth for ENCODINGS (each is cross-checked by decode round-trip + the RFC-8949 Appendix-A anchor); this manifest is the single source for VALUE DEFINITIONS. value = the language-neutral tagged form ({t,v}); formats = the per-format seeds that currently express it.",
+  "formats": {
+    "json": "6 shapes — Float + Bytes DEFERRED (a JSON number is ambiguous Int-vs-Float; JSON has no native byte type; they lock under CBOR)",
+    "cbor": "8 shapes — total (Float via RFC 8949 §4.2.2 shortest-float; Bytes via major-type-2)"
+  },
+  "values": [
+    {
+      "value": {
+        "t": "null"
+      },
+      "formats": ["cbor", "json"]
+    },
+    {
+      "value": {
+        "t": "bool",
+        "v": false
+      },
+      "formats": ["cbor", "json"]
+    },
+    {
+      "value": {
+        "t": "bool",
+        "v": true
+      },
+      "formats": ["cbor", "json"]
+    },
+    {
+      "value": {
+        "t": "int",
+        "v": "0"
+      },
+      "formats": ["cbor", "json"]
+    },
+    {
+      "value": {
+        "t": "int",
+        "v": "23"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "int",
+        "v": "24"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "int",
+        "v": "1000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "int",
+        "v": "1000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "int",
+        "v": "9223372036854775807"
+      },
+      "formats": ["cbor", "json"]
+    },
+    {
+      "value": {
+        "t": "int",
+        "v": "-1"
+      },
+      "formats": ["cbor", "json"]
+    },
+    {
+      "value": {
+        "t": "int",
+        "v": "-1000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "int",
+        "v": "-9223372036854775808"
+      },
+      "formats": ["cbor", "json"]
+    },
+    {
+      "value": {
+        "t": "str",
+        "v": ""
+      },
+      "formats": ["cbor", "json"]
+    },
+    {
+      "value": {
+        "t": "str",
+        "v": "a"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "str",
+        "v": "IETF"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "str",
+        "v": "a水b"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "0000000000000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "8000000000000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "3ff0000000000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "3ff8000000000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "40effc0000000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "40f86a0000000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "47efffffe0000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "7e37e43c8800759c"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "3e70000000000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "3f10000000000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "c010000000000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "c010666666666666"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "7ff0000000000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "fff0000000000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "float",
+        "v": "7ff8000000000000"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "bytes",
+        "v": ""
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "bytes",
+        "v": "01020304"
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "arr",
+        "v": []
+      },
+      "formats": ["cbor", "json"]
+    },
+    {
+      "value": {
+        "t": "arr",
+        "v": [
+          {
+            "t": "int",
+            "v": "1"
+          },
+          {
+            "t": "int",
+            "v": "2"
+          },
+          {
+            "t": "int",
+            "v": "3"
+          }
+        ]
+      },
+      "formats": ["cbor", "json"]
+    },
+    {
+      "value": {
+        "t": "arr",
+        "v": [
+          {
+            "t": "int",
+            "v": "1"
+          },
+          {
+            "t": "float",
+            "v": "3ff8000000000000"
+          },
+          {
+            "t": "bytes",
+            "v": "ff"
+          },
+          {
+            "t": "null"
+          }
+        ]
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "arr",
+        "v": [
+          {
+            "t": "int",
+            "v": "1"
+          },
+          {
+            "t": "arr",
+            "v": [
+              {
+                "t": "int",
+                "v": "2"
+              },
+              {
+                "t": "int",
+                "v": "3"
+              }
+            ]
+          }
+        ]
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "obj",
+        "v": []
+      },
+      "formats": ["cbor", "json"]
+    },
+    {
+      "value": {
+        "t": "obj",
+        "v": [
+          [
+            "a",
+            {
+              "t": "int",
+              "v": "1"
+            }
+          ]
+        ]
+      },
+      "formats": ["cbor", "json"]
+    },
+    {
+      "value": {
+        "t": "obj",
+        "v": [
+          [
+            "a",
+            {
+              "t": "int",
+              "v": "1"
+            }
+          ],
+          [
+            "b",
+            {
+              "t": "arr",
+              "v": [
+                {
+                  "t": "int",
+                  "v": "2"
+                },
+                {
+                  "t": "int",
+                  "v": "3"
+                }
+              ]
+            }
+          ]
+        ]
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "obj",
+        "v": [
+          [
+            "b",
+            {
+              "t": "int",
+              "v": "1"
+            }
+          ],
+          [
+            "a",
+            {
+              "t": "int",
+              "v": "2"
+            }
+          ]
+        ]
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "obj",
+        "v": [
+          [
+            "pi",
+            {
+              "t": "float",
+              "v": "400c000000000000"
+            }
+          ],
+          [
+            "raw",
+            {
+              "t": "bytes",
+              "v": "dead"
+            }
+          ]
+        ]
+      },
+      "formats": ["cbor"]
+    },
+    {
+      "value": {
+        "t": "int",
+        "v": "1"
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "int",
+        "v": "42"
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "int",
+        "v": "-42"
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "str",
+        "v": "hello"
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "str",
+        "v": "a b c"
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "str",
+        "v": "a\"b"
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "str",
+        "v": "a\\b"
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "str",
+        "v": "a/b"
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "str",
+        "v": "x\ny\tz"
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "str",
+        "v": "\u0001"
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "str",
+        "v": "héllo→世"
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "str",
+        "v": "😀"
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "arr",
+        "v": [
+          {
+            "t": "int",
+            "v": "1"
+          },
+          {
+            "t": "bool",
+            "v": true
+          },
+          {
+            "t": "null"
+          },
+          {
+            "t": "str",
+            "v": "x"
+          }
+        ]
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "arr",
+        "v": [
+          {
+            "t": "arr",
+            "v": [
+              {
+                "t": "int",
+                "v": "1"
+              }
+            ]
+          },
+          {
+            "t": "arr",
+            "v": []
+          }
+        ]
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "obj",
+        "v": [
+          [
+            "b",
+            {
+              "t": "int",
+              "v": "2"
+            }
+          ],
+          [
+            "a",
+            {
+              "t": "int",
+              "v": "1"
+            }
+          ]
+        ]
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "obj",
+        "v": [
+          [
+            "on",
+            {
+              "t": "bool",
+              "v": true
+            }
+          ],
+          [
+            "name",
+            {
+              "t": "str",
+              "v": "zeta"
+            }
+          ],
+          [
+            "nil",
+            {
+              "t": "null"
+            }
+          ]
+        ]
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "obj",
+        "v": [
+          [
+            "a\"b",
+            {
+              "t": "int",
+              "v": "1"
+            }
+          ]
+        ]
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "obj",
+        "v": [
+          [
+            "outer",
+            {
+              "t": "obj",
+              "v": [
+                [
+                  "inner",
+                  {
+                    "t": "bool",
+                    "v": true
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      },
+      "formats": ["json"]
+    },
+    {
+      "value": {
+        "t": "obj",
+        "v": [
+          [
+            "a",
+            {
+              "t": "arr",
+              "v": [
+                {
+                  "t": "obj",
+                  "v": [
+                    [
+                      "b",
+                      {
+                        "t": "arr",
+                        "v": [
+                          {
+                            "t": "int",
+                            "v": "1"
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              ]
+            }
+          ]
+        ]
+      },
+      "formats": ["json"]
+    }
+  ]
+}


### PR DESCRIPTION
First slice of **B-0982** (multi-format seeds; *nothing is single source of truth*), per your choice of the **unified-manifest + projections** structure.

## What the check found
The two existing seeds are **independently authored** — only 12 of 31 (JSON) / 42 (CBOR) values are shared, with different naming (`string-*` vs `str-*`, `int-42` vs `int-1000`) and 2 same-named vectors that legitimately differ (CBOR's `array-mixed`/`array-nested` carry Float/Bytes that JSON can't). So there was no shared canonical value set — just two trusted files.

## This slice (zero merged-seed churn)
- **`golden-vectors-values.json`** — the single source for WHICH canonical `DynamicValue`s exist: **61 distinct values** (the value-keyed union; 12 shared, 19 JSON-only, 30 CBOR-only), each tagged with the per-format seeds that express it. Value-keyed matching sidesteps the naming divergence + the 2 drifts entirely.
- **`golden-vectors-manifest.test.ts`** — proves the existing CBOR + JSON seeds are faithful **projections**:
  1. no seed value drifts from the manifest (every seed value is listed, its format flagged) + each encoding decodes back to its manifest value (via the merged CBOR/JSON decoders);
  2. each projection is complete (every flagged manifest value appears in that seed);
  3. **CBOR and JSON agree on every value both express** — the heart of *nothing is single source of truth*.

**Touches no merged byte-locked seed files** (manifest + test are new). 5 tests / 476 assertions; eslint/tsc/prettier clean.

## Remaining (later slices)
YAML + XML codecs (encode+decode × 4 oracles) join the manifest as projections; the full 4-format cross-validation is the capstone. The manifest is now the spec they project from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)