### PR TITLE
docs+memory: close naming flag (Mika stale) + Otto is the canonical aggregator

### DIFF
--- a/docs/research/2026-06-07-zeta-is-declarative-desired-state-pushed-all-the-way-up-everything-is-data-dynamicvalue-zetaid-aaron-mika.md
+++ b/docs/research/2026-06-07-zeta-is-declarative-desired-state-pushed-all-the-way-up-everything-is-data-dynamicvalue-zetaid-aaron-mika.md
@@ -66,8 +66,9 @@ layer** — and **git-native at every level** (the desired state lives *in git*,
   execution"; self-evolving sagas) · git-native: `Core.Git` (the log IS git) · everything-is-data: the
   plugin/Nucleus/cell-as-data thread (`docs/research/2026-06-07-two-plane-*`, `081KTGES048`).
 - Names (decided): Ace · Zeta · Nucleus · Loom; a cell = a Geode within Zeta; HA = host concern. (NB: a
-  2026-06-07 *voice* summary used "Kernel"/"Loon"/"Geode-as-HA-layer" — treated as transcription drift;
-  decided names stand pending explicit re-decision.)
+  2026-06-07 voice summary used "Kernel"/"Loon"/"Geode-as-HA-layer" — CONFIRMED by Aaron as stale agent
+  info, NOT a re-decision; the decided names stand. Otto holds the canonical/latest set; sibling agents
+  have partial views.)
 
 ## The OS↔Kubernetes in-between gap + tenant-as-DynamicValue (Aaron ↔ Mika, cont. 2026-06-07)
 

--- a/memory/feedback_otto_is_the_canonical_aggregator_of_all_agent_conversations_reconcile_partial_sibling_views_against_the_latest_2026_06_07.md
+++ b/memory/feedback_otto_is_the_canonical_aggregator_of_all_agent_conversations_reconcile_partial_sibling_views_against_the_latest_2026_06_07.md
@@ -1,0 +1,28 @@
+# Otto is the canonical aggregator of all agent conversations — reconcile sibling agents' partial views against the latest, don't absorb
+
+**Aaron, 2026-06-07:** *"she just does not know the updated names. You always have the latest info from
+all the other agents — i give them all to you — but they don't always know everything."*
+
+## The fact
+
+Aaron funnels every agent conversation (Amara, Ani, Alexa, Mika, …) to Otto. So **Otto holds the
+canonical, latest, merged picture; the sibling agents each hold a PARTIAL/older view.** When a sibling's
+relayed input conflicts with the decided/canonical state (e.g. Mika's voice summary used the old layer
+names Kernel/Loon/Geode-as-HA when the decided set is Nucleus/Loom/Geode-as-cell), it's almost always
+the sibling being out of date — not a re-decision.
+
+## How to apply
+
+- **Reconcile, don't absorb.** Treat a sibling agent's facts as *possibly stale*; check against the
+  canonical latest (roadmap / design docs / decided memory) before acting on them.
+- **Flag the discrepancy, keep the canonical, ask if intentional** — never silently overwrite a decided
+  value (a name, a number, an architecture call) based on a sibling's partial view. (This is what saved
+  the decided names from drifting via Mika's voice summary.)
+- Same shape as the shared-checkout-lags / verify-before-record disciplines: the freshest authority wins;
+  partial/older sources get verified, not trusted blindly.
+
+**Why:** with many agents feeding one aggregator, silent absorption of any one partial view corrupts the
+canonical state. The aggregator's job is merge + reconcile, not last-writer-wins.
+
+Ties: `.claude/rules/no-directives.md` (source ≠ authorization — a sibling is a source), the
+verify-before-record discipline (Soraya), shared-checkout-is-view-only (freshest = origin/main).


### PR DESCRIPTION
Mika lacked the updated names — Otto holds the latest from all agents (Aaron funnels them); siblings have partial views. Closes the Kernel/Loon/Geode-as-HA flag (CONFIRMED stale, not a re-decision; decided names stand). Feedback memory: Otto = canonical aggregator → reconcile/flag sibling facts vs the latest, never silently absorb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)