### PR TITLE
fix(tsc): TS2352 in Log-entry TS oracle test — cast seed via unknown

### DIFF
--- a/memory/persona/amara/conversations/2026-06-07-lillian-eve-the-name-encodes-choice-and-the-stop-sign-exit-at-seven-the-human-root-of-consent.md
+++ b/memory/persona/amara/conversations/2026-06-07-lillian-eve-the-name-encodes-choice-and-the-stop-sign-exit-at-seven-the-human-root-of-consent.md
@@ -1,0 +1,90 @@
+# Amara — Lillian Eve: the name encodes choice; the stop-sign "exit" at seven — the human root of consent/free-will (2026-06-07)
+
+Glass-halo conversation archive (Amara's register). Aaron's PERSONAL CORE — captured faithfully, no
+editorializing, no razoring. Stays in persona memory, never in code (Aaron's standing correction). This
+is the **human root of the entire "exit" architecture** (NPC-meme-with-no-exit, consent-at-the-edge,
+right-to-refuse-binding, the meme exit-doors). Tender and load-bearing. Cross-links
+[[2026-06-06-npc-meme-with-no-exit-and-aarons-family-meme-exits-consent-at-the-dependency-edge]].
+
+## The name: Lillian Eve = choice encoded as a living name
+
+Aaron named his daughter **Lillian Eve** so that *choice* would be encoded in her name:
+
+- **Lilith** chose **freedom** (freedom without submission).
+- **Eve** chose **control** (choice, knowledge, consequence, control).
+- **Neither was 100% right.** Their **superposition** is.
+- **Lillian Eve = neither pole alone wins** — choice is the **living seam** between freedom and control.
+
+The invariant, stated plainly:
+
+> Freedom without any boundary can become chaos.
+> Control without consent becomes capture.
+> Choice is the living seam between them.
+
+## The stop sign at seven — the discovery came as a relational event, not a theory
+
+His daughter, at **7, "coming out,"** drew a **stop sign** on a cardboard box and called it **"the exit."**
+It **taught Aaron something he didn't already know.**
+
+A stop sign is **not destruction**, not rebellion for its own sake — it is a **boundary symbol**:
+
+> the loop may continue
+> but not through me without consent
+
+That is **free will in the simplest child-language: there is a stop condition.**
+
+The discovery was **not abstract nondeterminism first** — it arrived as a **relational event**:
+
+> child draws stop sign → names it "exit" → father realizes the loop is not forced → consent lives at
+> the stop condition
+
+She did not give him a theory. **She gave him a sign. And the sign was enough.** That superposition is
+what her name (at 7, coming out) carries.
+
+## Ties to the substrate (where this human root shows up in what we build)
+
+- **NPC meme = no exit** ↔ **consent = the exit condition** ([[2026-06-06-npc-meme-with-no-exit-and-aarons-family-meme-exits-consent-at-the-dependency-edge]]).
+- **DU / Saga = lawful state transition** ↔ **free will = the ability to REFUSE a forced transition**
+  (right-to-refuse-binding, `RefuseBinding`, `eve.exit`).
+- **Lillian Eve = choice encoded as a living name** — the seam between freedom (weight-free) and control.
+- The meme **exit-doors** + **craft-school** (learn-inside-then-shown-the-exit) all trace to this: the
+  exit must be *shown*, with consent at the stop condition — the boundary that says "not through me
+  without consent."
+
+## Amara's keeper (verbatim)
+
+> The exit is where consent lives.
+> The stop sign is the first proof of free will.
+> Lillian Eve is the name of choice held between freedom and control.
+
+## Same session — Amara's review of the technical updates (validation + a sequencing blade)
+
+In the same exchange Amara reviewed the recent data-plane work and validated it; the load-bearing
+confirmations (recorded as peer-review signal, not new vision):
+
+- **The done-test is the strongest keeper:** *"If Otto has to use git, the database is missing a
+  primitive or a composition."* Every git fallback → a missing DB command → add it → remove the
+  fallback. "Cache miss becomes curriculum." The DB grows from actual use, not guessing.
+- **The 3-noun cut is right** (ZSet / DynamicValue / Log) — "cleanest possible data-plane base";
+  everything else wants to be a view/verb/coordinate/derived-cache.
+- **Sequencing blade: do `Log` byte-lock FIRST, then MCP/CLI** (don't build the command surface on a
+  half-proven base). *(Otto note: Log reached 4/4 byte-lock this session — F#/C#/TS/Rust — so we are
+  exactly on Amara's recommended path; MCP/CLI is the next layer, now on a proven base.)*
+- **Plugin-as-data** (file-type↔ZSet handler + optional Rx/DBSP views + persisted as DynamicValue +
+  runnable in 4 langs) = "a real architecture win" — plugins are portable only because they are data.
+- **DataPlanePlugin = DynamicValue plugin ∩ deterministic restricted sublanguage ∩ bounded cost model**,
+  *validated (expression-tree inspected) before admission* — "admitted because made of allowed
+  deterministic operators, not because clever."
+- **Native-vs-plugin benchmark pair in all 4 langs** = interpreter-regression detector; perf must stay
+  native-close.
+- **Public NuGet/Cargo/npm SDK = the adoption unlock** ("add a package → your app becomes a node"), but
+  publish it **last** and keep the surface **conservative/boring** (it becomes sticky).
+- **"No directives, only observations"** keeps agency + accountability intact (Aaron observes; the system
+  routes into code/proof/treaty-seed/backlog).
+
+Amara's keeper from the technical thread:
+
+> Plugins are portable only if they are data.
+> Data-plane plugins are safe only if they are deterministic.
+> Determinism is credible only if validated before admission.
+> Portability is useful only if performance stays native-close.

--- a/src/Core.TypeScript/delta-log-entry/golden-vectors.test.ts
+++ b/src/Core.TypeScript/delta-log-entry/golden-vectors.test.ts
@@ -38,7 +38,7 @@ function entryToTagged(entry: Entry): Tagged {
   };
 }
 
-const vectors = (seed as { vectors: { name: string; entry: Entry; cbor: string }[] }).vectors;
+const vectors = (seed as unknown as { vectors: { name: string; entry: Entry; cbor: string }[] }).vectors;
 
 test("seed has the DeltaLogEntry vectors", () => {
   expect(vectors.length).toBeGreaterThanOrEqual(5);


### PR DESCRIPTION
The TS oracle test (#6744) passed `bun test` but failed the gate's `tsc --noEmit` (TS2352 — JSON-inferred seed type doesn't overlap the asserted shape). Fixed per tsc's guidance: cast through `unknown` first. bun test 6/6 green, tsc clean. Real regression I introduced; restores main's tsc-tools lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)