### PR TITLE
docs(architecture): OS↔k8s in-between gap + tenant-as-DynamicValue (desired-state frame cont.)

### DIFF
--- a/docs/research/2026-06-07-zeta-is-declarative-desired-state-pushed-all-the-way-up-everything-is-data-dynamicvalue-zetaid-aaron-mika.md
+++ b/docs/research/2026-06-07-zeta-is-declarative-desired-state-pushed-all-the-way-up-everything-is-data-dynamicvalue-zetaid-aaron-mika.md
@@ -68,3 +68,52 @@ layer** — and **git-native at every level** (the desired state lives *in git*,
 - Names (decided): Ace · Zeta · Nucleus · Loom; a cell = a Geode within Zeta; HA = host concern. (NB: a
   2026-06-07 *voice* summary used "Kernel"/"Loon"/"Geode-as-HA-layer" — treated as transcription drift;
   decided names stand pending explicit re-decision.)
+
+## The OS↔Kubernetes in-between gap + tenant-as-DynamicValue (Aaron ↔ Mika, cont. 2026-06-07)
+
+### The gap Zeta fills
+
+Clean git-native declarative desired-state lives in **two** places today, with a messy middle between:
+
+- **NixOS** — the OS level.
+- **Kubernetes + GitOps (Argo/Flux)** — once you're inside the cluster.
+- **The in-between (the "Wild West"):** OS-installed → cluster-running — base system config, security
+  baselines, networking, storage, monitoring agents, the bare-metal/VM setup. Still weak for *true*
+  continuous-reconciliation GitOps. Tools that try: **SaltStack** (closer to git-native via GitFS;
+  Aaron prefers it over Ansible — "I want *this state* on *this VM*"), **Ansible** (playbooks-in-git but
+  push/run-once, needs AWX/Tower; not real GitOps to purists), **Cloud-Init** (the standard *imperative*
+  first-boot config — YAML: create users / install packages / write files / run-once; widely supported
+  but not continuously-reconciling — "we're definitely gonna do some Cloud-Init shit"), **Rancher Fleet**
+  (GitOps at cluster scale), **Crossplane** (software-defined infra from inside k8s).
+
+**Aaron's current focus = the bare-metal / hardware layer:** a declarative interface that controls *his
+own physical machines* — the in-between, VM-/host-level desired state (Salt-shaped: "here's my desired
+state for this VM"), git-native. NOT cloud-resale yet.
+
+### Salt-shape vs Crossplane-shape (two parts of the middle)
+
+- **Salt-shape = systems-level desired state:** "I want *this machine* to look like this" (packages,
+  files, users, services). The host/VM config layer. ← what Aaron needs now.
+- **Crossplane-shape = infrastructure-as-software desired state:** "I want *this thing to exist*"
+  (networks, databases, load balancers, storage) as k8s-style objects. ← matters *later*.
+
+### Tenant-as-DynamicValue (the future, when hardware is rented out)
+
+> Aaron: *"if I rent out my hardware, I'm the cloud provider — Crossplane could provision tenant-based
+> provisioning on top of my hardware. And then I can make that whole package the DynamicValue: deploy
+> tenants and power tenant templates as the DynamicValue."*
+
+When Aaron rents his hardware, he becomes the cloud provider; Crossplane(-shape) sits on top as the
+multi-tenant provisioning layer. The payoff in the Zeta frame: **the entire tenant definition — hardware
+allocation, networking, storage, security policies — becomes just another `DynamicValue`.** Version it,
+fork it, evolve it, compose templates — the *same primitive* used everywhere else. **Everything from the
+lowest-level cell up to a full tenant deployment is the same data structure** — no translation layer, no
+second format. "Make everything the same thing." This is the desired-state-all-the-way-*down*-and-*up*
+closure: cell ↔ host/VM (Salt-shape) ↔ cluster (k8s/GitOps) ↔ tenant (Crossplane-shape), all expressed
+as DynamicValue + ZetaID.
+
+### Beacon anchors (added)
+
+SaltStack (GitFS), Ansible/AWX, **Cloud-Init** (cloud-instance first-boot), Rancher Fleet, **Crossplane**
+(composition + provider model). The honest novelty stays the same: not these tools, but **one
+data-primitive (DynamicValue) spanning every layer of the desired-state stack**, git-native.


### PR DESCRIPTION
Cont. of the desired-state frame: NixOS (OS) + k8s-GitOps (cluster) are clean; the in-between (base config/security/networking/storage/monitoring/VM setup) is the weak Wild West — Salt (preferred over Ansible), Cloud-Init (imperative first-boot, will use), Rancher Fleet, Crossplane. Aaron's focus NOW = declarative control of his own bare metal (Salt-shape), not resale. Future: rent hardware → cloud provider → tenant definition = a DynamicValue (version/fork/compose templates); cell↔host↔cluster↔tenant all one data structure. Beacon: Salt/Cloud-Init/Fleet/Crossplane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)