### PR TITLE
rules(formal-proof-first): layered-lemma discipline — prove primitives as connected lemmas

### DIFF
--- a/.claude/rules/formal-proof-first-proven-by-default-consensus-not-validation-canonical-is-homeostat-proven-from-seed-ace-shields-zeta.md
+++ b/.claude/rules/formal-proof-first-proven-by-default-consensus-not-validation-canonical-is-homeostat-proven-from-seed-ace-shields-zeta.md
@@ -104,6 +104,46 @@ shape as [`automated-tests-are-the-shield-assert-dont-skip`](automated-tests-are
    first-class debt, not a nicety.
 6. **Treat Ace as the shield:** external deps adapt IN; the proven core never depends
    on an unproven external interface directly.
+7. **Prove primitives bottom-up as connected lemmas** (layered-lemma discipline,
+   below) — prove each primitive as it enters canonical, aimed at the guarantee
+   later proofs will lean on, and *cite* it rather than re-derive it.
+
+## Layered-lemma discipline (Kestrel 2026-06-03, maintainer-ratified)
+
+> Prove small primitives step-by-step as they enter canonical; **aim each proof
+> at the property that COMPOSES** (the guarantee later proofs assume), not just
+> the easy property; and **connect it as a named lemma** so the next proof cites
+> it instead of re-deriving it.
+
+Proofs build a *foundation* (not a pile) only when each primitive proof
+establishes the exact guarantee something above it leans on. "True-but-unused"
+doesn't compound; "true-and-load-bearing-and-connected" does. Three payoffs
+(Kestrel 2026-06-03):
+
+1. **Reusable lemmas** — a proven primitive is a lemma; the hard proof later
+   *composes trusted pieces* instead of re-proving from scratch. (Lean
+   `chain_rule_id_corollary` is general over any abelian group `G`: prove
+   "Z-set is an abelian group" once and the `G`-generic operator proofs land
+   for free.)
+2. **Localized failures** — proven foundation = a failed composite proof is
+   isolated to the *new* composition, not hunted through every layer.
+3. **Vacuity caught at the cheapest scope** — Tick-monoid-shaped vacuity is
+   obvious on a primitive in isolation, hidden inside a big composite. Prove at
+   smallest scope where "is this a real claim?" is clearest.
+
+**The 4-step move:** (1) prove each primitive as it enters canonical; (2) aim
+the proof at the compose-able guarantee (round-trip / injectivity / the algebra
+law / the invariant the next layer assumes); (3) **connect** it — name it as the
+lemma so the next proof *cites* rather than re-derives; (4) which also catches
+vacuity at the cheapest scope.
+
+**Empirical anchor — the cost of NOT connecting (2026-06-03):** `D∘I=id` was
+proven **three times independently** — Lean `chain_rule_id_corollary : D (I s) =
+s` (already on main, general over `G`) + C13 FsCheck (real Circuit) + C13 Z3
+(telescoping) — the C13 pair re-derived what Lean already had, *because the
+primitive lemma was not connected/cited*. Cross-tool agreement is the BP-16
+ideal, but un-connected it is invisible + re-derived. Per the Z-set canonical
+connection ledger (`docs/research/2026-06-03-zset-family-canonical-connection-four-language-bytelock-plus-four-tool-proofs.md`).
 
 ## Composes with
 


### PR DESCRIPTION
## What

Extends `formal-proof-first` with the **layered-lemma discipline** (Kestrel 2026-06-03, maintainer-ratified): prove small primitives step-by-step as they enter canonical; aim each proof at the property that **composes** (the guarantee later proofs assume), not just the easy one; **connect** it as a named lemma so the next proof cites it instead of re-deriving; which also catches vacuity at the cheapest scope.

## Why

This session proved `D∘I=id` **three times independently** — Lean `chain_rule_id_corollary : D (I s) = s` (general over abelian group `G`, already on main) + C13 FsCheck (real Circuit) + C13 Z3 (telescoping) — *because the primitive lemma was not connected/cited*. Cross-tool agreement is the BP-16 ideal, but un-connected it is invisible and re-derived. That is exactly the "disconnected proofs" the maintainer named. The discipline turns proofs into a foundation (each cited by what builds on it) rather than a pile.

## Changes

- Operational-discipline **bullet 7** → points at the new section.
- New **`## Layered-lemma discipline`** section: the carved sentence + 3 payoffs (reusable lemmas / localized failures / vacuity-at-cheapest-scope) + the 4-step move + the `D∘I=id`-proven-3× empirical anchor (cites the Z-set connection ledger #6640).
- Composes with `verify-existing-substrate-before-authoring` (search-first) + `asymmetric-critic-with-clarity-first` (already in the rule's composes-with).

Single-file rule edit. MD049-clean (single-`*` emphasis only), role-refs in body (`maintainer-ratified`; Kestrel = roster persona, per the rule's existing convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
