### PR TITLE
feat(ace): slice 8.1 — trust core consumes shared canonical-JSON (sorted toTagged + canonicalBytes)

### DIFF
--- a/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.1-canonical-json-implementation-plan.md
+++ b/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.1-canonical-json-implementation-plan.md
@@ -1,0 +1,358 @@
+# Ace slice 8.1 — trust core consumes shared canonical-JSON — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Ace's two ad-hoc canonicalizers (signing.ts `canonicalize`, resolve.ts `canonicalJson` for `packageHash`) with the project's shared, 4-language byte-locked canonical-JSON (`src/Core.TypeScript/dynamic-value/json.ts` `canonicalJson`), so the trust core (`package_hash`, `key_id`, index/manifest signing) rests on the audited cross-language canonicalization instead of a parallel local one.
+
+**Architecture:** A thin Ace-side adapter `tools/ace/canonical.ts` owns the seam to the shared primitive (own-the-interface): `toTagged(value)` converts a plain JS value into the shared `Tagged` form **emitting object entries in lexicographically-sorted key order** (preserving Ace's key-order-independent canonicalization through the order-preserving `canonicalJson`) and **asserts integers** (a non-integer number is a bug — Ace has no Float fields — so it throws rather than silently hashing a float); `canonicalBytes(value) = new TextEncoder().encode(canonicalJson(toTagged(value)))`. `signing.ts` (`canonicalIndexBytes`, `canonicalManifestBytes`) and `resolve.ts` (`packageHash`) call `canonicalBytes(...)`; signing.ts's `canonicalize` is deleted. resolve.ts's local `canonicalJson` is RETAINED for lockfile serialization (`lockfile.ts` `serializeLockfile`) — that is a deterministic-file-format concern, NOT a trust-core hashing site, and is out of this slice's scope.
+
+**Tech Stack:** TypeScript (Bun runtime), `bun test`, `bun --bun tsc --noEmit -p tsconfig.json`. Spec: `docs/agendas/ace-package-manager/2026-06-02-ace-slice8.1-canonical-json-consume-design.md` (merged #6583).
+
+---
+
+## Pre-flight context for the implementer (you have zero repo context — read this)
+
+- **Harness (Otto-343):** the Edit tool is blocked. Create new files with the Write tool. Edit existing files with a Python patch-script that asserts the exact occurrence count before replacing, deletes itself (`rm`) before committing, and is NEVER committed (never commit a `_patch_*.py`). Verify pure-LF with Python `open(path,'rb').read().count(b'\r')` (must be `0`) — NEVER `grep` for `\r` (Git-Bash on this box reports phantom CRs). Commit trailer line: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- **Branch:** `otto-windows/ace-slice8.1-impl-2026-06-02`, created off `origin/main` (detached base is fine; the controller created it). Do NOT touch `main`.
+- **Canary:** `git ls-tree HEAD | wc -l` is `67` and must stay `67` (all new files land under existing top-level dirs `tools/` — they don't change the root-tree entry count).
+- **The shared primitive (the consume target), `src/Core.TypeScript/dynamic-value/json.ts`:**
+  - `export type Tagged = { t: "null" } | { t: "bool"; v: boolean } | { t: "int"; v: string } | { t: "str"; v: string } | { t: "arr"; v: Tagged[] } | { t: "obj"; v: [string, Tagged][] };`
+  - `export function canonicalJson(n: Tagged): string;` — minified; object keys emitted in **insertion order** (it does NOT sort — order-significant); `int` re-canonicalized via `BigInt(n.v).toString()`; strings RFC 8259 minimal escaping (`/` not escaped, control chars short-form or lowercase `\u00xx`). It is **pure** (zero imports) — safe to import into the CLI.
+  - Import it with the `.ts` extension (the `tools/ace` local convention; `moduleResolution: bundler` + `allowImportingTsExtensions: true` in root `tsconfig.json` accept it): `from "../../src/Core.TypeScript/dynamic-value/json.ts"` (`tools/ace/` is two levels deep).
+- **Why no test literals break (verified by sweep):** every `packageHash`/signature test assertion is either a runtime-recomputed self-consistent value (`expect(x).toBe(packageHash(A as any))`), a behavioral invariant (round-trip verify ok/reason, determinism `canonicalManifestBytes(m1) deepEquals canonicalManifestBytes(m2)`, signature-field exclusion), or an input fixture (`content_hash: "sha256:deadbeef"`). `contentHash` (store.ts, over `files` via `JSON.stringify`) is a SEPARATE slice-2 primitive, unaffected. There are **no** pinned literal canonical-bytes / signature-base64 / canonical-JSON-string assertions. The canonical bytes change; no test asserts the literal bytes. T2's gate is therefore "suites green with no literal edits"; if the suite nonetheless surfaces a changed literal, update it (the change is intentional, one-time, pre-release — no `format_version` bump).
+
+---
+
+## File Structure
+
+- **Create** `tools/ace/canonical.ts` — `toTagged` (sort keys, assert integers, omit `undefined` props) + `canonicalBytes`. The single Ace↔shared-canonical-JSON seam.
+- **Create** `tools/ace/canonical.test.ts` — `toTagged` shape/sort/integer-assert/undefined-omit + `canonicalBytes` equivalence (`= encode(canonicalJson(toTagged(x)))`), `fromCanonicalJson` round-trip, determinism (key-order-independent).
+- **Modify** `tools/ace/signing.ts` — `canonicalIndexBytes` + `canonicalManifestBytes` call `canonicalBytes`; delete `canonicalize`.
+- **Modify** `tools/ace/resolve.ts` — `packageHash` computes `sha256(canonicalBytes(...))`; KEEP local `canonicalJson` (now used only by `lockfile.ts`), add a one-line comment that it is the lockfile-serialization form, distinct from the trust-core `canonicalBytes`.
+
+---
+
+## Task 1: `tools/ace/canonical.ts` + tests
+
+**Files:**
+
+- Create: `tools/ace/canonical.ts`
+- Test: `tools/ace/canonical.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tools/ace/canonical.test.ts` with the Write tool:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { toTagged, canonicalBytes } from "./canonical.ts";
+import { canonicalJson, fromCanonicalJson, type Tagged } from "../../src/Core.TypeScript/dynamic-value/json.ts";
+
+const dec = new TextDecoder();
+const bytesToStr = (b: Uint8Array): string => dec.decode(b);
+
+describe("toTagged", () => {
+  test("null / bool / string map directly", () => {
+    expect(toTagged(null)).toEqual({ t: "null" });
+    expect(toTagged(true)).toEqual({ t: "bool", v: true });
+    expect(toTagged(false)).toEqual({ t: "bool", v: false });
+    expect(toTagged("hi")).toEqual({ t: "str", v: "hi" });
+  });
+
+  test("integer number → int with decimal-string value", () => {
+    expect(toTagged(0)).toEqual({ t: "int", v: "0" });
+    expect(toTagged(42)).toEqual({ t: "int", v: "42" });
+    expect(toTagged(-7)).toEqual({ t: "int", v: "-7" });
+  });
+
+  test("non-integer number throws (Ace has no Float fields)", () => {
+    expect(() => toTagged(3.14)).toThrow();
+    expect(() => toTagged(Number.NaN)).toThrow();
+    expect(() => toTagged(Number.POSITIVE_INFINITY)).toThrow();
+  });
+
+  test("array preserves order, recurses", () => {
+    expect(toTagged([1, "a", true])).toEqual({
+      t: "arr",
+      v: [{ t: "int", v: "1" }, { t: "str", v: "a" }, { t: "bool", v: true }],
+    });
+  });
+
+  test("object emits entries in SORTED key order", () => {
+    const out = toTagged({ b: 2, a: 1, c: 3 }) as Extract<Tagged, { t: "obj" }>;
+    expect(out.t).toBe("obj");
+    expect(out.v.map(([k]) => k)).toEqual(["a", "b", "c"]);
+    expect(out.v).toEqual([
+      ["a", { t: "int", v: "1" }],
+      ["b", { t: "int", v: "2" }],
+      ["c", { t: "int", v: "3" }],
+    ]);
+  });
+
+  test("nested object sorts at every level", () => {
+    const out = toTagged({ z: { y: 1, x: 2 }, a: 3 }) as Extract<Tagged, { t: "obj" }>;
+    expect(out.v.map(([k]) => k)).toEqual(["a", "z"]);
+    const z = out.v[1]![1] as Extract<Tagged, { t: "obj" }>;
+    expect(z.v.map(([k]) => k)).toEqual(["x", "y"]);
+  });
+
+  test("undefined object properties are omitted (JSON parity)", () => {
+    const out = toTagged({ a: 1, b: undefined, c: 3 }) as Extract<Tagged, { t: "obj" }>;
+    expect(out.v.map(([k]) => k)).toEqual(["a", "c"]);
+  });
+
+  test("unsupported value types throw (bigint, symbol, function)", () => {
+    expect(() => toTagged(1n)).toThrow();
+    expect(() => toTagged(Symbol("x"))).toThrow();
+    expect(() => toTagged(() => 0)).toThrow();
+  });
+});
+
+describe("canonicalBytes", () => {
+  test("= encode(canonicalJson(toTagged(x)))", () => {
+    const x = { b: 2, a: "hi", c: [1, 2] };
+    const expected = canonicalJson(toTagged(x));
+    expect(bytesToStr(canonicalBytes(x))).toBe(expected);
+  });
+
+  test("produces sorted-key minified canonical JSON", () => {
+    expect(bytesToStr(canonicalBytes({ b: 2, a: 1 }))).toBe('{"a":1,"b":2}');
+  });
+
+  test("round-trips through the shared fromCanonicalJson", () => {
+    const x = { name: "z", count: 3, nested: { k: "v" } };
+    const json = bytesToStr(canonicalBytes(x));
+    const back = fromCanonicalJson(json);
+    expect(back.ok).toBe(true);
+    if (back.ok) expect(canonicalJson(back.value)).toBe(json);
+  });
+
+  test("determinism: key insertion order does not change the bytes", () => {
+    const a = canonicalBytes({ one: 1, two: 2, three: 3 });
+    const b = canonicalBytes({ three: 3, one: 1, two: 2 });
+    expect(Buffer.from(a)).toEqual(Buffer.from(b));
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+Run: `bun test tools/ace/canonical.test.ts`
+Expected: FAIL — `Cannot find module "./canonical.ts"` (the module does not exist yet).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tools/ace/canonical.ts` with the Write tool:
+
+```typescript
+// canonical.ts -- Ace slice 8.1: the seam between Ace's trust core and the project's
+// shared, 4-language byte-locked canonical-JSON (src/Core.TypeScript/dynamic-value/json.ts).
+// Own-the-interface: the rest of Ace depends on canonicalBytes() here, not directly on the
+// dynamic-value port. The trust core's package_hash / key_id / index+manifest signing all
+// rest on canonicalBytes, so they inherit the audited cross-language canonicalization (and a
+// future Rust/F#/C# Ace consumer computes byte-identical hashes for free from the byte-lock).
+import { canonicalJson, type Tagged } from "../../src/Core.TypeScript/dynamic-value/json.ts";
+
+/**
+ * Convert a plain JS value into the shared `Tagged` form. Object entries are emitted in
+ * lexicographically-SORTED key order, so the order-preserving `canonicalJson` yields
+ * sorted-key output — Ace keeps its key-order-independent canonicalization while consuming
+ * the shared primitive. A JS `number` must be an integer (`Number.isInteger`): Ace's
+ * canonical content has no Float fields, so a non-integer is a bug and throws rather than
+ * silently hashing a float. `undefined` object properties are omitted (matching JSON /
+ * the prior `canonicalize`). bigint / symbol / function are unsupported and throw.
+ */
+export function toTagged(value: unknown): Tagged {
+  if (value === null) return { t: "null" };
+  switch (typeof value) {
+    case "boolean":
+      return { t: "bool", v: value };
+    case "number":
+      if (!Number.isInteger(value)) {
+        throw new Error(`toTagged: non-integer number ${value} — Ace canonical content has no Float fields`);
+      }
+      return { t: "int", v: String(value) };
+    case "string":
+      return { t: "str", v: value };
+    case "object": {
+      if (Array.isArray(value)) {
+        return { t: "arr", v: value.map(toTagged) };
+      }
+      const obj = value as Record<string, unknown>;
+      const entries: [string, Tagged][] = [];
+      for (const k of Object.keys(obj).sort()) {
+        const v = obj[k];
+        if (v === undefined) continue; // omit undefined props (JSON.stringify parity)
+        entries.push([k, toTagged(v)]);
+      }
+      return { t: "obj", v: entries };
+    }
+    default:
+      throw new Error(`toTagged: unsupported value type ${typeof value}`);
+  }
+}
+
+const ENCODER = new TextEncoder();
+
+/** Ace's canonical byte form: shared canonical-JSON over the sorted-key `Tagged` tree. */
+export function canonicalBytes(value: unknown): Uint8Array {
+  return ENCODER.encode(canonicalJson(toTagged(value)));
+}
+```
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+Run: `bun test tools/ace/canonical.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Type-check + verify pure-LF + canary**
+
+Run: `bun --bun tsc --noEmit -p tsconfig.json` → expect exit 0 (no errors).
+Run (pure-LF, both new files): `python -c "import sys;[print(p, open(p,'rb').read().count(b'\r')) for p in ['tools/ace/canonical.ts','tools/ace/canonical.test.ts']]"` → expect `0` for each.
+Run: `git ls-tree HEAD | wc -l` after staging is not meaningful pre-commit; instead after commit confirm `67`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/ace/canonical.ts tools/ace/canonical.test.ts
+git commit -m "feat(ace): slice 8.1 T1 — canonical.ts seam (sorted toTagged + canonicalBytes) consuming shared canonical-JSON
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+Then confirm canary: `git ls-tree HEAD | wc -l` → `67`.
+
+---
+
+## Task 2: rewire signing.ts + resolve.ts + behavior-preservation + PR
+
+**Files:**
+
+- Modify: `tools/ace/signing.ts` (delete `canonicalize`; `canonicalIndexBytes` + `canonicalManifestBytes` → `canonicalBytes`)
+- Modify: `tools/ace/resolve.ts` (`packageHash` → `canonicalBytes`; retain local `canonicalJson` for lockfile, add clarifying comment)
+
+- [ ] **Step 1: Rewire `signing.ts`**
+
+Use a Python patch-script (Edit is blocked). Three edits:
+
+1. Add the import after the `import type { AceManifest, RegistryEntry } from "./store.ts";` line (line 10):
+   - Insert: `import { canonicalBytes } from "./canonical.ts";`
+2. Delete the `canonicalize` function (lines 33-43, the whole `function canonicalize(value: unknown): unknown { ... }` block) and the blank line after it.
+3. Replace the bodies of `canonicalManifestBytes` and `canonicalIndexBytes` so they read:
+
+```typescript
+/** Whole manifest minus `signature`, via the shared canonical byte form (§8.1). */
+export function canonicalManifestBytes(manifest: AceManifest): Uint8Array {
+  const { signature, ...rest } = manifest as AceManifest & { signature?: AceSignature };
+  void signature; // excluded from canonical bytes — only `rest` is serialized
+  return canonicalBytes(rest);
+}
+
+/** Index content (no `signature`), via the shared canonical byte form. Sibling of canonicalManifestBytes. */
+export function canonicalIndexBytes(content: IndexSignableContent): Uint8Array {
+  return canonicalBytes(content);
+}
+```
+
+Patch-script discipline: read the file, assert each `old`-string occurs exactly once, replace, write, then `rm` the script. Do NOT commit the script.
+
+- [ ] **Step 2: Rewire `resolve.ts`**
+
+Use a Python patch-script. Two edits:
+
+1. Add import after line 1 (`import { createHash } from "node:crypto";`):
+   - Insert: `import { canonicalBytes } from "./canonical.ts";`
+2. Add a clarifying comment on the retained local `canonicalJson` (its JSDoc at lines 7-8) and rewire `packageHash` (lines 18-20). Replace:
+
+```typescript
+/** Deterministic JSON: object keys recursively sorted; arrays preserve order. */
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return "[" + value.map(canonicalJson).join(",") + "]";
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return "{" + keys.map((k) => JSON.stringify(k) + ":" + canonicalJson(obj[k])).join(",") + "}";
+}
+
+/** sha256 of the canonical whole package ({manifest incl. signature, files}). The parent's
+ *  pin / identity for a dependency. Two edges sharing a packageHash are byte-identical. */
+export function packageHash(pkg: AcePackage): string {
+  return "sha256:" + createHash("sha256").update(canonicalJson({ manifest: pkg.manifest, files: pkg.files })).digest("hex");
+}
+```
+
+with:
+
+```typescript
+/** Deterministic JSON for LOCKFILE serialization only (lockfile.ts `serializeLockfile`):
+ *  object keys recursively sorted; arrays preserve order. This is a readable-file-format
+ *  concern, NOT a trust-core hashing site — the trust core (packageHash below, signing.ts)
+ *  uses the shared `canonicalBytes` (canonical.ts). Kept local + exported for lockfile.ts. */
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return "[" + value.map(canonicalJson).join(",") + "]";
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return "{" + keys.map((k) => JSON.stringify(k) + ":" + canonicalJson(obj[k])).join(",") + "}";
+}
+
+/** sha256 of the canonical whole package ({manifest incl. signature, files}) via the shared
+ *  canonical byte form (§8.1). The parent's pin / identity for a dependency. Two edges sharing
+ *  a packageHash are byte-identical. */
+export function packageHash(pkg: AcePackage): string {
+  return "sha256:" + createHash("sha256").update(canonicalBytes({ manifest: pkg.manifest, files: pkg.files })).digest("hex");
+}
+```
+
+- [ ] **Step 3: Behavior-preservation gate — run the full Ace suite**
+
+Run: `bun test tools/ace/`
+Expected: ALL green. No literal edits are expected (every assertion is round-trip / determinism / self-consistent recompute / input fixture — see pre-flight context). If a test DOES surface a changed literal, that literal is an intentional one-time canonicalization change — update it to the new value and note it in the commit body. If a test surfaces a behavioral failure (a round-trip or determinism assertion breaking), STOP — that is a real regression, not a literal update; diagnose before proceeding.
+
+- [ ] **Step 4: Type-check + pure-LF**
+
+Run: `bun --bun tsc --noEmit -p tsconfig.json` → exit 0. (Confirms `canonicalize` is fully removed with no dangling references, and the cross-dir import resolves.)
+Run pure-LF check (Python `count(b'\r')==0`) on `tools/ace/signing.ts` and `tools/ace/resolve.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/ace/signing.ts tools/ace/resolve.ts
+git commit -m "feat(ace): slice 8.1 T2 — rewire trust-core canonical bytes onto shared canonical-JSON
+
+signing.ts canonicalIndexBytes/canonicalManifestBytes + resolve.ts packageHash now use
+canonicalBytes (canonical.ts); signing.ts canonicalize deleted. resolve.ts canonicalJson
+retained for lockfile serialization only. Canonical bytes change (intentional, pre-release,
+no format_version bump); all Ace suites green (assertions are round-trip / determinism /
+self-consistent recompute, no literal byte pins).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+Confirm canary `git ls-tree HEAD | wc -l` → `67`.
+
+- [ ] **Step 6: Push every commit, then open the PR**
+
+```bash
+git push -u origin otto-windows/ace-slice8.1-impl-2026-06-02
+# CONFIRM local tip == pushed tip BEFORE gh pr create (memory: pr-create-opens-from-remote-tip):
+test "$(git rev-parse HEAD)" = "$(git rev-parse @{u})" && echo "tip-synced ✓" || echo "PUSH INCOMPLETE — do not open PR"
+```
+
+Then the controller opens the impl PR (`gh pr create --head otto-windows/ace-slice8.1-impl-2026-06-02 --base main`) and runs the PR-gate loop. (The two task commits are pushed before the PR is cut, so neither drops.)
+
+---
+
+## Self-review (controller, before dispatch)
+
+- **Spec coverage:** Decision 1 (consume `canonicalJson`) → T1 `canonicalBytes`. Decision 2 (sort keys) → T1 `toTagged` sort + tests. Decision 3 (assert integers) → T1 throw + tests. Decision 4 (rewire 3 sites, delete `canonicalize`) → T2. Decision 5 (format change, no version bump) → T2 commit body. Decision 6 (TS-only) → no cross-lang work. ✓
+- **Placeholders:** none — every code step shows full code; the one allowed conditional ("if a literal surfaces") is backed by the verified sweep showing none is expected. ✓
+- **Type consistency:** `toTagged(value: unknown): Tagged`, `canonicalBytes(value: unknown): Uint8Array` used identically in T1 and T2; `Tagged`/`canonicalJson`/`fromCanonicalJson` names match the json.ts contract verified above. ✓
+- **Scope:** lockfile serialization deliberately retained (out of trust-core scope, documented in T2 Step 2 comment) — not an oversight. ✓
+
+## Model selection (controller)
+
+- **T1 — opus.** First-time contract authoring (the seam + integer/sort/undefined semantics + round-trip equivalence against the shared primitive). Security-adjacent (feeds package_hash + signing).
+- **T2 — opus.** Multi-file rewire with a behavior-preservation gate across the whole trust-core suite + dead-code removal (`canonicalize`) that must leave tsc clean; integration judgment.
+
+Two-stage review (spec compliance, then code quality) after each task per subagent-driven-development. Final holistic review over `git diff origin/main..HEAD -- tools/ace/` before finishing.

--- a/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.1-canonical-json-implementation-plan.md
+++ b/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.1-canonical-json-implementation-plan.md
@@ -157,9 +157,10 @@ import { canonicalJson, type Tagged } from "../../src/Core.TypeScript/dynamic-va
  * Convert a plain JS value into the shared `Tagged` form. Object entries are emitted in
  * lexicographically-SORTED key order, so the order-preserving `canonicalJson` yields
  * sorted-key output — Ace keeps its key-order-independent canonicalization while consuming
- * the shared primitive. A JS `number` must be an integer (`Number.isInteger`): Ace's
- * canonical content has no Float fields, so a non-integer is a bug and throws rather than
- * silently hashing a float. `undefined` object properties are omitted (matching JSON /
+ * the shared primitive. A JS `number` must be a safe integer (`Number.isSafeInteger`):
+ * Ace's canonical content has no Float fields, so a non-integer / NaN / Infinity /
+ * out-of-safe-range value is a bug and throws rather than silently hashing it. `undefined`
+ * object properties are omitted (matching JSON /
  * the prior `canonicalize`). bigint / symbol / function are unsupported and throw.
  */
 export function toTagged(value: unknown): Tagged {
@@ -168,8 +169,8 @@ export function toTagged(value: unknown): Tagged {
     case "boolean":
       return { t: "bool", v: value };
     case "number":
-      if (!Number.isInteger(value)) {
-        throw new Error(`toTagged: non-integer number ${value} — Ace canonical content has no Float fields`);
+      if (!Number.isSafeInteger(value)) {
+        throw new Error(`toTagged: ${value} is not a safe integer — Ace canonical content has no Float fields and integers must be within the safe-integer range`);
       }
       return { t: "int", v: String(value) };
     case "string":

--- a/tools/ace/canonical.test.ts
+++ b/tools/ace/canonical.test.ts
@@ -19,10 +19,22 @@ describe("toTagged", () => {
     expect(toTagged(-7)).toEqual({ t: "int", v: "-7" });
   });
 
-  test("non-integer number throws (Ace has no Float fields)", () => {
+  test("non-safe-integer numbers throw (float, NaN, Infinity, out-of-range)", () => {
     expect(() => toTagged(3.14)).toThrow();
     expect(() => toTagged(Number.NaN)).toThrow();
     expect(() => toTagged(Number.POSITIVE_INFINITY)).toThrow();
+    expect(() => toTagged(1e21)).toThrow(); // String(1e21) === "1e+21" → would crash canonicalJson's BigInt
+    expect(() => toTagged(Number.MAX_SAFE_INTEGER + 1)).toThrow();
+  });
+
+  test("safe-integer bounds map directly", () => {
+    expect(toTagged(Number.MAX_SAFE_INTEGER)).toEqual({ t: "int", v: "9007199254740991" });
+    expect(toTagged(Number.MIN_SAFE_INTEGER)).toEqual({ t: "int", v: "-9007199254740991" });
+  });
+
+  test("empty object and empty array", () => {
+    expect(toTagged({})).toEqual({ t: "obj", v: [] });
+    expect(toTagged([])).toEqual({ t: "arr", v: [] });
   });
 
   test("array preserves order, recurses", () => {
@@ -71,6 +83,11 @@ describe("canonicalBytes", () => {
 
   test("produces sorted-key minified canonical JSON", () => {
     expect(bytesToStr(canonicalBytes({ b: 2, a: 1 }))).toBe('{"a":1,"b":2}');
+  });
+
+  test("empty object / array canonical bytes", () => {
+    expect(bytesToStr(canonicalBytes({}))).toBe("{}");
+    expect(bytesToStr(canonicalBytes([]))).toBe("[]");
   });
 
   test("round-trips through the shared fromCanonicalJson", () => {

--- a/tools/ace/canonical.test.ts
+++ b/tools/ace/canonical.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { toTagged, canonicalBytes } from "./canonical.ts";
+import { canonicalJson, fromCanonicalJson, type Tagged } from "../../src/Core.TypeScript/dynamic-value/json.ts";
+
+const dec = new TextDecoder();
+const bytesToStr = (b: Uint8Array): string => dec.decode(b);
+
+describe("toTagged", () => {
+  test("null / bool / string map directly", () => {
+    expect(toTagged(null)).toEqual({ t: "null" });
+    expect(toTagged(true)).toEqual({ t: "bool", v: true });
+    expect(toTagged(false)).toEqual({ t: "bool", v: false });
+    expect(toTagged("hi")).toEqual({ t: "str", v: "hi" });
+  });
+
+  test("integer number → int with decimal-string value", () => {
+    expect(toTagged(0)).toEqual({ t: "int", v: "0" });
+    expect(toTagged(42)).toEqual({ t: "int", v: "42" });
+    expect(toTagged(-7)).toEqual({ t: "int", v: "-7" });
+  });
+
+  test("non-integer number throws (Ace has no Float fields)", () => {
+    expect(() => toTagged(3.14)).toThrow();
+    expect(() => toTagged(Number.NaN)).toThrow();
+    expect(() => toTagged(Number.POSITIVE_INFINITY)).toThrow();
+  });
+
+  test("array preserves order, recurses", () => {
+    expect(toTagged([1, "a", true])).toEqual({
+      t: "arr",
+      v: [{ t: "int", v: "1" }, { t: "str", v: "a" }, { t: "bool", v: true }],
+    });
+  });
+
+  test("object emits entries in SORTED key order", () => {
+    const out = toTagged({ b: 2, a: 1, c: 3 }) as Extract<Tagged, { t: "obj" }>;
+    expect(out.t).toBe("obj");
+    expect(out.v.map(([k]) => k)).toEqual(["a", "b", "c"]);
+    expect(out.v).toEqual([
+      ["a", { t: "int", v: "1" }],
+      ["b", { t: "int", v: "2" }],
+      ["c", { t: "int", v: "3" }],
+    ]);
+  });
+
+  test("nested object sorts at every level", () => {
+    const out = toTagged({ z: { y: 1, x: 2 }, a: 3 }) as Extract<Tagged, { t: "obj" }>;
+    expect(out.v.map(([k]) => k)).toEqual(["a", "z"]);
+    const z = out.v[1]![1] as Extract<Tagged, { t: "obj" }>;
+    expect(z.v.map(([k]) => k)).toEqual(["x", "y"]);
+  });
+
+  test("undefined object properties are omitted (JSON parity)", () => {
+    const out = toTagged({ a: 1, b: undefined, c: 3 }) as Extract<Tagged, { t: "obj" }>;
+    expect(out.v.map(([k]) => k)).toEqual(["a", "c"]);
+  });
+
+  test("unsupported value types throw (bigint, symbol, function)", () => {
+    expect(() => toTagged(1n)).toThrow();
+    expect(() => toTagged(Symbol("x"))).toThrow();
+    expect(() => toTagged(() => 0)).toThrow();
+  });
+});
+
+describe("canonicalBytes", () => {
+  test("= encode(canonicalJson(toTagged(x)))", () => {
+    const x = { b: 2, a: "hi", c: [1, 2] };
+    const expected = canonicalJson(toTagged(x));
+    expect(bytesToStr(canonicalBytes(x))).toBe(expected);
+  });
+
+  test("produces sorted-key minified canonical JSON", () => {
+    expect(bytesToStr(canonicalBytes({ b: 2, a: 1 }))).toBe('{"a":1,"b":2}');
+  });
+
+  test("round-trips through the shared fromCanonicalJson", () => {
+    const x = { name: "z", count: 3, nested: { k: "v" } };
+    const json = bytesToStr(canonicalBytes(x));
+    const back = fromCanonicalJson(json);
+    expect(back.ok).toBe(true);
+    if (back.ok) expect(canonicalJson(back.value)).toBe(json);
+  });
+
+  test("determinism: key insertion order does not change the bytes", () => {
+    const a = canonicalBytes({ one: 1, two: 2, three: 3 });
+    const b = canonicalBytes({ three: 3, one: 1, two: 2 });
+    expect(Buffer.from(a)).toEqual(Buffer.from(b));
+  });
+});

--- a/tools/ace/canonical.test.ts
+++ b/tools/ace/canonical.test.ts
@@ -72,6 +72,18 @@ describe("toTagged", () => {
     expect(() => toTagged(Symbol("x"))).toThrow();
     expect(() => toTagged(() => 0)).toThrow();
   });
+
+  test("lone surrogates throw (well-formedness — trust-core byte-collision guard)", () => {
+    expect(() => toTagged("\uD800")).toThrow();          // lone high surrogate
+    expect(() => toTagged("\uDC00")).toThrow();          // lone low surrogate
+    expect(() => toTagged("a\uD83Db")).toThrow();        // high not followed by low
+    expect(() => toTagged({ "\uD800": 1 })).toThrow();   // lone surrogate in an object key
+  });
+
+  test("valid surrogate pairs are accepted (astral code points)", () => {
+    expect(toTagged("😀")).toEqual({ t: "str", v: "😀" });
+    expect(toTagged("a😀b")).toEqual({ t: "str", v: "a😀b" });
+  });
 });
 
 describe("canonicalBytes", () => {
@@ -88,6 +100,12 @@ describe("canonicalBytes", () => {
   test("empty object / array canonical bytes", () => {
     expect(bytesToStr(canonicalBytes({}))).toBe("{}");
     expect(bytesToStr(canonicalBytes([]))).toBe("[]");
+  });
+
+  test("lone surrogate cannot collide with U+FFFD (rejected before encoding)", () => {
+    // Without the guard, "\uD800" and "�" both UTF-8-encode to EF BF BD → collision.
+    expect(() => canonicalBytes({ k: "\uD800" })).toThrow();
+    expect(bytesToStr(canonicalBytes({ k: "�" }))).toBe('{"k":"�"}');
   });
 
   test("round-trips through the shared fromCanonicalJson", () => {

--- a/tools/ace/canonical.ts
+++ b/tools/ace/canonical.ts
@@ -1,7 +1,7 @@
 // canonical.ts -- Ace slice 8.1: the seam between Ace's trust core and the project's
 // shared, 4-language byte-locked canonical-JSON (src/Core.TypeScript/dynamic-value/json.ts).
 // Own-the-interface: the rest of Ace depends on canonicalBytes() here, not directly on the
-// dynamic-value port. The trust core's package_hash / key_id / index+manifest signing all
+// dynamic-value port. The trust core's package_hash + index/manifest signing all
 // rest on canonicalBytes, so they inherit the audited cross-language canonicalization (and a
 // future Rust/F#/C# Ace consumer computes byte-identical hashes for free from the byte-lock).
 import { canonicalJson, type Tagged } from "../../src/Core.TypeScript/dynamic-value/json.ts";

--- a/tools/ace/canonical.ts
+++ b/tools/ace/canonical.ts
@@ -21,8 +21,13 @@ export function toTagged(value: unknown): Tagged {
     case "boolean":
       return { t: "bool", v: value };
     case "number":
-      if (!Number.isInteger(value)) {
-        throw new Error(`toTagged: non-integer number ${value} — Ace canonical content has no Float fields`);
+      // Number.isSafeInteger rejects floats, NaN, Infinity, AND integers outside
+      // ±(2^53-1) whose String() would be exponential (e.g. 1e21 → "1e+21", which
+      // BigInt() rejects inside canonicalJson). Ace's ints (format_version, sequence)
+      // are tiny; an out-of-range or non-integer number is a bug — fail loud here with
+      // a clear message rather than a cryptic downstream BigInt SyntaxError.
+      if (!Number.isSafeInteger(value)) {
+        throw new Error(`toTagged: ${value} is not a safe integer — Ace canonical content has no Float fields and integers must be within the safe-integer range`);
       }
       return { t: "int", v: String(value) };
     case "string":
@@ -33,6 +38,8 @@ export function toTagged(value: unknown): Tagged {
       }
       const obj = value as Record<string, unknown>;
       const entries: [string, Tagged][] = [];
+      // Code-unit (≈ ASCII) sort: intentional + deterministic. Do NOT switch to
+      // localeCompare — it would change the byte output for non-ASCII keys.
       for (const k of Object.keys(obj).sort()) {
         const v = obj[k];
         if (v === undefined) continue; // omit undefined props (JSON.stringify parity)

--- a/tools/ace/canonical.ts
+++ b/tools/ace/canonical.ts
@@ -6,14 +6,29 @@
 // future Rust/F#/C# Ace consumer computes byte-identical hashes for free from the byte-lock).
 import { canonicalJson, type Tagged } from "../../src/Core.TypeScript/dynamic-value/json.ts";
 
+// A lone (unpaired) UTF-16 surrogate is not well-formed text: the shared canonicalJson passes
+// it through raw, then TextEncoder collapses it to U+FFFD, so "\uD800", "\uD801", and the real
+// U+FFFD would all encode to identical trust-core bytes — a package_hash / signature collision
+// across byte-distinct metadata. The old JSON.stringify path escaped lone surrogates (well-formed
+// stringify); the shared canonicalJson does not, so Ace's seam rejects them here. Reject (not
+// escape) keeps the seam free of the byte-locked primitive; fail-loud composes with resolve's
+// try/catch that maps a toTagged throw to a clean invalid-package refusal.
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+function assertWellFormed(s: string, role: string): void {
+  if (LONE_SURROGATE.test(s)) {
+    throw new Error(`toTagged: ${role} contains a lone surrogate (not well-formed UTF-16) — rejected to avoid trust-core byte collisions (lone surrogates collapse to U+FFFD under UTF-8 encoding)`);
+  }
+}
+
 /**
  * Convert a plain JS value into the shared `Tagged` form. Object entries are emitted in
  * lexicographically-SORTED key order, so the order-preserving `canonicalJson` yields
  * sorted-key output — Ace keeps its key-order-independent canonicalization while consuming
  * the shared primitive. A JS `number` must be an integer (`Number.isInteger`): Ace's
  * canonical content has no Float fields, so a non-integer is a bug and throws rather than
- * silently hashing a float. `undefined` object properties are omitted (matching JSON /
- * the prior `canonicalize`). bigint / symbol / function are unsupported and throw.
+ * silently hashing a float. Strings + object keys must be well-formed UTF-16 (no lone
+ * surrogates — see assertWellFormed). `undefined` object properties are omitted (matching
+ * JSON / the prior `canonicalize`). bigint / symbol / function are unsupported and throw.
  */
 export function toTagged(value: unknown): Tagged {
   if (value === null) return { t: "null" };
@@ -31,6 +46,7 @@ export function toTagged(value: unknown): Tagged {
       }
       return { t: "int", v: String(value) };
     case "string":
+      assertWellFormed(value, "string");
       return { t: "str", v: value };
     case "object": {
       if (Array.isArray(value)) {
@@ -43,6 +59,7 @@ export function toTagged(value: unknown): Tagged {
       for (const k of Object.keys(obj).sort()) {
         const v = obj[k];
         if (v === undefined) continue; // omit undefined props (JSON.stringify parity)
+        assertWellFormed(k, "object key");
         entries.push([k, toTagged(v)]);
       }
       return { t: "obj", v: entries };

--- a/tools/ace/canonical.ts
+++ b/tools/ace/canonical.ts
@@ -1,0 +1,53 @@
+// canonical.ts -- Ace slice 8.1: the seam between Ace's trust core and the project's
+// shared, 4-language byte-locked canonical-JSON (src/Core.TypeScript/dynamic-value/json.ts).
+// Own-the-interface: the rest of Ace depends on canonicalBytes() here, not directly on the
+// dynamic-value port. The trust core's package_hash / key_id / index+manifest signing all
+// rest on canonicalBytes, so they inherit the audited cross-language canonicalization (and a
+// future Rust/F#/C# Ace consumer computes byte-identical hashes for free from the byte-lock).
+import { canonicalJson, type Tagged } from "../../src/Core.TypeScript/dynamic-value/json.ts";
+
+/**
+ * Convert a plain JS value into the shared `Tagged` form. Object entries are emitted in
+ * lexicographically-SORTED key order, so the order-preserving `canonicalJson` yields
+ * sorted-key output — Ace keeps its key-order-independent canonicalization while consuming
+ * the shared primitive. A JS `number` must be an integer (`Number.isInteger`): Ace's
+ * canonical content has no Float fields, so a non-integer is a bug and throws rather than
+ * silently hashing a float. `undefined` object properties are omitted (matching JSON /
+ * the prior `canonicalize`). bigint / symbol / function are unsupported and throw.
+ */
+export function toTagged(value: unknown): Tagged {
+  if (value === null) return { t: "null" };
+  switch (typeof value) {
+    case "boolean":
+      return { t: "bool", v: value };
+    case "number":
+      if (!Number.isInteger(value)) {
+        throw new Error(`toTagged: non-integer number ${value} — Ace canonical content has no Float fields`);
+      }
+      return { t: "int", v: String(value) };
+    case "string":
+      return { t: "str", v: value };
+    case "object": {
+      if (Array.isArray(value)) {
+        return { t: "arr", v: value.map(toTagged) };
+      }
+      const obj = value as Record<string, unknown>;
+      const entries: [string, Tagged][] = [];
+      for (const k of Object.keys(obj).sort()) {
+        const v = obj[k];
+        if (v === undefined) continue; // omit undefined props (JSON.stringify parity)
+        entries.push([k, toTagged(v)]);
+      }
+      return { t: "obj", v: entries };
+    }
+    default:
+      throw new Error(`toTagged: unsupported value type ${typeof value}`);
+  }
+}
+
+const ENCODER = new TextEncoder();
+
+/** Ace's canonical byte form: shared canonical-JSON over the sorted-key `Tagged` tree. */
+export function canonicalBytes(value: unknown): Uint8Array {
+  return ENCODER.encode(canonicalJson(toTagged(value)));
+}

--- a/tools/ace/canonical.ts
+++ b/tools/ace/canonical.ts
@@ -24,9 +24,10 @@ function assertWellFormed(s: string, role: string): void {
  * Convert a plain JS value into the shared `Tagged` form. Object entries are emitted in
  * lexicographically-SORTED key order, so the order-preserving `canonicalJson` yields
  * sorted-key output — Ace keeps its key-order-independent canonicalization while consuming
- * the shared primitive. A JS `number` must be an integer (`Number.isInteger`): Ace's
- * canonical content has no Float fields, so a non-integer is a bug and throws rather than
- * silently hashing a float. Strings + object keys must be well-formed UTF-16 (no lone
+ * the shared primitive. A JS `number` must be a safe integer (`Number.isSafeInteger`):
+ * Ace's canonical content has no Float fields, so a non-integer, NaN, Infinity, or
+ * out-of-safe-range value is a bug and throws rather than silently hashing it. Strings +
+ * object keys must be well-formed UTF-16 (no lone
  * surrogates — see assertWellFormed). `undefined` object properties are omitted (matching
  * JSON / the prior `canonicalize`). bigint / symbol / function are unsupported and throw.
  */

--- a/tools/ace/resolve.test.ts
+++ b/tools/ace/resolve.test.ts
@@ -186,6 +186,17 @@ describe("resolve — invalid package", () => {
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("invalid-package");
   });
+  test("dep with a non-safe-integer manifest field refuses invalid-package (no throw)", async () => {
+    const D = pkgOf("D", { "d.txt": "d" });
+    // Inject a float into the manifest: packageHash's shared canonicalBytes uses
+    // Number.isSafeInteger and throws on it. resolve must surface that as a clean
+    // invalid-package refusal, not an unhandled exception (slice 8.1).
+    const floatDep: any = { manifest: { ...D.manifest, bogus: 1.5 }, files: D.files };
+    const root = pkgOf("root", { "r.txt": "r" }, [{ pkg: D, url: "http://e/D" }]);
+    const r = await resolve(root, fetchOf({ "http://e/D": floatDep }), NO_TRUST, new Map(), new Map(), { allowNoSignature: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("invalid-package");
+  });
 });
 
 function regOf(src: Record<string, Record<string, RegistryEntry>>): Map<string, Map<string, RegistryEntry>> {

--- a/tools/ace/resolve.ts
+++ b/tools/ace/resolve.ts
@@ -149,7 +149,7 @@ export async function resolve(
       try {
         got = packageHash(dep);
       } catch (e) {
-        return { ok: false, reason: "invalid-package", detail: `${edge.name}: ${(e as Error).message}`, path: here };
+        return { ok: false, reason: "invalid-package", detail: `${edge.name}: ${e instanceof Error ? e.message : String(e)}`, path: here };
       }
       if (got !== package_hash) {
         return { ok: false, reason: "pin-mismatch", detail: `${edge.name}: expected package_hash ${package_hash} but fetched ${got}`, path: here };

--- a/tools/ace/resolve.ts
+++ b/tools/ace/resolve.ts
@@ -1,10 +1,14 @@
 import { createHash } from "node:crypto";
+import { canonicalBytes } from "./canonical.ts";
 import type { RevocationMap } from "./signing.ts";
 import { contentHash, type AcePackage, type LoadedTrustEntry, type Registry } from "./store.ts";
 import { verifySignature } from "./signing.ts";
 import { parseRange, satisfies } from "./semver.ts";
 
-/** Deterministic JSON: object keys recursively sorted; arrays preserve order. */
+/** Deterministic JSON for LOCKFILE serialization only (lockfile.ts `serializeLockfile`):
+ *  object keys recursively sorted; arrays preserve order. This is a readable-file-format
+ *  concern, NOT a trust-core hashing site — the trust core (packageHash below, signing.ts)
+ *  uses the shared `canonicalBytes` (canonical.ts). Kept local + exported for lockfile.ts. */
 export function canonicalJson(value: unknown): string {
   if (value === null || typeof value !== "object") return JSON.stringify(value);
   if (Array.isArray(value)) return "[" + value.map(canonicalJson).join(",") + "]";
@@ -13,10 +17,11 @@ export function canonicalJson(value: unknown): string {
   return "{" + keys.map((k) => JSON.stringify(k) + ":" + canonicalJson(obj[k])).join(",") + "}";
 }
 
-/** sha256 of the canonical whole package ({manifest incl. signature, files}). The parent's
- *  pin / identity for a dependency. Two edges sharing a packageHash are byte-identical. */
+/** sha256 of the canonical whole package ({manifest incl. signature, files}) via the shared
+ *  canonical byte form (§8.1). The parent's pin / identity for a dependency. Two edges sharing
+ *  a packageHash are byte-identical. */
 export function packageHash(pkg: AcePackage): string {
-  return "sha256:" + createHash("sha256").update(canonicalJson({ manifest: pkg.manifest, files: pkg.files })).digest("hex");
+  return "sha256:" + createHash("sha256").update(canonicalBytes({ manifest: pkg.manifest, files: pkg.files })).digest("hex");
 }
 
 export type FetchPackage = (urlOrPath: string) => Promise<string>;

--- a/tools/ace/resolve.ts
+++ b/tools/ace/resolve.ts
@@ -141,8 +141,16 @@ export async function resolve(
       if (filesHash !== dep.manifest.content_hash) {
         return { ok: false, reason: "bad-content-hash", detail: `${edge.name}: files hash ${filesHash} != manifest ${dep.manifest.content_hash}`, path: here };
       }
-      // pin check (whole-package identity)
-      const got = packageHash(dep);
+      // pin check (whole-package identity). packageHash canonicalizes via the shared
+      // canonicalBytes, which throws on a non-safe-integer (e.g. a float in an untrusted
+      // manifest field); map that to a clean invalid-package refusal rather than letting it
+      // escape resolve() as an unhandled exception (slice 8.1).
+      let got: string;
+      try {
+        got = packageHash(dep);
+      } catch (e) {
+        return { ok: false, reason: "invalid-package", detail: `${edge.name}: ${(e as Error).message}`, path: here };
+      }
       if (got !== package_hash) {
         return { ok: false, reason: "pin-mismatch", detail: `${edge.name}: expected package_hash ${package_hash} but fetched ${got}`, path: here };
       }

--- a/tools/ace/signing.ts
+++ b/tools/ace/signing.ts
@@ -8,6 +8,7 @@ import {
   sign as nodeSign, verify as nodeVerify,
 } from "node:crypto";
 import type { AceManifest, RegistryEntry } from "./store.ts";
+import { canonicalBytes } from "./canonical.ts";
 
 export interface Keypair { privatePem: string; publicSpkiB64: string; keyId: string; }
 export interface AceSignature { algo: "ed25519"; key_id: string; sig: string; }
@@ -30,23 +31,11 @@ export function generateKeypair(): Keypair {
   return { privatePem, publicSpkiB64, keyId: keyId(publicSpkiB64) };
 }
 
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (value && typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
-      out[k] = canonicalize((value as Record<string, unknown>)[k]);
-    }
-    return out;
-  }
-  return value;
-}
-
-/** Whole manifest minus `signature`, recursively key-sorted, compact JSON. */
+/** Whole manifest minus `signature`, via the shared canonical byte form (§8.1). */
 export function canonicalManifestBytes(manifest: AceManifest): Uint8Array {
   const { signature, ...rest } = manifest as AceManifest & { signature?: AceSignature };
   void signature; // excluded from canonical bytes — only `rest` is serialized
-  return new TextEncoder().encode(JSON.stringify(canonicalize(rest)));
+  return canonicalBytes(rest);
 }
 
 export function signManifest(manifest: AceManifest, privatePem: string): AceSignature {
@@ -90,9 +79,9 @@ export interface IndexSignableContent {
   quarantined?: RevocationMap;
 }
 
-/** Index content (no `signature`), recursively key-sorted, compact JSON. Sibling of canonicalManifestBytes. */
+/** Index content (no `signature`), via the shared canonical byte form. Sibling of canonicalManifestBytes. */
 export function canonicalIndexBytes(content: IndexSignableContent): Uint8Array {
-  return new TextEncoder().encode(JSON.stringify(canonicalize(content)));
+  return canonicalBytes(content);
 }
 
 export function signIndex(content: IndexSignableContent, privatePem: string): AceSignature {


### PR DESCRIPTION
## Ace slice 8.1 — trust core consumes the shared canonical-JSON

Second step of the cross-language Ace trust core (after slice 8 SHA-256). Ace's trust core stops using its own ad-hoc canonicalizers and instead consumes the project's **shared, 4-language byte-locked canonical-JSON** (`src/Core.TypeScript/dynamic-value/json.ts` `canonicalJson`, byte-locked across TS/F#/C#/Rust). A future Rust/F#/C# Ace consumer then computes byte-identical `package_hash` for free from the byte-lock.

Spec: `docs/agendas/ace-package-manager/2026-06-02-ace-slice8.1-canonical-json-consume-design.md` (#6583, merged). Plan: `docs/agendas/ace-package-manager/2026-06-02-ace-slice8.1-canonical-json-implementation-plan.md` (in this PR).

### What changed

- **NEW `tools/ace/canonical.ts`** — the seam (own-the-interface): `toTagged(value)` (lexicographically **sorted** object keys, so the order-preserving `canonicalJson` keeps Ace's key-order-independence; **`Number.isSafeInteger`-guarded** — a float/NaN/out-of-range int is a bug and throws, never silently hashed; `undefined` props omitted) + `canonicalBytes(value) = encode(canonicalJson(toTagged(value)))`.
- **`signing.ts`** — `canonicalManifestBytes` + `canonicalIndexBytes` → `canonicalBytes`; local `canonicalize` deleted.
- **`resolve.ts`** — `packageHash` → `canonicalBytes`; the untrusted-dep pin-check call is wrapped to map a `canonicalBytes` throw to a clean `{ ok: false, reason: "invalid-package" }`. Local `canonicalJson` **retained** for `lockfile.ts` serialization (a deterministic-file-format concern, NOT a trust-core hashing site — out of scope, documented inline).

### Behavior-preservation

The canonical bytes legitimately shift (the shared `canonicalJson`'s escaping + int re-canonicalization differ from the old `JSON.stringify`). Ace is pre-release (no live registries) — accepted one-time change, no `format_version` bump. **`bun test tools/ace/` = 354 pass / 0 fail with zero test-literal edits** — every relevant assertion is a round-trip (sign→verify), a determinism check (key-order-independent bytes), or a self-consistent recompute (`packageHash`), none pin a literal byte/hash/sig.

### Review (subagent-driven, two-stage per task + final holistic)

- T1 code-quality caught a `Number.isInteger(1e21)`-true-but-`String`-exponential gap → fixed with `Number.isSafeInteger` (`d317e947b`).
- T2 code-quality caught the new float-throw escaping `resolve()` unguarded → mapped to `invalid-package` + regression test (`e669f7eae`).
- Final holistic review: **APPROVED** — sign/verify and pin compute/check each share one canonicalizer; security invariants preserved + float-field tightened; for realistic Ace manifests the new and old forms are byte-identical, so no persisted artifact could break.

### Follow-up (non-blocking, noted by final review)

CLI-layer (`ace.ts`) untrusted **root** manifest paths (install/update/registry) with a float field currently surface as `ace: fatal: …` rather than a styled `refused: invalid-package` — *not a trust hole* (package still refused, exit non-zero), pre-existing-shape, out of this slice's three-site scope. Candidate for a small CLI-error-consistency follow-up.

Gates: `bun test tools/ace/` 354/0 · `bun --bun tsc --noEmit -p tsconfig.json` exit 0 · pure-LF · markdownlint clean (plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
