### PR TITLE
feat(command/roadmap-#1): git-ref command verbs — branch/checkout/commit/log/status (LibGit2Sharp, local)

### DIFF
--- a/src/Core.Git/GitCommand.fs
+++ b/src/Core.Git/GitCommand.fs
@@ -1,0 +1,61 @@
+namespace Zeta.Core.Git
+
+open System
+open LibGit2Sharp
+open Zeta.Core
+
+/// **Git-ref command verbs** — the source-repo / working-branch operations that retire Otto's `git` CLI
+/// usage (roadmap #1, no-git-CLI). Distinct from `DbCommand` (Zeta.Core, the data-plane Log verbs over
+/// `IDeltaLog`): these operate on an actual working git repository via LibGit2Sharp — the "DB layer that
+/// understands git, running git-native." Verbs-as-data (a DU), interpreted by `run` over a `Repository`;
+/// the CLI + MCP thin-wrap it. LOCAL verbs only here (branch / checkout / commit / log / status);
+/// network verbs (push / sync) need credential handling and land in a follow-up slice.
+/// Punch-list: workitem 081KTGPC2XP.
+type GitCommand =
+    /// Create a branch at the current tip (does not switch). `git branch <name>`.
+    | Branch of name: string
+    /// Switch the working tree to a branch/committish. `git checkout <ref>`.
+    | Checkout of refName: string
+    /// Stage all changes + commit. `git add -A && git commit -m <message>`.
+    | Commit of message: string
+    /// Recent commits (newest first), up to `count`. `git log -n <count> --oneline`.
+    | Log of count: int
+    /// Working-tree status. `git status`.
+    | Status
+
+type GitCommandResult =
+    | Branched of name: string
+    | CheckedOut of name: string
+    | Committed of sha: string
+    | Logged of entries: (string * string)[]
+    | Statused of isClean: bool * pending: string[]
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module GitCommand =
+
+    /// Interpret a git-ref command over a working `Repository`. `now` supplies the deterministic clock
+    /// for commit signatures (DST-friendly — same seed, same commit metadata).
+    let run (repo: Repository) (now: unit -> DateTimeOffset) (cmd: GitCommand) : GitCommandResult =
+        match cmd with
+        | Branch name ->
+            let b = repo.CreateBranch name
+            Branched b.FriendlyName
+        | Checkout refName ->
+            let b = Commands.Checkout(repo, refName)
+            CheckedOut b.FriendlyName
+        | Commit message ->
+            Commands.Stage(repo, "*")
+            let sig_ = GitBackend.signature now
+            let c = repo.Commit(message, sig_, sig_)
+            Committed(c.Sha)
+        | Log count ->
+            let entries =
+                repo.Commits
+                |> Seq.truncate (max 0 count)
+                |> Seq.map (fun c -> c.Sha, c.MessageShort)
+                |> Seq.toArray
+            Logged entries
+        | Status ->
+            let st = repo.RetrieveStatus(StatusOptions())
+            let pending = st |> Seq.map (fun e -> e.FilePath) |> Seq.toArray
+            Statused(not st.IsDirty, pending)

--- a/src/Core.Git/Zeta.Core.Git.fsproj
+++ b/src/Core.Git/Zeta.Core.Git.fsproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <Compile Include="GitDeltaLog.fs" />
+    <Compile Include="GitCommand.fs" />
     <Compile Include="GitSnapshotStore.fs" />
   </ItemGroup>
 

--- a/tests/Tests.FSharp.Git/GitCommand.Tests.fs
+++ b/tests/Tests.FSharp.Git/GitCommand.Tests.fs
@@ -1,0 +1,68 @@
+module Zeta.Tests.Git.GitCommandTests
+
+open System
+open System.IO
+open System.Threading
+open LibGit2Sharp
+open global.Xunit
+open Zeta.Core.Git
+
+// Git-ref command verbs (roadmap #1, no-git-CLI) — branch/checkout/commit/log/status over a real working
+// repo via LibGit2Sharp. The CLI + MCP thin-wrap GitCommand.run; these tests drive it directly.
+
+let private fixedClock () = DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)
+let mutable private counter = 0
+
+let private withRepo (f: Repository -> string -> unit) =
+    let id = Interlocked.Increment(&counter)
+    let dir = Path.Combine(Path.GetTempPath(), "zeta-gitcmd-test", sprintf "gc-%04d" id)
+    if Directory.Exists dir then Directory.Delete(dir, true)
+    Directory.CreateDirectory dir |> ignore
+    Repository.Init(dir, isBare = false) |> ignore
+    use repo = new Repository(dir)
+    try f repo dir
+    finally
+        repo.Dispose()
+        try Directory.Delete(dir, true) with _ -> ()
+
+[<Fact>]
+let ``Commit stages+commits; Log returns it; Status is clean after`` () =
+    withRepo (fun repo dir ->
+        File.WriteAllText(Path.Combine(dir, "a.txt"), "hello")
+        match GitCommand.run repo fixedClock (GitCommand.Commit "first") with
+        | Committed sha -> Assert.False(String.IsNullOrEmpty sha)
+        | o -> Assert.Fail(sprintf "expected Committed, got %A" o)
+
+        match GitCommand.run repo fixedClock (GitCommand.Log 10) with
+        | Logged entries ->
+            Assert.Single(entries) |> ignore
+            Assert.Equal("first", snd entries.[0])
+        | o -> Assert.Fail(sprintf "expected Logged, got %A" o)
+
+        match GitCommand.run repo fixedClock GitCommand.Status with
+        | Statused(isClean, pending) ->
+            Assert.True(isClean)
+            Assert.Empty(pending)
+        | o -> Assert.Fail(sprintf "expected Statused, got %A" o))
+
+[<Fact>]
+let ``Status reports pending changes; Branch + Checkout switch the working tree`` () =
+    withRepo (fun repo dir ->
+        File.WriteAllText(Path.Combine(dir, "a.txt"), "hello")
+        GitCommand.run repo fixedClock (GitCommand.Commit "first") |> ignore
+
+        // an untracked file makes the tree dirty
+        File.WriteAllText(Path.Combine(dir, "b.txt"), "world")
+        match GitCommand.run repo fixedClock GitCommand.Status with
+        | Statused(isClean, pending) ->
+            Assert.False(isClean)
+            Assert.Contains("b.txt", pending)
+        | o -> Assert.Fail(sprintf "expected dirty Statused, got %A" o)
+
+        match GitCommand.run repo fixedClock (GitCommand.Branch "feature") with
+        | Branched name -> Assert.Equal("feature", name)
+        | o -> Assert.Fail(sprintf "expected Branched, got %A" o)
+
+        match GitCommand.run repo fixedClock (GitCommand.Checkout "feature") with
+        | CheckedOut name -> Assert.Equal("feature", name)
+        | o -> Assert.Fail(sprintf "expected CheckedOut, got %A" o))

--- a/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
+++ b/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <Compile Include="GitDeltaLog.Tests.fs" />
+    <Compile Include="GitCommand.Tests.fs" />
     <Compile Include="GitSnapshotStore.Tests.fs" />
     <Compile Include="GitRecoverableSpine.Tests.fs" />
     <Compile Include="DurableSagaGit.Tests.fs" />


### PR DESCRIPTION
Slice 2 of the no-git-CLI surface: the source-repo git verbs that retire Otto's `git` CLI, over a real `Repository` via LibGit2Sharp (distinct from DbCommand's data-plane Log verbs). `GitCommand` DU + `run`: Branch/Checkout/Commit(stage-all+commit, deterministic sig)/Log/Status. LOCAL only; push/sync (network/auth) follow-up. 2 tests green over a temp working repo. Next: push/sync, then CLI wrapper, then MCP. Punch-list 081KTGPC2XP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)