### PR TITLE
feat(command/roadmap-#1): the zeta CLI exe — runnable no-git-CLI tool (slice 4)

### DIFF
--- a/tools/zeta-cli/Program.fs
+++ b/tools/zeta-cli/Program.fs
@@ -1,0 +1,36 @@
+module Zeta.Cli.Program
+
+open System
+open LibGit2Sharp
+open Zeta.Core.Git
+
+/// The thin `zeta` CLI shell over the command core (roadmap #1, no-git-CLI; core-library-first). All the
+/// logic lives in CliParse (argv -> GitCommand) + GitCommand.run (over the repo) — both CI-tested in
+/// Zeta.Core.Git. This shell just opens the repo in the cwd, runs, prints, and returns an exit code.
+[<EntryPoint>]
+let main argv =
+    match CliParse.parse argv with
+    | Error msg ->
+        eprintfn "%s" msg
+        2
+    | Ok cmd ->
+        match Repository.Discover(Environment.CurrentDirectory) with
+        | null ->
+            eprintfn "zeta: not inside a git repository"
+            1
+        | repoPath ->
+            use repo = new Repository(repoPath)
+            match GitCommand.run repo (fun () -> DateTimeOffset.UtcNow) cmd with
+            | Branched n -> printfn "branched %s" n
+            | CheckedOut n -> printfn "checked out %s" n
+            | Committed sha -> printfn "committed %s" sha
+            | Logged entries ->
+                for (sha, msg) in entries do
+                    printfn "%s %s" (sha.Substring(0, min 9 sha.Length)) msg
+            | Statused(clean, pending) ->
+                if clean then
+                    printfn "clean"
+                else
+                    printfn "dirty (%d pending):" pending.Length
+                    for p in pending do printfn "  %s" p
+            0

--- a/tools/zeta-cli/Zeta.Cli.fsproj
+++ b/tools/zeta-cli/Zeta.Cli.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Zeta.Cli</RootNamespace>
+    <AssemblyName>zeta</AssemblyName>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Core.Git\Zeta.Core.Git.fsproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The thin runnable `zeta` CLI over the command core (core-first). `tools/zeta-cli` (standalone exe, Z3Verify pattern; AssemblyName `zeta`); ~30-line shell: discover repo → CliParse.parse → GitCommand.run → print. All logic CI-tested in Zeta.Core.Git.

**VERIFIED end-to-end (libgit2, zero git CLI):** `zeta status` → dirty/pending; `zeta log 3` → last 3 commits; `zeta` → usage. So `zeta status/log/branch/checkout/commit` now replace those `git` calls — first concrete step of the done-test. Next: MCP wrapper (Otto drives it) + push/sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)