### PR TITLE
research(fix): un-truncate two rule cross-references (Copilot on #6652)

### DIFF
--- a/docs/research/2026-06-03-kestrel-aaron-open-source-ethic-floor-governance-jurisdiction-relative-opa-federation-nexus-meta-jurisdiction-conflict-resolution-aaron-forwarded.md
+++ b/docs/research/2026-06-03-kestrel-aaron-open-source-ethic-floor-governance-jurisdiction-relative-opa-federation-nexus-meta-jurisdiction-conflict-resolution-aaron-forwarded.md
@@ -224,7 +224,7 @@ Refinements (what makes it real, not theatrical):
 
 Composes with: `must-paired-with-can-exit-pattern.md` (can't-stop-a-fork; bind by
 worth-staying-with not by being mandatory), `non-coercion-invariant.md`,
-`proud-if-pattern-propagates-...md`. **Rule/backlog candidate (OFFERED):** Nexus
+`proud-if-pattern-propagates-personal-filter-for-substrate-engineering.md`. **Rule/backlog candidate (OFFERED):** Nexus
 meta-jurisdiction as forkable peer (structural, interoperable forkability).
 
 ## Through-line
@@ -244,7 +244,7 @@ This note authors no rule and mints no doctrine — it **preserves** the
 engineering/governance substrate (per the verbatim-preservation trigger in
 `substrate-or-it-didnt-happen.md`) and **offers** the rule/backlog candidates for
 the maintainer to direct (the doctrine-level and floor-composing ones are not
-Otto's to mint unilaterally per `autonomous-decider-within-permission-bounds-...md`).
+Otto's to mint unilaterally per `autonomous-decider-within-permission-bounds-not-over-permission-liability-expansion.md`).
 Personal/wellbeing/personal-history content and the business ventures from the same
 exchange are intentionally excluded (harm-by-grammar; not Zeta engineering
 substrate). Verbatim-in-principle: the maintainer's exact formulations of the


### PR DESCRIPTION
Fix-forward for the 2 Copilot P1 threads on #6652 (merged before threads posted). Both valid: two cross-references used `...` ellipsis, making the cited rule files non-resolvable. Replaced with exact filenames (verified via `git ls-tree origin/main`):
- `proud-if-pattern-propagates-personal-filter-for-substrate-engineering.md`
- `autonomous-decider-within-permission-bounds-not-over-permission-liability-expansion.md`

Cross-reference integrity matters for substrate other agents follow. Canary 67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)