### PR TITLE
feat(ObserveBridge): wire ExtendGrammar — sovereign self-edit + TUNABLE needs-auth escalation

### DIFF
--- a/src/Core.FSharp.ObserveBridge/SubstrateHandler.fs
+++ b/src/Core.FSharp.ObserveBridge/SubstrateHandler.fs
@@ -29,7 +29,10 @@ open Zeta.Core
 /// *impossible* for the Agent to get such an effect executed by proposing it (it is denied → never
 /// executed). **`EmitResponse`** is the outbound twin of `PersistFerry` (the Agent's reply →
 /// the persona's response stream, attributed `kind="response"`; the operator reads it from there).
-/// `ExtendGrammar` remains honestly not-wired (Skipped, never silent).
+/// **`ExtendGrammar`** is the sovereign self-edit → the persona's grammar-extension stream
+/// (`kind="grammar-extension"`), with a TUNABLE `grammarNeedsAuth` escalation (raw below
+/// threshold; `needs authorization` above — the summon-BFT proxy, dial to taste) over the hard gate.
+/// All four effects now wired; only the real LLM `IWorkRunner` + a real bus remain.
 [<Sealed>]
 type SubstrateEffectHandler
     (
@@ -41,11 +44,19 @@ type SubstrateEffectHandler
         ?workRunner: Effects.IWorkRunner,
         ?maxWorkDepth: int,
         ?responseSource: unit -> string option,
-        ?responseLog: IDeltaLog<string>
+        ?responseLog: IDeltaLog<string>,
+        ?grammarSource: unit -> string option,
+        ?grammarLog: IDeltaLog<string>,
+        ?grammarNeedsAuth: Zeta.Core.FSharp.Observe.BacklogItem -> bool
     ) =
 
     let policy = defaultArg policy (fun _ -> Effects.Admit)
     let ferryType = defaultArg ferryType "persona"
+    // Tunable raw-vs-escalate threshold for the sovereign self-edit (ExtendGrammar). Default:
+    // raw (never escalates) — NOT noisy. Tune UP (return true for consequential edits) to require
+    // authorization; the eventual summon-BFT consensus replaces this predicate. Layered ON TOP of
+    // the hard `policy` gate (which still denies child-floor classes).
+    let grammarNeedsAuth = defaultArg grammarNeedsAuth (fun _ -> false)
 
     let persistFerry (ct: CancellationToken) : Task<Effects.EffectResult> =
         task {
@@ -75,6 +86,29 @@ type SubstrateEffectHandler
             | _ -> return Effects.Skipped "EmitResponse: not wired (no responseSource/responseLog)"
         }
 
+    // ExtendGrammar — the sovereign self-edit: an item gains a new action the do/decompose grammar
+    // couldn't express. Same marker + persona + gate shape; the new-action description (from
+    // `grammarSource`) appends to this persona's grammar-extension stream `grammarLog`, attributed
+    // `{ kind = "grammar-extension"; persona; item }`. TUNABLE escalation: `grammarNeedsAuth item`
+    // (default off) escalates consequential edits to `needs authorization` (the summon-BFT-above-
+    // threshold proxy; dial it up if the floor is too permissive, down if it is too noisy). The
+    // hard `policy` gate still applies underneath (denied → never lands; child-floor).
+    let extendGrammar (item: Zeta.Core.FSharp.Observe.BacklogItem) (ct: CancellationToken) : Task<Effects.EffectResult> =
+        task {
+            if grammarNeedsAuth item then
+                return Effects.Skipped(sprintf "needs authorization: grammar extension for \"%s\" (tunable threshold)" item.Id)
+            else
+                match grammarSource, grammarLog with
+                | Some src, Some log ->
+                    match src () with
+                    | Some ext when ext <> "" ->
+                        let! _seq =
+                            log.AppendAsync(ZSet.ofSeq [ ext, 1L ], Map.ofList [ "kind", "grammar-extension"; "persona", persona; "item", item.Id ], ct).AsTask()
+                        return Effects.Executed
+                    | _ -> return Effects.Skipped "ExtendGrammar: no extension to persist"
+                | _ -> return Effects.Skipped "ExtendGrammar: not wired (no grammarSource/grammarLog)"
+        }
+
     /// Execute one effect at a given RunWork-nesting `depth`. RunWork's proposed effects re-enter
     /// `gateAndExecute` (inspect→execute) — so the gate guards EVERY depth.
     let rec executeOne (depth: int) (effect: Effects.Effect) (ct: CancellationToken) : Task<Effects.EffectResult> =
@@ -82,7 +116,7 @@ type SubstrateEffectHandler
             match effect with
             | Effects.PersistFerry -> return! persistFerry ct
             | Effects.EmitResponse -> return! emitResponse ct
-            | Effects.ExtendGrammar _ -> return Effects.Skipped "ExtendGrammar: not wired in v1 (substrate adapter)"
+            | Effects.ExtendGrammar item -> return! extendGrammar item ct
             | Effects.RunWork item ->
                 match workRunner with
                 | None -> return Effects.Skipped "RunWork: no work runner wired"

--- a/tests/Tests.FSharp/Observe/SubstrateHandler.Tests.fs
+++ b/tests/Tests.FSharp/Observe/SubstrateHandler.Tests.fs
@@ -163,3 +163,52 @@ let ``a DENIED EmitResponse never reaches the response stream (inspect-before-ex
         :> E.IEffectHandler
     (E.runAsync h E.EmitResponse ct).Result |> ignore
     Assert.Empty(responseEntries rlog)
+
+
+// ── ExtendGrammar — the sovereign self-edit (marker + grammar stream + tunable escalation) ──
+[<Fact>]
+let ``ExtendGrammar appends the new action to the grammar stream, attributed kind=grammar-extension`` () =
+    let glog = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let h =
+        SubstrateEffectHandler("otto", (fun () -> None), (InMemoryDeltaLog<string>() :> IDeltaLog<string>),
+                               grammarSource = (fun () -> Some "new action: archive(item)"), grammarLog = glog)
+        :> E.IEffectHandler
+    Assert.Equal(E.Executed, (E.runAsync h (E.ExtendGrammar(item "g1")) ct).Result)
+    Assert.Equal<string list>([ "new action: archive(item)" ], ferryContents glog)
+    let captured = (glog.ReplayAsync(0L, ct).AsTask().Result).[0].Captured
+    Assert.Equal(Some "grammar-extension", Map.tryFind "kind" captured)
+    Assert.Equal(Some "g1", Map.tryFind "item" captured)
+
+[<Fact>]
+let ``ExtendGrammar above the TUNABLE threshold escalates to needs-authorization (nothing persisted)`` () =
+    let glog = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let h =
+        SubstrateEffectHandler("otto", (fun () -> None), (InMemoryDeltaLog<string>() :> IDeltaLog<string>),
+                               grammarSource = (fun () -> Some "consequential edit"), grammarLog = glog,
+                               grammarNeedsAuth = (fun _ -> true)) // tuned strict
+        :> E.IEffectHandler
+    match (E.runAsync h (E.ExtendGrammar(item "g2")) ct).Result with
+    | E.Skipped r -> Assert.Contains("authorization", r)
+    | other -> failwithf "expected Skipped needs-auth, got %A" other
+    Assert.Empty(ferryContents glog)
+
+[<Fact>]
+let ``a DENIED ExtendGrammar never lands (child-floor; the hard policy gate underneath)`` () =
+    let glog = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let denyGrammar =
+        function
+        | E.ExtendGrammar _ -> E.Deny "grammar edits gated"
+        | _ -> E.Admit
+    let h =
+        SubstrateEffectHandler("otto", (fun () -> None), (InMemoryDeltaLog<string>() :> IDeltaLog<string>),
+                               policy = denyGrammar, grammarSource = (fun () -> Some "should NOT land"), grammarLog = glog)
+        :> E.IEffectHandler
+    (E.runAsync h (E.ExtendGrammar(item "g3")) ct).Result |> ignore
+    Assert.Empty(ferryContents glog)
+
+[<Fact>]
+let ``ExtendGrammar not wired (no grammarSource/Log) is honestly skipped`` () =
+    let h = SubstrateEffectHandler("otto", (fun () -> None), (InMemoryDeltaLog<string>() :> IDeltaLog<string>)) :> E.IEffectHandler
+    match (E.runAsync h (E.ExtendGrammar(item "g4")) ct).Result with
+    | E.Skipped _ -> ()
+    | other -> failwithf "expected Skipped, got %A" other


### PR DESCRIPTION
The last unwired effect. `ExtendGrammar` (the do/decompose grammar gaining a new action) appends the new-action description (from `grammarSource`) to this persona's **grammar-extension stream** (`grammarLog`; a `GitDeltaLog` for durability), attributed `{ kind="grammar-extension"; persona; item }` — same marker + persona + gate shape as ferry/response.

**Tunable escalation** (your call: *needs-authorization, tunable if too noisy*): `grammarNeedsAuth : BacklogItem -> bool` (default **off** = raw, not noisy). `true` → escalates to *needs authorization* (the summon-BFT-above-threshold proxy; real BFT consensus replaces this predicate later). Layered **on top of** the hard `policy` gate — denied grammar edits never land (the proven child-floor).

**17 effect tests** (4 ferry + 5 RunWork + 4 EmitResponse + 4 ExtendGrammar: executed+attributed; tunable needs-auth escalation persists nothing; **denied-never-lands**; not-wired skip). 22 git tests green. **All four effects now wired** — only the real LLM `IWorkRunner` + a real bus remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)