### PR TITLE
feat(command/roadmap-#1): CLI parser brain — pure argv→GitCommand (slice 3)

### DIFF
--- a/src/Core.Git/CliParse.fs
+++ b/src/Core.Git/CliParse.fs
@@ -1,0 +1,25 @@
+namespace Zeta.Core.Git
+
+/// CLI argument parser for the git-ref command verbs (roadmap #1, no-git-CLI; core-library-first). PURE:
+/// `argv -> GitCommand` (or a usage error). Kept a library function so it's CI-tested; the runnable
+/// `zeta` exe stays a trivial shell (open repo → `parse argv` → `GitCommand.run` → print). The MCP
+/// wrapper maps tool-calls → GitCommand the same way. Mirrors a developer's git muscle-memory so the
+/// done-test (a full work-cycle with zero `git` CLI) reads naturally: `zeta commit "msg"`, `zeta log`, …
+module CliParse =
+
+    let usage =
+        "usage: zeta <commit <msg> | log [n] | branch <name> | checkout <ref> | status>"
+
+    let parse (argv: string[]) : Result<GitCommand, string> =
+        match List.ofArray argv with
+        | [ "commit"; msg ] -> Ok(GitCommand.Commit msg)
+        | [ "log" ] -> Ok(GitCommand.Log 20)
+        | [ "log"; n ] ->
+            match System.Int32.TryParse n with
+            | true, v when v > 0 -> Ok(GitCommand.Log v)
+            | _ -> Error(sprintf "log: expected a positive count, got '%s'" n)
+        | [ "branch"; name ] -> Ok(GitCommand.Branch name)
+        | [ "checkout"; refName ] -> Ok(GitCommand.Checkout refName)
+        | [ "status" ] -> Ok GitCommand.Status
+        | [] -> Error usage
+        | other -> Error(sprintf "unknown command: '%s'\n%s" (String.concat " " other) usage)

--- a/src/Core.Git/Zeta.Core.Git.fsproj
+++ b/src/Core.Git/Zeta.Core.Git.fsproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Compile Include="GitDeltaLog.fs" />
     <Compile Include="GitCommand.fs" />
+    <Compile Include="CliParse.fs" />
     <Compile Include="GitSnapshotStore.fs" />
   </ItemGroup>
 

--- a/tests/Tests.FSharp.Git/CliParse.Tests.fs
+++ b/tests/Tests.FSharp.Git/CliParse.Tests.fs
@@ -1,0 +1,22 @@
+module Zeta.Tests.Git.CliParseTests
+
+open global.Xunit
+open Zeta.Core.Git
+
+// The CLI arg parser (roadmap #1, no-git-CLI). Pure argv -> GitCommand; the runnable `zeta` exe is a
+// trivial shell over this + GitCommand.run. Keeping the brain a tested library fn = the exe stays thin.
+
+[<Fact>]
+let ``parse maps the git-ref verbs`` () =
+    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Commit "msg"), CliParse.parse [| "commit"; "msg" |])
+    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Log 20), CliParse.parse [| "log" |])
+    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Log 5), CliParse.parse [| "log"; "5" |])
+    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Branch "feature"), CliParse.parse [| "branch"; "feature" |])
+    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Checkout "main"), CliParse.parse [| "checkout"; "main" |])
+    Assert.Equal<Result<GitCommand, string>>(Ok GitCommand.Status, CliParse.parse [| "status" |])
+
+[<Fact>]
+let ``parse errors on empty, bad count, and unknown verbs`` () =
+    match CliParse.parse [||] with Error _ -> () | Ok o -> Assert.Fail(sprintf "expected usage error, got %A" o)
+    match CliParse.parse [| "log"; "abc" |] with Error _ -> () | Ok o -> Assert.Fail(sprintf "expected count error, got %A" o)
+    match CliParse.parse [| "frobnicate" |] with Error _ -> () | Ok o -> Assert.Fail(sprintf "expected unknown-command error, got %A" o)

--- a/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
+++ b/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <Compile Include="GitDeltaLog.Tests.fs" />
     <Compile Include="GitCommand.Tests.fs" />
+    <Compile Include="CliParse.Tests.fs" />
     <Compile Include="GitSnapshotStore.Tests.fs" />
     <Compile Include="GitRecoverableSpine.Tests.fs" />
     <Compile Include="DurableSagaGit.Tests.fs" />


### PR DESCRIPTION
The CLI's brain as a pure CI-tested library fn (core-first): `CliParse.parse: argv -> Result<GitCommand,string>` (commit/log/branch/checkout/status → verbs). The runnable `zeta` exe stays a trivial shell (parse → GitCommand.run → print); MCP maps tool-calls the same way. 2 tests green. Roadmap #1: DbCommand ✅ + GitCommand ✅ + CLI-parser ✅; remaining: thin exe shell + MCP wrapper, then push/sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)