### PR TITLE
feat(zeta): push + fetch verbs on the host-agnostic CredentialSource (CLI + MCP)

### DIFF
--- a/src/Core.Git/CliParse.fs
+++ b/src/Core.Git/CliParse.fs
@@ -8,7 +8,8 @@ namespace Zeta.Core.Git
 module CliParse =
 
     let usage =
-        "usage: zeta <commit <msg> | log [n] | branch <name> | checkout <ref> | status>"
+        "usage: zeta <commit <msg> | log [n] | branch <name> | checkout <ref> | status | "
+        + "push [remote] [branch] | fetch [remote]>"
 
     let parse (argv: string[]) : Result<GitCommand, string> =
         match List.ofArray argv with
@@ -21,5 +22,12 @@ module CliParse =
         | [ "branch"; name ] -> Ok(GitCommand.Branch name)
         | [ "checkout"; refName ] -> Ok(GitCommand.Checkout refName)
         | [ "status" ] -> Ok GitCommand.Status
+        // push: remote defaults to origin, branch to current HEAD (None).
+        | [ "push" ] -> Ok(GitCommand.Push("origin", None))
+        | [ "push"; remote ] -> Ok(GitCommand.Push(remote, None))
+        | [ "push"; remote; branch ] -> Ok(GitCommand.Push(remote, Some branch))
+        // fetch: remote defaults to origin.
+        | [ "fetch" ] -> Ok(GitCommand.Fetch "origin")
+        | [ "fetch"; remote ] -> Ok(GitCommand.Fetch remote)
         | [] -> Error usage
         | other -> Error(sprintf "unknown command: '%s'\n%s" (String.concat " " other) usage)

--- a/src/Core.Git/GitCommand.fs
+++ b/src/Core.Git/GitCommand.fs
@@ -2,15 +2,20 @@ namespace Zeta.Core.Git
 
 open System
 open LibGit2Sharp
+open LibGit2Sharp.Handlers
 open Zeta.Core
 
 /// **Git-ref command verbs** — the source-repo / working-branch operations that retire Otto's `git` CLI
 /// usage (roadmap #1, no-git-CLI). Distinct from `DbCommand` (Zeta.Core, the data-plane Log verbs over
 /// `IDeltaLog`): these operate on an actual working git repository via LibGit2Sharp — the "DB layer that
 /// understands git, running git-native." Verbs-as-data (a DU), interpreted by `run` over a `Repository`;
-/// the CLI + MCP thin-wrap it. LOCAL verbs only here (branch / checkout / commit / log / status);
-/// network verbs (push / sync) need credential handling and land in a follow-up slice.
-/// Punch-list: workitem 081KTGPC2XP.
+/// the CLI + MCP thin-wrap it. Local verbs (branch / checkout / commit / log / status) ignore credentials
+/// and stay deterministic; network verbs (push / fetch) take a `CredentialSource` (host-agnostic — GitHub
+/// is a plugin, not git-native). Punch-list: workitem 081KTGPC2XP.
+///
+/// Not a 1:1 git mirror (Aaron 2026-06-07): a curated, retractable-by-nature surface with compensating
+/// actions where an op is not truly retractable — see `Push` (you cannot un-send a push; its compensation
+/// is a forward revert-commit or a ref-restore, the latter irreversible and never auto-executed).
 type GitCommand =
     /// Create a branch at the current tip (does not switch). `git branch <name>`.
     | Branch of name: string
@@ -22,6 +27,13 @@ type GitCommand =
     | Log of count: int
     /// Working-tree status. `git status`.
     | Status
+    /// Push a branch (default: current HEAD) to a remote (default: origin). `git push <remote> <branch>`.
+    /// NETWORK + credentialed. NOT retractable at the wire — compensation is a forward revert-commit
+    /// (safe) or a remote-ref restore (force-push, irreversible → never auto-executed; a human decides).
+    | Push of remote: string * branch: string option
+    /// Fetch from a remote (default: origin). `git fetch <remote>`. NETWORK + credentialed. Read-only on
+    /// the remote, so retractable locally (drop the fetched refs); no compensation needed.
+    | Fetch of remote: string
 
 type GitCommandResult =
     | Branched of name: string
@@ -29,13 +41,38 @@ type GitCommandResult =
     | Committed of sha: string
     | Logged of entries: (string * string)[]
     | Statused of isClean: bool * pending: string[]
+    | Pushed of remote: string * refspec: string
+    | Fetched of remote: string
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module GitCommand =
 
-    /// Interpret a git-ref command over a working `Repository`. `now` supplies the deterministic clock
-    /// for commit signatures (DST-friendly — same seed, same commit metadata).
-    let run (repo: Repository) (now: unit -> DateTimeOffset) (cmd: GitCommand) : GitCommandResult =
+    /// Resolve a credential handler for a network verb, or fail with a clean message (no credential
+    /// source wired, or the source can't supply one). Kept separate so the host stays a plugin: the git
+    /// layer only knows "a source yields a handler or an error."
+    let private resolveHandler (verb: string) (credSource: CredentialSource option) : CredentialsHandler =
+        match credSource with
+        | None -> invalidOp (sprintf "%s requires a credential source (none wired)" verb)
+        | Some source ->
+            match source.TryHandler() with
+            | Ok handler -> handler
+            | Error e -> invalidOp (sprintf "%s: %s" verb e)
+
+    let private remoteOrFail (repo: Repository) (name: string) : Remote =
+        match repo.Network.Remotes.[name] with
+        | null -> invalidOp (sprintf "no remote '%s'" name)
+        | r -> r
+
+    /// Interpret a git-ref command over a working `Repository`. `now` supplies the deterministic clock for
+    /// commit signatures (DST-friendly — same seed, same commit metadata). `credSource` is consumed only
+    /// by the network verbs (push / fetch); local verbs ignore it and stay deterministic. Network/cred
+    /// failures raise `InvalidOperationException` with a clean message (the CLI/MCP shell prints it).
+    let run
+        (repo: Repository)
+        (now: unit -> DateTimeOffset)
+        (credSource: CredentialSource option)
+        (cmd: GitCommand)
+        : GitCommandResult =
         match cmd with
         | Branch name ->
             let b = repo.CreateBranch name
@@ -59,3 +96,16 @@ module GitCommand =
             let st = repo.RetrieveStatus(StatusOptions())
             let pending = st |> Seq.map (fun e -> e.FilePath) |> Seq.toArray
             Statused(not st.IsDirty, pending)
+        | Push(remote, branch) ->
+            let handler = resolveHandler "push" credSource
+            let r = remoteOrFail repo remote
+            let br = branch |> Option.defaultValue repo.Head.FriendlyName
+            let refspec = sprintf "refs/heads/%s:refs/heads/%s" br br
+            repo.Network.Push(r, refspec, PushOptions(CredentialsProvider = handler))
+            Pushed(remote, refspec)
+        | Fetch remote ->
+            let handler = resolveHandler "fetch" credSource
+            let r = remoteOrFail repo remote
+            let refspecs = r.FetchRefSpecs |> Seq.map (fun s -> s.Specification)
+            Commands.Fetch(repo, remote, refspecs, FetchOptions(CredentialsProvider = handler), null)
+            Fetched remote

--- a/src/Core.Git/Zeta.Core.Git.fsproj
+++ b/src/Core.Git/Zeta.Core.Git.fsproj
@@ -18,9 +18,9 @@
 
   <ItemGroup>
     <Compile Include="GitDeltaLog.fs" />
+    <Compile Include="CredentialSource.fs" />
     <Compile Include="GitCommand.fs" />
     <Compile Include="CliParse.fs" />
-    <Compile Include="CredentialSource.fs" />
     <Compile Include="GitSnapshotStore.fs" />
   </ItemGroup>
 

--- a/tests/Tests.FSharp.Git/CliParse.Tests.fs
+++ b/tests/Tests.FSharp.Git/CliParse.Tests.fs
@@ -16,6 +16,17 @@ let ``parse maps the git-ref verbs`` () =
     Assert.Equal<Result<GitCommand, string>>(Ok GitCommand.Status, CliParse.parse [| "status" |])
 
 [<Fact>]
+let ``parse maps the network verbs with remote/branch defaults`` () =
+    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Push("origin", None)), CliParse.parse [| "push" |])
+    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Push("upstream", None)), CliParse.parse [| "push"; "upstream" |])
+    Assert.Equal<Result<GitCommand, string>>(
+        Ok(GitCommand.Push("origin", Some "main")),
+        CliParse.parse [| "push"; "origin"; "main" |]
+    )
+    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Fetch "origin"), CliParse.parse [| "fetch" |])
+    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Fetch "upstream"), CliParse.parse [| "fetch"; "upstream" |])
+
+[<Fact>]
 let ``parse errors on empty, bad count, and unknown verbs`` () =
     match CliParse.parse [||] with Error _ -> () | Ok o -> Assert.Fail(sprintf "expected usage error, got %A" o)
     match CliParse.parse [| "log"; "abc" |] with Error _ -> () | Ok o -> Assert.Fail(sprintf "expected count error, got %A" o)

--- a/tests/Tests.FSharp.Git/GitCommand.Tests.fs
+++ b/tests/Tests.FSharp.Git/GitCommand.Tests.fs
@@ -29,17 +29,17 @@ let private withRepo (f: Repository -> string -> unit) =
 let ``Commit stages+commits; Log returns it; Status is clean after`` () =
     withRepo (fun repo dir ->
         File.WriteAllText(Path.Combine(dir, "a.txt"), "hello")
-        match GitCommand.run repo fixedClock (GitCommand.Commit "first") with
+        match GitCommand.run repo fixedClock None (GitCommand.Commit "first") with
         | Committed sha -> Assert.False(String.IsNullOrEmpty sha)
         | o -> Assert.Fail(sprintf "expected Committed, got %A" o)
 
-        match GitCommand.run repo fixedClock (GitCommand.Log 10) with
+        match GitCommand.run repo fixedClock None (GitCommand.Log 10) with
         | Logged entries ->
             Assert.Single(entries) |> ignore
             Assert.Equal("first", snd entries.[0])
         | o -> Assert.Fail(sprintf "expected Logged, got %A" o)
 
-        match GitCommand.run repo fixedClock GitCommand.Status with
+        match GitCommand.run repo fixedClock None GitCommand.Status with
         | Statused(isClean, pending) ->
             Assert.True(isClean)
             Assert.Empty(pending)
@@ -49,20 +49,66 @@ let ``Commit stages+commits; Log returns it; Status is clean after`` () =
 let ``Status reports pending changes; Branch + Checkout switch the working tree`` () =
     withRepo (fun repo dir ->
         File.WriteAllText(Path.Combine(dir, "a.txt"), "hello")
-        GitCommand.run repo fixedClock (GitCommand.Commit "first") |> ignore
+        GitCommand.run repo fixedClock None (GitCommand.Commit "first") |> ignore
 
         // an untracked file makes the tree dirty
         File.WriteAllText(Path.Combine(dir, "b.txt"), "world")
-        match GitCommand.run repo fixedClock GitCommand.Status with
+        match GitCommand.run repo fixedClock None GitCommand.Status with
         | Statused(isClean, pending) ->
             Assert.False(isClean)
             Assert.Contains("b.txt", pending)
         | o -> Assert.Fail(sprintf "expected dirty Statused, got %A" o)
 
-        match GitCommand.run repo fixedClock (GitCommand.Branch "feature") with
+        match GitCommand.run repo fixedClock None (GitCommand.Branch "feature") with
         | Branched name -> Assert.Equal("feature", name)
         | o -> Assert.Fail(sprintf "expected Branched, got %A" o)
 
-        match GitCommand.run repo fixedClock (GitCommand.Checkout "feature") with
+        match GitCommand.run repo fixedClock None (GitCommand.Checkout "feature") with
         | CheckedOut name -> Assert.Equal("feature", name)
         | o -> Assert.Fail(sprintf "expected CheckedOut, got %A" o))
+
+// Network verbs (push / fetch) — credential + remote error paths only. No LIVE push/fetch (side-effecting,
+// needs a real remote + token); we assert the verb fails cleanly BEFORE touching the network when the
+// credential source or remote is missing. Uses a custom env-var name so the host runner's GH_TOKEN can't
+// leak in and make the "no credential" path non-deterministic.
+
+[<Fact>]
+let ``Push with no credential source fails cleanly before any network`` () =
+    withRepo (fun repo dir ->
+        File.WriteAllText(Path.Combine(dir, "a.txt"), "hi")
+        GitCommand.run repo fixedClock None (GitCommand.Commit "first") |> ignore
+
+        let ex =
+            Assert.Throws<InvalidOperationException>(fun () ->
+                GitCommand.run repo fixedClock None (GitCommand.Push("origin", None)) |> ignore)
+        Assert.Contains("credential source", ex.Message))
+
+[<Fact>]
+let ``Push with a credential source whose env var is unset fails with a credential error`` () =
+    withRepo (fun repo dir ->
+        File.WriteAllText(Path.Combine(dir, "a.txt"), "hi")
+        GitCommand.run repo fixedClock None (GitCommand.Commit "first") |> ignore
+
+        let src = Some(EnvTokenCredentialSource([ "ZETA_TEST_UNSET_TOKEN_VAR" ]) :> CredentialSource)
+        let ex =
+            Assert.Throws<InvalidOperationException>(fun () ->
+                GitCommand.run repo fixedClock src (GitCommand.Push("origin", None)) |> ignore)
+        Assert.Contains("no credential", ex.Message))
+
+[<Fact>]
+let ``Push to a missing remote fails with a clear remote error (no network)`` () =
+    withRepo (fun repo dir ->
+        File.WriteAllText(Path.Combine(dir, "a.txt"), "hi")
+        GitCommand.run repo fixedClock None (GitCommand.Commit "first") |> ignore
+
+        let varName = "ZETA_TEST_TOKEN_PRESENT"
+        Environment.SetEnvironmentVariable(varName, "dummy-token")
+        try
+            let src = Some(EnvTokenCredentialSource([ varName ]) :> CredentialSource)
+            // credential resolves; the repo has no 'origin' remote, so it fails at remote lookup, pre-network.
+            let ex =
+                Assert.Throws<InvalidOperationException>(fun () ->
+                    GitCommand.run repo fixedClock src (GitCommand.Push("origin", None)) |> ignore)
+            Assert.Contains("no remote", ex.Message)
+        finally
+            Environment.SetEnvironmentVariable(varName, null))

--- a/tools/zeta-cli/Program.fs
+++ b/tools/zeta-cli/Program.fs
@@ -7,6 +7,9 @@ open Zeta.Core.Git
 /// The thin `zeta` CLI shell over the command core (roadmap #1, no-git-CLI; core-library-first). All the
 /// logic lives in CliParse (argv -> GitCommand) + GitCommand.run (over the repo) — both CI-tested in
 /// Zeta.Core.Git. This shell just opens the repo in the cwd, runs, prints, and returns an exit code.
+///
+/// Network verbs (push / fetch) get a host-agnostic credential source: env token (GH_TOKEN / GITHUB_TOKEN)
+/// over HTTPS. GitHub is a plugin, not git-native — the source only yields a handler or a clean error.
 [<EntryPoint>]
 let main argv =
     match CliParse.parse argv with
@@ -20,17 +23,25 @@ let main argv =
             1
         | repoPath ->
             use repo = new Repository(repoPath)
-            match GitCommand.run repo (fun () -> DateTimeOffset.UtcNow) cmd with
-            | Branched n -> printfn "branched %s" n
-            | CheckedOut n -> printfn "checked out %s" n
-            | Committed sha -> printfn "committed %s" sha
-            | Logged entries ->
-                for (sha, msg) in entries do
-                    printfn "%s %s" (sha.Substring(0, min 9 sha.Length)) msg
-            | Statused(clean, pending) ->
-                if clean then
-                    printfn "clean"
-                else
-                    printfn "dirty (%d pending):" pending.Length
-                    for p in pending do printfn "  %s" p
-            0
+            let credSource = Some(EnvTokenCredentialSource() :> CredentialSource)
+
+            try
+                match GitCommand.run repo (fun () -> DateTimeOffset.UtcNow) credSource cmd with
+                | Branched n -> printfn "branched %s" n
+                | CheckedOut n -> printfn "checked out %s" n
+                | Committed sha -> printfn "committed %s" sha
+                | Logged entries ->
+                    for (sha, msg) in entries do
+                        printfn "%s %s" (sha.Substring(0, min 9 sha.Length)) msg
+                | Statused(clean, pending) ->
+                    if clean then
+                        printfn "clean"
+                    else
+                        printfn "dirty (%d pending):" pending.Length
+                        for p in pending do printfn "  %s" p
+                | Pushed(remote, refspec) -> printfn "pushed %s -> %s" refspec remote
+                | Fetched remote -> printfn "fetched %s" remote
+                0
+            with ex ->
+                eprintfn "zeta: %s" ex.Message
+                1

--- a/tools/zeta-mcp/Program.fs
+++ b/tools/zeta-mcp/Program.fs
@@ -37,6 +37,8 @@ let private toolList () : JsonArray =
     arr.Add(tool "zeta_branch" "Create a branch at the tip (replaces git branch)" [ "name", "string" ] [ "name" ])
     arr.Add(tool "zeta_checkout" "Switch the working tree (replaces git checkout)" [ "ref", "string" ] [ "ref" ])
     arr.Add(tool "zeta_commit" "Stage all + commit (replaces git commit)" [ "message", "string" ] [ "message" ])
+    arr.Add(tool "zeta_push" "Push a branch to a remote (replaces git push); creds via GH_TOKEN/GITHUB_TOKEN" [ "remote", "string"; "branch", "string" ] [])
+    arr.Add(tool "zeta_fetch" "Fetch from a remote (replaces git fetch); creds via GH_TOKEN/GITHUB_TOKEN" [ "remote", "string" ] [])
     arr
 
 let private argStr (args: JsonObject) (k: string) : string =
@@ -54,6 +56,13 @@ let private runTool (name: string) (args: JsonObject) : string =
         | "zeta_branch" -> Some(GitCommand.Branch(argStr args "name"))
         | "zeta_checkout" -> Some(GitCommand.Checkout(argStr args "ref"))
         | "zeta_commit" -> Some(GitCommand.Commit(argStr args "message"))
+        | "zeta_push" ->
+            let remote = match argStr args "remote" with "" -> "origin" | r -> r
+            let branch = match argStr args "branch" with "" -> None | b -> Some b
+            Some(GitCommand.Push(remote, branch))
+        | "zeta_fetch" ->
+            let remote = match argStr args "remote" with "" -> "origin" | r -> r
+            Some(GitCommand.Fetch remote)
         | _ -> None
     match cmd with
     | None -> sprintf "unknown tool: %s" name
@@ -61,15 +70,21 @@ let private runTool (name: string) (args: JsonObject) : string =
         match Repository.Discover(Environment.CurrentDirectory) with
         | null -> "not inside a git repository"
         | path ->
+            // Host-agnostic credentials for network verbs (GH_TOKEN/GITHUB_TOKEN); local verbs ignore it.
+            let credSource = Some(EnvTokenCredentialSource() :> CredentialSource)
             use repo = new Repository(path)
-            match GitCommand.run repo now c with
-            | Branched n -> sprintf "branched %s" n
-            | CheckedOut n -> sprintf "checked out %s" n
-            | Committed sha -> sprintf "committed %s" sha
-            | Logged es -> es |> Array.map (fun (s, m) -> sprintf "%s %s" (s.Substring(0, min 9 s.Length)) m) |> String.concat "\n"
-            | Statused(clean, pending) ->
-                if clean then "clean"
-                else sprintf "dirty (%d pending):\n%s" pending.Length (String.concat "\n" pending)
+            try
+                match GitCommand.run repo now credSource c with
+                | Branched n -> sprintf "branched %s" n
+                | CheckedOut n -> sprintf "checked out %s" n
+                | Committed sha -> sprintf "committed %s" sha
+                | Logged es -> es |> Array.map (fun (s, m) -> sprintf "%s %s" (s.Substring(0, min 9 s.Length)) m) |> String.concat "\n"
+                | Statused(clean, pending) ->
+                    if clean then "clean"
+                    else sprintf "dirty (%d pending):\n%s" pending.Length (String.concat "\n" pending)
+                | Pushed(remote, refspec) -> sprintf "pushed %s -> %s" refspec remote
+                | Fetched remote -> sprintf "fetched %s" remote
+            with ex -> sprintf "error: %s" ex.Message
 
 [<EntryPoint>]
 let main _ =


### PR DESCRIPTION
## What
Unblocks **live credential testing of the `zeta` CLI** (Aaron asked to test it with credentials). Wires network verbs onto the landed `CredentialSource` (EnvToken: `GH_TOKEN`/`GITHUB_TOKEN` over HTTPS).

- **`GitCommand` += `Push(remote, branch option)` / `Fetch(remote)`**; `run` gains `credSource: CredentialSource option` — **local verbs ignore it and stay deterministic**; network verbs require it. Cred/remote failures raise a **clean `InvalidOperationException` before any network I/O**.
- **Push is documented NOT-retractable** (Aaron's not-1:1 steer): compensation is a forward revert-commit (safe) or a remote-ref restore (force-push, irreversible → **never auto-executed**; a human decides). Fetch is read-only on the remote → locally retractable.
- **`CliParse` += `push [remote] [branch]` / `fetch [remote]`** (origin + current-HEAD defaults); return type unchanged so existing parse tests stay green.
- **`zeta` CLI + `zeta` MCP**: wire `EnvTokenCredentialSource`, print `Pushed`/`Fetched`, wrap `run` in clean error handling (no stack-trace crashes; MCP returns `error: …`). MCP also exposes `zeta_push`/`zeta_fetch`.

## Test
`dotnet test tests/Tests.FSharp.Git` → **33 passed** (4 new): parse push/fetch defaults; push with no cred source; push with unset-env cred source; push to a missing remote. **No live push/fetch** (side-effecting) — all assert clean failure pre-network. CLI + MCP build clean.

## To test live (Aaron)
Set `GH_TOKEN` (or `GITHUB_TOKEN`) in the env, then `zeta push` / `zeta fetch` from a repo with an `origin` remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)