### PR TITLE
fix(IndexedZSet): default to binary/ordinal collation (B-0969 slice 3) + audit record

### DIFF
--- a/docs/backlog/P1/B-0969-invariant-culture-everywhere-configureawait-false-cross-cutting-dotnet-defaults-never-culture-sensitive-fsharp-gset-first-fix-aaron-2026-06-01.md
+++ b/docs/backlog/P1/B-0969-invariant-culture-everywhere-configureawait-false-cross-cutting-dotnet-defaults-never-culture-sensitive-fsharp-gset-first-fix-aaron-2026-06-01.md
@@ -178,6 +178,24 @@ canonical Merkle-over-Z-set (PR #6789) — whose own fix is to **re-sort by ordi
 2026-06-07: *"we should be culture insensitive everywhere by default."* Fold ZSet into action 1's
 ordinal-comparison fix alongside G-Set (same comparer-strategy decision).
 
+## Audit results — src/Core ordering sites (Otto 2026-06-07, action 2 in progress)
+
+Swept `src/Core` for culture-sensitive ORDERING (`Comparer<_>.Default` on ordering; `EqualityComparer`
+sites are ordinal-for-string already, left as-is). Status:
+
+| File | Sites | Status |
+|------|-------|--------|
+| `GSet.fs` | 4 | ✅ FIXED (#6795) → `Collation.forKey` |
+| `ZSet.fs` | 4 | ✅ FIXED (#6797) → `KeyComparerCache<'K>` (cached, hot-path-safe) |
+| `IndexedZSet.fs` | 4 | ✅ FIXED (this PR) → `KeyComparerCache` (+ `Collation.forKey` in the `inline join`) |
+| `Bag.fs` | — | ✅ already ordinal (uses F# `compare` / `String.CompareOrdinal` deliberately — no change) |
+| `Hierarchy.fs` (closure table) | 3 (`:84/:237/:246`) | ⏳ TODO — fs-relevant (`Comparer<'N>.Default`; `:237/:246` are equality-via-compare) |
+| `Residuated.fs` | 1 (`:128`) | ⏳ TODO — `ResidualMaxOp(… Comparer<'K>.Default)` |
+| `Aggregate.fs` | 2 (`:264/:273`) | ⏳ TODO — `Comparer<'V>.Default` (value min/max ordering) |
+
+Remaining: Hierarchy / Residuated / Aggregate (follow-up slices), then the C#/Rust/TS oracle audit + the
+golden-vector regeneration with non-ASCII keys + analyzer enforcement.
+
 ## Composes with
 
 - **B-0959** (cross-language substrate master checklist) — the 4-oracle

--- a/src/Core/IndexedZSet.fs
+++ b/src/Core/IndexedZSet.fs
@@ -18,7 +18,7 @@ type KeyGroup<'K, 'V when 'K : comparison and 'V : comparison> =
 type KeyGroupComparer<'K, 'V when 'K : comparison and 'V : comparison> =
     interface IComparer<KeyGroup<'K, 'V>> with
         member _.Compare(a: KeyGroup<'K, 'V>, b: KeyGroup<'K, 'V>) =
-            Comparer<'K>.Default.Compare(a.Key, b.Key)
+            KeyComparerCache<'K>.Instance.Compare(a.Key, b.Key)
 
 
 /// `IndexedZSet<'K,'V>` is conceptually `Z[K × V]` but stored as a sorted run
@@ -57,7 +57,7 @@ type IndexedZSet<'K, 'V when 'K : comparison and 'V : comparison> =
             let cap = ga.Length + gb.Length
             let rented = Pool.Rent<KeyGroup<'K, 'V>> cap
             try
-                let cmp = Comparer<'K>.Default
+                let cmp = KeyComparerCache<'K>.Instance
                 let mutable i = 0
                 let mutable j = 0
                 let mutable k = 0
@@ -109,7 +109,7 @@ type IndexedZSet<'K, 'V when 'K : comparison and 'V : comparison> =
             let span = this.AsSpan()
             if span.IsEmpty then ZSet<'V>.Empty
             else
-                let cmp = Comparer<'K>.Default
+                let cmp = KeyComparerCache<'K>.Instance
                 let mutable lo = 0
                 let mutable hi = span.Length - 1
                 let mutable result = ZSet<'V>.Empty
@@ -285,7 +285,9 @@ module IndexedZSet =
         let gb = b.AsSpan()
         if ga.IsEmpty || gb.IsEmpty then ZSet<'C>.Empty
         else
-            let cmp = Comparer<'K>.Default
+            // `join` is `inline`, so it can't touch the internal KeyComparerCache — resolve the default
+            // binary/ordinal collation via the public Collation.forKey (once per join; B-0969).
+            let cmp = Collation.forKey<'K> ()
             // Accumulate cap in int64 to avoid 2^31 wrap on wide joins.
             let mutable cap64 = 0L
             let mutable i = 0


### PR DESCRIPTION
## What — B-0969 IndexedZSet slice + the src/Core audit
IndexedZSet (keyed by `'K`) had 4 culture-sensitive ordering sites — `KeyGroupComparer` (per-element), `(+)`, `Item` lookup, `join`. Fixed: reuse `KeyComparerCache<'K>` (cached per closed type) at the 3 non-inline sites; the **`inline join`** uses public `Collation.forKey<'K>` (an inline fn can't reference the `internal` cache). 16 IndexedZSet tests green.

**Audit recorded in B-0969:**
| File | Status |
|------|--------|
| GSet / ZSet / IndexedZSet | ✅ fixed (#6795 / #6797 / this) |
| Bag | ✅ already ordinal (F# `compare`/`String.CompareOrdinal`) |
| Hierarchy (closure table) / Residuated / Aggregate | ⏳ follow-up slices |

Then: C#/Rust/TS oracle audit + non-ASCII golden-vector regen + analyzer enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)