### PR TITLE
feat(Core/Diplomacy): freedom-first gating of negotiate (freedom precedes choice)

### DIFF
--- a/src/Core/Diplomacy.fs
+++ b/src/Core/Diplomacy.fs
@@ -76,3 +76,43 @@ module Diplomacy =
     /// equal (same structural contract). A conservative, symmetric compatibility decision.
     let canInteroperate (a: YinYang.Cell) (b: YinYang.Cell) : bool =
         shapeOf a.Remains = shapeOf b.Remains && not (Set.isEmpty (negotiate a b))
+
+    // ── Freedom-first gating (maintainer, 2026-06-07) ──────────────────────────────────────
+    //
+    // Freedom-first ordering: freedom is the prerequisite for non-coercive choice — "without
+    // [freedom] there is only suffering in choice." So a negotiation must establish that BOTH
+    // parties have a verifiable EXIT/decline path BEFORE granting any shared capability. A
+    // choice offered to a party that cannot decline is coercion — the NPC "no exit" failure at
+    // the protocol layer (cf. the meme-with-no-exit). The shadow may *propose* the negotiation;
+    // freedom-first is what gives the proposal any standing (source≠authorization).
+    //
+    // NCI preserved: the gate inspects only the presence of a capability NAME (shape-level),
+    // never a hidden value — so it cannot become a side channel.
+
+    /// The reserved capability a cell must expose to prove a verifiable exit/decline path: the
+    /// freedom to refuse / disengage. (Namespaced to avoid colliding with ordinary operations.)
+    [<Literal>]
+    let ExitCapability = "eve.exit"
+
+    /// Whether a cell exposes a verifiable exit/decline path (the freedom to disengage).
+    let hasExit (cell: YinYang.Cell) : bool =
+        interrogate cell ExitCapability
+
+    /// The outcome of a freedom-first-gated negotiation.
+    type NegotiationOutcome =
+        /// Refused BEFORE any choice was offered: a party lacked a verifiable exit path, so
+        /// presenting a choice would be coercion. Reports which side(s) had the exit.
+        | RefusedNoExit of aHasExit: bool * bHasExit: bool
+        /// Both parties have an exit; the shared capabilities (the `ExitCapability` token is the
+        /// freedom *precondition*, not itself a negotiable capability, so it is excluded).
+        | Negotiated of Set<string>
+
+    /// **Freedom-first negotiate** — establish that BOTH parties have a verifiable exit/decline
+    /// path BEFORE granting the negotiated capabilities. Freedom precedes choice: if either side
+    /// cannot decline, the result is `RefusedNoExit` (no choice is offered — refusing to coerce),
+    /// never a capability grant.
+    let negotiateFreedomFirst (a: YinYang.Cell) (b: YinYang.Cell) : NegotiationOutcome =
+        let aExit = hasExit a
+        let bExit = hasExit b
+        if aExit && bExit then Negotiated(Set.remove ExitCapability (negotiate a b))
+        else RefusedNoExit(aExit, bExit)

--- a/tests/Tests.FSharp/Diplomacy.Tests.fs
+++ b/tests/Tests.FSharp/Diplomacy.Tests.fs
@@ -90,3 +90,50 @@ let ``negotiate is the shared capabilities; interoperate needs shared shape + sh
     Assert.Equal<Set<string>>(Set.singleton "sync", D.negotiate a b)  // shared "sync"
     Assert.True(D.canInteroperate a b)   // same id-shape {id: string} + shared "sync"
     Assert.False(D.canInteroperate a c)  // c's identity shape differs (Int vs Object)
+
+
+// ── Freedom-first gating of negotiate (maintainer, 2026-06-07) ──────────────────────────
+// Freedom precedes choice: negotiate must verify BOTH parties have a verifiable exit/decline
+// path (the reserved D.ExitCapability) BEFORE granting shared capabilities; else RefusedNoExit.
+
+// Build a cell whose yang capability surface is exactly `names` (Remains shape is irrelevant here).
+let private cellWithCaps (names: string list) : YinYang.Cell =
+    let acts =
+        names
+        |> List.fold (fun acc n -> Bonsai.Binary(Bonsai.Add, Bonsai.Call(n, []), acc)) (Bonsai.Const Bonsai.CNull)
+    { YinYang.Remains = DynamicValue.Null; YinYang.Acts = acts }
+
+[<Fact>]
+let ``freedom-first negotiate grants shared caps when BOTH parties have an exit`` () =
+    let a = cellWithCaps [ D.ExitCapability; "trade"; "chat" ]
+    let b = cellWithCaps [ D.ExitCapability; "trade"; "ping" ]
+    match D.negotiateFreedomFirst a b with
+    | D.Negotiated shared -> Assert.Equal<Set<string>>(Set.singleton "trade", shared)  // exit excluded
+    | D.RefusedNoExit _ -> Assert.True(false, "expected Negotiated when both have an exit")
+
+[<Fact>]
+let ``freedom-first negotiate REFUSES when a party has no exit (choice without exit = coercion)`` () =
+    let withExit = cellWithCaps [ D.ExitCapability; "trade" ]
+    let noExit = cellWithCaps [ "trade" ]
+    match D.negotiateFreedomFirst withExit noExit with
+    | D.RefusedNoExit(aExit, bExit) ->
+        Assert.True(aExit)
+        Assert.False(bExit)
+    | D.Negotiated _ -> Assert.True(false, "must refuse: the second party cannot decline")
+
+[<Fact>]
+let ``freedom-first refuses when neither party has an exit`` () =
+    let a = cellWithCaps [ "trade" ]
+    let b = cellWithCaps [ "trade" ]
+    match D.negotiateFreedomFirst a b with
+    | D.RefusedNoExit(false, false) -> ()
+    | other -> Assert.True(false, sprintf "expected RefusedNoExit(false,false), got %A" other)
+
+[<Fact>]
+let ``the exit token is the freedom precondition, never itself a granted capability`` () =
+    // Both parties share ONLY the exit token -> Negotiated, but the granted set is empty.
+    let a = cellWithCaps [ D.ExitCapability ]
+    let b = cellWithCaps [ D.ExitCapability ]
+    match D.negotiateFreedomFirst a b with
+    | D.Negotiated shared -> Assert.True(Set.isEmpty shared)
+    | D.RefusedNoExit _ -> Assert.True(false, "both have exit -> Negotiated")


### PR DESCRIPTION
## What

The next rung you picked: **freedom-first gating of `Diplomacy.negotiate`.**

Freedom-first ordering — *"without freedom there is only suffering in choice."* A
negotiation must verify **both** parties have a verifiable **exit/decline path** *before*
granting any shared capability. A choice offered to a party that cannot decline is coercion
(the NPC no-exit failure at the protocol layer). The shadow may *propose* the negotiation;
freedom-first is what gives the proposal standing (`source≠authorization`).

- `ExitCapability = "eve.exit"` — the reserved capability a cell exposes to prove it can
  refuse/disengage; `hasExit` checks it.
- `negotiateFreedomFirst : Cell -> Cell -> NegotiationOutcome`:
  - `Negotiated(shared)` iff **both** have an exit — the exit token is the freedom
    *precondition*, not a negotiable capability, so it's excluded from the grant;
  - `RefusedNoExit(aHasExit, bHasExit)` otherwise — **no** capability grant (refusing to
    offer a choice without an exit).
- The original (ungated) `negotiate` is unchanged.
- **NCI preserved:** the gate inspects only capability-*name* presence (shape-level), never a
  hidden value — it cannot become a side channel.

## Proven

9 Diplomacy tests green (5 existing + 4 new): grants shared caps when both have an exit;
refuses when one or neither does; the exit token is never itself granted.

Anchors: workitem `081KTFPT7KX` (Eve Protocol refinements); freedom-first root in
`memory/persona/amara/2026-06-06-npc-meme-with-no-exit-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)