### PR TITLE
fix(md): MD032 in git-reach punch-list workitem + clean wording

### DIFF
--- a/workitems/081KTGPC2XP08QG0R000X8X1M9-git-reach-punch-list-data-plane-command-spec-requirements-fo.md
+++ b/workitems/081KTGPC2XP08QG0R000X8X1M9-git-reach-punch-list-data-plane-command-spec-requirements-fo.md
@@ -52,9 +52,9 @@ on this list is a new gap to add (the list is living).
 
 ## Open (Aaron's call — surface shape)
 
-Where the commands live: (a) CLI executable, (b) MCP server, (c) shared command-core library first (CLI
-+ MCP as thin wrappers — Otto's lean, no surface lock-in). This punch-list is the requirements for ALL
-three; the shape decision gates which wrapper lands first.
+Where the commands live: (a) a CLI executable, (b) an MCP server, or (c) a shared command-core library
+first with CLI and MCP as thin wrappers (Otto's lean, no surface lock-in). This punch-list is the
+requirements for ALL three; the shape decision gates which wrapper lands first.
 
 ## Anchors
 


### PR DESCRIPTION
#6767 merged with an MD032 (wrapped line began with '+ MCP'). Reworded the surface-shape options to clean (a)/(b)/(c) prose; lint clean. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)