### PR TITLE
feat(infernet B-1000 slice 4): sum-product BP to a fixed point — runToFixpoint + per-family message distance

### DIFF
--- a/src/Bayesian/FactorGraph.fs
+++ b/src/Bayesian/FactorGraph.fs
@@ -152,7 +152,11 @@ module FactorGraph =
                 |> Map.exists (fun v m ->
                     match Map.tryFind v msgs' with
                     | None -> true
-                    | Some m' -> distance m m' > tol))
+                    // `not (d <= tol)` (not `d > tol`) so a NaN residual
+                    // counts as MOVED: `NaN > tol` is false in F#, which
+                    // would otherwise let a divergent/overflowed run
+                    // falsely report convergence.
+                    | Some m' -> not (distance m m' <= tol)))
 
     /// **Sum-product belief propagation to a fixed point.** Iterate
     /// `passOnce` until no factor→var message moves more than `tol` (by

--- a/src/Bayesian/FactorGraph.fs
+++ b/src/Bayesian/FactorGraph.fs
@@ -132,10 +132,52 @@ module FactorGraph =
                 factor.ComputeMessages incoming)
         { g with FactorToVar = updated }
 
-    /// Run `passOnce` `rounds` times (a fixed schedule; the
-    /// convergence-detecting fixed-point schedule is slice 4).
+    /// Run `passOnce` `rounds` times (a fixed schedule). For the
+    /// convergence-detecting schedule prefer `runToFixpoint`.
     let passRounds (rounds: int) (g: FactorGraph<'M>) : FactorGraph<'M> =
         let mutable current = g
         for _ in 1..rounds do
             current <- passOnce current
         current
+
+    /// True if any factor→var message in `b` differs from `a` by more
+    /// than `tol` under the per-family `distance` (the residual test).
+    let private moved (distance: 'M -> 'M -> float) (tol: float) (a: FactorGraph<'M>) (b: FactorGraph<'M>) : bool =
+        a.FactorToVar
+        |> Map.exists (fun fid msgs ->
+            match Map.tryFind fid b.FactorToVar with
+            | None -> true
+            | Some msgs' ->
+                msgs
+                |> Map.exists (fun v m ->
+                    match Map.tryFind v msgs' with
+                    | None -> true
+                    | Some m' -> distance m m' > tol))
+
+    /// **Sum-product belief propagation to a fixed point.** Iterate
+    /// `passOnce` until no factor→var message moves more than `tol` (by
+    /// the per-family `distance`), or `maxRounds` is reached. Returns
+    /// `(converged graph, rounds run, converged-before-the-cap?)`.
+    ///
+    /// On a tree this reaches the exact marginals; with loops it is loopy
+    /// BP (may not converge — hence the cap, like `NestedCircuit`'s
+    /// 64-iteration LFP cap). Structurally this *is* the DBSP
+    /// `NestedCircuit.Fixedpoint` (drive the inner clock to the least
+    /// fixed point, capped) at the factor-graph level; wiring the factor
+    /// graph as literal DBSP operators — for **incremental re-inference
+    /// on a data delta** — is the next integration (slice 4b).
+    let runToFixpoint
+        (distance: 'M -> 'M -> float)
+        (tol: float)
+        (maxRounds: int)
+        (g: FactorGraph<'M>)
+        : FactorGraph<'M> * int * bool =
+        let mutable current = g
+        let mutable rounds = 0
+        let mutable converged = false
+        while rounds < maxRounds && not converged do
+            let next = passOnce current
+            rounds <- rounds + 1
+            converged <- not (moved distance tol current next)
+            current <- next
+        current, rounds, converged

--- a/src/Bayesian/FactorGraph.fs
+++ b/src/Bayesian/FactorGraph.fs
@@ -140,23 +140,27 @@ module FactorGraph =
             current <- passOnce current
         current
 
-    /// True if any factor→var message in `b` differs from `a` by more
+    /// True if any factor→var message differs between `a` and `b` by more
     /// than `tol` under the per-family `distance` (the residual test).
+    /// Compared **symmetrically** over the union of keys: a factor id or
+    /// edge present on only one side counts as moved (a structural change
+    /// is never silently treated as convergence).
     let private moved (distance: 'M -> 'M -> float) (tol: float) (a: FactorGraph<'M>) (b: FactorGraph<'M>) : bool =
-        a.FactorToVar
-        |> Map.exists (fun fid msgs ->
-            match Map.tryFind fid b.FactorToVar with
-            | None -> true
-            | Some msgs' ->
-                msgs
-                |> Map.exists (fun v m ->
-                    match Map.tryFind v msgs' with
-                    | None -> true
+        let keys (m: Map<int, _>) = m |> Map.toList |> List.map fst |> Set.ofList
+        Set.union (keys a.FactorToVar) (keys b.FactorToVar)
+        |> Set.exists (fun fid ->
+            match Map.tryFind fid a.FactorToVar, Map.tryFind fid b.FactorToVar with
+            | Some ma, Some mb ->
+                Set.union (keys ma) (keys mb)
+                |> Set.exists (fun v ->
+                    match Map.tryFind v ma, Map.tryFind v mb with
                     // `not (d <= tol)` (not `d > tol`) so a NaN residual
                     // counts as MOVED: `NaN > tol` is false in F#, which
                     // would otherwise let a divergent/overflowed run
                     // falsely report convergence.
-                    | Some m' -> not (distance m m' <= tol)))
+                    | Some x, Some y -> not (distance x y <= tol)
+                    | _ -> true) // edge on only one side = moved
+            | _ -> true) // factor on only one side = moved
 
     /// **Sum-product belief propagation to a fixed point.** Iterate
     /// `passOnce` until no factor→var message moves more than `tol` (by

--- a/src/Bayesian/Message.fs
+++ b/src/Bayesian/Message.fs
@@ -120,9 +120,16 @@ module Gaussian =
     let divide (a: Gaussian) (b: Gaussian) : Gaussian = a / b
 
     /// Distance between two Gaussian messages — max abs difference of the
-    /// natural parameters (ν, τ). Used for BP convergence detection.
+    /// natural parameters (ν, τ). Used for BP convergence detection. A
+    /// non-finite parameter (overflow to ∞/NaN) returns `infinity` so it
+    /// always counts as "moved" — `max` would otherwise mask a NaN and
+    /// let a divergent run falsely report convergence.
     let distance (a: Gaussian) (b: Gaussian) : float =
-        max (abs (a.PrecisionMean - b.PrecisionMean)) (abs (a.Precision - b.Precision))
+        if not (System.Double.IsFinite a.PrecisionMean && System.Double.IsFinite a.Precision
+                && System.Double.IsFinite b.PrecisionMean && System.Double.IsFinite b.Precision) then
+            infinity
+        else
+            max (abs (a.PrecisionMean - b.PrecisionMean)) (abs (a.Precision - b.Precision))
 
     /// The runtime-polymorphic message algebra dictionary.
     let algebra : IMessage<Gaussian> =
@@ -202,9 +209,15 @@ module Beta =
     let divide (a: Beta) (b: Beta) : Beta = a / b
 
     /// Distance between two Beta messages — max abs difference of the
-    /// shape parameters (α, β). Used for BP convergence detection.
+    /// shape parameters (α, β). Used for BP convergence detection. A
+    /// non-finite parameter (overflow to ∞/NaN) returns `infinity` so it
+    /// always counts as "moved" (no false convergence on a divergent run).
     let distance (a: Beta) (b: Beta) : float =
-        max (abs (a.Alpha - b.Alpha)) (abs (a.Beta - b.Beta))
+        if not (System.Double.IsFinite a.Alpha && System.Double.IsFinite a.Beta
+                && System.Double.IsFinite b.Alpha && System.Double.IsFinite b.Beta) then
+            infinity
+        else
+            max (abs (a.Alpha - b.Alpha)) (abs (a.Beta - b.Beta))
 
     /// The runtime-polymorphic message algebra dictionary.
     let algebra : IMessage<Beta> =
@@ -264,9 +277,14 @@ module Bernoulli =
     let divide (a: Bernoulli) (b: Bernoulli) : Bernoulli = a / b
 
     /// Distance between two Bernoulli messages — abs difference of
-    /// P(true). Used for BP convergence detection.
+    /// P(true). Used for BP convergence detection. A non-finite P(true)
+    /// returns `infinity` so it always counts as "moved" (no false
+    /// convergence on a divergent run).
     let distance (a: Bernoulli) (b: Bernoulli) : float =
-        abs (a.ProbTrue - b.ProbTrue)
+        if not (System.Double.IsFinite a.ProbTrue && System.Double.IsFinite b.ProbTrue) then
+            infinity
+        else
+            abs (a.ProbTrue - b.ProbTrue)
 
     /// The runtime-polymorphic message algebra dictionary.
     let algebra : IMessage<Bernoulli> =

--- a/src/Bayesian/Message.fs
+++ b/src/Bayesian/Message.fs
@@ -119,6 +119,11 @@ module Gaussian =
     /// The EP cavity (= `a / b`).
     let divide (a: Gaussian) (b: Gaussian) : Gaussian = a / b
 
+    /// Distance between two Gaussian messages — max abs difference of the
+    /// natural parameters (ν, τ). Used for BP convergence detection.
+    let distance (a: Gaussian) (b: Gaussian) : float =
+        max (abs (a.PrecisionMean - b.PrecisionMean)) (abs (a.Precision - b.Precision))
+
     /// The runtime-polymorphic message algebra dictionary.
     let algebra : IMessage<Gaussian> =
         { new IMessage<Gaussian> with
@@ -196,6 +201,11 @@ module Beta =
     /// The EP cavity (= `a / b`).
     let divide (a: Beta) (b: Beta) : Beta = a / b
 
+    /// Distance between two Beta messages — max abs difference of the
+    /// shape parameters (α, β). Used for BP convergence detection.
+    let distance (a: Beta) (b: Beta) : float =
+        max (abs (a.Alpha - b.Alpha)) (abs (a.Beta - b.Beta))
+
     /// The runtime-polymorphic message algebra dictionary.
     let algebra : IMessage<Beta> =
         { new IMessage<Beta> with
@@ -252,6 +262,11 @@ module Bernoulli =
 
     /// The EP cavity (= `a / b`).
     let divide (a: Bernoulli) (b: Bernoulli) : Bernoulli = a / b
+
+    /// Distance between two Bernoulli messages — abs difference of
+    /// P(true). Used for BP convergence detection.
+    let distance (a: Bernoulli) (b: Bernoulli) : float =
+        abs (a.ProbTrue - b.ProbTrue)
 
     /// The runtime-polymorphic message algebra dictionary.
     let algebra : IMessage<Bernoulli> =

--- a/tests/Bayesian.Tests/Bayesian.Tests.fsproj
+++ b/tests/Bayesian.Tests/Bayesian.Tests.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="Message.Tests.fs" />
     <Compile Include="FactorGraph.Tests.fs" />
     <Compile Include="MessageBatch.Tests.fs" />
+    <Compile Include="Bp.Tests.fs" />
     <Compile Include="BayesianTests.fs" />
   </ItemGroup>
 

--- a/tests/Bayesian.Tests/Bp.Tests.fs
+++ b/tests/Bayesian.Tests/Bp.Tests.fs
@@ -60,3 +60,17 @@ let ``message distance is zero for equal messages and abs-difference otherwise``
     |> should (equalWithin 1e-12) 0.0
     Beta.distance (Beta.create 2.0 3.0) (Beta.create 2.5 3.0) |> should (equalWithin 1e-9) 0.5
     Bernoulli.distance (Bernoulli.create 0.3) (Bernoulli.create 0.5) |> should (equalWithin 1e-9) 0.2
+
+[<Fact>]
+let ``non-finite messages count as moved (no false convergence on overflow)`` () =
+    // an infinite-precision message (via record literal, bypassing the
+    // validated constructor) must NOT be silently reported as converged:
+    // distance returns infinity, and `moved` treats NaN/∞ residual as moved.
+    Gaussian.distance { PrecisionMean = 0.0; Precision = infinity } { PrecisionMean = 0.0; Precision = infinity }
+    |> System.Double.IsFinite |> should equal false
+    let g0 =
+        FactorGraph.empty Gaussian.algebra
+        |> FactorGraph.addFactor 0 (Factor.prior 0 { PrecisionMean = 0.0; Precision = infinity })
+        |> FactorGraph.addFactor 1 (Factor.prior 0 { PrecisionMean = 0.0; Precision = infinity })
+    let _g, _rounds, converged = FactorGraph.runToFixpoint Gaussian.distance 1e-9 5 g0
+    converged |> should equal false

--- a/tests/Bayesian.Tests/Bp.Tests.fs
+++ b/tests/Bayesian.Tests/Bp.Tests.fs
@@ -1,0 +1,62 @@
+module Zeta.Bayesian.Tests.BpTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Bayesian
+
+// Sum-product belief propagation to a fixed point (B-1000 slice 4):
+// FactorGraph.runToFixpoint iterates passOnce until the messages stop
+// moving (per-family distance < tol) or the round cap is hit — the
+// factor-graph analog of the DBSP NestedCircuit capped LFP iteration.
+// On a tree BP reaches the exact marginals. "The compilers don't lie."
+
+[<Fact>]
+let ``runToFixpoint reaches the exact product marginal and reports converged`` () =
+    let g0 =
+        FactorGraph.empty Gaussian.algebra
+        |> FactorGraph.addFactor 0 (Factor.prior 0 (Gaussian.ofMeanVariance 0.0 1.0))
+        |> FactorGraph.addFactor 1 (Factor.prior 0 (Gaussian.ofMeanVariance 2.0 1.0))
+    let g, _rounds, converged = FactorGraph.runToFixpoint Gaussian.distance 1e-9 20 g0
+    converged |> should equal true
+    let m = FactorGraph.marginal 0 g
+    Gaussian.mean m |> should (equalWithin 1e-9) 1.0
+    Gaussian.variance m |> should (equalWithin 1e-9) 0.5
+
+[<Fact>]
+let ``BP propagates evidence along an equality chain to every marginal`` () =
+    // x0 = x1 = x2 (two equality factors), with a Beta prior on each.
+    // every marginal must combine ALL three priors:
+    //   Beta(2,1)·Beta(1,2)·Beta(3,1) = Beta(4,2)  (α-1 sum = 3, β-1 sum = 1)
+    let g0 =
+        FactorGraph.empty Beta.algebra
+        |> FactorGraph.addFactor 0 (Factor.prior 0 (Beta.create 2.0 1.0))
+        |> FactorGraph.addFactor 1 (Factor.prior 1 (Beta.create 1.0 2.0))
+        |> FactorGraph.addFactor 2 (Factor.prior 2 (Beta.create 3.0 1.0))
+        |> FactorGraph.addFactor 3 (Factor.equality Beta.algebra [ 0; 1 ])
+        |> FactorGraph.addFactor 4 (Factor.equality Beta.algebra [ 1; 2 ])
+    let g, _rounds, converged = FactorGraph.runToFixpoint Beta.distance 1e-9 50 g0
+    converged |> should equal true
+    for v in [ 0; 1; 2 ] do
+        let m = FactorGraph.marginal v g
+        m.Alpha |> should (equalWithin 1e-6) 4.0
+        m.Beta |> should (equalWithin 1e-6) 2.0
+
+[<Fact>]
+let ``runToFixpoint respects the round cap (not converged when capped too low)`` () =
+    let g0 =
+        FactorGraph.empty Beta.algebra
+        |> FactorGraph.addFactor 0 (Factor.prior 0 (Beta.create 2.0 1.0))
+        |> FactorGraph.addFactor 1 (Factor.prior 1 (Beta.create 1.0 2.0))
+        |> FactorGraph.addFactor 2 (Factor.prior 2 (Beta.create 3.0 1.0))
+        |> FactorGraph.addFactor 3 (Factor.equality Beta.algebra [ 0; 1 ])
+        |> FactorGraph.addFactor 4 (Factor.equality Beta.algebra [ 1; 2 ])
+    let _g, rounds, converged = FactorGraph.runToFixpoint Beta.distance 1e-9 1 g0
+    rounds |> should equal 1
+    converged |> should equal false   // one round can't cross the whole chain
+
+[<Fact>]
+let ``message distance is zero for equal messages and abs-difference otherwise`` () =
+    Gaussian.distance (Gaussian.ofMeanVariance 0.0 1.0) (Gaussian.ofMeanVariance 0.0 1.0)
+    |> should (equalWithin 1e-12) 0.0
+    Beta.distance (Beta.create 2.0 3.0) (Beta.create 2.5 3.0) |> should (equalWithin 1e-9) 0.5
+    Bernoulli.distance (Bernoulli.create 0.3) (Bernoulli.create 0.5) |> should (equalWithin 1e-9) 0.2


### PR DESCRIPTION
## B-1000 slice 4 — sum-product BP to a fixed point

Belief propagation driven to convergence: iterate `passOnce` until no factor→var message moves more than `tol` (per-family `distance`), or `maxRounds` is hit. **On a tree this reaches the exact marginals**; with loops it is loopy BP (capped, like `NestedCircuit`'s 64-iteration LFP cap).

This is the **factor-graph analog of `NestedCircuit.Fixedpoint`** (drive the inner clock to the least fixed point, capped). Wiring the factor graph as literal DBSP operators — for **incremental re-inference on a data delta** (the differentiator vs stock Infer.NET) — is the next integration (slice 4b).

### Code
- `src/Bayesian/FactorGraph.fs`: **`runToFixpoint distance tol maxRounds g`** → `(converged graph, rounds, converged?)`; private `moved` residual test compares factor→var messages between rounds.
- `src/Bayesian/Message.fs` (additive): `Gaussian.distance` / `Beta.distance` / `Bernoulli.distance` (max abs diff of the defining params).

### Tests (`Bp.Tests.fs` — 4/4)
- reaches the exact product marginal + reports converged
- **evidence propagates along an equality chain `x0=x1=x2`** (priors `Beta(2,1)`,`Beta(1,2)`,`Beta(3,1)`) → every marginal = `Beta(4,2)` (all three priors combined) — real multi-round message passing
- respects the round cap (converged=false when capped to 1)
- message distance: 0 for equal, abs-diff otherwise

Spec: Kschischang–Frey–Loeliger 2001 (sum-product). `dotnet build -c Release`: **0 warnings**. `dotnet test`: **4/4**.

Slices: 1 `Vector`/`Wall` (merged) → 2 message algebra (merged) → 3 factor graph (merged) → **4 BP fixpoint (this)** → 4b incremental BP on `NestedCircuit` → 5 EP → 6 seed CE. Refs B-1000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
