### PR TITLE
feat(Core): Collation seed (DB-style, binary/ordinal default) + SQL parameterized-model capture

### DIFF
--- a/docs/backlog/P1/B-0969-invariant-culture-everywhere-configureawait-false-cross-cutting-dotnet-defaults-never-culture-sensitive-fsharp-gset-first-fix-aaron-2026-06-01.md
+++ b/docs/backlog/P1/B-0969-invariant-culture-everywhere-configureawait-false-cross-cutting-dotnet-defaults-never-culture-sensitive-fsharp-gset-first-fix-aaron-2026-06-01.md
@@ -80,6 +80,20 @@ Postgres `COLLATE`, ICU locales) — NOT a raw `IComparer` knob exposed as CS pl
 So strategy (a)'s "explicit comparer param" is really **"select a collation (default = binary/ordinal)"** —
 the comparer carried as identity is the chosen collation. Name + model the API in DB-collation terms.
 
+### Landed seed + parameterized model (2026-06-07)
+
+- **Seed LANDED:** `src/Core/Collation.fs` — DB-style collation selection: shipped default `binary`
+  (= `StringComparer.Ordinal`, codepoint/byte order), a named catalog (`binary`/`ordinal`/`ordinal-ci`/
+  `invariant`/`invariant-ci`), and **`Collation.forKey<'T>`** (ordinal for string — the fix — else
+  `Comparer<'T>.Default`). 5 tests. This is the stable seed every primitive slice consumes; it does not
+  move as the catalog grows.
+- **Design direction = SQL-Server parameterized model + application levels:**
+  `docs/research/2026-06-07-collation-as-sql-server-parameterized-model-with-application-levels-stable-binary-seed-aaron.md`
+  — collation = locale + code page + sensitivity flags (`_CI/_CS/_AI/_AS/_KI/_KS/_WI/_WS/_VSS/_BIN/_UTF8`),
+  selectable at server/database/column/query levels (our analog: shipped default → cell default → value
+  carries it (strategy (a)) → per-op override `ofSeqWith`). Mismatched-collation merge is an error to
+  surface, not a silent reinterpret.
+
 ### Slice plan (sequenced; parallelizable across Vera/Lior/Otto)
 
 The comparer becomes part of each collection's *identity*, so the type must CARRY it (or take it on every

--- a/docs/research/2026-06-07-collation-as-sql-server-parameterized-model-with-application-levels-stable-binary-seed-aaron.md
+++ b/docs/research/2026-06-07-collation-as-sql-server-parameterized-model-with-application-levels-stable-binary-seed-aaron.md
@@ -1,0 +1,78 @@
+# Collation = the SQL-Server parameterized model (sensitivity flags + application levels), over a stable binary/ordinal seed (Aaron, 2026-06-07)
+
+The design direction for B-0969's collation selection. We model collation the way **SQL Server** does —
+a parameterized string (locale + code page + a set of sensitivity flags), selectable at multiple
+application levels — and we ship a **stable binary/ordinal default** that doesn't move no matter how rich
+the parameter space gets. Faithful capture; Beacon-anchored.
+
+## The stable seed (confirmed)
+
+> Aaron: *"exactly — you found a stable seed even with all the parameters."*
+
+No matter how many parameters a collation grows, two things are invariant and shipped first
+(`src/Core/Collation.fs`, landed): the **default = binary / ordinal** (codepoint ≡ UTF-8 byte order; SQL
+`_BIN2`-shaped) and **`Collation.forKey<'T>`** resolving strings to `StringComparer.Ordinal` (the B-0969
+fix) and everything else to `Comparer<'T>.Default`. The parameter space below *refines the catalog* over
+time; the seed + default are fixed points.
+
+## The parameterized model (SQL Server collation anatomy)
+
+A SQL Server collation is a string like **`SQL_Latin1_General_CP1_CI_AS`**, decomposed as:
+
+| Component | Meaning |
+|-----------|---------|
+| `Latin1_General` | locale / designator — the alphabet's linguistic sorting rules |
+| `_CP1` | code page (1252) — non-Unicode encoding mapping |
+| `_CI` / `_CS` | **case** in/sensitive (`_CS` sorts lowercase ahead of uppercase) |
+| `_AI` / `_AS` | **accent** in/sensitive (`'a'` = `'á'` vs distinct) |
+| `_KI` / `_KS` | **kana** sensitivity (Katakana vs Hiragana) |
+| `_WI` / `_WS` | **width** sensitivity (half- vs full-width) |
+| `_VSS` | variation-selector sensitivity (CJK ideograph variants) |
+| `_UTF8` | UTF-8 storage for `char`/`varchar` |
+| `_BIN` / `_BIN2` | **binary** sort — strict bit pattern / code point, NOT linguistic |
+
+Our catalog grows toward this: a collation is **locale + encoding + a flag-set**, with `_BIN2` (codepoint
+binary) as our shipped default. The seed module's named entries (`binary`, `ordinal`, `ordinal-ci`,
+`invariant`, `invariant-ci`) are the first slice of this space — `-ci` is the `_CI` flag; accent/kana/width
+flags + locale designators are future catalog entries, all **opt-in**, never displacing the binary default.
+
+## Application LEVELS (scope + override precedence)
+
+SQL collation is selectable at four boundaries, each overriding the broader one:
+
+1. **Server instance** — installation default for all metadata.
+2. **Database** — `CREATE/ALTER DATABASE COLLATE …`.
+3. **Column** — `… VARCHAR(50) COLLATE … ` overrides the database default for one field.
+4. **Query expression** — `… COLLATE DATABASE_DEFAULT` forces a collation on-the-fly (vital when joining
+   columns of mismatched collation to avoid evaluation errors).
+
+**Our analog (the precedence chain):**
+
+| SQL level | Zeta analog |
+|-----------|-------------|
+| Server default | the shipped **`Collation.binary`** default (`forKey`) |
+| Database | a substrate/cell-scoped default collation (a DynamicValue config factor) |
+| Column | **comparer-is-part-of-identity** — the collation a value/primitive (G-Set/Z-set/Bag) *carries* (B-0969 strategy (a)) |
+| Query expression | an explicit collation passed to an operation (`ofSeqWith collation`, a join/merge override) |
+
+Two collations only need to agree where they meet (a CRDT `union` / a join) — exactly SQL's
+"`COLLATE DATABASE_DEFAULT` on the join" rule. Mismatched-collation merge is an **error to surface**, not a
+silent reinterpret (the Mars-Climate-Orbiter lesson — units/order mismatches must not compound silently;
+`.claude/rules/culture-invariant-by-default.md`).
+
+## Ties
+
+- B-0969 (the fix + strategy (a) + DB-collation framing) · `src/Core/Collation.fs` (the seed, landed) ·
+  the algebra-ladder primitives G-Set/Z-set/Bag (consume `Collation.forKey` / carry a collation) ·
+  `ZSetMerkle` (already ordinal — the reference order) · `.claude/rules/culture-invariant-by-default.md`
+  (the canonical collation = the treaty).
+
+## Beacon anchors
+
+- **SQL Server collations** (Microsoft) — the parameterized-string + four-level model captured here. ·
+  **PostgreSQL `COLLATE`** + `C`/`ucs_basic` (binary) · **ICU** locales (the linguistic engine behind
+  accent/kana/width sensitivity) · **Unicode Collation Algorithm (UCA, UTS #10)** + **ISO/IEC 14651** —
+  the standards for linguistic (non-binary) collation · **Unicode normalization (NFC/NFD)** — relevant to
+  accent sensitivity. Honest novelty: none in the collation model itself (it's SQL's, deliberately); the
+  contribution is applying it uniformly across a 4-language byte-locked substrate with a binary default
+  that all four oracles reproduce bit-for-bit.

--- a/src/Core/Collation.fs
+++ b/src/Core/Collation.fs
@@ -1,0 +1,64 @@
+namespace Zeta.Core
+
+open System
+open System.Collections.Generic
+
+/// **Database-style collation selection** (B-0969). A collation is a *named, selectable ordering* — modeled
+/// the way databases do it (SQL / Postgres `COLLATE`, ICU locales), NOT a raw `IComparer` knob exposed as
+/// CS plumbing (maintainer 2026-06-07). We ship a **catalog** of named collations and **one default**,
+/// chosen to be (i) identically supportable across all four oracle languages and (ii) familiar to database
+/// people — both of which point to **binary / ordinal** (codepoint ≡ UTF-8 byte order; DB "binary
+/// collation": `*_bin` / `BINARY` / Postgres `C`). Other collations (case-insensitive, invariant) are
+/// **opt-in** catalog entries, never the silent default.
+///
+/// The chosen collation is **part of a value's identity** (comparer-is-part-of-identity — B-0969 strategy
+/// (a)). The algebra-ladder primitives (G-Set → Bag → Z-set) resolve their string ordering through here
+/// instead of the culture-SENSITIVE `Comparer<string>.Default` (the live B-0969 defect). The comparator
+/// contract (ordinal / codepoint ≡ UTF-8 byte order) is the **collation treaty** every oracle + golden
+/// vector conforms to — see `.claude/rules/culture-invariant-by-default.md`.
+[<RequireQualifiedAccess>]
+module Collation =
+
+    /// The canonical default for STRING keys: ordinal (codepoint / byte order) = DB "binary collation".
+    /// All four oracles coincide on this order for the golden vectors (F# ordinal, C#
+    /// `StringComparer.Ordinal`, TS UTF-16 code-unit, Rust byte `Ord`); the astral/UTF-16 caveat is
+    /// resolved by the treaty picking codepoint ≡ UTF-8 byte order.
+    let binary: StringComparer = StringComparer.Ordinal
+
+    /// The default collation name we ship with.
+    [<Literal>]
+    let defaultName = "binary"
+
+    /// The named string-collation catalog (DB-style). `binary`/`ordinal` is the shipped default; the rest
+    /// are opt-in. Case-insensitive + invariant are *linguistic* — selectable, never the default.
+    let catalog: IReadOnlyDictionary<string, StringComparer> =
+        let d = Dictionary<string, StringComparer>(StringComparer.OrdinalIgnoreCase)
+        d.["binary"] <- StringComparer.Ordinal
+        d.["ordinal"] <- StringComparer.Ordinal
+        d.["ordinal-ci"] <- StringComparer.OrdinalIgnoreCase
+        d.["invariant"] <- StringComparer.InvariantCulture
+        d.["invariant-ci"] <- StringComparer.InvariantCultureIgnoreCase
+        d :> IReadOnlyDictionary<string, StringComparer>
+
+    /// Resolve a named collation from the catalog, or `None` if unknown (the caller decides the fallback —
+    /// typically `binary`).
+    let tryByName (name: string) : StringComparer option =
+        match catalog.TryGetValue name with
+        | true, c -> Some c
+        | _ -> None
+
+    /// Resolve a named collation, falling back to the `binary` default for an unknown name.
+    let byNameOrDefault (name: string) : StringComparer =
+        match tryByName name with
+        | Some c -> c
+        | None -> binary
+
+    /// The DEFAULT comparer for an arbitrary key type `'T` — the value primitives use unless an explicit
+    /// collation is selected. **Ordinal for `string`** (the B-0969 fix: never the culture-sensitive
+    /// `Comparer<string>.Default`); `Comparer<'T>.Default` for every other `'T` (numbers etc. are already
+    /// ordinal-equivalent, so the BCL default is correct + fast there).
+    let forKey<'T> () : IComparer<'T> =
+        if typeof<'T> = typeof<string> then
+            unbox<IComparer<'T>> (box (StringComparer.Ordinal :> IComparer<string>))
+        else
+            Comparer<'T>.Default

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Algebra.fs" />
+    <Compile Include="Collation.fs" />
     <Compile Include="Predicate.fs" />
     <Compile Include="Policy.fs" />
     <Compile Include="PolicyKind.fs" />

--- a/tests/Tests.FSharp/Collation.Tests.fs
+++ b/tests/Tests.FSharp/Collation.Tests.fs
@@ -1,0 +1,41 @@
+module Zeta.Tests.CollationTests
+
+open System
+open global.Xunit
+open Zeta.Core
+
+// DB-style collation selection (B-0969). The shipped default is BINARY/ordinal; the bug fix is that
+// forKey<string> resolves to ORDINAL, never the culture-sensitive Comparer<string>.Default.
+
+[<Fact>]
+let ``binary default is ordinal and is the shipped default name`` () =
+    Assert.Same(StringComparer.Ordinal, Collation.binary)
+    Assert.Equal("binary", Collation.defaultName)
+    Assert.Same(StringComparer.Ordinal, Collation.byNameOrDefault Collation.defaultName)
+
+[<Fact>]
+let ``catalog resolves named collations; unknown falls back to binary`` () =
+    Assert.Same(StringComparer.Ordinal, Collation.byNameOrDefault "ordinal")
+    Assert.Same(StringComparer.OrdinalIgnoreCase, Collation.byNameOrDefault "ordinal-ci")
+    Assert.Equal(None, Collation.tryByName "no-such-collation")
+    Assert.Same(StringComparer.Ordinal, Collation.byNameOrDefault "no-such-collation") // fallback
+
+[<Fact>]
+let ``catalog name lookup is itself case-insensitive`` () =
+    // selecting a collation by name shouldn't be culture/case-fragile
+    Assert.Same(StringComparer.Ordinal, Collation.byNameOrDefault "BINARY")
+
+[<Fact>]
+let ``forKey string is ORDINAL, not culture-sensitive (the B-0969 fix)`` () =
+    let c = Collation.forKey<string> ()
+    // ordinal: 'B'(66) < 'a'(97) => "B" sorts before "a". Culture-sensitive would put "a" first.
+    Assert.True(c.Compare("B", "a") < 0)
+    Assert.True(c.Compare("a", "B") > 0)
+    Assert.Equal(0, c.Compare("abc", "abc"))
+
+[<Fact>]
+let ``forKey non-string uses the default ordinal-equivalent comparer`` () =
+    let c = Collation.forKey<int> ()
+    Assert.True(c.Compare(1, 2) < 0)
+    Assert.True(c.Compare(2, 1) > 0)
+    Assert.Equal(0, c.Compare(7, 7))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -76,6 +76,7 @@
     <Compile Include="Clock.FullVertical.Tests.fs" />
     <Compile Include="Merkle.FullVertical.Tests.fs" />
     <Compile Include="ZSetMerkle.Tests.fs" />
+    <Compile Include="Collation.Tests.fs" />
     <Compile Include="SerializationSeed.FullVertical.Tests.fs" />
     <Compile Include="Identity.FullVertical.Tests.fs" />
     <Compile Include="Predicate3.Tests.fs" />


### PR DESCRIPTION
## What — B-0969 slice-1 foundation
The **stable collation seed** (Aaron confirmed it survives "all the parameters") + the SQL-Server parameterized-model design direction.

- **`src/Core/Collation.fs`** — DB-style collation selection: shipped default **`binary`** (`StringComparer.Ordinal`, codepoint/byte order); named catalog (`binary`/`ordinal`/`ordinal-ci`/`invariant`/`invariant-ci`, name lookup case-insensitive); **`forKey<'T>`** resolves string→Ordinal (the B-0969 fix — never culture-sensitive `Comparer<string>.Default`) else `Comparer<'T>.Default`. **5 tests** green.
- **Design capture** — collation = the SQL-Server parameterized model (locale + code page + sensitivity flags `_CI/_CS/_AI/_AS/_KI/_KS/_WI/_WS/_VSS/_BIN/_UTF8`), selectable at **server/database/column/query** levels. Our analog: shipped default → cell default → value carries it (strategy (a)) → per-op override `ofSeqWith`. The binary/ordinal seed is a fixed point; flags/locales refine the catalog over time. Mismatched-collation merge = error to surface, not silent reinterpret.
- B-0969 updated with the landed seed + design pointer.

Seed is **additive** (no existing API touched). The primitive rewiring (G-Set → Z-set carrying a collation) is the next slices, with Ilyana/Naledi/Soraya review.

## Test
`dotnet test … --filter CollationTests` → **5 passed**; Core builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)