### PR TITLE
docs(ace): slice 8.1 spec — trust core consumes the shared canonical-JSON

### DIFF
--- a/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.1-canonical-json-consume-design.md
+++ b/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.1-canonical-json-consume-design.md
@@ -1,0 +1,142 @@
+# Ace slice 8.1 — trust core consumes the shared canonical-JSON (design)
+
+> Spec for slice 8.1 of the Ace package manager (B-0288), second step of the
+> cross-language Ace trust core (after slice 8 SHA-256). Ace's trust core stops
+> using its own ad-hoc `canonicalize` + `JSON.stringify` and instead **consumes the
+> shared 4-language byte-locked canonical-JSON** (`src/Core.TypeScript/dynamic-value/json.ts`
+> `canonicalJson`, built by the DynamicValue serializer-roster lane). Brainstormed +
+> approved with the operator 2026-06-02 (consume the existing canonical-JSON; keep
+> Ace's current sorted-key robustness via a sorting `toTagged`).
+
+## Goal
+
+`package_hash`, `key_id`, and index/manifest signing all rest on a canonical byte
+form. Today Ace rolls its own (`canonicalize` = recursive key-sort, then
+`JSON.stringify`). This slice replaces that with the project's **single shared
+canonical-JSON primitive** — the same `canonicalJson` that is byte-locked across
+TS/F#/C#/Rust (`golden-vectors.json`, 31 vectors) — so Ace's trust core is built on
+the audited, cross-language-agreed canonicalization rather than a parallel ad-hoc one.
+A future Rust/F#/C# Ace consumer then computes byte-identical `package_hash` for free
+(inherited from the 4-language byte-lock).
+
+## Why consume, not build (investigation, operator 2026-06-02)
+
+- The DynamicValue lane already shipped `canonicalJson` (encode) + `fromCanonicalJson`
+  (decode, precision-safe + strict-canonical) across all four languages, byte-locked
+  on shared golden vectors. Building a second canonical-JSON in Ace would duplicate
+  audited cross-language substrate (`verify-existing-substrate-before-authoring`).
+- Ace's `IndexSignableContent` is entirely `int` / `string` / `object`
+  (`format_version` + `sequence` are ints, `issued_at` is a string, packages /
+  `revoked` / `quarantined` are nested objects). **No Float, no Bytes** — so the JSON
+  canonical form (which covers 6 of 8 shapes; Float/Bytes lock only under CBOR) covers
+  Ace completely. No CBOR needed for the Ace index.
+- Ace's current `canonicalize` **sorts keys** (`Object.keys().sort()`), and
+  `canonicalJson` is order-**preserving**. These reconcile cleanly: `canonicalJson`
+  preserves whatever order its `Tagged` input carries, so an Ace `toTagged` that
+  **sorts object keys** yields sorted-key canonical output — Ace keeps its current
+  key-order-independence *and* consumes the shared primitive. (Pure insertion-order
+  would downgrade Ace's robustness for no gain.)
+
+## Decisions (this spec locks them; operator 2026-06-02)
+
+1. **Consume `canonicalJson`.** Ace's canonical byte form becomes
+   `canonicalJson(toTagged(content))`, importing `canonicalJson` + the `Tagged` type
+   from `src/Core.TypeScript/dynamic-value/json.ts`. No new canonical-JSON is written.
+2. **`toTagged` sorts object keys.** The plain-JS → `Tagged` converter emits object
+   entries in lexicographically-**sorted** key order, preserving Ace's current
+   sorted-key (key-order-independent) robustness through the order-preserving
+   `canonicalJson`.
+3. **`toTagged` asserts integers.** A JS `number` must be an integer (`Number.isInteger`)
+   → emitted as `{t:"int", v:String(n)}`; a non-integer (accidental Float) is a hard
+   error (Ace has no Float fields, so a Float means a bug — fail loud, never silently
+   hash a float). `null`/`bool`/`string`/`array`/`object` map directly. `undefined`
+   object properties are omitted (matching JSON / the current `canonicalize`).
+4. **Rewire all three canonical-byte sites** to the shared form: `canonicalIndexBytes`
+   + `canonicalManifestBytes` (`tools/ace/signing.ts`) and `packageHash`
+   (`tools/ace/resolve.ts`). Delete the local `canonicalize`.
+5. **Format change accepted.** The exact canonical bytes shift (the shared
+   `canonicalJson`'s escaping + int re-canonicalization differ from the current
+   `JSON.stringify`), so previously-signed indexes / previously-computed `package_hash`
+   values change. Ace is pre-release (no live registries), so this is acceptable; no
+   `format_version` bump. Documented as a one-time canonicalization migration.
+6. **Scope is TypeScript-only.** The Ace CLI is TS; it consumes the TS `canonicalJson`.
+   The 4-language byte-lock means a future Rust/F#/C# Ace consumer inherits identical
+   `package_hash` without further work — no cross-language Ace is built in this slice.
+
+## Architecture
+
+A thin Ace-side adapter `tools/ace/canonical.ts` owns the boundary to the shared
+primitive (own-the-interface — the rest of Ace depends on this adapter, not directly
+on the dynamic-value port):
+
+```text
+tools/ace/canonical.ts
+  import { canonicalJson, type Tagged } from "../../src/Core.TypeScript/dynamic-value/json";
+  toTagged(value: unknown): Tagged        // sorts object keys; asserts integers
+  canonicalBytes(value: unknown): Uint8Array   // = encode(canonicalJson(toTagged(value)))
+```
+
+`signing.ts` (`canonicalIndexBytes`, `canonicalManifestBytes`) and `resolve.ts`
+(`packageHash`) call `canonicalBytes(...)`; the local recursive `canonicalize` is
+removed. Signing / verification / hashing semantics are otherwise unchanged — only the
+canonical byte producer is swapped.
+
+## Components
+
+- **`tools/ace/canonical.ts`** — `toTagged` + `canonicalBytes`; the single Ace↔shared
+  canonical-JSON seam. Imports `canonicalJson` + `Tagged` from the dynamic-value port.
+- **`tools/ace/signing.ts`** — `canonicalIndexBytes` / `canonicalManifestBytes` call
+  `canonicalBytes`; `canonicalize` deleted. `signIndex` / `verifyIndexSignature` /
+  `signManifest` / `verifySignature` unchanged (they already go through the
+  canonical-bytes helpers).
+- **`tools/ace/resolve.ts`** — `packageHash` computes `sha256(canonicalBytes(pkg))`
+  (whatever subset it currently canonicalizes, now via the shared form).
+
+## Testing
+
+- **Behavior-preservation (the load-bearing gate):** the existing Ace suites
+  (`tools/ace/ace.test.ts` + signing/publish/revocation tests) must stay green —
+  sign→verify round-trips, `package_hash` determinism + drift detection,
+  publish-side anti-rollback, revocation/quarantine, content_hash. The *values* change
+  (new canonicalization) but every invariant (round-trip, determinism, tamper-detect)
+  must hold. Update any test that pins a literal canonical hash/bytes to the new value
+  (the change is intentional, one-time).
+- **`toTagged` unit tests:** null / bool / integer-number / string / array / nested
+  object; **sorted-key output** (object with keys out of order → sorted); **integer
+  assertion** (a Float input → throws/declines); `undefined` property omitted.
+- **Equivalence cross-check:** for representative Ace index + manifest objects,
+  `canonicalBytes(x)` equals `canonicalJson(toTagged(x))` and decodes back via
+  `fromCanonicalJson` (round-trip through the shared primitive's own inverse).
+- **Determinism:** `canonicalBytes` of the same logical content with keys in different
+  insertion orders yields identical bytes (the sorted-key robustness).
+- Gates: `bun test tools/ace/`; `bun --bun tsc --noEmit -p tsconfig.json` exit 0;
+  markdownlint on this doc + any registry edit.
+
+## Scope / YAGNI
+
+In scope: `toTagged` (sorting, integer-asserting) + `canonicalBytes`; rewire the three
+canonical-byte sites; delete `canonicalize`; tests. Out of scope: Float/Bytes support
+(Ace has none); CBOR (Ace's index is JSON); adding a sorted-key *mode* to the shared
+`canonicalJson` (unnecessary — Ace sorts at `toTagged`); a cross-language Ace (the
+byte-lock already guarantees future parity); `format_version` bump (pre-release).
+
+## Files touched
+
+- `tools/ace/canonical.ts` — **new** (`toTagged` + `canonicalBytes`).
+- `tools/ace/signing.ts` — rewire `canonicalIndexBytes` + `canonicalManifestBytes` to
+  `canonicalBytes`; delete `canonicalize`.
+- `tools/ace/resolve.ts` — `packageHash` via `canonicalBytes`.
+- `tools/ace/canonical.test.ts` — **new** (`toTagged` + equivalence + determinism).
+- `tools/ace/ace.test.ts` (+ signing tests) — update any pinned canonical literals to
+  the new (intentional) values; all invariants stay asserted.
+
+## Decomposition (2 tasks)
+
+- **T1 — `tools/ace/canonical.ts` + tests.** `toTagged` (sort keys, assert integers,
+  omit undefined) + `canonicalBytes` consuming `canonicalJson`; unit tests (shapes,
+  sorted output, integer-assertion, equivalence + `fromCanonicalJson` round-trip,
+  determinism). TDD.
+- **T2 — rewire + behavior-preservation + PR.** Swap `canonicalIndexBytes` /
+  `canonicalManifestBytes` / `packageHash` onto `canonicalBytes`; delete
+  `canonicalize`; re-green the Ace suites (update intentional pinned literals); open
+  the impl PR + gate loop.


### PR DESCRIPTION
Spec for Ace slice 8.1 (cross-language trust core, after slice 8 SHA-256). Ace's trust core stops rolling its own `canonicalize`+`JSON.stringify` and **consumes the shared 4-language byte-locked `canonicalJson`** (the DynamicValue lane's `src/Core.TypeScript/dynamic-value/json.ts`).

**Investigation findings (operator-requested):**
- Ace's content (`IndexSignableContent`) is all int/string/object — no Float/Bytes — so the JSON canonical form (6/8 shapes) covers it fully.
- Ace's current `canonicalize` already **sorts keys**; the shared `canonicalJson` is order-**preserving** → reconciled by an Ace `toTagged` that **sorts object keys** (keeps Ace's key-order-independence while consuming the shared primitive).
- No plain-JS→`Tagged` converter exists in the lane — that's the one piece Ace writes.

**Design:** new `tools/ace/canonical.ts` (`toTagged` sorting+integer-asserting, + `canonicalBytes`) → rewire `canonicalIndexBytes`/`canonicalManifestBytes` (signing.ts) + `packageHash` (resolve.ts) → delete local `canonicalize`. Format change accepted (pre-release; no `format_version` bump). TS-only; 4-lang `package_hash` parity inherited from the byte-lock. 2-task decomposition in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)