### PR TITLE
feat(ace): slice 8.6 — verifyIndex 3-gate cross-language golden vectors

### DIFF
--- a/docs/agendas/ace-package-manager/2026-06-03-ace-slice8.6-verifyindex-gate-golden-vectors-design.md
+++ b/docs/agendas/ace-package-manager/2026-06-03-ace-slice8.6-verifyindex-gate-golden-vectors-design.md
@@ -1,0 +1,175 @@
+# Ace slice 8.6 — verifyIndex 3-gate cross-language golden vectors (design)
+
+> Seventh step of the cross-language Ace trust core (after slice 8 SHA-256, 8.1 canonical-JSON,
+> 8.2 package_hash, 8.3 ed25519, 8.4 index-signature, 8.5 canonical-JSON seam vectors).
+> `verifyIndex` (`tools/ace/registry-remote.ts`) is the trust **decision** at fetch time — the
+> policy that decides whether to accept a fetched registry index. It composes the 8.4
+> index-signature primitive and adds anti-rollback + freshness. It has unit tests
+> (`registry-remote.test.ts`) but no cross-language golden vectors, so a future Rust/F#/C# Ace has
+> no contract for the accept/reject decision. This slice anchors that decision. Brainstormed +
+> approved with the operator 2026-06-03 (scope: golden vectors for the verdict + gate-class, TS,
+> 4-lang parity spec'd; coverage: one cases[] layer over all five checks + ordering + offline;
+> no extraction — `verifyIndex` already exists).
+
+## Goal
+
+A consumer accepts a registry's package list only after `verifyIndex` passes. If two language
+implementations disagree on the decision, that is a security divergence — one Ace accepts a
+rolled-back, stale, or wrong-key index another rejects. This slice byte-locks the decision as a
+language-independent contract so every Ace agrees.
+
+`verifyIndex(doc, remote, trustStore, cacheMeta, now, opts)` is a **pure function of explicit
+inputs** (`now` is a parameter, not wall-clock), so the full policy — including freshness — is
+deterministic and vectorable.
+
+## The five checks (in order)
+
+`verifyIndex` returns `{ ok: true }` or `{ ok: false, reason }` after, in order:
+
+1. **pinned-key** — `signature.key_id !== remote.key_id` → reject (the index isn't even claiming
+   the registry's pinned key).
+2. **signature** — `verifyIndexSignature(content, signature, trustStore)` not ok → reject with
+   the sub-reason (`unsupported-algo` / `untrusted-key` / `bad-signature`). Composes 8.4.
+3. **anti-rollback** — `doc.sequence < cacheMeta.sequence_high_water` → reject (a replayed older
+   index).
+4. **future-skew** — `Date.parse(issued_at) - now > MAX_FUTURE_SKEW_MS` (300000 ms = 5 min) →
+   reject (issued implausibly in the future).
+5. **staleness** — when **not** offline: `now - issued > max_staleness_days` (per-remote, default
+   `DEFAULT_MAX_STALENESS_DAYS = 30`) → reject (too old). Skipped when `opts.offline`.
+
+Else `{ ok: true }`.
+
+## What this slice vectors — the verdict + a stable gate-class
+
+The cross-language contract is the **verdict** (`ok`) **and which gate fired**, NOT the English
+`reason` string (a non-TS Ace will word its messages differently). The fixture stores a stable
+`expected_gate` class; the TS oracle maps `verifyIndex`'s free-text `reason` to that class via
+documented substrings. The classes:
+
+| `expected_gate` | TS `reason` substring | meaning |
+|---|---|---|
+| `ok` | (verdict `ok: true`) | all five checks pass |
+| `pinned-key` | `pinned key` | check 1 |
+| `signature:unsupported-algo` | `signature` + `unsupported-algo` | check 2 |
+| `signature:untrusted-key` | `signature` + `untrusted-key` | check 2 |
+| `signature:bad-signature` | `signature` + `bad-signature` | check 2 |
+| `rollback` | `rollback` | check 3 |
+| `future-skew` | `future` | check 4 |
+| `stale` | `stale` | check 5 |
+
+## Canonical-gate status (operator 2026-06-03)
+
+Per the canonical-primitive gate (proof **and** 4-language byte-lock): this slice anchors the
+trust decision but it stays **TS-only + proof-owed → NOT canonical yet**. The golden vectors are
+the *data the eventual 4-language policy + proof run on*. The fixture is auto-discovered by
+`tools/ci/cross-verify-all.ts`, so the byte-lock is CI-enforced the moment it lands.
+
+## Decisions (this spec locks them; operator 2026-06-03)
+
+1. **Fixture-only — no extraction, no code change.** `verifyIndex` is already a named export and
+   `registry-remote.test.ts` already unit-tests it. 8.6 adds only the cross-language fixture under
+   `tests/cross-verification/verify-index-gate/`. No change to `registry-remote.ts` or its tests.
+
+2. **One `cases[]` layer.** `verifyIndex` is a verdict function, so each vector is one full input
+   tuple → expected verdict. No canonical/envelope/invalid split.
+
+3. **Per-case shape:**
+   `{ id, doc, remote, trust, cache_sequence_high_water, now, offline, expected_ok, expected_gate }`
+   where `doc` = `{ format_version, sequence, issued_at, packages, signature }`, `remote` =
+   `{ url, key_id, max_staleness_days? }`, `trust` = `{ key_id: { public_key } }`. The oracle
+   builds the `CacheMeta` from `cache_sequence_high_water`
+   (`{ url, sequence_high_water, index_content_hash: "", fetched_at: "" }` — `verifyIndex` reads
+   only `sequence_high_water`).
+
+4. **Vectors (~12) — happy path, each gate firing, two ordering cases, offline + custom staleness:**
+   - `happy-path` — valid sig · seq ≥ high-water · fresh issued_at → `ok`.
+   - `pinned-key-mismatch` — `remote.key_id` ≠ `signature.key_id` → `pinned-key`.
+   - `sig-untrusted-key` — `remote.key_id` == `signature.key_id` but key not in `trust` →
+     `signature:untrusted-key`.
+   - `sig-bad-signature` — tampered signature bytes (key trusted, pinned) → `signature:bad-signature`.
+   - `sig-unsupported-algo` — `signature.algo = "rsa"` (pinned, trusted) → `signature:unsupported-algo`.
+   - `rollback` — `doc.sequence < cache_sequence_high_water` (sig valid, fresh) → `rollback`.
+   - `future-skew` — `issued_at` 10 min after `now` (> 5 min skew) → `future-skew`.
+   - `stale-default` — `issued_at` > 30 days before `now`, not offline → `stale`.
+   - `stale-custom` — `remote.max_staleness_days = 1`, `issued_at` 2 days before `now` → `stale`.
+   - `offline-skips-staleness` — `offline: true`, `issued_at` > 30 days old, sig valid, seq ok →
+     `ok` (staleness gate skipped; future-skew not triggered).
+   - `order-pinned-key-beats-bad-sig` — `remote.key_id` ≠ `signature.key_id` **and** signature
+     tampered → `pinned-key` (check 1 returns before check 2).
+   - `order-rollback-beats-stale` — `sequence < high-water` **and** `issued_at` > 30 days old →
+     `rollback` (check 3 returns before check 5).
+
+5. **Independent verification (assert-don't-skip; non-tautology).** A Python re-implementation of
+   the five-check policy (key_id compare · ed25519 verify via `cryptography` · sequence compare ·
+   future-skew & staleness arithmetic with the real constants 300000 ms / 30 days · the same
+   check order) authors each `expected_ok` + `expected_gate`. The TS oracle runs the real
+   `verifyIndex` and reproduces them. Two separate policy implementations agreeing = genuine
+   cross-language contract, not a TS-vs-TS tautology. The fixed keypair is reused from 8.4
+   (`ed25519:0dbe5a2385bc2af4`); signatures are over each case's actual content (so the rollback /
+   freshness cases carry valid signatures over their varied `sequence` / `issued_at`).
+
+6. **No semantics change.** 8.6 adds a fixture only; `verifyIndex` behaviour is unchanged and
+   every existing assertion stays green.
+
+## Architecture
+
+```text
+tools/ace/registry-remote.ts                   # UNCHANGED: verifyIndex (+ constants
+                                               #   DEFAULT_MAX_STALENESS_DAYS=30, MAX_FUTURE_SKEW_MS=300000)
+tools/ace/registry-remote.test.ts              # UNCHANGED: verifyIndex unit tests
+
+tests/cross-verification/verify-index-gate/
+  vectors.json      # one cases[] layer (~12): full input tuple → expected_ok + expected_gate
+  cross-verify.ts   # imports verifyIndex; runs each case; maps reason→gate-class; ASSERTS;
+                    #   writes ts-output.json; exit!=0 on mismatch
+  ts-output.json    # committed oracle output
+```
+
+## Components
+
+- **`tests/cross-verification/verify-index-gate/vectors.json`** — new; `cases[]`.
+- **`tests/cross-verification/verify-index-gate/cross-verify.ts`** — new; TS oracle. For each
+  case, builds the `CacheMeta`, calls `verifyIndex`, maps the result to a gate-class, and asserts
+  `ok === expected_ok` and `gate === expected_gate`. Writes `ts-output.json`; exits non-zero on
+  any mismatch.
+- **`tests/cross-verification/verify-index-gate/ts-output.json`** — new; committed oracle output.
+
+## Testing
+
+- **Unit:** unchanged — `registry-remote.test.ts` already covers `verifyIndex`. 8.6 adds no unit
+  tests.
+- **Golden-vector (`cross-verification/verify-index-gate/`):** the TS oracle runs the real
+  `verifyIndex` per case and ASSERTS verdict + gate-class against the Python-derived expected;
+  writes `ts-output.json`; exits non-zero on any mismatch.
+- **Independent re-derivation:** a Python five-check re-implementation reproduces each
+  `expected_ok` + `expected_gate` (ed25519 verify via `cryptography`; the real constants + order).
+- **Behavior-preservation (load-bearing gate):** `bun test tools/ace/` stays green (no code
+  change); `bun --bun tsc --noEmit -p tsconfig.json` exit 0; `bun tools/ci/cross-verify-all.ts`
+  discovers + passes the new `verify-index-gate` dir (8/8).
+- **Gates:** the above + pure-LF + markdownlint on this doc.
+
+## Scope / YAGNI
+
+In scope: the verdict + gate-class golden vectors for all five checks + ordering + offline +
+custom staleness, with independently-verified expected values. Out of scope: a live F#/C#/Rust
+verifyIndex oracle (deferred until a non-TS Ace exists — 4-lang parity is spec'd + anchored by
+the fixture); the network/cache plumbing of `fetchRemoteIndex` (304/200/offline-fallback — that
+is I/O orchestration around `verifyIndex`, not the decision itself; stays in
+`registry-remote.test.ts`); byte-locking the exact English `reason` strings (the contract is
+verdict + gate-class); any change to the verification policy; the formal proof (formal-coverage /
+lean-proof lane); making `cross-verify` a required branch-protection check (separate
+operator/devops step).
+
+## Files touched
+
+- `tests/cross-verification/verify-index-gate/vectors.json` — **new**.
+- `tests/cross-verification/verify-index-gate/cross-verify.ts` — **new**.
+- `tests/cross-verification/verify-index-gate/ts-output.json` — **new** (committed output).
+
+## Decomposition (1 task)
+
+- **T1 — golden-vector fixture.** `tests/cross-verification/verify-index-gate/vectors.json` (~12
+  cases; expected verdict + gate-class independently re-derived via a Python five-check
+  re-implementation) + `cross-verify.ts` (runs `verifyIndex`, maps reason→gate-class, asserts,
+  exit-non-zero, writes `ts-output.json`); confirm `bun tools/ci/cross-verify-all.ts` discovers +
+  passes the new dir (8/8). No code or unit-test change.

--- a/tests/cross-verification/verify-index-gate/cross-verify.ts
+++ b/tests/cross-verification/verify-index-gate/cross-verify.ts
@@ -1,0 +1,77 @@
+// Ace verifyIndex 3-gate trust-core cross-verification oracle (TS).
+// Runs the real verifyIndex for each case; asserts the VERDICT (ok) + a stable GATE-CLASS;
+// writes ts-output.json; exit non-zero on any mismatch (assert-don't-skip).
+//
+// The cross-language contract is the verdict + which gate fired, NOT the English reason string
+// (a non-TS Ace words its messages differently). The fixture stores expected_gate as a stable
+// class; this oracle maps verifyIndex's free-text reason to that class via documented substrings:
+//   pinned-key                 <- "pinned key"
+//   signature:unsupported-algo <- "signature" + "unsupported-algo"
+//   signature:untrusted-key    <- "signature" + "untrusted-key"
+//   signature:bad-signature    <- "signature" + "bad-signature"
+//   rollback                   <- "rollback"
+//   future-skew                <- "future"
+//   stale                      <- "stale"
+//   ok                         <- verdict ok:true
+//
+// Each case's expected_ok + expected_gate were authored by an INDEPENDENT Python five-check
+// re-implementation of verifyIndex (key_id compare; ed25519 verify via `cryptography`; sequence
+// compare; future-skew & staleness arithmetic with the real constants 300000 ms / 30 days; same
+// check order). Python's policy impl is wholly separate from Ace's verifyIndex, so a match here is
+// genuine cross-language agreement, not a TS-vs-TS tautology. Run from this directory:
+// `bun cross-verify.ts`.
+import { verifyIndex, type IndexDoc, type CacheMeta, type VerifyOpts } from "../../../tools/ace/registry-remote.ts";
+import type { RemoteRegistryConfig } from "../../../tools/ace/store.ts";
+import type { TrustEntry } from "../../../tools/ace/signing.ts";
+
+interface Case {
+  id: string;
+  doc: IndexDoc;
+  remote: RemoteRegistryConfig;
+  trust: Record<string, TrustEntry>;
+  cache_sequence_high_water: number;
+  now: number;
+  offline: boolean;
+  expected_ok: boolean;
+  expected_gate: string;
+}
+
+const vec = JSON.parse(await Bun.file("vectors.json").text()) as { cases: Case[] };
+
+function gateOf(r: { ok: true } | { ok: false; reason: string }): string {
+  if (r.ok) return "ok";
+  const m = r.reason;
+  if (m.includes("pinned key")) return "pinned-key";
+  if (m.includes("signature")) {
+    if (m.includes("unsupported-algo")) return "signature:unsupported-algo";
+    if (m.includes("untrusted-key")) return "signature:untrusted-key";
+    if (m.includes("bad-signature")) return "signature:bad-signature";
+    return `signature:?(${m})`;
+  }
+  if (m.includes("rollback")) return "rollback";
+  if (m.includes("future")) return "future-skew";
+  if (m.includes("stale")) return "stale";
+  return `?(${m})`;
+}
+
+const out: Record<string, { ok: boolean; gate: string }> = {};
+let mismatches = 0;
+const fail = (msg: string): void => { mismatches++; console.error(msg); };
+
+for (const c of vec.cases) {
+  const cacheMeta: CacheMeta = {
+    url: c.remote.url, sequence_high_water: c.cache_sequence_high_water,
+    index_content_hash: "", fetched_at: "",
+  };
+  const trustStore = new Map<string, TrustEntry>(Object.entries(c.trust));
+  const opts: VerifyOpts = { offline: c.offline };
+  const r = verifyIndex(c.doc, c.remote, trustStore, cacheMeta, c.now, opts);
+  const gate = gateOf(r);
+  out[c.id] = { ok: r.ok, gate };
+  if (r.ok !== c.expected_ok) fail(`${c.id}: ok MISMATCH got=${r.ok} exp=${c.expected_ok}`);
+  if (gate !== c.expected_gate) fail(`${c.id}: gate MISMATCH got=${gate} exp=${c.expected_gate}`);
+}
+
+await Bun.write("ts-output.json", JSON.stringify(out, null, 2) + "\n");
+console.log(`verify-index-gate cross-verify: cases=${vec.cases.length}, ${mismatches} mismatches.`);
+if (mismatches > 0) process.exit(1);

--- a/tests/cross-verification/verify-index-gate/ts-output.json
+++ b/tests/cross-verification/verify-index-gate/ts-output.json
@@ -1,0 +1,50 @@
+{
+  "happy-path": {
+    "ok": true,
+    "gate": "ok"
+  },
+  "pinned-key-mismatch": {
+    "ok": false,
+    "gate": "pinned-key"
+  },
+  "sig-untrusted-key": {
+    "ok": false,
+    "gate": "signature:untrusted-key"
+  },
+  "sig-bad-signature": {
+    "ok": false,
+    "gate": "signature:bad-signature"
+  },
+  "sig-unsupported-algo": {
+    "ok": false,
+    "gate": "signature:unsupported-algo"
+  },
+  "rollback": {
+    "ok": false,
+    "gate": "rollback"
+  },
+  "future-skew": {
+    "ok": false,
+    "gate": "future-skew"
+  },
+  "stale-default": {
+    "ok": false,
+    "gate": "stale"
+  },
+  "stale-custom": {
+    "ok": false,
+    "gate": "stale"
+  },
+  "offline-skips-staleness": {
+    "ok": true,
+    "gate": "ok"
+  },
+  "order-pinned-key-beats-bad-sig": {
+    "ok": false,
+    "gate": "pinned-key"
+  },
+  "order-rollback-beats-stale": {
+    "ok": false,
+    "gate": "rollback"
+  }
+}

--- a/tests/cross-verification/verify-index-gate/vectors.json
+++ b/tests/cross-verification/verify-index-gate/vectors.json
@@ -1,0 +1,421 @@
+{
+  "cases": [
+    {
+      "id": "happy-path",
+      "doc": {
+        "format_version": 1,
+        "sequence": 5,
+        "issued_at": "2026-06-02T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          }
+        },
+        "signature": {
+          "algo": "ed25519",
+          "key_id": "ed25519:0dbe5a2385bc2af4",
+          "sig": "jI6hbX5olmTDelvv5Yafe9rDvHpNkhAAJAv9rNj4737689iyFI7RY9c12866fxteFTHQQAY99X7SLmGRdWaEAQ=="
+        }
+      },
+      "remote": {
+        "url": "https://r",
+        "key_id": "ed25519:0dbe5a2385bc2af4"
+      },
+      "trust": {
+        "ed25519:0dbe5a2385bc2af4": {
+          "public_key": "MCowBQYDK2VwAyEAoIUueNhaJSEZEGI789wqWx7JBSeGUxUPnFSPQHRhnIA="
+        }
+      },
+      "cache_sequence_high_water": 3,
+      "now": 1780444800000,
+      "offline": false,
+      "expected_ok": true,
+      "expected_gate": "ok"
+    },
+    {
+      "id": "pinned-key-mismatch",
+      "doc": {
+        "format_version": 1,
+        "sequence": 5,
+        "issued_at": "2026-06-02T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          }
+        },
+        "signature": {
+          "algo": "ed25519",
+          "key_id": "ed25519:0dbe5a2385bc2af4",
+          "sig": "jI6hbX5olmTDelvv5Yafe9rDvHpNkhAAJAv9rNj4737689iyFI7RY9c12866fxteFTHQQAY99X7SLmGRdWaEAQ=="
+        }
+      },
+      "remote": {
+        "url": "https://r",
+        "key_id": "ed25519:deadbeefdeadbeef"
+      },
+      "trust": {
+        "ed25519:0dbe5a2385bc2af4": {
+          "public_key": "MCowBQYDK2VwAyEAoIUueNhaJSEZEGI789wqWx7JBSeGUxUPnFSPQHRhnIA="
+        }
+      },
+      "cache_sequence_high_water": 3,
+      "now": 1780444800000,
+      "offline": false,
+      "expected_ok": false,
+      "expected_gate": "pinned-key"
+    },
+    {
+      "id": "sig-untrusted-key",
+      "doc": {
+        "format_version": 1,
+        "sequence": 5,
+        "issued_at": "2026-06-02T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          }
+        },
+        "signature": {
+          "algo": "ed25519",
+          "key_id": "ed25519:0dbe5a2385bc2af4",
+          "sig": "jI6hbX5olmTDelvv5Yafe9rDvHpNkhAAJAv9rNj4737689iyFI7RY9c12866fxteFTHQQAY99X7SLmGRdWaEAQ=="
+        }
+      },
+      "remote": {
+        "url": "https://r",
+        "key_id": "ed25519:0dbe5a2385bc2af4"
+      },
+      "trust": {},
+      "cache_sequence_high_water": 3,
+      "now": 1780444800000,
+      "offline": false,
+      "expected_ok": false,
+      "expected_gate": "signature:untrusted-key"
+    },
+    {
+      "id": "sig-bad-signature",
+      "doc": {
+        "format_version": 1,
+        "sequence": 5,
+        "issued_at": "2026-06-02T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          }
+        },
+        "signature": {
+          "algo": "ed25519",
+          "key_id": "ed25519:0dbe5a2385bc2af4",
+          "sig": "jI6hbX5olmTDelvv5Yafe9rDvHpNkhAAJAv9rNj4737689iyFI7RY9c12866fxteFTHQQAY99X7SLmGRdWaEAAAA"
+        }
+      },
+      "remote": {
+        "url": "https://r",
+        "key_id": "ed25519:0dbe5a2385bc2af4"
+      },
+      "trust": {
+        "ed25519:0dbe5a2385bc2af4": {
+          "public_key": "MCowBQYDK2VwAyEAoIUueNhaJSEZEGI789wqWx7JBSeGUxUPnFSPQHRhnIA="
+        }
+      },
+      "cache_sequence_high_water": 3,
+      "now": 1780444800000,
+      "offline": false,
+      "expected_ok": false,
+      "expected_gate": "signature:bad-signature"
+    },
+    {
+      "id": "sig-unsupported-algo",
+      "doc": {
+        "format_version": 1,
+        "sequence": 5,
+        "issued_at": "2026-06-02T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          }
+        },
+        "signature": {
+          "algo": "rsa",
+          "key_id": "ed25519:0dbe5a2385bc2af4",
+          "sig": "jI6hbX5olmTDelvv5Yafe9rDvHpNkhAAJAv9rNj4737689iyFI7RY9c12866fxteFTHQQAY99X7SLmGRdWaEAQ=="
+        }
+      },
+      "remote": {
+        "url": "https://r",
+        "key_id": "ed25519:0dbe5a2385bc2af4"
+      },
+      "trust": {
+        "ed25519:0dbe5a2385bc2af4": {
+          "public_key": "MCowBQYDK2VwAyEAoIUueNhaJSEZEGI789wqWx7JBSeGUxUPnFSPQHRhnIA="
+        }
+      },
+      "cache_sequence_high_water": 3,
+      "now": 1780444800000,
+      "offline": false,
+      "expected_ok": false,
+      "expected_gate": "signature:unsupported-algo"
+    },
+    {
+      "id": "rollback",
+      "doc": {
+        "format_version": 1,
+        "sequence": 2,
+        "issued_at": "2026-06-02T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          }
+        },
+        "signature": {
+          "algo": "ed25519",
+          "key_id": "ed25519:0dbe5a2385bc2af4",
+          "sig": "C7ltBBlBPQgwvgmMqVL06cJygYMOSmsJmTe5Z0NZEIMdW3Bz8hpDn0s5o0z9wxVVdQY1aIt78rxZkU0RLWcmCQ=="
+        }
+      },
+      "remote": {
+        "url": "https://r",
+        "key_id": "ed25519:0dbe5a2385bc2af4"
+      },
+      "trust": {
+        "ed25519:0dbe5a2385bc2af4": {
+          "public_key": "MCowBQYDK2VwAyEAoIUueNhaJSEZEGI789wqWx7JBSeGUxUPnFSPQHRhnIA="
+        }
+      },
+      "cache_sequence_high_water": 5,
+      "now": 1780444800000,
+      "offline": false,
+      "expected_ok": false,
+      "expected_gate": "rollback"
+    },
+    {
+      "id": "future-skew",
+      "doc": {
+        "format_version": 1,
+        "sequence": 5,
+        "issued_at": "2026-06-03T00:10:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          }
+        },
+        "signature": {
+          "algo": "ed25519",
+          "key_id": "ed25519:0dbe5a2385bc2af4",
+          "sig": "4IcbG9A+v69BJNEReujYj1SN2T3uUHKIy+z8a8cV2A7rHlKI1LhrEbfhtVN/p5zUh7N8B1CJf2Yp6fHq+fvmCw=="
+        }
+      },
+      "remote": {
+        "url": "https://r",
+        "key_id": "ed25519:0dbe5a2385bc2af4"
+      },
+      "trust": {
+        "ed25519:0dbe5a2385bc2af4": {
+          "public_key": "MCowBQYDK2VwAyEAoIUueNhaJSEZEGI789wqWx7JBSeGUxUPnFSPQHRhnIA="
+        }
+      },
+      "cache_sequence_high_water": 3,
+      "now": 1780444800000,
+      "offline": false,
+      "expected_ok": false,
+      "expected_gate": "future-skew"
+    },
+    {
+      "id": "stale-default",
+      "doc": {
+        "format_version": 1,
+        "sequence": 5,
+        "issued_at": "2026-04-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          }
+        },
+        "signature": {
+          "algo": "ed25519",
+          "key_id": "ed25519:0dbe5a2385bc2af4",
+          "sig": "dtGs97g3qAXVDwMwOEbNKTEXQ2VHOk4gvNeuOQIaTbXVPYotmUCWmNMawXYFObVBNZgD5MbVwwyBUIevPOmFCg=="
+        }
+      },
+      "remote": {
+        "url": "https://r",
+        "key_id": "ed25519:0dbe5a2385bc2af4"
+      },
+      "trust": {
+        "ed25519:0dbe5a2385bc2af4": {
+          "public_key": "MCowBQYDK2VwAyEAoIUueNhaJSEZEGI789wqWx7JBSeGUxUPnFSPQHRhnIA="
+        }
+      },
+      "cache_sequence_high_water": 3,
+      "now": 1780444800000,
+      "offline": false,
+      "expected_ok": false,
+      "expected_gate": "stale"
+    },
+    {
+      "id": "stale-custom",
+      "doc": {
+        "format_version": 1,
+        "sequence": 5,
+        "issued_at": "2026-06-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          }
+        },
+        "signature": {
+          "algo": "ed25519",
+          "key_id": "ed25519:0dbe5a2385bc2af4",
+          "sig": "eaepxS5TsVInlPvpZwps0+qYKXfri6wnkfu0UtlRWXZxQUkRBb5fs9hiX1jQqveeP8EjuLC9rmsOd0pWf7OACQ=="
+        }
+      },
+      "remote": {
+        "url": "https://r",
+        "key_id": "ed25519:0dbe5a2385bc2af4",
+        "max_staleness_days": 1
+      },
+      "trust": {
+        "ed25519:0dbe5a2385bc2af4": {
+          "public_key": "MCowBQYDK2VwAyEAoIUueNhaJSEZEGI789wqWx7JBSeGUxUPnFSPQHRhnIA="
+        }
+      },
+      "cache_sequence_high_water": 3,
+      "now": 1780444800000,
+      "offline": false,
+      "expected_ok": false,
+      "expected_gate": "stale"
+    },
+    {
+      "id": "offline-skips-staleness",
+      "doc": {
+        "format_version": 1,
+        "sequence": 5,
+        "issued_at": "2026-04-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          }
+        },
+        "signature": {
+          "algo": "ed25519",
+          "key_id": "ed25519:0dbe5a2385bc2af4",
+          "sig": "dtGs97g3qAXVDwMwOEbNKTEXQ2VHOk4gvNeuOQIaTbXVPYotmUCWmNMawXYFObVBNZgD5MbVwwyBUIevPOmFCg=="
+        }
+      },
+      "remote": {
+        "url": "https://r",
+        "key_id": "ed25519:0dbe5a2385bc2af4"
+      },
+      "trust": {
+        "ed25519:0dbe5a2385bc2af4": {
+          "public_key": "MCowBQYDK2VwAyEAoIUueNhaJSEZEGI789wqWx7JBSeGUxUPnFSPQHRhnIA="
+        }
+      },
+      "cache_sequence_high_water": 3,
+      "now": 1780444800000,
+      "offline": true,
+      "expected_ok": true,
+      "expected_gate": "ok"
+    },
+    {
+      "id": "order-pinned-key-beats-bad-sig",
+      "doc": {
+        "format_version": 1,
+        "sequence": 5,
+        "issued_at": "2026-06-02T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          }
+        },
+        "signature": {
+          "algo": "ed25519",
+          "key_id": "ed25519:0dbe5a2385bc2af4",
+          "sig": "jI6hbX5olmTDelvv5Yafe9rDvHpNkhAAJAv9rNj4737689iyFI7RY9c12866fxteFTHQQAY99X7SLmGRdWaEAAAA"
+        }
+      },
+      "remote": {
+        "url": "https://r",
+        "key_id": "ed25519:deadbeefdeadbeef"
+      },
+      "trust": {
+        "ed25519:0dbe5a2385bc2af4": {
+          "public_key": "MCowBQYDK2VwAyEAoIUueNhaJSEZEGI789wqWx7JBSeGUxUPnFSPQHRhnIA="
+        }
+      },
+      "cache_sequence_high_water": 3,
+      "now": 1780444800000,
+      "offline": false,
+      "expected_ok": false,
+      "expected_gate": "pinned-key"
+    },
+    {
+      "id": "order-rollback-beats-stale",
+      "doc": {
+        "format_version": 1,
+        "sequence": 2,
+        "issued_at": "2026-04-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          }
+        },
+        "signature": {
+          "algo": "ed25519",
+          "key_id": "ed25519:0dbe5a2385bc2af4",
+          "sig": "1cPT+IoSd3RI5VxwM2VNrPHQIcmlr6ABIPJj/Fje3kpSqoLxPbncVAUUU9r3a5B6T08iixIkR5uZSOkHzRp8Bw=="
+        }
+      },
+      "remote": {
+        "url": "https://r",
+        "key_id": "ed25519:0dbe5a2385bc2af4"
+      },
+      "trust": {
+        "ed25519:0dbe5a2385bc2af4": {
+          "public_key": "MCowBQYDK2VwAyEAoIUueNhaJSEZEGI789wqWx7JBSeGUxUPnFSPQHRhnIA="
+        }
+      },
+      "cache_sequence_high_water": 5,
+      "now": 1780444800000,
+      "offline": false,
+      "expected_ok": false,
+      "expected_gate": "rollback"
+    }
+  ]
+}


### PR DESCRIPTION
## Slice 8.6 — verifyIndex 3-gate golden vectors

Seventh step of the cross-language Ace trust core (after slice 8 SHA-256, 8.1 canonical-JSON, 8.2 package_hash, 8.3 ed25519, 8.4 index-signature, 8.5 canonical-JSON seam vectors). `verifyIndex` (`tools/ace/registry-remote.ts:88`) is the index-trust **decision** at fetch time — the policy deciding whether to accept a fetched registry index. A divergence between language implementations here is a security hole: one Ace accepts a rolled-back / stale / wrong-key index another rejects.

Spec: `docs/agendas/ace-package-manager/2026-06-03-ace-slice8.6-verifyindex-gate-golden-vectors-design.md` (in this PR).

### Scope — fixture-only
`verifyIndex` is already a named export with unit tests (`registry-remote.test.ts`). **No extraction, no code change.** It's a pure function of explicit inputs (`now` is a parameter), so the full policy — including freshness — is deterministic and vectorable.

### The five ordered checks
pinned-key (`signature.key_id == remote.key_id`) → signature (`verifyIndexSignature`, composes 8.4) → anti-rollback (`sequence ≥ high-water`) → future-skew (`issued − now ≤ 300000 ms`) → staleness (`now − issued ≤ max_staleness_days`, default 30d, skipped when `offline`).

### Contract = verdict + stable gate-class (not the English reason)
A non-TS Ace words messages differently, so the contract is the **verdict** + **which gate fired**. `expected_gate ∈ {ok, pinned-key, signature:{unsupported-algo|untrusted-key|bad-signature}, rollback, future-skew, stale}`; the oracle maps `verifyIndex`'s free-text `reason` → class via documented substrings.

### Fixture (`tests/cross-verification/verify-index-gate/`)
- `vectors.json` — **cases[12]** (`doc` + `remote` + `trust` + `cache_sequence_high_water` + `now` + `offline` → `expected_ok` + `expected_gate`): happy-path; each gate firing (pinned-key-mismatch · sig-untrusted-key · sig-bad-signature · sig-unsupported-algo · rollback · future-skew · stale-default · stale-custom · offline-skips-staleness); **two ordering cases** (`order-pinned-key-beats-bad-sig`, `order-rollback-beats-stale` — both conditions true, assert the earlier gate wins).
- `cross-verify.ts` — TS oracle runs the real `verifyIndex`, maps reason→gate-class, asserts verdict + gate; writes `ts-output.json`; exits non-zero on mismatch. **Auto-discovered by `cross-verify-all.ts` → 8/8.**

### Non-tautology
A **Python five-check re-implementation** (key_id compare · ed25519 verify via `cryptography` · sequence compare · future-skew & staleness arithmetic with the real constants `300000` ms / `30`d · same order) authored every `expected_ok` + `expected_gate`; the TS oracle (real `verifyIndex`) reproduces them with **0 mismatches** — two separate policy implementations agreeing. Fixed keypair reused from 8.4 (`ed25519:0dbe5a2385bc2af4`); signatures are over each case's actual content (rollback/freshness cases carry valid sigs over their varied `sequence`/`issued_at`).

### Canonical-gate status
Stays **TS-only + proof-owed → not canonical yet**.

### Gates (all green locally)
- `bun --bun tsc --noEmit -p tsconfig.json` → exit 0
- `bun test tools/ace/` → **372 pass** (no code change)
- `bun tools/ci/cross-verify-all.ts` → **8/8 primitives** (incl. the new `verify-index-gate` dir)
- all files pure-LF · markdownlint clean
- subagent review: **APPROVE** (non-tautology + check-ordering + reason→gate mapping + real-signatures all confirmed; 3 cases independently re-derived)

🤖 Generated with [Claude Code](https://claude.com/claude-code)