### PR TITLE
docs: Evolution — extend existing SchemaEvolution proof (bidirectional + parallel timelines + reindex-as-projection)

### DIFF
--- a/docs/research/2026-06-07-ddl-as-branchable-canary-rollback-as-root-selection-and-zero-downtime-schema-changes-as-math-proof-amara-aaron.md
+++ b/docs/research/2026-06-07-ddl-as-branchable-canary-rollback-as-root-selection-and-zero-downtime-schema-changes-as-math-proof-amara-aaron.md
@@ -1,0 +1,106 @@
+# DDL as branchable canary rollouts (rollback = root selection); zero-downtime breaking schema changes as a math proof (Amara + Aaron, 2026-06-07)
+
+The deployment/migration half of the COW Merkle-DAG capability — distinct from the *testing* half
+(`2026-06-07-cow-database-testing-from-prod-...`). Two contributions: Amara on DDL-as-branchable canary
+rollout, Aaron on zero-downtime breaking schema changes as a formal proof. Faithful capture; hype peeled.
+
+## 1. DDL/schema rollout becomes branchable; rollback becomes root selection (Amara)
+
+Normal DDL is burn-the-bridge: `ALTER TABLE` mutates prod shape in place; rollback needs an inverse
+migration that may lose data. With the COW Merkle-DAG store, DDL becomes **branchable**:
+
+```
+prod root R
+→ fork canary root C
+→ apply DDL / migration / new plugin / new index to C
+→ route 1% (or mirrored) traffic to C
+→ observe invariants, latency, errors, data diffs
+→ good: promote C / merge proven deltas    bad: drop C / stop routing
+```
+
+- **Rollback is not "run the opposite migration" — it is moving the active root pointer back to the
+  known-good DAG.** Keeper: **"DDL rollback becomes root selection, not archaeology."**
+- **A/B + canary at the database-STRUCTURE level** (not just app code): A = prod schema/root, B = candidate
+  schema/root; canary routes a slice to B; rollback stops routing to B; promotion makes B the new main root
+  (or merges approved deltas).
+- **A failed canary is not lost** — it stays an inspectable artifact: candidate root + traffic slice +
+  migration version + observed errors + Merkle diff + Z-set deltas + invariant failures + perf counters +
+  rollback reason. **Every failed rollout becomes a reproducible test case.**
+
+### Blade — external side effects still need a boundary
+
+The DAG can roll back *database state* by root pointer, but it **cannot unsend an email, uncharge a card,
+or uncall a webhook**. So:
+
+| Inside DAG | Outside DAG |
+|------------|-------------|
+| DDL, indexes, data transforms, views, plugins | emails, payments, webhooks, hardware calls |
+| → rollback by **root pointer** | → **outbox / saga / approval / idempotency / compensation** |
+
+(Same outbox/saga boundary as the prod-shadow testing safety law — one discipline, two uses.)
+
+### Schema is a value too
+
+```
+SchemaDefinition : DynamicValue      MigrationPlan : DynamicValue
+IndexDefinition  : DynamicValue      PluginVersion : DynamicValue
+```
+
+A rollout is then a **new self-describing app/database value with tests attached**: candidate root + schema
+value + migration value + tests/laws/vectors + compatibility gates + canary policy. Ties to
+app-as-DynamicValue (`2026-06-07-app-definition-as-dynamicvalue-...`) + plugin-as-data.
+
+Keeper: *Canary rollout becomes a branch. DDL becomes a value. Rollback becomes root-pointer selection.
+Promotion becomes admitting a proven DAG.* Not "migrations are less scary" — **"migrations become testable
+alternate timelines."** (And the COW substrate is also a debugger + fixture system + migration harness +
+replay engine + proof surface, all on the same primitive — the framing from the testing capture, applied
+to deployment.)
+
+## 2. Zero-downtime BREAKING schema changes as a MATH PROOF (Aaron)
+
+> Aaron: *"we are working through zero-downtime breaking schema changes too as a math proof — where the
+> schema updates are events on the stream, and up/down migrations plus backfill in both directions are
+> accounted for."*
+
+The formal target: a **breaking** schema change with **zero downtime**, **proven** rather than
+hand-rolled. The structure:
+
+- **Schema updates are events on the stream** — a schema version is a point in the same Z-set/Log the data
+  flows through, not an out-of-band DDL. (Schema-as-value, §1, made temporal.)
+- **Up AND down migrations** are both defined — the change is reversible by construction.
+- **Backfill in BOTH directions** is accounted for — old readers see new data correctly migrated *down*,
+  new readers see old data migrated *up*, during the overlap window. This is the
+  **expand/contract (parallel-change)** pattern, but made a **proof obligation** over the stream rather
+  than a runbook: the migration is correct iff every (reader-version × data-version) pair resolves to a
+  well-defined, lossless value for the duration of the transition.
+- **Math proof** — discharge that the bidirectional migration + backfill preserve the data's meaning across
+  the version boundary with no window where a reader gets an undefined/lossy view. A formal-verification
+  target (Soraya's portfolio): the property class is "online schema evolution correctness" — provable here
+  because schema, migration, and data are all values on one replayable, retractable, content-addressed
+  substrate.
+
+This is filed as a backlog item (a proof target), composing with the Merkle-DAG backend + the determinism
+work.
+
+## Hype-peel (honest status)
+
+Both are **designed/captured, not built**. The COW substrate (`081KTGTJC1Q`), root-pointer rollout
+machinery, canary routing, the outbox/saga boundary, and the schema-migration proof are all ahead of the
+landed seeds (`ZSetMerkle` + `Collation`). Powerful direction; not yet real.
+
+## Ties
+
+- `2026-06-07-cow-database-testing-from-prod-...` (the testing half; same COW/Merkle-DAG substrate + same
+  outbox/saga boundary) · `081KTGTJC1Q` (Merkle-DAG store) · `081KTGXPTQ` (COW testing workitem) ·
+  app-as-DynamicValue + plugin-as-data (schema/migration/index/plugin as values) · B-0969 + `081KTGEVV75`
+  (determinism — same-fork-same-root) · the formal-verification portfolio (Soraya — the schema-proof).
+
+## Beacon anchors
+
+- **Expand/contract (parallel change)** migration — Danilo Sato / Martin Fowler. · **Online schema change**:
+  gh-ost (GitHub), pt-online-schema-change (Percona), Facebook OSC, Stripe's 4-phase migrations. ·
+  **Database branching / canary**: Dolt, Neon/PlanetScale branches + deploy requests. · **Blue-green /
+  canary deployment** (app-level, here pushed to the schema level). · **Event-sourcing schema evolution /
+  upcasting** (Greg Young). Honest novelty: not these patterns individually, but **schema + migration as
+  stream events on a content-addressed retractable substrate, making zero-downtime breaking change a
+  discharged proof and rollback a root-pointer move** rather than a runbook.

--- a/docs/research/2026-06-07-evolution-schema-and-index-as-proven-projections-parallel-experiment-timelines-merge-contract-aaron-amara.md
+++ b/docs/research/2026-06-07-evolution-schema-and-index-as-proven-projections-parallel-experiment-timelines-merge-contract-aaron-amara.md
@@ -1,0 +1,173 @@
+# "Evolution" — schema + index as proven projections, parallel production experiment-timelines with a continual merge contract (Aaron + Amara, 2026-06-07)
+
+The flagship capability the COW Merkle-DAG substrate builds toward, which Aaron wants to name **"Evolution"
+something-or-other** (naming seed below, gated). It unifies three things Amara + Aaron worked through:
+zero-downtime breaking schema change *as a proof*, multiple parallel production experiments with a merge
+contract, and reindexing as a *proven projection from source truth*. Companion to the DDL/canary capture
+(`2026-06-07-ddl-as-branchable-canary-...`) and the COW-testing capture
+(`2026-06-07-cow-database-testing-from-prod-...`). Faithful capture; Beacon-anchored; hype peeled.
+
+## We already have the START — it's CALLED "Evolution" (Aaron: "the existing schema 0-downtime migration proof we have are called evolution something or other")
+
+The existing artifact is **`src/Core/SchemaEvolution.fs`** (the **B-0930** foundation — "the zero-downtime
+versioning seed"), 8 tests in `SchemaEvolution.Tests.fs`. It already provides:
+- **Migration algebra** — `addField` / `removeField` / `renameField`, total over `DynamicValue` (every
+  non-`Object` shape passes through), order-respecting.
+- **Forward compatibility** (old reader, new data): unknown fields *ignored* but *preserved* through
+  migrations that don't touch them (extensible-data passthrough).
+- **Backward compatibility** (new reader, old data): `addField` supplies a default for an absent field.
+- **`migrate fromV toV`** composing adjacent N→N+1 migrations; **forward-only seed** (downgrade = a separate
+  Down direction, not yet built). Lineage: Datomic schema-as-data, Kafka Schema Registry.
+- **B-0930** = the full **schema-registry-over-DBSP** (P1, architecture) cataloging these as rows.
+
+So "Evolution" is **not a name to decide** — it's the existing name of the started proof. Everything below
+is its **extension**: the *down* direction + bidirectional backfill + the full compatibility-window proof
+discharge (§1), parallel experiment-timelines (§2), reindex-as-projection (§3).
+
+> ⚠️ **Disambiguation:** `src/Core/Evolution.fs` is a DIFFERENT module — the **B-1019** privacy-as-anti-
+> collapse DST harness (pigeonhole bound), unrelated to schema migration. Do not conflate `Evolution.fs`
+> (B-1019, privacy) with `SchemaEvolution.fs` (B-0930, schema). This capability extends the latter.
+
+The reindex `full == incremental` theorem (§3) additionally rests on **DBSP incremental view maintenance**,
+already in `src/Core`:
+- **The `full == incremental` theorem IS DBSP's incrementalization soundness** — incremental view
+  computation equals from-scratch; exactly the reindex proof obligation. Z-sets + the chain rule are the engine.
+- **`IndexedZSet`** = an index as a derived Z-set; **`Aggregate`/`Residuated`** = derived views, already
+  maintained incrementally.
+- **Z-set retraction** = reversible deltas (the up/down-migration substrate).
+- **B-0829** (schemas-as-rows + cluster-fork-as-trust-boundary) = schema-as-data + fork, the
+  experiment-branch seed. The **COW Merkle-DAG store** (`081KTGTJC1Q`) gives cheap content-addressed timelines.
+
+## 1. Zero-downtime breaking schema change as a PROOF OBLIGATION (not a runbook)
+
+Schema changes are **events on the stream**; migrations are **transformations between schema versions**;
+backfills are **replayable stream jobs**; rollout/rollback is **root selection + a compatibility proof**.
+The proof shape (Amara):
+
+```
+old app + old schema works
+new app + new schema works
+old app + new schema works  during the compatibility window
+new app + old schema works  during the window (if needed)
+up-migration preserves meaning
+down-migration preserves meaning OR names the loss
+forward backfill converges
+reverse backfill undoes or compensates
+```
+
+**Killer invariant:** *a breaking change is admitted only when the "breaking" part has been moved OUTSIDE
+the compatibility window* — the classic **expand / migrate / contract** pattern made **formal** (expand →
+dual-write/translate → backfill forward → canary on the fork → prove invariants → promote → contract after
+the safety horizon → rollback by root-switch or reverse/compensating events).
+
+**Invertibility taxonomy (the proof must distinguish):**
+| Class | Property | Rollback |
+|-------|----------|----------|
+| lossless | `down(up(x)) = x` | inverse |
+| lossy | `down(up(x)) ≈ x` only if shadow/history retained | inverse + retained shadow |
+| non-invertible | — | **compensation**, not inverse |
+
+For zero-downtime rollback of destructive DDL you **retain shadow state** (old column/table/translation
+log/tombstones/derivable indexes) until the **rollback horizon** expires. Keeper: *DDL becomes stream
+history; migration becomes a reversible-or-explicitly-compensated morphism; backfill becomes replay; zero
+downtime becomes a compatibility theorem, not a deployment prayer.*
+
+## 2. Parallel production experiment-timelines with a continual merge contract (Aaron)
+
+Generalize §1 from one migration to **many concurrent experiments**, each a full alternate code+data
+universe rooted at prod `main`:
+
+```
+main  = production truth branch
+experiment E = code branch + data DAG branch + schema/event branch + side-effect sandbox
+             + a CONTINUAL MERGE CONTRACT with main
+```
+
+An experiment is **free inside its branch but accountable to main** via the contract (Aaron's exact
+requirement — "complete code and data freedom as long as it defines the continual merge contract"):
+
+```
+ExperimentContract =
+  baseMainRoot · experimentRoot · codeBranch · dataBranch · schemaVersion
+  mainToExperimentMerge · experimentToMainProjection · conflictPolicy
+  backfillForward · backfillReverse · sideEffectPolicy · promotionGate · rollbackRule
+```
+
+**Admissibility theorem:** *an experiment is admissible iff it can continuously reconcile main → experiment
+without corrupting main, and its promoted deltas satisfy the merge contract.* Many at once (new schema; new
+index/plugin; alternate agent policy; migration rehearsal), each ingesting main continuously, each
+droppable / archivable / promotable. This is **A/B on database reality** — schema, data shape, indexes,
+logs, plugins, agent policies — not just app behavior. Keeper: *Main is the trunk of truth; experiments are
+alternate production timelines; freedom lives in the branch, safety in the merge contract; promotion is
+admitting a proven timeline, not deploying.*
+
+## 3. The endgame — reindexing as a PROVEN PROJECTION (source sacred, indexes derived)
+
+Aaron's anchor: the LexisNexis legal-search / Solr full-and-incremental reindex problem, generalized.
+
+- **Source data is sacred; indexes are derived timelines / projections** — so indexes can be aggressively
+  rebuilt, forked, deleted, replaced, experimented with, because they are *not* the truth.
+- **Full reindex and incremental reindex are two execution strategies for the SAME derivation.** The proof
+  obligation:
+  ```
+  full(source up to T)  ==  incremental( full(source up to T0), deltas T0→T )
+  ```
+  (or, honestly, "same docs / fields / analyzers / IDs / deletions-tombstones / indexable facts; only
+  named allowed differences"). **This is the DBSP incrementalization theorem** — which is why we *already
+  have the start*.
+- Index experiment = an alternate derivation pipeline: fork source root → new index schema/analyzer/ranking
+  → full backfill + incremental tail → prove `full == incremental` → shadow queries → compare coverage /
+  missing docs / field distributions / query+ranking diffs / latency / size / invariant failures → promote
+  or keep as an inspectable Merkle-diff artifact. Keeper: *a search index is not a database; it is a proven
+  projection from source truth — every projection a branch, every backfill a replay, every experiment an
+  admissible timeline.*
+
+## Boundary law (carries across §1–§3, one discipline)
+
+The DAG rolls back **database state** by root pointer; it **cannot** unsend an email / uncharge a card /
+uncall a webhook. So:
+
+```
+Inside DAG  (DDL, indexes, data transforms, views, plugins, schema, data):  branch freely; rollback = root selection
+Outside DAG (emails, payments, webhooks, hardware):  outbox / sandbox / replay-token / idempotency / compensation / approval
+```
+
+Same outbox/saga boundary as the prod-shadow testing safety law — one rule, three uses.
+
+## Naming — "Evolution" is the EXISTING name (not a pending decision)
+
+Aaron corrected an earlier mis-capture: *"no — the existing schema 0-downtime migration proof we have are
+called evolution something or other."* The name is already in use: **`SchemaEvolution`** (`src/Core/
+SchemaEvolution.fs`, B-0930). The capability described here is the **`SchemaEvolution`/Evolution family**
+extended (down + bidirectional backfill, parallel experiment-timelines, reindex-as-projection) — keep using
+the existing `SchemaEvolution`/Evolution naming, don't coin a new one. (If a broader umbrella name is ever
+wanted for §2/§3, that would go through `naming-expert` + Ilyana — but the schema-proof core keeps its name.
+Beacon caveat for any external use: "schema evolution" is also Avro/Protobuf's generic term.)
+
+## Hype-peel (honest status)
+
+The **math core (DBSP incremental view maintenance) ships**; everything else here — root-pointer rollout,
+parallel experiment branches, the ExperimentContract, the schema-evolution proof discharge, the
+full==incremental reindex proof for a concrete index, the outbox/saga boundary — is **designed/captured,
+not built**, and sits on `081KTGTJC1Q` (the COW store) + the determinism work (B-0969 / `081KTGEVV75`).
+Strong endgame; the foundation is real, the product is not yet.
+
+## Ties
+
+- DBSP (`src/Core` circuit/stream, `IndexedZSet`, `Aggregate`, `Residuated`) — the full==incremental engine ·
+  Z-set retraction (reversible deltas) · `B-0829` (schemas-as-rows, fork-as-trust-boundary) · `081KTGTJC1Q`
+  (COW Merkle-DAG store) · `081KTGXPTQ` (COW testing) · `2026-06-07-ddl-as-branchable-canary-...` (the DDL
+  half) · app/plugin/schema-as-DynamicValue · B-0969 + `081KTGEVV75` (determinism) · the formal portfolio
+  (Soraya — the schema-evolution + full==incremental proofs).
+
+## Beacon anchors
+
+- **DBSP** (Budiu et al.) — incremental view maintenance; the `full == incremental` theorem. · **Expand/
+  contract (parallel change)** — Sato/Fowler. · **Online schema change** — gh-ost, pt-online-schema-change,
+  Facebook OSC, Stripe 4-phase. · **Event-sourcing schema evolution / upcasting** — Greg Young. · **Schema
+  evolution** — Avro/Protobuf. · **DB branching** — Dolt, Neon/PlanetScale. · **Search reindex** —
+  Solr/Elasticsearch full+incremental, LexisNexis legal search (Aaron's anchor). · **Materialized views /
+  derived data** — Kleppmann *DDIA* "turning the database inside out." Honest novelty: not these
+  individually, but **schema + index + experiments as content-addressed, retractable, DBSP-incremental
+  projections over one source-of-truth stream, making zero-downtime change, parallel prod timelines, and
+  full==incremental reindex discharged proofs rather than runbooks.**

--- a/workitems/081KTGYQ3A508QG0R002Y8Y5N2-evolution-extension-bidirectional-schema-migration-proof-par.md
+++ b/workitems/081KTGYQ3A508QG0R002Y8Y5N2-evolution-extension-bidirectional-schema-migration-proof-par.md
@@ -1,0 +1,63 @@
+---
+id: 081KTGYQ3A508QG0R002Y8Y5N2
+type: task
+state: backlog
+priority: P2
+slug: evolution-extension-bidirectional-schema-migration-proof-par
+title: "Evolution extension: bidirectional schema migration proof + parallel experiment-timelines (merge contract) + reindex-as-proven-projection"
+created: 2026-06-07T11:50:29.445Z
+depends_on: []
+composes_with: ["B-0930", "081KTGTJC1Q08QG0R002VCB55A", "081KTGXPTQ008QG0R0024H5RNW"]
+---
+
+# Evolution extension: bidirectional schema migration proof + parallel experiment-timelines (merge contract) + reindex-as-proven-projection
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTGYQ3A508QG0R002Y8Y5N2-*.md` glob. -->
+
+## Purpose
+
+Extend the EXISTING "Evolution" proof (`src/Core/SchemaEvolution.fs`, B-0930 — forward-only migration
+algebra + forward/backward compat, 8 tests) into the full capability Amara + Aaron worked through
+2026-06-07. Full design: `docs/research/2026-06-07-evolution-schema-and-index-as-proven-projections-...`.
+
+> Disambiguation: `SchemaEvolution.fs` (B-0930, schema) — NOT `Evolution.fs` (B-1019, privacy DST).
+
+## Three extensions (each a proof obligation, not a runbook)
+
+1. **Bidirectional zero-downtime breaking schema change.** Add the DOWN direction + backfill in both
+   directions to the forward-only seed. Proof: old/new app × old/new schema all valid in the compatibility
+   window; up preserves meaning; down preserves-or-names-loss; forward backfill converges; reverse undoes/
+   compensates. Invariant: a breaking change is admitted only when the breaking part is moved OUTSIDE the
+   window (expand/migrate/contract formalized). Invertibility taxonomy: lossless `down(up x)=x` / lossy
+   (needs retained shadow) / non-invertible (compensation). Retain shadow state to the rollback horizon.
+
+2. **Parallel production experiment-timelines + continual merge contract.** Many experiments forked from
+   `main`, each with full code+data+schema+side-effect-sandbox freedom, governed by an `ExperimentContract`
+   (baseMainRoot/experimentRoot/code/data/schema/mainToExperimentMerge/experimentToMainProjection/
+   conflictPolicy/backfill±/sideEffectPolicy/promotionGate/rollbackRule). Admissible iff it continuously
+   reconciles main→experiment without corrupting main and promoted deltas satisfy the contract.
+
+3. **Reindex as a proven projection.** Source sacred; indexes derived. `full(source≤T) ==
+   incremental(full(≤T0), Δ T0→T)` — which IS the DBSP incrementalization theorem (`IndexedZSet` is the
+   index-as-derived-Z-set). Index experiment = alternate derivation pipeline; promote the winning projection.
+
+## Boundary law (all three)
+
+Inside DAG: DDL/indexes/transforms/views/plugins/schema/data → rollback by root selection.
+Outside DAG: emails/payments/webhooks/hardware → outbox/sandbox/idempotency/compensation/approval.
+
+## Acceptance
+
+Down-migration + bidirectional backfill added to SchemaEvolution with the compatibility-window proof
+discharged for a concrete breaking change; an ExperimentContract type + admissibility check; a concrete
+index where `full == incremental` is proven (over DBSP). Each composes with the COW Merkle-DAG store.
+
+## Anchors
+
+- src/Core/SchemaEvolution.fs + B-0930 (the start) · DBSP (`IndexedZSet`/`Aggregate`/`Residuated` —
+  full==incremental) · Z-set retraction · B-0829 (schemas-as-rows/fork) · 081KTGTJC1Q (COW store) ·
+  081KTGXPTQ (COW testing) · B-0969 + 081KTGEVV75 (determinism) · Soraya (formal portfolio). Beacon: DBSP,
+  expand/contract (Sato/Fowler), gh-ost/pt-osc, event-sourcing upcasting, Dolt/Neon, DDIA derived data.
+


### PR DESCRIPTION
## What — Aaron + Amara 2026-06-07 (corrected to tie to the EXISTING artifact)

**"Evolution" is not a name to decide** — the existing zero-downtime schema migration proof is already **`src/Core/SchemaEvolution.fs` (B-0930)**: migration algebra (`addField`/`removeField`/`renameField`) + forward/backward compat + `migrate` (forward-only seed), 8 tests. *(Disambiguation: `Evolution.fs` is the B-1019 privacy DST harness — NOT schema; do not conflate.)*

Captured the **extension arc** (workitem `081KTGYQ3A5`, composes with B-0930 + `081KTGTJC1Q` + `081KTGXPTQ`):
1. **Bidirectional zero-downtime breaking change as a proof** — down direction + backfill both ways; compatibility-window invariant (breaking part outside the window = expand/migrate/contract formalized); invertibility taxonomy (lossless / lossy-with-shadow / non-invertible-compensation).
2. **Parallel production experiment-timelines + continual merge contract** (`ExperimentContract`; admissible iff it continuously reconciles with main without corrupting it). A/B on *database reality*, not just app behavior.
3. **Reindex as a proven projection** — source sacred, indexes derived; `full == incremental` **is the DBSP theorem we already have** (`IndexedZSet`). LexisNexis/Solr anchor.

**Boundary law** (all three): DAG state rolls back by root selection; external side effects need outbox/saga/compensation. Plus the **DDL-canary** half (companion doc).

**Hype peeled:** the math core (SchemaEvolution + DBSP) ships; the extensions are designed/captured, not built. Docs + workitem only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)