### PR TITLE
feat(Core): add result-returning FerryThrottler arity

### DIFF
--- a/openspec/specs/lsm-spine-family/profiles/fsharp.md
+++ b/openspec/specs/lsm-spine-family/profiles/fsharp.md
@@ -117,10 +117,10 @@ F# today. Prose bullets, no RFC-2119 keywords; those live in the base
   a `sent` counter. The hot path is allocation-free for the batch (the
   `ZSet<'K>` is passed by value as a readonly struct) and cost is bounded
   by the channel-write itself — depth-independent, as the spec requires.
-- The worker loop drains the channel synchronously via
-  `WaitToReadAsync(...).AsTask().Result`; inside the loop it takes
-  `spineLock`, invokes `spine.Insert(batch)`, and increments a `processed`
-  counter.
+- The worker loop awaits `WaitToReadAsync(...).AsTask()` in its background
+  worker; inside the loop it takes `spineLock`, invokes
+  `spine.Insert(batch)`, and increments a `processed` counter. It does not
+  block synchronously on the channel wait.
 - `Flush()` captures `target = sent` at entry and polls
   `processed >= target` with a `Task.Yield` in the wait loop. This gives
   the spec's linearisation-point semantics — a `Consolidate` immediately

--- a/src/Core/FerryThrottler.fs
+++ b/src/Core/FerryThrottler.fs
@@ -321,6 +321,13 @@ type FerryThrottler<'TItem, 'TResult>
             for i in 0 .. count - 1 do
                 requests.[i].TrySetResult results.[i]
 
+    let trySize (req: FerryRequest<'TItem, 'TResult>) =
+        try
+            Ok(sizeOf req.Item)
+        with ex ->
+            req.TrySetException ex
+            Error()
+
     let runFerry () : Task =
         backgroundTask {
             let reader = inbox.Reader
@@ -344,26 +351,31 @@ type FerryThrottler<'TItem, 'TResult>
                             req.Dispose()
                             pending <- ValueNone
                         | ValueSome req ->
-                            items.[0] <- req.Item
-                            requests.[0] <- req
-                            n <- 1
-                            bytes <- sizeOf req.Item
+                            match trySize req with
+                            | Ok sz ->
+                                items.[0] <- req.Item
+                                requests.[0] <- req
+                                n <- 1
+                                bytes <- sz
+                            | Error() -> req.Dispose()
                             pending <- ValueNone
                         | ValueNone -> ()
                         let mutable draining = true
                         while draining && n < config.MaxBatchSize do
                             match tryTakeActive reader with
                             | ValueSome req ->
-                                let sz = sizeOf req.Item
-                                match byteBudget with
-                                | Some cap when n > 0 && bytes + sz > cap ->
-                                    pending <- ValueSome req
-                                    draining <- false
-                                | _ ->
-                                    items.[n] <- req.Item
-                                    requests.[n] <- req
-                                    n <- n + 1
-                                    bytes <- bytes + sz
+                                match trySize req with
+                                | Ok sz ->
+                                    match byteBudget with
+                                    | Some cap when n > 0 && bytes + sz > cap ->
+                                        pending <- ValueSome req
+                                        draining <- false
+                                    | _ ->
+                                        items.[n] <- req.Item
+                                        requests.[n] <- req
+                                        n <- n + 1
+                                        bytes <- bytes + sz
+                                | Error() -> req.Dispose()
                             | ValueNone -> draining <- false
                         if n > 0 then
                             try

--- a/src/Core/FerryThrottler.fs
+++ b/src/Core/FerryThrottler.fs
@@ -6,6 +6,31 @@ open System.Threading.Channels
 open System.Threading.Tasks
 
 
+type private FerryRequest<'TItem, 'TResult>
+    (item: 'TItem,
+     completion: TaskCompletionSource<'TResult>,
+     cancellationRegistration: CancellationTokenRegistration) =
+
+    member _.Item = item
+    member _.Completion = completion
+    member _.IsCanceled = completion.Task.IsCanceled
+
+    member _.TrySetResult(result: 'TResult) =
+        completion.TrySetResult result |> ignore
+        cancellationRegistration.Dispose()
+
+    member _.TrySetException(ex: exn) =
+        completion.TrySetException ex |> ignore
+        cancellationRegistration.Dispose()
+
+    member _.TrySetCanceled(cancellationToken: CancellationToken) =
+        completion.TrySetCanceled cancellationToken |> ignore
+        cancellationRegistration.Dispose()
+
+    member _.Dispose() =
+        cancellationRegistration.Dispose()
+
+
 /// Configuration for a `FerryThrottler`.
 ///
 /// The defaults are the *deterministic* defaults: one ferry. A throttler
@@ -127,7 +152,7 @@ type FerryThrottler<'TItem>
             // One-item pushback: an item read but deferred to the NEXT boat because
             // it would have pushed the current boat over its byte budget. Keeps the
             // budget strict without needing a peek the channel doesn't offer.
-            let mutable pending = ValueNone
+            let mutable pending: 'TItem voption = ValueNone
             try
                 let mutable running = true
                 while running do
@@ -189,6 +214,203 @@ type FerryThrottler<'TItem>
 
     /// Signal that no more items will be enqueued, then await every ferry
     /// draining the queue to completion. After this the throttler is finished.
+    member _.CompleteAsync() : Task =
+        inbox.Writer.TryComplete() |> ignore
+        Task.WhenAll ferryTasks
+
+    interface IDisposable with
+        member _.Dispose() =
+            inbox.Writer.TryComplete() |> ignore
+            cts.Cancel()
+            try Task.WaitAll(ferryTasks, 500) |> ignore with _ -> ()
+            cts.Dispose()
+
+
+/// Request/response FerryThrottler arity. Producers submit one item and receive
+/// that item's `Task<'TResult>`; the ferry still processes boats in batches and
+/// fans aligned results back to the individual callers.
+///
+/// At `MaxDegreeOfParallelism = 1`, completion order is deterministic for
+/// non-cancelled items because one ferry drains boats in FIFO order. With
+/// multiple ferries, every item still receives exactly one result/fault/cancel,
+/// but cross-ferry completion order is intentionally not specified.
+[<Sealed>]
+type FerryThrottler<'TItem, 'TResult>
+    (config: FerryThrottlerConfig,
+     processBatch: ReadOnlyMemory<'TItem> -> CancellationToken -> Task<'TResult array>,
+     ?itemSizeBytes: 'TItem -> int) =
+
+    do
+        if config.MaxDegreeOfParallelism < 1 then
+            invalidArg (nameof config) "MaxDegreeOfParallelism must be >= 1"
+        if config.MaxBatchSize < 1 then
+            invalidArg (nameof config) "MaxBatchSize must be >= 1"
+        match config.MaxQueueSize with
+        | Some n when n < 1 -> invalidArg (nameof config) "MaxQueueSize, if set, must be >= 1"
+        | _ -> ()
+        match config.MaxBatchBytes with
+        | Some b when b < 1 -> invalidArg (nameof config) "MaxBatchBytes, if set, must be >= 1"
+        | Some _ when itemSizeBytes.IsNone ->
+            invalidArg (nameof itemSizeBytes) "itemSizeBytes is required when MaxBatchBytes is set"
+        | _ -> ()
+
+    let sizeOf = defaultArg itemSizeBytes (fun _ -> 0)
+    let ferries = config.MaxDegreeOfParallelism
+
+    let inbox : Channel<FerryRequest<'TItem, 'TResult>> =
+        match config.MaxQueueSize with
+        | Some cap ->
+            Channel.CreateBounded<FerryRequest<'TItem, 'TResult>>(
+                BoundedChannelOptions(cap,
+                    SingleReader = (ferries = 1),
+                    SingleWriter = false,
+                    FullMode = BoundedChannelFullMode.Wait))
+        | None ->
+            Channel.CreateUnbounded<FerryRequest<'TItem, 'TResult>>(
+                UnboundedChannelOptions(SingleReader = (ferries = 1), SingleWriter = false))
+
+    let cts = new CancellationTokenSource()
+    let byteBudget = config.MaxBatchBytes
+
+    let rec tryTakeActive (reader: ChannelReader<FerryRequest<'TItem, 'TResult>>) =
+        match reader.TryRead() with
+        | true, req when req.IsCanceled ->
+            req.Dispose()
+            tryTakeActive reader
+        | true, req -> ValueSome req
+        | false, _ -> ValueNone
+
+    let faultBoat (requests: FerryRequest<'TItem, 'TResult> array) (count: int) (ex: exn) =
+        for i in 0 .. count - 1 do
+            requests.[i].TrySetException ex
+
+    let cancelBoat
+        (requests: FerryRequest<'TItem, 'TResult> array)
+        (count: int)
+        (cancellationToken: CancellationToken)
+        =
+        for i in 0 .. count - 1 do
+            requests.[i].TrySetCanceled cancellationToken
+
+    let cancelRemaining
+        (reader: ChannelReader<FerryRequest<'TItem, 'TResult>>)
+        (pending: FerryRequest<'TItem, 'TResult> voption)
+        (cancellationToken: CancellationToken)
+        =
+        match pending with
+        | ValueSome req -> req.TrySetCanceled cancellationToken
+        | ValueNone -> ()
+
+        let mutable draining = true
+        while draining do
+            match reader.TryRead() with
+            | true, req -> req.TrySetCanceled cancellationToken
+            | false, _ -> draining <- false
+
+    let completeBoat
+        (requests: FerryRequest<'TItem, 'TResult> array)
+        (count: int)
+        (results: 'TResult array)
+        =
+        if results.Length <> count then
+            let ex =
+                InvalidOperationException(
+                    $"FerryThrottler result count mismatch: processor returned {results.Length} results for {count} items.")
+            faultBoat requests count ex
+        else
+            for i in 0 .. count - 1 do
+                requests.[i].TrySetResult results.[i]
+
+    let runFerry () : Task =
+        backgroundTask {
+            let reader = inbox.Reader
+            let items = Array.zeroCreate<'TItem> config.MaxBatchSize
+            let requests = Array.zeroCreate<FerryRequest<'TItem, 'TResult>> config.MaxBatchSize
+            let ct = cts.Token
+            let mutable pending: FerryRequest<'TItem, 'TResult> voption = ValueNone
+            try
+                let mutable running = true
+                while running do
+                    let mutable haveWork = pending.IsSome
+                    if not haveWork then
+                        let! more = reader.WaitToReadAsync ct
+                        haveWork <- more
+                        if not more then running <- false
+                    if haveWork then
+                        let mutable n = 0
+                        let mutable bytes = 0
+                        match pending with
+                        | ValueSome req when req.IsCanceled ->
+                            req.Dispose()
+                            pending <- ValueNone
+                        | ValueSome req ->
+                            items.[0] <- req.Item
+                            requests.[0] <- req
+                            n <- 1
+                            bytes <- sizeOf req.Item
+                            pending <- ValueNone
+                        | ValueNone -> ()
+                        let mutable draining = true
+                        while draining && n < config.MaxBatchSize do
+                            match tryTakeActive reader with
+                            | ValueSome req ->
+                                let sz = sizeOf req.Item
+                                match byteBudget with
+                                | Some cap when n > 0 && bytes + sz > cap ->
+                                    pending <- ValueSome req
+                                    draining <- false
+                                | _ ->
+                                    items.[n] <- req.Item
+                                    requests.[n] <- req
+                                    n <- n + 1
+                                    bytes <- bytes + sz
+                            | ValueNone -> draining <- false
+                        if n > 0 then
+                            try
+                                let! results = processBatch (ReadOnlyMemory(items, 0, n)) ct
+                                completeBoat requests n results
+                            with
+                            | :? OperationCanceledException when ct.IsCancellationRequested ->
+                                cancelBoat requests n ct
+                            | ex ->
+                                faultBoat requests n ex
+                            Array.Clear(items, 0, n)
+                            Array.Clear(requests, 0, n)
+            with :? OperationCanceledException ->
+                cancelRemaining reader pending ct
+        }
+
+    let ferryTasks : Task array =
+        Array.init ferries (fun _ -> runFerry ())
+
+    member _.ProcessAsync(item: 'TItem, ?cancellationToken: CancellationToken) : Task<'TResult> =
+        let ct = defaultArg cancellationToken CancellationToken.None
+        let completion =
+            TaskCompletionSource<'TResult>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+        if ct.IsCancellationRequested then
+            completion.TrySetCanceled ct |> ignore
+            completion.Task
+        else
+            let registration =
+                if ct.CanBeCanceled then
+                    ct.Register(fun () -> completion.TrySetCanceled ct |> ignore)
+                else
+                    Unchecked.defaultof<CancellationTokenRegistration>
+            let request = FerryRequest(item, completion, registration)
+            task {
+                try
+                    do! inbox.Writer.WriteAsync(request, ct).AsTask()
+                    return! completion.Task
+                with
+                | :? OperationCanceledException when ct.IsCancellationRequested ->
+                    request.TrySetCanceled ct
+                    return! completion.Task
+                | ex ->
+                    request.TrySetException ex
+                    return! completion.Task
+            }
+
     member _.CompleteAsync() : Task =
         inbox.Writer.TryComplete() |> ignore
         Task.WhenAll ferryTasks

--- a/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
+++ b/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
@@ -151,3 +151,121 @@ let ``invalid configuration is rejected at construction`` () =
     |> should throw typeof<ArgumentException>
     (fun () -> new FerryThrottler<int>({ FerryThrottlerConfig.deterministic with MaxBatchSize = 0 }, noop) |> ignore)
     |> should throw typeof<ArgumentException>
+
+
+[<Fact>]
+let ``result arity returns one aligned result per item`` () =
+    let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
+        task {
+            return
+                [| for i in 0 .. boat.Length - 1 do
+                       boat.Span.[i] * 10 |]
+        }
+    use throttler = new FerryThrottler<int, int>(FerryThrottlerConfig.deterministic, processBatch)
+    let tasks =
+        [ 1 .. 20 ]
+        |> List.map (fun x -> throttler.ProcessAsync x)
+        |> Array.ofList
+    Task.WaitAll(tasks |> Array.map (fun t -> t :> Task))
+    throttler.CompleteAsync().Wait()
+    tasks |> Array.map (fun t -> t.Result) |> should equal [| for x in 1 .. 20 -> x * 10 |]
+
+
+[<Fact>]
+let ``result arity faults entire boat on result-length mismatch`` () =
+    let processBatch (_boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
+        Task.FromResult [||]
+    let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 4 }
+    use throttler = new FerryThrottler<int, int>(config, processBatch)
+    let tasks =
+        [ 1 .. 4 ]
+        |> List.map (fun x -> throttler.ProcessAsync x)
+        |> Array.ofList
+    (fun () -> Task.WaitAll(tasks |> Array.map (fun t -> t :> Task))) |> should throw typeof<AggregateException>
+    throttler.CompleteAsync().Wait()
+    tasks
+    |> Array.forall (fun t -> t.IsFaulted && t.Exception.InnerExceptions |> Seq.exists (fun ex -> ex :? InvalidOperationException))
+    |> should equal true
+
+
+[<Fact>]
+let ``result arity faults every item when processor throws`` () =
+    let boom = InvalidOperationException "boom"
+    let processBatch (_boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
+        Task.FromException<int array> boom
+    use throttler = new FerryThrottler<int, int>(FerryThrottlerConfig.deterministic, processBatch)
+    let tasks =
+        [ 1 .. 3 ]
+        |> List.map (fun x -> throttler.ProcessAsync x)
+        |> Array.ofList
+    (fun () -> Task.WaitAll(tasks |> Array.map (fun t -> t :> Task))) |> should throw typeof<AggregateException>
+    throttler.CompleteAsync().Wait()
+    tasks |> Array.forall (fun t -> t.IsFaulted) |> should equal true
+
+
+[<Fact>]
+let ``result arity cancels queued item before shipping`` () =
+    let processed = ConcurrentQueue<int>()
+    let gate = new TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+    let entered = new TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+    let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
+        task {
+            processed.Enqueue boat.Span.[0]
+            entered.TrySetResult() |> ignore
+            do! gate.Task
+            return [| boat.Span.[0] |]
+        }
+    let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 1 }
+    use throttler = new FerryThrottler<int, int>(config, processBatch)
+    let first = throttler.ProcessAsync 1
+    entered.Task.Wait 2000 |> should equal true
+    use cts = new CancellationTokenSource()
+    let second = throttler.ProcessAsync(2, cts.Token)
+    cts.Cancel()
+    gate.SetResult()
+    first.Wait 2000 |> should equal true
+    (fun () -> second.Wait()) |> should throw typeof<AggregateException>
+    throttler.CompleteAsync().Wait()
+    second.IsCanceled |> should equal true
+    List.ofSeq processed |> should equal [ 1 ]
+
+
+[<Fact>]
+let ``result arity dispose cancels queued caller tasks`` () =
+    let entered = new TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+    let processBatch (boat: ReadOnlyMemory<int>) (ct: CancellationToken) : Task<int array> =
+        task {
+            entered.TrySetResult() |> ignore
+            do! Task.Delay(Timeout.Infinite, ct)
+            return [| boat.Span.[0] |]
+        }
+    let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 1 }
+    let throttler = new FerryThrottler<int, int>(config, processBatch)
+    let first = throttler.ProcessAsync 1
+    entered.Task.Wait 2000 |> should equal true
+    let second = throttler.ProcessAsync 2
+    (throttler :> IDisposable).Dispose()
+    Task.WhenAny(second :> Task, Task.Delay 2000).Result |> should equal (second :> Task)
+    second.IsCanceled |> should equal true
+    Task.WhenAny(first :> Task, Task.Delay 2000).Result |> should equal (first :> Task)
+    (first.IsCanceled || first.IsFaulted) |> should equal true
+
+
+[<Fact>]
+let ``result arity honors byte budget while preserving aligned results`` () =
+    let boats = ConcurrentQueue<int>()
+    let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
+        task {
+            boats.Enqueue boat.Length
+            return [| for i in 0 .. boat.Length - 1 -> boat.Span.[i] + 1 |]
+        }
+    let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 100; MaxBatchBytes = Some 25 }
+    use throttler = new FerryThrottler<int, int>(config, processBatch, itemSizeBytes = (fun _ -> 10))
+    let tasks =
+        [ 1 .. 10 ]
+        |> List.map (fun x -> throttler.ProcessAsync x)
+        |> Array.ofList
+    Task.WaitAll(tasks |> Array.map (fun t -> t :> Task))
+    throttler.CompleteAsync().Wait()
+    tasks |> Array.map (fun t -> t.Result) |> should equal [| for x in 1 .. 10 -> x + 1 |]
+    List.ofSeq boats |> List.forall (fun n -> n >= 1 && n <= 2) |> should equal true

--- a/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
+++ b/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
@@ -269,3 +269,30 @@ let ``result arity honors byte budget while preserving aligned results`` () =
     throttler.CompleteAsync().Wait()
     tasks |> Array.map (fun t -> t.Result) |> should equal [| for x in 1 .. 10 -> x + 1 |]
     List.ofSeq boats |> List.forall (fun n -> n >= 1 && n <= 2) |> should equal true
+
+
+[<Fact>]
+let ``result arity faults request when byte sizer throws`` () =
+    let processed = ConcurrentQueue<int>()
+    let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
+        task {
+            for i in 0 .. boat.Length - 1 do
+                processed.Enqueue boat.Span.[i]
+            return [| for i in 0 .. boat.Length - 1 -> boat.Span.[i] |]
+        }
+    let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 4; MaxBatchBytes = Some 100 }
+    let sizer item =
+        if item = 2 then invalidOp "size failed"
+        10
+    use throttler = new FerryThrottler<int, int>(config, processBatch, itemSizeBytes = sizer)
+    let ok1 = throttler.ProcessAsync 1
+    let bad = throttler.ProcessAsync 2
+    let ok3 = throttler.ProcessAsync 3
+    Task.WhenAll([| ok1; ok3 |]).Wait()
+    Task.WhenAny(bad :> Task, Task.Delay 2000).Result |> should equal (bad :> Task)
+    bad.IsFaulted |> should equal true
+    bad.Exception.InnerExceptions |> Seq.exists (fun ex -> ex.Message = "size failed") |> should equal true
+    throttler.CompleteAsync().Wait()
+    ok1.Result |> should equal 1
+    ok3.Result |> should equal 3
+    List.ofSeq processed |> should equal [ 1; 3 ]

--- a/workitems/081KTF10R0108QG0R003P44BA2-migrate-task-run-sites-off-threadpool-toward-foundationdb-si.md
+++ b/workitems/081KTF10R0108QG0R003P44BA2-migrate-task-run-sites-off-threadpool-toward-foundationdb-si.md
@@ -39,15 +39,12 @@ not push code changes to these files while that work is in flight; fold into it.
 
 ## Sites found (sweep 2026-06-06)
 
-1. **`src/Core/SpineAsync.fs:33`** — background merge worker is `Task.Run(fun () -> ...)`
-   that blocks on `reader.WaitToReadAsync(...).AsTask().Result` (sync-over-async,
-   line 42). Parks one threadpool thread for the spine's whole lifetime.
-   - Prepared (held, unpushed) patch: rewrite as a `backgroundTask` loop with
-     `let! ready = reader.WaitToReadAsync ct` — genuine async, parks no thread.
-     Verified locally: Core builds 0/0, Spine tests 30/30. Patch text saved at
-     `/tmp/spineasync-async-truthful.patch` (regenerate from this note if lost).
-   - Open design question for the FDB direction: should this worker exist as a
-     separate task at all, or fold into the single run loop?
+1. **`src/Core/SpineAsync.fs:33`** — background merge worker is still a
+   lifetime `Task.Run(Func<Task>(...))`. The sync-over-async blocker
+   (`reader.WaitToReadAsync(...).AsTask().Result`) was removed by PR #6693;
+   the worker now awaits `WaitToReadAsync`. Remaining design question for the
+   FDB direction: should this worker exist as a separate task at all, or fold
+   into `FerryThrottler` / the single run loop once the result arity lands?
 
 2. **`src/Core/Runtime.fs:77`** — `ShardedRuntime.StepAsync` fans shard work out
    via `Array.init shardCount (fun i -> Task.Run(...))` + `Task.WhenAll`.

--- a/workitems/done/2026/06/081KTF24T0R08QG0R0008Z3XDC-ferrythrottler-dual-sided-result-interface-individual-in-bat.md
+++ b/workitems/done/2026/06/081KTF24T0R08QG0R0008Z3XDC-ferrythrottler-dual-sided-result-interface-individual-in-bat.md
@@ -1,11 +1,12 @@
 ---
 id: 081KTF24T0R08QG0R0008Z3XDC
 type: task
-state: backlog
+state: done
 priority: P2
 slug: ferrythrottler-dual-sided-result-interface-individual-in-bat
 title: "FerryThrottler dual-sided result interface: individual-in, batched-middle, individual-result-out"
 created: 2026-06-06T18:11:55.544Z
+completed: 2026-06-06T18:42:00Z
 depends_on: []
 composes_with: []
 ---
@@ -21,6 +22,18 @@ composes_with: []
 Vera is **not aware of the throttler yet**; this is a candidate handoff the
 maintainer may route to her, not an accepted assignment. Suggestions below are
 Otto's, captured so whoever picks it up has them.
+
+## Completion
+
+Vera implemented `FerryThrottler<'TItem,'TResult>` beside the existing
+fire-and-forget arity. The new arity uses per-item
+`TaskCompletionSource<'TResult>` with `RunContinuationsAsynchronously`, keeps
+the self-clocked / byte-aware drain shape, fans aligned result arrays back to
+callers, faults an entire boat on result-count mismatch or processor exception,
+and skips queued items cancelled before shipment.
+
+Evidence: `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release
+--filter "FullyQualifiedName~FerryThrottler"` passed 14/14.
 
 Add the dual-sided ergonomic to FerryThrottler (the Itron IThrottler design):
 the producer submits **individual** items and gets back a `Task<TResult>` for


### PR DESCRIPTION
## Summary
- add `FerryThrottler<'TItem,'TResult>` beside the existing fire-and-forget arity
- keep producer ergonomics individual-item-in / `Task<'TResult>`-out while processors still receive self-clocked batches
- use per-item `TaskCompletionSource` with `RunContinuationsAsynchronously`, enforce result-count alignment, fan processor exceptions to every item in a boat, and cancel queued work on item cancellation or throttler disposal
- mark workitem `081KTF24T0R08QG0R0008Z3XDC` done and refresh the `Task.Run` coordination note for the post-#6693 `SpineAsync` state

## Itron calibration
I reviewed the attached Itron `Platform.DotNet/Threading/Tasks/Throttling` source for design signal. The Zeta version carries forward the good parts: per-item completion sources, safe continuation scheduling by default, explicit DoP configuration, and item-boundary completion/fault/cancel semantics. It deliberately keeps Zeta's simpler array-aligned batch-result contract rather than copying the older id/result overflow shape.

## Validation
- `dotnet build -c Release` — passed, 0 warnings / 0 errors
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~FerryThrottler"` — passed, 15/15
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release` — passed, 1728 passed / 1 skipped
- `dotnet test Zeta.sln -c Release` — passed, 2095 passed / 1 skipped
- `git diff --check` — passed
- `dotnet format --verify-no-changes --include ...touched files...` — passed
