### PR TITLE
feat(ObserveBridge): substrate-backed IEffectHandler — PersistFerry to a dedicated git ferry stream

### DIFF
--- a/src/Core.FSharp.ObserveBridge/SubstrateHandler.fs
+++ b/src/Core.FSharp.ObserveBridge/SubstrateHandler.fs
@@ -1,0 +1,52 @@
+namespace Zeta.Core.FSharp.ObserveBridge
+
+open System.Threading
+open System.Threading.Tasks
+open Zeta.Core
+
+/// **Bridge D (substrate) — the `IEffectHandler` adapter that performs real I/O via the substrate.**
+///
+/// The ONE place that touches the durable substrate. v1 wires **`PersistFerry`** (maintainer
+/// call: *marker + dedicated ferry stream*): the operator's ferried verbatim content is read from
+/// `ferrySource` (the bus seam — a `unit -> string option` injected by the caller, so the adapter
+/// is bus-agnostic) and appended to a **dedicated ferry stream** `ferryLog` — an
+/// `IDeltaLog<string>`; pass a `GitDeltaLog<string>` for git durability, or an in-memory log for
+/// tests. `PersistFerry` stays a MARKER: the content is sourced here, never carried in the effect.
+///
+/// The capability / inspect-before-execute gate is `policy` (default: admit all) — the shadow
+/// proposes; the handler admits. `EmitResponse` / `RunWork` / `ExtendGrammar` are NOT wired in v1
+/// — they return an honest `Skipped`, never a silent success (Result-over-exception). Honest async:
+/// the ferry append is genuine I/O (awaited); the not-wired arms complete synchronously.
+[<Sealed>]
+type SubstrateEffectHandler
+    (
+        ferrySource: unit -> string option,
+        ferryLog: IDeltaLog<string>,
+        ?policy: Effects.Effect -> Effects.Verdict
+    ) =
+
+    let policy = defaultArg policy (fun _ -> Effects.Admit)
+
+    interface Effects.IEffectHandler with
+        member _.InspectAsync(effect, _ct) = ValueTask<Effects.Verdict>(policy effect)
+
+        member _.ExecuteAsync(effect, ct) =
+            match effect with
+            | Effects.PersistFerry ->
+                match ferrySource () with
+                | Some content when content <> "" ->
+                    // Append the ferried content to the dedicated ferry stream (durable; the
+                    // ferry history). Content rides as a weight-1 ZSet<string> entry.
+                    let t =
+                        task {
+                            let! _seq = ferryLog.AppendAsync(ZSet.ofSeq [ content, 1L ], Map.empty, ct).AsTask()
+                            return Effects.Executed
+                        }
+                    ValueTask<Effects.EffectResult>(t)
+                | _ -> ValueTask<Effects.EffectResult>(Effects.Skipped "PersistFerry: no ferried content on the channel")
+            | Effects.EmitResponse ->
+                ValueTask<Effects.EffectResult>(Effects.Skipped "EmitResponse: not wired in v1 (substrate adapter)")
+            | Effects.RunWork _ ->
+                ValueTask<Effects.EffectResult>(Effects.Skipped "RunWork: not wired in v1 (agent hook pending)")
+            | Effects.ExtendGrammar _ ->
+                ValueTask<Effects.EffectResult>(Effects.Skipped "ExtendGrammar: not wired in v1 (substrate adapter)")

--- a/src/Core.FSharp.ObserveBridge/Zeta.Core.FSharp.ObserveBridge.fsproj
+++ b/src/Core.FSharp.ObserveBridge/Zeta.Core.FSharp.ObserveBridge.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="DurableObserve.fs" />
     <Compile Include="ObserveGrid.fs" />
     <Compile Include="Effects.fs" />
+    <Compile Include="SubstrateHandler.fs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Tests.FSharp.Git/SubstrateFerryGit.Tests.fs
+++ b/tests/Tests.FSharp.Git/SubstrateFerryGit.Tests.fs
@@ -1,0 +1,50 @@
+module Zeta.Tests.Git.SubstrateFerryGitTests
+
+open System
+open System.IO
+open System.Threading
+open global.Xunit
+open LibGit2Sharp
+open Zeta.Core
+open Zeta.Core.Git
+open Zeta.Core.FSharp.ObserveBridge
+
+module E = Zeta.Core.FSharp.ObserveBridge.Effects
+
+// ═══════════════════════════════════════════════════════════════════
+// Bridge D substrate on git: PersistFerry appends the ferried content to a dedicated
+// GitDeltaLog<string> ferry stream; the ferry history recovers from git alone.
+// ═══════════════════════════════════════════════════════════════════
+
+let private ct = CancellationToken.None
+let private fixedClock () = DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)
+let private codec () = CheckpointDeltaCodec<string>() :> IDeltaCodec<string>
+
+let mutable private counter = 0
+let private withRepoDir (f: string -> unit) =
+    let id = Interlocked.Increment(&counter)
+    let dir = Path.Combine(Path.GetTempPath(), "zeta-git-test", sprintf "ferry-%04d" id)
+    if Directory.Exists dir then Directory.Delete(dir, true)
+    Directory.CreateDirectory dir |> ignore
+    Repository.Init(dir, isBare = true) |> ignore
+    try f dir
+    finally try Directory.Delete(dir, true) with _ -> ()
+
+let private openLog (dir: string) : IDeltaLog<string> =
+    let repo = new Repository(dir)
+    GitDeltaLog<string>(repo, codec (), now = fixedClock) :> IDeltaLog<string>
+
+let private contents (log: IDeltaLog<string>) =
+    log.ReplayAsync(0L, ct).AsTask().Result
+    |> Array.collect (fun e -> e.Delta |> Seq.map (fun entry -> entry.Key) |> Seq.toArray)
+    |> Array.toList
+
+[<Fact>]
+let ``PersistFerry writes the ferry stream to git; it recovers from git alone`` () =
+    withRepoDir (fun dir ->
+        (let log = openLog dir
+         let h = SubstrateEffectHandler((fun () -> Some "operator ferried verbatim"), log) :> E.IEffectHandler
+         Assert.Equal(E.Executed, (E.runAsync h E.PersistFerry ct).Result))
+        // "Crash": a fresh GitDeltaLog over the same repo replays the ferry stream.
+        let log2 = openLog dir
+        Assert.Equal<string list>([ "operator ferried verbatim" ], contents log2))

--- a/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
+++ b/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="DurableYinYangGit.Tests.fs" />
     <Compile Include="DurableDiplomacyGit.Tests.fs" />
     <Compile Include="DurableObserveGit.Tests.fs" />
+    <Compile Include="SubstrateFerryGit.Tests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tests.FSharp/Observe/SubstrateHandler.Tests.fs
+++ b/tests/Tests.FSharp/Observe/SubstrateHandler.Tests.fs
@@ -1,0 +1,58 @@
+module Zeta.Tests.SubstrateHandlerTests
+
+open System.Threading
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.FSharp.Observe
+open Zeta.Core.FSharp.ObserveBridge
+
+module E = Zeta.Core.FSharp.ObserveBridge.Effects
+
+// ═══════════════════════════════════════════════════════════════════
+// Bridge D (substrate) — SubstrateEffectHandler. v1 wires PersistFerry (marker + dedicated
+// ferry stream): content from the bus seam -> appended to an IDeltaLog<string> ferry stream.
+// ═══════════════════════════════════════════════════════════════════
+
+let private ct = CancellationToken.None
+let private item id = { Id = id; Title = id; Ready = true; Ambiguous = false; NeedsNewAction = false }
+
+let private ferryContents (log: IDeltaLog<string>) =
+    log.ReplayAsync(0L, ct).AsTask().Result
+    |> Array.collect (fun e -> e.Delta |> Seq.map (fun entry -> entry.Key) |> Seq.toArray)
+    |> Array.toList
+
+[<Fact>]
+let ``PersistFerry appends the ferried content to the dedicated ferry stream`` () =
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let h = SubstrateEffectHandler((fun () -> Some "verbatim ferry payload"), log) :> E.IEffectHandler
+    let r = (E.runAsync h E.PersistFerry ct).Result
+    Assert.Equal(E.Executed, r)
+    Assert.Equal<string list>([ "verbatim ferry payload" ], ferryContents log)
+
+[<Fact>]
+let ``PersistFerry with no ferried content skips and appends nothing`` () =
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let h = SubstrateEffectHandler((fun () -> None), log) :> E.IEffectHandler
+    match (E.runAsync h E.PersistFerry ct).Result with
+    | E.Skipped _ -> ()
+    | other -> failwithf "expected Skipped, got %A" other
+    Assert.Empty(ferryContents log)
+
+[<Fact>]
+let ``a DENIED PersistFerry never touches the ferry stream (inspect-before-execute)`` () =
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let denyAll = fun _ -> E.Deny "no persistence without authorization"
+    let h = SubstrateEffectHandler((fun () -> Some "should not land"), log, policy = denyAll) :> E.IEffectHandler
+    match (E.runAsync h E.PersistFerry ct).Result with
+    | E.Skipped _ -> ()
+    | other -> failwithf "expected Skipped, got %A" other
+    Assert.Empty(ferryContents log)
+
+[<Fact>]
+let ``EmitResponse / RunWork / ExtendGrammar are honestly not-wired in v1 (never silent success)`` () =
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let h = SubstrateEffectHandler((fun () -> None), log) :> E.IEffectHandler
+    for e in [ E.EmitResponse; E.RunWork(item "x"); E.ExtendGrammar(item "g") ] do
+        match (E.runAsync h e ct).Result with
+        | E.Skipped _ -> ()
+        | other -> failwithf "expected Skipped for %A, got %A" e other

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -121,6 +121,7 @@
     <Compile Include="Observe/Chooser.Tests.fs" />
     <Compile Include="Observe/ObserveGrid.Tests.fs" />
     <Compile Include="Observe/Effects.Tests.fs" />
+    <Compile Include="Observe/SubstrateHandler.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Bridge D **substrate adapter** — the one place that touches the durable substrate. Your calls: `PersistFerry` stays a **marker** + lands in a **dedicated ferry stream**.

- The operator's ferried verbatim content is read from `ferrySource` (the bus seam — `unit -> string option`, injected so the adapter is bus-agnostic) and appended to `ferryLog` (an `IDeltaLog<string>`; pass a `GitDeltaLog<string>` for git durability).
- Capability / inspect-before-execute via `policy` (default admit).
- `EmitResponse` / `RunWork` / `ExtendGrammar` honestly **not wired in v1** (Skipped, never silent) — `RunWork` is the pending agent hook.

**Proven:** 4 pure (ferry appended; no-content→Skipped+nothing appended; **denied→nothing appended**; the three unwired effects honest-Skip) + 1 git integration (ferry stream written to git, **recovers from git alone**). 22 git tests green. **No raw git/gh** — the ferry persists via Core.Git through the `IDeltaLog` port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)