### PR TITLE
proof(B-1007 C1): Gaussian message product is a commutative group — Z3 + FsCheck (first real proof)

### DIFF
--- a/tests/Bayesian.Tests/Bayesian.Tests.fsproj
+++ b/tests/Bayesian.Tests/Bayesian.Tests.fsproj
@@ -30,5 +30,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FsUnit.Xunit" />
+    <PackageReference Include="FsCheck" />
+    <PackageReference Include="FsCheck.Xunit.v3" />
   </ItemGroup>
 </Project>

--- a/tests/Bayesian.Tests/Message.Tests.fs
+++ b/tests/Bayesian.Tests/Message.Tests.fs
@@ -1,7 +1,11 @@
 module Zeta.Bayesian.Tests.MessageTests
+#nowarn "0893"
 
 open FsUnit.Xunit
 open global.Xunit
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.Xunit
 open Zeta.Bayesian
 
 // The message algebra (B-1000 slice 2) — the inference kernel of the
@@ -177,3 +181,83 @@ let ``divide may yield an improper message and isProper detects it (EP cavity)``
     let cav = Gaussian.divide wide narrow            // τ = 0.5 - 1 = -0.5 < 0
     Gaussian.isProper cav |> should equal false
     cav.Precision |> should (equalWithin 1e-9) -0.5  // well-defined, just improper
+
+// ═══════════════════════════════════════════════════════════════════
+// C1 (B-1007 P0) — Gaussian message product is a COMMUTATIVE GROUP over
+// the proper-message domain. FsCheck half of the BP-16 cross-check; the
+// Z3 twin (Formal/Z3.Laws.Tests.fs) proves the ideal-real algebra is an
+// abelian group symbolically. THIS proves the float impl CONFORMS over
+// the domain. Disagreement IS the finding — the tolerance below is NOT
+// to be relaxed to hide a real divergence.
+//
+// Anchor: KFL 2001 (product = combine), Minka 2001 (divide = cavity),
+// Wainwright-Jordan 2008 §3 (exp-family natural params form a free
+// abelian group under +/-). Authored by Soraya (formal-verification-
+// expert) per B-1007. uniform identity is `Gaussian.One`.
+//
+// Domain discipline: generate over the NATURAL parameters (precision
+// τ>0, precision-mean ν) so every generated message is PROPER. Improper
+// messages are EP cavities, not a group failure (Minka 2001).
+// ═══════════════════════════════════════════════════════════════════
+
+/// Build a PROPER Gaussian from two raw floats (FsCheck's NormalFloat
+/// excludes NaN/inf), clamped to a well-conditioned band so a property
+/// failure means a REAL algebraic divergence, not an engineered overflow
+/// (overflow-at-the-edge is the separate Z3/C9 obligation). τ forced > 0
+/// so every message is proper (Gaussian.isProper) — improper messages are
+/// EP cavities, not a group failure (Minka 2001).
+let private mkProper (nuRaw: float) (tauRaw: float) : Gaussian =
+    let clamp lo hi x = max lo (min hi x)
+    { PrecisionMean = clamp -1.0e6 1.0e6 nuRaw
+      Precision = clamp 1.0e-6 1.0e6 (abs tauRaw) }
+
+/// Natural-parameter equality within an absolute tolerance. Compared on
+/// (ν, τ) directly — NOT mean/variance, because mean = ν/τ amplifies
+/// error near τ≈0 and would hide a true natural-param divergence. DO NOT widen.
+let private gEq (a: Gaussian) (b: Gaussian) : bool =
+    let tol = 1e-7
+    abs (a.PrecisionMean - b.PrecisionMean) <= tol
+    && abs (a.Precision - b.Precision) <= tol
+
+[<Property>]
+let ``C1 Gaussian product is associative``
+    (NormalFloat nuA) (NormalFloat tauA)
+    (NormalFloat nuB) (NormalFloat tauB)
+    (NormalFloat nuC) (NormalFloat tauC) =
+    let a, b, c = mkProper nuA tauA, mkProper nuB tauB, mkProper nuC tauC
+    gEq ((a * b) * c) (a * (b * c))
+
+[<Property>]
+let ``C1 Gaussian product is commutative``
+    (NormalFloat nuA) (NormalFloat tauA) (NormalFloat nuB) (NormalFloat tauB) =
+    let a, b = mkProper nuA tauA, mkProper nuB tauB
+    gEq (a * b) (b * a)
+
+[<Property>]
+let ``C1 Gaussian One is the two-sided identity for product``
+    (NormalFloat nuA) (NormalFloat tauA) =
+    let a = mkProper nuA tauA
+    gEq (Gaussian.One * a) a && gEq (a * Gaussian.One) a
+
+[<Property>]
+let ``C1 Gaussian divide is the right inverse of product (EP cavity round-trip)``
+    (NormalFloat nuA) (NormalFloat tauA) (NormalFloat nuB) (NormalFloat tauB) =
+    // (a * b) / b = a — the EP cavity recovers the message it removed.
+    let a, b = mkProper nuA tauA, mkProper nuB tauB
+    gEq ((a * b) / b) a
+
+[<Property>]
+let ``C1 Gaussian product of two proper messages stays proper (closure)``
+    (NormalFloat nuA) (NormalFloat tauA) (NormalFloat nuB) (NormalFloat tauB) =
+    // τ1>0 and τ2>0 ⇒ τ1+τ2>0. The half the PROPER domain satisfies;
+    // the cavity (divide) deliberately can leave it — Minka 2001.
+    let a, b = mkProper nuA tauA, mkProper nuB tauB
+    Gaussian.isProper (a * b)
+
+[<Property>]
+let ``C1 Gaussian divide is the natural-parameter inverse element``
+    (NormalFloat nuA) (NormalFloat tauA) (NormalFloat nuB) (NormalFloat tauB) =
+    // a / b = a * (One / b) — divide IS multiply-by-inverse (group law in element form).
+    let a, b = mkProper nuA tauA, mkProper nuB tauB
+    let invB = Gaussian.One / b
+    gEq (a / b) (a * invB)

--- a/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
@@ -438,3 +438,89 @@ let ``TLC model-checker is available when configured`` () =
     | None ->
         // Tool not installed — test is informational only.
         ()
+
+// ═══════════════════════════════════════════════════════════════════
+// B-1007 C1 — Gaussian message product is an ABELIAN GROUP on the
+// natural-parameter representation (ν = μ·τ, τ = 1/σ²). product =
+// component-wise add, divide = component-wise subtract, identity =
+// One = (0,0). This is ℝ² under vector +/- — the abelian-group axioms
+// hold symbolically over the IDEAL REALS (QF_LRA). The FsCheck twin in
+// tests/Bayesian.Tests/Message.Tests.fs proves the FLOAT impl conforms;
+// THIS proves the algebraic model is correct-by-construction.
+//
+// Anchor: KFL 2001 (sum-product), Minka 2001 (EP cavity = divide),
+// Wainwright-Jordan 2008 §3 (exp-family natural params = free abelian
+// group). Mirrors the Z-set abelian-group lemmas above (same property
+// class, Gaussian payload). Authored by Soraya per B-1007.
+//
+// Float overflow (proper closure can break when τ1+τ2 overflows to ∞)
+// is invisible to QF_LRA ideal reals — that is the FsCheck side's job
+// (closure property on the bounded domain) + the separate C9 obligation.
+// ═══════════════════════════════════════════════════════════════════
+
+[<Fact>]
+let ``Z3 proves Gaussian message product is associative (C1)`` () =
+    let script =
+        "(declare-const nuA Real)\n(declare-const tauA Real)\n" +
+        "(declare-const nuB Real)\n(declare-const tauB Real)\n" +
+        "(declare-const nuC Real)\n(declare-const tauC Real)\n" +
+        "(assert (not (and\n" +
+        "  (= (+ (+ nuA nuB) nuC)   (+ nuA (+ nuB nuC)))\n" +
+        "  (= (+ (+ tauA tauB) tauC) (+ tauA (+ tauB tauC))))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C1 Gaussian product associative" script
+
+[<Fact>]
+let ``Z3 proves Gaussian message product is commutative (C1)`` () =
+    let script =
+        "(declare-const nuA Real)\n(declare-const tauA Real)\n" +
+        "(declare-const nuB Real)\n(declare-const tauB Real)\n" +
+        "(assert (not (and\n" +
+        "  (= (+ nuA nuB)   (+ nuB nuA))\n" +
+        "  (= (+ tauA tauB) (+ tauB tauA)))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C1 Gaussian product commutative" script
+
+[<Fact>]
+let ``Z3 proves One (0,0) is the identity for Gaussian product (C1)`` () =
+    let script =
+        "(declare-const nuA Real)\n(declare-const tauA Real)\n" +
+        "(assert (not (and\n" +
+        "  (= (+ nuA 0.0)  nuA)  (= (+ tauA 0.0)  tauA)\n" +
+        "  (= (+ 0.0 nuA)  nuA)  (= (+ 0.0 tauA)  tauA))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C1 Gaussian product identity (0,0)" script
+
+[<Fact>]
+let ``Z3 proves Gaussian divide is the inverse via negation (C1)`` () =
+    let script =
+        "(declare-const nuA Real)\n(declare-const tauA Real)\n" +
+        "(assert (not (and\n" +
+        "  (= (- nuA nuA)   0.0)  (= (- tauA tauA)  0.0)\n" +
+        "  (= (+ nuA (- 0.0 nuA))   0.0)\n" +
+        "  (= (+ tauA (- 0.0 tauA)) 0.0))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C1 Gaussian product inverse (divide = subtract)" script
+
+[<Fact>]
+let ``Z3 proves Gaussian divide round-trips the product, the EP cavity (C1)`` () =
+    let script =
+        "(declare-const nuA Real)\n(declare-const tauA Real)\n" +
+        "(declare-const nuB Real)\n(declare-const tauB Real)\n" +
+        "(assert (not (and\n" +
+        "  (= (- (+ nuA nuB) nuB)   nuA)\n" +
+        "  (= (- (+ tauA tauB) tauB) tauA))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C1 Gaussian cavity round-trip ((a*b)/b = a)" script
+
+[<Fact>]
+let ``Z3 proves proper Gaussians are closed under product, guarded (C1)`` () =
+    let script =
+        "(declare-const tauA Real)\n(declare-const tauB Real)\n" +
+        // τA>0 and τB>0 ⇒ τA+τB>0 (proper closed under product). GUARDED
+        // implication, not unconditional — divide (cavity) can leave the
+        // proper domain (Minka 2001), which is correct, not a bug.
+        "(assert (not (=> (and (> tauA 0.0) (> tauB 0.0))\n" +
+        "                 (> (+ tauA tauB) 0.0))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C1 proper closed under product (guarded)" script


### PR DESCRIPTION
## What

The **first formal proof** closing B-1007's P0 — and the repo's first move off ~0 proven primitives. Gaussian message product = **abelian group** on the natural-parameter representation (ν, τ): product = component-wise add, divide = subtract, identity = `One` (0,0). Two independent tools per BP-16:

- **Z3** (`tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs`) — proves the **ideal-real algebra is an abelian group** symbolically: associativity, commutativity, identity, inverse (divide=subtract), EP-cavity round-trip `(a*b)/b=a`, + guarded proper-closure. 6 lemmas, QF_LRA, reuses `z3ScriptHolds` (zero new wiring; sits next to the existing Z-set abelian-group lemmas).
- **FsCheck** (`tests/Bayesian.Tests/Message.Tests.fs`) — proves the **float impl conforms** over the proper domain (τ>0): 6 properties, natural-parameter equality, **tolerance not relaxed**. Wires `FsCheck` + `FsCheck.Xunit.v3` into `Bayesian.Tests` (the repo's FsCheck-3 `[<Property>]` + `NormalFloat`-param convention; `#nowarn 0893`).

**The load-bearing split:** Z3 proves *the model is a group* (exact, no tolerance); FsCheck proves *the float code conforms* (within tolerance, on the domain). Disagreement IS the finding — neither alone is the proof.

## Verification

**Run locally with z3 on PATH:** FsCheck **6/6 passed**, Z3 **7/7 passed**, **0 skipped**. The proof actually executes — not consensus, not example-tests.

## Discipline

- Authored by **Soraya** (formal-verification-expert) per B-1007; cleanroom (no Infer.NET source).
- Anchor: KFL 2001 (sum-product), Minka 2001 (EP cavity = divide), Wainwright–Jordan 2008 §3 (exp-family natural params = free abelian group).
- Per **formal-proof-first**: this closes acceptance-half **(a) proof** for C1. The **hex/4×4 lineage edge (half b)** is owed before C1 is *canonical* — until then it is **validated/proven, not canonical**.

## ⚠️ Known gap (pre-existing — flagged, not introduced here)

`z3` is **not installed in `gate.yml` build-and-test**, so the **Z3 half self-skips in CI** (green-by-skip — the assert-don't-skip shape). I verified it **locally** with z3 present instead. **Follow-up owed:** add z3 to the CI build-and-test job so the Z3 proofs are *enforced*, not skipped. The FsCheck half runs in CI normally.

Next in the cadence: C2 (Beta), C3 (Bernoulli) — same Z3+FsCheck pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)