### PR TITLE
feat(command/roadmap-#1): data-plane command core — DbCommand DU + interpreter (core-library-first)

### DIFF
--- a/src/Core/Command.fs
+++ b/src/Core/Command.fs
@@ -1,0 +1,53 @@
+namespace Zeta.Core
+
+open System.Threading
+open System.Threading.Tasks
+
+/// The data-plane command surface as DATA — the core that the CLI and MCP thin-wrap (roadmap #1,
+/// no-git-CLI; core-library-first, Aaron 2026-06-07). A `DbCommand` is a *value*: input → DbCommand →
+/// `run` over any `IDeltaLog`. "Verbs as data" — fits the everything-is-data frame, and a DbCommand
+/// itself is serializable (a DU over ZSet/Map/int64).
+///
+/// These are the **backend-agnostic data-plane verbs** that already exist on `IDeltaLog`
+/// (append / history / get / status). The **git-ref verbs** (branch / checkout / status-of-working-ref /
+/// sync / push) need the git backend and extend this surface in `Core.Git` — they are the genuinely-new
+/// commands from the git-reach punch-list (081KTGPC2XP). Control-plane verbs (PR / merge) live in the
+/// Loom/consensus-repo layer, not here.
+type DbCommand<'K when 'K : comparison> =
+    /// Commit a delta (+ captured non-determinism) — the canonical `git commit` replacement.
+    | Append of delta: ZSet<'K> * captured: Map<string, string>
+    /// Read the log tail (entries with seq > `fromSeqExclusive`) — the `git log` replacement.
+    | History of fromSeqExclusive: int64
+    /// Read a single entry by its sequence number — the `git show <ref>` replacement.
+    | Get of seq: int64
+    /// The current high-water sequence — the `git status`/tip replacement.
+    | Status
+
+/// The result of running a `DbCommand` — also a value (a DU), so a wrapper can render/serialize it.
+type DbCommandResult<'K when 'K : comparison> =
+    | Appended of seq: int64
+    | History of entries: DeltaLogEntry<'K>[]
+    | Got of entry: DeltaLogEntry<'K> option
+    | Status of highWater: int64
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module DbCommand =
+
+    /// Interpret a command over a `Log`. Async (the data-plane I/O is async); the wrappers (CLI/MCP)
+    /// await this. Lossless mapping onto `IDeltaLog`: append→AppendAsync, history→ReplayAsync,
+    /// get→ReplayAsync(seq-1) then pick `Seq = seq`, status→HighWater.
+    let run (log: IDeltaLog<'K>) (ct: CancellationToken) (cmd: DbCommand<'K>) : Task<DbCommandResult<'K>> =
+        task {
+            match cmd with
+            | DbCommand.Append(delta, captured) ->
+                let! seq = log.AppendAsync(delta, captured, ct)
+                return DbCommandResult.Appended seq
+            | DbCommand.History fromSeqExclusive ->
+                let! entries = log.ReplayAsync(fromSeqExclusive, ct)
+                return DbCommandResult.History entries
+            | DbCommand.Get seq ->
+                let! entries = log.ReplayAsync(seq - 1L, ct)
+                return DbCommandResult.Got(entries |> Array.tryFind (fun e -> e.Seq = seq))
+            | DbCommand.Status ->
+                return DbCommandResult.Status log.HighWater
+        }

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -112,6 +112,7 @@
     <Compile Include="DiskSpineAsync.fs" />
     <Compile Include="FileSync.fs" />
     <Compile Include="DeltaLog.fs" />
+    <Compile Include="Command.fs" />
     <Compile Include="DeltaCodec.fs" />
     <Compile Include="DiskDeltaLog.fs" />
     <Compile Include="SnapshotStore.fs" />

--- a/tests/Tests.FSharp/Command.Tests.fs
+++ b/tests/Tests.FSharp/Command.Tests.fs
@@ -1,0 +1,46 @@
+module Zeta.Tests.CommandTests
+
+open System.Threading
+open System.Threading.Tasks
+open global.Xunit
+open Zeta.Core
+
+// The data-plane command core (roadmap #1, no-git-CLI; core-library-first). DbCommand is verbs-as-data;
+// `run` interprets over any IDeltaLog. CLI + MCP are thin wrappers over this; these tests exercise the
+// core directly over InMemoryDeltaLog (the DST/reference log).
+
+let private ct = CancellationToken.None
+let private run (log: IDeltaLog<string>) cmd = (DbCommand.run log ct cmd).Result
+
+[<Fact>]
+let ``Append assigns monotonic seqs; History replays them; Status reports high-water`` () =
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    let a1 = run log (DbCommand.Append(ZSet.ofKeys [ "a" ], Map.empty))
+    let a2 = run log (DbCommand.Append(ZSet.ofKeys [ "b" ], Map.ofList [ "k", "v" ]))
+    Assert.Equal(DbCommandResult.Appended 1L, a1)
+    Assert.Equal(DbCommandResult.Appended 2L, a2)
+
+    match run log (DbCommand.History 0L) with
+    | DbCommandResult.History entries ->
+        Assert.Equal<int64[]>([| 1L; 2L |], entries |> Array.map _.Seq)
+    | o -> Assert.Fail(sprintf "expected History, got %A" o)
+
+    match run log DbCommand.Status with
+    | DbCommandResult.Status hw -> Assert.Equal(2L, hw)
+    | o -> Assert.Fail(sprintf "expected Status, got %A" o)
+
+[<Fact>]
+let ``Get fetches a single entry by seq; captured round-trips`` () =
+    let log = InMemoryDeltaLog<string>() :> IDeltaLog<string>
+    run log (DbCommand.Append(ZSet.ofKeys [ "x" ], Map.empty)) |> ignore
+    run log (DbCommand.Append(ZSet.ofKeys [ "y" ], Map.ofList [ "actor", "otto" ])) |> ignore
+
+    match run log (DbCommand.Get 2L) with
+    | DbCommandResult.Got(Some e) ->
+        Assert.Equal(2L, e.Seq)
+        Assert.Equal<Map<string, string>>(Map.ofList [ "actor", "otto" ], e.Captured)
+    | o -> Assert.Fail(sprintf "expected Got(Some) for seq 2, got %A" o)
+
+    match run log (DbCommand.Get 99L) with
+    | DbCommandResult.Got None -> ()
+    | o -> Assert.Fail(sprintf "expected Got(None) for absent seq, got %A" o)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -228,6 +228,7 @@
     <Compile Include="Formal/Clock.Laws.Tests.fs" />
     <Compile Include="Formal/Crdt.Laws.Tests.fs" />
     <Compile Include="DeltaLogEntryCodec.Tests.fs" />
+    <Compile Include="Command.Tests.fs" />
     <Compile Include="Formal/Merkle.Laws.Tests.fs" />
     <Compile Include="Formal/Sketch.Laws.Tests.fs" />
     <Compile Include="Formal/Metric.Bounds.Tests.fs" />


### PR DESCRIPTION
First slice of the no-git-CLI command surface (roadmap #1; (c) core-library-first per Aaron). `DbCommand<'K>` DU (Append/History/Get/Status — verbs-as-data) + `DbCommand.run` over any `IDeltaLog`. CLI + MCP are thin wrappers over this core (no surface lock-in). Data-plane verbs map to existing IDeltaLog ops (Append→AppendAsync, History→ReplayAsync, Get→pick-by-seq, Status→HighWater). 2 tests green over InMemoryDeltaLog. Next: git-ref verbs (branch/checkout/push/sync) in Core.Git, then CLI, then MCP → the done-test (full work-cycle, zero git CLI). Punch-list 081KTGPC2XP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)