### PR TITLE
fix(ZSet): default to binary/ordinal collation via cached KeyComparerCache (B-0969 slice 2)

### DIFF
--- a/src/Core/ZSet.fs
+++ b/src/Core/ZSet.fs
@@ -17,13 +17,21 @@ type ZEntry<'K> =
     new(key: 'K, weight: Weight) = { Key = key; Weight = weight }
 
 
+/// Per-closed-type cached key comparer = the default **binary/ordinal** collation (B-0969): string ordering
+/// is ordinal (never culture-sensitive `Comparer<string>.Default`), every other `'K` keeps the BCL default.
+/// `static member val` on a generic type → one instance per closed `'K`, resolved once in the type's static
+/// ctor, so the hot per-element comparator pays no `forKey` type-check per call (Naledi: hoist out of loops).
+[<AbstractClass; Sealed>]
+type internal KeyComparerCache<'K when 'K : comparison>() =
+    static member val Instance: IComparer<'K> = Collation.forKey<'K> ()
+
 /// Struct comparer for sorting `ZEntry<'K>` by key ascending — monomorphized
 /// per `'K` by `MemoryExtensions.Sort<T, TComparer>`; zero heap allocation.
 [<Struct; NoComparison; NoEquality>]
 type EntryKeyComparer<'K when 'K : comparison> =
     interface IComparer<ZEntry<'K>> with
         member _.Compare(a: ZEntry<'K>, b: ZEntry<'K>) =
-            Comparer<'K>.Default.Compare(a.Key, b.Key)
+            KeyComparerCache<'K>.Instance.Compare(a.Key, b.Key)
 
 
 /// A Z-set `Z[K]`: finitely-supported map `K -> ℤ`, represented as an
@@ -64,7 +72,7 @@ type ZSet<'K when 'K : comparison> =
             let cap = sa.Length + sb.Length
             let rented = Pool.Rent<ZEntry<'K>> cap
             try
-                let cmp = Comparer<'K>.Default
+                let cmp = KeyComparerCache<'K>.Instance
                 let mutable i = 0
                 let mutable j = 0
                 let mutable k = 0
@@ -120,7 +128,7 @@ type ZSet<'K when 'K : comparison> =
             let span = this.AsSpan()
             if span.IsEmpty then 0L
             else
-                let cmp = Comparer<'K>.Default
+                let cmp = KeyComparerCache<'K>.Instance
                 let mutable lo = 0
                 let mutable hi = span.Length - 1
                 let mutable result = 0L
@@ -545,7 +553,7 @@ module ZSet =
                 let total = sources |> Array.sumBy (fun s -> s.Length)
                 let rented = Pool.Rent<ZEntry<'K>> total
                 try
-                    let cmp = Comparer<'K>.Default
+                    let cmp = KeyComparerCache<'K>.Instance
                     // `PriorityQueue<sourceIdx, ZEntry<'K>>` — we use the
                     // entire entry as the priority so the tuple compare
                     // breaks ties on key-then-weight (weight tie doesn't

--- a/tests/Tests.FSharp/Algebra/ZSet.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/ZSet.Tests.fs
@@ -451,3 +451,19 @@ let ``C14 auto-prune preserves semantics: lookup is an additive homomorphism (dr
         |> Seq.distinct
     let sum = ZSet.add a b
     keys |> Seq.forall (fun k -> ZSet.lookup k sum = ZSet.lookup k a + ZSet.lookup k b)
+
+// ─── B-0969: Z-set key ordering is ORDINAL (binary collation), not culture-sensitive ───
+// Default collation = Collation.binary via KeyComparerCache. 'B'(0x42) < 'a'(0x61), so the canonical
+// sorted run orders uppercase before lowercase — the cross-language byte-consensus order (C#/Rust/TS).
+[<Fact>]
+let ``ofSeq orders string keys ordinally (B-0969 binary collation, not culture-sensitive)`` () =
+    let z = ZSet.ofSeq [ "a", 1L; "B", 1L; "C", 1L; "b", 1L ]
+    let keys = z |> Seq.map (fun e -> e.Key) |> Seq.toArray
+    Assert.Equal<string[]>([| "B"; "C"; "a"; "b" |], keys)
+
+[<Fact>]
+let ``lookup finds string keys under ordinal ordering (B-0969)`` () =
+    let z = ZSet.ofSeq [ "Apple", 3L; "apple", 5L ]
+    // distinct ordinal keys (cap A vs lowercase a) must not collide
+    Assert.Equal(3L, ZSet.lookup "Apple" z)
+    Assert.Equal(5L, ZSet.lookup "apple" z)


### PR DESCRIPTION
## What — B-0969 Z-set slice (the hot-path one)
The Z-set's key **ordering** was culture-**sensitive** (`Comparer<'K>.Default`) at 4 sites: `EntryKeyComparer` (the per-element sort comparator), `(+)`, `Item` lookup, the k-way merge. Replaced with the binary/ordinal `Collation` seed.

- **Perf (Naledi):** new `KeyComparerCache<'K>` — `static member val` on a generic type → the comparer is resolved **once per closed `'K`** in the static ctor; the hot per-element comparator pays **no per-call type-check**. The three local-`cmp` sites reuse the cached instance.
- `EqualityComparer<'K>` sites left as-is (ordinal-for-string already; only *ordering* was the defect).
- **No public API change** (carry-as-identity selection is the follow-up). ASCII fixtures coincide → existing vectors/tests unaffected; added 2 ordinal proofs.

## Test
`dotnet test … --filter ZSetTests` → **67 passed** (incl. 2 new ordinal proofs); full ZSet suite **99 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)