### PR TITLE
ci(ace): gate trust-core cross-verification oracles + ace suite in CI

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1078,3 +1078,59 @@ jobs:
         # the .tsconfig.json strictness profile (verbatimModuleSyntax,
         # noUncheckedIndexedAccess, exactOptionalPropertyTypes).
         run: bun --bun tsc --noEmit -p tsconfig.json
+
+  cross-verify:
+    # Enforce the trust-core cross-language byte-lock + golden-vector oracles + the Ace
+    # package-manager suite. Previously only `lint (tsc tools)` type-checked these, so a
+    # regression to a committed golden vector, or a 4-language disagreement, could merge green.
+    # This job runs the ASSERTIONS (assert-dont-skip): every tests/cross-verification/<primitive>/
+    # oracle via tools/ci/cross-verify-all.ts (compare.ts = TS/F#/C#/Rust committed outputs vs the
+    # canonical vectors = the non-Byzantine compile-time agreement, baked in; cross-verify.ts = the
+    # TS golden-vector oracle) plus `bun test tools/ace/`. It asserts COMMITTED outputs, so no
+    # dotnet/rust toolchain is needed here. This is the ENFORCEMENT half of the canonical-primitive
+    # gate (proof + 4-language byte-lock); the proof half is the Soraya formal-coverage / lean-proof
+    # lane. NOTE: promoting this to a REQUIRED check (branch protection) is a separate operator/devops
+    # step — until then it runs + shows on every PR but does not block auto-merge.
+    name: cross-verify (trust-core oracles + ace suite)
+    timeout-minutes: 5
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Cache install.sh outputs (mise runtimes + dotnet tools + verifier jars)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.local/bin/mise
+            ~/.local/share/mise
+            ~/.cache/mise
+            ~/.dotnet/tools
+            ~/.elan
+            ~/.config/zeta
+          key: install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.mise.toml', 'tools/setup/**', 'global.json') }}
+
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        # Provides bun via mise (.mise.toml pin); shellenv wires BASH_ENV so later run: steps
+        # have bun on PATH. Retry rationale per lint-tsc-tools (mise+bun CDN 502 flake class).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            if ./tools/setup/install.sh; then exit 0; fi
+            [ "$attempt" = "5" ] && { echo "install.sh failed after 5 attempts"; exit 1; }
+            case "$attempt" in
+              1) backoff=10 ;;
+              2) backoff=30 ;;
+              3) backoff=60 ;;
+              4) backoff=120 ;;
+            esac
+            echo "install.sh attempt $attempt failed; retrying in ${backoff}s..." >&2
+            sleep "$backoff"
+          done
+
+      - name: Ace package-manager suite
+        run: bun test tools/ace/
+
+      - name: Cross-language byte-lock + golden-vector oracles
+        run: bun tools/ci/cross-verify-all.ts

--- a/tools/ci/cross-verify-all.ts
+++ b/tools/ci/cross-verify-all.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+// cross-verify-all.ts — CI runner for the trust-core cross-verification oracles.
+//
+// Runs every tests/cross-verification/<primitive>/ oracle and FAILS if any oracle fails OR
+// any primitive dir lacks a runnable oracle. The "no oracle = fail" rule is assert-don't-skip
+// (.claude/rules/automated-tests-are-the-shield-assert-dont-skip.md): a cross-verification
+// primitive with no oracle is an UNCHECKED primitive, not a silent pass.
+//
+// Two oracle shapes (each exits non-zero on mismatch, each reads RELATIVE paths from its own
+// dir — so each MUST run with cwd = the primitive dir):
+//   - compare.ts      : 4-language byte-lock — TS/F#/C#/Rust committed outputs vs the canonical
+//                       vectors. This is the non-Byzantine compile-time agreement, baked in:
+//                       it catches a lone-wrong oracle even if two agree wrongly.
+//   - cross-verify.ts : TS golden-vector oracle (newer TS-only primitives; 4-lang deferred).
+//
+// This is the ENFORCEMENT half of the canonical-primitive gate (proof + 4-language byte-lock);
+// the proof half lives in the Soraya formal-coverage / lean-proof lane. It does NOT regenerate
+// the F#/C#/Rust outputs (no dotnet/rust toolchain needed) — it asserts the committed outputs,
+// which is what makes a regression to a committed vector fail CI.
+import { readdirSync, existsSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const ROOT = "tests/cross-verification";
+
+const dirs = readdirSync(ROOT)
+  .map((name) => join(ROOT, name))
+  .filter((p) => statSync(p).isDirectory())
+  .sort();
+
+if (dirs.length === 0) {
+  console.error(`cross-verify-all: no primitive dirs under ${ROOT}/ — refusing to pass on an empty surface`);
+  process.exit(1);
+}
+
+let failed = 0;
+for (const dir of dirs) {
+  const entry = existsSync(join(dir, "compare.ts"))
+    ? "compare.ts"
+    : existsSync(join(dir, "cross-verify.ts"))
+      ? "cross-verify.ts"
+      : null;
+  if (entry === null) {
+    console.error(`✗ ${dir}: no oracle (compare.ts | cross-verify.ts) — unchecked primitive (assert-don't-skip)`);
+    failed++;
+    continue;
+  }
+  console.log(`→ ${dir}: ${entry}`);
+  // process.execPath under bun is the bun binary — run the oracle with the same runtime,
+  // cwd set to the primitive dir so its relative reads resolve.
+  const r = spawnSync(process.execPath, [entry], { cwd: dir, stdio: "inherit" });
+  if (r.status !== 0) {
+    console.error(`✗ ${dir}: ${entry} exited ${r.status === null ? `signal ${r.signal}` : r.status}`);
+    failed++;
+  } else {
+    console.log(`✓ ${dir}: ${entry} passed`);
+  }
+}
+
+console.log(`\ncross-verify-all: ${dirs.length - failed}/${dirs.length} primitives passed`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## What

The Ace trust-core's cross-language guarantee was **not CI-enforced**: only `lint (tsc tools)` type-checked the oracles, so a regression to a committed golden vector — or a 4-language disagreement — could merge green. A hole in the shield that reads as covered (`.claude/rules/automated-tests-are-the-shield-assert-dont-skip.md`).

## Change

- **`tools/ci/cross-verify-all.ts`** — auto-discovers every `tests/cross-verification/<primitive>/` dir, runs its oracle with `cwd` set to that dir (oracles read relative paths), and **fails on any mismatch OR any dir lacking an oracle** (assert-dont-skip — an unchecked primitive is not a silent pass). Two oracle shapes:
  - `compare.ts` — 4-language byte-lock: TS/F#/C#/Rust **committed** outputs vs the canonical vectors. The non-Byzantine compile-time agreement, baked in (catches a lone-wrong oracle even if two agree wrongly). Primitives: `sha256`, `yaml`, `zeta-id`.
  - `cross-verify.ts` — TS golden-vector oracle (TS-only primitives; 4-lang deferred). Primitives: `package-hash`, `ed25519`.
- **`gate.yml` job `cross-verify`** — runs the runner + `bun test tools/ace/`. Asserts **committed** outputs → no dotnet/rust toolchain needed in the job.

This is the **enforcement half** of the canonical-primitive gate (proof **and** 4-language byte-lock). The proof half stays the Soraya formal-coverage / `lean-proof` lane. As primitives earn proof + 4-lang over time, the proven BCL grows and this gate keeps the byte-lock honest.

## Verification

- Runner **5/5 exit 0** on current main.
- **Falsified:** corrupting one committed vector (`sha256/rust-output.json`) → runner exit 1, pinpoints the exact `Rust hex vs canonical MISMATCH`; restored → exit 0. The assertion actually fires.
- `gate.yml` parses (bun YAML); **actionlint exit 0**; **tsc strict exit 0**; pure-LF.

## Follow-up (operator / devops — not done here)

Promote the `cross-verify (trust-core oracles + ace suite)` check to a **required** status check in branch protection so it blocks auto-merge. Until then it runs + shows on every PR but does not gate merges (adding a required check is a branch-protection change outside agent authority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)