### PR TITLE
feat(infernet B-1000 slice 5): Expectation Propagation — non-conjugate factors via moment-matching (probit site), plugs into runToFixpoint

### DIFF
--- a/src/Bayesian/Bayesian.fsproj
+++ b/src/Bayesian/Bayesian.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="Message.fs" />
     <Compile Include="MessageBatch.fs" />
     <Compile Include="FactorGraph.fs" />
+    <Compile Include="Ep.fs" />
     <Compile Include="BayesianAggregate.fs" />
   </ItemGroup>
 

--- a/src/Bayesian/Ep.fs
+++ b/src/Bayesian/Ep.fs
@@ -82,7 +82,11 @@ module Ep =
         let z = m / s
         let lambda = inverseMills z
         let mHat = m + v * lambda / s
-        let vHat = v - v * v * lambda * (z + lambda) / (1.0 + v)
+        // v̂ = v − v²λ(z+λ)/(1+v) factored as v·(1 − (v/(1+v))·λ(z+λ)): the
+        // v/(1+v) factor stays ≤ 1, so a very broad but valid cavity (e.g.
+        // v = 1e308, accepted by the public constructor) doesn't overflow the
+        // v² intermediate to ∞ before the divide. Algebraically identical.
+        let vHat = v * (1.0 - (v / (1.0 + v)) * lambda * (z + lambda))
         Gaussian.ofMeanVariance mHat vHat
 
     /// A **probit EP factor** on a single Gaussian variable — the soft

--- a/src/Bayesian/Ep.fs
+++ b/src/Bayesian/Ep.fs
@@ -1,0 +1,87 @@
+namespace Zeta.Bayesian
+
+/// # Expectation Propagation (B-1000 slice 5)
+///
+/// EP handles **non-conjugate** factors — where the true factor `f(x)`
+/// isn't in the exponential family, so the exact message isn't either.
+/// EP approximates it by **moment matching**: for a factor,
+///
+///   1. **cavity** — `q_cav = marginal / f_message` (the belief *without*
+///      this factor). In the factor graph the incoming variable→factor
+///      message **is** the cavity (it's the product of every *other*
+///      factor — the sum-product variable rule, slice 3).
+///   2. **tilt** — `q_tilt ∝ q_cav · f(x)` (cavity × the true factor;
+///      generally not exp-family).
+///   3. **project** — `q_new = moment-match(q_tilt)` back to the exp-family
+///      (match mean + variance, for Gaussian).
+///   4. **divide** — the new factor→var message = `q_new / q_cav`.
+///
+/// The key structural fact: **EP is not a new engine — it is a new FACTOR
+/// TYPE.** An EP factor's `ComputeMessages` does cavity→tilt→project→divide;
+/// the existing `FactorGraph.runToFixpoint` (slice 4) drives it. On a tree
+/// with conjugate factors EP = exact BP; with a non-conjugate factor it is
+/// the moment-matched approximation.
+///
+/// Spec (clean-room, papers with proofs): Minka 2001 (EP); Rasmussen &
+/// Williams *GPML* §3.6 eq 3.58 (the probit site). The probit moment-match
+/// is cross-checked against numerical quadrature in the tests.
+
+/// Standard normal pdf/cdf (the probit site needs Φ; .NET has no built-in
+/// erf, so erf is the Abramowitz–Stegun 7.1.26 rational approximation,
+/// max abs error ≈ 1.5e-7).
+[<RequireQualifiedAccess>]
+module Normal =
+
+    /// Gauss error function via Abramowitz–Stegun 7.1.26.
+    let erf (x: float) : float =
+        let sign = if x < 0.0 then -1.0 else 1.0
+        let ax = abs x
+        let t = 1.0 / (1.0 + 0.3275911 * ax)
+        let y =
+            1.0
+            - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t - 0.284496736) * t + 0.254829592)
+              * t
+              * exp (-ax * ax)
+        sign * y
+
+    /// Standard normal pdf φ(x).
+    let pdf (x: float) : float = exp (-0.5 * x * x) / sqrt (2.0 * System.Math.PI)
+
+    /// Standard normal cdf Φ(x) = ½(1 + erf(x/√2)).
+    let cdf (x: float) : float = 0.5 * (1.0 + erf (x / sqrt 2.0))
+
+[<RequireQualifiedAccess>]
+module Ep =
+
+    /// The probit site projection: given a cavity Gaussian, return the
+    /// Gaussian that moment-matches `cavity · Φ(x)` (the tilted
+    /// distribution). GPML eq 3.58: with cavity `N(m, v)`,
+    ///   z = m / √(1+v),  λ = φ(z)/Φ(z)  (inverse Mills ratio),
+    ///   m̂ = m + vλ/√(1+v),  v̂ = v − v²λ(z+λ)/(1+v).
+    let probitProject (cavity: Gaussian) : Gaussian =
+        let m = Gaussian.mean cavity
+        let v = Gaussian.variance cavity
+        let s = sqrt (1.0 + v)
+        let z = m / s
+        let lambda = Normal.pdf z / Normal.cdf z
+        let mHat = m + v * lambda / s
+        let vHat = v - v * v * lambda * (z + lambda) / (1.0 + v)
+        Gaussian.ofMeanVariance mHat vHat
+
+    /// A **probit EP factor** on a single Gaussian variable — the soft
+    /// observation "x > 0" (likelihood Φ(x)). Plugs into `FactorGraph`;
+    /// drive with `FactorGraph.runToFixpoint`. Its outgoing message is
+    /// `project(cavity · Φ) / cavity`; when the cavity is improper/uniform
+    /// (e.g. before the prior has propagated) it sends `uniform` (no
+    /// information yet) rather than NaN.
+    let probitFactor (variable: int) : Factor<Gaussian> =
+        { Neighbors = [ variable ]
+          ComputeMessages =
+            fun incoming ->
+                match Map.tryFind variable incoming with
+                | Some cavity when Gaussian.isProper cavity ->
+                    let projected = probitProject cavity
+                    Map.ofList [ variable, Gaussian.divide projected cavity ]
+                | _ ->
+                    // no proper cavity yet → emit the flat message
+                    Map.ofList [ variable, Gaussian.One ] }

--- a/src/Bayesian/Ep.fs
+++ b/src/Bayesian/Ep.fs
@@ -53,6 +53,23 @@ module Normal =
 [<RequireQualifiedAccess>]
 module Ep =
 
+    /// Inverse Mills ratio λ(z) = φ(z)/Φ(z) — the normal hazard rate — computed
+    /// stably. For z ≪ 0, Φ(z) underflows to 0 and the naive `φ/Φ` is ∞/NaN;
+    /// there the asymptotic expansion λ(z) ≈ −z − 1/z + 2/z³ (from the lower-tail
+    /// Mills series Φ(z) = φ(z)·[1/w − 1/w³ + 3/w⁵ − …], w = −z) is finite and
+    /// accurate. This keeps the probit projection well-defined for arbitrarily
+    /// extreme cavities (which the fixpoint loop can drift into) instead of
+    /// throwing via `Gaussian.ofMeanVariance` on a non-finite moment.
+    let private inverseMills (z: float) : float =
+        let phi = Normal.pdf z
+        let cdf = Normal.cdf z
+        let naive = phi / cdf
+        if cdf > 0.0 && System.Double.IsFinite naive then naive
+        else
+            // z ≪ 0: Φ(z) underflowed; asymptotic hazard rate (leading 3 terms)
+            let zi = 1.0 / z
+            -z - zi + 2.0 * zi * zi * zi
+
     /// The probit site projection: given a cavity Gaussian, return the
     /// Gaussian that moment-matches `cavity · Φ(x)` (the tilted
     /// distribution). GPML eq 3.58: with cavity `N(m, v)`,
@@ -63,7 +80,7 @@ module Ep =
         let v = Gaussian.variance cavity
         let s = sqrt (1.0 + v)
         let z = m / s
-        let lambda = Normal.pdf z / Normal.cdf z
+        let lambda = inverseMills z
         let mHat = m + v * lambda / s
         let vHat = v - v * v * lambda * (z + lambda) / (1.0 + v)
         Gaussian.ofMeanVariance mHat vHat

--- a/tests/Bayesian.Tests/Bayesian.Tests.fsproj
+++ b/tests/Bayesian.Tests/Bayesian.Tests.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="FactorGraph.Tests.fs" />
     <Compile Include="MessageBatch.Tests.fs" />
     <Compile Include="Bp.Tests.fs" />
+    <Compile Include="Ep.Tests.fs" />
     <Compile Include="BayesianTests.fs" />
   </ItemGroup>
 

--- a/tests/Bayesian.Tests/Ep.Tests.fs
+++ b/tests/Bayesian.Tests/Ep.Tests.fs
@@ -53,6 +53,24 @@ let ``probit projection matches numerical quadrature of cavity times Phi`` () =
         Gaussian.mean proj |> should (equalWithin 2e-3) qMean
         Gaussian.variance proj |> should (equalWithin 2e-3) qVar
 
+// ─── Extreme negative cavity: Φ(z) underflows → asymptotic inverse Mills ───
+
+[<Fact>]
+let ``probit projection stays finite and proper for an extreme negative cavity`` () =
+    // cavity strongly contradicts "x > 0": Φ(z) underflows to 0, so the naive
+    // λ = φ/Φ would be ∞/NaN and throw via ofMeanVariance. The stabilized
+    // inverse Mills (asymptotic tail) must keep the projection finite, proper,
+    // and variance-reduced (the factor still adds information).
+    for m, v in [ (-15.0, 1.0); (-40.0, 0.25); (-8.0, 4.0) ] do
+        let proj = Ep.probitProject (Gaussian.ofMeanVariance m v)
+        Gaussian.isProper proj |> should equal true
+        Double.IsFinite(Gaussian.mean proj) |> should equal true
+        Double.IsFinite(Gaussian.variance proj) |> should equal true
+        // probit observation adds information → posterior variance ≤ cavity
+        Gaussian.variance proj |> should be (lessThanOrEqualTo v)
+        // and it pushes the (very negative) mean upward toward the constraint
+        Gaussian.mean proj |> should be (greaterThan m)
+
 // ─── EP as a factor in the existing BP loop ───
 
 [<Fact>]

--- a/tests/Bayesian.Tests/Ep.Tests.fs
+++ b/tests/Bayesian.Tests/Ep.Tests.fs
@@ -71,6 +71,18 @@ let ``probit projection stays finite and proper for an extreme negative cavity``
         // and it pushes the (very negative) mean upward toward the constraint
         Gaussian.mean proj |> should be (greaterThan m)
 
+[<Fact>]
+let ``probit projection stays finite for an extremely broad cavity (no v-squared overflow)`` () =
+    // v = 1e308 is finite + positive → accepted by the public constructor, so
+    // probitProject must handle it. The naive v² intermediate would overflow to
+    // ∞; the factored v·(1 − (v/(1+v))·λ(z+λ)) update stays in range.
+    for m, v in [ (0.0, 1e308); (1e150, 1e300); (-1e150, 1e300) ] do
+        let proj = Ep.probitProject (Gaussian.ofMeanVariance m v)
+        Gaussian.isProper proj |> should equal true
+        Double.IsFinite(Gaussian.mean proj) |> should equal true
+        Double.IsFinite(Gaussian.variance proj) |> should equal true
+        Gaussian.variance proj |> should be (lessThanOrEqualTo v)
+
 // ─── EP as a factor in the existing BP loop ───
 
 [<Fact>]

--- a/tests/Bayesian.Tests/Ep.Tests.fs
+++ b/tests/Bayesian.Tests/Ep.Tests.fs
@@ -1,0 +1,80 @@
+module Zeta.Bayesian.Tests.EpTests
+
+open System
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Bayesian
+
+// EP (B-1000 slice 5) — non-conjugate factors via moment matching. The
+// probit site's closed-form moments are checked against NUMERICAL
+// QUADRATURE of the tilted distribution N(x;m,v)·Φ(x) (self-verifying),
+// and an EP factor plugged into the existing FactorGraph + runToFixpoint
+// converges to the moment-matched posterior. "The compilers don't lie."
+
+// trapezoidal quadrature of f over [lo,hi] with n panels
+let private quad (f: float -> float) (lo: float) (hi: float) (n: int) : float =
+    let h = (hi - lo) / float n
+    let mutable s = 0.0
+    for i in 0 .. n do
+        let x = lo + float i * h
+        let w = if i = 0 || i = n then 0.5 else 1.0
+        s <- s + w * f x
+    s * h
+
+// moments (mean, variance) of the tilted distribution N(x;m,v)·Φ(x),
+// computed by quadrature — the ground truth for the probit projection.
+let private tiltedMoments (m: float) (v: float) : float * float =
+    let sd = sqrt v
+    let lo, hi = m - 12.0 * sd, m + 12.0 * sd
+    let n = 40000
+    let pdfN x = exp (-0.5 * (x - m) * (x - m) / v) / sqrt (2.0 * Math.PI * v)
+    let integrand (p: float -> float) x = pdfN x * Normal.cdf x * p x
+    let z = quad (integrand (fun _ -> 1.0)) lo hi n
+    let m1 = quad (integrand id) lo hi n / z
+    let m2 = quad (integrand (fun x -> x * x)) lo hi n / z
+    m1, m2 - m1 * m1
+
+// ─── Normal cdf/pdf (Abramowitz–Stegun erf) ───
+
+[<Fact>]
+let ``Normal cdf and pdf are accurate`` () =
+    Normal.cdf 0.0 |> should (equalWithin 1e-6) 0.5
+    Normal.cdf 1.96 |> should (equalWithin 1e-3) 0.975
+    Normal.cdf -1.0 |> should (equalWithin 1e-3) 0.1586553
+    Normal.pdf 0.0 |> should (equalWithin 1e-7) 0.3989422804
+
+// ─── The probit projection vs numerical quadrature (the formula is right) ───
+
+[<Fact>]
+let ``probit projection matches numerical quadrature of cavity times Phi`` () =
+    for m, v in [ (0.0, 1.0); (0.5, 2.0); (-1.0, 0.5); (1.5, 0.25) ] do
+        let proj = Ep.probitProject (Gaussian.ofMeanVariance m v)
+        let qMean, qVar = tiltedMoments m v
+        Gaussian.mean proj |> should (equalWithin 2e-3) qMean
+        Gaussian.variance proj |> should (equalWithin 2e-3) qVar
+
+// ─── EP as a factor in the existing BP loop ───
+
+[<Fact>]
+let ``EP probit factor in runToFixpoint converges to the moment-matched posterior`` () =
+    // prior N(0,1) + soft observation "x > 0" (probit). The marginal must
+    // converge to moment-match(N(0,1)·Φ) — verified against quadrature.
+    let g0 =
+        FactorGraph.empty Gaussian.algebra
+        |> FactorGraph.addFactor 0 (Factor.prior 0 (Gaussian.ofMeanVariance 0.0 1.0))
+        |> FactorGraph.addFactor 1 (Ep.probitFactor 0)
+    let g, _rounds, converged = FactorGraph.runToFixpoint Gaussian.distance 1e-9 50 g0
+    converged |> should equal true
+    let marginal = FactorGraph.marginal 0 g
+    let trueMean, trueVar = tiltedMoments 0.0 1.0
+    Gaussian.mean marginal |> should (equalWithin 2e-3) trueMean      // ≈ 0.564
+    Gaussian.variance marginal |> should (equalWithin 2e-3) trueVar   // ≈ 0.682
+    // the observation "x > 0" must shift the posterior mean positive
+    Gaussian.mean marginal |> should be (greaterThan 0.5)
+
+[<Fact>]
+let ``the probit factor emits a flat message under an improper (uniform) cavity`` () =
+    // before any prior has propagated, the cavity is uniform → no NaN,
+    // the factor sends the flat message (no information yet)
+    let out = (Ep.probitFactor 3).ComputeMessages (Map.ofList [ 3, Gaussian.One ])
+    out.[3] |> should equal Gaussian.One


### PR DESCRIPTION
## B-1000 slice 5 — Expectation Propagation (non-conjugate factors)

EP handles **non-conjugate** factors by **moment matching**. The structural win: **EP is not a new engine — it's a new FACTOR TYPE** that the existing `FactorGraph` + `runToFixpoint` (slice 4) drives.

### `src/Bayesian/Ep.fs`
- **`Normal.erf/pdf/cdf`** — standard normal Φ/φ (erf via Abramowitz–Stegun 7.1.26, max abs err ≈1.5e-7; .NET has no built-in erf).
- **`Ep.probitProject cavity`** — moment-match the tilted `N(m,v)·Φ(x)` back to a Gaussian (GPML eq 3.58): `z=m/√(1+v)`, `λ=φ(z)/Φ(z)`, `m̂=m+vλ/√(1+v)`, `v̂=v−v²λ(z+λ)/(1+v)`.
- **`Ep.probitFactor variable`** — a soft observation "x>0" (likelihood Φ(x)) as a `Factor<Gaussian>`: `ComputeMessages = project(cavity·Φ) / cavity`, where the incoming var→factor message **is** the cavity (the sum-product variable rule). Improper/uniform cavity → flat message (no NaN).

The EP cycle = **cavity (divide) → tilt (×factor) → project (moment-match) → divide** — cavity/divide are slice 2, project is the new bit, the loop is slice 4's `runToFixpoint`.

### Tests (`Ep.Tests.fs` — 4/4)
- `Normal` cdf/pdf accurate
- **probit projection matches NUMERICAL QUADRATURE** of `N(m,v)·Φ(x)` over 4 (m,v) cases — the formula is *verified*, not hardcoded
- **EP probit factor in `runToFixpoint` converges to the moment-matched posterior** (≈`N(0.564,0.682)`, verified vs quadrature; mean shifts positive on "x>0")
- improper-cavity → flat message (no NaN)

Spec (clean-room, papers with proofs): Minka 2001 (EP); Rasmussen–Williams *GPML* §3.6. `dotnet build -c Release`: **0 warnings**. `dotnet test`: **4/4**.

Slices: 1 Vector/Wall → 2 message algebra → 3 factor graph → 4 BP fixpoint (all merged) → **5 EP (this)** → 6 seed CE. Refs B-1000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
