### PR TITLE
fix(k3s): drop tokenFile on cluster-init server to break first-boot token deadlock

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -141,6 +141,23 @@ jobs:
         # to keep this cheap.
         run: nix flake check --no-build --show-trace
 
+      # Regression test for the k3s --cluster-init token deadlock
+      # (k3s-server.nix). Boots the control-plane k3s module in a QEMU VM
+      # via nixosTest and asserts the Kubernetes API comes all the way up:
+      # k3s.service reaches `active`, --cluster-init GENERATES the cluster
+      # token, the kubeconfig is written, the API answers /readyz, and the
+      # node registers. Pre-fix this would FAIL at wait_for_unit("k3s.service")
+      # because the unit crash-looped on the token-read timeout.
+      #
+      # Runs early (before the ~15-min ISO build) so a broken k3s fails
+      # fast. Hermetic — no internet, so it does NOT assert node Ready /
+      # pods Running (those need the Cilium CNI image); that is an online
+      # cluster-integration lane (B-0831 Slice 2+). ubuntu-24.04 runners
+      # expose /dev/kvm; the nixosTest driver falls back to TCG if absent.
+      - name: NixOS test — k3s control-plane reaches active (token-deadlock regression)
+        working-directory: full-ai-cluster
+        run: nix build .#checks.x86_64-linux.k3s-control-plane-cluster-init -L --print-build-logs
+
       - name: Build installer ISO
         working-directory: full-ai-cluster
         run: nix build .#installer-iso --print-build-logs

--- a/full-ai-cluster/flake.nix
+++ b/full-ai-cluster/flake.nix
@@ -183,6 +183,18 @@
           default = self.packages.${system}.installer-iso;
         };
 
+        # QEMU-backed NixOS VM tests. Gated to x86_64-linux because the
+        # nixosTest driver boots an x86_64 VM (and our cluster nodes are
+        # x86_64). Run one with:
+        #   nix build .#checks.x86_64-linux.k3s-control-plane-cluster-init -L
+        checks = nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
+          # Regression test for the k3s --cluster-init token deadlock:
+          # boots the control-plane k3s module in QEMU and asserts the API
+          # comes all the way up (see nixos/tests/k3s-cluster-init.nix).
+          k3s-control-plane-cluster-init =
+            import ./nixos/tests/k3s-cluster-init.nix { inherit pkgs; };
+        };
+
         devShells.default = pkgs.mkShell {
           name = "zeta-ai-cluster-admin";
           # Nix-managed admin tooling (k8s + age/sops + nix observability).

--- a/full-ai-cluster/nixos/modules/k3s-server.nix
+++ b/full-ai-cluster/nixos/modules/k3s-server.nix
@@ -12,7 +12,28 @@
   services.k3s = {
     enable = true;
     role = "server";
-    tokenFile = lib.mkDefault "/var/lib/rancher/k3s/server/token";
+
+    # Do NOT set `tokenFile` on the --cluster-init founding node.
+    #
+    # k3s treats `--token-file` as "READ the cluster token from this path",
+    # NOT "write it here". On a fresh single-node `--cluster-init` the file
+    # does not exist yet, so k3s sits in
+    #   "Waiting for /var/lib/rancher/k3s/server/token to be available"
+    # and after ~4 min exits with
+    #   fatal "Error: Timeout while trying to read the file"
+    # systemd then restarts it into the same wait — a permanent crash-loop
+    # in which the API server never comes up and /etc/rancher/k3s/k3s.yaml
+    # is never written.
+    #
+    # With no `tokenFile`, `--cluster-init` GENERATES the cluster token and
+    # persists it to /var/lib/rancher/k3s/server/{token,node-token} at that
+    # same default path — which is exactly what workers copy into
+    # /var/lib/rancher/k3s/agent/token to join (see hosts/worker-gpu/README).
+    # So removing this line fixes first-boot without changing the join flow.
+    #
+    # Empirically caught on node-115f93 first-boot install (2026-06-05):
+    # k3s-server crash-looped on the token-read timeout; removing the
+    # explicit tokenFile is the fix.
     clusterInit = lib.mkDefault true;
 
     extraFlags = [

--- a/full-ai-cluster/nixos/tests/k3s-cluster-init.nix
+++ b/full-ai-cluster/nixos/tests/k3s-cluster-init.nix
@@ -1,0 +1,112 @@
+# full-ai-cluster/nixos/tests/k3s-cluster-init.nix
+#
+# NixOS VM integration test: the K3S control-plane (`--cluster-init`
+# founding node) must boot all the way to a working Kubernetes API.
+#
+# This is the regression test for the first-boot token deadlock fixed in
+# `../modules/k3s-server.nix`: that module used to set
+#   tokenFile = "/var/lib/rancher/k3s/server/token"
+# alongside `clusterInit = true`, so k3s sat forever
+#   "Waiting for /var/lib/rancher/k3s/server/token to be available"
+# → "Timeout while trying to read the file" → crash-loop, and the API
+# server / kubeconfig never came up. Empirically caught on node-115f93
+# first-boot install (2026-06-05).
+#
+# `pkgs.nixosTest` boots the actual `k3s-server.nix` module in QEMU and
+# the build SUCCEEDS only if every assertion in `testScript` passes. The
+# single line `server.wait_for_unit("k3s.service")` is the precise inverse
+# of the bug — pre-fix it would time out (unit never reaches "active");
+# post-fix it reaches active because `--cluster-init` generates the token.
+#
+# OFFLINE SANDBOX SCOPE
+# ---------------------
+# nixosTest VMs run inside the Nix build sandbox with no internet, so the
+# bootstrap manifests (Cilium / cert-manager / Vault / ArgoCD) cannot pull
+# their images. We therefore:
+#   - override `services.k3s.manifests = {}` so no image-pull auto-deploy
+#     is attempted, and
+#   - assert everything the deadlock actually broke, all of which is
+#     local-only: k3s.service active, the cluster token GENERATED, the
+#     kubeconfig written, the API server healthy (/readyz), and the node
+#     object registering with the API.
+#
+# We deliberately do NOT assert the node reaches `Ready` or that pods are
+# `Running` — both require the Cilium CNI image, which needs internet.
+# That belongs in an online cluster-integration lane (B-0831 Slice 2+),
+# not this hermetic regression test.
+#
+# Run:
+#   cd full-ai-cluster
+#   nix build .#checks.x86_64-linux.k3s-control-plane-cluster-init -L
+#
+# Per .claude/rules/automated-tests-are-the-shield-assert-dont-skip.md:
+# the assertions exercise the real failure surface; the test fails (does
+# not skip) if k3s does not reach a working API.
+
+{ pkgs }:
+
+pkgs.nixosTest {
+  name = "k3s-control-plane-cluster-init";
+
+  nodes.server = { config, pkgs, lib, ... }: {
+    # Test the REAL control-plane k3s module (the file the fix touched).
+    imports = [ ../modules/k3s-server.nix ];
+
+    # Hermetic sandbox: drop the internet-dependent bootstrap manifests so
+    # the deploy controller does not thrash trying to pull Cilium/Vault/etc.
+    # k3s.service reaching `active` does not depend on these — they apply
+    # asynchronously after the API is up — but removing them keeps the test
+    # fast and the logs clean.
+    services.k3s.manifests = lib.mkForce { };
+
+    # k3s + embedded etcd want headroom; give the VM enough to come up.
+    virtualisation.memorySize = 2560; # MB
+    virtualisation.cores = 2;
+    virtualisation.diskSize = 6144; # MB — data dir + container images
+  };
+
+  testScript = ''
+    start_all()
+
+    # ── REGRESSION GATE ────────────────────────────────────────────────
+    # With the tokenFile↔cluster-init deadlock this unit NEVER reaches
+    # "active" (perpetual auto-restart on the token-read timeout). This is
+    # the single most important line in the test.
+    server.wait_for_unit("k3s.service", timeout=300)
+
+    # ── --cluster-init must GENERATE the cluster token ──────────────────
+    # The deadlock was precisely k3s waiting to READ this file instead of
+    # writing it. Post-fix, cluster-init generates it at the default path
+    # (which is what workers copy into /var/lib/rancher/k3s/agent/token).
+    server.wait_for_file("/var/lib/rancher/k3s/server/token", timeout=120)
+    server.succeed("test -s /var/lib/rancher/k3s/server/token")
+    server.succeed("test -s /var/lib/rancher/k3s/server/node-token")
+
+    # ── API server up + kubeconfig written ──────────────────────────────
+    # The buggy node never reached this stage (no /etc/rancher/k3s/k3s.yaml,
+    # kubectl fell back to localhost:8080 refused).
+    server.wait_for_file("/etc/rancher/k3s/k3s.yaml", timeout=120)
+    server.wait_until_succeeds(
+        "KUBECONFIG=/etc/rancher/k3s/k3s.yaml k3s kubectl get --raw='/readyz'",
+        timeout=180,
+    )
+
+    # ── Node object registers with the API ──────────────────────────────
+    # (Node stays NotReady offline because Cilium CNI cannot be pulled in
+    # the sandbox — that is expected; we assert registration, not Ready.)
+    server.wait_until_succeeds(
+        "KUBECONFIG=/etc/rancher/k3s/k3s.yaml k3s kubectl get nodes",
+        timeout=120,
+    )
+    server.succeed(
+        "KUBECONFIG=/etc/rancher/k3s/k3s.yaml k3s kubectl get nodes "
+        "-o jsonpath='{.items[0].metadata.name}' | grep -q server"
+    )
+
+    # Surface a bit of state into the build log for post-mortem.
+    print(server.succeed("systemctl --no-pager status k3s.service | head -n 5 || true"))
+    print(server.succeed(
+        "KUBECONFIG=/etc/rancher/k3s/k3s.yaml k3s kubectl get nodes -o wide || true"
+    ))
+  '';
+}

--- a/full-ai-cluster/nixos/tests/k3s-cluster-init.nix
+++ b/full-ai-cluster/nixos/tests/k3s-cluster-init.nix
@@ -45,7 +45,10 @@
 
 { pkgs }:
 
-pkgs.nixosTest {
+# nixpkgs 25.11 removed the top-level `pkgs.nixosTest` alias (throw added
+# 2025-10-27); the entry point is `pkgs.testers.nixosTest` — same
+# { name; nodes; testScript; } signature.
+pkgs.testers.nixosTest {
   name = "k3s-control-plane-cluster-init";
 
   nodes.server = { config, pkgs, lib, ... }: {


### PR DESCRIPTION
## Problem

Fresh single-node cluster installs crash-loop at first boot — Kubernetes never comes up. Empirically caught flashing + booting `node-115f93` (2026-06-05).

`k3s-server.nix` sets both:

```nix
tokenFile  = lib.mkDefault "/var/lib/rancher/k3s/server/token";
clusterInit = lib.mkDefault true;
```

k3s treats `--token-file` as **READ the token from this path**, not write it. On a fresh `--cluster-init` the file doesn't exist yet, so the server waits for a token it is itself supposed to generate:

```
k3s[…]: Waiting for /var/lib/rancher/k3s/server/token to be available
k3s[…]: fatal  Error: Timeout while trying to read the file      # ~4 min later
k3s.service: Failed with result 'exit-code'
k3s.service: Scheduled restart job, restart counter is at 2      # loops forever
```

Consequences: the API server never starts, `/etc/rancher/k3s/k3s.yaml` is never written, and `kubectl` falls back to `localhost:8080` (refused).

## Fix

Drop `tokenFile` on the cluster-init founding node. With no `--token-file`, `--cluster-init` **generates** the cluster token and persists it to the same default path `/var/lib/rancher/k3s/server/{token,node-token}`.

- First-boot deadlock is gone.
- Worker-join flow is **unchanged** — workers still copy the control-plane token into `/var/lib/rancher/k3s/agent/token` (per `hosts/worker-gpu/README`); that path is still populated, just generated instead of read-waited.
- Reboots are fine — the now-existing token is read normally.

One-line removal + an explanatory comment so this doesn't get re-added.

## Verification

- `build-ai-cluster-iso` CI (`nix flake check` + ISO build + QEMU full-install test) exercises a real cluster-init boot.
- Manual repro on `node-115f93`: `k3s.service` `activating` → token-read timeout → restart loop, no kubeconfig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
