### PR TITLE
proof(B-1007 C2,C3): Beta + Bernoulli message products are commutative groups — Z3 + FsCheck

### DIFF
--- a/tests/Bayesian.Tests/Message.Tests.fs
+++ b/tests/Bayesian.Tests/Message.Tests.fs
@@ -261,3 +261,153 @@ let ``C1 Gaussian divide is the natural-parameter inverse element``
     let a, b = mkProper nuA tauA, mkProper nuB tauB
     let invB = Gaussian.One / b
     gEq (a / b) (a * invB)
+
+// ═══════════════════════════════════════════════════════════════════
+// C2 (B-1007 P0) — Beta message product is a COMMUTATIVE GROUP on the
+// SHIFTED natural parameters (α−1, β−1): product = (α₁−1)+(α₂−1) ⇒
+// α_prod = α₁+α₂−1, divide subtracts, identity = One = Beta(1,1) ⇒
+// naturals (0,0). FsCheck half of the BP-16 cross-check; the Z3 twin
+// (Formal/Z3.Laws.Tests.fs) proves the ideal-real shifted-natural
+// algebra is an abelian group symbolically.
+//
+// Anchor: KFL 2001 (product = combine), Minka 2001 (divide = cavity),
+// Bishop PRML ch.2 (Beta-Bernoulli conjugacy; α−1,β−1 are the exp-family
+// naturals). Wainwright-Jordan 2008 §3.
+//
+// CLOSURE DIFFERS FROM C1: two ARBITRARY proper Betas are NOT closed
+// under product (α=0.1, α'=0.1 ⇒ 0.1+0.1−1 = −0.8 < 0, improper). The
+// meaningful closure is the CONJUGATE update: a proper prior × a
+// LIKELIHOOD (Beta(1+s,1+f), so α≥1,β≥1 ⇒ naturals ≥ 0) stays proper.
+// That is the law tested below — the honest Beta closure, not a false
+// "product of two propers stays proper" claim.
+// ═══════════════════════════════════════════════════════════════════
+
+/// A PROPER Beta (α>0, β>0) built from two raw floats, clamped to a
+/// well-conditioned band so a property failure is a REAL algebraic
+/// divergence. NOTE: proper ≠ closed-under-product for Beta (see header).
+let private mkProperBeta (aRaw: float) (bRaw: float) : Beta =
+    let clamp lo hi x = max lo (min hi x)
+    { Alpha = clamp 1.0e-6 1.0e6 (abs aRaw)
+      Beta = clamp 1.0e-6 1.0e6 (abs bRaw) }
+
+/// A LIKELIHOOD Beta = Beta(1+s, 1+f) with s,f ≥ 0, so α≥1 ∧ β≥1
+/// (shifted-naturals ≥ 0). Product of a proper prior with this stays
+/// proper — the conjugate-update closure.
+let private mkLikelihoodBeta (sRaw: float) (fRaw: float) : Beta =
+    let clampNonNeg hi x = max 0.0 (min hi (abs x))
+    { Alpha = 1.0 + clampNonNeg 1.0e6 sRaw
+      Beta = 1.0 + clampNonNeg 1.0e6 fRaw }
+
+/// Beta equality on the (α, β) parameters directly within tolerance. DO NOT widen.
+let private gEqBeta (a: Beta) (b: Beta) : bool =
+    let tol = 1e-7
+    abs (a.Alpha - b.Alpha) <= tol && abs (a.Beta - b.Beta) <= tol
+
+[<Property>]
+let ``C2 Beta product is associative``
+    (NormalFloat aA) (NormalFloat bA) (NormalFloat aB) (NormalFloat bB) (NormalFloat aC) (NormalFloat bC) =
+    let a, b, c = mkProperBeta aA bA, mkProperBeta aB bB, mkProperBeta aC bC
+    gEqBeta ((a * b) * c) (a * (b * c))
+
+[<Property>]
+let ``C2 Beta product is commutative``
+    (NormalFloat aA) (NormalFloat bA) (NormalFloat aB) (NormalFloat bB) =
+    let a, b = mkProperBeta aA bA, mkProperBeta aB bB
+    gEqBeta (a * b) (b * a)
+
+[<Property>]
+let ``C2 Beta One = Beta(1,1) is the two-sided identity for product``
+    (NormalFloat aA) (NormalFloat bA) =
+    let a = mkProperBeta aA bA
+    gEqBeta (Beta.One * a) a && gEqBeta (a * Beta.One) a
+
+[<Property>]
+let ``C2 Beta divide is the right inverse of product (EP cavity round-trip)``
+    (NormalFloat aA) (NormalFloat bA) (NormalFloat aB) (NormalFloat bB) =
+    let a, b = mkProperBeta aA bA, mkProperBeta aB bB
+    gEqBeta ((a * b) / b) a
+
+[<Property>]
+let ``C2 Beta divide is the shifted-natural inverse element``
+    (NormalFloat aA) (NormalFloat bA) (NormalFloat aB) (NormalFloat bB) =
+    let a, b = mkProperBeta aA bA, mkProperBeta aB bB
+    let invB = Beta.One / b
+    gEqBeta (a / b) (a * invB)
+
+[<Property>]
+let ``C2 Beta proper prior times a likelihood stays proper (conjugate closure)``
+    (NormalFloat aPrior) (NormalFloat bPrior) (NormalFloat s) (NormalFloat f) =
+    // proper prior (α>0,β>0) × likelihood Beta(1+s,1+f) (α≥1,β≥1) ⇒ proper.
+    // This is the HONEST Beta closure — NOT "two arbitrary propers stay proper".
+    let prior = mkProperBeta aPrior bPrior
+    let like = mkLikelihoodBeta s f
+    Beta.isProper (prior * like)
+
+// ═══════════════════════════════════════════════════════════════════
+// C3 (B-1007 P0) — Bernoulli message product is a COMMUTATIVE GROUP via
+// LOG-ODDS addition: ℓ = log(p/(1−p)); product adds log-odds (the impl
+// multiplies true/false masses + renormalizes, t/(t+f), which IS
+// log-odds add), divide subtracts, identity = One = P(true)=0.5 ⇒ ℓ=0.
+// FsCheck half of the BP-16 cross-check; the Z3 twin proves log-odds
+// add is an abelian group symbolically.
+//
+// Anchor: KFL 2001 / Minka 2001 / exponential-family (log-odds is the
+// Bernoulli natural parameter). Finite log-odds ⟺ p ∈ (0,1) (proper);
+// p ∈ {0,1} is a hard factor, not a message. Generators stay strictly
+// inside (0,1) via logistic of a bounded log-odds — both keeps the
+// prob-space arithmetic well-conditioned AND models "proper".
+//
+// CLOSURE (unlike Beta) IS unconditional: log-odds add is closed on ℝ,
+// and the logistic ℝ→(0,1) bijection carries that to p ∈ (0,1) — the
+// impl's normalizer t+f is always positive for proper inputs.
+// ═══════════════════════════════════════════════════════════════════
+
+/// A PROPER Bernoulli (p strictly in (0,1)) built as the logistic of a
+/// bounded log-odds (|ℓ| ≤ 8 ⇒ p ∈ ~(3e-4, 1−3e-4)) — keeps the
+/// probability-space product/divide well-conditioned so a property
+/// failure is a REAL divergence, not engineered saturation.
+let private mkProperBern (lRaw: float) : Bernoulli =
+    let clamp lo hi x = max lo (min hi x)
+    let l = clamp -8.0 8.0 lRaw
+    { ProbTrue = 1.0 / (1.0 + exp (-l)) }
+
+/// Bernoulli equality on P(true) within tolerance. DO NOT widen.
+let private gEqBern (a: Bernoulli) (b: Bernoulli) : bool =
+    abs (a.ProbTrue - b.ProbTrue) <= 1e-7
+
+[<Property>]
+let ``C3 Bernoulli product is associative``
+    (NormalFloat lA) (NormalFloat lB) (NormalFloat lC) =
+    let a, b, c = mkProperBern lA, mkProperBern lB, mkProperBern lC
+    gEqBern ((a * b) * c) (a * (b * c))
+
+[<Property>]
+let ``C3 Bernoulli product is commutative`` (NormalFloat lA) (NormalFloat lB) =
+    let a, b = mkProperBern lA, mkProperBern lB
+    gEqBern (a * b) (b * a)
+
+[<Property>]
+let ``C3 Bernoulli One = 0.5 is the two-sided identity for product`` (NormalFloat lA) =
+    let a = mkProperBern lA
+    gEqBern (Bernoulli.One * a) a && gEqBern (a * Bernoulli.One) a
+
+[<Property>]
+let ``C3 Bernoulli divide is the right inverse of product (EP cavity round-trip)``
+    (NormalFloat lA) (NormalFloat lB) =
+    let a, b = mkProperBern lA, mkProperBern lB
+    gEqBern ((a * b) / b) a
+
+[<Property>]
+let ``C3 Bernoulli divide is the log-odds inverse element``
+    (NormalFloat lA) (NormalFloat lB) =
+    let a, b = mkProperBern lA, mkProperBern lB
+    let invB = Bernoulli.One / b
+    gEqBern (a / b) (a * invB)
+
+[<Property>]
+let ``C3 Bernoulli product of two proper messages stays proper (closure)``
+    (NormalFloat lA) (NormalFloat lB) =
+    // p ∈ (0,1) ∧ p' ∈ (0,1) ⇒ t,f > 0 ⇒ t/(t+f) ∈ (0,1). Unconditional
+    // closure (log-odds add closed on ℝ; logistic bijection to (0,1)).
+    let a, b = mkProperBern lA, mkProperBern lB
+    Bernoulli.isProper (a * b)

--- a/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
@@ -524,3 +524,131 @@ let ``Z3 proves proper Gaussians are closed under product, guarded (C1)`` () =
         "                 (> (+ tauA tauB) 0.0))))\n" +
         "(check-sat)\n"
     z3ScriptHolds "C1 proper closed under product (guarded)" script
+
+// ═══════════════════════════════════════════════════════════════════
+// B-1007 C2 — Beta message product is an ABELIAN GROUP on the SHIFTED
+// natural parameters. The impl works on (α, β) directly: product =
+// α₁+α₂−1, divide = α₁−α₂+1, identity One = Beta(1,1). These ARE the
+// abelian-group axioms on the shifted naturals (n = α−1), proven here
+// symbolically over the ideal reals (QF_LRA). The FsCheck twin proves
+// the float impl conforms. Anchor: Bishop PRML ch.2, KFL 2001, Minka
+// 2001. Lemmas use the α-coordinate; β is identical by symmetry.
+//
+// CLOSURE differs from C1: proper (α>0) is NOT closed under product
+// (0.1+0.1−1<0). The honest closure is the conjugate update — proper
+// prior (α>0) × likelihood (α≥1) ⇒ proper. Stated as the guarded lemma.
+// ═══════════════════════════════════════════════════════════════════
+
+[<Fact>]
+let ``Z3 proves Beta product is associative on shifted naturals (C2)`` () =
+    let script =
+        "(declare-const aA Real)\n(declare-const aB Real)\n(declare-const aC Real)\n" +
+        // (a*b)*c = ((aA+aB-1)+aC-1) ; a*(b*c) = (aA+(aB+aC-1)-1)
+        "(assert (not (= (- (+ (- (+ aA aB) 1.0) aC) 1.0)\n" +
+        "                (- (+ aA (- (+ aB aC) 1.0)) 1.0))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C2 Beta product associative (shifted naturals)" script
+
+[<Fact>]
+let ``Z3 proves Beta product is commutative on shifted naturals (C2)`` () =
+    let script =
+        "(declare-const aA Real)\n(declare-const aB Real)\n" +
+        "(assert (not (= (- (+ aA aB) 1.0) (- (+ aB aA) 1.0))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C2 Beta product commutative" script
+
+[<Fact>]
+let ``Z3 proves Beta One = Beta(1,1) is the identity for product (C2)`` () =
+    let script =
+        "(declare-const aA Real)\n" +
+        // a * One : aA + 1 - 1 = aA ; One * a : 1 + aA - 1 = aA  (One.Alpha = 1)
+        "(assert (not (and (= (- (+ aA 1.0) 1.0) aA)\n" +
+        "                  (= (- (+ 1.0 aA) 1.0) aA))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C2 Beta product identity (Beta(1,1))" script
+
+[<Fact>]
+let ``Z3 proves Beta divide round-trips the product, the EP cavity (C2)`` () =
+    let script =
+        "(declare-const aA Real)\n(declare-const aB Real)\n" +
+        // (a*b)/b = ((aA+aB-1) - aB + 1) = aA
+        "(assert (not (= (+ (- (- (+ aA aB) 1.0) aB) 1.0) aA)))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C2 Beta cavity round-trip ((a*b)/b = a)" script
+
+[<Fact>]
+let ``Z3 proves Beta divide is the shifted-natural inverse element (C2)`` () =
+    let script =
+        "(declare-const aA Real)\n(declare-const aB Real)\n" +
+        // a/b = aA - aB + 1 ; a*(One/b) where One/b = 2 - aB :  aA + (2-aB) - 1 = aA - aB + 1
+        "(assert (not (= (+ (- aA aB) 1.0)\n" +
+        "                (- (+ aA (- 2.0 aB)) 1.0))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C2 Beta divide = multiply by inverse" script
+
+[<Fact>]
+let ``Z3 proves proper Beta prior times a likelihood stays proper, guarded (C2)`` () =
+    let script =
+        "(declare-const aPrior Real)\n(declare-const aLike Real)\n" +
+        // proper prior (aPrior>0) AND likelihood (aLike>=1) ⇒ aPrior+aLike-1 > 0.
+        // NOT unconditional: two arbitrary propers can give α<0 (improper).
+        "(assert (not (=> (and (> aPrior 0.0) (>= aLike 1.0))\n" +
+        "                 (> (- (+ aPrior aLike) 1.0) 0.0))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C2 Beta conjugate closure (prior x likelihood, guarded)" script
+
+// ═══════════════════════════════════════════════════════════════════
+// B-1007 C3 — Bernoulli message product is an ABELIAN GROUP via LOG-ODDS
+// addition. The impl computes in probability space (t/(t+f)); that is
+// mathematically log-odds add. Here Z3 proves the LOG-ODDS model
+// (ℓ ∈ ℝ, product = ℓ_a + ℓ_b, identity One = 0, inverse = negation) is
+// an abelian group over the ideal reals; the FsCheck twin proves the
+// prob-space float impl conforms. Anchor: KFL 2001, Minka 2001,
+// exponential-family (log-odds = Bernoulli natural parameter).
+//
+// CLOSURE is unconditional: ℝ is closed under +, and the logistic
+// ℝ→(0,1) bijection carries that to p ∈ (0,1) — so unlike Beta, any two
+// proper Bernoullis have a proper product. (No guard needed; the
+// FsCheck closure property exercises the prob-space normalizer.)
+// ═══════════════════════════════════════════════════════════════════
+
+[<Fact>]
+let ``Z3 proves Bernoulli product is associative in log-odds (C3)`` () =
+    let script =
+        "(declare-const lA Real)\n(declare-const lB Real)\n(declare-const lC Real)\n" +
+        "(assert (not (= (+ (+ lA lB) lC) (+ lA (+ lB lC)))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C3 Bernoulli product associative (log-odds)" script
+
+[<Fact>]
+let ``Z3 proves Bernoulli product is commutative in log-odds (C3)`` () =
+    let script =
+        "(declare-const lA Real)\n(declare-const lB Real)\n" +
+        "(assert (not (= (+ lA lB) (+ lB lA))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C3 Bernoulli product commutative" script
+
+[<Fact>]
+let ``Z3 proves One = 0.5 (log-odds 0) is the identity for Bernoulli product (C3)`` () =
+    let script =
+        "(declare-const lA Real)\n" +
+        "(assert (not (and (= (+ lA 0.0) lA) (= (+ 0.0 lA) lA))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C3 Bernoulli product identity (log-odds 0)" script
+
+[<Fact>]
+let ``Z3 proves Bernoulli divide is the inverse via log-odds negation (C3)`` () =
+    let script =
+        "(declare-const lA Real)\n" +
+        "(assert (not (and (= (- lA lA) 0.0)\n" +
+        "                  (= (+ lA (- 0.0 lA)) 0.0))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C3 Bernoulli divide = log-odds negation" script
+
+[<Fact>]
+let ``Z3 proves Bernoulli divide round-trips the product, the EP cavity (C3)`` () =
+    let script =
+        "(declare-const lA Real)\n(declare-const lB Real)\n" +
+        "(assert (not (= (- (+ lA lB) lB) lA)))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C3 Bernoulli cavity round-trip ((a*b)/b = a)" script


### PR DESCRIPTION
## What

The next two P0 proofs in Soraya's cadence after C1. Both prove the message product is an **abelian group**, each with two independent tools (BP-16).

- **C2 — Beta** on **shifted naturals** (α−1, β−1): product = α₁+α₂−1, divide = α₁−α₂+1, identity = `One` = Beta(1,1). **Z3** (6 lemmas, QF_LRA) proves the shifted-natural algebra is an abelian group; **FsCheck** (6 props) proves the float impl conforms. Anchor: Bishop PRML ch.2 + KFL 2001 + Minka 2001.
- **C3 — Bernoulli** via **log-odds add**: the impl multiplies true/false masses + renormalizes (`t/(t+f)`) = log-odds add, identity = `One` = P(true)=0.5 (ℓ=0). **Z3** (5 lemmas) proves the log-odds model is an abelian group; **FsCheck** (6 props) proves the prob-space impl conforms. Anchor: KFL 2001 + Minka 2001 + exp-family.

## The interesting finding: closure is NOT uniform across families

This is where authoring-against-the-actual-math mattered:

| Family | Proper closed under product? |
|---|---|
| Gaussian (C1) | **Yes** — τ+τ′ > 0 |
| **Beta (C2)** | **No** — α=0.1, α′=0.1 ⇒ 0.1+0.1−1 < 0 (improper). The honest closure is the **conjugate update**: proper prior × likelihood (α≥1) ⇒ proper. Tested as the guarded law — a naive "two propers stay proper" claim would be **false** and is deliberately avoided. |
| Bernoulli (C3) | **Yes, unconditionally** — log-odds add closed on ℝ; logistic ℝ→(0,1) bijection. |

## Verification

**Run locally with z3 on PATH:** FsCheck **12/12**, Z3 **11/11**, **0 skipped**.

## Discipline

- Per **formal-proof-first**: closes acceptance-half **(a) proof** for C2+C3; the hex/4×4 **lineage edge (half b)** is owed before *canonical*.
- Cleanroom (no Infer.NET source); authored following Soraya's C1→C14 routing.
- ⚠️ z3 still **self-skips in CI** (B-1009 — z3 not in `gate.yml`); verified locally instead. The FsCheck halves run in CI normally.

Next in the cadence: C11/C10 (MessageBatch — incl. the false "bit-exact, proven" prose) + C6 (NaN-safe `moved`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)