### PR TITLE
feat(ObserveBridge): Bridge C — NextAction projected onto the 4x4 ActionGrid (C1 fixed home cells)

### DIFF
--- a/src/Core.FSharp.ObserveBridge/ObserveGrid.fs
+++ b/src/Core.FSharp.ObserveBridge/ObserveGrid.fs
@@ -1,0 +1,111 @@
+namespace Zeta.Core.FSharp.ObserveBridge
+
+open Zeta.Core
+open Zeta.Core.FSharp.Observe
+
+/// **Bridge C — `NextAction` projected onto the 4×4 universal action grammar (`ActionGrid`).**
+///
+/// Design call C1 (maintainer, 2026-06-07): **fixed home cell per kind** — the Xbox-controller
+/// layout. The grid *geometry* is fixed (navigation is a pure function of position —
+/// label-independence is proven in `ActionGrid`); each tick the *World* projects which cells are
+/// **live** and what they mean (the labels). An action always lives at the same cell (muscle
+/// memory); `EditGrammar` relabels. Layout (row = chooser priority class; free modes fill row 2):
+///
+/// ```
+///        col0            col1             col2          col3
+/// row0  preserve_ferry  respond_operator  ·            ·        (channel)
+/// row1  do_item         decompose         edit_grammar  ·        (work)
+/// row2  explore         play              self_reflect  free_time(free)
+/// row3  ·               ·                 ·             ·        (reserved: summon-BFT, KPI…)
+/// ```
+[<RequireQualifiedAccess>]
+module ObserveGrid =
+
+    let private pos r c : ActionGrid.Position = { Row = r; Col = c }
+
+    /// The fixed home cell for an action kind (the C1 layout). `None` = not a grammar kind.
+    let homeOfKind (kind: string) : ActionGrid.Position option =
+        match kind with
+        | "preserve_ferry" -> Some(pos 0 0)
+        | "respond_to_operator" -> Some(pos 0 1)
+        | "do_item" -> Some(pos 1 0)
+        | "decompose" -> Some(pos 1 1)
+        | "edit_grammar" -> Some(pos 1 2)
+        | "explore" -> Some(pos 2 0)
+        | "play" -> Some(pos 2 1)
+        | "self_reflect" -> Some(pos 2 2)
+        | "free_time" -> Some(pos 2 3)
+        | _ -> None
+
+    /// The snake/lower kind tag of an action (matches the observe.ts wire form).
+    let kindOf (a: NextAction) : string =
+        match a with
+        | PreserveFerry _ -> "preserve_ferry"
+        | RespondToOperator _ -> "respond_to_operator"
+        | DoItem _ -> "do_item"
+        | Decompose _ -> "decompose"
+        | EditGrammar _ -> "edit_grammar"
+        | Explore _ -> "explore"
+        | Play _ -> "play"
+        | SelfReflect _ -> "self_reflect"
+        | FreeTime _ -> "free_time"
+
+    /// The fixed home cell for an action value.
+    let homeCell (a: NextAction) : ActionGrid.Position =
+        match homeOfKind (kindOf a) with
+        | Some p -> p
+        | None -> pos 3 3 // unreachable for the nine kinds
+
+    // ── availability per kind (mirrors observe.ts buildMenu predicates) ──
+    let private hasReady (w: World) = w.Backlog |> List.exists (fun i -> i.Ready && not i.Ambiguous)
+    let private hasAmbiguous (w: World) = w.Backlog |> List.exists (fun i -> i.Ambiguous)
+    let private hasNeeds (w: World) = w.Backlog |> List.exists (fun i -> i.NeedsNewAction)
+    let private opFerry (w: World) = match w.Operator with Some o -> o.PendingFerry | None -> false
+    let private opMsg (w: World) = match w.Operator with Some o -> o.PendingMessage | None -> false
+
+    /// Is the action at a home cell **live** this tick? (Free modes are always in the menu.)
+    let available (w: World) (kind: string) : bool =
+        match kind with
+        | "preserve_ferry" -> opFerry w
+        | "respond_to_operator" -> opMsg w
+        | "do_item" -> hasReady w
+        | "decompose" -> hasAmbiguous w
+        | "edit_grammar" -> hasNeeds w
+        | "explore"
+        | "play"
+        | "self_reflect"
+        | "free_time" -> true
+        | _ -> false
+
+    let private allKinds =
+        [ "preserve_ferry"; "respond_to_operator"; "do_item"; "decompose"; "edit_grammar"; "explore"; "play"; "self_reflect"; "free_time" ]
+
+    /// **Project** the World onto the 4×4 content layer: each home cell labeled
+    /// `{ kind; available }` (an `ActionGrid.World = Map<Position, DynamicValue>`). Reserved cells
+    /// stay unlabeled. This is the only place World state enters the grid — navigation never does.
+    let project (w: World) : ActionGrid.World =
+        allKinds
+        |> List.choose (fun k ->
+            homeOfKind k
+            |> Option.map (fun p ->
+                p, DynamicValue.Object [ "kind", DynamicValue.String k; "available", DynamicValue.Bool(available w k) ]))
+        |> Map.ofList
+
+    /// **Select a cell → the action it emits this tick**, if live. `do_item`/`decompose`/
+    /// `edit_grammar` resolve to the FIRST matching backlog item (mirrors the chooser); free
+    /// modes carry their canonical reason. `None` = the cell is dead/reserved this tick.
+    let actionAt (p: ActionGrid.Position) (w: World) : NextAction option =
+        match p.Row, p.Col with
+        | 0, 0 when opFerry w -> Some(PreserveFerry Chooser.PreserveFerryReason)
+        | 0, 1 when opMsg w -> Some(RespondToOperator Chooser.RespondToOperatorReason)
+        | 1, 0 -> w.Backlog |> List.tryFind (fun i -> i.Ready && not i.Ambiguous) |> Option.map DoItem
+        | 1, 1 -> w.Backlog |> List.tryFind (fun i -> i.Ambiguous) |> Option.map Decompose
+        | 1, 2 ->
+            w.Backlog
+            |> List.tryFind (fun i -> i.NeedsNewAction)
+            |> Option.map (fun i -> EditGrammar(Some i, sprintf "\"%s\" needs an action the do/decompose grammar can't express" i.Id))
+        | 2, 0 -> Some(Explore Chooser.ExploreReason)
+        | 2, 1 -> Some(Play Chooser.PlayReason)
+        | 2, 2 -> Some(SelfReflect Chooser.SelfReflectReason)
+        | 2, 3 -> Some(FreeTime Chooser.FreeTimeReason)
+        | _ -> None

--- a/src/Core.FSharp.ObserveBridge/Zeta.Core.FSharp.ObserveBridge.fsproj
+++ b/src/Core.FSharp.ObserveBridge/Zeta.Core.FSharp.ObserveBridge.fsproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Compile Include="ObserveBridge.fs" />
     <Compile Include="DurableObserve.fs" />
+    <Compile Include="ObserveGrid.fs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Tests.FSharp/Observe/ObserveGrid.Tests.fs
+++ b/tests/Tests.FSharp/Observe/ObserveGrid.Tests.fs
@@ -1,0 +1,71 @@
+module Zeta.Tests.ObserveGridTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.FSharp.Observe
+open Zeta.Core.FSharp.ObserveBridge
+
+// ═══════════════════════════════════════════════════════════════════
+// Bridge C — NextAction projected onto the 4x4 ActionGrid (C1: fixed home cell per kind).
+// Geometry fixed (navigation label-independent — proven); World projects live cells + labels.
+// ═══════════════════════════════════════════════════════════════════
+
+let private item id ready amb needs =
+    { Id = id; Title = id; Ready = ready; Ambiguous = amb; NeedsNewAction = needs }
+let private world backlog op = { Backlog = backlog; Operator = op; Mode = None }
+let private pos r c : ActionGrid.Position = { Row = r; Col = c }
+
+let private nineKinds =
+    [ "preserve_ferry"; "respond_to_operator"; "do_item"; "decompose"; "edit_grammar"
+      "explore"; "play"; "self_reflect"; "free_time" ]
+
+[<Fact>]
+let ``each kind has a distinct fixed home cell (the C1 layout)`` () =
+    let homes = nineKinds |> List.map (fun k -> (ObserveGrid.homeOfKind k).Value)
+    Assert.Equal(9, homes |> Set.ofList |> Set.count)
+    // spot-check the layout: free modes fill row 2; channel row 0; work row 1.
+    Assert.Equal(pos 0 0, (ObserveGrid.homeOfKind "preserve_ferry").Value)
+    Assert.Equal(pos 2 3, (ObserveGrid.homeOfKind "free_time").Value)
+    Assert.Equal(pos 1 2, (ObserveGrid.homeOfKind "edit_grammar").Value)
+
+[<Fact>]
+let ``project labels all nine home cells; availability tracks the World`` () =
+    let w = world [ item "r" true false false ] (Some { PendingMessage = true; PendingFerry = false })
+    let grid = ObserveGrid.project w
+    Assert.Equal(9, Map.count grid)
+    let avail kind =
+        match Map.tryFind (ObserveGrid.homeOfKind kind).Value grid with
+        | Some(DynamicValue.Object kvs) ->
+            kvs |> List.tryPick (fun (k, v) -> if k = "available" then Some v else None)
+        | _ -> None
+    Assert.Equal(Some(DynamicValue.Bool true), avail "respond_to_operator") // message pending
+    Assert.Equal(Some(DynamicValue.Bool false), avail "preserve_ferry")     // no ferry
+    Assert.Equal(Some(DynamicValue.Bool true), avail "do_item")             // ready item exists
+    Assert.Equal(Some(DynamicValue.Bool false), avail "decompose")          // none ambiguous
+    Assert.Equal(Some(DynamicValue.Bool true), avail "explore")             // free mode always live
+
+[<Fact>]
+let ``actionAt resolves a live cell to its action; dead/reserved cells -> None`` () =
+    let w = world [ item "r" true false false ] None
+    Assert.Equal(Some "do_item", ObserveGrid.actionAt (pos 1 0) w |> Option.map ObserveGrid.kindOf)
+    Assert.Equal(Some "free_time", ObserveGrid.actionAt (pos 2 3) w |> Option.map ObserveGrid.kindOf)
+    Assert.Equal(None, ObserveGrid.actionAt (pos 0 0) w) // no ferry -> dead
+    Assert.Equal(None, ObserveGrid.actionAt (pos 3 3) w) // reserved
+
+[<Fact>]
+let ``the chooser's pick is always selectable at its own home cell`` () =
+    // operator outranks: chooser picks RespondToOperator; selecting its home cell re-emits it.
+    let w = world [ item "r" true false false ] (Some { PendingMessage = true; PendingFerry = false })
+    let pick = Chooser.observe w
+    Assert.Equal(Some(ObserveGrid.kindOf pick), ObserveGrid.actionAt (ObserveGrid.homeCell pick) w |> Option.map ObserveGrid.kindOf)
+    // empty backlog: chooser picks explore; selectable at its cell.
+    let w2 = world [] None
+    let pick2 = Chooser.observe w2
+    Assert.Equal(Some pick2, ObserveGrid.actionAt (ObserveGrid.homeCell pick2) w2)
+
+[<Fact>]
+let ``KEYSTONE: navigation stays label-independent across different World projections`` () =
+    // Two very different Worlds -> two different projected label sets; geomNav must ignore them.
+    let wA = ObserveGrid.project (world [ item "r" true false false ] (Some { PendingMessage = true; PendingFerry = true }))
+    let wB = ObserveGrid.project (world [] None)
+    Assert.True(ActionGrid.labelIndependentOver wA wB ActionGrid.geomNav)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -119,6 +119,7 @@
     <Compile Include="Observe/DurableObserve.Tests.fs" />
     <Compile Include="Observe/ObserveBridge.Property.Tests.fs" />
     <Compile Include="Observe/Chooser.Tests.fs" />
+    <Compile Include="Observe/ObserveGrid.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
**Bridge C** (your call: **C1 — fixed home cell per kind**, the Xbox-controller layout, with the agreed row grouping). The grid geometry is fixed (navigation label-independent — proven in `ActionGrid`); each tick the World projects which cells are **live** + their labels.

```
       col0            col1             col2          col3
row0  preserve_ferry  respond_operator  ·            ·        (channel)
row1  do_item         decompose         edit_grammar  ·        (work)
row2  explore         play              self_reflect  free_time(free)
row3  ·               ·                 ·             ·        (reserved)
```

- `homeOfKind`/`homeCell` — fixed kind→Position (9 distinct cells of 16).
- `project : World -> ActionGrid.World` — labels each home cell `{kind; available}` (the only place World enters the grid).
- `actionAt : Position -> World -> NextAction option` — select a live cell → its action; dead/reserved → None.

**5 tests**, incl. the chooser's pick is always selectable at its home cell, and the **keystone**: navigation stays label-independent across different World projections (geometry/content separation holds end-to-end). Bridge **D** (execution layer) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)