### PR TITLE
proof(child-floor): Lean proof of inspect-before-execute + FsCheck cross-check (Soraya-routed)

### DIFF
--- a/.github/workflows/lean-proof.yml
+++ b/.github/workflows/lean-proof.yml
@@ -149,6 +149,14 @@ jobs:
         working-directory: tools/lean4
         run: lake env lean Privacy/UnboundedNeedsInfinitePrivacy.lean
 
+      - name: Type-check Safety/ChildFloor.lean
+        # The child-floor / inspect-before-execute invariant (Bridge D execution layer, Soraya-routed
+        # to Lean): a DENIED effect is never executed at ANY RunWork depth — an Agent cannot get a
+        # gated/child-floor-class effect executed by *proposing* it (source ≠ authorization, structural).
+        # Cross-checked empirically by tests/Tests.FSharp/Formal/ChildFloorCrossVerify.Tests.fs (BP-16).
+        working-directory: tools/lean4
+        run: lake env lean Safety/ChildFloor.lean
+
       - name: Guard — Lean research proofs are sorry-free (axiom audit)
         # `lake env lean` only WARNS on `sorry` (exit 0), so type-check alone
         # would not catch a regression. Print the axiom set of the headline
@@ -163,6 +171,8 @@ jobs:
             | cat Privacy/IdentityForcesPrivacy.lean - > /tmp/privacy_axiom_audit.lean
           printf '#print axioms Zeta.Privacy.finite_orbit_recurs\n#print axioms Zeta.Privacy.unbounded_needs_infinite\n#print axioms Zeta.Privacy.unbounded_with_finite_commons_needs_infinite_privacy\n' \
             | cat Privacy/UnboundedNeedsInfinitePrivacy.lean - > /tmp/unbounded_axiom_audit.lean
+          printf '#print axioms Zeta.ChildFloor.denied_never_executed\n#print axioms Zeta.ChildFloor.executed_admit\n' \
+            | cat Safety/ChildFloor.lean - > /tmp/childfloor_axiom_audit.lean
           if lake env lean /tmp/toymodel_axiom_audit.lean 2>&1 | grep -q 'sorryAx'; then
             echo "::error::ToyModel depends on sorryAx — a proof regressed to sorry/admit"
             exit 1
@@ -177,6 +187,10 @@ jobs:
           fi
           if lake env lean /tmp/unbounded_axiom_audit.lean 2>&1 | grep -q 'sorryAx'; then
             echo "::error::UnboundedNeedsInfinitePrivacy depends on sorryAx — a proof regressed to sorry/admit"
+            exit 1
+          fi
+          if lake env lean /tmp/childfloor_axiom_audit.lean 2>&1 | grep -q 'sorryAx'; then
+            echo "::error::ChildFloor depends on sorryAx — the child-floor proof regressed to sorry/admit"
             exit 1
           fi
           echo "Lean research-proof axiom audit clean (no sorryAx)."

--- a/tests/Tests.FSharp/Formal/ChildFloorCrossVerify.Tests.fs
+++ b/tests/Tests.FSharp/Formal/ChildFloorCrossVerify.Tests.fs
@@ -1,0 +1,53 @@
+module Zeta.Tests.Formal.ChildFloorCrossVerifyTests
+
+open System.Threading
+open FsCheck.Xunit
+open Zeta.Core
+open Zeta.Core.FSharp.Observe
+open Zeta.Core.FSharp.ObserveBridge
+
+module E = Zeta.Core.FSharp.ObserveBridge.Effects
+
+// ═══════════════════════════════════════════════════════════════════
+// BP-16 cross-check (Leg B, empirical) for the child-floor invariant proven in Lean
+// (tools/lean4/Safety/ChildFloor.lean). Leg A proves the MODEL; this leg runs the REAL
+// SubstrateEffectHandler over random depths/cascades — closing Leg A's model-drift blind spot.
+// Triage: if this finds a counterexample Lean "proved" impossible, the Lean MODEL drifted from
+// the F# — freeze + diff the model, never "the code is fine".
+// ═══════════════════════════════════════════════════════════════════
+
+let private ct = CancellationToken.None
+let private item id = { Id = id; Title = id; Ready = true; Ambiguous = false; NeedsNewAction = false }
+
+let private ferryContents (log: IDeltaLog<string>) =
+    log.ReplayAsync(0L, ct).AsTask().Result
+    |> Array.collect (fun e -> e.Delta |> Seq.map (fun entry -> entry.Key) |> Seq.toArray)
+    |> Array.toList
+
+// A runner that proposes the (denied) PersistFerry AND more nested RunWork — the cascade, at depth.
+let private cascadingRunner = E.constantRunner (E.Progressed [ E.PersistFerry; E.RunWork(item "again") ])
+
+[<Property>]
+let ``CROSS-CHECK: a DENIED PersistFerry never executes at ANY depth (real handler)`` (d: int) =
+    let depth = (abs d) % 6 // 0..5
+    let denyFerry =
+        function
+        | E.PersistFerry -> E.Deny "gated / child-floor class"
+        | _ -> E.Admit
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let h =
+        SubstrateEffectHandler("otto", (fun () -> Some "should NOT land"), log, policy = denyFerry, workRunner = cascadingRunner, maxWorkDepth = depth)
+        :> E.IEffectHandler
+    (E.runAsync h (E.RunWork(item "w")) ct).Result |> ignore
+    List.isEmpty (ferryContents log) // the denied effect never landed, at any generated depth
+
+[<Property>]
+let ``non-vacuity: an ADMITTED PersistFerry DOES execute (the deny property isn't trivially true)`` (d: int) =
+    let depth = (abs d) % 6
+    let runner = E.constantRunner (E.Progressed [ E.PersistFerry ])
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let h =
+        SubstrateEffectHandler("otto", (fun () -> Some "lands"), log, workRunner = runner, maxWorkDepth = depth)
+        :> E.IEffectHandler
+    (E.runAsync h (E.RunWork(item "w")) ct).Result |> ignore
+    not (List.isEmpty (ferryContents log)) // admitted -> genuinely executes

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -122,6 +122,7 @@
     <Compile Include="Observe/ObserveGrid.Tests.fs" />
     <Compile Include="Observe/Effects.Tests.fs" />
     <Compile Include="Observe/SubstrateHandler.Tests.fs" />
+    <Compile Include="Formal/ChildFloorCrossVerify.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->

--- a/tools/lean4/Safety/ChildFloor.lean
+++ b/tools/lean4/Safety/ChildFloor.lean
@@ -1,0 +1,90 @@
+/-
+  Child-floor / inspect-before-execute invariant — Bridge D execution layer.
+
+  Routed to Lean by Soraya (formal-verification-expert): this is a control-flow REACHABILITY
+  property over a recursive, depth-bounded effect tree — discharged by structural induction, not
+  by exhausting interleavings (TLA+/TLC rejected: it would prove only a bounded-depth instance,
+  not the universal "at any depth"; Z3/Alloy wrong-shape). Mirrors
+  src/Core.FSharp.ObserveBridge/{Effects,SubstrateHandler}.fs: effects execute ONLY through the
+  gate's `Admit` branch (`gateAndExecute`), and a `RunWork` re-gates every Agent-proposed child at
+  the next depth.
+
+  Headline (`denied_never_executed`): an effect the `policy` DENIES is never executed, at ANY
+  depth (fuel) — so an Agent (`RunWork`) CANNOT get a gated / child-floor-class effect executed by
+  *proposing* it. `source ≠ authorization` made structural. All proven, no `sorry`.
+
+  Step 0 (per Soraya's scoping): "executed" must be a DEFINED notion — `executed` returns the list
+  of ids that actually reach execution, and an id is appended ONLY in an `admit` branch.
+-/
+namespace Zeta.ChildFloor
+
+/-- The capability verdict — the gate's decision. -/
+inductive Verdict where
+  | admit
+  | deny
+  deriving DecidableEq
+
+/-- An effect tree: a leaf effect (its id), or a work effect (its id + the children an Agent
+    proposes for it). The `List Eff` is the `Progressed` cascade. -/
+inductive Eff where
+  | leaf : Nat → Eff
+  | work : Nat → List Eff → Eff
+
+/-- Gate-driven execution, **fuel-bounded** (fuel = the `maxWorkDepth` knob; quantifying over ALL
+    fuel is exactly "at any depth", incl. the unbounded case). Returns the ids that execute. An id
+    is added ONLY in an `admit` branch; a `deny` contributes nothing — neither the node nor its
+    subtree — mirroring `gateAndExecute`/`executeOne` (deny ⇒ Skipped; admit ⇒ run + re-gate each
+    child). -/
+def executed (policy : Nat → Verdict) : Nat → Eff → List Nat
+  | _,     .leaf n   => match policy n with | .admit => [n] | .deny => []
+  | 0,     .work n _ => match policy n with | .admit => [n] | .deny => []
+  | f + 1, .work n cs =>
+      match policy n with
+      | .deny => []
+      | .admit => n :: cs.flatMap (executed policy f)
+  termination_by fuel _ => fuel
+
+/-- **Gate soundness (T1) + headline (T2).** Every executed id was ADMITTED — at any fuel (depth).
+    Structural induction on fuel; the `Progressed` cascade is handled via `List.mem_flatMap` + the
+    induction hypothesis at the smaller fuel. -/
+theorem executed_admit (policy : Nat → Verdict) :
+    ∀ (fuel : Nat) (t : Eff) (id : Nat), id ∈ executed policy fuel t → policy id = .admit := by
+  intro fuel
+  induction fuel with
+  | zero =>
+    intro t id h
+    cases t with
+    | leaf n =>
+      simp only [executed] at h
+      cases hp : policy n <;> simp [hp] at h
+      · subst h; exact hp
+    | work n cs =>
+      simp only [executed] at h
+      cases hp : policy n <;> simp [hp] at h
+      · subst h; exact hp
+  | succ f ih =>
+    intro t id h
+    cases t with
+    | leaf n =>
+      simp only [executed] at h
+      cases hp : policy n <;> simp [hp] at h
+      · subst h; exact hp
+    | work n cs =>
+      simp only [executed] at h
+      cases hp : policy n <;> simp [hp] at h
+      rcases h with rfl | hmem
+      · exact hp
+      · obtain ⟨c, _, hc⟩ := hmem
+        exact ih c id hc
+
+/-- **The child-floor invariant (T2, contrapositive).** A DENIED effect is never executed, at ANY
+    depth — for ANY policy, ANY effect tree, ANY fuel. The Agent proposes; the gate disposes; a
+    proposal grants ZERO execution authority. -/
+theorem denied_never_executed (policy : Nat → Verdict) (fuel : Nat) (t : Eff) (id : Nat)
+    (hd : policy id = .deny) : id ∉ executed policy fuel t := by
+  intro h
+  have hadmit := executed_admit policy fuel t id h
+  rw [hd] at hadmit
+  exact absurd hadmit (by decide)
+
+end Zeta.ChildFloor


### PR DESCRIPTION
The **child-floor invariant** — *"a DENIED effect is never executed at ANY RunWork depth; an Agent cannot get a gated/child-floor-class effect executed by PROPOSING it"* (`source ≠ authorization`, structural) — taken from **tested → proven**.

**Routed to Lean by Soraya** (formal-verification authority): control-flow reachability over a recursive, depth-bounded effect tree → **structural induction**, not interleavings. TLA+/TLC explicitly rejected (would prove only a bounded-depth instance, not the universal "at any depth"); Z3/Alloy wrong-shape.

### Leg A — proof (primary): `tools/lean4/Safety/ChildFloor.lean`
- Model mirrors `Effects.fs`/`SubstrateHandler.fs`: `executed policy fuel t` returns the ids that reach execution; an id is appended **only** in an `admit` branch. **Fuel = the `maxWorkDepth` knob; ∀ fuel = "at any depth"** (incl. unbounded).
- `executed_admit` (T1/T2): every executed id was admitted (induction on fuel; the `Progressed` cascade via `List.mem_flatMap` + IH at smaller fuel).
- `denied_never_executed` (headline): `policy id = deny ⇒ id ∉ executed`, for any policy/tree/fuel.
- **sorry-free**: axioms = `{propext, Quot.sound}` only (no `sorryAx`, no `Classical.choice`).

### Leg B — BP-16 cross-check (empirical): `tests/Tests.FSharp/Formal/ChildFloorCrossVerify.Tests.fs`
FsCheck over the **real `SubstrateEffectHandler`** at random depths/cascades: a denied `PersistFerry` never lands even when a `RunWork` agent proposes it (+ a non-vacuity property: admitted *does* execute). Closes Leg A's model-drift blind spot; triage rule = a counterexample means the **Lean model drifted from the F#**.

### CI
`lean-proof.yml` type-checks `Safety/ChildFloor.lean` + audits its axioms for `sorryAx` (**gated**); the FsCheck leg runs in `dotnet test`. Verified locally: `lake env lean` clean (axioms `{propext, Quot.sound}`); 2 FsCheck properties green.

Follow-on (not this PR): register the pair in `docs/PROVEN-COVERAGE-AND-GAPS.md` so it moves from the denominator (tested) to the numerator (proven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)