### PR TITLE
docs(registry): two-axis note — consensus-tier ✅ is NOT a proof/canonical mark

### DIFF
--- a/docs/PRIMITIVE-REGISTRY.md
+++ b/docs/PRIMITIVE-REGISTRY.md
@@ -135,6 +135,19 @@ to agree. Three tiers, strongest first:
 
 Cells below use ✅ (present) / ⚠️ (partial — see note) / ❌ (absent).
 
+> **Two orthogonal axes — consensus-tier ✅ is NOT a proof/canonical mark.** The
+> ✅/⚠️/❌ above track the **consensus tier** (cross-language _agreement_: golden-vector
+> byte-consensus / compiler-parity). They do **not** mean _math-proven_. Even Tier-1
+> byte-consensus proves only that the four implementations _agree byte-for-byte_, not
+> that they are _correct w.r.t. the seed_ — four implementations can agree on the same
+> wrong behavior (the consensus≠validation trap). **Canonical** is the separate
+> proof axis: an item is canonical only with a proof-lineage edge to the seed (its
+> homeostat proven) + the hex (Cl(1,3))/4×4 connection — tracked by **B-1007** and
+> the [`formal-proof-first` rule](../.claude/rules/formal-proof-first-proven-by-default-consensus-not-validation-canonical-is-homeostat-proven-from-seed-ace-shields-zeta.md).
+> So a primitive can be Tier-1 ✅ **and** non-canonical at once: many primitives are
+> _validated_; ~0 are _proven_. Read ✅ as "ships + agrees across langs," never as
+> "proven."
+
 ## Tier-1/2 — the stable base (4-oracle)
 
 | Primitive                                                                         | TS  | F#  | C#  | Rust | Consensus                                                                                    | Locations                                                                                                                                                  |


### PR DESCRIPTION
## What

Aaron 2026-06-02: **"yes add the two-axis note to the registry."** Adds a note right after the consensus-tiers legend in `docs/PRIMITIVE-REGISTRY.md` so a reader of ✅ doesn't read it as "proven."

The two orthogonal axes:
- **✅/⚠️/❌ = consensus tier** (cross-language *agreement*: golden-vector byte-consensus / compiler-parity). Even **Tier-1 byte-consensus proves only that the four impls agree byte-for-byte, not that they are correct w.r.t. the seed** — four implementations can agree on the same wrong behavior (the consensus≠validation trap).
- **canonical = the separate proof axis** — proof-lineage edge to the seed (homeostat proven) + hex (Cl(1,3))/4×4 connection — tracked by **B-1007** and the `formal-proof-first` rule (#6613).

So a primitive can be **Tier-1 ✅ and non-canonical at once**: many primitives are validated; ~0 are proven. Read ✅ as "ships + agrees across langs," never "proven."

Closes the "is ✅ = proven?" confusion. Docs-only; rule-link target verified on main; markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)