### PR TITLE
fix(Core): ordinal collation for Hierarchy/Residuated/Aggregate — F# core audit COMPLETE (B-0969)

### DIFF
--- a/docs/backlog/P1/B-0969-invariant-culture-everywhere-configureawait-false-cross-cutting-dotnet-defaults-never-culture-sensitive-fsharp-gset-first-fix-aaron-2026-06-01.md
+++ b/docs/backlog/P1/B-0969-invariant-culture-everywhere-configureawait-false-cross-cutting-dotnet-defaults-never-culture-sensitive-fsharp-gset-first-fix-aaron-2026-06-01.md
@@ -189,12 +189,16 @@ sites are ordinal-for-string already, left as-is). Status:
 | `ZSet.fs` | 4 | ✅ FIXED (#6797) → `KeyComparerCache<'K>` (cached, hot-path-safe) |
 | `IndexedZSet.fs` | 4 | ✅ FIXED (this PR) → `KeyComparerCache` (+ `Collation.forKey` in the `inline join`) |
 | `Bag.fs` | — | ✅ already ordinal (uses F# `compare` / `String.CompareOrdinal` deliberately — no change) |
-| `Hierarchy.fs` (closure table) | 3 (`:84/:237/:246`) | ⏳ TODO — fs-relevant (`Comparer<'N>.Default`; `:237/:246` are equality-via-compare) |
-| `Residuated.fs` | 1 (`:128`) | ⏳ TODO — `ResidualMaxOp(… Comparer<'K>.Default)` |
-| `Aggregate.fs` | 2 (`:264/:273`) | ⏳ TODO — `Comparer<'V>.Default` (value min/max ordering) |
+| `Hierarchy.fs` (closure table) | 3 (`:84/:237/:246`) | ✅ FIXED → `KeyComparerCache<'N>` |
+| `Residuated.fs` | 1 (`:128`) | ✅ FIXED → `KeyComparerCache<'K>` |
+| `Aggregate.fs` | 2 (`:264/:273`) | ✅ FIXED → `KeyComparerCache<'V>` (value min/max now ordinal) |
 
-Remaining: Hierarchy / Residuated / Aggregate (follow-up slices), then the C#/Rust/TS oracle audit + the
-golden-vector regeneration with non-ASCII keys + analyzer enforcement.
+**F# `src/Core` ordering audit COMPLETE** — every culture-sensitive ordering site is now binary/ordinal (or
+was already ordinal, per Bag). Remaining B-0969 work: (1) C#/Rust/TS oracle audit (the other three
+languages); (2) regenerate the 4-oracle golden vectors with **non-ASCII** keys so the byte-consensus
+actually exercises ordinal (un-mask the ASCII fixtures); (3) analyzer enforcement
+(`CA1304/1305/1307/1310/2007` at error level) so it can't regress; (4) the carry-as-identity collation
+*selection* API (strategy (a)) on top of the now-correct default.
 
 ## Composes with
 

--- a/src/Core/Aggregate.fs
+++ b/src/Core/Aggregate.fs
@@ -261,7 +261,7 @@ type AggregateExtensions =
     static member GroupByMin<'K, 'G, 'V
         when 'K : comparison and 'G : comparison and 'V : comparison and 'G : not null>
         (this: Circuit, s: Stream<ZSet<'K>>, key: Func<'K, 'G>, value: Func<'K, 'V>) : Stream<ZSet<'G * 'V>> =
-        let cmp = Comparer<'V>.Default
+        let cmp = KeyComparerCache<'V>.Instance
         let min = Func<'V, 'V, 'V>(fun a b -> if cmp.Compare(a, b) <= 0 then a else b)
         this.RegisterStream (MinMaxOp(s.Op, key, value, min))
 
@@ -270,7 +270,7 @@ type AggregateExtensions =
     static member GroupByMax<'K, 'G, 'V
         when 'K : comparison and 'G : comparison and 'V : comparison and 'G : not null>
         (this: Circuit, s: Stream<ZSet<'K>>, key: Func<'K, 'G>, value: Func<'K, 'V>) : Stream<ZSet<'G * 'V>> =
-        let cmp = Comparer<'V>.Default
+        let cmp = KeyComparerCache<'V>.Instance
         let max = Func<'V, 'V, 'V>(fun a b -> if cmp.Compare(a, b) >= 0 then a else b)
         this.RegisterStream (MinMaxOp(s.Op, key, value, max))
 

--- a/src/Core/Hierarchy.fs
+++ b/src/Core/Hierarchy.fs
@@ -81,7 +81,7 @@ type ClosurePair<'N when 'N : comparison> =
         member this.CompareTo(other) =
             match other with
             | :? ClosurePair<'N> as p ->
-                let cmp = System.Collections.Generic.Comparer<'N>.Default
+                let cmp = KeyComparerCache<'N>.Instance
                 let c = cmp.Compare(this.Ancestor, p.Ancestor)
                 if c <> 0 then c
                 else
@@ -234,7 +234,7 @@ type HierarchyExtensions =
          closure: Stream<ZSet<ClosurePair<'N>>>,
          root: 'N) : Stream<ZSet<ClosurePair<'N>>> =
         this.Filter(closure, Func<_, _>(fun (p: ClosurePair<'N>) ->
-            System.Collections.Generic.Comparer<'N>.Default.Compare(p.Ancestor, root) = 0))
+            KeyComparerCache<'N>.Instance.Compare(p.Ancestor, root) = 0))
 
     /// Ancestors of `leaf` — from immediate parent up to root.
     [<Extension>]
@@ -243,4 +243,4 @@ type HierarchyExtensions =
          closure: Stream<ZSet<ClosurePair<'N>>>,
          leaf: 'N) : Stream<ZSet<ClosurePair<'N>>> =
         this.Filter(closure, Func<_, _>(fun (p: ClosurePair<'N>) ->
-            System.Collections.Generic.Comparer<'N>.Default.Compare(p.Descendant, leaf) = 0))
+            KeyComparerCache<'N>.Instance.Compare(p.Descendant, leaf) = 0))

--- a/src/Core/Residuated.fs
+++ b/src/Core/Residuated.fs
@@ -125,4 +125,4 @@ type ResidualExtensions =
     static member ResidualMax<'T, 'K
         when 'T : comparison and 'K : comparison and 'K : not null>
         (circuit: Circuit, input: Stream<ZSet<'T>>, keyFn: Func<'T, 'K>) : Stream<'K voption> =
-        circuit.RegisterStream (ResidualMaxOp(input.Op, keyFn, Comparer<'K>.Default))
+        circuit.RegisterStream (ResidualMaxOp(input.Op, keyFn, KeyComparerCache<'K>.Instance))


### PR DESCRIPTION
## What — the last F# core ordering sites (B-0969)
- **Hierarchy.fs** (closure table): `ClosurePair.CompareTo` + `DescendantsOf`/`AncestorsOf` filters → `KeyComparerCache<'N>`. `Equals`/`GetHashCode` already used `EqualityComparer` (ordinal) — left as-is.
- **Residuated.fs**: `ResidualMax` passed `Comparer<'K>.Default` → `KeyComparerCache<'K>`.
- **Aggregate.fs**: `GroupByMin`/`GroupByMax` value comparison (`Comparer<'V>.Default`) → `KeyComparerCache<'V>`, so string value min/max is now deterministic/ordinal.

**F# `src/Core` ordering audit COMPLETE** — with GSet/ZSet/IndexedZSet (landed) + Bag (already ordinal), the binary/ordinal collation default is enforced across the whole F# core.

## Test
`dotnet test … --filter Hierarchy|Residuated|Aggregate|Closure` → **51 passed** (1 pre-existing skip).

## Remaining B-0969
C#/Rust/TS oracle audit · non-ASCII golden-vector regen · analyzer enforcement (`CA1304/1305/1307/1310/2007`) · carry-as-identity selection API (strategy a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)