### PR TITLE
docs(capture): filesystem backend needs a Merkle DAG for command parity with git

### DIFF
--- a/docs/research/2026-06-07-filesystem-backend-needs-a-merkle-dag-for-command-parity-with-git-aaron.md
+++ b/docs/research/2026-06-07-filesystem-backend-needs-a-merkle-dag-for-command-parity-with-git-aaron.md
@@ -1,0 +1,68 @@
+# The filesystem backend needs a Merkle DAG (like git's) so the data-plane commands are EQUAL across git and filesystem (Aaron, 2026-06-07)
+
+The concrete requirement that makes "the data plane is ONE interface over both git AND filesystem"
+(`2026-06-07-command-surface-not-1to1-git-...`) actually hold. Faithful capture; Beacon-anchored.
+
+## The steer
+
+> Aaron: *"for our filesystem implementation we are going to need a Merkle tree or something like git does,
+> so our commands can be equal between filesystem and git."*
+
+## Why it's required (not optional)
+
+The one-interface promise is: the same retractable/historied/verifiable commands behave identically whether
+the bytes land in **git refs** or in **files**. Git gets those properties *for free* from its object model
+— a **content-addressed Merkle DAG** (blobs/trees/commits keyed by hash; history = a hash-chain of commits;
+integrity = hash verification; dedup + cheap diff = shared subtrees). A plain filesystem has **none** of
+that — it's mutable named bytes, no history, no content-addressing, no tamper-evidence. So to make the fs
+backend *equal* to the git backend under one interface, the fs implementation must grow its **own Merkle
+DAG / content-addressed store** — otherwise `commit`/`log`/`history`/`get`/retract/compensate cannot mean
+the same thing on both backends.
+
+Properties the fs backend gains from a Merkle DAG (achieving git-parity):
+
+| Property | git has it via | fs backend gets it via |
+|----------|----------------|------------------------|
+| History / log | commit hash-chain | Merkle-rooted entry chain |
+| Content-addressing / dedup | blob/tree SHA | chunk digest (FastCDC + MerkleHash) |
+| Integrity / tamper-evidence | object SHA verify | Merkle root verification |
+| Retraction parity | revert/reset over DAG | inverse-entry over the same DAG |
+| Cheap diff / incremental ship | shared subtrees | shared internal nodes (already the Merkle trick) |
+
+## We already have most of the primitives
+
+- **`src/Core/Merkle.fs`** — `MerkleHash` (XxHash128, zero-alloc struct) + the tree (leaf-hash,
+  internal-node combine, "ship only changed leaves + O(log N) path"). Built as the CAS-DBSP checkpoint
+  building block; the same machinery a content-addressed fs store needs.
+- **`FastCdc`** — content-defined chunking; pairs with Merkle (chunk → digest → tree), so two versions
+  sharing most bytes share most nodes (git-packfile-style incremental).
+- **`src/Core/DiskDeltaLog.fs`** — the fs delta-log backend that would sit *on* the content-addressed
+  store (its frame `[len][crc][payload]` is per-entry integrity; the Merkle DAG adds cross-entry history +
+  content-addressing + a verifiable root).
+
+**Gap to build:** a content-addressed object/blob store + a commit-equivalent (Merkle-rooted history node)
+over the fs, wired so `GitCommand`/`DbCommand` verbs resolve identically on the fs backend as on git.
+
+## Hash-strength caveat (honest)
+
+`Merkle.fs` uses **XxHash128 — non-cryptographic** (fast, collision-safe for same-tenant replication, NOT
+tamper-proof). Git uses SHA-1/SHA-256 (cryptographic). If the fs store must give git-equivalent
+**tamper-evidence / Byzantine integrity** (not just dedup + history), upgrade the leaf/node hash to
+**BLAKE3** (already flagged roadmap P2 in `Merkle.fs`). For plain history + dedup parity, XxHash128 is
+fine; for "as trustworthy as git's object integrity", it is not — pick per the property the fs store must
+match. This is a real decision, not a detail.
+
+## Ties
+
+- `docs/research/2026-06-07-command-surface-not-1to1-git-...` (the one-interface-over-git-and-fs steer this
+  satisfies) · `2026-06-07-identity-proof-tiers-*` (git = a Merkle DAG = half a blockchain; this builds the
+  fs half) · `src/Core/Merkle.fs` · `FastCdc` · `src/Core/DiskDeltaLog.fs` · roadmap #1 (no-git-CLI).
+
+## Beacon anchors
+
+- **Ralph Merkle**, "A digital signature based on a conventional encryption function" (CRYPTO 1987) — hash
+  trees. · **Git object model** (Linus Torvalds, 2005) — content-addressed Merkle DAG (blob/tree/commit).
+  · **Content-addressed storage**: Plan 9 **Venti** (Quinlan & Dorward, 2002), **IPFS** Merkle DAG (Benet,
+  2014), **Perkeep/Camlistore**, **Dat/hypercore**. · **FastCDC** — Xia et al., USENIX ATC 2016
+  (the chunker). Honest novelty: not a new Merkle store, but a content-addressed fs DAG built to be
+  *command-interchangeable with git* under one data-plane interface.

--- a/workitems/081KTGTJC1Q08QG0R002VCB55A-content-addressed-merkle-dag-over-the-filesystem-backend-for.md
+++ b/workitems/081KTGTJC1Q08QG0R002VCB55A-content-addressed-merkle-dag-over-the-filesystem-backend-for.md
@@ -1,0 +1,56 @@
+---
+id: 081KTGTJC1Q08QG0R002VCB55A
+type: task
+state: backlog
+priority: P1
+slug: content-addressed-merkle-dag-over-the-filesystem-backend-for
+title: "Content-addressed Merkle DAG over the filesystem backend for command parity with git"
+created: 2026-06-07T10:38:00.247Z
+depends_on: []
+composes_with: ["081KTGPC2XP08QG0R000X8X1M9"]
+---
+
+# Content-addressed Merkle DAG over the filesystem backend for command parity with git
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTGTJC1Q08QG0R002VCB55A-*.md` glob. -->
+
+## Purpose
+
+Make the data-plane "one interface over BOTH git and filesystem" actually hold (Aaron 2026-06-07): the
+fs backend needs its own **content-addressed Merkle DAG** so `commit`/`log`/`history`/`get`/retract/
+compensate mean the *same thing* on fs as on git. A plain filesystem has no history, no content-addressing,
+no tamper-evidence; git gets all three from its object model. Build the fs equivalent.
+
+Full rationale + property-parity table + hash-strength caveat:
+`docs/research/2026-06-07-filesystem-backend-needs-a-merkle-dag-for-command-parity-with-git-aaron.md`.
+
+## Build (primitives already exist — wire them into a store)
+
+- **Have:** `src/Core/Merkle.fs` (`MerkleHash`/XxHash128 tree, ship-changed-leaves+O(log N) path),
+  `FastCdc` (content-defined chunking), `src/Core/DiskDeltaLog.fs` (fs delta-log, per-entry `[len][crc]`).
+- **Build:** a content-addressed object/blob store (chunk → digest → Merkle tree) + a commit-equivalent
+  (Merkle-rooted history node) over the fs, wired so `GitCommand`/`DbCommand` verbs resolve identically on
+  the fs backend as on the git backend (the parity test: same command sequence → equivalent observable
+  history/get/retract results on both backends).
+
+## Open decision (Aaron's call — real, not a detail)
+
+**Hash strength.** `Merkle.fs` is XxHash128 (non-crypto: fast, dedup+history-safe, NOT tamper-proof). Git
+uses cryptographic SHA. If the fs store must match git's **tamper-evidence/Byzantine integrity**, upgrade
+leaf/node hash to **BLAKE3** (already roadmap-P2-flagged in `Merkle.fs`). For history+dedup parity only,
+XxHash128 suffices. Pick per the property the fs store must equal.
+
+## Acceptance
+
+A content-addressed Merkle store backs the fs delta-log; a parity test runs the same command sequence
+against git-backend and fs-backend and asserts equivalent observable results (history, get-by-coordinate,
+retraction/compensation). Hash-strength decision recorded.
+
+## Anchors
+
+- `docs/research/2026-06-07-filesystem-backend-needs-a-merkle-dag-...` ·
+  `docs/research/2026-06-07-command-surface-not-1to1-git-...` (the one-interface steer this satisfies) ·
+  `src/Core/Merkle.fs` · `FastCdc` · `src/Core/DiskDeltaLog.fs` · composes with `081KTGPC2XP` (punch-list).
+- Beacon: Merkle (CRYPTO 1987); git object model; Venti/IPFS/Perkeep (content-addressed stores); FastCDC.


### PR DESCRIPTION
## What
Captures Aaron's 2026-06-07 steer: *"for our filesystem implementation we are going to need a Merkle tree or something like git does, so our commands can be equal between filesystem and git."*

- **Capture doc** — why the fs backend needs a **content-addressed Merkle DAG**: git gets history / content-addressing / tamper-evidence free from its object model; a plain filesystem has none, so for the data-plane's one-interface-over-git-and-fs to hold, the fs backend must grow the equivalent. Property-parity table + the **XxHash128-vs-BLAKE3** hash-strength caveat (non-crypto dedup/history vs git-equivalent tamper-evidence — a real decision).
- **Backlog `081KTGTJC1Q`** (P1, composes with the git-reach punch-list `081KTGPC2XP`) — build a content-addressed store over the **existing** `Merkle.fs` + `FastCdc` + `DiskDeltaLog`, wired so `GitCommand`/`DbCommand` verbs resolve identically on both backends; parity test = same command sequence → equivalent observable history/get/retract.

Docs + workitem only; no code/build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)