### PR TITLE
docs(B-1006)+rule: register the Tick algebra / adapterize the sources; closed four-bucket sort (Amara + Prism, cross-AI triangulation)

### DIFF
--- a/.claude/rules/algebra-first-admission-canonical-primitives-bcl-registry-three-gate-ship-gate.md
+++ b/.claude/rules/algebra-first-admission-canonical-primitives-bcl-registry-three-gate-ship-gate.md
@@ -57,6 +57,28 @@ no taste, no seniority, no politics):
   *why* it's trustworthy — every entry is a contract Ace maintains across every
   target language.
 
+### 4. What registers vs what adapts — the closed four-bucket sort (Amara 2026-06-02)
+
+> The registry stores **atoms and laws**; sources, views, and transports **adapt**
+> into those laws. **Do not register a source when you can register the algebra it
+> emits.**
+
+Every candidate sorts into exactly one bucket — only the first is the registry/BCL:
+
+| Bucket | What | Examples |
+|---|---|---|
+| **registers** | atoms + laws = **algebras** | Z-set family · codec algebra · Tick algebra · generic-math base |
+| **adapts** | **sources · views · transports** | `TickSource*` (Manual/Timer/CircuitStep/WebSocket/GitEvent) · Rx + event-index (views) · the wire under the codec (transports) |
+| **executes** | **runtimes** | the DBSP Circuit step-loop |
+| **waives** | named **asymmetric exceptions** | host adapters that can't be cross-language-guaranteed |
+
+So when a candidate is a *source* (it emits values), register the **algebra it
+emits**, not the source — e.g. register the **Tick algebra** (`Tick`/`Delta`/`zero`/
+`advance`/`order`/`monotonicity`/`z⁻¹`); `WallClock`/`Timer`/`CircuitStep`/`WebSocket`/
+`GitEvent` tick-sources are adapters. The algebra-first procedure is the registry's
+**immune system**: it sorts every candidate into these four and admits only the
+algebras.
+
 ## Why this auto-loads
 
 Per [`wake-time-substrate.md`](wake-time-substrate.md): this fires at

--- a/docs/backlog/P1/B-1006-canonical-primitives-registry-plus-promotion-gate-plus-whats-the-difference-suspicion-test-no-special-index-class-if-it-is-just-a-zset-gset-emit-rx-composition-aaron-2026-06-02.md
+++ b/docs/backlog/P1/B-1006-canonical-primitives-registry-plus-promotion-gate-plus-whats-the-difference-suspicion-test-no-special-index-class-if-it-is-just-a-zset-gset-emit-rx-composition-aaron-2026-06-02.md
@@ -9,7 +9,7 @@ created: 2026-06-02
 last_updated: 2026-06-02
 depends_on: []
 composes_with: [B-1000, B-1004, B-1005, B-0428, B-0288, B-0824, B-0976]
-tags: [canonical-primitives, primitives-registry, promotion-gate, whats-the-difference-test, decomposition-direction-triage, earn-its-keep, minimal-vocabulary, suspicion-by-default, zset, gset, bag, indexed-zset, event-index, rx, bonsai, tick-source, aesthetics-gate, correctness-gate, orthogonal-primitive-axes, codec-axis, codec-as-primitive, registry-is-bcl, codec-algebra, algebra-first-admission-procedure, registry-is-ship-gate, temporal-operator-algebra, everything-is-algebra, tick-source-folds-to-algebra, asymmetric-exceptions, ace-distribution, cross-language-byte-lock, quality-uniqueness-composability-gate, infer-net, research, aaron]
+tags: [canonical-primitives, primitives-registry, promotion-gate, whats-the-difference-test, decomposition-direction-triage, earn-its-keep, minimal-vocabulary, suspicion-by-default, zset, gset, bag, indexed-zset, event-index, rx, bonsai, tick-source, aesthetics-gate, correctness-gate, orthogonal-primitive-axes, codec-axis, codec-as-primitive, registry-is-bcl, codec-algebra, algebra-first-admission-procedure, registry-is-ship-gate, temporal-operator-algebra, everything-is-algebra, tick-source-folds-to-algebra, register-algebra-adapterize-sources, four-bucket-taxonomy, cross-ai-triangulation, asymmetric-exceptions, ace-distribution, cross-language-byte-lock, quality-uniqueness-composability-gate, infer-net, research, aaron]
 type: research
 ---
 
@@ -335,6 +335,42 @@ temporal-operator algebra) + the generic-math base** — the deepest form of B-1
 The only non-algebra things left are the **runtimes** (drivers/engines that *execute*
 the algebra) and explicit **asymmetric exceptions** (host adapters) — neither of which
 is a registry primitive.
+
+### Register the Tick *algebra*; adapterize the sources (Amara) — tick-source is the *generator* (Prism)
+
+Two ferries sharpened the verdict (cross-AI triangulation: Otto + Amara + Prism all
+ran the procedure independently and converged on "tick-source folds to the time
+algebra"):
+
+- **Amara:** *"do not register sources when you can register the algebra they emit.
+  Register Tick. Adapterize TickSource."* So the **atom that registers** is the
+  **Tick algebra** — `Tick` / `Delta` / `zero(origin)` / `advance` / `order` /
+  `monotonicity` / `join(max)` / `z⁻¹`. The **sources are adapters**, *not*
+  primitives: `ManualTickSource`, `TimerTickSource`, `CircuitStepSource`,
+  `WebSocketTickSource`, `GitEventTickSource` — wall-clock / scheduler / file-watch /
+  TCP / WS / UI-loop / git-event all *emit* ticks; register the algebra once,
+  adapterize the emitters.
+- **Prism:** tick-source is the **generator** of the time algebra (the unit-tick
+  generates the `(ℕ,+,0)` monoid; `z⁻¹` generates the operator ring) — which is
+  exactly *why* a source adapts rather than registers: it's the generator of an
+  algebra, and the **algebra** is what registers, not its generator-implementations.
+
+### The closed four-bucket taxonomy (Amara's keeper)
+
+Amara's keeper — *"the registry stores atoms and laws; sources, views, and
+transports adapt into those laws"* — closes the sort. Everything audited lands in
+exactly one bucket:
+
+| Bucket | What | Examples |
+|---|---|---|
+| **registers** (the BCL) | atoms + laws = **algebras** | Z-set family · codec algebra · Tick algebra · generic-math base |
+| **adapts** (not registered) | **sources · views · transports** | `TickSource*` (sources) · Rx + event-index=`IndexedZSet`-keyed-by-Tick (views) · the wire under the codec (transports) |
+| **executes** (not registered) | **runtimes** | the DBSP Circuit step-loop |
+| **waives** (flagged, not registered) | named **asymmetric exceptions** | host adapters that can't be cross-language-guaranteed |
+
+Only the first bucket is the registry. The algebra-first procedure is the
+**registry's immune system** (Amara) — it sorts every candidate into these four and
+admits only the algebras.
 
 ## Acceptance (research → process)
 


### PR DESCRIPTION
Folds the Amara + Prism sharpening of the tick-source verdict into B-1006 + the saved rule (follow-up to merged #6607). **Cross-AI triangulation:** Otto + Amara + Prism each ran the algebra-first procedure independently and converged on "tick-source folds to the time algebra."

- **Amara:** *"do not register sources when you can register the algebra they emit. Register Tick. Adapterize TickSource."* → the atom that registers is the **Tick algebra** (`Tick`/`Delta`/`zero`/`advance`/`order`/`monotonicity`/`join`/`z⁻¹`); the **sources** (Manual/Timer/CircuitStep/WebSocket/GitEvent) are **adapters**, not primitives.
- **Prism:** tick-source is the **generator** of the time algebra (unit-tick → `(ℕ,+,0)` monoid; `z⁻¹` → operator ring) — which is *why* a source adapts rather than registers.
- **Amara's keeper → the closed four-bucket sort:** **registers** (atoms+laws = algebras) · **adapts** (sources/views/transports) · **executes** (runtimes) · **waives** (named asymmetric exceptions). Only the first is the registry/BCL; the algebra-first procedure is the registry's *immune system*.

Folded into B-1006 (procedure-run section + tick row) and the auto-loaded rule (new §4: what-registers-vs-what-adapts + the four-bucket table). md+strict 0; index regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
