### PR TITLE
feat(Log/081KTGD5JMD): backend migration step 3 — DiskDeltaLog onto canonical IEntryCodec

### DIFF
--- a/src/Core/DiskDeltaLog.fs
+++ b/src/Core/DiskDeltaLog.fs
@@ -3,7 +3,6 @@ namespace Zeta.Core
 open System
 open System.Collections.Generic
 open System.IO
-open System.Text.Json
 open System.Threading
 open System.Threading.Tasks
 
@@ -27,7 +26,7 @@ type private GroupCommitDeltaAppendRequest =
 /// metadata stays readable independent of the delta codec.
 [<Sealed>]
 type DiskDeltaLog<'K when 'K : comparison>
-    (dir: string, codec: IDeltaCodec<'K>, ?fsyncPerAppend: bool) =
+    (dir: string, entryCodec: IEntryCodec<'K>, ?fsyncPerAppend: bool) =
 
     let fsync = defaultArg fsyncPerAppend false
     let root = Path.GetFullPath dir
@@ -48,34 +47,11 @@ type DiskDeltaLog<'K when 'K : comparison>
             |> Array.choose (fun p -> match seqOf p with ValueSome v -> Some v | ValueNone -> None)
         if existing.Length = 0 then 0L else Array.max existing
 
-    let frame (captured: Map<string, string>) (delta: ZSet<'K>) : byte[] =
-        let dict = Dictionary<string, string>()
-        for KeyValue (k, v) in captured do dict.[k] <- v
-        let capBytes = JsonSerializer.SerializeToUtf8Bytes dict
-        let deltaBytes = codec.Encode delta
-        use ms = new MemoryStream()
-        use bw = new BinaryWriter(ms)
-        bw.Write(capBytes.Length)
-        bw.Write(capBytes)
-        bw.Write(deltaBytes.Length)
-        bw.Write(deltaBytes)
-        bw.Flush()
-        ms.ToArray()
+    // One file = the WHOLE entry (Seq + Delta + Captured) through the canonical `IEntryCodec`
+    // (the 4-language byte-locked DeltaLogEntryCodec format) — no per-backend framing, no System.Text.Json.
+    let frame (entry: DeltaLogEntry<'K>) : byte[] = entryCodec.Encode entry
 
-    let unframe (bytes: byte[]) : Map<string, string> * ZSet<'K> =
-        use ms = new MemoryStream(bytes)
-        use br = new BinaryReader(ms)
-        let capLen = br.ReadInt32()
-        let capBytes = br.ReadBytes capLen
-        let captured =
-            JsonSerializer.Deserialize<Dictionary<string, string>> capBytes
-            |> fun d ->
-                match d with
-                | null -> Map.empty
-                | _ -> d |> Seq.map (fun kv -> kv.Key, kv.Value) |> Map.ofSeq
-        let deltaLen = br.ReadInt32()
-        let deltaBytes = br.ReadBytes deltaLen
-        captured, codec.Decode deltaBytes
+    let unframe (bytes: byte[]) : DeltaLogEntry<'K> = entryCodec.Decode bytes
 
     // Atomic append: write to a `.delta.tmp` then rename to `.delta`. A crash
     // mid-write leaves at most an orphan `.tmp` (ignored by the `*.delta` glob),
@@ -101,7 +77,7 @@ type DiskDeltaLog<'K when 'K : comparison>
     interface IDeltaLog<'K> with
         member _.AppendAsync(delta, captured, ct) =
             let seq = lock gate (fun () -> nextSeq <- nextSeq + 1L; nextSeq)
-            let bytes = frame captured delta
+            let bytes = frame { Seq = seq; Delta = delta; Captured = captured }
             task {
                 do! writeFileAsync (nameFor seq) bytes ct
                 return seq
@@ -118,10 +94,10 @@ type DiskDeltaLog<'K when 'K : comparison>
                 |> Array.sortBy fst
             task {
                 let entries = ResizeArray<DeltaLogEntry<'K>>()
-                for (seq, path) in files do
+                for (_seq, path) in files do
                     let! bytes = File.ReadAllBytesAsync(path, ct)
-                    let captured, delta = unframe bytes
-                    entries.Add { Seq = seq; Delta = delta; Captured = captured }
+                    // The entry's Seq rides inside the canonical bytes (== the file-name seq we wrote).
+                    entries.Add(unframe bytes)
                 return entries.ToArray()
             }
             |> ValueTask<DeltaLogEntry<'K>[]>
@@ -157,7 +133,7 @@ type DiskDeltaLog<'K when 'K : comparison>
 [<Sealed>]
 type GroupCommitDiskDeltaLog<'K when 'K : comparison>
     (dir: string,
-     codec: IDeltaCodec<'K>,
+     entryCodec: IEntryCodec<'K>,
      ?config: FerryThrottlerConfig,
      ?maxBatchBytes: int) =
 
@@ -182,21 +158,10 @@ type GroupCommitDiskDeltaLog<'K when 'K : comparison>
                 (nameof config)
                 "GroupCommitDiskDeltaLog writes one segment file; MaxDegreeOfParallelism must be 1."
 
-    let framePayload (seq: int64) (captured: Map<string, string>) (delta: ZSet<'K>) : byte[] =
-        let dict = Dictionary<string, string>()
-        for KeyValue (k, v) in captured do
-            dict.[k] <- v
-        let capBytes = JsonSerializer.SerializeToUtf8Bytes dict
-        let deltaBytes = codec.Encode delta
-        use ms = new MemoryStream()
-        use bw = new BinaryWriter(ms)
-        bw.Write(seq)
-        bw.Write(capBytes.Length)
-        bw.Write(capBytes)
-        bw.Write(deltaBytes.Length)
-        bw.Write(deltaBytes)
-        bw.Flush()
-        ms.ToArray()
+    // The record PAYLOAD is the WHOLE entry (Seq + Delta + Captured) through the canonical `IEntryCodec`
+    // (the 4-language byte-locked format); the record wrapper (`frameRecord`: [len][crc][payload]) is kept
+    // for torn-write scanning. No per-payload framing, no System.Text.Json.
+    let framePayload (entry: DeltaLogEntry<'K>) : byte[] = entryCodec.Encode entry
 
     let frameRecord (payload: byte[]) : byte[] =
         use ms = new MemoryStream()
@@ -207,21 +172,7 @@ type GroupCommitDiskDeltaLog<'K when 'K : comparison>
         bw.Flush()
         ms.ToArray()
 
-    let decodePayload (payload: byte[]) : DeltaLogEntry<'K> =
-        use ms = new MemoryStream(payload)
-        use br = new BinaryReader(ms)
-        let seq = br.ReadInt64()
-        let capLen = br.ReadInt32()
-        let capBytes = br.ReadBytes capLen
-        let captured =
-            JsonSerializer.Deserialize<Dictionary<string, string>> capBytes
-            |> fun d ->
-                match d with
-                | null -> Map.empty
-                | _ -> d |> Seq.map (fun kv -> kv.Key, kv.Value) |> Map.ofSeq
-        let deltaLen = br.ReadInt32()
-        let deltaBytes = br.ReadBytes deltaLen
-        { Seq = seq; Delta = codec.Decode deltaBytes; Captured = captured }
+    let decodePayload (payload: byte[]) : DeltaLogEntry<'K> = entryCodec.Decode payload
 
     let scanEntries (truncateTrailingTornWrite: bool) : DeltaLogEntry<'K>[] =
         if not (File.Exists segmentPath) then
@@ -301,7 +252,7 @@ type GroupCommitDiskDeltaLog<'K when 'K : comparison>
                 ValueTask<int64>(Task.FromCanceled<int64> ct)
             else
                 let seq = lock gate (fun () -> nextSeq <- nextSeq + 1L; nextSeq)
-                let payload = framePayload seq captured delta
+                let payload = framePayload { Seq = seq; Delta = delta; Captured = captured }
                 let req = { Seq = seq; Record = frameRecord payload }
                 throttler.ProcessAsync(req, CancellationToken.None) |> ValueTask<int64>
 

--- a/tests/Tests.FSharp/Storage/DiskDeltaLog.Tests.fs
+++ b/tests/Tests.FSharp/Storage/DiskDeltaLog.Tests.fs
@@ -19,10 +19,17 @@ let private keyEnc (i: int) : DynamicValue = DynamicValue.Int(int64 i)
 let private keyDec (dv: DynamicValue) : int =
     match dv with DynamicValue.Int w -> int w | o -> failwithf "keyDec: %A" o
 
-type private FixedBytesDeltaCodec(bytesPerDelta: int) =
-    interface IDeltaCodec<int> with
-        member _.Encode _ = Array.zeroCreate bytesPerDelta
-        member _.Decode _ = ZSet<int>.Empty
+// A size-control test double: emits a fixed-size payload (to drive batching/segment behavior) but
+// PRESERVES the entry's Seq in the first 8 bytes so replay recovers it (the whole entry now rides the
+// IEntryCodec, so a codec that dropped Seq would make ReplayAsync(0) filter everything out).
+type private FixedBytesEntryCodec(bytesPerDelta: int) =
+    interface IEntryCodec<int> with
+        member _.Encode entry =
+            let b = Array.zeroCreate bytesPerDelta
+            System.BitConverter.GetBytes(entry.Seq).CopyTo(b, 0)
+            b
+        member _.Decode bytes =
+            { Seq = System.BitConverter.ToInt64(bytes, 0); Delta = ZSet<int>.Empty; Captured = Map.empty }
 
 let private withDir name (f: string -> unit) =
     let dir = DeterministicTestPath.nextDir name
@@ -33,7 +40,7 @@ let private withDir name (f: string -> unit) =
 [<Fact>]
 let ``append + replay round-trips deltas and captured through disk`` () =
     withDir "ddl-roundtrip" (fun dir ->
-        let log = DiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>()) :> IDeltaLog<int>
+        let log = DiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec)) :> IDeltaLog<int>
         log.AppendAsync(ZSet.ofKeys [ 1; 2 ], empty, ct).AsTask().Wait()
         log.AppendAsync(ZSet.ofKeys [ 3 ], Map.ofList [ "clock", "99" ], ct).AsTask().Wait()
         let entries = log.ReplayAsync(0L, ct).AsTask().Result
@@ -45,7 +52,7 @@ let ``append + replay round-trips deltas and captured through disk`` () =
 [<Fact>]
 let ``truncate deletes entry files; replay returns the tail; HighWater holds`` () =
     withDir "ddl-truncate" (fun dir ->
-        let log = DiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>()) :> IDeltaLog<int>
+        let log = DiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec)) :> IDeltaLog<int>
         for i in 1 .. 5 do log.AppendAsync(ZSet.ofKeys [ i ], empty, ct).AsTask().Wait()
         log.TruncateAsync(3L, ct).AsTask().Wait()
         log.ReplayAsync(0L, ct).AsTask().Result
@@ -57,10 +64,10 @@ let ``truncate deletes entry files; replay returns the tail; HighWater holds`` (
 let ``a FRESH instance recovers high-water + entries from disk`` () =
     withDir "ddl-reopen" (fun dir ->
         // First instance writes 3 entries, then "process exits".
-        (let log1 = DiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>()) :> IDeltaLog<int>
+        (let log1 = DiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec)) :> IDeltaLog<int>
          for i in 1 .. 3 do log1.AppendAsync(ZSet.ofKeys [ i ], empty, ct).AsTask().Wait())
         // Fresh instance over the same dir: continues the sequence, sees history.
-        let log2 = DiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>()) :> IDeltaLog<int>
+        let log2 = DiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec)) :> IDeltaLog<int>
         log2.HighWater |> should equal 3L
         log2.ReplayAsync(0L, ct).AsTask().Result.Length |> should equal 3
         let s4 = log2.AppendAsync(ZSet.ofKeys [ 4 ], empty, ct).AsTask().Result
@@ -70,7 +77,7 @@ let ``a FRESH instance recovers high-water + entries from disk`` () =
 [<Fact>]
 let ``disk log works through the canonical CBOR codec`` () =
     withDir "ddl-cbor" (fun dir ->
-        let log = DiskDeltaLog<int>(dir, CborDeltaCodec<int>(keyEnc, keyDec)) :> IDeltaLog<int>
+        let log = DiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec)) :> IDeltaLog<int>
         log.AppendAsync(ZSet.ofSeq [ 1, 1L; 2, -3L ], empty, ct).AsTask().Wait()
         let e = (log.ReplayAsync(0L, ct).AsTask().Result).[0]
         e.Delta |> should equal (ZSet.ofSeq [ 1, 1L; 2, -3L ]))
@@ -79,7 +86,7 @@ let ``disk log works through the canonical CBOR codec`` () =
 [<Fact>]
 let ``fsync-per-append round-trips`` () =
     withDir "ddl-fsync" (fun dir ->
-        let log = DiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>(), fsyncPerAppend = true) :> IDeltaLog<int>
+        let log = DiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec), fsyncPerAppend = true) :> IDeltaLog<int>
         log.AppendAsync(ZSet.ofKeys [ 7; 8 ], empty, ct).AsTask().Wait()
         (log.ReplayAsync(0L, ct).AsTask().Result).[0].Delta |> should equal (ZSet.ofKeys [ 7; 8 ]))
 
@@ -87,7 +94,7 @@ let ``fsync-per-append round-trips`` () =
 [<Fact>]
 let ``group-commit segment log appends and replays in sequence order`` () =
     withDir "gcdl-roundtrip" (fun dir ->
-        use log = new GroupCommitDiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>())
+        use log = new GroupCommitDiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec))
         let dlog = log :> IDeltaLog<int>
         let tasks =
             [| for i in 1 .. 20 ->
@@ -102,11 +109,11 @@ let ``group-commit segment log appends and replays in sequence order`` () =
 [<Fact>]
 let ``group-commit segment log recovers high-water across a fresh instance`` () =
     withDir "gcdl-reopen" (fun dir ->
-        (use log1 = new GroupCommitDiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>())
+        (use log1 = new GroupCommitDiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec))
          let dlog1 = log1 :> IDeltaLog<int>
          for i in 1 .. 3 do
              dlog1.AppendAsync(ZSet.ofKeys [ i ], empty, ct).AsTask().Wait())
-        use log2 = new GroupCommitDiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>())
+        use log2 = new GroupCommitDiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec))
         let dlog2 = log2 :> IDeltaLog<int>
         dlog2.HighWater |> should equal 3L
         dlog2.ReplayAsync(0L, ct).AsTask().Result.Length |> should equal 3
@@ -116,7 +123,7 @@ let ``group-commit segment log recovers high-water across a fresh instance`` () 
 [<Fact>]
 let ``group-commit segment log works through the canonical CBOR codec`` () =
     withDir "gcdl-cbor" (fun dir ->
-        use log = new GroupCommitDiskDeltaLog<int>(dir, CborDeltaCodec<int>(keyEnc, keyDec))
+        use log = new GroupCommitDiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec))
         let dlog = log :> IDeltaLog<int>
         dlog.AppendAsync(ZSet.ofSeq [ 1, 1L; 2, -3L ], empty, ct).AsTask().Wait()
         let e = (dlog.ReplayAsync(0L, ct).AsTask().Result).[0]
@@ -127,14 +134,14 @@ let ``group-commit segment log works through the canonical CBOR codec`` () =
 let ``group-commit segment log rejects multi-ferry writer configs`` () =
     withDir "gcdl-dop" (fun dir ->
         let config = { FerryThrottlerConfig.deterministic with MaxDegreeOfParallelism = 2 }
-        (fun () -> new GroupCommitDiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>(), config) |> ignore)
+        (fun () -> new GroupCommitDiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec), config) |> ignore)
         |> should throw typeof<System.ArgumentException>)
 
 
 [<Fact>]
 let ``group-commit segment log truncates torn trailing record on recovery`` () =
     withDir "gcdl-torn" (fun dir ->
-        (use log = new GroupCommitDiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>())
+        (use log = new GroupCommitDiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec))
          let dlog = log :> IDeltaLog<int>
          dlog.AppendAsync(ZSet.ofKeys [ 1 ], empty, ct).AsTask().Wait()
          dlog.AppendAsync(ZSet.ofKeys [ 2 ], empty, ct).AsTask().Wait())
@@ -144,7 +151,7 @@ let ``group-commit segment log truncates torn trailing record on recovery`` () =
         fs.Write([| 0x7uy; 0x8uy; 0x9uy |], 0, 3)
         fs.Flush()
         FileInfo(segment).Length |> should equal (before + 3L)
-        use recovered = new GroupCommitDiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>())
+        use recovered = new GroupCommitDiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec))
         let dlog = recovered :> IDeltaLog<int>
         dlog.HighWater |> should equal 2L
         dlog.ReplayAsync(0L, ct).AsTask().Result |> Array.map _.Seq |> should equal [| 1L; 2L |]
@@ -155,7 +162,7 @@ let ``group-commit segment log truncates torn trailing record on recovery`` () =
 let ``group-commit segment log shields admitted append from caller cancellation`` () =
     withDir "gcdl-cancel-after-admit" (fun dir ->
         let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 1 }
-        use log = new GroupCommitDiskDeltaLog<int>(dir, FixedBytesDeltaCodec(4 * 1024 * 1024), config)
+        use log = new GroupCommitDiskDeltaLog<int>(dir, FixedBytesEntryCodec(4 * 1024 * 1024), config)
         let dlog = log :> IDeltaLog<int>
         let first = dlog.AppendAsync(ZSet.ofKeys [ 1 ], empty, ct).AsTask()
         use cts = new CancellationTokenSource()
@@ -170,7 +177,7 @@ let ``group-commit segment log shields admitted append from caller cancellation`
 [<Fact>]
 let ``group-commit segment log live replay uses read-only scan during append`` () =
     withDir "gcdl-live-replay" (fun dir ->
-        use log = new GroupCommitDiskDeltaLog<int>(dir, FixedBytesDeltaCodec(8 * 1024 * 1024))
+        use log = new GroupCommitDiskDeltaLog<int>(dir, FixedBytesEntryCodec(8 * 1024 * 1024))
         let dlog = log :> IDeltaLog<int>
         let append = dlog.AppendAsync(ZSet.ofKeys [ 1 ], empty, ct).AsTask()
         // This must not require a read/write handle; the writer opens with
@@ -185,12 +192,12 @@ let ``end-to-end: RecoverableSpine recovers from the group-commit segment log`` 
     withDir "gcdl-spine" (fun dir ->
         let store = InMemorySnapshotStore<int>() :> ISnapshotStore<int>
         let live =
-            use log1 = new GroupCommitDiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>())
+            use log1 = new GroupCommitDiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec))
             let s = RecoverableSpine.create (log1 :> IDeltaLog<int>) store
             for i in 1 .. 6 do s.CommitAsync(ZSet.ofKeys [ i ]).Wait()
             s.CommitAsync(ZSet.neg (ZSet.ofKeys [ 3 ])).Wait()
             s
-        use log2 = new GroupCommitDiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>())
+        use log2 = new GroupCommitDiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec))
         let recovered = RecoverableSpine<int>.RecoverAsync(log2 :> IDeltaLog<int>, store).Result
         recovered.Consolidate() |> should equal (live.Consolidate())
         recovered.AppliedSeq |> should equal 7L
@@ -203,13 +210,13 @@ let ``end-to-end: RecoverableSpine recovers from the disk log across a fresh ins
         let store = InMemorySnapshotStore<int>() :> ISnapshotStore<int>
         // Live spine on a durable disk log.
         let live =
-            let log1 = DiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>()) :> IDeltaLog<int>
+            let log1 = DiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec)) :> IDeltaLog<int>
             let s = RecoverableSpine.create log1 store
             for i in 1 .. 6 do s.CommitAsync(ZSet.ofKeys [ i ]).Wait()
             s.CommitAsync(ZSet.neg (ZSet.ofKeys [ 3 ])).Wait()   // retract 3
             s
         // "Restart": fresh log over the same dir, recover by full replay (no snapshot).
-        let log2 = DiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>()) :> IDeltaLog<int>
+        let log2 = DiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec)) :> IDeltaLog<int>
         let recovered = RecoverableSpine<int>.RecoverAsync(log2, store).Result
         recovered.Consolidate() |> should equal (live.Consolidate())
         recovered.AppliedSeq |> should equal 7L
@@ -220,7 +227,7 @@ let ``end-to-end: RecoverableSpine recovers from the disk log across a fresh ins
 let ``end-to-end: snapshot+tail recovery survives a restart via the manifest`` () =
     withDir "ddl-snap-log" (fun logDir ->
         withDir "ddl-snap-store" (fun snapDir ->
-            let mkLog () = DiskDeltaLog<int>(logDir, CheckpointDeltaCodec<int>()) :> IDeltaLog<int>
+            let mkLog () = DiskDeltaLog<int>(logDir, CborEntryCodec<int>(keyEnc, keyDec)) :> IDeltaLog<int>
             let mkSnap () = DiskSnapshotStore<int>(snapDir, CheckpointDeltaCodec<int>()) :> ISnapshotStore<int>
             // Live: commit, snapshot (manifest → seq 5), commit more.
             let live =
@@ -239,13 +246,13 @@ let ``end-to-end: snapshot+tail recovery survives a restart via the manifest`` (
 [<Fact>]
 let ``orphan .tmp from a crashed append is ignored on recovery`` () =
     withDir "ddl-orphan" (fun dir ->
-        (let log = DiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>()) :> IDeltaLog<int>
+        (let log = DiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec)) :> IDeltaLog<int>
          log.AppendAsync(ZSet.ofKeys [ 1 ], empty, ct).AsTask().Wait()
          log.AppendAsync(ZSet.ofKeys [ 2 ], empty, ct).AsTask().Wait())
         // Simulate a crash mid-append: a leftover, torn .delta.tmp.
         File.WriteAllText(Path.Combine(dir, "00000000000000000003.delta.tmp"), "torn-garbage")
         // Fresh instance: orphan ignored, history intact, sequence continues at 3.
-        let log2 = DiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>()) :> IDeltaLog<int>
+        let log2 = DiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec)) :> IDeltaLog<int>
         log2.HighWater |> should equal 2L
         log2.ReplayAsync(0L, ct).AsTask().Result.Length |> should equal 2
         log2.AppendAsync(ZSet.ofKeys [ 3 ], empty, ct).AsTask().Result |> should equal 3L)
@@ -257,7 +264,7 @@ let ``recovery invariant holds over a long deterministic add/retract sequence`` 
         let snap = InMemorySnapshotStore<int>() :> ISnapshotStore<int>
         // 200 deterministic ops: ~1/3 are retractions, keys cycle through 0..16.
         let live =
-            let s = RecoverableSpine.create (DiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>()) :> IDeltaLog<int>) snap
+            let s = RecoverableSpine.create (DiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec)) :> IDeltaLog<int>) snap
             for i in 1 .. 200 do
                 let key = i % 17
                 let z = if i % 3 = 0 then ZSet.neg (ZSet.ofKeys [ key ]) else ZSet.ofKeys [ key ]
@@ -266,6 +273,6 @@ let ``recovery invariant holds over a long deterministic add/retract sequence`` 
         // Recover from a FRESH disk log (full replay): recovered == live, exactly.
         let recovered =
             RecoverableSpine<int>.RecoverAsync(
-                DiskDeltaLog<int>(dir, CheckpointDeltaCodec<int>()) :> IDeltaLog<int>, snap).Result
+                DiskDeltaLog<int>(dir, CborEntryCodec<int>(keyEnc, keyDec)) :> IDeltaLog<int>, snap).Result
         recovered.Consolidate() |> should equal (live.Consolidate())
         recovered.AppliedSeq |> should equal 200L)

--- a/tests/Tests.FSharp/Storage/DurabilityProperty.Tests.fs
+++ b/tests/Tests.FSharp/Storage/DurabilityProperty.Tests.fs
@@ -47,7 +47,7 @@ type ScenarioArb() =
 let ``recovery reconstructs fold(committed) for any script + cadence`` (s: Scenario) : bool =
     let logDir = DeterministicTestPath.nextDir "dprop-log"
     let snapDir = DeterministicTestPath.nextDir "dprop-snap"
-    let mkLog () = DiskDeltaLog<int>(logDir, CheckpointDeltaCodec<int>()) :> IDeltaLog<int>
+    let mkLog () = DiskDeltaLog<int>(logDir, CborEntryCodec<int>((fun (i: int) -> DynamicValue.Int(int64 i)), (function DynamicValue.Int v -> int v | o -> failwithf "key not Int: %A" o))) :> IDeltaLog<int>
     let mkSnap () = DiskSnapshotStore<int>(snapDir, CheckpointDeltaCodec<int>()) :> ISnapshotStore<int>
     try
         // Commit the whole script (with cadence → exercises snapshot + log GC).

--- a/tests/Tests.FSharp/Storage/DurabilitySim.Tests.fs
+++ b/tests/Tests.FSharp/Storage/DurabilitySim.Tests.fs
@@ -30,7 +30,7 @@ let ``DST: recovery invariant holds at EVERY crash point (deterministic enumerat
         let logDir = DeterministicTestPath.nextDir (sprintf "dst-log-%d" k)
         let snapDir = DeterministicTestPath.nextDir (sprintf "dst-snap-%d" k)
         try
-            let mkLog () = DiskDeltaLog<int>(logDir, CheckpointDeltaCodec<int>()) :> IDeltaLog<int>
+            let mkLog () = DiskDeltaLog<int>(logDir, CborEntryCodec<int>((fun (i: int) -> DynamicValue.Int(int64 i)), (function DynamicValue.Int v -> int v | o -> failwithf "key not Int: %A" o))) :> IDeltaLog<int>
             let mkSnap () = DiskSnapshotStore<int>(snapDir, CheckpointDeltaCodec<int>()) :> ISnapshotStore<int>
             let expected =
                 ops |> List.truncate k |> List.fold (fun acc z -> ZSet.add acc z) ZSet<int>.Empty


### PR DESCRIPTION
Completes the delta-log backend migration. Both DiskDeltaLog + GroupCommitDiskDeltaLog now serialize the WHOLE entry through the canonical `IEntryCodec` (4-lang byte-locked) instead of System.Text.Json. GroupCommit keeps its record wrapper ([len][crc][payload]) for torn-write scanning — only the payload encoding changed; file handles (+ the windows bug 081KTGGXMQ0) untouched. FixedBytes test double now preserves Seq (the whole entry rides the codec). 166/166 storage tests green.

**Backend migration COMPLETE**: GitDeltaLog (#6759) + DiskDeltaLog (this) both store the canonical format; the delta log is fully off System.Text.Json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)