### PR TITLE
feat(ace): slice 8.5 — canonical-JSON seam cross-language golden vectors

### DIFF
--- a/docs/agendas/ace-package-manager/2026-06-03-ace-slice8.5-canonical-json-golden-vectors-design.md
+++ b/docs/agendas/ace-package-manager/2026-06-03-ace-slice8.5-canonical-json-golden-vectors-design.md
@@ -1,0 +1,161 @@
+# Ace slice 8.5 — canonical-JSON seam golden vectors (design)
+
+> Sixth step of the cross-language Ace trust core (after slice 8 SHA-256, 8.1 canonical-JSON,
+> 8.2 package_hash, 8.3 ed25519, 8.4 index-signature). The Ace canonical seam
+> (`canonicalBytes` / `toTagged` in `tools/ace/canonical.ts`) is the byte form every
+> `package_hash` and every signature is computed over — but it has **no cross-language golden
+> vectors of its own**. This slice anchors the seam with a golden-vector fixture so a future
+> Rust/F#/C# Ace reproduces Ace's canonical byte form byte-identically. Brainstormed + approved
+> with the operator 2026-06-03 (scope: golden vectors for the seam delta, TS, 4-lang parity
+> spec'd; coverage: canonical + invalid; no extraction — `canonical.ts` already exists at 8.1).
+
+## Goal
+
+`canonicalBytes(value)` = `TextEncoder.encode(canonicalJson(toTagged(value)))`. It is the
+single byte form the trust core hashes (8.2 package_hash) and signs (8.3/8.4) over, so a
+non-TS Ace that disagrees on canonical bytes by one byte produces a different hash / a
+signature that won't verify. The seam is well unit-tested (`canonical.test.ts`) but has no
+language-independent contract. This slice gives it the golden-vector contract.
+
+## What this slice vectors — the seam delta, NOT the shared primitive
+
+`canonical.ts` is a **seam** (own-the-interface) over the project's shared, already-4-language-
+byte-locked `canonicalJson` (`src/Core.TypeScript/dynamic-value/json.ts`, with its own
+`golden-vectors*.json`). 8.5 does **not** re-vector the shared primitive. It vectors the
+**delta the seam adds** in `toTagged`:
+
+- **code-unit key sort** — object entries emitted in `Object.keys().sort()` (UTF-16 code-unit)
+  order, at every nesting level (Ace's key-order-independent canonicalization).
+- **safe-integer-only** — a JS `number` must be `Number.isSafeInteger`; float / NaN / Infinity /
+  out-of-safe-range throw (Ace canonical content has no Float fields).
+- **lone-surrogate rejection** — strings + object keys must be well-formed UTF-16; a lone
+  surrogate throws (it would collapse to U+FFFD under UTF-8, a trust-core byte collision).
+- **array order preserved** — arrays keep insertion order (only object *keys* sort) and recurse.
+
+## Canonical-gate status (operator 2026-06-03)
+
+Per the canonical-primitive gate (proof **and** 4-language byte-lock): this slice anchors the
+Ace seam but it stays **TS-only + proof-owed → NOT canonical yet**. The shared `canonicalJson`
+underneath is already 4-language byte-locked (its own fixtures); the seam's `toTagged` rules are
+TS-only until a non-TS Ace implements them. The golden vectors are the *data the eventual
+4-language seam + proof run on*. The new fixture is auto-discovered by
+`tools/ci/cross-verify-all.ts`, so the byte-lock is CI-enforced the moment it lands.
+
+## Decisions (this spec locks them; operator 2026-06-03)
+
+1. **Fixture-only — no extraction, no code change.** `canonical.ts` already exists as the named
+   primitive (8.1) and its unit tests (`canonical.test.ts`) are thorough. 8.5 adds only the
+   cross-language fixture under `tests/cross-verification/canonical-json/`. No change to
+   `canonical.ts` or `canonical.test.ts`.
+
+2. **Two layers (mirror 8.2–8.4; no envelope layer — no signing here).**
+   - **canonical** — `value` → `expected_canonical_json` (the byte string) **and**
+     `expected_sha256` = `sha256(canonicalBytes(value))` (composes slice 8 + 8.1; a non-TS Ace
+     computes canonical bytes then SHA-256 and matches both).
+   - **invalid** — `value` → `canonicalBytes` **throws**; assert it throws and that the message
+     contains `expected_error_substring`.
+
+3. **canonical (valid) vectors — generic JSON values exercising the seam rules:**
+   - keys out of order → sorted output; nested objects sort at every level.
+   - arrays preserve insertion order + recurse (NOT sorted).
+   - empty object `{}`, empty array `[]`, nested empties.
+   - mixed types (int / bool / null / str / arr / obj) in one structure.
+   - safe-integer bounds: `0`, a negative, `MAX_SAFE_INTEGER` (9007199254740991),
+     `MIN_SAFE_INTEGER` (-9007199254740991).
+   - well-formed unicode including an astral code point (e.g. `😀`) **in a value** — exercises
+     UTF-8 byte output.
+   - **Object keys stay BMP (≤ U+FFFF).** JS `.sort()` is UTF-16 code-unit order; Python's
+     `sort_keys` is code-point order; these agree on BMP but diverge on astral keys (surrogate
+     code units 0xD800–0xDFFF vs the real code point). Ace's real keys are ASCII (package names,
+     versions, field names), so BMP-only keys both keep the independent Python anchor faithful
+     and match the real key domain. Astral characters appear only in values (where no sort
+     applies).
+
+4. **invalid (reject) vectors — JSON-representable rejects only:**
+   - float / non-integer number (`3.14`) → throws (`expected_error_substring`: "safe integer").
+   - unsafe-magnitude integer (`1e21`, which `JSON.parse` yields as a float) → throws
+     ("safe integer").
+   - lone surrogate in a string value (`"\ud800"`) → throws ("lone surrogate").
+   - lone surrogate in an object key (`{"\ud800": 1}`) → throws ("lone surrogate").
+   The non-JSON-representable rejects (NaN, Infinity, bigint, symbol, function, and the
+   `undefined`-property omission) stay **unit-only** in `canonical.test.ts` — a JSON parser in
+   any language cannot yield them, so they are out of scope for a cross-language fixture.
+
+5. **Independent verification (assert-don't-skip; non-tautology).** The canonical layer's
+   `expected_canonical_json` is re-derived independently via Python
+   `json.dumps(content, sort_keys=True, ensure_ascii=False, separators=(",",":"))` and
+   `expected_sha256` via Python `hashlib.sha256` — so the valid layer is not a TS-vs-TS
+   tautology (Python's code-point key sort == JS code-unit sort on the BMP-only keys; both emit
+   raw unicode and minimal integers). The reject layer is anchored by the explicit Ace-specific
+   rule + the TS throw-assertion (vanilla `json.dumps` would **not** reject a float — that is
+   precisely the seam rule, stated rather than independently re-derived).
+
+6. **No semantics change.** 8.5 adds a fixture only; `canonicalBytes` / `toTagged` behaviour is
+   unchanged and every existing assertion stays green.
+
+## Architecture
+
+```text
+tools/ace/canonical.ts                         # UNCHANGED (8.1): canonicalBytes / toTagged
+tools/ace/canonical.test.ts                    # UNCHANGED: thorough seam unit tests
+
+tests/cross-verification/canonical-json/
+  vectors.json      # 2 layers: canonical[] · invalid[]
+  cross-verify.ts   # imports canonicalBytes (+ node:crypto sha256); ASSERTS each vector;
+                    #   writes ts-output.json; exit!=0 on mismatch
+  ts-output.json    # committed oracle output
+```
+
+## Components
+
+- **`tests/cross-verification/canonical-json/vectors.json`** — new; canonical[] (value +
+  expected_canonical_json + expected_sha256) · invalid[] (value + expected_error_substring).
+- **`tests/cross-verification/canonical-json/cross-verify.ts`** — new; TS oracle. Canonical
+  layer asserts `TextDecoder.decode(canonicalBytes(v.value)) === expected_canonical_json` AND
+  `sha256(canonicalBytes(v.value)) === expected_sha256`. Invalid layer asserts `canonicalBytes`
+  throws and the message includes `expected_error_substring`. Writes `ts-output.json`; exits
+  non-zero on any mismatch.
+- **`tests/cross-verification/canonical-json/ts-output.json`** — new; committed oracle output.
+
+## Testing
+
+- **Unit:** unchanged — `canonical.test.ts` already covers toTagged (sort, int, safe-int reject,
+  empty, array order, nested sort, undefined-omit, unsupported-type reject, lone-surrogate
+  reject, astral accept) and canonicalBytes (minified sorted, empty, surrogate-vs-U+FFFD,
+  round-trip, determinism). 8.5 adds no unit tests.
+- **Golden-vector (`cross-verification/canonical-json/`):** the TS oracle computes
+  `canonicalBytes` (+ SHA-256) for each canonical vector and ASSERTS against the
+  independently-derived expected values; asserts each invalid vector throws with the expected
+  substring; writes `ts-output.json`; exits non-zero on any mismatch.
+- **Independent re-derivation:** Python `json.dumps(sort_keys=True, ensure_ascii=False,
+  separators=(",",":"))` reproduces each `expected_canonical_json`; Python `hashlib.sha256`
+  reproduces each `expected_sha256`.
+- **Behavior-preservation (load-bearing gate):** `bun test tools/ace/` stays green (no code
+  change); `bun --bun tsc --noEmit -p tsconfig.json` exit 0; `bun tools/ci/cross-verify-all.ts`
+  discovers + passes the new `canonical-json` dir (7/7).
+- **Gates:** the above + pure-LF + markdownlint on this doc.
+
+## Scope / YAGNI
+
+In scope: the seam golden-vector fixture (canonical + invalid) with independently-verified
+expected values; SHA-256 composition anchor. Out of scope: re-vectoring the shared
+`canonicalJson` (already 4-language byte-locked under `dynamic-value/`); a live F#/C#/Rust
+canonical oracle (deferred until a non-TS Ace exists — 4-lang parity is spec'd + anchored by the
+fixture); the non-JSON-representable reject cases (stay unit-only); any change to the
+canonicalization mechanism; astral characters in object keys (BMP-only keys, by decision 3); the
+formal proof (formal-coverage / lean-proof lane); making `cross-verify` a required
+branch-protection check (separate operator/devops step).
+
+## Files touched
+
+- `tests/cross-verification/canonical-json/vectors.json` — **new**.
+- `tests/cross-verification/canonical-json/cross-verify.ts` — **new**.
+- `tests/cross-verification/canonical-json/ts-output.json` — **new** (committed output).
+
+## Decomposition (1 task)
+
+- **T1 — golden-vector fixture.** `tests/cross-verification/canonical-json/vectors.json`
+  (canonical + invalid layers; canonical expected values independently re-derived via Python
+  `json.dumps` + `hashlib.sha256`) + `cross-verify.ts` (asserts bytes + sha256 + throw-substring,
+  exit-non-zero, writes `ts-output.json`); confirm `bun tools/ci/cross-verify-all.ts` discovers +
+  passes the new dir (7/7). No code or unit-test change.

--- a/tests/cross-verification/canonical-json/cross-verify.ts
+++ b/tests/cross-verification/canonical-json/cross-verify.ts
@@ -1,0 +1,60 @@
+// Ace canonical-JSON seam trust-core cross-verification oracle (TS).
+// Asserts every vector against expected values; writes ts-output.json; exit non-zero on any
+// mismatch (assert-don't-skip). Two layers:
+//   canonical — canonicalBytes(value) decodes to expected_canonical_json AND sha256(bytes)
+//               equals expected_sha256 (composes slice 8 SHA-256 + 8.1 canonical-JSON).
+//   invalid   — canonicalBytes(value) THROWS and the message contains expected_error_substring
+//               (the seam's safe-integer + lone-surrogate rejection rules).
+// The canonical expected_canonical_json + expected_sha256 were re-derived independently via
+// Python `json.dumps(sort_keys=True, ensure_ascii=False, separators=(",",":"))` + hashlib.sha256
+// at fixture-creation time — Python's JSON impl is wholly separate from Ace's canonicalJson, so a
+// match here is genuine cross-language agreement, not a TS-vs-TS tautology. (Object keys are
+// BMP-only so Python's code-point key sort == JS's UTF-16 code-unit sort.) Run from this
+// directory: `bun cross-verify.ts`.
+import { createHash } from "node:crypto";
+import { canonicalBytes } from "../../../tools/ace/canonical.ts";
+
+interface CanonVec { id: string; value: unknown; expected_canonical_json: string; expected_sha256: string; }
+interface InvalidVec { id: string; value: unknown; expected_error_substring: string; }
+
+const vec = JSON.parse(await Bun.file("vectors.json").text()) as {
+  canonical: CanonVec[]; invalid: InvalidVec[];
+};
+
+const dec = new TextDecoder();
+const out: Record<string, unknown> = {};
+let mismatches = 0;
+const fail = (msg: string): void => { mismatches++; console.error(msg); };
+const sha256hex = (b: Uint8Array): string => createHash("sha256").update(b).digest("hex");
+
+// --- canonical layer: TS reproduces the Python-derived canonical bytes + their SHA-256 ---
+const canonOut: Record<string, { canonical_json: string; sha256: string }> = {};
+for (const v of vec.canonical) {
+  const bytes = canonicalBytes(v.value);
+  const got = dec.decode(bytes);
+  const hash = sha256hex(bytes);
+  canonOut[v.id] = { canonical_json: got, sha256: hash };
+  if (got !== v.expected_canonical_json) fail(`canonical ${v.id}: JSON MISMATCH\n  got=${got}\n  exp=${v.expected_canonical_json}`);
+  if (hash !== v.expected_sha256) fail(`canonical ${v.id}: sha256 MISMATCH got=${hash} exp=${v.expected_sha256}`);
+}
+out.canonical = canonOut;
+
+// --- invalid layer: canonicalBytes MUST throw with the expected substring ---
+const invalidOut: Record<string, string> = {};
+for (const v of vec.invalid) {
+  let result: string;
+  try {
+    canonicalBytes(v.value);
+    result = "ACCEPTED";
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    result = msg.includes(v.expected_error_substring) ? `threw:${v.expected_error_substring}` : `threw:OTHER(${msg})`;
+  }
+  invalidOut[v.id] = result;
+  if (result !== `threw:${v.expected_error_substring}`) fail(`invalid ${v.id}: expected throw containing "${v.expected_error_substring}", got ${result}`);
+}
+out.invalid = invalidOut;
+
+await Bun.write("ts-output.json", JSON.stringify(out, null, 2) + "\n");
+console.log(`canonical-json cross-verify: canonical=${vec.canonical.length} invalid=${vec.invalid.length}, ${mismatches} mismatches.`);
+if (mismatches > 0) process.exit(1);

--- a/tests/cross-verification/canonical-json/ts-output.json
+++ b/tests/cross-verification/canonical-json/ts-output.json
@@ -1,0 +1,42 @@
+{
+  "canonical": {
+    "sorted-keys": {
+      "canonical_json": "{\"a\":1,\"b\":2,\"c\":3}",
+      "sha256": "e6a3385fb77c287a712e7f406a451727f0625041823ecf23bea7ef39b2e39805"
+    },
+    "nested-sort": {
+      "canonical_json": "{\"a\":3,\"z\":{\"x\":2,\"y\":1}}",
+      "sha256": "8d4ec158025ac90e3962f423d3201b8e960ee4280830656f6e536587a1f00fe9"
+    },
+    "array-order-preserved": {
+      "canonical_json": "{\"a\":2,\"b\":1,\"list\":[3,1,2]}",
+      "sha256": "f82619973b09e20282197cb23f290431b48fe6ce8978e49f8af0dfdb8d3b26d0"
+    },
+    "empty-and-nested-empty": {
+      "canonical_json": "{\"arr\":[],\"nested\":{\"e\":[]},\"obj\":{}}",
+      "sha256": "ccc3f81599af114b8f05308c17631c5984f92024b508c931cbd9dd0eba0323d2"
+    },
+    "mixed-types": {
+      "canonical_json": "{\"a\":[1,false,null],\"b\":true,\"i\":42,\"n\":null,\"s\":\"hi\"}",
+      "sha256": "9a52e6150ab3aca73c6d493a4b7d9494803be3b3075ab9d40be6aa07a7544a89"
+    },
+    "safe-int-bounds": {
+      "canonical_json": "{\"max\":9007199254740991,\"min\":-9007199254740991,\"neg\":-7,\"zero\":0}",
+      "sha256": "f83aa6c73be26828dc4f9431b95fb09e49ae3b274ff1e122e395c436e2ea59c9"
+    },
+    "astral-in-value": {
+      "canonical_json": "{\"emoji\":\"a😀b\",\"plain\":\"text\"}",
+      "sha256": "9054e5aadb8543f3ea423e35d6eebd0799479e5fbd4d1929590cf1be4711651e"
+    },
+    "top-level-array": {
+      "canonical_json": "[3,{\"a\":2,\"b\":1},\"x\"]",
+      "sha256": "d355965e27d2b1b8caebfd6b5ead13f99811d386c6ed390266f594abc55b4bf3"
+    }
+  },
+  "invalid": {
+    "float": "threw:safe integer",
+    "unsafe-magnitude": "threw:safe integer",
+    "lone-surrogate-value": "threw:lone surrogate",
+    "lone-surrogate-key": "threw:lone surrogate"
+  }
+}

--- a/tests/cross-verification/canonical-json/vectors.json
+++ b/tests/cross-verification/canonical-json/vectors.json
@@ -1,0 +1,127 @@
+{
+  "canonical": [
+    {
+      "id": "sorted-keys",
+      "value": {
+        "b": 2,
+        "a": 1,
+        "c": 3
+      },
+      "expected_canonical_json": "{\"a\":1,\"b\":2,\"c\":3}",
+      "expected_sha256": "e6a3385fb77c287a712e7f406a451727f0625041823ecf23bea7ef39b2e39805"
+    },
+    {
+      "id": "nested-sort",
+      "value": {
+        "z": {
+          "y": 1,
+          "x": 2
+        },
+        "a": 3
+      },
+      "expected_canonical_json": "{\"a\":3,\"z\":{\"x\":2,\"y\":1}}",
+      "expected_sha256": "8d4ec158025ac90e3962f423d3201b8e960ee4280830656f6e536587a1f00fe9"
+    },
+    {
+      "id": "array-order-preserved",
+      "value": {
+        "list": [
+          3,
+          1,
+          2
+        ],
+        "b": 1,
+        "a": 2
+      },
+      "expected_canonical_json": "{\"a\":2,\"b\":1,\"list\":[3,1,2]}",
+      "expected_sha256": "f82619973b09e20282197cb23f290431b48fe6ce8978e49f8af0dfdb8d3b26d0"
+    },
+    {
+      "id": "empty-and-nested-empty",
+      "value": {
+        "obj": {},
+        "arr": [],
+        "nested": {
+          "e": []
+        }
+      },
+      "expected_canonical_json": "{\"arr\":[],\"nested\":{\"e\":[]},\"obj\":{}}",
+      "expected_sha256": "ccc3f81599af114b8f05308c17631c5984f92024b508c931cbd9dd0eba0323d2"
+    },
+    {
+      "id": "mixed-types",
+      "value": {
+        "n": null,
+        "b": true,
+        "i": 42,
+        "s": "hi",
+        "a": [
+          1,
+          false,
+          null
+        ]
+      },
+      "expected_canonical_json": "{\"a\":[1,false,null],\"b\":true,\"i\":42,\"n\":null,\"s\":\"hi\"}",
+      "expected_sha256": "9a52e6150ab3aca73c6d493a4b7d9494803be3b3075ab9d40be6aa07a7544a89"
+    },
+    {
+      "id": "safe-int-bounds",
+      "value": {
+        "zero": 0,
+        "neg": -7,
+        "max": 9007199254740991,
+        "min": -9007199254740991
+      },
+      "expected_canonical_json": "{\"max\":9007199254740991,\"min\":-9007199254740991,\"neg\":-7,\"zero\":0}",
+      "expected_sha256": "f83aa6c73be26828dc4f9431b95fb09e49ae3b274ff1e122e395c436e2ea59c9"
+    },
+    {
+      "id": "astral-in-value",
+      "value": {
+        "emoji": "a\ud83d\ude00b",
+        "plain": "text"
+      },
+      "expected_canonical_json": "{\"emoji\":\"a\ud83d\ude00b\",\"plain\":\"text\"}",
+      "expected_sha256": "9054e5aadb8543f3ea423e35d6eebd0799479e5fbd4d1929590cf1be4711651e"
+    },
+    {
+      "id": "top-level-array",
+      "value": [
+        3,
+        {
+          "b": 1,
+          "a": 2
+        },
+        "x"
+      ],
+      "expected_canonical_json": "[3,{\"a\":2,\"b\":1},\"x\"]",
+      "expected_sha256": "d355965e27d2b1b8caebfd6b5ead13f99811d386c6ed390266f594abc55b4bf3"
+    }
+  ],
+  "invalid": [
+    {
+      "id": "float",
+      "value": 3.14,
+      "expected_error_substring": "safe integer"
+    },
+    {
+      "id": "unsafe-magnitude",
+      "value": 1e+21,
+      "expected_error_substring": "safe integer"
+    },
+    {
+      "id": "lone-surrogate-value",
+      "value": {
+        "k": "\ud800"
+      },
+      "expected_error_substring": "lone surrogate"
+    },
+    {
+      "id": "lone-surrogate-key",
+      "value": {
+        "\ud800": 1
+      },
+      "expected_error_substring": "lone surrogate"
+    }
+  ]
+}


### PR DESCRIPTION
## Slice 8.5 — canonical-JSON seam golden vectors

Sixth step of the cross-language Ace trust core (after slice 8 SHA-256, 8.1 canonical-JSON, 8.2 package_hash, 8.3 ed25519, 8.4 index-signature). `canonicalBytes` (`tools/ace/canonical.ts`) is the byte form **every** `package_hash` and signature is computed over — a non-TS Ace that disagrees by one byte produces a different hash / a signature that won't verify. It had no cross-language golden vectors of its own. This anchors the Ace **seam**.

Spec: `docs/agendas/ace-package-manager/2026-06-03-ace-slice8.5-canonical-json-golden-vectors-design.md` (in this PR).

### Scope — the seam delta only
`canonical.ts` is a seam over the project's shared, already-4-language-byte-locked `canonicalJson` (`dynamic-value/golden-vectors*.json`). This slice vectors **only the delta `toTagged` adds**: code-unit key sort · safe-integer-only · lone-surrogate reject · array-order preserved. **Fixture-only — no extraction, no code change, no unit-test change** (`canonical.test.ts` already covers the unit behaviour).

### Fixture (`tests/cross-verification/canonical-json/`)
- `vectors.json` — **canonical[8]** (`value` + `expected_canonical_json` + `expected_sha256` — composes slice 8 + 8.1): sorted-keys · nested-sort · array-order-preserved · empty+nested-empty · mixed-types · safe-int-bounds (0 / neg / MAX_SAFE / MIN_SAFE) · astral-in-value (😀) · top-level-array. **invalid[4]**: float · unsafe-magnitude (`1e21`) · lone-surrogate-value · lone-surrogate-key → each asserts `canonicalBytes` **throws** + `expected_error_substring`.
- Object keys are **BMP-only** so Python's code-point key sort == JS's UTF-16 code-unit sort; the astral char appears only in a value (where no sort applies). Matches Ace's real ASCII key domain.
- `cross-verify.ts` — TS oracle asserts `canonicalBytes == expected_canonical_json` **and** `sha256(bytes) == expected_sha256` for canonical, `throws + substring` for invalid; writes `ts-output.json`; exits non-zero on mismatch. **Auto-discovered by `cross-verify-all.ts` → 7/7.**

### Non-tautology
`expected_canonical_json` + `expected_sha256` were authored by **Python** `json.dumps(sort_keys=True, ensure_ascii=False, separators=(",",":"))` + `hashlib.sha256`; the TS oracle (Ace `canonicalJson` + `node:crypto`) reproduces them with **0 mismatches** — genuine cross-language agreement, Python's JSON impl being wholly separate from Ace's. Non-JSON-representable rejects (NaN/Infinity/bigint/symbol/function/undefined-omit) stay **unit-only** — a JSON parser in any language can't yield them.

### Canonical-gate status
The Ace seam stays **TS-only + proof-owed → not canonical yet** (the shared primitive underneath is 4-lang; the seam's `toTagged` rules are TS-only until a non-TS Ace implements them).

### Gates (all green locally)
- `bun --bun tsc --noEmit -p tsconfig.json` → exit 0
- `bun test tools/ace/` → **372 pass** (no code change)
- `bun tools/ci/cross-verify-all.ts` → **7/7 primitives** (incl. the new `canonical-json` dir)
- all files pure-LF · markdownlint clean
- subagent review: **APPROVE** (independent re-derivation confirmed, BMP-key reasoning sound, invalid vectors trace to distinct throw paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)