### PR TITLE
docs(ace): slice 8.3 spec — ed25519 trust-core golden vectors (RFC 8032 + key_id + Ace envelope)

### DIFF
--- a/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.3-ed25519-golden-vectors-design.md
+++ b/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.3-ed25519-golden-vectors-design.md
@@ -1,0 +1,157 @@
+# Ace slice 8.3 — ed25519 trust-core golden vectors (design)
+
+> Spec for slice 8.3 of the Ace package manager (B-0288), fourth step of the
+> cross-language Ace trust core (after slice 8 SHA-256, 8.1 canonical-JSON, 8.2
+> package_hash). Ace's ed25519 signature primitive already works (node:crypto, slice 3
+> `signing.ts`); this slice **anchors it with a cross-language golden-vector fixture**
+> so a future Rust/F#/C# Ace verifies + produces Ace signatures identically. No
+> production code changes — the fixture + oracle are the deliverable. Brainstormed +
+> approved with the operator 2026-06-02 (scope: formalize + golden vectors, TS, parity
+> spec'd; vectors: RFC 8032 + key_id + Ace envelope + invalid; module: keep in
+> signing.ts, no extraction).
+
+## Goal
+
+Signature authenticity is the trust core's "who vouches" gate: `verifySignature` /
+`verifyIndexSignature` accept a package/index only if a trusted key signed its canonical
+bytes. Today the ed25519 primitive (`keyId`, `signManifest`/`verifySignature`,
+`signIndex`/`verifyIndexSignature` in `signing.ts`, all node:crypto) has **no
+known-answer vectors** — `signing.test.ts` covers round-trips + behavioral rejection
+(bad-signature / untrusted-key / no-signature / unsupported-algo) but nothing pins the
+crypto against published or independent vectors. So a future non-TS Ace has no contract
+to match. This slice adds a golden-vector fixture anchoring (a) raw ed25519 against the
+published RFC 8032 §7.1 vectors, (b) Ace's `key_id` derivation, (c) the full Ace
+signature envelope over a canonical manifest, and (d) invalid-rejection — the complete
+cross-language signature contract.
+
+## Why formalize, not reimplement (decision, operator 2026-06-02)
+
+- ed25519 is security-sensitive crypto; reimplementing it in F#/C#/Rust ("don't roll
+  your own crypto") is the wrong move. node:crypto's ed25519 is correct + native. A
+  future non-TS Ace uses its platform's ed25519 (ed25519-dalek / NSec / etc.). The
+  cross-language guarantee is **conformance to RFC 8032**, not a shared impl — so the
+  fixture (not a 4-language oracle) is the right deliverable. Consistent with 8.1/8.2
+  (TS-only, parity spec'd). No .NET/Rust ed25519 dependency is added.
+- ed25519 signatures are **deterministic** (RFC 8032): the same key + message yields the
+  same 64-byte signature in every conformant impl. So sign-reproduction is a valid
+  cross-language check (unlike randomized schemes).
+- The Ace-specific cross-language risks beyond raw ed25519 are: **`key_id` = sha256 of
+  the SPKI-DER public key** (the DER wrapper must encode identically across platforms)
+  and the **signature envelope** over a canonical message (8.1). The fixture anchors
+  both.
+
+## Decisions (this spec locks them; operator 2026-06-02)
+
+1. **Keep node:crypto ed25519 in `signing.ts`** — no extraction (the raw primitive is
+   consumed only by signing.ts), no 4-language reimplementation. `signing.ts` is
+   untouched by this slice.
+2. **Golden-vector fixture** `tests/cross-verification/ed25519/` with four layers:
+   - **RFC 8032 §7.1 raw conformance** — the published, independent vectors
+     (32-byte secret key, 32-byte public key, message, 64-byte signature). The TS oracle
+     imports the raw keys via **JWK** (`{ kty: "OKP", crv: "Ed25519", x: <pub b64url>,
+     d: <priv b64url> }` through `createPublicKey`/`createPrivateKey({ format: "jwk" })`
+     — cleaner than hand-rolling PKCS8/SPKI DER), then VERIFIES the RFC signature AND
+     SIGN-REPRODUCES it (deterministic → must equal the RFC signature byte-for-byte).
+   - **key_id derivation** — public key → SPKI-DER → sha256 → `"ed25519:" + first
+     16 hex` (composes slice-8 sha256; anchors the SPKI-DER encoding).
+   - **Ace signature envelope** — a fixed test keypair (PEM, committed in the fixture)
+     signs a canonical manifest (8.1) → expected `{ algo: "ed25519", key_id, sig }`
+     (sig base64). The full Ace signature flow via `signManifest`, reproducible.
+   - **Invalid-rejection** — tampered message / tampered signature / wrong (untrusted)
+     key → `verifySignature` returns `{ ok: false, reason }`. Verify MUST reject.
+3. **Independent verification (assert-don't-skip).** The RFC 8032 vectors ARE the
+   independent source for raw ed25519 (TS-vs-RFC, not TS-vs-TS). For the key_id +
+   envelope layers, an independent tool (Python `cryptography` or openssl) re-derives the
+   `key_id` and the signature to confirm the committed expected values — so no layer is
+   a TS-vs-TS tautology.
+4. **`cross-verify.ts` asserts** every vector (exit non-zero on any mismatch) + writes
+   `ts-output.json`. It imports only `signing.ts`'s EXISTING exports (`keyId`,
+   `signManifest`, `verifySignature`) + uses node:crypto directly for the raw-RFC layer —
+   `signing.ts` gains no new exports.
+5. **Same CI reality as 8.1/8.2.** The bun ace suite + the cross-verify oracles are NOT
+   CI-gated (`gate.yml` runs `dotnet test`; lint only type-checks) — the controller runs
+   them locally; the "wire bun ace + cross-verify into CI" follow-up still stands.
+
+## Architecture
+
+```text
+tests/cross-verification/ed25519/
+  vectors.json      # 4 layers: rfc8032[] · key_id[] · envelope[] · invalid[]
+  cross-verify.ts   # reads vectors.json; node:crypto (raw RFC layer) +
+                    #   keyId / signManifest / verifySignature (Ace layers);
+                    #   ASSERTS each vector; writes ts-output.json; exit!=0 on mismatch
+  ts-output.json    # committed oracle output (record that it passed)
+```
+
+No `tools/ace/` changes. The oracle's raw-RFC layer uses node:crypto's
+`createPublicKey`/`createPrivateKey({ format: "jwk" })` + `sign`/`verify(null, ...)`
+directly (it is exercising the SAME ed25519 that `signing.ts` uses under the hood,
+proving it is RFC-conformant). The key_id layer calls `keyId(spkiB64)`. The envelope
+layer calls `signManifest(manifest, privatePem)` + `verifySignature`. The invalid layer
+calls `verifySignature` with tampered inputs.
+
+## Components
+
+- **`tests/cross-verification/ed25519/vectors.json`** — **new**. Four arrays:
+  - `rfc8032`: `{ id, secret_hex, public_hex, message_hex, signature_hex }` (subset of
+    RFC 8032 §7.1 — e.g. TEST 1 empty message, TEST 2, TEST 3, and the longer TEST).
+  - `key_id`: `{ id, public_spki_b64, expected_key_id }`.
+  - `envelope`: `{ id, private_pem, manifest, expected_key_id, expected_sig }` (fixed
+    keypair; manifest is a canonical-signable manifest minus signature).
+  - `invalid`: `{ id, manifest_with_signature, trust, expected_reason }` (tampered /
+    untrusted cases).
+- **`tests/cross-verification/ed25519/cross-verify.ts`** — **new**. Reads the fixture;
+  per layer computes + ASSERTS against expected; writes `ts-output.json`; exits non-zero
+  on any mismatch.
+- **`tests/cross-verification/ed25519/ts-output.json`** — **new** (committed oracle
+  output).
+
+## Testing
+
+- **RFC 8032 layer:** for each vector, import the raw keypair (JWK), `verify` the RFC
+  signature (must be valid), and `sign` the message (must reproduce `signature_hex`
+  exactly — deterministic ed25519). This is the independent cross-language anchor.
+- **key_id layer:** `keyId(public_spki_b64) === expected_key_id`; the expected value
+  independently re-derived (Python `cryptography`: SPKI-DER → sha256 → `"ed25519:"+16hex`).
+- **envelope layer:** `signManifest(manifest, private_pem)` yields `{ algo:"ed25519",
+  key_id: expected_key_id, sig: expected_sig }`; `verifySignature` of the resulting
+  signed manifest (with a trust store containing the key) returns `{ ok: true }`. The
+  `expected_sig` independently re-derived (sign the canonical manifest bytes with the
+  same key via openssl/Python).
+- **invalid layer:** `verifySignature` returns the `expected_reason`
+  (`bad-signature` / `untrusted-key` / `no-signature` / `unsupported-algo`) for each
+  tampered/untrusted case. Verify MUST reject.
+- **Gates:** `cd tests/cross-verification/ed25519 && bun cross-verify.ts` exits 0
+  (`0 mismatches`); the independent Python/openssl re-derivation matches every committed
+  expected value; `bun --bun tsc --noEmit -p tsconfig.json` exit 0; pure-LF; markdownlint
+  on this doc + the plan. (`bun test tools/ace/` unchanged — no production code touched —
+  but run it to confirm no regression.)
+
+## Scope / YAGNI
+
+In scope: the four-layer golden-vector fixture + asserting oracle + independent
+verification of expected values. Out of scope: a live F#/C#/Rust ed25519 oracle (deferred
+until a non-TS Ace exists; RFC 8032 conformance is the cross-language guarantee);
+extracting an `ed25519.ts` module (the primitive is signing.ts-internal; revisit if 8.4
+needs it); any change to `signing.ts` / the runtime crypto; key rotation / multi-sig
+(later trust-core concerns); the CLI untrusted-input hardening + wiring bun-ace/cross-verify
+into CI (the standing follow-ups from 8.1/8.2 final reviews).
+
+## Files touched
+
+- `tests/cross-verification/ed25519/vectors.json` — **new**.
+- `tests/cross-verification/ed25519/cross-verify.ts` — **new**.
+- `tests/cross-verification/ed25519/ts-output.json` — **new** (committed output).
+
+## Decomposition (2 tasks)
+
+- **T1 — oracle + RFC 8032 raw layer + key_id layer.** `cross-verify.ts` skeleton
+  (reads vectors.json, writes ts-output.json, asserts, exit-non-zero); `rfc8032` +
+  `key_id` vectors with expected values; independent verification (RFC 8032 published
+  vectors for raw; Python/openssl for key_id). Confirm the oracle is green on these two
+  layers.
+- **T2 — Ace signature-envelope layer + invalid-rejection layer.** Add the `envelope`
+  vectors (fixed keypair → canonical manifest → `{ algo, key_id, sig }`, independently
+  re-derived) + the `invalid` vectors (tampered/untrusted → `verifySignature` rejects);
+  extend `cross-verify.ts` to assert both; confirm the full oracle green + `ts-output.json`
+  committed.


### PR DESCRIPTION
## Ace slice 8.3 spec — ed25519 trust-core golden vectors

Fourth step of the cross-language Ace trust core (after slice 8 SHA-256, 8.1 canonical-JSON, 8.2 package_hash). Spec only; implementation follows after plan + go-ahead.

ed25519 already works (node:crypto, slice 3 `signing.ts`) but has **no known-answer vectors** — `signing.test.ts` covers round-trips + behavioral rejection, nothing pins the crypto against published/independent vectors. This slice anchors it with a cross-language golden-vector fixture. **No production code change** — the fixture + asserting oracle are the deliverable.

**Decisions (brainstormed + approved with the operator 2026-06-02):**

1. **Keep node:crypto + signing.ts unchanged** — don't reimplement crypto in 4 langs (security-sensitive; a future non-TS Ace uses its platform's ed25519). The cross-language guarantee is **RFC 8032 conformance**, so the fixture (not a 4-lang oracle) is the deliverable. No extraction (the primitive is signing.ts-internal). Consistent with 8.1/8.2.
2. **Four-layer fixture** `tests/cross-verification/ed25519/`:
   - **RFC 8032 §7.1 raw** — published independent vectors; oracle imports raw keys via JWK, verifies + sign-reproduces (deterministic ed25519 → byte-exact). The foundational anchor.
   - **key_id** — public key → SPKI-DER → sha256 → `"ed25519:"+16hex` (composes slice-8 sha256; anchors the SPKI-DER cross-lang encoding).
   - **Ace envelope** — fixed test keypair signs a canonical manifest (8.1) → `{ algo, key_id, sig }` (full flow via `signManifest`).
   - **invalid-rejection** — tampered message/sig/wrong-key → `verifySignature` rejects (verify MUST reject).
3. **Independent verification (assert-don't-skip):** RFC 8032 vectors ARE the independent source for raw ed25519; key_id + envelope expected values independently re-derived (Python `cryptography`/openssl) — no TS-vs-TS tautology.
4. `cross-verify.ts` asserts (exit-non-zero) + imports only signing.ts's existing exports (`keyId`/`signManifest`/`verifySignature`) → signing.ts gains no new surface.

~2-task decomposition: T1 oracle + RFC 8032 + key_id layers → T2 Ace envelope + invalid layers.

Same CI reality as 8.1/8.2 (bun ace + cross-verify not CI-gated → controller runs locally; wire-into-CI follow-up stands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
