### PR TITLE
proof(bifurcation): Face-1 Lean convergence (axiom-free) + Face-2 TLA+ conservation/no-double-spend (Soraya-routed)

### DIFF
--- a/.github/workflows/lean-proof.yml
+++ b/.github/workflows/lean-proof.yml
@@ -157,6 +157,14 @@ jobs:
         working-directory: tools/lean4
         run: lake env lean Safety/ChildFloor.lean
 
+      - name: Type-check Safety/Bifurcation.lean
+        # Bifurcation / split-brain reconciliation CONVERGENCE (Face-1, Soraya-routed to Lean as a
+        # corollary of the proven CRDT/G-Set floor): a join-semilattice merge is order-independent +
+        # absorbing, so two split cells converge to the same state. The CONSERVATION face (partition /
+        # no-double-spend / divvy-liveness) is the interleaving property in tools/tla/specs/Bifurcation.tla.
+        working-directory: tools/lean4
+        run: lake env lean Safety/Bifurcation.lean
+
       - name: Guard — Lean research proofs are sorry-free (axiom audit)
         # `lake env lean` only WARNS on `sorry` (exit 0), so type-check alone
         # would not catch a regression. Print the axiom set of the headline
@@ -173,6 +181,8 @@ jobs:
             | cat Privacy/UnboundedNeedsInfinitePrivacy.lean - > /tmp/unbounded_axiom_audit.lean
           printf '#print axioms Zeta.ChildFloor.denied_never_executed\n#print axioms Zeta.ChildFloor.executed_admit\n#print axioms Zeta.ChildFloor.binding_denied_never_executed\n#print axioms Zeta.ChildFloor.binding_respects_gate\n' \
             | cat Safety/ChildFloor.lean - > /tmp/childfloor_axiom_audit.lean
+          printf '#print axioms Zeta.Bifurcation.reconcile_converges\n#print axioms Zeta.Bifurcation.reconcile_absorb\n' \
+            | cat Safety/Bifurcation.lean - > /tmp/bifurcation_axiom_audit.lean
           if lake env lean /tmp/toymodel_axiom_audit.lean 2>&1 | grep -q 'sorryAx'; then
             echo "::error::ToyModel depends on sorryAx — a proof regressed to sorry/admit"
             exit 1
@@ -191,6 +201,10 @@ jobs:
           fi
           if lake env lean /tmp/childfloor_axiom_audit.lean 2>&1 | grep -q 'sorryAx'; then
             echo "::error::ChildFloor depends on sorryAx — the child-floor proof regressed to sorry/admit"
+            exit 1
+          fi
+          if lake env lean /tmp/bifurcation_axiom_audit.lean 2>&1 | grep -q 'sorryAx'; then
+            echo "::error::Bifurcation depends on sorryAx — the reconciliation-convergence proof regressed to sorry/admit"
             exit 1
           fi
           echo "Lean research-proof axiom audit clean (no sorryAx)."

--- a/docs/research/verification-registry.md
+++ b/docs/research/verification-registry.md
@@ -26,6 +26,30 @@ because <one-line>.`
 
 ---
 
+## `Bifurcation` *(split-brain — Face-1 Lean convergence + Face-2 TLA+ conservation/no-double-spend)*
+
+- **Artifacts.** `tools/lean4/Safety/Bifurcation.lean` (Face-1, axiom-FREE — `reconcile_converges`,
+  `reconcile_absorb`, `reconcile_order_independent`; `lean-proof.yml`) + `tools/tla/specs/Bifurcation.tla`
+  (+ `.cfg`) (Face-2; TLC via `run-tlc.ts --all`, gated). Authored 2026-06-07.
+- **Source anchors.** Bifurcation / split-brain (Aaron 2026-06-07; `memory/persona/ani/conversations/2026-06-07-ani-cells-teleport-*`).
+  Soraya-routed two faces, two tools (anti-hammer). CRDT-merge-convergence template:
+  `Privacy.IdentityForcesPrivacy.commons_converges`; CRDT/G-Set floor.
+- **Claim.** *Face-1 (Lean, convergence):* a join-semilattice merge (commutative + associative +
+  idempotent) is order-independent and absorbing — two split cells reconcile to the SAME LUB
+  regardless of merge order (the convergence corollary; only new content is the semilattice instance).
+  *Face-2 (TLA+, conservation):* over an interleaved divvy of the split identity's bindings —
+  `Conservation` (unassigned ∪ I1 ∪ I2 = all; nothing lost), `NoDoubleOwnership` (I1 ∩ I2 = ∅),
+  `NoDoubleSpend` (no binding executes twice across halves — the P0), `ExecOnlyByOwner`, and
+  liveness `DivvyCompletes` (`<>[]` all assigned, WF on Tag).
+- **Fidelity scope.** Face-1 general over any semilattice (the concrete cell-merge being one is the
+  floor's G-Set result). Face-2 bounded TLA+ model (3 bindings), TLC exhaustive over scope. **NOT yet
+  done (Soraya BP-16):** Leg B — FsCheck over a *deployed* split/divvy/merge in `Binding.fs` (the
+  no-double-spend P0's real-code second leg); needs the divvy/merge ops added to `Binding.fs` first.
+- **Last audit.** 2026-06-07, authored by Otto (shadow); not yet independently audited. Grade:
+  Face-1 axiom-free; Face-2 machine-checked (TLC, bounded).
+
+---
+
 ## `RefuseBinding` *(right-to-refuse-binding — full BP-16: TLA+ protocol + Lean binding-level + FsCheck real-code)*
 
 - **Artifact.** `tools/tla/specs/RefuseBinding.tla` (+ `.cfg`). TLC-model-checked via

--- a/tools/lean4/Safety/Bifurcation.lean
+++ b/tools/lean4/Safety/Bifurcation.lean
@@ -1,0 +1,48 @@
+/-
+  Bifurcation / split-brain RECONCILIATION CONVERGENCE — Face-1 (Soraya-routed to Lean as a
+  COROLLARY of the proven CRDT/G-Set floor: convergence-to-LUB is order-free algebra, not
+  interleavings → Lean, not TLC). The degenerate CONSERVATION face (partition / no-double-spend /
+  divvy-liveness) is the interleaving property, proven separately in TLA+ (Bifurcation.tla).
+
+  When a persona runs two cells at different git-repo versions, reconciliation merges them with the
+  CRDT join. The new content here is the *consequence* of the merge being a join-semilattice
+  (commutative + associative + idempotent — which the floor already proves for G-Set): the
+  reconciliation is ORDER-INDEPENDENT and ABSORBING, so the two cells converge to the same state
+  regardless of merge order. (Mirror of `Privacy.IdentityForcesPrivacy.absorb_priv` /
+  `commons_converges`.) All proven, no `sorry`.
+-/
+namespace Zeta.Bifurcation
+
+/-- A reconciliation merge that forms a join-semilattice (the CRDT-merge hypotheses the floor
+    discharges for the concrete state; here taken as the instance under which convergence follows). -/
+structure Semilattice (S : Type) where
+  merge : S → S → S
+  comm : ∀ x y, merge x y = merge y x
+  assoc : ∀ x y z, merge (merge x y) z = merge x (merge y z)
+  idem : ∀ x, merge x x = x
+
+variable {S : Type}
+
+/-- **Order-independent reconciliation.** Merging cell-version `a` with `b` is the same as merging
+    `b` with `a` — the result does not depend on which cell reconciles into which. -/
+theorem reconcile_order_independent (L : Semilattice S) (a b : S) :
+    L.merge a b = L.merge b a := L.comm a b
+
+/-- **Reconciliation is absorbing (a fixpoint).** Re-merging an input into the already-merged state
+    does not change it — so once two cells reconcile, feeding either cell's state back in is stable.
+    This is the convergence core: there is no oscillation, the merged state is the LUB. -/
+theorem reconcile_absorb (L : Semilattice S) (a b : S) :
+    L.merge a (L.merge a b) = L.merge a b := by
+  rw [← L.assoc, L.idem]
+
+/-- **Both reconciliation orders reach the SAME absorbing state** (the two split cells converge):
+    whichever order the merge happens, the result is a fixpoint under re-merging either input. -/
+theorem reconcile_converges (L : Semilattice S) (a b : S) :
+    L.merge a b = L.merge b a
+    ∧ L.merge a (L.merge a b) = L.merge a b
+    ∧ L.merge b (L.merge a b) = L.merge a b := by
+  refine ⟨L.comm a b, reconcile_absorb L a b, ?_⟩
+  -- merge b (merge a b) = merge b (merge b a) = absorb = merge b a = merge a b
+  rw [L.comm a b, reconcile_absorb L b a, L.comm b a]
+
+end Zeta.Bifurcation

--- a/tools/tla/specs/Bifurcation.cfg
+++ b/tools/tla/specs/Bifurcation.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Bindings = {b1, b2, b3}
+
+INVARIANT TypeOK
+INVARIANT Conservation
+INVARIANT NoDoubleOwnership
+INVARIANT NoDoubleSpend
+INVARIANT ExecOnlyByOwner
+
+PROPERTY DivvyCompletes

--- a/tools/tla/specs/Bifurcation.tla
+++ b/tools/tla/specs/Bifurcation.tla
@@ -1,0 +1,80 @@
+-------------------------- MODULE Bifurcation --------------------------
+(* Bifurcation / split-brain CONSERVATION invariant — Face-2 (Soraya-routed to TLA+/TLC: a
+   transition-system safety+liveness property over an interleaved divvy, not algebra → not Lean).
+   Face-1 (reconciliation CONVERGENCE) is a Lean corollary of the proven CRDT floor, separate file.
+
+   When identity I bifurcates into halves I1, I2 (the degenerate split-brain case), its consented
+   bindings / consensus-bus contracts are PARTITIONED over a gradual "I-take-this / you-take-that"
+   divvy. Safety: nothing lost (conservation), nothing double-owned, no binding executes twice
+   across the halves (no double-spend — the P0). Liveness: the divvy eventually completes. Models
+   the deployed Binding layer's `Consented`/`Executed` at the split. Precedents: RefuseBinding.tla,
+   NciSafety.tla (race-to-claim), NciLiveness.tla / RecoveryHomeostat.tla (WF liveness). *)
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS Bindings   \* the consented bindings of identity I at the moment of the split
+
+VARIABLES
+    owner,    \* [Bindings -> {"none", "i1", "i2"}] : current owner (monotone once tagged)
+    execBy    \* [Bindings -> SUBSET {"i1", "i2"}]  : which halves have executed the binding
+
+vars == <<owner, execBy>>
+
+Halves == {"i1", "i2"}
+
+TypeOK ==
+    /\ owner \in [Bindings -> {"none", "i1", "i2"}]
+    /\ execBy \in [Bindings -> SUBSET Halves]
+
+Init ==
+    /\ owner = [b \in Bindings |-> "none"]   \* at the split, all bindings unassigned
+    /\ execBy = [b \in Bindings |-> {}]
+
+\* Tag a still-unassigned binding to a half (monotone: never un-tagged once owned).
+Tag(h, b) ==
+    /\ h \in Halves
+    /\ owner[b] = "none"
+    /\ owner' = [owner EXCEPT ![b] = h]
+    /\ UNCHANGED execBy
+
+\* Execute a binding — only by its OWNER, and only ONCE (already-executed is a sink → no re-spend).
+Exec(h, b) ==
+    /\ h \in Halves
+    /\ owner[b] = h
+    /\ execBy[b] = {}
+    /\ execBy' = [execBy EXCEPT ![b] = {h}]
+    /\ UNCHANGED owner
+
+\* Stutter at the fully-terminal state (all tagged, all owned bindings executed) so legitimate
+\* completion is not mis-reported as deadlock.
+Terminating ==
+    /\ \A b \in Bindings : owner[b] # "none"
+    /\ \A b \in Bindings : execBy[b] # {}
+    /\ UNCHANGED vars
+
+Next ==
+    \/ \E h \in Halves, b \in Bindings : Tag(h, b) \/ Exec(h, b)
+    \/ Terminating
+
+\* Weak fairness on tagging so the divvy makes progress (the eventual-completion liveness).
+Spec == Init /\ [][Next]_vars /\ WF_vars(\E h \in Halves, b \in Bindings : Tag(h, b))
+
+owned(h) == { b \in Bindings : owner[b] = h }
+unassigned == { b \in Bindings : owner[b] = "none" }
+
+\* ── Conservation: every binding is accounted for (unassigned ∪ I1 ∪ I2 = all). ──
+Conservation == (unassigned \cup owned("i1") \cup owned("i2")) = Bindings
+
+\* ── No double-ownership: the two halves' bindings are disjoint. ──
+NoDoubleOwnership == owned("i1") \cap owned("i2") = {}
+
+\* ── No double-spend (the P0): no binding is executed more than once, across both halves. ──
+NoDoubleSpend == \A b \in Bindings : Cardinality(execBy[b]) <= 1
+
+\* ── Execute only by owner: a half never executes a binding it does not own. ──
+ExecOnlyByOwner == \A b \in Bindings : \A h \in execBy[b] : owner[b] = h
+
+\* ── Liveness: the divvy eventually completes — every binding ends up owned by a half. ──
+DivvyCompletes == <>[] (unassigned = {})
+
+=============================================================================


### PR DESCRIPTION
Formalizes the **bifurcation / split-brain reconciliation invariant**. Soraya routed **two faces to two tools** (anti-hammer):

- **Face-1 (convergence) — Lean** (`tools/lean4/Safety/Bifurcation.lean`): a join-semilattice merge (comm+assoc+idem) is **order-independent + absorbing** → two split cells reconcile to the **same LUB** regardless of merge order. **Axiom-FREE.** A corollary of the proven CRDT/G-Set floor (only new content = the semilattice instance). Lean, not TLC (algebra, not interleavings).
- **Face-2 (conservation) — TLA+** (`tools/tla/specs/Bifurcation.tla`): over an interleaved divvy — **`Conservation`** (nothing lost), **`NoDoubleOwnership`** (I1 ∩ I2 = ∅), **`NoDoubleSpend`** (no binding executes twice across halves — the **P0**), **`ExecOnlyByOwner`**, + liveness **`DivvyCompletes`** (WF on Tag). TLC clean (gated sweep). TLA+, not Lean (temporal/liveness).

Both gated (lean-proof.yml type-check+audit; TLA+ sweep). Registered. **Pending BP-16 leg:** Leg B — FsCheck over a *deployed* split/divvy/merge in `Binding.fs` (the no-double-spend real-code second leg), which needs the divvy/merge ops added to `Binding.fs` first (a build). Bifurcation is the inverse of non-register-collapse; bindings = the divvied contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)