### PR TITLE
ci(soraya): standing formal-coverage cadence — "soraya on cron"

### DIFF
--- a/.github/workflows/soraya-formal-coverage-cadence.yml
+++ b/.github/workflows/soraya-formal-coverage-cadence.yml
@@ -1,0 +1,159 @@
+name: soraya-formal-coverage-cadence
+
+# Standing cadence for the formal-coverage backlog (B-1007). Fires whether
+# or not any AI is running; opens or updates a tracking issue with a
+# "formal-coverage" label that any wake-time agent can grep for as a
+# cold-start check, then dispatch Soraya (the formal-verification-expert)
+# for the next open proof. The trigger ages and stays visible until the
+# C1-C14 backlog is closed.
+#
+# Per Aaron 2026-06-02 ("soraya on cron"): the repo is formal-proof-first;
+# cross-AI consensus is NOT validation, and we are far behind on the math.
+# Soraya must work the asserted-in-prose -> proven-from-seed gap on a
+# STANDING cadence, not one-shot. Harness crons don't persist across
+# sessions, so this GitHub Actions schedule is the durable mechanism (same
+# pattern as razor-cadence.yml / B-0192): the workflow fires whether or not
+# any AI exists; the next wake-time agent picks up the artifact + dispatches
+# Soraya. The trigger ages and stays visible; the discipline does not depend
+# on agent-remembering-to-check.
+#
+# A GitHub Action cannot itself dispatch the Soraya subagent (she is a
+# Claude agent, not a CI script). So this workflow maintains the visible
+# tracking ISSUE (the C1-C14 routing checklist); the agent picking it up
+# runs the actual proof dispatch + lands the PR (CI runs FsCheck/Z3 =
+# proof execution).
+#
+# Composes with:
+#  - B-1007 (the formal-coverage catch-up row + Soraya's C1-C14 audit).
+#  - .claude/rules/formal-proof-first-...-ace-shields-zeta.md (the doctrine:
+#    consensus != validation; canonical = homeostat-proven-from-seed).
+#  - .claude/rules/automated-tests-are-the-shield-assert-dont-skip.md
+#    (a proof that self-skips in CI is a hole; the checklist tracks
+#    enforced-not-skipped).
+#  - razor-cadence.yml / B-0192 (the cadence mechanization pattern).
+#
+# Out of scope: the proof content (the FsCheck/Z3/TLA+ artefacts) is
+# authored by Soraya per dispatch; this workflow surfaces the visible
+# backlog artifact only.
+#
+# Security note (safe-pattern compliance): consumes only first-party
+# trusted context plus the workflow_dispatch `note` input. Every
+# expression is routed via env: into run blocks and quoted there as
+# "$VAR"; NOTE_INPUT is treated as untrusted and appended into the
+# markdown body where it cannot be interpreted as shell. Body template
+# lives in tools/soraya-formal-coverage/issue-body-template.md.
+
+on:
+  schedule:
+    # Daily 09:37 UTC -- off-the-hour, offset from razor-cadence (09:17)
+    # and budget-snapshot to avoid GHA cron thundering-herd.
+    - cron: "37 9 * * *"
+  workflow_dispatch:
+    inputs:
+      note:
+        description: "Optional note to attach to this cadence fire"
+        required: false
+        default: ""
+
+permissions:
+  # Top-level read-only per Scorecard TokenPermissions best-practice;
+  # the job scopes write narrowly.
+  contents: read
+
+concurrency:
+  # One cadence run at a time; retriggers cancel-in-progress because the
+  # artifact is idempotent (open-or-update tracking issue).
+  group: soraya-formal-coverage-cadence
+  cancel-in-progress: true
+
+jobs:
+  fire:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Verify required tooling
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          command -v gh >/dev/null
+          gh auth status
+
+      - name: Open or update formal-coverage tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTE_INPUT: ${{ github.event.inputs.note || '' }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          BODY_TEMPLATE: tools/soraya-formal-coverage/issue-body-template.md
+        run: |
+          set -euo pipefail
+          today="$(date -u +%Y-%m-%d)"
+          title="Formal-coverage cadence due (Soraya) -- $today"
+
+          if [ ! -f "$BODY_TEMPLATE" ]; then
+            echo "ERROR: body template not found at $BODY_TEMPLATE" >&2
+            exit 1
+          fi
+          body="$(cat "$BODY_TEMPLATE")"
+          body="${body//RUN_ID_PLACEHOLDER/$RUN_ID}"
+          body="${body//TODAY_PLACEHOLDER/$today}"
+
+          if [ -n "${NOTE_INPUT:-}" ]; then
+            body="$(printf '%s\n\n### Note\n\n%s\n' "$body" "$NOTE_INPUT")"
+          fi
+
+          existing="$(gh issue list \
+            --repo "$REPO" \
+            --label formal-coverage \
+            --state open \
+            --json number,title \
+            --limit 1 \
+            --jq '.[0].number // empty')"
+
+          AI_FOOTER=$'\n\n---\n🤖 *Posted by soraya-formal-coverage-cadence workflow (AI-generated content)*'
+          body="${body}${AI_FOOTER}"
+
+          if [ -n "$existing" ]; then
+            echo "Updating existing formal-coverage tracking issue #$existing"
+            gh issue edit "$existing" \
+              --repo "$REPO" \
+              --title "$title" \
+              --body "$body"
+            gh issue comment "$existing" \
+              --repo "$REPO" \
+              --body "Cadence fired again on $today (run $RUN_ID). The C1-C14 checklist above is the standing one; tick items as their proofs land, close this issue once the backlog is exhausted.${AI_FOOTER}"
+          else
+            echo "Opening new formal-coverage tracking issue"
+            label_err="$(mktemp)"
+            if ! gh label create formal-coverage \
+              --repo "$REPO" \
+              --description "Formal-coverage cadence (Soraya) -- fires daily via .github/workflows/soraya-formal-coverage-cadence.yml" \
+              --color "5319E7" 2>"$label_err"; then
+              if grep -q "already exists" "$label_err"; then
+                : # already exists, fine
+              else
+                echo "ERROR: gh label create failed for non-already-exists reason:" >&2
+                cat "$label_err" >&2
+                rm -f "$label_err"
+                exit 1
+              fi
+            fi
+            rm -f "$label_err"
+
+            gh issue create \
+              --repo "$REPO" \
+              --title "$title" \
+              --body "$body" \
+              --label formal-coverage
+          fi

--- a/.github/workflows/soraya-formal-coverage-cadence.yml
+++ b/.github/workflows/soraya-formal-coverage-cadence.yml
@@ -125,14 +125,19 @@ jobs:
           body="${body}${AI_FOOTER}"
 
           if [ -n "$existing" ]; then
-            echo "Updating existing formal-coverage tracking issue #$existing"
+            echo "Refreshing existing formal-coverage tracking issue #$existing"
+            # IMPORTANT: do NOT overwrite the body on recurring runs — the body
+            # is the LIVING checklist; agents tick C2-C14 in the issue itself as
+            # proofs land. Re-rendering the template would reset that progress
+            # (the template only SEEDS the issue at creation, below). Refresh
+            # only the TITLE (the date) + post a heartbeat comment; the checkbox
+            # state is preserved. (Codex P1 / Copilot, #6617.)
             gh issue edit "$existing" \
               --repo "$REPO" \
-              --title "$title" \
-              --body "$body"
+              --title "$title"
             gh issue comment "$existing" \
               --repo "$REPO" \
-              --body "Cadence fired again on $today (run $RUN_ID). The C1-C14 checklist above is the standing one; tick items as their proofs land, close this issue once the backlog is exhausted.${AI_FOOTER}"
+              --body "Cadence fired again on $today (run $RUN_ID). The C1-C14 checklist in the issue body is the standing one — tick items as their proofs land (this workflow does NOT overwrite it); close this issue once the backlog is exhausted.${AI_FOOTER}"
           else
             echo "Opening new formal-coverage tracking issue"
             label_err="$(mktemp)"

--- a/tools/soraya-formal-coverage/issue-body-template.md
+++ b/tools/soraya-formal-coverage/issue-body-template.md
@@ -25,7 +25,7 @@ We are far behind on the math — this cadence closes the gap, one proof at a ti
 - [ ] **C11/C10** — Batch product = scalar element-wise; round-trip `ofMessages∘toMessages=id` — **FsCheck + prose fix** (`MessageBatch.fs` "bit-exact, proven in tests" is FALSE as written — example-tested; Bernoulli lossy at p→0/1)
 - [ ] **C6** — NaN-safe `moved`/`distance`: divergent never reports converged — **Z3 ∧ FsCheck**
 
-## P1 — 1 primary tool (C12/C13/C14 unblock B-1006 registry promotion)
+## P1 — primarily one tool (C13 cross-checks Z3 ∧ FsCheck; C12/C13/C14 unblock B-1006 registry promotion)
 
 - [ ] **C5** — BP `runToFixpoint` exact-on-trees + termination — **TLA+/TLC** (3-var tree × bounded rounds — the one genuine fixpoint property; NOT hammer-bias)
 - [ ] **C7** — EP probit moment-match accuracy — **FsCheck** (lift `Ep.Tests.fs` quadrature cross-check from 4 fixed points to generated cavities; keep quadrature as oracle)
@@ -47,6 +47,6 @@ We are far behind on the math — this cadence closes the gap, one proof at a ti
 4. **Canonical needs the second half** — track proof-closure here (acc. 1–3); the hex/4×4 lineage edge (acc. 4) is a paired sub-task routed to the algebra owner. Soraya flags when a proven item is lineage-edge-ready.
 5. **Re-tier B-1006 on close** (acc. 5) — registry entries stay *validated / proof-owed* until their law closes AND connects to lineage.
 6. **Wrong-tool guards** — do NOT TLA+ pointwise group laws (Z3); do NOT Lean 3-line identities (Z3, seconds vs human-weeks; Lean reserved for the C5 theorem only if paper-grade ever wanted); do NOT LiquidF# the refinements (TECH-RADAR Hold → FsCheck+Z3).
-7. **z3-in-CI gap** — z3 is in `stryker-mutation.yml` but NOT `gate.yml`, so Z3 proofs **self-skip in CI** (green-by-skip; assert-don't-skip hole). Until z3 is added to the build-and-test job, verify Z3 locally where z3 is on PATH. Adding z3 to CI is a paired infra follow-up.
+7. **z3-in-CI gap** (B-1009) — the `z3` CLI is **not installed in any workflow** (`Z3.Laws.Tests.fs` shells to the `z3` CLI; `Microsoft.Z3` NuGet 4.12.2 is pinned but the harness uses the CLI). So in `gate.yml` the Z3 proofs **self-skip** (green-by-skip; assert-don't-skip hole). Until z3 is added to the build-and-test job, **verify Z3 locally** where z3 is on PATH. Adding z3 to CI is the B-1009 follow-up.
 
 Close this issue only when C1–C14 are all checked **and** their canonical lineage edges are authored.

--- a/tools/soraya-formal-coverage/issue-body-template.md
+++ b/tools/soraya-formal-coverage/issue-body-template.md
@@ -1,0 +1,52 @@
+# Formal-coverage cadence (Soraya) — the standing math backlog
+
+**Cadence fired TODAY_PLACEHOLDER (run RUN_ID_PLACEHOLDER).** This is the standing
+tracking issue for the B-1007 formal-coverage backlog. The repo is
+**formal-proof-first**: cross-AI consensus is NOT validation; *canonical ⟺ homeostat
+proven-from-seed* (see `.claude/rules/formal-proof-first-proven-by-default-consensus-not-validation-canonical-is-homeostat-proven-from-seed-ace-shields-zeta.md`).
+We are far behind on the math — this cadence closes the gap, one proof at a time.
+
+## How a wake-time agent works this issue
+
+1. Pick the **next unchecked item in order** (strict P0 → P1 → P2; do not skip ahead).
+2. **Dispatch Soraya** (`formal-verification-expert`) to author the proof + cross-check
+   tool per BP-16; she returns the artefact (advisory — the architect lands it).
+3. Land the proof as a PR; **CI runs FsCheck/Z3 = proof execution** (verify it does NOT
+   self-skip — z3-in-CI is a known gap; run locally where z3 is present until CI installs it).
+4. Tick the item here when **both tools land AND agree** (P0 needs ≥2 tools).
+5. A proven law is only **validated** until a **hex/4×4 lineage edge** (B-0999 Cl(1,3) /
+   B-0998) connects it to the seed — that is the second half of *canonical* (B-1007 acc. 4).
+
+## P0 — silent-corruption class (≥2 tools each; do first, in order)
+
+- [x] **C1** — Gaussian product = abelian group, id=`One`(0,0), inv via `/` — **Z3 ∧ FsCheck** — *DONE (PR #6616: Z3 6 lemmas + FsCheck 6 props, verified locally 0-skipped)*
+- [ ] **C2** — Beta product group on shifted naturals `(α−1,β−1)`, id=`Beta(1,1)` — **Z3 ∧ FsCheck** (anchor PRML ch.2)
+- [ ] **C3** — Bernoulli product group via log-odds add, id=0.5 — **Z3 ∧ FsCheck** (Z3 over log-odds, finite only for p∈(0,1); FsCheck generates p strictly inside (0,1))
+- [ ] **C11/C10** — Batch product = scalar element-wise; round-trip `ofMessages∘toMessages=id` — **FsCheck + prose fix** (`MessageBatch.fs` "bit-exact, proven in tests" is FALSE as written — example-tested; Bernoulli lossy at p→0/1)
+- [ ] **C6** — NaN-safe `moved`/`distance`: divergent never reports converged — **Z3 ∧ FsCheck**
+
+## P1 — 1 primary tool (C12/C13/C14 unblock B-1006 registry promotion)
+
+- [ ] **C5** — BP `runToFixpoint` exact-on-trees + termination — **TLA+/TLC** (3-var tree × bounded rounds — the one genuine fixpoint property; NOT hammer-bias)
+- [ ] **C7** — EP probit moment-match accuracy — **FsCheck** (lift `Ep.Tests.fs` quadrature cross-check from 4 fixed points to generated cavities; keep quadrature as oracle)
+- [ ] **C4** — `Message.marginal` = product-fold, generic; identity on empty — **FsCheck** (cheap once C1–C3 land)
+- [ ] **C12** — Codec = invariant functor, `decode∘encode=id`, closed product/sum/id — **FsCheck** (writing this IS the B-1006 admission gate)
+- [ ] **C13** — Tick = `(ℕ,+,0)` monoid + `z⁻¹/I/D` linear-operator algebra — **FsCheck ∧ Z3** (operator identities `I=Σz⁻ⁿ`, `D=1−z⁻¹`; **the Tick primitive cannot promote until this gate exists**)
+- [ ] **C14** — ±1 Z-set abelian group + earn-its-keep auto-prune preserves semantics — **FsCheck** (Shapiro CRDTs 2011)
+
+## P2 — accuracy-bound, documented (lowest urgency; bites only at extreme tails)
+
+- [ ] **C8** — inverse-Mills asymptotic O(1/z⁵) error bound — **Z3/interval** or documented analytic bound + FsCheck band
+- [ ] **C9** — v²-overflow safety in `vHat`: `v/(1+v)≤1` keeps intermediate finite ∀ valid v — **Z3** (QF_LRA)
+
+## Standing operating rules (per Soraya's B-1007 routing)
+
+1. **Strict order within tier** — C1 is the foundation; every later item assumes the message group is sound.
+2. **P0 is not "done" on one tool** — both the Z3 and FsCheck artefact must land AND agree. **Disagreement IS the finding** — escalate to the architect; do NOT relax the FsCheck tolerance to make them agree (BP-16).
+3. **Trend > absolute** — each closed item updates the portfolio metric in `memory/persona/soraya/NOTEBOOK.md`. The audit notes the ratio *dropped* this engine-shipping round (denominator +7, numerator +0); the cadence's job is to reverse it.
+4. **Canonical needs the second half** — track proof-closure here (acc. 1–3); the hex/4×4 lineage edge (acc. 4) is a paired sub-task routed to the algebra owner. Soraya flags when a proven item is lineage-edge-ready.
+5. **Re-tier B-1006 on close** (acc. 5) — registry entries stay *validated / proof-owed* until their law closes AND connects to lineage.
+6. **Wrong-tool guards** — do NOT TLA+ pointwise group laws (Z3); do NOT Lean 3-line identities (Z3, seconds vs human-weeks; Lean reserved for the C5 theorem only if paper-grade ever wanted); do NOT LiquidF# the refinements (TECH-RADAR Hold → FsCheck+Z3).
+7. **z3-in-CI gap** — z3 is in `stryker-mutation.yml` but NOT `gate.yml`, so Z3 proofs **self-skip in CI** (green-by-skip; assert-don't-skip hole). Until z3 is added to the build-and-test job, verify Z3 locally where z3 is on PATH. Adding z3 to CI is a paired infra follow-up.
+
+Close this issue only when C1–C14 are all checked **and** their canonical lineage edges are authored.


### PR DESCRIPTION
## What

Aaron 2026-06-02: **"soraya on cron."** The repo is formal-proof-first and far behind on the math — Soraya (formal-verification-expert) must work the B-1007 backlog on a **standing cadence**, not one-shot. Harness crons don't persist across sessions, so this is the durable mechanism (same pattern as `razor-cadence.yml` / B-0192).

- **`.github/workflows/soraya-formal-coverage-cadence.yml`** — fires daily (09:37 UTC, off-the-hour to dodge the GHA cron thundering-herd) + on `workflow_dispatch`. Opens/updates a **`formal-coverage`-labelled tracking issue** carrying the C1→C14 routing checklist. A GH Action can't dispatch the Soraya subagent (she's a Claude agent, not a CI script), so the workflow maintains the visible **backlog issue**; the wake-time agent picks it up, dispatches Soraya for the next open proof, and lands the PR (**CI runs FsCheck/Z3 = proof execution**). The trigger ages and stays visible; the discipline doesn't depend on agent-remembering-to-check.
- **`tools/soraya-formal-coverage/issue-body-template.md`** — Soraya's full C1→C14 routing (P0/P1/P2, tool-per-item, anchors) + the standing operating rules: strict order, ≥2-tools-on-P0, **disagreement-is-the-finding**, canonical-needs-the-lineage-edge, wrong-tool guards, and the **z3-in-CI green-by-skip gap**. C1 pre-checked (#6616).

## Safety

Safe-pattern compliant: the only untrusted input is the `workflow_dispatch` `note`, routed via `NOTE_INPUT` env + quoted, appended into the markdown body (never shell-interpreted) — mirrors razor-cadence's stance. markdownlint clean; YAML parses; `actions/checkout` SHA-pinned (v6.0.2) to match repo convention.

Composes: B-1007, the formal-proof-first rule, assert-don't-skip, razor-cadence/B-0192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)