### PR TITLE
feat(B-0883): memory-encrypt loop — self-encrypt a folder to PQ .zc (Aaron-runs; agent dry-run only)

### DIFF
--- a/tools/crypto/better-git-crypt/README.md
+++ b/tools/crypto/better-git-crypt/README.md
@@ -122,6 +122,35 @@ Exit codes:
 - `1` — runtime failure (validation / crypto feedback / file I/O)
 - `2` — usage error
 
+### Memory-encrypt loop (`memory-encrypt-loop.ts` — self-encrypt a folder)
+
+The loop over `--encrypt-file` for the "encrypt my private memories" use case.
+**Security model is load-bearing**: `encryptBytes(bytes, self, [])` makes `self`
+the SENDER (signs) AND sole self-recipient, so pure self-encryption means *only
+the holder of `self`'s secret bundle can decrypt*. Therefore **only-Aaron-decrypts
+requires Aaron to be the sender** — Aaron runs the real encrypt with his own
+secret bundle. An agent cannot run it (no secret bundle; generating one for Aaron
++ holding it would defeat the only-Aaron property). The agent CAN run `--dry-run`
+(no key, no writes) to preview.
+
+```bash
+# 1. one-time keygen (agent never sees the secret):
+bun tools/crypto/better-git-crypt/cli/main.ts --gen-recipient aaron@zeta --out-dir ~/.zeta-keys
+#    → ~/.zeta-keys/aaron@zeta.{recipient,secret}.json   (.zeta-keys/ is gitignored)
+
+# 2. self-encrypt (AARON runs this; plaintext stays in drop/, which is gitignored):
+bun tools/crypto/better-git-crypt/memory-encrypt-loop.ts \
+  --keys ~/.zeta-keys/aaron@zeta.secret.json --in drop --out memory/persona/aaron
+
+# preview without a key (agent-safe — no writes):
+bun tools/crypto/better-git-crypt/memory-encrypt-loop.ts --dry-run --in drop --out memory/persona/aaron
+```
+
+`--in <dir>` / `--out <dir>` (required), `--keys <secret-bundle>` (required unless
+`--dry-run`), `--in-ext` (default `.txt`), `--force` (overwrite existing `.zc`).
+Each `.zc` decrypts to the EXACT input bytes (no edit/summary/redaction). Then the
+agent commits the `.zc` (plaintext never leaves `drop/`).
+
 ## Tests
 
 ```bash

--- a/tools/crypto/better-git-crypt/README.md
+++ b/tools/crypto/better-git-crypt/README.md
@@ -130,6 +130,7 @@ the SENDER (signs) AND sole self-recipient, so pure self-encryption means *only
 the holder of `self`'s secret bundle can decrypt*. Therefore **only-Aaron-decrypts
 requires Aaron to be the sender** — Aaron runs the real encrypt with his own
 secret bundle. An agent cannot run it (no secret bundle; generating one for Aaron
+
 + holding it would defeat the only-Aaron property). The agent CAN run `--dry-run`
 (no key, no writes) to preview.
 

--- a/tools/crypto/better-git-crypt/README.md
+++ b/tools/crypto/better-git-crypt/README.md
@@ -124,33 +124,33 @@ Exit codes:
 
 ### Memory-encrypt loop (`memory-encrypt-loop.ts` — self-encrypt a folder)
 
-The loop over `--encrypt-file` for the "encrypt my private memories" use case.
-**Security model is load-bearing**: `encryptBytes(bytes, self, [])` makes `self`
-the SENDER (signs) AND sole self-recipient, so pure self-encryption means *only
-the holder of `self`'s secret bundle can decrypt*. Therefore **only-Aaron-decrypts
-requires Aaron to be the sender** — Aaron runs the real encrypt with his own
-secret bundle. An agent cannot run it (no secret bundle; generating one for Aaron
-
-+ holding it would defeat the only-Aaron property). The agent CAN run `--dry-run`
-(no key, no writes) to preview.
+The loop over `--encrypt-file` for the "encrypt a folder of private memories" use
+case. **Security model is load-bearing**: `encryptBytes(bytes, self, [])` makes
+`self` the SENDER (signs) AND sole self-recipient, so pure self-encryption means
+*only the holder of `self`'s secret bundle can decrypt*. Therefore
+**only-the-owner-decrypts requires the key owner to be the sender** — the owner
+runs the real encrypt with their own secret bundle. An agent cannot run it (no
+secret bundle; generating one for the owner and holding it would defeat the
+only-the-owner-decrypts property). An agent CAN run `--dry-run` (no key, no
+writes) to preview.
 
 ```bash
-# 1. one-time keygen (agent never sees the secret):
-bun tools/crypto/better-git-crypt/cli/main.ts --gen-recipient aaron@zeta --out-dir ~/.zeta-keys
-#    → ~/.zeta-keys/aaron@zeta.{recipient,secret}.json   (.zeta-keys/ is gitignored)
+# 1. one-time keygen (the agent never sees the secret):
+bun tools/crypto/better-git-crypt/cli/main.ts --gen-recipient <identity> --out-dir ~/.zeta-keys
+#    → ~/.zeta-keys/<identity>.{recipient,secret}.json   (.zeta-keys/ is gitignored)
 
-# 2. self-encrypt (AARON runs this; plaintext stays in drop/, which is gitignored):
+# 2. self-encrypt (the key owner runs this; keep plaintext in a gitignored dir):
 bun tools/crypto/better-git-crypt/memory-encrypt-loop.ts \
-  --keys ~/.zeta-keys/aaron@zeta.secret.json --in drop --out memory/persona/aaron
+  --keys ~/.zeta-keys/<identity>.secret.json --in <in-dir> --out <out-dir>
 
 # preview without a key (agent-safe — no writes):
-bun tools/crypto/better-git-crypt/memory-encrypt-loop.ts --dry-run --in drop --out memory/persona/aaron
+bun tools/crypto/better-git-crypt/memory-encrypt-loop.ts --dry-run --in <in-dir> --out <out-dir>
 ```
 
 `--in <dir>` / `--out <dir>` (required), `--keys <secret-bundle>` (required unless
 `--dry-run`), `--in-ext` (default `.txt`), `--force` (overwrite existing `.zc`).
 Each `.zc` decrypts to the EXACT input bytes (no edit/summary/redaction). Then the
-agent commits the `.zc` (plaintext never leaves `drop/`).
+agent commits the `.zc` (plaintext never leaves the gitignored input dir).
 
 ## Tests
 

--- a/tools/crypto/better-git-crypt/memory-encrypt-loop.test.ts
+++ b/tools/crypto/better-git-crypt/memory-encrypt-loop.test.ts
@@ -1,0 +1,107 @@
+/**
+ * tools/crypto/better-git-crypt/memory-encrypt-loop.test.ts
+ *
+ * The load-bearing property: a folder of plaintext self-encrypts to `.zc` and each
+ * `.zc` decrypts back to the EXACT input bytes with the SAME secret bundle (only
+ * Aaron, as sender/self-recipient, can decrypt). Plus listing/naming/skip behavior.
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  generateKeyPairJSON,
+  deserializeSecretBundle,
+  decryptBytes,
+  type SelfKeys,
+} from "./files";
+import { listInputs, outPathFor, encryptDir } from "./memory-encrypt-loop";
+
+let root: string;
+let inDir: string;
+let outDir: string;
+let self: SelfKeys;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "mem-enc-loop-"));
+  inDir = join(root, "in");
+  outDir = join(root, "out");
+  Bun.spawnSync(["mkdir", "-p", inDir]);
+  self = deserializeSecretBundle(generateKeyPairJSON("aaron@test").secret);
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("listInputs / outPathFor", () => {
+  test("lists only matching extension, sorted; ignores non-.txt", () => {
+    writeFileSync(join(inDir, "b.txt"), "b");
+    writeFileSync(join(inDir, "a.txt"), "a");
+    writeFileSync(join(inDir, "note.md"), "x");
+    expect(listInputs(inDir).map((p) => p.split("/").pop())).toEqual(["a.txt", "b.txt"]);
+  });
+  test("outPathFor strips inExt and appends .zc, preserving the name", () => {
+    expect(outPathFor("/x/drop/memory-foo.txt", "/x/out").endsWith("/out/memory-foo.zc")).toBe(true);
+  });
+  test("missing input dir → empty list (no throw)", () => {
+    expect(listInputs(join(root, "nope"))).toEqual([]);
+  });
+});
+
+describe("encryptDir — self-encrypt round-trip", () => {
+  test("each .zc decrypts back to EXACT input bytes (byte-for-byte)", () => {
+    const samples: Record<string, Uint8Array> = {
+      "plain.txt": new TextEncoder().encode("the word told me to do it"),
+      "binary.txt": new Uint8Array([0, 1, 2, 255, 254, 10, 13, 0]),
+      "unicode.txt": new TextEncoder().encode("μένω — what remains 🜂"),
+    };
+    for (const [name, bytes] of Object.entries(samples)) writeFileSync(join(inDir, name), bytes);
+
+    const res = encryptDir(self, inDir, outDir, {});
+    expect(res.errors).toEqual([]);
+    expect(res.encrypted).toHaveLength(3);
+
+    for (const e of res.encrypted) {
+      expect(existsSync(e.out)).toBe(true);
+      const dec = decryptBytes(readFileSync(e.out), self); // sender = self (self-encrypted)
+      expect(dec.ok).toBe(true);
+      if (dec.ok) {
+        const original = samples[e.in.split("/").pop()!]!;
+        expect(Array.from(dec.plaintext)).toEqual(Array.from(original));
+      }
+    }
+  });
+
+  test("only the holder of the secret bundle can decrypt (a different key fails)", () => {
+    writeFileSync(join(inDir, "secret.txt"), "private");
+    const res = encryptDir(self, inDir, outDir, {});
+    expect(res.encrypted).toHaveLength(1);
+    const other = deserializeSecretBundle(generateKeyPairJSON("not-aaron@test").secret);
+    const dec = decryptBytes(readFileSync(res.encrypted[0]!.out), other);
+    expect(dec.ok).toBe(false);
+  });
+
+  test("existing .zc is skipped unless --force", () => {
+    writeFileSync(join(inDir, "m.txt"), "v1");
+    const first = encryptDir(self, inDir, outDir, {});
+    expect(first.encrypted).toHaveLength(1);
+
+    const second = encryptDir(self, inDir, outDir, {});
+    expect(second.encrypted).toHaveLength(0);
+    expect(second.skipped).toHaveLength(1);
+
+    const forced = encryptDir(self, inDir, outDir, { force: true });
+    expect(forced.encrypted).toHaveLength(1);
+  });
+
+  test("creates the out dir if missing", () => {
+    writeFileSync(join(inDir, "m.txt"), "v");
+    const deepOut = join(outDir, "persona", "aaron");
+    expect(existsSync(deepOut)).toBe(false);
+    const res = encryptDir(self, inDir, deepOut, {});
+    expect(res.encrypted).toHaveLength(1);
+    expect(existsSync(deepOut)).toBe(true);
+  });
+});

--- a/tools/crypto/better-git-crypt/memory-encrypt-loop.test.ts
+++ b/tools/crypto/better-git-crypt/memory-encrypt-loop.test.ts
@@ -2,14 +2,15 @@
  * tools/crypto/better-git-crypt/memory-encrypt-loop.test.ts
  *
  * The load-bearing property: a folder of plaintext self-encrypts to `.zc` and each
- * `.zc` decrypts back to the EXACT input bytes with the SAME secret bundle (only
- * Aaron, as sender/self-recipient, can decrypt). Plus listing/naming/skip behavior.
+ * `.zc` decrypts back to the EXACT input bytes with the SAME secret bundle (only the
+ * secret-bundle holder, as sender/self-recipient, can decrypt). Plus listing/naming/
+ * skip behavior.
  */
 
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, basename } from "node:path";
 import {
   generateKeyPairJSON,
   deserializeSecretBundle,
@@ -27,8 +28,8 @@ beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), "mem-enc-loop-"));
   inDir = join(root, "in");
   outDir = join(root, "out");
-  Bun.spawnSync(["mkdir", "-p", inDir]);
-  self = deserializeSecretBundle(generateKeyPairJSON("aaron@test").secret);
+  mkdirSync(inDir, { recursive: true });
+  self = deserializeSecretBundle(generateKeyPairJSON("owner@test").secret);
 });
 
 afterEach(() => {
@@ -40,10 +41,11 @@ describe("listInputs / outPathFor", () => {
     writeFileSync(join(inDir, "b.txt"), "b");
     writeFileSync(join(inDir, "a.txt"), "a");
     writeFileSync(join(inDir, "note.md"), "x");
-    expect(listInputs(inDir).map((p) => p.split("/").pop())).toEqual(["a.txt", "b.txt"]);
+    expect(listInputs(inDir).map((p) => basename(p))).toEqual(["a.txt", "b.txt"]);
   });
   test("outPathFor strips inExt and appends .zc, preserving the name", () => {
-    expect(outPathFor("/x/drop/memory-foo.txt", "/x/out").endsWith("/out/memory-foo.zc")).toBe(true);
+    const out = outPathFor(join("x", "drop", "memory-foo.txt"), join("x", "out"));
+    expect(basename(out)).toBe("memory-foo.zc");
   });
   test("missing input dir → empty list (no throw)", () => {
     expect(listInputs(join(root, "nope"))).toEqual([]);
@@ -68,7 +70,7 @@ describe("encryptDir — self-encrypt round-trip", () => {
       const dec = decryptBytes(readFileSync(e.out), self); // sender = self (self-encrypted)
       expect(dec.ok).toBe(true);
       if (dec.ok) {
-        const original = samples[e.in.split("/").pop()!]!;
+        const original = samples[basename(e.in)]!;
         expect(Array.from(dec.plaintext)).toEqual(Array.from(original));
       }
     }
@@ -78,7 +80,7 @@ describe("encryptDir — self-encrypt round-trip", () => {
     writeFileSync(join(inDir, "secret.txt"), "private");
     const res = encryptDir(self, inDir, outDir, {});
     expect(res.encrypted).toHaveLength(1);
-    const other = deserializeSecretBundle(generateKeyPairJSON("not-aaron@test").secret);
+    const other = deserializeSecretBundle(generateKeyPairJSON("other@test").secret);
     const dec = decryptBytes(readFileSync(res.encrypted[0]!.out), other);
     expect(dec.ok).toBe(false);
   });
@@ -98,7 +100,7 @@ describe("encryptDir — self-encrypt round-trip", () => {
 
   test("creates the out dir if missing", () => {
     writeFileSync(join(inDir, "m.txt"), "v");
-    const deepOut = join(outDir, "persona", "aaron");
+    const deepOut = join(outDir, "persona", "owner");
     expect(existsSync(deepOut)).toBe(false);
     const res = encryptDir(self, inDir, deepOut, {});
     expect(res.encrypted).toHaveLength(1);

--- a/tools/crypto/better-git-crypt/memory-encrypt-loop.ts
+++ b/tools/crypto/better-git-crypt/memory-encrypt-loop.ts
@@ -2,31 +2,32 @@
 /**
  * tools/crypto/better-git-crypt/memory-encrypt-loop.ts
  *
- * Self-encrypt a folder of plaintext memories into post-quantum `.zc` envelopes —
- * the loop over the file CLI's encrypt step, for the "encrypt my non-1984 memories"
- * use case.
+ * Self-encrypt a folder of plaintext files into post-quantum `.zc` envelopes — the
+ * loop over the file CLI's encrypt step, for the "encrypt a folder of private
+ * memories" use case.
  *
  * SECURITY MODEL (load-bearing — read before running):
  *   `encryptBytes(bytes, self, [])` makes `self` the SENDER (it signs) AND the sole
  *   self-recipient (decryption-capable). With no extra recipients this is PURE
  *   self-encryption: ONLY the holder of `self`'s secret bundle can ever decrypt.
- *   Therefore "only AARON can decrypt" requires AARON to be the sender → AARON must
- *   run the real encrypt with HIS OWN secret bundle. An agent cannot run it: it has
- *   no secret bundle, and generating one for Aaron + holding it would defeat the
- *   only-Aaron property. The agent CAN run `--dry-run` (no key, no writes) to preview.
+ *   Therefore "only the owner can decrypt" requires THE OWNER to be the sender → the
+ *   key owner must run the real encrypt with their OWN secret bundle. An agent cannot
+ *   run it: it has no secret bundle, and generating one for the owner + holding it
+ *   would defeat the only-the-owner-decrypts property. An agent CAN run `--dry-run`
+ *   (no key, no writes) to preview.
  *
- * RUNBOOK (Aaron runs steps 1-2 locally; agent commits the .zc in step 3):
- *   1. one-time keygen (agent never sees the secret):
+ * RUNBOOK (the key owner runs steps 1-2 locally; an agent commits the .zc in step 3):
+ *   1. one-time keygen (the agent never sees the secret):
  *        bun tools/crypto/better-git-crypt/cli/main.ts \
- *          --gen-recipient aaron@zeta --out-dir ~/.zeta-keys
- *      → ~/.zeta-keys/aaron@zeta.recipient.json  (public; shareable)
- *        ~/.zeta-keys/aaron@zeta.secret.json     (SECRET — never commit; .zeta-keys/ is gitignored)
- *   2. self-encrypt the memories (this script):
+ *          --gen-recipient <identity> --out-dir ~/.zeta-keys
+ *      → ~/.zeta-keys/<identity>.recipient.json  (public; shareable)
+ *        ~/.zeta-keys/<identity>.secret.json     (SECRET — never commit; .zeta-keys/ is gitignored)
+ *   2. self-encrypt the folder (this script):
  *        bun tools/crypto/better-git-crypt/memory-encrypt-loop.ts \
- *          --keys ~/.zeta-keys/aaron@zeta.secret.json \
- *          --in drop --out memory/persona/aaron
- *      → one `.zc` per `*.txt` in drop/ (plaintext stays in drop/, which is gitignored)
- *   3. commit the `.zc` (the agent does this; plaintext never leaves drop/).
+ *          --keys ~/.zeta-keys/<identity>.secret.json \
+ *          --in <in-dir> --out <out-dir>
+ *      → one `.zc` per `*.txt` in <in-dir> (keep plaintext in a gitignored dir)
+ *   3. commit the `.zc` (the agent does this; plaintext never leaves the gitignored dir).
  *
  * The plaintext is preserved BYTE-FOR-BYTE inside the envelope — no edit, summary,
  * or redaction; decrypt returns the exact input bytes.
@@ -68,9 +69,10 @@ export interface EncryptDirResult {
 }
 
 /**
- * Self-encrypt every input under `inDir` to `<outDir>/<name>.zc`. `self` is Aaron's
- * secret bundle; pure self-encryption (no extra recipients) ⇒ only Aaron can decrypt.
- * Existing `.zc` are skipped unless `force`. Out dir is created if missing.
+ * Self-encrypt every input under `inDir` to `<outDir>/<name>.zc`. `self` is the key
+ * owner's secret bundle; pure self-encryption (no extra recipients) ⇒ only the
+ * secret-bundle holder can decrypt. Existing `.zc` are skipped unless `force`. The
+ * out dir is created if missing.
  */
 export function encryptDir(
   self: SelfKeys,
@@ -106,7 +108,7 @@ export function encryptDir(
 
 // --- CLI ---------------------------------------------------------------------
 
-/** Load Aaron's secret bundle; fail-closed if the file isn't a secret bundle. */
+/** Load the key owner's secret bundle; fail-closed if the file isn't a secret bundle. */
 function loadSelf(keysPath: string): SelfKeys {
   if (!existsSync(keysPath)) throw new Error(`--keys not found: ${keysPath}`);
   let parsed: unknown;
@@ -117,7 +119,7 @@ function loadSelf(keysPath: string): SelfKeys {
   }
   if (!looksLikeSecretBundle(parsed)) {
     throw new Error(
-      `--keys is not a secret bundle (need the SECRET key file, e.g. aaron@zeta.secret.json — ` +
+      `--keys is not a secret bundle (need the SECRET key file, e.g. <identity>.secret.json — ` +
         `NOT the .recipient.json public file): ${keysPath}`,
     );
   }
@@ -135,16 +137,16 @@ function flagValue(args: readonly string[], name: string): string | undefined {
 const USAGE = `memory-encrypt-loop — self-encrypt a folder of memories to post-quantum .zc
 
   Preview (no key, no writes — the only mode an agent should run):
-    bun tools/crypto/better-git-crypt/memory-encrypt-loop.ts --dry-run --in drop --out memory/persona/aaron
+    bun tools/crypto/better-git-crypt/memory-encrypt-loop.ts --dry-run --in <in-dir> --out <out-dir>
 
-  Real run (AARON only — requires Aaron's SECRET bundle as sender):
+  Real run (key owner only — requires the owner's SECRET bundle as sender):
     bun tools/crypto/better-git-crypt/memory-encrypt-loop.ts \\
-      --keys ~/.zeta-keys/aaron@zeta.secret.json --in drop --out memory/persona/aaron
+      --keys ~/.zeta-keys/<identity>.secret.json --in <in-dir> --out <out-dir>
 
   Flags:
     --in <dir>      input dir of plaintext files            (required)
     --out <dir>     output dir for .zc envelopes            (required)
-    --keys <file>   Aaron's SECRET bundle JSON              (required unless --dry-run)
+    --keys <file>   the owner's SECRET bundle JSON          (required unless --dry-run)
     --in-ext <ext>  input extension filter                  (default .txt)
     --dry-run       list inputs → outputs; no key, no writes
     --force         overwrite existing .zc
@@ -197,14 +199,14 @@ async function main(argv: readonly string[]): Promise<number> {
       process.stdout.write(`  ${f}  →  ${out}${exists}\n`);
     }
     process.stdout.write(
-      `\nTo actually encrypt, AARON runs with --keys <secret-bundle> (only-Aaron-decrypts requires Aaron as sender).\n`,
+      `\nTo actually encrypt, the key owner runs with --keys <secret-bundle> (the sender is the sole decryptor).\n`,
     );
     return 0;
   }
 
   if (!keys) {
     process.stderr.write(
-      `--keys is required for a real run (only AARON can run this — the secret bundle is the sender).\n` +
+      `--keys is required for a real run (only the key owner can run this — the secret bundle is the sender / sole decryptor).\n` +
         `Use --dry-run to preview without a key.\n\n${USAGE}`,
     );
     return 2;

--- a/tools/crypto/better-git-crypt/memory-encrypt-loop.ts
+++ b/tools/crypto/better-git-crypt/memory-encrypt-loop.ts
@@ -1,0 +1,235 @@
+#!/usr/bin/env bun
+/**
+ * tools/crypto/better-git-crypt/memory-encrypt-loop.ts
+ *
+ * Self-encrypt a folder of plaintext memories into post-quantum `.zc` envelopes —
+ * the loop over the file CLI's encrypt step, for the "encrypt my non-1984 memories"
+ * use case.
+ *
+ * SECURITY MODEL (load-bearing — read before running):
+ *   `encryptBytes(bytes, self, [])` makes `self` the SENDER (it signs) AND the sole
+ *   self-recipient (decryption-capable). With no extra recipients this is PURE
+ *   self-encryption: ONLY the holder of `self`'s secret bundle can ever decrypt.
+ *   Therefore "only AARON can decrypt" requires AARON to be the sender → AARON must
+ *   run the real encrypt with HIS OWN secret bundle. An agent cannot run it: it has
+ *   no secret bundle, and generating one for Aaron + holding it would defeat the
+ *   only-Aaron property. The agent CAN run `--dry-run` (no key, no writes) to preview.
+ *
+ * RUNBOOK (Aaron runs steps 1-2 locally; agent commits the .zc in step 3):
+ *   1. one-time keygen (agent never sees the secret):
+ *        bun tools/crypto/better-git-crypt/cli/main.ts \
+ *          --gen-recipient aaron@zeta --out-dir ~/.zeta-keys
+ *      → ~/.zeta-keys/aaron@zeta.recipient.json  (public; shareable)
+ *        ~/.zeta-keys/aaron@zeta.secret.json     (SECRET — never commit; .zeta-keys/ is gitignored)
+ *   2. self-encrypt the memories (this script):
+ *        bun tools/crypto/better-git-crypt/memory-encrypt-loop.ts \
+ *          --keys ~/.zeta-keys/aaron@zeta.secret.json \
+ *          --in drop --out memory/persona/aaron
+ *      → one `.zc` per `*.txt` in drop/ (plaintext stays in drop/, which is gitignored)
+ *   3. commit the `.zc` (the agent does this; plaintext never leaves drop/).
+ *
+ * The plaintext is preserved BYTE-FOR-BYTE inside the envelope — no edit, summary,
+ * or redaction; decrypt returns the exact input bytes.
+ */
+
+import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync, statSync } from "node:fs";
+import { join, basename } from "node:path";
+import {
+  deserializeSecretBundle,
+  looksLikeSecretBundle,
+  encryptBytes,
+  type SelfKeys,
+  type SecretBundleJSON,
+} from "./files";
+
+// --- pure helpers (unit-testable without a CLI / without a key for listing) ---
+
+/** Input files to encrypt: regular files under `inDir` with extension `inExt`. */
+export function listInputs(inDir: string, inExt = ".txt"): string[] {
+  if (!existsSync(inDir) || !statSync(inDir).isDirectory()) return [];
+  return readdirSync(inDir)
+    .filter((n) => n.toLowerCase().endsWith(inExt.toLowerCase()))
+    .map((n) => join(inDir, n))
+    .filter((p) => statSync(p).isFile())
+    .sort();
+}
+
+/** `<outDir>/<basename-without-inExt>.zc` — preserves the source name. */
+export function outPathFor(inFile: string, outDir: string, inExt = ".txt"): string {
+  let stem = basename(inFile);
+  if (stem.toLowerCase().endsWith(inExt.toLowerCase())) stem = stem.slice(0, stem.length - inExt.length);
+  return join(outDir, `${stem}.zc`);
+}
+
+export interface EncryptDirResult {
+  readonly encrypted: ReadonlyArray<{ readonly in: string; readonly out: string; readonly recipients: string[] }>;
+  readonly skipped: ReadonlyArray<{ readonly in: string; readonly reason: string }>;
+  readonly errors: ReadonlyArray<{ readonly in: string; readonly feedback: string }>;
+}
+
+/**
+ * Self-encrypt every input under `inDir` to `<outDir>/<name>.zc`. `self` is Aaron's
+ * secret bundle; pure self-encryption (no extra recipients) ⇒ only Aaron can decrypt.
+ * Existing `.zc` are skipped unless `force`. Out dir is created if missing.
+ */
+export function encryptDir(
+  self: SelfKeys,
+  inDir: string,
+  outDir: string,
+  opts: { force?: boolean; inExt?: string } = {},
+): EncryptDirResult {
+  const inExt = opts.inExt ?? ".txt";
+  const encrypted: Array<{ in: string; out: string; recipients: string[] }> = [];
+  const skipped: Array<{ in: string; reason: string }> = [];
+  const errors: Array<{ in: string; feedback: string }> = [];
+
+  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+
+  for (const inFile of listInputs(inDir, inExt)) {
+    const out = outPathFor(inFile, outDir, inExt);
+    if (existsSync(out) && !opts.force) {
+      skipped.push({ in: inFile, reason: `output exists (use --force): ${out}` });
+      continue;
+    }
+    const bytes = readFileSync(inFile); // Buffer is a Uint8Array
+    const res = encryptBytes(bytes, self, []); // [] = pure self-encryption
+    if (!res.ok) {
+      errors.push({ in: inFile, feedback: JSON.stringify(res.feedback) });
+      continue;
+    }
+    writeFileSync(out, res.envelopeBytes);
+    encrypted.push({ in: inFile, out, recipients: res.recipientIdentities });
+  }
+
+  return { encrypted, skipped, errors };
+}
+
+// --- CLI ---------------------------------------------------------------------
+
+/** Load Aaron's secret bundle; fail-closed if the file isn't a secret bundle. */
+function loadSelf(keysPath: string): SelfKeys {
+  if (!existsSync(keysPath)) throw new Error(`--keys not found: ${keysPath}`);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(keysPath, "utf8"));
+  } catch (e) {
+    throw new Error(`--keys is not valid JSON: ${keysPath} (${(e as Error).message})`);
+  }
+  if (!looksLikeSecretBundle(parsed)) {
+    throw new Error(
+      `--keys is not a secret bundle (need the SECRET key file, e.g. aaron@zeta.secret.json — ` +
+        `NOT the .recipient.json public file): ${keysPath}`,
+    );
+  }
+  return deserializeSecretBundle(parsed as SecretBundleJSON);
+}
+
+function flagValue(args: readonly string[], name: string): string | undefined {
+  const i = args.indexOf(name);
+  if (i < 0) return undefined;
+  const v = args[i + 1];
+  if (v === undefined || v.startsWith("--")) throw new Error(`${name} requires a value`);
+  return v;
+}
+
+const USAGE = `memory-encrypt-loop — self-encrypt a folder of memories to post-quantum .zc
+
+  Preview (no key, no writes — the only mode an agent should run):
+    bun tools/crypto/better-git-crypt/memory-encrypt-loop.ts --dry-run --in drop --out memory/persona/aaron
+
+  Real run (AARON only — requires Aaron's SECRET bundle as sender):
+    bun tools/crypto/better-git-crypt/memory-encrypt-loop.ts \\
+      --keys ~/.zeta-keys/aaron@zeta.secret.json --in drop --out memory/persona/aaron
+
+  Flags:
+    --in <dir>      input dir of plaintext files            (required)
+    --out <dir>     output dir for .zc envelopes            (required)
+    --keys <file>   Aaron's SECRET bundle JSON              (required unless --dry-run)
+    --in-ext <ext>  input extension filter                  (default .txt)
+    --dry-run       list inputs → outputs; no key, no writes
+    --force         overwrite existing .zc
+`;
+
+const KNOWN = new Set(["--in", "--out", "--keys", "--in-ext", "--dry-run", "--force", "--help", "-h"]);
+
+async function main(argv: readonly string[]): Promise<number> {
+  const args = argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(USAGE);
+    return 0;
+  }
+  for (const a of args) {
+    if (a.startsWith("--") && !KNOWN.has(a)) {
+      process.stderr.write(`unknown flag: ${a}\n\n${USAGE}`);
+      return 2;
+    }
+  }
+
+  let inDir: string | undefined, outDir: string | undefined, keys: string | undefined, inExt: string;
+  try {
+    inDir = flagValue(args, "--in");
+    outDir = flagValue(args, "--out");
+    keys = flagValue(args, "--keys");
+    inExt = flagValue(args, "--in-ext") ?? ".txt";
+  } catch (e) {
+    process.stderr.write(`${(e as Error).message}\n\n${USAGE}`);
+    return 2;
+  }
+  const dryRun = args.includes("--dry-run");
+  const force = args.includes("--force");
+
+  if (!inDir || !outDir) {
+    process.stderr.write(`--in and --out are required\n\n${USAGE}`);
+    return 2;
+  }
+
+  const inputs = listInputs(inDir, inExt);
+  if (inputs.length === 0) {
+    process.stderr.write(`no ${inExt} files found under ${inDir}\n`);
+    return 1;
+  }
+
+  if (dryRun) {
+    process.stdout.write(`DRY RUN — would self-encrypt ${inputs.length} file(s) (no key, no writes):\n`);
+    for (const f of inputs) {
+      const out = outPathFor(f, outDir, inExt);
+      const exists = existsSync(out) && !force ? "  [SKIP: output exists, use --force]" : "";
+      process.stdout.write(`  ${f}  →  ${out}${exists}\n`);
+    }
+    process.stdout.write(
+      `\nTo actually encrypt, AARON runs with --keys <secret-bundle> (only-Aaron-decrypts requires Aaron as sender).\n`,
+    );
+    return 0;
+  }
+
+  if (!keys) {
+    process.stderr.write(
+      `--keys is required for a real run (only AARON can run this — the secret bundle is the sender).\n` +
+        `Use --dry-run to preview without a key.\n\n${USAGE}`,
+    );
+    return 2;
+  }
+
+  let self: SelfKeys;
+  try {
+    self = loadSelf(keys);
+  } catch (e) {
+    process.stderr.write(`${(e as Error).message}\n`);
+    return 2;
+  }
+
+  const result = encryptDir(self, inDir, outDir, { force, inExt });
+  for (const e of result.encrypted) {
+    process.stdout.write(`encrypted  ${e.in}  →  ${e.out}  (recipients: ${e.recipients.join(", ")})\n`);
+  }
+  for (const s of result.skipped) process.stdout.write(`skipped    ${s.in}  (${s.reason})\n`);
+  for (const er of result.errors) process.stderr.write(`ERROR      ${er.in}  (${er.feedback})\n`);
+  process.stdout.write(
+    `\n${result.encrypted.length} encrypted, ${result.skipped.length} skipped, ${result.errors.length} errors.\n`,
+  );
+  return result.errors.length > 0 ? 1 : 0;
+}
+
+if (import.meta.main) {
+  main(process.argv).then((code) => process.exit(code));
+}


### PR DESCRIPTION
Aaron 2026-06-02: **"run the memory-encrypt loop script (shadow*)"**.

The loop over the better-git-crypt `--encrypt-file` step, for the *encrypt my private memories* use case.

**Security model is load-bearing (why the agent does NOT run the encrypt):** `encryptBytes(bytes, self, [])` makes `self` the SENDER (it signs) AND the sole self-recipient → pure self-encryption means *only the holder of `self`'s secret bundle can decrypt*. So **only-Aaron-decrypts requires AARON to be the sender** — Aaron runs the real encrypt with his own secret bundle. The agent cannot run it (no secret bundle; gen-ing one for Aaron + holding it would defeat the only-Aaron property). The agent CAN run `--dry-run` (no key, no writes).

**Runbook:**
1. `--gen-recipient aaron@zeta --out-dir ~/.zeta-keys` (one-time; agent never sees the secret; `.zeta-keys/` gitignored)
2. `memory-encrypt-loop.ts --keys ~/.zeta-keys/aaron@zeta.secret.json --in drop --out memory/persona/aaron` (AARON runs; plaintext stays in `drop/`, gitignored)
3. agent commits the `.zc` (plaintext never leaves `drop/`)

Each `.zc` decrypts to the **exact input bytes** — no edit/summary/redaction (the sacred-memory constraint).

- `encryptDir`/`listInputs`/`outPathFor` pure helpers + CLI (`--in`/`--out`/`--keys`/`--dry-run`/`--force`/`--in-ext`)
- fail-closed: real run without `--keys` errors; non-secret-bundle `--keys` rejected
- 7 tests pass: round-trip byte-for-byte (text/binary/unicode), wrong-key-fails, skip-unless-force, out-dir-create; scoped tsc clean; live `--dry-run` verified
- README runbook added

🤖 Generated with [Claude Code](https://claude.com/claude-code)