### PR TITLE
docs+backlog: re-add Log byte-lock workitem (081KTGD5JMD) + cadence section (post-tangle cleanup)

### DIFF
--- a/docs/research/2026-06-07-two-plane-git-native-database-minimal-nouns-cells-control-plane-three-host-substrates-aaron-otto.md
+++ b/docs/research/2026-06-07-two-plane-git-native-database-minimal-nouns-cells-control-plane-three-host-substrates-aaron-otto.md
@@ -141,6 +141,25 @@ interface must cover: commit/append, branch, checkout, log/history, diff, status
 the PR/merge control-plane verbs — each is either a noun-verb (`append`/`branch`/`history`) or a
 composition to expose.
 
+### The MCP/CLI surface IS a cell — with request-driven (not scheduled) cadence
+
+> Aaron: *"MCP/CLI can also serve as a type of cell, but one whose cadence is not schedule-based."*
+
+The command surface is not *outside* the cell model — it is itself a cell, keeping the architecture
+**cells all the way**. What distinguishes it is **cadence**, a cell property orthogonal to host
+substrate (§3):
+
+- **Scheduled / tick-driven cells** — tick stream from a clock (cron, systemd timer, the autonomous-loop
+  heartbeat). They advance on time.
+- **Request / event-driven cells** — the "tick" is an *incoming command*. The MCP/CLI cell wakes on an
+  MCP tool-call or CLI invocation, processes it against the data-plane nouns, and quiesces. No clock; the
+  request *is* the tick.
+
+Both are the same cell shape `(identity, Log)` driven by a tick stream; only the *source* of the ticks
+differs. So the MCP/CLI is a request-driven cell over the data-plane core — composing cleanly with the
+scheduled cells rather than being a special external gateway. (Cadence axis pairs with the host-substrate
+axis: a request-driven cell can be hosted on systemd, k8s, or Orleans just as a scheduled one can.)
+
 ## 3. Cell host substrates — three, each cell distinct
 
 > Aaron: *"support 1 systemd (and other OS service) cells, 2 raw kubernetes operator-pattern cells,

--- a/workitems/081KTGD5JMD08QG0R000CEZ1D5-log-noun-canonical-entry-byte-lock-deltalogentry-seq-delta-c.md
+++ b/workitems/081KTGD5JMD08QG0R000CEZ1D5-log-noun-canonical-entry-byte-lock-deltalogentry-seq-delta-c.md
@@ -1,0 +1,69 @@
+---
+id: 081KTGD5JMD08QG0R000CEZ1D5
+type: task
+state: backlog
+priority: P1
+slug: log-noun-canonical-entry-byte-lock-deltalogentry-seq-delta-c
+title: "Log noun canonical entry byte-lock (DeltaLogEntry: Seq+Delta+Captured) — all-lang/all-ser, replace ad-hoc System.Text.Json; completes the 3-noun data-plane proven base"
+created: 2026-06-07T06:43:49.517Z
+depends_on: []
+composes_with: []
+---
+
+# Log noun canonical entry byte-lock (DeltaLogEntry: Seq+Delta+Captured) — all-lang/all-ser, replace ad-hoc System.Text.Json; completes the 3-noun data-plane proven base
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTGD5JMD08QG0R000CEZ1D5-*.md` glob. -->
+
+## Why (the gap)
+
+Per the two-plane DB architecture (`docs/research/2026-06-07-two-plane-git-native-database-minimal-nouns-*`),
+the data plane's irreducible noun set is **three**: `ZSet` ✅ 4/4, `DynamicValue` ✅ 4/4, and **`Log` 🚧**.
+`Log` is the one noun NOT yet at the proven bar, so this completes the data-plane proven math base.
+
+The entry shape (`src/Core/DeltaLog.fs`):
+
+```fsharp
+type DeltaLogEntry<'K when 'K : comparison> =
+    { Seq: int64; Delta: ZSet<'K>; Captured: Map<string, string> }
+```
+
+**Hazard found (2026-06-07):** the current entry serialization is ad-hoc and .NET-specific —
+`GitDeltaLog.fs` and `DiskDeltaLog.fs` both encode `Captured` via `System.Text.Json`
+(`JsonSerializer.SerializeToUtf8Bytes` of a `Dictionary<string,string>`) and `Delta` via the ZSet
+codec, framed differently per backend. That is NOT 4-lang byte-lockable: STJ key ordering/escaping is
+platform-specific, and the `Captured` map keys must be **ordinal-sorted** (culture-invariant rule —
+B-0969 precedent) for cross-language/DST determinism. This is exactly why `Log` isn't proven.
+
+## What (the canonical encoding)
+
+Define ONE canonical entry encoding, CBOR (RFC 8949, matching the DynamicValue/ZSet exemplars), shared
+by every backend and all four oracles. The new byte-lock surface is just the **envelope** around the
+already-locked `Delta`:
+- `Seq : int64` — CBOR integer.
+- `Delta : ZSet<'K>` — reuse the existing canonical ZSet CBOR (already 4/4 locked).
+- `Captured : Map<string,string>` — CBOR map with **ordinal-sorted keys** (deterministic; the one real
+  decision). Empty map when the producer was pure.
+- Entry framing: a fixed 3-element CBOR array `[Seq, DeltaCbor, CapturedCbor]` (order-fixed, not a
+  by-name map, to avoid key-ordering questions on the envelope itself).
+
+## Slices (seed-first, one PR each)
+
+1. **Canonical seed + F# reference oracle** — author `log-entry/golden-vectors.json` (the seed: hand-
+   written canonical entries incl. empty/non-empty Captured, multi-key ordinal-ordering cases, ℤ
+   retraction deltas) + an F# entry encoder/decoder conforming to it + round-trip & byte-lock tests;
+   migrate `GitDeltaLog`/`DiskDeltaLog` off `System.Text.Json` onto the canonical encoder.
+2. **C# oracle** — native encoder/decoder replaying the seed (byte-identical).
+3. **Rust oracle** — same.
+4. **TS oracle** — same. → `Log` reaches 4/4; data-plane proven base complete.
+
+## Anchors
+
+- Architecture: `docs/research/2026-06-07-two-plane-git-native-database-minimal-nouns-cells-control-plane-three-host-substrates-aaron-otto.md`
+- Master checklist: **B-0959** (sovereign distributed DB, one git-native Z-set substrate)
+- Exemplars to mirror: DynamicValue CBOR (`src/Core.TypeScript/dynamic-value/golden-vectors-cbor.json`),
+  ZSet (`src/Core.TypeScript/z-set/golden-vectors.json`)
+- Code to migrate: `src/Core/DeltaLog.fs`, `src/Core.Git/GitDeltaLog.fs`, `src/Core/DiskDeltaLog.fs`
+- Discipline: `.claude/rules/culture-invariant-by-default.md` (ordinal `Captured` keys),
+  `.claude/rules/no-binary-in-proof-lineage.md` (hex-in-JSON golden vectors)


### PR DESCRIPTION
Re-applies content lost when #6728/#6729 were closed for branch-tangle conflicts: the Log byte-lock workitem file (referenced by #6730 + the roadmap) + the MCP/CLI-as-request-driven-cell cadence section in the design doc. Clean from current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)