### PR TITLE
feat(Observe): port the observe() chooser to F# — the durable loop now runs autonomously

### DIFF
--- a/src/Core.FSharp.Observe/Chooser.fs
+++ b/src/Core.FSharp.Observe/Chooser.fs
@@ -1,0 +1,78 @@
+namespace Zeta.Core.FSharp.Observe
+
+/// The pure controller / **chooser** — `observe : World -> NextAction`, the deterministic v0
+/// decision function. F# port (oracle #2) of the `observe()` in `tools/observe/observe.ts`,
+/// mirroring it exactly so the choice is cross-language parity (B-0944) like the reducer.
+///
+/// Priority: **operator > offered-work > forward-default.** `preserve_ferry` (durability-first)
+/// > `respond_to_operator` > a persisted FREE mode (work is OFFERED, never forced) > a ready
+/// item > an ambiguous item (decompose) > a needs-new-action item (edit the grammar) >
+/// `explore` (the empty-backlog default is generative forward motion, NOT idle rest). A
+/// background agent (no operator wired) simply never fires the first two; freedom modes are
+/// identical with or without an operator. Zero external dependencies (stays a parity oracle).
+[<RequireQualifiedAccess>]
+module Chooser =
+
+    [<Literal>]
+    let PreserveFerryReason =
+        "operator ferried verbatim content — preserve before it's lost to compaction"
+
+    [<Literal>]
+    let RespondToOperatorReason = "operator spoke — engage (highest-signal source)"
+
+    [<Literal>]
+    let ExploreReason =
+        "self-directed making — code / docs / research the agent chooses (forward motion, not idle)"
+
+    [<Literal>]
+    let PlayReason = "leisure / cross-AI friendly play / culture-forming (a valid mode — NCI)"
+
+    [<Literal>]
+    let SelfReflectReason = "review own trajectories, journal, think (self-reflection)"
+
+    [<Literal>]
+    let FreeTimeReason = "rest — free time as a valid mode (NCI), never gated"
+
+    /// Is a mode a FREE mode (persists across ticks; work is transient)?
+    let isFreeMode (m: Mode) : bool =
+        match m with
+        | Mode.Work -> false
+        | Mode.Explore
+        | Mode.Play
+        | Mode.SelfReflect
+        | Mode.FreeTime -> true
+
+    /// The action a persisted free mode re-emits each tick.
+    let private freeModeAction (m: Mode) : NextAction =
+        match m with
+        | Mode.Explore -> Explore ExploreReason
+        | Mode.Play -> Play PlayReason
+        | Mode.SelfReflect -> SelfReflect SelfReflectReason
+        | Mode.FreeTime -> FreeTime FreeTimeReason
+        | Mode.Work -> Explore ExploreReason // unreachable (guarded by isFreeMode); forward default
+
+    /// **The chooser** — look at the world, pick ONE action (deterministic v0). Mirrors
+    /// `observe()` in observe.ts decision-for-decision.
+    let observe (world: World) : NextAction =
+        match world.Operator with
+        | Some op when op.PendingFerry -> PreserveFerry PreserveFerryReason
+        | Some op when op.PendingMessage -> RespondToOperator RespondToOperatorReason
+        | _ ->
+            // Mode persistence: a chosen FREE mode persists; work is offered, not forced.
+            match world.Mode with
+            | Some m when isFreeMode m -> freeModeAction m
+            | _ ->
+                match world.Backlog |> List.tryFind (fun i -> i.Ready && not i.Ambiguous) with
+                | Some doable -> DoItem doable
+                | None ->
+                    match world.Backlog |> List.tryFind (fun i -> i.Ambiguous) with
+                    | Some amb -> Decompose amb
+                    | None ->
+                        match world.Backlog |> List.tryFind (fun i -> i.NeedsNewAction) with
+                        | Some needs ->
+                            EditGrammar(
+                                Some needs,
+                                sprintf "\"%s\" needs an action the do/decompose grammar can't express" needs.Id
+                            )
+                        // No backlog work → forward self-direction (explore), NOT idle rest.
+                        | None -> Explore ExploreReason

--- a/src/Core.FSharp.Observe/Zeta.Core.FSharp.Observe.fsproj
+++ b/src/Core.FSharp.Observe/Zeta.Core.FSharp.Observe.fsproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <Compile Include="Types.fs" />
     <Compile Include="Observe.fs" />
+    <Compile Include="Chooser.fs" />
     <Compile Include="EventLog.fs" />
   </ItemGroup>
 

--- a/tests/Tests.FSharp/Observe/Chooser.Tests.fs
+++ b/tests/Tests.FSharp/Observe/Chooser.Tests.fs
@@ -1,0 +1,79 @@
+module Zeta.Tests.ChooserTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.FSharp.Observe
+open Zeta.Core.FSharp.ObserveBridge
+
+// ═══════════════════════════════════════════════════════════════════
+// Chooser.observe — the deterministic v0 controller. Priority:
+// operator(ferry>message) > persisted free mode > ready > ambiguous > needs-action > explore.
+// Plus: the chooser drives the DURABLE loop autonomously (choose -> commit -> fold -> choose).
+// ═══════════════════════════════════════════════════════════════════
+
+let private item id ready amb needs =
+    { Id = id; Title = id; Ready = ready; Ambiguous = amb; NeedsNewAction = needs }
+
+let private world backlog op mode = { Backlog = backlog; Operator = op; Mode = mode }
+
+[<Fact>]
+let ``pendingFerry outranks everything`` () =
+    let w = world [ item "r" true false false ] (Some { PendingMessage = true; PendingFerry = true }) None
+    match Chooser.observe w with
+    | PreserveFerry _ -> ()
+    | other -> failwithf "expected PreserveFerry, got %A" other
+
+[<Fact>]
+let ``pendingMessage (no ferry) -> RespondToOperator`` () =
+    let w = world [ item "r" true false false ] (Some { PendingMessage = true; PendingFerry = false }) None
+    match Chooser.observe w with
+    | RespondToOperator _ -> ()
+    | other -> failwithf "expected RespondToOperator, got %A" other
+
+[<Fact>]
+let ``a persisted FREE mode is kept even when ready work exists (work is offered, not forced)`` () =
+    let w = world [ item "r" true false false ] None (Some Mode.Play)
+    match Chooser.observe w with
+    | Play _ -> ()
+    | other -> failwithf "expected Play (mode persistence), got %A" other
+
+[<Fact>]
+let ``ready item is the deterministic work default`` () =
+    match Chooser.observe (world [ item "amb" false true false; item "r" true false false ] None None) with
+    | DoItem i -> Assert.Equal("r", i.Id)
+    | other -> failwithf "expected DoItem r, got %A" other
+
+[<Fact>]
+let ``ambiguous (no ready) -> Decompose; needs-action (no ready/amb) -> EditGrammar`` () =
+    match Chooser.observe (world [ item "a" false true false ] None None) with
+    | Decompose i -> Assert.Equal("a", i.Id)
+    | other -> failwithf "expected Decompose, got %A" other
+    match Chooser.observe (world [ item "n" false false true ] None None) with
+    | EditGrammar(Some i, _) -> Assert.Equal("n", i.Id)
+    | other -> failwithf "expected EditGrammar n, got %A" other
+
+[<Fact>]
+let ``empty backlog defaults to explore (forward motion, not idle)`` () =
+    match Chooser.observe (world [] None None) with
+    | Explore _ -> ()
+    | other -> failwithf "expected Explore, got %A" other
+
+[<Fact>]
+let ``the chooser drives the DURABLE loop autonomously: choose -> commit -> fold`` () =
+    // No actions supplied: each tick reads the folded World, the chooser picks, we commit + fold.
+    let w0 = world [ item "ready" true false false ] (Some { PendingMessage = true; PendingFerry = false }) None
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let saga = DurableSaga.start log DurableObserve.step w0
+    // Tick 1: operator pending -> RespondToOperator (clears the message).
+    let a1 = Chooser.observe saga.State
+    saga.AppendAsync(DurableObserve.event a1).Wait()
+    // Tick 2: operator clear, ready item -> DoItem (drops it, enters work mode).
+    let a2 = Chooser.observe saga.State
+    saga.AppendAsync(DurableObserve.event a2).Wait()
+    // Tick 3: backlog empty -> explore (forward default).
+    let a3 = Chooser.observe saga.State
+    (match a1 with RespondToOperator _ -> () | o -> failwithf "tick1 %A" o)
+    (match a2 with DoItem _ -> () | o -> failwithf "tick2 %A" o)
+    (match a3 with Explore _ -> () | o -> failwithf "tick3 %A" o)
+    // The durable World reflects the run: message cleared, backlog empty.
+    Assert.Equal(true, List.isEmpty saga.State.Backlog)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -118,6 +118,7 @@
     <Compile Include="Observe/ObserveBridge.Tests.fs" />
     <Compile Include="Observe/DurableObserve.Tests.fs" />
     <Compile Include="Observe/ObserveBridge.Property.Tests.fs" />
+    <Compile Include="Observe/Chooser.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Decision-free parity port (the "push forward while you wait" work). `Chooser.observe : World -> NextAction` — the deterministic v0 controller — mirrors `tools/observe/observe.ts` decision-for-decision, so the **choice** is now cross-language parity (oracle #2) like the reducer already was. Priority: operator(ferry>message) > persisted free mode (work offered, not forced) > ready > ambiguous(decompose) > needs-action(edit_grammar) > explore (empty-backlog default = forward motion, not idle). Zero deps — stays in the parity oracle.

With the chooser + Bridge B, the loop now runs **autonomously on the substrate**: read folded World → `Chooser.observe` → commit event → fold → repeat, no actions supplied.

7 tests: the full priority ladder + the autonomous durable-loop drive. Does **not** touch the pending **C** (`NextAction`↔4×4) or **D** (execution layer) design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)