### PR TITLE
test(bifurcation): merge-associativity property + correct stale registry (Leg-B already landed → 4/4 full-3-leg)

### DIFF
--- a/docs/research/verification-registry.md
+++ b/docs/research/verification-registry.md
@@ -67,11 +67,12 @@ because <one-line>.`
 
 ---
 
-## `Bifurcation` *(split-brain — Face-1 Lean convergence + Face-2 TLA+ conservation/no-double-spend)*
+## `Bifurcation` *(split-brain — full BP-16: Lean convergence + TLA+ conservation + FsCheck deployed-divvy)*
 
 - **Artifacts.** `tools/lean4/Safety/Bifurcation.lean` (Face-1, axiom-FREE — `reconcile_converges`,
   `reconcile_absorb`, `reconcile_order_independent`; `lean-proof.yml`) + `tools/tla/specs/Bifurcation.tla`
-  (+ `.cfg`) (Face-2; TLC via `run-tlc.ts --all`, gated). Authored 2026-06-07.
+  (+ `.cfg`) (Face-2; TLC via `run-tlc.ts --all`, gated) + `tests/Tests.FSharp/Formal/BifurcationCrossVerify.Tests.fs`
+  (Leg-B/Face-3, FsCheck over the deployed `Binding.Divvy` ops). Authored 2026-06-07. **Full BP-16 (3 legs).**
 - **Source anchors.** Bifurcation / split-brain (Aaron 2026-06-07; `memory/persona/ani/conversations/2026-06-07-ani-cells-teleport-*`).
   Soraya-routed two faces, two tools (anti-hammer). CRDT-merge-convergence template:
   `Privacy.IdentityForcesPrivacy.commons_converges`; CRDT/G-Set floor.
@@ -83,11 +84,17 @@ because <one-line>.`
   `NoDoubleSpend` (no binding executes twice across halves — the P0), `ExecOnlyByOwner`, and
   liveness `DivvyCompletes` (`<>[]` all assigned, WF on Tag).
 - **Fidelity scope.** Face-1 general over any semilattice (the concrete cell-merge being one is the
-  floor's G-Set result). Face-2 bounded TLA+ model (3 bindings), TLC exhaustive over scope. **NOT yet
-  done (Soraya BP-16):** Leg B — FsCheck over a *deployed* split/divvy/merge in `Binding.fs` (the
-  no-double-spend P0's real-code second leg); needs the divvy/merge ops added to `Binding.fs` first.
+  floor's G-Set result). Face-2 bounded TLA+ model (3 bindings), TLC exhaustive over scope.
+  **Leg-B/Face-3 (FsCheck, deployed) LANDED** — `tests/Tests.FSharp/Formal/BifurcationCrossVerify.Tests.fs`
+  over the deployed `Binding.Divvy` ops (the divvy/merge ops were added to `Binding.fs`; this prior-
+  session leg was previously mis-recorded as "not yet done"): `Conservation`, `NoDoubleSpend` (the P0
+  real-code witness), `ExecOnlyByOwner`, and the Face-1 join-semilattice triple over the deployed
+  `Divvy.merge` — commutative + idempotent + **associative** (associativity added 2026-06-07 to close
+  the B-0969 failure class; `Divvy.merge` confirmed a lawful join). 5 properties green. **Full BP-16
+  (3 legs / 2 tools+empirical).** Triage: an FsCheck counterexample ⇒ `Divvy` drifted from the
+  proven TLA+/Lean model.
 - **Last audit.** 2026-06-07, authored by Otto (shadow); not yet independently audited. Grade:
-  Face-1 axiom-free; Face-2 machine-checked (TLC, bounded).
+  Face-1 axiom-free; Face-2 machine-checked (TLC, bounded); Leg-B FsCheck green (5 properties).
 
 ---
 

--- a/tests/Tests.FSharp/Formal/BifurcationCrossVerify.Tests.fs
+++ b/tests/Tests.FSharp/Formal/BifurcationCrossVerify.Tests.fs
@@ -48,3 +48,13 @@ let ``ExecOnlyByOwner: a half only executes a binding it owns`` (moves: (bool * 
 let ``Face-1 convergence: merge is commutative and idempotent (reconciliation order-independent + absorbing)`` (ma: (bool * bool * int) list) (mb: (bool * bool * int) list) =
     let a, b = build ma, build mb
     (Divvy.merge a b = Divvy.merge b a) && (Divvy.merge a a = a)
+
+// Associativity completes the join-semilattice triple (commutative + idempotent + ASSOCIATIVE = the
+// `L.assoc` field the Lean Bifurcation semilattice proves). Kept explicit per the B-0969 precedent:
+// a tie-break/sort that is commutative+idempotent but NOT associative is still NOT a lawful join —
+// exactly the failure class B-0969 exposed in a max-merge. Without it this leg would be blind to the
+// one law most likely to silently break under a key-ordering change.
+[<Property>]
+let ``Face-1 convergence: merge is associative (three-way reconciliation order-independent)`` (ma: (bool * bool * int) list) (mb: (bool * bool * int) list) (mc: (bool * bool * int) list) =
+    let a, b, c = build ma, build mb, build mc
+    Divvy.merge (Divvy.merge a b) c = Divvy.merge a (Divvy.merge b c)


### PR DESCRIPTION
## What

Two fixes surfaced by Soraya's coverage-ratio update — she reported bifurcation at **0.75 full-3-leg**, but that was driven by a **stale registry row**, not reality.

1. **Registry correction.** The `Bifurcation` row still read *"NOT yet done (Soraya BP-16): Leg B — FsCheck over a deployed split/divvy/merge in `Binding.fs` ... needs the divvy/merge ops added first."* Stale: the `Divvy` module was added to `Binding.fs` and `tests/Tests.FSharp/Formal/BifurcationCrossVerify.Tests.fs` has shipped FsCheck properties over it (Conservation, NoDoubleSpend, ExecOnlyByOwner, Face-1 convergence), wired in the fsproj, green on main. **Bifurcation was already full BP-16 (3 legs)** — the true safety-floor full-3-leg ratio is **4/4 = 1.00**, not 3/4.

2. **Associativity property added.** The existing Face-1 property checked commutative + idempotent but **omitted associativity** — the exact B-0969 failure class (a tie-break that's commutative+idempotent but not associative is still not a lawful join). The Lean Bifurcation semilattice proves `L.assoc`; this adds the matching empirical witness. Confirmed green ⇒ `Divvy.merge` is a lawful join-semilattice with no associativity hole. Brings the leg to parity with the NonRegisterCollapse leg.

## Verification
`dotnet test --filter BifurcationCrossVerify` → **5 passed**. Build 0-warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)