### PR TITLE
research(fix): TFeedback consistency + un-split OPLE acronym (Copilot on #6660)

### DIFF
--- a/docs/research/2026-06-03-three-bit-perfect-oracle-shapes-and-the-protection-model-aaron.md
+++ b/docs/research/2026-06-03-three-bit-perfect-oracle-shapes-and-the-protection-model-aaron.md
@@ -85,12 +85,12 @@ never has to be re-resolved.
 This places shape-1 precisely in the framework's existing substrate:
 
 - **The hexagonal / I/O-monad port** (`.claude/rules/bcl-interface-boundary-own-your-interfaces-hexagonal.md`:
-  *hexagonal IS the I/O-monad shape*). The serializer port — `parse : wire → Result<T, Feedback>`
+  *hexagonal IS the I/O-monad shape*). The serializer port — `parse : wire → Result<T, TFeedback>`
   — IS the Kleisli arrow at the external edge; **shape-1 is that port's first
   stage**, made bit-perfect across the oracles.
-- **OPLE `Observe`** — the external-observation intake (the "O" of Observe/Persist/
-  Limit/Emit). The serializer layer is the **first stage of Observe**: the raw
-  outside, mapped in and pinned.
+- **OPLE `Observe`** — the external-observation intake (the "O" of
+  `Observe`/`Persist`/`Limit`/`Emit`). The serializer layer is the **first stage of
+  Observe**: the raw outside, mapped in and pinned.
 - **The uncertainty-reduction telos** — the inference/Bayesian engine reduces
   uncertainty over observations downstream; shape-1 reduces it **at the I/O edge
   itself** — the prior to everything above it. Bit-perfect-at-the-edge means the


### PR DESCRIPTION
Fix-forward for 2 Copilot threads on #6660 (merged before threads posted). Both valid:
- **P1:** serializer port `Result<T, Feedback>` → `Result<T, TFeedback>` — consistency with the OPLE + monad-propagation convention (generic feedback, not a fixed `Feedback` type).
- **P2:** the OPLE acronym was split across a line break (rendered "Observe/Persist/ Limit/Emit"); reflowed + code-spanned each so `Observe`/`Persist`/`Limit`/`Emit` stays together.

Canary 67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)