### PR TITLE
feat(Log/081KTGD5JMD): cross-language golden seed for DeltaLogEntry + F# treaty lock

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,6 +14,14 @@ A relativistic git-native database: a **reliable data plane** (storage + read/wr
 **minimal-noun, all-language (F#/C#/Rust/TS), all-serializer PROVEN math base**. Two product shapes:
 data-plane-only, and data-plane + cell control plane.
 
+### Operating principle — convert every input into one of four channels
+
+Aaron 2026-06-07: anything thrown at this work that isn't already moving us toward the roadmap should be
+converted, on the spot, into exactly one of — **code · proof · treaty seed (golden-vector byte-lock) ·
+backlog** — and the backlog selection criterion is *"does it help us see the shape of the data layer
+clearly?"* Anything that converts to none of the four is drift. (Detail:
+`memory/feedback_aaron_triage_every_input_toward_roadmap_via_code_proof_treaty_seed_or_backlog_*`.)
+
 ### ITEM #1 — NO USE OF THE GIT CLI
 
 All persistence routes through **our DB layer** (understands filesystem + git, runs git-native:

--- a/memory/feedback_aaron_triage_every_input_toward_roadmap_via_code_proof_treaty_seed_or_backlog_to_see_data_layer_shape_clearly_2026_06_07.md
+++ b/memory/feedback_aaron_triage_every_input_toward_roadmap_via_code_proof_treaty_seed_or_backlog_to_see_data_layer_shape_clearly_2026_06_07.md
@@ -1,0 +1,28 @@
+# Triage every input toward the roadmap — code | proof | treaty seed | backlog — to see the data-layer shape clearly
+
+**Aaron, 2026-06-07 (verbatim intent):** *"anything i throw at you that's not moving us towards our
+roadmap either via code or proofs or treaty seeds or something we can backlog that will help us see
+the shape of our data layer clearly."*
+
+## The principle
+
+Every input Aaron throws (and he rambles — his words — and we're both forgetful) should be converted
+into roadmap motion through exactly one of four channels:
+
+1. **Code** — land the thing (e.g. the `DeltaLogEntry` canonical codec, F# reference oracle).
+2. **Proof** — formalize/verify it (the safety-floor arc; TLA+/Lean/FsCheck).
+3. **Treaty seed** — a golden-vector / byte-lock seed that becomes the cross-language treaty (the
+   4-lang byte-lock seeds; the "seed is the canonical data, every oracle grows code that agrees").
+4. **Backlog** — a tracked workitem when it's not yet buildable, *chosen so it helps us SEE THE SHAPE
+   OF THE DATA LAYER CLEARLY* (that's the selection criterion — not just "capture everything," but
+   capture what clarifies the data layer's shape).
+
+**Why:** keeps a rapid, rambling idea-stream from becoming lost context or unanchored docs. The unifying
+goal is a *clear view of the data-layer shape* — the minimal-noun proven base (ZSet/DynamicValue/Log),
+the format/plugin treaty, the cells. Anything not converting to one of the four channels is drift.
+
+**How to apply:** on each Aaron input, name the channel before acting (code / proof / treaty-seed /
+backlog). If it's backlog, ask "does this clarify the data-layer shape?" — if not, it's probably not
+worth a row. Capture faithfully (glass-halo for vision/personal); convert to channel for build-relevant.
+
+Ties: `docs/ROADMAP.md` (the don't-forget hub), the two-plane DB design doc, B-0959.

--- a/src/Core.TypeScript/delta-log-entry/golden-vectors.json
+++ b/src/Core.TypeScript/delta-log-entry/golden-vectors.json
@@ -1,0 +1,30 @@
+{
+  "_comment": "Cross-language byte-lock treaty for the Log noun's DeltaLogEntry { Seq; Delta; Captured } (workitem 081KTGD5JMD). The entry maps to a DynamicValue.Object with ordinal-ordered keys captured/delta/seq, then rides DynamicValue's canonical CBOR (RFC 8949) — so the Log entry inherits DynamicValue's existing 4-language byte-lock with no new canonical encoding (an entry is just a DynamicValue; no new noun). `cbor` is the canonical CBOR encoding as a lowercase hex string (hex-in-JSON per no-binary-in-proof-lineage). The F# reference oracle produced these (src/Core/DeltaCodec.fs DeltaLogEntryCodec.encodeCbor); C#/Rust/TS oracles MUST reproduce byte-identical. `captured` keys are ORDINAL-sorted in the encoding regardless of input order (culture-invariant; B-0969). Keys here are strings (DynamicValue.String); delta weights are int64.",
+  "vectors": [
+    {
+      "name": "empty",
+      "entry": { "seq": 0, "delta": [], "captured": {} },
+      "cbor": "a3686361707475726564a06564656c7461806373657100"
+    },
+    {
+      "name": "single_insert",
+      "entry": { "seq": 1, "delta": [["a", 1]], "captured": {} },
+      "cbor": "a3686361707475726564a06564656c746181826161016373657101"
+    },
+    {
+      "name": "multi_key_retract",
+      "entry": { "seq": 2, "delta": [["a", 1], ["b", -2], ["c", 3]], "captured": {} },
+      "cbor": "a3686361707475726564a06564656c7461838261610182616221826163036373657102"
+    },
+    {
+      "name": "captured_present",
+      "entry": { "seq": 7, "delta": [["x", -1]], "captured": { "seed": "42", "actor": "otto" } },
+      "cbor": "a3686361707475726564a2656163746f72646f74746f64736565646234326564656c746181826178206373657107"
+    },
+    {
+      "name": "captured_ordinal",
+      "entry": { "seq": 9, "delta": [["k", 5]], "captured": { "b": "2", "a": "1", "Z": "26" } },
+      "cbor": "a3686361707475726564a3615a62323661616131616261326564656c74618182616b056373657109"
+    }
+  ]
+}

--- a/tests/Tests.FSharp/DeltaLogEntryCodec.Tests.fs
+++ b/tests/Tests.FSharp/DeltaLogEntryCodec.Tests.fs
@@ -1,5 +1,7 @@
 module Zeta.Tests.DeltaLogEntryCodecTests
 
+open System.IO
+open System.Text.Json
 open global.Xunit
 open Zeta.Core
 
@@ -68,3 +70,46 @@ let ``Captured keys serialize in ORDINAL order regardless of insertion order`` (
             Assert.Equal<string list>([ "Z"; "a"; "b" ], kvs |> List.map fst)
         | _ -> Assert.True(false, "captured field missing or not Object")
     | o -> Assert.True(false, sprintf "entry not Object: %A" o)
+
+// ── The cross-language TREATY: F# is the reference oracle for the shared golden seed
+//    (src/Core.TypeScript/delta-log-entry/golden-vectors.json). C#/Rust/TS oracles MUST reproduce
+//    byte-identical CBOR. This locks F# encode→hex AND decode(hex)→round-trip against the seed. ──
+
+let private repoRoot () =
+    let mutable dir = DirectoryInfo(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location))
+    while not (isNull dir) && not (File.Exists(Path.Join(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+    if isNull dir then failwith "Could not locate repo root (Zeta.sln)." else dir.FullName
+
+let private toHex (b: byte[]) = b |> Array.map (sprintf "%02x") |> String.concat ""
+let private ofHex (s: string) =
+    [| for i in 0 .. 2 .. s.Length - 2 -> System.Convert.ToByte(s.Substring(i, 2), 16) |]
+
+let private entryOfJson (e: JsonElement) : DeltaLogEntry<string> =
+    let seq = (e.GetProperty "seq").GetInt64()
+    let delta =
+        [ for pair in (e.GetProperty "delta").EnumerateArray() ->
+            let arr = pair.EnumerateArray() |> Seq.toArray
+            arr.[0].GetString(), arr.[1].GetInt64() ]
+        |> ZSet.ofSeq
+    let captured =
+        [ for p in (e.GetProperty "captured").EnumerateObject() -> p.Name, p.Value.GetString() ]
+        |> Map.ofList
+    { Seq = seq; Delta = delta; Captured = captured }
+
+[<Fact>]
+let ``Golden treaty: F# reproduces the shared seed's canonical CBOR + round-trips it`` () =
+    let path = Path.Join(repoRoot (), "src", "Core.TypeScript", "delta-log-entry", "golden-vectors.json")
+    Assert.True(File.Exists path, sprintf "seed not found: %s" path)
+    use doc = JsonDocument.Parse(File.ReadAllText path)
+    let vectors = doc.RootElement.GetProperty("vectors").EnumerateArray() |> Seq.toArray
+    Assert.True(vectors.Length >= 5, "expected at least 5 golden vectors")
+    for v in vectors do
+        let name = (v.GetProperty "name").GetString()
+        let expectedHex = (v.GetProperty "cbor").GetString()
+        let e = entryOfJson (v.GetProperty "entry")
+        // encode → must equal the seed hex (the byte-lock the other oracles conform to)
+        Assert.Equal(expectedHex, toHex (DeltaLogEntryCodec.encodeCbor keyEnc e))
+        // decode(seed hex) → must round-trip back to the structured entry
+        let decoded = DeltaLogEntryCodec.decodeCbor keyDec (ofHex expectedHex)
+        Assert.True(eq e decoded, sprintf "round-trip mismatch for vector '%s'" name)


### PR DESCRIPTION
The byte-lock treaty seed for the `Log` noun (roadmap item #2). `src/Core.TypeScript/delta-log-entry/golden-vectors.json`: 5 canonical CBOR vectors (hex-in-JSON) — empty / single-insert / multi-key+ℤ-retraction / captured-present / captured-ordinal-sort. Produced by the F# reference oracle; C#/Rust/TS conform byte-identical (entry inherits DynamicValue's CBOR lock — no new encoding). F# test locks encode→hex + decode(hex)→round-trip. 5 tests green.

Next: C#/Rust/TS oracles replay the seed; migrate GitDeltaLog/DiskDeltaLog off System.Text.Json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)