### PR TITLE
perf(fsharp): remove sync waits and quadratic builders

### DIFF
--- a/src/Core/SchemaRegistry.fs
+++ b/src/Core/SchemaRegistry.fs
@@ -95,7 +95,8 @@ module SchemaRegistry =
             match getI "from", getI "to", Map.tryFind "ops" m with
             | Some f, Some t, Some (DynamicValue.Array ops) ->
                 ops
-                |> List.fold (fun acc o -> acc |> Result.bind (fun xs -> opOfDynamic o |> Result.map (fun x -> xs @ [ x ]))) (Ok [])
+                |> List.fold (fun acc o -> acc |> Result.bind (fun xs -> opOfDynamic o |> Result.map (fun x -> x :: xs))) (Ok [])
+                |> Result.map List.rev
                 |> Result.map (fun parsed -> { From = f; To = t; Ops = parsed })
             | _ -> Error "malformed migration"
         | _ -> Error "migration must be an object"
@@ -112,7 +113,8 @@ module SchemaRegistry =
                         match v with
                         | DynamicValue.Array migs ->
                             migs
-                            |> List.fold (fun a m -> a |> Result.bind (fun xs -> migOfDynamic m |> Result.map (fun x -> xs @ [ x ]))) (Ok [])
+                            |> List.fold (fun a m -> a |> Result.bind (fun xs -> migOfDynamic m |> Result.map (fun x -> x :: xs))) (Ok [])
+                            |> Result.map List.rev
                             |> Result.map (fun parsed -> { Schemas = Map.add id parsed reg.Schemas })
                         | _ -> Error(sprintf "schema '%s' must map to an array of migrations" id)))
                 (Ok empty)

--- a/src/Core/SoftValue.fs
+++ b/src/Core/SoftValue.fs
@@ -1,5 +1,7 @@
 namespace Zeta.Core
 
+open System.Collections.Generic
+
 /// **SoftValue — the value-axis "soft" DynamicValue seed (calibrated / probabilistic).**
 ///
 /// A normalized distribution over candidate `DynamicValue`s. The safety property is NOT
@@ -31,20 +33,27 @@ module SoftValue =
     /// Merge equal candidates (first-seen order), drop non-positive weights, normalize.
     /// `None` if nothing positive remains (empty or total ≈ 0) — no fabricated certainty.
     let private build (xs: (DynamicValue * float) list) : SoftValue option =
-        let merged =
-            xs
-            |> List.fold
-                (fun acc (d, w) ->
-                    if w <= 0.0 then
-                        acc
-                    else
-                        match acc |> List.tryFindIndex (fun (d2, _) -> d2 = d) with
-                        | Some i -> acc |> List.mapi (fun j (d2, w2) -> if j = i then (d2, w2 + w) else (d2, w2))
-                        | None -> acc @ [ d, w ])
-                []
-        let total = merged |> List.sumBy snd
-        if List.isEmpty merged || total <= EPS then None
-        else Some { Candidates = merged |> List.map (fun (d, w) -> d, w / total) }
+        let positions = Dictionary<DynamicValue, int>()
+        let merged = ResizeArray<DynamicValue * float>()
+        let mutable total = 0.0
+
+        for d, w in xs do
+            if w > 0.0 then
+                total <- total + w
+                match positions.TryGetValue d with
+                | true, i ->
+                    let existing, existingWeight = merged.[i]
+                    merged.[i] <- existing, existingWeight + w
+                | false, _ ->
+                    positions.Add(d, merged.Count)
+                    merged.Add(d, w)
+
+        if merged.Count = 0 || total <= EPS then None
+        else
+            Some
+                { Candidates =
+                    [ for d, w in merged do
+                          d, w / total ] }
 
     /// A point mass — fully certain at `dv` (confidence 1).
     let certain (dv: DynamicValue) : SoftValue = { Candidates = [ dv, 1.0 ] }

--- a/src/Core/SpineAsync.fs
+++ b/src/Core/SpineAsync.fs
@@ -30,22 +30,20 @@ type SpineAsync<'K when 'K : comparison>() =
     let cts = new CancellationTokenSource()
 
     let worker : Task =
-        Task.Run(fun () ->
-            let reader = inbox.Reader
-            try
-                let mutable item = Unchecked.defaultof<ZSet<'K>>
-                while not cts.IsCancellationRequested do
-                    // Block synchronously on the channel reader using
-                    // `WaitToReadAsync` awaited via `.GetAwaiter().GetResult()`.
-                    // Acceptable because the worker task has no other work.
-                    let ready =
-                        try reader.WaitToReadAsync(cts.Token).AsTask().Result
-                        with :? AggregateException -> false
-                    if ready then
-                        while reader.TryRead &item do
-                            lock spineLock (fun () -> spine.Insert item)
-                            Interlocked.Increment &processed |> ignore
-            with :? OperationCanceledException -> ())
+        Task.Run(Func<Task>(fun () ->
+            task {
+                let reader = inbox.Reader
+                try
+                    let mutable item = Unchecked.defaultof<ZSet<'K>>
+                    while not cts.IsCancellationRequested do
+                        let! ready = reader.WaitToReadAsync(cts.Token).AsTask()
+                        if ready then
+                            while reader.TryRead &item do
+                                lock spineLock (fun () -> spine.Insert item)
+                                Interlocked.Increment &processed |> ignore
+                with :? OperationCanceledException ->
+                    ()
+            }))
 
     /// Enqueue a batch for background merging. TryWrite MUST precede the
     /// `sent` increment — otherwise `Flush()` can observe `sent = N+1`

--- a/src/Core/Watermark.fs
+++ b/src/Core/Watermark.fs
@@ -2,6 +2,7 @@ namespace Zeta.Core
 
 open System
 open System.Runtime.CompilerServices
+open System.Threading
 
 
 /// Event-time watermark — a monotone lower-bound on "no event with
@@ -65,34 +66,41 @@ type WatermarkStrategy =
 type WatermarkTracker(strategy: WatermarkStrategy) =
     let mutable maxSeen = Int64.MinValue
     let mutable lastEmitted = Int64.MinValue
-    let lockObj = obj ()
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let candidateFor (observedMax: int64) : int64 =
+        match strategy with
+        | WatermarkStrategy.Monotonic -> observedMax
+        | WatermarkStrategy.BoundedLateness lateness ->
+            let latenessMs = int64 lateness.TotalMilliseconds
+            // Saturating subtraction: observedMax near Int64.MinValue would underflow + wrap to a
+            // large positive, breaking watermark monotonicity (Lior audit 2026-06-06). latenessMs >= 0.
+            if observedMax <= Int64.MinValue + latenessMs then Int64.MinValue
+            else observedMax - latenessMs
+        | WatermarkStrategy.Periodic (_interval, lateness) ->
+            let latenessMs = int64 lateness.TotalMilliseconds
+            // Saturating subtraction: observedMax near Int64.MinValue would underflow + wrap to a
+            // large positive, breaking watermark monotonicity (Lior audit 2026-06-06). latenessMs >= 0.
+            if observedMax <= Int64.MinValue + latenessMs then Int64.MinValue
+            else observedMax - latenessMs
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let rec publishMax (cell: byref<int64>) (value: int64) : int64 =
+        let current = Volatile.Read &cell
+        if value <= current then
+            current
+        else
+            let prior = Interlocked.CompareExchange(&cell, value, current)
+            if prior = current then value else publishMax &cell value
 
     /// Observe a new event timestamp. Returns the new watermark (may be
     /// unchanged from the previous value).
     member _.Observe(eventTime: int64) : int64 =
-        lock lockObj (fun () ->
-            if eventTime > maxSeen then maxSeen <- eventTime
-            let candidate =
-                match strategy with
-                | WatermarkStrategy.Monotonic -> maxSeen
-                | WatermarkStrategy.BoundedLateness lateness ->
-                    let latenessMs = int64 lateness.TotalMilliseconds
-                    // Saturating subtraction: maxSeen near Int64.MinValue would underflow + wrap to a
-                    // large positive, breaking watermark monotonicity (Lior audit 2026-06-06). latenessMs ≥ 0.
-                    if maxSeen <= Int64.MinValue + latenessMs then Int64.MinValue
-                    else maxSeen - latenessMs
-                | WatermarkStrategy.Periodic (_interval, lateness) ->
-                    let latenessMs = int64 lateness.TotalMilliseconds
-                    // Saturating subtraction: maxSeen near Int64.MinValue would underflow + wrap to a
-                    // large positive, breaking watermark monotonicity (Lior audit 2026-06-06). latenessMs ≥ 0.
-                    if maxSeen <= Int64.MinValue + latenessMs then Int64.MinValue
-                    else maxSeen - latenessMs
-            // Watermarks must be monotone non-decreasing.
-            if candidate > lastEmitted then lastEmitted <- candidate
-            lastEmitted)
+        let observedMax = publishMax &maxSeen eventTime
+        publishMax &lastEmitted (candidateFor observedMax)
 
-    member _.Current = lock lockObj (fun () -> lastEmitted)
-    member _.MaxObserved = lock lockObj (fun () -> maxSeen)
+    member _.Current = Volatile.Read &lastEmitted
+    member _.MaxObserved = Volatile.Read &maxSeen
 
 
 /// Predicate: is `eventTime` late according to the current watermark?


### PR DESCRIPTION
## Summary
- remove sync-over-async from `SpineAsync` by awaiting `WaitToReadAsync` in the background worker instead of blocking on `.Result`
- make `SoftValue` candidate merging linear-time while preserving first-seen ordering
- decode schema-registry arrays with cons + reverse instead of repeated list append
- replace `WatermarkTracker`'s monitor lock with monotone `Interlocked.CompareExchange` publish loops and volatile reads

## Audit Notes
- I did not add fake async wrappers around currently synchronous storage APIs. `DiskBackingStore` is sync by interface; a real async improvement should be an additive `IAsyncBackingStore` / async-backed spine design rather than `Task.Run` around synchronous file I/O.
- Remaining source locks are concentrated around intentionally serialized state or deterministic/test harness code; this PR removes the lock that contradicted `WatermarkTracker`'s atomic-publication intent.

## Validation
- `dotnet build -c Release` — passed, 0 warnings / 0 errors
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release` — passed, 1706 passed / 1 skipped
- `dotnet test Zeta.sln -c Release` — passed, 2073 passed / 1 skipped
- `git diff --check` — passed
- `dotnet format --verify-no-changes --include src/Core/SchemaRegistry.fs src/Core/SoftValue.fs src/Core/SpineAsync.fs src/Core/Watermark.fs` — passed
- `dotnet format --verify-no-changes` — failed on pre-existing unrelated C# formatting/analyzer drift in `src/Core.CSharp.*` and `tests/Tests.CSharp/*`; untouched by this PR
