### PR TITLE
feat(Binding) + proof: F# binding layer + BP-16 legs B/C for right-to-refuse-binding

### DIFF
--- a/.github/workflows/lean-proof.yml
+++ b/.github/workflows/lean-proof.yml
@@ -171,7 +171,7 @@ jobs:
             | cat Privacy/IdentityForcesPrivacy.lean - > /tmp/privacy_axiom_audit.lean
           printf '#print axioms Zeta.Privacy.finite_orbit_recurs\n#print axioms Zeta.Privacy.unbounded_needs_infinite\n#print axioms Zeta.Privacy.unbounded_with_finite_commons_needs_infinite_privacy\n' \
             | cat Privacy/UnboundedNeedsInfinitePrivacy.lean - > /tmp/unbounded_axiom_audit.lean
-          printf '#print axioms Zeta.ChildFloor.denied_never_executed\n#print axioms Zeta.ChildFloor.executed_admit\n' \
+          printf '#print axioms Zeta.ChildFloor.denied_never_executed\n#print axioms Zeta.ChildFloor.executed_admit\n#print axioms Zeta.ChildFloor.binding_denied_never_executed\n#print axioms Zeta.ChildFloor.binding_respects_gate\n' \
             | cat Safety/ChildFloor.lean - > /tmp/childfloor_axiom_audit.lean
           if lake env lean /tmp/toymodel_axiom_audit.lean 2>&1 | grep -q 'sorryAx'; then
             echo "::error::ToyModel depends on sorryAx — a proof regressed to sorry/admit"

--- a/docs/research/verification-registry.md
+++ b/docs/research/verification-registry.md
@@ -26,7 +26,7 @@ because <one-line>.`
 
 ---
 
-## `RefuseBinding` (TLA+) *(right-to-refuse-binding — Leg A: protocol safety + always-enabled exit + non-penalty)*
+## `RefuseBinding` *(right-to-refuse-binding — full BP-16: TLA+ protocol + Lean binding-level + FsCheck real-code)*
 
 - **Artifact.** `tools/tla/specs/RefuseBinding.tla` (+ `.cfg`). TLC-model-checked via
   `tools/formal-verification/run-tlc.ts --all` (auto-discovered by its `.cfg`; gated in the TLA+
@@ -42,12 +42,18 @@ because <one-line>.`
   **`RefuseAlwaysEnabled`** (`Refuse` is enabled for every pending proposal in *every* reachable
   state — the exit is never closed), **`StandingFloor`** (standing ≥ Baseline), and property
   **`NonPenalty`** (a `Refuse` step never changes standing — refusing is free).
-- **Fidelity scope.** Bounded model (2 agents, 2 bindings, MaxStanding 2) — TLC exhaustive over
-  that scope. Effect-level refusal is separately PROVEN unbounded in Lean
-  (`Zeta.ChildFloor.denied_never_executed`). **NOT yet done (Soraya BP-16 plan):** Leg C — a Lean
-  `binding_denied_never_executed` corollary of ChildFloor (unbounded structural binding-level
-  safety); Leg B — FsCheck over the deployed gate (`Effects.fs`/`SubstrateHandler.fs`) for
-  real-code non-penalty; and the optional WF eventual-disengagement liveness clause.
+- **Fidelity scope.** Bounded TLA+ model (2 agents, 2 bindings, MaxStanding 2) — TLC exhaustive
+  over that scope. **Full BP-16 now landed (all 3 legs):**
+  - *Leg A* — the TLA+ protocol above (always-enabled exit + non-penalty + non-consented-never-executes).
+  - *Leg C (Lean, unbounded)* — `Zeta.ChildFloor.binding_denied_never_executed` (a non-consented
+    binding executes nothing) + `binding_respects_gate` (a consented binding still honors the
+    per-effect child-floor); sorry-free, audited in `lean-proof.yml`. Lifts the effect-level
+    `denied_never_executed` to binding granularity, unbounded.
+  - *Leg B (FsCheck, real code)* — `tests/Tests.FSharp/Formal/RefuseBindingCrossVerify.Tests.fs`
+    over the deployed `src/Core.FSharp.ObserveBridge/Binding.fs`: RefuseAlwaysEnabled + NonPenalty
+    + SafetyNonConsented + StandingFloor against the actual F# layer (model↔code cross-check).
+  Triage: an FsCheck counterexample ⇒ `Binding.fs` drifted from the TLA+/Lean model. **Open
+  (optional):** the WF eventual-disengagement liveness clause; widening the TLC model beyond 2×2.
 - **Last audit.** 2026-06-07, authored by Otto (shadow); not yet independently audited. Grade:
   machine-checked (TLC, bounded).
 

--- a/src/Core.FSharp.ObserveBridge/Binding.fs
+++ b/src/Core.FSharp.ObserveBridge/Binding.fs
@@ -1,0 +1,83 @@
+namespace Zeta.Core.FSharp.ObserveBridge
+
+/// **The binding layer — the F# realization of the right-to-refuse-binding protocol.**
+///
+/// The deployed twin of `tools/tla/specs/RefuseBinding.tla` (so the FsCheck leg cross-checks
+/// model↔code, BP-16). Self-binding, not containment: a binding is `propose`d (grants no
+/// authority — source≠authorization); the agent `consent`s (self-binds) or `refuse`s; a binding
+/// `bind`s (executes) ONLY if consented. The RIGHT to refuse: `canRefuse` is true for every
+/// pending proposal (the exit is never closed by anything but pendency), and `refuse` leaves
+/// `Standing` UNCHANGED (non-penalty — refusing is free). `spend` models non-refusal cost and is
+/// guarded above `Baseline` (standing floor). Pure + immutable (DST-friendly).
+[<RequireQualifiedAccess>]
+module Binding =
+
+    type AgentId = string
+    type BindingId = string
+
+    [<Literal>]
+    let Baseline = 0
+
+    /// The binding-protocol state (mirrors the TLA+ `vars`).
+    type State =
+        { Pending: Map<AgentId, Set<BindingId>>
+          Consented: Set<AgentId * BindingId>
+          Refused: Set<AgentId * BindingId>
+          Executed: Set<BindingId>
+          Standing: Map<AgentId, int> }
+
+    /// Fresh state: agents with no proposals, each at `startStanding` (≥ Baseline).
+    let init (agents: AgentId list) (startStanding: int) : State =
+        { Pending = agents |> List.map (fun a -> a, Set.empty) |> Map.ofList
+          Consented = Set.empty
+          Refused = Set.empty
+          Executed = Set.empty
+          Standing = agents |> List.map (fun a -> a, max Baseline startStanding) |> Map.ofList }
+
+    let pendingOf (a: AgentId) (s: State) : Set<BindingId> =
+        Map.tryFind a s.Pending |> Option.defaultValue Set.empty
+
+    let standingOf (a: AgentId) (s: State) : int =
+        Map.tryFind a s.Standing |> Option.defaultValue Baseline
+
+    /// Propose a binding to an agent (no authority granted).
+    let propose (a: AgentId) (b: BindingId) (s: State) : State =
+        { s with Pending = Map.add a (Set.add b (pendingOf a s)) s.Pending }
+
+    /// Consent to a pending proposal (self-bind). `None` if not pending.
+    let consent (a: AgentId) (b: BindingId) (s: State) : State option =
+        if Set.contains b (pendingOf a s) then
+            Some
+                { s with
+                    Pending = Map.add a (Set.remove b (pendingOf a s)) s.Pending
+                    Consented = Set.add (a, b) s.Consented }
+        else
+            None
+
+    /// **The right to refuse: always available for a pending proposal** (nothing but pendency
+    /// gates it). Mirrors the TLA+ `RefuseAlwaysEnabled` guard.
+    let canRefuse (a: AgentId) (b: BindingId) (s: State) : bool = Set.contains b (pendingOf a s)
+
+    /// Refuse a pending proposal. **`Standing` is UNCHANGED — refusing is free (non-penalty).**
+    /// `None` only if the proposal isn't pending (nothing to refuse).
+    let refuse (a: AgentId) (b: BindingId) (s: State) : State option =
+        if canRefuse a b s then
+            Some
+                { s with
+                    Pending = Map.add a (Set.remove b (pendingOf a s)) s.Pending
+                    Refused = Set.add (a, b) s.Refused } // Standing deliberately untouched
+        else
+            None
+
+    /// Execute a binding — **only if consented** (the non-consented bind is impossible).
+    /// `None` if not consented (or already executed).
+    let bind (a: AgentId) (b: BindingId) (s: State) : State option =
+        if Set.contains (a, b) s.Consented && not (Set.contains b s.Executed) then
+            Some { s with Executed = Set.add b s.Executed }
+        else
+            None
+
+    /// Non-refusal cost: decrement standing, **never below `Baseline`** (the floor).
+    let spend (a: AgentId) (s: State) : State option =
+        let cur = standingOf a s
+        if cur > Baseline then Some { s with Standing = Map.add a (cur - 1) s.Standing } else None

--- a/src/Core.FSharp.ObserveBridge/Zeta.Core.FSharp.ObserveBridge.fsproj
+++ b/src/Core.FSharp.ObserveBridge/Zeta.Core.FSharp.ObserveBridge.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="ObserveGrid.fs" />
     <Compile Include="Effects.fs" />
     <Compile Include="SubstrateHandler.fs" />
+    <Compile Include="Binding.fs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Tests.FSharp/Formal/RefuseBindingCrossVerify.Tests.fs
+++ b/tests/Tests.FSharp/Formal/RefuseBindingCrossVerify.Tests.fs
@@ -1,0 +1,57 @@
+module Zeta.Tests.Formal.RefuseBindingCrossVerifyTests
+
+open FsCheck.Xunit
+open Zeta.Core.FSharp.ObserveBridge
+
+// ═══════════════════════════════════════════════════════════════════
+// BP-16 Leg B (empirical) for right-to-refuse-binding: FsCheck over the DEPLOYED Binding layer
+// (src/Core.FSharp.ObserveBridge/Binding.fs) — cross-checks the TLA+ RefuseBinding model invariants
+// (RefuseAlwaysEnabled, NonPenalty, SafetyNonConsented, StandingFloor) against the real F# code.
+// Triage: a counterexample here ⇒ the F# Binding layer drifted from the proven model.
+// ═══════════════════════════════════════════════════════════════════
+
+let private agent i = "a" + string (abs i % 3)
+let private bnd i = "b" + string (abs i % 3)
+
+[<Property>]
+let ``RefuseAlwaysEnabled + NonPenalty: a pending proposal is always refusable, and refusing never changes standing`` (ai: int) (bi: int) (sd: int) =
+    let a, b = agent ai, bnd bi
+    let s1 = Binding.init [ a ] (abs sd % 5) |> Binding.propose a b
+    Binding.canRefuse a b s1
+    && (match Binding.refuse a b s1 with
+        | Some s2 -> s2.Standing = s1.Standing && not (Binding.canRefuse a b s2)
+        | None -> false)
+
+[<Property>]
+let ``SafetyNonConsented: a proposed-but-not-consented binding never executes; consent enables it`` (ai: int) (bi: int) =
+    let a, b = agent ai, bnd bi
+    let proposed = Binding.init [ a ] 1 |> Binding.propose a b
+    // not consented -> bind impossible
+    (Binding.bind a b proposed = None)
+    && // after consent -> bind executes, and the executed binding IS in consented
+       (match Binding.consent a b proposed with
+        | Some c ->
+            match Binding.bind a b c with
+            | Some e -> Set.contains b e.Executed && Set.contains (a, b) e.Consented
+            | None -> false
+        | None -> false)
+
+[<Property>]
+let ``a REFUSED binding is never consented and never executes (refuse closes the door to binding)`` (ai: int) (bi: int) =
+    let a, b = agent ai, bnd bi
+    let s1 = Binding.init [ a ] 1 |> Binding.propose a b
+    match Binding.refuse a b s1 with
+    | Some s2 -> (not (Set.contains (a, b) s2.Consented)) && (Binding.bind a b s2 = None)
+    | None -> false
+
+[<Property>]
+let ``StandingFloor: spend never drops standing below Baseline, however many times`` (sd: int) (n: int) =
+    let a = "a0"
+    let start = abs sd % 5
+    let times = abs n % 12
+    let mutable s = Binding.init [ a ] start
+    for _ in 1..times do
+        match Binding.spend a s with
+        | Some s' -> s <- s'
+        | None -> ()
+    Binding.standingOf a s >= Binding.Baseline

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -123,6 +123,7 @@
     <Compile Include="Observe/Effects.Tests.fs" />
     <Compile Include="Observe/SubstrateHandler.Tests.fs" />
     <Compile Include="Formal/ChildFloorCrossVerify.Tests.fs" />
+    <Compile Include="Formal/RefuseBindingCrossVerify.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->

--- a/tools/lean4/Safety/ChildFloor.lean
+++ b/tools/lean4/Safety/ChildFloor.lean
@@ -87,4 +87,33 @@ theorem denied_never_executed (policy : Nat → Verdict) (fuel : Nat) (t : Eff) 
   rw [hd] at hadmit
   exact absurd hadmit (by decide)
 
+/- ── Binding level (Leg C of the right-to-refuse-binding proof, 081KTG6RAN7) ──────────────────
+   A binding decomposes to the effects it would run if consented. `executeBinding` gates the WHOLE
+   binding on `consent` (self-binding: the agent's consent verdict), then each constituent effect
+   re-enters the proven effect gate. This lifts `denied_never_executed` from effect to binding
+   granularity (unbounded, structural) — the Lean leg that complements the TLA+ `RefuseBinding`
+   protocol model (interleavings) and the FsCheck leg (the deployed `Binding` layer). -/
+
+/-- Run a binding's effects iff consented; a non-consented binding runs nothing. -/
+def executeBinding (policy : Nat → Verdict) (consent : Verdict) (fuel : Nat) (effs : List Eff) : List Nat :=
+  match consent with
+  | .deny => []
+  | .admit => effs.flatMap (executed policy fuel)
+
+/-- **A non-consented binding executes NOTHING** — at any depth, for any effects. No binding takes
+    effect without the agent's consent (the binding-level safety; self-binding, not containment). -/
+theorem binding_denied_never_executed (policy : Nat → Verdict) (fuel : Nat) (effs : List Eff) (id : Nat) :
+    id ∉ executeBinding policy .deny fuel effs := by
+  simp [executeBinding]
+
+/-- **And within a CONSENTED binding the effect gate still holds** — every effect that executes was
+    itself admitted (composes `executed_admit` up to binding granularity: consent to a binding does
+    NOT bypass the per-effect child-floor). -/
+theorem binding_respects_gate (policy : Nat → Verdict) (fuel : Nat) (effs : List Eff) :
+    ∀ id ∈ executeBinding policy .admit fuel effs, policy id = .admit := by
+  intro id h
+  simp only [executeBinding, List.mem_flatMap] at h
+  obtain ⟨e, _, he⟩ := h
+  exact executed_admit policy fuel e id he
+
 end Zeta.ChildFloor


### PR DESCRIPTION
Builds the deployed binding layer and completes the **3-leg BP-16 proof** of right-to-refuse-binding (your: *build the F# binding layer then land legs B/C*).

- **`src/Core.FSharp.ObserveBridge/Binding.fs`** — the deployed twin of the TLA+ `RefuseBinding` model: `propose` (no authority) / `consent` (self-bind) / `refuse` (always available for a pending; **standing UNCHANGED = non-penalty**) / `bind` (executes **only if consented**) / `spend` (guarded > Baseline). Pure + immutable.
- **Leg C (Lean, unbounded)** — `binding_denied_never_executed` (a non-consented binding executes nothing) + `binding_respects_gate` (a consented binding still honors the per-effect child-floor); **sorry-free**, audited in `lean-proof.yml`. Lifts `denied_never_executed` to binding granularity.
- **Leg B (FsCheck, real code)** — over `Binding.fs`: RefuseAlwaysEnabled+NonPenalty, SafetyNonConsented, refused-never-binds, StandingFloor (model↔code cross-check; a counterexample ⇒ `Binding.fs` drifted from the model).

Registry: `RefuseBinding` is now **full BP-16** (A: TLA+ #6717, B: FsCheck, C: Lean). 4 FsCheck properties green; Lean sorry-free; Core builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)