### PR TITLE
backlog: plugin DI-as-DynamicValue (negotiated base) + correct windows DiskDeltaLog diagnosis

### DIFF
--- a/workitems/081KTGES04808QG0R0010AK90E-file-type-plugin-model-plugin-file-type-zset-handler-optiona.md
+++ b/workitems/081KTGES04808QG0R0010AK90E-file-type-plugin-model-plugin-file-type-zset-handler-optiona.md
@@ -56,6 +56,43 @@ A **file-type plugin** has three layers, the last two optional:
 - How "current view = git main" maps precisely (the fold/IVM ↔ git working-tree correspondence).
 - Registration/discovery of plugins (a plugins-as-rows Log, naturally).
 
+## DI / interface contract as DynamicValue + what else can be a plugin (Aaron 2026-06-07)
+
+> "is there anything else we can make plugins given the data constraint of plugins? the thought is the
+> plugins depend on the interfaces and the DI setup can be part of the dynamicvalue too — or at least the
+> negotiated base; the host may have additional DI injections or requirements."
+
+**DI/wiring is also data.** A plugin depends on *interfaces*; that dependency contract can itself be a
+`DynamicValue` — at least a **negotiated base**: the plugin declares (as data) the interfaces it
+requires, the host's DI container resolves them, and the host **may inject additional** host-specific
+capabilities/requirements. This is the **Eve Protocol / QueryInterface** ("what shape do you support?")
+applied to plugin wiring: the DI contract is negotiated data, not compiled-in.
+
+This is also how a *deterministic* plugin can still reach effectful capability **without breaking the
+data-plane determinism contract** (`081KTGEVV75`): the plugin's pure core declares an effectful
+capability as a **required interface** (a DECLARED dependency); the host injects a concrete impl; the
+plugin logic stays DST-replayable given the same injected behavior (record/replay the injected calls).
+The determinism boundary becomes explicit — pure expression tree + declared injected deps — rather than
+"no effects at all." Negotiated base = the minimum interface set any host must satisfy; host extras are
+additive.
+
+**What else can be a plugin** (given plugin = deterministic restricted `DynamicValue` expression tree +
+declared interface deps — anything that fits this shape):
+
+- File-type handlers / codecs (the seed case) and their optional Rx indexed views.
+- Validators / schema mappers / migration (schema-evolution) rules — deterministic transforms.
+- Reducers / fold functions over a Log; access/redaction predicates (deterministic).
+- Query/transform pipelines (Rx/DBSP over ZSets); negotiation/diplomacy shapes (Eve Protocol as data).
+- **The DI/wiring contract itself** (the negotiated interface base) — data, not code.
+
+NOT a plugin (must be a host-injected capability the plugin *declares*, not embeds): anything inherently
+non-deterministic (clock, randomness, network/IO, ambient state) — surfaced as a required interface and
+recorded for DST replay.
+
+Open: the negotiated-base schema (how a plugin declares required interfaces in DynamicValue), and the
+host-extension protocol (how a host advertises additional injectables). Composes with Eve Protocol
+(`Diplomacy.fs`), the determinism contract (`081KTGEVV75`), and `DynamicValue` as the carrier.
+
 ## Performance parity + dual-implementation benchmark (Aaron 2026-06-07)
 
 > "the plugin that loads the dynamic value should be as fast as our hand-written F# we have without the

--- a/workitems/081KTGGXMQ008QG0R002BK46CF-windows-groupcommitdiskdeltalog-scanentries-io-sharingviolat.md
+++ b/workitems/081KTGGXMQ008QG0R002BK46CF-windows-groupcommitdiskdeltalog-scanentries-io-sharingviolat.md
@@ -31,20 +31,31 @@ Zeta.Tests.Storage.DiskDeltaLogTests."group-commit segment log truncates torn tr
 **Pre-existing + windows-specific** — NOT introduced by the Log-noun work; reproduces only on Windows
 (Unix file semantics don't enforce share-mode, so macOS/Linux CI is green). It keeps Windows CI red.
 
-## Diagnosis
+## Diagnosis (CORRECTED 2026-06-07 after reading the source)
 
-`scanEntries` (recovery path) opens `delta.segment` while another handle on the same file is still
-open (the writer/append handle, or the torn-write truncation re-open). Windows enforces file
-share-mode; a second open without a compatible `FileShare` flag → `IO_SharingViolation`. Unix ignores
-this, masking the bug off-Windows. It's in the **data-plane durability/recovery path** (`Log` noun
+The `scanEntries` open at `DiskDeltaLog.fs:231` **already** uses `FileShare.ReadWrite`:
+
+```fsharp
+use fs = new FileStream(segmentPath, FileMode.Open, access, FileShare.ReadWrite)
+```
+
+So the failing open is NOT the culprit — the `IO_SharingViolation` means **another live handle on
+`delta.segment` is open with a share mode that excludes this open** (i.e. the **writer/append
+FileStream** held elsewhere — likely the ctor/append path — was opened *without* `FileShare.ReadWrite`,
+or is not disposed before recovery scans). Windows enforces share-mode intersection across all open
+handles; Unix ignores it, masking the bug off-Windows. Data-plane durability/recovery path (`Log` noun
 backend), so it matters for the "reliable single-node DB" claim.
 
-## Fix direction
+## Fix direction (CORRECTED)
 
-- Open the segment with `FileShare.ReadWrite` (or `Read`) on the recovery scan, **and/or** ensure the
-  prior writer handle is flushed + disposed before `scanEntries` re-opens (deterministic handle
-  lifetime). Prefer `using`/`use` scoping so no handle outlives the read.
-- Add a Windows-aware test assertion (the test already exercises the path; the fix is in the open call).
+- **The fix is on the WRITER side, not the scan.** Find the append/writer `FileStream` open (the group-
+  commit writer; ctor `DiskDeltaLog.fs:~181` and the append path) and ensure it is opened with
+  `FileShare.ReadWrite` so a concurrent recovery read is allowed — **and/or** ensure the writer handle
+  is flushed + disposed before `scanEntries` runs (deterministic `use`/`using` lifetime; no writer
+  handle outliving a recovery scan).
+- Needs **Windows verification** — the failure only reproduces on Windows, so the fix can't be confirmed
+  on macOS/Linux locally; a Windows CI run (or a Windows owner) must verify. (This is why it was filed,
+  not blind-fixed: the scan's own open was already correct; the writer-handle lifecycle is the subtle part.)
 
 ## Anchors
 


### PR DESCRIPTION
1. **Plugin DI-as-data** (Aaron): a plugin's interface/DI contract is itself a DynamicValue — a negotiated base (plugin declares required interfaces; host resolves + may inject additional). Eve Protocol/QueryInterface applied to wiring; also how a deterministic plugin reaches effectful capability (declare as required interface → host injects → DST replays). Enumerates what-else-can-be-a-plugin. (081KTGES048)
2. **DiskDeltaLog diagnosis corrected**: scanEntries already has FileShare.ReadWrite, so the culprit is the writer handle (not the scan); fix is writer-side, needs windows verification. (081KTGGXMQ0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)