### PR TITLE
feat(Core): BonsaiSoft — soft evaluator makes the yang half executable (soft persist / sharp snap)

### DIFF
--- a/src/Core/BonsaiSoft.fs
+++ b/src/Core/BonsaiSoft.fs
@@ -1,0 +1,118 @@
+namespace Zeta.Core
+
+/// **BonsaiSoft — the soft evaluator that makes the yang half executable.**
+///
+/// `Bonsai.Expr` was representation-only (AST + serialize/parse); this module is the
+/// missing interpreter. It honours the maintainer's soft-vs-sharp resolution
+/// (2026-06-06): *"we need the soft version of persistence, and in the best case the soft
+/// version would collapse to the sharp version based on firing and confidence
+/// thresholds … snap into the sharp versions for execution."*
+///
+/// - **Soft** (`evalSoft`) is the persisted / wonder-holding semantics: every node yields a
+///   `SoftValue` (a normalised distribution over `DynamicValue`), so uncertainty is never
+///   silently collapsed. `Cond` is evaluated **softly** — *both* branches are evaluated and
+///   blended by the test's truth-confidence (no hard branch ⇒ branchless / shader-portable,
+///   per vision §4e "avoid `if`").
+/// - **Sharp** (`snap`) is the execution semantics: the single legitimate collapse,
+///   `SoftValue.resolve threshold` — a definite value iff confidence ≥ threshold, else held.
+///   This is the soft→sharp morphism; persistence keeps the `SoftValue`, execution snaps.
+///
+/// v1 supports `Const · Param · Binary · Cond`. `Lambda` / `Call` (closures / named
+/// functions) return an explicit `Error`, never a silent wrong answer (Result-over-exception).
+/// Note: because soft `Cond` evaluates BOTH branches, an error in the not-taken branch still
+/// propagates — soft evaluation means both branches are real, even at weight 0.
+[<RequireQualifiedAccess>]
+module BonsaiSoft =
+
+    open Bonsai
+
+    /// Variable environment — each `Param` resolves to a `SoftValue` distribution.
+    type Env = Map<string, SoftValue.SoftValue>
+
+    let private constToDv (c: ConstValue) : DynamicValue =
+        match c with
+        | CInt i -> DynamicValue.Int i
+        | CStr s -> DynamicValue.String s
+        | CBool b -> DynamicValue.Bool b
+        | CNull -> DynamicValue.Null
+
+    /// Apply a binary op to two CONCRETE values. Checked arithmetic (no silent overflow,
+    /// matching the ZSet weight discipline); ill-typed combinations are an honest `Error`.
+    let private applyOp (op: BinOp) (a: DynamicValue) (b: DynamicValue) : Result<DynamicValue, string> =
+        match op, a, b with
+        | Add, DynamicValue.Int x, DynamicValue.Int y -> Ok(DynamicValue.Int(Checked.(+) x y))
+        | Sub, DynamicValue.Int x, DynamicValue.Int y -> Ok(DynamicValue.Int(Checked.(-) x y))
+        | Mul, DynamicValue.Int x, DynamicValue.Int y -> Ok(DynamicValue.Int(Checked.(*) x y))
+        | Eq, x, y -> Ok(DynamicValue.Bool(x = y))
+        | Lt, DynamicValue.Int x, DynamicValue.Int y -> Ok(DynamicValue.Bool(x < y))
+        | And, DynamicValue.Bool x, DynamicValue.Bool y -> Ok(DynamicValue.Bool(x && y))
+        | Or, DynamicValue.Bool x, DynamicValue.Bool y -> Ok(DynamicValue.Bool(x || y))
+        | _ -> Error(sprintf "BonsaiSoft: ill-typed %A applied to %A, %A" op a b)
+
+    /// Sequence a list of Results — first `Error` wins, else `Ok` of all values.
+    let private sequence (xs: Result<'a, 'e> list) : Result<'a list, 'e> =
+        let rec go acc =
+            function
+            | [] -> Ok(List.rev acc)
+            | Ok x :: t -> go (x :: acc) t
+            | Error e :: _ -> Error e
+        go [] xs
+
+    /// Soft binary: the product distribution through `applyOp` (weights multiply), normalised.
+    let private combine (op: BinOp) (l: SoftValue.SoftValue) (r: SoftValue.SoftValue) : Result<SoftValue.SoftValue, string> =
+        [ for a, pa in SoftValue.candidates l do
+              for b, pb in SoftValue.candidates r do
+                  applyOp op a b |> Result.map (fun v -> v, pa * pb) ]
+        |> sequence
+        |> Result.bind (fun weighted ->
+            match SoftValue.ofWeighted weighted with
+            | Some sv -> Ok sv
+            | None -> Error "BonsaiSoft: degenerate distribution from Binary")
+
+    /// Split a (boolean) test distribution into P(true), P(false). Non-bool ⇒ Error.
+    let private boolSplit (sv: SoftValue.SoftValue) : Result<float * float, string> =
+        ((Ok(0.0, 0.0)), SoftValue.candidates sv)
+        ||> List.fold (fun acc (d, w) ->
+            acc
+            |> Result.bind (fun (pt, pf) ->
+                match d with
+                | DynamicValue.Bool true -> Ok(pt + w, pf)
+                | DynamicValue.Bool false -> Ok(pt, pf + w)
+                | other -> Error(sprintf "BonsaiSoft: Cond test must be Bool, got %A" other)))
+
+    /// **Soft evaluation** — the persisted/wonder-holding semantics. Every node yields a
+    /// `SoftValue`; uncertainty is preserved, never collapsed.
+    let rec evalSoft (env: Env) (expr: Expr) : Result<SoftValue.SoftValue, string> =
+        match expr with
+        | Const c -> Ok(SoftValue.certain (constToDv c))
+        | Param name ->
+            match Map.tryFind name env with
+            | Some sv -> Ok sv
+            | None -> Error(sprintf "BonsaiSoft: unbound param '%s'" name)
+        | Binary(op, l, r) ->
+            evalSoft env l
+            |> Result.bind (fun sl -> evalSoft env r |> Result.bind (combine op sl))
+        | Cond(test, thenE, elseE) ->
+            evalSoft env test
+            |> Result.bind boolSplit
+            |> Result.bind (fun (pt, pf) ->
+                evalSoft env thenE
+                |> Result.bind (fun sThen ->
+                    evalSoft env elseE
+                    |> Result.bind (fun sElse ->
+                        // Soft branch: blend BOTH branches by the test's truth-confidence.
+                        let blended =
+                            [ for d, w in SoftValue.candidates sThen -> d, w * pt ]
+                            @ [ for d, w in SoftValue.candidates sElse -> d, w * pf ]
+                        match SoftValue.ofWeighted blended with
+                        | Some sv -> Ok sv
+                        | None -> Error "BonsaiSoft: Cond produced an empty distribution")))
+        | Lambda _ -> Error "BonsaiSoft v1: Lambda not yet supported (closures pending)"
+        | Call(name, _) ->
+            Error(sprintf "BonsaiSoft v1: Call '%s' not yet supported (named functions pending)" name)
+
+    /// **The soft→sharp snap** — evaluate soft, then collapse to a definite value iff
+    /// confidence ≥ `threshold` (else `None` = held). The one legitimate collapse, at the
+    /// execution edge. `Error` only on an ill-typed / unsupported expression.
+    let snap (threshold: float) (env: Env) (expr: Expr) : Result<DynamicValue option, string> =
+        evalSoft env expr |> Result.map (SoftValue.resolve threshold)

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -50,6 +50,7 @@
     <Compile Include="SchemaRegistry.fs" />
     <Compile Include="Protobuf.fs" />
     <Compile Include="SoftValue.fs" />
+    <Compile Include="BonsaiSoft.fs" />
     <Compile Include="ActionGrid.fs" />
     <Compile Include="DynamicValueXmlPolicy.fs" />
     <Compile Include="Circuit.fs" />

--- a/tests/Tests.FSharp/Bonsai/BonsaiSoft.Tests.fs
+++ b/tests/Tests.FSharp/Bonsai/BonsaiSoft.Tests.fs
@@ -1,0 +1,105 @@
+module Zeta.Tests.BonsaiSoftTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.Bonsai
+
+
+// ═══════════════════════════════════════════════════════════════════
+// BonsaiSoft — the soft evaluator (yang made executable). Soft = SoftValue
+// distribution (persisted/wonder-holding); snap = SoftValue.resolve threshold
+// (the soft→sharp collapse for execution). Maintainer's soft-vs-sharp resolution.
+// ═══════════════════════════════════════════════════════════════════
+
+let private okSoft = function
+    | Ok (sv: SoftValue.SoftValue) -> sv
+    | Error e -> failwithf "expected Ok, got Error %s" e
+
+let private dist (sv: SoftValue.SoftValue) =
+    SoftValue.candidates sv |> List.sortBy (fun (d, _) -> sprintf "%A" d)
+
+// Assert via F#'s own `=` (honours DynamicValue's structural equality) — FsUnit's
+// `should equal` mis-compares Result-wrapped custom-equality types.
+let private snapShould (expected: DynamicValue option) (r: Result<DynamicValue option, string>) =
+    match r with
+    | Ok actual when actual = expected -> ()
+    | other -> failwithf "expected Ok %A, got %A" expected other
+
+
+[<Fact>]
+let ``Const + Binary arithmetic evaluates certain`` () =
+    let expr = Binary(Add, Const(CInt 2L), Const(CInt 3L))
+    let sv = BonsaiSoft.evalSoft Map.empty expr |> okSoft
+    SoftValue.confidence sv |> should equal 1.0
+    SoftValue.resolve 1.0 sv |> should equal (Some(DynamicValue.Int 5L))
+
+
+[<Fact>]
+let ``nested arithmetic: (2+3)*4 = 20`` () =
+    let expr = Binary(Mul, Binary(Add, Const(CInt 2L), Const(CInt 3L)), Const(CInt 4L))
+    BonsaiSoft.snap 1.0 Map.empty expr |> snapShould (Some(DynamicValue.Int 20L))
+
+
+[<Fact>]
+let ``Param resolves from the environment`` () =
+    let env = Map.ofList [ "x", SoftValue.certain (DynamicValue.Int 7L) ]
+    BonsaiSoft.snap 1.0 env (Binary(Add, Param "x", Const(CInt 1L))) |> snapShould (Some(DynamicValue.Int 8L))
+
+
+[<Fact>]
+let ``unbound param is an honest Error`` () =
+    match BonsaiSoft.evalSoft Map.empty (Param "nope") with
+    | Error _ -> ()
+    | Ok _ -> failwith "expected Error for unbound param"
+
+
+[<Fact>]
+let ``comparison + boolean ops`` () =
+    BonsaiSoft.snap 1.0 Map.empty (Binary(Lt, Const(CInt 1L), Const(CInt 2L))) |> snapShould (Some(DynamicValue.Bool true))
+    BonsaiSoft.snap 1.0 Map.empty (Binary(And, Const(CBool true), Const(CBool false))) |> snapShould (Some(DynamicValue.Bool false))
+    BonsaiSoft.snap 1.0 Map.empty (Binary(Eq, Const(CStr "a"), Const(CStr "a"))) |> snapShould (Some(DynamicValue.Bool true))
+
+
+[<Fact>]
+let ``Cond with a certain test takes the chosen branch sharply`` () =
+    let expr = Cond(Const(CBool true), Const(CInt 10L), Const(CInt 20L))
+    BonsaiSoft.snap 1.0 Map.empty expr |> snapShould (Some(DynamicValue.Int 10L))
+
+
+[<Fact>]
+let ``Cond is evaluated SOFTLY — both branches blended by the test's truth-confidence`` () =
+    // test ~ Bool{true:0.7, false:0.3}; then=10, else=20 -> {10:0.7, 20:0.3}
+    let test = SoftValue.ofWeighted [ DynamicValue.Bool true, 0.7; DynamicValue.Bool false, 0.3 ] |> Option.get
+    let env = Map.ofList [ "t", test ]
+    let expr = Cond(Param "t", Const(CInt 10L), Const(CInt 20L))
+    let sv = BonsaiSoft.evalSoft env expr |> okSoft
+    dist sv
+    |> should equal [ DynamicValue.Int 10L, 0.7; DynamicValue.Int 20L, 0.3 ]
+
+
+[<Fact>]
+let ``snap holds (None) below threshold, snaps (Some) at/above it`` () =
+    let test = SoftValue.ofWeighted [ DynamicValue.Bool true, 0.7; DynamicValue.Bool false, 0.3 ] |> Option.get
+    let env = Map.ofList [ "t", test ]
+    let expr = Cond(Param "t", Const(CInt 10L), Const(CInt 20L))
+    // confidence is 0.7 -> held above it, snapped to the mode at/below it.
+    BonsaiSoft.snap 0.8 env expr |> snapShould None
+    BonsaiSoft.snap 0.7 env expr |> snapShould (Some(DynamicValue.Int 10L))
+
+
+[<Fact>]
+let ``Lambda and Call are explicitly unsupported in v1 (no silent wrong answer)`` () =
+    match BonsaiSoft.evalSoft Map.empty (Lambda([ "x" ], Param "x")) with
+    | Error _ -> ()
+    | Ok _ -> failwith "expected Error for Lambda"
+    match BonsaiSoft.evalSoft Map.empty (Call("f", [ Const(CInt 1L) ])) with
+    | Error _ -> ()
+    | Ok _ -> failwith "expected Error for Call"
+
+
+[<Fact>]
+let ``ill-typed binary is an honest Error, never a silent coercion`` () =
+    match BonsaiSoft.evalSoft Map.empty (Binary(Add, Const(CInt 1L), Const(CStr "x"))) with
+    | Error _ -> ()
+    | Ok _ -> failwith "expected Error for ill-typed Add"

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -52,6 +52,7 @@
     <Compile Include="TriBoolean/Float.Tests.fs" />
     <Compile Include="Bonsai/Bonsai.Tests.fs" />
     <Compile Include="Bonsai/Resume.Tests.fs" />
+    <Compile Include="Bonsai/BonsaiSoft.Tests.fs" />
     <Compile Include="Core/Codec.Tests.fs" />
     <Compile Include="RangeSet.Tests.fs" />
     <Compile Include="DynamicValue.Tests.fs" />


### PR DESCRIPTION
## What

`Bonsai.Expr` was representation-only (AST + serialize/parse) — the yang half (`Acts`)
was inert data, nothing ran it. This adds the missing interpreter, built to your
**soft-vs-sharp resolution**: soft is persisted/wonder-holding, sharp is execution, and
the soft form **snaps** to sharp at firing/confidence thresholds.

- **`evalSoft : Env -> Expr -> Result<SoftValue,string>`** — the soft/persisted semantics.
  Every node yields a `SoftValue` distribution; uncertainty never silently collapses.
  `Cond` is evaluated **softly** — both branches evaluated and blended by the test's
  truth-confidence (no hard branch ⇒ branchless / shader-portable, §4e "avoid `if`").
  `Binary` = the probabilistic product distribution (checked arithmetic).
- **`snap : threshold -> Env -> Expr -> Result<DynamicValue option,string>`** — the
  soft→sharp collapse, which is exactly `SoftValue.resolve threshold` (definite iff
  confidence ≥ threshold, else held). The mechanism already existed; this wires it to the
  evaluator. Persistence keeps the `SoftValue`; execution snaps.

## Honest scope (v1)

Supports `Const · Param · Binary · Cond`. `Lambda` / `Call` (closures / named functions)
return an explicit `Error` — never a silent wrong answer (Result-over-exception). Ill-typed
binary and unbound params are honest Errors. Note: soft `Cond` evaluates **both** branches,
so an error in the not-taken branch still propagates (soft = both branches are real).

**10 tests green.** Pure Core (no native dep). Unblocks workitem `081KTFME2TQ`; the next
rung is wiring `Acts(Remains) → delta → GitDeltaLog commit → recover` — the same clean
composition the saga was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)