### PR TITLE
docs(ace): slice 8.2 spec — package_hash as content identity (signature-excluded composition)

### DIFF
--- a/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.2-package-hash-composition-design.md
+++ b/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.2-package-hash-composition-design.md
@@ -1,0 +1,177 @@
+# Ace slice 8.2 — package_hash composition (content identity) (design)
+
+> Spec for slice 8.2 of the Ace package manager (B-0288), third step of the
+> cross-language Ace trust core (after slice 8 SHA-256 + slice 8.1 canonical-JSON).
+> `package_hash` becomes a formally-defined, golden-vector-verified **content
+> identity** — the composition of the two trust-core primitives already built
+> (canonical-JSON 8.1 ∘ SHA-256 slice 8) — extracted into a dedicated module, with
+> the signature **excluded** from the hashed input. Brainstormed + approved with the
+> operator 2026-06-02 (scope: formalize + golden-vector, TS, parity spec'd;
+> signature: exclude → content identity).
+
+## Goal
+
+`package_hash` is the trust core's content-addressed identity: a parent pins a
+dependency by `package_hash`, and `resolve` refuses a fetched package whose
+recomputed hash differs from the pin. Today it is an **undocumented inline
+composition** in `resolve.ts` (`"sha256:" + sha256(canonicalBytes({ manifest, files }))`,
+manifest *including* its signature) with **no golden vectors** — slice 8 vectored
+SHA-256 and slice 8.1 the canonical-JSON, but nothing vectors the *composed*
+identity, so a change to the canonicalizer or the input shape shifts `package_hash`
+silently. This slice (1) defines the composition formally as a **content identity**
+(signature excluded), (2) extracts it into a dedicated trust-core module, and (3)
+anchors it with a golden-vector fixture whose expected values are independently
+verifiable — so a future Rust/F#/C# Ace consumer computes a byte-identical
+`package_hash` from the same fixture.
+
+## Decisions (this spec locks them; operator 2026-06-02)
+
+1. **Content identity — exclude the signature.**
+   `package_hash = "sha256:" + sha256Hex(canonicalBytes({ manifest: «manifest minus signature», files }))`.
+   The signature is excluded from the hashed input. Identity (what the package *is*)
+   is separated from authenticity (who vouches for it — still verified separately and
+   unchanged by `verifySignature` / `verifyIndexSignature`). This aligns the identity
+   input with `signing.ts`'s `canonicalManifestBytes`, which already strips the
+   signature when signing — so there is **one "content" notion** (manifest-minus-sig,
+   plus `files` for the package hash) underlying both signing and identity, removing
+   the prior asymmetry (the thing signed was manifest-minus-sig; the thing
+   identity-hashed was manifest-incl-sig).
+
+2. **No security loss; more stable.** The signature is verified regardless (the
+   resolve signature gate is unchanged), so excluding it from the identity removes
+   nothing. It makes `package_hash` **stable across re-signing** (key rotation /
+   multi-signer) and **identical for an unsigned package and its later-signed form** —
+   a content identity, not an artifact-blob identity.
+
+3. **Behavior change accepted.** `package_hash` values shift (the signature no longer
+   contributes, and 8.1 already shifted the canonical bytes). Ace is pre-release (no
+   live registries) → acceptable; no `format_version` bump. Documented as a one-time
+   identity-definition change.
+
+4. **Extract into a dedicated trust-core module** `tools/ace/package-hash.ts`,
+   co-located with `canonical.ts` (slice 8.1) as a named trust-core primitive. The
+   local `packageHash` is removed from `resolve.ts`; every import site is swept to the
+   new module.
+
+5. **Runtime hasher stays node:crypto SHA-256.** Native + fast + byte-identical to the
+   slice-8 SHA-256 oracle (which exists for cross-language *verification* — proving all
+   four languages compute SHA-256 identically — not as the runtime hasher). `contentHash`
+   (store.ts) already uses node:crypto the same way. The "composition" is of the two
+   *concepts* (canonical-JSON then SHA-256); the golden-vector fixture anchors that the
+   composed result is correct + reproducible.
+
+6. **Scope is TS + golden vectors; full 4-language oracle deferred.** Consistent with
+   8.1's "TS-only, 4-lang parity inherited." The composition's cross-language parity is
+   **spec'd and anchored by the fixture** (the `expected_canonical_json` + `expected_package_hash`
+   are the contract a future F#/C#/Rust Ace must reproduce). Porting `toTagged` + the
+   composition to F#/C#/Rust as a live 4-way oracle is deferred until a non-TS Ace
+   consumer exists.
+
+## Architecture
+
+```text
+tools/ace/package-hash.ts
+  import { canonicalBytes } from "./canonical.ts";   // slice 8.1 seam
+  import { createHash } from "node:crypto";          // runtime SHA-256 (native)
+  import type { AcePackage, AceManifest } from "./store.ts";
+  packageHash(pkg: AcePackage): string
+    = "sha256:" + sha256Hex(canonicalBytes({ manifest: stripSignature(pkg.manifest), files: pkg.files }))
+```
+
+`stripSignature` removes the `signature` field from the manifest (the same destructure
+`signing.ts` uses: `const { signature, ...rest } = manifest`). The rest of Ace depends
+on `packageHash` from this module; `resolve.ts` keeps its `try/catch` around the
+untrusted-dep call (the 8.1 T2 guard, mapping a `canonicalBytes` throw → `invalid-package`).
+
+`resolve.ts` (`packageHash(root)` seed + `packageHash(dep)` pin check), `lockfile.ts`
+(`packageHash` for lockfile nodes), `ace.test.ts`, and `resolve.test.ts` import
+`packageHash` from `./package-hash.ts`. `resolve.ts` no longer defines or exports it.
+`resolve.ts`'s local `canonicalJson` (lockfile serialization, retained in 8.1) is
+untouched.
+
+## Components
+
+- **`tools/ace/package-hash.ts`** — **new**. `packageHash(pkg)` over the
+  signature-excluded content (`{ manifest − signature, files }`) via `canonicalBytes`
+  + node:crypto SHA-256, in the `sha256:<hex>` form.
+- **`tools/ace/package-hash.test.ts`** — **new**. Unit tests: the `sha256:<hex>` form;
+  determinism (key-order-independent — inherited from the sorted `toTagged`); the
+  **signature-exclusion proof** (a package and the same package with a `signature`
+  field added → identical `packageHash`; and two packages differing only in their
+  signature value → identical `packageHash`); a float/lone-surrogate field still throws
+  (inherited from `toTagged`).
+- **`tools/ace/resolve.ts`** — `packageHash` removed; imported from `./package-hash.ts`;
+  the untrusted-dep `try/catch` guard retained.
+- **`tools/ace/lockfile.ts`** — import `packageHash` from `./package-hash.ts` (was
+  `./resolve.ts`); `canonicalJson` still from `./resolve.ts`.
+- **`tools/ace/ace.test.ts` + `tools/ace/resolve.test.ts`** — import `packageHash` from
+  `./package-hash.ts`.
+- **`tests/cross-verification/package-hash/vectors.json`** — **new**. Fixture packages,
+  each with `expected_canonical_json` (the intermediate canonical-JSON string — the
+  cross-language contract) and `expected_package_hash` (`sha256:<hex>`).
+- **`tests/cross-verification/package-hash/cross-verify.ts`** — **new**. Reads
+  `vectors.json`, computes `packageHash` + the canonical-JSON for each fixture, writes
+  `ts-output.json`, and **asserts** each against `expected_canonical_json` +
+  `expected_package_hash`, exit-non-zero on any mismatch (assert-don't-skip; mirrors
+  the sha256 oracle's `cross-verify.ts`).
+
+## Testing
+
+- **Unit (`package-hash.test.ts`):** form; determinism; **signature-exclusion proof**
+  (the load-bearing test for decision 1 — adding/altering `signature` does not change
+  `packageHash`); throw-inheritance (float / lone-surrogate field → throws, since the
+  composition runs through `toTagged`).
+- **Golden-vector (`cross-verification/package-hash/`):** the TS oracle computes from
+  the package object and asserts against the independently-derived expected values. The
+  expected `expected_package_hash` is verified **independently** (Python `hashlib` over
+  the `expected_canonical_json` bytes — the same independent-verification discipline
+  used for the slice-8 SHA-256 vectors), so the fixture is a genuine cross-language
+  contract, not a TS-vs-TS tautology.
+- **Behavior-preservation (the load-bearing gate):** the whole Ace suite
+  (`bun test tools/ace/`) stays green. `package_hash` *values* change (signature
+  excluded) but every assertion is a round-trip, a determinism check, or a
+  self-consistent recompute (`expect(x).toBe(packageHash(A))`) — none pin a literal
+  `package_hash` (verified by sweep in 8.1; re-confirm). Exclude-sig only makes pins
+  *more* stable (sign→verify still passes; pin compute/check still self-consistent).
+  If a test surfaces a behavioral failure (a round-trip or pin assertion breaking),
+  that is a real regression — STOP and diagnose, do not paper over.
+- Gates: `bun test tools/ace/`; `bun --bun tsc --noEmit -p tsconfig.json` exit 0;
+  the `cross-verification/package-hash/cross-verify.ts` check exits 0; markdownlint on
+  this doc + the plan.
+
+## Scope / YAGNI
+
+In scope: `package-hash.ts` (signature-excluded content identity) + tests; extract +
+sweep import sites; the golden-vector fixture + TS cross-verify with independently
+verified expected values. Out of scope: a live F#/C#/Rust `package_hash` oracle (port
+`toTagged` ×3 — deferred until a non-TS Ace exists; the byte-lock + fixture already
+guarantee future parity); `format_version` bump (pre-release); changing the signature /
+content_hash mechanisms (unchanged); the CLI untrusted-root hardening (the separate
+follow-up named by the 8.1 final review — `ace.ts` root paths surfacing `fatal:` vs a
+styled `refused:`).
+
+## Files touched
+
+- `tools/ace/package-hash.ts` — **new** (`packageHash`, signature-excluded).
+- `tools/ace/package-hash.test.ts` — **new**.
+- `tools/ace/resolve.ts` — remove local `packageHash`; import from `./package-hash.ts`;
+  keep the untrusted-dep `try/catch`.
+- `tools/ace/lockfile.ts` — import `packageHash` from `./package-hash.ts`.
+- `tools/ace/ace.test.ts`, `tools/ace/resolve.test.ts` — import `packageHash` from
+  `./package-hash.ts` (sweep).
+- `tests/cross-verification/package-hash/vectors.json` — **new**.
+- `tests/cross-verification/package-hash/cross-verify.ts` — **new**.
+
+## Decomposition (3 tasks)
+
+- **T1 — `tools/ace/package-hash.ts` + tests.** `packageHash` over
+  `{ manifest − signature, files }` via `canonicalBytes` + node:crypto SHA-256; unit
+  tests (form, determinism, **signature-exclusion proof**, throw-inheritance). TDD.
+- **T2 — extract + rewire + behavior-preservation.** Remove `packageHash` from
+  `resolve.ts`; sweep every import site (`resolve.ts`, `lockfile.ts`, `ace.test.ts`,
+  `resolve.test.ts`) to `./package-hash.ts`; re-green the Ace suite (values shift,
+  self-consistent — update any literal pin if one surfaces; none expected).
+- **T3 — golden-vector fixture.** `tests/cross-verification/package-hash/vectors.json`
+  (fixture packages → `expected_canonical_json` + `expected_package_hash`, independently
+  verified via Python `hashlib`) + `cross-verify.ts` (asserts, exit-non-zero on
+  mismatch); confirm the check is runnable + green.


### PR DESCRIPTION
## Ace slice 8.2 spec — package_hash as content identity

Third step of the cross-language Ace trust core (after slice 8 SHA-256, 8.1 canonical-JSON). Spec only; implementation follows in a separate PR after plan + go-ahead.

**Decisions locked (brainstormed + approved with the operator 2026-06-02):**

1. **Content identity — exclude the signature.** `package_hash = "sha256:" + sha256(canonicalBytes({ manifest − signature, files }))`. Aligns the identity input with `signing.ts`'s `canonicalManifestBytes` (which already strips the sig) → one "content" notion for both signing + identity. Identity (what) separated from authenticity (who — still verified by `verifySignature`). Stable across re-signing; unsigned and later-signed forms share a hash. No security loss (sig verified regardless). Behavior change accepted (pre-release, no `format_version` bump).
2. **Extract** to a dedicated trust-core module `tools/ace/package-hash.ts` (co-located with `canonical.ts`); sweep import sites (`resolve.ts`, `lockfile.ts`, `ace.test.ts`, `resolve.test.ts`); remove `packageHash` from `resolve.ts` (its untrusted-dep `try/catch` guard stays).
3. **Golden-vector fixture** `tests/cross-verification/package-hash/` (mirrors the sha256 oracle): fixture packages → `expected_canonical_json` (the cross-language contract) + `expected_package_hash`; TS `cross-verify.ts` asserts both, exit-non-zero on mismatch; expected values independently verified (Python `hashlib`, assert-don't-skip). Full F#/C#/Rust oracle deferred (parity spec'd + anchored) until a non-TS Ace exists.

Fills the real gap: the composed identity currently has **no golden vectors** (slice 8 vectored SHA-256, 8.1 the canonical-JSON, nothing the composition) and is an undocumented inline composition in `resolve.ts`.

~3-task decomposition: T1 `package-hash.ts` + tests (signature-exclusion proof) → T2 extract/rewire + re-green suite → T3 golden-vector fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
