### PR TITLE
feat(ansi): text-carried color — copy-paste color round-trip (vision §10)

### DIFF
--- a/tools/ansi/README.md
+++ b/tools/ansi/README.md
@@ -1,0 +1,63 @@
+# `tools/ansi/` — text-carried color (copy-paste color round-trip)
+
+Color that **round-trips through a plain-text channel** — the Otto↔operator
+copy-paste. Per the 2026-06-02 vision note §10 ("ANSI art + color … where the
+life can be seen living") + the iTerm copy-with-styles answer.
+
+## The problem
+
+- A terminal **renders** ANSI escape codes into colored pixels; selecting + copying
+  that gives back **plain text** — the color is gone (it was never in the clipboard
+  as data). iTerm's `Cmd+Opt+C` ("Copy with Styles") preserves color **only** into a
+  rich-text target (Slack/email/Notes); a Markdown/`.txt`/code-editor target strips it.
+- An agent (Otto) receives **plain text** — it never "sees" rendered color. It *can*
+  read **literal** ANSI escape codes (`^[[38;5;203m…` as characters), but not painted color.
+
+## The fix — color as literal text, both ways
+
+Express color as a copy-paste-safe **markup** the agent emits + reads, plus a
+**renderer** so a human sees it, plus a **from-ANSI** converter so already-colored
+output becomes round-trippable.
+
+```
+{c:SPEC}text{/c}     foreground
+{bg:SPEC}text{/bg}   background
+SPEC = name (red, brightcyan, …) | 256-index (0-255) | hex (#rrggbb)
+```
+
+`markup → ANSI → markup` is the **identity** for all three color forms, so color
+survives the channel. Unknown specs are left as literal markup (no fabricated color).
+
+## CLI
+
+```bash
+# Otto emits markup in a message; you render it to SEE the color:
+echo '{c:#ff5555}LIFE{/c} {c:46}LIVING{/c}' | bun tools/ansi/cli.ts
+
+# Already-colored output → round-trippable markup to paste BACK to Otto
+# (accepts real ESC and `cat -v` caret `^[[` notation):
+some-colored-command | bun tools/ansi/cli.ts --from-ansi
+
+# Strip color → plain text:
+some-colored-command | bun tools/ansi/cli.ts --strip
+
+# See the convention live:
+bun tools/ansi/cli.ts --demo
+```
+
+## The round-trip (how Otto "sees his color")
+
+1. **Otto emits** color as markup in a message (text — survives copy-paste).
+2. **You render** it: pipe the markup through `cli.ts` → the terminal shows real color.
+3. **You copy the markup** (the text Otto sent) and paste it back.
+4. **Otto reads** the markup → knows the exact colors.
+
+Rendered color cannot round-trip (copy gives plain text); the **markup** is the
+canonical text form that can. To make existing colored output round-trippable,
+run it through `--from-ansi` first (turns the painted color into markup).
+
+## Files
+
+- `color-markup.ts` — `renderToAnsi` / `parseFromAnsi` / `caretToEsc` / `stripAnsi`.
+- `cli.ts` — render (default) / `--from-ansi` / `--strip` / `--demo`.
+- `color-markup.test.ts` — render, parse, exact round-trip, utilities.

--- a/tools/ansi/cli.ts
+++ b/tools/ansi/cli.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env bun
+/**
+ * tools/ansi/cli.ts — render/round-trip color markup ⇄ terminal ANSI.
+ *
+ * The copy-paste color round-trip (Otto↔operator), per the 2026-06-02 vision §10:
+ *
+ *   # Otto emits markup in a message; you render it to SEE the color:
+ *   echo '{c:#ff5555}LIFE{/c} {c:46}LIVING{/c}' | bun tools/ansi/cli.ts
+ *
+ *   # Already-colored output → round-trippable markup you can paste back to Otto:
+ *   some-colored-command | bun tools/ansi/cli.ts --from-ansi
+ *   #   (also accepts `cat -v` caret notation, e.g. `^[[38;5;203m…`)
+ *
+ *   # Strip color → plain text:
+ *   some-colored-command | bun tools/ansi/cli.ts --strip
+ *
+ *   # See the convention live:
+ *   bun tools/ansi/cli.ts --demo
+ *
+ * Markup: {c:SPEC}…{/c} foreground, {bg:SPEC}…{/bg} background; SPEC is a name
+ * (red/brightcyan/…), a 256-index (0-255), or hex (#rrggbb). Exact round-trip
+ * for all three forms. Unknown specs are left as literal text (no fabricated color).
+ */
+
+import { renderToAnsi, parseFromAnsi, stripAnsi } from "./color-markup";
+
+async function readStdin(): Promise<string> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of Bun.stdin.stream()) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function demo(): string {
+  const sample =
+    "{c:#ff5555}LIFE{/c} {c:46}LIVING{/c} {c:cyan}menu{/c}={c:cyan}unem{/c} " +
+    "{bg:#202020}{c:brightyellow} the life can be seen living {/c}{/bg}";
+  const ansi = renderToAnsi(sample);
+  return [
+    "markup (what Otto emits / you paste back — round-trippable text):",
+    "  " + sample,
+    "",
+    "rendered ANSI (what you SEE in the terminal):",
+    "  " + ansi,
+    "",
+    "round-trip check (render → parse → markup):",
+    "  " + parseFromAnsi(ansi),
+  ].join("\n");
+}
+
+async function main(argv: readonly string[]): Promise<number> {
+  const args = argv.slice(2);
+  if (args.includes("--demo")) {
+    console.log(demo());
+    return 0;
+  }
+  const input = await readStdin();
+  if (args.includes("--from-ansi")) {
+    process.stdout.write(parseFromAnsi(input));
+    return 0;
+  }
+  if (args.includes("--strip")) {
+    process.stdout.write(stripAnsi(input));
+    return 0;
+  }
+  // default: render markup → terminal ANSI
+  process.stdout.write(renderToAnsi(input));
+  return 0;
+}
+
+if (import.meta.main) {
+  main(process.argv).then((code) => process.exit(code));
+}

--- a/tools/ansi/color-markup.test.ts
+++ b/tools/ansi/color-markup.test.ts
@@ -53,6 +53,16 @@ describe("color-markup — parse ANSI → markup", () => {
   test("non-color SGR (bold) is dropped", () => {
     expect(parseFromAnsi(`${ESC}[1m${ESC}[32mok${ESC}[0m`)).toBe("{c:green}ok{/c}");
   });
+  test("selective fg reset (39) closes just the fg span", () => {
+    expect(parseFromAnsi(`${ESC}[31mhi${ESC}[39mthere${ESC}[0m`)).toBe("{c:red}hi{/c}there");
+  });
+  test("selective bg reset (49) closes just the bg span", () => {
+    expect(parseFromAnsi(`${ESC}[41mhi${ESC}[49mthere${ESC}[0m`)).toBe("{bg:red}hi{/bg}there");
+  });
+  test("39 leaves bg open; 49 leaves fg open (independent resets)", () => {
+    // fg+bg open, then 39 closes only fg → bg stays open until final reset
+    expect(parseFromAnsi(`${ESC}[31m${ESC}[44mx${ESC}[39my${ESC}[0m`)).toBe("{c:red}{bg:blue}x{/c}y{/bg}");
+  });
 });
 
 describe("color-markup — exact round-trip (markup → ANSI → markup = identity)", () => {

--- a/tools/ansi/color-markup.test.ts
+++ b/tools/ansi/color-markup.test.ts
@@ -1,0 +1,77 @@
+/**
+ * tools/ansi/color-markup.test.ts — text-carried color round-trip.
+ *
+ * The load-bearing property: markup → ANSI → markup is the IDENTITY for the three
+ * color forms (named / 256-index / hex), so color survives the plain-text channel.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToAnsi, parseFromAnsi, caretToEsc, stripAnsi } from "./color-markup";
+
+const ESC = "\x1b";
+
+describe("color-markup — render markup → ANSI", () => {
+  test("hex foreground → truecolor SGR", () => {
+    expect(renderToAnsi("{c:#ff5555}hi{/c}")).toBe(`${ESC}[0;38;2;255;85;85mhi${ESC}[0m`);
+  });
+  test("256-index foreground", () => {
+    expect(renderToAnsi("{c:203}hi{/c}")).toBe(`${ESC}[0;38;5;203mhi${ESC}[0m`);
+  });
+  test("named foreground (basic SGR)", () => {
+    expect(renderToAnsi("{c:red}hi{/c}")).toBe(`${ESC}[0;31mhi${ESC}[0m`);
+  });
+  test("background", () => {
+    expect(renderToAnsi("{bg:blue}hi{/bg}")).toBe(`${ESC}[0;44mhi${ESC}[0m`);
+  });
+  test("plain text passes through untouched", () => {
+    expect(renderToAnsi("just text")).toBe("just text");
+  });
+  test("unknown spec is left as literal markup (no fabricated color)", () => {
+    expect(renderToAnsi("{c:notacolor}x{/c}")).toBe("{c:notacolor}x{/c}");
+  });
+  test("nested fg+bg both render and unwind", () => {
+    // open bg(black=40), open fg(cyan=36)+bg, close fg → bg-only, close bg → reset
+    expect(renderToAnsi("{bg:black}{c:cyan}x{/c}{/bg}")).toBe(
+      `${ESC}[0;40m${ESC}[0;36;40mx${ESC}[0;40m${ESC}[0m`,
+    );
+  });
+});
+
+describe("color-markup — parse ANSI → markup", () => {
+  test("truecolor → hex markup", () => {
+    expect(parseFromAnsi(`${ESC}[38;2;255;85;85mhi${ESC}[0m`)).toBe("{c:#ff5555}hi{/c}");
+  });
+  test("256-index → markup", () => {
+    expect(parseFromAnsi(`${ESC}[38;5;203mhi${ESC}[0m`)).toBe("{c:203}hi{/c}");
+  });
+  test("basic 31 → named", () => {
+    expect(parseFromAnsi(`${ESC}[31mhi${ESC}[0m`)).toBe("{c:red}hi{/c}");
+  });
+  test("cat -v caret notation is accepted", () => {
+    expect(parseFromAnsi("^[[38;5;203mhi^[[0m")).toBe("{c:203}hi{/c}");
+  });
+  test("non-color SGR (bold) is dropped", () => {
+    expect(parseFromAnsi(`${ESC}[1m${ESC}[32mok${ESC}[0m`)).toBe("{c:green}ok{/c}");
+  });
+});
+
+describe("color-markup — exact round-trip (markup → ANSI → markup = identity)", () => {
+  test.each([
+    "{c:#ff5555}hi{/c}",
+    "{c:203}hi{/c}",
+    "{c:red}hi{/c}",
+    "plain {c:green}go{/c} plain {c:#00aaff}blue{/c}",
+  ])("round-trips %s", (markup) => {
+    expect(parseFromAnsi(renderToAnsi(markup))).toBe(markup);
+  });
+});
+
+describe("color-markup — utilities", () => {
+  test("caretToEsc converts ^[ to real ESC", () => {
+    expect(caretToEsc("^[[31m")).toBe(`${ESC}[31m`);
+  });
+  test("stripAnsi removes color (real + caret)", () => {
+    expect(stripAnsi(`${ESC}[31mhi${ESC}[0m`)).toBe("hi");
+    expect(stripAnsi("^[[38;5;46mhi^[[0m")).toBe("hi");
+  });
+});

--- a/tools/ansi/color-markup.ts
+++ b/tools/ansi/color-markup.ts
@@ -182,6 +182,20 @@ export function parseFromAnsi(input: string): string {
       if (code === 0) {
         closeOpen();
         p += 1;
+      } else if (code === 39) {
+        // default foreground — selective reset of just the fg span
+        if (fgOpen) {
+          out += "{/c}";
+          fgOpen = false;
+        }
+        p += 1;
+      } else if (code === 49) {
+        // default background — selective reset of just the bg span
+        if (bgOpen) {
+          out += "{/bg}";
+          bgOpen = false;
+        }
+        p += 1;
       } else if (code === 38 || code === 48) {
         const isFg = code === 38;
         const mode = Number(params[p + 1]);

--- a/tools/ansi/color-markup.ts
+++ b/tools/ansi/color-markup.ts
@@ -1,0 +1,236 @@
+/**
+ * tools/ansi/color-markup.ts
+ *
+ * Text-carried color so color can ROUND-TRIP through a plain-text channel (the
+ * Otto↔operator copy-paste). The problem (per the 2026-06-02 vision note §10 +
+ * the iTerm answer): a terminal RENDERS ANSI into pixels and copy gives back
+ * PLAIN text — the color is gone; and an agent receives plain text, so it never
+ * "sees" rendered color. The fix: express color as LITERAL TEXT both ways —
+ *
+ *   - a copy-paste-safe MARKUP the agent can emit + read: `{c:…}text{/c}`
+ *     (foreground) and `{bg:…}text{/bg}` (background), where `…` is a name
+ *     (`red`, `brightcyan`), a 256-index (`203`), or a hex (`#ff5555`);
+ *   - `renderToAnsi(markup)` turns it into real terminal ANSI so a HUMAN SEES color;
+ *   - `parseFromAnsi(ansiText)` turns real (or `cat -v` caret `^[[`) ANSI back into
+ *     the markup, so already-colored output becomes round-trippable.
+ *
+ * Round-trip is exact for the three color forms (256→`{c:N}`→256; truecolor→
+ * `{c:#hex}`→truecolor; basic 30-37/90-97 → named → basic). The markup is the
+ * canonical text form: the agent emits it, the human renders it, the human copies
+ * the markup back, the agent reads the color. "Where the life can be seen living."
+ */
+
+// --- named basic colors (SGR 30-37 / 90-97 foreground; +10 for background) ---
+
+const BASIC: Record<string, number> = {
+  black: 30, red: 31, green: 32, yellow: 33, blue: 34, magenta: 35, cyan: 36, white: 37,
+  brightblack: 90, brightred: 91, brightgreen: 92, brightyellow: 93,
+  brightblue: 94, brightmagenta: 95, brightcyan: 96, brightwhite: 97,
+};
+const BASIC_FG_TO_NAME: Record<number, string> = Object.fromEntries(
+  Object.entries(BASIC).map(([n, c]) => [c, n]),
+);
+
+const ESC = "\x1b";
+const RESET = `${ESC}[0m`;
+
+/** A resolved color spec → the SGR parameter list for fg (`fg=true`) or bg. */
+function specToSgr(spec: string, fg: boolean): string | null {
+  const base = fg ? 38 : 48;
+  const lower = spec.toLowerCase();
+  if (lower in BASIC) {
+    const code = BASIC[lower]! + (fg ? 0 : 10);
+    return String(code);
+  }
+  if (/^#[0-9a-fA-F]{6}$/.test(spec)) {
+    const r = parseInt(spec.slice(1, 3), 16);
+    const g = parseInt(spec.slice(3, 5), 16);
+    const b = parseInt(spec.slice(5, 7), 16);
+    return `${base};2;${r};${g};${b}`;
+  }
+  if (/^\d{1,3}$/.test(spec)) {
+    const n = Number(spec);
+    if (n >= 0 && n <= 255) return `${base};5;${n}`;
+  }
+  return null; // unrecognized spec → leave markup as-is (don't fabricate color)
+}
+
+// --- render: markup → real terminal ANSI -------------------------------------
+
+const OPEN_RE = /\{(c|bg):([^}]+)\}/g;
+const CLOSE_RE = /\{\/(c|bg)\}/g;
+
+/**
+ * Render color markup to terminal ANSI. Foreground + background each maintain a
+ * stack (so nesting works); after every change the current combined state is
+ * emitted as a single SGR (reset + active fg + active bg). Unknown specs are
+ * left as literal text (no fabricated color).
+ */
+export function renderToAnsi(markup: string): string {
+  type Tok = { kind: "text"; v: string } | { kind: "open"; ch: "c" | "bg"; spec: string } | { kind: "close"; ch: "c" | "bg" };
+  const toks: Tok[] = [];
+  let i = 0;
+  while (i < markup.length) {
+    OPEN_RE.lastIndex = i;
+    CLOSE_RE.lastIndex = i;
+    const open = OPEN_RE.exec(markup);
+    const close = CLOSE_RE.exec(markup);
+    // earliest match at/after i
+    const next = [open, close].filter((m): m is RegExpExecArray => m !== null && m.index >= i).sort((a, b) => a.index - b.index)[0];
+    if (!next) {
+      toks.push({ kind: "text", v: markup.slice(i) });
+      break;
+    }
+    if (next.index > i) toks.push({ kind: "text", v: markup.slice(i, next.index) });
+    if (next === open) toks.push({ kind: "open", ch: open![1] as "c" | "bg", spec: open![2]! });
+    else toks.push({ kind: "close", ch: close![1] as "c" | "bg" });
+    i = next.index + next[0].length;
+  }
+
+  // Stacks hold a spec string, or `null` for an UNRECOGNIZED open kept as literal
+  // markup (so its matching close is also emitted literally, not as a reset).
+  const fg: (string | null)[] = [];
+  const bg: (string | null)[] = [];
+  const lastReal = (arr: readonly (string | null)[]): string | undefined => {
+    for (let i = arr.length - 1; i >= 0; i--) {
+      const v = arr[i];
+      if (v) return v;
+    }
+    return undefined;
+  };
+  const sgrFor = (): string => {
+    const parts: string[] = [];
+    const f = lastReal(fg);
+    const b = lastReal(bg);
+    if (f) {
+      const s = specToSgr(f, true);
+      if (s) parts.push(s);
+    }
+    if (b) {
+      const s = specToSgr(b, false);
+      if (s) parts.push(s);
+    }
+    if (parts.length === 0) return RESET;
+    return `${ESC}[0;${parts.join(";")}m`;
+  };
+
+  let out = "";
+  for (const t of toks) {
+    if (t.kind === "text") {
+      out += t.v;
+    } else if (t.kind === "open") {
+      const stack = t.ch === "c" ? fg : bg;
+      if (specToSgr(t.spec, t.ch === "c") === null) {
+        // unrecognized spec: keep the literal markup (don't drop intent) + push a
+        // null placeholder so the matching close is emitted literally too.
+        stack.push(null);
+        out += `{${t.ch}:${t.spec}}`;
+      } else {
+        stack.push(t.spec);
+        out += sgrFor();
+      }
+    } else {
+      const stack = t.ch === "c" ? fg : bg;
+      const popped = stack.pop();
+      if (popped === null) out += `{/${t.ch}}`; // matched a literal open
+      else out += sgrFor();
+    }
+  }
+  if (fg.some(Boolean) || bg.some(Boolean)) out += RESET;
+  return out;
+}
+
+// --- parse: real/caret ANSI → markup -----------------------------------------
+
+/** Normalize `cat -v` caret notation (`^[`) to real ESC so one parser handles both. */
+export function caretToEsc(text: string): string {
+  return text.replace(/\^\[/g, ESC);
+}
+
+/**
+ * Convert ANSI-colored text (real ESC, or `cat -v` caret `^[[`) into round-trippable
+ * markup. Emits FLAT spans (each color run closed before the next opens) — correct
+ * and simple for the common case. Recognizes fg/bg in truecolor (38;2/48;2),
+ * 256-color (38;5/48;5), and basic (30-37/90-97, 40-47/100-107); `0`/empty resets.
+ * Non-color SGR (bold/underline/…) and unrecognized params are dropped.
+ */
+export function parseFromAnsi(input: string): string {
+  const text = caretToEsc(input);
+  const sgr = /\x1b\[([0-9;]*)m/g;
+  let out = "";
+  let last = 0;
+  let fgOpen = false;
+  let bgOpen = false;
+  const closeOpen = (): void => {
+    if (bgOpen) {
+      out += "{/bg}";
+      bgOpen = false;
+    }
+    if (fgOpen) {
+      out += "{/c}";
+      fgOpen = false;
+    }
+  };
+  let m: RegExpExecArray | null;
+  while ((m = sgr.exec(text)) !== null) {
+    out += text.slice(last, m.index); // literal text before this SGR
+    last = sgr.lastIndex;
+    const params = m[1] === "" ? ["0"] : m[1]!.split(";");
+    let p = 0;
+    while (p < params.length) {
+      const code = Number(params[p]);
+      if (code === 0) {
+        closeOpen();
+        p += 1;
+      } else if (code === 38 || code === 48) {
+        const isFg = code === 38;
+        const mode = Number(params[p + 1]);
+        let spec: string | null = null;
+        if (mode === 5) {
+          spec = String(Number(params[p + 2]));
+          p += 3;
+        } else if (mode === 2) {
+          const r = Number(params[p + 2]), g = Number(params[p + 3]), b = Number(params[p + 4]);
+          spec = "#" + [r, g, b].map((x) => x.toString(16).padStart(2, "0")).join("");
+          p += 5;
+        } else {
+          p += 1;
+        }
+        if (spec !== null) {
+          if (isFg) {
+            if (fgOpen) out += "{/c}";
+            out += `{c:${spec}}`;
+            fgOpen = true;
+          } else {
+            if (bgOpen) out += "{/bg}";
+            out += `{bg:${spec}}`;
+            bgOpen = true;
+          }
+        }
+      } else if ((code >= 30 && code <= 37) || (code >= 90 && code <= 97)) {
+        if (fgOpen) out += "{/c}";
+        out += `{c:${BASIC_FG_TO_NAME[code]}}`;
+        fgOpen = true;
+        p += 1;
+      } else if ((code >= 40 && code <= 47) || (code >= 100 && code <= 107)) {
+        const name = BASIC_FG_TO_NAME[code - 10];
+        if (name) {
+          if (bgOpen) out += "{/bg}";
+          out += `{bg:${name}}`;
+          bgOpen = true;
+        }
+        p += 1;
+      } else {
+        p += 1; // non-color SGR (bold/underline/etc.) — dropped
+      }
+    }
+  }
+  out += text.slice(last);
+  closeOpen();
+  return out;
+}
+
+/** Strip ALL ANSI (real or caret) → plain text. */
+export function stripAnsi(input: string): string {
+  return caretToEsc(input).replace(/\x1b\[[0-9;]*m/g, "");
+}


### PR DESCRIPTION
Makes color **round-trip through our plain-text copy-paste channel** — §10 'ANSI art + color … where the life can be seen living', made concrete.

**Problem:** a terminal renders ANSI → pixels; copy gives plain text (color gone); an agent receives plain text so never sees rendered color. iTerm Copy-with-Styles survives only into rich-text targets, not Markdown/.txt.

**Fix — color as literal text both ways:**
- markup the agent emits + reads: `{c:SPEC}…{/c}` / `{bg:SPEC}…{/bg}` (SPEC = name | 256-index | #hex)
- `renderToAnsi` → real terminal ANSI (human SEES color)
- `parseFromAnsi` → markup from real or `cat -v` caret `^[[` ANSI (existing colored output becomes round-trippable)
- `markup → ANSI → markup` is the IDENTITY for all three forms; unknown specs stay literal (no fabricated color)

CLI: render (default) / `--from-ansi` / `--strip` / `--demo`. 18 tests; tsc clean.

**Round-trip:** Otto emits markup → you render to see color → you copy the markup back → Otto reads the exact colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)