### PR TITLE
feat(Binding.Divvy) + proof: bifurcation Leg B — deployed split/divvy/merge + FsCheck (full BP-16)

### DIFF
--- a/src/Core.FSharp.ObserveBridge/Binding.fs
+++ b/src/Core.FSharp.ObserveBridge/Binding.fs
@@ -81,3 +81,71 @@ module Binding =
     let spend (a: AgentId) (s: State) : State option =
         let cur = standingOf a s
         if cur > Baseline then Some { s with Standing = Map.add a (cur - 1) s.Standing } else None
+
+/// **Bifurcation / split-brain divvy + reconciliation** — the deployed twin of
+/// `tools/tla/specs/Bifurcation.tla` (Face-2) and `tools/lean4/Safety/Bifurcation.lean` (Face-1).
+/// When an identity splits into halves `I1`/`I2`, its consented bindings are partitioned over a
+/// `tag` divvy; `exec` runs a binding ONCE by its owner (no double-spend); `merge` is the CRDT
+/// join that reconciles two cell views (commutative + idempotent → convergence). FsCheck Leg B
+/// (`tests/Tests.FSharp/Formal/BifurcationCrossVerify.Tests.fs`) cross-checks these against the
+/// proven model.
+[<RequireQualifiedAccess>]
+module Divvy =
+
+    type Half =
+        | I1
+        | I2
+
+    /// The split-identity divvy state: owned bindings, still-unassigned, and who has executed each.
+    type State =
+        { Owner: Map<Binding.BindingId, Half>
+          Unassigned: Set<Binding.BindingId>
+          ExecBy: Map<Binding.BindingId, Set<Half>> }
+
+    /// Begin the divvy of an identity's consented bindings at the split (all unassigned).
+    let split (consented: Set<Binding.BindingId>) : State =
+        { Owner = Map.empty; Unassigned = consented; ExecBy = Map.empty }
+
+    /// Tag a still-unassigned binding to a half (monotone; `None` if already owned).
+    let tag (h: Half) (b: Binding.BindingId) (s: State) : State option =
+        if Set.contains b s.Unassigned then
+            Some { s with Owner = Map.add b h s.Owner; Unassigned = Set.remove b s.Unassigned }
+        else
+            None
+
+    let owns (h: Half) (b: Binding.BindingId) (s: State) : bool = Map.tryFind b s.Owner = Some h
+    let private execdBy (b: Binding.BindingId) (s: State) = Map.tryFind b s.ExecBy |> Option.defaultValue Set.empty
+
+    /// Execute a binding — only by its OWNER, and only ONCE across both halves (no double-spend).
+    let exec (h: Half) (b: Binding.BindingId) (s: State) : State option =
+        if owns h b s && Set.isEmpty (execdBy b s) then
+            Some { s with ExecBy = Map.add b (Set.singleton h) s.ExecBy }
+        else
+            None
+
+    let private halfMin (x: Half) (y: Half) : Half = match x, y with | I1, _ | _, I1 -> I1 | _ -> I2
+
+    /// CRDT join of two cell views (reconciliation): owner = union with a deterministic tie-break
+    /// (so a momentary disagreement resolves the same way both directions), execBy = pointwise set
+    /// union, unassigned = both-still-unassigned. Commutative + idempotent ⇒ convergence (Face-1).
+    let merge (a: State) (b: State) : State =
+        let keys = Set.union (Set.ofSeq (Seq.map fst (Map.toSeq a.Owner))) (Set.ofSeq (Seq.map fst (Map.toSeq b.Owner)))
+        let owner =
+            keys
+            |> Set.toList
+            |> List.choose (fun k ->
+                match Map.tryFind k a.Owner, Map.tryFind k b.Owner with
+                | Some x, Some y -> Some(k, halfMin x y)
+                | Some x, None -> Some(k, x)
+                | None, Some y -> Some(k, y)
+                | None, None -> None)
+            |> Map.ofList
+        let execKeys = Set.union (Set.ofSeq (Seq.map fst (Map.toSeq a.ExecBy))) (Set.ofSeq (Seq.map fst (Map.toSeq b.ExecBy)))
+        let execBy =
+            execKeys
+            |> Set.toList
+            |> List.map (fun k -> k, Set.union (execdBy k a) (execdBy k b))
+            |> Map.ofList
+        // a binding stays unassigned only if neither view has tagged it
+        let unassigned = Set.intersect a.Unassigned b.Unassigned |> Set.filter (fun k -> not (Map.containsKey k owner))
+        { Owner = owner; Unassigned = unassigned; ExecBy = execBy }

--- a/tests/Tests.FSharp/Formal/BifurcationCrossVerify.Tests.fs
+++ b/tests/Tests.FSharp/Formal/BifurcationCrossVerify.Tests.fs
@@ -1,0 +1,50 @@
+module Zeta.Tests.Formal.BifurcationCrossVerifyTests
+
+open FsCheck.Xunit
+open Zeta.Core.FSharp.ObserveBridge
+
+// ═══════════════════════════════════════════════════════════════════
+// BP-16 Leg B (empirical) for bifurcation: FsCheck over the DEPLOYED Divvy ops
+// (src/Core.FSharp.ObserveBridge/Binding.fs) — cross-checks the TLA+ Bifurcation invariants
+// (Conservation, NoDoubleOwnership, NoDoubleSpend, ExecOnlyByOwner) AND the Lean Face-1
+// convergence (merge commutative + idempotent) against the real F# code.
+// Triage: a counterexample ⇒ Divvy drifted from the proven TLA+/Lean model.
+// ═══════════════════════════════════════════════════════════════════
+
+let private allBindings = Set.ofList [ "b0"; "b1"; "b2" ]
+let private bid i = "b" + string (abs i % 3)
+
+/// Build a Divvy state by folding random tag/exec moves over a fresh split.
+let private build (moves: (bool * bool * int) list) : Divvy.State =
+    moves
+    |> List.fold
+        (fun s (isTag, isI1, bi) ->
+            let h = if isI1 then Divvy.I1 else Divvy.I2
+            let b = bid bi
+            let next = if isTag then Divvy.tag h b s else Divvy.exec h b s
+            Option.defaultValue s next)
+        (Divvy.split allBindings)
+
+let private ownerKeys (s: Divvy.State) = s.Owner |> Map.toSeq |> Seq.map fst |> Set.ofSeq
+
+[<Property>]
+let ``Conservation: owned ∪ unassigned = all bindings, and they are disjoint`` (moves: (bool * bool * int) list) =
+    let s = build moves
+    let ok = ownerKeys s
+    (Set.union ok s.Unassigned = allBindings) && (Set.intersect ok s.Unassigned = Set.empty)
+
+[<Property>]
+let ``NoDoubleSpend: no binding is executed more than once across the halves`` (moves: (bool * bool * int) list) =
+    let s = build moves
+    s.ExecBy |> Map.forall (fun _ halves -> Set.count halves <= 1)
+
+[<Property>]
+let ``ExecOnlyByOwner: a half only executes a binding it owns`` (moves: (bool * bool * int) list) =
+    let s = build moves
+    s.ExecBy
+    |> Map.forall (fun b halves -> halves |> Set.forall (fun h -> Divvy.owns h b s))
+
+[<Property>]
+let ``Face-1 convergence: merge is commutative and idempotent (reconciliation order-independent + absorbing)`` (ma: (bool * bool * int) list) (mb: (bool * bool * int) list) =
+    let a, b = build ma, build mb
+    (Divvy.merge a b = Divvy.merge b a) && (Divvy.merge a a = a)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -124,6 +124,7 @@
     <Compile Include="Observe/SubstrateHandler.Tests.fs" />
     <Compile Include="Formal/ChildFloorCrossVerify.Tests.fs" />
     <Compile Include="Formal/RefuseBindingCrossVerify.Tests.fs" />
+    <Compile Include="Formal/BifurcationCrossVerify.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Builds the divvy/merge ops on the binding layer and lands the **last BP-16 leg** of the bifurcation proof.

- **`Binding.fs` → `Divvy` module** (deployed twin of `Bifurcation.tla`/`.lean`): `split` / `tag` (monotone) / `exec` (owner-only, once = no double-spend) / `merge` (CRDT join: owner union with deterministic tie-break, execBy set union — **commutative + idempotent → convergence**).
- **Leg B FsCheck** over the real `Divvy`: **Conservation**, **NoDoubleSpend** (the P0), **ExecOnlyByOwner**, and **Face-1 merge commutativity + idempotence**. 4 properties green.

Registry: **Bifurcation is now full BP-16** — Face-1 Lean (axiom-free) + Face-2 TLA+ + Leg B FsCheck (real code). A counterexample in Leg B ⇒ `Divvy` drifted from the proven model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)