### PR TITLE
feat(seed-core): hex core slice 1 — six walls + atomic Vector on Cayley-Dickson ℂ

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Algebra.fs" />
     <Compile Include="CayleyDickson.fs" />
+    <Compile Include="HexCore.fs" />
     <Compile Include="Semiring.fs" />
     <Compile Include="Pool.fs" />
     <Compile Include="GSet.fs" />

--- a/src/Core/HexCore.fs
+++ b/src/Core/HexCore.fs
@@ -1,0 +1,107 @@
+namespace Zeta.Core
+
+/// # The hex core — the seed
+///
+/// The seed core (B-0998) is bounded by **six reservoir walls** (B-0985):
+/// the *hexagonal-six*. Each wall is a two-word primitive pair; together
+/// the 12 words are the 12 edges of the Cube-of-Space hexahedron and the
+/// 6 walls are its 6 faces.
+///
+/// This module lands the **most-inevitable-first** slice of the seed
+/// (B-0998 — *"build up nouns from the most inevitable first … vectors
+/// before trajectories"*): the six-wall enumeration (`Wall`) and the
+/// atomic noun (`Vector`), built directly on the existing Cayley–Dickson
+/// algebra (`Complex`) rather than re-implementing it. Later slices add
+/// the seed computation-expression DSL over a reduced Bayesian model and
+/// the `Trajectory` (a derived sequence of vectors).
+///
+/// ## Attribution (named attribution lives on B-0985, the history surface)
+///
+///   - **Remember When** + **Pay Attention** — the seed pair
+///   - **Which Way** + **How Much** — the vector pair (direction + magnitude)
+///   - **Rainbow Table**, **Observe Emit** — the remaining two walls
+///
+/// ## Core math (B-0999, held don't-collapse)
+///
+/// The 6 walls rhyme with the **6 bivectors of spacetime algebra
+/// Cl(1,3) = the 6 Lorentz generators (3 rotations + 3 boosts)** / the
+/// SE(3) 6-DOF / the cube's 6 faces / Cayley–Dickson. The cross-domain
+/// rhymes are refereed *adapters on this core interface* (B-0999), not a
+/// totalizing claim — the structural "6" is the through-line, the
+/// per-domain conformance stays a hypothesis to referee.
+
+/// The six reservoir walls (B-0985) — the hex core enumeration. The seed
+/// computation expression (a later slice) ranges over these (the
+/// hexahedron's six faces). Listed as the canonical pairs: the seed
+/// pair (`RememberWhen`, `PayAttention`), the vector pair (`WhichWay`,
+/// `HowMuch`), then `RainbowTable` and `ObserveEmit`.
+[<RequireQualifiedAccess>]
+type Wall =
+    | RememberWhen
+    | PayAttention
+    | WhichWay
+    | HowMuch
+    | RainbowTable
+    | ObserveEmit
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module Wall =
+
+    /// All six walls in canonical order (the cube's six faces).
+    let all : Wall list =
+        [ Wall.RememberWhen
+          Wall.PayAttention
+          Wall.WhichWay
+          Wall.HowMuch
+          Wall.RainbowTable
+          Wall.ObserveEmit ]
+
+/// The atomic noun of the seed core (B-0998 — *vectors before
+/// trajectories*). A vector is two reservoir walls in polar form:
+/// **Which Way** (direction, radians) and **How Much** (magnitude,
+/// non-negative). It is the polar view of the existing Cayley–Dickson ℂ
+/// (`Complex = Doubled<float>`): a vector *is* a complex number whose
+/// argument is Which Way and whose modulus is How Much. A `Trajectory`
+/// (a later slice) is a sequence of vectors — derived, not atomic.
+type Vector =
+    { /// Which Way — direction in radians.
+      WhichWay: float
+      /// How Much — magnitude (non-negative by construction).
+      HowMuch: float }
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module Vector =
+
+    /// The zero vector (no magnitude; direction conventionally 0).
+    let zero : Vector = { WhichWay = 0.0; HowMuch = 0.0 }
+
+    /// Construct a vector from direction (radians) and magnitude. A
+    /// negative magnitude is normalized to a non-negative modulus with
+    /// the direction flipped by π, so `HowMuch` is always a true modulus.
+    let make (whichWay: float) (howMuch: float) : Vector =
+        if howMuch < 0.0 then
+            { WhichWay = whichWay + System.Math.PI
+              HowMuch = -howMuch }
+        else
+            { WhichWay = whichWay
+              HowMuch = howMuch }
+
+    /// Cartesian projection onto the existing Cayley–Dickson ℂ
+    /// (`Complex = Doubled<float>`): Real = How Much · cos Which Way,
+    /// Imag = How Much · sin Which Way.
+    let toComplex (v: Vector) : Complex =
+        Doubled.make (v.HowMuch * cos v.WhichWay) (v.HowMuch * sin v.WhichWay)
+
+    /// Polar reading of a Cayley–Dickson ℂ value: modulus → How Much,
+    /// argument → Which Way. Inverse of `toComplex` for any vector with
+    /// non-negative magnitude and direction in (-π, π].
+    let ofComplex (c: Complex) : Vector =
+        { WhichWay = atan2 c.Imag c.Real
+          HowMuch = sqrt (c.Real * c.Real + c.Imag * c.Imag) }
+
+    /// Vector addition computed *through* the existing ℂ algebra
+    /// (`ImaginaryStack.complex`): project both vectors to ℂ, add in the
+    /// algebra, read the sum back as a polar vector. The seed core
+    /// composes the Cayley–Dickson substrate rather than re-deriving it.
+    let add (a: Vector) (b: Vector) : Vector =
+        ImaginaryStack.complex.Add(toComplex a, toComplex b) |> ofComplex

--- a/tests/Tests.FSharp/Algebra/HexCore.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/HexCore.Tests.fs
@@ -1,0 +1,66 @@
+module Zeta.Tests.Algebra.HexCoreTests
+
+open System
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+// The seed core's most-inevitable-first slice (B-0998): the six reservoir
+// walls (B-0985) + the atomic Vector noun, built on the existing
+// Cayley–Dickson ℂ (Complex). These tests anchor the canonical wall set
+// (the cube-of-space's six faces) and prove the Vector ↔ ℂ bijection plus
+// that Vector.add *composes* the existing complex algebra rather than
+// re-deriving it. "The compilers don't lie."
+
+// ─── The six reservoir walls (B-0985) ───
+
+[<Fact>]
+let ``the six reservoir walls are present, in canonical order`` () =
+    Wall.all
+    |> should
+        equal
+        [ Wall.RememberWhen
+          Wall.PayAttention
+          Wall.WhichWay
+          Wall.HowMuch
+          Wall.RainbowTable
+          Wall.ObserveEmit ]
+
+[<Fact>]
+let ``there are exactly six walls (the hexahedron's six faces)`` () =
+    Wall.all |> List.length |> should equal 6
+
+// ─── The atomic Vector noun (B-0998: vectors before trajectories) ───
+
+[<Fact>]
+let ``Vector zero has no magnitude`` () =
+    Vector.zero.HowMuch |> should equal 0.0
+
+[<Fact>]
+let ``Vector <-> Complex round-trips for non-negative magnitude`` () =
+    let v = Vector.make 0.7 2.5
+    let back = v |> Vector.toComplex |> Vector.ofComplex
+    back.WhichWay |> should (equalWithin 1e-9) v.WhichWay
+    back.HowMuch |> should (equalWithin 1e-9) v.HowMuch
+
+[<Fact>]
+let ``Vector.add composes the existing Cayley-Dickson C algebra`` () =
+    // east (1, 0) + north (1, π/2) = (1, 1) → modulus √2, argument π/4
+    let east = Vector.make 0.0 1.0
+    let north = Vector.make (Math.PI / 2.0) 1.0
+    let sum = Vector.add east north
+    sum.HowMuch |> should (equalWithin 1e-9) (sqrt 2.0)
+    sum.WhichWay |> should (equalWithin 1e-9) (Math.PI / 4.0)
+
+[<Fact>]
+let ``negative magnitude normalizes to a non-negative modulus`` () =
+    let v = Vector.make 0.0 -1.0
+    v.HowMuch |> should (equalWithin 1e-9) 1.0
+    // direction flipped by π → points the opposite way
+    cos v.WhichWay |> should (equalWithin 1e-9) -1.0
+
+[<Fact>]
+let ``toComplex lands a unit east vector on the real axis`` () =
+    let c = Vector.make 0.0 1.0 |> Vector.toComplex
+    c.Real |> should (equalWithin 1e-9) 1.0
+    c.Imag |> should (equalWithin 1e-9) 0.0

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -17,6 +17,7 @@
     <!-- Algebra/ -->
     <Compile Include="Algebra/Weight.Tests.fs" />
     <Compile Include="Algebra/CayleyDickson.Tests.fs" />
+    <Compile Include="Algebra/HexCore.Tests.fs" />
     <Compile Include="Algebra/Units.Tests.fs" />
     <Compile Include="Algebra/GSet.Tests.fs" />
     <Compile Include="Algebra/Bag.Tests.fs" />


### PR DESCRIPTION
## Seed core — slice 1 (the first real F# build)

Aaron 2026-06-02: *"ok let's actually start building the seed core in f#"* — pivot from documentation/backlog to **implementation**. This is the **most-inevitable-first** slice (B-0998: *"build up nouns from the most inevitable first … vectors before trajectories"*): the six reservoir walls + the atomic `Vector` noun, built **on** the existing Cayley–Dickson algebra (composition, not parallel-mint).

### What landed (`src/Core/HexCore.fs`, after `CayleyDickson.fs`)

- **`Wall`** (`[<RequireQualifiedAccess>]`) — the six reservoir walls (B-0985): `RememberWhen` · `PayAttention` (Aaron's seed pair) · `WhichWay` · `HowMuch` (Addison's vector pair = direction + magnitude) · `RainbowTable` · `ObserveEmit`. `Wall.all` = the cube-of-space's **six faces**, canonical order (12 words = the hexahedron's 12 edges).
- **`Vector`** — the atomic noun (B-0998): polar `{ WhichWay; HowMuch }`. It **is** the polar view of the existing ℂ (`Complex = Doubled<float>`): argument = Which Way, modulus = How Much. `Vector.toComplex` / `ofComplex` are the bridge; **`Vector.add` routes through `ImaginaryStack.complex.Add`** — the seed *composes* the Cayley–Dickson substrate.

### Tests (`tests/Tests.FSharp/Algebra/HexCore.Tests.fs` — 7/7 pass)

six walls present + canonical-order + exactly-six · `Vector` ↔ ℂ bijection · `Vector.add` composes the ℂ algebra (east + north = √2 @ π/4) · negative magnitude normalizes · unit-east lands on the real axis. *"The compilers don't lie."*

### Core math (B-0999, held don't-collapse)

The 6 walls rhyme with the **6 bivectors of Cl(1,3) = the 6 Lorentz generators** (3 rot + 3 boost) / SE(3) 6-DOF / cube faces. Cross-domain rhymes are **refereed adapters on this core interface**, not a totalizing claim.

### Deferred to later slices

The seed **computation-expression DSL** over a reduced Bayesian Infer.NET model; the reduced-Bayesian seam; **`Trajectory`** (a derived sequence of vectors); F# UOM angle/magnitude tags (B-0994 runtime-unit-tag).

### Review note

New public surface (`Wall`, `Vector`) — flagging for **public-api-designer (Ilyana)** review (advisory per GOVERNANCE §11; not gating). `dotnet build -c Release`: **0 warnings, 0 errors**. `dotnet test`: **7/7**.

Refs B-0985, B-0998, B-0999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
