### PR TITLE
feat(ObserveBridge): wire EmitResponse — the outbound twin of PersistFerry (reply → response stream)

### DIFF
--- a/src/Core.FSharp.ObserveBridge/SubstrateHandler.fs
+++ b/src/Core.FSharp.ObserveBridge/SubstrateHandler.fs
@@ -27,7 +27,9 @@ open Zeta.Core
 /// **Child-safety floor (load-bearing):** `executeOne` is reached ONLY through `gateAndExecute`'s
 /// `Admit` — at every recursion depth. So a `policy` that denies a gated/child-floor class makes it
 /// *impossible* for the Agent to get such an effect executed by proposing it (it is denied → never
-/// executed). `EmitResponse` / `ExtendGrammar` remain honestly not-wired (Skipped, never silent).
+/// executed). **`EmitResponse`** is the outbound twin of `PersistFerry` (the Agent's reply →
+/// the persona's response stream, attributed `kind="response"`; the operator reads it from there).
+/// `ExtendGrammar` remains honestly not-wired (Skipped, never silent).
 [<Sealed>]
 type SubstrateEffectHandler
     (
@@ -37,7 +39,9 @@ type SubstrateEffectHandler
         ?policy: Effects.Effect -> Effects.Verdict,
         ?ferryType: string,
         ?workRunner: Effects.IWorkRunner,
-        ?maxWorkDepth: int
+        ?maxWorkDepth: int,
+        ?responseSource: unit -> string option,
+        ?responseLog: IDeltaLog<string>
     ) =
 
     let policy = defaultArg policy (fun _ -> Effects.Admit)
@@ -53,13 +57,31 @@ type SubstrateEffectHandler
             | _ -> return Effects.Skipped "PersistFerry: no ferried content on the channel"
         }
 
+    // EmitResponse — the OUTBOUND twin of PersistFerry. The Agent-composed reply (read from
+    // `responseSource`, the bus seam) is appended to this persona's response stream `responseLog`,
+    // attributed `{ kind = "response"; persona }`. The operator reads the reply FROM that durable
+    // stream — so responding stays "behind the DB layer" (no raw bus send). Marker + persona +
+    // gate, symmetric to the inbound ferry. Not wired (no source/log) ⇒ honest Skipped.
+    let emitResponse (ct: CancellationToken) : Task<Effects.EffectResult> =
+        task {
+            match responseSource, responseLog with
+            | Some src, Some log ->
+                match src () with
+                | Some reply when reply <> "" ->
+                    let! _seq =
+                        log.AppendAsync(ZSet.ofSeq [ reply, 1L ], Map.ofList [ "kind", "response"; "persona", persona ], ct).AsTask()
+                    return Effects.Executed
+                | _ -> return Effects.Skipped "EmitResponse: no response to emit"
+            | _ -> return Effects.Skipped "EmitResponse: not wired (no responseSource/responseLog)"
+        }
+
     /// Execute one effect at a given RunWork-nesting `depth`. RunWork's proposed effects re-enter
     /// `gateAndExecute` (inspect→execute) — so the gate guards EVERY depth.
     let rec executeOne (depth: int) (effect: Effects.Effect) (ct: CancellationToken) : Task<Effects.EffectResult> =
         task {
             match effect with
             | Effects.PersistFerry -> return! persistFerry ct
-            | Effects.EmitResponse -> return Effects.Skipped "EmitResponse: not wired in v1 (substrate adapter)"
+            | Effects.EmitResponse -> return! emitResponse ct
             | Effects.ExtendGrammar _ -> return Effects.Skipped "ExtendGrammar: not wired in v1 (substrate adapter)"
             | Effects.RunWork item ->
                 match workRunner with

--- a/tests/Tests.FSharp/Observe/SubstrateHandler.Tests.fs
+++ b/tests/Tests.FSharp/Observe/SubstrateHandler.Tests.fs
@@ -113,3 +113,53 @@ let ``maxWorkDepth bounds runaway RunWork nesting (terminates, no cascade)`` () 
     let h = SubstrateEffectHandler("otto", (fun () -> Some "c"), log, workRunner = runner, maxWorkDepth = 1) :> E.IEffectHandler
     // Terminates (no stack overflow / no infinite loop) and the top-level work ran.
     Assert.Equal(E.Executed, (E.runAsync h (E.RunWork(item "w")) ct).Result)
+
+
+// ── EmitResponse — the outbound twin of PersistFerry (reply → persona response stream) ──────
+let private responseEntries (log: IDeltaLog<string>) = ferryContents log
+
+[<Fact>]
+let ``EmitResponse appends the Agent reply to the persona response stream, attributed kind=response`` () =
+    let rlog = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let h =
+        SubstrateEffectHandler("otto", (fun () -> None), (InMemoryDeltaLog<string>() :> IDeltaLog<string>),
+                               responseSource = (fun () -> Some "here is my reply"), responseLog = rlog)
+        :> E.IEffectHandler
+    Assert.Equal(E.Executed, (E.runAsync h E.EmitResponse ct).Result)
+    Assert.Equal<string list>([ "here is my reply" ], responseEntries rlog)
+    let captured = (rlog.ReplayAsync(0L, ct).AsTask().Result).[0].Captured
+    Assert.Equal(Some "response", Map.tryFind "kind" captured)
+    Assert.Equal(Some "otto", Map.tryFind "persona" captured)
+
+[<Fact>]
+let ``EmitResponse with no reply skips and sends nothing`` () =
+    let rlog = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let h =
+        SubstrateEffectHandler("otto", (fun () -> None), (InMemoryDeltaLog<string>() :> IDeltaLog<string>),
+                               responseSource = (fun () -> None), responseLog = rlog)
+        :> E.IEffectHandler
+    match (E.runAsync h E.EmitResponse ct).Result with
+    | E.Skipped _ -> ()
+    | other -> failwithf "expected Skipped, got %A" other
+    Assert.Empty(responseEntries rlog)
+
+[<Fact>]
+let ``EmitResponse not wired (no responseSource/Log) is honestly skipped`` () =
+    let h = SubstrateEffectHandler("otto", (fun () -> None), (InMemoryDeltaLog<string>() :> IDeltaLog<string>)) :> E.IEffectHandler
+    match (E.runAsync h E.EmitResponse ct).Result with
+    | E.Skipped _ -> ()
+    | other -> failwithf "expected Skipped, got %A" other
+
+[<Fact>]
+let ``a DENIED EmitResponse never reaches the response stream (inspect-before-execute)`` () =
+    let rlog = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let denyResponse =
+        function
+        | E.EmitResponse -> E.Deny "responses gated"
+        | _ -> E.Admit
+    let h =
+        SubstrateEffectHandler("otto", (fun () -> None), (InMemoryDeltaLog<string>() :> IDeltaLog<string>),
+                               policy = denyResponse, responseSource = (fun () -> Some "should NOT send"), responseLog = rlog)
+        :> E.IEffectHandler
+    (E.runAsync h E.EmitResponse ct).Result |> ignore
+    Assert.Empty(responseEntries rlog)


### PR DESCRIPTION
`EmitResponse` is the **outbound symmetric twin** of the inbound ferry: the Agent-composed reply (read from `responseSource`, the bus seam) is appended to this persona's **response stream** (`responseLog : IDeltaLog<string>`; a `GitDeltaLog` for git durability), attributed `{ kind="response"; persona }`. The operator reads the reply **from that durable stream** — responding stays *behind the DB layer* (no raw bus send).

Same marker + persona + gate shape as `PersistFerry`; goes through **inspect-before-execute** (a denied response never reaches the stream — the child-floor property applies here too). Not wired (no source/log) → honest `Skipped`.

`SubstrateEffectHandler` gains `?responseSource` + `?responseLog`. **13 effect tests** (4 ferry + 5 RunWork + 4 EmitResponse: executed + attributed `kind=response`; no-reply skip; not-wired skip; **denied-never-sent**). 22 git tests still green. `ExtendGrammar` is the last unwired effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)