### PR TITLE
feat(Log/081KTGD5JMD): backend migration step 1 — IEntryCodec seam + CborEntryCodec (additive)

### DIFF
--- a/src/Core/DeltaCodec.fs
+++ b/src/Core/DeltaCodec.fs
@@ -144,3 +144,27 @@ module DeltaLogEntryCodec =
         match DynamicValue.fromCanonicalJson json with
         | Ok dv -> DeltaLogEntryDynamic.ofDynamicValue keyDec dv
         | Error e -> invalidArg (nameof json) $"DeltaLogEntryCodec.decodeJson: non-decodable JSON: {e}"
+
+
+/// **Whole-entry serialization seam** — encodes a full `DeltaLogEntry` (Seq + Delta + Captured) to
+/// canonical bytes and back. The migration target for the durable backends (`GitDeltaLog` /
+/// `DiskDeltaLog`): serialize the WHOLE entry through this — the proven, 4-language byte-locked
+/// `DeltaLogEntryCodec` format (golden seed `src/Core.TypeScript/delta-log-entry/golden-vectors.json`) —
+/// replacing the per-backend `System.Text.Json` framing of the `Captured` map. Distinct from
+/// `IDeltaCodec` (which encodes only the ZSet delta): an entry is `(Seq, Delta, Captured)`, and the whole
+/// entry is the cross-language treaty unit. MUST be a lossless round-trip: `Decode (Encode e) = e`.
+type IEntryCodec<'K when 'K : comparison> =
+    abstract Encode: DeltaLogEntry<'K> -> byte[]
+    abstract Decode: byte[] -> DeltaLogEntry<'K>
+
+
+/// Canonical **CBOR** whole-entry codec — rides `DeltaLogEntryCodec` (the DynamicValue-locked canonical
+/// CBOR). The backend migration target: byte-identical across F#/C#/Rust/TS, so the on-disk / in-git
+/// bytes ARE the cross-language treaty. The `Seq` rides inside the entry, so `Decode` needs no external
+/// sequence argument.
+[<Sealed>]
+type CborEntryCodec<'K when 'K : comparison>
+    (keyEnc: 'K -> DynamicValue, keyDec: DynamicValue -> 'K) =
+    interface IEntryCodec<'K> with
+        member _.Encode entry = DeltaLogEntryCodec.encodeCbor keyEnc entry
+        member _.Decode bytes = DeltaLogEntryCodec.decodeCbor keyDec bytes

--- a/tests/Tests.FSharp/DeltaLogEntryCodec.Tests.fs
+++ b/tests/Tests.FSharp/DeltaLogEntryCodec.Tests.fs
@@ -113,3 +113,17 @@ let ``Golden treaty: F# reproduces the shared seed's canonical CBOR + round-trip
         // decode(seed hex) → must round-trip back to the structured entry
         let decoded = DeltaLogEntryCodec.decodeCbor keyDec (ofHex expectedHex)
         Assert.True(eq e decoded, sprintf "round-trip mismatch for vector '%s'" name)
+
+// ── The IEntryCodec seam (CborEntryCodec) — the backend migration target. It must be byte-faithful to
+//    the proven DeltaLogEntryCodec.encodeCbor (so backends storing via the seam store the treaty bytes)
+//    and round-trip losslessly. This is the interface GitDeltaLog/DiskDeltaLog migrate onto. ──
+
+[<Fact>]
+let ``CborEntryCodec is byte-faithful to DeltaLogEntryCodec.encodeCbor + round-trips`` () =
+    let codec = CborEntryCodec<string>(keyEnc, keyDec) :> IEntryCodec<string>
+    for e in samples do
+        // the seam produces exactly the proven canonical bytes
+        Assert.Equal<byte[]>(DeltaLogEntryCodec.encodeCbor keyEnc e, codec.Encode e)
+        // and decodes back losslessly
+        let rt = codec.Decode(codec.Encode e)
+        Assert.True(eq e rt, sprintf "CborEntryCodec round-trip mismatch for seq %d" e.Seq)


### PR DESCRIPTION
Seam-first start of the backend migration off System.Text.Json onto the canonical codec (Aaron-greenlit). Additive, zero ripple:
- `IEntryCodec<'K>` — whole-entry (Seq+Delta+Captured) codec seam the backends adopt (distinct from ZSet-only `IDeltaCodec`).
- `CborEntryCodec<'K>` — rides the proven `DeltaLogEntryCodec` (byte-identical across 4 langs).
- Test: byte-faithful to `DeltaLogEntryCodec.encodeCbor` + round-trips (6/6 green).

Next: migrate GitDeltaLog ctor `IDeltaCodec`→`IEntryCodec` (drops STJ framing; ~8 git test sites), then DiskDeltaLog — each a focused durability-path PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)