### PR TITLE
fix(ci)+docs: green markdownlint (workitem MD032) + capture file-type plugin model

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -71,6 +71,16 @@ using DynamicValue's byte-locked per-format serializer:
   future custom) is a **plugin** with special handling, registered behind a stable contract: **closed for
   modification, open for extension**. New file types extend via new plugins without touching the core; the
   MD+frontmatter treaty is one such plugin. This is the extensibility model for the whole format roster.
+- **What a plugin IS (Aaron 2026-06-07):** a file-type handler is just a **specific handler mapping that
+  file type ↔ a `ZSet`**. On top of that, a plugin may **optionally auto-define indexes as Rx queries over
+  the ZSet → incremental indexed views** (DBSP/IVM): the **current view table is computed this way, and it
+  *is* git's "main"** — the materialized current state = the incremental view over the Log's ZSets (our
+  mapping to git's working tree/HEAD). The indexed view is **optional per file type**; each file type
+  chooses its own indexes, described by **Rx queries** (ties to the Bonsai serialized-Rx substrate). And
+  the **plugin itself is persisted as a `DynamicValue`, not F#**, so the *same plugin runs in any of the 4
+  languages** (plugin-as-data, language-agnostic — no per-language reimplementation). Composes with: DBSP
+  IVM (`Circuit`/`Operators`/`Incremental`), Bonsai-serialized Rx queries, `DynamicValue` (the plugin
+  carrier), `ZSet` (the core). → backlog to design; clarifies the data-layer shape.
 
 ### Sequence (data plane first)
 

--- a/workitems/081KTGD5JMD08QG0R000CEZ1D5-log-noun-canonical-entry-byte-lock-deltalogentry-seq-delta-c.md
+++ b/workitems/081KTGD5JMD08QG0R000CEZ1D5-log-noun-canonical-entry-byte-lock-deltalogentry-seq-delta-c.md
@@ -38,15 +38,19 @@ B-0969 precedent) for cross-language/DST determinism. This is exactly why `Log` 
 
 ## What (the canonical encoding)
 
-Define ONE canonical entry encoding, CBOR (RFC 8949, matching the DynamicValue/ZSet exemplars), shared
-by every backend and all four oracles. The new byte-lock surface is just the **envelope** around the
-already-locked `Delta`:
-- `Seq : int64` — CBOR integer.
-- `Delta : ZSet<'K>` — reuse the existing canonical ZSet CBOR (already 4/4 locked).
-- `Captured : Map<string,string>` — CBOR map with **ordinal-sorted keys** (deterministic; the one real
-  decision). Empty map when the producer was pure.
-- Entry framing: a fixed 3-element CBOR array `[Seq, DeltaCbor, CapturedCbor]` (order-fixed, not a
-  by-name map, to avoid key-ordering questions on the envelope itself).
+The whole entry maps to a `DynamicValue.Object` and rides DynamicValue's already-byte-locked canonical
+serializers — so the entry INHERITS the 4-language lock with no new canonical encoding (an entry is just
+a DynamicValue; no new noun). As-shipped (F# reference, #6730/#6735):
+
+- `Object` with keys `captured` / `delta` / `seq` (ordinal key order — DynamicValue.Object is
+  order-preserving, so the mapping fixes the order).
+- `seq` → `DynamicValue.Int` (int64).
+- `delta` → `ZSetDynamic.toDynamicValue` (the existing ZSet↔DynamicValue mapping, already 4/4 locked).
+- `captured` → `DynamicValue.Object` with **ordinal-sorted keys** (culture-invariant, B-0969 — the one
+  real decision; deterministic across languages + DST). Empty object when the producer was pure.
+
+Format is per-stream/table (CBOR default for filesystem; YAML for git once a DynamicValue YAML
+serializer lands; JSON/XML also available) — all ride the same `DeltaLogEntryDynamic` mapping.
 
 ## Slices (seed-first, one PR each)
 

--- a/workitems/081KTGES04808QG0R0010AK90E-file-type-plugin-model-plugin-file-type-zset-handler-optiona.md
+++ b/workitems/081KTGES04808QG0R0010AK90E-file-type-plugin-model-plugin-file-type-zset-handler-optiona.md
@@ -1,0 +1,63 @@
+---
+id: 081KTGES04808QG0R0010AK90E
+type: task
+state: backlog
+priority: P2
+slug: file-type-plugin-model-plugin-file-type-zset-handler-optiona
+title: "File-type plugin model — plugin = file-type<->ZSet handler + OPTIONAL Rx-defined incremental indexed views (=git main); plugin persisted as DynamicValue to run in all 4 langs; open/closed"
+created: 2026-06-07T07:11:54.504Z
+depends_on: []
+composes_with: []
+---
+
+# File-type plugin model — plugin = file-type<->ZSet handler + OPTIONAL Rx-defined incremental indexed views (=git main); plugin persisted as DynamicValue to run in all 4 langs; open/closed
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTGES04808QG0R0010AK90E-*.md` glob. -->
+
+## Source (Aaron 2026-06-07, verbatim intent)
+
+> "the file type handlers are just specific handlers for zsets mapped to that file type. most indexes
+> over zsets for file types can be auto-defined too with the plugin as rx queries over the zset into
+> incremental indexed views; current view tables can always be computed this way and matches git's main
+> basically for our mapping here. but even that should be optional over the file type — the indexed view
+> is optional and each file type can choose its indexes and describe with rx queries. and we can persist
+> the plugin as a dynamicvalue instead of f# so it can run in any of our 4 languages."
+
+## The model
+
+A **file-type plugin** has three layers, the last two optional:
+
+1. **Handler = file-type ↔ `ZSet` mapping** (required). Parse a file of this type into a ZSet; emit it
+   back. This is the per-file-type realization of the format/header+body treaty (markdown, yaml, cbor, …).
+2. **Optional Rx-defined incremental indexed views.** A plugin MAY auto-define indexes as **Rx queries
+   over the ZSet** → DBSP/IVM **incremental indexed views**. The **current view table** is computed this
+   way, and it **IS git's "main"** in our mapping (materialized current state = the incremental view over
+   the Log's ZSets = git working tree/HEAD). **Optional per file type**; each type chooses its own indexes,
+   described by Rx queries.
+3. **Plugin persisted as a `DynamicValue`, not F# code.** The plugin is **data**, so the *same plugin runs
+   in any of the 4 languages* (no per-language reimplementation) — Bonsai-serialized Rx + DynamicValue
+   carrier make the index definitions portable.
+
+**Open/Closed:** new file types + new indexes extend via new plugins (data), never by modifying the core.
+
+## Composes with (existing substrate)
+
+- `ZSet` / `IndexedZSet` (the core + keyed index rung), DBSP IVM (`Circuit`/`Operators`/`Incremental`).
+- **Bonsai-serialized Rx** (the self-evolving-saga substrate — serialize the Rx query as DynamicValue;
+  see PRIMITIVE-REGISTRY "serializable deferred execution").
+- `DynamicValue` (plugin-as-data carrier, 4-lang byte-locked), the format/file-type treaty (ROADMAP).
+
+## Open questions
+
+- The plugin contract surface (what a plugin DynamicValue must declare: file-type tag, handler verbs,
+  optional index Rx-query list).
+- How "current view = git main" maps precisely (the fold/IVM ↔ git working-tree correspondence).
+- Registration/discovery of plugins (a plugins-as-rows Log, naturally).
+
+## Anchors
+
+- `docs/ROADMAP.md` (format/file-type treaty + this plugin model) · two-plane DB design doc · B-0959.
+- Depends conceptually on the Log noun byte-lock (081KTGD5JMD) + a DynamicValue YAML serializer +
+  the Bonsai-Rx serialization substrate.


### PR DESCRIPTION
**CI fix (priority):** the Log workitem tripped MD032 on main (list missing surrounding blank lines); markdownlint runs on `**/*.md` so it failed every gate. Fixed + corrected that section's stale framing to match shipped (DynamicValue.Object). The windows-build-test failure on that run was a flake (all test DLLs 'Test Run Successful').

**Capture (Aaron):** file-type plugin model — plugin = file-type↔ZSet handler + OPTIONAL Rx-defined incremental indexed views (= git's main in our mapping; optional per type) + plugin persisted as DynamicValue so the same plugin runs in all 4 languages. Roadmap + workitem 081KTGES048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)