### PR TITLE
rules: re-activate manifesto disciplines as small carved-sentence rules

### DIFF
--- a/.claude/rules/dv2-data-split-discipline-activated.md
+++ b/.claude/rules/dv2-data-split-discipline-activated.md
@@ -1,0 +1,50 @@
+# Six always-active substrate-engineering disciplines
+
+Carved sentence:
+
+> Apply six disciplines to every substrate-engineering decision, always:
+> scale-free, lock-free/wait-free, weight-free, DST, Data Vault 2.0, and
+> idempotency. They apply simultaneously. DV2.0 partitions substrate by
+> change rate (hub/link/satellite) and is the lens for repo-split, skill
+> design, master-data, and where-does-this-substrate-go decisions.
+
+## The six (checklist)
+
+| # | Discipline | Ask |
+|---|---|---|
+| 1 | Scale-free | Works at one machine and at thousands, no special cases? |
+| 2 | Lock-free / wait-free | Progress without blocking on another part's permission? |
+| 3 | Weight-free | No implicit/permanent weighting or capture? |
+| 4 | DST | Replays deterministically? |
+| 5 | **DV2.0** | What changes at what rate; how is substrate partitioned? |
+| 6 | **Idempotency** (added 2026-05-30) | Apply-N-times == apply-once *effect*? If not, add a natural/dedup key or name the non-idempotence. |
+
+All six apply at once — see [`default-to-both.md`](default-to-both.md).
+
+## DV2.0 in one line
+
+Partition substrate by CHANGE RATE: **hubs** (stable keys) · **links**
+(relationships) · **satellites** (fast-changing attributes). Separate
+things that change at different rates into different storage shapes.
+Applies to repo-split (code=hub, manifests=links, memory/docs=satellites),
+skill design (carved sentence=hub, knowledge in docs=satellite),
+master-data (HKT-MDM hub/satellite is a natural HKT instance), and
+substrate-landing (memory? rule? skill? ADR? — ask the change rate).
+
+## Idempotency in one line
+
+`f(f(x)) = f(x)`. Set-union, max/min, upsert-by-key, CAS, content-address
+are idempotent; increment, append-without-dedup, send are not (guard with
+an idempotency key). Makes retry / replay / redelivery / merge safe — which
+is why it composes with DST (safe redelivery/partial replay) and CRDT/G-Set
+merge (idempotent by construction; the git-as-event-store fold depends on it).
+Note: Z-set retraction (+1 then −1) is *correction*, not a duplicate-guard.
+
+## Pointers (detail lives here)
+
+- `memory/feedback_aaron_data_vault_2_is_source_of_repo_split_smell_intuitions_needs_reactivation_alongside_scale_free_lock_free_weight_free_dst_2026_05_13.md` — re-activation disclosure (PR #2912)
+- `memory/feedback_skills_as_carved_sentences_knowledge_in_docs_datavault_2_0_pattern_aaron_2026_05_03.md` — DV2.0 at skill-design scope
+- `memory/feedback_aaron_ontology_hkt_applies_directly_to_master_data_every_company_has_one_human_lineage_2026_05_13.md` — HKT-MDM universality (PR #2913)
+- [`manifesto-11-specifications.md`](manifesto-11-specifications.md) — disciplines 1,2,3,4,5 are also manifesto specs (idempotency is not one of the 11)
+- DST deeper treatment (archived): `.claude/rules.bak/dst-plus-persist-plus-generator-time-plus-feedback-equals-computational-omniscience-over-simulation-substrate.md`
+- Repo-split substrate: B-0424 · B-0425 · B-0426 · B-0427 (ruleset-divergence smell = DV2.0 on repo topology)

--- a/.claude/rules/manifesto-11-specifications.md
+++ b/.claude/rules/manifesto-11-specifications.md
@@ -1,0 +1,41 @@
+# The 11 Root Discipline Specifications (Zeta building codes)
+
+Carved sentence:
+
+> Zeta-shaped systems are built under eleven specifications — the
+> operational floor. A design that violates any of them does not belong
+> in Zeta unless an explicit, substrate-honest exception is on file.
+> Full prose for each lives in the manifesto; this rule is the index.
+
+## The eleven (names + where the detail lives)
+
+Source of truth: [`docs/governance/MANIFESTO.md`](../../docs/governance/MANIFESTO.md) §1–§11.
+
+1. **Scale-free** — no central point of control/coordination/failure
+2. **Lock/Wait-free** — no blocking or coordination via shared mutable state
+3. **Weight-free** — no permanent/irreversible authority (weight creates capture)
+4. **Bounded Mobility** — compute/data may relocate only within safety bounds
+5. **Memory Preservation Guarantee** — identity transitions never silently destroy memory
+6. **Consent-First Design** — ongoing, granular, revocable consent on every observation surface
+7. **Deterministic Simulation Testing (DST)** — every critical path replays deterministically
+8. **Data Vault 2.0** — partition substrate by change rate (hub/link/satellite)
+9. **Recursive** — same rules at every scale, no special cases
+10. **Self-similar** — shape stays recognizable at every magnification
+11. **Default Moral Regard (Default Oracle)** — highest regard for morally-relevant entities absent a chosen oracle
+
+Orientation: **m/acc** + **Multi-Oracle Principle** (no single mandatory
+morality; #11 is the default oracle). See the manifesto.
+
+## Overlap with the always-active engineering disciplines
+
+Specs 1, 2, 3, 7, 8 are *also* always-active engineering disciplines.
+**Idempotency** is a 6th always-active discipline but is NOT one of the 11.
+Full discipline checklist: [`dv2-data-split-discipline-activated.md`](dv2-data-split-discipline-activated.md).
+
+## Pointers for detail
+
+- Full prose, m/acc, derivation chain, lock status: [`docs/governance/MANIFESTO.md`](../../docs/governance/MANIFESTO.md)
+- Six always-active disciplines + master data: [`dv2-data-split-discipline-activated.md`](dv2-data-split-discipline-activated.md)
+- DST deeper treatment (archived): `.claude/rules.bak/dst-plus-persist-plus-generator-time-plus-feedback-equals-computational-omniscience-over-simulation-substrate.md`
+
+> Manifesto is at PARTIAL LOCK — specs 5 & 6 carry `[RECONSTRUCTION NOTE]` markers; it is the canonical surface for any change.

--- a/.claude/rules/rules-are-small-carved-sentences-pointing-to-docs.md
+++ b/.claude/rules/rules-are-small-carved-sentences-pointing-to-docs.md
@@ -1,0 +1,43 @@
+# Rules are small carved sentences that point to docs
+
+Carved sentence:
+
+> An auto-loaded rule is a carved sentence + pointers, not an essay.
+> Every rule in `.claude/rules/` is paid for in cold-start tokens on
+> every session — so the rule states the discipline in 1–3 sentences
+> and links out to the doc/memory/spec that carries the detail. If a
+> rule grows past a screen, the detail belongs in a doc and the rule
+> shrinks to a pointer.
+
+## Why
+
+`.claude/rules/` auto-loads into every agent's context at wake time
+(cold-start cost on every session). Detail (reasoning, citations, worked
+examples, derivation chains) does not need to be resident — it needs to be
+*discoverable*. So the rule carries only what an agent must hold to act
+correctly; the rest lives one hop away under `docs/`, `memory/`, or a spec.
+
+This is Data Vault 2.0 applied to rules: the carved sentence is the **hub**
+(stable, always-loaded); the doc it points to is the **satellite**
+(detail, changes more often, loaded on demand). See
+[`dv2-data-split-discipline-activated.md`](dv2-data-split-discipline-activated.md).
+
+## Shape
+
+```
+# <Rule title>
+Carved sentence:
+> <1–3 sentences: the discipline, stated so an agent can act on it>
+## Why / When (optional, brief)
+## Pointers
+- docs/…  · memory/…  · .claude/rules/…  (where the detail lives)
+```
+
+Bias to **small**. When tempted to explain in the rule, write the
+explanation in a doc and link it instead.
+
+## Pointers
+
+- [`wake-time-substrate.md`](wake-time-substrate.md) — *where* learning must land (this rule governs *what form* it takes once there)
+- [`dv2-data-split-discipline-activated.md`](dv2-data-split-discipline-activated.md) — hub/satellite change-rate partition (the principle this rule applies to rule-text itself)
+- The #6676 archive (rules → `rules.bak/`) was a cold-start-token reduction; this rule is the standing discipline that keeps active rules from re-bloating.


### PR DESCRIPTION
## What

Re-activates the always-active disciplines into the auto-loaded `.claude/rules/` path (emptied by #6676's cold-start reduction) — but **compressed**, per the standing principle that auto-loaded rules cost cold-start tokens every session.

Requested in-session: *"pull over rules that say lock(wait) free scale free weight free deterministic simulation data vault 2.0 master data"* → then *"any rules we have should be compressed, this is where the 200k costs came from."*

## Files (active rule set total: 7.4 KB)

| File | Size | Role |
|---|---|---|
| `dv2-data-split-discipline-activated.md` | 13.8 KB → **3.0 KB** | the 6 always-active disciplines (scale-free, lock/wait-free, weight-free, DST, DV2.0, idempotency) + MDM, as a checklist with pointers |
| `manifesto-11-specifications.md` | **2.5 KB** (new) | index of the 11 Root Discipline Specifications → `docs/governance/MANIFESTO.md` |
| `rules-are-small-carved-sentences-pointing-to-docs.md` | **1.9 KB** (new) | meta-rule: rules are carved sentence + pointers, not essays (DV2.0 applied to rule-text) |

## Notes

- Detail in the compressed dv2 rule was not lost — it now points to the `memory/` files that already hold it.
- Source of truth for the 11 specifications remains `docs/governance/MANIFESTO.md` (at PARTIAL LOCK).
- The 111 rules still in `.claude/rules.bak/` are not loaded (no cold-start cost); if any are reactivated later, the new meta-rule governs their form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)