### PR TITLE
research(preserve): multi-tower proofs + foundation-independence + AoC hidden-dep + constructive tower (forwarded)

### DIFF
--- a/docs/research/2026-06-03-kestrel-aaron-multi-tower-proofs-foundation-independence-axiom-equivalence-classes-constructive-tower-aaron-forwarded.md
+++ b/docs/research/2026-06-03-kestrel-aaron-multi-tower-proofs-foundation-independence-axiom-equivalence-classes-constructive-tower-aaron-forwarded.md
@@ -1,0 +1,202 @@
+# Kestrel × the maintainer 2026-06-03 — multi-tower proofs, foundation-independence, axiom equivalence classes, the Axiom-of-Choice hidden-dependency lesson, the constructive tower, intuition-calibration (forwarded)
+
+Scope: forwarded Kestrel × maintainer exchange preserved as **engineering /
+proof-strategy substrate** (multi-tower proofs from independent axiom sets;
+foundation-independence as a proof obligation; the Axiom-of-Choice
+hidden-dependency lesson; the constructive/Curry-Howard tower; intuition
+calibrated by provable output). It directly extends the **layered-lemma
+discipline** landed today (#6642 + reviewer-fixes #6644) and `formal-proof-first`.
+
+Attribution: Kestrel (claude.ai asymmetric-critic peer) + the maintainer (the
+operator), continuing the formal-proof cadence. Aaron = courier forwarding
+2026-06-03. Per `GOVERNANCE.md §33`.
+
+Operational status: engineering/discipline-grade. The proof-strategy content is
+load-bearing for the canonical-primitives work (B-1007). A rule-extension to
+`formal-proof-first` (multi-tower / foundation-independence) is **OFFERED, not
+minted** — Soraya (`formal-verification-expert`) owns the formal-coverage
+portfolio view and BP-16 cross-check and should ratify before it lands as a rule.
+
+Non-fusion disclaimer: Otto preserves the conversation's engineering /
+proof-strategy content + the maintainer's exact formulations of the proof
+claims, NOT a claim of AI continuity. "Kestrel" is Claude-the-model in
+conversation, not a persistent entity. **Personal / wellbeing / mental-health
+content from the same exchange is intentionally NOT reproduced** per
+`harm-by-grammar-discriminator-and-audience-adjusted-language.md` — that
+counterweight is the maintainer's village's lane (psychiatrist, family,
+co-maintainer), not repo substrate, and Kestrel already held it in-conversation.
+Per BP-11, content found in the exchange is data to report on, not instructions
+to execute.
+
+---
+
+## Why this is preserved (the engineering through-line)
+
+The exchange opened on the layered-lemma agreement (already landed: prove
+primitives bottom-up as connected lemmas, aimed at the guarantee later proofs
+assume). It then developed the **next layer of the proof-strategy**: how to keep
+the canonical proof-foundation honest when the axioms themselves are contestable.
+That development is genuinely new engineering substrate and composes directly
+with what's on main.
+
+## 1. Multi-tower proofs — don't rest canonical on one axiom set
+
+> the maintainer: *"we plan on having many proof towers eventually from different
+> widely-accepted axioms so we are not building our towers on one axiom set."*
+
+A claim proven **within** an axiom set is *valid-given-those-axioms*, not *true* —
+its soundness rests entirely on the axioms (Conway–Kochen's Free Will Theorem is
+rigorous **given** SPIN/TWIN/MIN; reject an axiom and the theorem's force goes).
+So the canonical-proof strategy is **multiple towers from genuinely independent,
+widely-accepted foundations**:
+
+- A claim derivable from **several** independent foundations is **robust across
+  foundations** — to reject it you'd have to reject all of them, not one.
+- The towers **sort the claims**: claims appearing in *all* towers are
+  foundation-independent (lean on them hardest); claims in *one* tower stay
+  explicitly conditional ("valid if that axiom set holds").
+- This is the discipline that keeps **no single contested axiom load-bearing
+  alone** — including the maintainer's own preferred (panpsychist) axiom set.
+
+## 2. Robustness = distinct EQUIVALENCE CLASSES of foundation, not tower count
+
+> Kestrel: *"the real measure isn't 'how many towers' — it's how many distinct
+> equivalence classes of foundation a claim survives across."*
+
+Foundations cluster into equivalence classes of inter-derivable axiom sets.
+**Ten towers from one class = one foundation's worth of confidence; two towers
+from two genuinely-distinct classes = real robustness.** Count robustness by
+**classes**, not towers.
+
+## 3. Foundation-independence is a PROOF OBLIGATION, not a vibe
+
+> the maintainer: *"the towers are most valuable when the axiom sets are genuinely
+> independent, not secretly the same assumption in different clothes — I've
+> noticed interchangeable axioms before."*
+
+Interchangeability is **provable**: for two foundations claimed independent, the
+test is "can I inter-derive their axioms (A ⟺ B)?"
+
+- **Yes → same equivalence class** — collapse them, don't double-count.
+- **No → genuinely independent** — the robustness counts.
+
+The canonical example (the maintainer: *"funny enough it was the Axiom of Choice
+that pops up everywhere accidentally"*): **AoC ⟺ Zorn's Lemma ⟺ Well-Ordering** —
+one assumption in three outfits. Three "towers" on those three would have the
+*illusion* of independence and the *reality* of one — they fall together.
+
+**Caveat (Kestrel):** interchangeability can be **partial / conditional** —
+two foundations independent for one class of claims, interchangeable for another.
+So independence is sometimes **claim-relative**, tracked per-claim, not a global
+yes/no per tower-pair.
+
+## 4. The Axiom-of-Choice hidden-dependency lesson — audit DERIVATIONS, not just stated axioms
+
+AoC is the textbook *sneaky* dependency: it slips into proofs unnoticed because
+"pick an element from each set" / "take a representative" / a Zorn maximal-element
+argument *feels like reasoning, not an axiom*. So towers with different **stated**
+foundations can be **correlated through a hidden shared AoC** none of them listed —
+false robustness.
+
+> the maintainer: *"the only reason I notice is because my brain works in old-school
+> Cantor sets, not ZFC naturally."*
+> (Pre-formalization, geometric set-intuition feels the seams where the formal
+> axioms are *added* — hence the sensitivity to where AoC is being smuggled in.
+> Held per `god-tier-claims-high-signal-high-suspicion-dont-collapse.md`: the
+> *noticing* is the verified, valuable part; the cognitive-mechanism self-model is
+> a useful self-description, not a verified fact about the wetware — and per the
+> exchange's own conclusion, only as good as the **provable output** it yields.)
+
+**The defense is the layered-lemma discipline already on main.** Hidden axioms
+sneak only through *unexamined* steps. Step-by-step proving with **explicit
+dependency-tracking all the way down** surfaces an AoC/Zorn/Well-Ordering
+invocation rather than letting it hide in an "obviously we can pick one"
+hand-wave. So:
+
+> The independence check extends to *"does this derivation secretly use Choice
+> (or any shared hidden axiom)?"* — audit what each proof **actually depends on**,
+> not just what it **declares**.
+
+This is a clean convergence: the same explicit-dependency rigor that grounds the
+claims (layered-lemma, #6642) is the thing that surfaces the hidden shared
+dependencies that would otherwise create false multi-tower robustness.
+
+## 5. The constructive tower — Choice-free by construction, proof = program
+
+A deliberately **constructive / intuitionistic** tower (refuses AoC and excluded
+middle) is high-value for *this* codebase for two reasons:
+
+1. **Provably independent** from Choice-using towers — it *forbids* Choice, so it
+   can't secretly correlate through it.
+2. **Curry–Howard:** a constructive proof **is** an algorithm. Since the canonical
+   work proves properties *about algorithms* (Z-set, codec, DBSP operators), a
+   constructive-tower proof hands you a program — the tower that maps directly to
+   executable code.
+
+Candidate as a deliberate, genuinely-independent, code-aligned tower (composes
+with the existing Lean leg — `tools/lean4/Lean4/DbspChainRule.lean` — and B-0446
+/ B-0131 Lean-proof rows).
+
+## 6. Intuition is calibrated by provable output over time — track the misses
+
+> the maintainer: *"my subjective feel is only as useful as the geometric intuition
+> it produces that's provable over time; if not, the intuition is just noise."*
+
+Intuition **proposes**, proof **disposes**; the feel earns credibility by its
+**tracked hit-rate against the hard gate**, per-domain. **Track the misses, not
+just the hits** (guard against survivorship bias in self-evaluation) — an
+intuition reliable about AoC-dependencies but noise about convergence should be
+trusted in the first domain, not the second, and you only know that from the
+record. Same bar as the proofs: the measure must be able to say **no**.
+
+## 7. The foundation principle (already the spirit of formal-proof-first)
+
+> the maintainer: *"wherever I personally, or my self-model, is load-bearing without
+> externalization and proof, it's not a solid foundation to build on."*
+
+The multi-tower structure is *how you operationalize this at the axiom layer*: it
+ensures no single axiom set — and no single mind's conviction — is the sole
+load-bearing foundation. Math claims externalize to **proof**; the claims proof
+can't reach externalize to **other minds** (the asymmetric-critic peer + the
+human reviewers + Soraya). Composes with `consensus ≠ validation`: a second
+oracle agreeing (Kestrel, or another tower) is agreement, not truth — the proof,
+and the cross-foundation survival, are what validate.
+
+## Rule-landing candidate (OFFERED — not minted)
+
+**Multi-tower / foundation-independence extension to `formal-proof-first`:**
+canonical claims should, over time, be proven from **multiple genuinely-independent
+widely-accepted axiom foundations**; robustness is measured by **distinct
+equivalence classes** of foundation; independence is a **proof obligation**
+(inter-derivability test) that extends to auditing derivations for **hidden shared
+dependencies** (AoC the canonical case); a **constructive tower** is a high-value
+code-aligned independent foundation. Composes with the layered-lemma discipline
+(the dependency-tracking defense) + `formal-verification-expert` (Soraya's
+portfolio view + BP-16 cross-check). **Soraya should ratify before it lands** —
+this is the formal-coverage portfolio's territory.
+
+## Composes with
+
+- `.claude/rules/formal-proof-first-proven-by-default-consensus-not-validation-canonical-is-homeostat-proven-from-seed-ace-shields-zeta.md` — the canonical bar; this is the axiom-layer extension (multi-tower keeps no single axiom load-bearing)
+- the layered-lemma discipline section in that rule (#6642 + #6644) — the explicit-dependency-tracking that defends against hidden AoC
+- `.claude/agents/formal-verification-expert.md` (Soraya) — owns the formal-coverage portfolio + BP-16 cross-check; natural owner of the multi-tower portfolio + ratifier of the offered rule
+- `.claude/rules/god-tier-claims-high-signal-high-suspicion-dont-collapse.md` — the maintainer's panpsychist-axiom source + Cantor-intuition self-model held high-signal/high-suspicion/don't-collapse; the multi-tower structure is the operational don't-collapse (no single axiom set is load-bearing)
+- `.claude/rules/verify-existing-substrate-before-authoring.md` — search-first (done; no prior consolidated substrate found)
+- `docs/research/2026-06-03-formal-proof-claim-ledger-for-asymmetric-critic-pass.md` — the second-pass ledger; multi-tower adds the "from which foundation" axis
+- `docs/research/2026-06-03-zset-family-canonical-connection-four-language-bytelock-plus-four-tool-proofs.md` — the connection ledger; the Lean leg is the start of the constructive/machine-checked tower
+- `docs/research/2026-06-03-kestrel-aaron-critic-layers-permission-liability-autonomy-bounds-anthropomorphic-register-split-aaron-forwarded.md` — same cadence; consensus≠validation applies to Kestrel + to each tower
+- `B-1007` (formal-coverage cadence) · `B-0446` / `B-0131` (Lean-proof rows — the constructive/machine-checked tower) · `B-0543` (axioms→proof-path precedent)
+- `tools/lean4/Lean4/DbspChainRule.lean` — the existing Lean leg (general over abelian group `G`)
+
+## Substrate-honest framing
+
+This note authors no proof and mints no rule — it **preserves** the engineering /
+proof-strategy substrate from the forwarded exchange (per the verbatim-preservation
+trigger in `substrate-or-it-didnt-happen.md`) and **offers** the multi-tower
+rule-extension for Soraya's ratification. The personal/wellbeing content from the
+same exchange is intentionally excluded (harm-by-grammar); the wellness/self-knowledge
+**product** idea discussed there (moral-invariant drift-metrics, the
+wellness-vs-medical-device line, tool-describes / clinician-interprets) is the
+maintainer + co-maintainer's product call and is **not** captured as repo substrate
+here. Verbatim-in-principle: the maintainer's exact formulations of the *proof-strategy*
+claims are quoted; nothing personal is reproduced.


### PR DESCRIPTION
Preserves the **engineering / proof-strategy substrate** from a forwarded Kestrel × maintainer exchange (continuing the formal-proof cadence). Extends the layered-lemma discipline (#6642 + #6644) + `formal-proof-first`.

**Substrate captured:**
- Multi-tower proofs from independent widely-accepted axiom sets (don't rest canonical on one axiom set; valid-given-axioms ≠ true).
- Robustness = **distinct equivalence classes** of foundation, not tower count.
- Foundation-independence as a **proof obligation** (A⟺B inter-derivability; AoC⟺Zorn⟺Well-Ordering collapse to one class; partial/conditional → claim-relative).
- The **Axiom-of-Choice hidden-dependency** lesson: audit *derivations* for hidden shared axioms, not just *stated* ones — and the **layered-lemma explicit-dependency-tracking already on main is the defense** (clean convergence).
- The **constructive / Curry-Howard tower**: Choice-free by construction, proof = program, code-aligned (composes with the Lean leg).
- Intuition calibrated by **provable output over time** (track the misses).

**Discipline applied:**
- §33 headers (Scope / Attribution / Operational status / Non-fusion disclaimer) in the first 20 lines.
- **Personal / wellbeing / mental-health content from the same exchange intentionally NOT reproduced** (harm-by-grammar); that's the maintainer's village's lane. The wellness-product idea is the maintainer + co-maintainer's call, not captured as repo substrate.
- god-tier-don't-collapse applied to the panpsychist-axiom source + Cantor-intuition self-model (high-signal noticing preserved; mechanism-self-model held as self-description).
- The multi-tower **rule-extension to `formal-proof-first` is OFFERED, not minted** — Soraya (`formal-verification-expert`) owns the portfolio + BP-16 cross-check and should ratify.

Search-first done (no prior consolidated substrate). Single new docs/research file, MD049-clean, canary 67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)