### PR TITLE
feat(infernet B-1000 slice 3): factor graph — bipartite data structure + sum-product passOnce + prior/equality factors

### DIFF
--- a/src/Bayesian/Bayesian.fsproj
+++ b/src/Bayesian/Bayesian.fsproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Compile Include="Message.fs" />
+    <Compile Include="FactorGraph.fs" />
     <Compile Include="BayesianAggregate.fs" />
   </ItemGroup>
 

--- a/src/Bayesian/FactorGraph.fs
+++ b/src/Bayesian/FactorGraph.fs
@@ -1,0 +1,141 @@
+namespace Zeta.Bayesian
+
+/// # The factor graph (B-1000 slice 3)
+///
+/// A **factor graph** is the bipartite structure inference runs on:
+/// *variable* nodes hold marginals, *factor* nodes connect variables and
+/// compute the messages they send to each neighbor. This slice is the
+/// **data structure + topology + the single sum-product round**
+/// (`passOnce`); the iterate-to-fixed-point *schedule* (on the DBSP
+/// `NestedCircuit.Fixedpoint`) is slice 4.
+///
+/// It is generic over the message family `'M` (slice 2: Gaussian / Beta /
+/// Bernoulli / …) via the `IMessage<'M>` algebra — `product` is the
+/// combine, `uniform` the identity. The two sum-product rules:
+///
+///   - **variable → factor** message = product of the factor→var messages
+///     from every *other* incident factor (a variable passes on the
+///     consensus of its other evidence).
+///   - **factor → variable** message = the factor's local rule applied to
+///     the incoming variable→factor messages (`Factor.ComputeMessages`).
+///
+/// Marginal at a variable = product of *all* incoming factor→var
+/// messages. Spec: Kschischang–Frey–Loeliger 2001 (sum-product).
+///
+/// Variable and factor identifiers are plain `int` indices (kept simple
+/// for this slice; a typed-DU / typed-factor form arrives with the model
+/// compiler later).
+
+/// A factor: the variables it connects, and how it computes the message
+/// it sends to each neighbor from the messages arriving from the others.
+/// `ComputeMessages incoming` maps (variable id → incoming var→factor
+/// message) to (variable id → outgoing factor→var message).
+type Factor<'M> =
+    { /// the variable ids this factor is incident to
+      Neighbors: int list
+      /// incoming var→factor messages (keyed by variable id) →
+      /// outgoing factor→var messages (keyed by variable id)
+      ComputeMessages: Map<int, 'M> -> Map<int, 'M> }
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module Factor =
+
+    /// A prior / observation factor on a single variable: it ignores any
+    /// incoming message and always sends the fixed `message` (a leaf of
+    /// the graph — the evidence).
+    let prior (variable: int) (message: 'M) : Factor<'M> =
+        { Neighbors = [ variable ]
+          ComputeMessages = fun _ -> Map.ofList [ variable, message ] }
+
+    /// An equality factor (all neighbors are the same variable): each
+    /// neighbor receives the **product of the messages from the other
+    /// neighbors** — the sum-product rule for the `=` factor. This is how
+    /// evidence about one copy propagates to the others.
+    let equality (algebra: IMessage<'M>) (neighbors: int list) : Factor<'M> =
+        { Neighbors = neighbors
+          ComputeMessages =
+            fun incoming ->
+                neighbors
+                |> List.map (fun target ->
+                    let toTarget =
+                        neighbors
+                        |> List.filter (fun n -> n <> target)
+                        |> List.choose (fun n -> Map.tryFind n incoming)
+                        |> List.fold (fun acc m -> algebra.Product(acc, m)) algebra.Uniform
+                    target, toTarget)
+                |> Map.ofList }
+
+/// A factor graph: the factors (by id) and the current factor→var
+/// messages. Variable→factor messages and marginals are *derived* from
+/// the factor→var messages by the sum-product variable rule, so the only
+/// state is `FactorToVar`. The message algebra travels with the graph.
+type FactorGraph<'M> =
+    { Algebra: IMessage<'M>
+      /// factor id → factor
+      Factors: Map<int, Factor<'M>>
+      /// factor id → (variable id → the factor→var message on that edge)
+      FactorToVar: Map<int, Map<int, 'M>> }
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module FactorGraph =
+
+    /// An empty graph over the given message algebra.
+    let empty (algebra: IMessage<'M>) : FactorGraph<'M> =
+        { Algebra = algebra; Factors = Map.empty; FactorToVar = Map.empty }
+
+    /// Add a factor under `id`; its outgoing edges start at `uniform`.
+    let addFactor (id: int) (factor: Factor<'M>) (g: FactorGraph<'M>) : FactorGraph<'M> =
+        let init =
+            factor.Neighbors
+            |> List.map (fun v -> v, g.Algebra.Uniform)
+            |> Map.ofList
+        { g with
+            Factors = Map.add id factor g.Factors
+            FactorToVar = Map.add id init g.FactorToVar }
+
+    /// The factor ids incident to a variable.
+    let private factorsOf (variable: int) (g: FactorGraph<'M>) : int list =
+        g.Factors
+        |> Map.toList
+        |> List.filter (fun (_, f) -> List.contains variable f.Neighbors)
+        |> List.map fst
+
+    /// Product of the factor→var messages from a chosen set of factors.
+    let private productFrom (variable: int) (factorIds: int list) (g: FactorGraph<'M>) : 'M =
+        factorIds
+        |> List.choose (fun fid -> g.FactorToVar |> Map.tryFind fid |> Option.bind (Map.tryFind variable))
+        |> List.fold (fun acc m -> g.Algebra.Product(acc, m)) g.Algebra.Uniform
+
+    /// The marginal at a variable = product of **all** incoming factor→var
+    /// messages.
+    let marginal (variable: int) (g: FactorGraph<'M>) : 'M =
+        productFrom variable (factorsOf variable g) g
+
+    /// The variable→factor message = product of factor→var messages from
+    /// **every other** incident factor (the sum-product variable rule).
+    let private varToFactor (variable: int) (excludeFactor: int) (g: FactorGraph<'M>) : 'M =
+        let others = factorsOf variable g |> List.filter (fun fid -> fid <> excludeFactor)
+        productFrom variable others g
+
+    /// One synchronous sum-product round: recompute every factor→var
+    /// message from the current variable→factor messages. Repeated to a
+    /// fixed point this is loopy BP; on a tree it converges exactly in a
+    /// bounded number of rounds (the schedule is slice 4).
+    let passOnce (g: FactorGraph<'M>) : FactorGraph<'M> =
+        let updated =
+            g.Factors
+            |> Map.map (fun fid factor ->
+                let incoming =
+                    factor.Neighbors
+                    |> List.map (fun v -> v, varToFactor v fid g)
+                    |> Map.ofList
+                factor.ComputeMessages incoming)
+        { g with FactorToVar = updated }
+
+    /// Run `passOnce` `rounds` times (a fixed schedule; the
+    /// convergence-detecting fixed-point schedule is slice 4).
+    let passRounds (rounds: int) (g: FactorGraph<'M>) : FactorGraph<'M> =
+        let mutable current = g
+        for _ in 1..rounds do
+            current <- passOnce current
+        current

--- a/tests/Bayesian.Tests/Bayesian.Tests.fsproj
+++ b/tests/Bayesian.Tests/Bayesian.Tests.fsproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <Compile Include="Message.Tests.fs" />
+    <Compile Include="FactorGraph.Tests.fs" />
     <Compile Include="BayesianTests.fs" />
   </ItemGroup>
 

--- a/tests/Bayesian.Tests/FactorGraph.Tests.fs
+++ b/tests/Bayesian.Tests/FactorGraph.Tests.fs
@@ -1,0 +1,76 @@
+module Zeta.Bayesian.Tests.FactorGraphTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Bayesian
+
+// The factor graph (B-1000 slice 3) — the bipartite data structure
+// inference runs on. These tests exercise the topology + the single
+// sum-product round (passOnce/passRounds) + the two factor rules
+// (prior, equality), grounded on slice 2's message algebra. The
+// fixed-point schedule is slice 4. "The compilers don't lie."
+
+// ─── Marginals = product of incoming factor→var messages ───
+
+[<Fact>]
+let ``single variable with two Gaussian priors → marginal is their product`` () =
+    // two prior factors (0, 1) both on variable 0
+    let g =
+        FactorGraph.empty Gaussian.algebra
+        |> FactorGraph.addFactor 0 (Factor.prior 0 (Gaussian.ofMeanVariance 0.0 1.0))
+        |> FactorGraph.addFactor 1 (Factor.prior 0 (Gaussian.ofMeanVariance 2.0 1.0))
+        |> FactorGraph.passOnce
+    let m = FactorGraph.marginal 0 g
+    Gaussian.mean m |> should (equalWithin 1e-9) 1.0      // precision-weighted midpoint
+    Gaussian.variance m |> should (equalWithin 1e-9) 0.5  // precision adds
+
+[<Fact>]
+let ``a lone prior makes the marginal equal the prior`` () =
+    let g =
+        FactorGraph.empty Gaussian.algebra
+        |> FactorGraph.addFactor 0 (Factor.prior 5 (Gaussian.ofMeanVariance 3.0 2.0))
+        |> FactorGraph.passOnce
+    let m = FactorGraph.marginal 5 g
+    Gaussian.mean m |> should (equalWithin 1e-9) 3.0
+    Gaussian.variance m |> should (equalWithin 1e-9) 2.0
+
+// ─── Equality propagates evidence between variables ───
+
+[<Fact>]
+let ``equality factor combines both priors into both marginals`` () =
+    // var 0 ~ Beta(2,1), var 1 ~ Beta(1,2), and x0 = x1 (equality).
+    // each marginal sees both priors → Beta(2,1)·Beta(1,2) = Beta(2,2).
+    let g =
+        FactorGraph.empty Beta.algebra
+        |> FactorGraph.addFactor 0 (Factor.prior 0 (Beta.create 2.0 1.0))
+        |> FactorGraph.addFactor 1 (Factor.prior 1 (Beta.create 1.0 2.0))
+        |> FactorGraph.addFactor 2 (Factor.equality Beta.algebra [ 0; 1 ])
+        |> FactorGraph.passRounds 2
+    let m0 = FactorGraph.marginal 0 g
+    let m1 = FactorGraph.marginal 1 g
+    m0.Alpha |> should (equalWithin 1e-9) 2.0
+    m0.Beta |> should (equalWithin 1e-9) 2.0
+    m1.Alpha |> should (equalWithin 1e-9) 2.0
+    m1.Beta |> should (equalWithin 1e-9) 2.0
+
+// ─── The two factor rules (unit) ───
+
+[<Fact>]
+let ``Factor.equality sends each neighbor the product of the others`` () =
+    let f = Factor.equality Gaussian.algebra [ 0; 1; 2 ]
+    let incoming =
+        Map.ofList
+            [ 0, Gaussian.ofMeanVariance 1.0 1.0
+              1, Gaussian.ofMeanVariance 2.0 1.0
+              2, Gaussian.ofMeanVariance 3.0 1.0 ]
+    let out = f.ComputeMessages incoming
+    // message to 0 = product of incoming[1], incoming[2] = N(2,1)·N(3,1)
+    Gaussian.mean out.[0] |> should (equalWithin 1e-9) 2.5
+    Gaussian.variance out.[0] |> should (equalWithin 1e-9) 0.5
+
+[<Fact>]
+let ``Factor.prior sends its fixed message regardless of incoming`` () =
+    let f = Factor.prior 7 (Gaussian.ofMeanVariance 4.0 1.0)
+    let out = f.ComputeMessages (Map.ofList [ 7, Gaussian.ofMeanVariance 99.0 99.0 ])
+    Gaussian.mean out.[7] |> should (equalWithin 1e-9) 4.0
+    Gaussian.variance out.[7] |> should (equalWithin 1e-9) 1.0


### PR DESCRIPTION
## B-1000 slice 3 — the factor graph

The bipartite structure inference runs on, generic over the slice-2 message family (Gaussian/Beta/Bernoulli) via `IMessage`. **Data structure + topology + the single sum-product round**; the iterate-to-fixed-point *schedule* (on the DBSP `NestedCircuit.Fixedpoint`) is slice 4.

### `src/Bayesian/FactorGraph.fs`
- **`Factor<'M>`** = `Neighbors` + `ComputeMessages` (incoming var→factor → outgoing factor→var). Constructors:
  - `Factor.prior` — a leaf/evidence factor (fixed message).
  - `Factor.equality` — each neighbor gets the **product of the others** (the sum-product `=` factor rule; how evidence propagates between variable copies).
- **`FactorGraph<'M>`** = the message algebra + factors + factor→var edge messages. Variable→factor messages and marginals are **derived** by the sum-product variable rule, so `FactorToVar` is the only state.
  - `marginal v` = product of all incoming factor→var messages
  - `passOnce` = one synchronous round; `passRounds n` = a fixed schedule

### Tests (`FactorGraph.Tests.fs` — 5/5)
single variable + two Gaussian priors → marginal = product (mean 1, var .5) · lone prior → marginal = the prior · **equality** of two vars `Beta(2,1)`,`Beta(1,2)` → both marginals = `Beta(2,2)` (evidence crosses the equality factor) · `equality` sends each neighbor the product of the others · `prior` sends its fixed message.

Spec: Kschischang–Frey–Loeliger 2001 (sum-product). New public surface (`Factor`, `FactorGraph`) — flagging for **public-api-designer (Ilyana)** (advisory). `dotnet build -c Release`: **0 warnings**. `dotnet test`: **5/5**.

Slices: 1 `Vector`/`Wall` (merged) → 2 message algebra (merged) → **3 factor graph (this)** → 4 sum-product BP on `NestedCircuit.Fixedpoint` → 5 EP → 6 seed CE. Refs B-1000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
