### PR TITLE
proof(B-1007 C11,C10,C6): batch↔scalar + round-trip + NaN-safe convergence — FsCheck + Z3; fix false "bit-exact" prose

### DIFF
--- a/src/Bayesian/MessageBatch.fs
+++ b/src/Bayesian/MessageBatch.fs
@@ -16,8 +16,13 @@ open Apache.Arrow.Types
 ///
 /// Each family supplies an `IColumnar<'M>` adapter (its natural-parameter
 /// columns): Gaussian = `(ν, τ)` (identity); Beta = `(α-1, β-1)`;
-/// Bernoulli = `log-odds`. The columnar `product`/`divide` are bit-exact
-/// equivalent to the scalar `Message` ops (proven in the tests).
+/// Bernoulli = `log-odds`. The columnar `product`/`divide` agree with the
+/// scalar `Message` ops on the VALUE, within float tolerance (property-
+/// tested: B-1007 C11). They are bit-exact only for **Gaussian** (identity
+/// columns, same adds in the same order); for **Beta** they differ by
+/// last-ULP reassociation ((α-1)+(α'-1)+1 vs α+α'-1), and for **Bernoulli**
+/// by representation (scalar product is computed in probability space
+/// `t/(t+f)`, the column is log-odds add) — value-equivalent, not bit-equal.
 
 /// A columnar batch in natural parameters: `Columns.[k].[i]` is the k-th
 /// natural parameter of the i-th message. `product`/`divide` are
@@ -91,8 +96,10 @@ module NaturalBatch =
     let toMessages (c: IColumnar<'M>) (b: NaturalBatch) : 'M[] = c.OfColumns b.Columns
 
     /// Batched message **product** = column-wise vector ADD (natural
-    /// parameters). Bit-exact equivalent to the scalar `product`,
-    /// element-wise — and SIMD-friendly over the contiguous columns.
+    /// parameters). Agrees with the scalar `product` element-wise on the
+    /// VALUE within float tolerance (B-1007 C11; bit-exact for Gaussian,
+    /// value-equal for Beta/Bernoulli) — and SIMD-friendly over the
+    /// contiguous columns.
     let product (a: NaturalBatch) (b: NaturalBatch) : NaturalBatch =
         { Columns = Array.map2 (fun (x: float[]) (y: float[]) -> Array.map2 (+) x y) a.Columns b.Columns }
 

--- a/tests/Bayesian.Tests/Message.Tests.fs
+++ b/tests/Bayesian.Tests/Message.Tests.fs
@@ -411,3 +411,49 @@ let ``C3 Bernoulli product of two proper messages stays proper (closure)``
     // closure (log-odds add closed on ℝ; logistic bijection to (0,1)).
     let a, b = mkProperBern lA, mkProperBern lB
     Bernoulli.isProper (a * b)
+// C6 (B-1007 P0) — convergence detection is NaN/divergence-SAFE. The BP
+// fixpoint loop (FactorGraph.runToFixpoint) decides convergence with the
+// residual test `not (distance x y <= tol)` — written that way (not
+// `d > tol`) precisely so a NaN/∞ residual counts as MOVED: `NaN <= tol`
+// is false in IEEE-754, so `not false` = moved ⇒ a divergent run can
+// NEVER falsely report convergence. The per-family `distance` feeds that
+// invariant by returning ∞ for any non-finite message.
+//
+// FsCheck half: the real-float `distance` returns 0 for identical (⇒
+// converged) and +∞ for a non-finite message (⇒ moved), per family. The
+// Z3 twin (Formal/Z3.Laws.Tests.fs) proves the boolean `not (d<=tol)`
+// logic incl. the IEEE NaN/∞ cases (QF_FP) + the finite threshold (QF_LRA).
+// ═══════════════════════════════════════════════════════════════════
+
+let private tolC6 = 1e-9
+/// The exact residual test from FactorGraph.runToFixpoint: NaN/∞ ⇒ moved.
+let private movedC6 (d: float) : bool = not (d <= tolC6)
+
+[<Property>]
+let ``C6 Gaussian identical converges, non-finite residual moves (never false-converged)``
+    (NormalFloat nu) (NormalFloat tau) =
+    let g = mkProper nu tau
+    let bad : Gaussian = { PrecisionMean = nan; Precision = 1.0 }
+    not (movedC6 (Gaussian.distance g g))                        // identical ⇒ converged
+    && System.Double.IsPositiveInfinity (Gaussian.distance g bad) // non-finite ⇒ ∞
+    && movedC6 (Gaussian.distance g bad)                         // ∞ ⇒ moved
+
+[<Property>]
+let ``C6 Beta identical converges, non-finite residual moves``
+    (NormalFloat aA) (NormalFloat bA) =
+    let clamp lo hi x = max lo (min hi x)
+    let d : Beta = { Alpha = clamp 1.0e-6 1.0e6 (abs aA); Beta = clamp 1.0e-6 1.0e6 (abs bA) }
+    let bad : Beta = { Alpha = nan; Beta = 1.0 }
+    not (movedC6 (Beta.distance d d))
+    && System.Double.IsPositiveInfinity (Beta.distance d bad)
+    && movedC6 (Beta.distance d bad)
+
+[<Property>]
+let ``C6 Bernoulli identical converges, non-finite residual moves``
+    (NormalFloat l) =
+    let p = 1.0 / (1.0 + exp (-(max -8.0 (min 8.0 l))))
+    let b : Bernoulli = { ProbTrue = p }
+    let bad : Bernoulli = { ProbTrue = nan }
+    not (movedC6 (Bernoulli.distance b b))
+    && System.Double.IsPositiveInfinity (Bernoulli.distance b bad)
+    && movedC6 (Bernoulli.distance b bad)

--- a/tests/Bayesian.Tests/MessageBatch.Tests.fs
+++ b/tests/Bayesian.Tests/MessageBatch.Tests.fs
@@ -1,13 +1,19 @@
 module Zeta.Bayesian.Tests.MessageBatchTests
+#nowarn "0893"
 
 open FsUnit.Xunit
 open global.Xunit
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.Xunit
 open Zeta.Bayesian
 
 // Columnar message batches (B-1000) — the Apache Arrow in-memory store
 // for bit-efficient message passing. The load-bearing property: batched
-// column-wise product/divide (natural-param vector add/sub) is bit-exact
-// equivalent to the scalar Message ops, for every family — AND the
+// column-wise product/divide (natural-param vector add/sub) AGREES with
+// the scalar Message ops on the VALUE within float tolerance, for every
+// family (B-1007 C11) — bit-exact for Gaussian, value-equal for
+// Beta/Bernoulli (reassociation / prob-space-vs-log-odds) — AND the
 // columns round-trip through an Arrow RecordBatch. "The compilers don't lie."
 
 // ─── Batched product = scalar product, element-wise, per family ───
@@ -83,3 +89,93 @@ let ``columnar pack/unpack is the identity and reports dim and count`` () =
     for i in 0 .. 2 do
         Gaussian.mean back.[i] |> should (equalWithin 1e-9) (Gaussian.mean gs.[i])
         Gaussian.variance back.[i] |> should (equalWithin 1e-9) (Gaussian.variance gs.[i])
+
+// ═══════════════════════════════════════════════════════════════════
+// C11 (B-1007 P0) — columnar batch product AGREES with the scalar
+// product, message-by-message, within float tolerance, per family.
+// This is the HONEST claim: the prose previously said "bit-exact,
+// proven in tests" which is FALSE for Beta (last-ULP reassociation:
+// (α-1)+(α'-1)+1 vs α+α'-1) and Bernoulli (scalar = prob-space t/(t+f),
+// column = log-odds add — value-equal, different bits). Gaussian IS
+// bit-exact; the property below asserts value-equality within tolerance
+// for all three (and Gaussian is additionally checked bit-exact).
+//
+// C10 (B-1007 P0) — round-trip toMessages ∘ ofMessages = id, per family,
+// within tolerance. Bernoulli is LOSSY at p→0/1 (log-odds saturates), so
+// its generator stays strictly inside (0,1) via logistic of bounded
+// log-odds — the honest "proper round-trips" claim, not "all p round-trip".
+// FsCheck half; no Z3 (these are float-conformance claims, not symbolic).
+// ═══════════════════════════════════════════════════════════════════
+
+let private mkG (nuRaw: float) (tauRaw: float) : Gaussian =
+    let clamp lo hi x = max lo (min hi x)
+    { PrecisionMean = clamp -1.0e6 1.0e6 nuRaw; Precision = clamp 1.0e-6 1.0e6 (abs tauRaw) }
+
+let private mkB (aRaw: float) (bRaw: float) : Beta =
+    let clamp lo hi x = max lo (min hi x)
+    { Alpha = clamp 1.0e-6 1.0e6 (abs aRaw); Beta = clamp 1.0e-6 1.0e6 (abs bRaw) }
+
+let private mkBern (lRaw: float) : Bernoulli =
+    let l = max -8.0 (min 8.0 lRaw)
+    { ProbTrue = 1.0 / (1.0 + exp (-l)) }
+
+let private batchProd1 (c: IColumnar<'M>) (a: 'M) (b: 'M) : 'M =
+    (NaturalBatch.product (NaturalBatch.ofMessages c [| a |]) (NaturalBatch.ofMessages c [| b |])
+     |> NaturalBatch.toMessages c).[0]
+
+let private roundTrip1 (c: IColumnar<'M>) (m: 'M) : 'M =
+    (NaturalBatch.toMessages c (NaturalBatch.ofMessages c [| m |])).[0]
+
+// ── C11: batch product = scalar product, per family ──
+
+[<Property>]
+let ``C11 Gaussian batch product = scalar product (bit-exact)``
+    (NormalFloat nuA) (NormalFloat tauA) (NormalFloat nuB) (NormalFloat tauB) =
+    let a, b = mkG nuA tauA, mkG nuB tauB
+    let bp = batchProd1 Columnar.gaussian a b
+    let sp = a * b
+    // Gaussian columns are the identity (ν,τ) and adds happen in the same
+    // order ⇒ genuinely bit-exact (exact equality, no tolerance).
+    bp.PrecisionMean = sp.PrecisionMean && bp.Precision = sp.Precision
+
+[<Property>]
+let ``C11 Beta batch product = scalar product (value-equal within tol)``
+    (NormalFloat aA) (NormalFloat bA) (NormalFloat aB) (NormalFloat bB) =
+    let a, b = mkB aA bA, mkB aB bB
+    let bp = batchProd1 Columnar.beta a b
+    let sp = a * b
+    abs (bp.Alpha - sp.Alpha) <= 1e-7 && abs (bp.Beta - sp.Beta) <= 1e-7
+
+[<Property>]
+let ``C11 Bernoulli batch product = scalar product (value-equal within tol)``
+    (NormalFloat lA) (NormalFloat lB) =
+    let a, b = mkBern lA, mkBern lB
+    let bp = batchProd1 Columnar.bernoulli a b
+    let sp = a * b
+    abs (bp.ProbTrue - sp.ProbTrue) <= 1e-7
+
+// ── C10: round-trip toMessages ∘ ofMessages = id, per family ──
+
+[<Property>]
+let ``C10 Gaussian round-trips through the columnar batch (bit-exact)``
+    (NormalFloat nuA) (NormalFloat tauA) =
+    let g = mkG nuA tauA
+    let r = roundTrip1 Columnar.gaussian g
+    r.PrecisionMean = g.PrecisionMean && r.Precision = g.Precision
+
+[<Property>]
+let ``C10 Beta round-trips through the columnar batch (within tol)``
+    (NormalFloat aA) (NormalFloat bA) =
+    let d = mkB aA bA
+    let r = roundTrip1 Columnar.beta d
+    abs (r.Alpha - d.Alpha) <= 1e-7 && abs (r.Beta - d.Beta) <= 1e-7
+
+[<Property>]
+let ``C10 proper Bernoulli round-trips through the columnar batch (within tol; lossy at p->0/1)``
+    (NormalFloat lA) =
+    // proper p strictly inside (0,1) via bounded log-odds round-trips; the
+    // log-odds representation is LOSSY at p→0/1 (saturation), so this is the
+    // honest "proper round-trips" claim, not "all p".
+    let b = mkBern lA
+    let r = roundTrip1 Columnar.bernoulli b
+    abs (r.ProbTrue - b.ProbTrue) <= 1e-7

--- a/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
@@ -652,3 +652,48 @@ let ``Z3 proves Bernoulli divide round-trips the product, the EP cavity (C3)`` (
         "(assert (not (= (- (+ lA lB) lB) lA)))\n" +
         "(check-sat)\n"
     z3ScriptHolds "C3 Bernoulli cavity round-trip ((a*b)/b = a)" script
+// B-1007 C6 — BP convergence detection (`not (distance x y <= tol)`) is
+// NaN/∞-SAFE: a divergent run can never falsely report convergence. The
+// NaN/∞ cases are IEEE-754 facts, so they are proven in Z3's
+// floating-point theory (QF_FP); the finite threshold is proven in
+// QF_LRA. The FsCheck twin (Bayesian.Tests/Message.Tests.fs) exercises
+// the real-float per-family `distance` (returns ∞ for non-finite). Anchor:
+// factory-native; the `moved` invariant in FactorGraph.runToFixpoint.
+// ═══════════════════════════════════════════════════════════════════
+
+[<Fact>]
+let ``Z3 proves a NaN residual counts as moved, never converged (C6)`` () =
+    // moved = not (fp.leq d tol). For NaN d, (fp.leq NaN tol) is FALSE ∀ tol,
+    // so moved is TRUE. Assert the negation (fp.leq d tol) under isNaN d ⇒ UNSAT.
+    let script =
+        "(set-logic QF_FP)\n" +
+        "(declare-const d (_ FloatingPoint 11 53))\n" +
+        "(declare-const tol (_ FloatingPoint 11 53))\n" +
+        "(assert (fp.isNaN d))\n" +
+        "(assert (fp.leq d tol))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C6 NaN residual is always moved" script
+
+[<Fact>]
+let ``Z3 proves a +infinity residual counts as moved for any finite tol (C6)`` () =
+    // (fp.leq +oo finite-tol) is FALSE, so +∞ residual is always moved.
+    let script =
+        "(set-logic QF_FP)\n" +
+        "(declare-const tol (_ FloatingPoint 11 53))\n" +
+        "(assert (not (fp.isInfinite tol)))\n" +
+        "(assert (not (fp.isNaN tol)))\n" +
+        "(assert (fp.leq (_ +oo 11 53) tol))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C6 +inf residual is always moved (finite tol)" script
+
+[<Fact>]
+let ``Z3 proves the finite convergence threshold has no converged-and-moved overlap (C6)`` () =
+    // For a finite residual d ≥ 0 and tol ≥ 0, converged (d ≤ tol) and moved
+    // (d > tol) are mutually exclusive — no d is BOTH. UNSAT ⇒ the threshold
+    // is an exact partition (no finite residual is misclassified).
+    let script =
+        "(declare-const d Real)\n(declare-const tol Real)\n" +
+        "(assert (>= d 0.0))\n(assert (>= tol 0.0))\n" +
+        "(assert (and (<= d tol) (> d tol)))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C6 finite threshold has no converged-and-moved overlap" script


### PR DESCRIPTION
## What

Closes the next three P0 items in Soraya's cadence (C1/C2/C3 already on main).

- **C11 — columnar batch product = scalar product**, per family, within float tolerance (FsCheck). **Fixes the false prose** B-1007 flagged: `src/MessageBatch.fs` + the test header claimed *"bit-exact equivalent (proven in tests)"* — **false** for Beta (last-ULP reassociation `(α-1)+(α'-1)+1` vs `α+α'-1`) and Bernoulli (scalar = prob-space `t/(t+f)`, column = log-odds add → value-equal, different bits). Only **Gaussian** is genuinely bit-exact (asserted exactly); Beta/Bernoulli value-equal within tol. Prose now honest.
- **C10 — round-trip** `toMessages ∘ ofMessages = id`, per family (FsCheck). Gaussian bit-exact; Beta within tol; **Bernoulli lossy at p→0/1** (log-odds saturation) → generator stays strictly inside (0,1), the honest "proper round-trips" claim.
- **C6 — BP convergence detection is NaN/divergence-SAFE.** `runToFixpoint` uses `not (distance x y <= tol)` so a NaN/∞ residual counts as **MOVED** (`NaN <= tol` is false in IEEE-754) ⇒ a divergent run can **never** falsely report convergence. Proven **both ways**:
  - **Z3 QF_FP** (3 lemmas): NaN ⇒ moved; +∞ ⇒ moved (any finite tol); finite threshold has no converged-and-moved overlap (QF_LRA). The IEEE NaN/∞ facts proven in Z3's *floating-point theory* — not just asserted in a code comment.
  - **FsCheck** (3 props): per-family `distance` returns 0 for identical (⇒ converged) and +∞ for a non-finite message (⇒ moved).

## Verification

**Run locally with z3 on PATH (on the rebased tree):** FsCheck **21/21** (C2/C3/C6/C10/C11), Z3 **14/14** (Beta/Bernoulli/C6), **0 skipped**.

## Discipline

- Rebased onto main after #6624 (C2/C3) merged; the Z3 + Message test-file append overlaps were hand-resolved (keep both) and re-verified green.
- Per **formal-proof-first**: closes acceptance-half **(a)** for C6/C10/C11; hex/4×4 **lineage edge (half b)** owed before *canonical*. C11 clears B-1007's flagged false-"proven" prose.
- ⚠️ z3 still **self-skips in CI** (B-1009 — not in `gate.yml`); verified locally. FsCheck halves run in CI.

That's the **entire P0 tier** of B-1007 (C1/C2/C3/C6/C10/C11) now proven, pending this merge. Next is P1 (C5 BP-exact-on-trees via TLA+, C7 EP cavities, C4/C12/C13/C14) — and **B-1009** so the Z3 halves stop self-skipping in the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)