### PR TITLE
feat(Core.Git): pluggable host-agnostic CredentialSource + command-surface design capture

### DIFF
--- a/docs/research/2026-06-07-command-surface-not-1to1-git-retractable-compensating-data-plane-one-interface-host-is-a-plugin-aaron.md
+++ b/docs/research/2026-06-07-command-surface-not-1to1-git-retractable-compensating-data-plane-one-interface-host-is-a-plugin-aaron.md
@@ -1,0 +1,90 @@
+# The command surface: NOT 1:1 with git, retractable-by-nature, compensating-actions-built-in; data-plane is the ONE interface; the host (GitHub) is a plugin (Aaron, 2026-06-07)
+
+Two related steers on roadmap #1 (the no-git-CLI command surface). Faithful capture; Mirror→Beacon. They
+refine — not replace — the git-reach punch-list (`081KTGPC2XP`): the punch-list enumerates *which* git
+reaches must be replaceable; this doc fixes the *shape* of the replacement.
+
+## 1. The zeta git commands are NOT a 1:1 mapping of git
+
+> Aaron: *"our git commands in zeta should not be one to one mapping — we don't need the full fidelity.
+> We are using it in a very specific way to stay retractable by nature, and we can have compensating
+> actions built into the commands themselves where it makes sense."*
+
+- **No full-fidelity mirror.** We do not reproduce git's whole porcelain/plumbing surface. We expose a
+  *curated* subset, chosen for how we actually use git.
+- **Retractable by nature.** The commands are shaped so the normal operation is *undoable* — the Z-set /
+  retraction model carried up into the command layer (an apply has a defined inverse; the log stays a
+  correctable stream, not a destructive mutation). This is the idempotency + retraction discipline made a
+  command-surface property, not just a data property.
+- **Compensating actions built into the commands** *where it makes sense*. For operations that are not
+  truly retractable (you cannot un-send a network push), the command carries its **compensation** — the
+  saga-style inverse (a revert-commit / restore-ref), so even irreversible-at-the-wire operations have a
+  defined "undo path" expressed in the command itself. (Beacon: Garcia-Molina & Salem, *Sagas*, 1987 —
+  compensating transactions; the established name for "no rollback, so define a semantic inverse".)
+
+Design consequence: each command declares, alongside its effect, *how it is taken back* — true retraction
+where the substrate allows it, a named compensating action where it does not. A git verb with neither is a
+smell (it's a raw-fidelity passthrough we said we don't want).
+
+## 2. End-state: data-plane commands for EVERYTHING; git-zeta commands are the freedom layer
+
+> Aaron: *"eventually I would like to use only data-plane commands for everything — the git/zeta commands
+> being the layer that allows more freedom but less composability. The data layer forces DB flows over git
+> AND filesystem consistently, so they are one interface — but git still takes advantage of its native
+> history and such naturally, even though it's one interface."*
+
+Two layers, with a clear gradient:
+
+| Layer | Freedom | Composability | Role |
+|-------|---------|---------------|------|
+| **git-zeta commands** | **more** | **less** | escape hatch — raw-er git reach when you need it |
+| **data-plane commands** | less (curated) | **more** (the goal) | the ONE interface; forces consistent DB flows |
+
+- **The data-plane is the single interface.** It **forces DB-shaped flows uniformly over BOTH git and the
+  filesystem** — same verbs, same retraction/compensation/idempotency guarantees, regardless of whether
+  the bytes land in git refs or in files. Two backends (git, fs), *one* interface — no per-backend dialect.
+- **Git's native strengths are still used, naturally, underneath.** One interface on top does **not** mean
+  throwing away git's history/Merkle-DAG/branching — those are leveraged transparently by the data-plane
+  when git is the backend. The uniform interface is a *cap*, not a *flattening*: you get consistency on
+  top and git's native history for free below.
+- **The direction of travel:** today we still reach for git-zeta commands (more freedom). The end-state is
+  *only* data-plane commands — the git layer becomes the rarely-used freedom/escape layer, and everything
+  routine goes through the one composable data-plane interface. (This is the "git-reach = gap detector"
+  loop's terminal condition: when no routine work needs the freedom layer, the gap is closed.)
+
+## 3. The host (GitHub) is a plugin, not git-native — pluggable, host-agnostic credentials
+
+> Aaron (same session): *"host-specific things don't belong in git — github is not git-native, it's a
+> plugin. We should support all [credential modes] eventually, including others like GitLab."*
+
+- **GitHub / GitLab / the `gh` CLI are HOST PLUGINS**, not part of the git-native core. The data-plane's
+  remote verbs (push/sync/fetch) must stay host-agnostic; anything GitHub-specific is a plugin behind a
+  contract.
+- **Credentials are a pluggable, host-agnostic abstraction** — `CredentialSource` (landed this round):
+  the git layer only knows "a source yields a `CredentialsHandler`, or an error to fall through on."
+  Concrete sources are plugins: **EnvToken** (HTTPS PAT from `GH_TOKEN`/`GITHUB_TOKEN` — landed; Aaron is
+  HTTPS-logged-in), then **GhCli** (`gh auth token`), **GitHelper** (`git credential fill`), **Ssh**
+  (ssh-agent/key) — each lands as needed, same contract, tried in priority order. A token-as-password with
+  username `x-access-token` is itself host-agnostic (any HTTPS git host accepting a PAT); the token's
+  *provenance* (a gh login vs a GitLab PAT) is the host plugin's concern, never git's.
+
+## Ties
+
+- Refines workitem `081KTGPC2XP` (git-reach punch-list) — its 1:1 table is the *gap inventory*, not the
+  command shape; this doc says the replacements are curated + retractable + compensating, not mirrors.
+- `docs/ROADMAP.md` #1 (no-git-CLI) · `src/Core/Command.fs` (DbCommand — data-plane verbs) ·
+  `src/Core.Git/GitCommand.fs` (git-zeta verbs, the freedom layer) ·
+  `src/Core.Git/CredentialSource.fs` (the pluggable host-agnostic credential abstraction, landed).
+- Disciplines: retraction = Z-set inverse (`src/Core/ZSet.fs`); idempotency (6th always-active);
+  compensation = Sagas (control-plane Loom layer is the multi-step saga home).
+
+## Beacon anchors
+
+- **Sagas / compensating transactions** — Hector Garcia-Molina & Kenneth Salem, *Sagas* (SIGMOD 1987):
+  long-lived transactions with semantic compensation instead of rollback.
+- **Retraction / differential** — DBSP (Budiu et al.) Z-sets: every insert has a defined retraction.
+- **One-interface-over-many-backends** — the repository/adapter pattern; here unified by the data-plane's
+  forced DB-flow uniformity over git + filesystem.
+- Honest novelty: not these patterns individually, but applying retraction+compensation+idempotency
+  *uniformly as the one command interface* over both git and the filesystem, with git's native history
+  retained underneath.

--- a/src/Core.Git/CredentialSource.fs
+++ b/src/Core.Git/CredentialSource.fs
@@ -1,0 +1,47 @@
+namespace Zeta.Core.Git
+
+open System
+open LibGit2Sharp
+open LibGit2Sharp.Handlers
+
+/// Credential source for remote git operations (push/fetch) — PLUGGABLE + host-AGNOSTIC.
+///
+/// Architectural rule (Aaron 2026-06-07): **GitHub is NOT git-native — it's a plugin.** Host-specific
+/// things (GitHub, GitLab, the `gh` CLI) do not belong in the git-native core. So the credential
+/// mechanism is an abstraction the git-native push/fetch consume; concrete sources are *plugins*:
+/// `EnvToken` (HTTPS PAT from env), `GhCli` (`gh auth token`), `GitHelper` (`git credential fill`), `Ssh`
+/// (ssh-agent/key). Multiple sources can be tried in order. A source yields a LibGit2Sharp
+/// `CredentialsHandler`; the git layer never names a host. v1 ships `EnvToken` (Aaron is HTTPS-logged-in);
+/// the rest land as needed — same pluggable contract.
+type CredentialSource =
+    /// Produce a credentials handler, or an error explaining why this source can't supply one
+    /// (so a caller can fall through to the next source in priority order).
+    abstract TryHandler: unit -> Result<CredentialsHandler, string>
+
+/// HTTPS token from an environment variable (default order: `GH_TOKEN`, then `GITHUB_TOKEN`).
+/// Host-AGNOSTIC at the git layer: a token used as the password with username `x-access-token` works for
+/// any HTTPS git host that accepts a PAT-as-password (GitHub, GitLab, …). The token's *provenance*
+/// (a `gh` login, a GitLab PAT) is the host plugin's concern, never git's.
+[<Sealed>]
+type EnvTokenCredentialSource(?envVars: string list) =
+    let vars = defaultArg envVars [ "GH_TOKEN"; "GITHUB_TOKEN" ]
+
+    /// The env var that supplied the token (or None), without building a handler — for diagnostics/tests.
+    member _.ResolvedVar() : string option =
+        vars
+        |> List.tryPick (fun v ->
+            match Environment.GetEnvironmentVariable v with
+            | null
+            | "" -> None
+            | _ -> Some v)
+
+    interface CredentialSource with
+        member this.TryHandler() =
+            match this.ResolvedVar() with
+            | Some v ->
+                let token = Environment.GetEnvironmentVariable v
+                Ok(
+                    CredentialsHandler(fun _ _ _ ->
+                        UsernamePasswordCredentials(Username = "x-access-token", Password = token) :> Credentials)
+                )
+            | None -> Error(sprintf "no credential: set one of %s" (String.concat ", " vars))

--- a/src/Core.Git/Zeta.Core.Git.fsproj
+++ b/src/Core.Git/Zeta.Core.Git.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="GitDeltaLog.fs" />
     <Compile Include="GitCommand.fs" />
     <Compile Include="CliParse.fs" />
+    <Compile Include="CredentialSource.fs" />
     <Compile Include="GitSnapshotStore.fs" />
   </ItemGroup>
 

--- a/tests/Tests.FSharp.Git/CredentialSource.Tests.fs
+++ b/tests/Tests.FSharp.Git/CredentialSource.Tests.fs
@@ -1,0 +1,42 @@
+module Zeta.Tests.Git.CredentialSourceTests
+
+open System
+open global.Xunit
+open Zeta.Core.Git
+
+// Pluggable, host-agnostic credential source (roadmap #1 push/sync). GitHub/gh/GitLab are HOST PLUGINS,
+// not git-native (Aaron 2026-06-07) — the git layer only knows "a source yields a handler or an error".
+// We test source-SELECTION (env present -> Ok handler; absent -> Error), never a live push (side-effecting).
+
+let private withEnv (pairs: (string * string option) list) (f: unit -> unit) =
+    let saved = pairs |> List.map (fun (k, _) -> k, Environment.GetEnvironmentVariable k)
+    try
+        for k, v in pairs do
+            Environment.SetEnvironmentVariable(k, Option.toObj v)
+        f ()
+    finally
+        for k, v in saved do
+            Environment.SetEnvironmentVariable(k, v)
+
+[<Fact>]
+let ``EnvToken resolves GH_TOKEN, prefers it over GITHUB_TOKEN, and yields a handler`` () =
+    withEnv [ "GH_TOKEN", Some "tok-gh"; "GITHUB_TOKEN", Some "tok-github" ] (fun () ->
+        let src = EnvTokenCredentialSource()
+        Assert.Equal(Some "GH_TOKEN", src.ResolvedVar())
+        match (src :> CredentialSource).TryHandler() with
+        | Ok h -> Assert.NotNull(box h)
+        | Error e -> Assert.Fail(sprintf "expected handler, got %s" e))
+
+[<Fact>]
+let ``EnvToken falls through to GITHUB_TOKEN when GH_TOKEN is unset`` () =
+    withEnv [ "GH_TOKEN", None; "GITHUB_TOKEN", Some "tok-github" ] (fun () ->
+        Assert.Equal(Some "GITHUB_TOKEN", EnvTokenCredentialSource().ResolvedVar()))
+
+[<Fact>]
+let ``EnvToken errors (no throw) when no env var is set, so a caller can fall through`` () =
+    withEnv [ "GH_TOKEN", None; "GITHUB_TOKEN", None ] (fun () ->
+        let src = EnvTokenCredentialSource()
+        Assert.Equal(None, src.ResolvedVar())
+        match (src :> CredentialSource).TryHandler() with
+        | Error _ -> ()
+        | Ok _ -> Assert.Fail "expected Error when no credential env var is set")

--- a/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
+++ b/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="GitDeltaLog.Tests.fs" />
     <Compile Include="GitCommand.Tests.fs" />
     <Compile Include="CliParse.Tests.fs" />
+    <Compile Include="CredentialSource.Tests.fs" />
     <Compile Include="GitSnapshotStore.Tests.fs" />
     <Compile Include="GitRecoverableSpine.Tests.fs" />
     <Compile Include="DurableSagaGit.Tests.fs" />

--- a/workitems/081KTGPC2XP08QG0R000X8X1M9-git-reach-punch-list-data-plane-command-spec-requirements-fo.md
+++ b/workitems/081KTGPC2XP08QG0R000X8X1M9-git-reach-punch-list-data-plane-command-spec-requirements-fo.md
@@ -44,6 +44,20 @@ checkout / status / sync / push) are the genuinely-new commands — they're git-
 must expose as first-class verbs over the git backend. PR/merge are *control-plane* (the consensus-repo /
 Loom layer), distinct from the data-plane DB commands.
 
+## Command SHAPE (Aaron 2026-06-07 — the table is a gap inventory, NOT a 1:1 mirror)
+
+The mapping above enumerates *which* git reaches must become replaceable — it is **not** a spec for
+full-fidelity git verbs. Per `docs/research/2026-06-07-command-surface-not-1to1-git-...-aaron.md`:
+- **Not 1:1 with git** — a curated subset, no full porcelain fidelity.
+- **Retractable by nature** — apply has a defined inverse (Z-set retraction carried to the command layer).
+- **Compensating action built in where not truly retractable** — e.g. `push` (can't un-send) carries a
+  saga-style compensation (revert-commit / restore-ref), not a raw passthrough.
+- **Data-plane = the ONE interface** forcing consistent DB flows over BOTH git and filesystem; the
+  git-zeta verbs are the *freedom-but-less-composable* escape layer. End-state: only data-plane commands
+  routinely; git's native history is still leveraged underneath the one interface.
+- **Host (GitHub/GitLab/gh) = a plugin, not git-native** — remote verbs stay host-agnostic; credentials
+  via the pluggable `CredentialSource` (`src/Core.Git/CredentialSource.fs`, EnvToken landed).
+
 ## Acceptance
 
 A data-plane command exists for every data-plane row above; Otto completes a full work-cycle


### PR DESCRIPTION
## What

**Code** — `CredentialSource` abstraction + `EnvTokenCredentialSource` (roadmap #1 push/sync foundation):
- The host (GitHub/GitLab/`gh`) is a **plugin, not git-native** (Aaron 2026-06-07). Remote git ops take credentials through a pluggable, **host-agnostic** abstraction; the git layer only knows "a source yields a handler, or an error to fall through on."
- `EnvTokenCredentialSource`: HTTPS PAT from `GH_TOKEN` then `GITHUB_TOKEN` as `x-access-token`:password. v1 source; `GhCli`/`GitHelper`/`Ssh` plug in next, same contract.
- **3 tests** (source-selection only). No live-push test (side-effecting).

**Capture** — command surface is NOT a 1:1 git mirror — curated, retractable-by-nature, compensating actions built in where not truly retractable; the data plane is the ONE interface over both git AND filesystem; git-zeta verbs are the freedom escape layer.

## Test
`dotnet test tests/Tests.FSharp.Git` → **29 passed** (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)