### PR TITLE
docs(architecture): names decided (Nucleus, Geode=host-concern) + ZetaID as universal cross-layer pointer

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,22 +24,37 @@ clearly?"* Anything that converts to none of the four is drift. (Detail:
 
 ### Layer names — TENTATIVE (pending naming-expert + Ilyana review; unanchored coinage = debt)
 
-Proposed set (Amara 2026-06-07) for the stack layers — **NOT yet load-bearing**; a naming-expert +
-public-API (Ilyana) pass decides before any public/glossary use:
+Proposed set (Amara 2026-06-07, refined with Aaron) — internal direction **decided**; still pending a
+naming-expert + public-API (Ilyana) pass before any **public/glossary** use (unanchored coinage = debt):
 
-| Layer | Tentative name | Settled? |
-|-------|----------------|----------|
+| Layer | Name | Status |
+|-------|------|--------|
 | package-manager-of-package-managers | **Ace** | ✅ settled |
 | data plane + cell substrate | **Zeta** | ✅ settled |
-| DI/plugin **microcore** (MEF-like) | **Kernel** (or `Nucleus` — Kernel is OS-overloaded) | tentative |
-| within-cell HA / resilience | **Geode**? | ⚠️ **collision** |
-| cross-cell saga / control layer | **Loom** (weaves cells without collapsing them) | tentative |
+| DI/plugin **microcore** (MEF-like) | **Nucleus** | ✅ decided (Aaron — over `Kernel`, which is OS-overloaded) |
+| cross-cell saga / control layer | **Loom** (weaves cells without collapsing them) | ✅ decided |
+| within-cell HA / resilience | *(no layer name)* | resolved — **a host concern, not a named layer** |
+| the cell's replication shape | **Geode** | the cell IS a geode (§1); not the HA shell |
 
-⚠️ **Naming collision to resolve:** we already established *cells ARE geodes* (full-replication-within /
-partial-across — see this doc's §1). So **`Geode` most naturally names the cell / its replication model,
-not the within-cell HA shell.** Using `Geode` for HA collides with that. The within-cell HA layer likely
-wants a different name (e.g. the resilience *shell* / *vault* / *anchor*); `Geode` should stay attached to
-the cell-as-geode concept. Flag for the naming pass.
+**Resolved (Aaron):** within-cell HA is **a host concern, not its own named layer** — k8s/Orleans provide
+it, systemd doesn't; it's a deployment property of a cell. So `Geode` stays attached to the **cell /
+replication concept** (a cell IS a geode — full-within/partial-across), and HA needs no separate coinage.
+Four named layers: **Ace · Zeta · Nucleus · Loom** (a cell = a Geode within Zeta). Public/glossary
+anchoring still goes through the naming-expert + Ilyana pass before any external use.
+
+### ZetaID — the universal cross-layer pointer
+
+> Aaron 2026-06-07: *"ZetaID is the universal pointer across layers — this makes DynamicValue able to even
+> describe its own dependencies."*
+
+**ZetaID** (the 128-bit identity primitive) is the **one address space across every layer** — cells,
+streams/`Log`s, plugins, Saga/Loom actors, packages (Ace), Nucleus-composed components. Because the
+pointer is universal, a `DynamicValue` can **reference anything by ZetaID** — which makes a DynamicValue
+**self-describing including its own dependencies**: a plugin's required interfaces / DI negotiated-base, a
+cell's references, a Saga's correlation, a package's deps are all just **ZetaID pointers embedded in the
+DynamicValue**. So the dependency graph is data (DynamicValue + ZetaID refs), resolvable by Nucleus, and
+the same address routes the cross-cell partitioned bus (Actor ID = ZetaID). This closes the
+plugin-as-data / DI-as-data loop: deps don't need a side-channel — they live *in* the value, by ZetaID.
 
 ### ITEM #1 — NO USE OF THE GIT CLI
 

--- a/workitems/081KTGES04808QG0R0010AK90E-file-type-plugin-model-plugin-file-type-zset-handler-optiona.md
+++ b/workitems/081KTGES04808QG0R0010AK90E-file-type-plugin-model-plugin-file-type-zset-handler-optiona.md
@@ -89,9 +89,18 @@ NOT a plugin (must be a host-injected capability the plugin *declares*, not embe
 non-deterministic (clock, randomness, network/IO, ambient state) — surfaced as a required interface and
 recorded for DST replay.
 
-Open: the negotiated-base schema (how a plugin declares required interfaces in DynamicValue), and the
-host-extension protocol (how a host advertises additional injectables). Composes with Eve Protocol
-(`Diplomacy.fs`), the determinism contract (`081KTGEVV75`), and `DynamicValue` as the carrier.
+**Dependencies are ZetaID refs — the value self-describes its own deps (Aaron 2026-06-07).** ZetaID is
+the *universal cross-layer pointer*, so a plugin's declared dependencies (its required interfaces /
+negotiated-base, other plugins, cells, streams it reads) are just **ZetaID references embedded in the
+plugin's `DynamicValue`**. The plugin is therefore **fully self-describing including its dependency
+graph** — no side-channel: deps live *in* the value, addressed by ZetaID, resolved by the microcore
+(Nucleus). The same ZetaID routes the cross-cell partitioned bus (Actor ID = ZetaID). This closes the
+plugin-as-data / DI-as-data loop.
+
+Open: the negotiated-base schema (how a plugin declares required interfaces — as a list of ZetaID/
+interface refs in DynamicValue), and the host-extension protocol (how a host advertises additional
+injectables). Composes with Eve Protocol (`Diplomacy.fs`), the determinism contract (`081KTGEVV75`),
+`ZetaId` (the universal pointer), and `DynamicValue` as the carrier.
 
 ## Serializers + primitives as plugins, and the MEF-like microcore (Aaron 2026-06-07)
 


### PR DESCRIPTION
1. Names (Aaron decided): microcore = **Nucleus** (over Kernel); within-cell HA = **host concern, not a named layer**; **Geode** = the cell/replication concept (a cell IS a geode). Four layers: Ace · Zeta · Nucleus · Loom. Public anchoring still via naming-expert + Ilyana.
2. **ZetaID = universal cross-layer pointer** (Aaron): one address space across all layers → a DynamicValue can reference anything by ZetaID → **self-describes its own dependencies** (plugin deps/negotiated-base = ZetaID refs in the value; no side-channel). Closes the plugin-as-data/DI-as-data loop. Captured in roadmap + plugin workitem 081KTGES048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)