### PR TITLE
Inventory Phase 5 (re-land): typed dynamic custom fields + post-merge PROGRESS captures

### DIFF
--- a/.github/workflows/inventory-phase5-proof.yml
+++ b/.github/workflows/inventory-phase5-proof.yml
@@ -1,0 +1,96 @@
+# Inventory — Phase 5 live REST proof (consumes admin creds from repo secrets)
+# ---------------------------------------------------------------------------------------
+# WHY THIS EXISTS: GitHub repository secrets are write-only via the API — they can ONLY
+# be read inside an Actions run. The Phase-5 client-path proofs (add typed fields,
+# per-type DB rejection, deactivate-preserves) need an ADMIN session, delivered by the
+# owner as repo secrets. This workflow runs inventory/proofs/phase5-custom-fields-proofs.ts.
+#
+# ADMIN CREDS (pick ONE; the two-secret form is recommended — zero parsing ambiguity):
+#   * RECOMMENDED: two secrets  INVENTORY_ADMIN_EMAIL  +  INVENTORY_ADMIN_PASSWORD
+#   * OR: a single secret  inventory_admin_login  as JSON {"email":"...","password":"..."}
+#
+# SAFETY (repo is PUBLIC):
+#   * The ONLY credentials are masked secrets. SUPABASE_URL + the publishable (anon) key
+#     are already public (they live in inventory/index.html).
+#   * Runs everything as ADMIN (admin has editor rights on items; validate_custom_fields()
+#     is SECURITY DEFINER so it fires for ALL writers — the per-type rejection proof holds
+#     regardless of role). No editor password is ever placed in this public repo.
+#   * Creds are written to $GITHUB_ENV WITHOUT echoing; the proof harness logs no tokens.
+#   * NO service_role. Read-only checkout (contents: read).
+#
+# PREREQUISITE: the owner must FIRST run inventory/sql/phase5.sql in the Supabase SQL
+# editor (installs the validation trigger). Without it the per-type-rejection proof fails
+# by design (malformed writes would be accepted).
+#
+# HOW TO RUN: push a commit to this branch whose message contains [run-phase5-proof]
+#   git commit --allow-empty -m "ci: run phase5 proof [run-phase5-proof]" && git push
+# (Gated so it never auto-runs / never creates live data on an ordinary push.)
+#
+# Phase 7 may delete this workflow once the build-time test users are burned.
+name: inventory-phase5-proof
+
+on:
+  push:
+    branches: ["claude/**"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  proof:
+    # Only run when explicitly requested (or manually dispatched), never on a plain push.
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[run-phase5-proof]') }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: latest
+
+      - name: Resolve admin creds (no echo)
+        env:
+          # Preferred: two dedicated secrets (no parsing ambiguity).
+          ADMIN_EMAIL_SECRET: ${{ secrets.INVENTORY_ADMIN_EMAIL }}
+          ADMIN_PASSWORD_SECRET: ${{ secrets.INVENTORY_ADMIN_PASSWORD }}
+          # Fallback: single secret as JSON {"email":"...","password":"..."}.
+          LOGIN: ${{ secrets.inventory_admin_login }}
+        run: |
+          EMAIL="$ADMIN_EMAIL_SECRET"
+          PW="$ADMIN_PASSWORD_SECRET"
+          if [ -z "$EMAIL" ] || [ -z "$PW" ]; then
+            if [ -n "$LOGIN" ]; then
+              EMAIL="$(printf '%s' "$LOGIN" | jq -r 'try .email catch empty' 2>/dev/null || true)"
+              PW="$(printf '%s' "$LOGIN" | jq -r 'try .password catch empty' 2>/dev/null || true)"
+            fi
+          fi
+          # Strip accidental trailing CR/LF (classic GitHub-secret paste footgun).
+          EMAIL="$(printf '%s' "$EMAIL" | tr -d '\r\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+          PW="$(printf '%s' "$PW" | tr -d '\r\n')"
+          HAS_AT=no; case "$EMAIL" in *@*) HAS_AT=yes;; esac
+          echo "admin email length=${#EMAIL} has_at=$HAS_AT ; password length=${#PW}"  # shape only, no values
+          if [ -z "$EMAIL" ] || [ "$EMAIL" = "null" ] || [ -z "$PW" ] || [ "$PW" = "null" ]; then
+            echo "::error::Admin creds unresolved. EASIEST FIX: add repo secrets INVENTORY_ADMIN_EMAIL + INVENTORY_ADMIN_PASSWORD (recommended). OR overwrite inventory_admin_login with JSON: {\"email\":\"<admin email>\",\"password\":\"<admin password>\"}. (The current inventory_admin_login value is not parseable as either.)"
+            exit 2
+          fi
+          # Mask the resolved values, then export WITHOUT printing them.
+          echo "::add-mask::$EMAIL"
+          echo "::add-mask::$PW"
+          {
+            echo "ADMIN_EMAIL=$EMAIL"
+            echo "ADMIN_PASSWORD=$PW"
+            # run the editor-slot proofs as admin too (the trigger validates all roles)
+            echo "EDITOR_EMAIL=$EMAIL"
+            echo "EDITOR_PASSWORD=$PW"
+          } >> "$GITHUB_ENV"
+          echo "admin creds resolved (values masked)"
+
+      - name: Run Phase 5 custom-field proofs (admin session, publishable key, NO service_role)
+        env:
+          # public, low-privilege values (already in inventory/index.html)
+          SUPABASE_URL: https://mdtbgreryqddloluhdmm.supabase.co
+          SUPABASE_ANON_KEY: sb_publishable_UjTK7ZQ0uGX_mEm9HJOT6Q_MJjPvKE3
+        run: |
+          bun inventory/proofs/phase5-custom-fields-proofs.ts

--- a/inventory/PROGRESS.md
+++ b/inventory/PROGRESS.md
@@ -102,11 +102,35 @@ un-archive.
   RLS unchanged (no new policy / USING(true) / GRANT). Full raw output in "Phase 4 — FIXED run"
   appendix. Phase-7 Auditor re-verifies on the live site (and may run the owner-side SQL companion
   `sql/proofs/phase4_proofs.sql`, incl. its pg_policies no-permissive-items-policy check).
-- [ ] Phase 5 — Typed dynamic fields (CENTERPIECE; use higher reasoning effort).
+- [x] Phase 5 — Typed dynamic fields (CENTERPIECE; use higher reasoning effort).
 GATE: dedicated test suite passes; add-field applies to ALL items; per-type validation;
 search/sort INCLUDE custom fields; XSS-safe.
 VERIFY: add one field of each type; enter a <script> payload as a value → rendered inert; search by
 a custom field returns correct items; "number" rejects text.
+  STATUS (2026-06-03, 5a checkpoint — NOT [x]; live DB proofs pending owner creds + SQL-editor run):
+  CODE COMPLETE — sql/phase5.sql (BEFORE INS/UPD validate_custom_fields() trigger: DB-side per-type
+  validation + unknown-key reject + GIN index; loosens no RLS); lib/custom-fields.js shared typed
+  comparator/coercion/validation (+ peer .d.ts so the test stays type-checked, not skipped);
+  index.html UI (custom columns in table+cards, typed search + typed multi-sort, typed form inputs,
+  admin Manage-fields add/deactivate; centralized ITEM_SELECT incl. custom_fields; cleaned a stray
+  0x01 byte in the search join); REST harness proofs/phase5-custom-fields-proofs.ts; SQL proof
+  sql/proofs/phase5_proofs.sql. PROVEN NOW, NO CREDS (raw output in the "Phase 5 evidence" appendix):
+  (a) 20/20 bun unit tests incl. broken-vs-fixed numeric sort (sabotaged comparator -> 2 fail);
+  (b) REAL-BROWSER (Playwright, real renderHead()/applyView()): numeric sort [9,10,100] asc &
+      [100,10,9] desc (NOT lexicographic 10,100,9); an `<img onerror>`+`<script>` payload rendered
+      INERT as BOTH a custom VALUE and a field LABEL (window.__xss stayed undefined; innerHTML
+      escaped to `&lt;img...`); custom-field VALUE searchable (search "100" -> only the rating=100
+      row). The lib
+      loaded from CSP 'self'. (CDN-blocked-by-proxy note: the container proxy MITMs jsdelivr's cert,
+      so the proof ran against a gitignored _proof_tmp/boot.html = index.html with ONLY the CDN tag
+      swapped for a supabase stub — no source divergence; the real merged site has no such block.)
+  PENDING (needs OWNER): (1) run sql/phase5.sql then sql/proofs/phase5_proofs.sql in the SQL editor
+  (expect all rows PASSED incl. typed-vs-lexicographic sort); (2) create a BURNABLE admin test user +
+  provide ADMIN_*/EDITOR_* creds via ENV so Claude runs phase5-custom-fields-proofs.ts (live: per-type
+  DB-rejection via direct REST as editor, add-field-appears-on-all, deactivate-preserves-values+history,
+  anon default-deny). required-at-DB intentionally DEFERRED (would break edits of the 210 existing
+  items); required stays an app-side UX nudge. NOT marked [x] until (1)+(2) show observed output.
+  LIVE GATE PASSED (2026-06-03): owner ran sql/phase5.sql + sql/proofs/phase5_proofs.sql in the SQL editor — ALL 12 rows PASSED (per-type accept/reject + numeric-cast sort [10,100,9] vs [9,10,100] + no-permissive). Editor direct-REST unknown-key write REJECTED 400 post-install (was 204 before). CI run #11 (.github/workflows/inventory-phase5-proof.yml, admin secret, publishable key, NO service_role) = ALL PASS: (1) admin added 5 typed fields; (2) visible to editor + every item has custom_fields; (2b) 5 valid values stored; (3) all 6 malformed/unknown writes DB-rejected with correct per-type messages, valid value intact; (4) <script>/onerror stored verbatim as data; (5) deactivate -> value 42 PRESERVED + change_log history intact; (6) anon default-deny on all four tables = []. Two harness bugs the live run surfaced + fixed (PGRST102 heterogeneous bulk-insert keys; jsonb order-insensitive comparison) — feature itself unchanged. Phase-7 Auditor re-verifies on the live merged site. CLEANUP (owner, pre-launch SQL editor): archived throwaway items 216/225/226/227/228 + inactive defs 'p5_mpyh93ei_%' and 'p5_mpyhaucf_%'. Build-time test users (editor@/viewer@ + admin secret) are chat/secret-shared -> burn in Phase 7 (residual risk register).
 - [ ] Phase 6 — QR labels + export.
 GATE: scan resolves post-login; export round-trips incl. unicode/comma/quote.
 VERIFY: generate + scan a label → correct item after login; export then re-import → identical data.
@@ -137,6 +161,20 @@ data layer + Phase-1 audit capture + Phase-2 auth/role were already proven on th
 during the build (see the "Live-site evidence" appendix); only the structural/visual observation of
 a/b/c/d remains for the Auditor.
 
+PHASE 5 LIVE RE-VERIFY (owner-added 2026-06-03 post-merge) — the Auditor MUST run these on the
+merged, live, NO-PROXY site signed in AS THE TRUE EDITOR user (not admin), and show RAW observed output:
+  (a) editor-role write enforcement END-TO-END as the actual editor — add/edit a custom-field value and
+      confirm it is accepted, then confirm a viewer's write is refused BY THE DB (RLS, 0 rows). WHY this is
+      called out explicitly: the build-time CI proof (.github/workflows/inventory-phase5-proof.yml) ran the
+      editor-slot proofs with the ADMIN secret, because GitHub repo secrets are only readable inside an
+      Actions run and no editor password may live in this PUBLIC repo. validate_custom_fields() is SECURITY
+      DEFINER so it fires for ALL writers, and a local TRUE-editor direct-REST rejection WAS proven during the
+      build — but automated per-role CI coverage has a DOCUMENTED GAP (editor slot exercised as admin). The
+      Auditor closes that gap on the live site as the real editor.
+  (b) per-type SORT correctness over custom fields — confirm a "number" custom field sorts NUMERICALLY
+      (9 < 10 < 100, NOT lexicographic 10,100,9) and a "date" custom field sorts CHRONOLOGICALLY, both asc
+      and desc, in the live DOM. This is the single most likely place for a subtle regression.
+
 ## If a gate fails
 
 Stop the phase. Diagnose + fix + re-verify, or escalate. Never mark passed to advance.
@@ -151,7 +189,17 @@ email+password shared in chat — treat as compromised. Phase 7: delete or rotat
 supabase-js loads from jsdelivr with no SRI/fallback — Phase 7 adds exact-version pin + SRI (and
 consider vendoring) so a blocked/compromised CDN can't break or tamper with the app · **CSP
 'unsafe-inline'**: baseline CSP allows inline script/style for the single-file build — Phase 7 moves
-JS/CSS external + nonces/SRI and drops 'unsafe-inline'.
+JS/CSS external + nonces/SRI and drops 'unsafe-inline'. · **required-at-DB DEFERRED (v1 trade-off, by design)**:
+custom-field "required" is enforced as a CLIENT-SIDE UI NUDGE ONLY, not a DB trigger. Trigger-level
+"required" would break edits of the 210 pre-existing items, which have no value for a newly-added required
+field (every UPDATE of an old row would fail validation). Accepted v1 trade-off for the current
+scale/threat model; revisit if user count grows or the threat model changes (e.g., enforce required only
+for rows created after the field, or backfill before enforcing). · **OWNER-PENDING PHASE-5 PROOF CLEANUP
+(NOT orphaned data — context for the Auditor)**: the Phase-5 live proofs intentionally left throwaway items
+216/225/226/227/228 (archived) + inactive field definitions matching 'p5_mpyh93ei_%' and 'p5_mpyhaucf_%'.
+These are EXPECTED proof residue; the owner will remove them in the Supabase SQL editor when ready (disable
+change_log_immutable -> delete their change_log rows + items + defs -> re-enable). Auditor: do NOT flag
+these as orphaned/unexplained data.
 
 ## Open items (resolve in Phase 0a)
 
@@ -258,20 +306,20 @@ approval before Phase 0b.
 ### Item #7 — Plain Supabase web-dashboard setup steps (for Phase 0b; service_role NOT requested)
 
 1. Go to **app.supabase.com** → sign in → **New project**.
-2. Pick your org → **Name** (e.g., `zeta-inventory`) → **Database password**: click *Generate*, then
+2. Pick your org → **Name** (e.g., `zeta-inventory`) → **Database password**: click _Generate_, then
    store it in YOUR password manager (NOT in this repo, NOT pasted to me) → **Region**: pick a **US**
    region → **Plan: Free** → **Create new project**. (First provision takes a couple of minutes.)
 3. **RLS on new tables**: heads-up — Supabase enforces RLS **per table**, not via a single global
-   "Enable RLS on new tables" switch. In the Table Editor's *New table* dialog there is an **"Enable
+   "Enable RLS on new tables" switch. In the Table Editor's _New table_ dialog there is an **"Enable
    Row Level Security (RLS)"** checkbox that is **ON by default — leave it on.** Additionally, in
    Phase 1 I create every table via SQL with an explicit `ALTER TABLE … ENABLE ROW LEVEL SECURITY`, so
    RLS-on is guaranteed regardless of the dashboard default. (Flagging because the bundle's exact
    wording assumes a toggle that isn't labeled that way today — the protection is real either way.)
 4. **Find the values I'll need in Phase 0b** — go to **Project Settings → API Keys**:
-   - **Project URL**: copy it (looks like `https://<ref>.supabase.co`). (Also shown in the *Connect*
+   - **Project URL**: copy it (looks like `https://<ref>.supabase.co`). (Also shown in the _Connect_
      dialog / Settings → Data API.)
    - **Public key**: copy the **Publishable** key (`sb_publishable_…`) — OR, if you're on legacy keys,
-     the **anon** `public` key from the *Legacy API Keys* tab. Either is fine for client code.
+     the **anon** `public` key from the _Legacy API Keys_ tab. Either is fine for client code.
    - **Do NOT** copy or send the **secret** (`sb_secret_…`) / **service_role** key. I won't ask for it
      and won't use it.
 5. Provide me, when you're ready for Phase 0b: the **Project URL** + the **publishable/anon public**
@@ -782,3 +830,63 @@ Remove in the SQL editor like the Phase-1 proof item:
 `delete from public.items where id in (212,213,214);`
 `alter table public.change_log enable trigger change_log_immutable;`
 (The items id sequence is unaffected — next auto id continues after the current max.)
+
+## Phase 5 evidence (5a checkpoint, 2026-06-03 — Claude, NO creds yet)
+
+Recorded per the Evidence rule. Live DB proofs (owner creds + SQL editor) still pending — see the
+Phase 5 STATUS line. These are the credential-free proofs run THIS session.
+
+### Unit suite (bun) — 20/20, with broken-vs-fixed
+
+```
+$ bun test inventory/proofs/custom-fields.unit.test.ts
+ 20 pass / 0 fail / 52 expect() calls
+# deliberate break (toNumeric num path -> String(v)) => 2 fail incl. the numeric-order test;
+# revert => 20 pass. (CLAUDE.md 'key test FAILS on broken code, passes when fixed'.)
+```
+
+### Real-browser (Playwright + Chrome 149) against the REAL renderHead()/applyView()
+
+Injected state: number field `rating` {9,10,100}; XSS payload `<img src=x onerror="window.__xss=1"><script>window.__xss=1</script>` as BOTH a custom VALUE and a field LABEL; sort key `cf:rating`.
+
+```json
+{ "headers_count": 13, "rating_header": "Rating \u25b2",
+  "rating_column_order_ascending": ["9","10","100"],
+  "xss_value_cell_textContent_is_literal": true,
+  "xss_value_cell_has_live_img_or_script": false,
+  "xss_value_cell_innerHTML_escaped_head": "&lt;img src=x onerror=\"window.__xss=1\"&g",
+  "malicious_header_textContent_is_literal": true,
+  "malicious_header_has_live_img_or_script": false,
+  "custom_fields_lib_loaded": true }
+// follow-up: { "xss_global_after_render": "undefined",   // payload NEVER executed
+//             "rating_desc": ["100","10","9"],
+//             "search_100_rows": ["3:100"] }            // custom VALUE searchable
+```
+
+Interpretation: risk (ii) typed numeric search+sort and risk (iii) XSS-safe render (values AND field
+names, at header + cell) PROVEN in a real browser. Risk (i) DB-side validation is proven structurally
+by sql/phase5.sql + the SQL/REST proofs (pending owner run). The Phase-7 Auditor re-verifies on the
+live merged site.
+
+### Live admin-path proof — CI run #11 (2026-06-03) — ALL PASS
+
+Run via .github/workflows/inventory-phase5-proof.yml (INVENTORY_ADMIN_EMAIL/PASSWORD secrets; publishable key; NO service_role). Raw observed:
+
+```
+admin role -> "admin"
+(1) 5 typed field defs created (http 201): PASS
+(2) all 5 defs visible to editor AND every item has a custom_fields object: PASS
+(2b) set valid custom_fields -> http 200; all five typed values stored: PASS
+(3) per-type validation REJECTED at the DB (direct REST):
+   number<-string   -> 400 ((number) must be a JSON number (got string))
+   boolean<-string  -> 400 ((boolean) must be a JSON boolean (got string))
+   date<-2024-13-40 -> 400 ((date) is not a valid calendar date (got 2024-13-40))
+   dropdown<-purple -> 400 ((dropdown) value purple is not an allowed option)
+   text<-number     -> 400 ((text) must be a JSON string (got number))
+   unknown key      -> 400 (no field_definitions row exists)
+   value intact after all rejects -> OK ; ASSERTION PASS
+(4) <img onerror>+<script> stored verbatim as a JSON string: PASS
+(5) deactivate field -> number value (42) PRESERVED; change_log custom_fields history 2 rows: PASS
+(6) anon items/field_definitions/change_log/profiles all [] : PASS
+=== SUMMARY: (1)=PASS (2)=PASS (2b)=PASS (3)=PASS (4)=PASS (5)=PASS (6)=PASS ===
+```

--- a/inventory/index.html
+++ b/inventory/index.html
@@ -251,6 +251,7 @@
             <label class="attn-toggle"><input type="checkbox" id="f-archived" /> Include archived</label>
             <button id="reset-btn" class="secondary" type="button">Reset</button>
             <button id="add-btn" class="btn-sm hidden" type="button">+ Add item</button>
+            <button id="manage-fields-btn" class="btn-sm secondary hidden" type="button">⚙ Manage fields</button>
             <span class="sort-hint">Tip: click a column to sort · shift-click to add a secondary sort</span>
           </div>
           <span class="count-pill" id="count-pill">—</span>
@@ -304,8 +305,12 @@
 
   <!-- supabase-js v2. NOTE (Phase 7): pin an exact version + add SRI. -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <!-- Phase 5: shared custom-field logic (same-origin; CSP script-src 'self').
+       ONE SOURCE OF TRUTH with inventory/proofs/custom-fields.unit.test.ts. -->
+  <script src="lib/custom-fields.js"></script>
   <script>
     "use strict";
+    const CF = window.CustomFields;  // shared typed-custom-field logic (lib/custom-fields.js)
 
     // Public, low-privilege key (publishable/anon). Safe in client code by design;
     // real security is Postgres RLS. NEVER place the service_role/secret key here.
@@ -319,7 +324,7 @@
     // In-memory state we MUST be able to clear on sign-out (shared-device safety).
     // `items` is the canonical DB copy; `view` is the derived filtered+sorted list.
     let state = { user: null, role: null, sampleItem: null, items: [], view: [], sortKeys: [],
-                  showArchived: false, debug: false };
+                  showArchived: false, debug: false, fieldDefs: [] };
 
     const $ = (id) => document.getElementById(id);
     const signinView = $("signin-view"), appView = $("app-view"), statusEl = $("status");
@@ -355,6 +360,41 @@
     ];
     // search spans exactly these 5 fields (Phase 3 scope; custom fields = Phase 5).
     const SEARCH_FIELDS = ["name","brand","model_pn","device_type","category"];
+
+    // ---- Phase 5: typed dynamic custom fields ----
+    // ONE select list (now incl. custom_fields) — was duplicated 4x; centralized.
+    const ITEM_SELECT = "id,name,brand,model_pn,qty,device_type,category,status,location,assignment_purpose,notes,value,serial,is_archived,custom_fields,version,created_at,updated_at";
+
+    function activeDefs() { return state.fieldDefs.filter((d) => d.is_active); }
+    function customColumns() {
+      return activeDefs().map((d) => ({
+        key: "cf:" + d.key, label: d.label, def: d, isCustom: true,
+        ctype: CF.comparatorType(d.type),
+      }));
+    }
+    function allColumns() { return COLUMNS.concat(customColumns()); }
+    function defByKey(key) { return state.fieldDefs.find((d) => d.key === key) || null; }
+    // accessor + comparator type for a sort key (core OR "cf:<key>" custom).
+    function colMeta(key) {
+      if (key.indexOf("cf:") === 0) {
+        const d = activeDefs().find((x) => x.key === key.slice(3));
+        if (!d) return null;
+        return { ctype: CF.comparatorType(d.type),
+                 get: (it) => (it.custom_fields ? it.custom_fields[d.key] : null) };
+      }
+      const col = COLUMNS.find((c) => c.key === key);
+      if (!col) return null;
+      return { ctype: col.type === "num" ? "num" : "str", get: (it) => it[key] };
+    }
+    // merge form custom values onto the item's EXISTING custom_fields so INACTIVE
+    // keys (not shown in the form) are PRESERVED, never dropped on save.
+    function mergeCustom(origCf, formCustom) {
+      const out = Object.assign({}, origCf || {});
+      for (const k of Object.keys(formCustom)) {
+        if (formCustom[k] === null) delete out[k]; else out[k] = formCustom[k];
+      }
+      return out;
+    }
 
     function statusPillClass(s) {
       if (s === "Needs Attention") return "pill pill-attn";
@@ -393,7 +433,11 @@
         if (fl && it.location !== fl) return false;
         if (attn && it.status !== "Needs Attention") return false;
         if (q) {
-          const hay = SEARCH_FIELDS.map((f) => (it[f] == null ? "" : String(it[f]).toLowerCase())).join("  ");
+          let hay = SEARCH_FIELDS.map((f) => (it[f] == null ? "" : String(it[f]).toLowerCase())).join("  ");
+          for (const d of activeDefs()) {
+            const cv = it.custom_fields ? it.custom_fields[d.key] : null;
+            hay += "  " + CF.searchTextForValue(d, cv).toLowerCase();
+          }
           if (!hay.includes(q)) return false;
         }
         return true;
@@ -403,22 +447,12 @@
       if (state.sortKeys.length) {
         rows = rows.slice().sort((a, b) => {
           for (const { key, dir } of state.sortKeys) {
-            const col = COLUMNS.find((c) => c.key === key);
-            let av = a[key], bv = b[key];
-            let cmp;
-            if (col && col.type === "num") {
-              av = (av == null ? null : Number(av)); bv = (bv == null ? null : Number(bv));
-              if (av == null && bv == null) cmp = 0;
-              else if (av == null) cmp = 1;        // nulls last
-              else if (bv == null) cmp = -1;
-              else cmp = av - bv;
-            } else {
-              const as = (av == null ? "" : String(av)), bs = (bv == null ? "" : String(bv));
-              if (as === "" && bs === "") cmp = 0;
-              else if (as === "") cmp = 1;
-              else if (bs === "") cmp = -1;
-              else cmp = as.localeCompare(bs, undefined, { sensitivity:"base", numeric:true });
-            }
+            const meta = colMeta(key);
+            if (!meta) continue;
+            // shared typed comparator (lib/custom-fields.js): numeric/date/bool/str,
+            // nulls treated as +inf so the dir flip gives the same null semantics
+            // as the core columns did. Custom keys are "cf:<key>".
+            const cmp = CF.compareValues(meta.ctype, meta.get(a), meta.get(b));
             if (cmp !== 0) return dir === "desc" ? -cmp : cmp;
           }
           return 0;
@@ -430,7 +464,7 @@
 
     function renderHead() {
       const tr = $("inv-thead"); tr.replaceChildren();
-      for (const col of COLUMNS) {
+      for (const col of allColumns()) {
         const th = document.createElement("th");
         th.textContent = col.label;             // textContent (labels are static, but keep the discipline)
         const sk = state.sortKeys.find((s) => s.key === col.key);
@@ -492,6 +526,10 @@
         tr.appendChild(stTd);
         tr.appendChild(td(it.location));
         tr.appendChild(td(it.notes, "cell-notes"));
+        for (const d of activeDefs()) {                       // Phase 5 custom columns
+          const cv = it.custom_fields ? it.custom_fields[d.key] : null;
+          tr.appendChild(td(CF.displayText(d, cv), d.type === "number" ? "num" : null));
+        }
         if (canWrite()) {
           const atd = document.createElement("td");
           atd.appendChild(rowActions(it));
@@ -522,6 +560,10 @@
           kv.appendChild(kd); kv.appendChild(vd);
         };
         pair("Qty", it.qty); pair("Type", it.device_type); pair("Category", it.category); pair("Location", it.location);
+        for (const d of activeDefs()) {                       // Phase 5 custom fields
+          const cv = it.custom_fields ? it.custom_fields[d.key] : null;
+          pair(d.label, CF.displayText(d, cv));
+        }
         card.appendChild(kv);
 
         if (it.notes) { const nd = document.createElement("div"); nd.className = "card-notes"; nd.textContent = String(it.notes); card.appendChild(nd); }
@@ -562,7 +604,7 @@
       let data, error;
       for (let attempt = 0; attempt < 2; attempt++) {
         ({ data, error } = await sb.from("items")
-          .select("id,name,brand,model_pn,qty,device_type,category,status,location,assignment_purpose,notes,value,serial,is_archived,version,created_at,updated_at")
+          .select(ITEM_SELECT)
           .order("id", { ascending: true }));
         if (!error) break;
         showMsg(inv, "Backend waking up… retrying", "info");
@@ -673,11 +715,50 @@
         cell.appendChild(el); body.appendChild(cell);
         inputs[f.key] = el;
       }
-      return inputs;
+      // ---- Phase 5: typed inputs for active custom fields. Labels + dropdown
+      //      options set via textContent ONLY (XSS-safe), same discipline as core.
+      const customInputs = {};
+      const defs = activeDefs();
+      if (defs.length) {
+        const sep = document.createElement("div"); sep.className = "full";
+        const sh = document.createElement("div"); sh.className = "muted";
+        sh.style.cssText = "border-top:1px solid var(--panel-border);padding-top:8px;font-size:.74rem;text-transform:uppercase;letter-spacing:.5px;";
+        sh.textContent = "Custom fields"; sep.appendChild(sh); body.appendChild(sep);
+      }
+      const curCf = item.custom_fields || {};
+      for (const d of defs) {
+        const cell = document.createElement("div");
+        const lab = document.createElement("label"); lab.textContent = d.label; lab.htmlFor = "cf-" + d.key;
+        cell.appendChild(lab);
+        const cur = curCf[d.key];
+        let el;
+        if (d.type === "dropdown") {
+          el = document.createElement("select");
+          const blank = document.createElement("option"); blank.value = ""; blank.textContent = "(none)"; el.appendChild(blank);
+          for (const opt of (d.options || [])) { const o = document.createElement("option"); o.value = opt; o.textContent = opt; el.appendChild(o); }
+          el.value = cur == null ? "" : String(cur);
+        } else if (d.type === "boolean") {
+          el = document.createElement("select");
+          for (const ov of [["", "(none)"], ["true", "Yes"], ["false", "No"]]) { const o = document.createElement("option"); o.value = ov[0]; o.textContent = ov[1]; el.appendChild(o); }
+          el.value = cur === true ? "true" : cur === false ? "false" : "";
+        } else {
+          el = document.createElement("input");
+          el.type = d.type === "number" ? "number" : d.type === "date" ? "date" : "text";
+          if (d.type === "number") el.step = "any";
+          el.value = cur == null ? "" : String(cur);
+        }
+        el.id = "cf-" + d.key;
+        cell.appendChild(el); body.appendChild(cell);
+        customInputs[d.key] = el;
+      }
+      return { core: inputs, custom: customInputs };
     }
 
-    // collect + type-validate; returns {ok, values} or {ok:false, error}
-    function collectForm(inputs) {
+    // collect + type-validate; returns {ok, values, custom} or {ok:false, error}.
+    // refs = { core, custom } from buildForm. `custom` maps active def key -> typed
+    // value (null = cleared). The DB trigger (phase5.sql) is the FINAL authority.
+    function collectForm(refs) {
+      const inputs = refs.core, customInputs = refs.custom || {};
       const values = {};
       for (const f of EDIT_FIELDS) {
         const raw = inputs[f.key].value;
@@ -692,7 +773,15 @@
           values[f.key] = t === "" ? null : t;
         }
       }
-      return { ok:true, values };
+      const custom = {};
+      for (const d of activeDefs()) {
+        const el = customInputs[d.key];
+        if (!el) continue;
+        const r = CF.coerceFormValue(d, el.value);
+        if (!r.ok) return { ok:false, error: r.error };
+        custom[d.key] = r.value;
+      }
+      return { ok:true, values, custom };
     }
 
     function diffFields(orig, next) {
@@ -714,6 +803,7 @@
       p.textContent = "Confirm these changes:"; body.appendChild(p);
       const dl = document.createElement("div"); dl.className = "diff-list";
       for (const k of Object.keys(changed)) {
+        if (k === "custom_fields") { renderCustomDiff(orig.custom_fields || {}, changed.custom_fields || {}, dl); continue; }
         const kd = document.createElement("div"); kd.className = "k"; kd.textContent = k;
         const vd = document.createElement("div");
         const oldS = document.createElement("span"); oldS.className = "diff-old";
@@ -736,13 +826,15 @@
       const orig = state.items.find((x) => x.id === item.id) || item;
       state.editing = { id: orig.id, version: orig.version };
       openModal("Edit item #" + orig.id);
-      const inputs = buildForm(orig);
+      const refs = buildForm(orig);
       const foot = $("modal-foot");
       foot.appendChild(footBtn("Cancel", "secondary", closeModal));
       foot.appendChild(footBtn("Review changes", "", () => {
-        const c = collectForm(inputs);
+        const c = collectForm(refs);
         if (!c.ok) { modalMsg(c.error, "bad"); return; }
         const changed = diffFields(orig, c.values);
+        const mergedCf = mergeCustom(orig.custom_fields, c.custom);
+        if (JSON.stringify(mergedCf) !== JSON.stringify(orig.custom_fields || {})) changed.custom_fields = mergedCf;
         if (Object.keys(changed).length === 0) { modalMsg("No changes to save.", "info"); return; }
         showDiffConfirm(orig, changed, () => saveEdit(orig, changed));
       }));
@@ -752,7 +844,7 @@
       setStatus("Saving…");
       const { data, error } = await sb.from("items")
         .update(changed).eq("id", orig.id).eq("version", orig.version)
-        .select("id,name,brand,model_pn,qty,device_type,category,status,location,assignment_purpose,notes,value,serial,is_archived,version,created_at,updated_at");
+        .select(ITEM_SELECT);
       setStatus("");
       if (error) { modalMsg("Save failed: " + error.message, "bad"); return; }
       if (!data || data.length === 0) { await handleZeroRows(orig, "save"); return; }
@@ -792,11 +884,11 @@
       if (!canWrite()) return;
       const blank = {}; for (const f of EDIT_FIELDS) blank[f.key] = null;
       openModal("Add item");
-      const inputs = buildForm(blank);
+      const refs = buildForm(blank);
       const foot = $("modal-foot");
       foot.appendChild(footBtn("Cancel", "secondary", closeModal));
       foot.appendChild(footBtn("Review", "", () => {
-        const c = collectForm(inputs);
+        const c = collectForm(refs);
         if (!c.ok) { modalMsg(c.error, "bad"); return; }
         if (c.values.name == null) { modalMsg("Name is required for a new item.", "bad"); return; }
         // confirm: show the non-empty fields
@@ -809,28 +901,36 @@
           const vd = document.createElement("div"); vd.className = "diff-new"; vd.textContent = String(c.values[f.key]);
           dl.appendChild(kd); dl.appendChild(vd);
         }
+        for (const d of activeDefs()) {
+          if (c.custom[d.key] == null) continue;
+          const kd = document.createElement("div"); kd.className = "k"; kd.textContent = d.label;
+          const vd = document.createElement("div"); vd.className = "diff-new"; vd.textContent = CF.displayText(d, c.custom[d.key]);
+          dl.appendChild(kd); dl.appendChild(vd);
+        }
         body.appendChild(dl);
         const ft = $("modal-foot"); ft.replaceChildren();
-        ft.appendChild(footBtn("Back", "secondary", () => openAddPrefilled(c.values)));
-        ft.appendChild(footBtn("Create item", "", () => addItem(c.values)));
+        ft.appendChild(footBtn("Back", "secondary", () => openAddPrefilled(c.values, c.custom)));
+        ft.appendChild(footBtn("Create item", "", () => addItem(c.values, c.custom)));
       }));
     }
-    function openAddPrefilled(values) {
+    function openAddPrefilled(values, customVals) {
       openModal("Add item");
-      const inputs = buildForm(values);
+      const seed = Object.assign({}, values, { custom_fields: customVals || {} });
+      const refs = buildForm(seed);
       const foot = $("modal-foot");
       foot.appendChild(footBtn("Cancel", "secondary", closeModal));
       foot.appendChild(footBtn("Review", "", () => {
-        const c = collectForm(inputs);
+        const c = collectForm(refs);
         if (!c.ok) { modalMsg(c.error, "bad"); return; }
         if (c.values.name == null) { modalMsg("Name is required.", "bad"); return; }
-        addItem(c.values);
+        addItem(c.values, c.custom);
       }));
     }
-    async function addItem(values) {
+    async function addItem(values, customVals) {
       setStatus("Adding…");
-      const { data, error } = await sb.from("items").insert([values])
-        .select("id,name,brand,model_pn,qty,device_type,category,status,location,assignment_purpose,notes,value,serial,is_archived,version,created_at,updated_at");
+      const payload = Object.assign({}, values, { custom_fields: mergeCustom({}, customVals || {}) });
+      const { data, error } = await sb.from("items").insert([payload])
+        .select(ITEM_SELECT);
       setStatus("");
       if (error) { modalMsg("Add failed: " + error.message, "bad"); return; }
       if (!data || data.length === 0) { modalMsg("The database refused this insert (role=" + state.role + ").", "bad"); return; }
@@ -859,7 +959,7 @@
         setStatus(toArchived ? "Archiving…" : "Un-archiving…");
         const { data, error } = await sb.from("items")
           .update({ is_archived: toArchived }).eq("id", orig.id).eq("version", orig.version)
-          .select("id,name,brand,model_pn,qty,device_type,category,status,location,assignment_purpose,notes,value,serial,is_archived,version,created_at,updated_at");
+          .select(ITEM_SELECT);
         setStatus("");
         if (error) { modalMsg("Failed: " + error.message, "bad"); return; }
         if (!data || data.length === 0) { await handleZeroRows(orig, toArchived ? "archive" : "un-archive"); return; }
@@ -904,6 +1004,147 @@
       body.appendChild(list);
     }
 
+    // ---- Phase 5: per-changed-custom-field diff rows (labels + values via
+    //      textContent — XSS-safe) ----
+    function renderCustomDiff(origCf, newCf, dl) {
+      const keys = new Set([...Object.keys(origCf || {}), ...Object.keys(newCf || {})]);
+      for (const sk of keys) {
+        const ov = (origCf || {})[sk], nv = (newCf || {})[sk];
+        if (JSON.stringify(ov) === JSON.stringify(nv)) continue;
+        const d = defByKey(sk) || { type: "text", label: sk };
+        const kd = document.createElement("div"); kd.className = "k"; kd.textContent = d.label || sk;
+        const vd = document.createElement("div");
+        const oS = document.createElement("span"); oS.className = "diff-old";
+        oS.textContent = ov == null ? "(empty)" : CF.displayText(d, ov);
+        vd.appendChild(oS); vd.appendChild(document.createTextNode("  →  "));
+        const nS = document.createElement("span"); nS.className = "diff-new";
+        nS.textContent = nv == null ? "(empty)" : CF.displayText(d, nv);
+        vd.appendChild(nS);
+        dl.appendChild(kd); dl.appendChild(vd);
+      }
+    }
+
+    // =========================================================================
+    // Phase 5: ADMIN custom-field management (add / deactivate / reactivate).
+    // The DATABASE (field_definitions RLS: INSERT/UPDATE = admin) is the real
+    // gate; this UI is cosmetic. Adding a definition makes the field appear on
+    // EVERY item instantly (custom_fields default '{}'); deactivating sets
+    // is_active=false and PRESERVES stored values + change_log history.
+    // =========================================================================
+    function isAdmin() { return state.role === "admin"; }
+
+    async function loadFieldDefs() {
+      const { data, error } = await sb.from("field_definitions")
+        .select("key,label,type,options,required,is_active,created_at")
+        .order("created_at", { ascending: true });
+      state.fieldDefs = !error && Array.isArray(data) ? data : [];
+    }
+
+    function openManageFields() {
+      if (!isAdmin()) return;
+      openModal("Manage custom fields");
+      renderManageFields();
+    }
+
+    function renderManageFields() {
+      const body = $("modal-body"); body.replaceChildren(); body.className = "modal-body";
+
+      const listWrap = document.createElement("div");
+      const h = document.createElement("div"); h.className = "muted";
+      h.style.cssText = "font-size:.74rem;text-transform:uppercase;letter-spacing:.5px;margin-bottom:6px;";
+      h.textContent = "Existing fields"; listWrap.appendChild(h);
+      if (state.fieldDefs.length === 0) {
+        const e = document.createElement("div"); e.className = "muted"; e.textContent = "No custom fields yet.";
+        listWrap.appendChild(e);
+      } else {
+        const list = document.createElement("div"); list.className = "hist-list";
+        for (const d of state.fieldDefs) {
+          const row = document.createElement("div"); row.className = "hist-row row"; row.style.justifyContent = "space-between";
+          const meta = document.createElement("div");
+          const strong = document.createElement("strong"); strong.textContent = d.label;       // XSS-safe
+          const sub = document.createElement("div"); sub.className = "hh";
+          sub.textContent = d.key + " · " + d.type + (d.is_active ? "" : " · INACTIVE") +
+            (d.options && d.options.length ? " · [" + d.options.join(", ") + "]" : "");  // textContent => safe
+          meta.appendChild(strong); meta.appendChild(sub);
+          const btn = footBtn(d.is_active ? "Deactivate" : "Reactivate", d.is_active ? "btn-sm danger" : "btn-sm", () => setFieldActive(d, !d.is_active));
+          row.appendChild(meta); row.appendChild(btn);
+          list.appendChild(row);
+        }
+        listWrap.appendChild(list);
+      }
+      body.appendChild(listWrap);
+      body.appendChild(document.createElement("hr"));
+
+      const addH = document.createElement("div"); addH.className = "muted";
+      addH.style.cssText = "font-size:.74rem;text-transform:uppercase;letter-spacing:.5px;margin-bottom:6px;";
+      addH.textContent = "Add a field"; body.appendChild(addH);
+
+      const grid = document.createElement("div"); grid.className = "modal-body form-grid";
+      const mk = (labelText, el, full) => {
+        const cell = document.createElement("div"); if (full) cell.className = "full";
+        const lab = document.createElement("label"); lab.textContent = labelText; cell.appendChild(lab);
+        cell.appendChild(el); grid.appendChild(cell); return el;
+      };
+      const keyEl = mk("Key (a–z, 0–9, _; starts with a letter)", document.createElement("input"));
+      keyEl.placeholder = "warranty_expires";
+      const labelEl = mk("Label", document.createElement("input"));
+      labelEl.placeholder = "Warranty expires";
+      const typeEl = document.createElement("select");
+      for (const t of CF.CUSTOM_TYPES) { const o = document.createElement("option"); o.value = t; o.textContent = t; typeEl.appendChild(o); }
+      mk("Type", typeEl);
+      const reqEl = document.createElement("select");
+      for (const rv of [["false", "Optional"], ["true", "Required (UX nudge)"]]) { const o = document.createElement("option"); o.value = rv[0]; o.textContent = rv[1]; reqEl.appendChild(o); }
+      mk("Required", reqEl);
+      const optsEl = document.createElement("textarea");
+      optsEl.placeholder = "one option per line (dropdown only)";
+      const optsCell = mk("Options", optsEl, true);
+      const syncOpts = () => { optsCell.parentElement.style.display = typeEl.value === "dropdown" ? "" : "none"; };
+      typeEl.addEventListener("change", syncOpts); syncOpts();
+      body.appendChild(grid);
+
+      const foot = $("modal-foot"); foot.replaceChildren();
+      foot.appendChild(footBtn("Close", "secondary", closeModal));
+      foot.appendChild(footBtn("Add field", "", () => {
+        addFieldDef({ key: keyEl.value.trim(), label: labelEl.value.trim(), type: typeEl.value,
+                      required: reqEl.value === "true", optionsText: optsEl.value });
+      }));
+    }
+
+    async function addFieldDef(input) {
+      if (!CF.isValidKey(input.key)) { modalMsg("Key must be a–z / 0–9 / _ and start with a letter.", "bad"); return; }
+      if (!input.label) { modalMsg("Label is required.", "bad"); return; }
+      let options = null;
+      if (input.type === "dropdown") {
+        options = CF.parseOptions(input.optionsText);
+        if (options.length === 0) { modalMsg("A dropdown needs at least one option.", "bad"); return; }
+      }
+      setStatus("Adding field…");
+      const row = { key: input.key, label: input.label, type: input.type, required: input.required };
+      if (options) row.options = options;
+      const { data, error } = await sb.from("field_definitions").insert([row]).select("key");
+      setStatus("");
+      if (error) { modalMsg("Add field failed: " + error.message, "bad"); return; }
+      if (!data || data.length === 0) { modalMsg("The database refused this (admin only). RLS is the gate.", "bad"); return; }
+      await loadFieldDefs();
+      renderHead(); applyView();
+      openManageFields();
+      setStatus("Added field \"" + input.key + "\".");
+    }
+
+    async function setFieldActive(def, active) {
+      if (!isAdmin()) return;
+      setStatus(active ? "Reactivating…" : "Deactivating…");
+      const { data, error } = await sb.from("field_definitions")
+        .update({ is_active: active }).eq("key", def.key).select("key,is_active");
+      setStatus("");
+      if (error) { modalMsg("Update failed: " + error.message, "bad"); return; }
+      if (!data || data.length === 0) { modalMsg("The database refused this (admin only). RLS is the gate.", "bad"); return; }
+      await loadFieldDefs();
+      renderHead(); applyView();
+      renderManageFields();
+      setStatus((active ? "Reactivated" : "Deactivated") + " \"" + def.key + "\".");
+    }
+
     // ---- shared: replace a row in state.items by id -------------------------
     function mergeRow(row) {
       const i = state.items.findIndex((x) => x.id === row.id);
@@ -913,6 +1154,7 @@
     function applyWriteUi() {
       const w = canWrite();
       $("add-btn").classList.toggle("hidden", !w);
+      $("manage-fields-btn").classList.toggle("hidden", !isAdmin());
       $("debug-wrap").classList.toggle("hidden", state.role !== "admin");
       if (state.role !== "admin") { state.debug = false; $("debug-toggle").checked = false; $("diag-panel").classList.add("hidden"); }
     }
@@ -928,6 +1170,7 @@
       applyWriteUi();
       hide(signinView); appView.classList.remove("hidden"); hide($("probe-msg"));
       setStatus("");
+      await loadFieldDefs();   // load custom-field definitions before rendering columns
       await loadInventory();
     }
 
@@ -962,9 +1205,9 @@
       setStatus("Signing out…");
       await sb.auth.signOut();
       state = { user:null, role:null, sampleItem:null, items:[], view:[], sortKeys:[],
-                showArchived:false, debug:false };
+                showArchived:false, debug:false, fieldDefs:[] };
       closeModal();
-      $("add-btn").classList.add("hidden"); $("debug-wrap").classList.add("hidden");
+      $("add-btn").classList.add("hidden"); $("manage-fields-btn").classList.add("hidden"); $("debug-wrap").classList.add("hidden");
       $("diag-panel").classList.add("hidden"); $("f-archived").checked = false;
       $("who").textContent = ""; $("role").textContent = "";
       $("sample-item").textContent = "—";
@@ -986,6 +1229,7 @@
       $("probe-btn").addEventListener("click", onProbe);
       $("signout-btn").addEventListener("click", onSignOut);
       $("add-btn").addEventListener("click", openAdd);
+      $("manage-fields-btn").addEventListener("click", openManageFields);
       $("modal-x").addEventListener("click", closeModal);
       $("modal-overlay").addEventListener("click", (e) => { if (e.target === $("modal-overlay")) closeModal(); });
       document.addEventListener("keydown", (e) => { if (e.key === "Escape" && !$("modal-overlay").classList.contains("hidden")) closeModal(); });

--- a/inventory/lib/custom-fields.d.ts
+++ b/inventory/lib/custom-fields.d.ts
@@ -1,0 +1,58 @@
+/**
+ * Inventory — type declarations for the shared custom-field logic (Phase 5).
+ * ---------------------------------------------------------------------------
+ * Sidecar for custom-fields.js. The .js stays a plain UMD module (no
+ * import/export keywords) so it loads BOTH as a same-origin browser
+ * `<script src>` (CSP script-src 'self', no build step) AND is importable by
+ * bun via CJS interop — see the .js header. This .d.ts is type-only: it ships
+ * nothing to the browser and compiles to nothing; it exists solely so the
+ * strict repo-wide `tsc --noEmit` (lint (tsc tools)) can type-check the
+ * `import CF from "../lib/custom-fields.js"` in custom-fields.unit.test.ts
+ * WITHOUT excluding inventory from the gate (the test stays type-checked — the
+ * shield is asserted, not skipped). Mirrors the runtime export object.
+ */
+
+/** Declared custom-field type tags (mirrors the runtime CUSTOM_TYPES array). */
+export type CustomFieldType = "text" | "number" | "date" | "dropdown" | "boolean";
+
+/** Which client-side comparator a declared field type sorts under. */
+export type ComparatorType = "num" | "date" | "bool" | "str";
+
+/** A custom-field definition (the app passes objects with at least `type`). */
+export interface FieldDef {
+  type: string;
+  label?: string;
+  key?: string;
+  options?: readonly string[] | null;
+}
+
+/** A coerced/typed custom-field value; null = empty/cleared. */
+export type TypedValue = string | number | boolean | null;
+
+/** Result of coercing raw form input to a typed value. */
+export type CoerceResult =
+  | { ok: true; value: TypedValue }
+  | { ok: false; error: string };
+
+/** Result of validating an already-typed value against its declared type. */
+export type ValidateResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+/** The object returned by the UMD factory (default export + window.CustomFields). */
+export interface CustomFieldsApi {
+  readonly CUSTOM_TYPES: readonly string[];
+  isValidCalendarDate(s: unknown): boolean;
+  comparatorType(fieldType: string): ComparatorType;
+  coerceFormValue(def: FieldDef, raw: unknown): CoerceResult;
+  validateTypedValue(def: FieldDef, value: unknown): ValidateResult;
+  compareValues(ctype: string, a: unknown, b: unknown): number;
+  toNumeric(ctype: string, v: unknown): number | null;
+  searchTextForValue(def: FieldDef, value: unknown): string;
+  displayText(def: FieldDef, value: unknown): string;
+  isValidKey(key: unknown): boolean;
+  parseOptions(text: unknown): string[];
+}
+
+declare const CustomFields: CustomFieldsApi;
+export default CustomFields;

--- a/inventory/lib/custom-fields.js
+++ b/inventory/lib/custom-fields.js
@@ -1,0 +1,198 @@
+/**
+ * Inventory — shared custom-field logic (Phase 5)
+ * ---------------------------------------------------------------------------
+ * ONE SOURCE OF TRUTH for typed custom-field behaviour, used by BOTH:
+ *   - index.html (loaded as a plain same-origin <script src> -> window.CustomFields;
+ *     CSP script-src 'self' already permits it, no build step)
+ *   - inventory/proofs/custom-fields.unit.test.ts (bun test, via CJS interop)
+ *
+ * It is PURE (no DOM, no network) so the comparator / coercion / validation logic
+ * is unit-testable in isolation. The DATABASE (inventory/sql/phase5.sql trigger)
+ * is the FINAL authority on validity; the app-side mirror here is convenience +
+ * UX only (zero-trust: an editor with the anon key can bypass the client).
+ *
+ * UMD wrapper: no import/export keywords, so it loads in a non-module browser
+ * <script> AND is requireable/importable by bun.
+ */
+(function (root, factory) {
+  "use strict";
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api; // bun / node
+  root.CustomFields = api; // browser global
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  const CUSTOM_TYPES = ["text", "number", "date", "dropdown", "boolean"];
+  const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+  // A calendar-real YYYY-MM-DD (rejects 2024-13-40, 2023-02-29, etc.). Mirrors
+  // the DB trigger's regex + ::date cast. Uses UTC to avoid local-tz roll-over.
+  function isValidCalendarDate(s) {
+    if (typeof s !== "string" || !DATE_RE.test(s)) return false;
+    const y = Number(s.slice(0, 4));
+    const m = Number(s.slice(5, 7));
+    const d = Number(s.slice(8, 10));
+    const dt = new Date(Date.UTC(y, m - 1, d));
+    return dt.getUTCFullYear() === y && dt.getUTCMonth() === m - 1 && dt.getUTCDate() === d;
+  }
+
+  // Which client-side comparator a declared field type sorts under.
+  function comparatorType(fieldType) {
+    if (fieldType === "number") return "num";
+    if (fieldType === "date") return "date";
+    if (fieldType === "boolean") return "bool";
+    return "str"; // text + dropdown
+  }
+
+  // --- coercion: raw form input (string) -> typed JS value, or an error --------
+  // raw is input.value (text/number/date) or select value (dropdown/boolean).
+  // Returns { ok:true, value } (value is null for "empty/cleared") or
+  // { ok:false, error }. App-side mirror of the DB trigger.
+  function coerceFormValue(def, raw) {
+    const type = def.type;
+    if (type === "boolean") {
+      // select value: "" (none) | "true" | "false"
+      if (raw === "" || raw == null) return { ok: true, value: null };
+      if (raw === "true") return { ok: true, value: true };
+      if (raw === "false") return { ok: true, value: false };
+      return { ok: false, error: `${def.label}: invalid boolean.` };
+    }
+    const s = String(raw == null ? "" : raw).trim();
+    if (s === "") return { ok: true, value: null }; // empty = cleared
+    if (type === "text") {
+      return { ok: true, value: s };
+    }
+    if (type === "number") {
+      const n = Number(s);
+      if (!Number.isFinite(n)) return { ok: false, error: `${def.label} must be a number.` };
+      return { ok: true, value: n };
+    }
+    if (type === "date") {
+      if (!isValidCalendarDate(s)) return { ok: false, error: `${def.label} must be a valid date (YYYY-MM-DD).` };
+      return { ok: true, value: s };
+    }
+    if (type === "dropdown") {
+      const opts = Array.isArray(def.options) ? def.options : [];
+      if (!opts.includes(s)) return { ok: false, error: `${def.label} must be one of: ${opts.join(", ")}.` };
+      return { ok: true, value: s };
+    }
+    return { ok: false, error: `${def.label}: unsupported field type.` };
+  }
+
+  // --- validation: an already-typed JS value matches the declared type ---------
+  // Final app-side guard before sending to the DB. null = cleared = always ok.
+  function validateTypedValue(def, value) {
+    if (value === null || value === undefined) return { ok: true };
+    const type = def.type;
+    if (type === "text") {
+      return typeof value === "string" ? { ok: true } : { ok: false, error: `${def.label}: expected text.` };
+    }
+    if (type === "number") {
+      return typeof value === "number" && Number.isFinite(value)
+        ? { ok: true }
+        : { ok: false, error: `${def.label}: expected a number.` };
+    }
+    if (type === "boolean") {
+      return typeof value === "boolean" ? { ok: true } : { ok: false, error: `${def.label}: expected true/false.` };
+    }
+    if (type === "date") {
+      return typeof value === "string" && isValidCalendarDate(value)
+        ? { ok: true }
+        : { ok: false, error: `${def.label}: expected YYYY-MM-DD.` };
+    }
+    if (type === "dropdown") {
+      const opts = Array.isArray(def.options) ? def.options : [];
+      return typeof value === "string" && opts.includes(value)
+        ? { ok: true }
+        : { ok: false, error: `${def.label}: not an allowed option.` };
+    }
+    return { ok: false, error: `${def.label}: unsupported field type.` };
+  }
+
+  // --- comparator: returns negative/0/positive; null/invalid treated as +inf so
+  //     the caller's `dir==="desc" ? -cmp : cmp` flip gives the SAME null
+  //     semantics as core columns. ctype from comparatorType().
+  function compareValues(ctype, a, b) {
+    if (ctype === "str") {
+      const as = a == null ? "" : String(a);
+      const bs = b == null ? "" : String(b);
+      if (as === "" && bs === "") return 0;
+      if (as === "") return 1; // empty last
+      if (bs === "") return -1;
+      return as.localeCompare(bs, undefined, { sensitivity: "base", numeric: true });
+    }
+    // numeric-ish: num, date, bool all reduce to a comparable number or null
+    const na = toNumeric(ctype, a);
+    const nb = toNumeric(ctype, b);
+    if (na == null && nb == null) return 0;
+    if (na == null) return 1; // null/invalid last
+    if (nb == null) return -1;
+    return na < nb ? -1 : na > nb ? 1 : 0;
+  }
+
+  function toNumeric(ctype, v) {
+    if (v == null || v === "") return null;
+    if (ctype === "num") {
+      const n = Number(v);
+      return Number.isFinite(n) ? n : null;
+    }
+    if (ctype === "bool") {
+      return typeof v === "boolean" ? (v ? 1 : 0) : null; // false < true
+    }
+    if (ctype === "date") {
+      if (!isValidCalendarDate(String(v))) return null;
+      const t = Date.parse(String(v) + "T00:00:00Z");
+      return Number.isFinite(t) ? t : null;
+    }
+    return null;
+  }
+
+  // --- search haystack text for a stored value (type-aware). Caller lowercases.
+  //     boolean -> "true yes" / "false no" so either spelling matches.
+  function searchTextForValue(def, value) {
+    if (value === null || value === undefined) return "";
+    if (def.type === "boolean") return value ? "true yes" : "false no";
+    return String(value);
+  }
+
+  // --- display text for a rendered cell. null -> "" (caller renders the dash);
+  //     boolean -> Yes/No; everything else -> String(value).
+  function displayText(def, value) {
+    if (value === null || value === undefined) return "";
+    if (def.type === "boolean") return value ? "Yes" : "No";
+    return String(value);
+  }
+
+  // --- admin helpers -----------------------------------------------------------
+  const KEY_RE = /^[a-z][a-z0-9_]*$/; // stable slug, safe in JSONB + UI ids
+  function isValidKey(key) {
+    return typeof key === "string" && key.length >= 1 && key.length <= 60 && KEY_RE.test(key);
+  }
+  // options textarea (newline- or comma-separated) -> de-duped, trimmed, non-empty
+  function parseOptions(text) {
+    const seen = new Set();
+    const out = [];
+    for (const raw of String(text == null ? "" : text).split(/[\n,]/)) {
+      const t = raw.trim();
+      if (t !== "" && !seen.has(t)) {
+        seen.add(t);
+        out.push(t);
+      }
+    }
+    return out;
+  }
+
+  return {
+    CUSTOM_TYPES,
+    isValidCalendarDate,
+    comparatorType,
+    coerceFormValue,
+    validateTypedValue,
+    compareValues,
+    toNumeric,
+    searchTextForValue,
+    displayText,
+    isValidKey,
+    parseOptions,
+  };
+});

--- a/inventory/proofs/custom-fields.unit.test.ts
+++ b/inventory/proofs/custom-fields.unit.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Inventory — Phase 5 custom-field UNIT tests (pure, no network, deterministic)
+ * ---------------------------------------------------------------------------
+ * Tests the SHARED logic in inventory/lib/custom-fields.js that BOTH the browser
+ * (index.html) and these tests use — so the typed sort / coercion / validation
+ * are covered in isolation, not only end-to-end (the phase that "most needs
+ * ongoing assertions", per the owner's brief).
+ *
+ * Run:  bun test inventory/proofs/custom-fields.unit.test.ts
+ *
+ * Includes the BROKEN-vs-FIXED demonstration the CLAUDE.md requires: a naive
+ * string comparator yields the wrong numeric order (10,100,9); the real
+ * comparator yields the correct order (9,10,100).
+ */
+import { describe, test, expect } from "bun:test";
+import CF from "../lib/custom-fields.js";
+
+const def = (type: string, options?: string[]) => ({ key: "k", label: "K", type, options: options ?? null });
+
+describe("coerceFormValue (raw form input -> typed value)", () => {
+  test("text", () => {
+    expect(CF.coerceFormValue(def("text"), "  hi ")).toEqual({ ok: true, value: "hi" });
+    expect(CF.coerceFormValue(def("text"), "")).toEqual({ ok: true, value: null });
+  });
+  test("number accepts numeric, rejects text", () => {
+    expect(CF.coerceFormValue(def("number"), "42")).toEqual({ ok: true, value: 42 });
+    expect(CF.coerceFormValue(def("number"), "-3.5")).toEqual({ ok: true, value: -3.5 });
+    expect(CF.coerceFormValue(def("number"), "")).toEqual({ ok: true, value: null });
+    expect(CF.coerceFormValue(def("number"), "abc").ok).toBe(false);
+    expect(CF.coerceFormValue(def("number"), "1e999").ok).toBe(false); // Infinity rejected
+  });
+  test("date accepts real calendar dates, rejects impossible ones", () => {
+    expect(CF.coerceFormValue(def("date"), "2024-02-29")).toEqual({ ok: true, value: "2024-02-29" });
+    expect(CF.coerceFormValue(def("date"), "2023-02-29").ok).toBe(false); // not a leap year
+    expect(CF.coerceFormValue(def("date"), "2024-13-40").ok).toBe(false);
+    expect(CF.coerceFormValue(def("date"), "nope").ok).toBe(false);
+  });
+  test("dropdown enforces option membership", () => {
+    const d = def("dropdown", ["red", "green"]);
+    expect(CF.coerceFormValue(d, "green")).toEqual({ ok: true, value: "green" });
+    expect(CF.coerceFormValue(d, "purple").ok).toBe(false);
+    expect(CF.coerceFormValue(d, "")).toEqual({ ok: true, value: null });
+  });
+  test("boolean tri-state select", () => {
+    expect(CF.coerceFormValue(def("boolean"), "true")).toEqual({ ok: true, value: true });
+    expect(CF.coerceFormValue(def("boolean"), "false")).toEqual({ ok: true, value: false });
+    expect(CF.coerceFormValue(def("boolean"), "")).toEqual({ ok: true, value: null });
+  });
+});
+
+describe("validateTypedValue (app-side mirror of the DB trigger)", () => {
+  test("null is always allowed", () => {
+    for (const t of CF.CUSTOM_TYPES) expect(CF.validateTypedValue(def(t, ["x"]), null).ok).toBe(true);
+  });
+  test("type mismatches rejected", () => {
+    expect(CF.validateTypedValue(def("number"), "5" as unknown as number).ok).toBe(false);
+    expect(CF.validateTypedValue(def("boolean"), "true" as unknown as boolean).ok).toBe(false);
+    expect(CF.validateTypedValue(def("text"), 5 as unknown as string).ok).toBe(false);
+    expect(CF.validateTypedValue(def("dropdown", ["a"]), "b").ok).toBe(false);
+  });
+});
+
+describe("numeric sort: BROKEN (string) vs FIXED (typed)", () => {
+  const nums = ["10", "9", "100"]; // stored as JSON numbers; shown here as the values
+  test("a naive STRING comparator gets it WRONG (10,100,9)", () => {
+    const naive = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+    expect([...nums].sort(naive)).toEqual(["10", "100", "9"]); // the "10 < 9" bug
+  });
+  test("the REAL typed comparator gets it RIGHT (9,10,100)", () => {
+    const real = (a: string, b: string) => CF.compareValues("num", a, b);
+    expect([...nums].sort(real)).toEqual(["9", "10", "100"]);
+  });
+});
+
+describe("compareValues: nulls, mixed, and the five types", () => {
+  test("nulls sort last on ascending (treated as +inf, flipped by dir like core)", () => {
+    const arr = [5, null, 1, 10, null];
+    const sorted = [...arr].sort((a, b) => CF.compareValues("num", a, b));
+    expect(sorted).toEqual([1, 5, 10, null, null]);
+  });
+  test("mixed/invalid values degrade gracefully (no throw; invalid last)", () => {
+    const arr = [3, "not-a-number", 1, undefined, 2];
+    let sorted: unknown[] = [];
+    expect(() => {
+      sorted = [...arr].sort((a, b) => CF.compareValues("num", a, b));
+    }).not.toThrow();
+    expect(sorted.slice(0, 3)).toEqual([1, 2, 3]); // valid numbers first, in order
+  });
+  test("date comparator is chronological, not lexicographic-on-prefix-only", () => {
+    const arr = ["2024-12-01", "2024-02-28", "2024-02-29"];
+    const sorted = [...arr].sort((a, b) => CF.compareValues("date", a, b));
+    expect(sorted).toEqual(["2024-02-28", "2024-02-29", "2024-12-01"]);
+  });
+  test("boolean: false < true; nulls last", () => {
+    const arr = [true, false, null, true];
+    const sorted = [...arr].sort((a, b) => CF.compareValues("bool", a, b));
+    expect(sorted).toEqual([false, true, true, null]);
+  });
+  test("string comparator is numeric-aware within text", () => {
+    const arr = ["item10", "item2", "item1"];
+    const sorted = [...arr].sort((a, b) => CF.compareValues("str", a, b));
+    expect(sorted).toEqual(["item1", "item2", "item10"]);
+  });
+});
+
+describe("searchTextForValue + displayText", () => {
+  test("boolean is searchable as both true/yes and false/no", () => {
+    expect(CF.searchTextForValue(def("boolean"), true)).toBe("true yes");
+    expect(CF.searchTextForValue(def("boolean"), false)).toBe("false no");
+  });
+  test("null -> empty search text", () => {
+    expect(CF.searchTextForValue(def("text"), null)).toBe("");
+  });
+  test("displayText renders booleans Yes/No and null as empty", () => {
+    expect(CF.displayText(def("boolean"), true)).toBe("Yes");
+    expect(CF.displayText(def("boolean"), false)).toBe("No");
+    expect(CF.displayText(def("text"), null)).toBe("");
+    expect(CF.displayText(def("number"), 0)).toBe("0");
+  });
+});
+
+describe("admin helpers", () => {
+  test("isValidKey enforces a safe slug", () => {
+    expect(CF.isValidKey("warranty_expires")).toBe(true);
+    expect(CF.isValidKey("Warranty")).toBe(false); // no uppercase
+    expect(CF.isValidKey("2cool")).toBe(false); // must start with a letter
+    expect(CF.isValidKey("has space")).toBe(false);
+    expect(CF.isValidKey("")).toBe(false);
+  });
+  test("parseOptions splits, trims, de-dupes, drops empties", () => {
+    expect(CF.parseOptions("red, green\n blue ,red,")).toEqual(["red", "green", "blue"]);
+    expect(CF.parseOptions("")).toEqual([]);
+  });
+});
+
+describe("isValidCalendarDate", () => {
+  test("real vs impossible", () => {
+    expect(CF.isValidCalendarDate("2024-02-29")).toBe(true);
+    expect(CF.isValidCalendarDate("2023-02-29")).toBe(false);
+    expect(CF.isValidCalendarDate("2024-00-10")).toBe(false);
+    expect(CF.isValidCalendarDate("2024-1-1")).toBe(false); // must be zero-padded
+  });
+});

--- a/inventory/proofs/phase5-custom-fields-proofs.ts
+++ b/inventory/proofs/phase5-custom-fields-proofs.ts
@@ -1,0 +1,320 @@
+/**
+ * Inventory — Phase 5 custom-field proofs (REST; admin + editor sessions; NO service_role)
+ * ---------------------------------------------------------------------------
+ * Proves the Phase-5 gate end-to-end against the LIVE Supabase backend using
+ * ONLY the publishable (anon) key. The DB trigger (sql/phase5.sql) + RLS are the
+ * real machinery; this script exercises them and prints RAW observed output.
+ *
+ * Gate proofs (spec.md Phase 5 + the owner's brief):
+ *   (1) ADD one field of EACH of the five types (text/number/date/dropdown/boolean)
+ *       — admin only (field_definitions RLS).
+ *   (2) APPEARS ON EVERY ITEM — the definitions are global; custom_fields default
+ *       '{}' on every row, so a field is available on all items at once.
+ *   (3) PER-TYPE VALIDATION, DB-REJECTED via REST bypassing the client — sent as
+ *       the EDITOR (the zero-trust case: an editor with the anon key hitting
+ *       PostgREST directly). A malformed value of each type is rejected by the DB.
+ *   (4) XSS value STORED verbatim as data (render-inert is the Playwright proof).
+ *   (5) DEACTIVATE a field -> stored values + change_log history PRESERVED.
+ *   (6) RLS still default-deny: unauthenticated anon read on all four sensitive
+ *       tables returns [].
+ *   (Numeric-sort correctness is proven by the SQL proof phase5_proofs.sql +
+ *    the unit suite + the Playwright in-app sort; PostgREST JSON-arrow ordering
+ *    is lexicographic by design, so it is NOT the sort mechanism — shown here
+ *    only to demonstrate the "10 < 9" trap the client/SQL layers avoid.)
+ *
+ * SAFETY / HONESTY:
+ *   - Operates on THROWAWAY items + throwaway field defs (unique run suffix),
+ *     never seed rows. Throwaway items cannot be client-DELETEd (no DELETE
+ *     policy by design) so they are left ARCHIVED and flagged for owner SQL
+ *     cleanup. Throwaway field defs are left is_active=false (NOT hard-deleted —
+ *     same "never delete a definition with data" rule) and flagged for cleanup.
+ *   - Creds + key come from ENV, never hard-coded, never logged. Access tokens
+ *     are never printed. service_role / sb_secret_* is NEVER used.
+ *
+ *   PREREQUISITE: the owner must have run sql/phase1.sql, sql/phase4.sql AND
+ *   sql/phase5.sql first (the validation trigger must exist for proof 3).
+ *
+ *   Run:
+ *     SUPABASE_URL=https://<ref>.supabase.co \
+ *     SUPABASE_ANON_KEY=sb_publishable_... \
+ *     ADMIN_EMAIL=... ADMIN_PASSWORD=... \
+ *     EDITOR_EMAIL=... EDITOR_PASSWORD=... \
+ *     bun inventory/proofs/phase5-custom-fields-proofs.ts
+ */
+
+const URL = req("SUPABASE_URL");
+const ANON = req("SUPABASE_ANON_KEY");
+const ADMIN_EMAIL = req("ADMIN_EMAIL");
+const ADMIN_PASSWORD = req("ADMIN_PASSWORD");
+const EDITOR_EMAIL = req("EDITOR_EMAIL");
+const EDITOR_PASSWORD = req("EDITOR_PASSWORD");
+
+function req(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`MISSING ENV: ${name}`);
+    process.exit(2);
+  }
+  return v;
+}
+
+type RestResult = { status: number; body: unknown };
+
+async function rest(
+  method: string,
+  path: string,
+  token: string,
+  opts: { body?: unknown; prefer?: string } = {},
+): Promise<RestResult> {
+  const headers: Record<string, string> = { apikey: ANON, Authorization: `Bearer ${token}` };
+  if (opts.body !== undefined) headers["Content-Type"] = "application/json";
+  if (opts.prefer) headers["Prefer"] = opts.prefer;
+  const init: RequestInit = { method, headers };
+  if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
+  const res = await fetch(`${URL}/rest/v1/${path}`, init);
+  const text = await res.text();
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { status: res.status, body };
+}
+
+async function signIn(email: string, password: string, label: string): Promise<string> {
+  const res = await fetch(`${URL}/auth/v1/token?grant_type=password`, {
+    method: "POST",
+    headers: { apikey: ANON, "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+  const text = await res.text();
+  let j: { access_token?: string } = {};
+  try { j = JSON.parse(text) as { access_token?: string }; } catch { /* non-JSON */ }
+  if (!res.ok || !j.access_token) {
+    // The auth error body states the REASON (invalid_grant vs email_not_confirmed)
+    // and never echoes the submitted password — safe to print.
+    console.error(`SIGN-IN FAILED for ${label} (http ${res.status}): ${text}`);
+    process.exit(2);
+  }
+  return j.access_token; // never printed
+}
+
+function line(s = "") {
+  console.log(s);
+}
+function arr(b: unknown): unknown[] {
+  return Array.isArray(b) ? b : [];
+}
+function ok2xx(s: number): boolean {
+  return s >= 200 && s < 300;
+}
+
+// jsonb is UNORDERED — Postgres normalizes key order on storage, so compare the
+// custom_fields object key-by-key (NOT JSON.stringify, which is order-sensitive).
+function sameCf(stored: unknown, sent: Record<string, unknown>): boolean {
+  if (!stored || typeof stored !== "object") return false;
+  const so = stored as Record<string, unknown>;
+  const sk = Object.keys(so), tk = Object.keys(sent);
+  if (sk.length !== tk.length) return false;
+  return tk.every((k) => JSON.stringify(so[k]) === JSON.stringify(sent[k]));
+}
+
+async function main() {
+  line("=== Phase 5 custom-field proofs (admin+editor sessions, publishable key, NO service_role) ===");
+  line(`URL=${URL}`);
+  line("");
+
+  const adminToken = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD, "admin");
+  const editorToken = await signIn(EDITOR_EMAIL, EDITOR_PASSWORD, "editor");
+
+  const adminRole = (await rest("POST", "rpc/current_user_role", adminToken, { body: {} })).body;
+  const editorRole = (await rest("POST", "rpc/current_user_role", editorToken, { body: {} })).body;
+  line(`admin  role -> ${JSON.stringify(adminRole)}`);
+  line(`editor role -> ${JSON.stringify(editorRole)}`);
+  if (adminRole !== "admin") line("WARNING: ADMIN_* user is not 'admin'; field-def proofs will be RLS-refused.");
+  if (editorRole !== "editor" && editorRole !== "admin") line("WARNING: EDITOR_* user cannot write items.");
+  line("");
+
+  // unique suffix so re-runs never collide (key must match ^[a-z][a-z0-9_]*$)
+  const sfx = "p5_" + Date.now().toString(36);
+  const F = {
+    text: `${sfx}_text`,
+    number: `${sfx}_number`,
+    date: `${sfx}_date`,
+    dropdown: `${sfx}_dropdown`,
+    boolean: `${sfx}_boolean`,
+  };
+  // NOTE: PostgREST bulk insert (array) requires EVERY object to have the SAME key
+  // set (PGRST102 "All object keys must match") — so all five carry `options`
+  // (null for non-dropdowns). The DB CHECK allows NULL options for non-dropdowns.
+  const defs = [
+    { key: F.text, label: "P5 Text", type: "text", options: null, required: false },
+    { key: F.number, label: "P5 Number", type: "number", options: null, required: false },
+    { key: F.date, label: "P5 Date", type: "date", options: null, required: false },
+    { key: F.dropdown, label: "P5 Dropdown", type: "dropdown", options: ["red", "green", "blue"], required: false },
+    { key: F.boolean, label: "P5 Boolean", type: "boolean", options: null, required: false },
+  ];
+
+  // ---------------------------------------------------------------------------
+  // (1) ADD one field of each of the five types (admin).
+  // ---------------------------------------------------------------------------
+  line("---- (1) PROOF: admin adds one field of EACH of the five types ----");
+  const ins = await rest("POST", "field_definitions", adminToken, { body: defs, prefer: "return=representation" });
+  const created = arr(ins.body) as Record<string, unknown>[];
+  line(`insert field_definitions -> http ${ins.status}; rows=${created.length}`);
+  for (const d of created) line(`  + ${d["key"]} (${d["type"]}) is_active=${d["is_active"]}`);
+  const p1 = ins.status === 201 && created.length === 5;
+  line(`(1) ASSERTION 5 typed field defs created (http 201): ${p1 ? "PASS" : "FAIL"}`);
+  if (!p1) {
+    line(`  raw: ${JSON.stringify(ins.body)}`);
+  }
+  line("");
+
+  // ---------------------------------------------------------------------------
+  // (2) APPEARS ON EVERY ITEM — definitions are global; custom_fields default '{}'.
+  // ---------------------------------------------------------------------------
+  line("---- (2) PROOF: the new fields are available on EVERY item ----");
+  const visDefs = arr((await rest("GET", `field_definitions?select=key,type,is_active&key=like.${sfx}_*`, editorToken)).body);
+  line(`field_definitions visible to the EDITOR (non-admin) role: ${visDefs.length} of 5`);
+  const sampleItems = arr((await rest("GET", "items?select=id,custom_fields&order=id.asc&limit=5", editorToken)).body) as Record<string, unknown>[];
+  const allObjects = sampleItems.length > 0 && sampleItems.every((r) => r["custom_fields"] !== null && typeof r["custom_fields"] === "object");
+  line(`sample of existing items (custom_fields is an object on each — the field slot exists on all):`);
+  for (const r of sampleItems) line(`  #${r["id"]} custom_fields=${JSON.stringify(r["custom_fields"])}`);
+  const p2 = visDefs.length === 5 && allObjects;
+  line(`(2) ASSERTION all 5 defs visible to a viewer/editor AND every sampled item has a custom_fields object: ${p2 ? "PASS" : "FAIL"}`);
+  line("");
+
+  // SETUP: a throwaway item the EDITOR owns the writes on.
+  line("---- SETUP: editor inserts throwaway __phase5_proof_item__ ----");
+  const itemIns = await rest("POST", "items", editorToken, {
+    body: { name: "__phase5_proof_item__", status: "In Storage", qty: 1 },
+    prefer: "return=representation",
+  });
+  const item = arr(itemIns.body)[0] as Record<string, unknown> | undefined;
+  if (itemIns.status !== 201 || !item) {
+    line(`INSERT failed (http ${itemIns.status}): ${JSON.stringify(itemIns.body)}`);
+    process.exit(1);
+  }
+  const id = item["id"] as number;
+  line(`created item id=${id} custom_fields=${JSON.stringify(item["custom_fields"])}`);
+  line("");
+
+  // valid values of all five types in one write (editor):
+  line("---- (2b) editor sets one VALID value of each type on the item ----");
+  const validCf = { [F.text]: "hello", [F.number]: 42, [F.date]: "2024-02-29", [F.dropdown]: "green", [F.boolean]: true };
+  const setValid = await rest("PATCH", `items?id=eq.${id}`, editorToken, { body: { custom_fields: validCf }, prefer: "return=representation" });
+  const afterValid = arr(setValid.body)[0] as Record<string, unknown> | undefined;
+  line(`set valid custom_fields -> http ${setValid.status}; stored=${JSON.stringify(afterValid?.["custom_fields"])}`);
+  const p2b = ok2xx(setValid.status) && sameCf(afterValid?.["custom_fields"], validCf);
+  line(`(2b) ASSERTION all five valid typed values accepted + stored: ${p2b ? "PASS" : "FAIL"}`);
+  line("");
+
+  // ---------------------------------------------------------------------------
+  // (3) PER-TYPE VALIDATION, DB-REJECTED via REST as the EDITOR (bypassing client)
+  // ---------------------------------------------------------------------------
+  line("---- (3) PROOF: per-type validation REJECTED at the DB (editor, direct REST) ----");
+  const bad: Array<[string, Record<string, unknown>]> = [
+    [`number <- string "not-a-number"`, { [F.number]: "not-a-number" }],
+    [`boolean <- string "yes"`, { [F.boolean]: "yes" }],
+    [`date <- "2024-13-40"`, { [F.date]: "2024-13-40" }],
+    [`dropdown <- "purple" (not an option)`, { [F.dropdown]: "purple" }],
+    [`text <- number 123`, { [F.text]: 123 }],
+    [`unknown key`, { [`${sfx}_unknown`]: "x" }],
+  ];
+  let p3 = true;
+  for (const [desc, cf] of bad) {
+    const r = await rest("PATCH", `items?id=eq.${id}`, editorToken, { body: { custom_fields: { ...validCf, ...cf } } });
+    const rejected = !ok2xx(r.status);
+    if (!rejected) p3 = false;
+    const msg = typeof r.body === "object" && r.body && "message" in (r.body as Record<string, unknown>) ? (r.body as Record<string, unknown>)["message"] : r.body;
+    line(`  ${desc.padEnd(40)} -> http ${r.status} ${rejected ? "REJECTED" : "ACCEPTED (BUG!)"}  ${rejected ? "(" + JSON.stringify(msg) + ")" : ""}`);
+  }
+  // confirm the valid value is unchanged after the rejected writes
+  const stillValid = arr((await rest("GET", `items?id=eq.${id}&select=custom_fields`, editorToken)).body)[0] as Record<string, unknown> | undefined;
+  const intact = sameCf(stillValid?.["custom_fields"], validCf);
+  line(`  value intact after all rejects: ${JSON.stringify(stillValid?.["custom_fields"])} -> ${intact ? "OK" : "MISMATCH"}`);
+  line(`(3) ASSERTION every malformed value + unknown key DB-rejected, valid value intact: ${p3 && intact ? "PASS" : "FAIL"}`);
+  line("");
+
+  // ---------------------------------------------------------------------------
+  // (4) XSS value STORED verbatim as data (render-inert proven in Playwright).
+  // ---------------------------------------------------------------------------
+  line("---- (4) PROOF: a <script>/onerror payload is stored as DATA (text), accepted by the DB ----");
+  const XSS = `<img src=x onerror="window.__xss=1"><script>window.__xss=1</script>`;
+  const setXss = await rest("PATCH", `items?id=eq.${id}`, editorToken, { body: { custom_fields: { ...validCf, [F.text]: XSS } }, prefer: "return=representation" });
+  const xssStored = (arr(setXss.body)[0] as Record<string, unknown> | undefined)?.["custom_fields"] as Record<string, unknown> | undefined;
+  line(`stored text field -> http ${setXss.status}; value=${JSON.stringify(xssStored?.[F.text])}`);
+  const p4 = ok2xx(setXss.status) && xssStored?.[F.text] === XSS;
+  line(`(4) ASSERTION payload stored verbatim as a JSON string (render-inert proof = Playwright): ${p4 ? "PASS" : "FAIL"}`);
+  line("");
+
+  // ---------------------------------------------------------------------------
+  // (5) DEACTIVATE a field -> stored values + history PRESERVED.
+  // ---------------------------------------------------------------------------
+  line("---- (5) PROOF: deactivate a field; stored values + change_log history preserved ----");
+  const deact = await rest("PATCH", `field_definitions?key=eq.${F.number}`, adminToken, { body: { is_active: false }, prefer: "return=representation" });
+  const deactRow = arr(deact.body)[0] as Record<string, unknown> | undefined;
+  line(`admin deactivate ${F.number} -> http ${deact.status}; is_active=${deactRow?.["is_active"]}`);
+  const afterDeact = arr((await rest("GET", `items?id=eq.${id}&select=custom_fields`, editorToken)).body)[0] as Record<string, unknown> | undefined;
+  const numPreserved = (afterDeact?.["custom_fields"] as Record<string, unknown> | undefined)?.[F.number] === 42;
+  line(`item custom_fields after deactivation: ${JSON.stringify(afterDeact?.["custom_fields"])}`);
+  line(`  number value (42) still present despite the field being inactive: ${numPreserved ? "PRESERVED" : "LOST"}`);
+  const hist = arr((await rest("GET", `change_log?item_id=eq.${id}&field=eq.custom_fields&order=id.asc&select=id,field,old_value,new_value,changed_at`, editorToken)).body) as Record<string, unknown>[];
+  line(`change_log custom_fields history rows (append-only, ${hist.length} total):`);
+  for (const h of hist) line(`  #${h["id"]} custom_fields changed @ ${h["changed_at"]}`);
+  const p5 = deactRow?.["is_active"] === false && numPreserved && hist.length >= 1;
+  line(`(5) ASSERTION field deactivated AND value preserved AND history intact: ${p5 ? "PASS" : "FAIL"}`);
+  line("");
+
+  // numeric-sort trap demonstration (NOT the sort mechanism; client/SQL/unit own that)
+  line("---- (note) PostgREST JSON-arrow ordering is lexicographic (the \"10 < 9\" trap) ----");
+  line("  numeric correctness is enforced client-side (lib/custom-fields.js compareValues),");
+  line("  proven in phase5_proofs.sql (cast ::numeric) + custom-fields.unit.test.ts + Playwright.");
+  line("");
+
+  // ---------------------------------------------------------------------------
+  // (6) RLS still default-deny: unauthenticated anon read on 4 tables -> []
+  // ---------------------------------------------------------------------------
+  line("---- (6) PROOF: RLS still default-deny (unauthenticated anon, all four sensitive tables) ----");
+  let p6 = true;
+  for (const t of ["items", "field_definitions", "change_log", "profiles"]) {
+    const res = await fetch(`${URL}/rest/v1/${t}?select=*&limit=2`, {
+      headers: { apikey: ANON, Authorization: `Bearer ${ANON}` }, // anon, NOT a user token
+    });
+    const body = await res.text();
+    const empty = body.trim() === "[]";
+    if (!empty) p6 = false;
+    line(`  anon ${t.padEnd(18)} http ${res.status} -> ${body}`);
+  }
+  line(`(6) ASSERTION all four anon reads == [] : ${p6 ? "PASS" : "FAIL"}`);
+  line("");
+
+  // ---------------------------------------------------------------------------
+  // CLEANUP: archive the throwaway item (cannot DELETE via client); deactivate
+  // the throwaway field defs (NOT hard-deleted — they have data on the item).
+  // ---------------------------------------------------------------------------
+  await rest("PATCH", `items?id=eq.${id}`, editorToken, {
+    body: { is_archived: true, name: "__phase5_proof artifact — owner: remove in SQL editor before launch" },
+  });
+  for (const k of Object.values(F)) {
+    await rest("PATCH", `field_definitions?key=eq.${k}`, adminToken, { body: { is_active: false } });
+  }
+  line(`CLEANUP: throwaway item id=${id} left ARCHIVED; throwaway field defs (${Object.values(F).join(", ")}) left is_active=false.`);
+  line(`  Owner follow-up (SQL editor): disable change_log_immutable trigger -> delete change_log where item_id=${id};`);
+  line(`  delete items where id=${id}; delete from field_definitions where key like '${sfx}_%'; re-enable trigger.`);
+  line("");
+
+  const allPass = p1 && p2 && p2b && p3 && intact && p4 && p5 && p6;
+  line(`=== SUMMARY: (1)=${b(p1)} (2)=${b(p2)} (2b)=${b(p2b)} (3)=${b(p3 && intact)} (4)=${b(p4)} (5)=${b(p5)} (6)=${b(p6)} ===`);
+  process.exit(allPass ? 0 : 1);
+}
+
+function b(v: boolean): string {
+  return v ? "PASS" : "FAIL";
+}
+
+main().catch((e) => {
+  console.error("UNEXPECTED ERROR:", e instanceof Error ? e.message : String(e));
+  process.exit(1);
+});

--- a/inventory/sql/RUN.md
+++ b/inventory/sql/RUN.md
@@ -51,6 +51,37 @@ nothing (no new RLS policy, no GRANT/REVOKE).
 Phase 4 gate is **passed** only when all four proofs show observed output and the
 anon checks still return `[]`. Until then PROGRESS.md keeps Phase 4 as `[ ]`.
 
+## Phase 5 (Typed dynamic custom fields)
+
+Run AFTER `phase1.sql` + `phase4.sql`. Additive + idempotent; loosens nothing (no new RLS policy,
+no GRANT/REVOKE).
+
+1. **`phase5.sql`** — owner pastes into the Supabase **SQL editor** and runs once. Adds a GIN index
+   on `items.custom_fields` and the `validate_custom_fields()` BEFORE INSERT/UPDATE trigger (DB-side
+   per-type validation against `field_definitions`; rejects malformed values + unknown keys even from
+   a direct PostgREST write with the anon key). A trigger (not a CHECK constraint) because a CHECK
+   cannot subquery `field_definitions`.
+
+2. **`proofs/phase5_proofs.sql`** — owner runs in the SQL editor. Returns a results table; every row
+   should read `PASSED…` (per-type accept/reject + unknown-key reject + numeric-cast sort
+   broken-vs-fixed `[10,100,9]` lexicographic vs `[9,10,100]` typed + no-permissive-policy). Runs in
+   a `BEGIN…ROLLBACK`, so it leaves no artifacts.
+
+3. **Client-path proofs** — `inventory/proofs/phase5-custom-fields-proofs.ts` (Claude runs with the
+   ADMIN test user for field-def create/deactivate AND the EDITOR test user for value writes;
+   publishable/anon key, NO service_role). Proves: add one field of each of the 5 types; defs visible
+   to viewer/editor + every item has a custom_fields slot; per-type validation DB-rejected via direct
+   REST as the editor (the zero-trust bypass case); `<script>`/onerror stored verbatim as data;
+   deactivate-preserves-values+history; anon default-deny on all four sensitive tables. Needs ENV:
+   `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `ADMIN_EMAIL/ADMIN_PASSWORD`, `EDITOR_EMAIL/EDITOR_PASSWORD`.
+
+4. **Browser proofs** (numeric sort + XSS-inert render of values AND field names) were run this
+   session in real Chrome via Playwright (see PROGRESS.md "Phase 5 evidence"); the Phase-7 Auditor
+   re-verifies on the live merged site.
+
+Phase 5 gate is **passed** only when proofs 1–3 show observed output (and the anon checks still return
+`[]`). Until then PROGRESS.md keeps Phase 5 as `[~]`.
+
 ## Test users (create AFTER step 1)
 
 Once `phase1.sql` has run, the `handle_new_user` trigger will auto-create a

--- a/inventory/sql/phase5.sql
+++ b/inventory/sql/phase5.sql
@@ -1,0 +1,196 @@
+-- =============================================================================
+-- Inventory — Phase 5: Typed dynamic custom fields (CENTERPIECE)
+-- Source-of-truth migration. Run ONCE in the Supabase SQL editor (owner/postgres),
+-- AFTER inventory/sql/phase1.sql and inventory/sql/phase4.sql, and BEFORE
+-- inventory/sql/proofs/phase5_proofs.sql. Idempotent (create-or-replace /
+-- drop-if-exists / if-not-exists) — safe to re-run.
+--
+-- Governing contract: inventory/spec.md, inventory/CLAUDE.md, inventory/PROGRESS.md.
+--
+-- WHAT THIS ADDS (and ONLY this):
+--   1. A GIN index on items.custom_fields (deferred from Phase 1 per decision #5).
+--   2. A BEFORE INSERT/UPDATE validation TRIGGER on public.items that validates
+--      every custom_fields value against its field_definitions-declared type, so a
+--      malformed write — even one sent straight to PostgREST with the anon key,
+--      bypassing the client — is REJECTED AT THE DATABASE. The DB is the final
+--      authority; app-side validation is convenience only (zero-trust, spec.md).
+--
+-- WHY A TRIGGER, NOT A CHECK CONSTRAINT:
+--   A column CHECK constraint cannot contain a subquery, so it cannot look up the
+--   declared type in another table (public.field_definitions). The valid type is
+--   row-driven by that table, so validation must be a trigger that reads it.
+--
+-- SECURITY — NOTHING IS LOOSENED:
+--   * No new RLS policy. No `USING (true)`. No permissive policy. No GRANT/REVOKE.
+--   * Adding a field_definitions row still requires admin (Phase-1 RLS, unchanged):
+--       field_definitions_insert  WITH CHECK admin
+--       field_definitions_update  USING/CHECK admin   (deactivate = is_active=false)
+--   * Writing custom_fields on an item still requires editor/admin (Phase-1
+--     items_update / items_insert, unchanged). This trigger ADDS type validation
+--     on top; it never grants write access.
+--   * change_log stays immutable; the Phase-1 audit trigger already logs
+--     custom_fields changes (old JSON -> new JSON) as field='custom_fields'.
+--   * The Phase-5 gate's RLS re-check (anon read on all four sensitive tables ->
+--     []) must still pass unchanged after this runs.
+--
+-- VALIDATION FUNCTION — SECURITY DEFINER, search_path='':
+--   Runs as the owner so it can read field_definitions regardless of the writer's
+--   read policy (validation must not depend on the writer's RLS). It ONLY READS
+--   field_definitions (no writes) -> no privilege-escalation surface. Everything
+--   is schema-qualified (public.*) because search_path is empty; pg_catalog
+--   built-ins (jsonb_each, jsonb_typeof, array_length) still resolve implicitly.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. GIN index on items.custom_fields (Phase-1 decision #5: deferred to Phase 5).
+--    jsonb_path_ops: smaller/faster index supporting containment (@>) + key
+--    membership lookups, the shape a future server-side custom-field search uses.
+--    (Phase-5 search/sort itself runs client-side over the loaded rows, the same
+--    as Phase 3; this index is additive infrastructure, not the active mechanism.)
+-- -----------------------------------------------------------------------------
+create index if not exists items_custom_fields_gin
+  on public.items using gin (custom_fields jsonb_path_ops);
+
+-- -----------------------------------------------------------------------------
+-- 2. Validation function: every custom_fields value matches its declared type.
+--    Type rules (jsonb_typeof of the value):
+--      text     -> 'string'
+--      number   -> 'number'
+--      boolean  -> 'boolean'
+--      date     -> 'string' matching YYYY-MM-DD AND a real calendar date
+--      dropdown -> 'string' that is one of field_definitions.options[]
+--    JSON null  -> allowed for any type (means "cleared / unset").
+--    Unknown key (no field_definitions row) -> REJECTED (zero-trust: the client
+--      cannot stuff arbitrary keys via PostgREST).
+--    A key whose definition is INACTIVE is still validated against its type (its
+--      value is preserved historical data; "deactivate" never deletes values).
+-- -----------------------------------------------------------------------------
+create or replace function public.validate_custom_fields()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  k   text;
+  v   jsonb;
+  def record;
+  vt  text;
+  txt text;
+begin
+  -- Only validate when custom_fields is actually being set/changed. On UPDATE,
+  -- if custom_fields is untouched, skip entirely: this is what lets a field be
+  -- deactivated, or its options tightened, WITHOUT blocking ordinary edits of the
+  -- 210 existing items (whose stored values predate the change).
+  if tg_op = 'UPDATE' and new.custom_fields is not distinct from old.custom_fields then
+    return new;
+  end if;
+
+  -- column is NOT NULL DEFAULT '{}'; be defensive anyway.
+  if new.custom_fields is null then
+    new.custom_fields := '{}'::jsonb;
+    return new;
+  end if;
+
+  if jsonb_typeof(new.custom_fields) <> 'object' then
+    raise exception 'custom_fields must be a JSON object (got %)', jsonb_typeof(new.custom_fields)
+      using errcode = '22023';
+  end if;
+
+  for k, v in select key, value from jsonb_each(new.custom_fields) loop
+    select fd.key, fd.label, fd.type, fd.options, fd.is_active
+      into def
+      from public.field_definitions fd
+      where fd.key = k;
+
+    if not found then
+      raise exception 'unknown custom field "%": no field_definitions row exists', k
+        using errcode = '23514';
+    end if;
+
+    vt := jsonb_typeof(v);
+
+    -- JSON null = cleared/unset: allowed for every type.
+    if vt = 'null' then
+      continue;
+    end if;
+
+    if def.type = 'text' then
+      if vt <> 'string' then
+        raise exception 'custom field "%" (text) must be a JSON string (got %)', k, vt
+          using errcode = '23514';
+      end if;
+
+    elsif def.type = 'number' then
+      if vt <> 'number' then
+        raise exception 'custom field "%" (number) must be a JSON number (got %)', k, vt
+          using errcode = '23514';
+      end if;
+
+    elsif def.type = 'boolean' then
+      if vt <> 'boolean' then
+        raise exception 'custom field "%" (boolean) must be a JSON boolean (got %)', k, vt
+          using errcode = '23514';
+      end if;
+
+    elsif def.type = 'date' then
+      if vt <> 'string' then
+        raise exception 'custom field "%" (date) must be a JSON string YYYY-MM-DD (got %)', k, vt
+          using errcode = '23514';
+      end if;
+      txt := v #>> '{}';                         -- scalar text without JSON quotes
+      if txt !~ '^\d{4}-\d{2}-\d{2}$' then
+        raise exception 'custom field "%" (date) must match YYYY-MM-DD (got %)', k, txt
+          using errcode = '23514';
+      end if;
+      begin
+        perform txt::date;                       -- rejects e.g. 2024-13-40
+      exception when others then
+        raise exception 'custom field "%" (date) is not a valid calendar date (got %)', k, txt
+          using errcode = '23514';
+      end;
+
+    elsif def.type = 'dropdown' then
+      if vt <> 'string' then
+        raise exception 'custom field "%" (dropdown) must be a JSON string (got %)', k, vt
+          using errcode = '23514';
+      end if;
+      if def.options is null or array_length(def.options, 1) is null then
+        raise exception 'custom field "%" (dropdown) has no options configured', k
+          using errcode = '23514';
+      end if;
+      txt := v #>> '{}';
+      if not (txt = any (def.options)) then
+        raise exception 'custom field "%" (dropdown) value % is not an allowed option', k, txt
+          using errcode = '23514';
+      end if;
+
+    else
+      -- field_definitions.type already CHECK-constrained to the five; defensive.
+      raise exception 'custom field "%" has unsupported declared type %', k, def.type
+        using errcode = '23514';
+    end if;
+  end loop;
+
+  return new;
+end
+$$;
+
+drop trigger if exists items_validate_custom_fields on public.items;
+create trigger items_validate_custom_fields
+  before insert or update on public.items
+  for each row execute function public.validate_custom_fields();
+
+-- =============================================================================
+-- End Phase 5 schema. Three BEFORE triggers now fire on items UPDATE
+-- (items_validate_custom_fields + items_bump_version + items_set_updated_at);
+-- they read/touch disjoint things (custom_fields validation vs version vs
+-- updated_at) so firing order is irrelevant. The AFTER audit trigger still logs
+-- the 14 business columns incl. custom_fields (old JSON -> new JSON).
+--
+-- Next: run inventory/sql/proofs/phase5_proofs.sql (owner, SQL editor) to prove
+-- per-type validation (accept/reject) + numeric-cast sort (lexicographic vs
+-- typed) + unknown-key reject + no-permissive-policy. Then the client-path proofs
+-- in inventory/proofs/phase5-custom-fields-proofs.ts (admin + editor sessions,
+-- publishable key, NO service_role).
+-- =============================================================================

--- a/inventory/sql/proofs/phase5_proofs.sql
+++ b/inventory/sql/proofs/phase5_proofs.sql
@@ -1,0 +1,196 @@
+-- =============================================================================
+-- Inventory — Phase 5 proofs (SQL editor / privileged owner path)
+-- Run AFTER inventory/sql/phase1.sql, phase4.sql AND phase5.sql, in the Supabase
+-- SQL editor. Runs in ONE transaction that ROLLS BACK -> no artifacts (the
+-- throwaway field_definitions rows + items + change_log rows all vanish).
+--
+-- Proves (privileged/owner path; the DB trigger is the real machinery):
+--   #1  ACCEPT: a valid value of every type (text/number/date/dropdown/boolean)
+--       is accepted into items.custom_fields.
+--   #2  REJECT (per-type, broken-vs-fixed): a malformed value of each type is
+--       REJECTED by the validation trigger (the write raises) — NOT stored.
+--   #3  REJECT unknown key: a custom_fields key with no field_definitions row is
+--       rejected (zero-trust; the client cannot stuff arbitrary keys).
+--   #4  TYPED SORT (the "10 < 9" trap): ordering a number custom field by raw
+--       JSON text is LEXICOGRAPHIC (10, 100, 9 — wrong); ordering by the value
+--       CAST to numeric is correct (9, 10, 100). Proves the casting principle is
+--       authoritative at the DB, not just in the client.
+--   #5  NO PERMISSIVE POLICY snuck in on items or field_definitions
+--       (qual/with_check are role-gated, never `true`).
+--
+-- HOW TO READ: one results table; rows starting "PASSED" are satisfied
+-- assertions. Any "FAILED"/"UNEXPECTED" -> STOP, do not mark the gate passed.
+-- =============================================================================
+
+begin;
+
+create temporary table _p5_results (seq int, step text, result text) on commit drop;
+
+do $$
+declare
+  v_item   bigint;
+  v_a      bigint;
+  v_b      bigint;
+  v_c      bigint;
+  lex      text;
+  num      text;
+begin
+  -- SETUP: one field definition of each of the five types (owner bypasses RLS).
+  insert into public.field_definitions (key, label, type, options, required, is_active) values
+    ('__p5_text__',   'P5 Text',     'text',     null,                       false, true),
+    ('__p5_number__', 'P5 Number',   'number',   null,                       false, true),
+    ('__p5_date__',   'P5 Date',     'date',     null,                       false, true),
+    ('__p5_drop__',   'P5 Dropdown', 'dropdown', array['red','green','blue'], false, true),
+    ('__p5_bool__',   'P5 Boolean',  'boolean',  null,                       false, true);
+
+  insert into public.items (name, status, notes)
+  values ('__phase5_proof_item__', 'In Storage', 'orig')
+  returning id into v_item;
+  insert into _p5_results values (0, 'setup', format('item id=%s + 5 typed field defs created', v_item));
+
+  -- ---- PROOF #1: ACCEPT a valid value of every type --------------------------
+  begin
+    update public.items
+       set custom_fields = jsonb_build_object(
+             '__p5_text__',   'hello',
+             '__p5_number__', 42,
+             '__p5_date__',   '2024-02-29',     -- a real leap day
+             '__p5_drop__',   'green',
+             '__p5_bool__',   true)
+     where id = v_item;
+    insert into _p5_results values (1, '#1 ACCEPT all five valid',
+      'PASSED: text/number/date/dropdown/boolean valid values accepted');
+  exception when others then
+    insert into _p5_results values (1, '#1 ACCEPT all five valid',
+      format('FAILED: valid values were rejected: %s', sqlerrm));
+  end;
+
+  -- ---- PROOF #2: REJECT a malformed value of each type -----------------------
+  -- number must be a JSON number, not a string:
+  begin
+    update public.items set custom_fields = '{"__p5_number__": "not-a-number"}'::jsonb where id = v_item;
+    insert into _p5_results values (2, '#2 REJECT number<-string',
+      'FAILED: a STRING was accepted into a number field (validation missing!)');
+  exception when others then
+    insert into _p5_results values (2, '#2 REJECT number<-string',
+      format('PASSED: rejected (%s)', sqlerrm));
+  end;
+
+  -- boolean must be a JSON boolean, not a string:
+  begin
+    update public.items set custom_fields = '{"__p5_bool__": "yes"}'::jsonb where id = v_item;
+    insert into _p5_results values (3, '#2 REJECT boolean<-string',
+      'FAILED: a STRING was accepted into a boolean field');
+  exception when others then
+    insert into _p5_results values (3, '#2 REJECT boolean<-string',
+      format('PASSED: rejected (%s)', sqlerrm));
+  end;
+
+  -- date must be a real YYYY-MM-DD:
+  begin
+    update public.items set custom_fields = '{"__p5_date__": "2024-13-40"}'::jsonb where id = v_item;
+    insert into _p5_results values (4, '#2 REJECT date<-bad',
+      'FAILED: an impossible date (2024-13-40) was accepted');
+  exception when others then
+    insert into _p5_results values (4, '#2 REJECT date<-bad',
+      format('PASSED: rejected (%s)', sqlerrm));
+  end;
+
+  -- dropdown must be one of the configured options:
+  begin
+    update public.items set custom_fields = '{"__p5_drop__": "purple"}'::jsonb where id = v_item;
+    insert into _p5_results values (5, '#2 REJECT dropdown<-not-an-option',
+      'FAILED: an out-of-list dropdown value was accepted');
+  exception when others then
+    insert into _p5_results values (5, '#2 REJECT dropdown<-not-an-option',
+      format('PASSED: rejected (%s)', sqlerrm));
+  end;
+
+  -- text must be a JSON string, not a number:
+  begin
+    update public.items set custom_fields = '{"__p5_text__": 123}'::jsonb where id = v_item;
+    insert into _p5_results values (6, '#2 REJECT text<-number',
+      'FAILED: a NUMBER was accepted into a text field');
+  exception when others then
+    insert into _p5_results values (6, '#2 REJECT text<-number',
+      format('PASSED: rejected (%s)', sqlerrm));
+  end;
+
+  -- ---- PROOF #3: REJECT an unknown key ---------------------------------------
+  begin
+    update public.items set custom_fields = '{"__p5_unknown__": "x"}'::jsonb where id = v_item;
+    insert into _p5_results values (7, '#3 REJECT unknown key',
+      'FAILED: a key with no field_definitions row was accepted');
+  exception when others then
+    insert into _p5_results values (7, '#3 REJECT unknown key',
+      format('PASSED: rejected (%s)', sqlerrm));
+  end;
+
+  -- confirm the rejected writes left the valid PROOF#1 value intact (no overwrite)
+  if (select custom_fields ->> '__p5_text__' from public.items where id = v_item) = 'hello' then
+    insert into _p5_results values (8, '#2/#3 value intact after rejects',
+      'PASSED: custom_fields still {text:hello,...} — rejected writes changed nothing');
+  else
+    insert into _p5_results values (8, '#2/#3 value intact after rejects',
+      'FAILED: a rejected write leaked through');
+  end if;
+
+  -- ---- PROOF #4: typed sort (10 < 9 trap) ------------------------------------
+  insert into public.items (name, status, custom_fields) values
+    ('__p5_sort_a__', 'In Storage', '{"__p5_number__": 9}'::jsonb)   returning id into v_a;
+  insert into public.items (name, status, custom_fields) values
+    ('__p5_sort_b__', 'In Storage', '{"__p5_number__": 10}'::jsonb)  returning id into v_b;
+  insert into public.items (name, status, custom_fields) values
+    ('__p5_sort_c__', 'In Storage', '{"__p5_number__": 100}'::jsonb) returning id into v_c;
+
+  select string_agg(custom_fields ->> '__p5_number__', ',' order by custom_fields ->> '__p5_number__')
+    into lex
+    from public.items where id in (v_a, v_b, v_c);
+
+  select string_agg(custom_fields ->> '__p5_number__', ',' order by (custom_fields ->> '__p5_number__')::numeric)
+    into num
+    from public.items where id in (v_a, v_b, v_c);
+
+  insert into _p5_results values (9, '#4 LEXICOGRAPHIC (raw ->> text)',
+    format('order by ->>text  = [%s]  (the "10 < 9" bug)', lex));
+  if num = '9,10,100' and lex = '10,100,9' then
+    insert into _p5_results values (10, '#4 TYPED (cast ::numeric)',
+      format('PASSED: order by (->>text)::numeric = [%s]  (correct numeric order)', num));
+  else
+    insert into _p5_results values (10, '#4 TYPED (cast ::numeric)',
+      format('CHECK: typed=[%s] lex=[%s] (expected typed 9,10,100 / lex 10,100,9)', num, lex));
+  end if;
+end
+$$;
+
+-- ---- PROOF #5: no permissive policy on items OR field_definitions -----------
+insert into _p5_results
+select 11,
+       '#5 no permissive policy',
+       case when count(*) = 0
+            then 'PASSED: 0 items/field_definitions policies with USING(true)/WITH CHECK(true)'
+            else format('FAILED: %s permissive policy(ies): %s', count(*), string_agg(policyname, ', '))
+       end
+from pg_policies
+where schemaname = 'public'
+  and tablename in ('items', 'field_definitions')
+  and (coalesce(qual, '') = 'true' or coalesce(with_check, '') = 'true');
+
+select seq, step, result from _p5_results order by seq;
+
+rollback;  -- discards the throwaway field defs + items + change_log rows + tampers
+
+-- Expected result rows (all PASSED, plus the lexicographic demo row):
+--   0   setup                          item id=... + 5 typed field defs created
+--   1   #1 ACCEPT all five valid       PASSED: ... valid values accepted
+--   2   #2 REJECT number<-string       PASSED: rejected (custom field "__p5_number__" (number) must be a JSON number ...)
+--   3   #2 REJECT boolean<-string      PASSED: rejected (...)
+--   4   #2 REJECT date<-bad            PASSED: rejected (...)
+--   5   #2 REJECT dropdown<-not-option PASSED: rejected (...)
+--   6   #2 REJECT text<-number         PASSED: rejected (...)
+--   7   #3 REJECT unknown key          PASSED: rejected (unknown custom field "__p5_unknown__" ...)
+--   8   #2/#3 value intact after rejects  PASSED: custom_fields still {text:hello,...}
+--   9   #4 LEXICOGRAPHIC               order by ->>text  = [10,100,9]  (the bug)
+--   10  #4 TYPED (cast ::numeric)      PASSED: order by (->>text)::numeric = [9,10,100]
+--   11  #5 no permissive policy        PASSED: 0 ... policies with USING(true)/WITH CHECK(true)
+-- =============================================================================


### PR DESCRIPTION
## Why this PR exists

PR #6445 was recorded **merged** (head `5a5ea78`), but `main` was subsequently **rewound to `2477198` (#6672)**, which dropped the Phase 5 squash. Consequence: the live GitHub-Pages inventory site (served from `main`) reverted to **Phase 4** — confirmed by the owner ("the page shows phase 4"). This PR **re-lands the exact gate-passed Phase 5 tree** on top of current `main`.

- Recovered from the durable PR head `5a5ea78` (verified `b4c4812 ⊆ 5a5ea78`, so it includes the earlier markdownlint MD045 fix).
- Touches **only** `inventory/` + the proof workflow — `#6672` doesn't touch `inventory/`, so no conflict; Phase 4 is intact.
- Local re-verify on this commit: **bun unit suite 20 pass / 0 fail**.

⚠️ **Worth a look:** `main` was force-rewound past a *merged* PR even though force-push to `main` is supposed to be blocked by the repo ruleset. The mechanism (bypassed rule? mirror reconciliation? revert-via-reset?) is itself worth understanding so this doesn't recur.

## Feature (unchanged from the merged-then-dropped version)

The three named risks, all addressed:
1. **DB-side type validation** — `sql/phase5.sql` `BEFORE INSERT/UPDATE` trigger `validate_custom_fields()` (a trigger, not a CHECK — a CHECK can't subquery `field_definitions`). Rejects malformed values + unknown keys **at the database**, even via direct PostgREST with the anon key. `SECURITY DEFINER`. **No RLS/GRANT change.**
2. **Typed search & sort** — per-type comparator in the shared `lib/custom-fields.js` (number→numeric `9<10<100`, date→chronological, boolean, text/dropdown), client-side consistent with Phase 3.
3. **XSS-safe render** — field names AND values via `textContent`, never `innerHTML` of raw input, at every render site.

Plus the admin Manage-fields add/deactivate UI (soft-remove via `is_active`; never hard-delete a definition with data).

**Gate evidence** (recorded in `PROGRESS.md`): SQL proof 12/12 PASSED (owner-run); true-editor direct-REST unknown-key rejection (400 post-install); CI run #11 all-PASS; real-browser XSS-inert + numeric/chronological sort; 20/20 unit tests; deactivate-preserves-values+history.

## Three owner-directed PROGRESS.md captures (post-merge)

1. **Phase 7 Auditor brief** — explicit live re-verify **as the TRUE EDITOR** user: (a) editor-role write enforcement end-to-end, documenting the **CI editor-slot-ran-as-admin gap** (GitHub repo secrets are only readable inside an Actions run, so no editor password may live in this public repo; the local true-editor rejection covered it, but automated per-role CI coverage has a documented gap); (b) per-type custom-field **sort correctness** (number numerically, date chronologically) — the most likely subtle-regression site.
2. **Residual Risk Register — required-at-DB deferred**: `required` is a client-side UI nudge only; a DB-trigger `required` would break edits of the 210 pre-existing items that have no value for a newly-added required field. Accepted v1 trade-off for current scale/threat model; revisit on growth/threat change.
3. **Owner-pending Phase-5 proof cleanup**: throwaway items 216/225/226/227/228 + inactive `p5_*` field defs noted as **expected residue** (owner to remove in the SQL editor) so the Auditor doesn't flag them as orphaned data.

## After merge (owner)

- Live re-verify the two items above on your device (after Pages CDN propagation), as the true editor.
- SQL-editor cleanup of the proof residue when ready.
- Build-time test users remain chat/secret-shared → burn in Phase 7.

**Not auto-merged — yours to review and merge.** Not starting Phase 6.

https://claude.ai/code/session_017GpaRnmUo2Nf8iyNbhQtJM

---
_Generated by [Claude Code](https://claude.ai/code/session_017GpaRnmUo2Nf8iyNbhQtJM)_