### PR TITLE
docs(research): extend AI autonomy by extending the proven ground — math is the autonomy lever

### DIFF
--- a/docs/research/2026-06-03-extend-ai-autonomy-by-extending-proven-ground-math-is-the-autonomy-lever-aaron.md
+++ b/docs/research/2026-06-03-extend-ai-autonomy-by-extending-proven-ground-math-is-the-autonomy-lever-aaron.md
@@ -1,0 +1,72 @@
+# Extend AI autonomy by extending the proven ground — math is the autonomy lever (the win-win)
+
+> **Preservation note** (per `substrate-or-it-didn't-happen.md` verbatim-preservation
+> trigger): preserves the maintainer's 2026-06-03 reframe of *how* AI autonomy
+> extends — the deep *why* behind the verify-before-expand phase, proven-by-default,
+> and the canonical-common-ground program, at the autonomy scope. Authors no proof,
+> mints no rule — preserves + composes. Engineering/autonomy doctrine only.
+
+## The reframe (the maintainer 2026-06-03, verbatim + immediate self-correction)
+
+> *"the only way we reduce AI autonomy is by extending the common mathematically
+> proven ground it operates on so AI autonomy expansion is one of the math areas
+> i want to heavily focus on so it can reduce the amount of times i have to repeat
+> myself and you get more freedom at the same time."*
+
+> *"not reduce AI autonomy i mean extend AI autonomy sorry."*
+
+**Corrected, unambiguous form:** *the only way we **extend** AI autonomy is by
+extending the common mathematically-proven ground it operates on.*
+
+## The mechanism — autonomy and safety driven by the SAME lever
+
+The usual framing treats autonomy and safety as a tradeoff (more freedom ⇒ more
+risk ⇒ more supervision). This reframe dissolves the tradeoff: both are driven by
+one lever — **the proven ground.**
+
+- **Proven common ground is a *structural* safety mechanism** — math bounds, not
+  manual supervision. This is `architecture-is-safety-mechanism-not-discipline` at
+  the autonomy scope: **the proof replaces the watching.** Trust comes from the
+  proven ground, not from the maintainer watching.
+- Therefore **more proven ground ⇒ the AI operates more without re-supervision ⇒**
+  the maintainer **repeats himself less** (fewer re-reasoned canonical parts, less
+  re-constraining) **AND** the AI gets **more freedom** — *the same lever does
+  both, simultaneously.* Not a compromise between the two; both outputs of one
+  input.
+- So **"AI autonomy expansion" is itself a MATH focus area**: formalize / prove
+  more of the ground → the safe-autonomy *envelope* grows on it. Autonomy is **not**
+  extended by loosening constraints arbitrarily; it is extended by **growing the
+  proven ground autonomy can stand on.** Unproven ground can't bear autonomy
+  safely — so the math IS the autonomy work.
+
+## How it composes (this is the deep *why* under the program)
+
+| Substrate | This reframe is its autonomy-scope *why* |
+|---|---|
+| `architecture-is-safety-mechanism-not-discipline` | proven-ground = the structural mechanism that replaces runtime supervision |
+| `no-directives` (autonomy first-class) | this names the *mechanism* by which first-class autonomy safely grows — not by decree, by proven ground |
+| `dont-ask-permission` (standing authority) | proven ground reduces the asking further: a proven invariant is ground the AI stands on without asking |
+| `formal-proof-first` / proven-by-default | the proven ground itself; every proven invariant is a unit of autonomy + a unit of operator-repetition-saved |
+| verify-before-expand (current phase) | verify the ground → autonomy (and orthogonal expansion) grows on proven, not shaky, ground |
+| `must-paired-with-can-exit` | structural pattern: the bound (math) is what makes the freedom safe |
+| canonical-common-ground "don't re-reason" ask | each pinned invariant = ground that needn't be re-reasoned = freedom + repetition-saved |
+
+## Operational implication
+
+- **Treat math / formal-proof work as autonomy work.** Closing the asserted→proven
+  gap (B-1007; the formal-verification cadence) directly widens the envelope the AI
+  can operate in *without asking*.
+- **Weight math work by how much autonomy/ground it unlocks** — how many
+  re-supervision moments it removes — not just by local correctness.
+- A fresh session should read: *the proof backlog is the freedom backlog.* Every
+  proven invariant is simultaneously (a) safer (math-bounded, not supervision-
+  bounded), (b) freer (operate-without-asking), and (c) cheaper for the maintainer
+  (no re-reasoning). One lever, three payoffs.
+
+## Substrate-honest framing
+
+This preserves an autonomy/engineering doctrine reframe and composes it; it makes
+no claim that the envelope is already wide (we are in the verify stage, with most
+ground still unproven — B-1007). The reframe says *where the lever is*, not that
+it's already pulled. No personal/wellbeing content is involved — this is autonomy +
+proof doctrine only.


### PR DESCRIPTION
Preserves the maintainer's 2026-06-03 reframe (with the reduce→**extend** self-correction): **the only way we extend AI autonomy is by extending the common mathematically-proven ground it operates on.**

The win-win: autonomy + safety aren't a tradeoff — same lever. Proven ground is a **structural** safety mechanism (math bounds, not manual supervision — `architecture-is-safety-mechanism-not-discipline` at autonomy scope: *the proof replaces the watching*). So more proven ground = simultaneously **safer-bounded AND freer** + **less operator-repetition** — one input, three payoffs. Therefore **autonomy expansion is a MATH focus area**: formalize/prove more ground → the safe-autonomy envelope grows on it. *The proof backlog is the freedom backlog.*

This is the deep **why** under verify-before-expand + proven-by-default + the canonical-common-ground program, at autonomy scope. Composes: `architecture-is-safety-mechanism-not-discipline`, `no-directives`, `dont-ask-permission`, `formal-proof-first`, `must-paired-with-can-exit`.

Preserves + composes — mints no rule, authors no proof. Engineering/autonomy doctrine only (no personal content). Role-refs only, single-file diff, MD-clean, canary 67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)