### PR TITLE
feat(ace): slice 8.2 — package_hash as content identity (signature-excluded composition)

### DIFF
--- a/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.2-package-hash-composition-implementation-plan.md
+++ b/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.2-package-hash-composition-implementation-plan.md
@@ -1,0 +1,436 @@
+# Ace slice 8.2 — package_hash composition (content identity) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `package_hash` a formally-defined, golden-vector-verified **content identity** — `"sha256:" + sha256(canonicalBytes({ manifest − signature, files }))` — extracted into a dedicated trust-core module, composing the two primitives already built (canonical-JSON 8.1 ∘ SHA-256 slice 8), with the signature excluded from the hashed input.
+
+**Architecture:** A new `tools/ace/package-hash.ts` owns `packageHash(pkg)`, hashing the package CONTENT (manifest minus its `signature`, plus `files`) via `canonicalBytes` (the 8.1 seam) + node:crypto SHA-256. Excluding the signature aligns the identity input with `signing.ts`'s `canonicalManifestBytes` (which already strips the sig) and makes the hash stable across re-signing. The local `packageHash` leaves `resolve.ts`; all import sites are swept to the new module. A golden-vector fixture under `tests/cross-verification/package-hash/` anchors the composition with independently-verified expected values.
+
+**Tech Stack:** TypeScript (Bun runtime), `bun test`, `bun --bun tsc --noEmit -p tsconfig.json`, Python `hashlib` (independent expected-value verification). Spec: `docs/agendas/ace-package-manager/2026-06-02-ace-slice8.2-package-hash-composition-design.md` (merged #6602).
+
+---
+
+## Pre-flight context for the implementer (zero repo context — read this)
+
+- **Harness (Otto-343):** the Edit tool is blocked. NEW files → Write tool. EXISTING files → a Python patch-script that asserts each `old` occurs exactly once, replaces, writes `newline="\n"`, asserts zero CR bytes, then `rm`s itself (NEVER commit a `_patch_*.py`). Verify pure-LF: `python -c "print(open('PATH','rb').read().count(b'\r'))"` prints `0`. NEVER grep for `\r`.
+- **Commit trailer (exact):** `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. **Commit with:** `git -c user.email=aaron_bond@yahoo.com commit ...`. Run from repo root. Wrap git network ops in `timeout --kill-after=5s 60s`.
+- **Branch:** `otto-windows/ace-slice8.2-impl-2026-06-02`, already checked out off `origin/main`. Do NOT switch branches; do NOT touch `main`.
+- **Canary:** `git ls-tree HEAD | wc -l` is `67` and must stay `67` (`tools/ace/*` and `tests/cross-verification/package-hash/*` are under existing top-level dirs).
+- **CI reality (important):** `bun test tools/ace/` is NOT run by CI (`gate.yml`'s `build-and-test` runs `dotnet test`; `lint (tsc tools)` only type-checks). So `bun test tools/ace/` is a **controller-enforced local gate** — run it and require green; do not assume CI will catch a TS test regression. The cross-verify fixture (T3) is likewise a local/standalone assert (mirrors sha256/zeta-id) — its `cross-verify.ts` must ASSERT (exit non-zero on mismatch) and be run locally.
+- **Types (`tools/ace/store.ts`):** `AceManifest` already has an optional `signature?: { algo; key_id; sig }` field, so `const { signature, ...rest } = pkg.manifest` destructures cleanly (no cast). `AcePackage = { manifest: AceManifest; files: Record<string, string> }`.
+- **The 8.1 seam (`tools/ace/canonical.ts`):** `canonicalBytes(value: unknown): Uint8Array` (sorted-key `toTagged` → shared `canonicalJson`; throws on non-safe-integer or lone-surrogate). `toTagged` + the shared `canonicalJson` are at `canonical.ts` + `../../src/Core.TypeScript/dynamic-value/json.ts`.
+
+---
+
+## File Structure
+
+- **Create** `tools/ace/package-hash.ts` — `packageHash(pkg)` (signature-excluded content identity).
+- **Create** `tools/ace/package-hash.test.ts` — unit tests (form, determinism, signature-exclusion proof, content-change, throw-inheritance).
+- **Modify** `tools/ace/resolve.ts` — remove the local `packageHash` (and its now-unused `createHash` + `canonicalBytes` imports); import `packageHash` from `./package-hash.ts`; keep the local `canonicalJson` (lockfile) + the untrusted-dep `try/catch`.
+- **Modify** 8 import sites — sweep `packageHash` from `./resolve.ts` → `./package-hash.ts`: `ace.ts`, `lockfile.ts`, `registry-publish.ts`, `ace.test.ts`, `lockfile.test.ts`, `registry-publish.test.ts`, `resolve.test.ts`, `solver.test.ts`, `solver.z3.test.ts`.
+- **Create** `tests/cross-verification/package-hash/vectors.json` + `cross-verify.ts` (+ committed `ts-output.json`).
+
+---
+
+## Task 1: `tools/ace/package-hash.ts` + tests
+
+**Files:**
+
+- Create: `tools/ace/package-hash.ts`
+- Test: `tools/ace/package-hash.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tools/ace/package-hash.test.ts` with the Write tool, EXACTLY:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { packageHash } from "./package-hash.ts";
+import type { AcePackage } from "./store.ts";
+
+const base: AcePackage = {
+  manifest: { format_version: 1, name: "x", version: "1.0.0", content_hash: "sha256:deadbeef" },
+  files: { "a.txt": "a" },
+};
+
+describe("packageHash", () => {
+  test("sha256:<hex> form", () => {
+    expect(packageHash(base)).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  test("deterministic + key-order-independent", () => {
+    const reordered: AcePackage = {
+      manifest: { version: "1.0.0", content_hash: "sha256:deadbeef", name: "x", format_version: 1 },
+      files: { "a.txt": "a" },
+    };
+    expect(packageHash(reordered)).toBe(packageHash(base));
+  });
+
+  test("EXCLUDES signature — adding a signature does not change the hash", () => {
+    const signed: AcePackage = {
+      manifest: { ...base.manifest, signature: { algo: "ed25519", key_id: "ed25519:abcd", sig: "AAAA" } },
+      files: base.files,
+    };
+    expect(packageHash(signed)).toBe(packageHash(base));
+  });
+
+  test("EXCLUDES signature — two different signatures yield the same hash", () => {
+    const sigA: AcePackage = { manifest: { ...base.manifest, signature: { algo: "ed25519", key_id: "ed25519:aaaa", sig: "AAAA" } }, files: base.files };
+    const sigB: AcePackage = { manifest: { ...base.manifest, signature: { algo: "ed25519", key_id: "ed25519:bbbb", sig: "BBBB" } }, files: base.files };
+    expect(packageHash(sigA)).toBe(packageHash(sigB));
+  });
+
+  test("content change DOES change the hash", () => {
+    const diffVersion: AcePackage = { manifest: { ...base.manifest, version: "2.0.0" }, files: base.files };
+    expect(packageHash(diffVersion)).not.toBe(packageHash(base));
+    const diffFiles: AcePackage = { manifest: base.manifest, files: { "a.txt": "b" } };
+    expect(packageHash(diffFiles)).not.toBe(packageHash(base));
+  });
+
+  test("throws (via toTagged) on a non-safe-integer or lone-surrogate field", () => {
+    const floatPkg = { manifest: { ...base.manifest, bogus: 1.5 }, files: base.files } as unknown as AcePackage;
+    expect(() => packageHash(floatPkg)).toThrow();
+    const surrPkg = { manifest: { ...base.manifest, bogus: "\uD800" }, files: base.files } as unknown as AcePackage;
+    expect(() => packageHash(surrPkg)).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+Run: `bun test tools/ace/package-hash.test.ts`
+Expected: FAIL — `Cannot find module "./package-hash.ts"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tools/ace/package-hash.ts` with the Write tool, EXACTLY:
+
+```typescript
+// package-hash.ts -- Ace slice 8.2: package_hash as CONTENT IDENTITY.
+// Composes the two trust-core primitives — canonical-JSON (8.1, via canonicalBytes) and
+// SHA-256 — over the package CONTENT: the manifest MINUS its signature, plus files. The
+// signature is excluded so identity (what the package is) is separate from authenticity
+// (who vouches for it — verified separately by signing.ts). This aligns the identity input
+// with signing.ts's canonicalManifestBytes (which also strips the signature): one "content"
+// notion underlies both signing and identity, and the hash is stable across re-signing.
+// Runtime hasher is node:crypto SHA-256 (native; byte-identical to the slice-8 SHA-256
+// oracle, which exists for cross-language verification, not as the runtime hasher).
+import { createHash } from "node:crypto";
+import { canonicalBytes } from "./canonical.ts";
+import type { AcePackage } from "./store.ts";
+
+/**
+ * Content identity: `sha256:<hex>` of canonicalBytes({ manifest − signature, files }).
+ * The parent's pin / identity for a dependency — two edges sharing a packageHash have
+ * byte-identical CONTENT regardless of signature. Throws (via canonicalBytes / toTagged)
+ * on a non-safe-integer or lone-surrogate field; resolve maps that to invalid-package.
+ */
+export function packageHash(pkg: AcePackage): string {
+  const { signature, ...rest } = pkg.manifest; // exclude signature from the identity
+  void signature;
+  return "sha256:" + createHash("sha256").update(canonicalBytes({ manifest: rest, files: pkg.files })).digest("hex");
+}
+```
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+Run: `bun test tools/ace/package-hash.test.ts`
+Expected: PASS (all 6 cases).
+
+- [ ] **Step 5: Type-check + pure-LF**
+
+Run: `bun --bun tsc --noEmit -p tsconfig.json` → exit 0.
+Run pure-LF (CR==0) on both new files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/ace/package-hash.ts tools/ace/package-hash.test.ts
+git -c user.email=aaron_bond@yahoo.com commit -m "feat(ace): slice 8.2 T1 — package-hash.ts content identity (signature-excluded composition)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+Confirm `git ls-tree HEAD | wc -l` == 67.
+
+---
+
+## Task 2: extract from resolve.ts + sweep 9 import sites + behavior-preservation
+
+**Files:**
+
+- Modify: `tools/ace/resolve.ts` (remove local `packageHash` + now-unused imports; import from `./package-hash.ts`)
+- Modify: `ace.ts`, `lockfile.ts`, `registry-publish.ts`, `ace.test.ts`, `lockfile.test.ts`, `registry-publish.test.ts`, `resolve.test.ts`, `solver.test.ts`, `solver.z3.test.ts`
+
+- [ ] **Step 1: Edit `resolve.ts` via patch-script**
+
+Three replacements (assert each occurs exactly once):
+
+Replacement 1 — drop the two imports now used only by the removed `packageHash`, add the new import. OLD:
+
+```typescript
+import { createHash } from "node:crypto";
+import { canonicalBytes } from "./canonical.ts";
+import type { RevocationMap } from "./signing.ts";
+```
+
+NEW:
+
+```typescript
+import type { RevocationMap } from "./signing.ts";
+import { packageHash } from "./package-hash.ts";
+```
+
+Replacement 2 — remove the local `packageHash` definition. OLD:
+
+```typescript
+/** sha256 of the canonical whole package ({manifest incl. signature, files}) via the shared
+ *  canonical byte form (§8.1). The parent's pin / identity for a dependency. Two edges sharing
+ *  a packageHash are byte-identical. */
+export function packageHash(pkg: AcePackage): string {
+  return "sha256:" + createHash("sha256").update(canonicalBytes({ manifest: pkg.manifest, files: pkg.files })).digest("hex");
+}
+
+```
+
+NEW (empty string — remove it, including the trailing blank line):
+
+```text
+```
+
+(Note: `resolve.ts`'s local `canonicalJson` + its JSDoc — the one retained in 8.1 for lockfile serialization — stays untouched. Only the `packageHash` block and the two imports change.)
+
+- [ ] **Step 2: Sweep the 9 import sites via patch-script**
+
+For each file, replace the `./resolve.ts` import of `packageHash` with a `./package-hash.ts` import (splitting the import line where other symbols are also imported from `./resolve.ts`). Exact per-file edits:
+
+`ace.ts` — OLD `import { resolve, packageHash } from "./resolve.ts";` → NEW two lines:
+
+```typescript
+import { resolve } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
+```
+
+`lockfile.ts` — OLD `import { canonicalJson, packageHash } from "./resolve.ts";` → NEW:
+
+```typescript
+import { canonicalJson } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
+```
+
+`registry-publish.ts` — OLD `import { packageHash } from "./resolve.ts";` → NEW `import { packageHash } from "./package-hash.ts";`
+
+`ace.test.ts` — OLD `import { packageHash } from "./resolve.ts";` → NEW `import { packageHash } from "./package-hash.ts";`
+
+`lockfile.test.ts` — OLD `import { packageHash } from "./resolve.ts";` → NEW `import { packageHash } from "./package-hash.ts";`
+
+`registry-publish.test.ts` — OLD `import { packageHash } from "./resolve.ts";` → NEW `import { packageHash } from "./package-hash.ts";`
+
+`resolve.test.ts` — OLD `import { packageHash, resolve, type FetchPackage } from "./resolve.ts";` → NEW:
+
+```typescript
+import { resolve, type FetchPackage } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
+```
+
+`solver.test.ts` — OLD `import { packageHash, type FetchPackage } from "./resolve.ts";` → NEW:
+
+```typescript
+import { type FetchPackage } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
+```
+
+`solver.z3.test.ts` — OLD `import { packageHash, type FetchPackage } from "./resolve.ts";` → NEW:
+
+```typescript
+import { type FetchPackage } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
+```
+
+After the sweep, confirm zero remaining `packageHash` imports from `./resolve.ts`: run `grep -rn 'packageHash.*resolve' tools/ace/` and expect no import hits (only resolve.ts's internal call sites + comments, which now resolve the imported symbol).
+
+- [ ] **Step 3: Type-check**
+
+Run: `bun --bun tsc --noEmit -p tsconfig.json` → exit 0. This catches any unused-import (e.g. if `createHash`/`canonicalBytes` were left dangling in resolve.ts, or a `type FetchPackage`-only import that needs `import type`), and confirms the cross-module wiring resolves. Fix any error (e.g. if tsc flags `import { type FetchPackage }` prefer `import type { FetchPackage }`).
+
+- [ ] **Step 4: Behavior-preservation gate — full Ace suite (local; CI does NOT run this)**
+
+Run: `bun test tools/ace/` → ALL green. `package_hash` values change (signature now excluded) but every assertion is a round-trip / determinism / self-consistent recompute — none pins a literal hash (re-confirm; none expected). If a behavioral assertion fails (round-trip / pin), STOP and diagnose — real regression. If a literal pin surfaces, update it (intentional one-time change) + note in commit.
+
+- [ ] **Step 5: Pure-LF + commit**
+
+Pure-LF (CR==0) on every modified file. Then:
+
+```bash
+git add tools/ace/resolve.ts tools/ace/ace.ts tools/ace/lockfile.ts tools/ace/registry-publish.ts tools/ace/ace.test.ts tools/ace/lockfile.test.ts tools/ace/registry-publish.test.ts tools/ace/resolve.test.ts tools/ace/solver.test.ts tools/ace/solver.z3.test.ts
+git -c user.email=aaron_bond@yahoo.com commit -m "feat(ace): slice 8.2 T2 — extract packageHash to package-hash.ts, sweep 9 import sites
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+Confirm `git ls-tree HEAD | wc -l` == 67.
+
+---
+
+## Task 3: golden-vector fixture (independently verified)
+
+**Files:**
+
+- Create: `tests/cross-verification/package-hash/vectors.json`
+- Create: `tests/cross-verification/package-hash/cross-verify.ts`
+- Create (committed output): `tests/cross-verification/package-hash/ts-output.json`
+
+- [ ] **Step 1: Write `cross-verify.ts`**
+
+Create `tests/cross-verification/package-hash/cross-verify.ts` with the Write tool, EXACTLY:
+
+```typescript
+// Ace package_hash content-identity cross-verification oracle (TS).
+// Reads vectors.json, computes packageHash + the intermediate canonical-JSON for each
+// fixture package, writes ts-output.json, and ASSERTS each against the fixture's
+// expected_canonical_json + expected_package_hash (exit non-zero on any mismatch —
+// assert-don't-skip). The expected values are the cross-language contract: a future
+// F#/C#/Rust Ace must reproduce them. Run from this directory: `bun cross-verify.ts`.
+import { packageHash } from "../../../tools/ace/package-hash.ts";
+import { canonicalBytes } from "../../../tools/ace/canonical.ts";
+import type { AcePackage } from "../../../tools/ace/store.ts";
+
+interface Vec {
+  id: string;
+  package: AcePackage;
+  expected_canonical_json: string;
+  expected_package_hash: string;
+}
+
+const dec = new TextDecoder();
+const vectors = (JSON.parse(await Bun.file("vectors.json").text()) as { vectors: Vec[] }).vectors;
+
+const results: Record<string, { canonical_json: string; package_hash: string }> = {};
+let mismatches = 0;
+
+for (const v of vectors) {
+  const { signature, ...rest } = v.package.manifest;
+  void signature;
+  const canonical = dec.decode(canonicalBytes({ manifest: rest, files: v.package.files }));
+  const hash = packageHash(v.package);
+  results[v.id] = { canonical_json: canonical, package_hash: hash };
+  if (canonical !== v.expected_canonical_json) {
+    mismatches++;
+    console.error(`canonical MISMATCH ${v.id}:\n  got=${canonical}\n  exp=${v.expected_canonical_json}`);
+  }
+  if (hash !== v.expected_package_hash) {
+    mismatches++;
+    console.error(`package_hash MISMATCH ${v.id}: got=${hash} exp=${v.expected_package_hash}`);
+  }
+}
+
+await Bun.write("ts-output.json", JSON.stringify(results, null, 2) + "\n");
+console.log(`package_hash cross-verify: ${vectors.length} vectors, ${mismatches} mismatches.`);
+if (mismatches > 0) process.exit(1);
+```
+
+- [ ] **Step 2: Write `vectors.json` with the fixtures (expected fields blank for now)**
+
+Create `tests/cross-verification/package-hash/vectors.json` with these four fixture packages. Leave `expected_canonical_json` and `expected_package_hash` as empty strings for now — Step 3 fills them from the oracle, Step 4 independently verifies.
+
+```json
+{
+  "description": "Ace package_hash content-identity vectors (TS now; F#/C#/Rust must match). Each: package -> canonical-JSON of {manifest-minus-signature, files} + sha256: package_hash.",
+  "vectors": [
+    {
+      "id": "minimal",
+      "package": { "manifest": { "format_version": 1, "name": "x", "version": "1.0.0", "content_hash": "sha256:deadbeef" }, "files": { "a.txt": "a" } },
+      "expected_canonical_json": "",
+      "expected_package_hash": ""
+    },
+    {
+      "id": "signature-excluded",
+      "package": { "manifest": { "format_version": 1, "name": "x", "version": "1.0.0", "content_hash": "sha256:deadbeef", "signature": { "algo": "ed25519", "key_id": "ed25519:abcd", "sig": "AAAA" } }, "files": { "a.txt": "a" } },
+      "expected_canonical_json": "",
+      "expected_package_hash": ""
+    },
+    {
+      "id": "with-dependencies",
+      "package": { "manifest": { "format_version": 1, "name": "root", "version": "2.1.0", "content_hash": "sha256:cafe", "dependencies": [ { "kind": "registry", "name": "dep", "version": "^1.0.0" } ] }, "files": { "r.txt": "r" } },
+      "expected_canonical_json": "",
+      "expected_package_hash": ""
+    },
+    {
+      "id": "key-order-independent",
+      "package": { "manifest": { "version": "1.0.0", "content_hash": "sha256:deadbeef", "name": "x", "format_version": 1 }, "files": { "a.txt": "a" } },
+      "expected_canonical_json": "",
+      "expected_package_hash": ""
+    }
+  ]
+}
+```
+
+Note: `minimal` and `signature-excluded` MUST end up with identical `expected_canonical_json` + `expected_package_hash` (the signature is excluded). `minimal` and `key-order-independent` MUST also be identical (sorted keys). These equalities are the fixture's built-in proof.
+
+- [ ] **Step 3: Populate expected values from the oracle**
+
+From the fixture dir, run a one-off to print the computed canonical-JSON + hash per vector, then fill them into `vectors.json` via a patch-script:
+
+```bash
+cd tests/cross-verification/package-hash
+bun -e 'import { packageHash } from "../../../tools/ace/package-hash.ts"; import { canonicalBytes } from "../../../tools/ace/canonical.ts"; const dec=new TextDecoder(); const vs=JSON.parse(await Bun.file("vectors.json").text()).vectors; for (const v of vs){ const {signature,...rest}=v.package.manifest; void signature; console.log(v.id); console.log(JSON.stringify(dec.decode(canonicalBytes({manifest:rest,files:v.package.files})))); console.log(packageHash(v.package)); }'
+cd ../../..
+```
+
+Fill each vector's `expected_canonical_json` (the printed JSON-string, unescaped into the JSON file) and `expected_package_hash`. Confirm `minimal` == `signature-excluded` == `key-order-independent` for both fields.
+
+- [ ] **Step 4: Independently verify the expected hashes (assert-don't-skip — NOT TS-vs-TS)**
+
+For each vector, confirm `expected_package_hash` is genuinely `sha256:` of the UTF-8 bytes of `expected_canonical_json`, using Python (independent of the TS oracle):
+
+```bash
+python -c "
+import json, hashlib
+d = json.load(open('tests/cross-verification/package-hash/vectors.json', encoding='utf-8'))
+ok = True
+for v in d['vectors']:
+    cj = v['expected_canonical_json']
+    exp = v['expected_package_hash']
+    got = 'sha256:' + hashlib.sha256(cj.encode('utf-8')).hexdigest()
+    mark = 'OK' if got == exp else 'MISMATCH'
+    if got != exp: ok = False
+    print(v['id'], mark)
+print('ALL-OK' if ok else 'FAIL')
+"
+```
+
+Expected: every vector `OK` + `ALL-OK`. If any MISMATCH, the expected_package_hash was wrong — fix it to the Python-computed value (Python is the independent source of truth for the SHA-256). This is the assert-don't-skip step: the fixture is verified by a second, independent SHA-256 implementation, not just the TS oracle.
+
+- [ ] **Step 5: Run the oracle (assert green) + commit**
+
+```bash
+cd tests/cross-verification/package-hash && bun cross-verify.ts && cd ../../..
+```
+
+Expected: `... 0 mismatches.` exit 0, and `ts-output.json` written. Pure-LF (CR==0) on all three files. Then:
+
+```bash
+git add tests/cross-verification/package-hash/vectors.json tests/cross-verification/package-hash/cross-verify.ts tests/cross-verification/package-hash/ts-output.json
+git -c user.email=aaron_bond@yahoo.com commit -m "test(ace): slice 8.2 T3 — package_hash golden-vector fixture (independently verified)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+Confirm `git ls-tree HEAD | wc -l` == 67.
+
+---
+
+## Self-review (controller, before dispatch)
+
+- **Spec coverage:** Decision 1 (exclude signature) → T1 `{ signature, ...rest }` + the two signature-exclusion tests + the `signature-excluded` fixture. Decision 2 (no security loss / stable) → exclusion tests. Decision 3 (behavior change) → T2 Step 4. Decision 4 (extract module) → T1 + T2. Decision 5 (node:crypto) → T1. Decision 6 (TS + golden vectors, parity spec'd) → T3 (expected values are the contract; independently verified). ✓
+- **Placeholders:** none — full code in every step; the only conditional ("if a literal pin surfaces") is backed by the 8.1 sweep showing none. ✓
+- **Type consistency:** `packageHash(pkg: AcePackage): string` identical across T1/T2/T3; `{ signature, ...rest }` mirrors `signing.ts`; `AcePackage`/`AceManifest` per store.ts. ✓
+- **Scope:** CLI untrusted-root hardening + wiring `bun test tools/ace/` into CI are explicitly deferred follow-ups, not in this slice. ✓
+
+## Model selection (controller)
+
+- **T1 — opus** (security-adjacent identity primitive + first-time contract).
+- **T2 — opus** (10-file extract/sweep with the behavior-preservation gate + resolve.ts import-cleanup; integration judgment).
+- **T3 — opus** (fixture authoring + the independent-verification discipline; getting the canonical-JSON expected strings exactly right is fiddly).
+
+Two-stage review (spec compliance → code quality) after each task. Final holistic review over `git diff origin/main..HEAD -- tools/ace/ tests/cross-verification/package-hash/`. Then the controller opens the impl PR + runs the PR-gate loop.

--- a/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.2-package-hash-composition-implementation-plan.md
+++ b/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.2-package-hash-composition-implementation-plan.md
@@ -13,7 +13,7 @@
 ## Pre-flight context for the implementer (zero repo context — read this)
 
 - **Harness (Otto-343):** the Edit tool is blocked. NEW files → Write tool. EXISTING files → a Python patch-script that asserts each `old` occurs exactly once, replaces, writes `newline="\n"`, asserts zero CR bytes, then `rm`s itself (NEVER commit a `_patch_*.py`). Verify pure-LF: `python -c "print(open('PATH','rb').read().count(b'\r'))"` prints `0`. NEVER grep for `\r`.
-- **Commit trailer (exact):** `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. **Commit with:** `git -c user.email=aaron_bond@yahoo.com commit ...`. Run from repo root. Wrap git network ops in `timeout --kill-after=5s 60s`.
+- **Commit trailer (exact):** `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. **Commit with:** `git -c user.email=<zeta-commit-email> commit ...`. Run from repo root. Wrap git network ops in `timeout --kill-after=5s 60s`.
 - **Branch:** `otto-windows/ace-slice8.2-impl-2026-06-02`, already checked out off `origin/main`. Do NOT switch branches; do NOT touch `main`.
 - **Canary:** `git ls-tree HEAD | wc -l` is `67` and must stay `67` (`tools/ace/*` and `tests/cross-verification/package-hash/*` are under existing top-level dirs).
 - **CI reality (important):** `bun test tools/ace/` is NOT run by CI (`gate.yml`'s `build-and-test` runs `dotnet test`; `lint (tsc tools)` only type-checks). So `bun test tools/ace/` is a **controller-enforced local gate** — run it and require green; do not assume CI will catch a TS test regression. The cross-verify fixture (T3) is likewise a local/standalone assert (mirrors sha256/zeta-id) — its `cross-verify.ts` must ASSERT (exit non-zero on mismatch) and be run locally.
@@ -146,7 +146,7 @@ Run pure-LF (CR==0) on both new files.
 
 ```bash
 git add tools/ace/package-hash.ts tools/ace/package-hash.test.ts
-git -c user.email=aaron_bond@yahoo.com commit -m "feat(ace): slice 8.2 T1 — package-hash.ts content identity (signature-excluded composition)
+git -c user.email=<zeta-commit-email> commit -m "feat(ace): slice 8.2 T1 — package-hash.ts content identity (signature-excluded composition)
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```
@@ -263,7 +263,7 @@ Pure-LF (CR==0) on every modified file. Then:
 
 ```bash
 git add tools/ace/resolve.ts tools/ace/ace.ts tools/ace/lockfile.ts tools/ace/registry-publish.ts tools/ace/ace.test.ts tools/ace/lockfile.test.ts tools/ace/registry-publish.test.ts tools/ace/resolve.test.ts tools/ace/solver.test.ts tools/ace/solver.z3.test.ts
-git -c user.email=aaron_bond@yahoo.com commit -m "feat(ace): slice 8.2 T2 — extract packageHash to package-hash.ts, sweep 9 import sites
+git -c user.email=<zeta-commit-email> commit -m "feat(ace): slice 8.2 T2 — extract packageHash to package-hash.ts, sweep 9 import sites
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```
@@ -411,7 +411,7 @@ Expected: `... 0 mismatches.` exit 0, and `ts-output.json` written. Pure-LF (CR=
 
 ```bash
 git add tests/cross-verification/package-hash/vectors.json tests/cross-verification/package-hash/cross-verify.ts tests/cross-verification/package-hash/ts-output.json
-git -c user.email=aaron_bond@yahoo.com commit -m "test(ace): slice 8.2 T3 — package_hash golden-vector fixture (independently verified)
+git -c user.email=<zeta-commit-email> commit -m "test(ace): slice 8.2 T3 — package_hash golden-vector fixture (independently verified)
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```

--- a/tests/cross-verification/package-hash/cross-verify.ts
+++ b/tests/cross-verification/package-hash/cross-verify.ts
@@ -1,0 +1,42 @@
+// Ace package_hash content-identity cross-verification oracle (TS).
+// Reads vectors.json, computes packageHash + the intermediate canonical-JSON for each
+// fixture package, writes ts-output.json, and ASSERTS each against the fixture's
+// expected_canonical_json + expected_package_hash (exit non-zero on any mismatch —
+// assert-don't-skip). The expected values are the cross-language contract: a future
+// F#/C#/Rust Ace must reproduce them. Run from this directory: `bun cross-verify.ts`.
+import { packageHash } from "../../../tools/ace/package-hash.ts";
+import { canonicalBytes } from "../../../tools/ace/canonical.ts";
+import type { AcePackage } from "../../../tools/ace/store.ts";
+
+interface Vec {
+  id: string;
+  package: AcePackage;
+  expected_canonical_json: string;
+  expected_package_hash: string;
+}
+
+const dec = new TextDecoder();
+const vectors = (JSON.parse(await Bun.file("vectors.json").text()) as { vectors: Vec[] }).vectors;
+
+const results: Record<string, { canonical_json: string; package_hash: string }> = {};
+let mismatches = 0;
+
+for (const v of vectors) {
+  const { signature, ...rest } = v.package.manifest;
+  void signature;
+  const canonical = dec.decode(canonicalBytes({ manifest: rest, files: v.package.files }));
+  const hash = packageHash(v.package);
+  results[v.id] = { canonical_json: canonical, package_hash: hash };
+  if (canonical !== v.expected_canonical_json) {
+    mismatches++;
+    console.error(`canonical MISMATCH ${v.id}:\n  got=${canonical}\n  exp=${v.expected_canonical_json}`);
+  }
+  if (hash !== v.expected_package_hash) {
+    mismatches++;
+    console.error(`package_hash MISMATCH ${v.id}: got=${hash} exp=${v.expected_package_hash}`);
+  }
+}
+
+await Bun.write("ts-output.json", JSON.stringify(results, null, 2) + "\n");
+console.log(`package_hash cross-verify: ${vectors.length} vectors, ${mismatches} mismatches.`);
+if (mismatches > 0) process.exit(1);

--- a/tests/cross-verification/package-hash/ts-output.json
+++ b/tests/cross-verification/package-hash/ts-output.json
@@ -1,0 +1,18 @@
+{
+  "minimal": {
+    "canonical_json": "{\"files\":{\"a.txt\":\"a\"},\"manifest\":{\"content_hash\":\"sha256:deadbeef\",\"format_version\":1,\"name\":\"x\",\"version\":\"1.0.0\"}}",
+    "package_hash": "sha256:52d5eea3ab33c6a4aa9665c57ea555325b68196b7b6023aea4c4b57e72a278a8"
+  },
+  "signature-excluded": {
+    "canonical_json": "{\"files\":{\"a.txt\":\"a\"},\"manifest\":{\"content_hash\":\"sha256:deadbeef\",\"format_version\":1,\"name\":\"x\",\"version\":\"1.0.0\"}}",
+    "package_hash": "sha256:52d5eea3ab33c6a4aa9665c57ea555325b68196b7b6023aea4c4b57e72a278a8"
+  },
+  "with-dependencies": {
+    "canonical_json": "{\"files\":{\"r.txt\":\"r\"},\"manifest\":{\"content_hash\":\"sha256:cafe\",\"dependencies\":[{\"kind\":\"registry\",\"name\":\"dep\",\"version\":\"^1.0.0\"}],\"format_version\":1,\"name\":\"root\",\"version\":\"2.1.0\"}}",
+    "package_hash": "sha256:ad0e910bc6e0cde4d4f49a0a75b6afec500e30d1ca431841957ac4c6617abd29"
+  },
+  "key-order-independent": {
+    "canonical_json": "{\"files\":{\"a.txt\":\"a\"},\"manifest\":{\"content_hash\":\"sha256:deadbeef\",\"format_version\":1,\"name\":\"x\",\"version\":\"1.0.0\"}}",
+    "package_hash": "sha256:52d5eea3ab33c6a4aa9665c57ea555325b68196b7b6023aea4c4b57e72a278a8"
+  }
+}

--- a/tests/cross-verification/package-hash/vectors.json
+++ b/tests/cross-verification/package-hash/vectors.json
@@ -1,0 +1,81 @@
+{
+  "description": "Ace package_hash content-identity vectors (TS now; F#/C#/Rust must match). Each: package -> canonical-JSON of {manifest-minus-signature, files} + sha256: package_hash.",
+  "vectors": [
+    {
+      "id": "minimal",
+      "package": {
+        "manifest": {
+          "format_version": 1,
+          "name": "x",
+          "version": "1.0.0",
+          "content_hash": "sha256:deadbeef"
+        },
+        "files": {
+          "a.txt": "a"
+        }
+      },
+      "expected_canonical_json": "{\"files\":{\"a.txt\":\"a\"},\"manifest\":{\"content_hash\":\"sha256:deadbeef\",\"format_version\":1,\"name\":\"x\",\"version\":\"1.0.0\"}}",
+      "expected_package_hash": "sha256:52d5eea3ab33c6a4aa9665c57ea555325b68196b7b6023aea4c4b57e72a278a8"
+    },
+    {
+      "id": "signature-excluded",
+      "package": {
+        "manifest": {
+          "format_version": 1,
+          "name": "x",
+          "version": "1.0.0",
+          "content_hash": "sha256:deadbeef",
+          "signature": {
+            "algo": "ed25519",
+            "key_id": "ed25519:abcd",
+            "sig": "AAAA"
+          }
+        },
+        "files": {
+          "a.txt": "a"
+        }
+      },
+      "expected_canonical_json": "{\"files\":{\"a.txt\":\"a\"},\"manifest\":{\"content_hash\":\"sha256:deadbeef\",\"format_version\":1,\"name\":\"x\",\"version\":\"1.0.0\"}}",
+      "expected_package_hash": "sha256:52d5eea3ab33c6a4aa9665c57ea555325b68196b7b6023aea4c4b57e72a278a8"
+    },
+    {
+      "id": "with-dependencies",
+      "package": {
+        "manifest": {
+          "format_version": 1,
+          "name": "root",
+          "version": "2.1.0",
+          "content_hash": "sha256:cafe",
+          "dependencies": [
+            {
+              "kind": "registry",
+              "name": "dep",
+              "version": "^1.0.0"
+            }
+          ]
+        },
+        "files": {
+          "r.txt": "r"
+        }
+      },
+      "expected_canonical_json": "{\"files\":{\"r.txt\":\"r\"},\"manifest\":{\"content_hash\":\"sha256:cafe\",\"dependencies\":[{\"kind\":\"registry\",\"name\":\"dep\",\"version\":\"^1.0.0\"}],\"format_version\":1,\"name\":\"root\",\"version\":\"2.1.0\"}}",
+      "expected_package_hash": "sha256:ad0e910bc6e0cde4d4f49a0a75b6afec500e30d1ca431841957ac4c6617abd29"
+    },
+    {
+      "id": "key-order-independent",
+      "package": {
+        "manifest": {
+          "version": "1.0.0",
+          "content_hash": "sha256:deadbeef",
+          "name": "x",
+          "format_version": 1
+        },
+        "files": {
+          "a.txt": "a"
+        }
+      },
+      "expected_canonical_json": "{\"files\":{\"a.txt\":\"a\"},\"manifest\":{\"content_hash\":\"sha256:deadbeef\",\"format_version\":1,\"name\":\"x\",\"version\":\"1.0.0\"}}",
+      "expected_package_hash": "sha256:52d5eea3ab33c6a4aa9665c57ea555325b68196b7b6023aea4c4b57e72a278a8"
+    }
+  ]
+}

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -8,7 +8,7 @@ import { listInstalled, contentHash, listTrustedKeys, loadRegistry } from "./sto
 import { readRegistriesConfig } from "./store.ts";
 import { generateKeypair, signManifest } from "./signing.ts";
 import { generateKeypair as gkpA, signIndex as sidxA } from "./signing.ts";
-import { packageHash } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
 import { parseLockfile } from "./lockfile.ts";
 import { parseIndex } from "./registry-remote.ts";
 
@@ -937,9 +937,13 @@ describe("install --frozen (slice 5.3)", () => {
     // check PASSES and execution reaches the shape guard — the exact line that throws unguarded.
     // Mirrors the untrusted-signature/atomicity tests: build the lock directly to reach a gate.
     const dir = mkdtempSync(join(tmpdir(), "ace-frozen-malformed-"));
-    const malformed = {}; // valid JSON, no manifest/files — packageHash() runs, np.manifest.content_hash throws
+    const malformed = {}; // valid JSON, no manifest/files — hits PASS-1 shape guard before packageHash runs
     const aPath = join(dir, "A.json"); writeFileSync(aPath, JSON.stringify(malformed));
-    const aHash = packageHash(malformed as any); // pin == the malformed payload's hash → pin check passes
+    // Any pin value works: the PASS-1 shape guard refuses the malformed node BEFORE the pin check,
+    // so the value is never compared. (packageHash now excludes the signature and throws on a
+    // manifest-less payload, so it can no longer be called on `malformed` to derive the pin —
+    // a placeholder hash exercises the same guard.) slice 8.2.
+    const aHash = "sha256:" + "0".repeat(64);
     const root = { manifest: { format_version:1, name:"root", version:"1.0.0", content_hash: h({ "r.txt":"r" }), dependencies:[{ kind:"inline" as const, name:"A", version:"1.0.0", url: aPath, package_hash: aHash }] }, files: { "r.txt":"r" } };
     const rootPath = join(dir, "root.json"); writeFileSync(rootPath, JSON.stringify(root));
     const lock = {

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -932,10 +932,9 @@ describe("install --frozen (slice 5.3)", () => {
   test("--frozen with a malformed (JSON-valid but not a well-formed package) locked node refuses cleanly (no throw)", async () => {
     // The fetched node bytes + lockfile are untrusted. A payload that parses as JSON but is not a
     // well-formed package (no manifest/files) must hit the PASS-1 shape guard and refuse (exit 1)
-    // rather than THROW (np.manifest.content_hash on an undefined manifest). To EXERCISE the guard
-    // (not an earlier check), the lock must pin the MALFORMED payload's package_hash so the pin
-    // check PASSES and execution reaches the shape guard — the exact line that throws unguarded.
-    // Mirrors the untrusted-signature/atomicity tests: build the lock directly to reach a gate.
+    // rather than THROW. The shape guard runs BEFORE the pin check, so the malformed node is
+    // refused at the guard regardless of the lock's pin value (a placeholder pin is used below).
+    // Mirrors the untrusted-signature/atomicity tests: build the lock directly to reach the gate.
     const dir = mkdtempSync(join(tmpdir(), "ace-frozen-malformed-"));
     const malformed = {}; // valid JSON, no manifest/files — hits PASS-1 shape guard before packageHash runs
     const aPath = join(dir, "A.json"); writeFileSync(aPath, JSON.stringify(malformed));

--- a/tools/ace/ace.ts
+++ b/tools/ace/ace.ts
@@ -27,7 +27,8 @@ import {
 import { generateKeypair, signManifest, verifySignature, keyId, publicKeyInfoFromPrivatePem, verifyIndexSignature, signIndex } from "./signing";
 import type { IndexSignableContent, RevocationMap } from "./signing";
 import { applyRevoke, applyQuarantine, applyUnquarantine } from "./registry-revoke.ts";
-import { resolve, packageHash } from "./resolve.ts";
+import { resolve } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
 import { buildLockfile, serializeLockfile, parseLockfile, verifyRootMatchesLock, lockfilesEqual, buildLeafLockfile } from "./lockfile.ts";
 import { solve } from "./solver.ts";
 

--- a/tools/ace/lockfile.test.ts
+++ b/tools/ace/lockfile.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { buildLockfile } from "./lockfile.ts";
-import { packageHash } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
 import { contentHash } from "./store.ts";
 import type { AcePackage, AceDependency, RegistryEntry, Registry } from "./store.ts";
 

--- a/tools/ace/lockfile.ts
+++ b/tools/ace/lockfile.ts
@@ -1,4 +1,5 @@
-import { canonicalJson, packageHash } from "./resolve.ts";
+import { canonicalJson } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
 import type { AcePackage, Registry } from "./store.ts";
 
 export type LockNode = { name: string; version: string; url: string; package_hash: string };

--- a/tools/ace/package-hash.test.ts
+++ b/tools/ace/package-hash.test.ts
@@ -41,6 +41,15 @@ describe("packageHash", () => {
     expect(packageHash(diffFiles)).not.toBe(packageHash(base));
   });
 
+  test("dependencies are part of the identity", () => {
+    const withDeps: AcePackage = {
+      manifest: { ...base.manifest, dependencies: [{ kind: "registry" as const, name: "dep", version: "^1.0.0" }] },
+      files: base.files,
+    };
+    expect(packageHash(withDeps)).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(packageHash(withDeps)).not.toBe(packageHash(base));
+  });
+
   test("throws (via toTagged) on a non-safe-integer or lone-surrogate field", () => {
     const floatPkg = { manifest: { ...base.manifest, bogus: 1.5 }, files: base.files } as unknown as AcePackage;
     expect(() => packageHash(floatPkg)).toThrow();

--- a/tools/ace/package-hash.test.ts
+++ b/tools/ace/package-hash.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { packageHash } from "./package-hash.ts";
+import type { AcePackage } from "./store.ts";
+
+const base: AcePackage = {
+  manifest: { format_version: 1, name: "x", version: "1.0.0", content_hash: "sha256:deadbeef" },
+  files: { "a.txt": "a" },
+};
+
+describe("packageHash", () => {
+  test("sha256:<hex> form", () => {
+    expect(packageHash(base)).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  test("deterministic + key-order-independent", () => {
+    const reordered: AcePackage = {
+      manifest: { version: "1.0.0", content_hash: "sha256:deadbeef", name: "x", format_version: 1 },
+      files: { "a.txt": "a" },
+    };
+    expect(packageHash(reordered)).toBe(packageHash(base));
+  });
+
+  test("EXCLUDES signature — adding a signature does not change the hash", () => {
+    const signed: AcePackage = {
+      manifest: { ...base.manifest, signature: { algo: "ed25519", key_id: "ed25519:abcd", sig: "AAAA" } },
+      files: base.files,
+    };
+    expect(packageHash(signed)).toBe(packageHash(base));
+  });
+
+  test("EXCLUDES signature — two different signatures yield the same hash", () => {
+    const sigA: AcePackage = { manifest: { ...base.manifest, signature: { algo: "ed25519", key_id: "ed25519:aaaa", sig: "AAAA" } }, files: base.files };
+    const sigB: AcePackage = { manifest: { ...base.manifest, signature: { algo: "ed25519", key_id: "ed25519:bbbb", sig: "BBBB" } }, files: base.files };
+    expect(packageHash(sigA)).toBe(packageHash(sigB));
+  });
+
+  test("content change DOES change the hash", () => {
+    const diffVersion: AcePackage = { manifest: { ...base.manifest, version: "2.0.0" }, files: base.files };
+    expect(packageHash(diffVersion)).not.toBe(packageHash(base));
+    const diffFiles: AcePackage = { manifest: base.manifest, files: { "a.txt": "b" } };
+    expect(packageHash(diffFiles)).not.toBe(packageHash(base));
+  });
+
+  test("throws (via toTagged) on a non-safe-integer or lone-surrogate field", () => {
+    const floatPkg = { manifest: { ...base.manifest, bogus: 1.5 }, files: base.files } as unknown as AcePackage;
+    expect(() => packageHash(floatPkg)).toThrow();
+    const surrPkg = { manifest: { ...base.manifest, bogus: "\uD800" }, files: base.files } as unknown as AcePackage;
+    expect(() => packageHash(surrPkg)).toThrow();
+  });
+});

--- a/tools/ace/package-hash.ts
+++ b/tools/ace/package-hash.ts
@@ -1,0 +1,24 @@
+// package-hash.ts -- Ace slice 8.2: package_hash as CONTENT IDENTITY.
+// Composes the two trust-core primitives — canonical-JSON (8.1, via canonicalBytes) and
+// SHA-256 — over the package CONTENT: the manifest MINUS its signature, plus files. The
+// signature is excluded so identity (what the package is) is separate from authenticity
+// (who vouches for it — verified separately by signing.ts). This aligns the identity input
+// with signing.ts's canonicalManifestBytes (which also strips the signature): one "content"
+// notion underlies both signing and identity, and the hash is stable across re-signing.
+// Runtime hasher is node:crypto SHA-256 (native; byte-identical to the slice-8 SHA-256
+// oracle, which exists for cross-language verification, not as the runtime hasher).
+import { createHash } from "node:crypto";
+import { canonicalBytes } from "./canonical.ts";
+import type { AcePackage } from "./store.ts";
+
+/**
+ * Content identity: `sha256:<hex>` of canonicalBytes({ manifest − signature, files }).
+ * The parent's pin / identity for a dependency — two edges sharing a packageHash have
+ * byte-identical CONTENT regardless of signature. Throws (via canonicalBytes / toTagged)
+ * on a non-safe-integer or lone-surrogate field; resolve maps that to invalid-package.
+ */
+export function packageHash(pkg: AcePackage): string {
+  const { signature, ...rest } = pkg.manifest; // exclude signature from the identity
+  void signature;
+  return "sha256:" + createHash("sha256").update(canonicalBytes({ manifest: rest, files: pkg.files })).digest("hex");
+}

--- a/tools/ace/package-hash.ts
+++ b/tools/ace/package-hash.ts
@@ -2,9 +2,10 @@
 // Composes the two trust-core primitives — canonical-JSON (8.1, via canonicalBytes) and
 // SHA-256 — over the package CONTENT: the manifest MINUS its signature, plus files. The
 // signature is excluded so identity (what the package is) is separate from authenticity
-// (who vouches for it — verified separately by signing.ts). This aligns the identity input
-// with signing.ts's canonicalManifestBytes (which also strips the signature): one "content"
-// notion underlies both signing and identity, and the hash is stable across re-signing.
+// (who vouches for it — verified separately by signing.ts). Same EXCLUSION as signing.ts's
+// canonicalManifestBytes (which also strips the signature) but a different SCOPE: signing
+// covers the manifest alone; package identity covers { manifest, files }. The hash is stable
+// across re-signing.
 // Runtime hasher is node:crypto SHA-256 (native; byte-identical to the slice-8 SHA-256
 // oracle, which exists for cross-language verification, not as the runtime hasher).
 import { createHash } from "node:crypto";

--- a/tools/ace/registry-publish.test.ts
+++ b/tools/ace/registry-publish.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { joinUrl, nextSequence, buildIndexDoc } from "./registry-publish.ts";
 import { generateKeypair, verifyIndexSignature, publicKeyInfoFromPrivatePem } from "./signing.ts";
 import { parseIndex } from "./registry-remote.ts";
-import { packageHash } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
 import { contentHash } from "./store.ts";
 
 // helper: a minimal well-formed AcePackage with a correct content_hash

--- a/tools/ace/registry-publish.ts
+++ b/tools/ace/registry-publish.ts
@@ -2,7 +2,7 @@
 // Inverts the consumer: build the signed IndexSignableContent a slice-6 consumer accepts.
 // No I/O — the caller (ace.ts) reads the package files + sequence + pem and writes the output.
 import type { AcePackage, RegistryEntry } from "./store.ts";
-import { packageHash } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
 import type { IndexSignableContent, RevocationMap } from "./signing.ts";
 import { signIndex } from "./signing.ts";
 import type { IndexDoc } from "./registry-remote.ts";

--- a/tools/ace/resolve.test.ts
+++ b/tools/ace/resolve.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { packageHash, resolve, type FetchPackage } from "./resolve.ts";
+import { resolve, type FetchPackage } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
 import type { AcePackage, AceDependency } from "./store.ts";
 import { contentHash } from "./store.ts";
 import type { RegistryEntry } from "./store.ts";

--- a/tools/ace/resolve.ts
+++ b/tools/ace/resolve.ts
@@ -1,6 +1,5 @@
-import { createHash } from "node:crypto";
-import { canonicalBytes } from "./canonical.ts";
 import type { RevocationMap } from "./signing.ts";
+import { packageHash } from "./package-hash.ts";
 import { contentHash, type AcePackage, type LoadedTrustEntry, type Registry } from "./store.ts";
 import { verifySignature } from "./signing.ts";
 import { parseRange, satisfies } from "./semver.ts";
@@ -15,13 +14,6 @@ export function canonicalJson(value: unknown): string {
   const obj = value as Record<string, unknown>;
   const keys = Object.keys(obj).sort();
   return "{" + keys.map((k) => JSON.stringify(k) + ":" + canonicalJson(obj[k])).join(",") + "}";
-}
-
-/** sha256 of the canonical whole package ({manifest incl. signature, files}) via the shared
- *  canonical byte form (§8.1). The parent's pin / identity for a dependency. Two edges sharing
- *  a packageHash are byte-identical. */
-export function packageHash(pkg: AcePackage): string {
-  return "sha256:" + createHash("sha256").update(canonicalBytes({ manifest: pkg.manifest, files: pkg.files })).digest("hex");
 }
 
 export type FetchPackage = (urlOrPath: string) => Promise<string>;

--- a/tools/ace/solver.test.ts
+++ b/tools/ace/solver.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { solve } from "./solver.ts";
-import { packageHash, type FetchPackage } from "./resolve.ts";
+import type { FetchPackage } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
 import { contentHash } from "./store.ts";
 import type { AcePackage, AceDependency, RegistryEntry } from "./store.ts";
 

--- a/tools/ace/solver.z3.test.ts
+++ b/tools/ace/solver.z3.test.ts
@@ -18,7 +18,8 @@
 import { describe, test, expect } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { solve } from "./solver.ts";
-import { packageHash, type FetchPackage } from "./resolve.ts";
+import type { FetchPackage } from "./resolve.ts";
+import { packageHash } from "./package-hash.ts";
 import { contentHash } from "./store.ts";
 import type { AcePackage, AceDependency, RegistryEntry } from "./store.ts";
 import { satisfies } from "./semver.ts";


### PR DESCRIPTION
## Ace slice 8.2 — package_hash as content identity (signature-excluded composition)

Third step of the cross-language Ace trust core (after slice 8 SHA-256, 8.1 canonical-JSON). `package_hash` becomes a formally-defined, golden-vector-verified **content identity** — `"sha256:" + sha256(canonicalBytes({ manifest − signature, files }))` — composing the two primitives already built, extracted into a dedicated module, with the signature excluded.

Spec: `docs/agendas/ace-package-manager/2026-06-02-ace-slice8.2-package-hash-composition-design.md` (#6602, merged). Plan in this PR.

### What changed (3 tasks, subagent-driven; two-stage review per task + final holistic)

- **NEW `tools/ace/package-hash.ts`** — `packageHash(pkg)` over `{ manifest − signature, files }` via `canonicalBytes` (8.1) + node:crypto SHA-256. Signature **excluded** → identity (what) separated from authenticity (who, verified separately). Aligns the *exclusion* with `signing.ts`'s `canonicalManifestBytes` (different *scope*: signing covers manifest alone, identity covers `{manifest, files}`). Stable across re-signing; unsigned & later-signed forms share a hash. No security loss (sig verified regardless).
- **`resolve.ts`** — old signature-including `packageHash` removed (+ now-unused `createHash`/`canonicalBytes` imports dropped); imports the new module; local `canonicalJson` (lockfile) + untrusted-dep `try/catch` kept.
- **9 import sites swept** to `./package-hash.ts` (`ace.ts`, `lockfile.ts`, `registry-publish.ts` + 6 test files). One `ace.test.ts` fixture: a `packageHash({})` *setup helper* → placeholder pin (the new packageHash throws on a manifest-less `{}`; the frozen-install PASS-1 shape guard refuses the malformed node **before** the pin is compared — verified; assertions unchanged).
- **NEW golden-vector fixture** `tests/cross-verification/package-hash/` (vectors.json + cross-verify.ts + ts-output.json). Expected values **independently verified via Python `hashlib`** (not TS-vs-TS); `cross-verify.ts` asserts (exit-non-zero). `minimal == signature-excluded == key-order-independent` (identical hash — structural proof of exclusion + key-sort); `with-dependencies` distinct.

### Review caught + fixed (before merge)

- T1: header comment overstated "aligns the identity input" → clarified same-exclusion/different-scope; added a dependencies-in-identity unit test.
- Final holistic: independently re-ran the Python verification, proved the oracle's assert fires (corrupt vector → exit 1), verified the content_hash/package_hash/signature triad is non-circular and the resolve chain (content_hash → pin → declared-identity → signature gate) intact.

### Behavior-preservation

`package_hash` values shift (signature excluded; pre-release, no `format_version` bump). `bun test tools/ace/` = **364/0** with no literal-hash pins changed (every assertion is round-trip / determinism / self-consistent recompute). tsc exit 0.

> Note: `bun test tools/ace/` is a **local gate** — `gate.yml` runs `dotnet test` only; the bun ace suite + cross-verify are not CI-gated (pre-existing).

### Follow-ups (non-blocking, noted by review)

1. **CLI untrusted-input throw hardening** — `ace.ts:990` (frozen install) + `ace.ts:821` (registry add) can throw uncaught on a float/lone-surrogate manifest field past their coarse shape guard. **Confirmed identical pre/post-8.2** (8.2 changed only *what* is hashed). Wrap like `resolve.ts:142` already does. Extends the 8.1-named CLI-untrusted-root follow-up.
2. **Wire the bun ace suite + cross-verify into CI** so the cross-language contract is enforced, not just authored.

Gates: `bun test tools/ace/` 364/0 · tsc exit 0 · cross-verify 0 mismatches + Python ALL-OK · pure-LF · markdownlint (plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
