### PR TITLE
feat(Core): canonical Merkle-over-Z-set primitive (fs-Merkle backend foundation)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -80,6 +80,7 @@
     <Compile Include="NovelMathExt.fs" />
     <Compile Include="FastCdc.fs" />
     <Compile Include="Merkle.fs" />
+    <Compile Include="ZSetMerkle.fs" />
     <Compile Include="Residuated.fs" />
     <Compile Include="Aggregate.fs" />
     <Compile Include="RobustStats.fs" />

--- a/src/Core/ZSetMerkle.fs
+++ b/src/Core/ZSetMerkle.fs
@@ -1,0 +1,83 @@
+namespace Zeta.Core
+
+open System
+open System.Buffers.Binary
+
+/// **Canonical Merkle root over a Z-set** — the foundation of the fs-Merkle / git-compatible replacement
+/// backend (workitem 081KTGTJC1Q; Aaron 2026-06-07). The Merkle leaves ARE the retractable DBSP Z-set
+/// entries, so the content-addressed root is a *pure function of the NET Z-set state*: **retraction is
+/// native** — equal Z-sets produce equal roots, and `+w` then `−w` on a key is a no-op on the root (the
+/// canceled entry simply isn't in the support). Two Z-sets differing by a small delta share most leaves →
+/// most internal nodes → cheap incremental diff (the Merkle trick, now over Z-set deltas).
+///
+/// **Hash-parameterized.** `rootWith` takes the hash function, so the structure + canonicalization are
+/// independent of the digest. Today the default `root` uses `MerkleHash.ofBytes` (XxHash128 —
+/// dedup/history-grade). The git-replacement object store will pass **BLAKE3** (cryptographic,
+/// tamper-respecting — Aaron's decision; not yet a dependency). Swap at the call site, not in the algebra.
+///
+/// **Canonical order is by ENCODED-KEY BYTES (codepoint / byte-ordinal lexicographic)** — deliberately NOT
+/// the Z-set's internal `Comparer<'K>.Default` order, which is culture-SENSITIVE for strings (B-0969 /
+/// the culture-invariant rule). Re-sorting by key bytes here is exactly what makes the root cross-language
+/// **byte-lockable** (the same root in F#/C#/Rust/TS given the same `encodeKey` + hash). The seed is the
+/// treaty.
+[<RequireQualifiedAccess>]
+module ZSetMerkle =
+
+    /// Canonical leaf encoding for one `(key, weight)` entry:
+    /// `[4-byte LE keyLen][keyBytes][8-byte LE weight]`. Length-prefixing the key makes the encoding
+    /// injective (no `(k1,k2)` vs `(k1++k2)` ambiguity); little-endian fixes byte order across languages.
+    let private leafBytes (keyBytes: byte[]) (weight: Weight) : byte[] =
+        let buf = Array.zeroCreate<byte> (4 + keyBytes.Length + 8)
+        BinaryPrimitives.WriteInt32LittleEndian(Span<byte>(buf, 0, 4), keyBytes.Length)
+        Array.blit keyBytes 0 buf 4 keyBytes.Length
+        BinaryPrimitives.WriteInt64LittleEndian(Span<byte>(buf, 4 + keyBytes.Length, 8), weight)
+        buf
+
+    /// Lexicographic ordinal comparison of two byte arrays (the cross-language canonical order).
+    let private byteCompare (a: byte[]) (b: byte[]) : int =
+        let n = min a.Length b.Length
+        let mutable i = 0
+        let mutable r = 0
+        while r = 0 && i < n do
+            r <- compare a.[i] b.[i]
+            i <- i + 1
+        if r <> 0 then r else compare a.Length b.Length
+
+    /// Combine two child digests into a parent: 32 LE bytes `a.Hi a.Lo b.Hi b.Lo`, re-hashed.
+    let private combine (hash: byte[] -> MerkleHash) (a: MerkleHash) (b: MerkleHash) : MerkleHash =
+        let buf = Array.zeroCreate<byte> 32
+        BinaryPrimitives.WriteUInt64LittleEndian(Span<byte>(buf, 0, 8), a.Hi)
+        BinaryPrimitives.WriteUInt64LittleEndian(Span<byte>(buf, 8, 8), a.Lo)
+        BinaryPrimitives.WriteUInt64LittleEndian(Span<byte>(buf, 16, 8), b.Hi)
+        BinaryPrimitives.WriteUInt64LittleEndian(Span<byte>(buf, 24, 8), b.Lo)
+        hash buf
+
+    /// Fold a level of digests bottom-up; an odd trailing node is promoted (duplicated) — the standard
+    /// Merkle construction. (Note: the duplicate-last shape has the well-known second-preimage caveat; for
+    /// a tamper-evident store this is paired with BLAKE3 + the length-prefixed injective leaf encoding.)
+    let rec private fold (hash: byte[] -> MerkleHash) (level: MerkleHash[]) : MerkleHash =
+        match level.Length with
+        | 0 -> hash (Array.empty<byte>) // canonical empty root
+        | 1 -> level.[0]
+        | n ->
+            let parents = Array.zeroCreate<MerkleHash> ((n + 1) / 2)
+            for i in 0 .. parents.Length - 1 do
+                let a = level.[2 * i]
+                let b = if 2 * i + 1 < n then level.[2 * i + 1] else a
+                parents.[i] <- combine hash a b
+            fold hash parents
+
+    /// Canonical Merkle root over `z` with an explicit hash function. Leaves = `(key, weight)` entries
+    /// encoded + sorted by key bytes (ordinal); folded bottom-up. Deterministic + retraction-native.
+    let rootWith (hash: byte[] -> MerkleHash) (encodeKey: 'K -> byte[]) (z: ZSet<'K>) : MerkleHash =
+        let leaves =
+            [| for e in z -> struct (encodeKey e.Key, e.Weight) |]
+            |> Array.sortWith (fun (struct (ka, _)) (struct (kb, _)) -> byteCompare ka kb)
+            |> Array.map (fun (struct (kb, w)) -> hash (leafBytes kb w))
+
+        fold hash leaves
+
+    /// Canonical Merkle root using the default digest (XxHash128 via `MerkleHash.ofBytes`). For the
+    /// git-replacement / tamper-evident store, call `rootWith` with BLAKE3 instead (081KTGTJC1Q).
+    let root (encodeKey: 'K -> byte[]) (z: ZSet<'K>) : MerkleHash =
+        rootWith (fun (b: byte[]) -> MerkleHash.ofBytes (ReadOnlySpan<byte> b)) encodeKey z

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -75,6 +75,7 @@
     <Compile Include="GSet.FourSer.Tests.fs" />
     <Compile Include="Clock.FullVertical.Tests.fs" />
     <Compile Include="Merkle.FullVertical.Tests.fs" />
+    <Compile Include="ZSetMerkle.Tests.fs" />
     <Compile Include="SerializationSeed.FullVertical.Tests.fs" />
     <Compile Include="Identity.FullVertical.Tests.fs" />
     <Compile Include="Predicate3.Tests.fs" />

--- a/tests/Tests.FSharp/ZSetMerkle.Tests.fs
+++ b/tests/Tests.FSharp/ZSetMerkle.Tests.fs
@@ -1,0 +1,85 @@
+module Zeta.Tests.ZSetMerkleTests
+
+open System
+open System.Text
+open global.Xunit
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.Xunit
+open Zeta.Core
+
+// Canonical Merkle-over-Z-set (081KTGTJC1Q) — the math leg. The root must be a pure function of the NET
+// Z-set state (retraction-native), order-independent (canonical), and hash-parameterized. The universal
+// properties use INT keys: int is a clean total order, so ZSet.ofSeq is order-independent on it. (String
+// keys go through ZSet's culture-SENSITIVE Comparer<'K>.Default sort — the live B-0969 class — where
+// forward-vs-reverse ofSeq of culture-colliding strings yields genuinely DIFFERENT net Z-sets; the Merkle
+// then correctly gives different roots. Cross-language STRING byte-lock is a golden-vector concern, not a
+// property of this module — see the xUnit anchors for the UTF-8 string encoding.)
+let private enc (s: string) : byte[] = Encoding.UTF8.GetBytes s
+
+let private encI (i: int) : byte[] =
+    let b = Array.zeroCreate<byte> 4
+    System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(Span<byte> b, i)
+    b
+
+// Weights are bounded to a non-overflowing range: with duplicate keys, ZSet.ofSeq SUMS weights, and int64
+// summation overflows order-dependently — an arithmetic-overflow concern of ofSeq, not of the Merkle root
+// (which faithfully reflects whatever net Z-set it is handed). Bounding keeps the properties on their
+// honest domain.
+let private boundW (w: int64) : int64 = w % 1_000_000L
+
+let private zsetOf (pairs: (int * int64) list) : ZSet<int> =
+    pairs |> List.map (fun (k, w) -> k, boundW w) |> ZSet.ofSeq
+
+// --- universal properties (FsCheck) ---
+
+[<Property>]
+let ``root is order-independent: equal net Z-sets => equal roots`` (pairs: (int * int64) list) =
+    let z1 = zsetOf pairs
+    let z2 = zsetOf (List.rev pairs)
+    ZSetMerkle.root encI z1 = ZSetMerkle.root encI z2
+
+[<Property>]
+let ``retraction is a no-op on the root: +w then -w cancels`` (pairs: (int * int64) list) (k: int) (w: int64) =
+    let wb = boundW w
+
+    (wb <> 0L)
+    ==> lazy
+        (let z = zsetOf pairs
+         let z' = z + ZSet.singleton k wb + ZSet.singleton k (-wb)
+         ZSetMerkle.root encI z = ZSetMerkle.root encI z')
+
+[<Property>]
+let ``root is deterministic across repeated computation`` (pairs: (int * int64) list) =
+    let z = zsetOf pairs
+    ZSetMerkle.root encI z = ZSetMerkle.root encI z
+
+[<Property>]
+let ``default root equals rootWith the XxHash128 digest`` (pairs: (int * int64) list) =
+    let z = zsetOf pairs
+    let xx (b: byte[]) = MerkleHash.ofBytes (ReadOnlySpan<byte> b)
+    ZSetMerkle.root encI z = ZSetMerkle.rootWith xx encI z
+
+// --- anchors (xUnit) ---
+
+[<Fact>]
+let ``empty root is deterministic and distinct from a singleton`` () =
+    let empty = ZSet<string>.Empty
+    Assert.Equal(ZSetMerkle.root enc empty, ZSetMerkle.root enc empty)
+    Assert.NotEqual(ZSetMerkle.root enc empty, ZSetMerkle.root enc (ZSet.ofSeq [ "a", 1L ]))
+
+[<Fact>]
+let ``distinct content yields distinct roots (key and weight sensitivity)`` () =
+    let r kvs = ZSetMerkle.root enc (ZSet.ofSeq kvs)
+    Assert.NotEqual(r [ "a", 1L ], r [ "a", 2L ]) // weight matters
+    Assert.NotEqual(r [ "a", 1L ], r [ "b", 1L ]) // key matters
+    Assert.NotEqual(r [ "a", 1L ], r [ "a", 1L; "b", 1L ]) // support matters
+
+[<Fact>]
+let ``a different digest yields a different root for non-empty input`` () =
+    let z = ZSet.ofSeq [ "a", 1L; "b", 2L ]
+    // alternate digest: swap hi/lo of the default — a genuinely different hash function
+    let alt (b: byte[]) =
+        let h = MerkleHash.ofBytes(ReadOnlySpan<byte> b)
+        MerkleHash(h.Lo, h.Hi)
+    Assert.NotEqual(ZSetMerkle.root enc z, ZSetMerkle.rootWith alt enc z)


### PR DESCRIPTION
## What
First buildable slice of the git-compatible fs backend (`081KTGTJC1Q`, greenlit easy-first). The Merkle **leaves ARE the retractable DBSP Z-set entries**, so the content-addressed root is a **pure function of the net Z-set state** — retraction is native (equal Z-sets → equal roots; `+w` then `−w` is a no-op on the root).

- **`ZSetMerkle.rootWith`** (hash-parameterized) + **`root`** (default XxHash128). **BLAKE3** plugs in at the call site for the tamper-evident store (Aaron's decision; not yet a dependency) — swap the digest, not the algebra.
- **Canonical order by encoded-key bytes (ordinal)** — deliberately NOT the Z-set's internal culture-**sensitive** `Comparer.Default` (B-0969); this is what makes the root cross-language **byte-lockable**. Length-prefixed injective leaf encoding; LE byte order fixed across languages.

## Test — math leg, 7 green (FsCheck + xUnit)
order-independence · retraction-no-op · determinism · `root`==`rootWith` · empty determinism · key/weight/support sensitivity · distinct-digest→distinct-root. Universal properties use `int` keys (clean total order); string UTF-8 encoding anchored in xUnit facts.

> FsCheck note: with string keys the order-independence property *correctly* fails — `ZSet.ofSeq` sorts via culture-**sensitive** `Comparer.Default` (live B-0969 class), so forward-vs-reverse `ofSeq` of culture-colliding strings yields genuinely different net Z-sets. The Merkle is right; `ofSeq` is the issue (filing separately).

## Follow-up (parallelizable → Vera/Lior)
4-lang golden vectors (C#/Rust/TS oracles) · BLAKE3 dependency · closure-table DAG · content-addressed store wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)