### PR TITLE
feat(Core): DurableDiplomacy — cached polymorphic diplomacy over an infinite stream (git-backed agreement fold)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -45,6 +45,7 @@
     <Compile Include="DynamicValue.fs" />
     <Compile Include="YinYang.fs" />
     <Compile Include="Diplomacy.fs" />
+    <Compile Include="DurableDiplomacy.fs" />
     <Compile Include="DynamicValueFold.fs" />
     <Compile Include="SchemaEvolution.fs" />
     <Compile Include="SchemaRegistry.fs" />

--- a/src/Core/DurableDiplomacy.fs
+++ b/src/Core/DurableDiplomacy.fs
@@ -1,0 +1,171 @@
+namespace Zeta.Core
+
+/// **DurableDiplomacy — cached polymorphic diplomacy OVER AN INFINITE STREAM.**
+///
+/// The durable half of the V8-hidden-shapes/PIC cache (`Diplomacy.negotiateCached`): the
+/// shape-keyed negotiation cache becomes a **fold over an agreement stream**. Each
+/// freedom-first agreement is appended to an `IDeltaLog` (e.g. `GitDeltaLog` — the agreement
+/// log = the relationship's history); the live cache is the fold of that stream. Recovery
+/// replays the log and rebuilds the cache — cached polymorphic diplomacy that survives crash.
+///
+/// **Design calls (Otto, 2026-06-07):**
+///  - *Serialization:* `Shape`/`Profile`/`NegotiationOutcome` → `DynamicValue` → canonical-CBOR
+///    hex (rides the byte-locked codec; a comparison-able `string` delta-log event). Capability
+///    sets serialise ordinal-sorted (culture-invariant) for determinism.
+///  - *Supersession:* **last-write-wins per profile-pair key**, via an immutable `Map` fold. A
+///    re-negotiation of the *same* shape supersedes the prior agreement; a *shape change* is a
+///    different key, so agreements for different shapes coexist (natural PIC invalidation).
+///  - *Shadow:* an agreement is *proposed* onto the stream (an append); the **fold (what
+///    remains) is the authority**, never a single append (source≠authorization).
+[<RequireQualifiedAccess>]
+module DurableDiplomacy =
+
+    let private sequence (xs: Result<'a, string> list) : Result<'a list, string> =
+        let rec go acc =
+            function
+            | [] -> Ok(List.rev acc)
+            | Ok x :: t -> go (x :: acc) t
+            | Error e :: _ -> Error e
+        go [] xs
+
+    // ── Shape ⇄ DynamicValue (compact tag encoding) ──
+    let rec shapeToDv (s: Diplomacy.Shape) : DynamicValue =
+        match s with
+        | Diplomacy.SNull -> DynamicValue.String "N"
+        | Diplomacy.SBool -> DynamicValue.String "B"
+        | Diplomacy.SInt -> DynamicValue.String "I"
+        | Diplomacy.SFloat -> DynamicValue.String "F"
+        | Diplomacy.SString -> DynamicValue.String "S"
+        | Diplomacy.SBytes -> DynamicValue.String "Y"
+        | Diplomacy.SArray xs -> DynamicValue.Object [ "a", DynamicValue.Array(List.map shapeToDv xs) ]
+        | Diplomacy.SObject kvs ->
+            DynamicValue.Object
+                [ "o", DynamicValue.Array [ for k, v in kvs -> DynamicValue.Array [ DynamicValue.String k; shapeToDv v ] ] ]
+
+    let rec shapeOfDv (dv: DynamicValue) : Result<Diplomacy.Shape, string> =
+        match dv with
+        | DynamicValue.String "N" -> Ok Diplomacy.SNull
+        | DynamicValue.String "B" -> Ok Diplomacy.SBool
+        | DynamicValue.String "I" -> Ok Diplomacy.SInt
+        | DynamicValue.String "F" -> Ok Diplomacy.SFloat
+        | DynamicValue.String "S" -> Ok Diplomacy.SString
+        | DynamicValue.String "Y" -> Ok Diplomacy.SBytes
+        | DynamicValue.Object [ "a", DynamicValue.Array xs ] ->
+            xs |> List.map shapeOfDv |> sequence |> Result.map Diplomacy.SArray
+        | DynamicValue.Object [ "o", DynamicValue.Array kvs ] ->
+            kvs
+            |> List.map (fun kv ->
+                match kv with
+                | DynamicValue.Array [ DynamicValue.String k; v ] -> shapeOfDv v |> Result.map (fun s -> k, s)
+                | other -> Error(sprintf "shapeOfDv: bad object entry %A" other))
+            |> sequence
+            |> Result.map Diplomacy.SObject
+        | other -> Error(sprintf "shapeOfDv: unrecognised shape %A" other)
+
+    // ── Profile ⇄ DynamicValue ──
+    let profileToDv (p: Diplomacy.Profile) : DynamicValue =
+        DynamicValue.Object
+            [ "id", shapeToDv p.Identity
+              // Set<string> enumerates ordinal-sorted — culture-invariant, deterministic.
+              "caps", DynamicValue.Array [ for c in p.Capabilities -> DynamicValue.String c ] ]
+
+    let profileOfDv (dv: DynamicValue) : Result<Diplomacy.Profile, string> =
+        match dv with
+        | DynamicValue.Object kvs ->
+            let find k = kvs |> List.tryPick (fun (kk, v) -> if kk = k then Some v else None)
+            match find "id", find "caps" with
+            | Some idDv, Some(DynamicValue.Array caps) ->
+                shapeOfDv idDv
+                |> Result.bind (fun id ->
+                    caps
+                    |> List.map (function
+                        | DynamicValue.String s -> Ok s
+                        | other -> Error(sprintf "profileOfDv: bad capability %A" other))
+                    |> sequence
+                    |> Result.map (fun cs -> { Diplomacy.Identity = id; Diplomacy.Capabilities = Set.ofList cs }))
+            | _ -> Error "profileOfDv: missing id/caps"
+        | other -> Error(sprintf "profileOfDv: expected Object, got %A" other)
+
+    // ── NegotiationOutcome ⇄ DynamicValue ──
+    let outcomeToDv (o: Diplomacy.NegotiationOutcome) : DynamicValue =
+        match o with
+        | Diplomacy.RefusedNoExit(a, b) ->
+            DynamicValue.Object [ "k", DynamicValue.String "refused"; "a", DynamicValue.Bool a; "b", DynamicValue.Bool b ]
+        | Diplomacy.Negotiated caps ->
+            DynamicValue.Object
+                [ "k", DynamicValue.String "negotiated"
+                  "caps", DynamicValue.Array [ for c in caps -> DynamicValue.String c ] ]
+
+    let outcomeOfDv (dv: DynamicValue) : Result<Diplomacy.NegotiationOutcome, string> =
+        match dv with
+        | DynamicValue.Object kvs ->
+            let find k = kvs |> List.tryPick (fun (kk, v) -> if kk = k then Some v else None)
+            match find "k" with
+            | Some(DynamicValue.String "refused") ->
+                match find "a", find "b" with
+                | Some(DynamicValue.Bool a), Some(DynamicValue.Bool b) -> Ok(Diplomacy.RefusedNoExit(a, b))
+                | _ -> Error "outcomeOfDv: refused missing a/b"
+            | Some(DynamicValue.String "negotiated") ->
+                match find "caps" with
+                | Some(DynamicValue.Array caps) ->
+                    caps
+                    |> List.map (function
+                        | DynamicValue.String s -> Ok s
+                        | other -> Error(sprintf "outcomeOfDv: bad cap %A" other))
+                    |> sequence
+                    |> Result.map (fun cs -> Diplomacy.Negotiated(Set.ofList cs))
+                | _ -> Error "outcomeOfDv: negotiated missing caps"
+            | other -> Error(sprintf "outcomeOfDv: bad kind %A" other)
+        | other -> Error(sprintf "outcomeOfDv: expected Object, got %A" other)
+
+    // ── Agreement (profileA, profileB, outcome) ⇄ hex event ──
+    let private agreementToDv (a: Diplomacy.Profile) (b: Diplomacy.Profile) (o: Diplomacy.NegotiationOutcome) : DynamicValue =
+        DynamicValue.Object [ "a", profileToDv a; "b", profileToDv b; "o", outcomeToDv o ]
+
+    /// Encode an agreement as a canonical-CBOR hex string — the delta-log event.
+    let encodeAgreement (a: Diplomacy.Profile) (b: Diplomacy.Profile) (o: Diplomacy.NegotiationOutcome) : string =
+        System.Convert.ToHexString(DynamicValue.toCanonicalCbor (agreementToDv a b o))
+
+    /// Decode an agreement event. Undecodable ⇒ `invalidArg` (corruption of our own encoding).
+    let decodeAgreement (s: string) : Diplomacy.Profile * Diplomacy.Profile * Diplomacy.NegotiationOutcome =
+        let fail e = invalidArg (nameof s) $"DurableDiplomacy.decodeAgreement: {e}"
+        match DynamicValue.fromCanonicalCbor (System.Convert.FromHexString s) with
+        | Error e -> fail (sprintf "undecodable CBOR: %A" e)
+        | Ok(DynamicValue.Object kvs) ->
+            let find k = kvs |> List.tryPick (fun (kk, v) -> if kk = k then Some v else None)
+            match find "a", find "b", find "o" with
+            | Some aDv, Some bDv, Some oDv ->
+                match profileOfDv aDv, profileOfDv bDv, outcomeOfDv oDv with
+                | Ok a, Ok b, Ok o -> a, b, o
+                | r1, r2, r3 -> fail (sprintf "%A / %A / %A" r1 r2 r3)
+            | _ -> fail "missing a/b/o"
+        | Ok other -> fail (sprintf "expected Object, got %A" other)
+
+    // ── The durable cache = a Map fold over the agreement stream (last-write-wins) ──
+
+    /// The durable negotiation cache: profile-pair → outcome. Immutable; supersession is
+    /// last-write-wins (a later agreement for the same key replaces the earlier).
+    type DurableCache = Map<Diplomacy.Profile * Diplomacy.Profile, Diplomacy.NegotiationOutcome>
+
+    /// The empty durable cache (the fold's seed / a fresh relationship history).
+    let empty : DurableCache = Map.empty
+
+    /// `DurableSaga` `step`: fold one agreement event into the cache (last-write-wins, so a
+    /// re-negotiation supersedes). Forward-only fold; `weight` ignored. Compose with
+    /// `DurableSaga.start log DurableDiplomacy.step DurableDiplomacy.empty` over a
+    /// `GitDeltaLog<string>`; recovery rebuilds the cache from the agreement stream.
+    let step : DurableCache -> string -> int64 -> DurableCache =
+        fun cache encoded _weight ->
+            let a, b, o = decodeAgreement encoded
+            Map.add (a, b) o cache
+
+    /// Look up a cached agreement for two cells (by their shape-profiles).
+    let lookup (cache: DurableCache) (a: YinYang.Cell) (b: YinYang.Cell) : Diplomacy.NegotiationOutcome option =
+        Map.tryFind (Diplomacy.describe a, Diplomacy.describe b) cache
+
+    /// The agreement event to append when recording a fresh freedom-first negotiation between
+    /// two cells: compute the outcome, return `(outcome, event)`. The caller appends `event`
+    /// to the log (an `IDeltaLog<string>` / `DurableSaga`); the fold then carries it.
+    let recordEvent (a: YinYang.Cell) (b: YinYang.Cell) : Diplomacy.NegotiationOutcome * string =
+        let outcome = Diplomacy.negotiateFreedomFirst a b
+        outcome, encodeAgreement (Diplomacy.describe a) (Diplomacy.describe b) outcome

--- a/tests/Tests.FSharp.Git/DurableDiplomacyGit.Tests.fs
+++ b/tests/Tests.FSharp.Git/DurableDiplomacyGit.Tests.fs
@@ -1,0 +1,64 @@
+module Zeta.Tests.Git.DurableDiplomacyGitTests
+
+open System
+open System.IO
+open System.Threading
+open global.Xunit
+open LibGit2Sharp
+open Zeta.Core
+open Zeta.Core.Git
+
+module D = Zeta.Core.Diplomacy
+module DD = Zeta.Core.DurableDiplomacy
+
+// ═══════════════════════════════════════════════════════════════════
+// Cached polymorphic diplomacy OVER AN INFINITE STREAM, on the git DB: agreements ride a
+// GitDeltaLog<string>; crash → the shape-keyed cache is rebuilt by folding the git stream.
+// ═══════════════════════════════════════════════════════════════════
+
+let private fixedClock () = DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)
+let private codec () = CheckpointDeltaCodec<string>() :> IDeltaCodec<string>
+
+let private cellOf (remains: DynamicValue) (names: string list) : YinYang.Cell =
+    let acts =
+        names |> List.fold (fun acc n -> Bonsai.Binary(Bonsai.Add, Bonsai.Call(n, []), acc)) (Bonsai.Const Bonsai.CNull)
+    { YinYang.Remains = remains; YinYang.Acts = acts }
+
+let mutable private counter = 0
+
+let private withRepoDir (f: string -> unit) =
+    let id = Interlocked.Increment(&counter)
+    let dir = Path.Combine(Path.GetTempPath(), "zeta-git-test", sprintf "ddip-%04d" id)
+    if Directory.Exists dir then Directory.Delete(dir, true)
+    Directory.CreateDirectory dir |> ignore
+    Repository.Init(dir, isBare = true) |> ignore
+    try f dir
+    finally try Directory.Delete(dir, true) with _ -> ()
+
+let private openLog (dir: string) : IDeltaLog<string> =
+    let repo = new Repository(dir)
+    GitDeltaLog<string>(repo, codec (), now = fixedClock) :> IDeltaLog<string>
+
+
+[<Fact>]
+let ``agreement stream persists on git and the cache recovers from git alone`` () =
+    withRepoDir (fun dir ->
+        let a = cellOf (DynamicValue.Int 1L) [ D.ExitCapability; "trade" ]
+        let b = cellOf (DynamicValue.Int 9L) [ D.ExitCapability; "trade" ]
+        let noExit = cellOf (DynamicValue.Int 3L) [ "trade" ]  // freedom-first will refuse
+        let outA, evA = DD.recordEvent a b
+        let outR, evR = DD.recordEvent a noExit
+        (let log = openLog dir
+         let saga = DurableSaga.start log DD.step DD.empty
+         saga.AppendAsync(evA).Wait()
+         saga.AppendAsync(evR).Wait()
+         Assert.Equal(Some outA, DD.lookup saga.State a b))
+        // "Crash": rebuild the shape-keyed cache by folding the git agreement stream.
+        let log2 = openLog dir
+        let resumed = DurableSaga<DD.DurableCache, string>.ResumeAsync(log2, DD.step, DD.empty).Result
+        Assert.Equal(Some outA, DD.lookup resumed.State a b)
+        Assert.Equal(Some outR, DD.lookup resumed.State a noExit)
+        // The refused agreement is faithfully a RefusedNoExit (freedom-first held).
+        match DD.lookup resumed.State a noExit with
+        | Some(D.RefusedNoExit(true, false)) -> ()
+        | other -> Assert.True(false, sprintf "expected RefusedNoExit(true,false), got %A" other))

--- a/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
+++ b/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="GitRecoverableSpine.Tests.fs" />
     <Compile Include="DurableSagaGit.Tests.fs" />
     <Compile Include="DurableYinYangGit.Tests.fs" />
+    <Compile Include="DurableDiplomacyGit.Tests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tests.FSharp/DurableDiplomacy.Tests.fs
+++ b/tests/Tests.FSharp/DurableDiplomacy.Tests.fs
@@ -1,0 +1,68 @@
+module Zeta.Tests.DurableDiplomacyTests
+
+open System.Threading
+open global.Xunit
+open Zeta.Core
+
+module D = Zeta.Core.Diplomacy
+module DD = Zeta.Core.DurableDiplomacy
+
+// ═══════════════════════════════════════════════════════════════════
+// DurableDiplomacy — cached polymorphic diplomacy OVER A STREAM: agreements fold into a
+// Map (last-write-wins supersession); recovery rebuilds the cache from the agreement log.
+// ═══════════════════════════════════════════════════════════════════
+
+let private ct = CancellationToken.None
+
+let private cellOf (remains: DynamicValue) (names: string list) : YinYang.Cell =
+    let acts =
+        names |> List.fold (fun acc n -> Bonsai.Binary(Bonsai.Add, Bonsai.Call(n, []), acc)) (Bonsai.Const Bonsai.CNull)
+    { YinYang.Remains = remains; YinYang.Acts = acts }
+
+[<Fact>]
+let ``Profile and NegotiationOutcome round-trip through the agreement codec`` () =
+    let a = D.describe (cellOf (DynamicValue.Int 1L) [ D.ExitCapability; "trade" ])
+    let b = D.describe (cellOf (DynamicValue.Object [ "x", DynamicValue.String "s" ]) [ D.ExitCapability; "trade"; "ping" ])
+    let o = D.Negotiated(Set.ofList [ "trade" ])
+    let a2, b2, o2 = DD.encodeAgreement a b o |> DD.decodeAgreement
+    Assert.Equal(a, a2)
+    Assert.Equal(b, b2)
+    Assert.Equal(o, o2)
+
+[<Fact>]
+let ``agreements fold into the durable cache and recover from the stream`` () =
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let a = cellOf (DynamicValue.Int 1L) [ D.ExitCapability; "trade" ]
+    let b = cellOf (DynamicValue.Int 9L) [ D.ExitCapability; "trade" ]
+    let saga = DurableSaga.start log DD.step DD.empty
+    let outcome, ev = DD.recordEvent a b
+    saga.AppendAsync(ev).Wait()
+    Assert.Equal(Some outcome, DD.lookup saga.State a b)
+    // Recover from the agreement stream alone.
+    let resumed = DurableSaga<DD.DurableCache, string>.ResumeAsync(log, DD.step, DD.empty).Result
+    Assert.Equal(Some outcome, DD.lookup resumed.State a b)
+
+[<Fact>]
+let ``supersession is last-write-wins for the same profile-pair key`` () =
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let a = D.describe (cellOf (DynamicValue.Int 1L) [ D.ExitCapability; "trade" ])
+    let b = D.describe (cellOf (DynamicValue.Int 9L) [ D.ExitCapability; "trade" ])
+    let saga = DurableSaga.start log DD.step DD.empty
+    saga.AppendAsync(DD.encodeAgreement a b (D.Negotiated(Set.ofList [ "trade" ]))).Wait()
+    saga.AppendAsync(DD.encodeAgreement a b (D.Negotiated(Set.ofList [ "trade"; "extra" ]))).Wait()
+    // Same key -> last write wins.
+    Assert.Equal(Some(D.Negotiated(Set.ofList [ "trade"; "extra" ])), Map.tryFind (a, b) saga.State)
+    Assert.Equal(1, Map.count saga.State)
+
+[<Fact>]
+let ``a different shape coexists as a separate agreement (PIC invalidation by key)`` () =
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let aInt = cellOf (DynamicValue.Int 1L) [ D.ExitCapability; "trade" ]
+    let aStr = cellOf (DynamicValue.String "x") [ D.ExitCapability; "trade" ]  // different shape
+    let b = cellOf (DynamicValue.Int 9L) [ D.ExitCapability; "trade" ]
+    let saga = DurableSaga.start log DD.step DD.empty
+    let _, ev1 = DD.recordEvent aInt b
+    let _, ev2 = DD.recordEvent aStr b
+    saga.AppendAsync(ev1).Wait()
+    saga.AppendAsync(ev2).Wait()
+    Assert.Equal(2, Map.count saga.State)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -43,6 +43,7 @@
     <Compile Include="YinYang.Homoiconic.Tests.fs" />
     <Compile Include="ReflectionEngine.Tests.fs" />
     <Compile Include="Diplomacy.Tests.fs" />
+    <Compile Include="DurableDiplomacy.Tests.fs" />
     <Compile Include="Reconcile.Tests.fs" />
     <Compile Include="Reconcile.Legs.Tests.fs" />
     <Compile Include="EngineLoop.Tests.fs" />


### PR DESCRIPTION
## What

The **durable half** of the V8-hidden-shapes/PIC cache: the shape-keyed negotiation cache
becomes a **fold over an agreement stream**. Each freedom-first agreement is appended to an
`IDeltaLog` (e.g. `GitDeltaLog` — the agreement log = the relationship's history); the live
cache is the fold; recovery replays the stream and rebuilds the cache. Cached diplomacy that
survives crash — the literal *"over an infinite stream"* half.

Pure Core over `IDeltaLog`; tested in-memory **and** on git.

## Design calls (per "make the serialization calls yourself")

- **Serialization:** `Shape`/`Profile`/`NegotiationOutcome` → `DynamicValue` → canonical-CBOR
  hex (byte-locked codec; comparison-able `string` event). Capability sets serialize
  **ordinal-sorted** (culture-invariant, deterministic).
- **Supersession:** **last-write-wins** per profile-pair key (immutable `Map` fold). Same-shape
  re-negotiation supersedes; a shape change is a different key (coexists) = PIC invalidation.
- **Shadow:** an agreement is *proposed* onto the stream (an append); the **fold (what remains)
  is the authority**, never a single append (`source≠authorization`).

## NCI preserved end-to-end

Only shapes + capability **names** are serialized, never hidden values — the agreement stream
cannot leak secrets.

## Proven

4 pure (codec round-trip; fold + recover; last-write-wins supersession; different shape
coexists) + 1 git integration (agreement stream persists on git, cache recovers from git
alone, freedom-first `RefusedNoExit` faithful). **20 git tests green.** Closes the
"over an infinite stream" half of `081KTFPT7KX`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)