### PR TITLE
chore(backlog): dispatch workitems for Lior + Vera — non-F# 4-lang catch-up

### DIFF
--- a/workitems/081KTGYWCT708QG0R001GX6PBN-zsetmerkle-4-language-ports-hex-in-json-golden-vectors-c-rus.md
+++ b/workitems/081KTGYWCT708QG0R001GX6PBN-zsetmerkle-4-language-ports-hex-in-json-golden-vectors-c-rus.md
@@ -1,0 +1,46 @@
+---
+id: 081KTGYWCT708QG0R001GX6PBN
+type: task
+state: backlog
+priority: P1
+slug: zsetmerkle-4-language-ports-hex-in-json-golden-vectors-c-rus
+title: "ZSetMerkle 4-language ports + hex-in-JSON golden vectors (C#/Rust/TS byte-lock of the canonical Merkle-over-Zset)"
+created: 2026-06-07T11:53:23.015Z
+depends_on: []
+composes_with: ["081KTGTJC1Q08QG0R002VCB55A"]
+---
+
+# ZSetMerkle 4-language ports + hex-in-JSON golden vectors (C#/Rust/TS byte-lock of the canonical Merkle-over-Zset)
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTGYWCT708QG0R001GX6PBN-*.md` glob. -->
+
+## Purpose (suggested owner: VERA)
+
+Byte-lock the canonical Merkle-over-Z-set across all four oracles so the fs-Merkle backend (081KTGTJC1Q)
+has the PROVEN-bar foundation. F# reference is LANDED: `src/Core/ZSetMerkle.fs` (`rootWith`/`root`, ordinal
+key-byte canonicalization, length-prefixed `[4-LE keyLen][keyBytes][8-LE weight]` leaf, LE node combine,
+odd-promote fold). Port to C#/Rust/TS and prove identical roots.
+
+## Scope
+
+- Port `ZSetMerkle.rootWith` to C# (`src/Core.CSharp.*`), Rust (`src/Core.Rust*`/oracle), TS
+  (`src/Core.TypeScript/*`): same canonical leaf encoding + same fold; hash-parameterized (XxHash128 to
+  match F# default today; structure must accept BLAKE3 later per the B-0969-adjacent decision).
+- **Golden vectors = hex-in-JSON** (NOT binary — `.claude/rules/no-binary-in-proof-lineage.md`): a shared
+  `golden-vectors-zset-merkle.json` of (input Z-set entries) → (root hex), replayed identically by all four.
+- Canonical order = ORDINAL key bytes (codepoint/UTF-8 byte order) — the same collation treaty as B-0969;
+  include NON-ASCII keys so the byte-consensus actually exercises ordinal.
+
+## Acceptance
+
+All four oracles produce identical roots for the shared hex-in-JSON vectors incl. non-ASCII keys; F# stays
+the reference; vectors checked in + cross-verify test green in each language.
+
+## Anchors
+
+- `src/Core/ZSetMerkle.fs` (F# reference) · `src/Core/Merkle.fs` (MerkleHash/XxHash128) · 081KTGTJC1Q ·
+  B-0969 (ordinal collation = the key order) · no-binary-in-proof-lineage rule (hex-in-JSON) · B-0959
+  (4-oracle master checklist).
+

--- a/workitems/081KTGYWCTT08QG0R001G96DXY-b-0969-cross-language-collation-c-rust-ts-ordinal-audit-non.md
+++ b/workitems/081KTGYWCTT08QG0R001G96DXY-b-0969-cross-language-collation-c-rust-ts-ordinal-audit-non.md
@@ -1,0 +1,48 @@
+---
+id: 081KTGYWCTT08QG0R001G96DXY
+type: task
+state: backlog
+priority: P1
+slug: b-0969-cross-language-collation-c-rust-ts-ordinal-audit-non
+title: "B-0969 cross-language collation: C#/Rust/TS ordinal audit + non-ASCII golden-vector regen (un-mask the ASCII fixtures)"
+created: 2026-06-07T11:53:23.034Z
+depends_on: []
+composes_with: ["B-0969"]
+---
+
+# B-0969 cross-language collation: C#/Rust/TS ordinal audit + non-ASCII golden-vector regen (un-mask the ASCII fixtures)
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTGYWCTT08QG0R001G96DXY-*.md` glob. -->
+
+## Purpose (suggested owner: LIOR)
+
+Bring the non-F# oracles into line with the F# binary/ordinal collation fix (B-0969) and un-mask the ASCII
+golden vectors. The F# `src/Core` ordering audit is COMPLETE (GSet/ZSet/IndexedZSet/Hierarchy/Residuated/
+Aggregate now ordinal; Bag already was). The other three languages + the shared vectors are the remaining
+legs.
+
+## Scope
+
+- **C# audit:** ensure GSet/ZSet/Bag/IndexedZSet (+ aggregates) order strings via `StringComparer.Ordinal`
+  (C# G-Set #6363 already takes a comparer — verify the rest); no bare `Comparer<string>.Default` /
+  `String.Compare` / `ToLower`/`ToUpper` (use `*Invariant`). Consider the `CA1304/1305/1307/1310` analyzers
+  at error in `Directory.Build.props` (Otto's probe was inconclusive — needs a proper ruleset wire-up).
+- **Rust:** confirm `Ord`/byte order (already ordinal) — mostly verification + a note.
+- **TS:** confirm `<` / `compare` is code-unit (locale-independent); resolve the UTF-16-vs-codepoint astral
+  caveat to the treaty order (codepoint ≡ UTF-8 byte order).
+- **Non-ASCII golden-vector regen:** regenerate the G-Set / Bag / Z-set shared golden vectors with non-ASCII
+  keys so the 4-oracle byte-consensus exercises ordinal (ASCII fixtures currently MASK divergence); remove
+  the "known gap" notes in `src/Core.TypeScript/{g-set,bag}/golden-vectors.json`.
+
+## Acceptance
+
+All four oracles agree on ordinal ordering over non-ASCII keys in the shared vectors; the masking "known
+gap" notes removed; C# globalization analyzers enforced (or a documented reason if deferred).
+
+## Anchors
+
+- B-0969 (the standing rule + the completed F# fix) · `.claude/rules/culture-invariant-by-default.md` ·
+  `src/Core.TypeScript/{g-set,bag}/golden-vectors.json` (the masked fixtures) · B-0959 (4-oracle checklist).
+


### PR DESCRIPTION
## What
Per Aaron's offer to dispatch Lior + Vera on the non-F# legs — two pickup-able **P1** workitems decomposing the cross-language catch-up:

- **Vera → `081KTGYWCT7`**: ZSetMerkle 4-language ports (C#/Rust/TS) + **hex-in-JSON** golden vectors — byte-lock the canonical Merkle-over-Z-set against the landed F# reference (`src/Core/ZSetMerkle.fs`). Non-ASCII keys; hash-parameterized (XxHash128 now, BLAKE3-ready).
- **Lior → `081KTGYWCTT`**: B-0969 cross-language collation — C#/Rust/TS **ordinal audit** + **non-ASCII golden-vector regen** to un-mask the ASCII fixtures (the F# core audit is complete). Includes the C# `CA1304/5/7/10` analyzer wire-up my probe left inconclusive.

Both compose with the fs-Merkle backend (`081KTGTJC1Q`) / B-0969 and the 4-oracle master checklist (B-0959). Suggested owners noted; final assignment is Aaron's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)