### PR TITLE
ci(ace): fix-forward — bun install in cross-verify job (z3-solver MODULE_NOT_FOUND)

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1086,8 +1086,9 @@ jobs:
     # This job runs the ASSERTIONS (assert-dont-skip): every tests/cross-verification/<primitive>/
     # oracle via tools/ci/cross-verify-all.ts (compare.ts = TS/F#/C#/Rust committed outputs vs the
     # canonical vectors = the non-Byzantine compile-time agreement, baked in; cross-verify.ts = the
-    # TS golden-vector oracle) plus `bun test tools/ace/`. It asserts COMMITTED outputs, so no
-    # dotnet/rust toolchain is needed here. This is the ENFORCEMENT half of the canonical-primitive
+    # TS golden-vector oracle) plus `bun test tools/ace/`. The ORACLES assert COMMITTED outputs (no
+    # dotnet/rust toolchain needed); the ace suite installs npm deps (z3-solver) + uses the runner
+    # node for its solver Z3 differential. This is the ENFORCEMENT half of the canonical-primitive
     # gate (proof + 4-language byte-lock); the proof half is the Soraya formal-coverage / lean-proof
     # lane. NOTE: promoting this to a REQUIRED check (branch protection) is a separate operator/devops
     # step — until then it runs + shows on every PR but does not block auto-merge.
@@ -1128,6 +1129,12 @@ jobs:
             echo "install.sh attempt $attempt failed; retrying in ${backoff}s..." >&2
             sleep "$backoff"
           done
+
+      - name: Install npm devDependencies (z3-solver for the ace solver Z3 differential, etc.)
+        # The ace suite's solver.z3.test.ts spawns node to require('z3-solver') (assert-dont-skip:
+        # it FAILS rather than skips if the dep is absent). --frozen-lockfile fails if the lockfile
+        # is stale vs package.json (same discipline as lint-tsc-tools).
+        run: bun install --frozen-lockfile
 
       - name: Ace package-manager suite
         run: bun test tools/ace/

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1089,7 +1089,7 @@ jobs:
     # TS golden-vector oracle) plus `bun test tools/ace/`. The ORACLES assert COMMITTED outputs (no
     # dotnet/rust toolchain needed); the ace suite installs npm deps (z3-solver) + uses the runner
     # node for its solver Z3 differential. This is the ENFORCEMENT half of the canonical-primitive
-    # gate (proof + 4-language byte-lock); the proof half is the Soraya formal-coverage / lean-proof
+    # gate (proof + 4-language byte-lock); the proof half is the formal-coverage cadence / lean-proof
     # lane. NOTE: promoting this to a REQUIRED check (branch protection) is a separate operator/devops
     # step — until then it runs + shows on every PR but does not block auto-merge.
     name: cross-verify (trust-core oracles + ace suite)


### PR DESCRIPTION
## Fix-forward for #6641

#6641 added the `cross-verify` gate.yml job, but it **squash-merged before its own (non-required) job went green** — auto-merge fires on *required* checks only, and `cross-verify` is intentionally non-required (promoting it to required is the operator/devops follow-up). So main's `cross-verify` job now **fails on every PR**:

`bun test tools/ace/` runs `tools/ace/solver.z3.test.ts`, which spawns `node` to `require('z3-solver')` (deliberately **no-skip** per `automated-tests-are-the-shield-assert-dont-skip.md` — it FAILS, not skips, when the dep is absent). The job had no `bun install`, so `z3-solver` is `MODULE_NOT_FOUND`. (It passed locally where `node_modules` is present.)

## Change

Add `bun install --frozen-lockfile` before the ace-suite step (mirrors `lint-tsc-tools`). The cross-verify **oracles** still need no toolchain (they assert committed outputs); only the ace suite's Z3 differential needs the npm dep + the runner's preinstalled node.

## Verification

`actionlint` exit 0; YAML parses; pure-LF; single-file diff. **On this PR the `cross-verify` job runs with the fix**, so a green `cross-verify (trust-core oracles + ace suite)` check IS the confirmation.

Note: this PR's `cross-verify` check still runs against *this branch's* fixed gate.yml, so it should be green; if it's red for the z3 reason that would mean the fix is wrong — watch that specific check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)