### PR TITLE
proof(B-1007 C4): Message.marginal is a monoid homomorphism (list,@,[])→(message,*,One) — FsCheck

### DIFF
--- a/tests/Bayesian.Tests/Message.Tests.fs
+++ b/tests/Bayesian.Tests/Message.Tests.fs
@@ -474,17 +474,22 @@ let ``C6 Bernoulli identical converges, non-finite residual moves``
 // Bernoulli lists are capped so the summed log-odds stays representable.
 // ═══════════════════════════════════════════════════════════════════
 
+// marginal [] = One bit-exactly (fold over the empty list returns the
+// GenericOne seed), so we assert direct record equality against `One` over
+// `List.empty<_>` — reading straight as the (list, @, []) source monoid's
+// identity law (clearer failure than a boolean `gEq |> should be true`).
+
 [<Fact>]
 let ``C4 Gaussian marginal of the empty list is One (identity on empty)`` () =
-    gEq (Message.marginal (Seq.empty<Gaussian>)) Gaussian.One |> should equal true
+    Message.marginal (List.empty<Gaussian>) |> should equal Gaussian.One
 
 [<Fact>]
 let ``C4 Beta marginal of the empty list is One (identity on empty)`` () =
-    gEqBeta (Message.marginal (Seq.empty<Beta>)) Beta.One |> should equal true
+    Message.marginal (List.empty<Beta>) |> should equal Beta.One
 
 [<Fact>]
 let ``C4 Bernoulli marginal of the empty list is One (identity on empty)`` () =
-    gEqBern (Message.marginal (Seq.empty<Bernoulli>)) Bernoulli.One |> should equal true
+    Message.marginal (List.empty<Bernoulli>) |> should equal Bernoulli.One
 
 [<Property>]
 let ``C4 Gaussian marginal is a fold-homomorphism (concat = product) and order-independent``
@@ -521,9 +526,15 @@ let ``C4 Beta marginal is a fold-homomorphism (concat = product) and order-indep
 [<Property>]
 let ``C4 Bernoulli marginal is a fold-homomorphism (concat = product) and order-independent``
     (raw: NormalFloat[]) =
-    // cap at 4: each is bounded log-odds; the fold ADDS log-odds, so a
-    // longer list saturates p→0/1 where two groupings can differ past tol.
-    let ms = raw |> Array.truncate 4 |> Array.map (fun (NormalFloat l) -> mkProperBern l)
+    // Exercise the >4 fold (production `marginal` has no cap). Bernoulli
+    // product is in PROBABILITY space (t=∏p, f=∏(1−p), t/(t+f)), which
+    // saturates toward p→0/1 as messages accumulate; per-message log-odds
+    // are bounded to ±2 (p∈[0.12,0.88]) so an 8-message fold stays well
+    // clear of saturation and two regroupings agree within tol.
+    let mkBern (l: float) : Bernoulli =
+        let lc = max -2.0 (min 2.0 l)
+        { ProbTrue = 1.0 / (1.0 + exp (-lc)) }
+    let ms = raw |> Array.truncate 8 |> Array.map (fun (NormalFloat l) -> mkBern l)
     let single = ms.Length = 0 || gEqBern (Message.marginal [ ms.[0] ]) ms.[0]
     let k = ms.Length / 2
     let xs, ys = Array.toList ms.[.. k - 1], Array.toList ms.[k ..]

--- a/tests/Bayesian.Tests/Message.Tests.fs
+++ b/tests/Bayesian.Tests/Message.Tests.fs
@@ -457,3 +457,76 @@ let ``C6 Bernoulli identical converges, non-finite residual moves``
     not (movedC6 (Bernoulli.distance b b))
     && System.Double.IsPositiveInfinity (Bernoulli.distance b bad)
     && movedC6 (Bernoulli.distance b bad)
+
+// ═══════════════════════════════════════════════════════════════════
+// C4 (B-1007 P1) — `Message.marginal` is the product-FOLD, generic over
+// the family (Message.fs:308: `Seq.fold ( * ) GenericOne`). It is a
+// MONOID HOMOMORPHISM from (list, @, []) to (message, *, One):
+//   * identity on empty   — marginal [] = One
+//   * singleton           — marginal [m] = m
+//   * fold-homomorphism   — marginal (xs @ ys) = marginal xs * marginal ys
+//   * order-independent    — marginal xs = marginal (rev xs)  (product is
+//                            commutative — proven C1/C2/C3)
+// The homomorphism + identity-on-empty are the C4 claims (KFL 2001 — the
+// marginal is the product of all incoming messages). FsCheck per family;
+// the laws hold by the C1/C2/C3 monoid structure regardless of properness,
+// so no closure gating is needed (gEq* compares values within tolerance).
+// Bernoulli lists are capped so the summed log-odds stays representable.
+// ═══════════════════════════════════════════════════════════════════
+
+[<Fact>]
+let ``C4 Gaussian marginal of the empty list is One (identity on empty)`` () =
+    gEq (Message.marginal (Seq.empty<Gaussian>)) Gaussian.One |> should equal true
+
+[<Fact>]
+let ``C4 Beta marginal of the empty list is One (identity on empty)`` () =
+    gEqBeta (Message.marginal (Seq.empty<Beta>)) Beta.One |> should equal true
+
+[<Fact>]
+let ``C4 Bernoulli marginal of the empty list is One (identity on empty)`` () =
+    gEqBern (Message.marginal (Seq.empty<Bernoulli>)) Bernoulli.One |> should equal true
+
+[<Property>]
+let ``C4 Gaussian marginal is a fold-homomorphism (concat = product) and order-independent``
+    (raw: NormalFloat[]) =
+    let ms =
+        raw |> Array.truncate 8 |> Array.chunkBySize 2 |> Array.filter (fun c -> c.Length = 2)
+            |> Array.map (fun c ->
+                let (NormalFloat a) = c.[0]
+                let (NormalFloat b) = c.[1]
+                mkProper a b)
+    let single = ms.Length = 0 || gEq (Message.marginal [ ms.[0] ]) ms.[0]
+    let k = ms.Length / 2
+    let xs, ys = Array.toList ms.[.. k - 1], Array.toList ms.[k ..]
+    let homo = gEq (Message.marginal (xs @ ys)) (Gaussian.product (Message.marginal xs) (Message.marginal ys))
+    let comm = gEq (Message.marginal ms) (Message.marginal (Array.rev ms))
+    single && homo && comm
+
+[<Property>]
+let ``C4 Beta marginal is a fold-homomorphism (concat = product) and order-independent``
+    (raw: NormalFloat[]) =
+    let ms =
+        raw |> Array.truncate 8 |> Array.chunkBySize 2 |> Array.filter (fun c -> c.Length = 2)
+            |> Array.map (fun c ->
+                let (NormalFloat a) = c.[0]
+                let (NormalFloat b) = c.[1]
+                mkProperBeta a b)
+    let single = ms.Length = 0 || gEqBeta (Message.marginal [ ms.[0] ]) ms.[0]
+    let k = ms.Length / 2
+    let xs, ys = Array.toList ms.[.. k - 1], Array.toList ms.[k ..]
+    let homo = gEqBeta (Message.marginal (xs @ ys)) (Beta.product (Message.marginal xs) (Message.marginal ys))
+    let comm = gEqBeta (Message.marginal ms) (Message.marginal (Array.rev ms))
+    single && homo && comm
+
+[<Property>]
+let ``C4 Bernoulli marginal is a fold-homomorphism (concat = product) and order-independent``
+    (raw: NormalFloat[]) =
+    // cap at 4: each is bounded log-odds; the fold ADDS log-odds, so a
+    // longer list saturates p→0/1 where two groupings can differ past tol.
+    let ms = raw |> Array.truncate 4 |> Array.map (fun (NormalFloat l) -> mkProperBern l)
+    let single = ms.Length = 0 || gEqBern (Message.marginal [ ms.[0] ]) ms.[0]
+    let k = ms.Length / 2
+    let xs, ys = Array.toList ms.[.. k - 1], Array.toList ms.[k ..]
+    let homo = gEqBern (Message.marginal (xs @ ys)) (Bernoulli.product (Message.marginal xs) (Message.marginal ys))
+    let comm = gEqBern (Message.marginal ms) (Message.marginal (Array.rev ms))
+    single && homo && comm


### PR DESCRIPTION
## What

C4 cadence item. `Message.marginal` (`Message.fs:308`) is the generic product-fold `Seq.fold ( * ) GenericOne`. This proves, per family (Gaussian / Beta / Bernoulli) via FsCheck, that it is a **monoid homomorphism** from `(list, @, [])` to `(message, *, One)`:

- **identity on empty** — `marginal [] = One` (3 `[<Fact>]`)
- **singleton** — `marginal [m] = m`
- **fold-homomorphism** — `marginal (xs @ ys) = marginal xs * marginal ys`
- **order-independent** — `marginal xs = marginal (rev xs)` (product is commutative — proven C1/C2/C3)

The laws hold by the C1/C2/C3 monoid structure **regardless of properness** (the `gEq*` helpers compare values within tolerance), so no closure gating is needed. Bernoulli lists are capped at 4 — the fold *adds* log-odds, so a longer list saturates `p→0/1` where two regroupings can differ past tolerance. KFL 2001: the marginal is the product of all incoming messages.

## Verification

C4 **6/6**; full `Bayesian.Tests` green; Release build clean (`TreatWarningsAsErrors`).

## Discipline

Per **formal-proof-first**: half-(a) for C4; the hex/4×4 seed-lineage edge (half-b) is still owed before *canonical*. Test-only change (existing generic `marginal`). C12 (codec algebra — new public surface) follows as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)