### PR TITLE
docs(Evolution): backward-projection constraint — expand-into gated on contract-complete

### DIFF
--- a/docs/research/2026-06-07-evolution-schema-and-index-as-proven-projections-parallel-experiment-timelines-merge-contract-aaron-amara.md
+++ b/docs/research/2026-06-07-evolution-schema-and-index-as-proven-projections-parallel-experiment-timelines-merge-contract-aaron-amara.md
@@ -67,6 +67,34 @@ the safety horizon → rollback by root-switch or reverse/compensating events).
 | lossy | `down(up(x)) ≈ x` only if shadow/history retained | inverse + retained shadow |
 | non-invertible | — | **compensation**, not inverse |
 
+**Backward-projection constraint — you cannot EXPAND-INTO new relations until contract completes (Aaron
+2026-06-07).** A subtle but mathematically-forced *temporal ordering* on expand/migrate/contract:
+
+> *"when you add new relations to the database you can't expand into them until the migration window is
+> complete and the old flat code is removed — because you can't project backwards in a lossless way. So you
+> have to wait to expand until the expanded relations are all that exists."*
+
+Adding a relation (the *schema* expand) is safe and reversible. But **writing data that only the new
+relations can represent** (the *behavioral* expand — "expand-into") is **not** safe while any old flat
+reader still exists, because serving that reader requires projecting the richer shape back down to the flat
+shape — a **lossy backward projection** (the down direction of an `addField`-of-structure is fine, but the
+down of "data that has no flat representation" is information loss). So the gate:
+
+```
+1. expand schema      — add the new relations; nobody writes the richer-only data yet (reversible)
+2. migration window   — old flat + new relational coexist; backfill; old readers still served by lossless down-projection
+3. CONTRACT           — remove the old flat code / the last old reader
+4. expand-INTO         — only NOW write data that only the new relations can hold
+                         (safe because the expanded relations are all that exists — no backward projection owed)
+```
+
+The rule: **expand-into is gated on contract-complete** — `mayExpandInto(relation) ⟺ no reader remains that
+needs a lossless flat projection of it`. This is the down-direction of the invertibility taxonomy applied
+*temporally*: a write is admissible only when its backward projection to every still-living reader is
+lossless (or no such reader exists). It's a correctness barrier, not a policy convenience — emitting
+richer-only data during the window would owe a lossy down-projection to a flat reader and corrupt it.
+(Mechanizable: track the window/contract state; gate expand-into writes on "no flat reader remains".)
+
 For zero-downtime rollback of destructive DDL you **retain shadow state** (old column/table/translation
 log/tombstones/derivable indexes) until the **rollback horizon** expires. Keeper: *DDL becomes stream
 history; migration becomes a reversible-or-explicitly-compensated morphism; backfill becomes replay; zero

--- a/workitems/081KTGYQ3A508QG0R002Y8Y5N2-evolution-extension-bidirectional-schema-migration-proof-par.md
+++ b/workitems/081KTGYQ3A508QG0R002Y8Y5N2-evolution-extension-bidirectional-schema-migration-proof-par.md
@@ -33,6 +33,14 @@ algebra + forward/backward compat, 8 tests) into the full capability Amara + Aar
    window (expand/migrate/contract formalized). Invertibility taxonomy: lossless `down(up x)=x` / lossy
    (needs retained shadow) / non-invertible (compensation). Retain shadow state to the rollback horizon.
 
+1b. **Backward-projection constraint (Aaron 2026-06-07) — expand-INTO is gated on contract-complete.**
+   Adding a relation is reversible; *writing data only the new relations can represent* is NOT safe while
+   any old flat reader remains (serving it needs a LOSSY backward projection). Gate:
+   expand-schema → migration window (coexist + backfill, old readers served by lossless down-projection) →
+   CONTRACT (remove last flat reader) → only THEN expand-into. Rule: `mayExpandInto(rel) ⟺ no reader needs
+   a lossless flat projection of it`. Mechanizable: track window/contract state, gate expand-into writes.
+   A correctness barrier, not policy. Full: the Evolution research doc §1.
+
 2. **Parallel production experiment-timelines + continual merge contract.** Many experiments forked from
    `main`, each with full code+data+schema+side-effect-sandbox freedom, governed by an `ExperimentContract`
    (baseMainRoot/experimentRoot/code/data/schema/mainToExperimentMerge/experimentToMainProjection/


### PR DESCRIPTION
## What
Captures Aaron's 2026-06-07 constraint: *"you can't expand into new relations until the migration window is complete and the old flat code is removed, because you can't project backwards losslessly."*

A mathematically-forced **temporal ordering** on expand/migrate/contract:
- Adding a relation is reversible; **writing data only the new relations can represent** is **not** safe while any old flat reader remains (serving it needs a **lossy backward projection**).
- Gate: expand-schema → migration window (coexist, backfill; old readers served by *lossless* down-projection) → **CONTRACT** (remove last flat reader) → **only then expand-into**.
- Rule: `mayExpandInto(rel) ⟺ no reader needs a lossless flat projection of it` — the down-direction of the invertibility taxonomy applied *temporally*; mechanizable by tracking window/contract state. A correctness barrier, not policy.

Captured in the Evolution research doc (§1) + the extension workitem (`081KTGYQ3A5`). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)