### PR TITLE
feat(Core/Diplomacy): cached polymorphic diplomacy = V8 hidden-shapes / PIC (shape-keyed, NCI-safe)

### DIFF
--- a/src/Core/Diplomacy.fs
+++ b/src/Core/Diplomacy.fs
@@ -116,3 +116,33 @@ module Diplomacy =
         let bExit = hasExit b
         if aExit && bExit then Negotiated(Set.remove ExitCapability (negotiate a b))
         else RefusedNoExit(aExit, bExit)
+
+    // ── Cached polymorphic diplomacy = V8 hidden-shapes / PIC (maintainer, 2026-06-07) ──────
+    //
+    // "Cached polymorphic diplomacy over time" is the V8 hidden-shapes optimization
+    // (polymorphic inline caching keyed by SHAPE) applied to the freedom-first handshake. Two
+    // counterparts with the same shape-profile share ONE cache entry — so a repeated handshake
+    // is a cache hit, not a re-derivation (polymorphic: one site, many shapes). A shape change
+    // is a different key (natural invalidation). The cache keys on the `Profile` (shape +
+    // capability NAMES) — never on hidden values — so the NCI shape-only guarantee is preserved:
+    // same shape, different secrets ⇒ same cache entry ⇒ no side channel. (`shapeOf` = the
+    // hidden class/map; this Dictionary = the polymorphic inline cache.)
+
+    /// A polymorphic inline cache for freedom-first negotiation outcomes, keyed by the pair of
+    /// shape-profiles. Caller-owned (per relationship/site); for the durable "over an infinite
+    /// stream" form, fold an agreement stream (`GitDeltaLog`) into one of these.
+    type NegotiationCache = System.Collections.Generic.Dictionary<Profile * Profile, NegotiationOutcome>
+
+    /// A fresh, empty negotiation cache.
+    let newCache () : NegotiationCache = System.Collections.Generic.Dictionary()
+
+    /// **Cached freedom-first negotiate** — memoise the outcome by the (a, b) shape-profile pair.
+    /// Same shapes (even with different hidden values) ⇒ cache hit; different shape ⇒ recompute.
+    let negotiateCached (cache: NegotiationCache) (a: YinYang.Cell) (b: YinYang.Cell) : NegotiationOutcome =
+        let key = (describe a, describe b)
+        match cache.TryGetValue key with
+        | true, cached -> cached
+        | _ ->
+            let outcome = negotiateFreedomFirst a b
+            cache.[key] <- outcome
+            outcome

--- a/tests/Tests.FSharp/Diplomacy.Tests.fs
+++ b/tests/Tests.FSharp/Diplomacy.Tests.fs
@@ -137,3 +137,45 @@ let ``the exit token is the freedom precondition, never itself a granted capabil
     match D.negotiateFreedomFirst a b with
     | D.Negotiated shared -> Assert.True(Set.isEmpty shared)
     | D.RefusedNoExit _ -> Assert.True(false, "both have exit -> Negotiated")
+
+
+// ── Cached polymorphic diplomacy = V8 hidden-shapes / PIC (maintainer, 2026-06-07) ──────
+// negotiateCached memoises by shape-PROFILE. Same shape (even different hidden values) ⇒
+// one cache entry (hit); different shape ⇒ new entry. Keyed on shape, never secret ⇒ NCI held.
+
+let private cellOf (remains: DynamicValue) (names: string list) : YinYang.Cell =
+    let acts =
+        names |> List.fold (fun acc n -> Bonsai.Binary(Bonsai.Add, Bonsai.Call(n, []), acc)) (Bonsai.Const Bonsai.CNull)
+    { YinYang.Remains = remains; YinYang.Acts = acts }
+
+[<Fact>]
+let ``negotiateCached matches direct negotiate and reuses one entry on repeat`` () =
+    let a = cellOf (DynamicValue.Int 1L) [ D.ExitCapability; "trade" ]
+    let b = cellOf (DynamicValue.Int 9L) [ D.ExitCapability; "trade" ]
+    let cache = D.newCache ()
+    let first = D.negotiateCached cache a b
+    let second = D.negotiateCached cache a b
+    Assert.Equal(D.negotiateFreedomFirst a b, first)
+    Assert.Equal(first, second)
+    Assert.Equal(1, cache.Count)
+
+[<Fact>]
+let ``same shape, DIFFERENT secrets share one cache entry (PIC keys on shape, not secret -> NCI held)`` () =
+    let a = cellOf (DynamicValue.Int 1L) [ D.ExitCapability; "trade" ]
+    let aDifferentSecret = cellOf (DynamicValue.Int 2L) [ D.ExitCapability; "trade" ]  // same shape, diff value
+    let b = cellOf (DynamicValue.Int 9L) [ D.ExitCapability; "trade" ]
+    let cache = D.newCache ()
+    let r1 = D.negotiateCached cache a b
+    let r2 = D.negotiateCached cache aDifferentSecret b
+    Assert.Equal(r1, r2)        // identical outcome — secret is invisible to the cache
+    Assert.Equal(1, cache.Count) // ONE entry: same shape-profile -> same key
+
+[<Fact>]
+let ``a DIFFERENT shape is a different key (natural invalidation)`` () =
+    let a = cellOf (DynamicValue.Int 1L) [ D.ExitCapability; "trade" ]
+    let aOtherShape = cellOf (DynamicValue.String "x") [ D.ExitCapability; "trade" ]  // SString vs SInt
+    let b = cellOf (DynamicValue.Int 9L) [ D.ExitCapability; "trade" ]
+    let cache = D.newCache ()
+    D.negotiateCached cache a b |> ignore
+    D.negotiateCached cache aOtherShape b |> ignore
+    Assert.Equal(2, cache.Count)  // shape change -> miss -> new entry


### PR DESCRIPTION
## What

"Cached polymorphic diplomacy over time" realized as the **V8 hidden-shapes optimization**
(your framing): a **polymorphic inline cache** for freedom-first negotiation outcomes, keyed
by the `(a, b)` shape-**Profile** pair.

- Same shape (even different hidden values) → **one** cache entry (hit, no re-derivation —
  *polymorphic*: one site, many shapes).
- A shape change is a different key → **natural invalidation**.
- `shapeOf` = the hidden class/map; the `Dictionary` = the PIC.

## NCI preserved (load-bearing)

The cache keys on `Profile` (shape + capability **names**), **never** on hidden values — so
same-shape / different-secret counterparts share one entry and the cache **cannot become a
side channel**. Proven by test.

## Surface

- `NegotiationCache = Dictionary<Profile*Profile, NegotiationOutcome>`, `newCache`,
  `negotiateCached` (memoises `negotiateFreedomFirst`).
- Caller-owned cache (per relationship/site). The durable **"over an infinite stream"** form
  — fold an agreement stream (`GitDeltaLog`) into one of these — is the documented follow-on.

## Proven

12 Diplomacy tests green (9 existing + 3 new): `cached == direct` and one entry on repeat;
**same-shape / different-secret share one entry** (NCI); different shape → new entry.

Anchors: V8 hidden classes, Self maps, Hölzle PICs (workitem `081KTFPT7KX`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)