### PR TITLE
feat+proof(B-1007 C12): the codec algebra — invariant functor closed under id/product/sum (decode∘encode=id) — FsCheck

### DIFF
--- a/src/Core/Codec.fs
+++ b/src/Core/Codec.fs
@@ -29,9 +29,13 @@ module Codec =
     // from component codecs and preserve round-trip by construction (proven
     // in tests/Tests.FSharp/Core/Codec.Tests.fs — B-1007 C12). Prior art:
     // scodec `xmap`/`~`/`|+|`, Haskell `codec`, profunctor-optics.
+    //
+    // NOTE on notation: B-1006 writes the abstract codec as `Codec<a>`; the
+    // concrete F# type here is `ICodec<a, 'Wire, 'Feedback>`. Below, B-1006's
+    // `Codec<a>` ≙ `ICodec<a, _, _>` (the wire/feedback params elided).
 
     /// The **identity** codec — wire = value, total (never declines): the
-    /// algebra's identity element (`Codec<unit>` is `identity<unit>`).
+    /// algebra's identity element (B-1006's `Codec<unit>` ≙ `identity<unit>()`).
     /// `Deserialize ∘ Serialize = id` holds trivially (`Ok` round-trips `Ok`).
     let identity<'T, 'Feedback> () : ICodec<'T, 'T, 'Feedback> =
         { new ICodec<'T, 'T, 'Feedback> with
@@ -57,16 +61,22 @@ module Codec =
         (cb: ICodec<'B, 'WB, 'Feedback>)
         : ICodec<'A * 'B, 'WA * 'WB, 'Feedback> =
         { new ICodec<'A * 'B, 'WA * 'WB, 'Feedback> with
+            // short-circuit: if the left declines, the right codec is never
+            // invoked (no wasted work / no side effects on a doomed encode).
             member _.Serialize((a, b)) =
-                match ca.Serialize a, cb.Serialize b with
-                | Ok wa, Ok wb -> Ok(wa, wb)
-                | Error e, _ -> Error e
-                | _, Error e -> Error e
+                match ca.Serialize a with
+                | Error e -> Error e
+                | Ok wa ->
+                    match cb.Serialize b with
+                    | Error e -> Error e
+                    | Ok wb -> Ok(wa, wb)
             member _.Deserialize((wa, wb)) =
-                match ca.Deserialize wa, cb.Deserialize wb with
-                | Ok a, Ok b -> Ok(a, b)
-                | Error e, _ -> Error e
-                | _, Error e -> Error e
+                match ca.Deserialize wa with
+                | Error e -> Error e
+                | Ok a ->
+                    match cb.Deserialize wb with
+                    | Error e -> Error e
+                    | Ok b -> Ok(a, b)
             member _.Name = "(" + ca.Name + " * " + cb.Name + ")" }
 
     /// **Sum** (tagged) — a codec for the tagged choice of `'A` or `'B`,

--- a/src/Core/Codec.fs
+++ b/src/Core/Codec.fs
@@ -22,3 +22,68 @@ module Codec =
         abstract member Deserialize: wire: 'Wire -> Result<'T, 'Feedback>
         /// A stable identifier for this codec (e.g. "bonsai/canonical-json-v1").
         abstract member Name: string
+
+    // ── the codec algebra (B-1006): a codec is an **invariant functor**
+    // with the round-trip law `Deserialize ∘ Serialize = id`, closed under
+    // identity, product, and sum. These combinators build composite codecs
+    // from component codecs and preserve round-trip by construction (proven
+    // in tests/Tests.FSharp/Core/Codec.Tests.fs — B-1007 C12). Prior art:
+    // scodec `xmap`/`~`/`|+|`, Haskell `codec`, profunctor-optics.
+
+    /// The **identity** codec — wire = value, total (never declines): the
+    /// algebra's identity element (`Codec<unit>` is `identity<unit>`).
+    /// `Deserialize ∘ Serialize = id` holds trivially (`Ok` round-trips `Ok`).
+    let identity<'T, 'Feedback> () : ICodec<'T, 'T, 'Feedback> =
+        { new ICodec<'T, 'T, 'Feedback> with
+            member _.Serialize value = Ok value
+            member _.Deserialize wire = Ok wire
+            member _.Name = "codec/identity-v1" }
+
+    /// **Invariant-functor map** — re-target a codec from `'A` to `'B` given
+    /// a bijection (`fwd`, `bwd`). Round-trip is preserved when `fwd`/`bwd`
+    /// are inverse: `Deserialize(Serialize y) = map fwd (Deserialize(Serialize (bwd y))) = Ok (fwd (bwd y)) = Ok y`.
+    /// (scodec `xmap` / Haskell invariant `invmap`.)
+    let imap (fwd: 'A -> 'B) (bwd: 'B -> 'A) (c: ICodec<'A, 'Wire, 'Feedback>) : ICodec<'B, 'Wire, 'Feedback> =
+        { new ICodec<'B, 'Wire, 'Feedback> with
+            member _.Serialize value = c.Serialize(bwd value)
+            member _.Deserialize wire = c.Deserialize wire |> Result.map fwd
+            member _.Name = c.Name + "/imap" }
+
+    /// **Product** — combine codecs for `'A` and `'B` into a codec for the
+    /// pair, wire = pair of wires. Closed: round-trips iff both components do.
+    /// A decline on either side surfaces as `Error` (no silent corruption).
+    let product
+        (ca: ICodec<'A, 'WA, 'Feedback>)
+        (cb: ICodec<'B, 'WB, 'Feedback>)
+        : ICodec<'A * 'B, 'WA * 'WB, 'Feedback> =
+        { new ICodec<'A * 'B, 'WA * 'WB, 'Feedback> with
+            member _.Serialize((a, b)) =
+                match ca.Serialize a, cb.Serialize b with
+                | Ok wa, Ok wb -> Ok(wa, wb)
+                | Error e, _ -> Error e
+                | _, Error e -> Error e
+            member _.Deserialize((wa, wb)) =
+                match ca.Deserialize wa, cb.Deserialize wb with
+                | Ok a, Ok b -> Ok(a, b)
+                | Error e, _ -> Error e
+                | _, Error e -> Error e
+            member _.Name = "(" + ca.Name + " * " + cb.Name + ")" }
+
+    /// **Sum** (tagged) — a codec for the tagged choice of `'A` or `'B`,
+    /// wire = tagged choice of wires. Closed: round-trips iff both components
+    /// do; the tag is preserved, so a `Choice1Of2` never decodes as a
+    /// `Choice2Of2`.
+    let sum
+        (ca: ICodec<'A, 'WA, 'Feedback>)
+        (cb: ICodec<'B, 'WB, 'Feedback>)
+        : ICodec<Choice<'A, 'B>, Choice<'WA, 'WB>, 'Feedback> =
+        { new ICodec<Choice<'A, 'B>, Choice<'WA, 'WB>, 'Feedback> with
+            member _.Serialize value =
+                match value with
+                | Choice1Of2 a -> ca.Serialize a |> Result.map Choice1Of2
+                | Choice2Of2 b -> cb.Serialize b |> Result.map Choice2Of2
+            member _.Deserialize wire =
+                match wire with
+                | Choice1Of2 wa -> ca.Deserialize wa |> Result.map Choice1Of2
+                | Choice2Of2 wb -> cb.Deserialize wb |> Result.map Choice2Of2
+            member _.Name = "(" + ca.Name + " + " + cb.Name + ")" }

--- a/tests/Tests.FSharp/Core/Codec.Tests.fs
+++ b/tests/Tests.FSharp/Core/Codec.Tests.fs
@@ -1,9 +1,7 @@
-module Zeta.Tests.CodecTests
+module Zeta.Tests.Core.CodecTests
 
 open Xunit
-open FsCheck
 open FsCheck.Xunit
-open Zeta.Core
 open Zeta.Core.Codec
 
 // ═══════════════════════════════════════════════════════════════════

--- a/tests/Tests.FSharp/Core/Codec.Tests.fs
+++ b/tests/Tests.FSharp/Core/Codec.Tests.fs
@@ -1,0 +1,103 @@
+module Zeta.Tests.CodecTests
+
+open Xunit
+open FsCheck
+open FsCheck.Xunit
+open Zeta.Core
+open Zeta.Core.Codec
+
+// ═══════════════════════════════════════════════════════════════════
+// C12 (B-1007 P1) — the CODEC ALGEBRA (B-1006 §122-126): a codec is an
+// INVARIANT FUNCTOR with the round-trip law `Deserialize ∘ Serialize = id`,
+// closed under IDENTITY, PRODUCT, and SUM. We build composite codecs from
+// the `identity` base via `imap` / `product` / `sum` and prove (FsCheck):
+//   * round-trip CLOSURE   — each combinator preserves `decode∘encode=id`
+//   * invariant-FUNCTOR laws — imap id id = id ; imap composes
+//   * partiality is HONEST — a declining component surfaces `Error` through
+//     `product` (closure is honest about partial codecs; no silent
+//     corruption that would let a bad value masquerade as a good one)
+// Codecs are over a `string` decline channel. This makes B-1006's
+// "the codec axis is an algebra" claim TRUE. Prior art: scodec / Haskell
+// `codec` / profunctor-optics. "The compilers don't lie."
+// ═══════════════════════════════════════════════════════════════════
+
+/// true iff `Deserialize (Serialize x) = Ok x` (the round-trip law).
+let private roundTrips (c: ICodec<'T, 'W, string>) (x: 'T) : bool =
+    match c.Serialize x with
+    | Ok w -> (match c.Deserialize w with
+               | Ok y -> y = x
+               | Error _ -> false)
+    | Error _ -> false
+
+// total base codecs (identity element of the algebra) ...
+let private idInt : ICodec<int, int, string> = identity ()
+let private idStr : ICodec<string, string, string> = identity ()
+// ... and a non-trivial imap'd codec (real wire transform: ±1000 offset)
+let private shiftedInt : ICodec<int, int, string> =
+    imap (fun n -> n + 1000) (fun n -> n - 1000) idInt
+// a PARTIAL codec — declines (Error) outside [-100, 100]
+let private boundedInt : ICodec<int, int, string> =
+    { new ICodec<int, int, string> with
+        member _.Serialize n =
+            if abs n <= 100 then Ok n else Error(sprintf "value out of range: %d" n)
+        member _.Deserialize w =
+            if abs w <= 100 then Ok w else Error(sprintf "wire out of range: %d" w)
+        member _.Name = "boundedInt" }
+
+// ── round-trip closure: each combinator preserves decode∘encode = id ──
+
+[<Property>]
+let ``C12 identity codec round-trips (decode∘encode = id)`` (x: int) = roundTrips idInt x
+
+[<Property>]
+let ``C12 imap with an inverse bijection preserves round-trip`` (x: int) = roundTrips shiftedInt x
+
+[<Property>]
+let ``C12 product codec round-trips (closed under product)`` (a: int) (b: string) =
+    roundTrips (product idInt idStr) (a, b)
+
+[<Property>]
+let ``C12 sum codec round-trips and preserves the tag (closed under sum)`` (useLeft: bool) (a: int) (b: string) =
+    let c = sum idInt idStr
+    roundTrips c (if useLeft then Choice1Of2 a else Choice2Of2 b)
+
+[<Property>]
+let ``C12 nested product∘sum∘imap composite round-trips (closure composes)`` (a: int) (b: string) (useLeft: bool) =
+    // ((shiftedInt + idStr) × idInt) — exercise all three combinators stacked
+    let c = product (sum shiftedInt idStr) idInt
+    roundTrips c ((if useLeft then Choice1Of2 a else Choice2Of2 b), a)
+
+// ── invariant-functor laws ──
+
+[<Property>]
+let ``C12 imap id id is the identity functor (law 1: imap id id c = c)`` (x: int) =
+    let c = imap id id idInt
+    (c.Serialize x = idInt.Serialize x)
+    && (match idInt.Serialize x with
+        | Ok w -> c.Deserialize w = idInt.Deserialize w
+        | Error _ -> true)
+
+[<Property>]
+let ``C12 imap composition law (imap g g' ∘ imap f f' = imap (g∘f) (f'∘g'))`` (x: int) (w: int) =
+    // holds structurally for ANY maps (functor composition; not a round-trip
+    // claim) — so f/g need not be bijections here.
+    let f n = n + 7
+    let f' n = n - 7
+    let g n = n * 2
+    let g' n = n / 2
+    let lhs = imap g g' (imap f f' idInt)
+    let rhs = imap (g << f) (f' << g') idInt
+    lhs.Serialize x = rhs.Serialize x && lhs.Deserialize w = rhs.Deserialize w
+
+// ── partiality is honest: a declining component surfaces Error ──
+
+[<Fact>]
+let ``C12 product propagates a component decline as Error (no silent corruption)`` () =
+    let c = product boundedInt idStr
+    // out-of-range left component → the whole product must DECLINE, not
+    // silently encode a corrupt pair.
+    match c.Serialize(5000, "x") with
+    | Error _ -> ()
+    | Ok _ -> Assert.True(false, "product silently accepted an out-of-range component")
+    // in-range still round-trips (closure holds on the accepted domain)
+    Assert.True(roundTrips c (50, "y"))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -38,6 +38,7 @@
     <Compile Include="TriBoolean/Float.Tests.fs" />
     <Compile Include="Bonsai/Bonsai.Tests.fs" />
     <Compile Include="Bonsai/Resume.Tests.fs" />
+    <Compile Include="Core/Codec.Tests.fs" />
     <Compile Include="RangeSet.Tests.fs" />
     <Compile Include="DynamicValue.Tests.fs" />
     <Compile Include="DynamicValue.GoldenVectors.Tests.fs" />


### PR DESCRIPTION
## What

Makes B-1006's **asserted-in-prose** "the codec axis is an algebra" claim **true**, and proves it. B-1006 §122-126 commits to: *a codec is an **invariant functor** with the round-trip law `Deserialize ∘ Serialize = id`, closed under identity, product, and sum*. Only the bare `ICodec` port existed — B-1007 flags C12 asserted-in-prose, "writing these IS the work." This adds the combinators **and** the proof.

### `src/Core/Codec.fs` — the codec algebra over the existing port (hexagonal, Result-typed)
- `identity<'T> : ICodec<'T,'T,'F>` — the algebra's identity element (`Codec<unit>`)
- `imap fwd bwd` — the **invariant-functor map**, re-target `'A→'B` via a bijection
- `product ca cb : ICodec<'A*'B, 'WA*'WB, 'F>` — pair; declines if either component does
- `sum ca cb : ICodec<Choice<'A,'B>, Choice<'WA,'WB>, 'F>` — tagged choice; tag preserved

Prior art: scodec `xmap`/`~`/`|+|`, Haskell `codec`, profunctor-optics.

### `tests/Tests.FSharp/Core/Codec.Tests.fs` (C12) — FsCheck proofs
- **round-trip closure** — `identity` / `imap` (inverse bijection) / `product` / `sum` / a nested `product∘sum∘imap` composite each preserve `decode∘encode = id`
- **invariant-functor laws** — `imap id id = id`; the composition law `imap g g' ∘ imap f f' = imap (g∘f) (f'∘g')` (structural — holds for any maps, not a round-trip claim, so no bijectivity needed)
- **partiality is honest** — a declining component surfaces `Error` through `product` (no silent corruption that would let a bad value masquerade as good); the accepted domain still round-trips

## Verification

C12 **8/8**; Core Release build clean (`TreatWarningsAsErrors`).

## Discipline

Per **formal-proof-first**: half-(a) for C12. The hex/4×4 seed-lineage edge (half-b) is still owed before *canonical*. This is the first cadence item that **builds public surface** to make an asserted-in-prose claim real (the rest were tests over existing code) — the combinators match B-1006's stated algebra exactly (id/product/sum/imap).

This lands **all of B-1007 P1 except C13 (Tick) + C14 (Z-set)** — both FsCheck. Combined with P0 (C1/C2/C3/C6/C10/C11), the registry codec/marginal/BP/EP/message-group proofs are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)