### PR TITLE
feat(ace): slice 8.7 — revoke/quarantine mark algebra cross-language golden vectors

### DIFF
--- a/docs/agendas/ace-package-manager/2026-06-03-ace-slice8.7-revoke-quarantine-algebra-golden-vectors-design.md
+++ b/docs/agendas/ace-package-manager/2026-06-03-ace-slice8.7-revoke-quarantine-algebra-golden-vectors-design.md
@@ -1,0 +1,171 @@
+# Ace slice 8.7 — revoke/quarantine mark algebra cross-language golden vectors (design)
+
+> Eighth step of the cross-language Ace trust core (after slice 8 SHA-256, 8.1 canonical-JSON,
+> 8.2 package_hash, 8.3 ed25519, 8.4 index-signature, 8.5 canonical-JSON seam vectors, 8.6
+> verifyIndex 3-gate). `registry-revoke.ts` (slice 7) is the **publisher-side** state machine for
+> marking a package version bad inside the signed index: `applyRevoke` / `applyQuarantine` /
+> `applyUnquarantine`. It has unit tests but no cross-language golden vectors, so a future
+> Rust/F#/C# Ace has no contract for the mark transitions — and the marks are security state that
+> 8.4 signs and 8.6 enforces. This slice anchors the transitions. Brainstormed + approved with the
+> operator 2026-06-03 ("revoke/quarantine algebra now, then depth next"; scope: golden vectors for
+> the transitions + error cases, TS, 4-lang parity spec'd; no extraction — `registry-revoke.ts`
+> already exists).
+
+## Goal
+
+Two mark severities live inside `IndexSignableContent`:
+
+- **revoked** — terminal "this version is poisoned, never use it" (CVE, malicious release, leaked
+  key). Permanent.
+- **quarantined** — provisional "hold off, pending review". Reversible (`applyUnquarantine`).
+
+The full lifecycle: a maintainer **applies a mark** (this algebra) → **signs** the new index
+(8.4) → publishes → a consumer **authenticates** it (8.6) → **refuses** the marked version. If two
+language implementations disagree on the content that results from a mark op, they produce/expect
+**different signed indexes** (signature mismatch) or **divergent revocation state** (one Ace
+installs a CVE'd version another refuses). This slice byte-locks every transition so "this version
+is poisoned" means the same thing in every language. It closes the marks loop: **8.7 authors →
+8.4 signs → 8.6 enforces.**
+
+## The algebra (pure content → content transitions)
+
+`registry-revoke.ts` exports three pure functions over `IndexSignableContent`:
+
+- `applyRevoke(prev, name, version, reason?, at)` → content. Removes the version from
+  `quarantined` and adds it to `revoked` (**revoke supersedes quarantine**). Always succeeds.
+- `applyQuarantine(prev, name, version, reason?, at)` → content | `{ error }`. **Errors if the
+  version is already revoked** ("revoke is terminal — cannot downgrade a permanent mark").
+- `applyUnquarantine(prev, name, version, at)` → content | `{ error }`. **Errors if the version
+  is not quarantined.**
+
+All three end with `withFmt`, which: (a) sets `format_version = 2` iff a mark remains, else `1`;
+(b) strips empty mark maps (so a v1 result never carries `revoked:{}`/`quarantined:{}`, which
+`parseIndex` rejects); (c) sets `issued_at = at`. This is the **v2-iff-marks rule the 8.4 review
+caught**, enforced automatically. `RevocationEntry` is `{ reason?, at }` — `reason` is present only
+when provided.
+
+## Canonical-gate status (operator 2026-06-03)
+
+Per the canonical-primitive gate (proof **and** 4-language byte-lock): this slice anchors the mark
+algebra but it stays **TS-only + proof-owed → NOT canonical yet**. The golden vectors are the
+*data the eventual 4-language algebra + proof run on*. The fixture is auto-discovered by
+`tools/ci/cross-verify-all.ts`, so the byte-lock is CI-enforced the moment it lands.
+
+## Decisions (this spec locks them; operator 2026-06-03)
+
+1. **Fixture-only — no extraction, no code change.** `registry-revoke.ts` is already a named
+   module (slice 7) with unit tests. 8.7 adds only the cross-language fixture under
+   `tests/cross-verification/revoke-quarantine/`. No change to `registry-revoke.ts` or its tests.
+
+2. **Two layers.**
+   - **transitions** — `(prev, op, name, version, reason?, at)` → resulting content, byte-locked
+     via `expected_canonical_json` (= `canonicalBytes(result)`, composes 8.5/8.1) **and**
+     `expected_sha256` (= `sha256` of those bytes, composes slice 8). The result is exactly what a
+     maintainer would then sign (8.4).
+   - **invalid** — `(prev, op, …)` → `{ error }`; assert `"error" in result` and the message
+     contains `expected_error_substring`.
+
+3. **Per-case shape:**
+   `{ id, op, prev, name, version, reason?, at, expected_canonical_json, expected_sha256 }` for
+   transitions; `{ id, op, prev, name, version, reason?, at, expected_error_substring }` for
+   invalid. `op ∈ { revoke, quarantine, unquarantine }`; the oracle dispatches to the matching
+   function. `prev` is a full `IndexSignableContent`.
+
+4. **transition vectors (~8):**
+   - `revoke-fresh` — `prev` has no marks → `applyRevoke` → version in `revoked`,
+     `format_version: 2`.
+   - `quarantine-fresh` — no marks → `applyQuarantine` → version in `quarantined`,
+     `format_version: 2`.
+   - `revoke-supersedes-quarantine` — `prev` has the version quarantined → `applyRevoke` same
+     version → moved to `revoked`, removed from `quarantined`.
+   - `unquarantine-back-to-v1` — `prev` has exactly one quarantined version (no revoked) →
+     `applyUnquarantine` → `quarantined` empties → map stripped → `format_version` back to `1`.
+   - `revoke-without-reason` — `applyRevoke` with `reason` omitted → entry is `{ at }` only (no
+     `reason` field).
+   - `quarantine-with-reason` — entry is `{ at, reason }`.
+   - `revoke-one-of-two-quarantined` — `prev` has two quarantined versions → revoke one → it moves
+     to `revoked`, the other stays quarantined, `format_version` stays `2`.
+   - `multi-package` — `prev` has a mark on package A → add a mark on package B → both present.
+
+5. **invalid vectors (2):**
+   - `quarantine-after-revoke` — `prev` has the version revoked → `applyQuarantine` → error;
+     `expected_error_substring`: "terminal".
+   - `unquarantine-not-quarantined` — `prev` has no quarantine for the version → `applyUnquarantine`
+     → error; `expected_error_substring`: "not quarantined".
+
+6. **Independent verification (assert-don't-skip; non-tautology).** A Python re-implementation of
+   the three apply functions + `withFmt` (the supersession rules, the v2-iff-marks +
+   empty-map-strip logic, `issued_at = at`) authors each transition's `expected_canonical_json`
+   (via `json.dumps(sort_keys=True, ensure_ascii=False, separators=(",",":"))`) + `expected_sha256`
+   (via `hashlib.sha256`), and each invalid case's `expected_error_substring`. The TS oracle runs
+   the **real** apply functions and reproduces them. Two separate algebra implementations agreeing
+   = genuine cross-language contract, not a TS-vs-TS tautology. Object keys (package names,
+   versions, entry fields) are BMP/ASCII, so Python's code-point key sort == JS code-unit sort (per
+   the 8.5 reasoning).
+
+7. **No semantics change.** 8.7 adds a fixture only; `registry-revoke.ts` behaviour is unchanged
+   and every existing assertion stays green.
+
+## Architecture
+
+```text
+tools/ace/registry-revoke.ts                   # UNCHANGED (slice 7): applyRevoke / applyQuarantine
+                                               #   / applyUnquarantine (+ internal withFmt)
+tools/ace/registry-revoke.test.ts (if present) # UNCHANGED unit tests
+
+tests/cross-verification/revoke-quarantine/
+  vectors.json      # two layers: transitions[] · invalid[]
+  cross-verify.ts   # dispatches op -> apply fn; canonicalBytes(result) + sha256 for transitions,
+                    #   error+substring for invalid; writes ts-output.json; exit!=0 on mismatch
+  ts-output.json    # committed oracle output
+```
+
+## Components
+
+- **`tests/cross-verification/revoke-quarantine/vectors.json`** — new; `transitions[]` +
+  `invalid[]`.
+- **`tests/cross-verification/revoke-quarantine/cross-verify.ts`** — new; TS oracle. Dispatches
+  each case's `op` to the matching apply function; for transitions asserts
+  `canonicalBytes(result) === expected_canonical_json` AND `sha256 === expected_sha256`; for
+  invalid asserts the result carries `error` containing `expected_error_substring`. Writes
+  `ts-output.json`; exits non-zero on any mismatch.
+- **`tests/cross-verification/revoke-quarantine/ts-output.json`** — new; committed oracle output.
+
+## Testing
+
+- **Unit:** unchanged — `registry-revoke.test.ts` (if present) already covers the apply functions.
+  8.7 adds no unit tests.
+- **Golden-vector (`cross-verification/revoke-quarantine/`):** the TS oracle runs the real apply
+  functions per case and ASSERTS the resulting canonical bytes + SHA-256 (transitions) or the
+  error substring (invalid) against the Python-derived expected; writes `ts-output.json`; exits
+  non-zero on any mismatch.
+- **Independent re-derivation:** a Python algebra re-implementation reproduces each transition's
+  canonical + sha256 and each invalid case's error.
+- **Behavior-preservation (load-bearing gate):** `bun test tools/ace/` stays green (no code
+  change); `bun --bun tsc --noEmit -p tsconfig.json` exit 0; `bun tools/ci/cross-verify-all.ts`
+  discovers + passes the new `revoke-quarantine` dir (9/9).
+- **Gates:** the above + pure-LF + markdownlint on this doc.
+
+## Scope / YAGNI
+
+In scope: the transition + error golden vectors for the three apply functions + the `withFmt`
+v2/strip logic, with independently-verified expected values; SHA-256 composition anchor. Out of
+scope: a live F#/C#/Rust revoke oracle (deferred until a non-TS Ace exists — 4-lang parity is
+spec'd + anchored by the fixture); the consumer-side enforcement of marks (that is the
+resolve/install path, separate from the authoring algebra); any change to the algebra; the formal
+proof (formal-coverage / lean-proof lane); making `cross-verify` a required branch-protection
+check (separate operator/devops step).
+
+## Files touched
+
+- `tests/cross-verification/revoke-quarantine/vectors.json` — **new**.
+- `tests/cross-verification/revoke-quarantine/cross-verify.ts` — **new**.
+- `tests/cross-verification/revoke-quarantine/ts-output.json` — **new** (committed output).
+
+## Decomposition (1 task)
+
+- **T1 — golden-vector fixture.** `tests/cross-verification/revoke-quarantine/vectors.json` (~8
+  transitions + 2 invalid; expected values independently re-derived via a Python algebra
+  re-implementation) + `cross-verify.ts` (dispatches op, asserts canonical + sha256 / error,
+  exit-non-zero, writes `ts-output.json`); confirm `bun tools/ci/cross-verify-all.ts` discovers +
+  passes the new dir (9/9). No code or unit-test change.

--- a/tests/cross-verification/revoke-quarantine/cross-verify.ts
+++ b/tests/cross-verification/revoke-quarantine/cross-verify.ts
@@ -1,0 +1,77 @@
+// Ace revoke/quarantine mark-algebra trust-core cross-verification oracle (TS).
+// Dispatches each case's op to the real applyRevoke / applyQuarantine / applyUnquarantine and
+// asserts the result; writes ts-output.json; exit non-zero on any mismatch (assert-don't-skip).
+// Two layers:
+//   transitions — the apply produces content; assert canonicalBytes(content) == expected_canonical_json
+//                 AND sha256(bytes) == expected_sha256 (composes slice 8 SHA-256 + 8.1/8.5 canonical).
+//                 The content is exactly what a maintainer would then sign (8.4).
+//   invalid     — the apply returns { error }; assert error contains expected_error_substring
+//                 (the supersession guards: revoke-terminal, unquarantine-must-be-quarantined).
+//
+// Each expected value was authored by an INDEPENDENT Python re-implementation of the algebra
+// (the three apply functions + withFmt: revoke-supersedes-quarantine, revoke-terminal, the
+// v2-iff-marks + empty-map-strip logic, issued_at=at) + json.dumps(sort_keys) + hashlib.sha256.
+// Python's algebra impl is wholly separate from registry-revoke.ts, so a match here is genuine
+// cross-language agreement, not a TS-vs-TS tautology. Run from this directory: `bun cross-verify.ts`.
+import { createHash } from "node:crypto";
+import { applyRevoke, applyQuarantine, applyUnquarantine } from "../../../tools/ace/registry-revoke.ts";
+import { canonicalBytes } from "../../../tools/ace/canonical.ts";
+import type { IndexSignableContent } from "../../../tools/ace/index-signature.ts";
+
+interface BaseCase {
+  id: string;
+  op: "revoke" | "quarantine" | "unquarantine";
+  prev: IndexSignableContent;
+  name: string;
+  version: string;
+  reason?: string;
+  at: string;
+}
+interface TransitionCase extends BaseCase { expected_canonical_json: string; expected_sha256: string; }
+interface InvalidCase extends BaseCase { expected_error_substring: string; }
+
+const vec = JSON.parse(await Bun.file("vectors.json").text()) as {
+  transitions: TransitionCase[]; invalid: InvalidCase[];
+};
+
+function applyOp(c: BaseCase): IndexSignableContent | { error: string } {
+  if (c.op === "revoke") return applyRevoke(c.prev, c.name, c.version, c.reason, c.at);
+  if (c.op === "quarantine") return applyQuarantine(c.prev, c.name, c.version, c.reason, c.at);
+  return applyUnquarantine(c.prev, c.name, c.version, c.at);
+}
+
+const dec = new TextDecoder();
+const out: Record<string, unknown> = {};
+let mismatches = 0;
+const fail = (msg: string): void => { mismatches++; console.error(msg); };
+const sha256hex = (b: Uint8Array): string => createHash("sha256").update(b).digest("hex");
+
+// --- transitions: real apply produces content; assert canonical bytes + sha256 ---
+const tOut: Record<string, { canonical_json: string; sha256: string }> = {};
+for (const c of vec.transitions) {
+  const r = applyOp(c);
+  if ("error" in r) { fail(`transition ${c.id}: unexpected error ${r.error}`); continue; }
+  const bytes = canonicalBytes(r);
+  const got = dec.decode(bytes);
+  const hash = sha256hex(bytes);
+  tOut[c.id] = { canonical_json: got, sha256: hash };
+  if (got !== c.expected_canonical_json) fail(`transition ${c.id}: JSON MISMATCH\n  got=${got}\n  exp=${c.expected_canonical_json}`);
+  if (hash !== c.expected_sha256) fail(`transition ${c.id}: sha256 MISMATCH got=${hash} exp=${c.expected_sha256}`);
+}
+out.transitions = tOut;
+
+// --- invalid: real apply returns { error } containing the expected substring ---
+const iOut: Record<string, string> = {};
+for (const c of vec.invalid) {
+  const r = applyOp(c);
+  let result: string;
+  if (!("error" in r)) result = "ACCEPTED";
+  else result = r.error.includes(c.expected_error_substring) ? `error:${c.expected_error_substring}` : `error:OTHER(${r.error})`;
+  iOut[c.id] = result;
+  if (result !== `error:${c.expected_error_substring}`) fail(`invalid ${c.id}: expected error containing "${c.expected_error_substring}", got ${result}`);
+}
+out.invalid = iOut;
+
+await Bun.write("ts-output.json", JSON.stringify(out, null, 2) + "\n");
+console.log(`revoke-quarantine cross-verify: transitions=${vec.transitions.length} invalid=${vec.invalid.length}, ${mismatches} mismatches.`);
+if (mismatches > 0) process.exit(1);

--- a/tests/cross-verification/revoke-quarantine/ts-output.json
+++ b/tests/cross-verification/revoke-quarantine/ts-output.json
@@ -1,0 +1,40 @@
+{
+  "transitions": {
+    "revoke-fresh": {
+      "canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"revoked\":{\"leaf\":{\"1.0.0\":{\"at\":\"2026-06-02T00:00:00Z\",\"reason\":\"cve\"}}},\"sequence\":5}",
+      "sha256": "81840fe2e22e169d6c8db6c229fb18eb4c65b225805043ffdd916256087b9473"
+    },
+    "quarantine-fresh": {
+      "canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"quarantined\":{\"tool\":{\"2.0.0\":{\"at\":\"2026-06-02T00:00:00Z\",\"reason\":\"review\"}}},\"sequence\":5}",
+      "sha256": "ca2d8c13e712270311cd503b7122cf64b4adedf35f3baef561596a9b74a15f46"
+    },
+    "revoke-supersedes-quarantine": {
+      "canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"revoked\":{\"leaf\":{\"1.0.0\":{\"at\":\"2026-06-02T00:00:00Z\",\"reason\":\"cve\"}}},\"sequence\":6}",
+      "sha256": "c1322c1edf73c40659c68352333154b7fe00721bcb726378ddeabd71fbf061f4"
+    },
+    "unquarantine-back-to-v1": {
+      "canonical_json": "{\"format_version\":1,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"sequence\":7}",
+      "sha256": "397be54f9145e9f3626388e95e0dbb9300a6ecb799b2b82bb786150fb87fe1a9"
+    },
+    "revoke-without-reason": {
+      "canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"revoked\":{\"leaf\":{\"1.0.0\":{\"at\":\"2026-06-02T00:00:00Z\"}}},\"sequence\":5}",
+      "sha256": "266cda62ada5ed6c28cd197ffa3cba6fa2c8fa018381ba7d727f9f0aaf366024"
+    },
+    "quarantine-alongside-revoked": {
+      "canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"quarantined\":{\"tool\":{\"2.0.0\":{\"at\":\"2026-06-02T00:00:00Z\",\"reason\":\"review\"}}},\"revoked\":{\"leaf\":{\"1.0.0\":{\"at\":\"2026-05-01T00:00:00Z\",\"reason\":\"cve\"}}},\"sequence\":8}",
+      "sha256": "9b1ff01071e3c2e28ff9a83f90de1b0d27cecb85bed617d1568b0b867e5e4a05"
+    },
+    "revoke-one-of-two-quarantined": {
+      "canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"quarantined\":{\"tool\":{\"2.0.0\":{\"at\":\"2026-05-02T00:00:00Z\",\"reason\":\"audit\"}}},\"revoked\":{\"leaf\":{\"1.0.0\":{\"at\":\"2026-06-02T00:00:00Z\",\"reason\":\"cve\"}}},\"sequence\":9}",
+      "sha256": "fc4e40dbccf3947b4dd4c6d0636fc7df4eff7d662dcc3ef37ce172887dc9cbcb"
+    },
+    "multi-package": {
+      "canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"revoked\":{\"leaf\":{\"1.0.0\":{\"at\":\"2026-05-01T00:00:00Z\",\"reason\":\"cve\"}},\"tool\":{\"2.0.0\":{\"at\":\"2026-06-02T00:00:00Z\",\"reason\":\"malware\"}}},\"sequence\":10}",
+      "sha256": "92e760a160916a137eeb09303140a93b935f0a439a82fbfc36fbc028a574fbc6"
+    }
+  },
+  "invalid": {
+    "quarantine-after-revoke": "error:terminal",
+    "unquarantine-not-quarantined": "error:not quarantined"
+  }
+}

--- a/tests/cross-verification/revoke-quarantine/vectors.json
+++ b/tests/cross-verification/revoke-quarantine/vectors.json
@@ -1,0 +1,345 @@
+{
+  "transitions": [
+    {
+      "id": "revoke-fresh",
+      "op": "revoke",
+      "prev": {
+        "format_version": 1,
+        "sequence": 5,
+        "issued_at": "2026-06-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          },
+          "tool": {
+            "2.0.0": {
+              "url": "https://x/tool-2.0.0.json",
+              "package_hash": "sha256:bb"
+            }
+          }
+        }
+      },
+      "name": "leaf",
+      "version": "1.0.0",
+      "reason": "cve",
+      "at": "2026-06-02T00:00:00Z",
+      "expected_canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"revoked\":{\"leaf\":{\"1.0.0\":{\"at\":\"2026-06-02T00:00:00Z\",\"reason\":\"cve\"}}},\"sequence\":5}",
+      "expected_sha256": "81840fe2e22e169d6c8db6c229fb18eb4c65b225805043ffdd916256087b9473"
+    },
+    {
+      "id": "quarantine-fresh",
+      "op": "quarantine",
+      "prev": {
+        "format_version": 1,
+        "sequence": 5,
+        "issued_at": "2026-06-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          },
+          "tool": {
+            "2.0.0": {
+              "url": "https://x/tool-2.0.0.json",
+              "package_hash": "sha256:bb"
+            }
+          }
+        }
+      },
+      "name": "tool",
+      "version": "2.0.0",
+      "reason": "review",
+      "at": "2026-06-02T00:00:00Z",
+      "expected_canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"quarantined\":{\"tool\":{\"2.0.0\":{\"at\":\"2026-06-02T00:00:00Z\",\"reason\":\"review\"}}},\"sequence\":5}",
+      "expected_sha256": "ca2d8c13e712270311cd503b7122cf64b4adedf35f3baef561596a9b74a15f46"
+    },
+    {
+      "id": "revoke-supersedes-quarantine",
+      "op": "revoke",
+      "prev": {
+        "format_version": 2,
+        "sequence": 6,
+        "issued_at": "2026-06-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          },
+          "tool": {
+            "2.0.0": {
+              "url": "https://x/tool-2.0.0.json",
+              "package_hash": "sha256:bb"
+            }
+          }
+        },
+        "quarantined": {
+          "leaf": {
+            "1.0.0": {
+              "reason": "review",
+              "at": "2026-05-01T00:00:00Z"
+            }
+          }
+        }
+      },
+      "name": "leaf",
+      "version": "1.0.0",
+      "reason": "cve",
+      "at": "2026-06-02T00:00:00Z",
+      "expected_canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"revoked\":{\"leaf\":{\"1.0.0\":{\"at\":\"2026-06-02T00:00:00Z\",\"reason\":\"cve\"}}},\"sequence\":6}",
+      "expected_sha256": "c1322c1edf73c40659c68352333154b7fe00721bcb726378ddeabd71fbf061f4"
+    },
+    {
+      "id": "unquarantine-back-to-v1",
+      "op": "unquarantine",
+      "prev": {
+        "format_version": 2,
+        "sequence": 7,
+        "issued_at": "2026-06-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          },
+          "tool": {
+            "2.0.0": {
+              "url": "https://x/tool-2.0.0.json",
+              "package_hash": "sha256:bb"
+            }
+          }
+        },
+        "quarantined": {
+          "leaf": {
+            "1.0.0": {
+              "reason": "review",
+              "at": "2026-05-01T00:00:00Z"
+            }
+          }
+        }
+      },
+      "name": "leaf",
+      "version": "1.0.0",
+      "at": "2026-06-02T00:00:00Z",
+      "expected_canonical_json": "{\"format_version\":1,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"sequence\":7}",
+      "expected_sha256": "397be54f9145e9f3626388e95e0dbb9300a6ecb799b2b82bb786150fb87fe1a9"
+    },
+    {
+      "id": "revoke-without-reason",
+      "op": "revoke",
+      "prev": {
+        "format_version": 1,
+        "sequence": 5,
+        "issued_at": "2026-06-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          },
+          "tool": {
+            "2.0.0": {
+              "url": "https://x/tool-2.0.0.json",
+              "package_hash": "sha256:bb"
+            }
+          }
+        }
+      },
+      "name": "leaf",
+      "version": "1.0.0",
+      "at": "2026-06-02T00:00:00Z",
+      "expected_canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"revoked\":{\"leaf\":{\"1.0.0\":{\"at\":\"2026-06-02T00:00:00Z\"}}},\"sequence\":5}",
+      "expected_sha256": "266cda62ada5ed6c28cd197ffa3cba6fa2c8fa018381ba7d727f9f0aaf366024"
+    },
+    {
+      "id": "quarantine-alongside-revoked",
+      "op": "quarantine",
+      "prev": {
+        "format_version": 2,
+        "sequence": 8,
+        "issued_at": "2026-06-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          },
+          "tool": {
+            "2.0.0": {
+              "url": "https://x/tool-2.0.0.json",
+              "package_hash": "sha256:bb"
+            }
+          }
+        },
+        "revoked": {
+          "leaf": {
+            "1.0.0": {
+              "reason": "cve",
+              "at": "2026-05-01T00:00:00Z"
+            }
+          }
+        }
+      },
+      "name": "tool",
+      "version": "2.0.0",
+      "reason": "review",
+      "at": "2026-06-02T00:00:00Z",
+      "expected_canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"quarantined\":{\"tool\":{\"2.0.0\":{\"at\":\"2026-06-02T00:00:00Z\",\"reason\":\"review\"}}},\"revoked\":{\"leaf\":{\"1.0.0\":{\"at\":\"2026-05-01T00:00:00Z\",\"reason\":\"cve\"}}},\"sequence\":8}",
+      "expected_sha256": "9b1ff01071e3c2e28ff9a83f90de1b0d27cecb85bed617d1568b0b867e5e4a05"
+    },
+    {
+      "id": "revoke-one-of-two-quarantined",
+      "op": "revoke",
+      "prev": {
+        "format_version": 2,
+        "sequence": 9,
+        "issued_at": "2026-06-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          },
+          "tool": {
+            "2.0.0": {
+              "url": "https://x/tool-2.0.0.json",
+              "package_hash": "sha256:bb"
+            }
+          }
+        },
+        "quarantined": {
+          "leaf": {
+            "1.0.0": {
+              "reason": "review",
+              "at": "2026-05-01T00:00:00Z"
+            }
+          },
+          "tool": {
+            "2.0.0": {
+              "reason": "audit",
+              "at": "2026-05-02T00:00:00Z"
+            }
+          }
+        }
+      },
+      "name": "leaf",
+      "version": "1.0.0",
+      "reason": "cve",
+      "at": "2026-06-02T00:00:00Z",
+      "expected_canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"quarantined\":{\"tool\":{\"2.0.0\":{\"at\":\"2026-05-02T00:00:00Z\",\"reason\":\"audit\"}}},\"revoked\":{\"leaf\":{\"1.0.0\":{\"at\":\"2026-06-02T00:00:00Z\",\"reason\":\"cve\"}}},\"sequence\":9}",
+      "expected_sha256": "fc4e40dbccf3947b4dd4c6d0636fc7df4eff7d662dcc3ef37ce172887dc9cbcb"
+    },
+    {
+      "id": "multi-package",
+      "op": "revoke",
+      "prev": {
+        "format_version": 2,
+        "sequence": 10,
+        "issued_at": "2026-06-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          },
+          "tool": {
+            "2.0.0": {
+              "url": "https://x/tool-2.0.0.json",
+              "package_hash": "sha256:bb"
+            }
+          }
+        },
+        "revoked": {
+          "leaf": {
+            "1.0.0": {
+              "reason": "cve",
+              "at": "2026-05-01T00:00:00Z"
+            }
+          }
+        }
+      },
+      "name": "tool",
+      "version": "2.0.0",
+      "reason": "malware",
+      "at": "2026-06-02T00:00:00Z",
+      "expected_canonical_json": "{\"format_version\":2,\"issued_at\":\"2026-06-02T00:00:00Z\",\"packages\":{\"leaf\":{\"1.0.0\":{\"package_hash\":\"sha256:aa\",\"url\":\"https://x/leaf-1.0.0.json\"}},\"tool\":{\"2.0.0\":{\"package_hash\":\"sha256:bb\",\"url\":\"https://x/tool-2.0.0.json\"}}},\"revoked\":{\"leaf\":{\"1.0.0\":{\"at\":\"2026-05-01T00:00:00Z\",\"reason\":\"cve\"}},\"tool\":{\"2.0.0\":{\"at\":\"2026-06-02T00:00:00Z\",\"reason\":\"malware\"}}},\"sequence\":10}",
+      "expected_sha256": "92e760a160916a137eeb09303140a93b935f0a439a82fbfc36fbc028a574fbc6"
+    }
+  ],
+  "invalid": [
+    {
+      "id": "quarantine-after-revoke",
+      "op": "quarantine",
+      "prev": {
+        "format_version": 2,
+        "sequence": 11,
+        "issued_at": "2026-06-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          },
+          "tool": {
+            "2.0.0": {
+              "url": "https://x/tool-2.0.0.json",
+              "package_hash": "sha256:bb"
+            }
+          }
+        },
+        "revoked": {
+          "leaf": {
+            "1.0.0": {
+              "reason": "cve",
+              "at": "2026-05-01T00:00:00Z"
+            }
+          }
+        }
+      },
+      "name": "leaf",
+      "version": "1.0.0",
+      "reason": "review",
+      "at": "2026-06-02T00:00:00Z",
+      "expected_error_substring": "terminal"
+    },
+    {
+      "id": "unquarantine-not-quarantined",
+      "op": "unquarantine",
+      "prev": {
+        "format_version": 1,
+        "sequence": 12,
+        "issued_at": "2026-06-01T00:00:00Z",
+        "packages": {
+          "leaf": {
+            "1.0.0": {
+              "url": "https://x/leaf-1.0.0.json",
+              "package_hash": "sha256:aa"
+            }
+          },
+          "tool": {
+            "2.0.0": {
+              "url": "https://x/tool-2.0.0.json",
+              "package_hash": "sha256:bb"
+            }
+          }
+        }
+      },
+      "name": "leaf",
+      "version": "1.0.0",
+      "at": "2026-06-02T00:00:00Z",
+      "expected_error_substring": "not quarantined"
+    }
+  ]
+}


### PR DESCRIPTION
## Slice 8.7 — revoke/quarantine mark algebra golden vectors

Eighth step of the cross-language Ace trust core (after 8 SHA-256, 8.1 canonical-JSON, 8.2 package_hash, 8.3 ed25519, 8.4 index-signature, 8.5 canonical-JSON seam vectors, 8.6 verifyIndex 3-gate). `registry-revoke.ts` (slice 7) is the **publisher-side** state machine for marking a package version bad inside the signed index. The marks are security state that 8.4 *signs* and 8.6 *enforces* — a cross-language disagreement on a mark transition forks revocation state (one Ace installs a CVE'd version another refuses). This byte-locks the transitions, **closing the marks loop: 8.7 authors → 8.4 signs → 8.6 enforces**.

Spec: `docs/agendas/ace-package-manager/2026-06-03-ace-slice8.7-revoke-quarantine-algebra-golden-vectors-design.md` (in this PR).

### Scope — fixture-only
`registry-revoke.ts` already exists with unit tests. **No extraction, no code change.**

### The algebra (pure content → content)
`applyRevoke` (removes from quarantined, adds to revoked — **revoke supersedes quarantine**; always succeeds) · `applyQuarantine` (**errors if already revoked** — revoke is terminal) · `applyUnquarantine` (errors if not quarantined). All end with `withFmt`: `format_version = 2` iff a mark remains else `1`, empty mark maps stripped (**the v2-iff-marks rule the 8.4 review caught**, enforced automatically), `issued_at = at`.

### Fixture (`tests/cross-verification/revoke-quarantine/`)
- `vectors.json` — **transitions[8]** (`op + prev + name + version + reason? + at → expected_canonical_json + expected_sha256`, composing 8.5/8.1 + slice 8): revoke-fresh · quarantine-fresh · revoke-supersedes-quarantine · **unquarantine-back-to-v1** (empty-map strip + `format_version` 2→1) · revoke-without-reason (optional `reason`) · quarantine-alongside-revoked · revoke-one-of-two-quarantined · multi-package. **invalid[2]**: quarantine-after-revoke → "terminal" · unquarantine-not-quarantined → "not quarantined".
- `cross-verify.ts` — TS oracle dispatches each `op` to the **real** apply functions; asserts `canonicalBytes(result)` + sha256 (transitions), error+substring (invalid); writes `ts-output.json`; exits non-zero on mismatch. **Auto-discovered by `cross-verify-all.ts` → 9/9.**

### Non-tautology
A **Python re-implementation** of the three apply functions + `withFmt` (supersession rules; v2-iff-marks + empty-map-strip; `issued_at=at`) + `json.dumps(sort_keys)` + `hashlib.sha256` authored every expected result; the TS oracle (real apply functions) reproduces them with **0 mismatches** — two separate algebra implementations agreeing. Object keys ASCII/BMP so Python code-point sort == JS code-unit sort.

### Canonical-gate status
Stays **TS-only + proof-owed → not canonical yet**.

### Gates (all green locally)
- tsc 0 · `bun test tools/ace/` **372 pass** (no code change) · `bun tools/ci/cross-verify-all.ts` **9/9** · all files pure-LF · markdownlint clean
- subagent review: **APPROVE** (non-tautology + `withFmt` v2/strip + supersession + reason-optional all confirmed; 3 transitions independently re-derived)

🤖 Generated with [Claude Code](https://claude.com/claude-code)