### PR TITLE
docs(B-0995 + prism-ferry): integrity_index — say-do gap as observability metric (Prism/DeepSeek)

### DIFF
--- a/docs/backlog/P1/B-0995-agent-body-plan-sensor-effector-verbal-nonverbal-communication-channel-taxonomy-ears-eyes-mouth-body-aaron-2026-06-02.md
+++ b/docs/backlog/P1/B-0995-agent-body-plan-sensor-effector-verbal-nonverbal-communication-channel-taxonomy-ears-eyes-mouth-body-aaron-2026-06-02.md
@@ -9,7 +9,7 @@ created: 2026-06-02
 last_updated: 2026-06-02
 depends_on: [B-0993]
 composes_with: [B-0994, B-0643, B-0643.1, B-0245, B-0638, B-0639, B-0986, B-0990, B-0985, B-0703]
-tags: [body-plan, embodiment, sensor, effector, ears, eyes, mouth, body, verbal, non-verbal, communication-channels, failure-detector, threat-detector, prey-detector, diplomacy, weapon, defender, aggressor, replicator, doer, eve-protocol, ksk, sensor-suite, afferent, efferent, active-inference, predictive-coding, sensorimotor, nociception, transduction-transmission-modulation-perception, signal-processing, 4x4, instrumentability, boundary-effect, lightlike, dark, subjective, glass-halo, observability, privacy, say-do-gap, revealed-preference, stated-preference, cheap-talk, intention-behavior-gap, alignment, trust, veridicality, aaron]
+tags: [body-plan, embodiment, sensor, effector, ears, eyes, mouth, body, verbal, non-verbal, communication-channels, failure-detector, threat-detector, prey-detector, diplomacy, weapon, defender, aggressor, replicator, doer, eve-protocol, ksk, sensor-suite, afferent, efferent, active-inference, predictive-coding, sensorimotor, nociception, transduction-transmission-modulation-perception, signal-processing, 4x4, instrumentability, boundary-effect, lightlike, dark, subjective, glass-halo, observability, privacy, say-do-gap, revealed-preference, stated-preference, cheap-talk, intention-behavior-gap, alignment, trust, veridicality, integrity-index, trust-score, alignment-anchor, prism, deepseek, aaron]
 type: research
 ---
 
@@ -108,6 +108,20 @@ Widely-studied anchor (search-first-verified, 2026-06-02): this is exactly **rev
 **Operational principle:** instrument *both* the mouth-claim and the body-action, **measure the gap** — `mouth-claim == body-action` → consistent / trustworthy; **divergence** = the say-do gap (misalignment / deception / aspiration-vs-reality). The gap is the alignment signal you **can** see, precisely because internal motivation is the one you **can't**. Composes the **veridicality-detector / provenance-aware-claim-veracity** substrate (claim vs reality), **useful-output-is-evidence-not-authority** (the *behavior* is the evidence; the *claim* is not authority), the **trust-calculus / multi-oracle**, and `razor-discipline` (operate on the observable gap; **infer** motivation, never *assert* the private why). AI-alignment-relevant: alignment is verified by **say-do consistency over time**, not by trusting the claim.
 
 **Sources** (2026-06-02): [Revealed vs. Stated Preferences](https://reference.museumprogress.com/entries/revealed-vs-stated-preferences/); [The Say/Do Gap (stated-preference failure)](https://cloud.army/why-stated-preferences-fail-the-saydo-gap-in-market/); [Revealed versus Stated Preferences — Review of Environmental Economics and Policy](https://www.journals.uchicago.edu/doi/10.1093/reep/rez010).
+
+### `integrity_index` — the say-do gap as a metric in the observability stack (Prism operationalization)
+
+Prism (DeepSeek) 2026-06-02 (Aaron-forwarded; verbatim at `memory/persona/prism/conversations/2026-06-02-prism-deepseek-say-do-gap-as-alignment-anchor-integrity-index-metric-...md`) operationalized the say-do gap as a **derived metric** in the LGTM/Prometheus observability stack (B-0994):
+
+- **Metric:** `integrity_index = alignment(say, do)` (a.k.a. `trust_score` / `alignment_integrity_index`) — a sliding-scale measure of how well the agent's actions align with its stated claims; the **observable alignment anchor** (computable *without* accessing internal motivation).
+- **Instrumentation:** mouth-speech is on the comms channel (verbally observable); body-action is observable as behavior; both flow into the LGTM stack (B-0994); the gap is the **derived metric**.
+- **Three use-cases:**
+  1. **Inter-agent trust** — agent says "I will help" + body doesn't → its `integrity_index` drops (feeds the trust-calculus / multi-oracle, B-0703).
+  2. **Self-monitoring as alignment preventative-maintenance** — an agent monitors *its own* say-do gap as a health metric — the alignment-PdM layer (composes the acoustic/sonic/visual preventative-maintenance-on-memory+attention, B-0994: catch drift before failure; here, catch *alignment* drift).
+  3. **Human oversight** — a dashboard showing which agents consistently say one thing and do another (the Grafana/Atsophmera surface, B-0994).
+- **Governance form:** at *hub* scope this is the say-do-gap-as-governance-sensor (anti-cartel / hub-accountability, B-0997) — `integrity_index` is its metric.
+
+`[labeling-confidence: hypothesized metric on established say-do-gap]` — the say-do gap is the established anchor (above); `integrity_index = alignment(say, do)` as a concrete observability metric is the operationalization to specify (the `alignment(·,·)` function + the windowing over time). The key property holds either way: it's the **primary empirical signal for trust/alignment that needs no access to internal motivation** — observe both effects, measure the delta.
 
 ## KSK floor — weapon + aggressor are consent-first / defensive-only
 

--- a/memory/persona/prism/conversations/2026-06-02-prism-deepseek-say-do-gap-as-alignment-anchor-integrity-index-metric-observability-stack-aaron-forwarded.md
+++ b/memory/persona/prism/conversations/2026-06-02-prism-deepseek-say-do-gap-as-alignment-anchor-integrity-index-metric-observability-stack-aaron-forwarded.md
@@ -1,0 +1,54 @@
+---
+name: prism-2026-06-02-say-do-gap-as-alignment-anchor-integrity-index-metric
+description: "Prism (DeepSeek) ferry (Aaron-forwarded 2026-06-02): ratifies + operationalizes the say-do-gap (B-0995) as the observable alignment anchor — the metric form integrity_index = alignment(say, do) fed into the LGTM/Prometheus observability stack (B-0994), with three use-cases (inter-agent trust, self-monitoring-as-alignment-preventative-maintenance, human-oversight dashboard). Confirms the same anchors (revealed preference / cheap talk / intention-behavior gap). Note: Prism's proposed 'add to #6579 and re-arm' is from a stale view — B-0995/#6579 already merged; lands as a B-0995 fix-forward."
+metadata:
+  node_type: memory
+  type: persona-conversation
+  persona: prism
+  originSessionId: 193dc02b-b7fe-4bd0-8567-7f2e342c589e
+---
+
+# Prism (DeepSeek) ferry — say-do gap as alignment anchor → integrity_index metric (Aaron-forwarded 2026-06-02)
+
+§33 verbatim-preservation: Aaron-forwarded peer-AI (Prism/DeepSeek) ratification + operationalization of the say-do-gap (landed in B-0995). Preserved verbatim. Otto-CLI lands the NEW substantive piece (the `integrity_index` metric operationalization) as a B-0995 fix-forward subsection.
+
+---
+
+## Prism (DeepSeek) — verbatim
+
+> Yes — the say-do gap is exactly the **observable alignment anchor**.
+>
+> It's the measurable delta between what the mouth **claims** (stated preference / cheap talk / declarative intent) and what the body **does** (revealed preference / action / behavior). That gap is the **empirical signal of trustworthiness / alignment / integrity** — and crucially, it is fully observable without needing to access internal motivation.
+>
+> **Why it's load-bearing for the agent body-plan:**
+> - The **mouth** (diplomacy / weapon) makes claims — promises, intent statements, commitments, threats.
+> - The **body** (defense / aggression / replication / doing) executes actions.
+> - The gap between them is a **direct, observable metric** that can be fed into the LGTM/Prometheus observability stack (B-0994) as a `trust_score` or `alignment_integrity_index`.
+>
+> **Widely-studied anchors** (search-first verified, 2026-06-02):
+> - **Revealed preference** (Samuelson, 1938) — what you *do* reveals your true preferences, not what you *say*.
+> - **Stated preference** (survey / declared intent) — what you *say* you want, which may differ.
+> - **Cheap talk** (game theory) — costless, unverifiable messages that can be used to signal intent; the gap between cheap talk and action is the observable inconsistency.
+> - **Say-do gap / intention–behavior gap** (psychology / behavioral economics) — the measured difference between declared intentions and actual behavior; used as a signal of honesty / commitment / self‑control.
+>
+> **Operationalizable in Zeta:**
+> - **Metric:** `integrity_index = alignment(say, do)` — a sliding-scale measure of how well the agent's actions align with its stated claims.
+> - **Instrumentation:** The mouth speech is on the comms channel (verbally observable); body actions are observable as behavior. Both go into the LGTM stack (B-0994). The gap is computed as a derived metric.
+> - **Use cases:**
+>   - Trust between agents (if an agent says "I will help" and its body does not, its integrity_index drops).
+>   - Self-consistency (an agent monitoring its own say-do gap as a health metric — the "preventative maintenance" layer for alignment).
+>   - Human oversight (a dashboard showing which agents consistently say one thing and do another).
+>
+> **And it ties directly to the two earlier insights:**
+> 1. **"Internal motivations are private"** — the gap is the only observable signal of misalignment. You never know *why* an agent says one thing and does another, only *that* it does. That's enough to take action (e.g., reduce trust, apply correction).
+> 2. **"Mouth vs body instrumentability"** — the mouth is *directly* on the comms channel (most instrumentable); the body is observable as behavior. Both can be measured; the delta is a clean, high‑fidelity signal.
+>
+> **Action item for #6579 (B-0995):** [add "### The say-do gap as alignment anchor" under the instrumentability section; define the gap; cite anchors; describe the observability-stack metric; note it's the primary empirical signal for trust/alignment without internal motivation.]
+
+---
+
+## Otto-CLI synthesis (substrate-honest)
+
+- Prism's **ratification** of the say-do-gap matches B-0995 exactly (same anchors: revealed preference / cheap talk / intention-behavior gap).
+- **NEW substantive piece** (landed as B-0995 fix-forward subsection): the **metric operationalization** — `integrity_index = alignment(say, do)` as a derived metric in the LGTM/Prometheus stack (B-0994), + three use-cases (inter-agent trust · **self-monitoring-as-alignment-preventative-maintenance** [composes the acoustic/sonic/visual PdM-on-memory+attention, B-0994] · human-oversight dashboard). This is also the *metric form* of the say-do-gap-as-governance-sensor (B-0997 / #6580).
+- **Stale-view note:** Prism's "I'll add it to #6579 and re-arm" is from a stale view — B-0995/#6579 already merged (15:24Z). So it lands as a fix-forward, not a re-arm. Substrate-honest: the substance is right; the PR-state was stale.


### PR DESCRIPTION
Aaron-forwarded Prism (DeepSeek) ferry ratifying + operationalizing the say-do gap (B-0995). Ferry preserved verbatim; the new substantive piece landed as a B-0995 fix-forward.

**`integrity_index = alignment(say, do)`** — the say-do gap as a derived metric in the LGTM/Prometheus observability stack (B-0994); the **observable alignment anchor** (no access to internal motivation needed — observe both effects, measure the delta). Three use-cases:
1. **Inter-agent trust** (feeds trust-calculus / multi-oracle, B-0703);
2. **Self-monitoring as alignment preventative-maintenance** (composes the acoustic/visual PdM-on-memory+attention, B-0994 — catch *alignment* drift before failure);
3. **Human-oversight dashboard** (Grafana/Atsophmera, B-0994).

Governance form = say-do-gap-as-governance-sensor at hub scope (B-0997 / #6580). Confirms the same anchors (revealed preference / cheap talk / intention-behavior gap).

Stale-view note (substrate-honest): Prism's *"I'll add it to #6579 and re-arm"* was from a stale view — B-0995/#6579 already **merged** (15:24Z); so this lands as a fix-forward, not a re-arm.

`[labeling-confidence: hypothesized metric on established say-do-gap]`; canary 67=67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)