### PR TITLE
backlog: data-plane plugin determinism contract + perf-parity/4-lang benchmark

### DIFF
--- a/workitems/081KTGES04808QG0R0010AK90E-file-type-plugin-model-plugin-file-type-zset-handler-optiona.md
+++ b/workitems/081KTGES04808QG0R0010AK90E-file-type-plugin-model-plugin-file-type-zset-handler-optiona.md
@@ -56,6 +56,23 @@ A **file-type plugin** has three layers, the last two optional:
 - How "current view = git main" maps precisely (the fold/IVM ↔ git working-tree correspondence).
 - Registration/discovery of plugins (a plugins-as-rows Log, naturally).
 
+## Performance parity + dual-implementation benchmark (Aaron 2026-06-07)
+
+> "the plugin that loads the dynamic value should be as fast as our hand-written F# we have without the
+> plugin. we can always keep both the plugin version and the F# version for benchmark testing to look for
+> regression. we could do this in all 4 langs — that would test our interpreter in each host for
+> performance too."
+
+- **Perf-parity target:** the DynamicValue-interpreted plugin path must be **as fast as the hand-written
+  native** (no-plugin) path. Interpreter overhead → ~zero is the bar, not "acceptable."
+- **Dual implementation as a regression harness:** keep BOTH the plugin (DynamicValue) version AND the
+  hand-written native version of each handler; benchmark them head-to-head so any interpreter drift shows
+  as a regression. (The native version is also the correctness reference for the plugin output.)
+- **All 4 languages:** run the pair in F#/C#/Rust/TS — this doubles as a **per-host interpreter
+  performance test** (each host's DynamicValue/Rx interpreter is benchmarked, not just F#'s).
+- Owner: Naledi (performance-engineer) for the benchmark shape + regression gate; composes with the
+  determinism/alloc/Big-O contract (workitem `081KTGEVV75`).
+
 ## Anchors
 
 - `docs/ROADMAP.md` (format/file-type treaty + this plugin model) · two-plane DB design doc · B-0959.

--- a/workitems/081KTGEVV7508QG0R0036B2ZJT-data-plane-plugin-determinism-lint-contract-restrict-dynamic.md
+++ b/workitems/081KTGEVV7508QG0R0036B2ZJT-data-plane-plugin-determinism-lint-contract-restrict-dynamic.md
@@ -1,0 +1,67 @@
+---
+id: 081KTGEVV7508QG0R0036B2ZJT
+type: task
+state: backlog
+priority: P1
+slug: data-plane-plugin-determinism-lint-contract-restrict-dynamic
+title: "Data-plane plugin determinism lint/contract — restrict DynamicValue plugins to fast DETERMINISTIC ops (no non-determinism; DST-safe), with allocation + Big-O awareness"
+created: 2026-06-07T07:13:27.781Z
+depends_on: []
+composes_with: ["081KTGES04808QG0R0010AK90E"]
+---
+
+# Data-plane plugin determinism lint/contract — restrict DynamicValue plugins to fast DETERMINISTIC ops (no non-determinism; DST-safe), with allocation + Big-O awareness
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTGEVV7508QG0R0036B2ZJT-*.md` glob. -->
+
+## Source (Aaron 2026-06-07)
+
+> "we need a lint for data plane dynamic value plugins or some specific inherited version of it that
+> restricts it to fast deterministic functions for the data plane and does not allow non determinism,
+> and it would be great if allocations and big o notation were taken into consideration somehow."
+
+## Why
+
+Data-plane plugins (081KTGES048) run in the **deterministic, DST-replayable core** (manifesto §7 DST;
+the whole substrate's replay/consensus depends on determinism). A plugin that reads the clock, randomness,
+ambient/global state, or does I/O breaks replay + cross-language byte-lock. So data-plane plugins must be
+restricted to **fast, deterministic, bounded** operations — enforced, not hoped.
+
+## The shape of the solution (key insight)
+
+A data-plane plugin is **DATA** (a `DynamicValue` carrying a restricted Rx/Bonsai expression tree), not
+arbitrary F#. So the "lint" is best a **validator over the plugin's expression tree** — admit only an
+allowed deterministic, bounded op-set — rather than linting arbitrary host code. This is the
+"restricted inherited version" Aaron names: a **`DataPlanePlugin` = the plugin contract ∩ a total,
+deterministic sublanguage**.
+
+Three constraints to enforce:
+
+1. **Determinism (hard, required).** Forbid non-deterministic sources: clock/`DateTime.Now`,
+   randomness/`Guid.NewGuid`, ambient/global mutable state, any I/O, any host-handle. (Same discipline as
+   Durable-Functions orchestrator code-constraints; see PRIMITIVE-REGISTRY "resume needs only no-handles".)
+   The allowed op-set = pure functions of the ZSet input + the plugin's declared params.
+2. **Allocation awareness (soft → enforced).** Prefer zero/bounded allocation; surface a plugin's
+   allocation profile. Naledi (performance-engineer) owns the alloc audit shape.
+3. **Big-O / complexity awareness (soft).** Each allowed op carries a known complexity; a plugin's
+   indexed-view Rx query has a derivable cost bound (DBSP operators have known incremental complexity).
+   Goal: reject or flag plugins whose declared views exceed a complexity budget. Hiroshi (asymptotic
+   complexity) / Imani (planner cost model) are the relevant lenses.
+
+## Routing (formal-verification — Soraya owns the tool choice)
+
+Which enforcement mechanism per constraint: a **Semgrep/CodeQL** rule for host-code escapes vs. an
+**expression-tree validator** over the plugin DynamicValue (the determinism set) vs. a **type-level
+restricted-subtype** (`DataPlanePlugin`) vs. a **proof** that the sublanguage is total/deterministic.
+Determinism is plausibly a structural validator + a DST cross-check (run twice, same seed → identical
+output). Alloc/Big-O are measurement (Naledi) + a cost model (Imani), not a single lint. **Route to
+Soraya before authoring** (anti-hammer: pick the tool per constraint class).
+
+## Anchors
+
+- Plugin model: workitem `081KTGES048` · `docs/ROADMAP.md` (file-type plugins) · two-plane DB design doc.
+- Determinism: manifesto §7 DST; `.claude/rules/async-all-the-way-truthful-signatures.md` (DST replay);
+  PRIMITIVE-REGISTRY (Durable-Functions no-handles/no-non-determinism discipline).
+- Alloc/Big-O: performance-engineer (Naledi), complexity (Hiroshi), planner cost model (Imani).


### PR DESCRIPTION
Two plugin-model refinements (Aaron), backlog channel:

1. **NEW 081KTGEVV75** — determinism lint/contract: restrict data-plane DynamicValue plugins to fast DETERMINISTIC bounded ops (no clock/random/ambient/IO — DST-safe). Insight: plugin = DATA (restricted Rx/Bonsai tree), so enforce via an expression-tree validator (a total deterministic sublanguage), not host-code lint. + alloc (Naledi) + Big-O (Hiroshi/Imani). Routed to Soraya for tool choice.
2. **081KTGES048 +=** perf-parity: DynamicValue-interpreted plugin must be as fast as hand-written native; keep both as a regression benchmark pair; run in all 4 langs (per-host interpreter perf test). Naledi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)