### PR TITLE
docs: fs content-hash/multi-parent design + confirmed ZSet culture-ordering instance (B-0969 escalation)

### DIFF
--- a/docs/backlog/P1/B-0969-invariant-culture-everywhere-configureawait-false-cross-cutting-dotnet-defaults-never-culture-sensitive-fsharp-gset-first-fix-aaron-2026-06-01.md
+++ b/docs/backlog/P1/B-0969-invariant-culture-everywhere-configureawait-false-cross-cutting-dotnet-defaults-never-culture-sensitive-fsharp-gset-first-fix-aaron-2026-06-01.md
@@ -88,6 +88,35 @@ documented as a "known gap" in `src/Core.TypeScript/{g-set,bag}/golden-vectors.j
   `.claude/rules/`): "Zeta is server/library code — invariant culture / ordinal
   by default; `ConfigureAwait(false)` by default; culture-sensitive is opt-in."
 
+## URGENCY ESCALATION (maintainer 2026-06-07) — do this sooner rather than later
+
+> *"we need to do this sooner rather than later cause it affects all 4 lang and a lot of surface area
+> before we get too far."*
+
+The longer the 4-language surface grows, the more code is written against the culture-sensitive default and
+the more golden vectors bake in ASCII-masked parity — so the fix gets strictly more expensive over time.
+Treat B-0969 as **do-now**, ahead of net-new primitive surface. The collation choice (ordinal / codepoint ≡
+UTF-8 byte order) is the **treaty** every oracle + every golden vector must conform to; landing it early is
+what keeps the 4-oracle byte-consensus cheap. Gating decision (comparer strategy a-vs-b) is in action 1 —
+pin it first so the cross-language fix can proceed.
+
+## Confirmed located instance — ZSet (not just G-Set), empirically verified (Otto 2026-06-07)
+
+The same defect lives in **`ZSet`**, the load-bearing data-plane primitive, not only G-Set:
+`EntryKeyComparer` and the ofSeq/merge paths sort via **`Comparer<'K>.Default`** —
+`src/Core/ZSet.fs:26, 67, 123, 548` — which is **culture-sensitive for `string`**. (Equality uses
+`EqualityComparer<'K>.Default`, which IS ordinal for string, so only the **ordering** diverges — but
+ordering drives the canonical sorted-run invariant, so culture-colliding distinct strings can be
+mis-ordered/merged → an order-dependent net Z-set.)
+
+**Empirically confirmed**, not source-read only: an FsCheck order-independence property over
+`ZSet.ofSeq` with **string** keys is falsifiable (forward-vs-reverse `ofSeq` of culture-colliding strings
+yields different net Z-sets); the same property over **`int`** keys passes. Surfaced while landing the
+canonical Merkle-over-Z-set (PR #6789) — whose own fix is to **re-sort by ordinal key bytes**, sidestepping
+`ZSet`'s culture-sensitive order (the pattern the ZSet fix should adopt). Reaffirmed by the maintainer
+2026-06-07: *"we should be culture insensitive everywhere by default."* Fold ZSet into action 1's
+ordinal-comparison fix alongside G-Set (same comparer-strategy decision).
+
 ## Composes with
 
 - **B-0959** (cross-language substrate master checklist) — the 4-oracle

--- a/docs/research/2026-06-07-filesystem-backend-needs-a-merkle-dag-for-command-parity-with-git-aaron.md
+++ b/docs/research/2026-06-07-filesystem-backend-needs-a-merkle-dag-for-command-parity-with-git-aaron.md
@@ -101,12 +101,33 @@ Three moves that make the fs-Merkle store *be* the existing substrate rather tha
    Same closure-table-over-Z-sets, Merkle-rooted, both ways — chosen per deployment, identical commands on
    top. (This mirrors git's own loose-objects-vs-packfile duality.)
 
-Added Beacon: **closure table** — Bill Karwin, *SQL Antipatterns* (2010), the closure-table pattern for
-storing hierarchies/DAGs relationally (ancestor/descendant/depth); transitive-closure relations.
-**Single-file DB** — SQLite (D. Richard Hipp) — one-file database + pluggable VFS. Novelty stays honest:
-not a new Merkle store nor a new closure table, but **Merkle-hashing the DBSP Z-set so the
-content-addressed history is natively retractable, with the DAG itself a Z-set closure table**, materialized
-single- or multi-file under one command interface.
+4. **Content-addressed nodes → single-instance + multi-parent + an explicit edit-scope choice** (Aaron
+   2026-06-07): *"based on content-based hashes, a single file is only represented once and it can live
+   under two different folders at the same time; then when you edit a file you choose to save it just to
+   that one folder (the default, like regular filesystems) or to do a content update everywhere."*
+   - **Single-instance.** Each file's content is stored **once**, keyed by its **content hash (BLAKE3)** —
+     identical content under many paths is one node (dedup / single-instance storage). The content hash
+     *is* the node id; the `ZSetMerkle` root over the node's bytes/entries is the natural key.
+   - **Multi-parent.** A content node can sit under **two (or N) folders simultaneously** — many parent
+     edges to one node in the closure table (a Z-set of edges naturally allows many-to-one). Hardlink- /
+     git-blob-shaped: one blob, multiple tree entries.
+   - **Two edit modes — the user chooses scope:**
+     | Mode | Semantics | Mechanism |
+     |------|-----------|-----------|
+     | **save-to-this-folder** (DEFAULT, regular-fs feel) | copy-on-write fork — only *this* folder sees the change | new content node (new hash); repoint **only this folder's edge**; other referrers keep the old node |
+     | **content-update-everywhere** | every folder referencing the content follows the change | replace the content node; **all parent edges** that pointed at the old hash now point at the new hash |
+   - Both modes are pure closure-table edge edits (retraction repoints an edge; idempotent by content
+     hash) — so they inherit DST-replay + the retractable/compensating command discipline.
+
+Added Beacon: **closure table** — Bill Karwin, *SQL Antipatterns* (2010), hierarchies/DAGs relationally
+(ancestor/descendant/depth). **Single-file DB** — SQLite (D. Richard Hipp), one-file DB + pluggable VFS.
+**Content-addressed single-instance + multi-reference**: Unix **hardlinks** (one inode, many dir entries),
+**git blobs** (content-addressed, shared across trees/commits), single-instance storage (Windows SIS),
+**copy-on-write clones** (ZFS / btrfs / APFS) — the COW-local-vs-propagate choice is exactly "clone the
+blob and repoint one edge" vs "edit the shared object." Novelty stays honest: not a new Merkle store nor a
+new closure table, but **Merkle-hashing the DBSP Z-set so the content-addressed history is natively
+retractable, the DAG itself a Z-set closure table with content-hash single-instance multi-parent nodes**,
+materialized single- or multi-file under one command interface.
 
 ## Ties
 

--- a/workitems/081KTGTJC1Q08QG0R002VCB55A-content-addressed-merkle-dag-over-the-filesystem-backend-for.md
+++ b/workitems/081KTGTJC1Q08QG0R002VCB55A-content-addressed-merkle-dag-over-the-filesystem-backend-for.md
@@ -48,6 +48,28 @@ Full rationale + property-parity table + hash-strength caveat:
   OR **multi-file** (ride the OS filesystem; dirs/files ARE nodes, git-loose-object-shaped). Mirrors git's
   loose-vs-packfile duality. Both must pass the same backend-parity test.
 - Beacon add: closure table (Karwin, *SQL Antipatterns* 2010); single-file DB + VFS (SQLite).
+- **F# foundation LANDED (PR #6789):** `src/Core/ZSetMerkle.fs` — hash-parameterized canonical
+  Merkle-over-Z-set (`rootWith`/`root`), ordinal key-byte canonicalization, 7 FsCheck+xUnit properties
+  (retraction-native, order-independent, deterministic, sensitivity). Remaining: 4-lang golden vectors,
+  BLAKE3 dependency, closure-table DAG, store wiring.
+
+### Content-addressed nodes — single-instance + multi-parent + edit-scope choice (Aaron 2026-06-07)
+
+> *"based on content-based hashes a single file is only represented once and it can live under two
+> different folders at the same time; then when you edit a file you choose to save it just to that one
+> folder (the default, like regular filesystems) or to do a content update everywhere."*
+
+- **Single-instance**: content stored ONCE, keyed by content hash (BLAKE3); the `ZSetMerkle` root is the
+  node id. Identical content under many paths = one node (dedup).
+- **Multi-parent**: a content node can sit under N folders at once — many parent edges → one node in the
+  closure table (Z-set of edges allows many-to-one). Hardlink-/git-blob-shaped.
+- **Two edit modes (user chooses scope):** (1) **save-to-this-folder** = DEFAULT, copy-on-write fork —
+  new content node, repoint ONLY this folder's edge (regular-fs feel); (2) **content-update-everywhere** =
+  replace the node, ALL parent edges following the old hash now point at the new hash. Both are pure
+  closure-table edge edits (retraction repoints; idempotent by content hash) → inherit DST + the
+  retractable/compensating discipline.
+- Beacon: Unix hardlinks; git blobs; single-instance storage; COW clones (ZFS/btrfs/APFS).
+- Full: `docs/research/2026-06-07-filesystem-backend-needs-a-merkle-dag-...` §4.
 
 ## Hash strength — DECIDED: BLAKE3 (Aaron 2026-06-07)
 


### PR DESCRIPTION
## What — three maintainer steers (2026-06-07)

1. **Content-based hashing in the fs/closure-table backend** (`081KTGTJC1Q`): a file stored **once** by content hash (single-instance), able to live under **N folders at once** (multi-parent edges), with editing choosing scope — **save-to-this-folder** (DEFAULT, copy-on-write fork) vs **content-update-everywhere** (replace node, all parent edges follow). Both are pure closure-table edge edits (retraction repoints; idempotent by content hash). Captured in the doc §4 + workitem. Hardlink / git-blob / COW anchors.

2. **"Culture insensitive everywhere by default"** + **"we have collation treaties committed or on backlog"** → the treaty **is B-0969**. Added the **empirically confirmed ZSet instance** (not just G-Set): `EntryKeyComparer`/`ofSeq` sort via `Comparer<'K>.Default` (culture-sensitive for string) at `ZSet.fs:26/67/123/548`; FsCheck order-independence over string keys is falsifiable, int keys pass (found while landing the Merkle, #6789).

3. **"Do this sooner rather than later — affects all 4 lang and a lot of surface area"** → urgency-escalation note on B-0969 (do-now ahead of net-new primitive surface). Gating comparer-strategy decision flagged to pin first.

Docs + workitem only; no code/build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)