### PR TITLE
test(ObserveBridge): FsCheck randomized refinement for World/NextAction round-trips + fold semantics

### DIFF
--- a/tests/Tests.FSharp/Observe/ObserveBridge.Property.Tests.fs
+++ b/tests/Tests.FSharp/Observe/ObserveBridge.Property.Tests.fs
@@ -1,0 +1,30 @@
+module Zeta.Tests.ObserveBridgePropertyTests
+
+open FsCheck
+open FsCheck.Xunit
+open Zeta.Core.FSharp.Observe
+open Zeta.Core.FSharp.ObserveBridge
+
+// ═══════════════════════════════════════════════════════════════════
+// Randomized refinement (FsCheck) for the observe<->DynamicValue bridge: round-trip fidelity
+// for arbitrary World/NextAction, and that the encoded event path preserves Algebra semantics.
+// Plain records/DUs of primitives -> FsCheck's default generators suffice.
+// ═══════════════════════════════════════════════════════════════════
+
+[<Property>]
+let ``NextAction round-trips through DynamicValue for all generated values`` (a: NextAction) =
+    ObserveBridge.nextActionOfDv (ObserveBridge.nextActionToDv a) = Ok a
+
+[<Property>]
+let ``NextAction round-trips through canonical-CBOR hex`` (a: NextAction) =
+    ObserveBridge.decodeAction (ObserveBridge.encodeAction a) = a
+
+[<Property>]
+let ``World round-trips through DynamicValue for all generated values`` (w: World) =
+    ObserveBridge.worldOfDv (ObserveBridge.worldToDv w) = Ok w
+
+[<Property>]
+let ``the encoded event path preserves Algebra.fold semantics`` (w: World) (actions: NextAction list) =
+    let viaSubstrate =
+        actions |> List.map (ObserveBridge.encodeAction >> ObserveBridge.decodeAction) |> Algebra.fold w
+    viaSubstrate = Algebra.fold w actions

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -117,6 +117,7 @@
     <Compile Include="Observe/EventLog.Tests.fs" />
     <Compile Include="Observe/ObserveBridge.Tests.fs" />
     <Compile Include="Observe/DurableObserve.Tests.fs" />
+    <Compile Include="Observe/ObserveBridge.Property.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Decision-free hardening of Bridges A/B while the C/D design is pending. Four FsCheck properties (100 cases each): `NextAction` round-trips through `DynamicValue` and through canonical-CBOR hex; `World` round-trips through `DynamicValue`; and the **encoded event path preserves `Algebra.fold` semantics** for arbitrary `(World, NextAction list)`. Complements the example-based tests with the randomized refinement leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)