### PR TITLE
feat(SchemaRegistry): derive per-op inverses → migrateValueDown over schemas-as-rows

### DIFF
--- a/src/Core/SchemaRegistry.fs
+++ b/src/Core/SchemaRegistry.fs
@@ -44,22 +44,51 @@ module SchemaRegistry =
     let applyOps (ops: FieldOp list) (v: DynamicValue) : DynamicValue =
         List.fold (fun acc op -> applyOp op acc) v ops
 
+    /// Invert one op for the DOWN direction. `AddField`/`RenameField` are LOSSLESS-invertible;
+    /// `RemoveField` is **non-invertible at the registry level** (the removed value is gone and the op
+    /// carries no down-default), so it returns `None` — the whole migration's `Down` then becomes `None`
+    /// (rollback there needs compensation, not an inverse — the honest taxonomy).
+    let invertOp (op: FieldOp) : FieldOp option =
+        match op with
+        | AddField (k, _) -> Some(RemoveField k)
+        | RenameField (o, n) -> Some(RenameField(n, o))
+        | RemoveField _ -> None
+
+    /// Invert a migration's op list: invert each op AND reverse the order (the inverse of `f ∘ g` is
+    /// `g⁻¹ ∘ f⁻¹`). `None` if any op is non-invertible.
+    let invertOps (ops: FieldOp list) : FieldOp list option =
+        let rec loop acc =
+            function
+            | [] -> Some acc // already reversed by prepending
+            | op :: rest ->
+                match invertOp op with
+                | Some inv -> loop (inv :: acc) rest
+                | None -> None
+        loop [] ops
+
+    let private seMigsOf (migs: Migration list) : SchemaEvolution.Migration list =
+        migs
+        |> List.map (fun m ->
+            { SchemaEvolution.From = m.From
+              SchemaEvolution.To = m.To
+              SchemaEvolution.Up = applyOps m.Ops
+              // Down derived by inverting the op list (reversed); None if any op is non-invertible.
+              SchemaEvolution.Down = invertOps m.Ops |> Option.map applyOps })
+
     /// Migrate a value of `schemaId` from `fromV` up to `toV` by composing the registered ops.
     /// Clean Error on unknown schema / missing step / downgrade (total).
     let migrateValue (r: Registry) (schemaId: string) (fromV: int) (toV: int) (value: DynamicValue) : Result<DynamicValue, string> =
         match Map.tryFind schemaId r.Schemas with
         | None -> Error(sprintf "unknown schema '%s'" schemaId)
-        | Some migs ->
-            let seMigs =
-                migs
-                |> List.map (fun m ->
-                    { SchemaEvolution.From = m.From
-                      SchemaEvolution.To = m.To
-                      SchemaEvolution.Up = applyOps m.Ops
-                      // Down = None for now: deriving per-op inverses from the registry's FieldOp list
-                      // (so migrateDown works on registry schemas) is the next Evolution-extension slice.
-                      SchemaEvolution.Down = None })
-            SchemaEvolution.migrate seMigs fromV toV value
+        | Some migs -> SchemaEvolution.migrate (seMigsOf migs) fromV toV value
+
+    /// Migrate a value of `schemaId` DOWN from `fromV` to `toV` using the derived per-op inverses.
+    /// Errors (not silent pass) on unknown schema, a missing step, or a non-invertible migration
+    /// (one containing a `RemoveField` — rollback there needs compensation).
+    let migrateValueDown (r: Registry) (schemaId: string) (fromV: int) (toV: int) (value: DynamicValue) : Result<DynamicValue, string> =
+        match Map.tryFind schemaId r.Schemas with
+        | None -> Error(sprintf "unknown schema '%s'" schemaId)
+        | Some migs -> SchemaEvolution.migrateDown (seMigsOf migs) fromV toV value
 
     // ── schemas-as-rows: the registry IS a DynamicValue (rides the proven codecs) ──
     let private opToDynamic (op: FieldOp) : DynamicValue =

--- a/tests/Tests.FSharp/SchemaRegistry.Tests.fs
+++ b/tests/Tests.FSharp/SchemaRegistry.Tests.fs
@@ -77,3 +77,27 @@ let ``SchemaRegistry: applyOps interprets to the same transform as SchemaEvoluti
     let viaOps = SR.applyOps [ SR.AddField("b", DynamicValue.Int 2L); SR.RenameField("a", "id") ] v
     let viaSE = v |> SchemaEvolution.addField "b" (DynamicValue.Int 2L) |> SchemaEvolution.renameField "a" "id"
     Assert.Equal(viaSE, viaOps)
+
+// ── registry-derived inverses: migrateValueDown (Evolution down-direction over schemas-as-rows) ──
+
+[<Fact>]
+let ``SchemaRegistry: migrateValueDown round-trips a lossless (add+rename) schema back to the original`` () =
+    let v1 = DynamicValue.Object [ "name", DynamicValue.String "Ada" ]
+    let back = SR.migrateValue reg "user" 1 3 v1 |> Result.bind (SR.migrateValueDown reg "user" 3 1)
+    Assert.Equal<Result<DynamicValue, string>>(Ok v1, back)
+
+[<Fact>]
+let ``SchemaRegistry: migrateValueDown errors on a non-invertible (RemoveField) schema`` () =
+    // "order" v1->v2 is a RemoveField (the dropped value is gone) => non-invertible, must error not silently pass.
+    let v2 = DynamicValue.Object [ "id", DynamicValue.Int 1L ]
+    match SR.migrateValueDown reg "order" 2 1 v2 with
+    | Error msg -> Assert.Contains("non-invertible", msg)
+    | Ok _ -> Assert.Fail "expected non-invertible error for the RemoveField migration"
+
+[<Fact>]
+let ``SchemaRegistry: invertOps reverses order and inverts each op; None if any op is non-invertible`` () =
+    Assert.Equal<SR.FieldOp list option>(
+        Some [ SR.RemoveField "b"; SR.RenameField("new", "old") ],
+        SR.invertOps [ SR.RenameField("old", "new"); SR.AddField("b", DynamicValue.Int 0L) ]
+    )
+    Assert.Equal<SR.FieldOp list option>(None, SR.invertOps [ SR.RemoveField "x" ])


### PR DESCRIPTION
## What — second Evolution-extension slice (`081KTGYQ3A5`)
The registry now **derives the down direction from its `FieldOp` list**, so `migrateDown` works on registry schemas.

- **`invertOp`**: `AddField → RemoveField`, `RenameField → swapped` (lossless); `RemoveField → None` (non-invertible — dropped value gone, no down-default).
- **`invertOps`**: invert each op **and reverse order** (`(f∘g)⁻¹ = g⁻¹∘f⁻¹`); `None` if any op is non-invertible.
- **`migrateValueDown`**: registry down-migration; errors (not silent) on unknown schema / missing step / non-invertible migration.

## Test
`dotnet test … --filter SchemaRegistry` → **9 passed** (3 new: lossless "user" 1→3→1 round-trip; non-invertible "order" errors; `invertOps` reverse+invert+None-propagation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)