### PR TITLE
feat(SchemaEvolution): bidirectional migration — down direction + invertibility taxonomy (Evolution extension)

### DIFF
--- a/src/Core/SchemaEvolution.fs
+++ b/src/Core/SchemaEvolution.fs
@@ -21,11 +21,16 @@ namespace Zeta.Core
 [<RequireQualifiedAccess>]
 module SchemaEvolution =
 
-    /// An adjacent-version migration: transforms a value of shape `From` into shape `To = From+1`.
+    /// An adjacent-version migration: `Up` transforms shape `From` into `To = From+1`; `Down` is the
+    /// inverse (`To -> From`) used for zero-downtime ROLLBACK. `Down = None` means **non-invertible** —
+    /// rollback requires compensation, not an inverse (the invertibility taxonomy: lossless / lossy / none).
+    /// Use the smart constructors (`addFieldMigration` / `renameFieldMigration` / `removeFieldMigration`)
+    /// to get a correct `Up`+`Down` pair; the bare record stays available for custom migrations.
     type Migration =
         { From: int
           To: int
-          Up: DynamicValue -> DynamicValue }
+          Up: DynamicValue -> DynamicValue
+          Down: (DynamicValue -> DynamicValue) option }
 
     /// Ensure `key` is present, supplying `def` when absent (BACKWARD compat: a new reader gives
     /// old data a default for a field it didn't have). Idempotent; preserves existing value + order.
@@ -57,11 +62,29 @@ module SchemaEvolution =
         | DynamicValue.Object kvs -> DynamicValue.Object(kvs |> List.filter (fun (k, _) -> knownKeys.Contains k))
         | other -> other
 
+    /// `addField` is **lossless-invertible**: the inverse is `removeField key` — removing a field the
+    /// up-migration added restores the prior shape exactly, so `down(up(x)) = x`.
+    let addFieldMigration (fromV: int) (key: string) (def: DynamicValue) : Migration =
+        { From = fromV; To = fromV + 1; Up = addField key def; Down = Some(removeField key) }
+
+    /// `renameField` is **lossless-invertible**: the inverse is the rename swapped.
+    let renameFieldMigration (fromV: int) (oldKey: string) (newKey: string) : Migration =
+        { From = fromV
+          To = fromV + 1
+          Up = renameField oldKey newKey
+          Down = Some(renameField newKey oldKey) }
+
+    /// `removeField` is **LOSSY**: the removed value cannot be recovered, so the down-migration restores
+    /// only `downDefault` (it NAMES the loss rather than pretending to invert). Round-trip is therefore
+    /// `down(up(x)) = x` only on the fields other than `key`; `key` returns as `downDefault`.
+    let removeFieldMigration (fromV: int) (key: string) (downDefault: DynamicValue) : Migration =
+        { From = fromV; To = fromV + 1; Up = removeField key; Down = Some(addField key downDefault) }
+
     /// Migrate `value` from version `fromV` up to `toV` by composing the adjacent migrations in
     /// `migrations` (each must step From -> From+1). Returns Error if a step is missing or a
-    /// downgrade is requested (the seed is forward-only; downgrade = a separate Down direction).
+    /// downgrade is requested (use `migrateDown` for the inverse direction).
     let migrate (migrations: Migration list) (fromV: int) (toV: int) (value: DynamicValue) : Result<DynamicValue, string> =
-        if toV < fromV then Error(sprintf "downgrade %d -> %d not supported in the evolution seed" fromV toV)
+        if toV < fromV then Error(sprintf "downgrade %d -> %d not supported by migrate; use migrateDown" fromV toV)
         else
             let rec step cur v =
                 if cur = toV then Ok v
@@ -69,4 +92,25 @@ module SchemaEvolution =
                     match migrations |> List.tryFind (fun m -> m.From = cur && m.To = cur + 1) with
                     | Some m -> step (cur + 1) (m.Up v)
                     | None -> Error(sprintf "no migration registered from version %d to %d" cur (cur + 1))
+            step fromV value
+
+    /// Migrate `value` DOWN from `fromV` to `toV` (`toV <= fromV`) by composing the registered `Down`
+    /// inverses in reverse order. Returns Error if a step is missing OR is **non-invertible** (`Down = None`
+    /// — rollback there requires compensation, not an inverse). This is the zero-downtime ROLLBACK path:
+    /// rollback by replaying inverses, distinct from "root selection" rollback at the store layer.
+    let migrateDown (migrations: Migration list) (fromV: int) (toV: int) (value: DynamicValue) : Result<DynamicValue, string> =
+        if toV > fromV then Error(sprintf "migrateDown requires toV <= fromV, got %d -> %d" fromV toV)
+        else
+            let rec step cur v =
+                if cur = toV then Ok v
+                else
+                    match migrations |> List.tryFind (fun m -> m.To = cur && m.From = cur - 1) with
+                    | Some m ->
+                        match m.Down with
+                        | Some down -> step (cur - 1) (down v)
+                        | None ->
+                            Error(
+                                sprintf "migration %d -> %d is non-invertible (rollback needs compensation, not an inverse)" m.From m.To
+                            )
+                    | None -> Error(sprintf "no migration registered from version %d to %d" (cur - 1) cur)
             step fromV value

--- a/src/Core/SchemaRegistry.fs
+++ b/src/Core/SchemaRegistry.fs
@@ -51,7 +51,14 @@ module SchemaRegistry =
         | None -> Error(sprintf "unknown schema '%s'" schemaId)
         | Some migs ->
             let seMigs =
-                migs |> List.map (fun m -> { SchemaEvolution.From = m.From; SchemaEvolution.To = m.To; SchemaEvolution.Up = applyOps m.Ops })
+                migs
+                |> List.map (fun m ->
+                    { SchemaEvolution.From = m.From
+                      SchemaEvolution.To = m.To
+                      SchemaEvolution.Up = applyOps m.Ops
+                      // Down = None for now: deriving per-op inverses from the registry's FieldOp list
+                      // (so migrateDown works on registry schemas) is the next Evolution-extension slice.
+                      SchemaEvolution.Down = None })
             SchemaEvolution.migrate seMigs fromV toV value
 
     // ── schemas-as-rows: the registry IS a DynamicValue (rides the proven codecs) ──

--- a/tests/Tests.FSharp/SchemaEvolution.Tests.fs
+++ b/tests/Tests.FSharp/SchemaEvolution.Tests.fs
@@ -77,8 +77,8 @@ let ``Schema: renameField is involutive when the target key is fresh (lossless r
 
 // ── migration chains compose ──
 
-let private m12 : SE.Migration = { From = 1; To = 2; Up = SE.addField "f2" (DynamicValue.Int 0L) }
-let private m23 : SE.Migration = { From = 2; To = 3; Up = SE.addField "f3" (DynamicValue.String "") }
+let private m12 : SE.Migration = SE.addFieldMigration 1 "f2" (DynamicValue.Int 0L)
+let private m23 : SE.Migration = SE.addFieldMigration 2 "f3" (DynamicValue.String "")
 let private regstry = [ m12; m23 ]
 
 [<Property(Arbitrary = [| typeof<ObjArb> |])>]
@@ -119,3 +119,38 @@ let ``Schema: zero-downtime scenario — v1 data is readable by a v3 consumer, v
     // knows and IGNORES f2/f3 (forward compat) — the extra data round-trips untouched if re-emitted.
     let v3 = DynamicValue.Object [ "id", DynamicValue.Int 9L; "f2", DynamicValue.Int 0L; "f3", DynamicValue.String "" ]
     Assert.Equal(DynamicValue.Object [ "id", DynamicValue.Int 9L ], SE.project (Set.ofList [ "id" ]) v3)
+
+// ── bidirectional migration (the Evolution down-direction; B-0930 extension) ──
+
+[<Fact>]
+let ``Schema: migrateDown inverts a lossless addField chain back to the original`` () =
+    let v = DynamicValue.Object [ "a", DynamicValue.Int 1L ]
+    let up = SE.migrate regstry 1 3 v
+    match up with
+    | Ok up3 ->
+        match SE.migrateDown regstry 3 1 up3 with
+        | Ok back -> Assert.Equal<DynamicValue>(v, back) // down(up(x)) = x for lossless add
+        | Error e -> Assert.Fail(sprintf "migrateDown failed: %s" e)
+    | Error e -> Assert.Fail(sprintf "migrate failed: %s" e)
+
+[<Fact>]
+let ``Schema: renameFieldMigration round-trips losslessly via migrateDown`` () =
+    let reg = [ SE.renameFieldMigration 1 "old" "new" ]
+    let v = DynamicValue.Object [ "old", DynamicValue.Int 7L ]
+    let back = SE.migrate reg 1 2 v |> Result.bind (SE.migrateDown reg 2 1)
+    Assert.Equal<Result<DynamicValue, string>>(Ok v, back)
+
+[<Fact>]
+let ``Schema: removeFieldMigration is LOSSY - down restores the named default, not the original`` () =
+    let reg = [ SE.removeFieldMigration 1 "secret" (DynamicValue.String "REDACTED") ]
+    let v = DynamicValue.Object [ "secret", DynamicValue.String "hunter2" ]
+    let back = SE.migrate reg 1 2 v |> Result.bind (SE.migrateDown reg 2 1)
+    // the original value is gone; the down-migration names the loss with the default
+    Assert.Equal<Result<DynamicValue, string>>(Ok(DynamicValue.Object [ "secret", DynamicValue.String "REDACTED" ]), back)
+
+[<Fact>]
+let ``Schema: a non-invertible migration (Down=None) makes migrateDown error, not silently pass`` () =
+    let reg = [ { SE.From = 1; SE.To = 2; SE.Up = SE.addField "x" (DynamicValue.Int 0L); SE.Down = None } ]
+    match SE.migrateDown reg 2 1 (DynamicValue.Object [ "x", DynamicValue.Int 0L ]) with
+    | Error msg -> Assert.Contains("non-invertible", msg)
+    | Ok _ -> Assert.Fail "expected non-invertible error"


### PR DESCRIPTION
## What — first code slice of the Evolution extension (`081KTGYQ3A5`)
Builds the **down direction** on the existing `SchemaEvolution` seed (B-0930) — the zero-downtime rollback path.

- **`Migration` gains `Down: (DynamicValue -> DynamicValue) option`** — `None` = **non-invertible** (rollback needs compensation, not an inverse).
- **Smart constructors encode the invertibility taxonomy:**
  - `addFieldMigration` → **lossless** (`Down = removeField`; `down(up x) = x`)
  - `renameFieldMigration` → **lossless** (`Down` = rename swapped)
  - `removeFieldMigration` → **lossy** (`Down = addField default` — *names the loss*; the removed value can't be recovered)
- **`migrateDown`** composes registered `Down` inverses in reverse; **errors (not silent pass)** on a missing step or a non-invertible migration.
- `SchemaRegistry` migrations carry `Down = None` for now (deriving per-op inverses from the `FieldOp` list is the next slice).

## Test
`dotnet test … --filter SchemaEvolution|SchemaRegistry` → **18 passed** (4 new: lossless add/rename round-trips, lossy-remove names-the-loss, non-invertible errors).

Greenfield API change (the `Down` field); existing `Migration` construction updated to the smart constructors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)