### PR TITLE
test(ace): slice 8.3 — ed25519 trust-core golden vectors (RFC 8032 + key_id + envelope + invalid)

### DIFF
--- a/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.3-ed25519-golden-vectors-implementation-plan.md
+++ b/docs/agendas/ace-package-manager/2026-06-02-ace-slice8.3-ed25519-golden-vectors-implementation-plan.md
@@ -1,0 +1,331 @@
+# Ace slice 8.3 — ed25519 trust-core golden vectors — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Anchor Ace's ed25519 signature primitive (node:crypto, `signing.ts`) with a four-layer golden-vector fixture — RFC 8032 §7.1 raw conformance + `key_id` derivation + the Ace signature envelope + invalid-rejection — so a future Rust/F#/C# Ace verifies + produces Ace signatures identically. **No `tools/ace/` change** — the fixture + asserting oracle are the deliverable.
+
+**Architecture:** New `tests/cross-verification/ed25519/{vectors.json, cross-verify.ts, ts-output.json}` (mirrors the sha256 / package-hash oracles). `cross-verify.ts` uses node:crypto directly for the raw-RFC layer (JWK key import) and `signing.ts`'s EXISTING exports (`keyId`, `signManifest`, `verifySignature`) for the Ace layers; it ASSERTS every vector (exit non-zero on mismatch). Expected values are independently verified (RFC 8032 published vectors for raw ed25519; Python `cryptography` for key_id + envelope).
+
+**Tech Stack:** TypeScript (Bun runtime), node:crypto ed25519, `bun --bun tsc --noEmit -p tsconfig.json`, Python `cryptography` (independent verification). Spec: `docs/agendas/ace-package-manager/2026-06-02-ace-slice8.3-ed25519-golden-vectors-design.md` (merged #6614).
+
+---
+
+## Pre-flight context for the implementer (zero repo context — read this)
+
+- **Harness (Otto-343):** Edit tool blocked. NEW files → Write tool. Editing JSON to fill expected values → a Python patch-script (assert single-occurrence, `rm` before commit, never commit `_patch_*.py`). Verify pure-LF: `python -c "print(open('PATH','rb').read().count(b'\r'))"` prints `0`. NEVER grep for `\r`.
+- **Commit trailer (exact):** `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. **Commit with:** `git -c user.email=<zeta-commit-email> commit ...` (the repo-local Zeta identity per the project convention — use the email already configured for this repo's commits, NOT the global one). Run from repo root. Wrap git network ops in `timeout --kill-after=5s 60s`.
+- **Branch:** `otto-windows/ace-slice8.3-impl-2026-06-02`, already checked out off `origin/main`. Do NOT switch branches; do NOT touch `main`.
+- **Canary:** `git ls-tree HEAD | wc -l` is `67` and must stay `67` (new files are under existing `tests/`).
+- **CI reality:** `bun test tools/ace/` + the cross-verify oracles are NOT CI-gated (`gate.yml` runs `dotnet test`; lint only type-checks). So running the oracle locally + requiring green is the load-bearing gate. `cross-verify.ts` must ASSERT (exit non-zero) so any run is a real signal.
+- **`signing.ts` exports you will use (do NOT modify signing.ts):**
+  - `keyId(spkiB64: string): string` → `"ed25519:" + sha256(SPKI-DER).slice(0,16hex)`.
+  - `signManifest(manifest, privatePem): { algo:"ed25519"; key_id; sig }` (sig base64; signs `canonicalManifestBytes` = canonical bytes of manifest-minus-signature, 8.1).
+  - `verifySignature(manifest, trustStore: Map<key_id, { public_key; label? }>): { ok:true; key_id; label? } | { ok:false; reason }` (reasons: `no-signature` / `unsupported-algo` / `untrusted-key` / `bad-signature`).
+  - `generateKeypair(): { privatePem; publicSpkiB64; keyId }` (for the fixed envelope keypair).
+- **node:crypto ed25519 from raw RFC keys via JWK** (cleaner than DER): a 32-byte secret seed + 32-byte public key →
+  - `createPrivateKey({ key: { kty:"OKP", crv:"Ed25519", d: Buffer.from(secretHex,"hex").toString("base64url"), x: Buffer.from(publicHex,"hex").toString("base64url") }, format:"jwk" })`
+  - `createPublicKey({ key: { kty:"OKP", crv:"Ed25519", x: Buffer.from(publicHex,"hex").toString("base64url") }, format:"jwk" })`
+  - sign: `sign(null, msgBytes, priv)` → Buffer; verify: `verify(null, msgBytes, pub, sigBytes)` → boolean. (`null` algorithm = pure Ed25519.)
+  - SPKI-DER base64 (for keyId): `createPublicKey(jwk).export({ type:"spki", format:"der" }).toString("base64")`.
+- **RFC 8032 §7.1 vectors (VERIFIED from rfc-editor.org/rfc/rfc8032.txt — use these exact hex strings, concatenated, lowercase):**
+
+  | id | secret_hex | public_hex | message_hex | signature_hex |
+  |---|---|---|---|---|
+  | rfc8032-test1 | `9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60` | `d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a` | `` (empty) | `e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b` |
+  | rfc8032-test2 | `4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb` | `3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c` | `72` | `92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00` |
+  | rfc8032-test3 | `c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7` | `fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025` | `af82` | `6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a` |
+  | rfc8032-sha-abc | `833fe62409237b9d62ec77587520911e9a759cec1d19755b7da901b96dca3d42` | `ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf` | `ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f` | `dc2a4459e7369633a52b1bf277839a00201009a3efbf3ecb69bea2186c26b58909351fc9ac90b3ecfdfbc7c66431e0303dca179c138ac17ad9bef1177331a704` |
+
+  (These are the published standard — they ARE the independent source for the raw-ed25519 layer.)
+
+---
+
+## File Structure
+
+- **Create** `tests/cross-verification/ed25519/vectors.json` — 4 arrays: `rfc8032`, `key_id`, `envelope`, `invalid`.
+- **Create** `tests/cross-verification/ed25519/cross-verify.ts` — reads vectors.json, asserts all layers, writes ts-output.json, exit-non-zero on mismatch.
+- **Create** `tests/cross-verification/ed25519/ts-output.json` — committed oracle output.
+
+---
+
+## Task 1: oracle + RFC 8032 raw layer + key_id layer
+
+**Files:**
+
+- Create: `tests/cross-verification/ed25519/cross-verify.ts`
+- Create: `tests/cross-verification/ed25519/vectors.json`
+
+- [ ] **Step 1: Write `vectors.json` with the `rfc8032` + `key_id` layers**
+
+The `rfc8032` array is the 4 verified vectors from the table above. The `key_id` array reuses the same public keys (by hex) — the oracle derives SPKI-DER from each and computes `keyId`; leave `expected_key_id` empty for now (filled in Step 3, independently verified in Step 4). The `envelope` + `invalid` arrays are added in Task 2 (start them as empty arrays). Write `tests/cross-verification/ed25519/vectors.json`:
+
+```json
+{
+  "description": "Ace ed25519 trust-core vectors (TS now; any RFC-8032-conformant impl must match). rfc8032 = published RFC 8032 7.1; key_id = SPKI-DER->sha256->ed25519:16hex; envelope = full Ace signature; invalid = verify must reject.",
+  "rfc8032": [
+    { "id": "rfc8032-test1", "secret_hex": "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60", "public_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a", "message_hex": "", "signature_hex": "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b" },
+    { "id": "rfc8032-test2", "secret_hex": "4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb", "public_hex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c", "message_hex": "72", "signature_hex": "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00" },
+    { "id": "rfc8032-test3", "secret_hex": "c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7", "public_hex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025", "message_hex": "af82", "signature_hex": "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a" },
+    { "id": "rfc8032-sha-abc", "secret_hex": "833fe62409237b9d62ec77587520911e9a759cec1d19755b7da901b96dca3d42", "public_hex": "ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf", "message_hex": "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f", "signature_hex": "dc2a4459e7369633a52b1bf277839a00201009a3efbf3ecb69bea2186c26b58909351fc9ac90b3ecfdfbc7c66431e0303dca179c138ac17ad9bef1177331a704" }
+  ],
+  "key_id": [
+    { "id": "key_id-test1", "public_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a", "expected_key_id": "" },
+    { "id": "key_id-test2", "public_hex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c", "expected_key_id": "" },
+    { "id": "key_id-test3", "public_hex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025", "expected_key_id": "" }
+  ],
+  "envelope": [],
+  "invalid": []
+}
+```
+
+- [ ] **Step 2: Write `cross-verify.ts` (RFC + key_id layers; envelope/invalid stubs)**
+
+Create `tests/cross-verification/ed25519/cross-verify.ts`:
+
+```typescript
+// Ace ed25519 trust-core cross-verification oracle (TS).
+// Asserts every vector against expected values; writes ts-output.json; exit non-zero on
+// any mismatch (assert-don't-skip). rfc8032 = published RFC 8032 7.1 (the independent
+// cross-language anchor; node:crypto must verify + deterministically reproduce each sig).
+// key_id / envelope / invalid exercise the Ace surface via signing.ts's existing exports.
+// Run from this directory: `bun cross-verify.ts`.
+import { createPrivateKey, createPublicKey, sign as nodeSign, verify as nodeVerify } from "node:crypto";
+import { keyId, signManifest, verifySignature, type TrustEntry } from "../../../tools/ace/signing.ts";
+
+const hexToBuf = (h: string): Buffer => Buffer.from(h, "hex");
+const b64url = (h: string): string => Buffer.from(h, "hex").toString("base64url");
+
+interface RfcVec { id: string; secret_hex: string; public_hex: string; message_hex: string; signature_hex: string; }
+interface KeyIdVec { id: string; public_hex: string; expected_key_id: string; }
+interface EnvVec { id: string; private_pem: string; manifest: Record<string, unknown>; expected_key_id: string; expected_sig: string; }
+interface InvalidVec { id: string; manifest: Record<string, unknown>; trust: Record<string, TrustEntry>; expected_reason: string; }
+
+const vec = JSON.parse(await Bun.file("vectors.json").text()) as {
+  rfc8032: RfcVec[]; key_id: KeyIdVec[]; envelope: EnvVec[]; invalid: InvalidVec[];
+};
+
+const out: Record<string, unknown> = {};
+let mismatches = 0;
+const fail = (msg: string): void => { mismatches++; console.error(msg); };
+
+// --- rfc8032 layer: verify the published sig + deterministically reproduce it ---
+const rfcOut: Record<string, { verified: boolean; reproduced: string }> = {};
+for (const v of vec.rfc8032) {
+  const priv = createPrivateKey({ key: { kty: "OKP", crv: "Ed25519", d: b64url(v.secret_hex), x: b64url(v.public_hex) }, format: "jwk" });
+  const pub = createPublicKey({ key: { kty: "OKP", crv: "Ed25519", x: b64url(v.public_hex) }, format: "jwk" });
+  const msg = hexToBuf(v.message_hex);
+  const verified = nodeVerify(null, msg, pub, hexToBuf(v.signature_hex));
+  const reproduced = (nodeSign(null, msg, priv) as Buffer).toString("hex");
+  rfcOut[v.id] = { verified, reproduced };
+  if (!verified) fail(`rfc8032 ${v.id}: node failed to VERIFY the published signature`);
+  if (reproduced !== v.signature_hex) fail(`rfc8032 ${v.id}: reproduce MISMATCH\n  got=${reproduced}\n  exp=${v.signature_hex}`);
+}
+out.rfc8032 = rfcOut;
+
+// --- key_id layer: SPKI-DER -> sha256 -> ed25519:16hex ---
+const keyIdOut: Record<string, string> = {};
+for (const v of vec.key_id) {
+  const pub = createPublicKey({ key: { kty: "OKP", crv: "Ed25519", x: b64url(v.public_hex) }, format: "jwk" });
+  const spkiB64 = (pub.export({ type: "spki", format: "der" }) as Buffer).toString("base64");
+  const kid = keyId(spkiB64);
+  keyIdOut[v.id] = kid;
+  if (v.expected_key_id !== "" && kid !== v.expected_key_id) fail(`key_id ${v.id}: MISMATCH got=${kid} exp=${v.expected_key_id}`);
+}
+out.key_id = keyIdOut;
+
+// --- envelope layer (Task 2) ---
+const envOut: Record<string, { key_id: string; sig: string; verify_ok: boolean }> = {};
+for (const v of vec.envelope) {
+  const sig = signManifest(v.manifest as never, v.private_pem);
+  const trust = new Map<string, TrustEntry>();
+  // derive the public_key (SPKI-DER b64) from the private pem to build the trust store
+  const pub = createPublicKey(createPrivateKey(v.private_pem));
+  const spkiB64 = (pub.export({ type: "spki", format: "der" }) as Buffer).toString("base64");
+  trust.set(sig.key_id, { public_key: spkiB64 });
+  const signed = { ...v.manifest, signature: sig };
+  const vr = verifySignature(signed as never, trust);
+  envOut[v.id] = { key_id: sig.key_id, sig: sig.sig, verify_ok: vr.ok };
+  if (v.expected_key_id !== "" && sig.key_id !== v.expected_key_id) fail(`envelope ${v.id}: key_id MISMATCH got=${sig.key_id} exp=${v.expected_key_id}`);
+  if (v.expected_sig !== "" && sig.sig !== v.expected_sig) fail(`envelope ${v.id}: sig MISMATCH got=${sig.sig} exp=${v.expected_sig}`);
+  if (!vr.ok) fail(`envelope ${v.id}: verifySignature rejected a freshly-signed manifest`);
+}
+out.envelope = envOut;
+
+// --- invalid layer (Task 2): verify MUST reject ---
+const invalidOut: Record<string, string> = {};
+for (const v of vec.invalid) {
+  const trust = new Map<string, TrustEntry>(Object.entries(v.trust));
+  const vr = verifySignature(v.manifest as never, trust);
+  const reason = vr.ok ? "ACCEPTED" : vr.reason;
+  invalidOut[v.id] = reason;
+  if (reason !== v.expected_reason) fail(`invalid ${v.id}: expected reason=${v.expected_reason} got=${reason}`);
+}
+out.invalid = invalidOut;
+
+await Bun.write("ts-output.json", JSON.stringify(out, null, 2) + "\n");
+console.log(`ed25519 cross-verify: rfc8032=${vec.rfc8032.length} key_id=${vec.key_id.length} envelope=${vec.envelope.length} invalid=${vec.invalid.length}, ${mismatches} mismatches.`);
+if (mismatches > 0) process.exit(1);
+```
+
+(Note: the `envelope` + `invalid` loops are written now but iterate empty arrays until Task 2 populates them. `TrustEntry` is exported from signing.ts — confirm the import name; if not exported, use `{ public_key: string; label?: string }` inline.)
+
+- [ ] **Step 3: Run the oracle to fill `key_id` expected values**
+
+```bash
+cd tests/cross-verification/ed25519 && bun cross-verify.ts && cd ../../..
+```
+
+It writes `ts-output.json` with the computed `key_id` values (and rfc8032 verified+reproduced). Read `ts-output.json`'s `key_id` map and fill each `expected_key_id` in `vectors.json` via a Python patch-script. Re-run the oracle → `0 mismatches`.
+
+- [ ] **Step 4: Independently verify the key_id values (Python `cryptography` — NOT node)**
+
+```bash
+python -c "
+import json, hashlib
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.hazmat.primitives import serialization
+d = json.load(open('tests/cross-verification/ed25519/vectors.json', encoding='utf-8'))
+ok = True
+for v in d['key_id']:
+    pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(v['public_hex']))
+    spki = pub.public_bytes(serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo)
+    kid = 'ed25519:' + hashlib.sha256(spki).hexdigest()[:16]
+    mark = 'OK' if kid == v['expected_key_id'] else 'MISMATCH'
+    if kid != v['expected_key_id']: ok = False
+    print(v['id'], mark)
+print('ALL-OK' if ok else 'FAIL')
+"
+```
+
+Expected: every `OK` + `ALL-OK`. Python's `cryptography` builds the SPKI-DER independently (no hand-rolled prefix) — if any MISMATCH, the expected_key_id is wrong; fix to the Python value. Paste this output in the report (assert-don't-skip evidence). If `cryptography` is not installed, `pip install cryptography` first (it is a standard, widely-used package — provenance-vetted).
+
+- [ ] **Step 5: tsc + pure-LF + commit**
+
+`bun --bun tsc --noEmit -p tsconfig.json` → exit 0. Pure-LF (CR==0) on all three files. Then:
+
+```bash
+git add tests/cross-verification/ed25519/vectors.json tests/cross-verification/ed25519/cross-verify.ts tests/cross-verification/ed25519/ts-output.json
+git -c user.email=<zeta-commit-email> commit -m "test(ace): slice 8.3 T1 — ed25519 oracle + RFC 8032 raw + key_id vectors (independently verified)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+Confirm `git ls-tree HEAD | wc -l` == 67.
+
+---
+
+## Task 2: Ace signature-envelope layer + invalid-rejection layer
+
+**Files:**
+
+- Modify: `tests/cross-verification/ed25519/vectors.json` (populate `envelope` + `invalid`)
+- (cross-verify.ts already handles both layers from Task 1)
+
+- [ ] **Step 1: Generate the fixed envelope keypair + signable manifest**
+
+Generate ONE fixed keypair (committed in the fixture) + sign a canonical manifest, capturing the values to populate the `envelope` vector:
+
+```bash
+cd tests/cross-verification/ed25519
+bun -e '
+import { generateKeypair, signManifest } from "../../../tools/ace/signing.ts";
+const kp = generateKeypair();
+const manifest = { format_version: 1, name: "demo", version: "1.0.0", content_hash: "sha256:deadbeef" };
+const sig = signManifest(manifest as never, kp.privatePem);
+console.log(JSON.stringify({ privatePem: kp.privatePem, publicSpkiB64: kp.publicSpkiB64, manifest, expected_key_id: sig.key_id, expected_sig: sig.sig }, null, 2));
+'
+cd ../../..
+```
+
+Use the printed JSON to fill ONE `envelope` vector in `vectors.json` (via a Python patch-script replacing the empty `"envelope": []`):
+
+```json
+"envelope": [
+  { "id": "ace-manifest-1", "private_pem": "<privatePem with literal \n preserved as JSON \\n>", "manifest": { "format_version": 1, "name": "demo", "version": "1.0.0", "content_hash": "sha256:deadbeef" }, "expected_key_id": "<from output>", "expected_sig": "<from output>" }
+]
+```
+
+(The PEM has newlines — in JSON they become `\n`. The patch-script should JSON-encode the PEM string so they are stored correctly.)
+
+- [ ] **Step 2: Populate the `invalid` layer**
+
+Add invalid-rejection vectors. Build them so `verifySignature` returns each `reason`. Use the SAME fixed keypair's `publicSpkiB64` for the trust store where a key must be trusted:
+
+```json
+"invalid": [
+  { "id": "no-signature", "manifest": { "format_version": 1, "name": "demo", "version": "1.0.0", "content_hash": "sha256:deadbeef" }, "trust": {}, "expected_reason": "no-signature" },
+  { "id": "unsupported-algo", "manifest": { "format_version": 1, "name": "demo", "version": "1.0.0", "content_hash": "sha256:deadbeef", "signature": { "algo": "rsa", "key_id": "ed25519:0000000000000000", "sig": "AAAA" } }, "trust": {}, "expected_reason": "unsupported-algo" },
+  { "id": "untrusted-key", "manifest": { "format_version": 1, "name": "demo", "version": "1.0.0", "content_hash": "sha256:deadbeef", "signature": { "algo": "ed25519", "key_id": "ed25519:ffffffffffffffff", "sig": "AAAA" } }, "trust": {}, "expected_reason": "untrusted-key" },
+  { "id": "bad-signature", "manifest": { "format_version": 1, "name": "TAMPERED", "version": "1.0.0", "content_hash": "sha256:deadbeef", "signature": { "algo": "ed25519", "key_id": "<envelope key_id>", "sig": "<envelope sig>" } }, "trust": { "<envelope key_id>": { "public_key": "<envelope publicSpkiB64>" } }, "expected_reason": "bad-signature" }
+]
+```
+
+For `bad-signature`: reuse the envelope's `key_id` + `sig` but TAMPER the manifest (e.g. `name: "TAMPERED"`) so the signature no longer matches the canonical bytes, with the key trusted → `verifySignature` reaches the crypto check and returns `bad-signature`. (If a manifest field other than `name` is cleaner to tamper, any content change works — the point is the signed canonical bytes differ.)
+
+- [ ] **Step 3: Run the oracle (envelope + invalid now populated) → green**
+
+```bash
+cd tests/cross-verification/ed25519 && bun cross-verify.ts && cd ../../..
+```
+
+Expected: `... 0 mismatches.` exit 0. All four layers assert.
+
+- [ ] **Step 4: Independently verify the envelope signature (Python `cryptography`)**
+
+Confirm the envelope `expected_sig` is a valid ed25519 signature by the envelope key over the canonical manifest bytes — independently of node. The oracle emits the canonical bytes; capture them and verify in Python:
+
+```bash
+cd tests/cross-verification/ed25519
+bun -e '
+import { canonicalManifestBytes } from "../../../tools/ace/signing.ts";
+const v = JSON.parse(await Bun.file("vectors.json").text()).envelope[0];
+console.log(Buffer.from(canonicalManifestBytes(v.manifest as never)).toString("hex"));
+' > /tmp/ace-env-canonical-hex.txt
+cd ../../..
+python -c "
+import json
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+d = json.load(open('tests/cross-verification/ed25519/vectors.json', encoding='utf-8'))['envelope'][0]
+canon = bytes.fromhex(open('/tmp/ace-env-canonical-hex.txt').read().strip())
+priv = load_pem_private_key(d['private_pem'].encode(), password=None)
+pub = priv.public_key()
+import base64
+sig = base64.b64decode(d['expected_sig'])
+try:
+    pub.verify(sig, canon); print('envelope-sig OK')
+except Exception as e:
+    print('envelope-sig FAIL', e)
+"
+```
+
+Expected: `envelope-sig OK` (Python's independent ed25519 verify accepts node's signature over the canonical bytes). Paste in the report. (canonicalManifestBytes is exported from signing.ts; if not, import canonicalBytes from canonical.ts + replicate the manifest-minus-signature destructure.)
+
+- [ ] **Step 5: tsc + pure-LF + commit**
+
+`bun --bun tsc --noEmit -p tsconfig.json` → exit 0. Re-run the oracle once more (regenerate ts-output.json with all layers). Pure-LF (CR==0). Then:
+
+```bash
+git add tests/cross-verification/ed25519/vectors.json tests/cross-verification/ed25519/ts-output.json
+git -c user.email=<zeta-commit-email> commit -m "test(ace): slice 8.3 T2 — ed25519 Ace signature-envelope + invalid-rejection vectors
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+Confirm `git ls-tree HEAD | wc -l` == 67.
+
+---
+
+## Self-review (controller, before dispatch)
+
+- **Spec coverage:** RFC 8032 layer (T1: verify + reproduce against the published vectors) ✓; key_id layer (T1: SPKI-DER→sha256, Python-independent) ✓; Ace envelope (T2: signManifest → key_id+sig, Python-verified) ✓; invalid-rejection (T2: 4 reasons) ✓; independent verification at every Ace layer ✓; node:crypto + signing.ts unchanged ✓.
+- **Placeholders:** the RFC vectors are the verified published values (fetched from rfc-editor.org); key_id/envelope expected values are filled-from-oracle-then-independently-verified (the only legitimate "fill in" — it's how golden vectors are authored, with the Python cross-check as the real anchor).
+- **Type consistency:** `keyId`, `signManifest`, `verifySignature`, `generateKeypair`, `canonicalManifestBytes`, `TrustEntry` per signing.ts; the oracle imports only existing exports.
+- **Scope:** signing.ts untouched; no module extraction; no CI wiring (standing follow-up).
+
+## Model selection (controller)
+
+- **T1 — opus** (crypto-vector authoring + the JWK raw-key import + independent verification discipline; first-time contract, security-adjacent).
+- **T2 — opus** (the Ace envelope + invalid-rejection construction + independent sig verification; security-adjacent + fiddly PEM/canonical handling).
+
+Two-stage review (spec compliance → code quality) after each task. Final holistic review over `git diff origin/main..HEAD -- tests/cross-verification/ed25519/`. Then the controller opens the impl PR + runs the PR-gate loop.

--- a/tests/cross-verification/ed25519/cross-verify.ts
+++ b/tests/cross-verification/ed25519/cross-verify.ts
@@ -1,0 +1,81 @@
+// Ace ed25519 trust-core cross-verification oracle (TS).
+// Asserts every vector against expected values; writes ts-output.json; exit non-zero on
+// any mismatch (assert-don't-skip). rfc8032 = published RFC 8032 7.1 (the independent
+// cross-language anchor; node:crypto must verify + deterministically reproduce each sig).
+// key_id / envelope / invalid exercise the Ace surface via signing.ts's existing exports.
+// Run from this directory: `bun cross-verify.ts`.
+import { createPrivateKey, createPublicKey, sign as nodeSign, verify as nodeVerify } from "node:crypto";
+import { keyId, signManifest, verifySignature, type TrustEntry } from "../../../tools/ace/signing.ts";
+
+const hexToBuf = (h: string): Buffer => Buffer.from(h, "hex");
+const b64url = (h: string): string => Buffer.from(h, "hex").toString("base64url");
+
+interface RfcVec { id: string; secret_hex: string; public_hex: string; message_hex: string; signature_hex: string; }
+interface KeyIdVec { id: string; public_hex: string; expected_key_id: string; }
+interface EnvVec { id: string; private_pem: string; manifest: Record<string, unknown>; expected_key_id: string; expected_sig: string; }
+interface InvalidVec { id: string; manifest: Record<string, unknown>; trust: Record<string, TrustEntry>; expected_reason: string; }
+
+const vec = JSON.parse(await Bun.file("vectors.json").text()) as {
+  rfc8032: RfcVec[]; key_id: KeyIdVec[]; envelope: EnvVec[]; invalid: InvalidVec[];
+};
+
+const out: Record<string, unknown> = {};
+let mismatches = 0;
+const fail = (msg: string): void => { mismatches++; console.error(msg); };
+
+// --- rfc8032 layer: verify the published sig + deterministically reproduce it ---
+const rfcOut: Record<string, { verified: boolean; reproduced: string }> = {};
+for (const v of vec.rfc8032) {
+  const priv = createPrivateKey({ key: { kty: "OKP", crv: "Ed25519", d: b64url(v.secret_hex), x: b64url(v.public_hex) }, format: "jwk" });
+  const pub = createPublicKey({ key: { kty: "OKP", crv: "Ed25519", x: b64url(v.public_hex) }, format: "jwk" });
+  const msg = hexToBuf(v.message_hex);
+  const verified = nodeVerify(null, msg, pub, hexToBuf(v.signature_hex));
+  const reproduced = (nodeSign(null, msg, priv) as Buffer).toString("hex");
+  rfcOut[v.id] = { verified, reproduced };
+  if (!verified) fail(`rfc8032 ${v.id}: node failed to VERIFY the published signature`);
+  if (reproduced !== v.signature_hex) fail(`rfc8032 ${v.id}: reproduce MISMATCH\n  got=${reproduced}\n  exp=${v.signature_hex}`);
+}
+out.rfc8032 = rfcOut;
+
+// --- key_id layer: SPKI-DER -> sha256 -> ed25519:16hex ---
+const keyIdOut: Record<string, string> = {};
+for (const v of vec.key_id) {
+  const pub = createPublicKey({ key: { kty: "OKP", crv: "Ed25519", x: b64url(v.public_hex) }, format: "jwk" });
+  const spkiB64 = (pub.export({ type: "spki", format: "der" }) as Buffer).toString("base64");
+  const kid = keyId(spkiB64);
+  keyIdOut[v.id] = kid;
+  if (v.expected_key_id !== "" && kid !== v.expected_key_id) fail(`key_id ${v.id}: MISMATCH got=${kid} exp=${v.expected_key_id}`);
+}
+out.key_id = keyIdOut;
+
+// --- envelope layer (Task 2 populates vec.envelope) ---
+const envOut: Record<string, { key_id: string; sig: string; verify_ok: boolean }> = {};
+for (const v of vec.envelope) {
+  const sig = signManifest(v.manifest as never, v.private_pem);
+  const trust = new Map<string, TrustEntry>();
+  const pub = createPublicKey(createPrivateKey(v.private_pem));
+  const spkiB64 = (pub.export({ type: "spki", format: "der" }) as Buffer).toString("base64");
+  trust.set(sig.key_id, { public_key: spkiB64 });
+  const signed = { ...v.manifest, signature: sig };
+  const vr = verifySignature(signed as never, trust);
+  envOut[v.id] = { key_id: sig.key_id, sig: sig.sig, verify_ok: vr.ok };
+  if (v.expected_key_id !== "" && sig.key_id !== v.expected_key_id) fail(`envelope ${v.id}: key_id MISMATCH got=${sig.key_id} exp=${v.expected_key_id}`);
+  if (v.expected_sig !== "" && sig.sig !== v.expected_sig) fail(`envelope ${v.id}: sig MISMATCH got=${sig.sig} exp=${v.expected_sig}`);
+  if (!vr.ok) fail(`envelope ${v.id}: verifySignature rejected a freshly-signed manifest`);
+}
+out.envelope = envOut;
+
+// --- invalid layer (Task 2 populates vec.invalid): verify MUST reject ---
+const invalidOut: Record<string, string> = {};
+for (const v of vec.invalid) {
+  const trust = new Map<string, TrustEntry>(Object.entries(v.trust));
+  const vr = verifySignature(v.manifest as never, trust);
+  const reason = vr.ok ? "ACCEPTED" : vr.reason;
+  invalidOut[v.id] = reason;
+  if (reason !== v.expected_reason) fail(`invalid ${v.id}: expected reason=${v.expected_reason} got=${reason}`);
+}
+out.invalid = invalidOut;
+
+await Bun.write("ts-output.json", JSON.stringify(out, null, 2) + "\n");
+console.log(`ed25519 cross-verify: rfc8032=${vec.rfc8032.length} key_id=${vec.key_id.length} envelope=${vec.envelope.length} invalid=${vec.invalid.length}, ${mismatches} mismatches.`);
+if (mismatches > 0) process.exit(1);

--- a/tests/cross-verification/ed25519/ts-output.json
+++ b/tests/cross-verification/ed25519/ts-output.json
@@ -1,0 +1,27 @@
+{
+  "rfc8032": {
+    "rfc8032-test1": {
+      "verified": true,
+      "reproduced": "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b"
+    },
+    "rfc8032-test2": {
+      "verified": true,
+      "reproduced": "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00"
+    },
+    "rfc8032-test3": {
+      "verified": true,
+      "reproduced": "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a"
+    },
+    "rfc8032-sha-abc": {
+      "verified": true,
+      "reproduced": "dc2a4459e7369633a52b1bf277839a00201009a3efbf3ecb69bea2186c26b58909351fc9ac90b3ecfdfbc7c66431e0303dca179c138ac17ad9bef1177331a704"
+    }
+  },
+  "key_id": {
+    "key_id-test1": "ed25519:06e3fd8fda29bb60",
+    "key_id-test2": "ed25519:deb2ded39dc26fce",
+    "key_id-test3": "ed25519:8d39ba50abe50f77"
+  },
+  "envelope": {},
+  "invalid": {}
+}

--- a/tests/cross-verification/ed25519/ts-output.json
+++ b/tests/cross-verification/ed25519/ts-output.json
@@ -22,6 +22,17 @@
     "key_id-test2": "ed25519:deb2ded39dc26fce",
     "key_id-test3": "ed25519:8d39ba50abe50f77"
   },
-  "envelope": {},
-  "invalid": {}
+  "envelope": {
+    "ace-manifest-1": {
+      "key_id": "ed25519:20d865ce18b9aee5",
+      "sig": "luHkOQ1gUuiaac029DsOjJ4vYjGMY3k81ow5Ej9gk2KN7WZbO04imR+JWo/iqcRMbNPzcDvNNkbQO+ETyXyuCg==",
+      "verify_ok": true
+    }
+  },
+  "invalid": {
+    "no-signature": "no-signature",
+    "unsupported-algo": "unsupported-algo",
+    "untrusted-key": "untrusted-key",
+    "bad-signature": "bad-signature"
+  }
 }

--- a/tests/cross-verification/ed25519/vectors.json
+++ b/tests/cross-verification/ed25519/vectors.json
@@ -11,6 +11,83 @@
     { "id": "key_id-test2", "public_hex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c", "expected_key_id": "ed25519:deb2ded39dc26fce" },
     { "id": "key_id-test3", "public_hex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025", "expected_key_id": "ed25519:8d39ba50abe50f77" }
   ],
-  "envelope": [],
-  "invalid": []
+  "envelope": [
+    {
+      "id": "ace-manifest-1",
+      "private_pem": "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIGZ8ya6nqqEM9a0gFdmqJyVlxdJ85dsnNOljlTaa/ISl\n-----END PRIVATE KEY-----\n",
+      "manifest": {
+        "format_version": 1,
+        "name": "demo",
+        "version": "1.0.0",
+        "content_hash": "sha256:deadbeef"
+      },
+      "expected_key_id": "ed25519:20d865ce18b9aee5",
+      "expected_sig": "luHkOQ1gUuiaac029DsOjJ4vYjGMY3k81ow5Ej9gk2KN7WZbO04imR+JWo/iqcRMbNPzcDvNNkbQO+ETyXyuCg=="
+    }
+  ],
+  "invalid": [
+    {
+      "id": "no-signature",
+      "manifest": {
+        "format_version": 1,
+        "name": "demo",
+        "version": "1.0.0",
+        "content_hash": "sha256:deadbeef"
+      },
+      "trust": {},
+      "expected_reason": "no-signature"
+    },
+    {
+      "id": "unsupported-algo",
+      "manifest": {
+        "format_version": 1,
+        "name": "demo",
+        "version": "1.0.0",
+        "content_hash": "sha256:deadbeef",
+        "signature": {
+          "algo": "rsa",
+          "key_id": "ed25519:0000000000000000",
+          "sig": "AAAA"
+        }
+      },
+      "trust": {},
+      "expected_reason": "unsupported-algo"
+    },
+    {
+      "id": "untrusted-key",
+      "manifest": {
+        "format_version": 1,
+        "name": "demo",
+        "version": "1.0.0",
+        "content_hash": "sha256:deadbeef",
+        "signature": {
+          "algo": "ed25519",
+          "key_id": "ed25519:ffffffffffffffff",
+          "sig": "AAAA"
+        }
+      },
+      "trust": {},
+      "expected_reason": "untrusted-key"
+    },
+    {
+      "id": "bad-signature",
+      "manifest": {
+        "format_version": 1,
+        "name": "TAMPERED",
+        "version": "1.0.0",
+        "content_hash": "sha256:deadbeef",
+        "signature": {
+          "algo": "ed25519",
+          "key_id": "ed25519:20d865ce18b9aee5",
+          "sig": "luHkOQ1gUuiaac029DsOjJ4vYjGMY3k81ow5Ej9gk2KN7WZbO04imR+JWo/iqcRMbNPzcDvNNkbQO+ETyXyuCg=="
+        }
+      },
+      "trust": {
+        "ed25519:20d865ce18b9aee5": {
+          "public_key": "MCowBQYDK2VwAyEAksYNmV2u2lcf/Sov0t2WZMBE7oImBVpWT3/wXjxO5/w="
+        }
+      },
+      "expected_reason": "bad-signature"
+    }
+  ]
 }

--- a/tests/cross-verification/ed25519/vectors.json
+++ b/tests/cross-verification/ed25519/vectors.json
@@ -1,0 +1,16 @@
+{
+  "description": "Ace ed25519 trust-core vectors (TS now; any RFC-8032-conformant impl must match). rfc8032 = published RFC 8032 7.1; key_id = SPKI-DER->sha256->ed25519:16hex; envelope = full Ace signature; invalid = verify must reject.",
+  "rfc8032": [
+    { "id": "rfc8032-test1", "secret_hex": "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60", "public_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a", "message_hex": "", "signature_hex": "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b" },
+    { "id": "rfc8032-test2", "secret_hex": "4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb", "public_hex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c", "message_hex": "72", "signature_hex": "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00" },
+    { "id": "rfc8032-test3", "secret_hex": "c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7", "public_hex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025", "message_hex": "af82", "signature_hex": "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a" },
+    { "id": "rfc8032-sha-abc", "secret_hex": "833fe62409237b9d62ec77587520911e9a759cec1d19755b7da901b96dca3d42", "public_hex": "ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf", "message_hex": "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f", "signature_hex": "dc2a4459e7369633a52b1bf277839a00201009a3efbf3ecb69bea2186c26b58909351fc9ac90b3ecfdfbc7c66431e0303dca179c138ac17ad9bef1177331a704" }
+  ],
+  "key_id": [
+    { "id": "key_id-test1", "public_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a", "expected_key_id": "ed25519:06e3fd8fda29bb60" },
+    { "id": "key_id-test2", "public_hex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c", "expected_key_id": "ed25519:deb2ded39dc26fce" },
+    { "id": "key_id-test3", "public_hex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025", "expected_key_id": "ed25519:8d39ba50abe50f77" }
+  ],
+  "envelope": [],
+  "invalid": []
+}


### PR DESCRIPTION
## Ace slice 8.3 — ed25519 trust-core golden vectors

Fourth step of the cross-language Ace trust core (after slice 8 SHA-256, 8.1 canonical-JSON, 8.2 package_hash). Anchors Ace's ed25519 signature primitive (node:crypto, `signing.ts`) with a four-layer golden-vector fixture so a future Rust/F#/C# Ace verifies + produces Ace signatures identically. **No production code change** — `signing.ts` is untouched (confirmed empty diff); the fixture + asserting oracle are the deliverable.

Spec: `docs/agendas/ace-package-manager/2026-06-02-ace-slice8.3-ed25519-golden-vectors-design.md` (#6614, merged). Plan in this PR.

### What landed (2 tasks, subagent-driven; two-stage review per task + final holistic — all APPROVED)

`tests/cross-verification/ed25519/` (mirrors the sha256 / package-hash oracles): `vectors.json` + `cross-verify.ts` (asserts every vector, exit-non-zero on mismatch) + `ts-output.json`. Four layers:

- **RFC 8032 §7.1 raw conformance** (4 vectors) — the *published* vectors (fetched from rfc-editor.org, spot-confirmed byte-identical by reviewers). node:crypto imports the raw keys via JWK, **verifies** the published signature AND **deterministically sign-reproduces** it byte-for-byte → proves node:crypto ≡ RFC 8032 (the cross-language anchor).
- **key_id derivation** (3 vectors) — public key → SPKI-DER → sha256 → `"ed25519:"+16hex`; expected values **independently re-derived via Python `cryptography`** (not TS-vs-TS).
- **Ace signature envelope** (1 vector) — a fixed test keypair signs a canonical manifest (8.1) → `{ algo, key_id, sig }` via `signManifest`; the committed sig **independently verified by Python `cryptography`** over the canonical bytes (genuinely signs, not echoed).
- **invalid-rejection** (4 vectors) — `no-signature` / `unsupported-algo` / `untrusted-key` / `bad-signature`, each hitting a *distinct* `verifySignature` branch in order (reviewer-confirmed `bad-signature` genuinely reaches the crypto step via trusted-key + tampered-manifest, not an earlier short-circuit).

### Independent verification (assert-don't-skip)

RFC 8032 vectors ARE the independent source for raw ed25519; key_id + envelope expected values independently re-derived/verified by Python `cryptography` (a second, separate ed25519 + SPKI-DER + sha256 impl). No layer is a TS-vs-TS tautology. The final holistic review re-reproduced all three independent anchors from scratch.

### Gates

`cross-verify.ts` → `rfc8032=4 key_id=3 envelope=1 invalid=4, 0 mismatches` (exit 0) · Python independent: key_id ALL-OK + envelope-sig OK · tsc exit 0 · `bun test tools/ace/` 364/0 (unaffected — no production change) · pure-LF · canary 67.

Same CI reality as 8.1/8.2 (the cross-verify oracle is local/standalone, not CI-gated → controller ran it locally; the wire-into-CI follow-up stands). Standing follow-ups unchanged: CLI untrusted-input hardening + wiring bun-ace/cross-verify into CI. Next: **8.4 index-verify** (composes ed25519 + canonical + key_id-lookup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
