### PR TITLE
proof(B-1007 C13): DBSP operator algebra (z⁻¹/I/D) + Tick (ℕ,+,0) monoid — FsCheck + Z3

### DIFF
--- a/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
@@ -697,3 +697,42 @@ let ``Z3 proves the finite convergence threshold has no converged-and-moved over
         "(assert (and (<= d tol) (> d tol)))\n" +
         "(check-sat)\n"
     z3ScriptHolds "C6 finite threshold has no converged-and-moved overlap" script
+
+
+// ═══════════════════════════════════════════════════════════════════
+// C13 (B-1007 P1) — the DBSP operator-inverse identities, symbolically
+// over the IDEAL REALS (QF_LRA). z⁻¹ (delay): (z⁻¹ x)[t] = x[t−1], x[−1]=0.
+// I (integrate): I(s)[t] = Σ_{i≤t} s[i]. D (differentiate): D(x)[t] =
+// x[t] − x[t−1] = (1 − z⁻¹)(x). The substance is the TELESCOPING:
+// D∘I = I∘D = id over a bounded 3-tick stream s0,s1,s2. The FsCheck twin
+// (Operators/OperatorAlgebra.Tests.fs C13) runs the REAL Circuit on int64
+// Z-sets; Z3 proves the algebra over ideal reals (BP-16 cross-check).
+// Spec: DBSP (Budiu et al.) — I = (1−z⁻¹)⁻¹.
+// ═══════════════════════════════════════════════════════════════════
+
+[<Fact>]
+let ``Z3 proves C13 D∘I = id (differentiate of integrate telescopes to each tick)`` () =
+    // I[t]=Σ_{i≤t}s[i]; D(I(s))[t]=I[t]−I[t−1] must equal s[t] for every t.
+    // assert the violation (some tick disagrees) ⇒ UNSAT ⇒ identity holds.
+    let script =
+        "(set-logic QF_LRA)\n" +
+        "(declare-const s0 Real)(declare-const s1 Real)(declare-const s2 Real)\n" +
+        "(assert (or\n" +
+        "  (not (= (- s0 0.0) s0))\n" +
+        "  (not (= (- (+ s0 s1) s0) s1))\n" +
+        "  (not (= (- (+ s0 s1 s2) (+ s0 s1)) s2))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C13 D∘I = id" script
+
+[<Fact>]
+let ``Z3 proves C13 I∘D = id (integrate of differentiate telescopes to each tick)`` () =
+    // D(s)[t]=s[t]−s[t−1] (s[−1]=0); I(D(s))[t]=Σ_{i≤t}D(s)[i] must equal s[t].
+    let script =
+        "(set-logic QF_LRA)\n" +
+        "(declare-const s0 Real)(declare-const s1 Real)(declare-const s2 Real)\n" +
+        "(assert (or\n" +
+        "  (not (= (- s0 0.0) s0))\n" +
+        "  (not (= (+ (- s0 0.0) (- s1 s0)) s1))\n" +
+        "  (not (= (+ (- s0 0.0) (- s1 s0) (- s2 s1)) s2))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "C13 I∘D = id" script

--- a/tests/Tests.FSharp/Operators/OperatorAlgebra.Tests.fs
+++ b/tests/Tests.FSharp/Operators/OperatorAlgebra.Tests.fs
@@ -1,0 +1,111 @@
+module Zeta.Tests.Operators.OperatorAlgebraTests
+#nowarn "0893"
+
+open FsCheck.Xunit
+open Zeta.Core
+
+// ═══════════════════════════════════════════════════════════════════
+// C13 (B-1007 P1) — the DBSP linear-operator algebra over Stream<ZSet>
+// (Incremental/Circuit): z⁻¹ (delay), I (integrate), D (differentiate),
+// plus the Tick (ℕ,+,0) monoid the streams are indexed by. The existing
+// Circuit.Tests.fs proves these as fixed [<Fact>] EXAMPLES; C13 GENERALISES
+// them to FsCheck over random delta-sequences and adds the operator
+// identities. Spec: DBSP (Budiu et al.) — I = (1−z⁻¹)⁻¹, D = 1−z⁻¹,
+// D∘I = I∘D = id. The symbolic operator identities are cross-checked in
+// Z3 (Z3.Laws.Tests.fs C13) per BP-16: FsCheck on the real Circuit ∧ Z3 on
+// ideal reals. "The compilers don't lie."
+// ═══════════════════════════════════════════════════════════════════
+
+// build a per-tick ZSet delta from generated pairs: keys in 0..4 (small,
+// so cancellations happen across ticks), weights in −6..6 (some 0 → pruned).
+let private mkDelta (pairs: (int * int) list) : ZSet<int> =
+    pairs |> List.map (fun (k, w) -> (abs (k % 5)), int64 (w % 7)) |> ZSet.ofSeq
+
+let private capTicks (raw: (int * int) list list) = raw |> List.truncate 6 |> List.map mkDelta
+
+// ── D∘I = id : differentiate recovers the per-tick delta from the snapshot ──
+[<Property>]
+let ``C13 D∘I = id (differentiate of integrate recovers each tick's delta)``
+    (raw: (int * int) list list) =
+    let ticks = capTicks raw
+    let c = Circuit.create ()
+    let input = c.ZSetInput<int>()
+    let out = c.Output(c.DifferentiateZSet(c.IntegrateZSet input.Stream))
+    ticks
+    |> List.forall (fun d ->
+        input.Send d
+        c.Step()
+        out.Current = d)
+
+// ── I∘D = id : integrate telescopes the per-tick differences back ──
+[<Property>]
+let ``C13 I∘D = id (integrate of differentiate recovers each tick's delta)``
+    (raw: (int * int) list list) =
+    let ticks = capTicks raw
+    let c = Circuit.create ()
+    let input = c.ZSetInput<int>()
+    let out = c.Output(c.IntegrateZSet(c.DifferentiateZSet input.Stream))
+    ticks
+    |> List.forall (fun d ->
+        input.Send d
+        c.Step()
+        out.Current = d)
+
+// ── z⁻¹ defining property : delay(s)[t] = s[t−1], empty at t=0 ──
+[<Property>]
+let ``C13 z⁻¹ (delay) emits the previous tick's input (empty at t=0)``
+    (raw: (int * int) list list) =
+    let ticks = capTicks raw
+    let c = Circuit.create ()
+    let input = c.ZSetInput<int>()
+    let out = c.Output(c.DelayZSet input.Stream)
+    let mutable prev = ZSet.empty<int>
+    ticks
+    |> List.forall (fun d ->
+        input.Send d
+        c.Step()
+        let ok = (out.Current = prev)
+        prev <- d
+        ok)
+
+// ── D = 1 − z⁻¹ : differentiate equals input minus its own delay ──
+[<Property>]
+let ``C13 D = 1 − z⁻¹ (differentiate equals input minus delay)``
+    (raw: (int * int) list list) =
+    let ticks = capTicks raw
+    let c = Circuit.create ()
+    let input = c.ZSetInput<int>()
+    let dOut = c.Output(c.DifferentiateZSet input.Stream)
+    let rhsOut = c.Output(c.Plus(input.Stream, c.Negate(c.DelayZSet input.Stream)))
+    ticks
+    |> List.forall (fun d ->
+        input.Send d
+        c.Step()
+        dOut.Current = rhsOut.Current)
+
+// ── I = Σ z⁻ⁿ : integrate is the running sum (monotone snapshot) ──
+[<Property>]
+let ``C13 I = running sum (integrate snapshot = fold of all deltas so far)``
+    (raw: (int * int) list list) =
+    let ticks = capTicks raw
+    let c = Circuit.create ()
+    let input = c.ZSetInput<int>()
+    let out = c.Output(c.IntegrateZSet input.Stream)
+    let mutable acc = ZSet.empty<int>
+    ticks
+    |> List.forall (fun d ->
+        input.Send d
+        c.Step()
+        acc <- ZSet.add acc d
+        out.Current = acc)
+
+// ── the Tick (ℕ,+,0) monoid the operator stream is indexed by ──
+// `tick` is a [<Measure>] (Window.fs); `int<tick>` addition is the integer
+// monoid lifted to the logical-clock unit-of-measure — the UoM is the safety
+// (no tick/ms swap), the algebra is ℤ's commutative monoid with identity 0.
+[<Property>]
+let ``C13 Tick is the (ℕ,+,0) commutative monoid`` (a: int) (b: int) (d: int) =
+    let ta, tb, tc = a * 1<tick>, b * 1<tick>, d * 1<tick>
+    (ta + tb) + tc = ta + (tb + tc)              // associative
+    && ta + 0<tick> = ta && 0<tick> + ta = ta    // two-sided identity
+    && ta + tb = tb + ta                          // commutative

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -69,6 +69,7 @@
     <Compile Include="Operators/Fusion.Tests.fs" />
     <Compile Include="Operators/ResidualMax.Tests.fs" />
     <Compile Include="Operators/Differentiate.Tests.fs" />
+    <Compile Include="Operators/OperatorAlgebra.Tests.fs" />
     <Compile Include="Operators/RecursiveCounting.MultiSeed.Tests.fs" />
     <Compile Include="Operators/RecursiveSemiNaive.Boundary.Tests.fs" />
     <Compile Include="Operators/CrmScenarios.Tests.fs" />


### PR DESCRIPTION
## What

C13 cadence item — the **DBSP linear-operator algebra** over `Stream<ZSet>`. `Circuit.Tests.fs` proves these as fixed `[<Fact>]` examples; C13 **generalises** them to FsCheck over random delta-sequences and adds the operator-inverse identities in Z3 (BP-16: real Circuit ∧ ideal reals). Spec: DBSP (Budiu et al.) — `I = (1−z⁻¹)⁻¹`, `D = 1−z⁻¹`, `D∘I = I∘D = id`.

### `Operators/OperatorAlgebra.Tests.fs` (FsCheck, random `ZSet<int>` delta sequences via the Circuit harness, sync `Step()`)
- **D∘I = id** and **I∘D = id** — each tick's delta is recovered
- **z⁻¹ defining property** — `delay` emits the previous tick's input (empty at t=0)
- **D = 1 − z⁻¹** — `DifferentiateZSet = input − DelayZSet` (via `Plus`/`Negate`)
- **I = running sum** — `IntegrateZSet` snapshot = fold of all deltas so far
- **Tick `(ℕ,+,0)` monoid** — `int<tick>` assoc/identity/commut (the UoM is the tick/ms safety; the algebra is ℤ's commutative monoid)

### `Formal/Z3.Laws.Tests.fs` (QF_LRA, symbolic 3-tick scalar stream)
- **D∘I = id** and **I∘D = id** — the telescoping operator-inverse identities (assert the violation ⇒ UNSAT ⇒ identity holds)

## Verification

C13 **8/8** (6 FsCheck + 2 Z3), **0 skipped** (z3 on PATH locally). Release build clean.

## Discipline

Per **formal-proof-first**: half-(a) for C13. The hex/4×4 seed-lineage edge (half-b) is still owed before *canonical*. Z3 legs still self-skip in CI pending **B-1009**; verified locally.

This lands **all of B-1007 P1** (C4, C5, C7, C12, C13, C14) on top of P0 (C1/C2/C3/C6/C10/C11) — the full message-group / marginal / BP / EP / batch / codec / Z-set / operator-algebra proof set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)