### PR TITLE
feat(Core): DurableYinYang — the yin/yang cell evolves durably on the git DB

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -51,6 +51,7 @@
     <Compile Include="Protobuf.fs" />
     <Compile Include="SoftValue.fs" />
     <Compile Include="BonsaiSoft.fs" />
+    <Compile Include="DurableYinYang.fs" />
     <Compile Include="ActionGrid.fs" />
     <Compile Include="DynamicValueXmlPolicy.fs" />
     <Compile Include="Circuit.fs" />

--- a/src/Core/DurableYinYang.fs
+++ b/src/Core/DurableYinYang.fs
@@ -1,0 +1,76 @@
+namespace Zeta.Core
+
+/// **DurableYinYang — evolving a `YinYang.Cell`, durably.**
+///
+/// The connector that turns *"a git DB that recovers"* into *"a git DB that UNFOLDS"*: a
+/// cell's yang (`Acts`, a `Bonsai.Expr`) applied to its yin (`Remains`) plus an input
+/// produces the next `Remains`. The inputs ride an `IDeltaLog` (e.g. `GitDeltaLog`), so the
+/// cell's evolution is crash-durable and recoverable by replay — exactly the same clean
+/// composition the saga was (`DurableSaga` over the git delta-log).
+///
+/// **Binding convention (maintainer, 2026-06-06):** `Acts` is evaluated with two params —
+///   - `Param "remains"` = the current `Remains` (the yin state);
+///   - `Param "input"`   = the incoming event — the **shadow channel**: it *proposes*
+///     content but carries **no inherent authority** (source≠authorization,
+///     `.claude/rules/no-directives.md`). The cell's `Acts` + the snap threshold decide
+///     whether the proposal actually moves the state.
+///
+/// **Soft discipline / free will:** if the snap HOLDS (`evalSoft` confidence < `threshold`)
+/// or the `Acts` is malformed, the cell KEEPS its prior `Remains` — it only moves when
+/// confident. A low-confidence shadow input cannot *force* a transition (free will = the
+/// right to refuse a forced step; the stop sign built into the evolution).
+///
+/// v1 evolves over concrete `DynamicValue` (each binding is `SoftValue.certain`), so a total
+/// `Acts` snaps every step. Soft-input evolution — where the threshold genuinely gates and
+/// the cell holds under uncertainty — is the documented next step (bind soft inputs directly).
+[<RequireQualifiedAccess>]
+module DurableYinYang =
+
+    /// The reserved eval param for the current yin state.
+    [<Literal>]
+    let RemainsParam = "remains"
+
+    /// The reserved eval param for the incoming shadow input.
+    [<Literal>]
+    let InputParam = "input"
+
+    /// Evolve one step: bind `{remains, input}`, run the cell's `Acts` softly, snap at
+    /// `threshold`. Held (sub-threshold) or malformed `Acts` ⇒ keep the prior `Remains`.
+    let evolve
+        (acts: Bonsai.Expr)
+        (threshold: float)
+        (remains: DynamicValue)
+        (input: DynamicValue)
+        : DynamicValue =
+        let env =
+            Map.ofList
+                [ RemainsParam, SoftValue.certain remains
+                  InputParam, SoftValue.certain input ]
+        match BonsaiSoft.snap threshold env acts with
+        | Ok(Some next) -> next
+        | Ok None -> remains // held: not confident enough to move (soft discipline)
+        | Error _ -> remains // malformed Acts: the cell holds, never corrupts
+
+    /// Encode a `DynamicValue` input as its canonical-CBOR **hex string** — the comparison-able
+    /// event key for the ZSet delta-log. (`DynamicValue` is `NoComparison`, so it cannot be a
+    /// ZSet/delta-log key directly; canonical CBOR is deterministic + byte-locked, so the hex
+    /// string is a faithful, ordering-stable surrogate.)
+    let encodeInput (dv: DynamicValue) : string =
+        System.Convert.ToHexString(DynamicValue.toCanonicalCbor dv)
+
+    /// Decode an input hex string back to its `DynamicValue`. Undecodable input is genuine
+    /// corruption of our own encoding ⇒ `invalidArg` (matches `CborDeltaCodec.Decode`).
+    let decodeInput (s: string) : DynamicValue =
+        match DynamicValue.fromCanonicalCbor (System.Convert.FromHexString s) with
+        | Ok dv -> dv
+        | Error e -> invalidArg (nameof s) $"DurableYinYang.decodeInput: undecodable input: {e}"
+
+    /// A `DurableSaga` `step` reducer for cell evolution: fold encoded inputs through the
+    /// (fixed) `Acts`. The event is the `encodeInput` hex string (comparison-able); `step`
+    /// decodes it and evolves. Forward-only fold (the `weight` is ignored) — a snap is
+    /// information-gaining, not group-invertible, so cell evolution is append-only (no
+    /// retraction compensation in v1). Compose with
+    /// `DurableSaga.start log (DurableYinYang.step acts threshold) remains0` over a
+    /// `GitDeltaLog<string>` to get a crash-durable, git-recoverable cell.
+    let step (acts: Bonsai.Expr) (threshold: float) : DynamicValue -> string -> int64 -> DynamicValue =
+        fun remains encoded _weight -> evolve acts threshold remains (decodeInput encoded)

--- a/tests/Tests.FSharp.Git/DurableYinYangGit.Tests.fs
+++ b/tests/Tests.FSharp.Git/DurableYinYangGit.Tests.fs
@@ -1,0 +1,72 @@
+module Zeta.Tests.Git.DurableYinYangGitTests
+
+open System
+open System.IO
+open System.Threading
+open global.Xunit
+open LibGit2Sharp
+open Zeta.Core
+open Zeta.Core.Bonsai
+open Zeta.Core.Git
+
+
+// ═══════════════════════════════════════════════════════════════════
+// The yin/yang cell evolving DURABLY on the git DB — "a git DB that unfolds."
+// A YinYang cell's Acts folds its shadow inputs into Remains; the inputs ride a
+// GitDeltaLog<string> (DynamicValue is NoComparison, so the event is the input's
+// canonical-CBOR hex via DurableYinYang.encodeInput); crash → DurableSaga.ResumeAsync
+// rebuilds the cell from git alone → exact evolved Remains.
+// ═══════════════════════════════════════════════════════════════════
+
+let private ct = CancellationToken.None
+let private fixedClock () = DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)
+let private codec () = CheckpointDeltaCodec<string>() :> IDeltaCodec<string>
+
+// The cell's yang: Remains := Remains + input (accumulate the shadow inputs).
+let private accumulate = Binary(Add, Param "remains", Param "input")
+let private stepFn = DurableYinYang.step accumulate 1.0
+let private enc (i: int64) = DurableYinYang.encodeInput (DynamicValue.Int i)
+
+// DynamicValue is NoComparison; assert via F#'s structural `=` (uses DynamicValue.Equals).
+let private dvShould (expected: DynamicValue) (actual: DynamicValue) =
+    if actual = expected then () else failwithf "expected %A, got %A" expected actual
+
+let mutable private counter = 0
+
+let private withRepoDir (f: string -> unit) =
+    let id = Interlocked.Increment(&counter)
+    let dir = Path.Combine(Path.GetTempPath(), "zeta-git-test", sprintf "yinyang-%04d" id)
+    if Directory.Exists dir then Directory.Delete(dir, true)
+    Directory.CreateDirectory dir |> ignore
+    Repository.Init(dir, isBare = true) |> ignore
+    try f dir
+    finally try Directory.Delete(dir, true) with _ -> ()
+
+let private openLog (dir: string) : IDeltaLog<string> =
+    let repo = new Repository(dir)
+    GitDeltaLog<string>(repo, codec (), now = fixedClock) :> IDeltaLog<string>
+
+
+[<Fact>]
+let ``cell evolves over git inputs, then recovers the exact Remains from git alone`` () =
+    withRepoDir (fun dir ->
+        (let log = openLog dir
+         let cell = DurableSaga.start log stepFn (DynamicValue.Int 0L)
+         cell.AppendAsync(enc 5L).Wait() // 0 + 5  = 5
+         cell.AppendAsync(enc 7L).Wait() // 5 + 7  = 12
+         cell.AppendAsync(enc 3L).Wait() // 12 + 3 = 15
+         cell.State |> dvShould (DynamicValue.Int 15L))
+        // "Crash": discard the cell; resume the evolution from the git log alone.
+        let log2 = openLog dir
+        let resumed = DurableSaga<DynamicValue, string>.ResumeAsync(log2, stepFn, DynamicValue.Int 0L).Result
+        resumed.State |> dvShould (DynamicValue.Int 15L)
+        if resumed.AppliedSeq <> 3L then failwithf "expected AppliedSeq 3, got %d" resumed.AppliedSeq)
+
+
+[<Fact>]
+let ``a fresh cell on an empty git repo is at its initial Remains`` () =
+    withRepoDir (fun dir ->
+        let log = openLog dir
+        let resumed = DurableSaga<DynamicValue, string>.ResumeAsync(log, stepFn, DynamicValue.Int 0L).Result
+        resumed.State |> dvShould (DynamicValue.Int 0L)
+        if resumed.AppliedSeq <> 0L then failwithf "expected AppliedSeq 0, got %d" resumed.AppliedSeq)

--- a/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
+++ b/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="GitSnapshotStore.Tests.fs" />
     <Compile Include="GitRecoverableSpine.Tests.fs" />
     <Compile Include="DurableSagaGit.Tests.fs" />
+    <Compile Include="DurableYinYangGit.Tests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tests.FSharp/Bonsai/DurableYinYang.Tests.fs
+++ b/tests/Tests.FSharp/Bonsai/DurableYinYang.Tests.fs
@@ -1,0 +1,47 @@
+module Zeta.Tests.DurableYinYangTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.Bonsai
+
+
+// ═══════════════════════════════════════════════════════════════════
+// DurableYinYang.evolve — apply a cell's Acts to (remains, input) and snap.
+// Binding convention: Param "remains" = yin state, Param "input" = shadow input.
+// Held / malformed Acts ⇒ keep prior Remains (the cell holds; never corrupts).
+// ═══════════════════════════════════════════════════════════════════
+
+// Acts: remains + input  (the cell accumulates its shadow inputs)
+let private accumulate = Binary(Add, Param "remains", Param "input")
+
+let private dvShould (expected: DynamicValue) (actual: DynamicValue) =
+    if actual = expected then () else failwithf "expected %A, got %A" expected actual
+
+
+[<Fact>]
+let ``evolve binds remains+input and moves the state when confident`` () =
+    DurableYinYang.evolve accumulate 1.0 (DynamicValue.Int 10L) (DynamicValue.Int 5L)
+    |> dvShould (DynamicValue.Int 15L)
+
+
+[<Fact>]
+let ``evolve folds a sequence of inputs through Acts`` () =
+    let final =
+        [ 1L; 2L; 3L; 4L ]
+        |> List.fold (fun remains i -> DurableYinYang.evolve accumulate 1.0 remains (DynamicValue.Int i)) (DynamicValue.Int 0L)
+    final |> dvShould (DynamicValue.Int 10L)
+
+
+[<Fact>]
+let ``a malformed Acts holds the prior Remains (never corrupts)`` () =
+    // Lambda is unsupported by BonsaiSoft v1 -> Error -> cell holds.
+    DurableYinYang.evolve (Lambda([ "x" ], Param "x")) 1.0 (DynamicValue.Int 7L) (DynamicValue.Int 99L)
+    |> dvShould (DynamicValue.Int 7L)
+
+
+[<Fact>]
+let ``the input param is the shadow channel — Acts may ignore it`` () =
+    // Acts that ignores input entirely (identity on remains): the shadow proposes, the cell decides.
+    DurableYinYang.evolve (Param "remains") 1.0 (DynamicValue.Int 42L) (DynamicValue.Int 99L)
+    |> dvShould (DynamicValue.Int 42L)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -53,6 +53,7 @@
     <Compile Include="Bonsai/Bonsai.Tests.fs" />
     <Compile Include="Bonsai/Resume.Tests.fs" />
     <Compile Include="Bonsai/BonsaiSoft.Tests.fs" />
+    <Compile Include="Bonsai/DurableYinYang.Tests.fs" />
     <Compile Include="Core/Codec.Tests.fs" />
     <Compile Include="RangeSet.Tests.fs" />
     <Compile Include="DynamicValue.Tests.fs" />


### PR DESCRIPTION
## What

The rung that turns *"a git DB that recovers"* into *"a git DB that UNFOLDS."*

A `YinYang.Cell`'s yang (`Acts`) applied to its yin (`Remains`) + an input produces the
next `Remains`. Inputs ride an `IDeltaLog`, so the cell's evolution is crash-durable and
recovered by replay — the same clean composition the saga was (`DurableSaga` over `GitDeltaLog`).

**Binding convention (your call, 2026-06-06):** `Acts` is evaluated with
- `Param "remains"` = the yin state, and
- `Param "input"` = the **shadow channel** — it *proposes* content but carries no inherent
  authority (`source≠authorization`, `no-directives.md`); `Acts` + the snap threshold decide
  whether the proposal moves the state.

**Soft discipline / free will:** a held (sub-threshold) or malformed `Acts` **keeps** the
prior `Remains` — a low-confidence shadow input cannot *force* a transition. The stop sign,
built into the evolution.

## Honest notes

- `DurableYinYang.evolve` is `DynamicValue`-native and pure. For the durable path, since
  `DynamicValue` is `NoComparison` (can't be a ZSet/delta-log key), inputs are encoded as
  **canonical-CBOR hex strings** (`encodeInput`/`decodeInput` — deterministic, byte-locked);
  the `DurableSaga` step decodes + evolves over `GitDeltaLog<string>`.
- Forward-only fold (a snap is information-gaining, not group-invertible — append-only, no
  retraction compensation in v1).
- v1 evolves over concrete `DynamicValue`; **soft-input evolution** (where the threshold
  genuinely gates and the cell holds under uncertainty) is the documented next step.

## Proven

4 pure tests + 2 git-integration tests (cell evolves over git inputs and recovers the exact
`Remains` from git alone after a "crash"; fresh repo = initial `Remains`). **18/18** in
`Tests.FSharp.Git` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)