### PR TITLE
feat(ObserveBridge): Bridge B — the observe controller loop, durable on the git DB

### DIFF
--- a/src/Core.FSharp.ObserveBridge/DurableObserve.fs
+++ b/src/Core.FSharp.ObserveBridge/DurableObserve.fs
@@ -1,0 +1,33 @@
+namespace Zeta.Core.FSharp.ObserveBridge
+
+open Zeta.Core
+open Zeta.Core.FSharp.Observe
+
+/// **Bridge B — the observe controller loop, durable on the git DB.**
+///
+/// The reducer call (per the integration doc): the durable `World`-cell step **delegates to
+/// `Observe.Algebra.simulate`** — the same byte-parity reducer observe.ts runs. So `World` is
+/// the persisted `Remains`, each chosen `NextAction` is a delta-log event (`ObserveBridge`
+/// encoding), and recovery folds the stream — `DurableSaga.ResumeAsync` rebuilds the exact
+/// `World` from the git log alone. The agent's loop becomes read-folded-World → choose → commit
+/// delta → repeat, with no raw git/gh (the commit is a delta-log append).
+///
+/// **Reversible by design:** the step is just a function. Today it delegates to
+/// `Algebra.simulate`; once `BonsaiSoft` can express the full reducer, the cell's `Acts` can
+/// supply the step instead — without changing any caller (Bridge B, the "delegate now, grow
+/// Bonsai later" call).
+[<RequireQualifiedAccess>]
+module DurableObserve =
+
+    /// The empty initial world (background agent: no operator, no mode, empty backlog).
+    let emptyWorld : World = { Backlog = []; Operator = None; Mode = None }
+
+    /// `DurableSaga` step: decode the action event and apply the parity reducer. Forward-only
+    /// fold (`weight` ignored — an observe action is a forward transition, not group-invertible).
+    /// Compose with `DurableSaga.start log DurableObserve.step initialWorld` over a
+    /// `GitDeltaLog<string>` to run the controller loop durably on git.
+    let step : World -> string -> int64 -> World =
+        fun world encoded _weight -> Algebra.simulate world (ObserveBridge.decodeAction encoded)
+
+    /// The delta-log event for a chosen action (canonical-CBOR hex via `ObserveBridge`).
+    let event (action: NextAction) : string = ObserveBridge.encodeAction action

--- a/src/Core.FSharp.ObserveBridge/Zeta.Core.FSharp.ObserveBridge.fsproj
+++ b/src/Core.FSharp.ObserveBridge/Zeta.Core.FSharp.ObserveBridge.fsproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <Compile Include="ObserveBridge.fs" />
+    <Compile Include="DurableObserve.fs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Tests.FSharp.Git/DurableObserveGit.Tests.fs
+++ b/tests/Tests.FSharp.Git/DurableObserveGit.Tests.fs
@@ -1,0 +1,50 @@
+module Zeta.Tests.Git.DurableObserveGitTests
+
+open System
+open System.IO
+open System.Threading
+open global.Xunit
+open LibGit2Sharp
+open Zeta.Core
+open Zeta.Core.Git
+open Zeta.Core.FSharp.Observe
+open Zeta.Core.FSharp.ObserveBridge
+
+// ═══════════════════════════════════════════════════════════════════
+// The observe controller loop running on the GIT DB: each NextAction is a git commit; crash →
+// the World (= Remains) is rebuilt by folding the git event stream. "everything behind the DB."
+// ═══════════════════════════════════════════════════════════════════
+
+let private fixedClock () = DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)
+let private codec () = CheckpointDeltaCodec<string>() :> IDeltaCodec<string>
+let private item id = { Id = id; Title = id; Ready = true; Ambiguous = false; NeedsNewAction = false }
+
+let mutable private counter = 0
+let private withRepoDir (f: string -> unit) =
+    let id = Interlocked.Increment(&counter)
+    let dir = Path.Combine(Path.GetTempPath(), "zeta-git-test", sprintf "observe-%04d" id)
+    if Directory.Exists dir then Directory.Delete(dir, true)
+    Directory.CreateDirectory dir |> ignore
+    Repository.Init(dir, isBare = true) |> ignore
+    try f dir
+    finally try Directory.Delete(dir, true) with _ -> ()
+
+let private openLog (dir: string) : IDeltaLog<string> =
+    let repo = new Repository(dir)
+    GitDeltaLog<string>(repo, codec (), now = fixedClock) :> IDeltaLog<string>
+
+[<Fact>]
+let ``observe loop runs on git: actions commit, World recovers from git alone`` () =
+    withRepoDir (fun dir ->
+        let amb = { item "amb" with Ambiguous = true; Ready = false }
+        let w0 = { Backlog = [ amb; item "ready" ]; Operator = Some { PendingMessage = true; PendingFerry = false }; Mode = None }
+        let actions = [ RespondToOperator "hi"; Decompose amb; DoItem(item "ready"); Explore "onward" ]
+        let expected = Algebra.fold w0 actions
+        (let log = openLog dir
+         let saga = DurableSaga.start log DurableObserve.step w0
+         for a in actions do saga.AppendAsync(DurableObserve.event a).Wait()
+         Assert.Equal(expected, saga.State))
+        // "Crash": rebuild World by folding the git event stream.
+        let log2 = openLog dir
+        let resumed = DurableSaga<World, string>.ResumeAsync(log2, DurableObserve.step, w0).Result
+        Assert.Equal(expected, resumed.State))

--- a/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
+++ b/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
@@ -18,11 +18,14 @@
     <Compile Include="DurableSagaGit.Tests.fs" />
     <Compile Include="DurableYinYangGit.Tests.fs" />
     <Compile Include="DurableDiplomacyGit.Tests.fs" />
+    <Compile Include="DurableObserveGit.Tests.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\Core.fsproj" />
     <ProjectReference Include="..\..\src\Core.Git\Zeta.Core.Git.fsproj" />
+    <ProjectReference Include="..\..\src\Core.FSharp.Observe\Zeta.Core.FSharp.Observe.fsproj" />
+    <ProjectReference Include="..\..\src\Core.FSharp.ObserveBridge\Zeta.Core.FSharp.ObserveBridge.fsproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tests.FSharp/Observe/DurableObserve.Tests.fs
+++ b/tests/Tests.FSharp/Observe/DurableObserve.Tests.fs
@@ -1,0 +1,35 @@
+module Zeta.Tests.DurableObserveTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.FSharp.Observe
+open Zeta.Core.FSharp.ObserveBridge
+
+// ═══════════════════════════════════════════════════════════════════
+// Bridge B — the observe controller loop running DURABLY: World = Remains, each NextAction is
+// a delta-log event, step = Observe.Algebra.simulate; DurableSaga.ResumeAsync folds the stream
+// back to the exact World. The controller loop on the (in-memory here) substrate.
+// ═══════════════════════════════════════════════════════════════════
+
+let private item id =
+    { Id = id; Title = id; Ready = true; Ambiguous = false; NeedsNewAction = false }
+
+[<Fact>]
+let ``durable observe loop folds + resumes to the same World as Algebra.fold`` () =
+    let amb = { item "amb" with Ambiguous = true; Ready = false }
+    let w0 = { Backlog = [ amb; item "ready" ]; Operator = Some { PendingMessage = true; PendingFerry = true }; Mode = None }
+    let actions = [ RespondToOperator "hi"; Decompose amb; DoItem(item "ready"); Explore "onward" ]
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let saga = DurableSaga.start log DurableObserve.step w0
+    for a in actions do
+        saga.AppendAsync(DurableObserve.event a).Wait()
+    Assert.Equal(Algebra.fold w0 actions, saga.State)
+    // Recover from the event stream alone.
+    let resumed = DurableSaga<World, string>.ResumeAsync(log, DurableObserve.step, w0).Result
+    Assert.Equal(Algebra.fold w0 actions, resumed.State)
+
+[<Fact>]
+let ``a fresh durable observe loop is the initial World`` () =
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let resumed = DurableSaga<World, string>.ResumeAsync(log, DurableObserve.step, DurableObserve.emptyWorld).Result
+    Assert.Equal(DurableObserve.emptyWorld, resumed.State)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -116,6 +116,7 @@
     <Compile Include="Observe/GoldenVectors.Tests.fs" />
     <Compile Include="Observe/EventLog.Tests.fs" />
     <Compile Include="Observe/ObserveBridge.Tests.fs" />
+    <Compile Include="Observe/DurableObserve.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
## What

**Bridge B** — the observe controller loop now runs **on the git DB**. The reducer call (the
reversible "delegate now, grow Bonsai later"): the durable `World`-cell step **delegates to
`Observe.Algebra.simulate`** — the same byte-parity reducer observe.ts runs.

- `World` = the persisted `Remains`; each chosen `NextAction` = a delta-log event (Bridge A
  encoding); `DurableSaga.ResumeAsync` folds the stream back to the exact `World`.
- The agent's loop becomes **read-folded-World → choose → commit delta → repeat**, with no raw
  git/gh — the commit is a delta-log append ("everything behind the DB layer").
- `DurableObserve.step` is just a function, so swapping it to a Bonsai-`Acts` source later
  changes **no caller** — the reversibility that made this call safe to take now.

## Proven

- 2 pure: durable fold + resume `== Algebra.fold`; a fresh loop = the initial World.
- 1 git integration: **the observe loop runs on git — actions commit, World recovers from git
  alone** after a crash.
- 21 git tests green.

Remaining: **C** (`NextAction` ↔ 4×4 `ActionGrid` — your call) and **D** (the execution layer:
turn a chosen action into real effects through the substrate, no raw git/gh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)