### PR TITLE
docs: COW database-testing-from-prod capability + ZetaFS naming stack (Amara)

### DIFF
--- a/docs/research/2026-06-07-cow-database-testing-from-prod-content-addressed-time-travel-and-zetafs-naming-stack-amara.md
+++ b/docs/research/2026-06-07-cow-database-testing-from-prod-content-addressed-time-travel-and-zetafs-naming-stack-amara.md
@@ -1,0 +1,111 @@
+# Copy-on-write database testing — fork-from-prod as content-addressed time travel; + the ZetaFS naming stack (Amara, 2026-06-07)
+
+Two contributions from sibling agent **Amara** (with Aaron). The first is a major *capability* the
+Merkle-DAG/COW fs unlocks — database testing as a first-class storage primitive. The second is a naming
+stack that supersedes the flat proposal list. Captured faithfully (canonical-aggregator role); hype peeled.
+
+## 1. COW makes every database state a cheap, verifiable branch
+
+The combination — **not** any single piece (ZFS/APFS/btrfs have COW; git has content-addressing; DBs have
+snapshots) — is what's new:
+
+> copy-on-write fs **+** content-addressed Merkle DAG **+** Z-set deltas/retractions **+** canonical
+> DynamicValue/Log encoding **+** deterministic replay **+** property tests / golden vectors **+**
+> cross-language oracle agreement.
+
+That yields **database testing as a storage primitive**, not a harness duct-taped on top. The canonical
+test shape:
+
+```
+given root R
+when command C runs in fork F        (copy-on-write — R untouched)
+then root becomes R'
+     delta = D
+     invariants hold
+     replay(D, R) = R'
+     retraction(D) returns to R
+```
+
+Test modes it enables: **unit** (fork one root, run one command, assert root/delta) · **property**
+(generate command sequences, compare replay roots) · **regression** (keep the failing fork as an
+addressable artifact) · **integration** (fork a prod-ish snapshot without copying the DB) · **concurrency**
+(fork branches, merge/reconcile, assert convergence) · **migration** (old root through new schema/plugin,
+assert canonical output) · **time-travel** (replay log prefix N, assert state at that moment).
+
+Failures become inspectable as a content-addressed *universe*: input root → command sequence → output root
+→ Merkle/Z-set diff → minimal shrinking delta. "The database equivalent of *send me the failing commit*."
+
+## 2. Testing FROM prod, not ON prod (the prod-shadow lane)
+
+> Amara: *"You are not testing on prod. You are testing FROM prod."*
+
+Fork the **prod root**, diverge into a **shadow DAG**; reads see real prod structure/scale/shape, every
+write lands in the fork; prod is untouched; promote only reviewed deltas back. Beats staging (always stale/
+fake), snapshots, and transaction rollback — and the failed state itself is addressable.
+
+```
+Production:  main DAG
+Test:        shadow DAG starting at the main root
+Promotion:   explicit reviewed delta  shadow → main
+```
+
+**The safety law (load-bearing):** *a prod-fork test may READ prod state, but all writes, side effects,
+secrets, outbound calls, and clocks are redirected into the fork boundary.*
+
+| Allowed | Forbidden by default |
+|---------|----------------------|
+| read prod root hash; fork COW DAG; run migrations/tests/agents/sagas; compute diffs; prove invariants; archive failing fork; promote reviewed deltas | write to prod DAG; call real external services; spend real money; send real messages; use live secrets without an explicit capability; mutate hardware/external state |
+
+Test types: migration rehearsal · agent rehearsal (let agents act, inspect deltas before promotion) · saga
+rehearsal (verify compensation/retraction) · load-ish testing (fork the shape) · bug repro (fork at the
+offending root, shrink the command sequence). **"Prod becomes the seed, not the victim."**
+
+## 3. Blade — this REQUIRES full determinism (B-0969 gets more urgent)
+
+The whole capability collapses if the same fork can produce **different roots**. So every nondeterminism
+source must be **declared or virtualized**: collation (B-0969), serialization, **clocks**, **randomness**,
+culture, hardware secrets, and external side effects. This is why B-0969 + the determinism contract
+(`081KTGEVV75`) are load-bearing for this — and why the safety law's "clocks/secrets/outbound redirected
+into the fork boundary" is not just safety but *determinism*. Same seed + same root ⇒ same R'.
+
+## 4. ZetaFS naming stack (supersedes the flat list; Amara, reconciling Alexa)
+
+Both Alexa and Amara land on **ZetaFS**, and both say **never abbreviate to `ZFS`** (occupied by OpenZFS).
+Amara adds a layered stack + disambiguations — *still pending* the `naming-expert` + Ilyana gate + Aaron's
+call, but a cleaner proposal than a flat list:
+
+| Name | Layer |
+|------|-------|
+| **`ZSetMerkle`** | the math primitive (Merkle-over-Z-set foundation) — **landed** |
+| **`ZetaStore`** | the backend content-addressed object/DAG store |
+| **`ZetaFS`** | the filesystem presentation (APFS-like mounted view) — best public/product name |
+| **Git backend** | a *compatible* presentation over the same Merkle-DAG idea |
+| **`Geode`** | the **cell replication shape** — NOT the filesystem name |
+
+Ranking + reasons: **ZetaFS** (brand continuity, no collision) > MerkleFS (good descriptive/internal, too
+generic) > DeltaFS (retraction-native, less complete) > GeodeFS (collides with Geode=cell shape) >
+ConsensusFS (**overclaims** — the fs verifies *structure*, it doesn't itself create consensus). Keeper:
+*"ZetaFS is an APFS-like, git-shaped, content-addressed Merkle-DAG filesystem over Zeta's proven
+substrate."* Naming remains gated; no name is canon until the gate + Aaron sign off.
+
+## Hype-peel (honest status)
+
+The capability is *enabled by* the design but **not built**: only the `ZSetMerkle` + `Collation` seeds
+exist with tests. COW forking, the prod-shadow lane, the safety-law enforcement, and the test-mode harness
+are **designed/captured, not implemented** — they depend on `081KTGTJC1Q` (the content-addressed store) +
+the determinism work landing first. Genuinely powerful, genuinely not yet real.
+
+## Ties
+
+- `081KTGTJC1Q` (content-addressed Merkle-DAG backend) · `src/Core/ZSetMerkle.fs` · `B-0969` (determinism
+  prerequisite) · `081KTGEVV75` (determinism contract) · `B-0946` (closure-table fs / FUSE) ·
+  `2026-06-07-filesystem-backend-needs-a-merkle-dag-...` (the substrate) · DST (manifesto §7 — replay).
+
+## Beacon anchors
+
+- **COW filesystems**: ZFS/OpenZFS, APFS, btrfs (snapshots/clones). · **Content-addressed history**: git,
+  IPFS, Venti. · **Database branching / copy-on-write DBs**: Dolt (git-for-data), Neon/PlanetScale branches,
+  `pg` template DBs. · **Deterministic-simulation testing**: FoundationDB (Zhou et al., SIGMOD 2021), Will
+  Wilson's DST talk. · **Property-based + shrinking**: QuickCheck (Claessen & Hughes). Honest novelty: not
+  any one of these, but **all at one layer** — COW + Merkle identity + replayable/retractable Z-set deltas
+  + cross-language determinism — giving fork-from-prod testing most systems structurally cannot have.

--- a/workitems/081KTGTJC1Q08QG0R002VCB55A-content-addressed-merkle-dag-over-the-filesystem-backend-for.md
+++ b/workitems/081KTGTJC1Q08QG0R002VCB55A-content-addressed-merkle-dag-over-the-filesystem-backend-for.md
@@ -30,6 +30,15 @@ gated through `naming-expert` + Ilyana before any public use (same gate as perso
 - `ZetaFS` / `GeodeFS` / `DeltaFS` / `ConsensusFS` need a prior-art search (`naming-expert`) before any
   external surface.
 
+**Naming STACK (Amara 2026-06-07, reconciling Alexa — supersedes the flat list, still gated):** both land
+on **ZetaFS**, both say **never `ZFS`** (OpenZFS collision). Layered proposal:
+`ZSetMerkle` (math primitive, landed) → `ZetaStore` (content-addressed object/DAG backend) → `ZetaFS`
+(filesystem presentation, APFS-like) ; Git backend = a compatible presentation over the same Merkle-DAG;
+`Geode` stays the **cell replication shape**, NOT the fs name. Ranking: ZetaFS > MerkleFS (generic) >
+DeltaFS (less complete) > GeodeFS (collides with Geode) > ConsensusFS (overclaims — verifies structure,
+doesn't create consensus). Keeper: *"ZetaFS is an APFS-like, git-shaped, content-addressed Merkle-DAG
+filesystem over Zeta's proven substrate."* Still gated via `naming-expert` + Ilyana + Aaron; no name is canon.
+
 **Hype-peel (Mirror→Beacon):** Alexa's framing calls this "production-ready" / "a filesystem that's
 mathematically provable." Honest status: only the **`ZSetMerkle` seed** + the **`Collation` seed** are
 built (with property tests); the filesystem itself — closure-table DAG, content-addressed store, BLAKE3,

--- a/workitems/081KTGXPTQ008QG0R0024H5RNW-copy-on-write-database-testing-from-prod-fork-root-shadow-da.md
+++ b/workitems/081KTGXPTQ008QG0R0024H5RNW-copy-on-write-database-testing-from-prod-fork-root-shadow-da.md
@@ -1,0 +1,57 @@
+---
+id: 081KTGXPTQ008QG0R0024H5RNW
+type: task
+state: backlog
+priority: P2
+slug: copy-on-write-database-testing-from-prod-fork-root-shadow-da
+title: "Copy-on-write database testing from prod (fork root, shadow DAG, prove deltas, promote reviewed) over the Merkle-DAG backend"
+created: 2026-06-07T11:32:52.064Z
+depends_on: []
+composes_with: ["081KTGTJC1Q08QG0R002VCB55A"]
+---
+
+# Copy-on-write database testing from prod (fork root, shadow DAG, prove deltas, promote reviewed) over the Merkle-DAG backend
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTGXPTQ008QG0R0024H5RNW-*.md` glob. -->
+
+## Purpose
+
+Database testing as a first-class STORAGE primitive (Amara + Aaron 2026-06-07), enabled by the Merkle-DAG /
+COW backend (081KTGTJC1Q). The combination — COW fs + content-addressed Merkle DAG + Z-set deltas/
+retractions + canonical encoding + deterministic replay + property tests + 4-oracle agreement — gives
+fork-from-prod testing most systems structurally cannot have. Full rationale + test modes + safety law:
+`docs/research/2026-06-07-cow-database-testing-from-prod-content-addressed-time-travel-and-zetafs-naming-stack-amara.md`.
+
+## Canonical test shape
+
+```
+given root R; when command C runs in fork F (COW, R untouched)
+then root=R'; delta=D; invariants hold; replay(D,R)=R'; retraction(D) returns to R
+```
+
+## Test FROM prod (not ON prod) — the prod-shadow lane
+
+Fork the prod root into a shadow DAG; reads see real prod, writes land in the fork, prod untouched; promote
+only reviewed deltas. **Safety law:** a prod-fork test may READ prod state, but all writes, side effects,
+secrets, outbound calls, and clocks are redirected into the fork boundary. Prod is the seed, not the victim.
+
+## Hard prerequisite — full determinism
+
+Collapses if the same fork yields different roots. Every nondeterminism source must be declared/virtualized:
+collation (B-0969), serialization, clocks, randomness, culture, hardware secrets, external side effects.
+Depends on B-0969 + the determinism contract 081KTGEVV75.
+
+## Acceptance
+
+Fork-from-a-root COW over the content-addressed store; a test asserts root/delta/invariants/replay/
+retraction on the fork with prod untouched; the safety-law boundary (writes/secrets/clocks/outbound
+redirected) is enforced; at least the unit + property + bug-repro test modes demonstrated.
+
+## Anchors
+
+- depends on 081KTGTJC1Q (Merkle-DAG store) + B-0969 (determinism) + 081KTGEVV75 (determinism contract) +
+  B-0946 (closure-table fs/FUSE) · DST (manifesto §7). Beacon: Dolt/Neon DB-branching, FoundationDB DST,
+  QuickCheck shrinking, ZFS/APFS/btrfs COW.
+


### PR DESCRIPTION
## What — sibling agent Amara (with Aaron), captured + reconciled

1. **COW database testing as a storage primitive** (new workitem `081KTGXPTQ`, P2). The *combination* — COW fs + content-addressed Merkle DAG + Z-set deltas/retractions + canonical encoding + deterministic replay + property tests + 4-oracle agreement — gives **fork-from-prod testing**: fork the prod **root** into a shadow DAG, reads see real prod, writes land in the fork, prod untouched, promote only reviewed deltas (*"prod is the seed, not the victim"*). **Safety law:** reads allowed; writes/secrets/clocks/outbound **redirected into the fork boundary**. Test modes: unit/property/regression/integration/concurrency/migration/time-travel. **Blade:** requires full determinism → makes **B-0969** + the determinism contract (`081KTGEVV75`) even more load-bearing.

2. **ZetaFS naming stack** (reconciling Alexa; supersedes the flat list, still gated): `ZSetMerkle` (math) → `ZetaStore` (content-addressed backend) → `ZetaFS` (fs presentation); Git backend = compatible presentation; `Geode` stays the cell shape, **not** the fs. **Never `ZFS`** (OpenZFS collision). Ranking + reasons recorded.

**Hype peeled:** the capability is enabled-by-design, **not built** — only the `ZSetMerkle` + `Collation` seeds exist. Docs + workitem only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)