### PR TITLE
feat(Log/081KTGD5JMD): canonical DeltaLogEntry codec — F# reference oracle (format-parameterized, ordinal-deterministic)

### DIFF
--- a/src/Core/DeltaCodec.fs
+++ b/src/Core/DeltaCodec.fs
@@ -61,3 +61,86 @@ type CborDeltaCodec<'K when 'K : comparison>
             match DynamicValue.fromCanonicalCbor bytes with
             | Ok dv -> ZSetDynamic.ofDynamicValue keyDec dv
             | Error e -> invalidArg (nameof bytes) $"CborDeltaCodec.Decode: non-decodable CBOR: {e}"
+
+
+/// `DeltaLogEntry` ↔ `DynamicValue` mapping — the canonical **Log-entry envelope**, the
+/// `Log` noun's path to the 4-language proven bar (workitem 081KTGD5JMD). A whole entry
+/// `{ Seq; Delta; Captured }` becomes a `DynamicValue.Object` with the keys
+/// `captured` / `delta` / `seq` (ordinal order), so the entry rides DynamicValue's
+/// golden-vector-locked canonical CBOR — the Log entry INHERITS the existing 4-lang
+/// byte-lock rather than inventing a new canonical encoding (it adds no new noun: an
+/// entry is just a `DynamicValue`). `Captured` keys are **ordinal-sorted**
+/// (culture-invariant; B-0969) for cross-language + DST determinism — the prior
+/// `System.Text.Json` `Dictionary` encoding in `GitDeltaLog`/`DiskDeltaLog` is NOT
+/// canonical and is the gap this closes. Lossless round-trip: `ofDynamicValue (toDynamicValue e) = e`.
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module DeltaLogEntryDynamic =
+
+    let toDynamicValue (keyEnc: 'K -> DynamicValue) (entry: DeltaLogEntry<'K>) : DynamicValue =
+        let captured =
+            entry.Captured
+            |> Map.toList
+            |> List.sortWith (fun (a, _) (b, _) -> System.String.CompareOrdinal(a, b))
+            |> List.map (fun (k, v) -> k, DynamicValue.String v)
+        DynamicValue.Object
+            [ "captured", DynamicValue.Object captured
+              "delta", ZSetDynamic.toDynamicValue keyEnc entry.Delta
+              "seq", DynamicValue.Int entry.Seq ]
+
+    let ofDynamicValue (keyDec: DynamicValue -> 'K) (dv: DynamicValue) : DeltaLogEntry<'K> =
+        match dv with
+        | DynamicValue.Object fields ->
+            let find name =
+                match List.tryFind (fun (k, _) -> k = name) fields with
+                | Some(_, v) -> v
+                | None -> invalidArg (nameof dv) $"DeltaLogEntryDynamic: missing field '{name}'"
+            let seq =
+                match find "seq" with
+                | DynamicValue.Int s -> s
+                | o -> invalidArg (nameof dv) $"DeltaLogEntryDynamic: 'seq' not Int: {o}"
+            let delta = ZSetDynamic.ofDynamicValue keyDec (find "delta")
+            let captured =
+                match find "captured" with
+                | DynamicValue.Object kvs ->
+                    kvs
+                    |> List.map (fun (k, v) ->
+                        match v with
+                        | DynamicValue.String s -> k, s
+                        | o -> invalidArg (nameof dv) $"DeltaLogEntryDynamic: captured['{k}'] not String: {o}")
+                    |> Map.ofList
+                | o -> invalidArg (nameof dv) $"DeltaLogEntryDynamic: 'captured' not Object: {o}"
+            { Seq = seq; Delta = delta; Captured = captured }
+        | other -> invalidArg (nameof dv) $"DeltaLogEntryDynamic: expected Object, got {other}"
+
+
+/// Format-parameterized canonical codec for a whole `DeltaLogEntry` (Seq + Delta + Captured), the
+/// 4-language treaty target for the `Log` noun. The format-INDEPENDENT core is the
+/// `DeltaLogEntryDynamic` mapping; each concrete format rides DynamicValue's already-byte-locked
+/// per-format serializer, so the bytes/text are reproducible across F#/C#/Rust/TS.
+///
+/// Per-stream/table format choice (Aaron 2026-06-07): **git check-ins default to YAML** (diffable,
+/// human-readable history) and **filesystem defaults to CBOR** (speed); all formats are optionally
+/// selectable per stream/table at the backend layer. CBOR/JSON/XML round-trip exists today; **YAML is
+/// a prerequisite gap** (DynamicValue has no `toYaml`/`fromYaml` yet — tracked for the git-default path).
+/// These functions are the canonical replacement for the per-backend `System.Text.Json` framing in
+/// `GitDeltaLog`/`DiskDeltaLog`.
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module DeltaLogEntryCodec =
+
+    /// Canonical CBOR (the filesystem default — speed; complete 8/8 shapes, full round-trip).
+    let encodeCbor (keyEnc: 'K -> DynamicValue) (entry: DeltaLogEntry<'K>) : byte[] =
+        DeltaLogEntryDynamic.toDynamicValue keyEnc entry |> DynamicValue.toCanonicalCbor
+
+    let decodeCbor (keyDec: DynamicValue -> 'K) (bytes: byte[]) : DeltaLogEntry<'K> =
+        match DynamicValue.fromCanonicalCbor bytes with
+        | Ok dv -> DeltaLogEntryDynamic.ofDynamicValue keyDec dv
+        | Error e -> invalidArg (nameof bytes) $"DeltaLogEntryCodec.decodeCbor: non-decodable CBOR: {e}"
+
+    /// Canonical JSON (text — a diff-friendly option until the YAML git-default serializer lands).
+    let encodeJson (keyEnc: 'K -> DynamicValue) (entry: DeltaLogEntry<'K>) : Result<string, EncodeError> =
+        DeltaLogEntryDynamic.toDynamicValue keyEnc entry |> DynamicValue.toCanonicalJson
+
+    let decodeJson (keyDec: DynamicValue -> 'K) (json: string) : DeltaLogEntry<'K> =
+        match DynamicValue.fromCanonicalJson json with
+        | Ok dv -> DeltaLogEntryDynamic.ofDynamicValue keyDec dv
+        | Error e -> invalidArg (nameof json) $"DeltaLogEntryCodec.decodeJson: non-decodable JSON: {e}"

--- a/tests/Tests.FSharp/DeltaLogEntryCodec.Tests.fs
+++ b/tests/Tests.FSharp/DeltaLogEntryCodec.Tests.fs
@@ -1,0 +1,70 @@
+module Zeta.Tests.DeltaLogEntryCodecTests
+
+open global.Xunit
+open Zeta.Core
+
+// ═══════════════════════════════════════════════════════════════════
+// `Log` noun — canonical entry codec (workitem 081KTGD5JMD). The F# REFERENCE oracle for the
+// DeltaLogEntry byte-lock: a whole entry { Seq; Delta; Captured } maps to a DynamicValue.Object
+// (captured/delta/seq, ordinal order) and rides DynamicValue's already-4-lang-locked canonical
+// serializers — so the Log entry inherits the byte-lock with NO new canonical encoding (no new noun).
+// These tests prove the F# side: lossless round-trip, deterministic byte-stability, and ORDINAL
+// Captured-key ordering (culture-invariant; B-0969 — the property the old System.Text.Json framing
+// did not guarantee). The cross-language hex treaty (C#/Rust/TS conform) is the follow-up seed slice.
+// ═══════════════════════════════════════════════════════════════════
+
+let private keyEnc (s: string) : DynamicValue = DynamicValue.String s
+let private keyDec (dv: DynamicValue) : string =
+    match dv with
+    | DynamicValue.String s -> s
+    | o -> failwithf "key not String: %A" o
+
+let private entry seq pairs captured : DeltaLogEntry<string> =
+    { Seq = seq; Delta = ZSet.ofSeq pairs; Captured = Map.ofList captured }
+
+let private samples : DeltaLogEntry<string> list =
+    [ entry 0L [] []                                            // empty entry
+      entry 1L [ "a", 1L ] []                                   // single insert, no captured
+      entry 2L [ "a", 1L; "b", -2L; "c", 3L ] []                // multi-key incl. ℤ retraction (-2)
+      entry 7L [ "x", -1L ] [ "seed", "42"; "actor", "otto" ]   // captured present
+      entry 9L [ "k", 5L ] [ "b", "2"; "a", "1"; "Z", "26" ] ]  // captured needing ordinal sort
+
+let private eq (a: DeltaLogEntry<string>) (b: DeltaLogEntry<string>) =
+    a.Seq = b.Seq && a.Delta = b.Delta && a.Captured = b.Captured
+
+[<Fact>]
+let ``CBOR round-trip: decodeCbor (encodeCbor e) = e for all samples`` () =
+    for e in samples do
+        let rt = DeltaLogEntryCodec.decodeCbor keyDec (DeltaLogEntryCodec.encodeCbor keyEnc e)
+        Assert.True(eq e rt, sprintf "CBOR round-trip mismatch for seq %d" e.Seq)
+
+[<Fact>]
+let ``JSON round-trip: decodeJson (encodeJson e) = e for all samples`` () =
+    for e in samples do
+        match DeltaLogEntryCodec.encodeJson keyEnc e with
+        | Ok json ->
+            let rt = DeltaLogEntryCodec.decodeJson keyDec json
+            Assert.True(eq e rt, sprintf "JSON round-trip mismatch for seq %d" e.Seq)
+        | Error err -> Assert.True(false, sprintf "encodeJson failed for seq %d: %A" e.Seq err)
+
+[<Fact>]
+let ``Byte-stability: encodeCbor is deterministic (same entry -> same bytes)`` () =
+    for e in samples do
+        let a = DeltaLogEntryCodec.encodeCbor keyEnc e
+        let b = DeltaLogEntryCodec.encodeCbor keyEnc e
+        Assert.Equal<byte[]>(a, b)
+
+[<Fact>]
+let ``Captured keys serialize in ORDINAL order regardless of insertion order`` () =
+    // Same pairs, different insertion order -> identical canonical bytes (ordinal-sorted keys).
+    let e1 = entry 3L [ "k", 1L ] [ "b", "2"; "a", "1"; "Z", "26" ]
+    let e2 = entry 3L [ "k", 1L ] [ "Z", "26"; "a", "1"; "b", "2" ]
+    Assert.Equal<byte[]>(DeltaLogEntryCodec.encodeCbor keyEnc e1, DeltaLogEntryCodec.encodeCbor keyEnc e2)
+    // And the mapping's captured-object keys are in ordinal order: 'Z'(90) < 'a'(97) < 'b'(98).
+    match DeltaLogEntryDynamic.toDynamicValue keyEnc e1 with
+    | DynamicValue.Object fields ->
+        match List.tryFind (fun (k, _) -> k = "captured") fields with
+        | Some(_, DynamicValue.Object kvs) ->
+            Assert.Equal<string list>([ "Z"; "a"; "b" ], kvs |> List.map fst)
+        | _ -> Assert.True(false, "captured field missing or not Object")
+    | o -> Assert.True(false, sprintf "entry not Object: %A" o)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -227,6 +227,7 @@
     <Compile Include="Formal/Jaccard.Laws.Tests.fs" />
     <Compile Include="Formal/Clock.Laws.Tests.fs" />
     <Compile Include="Formal/Crdt.Laws.Tests.fs" />
+    <Compile Include="DeltaLogEntryCodec.Tests.fs" />
     <Compile Include="Formal/Merkle.Laws.Tests.fs" />
     <Compile Include="Formal/Sketch.Laws.Tests.fs" />
     <Compile Include="Formal/Metric.Bounds.Tests.fs" />


### PR DESCRIPTION
First slice of the `Log` noun byte-lock (the one remaining data-plane proven-base gap; ZSet ✅ + DynamicValue ✅ + Log = complete). The entry `{ Seq; Delta; Captured }` maps to a `DynamicValue.Object` (captured/delta/seq, ordinal order) riding DynamicValue's already-4-lang-locked serializers — **inherits the byte-lock, no new canonical encoding, no new noun**.

- `DeltaLogEntryDynamic.toDynamicValue/ofDynamicValue` — format-independent canonical mapping; `Captured` keys **ordinal-sorted** (B-0969 — what the old `System.Text.Json` framing didn't guarantee).
- `DeltaLogEntryCodec.encodeCbor/decodeCbor` (fs default) + `encodeJson/decodeJson`. Format = per-stream choice (git→YAML, fs→CBOR; all optional). **YAML is a prerequisite gap** (no `DynamicValue.toYaml` yet).
- 4 tests green: CBOR + JSON round-trip, byte-stability, ordinal Captured-key ordering.

Next slices: cross-lang hex seed (C#/Rust/TS conform), backend migration off System.Text.Json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)