### PR TITLE
razor context-startup-loaded surfaces (CLAUDE.md + carved-sentence rule)

### DIFF
--- a/.claude/rules/rules-are-small-carved-sentences-pointing-to-docs.md
+++ b/.claude/rules/rules-are-small-carved-sentences-pointing-to-docs.md
@@ -1,26 +1,37 @@
-# Rules are small carved sentences that point to docs
+# Anything loaded at context startup is a carved sentence that points to docs
 
 Carved sentence:
 
-> An auto-loaded rule is a carved sentence + pointers, not an essay.
-> Every rule in `.claude/rules/` is paid for in cold-start tokens on
-> every session — so the rule states the discipline in 1–3 sentences
-> and links out to the doc/memory/spec that carries the detail. If a
-> rule grows past a screen, the detail belongs in a doc and the rule
-> shrinks to a pointer.
+> Anything auto-loaded at context startup is a carved sentence + pointers,
+> not an essay. Every byte that loads on every wake — rules, `CLAUDE.md`,
+> `MEMORY.md`, agent/skill front-matter, hooks — is paid for in cold-start
+> tokens on every session, by every agent. So a startup-loaded surface
+> states only what an agent must hold to act, in 1–3 sentences, and links
+> out to the doc/memory/spec that carries the detail. If it grows past a
+> screen, the detail belongs in a satellite and the surface shrinks to a
+> pointer.
 
 ## Why
 
-`.claude/rules/` auto-loads into every agent's context at wake time
-(cold-start cost on every session). Detail (reasoning, citations, worked
-examples, derivation chains) does not need to be resident — it needs to be
-*discoverable*. So the rule carries only what an agent must hold to act
-correctly; the rest lives one hop away under `docs/`, `memory/`, or a spec.
+The context-startup set (`.claude/rules/`, `CLAUDE.md`, the `MEMORY.md`
+hub, agent/skill descriptions, hook output) loads into every agent's
+context at wake time — a cold-start cost paid on every session, multiplied
+by every agent in the fleet. Detail (reasoning, citations, worked examples,
+derivation chains, the full recall index) does not need to be resident — it
+needs to be *discoverable*. So the resident surface carries only the
+act-on-it sentence; the rest lives one hop away under `docs/`, `memory/`,
+a satellite index, or a spec.
 
-This is Data Vault 2.0 applied to rules: the carved sentence is the **hub**
-(stable, always-loaded); the doc it points to is the **satellite**
-(detail, changes more often, loaded on demand). See
+This is Data Vault 2.0 applied to the startup surface itself: the carved
+sentence is the **hub** (stable, always-loaded); the doc/index it points to
+is the **satellite** (detail, changes more often, loaded on demand). See
 [`dv2-data-split-discipline-activated.md`](dv2-data-split-discipline-activated.md).
+
+Worked example — `MEMORY.md` (2026-06-04): a 210KB / 399-entry inline log
+became a ~1.5KB hub pointing at `CURRENT-*.md` (fast path),
+`docs/trajectories/*/RESUME.md` (current vectors), and `INDEX.md` (the full
+recall index, loaded on demand). The hub changes only when a *surface*
+changes; facts land in topic files + one `INDEX.md` line, never in the hub.
 
 ## Shape
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,32 +45,16 @@ See [`docs/CONFLICT-RESOLUTION.md`](docs/CONFLICT-RESOLUTION.md). On deadlock, t
 - **Result-over-exception** — errors surface as `Result<_, DbspError>`; no exceptions on hot paths.
 - **Memory fast-path** — read `~/.claude/projects/<slug>/memory/CURRENT-*.md` before raw
   `feedback_*.md` logs; CURRENT files win on conflict with older raw memories.
-- **`references/prior-art/` — explicit-target searches ONLY (curated prior-art surface, NOT our code).**
-  Mirror state of OTHER repos (protobuf, gRPC, Redis, etc.); gitignored; gigabytes; the only
-  folder where a naive plain `grep -r` or `find | xargs grep` from `.` becomes a 2-hour runaway.
-  BUT also the curated prior-art surface for backlog-item research — humans who've solved similar
-  problems, cutting-edge + tried-and-true. Two modes: **explicit-target encouraged**
-  (`rg "pattern" references/prior-art/postgres/` during backlog research; check
-  `docs/PRIOR-ART-LIST.md` + `references/notes/` first); **unconstrained scan needs the right tool**
-  — `rg "pattern" .` is safe-by-default (ripgrep respects gitignore), but plain `grep -r` needs
-  `--exclude-dir=upstreams` (basename, NOT a path) or an explicit allowlist
-  (`memory/ docs/ .claude/ tools/`). Refresh the mirror on demand: `tools/setup/common/sync-prior-art.sh`.
+- **`references/prior-art/` — explicit-target searches ONLY; NOT our code.** Gitignored, gigabytes,
+  mirror of other repos; a naive `grep -r .` is a 2-hour runaway. Explicit-target `rg` encouraged
+  (check `docs/PRIOR-ART-LIST.md` first); unconstrained `grep -r` needs `--exclude-dir=upstreams`.
   Full: `.claude/rules.bak/references-prior-art-not-our-code-search-excludes.md`.
 - **Thoughts free, actions razored** — journal to `memory/` freely; CLAUDE.md additions
-  are razored (cooling-period required, disposition-shaping bar). Full: `memory/feedback_thoughts_free_actions_razored_*`.
-- **Heartbeat-via-commit = externalized idle counter** — the AgencySignature v1 trailer
-  block on every commit + `git log --since="2min ago" origin/main` IS the externalized
-  counter for the N=6 brief-ack threshold in
-  `.claude/rules.bak/holding-without-named-dependency-is-standing-by-failure.md`. Each
-  autonomous-loop tick: if you emit "Quiet."/"Holding."/"Standing by." with NO commit
-  produced in the prior tick window AND no named-dependency named explicitly, that IS
-  the failure mode the rule was carved against. The narrative self-model counter is
-  unreliable (Kira 2026-05-27 caught Otto-CLI emitting 100+ "Quiet." with the counter
-  never firing — the agent cannot count itself). Commits produce durable substrate per
-  `.claude/rules.bak/substrate-or-it-didnt-happen.md`; git log queries produce a persistent
-  counter that survives compaction; the rule's forcing function fires reliably only
-  when externalized. Audit via `bun tools/hygiene/audit-agencysignature-main-tip.ts
-  --since YYYY-MM-DD --max N`. Spec: AgencySignature Convention v1 trailer block
-  (10 fields + `Co-authored-by:`) per
-  `docs/research/2026-04-26-gemini-deep-think-agencysignature-commit-attribution-convention-validation-and-refinement.md`
-  §10.
+  are razored (cooling-period, disposition-shaping bar). Full: `memory/feedback_thoughts_free_actions_razored_*`.
+- **Heartbeat-via-commit = externalized idle counter** — "Quiet."/"Holding." with no commit in the
+  prior tick window AND no named dependency IS the standing-by failure (the narrative self-counter is
+  unreliable; externalize it via `git log --since="2min ago" origin/main`). Every commit carries the
+  AgencySignature v1 trailer (10 fields + `Co-authored-by:`); audit via
+  `bun tools/hygiene/audit-agencysignature-main-tip.ts`.
+  Full: `.claude/rules.bak/holding-without-named-dependency-is-standing-by-failure.md`;
+  spec `docs/research/2026-04-26-gemini-deep-think-agencysignature-commit-attribution-convention-validation-and-refinement.md` §10.


### PR DESCRIPTION
## What

Cold-start-token reduction on the always-loaded context surface, plus the standing discipline that keeps it from re-bloating.

- **carved-sentence rule** (`.claude/rules/rules-are-small-carved-sentences-pointing-to-docs.md`): retitled and scope-widened from `.claude/rules/` only to **anything auto-loaded at context startup** — CLAUDE.md, MEMORY.md, agent/skill front-matter, hooks. Every byte loads on every wake, multiplied by every agent. Added the MEMORY.md hub as a worked example.
- **CLAUDE.md**: razored the Conventions section (`references/prior-art/` 14→4 lines, `Heartbeat-via-commit` 16→7). Every razored convention keeps its `Full:` pointer — detail moved the one hop it already referenced; nothing lost.

## Why

DV2.0 hub/satellite applied to the startup surface itself: the resident text is the hub (carved sentence), detail is the satellite (loaded on demand). Companion change this session: `MEMORY.md` (in `~/.claude/`, not tracked) went 210KB → ~1.5KB hub + `INDEX.md` on-demand recall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)