### PR TITLE
feat(Core/DurableYinYang): soft-Remains evolution — cell holds the superposition, snaps only at read

### DIFF
--- a/src/Core/DurableYinYang.fs
+++ b/src/Core/DurableYinYang.fs
@@ -74,3 +74,79 @@ module DurableYinYang =
     /// `GitDeltaLog<string>` to get a crash-durable, git-recoverable cell.
     let step (acts: Bonsai.Expr) (threshold: float) : DynamicValue -> string -> int64 -> DynamicValue =
         fun remains encoded _weight -> evolve acts threshold remains (decodeInput encoded)
+
+    // ── Soft-Remains evolution (maintainer's "soft version of persistence", 2026-06-07) ────
+    //
+    // The genuinely-soft cell: `Remains` is a `SoftValue` (a distribution), persisted SOFT.
+    // Evolution does NOT snap — it folds the soft input through `Acts` and keeps the resulting
+    // distribution (the cell HOLDS the superposition). `resolve threshold` is a READ-time
+    // operation (the execution edge) — "snap into the sharp version for execution," never baked
+    // into state. This is where the threshold genuinely gates: a low-confidence cell stays soft
+    // until enough evidence accrues to snap (free will = refuse a forced collapse).
+
+    /// `SoftValue` ⇄ `DynamicValue`: a distribution serialises as an array of `[value, weight]`
+    /// pairs (canonical, so it rides the byte-locked CBOR codec like any `DynamicValue`).
+    let softToDynamicValue (sv: SoftValue.SoftValue) : DynamicValue =
+        DynamicValue.Array
+            [ for d, w in SoftValue.candidates sv -> DynamicValue.Array [ d; DynamicValue.Float w ] ]
+
+    let softOfDynamicValue (dv: DynamicValue) : Result<SoftValue.SoftValue, string> =
+        match dv with
+        | DynamicValue.Array pairs ->
+            let parsed =
+                pairs
+                |> List.map (fun p ->
+                    match p with
+                    | DynamicValue.Array [ v; DynamicValue.Float w ] -> Ok(v, w)
+                    | other -> Error(sprintf "softOfDynamicValue: expected [value, Float weight], got %A" other))
+            let rec seqr acc =
+                function
+                | [] -> Ok(List.rev acc)
+                | Ok x :: t -> seqr (x :: acc) t
+                | Error e :: _ -> Error e
+            match seqr [] parsed with
+            | Error e -> Error e
+            | Ok xs ->
+                match SoftValue.ofWeighted xs with
+                | Some sv -> Ok sv
+                | None -> Error "softOfDynamicValue: degenerate/empty distribution"
+        | other -> Error(sprintf "softOfDynamicValue: expected Array, got %A" other)
+
+    /// **Soft evolve** — fold a soft input through `Acts`, keeping the resulting distribution
+    /// (NO snap). The persisted/wonder-holding step.
+    let evolveSoft
+        (acts: Bonsai.Expr)
+        (remains: SoftValue.SoftValue)
+        (input: SoftValue.SoftValue)
+        : Result<SoftValue.SoftValue, string> =
+        let env = Map.ofList [ RemainsParam, remains; InputParam, input ]
+        BonsaiSoft.evalSoft env acts
+
+    /// **The read-time snap** — `resolve threshold` on the soft `Remains`: a definite value iff
+    /// confidence ≥ threshold, else `None` (held). Execution edge only; state stays soft.
+    let readSharp (threshold: float) (remains: SoftValue.SoftValue) : DynamicValue option =
+        SoftValue.resolve threshold remains
+
+    /// Encode a soft input (a `SoftValue`) as a canonical-CBOR hex string for the delta-log event.
+    let encodeSoftInput (sv: SoftValue.SoftValue) : string =
+        System.Convert.ToHexString(DynamicValue.toCanonicalCbor (softToDynamicValue sv))
+
+    /// Decode a soft-input hex string back to a `SoftValue`. Undecodable ⇒ `invalidArg`.
+    let decodeSoftInput (s: string) : SoftValue.SoftValue =
+        let dv =
+            match DynamicValue.fromCanonicalCbor (System.Convert.FromHexString s) with
+            | Ok dv -> dv
+            | Error e -> invalidArg (nameof s) $"DurableYinYang.decodeSoftInput: undecodable: {e}"
+        match softOfDynamicValue dv with
+        | Ok sv -> sv
+        | Error e -> invalidArg (nameof s) $"DurableYinYang.decodeSoftInput: {e}"
+
+    /// A `DurableSaga` `step` for SOFT cell evolution: fold encoded soft inputs through `Acts`,
+    /// keeping the distribution (no snap). Malformed `Acts` ⇒ keep the prior soft `Remains`.
+    /// Compose with `DurableSaga.start log (DurableYinYang.stepSoft acts) remains0Soft` over a
+    /// `GitDeltaLog<string>` — the soft cell persists and recovers its full distribution.
+    let stepSoft (acts: Bonsai.Expr) : SoftValue.SoftValue -> string -> int64 -> SoftValue.SoftValue =
+        fun remains encoded _weight ->
+            match evolveSoft acts remains (decodeSoftInput encoded) with
+            | Ok next -> next
+            | Error _ -> remains

--- a/tests/Tests.FSharp.Git/DurableYinYangGit.Tests.fs
+++ b/tests/Tests.FSharp.Git/DurableYinYangGit.Tests.fs
@@ -70,3 +70,33 @@ let ``a fresh cell on an empty git repo is at its initial Remains`` () =
         let resumed = DurableSaga<DynamicValue, string>.ResumeAsync(log, stepFn, DynamicValue.Int 0L).Result
         resumed.State |> dvShould (DynamicValue.Int 0L)
         if resumed.AppliedSeq <> 0L then failwithf "expected AppliedSeq 0, got %d" resumed.AppliedSeq)
+
+
+// ── Soft-Remains cell on the git DB: persists + recovers the full DISTRIBUTION ──────────
+module SV = Zeta.Core.SoftValue
+
+let private stepSoftFn = DurableYinYang.stepSoft accumulate  // Acts = remains + input, no snap
+
+let private softShould (expected: (DynamicValue * float) list) (sv: SV.SoftValue) =
+    let norm xs = xs |> List.sortBy (fun (d, _) -> sprintf "%A" d)
+    let a = norm (SV.candidates sv)
+    let e = norm expected
+    if List.length a <> List.length e then failwithf "size: expected %A got %A" e a
+    List.iter2 (fun (d1, w1) (d2, w2) ->
+        if d1 <> d2 || abs (w1 - w2) > 1e-9 then failwithf "expected %A got %A" e a) a e
+
+[<Fact>]
+let ``soft cell persists + recovers its full distribution from git alone`` () =
+    withRepoDir (fun dir ->
+        let remains0 = SV.certain (DynamicValue.Int 0L)
+        let softInput = SV.ofWeighted [ DynamicValue.Int 1L, 0.5; DynamicValue.Int 2L, 0.5 ] |> Option.get
+        (let log = openLog dir
+         let cell = DurableSaga.start log stepSoftFn remains0
+         cell.AppendAsync(DurableYinYang.encodeSoftInput softInput).Wait()  // -> {1:0.5, 2:0.5}
+         cell.State |> softShould [ DynamicValue.Int 1L, 0.5; DynamicValue.Int 2L, 0.5 ])
+        // "Crash": recover the SOFT distribution from git alone.
+        let log2 = openLog dir
+        let resumed = DurableSaga<SV.SoftValue, string>.ResumeAsync(log2, stepSoftFn, remains0).Result
+        resumed.State |> softShould [ DynamicValue.Int 1L, 0.5; DynamicValue.Int 2L, 0.5 ]
+        // held under uncertainty: stays soft until read-time snap
+        if DurableYinYang.readSharp 0.6 resumed.State <> None then failwith "expected held (None) above confidence")

--- a/tests/Tests.FSharp/Bonsai/DurableYinYang.Tests.fs
+++ b/tests/Tests.FSharp/Bonsai/DurableYinYang.Tests.fs
@@ -45,3 +45,50 @@ let ``the input param is the shadow channel — Acts may ignore it`` () =
     // Acts that ignores input entirely (identity on remains): the shadow proposes, the cell decides.
     DurableYinYang.evolve (Param "remains") 1.0 (DynamicValue.Int 42L) (DynamicValue.Int 99L)
     |> dvShould (DynamicValue.Int 42L)
+
+
+// ── Soft-Remains evolution (maintainer's "soft version of persistence", 2026-06-07) ──────
+// Remains is a SoftValue (distribution), persisted soft; evolveSoft folds the soft input
+// through Acts WITHOUT snapping (holds the superposition); readSharp snaps only at read.
+
+module SV = Zeta.Core.SoftValue
+
+let private softShould (expected: (DynamicValue * float) list) (sv: SV.SoftValue) =
+    let norm xs = xs |> List.sortBy (fun (d, _) -> sprintf "%A" d)
+    let a = norm (SV.candidates sv)
+    let e = norm expected
+    if List.length a <> List.length e then failwithf "distribution size: expected %A got %A" e a
+    List.iter2
+        (fun (d1, w1) (d2, w2) ->
+            if d1 <> d2 || abs (w1 - w2) > 1e-9 then failwithf "expected %A got %A" e a)
+        a e
+
+[<Fact>]
+let ``SoftValue <-> DynamicValue round-trips`` () =
+    let sv = SV.ofWeighted [ DynamicValue.Int 1L, 0.25; DynamicValue.Int 2L, 0.75 ] |> Option.get
+    match DurableYinYang.softOfDynamicValue (DurableYinYang.softToDynamicValue sv) with
+    | Ok back -> back |> softShould [ DynamicValue.Int 1L, 0.25; DynamicValue.Int 2L, 0.75 ]
+    | Error e -> failwithf "round-trip failed: %s" e
+
+[<Fact>]
+let ``evolveSoft folds a soft input through Acts and HOLDS the distribution (no snap)`` () =
+    // remains = certain 0; input ~ {1:0.5, 2:0.5}; Acts = remains + input -> {1:0.5, 2:0.5}
+    let remains = SV.certain (DynamicValue.Int 0L)
+    let input = SV.ofWeighted [ DynamicValue.Int 1L, 0.5; DynamicValue.Int 2L, 0.5 ] |> Option.get
+    match DurableYinYang.evolveSoft accumulate remains input with
+    | Ok next ->
+        next |> softShould [ DynamicValue.Int 1L, 0.5; DynamicValue.Int 2L, 0.5 ]
+        // held under uncertainty: confidence 0.5
+        DurableYinYang.readSharp 0.6 next |> ignore
+        if DurableYinYang.readSharp 0.6 next <> None then failwith "expected None (held) above confidence"
+        if DurableYinYang.readSharp 0.5 next = None then failwith "expected Some at/below confidence"
+    | Error e -> failwithf "evolveSoft failed: %s" e
+
+[<Fact>]
+let ``readSharp snaps a certain soft Remains`` () =
+    let remains = SV.certain (DynamicValue.Int 5L)
+    let input = SV.certain (DynamicValue.Int 7L)
+    match DurableYinYang.evolveSoft accumulate remains input with
+    | Ok next ->
+        if DurableYinYang.readSharp 1.0 next <> Some(DynamicValue.Int 12L) then failwith "expected Some(Int 12)"
+    | Error e -> failwithf "evolveSoft failed: %s" e


### PR DESCRIPTION
## What

The foundational rung you greenlit: **soft-`Remains` evolution** — making the cell's
softness real. My design call, faithful to your "soft version of persistence" + "snap at
execution":

- The cell persists `Remains` as a **`SoftValue`** (soft state on disk).
- Evolution **does not snap** — `evolveSoft` folds the soft input through `Acts` and keeps
  the resulting distribution (the cell *holds the superposition*).
- `readSharp threshold` = `SoftValue.resolve` is a **read-time** op (the execution edge) —
  "snap into the sharp version for execution," never baked into state.

This is where the threshold finally *gates*: a low-confidence cell stays soft until evidence
accrues — free will = refusing a forced collapse. The v1 concrete `evolve`/`step` is kept.

## Surface

- `evolveSoft : Acts -> SoftValue -> SoftValue -> Result<SoftValue,_>` (no snap)
- `readSharp : threshold -> SoftValue -> DynamicValue option`
- `softToDynamicValue` / `softOfDynamicValue` (distribution ⇄ `DynamicValue`, rides the
  byte-locked CBOR codec) + `encodeSoftInput` / `decodeSoftInput`
- `stepSoft` — `DurableSaga` reducer over `GitDeltaLog<string>`; the soft cell persists +
  recovers its **full distribution**; malformed `Acts` holds the prior soft `Remains`.

## Proven

7 pure tests (SoftValue⇄DV round-trip; `evolveSoft` holds `{1:0.5, 2:0.5}` — None above
confidence, Some at/below; certain snap) + git integration (soft cell persists + recovers
the distribution from git alone, stays held above threshold). **19 git tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)