### PR TITLE
rules(formal-proof-first): payoff #4 honesty — hex core is speculation; proven = search-last not search-never

### DIFF
--- a/.claude/rules/formal-proof-first-proven-by-default-consensus-not-validation-canonical-is-homeostat-proven-from-seed-ace-shields-zeta.md
+++ b/.claude/rules/formal-proof-first-proven-by-default-consensus-not-validation-canonical-is-homeostat-proven-from-seed-ace-shields-zeta.md
@@ -132,17 +132,26 @@ doesn't compound; "true-and-load-bearing-and-connected" does. Four payoffs
    smallest scope where "is this a real claim?" is clearest.
 4. **Reduced debug surface (system-level, AIs + humans)** — the runtime corollary
    of #2, generalized from proof-failure-localization to *bug-search*. Code with a
-   math-verified homeostat + 4-oracle byte-lock — itself proven down to the
-   bit-perfect oracles / the proven hexagonal vector-wall reservoir-computing core
-   dimensions — is **excluded from the bug-suspect surface** once proven. When a
-   bug arises, search the **less-rigorously-proven code first**; the proven
-   components can't be the cause until everything less-proven is ruled out. This
-   bounds the debug search and **reduces debugging uncertainty for both AIs and
-   humans at a system level** — proven = not-a-suspect, so the proof investment
-   pays out again every time something breaks. (Honest scope: this excludes only
-   what is *actually* proven — per proven-by-default, the unbadged/unproven set is
-   the default suspect surface; the exclusion grows as more primitives earn the
-   homeostat-proven-from-seed bar.)
+   math-verified homeostat + 4-oracle byte-lock — proven down to the bit-perfect
+   oracles (and, as the stack matures, the hexagonal vector-wall reservoir-computing
+   core) — drops to the **bottom of the bug-suspect surface** once proven. When a
+   bug arises, search the **less-rigorously-proven code first**; proven components
+   are the **last place to look**, not the first. (Not an *absolute* exclusion: a
+   proof verifies **code-matches-spec, not spec-matches-intent** — a wrong/incomplete
+   spec can still harbor a bug, the valid-given-axioms ≠ true point at debug scope —
+   so proven = search-*last*, not search-*never*.) This bounds the debug search and
+   **reduces debugging uncertainty for both AIs and humans at a system level** —
+   proven = search-last, so the proof investment pays out again every time something
+   breaks. (Honest scope: this de-prioritizes only what is *actually* proven — per
+   proven-by-default, the unbadged/unproven set is the default suspect surface; the
+   de-prioritization grows as more primitives earn the homeostat-proven-from-seed
+   bar. Concretely today: the **hex / vector-wall reservoir core is a LOT of
+   speculation** — NOT proven, not fully 4-language — so it is **firmly a suspect**,
+   not excluded. The aspiration: **if** it's proven **from first principles** (its
+   own intellectual tower, encoded in CS techniques + math proofs) it becomes **its
+   own proof tower** — a genuinely-independent foundation per the multi-tower
+   discipline — and only *then* drops down the suspect surface. Until proven it's
+   speculation, not an exclusion — **don't pre-exclude it**.)
 
 **The 4-step move:** (1) prove each primitive as it enters canonical; (2) aim
 the proof at the composable guarantee (round-trip / injectivity / the algebra

--- a/.claude/rules/formal-proof-first-proven-by-default-consensus-not-validation-canonical-is-homeostat-proven-from-seed-ace-shields-zeta.md
+++ b/.claude/rules/formal-proof-first-proven-by-default-consensus-not-validation-canonical-is-homeostat-proven-from-seed-ace-shields-zeta.md
@@ -138,8 +138,9 @@ doesn't compound; "true-and-load-bearing-and-connected" does. Four payoffs
    bug arises, search the **less-rigorously-proven code first**; proven components
    are the **last place to look**, not the first. (Not an *absolute* exclusion: a
    proof verifies **code-matches-spec, not spec-matches-intent** — a wrong/incomplete
-   spec can still harbor a bug, the valid-given-axioms ≠ true point at debug scope —
-   so proven = search-*last*, not search-*never*.) This bounds the debug search and
+   spec can still harbor a bug (the "valid-given-axioms ≠ true" point, at debug
+   scope) — so proven = search-*last*, not search-*never*.) This bounds the debug
+   search and
    **reduces debugging uncertainty for both AIs and humans at a system level** —
    proven = search-last, so the proof investment pays out again every time something
    breaks. (Honest scope: this de-prioritizes only what is *actually* proven — per


### PR DESCRIPTION
Fix-forward for the maintainer's catch + Copilot P1 on #6662 (both landed after #6662 merged; this is clean off current main — the earlier in-flight branch was stale on a sibling note, so abandoned).

Two honesty corrections to payoff #4:
- **Hex core (the maintainer):** it's *a LOT of speculation* — NOT proven, not fully 4-language — so **firmly a suspect**, not excluded. Aspiration: **if** proven **from first principles** (its own intellectual tower, CS-encoded + math proofs) it becomes **its own proof tower** (genuinely-independent multi-tower foundation), and only then drops down the suspect surface. Don't pre-exclude it. (Removed the earlier 'the *proven* hexagonal core' overclaim.)
- **Spec-vs-intent (Copilot P1):** 'proven components can't be the cause' overclaimed — a proof verifies **code-matches-spec, not spec-matches-intent**, so a wrong/incomplete spec can still harbor a bug (valid-given-axioms ≠ true, at debug scope). Reframed: proven = **search-LAST** (bottom of the suspect surface), not search-never.

Diff is the rule only (no note revert). MD049-clean, role-refs only, canary 67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)